### PR TITLE
Fix Issues #86: CLI installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -628,10 +628,10 @@ The CLI is bundled with Maestro as a JavaScript file. Create a shell wrapper to 
 
 ```bash
 # macOS (after installing Maestro.app)
-echo '#!/bin/bash\nnode "/Applications/Maestro.app/Contents/Resources/maestro-cli.js" "$@"' | sudo tee /usr/local/bin/maestro-cli && sudo chmod +x /usr/local/bin/maestro-cli
+printf '#!/bin/bash\nnode "/Applications/Maestro.app/Contents/Resources/maestro-cli.js" "$@"\n' | sudo tee /usr/local/bin/maestro-cli && sudo chmod +x /usr/local/bin/maestro-cli
 
 # Linux (deb/rpm installs to /opt)
-echo '#!/bin/bash\nnode "/opt/Maestro/resources/maestro-cli.js" "$@"' | sudo tee /usr/local/bin/maestro-cli && sudo chmod +x /usr/local/bin/maestro-cli
+printf '#!/bin/bash\nnode "/opt/Maestro/resources/maestro-cli.js" "$@"\n' | sudo tee /usr/local/bin/maestro-cli && sudo chmod +x /usr/local/bin/maestro-cli
 
 # Windows (PowerShell as Administrator) - create a batch file
 @"


### PR DESCRIPTION
## Summary
This PR contains fixes for two issues:

### Issue #86: CLI Installation Instructions
Fixes #86 - CLI installation instructions use `echo` which creates literal `\n` characters instead of actual newlines, making the generated wrapper scripts invalid.

**Changes:**
- Changed macOS installation command to use `printf` instead of `echo`
- Changed Linux installation command to use `printf` instead of `echo`
- Added trailing `\n` to ensure proper script formatting

**Testing:**
- Generated test scripts using both commands
- Verified newlines are actual characters (not literal `\n`) using `od -c`
- Validated script syntax using `bash -n`
- Both macOS and Linux commands produce valid, executable wrapper scripts