### PR TITLE
fix: file explorer auto-refresh with visual feedback and legacy migration

### DIFF
--- a/src/__tests__/renderer/components/FileExplorerPanel.test.tsx
+++ b/src/__tests__/renderer/components/FileExplorerPanel.test.tsx
@@ -712,60 +712,79 @@ describe('FileExplorerPanel', () => {
 	});
 
 	describe('Auto-refresh Timer', () => {
-		it('starts timer when interval is set', () => {
+		it('starts timer when interval is set', async () => {
 			const session = createMockSession({ fileTreeAutoRefreshInterval: 5 });
 			render(<FileExplorerPanel {...defaultProps} session={session} />);
 
 			expect(defaultProps.refreshFileTree).not.toHaveBeenCalled();
 
-			act(() => {
-				vi.advanceTimersByTime(5000);
+			await act(async () => {
+				await vi.advanceTimersByTimeAsync(5000);
 			});
 
 			expect(defaultProps.refreshFileTree).toHaveBeenCalledWith('session-1');
 		});
 
-		it('calls refresh at interval repeatedly', () => {
+		it('shows brief spin animation during auto-refresh', async () => {
 			const session = createMockSession({ fileTreeAutoRefreshInterval: 5 });
 			render(<FileExplorerPanel {...defaultProps} session={session} />);
 
-			act(() => {
-				vi.advanceTimersByTime(15000);
+			await act(async () => {
+				await vi.advanceTimersByTimeAsync(5000);
+			});
+
+			// Icon should be spinning after auto-refresh fires
+			const refreshIcon = screen.getByTestId('refresh-icon');
+			expect(refreshIcon.className).toContain('animate-spin');
+
+			// After 500ms the spin stops
+			await act(async () => {
+				await vi.advanceTimersByTimeAsync(500);
+			});
+			expect(refreshIcon.className).not.toContain('animate-spin');
+		});
+
+		it('calls refresh at interval repeatedly', async () => {
+			const session = createMockSession({ fileTreeAutoRefreshInterval: 5 });
+			render(<FileExplorerPanel {...defaultProps} session={session} />);
+
+			await act(async () => {
+				await vi.advanceTimersByTimeAsync(15000);
 			});
 
 			expect(defaultProps.refreshFileTree).toHaveBeenCalledTimes(3);
 		});
 
-		it('does not start timer when interval is 0', () => {
+		it('does not start timer when interval is 0', async () => {
 			render(<FileExplorerPanel {...defaultProps} />);
 
-			act(() => {
-				vi.advanceTimersByTime(60000);
+			await act(async () => {
+				await vi.advanceTimersByTimeAsync(60000);
 			});
 
 			expect(defaultProps.refreshFileTree).not.toHaveBeenCalled();
 		});
 
-		it('clears timer on unmount', () => {
+		it('clears timer on unmount', async () => {
 			const session = createMockSession({ fileTreeAutoRefreshInterval: 5 });
 			const { unmount } = render(<FileExplorerPanel {...defaultProps} session={session} />);
 
 			unmount();
 
-			act(() => {
-				vi.advanceTimersByTime(10000);
+			await act(async () => {
+				await vi.advanceTimersByTimeAsync(10000);
 			});
 
 			// No calls after unmount
 			expect(defaultProps.refreshFileTree).not.toHaveBeenCalled();
 		});
 
-		it('restarts timer when interval changes', () => {
+		it('restarts timer when interval changes', async () => {
 			const session = createMockSession({ fileTreeAutoRefreshInterval: 60 });
 			const { rerender } = render(<FileExplorerPanel {...defaultProps} session={session} />);
 
-			act(() => {
-				vi.advanceTimersByTime(30000);
+			await act(async () => {
+				await vi.advanceTimersByTimeAsync(30000);
 			});
 
 			expect(defaultProps.refreshFileTree).not.toHaveBeenCalled();
@@ -774,8 +793,8 @@ describe('FileExplorerPanel', () => {
 			const newSession = createMockSession({ fileTreeAutoRefreshInterval: 5 });
 			rerender(<FileExplorerPanel {...defaultProps} session={newSession} />);
 
-			act(() => {
-				vi.advanceTimersByTime(5000);
+			await act(async () => {
+				await vi.advanceTimersByTimeAsync(5000);
 			});
 
 			expect(defaultProps.refreshFileTree).toHaveBeenCalledTimes(1);

--- a/src/__tests__/renderer/hooks/useInputProcessing.test.ts
+++ b/src/__tests__/renderer/hooks/useInputProcessing.test.ts
@@ -338,6 +338,7 @@ describe('useInputProcessing', () => {
 		];
 
 		it('matches and processes custom AI command', async () => {
+			vi.useFakeTimers();
 			const deps = createDeps({
 				inputValue: '/commit',
 				customAICommands: customCommands,
@@ -352,6 +353,7 @@ describe('useInputProcessing', () => {
 			expect(mockSetInputValue).toHaveBeenCalledWith('');
 			expect(mockSetSlashCommandOpen).toHaveBeenCalledWith(false);
 			expect(mockSyncAiInputToSession).toHaveBeenCalledWith('');
+			vi.useRealTimers();
 		});
 
 		it('does not match unknown slash command as custom command', async () => {
@@ -441,6 +443,7 @@ describe('useInputProcessing', () => {
 		];
 
 		it('matches and processes speckit command', async () => {
+			vi.useFakeTimers();
 			const deps = createDeps({
 				inputValue: '/speckit.help',
 				customAICommands: speckitCommands,
@@ -454,9 +457,11 @@ describe('useInputProcessing', () => {
 			// Should clear input (indicates command was matched)
 			expect(mockSetInputValue).toHaveBeenCalledWith('');
 			expect(mockSetSlashCommandOpen).toHaveBeenCalledWith(false);
+			vi.useRealTimers();
 		});
 
 		it('matches speckit.constitution command', async () => {
+			vi.useFakeTimers();
 			const deps = createDeps({
 				inputValue: '/speckit.constitution',
 				customAICommands: speckitCommands,
@@ -468,6 +473,7 @@ describe('useInputProcessing', () => {
 			});
 
 			expect(mockSetInputValue).toHaveBeenCalledWith('');
+			vi.useRealTimers();
 		});
 
 		it('does not match partial speckit command', async () => {
@@ -508,6 +514,7 @@ describe('useInputProcessing', () => {
 		];
 
 		it('matches custom command when both types present', async () => {
+			vi.useFakeTimers();
 			const deps = createDeps({
 				inputValue: '/commit',
 				customAICommands: combinedCommands,
@@ -519,9 +526,11 @@ describe('useInputProcessing', () => {
 			});
 
 			expect(mockSetInputValue).toHaveBeenCalledWith('');
+			vi.useRealTimers();
 		});
 
 		it('matches speckit command when both types present', async () => {
+			vi.useFakeTimers();
 			const deps = createDeps({
 				inputValue: '/speckit.help',
 				customAICommands: combinedCommands,
@@ -533,6 +542,7 @@ describe('useInputProcessing', () => {
 			});
 
 			expect(mockSetInputValue).toHaveBeenCalledWith('');
+			vi.useRealTimers();
 		});
 	});
 
@@ -769,6 +779,7 @@ describe('useInputProcessing', () => {
 
 	describe('override input value', () => {
 		it('uses overrideInputValue when provided', async () => {
+			vi.useFakeTimers();
 			const customCommands: CustomAICommand[] = [
 				{ id: 'commit', command: '/commit', description: 'Commit', prompt: 'Commit.' },
 			];
@@ -784,6 +795,7 @@ describe('useInputProcessing', () => {
 
 			// Should match the override value, not the inputValue
 			expect(mockSetInputValue).toHaveBeenCalledWith('');
+			vi.useRealTimers();
 		});
 	});
 
@@ -955,6 +967,7 @@ describe('useInputProcessing', () => {
 
 	describe('command history tracking', () => {
 		it('adds slash command to aiCommandHistory', async () => {
+			vi.useFakeTimers();
 			const customCommands: CustomAICommand[] = [
 				{ id: 'test', command: '/test', description: 'Test', prompt: 'Test prompt.' },
 			];
@@ -975,6 +988,7 @@ describe('useInputProcessing', () => {
 			const setSessionsCall = mockSetSessions.mock.calls[0][0];
 			const updatedSessions = setSessionsCall([session]);
 			expect(updatedSessions[0].aiCommandHistory).toContain('/test');
+			vi.useRealTimers();
 		});
 	});
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1202,6 +1202,11 @@ function MaestroConsoleInner() {
 				session = { ...session, projectRoot: session.cwd };
 			}
 
+			// Migration: ensure fileTreeAutoRefreshInterval is set (default 180s for legacy sessions)
+			if (session.fileTreeAutoRefreshInterval == null) {
+				session = { ...session, fileTreeAutoRefreshInterval: 180 };
+			}
+
 			// Sessions must have aiTabs - if missing, this is a data corruption issue
 			// Create a default tab to prevent crashes when code calls .find() on aiTabs
 			if (!session.aiTabs || session.aiTabs.length === 0) {

--- a/src/renderer/components/FileExplorerPanel.tsx
+++ b/src/renderer/components/FileExplorerPanel.tsx
@@ -490,9 +490,14 @@ function FileExplorerPanelInner(props: FileExplorerPanelProps) {
 
 		// Start new timer if interval is set
 		if (autoRefreshInterval > 0) {
-			autoRefreshTimerRef.current = setInterval(() => {
-				// Use refs to get latest values without causing effect re-runs
-				refreshFileTreeRef.current(sessionIdRef.current);
+			autoRefreshTimerRef.current = setInterval(async () => {
+				// Brief spin animation so user can see auto-refresh is active
+				setIsRefreshing(true);
+				try {
+					await refreshFileTreeRef.current(sessionIdRef.current);
+				} finally {
+					setTimeout(() => setIsRefreshing(false), 500);
+				}
 			}, autoRefreshInterval * 1000);
 		}
 

--- a/src/renderer/hooks/props/useRightPanelProps.ts
+++ b/src/renderer/hooks/props/useRightPanelProps.ts
@@ -233,6 +233,7 @@ export function useRightPanelProps(deps: UseRightPanelPropsDeps) {
 		[
 			// Primitive dependencies for minimal re-computation
 			deps.activeSession?.id,
+			deps.activeSession?.fileTreeAutoRefreshInterval,
 			deps.activeSession?.autoRunContent,
 			deps.activeSession?.autoRunContentVersion,
 			deps.theme,


### PR DESCRIPTION
## Summary

- Auto-refresh in File Explorer now shows a brief spinner pulse so users can see it's working
- Legacy sessions without `fileTreeAutoRefreshInterval` are migrated to the 180s default on load
- Right panel re-renders when auto-refresh interval changes (added to `useMemo` deps)

## Changes

| File | What |
|------|------|
| `FileExplorerPanel.tsx` | Auto-refresh callback now `await`s the refresh and shows a 500ms spin animation |
| `App.tsx` | Migration: backfill `fileTreeAutoRefreshInterval: 180` for legacy sessions |
| `useRightPanelProps.ts` | Added `fileTreeAutoRefreshInterval` to memo dependency array |
| `FileExplorerPanel.test.tsx` | Upgraded timer tests to async (`advanceTimersByTimeAsync`); added spinner start/stop coverage |
| `useInputProcessing.test.ts` | Isolated fake timers per test to prevent cross-test timer leaks |

## Test plan

- [x] All 18,585 tests pass (0 failures)
- [ ] Open File Explorer, set auto-refresh interval, confirm spinner pulses on each cycle
- [ ] Load a session created before this change, verify it gets the 180s default
- [ ] Change the auto-refresh interval in settings while the right panel is open — confirm it takes effect immediately