### PR TITLE
feat: increase default agent input box height

### DIFF
--- a/src/renderer/components/InputArea.tsx
+++ b/src/renderer/components/InputArea.tsx
@@ -841,8 +841,8 @@ export const InputArea = React.memo(function InputArea(props: InputAreaProps) {
 							)}
 							<textarea
 								ref={inputRef}
-								className={`flex-1 bg-transparent text-sm outline-none ${isTerminalMode ? 'pl-1.5' : 'pl-3'} pt-3 pr-3 resize-none min-h-[2.5rem] scrollbar-thin`}
-								style={{ color: theme.colors.textMain, maxHeight: '7rem' }}
+								className={`flex-1 bg-transparent text-sm outline-none ${isTerminalMode ? 'pl-1.5' : 'pl-3'} pt-3 pr-3 resize-none min-h-[3.5rem] scrollbar-thin`}
+								style={{ color: theme.colors.textMain, maxHeight: '11rem' }}
 								placeholder={
 									isTerminalMode
 										? 'Run shell command...'
@@ -907,7 +907,7 @@ export const InputArea = React.memo(function InputArea(props: InputAreaProps) {
 									const textarea = e.target;
 									requestAnimationFrame(() => {
 										textarea.style.height = 'auto';
-										textarea.style.height = `${Math.min(textarea.scrollHeight, 112)}px`;
+										textarea.style.height = `${Math.min(textarea.scrollHeight, 176)}px`;
 									});
 								}}
 								onKeyDown={handleInputKeyDown}
@@ -917,7 +917,7 @@ export const InputArea = React.memo(function InputArea(props: InputAreaProps) {
 									handleDrop(e);
 								}}
 								onDragOver={(e) => e.preventDefault()}
-								rows={1}
+								rows={2}
 							/>
 						</div>
 


### PR DESCRIPTION
## Summary
Make the agent session input feel like a real textarea by default.

## Changes
- increase default rows from `1` to `2`
- raise minimum input height from `2.5rem` to `3.5rem`
- increase max auto-grow cap from `112px` to `176px`
- increase max visual height from `7rem` to `11rem`

## Validation
- `npm run test -- src/__tests__/renderer/components/InputArea.test.tsx`
- `npx tsc -p tsconfig.lint.json --noEmit`

Closes #356
