### PR TITLE
Improve context merge toast notifications with useful info

### DIFF
--- a/src/renderer/types/contextMerge.ts
+++ b/src/renderer/types/contextMerge.ts
@@ -68,6 +68,12 @@ export interface MergeResult {
   targetSessionId?: string;
   /** Target tab ID when merging into existing tab */
   targetTabId?: string;
+  /** Source session name for display in notifications */
+  sourceSessionName?: string;
+  /** Target session name for display in notifications */
+  targetSessionName?: string;
+  /** Estimated token count of the transferred context */
+  estimatedTokens?: number;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Add `sourceSessionName`, `targetSessionName`, `estimatedTokens` to `MergeResult` type
- Show source→target with token counts in merge/transfer toast notifications
- Include tokens saved info when grooming reduces context size
- Add `MergeSessionCreatedInfo` interface for richer callback data
- Make toasts clickable by including `sessionId`/`tabId`
- Replace generic 'Source'/'Target' fallbacks with descriptive names ('Current Session'/'Selected Session')

## Test plan

- [ ] Merge context from one session into an existing session tab - verify toast shows source→target names with token count
- [ ] Create new merged session from two sources - verify toast shows combined names and token info
- [ ] Transfer context via Send to Agent - verify toast shows source→target with token estimate
- [ ] Click on toast notification - verify it navigates to the correct session/tab