### PR TITLE
BUG FIX: dev server port must be configured via `VITE_PORT`

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -214,13 +214,16 @@ const cliWatcher = createCliWatcher({
 	getUserDataPath: () => app.getPath('userData'),
 });
 
+const devServerPort = process.env.VITE_PORT ? parseInt(process.env.VITE_PORT, 10) : 5173;
+const devServerUrl = `http://localhost:${devServerPort}`;
+
 // Create window manager with dependency injection (Phase 4 refactoring)
 const windowManager = createWindowManager({
 	windowStateStore,
 	isDevelopment,
 	preloadPath: path.join(__dirname, 'preload.js'),
 	rendererPath: path.join(__dirname, '../renderer/index.html'),
-	devServerUrl: 'http://localhost:5173',
+	devServerUrl: devServerUrl,
 });
 
 // Create web server factory with dependency injection (Phase 2 refactoring)

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -51,7 +51,7 @@ export default defineConfig(({ mode }) => ({
 		emptyOutDir: true,
 	},
 	server: {
-		port: process.env.VITE_PORT ? parseInt(process.env.VITE_PORT) : 5173,
+		port: process.env.VITE_PORT ? parseInt(process.env.VITE_PORT, 10) : 5173,
 		hmr: !disableHmr,
 		// Disable file watching entirely when HMR is disabled to prevent any reloads
 		watch: disableHmr ? null : undefined,


### PR DESCRIPTION
# BUG FIX: dev server port must be configured via `VITE_PORT`

## Summary

We need to avoid using the hardcoded localhost:5173 for the dev server and localhost:5174 for the web dev server.

Recent commits broke my MaestroDev launcher, which uses

```bash
# Vite port for main renderer (optional - defaults to 5198)
# shellcheck disable=SC2034
VITE_PORT=5198

# Vite port for web interface (optional - defaults to 5199)
# shellcheck disable=SC2034
VITE_WEB_PORT=5199
```

## CHANGES

- Extract dev server port and URL into separate variables
- Add radix parameter to `parseInt` for proper number parsing
- Sync port configuration between Vite config and main process
- Use consistent port parsing with explicit base 10 radix