### PR TITLE
fix: Filter worktree child sessions from web UI sidebar

### DIFF
--- a/src/main/web-server/types.ts
+++ b/src/main/web-server/types.ts
@@ -111,6 +111,9 @@ export interface SessionData {
 	activeTabId?: string;
 	/** Whether session is bookmarked (shows in Bookmarks group) */
 	bookmarked?: boolean;
+	/** Worktree subagent support */
+	parentSessionId?: string | null;
+	worktreeBranch?: string | null;
 }
 
 /**

--- a/src/web/utils/sessionGrouping.ts
+++ b/src/web/utils/sessionGrouping.ts
@@ -1,0 +1,155 @@
+/**
+ * Session Grouping Utilities
+ *
+ * Shared logic for organizing sessions into groups (bookmarks, named groups, ungrouped).
+ * Used by Sidebar, AllSessionsView, and SessionPillBar to avoid duplication.
+ */
+
+import type { Session, GroupInfo } from '../hooks/useSessions';
+
+/**
+ * Find the parent session for a worktree child.
+ * Uses parentSessionId when available, falls back to path pattern matching.
+ */
+export function findParentSession(session: Session, sessions: Session[]): Session | null {
+	if (session.parentSessionId) {
+		return sessions.find((s) => s.id === session.parentSessionId) || null;
+	}
+
+	// Try to infer parent from worktree path patterns
+	const cwd = session.cwd;
+	const worktreeMatch = cwd.match(/^(.+?)[-]?WorkTrees[\/\\]([^\/\\]+)/i);
+
+	if (worktreeMatch) {
+		const basePath = worktreeMatch[1];
+		return (
+			sessions.find(
+				(s) =>
+					s.id !== session.id &&
+					!s.parentSessionId &&
+					(s.cwd === basePath ||
+						s.cwd.startsWith(basePath + '/') ||
+						s.cwd.startsWith(basePath + '\\'))
+			) || null
+		);
+	}
+
+	return null;
+}
+
+/**
+ * Compute display name for a session.
+ * Worktree children show "ParentName: branch-name".
+ */
+export function getSessionDisplayName(session: Session, sessions: Session[]): string {
+	const parent = findParentSession(session, sessions);
+	if (parent) {
+		const branchName = session.worktreeBranch || session.name;
+		return `${parent.name}: ${branchName}`;
+	}
+	return session.name;
+}
+
+/**
+ * Get the effective group for a session.
+ * Worktree children inherit their parent's group.
+ */
+export function getSessionEffectiveGroup(
+	session: Session,
+	sessions: Session[]
+): { groupId: string | null; groupName: string | null; groupEmoji: string | null } {
+	const parent = findParentSession(session, sessions);
+	if (parent) {
+		return {
+			groupId: parent.groupId || null,
+			groupName: parent.groupName || null,
+			groupEmoji: parent.groupEmoji || null,
+		};
+	}
+	return {
+		groupId: session.groupId || null,
+		groupName: session.groupName || null,
+		groupEmoji: session.groupEmoji || null,
+	};
+}
+
+/**
+ * Result of grouping sessions
+ */
+export interface GroupedSessions {
+	sessionsByGroup: Record<string, GroupInfo>;
+	sortedGroupKeys: string[];
+}
+
+/**
+ * Organize sessions into groups with bookmarks first and ungrouped last.
+ *
+ * @param filteredSessions - Sessions after any search filtering
+ * @param allSessions - All sessions (needed for worktree parent lookup)
+ */
+export function groupSessions(filteredSessions: Session[], allSessions: Session[]): GroupedSessions {
+	const groups: Record<string, GroupInfo> = {};
+
+	// Exclude worktree children from the main list (they nest under their parent in the Electron app)
+	const topLevelSessions = filteredSessions.filter((s) => !s.parentSessionId);
+
+	// Add bookmarked sessions to a special "bookmarks" group
+	const bookmarkedSessions = topLevelSessions.filter((s) => s.bookmarked);
+	if (bookmarkedSessions.length > 0) {
+		groups['bookmarks'] = {
+			id: 'bookmarks',
+			name: 'Bookmarks',
+			emoji: null,
+			sessions: bookmarkedSessions,
+		};
+	}
+
+	// Organize sessions by their effective group
+	for (const session of topLevelSessions) {
+		const effectiveGroup = getSessionEffectiveGroup(session, allSessions);
+		const groupKey = effectiveGroup.groupId || 'ungrouped';
+
+		if (!groups[groupKey]) {
+			groups[groupKey] = {
+				id: effectiveGroup.groupId,
+				name: effectiveGroup.groupName || 'Ungrouped',
+				emoji: effectiveGroup.groupEmoji,
+				sessions: [],
+			};
+		}
+		groups[groupKey].sessions.push(session);
+	}
+
+	// Sort: bookmarks first, named groups alphabetically, ungrouped last
+	const sortedGroupKeys = Object.keys(groups).sort((a, b) => {
+		if (a === 'bookmarks') return -1;
+		if (b === 'bookmarks') return 1;
+		if (a === 'ungrouped') return 1;
+		if (b === 'ungrouped') return -1;
+		return groups[a].name.localeCompare(groups[b].name);
+	});
+
+	return { sessionsByGroup: groups, sortedGroupKeys };
+}
+
+/**
+ * Filter sessions by a search query against name, cwd, toolType, and worktree branch.
+ */
+export function filterSessions(
+	sessions: Session[],
+	query: string,
+	allSessions: Session[]
+): Session[] {
+	if (!query.trim()) return sessions;
+	const q = query.toLowerCase();
+	return sessions.filter((session) => {
+		const displayName = getSessionDisplayName(session, allSessions);
+		return (
+			displayName.toLowerCase().includes(q) ||
+			session.name.toLowerCase().includes(q) ||
+			session.cwd.toLowerCase().includes(q) ||
+			(session.toolType && session.toolType.toLowerCase().includes(q)) ||
+			(session.worktreeBranch && session.worktreeBranch.toLowerCase().includes(q))
+		);
+	});
+}


### PR DESCRIPTION
## fix: Filter worktree child sessions from web UI sidebar

### Problem

The web UI sidebar displayed significantly more agents than the Electron desktop app. Every worktree child session (branches spawned from a parent agent's worktree config) appeared as a top-level item in the sidebar, inflating the visible agent count. For example, a parent agent with 2 worktree children showed as 3 separate entries in the web sidebar, but only 1 (with expandable children) in the desktop app.

### Root Cause

The Electron desktop sidebar in `SessionList.tsx` filters out sessions where `parentSessionId` is set — worktree children are excluded from the main list and rendered as nested sub-items under their parent. The web sidebar had no equivalent filtering: `groupSessions()` in `sessionGrouping.ts` passed every session through to the rendered output without checking for parent-child relationships.

Additionally, the server-side `SessionData` type in `types.ts` did not declare `parentSessionId` or `worktreeBranch`, even though the factory was already serializing and sending those fields to web clients — a type-safety gap.

### Fix

**`src/main/web-server/types.ts`**
- Added `parentSessionId?: string | null` and `worktreeBranch?: string | null` to the `SessionData` interface, aligning the type definition with the data already being sent by the server factory.

**`src/web/utils/sessionGrouping.ts`**
- Added a `topLevelSessions` filter at the top of `groupSessions()` that excludes sessions with a `parentSessionId`, matching the Electron sidebar behavior.
- Both the bookmarks extraction and the group-assignment loop now operate on `topLevelSessions` instead of the unfiltered input.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sessions now support hierarchical organization with parent-child relationships.
  * Added session grouping and filtering capabilities to better organize and discover work sessions.
  * Session display names now adapt based on their organizational context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->