### PR TITLE
Add local manifest feature for custom playbooks

### DIFF
--- a/docs/examples/local-manifest.json
+++ b/docs/examples/local-manifest.json
@@ -1,0 +1,54 @@
+{
+  "lastUpdated": "2026-01-17",
+  "playbooks": [
+    {
+      "id": "my-custom-playbook",
+      "title": "My Custom Security Audit",
+      "description": "Internal security audit playbook for our organization",
+      "category": "Custom",
+      "author": "Internal Team",
+      "lastUpdated": "2026-01-17",
+      "path": "/Users/me/.maestro/custom-playbooks/security-audit",
+      "documents": [
+        {
+          "filename": "1_SCAN",
+          "resetOnCompletion": false
+        },
+        {
+          "filename": "2_ANALYZE",
+          "resetOnCompletion": true
+        },
+        {
+          "filename": "3_REPORT",
+          "resetOnCompletion": false
+        }
+      ],
+      "loopEnabled": false,
+      "maxLoops": null,
+      "prompt": null,
+      "assets": ["config.yaml", "rules.json"]
+    },
+    {
+      "id": "development-security",
+      "title": "Enhanced Development Security (Override)",
+      "description": "Custom version of the official playbook with our internal modifications",
+      "category": "Development",
+      "author": "Our Team",
+      "lastUpdated": "2026-01-17",
+      "path": "~/maestro-playbooks/dev-security",
+      "documents": [
+        {
+          "filename": "SETUP",
+          "resetOnCompletion": false
+        },
+        {
+          "filename": "SCAN",
+          "resetOnCompletion": true
+        }
+      ],
+      "loopEnabled": true,
+      "maxLoops": 3,
+      "prompt": "Custom prompt for our workflow"
+    }
+  ]
+}

--- a/docs/local-manifest.md
+++ b/docs/local-manifest.md
@@ -1,0 +1,257 @@
+# Local Manifest for Custom Playbooks
+
+The local manifest feature allows you to extend the Playbook Exchange with custom or work-in-progress playbooks that are stored locally instead of in the public GitHub repository.
+
+## Overview
+
+- **File Location:** `<userData>/local-manifest.json` (same directory as `marketplace-cache.json`)
+- **Format:** Same structure as the official `manifest.json` from GitHub
+- **Optional:** If the file doesn't exist, Maestro works normally with official playbooks only
+- **Hot Reload:** Changes to `local-manifest.json` automatically refresh the Playbook Exchange
+
+## Use Cases
+
+### 1. Bespoke Playbooks
+Create organization-specific playbooks that aren't suitable for public sharing:
+- Internal tools and workflows
+- Proprietary processes
+- Environment-specific automation
+- Company-specific security policies
+
+### 2. Playbook Development
+Iterate on new playbooks locally before submitting them to the [Maestro-Playbooks repository](https://github.com/pedramamini/Maestro-Playbooks):
+- Test playbook structure and documents
+- Refine prompts and loop behavior
+- Validate asset bundling
+- Preview in the UI before publishing
+
+## How It Works
+
+### Merge Semantics
+
+When both official and local manifests exist, they are merged by `id`:
+
+1. **Override:** Local playbooks with the same `id` as official ones **override** the official version
+2. **Append:** Local playbooks with unique `id`s are **added** to the catalog
+3. **Source Tagging:** All playbooks are tagged with `source: 'official' | 'local'` for UI distinction
+
+**Example:**
+```
+Official playbooks: [A, B, C]
+Local playbooks:    [B_custom, D]
+Merged result:      [A, B_custom, C, D]
+                         ↑ override   ↑ append
+```
+
+### Path Resolution
+
+Local playbooks support local filesystem paths:
+
+- **Absolute paths:** `/Users/me/.maestro/custom-playbooks/security`
+- **Tilde paths:** `~/maestro-playbooks/security`
+- **Import behavior:** Files are copied from the local path instead of fetched from GitHub
+
+## Schema
+
+The local manifest uses the exact same structure as the official manifest. See [examples/local-manifest.json](./examples/local-manifest.json) for a complete example.
+
+### Required Fields
+
+Each playbook entry must include:
+
+- `id` - Unique identifier (use same ID as official to override)
+- `title` - Display name
+- `description` - Short description for search and tiles
+- `category` - Top-level category
+- `author` - Creator name
+- `lastUpdated` - Date in YYYY-MM-DD format
+- `path` - **Local filesystem path** or GitHub path
+- `documents` - Array of document entries with `filename` and `resetOnCompletion`
+- `loopEnabled` - Whether to loop through documents
+- `prompt` - Custom prompt or `null` for Maestro default
+
+### Optional Fields
+
+- `subcategory` - Nested category
+- `authorLink` - URL to author's website
+- `tags` - Searchable keyword array
+- `maxLoops` - Maximum loop iterations (null for unlimited)
+- `assets` - Asset files from `assets/` subfolder
+
+## Creating a Local Playbook
+
+### Step 1: Create Playbook Files
+
+Organize your playbook in a local directory:
+
+```
+~/my-playbooks/security-audit/
+├── 1_SCAN.md
+├── 2_ANALYZE.md
+├── 3_REPORT.md
+├── README.md (optional)
+└── assets/
+    ├── config.yaml
+    └── rules.json
+```
+
+### Step 2: Create local-manifest.json
+
+Location: `<userData>/local-manifest.json`
+
+On macOS: `~/Library/Application Support/Maestro/local-manifest.json`
+
+```json
+{
+  "lastUpdated": "2026-01-17",
+  "playbooks": [
+    {
+      "id": "security-audit-internal",
+      "title": "Internal Security Audit",
+      "description": "Custom security audit for our infrastructure",
+      "category": "Security",
+      "author": "Security Team",
+      "lastUpdated": "2026-01-17",
+      "path": "~/my-playbooks/security-audit",
+      "documents": [
+        { "filename": "1_SCAN", "resetOnCompletion": false },
+        { "filename": "2_ANALYZE", "resetOnCompletion": true },
+        { "filename": "3_REPORT", "resetOnCompletion": false }
+      ],
+      "loopEnabled": false,
+      "prompt": null,
+      "assets": ["config.yaml", "rules.json"]
+    }
+  ]
+}
+```
+
+### Step 3: Open Playbook Exchange
+
+Your local playbook will appear with a **"Local"** badge, distinguishing it from official playbooks.
+
+### Step 4: Import and Use
+
+Import works the same as official playbooks - files are copied from your local path to the Auto Run folder.
+
+## Hot Reload
+
+Changes to `local-manifest.json` trigger an automatic refresh:
+
+1. Edit your local manifest
+2. Save the file
+3. The Playbook Exchange automatically reloads (500ms debounce)
+4. No need to restart Maestro
+
+This enables rapid iteration during playbook development.
+
+## Error Handling
+
+### Invalid JSON
+**Behavior:** Warning logged, empty array used, Maestro continues with official playbooks only
+
+**Fix:** Validate JSON syntax using a JSON validator
+
+### Missing Required Fields
+**Behavior:** Invalid entries are skipped with warnings, valid entries are loaded
+
+**Fix:** Ensure all playbooks have `id`, `title`, `path`, and `documents`
+
+### Local Path Doesn't Exist
+**Behavior:** Clear error message during import, playbook listing works normally
+
+**Fix:** Verify the `path` field points to an existing directory
+
+### File Watch Errors
+**Behavior:** Warning logged, hot reload disabled, normal operation continues
+
+**Effect:** You'll need to restart Maestro to see manifest changes
+
+## UI Indicators
+
+Local playbooks are visually distinguished in the Playbook Exchange:
+
+- **Badge:** Blue "Local" badge next to category
+- **Tooltip:** "Custom local playbook" on hover
+- **Search:** Works across both official and local playbooks
+- **Categories:** New categories from local playbooks appear in filters
+
+## Development Workflow
+
+### Testing Before Publishing
+
+1. Create your playbook files locally
+2. Add to `local-manifest.json`
+3. Test import and execution in Maestro
+4. Refine documents and prompts
+5. When ready, submit a PR to [Maestro-Playbooks](https://github.com/pedramamini/Maestro-Playbooks)
+6. Remove from local manifest once published
+
+### Overriding Official Playbooks
+
+Use the same `id` as the official playbook to test modifications:
+
+```json
+{
+  "id": "development-security",  // Same as official
+  "title": "Dev Security (Custom)",
+  "path": "~/my-version/dev-security",
+  ...
+}
+```
+
+This allows you to:
+- Add custom documents
+- Modify prompts
+- Change loop behavior
+- Test improvements before contributing
+
+## Troubleshooting
+
+### Playbook Doesn't Appear
+
+1. Check JSON syntax in `local-manifest.json`
+2. Verify all required fields are present
+3. Look for warnings in console logs
+4. Ensure `path` field is set correctly
+
+### Import Fails
+
+1. Verify the local `path` exists
+2. Check file permissions on playbook directory
+3. Ensure documents have `.md` extension
+4. Verify assets exist in `assets/` subfolder
+
+### Hot Reload Not Working
+
+1. Check console for file watcher errors
+2. Verify `local-manifest.json` path is correct
+3. Try restarting Maestro
+4. Check file system permissions
+
+## Related Files
+
+- **Manifest types:** `src/shared/marketplace-types.ts`
+- **Marketplace handlers:** `src/main/ipc/handlers/marketplace.ts`
+- **Import logic:** `marketplace:importPlaybook` handler
+- **UI component:** `src/renderer/components/MarketplaceModal.tsx`
+- **React hook:** `src/renderer/hooks/batch/useMarketplace.ts`
+
+## Security Considerations
+
+- Local manifest is **not synced** or shared
+- Paths are validated before file operations
+- Local-only playbooks remain private
+- No network requests for local paths
+- File watching is non-blocking and fails gracefully
+
+## Future Enhancements
+
+Potential improvements for consideration:
+
+- JSON schema validation
+- Visual editor for local manifest
+- UI controls to manage local playbooks
+- Relative paths from Auto Run directory
+- Local manifest templates
+- Import/export for sharing local manifests

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -1325,6 +1325,11 @@ contextBridge.exposeInMainWorld('maestro', {
       ipcRenderer.invoke('marketplace:getReadme', playbookPath),
     importPlaybook: (playbookId: string, targetFolderName: string, autoRunFolderPath: string, sessionId: string, sshRemoteId?: string) =>
       ipcRenderer.invoke('marketplace:importPlaybook', playbookId, targetFolderName, autoRunFolderPath, sessionId, sshRemoteId),
+    onManifestChanged: (handler: () => void) => {
+      const wrappedHandler = () => handler();
+      ipcRenderer.on('marketplace:manifestChanged', wrappedHandler);
+      return () => ipcRenderer.removeListener('marketplace:manifestChanged', wrappedHandler);
+    },
   },
 
   // Debug Package API (generate support bundles for bug reporting)

--- a/src/renderer/components/MarketplaceModal.tsx
+++ b/src/renderer/components/MarketplaceModal.tsx
@@ -174,8 +174,8 @@ function PlaybookTile({ playbook, theme, isSelected, onSelect }: PlaybookTilePro
         }),
       }}
     >
-      {/* Category badge */}
-      <div className="flex items-center gap-2 mb-2">
+      {/* Category and source badges */}
+      <div className="flex items-center gap-2 mb-2 flex-wrap">
         <span
           className="px-2 py-0.5 rounded text-xs"
           style={{
@@ -188,6 +188,18 @@ function PlaybookTile({ playbook, theme, isSelected, onSelect }: PlaybookTilePro
         {playbook.subcategory && (
           <span className="text-xs" style={{ color: theme.colors.textDim }}>
             / {playbook.subcategory}
+          </span>
+        )}
+        {playbook.source === 'local' && (
+          <span
+            className="px-2 py-0.5 rounded text-xs font-medium"
+            style={{
+              backgroundColor: '#3b82f620',
+              color: '#3b82f6',
+            }}
+            title="Custom local playbook"
+          >
+            Local
           </span>
         )}
       </div>

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -1008,6 +1008,7 @@ interface MaestroAPI {
           loopEnabled: boolean;
           maxLoops?: number | null;
           prompt: string | null;
+          source?: 'official' | 'local';
         }>;
       };
       fromCache?: boolean;
@@ -1036,6 +1037,7 @@ interface MaestroAPI {
           loopEnabled: boolean;
           maxLoops?: number | null;
           prompt: string | null;
+          source?: 'official' | 'local';
         }>;
       };
       fromCache?: boolean;
@@ -1066,6 +1068,7 @@ interface MaestroAPI {
       importedDocs?: string[];
       error?: string;
     }>;
+    onManifestChanged: (handler: () => void) => () => void;
   };
   // Updates API
   updates: {

--- a/src/renderer/hooks/batch/useMarketplace.ts
+++ b/src/renderer/hooks/batch/useMarketplace.ts
@@ -152,6 +152,25 @@ export function useMarketplace(): UseMarketplaceReturn {
     loadManifest();
   }, []);
 
+  // Hot reload: listen for manifest changes (local-manifest.json edits)
+  useEffect(() => {
+    const cleanup = window.maestro.marketplace.onManifestChanged(async () => {
+      console.log('Local manifest changed, reloading...');
+      try {
+        const result = await window.maestro.marketplace.getManifest();
+        if (result.success && result.manifest) {
+          setManifest(result.manifest);
+          setFromCache(result.fromCache ?? false);
+          setCacheAge(result.cacheAge ?? null);
+        }
+      } catch (err) {
+        console.error('Failed to reload manifest after change:', err);
+      }
+    });
+
+    return cleanup;
+  }, []);
+
   // Extract playbooks from manifest
   const playbooks = useMemo(() => {
     return manifest?.playbooks ?? [];

--- a/src/shared/marketplace-types.ts
+++ b/src/shared/marketplace-types.ts
@@ -22,6 +22,11 @@ export interface MarketplaceManifest {
 }
 
 /**
+ * Playbook source type - distinguishes official GitHub playbooks from local ones.
+ */
+export type PlaybookSource = 'official' | 'local';
+
+/**
  * Individual playbook entry in the marketplace manifest.
  */
 export interface MarketplacePlaybook {
@@ -43,7 +48,7 @@ export interface MarketplacePlaybook {
   tags?: string[];
   /** Last update date in YYYY-MM-DD format */
   lastUpdated: string;
-  /** Folder path in repo for fetching documents */
+  /** Folder path in repo for fetching documents (GitHub path or local filesystem path) */
   path: string;
   /** Ordered list of documents in the playbook */
   documents: MarketplaceDocument[];
@@ -59,6 +64,8 @@ export interface MarketplacePlaybook {
    * that are bundled with the playbook.
    */
   assets?: string[];
+  /** Source of the playbook - official (from GitHub) or local (from local-manifest.json) */
+  source?: PlaybookSource;
 }
 
 /**


### PR DESCRIPTION
# Add local manifest feature for custom playbooks

## Summary

This PR introduces a new "local manifest" feature that allows users to define custom or work-in-progress playbooks stored locally on their filesystem. These local playbooks can override official ones from the GitHub repository or be added as new entries, enabling private, organization-specific automation without requiring public sharing. The implementation includes manifest merging, hot reload for development, and UI indicators to distinguish local playbooks.

## Related Issues

Closes #203 

## Screenshots

The Category view with the "Local" badge:

<img width="936" height="722" alt="image" src="https://github.com/user-attachments/assets/23c87f6d-2b2a-4f05-998a-f0eb75c0de17" />

The local playbook view:

<img width="911" height="1009" alt="image" src="https://github.com/user-attachments/assets/b9b92063-3f9e-4e78-aedc-a4cc862e42e5" />


## Files Changed

- **docs/examples/local-manifest.json** (new file): Provides a sample JSON structure for the local manifest, demonstrating how to define custom playbooks with local paths, overrides, and various configurations.
- **docs/local-manifest.md** (new file): Comprehensive documentation explaining the local manifest feature, including setup, merge semantics, path resolution, error handling, and development workflows.
- **src/main/ipc/handlers/marketplace.ts** (modified): Core implementation of local manifest support, including reading, merging, and file watching. Adds functions for path resolution, manifest merging by ID, and hot reload via file system watchers.
- **src/main/preload.ts** (modified): Exposes a new `onManifestChanged` API method to the renderer for listening to manifest updates.
- **src/renderer/components/MarketplaceModal.tsx** (modified): Updates the playbook tile UI to display a "Local" badge for local playbooks, with tooltips for distinction.
- **src/renderer/global.d.ts** (modified): Extends TypeScript definitions to include the optional `source` field in marketplace types.
- **src/renderer/hooks/batch/useMarketplace.ts** (modified): Adds a React effect to listen for manifest changes and trigger automatic reloads in the UI.
- **src/shared/marketplace-types.ts** (modified): Introduces `PlaybookSource` type and adds `source` field to `MarketplacePlaybook` interface for tagging official vs. local playbooks.

## Code Changes

### Key Additions in `src/main/ipc/handlers/marketplace.ts`
- **Local Manifest Reading and Merging**: New functions `readLocalManifest()` and `mergeManifests()` handle loading local JSON and combining it with official manifests. Merging prioritizes local playbooks by ID, appending unique ones, and tags all with `source` for UI.
  ```typescript
  function mergeManifests(official: MarketplaceManifest | null, local: MarketplaceManifest | null): MarketplaceManifest {
    // Logic to merge by ID, with local overrides and source tagging
  }
  ```
- **Path Resolution and Fetching**: Extended `fetchDocument()`, `fetchAsset()`, and `fetchReadme()` to detect local paths (absolute or tilde-prefixed) and read from filesystem instead of GitHub. Added `resolveTildePath()` for home directory expansion.
  ```typescript
  if (isLocalPath(playbookPath)) {
    const resolvedPath = resolveTildePath(playbookPath);
    // Read from local filesystem
  }
  ```
- **Hot Reload Watcher**: `setupLocalManifestWatcher()` sets up a debounced file watcher on `local-manifest.json` to emit IPC events for UI refresh. Includes cleanup on app quit.
  ```typescript
  localManifestWatcher = fsSync.watch(localManifestPath, (eventType) => {
    // Debounced refresh logic
  });
  ```
- **Handler Updates**: Modified `getManifest` and `refreshManifest` to incorporate local manifest reading and merging, ensuring graceful degradation if official fetch fails.

### UI Enhancements
- **Badge Display in MarketplaceModal.tsx**: Added conditional rendering of a "Local" badge with blue styling and tooltip.
  ```tsx
  {playbook.source === 'local' && (
    <span className="px-2 py-0.5 rounded text-xs font-medium" style={{ backgroundColor: '#3b82f620', color: '#3b82f6' }} title="Custom local playbook">
      Local
    </span>
  )}
  ```
- **Hot Reload in useMarketplace.ts**: New effect listens for `marketplace:manifestChanged` events and reloads the manifest asynchronously.
  ```typescript
  useEffect(() => {
    const cleanup = window.maestro.marketplace.onManifestChanged(() => {
      // Reload manifest logic
    });
    return cleanup;
  }, []);
  ```

### Type Definitions
- Added `source?: PlaybookSource` to `MarketplacePlaybook` for distinguishing origins, ensuring type safety across components.

## Reason for Changes

This feature addresses the need for users to create private, custom playbooks without contributing them publicly to the Maestro-Playbooks repository. It supports development workflows by allowing local testing and iteration before publishing, and enables organizations to maintain proprietary automation. The implementation ensures backward compatibility—official playbooks work unchanged—and provides a seamless extension mechanism. Hot reload improves developer experience by avoiding app restarts during manifest edits.

## Impact of Changes

- **Functionality**: Users can now define local playbooks that integrate with the existing marketplace, supporting overrides and additions. This expands Maestro's flexibility for custom use cases like internal security audits or environment-specific workflows.
- **Performance**: Minimal impact; local manifest reading is lightweight, and file watching is debounced (500ms) to avoid excessive refreshes. Official manifest caching remains intact.
- **User Experience**: Local playbooks are visually distinguished with badges, and changes auto-refresh the UI. No disruption to existing users—local manifest is optional.
- **Security**: Local paths are validated, and file operations are restricted to user-specified directories. No network exposure for local playbooks.
- **Maintainability**: Code is modular with clear separation of concerns (e.g., merging logic, path handling). Error handling ensures graceful failures without crashing the app.

## Test Plan

1. **Manual Testing**:
   - Create a `local-manifest.json` in the user data directory with sample playbooks (using absolute or tilde paths).
   - Verify playbooks appear in the Marketplace Modal with "Local" badges.
   - Test importing a local playbook—ensure documents and assets are copied from local paths.
   - Edit `local-manifest.json` and confirm hot reload updates the UI without restart.
   - Override an official playbook by matching IDs and verify the local version takes precedence.
   - Test error scenarios: invalid JSON, missing paths, non-existent files—ensure warnings are logged and app continues functioning.

2. **Edge Cases**:
   - No local manifest file: App should work with official playbooks only.
   - Official manifest fetch failure: App should load local playbooks if available.
   - File watcher errors: App should log warnings but not fail.
   - Mixed paths: Ensure GitHub and local paths coexist in merged manifest.

3. **Integration Testing**:
   - Run full import workflows for local playbooks, including assets and READMEs.
   - Verify search and filtering work across official and local playbooks.

## Additional Notes

- **Potential Bugs**: 
  - File watcher may fail on some filesystems (e.g., network drives); mitigated by non-blocking error handling.
  - Tilde path resolution assumes Unix-like behavior; Windows tilde handling might need adjustment if issues arise.
  - Large local manifests could impact load times; consider pagination if performance degrades.
  - Race conditions in hot reload: Debouncing helps, but rapid edits might still cause minor UI flicker.
- **Future Enhancements**: As noted in docs, potential for JSON schema validation, visual editors, or export/import features.
- **Dependencies**: No new external deps; uses existing Electron/fs modules.
- **Breaking Changes**: None; all changes are additive and backward-compatible.