### PR TITLE
feat: add native titlebar option

### DIFF
--- a/src/__tests__/main/stores/utils.test.ts
+++ b/src/__tests__/main/stores/utils.test.ts
@@ -212,6 +212,7 @@ describe('stores/utils', () => {
 			expect(result).toEqual({
 				crashReportingEnabled: true,
 				disableGpuAcceleration: false,
+				useNativeTitleBar: false,
 			});
 		});
 
@@ -233,6 +234,7 @@ describe('stores/utils', () => {
 			expect(result).toEqual({
 				crashReportingEnabled: true,
 				disableGpuAcceleration: true,
+				useNativeTitleBar: false,
 			});
 		});
 
@@ -252,6 +254,7 @@ describe('stores/utils', () => {
 			expect(result).toEqual({
 				crashReportingEnabled: true,
 				disableGpuAcceleration: false,
+				useNativeTitleBar: false,
 			});
 		});
 	});

--- a/src/main/app-lifecycle/window-manager.ts
+++ b/src/main/app-lifecycle/window-manager.ts
@@ -56,6 +56,8 @@ export interface WindowManagerDependencies {
 	rendererPath: string;
 	/** Development server URL */
 	devServerUrl: string;
+	/** Whether to use the native OS title bar instead of custom title bar */
+	useNativeTitleBar: boolean;
 }
 
 /** Window manager instance */
@@ -71,7 +73,7 @@ export interface WindowManager {
  * @returns WindowManager instance
  */
 export function createWindowManager(deps: WindowManagerDependencies): WindowManager {
-	const { windowStateStore, isDevelopment, preloadPath, rendererPath, devServerUrl } = deps;
+	const { windowStateStore, isDevelopment, preloadPath, rendererPath, devServerUrl, useNativeTitleBar } = deps;
 
 	return {
 		createWindow: (): BrowserWindow => {
@@ -86,7 +88,7 @@ export function createWindowManager(deps: WindowManagerDependencies): WindowMana
 				minWidth: 1000,
 				minHeight: 600,
 				backgroundColor: '#0b0b0d',
-				titleBarStyle: 'hiddenInset',
+				...(useNativeTitleBar ? {} : { titleBarStyle: 'hiddenInset' as const }),
 				webPreferences: {
 					preload: preloadPath,
 					contextIsolation: true,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -143,7 +143,7 @@ if (isDevelopment && !DEMO_MODE && !process.env.USE_PROD_DATA) {
 const { syncPath, bootstrapStore } = initializeStores({ productionDataPath });
 
 // Get early settings before Sentry init (for crash reporting and GPU acceleration)
-const { crashReportingEnabled, disableGpuAcceleration } = getEarlySettings(syncPath);
+const { crashReportingEnabled, disableGpuAcceleration, useNativeTitleBar } = getEarlySettings(syncPath);
 
 // Disable GPU hardware acceleration if user has opted out or in WSL environment
 // Must be called before app.ready event
@@ -234,6 +234,7 @@ const windowManager = createWindowManager({
 	preloadPath: path.join(__dirname, 'preload.js'),
 	rendererPath: path.join(__dirname, '../renderer/index.html'),
 	devServerUrl: devServerUrl,
+	useNativeTitleBar,
 });
 
 // Create web server factory with dependency injection (Phase 2 refactoring)

--- a/src/main/stores/utils.ts
+++ b/src/main/stores/utils.ts
@@ -197,10 +197,12 @@ function isWslEnvironment(): boolean {
 export function getEarlySettings(syncPath: string): {
 	crashReportingEnabled: boolean;
 	disableGpuAcceleration: boolean;
+	useNativeTitleBar: boolean;
 } {
 	const earlyStore = new Store<{
 		crashReportingEnabled: boolean;
 		disableGpuAcceleration: boolean;
+		useNativeTitleBar: boolean;
 	}>({
 		name: 'maestro-settings',
 		cwd: syncPath,
@@ -217,6 +219,7 @@ export function getEarlySettings(syncPath: string): {
 	return {
 		crashReportingEnabled: earlyStore.get('crashReportingEnabled', true),
 		disableGpuAcceleration: explicitGpuSetting ?? defaultDisableGpu,
+		useNativeTitleBar: earlyStore.get('useNativeTitleBar', false),
 	};
 }
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -571,6 +571,9 @@ function MaestroConsoleInner() {
 
 		// File tab refresh settings
 		fileTabAutoRefreshEnabled,
+
+		// Title bar settings
+		useNativeTitleBar,
 	} = settings;
 
 	// --- KEYBOARD SHORTCUT HELPERS ---
@@ -13306,7 +13309,7 @@ You are taking over this conversation. Based on the context above, provide a bri
 		<GitStatusProvider sessions={sessions} activeSessionId={activeSessionId}>
 			<div
 				className={`flex h-screen w-full font-mono overflow-hidden transition-colors duration-300 ${
-					isMobileLandscape ? 'pt-0' : 'pt-10'
+					isMobileLandscape || useNativeTitleBar ? 'pt-0' : 'pt-10'
 				}`}
 				style={{
 					backgroundColor: theme.colors.bgMain,
@@ -13353,8 +13356,8 @@ You are taking over this conversation. Based on the context above, provide a bri
 					</div>
 				)}
 
-				{/* --- DRAGGABLE TITLE BAR (hidden in mobile landscape) --- */}
-				{!isMobileLandscape && (
+				{/* --- DRAGGABLE TITLE BAR (hidden in mobile landscape or when using native title bar) --- */}
+				{!isMobileLandscape && !useNativeTitleBar && (
 					<div
 						className="fixed top-0 left-0 right-0 h-10 flex items-center justify-center"
 						style={

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -311,6 +311,9 @@ export const SettingsModal = memo(function SettingsModal(props: SettingsModalPro
 		// Automatic tab naming settings
 		automaticTabNamingEnabled,
 		setAutomaticTabNamingEnabled,
+		// Title bar settings
+		useNativeTitleBar,
+		setUseNativeTitleBar,
 	} = useSettings();
 
 	const [activeTab, setActiveTab] = useState<
@@ -1546,6 +1549,53 @@ export const SettingsModal = memo(function SettingsModal(props: SettingsModalPro
 											<span
 												className={`absolute left-0 top-0.5 w-4 h-4 rounded-full bg-white transition-transform ${
 													disableConfetti ? 'translate-x-5' : 'translate-x-0.5'
+												}`}
+											/>
+										</button>
+									</div>
+
+									{/* Native Title Bar Toggle */}
+									<div
+										className="flex items-center justify-between cursor-pointer pt-3 border-t"
+										style={{ borderColor: theme.colors.border }}
+										onClick={() => setUseNativeTitleBar(!useNativeTitleBar)}
+										role="button"
+										tabIndex={0}
+										onKeyDown={(e) => {
+											if (e.key === 'Enter' || e.key === ' ') {
+												e.preventDefault();
+												setUseNativeTitleBar(!useNativeTitleBar);
+											}
+										}}
+									>
+										<div className="flex-1 pr-3">
+											<div className="font-medium" style={{ color: theme.colors.textMain }}>
+												Use native title bar
+											</div>
+											<div
+												className="text-xs opacity-50 mt-0.5"
+												style={{ color: theme.colors.textDim }}
+											>
+												Use the OS native title bar instead of Maestro&apos;s custom title bar. Requires restart to take effect.
+											</div>
+										</div>
+										<button
+											onClick={(e) => {
+												e.stopPropagation();
+												setUseNativeTitleBar(!useNativeTitleBar);
+											}}
+											className="relative w-10 h-5 rounded-full transition-colors flex-shrink-0"
+											style={{
+												backgroundColor: useNativeTitleBar
+													? theme.colors.accent
+													: theme.colors.bgActivity,
+											}}
+											role="switch"
+											aria-checked={useNativeTitleBar}
+										>
+											<span
+												className={`absolute left-0 top-0.5 w-4 h-4 rounded-full bg-white transition-transform ${
+													useNativeTitleBar ? 'translate-x-5' : 'translate-x-0.5'
 												}`}
 											/>
 										</button>

--- a/src/renderer/hooks/settings/useSettings.ts
+++ b/src/renderer/hooks/settings/useSettings.ts
@@ -350,6 +350,10 @@ export interface UseSettingsReturn {
 	// File tab auto-refresh settings
 	fileTabAutoRefreshEnabled: boolean;
 	setFileTabAutoRefreshEnabled: (value: boolean) => void;
+
+	// Title bar settings
+	useNativeTitleBar: boolean;
+	setUseNativeTitleBar: (value: boolean) => void;
 }
 
 export function useSettings(): UseSettingsReturn {
@@ -507,6 +511,9 @@ export function useSettings(): UseSettingsReturn {
 
 	// File tab auto-refresh settings
 	const [fileTabAutoRefreshEnabled, setFileTabAutoRefreshEnabledState] = useState(false); // Default: disabled
+
+	// Title bar settings
+	const [useNativeTitleBar, setUseNativeTitleBarState] = useState(false); // Default: use custom title bar
 
 	// Wrapper functions that persist to electron-store
 	// PERF: All wrapped in useCallback to prevent re-renders
@@ -1322,6 +1329,12 @@ export function useSettings(): UseSettingsReturn {
 		window.maestro.settings.set('fileTabAutoRefreshEnabled', value);
 	}, []);
 
+	// Native title bar toggle (requires restart)
+	const setUseNativeTitleBar = useCallback((value: boolean) => {
+		setUseNativeTitleBarState(value);
+		window.maestro.settings.set('useNativeTitleBar', value);
+	}, []);
+
 	// Load settings from electron-store
 	// This function is called on mount and on system resume (after sleep/suspend)
 	// PERF: Use batch loading to reduce IPC calls from ~60 to 3
@@ -1396,6 +1409,7 @@ export function useSettings(): UseSettingsReturn {
 				const savedSshRemoteHonorGitignore = allSettings['sshRemoteHonorGitignore'];
 				const savedAutomaticTabNamingEnabled = allSettings['automaticTabNamingEnabled'];
 				const savedFileTabAutoRefreshEnabled = allSettings['fileTabAutoRefreshEnabled'];
+				const savedUseNativeTitleBar = allSettings['useNativeTitleBar'];
 
 				if (savedEnterToSendAI !== undefined) setEnterToSendAIState(savedEnterToSendAI as boolean);
 				if (savedEnterToSendTerminal !== undefined)
@@ -1760,6 +1774,11 @@ export function useSettings(): UseSettingsReturn {
 				if (savedFileTabAutoRefreshEnabled !== undefined) {
 					setFileTabAutoRefreshEnabledState(savedFileTabAutoRefreshEnabled as boolean);
 				}
+
+				// Title bar settings
+				if (savedUseNativeTitleBar !== undefined) {
+					setUseNativeTitleBarState(savedUseNativeTitleBar as boolean);
+				}
 			} catch (error) {
 				console.error('[Settings] Failed to load settings:', error);
 			} finally {
@@ -1938,6 +1957,8 @@ export function useSettings(): UseSettingsReturn {
 			setAutomaticTabNamingEnabled,
 			fileTabAutoRefreshEnabled,
 			setFileTabAutoRefreshEnabled,
+			useNativeTitleBar,
+			setUseNativeTitleBar,
 		}),
 		[
 			// State values
@@ -2083,6 +2104,8 @@ export function useSettings(): UseSettingsReturn {
 			setAutomaticTabNamingEnabled,
 			fileTabAutoRefreshEnabled,
 			setFileTabAutoRefreshEnabled,
+			useNativeTitleBar,
+			setUseNativeTitleBar,
 		]
 	);
 }


### PR DESCRIPTION
Adds a toggle in Settings > General to switch from Maestro's custom title bar to the OS native title bar. Useful for tiling window manager users where the custom title bar is wasted vertical space. Requires restart to take effect.