### PR TITLE
fix: correct context usage calculation to include cacheRead tokens an…

### DIFF
--- a/src/__tests__/main/process-listeners/usage-listener.test.ts
+++ b/src/__tests__/main/process-listeners/usage-listener.test.ts
@@ -162,19 +162,21 @@ describe('Usage Listener', () => {
 			});
 		});
 
-		it('should handle zero context window gracefully', async () => {
+		it('should handle zero context window gracefully (falls back to 200k default)', async () => {
 			setupListener();
 			const handler = eventHandlers.get('usage');
 			const usageStats = createMockUsageStats({ contextWindow: 0 });
 
 			handler?.('group-chat-test-chat-123-participant-TestAgent-abc123', usageStats);
 
+			// With contextWindow 0, falls back to 200k default
+			// 1800 / 200000 = 0.9% -> rounds to 1%
 			await vi.waitFor(() => {
 				expect(mockDeps.groupChatStorage.updateParticipant).toHaveBeenCalledWith(
 					'test-chat-123',
 					'TestAgent',
 					expect.objectContaining({
-						contextUsage: 0,
+						contextUsage: 1,
 					})
 				);
 			});

--- a/src/__tests__/renderer/components/HistoryDetailModal.test.tsx
+++ b/src/__tests__/renderer/components/HistoryDetailModal.test.tsx
@@ -470,9 +470,9 @@ describe('HistoryDetailModal', () => {
 				/>
 			);
 
-			// Context = (inputTokens + cacheCreationInputTokens) / contextWindow (cacheRead excluded)
-			// (5000 + 5000) / 100000 = 10%
-			expect(screen.getByText('10%')).toBeInTheDocument();
+			// Context = (inputTokens + cacheReadInputTokens + cacheCreationInputTokens) / contextWindow
+			// (5000 + 2000 + 5000) / 100000 = 12%
+			expect(screen.getByText('12%')).toBeInTheDocument();
 		});
 
 		it('should display token counts', () => {

--- a/src/__tests__/renderer/utils/contextExtractor.test.ts
+++ b/src/__tests__/renderer/utils/contextExtractor.test.ts
@@ -650,8 +650,8 @@ describe('calculateTotalTokens', () => {
 
 		const total = calculateTotalTokens(contexts);
 
-		// input + cacheCreation for each context (cacheRead excluded - cumulative)
-		expect(total).toBe(450); // (100+25) + (300+25)
+		// input + cacheRead + cacheCreation for each context
+		expect(total).toBe(575); // (100+50+25) + (300+75+25)
 	});
 });
 
@@ -694,8 +694,8 @@ describe('getContextSummary', () => {
 
 		expect(summary.totalSources).toBe(2);
 		expect(summary.totalLogs).toBe(5);
-		// (100+25) + (200+25) = 350 (cacheRead excluded - cumulative)
-		expect(summary.estimatedTokens).toBe(350);
+		// (100+50+25) + (200+75+25) = 475 (input + cacheRead + cacheCreation)
+		expect(summary.estimatedTokens).toBe(475);
 		expect(summary.byAgent['claude-code']).toBe(1);
 		expect(summary.byAgent['opencode']).toBe(1);
 	});

--- a/src/main/parsers/usage-aggregator.ts
+++ b/src/main/parsers/usage-aggregator.ts
@@ -60,12 +60,16 @@ const COMBINED_CONTEXT_AGENTS: Set<ToolType> = new Set(['codex']);
 /**
  * Calculate total context tokens based on agent-specific semantics.
  *
- * IMPORTANT: Claude Code reports CUMULATIVE session tokens, not per-request tokens.
- * The cacheReadInputTokens can exceed the context window because they accumulate
- * across all turns in the conversation. For context pressure display, we should
- * only count tokens that represent NEW context being added:
+ * For a single Anthropic API call, the total input context is the sum of:
+ *   inputTokens + cacheReadInputTokens + cacheCreationInputTokens
+ * These three fields partition the input into uncached, cache-hit, and newly-cached segments.
  *
- * Claude models: Context = input + cacheCreation (excludes cacheRead - already cached)
+ * CAVEAT: When Claude Code performs multi-tool turns (many internal API calls),
+ * the reported values may be accumulated across all internal calls within the turn.
+ * In that case the total can exceed the context window. Callers should check for
+ * this and skip the update (see estimateContextUsage).
+ *
+ * Claude models: Context = input + cacheRead + cacheCreation
  * OpenAI models: Context = input + output (combined limit)
  *
  * @param stats - The usage statistics containing token counts
@@ -79,34 +83,31 @@ export function calculateContextTokens(
 	>,
 	agentId?: ToolType
 ): number {
-	// For Claude: inputTokens = uncached new tokens, cacheCreationInputTokens = newly cached tokens
-	// cacheReadInputTokens are EXCLUDED because they represent already-cached context
-	// that Claude Code reports cumulatively across the session, not per-request.
-	// Including them would cause context % to exceed 100% impossibly.
-	const baseTokens = stats.inputTokens + (stats.cacheCreationInputTokens || 0);
-
 	// OpenAI models have combined input+output context limits
 	if (agentId && COMBINED_CONTEXT_AGENTS.has(agentId)) {
-		return baseTokens + stats.outputTokens;
+		return stats.inputTokens + (stats.cacheCreationInputTokens || 0) + stats.outputTokens;
 	}
 
-	// Claude models: output tokens don't consume context window
-	return baseTokens;
+	// Claude models: total input = uncached + cache-hit + newly-cached
+	// Output tokens don't consume the input context window
+	return (
+		stats.inputTokens + (stats.cacheReadInputTokens || 0) + (stats.cacheCreationInputTokens || 0)
+	);
 }
 
 /**
  * Estimate context usage percentage when the agent doesn't provide it directly.
  * Uses agent-specific default context window sizes for accurate estimation.
  *
- * IMPORTANT: Context calculation varies by agent:
- * - Claude models: inputTokens + cacheCreationInputTokens
- *   (cacheRead excluded - cumulative, output excluded - separate limit)
- * - OpenAI models (Codex): inputTokens + outputTokens
- *   (combined context window includes both input and output)
+ * Context calculation varies by agent:
+ * - Claude models: inputTokens + cacheReadInputTokens + cacheCreationInputTokens
+ * - OpenAI models (Codex): inputTokens + outputTokens (combined limit)
  *
- * Note: cacheReadInputTokens are NOT included because Claude Code reports them
- * as cumulative session totals, not per-request values. Including them would
- * cause context percentage to exceed 100% impossibly.
+ * Returns null when the calculated total exceeds the context window, which indicates
+ * accumulated values from multi-tool turns (many internal API calls within one turn).
+ * A single API call's total input can never exceed the context window, so values
+ * above it are definitely accumulated. Callers should preserve the previous valid
+ * percentage when this returns null.
  *
  * @param stats - The usage statistics containing token counts
  * @param agentId - The agent identifier for agent-specific context window size
@@ -126,19 +127,23 @@ export function estimateContextUsage(
 	// Calculate total context using agent-specific semantics
 	const totalContextTokens = calculateContextTokens(stats, agentId);
 
-	// If context window is provided and valid, use it
-	if (stats.contextWindow && stats.contextWindow > 0) {
-		return Math.min(100, Math.round((totalContextTokens / stats.contextWindow) * 100));
-	}
+	// Determine effective context window
+	const effectiveContextWindow =
+		stats.contextWindow && stats.contextWindow > 0
+			? stats.contextWindow
+			: agentId && agentId !== 'terminal'
+				? DEFAULT_CONTEXT_WINDOWS[agentId] || 0
+				: 0;
 
-	// If no agent specified or terminal, cannot estimate
-	if (!agentId || agentId === 'terminal') {
+	if (!effectiveContextWindow || effectiveContextWindow <= 0) {
 		return null;
 	}
 
-	// Use agent-specific default context window
-	const defaultContextWindow = DEFAULT_CONTEXT_WINDOWS[agentId];
-	if (!defaultContextWindow || defaultContextWindow <= 0) {
+	// If total exceeds context window, the values are accumulated across multiple
+	// internal API calls within a complex turn (tool use chains). A single API call's
+	// total input cannot exceed the context window. Return null to signal callers
+	// should keep the previous valid percentage.
+	if (totalContextTokens > effectiveContextWindow) {
 		return null;
 	}
 
@@ -146,7 +151,7 @@ export function estimateContextUsage(
 		return 0;
 	}
 
-	return Math.min(100, Math.round((totalContextTokens / defaultContextWindow) * 100));
+	return Math.round((totalContextTokens / effectiveContextWindow) * 100);
 }
 
 /**


### PR DESCRIPTION
### Problem

The context window usage gauge had several bugs causing inaccurate readings:

1. **Underestimation** — `cacheReadInputTokens` was excluded from the formula. For a single Anthropic API call, the total input context is `inputTokens + cacheReadInputTokens + cacheCreationInputTokens` (three partitions of the same input: uncached, cache-hit, newly-cached). Excluding cache-read meant the gauge showed ~3% when reality was ~23%.

2. **False 100%** — During complex multi-tool turns, Claude Code accumulates token values across all internal API calls in a single `result` JSONL message. With cache-read included, these accumulated totals easily exceed the 200K context window (e.g., 2.5M cache-read from 40 internal calls each reading ~62K). The old code capped at 100%, triggering false compact warnings.

3. **Tooltip inconsistency** — `MainPanel.tsx` recalculated context tokens independently from raw tab `usageStats`, bypassing the fix in `App.tsx`. The hover tooltip still showed 100% even when the gauge was correct.

4. **Group chat affected** — The usage-listener for group chat participants and moderators had the same formula bug, passing through inflated percentages.

### Root cause

Claude Code reports a single `result` JSONL event per turn with token values **summed across all internal API calls**. For a turn with N tool uses, each internal call reads the full conversation from cache, so:

- `cacheReadInputTokens` ≈ context_size × N (e.g., 62K × 40 = 2.5M)
- `inputTokens` ≈ uncached_portion × N
- `outputTokens` ≈ per_call_output × N

These sums are useful for billing but meaningless for measuring context window fill. A single API call's total input can never exceed the context window, so `total > window` definitively indicates accumulated values.

### Fix

- **Formula**: `calculateContextTokens` now includes all three input token types: `input + cacheRead + cacheCreation`
- **Accumulated detection**: `estimateContextUsage` returns `null` when `total > contextWindow` (impossible for a single call → must be accumulated)
- **App.tsx**: When `null`, skips the update entirely — the last valid percentage is preserved. No estimates, no high-water mark, just real measurements.
- **MainPanel.tsx**: When raw tokens exceed window, back-derives display tokens from `session.contextUsage` (the preserved percentage)
- **usage-listener.ts**: Group chat participant uses conditional update (omits context fields when accumulated). Moderator emits `-1` sentinel so the UI handler preserves previous values.
- **Removed `Math.min(100, ...)`**: No longer needed — the `null` return handles overflow, and valid measurements are mathematically bounded to 0-100%.

### Behavior

| Scenario | Before | After |
|----------|--------|-------|
| Normal turn | underestimated | accurate |
| Multi-tool turn | 100% (false positive) | Holds last valid % |
| Hover tooltip during tool turn | 100% | Same as gauge |
| Compact warning | Premature | Only at real thresholds |

### Files changed (11)

**Source (5):**
- `src/renderer/utils/contextUsage.ts` — Formula fix + accumulated detection
- `src/main/parsers/usage-aggregator.ts` — Same formula fix (main process copy)
- `src/renderer/App.tsx` — Simplified onUsage handler, skip update when null
- `src/renderer/components/MainPanel.tsx` — Derive from preserved percentage when accumulated
- `src/main/process-listeners/usage-listener.ts` — Group chat accumulated value handling

**Tests (6):**
- `contextUsage.test.ts` — Updated assertions for new formula, added accumulated detection tests
- `usage-aggregator.test.ts` — Same pattern, added accumulated detection tests
- `usage-listener.test.ts` — Updated fallback test for 200K default window
- `MainPanel.test.tsx` — Updated cap test to use preserved `session.contextUsage`
- `contextExtractor.test.ts` — Updated token totals (450→575, 350→475)
- `HistoryDetailModal.test.tsx` — Updated display percentage (10%→12%)

### Testing

- 16,316 tests passing, 0 failures
- TypeScript clean (all 3 configs)
- ESLint: 0 errors (37 pre-existing warnings, none from this change)
- Full production build passes (prompts, main, preload, renderer, web, cli)
