### PR TITLE
feat(acp): Add ACP protocol support for OpenCode integration

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -102,7 +102,7 @@ The major contributions to 0.14.x remain:
 - Leaderboard tracking now works across multiple systems and syncs level from cloud 🏆
 - Agent duplication. Pro tip: Consider a group of unused "Template" agents ✌️
 - New setting to prevent system from going to sleep while agents are active 🛏️
-- The tab menu has a new "Publish as GitHub Gist" option  📝
+- The tab menu has a new "Publish as GitHub Gist" option 📝
 - The tab menu has options to move the tab to the first or last position 🔀
 - [Maestro-Playbooks](https://github.com/pedramamini/Maestro-Playbooks) can now contain non-markdown assets 📙
 - Improved default shell detection 🐚
@@ -131,10 +131,12 @@ Thanks for the contributions: @t1mmen @aejfager @Crumbgrabber @whglaser @b3nw @d
 - TAKE TWO! Fixed Linux ARM64 build architecture contamination issues 🏗️
 
 ### v0.13.1 Changes
+
 - Fixed Linux ARM64 build architecture contamination issues 🏗️
 - Enhanced error handling for Auto Run batch processing 🚨
 
 ### v0.13.0 Changes
+
 - Added a global usage dashboard, data collection begins with this install 🎛️
 - Added a Playbook Exchange for downloading pre-defined Auto Run playbooks from [Maestro-Playbooks](https://github.com/pedramamini/Maestro-Playbooks) 📕
 - Bundled OpenSpec commands for structured change proposals 📝
@@ -158,15 +160,19 @@ Thanks for the contributions: @t1mmen @aejfager @Crumbgrabber @whglaser @b3nw @d
 The big changes in the v0.12.x line are the following three:
 
 ## Show Thinking
-🤔 There is now a toggle to show thinking for the agent, the default for new tabs is off, though this can be changed under Settings > General. The toggle shows next to History and Read-Only. Very similar pattern. This has been the #1 most requested feature, though personally, I don't think I'll use it as I prefer to not see the details of the work, but the results of the work. Just as we work with our colleagues. 
+
+🤔 There is now a toggle to show thinking for the agent, the default for new tabs is off, though this can be changed under Settings > General. The toggle shows next to History and Read-Only. Very similar pattern. This has been the #1 most requested feature, though personally, I don't think I'll use it as I prefer to not see the details of the work, but the results of the work. Just as we work with our colleagues.
 
 ## GitHub Spec-Kit Integration
+
 🎯 Added [GitHub Spec-Kit](https://github.com/github/spec-kit) commands into Maestro with a built in updater to grab the latest prompts from the repository. We do override `/speckit-implement` (the final step) to create Auto Run docs and guide the user through their execution, which thanks to Wortrees from v0.11.x allows us to run in parallel!
 
 ## Context Management Tools
+
 📖 Added context management options from tab right-click menu. You can now compress, merge, and transfer contexts between agents. You will received (configurable) warnings at 60% and 80% context consumption with a hint to compact.
 
 ## Changes Specific to v0.12.3:
+
 - We now have hosted documentation through Mintlify 📚
 - Export any tab conversation as self-contained themed HTML file 📄
 - Publish files as private/public Gists 🌐
@@ -279,6 +285,7 @@ The big changes in the v0.12.x line are the following three:
 Minor bugfixes on top of v0.7.3:
 
 # Onboarding, Wizard, and Tours
+
 - Implemented comprehensive onboarding wizard with integrated tour system 🚀
 - Added project-understanding confidence display to wizard UI 🎨
 - Enhanced keyboard navigation across all wizard screens ⌨️
@@ -286,6 +293,7 @@ Minor bugfixes on top of v0.7.3:
 - Added First Run Celebration modal with confetti animation 🎉
 
 # UI / UX Enhancements
+
 - Added expand-to-fullscreen button for Auto Run interface 🖥️
 - Created dedicated modal component and improved modal priority constants for expanded Auto Run view 📐
 - Enhanced user experience with fullscreen editing capabilities ✨
@@ -295,15 +303,18 @@ Minor bugfixes on top of v0.7.3:
 - Enhanced toast context with agent name for OS notifications 📢
 
 # Auto Run Workflow Improvements
+
 - Created phase document generation for Auto Run workflow 📄
 - Added real-time log streaming to the LogViewer component 📊
 
 # Application Behavior / Core Fixes
+
 - Added validation to prevent nested worktrees inside the main repository 🚫
 - Fixed process manager to properly emit exit events on errors 🔧
 - Fixed process exit handling to ensure proper cleanup 🧹
 
 # Update System
+
 - Implemented automatic update checking on application startup 🚀
 - Added settings toggle for enabling/disabling startup update checks ⚙️
 
@@ -321,6 +332,7 @@ Minor bugfixes on top of v0.7.3:
 **Latest: v0.6.1** | Released December 4, 2025
 
 In this release...
+
 - Added recursive subfolder support for Auto Run markdown files 🗂️
 - Enhanced document tree display with expandable folder navigation 🌳
 - Enabled creating documents in subfolders with path selection 📁
@@ -333,6 +345,7 @@ In this release...
 - Added support for nested folder structures in document management 🏗️
 
 Plus the pre-release ALPHA...
+
 - Template vars now set context in default autorun prompt 🚀
 - Added Enter key support for queued message confirmation dialog ⌨️
 - Kill process capability added to System Process Monitor 💀
@@ -492,6 +505,7 @@ Plus the pre-release ALPHA...
 All releases are available on the [GitHub Releases page](https://github.com/RunMaestro/Maestro/releases).
 
 Maestro is available for:
+
 - **macOS** - Apple Silicon (arm64) and Intel (x64)
 - **Windows** - x64
 - **Linux** - x64 and arm64, AppImage, deb, and rpm packages

--- a/src/__tests__/main/acp/acp-adapter.test.ts
+++ b/src/__tests__/main/acp/acp-adapter.test.ts
@@ -216,7 +216,7 @@ describe('ACP Adapter', () => {
 		});
 
 		describe('current_mode_update', () => {
-			it('should return null for mode updates', () => {
+			it('should convert mode update to system message', () => {
 				const update = {
 					current_mode_update: {
 						currentModeId: 'code',
@@ -225,7 +225,117 @@ describe('ACP Adapter', () => {
 
 				const event = acpUpdateToParseEvent(testSessionId, update);
 
-				expect(event).toBeNull();
+				expect(event).not.toBeNull();
+				expect(event?.type).toBe('system');
+				expect(event?.text).toBe('Mode changed to: code');
+				expect(event?.sessionId).toBe(testSessionId);
+			});
+		});
+
+		describe('usage_update', () => {
+			it('should convert usage update to usage ParsedEvent', () => {
+				const update = {
+					usage_update: {
+						used: 5000,
+						size: 128000,
+					},
+				} as unknown as SessionUpdate;
+
+				const event = acpUpdateToParseEvent(testSessionId, update);
+
+				expect(event).not.toBeNull();
+				expect(event?.type).toBe('usage');
+				expect(event?.sessionId).toBe(testSessionId);
+				expect(event?.usage).toEqual({
+					inputTokens: 5000,
+					outputTokens: 0,
+					cacheReadTokens: 0,
+					cacheCreationTokens: 0,
+					contextWindow: 128000,
+					costUsd: 0,
+				});
+			});
+
+			it('should include USD cost when provided', () => {
+				const update = {
+					usage_update: {
+						used: 10000,
+						size: 128000,
+						cost: {
+							amount: 0.0125,
+							currency: 'USD',
+						},
+					},
+				} as unknown as SessionUpdate;
+
+				const event = acpUpdateToParseEvent(testSessionId, update);
+
+				expect(event).not.toBeNull();
+				expect(event?.usage?.costUsd).toBe(0.0125);
+			});
+
+			it('should set costUsd to 0 for non-USD currencies', () => {
+				const update = {
+					usage_update: {
+						used: 10000,
+						size: 128000,
+						cost: {
+							amount: 0.01,
+							currency: 'EUR',
+						},
+					},
+				} as unknown as SessionUpdate;
+
+				const event = acpUpdateToParseEvent(testSessionId, update);
+
+				expect(event).not.toBeNull();
+				expect(event?.usage?.costUsd).toBe(0);
+			});
+		});
+
+		describe('config_option_update', () => {
+			it('should convert config option update to system message', () => {
+				const update = {
+					config_option_update: {
+						key: 'model',
+						value: 'claude-3-opus',
+					},
+				} as unknown as SessionUpdate;
+
+				const event = acpUpdateToParseEvent(testSessionId, update);
+
+				expect(event).not.toBeNull();
+				expect(event?.type).toBe('system');
+				expect(event?.text).toBe('Config updated: model = "claude-3-opus"');
+				expect(event?.sessionId).toBe(testSessionId);
+			});
+
+			it('should handle complex config values', () => {
+				const update = {
+					config_option_update: {
+						key: 'options',
+						value: { streaming: true, maxTokens: 4096 },
+					},
+				} as unknown as SessionUpdate;
+
+				const event = acpUpdateToParseEvent(testSessionId, update);
+
+				expect(event).not.toBeNull();
+				expect(event?.text).toBe('Config updated: options = {"streaming":true,"maxTokens":4096}');
+			});
+
+			it('should handle boolean config values', () => {
+				const update = {
+					config_option_update: {
+						key: 'verboseMode',
+						value: true,
+					},
+				} as unknown as SessionUpdate;
+
+				const event = acpUpdateToParseEvent(testSessionId, update);
+
+				expect(event).not.toBeNull();
+				expect(event?.text).toBe('Config updated: verboseMode = true');
 			});
 		});
 	});

--- a/src/__tests__/main/acp/acp-adapter.test.ts
+++ b/src/__tests__/main/acp/acp-adapter.test.ts
@@ -1,0 +1,303 @@
+import { describe, it, expect } from 'vitest';
+import {
+	acpUpdateToParseEvent,
+	createSessionIdEvent,
+	createResultEvent,
+	createErrorEvent,
+} from '../../../main/acp/acp-adapter';
+import type { SessionUpdate } from '../../../main/acp/types';
+
+describe('ACP Adapter', () => {
+	const testSessionId = 'test-session-123';
+
+	describe('acpUpdateToParseEvent', () => {
+		describe('agent_message_chunk', () => {
+			it('should convert OpenCode format text chunk to ParsedEvent', () => {
+				// OpenCode sends: { type: 'text', text: 'Hello' }
+				const update = {
+					agent_message_chunk: {
+						content: { type: 'text', text: 'Hello, world!' },
+					},
+				} as unknown as SessionUpdate;
+
+				const event = acpUpdateToParseEvent(testSessionId, update);
+
+				expect(event).not.toBeNull();
+				expect(event?.type).toBe('text');
+				expect(event?.text).toBe('Hello, world!');
+				expect(event?.isPartial).toBe(true);
+				expect(event?.sessionId).toBe(testSessionId);
+			});
+
+			it('should convert ACP spec format text chunk to ParsedEvent', () => {
+				// ACP spec: { text: { text: 'Hello' } }
+				const update = {
+					agent_message_chunk: {
+						content: { text: { text: 'Spec format text' } },
+					},
+				} as unknown as SessionUpdate;
+
+				const event = acpUpdateToParseEvent(testSessionId, update);
+
+				expect(event).not.toBeNull();
+				expect(event?.type).toBe('text');
+				expect(event?.text).toBe('Spec format text');
+			});
+
+			it('should handle image content blocks', () => {
+				const update = {
+					agent_message_chunk: {
+						content: { image: { data: 'base64...', mimeType: 'image/png' } },
+					},
+				} as unknown as SessionUpdate;
+
+				const event = acpUpdateToParseEvent(testSessionId, update);
+
+				expect(event).not.toBeNull();
+				expect(event?.text).toBe('[image]');
+			});
+
+			it('should handle resource_link content blocks', () => {
+				const update = {
+					agent_message_chunk: {
+						content: { resource_link: { uri: 'file://test.txt', name: 'test.txt' } },
+					},
+				} as unknown as SessionUpdate;
+
+				const event = acpUpdateToParseEvent(testSessionId, update);
+
+				expect(event).not.toBeNull();
+				expect(event?.text).toBe('[resource: test.txt]');
+			});
+		});
+
+		describe('agent_thought_chunk', () => {
+			it('should convert thought chunks with [thinking] prefix', () => {
+				const update = {
+					agent_thought_chunk: {
+						content: { type: 'text', text: 'Let me think about this...' },
+					},
+				} as unknown as SessionUpdate;
+
+				const event = acpUpdateToParseEvent(testSessionId, update);
+
+				expect(event).not.toBeNull();
+				expect(event?.type).toBe('text');
+				expect(event?.text).toBe('[thinking] Let me think about this...');
+				expect(event?.isPartial).toBe(true);
+			});
+		});
+
+		describe('user_message_chunk', () => {
+			it('should return null for user message chunks (not displayed)', () => {
+				const update = {
+					user_message_chunk: {
+						content: { type: 'text', text: 'User input' },
+					},
+				} as unknown as SessionUpdate;
+
+				const event = acpUpdateToParseEvent(testSessionId, update);
+
+				expect(event).toBeNull();
+			});
+		});
+
+		describe('tool_call', () => {
+			it('should convert tool_call to tool_use ParsedEvent', () => {
+				const update = {
+					tool_call: {
+						toolCallId: 'tc-123',
+						title: 'Read File',
+						kind: 'read',
+						status: 'in_progress',
+						rawInput: { path: '/test/file.txt' },
+					},
+				} as unknown as SessionUpdate;
+
+				const event = acpUpdateToParseEvent(testSessionId, update);
+
+				expect(event).not.toBeNull();
+				expect(event?.type).toBe('tool_use');
+				expect(event?.toolName).toBe('Read File');
+				expect(event?.toolState).toEqual({
+					id: 'tc-123',
+					input: { path: '/test/file.txt' },
+					status: 'running', // 'in_progress' maps to 'running'
+				});
+			});
+
+			it('should map tool status correctly', () => {
+				const statuses = [
+					{ acp: 'pending', expected: 'pending' },
+					{ acp: 'in_progress', expected: 'running' },
+					{ acp: 'completed', expected: 'completed' },
+					{ acp: 'failed', expected: 'error' },
+				];
+
+				for (const { acp, expected } of statuses) {
+					const update = {
+						tool_call: {
+							toolCallId: 'tc-test',
+							title: 'Test',
+							status: acp,
+						},
+					} as unknown as SessionUpdate;
+
+					const event = acpUpdateToParseEvent(testSessionId, update);
+					const toolState = event?.toolState as { status?: string } | undefined;
+					expect(toolState?.status).toBe(expected);
+				}
+			});
+		});
+
+		describe('tool_call_update', () => {
+			it('should convert tool_call_update with output', () => {
+				const update = {
+					tool_call_update: {
+						toolCallId: 'tc-123',
+						title: 'Read File',
+						status: 'completed',
+						rawInput: { path: '/test/file.txt' },
+						rawOutput: { content: 'file contents' },
+					},
+				} as unknown as SessionUpdate;
+
+				const event = acpUpdateToParseEvent(testSessionId, update);
+				const toolState = event?.toolState as { output?: unknown; status?: string } | undefined;
+
+				expect(event).not.toBeNull();
+				expect(event?.type).toBe('tool_use');
+				expect(toolState?.output).toEqual({ content: 'file contents' });
+				expect(toolState?.status).toBe('completed');
+			});
+		});
+
+		describe('plan', () => {
+			it('should convert plan to system message', () => {
+				const update = {
+					plan: {
+						entries: [
+							{ content: 'Read the file', status: 'completed', priority: 'high' },
+							{ content: 'Analyze content', status: 'in_progress', priority: 'medium' },
+							{ content: 'Write response', status: 'pending', priority: 'low' },
+						],
+					},
+				} as unknown as SessionUpdate;
+
+				const event = acpUpdateToParseEvent(testSessionId, update);
+
+				expect(event).not.toBeNull();
+				expect(event?.type).toBe('system');
+				expect(event?.text).toContain('Plan:');
+				expect(event?.text).toContain('[completed] Read the file');
+				expect(event?.text).toContain('[in_progress] Analyze content');
+				expect(event?.text).toContain('[pending] Write response');
+			});
+		});
+
+		describe('available_commands_update', () => {
+			it('should convert to init event with slash commands', () => {
+				const update = {
+					available_commands_update: {
+						availableCommands: [
+							{ name: '/help', description: 'Show help' },
+							{ name: '/clear', description: 'Clear history' },
+							{ name: '/compact', description: 'Compact mode' },
+						],
+					},
+				} as unknown as SessionUpdate;
+
+				const event = acpUpdateToParseEvent(testSessionId, update);
+
+				expect(event).not.toBeNull();
+				expect(event?.type).toBe('init');
+				expect(event?.slashCommands).toEqual(['/help', '/clear', '/compact']);
+			});
+		});
+
+		describe('current_mode_update', () => {
+			it('should return null for mode updates', () => {
+				const update = {
+					current_mode_update: {
+						currentModeId: 'code',
+					},
+				} as unknown as SessionUpdate;
+
+				const event = acpUpdateToParseEvent(testSessionId, update);
+
+				expect(event).toBeNull();
+			});
+		});
+	});
+
+	describe('createSessionIdEvent', () => {
+		it('should create an init event with sessionId', () => {
+			const event = createSessionIdEvent('new-session-456');
+
+			expect(event.type).toBe('init');
+			expect(event.sessionId).toBe('new-session-456');
+			expect(event.raw).toEqual({
+				type: 'session_created',
+				sessionId: 'new-session-456',
+			});
+		});
+	});
+
+	describe('createResultEvent', () => {
+		it('should create a result event with usage data', () => {
+			const usage = {
+				inputTokens: 100,
+				outputTokens: 50,
+				totalTokens: 150,
+			};
+
+			const event = createResultEvent(testSessionId, 'Task completed', 'end_turn', usage);
+
+			expect(event.type).toBe('result');
+			expect(event.text).toBe('Task completed');
+			expect(event.sessionId).toBe(testSessionId);
+			expect(event.usage).toEqual({
+				inputTokens: 100,
+				outputTokens: 50,
+				cacheReadTokens: 0,
+				cacheCreationTokens: 0,
+				costUsd: 0,
+				contextWindow: 0,
+			});
+		});
+
+		it('should create a result event without usage data', () => {
+			const event = createResultEvent(testSessionId, 'Done', 'end_turn');
+
+			expect(event.type).toBe('result');
+			expect(event.text).toBe('Done');
+			expect(event.usage).toBeUndefined();
+		});
+
+		it('should handle partial usage data', () => {
+			const usage = {
+				inputTokens: 100,
+				// outputTokens missing
+			};
+
+			const event = createResultEvent(testSessionId, 'Done', 'end_turn', usage);
+
+			expect(event.usage?.inputTokens).toBe(100);
+			expect(event.usage?.outputTokens).toBe(0);
+		});
+	});
+
+	describe('createErrorEvent', () => {
+		it('should create an error event', () => {
+			const event = createErrorEvent(testSessionId, 'Connection failed');
+
+			expect(event.type).toBe('error');
+			expect(event.text).toBe('Connection failed');
+			expect(event.sessionId).toBe(testSessionId);
+			expect(event.raw).toEqual({
+				type: 'error',
+				message: 'Connection failed',
+			});
+		});
+	});
+});

--- a/src/__tests__/main/acp/acp-client.test.ts
+++ b/src/__tests__/main/acp/acp-client.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ACPClient, type ACPClientConfig } from '../../../main/acp/acp-client';
+import type { SessionUpdate } from '../../../main/acp/types';
+
+// Mock child_process with factory that doesn't reference external variables
+vi.mock('child_process', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('child_process')>();
+	return {
+		...actual,
+		default: {
+			...actual,
+			spawn: vi.fn(),
+		},
+		spawn: vi.fn(),
+	};
+});
+
+// Mock readline
+vi.mock('readline', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('readline')>();
+	return {
+		...actual,
+		default: {
+			...actual,
+			createInterface: vi.fn(),
+		},
+		createInterface: vi.fn(),
+	};
+});
+
+// Mock logger
+vi.mock('../../../main/utils/logger', () => ({
+	logger: {
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+		debug: vi.fn(),
+	},
+}));
+
+describe('ACPClient', () => {
+	const mockConfig: ACPClientConfig = {
+		command: 'opencode',
+		args: ['acp'],
+		cwd: '/test/project',
+		env: { TEST_VAR: 'test' },
+	};
+
+	describe('constructor', () => {
+		it('should create client with config', () => {
+			const client = new ACPClient(mockConfig);
+
+			expect(client).toBeInstanceOf(ACPClient);
+			expect(client.getIsConnected()).toBe(false);
+			expect(client.getAgentCapabilities()).toBeNull();
+			expect(client.getAgentInfo()).toBeNull();
+		});
+
+		it('should accept custom client info', () => {
+			const configWithClientInfo: ACPClientConfig = {
+				...mockConfig,
+				clientInfo: {
+					name: 'custom-client',
+					version: '1.0.0',
+					title: 'Custom Client',
+				},
+			};
+
+			const client = new ACPClient(configWithClientInfo);
+			expect(client).toBeInstanceOf(ACPClient);
+		});
+
+		it('should accept custom client capabilities', () => {
+			const configWithCapabilities: ACPClientConfig = {
+				...mockConfig,
+				clientCapabilities: {
+					fs: {
+						readTextFile: true,
+						writeTextFile: false,
+					},
+					terminal: false,
+				},
+			};
+
+			const client = new ACPClient(configWithCapabilities);
+			expect(client).toBeInstanceOf(ACPClient);
+		});
+	});
+
+	describe('getProcess', () => {
+		it('should return null before connection', () => {
+			const client = new ACPClient(mockConfig);
+			expect(client.getProcess()).toBeNull();
+		});
+	});
+
+	describe('getIsConnected', () => {
+		it('should return false before connection', () => {
+			const client = new ACPClient(mockConfig);
+			expect(client.getIsConnected()).toBe(false);
+		});
+	});
+
+	describe('event emitter', () => {
+		it('should support event listeners', () => {
+			const client = new ACPClient(mockConfig);
+			const mockListener = vi.fn();
+
+			client.on('error', mockListener);
+			client.emit('error', new Error('Test error'));
+
+			expect(mockListener).toHaveBeenCalledTimes(1);
+			expect(mockListener).toHaveBeenCalledWith(expect.any(Error));
+		});
+
+		it('should support session:update events', () => {
+			const client = new ACPClient(mockConfig);
+			const mockListener = vi.fn();
+
+			client.on('session:update', mockListener);
+			client.emit('session:update', 'session-123', {
+				agent_message_chunk: { content: { text: { text: 'Hello' } } },
+			} as SessionUpdate);
+
+			expect(mockListener).toHaveBeenCalledWith('session-123', expect.any(Object));
+		});
+
+		it('should support disconnected events', () => {
+			const client = new ACPClient(mockConfig);
+			const mockListener = vi.fn();
+
+			client.on('disconnected', mockListener);
+			client.emit('disconnected');
+
+			expect(mockListener).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe('disconnect before connect', () => {
+		it('should handle disconnect gracefully when not connected', () => {
+			const client = new ACPClient(mockConfig);
+
+			// Should not throw
+			expect(() => client.disconnect()).not.toThrow();
+			expect(client.getIsConnected()).toBe(false);
+		});
+	});
+});
+
+describe('ACP Client Utilities', () => {
+	describe('redactForLogging', () => {
+		// We test this by observing the behavior through the client
+		// The actual function is private, but we can verify its behavior through logs
+
+		it('should preserve method and id in requests', () => {
+			// This is implicitly tested through the client's logging behavior
+			// The redactForLogging function keeps metadata intact
+			expect(true).toBe(true); // Placeholder for documentation
+		});
+	});
+});
+
+describe('ACP Protocol Constants', () => {
+	it('should use protocol version 1', async () => {
+		// Import the constant directly using dynamic import
+		const { CURRENT_PROTOCOL_VERSION } = await import('../../../main/acp/types');
+		expect(CURRENT_PROTOCOL_VERSION).toBe(1);
+	});
+});

--- a/src/__tests__/main/acp/acp-client.test.ts
+++ b/src/__tests__/main/acp/acp-client.test.ts
@@ -145,6 +145,16 @@ describe('ACPClient', () => {
 			expect(client.getIsConnected()).toBe(false);
 		});
 	});
+
+	describe('authenticate', () => {
+		it('should throw if not connected', async () => {
+			const client = new ACPClient(mockConfig);
+
+			await expect(client.authenticate('google-oauth')).rejects.toThrow(
+				'Not connected - call connect() first'
+			);
+		});
+	});
 });
 
 describe('ACP Client Utilities', () => {

--- a/src/__tests__/main/acp/acp-error-detector.test.ts
+++ b/src/__tests__/main/acp/acp-error-detector.test.ts
@@ -222,6 +222,94 @@ describe('ACP Error Detector', () => {
 				expect(result.type).toBe('rate_limited');
 			});
 		});
+
+		describe('Gemini CLI error patterns', () => {
+			it('should match Gemini CLI Google auth failure', () => {
+				const result = detectAcpError('Google auth failed');
+				expect(result.type).toBe('auth_expired');
+				expect(result.recoverable).toBe(true);
+			});
+
+			it('should match Gemini CLI GOOGLE_API_KEY pattern', () => {
+				const result = detectAcpError('Please set GOOGLE_API_KEY environment variable');
+				expect(result.type).toBe('auth_expired');
+				expect(result.recoverable).toBe(true);
+			});
+
+			it('should match Gemini CLI GOOGLE_CLOUD_PROJECT pattern', () => {
+				const result = detectAcpError(
+					'GOOGLE_CLOUD_PROJECT not configured for this request'
+				);
+				expect(result.type).toBe('auth_expired');
+				expect(result.recoverable).toBe(true);
+			});
+
+			it('should match Gemini CLI RESOURCE_EXHAUSTED pattern', () => {
+				const result = detectAcpError('Error: RESOURCE_EXHAUSTED: quota exceeded', undefined, 'gemini-cli');
+				expect(result.type).toBe('rate_limited');
+				expect(result.recoverable).toBe(true);
+			});
+
+			it('should match Gemini CLI PERMISSION_DENIED pattern', () => {
+				const result = detectAcpError('PERMISSION_DENIED: missing required IAM role');
+				expect(result.type).toBe('permission_denied');
+				expect(result.recoverable).toBe(false);
+			});
+
+			it('should match Gemini CLI UNAVAILABLE pattern', () => {
+				const result = detectAcpError('UNAVAILABLE: service is currently down');
+				expect(result.type).toBe('network_error');
+				expect(result.recoverable).toBe(true);
+			});
+
+			it('should match Gemini CLI login required pattern', () => {
+				const result = detectAcpError('login required to access this resource');
+				expect(result.type).toBe('auth_expired');
+				expect(result.recoverable).toBe(true);
+			});
+		});
+
+		describe('agentType parameter', () => {
+			it('should prioritize specified agent patterns when agentType is provided', () => {
+				// GOOGLE_API_KEY is only in Gemini CLI patterns
+				const result = detectAcpError(
+					'Missing GOOGLE_API_KEY',
+					undefined,
+					'gemini-cli'
+				);
+				expect(result.type).toBe('auth_expired');
+			});
+
+			it('should still match patterns without agentType specified', () => {
+				// GOOGLE_API_KEY should still match via fallback to all ACP agents
+				const result = detectAcpError('Missing GOOGLE_API_KEY');
+				expect(result.type).toBe('auth_expired');
+			});
+
+			it('should check all ACP agents when agentType does not match', () => {
+				// RESOURCE_EXHAUSTED is a Gemini CLI pattern, but works for any ACP agent
+				const result = detectAcpError(
+					'RESOURCE_EXHAUSTED',
+					undefined,
+					'opencode'
+				);
+				expect(result.type).toBe('rate_limited');
+			});
+
+			it('should work with opencode agentType for OpenCode-specific patterns', () => {
+				const result = detectAcpError('invalid key error', undefined, 'opencode');
+				expect(result.type).toBe('auth_expired');
+			});
+
+			it('should fall back to keyword detection when no pattern matches', () => {
+				const result = detectAcpError(
+					'unauthorized access to resource',
+					undefined,
+					'gemini-cli'
+				);
+				expect(result.type).toBe('auth_expired');
+			});
+		});
 	});
 
 	describe('isExpectedDisconnect', () => {

--- a/src/__tests__/main/acp/acp-error-detector.test.ts
+++ b/src/__tests__/main/acp/acp-error-detector.test.ts
@@ -1,0 +1,269 @@
+import { describe, it, expect } from 'vitest';
+import {
+	detectAcpError,
+	isExpectedDisconnect,
+	type DetectedError,
+} from '../../../main/acp/acp-error-detector';
+
+describe('ACP Error Detector', () => {
+	describe('detectAcpError', () => {
+		describe('JSON-RPC error codes', () => {
+			it('should detect auth errors from error code', () => {
+				const result = detectAcpError({ code: -32001, message: 'Unauthorized' });
+				expect(result.type).toBe('auth_expired');
+				expect(result.recoverable).toBe(true);
+			});
+
+			it('should detect auth expired from error code', () => {
+				const result = detectAcpError({ code: -32002, message: 'Token expired' });
+				expect(result.type).toBe('auth_expired');
+				expect(result.recoverable).toBe(true);
+			});
+
+			it('should detect rate limiting from error code', () => {
+				const result = detectAcpError({ code: -32010, message: 'Rate limited' });
+				expect(result.type).toBe('rate_limited');
+				expect(result.recoverable).toBe(true);
+			});
+
+			it('should detect quota exceeded from error code', () => {
+				const result = detectAcpError({ code: -32011, message: 'Quota exceeded' });
+				expect(result.type).toBe('rate_limited');
+				expect(result.recoverable).toBe(true);
+			});
+
+			it('should detect context too long from error code', () => {
+				const result = detectAcpError({ code: -32020, message: 'Context too long' });
+				expect(result.type).toBe('token_exhaustion');
+				expect(result.recoverable).toBe(true);
+			});
+
+			it('should detect token limit from error code', () => {
+				const result = detectAcpError({ code: -32021, message: 'Token limit exceeded' });
+				expect(result.type).toBe('token_exhaustion');
+				expect(result.recoverable).toBe(true);
+			});
+
+			it('should detect session not found from error code', () => {
+				const result = detectAcpError({ code: -32030, message: 'Session not found' });
+				expect(result.type).toBe('session_not_found');
+				expect(result.recoverable).toBe(true);
+			});
+
+			it('should detect connection error from error code', () => {
+				const result = detectAcpError({ code: -32040, message: 'Connection failed' });
+				expect(result.type).toBe('network_error');
+				expect(result.recoverable).toBe(true);
+			});
+
+			it('should detect permission denied from error code', () => {
+				const result = detectAcpError({ code: -32050, message: 'Permission denied' });
+				expect(result.type).toBe('permission_denied');
+				expect(result.recoverable).toBe(false);
+			});
+
+			it('should detect parse error from standard JSON-RPC code', () => {
+				const result = detectAcpError({ code: -32700, message: 'Parse error' });
+				expect(result.type).toBe('agent_crashed');
+			});
+
+			it('should detect internal error from standard JSON-RPC code', () => {
+				const result = detectAcpError({ code: -32603, message: 'Internal error' });
+				expect(result.type).toBe('agent_crashed');
+			});
+		});
+
+		describe('message-based detection', () => {
+			it('should detect auth errors from message keywords', () => {
+				const tests = [
+					'Invalid API key provided',
+					'Authentication failed',
+					'Unauthorized access',
+					'Error 401: Unauthorized',
+				];
+
+				for (const message of tests) {
+					const result = detectAcpError(message);
+					expect(result.type).toBe('auth_expired');
+					expect(result.recoverable).toBe(true);
+				}
+			});
+
+			it('should detect rate limiting from message keywords', () => {
+				const tests = [
+					'Rate limit exceeded',
+					'Too many requests',
+					'Quota exceeded',
+					'Error 429: Rate limited',
+				];
+
+				for (const message of tests) {
+					const result = detectAcpError(message);
+					expect(result.type).toBe('rate_limited');
+					expect(result.recoverable).toBe(true);
+				}
+			});
+
+			it('should detect token exhaustion from message keywords', () => {
+				const tests = [
+					'Context length exceeded',
+					'Maximum tokens reached',
+					'Token limit exceeded',
+					'Input too long',
+				];
+
+				for (const message of tests) {
+					const result = detectAcpError(message);
+					expect(result.type).toBe('token_exhaustion');
+					expect(result.recoverable).toBe(true);
+				}
+			});
+
+			it('should detect network errors from message keywords', () => {
+				const tests = [
+					'Connection failed',
+					'Network error occurred',
+					'Request timed out',
+					'ECONNREFUSED',
+					'ECONNRESET',
+					'ETIMEDOUT',
+				];
+
+				for (const message of tests) {
+					const result = detectAcpError(message);
+					expect(result.type).toBe('network_error');
+					expect(result.recoverable).toBe(true);
+				}
+			});
+
+			it('should detect session not found from message keywords', () => {
+				const result = detectAcpError('Session not found');
+				expect(result.type).toBe('session_not_found');
+				expect(result.recoverable).toBe(true);
+			});
+
+			it('should detect permission denied from message keywords', () => {
+				const tests = ['Permission denied', 'Access denied'];
+
+				for (const message of tests) {
+					const result = detectAcpError(message);
+					expect(result.type).toBe('permission_denied');
+					expect(result.recoverable).toBe(false);
+				}
+			});
+
+			it('should return unknown for unrecognized errors', () => {
+				const result = detectAcpError('Some random error message');
+				expect(result.type).toBe('unknown');
+				expect(result.recoverable).toBe(false);
+			});
+		});
+
+		describe('Error input types', () => {
+			it('should handle Error objects', () => {
+				const error = new Error('Invalid API key');
+				const result = detectAcpError(error);
+				expect(result.type).toBe('auth_expired');
+				// Message is replaced with user-friendly version from OpenCode patterns
+				expect(result.message).toContain('Invalid');
+			});
+
+			it('should handle string errors', () => {
+				const result = detectAcpError('Rate limit exceeded');
+				expect(result.type).toBe('rate_limited');
+				// Message is replaced with user-friendly version from OpenCode patterns
+				expect(result.message).toContain('Rate limit');
+			});
+
+			it('should handle objects with code and message', () => {
+				const result = detectAcpError({ code: -32010, message: 'Rate limited' });
+				expect(result.type).toBe('rate_limited');
+				expect(result.message).toBe('Rate limited');
+			});
+
+			it('should handle objects with only message', () => {
+				const result = detectAcpError({ message: 'Connection refused' });
+				expect(result.type).toBe('network_error');
+				// Message is replaced with user-friendly version from OpenCode patterns
+				expect(result.message).toContain('Connection');
+			});
+
+			it('should handle objects with no message', () => {
+				const result = detectAcpError({ code: 500 } as { code: number; message?: string });
+				expect(result.type).toBe('unknown');
+				expect(result.message).toBe('Unknown error');
+			});
+
+			it('should use jsonRpcCode parameter when provided', () => {
+				const result = detectAcpError('Something went wrong', -32010);
+				expect(result.type).toBe('rate_limited');
+			});
+
+			it('should preserve original message when no pattern matches', () => {
+				const result = detectAcpError('Some unique unrecognized error');
+				expect(result.type).toBe('unknown');
+				expect(result.message).toBe('Some unique unrecognized error');
+			});
+		});
+
+		describe('OpenCode error patterns', () => {
+			it('should match OpenCode-specific auth patterns', () => {
+				const result = detectAcpError('invalid key provided');
+				expect(result.type).toBe('auth_expired');
+			});
+
+			it('should match OpenCode context exceeded pattern', () => {
+				const result = detectAcpError('context length exceeded the maximum');
+				expect(result.type).toBe('token_exhaustion');
+			});
+
+			it('should match OpenCode rate limit patterns', () => {
+				const result = detectAcpError('rate limit reached');
+				expect(result.type).toBe('rate_limited');
+			});
+		});
+	});
+
+	describe('isExpectedDisconnect', () => {
+		it('should identify connection closed as expected', () => {
+			expect(isExpectedDisconnect(new Error('Connection closed'))).toBe(true);
+			expect(isExpectedDisconnect('Connection closed')).toBe(true);
+		});
+
+		it('should identify process exited as expected', () => {
+			expect(isExpectedDisconnect(new Error('Process exited'))).toBe(true);
+		});
+
+		it('should identify cancelled as expected', () => {
+			expect(isExpectedDisconnect(new Error('Operation cancelled'))).toBe(true);
+		});
+
+		it('should identify SIGTERM as expected', () => {
+			expect(isExpectedDisconnect(new Error('Received SIGTERM'))).toBe(true);
+		});
+
+		it('should identify SIGINT as expected', () => {
+			expect(isExpectedDisconnect(new Error('Received SIGINT'))).toBe(true);
+		});
+
+		it('should not identify other errors as expected', () => {
+			expect(isExpectedDisconnect(new Error('Invalid API key'))).toBe(false);
+			expect(isExpectedDisconnect(new Error('Rate limited'))).toBe(false);
+			expect(isExpectedDisconnect(new Error('Network error'))).toBe(false);
+		});
+	});
+
+	describe('DetectedError interface', () => {
+		it('should have correct structure', () => {
+			const error: DetectedError = {
+				type: 'auth_expired',
+				message: 'API key invalid',
+				recoverable: true,
+			};
+
+			expect(error.type).toBe('auth_expired');
+			expect(error.message).toBe('API key invalid');
+			expect(error.recoverable).toBe(true);
+		});
+	});
+});

--- a/src/__tests__/main/acp/acp-types.test.ts
+++ b/src/__tests__/main/acp/acp-types.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect } from 'vitest';
+import {
+	CURRENT_PROTOCOL_VERSION,
+	type JsonRpcRequest,
+	type JsonRpcResponse,
+	type JsonRpcNotification,
+	type ContentBlock,
+	type ContentBlockFlat,
+	type SessionUpdate,
+	type ToolCallStatus,
+	type StopReason,
+} from '../../../main/acp/types';
+
+describe('ACP Types', () => {
+	describe('Protocol Version', () => {
+		it('should have current protocol version defined', () => {
+			expect(CURRENT_PROTOCOL_VERSION).toBe(1);
+			expect(typeof CURRENT_PROTOCOL_VERSION).toBe('number');
+		});
+	});
+
+	describe('JSON-RPC Types', () => {
+		it('should allow valid JsonRpcRequest structure', () => {
+			const request: JsonRpcRequest = {
+				jsonrpc: '2.0',
+				id: 1,
+				method: 'initialize',
+				params: { protocolVersion: 1 },
+			};
+
+			expect(request.jsonrpc).toBe('2.0');
+			expect(request.id).toBe(1);
+			expect(request.method).toBe('initialize');
+		});
+
+		it('should allow null id for notifications that became requests', () => {
+			const request: JsonRpcRequest = {
+				jsonrpc: '2.0',
+				id: null,
+				method: 'session/cancel',
+			};
+
+			expect(request.id).toBeNull();
+		});
+
+		it('should allow string id', () => {
+			const request: JsonRpcRequest = {
+				jsonrpc: '2.0',
+				id: 'uuid-123',
+				method: 'test',
+			};
+
+			expect(request.id).toBe('uuid-123');
+		});
+
+		it('should allow valid JsonRpcResponse with result', () => {
+			const response: JsonRpcResponse = {
+				jsonrpc: '2.0',
+				id: 1,
+				result: { sessionId: 'test-123' },
+			};
+
+			expect(response.result).toEqual({ sessionId: 'test-123' });
+			expect(response.error).toBeUndefined();
+		});
+
+		it('should allow valid JsonRpcResponse with error', () => {
+			const response: JsonRpcResponse = {
+				jsonrpc: '2.0',
+				id: 1,
+				error: {
+					code: -32600,
+					message: 'Invalid Request',
+					data: { details: 'Missing method' },
+				},
+			};
+
+			expect(response.error?.code).toBe(-32600);
+			expect(response.error?.message).toBe('Invalid Request');
+		});
+
+		it('should allow valid JsonRpcNotification', () => {
+			const notification: JsonRpcNotification = {
+				jsonrpc: '2.0',
+				method: 'session/update',
+				params: { sessionId: 'test', update: {} },
+			};
+
+			expect(notification.method).toBe('session/update');
+			expect(notification.params).toBeDefined();
+		});
+	});
+
+	describe('ContentBlock Types', () => {
+		it('should allow text content block (spec format)', () => {
+			const block: ContentBlock = {
+				text: {
+					text: 'Hello, world!',
+					annotations: { priority: 1 },
+				},
+			};
+
+			expect('text' in block).toBe(true);
+		});
+
+		it('should allow image content block', () => {
+			const block: ContentBlock = {
+				image: {
+					data: 'base64encodeddata',
+					mimeType: 'image/png',
+					uri: 'file:///path/to/image.png',
+				},
+			};
+
+			expect('image' in block).toBe(true);
+		});
+
+		it('should allow resource_link content block', () => {
+			const block: ContentBlock = {
+				resource_link: {
+					uri: 'file:///path/to/file.txt',
+					name: 'file.txt',
+					mimeType: 'text/plain',
+					size: 1024,
+				},
+			};
+
+			expect('resource_link' in block).toBe(true);
+		});
+
+		it('should allow embedded resource content block', () => {
+			const block: ContentBlock = {
+				resource: {
+					resource: {
+						uri: 'file:///test.txt',
+						text: 'File contents',
+						mimeType: 'text/plain',
+					},
+				},
+			};
+
+			expect('resource' in block).toBe(true);
+		});
+	});
+
+	describe('ContentBlockFlat Types (OpenCode format)', () => {
+		it('should allow flat text content block', () => {
+			const block: ContentBlockFlat = {
+				type: 'text',
+				text: 'Hello from OpenCode!',
+			};
+
+			expect(block.type).toBe('text');
+			expect(block.text).toBe('Hello from OpenCode!');
+		});
+
+		it('should allow flat image content block', () => {
+			const block: ContentBlockFlat = {
+				type: 'image',
+				data: 'base64data',
+				mimeType: 'image/jpeg',
+			};
+
+			expect(block.type).toBe('image');
+		});
+
+		it('should allow flat resource_link content block', () => {
+			const block: ContentBlockFlat = {
+				type: 'resource_link',
+				uri: 'file:///path/to/file',
+				name: 'file.txt',
+			};
+
+			expect(block.type).toBe('resource_link');
+		});
+	});
+
+	describe('SessionUpdate Types', () => {
+		it('should recognize agent_message_chunk update', () => {
+			const update: SessionUpdate = {
+				agent_message_chunk: {
+					content: { text: { text: 'Response' } },
+				},
+			};
+
+			expect('agent_message_chunk' in update).toBe(true);
+		});
+
+		it('should recognize tool_call update', () => {
+			const update: SessionUpdate = {
+				tool_call: {
+					toolCallId: 'tc-123',
+					title: 'Read File',
+					kind: 'read',
+					status: 'pending',
+				},
+			};
+
+			expect('tool_call' in update).toBe(true);
+		});
+
+		it('should recognize plan update', () => {
+			const update: SessionUpdate = {
+				plan: {
+					entries: [
+						{ content: 'Step 1', priority: 'high', status: 'completed' },
+						{ content: 'Step 2', priority: 'medium', status: 'pending' },
+					],
+				},
+			};
+
+			expect('plan' in update).toBe(true);
+		});
+	});
+
+	describe('ToolCallStatus Values', () => {
+		it('should accept valid tool call statuses', () => {
+			const statuses: ToolCallStatus[] = ['pending', 'in_progress', 'completed', 'failed'];
+
+			expect(statuses).toHaveLength(4);
+			expect(statuses).toContain('pending');
+			expect(statuses).toContain('in_progress');
+			expect(statuses).toContain('completed');
+			expect(statuses).toContain('failed');
+		});
+	});
+
+	describe('StopReason Values', () => {
+		it('should accept valid stop reasons', () => {
+			const reasons: StopReason[] = [
+				'end_turn',
+				'max_tokens',
+				'max_turn_requests',
+				'refusal',
+				'cancelled',
+			];
+
+			expect(reasons).toHaveLength(5);
+			expect(reasons).toContain('end_turn');
+			expect(reasons).toContain('cancelled');
+		});
+	});
+});

--- a/src/__tests__/main/acp/acp-types.test.ts
+++ b/src/__tests__/main/acp/acp-types.test.ts
@@ -9,6 +9,9 @@ import {
 	type SessionUpdate,
 	type ToolCallStatus,
 	type StopReason,
+	type UsageUpdate,
+	type UsageCost,
+	type ConfigOptionUpdate,
 } from '../../../main/acp/types';
 
 describe('ACP Types', () => {
@@ -211,6 +214,32 @@ describe('ACP Types', () => {
 
 			expect('plan' in update).toBe(true);
 		});
+
+		it('should recognize usage_update', () => {
+			const update: SessionUpdate = {
+				usage_update: {
+					used: 5000,
+					size: 128000,
+					cost: {
+						amount: 0.0125,
+						currency: 'USD',
+					},
+				},
+			};
+
+			expect('usage_update' in update).toBe(true);
+		});
+
+		it('should recognize config_option_update', () => {
+			const update: SessionUpdate = {
+				config_option_update: {
+					key: 'model',
+					value: 'claude-3-opus',
+				},
+			};
+
+			expect('config_option_update' in update).toBe(true);
+		});
 	});
 
 	describe('ToolCallStatus Values', () => {
@@ -238,6 +267,95 @@ describe('ACP Types', () => {
 			expect(reasons).toHaveLength(5);
 			expect(reasons).toContain('end_turn');
 			expect(reasons).toContain('cancelled');
+		});
+	});
+
+	describe('UsageUpdate Types', () => {
+		it('should allow usage update without cost', () => {
+			const usage: UsageUpdate = {
+				used: 5000,
+				size: 128000,
+			};
+
+			expect(usage.used).toBe(5000);
+			expect(usage.size).toBe(128000);
+			expect(usage.cost).toBeUndefined();
+		});
+
+		it('should allow usage update with cost', () => {
+			const usage: UsageUpdate = {
+				used: 10000,
+				size: 200000,
+				cost: {
+					amount: 0.025,
+					currency: 'USD',
+				},
+			};
+
+			expect(usage.used).toBe(10000);
+			expect(usage.size).toBe(200000);
+			expect(usage.cost?.amount).toBe(0.025);
+			expect(usage.cost?.currency).toBe('USD');
+		});
+
+		it('should allow UsageCost with different currencies', () => {
+			const usdCost: UsageCost = { amount: 0.01, currency: 'USD' };
+			const eurCost: UsageCost = { amount: 0.009, currency: 'EUR' };
+
+			expect(usdCost.currency).toBe('USD');
+			expect(eurCost.currency).toBe('EUR');
+		});
+	});
+
+	describe('ConfigOptionUpdate Types', () => {
+		it('should allow string config values', () => {
+			const config: ConfigOptionUpdate = {
+				key: 'model',
+				value: 'claude-3-opus',
+			};
+
+			expect(config.key).toBe('model');
+			expect(config.value).toBe('claude-3-opus');
+		});
+
+		it('should allow boolean config values', () => {
+			const config: ConfigOptionUpdate = {
+				key: 'streaming',
+				value: true,
+			};
+
+			expect(config.key).toBe('streaming');
+			expect(config.value).toBe(true);
+		});
+
+		it('should allow numeric config values', () => {
+			const config: ConfigOptionUpdate = {
+				key: 'maxTokens',
+				value: 4096,
+			};
+
+			expect(config.key).toBe('maxTokens');
+			expect(config.value).toBe(4096);
+		});
+
+		it('should allow object config values', () => {
+			const config: ConfigOptionUpdate = {
+				key: 'options',
+				value: { streaming: true, verbose: false },
+			};
+
+			expect(config.key).toBe('options');
+			expect(config.value).toEqual({ streaming: true, verbose: false });
+		});
+
+		it('should allow null config values', () => {
+			const config: ConfigOptionUpdate = {
+				key: 'customPrompt',
+				value: null,
+			};
+
+			expect(config.key).toBe('customPrompt');
+			expect(config.value).toBeNull();
 		});
 	});
 });

--- a/src/__tests__/main/agents/capabilities.test.ts
+++ b/src/__tests__/main/agents/capabilities.test.ts
@@ -29,6 +29,7 @@ describe('agent-capabilities', () => {
 			expect(capabilities.supportsResultMessages).toBe(false);
 			expect(capabilities.supportsWizard).toBe(false);
 			expect(capabilities.supportsGroupChatModeration).toBe(false);
+			expect(capabilities.supportsACP).toBe(false);
 			expect(capabilities.usesJsonLineOutput).toBe(false);
 			expect(capabilities.usesCombinedContextWindow).toBe(false);
 		});
@@ -51,6 +52,7 @@ describe('agent-capabilities', () => {
 			expect(DEFAULT_CAPABILITIES.supportsResultMessages).toBe(false);
 			expect(DEFAULT_CAPABILITIES.supportsWizard).toBe(false);
 			expect(DEFAULT_CAPABILITIES.supportsGroupChatModeration).toBe(false);
+			expect(DEFAULT_CAPABILITIES.supportsACP).toBe(false);
 			expect(DEFAULT_CAPABILITIES.usesJsonLineOutput).toBe(false);
 			expect(DEFAULT_CAPABILITIES.usesCombinedContextWindow).toBe(false);
 		});
@@ -165,6 +167,7 @@ describe('agent-capabilities', () => {
 				expect(typeof AGENT_CAPABILITIES[agentId].supportsResultMessages).toBe('boolean');
 				expect(typeof AGENT_CAPABILITIES[agentId].supportsWizard).toBe('boolean');
 				expect(typeof AGENT_CAPABILITIES[agentId].supportsGroupChatModeration).toBe('boolean');
+				expect(typeof AGENT_CAPABILITIES[agentId].supportsACP).toBe('boolean');
 				expect(typeof AGENT_CAPABILITIES[agentId].usesJsonLineOutput).toBe('boolean');
 				expect(typeof AGENT_CAPABILITIES[agentId].usesCombinedContextWindow).toBe('boolean');
 			}
@@ -253,6 +256,12 @@ describe('agent-capabilities', () => {
 			expect(hasCapability('codex', 'usesCombinedContextWindow')).toBe(true);
 			expect(hasCapability('claude-code', 'usesCombinedContextWindow')).toBe(false);
 			expect(hasCapability('opencode', 'usesCombinedContextWindow')).toBe(false);
+
+			// supportsACP
+			expect(hasCapability('opencode', 'supportsACP')).toBe(true);
+			expect(hasCapability('claude-code', 'supportsACP')).toBe(false);
+			expect(hasCapability('codex', 'supportsACP')).toBe(false);
+			expect(hasCapability('terminal', 'supportsACP')).toBe(false);
 		});
 	});
 
@@ -280,6 +289,7 @@ describe('agent-capabilities', () => {
 				'supportsContextExport',
 				'supportsWizard',
 				'supportsGroupChatModeration',
+				'supportsACP',
 				'usesJsonLineOutput',
 				'usesCombinedContextWindow',
 			];

--- a/src/__tests__/renderer/components/AgentSessionsModal.test.tsx
+++ b/src/__tests__/renderer/components/AgentSessionsModal.test.tsx
@@ -944,10 +944,15 @@ describe('AgentSessionsModal', () => {
 
 			const input = screen.getByPlaceholderText(/Search.*sessions/);
 
-			// Navigate down then up
+			// Navigate down first and wait for the state update
 			fireEvent.keyDown(input, { key: 'ArrowDown' });
-			fireEvent.keyDown(input, { key: 'ArrowUp' });
+			await waitFor(() => {
+				const secondButton = screen.getByText('Second').closest('button');
+				expect(secondButton).toHaveStyle({ backgroundColor: mockTheme.colors.accent });
+			});
 
+			// Then navigate back up
+			fireEvent.keyDown(input, { key: 'ArrowUp' });
 			await waitFor(() => {
 				const firstButton = screen.getByText('First').closest('button');
 				expect(firstButton).toHaveStyle({ backgroundColor: mockTheme.colors.accent });

--- a/src/main/acp/acp-adapter.ts
+++ b/src/main/acp/acp-adapter.ts
@@ -1,0 +1,248 @@
+/**
+ * ACP to ParsedEvent Adapter
+ *
+ * Converts ACP session updates to Maestro's internal ParsedEvent format,
+ * enabling seamless integration with existing UI components.
+ */
+
+import type { ParsedEvent } from '../parsers/agent-output-parser';
+import type {
+  SessionUpdate,
+  SessionId,
+  ContentBlock,
+  ToolCallStatus,
+} from './types';
+import { logger } from '../utils/logger';
+
+const LOG_CONTEXT = '[ACPAdapter]';
+
+/**
+ * Extract text from a ContentBlock
+ * Handles both ACP spec format and OpenCode's actual format:
+ * - ACP spec: { text: { text: '...' } }
+ * - OpenCode: { type: 'text', text: '...' }
+ */
+function extractText(block: ContentBlock): string {
+  const content = block as any;
+  
+  logger.debug('Extracting text from content block', LOG_CONTEXT, { content });
+  
+  // OpenCode format: { type: 'text', text: '...' }
+  if (content.type === 'text' && typeof content.text === 'string') {
+    return content.text;
+  }
+  
+  // ACP spec format: { text: { text: '...' } }
+  if ('text' in content && content.text && typeof content.text === 'object' && 'text' in content.text) {
+    return content.text.text;
+  }
+  
+  // Simple text field
+  if ('text' in content && typeof content.text === 'string') {
+    return content.text;
+  }
+  
+  // Direct string content
+  if (typeof content === 'string') {
+    return content;
+  }
+  
+  if ('image' in content) {
+    return '[image]';
+  }
+  if ('resource_link' in content) {
+    return `[resource: ${content.resource_link.name}]`;
+  }
+  if ('resource' in content) {
+    const res = content.resource.resource;
+    if ('text' in res) {
+      return res.text;
+    }
+    return '[binary resource]';
+  }
+  
+  // Fallback: try to stringify
+  logger.warn('Unknown content block format', LOG_CONTEXT, { content });
+  return typeof content === 'object' ? JSON.stringify(content) : String(content);
+}
+
+/**
+ * Map ACP ToolCallStatus to Maestro status
+ */
+function mapToolStatus(status?: ToolCallStatus): string {
+  switch (status) {
+    case 'pending':
+      return 'pending';
+    case 'in_progress':
+      return 'running';
+    case 'completed':
+      return 'completed';
+    case 'failed':
+      return 'error';
+    default:
+      return 'pending';
+  }
+}
+
+/**
+ * Convert an ACP SessionUpdate to a Maestro ParsedEvent
+ */
+export function acpUpdateToParseEvent(
+  sessionId: SessionId,
+  update: SessionUpdate
+): ParsedEvent | null {
+  logger.debug('Converting ACP update to ParsedEvent', LOG_CONTEXT, { 
+    sessionId, 
+    updateKeys: Object.keys(update),
+    update 
+  });
+  
+  // Agent message chunk (streaming text)
+  if ('agent_message_chunk' in update) {
+    const chunk = update.agent_message_chunk;
+    logger.debug('Processing agent_message_chunk', LOG_CONTEXT, { chunk });
+    const text = extractText(chunk.content);
+    return {
+      type: 'text',
+      text,
+      isPartial: true,
+      sessionId,
+      raw: update,
+    };
+  }
+
+  // Agent thought chunk (thinking/reasoning) - map to 'text' type with marker
+  if ('agent_thought_chunk' in update) {
+    const text = extractText(update.agent_thought_chunk.content);
+    return {
+      type: 'text',
+      text: `[thinking] ${text}`,
+      isPartial: true,
+      sessionId,
+      raw: update,
+    };
+  }
+
+  // User message chunk (echo of user input)
+  if ('user_message_chunk' in update) {
+    // Usually not displayed, but can be used for confirmation
+    return null;
+  }
+
+  // Tool call started
+  if ('tool_call' in update) {
+    const tc = update.tool_call;
+    return {
+      type: 'tool_use',
+      toolName: tc.title,
+      toolState: {
+        id: tc.toolCallId,
+        input: tc.rawInput,
+        status: mapToolStatus(tc.status),
+      },
+      sessionId,
+      raw: update,
+    };
+  }
+
+  // Tool call update
+  if ('tool_call_update' in update) {
+    const tc = update.tool_call_update;
+    return {
+      type: 'tool_use',
+      toolName: tc.title || '',
+      toolState: {
+        id: tc.toolCallId,
+        input: tc.rawInput,
+        output: tc.rawOutput,
+        status: mapToolStatus(tc.status),
+      },
+      sessionId,
+      raw: update,
+    };
+  }
+
+  // Plan update - map to system message
+  if ('plan' in update) {
+    const entries = update.plan.entries.map((e) => `- [${e.status}] ${e.content}`).join('\n');
+    return {
+      type: 'system',
+      text: `Plan:\n${entries}`,
+      sessionId,
+      raw: update,
+    };
+  }
+
+  // Available commands update
+  if ('available_commands_update' in update) {
+    // Map to slash commands for UI
+    return {
+      type: 'init',
+      slashCommands: update.available_commands_update.availableCommands.map((c) => c.name),
+      sessionId,
+      raw: update,
+    };
+  }
+
+  // Mode update
+  if ('current_mode_update' in update) {
+    // Could emit a mode change event
+    return null;
+  }
+
+  return null;
+}
+
+/**
+ * Create an init event from ACP session creation
+ */
+export function createSessionIdEvent(sessionId: SessionId): ParsedEvent {
+  return {
+    type: 'init',
+    sessionId,
+    raw: { type: 'session_created', sessionId },
+  };
+}
+
+/**
+ * Create a result event from ACP prompt response
+ */
+export function createResultEvent(
+  sessionId: SessionId,
+  text: string,
+  _stopReason: string,
+  usage?: { inputTokens?: number; outputTokens?: number; totalTokens?: number }
+): ParsedEvent {
+  // Convert ACP usage format to Maestro's ParsedEvent usage format
+  const eventUsage = usage ? {
+    inputTokens: usage.inputTokens || 0,
+    outputTokens: usage.outputTokens || 0,
+    // ACP doesn't provide cache tokens, so default to 0
+    cacheReadTokens: 0,
+    cacheCreationTokens: 0,
+    // ACP doesn't provide cost, calculated separately based on model
+    costUsd: 0,
+    // Context window should be configured in agent settings
+    contextWindow: 0,
+  } : undefined;
+
+  return {
+    type: 'result',
+    text,
+    sessionId,
+    usage: eventUsage,
+    raw: { type: 'prompt_response', stopReason: _stopReason, usage },
+  };
+}
+
+/**
+ * Create an error event
+ */
+export function createErrorEvent(sessionId: SessionId, message: string): ParsedEvent {
+  return {
+    type: 'error',
+    text: message,
+    sessionId,
+    raw: { type: 'error', message },
+  };
+}

--- a/src/main/acp/acp-adapter.ts
+++ b/src/main/acp/acp-adapter.ts
@@ -186,8 +186,45 @@ export function acpUpdateToParseEvent(
 
 	// Mode update
 	if ('current_mode_update' in update) {
-		// Could emit a mode change event
-		return null;
+		// Emit a system message for mode changes
+		return {
+			type: 'system',
+			text: `Mode changed to: ${update.current_mode_update.currentModeId}`,
+			sessionId,
+			raw: update,
+		};
+	}
+
+	// Usage update (token usage and cost information)
+	if ('usage_update' in update) {
+		const usage = update.usage_update;
+		return {
+			type: 'usage',
+			sessionId,
+			usage: {
+				// usage_update provides cumulative context usage, not per-turn tokens
+				// Map 'used' to inputTokens as it represents tokens in context
+				inputTokens: usage.used,
+				outputTokens: 0,
+				cacheReadTokens: 0,
+				cacheCreationTokens: 0,
+				contextWindow: usage.size,
+				// Convert cost if provided
+				costUsd: usage.cost?.currency === 'USD' ? usage.cost.amount : 0,
+			},
+			raw: update,
+		};
+	}
+
+	// Config option update (session configuration changes)
+	if ('config_option_update' in update) {
+		const config = update.config_option_update;
+		return {
+			type: 'system',
+			text: `Config updated: ${config.key} = ${JSON.stringify(config.value)}`,
+			sessionId,
+			raw: update,
+		};
 	}
 
 	return null;

--- a/src/main/acp/acp-adapter.ts
+++ b/src/main/acp/acp-adapter.ts
@@ -6,12 +6,7 @@
  */
 
 import type { ParsedEvent } from '../parsers/agent-output-parser';
-import type {
-  SessionUpdate,
-  SessionId,
-  ContentBlock,
-  ToolCallStatus,
-} from './types';
+import type { SessionUpdate, SessionId, ContentBlock, ToolCallStatus } from './types';
 import { logger } from '../utils/logger';
 
 const LOG_CONTEXT = '[ACPAdapter]';
@@ -23,226 +18,233 @@ const LOG_CONTEXT = '[ACPAdapter]';
  * - OpenCode: { type: 'text', text: '...' }
  */
 function extractText(block: ContentBlock): string {
-  const content = block as any;
-  
-  logger.debug('Extracting text from content block', LOG_CONTEXT, { content });
-  
-  // OpenCode format: { type: 'text', text: '...' }
-  if (content.type === 'text' && typeof content.text === 'string') {
-    return content.text;
-  }
-  
-  // ACP spec format: { text: { text: '...' } }
-  if ('text' in content && content.text && typeof content.text === 'object' && 'text' in content.text) {
-    return content.text.text;
-  }
-  
-  // Simple text field
-  if ('text' in content && typeof content.text === 'string') {
-    return content.text;
-  }
-  
-  // Direct string content
-  if (typeof content === 'string') {
-    return content;
-  }
-  
-  if ('image' in content) {
-    return '[image]';
-  }
-  if ('resource_link' in content) {
-    return `[resource: ${content.resource_link.name}]`;
-  }
-  if ('resource' in content) {
-    const res = content.resource.resource;
-    if ('text' in res) {
-      return res.text;
-    }
-    return '[binary resource]';
-  }
-  
-  // Fallback: try to stringify
-  logger.warn('Unknown content block format', LOG_CONTEXT, { content });
-  return typeof content === 'object' ? JSON.stringify(content) : String(content);
+	const content = block as any;
+
+	logger.debug('Extracting text from content block', LOG_CONTEXT, { content });
+
+	// OpenCode format: { type: 'text', text: '...' }
+	if (content.type === 'text' && typeof content.text === 'string') {
+		return content.text;
+	}
+
+	// ACP spec format: { text: { text: '...' } }
+	if (
+		'text' in content &&
+		content.text &&
+		typeof content.text === 'object' &&
+		'text' in content.text
+	) {
+		return content.text.text;
+	}
+
+	// Simple text field
+	if ('text' in content && typeof content.text === 'string') {
+		return content.text;
+	}
+
+	// Direct string content
+	if (typeof content === 'string') {
+		return content;
+	}
+
+	if ('image' in content) {
+		return '[image]';
+	}
+	if ('resource_link' in content) {
+		return `[resource: ${content.resource_link.name}]`;
+	}
+	if ('resource' in content) {
+		const res = content.resource.resource;
+		if ('text' in res) {
+			return res.text;
+		}
+		return '[binary resource]';
+	}
+
+	// Fallback: try to stringify
+	logger.warn('Unknown content block format', LOG_CONTEXT, { content });
+	return typeof content === 'object' ? JSON.stringify(content) : String(content);
 }
 
 /**
  * Map ACP ToolCallStatus to Maestro status
  */
 function mapToolStatus(status?: ToolCallStatus): string {
-  switch (status) {
-    case 'pending':
-      return 'pending';
-    case 'in_progress':
-      return 'running';
-    case 'completed':
-      return 'completed';
-    case 'failed':
-      return 'error';
-    default:
-      return 'pending';
-  }
+	switch (status) {
+		case 'pending':
+			return 'pending';
+		case 'in_progress':
+			return 'running';
+		case 'completed':
+			return 'completed';
+		case 'failed':
+			return 'error';
+		default:
+			return 'pending';
+	}
 }
 
 /**
  * Convert an ACP SessionUpdate to a Maestro ParsedEvent
  */
 export function acpUpdateToParseEvent(
-  sessionId: SessionId,
-  update: SessionUpdate
+	sessionId: SessionId,
+	update: SessionUpdate
 ): ParsedEvent | null {
-  logger.debug('Converting ACP update to ParsedEvent', LOG_CONTEXT, { 
-    sessionId, 
-    updateKeys: Object.keys(update),
-    update 
-  });
-  
-  // Agent message chunk (streaming text)
-  if ('agent_message_chunk' in update) {
-    const chunk = update.agent_message_chunk;
-    logger.debug('Processing agent_message_chunk', LOG_CONTEXT, { chunk });
-    const text = extractText(chunk.content);
-    return {
-      type: 'text',
-      text,
-      isPartial: true,
-      sessionId,
-      raw: update,
-    };
-  }
+	logger.debug('Converting ACP update to ParsedEvent', LOG_CONTEXT, {
+		sessionId,
+		updateKeys: Object.keys(update),
+		update,
+	});
 
-  // Agent thought chunk (thinking/reasoning) - map to 'text' type with marker
-  if ('agent_thought_chunk' in update) {
-    const text = extractText(update.agent_thought_chunk.content);
-    return {
-      type: 'text',
-      text: `[thinking] ${text}`,
-      isPartial: true,
-      sessionId,
-      raw: update,
-    };
-  }
+	// Agent message chunk (streaming text)
+	if ('agent_message_chunk' in update) {
+		const chunk = update.agent_message_chunk;
+		logger.debug('Processing agent_message_chunk', LOG_CONTEXT, { chunk });
+		const text = extractText(chunk.content);
+		return {
+			type: 'text',
+			text,
+			isPartial: true,
+			sessionId,
+			raw: update,
+		};
+	}
 
-  // User message chunk (echo of user input)
-  if ('user_message_chunk' in update) {
-    // Usually not displayed, but can be used for confirmation
-    return null;
-  }
+	// Agent thought chunk (thinking/reasoning) - map to 'text' type with marker
+	if ('agent_thought_chunk' in update) {
+		const text = extractText(update.agent_thought_chunk.content);
+		return {
+			type: 'text',
+			text: `[thinking] ${text}`,
+			isPartial: true,
+			sessionId,
+			raw: update,
+		};
+	}
 
-  // Tool call started
-  if ('tool_call' in update) {
-    const tc = update.tool_call;
-    return {
-      type: 'tool_use',
-      toolName: tc.title,
-      toolState: {
-        id: tc.toolCallId,
-        input: tc.rawInput,
-        status: mapToolStatus(tc.status),
-      },
-      sessionId,
-      raw: update,
-    };
-  }
+	// User message chunk (echo of user input)
+	if ('user_message_chunk' in update) {
+		// Usually not displayed, but can be used for confirmation
+		return null;
+	}
 
-  // Tool call update
-  if ('tool_call_update' in update) {
-    const tc = update.tool_call_update;
-    return {
-      type: 'tool_use',
-      toolName: tc.title || '',
-      toolState: {
-        id: tc.toolCallId,
-        input: tc.rawInput,
-        output: tc.rawOutput,
-        status: mapToolStatus(tc.status),
-      },
-      sessionId,
-      raw: update,
-    };
-  }
+	// Tool call started
+	if ('tool_call' in update) {
+		const tc = update.tool_call;
+		return {
+			type: 'tool_use',
+			toolName: tc.title,
+			toolState: {
+				id: tc.toolCallId,
+				input: tc.rawInput,
+				status: mapToolStatus(tc.status),
+			},
+			sessionId,
+			raw: update,
+		};
+	}
 
-  // Plan update - map to system message
-  if ('plan' in update) {
-    const entries = update.plan.entries.map((e) => `- [${e.status}] ${e.content}`).join('\n');
-    return {
-      type: 'system',
-      text: `Plan:\n${entries}`,
-      sessionId,
-      raw: update,
-    };
-  }
+	// Tool call update
+	if ('tool_call_update' in update) {
+		const tc = update.tool_call_update;
+		return {
+			type: 'tool_use',
+			toolName: tc.title || '',
+			toolState: {
+				id: tc.toolCallId,
+				input: tc.rawInput,
+				output: tc.rawOutput,
+				status: mapToolStatus(tc.status),
+			},
+			sessionId,
+			raw: update,
+		};
+	}
 
-  // Available commands update
-  if ('available_commands_update' in update) {
-    // Map to slash commands for UI
-    return {
-      type: 'init',
-      slashCommands: update.available_commands_update.availableCommands.map((c) => c.name),
-      sessionId,
-      raw: update,
-    };
-  }
+	// Plan update - map to system message
+	if ('plan' in update) {
+		const entries = update.plan.entries.map((e) => `- [${e.status}] ${e.content}`).join('\n');
+		return {
+			type: 'system',
+			text: `Plan:\n${entries}`,
+			sessionId,
+			raw: update,
+		};
+	}
 
-  // Mode update
-  if ('current_mode_update' in update) {
-    // Could emit a mode change event
-    return null;
-  }
+	// Available commands update
+	if ('available_commands_update' in update) {
+		// Map to slash commands for UI
+		return {
+			type: 'init',
+			slashCommands: update.available_commands_update.availableCommands.map((c) => c.name),
+			sessionId,
+			raw: update,
+		};
+	}
 
-  return null;
+	// Mode update
+	if ('current_mode_update' in update) {
+		// Could emit a mode change event
+		return null;
+	}
+
+	return null;
 }
 
 /**
  * Create an init event from ACP session creation
  */
 export function createSessionIdEvent(sessionId: SessionId): ParsedEvent {
-  return {
-    type: 'init',
-    sessionId,
-    raw: { type: 'session_created', sessionId },
-  };
+	return {
+		type: 'init',
+		sessionId,
+		raw: { type: 'session_created', sessionId },
+	};
 }
 
 /**
  * Create a result event from ACP prompt response
  */
 export function createResultEvent(
-  sessionId: SessionId,
-  text: string,
-  _stopReason: string,
-  usage?: { inputTokens?: number; outputTokens?: number; totalTokens?: number }
+	sessionId: SessionId,
+	text: string,
+	_stopReason: string,
+	usage?: { inputTokens?: number; outputTokens?: number; totalTokens?: number }
 ): ParsedEvent {
-  // Convert ACP usage format to Maestro's ParsedEvent usage format
-  const eventUsage = usage ? {
-    inputTokens: usage.inputTokens || 0,
-    outputTokens: usage.outputTokens || 0,
-    // ACP doesn't provide cache tokens, so default to 0
-    cacheReadTokens: 0,
-    cacheCreationTokens: 0,
-    // ACP doesn't provide cost, calculated separately based on model
-    costUsd: 0,
-    // Context window should be configured in agent settings
-    contextWindow: 0,
-  } : undefined;
+	// Convert ACP usage format to Maestro's ParsedEvent usage format
+	const eventUsage = usage
+		? {
+				inputTokens: usage.inputTokens || 0,
+				outputTokens: usage.outputTokens || 0,
+				// ACP doesn't provide cache tokens, so default to 0
+				cacheReadTokens: 0,
+				cacheCreationTokens: 0,
+				// ACP doesn't provide cost, calculated separately based on model
+				costUsd: 0,
+				// Context window should be configured in agent settings
+				contextWindow: 0,
+			}
+		: undefined;
 
-  return {
-    type: 'result',
-    text,
-    sessionId,
-    usage: eventUsage,
-    raw: { type: 'prompt_response', stopReason: _stopReason, usage },
-  };
+	return {
+		type: 'result',
+		text,
+		sessionId,
+		usage: eventUsage,
+		raw: { type: 'prompt_response', stopReason: _stopReason, usage },
+	};
 }
 
 /**
  * Create an error event
  */
 export function createErrorEvent(sessionId: SessionId, message: string): ParsedEvent {
-  return {
-    type: 'error',
-    text: message,
-    sessionId,
-    raw: { type: 'error', message },
-  };
+	return {
+		type: 'error',
+		text: message,
+		sessionId,
+		raw: { type: 'error', message },
+	};
 }

--- a/src/main/acp/acp-client.ts
+++ b/src/main/acp/acp-client.ts
@@ -1,0 +1,645 @@
+/**
+ * ACP (Agent Client Protocol) Client Implementation
+ *
+ * A client for communicating with ACP-compatible agents like OpenCode.
+ * Uses JSON-RPC 2.0 over stdio to communicate with the agent process.
+ *
+ * @see https://agentclientprotocol.com/protocol/overview
+ */
+
+import { spawn, ChildProcess } from 'child_process';
+import { EventEmitter } from 'events';
+import { createInterface, Interface } from 'readline';
+import { logger } from '../utils/logger';
+import type {
+  RequestId,
+  JsonRpcRequest,
+  JsonRpcResponse,
+  JsonRpcNotification,
+  Implementation,
+  ClientCapabilities,
+  AgentCapabilities,
+  InitializeRequest,
+  InitializeResponse,
+  SessionId,
+  NewSessionRequest,
+  NewSessionResponse,
+  LoadSessionRequest,
+  LoadSessionResponse,
+  PromptRequest,
+  PromptResponse,
+  ContentBlock,
+  SessionNotification,
+  SessionUpdate,
+  CancelNotification,
+  RequestPermissionRequest,
+  RequestPermissionResponse,
+  ReadTextFileRequest,
+  ReadTextFileResponse,
+  WriteTextFileRequest,
+  WriteTextFileResponse,
+  CreateTerminalRequest,
+  CreateTerminalResponse,
+  TerminalOutputRequest,
+  TerminalOutputResponse,
+} from './types';
+import { CURRENT_PROTOCOL_VERSION } from './types';
+
+const LOG_CONTEXT = '[ACPClient]';
+
+/**
+ * Redact sensitive content from JSON-RPC messages for safe logging.
+ * Keeps method/id metadata but redacts large payloads like prompts, file contents, and base64 images.
+ */
+function redactForLogging(message: unknown): unknown {
+  if (!message || typeof message !== 'object') return message;
+  
+  const obj = message as Record<string, unknown>;
+  const redacted: Record<string, unknown> = {};
+  
+  for (const [key, value] of Object.entries(obj)) {
+    if (key === 'id' || key === 'jsonrpc' || key === 'method') {
+      // Keep metadata as-is
+      redacted[key] = value;
+    } else if (key === 'params' || key === 'result') {
+      // Summarize params/result
+      if (value && typeof value === 'object') {
+        const inner = value as Record<string, unknown>;
+        const summary: Record<string, unknown> = {};
+        for (const [innerKey, innerValue] of Object.entries(inner)) {
+          if (typeof innerValue === 'string' && innerValue.length > 100) {
+            summary[innerKey] = `[REDACTED: ${innerValue.length} chars]`;
+          } else if (Array.isArray(innerValue)) {
+            summary[innerKey] = `[Array: ${innerValue.length} items]`;
+          } else if (innerValue && typeof innerValue === 'object') {
+            summary[innerKey] = `[Object: ${Object.keys(innerValue).join(', ')}]`;
+          } else {
+            summary[innerKey] = innerValue;
+          }
+        }
+        redacted[key] = summary;
+      } else {
+        redacted[key] = value;
+      }
+    } else if (key === 'error') {
+      // Keep error info
+      redacted[key] = value;
+    } else {
+      // Redact other fields
+      if (typeof value === 'string' && value.length > 100) {
+        redacted[key] = `[REDACTED: ${value.length} chars]`;
+      } else {
+        redacted[key] = value;
+      }
+    }
+  }
+  
+  return redacted;
+}
+
+/**
+ * Events emitted by the ACP client
+ */
+export interface ACPClientEvents {
+  /** Session update notification from agent */
+  'session:update': (sessionId: SessionId, update: SessionUpdate) => void;
+  /** Permission request from agent */
+  'session:permission_request': (
+    request: RequestPermissionRequest,
+    respond: (response: RequestPermissionResponse) => void
+  ) => void;
+  /** File read request from agent */
+  'fs:read': (
+    request: ReadTextFileRequest,
+    respond: (response: ReadTextFileResponse) => void
+  ) => void;
+  /** File write request from agent */
+  'fs:write': (
+    request: WriteTextFileRequest,
+    respond: (response: WriteTextFileResponse) => void
+  ) => void;
+  /** Terminal create request from agent */
+  'terminal:create': (
+    request: CreateTerminalRequest,
+    respond: (response: CreateTerminalResponse) => void
+  ) => void;
+  /** Terminal output request from agent */
+  'terminal:output': (
+    request: TerminalOutputRequest,
+    respond: (response: TerminalOutputResponse) => void
+  ) => void;
+  /** Error occurred */
+  error: (error: Error) => void;
+  /** Client disconnected */
+  disconnected: () => void;
+}
+
+/**
+ * Configuration for ACP client
+ */
+export interface ACPClientConfig {
+  /** Command to spawn the agent (e.g., 'opencode') */
+  command: string;
+  /** Arguments for the agent command (e.g., ['acp']) */
+  args: string[];
+  /** Working directory for the agent process */
+  cwd: string;
+  /** Environment variables for the agent process */
+  env?: Record<string, string>;
+  /** Client info to send during initialization */
+  clientInfo?: Implementation;
+  /** Client capabilities */
+  clientCapabilities?: ClientCapabilities;
+}
+
+/**
+ * ACP Client for communicating with agents via JSON-RPC over stdio
+ */
+export class ACPClient extends EventEmitter {
+  private process: ChildProcess | null = null;
+  private readline: Interface | null = null;
+  private requestId = 0;
+  private pendingRequests = new Map<
+    RequestId,
+    {
+      resolve: (result: unknown) => void;
+      reject: (error: Error) => void;
+      method: string;
+    }
+  >();
+  private config: ACPClientConfig;
+  private isConnected = false;
+  private agentCapabilities: AgentCapabilities | null = null;
+  private agentInfo: Implementation | null = null;
+
+  constructor(config: ACPClientConfig) {
+    super();
+    this.config = config;
+  }
+
+  /**
+   * Get the underlying child process (for PID access)
+   */
+  getProcess(): ChildProcess | null {
+    return this.process;
+  }
+
+  /**
+   * Start the agent process and initialize the connection
+   */
+  async connect(): Promise<InitializeResponse> {
+    if (this.isConnected) {
+      throw new Error('Already connected');
+    }
+
+    const fullCommand = `${this.config.command} ${this.config.args.join(' ')}`;
+    logger.info(`Starting ACP agent: ${fullCommand}`, LOG_CONTEXT);
+
+    // Build environment with extended PATH
+    // Electron doesn't inherit the user's shell PATH, so we need to add common paths
+    // where node, npm, and other tools are typically installed
+    const env = { ...process.env, ...this.config.env };
+    const isWin = process.platform === 'win32';
+    
+    if (isWin) {
+      const appData = process.env.APPDATA || '';
+      const localAppData = process.env.LOCALAPPDATA || '';
+      const programFiles = process.env.ProgramFiles || 'C:\\Program Files';
+      const standardPaths = [
+        `${appData}\\npm`,
+        `${localAppData}\\npm`,
+        `${programFiles}\\nodejs`,
+        `${programFiles}\\Git\\cmd`,
+      ].join(';');
+      env.PATH = env.PATH ? `${standardPaths};${env.PATH}` : standardPaths;
+    } else {
+      // macOS/Linux: Add Homebrew, nvm, volta, fnm, and standard paths
+      const home = process.env.HOME || '';
+      const standardPaths = [
+        '/opt/homebrew/bin',           // Homebrew on Apple Silicon
+        '/usr/local/bin',              // Homebrew on Intel, many CLI tools
+        `${home}/.nvm/versions/node`,  // nvm (we'll expand this below)
+        `${home}/.volta/bin`,          // Volta
+        `${home}/.fnm`,                // fnm
+        `${home}/.local/bin`,          // pipx, etc.
+        '/usr/bin',
+        '/bin',
+        '/usr/sbin',
+        '/sbin',
+      ].join(':');
+      
+      // Also try to detect the active nvm node version
+      const nvmDir = process.env.NVM_DIR || `${home}/.nvm`;
+      let nvmNodePath = '';
+      try {
+        // Try to read the default version
+        const fs = require('fs');
+        const path = require('path');
+        const defaultVersionFile = path.join(nvmDir, 'alias', 'default');
+        if (fs.existsSync(defaultVersionFile)) {
+          const version = fs.readFileSync(defaultVersionFile, 'utf8').trim();
+          const nodePath = path.join(nvmDir, 'versions', 'node', `v${version.replace(/^v/, '')}`, 'bin');
+          if (fs.existsSync(nodePath)) {
+            nvmNodePath = nodePath;
+          }
+        }
+      } catch {
+        // Ignore errors - nvm might not be installed
+      }
+      
+      const allPaths = nvmNodePath ? `${nvmNodePath}:${standardPaths}` : standardPaths;
+      env.PATH = env.PATH ? `${allPaths}:${env.PATH}` : allPaths;
+    }
+
+    // Spawn the agent process
+    this.process = spawn(this.config.command, this.config.args, {
+      cwd: this.config.cwd,
+      env,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    if (!this.process.stdout || !this.process.stdin) {
+      throw new Error('Failed to create agent process with stdio');
+    }
+
+    // Set up readline for line-by-line JSON-RPC parsing
+    this.readline = createInterface({
+      input: this.process.stdout,
+      crlfDelay: Infinity,
+    });
+
+    this.readline.on('line', (line) => this.handleLine(line));
+
+    this.process.stderr?.on('data', (data) => {
+      logger.warn(`Agent stderr: ${data.toString()}`, LOG_CONTEXT);
+    });
+
+    this.process.on('close', (code) => {
+      logger.info(`Agent process exited with code ${code}`, LOG_CONTEXT);
+      this.handleDisconnect();
+    });
+
+    this.process.on('error', (error) => {
+      logger.error(`Agent process error: ${error.message}`, LOG_CONTEXT);
+      this.emit('error', error);
+    });
+
+    // Send initialize request
+    const initRequest: InitializeRequest = {
+      protocolVersion: CURRENT_PROTOCOL_VERSION,
+      clientInfo: this.config.clientInfo || {
+        name: 'maestro',
+        version: '0.12.0',
+        title: 'Maestro',
+      },
+      clientCapabilities: this.config.clientCapabilities || {
+        fs: {
+          readTextFile: true,
+          writeTextFile: true,
+        },
+        terminal: true,
+      },
+    };
+
+    const response = (await this.sendRequest('initialize', initRequest)) as InitializeResponse;
+
+    this.agentCapabilities = response.agentCapabilities || null;
+    this.agentInfo = response.agentInfo || null;
+    this.isConnected = true;
+
+    logger.info(
+      `Connected to agent: ${this.agentInfo?.name || 'unknown'} v${this.agentInfo?.version || '?'}`,
+      LOG_CONTEXT
+    );
+
+    return response;
+  }
+
+  /**
+   * Disconnect from the agent
+   */
+  disconnect(): void {
+    if (this.process) {
+      this.process.kill();
+      this.process = null;
+    }
+    this.handleDisconnect();
+  }
+
+  /**
+   * Create a new session
+   */
+  async newSession(cwd: string): Promise<NewSessionResponse> {
+    const request: NewSessionRequest = {
+      cwd,
+      mcpServers: [], // No MCP servers for now
+    };
+    return (await this.sendRequest('session/new', request)) as NewSessionResponse;
+  }
+
+  /**
+   * Load an existing session
+   */
+  async loadSession(sessionId: SessionId, cwd: string): Promise<LoadSessionResponse> {
+    if (!this.agentCapabilities?.loadSession) {
+      throw new Error('Agent does not support loading sessions');
+    }
+    const request: LoadSessionRequest = {
+      sessionId,
+      cwd,
+      mcpServers: [],
+    };
+    return (await this.sendRequest('session/load', request)) as LoadSessionResponse;
+  }
+
+  /**
+   * Send a prompt to the agent
+   * 
+   * Note: ACP ContentBlock format is { type: 'text', text: 'content' }
+   * not { text: { text: 'content' } } as the union type suggests
+   */
+  async prompt(sessionId: SessionId, text: string): Promise<PromptResponse> {
+    // ACP uses a simpler content block format for text
+    const contentBlock = {
+      type: 'text',
+      text,
+    };
+    const request: PromptRequest = {
+      sessionId,
+      prompt: [contentBlock as unknown as ContentBlock],
+    };
+    return (await this.sendRequest('session/prompt', request)) as PromptResponse;
+  }
+
+  /**
+   * Send a prompt with images
+   */
+  async promptWithImages(
+    sessionId: SessionId,
+    text: string,
+    images: Array<{ data: string; mimeType: string }>
+  ): Promise<PromptResponse> {
+    const contentBlocks: ContentBlock[] = [{ text: { text } }];
+
+    for (const image of images) {
+      contentBlocks.push({
+        image: {
+          data: image.data,
+          mimeType: image.mimeType,
+        },
+      });
+    }
+
+    const request: PromptRequest = {
+      sessionId,
+      prompt: contentBlocks,
+    };
+    return (await this.sendRequest('session/prompt', request)) as PromptResponse;
+  }
+
+  /**
+   * Cancel ongoing operations for a session
+   */
+  cancel(sessionId: SessionId): void {
+    const notification: CancelNotification = { sessionId };
+    this.sendNotification('session/cancel', notification);
+  }
+
+  /**
+   * Get agent capabilities
+   */
+  getAgentCapabilities(): AgentCapabilities | null {
+    return this.agentCapabilities;
+  }
+
+  /**
+   * Get agent info
+   */
+  getAgentInfo(): Implementation | null {
+    return this.agentInfo;
+  }
+
+  /**
+   * Check if connected
+   */
+  getIsConnected(): boolean {
+    return this.isConnected;
+  }
+
+  // ============================================================================
+  // Private methods
+  // ============================================================================
+
+  private handleLine(line: string): void {
+    if (!line.trim()) return;
+
+    try {
+      const message = JSON.parse(line);
+
+      // Log all inbound messages at transport layer (with sensitive data redacted)
+      if ('id' in message && message.id !== null) {
+        if ('result' in message || 'error' in message) {
+          // Response to our request
+          logger.debug('[INBOUND RESPONSE]', '[ACP Transport]', { id: message.id, hasResult: 'result' in message, hasError: 'error' in message, data: redactForLogging(message) });
+          this.handleResponse(message as JsonRpcResponse);
+        } else {
+          // Request from the agent to us
+          logger.debug('[INBOUND REQUEST]', '[ACP Transport]', { method: message.method, id: message.id, data: redactForLogging(message) });
+          this.handleAgentRequest(message as JsonRpcRequest);
+        }
+      } else if ('method' in message) {
+        // Notification
+        logger.debug('[INBOUND NOTIFICATION]', '[ACP Transport]', { method: message.method, data: redactForLogging(message) });
+        this.handleNotification(message as JsonRpcNotification);
+      }
+    } catch (error) {
+      logger.error(`Failed to parse JSON-RPC message: ${line}`, LOG_CONTEXT);
+    }
+  }
+
+  private handleResponse(response: JsonRpcResponse): void {
+    const pending = this.pendingRequests.get(response.id);
+    if (!pending) {
+      logger.warn(`Received response for unknown request: ${response.id}`, LOG_CONTEXT);
+      return;
+    }
+
+    this.pendingRequests.delete(response.id);
+
+    if (response.error) {
+      pending.reject(new Error(`${response.error.message} (code: ${response.error.code})`));
+    } else {
+      pending.resolve(response.result);
+    }
+  }
+
+  private handleNotification(notification: JsonRpcNotification): void {
+    switch (notification.method) {
+      case 'session/update': {
+        const params = notification.params as SessionNotification;
+        // OpenCode uses a slightly different format: { sessionUpdate: 'type', ...data }
+        // Convert to standard format if needed
+        const update = this.normalizeSessionUpdate(params.update || params);
+        this.emit('session:update', params.sessionId, update);
+        break;
+      }
+      default:
+        logger.debug(`Unhandled notification: ${notification.method}`, LOG_CONTEXT);
+    }
+  }
+
+  /**
+   * Normalize session update format from OpenCode
+   * OpenCode sends: { sessionUpdate: 'agent_message_chunk', content: {...} }
+   * We need: { agent_message_chunk: { content: {...} } }
+   */
+  private normalizeSessionUpdate(update: unknown): SessionUpdate {
+    const raw = update as Record<string, unknown>;
+    
+    if ('sessionUpdate' in raw) {
+      const updateType = raw.sessionUpdate as string;
+      const { sessionUpdate, ...rest } = raw;
+      
+      // Convert to standard ACP format
+      return { [updateType]: rest } as unknown as SessionUpdate;
+    }
+    
+    return update as SessionUpdate;
+  }
+
+  private handleAgentRequest(request: JsonRpcRequest): void {
+    const respond = (result: unknown) => {
+      this.sendResponse(request.id, result);
+    };
+
+    const respondError = (code: number, message: string) => {
+      this.sendErrorResponse(request.id, code, message);
+    };
+
+    switch (request.method) {
+      case 'session/request_permission': {
+        const params = request.params as RequestPermissionRequest;
+        this.emit('session:permission_request', params, (response: RequestPermissionResponse) => {
+          respond(response);
+        });
+        break;
+      }
+      case 'fs/read_text_file': {
+        const params = request.params as ReadTextFileRequest;
+        this.emit('fs:read', params, (response: ReadTextFileResponse) => {
+          respond(response);
+        });
+        break;
+      }
+      case 'fs/write_text_file': {
+        const params = request.params as WriteTextFileRequest;
+        this.emit('fs:write', params, (response: WriteTextFileResponse) => {
+          respond(response);
+        });
+        break;
+      }
+      case 'terminal/create': {
+        const params = request.params as CreateTerminalRequest;
+        this.emit('terminal:create', params, (response: CreateTerminalResponse) => {
+          respond(response);
+        });
+        break;
+      }
+      case 'terminal/output': {
+        const params = request.params as TerminalOutputRequest;
+        this.emit('terminal:output', params, (response: TerminalOutputResponse) => {
+          respond(response);
+        });
+        break;
+      }
+      default:
+        logger.warn(`Unhandled agent request: ${request.method}`, LOG_CONTEXT);
+        respondError(-32601, `Method not found: ${request.method}`);
+    }
+  }
+
+  private sendRequest(method: string, params: unknown): Promise<unknown> {
+    return new Promise((resolve, reject) => {
+      const id = ++this.requestId;
+      const request: JsonRpcRequest = {
+        jsonrpc: '2.0',
+        id,
+        method,
+        params,
+      };
+
+      this.pendingRequests.set(id, { resolve, reject, method });
+
+      const line = JSON.stringify(request) + '\n';
+      logger.debug(`Sending request: ${method} (id: ${id})`, LOG_CONTEXT);
+      logger.debug('[OUTBOUND REQUEST]', '[ACP Transport]', { method, id, data: redactForLogging(request) });
+
+      if (!this.process?.stdin?.writable) {
+        reject(new Error('Agent process is not writable'));
+        return;
+      }
+
+      this.process.stdin.write(line);
+    });
+  }
+
+  private sendNotification(method: string, params: unknown): void {
+    const notification: JsonRpcNotification = {
+      jsonrpc: '2.0',
+      method,
+      params,
+    };
+
+    const line = JSON.stringify(notification) + '\n';
+    logger.debug(`Sending notification: ${method}`, LOG_CONTEXT);
+    logger.debug('[OUTBOUND NOTIFICATION]', '[ACP Transport]', { method, data: redactForLogging(notification) });
+
+    if (this.process?.stdin?.writable) {
+      this.process.stdin.write(line);
+    }
+  }
+
+  private sendResponse(id: RequestId, result: unknown): void {
+    const response: JsonRpcResponse = {
+      jsonrpc: '2.0',
+      id,
+      result,
+    };
+
+    const line = JSON.stringify(response) + '\n';
+    logger.debug('[OUTBOUND RESPONSE]', '[ACP Transport]', { id, data: redactForLogging(response) });
+
+    if (this.process?.stdin?.writable) {
+      this.process.stdin.write(line);
+    }
+  }
+
+  private sendErrorResponse(id: RequestId, code: number, message: string): void {
+    const response: JsonRpcResponse = {
+      jsonrpc: '2.0',
+      id,
+      error: { code, message },
+    };
+
+    const line = JSON.stringify(response) + '\n';
+    logger.debug('[OUTBOUND ERROR RESPONSE]', '[ACP Transport]', { id, code, message, data: redactForLogging(response) });
+
+    if (this.process?.stdin?.writable) {
+      this.process.stdin.write(line);
+    }
+  }
+
+  private handleDisconnect(): void {
+    this.isConnected = false;
+    this.readline?.close();
+    this.readline = null;
+
+    // Reject all pending requests
+    for (const [id, pending] of this.pendingRequests) {
+      pending.reject(new Error('Connection closed'));
+      this.pendingRequests.delete(id);
+    }
+
+    this.emit('disconnected');
+  }
+}

--- a/src/main/acp/acp-client.ts
+++ b/src/main/acp/acp-client.ts
@@ -22,6 +22,8 @@ import type {
 	AgentCapabilities,
 	InitializeRequest,
 	InitializeResponse,
+	AuthenticateRequest,
+	AuthenticateResponse,
 	SessionId,
 	NewSessionRequest,
 	NewSessionResponse,
@@ -335,6 +337,34 @@ export class ACPClient extends EventEmitter {
 	}
 
 	/**
+	 * Authenticate with the agent.
+	 *
+	 * Some agents (e.g., Gemini CLI) require an explicit authenticate call
+	 * between initialize and session/new. Call this method after connect()
+	 * if the InitializeResponse includes authMethods.
+	 *
+	 * @param authMethodId - The ID of the auth method to use (from InitializeResponse.authMethods)
+	 * @param params - Optional auth parameters (e.g., API key, token)
+	 * @returns AuthenticateResponse indicating success or failure
+	 */
+	async authenticate(
+		authMethodId: string,
+		params?: Record<string, unknown>
+	): Promise<AuthenticateResponse> {
+		if (!this.isConnected) {
+			throw new Error('Not connected - call connect() first');
+		}
+
+		const request: AuthenticateRequest = {
+			authMethodId,
+			params,
+		};
+
+		logger.info(`Authenticating with method: ${authMethodId}`, LOG_CONTEXT);
+		return (await this.sendRequest('authenticate', request)) as AuthenticateResponse;
+	}
+
+	/**
 	 * Create a new session
 	 */
 	async newSession(cwd: string): Promise<NewSessionResponse> {
@@ -363,21 +393,34 @@ export class ACPClient extends EventEmitter {
 	/**
 	 * Send a prompt to the agent
 	 *
-	 * Note: OpenCode uses the flat ContentBlock format: { type: 'text', text: 'content' }
-	 * rather than the nested spec format { text: { text: 'content' } }.
-	 * We use ContentBlockFlat here for OpenCode compatibility.
+	 * Supports two content block formats:
+	 * - Flat format (useFlatFormat=true): { type: 'text', text: 'content' } (OpenCode convention)
+	 * - Spec format (useFlatFormat=false): { text: { text: 'content' } } (standard ACP, Gemini CLI)
+	 *
+	 * @param sessionId - The session ID
+	 * @param text - The prompt text
+	 * @param useFlatFormat - Use flat content block format (default: true for OpenCode compat)
 	 */
-	async prompt(sessionId: SessionId, text: string): Promise<PromptResponse> {
-		// OpenCode uses flat content block format
-		const contentBlock: ContentBlockFlat = {
-			type: 'text',
-			text,
-		};
-		const request: PromptRequest = {
-			sessionId,
+	async prompt(sessionId: SessionId, text: string, useFlatFormat = true): Promise<PromptResponse> {
+		let prompt: ContentBlock[];
+
+		if (useFlatFormat) {
+			// OpenCode uses flat content block format
+			const contentBlock: ContentBlockFlat = {
+				type: 'text',
+				text,
+			};
 			// Cast to ContentBlock[] since PromptRequest expects that type
 			// but we're sending the flat format that OpenCode understands
-			prompt: [contentBlock as unknown as ContentBlock],
+			prompt = [contentBlock as unknown as ContentBlock];
+		} else {
+			// Standard ACP spec format (Gemini CLI and other conforming agents)
+			prompt = [{ text: { text } }];
+		}
+
+		const request: PromptRequest = {
+			sessionId,
+			prompt,
 		};
 		return (await this.sendRequest('session/prompt', request)) as PromptResponse;
 	}

--- a/src/main/acp/acp-client.ts
+++ b/src/main/acp/acp-client.ts
@@ -11,6 +11,7 @@ import { spawn, ChildProcess } from 'child_process';
 import { EventEmitter } from 'events';
 import { createInterface, Interface } from 'readline';
 import { logger } from '../utils/logger';
+import { getAppVersion } from './version';
 import type {
 	RequestId,
 	JsonRpcRequest,
@@ -29,6 +30,7 @@ import type {
 	PromptRequest,
 	PromptResponse,
 	ContentBlock,
+	ContentBlockFlat,
 	SessionNotification,
 	SessionUpdate,
 	CancelNotification,
@@ -295,7 +297,7 @@ export class ACPClient extends EventEmitter {
 			protocolVersion: CURRENT_PROTOCOL_VERSION,
 			clientInfo: this.config.clientInfo || {
 				name: 'maestro',
-				version: '0.12.0',
+				version: getAppVersion(),
 				title: 'Maestro',
 			},
 			clientCapabilities: this.config.clientCapabilities || {
@@ -361,17 +363,20 @@ export class ACPClient extends EventEmitter {
 	/**
 	 * Send a prompt to the agent
 	 *
-	 * Note: ACP ContentBlock format is { type: 'text', text: 'content' }
-	 * not { text: { text: 'content' } } as the union type suggests
+	 * Note: OpenCode uses the flat ContentBlock format: { type: 'text', text: 'content' }
+	 * rather than the nested spec format { text: { text: 'content' } }.
+	 * We use ContentBlockFlat here for OpenCode compatibility.
 	 */
 	async prompt(sessionId: SessionId, text: string): Promise<PromptResponse> {
-		// ACP uses a simpler content block format for text
-		const contentBlock = {
+		// OpenCode uses flat content block format
+		const contentBlock: ContentBlockFlat = {
 			type: 'text',
 			text,
 		};
 		const request: PromptRequest = {
 			sessionId,
+			// Cast to ContentBlock[] since PromptRequest expects that type
+			// but we're sending the flat format that OpenCode understands
 			prompt: [contentBlock as unknown as ContentBlock],
 		};
 		return (await this.sendRequest('session/prompt', request)) as PromptResponse;

--- a/src/main/acp/acp-client.ts
+++ b/src/main/acp/acp-client.ts
@@ -12,36 +12,36 @@ import { EventEmitter } from 'events';
 import { createInterface, Interface } from 'readline';
 import { logger } from '../utils/logger';
 import type {
-  RequestId,
-  JsonRpcRequest,
-  JsonRpcResponse,
-  JsonRpcNotification,
-  Implementation,
-  ClientCapabilities,
-  AgentCapabilities,
-  InitializeRequest,
-  InitializeResponse,
-  SessionId,
-  NewSessionRequest,
-  NewSessionResponse,
-  LoadSessionRequest,
-  LoadSessionResponse,
-  PromptRequest,
-  PromptResponse,
-  ContentBlock,
-  SessionNotification,
-  SessionUpdate,
-  CancelNotification,
-  RequestPermissionRequest,
-  RequestPermissionResponse,
-  ReadTextFileRequest,
-  ReadTextFileResponse,
-  WriteTextFileRequest,
-  WriteTextFileResponse,
-  CreateTerminalRequest,
-  CreateTerminalResponse,
-  TerminalOutputRequest,
-  TerminalOutputResponse,
+	RequestId,
+	JsonRpcRequest,
+	JsonRpcResponse,
+	JsonRpcNotification,
+	Implementation,
+	ClientCapabilities,
+	AgentCapabilities,
+	InitializeRequest,
+	InitializeResponse,
+	SessionId,
+	NewSessionRequest,
+	NewSessionResponse,
+	LoadSessionRequest,
+	LoadSessionResponse,
+	PromptRequest,
+	PromptResponse,
+	ContentBlock,
+	SessionNotification,
+	SessionUpdate,
+	CancelNotification,
+	RequestPermissionRequest,
+	RequestPermissionResponse,
+	ReadTextFileRequest,
+	ReadTextFileResponse,
+	WriteTextFileRequest,
+	WriteTextFileResponse,
+	CreateTerminalRequest,
+	CreateTerminalResponse,
+	TerminalOutputRequest,
+	TerminalOutputResponse,
 } from './types';
 import { CURRENT_PROTOCOL_VERSION } from './types';
 
@@ -52,594 +52,627 @@ const LOG_CONTEXT = '[ACPClient]';
  * Keeps method/id metadata but redacts large payloads like prompts, file contents, and base64 images.
  */
 function redactForLogging(message: unknown): unknown {
-  if (!message || typeof message !== 'object') return message;
-  
-  const obj = message as Record<string, unknown>;
-  const redacted: Record<string, unknown> = {};
-  
-  for (const [key, value] of Object.entries(obj)) {
-    if (key === 'id' || key === 'jsonrpc' || key === 'method') {
-      // Keep metadata as-is
-      redacted[key] = value;
-    } else if (key === 'params' || key === 'result') {
-      // Summarize params/result
-      if (value && typeof value === 'object') {
-        const inner = value as Record<string, unknown>;
-        const summary: Record<string, unknown> = {};
-        for (const [innerKey, innerValue] of Object.entries(inner)) {
-          if (typeof innerValue === 'string' && innerValue.length > 100) {
-            summary[innerKey] = `[REDACTED: ${innerValue.length} chars]`;
-          } else if (Array.isArray(innerValue)) {
-            summary[innerKey] = `[Array: ${innerValue.length} items]`;
-          } else if (innerValue && typeof innerValue === 'object') {
-            summary[innerKey] = `[Object: ${Object.keys(innerValue).join(', ')}]`;
-          } else {
-            summary[innerKey] = innerValue;
-          }
-        }
-        redacted[key] = summary;
-      } else {
-        redacted[key] = value;
-      }
-    } else if (key === 'error') {
-      // Keep error info
-      redacted[key] = value;
-    } else {
-      // Redact other fields
-      if (typeof value === 'string' && value.length > 100) {
-        redacted[key] = `[REDACTED: ${value.length} chars]`;
-      } else {
-        redacted[key] = value;
-      }
-    }
-  }
-  
-  return redacted;
+	if (!message || typeof message !== 'object') return message;
+
+	const obj = message as Record<string, unknown>;
+	const redacted: Record<string, unknown> = {};
+
+	for (const [key, value] of Object.entries(obj)) {
+		if (key === 'id' || key === 'jsonrpc' || key === 'method') {
+			// Keep metadata as-is
+			redacted[key] = value;
+		} else if (key === 'params' || key === 'result') {
+			// Summarize params/result
+			if (value && typeof value === 'object') {
+				const inner = value as Record<string, unknown>;
+				const summary: Record<string, unknown> = {};
+				for (const [innerKey, innerValue] of Object.entries(inner)) {
+					if (typeof innerValue === 'string' && innerValue.length > 100) {
+						summary[innerKey] = `[REDACTED: ${innerValue.length} chars]`;
+					} else if (Array.isArray(innerValue)) {
+						summary[innerKey] = `[Array: ${innerValue.length} items]`;
+					} else if (innerValue && typeof innerValue === 'object') {
+						summary[innerKey] = `[Object: ${Object.keys(innerValue).join(', ')}]`;
+					} else {
+						summary[innerKey] = innerValue;
+					}
+				}
+				redacted[key] = summary;
+			} else {
+				redacted[key] = value;
+			}
+		} else if (key === 'error') {
+			// Keep error info
+			redacted[key] = value;
+		} else {
+			// Redact other fields
+			if (typeof value === 'string' && value.length > 100) {
+				redacted[key] = `[REDACTED: ${value.length} chars]`;
+			} else {
+				redacted[key] = value;
+			}
+		}
+	}
+
+	return redacted;
 }
 
 /**
  * Events emitted by the ACP client
  */
 export interface ACPClientEvents {
-  /** Session update notification from agent */
-  'session:update': (sessionId: SessionId, update: SessionUpdate) => void;
-  /** Permission request from agent */
-  'session:permission_request': (
-    request: RequestPermissionRequest,
-    respond: (response: RequestPermissionResponse) => void
-  ) => void;
-  /** File read request from agent */
-  'fs:read': (
-    request: ReadTextFileRequest,
-    respond: (response: ReadTextFileResponse) => void
-  ) => void;
-  /** File write request from agent */
-  'fs:write': (
-    request: WriteTextFileRequest,
-    respond: (response: WriteTextFileResponse) => void
-  ) => void;
-  /** Terminal create request from agent */
-  'terminal:create': (
-    request: CreateTerminalRequest,
-    respond: (response: CreateTerminalResponse) => void
-  ) => void;
-  /** Terminal output request from agent */
-  'terminal:output': (
-    request: TerminalOutputRequest,
-    respond: (response: TerminalOutputResponse) => void
-  ) => void;
-  /** Error occurred */
-  error: (error: Error) => void;
-  /** Client disconnected */
-  disconnected: () => void;
+	/** Session update notification from agent */
+	'session:update': (sessionId: SessionId, update: SessionUpdate) => void;
+	/** Permission request from agent */
+	'session:permission_request': (
+		request: RequestPermissionRequest,
+		respond: (response: RequestPermissionResponse) => void
+	) => void;
+	/** File read request from agent */
+	'fs:read': (
+		request: ReadTextFileRequest,
+		respond: (response: ReadTextFileResponse) => void
+	) => void;
+	/** File write request from agent */
+	'fs:write': (
+		request: WriteTextFileRequest,
+		respond: (response: WriteTextFileResponse) => void
+	) => void;
+	/** Terminal create request from agent */
+	'terminal:create': (
+		request: CreateTerminalRequest,
+		respond: (response: CreateTerminalResponse) => void
+	) => void;
+	/** Terminal output request from agent */
+	'terminal:output': (
+		request: TerminalOutputRequest,
+		respond: (response: TerminalOutputResponse) => void
+	) => void;
+	/** Error occurred */
+	error: (error: Error) => void;
+	/** Client disconnected */
+	disconnected: () => void;
 }
 
 /**
  * Configuration for ACP client
  */
 export interface ACPClientConfig {
-  /** Command to spawn the agent (e.g., 'opencode') */
-  command: string;
-  /** Arguments for the agent command (e.g., ['acp']) */
-  args: string[];
-  /** Working directory for the agent process */
-  cwd: string;
-  /** Environment variables for the agent process */
-  env?: Record<string, string>;
-  /** Client info to send during initialization */
-  clientInfo?: Implementation;
-  /** Client capabilities */
-  clientCapabilities?: ClientCapabilities;
+	/** Command to spawn the agent (e.g., 'opencode') */
+	command: string;
+	/** Arguments for the agent command (e.g., ['acp']) */
+	args: string[];
+	/** Working directory for the agent process */
+	cwd: string;
+	/** Environment variables for the agent process */
+	env?: Record<string, string>;
+	/** Client info to send during initialization */
+	clientInfo?: Implementation;
+	/** Client capabilities */
+	clientCapabilities?: ClientCapabilities;
 }
 
 /**
  * ACP Client for communicating with agents via JSON-RPC over stdio
  */
 export class ACPClient extends EventEmitter {
-  private process: ChildProcess | null = null;
-  private readline: Interface | null = null;
-  private requestId = 0;
-  private pendingRequests = new Map<
-    RequestId,
-    {
-      resolve: (result: unknown) => void;
-      reject: (error: Error) => void;
-      method: string;
-    }
-  >();
-  private config: ACPClientConfig;
-  private isConnected = false;
-  private agentCapabilities: AgentCapabilities | null = null;
-  private agentInfo: Implementation | null = null;
+	private process: ChildProcess | null = null;
+	private readline: Interface | null = null;
+	private requestId = 0;
+	private pendingRequests = new Map<
+		RequestId,
+		{
+			resolve: (result: unknown) => void;
+			reject: (error: Error) => void;
+			method: string;
+		}
+	>();
+	private config: ACPClientConfig;
+	private isConnected = false;
+	private agentCapabilities: AgentCapabilities | null = null;
+	private agentInfo: Implementation | null = null;
 
-  constructor(config: ACPClientConfig) {
-    super();
-    this.config = config;
-  }
+	constructor(config: ACPClientConfig) {
+		super();
+		this.config = config;
+	}
 
-  /**
-   * Get the underlying child process (for PID access)
-   */
-  getProcess(): ChildProcess | null {
-    return this.process;
-  }
+	/**
+	 * Get the underlying child process (for PID access)
+	 */
+	getProcess(): ChildProcess | null {
+		return this.process;
+	}
 
-  /**
-   * Start the agent process and initialize the connection
-   */
-  async connect(): Promise<InitializeResponse> {
-    if (this.isConnected) {
-      throw new Error('Already connected');
-    }
+	/**
+	 * Start the agent process and initialize the connection
+	 */
+	async connect(): Promise<InitializeResponse> {
+		if (this.isConnected) {
+			throw new Error('Already connected');
+		}
 
-    const fullCommand = `${this.config.command} ${this.config.args.join(' ')}`;
-    logger.info(`Starting ACP agent: ${fullCommand}`, LOG_CONTEXT);
+		const fullCommand = `${this.config.command} ${this.config.args.join(' ')}`;
+		logger.info(`Starting ACP agent: ${fullCommand}`, LOG_CONTEXT);
 
-    // Build environment with extended PATH
-    // Electron doesn't inherit the user's shell PATH, so we need to add common paths
-    // where node, npm, and other tools are typically installed
-    const env = { ...process.env, ...this.config.env };
-    const isWin = process.platform === 'win32';
-    
-    if (isWin) {
-      const appData = process.env.APPDATA || '';
-      const localAppData = process.env.LOCALAPPDATA || '';
-      const programFiles = process.env.ProgramFiles || 'C:\\Program Files';
-      const standardPaths = [
-        `${appData}\\npm`,
-        `${localAppData}\\npm`,
-        `${programFiles}\\nodejs`,
-        `${programFiles}\\Git\\cmd`,
-      ].join(';');
-      env.PATH = env.PATH ? `${standardPaths};${env.PATH}` : standardPaths;
-    } else {
-      // macOS/Linux: Add Homebrew, nvm, volta, fnm, and standard paths
-      const home = process.env.HOME || '';
-      const standardPaths = [
-        '/opt/homebrew/bin',           // Homebrew on Apple Silicon
-        '/usr/local/bin',              // Homebrew on Intel, many CLI tools
-        `${home}/.nvm/versions/node`,  // nvm (we'll expand this below)
-        `${home}/.volta/bin`,          // Volta
-        `${home}/.fnm`,                // fnm
-        `${home}/.local/bin`,          // pipx, etc.
-        '/usr/bin',
-        '/bin',
-        '/usr/sbin',
-        '/sbin',
-      ].join(':');
-      
-      // Also try to detect the active nvm node version
-      const nvmDir = process.env.NVM_DIR || `${home}/.nvm`;
-      let nvmNodePath = '';
-      try {
-        // Try to read the default version
-        const fs = require('fs');
-        const path = require('path');
-        const defaultVersionFile = path.join(nvmDir, 'alias', 'default');
-        if (fs.existsSync(defaultVersionFile)) {
-          const version = fs.readFileSync(defaultVersionFile, 'utf8').trim();
-          const nodePath = path.join(nvmDir, 'versions', 'node', `v${version.replace(/^v/, '')}`, 'bin');
-          if (fs.existsSync(nodePath)) {
-            nvmNodePath = nodePath;
-          }
-        }
-      } catch {
-        // Ignore errors - nvm might not be installed
-      }
-      
-      const allPaths = nvmNodePath ? `${nvmNodePath}:${standardPaths}` : standardPaths;
-      env.PATH = env.PATH ? `${allPaths}:${env.PATH}` : allPaths;
-    }
+		// Build environment with extended PATH
+		// Electron doesn't inherit the user's shell PATH, so we need to add common paths
+		// where node, npm, and other tools are typically installed
+		const env = { ...process.env, ...this.config.env };
+		const isWin = process.platform === 'win32';
 
-    // Spawn the agent process
-    this.process = spawn(this.config.command, this.config.args, {
-      cwd: this.config.cwd,
-      env,
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
+		if (isWin) {
+			const appData = process.env.APPDATA || '';
+			const localAppData = process.env.LOCALAPPDATA || '';
+			const programFiles = process.env.ProgramFiles || 'C:\\Program Files';
+			const standardPaths = [
+				`${appData}\\npm`,
+				`${localAppData}\\npm`,
+				`${programFiles}\\nodejs`,
+				`${programFiles}\\Git\\cmd`,
+			].join(';');
+			env.PATH = env.PATH ? `${standardPaths};${env.PATH}` : standardPaths;
+		} else {
+			// macOS/Linux: Add Homebrew, nvm, volta, fnm, and standard paths
+			const home = process.env.HOME || '';
+			const standardPaths = [
+				'/opt/homebrew/bin', // Homebrew on Apple Silicon
+				'/usr/local/bin', // Homebrew on Intel, many CLI tools
+				`${home}/.nvm/versions/node`, // nvm (we'll expand this below)
+				`${home}/.volta/bin`, // Volta
+				`${home}/.fnm`, // fnm
+				`${home}/.local/bin`, // pipx, etc.
+				'/usr/bin',
+				'/bin',
+				'/usr/sbin',
+				'/sbin',
+			].join(':');
 
-    if (!this.process.stdout || !this.process.stdin) {
-      throw new Error('Failed to create agent process with stdio');
-    }
+			// Also try to detect the active nvm node version
+			const nvmDir = process.env.NVM_DIR || `${home}/.nvm`;
+			let nvmNodePath = '';
+			try {
+				// Try to read the default version
+				const fs = require('fs');
+				const path = require('path');
+				const defaultVersionFile = path.join(nvmDir, 'alias', 'default');
+				if (fs.existsSync(defaultVersionFile)) {
+					const version = fs.readFileSync(defaultVersionFile, 'utf8').trim();
+					const nodePath = path.join(
+						nvmDir,
+						'versions',
+						'node',
+						`v${version.replace(/^v/, '')}`,
+						'bin'
+					);
+					if (fs.existsSync(nodePath)) {
+						nvmNodePath = nodePath;
+					}
+				}
+			} catch {
+				// Ignore errors - nvm might not be installed
+			}
 
-    // Set up readline for line-by-line JSON-RPC parsing
-    this.readline = createInterface({
-      input: this.process.stdout,
-      crlfDelay: Infinity,
-    });
+			const allPaths = nvmNodePath ? `${nvmNodePath}:${standardPaths}` : standardPaths;
+			env.PATH = env.PATH ? `${allPaths}:${env.PATH}` : allPaths;
+		}
 
-    this.readline.on('line', (line) => this.handleLine(line));
+		// Spawn the agent process
+		this.process = spawn(this.config.command, this.config.args, {
+			cwd: this.config.cwd,
+			env,
+			stdio: ['pipe', 'pipe', 'pipe'],
+		});
 
-    this.process.stderr?.on('data', (data) => {
-      logger.warn(`Agent stderr: ${data.toString()}`, LOG_CONTEXT);
-    });
+		if (!this.process.stdout || !this.process.stdin) {
+			throw new Error('Failed to create agent process with stdio');
+		}
 
-    this.process.on('close', (code) => {
-      logger.info(`Agent process exited with code ${code}`, LOG_CONTEXT);
-      this.handleDisconnect();
-    });
+		// Set up readline for line-by-line JSON-RPC parsing
+		this.readline = createInterface({
+			input: this.process.stdout,
+			crlfDelay: Infinity,
+		});
 
-    this.process.on('error', (error) => {
-      logger.error(`Agent process error: ${error.message}`, LOG_CONTEXT);
-      this.emit('error', error);
-    });
+		this.readline.on('line', (line) => this.handleLine(line));
 
-    // Send initialize request
-    const initRequest: InitializeRequest = {
-      protocolVersion: CURRENT_PROTOCOL_VERSION,
-      clientInfo: this.config.clientInfo || {
-        name: 'maestro',
-        version: '0.12.0',
-        title: 'Maestro',
-      },
-      clientCapabilities: this.config.clientCapabilities || {
-        fs: {
-          readTextFile: true,
-          writeTextFile: true,
-        },
-        terminal: true,
-      },
-    };
+		this.process.stderr?.on('data', (data) => {
+			logger.warn(`Agent stderr: ${data.toString()}`, LOG_CONTEXT);
+		});
 
-    const response = (await this.sendRequest('initialize', initRequest)) as InitializeResponse;
+		this.process.on('close', (code) => {
+			logger.info(`Agent process exited with code ${code}`, LOG_CONTEXT);
+			this.handleDisconnect();
+		});
 
-    this.agentCapabilities = response.agentCapabilities || null;
-    this.agentInfo = response.agentInfo || null;
-    this.isConnected = true;
+		this.process.on('error', (error) => {
+			logger.error(`Agent process error: ${error.message}`, LOG_CONTEXT);
+			this.emit('error', error);
+		});
 
-    logger.info(
-      `Connected to agent: ${this.agentInfo?.name || 'unknown'} v${this.agentInfo?.version || '?'}`,
-      LOG_CONTEXT
-    );
+		// Send initialize request
+		const initRequest: InitializeRequest = {
+			protocolVersion: CURRENT_PROTOCOL_VERSION,
+			clientInfo: this.config.clientInfo || {
+				name: 'maestro',
+				version: '0.12.0',
+				title: 'Maestro',
+			},
+			clientCapabilities: this.config.clientCapabilities || {
+				fs: {
+					readTextFile: true,
+					writeTextFile: true,
+				},
+				terminal: true,
+			},
+		};
 
-    return response;
-  }
+		const response = (await this.sendRequest('initialize', initRequest)) as InitializeResponse;
 
-  /**
-   * Disconnect from the agent
-   */
-  disconnect(): void {
-    if (this.process) {
-      this.process.kill();
-      this.process = null;
-    }
-    this.handleDisconnect();
-  }
+		this.agentCapabilities = response.agentCapabilities || null;
+		this.agentInfo = response.agentInfo || null;
+		this.isConnected = true;
 
-  /**
-   * Create a new session
-   */
-  async newSession(cwd: string): Promise<NewSessionResponse> {
-    const request: NewSessionRequest = {
-      cwd,
-      mcpServers: [], // No MCP servers for now
-    };
-    return (await this.sendRequest('session/new', request)) as NewSessionResponse;
-  }
+		logger.info(
+			`Connected to agent: ${this.agentInfo?.name || 'unknown'} v${this.agentInfo?.version || '?'}`,
+			LOG_CONTEXT
+		);
 
-  /**
-   * Load an existing session
-   */
-  async loadSession(sessionId: SessionId, cwd: string): Promise<LoadSessionResponse> {
-    if (!this.agentCapabilities?.loadSession) {
-      throw new Error('Agent does not support loading sessions');
-    }
-    const request: LoadSessionRequest = {
-      sessionId,
-      cwd,
-      mcpServers: [],
-    };
-    return (await this.sendRequest('session/load', request)) as LoadSessionResponse;
-  }
+		return response;
+	}
 
-  /**
-   * Send a prompt to the agent
-   * 
-   * Note: ACP ContentBlock format is { type: 'text', text: 'content' }
-   * not { text: { text: 'content' } } as the union type suggests
-   */
-  async prompt(sessionId: SessionId, text: string): Promise<PromptResponse> {
-    // ACP uses a simpler content block format for text
-    const contentBlock = {
-      type: 'text',
-      text,
-    };
-    const request: PromptRequest = {
-      sessionId,
-      prompt: [contentBlock as unknown as ContentBlock],
-    };
-    return (await this.sendRequest('session/prompt', request)) as PromptResponse;
-  }
+	/**
+	 * Disconnect from the agent
+	 */
+	disconnect(): void {
+		if (this.process) {
+			this.process.kill();
+			this.process = null;
+		}
+		this.handleDisconnect();
+	}
 
-  /**
-   * Send a prompt with images
-   */
-  async promptWithImages(
-    sessionId: SessionId,
-    text: string,
-    images: Array<{ data: string; mimeType: string }>
-  ): Promise<PromptResponse> {
-    const contentBlocks: ContentBlock[] = [{ text: { text } }];
+	/**
+	 * Create a new session
+	 */
+	async newSession(cwd: string): Promise<NewSessionResponse> {
+		const request: NewSessionRequest = {
+			cwd,
+			mcpServers: [], // No MCP servers for now
+		};
+		return (await this.sendRequest('session/new', request)) as NewSessionResponse;
+	}
 
-    for (const image of images) {
-      contentBlocks.push({
-        image: {
-          data: image.data,
-          mimeType: image.mimeType,
-        },
-      });
-    }
+	/**
+	 * Load an existing session
+	 */
+	async loadSession(sessionId: SessionId, cwd: string): Promise<LoadSessionResponse> {
+		if (!this.agentCapabilities?.loadSession) {
+			throw new Error('Agent does not support loading sessions');
+		}
+		const request: LoadSessionRequest = {
+			sessionId,
+			cwd,
+			mcpServers: [],
+		};
+		return (await this.sendRequest('session/load', request)) as LoadSessionResponse;
+	}
 
-    const request: PromptRequest = {
-      sessionId,
-      prompt: contentBlocks,
-    };
-    return (await this.sendRequest('session/prompt', request)) as PromptResponse;
-  }
+	/**
+	 * Send a prompt to the agent
+	 *
+	 * Note: ACP ContentBlock format is { type: 'text', text: 'content' }
+	 * not { text: { text: 'content' } } as the union type suggests
+	 */
+	async prompt(sessionId: SessionId, text: string): Promise<PromptResponse> {
+		// ACP uses a simpler content block format for text
+		const contentBlock = {
+			type: 'text',
+			text,
+		};
+		const request: PromptRequest = {
+			sessionId,
+			prompt: [contentBlock as unknown as ContentBlock],
+		};
+		return (await this.sendRequest('session/prompt', request)) as PromptResponse;
+	}
 
-  /**
-   * Cancel ongoing operations for a session
-   */
-  cancel(sessionId: SessionId): void {
-    const notification: CancelNotification = { sessionId };
-    this.sendNotification('session/cancel', notification);
-  }
+	/**
+	 * Send a prompt with images
+	 */
+	async promptWithImages(
+		sessionId: SessionId,
+		text: string,
+		images: Array<{ data: string; mimeType: string }>
+	): Promise<PromptResponse> {
+		const contentBlocks: ContentBlock[] = [{ text: { text } }];
 
-  /**
-   * Get agent capabilities
-   */
-  getAgentCapabilities(): AgentCapabilities | null {
-    return this.agentCapabilities;
-  }
+		for (const image of images) {
+			contentBlocks.push({
+				image: {
+					data: image.data,
+					mimeType: image.mimeType,
+				},
+			});
+		}
 
-  /**
-   * Get agent info
-   */
-  getAgentInfo(): Implementation | null {
-    return this.agentInfo;
-  }
+		const request: PromptRequest = {
+			sessionId,
+			prompt: contentBlocks,
+		};
+		return (await this.sendRequest('session/prompt', request)) as PromptResponse;
+	}
 
-  /**
-   * Check if connected
-   */
-  getIsConnected(): boolean {
-    return this.isConnected;
-  }
+	/**
+	 * Cancel ongoing operations for a session
+	 */
+	cancel(sessionId: SessionId): void {
+		const notification: CancelNotification = { sessionId };
+		this.sendNotification('session/cancel', notification);
+	}
 
-  // ============================================================================
-  // Private methods
-  // ============================================================================
+	/**
+	 * Get agent capabilities
+	 */
+	getAgentCapabilities(): AgentCapabilities | null {
+		return this.agentCapabilities;
+	}
 
-  private handleLine(line: string): void {
-    if (!line.trim()) return;
+	/**
+	 * Get agent info
+	 */
+	getAgentInfo(): Implementation | null {
+		return this.agentInfo;
+	}
 
-    try {
-      const message = JSON.parse(line);
+	/**
+	 * Check if connected
+	 */
+	getIsConnected(): boolean {
+		return this.isConnected;
+	}
 
-      // Log all inbound messages at transport layer (with sensitive data redacted)
-      if ('id' in message && message.id !== null) {
-        if ('result' in message || 'error' in message) {
-          // Response to our request
-          logger.debug('[INBOUND RESPONSE]', '[ACP Transport]', { id: message.id, hasResult: 'result' in message, hasError: 'error' in message, data: redactForLogging(message) });
-          this.handleResponse(message as JsonRpcResponse);
-        } else {
-          // Request from the agent to us
-          logger.debug('[INBOUND REQUEST]', '[ACP Transport]', { method: message.method, id: message.id, data: redactForLogging(message) });
-          this.handleAgentRequest(message as JsonRpcRequest);
-        }
-      } else if ('method' in message) {
-        // Notification
-        logger.debug('[INBOUND NOTIFICATION]', '[ACP Transport]', { method: message.method, data: redactForLogging(message) });
-        this.handleNotification(message as JsonRpcNotification);
-      }
-    } catch (error) {
-      logger.error(`Failed to parse JSON-RPC message: ${line}`, LOG_CONTEXT);
-    }
-  }
+	// ============================================================================
+	// Private methods
+	// ============================================================================
 
-  private handleResponse(response: JsonRpcResponse): void {
-    const pending = this.pendingRequests.get(response.id);
-    if (!pending) {
-      logger.warn(`Received response for unknown request: ${response.id}`, LOG_CONTEXT);
-      return;
-    }
+	private handleLine(line: string): void {
+		if (!line.trim()) return;
 
-    this.pendingRequests.delete(response.id);
+		try {
+			const message = JSON.parse(line);
 
-    if (response.error) {
-      pending.reject(new Error(`${response.error.message} (code: ${response.error.code})`));
-    } else {
-      pending.resolve(response.result);
-    }
-  }
+			// Log all inbound messages at transport layer (with sensitive data redacted)
+			if ('id' in message && message.id !== null) {
+				if ('result' in message || 'error' in message) {
+					// Response to our request
+					logger.debug('[INBOUND RESPONSE]', '[ACP Transport]', {
+						id: message.id,
+						hasResult: 'result' in message,
+						hasError: 'error' in message,
+						data: redactForLogging(message),
+					});
+					this.handleResponse(message as JsonRpcResponse);
+				} else {
+					// Request from the agent to us
+					logger.debug('[INBOUND REQUEST]', '[ACP Transport]', {
+						method: message.method,
+						id: message.id,
+						data: redactForLogging(message),
+					});
+					this.handleAgentRequest(message as JsonRpcRequest);
+				}
+			} else if ('method' in message) {
+				// Notification
+				logger.debug('[INBOUND NOTIFICATION]', '[ACP Transport]', {
+					method: message.method,
+					data: redactForLogging(message),
+				});
+				this.handleNotification(message as JsonRpcNotification);
+			}
+		} catch (error) {
+			logger.error(`Failed to parse JSON-RPC message: ${line}`, LOG_CONTEXT);
+		}
+	}
 
-  private handleNotification(notification: JsonRpcNotification): void {
-    switch (notification.method) {
-      case 'session/update': {
-        const params = notification.params as SessionNotification;
-        // OpenCode uses a slightly different format: { sessionUpdate: 'type', ...data }
-        // Convert to standard format if needed
-        const update = this.normalizeSessionUpdate(params.update || params);
-        this.emit('session:update', params.sessionId, update);
-        break;
-      }
-      default:
-        logger.debug(`Unhandled notification: ${notification.method}`, LOG_CONTEXT);
-    }
-  }
+	private handleResponse(response: JsonRpcResponse): void {
+		const pending = this.pendingRequests.get(response.id);
+		if (!pending) {
+			logger.warn(`Received response for unknown request: ${response.id}`, LOG_CONTEXT);
+			return;
+		}
 
-  /**
-   * Normalize session update format from OpenCode
-   * OpenCode sends: { sessionUpdate: 'agent_message_chunk', content: {...} }
-   * We need: { agent_message_chunk: { content: {...} } }
-   */
-  private normalizeSessionUpdate(update: unknown): SessionUpdate {
-    const raw = update as Record<string, unknown>;
-    
-    if ('sessionUpdate' in raw) {
-      const updateType = raw.sessionUpdate as string;
-      const { sessionUpdate, ...rest } = raw;
-      
-      // Convert to standard ACP format
-      return { [updateType]: rest } as unknown as SessionUpdate;
-    }
-    
-    return update as SessionUpdate;
-  }
+		this.pendingRequests.delete(response.id);
 
-  private handleAgentRequest(request: JsonRpcRequest): void {
-    const respond = (result: unknown) => {
-      this.sendResponse(request.id, result);
-    };
+		if (response.error) {
+			pending.reject(new Error(`${response.error.message} (code: ${response.error.code})`));
+		} else {
+			pending.resolve(response.result);
+		}
+	}
 
-    const respondError = (code: number, message: string) => {
-      this.sendErrorResponse(request.id, code, message);
-    };
+	private handleNotification(notification: JsonRpcNotification): void {
+		switch (notification.method) {
+			case 'session/update': {
+				const params = notification.params as SessionNotification;
+				// OpenCode uses a slightly different format: { sessionUpdate: 'type', ...data }
+				// Convert to standard format if needed
+				const update = this.normalizeSessionUpdate(params.update || params);
+				this.emit('session:update', params.sessionId, update);
+				break;
+			}
+			default:
+				logger.debug(`Unhandled notification: ${notification.method}`, LOG_CONTEXT);
+		}
+	}
 
-    switch (request.method) {
-      case 'session/request_permission': {
-        const params = request.params as RequestPermissionRequest;
-        this.emit('session:permission_request', params, (response: RequestPermissionResponse) => {
-          respond(response);
-        });
-        break;
-      }
-      case 'fs/read_text_file': {
-        const params = request.params as ReadTextFileRequest;
-        this.emit('fs:read', params, (response: ReadTextFileResponse) => {
-          respond(response);
-        });
-        break;
-      }
-      case 'fs/write_text_file': {
-        const params = request.params as WriteTextFileRequest;
-        this.emit('fs:write', params, (response: WriteTextFileResponse) => {
-          respond(response);
-        });
-        break;
-      }
-      case 'terminal/create': {
-        const params = request.params as CreateTerminalRequest;
-        this.emit('terminal:create', params, (response: CreateTerminalResponse) => {
-          respond(response);
-        });
-        break;
-      }
-      case 'terminal/output': {
-        const params = request.params as TerminalOutputRequest;
-        this.emit('terminal:output', params, (response: TerminalOutputResponse) => {
-          respond(response);
-        });
-        break;
-      }
-      default:
-        logger.warn(`Unhandled agent request: ${request.method}`, LOG_CONTEXT);
-        respondError(-32601, `Method not found: ${request.method}`);
-    }
-  }
+	/**
+	 * Normalize session update format from OpenCode
+	 * OpenCode sends: { sessionUpdate: 'agent_message_chunk', content: {...} }
+	 * We need: { agent_message_chunk: { content: {...} } }
+	 */
+	private normalizeSessionUpdate(update: unknown): SessionUpdate {
+		const raw = update as Record<string, unknown>;
 
-  private sendRequest(method: string, params: unknown): Promise<unknown> {
-    return new Promise((resolve, reject) => {
-      const id = ++this.requestId;
-      const request: JsonRpcRequest = {
-        jsonrpc: '2.0',
-        id,
-        method,
-        params,
-      };
+		if ('sessionUpdate' in raw) {
+			const updateType = raw.sessionUpdate as string;
+			const { sessionUpdate, ...rest } = raw;
 
-      this.pendingRequests.set(id, { resolve, reject, method });
+			// Convert to standard ACP format
+			return { [updateType]: rest } as unknown as SessionUpdate;
+		}
 
-      const line = JSON.stringify(request) + '\n';
-      logger.debug(`Sending request: ${method} (id: ${id})`, LOG_CONTEXT);
-      logger.debug('[OUTBOUND REQUEST]', '[ACP Transport]', { method, id, data: redactForLogging(request) });
+		return update as SessionUpdate;
+	}
 
-      if (!this.process?.stdin?.writable) {
-        reject(new Error('Agent process is not writable'));
-        return;
-      }
+	private handleAgentRequest(request: JsonRpcRequest): void {
+		const respond = (result: unknown) => {
+			this.sendResponse(request.id, result);
+		};
 
-      this.process.stdin.write(line);
-    });
-  }
+		const respondError = (code: number, message: string) => {
+			this.sendErrorResponse(request.id, code, message);
+		};
 
-  private sendNotification(method: string, params: unknown): void {
-    const notification: JsonRpcNotification = {
-      jsonrpc: '2.0',
-      method,
-      params,
-    };
+		switch (request.method) {
+			case 'session/request_permission': {
+				const params = request.params as RequestPermissionRequest;
+				this.emit('session:permission_request', params, (response: RequestPermissionResponse) => {
+					respond(response);
+				});
+				break;
+			}
+			case 'fs/read_text_file': {
+				const params = request.params as ReadTextFileRequest;
+				this.emit('fs:read', params, (response: ReadTextFileResponse) => {
+					respond(response);
+				});
+				break;
+			}
+			case 'fs/write_text_file': {
+				const params = request.params as WriteTextFileRequest;
+				this.emit('fs:write', params, (response: WriteTextFileResponse) => {
+					respond(response);
+				});
+				break;
+			}
+			case 'terminal/create': {
+				const params = request.params as CreateTerminalRequest;
+				this.emit('terminal:create', params, (response: CreateTerminalResponse) => {
+					respond(response);
+				});
+				break;
+			}
+			case 'terminal/output': {
+				const params = request.params as TerminalOutputRequest;
+				this.emit('terminal:output', params, (response: TerminalOutputResponse) => {
+					respond(response);
+				});
+				break;
+			}
+			default:
+				logger.warn(`Unhandled agent request: ${request.method}`, LOG_CONTEXT);
+				respondError(-32601, `Method not found: ${request.method}`);
+		}
+	}
 
-    const line = JSON.stringify(notification) + '\n';
-    logger.debug(`Sending notification: ${method}`, LOG_CONTEXT);
-    logger.debug('[OUTBOUND NOTIFICATION]', '[ACP Transport]', { method, data: redactForLogging(notification) });
+	private sendRequest(method: string, params: unknown): Promise<unknown> {
+		return new Promise((resolve, reject) => {
+			const id = ++this.requestId;
+			const request: JsonRpcRequest = {
+				jsonrpc: '2.0',
+				id,
+				method,
+				params,
+			};
 
-    if (this.process?.stdin?.writable) {
-      this.process.stdin.write(line);
-    }
-  }
+			this.pendingRequests.set(id, { resolve, reject, method });
 
-  private sendResponse(id: RequestId, result: unknown): void {
-    const response: JsonRpcResponse = {
-      jsonrpc: '2.0',
-      id,
-      result,
-    };
+			const line = JSON.stringify(request) + '\n';
+			logger.debug(`Sending request: ${method} (id: ${id})`, LOG_CONTEXT);
+			logger.debug('[OUTBOUND REQUEST]', '[ACP Transport]', {
+				method,
+				id,
+				data: redactForLogging(request),
+			});
 
-    const line = JSON.stringify(response) + '\n';
-    logger.debug('[OUTBOUND RESPONSE]', '[ACP Transport]', { id, data: redactForLogging(response) });
+			if (!this.process?.stdin?.writable) {
+				reject(new Error('Agent process is not writable'));
+				return;
+			}
 
-    if (this.process?.stdin?.writable) {
-      this.process.stdin.write(line);
-    }
-  }
+			this.process.stdin.write(line);
+		});
+	}
 
-  private sendErrorResponse(id: RequestId, code: number, message: string): void {
-    const response: JsonRpcResponse = {
-      jsonrpc: '2.0',
-      id,
-      error: { code, message },
-    };
+	private sendNotification(method: string, params: unknown): void {
+		const notification: JsonRpcNotification = {
+			jsonrpc: '2.0',
+			method,
+			params,
+		};
 
-    const line = JSON.stringify(response) + '\n';
-    logger.debug('[OUTBOUND ERROR RESPONSE]', '[ACP Transport]', { id, code, message, data: redactForLogging(response) });
+		const line = JSON.stringify(notification) + '\n';
+		logger.debug(`Sending notification: ${method}`, LOG_CONTEXT);
+		logger.debug('[OUTBOUND NOTIFICATION]', '[ACP Transport]', {
+			method,
+			data: redactForLogging(notification),
+		});
 
-    if (this.process?.stdin?.writable) {
-      this.process.stdin.write(line);
-    }
-  }
+		if (this.process?.stdin?.writable) {
+			this.process.stdin.write(line);
+		}
+	}
 
-  private handleDisconnect(): void {
-    this.isConnected = false;
-    this.readline?.close();
-    this.readline = null;
+	private sendResponse(id: RequestId, result: unknown): void {
+		const response: JsonRpcResponse = {
+			jsonrpc: '2.0',
+			id,
+			result,
+		};
 
-    // Reject all pending requests
-    for (const [id, pending] of this.pendingRequests) {
-      pending.reject(new Error('Connection closed'));
-      this.pendingRequests.delete(id);
-    }
+		const line = JSON.stringify(response) + '\n';
+		logger.debug('[OUTBOUND RESPONSE]', '[ACP Transport]', {
+			id,
+			data: redactForLogging(response),
+		});
 
-    this.emit('disconnected');
-  }
+		if (this.process?.stdin?.writable) {
+			this.process.stdin.write(line);
+		}
+	}
+
+	private sendErrorResponse(id: RequestId, code: number, message: string): void {
+		const response: JsonRpcResponse = {
+			jsonrpc: '2.0',
+			id,
+			error: { code, message },
+		};
+
+		const line = JSON.stringify(response) + '\n';
+		logger.debug('[OUTBOUND ERROR RESPONSE]', '[ACP Transport]', {
+			id,
+			code,
+			message,
+			data: redactForLogging(response),
+		});
+
+		if (this.process?.stdin?.writable) {
+			this.process.stdin.write(line);
+		}
+	}
+
+	private handleDisconnect(): void {
+		this.isConnected = false;
+		this.readline?.close();
+		this.readline = null;
+
+		// Reject all pending requests
+		for (const [id, pending] of this.pendingRequests) {
+			pending.reject(new Error('Connection closed'));
+			this.pendingRequests.delete(id);
+		}
+
+		this.emit('disconnected');
+	}
 }

--- a/src/main/acp/acp-error-detector.ts
+++ b/src/main/acp/acp-error-detector.ts
@@ -5,8 +5,8 @@
  * Maps JSON-RPC error codes and error messages to AgentErrorType for proper
  * error handling and user feedback.
  *
- * This module uses the existing OPENCODE_ERROR_PATTERNS from error-patterns.ts
- * for text-based error matching, plus JSON-RPC standard error code mapping.
+ * This module checks error patterns for all ACP-compatible agents (OpenCode,
+ * Gemini CLI, etc.) from error-patterns.ts, plus JSON-RPC standard error code mapping.
  */
 
 import type { AgentErrorType } from '../../shared/types';
@@ -155,20 +155,29 @@ function isRecoverableError(type: AgentErrorType): boolean {
 }
 
 /**
+ * ACP-compatible agent IDs for pattern matching.
+ * These agents have supportsACP: true and registered error patterns.
+ */
+const ACP_AGENT_IDS = ['opencode', 'gemini-cli'] as const;
+
+/**
  * Detect error type from an ACP error
  *
  * Uses a multi-step approach:
  * 1. Check JSON-RPC error code if present
- * 2. Match error message against OpenCode error patterns
- * 3. Fall back to 'unknown' if no match
+ * 2. Match error message against agent-specific error patterns
+ * 3. Fall back to keyword-based detection
+ * 4. Fall back to 'unknown' if no match
  *
  * @param error - The error object (can be Error, JSON-RPC error, or string)
  * @param jsonRpcCode - Optional JSON-RPC error code
+ * @param agentType - Optional agent type to check specific patterns first (e.g., 'opencode', 'gemini-cli')
  * @returns Detected error with type, message, and recoverability
  */
 export function detectAcpError(
 	error: Error | { code?: number; message?: string } | string,
-	jsonRpcCode?: number
+	jsonRpcCode?: number,
+	agentType?: string
 ): DetectedError {
 	// Extract error message
 	let message: string;
@@ -197,15 +206,32 @@ export function detectAcpError(
 		}
 	}
 
-	// Step 2: Try to match against OpenCode error patterns
-	const patterns = getErrorPatterns('opencode');
-	const patternMatch = matchErrorPattern(patterns, message);
-	if (patternMatch) {
-		return {
-			type: patternMatch.type,
-			message: patternMatch.message,
-			recoverable: patternMatch.recoverable,
-		};
+	// Step 2: Try to match against agent error patterns
+	// If agentType is specified, check that agent's patterns first
+	if (agentType) {
+		const patterns = getErrorPatterns(agentType);
+		const patternMatch = matchErrorPattern(patterns, message);
+		if (patternMatch) {
+			return {
+				type: patternMatch.type,
+				message: patternMatch.message,
+				recoverable: patternMatch.recoverable,
+			};
+		}
+	}
+
+	// Then check all ACP-compatible agents' patterns (skipping the one already checked)
+	for (const id of ACP_AGENT_IDS) {
+		if (id === agentType) continue; // Already checked above
+		const patterns = getErrorPatterns(id);
+		const patternMatch = matchErrorPattern(patterns, message);
+		if (patternMatch) {
+			return {
+				type: patternMatch.type,
+				message: patternMatch.message,
+				recoverable: patternMatch.recoverable,
+			};
+		}
 	}
 
 	// Step 3: Check for common error keywords in the message

--- a/src/main/acp/acp-error-detector.ts
+++ b/src/main/acp/acp-error-detector.ts
@@ -1,0 +1,314 @@
+/**
+ * ACP Error Detection
+ *
+ * Detects and categorizes errors from ACP (Agent Client Protocol) interactions.
+ * Maps JSON-RPC error codes and error messages to AgentErrorType for proper
+ * error handling and user feedback.
+ *
+ * This module uses the existing OPENCODE_ERROR_PATTERNS from error-patterns.ts
+ * for text-based error matching, plus JSON-RPC standard error code mapping.
+ */
+
+import type { AgentErrorType } from '../../shared/types';
+import { getErrorPatterns, matchErrorPattern } from '../parsers/error-patterns';
+
+/**
+ * Standard JSON-RPC error codes
+ * @see https://www.jsonrpc.org/specification#error_object
+ */
+const JSON_RPC_ERROR_CODES = {
+	// Standard JSON-RPC errors
+	PARSE_ERROR: -32700,
+	INVALID_REQUEST: -32600,
+	METHOD_NOT_FOUND: -32601,
+	INVALID_PARAMS: -32602,
+	INTERNAL_ERROR: -32603,
+
+	// Server errors (reserved range: -32000 to -32099)
+	SERVER_ERROR_START: -32099,
+	SERVER_ERROR_END: -32000,
+} as const;
+
+/**
+ * ACP-specific error codes (within the server error range)
+ * These are based on common ACP implementation patterns
+ */
+const ACP_ERROR_CODES = {
+	// Authentication/authorization errors
+	UNAUTHORIZED: -32001,
+	AUTH_EXPIRED: -32002,
+	AUTH_INVALID: -32003,
+
+	// Rate limiting
+	RATE_LIMITED: -32010,
+	QUOTA_EXCEEDED: -32011,
+
+	// Context/token errors
+	CONTEXT_TOO_LONG: -32020,
+	TOKEN_LIMIT_EXCEEDED: -32021,
+
+	// Session errors
+	SESSION_NOT_FOUND: -32030,
+	SESSION_EXPIRED: -32031,
+
+	// Network/connection errors
+	CONNECTION_ERROR: -32040,
+	TIMEOUT: -32041,
+
+	// Permission errors
+	PERMISSION_DENIED: -32050,
+} as const;
+
+/**
+ * Result of error detection
+ */
+export interface DetectedError {
+	type: AgentErrorType;
+	message: string;
+	recoverable: boolean;
+}
+
+/**
+ * Map a JSON-RPC error code to an AgentErrorType
+ */
+function mapErrorCodeToType(code: number): AgentErrorType | null {
+	// Standard JSON-RPC errors
+	if (code === JSON_RPC_ERROR_CODES.PARSE_ERROR) {
+		return 'agent_crashed';
+	}
+	if (code === JSON_RPC_ERROR_CODES.INVALID_REQUEST) {
+		return 'agent_crashed';
+	}
+	if (code === JSON_RPC_ERROR_CODES.METHOD_NOT_FOUND) {
+		return 'agent_crashed';
+	}
+	if (code === JSON_RPC_ERROR_CODES.INVALID_PARAMS) {
+		return 'agent_crashed';
+	}
+	if (code === JSON_RPC_ERROR_CODES.INTERNAL_ERROR) {
+		return 'agent_crashed';
+	}
+
+	// ACP-specific error codes
+	switch (code) {
+		// Auth errors
+		case ACP_ERROR_CODES.UNAUTHORIZED:
+		case ACP_ERROR_CODES.AUTH_EXPIRED:
+		case ACP_ERROR_CODES.AUTH_INVALID:
+			return 'auth_expired';
+
+		// Rate limiting
+		case ACP_ERROR_CODES.RATE_LIMITED:
+		case ACP_ERROR_CODES.QUOTA_EXCEEDED:
+			return 'rate_limited';
+
+		// Context/token exhaustion
+		case ACP_ERROR_CODES.CONTEXT_TOO_LONG:
+		case ACP_ERROR_CODES.TOKEN_LIMIT_EXCEEDED:
+			return 'token_exhaustion';
+
+		// Session errors
+		case ACP_ERROR_CODES.SESSION_NOT_FOUND:
+		case ACP_ERROR_CODES.SESSION_EXPIRED:
+			return 'session_not_found';
+
+		// Network errors
+		case ACP_ERROR_CODES.CONNECTION_ERROR:
+		case ACP_ERROR_CODES.TIMEOUT:
+			return 'network_error';
+
+		// Permission errors
+		case ACP_ERROR_CODES.PERMISSION_DENIED:
+			return 'permission_denied';
+	}
+
+	// Check if it's in the server error range
+	if (
+		code >= JSON_RPC_ERROR_CODES.SERVER_ERROR_START &&
+		code <= JSON_RPC_ERROR_CODES.SERVER_ERROR_END
+	) {
+		// Generic server error - will fall through to message-based detection
+		return null;
+	}
+
+	return null;
+}
+
+/**
+ * Determine if an error is recoverable based on its type
+ */
+function isRecoverableError(type: AgentErrorType): boolean {
+	switch (type) {
+		case 'auth_expired':
+		case 'token_exhaustion':
+		case 'rate_limited':
+		case 'network_error':
+		case 'session_not_found':
+		case 'agent_crashed':
+			return true;
+		case 'permission_denied':
+			return false;
+		case 'unknown':
+		default:
+			return false;
+	}
+}
+
+/**
+ * Detect error type from an ACP error
+ *
+ * Uses a multi-step approach:
+ * 1. Check JSON-RPC error code if present
+ * 2. Match error message against OpenCode error patterns
+ * 3. Fall back to 'unknown' if no match
+ *
+ * @param error - The error object (can be Error, JSON-RPC error, or string)
+ * @param jsonRpcCode - Optional JSON-RPC error code
+ * @returns Detected error with type, message, and recoverability
+ */
+export function detectAcpError(
+	error: Error | { code?: number; message?: string } | string,
+	jsonRpcCode?: number
+): DetectedError {
+	// Extract error message
+	let message: string;
+	let code: number | undefined = jsonRpcCode;
+
+	if (typeof error === 'string') {
+		message = error;
+	} else if (error instanceof Error) {
+		message = error.message;
+	} else {
+		message = error.message || 'Unknown error';
+		if (error.code !== undefined) {
+			code = error.code;
+		}
+	}
+
+	// Step 1: Try to map from JSON-RPC error code
+	if (code !== undefined) {
+		const typeFromCode = mapErrorCodeToType(code);
+		if (typeFromCode) {
+			return {
+				type: typeFromCode,
+				message,
+				recoverable: isRecoverableError(typeFromCode),
+			};
+		}
+	}
+
+	// Step 2: Try to match against OpenCode error patterns
+	const patterns = getErrorPatterns('opencode');
+	const patternMatch = matchErrorPattern(patterns, message);
+	if (patternMatch) {
+		return {
+			type: patternMatch.type,
+			message: patternMatch.message,
+			recoverable: patternMatch.recoverable,
+		};
+	}
+
+	// Step 3: Check for common error keywords in the message
+	const lowerMessage = message.toLowerCase();
+
+	// Auth errors
+	if (
+		lowerMessage.includes('unauthorized') ||
+		lowerMessage.includes('authentication') ||
+		lowerMessage.includes('api key') ||
+		lowerMessage.includes('invalid key') ||
+		lowerMessage.includes('401')
+	) {
+		return {
+			type: 'auth_expired',
+			message,
+			recoverable: true,
+		};
+	}
+
+	// Rate limiting
+	if (
+		lowerMessage.includes('rate limit') ||
+		lowerMessage.includes('too many requests') ||
+		lowerMessage.includes('quota') ||
+		lowerMessage.includes('429')
+	) {
+		return {
+			type: 'rate_limited',
+			message,
+			recoverable: true,
+		};
+	}
+
+	// Token exhaustion
+	if (
+		lowerMessage.includes('context') ||
+		lowerMessage.includes('token') ||
+		lowerMessage.includes('too long') ||
+		lowerMessage.includes('max length')
+	) {
+		return {
+			type: 'token_exhaustion',
+			message,
+			recoverable: true,
+		};
+	}
+
+	// Network errors
+	if (
+		lowerMessage.includes('connection') ||
+		lowerMessage.includes('network') ||
+		lowerMessage.includes('timeout') ||
+		lowerMessage.includes('econnrefused') ||
+		lowerMessage.includes('econnreset') ||
+		lowerMessage.includes('etimedout')
+	) {
+		return {
+			type: 'network_error',
+			message,
+			recoverable: true,
+		};
+	}
+
+	// Session errors
+	if (lowerMessage.includes('session') && lowerMessage.includes('not found')) {
+		return {
+			type: 'session_not_found',
+			message,
+			recoverable: true,
+		};
+	}
+
+	// Permission errors
+	if (lowerMessage.includes('permission denied') || lowerMessage.includes('access denied')) {
+		return {
+			type: 'permission_denied',
+			message,
+			recoverable: false,
+		};
+	}
+
+	// Default to unknown
+	return {
+		type: 'unknown',
+		message,
+		recoverable: false,
+	};
+}
+
+/**
+ * Check if an error message indicates an expected disconnect
+ * (not a real error, just a normal shutdown)
+ */
+export function isExpectedDisconnect(error: Error | string): boolean {
+	const message = typeof error === 'string' ? error : error.message;
+	const lowerMessage = message.toLowerCase();
+
+	return (
+		lowerMessage.includes('connection closed') ||
+		lowerMessage.includes('process exited') ||
+		lowerMessage.includes('cancelled') ||
+		lowerMessage.includes('sigterm') ||
+		lowerMessage.includes('sigint')
+	);
+}

--- a/src/main/acp/acp-process.ts
+++ b/src/main/acp/acp-process.ts
@@ -1,0 +1,578 @@
+/**
+ * ACP Process Wrapper
+ *
+ * Wraps an ACPClient to provide the same interface as ProcessManager
+ * for ACP-enabled agents like OpenCode.
+ *
+ * This allows seamless switching between:
+ * - Standard mode: spawn process → parse stdout JSON
+ * - ACP mode: ACPClient → JSON-RPC over stdio
+ */
+
+import { EventEmitter } from 'events';
+import { ACPClient, type ACPClientConfig } from './acp-client';
+import {
+  acpUpdateToParseEvent,
+  createSessionIdEvent,
+  createResultEvent,
+} from './acp-adapter';
+import type { SessionUpdate, SessionId } from './types';
+import { logger } from '../utils/logger';
+
+const LOG_CONTEXT = '[ACPProcess]';
+
+// Sentry import for error reporting (optional - may not be available in tests)
+let Sentry: { captureException: (error: Error, context?: unknown) => void } | null = null;
+try {
+  // Dynamic import to avoid issues in test environment
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  Sentry = require('@sentry/electron/main');
+} catch {
+  // Sentry not available (e.g., in tests)
+}
+
+/**
+ * Report an error to Sentry if available
+ */
+function captureError(error: Error, context: { tags: Record<string, string>; extra: Record<string, unknown> }): void {
+  if (Sentry) {
+    Sentry.captureException(error, context);
+  }
+}
+
+/**
+ * Check if an error is an expected disconnect (not a fatal error)
+ */
+function isExpectedDisconnect(error: Error): boolean {
+  const message = error.message.toLowerCase();
+  return (
+    message.includes('connection closed') ||
+    message.includes('process exited') ||
+    message.includes('cancelled') ||
+    message.includes('sigterm') ||
+    message.includes('sigint')
+  );
+}
+
+export interface ACPProcessConfig {
+  /** Maestro session ID */
+  sessionId: string;
+  /** Agent type (e.g., 'opencode') */
+  toolType: string;
+  /** Working directory */
+  cwd: string;
+  /** Command to run (e.g., 'opencode') */
+  command: string;
+  /** Additional arguments for the command (e.g., custom args, SSH wrapper) */
+  args?: string[];
+  /** Initial prompt to send */
+  prompt?: string;
+  /** Images to include with prompt (only used for initial prompt, not follow-ups) */
+  images?: Array<{ data: string; mimeType: string }>;
+  /** ACP session ID for resume */
+  acpSessionId?: string;
+  /** Custom environment variables */
+  customEnvVars?: Record<string, string>;
+  /** Context window size */
+  contextWindow?: number;
+  /** Auto-approve permission requests (YOLO mode) - default: false for security */
+  autoApprovePermissions?: boolean;
+}
+
+/**
+ * Represents an ACP-based agent process.
+ * Emits the same events as ProcessManager for compatibility:
+ * - 'data': parsed event data
+ * - 'exit': process exit
+ * - 'agent-error': agent errors
+ */
+export class ACPProcess extends EventEmitter {
+  private client: ACPClient;
+  private config: ACPProcessConfig;
+  private acpSessionId: SessionId | null = null;
+  private streamedText = ''; // Text accumulated during current prompt
+  private emittedTextLength = 0; // Track how much text we've emitted (for deduplication within a response)
+  private totalAccumulatedText = ''; // All text across all prompts (for cross-prompt deduplication)
+  private startTime: number;
+  private isLoadingSession = false; // Track if we're loading a session (to ignore historical messages)
+  private imagesConsumed = false; // Track if images have been sent (to avoid resending on follow-ups)
+
+  constructor(config: ACPProcessConfig) {
+    super();
+    this.config = config;
+    this.startTime = Date.now();
+
+    // Create ACP client
+    // Support custom args (SSH wrapper, custom arguments) while keeping 'acp' as first arg
+    const clientArgs = ['acp', ...(config.args || [])];
+    const clientConfig: ACPClientConfig = {
+      command: config.command,
+      args: clientArgs,
+      cwd: config.cwd,
+      env: config.customEnvVars,
+      clientInfo: {
+        name: 'maestro',
+        version: '0.12.0',
+        title: 'Maestro',
+      },
+      // Disable terminal capability until we implement the handlers
+      // Advertising capabilities we can't fulfill causes agents to hang
+      clientCapabilities: {
+        fs: {
+          readTextFile: true,
+          writeTextFile: true,
+        },
+        terminal: false, // Disabled: handlers not implemented yet
+      },
+    };
+
+    this.client = new ACPClient(clientConfig);
+
+    // Wire up ACP events
+    this.setupEventHandlers();
+  }
+
+  /**
+   * Get the PID of the spawned OpenCode process
+   */
+  get pid(): number {
+    const process = this.client.getProcess();
+    return process?.pid ?? -1;
+  }
+
+  /**
+   * Get session info for compatibility
+   */
+  getInfo(): {
+    sessionId: string;
+    toolType: string;
+    pid: number;
+    cwd: string;
+    isTerminal: boolean;
+    isBatchMode: boolean;
+    startTime: number;
+    command: string;
+    args: string[];
+  } {
+    return {
+      sessionId: this.config.sessionId,
+      toolType: this.config.toolType,
+      pid: this.pid,
+      cwd: this.config.cwd,
+      isTerminal: false,
+      isBatchMode: true,
+      startTime: this.startTime,
+      command: this.config.command,
+      args: ['acp', ...(this.config.args || [])],
+    };
+  }
+
+  /**
+   * Connect to ACP agent and run the initial prompt
+   */
+  async start(): Promise<{ pid: number; success: boolean }> {
+    try {
+      logger.info(`Starting ACP process for ${this.config.toolType}`, LOG_CONTEXT, {
+        sessionId: this.config.sessionId,
+        command: this.config.command,
+        hasPrompt: !!this.config.prompt,
+      });
+
+      // Connect to the ACP agent
+      const initResponse = await this.client.connect();
+
+      logger.info(`ACP connected to ${initResponse.agentInfo?.name}`, LOG_CONTEXT, {
+        version: initResponse.agentInfo?.version,
+        protocolVersion: initResponse.protocolVersion,
+      });
+
+      // Create or load session
+      if (this.config.acpSessionId) {
+        // Resume existing session
+        // Set flag to ignore historical messages during session load
+        this.isLoadingSession = true;
+        await this.client.loadSession(this.config.acpSessionId, this.config.cwd);
+        this.acpSessionId = this.config.acpSessionId;
+        // Clear flag after session load completes
+        this.isLoadingSession = false;
+        logger.debug('Session loaded, ignoring historical messages received during load', LOG_CONTEXT);
+      } else {
+        // Create new session
+        const sessionResponse = await this.client.newSession(this.config.cwd);
+        this.acpSessionId = sessionResponse.sessionId;
+      }
+
+      // Emit session_id event
+      const sessionIdEvent = createSessionIdEvent(this.acpSessionId);
+      this.emit('data', this.config.sessionId, sessionIdEvent);
+
+      // If we have a prompt, send it (with images only on initial prompt)
+      if (this.config.prompt) {
+        // Pass images only for the initial prompt, then mark as consumed
+        const imagesToSend = !this.imagesConsumed ? this.config.images : undefined;
+        this.imagesConsumed = true;
+        this.sendPrompt(this.config.prompt, imagesToSend);
+      }
+
+      return { pid: this.pid, success: true };
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error));
+      const message = err.message;
+      logger.error(`Failed to start ACP process: ${message}`, LOG_CONTEXT);
+
+      // Report unexpected errors to Sentry (not expected disconnects)
+      if (!isExpectedDisconnect(err)) {
+        captureError(err, {
+          tags: {
+            component: 'ACPProcess',
+            operation: 'start',
+            toolType: this.config.toolType,
+          },
+          extra: {
+            sessionId: this.config.sessionId,
+            command: this.config.command,
+          },
+        });
+      }
+
+      this.emit('agent-error', this.config.sessionId, {
+        type: 'unknown',
+        message,
+        recoverable: isExpectedDisconnect(err),
+      });
+      this.emit('exit', this.config.sessionId, 1);
+
+      return { pid: -1, success: false };
+    }
+  }
+
+  /**
+   * Send a prompt to the agent
+   * @param text - The prompt text
+   * @param images - Optional images to include (only for initial prompt, not follow-ups via write())
+   */
+  async sendPrompt(text: string, images?: Array<{ data: string; mimeType: string }>): Promise<void> {
+    if (!this.acpSessionId) {
+      logger.error('Cannot send prompt: no ACP session', LOG_CONTEXT);
+      return;
+    }
+
+    // Clear streamed text for new prompt (but keep totalAccumulatedText for cross-prompt dedup)
+    this.streamedText = '';
+    this.emittedTextLength = 0; // Reset emission tracker for new prompt
+
+    try {
+      logger.debug(`Sending prompt to ACP agent`, LOG_CONTEXT, {
+        sessionId: this.config.sessionId,
+        promptLength: text.length,
+        hasImages: !!images && images.length > 0,
+      });
+
+      let response;
+      // Only include images if explicitly passed (for initial prompt)
+      if (images && images.length > 0) {
+        response = await this.client.promptWithImages(
+          this.acpSessionId,
+          text,
+          images
+        );
+      } else {
+        response = await this.client.prompt(this.acpSessionId, text);
+      }
+
+      logger.debug('Received prompt response from ACP agent', LOG_CONTEXT, {
+        stopReason: response.stopReason,
+        hasUsage: !!response.usage,
+        usage: response.usage,
+      });
+
+      // Workaround for OpenCode bug: Remove previous response if it's repeated
+      // OpenCode may send cumulative text (all previous messages + new message)
+      let finalText = this.streamedText;
+      if (this.totalAccumulatedText && finalText.startsWith(this.totalAccumulatedText)) {
+        // Agent repeated the previous response - extract only the new part
+        const newContent = finalText.substring(this.totalAccumulatedText.length);
+        logger.debug('Detected cumulative response, extracting delta', LOG_CONTEXT, {
+          previousLength: this.totalAccumulatedText.length,
+          totalLength: finalText.length,
+          deltaLength: newContent.length,
+        });
+        finalText = newContent;
+      }
+
+      // Update total accumulated text for next deduplication check
+      this.totalAccumulatedText += finalText;
+
+      // Emit final result event to signal completion
+      // Include finalText (deduplicated) so ProcessManager can emit it if streaming was disabled
+      const resultEvent = createResultEvent(
+        this.config.sessionId,
+        finalText, // Use deduplicated text
+        response.stopReason,
+        response.usage // Include usage stats from response
+      );
+      this.emit('data', this.config.sessionId, resultEvent);
+
+      // If stop reason indicates completion, emit exit
+      if (response.stopReason === 'end_turn' || response.stopReason === 'cancelled') {
+        this.emit('exit', this.config.sessionId, 0);
+      }
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error));
+      const message = err.message;
+      
+      // Check if this is an expected disconnect (user cancelled, process killed, etc.)
+      if (isExpectedDisconnect(err)) {
+        logger.debug(`ACP prompt cancelled/disconnected: ${message}`, LOG_CONTEXT);
+        // Don't emit agent-error for expected disconnects - just exit cleanly
+        this.emit('exit', this.config.sessionId, 0);
+        return;
+      }
+      
+      logger.error(`ACP prompt failed: ${message}`, LOG_CONTEXT);
+
+      // Report unexpected errors to Sentry
+      captureError(err, {
+        tags: {
+          component: 'ACPProcess',
+          operation: 'sendPrompt',
+          toolType: this.config.toolType,
+        },
+        extra: {
+          sessionId: this.config.sessionId,
+          acpSessionId: this.acpSessionId,
+        },
+      });
+
+      this.emit('agent-error', this.config.sessionId, {
+        type: 'unknown',
+        message,
+        recoverable: false,
+      });
+    }
+  }
+
+  /**
+   * Write data to the agent (for follow-up prompts)
+   * Note: Images are NOT resent on follow-up prompts - they're only for the initial prompt
+   */
+  async write(data: string): Promise<void> {
+    // In ACP mode, writing is sending a new prompt (without images)
+    await this.sendPrompt(data);
+  }
+
+  /**
+   * Cancel ongoing operations
+   */
+  cancel(): void {
+    if (this.acpSessionId) {
+      this.client.cancel(this.acpSessionId);
+    }
+  }
+
+  /**
+   * Kill the ACP process
+   */
+  kill(): void {
+    this.client.disconnect();
+    this.emit('exit', this.config.sessionId, 0);
+  }
+
+  /**
+   * Interrupt (same as cancel for ACP)
+   */
+  interrupt(): void {
+    this.cancel();
+  }
+
+  /**
+   * Set up event handlers for ACP client
+   */
+  private setupEventHandlers(): void {
+    // Handle session updates
+    this.client.on('session:update', (sessionId: SessionId, update: SessionUpdate) => {
+      // Ignore updates during session load - these are historical messages
+      if (this.isLoadingSession) {
+        logger.debug('Ignoring session update during session load (historical message)', LOG_CONTEXT, {
+          updateKeys: Object.keys(update)
+        });
+        return;
+      }
+
+      const event = acpUpdateToParseEvent(sessionId, update);
+      if (event) {
+        // Accumulate text for final result
+        if (event.type === 'text' && event.text) {
+          // Fix: Handle cross-prompt overlap before accumulating
+          // If streamedText starts with totalAccumulatedText, the agent is sending cumulative content
+          let adjustedText = event.text;
+          
+          // Check if this new text chunk overlaps with what we've already accumulated
+          // This handles the case where agents send cumulative text (all previous + new)
+          if (this.totalAccumulatedText && this.streamedText.length === 0) {
+            // First chunk of a new prompt - check for cross-prompt overlap
+            if (adjustedText.startsWith(this.totalAccumulatedText)) {
+              // Agent repeated previous response - extract only the new part
+              adjustedText = adjustedText.substring(this.totalAccumulatedText.length);
+              logger.debug('Trimmed cross-prompt overlap from streaming chunk', LOG_CONTEXT, {
+                overlapLength: this.totalAccumulatedText.length,
+                adjustedLength: adjustedText.length,
+              });
+            }
+          }
+          
+          this.streamedText += adjustedText;
+          
+          // Emit only new content that hasn't been emitted yet (within this prompt)
+          if (adjustedText.length > 0 && this.streamedText.length > this.emittedTextLength) {
+            const newText = this.streamedText.substring(this.emittedTextLength);
+            this.emittedTextLength = this.streamedText.length;
+            
+            // Emit only the delta
+            const deltaEvent = { ...event, text: newText };
+            this.emit('data', this.config.sessionId, deltaEvent);
+          }
+          // Skip emitting if we've already sent this text
+        } else {
+          // Non-text events - emit as-is
+          this.emit('data', this.config.sessionId, event);
+        }
+      }
+    });
+
+    // Handle permission requests
+    // Only auto-approve if explicitly enabled via config (YOLO mode)
+    // Otherwise, cancel the request for security
+    this.client.on('session:permission_request', (request, respond) => {
+      logger.debug(`ACP permission request: ${request.toolCall.title}`, LOG_CONTEXT, {
+        autoApproveEnabled: this.config.autoApprovePermissions,
+      });
+
+      if (this.config.autoApprovePermissions) {
+        // YOLO mode: Find allow option and auto-approve
+        const allowOption = request.options.find(
+          (o: { kind: string; optionId: string }) => o.kind === 'allow_once' || o.kind === 'allow_always'
+        );
+        if (allowOption) {
+          logger.debug(`Auto-approving permission request (YOLO mode)`, LOG_CONTEXT, {
+            optionId: allowOption.optionId,
+            kind: allowOption.kind,
+          });
+          respond({ outcome: { selected: { optionId: allowOption.optionId } } });
+        } else {
+          logger.warn(`No allow option found in permission request, cancelling`, LOG_CONTEXT);
+          respond({ outcome: { cancelled: {} } });
+        }
+      } else {
+        // Normal mode: Reject permission requests for security
+        // TODO: Implement UI flow to prompt user for approval
+        logger.warn(`Permission request rejected (auto-approve not enabled)`, LOG_CONTEXT, {
+          toolTitle: request.toolCall.title,
+        });
+        respond({ outcome: { cancelled: {} } });
+      }
+    });
+
+    // Handle file system read requests
+    // Return proper errors instead of fabricating success with empty content
+    this.client.on('fs:read', async (request, respond) => {
+      try {
+        const fs = await import('fs');
+        const content = fs.readFileSync(request.path, 'utf-8');
+        
+        // Support line/limit parameters if provided
+        if (request.line !== undefined || request.limit !== undefined) {
+          const lines = content.split('\n');
+          const startLine = (request.line ?? 1) - 1; // Convert to 0-indexed
+          const limit = request.limit ?? lines.length;
+          const slicedLines = lines.slice(startLine, startLine + limit);
+          respond({ content: slicedLines.join('\n') });
+        } else {
+          respond({ content });
+        }
+      } catch (err) {
+        const error = err as Error;
+        logger.error(`Failed to read file: ${request.path}`, LOG_CONTEXT, {
+          error: error.message,
+        });
+        // Return JSON-RPC style error so the agent knows the operation failed
+        respond({
+          error: {
+            code: -32000,
+            message: `Failed to read file: ${request.path}`,
+            data: { error: error.message },
+          },
+        });
+      }
+    });
+
+    // Handle file system write requests
+    // Return proper errors instead of fabricating success
+    this.client.on('fs:write', async (request, respond) => {
+      try {
+        const fs = await import('fs');
+        fs.writeFileSync(request.path, request.content, 'utf-8');
+        respond({});
+      } catch (err) {
+        const error = err as Error;
+        logger.error(`Failed to write file: ${request.path}`, LOG_CONTEXT, {
+          error: error.message,
+        });
+        // Return JSON-RPC style error so the agent knows the operation failed
+        respond({
+          error: {
+            code: -32001,
+            message: `Failed to write file: ${request.path}`,
+            data: { error: error.message },
+          },
+        });
+      }
+    });
+
+    // Handle disconnection
+    this.client.on('disconnected', () => {
+      logger.info('ACP client disconnected', LOG_CONTEXT);
+    });
+
+    // Handle errors
+    this.client.on('error', (error) => {
+      // Check if this is an expected disconnect
+      if (isExpectedDisconnect(error)) {
+        logger.debug(`ACP client disconnected (expected): ${error.message}`, LOG_CONTEXT);
+        return;
+      }
+      
+      logger.error(`ACP client error: ${error.message}`, LOG_CONTEXT);
+      
+      // Report unexpected errors to Sentry
+      captureError(error, {
+        tags: {
+          component: 'ACPProcess',
+          operation: 'clientError',
+          toolType: this.config.toolType,
+        },
+        extra: {
+          sessionId: this.config.sessionId,
+          acpSessionId: this.acpSessionId,
+        },
+      });
+      
+      this.emit('agent-error', this.config.sessionId, {
+        type: 'unknown',
+        message: error.message,
+        recoverable: false,
+      });
+    });
+  }
+}
+
+/**
+ * Create and start an ACP process
+ */
+export async function spawnACPProcess(
+  config: ACPProcessConfig
+): Promise<{ process: ACPProcess; pid: number; success: boolean }> {
+  const process = new ACPProcess(config);
+  const result = await process.start();
+  return { process, ...result };
+}

--- a/src/main/acp/acp-process.ts
+++ b/src/main/acp/acp-process.ts
@@ -63,6 +63,17 @@ export interface ACPProcessConfig {
 	command: string;
 	/** Additional arguments for the command (e.g., custom args, SSH wrapper) */
 	args?: string[];
+	/**
+	 * ACP-specific arguments that enable the agent's ACP mode.
+	 * These are prepended before any custom args.
+	 *
+	 * Examples:
+	 * - OpenCode: ['acp'] → `opencode acp`
+	 * - Gemini CLI: ['--acp'] → `gemini --acp`
+	 *
+	 * Defaults to ['acp'] if not specified (OpenCode convention).
+	 */
+	acpArgs?: string[];
 	/** Initial prompt to send */
 	prompt?: string;
 	/** Images to include with prompt (only used for initial prompt, not follow-ups) */
@@ -75,6 +86,12 @@ export interface ACPProcessConfig {
 	contextWindow?: number;
 	/** Auto-approve permission requests (YOLO mode) - default: false for security */
 	autoApprovePermissions?: boolean;
+	/**
+	 * Use the flat content block format for prompts.
+	 * - true (default): Use flat format { type: 'text', text: '...' } (OpenCode convention)
+	 * - false: Use spec format { text: { text: '...' } } (standard ACP, Gemini CLI)
+	 */
+	useFlatContentBlocks?: boolean;
 }
 
 /**
@@ -101,8 +118,9 @@ export class ACPProcess extends EventEmitter {
 		this.startTime = Date.now();
 
 		// Create ACP client
-		// Support custom args (SSH wrapper, custom arguments) while keeping 'acp' as first arg
-		const clientArgs = ['acp', ...(config.args || [])];
+		// Use agent-specific ACP args (e.g., ['acp'] for OpenCode, ['--acp'] for Gemini CLI)
+		// Defaults to ['acp'] for backward compatibility with OpenCode
+		const clientArgs = [...(config.acpArgs || ['acp']), ...(config.args || [])];
 		const clientConfig: ACPClientConfig = {
 			command: config.command,
 			args: clientArgs,
@@ -161,7 +179,7 @@ export class ACPProcess extends EventEmitter {
 			isBatchMode: true,
 			startTime: this.startTime,
 			command: this.config.command,
-			args: ['acp', ...(this.config.args || [])],
+			args: [...(this.config.acpArgs || ['acp']), ...(this.config.args || [])],
 		};
 	}
 
@@ -182,7 +200,25 @@ export class ACPProcess extends EventEmitter {
 			logger.info(`ACP connected to ${initResponse.agentInfo?.name}`, LOG_CONTEXT, {
 				version: initResponse.agentInfo?.version,
 				protocolVersion: initResponse.protocolVersion,
+				hasAuthMethods: !!(initResponse.authMethods && initResponse.authMethods.length > 0),
 			});
+
+			// Authenticate if the agent requires it (e.g., Gemini CLI)
+			// Auto-select the first available auth method as default
+			if (initResponse.authMethods && initResponse.authMethods.length > 0) {
+				const defaultAuth = initResponse.authMethods[0];
+				logger.info(`Agent requires authentication, using method: ${defaultAuth.id}`, LOG_CONTEXT, {
+					availableMethods: initResponse.authMethods.map((m) => m.id),
+				});
+
+				const authResponse = await this.client.authenticate(defaultAuth.id);
+				if (!authResponse.success) {
+					throw new Error(
+						`Authentication failed: ${authResponse.error || 'Unknown auth error'}`
+					);
+				}
+				logger.info('Authentication successful', LOG_CONTEXT);
+			}
 
 			// Create or load session
 			if (this.config.acpSessionId) {
@@ -237,7 +273,7 @@ export class ACPProcess extends EventEmitter {
 			}
 
 			// Detect error type using ACP error detector
-			const detectedError = detectAcpError(err);
+			const detectedError = detectAcpError(err, undefined, this.config.toolType);
 			this.emit('agent-error', this.config.sessionId, {
 				type: detectedError.type,
 				message: detectedError.message,
@@ -279,7 +315,9 @@ export class ACPProcess extends EventEmitter {
 			if (images && images.length > 0) {
 				response = await this.client.promptWithImages(this.acpSessionId, text, images);
 			} else {
-				response = await this.client.prompt(this.acpSessionId, text);
+				// Use flat content blocks for OpenCode (default), spec format for others
+				const useFlatFormat = this.config.useFlatContentBlocks !== false;
+				response = await this.client.prompt(this.acpSessionId, text, useFlatFormat);
 			}
 
 			logger.debug('Received prompt response from ACP agent', LOG_CONTEXT, {
@@ -347,7 +385,7 @@ export class ACPProcess extends EventEmitter {
 			});
 
 			// Detect error type using ACP error detector
-			const detectedError = detectAcpError(err);
+			const detectedError = detectAcpError(err, undefined, this.config.toolType);
 			this.emit('agent-error', this.config.sessionId, {
 				type: detectedError.type,
 				message: detectedError.message,
@@ -567,7 +605,7 @@ export class ACPProcess extends EventEmitter {
 			});
 
 			// Detect error type using ACP error detector
-			const detectedError = detectAcpError(error);
+			const detectedError = detectAcpError(error, undefined, this.config.toolType);
 			this.emit('agent-error', this.config.sessionId, {
 				type: detectedError.type,
 				message: detectedError.message,

--- a/src/main/acp/acp-process.ts
+++ b/src/main/acp/acp-process.ts
@@ -14,6 +14,7 @@ import { ACPClient, type ACPClientConfig } from './acp-client';
 import { acpUpdateToParseEvent, createSessionIdEvent, createResultEvent } from './acp-adapter';
 import type { SessionUpdate, SessionId } from './types';
 import { logger } from '../utils/logger';
+import { getAppVersion } from './version';
 
 const LOG_CONTEXT = '[ACPProcess]';
 
@@ -111,7 +112,7 @@ export class ACPProcess extends EventEmitter {
 			env: config.customEnvVars,
 			clientInfo: {
 				name: 'maestro',
-				version: '0.12.0',
+				version: getAppVersion(),
 				title: 'Maestro',
 			},
 			// Disable terminal capability until we implement the handlers

--- a/src/main/acp/acp-process.ts
+++ b/src/main/acp/acp-process.ts
@@ -11,11 +11,7 @@
 
 import { EventEmitter } from 'events';
 import { ACPClient, type ACPClientConfig } from './acp-client';
-import {
-  acpUpdateToParseEvent,
-  createSessionIdEvent,
-  createResultEvent,
-} from './acp-adapter';
+import { acpUpdateToParseEvent, createSessionIdEvent, createResultEvent } from './acp-adapter';
 import type { SessionUpdate, SessionId } from './types';
 import { logger } from '../utils/logger';
 
@@ -24,59 +20,62 @@ const LOG_CONTEXT = '[ACPProcess]';
 // Sentry import for error reporting (optional - may not be available in tests)
 let Sentry: { captureException: (error: Error, context?: unknown) => void } | null = null;
 try {
-  // Dynamic import to avoid issues in test environment
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  Sentry = require('@sentry/electron/main');
+	// Dynamic import to avoid issues in test environment
+	// eslint-disable-next-line @typescript-eslint/no-require-imports
+	Sentry = require('@sentry/electron/main');
 } catch {
-  // Sentry not available (e.g., in tests)
+	// Sentry not available (e.g., in tests)
 }
 
 /**
  * Report an error to Sentry if available
  */
-function captureError(error: Error, context: { tags: Record<string, string>; extra: Record<string, unknown> }): void {
-  if (Sentry) {
-    Sentry.captureException(error, context);
-  }
+function captureError(
+	error: Error,
+	context: { tags: Record<string, string>; extra: Record<string, unknown> }
+): void {
+	if (Sentry) {
+		Sentry.captureException(error, context);
+	}
 }
 
 /**
  * Check if an error is an expected disconnect (not a fatal error)
  */
 function isExpectedDisconnect(error: Error): boolean {
-  const message = error.message.toLowerCase();
-  return (
-    message.includes('connection closed') ||
-    message.includes('process exited') ||
-    message.includes('cancelled') ||
-    message.includes('sigterm') ||
-    message.includes('sigint')
-  );
+	const message = error.message.toLowerCase();
+	return (
+		message.includes('connection closed') ||
+		message.includes('process exited') ||
+		message.includes('cancelled') ||
+		message.includes('sigterm') ||
+		message.includes('sigint')
+	);
 }
 
 export interface ACPProcessConfig {
-  /** Maestro session ID */
-  sessionId: string;
-  /** Agent type (e.g., 'opencode') */
-  toolType: string;
-  /** Working directory */
-  cwd: string;
-  /** Command to run (e.g., 'opencode') */
-  command: string;
-  /** Additional arguments for the command (e.g., custom args, SSH wrapper) */
-  args?: string[];
-  /** Initial prompt to send */
-  prompt?: string;
-  /** Images to include with prompt (only used for initial prompt, not follow-ups) */
-  images?: Array<{ data: string; mimeType: string }>;
-  /** ACP session ID for resume */
-  acpSessionId?: string;
-  /** Custom environment variables */
-  customEnvVars?: Record<string, string>;
-  /** Context window size */
-  contextWindow?: number;
-  /** Auto-approve permission requests (YOLO mode) - default: false for security */
-  autoApprovePermissions?: boolean;
+	/** Maestro session ID */
+	sessionId: string;
+	/** Agent type (e.g., 'opencode') */
+	toolType: string;
+	/** Working directory */
+	cwd: string;
+	/** Command to run (e.g., 'opencode') */
+	command: string;
+	/** Additional arguments for the command (e.g., custom args, SSH wrapper) */
+	args?: string[];
+	/** Initial prompt to send */
+	prompt?: string;
+	/** Images to include with prompt (only used for initial prompt, not follow-ups) */
+	images?: Array<{ data: string; mimeType: string }>;
+	/** ACP session ID for resume */
+	acpSessionId?: string;
+	/** Custom environment variables */
+	customEnvVars?: Record<string, string>;
+	/** Context window size */
+	contextWindow?: number;
+	/** Auto-approve permission requests (YOLO mode) - default: false for security */
+	autoApprovePermissions?: boolean;
 }
 
 /**
@@ -87,492 +86,499 @@ export interface ACPProcessConfig {
  * - 'agent-error': agent errors
  */
 export class ACPProcess extends EventEmitter {
-  private client: ACPClient;
-  private config: ACPProcessConfig;
-  private acpSessionId: SessionId | null = null;
-  private streamedText = ''; // Text accumulated during current prompt
-  private emittedTextLength = 0; // Track how much text we've emitted (for deduplication within a response)
-  private totalAccumulatedText = ''; // All text across all prompts (for cross-prompt deduplication)
-  private startTime: number;
-  private isLoadingSession = false; // Track if we're loading a session (to ignore historical messages)
-  private imagesConsumed = false; // Track if images have been sent (to avoid resending on follow-ups)
+	private client: ACPClient;
+	private config: ACPProcessConfig;
+	private acpSessionId: SessionId | null = null;
+	private streamedText = ''; // Text accumulated during current prompt
+	private emittedTextLength = 0; // Track how much text we've emitted (for deduplication within a response)
+	private totalAccumulatedText = ''; // All text across all prompts (for cross-prompt deduplication)
+	private startTime: number;
+	private isLoadingSession = false; // Track if we're loading a session (to ignore historical messages)
+	private imagesConsumed = false; // Track if images have been sent (to avoid resending on follow-ups)
 
-  constructor(config: ACPProcessConfig) {
-    super();
-    this.config = config;
-    this.startTime = Date.now();
+	constructor(config: ACPProcessConfig) {
+		super();
+		this.config = config;
+		this.startTime = Date.now();
 
-    // Create ACP client
-    // Support custom args (SSH wrapper, custom arguments) while keeping 'acp' as first arg
-    const clientArgs = ['acp', ...(config.args || [])];
-    const clientConfig: ACPClientConfig = {
-      command: config.command,
-      args: clientArgs,
-      cwd: config.cwd,
-      env: config.customEnvVars,
-      clientInfo: {
-        name: 'maestro',
-        version: '0.12.0',
-        title: 'Maestro',
-      },
-      // Disable terminal capability until we implement the handlers
-      // Advertising capabilities we can't fulfill causes agents to hang
-      clientCapabilities: {
-        fs: {
-          readTextFile: true,
-          writeTextFile: true,
-        },
-        terminal: false, // Disabled: handlers not implemented yet
-      },
-    };
+		// Create ACP client
+		// Support custom args (SSH wrapper, custom arguments) while keeping 'acp' as first arg
+		const clientArgs = ['acp', ...(config.args || [])];
+		const clientConfig: ACPClientConfig = {
+			command: config.command,
+			args: clientArgs,
+			cwd: config.cwd,
+			env: config.customEnvVars,
+			clientInfo: {
+				name: 'maestro',
+				version: '0.12.0',
+				title: 'Maestro',
+			},
+			// Disable terminal capability until we implement the handlers
+			// Advertising capabilities we can't fulfill causes agents to hang
+			clientCapabilities: {
+				fs: {
+					readTextFile: true,
+					writeTextFile: true,
+				},
+				terminal: false, // Disabled: handlers not implemented yet
+			},
+		};
 
-    this.client = new ACPClient(clientConfig);
+		this.client = new ACPClient(clientConfig);
 
-    // Wire up ACP events
-    this.setupEventHandlers();
-  }
+		// Wire up ACP events
+		this.setupEventHandlers();
+	}
 
-  /**
-   * Get the PID of the spawned OpenCode process
-   */
-  get pid(): number {
-    const process = this.client.getProcess();
-    return process?.pid ?? -1;
-  }
+	/**
+	 * Get the PID of the spawned OpenCode process
+	 */
+	get pid(): number {
+		const process = this.client.getProcess();
+		return process?.pid ?? -1;
+	}
 
-  /**
-   * Get session info for compatibility
-   */
-  getInfo(): {
-    sessionId: string;
-    toolType: string;
-    pid: number;
-    cwd: string;
-    isTerminal: boolean;
-    isBatchMode: boolean;
-    startTime: number;
-    command: string;
-    args: string[];
-  } {
-    return {
-      sessionId: this.config.sessionId,
-      toolType: this.config.toolType,
-      pid: this.pid,
-      cwd: this.config.cwd,
-      isTerminal: false,
-      isBatchMode: true,
-      startTime: this.startTime,
-      command: this.config.command,
-      args: ['acp', ...(this.config.args || [])],
-    };
-  }
+	/**
+	 * Get session info for compatibility
+	 */
+	getInfo(): {
+		sessionId: string;
+		toolType: string;
+		pid: number;
+		cwd: string;
+		isTerminal: boolean;
+		isBatchMode: boolean;
+		startTime: number;
+		command: string;
+		args: string[];
+	} {
+		return {
+			sessionId: this.config.sessionId,
+			toolType: this.config.toolType,
+			pid: this.pid,
+			cwd: this.config.cwd,
+			isTerminal: false,
+			isBatchMode: true,
+			startTime: this.startTime,
+			command: this.config.command,
+			args: ['acp', ...(this.config.args || [])],
+		};
+	}
 
-  /**
-   * Connect to ACP agent and run the initial prompt
-   */
-  async start(): Promise<{ pid: number; success: boolean }> {
-    try {
-      logger.info(`Starting ACP process for ${this.config.toolType}`, LOG_CONTEXT, {
-        sessionId: this.config.sessionId,
-        command: this.config.command,
-        hasPrompt: !!this.config.prompt,
-      });
+	/**
+	 * Connect to ACP agent and run the initial prompt
+	 */
+	async start(): Promise<{ pid: number; success: boolean }> {
+		try {
+			logger.info(`Starting ACP process for ${this.config.toolType}`, LOG_CONTEXT, {
+				sessionId: this.config.sessionId,
+				command: this.config.command,
+				hasPrompt: !!this.config.prompt,
+			});
 
-      // Connect to the ACP agent
-      const initResponse = await this.client.connect();
+			// Connect to the ACP agent
+			const initResponse = await this.client.connect();
 
-      logger.info(`ACP connected to ${initResponse.agentInfo?.name}`, LOG_CONTEXT, {
-        version: initResponse.agentInfo?.version,
-        protocolVersion: initResponse.protocolVersion,
-      });
+			logger.info(`ACP connected to ${initResponse.agentInfo?.name}`, LOG_CONTEXT, {
+				version: initResponse.agentInfo?.version,
+				protocolVersion: initResponse.protocolVersion,
+			});
 
-      // Create or load session
-      if (this.config.acpSessionId) {
-        // Resume existing session
-        // Set flag to ignore historical messages during session load
-        this.isLoadingSession = true;
-        await this.client.loadSession(this.config.acpSessionId, this.config.cwd);
-        this.acpSessionId = this.config.acpSessionId;
-        // Clear flag after session load completes
-        this.isLoadingSession = false;
-        logger.debug('Session loaded, ignoring historical messages received during load', LOG_CONTEXT);
-      } else {
-        // Create new session
-        const sessionResponse = await this.client.newSession(this.config.cwd);
-        this.acpSessionId = sessionResponse.sessionId;
-      }
+			// Create or load session
+			if (this.config.acpSessionId) {
+				// Resume existing session
+				// Set flag to ignore historical messages during session load
+				this.isLoadingSession = true;
+				await this.client.loadSession(this.config.acpSessionId, this.config.cwd);
+				this.acpSessionId = this.config.acpSessionId;
+				// Clear flag after session load completes
+				this.isLoadingSession = false;
+				logger.debug(
+					'Session loaded, ignoring historical messages received during load',
+					LOG_CONTEXT
+				);
+			} else {
+				// Create new session
+				const sessionResponse = await this.client.newSession(this.config.cwd);
+				this.acpSessionId = sessionResponse.sessionId;
+			}
 
-      // Emit session_id event
-      const sessionIdEvent = createSessionIdEvent(this.acpSessionId);
-      this.emit('data', this.config.sessionId, sessionIdEvent);
+			// Emit session_id event
+			const sessionIdEvent = createSessionIdEvent(this.acpSessionId);
+			this.emit('data', this.config.sessionId, sessionIdEvent);
 
-      // If we have a prompt, send it (with images only on initial prompt)
-      if (this.config.prompt) {
-        // Pass images only for the initial prompt, then mark as consumed
-        const imagesToSend = !this.imagesConsumed ? this.config.images : undefined;
-        this.imagesConsumed = true;
-        this.sendPrompt(this.config.prompt, imagesToSend);
-      }
+			// If we have a prompt, send it (with images only on initial prompt)
+			if (this.config.prompt) {
+				// Pass images only for the initial prompt, then mark as consumed
+				const imagesToSend = !this.imagesConsumed ? this.config.images : undefined;
+				this.imagesConsumed = true;
+				this.sendPrompt(this.config.prompt, imagesToSend);
+			}
 
-      return { pid: this.pid, success: true };
-    } catch (error) {
-      const err = error instanceof Error ? error : new Error(String(error));
-      const message = err.message;
-      logger.error(`Failed to start ACP process: ${message}`, LOG_CONTEXT);
+			return { pid: this.pid, success: true };
+		} catch (error) {
+			const err = error instanceof Error ? error : new Error(String(error));
+			const message = err.message;
+			logger.error(`Failed to start ACP process: ${message}`, LOG_CONTEXT);
 
-      // Report unexpected errors to Sentry (not expected disconnects)
-      if (!isExpectedDisconnect(err)) {
-        captureError(err, {
-          tags: {
-            component: 'ACPProcess',
-            operation: 'start',
-            toolType: this.config.toolType,
-          },
-          extra: {
-            sessionId: this.config.sessionId,
-            command: this.config.command,
-          },
-        });
-      }
+			// Report unexpected errors to Sentry (not expected disconnects)
+			if (!isExpectedDisconnect(err)) {
+				captureError(err, {
+					tags: {
+						component: 'ACPProcess',
+						operation: 'start',
+						toolType: this.config.toolType,
+					},
+					extra: {
+						sessionId: this.config.sessionId,
+						command: this.config.command,
+					},
+				});
+			}
 
-      this.emit('agent-error', this.config.sessionId, {
-        type: 'unknown',
-        message,
-        recoverable: isExpectedDisconnect(err),
-      });
-      this.emit('exit', this.config.sessionId, 1);
+			this.emit('agent-error', this.config.sessionId, {
+				type: 'unknown',
+				message,
+				recoverable: isExpectedDisconnect(err),
+			});
+			this.emit('exit', this.config.sessionId, 1);
 
-      return { pid: -1, success: false };
-    }
-  }
+			return { pid: -1, success: false };
+		}
+	}
 
-  /**
-   * Send a prompt to the agent
-   * @param text - The prompt text
-   * @param images - Optional images to include (only for initial prompt, not follow-ups via write())
-   */
-  async sendPrompt(text: string, images?: Array<{ data: string; mimeType: string }>): Promise<void> {
-    if (!this.acpSessionId) {
-      logger.error('Cannot send prompt: no ACP session', LOG_CONTEXT);
-      return;
-    }
+	/**
+	 * Send a prompt to the agent
+	 * @param text - The prompt text
+	 * @param images - Optional images to include (only for initial prompt, not follow-ups via write())
+	 */
+	async sendPrompt(
+		text: string,
+		images?: Array<{ data: string; mimeType: string }>
+	): Promise<void> {
+		if (!this.acpSessionId) {
+			logger.error('Cannot send prompt: no ACP session', LOG_CONTEXT);
+			return;
+		}
 
-    // Clear streamed text for new prompt (but keep totalAccumulatedText for cross-prompt dedup)
-    this.streamedText = '';
-    this.emittedTextLength = 0; // Reset emission tracker for new prompt
+		// Clear streamed text for new prompt (but keep totalAccumulatedText for cross-prompt dedup)
+		this.streamedText = '';
+		this.emittedTextLength = 0; // Reset emission tracker for new prompt
 
-    try {
-      logger.debug(`Sending prompt to ACP agent`, LOG_CONTEXT, {
-        sessionId: this.config.sessionId,
-        promptLength: text.length,
-        hasImages: !!images && images.length > 0,
-      });
+		try {
+			logger.debug(`Sending prompt to ACP agent`, LOG_CONTEXT, {
+				sessionId: this.config.sessionId,
+				promptLength: text.length,
+				hasImages: !!images && images.length > 0,
+			});
 
-      let response;
-      // Only include images if explicitly passed (for initial prompt)
-      if (images && images.length > 0) {
-        response = await this.client.promptWithImages(
-          this.acpSessionId,
-          text,
-          images
-        );
-      } else {
-        response = await this.client.prompt(this.acpSessionId, text);
-      }
+			let response;
+			// Only include images if explicitly passed (for initial prompt)
+			if (images && images.length > 0) {
+				response = await this.client.promptWithImages(this.acpSessionId, text, images);
+			} else {
+				response = await this.client.prompt(this.acpSessionId, text);
+			}
 
-      logger.debug('Received prompt response from ACP agent', LOG_CONTEXT, {
-        stopReason: response.stopReason,
-        hasUsage: !!response.usage,
-        usage: response.usage,
-      });
+			logger.debug('Received prompt response from ACP agent', LOG_CONTEXT, {
+				stopReason: response.stopReason,
+				hasUsage: !!response.usage,
+				usage: response.usage,
+			});
 
-      // Workaround for OpenCode bug: Remove previous response if it's repeated
-      // OpenCode may send cumulative text (all previous messages + new message)
-      let finalText = this.streamedText;
-      if (this.totalAccumulatedText && finalText.startsWith(this.totalAccumulatedText)) {
-        // Agent repeated the previous response - extract only the new part
-        const newContent = finalText.substring(this.totalAccumulatedText.length);
-        logger.debug('Detected cumulative response, extracting delta', LOG_CONTEXT, {
-          previousLength: this.totalAccumulatedText.length,
-          totalLength: finalText.length,
-          deltaLength: newContent.length,
-        });
-        finalText = newContent;
-      }
+			// Workaround for OpenCode bug: Remove previous response if it's repeated
+			// OpenCode may send cumulative text (all previous messages + new message)
+			let finalText = this.streamedText;
+			if (this.totalAccumulatedText && finalText.startsWith(this.totalAccumulatedText)) {
+				// Agent repeated the previous response - extract only the new part
+				const newContent = finalText.substring(this.totalAccumulatedText.length);
+				logger.debug('Detected cumulative response, extracting delta', LOG_CONTEXT, {
+					previousLength: this.totalAccumulatedText.length,
+					totalLength: finalText.length,
+					deltaLength: newContent.length,
+				});
+				finalText = newContent;
+			}
 
-      // Update total accumulated text for next deduplication check
-      this.totalAccumulatedText += finalText;
+			// Update total accumulated text for next deduplication check
+			this.totalAccumulatedText += finalText;
 
-      // Emit final result event to signal completion
-      // Include finalText (deduplicated) so ProcessManager can emit it if streaming was disabled
-      const resultEvent = createResultEvent(
-        this.config.sessionId,
-        finalText, // Use deduplicated text
-        response.stopReason,
-        response.usage // Include usage stats from response
-      );
-      this.emit('data', this.config.sessionId, resultEvent);
+			// Emit final result event to signal completion
+			// Include finalText (deduplicated) so ProcessManager can emit it if streaming was disabled
+			const resultEvent = createResultEvent(
+				this.config.sessionId,
+				finalText, // Use deduplicated text
+				response.stopReason,
+				response.usage // Include usage stats from response
+			);
+			this.emit('data', this.config.sessionId, resultEvent);
 
-      // If stop reason indicates completion, emit exit
-      if (response.stopReason === 'end_turn' || response.stopReason === 'cancelled') {
-        this.emit('exit', this.config.sessionId, 0);
-      }
-    } catch (error) {
-      const err = error instanceof Error ? error : new Error(String(error));
-      const message = err.message;
-      
-      // Check if this is an expected disconnect (user cancelled, process killed, etc.)
-      if (isExpectedDisconnect(err)) {
-        logger.debug(`ACP prompt cancelled/disconnected: ${message}`, LOG_CONTEXT);
-        // Don't emit agent-error for expected disconnects - just exit cleanly
-        this.emit('exit', this.config.sessionId, 0);
-        return;
-      }
-      
-      logger.error(`ACP prompt failed: ${message}`, LOG_CONTEXT);
+			// If stop reason indicates completion, emit exit
+			if (response.stopReason === 'end_turn' || response.stopReason === 'cancelled') {
+				this.emit('exit', this.config.sessionId, 0);
+			}
+		} catch (error) {
+			const err = error instanceof Error ? error : new Error(String(error));
+			const message = err.message;
 
-      // Report unexpected errors to Sentry
-      captureError(err, {
-        tags: {
-          component: 'ACPProcess',
-          operation: 'sendPrompt',
-          toolType: this.config.toolType,
-        },
-        extra: {
-          sessionId: this.config.sessionId,
-          acpSessionId: this.acpSessionId,
-        },
-      });
+			// Check if this is an expected disconnect (user cancelled, process killed, etc.)
+			if (isExpectedDisconnect(err)) {
+				logger.debug(`ACP prompt cancelled/disconnected: ${message}`, LOG_CONTEXT);
+				// Don't emit agent-error for expected disconnects - just exit cleanly
+				this.emit('exit', this.config.sessionId, 0);
+				return;
+			}
 
-      this.emit('agent-error', this.config.sessionId, {
-        type: 'unknown',
-        message,
-        recoverable: false,
-      });
-    }
-  }
+			logger.error(`ACP prompt failed: ${message}`, LOG_CONTEXT);
 
-  /**
-   * Write data to the agent (for follow-up prompts)
-   * Note: Images are NOT resent on follow-up prompts - they're only for the initial prompt
-   */
-  async write(data: string): Promise<void> {
-    // In ACP mode, writing is sending a new prompt (without images)
-    await this.sendPrompt(data);
-  }
+			// Report unexpected errors to Sentry
+			captureError(err, {
+				tags: {
+					component: 'ACPProcess',
+					operation: 'sendPrompt',
+					toolType: this.config.toolType,
+				},
+				extra: {
+					sessionId: this.config.sessionId,
+					acpSessionId: this.acpSessionId,
+				},
+			});
 
-  /**
-   * Cancel ongoing operations
-   */
-  cancel(): void {
-    if (this.acpSessionId) {
-      this.client.cancel(this.acpSessionId);
-    }
-  }
+			this.emit('agent-error', this.config.sessionId, {
+				type: 'unknown',
+				message,
+				recoverable: false,
+			});
+		}
+	}
 
-  /**
-   * Kill the ACP process
-   */
-  kill(): void {
-    this.client.disconnect();
-    this.emit('exit', this.config.sessionId, 0);
-  }
+	/**
+	 * Write data to the agent (for follow-up prompts)
+	 * Note: Images are NOT resent on follow-up prompts - they're only for the initial prompt
+	 */
+	async write(data: string): Promise<void> {
+		// In ACP mode, writing is sending a new prompt (without images)
+		await this.sendPrompt(data);
+	}
 
-  /**
-   * Interrupt (same as cancel for ACP)
-   */
-  interrupt(): void {
-    this.cancel();
-  }
+	/**
+	 * Cancel ongoing operations
+	 */
+	cancel(): void {
+		if (this.acpSessionId) {
+			this.client.cancel(this.acpSessionId);
+		}
+	}
 
-  /**
-   * Set up event handlers for ACP client
-   */
-  private setupEventHandlers(): void {
-    // Handle session updates
-    this.client.on('session:update', (sessionId: SessionId, update: SessionUpdate) => {
-      // Ignore updates during session load - these are historical messages
-      if (this.isLoadingSession) {
-        logger.debug('Ignoring session update during session load (historical message)', LOG_CONTEXT, {
-          updateKeys: Object.keys(update)
-        });
-        return;
-      }
+	/**
+	 * Kill the ACP process
+	 */
+	kill(): void {
+		this.client.disconnect();
+		this.emit('exit', this.config.sessionId, 0);
+	}
 
-      const event = acpUpdateToParseEvent(sessionId, update);
-      if (event) {
-        // Accumulate text for final result
-        if (event.type === 'text' && event.text) {
-          // Fix: Handle cross-prompt overlap before accumulating
-          // If streamedText starts with totalAccumulatedText, the agent is sending cumulative content
-          let adjustedText = event.text;
-          
-          // Check if this new text chunk overlaps with what we've already accumulated
-          // This handles the case where agents send cumulative text (all previous + new)
-          if (this.totalAccumulatedText && this.streamedText.length === 0) {
-            // First chunk of a new prompt - check for cross-prompt overlap
-            if (adjustedText.startsWith(this.totalAccumulatedText)) {
-              // Agent repeated previous response - extract only the new part
-              adjustedText = adjustedText.substring(this.totalAccumulatedText.length);
-              logger.debug('Trimmed cross-prompt overlap from streaming chunk', LOG_CONTEXT, {
-                overlapLength: this.totalAccumulatedText.length,
-                adjustedLength: adjustedText.length,
-              });
-            }
-          }
-          
-          this.streamedText += adjustedText;
-          
-          // Emit only new content that hasn't been emitted yet (within this prompt)
-          if (adjustedText.length > 0 && this.streamedText.length > this.emittedTextLength) {
-            const newText = this.streamedText.substring(this.emittedTextLength);
-            this.emittedTextLength = this.streamedText.length;
-            
-            // Emit only the delta
-            const deltaEvent = { ...event, text: newText };
-            this.emit('data', this.config.sessionId, deltaEvent);
-          }
-          // Skip emitting if we've already sent this text
-        } else {
-          // Non-text events - emit as-is
-          this.emit('data', this.config.sessionId, event);
-        }
-      }
-    });
+	/**
+	 * Interrupt (same as cancel for ACP)
+	 */
+	interrupt(): void {
+		this.cancel();
+	}
 
-    // Handle permission requests
-    // Only auto-approve if explicitly enabled via config (YOLO mode)
-    // Otherwise, cancel the request for security
-    this.client.on('session:permission_request', (request, respond) => {
-      logger.debug(`ACP permission request: ${request.toolCall.title}`, LOG_CONTEXT, {
-        autoApproveEnabled: this.config.autoApprovePermissions,
-      });
+	/**
+	 * Set up event handlers for ACP client
+	 */
+	private setupEventHandlers(): void {
+		// Handle session updates
+		this.client.on('session:update', (sessionId: SessionId, update: SessionUpdate) => {
+			// Ignore updates during session load - these are historical messages
+			if (this.isLoadingSession) {
+				logger.debug(
+					'Ignoring session update during session load (historical message)',
+					LOG_CONTEXT,
+					{
+						updateKeys: Object.keys(update),
+					}
+				);
+				return;
+			}
 
-      if (this.config.autoApprovePermissions) {
-        // YOLO mode: Find allow option and auto-approve
-        const allowOption = request.options.find(
-          (o: { kind: string; optionId: string }) => o.kind === 'allow_once' || o.kind === 'allow_always'
-        );
-        if (allowOption) {
-          logger.debug(`Auto-approving permission request (YOLO mode)`, LOG_CONTEXT, {
-            optionId: allowOption.optionId,
-            kind: allowOption.kind,
-          });
-          respond({ outcome: { selected: { optionId: allowOption.optionId } } });
-        } else {
-          logger.warn(`No allow option found in permission request, cancelling`, LOG_CONTEXT);
-          respond({ outcome: { cancelled: {} } });
-        }
-      } else {
-        // Normal mode: Reject permission requests for security
-        // TODO: Implement UI flow to prompt user for approval
-        logger.warn(`Permission request rejected (auto-approve not enabled)`, LOG_CONTEXT, {
-          toolTitle: request.toolCall.title,
-        });
-        respond({ outcome: { cancelled: {} } });
-      }
-    });
+			const event = acpUpdateToParseEvent(sessionId, update);
+			if (event) {
+				// Accumulate text for final result
+				if (event.type === 'text' && event.text) {
+					// Fix: Handle cross-prompt overlap before accumulating
+					// If streamedText starts with totalAccumulatedText, the agent is sending cumulative content
+					let adjustedText = event.text;
 
-    // Handle file system read requests
-    // Return proper errors instead of fabricating success with empty content
-    this.client.on('fs:read', async (request, respond) => {
-      try {
-        const fs = await import('fs');
-        const content = fs.readFileSync(request.path, 'utf-8');
-        
-        // Support line/limit parameters if provided
-        if (request.line !== undefined || request.limit !== undefined) {
-          const lines = content.split('\n');
-          const startLine = (request.line ?? 1) - 1; // Convert to 0-indexed
-          const limit = request.limit ?? lines.length;
-          const slicedLines = lines.slice(startLine, startLine + limit);
-          respond({ content: slicedLines.join('\n') });
-        } else {
-          respond({ content });
-        }
-      } catch (err) {
-        const error = err as Error;
-        logger.error(`Failed to read file: ${request.path}`, LOG_CONTEXT, {
-          error: error.message,
-        });
-        // Return JSON-RPC style error so the agent knows the operation failed
-        respond({
-          error: {
-            code: -32000,
-            message: `Failed to read file: ${request.path}`,
-            data: { error: error.message },
-          },
-        });
-      }
-    });
+					// Check if this new text chunk overlaps with what we've already accumulated
+					// This handles the case where agents send cumulative text (all previous + new)
+					if (this.totalAccumulatedText && this.streamedText.length === 0) {
+						// First chunk of a new prompt - check for cross-prompt overlap
+						if (adjustedText.startsWith(this.totalAccumulatedText)) {
+							// Agent repeated previous response - extract only the new part
+							adjustedText = adjustedText.substring(this.totalAccumulatedText.length);
+							logger.debug('Trimmed cross-prompt overlap from streaming chunk', LOG_CONTEXT, {
+								overlapLength: this.totalAccumulatedText.length,
+								adjustedLength: adjustedText.length,
+							});
+						}
+					}
 
-    // Handle file system write requests
-    // Return proper errors instead of fabricating success
-    this.client.on('fs:write', async (request, respond) => {
-      try {
-        const fs = await import('fs');
-        fs.writeFileSync(request.path, request.content, 'utf-8');
-        respond({});
-      } catch (err) {
-        const error = err as Error;
-        logger.error(`Failed to write file: ${request.path}`, LOG_CONTEXT, {
-          error: error.message,
-        });
-        // Return JSON-RPC style error so the agent knows the operation failed
-        respond({
-          error: {
-            code: -32001,
-            message: `Failed to write file: ${request.path}`,
-            data: { error: error.message },
-          },
-        });
-      }
-    });
+					this.streamedText += adjustedText;
 
-    // Handle disconnection
-    this.client.on('disconnected', () => {
-      logger.info('ACP client disconnected', LOG_CONTEXT);
-    });
+					// Emit only new content that hasn't been emitted yet (within this prompt)
+					if (adjustedText.length > 0 && this.streamedText.length > this.emittedTextLength) {
+						const newText = this.streamedText.substring(this.emittedTextLength);
+						this.emittedTextLength = this.streamedText.length;
 
-    // Handle errors
-    this.client.on('error', (error) => {
-      // Check if this is an expected disconnect
-      if (isExpectedDisconnect(error)) {
-        logger.debug(`ACP client disconnected (expected): ${error.message}`, LOG_CONTEXT);
-        return;
-      }
-      
-      logger.error(`ACP client error: ${error.message}`, LOG_CONTEXT);
-      
-      // Report unexpected errors to Sentry
-      captureError(error, {
-        tags: {
-          component: 'ACPProcess',
-          operation: 'clientError',
-          toolType: this.config.toolType,
-        },
-        extra: {
-          sessionId: this.config.sessionId,
-          acpSessionId: this.acpSessionId,
-        },
-      });
-      
-      this.emit('agent-error', this.config.sessionId, {
-        type: 'unknown',
-        message: error.message,
-        recoverable: false,
-      });
-    });
-  }
+						// Emit only the delta
+						const deltaEvent = { ...event, text: newText };
+						this.emit('data', this.config.sessionId, deltaEvent);
+					}
+					// Skip emitting if we've already sent this text
+				} else {
+					// Non-text events - emit as-is
+					this.emit('data', this.config.sessionId, event);
+				}
+			}
+		});
+
+		// Handle permission requests
+		// Only auto-approve if explicitly enabled via config (YOLO mode)
+		// Otherwise, cancel the request for security
+		this.client.on('session:permission_request', (request, respond) => {
+			logger.debug(`ACP permission request: ${request.toolCall.title}`, LOG_CONTEXT, {
+				autoApproveEnabled: this.config.autoApprovePermissions,
+			});
+
+			if (this.config.autoApprovePermissions) {
+				// YOLO mode: Find allow option and auto-approve
+				const allowOption = request.options.find(
+					(o: { kind: string; optionId: string }) =>
+						o.kind === 'allow_once' || o.kind === 'allow_always'
+				);
+				if (allowOption) {
+					logger.debug(`Auto-approving permission request (YOLO mode)`, LOG_CONTEXT, {
+						optionId: allowOption.optionId,
+						kind: allowOption.kind,
+					});
+					respond({ outcome: { selected: { optionId: allowOption.optionId } } });
+				} else {
+					logger.warn(`No allow option found in permission request, cancelling`, LOG_CONTEXT);
+					respond({ outcome: { cancelled: {} } });
+				}
+			} else {
+				// Normal mode: Reject permission requests for security
+				// TODO: Implement UI flow to prompt user for approval
+				logger.warn(`Permission request rejected (auto-approve not enabled)`, LOG_CONTEXT, {
+					toolTitle: request.toolCall.title,
+				});
+				respond({ outcome: { cancelled: {} } });
+			}
+		});
+
+		// Handle file system read requests
+		// Return proper errors instead of fabricating success with empty content
+		this.client.on('fs:read', async (request, respond) => {
+			try {
+				const fs = await import('fs');
+				const content = fs.readFileSync(request.path, 'utf-8');
+
+				// Support line/limit parameters if provided
+				if (request.line !== undefined || request.limit !== undefined) {
+					const lines = content.split('\n');
+					const startLine = (request.line ?? 1) - 1; // Convert to 0-indexed
+					const limit = request.limit ?? lines.length;
+					const slicedLines = lines.slice(startLine, startLine + limit);
+					respond({ content: slicedLines.join('\n') });
+				} else {
+					respond({ content });
+				}
+			} catch (err) {
+				const error = err as Error;
+				logger.error(`Failed to read file: ${request.path}`, LOG_CONTEXT, {
+					error: error.message,
+				});
+				// Return JSON-RPC style error so the agent knows the operation failed
+				respond({
+					error: {
+						code: -32000,
+						message: `Failed to read file: ${request.path}`,
+						data: { error: error.message },
+					},
+				});
+			}
+		});
+
+		// Handle file system write requests
+		// Return proper errors instead of fabricating success
+		this.client.on('fs:write', async (request, respond) => {
+			try {
+				const fs = await import('fs');
+				fs.writeFileSync(request.path, request.content, 'utf-8');
+				respond({});
+			} catch (err) {
+				const error = err as Error;
+				logger.error(`Failed to write file: ${request.path}`, LOG_CONTEXT, {
+					error: error.message,
+				});
+				// Return JSON-RPC style error so the agent knows the operation failed
+				respond({
+					error: {
+						code: -32001,
+						message: `Failed to write file: ${request.path}`,
+						data: { error: error.message },
+					},
+				});
+			}
+		});
+
+		// Handle disconnection
+		this.client.on('disconnected', () => {
+			logger.info('ACP client disconnected', LOG_CONTEXT);
+		});
+
+		// Handle errors
+		this.client.on('error', (error) => {
+			// Check if this is an expected disconnect
+			if (isExpectedDisconnect(error)) {
+				logger.debug(`ACP client disconnected (expected): ${error.message}`, LOG_CONTEXT);
+				return;
+			}
+
+			logger.error(`ACP client error: ${error.message}`, LOG_CONTEXT);
+
+			// Report unexpected errors to Sentry
+			captureError(error, {
+				tags: {
+					component: 'ACPProcess',
+					operation: 'clientError',
+					toolType: this.config.toolType,
+				},
+				extra: {
+					sessionId: this.config.sessionId,
+					acpSessionId: this.acpSessionId,
+				},
+			});
+
+			this.emit('agent-error', this.config.sessionId, {
+				type: 'unknown',
+				message: error.message,
+				recoverable: false,
+			});
+		});
+	}
 }
 
 /**
  * Create and start an ACP process
  */
 export async function spawnACPProcess(
-  config: ACPProcessConfig
+	config: ACPProcessConfig
 ): Promise<{ process: ACPProcess; pid: number; success: boolean }> {
-  const process = new ACPProcess(config);
-  const result = await process.start();
-  return { process, ...result };
+	const process = new ACPProcess(config);
+	const result = await process.start();
+	return { process, ...result };
 }

--- a/src/main/acp/acp-process.ts
+++ b/src/main/acp/acp-process.ts
@@ -15,6 +15,10 @@ import { acpUpdateToParseEvent, createSessionIdEvent, createResultEvent } from '
 import type { SessionUpdate, SessionId } from './types';
 import { logger } from '../utils/logger';
 import { getAppVersion } from './version';
+import {
+	detectAcpError,
+	isExpectedDisconnect as isExpectedDisconnectError,
+} from './acp-error-detector';
 
 const LOG_CONTEXT = '[ACPProcess]';
 
@@ -42,16 +46,10 @@ function captureError(
 
 /**
  * Check if an error is an expected disconnect (not a fatal error)
+ * Uses the centralized detection from acp-error-detector
  */
 function isExpectedDisconnect(error: Error): boolean {
-	const message = error.message.toLowerCase();
-	return (
-		message.includes('connection closed') ||
-		message.includes('process exited') ||
-		message.includes('cancelled') ||
-		message.includes('sigterm') ||
-		message.includes('sigint')
-	);
+	return isExpectedDisconnectError(error);
 }
 
 export interface ACPProcessConfig {
@@ -238,10 +236,12 @@ export class ACPProcess extends EventEmitter {
 				});
 			}
 
+			// Detect error type using ACP error detector
+			const detectedError = detectAcpError(err);
 			this.emit('agent-error', this.config.sessionId, {
-				type: 'unknown',
-				message,
-				recoverable: isExpectedDisconnect(err),
+				type: detectedError.type,
+				message: detectedError.message,
+				recoverable: detectedError.recoverable || isExpectedDisconnect(err),
 			});
 			this.emit('exit', this.config.sessionId, 1);
 
@@ -346,10 +346,12 @@ export class ACPProcess extends EventEmitter {
 				},
 			});
 
+			// Detect error type using ACP error detector
+			const detectedError = detectAcpError(err);
 			this.emit('agent-error', this.config.sessionId, {
-				type: 'unknown',
-				message,
-				recoverable: false,
+				type: detectedError.type,
+				message: detectedError.message,
+				recoverable: detectedError.recoverable,
 			});
 		}
 	}
@@ -564,10 +566,12 @@ export class ACPProcess extends EventEmitter {
 				},
 			});
 
+			// Detect error type using ACP error detector
+			const detectedError = detectAcpError(error);
 			this.emit('agent-error', this.config.sessionId, {
-				type: 'unknown',
-				message: error.message,
-				recoverable: false,
+				type: detectedError.type,
+				message: detectedError.message,
+				recoverable: detectedError.recoverable,
 			});
 		});
 	}

--- a/src/main/acp/index.ts
+++ b/src/main/acp/index.ts
@@ -1,0 +1,19 @@
+/**
+ * ACP (Agent Client Protocol) Module
+ *
+ * Provides standardized communication with ACP-compatible agents like OpenCode.
+ * This enables Maestro to use a single protocol for all agents instead of
+ * custom parsers for each agent type.
+ *
+ * @see https://agentclientprotocol.com/
+ */
+
+export { ACPClient, type ACPClientConfig, type ACPClientEvents } from './acp-client';
+export * from './types';
+export {
+  acpUpdateToParseEvent,
+  createSessionIdEvent,
+  createResultEvent,
+  createErrorEvent,
+} from './acp-adapter';
+export { ACPProcess, spawnACPProcess, type ACPProcessConfig } from './acp-process';

--- a/src/main/acp/index.ts
+++ b/src/main/acp/index.ts
@@ -11,9 +11,9 @@
 export { ACPClient, type ACPClientConfig, type ACPClientEvents } from './acp-client';
 export * from './types';
 export {
-  acpUpdateToParseEvent,
-  createSessionIdEvent,
-  createResultEvent,
-  createErrorEvent,
+	acpUpdateToParseEvent,
+	createSessionIdEvent,
+	createResultEvent,
+	createErrorEvent,
 } from './acp-adapter';
 export { ACPProcess, spawnACPProcess, type ACPProcessConfig } from './acp-process';

--- a/src/main/acp/index.ts
+++ b/src/main/acp/index.ts
@@ -17,3 +17,4 @@ export {
 	createErrorEvent,
 } from './acp-adapter';
 export { ACPProcess, spawnACPProcess, type ACPProcessConfig } from './acp-process';
+export { getAppVersion } from './version';

--- a/src/main/acp/index.ts
+++ b/src/main/acp/index.ts
@@ -18,3 +18,8 @@ export {
 } from './acp-adapter';
 export { ACPProcess, spawnACPProcess, type ACPProcessConfig } from './acp-process';
 export { getAppVersion } from './version';
+export {
+	detectAcpError,
+	isExpectedDisconnect,
+	type DetectedError,
+} from './acp-error-detector';

--- a/src/main/acp/types.ts
+++ b/src/main/acp/types.ts
@@ -1,0 +1,456 @@
+/**
+ * ACP (Agent Client Protocol) Type Definitions
+ *
+ * Based on the ACP specification at https://agentclientprotocol.com/protocol/schema
+ * These types define the JSON-RPC messages for communicating with ACP-compatible agents.
+ */
+
+// ============================================================================
+// Core JSON-RPC Types
+// ============================================================================
+
+export type RequestId = string | number | null;
+
+export interface JsonRpcRequest {
+  jsonrpc: '2.0';
+  id: RequestId;
+  method: string;
+  params?: unknown;
+}
+
+export interface JsonRpcResponse {
+  jsonrpc: '2.0';
+  id: RequestId;
+  result?: unknown;
+  error?: JsonRpcError;
+}
+
+export interface JsonRpcNotification {
+  jsonrpc: '2.0';
+  method: string;
+  params?: unknown;
+}
+
+export interface JsonRpcError {
+  code: number;
+  message: string;
+  data?: unknown;
+}
+
+// ============================================================================
+// Protocol Version
+// ============================================================================
+
+export type ProtocolVersion = number;
+export const CURRENT_PROTOCOL_VERSION: ProtocolVersion = 1;
+
+// ============================================================================
+// Implementation Info
+// ============================================================================
+
+export interface Implementation {
+  name: string;
+  version: string;
+  title?: string;
+}
+
+// ============================================================================
+// Capabilities
+// ============================================================================
+
+export interface ClientCapabilities {
+  fs?: {
+    readTextFile?: boolean;
+    writeTextFile?: boolean;
+  };
+  terminal?: boolean;
+}
+
+export interface AgentCapabilities {
+  loadSession?: boolean;
+  mcpCapabilities?: {
+    http?: boolean;
+    sse?: boolean;
+  };
+  promptCapabilities?: {
+    audio?: boolean;
+    embeddedContext?: boolean;
+    image?: boolean;
+  };
+  sessionCapabilities?: Record<string, unknown>;
+}
+
+// ============================================================================
+// Initialize
+// ============================================================================
+
+export interface InitializeRequest {
+  protocolVersion: ProtocolVersion;
+  clientInfo?: Implementation;
+  clientCapabilities?: ClientCapabilities;
+}
+
+export interface InitializeResponse {
+  protocolVersion: ProtocolVersion;
+  agentInfo?: Implementation;
+  agentCapabilities?: AgentCapabilities;
+  authMethods?: AuthMethod[];
+}
+
+export interface AuthMethod {
+  id: string;
+  name: string;
+  description?: string;
+}
+
+// ============================================================================
+// Session Management
+// ============================================================================
+
+export type SessionId = string;
+
+export interface McpServerStdio {
+  name: string;
+  command: string;
+  args: string[];
+  env: EnvVariable[];
+}
+
+export interface EnvVariable {
+  name: string;
+  value: string;
+}
+
+export type McpServer = { stdio: McpServerStdio };
+
+export interface NewSessionRequest {
+  cwd: string;
+  mcpServers: McpServer[];
+}
+
+export interface NewSessionResponse {
+  sessionId: SessionId;
+  modes?: SessionModeState;
+}
+
+export interface LoadSessionRequest {
+  sessionId: SessionId;
+  cwd: string;
+  mcpServers: McpServer[];
+}
+
+export interface LoadSessionResponse {
+  modes?: SessionModeState;
+}
+
+export interface SessionModeState {
+  availableModes: SessionMode[];
+  currentModeId: SessionModeId;
+}
+
+export type SessionModeId = string;
+
+export interface SessionMode {
+  id: SessionModeId;
+  name: string;
+  description?: string;
+}
+
+// ============================================================================
+// Content Blocks
+// ============================================================================
+
+export interface TextContent {
+  text: string;
+  annotations?: Annotations;
+}
+
+export interface ImageContent {
+  data: string;
+  mimeType: string;
+  uri?: string;
+  annotations?: Annotations;
+}
+
+export interface ResourceLink {
+  uri: string;
+  name: string;
+  mimeType?: string;
+  description?: string;
+  title?: string;
+  size?: number;
+  annotations?: Annotations;
+}
+
+export interface EmbeddedResource {
+  resource: TextResourceContents | BlobResourceContents;
+  annotations?: Annotations;
+}
+
+export interface TextResourceContents {
+  uri: string;
+  text: string;
+  mimeType?: string;
+}
+
+export interface BlobResourceContents {
+  uri: string;
+  blob: string;
+  mimeType?: string;
+}
+
+export interface Annotations {
+  audience?: Role[];
+  lastModified?: string;
+  priority?: number;
+}
+
+export type Role = 'assistant' | 'user';
+
+export type ContentBlock =
+  | { text: TextContent }
+  | { image: ImageContent }
+  | { resource_link: ResourceLink }
+  | { resource: EmbeddedResource };
+
+// ============================================================================
+// Prompt
+// ============================================================================
+
+export interface PromptRequest {
+  sessionId: SessionId;
+  prompt: ContentBlock[];
+}
+
+export type StopReason =
+  | 'end_turn'
+  | 'max_tokens'
+  | 'max_turn_requests'
+  | 'refusal'
+  | 'cancelled';
+
+export interface PromptResponse {
+  stopReason: StopReason;
+  usage?: {
+    inputTokens?: number;
+    outputTokens?: number;
+    totalTokens?: number;
+  };
+}
+
+// ============================================================================
+// Session Updates (Notifications)
+// ============================================================================
+
+export interface SessionNotification {
+  sessionId: SessionId;
+  update: SessionUpdate;
+}
+
+export type SessionUpdate =
+  | { user_message_chunk: ContentChunk }
+  | { agent_message_chunk: ContentChunk }
+  | { agent_thought_chunk: ContentChunk }
+  | { tool_call: ToolCall }
+  | { tool_call_update: ToolCallUpdate }
+  | { plan: Plan }
+  | { available_commands_update: AvailableCommandsUpdate }
+  | { current_mode_update: CurrentModeUpdate };
+
+export interface ContentChunk {
+  content: ContentBlock;
+}
+
+// ============================================================================
+// Tool Calls
+// ============================================================================
+
+export type ToolCallId = string;
+
+export type ToolKind =
+  | 'read'
+  | 'edit'
+  | 'delete'
+  | 'move'
+  | 'search'
+  | 'execute'
+  | 'think'
+  | 'fetch'
+  | 'switch_mode'
+  | 'other';
+
+export type ToolCallStatus = 'pending' | 'in_progress' | 'completed' | 'failed';
+
+export interface ToolCall {
+  toolCallId: ToolCallId;
+  title: string;
+  kind?: ToolKind;
+  status?: ToolCallStatus;
+  rawInput?: unknown;
+  rawOutput?: unknown;
+  content?: ToolCallContent[];
+  locations?: ToolCallLocation[];
+}
+
+export interface ToolCallUpdate {
+  toolCallId: ToolCallId;
+  title?: string;
+  kind?: ToolKind;
+  status?: ToolCallStatus;
+  rawInput?: unknown;
+  rawOutput?: unknown;
+  content?: ToolCallContent[];
+  locations?: ToolCallLocation[];
+}
+
+export type ToolCallContent =
+  | { content: { content: ContentBlock } }
+  | { diff: Diff }
+  | { terminal: Terminal };
+
+export interface Diff {
+  path: string;
+  oldText?: string;
+  newText: string;
+}
+
+export interface Terminal {
+  terminalId: string;
+}
+
+export interface ToolCallLocation {
+  path: string;
+  line?: number;
+}
+
+// ============================================================================
+// Plan
+// ============================================================================
+
+export interface Plan {
+  entries: PlanEntry[];
+}
+
+export interface PlanEntry {
+  content: string;
+  priority: PlanEntryPriority;
+  status: PlanEntryStatus;
+}
+
+export type PlanEntryPriority = 'high' | 'medium' | 'low';
+export type PlanEntryStatus = 'pending' | 'in_progress' | 'completed';
+
+// ============================================================================
+// Commands
+// ============================================================================
+
+export interface AvailableCommandsUpdate {
+  availableCommands: AvailableCommand[];
+}
+
+export interface AvailableCommand {
+  name: string;
+  description: string;
+  input?: AvailableCommandInput;
+}
+
+export interface AvailableCommandInput {
+  hint: string;
+}
+
+export interface CurrentModeUpdate {
+  currentModeId: SessionModeId;
+}
+
+// ============================================================================
+// Permission Request (Client → Agent response)
+// ============================================================================
+
+export interface RequestPermissionRequest {
+  sessionId: SessionId;
+  toolCall: ToolCallUpdate;
+  options: PermissionOption[];
+}
+
+export interface PermissionOption {
+  optionId: PermissionOptionId;
+  name: string;
+  kind: PermissionOptionKind;
+}
+
+export type PermissionOptionId = string;
+export type PermissionOptionKind = 'allow_once' | 'allow_always' | 'reject_once' | 'reject_always';
+
+export interface RequestPermissionResponse {
+  outcome: RequestPermissionOutcome;
+}
+
+export type RequestPermissionOutcome =
+  | { cancelled: Record<string, never> }
+  | { selected: { optionId: PermissionOptionId } };
+
+// ============================================================================
+// File System (Client methods)
+// ============================================================================
+
+export interface ReadTextFileRequest {
+  sessionId: SessionId;
+  path: string;
+  line?: number;
+  limit?: number;
+}
+
+export interface ReadTextFileResponse {
+  content: string;
+}
+
+export interface WriteTextFileRequest {
+  sessionId: SessionId;
+  path: string;
+  content: string;
+}
+
+export interface WriteTextFileResponse {
+  // Empty response
+}
+
+// ============================================================================
+// Terminal (Client methods)
+// ============================================================================
+
+export interface CreateTerminalRequest {
+  sessionId: SessionId;
+  command: string;
+  args?: string[];
+  cwd?: string;
+  env?: EnvVariable[];
+  outputByteLimit?: number;
+}
+
+export interface CreateTerminalResponse {
+  terminalId: string;
+}
+
+export interface TerminalOutputRequest {
+  sessionId: SessionId;
+  terminalId: string;
+}
+
+export interface TerminalOutputResponse {
+  output: string;
+  truncated: boolean;
+  exitStatus?: TerminalExitStatus;
+}
+
+export interface TerminalExitStatus {
+  exitCode?: number;
+  signal?: string;
+}
+
+// ============================================================================
+// Cancel
+// ============================================================================
+
+export interface CancelNotification {
+  sessionId: SessionId;
+}

--- a/src/main/acp/types.ts
+++ b/src/main/acp/types.ts
@@ -104,6 +104,32 @@ export interface AuthMethod {
 }
 
 // ============================================================================
+// Authentication
+// ============================================================================
+
+/**
+ * Authentication request sent after initialize when the agent
+ * reports authMethods in the InitializeResponse.
+ *
+ * Some agents (e.g., Gemini CLI) require an explicit authenticate call
+ * between initialize and session/new. The client selects which auth
+ * method to use from the list provided in InitializeResponse.authMethods.
+ */
+export interface AuthenticateRequest {
+	/** The selected auth method ID (from InitializeResponse.authMethods) */
+	authMethodId: string;
+	/** Optional auth parameters (e.g., API key, token) */
+	params?: Record<string, unknown>;
+}
+
+export interface AuthenticateResponse {
+	/** Whether authentication was successful */
+	success: boolean;
+	/** Error message if authentication failed */
+	error?: string;
+}
+
+// ============================================================================
 // Session Management
 // ============================================================================
 

--- a/src/main/acp/types.ts
+++ b/src/main/acp/types.ts
@@ -270,7 +270,9 @@ export type SessionUpdate =
 	| { tool_call_update: ToolCallUpdate }
 	| { plan: Plan }
 	| { available_commands_update: AvailableCommandsUpdate }
-	| { current_mode_update: CurrentModeUpdate };
+	| { current_mode_update: CurrentModeUpdate }
+	| { usage_update: UsageUpdate }
+	| { config_option_update: ConfigOptionUpdate };
 
 export interface ContentChunk {
 	content: ContentBlock;
@@ -375,6 +377,48 @@ export interface AvailableCommandInput {
 
 export interface CurrentModeUpdate {
 	currentModeId: SessionModeId;
+}
+
+// ============================================================================
+// Usage Update
+// ============================================================================
+
+/**
+ * Usage update sent by agents to report token usage and cost.
+ * Based on OpenCode's ACP implementation:
+ * - used: number of tokens used in the current context
+ * - size: total context window size
+ * - cost: optional cost information with amount and currency
+ */
+export interface UsageUpdate {
+	/** Number of tokens used in the current context */
+	used: number;
+	/** Total context window size */
+	size: number;
+	/** Optional cost information */
+	cost?: UsageCost;
+}
+
+export interface UsageCost {
+	/** Cost amount (e.g., 0.0025) */
+	amount: number;
+	/** Currency code (e.g., "USD") */
+	currency: string;
+}
+
+// ============================================================================
+// Config Option Update
+// ============================================================================
+
+/**
+ * Config option update sent by agents when session configuration changes.
+ * Used to notify the client of configuration changes that occurred during the session.
+ */
+export interface ConfigOptionUpdate {
+	/** The configuration option that changed */
+	key: string;
+	/** The new value for the configuration option */
+	value: unknown;
 }
 
 // ============================================================================

--- a/src/main/acp/types.ts
+++ b/src/main/acp/types.ts
@@ -207,11 +207,31 @@ export interface Annotations {
 
 export type Role = 'assistant' | 'user';
 
+/**
+ * ContentBlock represents a unit of content in prompts and responses.
+ *
+ * Note: There are two formats in use:
+ * 1. Spec format (nested): { text: { text: 'content' } }
+ * 2. OpenCode format (flat): { type: 'text', text: 'content' }
+ *
+ * We define the spec format here. The flat format is handled via type casting
+ * in acp-client.ts for OpenCode compatibility.
+ */
 export type ContentBlock =
 	| { text: TextContent }
 	| { image: ImageContent }
 	| { resource_link: ResourceLink }
 	| { resource: EmbeddedResource };
+
+/**
+ * Alternative flat format used by some agents (e.g., OpenCode).
+ * Use this for agents that expect { type: 'text', text: '...' } instead of { text: { text: '...' } }
+ */
+export type ContentBlockFlat =
+	| { type: 'text'; text: string }
+	| { type: 'image'; data: string; mimeType: string }
+	| { type: 'resource_link'; uri: string; name: string }
+	| { type: 'resource'; resource: TextResourceContents | BlobResourceContents };
 
 // ============================================================================
 // Prompt

--- a/src/main/acp/types.ts
+++ b/src/main/acp/types.ts
@@ -12,29 +12,29 @@
 export type RequestId = string | number | null;
 
 export interface JsonRpcRequest {
-  jsonrpc: '2.0';
-  id: RequestId;
-  method: string;
-  params?: unknown;
+	jsonrpc: '2.0';
+	id: RequestId;
+	method: string;
+	params?: unknown;
 }
 
 export interface JsonRpcResponse {
-  jsonrpc: '2.0';
-  id: RequestId;
-  result?: unknown;
-  error?: JsonRpcError;
+	jsonrpc: '2.0';
+	id: RequestId;
+	result?: unknown;
+	error?: JsonRpcError;
 }
 
 export interface JsonRpcNotification {
-  jsonrpc: '2.0';
-  method: string;
-  params?: unknown;
+	jsonrpc: '2.0';
+	method: string;
+	params?: unknown;
 }
 
 export interface JsonRpcError {
-  code: number;
-  message: string;
-  data?: unknown;
+	code: number;
+	message: string;
+	data?: unknown;
 }
 
 // ============================================================================
@@ -49,9 +49,9 @@ export const CURRENT_PROTOCOL_VERSION: ProtocolVersion = 1;
 // ============================================================================
 
 export interface Implementation {
-  name: string;
-  version: string;
-  title?: string;
+	name: string;
+	version: string;
+	title?: string;
 }
 
 // ============================================================================
@@ -59,25 +59,25 @@ export interface Implementation {
 // ============================================================================
 
 export interface ClientCapabilities {
-  fs?: {
-    readTextFile?: boolean;
-    writeTextFile?: boolean;
-  };
-  terminal?: boolean;
+	fs?: {
+		readTextFile?: boolean;
+		writeTextFile?: boolean;
+	};
+	terminal?: boolean;
 }
 
 export interface AgentCapabilities {
-  loadSession?: boolean;
-  mcpCapabilities?: {
-    http?: boolean;
-    sse?: boolean;
-  };
-  promptCapabilities?: {
-    audio?: boolean;
-    embeddedContext?: boolean;
-    image?: boolean;
-  };
-  sessionCapabilities?: Record<string, unknown>;
+	loadSession?: boolean;
+	mcpCapabilities?: {
+		http?: boolean;
+		sse?: boolean;
+	};
+	promptCapabilities?: {
+		audio?: boolean;
+		embeddedContext?: boolean;
+		image?: boolean;
+	};
+	sessionCapabilities?: Record<string, unknown>;
 }
 
 // ============================================================================
@@ -85,22 +85,22 @@ export interface AgentCapabilities {
 // ============================================================================
 
 export interface InitializeRequest {
-  protocolVersion: ProtocolVersion;
-  clientInfo?: Implementation;
-  clientCapabilities?: ClientCapabilities;
+	protocolVersion: ProtocolVersion;
+	clientInfo?: Implementation;
+	clientCapabilities?: ClientCapabilities;
 }
 
 export interface InitializeResponse {
-  protocolVersion: ProtocolVersion;
-  agentInfo?: Implementation;
-  agentCapabilities?: AgentCapabilities;
-  authMethods?: AuthMethod[];
+	protocolVersion: ProtocolVersion;
+	agentInfo?: Implementation;
+	agentCapabilities?: AgentCapabilities;
+	authMethods?: AuthMethod[];
 }
 
 export interface AuthMethod {
-  id: string;
-  name: string;
-  description?: string;
+	id: string;
+	name: string;
+	description?: string;
 }
 
 // ============================================================================
@@ -110,50 +110,50 @@ export interface AuthMethod {
 export type SessionId = string;
 
 export interface McpServerStdio {
-  name: string;
-  command: string;
-  args: string[];
-  env: EnvVariable[];
+	name: string;
+	command: string;
+	args: string[];
+	env: EnvVariable[];
 }
 
 export interface EnvVariable {
-  name: string;
-  value: string;
+	name: string;
+	value: string;
 }
 
 export type McpServer = { stdio: McpServerStdio };
 
 export interface NewSessionRequest {
-  cwd: string;
-  mcpServers: McpServer[];
+	cwd: string;
+	mcpServers: McpServer[];
 }
 
 export interface NewSessionResponse {
-  sessionId: SessionId;
-  modes?: SessionModeState;
+	sessionId: SessionId;
+	modes?: SessionModeState;
 }
 
 export interface LoadSessionRequest {
-  sessionId: SessionId;
-  cwd: string;
-  mcpServers: McpServer[];
+	sessionId: SessionId;
+	cwd: string;
+	mcpServers: McpServer[];
 }
 
 export interface LoadSessionResponse {
-  modes?: SessionModeState;
+	modes?: SessionModeState;
 }
 
 export interface SessionModeState {
-  availableModes: SessionMode[];
-  currentModeId: SessionModeId;
+	availableModes: SessionMode[];
+	currentModeId: SessionModeId;
 }
 
 export type SessionModeId = string;
 
 export interface SessionMode {
-  id: SessionModeId;
-  name: string;
-  description?: string;
+	id: SessionModeId;
+	name: string;
+	description?: string;
 }
 
 // ============================================================================
@@ -161,81 +161,76 @@ export interface SessionMode {
 // ============================================================================
 
 export interface TextContent {
-  text: string;
-  annotations?: Annotations;
+	text: string;
+	annotations?: Annotations;
 }
 
 export interface ImageContent {
-  data: string;
-  mimeType: string;
-  uri?: string;
-  annotations?: Annotations;
+	data: string;
+	mimeType: string;
+	uri?: string;
+	annotations?: Annotations;
 }
 
 export interface ResourceLink {
-  uri: string;
-  name: string;
-  mimeType?: string;
-  description?: string;
-  title?: string;
-  size?: number;
-  annotations?: Annotations;
+	uri: string;
+	name: string;
+	mimeType?: string;
+	description?: string;
+	title?: string;
+	size?: number;
+	annotations?: Annotations;
 }
 
 export interface EmbeddedResource {
-  resource: TextResourceContents | BlobResourceContents;
-  annotations?: Annotations;
+	resource: TextResourceContents | BlobResourceContents;
+	annotations?: Annotations;
 }
 
 export interface TextResourceContents {
-  uri: string;
-  text: string;
-  mimeType?: string;
+	uri: string;
+	text: string;
+	mimeType?: string;
 }
 
 export interface BlobResourceContents {
-  uri: string;
-  blob: string;
-  mimeType?: string;
+	uri: string;
+	blob: string;
+	mimeType?: string;
 }
 
 export interface Annotations {
-  audience?: Role[];
-  lastModified?: string;
-  priority?: number;
+	audience?: Role[];
+	lastModified?: string;
+	priority?: number;
 }
 
 export type Role = 'assistant' | 'user';
 
 export type ContentBlock =
-  | { text: TextContent }
-  | { image: ImageContent }
-  | { resource_link: ResourceLink }
-  | { resource: EmbeddedResource };
+	| { text: TextContent }
+	| { image: ImageContent }
+	| { resource_link: ResourceLink }
+	| { resource: EmbeddedResource };
 
 // ============================================================================
 // Prompt
 // ============================================================================
 
 export interface PromptRequest {
-  sessionId: SessionId;
-  prompt: ContentBlock[];
+	sessionId: SessionId;
+	prompt: ContentBlock[];
 }
 
-export type StopReason =
-  | 'end_turn'
-  | 'max_tokens'
-  | 'max_turn_requests'
-  | 'refusal'
-  | 'cancelled';
+export type StopReason = 'end_turn' | 'max_tokens' | 'max_turn_requests' | 'refusal' | 'cancelled';
 
 export interface PromptResponse {
-  stopReason: StopReason;
-  usage?: {
-    inputTokens?: number;
-    outputTokens?: number;
-    totalTokens?: number;
-  };
+	stopReason: StopReason;
+	usage?: {
+		inputTokens?: number;
+		outputTokens?: number;
+		totalTokens?: number;
+	};
 }
 
 // ============================================================================
@@ -243,22 +238,22 @@ export interface PromptResponse {
 // ============================================================================
 
 export interface SessionNotification {
-  sessionId: SessionId;
-  update: SessionUpdate;
+	sessionId: SessionId;
+	update: SessionUpdate;
 }
 
 export type SessionUpdate =
-  | { user_message_chunk: ContentChunk }
-  | { agent_message_chunk: ContentChunk }
-  | { agent_thought_chunk: ContentChunk }
-  | { tool_call: ToolCall }
-  | { tool_call_update: ToolCallUpdate }
-  | { plan: Plan }
-  | { available_commands_update: AvailableCommandsUpdate }
-  | { current_mode_update: CurrentModeUpdate };
+	| { user_message_chunk: ContentChunk }
+	| { agent_message_chunk: ContentChunk }
+	| { agent_thought_chunk: ContentChunk }
+	| { tool_call: ToolCall }
+	| { tool_call_update: ToolCallUpdate }
+	| { plan: Plan }
+	| { available_commands_update: AvailableCommandsUpdate }
+	| { current_mode_update: CurrentModeUpdate };
 
 export interface ContentChunk {
-  content: ContentBlock;
+	content: ContentBlock;
 }
 
 // ============================================================================
@@ -268,59 +263,59 @@ export interface ContentChunk {
 export type ToolCallId = string;
 
 export type ToolKind =
-  | 'read'
-  | 'edit'
-  | 'delete'
-  | 'move'
-  | 'search'
-  | 'execute'
-  | 'think'
-  | 'fetch'
-  | 'switch_mode'
-  | 'other';
+	| 'read'
+	| 'edit'
+	| 'delete'
+	| 'move'
+	| 'search'
+	| 'execute'
+	| 'think'
+	| 'fetch'
+	| 'switch_mode'
+	| 'other';
 
 export type ToolCallStatus = 'pending' | 'in_progress' | 'completed' | 'failed';
 
 export interface ToolCall {
-  toolCallId: ToolCallId;
-  title: string;
-  kind?: ToolKind;
-  status?: ToolCallStatus;
-  rawInput?: unknown;
-  rawOutput?: unknown;
-  content?: ToolCallContent[];
-  locations?: ToolCallLocation[];
+	toolCallId: ToolCallId;
+	title: string;
+	kind?: ToolKind;
+	status?: ToolCallStatus;
+	rawInput?: unknown;
+	rawOutput?: unknown;
+	content?: ToolCallContent[];
+	locations?: ToolCallLocation[];
 }
 
 export interface ToolCallUpdate {
-  toolCallId: ToolCallId;
-  title?: string;
-  kind?: ToolKind;
-  status?: ToolCallStatus;
-  rawInput?: unknown;
-  rawOutput?: unknown;
-  content?: ToolCallContent[];
-  locations?: ToolCallLocation[];
+	toolCallId: ToolCallId;
+	title?: string;
+	kind?: ToolKind;
+	status?: ToolCallStatus;
+	rawInput?: unknown;
+	rawOutput?: unknown;
+	content?: ToolCallContent[];
+	locations?: ToolCallLocation[];
 }
 
 export type ToolCallContent =
-  | { content: { content: ContentBlock } }
-  | { diff: Diff }
-  | { terminal: Terminal };
+	| { content: { content: ContentBlock } }
+	| { diff: Diff }
+	| { terminal: Terminal };
 
 export interface Diff {
-  path: string;
-  oldText?: string;
-  newText: string;
+	path: string;
+	oldText?: string;
+	newText: string;
 }
 
 export interface Terminal {
-  terminalId: string;
+	terminalId: string;
 }
 
 export interface ToolCallLocation {
-  path: string;
-  line?: number;
+	path: string;
+	line?: number;
 }
 
 // ============================================================================
@@ -328,13 +323,13 @@ export interface ToolCallLocation {
 // ============================================================================
 
 export interface Plan {
-  entries: PlanEntry[];
+	entries: PlanEntry[];
 }
 
 export interface PlanEntry {
-  content: string;
-  priority: PlanEntryPriority;
-  status: PlanEntryStatus;
+	content: string;
+	priority: PlanEntryPriority;
+	status: PlanEntryStatus;
 }
 
 export type PlanEntryPriority = 'high' | 'medium' | 'low';
@@ -345,21 +340,21 @@ export type PlanEntryStatus = 'pending' | 'in_progress' | 'completed';
 // ============================================================================
 
 export interface AvailableCommandsUpdate {
-  availableCommands: AvailableCommand[];
+	availableCommands: AvailableCommand[];
 }
 
 export interface AvailableCommand {
-  name: string;
-  description: string;
-  input?: AvailableCommandInput;
+	name: string;
+	description: string;
+	input?: AvailableCommandInput;
 }
 
 export interface AvailableCommandInput {
-  hint: string;
+	hint: string;
 }
 
 export interface CurrentModeUpdate {
-  currentModeId: SessionModeId;
+	currentModeId: SessionModeId;
 }
 
 // ============================================================================
@@ -367,51 +362,51 @@ export interface CurrentModeUpdate {
 // ============================================================================
 
 export interface RequestPermissionRequest {
-  sessionId: SessionId;
-  toolCall: ToolCallUpdate;
-  options: PermissionOption[];
+	sessionId: SessionId;
+	toolCall: ToolCallUpdate;
+	options: PermissionOption[];
 }
 
 export interface PermissionOption {
-  optionId: PermissionOptionId;
-  name: string;
-  kind: PermissionOptionKind;
+	optionId: PermissionOptionId;
+	name: string;
+	kind: PermissionOptionKind;
 }
 
 export type PermissionOptionId = string;
 export type PermissionOptionKind = 'allow_once' | 'allow_always' | 'reject_once' | 'reject_always';
 
 export interface RequestPermissionResponse {
-  outcome: RequestPermissionOutcome;
+	outcome: RequestPermissionOutcome;
 }
 
 export type RequestPermissionOutcome =
-  | { cancelled: Record<string, never> }
-  | { selected: { optionId: PermissionOptionId } };
+	| { cancelled: Record<string, never> }
+	| { selected: { optionId: PermissionOptionId } };
 
 // ============================================================================
 // File System (Client methods)
 // ============================================================================
 
 export interface ReadTextFileRequest {
-  sessionId: SessionId;
-  path: string;
-  line?: number;
-  limit?: number;
+	sessionId: SessionId;
+	path: string;
+	line?: number;
+	limit?: number;
 }
 
 export interface ReadTextFileResponse {
-  content: string;
+	content: string;
 }
 
 export interface WriteTextFileRequest {
-  sessionId: SessionId;
-  path: string;
-  content: string;
+	sessionId: SessionId;
+	path: string;
+	content: string;
 }
 
 export interface WriteTextFileResponse {
-  // Empty response
+	// Empty response
 }
 
 // ============================================================================
@@ -419,32 +414,32 @@ export interface WriteTextFileResponse {
 // ============================================================================
 
 export interface CreateTerminalRequest {
-  sessionId: SessionId;
-  command: string;
-  args?: string[];
-  cwd?: string;
-  env?: EnvVariable[];
-  outputByteLimit?: number;
+	sessionId: SessionId;
+	command: string;
+	args?: string[];
+	cwd?: string;
+	env?: EnvVariable[];
+	outputByteLimit?: number;
 }
 
 export interface CreateTerminalResponse {
-  terminalId: string;
+	terminalId: string;
 }
 
 export interface TerminalOutputRequest {
-  sessionId: SessionId;
-  terminalId: string;
+	sessionId: SessionId;
+	terminalId: string;
 }
 
 export interface TerminalOutputResponse {
-  output: string;
-  truncated: boolean;
-  exitStatus?: TerminalExitStatus;
+	output: string;
+	truncated: boolean;
+	exitStatus?: TerminalExitStatus;
 }
 
 export interface TerminalExitStatus {
-  exitCode?: number;
-  signal?: string;
+	exitCode?: number;
+	signal?: string;
 }
 
 // ============================================================================
@@ -452,5 +447,5 @@ export interface TerminalExitStatus {
 // ============================================================================
 
 export interface CancelNotification {
-  sessionId: SessionId;
+	sessionId: SessionId;
 }

--- a/src/main/acp/version.ts
+++ b/src/main/acp/version.ts
@@ -1,0 +1,34 @@
+/**
+ * Version utility for ACP module
+ *
+ * Provides a safe way to get the Maestro app version that works
+ * in both Electron main process and test environments.
+ */
+
+/**
+ * Get the Maestro app version.
+ * Falls back to package.json version if Electron app is not available.
+ */
+export function getAppVersion(): string {
+	try {
+		// Try to get version from Electron app
+		// eslint-disable-next-line @typescript-eslint/no-require-imports
+		const { app } = require('electron');
+		if (app && typeof app.getVersion === 'function') {
+			return app.getVersion();
+		}
+	} catch {
+		// Electron not available (e.g., in tests)
+	}
+
+	try {
+		// Fall back to package.json
+		// eslint-disable-next-line @typescript-eslint/no-require-imports
+		const pkg = require('../../../package.json');
+		return pkg.version || '0.0.0';
+	} catch {
+		// Package.json not available
+	}
+
+	return '0.0.0';
+}

--- a/src/main/agents/capabilities.ts
+++ b/src/main/agents/capabilities.ts
@@ -234,8 +234,9 @@ export const AGENT_CAPABILITIES: Record<string, AgentCapabilities> = {
 	/**
 	 * Gemini CLI - Google's Gemini model CLI
 	 *
-	 * PLACEHOLDER: Most capabilities set to false until Gemini CLI is stable
-	 * and can be tested. Update this configuration when integrating the agent.
+	 * ACP support verified via @agentclientprotocol/sdk v0.16.1, protocol version 1.
+	 * Listed on agentclientprotocol.com. Uses `gemini --acp` flag to enable ACP mode.
+	 * Requires authentication call between initialize and session/new.
 	 */
 	'gemini-cli': {
 		supportsResume: false,
@@ -261,7 +262,7 @@ export const AGENT_CAPABILITIES: Record<string, AgentCapabilities> = {
 		supportsGroupChatModeration: false, // PLACEHOLDER
 		usesJsonLineOutput: false, // PLACEHOLDER
 		usesCombinedContextWindow: false, // PLACEHOLDER
-		supportsACP: false, // PLACEHOLDER
+		supportsACP: true, // Gemini CLI supports ACP via @agentclientprotocol/sdk
 	},
 
 	/**

--- a/src/main/agents/capabilities.ts
+++ b/src/main/agents/capabilities.ts
@@ -82,6 +82,9 @@ export interface AgentCapabilities {
 	/** Agent uses a combined input+output context window (vs separate limits) */
 	usesCombinedContextWindow: boolean;
 
+	/** Agent supports Agent Client Protocol (ACP) for JSON-RPC communication */
+	supportsACP: boolean;
+
 	/** How images should be handled on resume when -i flag is not available.
 	 * 'prompt-embed': Save images to temp files and embed file paths in the prompt text.
 	 * undefined: Use default image handling (or no special resume handling needed). */
@@ -116,6 +119,7 @@ export const DEFAULT_CAPABILITIES: AgentCapabilities = {
 	supportsGroupChatModeration: false,
 	usesJsonLineOutput: false,
 	usesCombinedContextWindow: false,
+	supportsACP: false,
 };
 
 /**
@@ -158,6 +162,7 @@ export const AGENT_CAPABILITIES: Record<string, AgentCapabilities> = {
 		supportsGroupChatModeration: true, // Can serve as group chat moderator
 		usesJsonLineOutput: false, // Uses stream-json, not JSONL
 		usesCombinedContextWindow: false, // Claude has separate input/output limits
+		supportsACP: false, // Claude Code uses stream-json output format
 	},
 
 	/**
@@ -188,6 +193,7 @@ export const AGENT_CAPABILITIES: Record<string, AgentCapabilities> = {
 		supportsGroupChatModeration: false,
 		usesJsonLineOutput: false,
 		usesCombinedContextWindow: false,
+		supportsACP: false, // Terminal is not an AI agent
 	},
 
 	/**
@@ -221,6 +227,7 @@ export const AGENT_CAPABILITIES: Record<string, AgentCapabilities> = {
 		supportsGroupChatModeration: true, // Can serve as group chat moderator
 		usesJsonLineOutput: true, // Uses JSONL output format
 		usesCombinedContextWindow: true, // OpenAI models use combined context window
+		supportsACP: false, // Codex uses JSONL output format
 		imageResumeMode: 'prompt-embed', // codex exec resume doesn't support -i; embed file paths in prompt text
 	},
 
@@ -254,6 +261,7 @@ export const AGENT_CAPABILITIES: Record<string, AgentCapabilities> = {
 		supportsGroupChatModeration: false, // PLACEHOLDER
 		usesJsonLineOutput: false, // PLACEHOLDER
 		usesCombinedContextWindow: false, // PLACEHOLDER
+		supportsACP: false, // PLACEHOLDER
 	},
 
 	/**
@@ -286,6 +294,7 @@ export const AGENT_CAPABILITIES: Record<string, AgentCapabilities> = {
 		supportsGroupChatModeration: false, // PLACEHOLDER
 		usesJsonLineOutput: false, // PLACEHOLDER
 		usesCombinedContextWindow: false, // PLACEHOLDER
+		supportsACP: false, // PLACEHOLDER
 	},
 
 	/**
@@ -319,6 +328,7 @@ export const AGENT_CAPABILITIES: Record<string, AgentCapabilities> = {
 		supportsGroupChatModeration: true, // Can serve as group chat moderator
 		usesJsonLineOutput: true, // Uses JSONL output format
 		usesCombinedContextWindow: false, // Depends on model provider
+		supportsACP: true, // OpenCode supports Agent Client Protocol
 	},
 
 	/**
@@ -351,6 +361,7 @@ export const AGENT_CAPABILITIES: Record<string, AgentCapabilities> = {
 		supportsGroupChatModeration: true, // Can serve as group chat moderator
 		usesJsonLineOutput: true, // Uses JSONL output format
 		usesCombinedContextWindow: false, // Depends on model provider
+		supportsACP: false, // Factory Droid uses JSONL output format
 	},
 
 	/**
@@ -384,6 +395,7 @@ export const AGENT_CAPABILITIES: Record<string, AgentCapabilities> = {
 		supportsGroupChatModeration: false, // PLACEHOLDER
 		usesJsonLineOutput: false, // PLACEHOLDER
 		usesCombinedContextWindow: false, // PLACEHOLDER
+		supportsACP: false, // PLACEHOLDER
 	},
 };
 

--- a/src/main/agents/definitions.ts
+++ b/src/main/agents/definitions.ts
@@ -305,6 +305,22 @@ export const AGENT_DEFINITIONS: AgentDefinition[] = [
 					'Maximum context window size in tokens. Required for context usage display. Varies by model (e.g., 400000 for Claude/GPT-5.2, 128000 for GPT-4o).',
 				default: 128000, // Default for common models (GPT-4, etc.)
 			},
+			{
+				key: 'useACP',
+				type: 'checkbox',
+				label: 'Use ACP Protocol',
+				description:
+					'Use the Agent Client Protocol (ACP) for communication instead of JSON output parsing. ACP provides a standardized protocol for agent communication.',
+				default: false, // Opt-in for now, will become default once stable
+			},
+			{
+				key: 'acpShowStreaming',
+				type: 'checkbox',
+				label: 'Show Streaming Output',
+				description:
+					'Show streaming text output in real-time when using ACP mode. Disable for cleaner output with only the final result.',
+				default: true, // Show streaming by default for better UX
+			},
 		],
 	},
 	{

--- a/src/main/agents/definitions.ts
+++ b/src/main/agents/definitions.ts
@@ -99,6 +99,8 @@ export interface AgentConfig {
 	defaultEnvVars?: Record<string, string>; // Default environment variables for this agent (merged with user customEnvVars)
 	readOnlyEnvOverrides?: Record<string, string>; // Env var overrides applied in read-only mode (replaces keys from defaultEnvVars)
 	readOnlyCliEnforced?: boolean; // Whether the agent's CLI enforces read-only mode (false = prompt-only enforcement)
+	/** ACP-specific args that enable the agent's ACP mode (e.g., ['acp'] for OpenCode, ['--acp'] for Gemini CLI) */
+	acpArgs?: string[];
 }
 
 /**
@@ -208,6 +210,8 @@ export const AGENT_DEFINITIONS: AgentDefinition[] = [
 		imageArgs: undefined,
 		modelArgs: (modelId: string) => ['-m', modelId],
 		promptArgs: (prompt: string) => ['-p', prompt],
+		// ACP mode: gemini --acp (uses '--acp' flag, not 'acp' subcommand)
+		acpArgs: ['--acp'],
 		configOptions: [
 			{
 				key: 'model',
@@ -236,6 +240,22 @@ export const AGENT_DEFINITIONS: AgentDefinition[] = [
 				description:
 					'Maximum context window size in tokens. Common values: 1048576 (Gemini 2.5 Pro), 32767 (Gemini 2.5 Flash).',
 				default: 1048576,
+			},
+			{
+				key: 'useACP',
+				type: 'checkbox' as const,
+				label: 'Use ACP Protocol',
+				description:
+					'Use the Agent Client Protocol (ACP) for communication instead of JSON output parsing. ACP provides a standardized protocol for agent communication.',
+				default: false, // Opt-in for now
+			},
+			{
+				key: 'acpShowStreaming',
+				type: 'checkbox' as const,
+				label: 'Show Streaming Output',
+				description:
+					'Show streaming text output in real-time when using ACP mode. Disable for cleaner output with only the final result.',
+				default: true, // Show streaming by default
 			},
 		],
 	},
@@ -280,6 +300,8 @@ export const AGENT_DEFINITIONS: AgentDefinition[] = [
 		readOnlyEnvOverrides: {
 			OPENCODE_CONFIG_CONTENT: '{"permission":{"question":"deny"},"tools":{"question":false}}',
 		},
+		// ACP mode: opencode acp (uses 'acp' subcommand)
+		acpArgs: ['acp'],
 		// Agent-specific configuration options shown in UI
 		configOptions: [
 			{

--- a/src/main/ipc/handlers/process.ts
+++ b/src/main/ipc/handlers/process.ts
@@ -525,6 +525,7 @@ export function registerProcessHandlers(deps: ProcessHandlerDependencies): void 
 						useACP: true,
 						acpShowStreaming,
 						acpSessionId: config.agentSessionId, // For session resume
+						acpArgs: agent?.acpArgs, // Agent-specific ACP args (e.g., ['acp'] for OpenCode, ['--acp'] for Gemini CLI)
 					});
 
 					logger.info(`ACP process spawned successfully`, LOG_CONTEXT, {

--- a/src/main/ipc/handlers/process.ts
+++ b/src/main/ipc/handlers/process.ts
@@ -299,6 +299,21 @@ export function registerProcessHandlers(deps: ProcessHandlerDependencies): void 
 				);
 
 				// ========================================================================
+				// ACP Mode Detection: Check if agent supports ACP and it's enabled
+				// ACP provides a standardized JSON-RPC protocol for agent communication
+				// ========================================================================
+				const useACP =
+					agent?.capabilities?.supportsACP && (agentConfigValues.useACP === true || false);
+				const acpShowStreaming = agentConfigValues.acpShowStreaming !== false; // Default to true
+
+				if (useACP) {
+					logger.info(`Using ACP mode for ${config.toolType}`, LOG_CONTEXT, {
+						sessionId: config.sessionId,
+						acpShowStreaming,
+					});
+				}
+
+				// ========================================================================
 				// Command Resolution: Apply session-level custom path override if set
 				// This allows users to override the detected agent path per-session
 				//
@@ -494,6 +509,36 @@ export function registerProcessHandlers(deps: ProcessHandlerDependencies): void 
 					isSshCommand: !!sshRemoteUsed,
 					globalEnvVarsCount: Object.keys(globalShellEnvVars).length,
 				});
+
+				// For ACP mode, we need to use spawnAsync since ACP initialization is async
+				if (useACP && !sshRemoteUsed) {
+					const result = await processManager.spawnAsync({
+						...config,
+						command: commandToSpawn,
+						args: argsToSpawn,
+						cwd: config.cwd,
+						requiresPty: false, // ACP doesn't use PTY
+						prompt: config.prompt,
+						contextWindow,
+						customEnvVars: customEnvVarsToPass,
+						projectPath: config.cwd,
+						useACP: true,
+						acpShowStreaming,
+						acpSessionId: config.agentSessionId, // For session resume
+					});
+
+					logger.info(`ACP process spawned successfully`, LOG_CONTEXT, {
+						sessionId: config.sessionId,
+						pid: result.pid,
+						useACP: true,
+						acpShowStreaming,
+					});
+
+					// Add power block reason for AI sessions
+					powerManager.addBlockReason(`session:${config.sessionId}`);
+
+					return result;
+				}
 
 				const result = processManager.spawn({
 					...config,

--- a/src/main/parsers/error-patterns.ts
+++ b/src/main/parsers/error-patterns.ts
@@ -674,6 +674,209 @@ const FACTORY_DROID_ERROR_PATTERNS: AgentErrorPatterns = {
 };
 
 // ============================================================================
+// Gemini CLI Error Patterns
+// ============================================================================
+
+const GEMINI_CLI_ERROR_PATTERNS: AgentErrorPatterns = {
+	auth_expired: [
+		{
+			// Google OAuth authentication failure
+			pattern: /google.*auth.*fail|oauth.*fail|oauth.*error/i,
+			message: 'Google authentication failed. Please re-authenticate with Google.',
+			recoverable: true,
+		},
+		{
+			// API key not set or invalid
+			pattern: /GOOGLE_API_KEY/i,
+			message: 'Google API key not set. Please set GOOGLE_API_KEY environment variable.',
+			recoverable: true,
+		},
+		{
+			// Cloud project not configured
+			pattern: /GOOGLE_CLOUD_PROJECT/i,
+			message:
+				'Google Cloud project not configured. Please set GOOGLE_CLOUD_PROJECT environment variable.',
+			recoverable: true,
+		},
+		{
+			pattern: /invalid.*api.*key/i,
+			message: 'Invalid API key. Please check your Google credentials.',
+			recoverable: true,
+		},
+		{
+			pattern: /authentication.*failed/i,
+			message: 'Authentication failed. Please verify your Google credentials.',
+			recoverable: true,
+		},
+		{
+			pattern: /unauthorized/i,
+			message: 'Unauthorized access. Please check your Google API key or OAuth token.',
+			recoverable: true,
+		},
+		{
+			// API 401 from Google
+			pattern: /api.*error:\s*401|status.*code.*401/i,
+			message: 'Authentication failed (401). Please re-authenticate with Google.',
+			recoverable: true,
+		},
+		{
+			pattern: /api.*key.*expired/i,
+			message: 'Your API key has expired. Please renew your Google credentials.',
+			recoverable: true,
+		},
+		{
+			// Google-specific login prompt
+			pattern: /please.*log\s*in|please.*authenticate|login required/i,
+			message: 'Authentication required. Please log in to Google.',
+			recoverable: true,
+		},
+	],
+
+	token_exhaustion: [
+		{
+			pattern: /context.*exceeded/i,
+			message: 'Context limit exceeded. Start a new session.',
+			recoverable: true,
+		},
+		{
+			pattern: /maximum.*tokens/i,
+			message: 'Maximum token limit reached. Start a new session.',
+			recoverable: true,
+		},
+		{
+			pattern: /token.*limit/i,
+			message: 'Token limit reached. Consider starting a fresh conversation.',
+			recoverable: true,
+		},
+		{
+			pattern: /prompt.*too\s+long/i,
+			message: 'Prompt is too long. Try a shorter message or start a new session.',
+			recoverable: true,
+		},
+		{
+			pattern: /input.*too large/i,
+			message: 'Input is too large for the context window.',
+			recoverable: true,
+		},
+	],
+
+	rate_limited: [
+		{
+			pattern: /rate.*limit/i,
+			message: 'Rate limit exceeded. Please wait before trying again.',
+			recoverable: true,
+		},
+		{
+			pattern: /too many requests/i,
+			message: 'Too many requests. Please wait before sending more messages.',
+			recoverable: true,
+		},
+		{
+			pattern: /quota.*exceeded/i,
+			message: 'Your API quota has been exceeded. Resume when quota resets.',
+			recoverable: true,
+		},
+		{
+			// HTTP 429 - Rate limited
+			pattern: /\b429\b/,
+			message: 'Rate limited. Please wait and try again.',
+			recoverable: true,
+		},
+		{
+			// Google-specific: RESOURCE_EXHAUSTED gRPC error
+			pattern: /RESOURCE_EXHAUSTED/i,
+			message: 'Google API resource exhausted. Please wait and try again.',
+			recoverable: true,
+		},
+		{
+			pattern: /usage.?limit|hit your.*limit/i,
+			message: 'Usage limit reached. Please wait or check your plan quota.',
+			recoverable: true,
+		},
+	],
+
+	network_error: [
+		{
+			pattern: /connection\s*(failed|refused|error|reset|closed)/i,
+			message: 'Connection failed. Check your internet connection.',
+			recoverable: true,
+		},
+		{
+			pattern: /ECONNREFUSED|ECONNRESET|ETIMEDOUT|ENOTFOUND/i,
+			message: 'Network error. Check your internet connection.',
+			recoverable: true,
+		},
+		{
+			pattern: /request\s+timed?\s*out|timed?\s*out\s+waiting/i,
+			message: 'Request timed out. Please try again.',
+			recoverable: true,
+		},
+		{
+			pattern: /network\s+(error|failure|unavailable)/i,
+			message: 'Network error occurred. Please check your connection.',
+			recoverable: true,
+		},
+		{
+			// Google-specific: UNAVAILABLE gRPC error
+			pattern: /UNAVAILABLE/i,
+			message: 'Google API service unavailable. Please try again later.',
+			recoverable: true,
+		},
+	],
+
+	permission_denied: [
+		{
+			pattern: /permission denied/i,
+			message: 'Permission denied. The agent cannot access the requested resource.',
+			recoverable: false,
+		},
+		{
+			pattern: /access denied/i,
+			message: 'Access denied to the requested resource.',
+			recoverable: false,
+		},
+		{
+			// Google-specific: PERMISSION_DENIED gRPC error
+			pattern: /PERMISSION_DENIED/i,
+			message: 'Google API permission denied. Check your project permissions.',
+			recoverable: false,
+		},
+		{
+			pattern: /\b403\b.*forbidden|\bforbidden\b.*\b403\b/i,
+			message: 'Forbidden. You may need additional Google Cloud permissions.',
+			recoverable: false,
+		},
+	],
+
+	agent_crashed: [
+		{
+			pattern: /\b(fatal|unexpected|internal|unhandled)\s+error\b/i,
+			message: 'An unexpected error occurred in the agent.',
+			recoverable: true,
+		},
+		{
+			// Google-specific: INTERNAL gRPC error
+			pattern: /\bINTERNAL\b/,
+			message: 'Google API internal error. Please try again.',
+			recoverable: true,
+		},
+	],
+
+	session_not_found: [
+		{
+			pattern: /session.*not found/i,
+			message: 'Session not found. Starting fresh conversation.',
+			recoverable: true,
+		},
+		{
+			pattern: /invalid.*session/i,
+			message: 'Invalid session. Starting fresh conversation.',
+			recoverable: true,
+		},
+	],
+};
+
+// ============================================================================
 // SSH Error Patterns
 // ============================================================================
 
@@ -864,6 +1067,7 @@ const patternRegistry = new Map<ToolType, AgentErrorPatterns>([
 	['opencode', OPENCODE_ERROR_PATTERNS],
 	['codex', CODEX_ERROR_PATTERNS],
 	['factory-droid', FACTORY_DROID_ERROR_PATTERNS],
+	['gemini-cli', GEMINI_CLI_ERROR_PATTERNS],
 ]);
 
 /**

--- a/src/main/process-manager/ProcessManager.ts
+++ b/src/main/process-manager/ProcessManager.ts
@@ -12,6 +12,7 @@ import type {
 } from './types';
 import { PtySpawner } from './spawners/PtySpawner';
 import { ChildProcessSpawner } from './spawners/ChildProcessSpawner';
+import { AcpSpawner } from './spawners/AcpSpawner';
 import { DataBufferManager } from './handlers/DataBufferManager';
 import { LocalCommandRunner } from './runners/LocalCommandRunner';
 import { SshCommandRunner } from './runners/SshCommandRunner';
@@ -23,7 +24,7 @@ import type { SshRemoteConfig } from '../../shared/types';
  * ProcessManager orchestrates spawning and managing processes for sessions.
  *
  * Responsibilities:
- * - Spawn PTY and child processes
+ * - Spawn PTY, child processes, and ACP processes
  * - Route data events from processes
  * - Provide process lifecycle management (write, resize, interrupt, kill)
  * - Execute commands (local and SSH remote)
@@ -33,6 +34,7 @@ export class ProcessManager extends EventEmitter {
 	private bufferManager: DataBufferManager;
 	private ptySpawner: PtySpawner;
 	private childProcessSpawner: ChildProcessSpawner;
+	private acpSpawner: AcpSpawner;
 	private localCommandRunner: LocalCommandRunner;
 	private sshCommandRunner: SshCommandRunner;
 
@@ -41,14 +43,38 @@ export class ProcessManager extends EventEmitter {
 		this.bufferManager = new DataBufferManager(this.processes, this);
 		this.ptySpawner = new PtySpawner(this.processes, this, this.bufferManager);
 		this.childProcessSpawner = new ChildProcessSpawner(this.processes, this, this.bufferManager);
+		this.acpSpawner = new AcpSpawner(this.processes, this);
 		this.localCommandRunner = new LocalCommandRunner(this);
 		this.sshCommandRunner = new SshCommandRunner(this);
 	}
 
 	/**
-	 * Spawn a new process for a session
+	 * Spawn a new process for a session.
+	 * Routes to appropriate spawner based on config:
+	 * - ACP mode: AcpSpawner (async)
+	 * - PTY mode: PtySpawner
+	 * - Default: ChildProcessSpawner
 	 */
 	spawn(config: ProcessConfig): SpawnResult {
+		// ACP mode requires async spawning, but we maintain sync interface
+		// for backwards compatibility. The caller should use spawnAsync for ACP.
+		if (config.useACP) {
+			logger.warn(
+				'[ProcessManager] spawn() called with useACP=true, use spawnAsync() instead',
+				'ProcessManager',
+				{ sessionId: config.sessionId }
+			);
+			// Start async spawn but return immediately
+			// The actual result will come via events
+			this.spawnAsync(config).catch((error) => {
+				logger.error('[ProcessManager] ACP spawn failed', 'ProcessManager', {
+					sessionId: config.sessionId,
+					error: String(error),
+				});
+			});
+			return { pid: -1, success: true }; // Placeholder until async completes
+		}
+
 		const usePty = this.shouldUsePty(config);
 
 		if (usePty) {
@@ -56,6 +82,19 @@ export class ProcessManager extends EventEmitter {
 		} else {
 			return this.childProcessSpawner.spawn(config);
 		}
+	}
+
+	/**
+	 * Spawn a new process asynchronously.
+	 * Required for ACP mode which involves async initialization.
+	 */
+	async spawnAsync(config: ProcessConfig): Promise<SpawnResult> {
+		if (config.useACP) {
+			return this.acpSpawner.spawn(config);
+		}
+
+		// For non-ACP, delegate to sync spawn
+		return this.spawn(config);
 	}
 
 	private shouldUsePty(config: ProcessConfig): boolean {
@@ -82,6 +121,15 @@ export class ProcessManager extends EventEmitter {
 					process.lastCommand = command.trim();
 				}
 				process.ptyProcess.write(data);
+				return true;
+			} else if (process.acpProcess) {
+				// ACP mode: write is async, fire and forget
+				process.acpProcess.write(data).catch((error) => {
+					logger.error('[ProcessManager] ACP write failed', 'ProcessManager', {
+						sessionId,
+						error: String(error),
+					});
+				});
 				return true;
 			} else if (process.childProcess?.stdin) {
 				process.childProcess.stdin.write(data);
@@ -132,6 +180,10 @@ export class ProcessManager extends EventEmitter {
 		try {
 			if (process.isTerminal && process.ptyProcess) {
 				process.ptyProcess.write('\x03');
+				return true;
+			} else if (process.acpProcess) {
+				// ACP mode: use the cancel method
+				process.acpProcess.interrupt();
 				return true;
 			} else if (process.childProcess) {
 				const child = process.childProcess;
@@ -206,6 +258,9 @@ export class ProcessManager extends EventEmitter {
 
 			if (process.isTerminal && process.ptyProcess) {
 				process.ptyProcess.kill();
+			} else if (process.acpProcess) {
+				// ACP mode: use the kill method
+				process.acpProcess.kill();
 			} else if (process.childProcess) {
 				const pid = process.childProcess.pid;
 				if (isWindows() && pid) {

--- a/src/main/process-manager/spawners/AcpSpawner.ts
+++ b/src/main/process-manager/spawners/AcpSpawner.ts
@@ -38,6 +38,7 @@ export class AcpSpawner {
 			customEnvVars,
 			acpSessionId,
 			acpShowStreaming = true,
+			acpArgs,
 		} = config;
 
 		logger.info(`${LOG_CONTEXT} Spawning ACP process`, LOG_CONTEXT, {
@@ -61,6 +62,7 @@ export class AcpSpawner {
 				cwd,
 				command,
 				args, // Pass through any custom args (SSH wrapper, etc.)
+				acpArgs, // Agent-specific ACP args (e.g., ['acp'] for OpenCode, ['--acp'] for Gemini CLI)
 				prompt,
 				images: acpImages,
 				acpSessionId,
@@ -69,6 +71,8 @@ export class AcpSpawner {
 				// YOLO mode: auto-approve all permission requests
 				// This matches the behavior of other agents in Maestro
 				autoApprovePermissions: true,
+				// OpenCode uses flat content blocks, other agents use spec format
+				useFlatContentBlocks: toolType === 'opencode',
 			};
 
 			// Create and configure ACP process

--- a/src/main/process-manager/spawners/AcpSpawner.ts
+++ b/src/main/process-manager/spawners/AcpSpawner.ts
@@ -1,0 +1,273 @@
+// src/main/process-manager/spawners/AcpSpawner.ts
+
+import { EventEmitter } from 'events';
+import * as fs from 'fs';
+import * as path from 'path';
+import { logger } from '../../utils/logger';
+import { ACPProcess, type ACPProcessConfig } from '../../acp';
+import type { ProcessConfig, ManagedProcess, SpawnResult, ParsedEvent } from '../types';
+
+const LOG_CONTEXT = '[AcpSpawner]';
+
+/**
+ * Handles spawning of ACP (Agent Client Protocol) processes.
+ * Used for agents that support the ACP protocol like OpenCode.
+ *
+ * ACP provides a standardized JSON-RPC based communication protocol
+ * that eliminates the need for custom output parsers.
+ */
+export class AcpSpawner {
+	constructor(
+		private processes: Map<string, ManagedProcess>,
+		private emitter: EventEmitter
+	) {}
+
+	/**
+	 * Spawn an ACP process for a session
+	 */
+	async spawn(config: ProcessConfig): Promise<SpawnResult> {
+		const {
+			sessionId,
+			toolType,
+			cwd,
+			command,
+			args,
+			prompt,
+			images,
+			contextWindow,
+			customEnvVars,
+			acpSessionId,
+			acpShowStreaming = true,
+		} = config;
+
+		logger.info(`${LOG_CONTEXT} Spawning ACP process`, LOG_CONTEXT, {
+			sessionId,
+			toolType,
+			command,
+			hasPrompt: !!prompt,
+			hasImages: !!(images && images.length > 0),
+			acpSessionId,
+			acpShowStreaming,
+		});
+
+		try {
+			// Convert base64 images to the format expected by ACP
+			const acpImages = await this.convertImages(images);
+
+			// Build ACP process config
+			const acpConfig: ACPProcessConfig = {
+				sessionId,
+				toolType,
+				cwd,
+				command,
+				args, // Pass through any custom args (SSH wrapper, etc.)
+				prompt,
+				images: acpImages,
+				acpSessionId,
+				customEnvVars,
+				contextWindow,
+				// YOLO mode: auto-approve all permission requests
+				// This matches the behavior of other agents in Maestro
+				autoApprovePermissions: true,
+			};
+
+			// Create and configure ACP process
+			const acpProcess = new ACPProcess(acpConfig);
+
+			// Create managed process entry
+			const managedProcess: ManagedProcess = {
+				sessionId,
+				toolType,
+				acpProcess,
+				cwd,
+				pid: -1, // Will be updated after start
+				isTerminal: false,
+				isBatchMode: true,
+				isAcpMode: true,
+				acpShowStreaming,
+				startTime: Date.now(),
+				contextWindow,
+				command,
+				args,
+				querySource: config.querySource,
+				tabId: config.tabId,
+				projectPath: config.projectPath,
+				sshRemoteId: config.sshRemoteId,
+				sshRemoteHost: config.sshRemoteHost,
+			};
+
+			this.processes.set(sessionId, managedProcess);
+
+			// Wire up ACP events to ProcessManager events
+			this.setupEventHandlers(acpProcess, sessionId, acpShowStreaming);
+
+			// Start the ACP process
+			const result = await acpProcess.start();
+
+			// Update PID after start
+			managedProcess.pid = result.pid;
+
+			logger.info(`${LOG_CONTEXT} ACP process started`, LOG_CONTEXT, {
+				sessionId,
+				pid: result.pid,
+				success: result.success,
+			});
+
+			return result;
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			logger.error(`${LOG_CONTEXT} Failed to spawn ACP process: ${message}`, LOG_CONTEXT, {
+				sessionId,
+			});
+
+			// Emit error and exit events
+			this.emitter.emit('agent-error', sessionId, {
+				type: 'unknown',
+				message,
+				recoverable: false,
+			});
+			this.emitter.emit('exit', sessionId, 1);
+
+			return { pid: -1, success: false };
+		}
+	}
+
+	/**
+	 * Convert base64 image strings to ACP image format
+	 */
+	private async convertImages(
+		images?: string[]
+	): Promise<Array<{ data: string; mimeType: string }> | undefined> {
+		if (!images || images.length === 0) {
+			return undefined;
+		}
+
+		const acpImages: Array<{ data: string; mimeType: string }> = [];
+
+		for (const image of images) {
+			// Check if it's a base64 data URL
+			const dataUrlMatch = image.match(/^data:([^;]+);base64,(.+)$/);
+			if (dataUrlMatch) {
+				acpImages.push({
+					mimeType: dataUrlMatch[1],
+					data: dataUrlMatch[2],
+				});
+			} else if (image.startsWith('/') || image.match(/^[A-Za-z]:\\/)) {
+				// It's a file path - read and convert to base64
+				try {
+					const fileBuffer = fs.readFileSync(image);
+					const base64Data = fileBuffer.toString('base64');
+					const ext = path.extname(image).toLowerCase();
+					const mimeType = this.getMimeType(ext);
+					acpImages.push({
+						mimeType,
+						data: base64Data,
+					});
+				} catch (err) {
+					logger.warn(`${LOG_CONTEXT} Failed to read image file: ${image}`, LOG_CONTEXT, {
+						error: String(err),
+					});
+				}
+			} else {
+				// Assume it's raw base64 data
+				acpImages.push({
+					mimeType: 'image/png', // Default to PNG
+					data: image,
+				});
+			}
+		}
+
+		return acpImages.length > 0 ? acpImages : undefined;
+	}
+
+	/**
+	 * Get MIME type from file extension
+	 */
+	private getMimeType(ext: string): string {
+		const mimeTypes: Record<string, string> = {
+			'.png': 'image/png',
+			'.jpg': 'image/jpeg',
+			'.jpeg': 'image/jpeg',
+			'.gif': 'image/gif',
+			'.webp': 'image/webp',
+			'.svg': 'image/svg+xml',
+		};
+		return mimeTypes[ext] || 'image/png';
+	}
+
+	/**
+	 * Set up event handlers to bridge ACP events to ProcessManager events
+	 */
+	private setupEventHandlers(
+		acpProcess: ACPProcess,
+		sessionId: string,
+		showStreaming: boolean
+	): void {
+		// Handle parsed data events from ACP
+		acpProcess.on('data', (_sid: string, event: ParsedEvent) => {
+			// For 'text' events, only emit if streaming is enabled
+			// The 'result' event will contain the final text regardless
+			if (event.type === 'text' && !showStreaming) {
+				logger.debug(`${LOG_CONTEXT} Suppressing streaming text (acpShowStreaming=false)`, LOG_CONTEXT, {
+					sessionId,
+					textLength: event.text?.length,
+				});
+				return;
+			}
+
+			// Emit the parsed event directly - ACP already produces ParsedEvent objects
+			this.emitter.emit('data', sessionId, event);
+
+			// Also emit specific events based on event type
+			switch (event.type) {
+				case 'init':
+					// Session ID is provided in the 'init' event
+					if (event.sessionId) {
+						this.emitter.emit('session-id', sessionId, event.sessionId);
+					}
+					break;
+				case 'usage':
+					if (event.usage) {
+						this.emitter.emit('usage', sessionId, event.usage);
+					}
+					break;
+				case 'tool_use':
+					// Tool execution events - emit tool-execution for UI
+					if (event.toolName && event.toolState) {
+						this.emitter.emit('tool-execution', sessionId, {
+							toolName: event.toolName,
+							state: event.toolState,
+							timestamp: Date.now(),
+						});
+					}
+					break;
+			}
+		});
+
+		// Handle agent errors
+		acpProcess.on('agent-error', (_sid: string, error: unknown) => {
+			this.emitter.emit('agent-error', sessionId, error);
+		});
+
+		// Handle process exit
+		acpProcess.on('exit', (_sid: string, code: number) => {
+			const managedProcess = this.processes.get(sessionId);
+
+			// Emit query-complete event for stats tracking
+			if (managedProcess) {
+				this.emitter.emit('query-complete', sessionId, {
+					sessionId,
+					agentType: managedProcess.toolType,
+					source: managedProcess.querySource || 'user',
+					startTime: managedProcess.startTime,
+					duration: Date.now() - managedProcess.startTime,
+					projectPath: managedProcess.projectPath,
+					tabId: managedProcess.tabId,
+				});
+			}
+
+			this.emitter.emit('exit', sessionId, code);
+			this.processes.delete(sessionId);
+		});
+	}
+}

--- a/src/main/process-manager/spawners/AcpSpawner.ts
+++ b/src/main/process-manager/spawners/AcpSpawner.ts
@@ -208,10 +208,14 @@ export class AcpSpawner {
 			// For 'text' events, only emit if streaming is enabled
 			// The 'result' event will contain the final text regardless
 			if (event.type === 'text' && !showStreaming) {
-				logger.debug(`${LOG_CONTEXT} Suppressing streaming text (acpShowStreaming=false)`, LOG_CONTEXT, {
-					sessionId,
-					textLength: event.text?.length,
-				});
+				logger.debug(
+					`${LOG_CONTEXT} Suppressing streaming text (acpShowStreaming=false)`,
+					LOG_CONTEXT,
+					{
+						sessionId,
+						textLength: event.text?.length,
+					}
+				);
 				return;
 			}
 

--- a/src/main/process-manager/spawners/index.ts
+++ b/src/main/process-manager/spawners/index.ts
@@ -1,2 +1,3 @@
 export { PtySpawner } from './PtySpawner';
 export { ChildProcessSpawner } from './ChildProcessSpawner';
+export { AcpSpawner } from './AcpSpawner';

--- a/src/main/process-manager/types.ts
+++ b/src/main/process-manager/types.ts
@@ -42,6 +42,13 @@ export interface ProcessConfig {
 	acpShowStreaming?: boolean;
 	/** ACP session ID for resuming a session */
 	acpSessionId?: string;
+	/**
+	 * ACP-specific arguments that enable the agent's ACP mode.
+	 * These are prepended before any custom args.
+	 * Examples: ['acp'] for OpenCode, ['--acp'] for Gemini CLI.
+	 * Defaults to ['acp'] if not specified.
+	 */
+	acpArgs?: string[];
 }
 
 /**

--- a/src/main/process-manager/types.ts
+++ b/src/main/process-manager/types.ts
@@ -36,6 +36,12 @@ export interface ProcessConfig {
 	sendPromptViaStdinRaw?: boolean;
 	/** Script to send via stdin for SSH execution (bypasses shell escaping) */
 	sshStdinScript?: string;
+	/** If true, use ACP (Agent Client Protocol) for communication */
+	useACP?: boolean;
+	/** If true, show streaming output in ACP mode (default: true) */
+	acpShowStreaming?: boolean;
+	/** ACP session ID for resuming a session */
+	acpSessionId?: string;
 }
 
 /**
@@ -46,11 +52,14 @@ export interface ManagedProcess {
 	toolType: string;
 	ptyProcess?: IPty;
 	childProcess?: ChildProcess;
+	acpProcess?: import('../acp').ACPProcess;
 	cwd: string;
 	pid: number;
 	isTerminal: boolean;
 	isBatchMode?: boolean;
 	isStreamJsonMode?: boolean;
+	isAcpMode?: boolean;
+	acpShowStreaming?: boolean;
 	jsonBuffer?: string;
 	lastCommand?: string;
 	sessionIdEmitted?: boolean;

--- a/src/renderer/components/shared/AgentConfigPanel.tsx
+++ b/src/renderer/components/shared/AgentConfigPanel.tsx
@@ -606,10 +606,22 @@ export function AgentConfigPanel({
 						style={{ borderColor: theme.colors.border, backgroundColor: theme.colors.bgMain }}
 					>
 						<label
-							className="block text-xs font-medium mb-2"
+							className="block text-xs font-medium mb-2 flex items-center gap-2"
 							style={{ color: theme.colors.textDim }}
 						>
-							{option.label}
+							<span>{option.label}</span>
+							{/* BETA badge for experimental ACP features */}
+							{(option.key === 'useACP' || option.key === 'acpShowStreaming') && (
+								<span
+									className="px-1.5 py-0.5 rounded text-[10px] font-semibold uppercase"
+									style={{
+										backgroundColor: theme.colors.accent,
+										color: theme.colors.bgMain,
+									}}
+								>
+									BETA
+								</span>
+							)}
 						</label>
 						{option.type === 'number' && (
 							<input


### PR DESCRIPTION
## Summary

This PR adds support for the Agent Client Protocol (ACP) to enable native integration with OpenCode and other ACP-compatible agents.

## Key Changes

### ACP Protocol Implementation
- **ACP Client** (`acp-client.ts`): JSON-RPC 2.0 client for stdio communication with ACP agents
- **ACP Process** (`acp-process.ts`): Wrapper that provides ProcessManager-compatible interface for ACP agents
- **ACP Adapter** (`acp-adapter.ts`): Converts ACP session updates to Maestro's ParsedEvent format
- **ACP Types** (`types.ts`): Complete TypeScript definitions for ACP protocol spec

### Bug Fixes
- **Historical Message Accumulation**: Fixed issue where loading existing ACP sessions would replay all historical messages and accumulate them in the UI. Added `isLoadingSession` flag to ignore session updates during `session/load`.
- **Usage Stats**: Added support for forwarding token usage statistics from ACP responses (though OpenCode currently doesn't provide this data per the optional ACP spec).

### Configuration & Debugging
- **Agent Configuration**: Added `useACP` and `acpShowStreaming` options to agent configs for per-agent ACP mode control
- **Debug Logging**: Added `MAESTRO_LOG_LEVEL` environment variable support and `dev:main:debug` script for easier debugging
- **Spawn Logic**: Updated process spawning to check agent capabilities and config to determine ACP vs CLI mode

### OpenCode Integration
- **Detection**: OpenCode is now auto-detected and configured with ACP support
- **Capabilities**: Marked OpenCode as supporting ACP, session resume, images, and JSON output
- **Session Management**: Load/resume OpenCode sessions via ACP `session/load` method

## Testing

Tested with OpenCode v1.0.190:
- ✅ New sessions create and stream responses correctly
- ✅ Session resume loads history without accumulation
- ✅ Streaming text displays properly in UI
- ✅ Tool calls and thinking blocks are parsed
- ✅ Historical messages are filtered during session load

## Known Limitations

1. **Token Usage**: OpenCode doesn't currently report token usage in ACP responses (usage field is optional per spec)
2. **Session Cleanup**: Agent sessions remain in agent storage after Maestro session deletion (needs ACP session deletion support)

## Checklist

- [x] Code follows project style guidelines
- [x] Tested locally with OpenCode
- [x] Commit messages follow conventional commits
- [x] Fixed historical message accumulation bug
- [x] Added debug logging improvements

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full ACP support: interactive streaming agent sessions, resumable sessions, image-enabled prompts, richer session events (results, errors, tool usage) and session controls (cancel/interrupt).
  * ACP-backed process path and spawn mode for agents, with option to resume via session ID.
  * Agent settings expose ACP options (including streaming toggle) marked as Beta.

* **Documentation**
  * Release notes formatting normalized for clearer rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->