### PR TITLE
Add confirmation input to prevent accidental working directory deletion

### DIFF
--- a/src/renderer/components/DeleteAgentConfirmModal.tsx
+++ b/src/renderer/components/DeleteAgentConfirmModal.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useCallback } from 'react';
+import React, { useRef, useCallback, useState } from 'react';
 import { AlertTriangle, Trash2 } from 'lucide-react';
 import type { Theme } from '../types';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
@@ -22,6 +22,8 @@ export function DeleteAgentConfirmModal({
 	onClose,
 }: DeleteAgentConfirmModalProps) {
 	const confirmButtonRef = useRef<HTMLButtonElement>(null);
+	const [confirmationText, setConfirmationText] = useState('');
+	const isEraseEnabled = confirmationText === agentName;
 
 	const handleConfirm = useCallback(() => {
 		onConfirm();
@@ -76,19 +78,22 @@ export function DeleteAgentConfirmModal({
 							color: '#ffffff',
 						}}
 					>
-						Confirm
+						Agent Only
 					</button>
 					<button
 						type="button"
-						onClick={handleConfirmAndErase}
-						onKeyDown={(e) => handleKeyDown(e, handleConfirmAndErase)}
-						className="px-4 py-2 rounded transition-colors outline-none focus:ring-2 focus:ring-offset-1"
+						onClick={isEraseEnabled ? handleConfirmAndErase : undefined}
+						onKeyDown={isEraseEnabled ? (e) => handleKeyDown(e, handleConfirmAndErase) : undefined}
+						disabled={!isEraseEnabled}
+						className={`px-4 py-2 rounded transition-colors outline-none focus:ring-2 focus:ring-offset-1 ${
+							!isEraseEnabled ? 'opacity-50 cursor-not-allowed' : ''
+						}`}
 						style={{
 							backgroundColor: theme.colors.error,
 							color: '#ffffff',
 						}}
 					>
-						Confirm and Erase
+						Agent + Work Directory
 					</button>
 				</div>
 			}
@@ -102,10 +107,12 @@ export function DeleteAgentConfirmModal({
 				</div>
 				<div className="space-y-3">
 					<p className="leading-relaxed" style={{ color: theme.colors.textMain }}>
-						Are you sure you want to delete the agent "{agentName}"? This action cannot be undone.
+						<strong style={{ color: theme.colors.warning }}>Danger:</strong> You are about to delete
+						the agent "{agentName}". This action cannot be undone.
 					</p>
 					<p className="text-sm leading-relaxed" style={{ color: theme.colors.textDim }}>
-						<strong>Confirm and Erase</strong> will also move the working directory to the trash:
+						<strong>Agent + Work Directory</strong> will also move the working directory to the
+						trash:
 					</p>
 					<code
 						className="block text-xs px-2 py-1 rounded break-all"
@@ -117,6 +124,19 @@ export function DeleteAgentConfirmModal({
 					>
 						{workingDirectory}
 					</code>
+					<input
+						type="text"
+						value={confirmationText}
+						onChange={(e) => setConfirmationText(e.target.value)}
+						placeholder="Type the agent name here to confirm directory deletion"
+						className="block w-full text-sm px-3 py-2 rounded outline-none focus:ring-2 focus:ring-offset-1"
+						style={{
+							backgroundColor: theme.colors.bgMain,
+							color: theme.colors.textMain,
+							border: `1px solid ${theme.colors.border}`,
+						}}
+						aria-label="Confirm agent name"
+					/>
 				</div>
 			</div>
 		</Modal>


### PR DESCRIPTION
# Add confirmation input to prevent accidental working directory deletion

## Summary

This PR enhances the `DeleteAgentConfirmModal` component by adding a confirmation input safeguard to prevent accidental deletion of agent working directories. The destructive "delete with directory" action now requires users to type the exact agent name before the button becomes enabled.

Closes #206 

## Screenshots

Old UI (with no confirmation on the destructive "Confirm and Erase" button):

<img width="522" height="305" alt="image" src="https://github.com/user-attachments/assets/01288d81-38d8-426d-b170-c7a43e3e4268" />

New UI:

<img width="521" height="360" alt="image" src="https://github.com/user-attachments/assets/2be45922-8cfd-4b6e-9b79-c0d31540a615" />

And the "Agent + Work Directory" button only becomes enabled when the agent name is filled in:

<img width="518" height="352" alt="image" src="https://github.com/user-attachments/assets/934127e0-8989-4384-b084-fd458f8fc5d3" />


## Files Changed

| File | Change Type | Description |
|------|-------------|-------------|
| `src/renderer/components/DeleteAgentConfirmModal.tsx` | Modified | Added confirmation input and updated button labels |
| `src/__tests__/renderer/components/DeleteAgentConfirmModal.test.tsx` | Modified | Updated tests for new UI and added tests for confirmation input behavior |

## Code Changes

### DeleteAgentConfirmModal.tsx

**1. Added state management for confirmation input:**
```tsx
const [confirmationText, setConfirmationText] = useState('');
const isEraseEnabled = confirmationText === agentName;
```

**2. Renamed buttons for clarity:**
- "Confirm" → "Agent Only"
- "Confirm and Erase" → "Agent + Work Directory"

**3. Added disabled state logic to the destructive button:**
```tsx
<button
    type="button"
    onClick={isEraseEnabled ? handleConfirmAndErase : undefined}
    onKeyDown={isEraseEnabled ? (e) => handleKeyDown(e, handleConfirmAndErase) : undefined}
    disabled={!isEraseEnabled}
    className={`px-4 py-2 rounded transition-colors outline-none focus:ring-2 focus:ring-offset-1 ${
        !isEraseEnabled ? 'opacity-50 cursor-not-allowed' : ''
    }`}
    ...
>
```

**4. Added danger warning and confirmation input field:**
```tsx
<strong style={{ color: theme.colors.warning }}>Danger:</strong>
...
<input
    type="text"
    value={confirmationText}
    onChange={(e) => setConfirmationText(e.target.value)}
    placeholder="Type the agent name here to confirm directory deletion"
    aria-label="Confirm agent name"
/>
```

### DeleteAgentConfirmModal.test.tsx

Added a new test suite `confirmation input` with the following test cases:
- Button disabled by default
- Button enabled when exact agent name is typed
- Button remains disabled with partial name
- Button remains disabled with incorrect case
- Confirmation input renders with proper placeholder
- Danger warning displays with high-contrast color

## Reason for Changes

The previous implementation allowed users to accidentally delete an agent's entire working directory with a single click. This is a **destructive and irreversible operation** that could result in significant data loss. The confirmation input pattern (similar toGitHub's repository deletion) adds a deliberate friction point that:

1. Forces users to acknowledge what they're deleting
2. Prevents misclicks from causing data loss
3. Makes the severity of the action explicit with a "Danger" warning

## Impact of Changes

- **User Experience**: Slightly more friction for the destructive action, but significantly improved safety
- **Accessibility**: The input field includes proper `aria-label` for screen readers
- **Visual Clarity**: Renamed buttons more clearly indicate what each action does
- **No Breaking Changes**: The component's external API remains unchanged

## Potential Bugs / Considerations

1. **Case Sensitivity**: The confirmation is case-sensitive (`confirmationText === agentName`). This is intentional for security but users may be confused if they type the name with different casing.

2. **Copy-Paste**: Users can copy-paste the agent name from the modal text, which somewhat defeats the purpose of the confirmation. Consider whether this is acceptable UX.

3. **State Persistence**: The `confirmationText` state resets when the modal unmounts. If the modal is closed and reopened, users must type the name again (expected behavior).

## Test Plan

- All existing tests have been updated to reflect the new button names
- New test cases cover:
  - Default disabled state of the destructive button
  - Exact match enabling the button
  - Partial match keeping button disabled
  - Case mismatch keeping button disabled
  - Proper placeholder and accessibility attributes
  - Danger warning visibility

Run tests with:
```bash
npm test -- DeleteAgentConfirmModal
```

## Additional Notes

- The confirmation uses strict equality (`===`), not a case-insensitive comparison. This is a deliberate design choice to require exact input.
- The visual styling uses `opacity-50` and `cursor-not-allowed` for the disabled state, maintaining consistency with common UI patterns.