### PR TITLE
feat: worktree auto-discovery and custom Claude command support

### DIFF
--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -352,6 +352,27 @@ contextBridge.exposeInMainWorld('maestro', {
         installed: boolean;
         authenticated: boolean;
       }>,
+    // List all worktrees for a git repository
+    listWorktrees: (cwd: string) =>
+      ipcRenderer.invoke('git:listWorktrees', cwd) as Promise<{
+        worktrees: Array<{
+          path: string;
+          head: string;
+          branch: string | null;
+          isBare: boolean;
+        }>;
+      }>,
+    // Scan a directory for subdirectories that are git repositories or worktrees
+    scanWorktreeDirectory: (parentPath: string) =>
+      ipcRenderer.invoke('git:scanWorktreeDirectory', parentPath) as Promise<{
+        gitSubdirs: Array<{
+          path: string;
+          name: string;
+          isWorktree: boolean;
+          branch: string | null;
+          repoRoot: string | null;
+        }>;
+      }>,
   },
 
   // File System API
@@ -1237,6 +1258,23 @@ export interface MaestroAPI {
     checkGhCli: (ghPath?: string) => Promise<{
       installed: boolean;
       authenticated: boolean;
+    }>;
+    listWorktrees: (cwd: string) => Promise<{
+      worktrees: Array<{
+        path: string;
+        head: string;
+        branch: string | null;
+        isBare: boolean;
+      }>;
+    }>;
+    scanWorktreeDirectory: (parentPath: string) => Promise<{
+      gitSubdirs: Array<{
+        path: string;
+        name: string;
+        isWorktree: boolean;
+        branch: string | null;
+        repoRoot: string | null;
+      }>;
     }>;
   };
   fs: {

--- a/src/renderer/components/SessionList.tsx
+++ b/src/renderer/components/SessionList.tsx
@@ -568,6 +568,8 @@ interface SessionListProps {
   setSessions: React.Dispatch<React.SetStateAction<Session[]>>;
   createNewGroup: () => void;
   addNewSession: () => void;
+  onDeleteSession?: (id: string) => void;
+  onDeleteWorktreeGroup?: (groupId: string) => void;
 
   // Rename modal handlers (for context menu rename)
   setRenameInstanceModalOpen: (open: boolean) => void;
@@ -634,6 +636,7 @@ export function SessionList(props: SessionListProps) {
     handleDragStart, handleDragOver, handleDropOnGroup, handleDropOnUngrouped,
     finishRenamingGroup, finishRenamingSession, startRenamingGroup,
     startRenamingSession, showConfirmation, setGroups, setSessions, createNewGroup, addNewSession,
+    onDeleteSession, onDeleteWorktreeGroup,
     setRenameInstanceModalOpen, setRenameInstanceValue, setRenameInstanceSessionId,
     onEditAgent,
     activeBatchSessionIds = [],
@@ -713,6 +716,12 @@ export function SessionList(props: SessionListProps) {
   };
 
   const handleDeleteSession = (sessionId: string) => {
+    // Use the parent's delete handler if provided (includes proper cleanup)
+    if (onDeleteSession) {
+      onDeleteSession(sessionId);
+      return;
+    }
+    // Fallback to local delete logic
     const session = sessions.find(s => s.id === sessionId);
     if (!session) return;
     showConfirmation(
@@ -1595,6 +1604,7 @@ export function SessionList(props: SessionListProps) {
                       <span onDoubleClick={() => startRenamingGroup(group.id)}>{group.name}</span>
                     )}
                   </div>
+                  {/* Delete button for empty groups */}
                   {groupSessions.length === 0 && (
                     <button
                       onClick={(e) => {
@@ -1611,6 +1621,20 @@ export function SessionList(props: SessionListProps) {
                       title="Delete empty group"
                     >
                       <X className="w-3 h-3" />
+                    </button>
+                  )}
+                  {/* Delete button for worktree groups with agents */}
+                  {group.emoji === '🌳' && groupSessions.length > 0 && onDeleteWorktreeGroup && (
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onDeleteWorktreeGroup(group.id);
+                      }}
+                      className="p-1 rounded hover:bg-red-500/20 opacity-0 group-hover:opacity-100 transition-opacity"
+                      style={{ color: theme.colors.error }}
+                      title="Remove group and all agents"
+                    >
+                      <Trash2 className="w-3 h-3" />
                     </button>
                   )}
                 </div>

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -329,6 +329,8 @@ export interface Session {
   gitBranches?: string[];
   gitTags?: string[];
   gitRefsCacheTime?: number;  // Timestamp when branches/tags were last fetched
+  // Worktree parent path - if set, this session is a worktree parent that should be scanned for new worktrees
+  worktreeParentPath?: string;
   // File Explorer per-session state
   fileTree: any[];
   fileExplorerExpanded: string[];


### PR DESCRIPTION
Worktree Features:
- Auto-detect directories containing git worktrees and create grouped agents
- Periodic scanner (30s) discovers new worktrees in watched directories
- Track removed worktree paths to prevent re-discovery
- Bulk delete worktree groups with all agents (trash icon on 🌳 groups)
- Wire SessionList delete through App.tsx for proper cleanup

Custom Claude Commands:
- Discover custom commands from .claude/commands/ directories
- Merge custom commands with built-in agent commands
- Run both discovery methods in parallel for faster loading