### PR TITLE
fix: handle Codex turn.failed errors and add model selection

### DIFF
--- a/src/main/agents/definitions.ts
+++ b/src/main/agents/definitions.ts
@@ -156,15 +156,30 @@ export const AGENT_DEFINITIONS: AgentDefinition[] = [
 		yoloModeArgs: ['--dangerously-bypass-approvals-and-sandbox'], // Full access mode
 		workingDirArgs: (dir: string) => ['-C', dir], // Set working directory
 		imageArgs: (imagePath: string) => ['-i', imagePath], // Image attachment: codex exec -i /path/to/image.png
+		modelArgs: (modelId: string) => ['-m', modelId], // Model selection: codex exec -m gpt-5.3-codex
 		// Agent-specific configuration options shown in UI
 		configOptions: [
+			{
+				key: 'model',
+				type: 'text',
+				label: 'Model',
+				description:
+					'Model override (e.g., gpt-5.3-codex, o3). Leave empty to use the default from ~/.codex/config.toml.',
+				default: '', // Empty = use Codex's default model from config.toml
+				argBuilder: (value: string) => {
+					if (value && value.trim()) {
+						return ['-m', value.trim()];
+					}
+					return [];
+				},
+			},
 			{
 				key: 'contextWindow',
 				type: 'number',
 				label: 'Context Window Size',
 				description:
-					'Maximum context window size in tokens. Required for context usage display. Common values: 400000 (GPT-5.2), 128000 (GPT-4o).',
-				default: 400000, // Default for GPT-5.2 models
+					'Maximum context window size in tokens. Required for context usage display. Common values: 400000 (GPT-5.2/5.3), 128000 (GPT-4o).',
+				default: 400000, // Default for GPT-5.2+ models
 			},
 		],
 	},


### PR DESCRIPTION
## Summary

- Handle `turn.failed` events in the Codex output parser — previously these fell through to a generic `system` event, causing raw JSON to leak into the terminal instead of a clean error message
- Add `-m, --model` support to Codex agent definition so users can override the model from Settings or per-session, instead of relying solely on `~/.codex/config.toml`
- Add missing model entries to `MODEL_CONTEXT_WINDOWS` (gpt-5.1-codex, gpt-5.2-codex, gpt-5.3 family)

Closes #392

## Details

The reporter's Codex agent was exiting with code 1 and displaying raw JSON like:
```
{"type":"turn.failed","error":{"message":"stream disconnected before completion: The model gpt-5.3-codex does not exist..."}}
```

**Root causes:**
1. `CodexRawMessage.type` didn't include `turn.failed` — the parser's `transformMessage()` fell to the default case, emitting it as a silent `system` event
2. The `error` field type was `string` but Codex sends `{ message, type }` objects for `turn.failed`
3. `detectErrorFromLine()` didn't check for `turn.failed` (Claude's parser already handled this pattern)
4. No `modelArgs` or model config option existed for Codex despite the CLI supporting `-m, --model`

**Changes:**
- `codex-output-parser.ts`: Added `turn.failed` to type union, updated `error` field to `string | { message?, type? }`, added handlers in both `transformMessage()` and `detectErrorFromLine()`
- `definitions.ts`: Added `modelArgs` and `model` config option (text field, empty default = use config.toml)
- Updated test suite with `turn.failed` coverage

## Test plan

- [ ] Verify `turn.failed` events display as clean error messages in the terminal
- [ ] Verify model override works via Settings → Codex → Model
- [ ] Verify empty model field falls back to `~/.codex/config.toml` default

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a model selection option in the Codex agent configuration UI for easy model override.
  * Extended support for new GPT-5 Codex model variants (gpt-5.1, gpt-5.2, gpt-5.3, and specialized variants).

* **Bug Fixes**
  * Improved error message extraction and handling for failed turn events with better nested error detection.

* **Tests**
  * Expanded test coverage for error parsing and turn.failed event scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->