### PR TITLE
feat: add collapsible tool call display in session browser

### DIFF
--- a/src/renderer/components/AgentSessionsModal.tsx
+++ b/src/renderer/components/AgentSessionsModal.tsx
@@ -5,6 +5,7 @@ import { useLayerStack } from '../contexts/LayerStackContext';
 import { useListNavigation } from '../hooks/useListNavigation';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
 import { formatSize, formatRelativeTime } from '../utils/formatters';
+import { ToolCallCard } from './ToolCallCard';
 
 interface AgentSession {
   sessionId: string;
@@ -470,23 +471,36 @@ export function AgentSessionsModal({
                 key={msg.uuid || idx}
                 className={`flex ${msg.type === 'user' ? 'justify-end' : 'justify-start'}`}
               >
-                <div
-                  className="max-w-[85%] rounded-lg px-4 py-2 text-sm"
-                  style={{
-                    backgroundColor: msg.type === 'user' ? theme.colors.accent : theme.colors.bgMain,
-                    color: msg.type === 'user' ? (theme.mode === 'light' ? '#fff' : '#000') : theme.colors.textMain,
-                  }}
-                >
-                  <div className="whitespace-pre-wrap break-words">
-                    {msg.content || (msg.toolUse ? `[Tool: ${msg.toolUse[0]?.name || 'unknown'}]` : '[No content]')}
+                {/* Tool call messages - render with ToolCallCard */}
+                {msg.toolUse && msg.toolUse.length > 0 ? (
+                  <div className="max-w-[85%]">
+                    <ToolCallCard
+                      theme={theme}
+                      toolUse={msg.toolUse}
+                      timestamp={formatRelativeTime(msg.timestamp)}
+                      defaultExpanded={false}
+                    />
                   </div>
+                ) : (
+                  /* Regular text messages */
                   <div
-                    className="text-[10px] mt-1 opacity-60"
-                    style={{ color: msg.type === 'user' ? (theme.mode === 'light' ? '#fff' : '#000') : theme.colors.textDim }}
+                    className="max-w-[85%] rounded-lg px-4 py-2 text-sm"
+                    style={{
+                      backgroundColor: msg.type === 'user' ? theme.colors.accent : theme.colors.bgMain,
+                      color: msg.type === 'user' ? (theme.mode === 'light' ? '#fff' : '#000') : theme.colors.textMain,
+                    }}
                   >
-                    {formatRelativeTime(msg.timestamp)}
+                    <div className="whitespace-pre-wrap break-words">
+                      {msg.content || '[No content]'}
+                    </div>
+                    <div
+                      className="text-[10px] mt-1 opacity-60"
+                      style={{ color: msg.type === 'user' ? (theme.mode === 'light' ? '#fff' : '#000') : theme.colors.textDim }}
+                    >
+                      {formatRelativeTime(msg.timestamp)}
+                    </div>
                   </div>
-                </div>
+                )}
               </div>
             ))}
 

--- a/src/renderer/components/ToolCallCard.tsx
+++ b/src/renderer/components/ToolCallCard.tsx
@@ -1,0 +1,257 @@
+import { useState, memo } from 'react';
+import { ChevronDown, ChevronRight, Clock, CheckCircle2, Loader2, AlertCircle } from 'lucide-react';
+import type { Theme } from '../types';
+
+/**
+ * Tool call state from OpenCode/Codex sessions
+ */
+interface ToolState {
+  status?: string;
+  input?: unknown;
+  output?: unknown;
+}
+
+/**
+ * Tool use entry from session messages
+ * Supports both Claude format (name) and OpenCode format (tool)
+ */
+interface ToolUseEntry {
+  name?: string;
+  tool?: string;
+  state?: ToolState;
+  // Additional fields that might be present
+  id?: string;
+  type?: string;
+}
+
+interface ToolCallCardProps {
+  theme: Theme;
+  toolUse: ToolUseEntry[];
+  timestamp?: string;
+  /** Whether the card starts expanded or collapsed */
+  defaultExpanded?: boolean;
+}
+
+/**
+ * Get tool name from tool use entry - supports both Claude (name) and OpenCode (tool) formats
+ */
+function getToolName(tool: ToolUseEntry): string {
+  return tool?.name || tool?.tool || 'unknown';
+}
+
+/**
+ * Get status icon based on tool state
+ */
+function StatusIcon({ status, theme }: { status?: string; theme: Theme }) {
+  switch (status) {
+    case 'completed':
+    case 'success':
+      return <CheckCircle2 className="w-3.5 h-3.5" style={{ color: theme.colors.success }} />;
+    case 'running':
+    case 'pending':
+      return <Loader2 className="w-3.5 h-3.5 animate-spin" style={{ color: theme.colors.warning }} />;
+    case 'error':
+    case 'failed':
+      return <AlertCircle className="w-3.5 h-3.5" style={{ color: theme.colors.error }} />;
+    default:
+      return <CheckCircle2 className="w-3.5 h-3.5" style={{ color: theme.colors.success }} />;
+  }
+}
+
+/**
+ * Collapsible JSON content section
+ */
+const CollapsibleContent = memo(function CollapsibleContent({
+  label,
+  content,
+  theme,
+  defaultExpanded = false,
+  maxCollapsedLines = 5,
+}: {
+  label: string;
+  content: unknown;
+  theme: Theme;
+  defaultExpanded?: boolean;
+  maxCollapsedLines?: number;
+}) {
+  const [expanded, setExpanded] = useState(defaultExpanded);
+
+  if (content === undefined || content === null) return null;
+
+  const formattedContent = typeof content === 'string'
+    ? content
+    : JSON.stringify(content, null, 2);
+
+  const lines = formattedContent.split('\n');
+  const isLong = lines.length > maxCollapsedLines;
+  const displayContent = expanded || !isLong
+    ? formattedContent
+    : lines.slice(0, maxCollapsedLines).join('\n') + '\n...';
+
+  return (
+    <div className="mt-2">
+      <div
+        className="flex items-center gap-1 text-xs font-medium mb-1 cursor-pointer select-none"
+        style={{ color: theme.colors.textDim }}
+        onClick={() => isLong && setExpanded(!expanded)}
+      >
+        <span>{label}:</span>
+        {isLong && (
+          <button
+            className="text-xs hover:underline ml-1"
+            style={{ color: theme.colors.accent }}
+          >
+            {expanded ? 'Show less' : 'Show more'}
+          </button>
+        )}
+      </div>
+      <pre
+        className="text-xs font-mono p-2 rounded overflow-x-auto whitespace-pre-wrap break-words"
+        style={{
+          backgroundColor: theme.colors.bgMain,
+          color: theme.colors.textMain,
+          maxHeight: expanded ? 'none' : '150px',
+        }}
+      >
+        {displayContent}
+      </pre>
+    </div>
+  );
+});
+
+/**
+ * ToolCallCard - Displays tool execution details with collapsible sections
+ * 
+ * Features:
+ * - Collapsible card (show/hide entire tool details)
+ * - Tool name with status indicator
+ * - Time and Status fields
+ * - Collapsible Input section with JSON formatting
+ * - Collapsible Output section with JSON formatting
+ * - "Show more" links for long content
+ */
+export const ToolCallCard = memo(function ToolCallCard({
+  theme,
+  toolUse,
+  timestamp,
+  defaultExpanded = false,
+}: ToolCallCardProps) {
+  const [expanded, setExpanded] = useState(defaultExpanded);
+
+  if (!toolUse || toolUse.length === 0) return null;
+
+  // Get first tool (usually there's only one per message)
+  const tool = toolUse[0];
+  const toolName = getToolName(tool);
+  const state = tool.state;
+  const status = state?.status || 'completed';
+
+  // Collapsed view - just show tool name and "Show more"
+  if (!expanded) {
+    return (
+      <div
+        className="rounded-lg px-4 py-3 text-sm cursor-pointer hover:opacity-90 transition-opacity"
+        style={{
+          backgroundColor: theme.colors.bgActivity,
+          borderLeft: `3px solid ${theme.colors.warning}`,
+        }}
+        onClick={() => setExpanded(true)}
+      >
+        <div className="flex items-center gap-2">
+          <ChevronRight className="w-4 h-4 shrink-0" style={{ color: theme.colors.textDim }} />
+          <span
+            className="px-1.5 py-0.5 rounded text-xs font-medium"
+            style={{
+              backgroundColor: `${theme.colors.warning}20`,
+              color: theme.colors.warning,
+            }}
+          >
+            Tool: {toolName}
+          </span>
+          <StatusIcon status={status} theme={theme} />
+          <button
+            className="text-xs hover:underline ml-auto"
+            style={{ color: theme.colors.accent }}
+          >
+            Show more
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // Expanded view - show all details
+  return (
+    <div
+      className="rounded-lg text-sm overflow-hidden"
+      style={{
+        backgroundColor: theme.colors.bgActivity,
+        borderLeft: `3px solid ${theme.colors.warning}`,
+      }}
+    >
+      {/* Header - clickable to collapse */}
+      <div
+        className="px-4 py-3 cursor-pointer hover:opacity-90 transition-opacity flex items-center gap-2"
+        style={{ backgroundColor: `${theme.colors.warning}08` }}
+        onClick={() => setExpanded(false)}
+      >
+        <ChevronDown className="w-4 h-4 shrink-0" style={{ color: theme.colors.textDim }} />
+        <span
+          className="px-1.5 py-0.5 rounded text-xs font-medium"
+          style={{
+            backgroundColor: `${theme.colors.warning}20`,
+            color: theme.colors.warning,
+          }}
+        >
+          Tool: {toolName}
+        </span>
+        <StatusIcon status={status} theme={theme} />
+        <button
+          className="text-xs hover:underline ml-auto"
+          style={{ color: theme.colors.accent }}
+        >
+          Collapse
+        </button>
+      </div>
+
+      {/* Content */}
+      <div className="px-4 py-3">
+        {/* Input section */}
+        {state?.input !== undefined && (
+          <CollapsibleContent
+            label="Input"
+            content={state.input}
+            theme={theme}
+            defaultExpanded={false}
+          />
+        )}
+
+        {/* Status and Time row */}
+        <div className="flex items-center gap-4 mt-3 text-xs" style={{ color: theme.colors.textDim }}>
+          {timestamp && (
+            <div className="flex items-center gap-1">
+              <Clock className="w-3 h-3" />
+              <span>Time: {timestamp}</span>
+            </div>
+          )}
+          <div className="flex items-center gap-1">
+            <StatusIcon status={status} theme={theme} />
+            <span>Status: {status}</span>
+          </div>
+        </div>
+
+        {/* Output section */}
+        {state?.output !== undefined && (
+          <CollapsibleContent
+            label="Output"
+            content={state.output}
+            theme={theme}
+            defaultExpanded={false}
+          />
+        )}
+      </div>
+    </div>
+  );
+});
+
+export default ToolCallCard;


### PR DESCRIPTION
Add ToolCallCard component that displays tool execution details from session history with collapsible sections for better readability.

## Features

- **Collapsible card header** - Collapsed shows `[Tool: toolname]` with status indicator and "Show more" link
- **Expandable Input section** - JSON-formatted input with "Show more/less" for long content
- **Expandable Output section** - JSON-formatted output with "Show more/less" for long content
- **Time and Status fields** - Shows execution timestamp and completion status
- **Status indicators** - Visual icons for completed (checkmark), running (spinner), error states
- **Multi-format support** - Works with both Claude (`name`) and OpenCode (`tool`) tool formats

## Files Changed

- **ToolCallCard.tsx** (new) - Reusable component for displaying tool calls with collapsible sections
- **AgentSessionsBrowser.tsx** - Integrate ToolCallCard, add getToolName helper function
- **AgentSessionsModal.tsx** - Integrate ToolCallCard for consistency across session views

## Screenshots

**When collapsed:**
```
[Tool: bash] ✓  Show more
```

**When expanded:**
```
[Tool: bash] ✓  Collapse

Input:
{
  "command": "git status && git diff..."
}

Time: 6h ago    Status: completed

Output:
On branch feat/auth-sessions
Your branch is up to date...
```

## Preview

<img width="830" height="1002" alt="image" src="https://github.com/user-attachments/assets/47eefaae-9191-4f3f-9085-3daf7f789fd5" />
