### PR TITLE
refactor: extract getStdinFlags helper for Windows stdin transport

### DIFF
--- a/src/__tests__/renderer/utils/spawnHelpers.test.ts
+++ b/src/__tests__/renderer/utils/spawnHelpers.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { getStdinFlags } from '../../../renderer/utils/spawnHelpers';
+
+describe('getStdinFlags', () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('returns both false on non-Windows platforms', () => {
+		vi.spyOn(window.navigator, 'platform', 'get').mockReturnValue('MacIntel');
+		const result = getStdinFlags({ isSshSession: false, supportsStreamJsonInput: true });
+		expect(result).toEqual({ sendPromptViaStdin: false, sendPromptViaStdinRaw: false });
+	});
+
+	it('returns sendPromptViaStdin when Windows + stream-json supported', () => {
+		vi.spyOn(window.navigator, 'platform', 'get').mockReturnValue('Win32');
+		const result = getStdinFlags({ isSshSession: false, supportsStreamJsonInput: true });
+		expect(result).toEqual({ sendPromptViaStdin: true, sendPromptViaStdinRaw: false });
+	});
+
+	it('returns sendPromptViaStdinRaw when Windows + stream-json unsupported', () => {
+		vi.spyOn(window.navigator, 'platform', 'get').mockReturnValue('Win32');
+		const result = getStdinFlags({ isSshSession: false, supportsStreamJsonInput: false });
+		expect(result).toEqual({ sendPromptViaStdin: false, sendPromptViaStdinRaw: true });
+	});
+
+	it('returns both false for SSH sessions on Windows', () => {
+		vi.spyOn(window.navigator, 'platform', 'get').mockReturnValue('Win32');
+		const result = getStdinFlags({ isSshSession: true, supportsStreamJsonInput: true });
+		expect(result).toEqual({ sendPromptViaStdin: false, sendPromptViaStdinRaw: false });
+	});
+
+	it('returns both false for SSH sessions on Windows without stream-json', () => {
+		vi.spyOn(window.navigator, 'platform', 'get').mockReturnValue('Win32');
+		const result = getStdinFlags({ isSshSession: true, supportsStreamJsonInput: false });
+		expect(result).toEqual({ sendPromptViaStdin: false, sendPromptViaStdinRaw: false });
+	});
+});

--- a/src/renderer/hooks/agent/useAgentExecution.ts
+++ b/src/renderer/hooks/agent/useAgentExecution.ts
@@ -8,6 +8,7 @@ import type {
 	ToolType,
 } from '../../types';
 import { getActiveTab } from '../../utils/tabHelpers';
+import { getStdinFlags } from '../../utils/spawnHelpers';
 import { generateId } from '../../utils/ids';
 
 /**
@@ -399,13 +400,10 @@ export function useAgentExecution(deps: UseAgentExecutionDeps): UseAgentExecutio
 					// Spawn the agent for batch processing
 					// Use effectiveCwd which may be a worktree path for parallel execution
 					const commandToUse = agent.path || agent.command;
-					// Use stdin transport on Windows local runs to avoid CLI length/escaping issues.
-					// SSH sessions have a dedicated stdin-script path and should not use these flags.
-					const isWindows = navigator.platform.toLowerCase().includes('win');
-					const isSshSession = !!session.sshRemoteId || !!session.sessionSshRemoteConfig?.enabled;
-					const supportsStreamJson = agent.capabilities?.supportsStreamJsonInput ?? false;
-					const sendPromptViaStdin = isWindows && !isSshSession && supportsStreamJson;
-					const sendPromptViaStdinRaw = isWindows && !isSshSession && !supportsStreamJson;
+					const { sendPromptViaStdin, sendPromptViaStdinRaw } = getStdinFlags({
+						isSshSession: !!session.sshRemoteId || !!session.sessionSshRemoteConfig?.enabled,
+						supportsStreamJsonInput: agent.capabilities?.supportsStreamJsonInput ?? false,
+					});
 					// Batch processing (Auto Run) should NOT use read-only mode - it needs to make changes
 					window.maestro.process
 						.spawn({
@@ -563,12 +561,10 @@ export function useAgentExecution(deps: UseAgentExecutionDeps): UseAgentExecutio
 						}
 					}
 					const commandToUse = sessionConfig?.customPath || agent.path || agent.command;
-					// Keep synopsis prompt delivery consistent with regular local Auto Run runs.
-					const isWindows = navigator.platform.toLowerCase().includes('win');
-					const isSshSession = !!effectiveSessionSshRemoteConfig?.enabled;
-					const supportsStreamJson = agent.capabilities?.supportsStreamJsonInput ?? false;
-					const sendPromptViaStdin = isWindows && !isSshSession && supportsStreamJson;
-					const sendPromptViaStdinRaw = isWindows && !isSshSession && !supportsStreamJson;
+					const { sendPromptViaStdin, sendPromptViaStdinRaw } = getStdinFlags({
+						isSshSession: !!effectiveSessionSshRemoteConfig?.enabled,
+						supportsStreamJsonInput: agent.capabilities?.supportsStreamJsonInput ?? false,
+					});
 					window.maestro.process
 						.spawn({
 							sessionId: targetSessionId,

--- a/src/renderer/utils/spawnHelpers.ts
+++ b/src/renderer/utils/spawnHelpers.ts
@@ -1,0 +1,22 @@
+/**
+ * Compute stdin transport flags for spawning agents on Windows.
+ *
+ * On Windows the cmd.exe command line is limited to ~8 KB and special
+ * characters cause escaping issues.  Sending the prompt via stdin
+ * side-steps both problems.
+ *
+ * SSH sessions must NOT use these flags — they have a dedicated
+ * stdin-script path handled by ChildProcessSpawner.
+ */
+export function getStdinFlags(opts: {
+	isSshSession: boolean;
+	supportsStreamJsonInput: boolean;
+}): { sendPromptViaStdin: boolean; sendPromptViaStdinRaw: boolean } {
+	const isWindows = navigator.platform.toLowerCase().includes('win');
+	const useStdin = isWindows && !opts.isSshSession;
+
+	return {
+		sendPromptViaStdin: useStdin && opts.supportsStreamJsonInput,
+		sendPromptViaStdinRaw: useStdin && !opts.supportsStreamJsonInput,
+	};
+}


### PR DESCRIPTION
## Summary

- Extracts duplicated Windows stdin flag logic into a shared `getStdinFlags()` utility
- Adds SSH session exclusion to `useInputProcessing` and `inlineWizardConversation` paths (previously missing)
- Follows up on #376

## Changes

- **New:** `src/renderer/utils/spawnHelpers.ts` — single source of truth for `sendPromptViaStdin` / `sendPromptViaStdinRaw` computation
- **Updated:** `useAgentExecution.ts`, `useInputProcessing.ts`, `inlineWizardConversation.ts` — replaced 4 inline copies with `getStdinFlags()` calls
- **New:** `src/__tests__/renderer/utils/spawnHelpers.test.ts` — 5 tests covering all flag combinations

## Context

PR #376 added stdin transport flags to the batch spawn paths in `useAgentExecution`. This brought the total to 4 copies of the same 6-line computation across the renderer. This PR consolidates them and makes SSH exclusion consistent everywhere (the spawner's if-else chain already made this safe, but the explicit guard is clearer).

## Test plan

- [ ] `npm run lint` passes
- [ ] All 71 affected tests pass (`spawnHelpers`, `useAgentExecution`, `useInputProcessing`, `inlineWizardConversation`)
- [ ] Windows Auto Run behavior unchanged (stdin transport still active for local runs)
- [ ] SSH sessions unaffected (flags correctly disabled)