### PR TITLE
fix: correct regex for UUID tab IDs in WebSocket session output broad…

### DIFF
--- a/src/main/constants.ts
+++ b/src/main/constants.ts
@@ -23,8 +23,9 @@ export const REGEX_PARTICIPANT_TIMESTAMP = /^group-chat-(.+)-participant-(.+)-(\
 export const REGEX_PARTICIPANT_FALLBACK = /^group-chat-(.+)-participant-([^-]+)-/;
 
 // Web broadcast session ID patterns
-export const REGEX_AI_SUFFIX = /-ai-[^-]+$/;
-export const REGEX_AI_TAB_ID = /-ai-([^-]+)$/;
+// Tab IDs are UUIDs (e.g., 73aaeb23-6673-45a4-8fdf-c769802f79bb) so we must match the full UUID after -ai-
+export const REGEX_AI_SUFFIX = /-ai-[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i;
+export const REGEX_AI_TAB_ID = /-ai-([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})$/i;
 
 // Auto Run session ID patterns (batch and synopsis operations)
 // Format: {sessionId}-batch-{timestamp} or {sessionId}-synopsis-{timestamp}

--- a/src/main/process-listeners/__tests__/data-listener.test.ts
+++ b/src/main/process-listeners/__tests__/data-listener.test.ts
@@ -42,8 +42,8 @@ describe('Data Listener', () => {
 		mockPatterns = {
 			REGEX_MODERATOR_SESSION: /^group-chat-(.+)-moderator-/,
 			REGEX_MODERATOR_SESSION_TIMESTAMP: /^group-chat-(.+)-moderator-\d+$/,
-			REGEX_AI_SUFFIX: /-ai-[^-]+$/,
-			REGEX_AI_TAB_ID: /-ai-([^-]+)$/,
+			REGEX_AI_SUFFIX: /-ai-[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i,
+			REGEX_AI_TAB_ID: /-ai-([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})$/i,
 			REGEX_BATCH_SESSION: /-batch-\d+$/,
 			REGEX_SYNOPSIS_SESSION: /-synopsis-\d+$/,
 		};
@@ -87,35 +87,35 @@ describe('Data Listener', () => {
 			);
 		});
 
-		it('should broadcast to web clients for AI sessions', () => {
+		it('should broadcast to web clients for AI sessions with UUID tab IDs', () => {
 			setupListener();
 			const handler = eventHandlers.get('data');
 
-			handler?.('session-123-ai-tab1', 'test output');
+			handler?.('51cee651-6629-4de8-abdd-1c1540555f2d-ai-73aaeb23-6673-45a4-8fdf-c769802f79bb', 'test output');
 
 			expect(mockWebServer.broadcastToSessionClients).toHaveBeenCalledWith(
-				'session-123',
+				'51cee651-6629-4de8-abdd-1c1540555f2d',
 				expect.objectContaining({
 					type: 'session_output',
-					sessionId: 'session-123',
-					tabId: 'tab1',
+					sessionId: '51cee651-6629-4de8-abdd-1c1540555f2d',
+					tabId: '73aaeb23-6673-45a4-8fdf-c769802f79bb',
 					data: 'test output',
 					source: 'ai',
 				})
 			);
 		});
 
-		it('should extract base session ID correctly', () => {
+		it('should extract base session ID correctly from UUID format', () => {
 			setupListener();
 			const handler = eventHandlers.get('data');
 
-			handler?.('my-session-ai-mytab', 'test output');
+			handler?.('a053b4b3-95af-46cc-aaa4-3d37785038be-ai-66fc905c-3062-4192-9a84-d239af5fc826', 'test output');
 
 			expect(mockWebServer.broadcastToSessionClients).toHaveBeenCalledWith(
-				'my-session',
+				'a053b4b3-95af-46cc-aaa4-3d37785038be',
 				expect.objectContaining({
-					sessionId: 'my-session',
-					tabId: 'mytab',
+					sessionId: 'a053b4b3-95af-46cc-aaa4-3d37785038be',
+					tabId: '66fc905c-3062-4192-9a84-d239af5fc826',
 				})
 			);
 		});
@@ -240,7 +240,7 @@ describe('Data Listener', () => {
 			const handler = eventHandlers.get('data');
 
 			// Session ID with "batch" in the UUID but not matching the pattern -batch-{digits}
-			handler?.('session-batch-uuid-ai-tab1', 'output');
+			handler?.('session-batch-uuid-ai-a1b2c3d4-e5f6-7890-abcd-ef1234567890', 'output');
 
 			// Should broadcast because it doesn't match the -batch-\d+$ pattern
 			expect(mockWebServer.broadcastToSessionClients).toHaveBeenCalled();
@@ -251,12 +251,12 @@ describe('Data Listener', () => {
 			setupListener();
 			const handler = eventHandlers.get('data');
 
-			handler?.('session-123-ai-tab1', 'test output');
+			handler?.('session-123-ai-a1b2c3d4-e5f6-7890-abcd-ef1234567890', 'test output');
 
 			// Should still forward to renderer
 			expect(mockSafeSend).toHaveBeenCalledWith(
 				'process:data',
-				'session-123-ai-tab1',
+				'session-123-ai-a1b2c3d4-e5f6-7890-abcd-ef1234567890',
 				'test output'
 			);
 			// But not broadcast (no web server)
@@ -269,8 +269,8 @@ describe('Data Listener', () => {
 			setupListener();
 			const handler = eventHandlers.get('data');
 
-			handler?.('session-123-ai-tab1', 'output 1');
-			handler?.('session-123-ai-tab1', 'output 2');
+			handler?.('session-123-ai-a1b2c3d4-e5f6-7890-abcd-ef1234567890', 'output 1');
+			handler?.('session-123-ai-a1b2c3d4-e5f6-7890-abcd-ef1234567890', 'output 2');
 
 			const calls = mockWebServer.broadcastToSessionClients.mock.calls;
 			const msgId1 = calls[0][1].msgId;
@@ -286,7 +286,7 @@ describe('Data Listener', () => {
 			setupListener();
 			const handler = eventHandlers.get('data');
 
-			handler?.('session-123-ai-tab1', 'test output');
+			handler?.('session-123-ai-a1b2c3d4-e5f6-7890-abcd-ef1234567890', 'test output');
 
 			const msgId = mockWebServer.broadcastToSessionClients.mock.calls[0][1].msgId;
 			const timestamp = parseInt(msgId.split('-')[0], 10);
@@ -301,7 +301,7 @@ describe('Data Listener', () => {
 			setupListener();
 			const handler = eventHandlers.get('data');
 
-			handler?.('session-123-ai-tab1', 'ai output');
+			handler?.('session-123-ai-a1b2c3d4-e5f6-7890-abcd-ef1234567890', 'ai output');
 
 			expect(mockWebServer.broadcastToSessionClients).toHaveBeenCalledWith(
 				expect.anything(),

--- a/src/main/process-listeners/__tests__/exit-listener.test.ts
+++ b/src/main/process-listeners/__tests__/exit-listener.test.ts
@@ -97,8 +97,8 @@ describe('Exit Listener', () => {
 			patterns: {
 				REGEX_MODERATOR_SESSION: /^group-chat-(.+)-moderator-/,
 				REGEX_MODERATOR_SESSION_TIMESTAMP: /^group-chat-(.+)-moderator-\d+$/,
-				REGEX_AI_SUFFIX: /-ai-[^-]+$/,
-				REGEX_AI_TAB_ID: /-ai-([^-]+)$/,
+				REGEX_AI_SUFFIX: /-ai-[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i,
+				REGEX_AI_TAB_ID: /-ai-([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})$/i,
 				REGEX_BATCH_SESSION: /-batch-\d+$/,
 				REGEX_SYNOPSIS_SESSION: /-synopsis-\d+$/,
 			},

--- a/src/main/process-listeners/__tests__/session-id-listener.test.ts
+++ b/src/main/process-listeners/__tests__/session-id-listener.test.ts
@@ -66,8 +66,8 @@ describe('Session ID Listener', () => {
 			patterns: {
 				REGEX_MODERATOR_SESSION: /^group-chat-(.+)-moderator-/,
 				REGEX_MODERATOR_SESSION_TIMESTAMP: /^group-chat-(.+)-moderator-\d+$/,
-				REGEX_AI_SUFFIX: /-ai-[^-]+$/,
-				REGEX_AI_TAB_ID: /-ai-([^-]+)$/,
+				REGEX_AI_SUFFIX: /-ai-[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i,
+				REGEX_AI_TAB_ID: /-ai-([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})$/i,
 				REGEX_BATCH_SESSION: /-batch-\d+$/,
 				REGEX_SYNOPSIS_SESSION: /-synopsis-\d+$/,
 			},

--- a/src/main/process-listeners/__tests__/usage-listener.test.ts
+++ b/src/main/process-listeners/__tests__/usage-listener.test.ts
@@ -80,8 +80,8 @@ describe('Usage Listener', () => {
 			patterns: {
 				REGEX_MODERATOR_SESSION: /^group-chat-(.+)-moderator-/,
 				REGEX_MODERATOR_SESSION_TIMESTAMP: /^group-chat-(.+)-moderator-\d+$/,
-				REGEX_AI_SUFFIX: /-ai-[^-]+$/,
-				REGEX_AI_TAB_ID: /-ai-([^-]+)$/,
+				REGEX_AI_SUFFIX: /-ai-[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i,
+				REGEX_AI_TAB_ID: /-ai-([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})$/i,
 				REGEX_BATCH_SESSION: /-batch-\d+$/,
 				REGEX_SYNOPSIS_SESSION: /-synopsis-\d+$/,
 			},

--- a/src/main/process-listeners/exit-listener.ts
+++ b/src/main/process-listeners/exit-listener.ts
@@ -416,7 +416,7 @@ export function setupExitListener(
 		if (webServer) {
 			// Extract base session ID from formats: {id}-ai-{tabId}, {id}-terminal, {id}-batch-{timestamp}, {id}-synopsis-{timestamp}
 			const baseSessionId = sessionId.replace(
-				/-ai-[^-]+$|-terminal$|-batch-\d+$|-synopsis-\d+$/,
+				/-ai-[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$|-terminal$|-batch-\d+$|-synopsis-\d+$/i,
 				''
 			);
 			webServer.broadcastToSessionClients(baseSessionId, {


### PR DESCRIPTION
### Problem

The web UI (mobile/desktop) does not receive real-time chat updates via WebSocket. Users must refresh the page to see new AI responses. The `session_output` messages are never delivered to connected web clients.

### Root Cause

Process session IDs use the format `{sessionId}-ai-{tabId}`, where both parts are UUIDs containing dashes:

```
51cee651-6629-4de8-abdd-1c1540555f2d-ai-73aaeb23-6673-45a4-8fdf-c769802f79bb
```

The regex `REGEX_AI_SUFFIX = /-ai-[^-]+$/` uses `[^-]+` which only matches characters **without dashes**. Since UUID tab IDs contain dashes, the regex only captures the last segment (`c769802f79bb`), producing an incorrect `baseSessionId`:

```
Expected: 51cee651-6629-4de8-abdd-1c1540555f2d
Actual:   51cee651-6629-4de8-abdd-1c1540555f2d-ai-73aaeb23-6673-45a4-8fdf
```

This mismatched `baseSessionId` never equals the client's `subscribedSessionId`, so `broadcastToSession()` silently drops every `session_output` message.

### Why Tests Didn't Catch It

All existing tests used simple non-UUID tab IDs like `tab1` or `mytab` (no dashes), so the old regex worked fine in tests but failed in production.

### Fix

Updated the regex to explicitly match UUID format (`[a-f0-9]{8}-[a-f0-9]{4}-...`), consistent with the pattern already used for `REGEX_PARTICIPANT_UUID` in the same file.

### Changes

| File | What changed |
|------|-------------|
| `src/main/constants.ts` | `REGEX_AI_SUFFIX` and `REGEX_AI_TAB_ID` updated from `/-ai-[^-]+$/` to full UUID pattern |
| `src/main/process-listeners/exit-listener.ts` | Same fix for a hardcoded copy of the regex used in `session_exit` broadcasts |
| `src/main/process-listeners/__tests__/data-listener.test.ts` | Tests now use realistic UUID session/tab IDs instead of `tab1` |
| `src/main/process-listeners/__tests__/exit-listener.test.ts` | Mock patterns updated to match new regex |
| `src/main/process-listeners/__tests__/session-id-listener.test.ts` | Mock patterns updated to match new regex |
| `src/main/process-listeners/__tests__/usage-listener.test.ts` | Mock patterns updated to match new regex |

### Before / After

```
Before: /-ai-[^-]+$/           → matches "-c769802f79bb" only (WRONG)
After:  /-ai-[a-f0-9]{8}-...$/ → matches "-ai-73aaeb23-6673-45a4-8fdf-c769802f79bb" (CORRECT)
```
