### PR TITLE
fix: keep auto-run loop completion counters consistent

### DIFF
--- a/src/renderer/hooks/batch/useBatchProcessor.ts
+++ b/src/renderer/hooks/batch/useBatchProcessor.ts
@@ -1414,15 +1414,19 @@ export function useBatchProcessor({
 					newTotalTasks += taskCount;
 				}
 
+				// Capture completed-loop metrics before resetting counters
+				const completedLoopNumber = loopIteration + 1;
+				const completedLoopTasks = loopTasksCompleted;
+
 				// Calculate loop elapsed time
 				const loopElapsedMs = Date.now() - loopStartTime;
 
 				// Add loop summary history entry
-				const loopSummary = `Loop ${loopIteration + 1} completed: ${loopTasksCompleted} task${loopTasksCompleted !== 1 ? 's' : ''} accomplished`;
+				const loopSummary = `Loop ${completedLoopNumber} completed: ${completedLoopTasks} task${completedLoopTasks !== 1 ? 's' : ''} accomplished`;
 				const loopDetails = [
-					`**Loop ${loopIteration + 1} Summary**`,
+					`**Loop ${completedLoopNumber} Summary**`,
 					'',
-					`- **Tasks Accomplished:** ${loopTasksCompleted}`,
+					`- **Tasks Accomplished:** ${completedLoopTasks}`,
 					`- **Duration:** ${formatElapsedTime(loopElapsedMs)}`,
 					loopTotalInputTokens > 0 || loopTotalOutputTokens > 0
 						? `- **Tokens:** ${(loopTotalInputTokens + loopTotalOutputTokens).toLocaleString()} (${loopTotalInputTokens.toLocaleString()} in / ${loopTotalOutputTokens.toLocaleString()} out)`
@@ -1463,9 +1467,9 @@ export function useBatchProcessor({
 				loopTotalCost = 0;
 
 				// AUTORUN LOG: Loop completion
-				window.maestro.logger.autorun(`Loop ${loopIteration + 1} completed`, session.name, {
-					loopNumber: loopIteration + 1,
-					tasksCompleted: loopTasksCompleted,
+				window.maestro.logger.autorun(`Loop ${completedLoopNumber} completed`, session.name, {
+					loopNumber: completedLoopNumber,
+					tasksCompleted: completedLoopTasks,
 					tasksForNextLoop: newTotalTasks,
 				});
 


### PR DESCRIPTION
## Summary
This PR fixes an Auto Run loop counter accuracy issue by preserving loop metrics before per-loop counters are reset.

## Problem
During looping Auto Run sessions, loop-related output could become inconsistent because loop counters were reset before some completion logs were emitted.

## Root cause
`loopTasksCompleted` and related values were reset for the next loop before the completion logger consumed them, which could produce misleading loop completion numbers in runtime output.

## What changed
- In `useBatchProcessor`, capture completed-loop values before reset:
  - `completedLoopNumber`
  - `completedLoopTasks`
- Use captured values for:
  - loop summary text
  - loop summary details
  - loop completion logger payload
- Keep reset logic unchanged for next-iteration behavior.

## Validation
- Verified the loop summary/log code path now uses pre-reset values consistently.
- Confirmed no changes to state-machine transitions or loop stop conditions.

## Scope
- Targeted fix only for loop completion metric consistency.
- No architectural changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of loop completion metrics in batch processing reports. Loop summaries and detailed logs now correctly report elapsed time, token usage, and associated costs based on actual completed loop values. This ensures consistent and accurate tracking of progress and resource consumption across all batch operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->