### PR TITLE
fix: prevent blur from overwriting model dropdown selection on Windows

### DIFF
--- a/src/renderer/components/shared/AgentConfigPanel.tsx
+++ b/src/renderer/components/shared/AgentConfigPanel.tsx
@@ -61,6 +61,8 @@ function ModelTextInput({
 	const inputRef = useRef<HTMLInputElement>(null);
 	// Keep track of the committed value (what was actually selected/saved)
 	const committedValueRef = useRef(value);
+	// Track whether a dropdown selection was just made (to prevent blur from overwriting it)
+	const selectionMadeRef = useRef(false);
 
 	// Update committed value when value prop changes from outside
 	useEffect(() => {
@@ -127,6 +129,11 @@ function ModelTextInput({
 						onBlur={() => {
 							// Delay to allow click on dropdown item
 							setTimeout(() => {
+								// If a dropdown item was clicked, skip blur logic — the click handler already committed the value
+								if (selectionMadeRef.current) {
+									selectionMadeRef.current = false;
+									return;
+								}
 								setShowDropdown(false);
 								if (isFiltering) {
 									// If user was filtering but didn't select, keep the filter text as the value
@@ -177,6 +184,7 @@ function ModelTextInput({
 									type="button"
 									onClick={(e) => {
 										e.stopPropagation();
+										selectionMadeRef.current = true;
 										onChange(model);
 										committedValueRef.current = model;
 										setShowDropdown(false);

--- a/src/renderer/components/shared/AgentConfigPanel.tsx
+++ b/src/renderer/components/shared/AgentConfigPanel.tsx
@@ -190,6 +190,7 @@ function ModelTextInput({
 										setShowDropdown(false);
 										setFilterText('');
 										setIsFiltering(false);
+										onBlur();
 									}}
 									className="w-full text-left px-3 py-2 text-xs font-mono hover:bg-white/10 transition-colors"
 									style={{


### PR DESCRIPTION
## Summary

- Fixes a race condition in `ModelTextInput` (AgentConfigPanel) where clicking a model from the dropdown would briefly appear selected, then revert to the typed filter text
- Root cause: the input's `onBlur` fires before the dropdown item's `onClick`. A stale closure in the 150ms `setTimeout` would call `onChange(filterText)` after the click handler had already committed the selected model
- Added a `selectionMadeRef` ref that the click handler sets to `true` before committing — the blur's `setTimeout` checks this flag and skips its logic entirely when a selection was just made

## Test plan

- [x] Open New Agent modal, select OpenCode
- [x] Type partial model name (e.g. `gith`) — dropdown shows filtered results
- [x] Click a model from the dropdown
- [x] Verify the model field retains the clicked value instead of reverting to the typed text

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed model selection persistence in the Agent Config Panel so dropdown selections are reliably retained when the input loses focus.
  * Ensures selected model is committed and the dropdown closes immediately, preventing accidental overwrites or lost choices.
  * Improves overall stability of model selection interactions in the panel.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->