### PR TITLE
feat: add persistent chat side alignment toggle

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -467,6 +467,8 @@ function MaestroConsoleInner() {
 		setMarkdownEditMode,
 		chatRawTextMode,
 		setChatRawTextMode,
+		chatUserMessagesOnRight,
+		setChatUserMessagesOnRight,
 		showHiddenFiles,
 		setShowHiddenFiles,
 		terminalWidth,
@@ -11065,6 +11067,7 @@ You are taking over this conversation. Based on the context above, provide a bri
 		filePreviewLoading,
 		markdownEditMode,
 		chatRawTextMode,
+		chatUserMessagesOnRight,
 		shortcuts,
 		rightPanelOpen,
 		maxOutputLines,
@@ -12380,6 +12383,7 @@ You are taking over this conversation. Based on the context above, provide a bri
 									onReorderQueuedItems={handleReorderGroupChatQueueItems}
 									markdownEditMode={markdownEditMode}
 									onToggleMarkdownEditMode={() => setMarkdownEditMode(!markdownEditMode)}
+									chatUserMessagesOnRight={chatUserMessagesOnRight}
 									maxOutputLines={maxOutputLines}
 									enterToSendAI={enterToSendAI}
 									setEnterToSendAI={setEnterToSendAI}
@@ -12492,6 +12496,8 @@ You are taking over this conversation. Based on the context above, provide a bri
 							setDefaultSaveToHistory={setDefaultSaveToHistory}
 							defaultShowThinking={defaultShowThinking}
 							setDefaultShowThinking={setDefaultShowThinking}
+							chatUserMessagesOnRight={chatUserMessagesOnRight}
+							setChatUserMessagesOnRight={setChatUserMessagesOnRight}
 							fontFamily={fontFamily}
 							setFontFamily={setFontFamily}
 							fontSize={fontSize}

--- a/src/renderer/components/GroupChatMessages.tsx
+++ b/src/renderer/components/GroupChatMessages.tsx
@@ -29,6 +29,7 @@ interface GroupChatMessagesProps {
 	markdownEditMode?: boolean;
 	onToggleMarkdownEditMode?: () => void;
 	maxOutputLines?: number;
+	userMessagesOnRight?: boolean;
 	/** Pre-computed participant colors (if provided, overrides internal color generation) */
 	participantColors?: Record<string, string>;
 }
@@ -48,6 +49,7 @@ export const GroupChatMessages = forwardRef<GroupChatMessagesHandle, GroupChatMe
 			markdownEditMode,
 			onToggleMarkdownEditMode,
 			maxOutputLines = 30,
+			userMessagesOnRight = true,
 			participantColors: externalColors,
 		},
 		ref
@@ -216,6 +218,7 @@ export const GroupChatMessages = forwardRef<GroupChatMessagesHandle, GroupChatMe
 					messages.map((msg, index) => {
 						const isUser = msg.from === 'user';
 						const isSystem = msg.from === 'system';
+						const alignMessageRight = isUser ? userMessagesOnRight : !userMessagesOnRight;
 						const msgKey = `${msg.timestamp}-${index}`;
 						const isExpanded = expandedMessages.has(msgKey);
 
@@ -241,11 +244,11 @@ export const GroupChatMessages = forwardRef<GroupChatMessagesHandle, GroupChatMe
 							<div
 								key={msgKey}
 								data-message-timestamp={msg.timestamp}
-								className={`flex gap-4 group ${isUser ? 'flex-row-reverse' : ''} px-6 py-2`}
+								className={`flex gap-4 group ${alignMessageRight ? 'flex-row-reverse' : ''} px-6 py-2`}
 							>
 								{/* Timestamp - outside bubble, like AI Terminal */}
 								<div
-									className={`w-20 shrink-0 text-[10px] pt-2 ${isUser ? 'text-right' : 'text-left'}`}
+									className={`w-20 shrink-0 text-[10px] pt-2 ${alignMessageRight ? 'text-right' : 'text-left'}`}
 									style={{ color: theme.colors.textDim, opacity: 0.6 }}
 								>
 									{formatTimestamp(msg.timestamp)}
@@ -253,7 +256,7 @@ export const GroupChatMessages = forwardRef<GroupChatMessagesHandle, GroupChatMe
 
 								{/* Message bubble */}
 								<div
-									className={`flex-1 min-w-0 p-4 pb-10 rounded-xl border ${isUser ? 'rounded-tr-none' : 'rounded-tl-none'} relative overflow-hidden`}
+									className={`flex-1 min-w-0 p-4 pb-10 rounded-xl border ${alignMessageRight ? 'rounded-tr-none' : 'rounded-tl-none'} relative overflow-hidden`}
 									style={{
 										backgroundColor: isUser
 											? `color-mix(in srgb, ${theme.colors.accent} 20%, ${theme.colors.bgSidebar})`

--- a/src/renderer/components/GroupChatPanel.tsx
+++ b/src/renderer/components/GroupChatPanel.tsx
@@ -58,6 +58,7 @@ interface GroupChatPanelProps {
 	// Markdown toggle (Cmd+E)
 	markdownEditMode?: boolean;
 	onToggleMarkdownEditMode?: () => void;
+	chatUserMessagesOnRight?: boolean;
 	// Output collapsing
 	maxOutputLines?: number;
 	// Input send behavior
@@ -101,6 +102,7 @@ export function GroupChatPanel({
 	onReorderQueuedItems,
 	markdownEditMode,
 	onToggleMarkdownEditMode,
+	chatUserMessagesOnRight = true,
 	maxOutputLines,
 	enterToSendAI,
 	setEnterToSendAI,
@@ -132,6 +134,7 @@ export function GroupChatPanel({
 				state={state}
 				markdownEditMode={markdownEditMode}
 				onToggleMarkdownEditMode={onToggleMarkdownEditMode}
+				userMessagesOnRight={chatUserMessagesOnRight}
 				maxOutputLines={maxOutputLines}
 				participantColors={participantColors}
 			/>

--- a/src/renderer/components/MainPanel.tsx
+++ b/src/renderer/components/MainPanel.tsx
@@ -108,6 +108,7 @@ interface MainPanelProps {
 	filePreviewLoading?: { name: string; path: string } | null;
 	markdownEditMode: boolean; // FilePreview: whether editing file content
 	chatRawTextMode: boolean; // TerminalOutput: whether to show raw text in AI responses
+	chatUserMessagesOnRight: boolean; // Chat alignment preference
 	shortcuts: Record<string, Shortcut>;
 	rightPanelOpen: boolean;
 	maxOutputLines: number;
@@ -388,6 +389,7 @@ export const MainPanel = React.memo(
 			filePreviewLoading,
 			markdownEditMode: _markdownEditMode,
 			chatRawTextMode,
+			chatUserMessagesOnRight,
 			shortcuts,
 			rightPanelOpen,
 			maxOutputLines,
@@ -1770,6 +1772,7 @@ export const MainPanel = React.memo(
 											inputRef={inputRef}
 											logsEndRef={logsEndRef}
 											maxOutputLines={maxOutputLines}
+											userMessagesOnRight={chatUserMessagesOnRight}
 											onDeleteLog={props.onDeleteLog}
 											onRemoveQueuedItem={onRemoveQueuedItem}
 											onInterrupt={handleInterrupt}

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -32,6 +32,7 @@ import {
 	PartyPopper,
 	Tag,
 	User,
+	MessageSquare,
 } from 'lucide-react';
 import { useSettings } from '../hooks';
 import type {
@@ -257,6 +258,8 @@ interface SettingsModalProps {
 	setDefaultSaveToHistory: (value: boolean) => void;
 	defaultShowThinking: 'off' | 'on' | 'sticky';
 	setDefaultShowThinking: (value: 'off' | 'on' | 'sticky') => void;
+	chatUserMessagesOnRight: boolean;
+	setChatUserMessagesOnRight: (value: boolean) => void;
 	osNotificationsEnabled: boolean;
 	setOsNotificationsEnabled: (value: boolean) => void;
 	audioFeedbackEnabled: boolean;
@@ -1435,6 +1438,16 @@ export const SettingsModal = memo(function SettingsModal(props: SettingsModalPro
 									/>
 								</div>
 							</div>
+
+							<SettingCheckbox
+								icon={MessageSquare}
+								sectionLabel="Chat Layout"
+								title="Place user messages on the right"
+								description="Toggle chat bubble alignment across session and group chat views."
+								checked={props.chatUserMessagesOnRight}
+								onChange={props.setChatUserMessagesOnRight}
+								theme={theme}
+							/>
 
 							{/* Sleep Prevention */}
 							<div>

--- a/src/renderer/components/TerminalOutput.tsx
+++ b/src/renderer/components/TerminalOutput.tsx
@@ -79,6 +79,7 @@ interface LogItemProps {
 	// Markdown rendering mode for AI responses (when true, shows raw text)
 	markdownEditMode: boolean;
 	onToggleMarkdownEditMode: () => void;
+	userMessagesOnRight: boolean;
 	// Replay message callback (AI mode only)
 	onReplayMessage?: (text: string, images?: string[]) => void;
 	// File linking support
@@ -121,6 +122,7 @@ const LogItemComponent = memo(
 		ansiConverter,
 		markdownEditMode,
 		onToggleMarkdownEditMode,
+		userMessagesOnRight,
 		onReplayMessage,
 		fileTree,
 		cwd,
@@ -326,15 +328,16 @@ const LogItemComponent = memo(
 				: htmlContent;
 
 		const isUserMessage = log.source === 'user';
+		const alignMessageRight = isUserMessage ? userMessagesOnRight : !userMessagesOnRight;
 
 		return (
 			<div
 				ref={logItemRef}
-				className={`flex gap-4 group ${isUserMessage ? 'flex-row-reverse' : ''} px-6 py-2`}
+				className={`flex gap-4 group ${alignMessageRight ? 'flex-row-reverse' : ''} px-6 py-2`}
 				data-log-index={index}
 			>
 				<div
-					className={`w-20 shrink-0 text-[10px] pt-2 ${isUserMessage ? 'text-right' : 'text-left'}`}
+					className={`w-20 shrink-0 text-[10px] pt-2 ${alignMessageRight ? 'text-right' : 'text-left'}`}
 					style={{ fontFamily, color: theme.colors.textDim, opacity: 0.6 }}
 				>
 					{(() => {
@@ -360,7 +363,7 @@ const LogItemComponent = memo(
 					})()}
 				</div>
 				<div
-					className={`flex-1 min-w-0 p-4 pb-10 rounded-xl border ${isUserMessage ? 'rounded-tr-none' : 'rounded-tl-none'} relative overflow-hidden`}
+					className={`flex-1 min-w-0 p-4 pb-10 rounded-xl border ${alignMessageRight ? 'rounded-tr-none' : 'rounded-tl-none'} relative overflow-hidden`}
 					style={{
 						backgroundColor: isUserMessage
 							? isAIMode
@@ -954,6 +957,7 @@ interface TerminalOutputProps {
 	initialScrollTop?: number; // Initial scroll position to restore
 	markdownEditMode: boolean; // Whether to show raw markdown or rendered markdown for AI responses
 	setMarkdownEditMode: (value: boolean) => void; // Toggle markdown mode
+	userMessagesOnRight: boolean; // Chat alignment preference
 	onReplayMessage?: (text: string, images?: string[]) => void; // Replay a user message
 	fileTree?: FileNode[]; // File tree for linking file references
 	cwd?: string; // Current working directory for proximity-based matching
@@ -991,6 +995,7 @@ export const TerminalOutput = memo(
 			initialScrollTop,
 			markdownEditMode,
 			setMarkdownEditMode,
+			userMessagesOnRight = true,
 			onReplayMessage,
 			fileTree,
 			cwd,
@@ -1608,6 +1613,7 @@ export const TerminalOutput = memo(
 							ansiConverter={ansiConverter}
 							markdownEditMode={markdownEditMode}
 							onToggleMarkdownEditMode={toggleMarkdownEditMode}
+							userMessagesOnRight={userMessagesOnRight}
 							onReplayMessage={onReplayMessage}
 							fileTree={fileTree}
 							cwd={cwd}

--- a/src/renderer/hooks/props/useMainPanelProps.ts
+++ b/src/renderer/hooks/props/useMainPanelProps.ts
@@ -63,6 +63,7 @@ export interface UseMainPanelPropsDeps {
 	filePreviewLoading: { name: string; path: string } | null;
 	markdownEditMode: boolean; // FilePreview: whether editing file content
 	chatRawTextMode: boolean; // TerminalOutput: whether to show raw text in AI responses
+	chatUserMessagesOnRight: boolean; // Chat alignment preference
 	shortcuts: Record<string, Shortcut>;
 	rightPanelOpen: boolean;
 	maxOutputLines: number;
@@ -334,6 +335,7 @@ export function useMainPanelProps(deps: UseMainPanelPropsDeps) {
 			filePreviewLoading: deps.filePreviewLoading,
 			markdownEditMode: deps.markdownEditMode,
 			chatRawTextMode: deps.chatRawTextMode,
+			chatUserMessagesOnRight: deps.chatUserMessagesOnRight,
 			shortcuts: deps.shortcuts,
 			rightPanelOpen: deps.rightPanelOpen,
 			maxOutputLines: deps.maxOutputLines,
@@ -555,6 +557,7 @@ export function useMainPanelProps(deps: UseMainPanelPropsDeps) {
 			deps.filePreviewLoading,
 			deps.markdownEditMode,
 			deps.chatRawTextMode,
+			deps.chatUserMessagesOnRight,
 			deps.shortcuts,
 			deps.rightPanelOpen,
 			deps.maxOutputLines,

--- a/src/renderer/hooks/settings/useSettings.ts
+++ b/src/renderer/hooks/settings/useSettings.ts
@@ -179,10 +179,12 @@ export interface UseSettingsReturn {
 	rightPanelWidth: number;
 	markdownEditMode: boolean; // FilePreview: whether editing file content (vs viewing rendered)
 	chatRawTextMode: boolean; // TerminalOutput: whether to show raw text in AI responses (vs rendered markdown)
+	chatUserMessagesOnRight: boolean; // Chat alignment: true=user right, false=user left
 	setLeftSidebarWidth: (value: number) => void;
 	setRightPanelWidth: (value: number) => void;
 	setMarkdownEditMode: (value: boolean) => void;
 	setChatRawTextMode: (value: boolean) => void;
+	setChatUserMessagesOnRight: (value: boolean) => void;
 	showHiddenFiles: boolean;
 	setShowHiddenFiles: (value: boolean) => void;
 
@@ -399,6 +401,7 @@ export function useSettings(): UseSettingsReturn {
 	const [rightPanelWidth, setRightPanelWidthState] = useState(384);
 	const [markdownEditMode, setMarkdownEditModeState] = useState(false); // FilePreview: edit file content
 	const [chatRawTextMode, setChatRawTextModeState] = useState(false); // TerminalOutput: show raw text in AI responses
+	const [chatUserMessagesOnRight, setChatUserMessagesOnRightState] = useState(true); // Default: user right, assistant left
 	const [showHiddenFiles, setShowHiddenFilesState] = useState(true); // Default: show hidden files
 
 	// Terminal Config
@@ -637,6 +640,11 @@ export function useSettings(): UseSettingsReturn {
 	const setChatRawTextMode = useCallback((value: boolean) => {
 		setChatRawTextModeState(value);
 		window.maestro.settings.set('chatRawTextMode', value);
+	}, []);
+
+	const setChatUserMessagesOnRight = useCallback((value: boolean) => {
+		setChatUserMessagesOnRightState(value);
+		window.maestro.settings.set('chatUserMessagesOnRight', value);
 	}, []);
 
 	const setShowHiddenFiles = useCallback((value: boolean) => {
@@ -1379,6 +1387,7 @@ export function useSettings(): UseSettingsReturn {
 			const savedLeftSidebarWidth = allSettings['leftSidebarWidth'];
 			const savedRightPanelWidth = allSettings['rightPanelWidth'];
 			const savedMarkdownEditMode = allSettings['markdownEditMode'];
+			const savedChatUserMessagesOnRight = allSettings['chatUserMessagesOnRight'];
 			const savedShowHiddenFiles = allSettings['showHiddenFiles'];
 			const savedShortcuts = allSettings['shortcuts'];
 			const savedTabShortcuts = allSettings['tabShortcuts'];
@@ -1469,6 +1478,8 @@ export function useSettings(): UseSettingsReturn {
 			const savedChatRawTextMode = allSettings['chatRawTextMode'];
 			if (savedChatRawTextMode !== undefined)
 				setChatRawTextModeState(savedChatRawTextMode as boolean);
+			if (savedChatUserMessagesOnRight !== undefined)
+				setChatUserMessagesOnRightState(savedChatUserMessagesOnRight as boolean);
 			if (savedShowHiddenFiles !== undefined)
 				setShowHiddenFilesState(savedShowHiddenFiles as boolean);
 			if (savedActiveThemeId !== undefined) setActiveThemeIdState(savedActiveThemeId as ThemeId);
@@ -1883,10 +1894,12 @@ export function useSettings(): UseSettingsReturn {
 			rightPanelWidth,
 			markdownEditMode,
 			chatRawTextMode,
+			chatUserMessagesOnRight,
 			setLeftSidebarWidth,
 			setRightPanelWidth,
 			setMarkdownEditMode,
 			setChatRawTextMode,
+			setChatUserMessagesOnRight,
 			showHiddenFiles,
 			setShowHiddenFiles,
 			terminalWidth,
@@ -2016,6 +2029,7 @@ export function useSettings(): UseSettingsReturn {
 			rightPanelWidth,
 			markdownEditMode,
 			chatRawTextMode,
+			chatUserMessagesOnRight,
 			showHiddenFiles,
 			terminalWidth,
 			logLevel,
@@ -2061,6 +2075,8 @@ export function useSettings(): UseSettingsReturn {
 			setLeftSidebarWidth,
 			setRightPanelWidth,
 			setMarkdownEditMode,
+			setChatRawTextMode,
+			setChatUserMessagesOnRight,
 			setShowHiddenFiles,
 			setTerminalWidth,
 			setLogLevel,


### PR DESCRIPTION
## Summary
Adds a persistent chat layout preference so users can choose whether their own messages render on the right or left.

## Changes
- add new setting: `chatUserMessagesOnRight` (default `true`)
- expose setting in Display settings as: "Place user messages on the right"
- wire setting through app props and main panel props
- apply alignment logic in:
  - `TerminalOutput` (single-agent chat)
  - `GroupChatMessages` (group chat view)
- preserve existing default behavior while enabling immediate runtime switching

## Validation
- `npm run test -- src/__tests__/renderer/components/TerminalOutput.test.tsx src/__tests__/renderer/components/SettingsModal.test.tsx`
- `npx tsc -p tsconfig.lint.json --noEmit`

Closes #358
