### PR TITLE
fix: Files panel hangs on "Loading remote files..." indefinitely

### DIFF
--- a/src/main/utils/execFile.ts
+++ b/src/main/utils/execFile.ts
@@ -6,6 +6,8 @@ const execFileAsync = promisify(execFile);
 
 export interface ExecOptions {
 	input?: string; // Content to write to stdin
+	/** Timeout in milliseconds. If the process exceeds this, it is killed and an error is returned. */
+	timeout?: number;
 }
 
 // Maximum buffer size for command output (10MB)
@@ -90,11 +92,14 @@ export async function execFileNoThrow(
 	// Handle backward compatibility: options can be env (old signature) or ExecOptions (new)
 	let env: NodeJS.ProcessEnv | undefined;
 	let input: string | undefined;
+	let timeout: number | undefined;
 
 	if (options) {
-		if ('input' in options) {
+		if ('input' in options || 'timeout' in options) {
 			// New signature with ExecOptions
-			input = options.input;
+			const execOpts = options as ExecOptions;
+			input = execOpts.input;
+			timeout = execOpts.timeout;
 		} else {
 			// Old signature with just env
 			env = options as NodeJS.ProcessEnv;
@@ -103,7 +108,7 @@ export async function execFileNoThrow(
 
 	// If input is provided, use spawn instead of execFile to write to stdin
 	if (input !== undefined) {
-		return execFileWithInput(command, args, cwd, input);
+		return execFileWithInput(command, args, cwd, input, timeout);
 	}
 
 	try {
@@ -118,6 +123,7 @@ export async function execFileNoThrow(
 			encoding: 'utf8',
 			maxBuffer: EXEC_MAX_BUFFER,
 			shell: useShell,
+			timeout,
 		});
 
 		return {
@@ -144,7 +150,8 @@ async function execFileWithInput(
 	command: string,
 	args: string[],
 	cwd: string | undefined,
-	input: string
+	input: string,
+	timeout?: number
 ): Promise<ExecResult> {
 	return new Promise((resolve) => {
 		const isWindows = process.platform === 'win32';
@@ -158,6 +165,16 @@ async function execFileWithInput(
 
 		let stdout = '';
 		let stderr = '';
+		let killed = false;
+
+		// spawn() doesn't support timeout natively, so implement it manually
+		let timer: ReturnType<typeof setTimeout> | undefined;
+		if (timeout && timeout > 0) {
+			timer = setTimeout(() => {
+				killed = true;
+				child.kill();
+			}, timeout);
+		}
 
 		child.stdout?.on('data', (data) => {
 			stdout += data.toString();
@@ -168,14 +185,16 @@ async function execFileWithInput(
 		});
 
 		child.on('close', (code) => {
+			if (timer) clearTimeout(timer);
 			resolve({
 				stdout,
-				stderr,
-				exitCode: code ?? 1,
+				stderr: killed ? `${stderr}\nETIMEDOUT: process timed out after ${timeout}ms` : stderr,
+				exitCode: killed ? 'ETIMEDOUT' : (code ?? 1),
 			});
 		});
 
 		child.on('error', (err) => {
+			if (timer) clearTimeout(timer);
 			resolve({
 				stdout: '',
 				stderr: err.message,

--- a/src/main/utils/remote-fs.ts
+++ b/src/main/utils/remote-fs.ts
@@ -68,7 +68,7 @@ export interface RemoteFsDeps {
  */
 const defaultDeps: RemoteFsDeps = {
 	execSsh: (command: string, args: string[]): Promise<ExecResult> => {
-		return execFileNoThrow(command, args);
+		return execFileNoThrow(command, args, undefined, { timeout: SSH_COMMAND_TIMEOUT_MS });
 	},
 	buildSshArgs: (config: SshRemoteConfig): string[] => {
 		return sshRemoteManager.buildSshArgs(config);
@@ -94,6 +94,7 @@ const RECOVERABLE_SSH_ERRORS = [
 	/read: Connection reset by peer/i,
 	/banner exchange/i, // SSH handshake failed - often due to stale ControlMaster sockets
 	/socket is not connected/i, // Connection dropped before handshake
+	/ETIMEDOUT/i, // Command timed out - SSH connection may be stale
 ];
 
 /**
@@ -111,6 +112,13 @@ const DEFAULT_RETRY_CONFIG = {
 	baseDelayMs: 500,
 	maxDelayMs: 5000,
 };
+
+/**
+ * Timeout for individual SSH commands in milliseconds.
+ * Prevents hung SSH connections (e.g., stale ControlMaster sockets)
+ * from blocking the file tree load indefinitely.
+ */
+const SSH_COMMAND_TIMEOUT_MS = 30000;
 
 /**
  * Sleep for a specified duration with jitter.
@@ -165,7 +173,8 @@ async function execRemoteCommand(
 
 		// Check if this is a recoverable error
 		const combinedOutput = `${result.stderr} ${result.stdout}`;
-		if (isRecoverableSshError(combinedOutput) && attempt < maxRetries) {
+		const isNodeTimeout = result.exitCode === 'ETIMEDOUT';
+		if ((isRecoverableSshError(combinedOutput) || isNodeTimeout) && attempt < maxRetries) {
 			const delay = getBackoffDelay(attempt, baseDelayMs, maxDelayMs);
 			logger.debug(
 				`[remote-fs] SSH transient error (attempt ${attempt + 1}/${maxRetries + 1}), retrying in ${delay}ms: ${result.stderr.slice(0, 100)}`


### PR DESCRIPTION
## Problem

The Files right panel in SSH remote sessions gets permanently stuck showing "Loading remote files..." with a spinner and a stale progress count (e.g., "25 files in 7 folders"), but never actually renders the file tree. This happens especially after extended Maestro usage (hours), making the Files panel effectively non-functional for remote sessions.

<img width="993" height="672" alt="image" src="https://github.com/user-attachments/assets/32fa89b6-5bf7-40fe-a559-0e03fec71cfa" />

## Root Cause Analysis

I traced the issue through three interacting code paths:

### 1. No timeout on SSH commands — the primary cause

`loadFileTree()` (`fileExplorer.ts`) walks the remote directory tree by making **one SSH call per directory** via `window.maestro.fs.readDir`. Each call flows through:

```
loadFileTreeRecursive (per directory, sequential for-of loop)
  → IPC: fs:readDir
    → readDirRemote (remote-fs.ts)
      → execRemoteCommand
        → execFileNoThrow('ssh', args)  ← NO TIMEOUT
```

`execFileNoThrow` (`execFile.ts`) calls Node's `execFile` without a `timeout` option. If any single SSH command hangs (stale ControlMaster socket, keepalive failure, network degradation after hours of use), the promise never resolves. Since directories are processed sequentially in a `for...of` loop, one hung SSH call blocks the entire tree walk forever.

The progress callback fires after each directory completes, which is why users see "25 files in 7 folders" — that's the count from the last directory that succeeded before the hang. `fileTreeLoading` stays `true` permanently, so the UI never transitions from the spinner to the file list.

The overall `Promise.all([loadFileTree, directorySize])` in `useFileTreeManagement.ts` also cannot resolve because even if `directorySize` (a single `du`/`find` command) completes, `Promise.all` waits for both.

### 2. Stale closure in async callbacks

The `useEffect` that triggers the initial file tree load captures `activeSessionId` from its closure. The `.then()` and `.catch()` callbacks use this captured value to identify which session to update. If the user switches sessions while loading is in progress, the callbacks fire with the old `activeSessionId` — which can cause the completion state to target the wrong session, leaving the original session's `fileTreeLoading` permanently stuck at `true`.

### 3. Timed-out SSH commands weren't retried

Even after adding timeouts, Node kills the process with an `ETIMEDOUT` error code. This pattern wasn't in the `RECOVERABLE_SSH_ERRORS` list, so timed-out commands would fail without retry rather than being retried with the existing exponential backoff logic.

## Fixes

### Fix 1: Add 30s timeout to SSH commands

**Files:** `src/main/utils/execFile.ts`, `src/main/utils/remote-fs.ts`

- Added `timeout` option to `ExecOptions` interface and pass it through to Node's `execFile`
- Set `SSH_COMMAND_TIMEOUT_MS = 30000` (30 seconds) for all SSH remote filesystem commands
- This ensures hung SSH connections are killed and surfaced as errors rather than blocking forever

### Fix 2: Fix stale closure in async callbacks

**File:** `src/renderer/hooks/git/useFileTreeManagement.ts`

- Capture `session.id` at the start of the effect into a local `const sessionId`
- Use `sessionId` (stable, bound at effect start) instead of `activeSessionId` (from closure, can change) in all `.then()`, `.catch()`, and progress callbacks
- This ensures the loading completion always targets the correct session regardless of whether the user switched sessions during the load

### Fix 3: Add ETIMEDOUT to recoverable SSH errors

**File:** `src/main/utils/remote-fs.ts`

- Added `/ETIMEDOUT/i` pattern to `RECOVERABLE_SSH_ERRORS`
- When a timeout kills an SSH process, the existing retry logic now kicks in with exponential backoff (up to 3 retries)
- If all retries fail, the error propagates to the `.catch()` handler which sets `fileTreeError` and schedules a 20s retry — so the user sees an error message instead of an infinite spinner

## Testing

- All 68 existing tests pass (`execFile.test.ts`: 23 tests, `remote-fs.test.ts`: 45 tests)
- No new TypeScript errors introduced (pre-existing errors in `src/prompts/index.ts` are unrelated)

## User Impact

Before: Files panel shows "Loading remote files..." forever after SSH connection degrades (common after hours of use). Only workaround was restarting Maestro.

After: If an SSH command hangs, it times out after 30s, retries up to 3 times with backoff, and either succeeds on retry or shows a clear error with automatic retry after 20s. Session switching during loading no longer corrupts loading state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * SSH commands now timeout after 30 seconds and are retried when timeouts occur.
  * File-tree loading fixes prevent stale session state and ensure progress/errors are tied to the correct load session.
  * Recursive directory reads now skip unreadable subfolders instead of aborting the entire tree load.

* **New Features**
  * Optional configurable process timeouts: external commands can be killed after a set time, preserve partial output, and report timeout status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->