### PR TITLE
feat: show hidden files and directories in file tree

### DIFF
--- a/src/__tests__/renderer/utils/fileExplorer.test.ts
+++ b/src/__tests__/renderer/utils/fileExplorer.test.ts
@@ -188,7 +188,7 @@ describe('fileExplorer utils', () => {
       expect(result[2]).toEqual({ name: 'README.md', type: 'file' });
     });
 
-    it('skips hidden files (starting with .)', async () => {
+    it('includes hidden files and directories (starting with .)', async () => {
       vi.mocked(window.maestro.fs.readDir)
         .mockResolvedValueOnce([
           { name: '.git', isFile: false, isDirectory: true },
@@ -197,12 +197,16 @@ describe('fileExplorer utils', () => {
           { name: 'src', isFile: false, isDirectory: true },
           { name: 'README.md', isFile: true, isDirectory: false },
         ])
-        .mockResolvedValue([]); // Empty for src folder recursion
+        .mockResolvedValue([]); // Empty for recursive folder calls
 
       const result = await loadFileTree('/project');
 
-      expect(result).toHaveLength(2);
-      expect(result.find((n) => n.name.startsWith('.'))).toBeUndefined();
+      expect(result).toHaveLength(5);
+      expect(result.find((n) => n.name === '.git')).toBeDefined();
+      expect(result.find((n) => n.name === '.gitignore')).toBeDefined();
+      expect(result.find((n) => n.name === '.env')).toBeDefined();
+      expect(result.find((n) => n.name === 'src')).toBeDefined();
+      expect(result.find((n) => n.name === 'README.md')).toBeDefined();
     });
 
     it('skips node_modules directory', async () => {

--- a/src/renderer/utils/fileExplorer.ts
+++ b/src/renderer/utils/fileExplorer.ts
@@ -34,8 +34,8 @@ export async function loadFileTree(
     const tree: FileTreeNode[] = [];
 
     for (const entry of entries) {
-      // Skip hidden files and common ignore patterns
-      if (entry.name.startsWith('.') || entry.name === 'node_modules' || entry.name === '__pycache__') {
+      // Skip common ignore patterns (but allow hidden files/directories starting with .)
+      if (entry.name === 'node_modules' || entry.name === '__pycache__') {
         continue;
       }
 


### PR DESCRIPTION
Fixes #17

This PR adds support for viewing hidden files and directories in Maestro's File System Tree viewer.

### Changes
- Removed filter that skipped files/directories starting with '.'
- Users can now see and reference hidden files like `.meta/ai-context.md`, `.env`, `.gitignore`
- Keep existing filters for `node_modules` and `__pycache__`
- Updated tests to verify hidden files are included

### Testing
Updated existing test case in `src/__tests__/renderer/utils/fileExplorer.test.ts` to verify that hidden files and directories are now included in the file tree.

Generated with [Claude Code](https://claude.ai/code)