### PR TITLE
feat: add copy-on-drag support in Auto Run dialog

### DIFF
--- a/src/main/debug-package/__tests__/packager.test.ts
+++ b/src/main/debug-package/__tests__/packager.test.ts
@@ -210,6 +210,7 @@ describe('Debug Package Packager', () => {
         'storage-info.json': { paths: {} },
         'group-chats.json': [],
         'batch-state.json': { activeSessions: [] },
+        'windows-diagnostics.json': { platform: 'win32' },
         'collection-errors.json': [],
       };
 
@@ -218,8 +219,8 @@ describe('Debug Package Packager', () => {
       const zip = new AdmZip(result.path);
       const entryNames = zip.getEntries().map((e) => e.entryName);
 
-      // All 14 JSON files + README
-      expect(entryNames).toHaveLength(15);
+      // All 15 JSON files + README
+      expect(entryNames).toHaveLength(16);
       expect(entryNames).toContain('README.md');
 
       for (const filename of Object.keys(fullContents)) {

--- a/src/main/debug-package/packager.ts
+++ b/src/main/debug-package/packager.ts
@@ -22,6 +22,7 @@ export interface PackageContents {
   'storage-info.json': unknown;
   'group-chats.json': unknown;
   'batch-state.json': unknown;
+  'windows-diagnostics.json': unknown;
   'collection-errors.json'?: unknown;
 }
 

--- a/src/renderer/components/BatchRunnerModal.tsx
+++ b/src/renderer/components/BatchRunnerModal.tsx
@@ -617,7 +617,7 @@ export function BatchRunnerModal(props: BatchRunnerModalProps) {
           {/* Left side: Hint */}
           <div className="flex items-center gap-2 text-xs" style={{ color: theme.colors.textDim }}>
             <span className="px-1.5 py-0.5 rounded border text-[10px] font-mono" style={{ borderColor: theme.colors.border, backgroundColor: theme.colors.bgActivity }}>
-              {navigator.platform.toLowerCase().includes('mac') ? '⌘' : 'Ctrl'} + Drag
+              {(navigator.userAgentData?.platform?.toLowerCase().includes('mac') || navigator.platform.toLowerCase().includes('mac')) ? '⌘' : 'Ctrl'} + Drag
             </span>
             <span>to copy document</span>
           </div>

--- a/src/renderer/components/DocumentsPanel.tsx
+++ b/src/renderer/components/DocumentsPanel.tsx
@@ -617,7 +617,7 @@ export function DocumentsPanel({
     setIsCopyDrag(isCopy);
     e.dataTransfer.dropEffect = isCopy ? 'copy' : 'move';
     
-    if (draggedId && draggedId !== id) {
+    if (draggedId && (isCopy || draggedId !== id)) {
       // Get the element's bounding rect to determine if cursor is in top or bottom half
       const rect = e.currentTarget.getBoundingClientRect();
       const midY = rect.top + rect.height / 2;
@@ -633,7 +633,14 @@ export function DocumentsPanel({
         setDropTargetIndex(dropIndex);
       }
     }
-  }, [draggedId, documents, isCopyDrag]);
+  }, [draggedId, documents]);
+
+  const handleDragLeave = useCallback((e: React.DragEvent) => {
+    // Only clear if leaving the entire documents container (not just moving between items)
+    if (e.currentTarget === e.target) {
+      setDropTargetIndex(null);
+    }
+  }, []);
 
   const handleDragEnd = useCallback(() => {
     if (draggedId && dropTargetIndex !== null) {
@@ -758,7 +765,7 @@ export function DocumentsPanel({
             <p className="text-xs mt-1">Click "+ Add Docs" to select documents to run</p>
           </div>
         ) : (
-          <div>
+          <div onDragLeave={handleDragLeave}>
             {documents.map((doc, index) => {
               const docTaskCount = taskCounts[doc.filename] ?? 0;
               const isBeingDragged = draggedId === doc.id;


### PR DESCRIPTION
## Summary

This PR adds the ability to **copy documents by holding Cmd (Mac) or Ctrl (Windows) while dragging** in the Auto Run Configuration dialog.

## Changes

### New Features
- **Copy-on-drag**: Hold Cmd/Ctrl while dragging a document to create a copy instead of moving it
- **Floating plus icon**: A green plus icon follows the cursor when in copy mode, similar to macOS Finder behavior
- **Drop indicator line**: Visual indicator shows the exact insertion position between documents (with circles on each end)
- **Keyboard shortcut hint**: Tag-style hint in the dialog footer shows the shortcut (`⌘ + Drag` on Mac, `Ctrl + Drag` on Windows)

### UX Improvements
- Precise cursor position detection determines if drop happens before or after a document
- Drop inca
This PR adds the ability to **copy documents by holding Cmd (Mac) or Ctrl (Windows) while dragging** in the Auto Run Configuration dialog.

## Changes

### New Features
- **Copy-on-drag**: Hold Cmd/Ctrl while dragging a document to create hments/assets/place
## Changes

### New Features
- **Copy-on-drag**: Hold Cmd/Ctrl while dragging a document to create a copy instead of moving iition
3. Hold ⌘ Cmd (Mac- *Ctrl (Windows)- **Floating plus icon**: A green plus icon follows the cursor when in copy mode, sat the indicato- **Drop indicator line**: Visual indicator shows the exact insertion position between documents (with cirt's style- **Keyboard shortcut hint**: Tag-style hint in the dialog footer shows the shortcut (`⌘ + Drag` on Mac, `uild`)

## Preview

<img width="972" height="1338" alt="image" src="https://github.com/user-attachments/assets/926c0692-1875-4caa-828d-ba5ef93f764a" />