### PR TITLE
Merge PR #120: consolidate tilde expansion and version utilities

### DIFF
--- a/src/__tests__/main/process-manager.test.ts
+++ b/src/__tests__/main/process-manager.test.ts
@@ -29,7 +29,6 @@ import {
   ProcessManager,
   detectNodeVersionManagerPaths,
   buildUnixBasePath,
-  sortNodeVersionsDescending,
   type UsageStats,
   type ModelStats,
   type AgentError,
@@ -530,56 +529,4 @@ describe('process-manager.ts', () => {
     });
   });
 
-  describe('sortNodeVersionsDescending', () => {
-    it('should sort versions in descending order (latest first)', () => {
-      const versions = ['v16.14.0', 'v20.10.0', 'v18.19.1', 'v14.21.3'];
-      const result = sortNodeVersionsDescending(versions);
-
-      expect(result).toEqual(['v20.10.0', 'v18.19.1', 'v16.14.0', 'v14.21.3']);
-    });
-
-    it('should handle versions with different minor versions', () => {
-      const versions = ['v20.1.0', 'v20.10.0', 'v20.2.0'];
-      const result = sortNodeVersionsDescending(versions);
-
-      expect(result).toEqual(['v20.10.0', 'v20.2.0', 'v20.1.0']);
-    });
-
-    it('should handle versions with different patch versions', () => {
-      const versions = ['v20.10.1', 'v20.10.10', 'v20.10.2'];
-      const result = sortNodeVersionsDescending(versions);
-
-      expect(result).toEqual(['v20.10.10', 'v20.10.2', 'v20.10.1']);
-    });
-
-    it('should handle single version', () => {
-      const versions = ['v18.0.0'];
-      const result = sortNodeVersionsDescending(versions);
-
-      expect(result).toEqual(['v18.0.0']);
-    });
-
-    it('should handle empty array', () => {
-      const versions: string[] = [];
-      const result = sortNodeVersionsDescending(versions);
-
-      expect(result).toEqual([]);
-    });
-
-    it('should mutate and return the original array', () => {
-      const versions = ['v16.0.0', 'v20.0.0'];
-      const result = sortNodeVersionsDescending(versions);
-
-      expect(result).toBe(versions); // Same reference
-      expect(versions).toEqual(['v20.0.0', 'v16.0.0']); // Original is mutated
-    });
-
-    it('should handle LTS version naming patterns', () => {
-      // Real-world nvm version directory names
-      const versions = ['v18.20.4', 'v20.18.0', 'v22.11.0', 'v21.7.3'];
-      const result = sortNodeVersionsDescending(versions);
-
-      expect(result).toEqual(['v22.11.0', 'v21.7.3', 'v20.18.0', 'v18.20.4']);
-    });
-  });
 });

--- a/src/__tests__/main/utils/ssh-command-builder.test.ts
+++ b/src/__tests__/main/utils/ssh-command-builder.test.ts
@@ -1,20 +1,28 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
   buildSshCommand,
   buildRemoteCommand,
 } from '../../../main/utils/ssh-command-builder';
 import type { SshRemoteConfig } from '../../../shared/types';
+import * as os from 'os';
+
+// Mock os.homedir() for consistent path expansion tests
+vi.mock('os', async () => {
+  const actual = await vi.importActual('os');
+  return {
+    ...actual,
+    homedir: vi.fn(() => '/Users/testuser'),
+  };
+});
 
 describe('ssh-command-builder', () => {
-  const originalEnv = process.env;
-
   beforeEach(() => {
-    // Mock HOME for consistent path expansion tests
-    process.env = { ...originalEnv, HOME: '/Users/testuser' };
+    // Reset mock to ensure consistent behavior
+    vi.mocked(os.homedir).mockReturnValue('/Users/testuser');
   });
 
   afterEach(() => {
-    process.env = originalEnv;
+    vi.clearAllMocks();
   });
 
   // Base config for testing

--- a/src/__tests__/shared/pathUtils.test.ts
+++ b/src/__tests__/shared/pathUtils.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Tests for shared path and version utility functions
+ *
+ * @file src/shared/pathUtils.ts
+ *
+ * These utilities consolidate duplicated logic found across:
+ * - agent-detector.ts (expandTilde)
+ * - ssh-command-builder.ts (expandPath)
+ * - ssh-config-parser.ts (expandPath)
+ * - ssh-remote-manager.ts (expandPath)
+ * - process-manager.ts (inline tilde expansion)
+ * - update-checker.ts (version comparison)
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import * as os from 'os';
+import { expandTilde, parseVersion, compareVersions } from '../../shared/pathUtils';
+
+// Mock os.homedir for consistent test behavior
+vi.mock('os', async () => {
+  const actual = await vi.importActual<typeof os>('os');
+  return {
+    ...actual,
+    homedir: vi.fn(() => '/Users/testuser'),
+  };
+});
+
+describe('expandTilde', () => {
+  describe('basic tilde expansion', () => {
+    it('should expand ~/path to home directory + path', () => {
+      expect(expandTilde('~/Documents')).toBe('/Users/testuser/Documents');
+    });
+
+    it('should expand ~ alone to home directory', () => {
+      expect(expandTilde('~')).toBe('/Users/testuser');
+    });
+
+    it('should expand ~/path/to/file correctly', () => {
+      expect(expandTilde('~/.ssh/id_rsa')).toBe('/Users/testuser/.ssh/id_rsa');
+    });
+
+    it('should preserve paths without tilde', () => {
+      expect(expandTilde('/absolute/path')).toBe('/absolute/path');
+      expect(expandTilde('relative/path')).toBe('relative/path');
+      expect(expandTilde('./local/path')).toBe('./local/path');
+    });
+
+    it('should not expand tilde in middle of path', () => {
+      expect(expandTilde('/path/with~tilde')).toBe('/path/with~tilde');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle empty string', () => {
+      expect(expandTilde('')).toBe('');
+    });
+
+    it('should handle paths with spaces', () => {
+      expect(expandTilde('~/My Documents/file.txt')).toBe('/Users/testuser/My Documents/file.txt');
+    });
+
+    it('should handle deeply nested paths', () => {
+      expect(expandTilde('~/.local/share/fnm/node-versions/v20.0.0/installation/bin'))
+        .toBe('/Users/testuser/.local/share/fnm/node-versions/v20.0.0/installation/bin');
+    });
+  });
+
+  describe('cross-platform consistency', () => {
+    it('should handle Windows-style home (when provided)', () => {
+      vi.mocked(os.homedir).mockReturnValue('C:\\Users\\testuser');
+      const result = expandTilde('~/.config');
+      expect(result).toContain('testuser');
+      expect(result).toContain('.config');
+    });
+  });
+});
+
+describe('parseVersion', () => {
+  it('should parse version with v prefix', () => {
+    expect(parseVersion('v22.10.0')).toEqual([22, 10, 0]);
+  });
+
+  it('should parse version without v prefix', () => {
+    expect(parseVersion('0.14.0')).toEqual([0, 14, 0]);
+  });
+
+  it('should handle single digit versions', () => {
+    expect(parseVersion('v8.0.0')).toEqual([8, 0, 0]);
+  });
+
+  it('should handle versions with more than 3 parts', () => {
+    expect(parseVersion('1.2.3.4')).toEqual([1, 2, 3, 4]);
+  });
+
+  it('should handle non-numeric parts as 0', () => {
+    expect(parseVersion('1.beta.3')).toEqual([1, 0, 3]);
+  });
+});
+
+describe('compareVersions', () => {
+  describe('basic version comparison', () => {
+    it('should return 1 when a > b', () => {
+      expect(compareVersions('v22.0.0', 'v20.0.0')).toBe(1);
+    });
+
+    it('should return -1 when a < b', () => {
+      expect(compareVersions('v20.0.0', 'v22.0.0')).toBe(-1);
+    });
+
+    it('should return 0 for equal versions', () => {
+      expect(compareVersions('v20.10.0', 'v20.10.0')).toBe(0);
+    });
+  });
+
+  describe('minor version comparison', () => {
+    it('should compare by minor version when major is equal', () => {
+      expect(compareVersions('v20.11.0', 'v20.10.0')).toBe(1);
+      expect(compareVersions('v20.10.0', 'v20.11.0')).toBe(-1);
+    });
+
+    it('should handle v18.20 vs v18.2 correctly (20 > 2)', () => {
+      expect(compareVersions('v18.20.0', 'v18.2.0')).toBe(1);
+    });
+  });
+
+  describe('patch version comparison', () => {
+    it('should compare by patch when major and minor are equal', () => {
+      expect(compareVersions('v20.10.5', 'v20.10.3')).toBe(1);
+      expect(compareVersions('v20.10.3', 'v20.10.5')).toBe(-1);
+    });
+  });
+
+  describe('array sorting', () => {
+    it('should sort ascending when used directly', () => {
+      const versions = ['v22.21.0', 'v18.17.0', 'v20.10.0'];
+      const sorted = [...versions].sort(compareVersions);
+      expect(sorted).toEqual(['v18.17.0', 'v20.10.0', 'v22.21.0']);
+    });
+
+    it('should sort descending when args are flipped', () => {
+      const versions = ['v18.17.0', 'v22.21.0', 'v20.10.0', 'v18.2.0', 'v21.0.0'];
+      const sorted = [...versions].sort((a, b) => compareVersions(b, a));
+      expect(sorted).toEqual(['v22.21.0', 'v21.0.0', 'v20.10.0', 'v18.17.0', 'v18.2.0']);
+    });
+
+    it('should handle single-digit versions', () => {
+      const versions = ['v8.0.0', 'v16.0.0', 'v4.0.0', 'v12.0.0'];
+      const sorted = [...versions].sort((a, b) => compareVersions(b, a));
+      expect(sorted).toEqual(['v16.0.0', 'v12.0.0', 'v8.0.0', 'v4.0.0']);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle versions without v prefix', () => {
+      expect(compareVersions('22.0.0', '20.0.0')).toBe(1);
+    });
+
+    it('should handle mixed v prefix', () => {
+      expect(compareVersions('v22.0.0', '20.0.0')).toBe(1);
+    });
+
+    it('should handle versions with different part counts', () => {
+      expect(compareVersions('1.0', '1.0.0')).toBe(0);
+      expect(compareVersions('1.0.1', '1.0')).toBe(1);
+    });
+  });
+});

--- a/src/main/agent-detector.ts
+++ b/src/main/agent-detector.ts
@@ -4,6 +4,7 @@ import * as os from 'os';
 import * as fs from 'fs';
 import * as path from 'path';
 import { AgentCapabilities, getAgentCapabilities } from './agent-capabilities';
+import { expandTilde } from '../shared/pathUtils';
 
 // Re-export AgentCapabilities for convenience
 export { AgentCapabilities } from './agent-capabilities';
@@ -290,17 +291,6 @@ export class AgentDetector {
   }
 
   /**
-   * Expand tilde (~) to home directory in paths.
-   * This is necessary because Node.js fs functions don't understand shell tilde expansion.
-   */
-  private expandTilde(filePath: string): string {
-    if (filePath.startsWith('~/') || filePath === '~') {
-      return path.join(os.homedir(), filePath.slice(1));
-    }
-    return filePath;
-  }
-
-  /**
    * Check if a custom path points to a valid executable
    * On Windows, also tries .cmd and .exe extensions if the path doesn't exist as-is
    */
@@ -308,7 +298,7 @@ export class AgentDetector {
     const isWindows = process.platform === 'win32';
 
     // Expand tilde to home directory (Node.js fs doesn't understand ~)
-    const expandedPath = this.expandTilde(customPath);
+    const expandedPath = expandTilde(customPath);
 
     // Helper to check if a specific path exists and is a file
     const checkPath = async (pathToCheck: string): Promise<boolean> => {

--- a/src/main/ssh-remote-manager.ts
+++ b/src/main/ssh-remote-manager.ts
@@ -6,9 +6,9 @@
  */
 
 import * as fs from 'fs';
-import * as path from 'path';
 import { SshRemoteConfig, SshRemoteTestResult } from '../shared/types';
 import { execFileNoThrow, ExecResult } from './utils/execFile';
+import { expandTilde } from '../shared/pathUtils';
 
 /**
  * Validation result for SSH remote configuration.
@@ -127,7 +127,7 @@ export class SshRemoteManager {
 
     // Private key file existence check (only if path is provided)
     if (config.privateKeyPath && config.privateKeyPath.trim() !== '') {
-      const keyPath = this.expandPath(config.privateKeyPath);
+      const keyPath = expandTilde(config.privateKeyPath);
       if (!this.deps.checkFileAccess(keyPath)) {
         errors.push(`Private key not readable: ${config.privateKeyPath}`);
       }
@@ -236,11 +236,11 @@ export class SshRemoteManager {
     if (config.useSshConfig) {
       // Only add key if explicitly provided (as override)
       if (config.privateKeyPath && config.privateKeyPath.trim()) {
-        args.push('-i', this.expandPath(config.privateKeyPath));
+        args.push('-i', expandTilde(config.privateKeyPath));
       }
     } else {
       // Direct connection: require private key
-      args.push('-i', this.expandPath(config.privateKeyPath));
+      args.push('-i', expandTilde(config.privateKeyPath));
     }
 
     // Default SSH options
@@ -267,20 +267,6 @@ export class SshRemoteManager {
     }
 
     return args;
-  }
-
-  /**
-   * Expand tilde (~) in paths to the user's home directory.
-   *
-   * @param filePath Path that may start with ~
-   * @returns Expanded absolute path
-   */
-  private expandPath(filePath: string): string {
-    if (filePath.startsWith('~')) {
-      const homeDir = process.env.HOME || process.env.USERPROFILE || '';
-      return path.join(homeDir, filePath.slice(1));
-    }
-    return filePath;
   }
 
   /**

--- a/src/main/update-checker.ts
+++ b/src/main/update-checker.ts
@@ -3,6 +3,8 @@
  * Fetches release information from GitHub API to check for updates
  */
 
+import { compareVersions } from '../shared/pathUtils';
+
 // GitHub repository information
 const GITHUB_OWNER = 'pedramamini';
 const GITHUB_REPO = 'Maestro';
@@ -74,36 +76,6 @@ function hasAssetsForPlatform(release: Release): boolean {
   }
 }
 
-/**
- * Parse version string to comparable array
- * e.g., "0.7.0" -> [0, 7, 0]
- */
-function parseVersion(version: string): number[] {
-  // Remove 'v' prefix if present
-  const cleaned = version.replace(/^v/, '');
-  return cleaned.split('.').map(n => parseInt(n, 10) || 0);
-}
-
-/**
- * Compare two versions
- * Returns: 1 if a > b, -1 if a < b, 0 if equal
- */
-function compareVersions(a: string, b: string): number {
-  const partsA = parseVersion(a);
-  const partsB = parseVersion(b);
-
-  const maxLength = Math.max(partsA.length, partsB.length);
-
-  for (let i = 0; i < maxLength; i++) {
-    const numA = partsA[i] || 0;
-    const numB = partsB[i] || 0;
-
-    if (numA > numB) return 1;
-    if (numA < numB) return -1;
-  }
-
-  return 0;
-}
 
 /**
  * Fetch all releases from GitHub API

--- a/src/main/utils/ssh-command-builder.ts
+++ b/src/main/utils/ssh-command-builder.ts
@@ -9,7 +9,7 @@
 
 import { SshRemoteConfig } from '../../shared/types';
 import { shellEscape, buildShellCommand } from './shell-escape';
-import * as path from 'path';
+import { expandTilde } from '../../shared/pathUtils';
 
 /**
  * Result of building an SSH command.
@@ -47,20 +47,6 @@ const DEFAULT_SSH_OPTIONS: Record<string, string> = {
   ClearAllForwardings: 'yes', // Disable port forwarding from SSH config (avoids "Address already in use" errors)
   RequestTTY: 'no', // Don't request a TTY for command execution (avoids shell rc issues)
 };
-
-/**
- * Expand tilde (~) in paths to the user's home directory.
- *
- * @param filePath Path that may start with ~
- * @returns Expanded absolute path
- */
-function expandPath(filePath: string): string {
-  if (filePath.startsWith('~')) {
-    const homeDir = process.env.HOME || process.env.USERPROFILE || '';
-    return path.join(homeDir, filePath.slice(1));
-  }
-  return filePath;
-}
 
 /**
  * Build the remote shell command string from command, args, cwd, and env.
@@ -188,11 +174,11 @@ export function buildSshCommand(
   if (config.useSshConfig) {
     // Only specify identity file if explicitly provided (override SSH config)
     if (config.privateKeyPath && config.privateKeyPath.trim()) {
-      args.push('-i', expandPath(config.privateKeyPath));
+      args.push('-i', expandTilde(config.privateKeyPath));
     }
   } else {
     // Direct connection: require private key
-    args.push('-i', expandPath(config.privateKeyPath));
+    args.push('-i', expandTilde(config.privateKeyPath));
   }
 
   // Default SSH options for non-interactive operation

--- a/src/main/utils/ssh-config-parser.ts
+++ b/src/main/utils/ssh-config-parser.ts
@@ -10,6 +10,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+import { expandTilde } from '../../shared/pathUtils';
 
 /**
  * Parsed SSH config host entry.
@@ -85,19 +86,6 @@ function getDefaultDeps(): SshConfigParserDeps {
 }
 
 /**
- * Expand tilde (~) in paths to the user's home directory.
- */
-function expandPath(filePath: string, homeDir: string): string {
-  if (filePath.startsWith('~/')) {
-    return path.join(homeDir, filePath.slice(2));
-  }
-  if (filePath === '~') {
-    return homeDir;
-  }
-  return filePath;
-}
-
-/**
  * Normalize an IdentityFile path.
  * Handles ~ expansion and resolves %d, %h, %r tokens.
  */
@@ -107,7 +95,7 @@ function normalizeIdentityFile(
   user: string | undefined,
   homeDir: string
 ): string {
-  let normalized = expandPath(identityFile, homeDir);
+  let normalized = expandTilde(identityFile, homeDir);
 
   // Replace common SSH config tokens
   normalized = normalized.replace(/%d/g, homeDir);

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -13,3 +13,4 @@ export * from './gitUtils';
 export * from './emojiUtils';
 export * from './treeUtils';
 export * from './stringUtils';
+export * from './pathUtils';

--- a/src/shared/pathUtils.ts
+++ b/src/shared/pathUtils.ts
@@ -1,0 +1,109 @@
+/**
+ * Shared path and version utility functions
+ *
+ * This module provides utilities used across multiple parts of the application.
+ *
+ * Consolidates duplicated logic from:
+ * - agent-detector.ts (expandTilde)
+ * - ssh-command-builder.ts (expandPath)
+ * - ssh-config-parser.ts (expandPath)
+ * - ssh-remote-manager.ts (expandPath)
+ * - process-manager.ts (inline tilde expansion)
+ * - update-checker.ts (version comparison)
+ */
+
+import * as os from 'os';
+import * as path from 'path';
+
+/**
+ * Expand tilde (~) to home directory in paths.
+ *
+ * Node.js fs functions don't understand shell tilde expansion,
+ * so this function provides consistent tilde handling across the codebase.
+ *
+ * @param filePath - Path that may start with ~ or ~/
+ * @param homeDir - Optional custom home directory (for testing/dependency injection)
+ * @returns Expanded absolute path with ~ replaced by home directory
+ *
+ * @example
+ * ```typescript
+ * expandTilde('~/.ssh/id_rsa')   // '/Users/username/.ssh/id_rsa'
+ * expandTilde('~')               // '/Users/username'
+ * expandTilde('/absolute/path') // '/absolute/path' (unchanged)
+ * expandTilde('~/config', '/custom/home') // '/custom/home/config'
+ * ```
+ */
+export function expandTilde(filePath: string, homeDir?: string): string {
+  if (!filePath) {
+    return filePath;
+  }
+
+  const home = homeDir ?? os.homedir();
+
+  if (filePath === '~') {
+    return home;
+  }
+
+  if (filePath.startsWith('~/')) {
+    return path.join(home, filePath.slice(2));
+  }
+
+  return filePath;
+}
+
+/**
+ * Parse version string to comparable array of numbers.
+ *
+ * @param version - Version string (e.g., "v22.10.0" or "0.14.0")
+ * @returns Array of version numbers (e.g., [22, 10, 0])
+ *
+ * @example
+ * ```typescript
+ * parseVersion('v22.10.0')  // [22, 10, 0]
+ * parseVersion('0.14.0')    // [0, 14, 0]
+ * ```
+ */
+export function parseVersion(version: string): number[] {
+  const cleaned = version.replace(/^v/, '');
+  return cleaned.split('.').map(n => parseInt(n, 10) || 0);
+}
+
+/**
+ * Compare two version strings.
+ *
+ * Returns: 1 if a > b, -1 if a < b, 0 if equal.
+ * Handles versions with or without 'v' prefix.
+ *
+ * @param a - First version string
+ * @param b - Second version string
+ * @returns 1 if a > b, -1 if a < b, 0 if equal
+ *
+ * @example
+ * ```typescript
+ * compareVersions('v22.0.0', 'v20.0.0')  // 1 (a > b)
+ * compareVersions('v18.0.0', 'v20.0.0')  // -1 (a < b)
+ * compareVersions('v20.0.0', 'v20.0.0')  // 0 (equal)
+ *
+ * // For descending sort (highest first):
+ * versions.sort((a, b) => compareVersions(b, a))
+ *
+ * // For ascending sort (lowest first):
+ * versions.sort(compareVersions)
+ * ```
+ */
+export function compareVersions(a: string, b: string): number {
+  const partsA = parseVersion(a);
+  const partsB = parseVersion(b);
+
+  const maxLength = Math.max(partsA.length, partsB.length);
+
+  for (let i = 0; i < maxLength; i++) {
+    const numA = partsA[i] || 0;
+    const numB = partsB[i] || 0;
+
+    if (numA > numB) return 1;
+    if (numA < numB) return -1;
+  }
+
+  return 0;
+}


### PR DESCRIPTION
Resolves merge conflicts with main after #119 was merged:
- Use shared compareVersions() instead of sortNodeVersionsDescending()
- Remove redundant sortNodeVersionsDescending helper function
- Remove sortNodeVersionsDescending tests (covered by pathUtils.test.ts)

Creates src/shared/pathUtils.ts with:
- expandTilde(): consolidated from 5 duplicate implementations
- parseVersion(): parse semver strings to arrays
- compareVersions(): compare version strings (1/-1/0)

Refactors 6 files to use shared utilities, reducing ~38 lines of duplication.