### PR TITLE
Improve out-of-credits warnings with structured provider details

### DIFF
--- a/src/__tests__/main/parsers/error-patterns.test.ts
+++ b/src/__tests__/main/parsers/error-patterns.test.ts
@@ -332,6 +332,16 @@ describe('error-patterns', () => {
 				expect(result?.type).toBe('rate_limited');
 				expect(result?.recoverable).toBe(false);
 			});
+
+			it('should detect credit exhaustion (exceeded current quota)', () => {
+				const result = matchErrorPattern(
+					CLAUDE_ERROR_PATTERNS,
+					'You exceeded your current quota, please check your plan and billing details.'
+				);
+				expect(result).not.toBeNull();
+				expect(result?.type).toBe('rate_limited');
+				expect(result?.recoverable).toBe(false);
+			});
 		});
 
 		describe('network_error patterns', () => {
@@ -465,6 +475,16 @@ describe('error-patterns', () => {
 
 				it('should match "quota exceeded"', () => {
 					const result = matchErrorPattern(CODEX_ERROR_PATTERNS, 'quota exceeded');
+					expect(result).not.toBeNull();
+					expect(result?.type).toBe('rate_limited');
+					expect(result?.recoverable).toBe(false);
+				});
+
+				it('should detect credit exhaustion (billing/quota)', () => {
+					const result = matchErrorPattern(
+						CODEX_ERROR_PATTERNS,
+						'Error: insufficient_quota (You exceeded your current quota, please check your plan and billing details.)'
+					);
 					expect(result).not.toBeNull();
 					expect(result?.type).toBe('rate_limited');
 					expect(result?.recoverable).toBe(false);

--- a/src/__tests__/renderer/components/AgentErrorModal.test.tsx
+++ b/src/__tests__/renderer/components/AgentErrorModal.test.tsx
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { LayerStackProvider } from '../../../renderer/contexts/LayerStackContext';
+import { AgentErrorModal } from '../../../renderer/components/AgentErrorModal';
+import type { Theme, AgentError } from '../../../renderer/types';
+
+const mockTheme: Theme = {
+	id: 'test-theme',
+	name: 'Test Theme',
+	mode: 'dark',
+	colors: {
+		bgMain: '#1a1a1a',
+		bgSidebar: '#242424',
+		bgActivity: '#2a2a2a',
+		textMain: '#ffffff',
+		textDim: '#888888',
+		accent: '#3b82f6',
+		accentForeground: '#ffffff',
+		border: '#333333',
+		error: '#ef4444',
+		success: '#22c55e',
+		warning: '#f59e0b',
+		cursor: '#ffffff',
+		terminalBg: '#1a1a1a',
+	},
+};
+
+const TestWrapper = ({ children }: { children: React.ReactNode }) => (
+	<LayerStackProvider>{children}</LayerStackProvider>
+);
+
+describe('AgentErrorModal', () => {
+	it('should show rate limit info when headers are present in parsedJson', () => {
+		const error: AgentError = {
+			type: 'rate_limited',
+			message: 'Usage credits exhausted (billing/quota).',
+			recoverable: false,
+			agentId: 'claude-code',
+			timestamp: Date.now(),
+			parsedJson: {
+				headers: {
+					'retry-after': '30',
+					'x-ratelimit-remaining-requests': '0',
+					'x-ratelimit-limit-requests': '100',
+					'x-ratelimit-reset-requests': '10',
+					'x-ratelimit-remaining-tokens': '0',
+					'x-ratelimit-limit-tokens': '1000',
+					'x-ratelimit-reset-tokens': '10',
+				},
+			},
+		};
+
+		render(
+			<AgentErrorModal
+				theme={mockTheme}
+				error={error}
+				agentName="Claude Code"
+				sessionName="Test Session"
+				recoveryActions={[]}
+				onDismiss={vi.fn()}
+				dismissible={false}
+			/>,
+			{ wrapper: TestWrapper }
+		);
+
+		expect(screen.getByText('Usage Limit Reached')).toBeInTheDocument();
+		expect(screen.getByText('Rate limit info')).toBeInTheDocument();
+		expect(screen.getByText('Retry after: 30s')).toBeInTheDocument();
+		expect(screen.getByText('Requests: 0/100 (in 10s)')).toBeInTheDocument();
+		expect(screen.getByText('Tokens: 0/1,000 (in 10s)')).toBeInTheDocument();
+	});
+
+	it('should not show rate limit info for non-rate-limited errors', () => {
+		const error: AgentError = {
+			type: 'network_error',
+			message: 'Connection failed.',
+			recoverable: true,
+			agentId: 'claude-code',
+			timestamp: Date.now(),
+			parsedJson: {
+				headers: {
+					'retry-after': '30',
+				},
+			},
+		};
+
+		render(
+			<AgentErrorModal
+				theme={mockTheme}
+				error={error}
+				agentName="Claude Code"
+				sessionName="Test Session"
+				recoveryActions={[]}
+				onDismiss={vi.fn()}
+				dismissible={true}
+			/>,
+			{ wrapper: TestWrapper }
+		);
+
+		expect(screen.queryByText('Rate limit info')).toBeNull();
+	});
+
+	it('should parse nested tuple-style header containers', () => {
+		const error: AgentError = {
+			type: 'rate_limited',
+			message: 'Usage limit reached.',
+			recoverable: false,
+			agentId: 'codex',
+			timestamp: Date.now(),
+			parsedJson: {
+				error: {
+					response_headers: [
+						['retry-after', 'Wed, 21 Oct 2030 07:28:00 GMT'],
+						['x-ratelimit-remaining-requests', '1'],
+						['x-ratelimit-limit-requests', '100'],
+					],
+				},
+			},
+		};
+
+		render(
+			<AgentErrorModal
+				theme={mockTheme}
+				error={error}
+				agentName="Codex"
+				sessionName="Test Session"
+				recoveryActions={[]}
+				onDismiss={vi.fn()}
+				dismissible={false}
+			/>,
+			{ wrapper: TestWrapper }
+		);
+
+		expect(screen.getByText('Rate limit info')).toBeInTheDocument();
+		expect(screen.getByText(/^Retry after: at /)).toBeInTheDocument();
+		expect(screen.getByText('Requests: 1/100')).toBeInTheDocument();
+	});
+});

--- a/src/main/parsers/error-patterns.ts
+++ b/src/main/parsers/error-patterns.ts
@@ -54,6 +54,15 @@ export type AgentErrorPatterns = {
 	[K in AgentErrorType]?: ErrorPattern[];
 };
 
+const QUOTA_EXCEEDED_PATTERN =
+	/exceed(?:ed|s)?\b.*?\bquota\b|\bquota\b.*?\bexceed(?:ed|s)?\b/i;
+const CREDIT_EXHAUSTION_PATTERN =
+	/insufficient[_\s-]*quota|insufficient[_\s-]*credits?|insufficient balance|not enough credits?|no (?:remaining )?credits?|credits? exhausted|(?:credit|quota) exhausted|credit balance.*too low|balance.*too low|out of (?:credits?|quota)|billing.*(?:hard\s+)?limit|plan and billing details|payment required|\b402\b.*payment required|\bpayment required\b.*\b402\b/i;
+const QUOTA_EXCEEDED_MESSAGE =
+	'Usage limit reached (quota). Add credits/upgrade your plan (or wait for quota reset), then retry.';
+const CREDIT_EXHAUSTION_MESSAGE =
+	"Usage credits exhausted (billing/quota). Restarting won't help; add credits/upgrade your plan, then retry.";
+
 // ============================================================================
 // Claude Code Error Patterns
 // ============================================================================
@@ -188,14 +197,22 @@ export const CLAUDE_ERROR_PATTERNS: AgentErrorPatterns = {
 			recoverable: true,
 		},
 		{
-			pattern: /quota exceeded/i,
-			message: 'Your API quota has been exceeded.',
+			// OpenAI-style: "You exceeded your current quota, please check your plan and billing details."
+			pattern: QUOTA_EXCEEDED_PATTERN,
+			message: QUOTA_EXCEEDED_MESSAGE,
+			recoverable: false,
+		},
+		{
+			// Common provider codes/messages for credit exhaustion
+			pattern: CREDIT_EXHAUSTION_PATTERN,
+			message: CREDIT_EXHAUSTION_MESSAGE,
 			recoverable: false,
 		},
 		{
 			// Matches: "usage limit" or "hit your limit"
 			pattern: /usage.?limit|hit your.*limit/i,
-			message: 'Usage limit reached. Check your plan for available quota.',
+			message:
+				'Usage limit reached. Check your plan/billing (or wait for quota reset), then retry.',
 			recoverable: false,
 		},
 	],
@@ -447,8 +464,15 @@ export const CODEX_ERROR_PATTERNS: AgentErrorPatterns = {
 			recoverable: true,
 		},
 		{
-			pattern: /quota.*exceeded/i,
-			message: 'Your API quota has been exceeded.',
+			// OpenAI-style: "You exceeded your current quota, please check your plan and billing details."
+			pattern: QUOTA_EXCEEDED_PATTERN,
+			message: QUOTA_EXCEEDED_MESSAGE,
+			recoverable: false,
+		},
+		{
+			// Common provider codes/messages for credit exhaustion
+			pattern: CREDIT_EXHAUSTION_PATTERN,
+			message: CREDIT_EXHAUSTION_MESSAGE,
 			recoverable: false,
 		},
 		{

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -3063,7 +3063,9 @@ function MaestroConsoleInner() {
 									: agentError.type === 'token_exhaustion'
 										? '- Start a new session to reset the context window'
 										: agentError.type === 'rate_limited'
-											? '- Wait a few minutes before retrying'
+											? agentError.recoverable
+												? '- Wait a few minutes before retrying'
+												: '- Add credits/upgrade your plan (or wait for quota reset), then resume Auto Run'
 											: agentError.type === 'network_error'
 												? '- Check your internet connection and try again'
 												: '- Review the error message and take appropriate action',

--- a/src/renderer/components/AgentErrorModal.tsx
+++ b/src/renderer/components/AgentErrorModal.tsx
@@ -35,6 +35,192 @@ import { MODAL_PRIORITIES } from '../constants/modalPriorities';
 import { Modal } from './ui/Modal';
 import { CollapsibleJsonViewer } from './CollapsibleJsonViewer';
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function addHeaderEntry(headers: Record<string, string>, key: string, value: unknown): void {
+	if (typeof value === 'string' || typeof value === 'number') {
+		headers[key.toLowerCase()] = String(value);
+	}
+}
+
+function collectHeadersFromContainer(headers: Record<string, string>, container: unknown): void {
+	if (isRecord(container)) {
+		for (const [hKey, hValue] of Object.entries(container)) {
+			addHeaderEntry(headers, hKey, hValue);
+		}
+		return;
+	}
+
+	if (Array.isArray(container)) {
+		for (const entry of container) {
+			if (Array.isArray(entry) && entry.length >= 2 && typeof entry[0] === 'string') {
+				addHeaderEntry(headers, entry[0], entry[1]);
+			} else if (isRecord(entry) && typeof entry.key === 'string') {
+				addHeaderEntry(headers, entry.key, entry.value);
+			}
+		}
+	}
+}
+
+function isHeaderContainerKey(keyLower: string): boolean {
+	return (
+		keyLower === 'headers' ||
+		keyLower === 'responseheaders' ||
+		keyLower === 'response_headers' ||
+		keyLower === 'httpheaders' ||
+		keyLower === 'http_headers' ||
+		keyLower.endsWith('_headers') ||
+		keyLower.endsWith('-headers')
+	);
+}
+
+function collectHeaderMaps(parsedJson: unknown): Record<string, string> {
+	const headers: Record<string, string> = {};
+
+	const stack: Array<{ value: unknown; depth: number }> = [{ value: parsedJson, depth: 0 }];
+	const seen = new Set<object>();
+
+	while (stack.length > 0) {
+		const current = stack.pop();
+		if (!current) break;
+
+		const { value, depth } = current;
+		if (depth > 6 || value === null || value === undefined) continue;
+
+		if (Array.isArray(value)) {
+			for (const item of value) {
+				stack.push({ value: item, depth: depth + 1 });
+			}
+			continue;
+		}
+
+		if (!isRecord(value)) continue;
+		if (seen.has(value)) continue;
+		seen.add(value);
+
+		for (const [key, child] of Object.entries(value)) {
+			if (isHeaderContainerKey(key.toLowerCase())) {
+				collectHeadersFromContainer(headers, child);
+			}
+
+			stack.push({ value: child, depth: depth + 1 });
+		}
+	}
+
+	return headers;
+}
+
+function parseFiniteInt(value: string | undefined): number | null {
+	if (!value) return null;
+	const normalized = value.trim();
+	if (!/^-?\d+$/.test(normalized)) return null;
+	const n = Number(normalized);
+	return Number.isSafeInteger(n) ? n : null;
+}
+
+function formatResetValue(raw: string | undefined): string | null {
+	if (!raw) return null;
+	const v = raw.trim();
+	if (!v) return null;
+
+	// Duration formats (e.g., "30s", "120ms", "2m", "1h")
+	const durationMatch = v.match(/^(\d+(?:\.\d+)?)(ms|s|m|h)$/i);
+	if (durationMatch) {
+		const amount = Number(durationMatch[1]);
+		const unit = durationMatch[2].toLowerCase();
+		if (!Number.isFinite(amount)) return v;
+		const seconds =
+			unit === 'ms' ? amount / 1000 : unit === 'm' ? amount * 60 : unit === 'h' ? amount * 3600 : amount;
+		const rounded = Math.max(0, Math.round(seconds));
+		return `in ${rounded}s`;
+	}
+
+	// Plain seconds (common for reset values)
+	if (/^\d{1,9}$/.test(v)) {
+		return `in ${parseInt(v, 10)}s`;
+	}
+
+	// Epoch seconds/ms
+	if (/^\d{10,}$/.test(v)) {
+		const asNumber = Number(v);
+		const ms = asNumber > 1e12 ? asNumber : asNumber > 1e9 ? asNumber * 1000 : asNumber;
+		const d = new Date(ms);
+		if (!Number.isNaN(d.getTime())) {
+			return `at ${d.toLocaleTimeString()}`;
+		}
+	}
+
+	// ISO-8601 timestamps
+	if (/[a-z]/i.test(v) || v.includes('-') || v.includes('T') || v.includes(':') || v.includes(',')) {
+		const d = new Date(v);
+		if (!Number.isNaN(d.getTime())) {
+			return `at ${d.toLocaleTimeString()}`;
+		}
+	}
+
+	return v;
+}
+
+function extractRateLimitInfoLines(parsedJson: unknown): string[] {
+	if (parsedJson === undefined || parsedJson === null) return [];
+
+	const headers = collectHeaderMaps(parsedJson);
+	const getHeader = (...names: string[]) => {
+		for (const name of names) {
+			const v = headers[name.toLowerCase()];
+			if (v !== undefined) return v;
+		}
+		return undefined;
+	};
+
+	const retryAfterRaw = getHeader('retry-after');
+	const retryAfter = parseFiniteInt(retryAfterRaw);
+	const retryAfterFormatted = retryAfter === null ? formatResetValue(retryAfterRaw) : null;
+
+	const requestsRemaining = parseFiniteInt(
+		getHeader('x-ratelimit-remaining-requests', 'anthropic-ratelimit-requests-remaining')
+	);
+	const requestsLimit = parseFiniteInt(
+		getHeader('x-ratelimit-limit-requests', 'anthropic-ratelimit-requests-limit')
+	);
+	const requestsReset = formatResetValue(
+		getHeader('x-ratelimit-reset-requests', 'anthropic-ratelimit-requests-reset')
+	);
+
+	const tokensRemaining = parseFiniteInt(
+		getHeader('x-ratelimit-remaining-tokens', 'anthropic-ratelimit-tokens-remaining')
+	);
+	const tokensLimit = parseFiniteInt(getHeader('x-ratelimit-limit-tokens', 'anthropic-ratelimit-tokens-limit'));
+	const tokensReset = formatResetValue(getHeader('x-ratelimit-reset-tokens', 'anthropic-ratelimit-tokens-reset'));
+
+	const lines: string[] = [];
+	if (retryAfter !== null) {
+		lines.push(`Retry after: ${retryAfter}s`);
+	} else if (retryAfterFormatted) {
+		lines.push(`Retry after: ${retryAfterFormatted}`);
+	}
+
+	if (requestsRemaining !== null || requestsLimit !== null) {
+		const remainingText = requestsRemaining !== null ? `${requestsRemaining}` : '?';
+		const limitText = requestsLimit !== null ? `${requestsLimit}` : '?';
+		lines.push(`Requests: ${remainingText}/${limitText}${requestsReset ? ` (${requestsReset})` : ''}`);
+	} else if (requestsReset) {
+		lines.push(`Requests reset: ${requestsReset}`);
+	}
+
+	if (tokensRemaining !== null || tokensLimit !== null) {
+		const remainingText = tokensRemaining !== null ? `${tokensRemaining.toLocaleString('en-US')}` : '?';
+		const limitText = tokensLimit !== null ? `${tokensLimit.toLocaleString('en-US')}` : '?';
+		lines.push(`Tokens: ${remainingText}/${limitText}${tokensReset ? ` (${tokensReset})` : ''}`);
+	} else if (tokensReset) {
+		lines.push(`Tokens reset: ${tokensReset}`);
+	}
+
+	return lines;
+}
+
 /**
  * Props for recovery action buttons
  */
@@ -133,10 +319,17 @@ export function AgentErrorModal({
 
 	// Check if we have JSON details to show
 	const hasJsonDetails = error.parsedJson !== undefined;
+	const rateLimitInfoLines = useMemo(
+		() => (error.type === 'rate_limited' ? extractRateLimitInfoLines(error.parsedJson) : []),
+		[error.type, error.parsedJson]
+	);
 
 	const errorColor = getErrorColor(error, theme);
 	const errorIcon = getErrorIcon(error.type);
-	const errorTitle = getErrorTitle(error.type);
+	const errorTitle =
+		error.type === 'rate_limited' && !error.recoverable
+			? 'Usage Limit Reached'
+			: getErrorTitle(error.type);
 
 	return (
 		<Modal
@@ -165,6 +358,21 @@ export function AgentErrorModal({
 				<p className="text-sm leading-relaxed" style={{ color: theme.colors.textMain }}>
 					{error.message}
 				</p>
+
+				{/* Rate limit details (when available in provider error JSON) */}
+				{rateLimitInfoLines.length > 0 && (
+					<div
+						className="text-xs border rounded px-3 py-2 space-y-1"
+						style={{ borderColor: theme.colors.border, color: theme.colors.textDim }}
+					>
+						<div className="font-medium" style={{ color: theme.colors.textMain }}>
+							Rate limit info
+						</div>
+						{rateLimitInfoLines.map((line, idx) => (
+							<div key={`${idx}:${line}`}>{line}</div>
+						))}
+					</div>
+				)}
 
 				{/* Timestamp */}
 				<div className="text-xs" style={{ color: theme.colors.textDim }}>

--- a/src/renderer/hooks/agent/useAgentErrorRecovery.tsx
+++ b/src/renderer/hooks/agent/useAgentErrorRecovery.tsx
@@ -108,7 +108,9 @@ function getRecoveryActionsForError(
 				actions.push({
 					id: 'retry',
 					label: 'Try Again',
-					description: 'Wait a moment and retry',
+					description: error.recoverable
+						? 'Wait a moment and retry'
+						: 'After adding credits/upgrading your plan, retry',
 					primary: true,
 					icon: <RefreshCw className="w-4 h-4" />,
 					onClick: options.onRetry,


### PR DESCRIPTION
## Summary

Improve out-of-credits failures so users get actionable details instead of a generic `Agent exited with code 1`.

This intentionally avoids token-tracking complexity and uses structured provider error payloads/headers when available.

## What changed

- Expanded non-recoverable quota/credit exhaustion detection for Claude Code and Codex.
- Preserved structured JSON error payloads (`parsedJson`) in parser output.
- Added structured fallback (`type: unknown`) to preserve provider error text when no known pattern matches.
- Improved Agent Error modal for non-recoverable usage-limit failures:
  - Title: `Usage Limit Reached`
  - Optional `Rate limit info` section from parsed headers (`retry-after`, request/token limits and reset values)
- Updated recovery messaging to distinguish recoverable throttling vs out-of-credits scenarios.

## Why

- Users can quickly decide whether retrying helps.
- Out-of-credits cases now provide concrete next steps (add credits/upgrade/wait for reset).
- Works across providers that return similar structured errors and headers.

## Scope

Only files directly involved in this feature were changed:

- `src/main/parsers/error-patterns.ts`
- `src/main/parsers/claude-output-parser.ts`
- `src/main/parsers/codex-output-parser.ts`
- `src/renderer/components/AgentErrorModal.tsx`
- `src/renderer/hooks/agent/useAgentErrorRecovery.tsx`
- `src/renderer/App.tsx`
- `src/__tests__/main/parsers/error-patterns.test.ts`
- `src/__tests__/main/parsers/claude-output-parser.test.ts`
- `src/__tests__/main/parsers/codex-output-parser.test.ts`
- `src/__tests__/renderer/components/AgentErrorModal.test.tsx`

## Validation

- `npm run lint`
- `npm run lint:eslint`
- `npm test -- src/__tests__/main/parsers/error-patterns.test.ts src/__tests__/main/parsers/claude-output-parser.test.ts src/__tests__/main/parsers/codex-output-parser.test.ts src/__tests__/renderer/components/AgentErrorModal.test.tsx --silent`
- `npm test -- src/__tests__/renderer/hooks/useAgentErrorRecovery.test.ts --silent`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Rate limit information now displayed in error messages, including retry-after times and request limits
  * Improved detection and classification of quota exhaustion scenarios
  * Enhanced error guidance with specific recommendations based on whether limits are recoverable (retry later vs. add credits/upgrade plan)
  * Error modal now displays "Usage Limit Reached" information for non-recoverable quota issues

<!-- end of auto-generated comment: release notes by coderabbit.ai -->