### PR TITLE
fix: align markdown ordered-list markers for paragraph-wrapped items

### DIFF
--- a/src/__tests__/renderer/utils/markdownConfig.test.ts
+++ b/src/__tests__/renderer/utils/markdownConfig.test.ts
@@ -213,6 +213,20 @@ describe('generateProseStyles', () => {
 			expect(css).toContain('.prose li ul, .prose li ol { margin: 0 !important');
 		});
 
+		it('should include baseline alignment selectors for styled first-child content inside list-item paragraphs', () => {
+			const css = generateProseStyles({ theme: mockTheme, compactSpacing: true });
+			expect(css).toContain(
+				'.prose li > p > strong:first-child, .prose li > p > b:first-child, .prose li > p > em:first-child, .prose li > p > code:first-child, .prose li > p > a:first-child { vertical-align: baseline; line-height: inherit; }'
+			);
+		});
+
+		it('should normalize list-item paragraphs even when compactSpacing is false', () => {
+			const css = generateProseStyles({ theme: mockTheme, compactSpacing: false });
+			expect(css).toContain(
+				'.prose li > p { margin: 0 !important; display: inline; vertical-align: baseline; line-height: inherit; }'
+			);
+		});
+
 		it('should use 3px border-left on blockquote when compact', () => {
 			const css = generateProseStyles({ theme: mockTheme, compactSpacing: true });
 			expect(css).toContain(`border-left: 3px solid ${mockTheme.colors.border}`);
@@ -512,7 +526,9 @@ describe('generateTerminalProseStyles', () => {
 
 	it('should include li inline styling rules', () => {
 		const css = generateTerminalProseStyles(mockTheme, scopeSelector);
-		expect(css).toContain(`${scopeSelector} .prose li > p { margin: 0 !important; display: inline; }`);
+		expect(css).toContain(
+			`${scopeSelector} .prose li > p { margin: 0 !important; display: inline; vertical-align: baseline; line-height: inherit; }`
+		);
 	});
 
 	it('should include marker styling for list items', () => {
@@ -520,9 +536,10 @@ describe('generateTerminalProseStyles', () => {
 		expect(css).toContain(`${scopeSelector} .prose li::marker { font-weight: normal; }`);
 	});
 
-	it('should include extra vertical-align rule for first-child strong/b/em/code/a in li', () => {
+	it('should include extra vertical-align rule for styled first-child content in list items', () => {
 		const css = generateTerminalProseStyles(mockTheme, scopeSelector);
 		expect(css).toContain(`${scopeSelector} .prose li > strong:first-child`);
+		expect(css).toContain(`${scopeSelector} .prose li > p > strong:first-child`);
 		expect(css).toContain('vertical-align: baseline');
 	});
 

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -336,12 +336,29 @@ textarea::placeholder {
   display: list-item !important;
 }
 
+.prose li > p {
+  display: inline !important;
+  margin: 0 !important;
+  vertical-align: baseline;
+  line-height: inherit;
+}
+
+.prose li > p + ul,
+.prose li > p + ol {
+  margin-top: 0 !important;
+}
+
 /* Fix bullet alignment when first element is bold/styled */
 .prose li > strong:first-child,
 .prose li > b:first-child,
 .prose li > em:first-child,
 .prose li > code:first-child,
-.prose li > a:first-child {
+.prose li > a:first-child,
+.prose li > p > strong:first-child,
+.prose li > p > b:first-child,
+.prose li > p > em:first-child,
+.prose li > p > code:first-child,
+.prose li > p > a:first-child {
   vertical-align: baseline;
   line-height: inherit;
 }

--- a/src/renderer/utils/markdownConfig.ts
+++ b/src/renderer/utils/markdownConfig.ts
@@ -124,8 +124,9 @@ export function generateProseStyles(options: ProseStylesOptions): string {
     ${s} ol { list-style-type: decimal; }
     ${compactSpacing ? `${s} li ul, ${s} li ol { margin: 0 !important; padding-left: 1.5em; list-style-position: outside; }` : ''}
     ${s} li { margin: ${compactSpacing ? '0' : '0.25em 0'} !important; ${compactSpacing ? 'padding: 0;' : ''} line-height: 1.4; display: list-item; }
-    ${compactSpacing ? `${s} li > p { margin: 0 !important; display: inline; }` : ''}
-    ${compactSpacing ? `${s} li > p + ul, ${s} li > p + ol { margin-top: 0 !important; }` : ''}
+    ${s} li > p { margin: 0 !important; display: inline; vertical-align: baseline; line-height: inherit; }
+    ${s} li > p + ul, ${s} li > p + ol { margin-top: 0 !important; }
+    ${s} li > p > strong:first-child, ${s} li > p > b:first-child, ${s} li > p > em:first-child, ${s} li > p > code:first-child, ${s} li > p > a:first-child { vertical-align: baseline; line-height: inherit; }
     ${s} li::marker { color: ${colors.textMain}; }
     ${s} li:has(> input[type="checkbox"]) { list-style: none; margin-left: -1.5em; }
     ${s} code { background-color: ${colors.bgActivity}; color: ${colors.textMain}; padding: 0.2em 0.4em; border-radius: 3px; font-size: 0.9em; }
@@ -501,7 +502,7 @@ export function generateTerminalProseStyles(theme: Theme, scopeSelector: string)
     ${s} > ul, ${s} > ol { color: ${c.textMain}; margin: 0.25em 0 !important; padding-left: 2em; list-style-position: outside; }
     ${s} li ul, ${s} li ol { margin: 0 !important; padding-left: 1.5em; list-style-position: outside; }
     ${s} li { margin: 0 !important; padding: 0; line-height: 1.4; display: list-item; }
-    ${s} li > p { margin: 0 !important; display: inline; }
+    ${s} li > p { margin: 0 !important; display: inline; vertical-align: baseline; line-height: inherit; }
     ${s} li > p + ul, ${s} li > p + ol { margin-top: 0 !important; }
     ${s} li:has(> input[type="checkbox"]) { list-style: none; margin-left: -1.5em; }
     ${s} code { background-color: ${c.bgSidebar}; color: ${c.textMain}; padding: 0.15em 0.3em; border-radius: 3px; font-size: 0.9em; }
@@ -515,7 +516,8 @@ export function generateTerminalProseStyles(theme: Theme, scopeSelector: string)
     ${s} th { background-color: ${c.bgSidebar}; font-weight: bold; }
     ${s} strong { font-weight: bold; }
     ${s} em { font-style: italic; }
-    ${s} li > strong:first-child, ${s} li > b:first-child, ${s} li > em:first-child, ${s} li > code:first-child, ${s} li > a:first-child { vertical-align: baseline; line-height: inherit; }
+    ${s} li > strong:first-child, ${s} li > b:first-child, ${s} li > em:first-child, ${s} li > code:first-child, ${s} li > a:first-child,
+    ${s} li > p > strong:first-child, ${s} li > p > b:first-child, ${s} li > p > em:first-child, ${s} li > p > code:first-child, ${s} li > p > a:first-child { vertical-align: baseline; line-height: inherit; }
     ${s} li::marker { font-weight: normal; }
   `;
 }

--- a/src/web/index.css
+++ b/src/web/index.css
@@ -367,12 +367,29 @@ p, span, div, article, section {
   display: list-item !important;
 }
 
+.prose li > p {
+  display: inline !important;
+  margin: 0 !important;
+  vertical-align: baseline;
+  line-height: inherit;
+}
+
+.prose li > p + ul,
+.prose li > p + ol {
+  margin-top: 0 !important;
+}
+
 /* Fix bullet alignment when first element is bold/styled */
 .prose li > strong:first-child,
 .prose li > b:first-child,
 .prose li > em:first-child,
 .prose li > code:first-child,
-.prose li > a:first-child {
+.prose li > a:first-child,
+.prose li > p > strong:first-child,
+.prose li > p > b:first-child,
+.prose li > p > em:first-child,
+.prose li > p > code:first-child,
+.prose li > p > a:first-child {
   vertical-align: baseline;
   line-height: inherit;
 }


### PR DESCRIPTION
## Summary
- normalize list-item paragraph rendering so markdown-generated `<li><p>...</p></li>` content stays marker-aligned
- extend first-child styled selector coverage to paragraph-wrapped lead content
- apply the same alignment rules in both renderer and web stylesheet paths
- update markdown style generator expectations in tests

## Reproduction
- reproduced via Agent Browser harness with markdown list items whose lead content is wrapped in `<p><strong>...</strong></p>`
- on `main`, computed style for `.prose li > p` was `display: block` with default margins
- with this fix, `.prose li > p` is `display: inline` with zero margins to keep marker/text baseline aligned

## Validation
- `npm run test -- src/__tests__/renderer/utils/markdownConfig.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Updated Markdown list rendering to display paragraphs inline within list items with improved vertical alignment and line-height handling.
  * Enhanced styling for styled content (bold, italic, code, links) within list item paragraphs for consistent visual alignment.

* **Tests**
  * Added comprehensive test coverage for inline paragraph rendering in list items across various styling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->