### PR TITLE
fix: replace JS resize detection with CSS container queries for header

### DIFF
--- a/src/renderer/components/GitStatusWidget.tsx
+++ b/src/renderer/components/GitStatusWidget.tsx
@@ -11,8 +11,6 @@ interface GitStatusWidgetProps {
 	theme: Theme;
 	onViewDiff: () => void;
 	onViewLog?: () => void;
-	/** Use compact mode - just show file count without breakdown */
-	compact?: boolean;
 }
 
 /**
@@ -33,7 +31,6 @@ export const GitStatusWidget = memo(function GitStatusWidget({
 	theme,
 	onViewDiff,
 	onViewLog,
-	compact = false,
 }: GitStatusWidgetProps) {
 	// Tooltip hover state with timeout for smooth UX
 	const [tooltipOpen, setTooltipOpen] = useState(false);
@@ -89,41 +86,39 @@ export const GitStatusWidget = memo(function GitStatusWidget({
 				onClick={onViewDiff}
 				className="flex items-center gap-2 px-2 py-1 rounded text-xs transition-colors hover:bg-white/5"
 				style={{ color: theme.colors.textMain }}
-				title={compact ? `+${additions} −${deletions} ~${modified}` : undefined}
+				title={`+${additions} −${deletions} ~${modified}`}
 			>
-				{compact ? (
-					// Compact mode: just show file count
-					<span className="flex items-center gap-1">
-						<FileDiff className="w-3 h-3" style={{ color: theme.colors.textDim }} />
-						<span style={{ color: theme.colors.textDim }}>{fileCount}</span>
-					</span>
-				) : (
-					// Full mode: show breakdown by type
-					<>
-						<GitBranch className="w-3 h-3" />
+				{/* Compact mode: just show file count - shown at narrow widths via CSS */}
+				<span className="header-git-status-compact flex items-center gap-1">
+					<FileDiff className="w-3 h-3" style={{ color: theme.colors.textDim }} />
+					<span style={{ color: theme.colors.textDim }}>{fileCount}</span>
+				</span>
 
-						{additions > 0 && (
-							<span className="flex items-center gap-0.5 text-green-500">
-								<Plus className="w-3 h-3" />
-								{additions}
-							</span>
-						)}
+				{/* Full mode: show breakdown by type - shown at wider widths via CSS */}
+				<span className="header-git-status-full flex items-center gap-2">
+					<GitBranch className="w-3 h-3" />
 
-						{deletions > 0 && (
-							<span className="flex items-center gap-0.5 text-red-500">
-								<Minus className="w-3 h-3" />
-								{deletions}
-							</span>
-						)}
+					{additions > 0 && (
+						<span className="flex items-center gap-0.5 text-green-500">
+							<Plus className="w-3 h-3" />
+							{additions}
+						</span>
+					)}
 
-						{modified > 0 && (
-							<span className="flex items-center gap-0.5 text-orange-500">
-								<FileEdit className="w-3 h-3" />
-								{modified}
-							</span>
-						)}
-					</>
-				)}
+					{deletions > 0 && (
+						<span className="flex items-center gap-0.5 text-red-500">
+							<Minus className="w-3 h-3" />
+							{deletions}
+						</span>
+					)}
+
+					{modified > 0 && (
+						<span className="flex items-center gap-0.5 text-orange-500">
+							<FileEdit className="w-3 h-3" />
+							{modified}
+						</span>
+					)}
+				</span>
 			</button>
 
 			{/* Hover tooltip showing file list with GitHub-style diff bars */}

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -449,6 +449,116 @@ svg.wand-sparkle-active path:nth-child(8) { animation-delay: 1.2s; }
 }
 
 /* Reduced motion preference - accessibility best practice */
+/* ==========================================
+   Header Bar Container Queries
+   ==========================================
+   CSS-only responsive behavior for the main panel header.
+   Uses container queries to show/hide elements based on header width.
+   This replaces JavaScript-based panelWidth detection for reliability.
+*/
+
+/* Define the header as a container query context */
+.header-container {
+  container-type: inline-size;
+  container-name: header;
+}
+
+/* Default: all elements visible */
+.header-session-name,
+.header-cost-widget,
+.header-uuid-pill,
+.header-context-widget,
+.header-git-branch-text {
+  display: flex;
+}
+
+/* At narrower widths, progressively hide elements */
+/* Below 700px: Use compact context display (handled by compact class) */
+@container header (max-width: 700px) {
+  .header-context-label-full {
+    display: none;
+  }
+  .header-context-label-compact {
+    display: block;
+  }
+  .header-context-gauge {
+    width: 4rem; /* w-16 */
+  }
+}
+
+/* Below 550px: Hide git widget details (show compact) - handled by component */
+
+/* Below 500px: Hide git branch text, show icon only */
+@container header (max-width: 500px) {
+  .header-git-branch-text {
+    display: none;
+  }
+}
+
+/* Below 400px: Hide UUID pill */
+@container header (max-width: 400px) {
+  .header-uuid-pill {
+    display: none;
+  }
+}
+
+/* Below 350px: Hide cost widget */
+@container header (max-width: 350px) {
+  .header-cost-widget {
+    display: none;
+  }
+}
+
+/* Below 300px: Hide session name */
+@container header (max-width: 300px) {
+  .header-session-name {
+    display: none;
+  }
+}
+
+/* When AUTO mode button is visible, we need earlier breakpoints.
+   Use a modifier class on the container to shift thresholds. */
+.header-container.header-auto-mode .header-context-label-full {
+  display: none;
+}
+.header-container.header-auto-mode .header-context-label-compact {
+  display: block;
+}
+
+@container header (max-width: 880px) {
+  .header-container.header-auto-mode .header-context-gauge {
+    width: 4rem;
+  }
+}
+
+@container header (max-width: 680px) {
+  .header-auto-mode .header-git-branch-text {
+    display: none;
+  }
+}
+
+@container header (max-width: 580px) {
+  .header-auto-mode .header-uuid-pill {
+    display: none;
+  }
+}
+
+@container header (max-width: 530px) {
+  .header-auto-mode .header-cost-widget {
+    display: none;
+  }
+}
+
+@container header (max-width: 480px) {
+  .header-auto-mode .header-session-name {
+    display: none;
+  }
+}
+
+/* ==========================================
+   End Header Bar Container Queries
+   ========================================== */
+
 @media (prefers-reduced-motion: reduce) {
   .animate-pulse,
   .animate-spin,

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -468,8 +468,14 @@ svg.wand-sparkle-active path:nth-child(8) { animation-delay: 1.2s; }
 .header-cost-widget,
 .header-uuid-pill,
 .header-context-widget,
-.header-git-branch-text {
+.header-git-branch-text,
+.header-git-status-full {
   display: flex;
+}
+
+/* Git status compact mode hidden by default (shown at narrow widths) */
+.header-git-status-compact {
+  display: none;
 }
 
 /* At narrower widths, progressively hide elements */
@@ -486,7 +492,15 @@ svg.wand-sparkle-active path:nth-child(8) { animation-delay: 1.2s; }
   }
 }
 
-/* Below 550px: Hide git widget details (show compact) - handled by component */
+/* Below 550px: Show compact git status (file count only), hide full breakdown */
+@container header (max-width: 550px) {
+  .header-git-status-full {
+    display: none;
+  }
+  .header-git-status-compact {
+    display: flex;
+  }
+}
 
 /* Below 500px: Hide git branch text, show icon only */
 @container header (max-width: 500px) {
@@ -531,26 +545,36 @@ svg.wand-sparkle-active path:nth-child(8) { animation-delay: 1.2s; }
   }
 }
 
+/* Below 730px in auto-mode: Show compact git status */
+@container header (max-width: 730px) {
+  .header-container.header-auto-mode .header-git-status-full {
+    display: none;
+  }
+  .header-container.header-auto-mode .header-git-status-compact {
+    display: flex;
+  }
+}
+
 @container header (max-width: 680px) {
-  .header-auto-mode .header-git-branch-text {
+  .header-container.header-auto-mode .header-git-branch-text {
     display: none;
   }
 }
 
 @container header (max-width: 580px) {
-  .header-auto-mode .header-uuid-pill {
+  .header-container.header-auto-mode .header-uuid-pill {
     display: none;
   }
 }
 
 @container header (max-width: 530px) {
-  .header-auto-mode .header-cost-widget {
+  .header-container.header-auto-mode .header-cost-widget {
     display: none;
   }
 }
 
 @container header (max-width: 480px) {
-  .header-auto-mode .header-session-name {
+  .header-container.header-auto-mode .header-session-name {
     display: none;
   }
 }


### PR DESCRIPTION
The header bar elements were overlapping on smaller screens and not properly restoring when the window was resized larger. The JavaScript- based ResizeObserver with threshold detection was unreliable.

This commit replaces the JS approach with CSS container queries:
- Add header-container class with container-type: inline-size
- Use @container queries to progressively hide elements at breakpoints
- Remove panelWidth state, ResizeObserver, and related variables
- Add CSS classes to header elements for container query targeting
- Support header-auto-mode modifier for when AUTO button is visible

Benefits:
- Instant response to size changes (no state update delays)
- No bugs with threshold detection or resize event batching
- Reduced React re-renders (elements always in DOM, CSS controls visibility)
- Simpler code (~100 lines of JS removed)

Fixes #420

Session: 64f29ed8-30fe-4b59-a4d3-f6bf87e2d3d6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Header responsiveness moved from JavaScript to CSS container-query-like behavior for smoother, more reliable resizing and truncation.
  * Git/status and context displays now render consistently while their visibility is controlled by responsive styles rather than runtime width checks.

* **Style**
  * New CSS rules introduce progressive breakpoints and an auto mode for the header, plus improved reduced-motion handling for header animations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->