### PR TITLE
fix: align numbered markdown lists when first token is bold

### DIFF
--- a/src/renderer/utils/markdownConfig.ts
+++ b/src/renderer/utils/markdownConfig.ts
@@ -124,10 +124,12 @@ export function generateProseStyles(options: ProseStylesOptions): string {
     ${s} ol { list-style-type: decimal; }
     ${compactSpacing ? `${s} li ul, ${s} li ol { margin: 0 !important; padding-left: 1.5em; list-style-position: outside; }` : ''}
     ${s} li { margin: ${compactSpacing ? '0' : '0.25em 0'} !important; ${compactSpacing ? 'padding: 0;' : ''} line-height: 1.4; display: list-item; }
-    ${s} li > p { margin: 0 !important; display: inline; vertical-align: baseline; line-height: inherit; }
+    ${s} ol li { padding-left: 0.15em; }
+    ${s} li > p { margin: 0 !important; display: block; line-height: inherit; }
     ${s} li > p + ul, ${s} li > p + ol { margin-top: 0 !important; }
     ${s} li > p > strong:first-child, ${s} li > p > b:first-child, ${s} li > p > em:first-child, ${s} li > p > code:first-child, ${s} li > p > a:first-child { vertical-align: baseline; line-height: inherit; }
     ${s} li::marker { color: ${colors.textMain}; }
+    ${s} ol li::marker { font-variant-numeric: tabular-nums; font-weight: 400; }
     ${s} li:has(> input[type="checkbox"]) { list-style: none; margin-left: -1.5em; }
     ${s} code { background-color: ${colors.bgActivity}; color: ${colors.textMain}; padding: 0.2em 0.4em; border-radius: 3px; font-size: 0.9em; }
     ${s} pre { background-color: ${colors.bgActivity}; color: ${colors.textMain}; padding: 1em; border-radius: 6px; overflow-x: auto; ${compactSpacing ? 'margin: 0.35em 0 !important;' : ''} }


### PR DESCRIPTION
## Summary
Fixes numbered list alignment in markdown when a list item starts with bold (or other styled inline) content.

## Problem
In some markdown content, ordered-list markers become visually misaligned when the first inline token is styled (for example `**bold**`).

## Root cause
The prose style layer rendered `li > p` as `inline`, which can create marker/baseline inconsistencies with styled first tokens in ordered lists.

## What changed
- Changed markdown prose style for list paragraphs:
  - `li > p` from `display: inline` to `display: block`
- Added small ordered-list spacing normalization:
  - `ol li { padding-left: 0.15em; }`
- Added ordered-list marker consistency styling:
  - `ol li::marker { font-variant-numeric: tabular-nums; font-weight: 400; }`

## Validation
- Verified style output in markdown renderer path (`generateProseStyles`) and compared before/after behavior with ordered lists containing bold-leading items.

## Scope
- Targeted markdown rendering style fix only.
- No auto-run/state-machine logic changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined visual layout and presentation of paragraphs within list items, improving overall consistency and spacing
  * Enhanced ordered list styling with improved item padding and refined numeric marker formatting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->