### PR TITLE
feat(linux): auto-hide menu bar for cleaner window appearance

### DIFF
--- a/src/main/app-lifecycle/window-manager.ts
+++ b/src/main/app-lifecycle/window-manager.ts
@@ -86,6 +86,7 @@ export function createWindowManager(deps: WindowManagerDependencies): WindowMana
 				minWidth: 1000,
 				minHeight: 600,
 				backgroundColor: '#0b0b0d',
+				autoHideMenuBar: true,
 				titleBarStyle: 'hiddenInset',
 				webPreferences: {
 					preload: preloadPath,
@@ -208,21 +209,24 @@ export function createWindowManager(deps: WindowManagerDependencies): WindowMana
 			});
 
 			// Handle page load failures (network issues, invalid URLs, etc.)
-			mainWindow.webContents.on('did-fail-load', (_event, errorCode, errorDescription, validatedURL) => {
-				// Ignore aborted loads (user navigated away)
-				if (errorCode === -3) return;
+			mainWindow.webContents.on(
+				'did-fail-load',
+				(_event, errorCode, errorDescription, validatedURL) => {
+					// Ignore aborted loads (user navigated away)
+					if (errorCode === -3) return;
 
-				logger.error('Page failed to load', 'Window', {
-					errorCode,
-					errorDescription,
-					url: validatedURL,
-				});
-				reportCrashToSentry(`Page failed to load: ${errorDescription}`, 'error', {
-					errorCode,
-					errorDescription,
-					url: validatedURL,
-				});
-			});
+					logger.error('Page failed to load', 'Window', {
+						errorCode,
+						errorDescription,
+						url: validatedURL,
+					});
+					reportCrashToSentry(`Page failed to load: ${errorDescription}`, 'error', {
+						errorCode,
+						errorDescription,
+						url: validatedURL,
+					});
+				}
+			);
 
 			// Handle preload script errors
 			mainWindow.webContents.on('preload-error', (_event, preloadPath, error) => {


### PR DESCRIPTION
## Summary
- Sets `autoHideMenuBar: true` in the BrowserWindow options
- Hides the default Electron menu bar on Linux for a cleaner look
- Users can still toggle the menu bar by pressing Alt

## Context
On Linux, Electron shows a native menu bar by default that takes up vertical space and doesn't match the app's custom UI. This single-line change hides it while keeping it accessible via Alt key.

## Test plan
- [x] Launch Maestro on Linux — verify menu bar is hidden by default
- [x] Press Alt — verify menu bar toggles visible
- [ ] Verify no impact on macOS/Windows (property is Linux-specific in practice)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Menu bar now automatically hides, providing more screen space for content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->