### PR TITLE
fix: stop overriding SSH ControlMaster/ControlPath/ControlPersist configs

### DIFF
--- a/docs/ssh-remote-execution.md
+++ b/docs/ssh-remote-execution.md
@@ -235,6 +235,14 @@ This is especially useful for:
 - **Import from SSH config** — Use the dropdown when adding remotes to import from `~/.ssh/config`; saves time and keeps configuration consistent
 - **Bastion hosts** — Use `ProxyJump` in your SSH config for multi-hop connections; Maestro inherits this automatically
 - **Key management** — Use `ssh-agent` to avoid passphrase prompts
+- **Connection multiplexing** — Maestro respects `ControlMaster`, `ControlPath`, and `ControlPersist` from your `~/.ssh/config`. This is highly recommended if you use hardware security keys (e.g., YubiKey) to avoid repeated touches per connection. Example config:
+  ```
+  Host dev-server
+      ControlMaster auto
+      ControlPath ~/.ssh/sockets/%r@%h-%p
+      ControlPersist 600
+  ```
+  Make sure the socket directory exists (`mkdir -p ~/.ssh/sockets`). Use `%h`, `%p`, and `%r` tokens in `ControlPath` to keep sockets unique per host/port/user.
 - **Keep-alive** — Configure `ServerAliveInterval` in SSH config for long sessions
 - **Test manually first** — Verify `ssh host 'claude --version'` works before configuring in Maestro
 

--- a/src/main/ssh-remote-manager.ts
+++ b/src/main/ssh-remote-manager.ts
@@ -68,9 +68,6 @@ export class SshRemoteManager {
 		ConnectTimeout: '10', // Connection timeout in seconds
 		ClearAllForwardings: 'yes', // Disable port forwarding from SSH config (avoids "Address already in use" errors)
 		RequestTTY: 'no', // Don't request a TTY for command execution (avoids shell rc issues)
-		ControlMaster: 'no', // Disable connection multiplexing to prevent "UNKNOWN port -1" errors when multiple agents connect to same server
-		ControlPath: 'none', // Ensure no ControlPath is used from ~/.ssh/config
-		ControlPersist: 'no', // Don't persist control connections
 	};
 
 	/**


### PR DESCRIPTION
Maestro was forcibly disabling SSH connection multiplexing, requiring a hardware security key touch (or passphrase) for every SSH connection. Users who configure ControlMaster in ~/.ssh/config should have that respected. Updated docs with connection multiplexing guidance.