### PR TITLE
refactor: create fileExplorerStore, consolidate scattered file explor…

### DIFF
--- a/src/__tests__/renderer/hooks/useFileTreeManagement.test.ts
+++ b/src/__tests__/renderer/hooks/useFileTreeManagement.test.ts
@@ -18,6 +18,7 @@ import type { RightPanelHandle } from '../../../renderer/components/RightPanel';
 import type { RefObject, SetStateAction } from 'react';
 import { loadFileTree, compareFileTrees } from '../../../renderer/utils/fileExplorer';
 import { gitService } from '../../../renderer/services/git';
+import { useFileExplorerStore } from '../../../renderer/stores/fileExplorerStore';
 
 vi.mock('../../../renderer/utils/fileExplorer', () => ({
 	loadFileTree: vi.fn(),
@@ -90,7 +91,6 @@ const createDeps = (
 	setSessions: state.setSessions,
 	activeSessionId: state.getSessions()[0]?.id ?? null,
 	activeSession: state.getSessions()[0] ?? null,
-	fileTreeFilter: '',
 	rightPanelRef: { current: { refreshHistoryPanel: vi.fn() } },
 	...overrides,
 });
@@ -104,6 +104,7 @@ describe('useFileTreeManagement', () => {
 
 	beforeEach(() => {
 		vi.clearAllMocks();
+		useFileExplorerStore.setState({ fileTreeFilter: '' });
 		originalHistory = window.maestro.history as typeof window.maestro.history | undefined;
 		window.maestro = {
 			...window.maestro,
@@ -233,8 +234,9 @@ describe('useFileTreeManagement', () => {
 			{ name: 'notes.txt', type: 'file' },
 		];
 
+		useFileExplorerStore.setState({ fileTreeFilter: 'read' });
 		const state = createSessionsState([createMockSession({ fileTree })]);
-		const deps = createDeps(state, { fileTreeFilter: 'read' });
+		const deps = createDeps(state);
 		const { result } = renderHook(() => useFileTreeManagement(deps));
 
 		expect(result.current.filteredFileTree).toEqual([

--- a/src/__tests__/renderer/stores/fileExplorerStore.test.ts
+++ b/src/__tests__/renderer/stores/fileExplorerStore.test.ts
@@ -1,0 +1,305 @@
+/**
+ * Tests for fileExplorerStore — File explorer UI state management
+ *
+ * Tests file tree UI state, file preview loading, flat file list,
+ * and document graph view state. Covers functional updaters,
+ * atomic graph actions, and non-React access helpers.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+	useFileExplorerStore,
+	getFileExplorerState,
+	getFileExplorerActions,
+} from '../../../renderer/stores/fileExplorerStore';
+import type { FlatTreeNode } from '../../../renderer/utils/fileExplorer';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function createFlatTreeNode(overrides: Partial<FlatTreeNode> = {}): FlatTreeNode {
+	return {
+		name: overrides.name ?? 'file.ts',
+		type: overrides.type ?? 'file',
+		fullPath: overrides.fullPath ?? 'src/file.ts',
+		isFolder: overrides.isFolder ?? false,
+		...overrides,
+	} as FlatTreeNode;
+}
+
+function resetStore() {
+	useFileExplorerStore.setState({
+		selectedFileIndex: 0,
+		fileTreeFilter: '',
+		fileTreeFilterOpen: false,
+		filePreviewLoading: null,
+		flatFileList: [],
+		isGraphViewOpen: false,
+		graphFocusFilePath: undefined,
+		lastGraphFocusFilePath: undefined,
+	});
+}
+
+// ============================================================================
+// Setup
+// ============================================================================
+
+beforeEach(() => {
+	resetStore();
+});
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('fileExplorerStore', () => {
+	describe('initial state', () => {
+		it('has correct default values', () => {
+			const state = useFileExplorerStore.getState();
+			expect(state.selectedFileIndex).toBe(0);
+			expect(state.fileTreeFilter).toBe('');
+			expect(state.fileTreeFilterOpen).toBe(false);
+			expect(state.filePreviewLoading).toBeNull();
+			expect(state.flatFileList).toEqual([]);
+			expect(state.isGraphViewOpen).toBe(false);
+			expect(state.graphFocusFilePath).toBeUndefined();
+			expect(state.lastGraphFocusFilePath).toBeUndefined();
+		});
+	});
+
+	describe('file tree UI state', () => {
+		it('setSelectedFileIndex sets with value', () => {
+			useFileExplorerStore.getState().setSelectedFileIndex(5);
+			expect(useFileExplorerStore.getState().selectedFileIndex).toBe(5);
+		});
+
+		it('setSelectedFileIndex supports functional updater', () => {
+			useFileExplorerStore.getState().setSelectedFileIndex(3);
+			useFileExplorerStore.getState().setSelectedFileIndex((prev) => prev + 2);
+			expect(useFileExplorerStore.getState().selectedFileIndex).toBe(5);
+		});
+
+		it('setFileTreeFilter sets with value', () => {
+			useFileExplorerStore.getState().setFileTreeFilter('utils');
+			expect(useFileExplorerStore.getState().fileTreeFilter).toBe('utils');
+		});
+
+		it('setFileTreeFilter supports functional updater', () => {
+			useFileExplorerStore.getState().setFileTreeFilter('hel');
+			useFileExplorerStore.getState().setFileTreeFilter((prev) => prev + 'lo');
+			expect(useFileExplorerStore.getState().fileTreeFilter).toBe('hello');
+		});
+
+		it('setFileTreeFilterOpen sets with value', () => {
+			useFileExplorerStore.getState().setFileTreeFilterOpen(true);
+			expect(useFileExplorerStore.getState().fileTreeFilterOpen).toBe(true);
+		});
+
+		it('setFileTreeFilterOpen supports functional updater', () => {
+			useFileExplorerStore.getState().setFileTreeFilterOpen(false);
+			useFileExplorerStore.getState().setFileTreeFilterOpen((prev) => !prev);
+			expect(useFileExplorerStore.getState().fileTreeFilterOpen).toBe(true);
+		});
+	});
+
+	describe('file preview loading', () => {
+		it('sets loading state with name and path', () => {
+			useFileExplorerStore.getState().setFilePreviewLoading({
+				name: 'index.ts',
+				path: '/project/src/index.ts',
+			});
+			expect(useFileExplorerStore.getState().filePreviewLoading).toEqual({
+				name: 'index.ts',
+				path: '/project/src/index.ts',
+			});
+		});
+
+		it('clears loading state with null', () => {
+			useFileExplorerStore.getState().setFilePreviewLoading({
+				name: 'file.ts',
+				path: '/path/file.ts',
+			});
+			useFileExplorerStore.getState().setFilePreviewLoading(null);
+			expect(useFileExplorerStore.getState().filePreviewLoading).toBeNull();
+		});
+	});
+
+	describe('flat file list', () => {
+		it('sets flat file list', () => {
+			const nodes = [
+				createFlatTreeNode({ name: 'src', isFolder: true, fullPath: 'src' }),
+				createFlatTreeNode({ name: 'index.ts', fullPath: 'src/index.ts' }),
+			];
+			useFileExplorerStore.getState().setFlatFileList(nodes);
+			expect(useFileExplorerStore.getState().flatFileList).toHaveLength(2);
+			expect(useFileExplorerStore.getState().flatFileList[0].name).toBe('src');
+		});
+
+		it('clears flat file list with empty array', () => {
+			useFileExplorerStore.getState().setFlatFileList([createFlatTreeNode()]);
+			useFileExplorerStore.getState().setFlatFileList([]);
+			expect(useFileExplorerStore.getState().flatFileList).toEqual([]);
+		});
+	});
+
+	describe('document graph actions', () => {
+		it('focusFileInGraph atomically sets all three fields', () => {
+			useFileExplorerStore.getState().focusFileInGraph('src/utils/helpers.ts');
+
+			const state = useFileExplorerStore.getState();
+			expect(state.graphFocusFilePath).toBe('src/utils/helpers.ts');
+			expect(state.lastGraphFocusFilePath).toBe('src/utils/helpers.ts');
+			expect(state.isGraphViewOpen).toBe(true);
+		});
+
+		it('focusFileInGraph overwrites previous focus path', () => {
+			useFileExplorerStore.getState().focusFileInGraph('first.ts');
+			useFileExplorerStore.getState().focusFileInGraph('second.ts');
+
+			const state = useFileExplorerStore.getState();
+			expect(state.graphFocusFilePath).toBe('second.ts');
+			expect(state.lastGraphFocusFilePath).toBe('second.ts');
+		});
+
+		it('focusFileInGraph works after closeGraphView', () => {
+			useFileExplorerStore.getState().focusFileInGraph('first.ts');
+			useFileExplorerStore.getState().closeGraphView();
+			useFileExplorerStore.getState().focusFileInGraph('second.ts');
+
+			const state = useFileExplorerStore.getState();
+			expect(state.graphFocusFilePath).toBe('second.ts');
+			expect(state.isGraphViewOpen).toBe(true);
+		});
+
+		it('openLastDocumentGraph opens with last path', () => {
+			useFileExplorerStore.getState().focusFileInGraph('src/App.tsx');
+			useFileExplorerStore.getState().closeGraphView();
+
+			// Re-open with last path
+			useFileExplorerStore.getState().openLastDocumentGraph();
+
+			const state = useFileExplorerStore.getState();
+			expect(state.graphFocusFilePath).toBe('src/App.tsx');
+			expect(state.isGraphViewOpen).toBe(true);
+			expect(state.lastGraphFocusFilePath).toBe('src/App.tsx');
+		});
+
+		it('openLastDocumentGraph is no-op when no previous path', () => {
+			useFileExplorerStore.getState().openLastDocumentGraph();
+
+			const state = useFileExplorerStore.getState();
+			expect(state.isGraphViewOpen).toBe(false);
+			expect(state.graphFocusFilePath).toBeUndefined();
+		});
+
+		it('closeGraphView clears isGraphViewOpen and graphFocusFilePath', () => {
+			useFileExplorerStore.getState().focusFileInGraph('file.ts');
+			useFileExplorerStore.getState().closeGraphView();
+
+			const state = useFileExplorerStore.getState();
+			expect(state.isGraphViewOpen).toBe(false);
+			expect(state.graphFocusFilePath).toBeUndefined();
+		});
+
+		it('closeGraphView preserves lastGraphFocusFilePath', () => {
+			useFileExplorerStore.getState().focusFileInGraph('important.ts');
+			useFileExplorerStore.getState().closeGraphView();
+
+			expect(useFileExplorerStore.getState().lastGraphFocusFilePath).toBe('important.ts');
+		});
+
+		it('setIsGraphViewOpen directly sets the boolean', () => {
+			useFileExplorerStore.getState().setIsGraphViewOpen(true);
+			expect(useFileExplorerStore.getState().isGraphViewOpen).toBe(true);
+
+			useFileExplorerStore.getState().setIsGraphViewOpen(false);
+			expect(useFileExplorerStore.getState().isGraphViewOpen).toBe(false);
+		});
+
+		it('full lifecycle: focus → close → reopen last', () => {
+			// Focus on a file
+			useFileExplorerStore.getState().focusFileInGraph('src/main.ts');
+			expect(useFileExplorerStore.getState().isGraphViewOpen).toBe(true);
+
+			// Close the view
+			useFileExplorerStore.getState().closeGraphView();
+			expect(useFileExplorerStore.getState().isGraphViewOpen).toBe(false);
+			expect(useFileExplorerStore.getState().graphFocusFilePath).toBeUndefined();
+
+			// Re-open last
+			useFileExplorerStore.getState().openLastDocumentGraph();
+			expect(useFileExplorerStore.getState().isGraphViewOpen).toBe(true);
+			expect(useFileExplorerStore.getState().graphFocusFilePath).toBe('src/main.ts');
+		});
+
+		it('multiple files: focus A → focus B → close → open last gets B', () => {
+			useFileExplorerStore.getState().focusFileInGraph('a.ts');
+			useFileExplorerStore.getState().focusFileInGraph('b.ts');
+			useFileExplorerStore.getState().closeGraphView();
+			useFileExplorerStore.getState().openLastDocumentGraph();
+
+			expect(useFileExplorerStore.getState().graphFocusFilePath).toBe('b.ts');
+		});
+	});
+
+	describe('non-React access', () => {
+		it('getFileExplorerState returns current state', () => {
+			useFileExplorerStore.getState().setFileTreeFilter('search');
+			const state = getFileExplorerState();
+			expect(state.fileTreeFilter).toBe('search');
+		});
+
+		it('getFileExplorerActions returns action functions', () => {
+			const actions = getFileExplorerActions();
+			expect(typeof actions.setSelectedFileIndex).toBe('function');
+			expect(typeof actions.setFileTreeFilter).toBe('function');
+			expect(typeof actions.setFileTreeFilterOpen).toBe('function');
+			expect(typeof actions.setFilePreviewLoading).toBe('function');
+			expect(typeof actions.setFlatFileList).toBe('function');
+			expect(typeof actions.focusFileInGraph).toBe('function');
+			expect(typeof actions.openLastDocumentGraph).toBe('function');
+			expect(typeof actions.closeGraphView).toBe('function');
+			expect(typeof actions.setIsGraphViewOpen).toBe('function');
+		});
+
+		it('actions from getFileExplorerActions update state', () => {
+			const actions = getFileExplorerActions();
+			actions.setSelectedFileIndex(10);
+			actions.setFileTreeFilter('test');
+			actions.focusFileInGraph('via-actions.ts');
+
+			const state = getFileExplorerState();
+			expect(state.selectedFileIndex).toBe(10);
+			expect(state.fileTreeFilter).toBe('test');
+			expect(state.graphFocusFilePath).toBe('via-actions.ts');
+			expect(state.isGraphViewOpen).toBe(true);
+		});
+	});
+
+	describe('store reset', () => {
+		it('resets all state to defaults', () => {
+			// Set non-default values
+			const store = useFileExplorerStore.getState();
+			store.setSelectedFileIndex(99);
+			store.setFileTreeFilter('search');
+			store.setFileTreeFilterOpen(true);
+			store.setFilePreviewLoading({ name: 'f', path: '/f' });
+			store.setFlatFileList([createFlatTreeNode()]);
+			store.focusFileInGraph('some/path.ts');
+
+			// Reset
+			resetStore();
+
+			const state = useFileExplorerStore.getState();
+			expect(state.selectedFileIndex).toBe(0);
+			expect(state.fileTreeFilter).toBe('');
+			expect(state.fileTreeFilterOpen).toBe(false);
+			expect(state.filePreviewLoading).toBeNull();
+			expect(state.flatFileList).toEqual([]);
+			expect(state.isGraphViewOpen).toBe(false);
+			expect(state.graphFocusFilePath).toBeUndefined();
+			expect(state.lastGraphFocusFilePath).toBeUndefined();
+		});
+	});
+});

--- a/src/__tests__/renderer/stores/uiStore.test.ts
+++ b/src/__tests__/renderer/stores/uiStore.test.ts
@@ -18,9 +18,6 @@ function resetStore() {
 		preFilterActiveTabId: null,
 		preTerminalFileTabId: null,
 		selectedSidebarIndex: 0,
-		selectedFileIndex: 0,
-		fileTreeFilter: '',
-		fileTreeFilterOpen: false,
 		flashNotification: null,
 		successFlashNotification: null,
 		outputSearchOpen: false,
@@ -50,9 +47,6 @@ describe('uiStore', () => {
 			expect(state.preFilterActiveTabId).toBeNull();
 			expect(state.preTerminalFileTabId).toBeNull();
 			expect(state.selectedSidebarIndex).toBe(0);
-			expect(state.selectedFileIndex).toBe(0);
-			expect(state.fileTreeFilter).toBe('');
-			expect(state.fileTreeFilterOpen).toBe(false);
 			expect(state.flashNotification).toBeNull();
 			expect(state.successFlashNotification).toBeNull();
 			expect(state.outputSearchOpen).toBe(false);
@@ -198,29 +192,6 @@ describe('uiStore', () => {
 		});
 	});
 
-	describe('file explorer state', () => {
-		it('sets selected file index', () => {
-			useUIStore.getState().setSelectedFileIndex(10);
-			expect(useUIStore.getState().selectedFileIndex).toBe(10);
-		});
-
-		it('sets selected file index with an updater', () => {
-			useUIStore.getState().setSelectedFileIndex(5);
-			useUIStore.getState().setSelectedFileIndex((prev) => Math.max(0, prev - 3));
-			expect(useUIStore.getState().selectedFileIndex).toBe(2);
-		});
-
-		it('sets file tree filter', () => {
-			useUIStore.getState().setFileTreeFilter('test');
-			expect(useUIStore.getState().fileTreeFilter).toBe('test');
-		});
-
-		it('sets file tree filter open', () => {
-			useUIStore.getState().setFileTreeFilterOpen(true);
-			expect(useUIStore.getState().fileTreeFilterOpen).toBe(true);
-		});
-	});
-
 	describe('flash notification state', () => {
 		it('sets flash notification', () => {
 			useUIStore.getState().setFlashNotification('Commands disabled');
@@ -307,7 +278,7 @@ describe('uiStore', () => {
 
 			// Change unrelated state
 			act(() => {
-				useUIStore.getState().setFileTreeFilter('test');
+				useUIStore.getState().setOutputSearchQuery('test');
 			});
 
 			// Should not have re-rendered (selector isolation)
@@ -337,7 +308,7 @@ describe('uiStore', () => {
 		it('returns stable action references across state changes', () => {
 			const actionsBefore = useUIStore.getState();
 			useUIStore.getState().setLeftSidebarOpen(false);
-			useUIStore.getState().setFileTreeFilter('changed');
+			useUIStore.getState().setOutputSearchQuery('changed');
 			const actionsAfter = useUIStore.getState();
 
 			// Actions must be the same function references after state mutations.
@@ -346,33 +317,29 @@ describe('uiStore', () => {
 			expect(actionsAfter.setLeftSidebarOpen).toBe(actionsBefore.setLeftSidebarOpen);
 			expect(actionsAfter.toggleLeftSidebar).toBe(actionsBefore.toggleLeftSidebar);
 			expect(actionsAfter.setActiveFocus).toBe(actionsBefore.setActiveFocus);
-			expect(actionsAfter.setFileTreeFilter).toBe(actionsBefore.setFileTreeFilter);
 			expect(actionsAfter.setFlashNotification).toBe(actionsBefore.setFlashNotification);
 			expect(actionsAfter.setSelectedSidebarIndex).toBe(actionsBefore.setSelectedSidebarIndex);
 		});
 
 		it('extracted actions still mutate state correctly', () => {
 			// Grab actions once, then call them — mirrors the App.tsx pattern
-			const { setLeftSidebarOpen, setFileTreeFilter, setActiveFocus } = useUIStore.getState();
+			const { setLeftSidebarOpen, setActiveFocus } = useUIStore.getState();
 
 			setLeftSidebarOpen(false);
 			expect(useUIStore.getState().leftSidebarOpen).toBe(false);
-
-			setFileTreeFilter('hello');
-			expect(useUIStore.getState().fileTreeFilter).toBe('hello');
 
 			setActiveFocus('sidebar');
 			expect(useUIStore.getState().activeFocus).toBe('sidebar');
 		});
 
 		it('extracted actions work with updater functions', () => {
-			const { setSelectedFileIndex } = useUIStore.getState();
+			const { setSelectedSidebarIndex } = useUIStore.getState();
 
-			setSelectedFileIndex(10);
-			expect(useUIStore.getState().selectedFileIndex).toBe(10);
+			setSelectedSidebarIndex(10);
+			expect(useUIStore.getState().selectedSidebarIndex).toBe(10);
 
-			setSelectedFileIndex((prev) => prev - 3);
-			expect(useUIStore.getState().selectedFileIndex).toBe(7);
+			setSelectedSidebarIndex((prev) => prev - 3);
+			expect(useUIStore.getState().selectedSidebarIndex).toBe(7);
 		});
 	});
 

--- a/src/renderer/components/RightPanel.tsx
+++ b/src/renderer/components/RightPanel.tsx
@@ -461,10 +461,11 @@ export const RightPanel = memo(
 					ref={fileTreeContainerRef}
 					className="flex-1 px-4 pb-4 overflow-y-auto overflow-x-hidden min-w-[24rem] outline-none scrollbar-thin"
 					tabIndex={-1}
-					onClick={() => {
+					onClick={(e) => {
 						setActiveFocus('right');
 						// Only focus the container for file explorer, not for autorun (which has its own focus management)
-						if (activeRightTab === 'files') {
+						// Skip when the filter input is focused — otherwise the container steals focus from it
+						if (activeRightTab === 'files' && e.target !== fileTreeFilterInputRef.current) {
 							fileTreeContainerRef.current?.focus();
 						}
 					}}

--- a/src/renderer/hooks/git/useFileTreeManagement.ts
+++ b/src/renderer/hooks/git/useFileTreeManagement.ts
@@ -12,6 +12,7 @@ import {
 import { fuzzyMatch } from '../../utils/search';
 import { gitService } from '../../services/git';
 import { logger } from '../../utils/logger';
+import { useFileExplorerStore } from '../../stores/fileExplorerStore';
 
 /**
  * Retry delay for file tree errors (20 seconds).
@@ -93,8 +94,6 @@ export interface UseFileTreeManagementDeps {
 	activeSessionId: string | null;
 	/** Currently active session (derived from sessions) */
 	activeSession: Session | null;
-	/** File tree filter string */
-	fileTreeFilter: string;
 	/** Ref to RightPanel for refreshing history */
 	rightPanelRef: React.RefObject<RightPanelHandle | null>;
 	/** SSH remote ignore patterns (glob patterns) */
@@ -136,11 +135,12 @@ export function useFileTreeManagement(
 		setSessions,
 		activeSessionId,
 		activeSession,
-		fileTreeFilter,
 		rightPanelRef,
 		sshRemoteIgnorePatterns,
 		sshRemoteHonorGitignore,
 	} = deps;
+
+	const fileTreeFilter = useFileExplorerStore((s) => s.fileTreeFilter);
 
 	// Build SSH context options from settings
 	const sshContextOptions: SshContextOptions = useMemo(

--- a/src/renderer/hooks/ui/useAppHandlers.ts
+++ b/src/renderer/hooks/ui/useAppHandlers.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import type { Session, FocusArea } from '../../types';
 import { shouldOpenExternally, getAllFolderPaths } from '../../utils/fileExplorer';
 import { useModalStore } from '../../stores/modalStore';
+import { useFileExplorerStore } from '../../stores/fileExplorerStore';
 
 /** Loading state for file preview (shown while fetching remote files) */
 export interface FilePreviewLoading {
@@ -29,8 +30,6 @@ export interface UseAppHandlersDeps {
 	setSessions: React.Dispatch<React.SetStateAction<Session[]>>;
 	/** Focus area setter */
 	setActiveFocus: React.Dispatch<React.SetStateAction<FocusArea>>;
-	/** File preview loading state setter (for remote file loading indicator) */
-	setFilePreviewLoading?: (loading: FilePreviewLoading | null) => void;
 	/** Confirmation modal message setter */
 	setConfirmModalMessage: (message: string) => void;
 	/** Confirmation modal callback setter */
@@ -106,7 +105,6 @@ export function useAppHandlers(deps: UseAppHandlersDeps): UseAppHandlersReturn {
 		activeSessionId,
 		setSessions,
 		setActiveFocus,
-		setFilePreviewLoading,
 		setConfirmModalMessage,
 		setConfirmModalOnConfirm,
 		setConfirmModalOpen,
@@ -208,8 +206,10 @@ export function useAppHandlers(deps: UseAppHandlersDeps): UseAppHandlersReturn {
 				}
 
 				// Show loading state for remote files (SSH sessions may be slow)
-				if (sshRemoteId && setFilePreviewLoading) {
-					setFilePreviewLoading({ name: node.name, path: fullPath });
+				if (sshRemoteId) {
+					useFileExplorerStore
+						.getState()
+						.setFilePreviewLoading({ name: node.name, path: fullPath });
 				}
 
 				try {
@@ -234,9 +234,7 @@ export function useAppHandlers(deps: UseAppHandlersDeps): UseAppHandlersReturn {
 					console.error('Failed to read file:', error);
 				} finally {
 					// Clear loading state
-					if (setFilePreviewLoading) {
-						setFilePreviewLoading(null);
-					}
+					useFileExplorerStore.getState().setFilePreviewLoading(null);
 				}
 			}
 		},
@@ -246,7 +244,6 @@ export function useAppHandlers(deps: UseAppHandlersDeps): UseAppHandlersReturn {
 			setConfirmModalOnConfirm,
 			setConfirmModalOpen,
 			setActiveFocus,
-			setFilePreviewLoading,
 			onOpenFileTab,
 		]
 	);

--- a/src/renderer/stores/fileExplorerStore.ts
+++ b/src/renderer/stores/fileExplorerStore.ts
@@ -1,0 +1,159 @@
+/**
+ * fileExplorerStore - Zustand store for file explorer UI state
+ *
+ * Consolidates file explorer state previously scattered across:
+ * - uiStore (selectedFileIndex, fileTreeFilter, fileTreeFilterOpen)
+ * - App.tsx useState (filePreviewLoading, flatFileList, graph view state)
+ *
+ * Per-session file tree DATA (fileTree, fileExplorerExpanded, etc.) stays
+ * in sessionStore — deeply embedded in the Session type with 200+ call sites.
+ *
+ * Can be used outside React via getFileExplorerState() / getFileExplorerActions().
+ */
+
+import { create } from 'zustand';
+import type { FlatTreeNode } from '../utils/fileExplorer';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface FilePreviewLoading {
+	name: string;
+	path: string;
+}
+
+export interface FileExplorerStoreState {
+	// File tree UI (migrated from uiStore)
+	selectedFileIndex: number;
+	fileTreeFilter: string;
+	fileTreeFilterOpen: boolean;
+
+	// File preview loading indicator (migrated from App.tsx)
+	filePreviewLoading: FilePreviewLoading | null;
+
+	// Flattened file list for keyboard navigation (migrated from App.tsx)
+	flatFileList: FlatTreeNode[];
+
+	// Document Graph view state (migrated from App.tsx)
+	isGraphViewOpen: boolean;
+	graphFocusFilePath: string | undefined;
+	lastGraphFocusFilePath: string | undefined;
+}
+
+export interface FileExplorerStoreActions {
+	// File tree UI
+	setSelectedFileIndex: (index: number | ((prev: number) => number)) => void;
+	setFileTreeFilter: (filter: string | ((prev: string) => string)) => void;
+	setFileTreeFilterOpen: (open: boolean | ((prev: boolean) => boolean)) => void;
+
+	// File preview loading
+	setFilePreviewLoading: (loading: FilePreviewLoading | null) => void;
+
+	// Flat file list
+	setFlatFileList: (list: FlatTreeNode[]) => void;
+
+	// Document Graph
+	/** Open graph focused on a file. Atomically sets focus path, last path, and opens view. */
+	focusFileInGraph: (relativePath: string) => void;
+	/** Re-open the last document graph. No-op if no previous path exists. */
+	openLastDocumentGraph: () => void;
+	/** Close the graph view. Preserves lastGraphFocusFilePath for re-open. */
+	closeGraphView: () => void;
+	/** Direct setter for isGraphViewOpen (for inline callbacks with side-effects). */
+	setIsGraphViewOpen: (open: boolean) => void;
+}
+
+export type FileExplorerStore = FileExplorerStoreState & FileExplorerStoreActions;
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Resolve a value-or-updater argument, matching React's setState signature.
+ */
+function resolve<T>(valOrFn: T | ((prev: T) => T), prev: T): T {
+	return typeof valOrFn === 'function' ? (valOrFn as (prev: T) => T)(prev) : valOrFn;
+}
+
+// ============================================================================
+// Store
+// ============================================================================
+
+export const useFileExplorerStore = create<FileExplorerStore>()((set, get) => ({
+	// --- State ---
+	selectedFileIndex: 0,
+	fileTreeFilter: '',
+	fileTreeFilterOpen: false,
+	filePreviewLoading: null,
+	flatFileList: [],
+	isGraphViewOpen: false,
+	graphFocusFilePath: undefined,
+	lastGraphFocusFilePath: undefined,
+
+	// --- Actions ---
+	setSelectedFileIndex: (v) => set((s) => ({ selectedFileIndex: resolve(v, s.selectedFileIndex) })),
+	setFileTreeFilter: (v) => set((s) => ({ fileTreeFilter: resolve(v, s.fileTreeFilter) })),
+	setFileTreeFilterOpen: (v) =>
+		set((s) => ({ fileTreeFilterOpen: resolve(v, s.fileTreeFilterOpen) })),
+
+	setFilePreviewLoading: (loading) => set({ filePreviewLoading: loading }),
+
+	setFlatFileList: (list) => set({ flatFileList: list }),
+
+	focusFileInGraph: (relativePath) =>
+		set({
+			graphFocusFilePath: relativePath,
+			lastGraphFocusFilePath: relativePath,
+			isGraphViewOpen: true,
+		}),
+
+	openLastDocumentGraph: () => {
+		const { lastGraphFocusFilePath } = get();
+		if (lastGraphFocusFilePath) {
+			set({
+				graphFocusFilePath: lastGraphFocusFilePath,
+				isGraphViewOpen: true,
+			});
+		}
+	},
+
+	closeGraphView: () =>
+		set({
+			isGraphViewOpen: false,
+			graphFocusFilePath: undefined,
+		}),
+
+	setIsGraphViewOpen: (open) => set({ isGraphViewOpen: open }),
+}));
+
+// ============================================================================
+// Non-React access
+// ============================================================================
+
+/**
+ * Get current file explorer state snapshot.
+ * Use outside React (services, orchestrators, IPC handlers).
+ */
+export function getFileExplorerState() {
+	return useFileExplorerStore.getState();
+}
+
+/**
+ * Get stable file explorer action references outside React.
+ */
+export function getFileExplorerActions() {
+	const state = useFileExplorerStore.getState();
+	return {
+		setSelectedFileIndex: state.setSelectedFileIndex,
+		setFileTreeFilter: state.setFileTreeFilter,
+		setFileTreeFilterOpen: state.setFileTreeFilterOpen,
+		setFilePreviewLoading: state.setFilePreviewLoading,
+		setFlatFileList: state.setFlatFileList,
+		focusFileInGraph: state.focusFileInGraph,
+		openLastDocumentGraph: state.openLastDocumentGraph,
+		closeGraphView: state.closeGraphView,
+		setIsGraphViewOpen: state.setIsGraphViewOpen,
+	};
+}

--- a/src/renderer/stores/uiStore.ts
+++ b/src/renderer/stores/uiStore.ts
@@ -1,9 +1,11 @@
 /**
  * uiStore - Zustand store for centralized UI layout state management
  *
- * Replaces UILayoutContext. All sidebar, focus, file explorer, notification,
- * and editing states live here. Components subscribe to individual slices
- * via selectors to avoid unnecessary re-renders.
+ * Replaces UILayoutContext. All sidebar, focus, notification, and editing
+ * states live here. Components subscribe to individual slices via selectors
+ * to avoid unnecessary re-renders.
+ *
+ * File explorer UI state has been moved to fileExplorerStore.
  *
  * Can be used outside React via useUIStore.getState() / useUIStore.setState().
  */
@@ -31,11 +33,6 @@ export interface UIStoreState {
 
 	// Session sidebar selection
 	selectedSidebarIndex: number;
-
-	// File explorer
-	selectedFileIndex: number;
-	fileTreeFilter: string;
-	fileTreeFilterOpen: boolean;
 
 	// Flash notifications
 	flashNotification: string | null;
@@ -79,11 +76,6 @@ export interface UIStoreActions {
 	// Session sidebar selection
 	setSelectedSidebarIndex: (index: number | ((prev: number) => number)) => void;
 
-	// File explorer
-	setSelectedFileIndex: (index: number | ((prev: number) => number)) => void;
-	setFileTreeFilter: (filter: string | ((prev: string) => string)) => void;
-	setFileTreeFilterOpen: (open: boolean | ((prev: boolean) => boolean)) => void;
-
 	// Flash notifications
 	setFlashNotification: (msg: string | null | ((prev: string | null) => string | null)) => void;
 	setSuccessFlashNotification: (
@@ -123,9 +115,6 @@ export const useUIStore = create<UIStore>()((set) => ({
 	preFilterActiveTabId: null,
 	preTerminalFileTabId: null,
 	selectedSidebarIndex: 0,
-	selectedFileIndex: 0,
-	fileTreeFilter: '',
-	fileTreeFilterOpen: false,
 	flashNotification: null,
 	successFlashNotification: null,
 	outputSearchOpen: false,
@@ -157,11 +146,6 @@ export const useUIStore = create<UIStore>()((set) => ({
 
 	setSelectedSidebarIndex: (v) =>
 		set((s) => ({ selectedSidebarIndex: resolve(v, s.selectedSidebarIndex) })),
-
-	setSelectedFileIndex: (v) => set((s) => ({ selectedFileIndex: resolve(v, s.selectedFileIndex) })),
-	setFileTreeFilter: (v) => set((s) => ({ fileTreeFilter: resolve(v, s.fileTreeFilter) })),
-	setFileTreeFilterOpen: (v) =>
-		set((s) => ({ fileTreeFilterOpen: resolve(v, s.fileTreeFilterOpen) })),
 
 	setFlashNotification: (v) => set((s) => ({ flashNotification: resolve(v, s.flashNotification) })),
 	setSuccessFlashNotification: (v) =>


### PR DESCRIPTION
## Summary

- **Create `fileExplorerStore`** — new Zustand store (159 lines, 8 state fields, 9 actions) that consolidates file explorer UI state previously scattered across `uiStore`, `App.tsx` useState, and hook dependency props
- **Migrate from uiStore**: `selectedFileIndex`, `fileTreeFilter`, `fileTreeFilterOpen` (3 fields + 3 actions removed from uiStore)
- **Migrate from App.tsx**: `filePreviewLoading`, `flatFileList`, `isGraphViewOpen`, `graphFocusFilePath`, `lastGraphFocusFilePath` (5 useState + 1 useRef + 2 useCallbacks + 1 sync useEffect removed)
- **Decouple hooks from prop threading**: `useAppHandlers` reads `setFilePreviewLoading` from store directly; `useFileTreeManagement` reads `fileTreeFilter` from store directly
- **Atomic document graph actions**: `focusFileInGraph()`, `openLastDocumentGraph()`, `closeGraphView()` replace manual multi-setState coordination + ref sync pattern
- **Fix file tree filter focus bug**: RightPanel container `onClick` was stealing focus from the filter input via event bubbling — added guard to skip `fileTreeContainerRef.focus()` when the click target is the filter input

## Test plan

- 25 new tests for fileExplorerStore (initial state, functional updaters, file preview loading, flat file list, document graph atomicity/lifecycle, non-React access, store reset)
- Updated uiStore tests (removed migrated file explorer tests, updated action stability tests)
- Updated useFileTreeManagement test (filter state now set via store instead of deps)
- TypeScript check passes (`npx tsc --noEmit`) — zero errors
- Full test suite passes (18,737 tests)
- Manual: File tree filter/search — open, type, clear, close/reopen
- Manual: File selection & keyboard navigation in file tree
- Manual: File preview loading indicator (especially on SSH remote sessions)
- Manual: Document Graph open → close → reopen-last lifecycle
- Manual: Click away from filter input, click back — should retain focus without holding mouse