### PR TITLE
feat: add material-style icon mapping in file explorer

### DIFF
--- a/src/__tests__/renderer/components/FileExplorerPanel.test.tsx
+++ b/src/__tests__/renderer/components/FileExplorerPanel.test.tsx
@@ -162,6 +162,16 @@ vi.mock('../../../renderer/utils/theme', () => ({
 		if (type === 'deleted') return <span data-testid="deleted-icon">-</span>;
 		return <span data-testid="file-icon">📄</span>;
 	},
+	getExplorerFileIcon: (name: string, _theme: Theme, type?: string) => {
+		if (type === 'added') return <span data-testid="added-icon">+</span>;
+		if (type === 'modified') return <span data-testid="modified-icon">~</span>;
+		if (type === 'deleted') return <span data-testid="deleted-icon">-</span>;
+		void name;
+		return <span data-testid="file-icon">📄</span>;
+	},
+	getExplorerFolderIcon: (_name: string, _isExpanded: boolean, _theme: Theme) => (
+		<span data-testid="folder-icon">📁</span>
+	),
 }));
 
 // Mock MODAL_PRIORITIES

--- a/src/renderer/components/FileExplorerPanel.tsx
+++ b/src/renderer/components/FileExplorerPanel.tsx
@@ -32,7 +32,7 @@ import {
 	findNodeInTree,
 	countNodesInTree,
 } from '../utils/fileExplorer';
-import { getFileIcon } from '../utils/theme';
+import { getExplorerFileIcon, getExplorerFolderIcon } from '../utils/theme';
 import { useLayerStack } from '../contexts/LayerStackContext';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
 import { useClickOutside } from '../hooks/ui/useClickOutside';
@@ -969,11 +969,9 @@ function FileExplorerPanelInner(props: FileExplorerPanelProps) {
 							<ChevronRight className="w-3 h-3 flex-shrink-0" />
 						))}
 					<span className="flex-shrink-0">
-						{isFolder ? (
-							<Folder className="w-3.5 h-3.5" style={{ color: theme.colors.accent }} />
-						) : (
-							getFileIcon(change?.type, theme)
-						)}
+						{isFolder
+							? getExplorerFolderIcon(node.name, isExpanded, theme)
+							: getExplorerFileIcon(node.name, theme, change?.type)}
 					</span>
 					<span
 						className={`truncate min-w-0 flex-1 ${change ? 'font-medium' : ''}`}

--- a/src/renderer/utils/theme.tsx
+++ b/src/renderer/utils/theme.tsx
@@ -1,4 +1,22 @@
-import { FilePlus, Trash2, FileCode, FileText } from 'lucide-react';
+import {
+	BookOpen,
+	Database,
+	File,
+	FileCode,
+	FileImage,
+	FilePlus,
+	FileText,
+	FlaskConical,
+	Folder,
+	FolderOpen,
+	GitBranch,
+	ImageIcon,
+	Lock,
+	Package,
+	Server,
+	Settings,
+	Trash2,
+} from 'lucide-react';
 import type { Theme, SessionState, FileChangeType } from '../types';
 
 // Re-export formatActiveTime from formatters for backwards compatibility
@@ -52,4 +70,217 @@ export const getFileIcon = (type: FileChangeType | undefined, theme: Theme): JSX
 		default:
 			return <FileText className="w-3.5 h-3.5" style={{ color: theme.colors.textDim }} />;
 	}
+};
+
+const CODE_EXTENSIONS = new Set([
+	'ts',
+	'tsx',
+	'js',
+	'jsx',
+	'mjs',
+	'cjs',
+	'py',
+	'rb',
+	'go',
+	'rs',
+	'java',
+	'kt',
+	'swift',
+	'cpp',
+	'c',
+	'h',
+	'hpp',
+	'cs',
+	'php',
+	'lua',
+	'sh',
+	'zsh',
+	'fish',
+	'bash',
+	'sql',
+]);
+
+const CONFIG_EXTENSIONS = new Set(['json', 'yaml', 'yml', 'toml', 'ini', 'conf', 'cfg']);
+const DOC_EXTENSIONS = new Set(['md', 'mdx', 'txt', 'rst']);
+const IMAGE_EXTENSIONS = new Set(['png', 'jpg', 'jpeg', 'gif', 'svg', 'webp', 'ico', 'bmp']);
+const ARCHIVE_EXTENSIONS = new Set(['zip', 'tar', 'gz', 'tgz', 'rar', '7z']);
+const LOCK_FILE_NAMES = new Set([
+	'package-lock.json',
+	'pnpm-lock.yaml',
+	'yarn.lock',
+	'bun.lock',
+	'bun.lockb',
+	'composer.lock',
+	'cargo.lock',
+	'poetry.lock',
+]);
+const CONFIG_FILE_NAMES = new Set([
+	'.env',
+	'.env.local',
+	'.env.development',
+	'.env.production',
+	'.gitignore',
+	'.gitattributes',
+	'dockerfile',
+	'compose.yml',
+	'compose.yaml',
+	'docker-compose.yml',
+	'docker-compose.yaml',
+	'tsconfig.json',
+	'vite.config.ts',
+	'vite.config.js',
+	'webpack.config.js',
+	'eslint.config.js',
+	'eslint.config.mjs',
+	'prettier.config.js',
+	'next.config.js',
+	'next.config.ts',
+]);
+
+const DOC_FOLDER_NAMES = new Set(['docs', 'doc', 'documentation', 'notes', 'wiki']);
+const TEST_FOLDER_NAMES = new Set(['test', 'tests', '__tests__', 'spec', 'specs', 'e2e']);
+const CONFIG_FOLDER_NAMES = new Set([
+	'.github',
+	'.vscode',
+	'.claude',
+	'.codex',
+	'config',
+	'configs',
+	'settings',
+]);
+const ASSET_FOLDER_NAMES = new Set(['assets', 'images', 'img', 'icons', 'public', 'static', 'media']);
+const DEP_FOLDER_NAMES = new Set(['node_modules', 'vendor', 'deps', 'packages']);
+const DATA_FOLDER_NAMES = new Set(['data', 'db', 'database', 'migrations', 'seeds']);
+const SECURE_FOLDER_NAMES = new Set(['secrets', 'certs', 'certificates', 'keys']);
+const INFRA_FOLDER_NAMES = new Set(['scripts', 'infra', 'deployment', 'docker', 'ops', 'bin']);
+
+const normalizeName = (name: string): string => name.trim().toLowerCase();
+
+const fileTypeColor = (type: FileChangeType | undefined, fallback: string): string => {
+	if (type === 'added') return 'var(--maestro-success-color)';
+	if (type === 'deleted') return 'var(--maestro-error-color)';
+	if (type === 'modified') return 'var(--maestro-warning-color)';
+	return fallback;
+};
+
+export const getExplorerFileIcon = (
+	fileName: string,
+	theme: Theme,
+	type?: FileChangeType
+): JSX.Element => {
+	const normalized = normalizeName(fileName);
+	const ext = normalized.includes('.') ? normalized.split('.').pop() ?? '' : '';
+	const isTestFile =
+		normalized.includes('.test.') ||
+		normalized.includes('.spec.') ||
+		normalized.endsWith('.test') ||
+		normalized.endsWith('.spec');
+
+	const style = {
+		'--maestro-success-color': theme.colors.success,
+		'--maestro-error-color': theme.colors.error,
+		'--maestro-warning-color': theme.colors.warning,
+	};
+
+	if (LOCK_FILE_NAMES.has(normalized)) {
+		return <Lock className="w-3.5 h-3.5" style={{ ...style, color: fileTypeColor(type, theme.colors.warning) }} />;
+	}
+	if (CONFIG_FILE_NAMES.has(normalized) || CONFIG_EXTENSIONS.has(ext)) {
+		return (
+			<Settings
+				className="w-3.5 h-3.5"
+				style={{ ...style, color: fileTypeColor(type, theme.colors.warning) }}
+			/>
+		);
+	}
+	if (IMAGE_EXTENSIONS.has(ext)) {
+		return (
+			<FileImage
+				className="w-3.5 h-3.5"
+				style={{ ...style, color: fileTypeColor(type, theme.colors.accent) }}
+			/>
+		);
+	}
+	if (DOC_EXTENSIONS.has(ext)) {
+		return (
+			<BookOpen
+				className="w-3.5 h-3.5"
+				style={{ ...style, color: fileTypeColor(type, theme.colors.accent) }}
+			/>
+		);
+	}
+	if (ARCHIVE_EXTENSIONS.has(ext)) {
+		return (
+			<Package
+				className="w-3.5 h-3.5"
+				style={{ ...style, color: fileTypeColor(type, theme.colors.warning) }}
+			/>
+		);
+	}
+	if (isTestFile) {
+		return (
+			<FlaskConical
+				className="w-3.5 h-3.5"
+				style={{ ...style, color: fileTypeColor(type, theme.colors.warning) }}
+			/>
+		);
+	}
+	if (CODE_EXTENSIONS.has(ext)) {
+		return (
+			<FileCode
+				className="w-3.5 h-3.5"
+				style={{ ...style, color: fileTypeColor(type, theme.colors.accent) }}
+			/>
+		);
+	}
+	if (ext === 'csv' || ext === 'tsv') {
+		return (
+			<Database
+				className="w-3.5 h-3.5"
+				style={{ ...style, color: fileTypeColor(type, theme.colors.accent) }}
+			/>
+		);
+	}
+	return <File className="w-3.5 h-3.5" style={{ ...style, color: fileTypeColor(type, theme.colors.textDim) }} />;
+};
+
+export const getExplorerFolderIcon = (
+	folderName: string,
+	isExpanded: boolean,
+	theme: Theme
+): JSX.Element => {
+	const normalized = normalizeName(folderName);
+
+	if (normalized === '.git') {
+		return <GitBranch className="w-3.5 h-3.5" style={{ color: theme.colors.warning }} />;
+	}
+	if (DOC_FOLDER_NAMES.has(normalized)) {
+		return <BookOpen className="w-3.5 h-3.5" style={{ color: theme.colors.accent }} />;
+	}
+	if (TEST_FOLDER_NAMES.has(normalized)) {
+		return <FlaskConical className="w-3.5 h-3.5" style={{ color: theme.colors.warning }} />;
+	}
+	if (CONFIG_FOLDER_NAMES.has(normalized)) {
+		return <Settings className="w-3.5 h-3.5" style={{ color: theme.colors.warning }} />;
+	}
+	if (ASSET_FOLDER_NAMES.has(normalized)) {
+		return <ImageIcon className="w-3.5 h-3.5" style={{ color: theme.colors.accent }} />;
+	}
+	if (DEP_FOLDER_NAMES.has(normalized)) {
+		return <Package className="w-3.5 h-3.5" style={{ color: theme.colors.warning }} />;
+	}
+	if (DATA_FOLDER_NAMES.has(normalized)) {
+		return <Database className="w-3.5 h-3.5" style={{ color: theme.colors.accent }} />;
+	}
+	if (SECURE_FOLDER_NAMES.has(normalized)) {
+		return <Lock className="w-3.5 h-3.5" style={{ color: theme.colors.error }} />;
+	}
+	if (INFRA_FOLDER_NAMES.has(normalized)) {
+		return <Server className="w-3.5 h-3.5" style={{ color: theme.colors.accent }} />;
+	}
+	return isExpanded ? (
+		<FolderOpen className="w-3.5 h-3.5" style={{ color: theme.colors.accent }} />
+	) : (
+		<Folder className="w-3.5 h-3.5" style={{ color: theme.colors.accent }} />
+	);
 };


### PR DESCRIPTION
## Summary
Adds VSCode-style semantic icon mapping in the file explorer (Material-icon-theme inspired), including special folder and file categories.

## Changes
- `theme.tsx`
  - add semantic file icon mapping by extension/name
  - add semantic folder icon mapping by common folder names (`.git`, docs, tests, config, assets, deps, etc.)
- `FileExplorerPanel.tsx`
  - use the new semantic icon helpers for both files and folders
- `FileExplorerPanel.test.tsx`
  - update theme mock exports to support the new icon helpers

## Validation
- `npm run test -- src/__tests__/renderer/utils/theme.test.tsx src/__tests__/renderer/components/FileExplorerPanel.test.tsx`
- `npx tsc -p tsconfig.lint.json --noEmit`

Closes #355


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * File explorer icons now provide more detailed visual indicators for different file types
  * Added contextual visual indicators for file change status (added, modified, deleted)
  * Enhanced folder icon styling with improved context-aware presentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->