### PR TITLE
Fix Windows wizard failure by sending prompt via stdin for stream-json mode

### DIFF
--- a/src/main/process-manager/spawners/ChildProcessSpawner.ts
+++ b/src/main/process-manager/spawners/ChildProcessSpawner.ts
@@ -73,7 +73,11 @@ export class ChildProcessSpawner {
 
 		// Check if prompt will be sent via stdin instead of command line
 		// This is critical for SSH remote execution to avoid shell escaping issues
-		const promptViaStdin = sendPromptViaStdin || sendPromptViaStdinRaw;
+		// Also critical on Windows: when using stream-json output mode, the prompt is sent
+		// via stdin (see stream-json stdin write below). Adding it as a CLI arg too would
+		// exceed cmd.exe's ~8191 character command line limit, causing immediate exit code 1.
+		const argsHaveStreamJson = args.some((arg) => arg.includes('stream-json'));
+		const promptViaStdin = sendPromptViaStdin || sendPromptViaStdinRaw || argsHaveStreamJson;
 
 		// Build final args based on batch mode and images
 		let finalArgs: string[];


### PR DESCRIPTION
## Summary
- Fix Windows wizard failure caused by command line length exceeding cmd.exe's ~8191 character limit
- When using `stream-json` output mode, the prompt is now sent only via stdin (not duplicated as CLI arg)

## Root Cause
On Windows with `stream-json` mode, the prompt was being added both as a CLI argument AND sent via stdin. This caused the command line to exceed Windows' limit, resulting in immediate exit code 1.

## Test Plan
- [x] Verified build succeeds
- [x] Verified 18,179 tests pass (18 failures are pre-existing Windows path separator issues)
- [ ] Manual test on Windows with wizard mode

Fixes #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)
