### PR TITLE
fix: await process.kill() in killBatchRun to prevent race condition

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -6684,9 +6684,9 @@ You are taking over this conversation. Based on the context above, provide a bri
 	// Handler to force kill a batch run (process killed immediately, no waiting)
 	// Confirmation is handled by the calling component's own modal
 	const handleKillBatchRun = useCallback(
-		(sessionId: string) => {
+		async (sessionId: string) => {
 			console.log('[App:handleKillBatchRun] Force killing sessionId:', sessionId);
-			killBatchRun(sessionId);
+			await killBatchRun(sessionId);
 		},
 		[killBatchRun]
 	);


### PR DESCRIPTION
## Summary
- Fixed race condition in `killBatchRun` where `window.maestro.process.kill()` (returns `Promise<boolean>` via IPC) was never awaited, causing state cleanup steps to execute before process termination completed
- Added try/catch around the awaited kill to ensure cleanup proceeds even if the kill fails

## Test plan
- [ ] Start an Auto Run batch, click Kill while agent is active — verify process terminates before batch state resets
- [ ] Kill during error-paused state — verify error resolution and cleanup happen in correct order
- [ ] `npm run lint` passes clean