### PR TITLE
perf: reduce pane resize lag during drag

### DIFF
--- a/src/renderer/components/GroupChatRightPanel.tsx
+++ b/src/renderer/components/GroupChatRightPanel.tsx
@@ -81,6 +81,8 @@ export function GroupChatRightPanel({
 }: GroupChatRightPanelProps): JSX.Element | null {
 	// Color preferences state
 	const [colorPreferences, setColorPreferences] = useState<Record<string, number>>({});
+	const [isResizingPanel, setIsResizingPanel] = useState(false);
+	const panelRef = useRef<HTMLDivElement>(null);
 
 	// Load color preferences on mount
 	useEffect(() => {
@@ -235,7 +237,8 @@ export function GroupChatRightPanel({
 
 	return (
 		<div
-			className="relative border-l flex flex-col transition-all duration-300"
+			ref={panelRef}
+			className={`relative border-l flex flex-col ${isResizingPanel ? 'transition-none' : 'transition-[width] duration-150'}`}
 			style={{
 				width: `${width}px`,
 				backgroundColor: theme.colors.bgSidebar,
@@ -247,6 +250,7 @@ export function GroupChatRightPanel({
 				className="absolute top-0 left-0 w-1 h-full cursor-col-resize hover:bg-blue-500 transition-colors z-20"
 				onMouseDown={(e) => {
 					e.preventDefault();
+					setIsResizingPanel(true);
 					const startX = e.clientX;
 					const startWidth = width;
 					let currentWidth = startWidth;
@@ -254,10 +258,14 @@ export function GroupChatRightPanel({
 					const handleMouseMove = (moveEvent: MouseEvent) => {
 						const delta = startX - moveEvent.clientX; // Reversed for right panel
 						currentWidth = Math.max(200, Math.min(600, startWidth + delta));
-						setWidthState(currentWidth);
+						if (panelRef.current) {
+							panelRef.current.style.width = `${currentWidth}px`;
+						}
 					};
 
 					const handleMouseUp = () => {
+						setIsResizingPanel(false);
+						setWidthState(currentWidth);
 						window.maestro.settings.set('rightPanelWidth', currentWidth);
 						document.removeEventListener('mousemove', handleMouseMove);
 						document.removeEventListener('mouseup', handleMouseUp);

--- a/src/renderer/components/RightPanel.tsx
+++ b/src/renderer/components/RightPanel.tsx
@@ -207,6 +207,7 @@ export const RightPanel = memo(
 		const historyPanelRef = useRef<HistoryPanelHandle>(null);
 		const autoRunRef = useRef<AutoRunHandle>(null);
 		const panelRef = useRef<HTMLDivElement>(null);
+		const [isResizingRightPanel, setIsResizingRightPanel] = useState(false);
 
 		// Elapsed time for Auto Run display - tracks wall clock time from startTime
 		const [elapsedTime, setElapsedTime] = useState<string>('');
@@ -387,7 +388,7 @@ export const RightPanel = memo(
 			<div
 				ref={panelRef}
 				tabIndex={0}
-				className={`border-l flex flex-col transition-all duration-300 outline-none relative ${rightPanelOpen ? '' : 'w-0 overflow-hidden opacity-0'} ${activeFocus === 'right' ? 'ring-1 ring-inset z-10' : ''}`}
+				className={`border-l flex flex-col ${isResizingRightPanel ? 'transition-none' : 'transition-[width] duration-150'} outline-none relative ${rightPanelOpen ? '' : 'w-0 overflow-hidden opacity-0'} ${activeFocus === 'right' ? 'ring-1 ring-inset z-10' : ''}`}
 				style={
 					{
 						width: rightPanelOpen ? `${rightPanelWidth}px` : '0',
@@ -405,6 +406,7 @@ export const RightPanel = memo(
 						className="absolute top-0 left-0 w-1 h-full cursor-col-resize hover:bg-blue-500 transition-colors z-20"
 						onMouseDown={(e) => {
 							e.preventDefault();
+							setIsResizingRightPanel(true);
 							const startX = e.clientX;
 							const startWidth = rightPanelWidth;
 							let currentWidth = startWidth;
@@ -420,6 +422,7 @@ export const RightPanel = memo(
 
 							const handleMouseUp = () => {
 								// Only update React state once on mouseup
+								setIsResizingRightPanel(false);
 								setRightPanelWidthState(currentWidth);
 								window.maestro.settings.set('rightPanelWidth', currentWidth);
 								document.removeEventListener('mousemove', handleMouseMove);

--- a/src/renderer/components/SessionList.tsx
+++ b/src/renderer/components/SessionList.tsx
@@ -1232,6 +1232,7 @@ function SessionListInner(props: SessionListProps) {
 	const isAnyBusy = useMemo(() => sessions.some((s) => s.state === 'busy'), [sessions]);
 
 	const [sessionFilter, setSessionFilter] = useState('');
+	const [isResizingSidebar, setIsResizingSidebar] = useState(false);
 	const sessionFilterOpen = useUIStore((s) => s.sessionFilterOpen);
 	const setSessionFilterOpen = useUIStore((s) => s.setSessionFilterOpen);
 	const [preFilterGroupStates, setPreFilterGroupStates] = useState<Map<string, boolean>>(new Map());
@@ -1907,7 +1908,7 @@ function SessionListInner(props: SessionListProps) {
 		<div
 			ref={sidebarContainerRef}
 			tabIndex={0}
-			className={`border-r flex flex-col shrink-0 transition-all duration-300 outline-none relative z-20 ${activeFocus === 'sidebar' && !activeGroupChatId ? 'ring-1 ring-inset' : ''}`}
+			className={`border-r flex flex-col shrink-0 ${isResizingSidebar ? 'transition-none' : 'transition-[width] duration-150'} outline-none relative z-20 ${activeFocus === 'sidebar' && !activeGroupChatId ? 'ring-1 ring-inset' : ''}`}
 			style={
 				{
 					width: leftSidebarOpen ? `${leftSidebarWidthState}px` : '64px',
@@ -1938,6 +1939,7 @@ function SessionListInner(props: SessionListProps) {
 					className="absolute top-0 right-0 w-1 h-full cursor-col-resize hover:bg-blue-500 transition-colors z-20"
 					onMouseDown={(e) => {
 						e.preventDefault();
+						setIsResizingSidebar(true);
 						const startX = e.clientX;
 						const startWidth = leftSidebarWidthState;
 						let currentWidth = startWidth;
@@ -1953,6 +1955,7 @@ function SessionListInner(props: SessionListProps) {
 
 						const handleMouseUp = () => {
 							// Only update React state once on mouseup
+							setIsResizingSidebar(false);
 							setLeftSidebarWidthState(currentWidth);
 							window.maestro.settings.set('leftSidebarWidth', currentWidth);
 							document.removeEventListener('mousemove', handleMouseMove);


### PR DESCRIPTION
## Summary
- disable width transitions while panel drag is in progress
- keep collapse/expand animation by only transitioning width when not actively resizing
- apply the same drag optimization to group chat right panels

## Changes
- `SessionList`: removes width transition during live drag and commits width once on mouseup
- `RightPanel`: same transition gating + mouseup-only state commit
- `GroupChatRightPanel` and `GroupChatParticipants`: switch to direct DOM width update during drag, state commit on mouseup

## Validation
- `npx tsc -p tsconfig.lint.json --noEmit`
- `npm run test -- src/__tests__/renderer/components/SessionList.test.tsx src/__tests__/renderer/components/RightPanel.test.tsx`

Closes #354
