### PR TITLE
fix: display correct tool names for OpenCode sessions

### DIFF
--- a/src/renderer/components/AgentSessionsBrowser.tsx
+++ b/src/renderer/components/AgentSessionsBrowser.tsx
@@ -11,6 +11,16 @@ import { useSessionPagination } from '../hooks/useSessionPagination';
 import { useFilteredAndSortedSessions } from '../hooks/useFilteredAndSortedSessions';
 import { useClickOutside } from '../hooks';
 
+/**
+ * Get tool name from toolUse array - supports both Claude (name) and OpenCode (tool) formats
+ */
+function getToolName(toolUse: any[] | undefined): string {
+  if (!toolUse || toolUse.length === 0) return 'unknown';
+  const firstTool = toolUse[0];
+  // Claude format uses 'name', OpenCode format uses 'tool'
+  return firstTool?.name || firstTool?.tool || 'unknown';
+}
+
 type SearchMode = 'title' | 'user' | 'assistant' | 'all';
 
 interface SearchResult {
@@ -498,7 +508,7 @@ export function AgentSessionsBrowser({
         id: msg.uuid || `${viewingSession.sessionId}-${idx}`,
         timestamp: new Date(msg.timestamp).getTime(),
         source: msg.type === 'user' ? 'user' as const : 'stdout' as const,
-        text: msg.content || (msg.toolUse ? `[Tool: ${msg.toolUse[0]?.name || 'unknown'}]` : '[No content]'),
+        text: msg.content || (msg.toolUse ? `[Tool: ${getToolName(msg.toolUse)}]` : '[No content]'),
       }));
       // Pass session name and starred status for the new tab
       const isStarred = starredSessions.has(viewingSession.sessionId);
@@ -923,7 +933,7 @@ export function AgentSessionsBrowser({
                 }}
               >
                 <div className="whitespace-pre-wrap break-words">
-                  {msg.content || (msg.toolUse ? `[Tool: ${msg.toolUse[0]?.name || 'unknown'}]` : '[No content]')}
+                  {msg.content || (msg.toolUse ? `[Tool: ${getToolName(msg.toolUse)}]` : '[No content]')}
                 </div>
                 <div
                   className="text-[10px] mt-2 opacity-60"

--- a/src/renderer/components/AgentSessionsModal.tsx
+++ b/src/renderer/components/AgentSessionsModal.tsx
@@ -6,6 +6,16 @@ import { useListNavigation } from '../hooks/useListNavigation';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
 import { formatSize, formatRelativeTime } from '../utils/formatters';
 
+/**
+ * Get tool name from toolUse array - supports both Claude (name) and OpenCode (tool) formats
+ */
+function getToolName(toolUse: any[] | undefined): string {
+  if (!toolUse || toolUse.length === 0) return 'unknown';
+  const firstTool = toolUse[0];
+  // Claude format uses 'name', OpenCode format uses 'tool'
+  return firstTool?.name || firstTool?.tool || 'unknown';
+}
+
 interface AgentSession {
   sessionId: string;
   projectPath: string;
@@ -478,7 +488,7 @@ export function AgentSessionsModal({
                   }}
                 >
                   <div className="whitespace-pre-wrap break-words">
-                    {msg.content || (msg.toolUse ? `[Tool: ${msg.toolUse[0]?.name || 'unknown'}]` : '[No content]')}
+                    {msg.content || (msg.toolUse ? `[Tool: ${getToolName(msg.toolUse)}]` : '[No content]')}
                   </div>
                   <div
                     className="text-[10px] mt-1 opacity-60"


### PR DESCRIPTION
## Summary

Fixes tool names displaying as \"[Tool: unknown]\" for OpenCode sessions in the Sessions Browser.

## Problem

When viewing OpenCode session history, tool calls were showing as \`[Tool: unknown]\` instead of the actual tool name. This happened because:

- **Claude format**: stores tool name in \`toolUse[0].name\`
- **OpenCode format**: stores tool name in \`toolUse[0].tool\`

The session browser was only checking the \`name\` property, missing OpenCode's \`tool\` property.

## Solution

Added a \`getToolName()\` helper function that checks both formats:

\`\`\`typescript
function getToolName(toolUse: any[] | undefined): string {
  if (!toolUse || toolUse.length === 0) return 'unknown';
  const firstTool = toolUse[0];
  // Claude format uses 'name', OpenCode format uses 'tool'
  return firstTool?.name || firstTool?.tool || 'unknown';
}
\`\`\`

## Files Changed

- **AgentSessionsBrowser.tsx**: Add helper function and update 2 usages (log entry conversion and message bubble display)
- **AgentSessionsModal.tsx**: Add helper function and update 1 usage (message bubble display)

## Testing

1. Use OpenCode agent for a session that involves tool calls
2. Open Sessions Browser (Cmd+Shift+H)
3. View the session details
4. Verify tool names display correctly instead of \"unknown\"

## Preview 

<img width="584" height="297" alt="image" src="https://github.com/user-attachments/assets/29250769-e431-46eb-b254-6245c5b0446b" />
