### PR TITLE
fix: prevent duplicate CLI flags in buildAgentArgs

### DIFF
--- a/src/__tests__/main/utils/agent-args.test.ts
+++ b/src/__tests__/main/utils/agent-args.test.ts
@@ -170,6 +170,36 @@ describe('buildAgentArgs', () => {
 		expect(result).toEqual(['--print']);
 	});
 
+	it('deduplicates Codex bypass flag when batch and yolo args both include it', () => {
+		const agent = makeAgent({
+			batchModeArgs: ['--dangerously-bypass-approvals-and-sandbox', '--skip-git-repo-check'],
+			yoloModeArgs: ['--dangerously-bypass-approvals-and-sandbox'],
+		});
+		const result = buildAgentArgs(agent, {
+			baseArgs: ['--json'],
+			prompt: 'fix bug',
+			yoloMode: true,
+		});
+		expect(result).toEqual([
+			'--json',
+			'--dangerously-bypass-approvals-and-sandbox',
+			'--skip-git-repo-check',
+		]);
+	});
+
+	it('does not deduplicate positional args when deduplicating flags', () => {
+		const agent = makeAgent({
+			batchModeArgs: ['--dangerously-bypass-approvals-and-sandbox'],
+			yoloModeArgs: ['--dangerously-bypass-approvals-and-sandbox'],
+		});
+		const result = buildAgentArgs(agent, {
+			baseArgs: ['input-a', 'input-a'],
+			prompt: 'fix bug',
+			yoloMode: true,
+		});
+		expect(result).toEqual(['input-a', 'input-a', '--dangerously-bypass-approvals-and-sandbox']);
+	});
+
 	// -- resumeArgs --
 	it('adds resumeArgs when agentSessionId provided', () => {
 		const agent = makeAgent({

--- a/src/main/utils/agent-args.ts
+++ b/src/main/utils/agent-args.ts
@@ -81,7 +81,21 @@ export function buildAgentArgs(
 		finalArgs = [...finalArgs, ...agent.resumeArgs(options.agentSessionId)];
 	}
 
-	return finalArgs;
+	// Deduplicate repeated flag-style arguments while preserving order.
+	// Positional arguments (non-flags) are intentionally left untouched.
+	const seenFlags = new Set<string>();
+	const dedupedArgs: string[] = [];
+	for (const arg of finalArgs) {
+		if (arg.startsWith('-')) {
+			if (seenFlags.has(arg)) {
+				continue;
+			}
+			seenFlags.add(arg);
+		}
+		dedupedArgs.push(arg);
+	}
+
+	return dedupedArgs;
 }
 
 export function applyAgentConfigOverrides(


### PR DESCRIPTION
## Summary
- deduplicate repeated flag-style args in `buildAgentArgs()` while preserving order
- only deduplicate flags (`-`/`--`), leaving positional args unchanged
- add regression tests for the Codex duplicate bypass flag case and positional-arg safety

## Why
When both batch mode and YOLO mode contribute the same flag (for example Codex `--dangerously-bypass-approvals-and-sandbox`), the final argv can contain duplicates and Codex exits with code 2.

Fixes #398


## Follow-up Fix (Wizard/Codex)
- fix wizard conversation output selection for Codex when multiple `agent_message` events occur in one turn
- keep the latest Codex result text and emit at turn completion instead of taking the first interim message
- add regression test in `StdoutHandler.test.ts` to ensure only the final Codex message is emitted

This addresses cases where Wizard got stuck showing interim text like "I’m checking the directory..." instead of the actual final answer.
