### PR TITLE
feat(opencode): Enable real-time streaming and tool execution events

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2234,6 +2234,11 @@ function setupProcessListeners() {
       mainWindow?.webContents.send('process:slash-commands', sessionId, slashCommands);
     });
 
+    // Handle tool execution events (OpenCode, Codex)
+    processManager.on('tool-execution', (sessionId: string, toolEvent: { toolName: string; state?: unknown; timestamp: number }) => {
+      mainWindow?.webContents.send('process:tool-execution', sessionId, toolEvent);
+    });
+
     // Handle stderr separately from runCommand (for clean command execution)
     processManager.on('stderr', (sessionId: string, data: string) => {
       mainWindow?.webContents.send('process:stderr', sessionId, data);

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -130,6 +130,11 @@ contextBridge.exposeInMainWorld('maestro', {
       ipcRenderer.on('process:slash-commands', handler);
       return () => ipcRenderer.removeListener('process:slash-commands', handler);
     },
+    onToolExecution: (callback: (sessionId: string, toolEvent: { toolName: string; state?: unknown; timestamp: number }) => void) => {
+      const handler = (_: any, sessionId: string, toolEvent: { toolName: string; state?: unknown; timestamp: number }) => callback(sessionId, toolEvent);
+      ipcRenderer.on('process:tool-execution', handler);
+      return () => ipcRenderer.removeListener('process:tool-execution', handler);
+    },
     // Remote command execution from web interface
     // This allows web commands to go through the same code path as desktop commands
     // inputMode is optional - if provided, renderer should use it instead of session state
@@ -1181,6 +1186,7 @@ export interface MaestroAPI {
     onExit: (callback: (sessionId: string, code: number) => void) => () => void;
     onSessionId: (callback: (sessionId: string, agentSessionId: string) => void) => () => void;
     onSlashCommands: (callback: (sessionId: string, slashCommands: string[]) => void) => () => void;
+    onToolExecution: (callback: (sessionId: string, toolEvent: { toolName: string; state?: unknown; timestamp: number }) => void) => () => void;
     onRemoteCommand: (callback: (sessionId: string, command: string) => void) => () => void;
     onRemoteSwitchMode: (callback: (sessionId: string, mode: 'ai' | 'terminal') => void) => () => void;
     onRemoteInterrupt: (callback: (sessionId: string) => void) => () => void;

--- a/src/main/process-manager.ts
+++ b/src/main/process-manager.ts
@@ -724,10 +724,23 @@ export class ProcessManager extends EventEmitter {
                       this.emit('slash-commands', sessionId, slashCommands);
                     }
 
-                    // Accumulate text from partial streaming events (OpenCode text messages)
-                    // Skip error events - they're handled separately by detectErrorFromLine
+                    // Handle streaming text events (OpenCode, Codex reasoning)
+                    // Emit partial text immediately for real-time streaming UX
+                    // Also accumulate for final result assembly if needed
                     if (event.type === 'text' && event.isPartial && event.text) {
                       managedProcess.streamedText = (managedProcess.streamedText || '') + event.text;
+                      // Emit streaming text immediately for real-time display
+                      this.emit('data', sessionId, event.text);
+                    }
+
+                    // Handle tool execution events (OpenCode, Codex)
+                    // Emit tool events so UI can display what the agent is doing
+                    if (event.type === 'tool_use' && event.toolName) {
+                      this.emit('tool-execution', sessionId, {
+                        toolName: event.toolName,
+                        state: event.toolState,
+                        timestamp: Date.now(),
+                      });
                     }
 
                     // Skip processing error events further - they're handled by agent-error emission

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -155,6 +155,7 @@ interface MaestroAPI {
     onExit: (callback: (sessionId: string, code: number) => void) => () => void;
     onSessionId: (callback: (sessionId: string, agentSessionId: string) => void) => () => void;
     onSlashCommands: (callback: (sessionId: string, slashCommands: string[]) => void) => () => void;
+    onToolExecution: (callback: (sessionId: string, toolEvent: { toolName: string; state?: unknown; timestamp: number }) => void) => () => void;
     onRemoteCommand: (callback: (sessionId: string, command: string, inputMode?: 'ai' | 'terminal') => void) => () => void;
     onRemoteSwitchMode: (callback: (sessionId: string, mode: 'ai' | 'terminal') => void) => () => void;
     onRemoteInterrupt: (callback: (sessionId: string) => void) => () => void;

--- a/src/renderer/services/process.ts
+++ b/src/renderer/services/process.ts
@@ -90,5 +90,12 @@ export const processService = {
    */
   onSessionId(handler: ProcessSessionIdHandler): () => void {
     return window.maestro.process.onSessionId(handler);
+  },
+
+  /**
+   * Register handler for tool execution events (OpenCode, Codex)
+   */
+  onToolExecution(handler: (sessionId: string, toolEvent: { toolName: string; state?: unknown; timestamp: number }) => void): () => void {
+    return window.maestro.process.onToolExecution(handler);
   }
 };


### PR DESCRIPTION
## 🎯 Summary

Enable real-time streaming for OpenCode agent responses instead of buffering until completion. Also emit tool execution events so the UI can display what tools the agent is using.

**Fixes #58**

## 🐛 Problem

When using OpenCode agents in Maestro:
1. **No Token Streaming**: Responses are buffered and displayed all at once after completion, instead of streaming token-by-token in real-time
2. **No Tool Execution Visibility**: Tool executions happen silently with no UI indication

## ✅ Root Cause Analysis

In `process-manager.ts`, lines 727-731 (before fix):

```typescript
// Accumulate text from partial streaming events (OpenCode text messages)
if (event.type === 'text' && event.isPartial && event.text) {
    managedProcess.streamedText = (managedProcess.streamedText || '') + event.text;
    // ❌ NO emit() here - text was only buffered, never displayed!
}
```

Text was accumulated in `streamedText` but only emitted when `step_finish` with `reason: 'stop'` arrived.

## ✅ Solution

### 1. Enable Real-Time Streaming
Emit partial text immediately instead of only accumulating:

```typescript
if (event.type === 'text' && event.isPartial && event.text) {
    managedProcess.streamedText = (managedProcess.streamedText || '') + event.text;
    // ✅ Emit streaming text immediately for real-time display
    this.emit('data', sessionId, event.text);
}
```

### 2. Emit Tool Execution Events
Add tool event emission for UI visibility:

```typescript
if (event.type === 'tool_use' && event.toolName) {
    this.emit('tool-execution', sessionId, {
        toolName: event.toolName,
        state: event.toolState,
        timestamp: Date.now(),
    });
}
```

## 📝 Changes

| File | Change |
|------|--------|
| `src/main/process-manager.ts` | Emit 'data' event immediately for partial text; emit 'tool-execution' events |
| `src/main/index.ts` | Forward tool-execution events to renderer via IPC |
| `src/main/preload.ts` | Add onToolExecution handler for IPC bridge |
| `src/renderer/services/process.ts` | Add onToolExecution service method |
| `src/renderer/global.d.ts` | Add type definition for onToolExecution |

## 🧪 Testing

- [x] TypeScript lint passes
- [x] Build passes (main, renderer, web, CLI)
- [ ] Manual testing with OpenCode agent

## 📋 Checklist

- [x] Code follows project style guidelines
- [x] Conventional commit format used
- [x] No breaking changes
- [x] Backward compatible (existing behavior for Claude/Codex unchanged)
- [x] Type definitions added

## 🔗 Related

- **Fixes**: #58
- **Type**: Feature enhancement
- **Impact**: OpenCode users get real-time streaming and tool visibility
- **Breaking Changes**: None

## 📸 Before vs After

### Before
- Text appears all at once after AI finishes generating
- No indication of which tools are being used

### After
- Text streams in real-time as AI generates it ✅
- Tool execution events emitted for future UI display ✅

---

**Note**: The tool-execution events are now being emitted but the UI currently doesn't display them. A follow-up PR could add a UI component to show tool execution status (similar to how other coding assistants show tool activity).