### PR TITLE
docs: add Contributors section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -638,6 +638,11 @@ To access Maestro from outside your local network (e.g., on mobile data or from 
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, architecture details, and contribution guidelines.
 
+## Contributors
+
+- [@pedramamini](https://github.com/pedramamini) - Creator and maintainer
+- [@mattjay](https://github.com/mattjay) - Contributor and tester
+
 ## License
 
 [AGPL-3.0 License](LICENSE)


### PR DESCRIPTION
## Summary

- Adds a Contributors section to the README to recognize project contributors
- Lists @pedramamini as creator/maintainer and @mattjay as contributor/tester

## Test plan

- [x] Verify README renders correctly with the new section
- [x] Verify GitHub profile links work

🤖 Generated with [Claude Code](https://claude.com/claude-code)