### PR TITLE
feat: Add CPU/memory stats to Process Monitor

### DIFF
--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -463,6 +463,9 @@ export interface MaestroAPI {
       cwd: string;
       isTerminal: boolean;
       isBatchMode: boolean;
+      cpu: number;
+      memory: number;
+      runtime: string;
     }>>;
     onData: (callback: (sessionId: string, data: string) => void) => () => void;
     onExit: (callback: (sessionId: string, code: number) => void) => () => void;

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -2609,6 +2609,13 @@ export default function MaestroConsole() {
     if (mainKey === '[' && (key === '[' || key === '{')) return true;
     if (mainKey === ']' && (key === ']' || key === '}')) return true;
 
+    // For Alt+Meta shortcuts on macOS, e.key produces special characters (e.g., Alt+p = π, Alt+l = ¬)
+    // Use e.code to get the physical key pressed instead
+    if (altPressed && e.code) {
+      const codeKey = e.code.replace('Key', '').toLowerCase();
+      return codeKey === mainKey;
+    }
+
     return key === mainKey;
   };
 
@@ -2686,7 +2693,9 @@ export default function MaestroConsole() {
         // Allow jumpToBottom (Cmd+Shift+J) from anywhere - always scroll main panel to bottom
         const isJumpToBottomShortcut = (e.metaKey || e.ctrlKey) && e.shiftKey && keyLower === 'j';
         // Allow system utility shortcuts (Alt+Cmd+L for logs, Alt+Cmd+P for processes) even when modals are open
-        const isSystemUtilShortcut = e.altKey && (e.metaKey || e.ctrlKey) && (keyLower === 'l' || keyLower === 'p');
+        // Use e.code because Alt on macOS produces special characters (Alt+P = π, Alt+L = ¬)
+        const codeKey = e.code?.replace('Key', '').toLowerCase();
+        const isSystemUtilShortcut = e.altKey && (e.metaKey || e.ctrlKey) && (codeKey === 'l' || codeKey === 'p');
         // Allow session jump shortcuts (Alt+Cmd+NUMBER) even when modals are open
         const isSessionJumpShortcut = e.altKey && (e.metaKey || e.ctrlKey) && /^[0-9]$/.test(e.key);
 

--- a/src/renderer/components/ProcessMonitor.tsx
+++ b/src/renderer/components/ProcessMonitor.tsx
@@ -19,6 +19,9 @@ interface ActiveProcess {
   cwd: string;
   isTerminal: boolean;
   isBatchMode: boolean;
+  cpu: number;
+  memory: number;
+  runtime: string;
 }
 
 interface ProcessNode {
@@ -36,6 +39,9 @@ interface ProcessNode {
   cwd?: string;
   claudeSessionId?: string; // UUID octet from the Claude session (for AI processes)
   tabId?: string; // Tab ID for navigation to specific AI tab
+  cpu?: number;
+  memory?: number;
+  runtime?: string;
 }
 
 export function ProcessMonitor(props: ProcessMonitorProps) {
@@ -275,7 +281,10 @@ export function ProcessMonitor(props: ProcessMonitorProps) {
           toolType: proc.toolType,
           cwd: proc.cwd,
           claudeSessionId,
-          tabId
+          tabId,
+          cpu: proc.cpu,
+          memory: proc.memory,
+          runtime: proc.runtime,
         });
       });
 
@@ -535,6 +544,9 @@ export function ProcessMonitor(props: ProcessMonitorProps) {
     }
 
     if (node.type === 'process') {
+      // Determine CPU color based on usage
+      const cpuColor = (node.cpu ?? 0) > 50 ? theme.colors.error : (node.cpu ?? 0) > 20 ? theme.colors.warning : theme.colors.success;
+
       return (
         <div
           ref={isSelected ? selectedNodeRef as React.RefObject<HTMLDivElement> : null}
@@ -555,7 +567,7 @@ export function ProcessMonitor(props: ProcessMonitorProps) {
           <div className="w-4 h-4 flex-shrink-0" />
           <div
             className="w-2 h-2 rounded-full flex-shrink-0"
-            style={{ backgroundColor: theme.colors.success }}
+            style={{ backgroundColor: cpuColor }}
           />
           <span className="text-sm flex-1 truncate">{node.label}</span>
           {node.claudeSessionId && node.sessionId && onNavigateToSession && (
@@ -577,17 +589,23 @@ export function ProcessMonitor(props: ProcessMonitorProps) {
               {node.claudeSessionId.substring(0, 8)}...
             </span>
           )}
-          <span className="text-xs font-mono flex-shrink-0" style={{ color: theme.colors.textDim }}>
-            PID: {node.pid}
+          {/* CPU/Memory stats */}
+          <span
+            className="text-xs font-mono flex-shrink-0 px-1.5 py-0.5 rounded"
+            style={{ backgroundColor: `${cpuColor}20`, color: cpuColor }}
+            title={`CPU: ${(node.cpu ?? 0).toFixed(1)}%`}
+          >
+            {(node.cpu ?? 0).toFixed(0)}%
           </span>
           <span
-            className="text-xs px-2 py-0.5 rounded"
-            style={{
-              backgroundColor: `${theme.colors.success}20`,
-              color: theme.colors.success
-            }}
+            className="text-xs font-mono flex-shrink-0"
+            style={{ color: theme.colors.textDim }}
+            title={`Memory: ${(node.memory ?? 0).toFixed(1)}%`}
           >
-            Running
+            {(node.memory ?? 0).toFixed(1)}% RAM
+          </span>
+          <span className="text-xs font-mono flex-shrink-0" style={{ color: theme.colors.textDim }}>
+            PID: {node.pid}
           </span>
         </div>
       );


### PR DESCRIPTION
## Summary

- Enhanced `getActiveProcesses` IPC to fetch CPU%, memory%, and runtime for each Maestro-managed process using `ps`
- Updated Process Monitor UI to display color-coded CPU indicators (green <20%, yellow 20-50%, red >50%) with RAM percentage
- Fixed Alt+Meta keyboard shortcuts on macOS (e.g., Option+Cmd+P for Process Monitor) by using `e.code` instead of `e.key` for special character handling

## Screenshots

The Process Monitor now shows real-time CPU and memory usage for each process Maestro is managing, helping users identify resource-hungry sessions.

## Test plan

- [ ] Open Process Monitor via hamburger menu → "System Processes"
- [ ] Verify CPU% and RAM% are displayed for each running process
- [ ] Verify color coding: green (<20% CPU), yellow (20-50%), red (>50%)
- [ ] Test Option+Cmd+P shortcut opens Process Monitor on macOS
- [ ] Test Option+Cmd+L shortcut still opens Log Viewer on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)