### PR TITLE
feat: enable fuzzy matching for slash commands and session filter

### DIFF
--- a/src/__tests__/renderer/hooks/useInputKeyDown.test.ts
+++ b/src/__tests__/renderer/hooks/useInputKeyDown.test.ts
@@ -553,7 +553,7 @@ describe('Slash command autocomplete', () => {
 	it('filters out aiOnly commands in terminal mode', () => {
 		setActiveSession({ inputMode: 'terminal' });
 		// Only /run is aiOnly, so it should be filtered out
-		// Input is '/r' which only matches /run
+		// With fuzzy matching, '/r' matches /clear (has 'r') but NOT /run (aiOnly excluded)
 		const deps = createMockDeps({ inputValue: '/r', allSlashCommands: commands });
 		const { result } = renderHook(() => useInputKeyDown(deps));
 		const e = createKeyEvent('Enter');
@@ -562,8 +562,8 @@ describe('Slash command autocomplete', () => {
 			result.current.handleInputKeyDown(e);
 		});
 
-		// No matching command after filtering, so setInputValue should not be called
-		expect(deps.setInputValue).not.toHaveBeenCalled();
+		// /clear fuzzy-matches 'r', so it gets selected (but /run is excluded as aiOnly)
+		expect(deps.setInputValue).toHaveBeenCalledWith('/clear');
 	});
 
 	it('filters out terminalOnly commands in AI mode', () => {

--- a/src/renderer/components/InputArea.tsx
+++ b/src/renderer/components/InputArea.tsx
@@ -24,7 +24,7 @@ import {
 	formatEnterToSendTooltip,
 } from '../utils/shortcutFormatter';
 import type { TabCompletionSuggestion, TabCompletionFilter } from '../hooks';
-import { filterAndSortSlashCommands } from '../utils/search';
+import { filterAndSortSlashCommands, type SlashCommandEntry } from '../utils/search';
 import type {
 	SummarizeProgress,
 	SummarizeResult,
@@ -39,13 +39,6 @@ import { SummarizeProgressOverlay } from './SummarizeProgressOverlay';
 import { WizardInputPanel } from './InlineWizard';
 import { useAgentCapabilities, useScrollIntoView } from '../hooks';
 import { getProviderDisplayName } from '../utils/sessionValidation';
-
-interface SlashCommand {
-	command: string;
-	description: string;
-	terminalOnly?: boolean;
-	aiOnly?: boolean;
-}
 
 interface InputAreaProps {
 	session: Session;
@@ -69,7 +62,7 @@ interface InputAreaProps {
 	setCommandHistorySelectedIndex: (index: number) => void;
 	slashCommandOpen: boolean;
 	setSlashCommandOpen: (open: boolean) => void;
-	slashCommands: SlashCommand[];
+	slashCommands: SlashCommandEntry[];
 	selectedSlashCommandIndex: number;
 	setSelectedSlashCommandIndex: (index: number) => void;
 	inputRef: React.RefObject<HTMLTextAreaElement>;

--- a/src/renderer/components/SessionList.tsx
+++ b/src/renderer/components/SessionList.tsx
@@ -1904,14 +1904,26 @@ function SessionListInner(props: SessionListProps) {
 	}, [sessionFilterOpen]);
 
 	// Temporarily expand groups when filtering to show matching sessions
-	// Note: Only depend on sessionFilter and sessions (not filteredSessions which changes reference each render)
+	// Uses the same matching logic as sessionCategories to stay consistent
 	useEffect(() => {
 		if (sessionFilter) {
-			// Find groups that contain matching sessions (search session name AND AI tab names)
 			const groupsWithMatches = new Set<string>();
 			const matchingSessions = sessions.filter((s) => {
+				// Skip worktree children (same as sessionCategories)
+				if (s.parentSessionId) return false;
 				if (fuzzyMatch(s.name, sessionFilter)) return true;
 				if (s.aiTabs?.some((tab) => tab.name && fuzzyMatch(tab.name, sessionFilter))) return true;
+				// Match worktree children branch names (same as sessionCategories)
+				const worktreeChildren = worktreeChildrenByParentId.get(s.id);
+				if (
+					worktreeChildren?.some(
+						(child) =>
+							(child.worktreeBranch && fuzzyMatch(child.worktreeBranch, sessionFilter)) ||
+							fuzzyMatch(child.name, sessionFilter)
+					)
+				) {
+					return true;
+				}
 				return false;
 			});
 
@@ -1941,7 +1953,7 @@ function SessionListInner(props: SessionListProps) {
 			setGroups((prev) => prev.map((g) => ({ ...g, collapsed: true })));
 			setBookmarksCollapsed(false);
 		}
-	}, [sessionFilter]);
+	}, [sessionFilter, sessions, worktreeChildrenByParentId]);
 
 	// Get the jump number (1-9, 0=10th) for a session based on its position in visibleSessions
 	const getSessionJumpNumber = (sessionId: string): string | null => {

--- a/src/renderer/components/SessionList.tsx
+++ b/src/renderer/components/SessionList.tsx
@@ -54,7 +54,12 @@ import { getStatusColor, getContextColor, formatActiveTime } from '../utils/them
 import { formatShortcutKeys } from '../utils/shortcutFormatter';
 import { SessionItem } from './SessionItem';
 import { GroupChatList } from './GroupChatList';
-import { useLiveOverlay, useClickOutside, useResizablePanel, useContextMenuPosition } from '../hooks';
+import {
+	useLiveOverlay,
+	useClickOutside,
+	useResizablePanel,
+	useContextMenuPosition,
+} from '../hooks';
 import { useGitFileStatus } from '../contexts/GitStatusContext';
 import { useUIStore } from '../stores/uiStore';
 import { fuzzyMatch } from '../utils/search';
@@ -1904,10 +1909,9 @@ function SessionListInner(props: SessionListProps) {
 		if (sessionFilter) {
 			// Find groups that contain matching sessions (search session name AND AI tab names)
 			const groupsWithMatches = new Set<string>();
-			const query = sessionFilter.toLowerCase();
 			const matchingSessions = sessions.filter((s) => {
-				if (s.name.toLowerCase().includes(query)) return true;
-				if (s.aiTabs?.some((tab) => tab.name?.toLowerCase().includes(query))) return true;
+				if (fuzzyMatch(s.name, sessionFilter)) return true;
+				if (s.aiTabs?.some((tab) => tab.name && fuzzyMatch(tab.name, sessionFilter))) return true;
 				return false;
 			});
 

--- a/src/renderer/components/SessionList.tsx
+++ b/src/renderer/components/SessionList.tsx
@@ -57,6 +57,7 @@ import { GroupChatList } from './GroupChatList';
 import { useLiveOverlay, useClickOutside, useResizablePanel, useContextMenuPosition } from '../hooks';
 import { useGitFileStatus } from '../contexts/GitStatusContext';
 import { useUIStore } from '../stores/uiStore';
+import { fuzzyMatch } from '../utils/search';
 
 // ============================================================================
 // SessionContextMenu - Right-click context menu for session items
@@ -1743,8 +1744,8 @@ function SessionListInner(props: SessionListProps) {
 	// Consolidated session categorization and sorting - computed in a single pass
 	// This replaces 12+ chained useMemo calls with one comprehensive computation
 	const sessionCategories = useMemo(() => {
-		// Step 1: Filter sessions based on search query
-		const query = sessionFilter?.toLowerCase() ?? '';
+		// Step 1: Filter sessions based on search query (fuzzy match)
+		const query = sessionFilter ?? '';
 		const filtered: Session[] = [];
 
 		for (const s of sessions) {
@@ -1755,12 +1756,12 @@ function SessionListInner(props: SessionListProps) {
 				filtered.push(s);
 			} else {
 				// Match session name
-				if (s.name.toLowerCase().includes(query)) {
+				if (fuzzyMatch(s.name, query)) {
 					filtered.push(s);
 					continue;
 				}
 				// Match any AI tab name
-				if (s.aiTabs?.some((tab) => tab.name?.toLowerCase().includes(query))) {
+				if (s.aiTabs?.some((tab) => tab.name && fuzzyMatch(tab.name, query))) {
 					filtered.push(s);
 					continue;
 				}
@@ -1769,8 +1770,8 @@ function SessionListInner(props: SessionListProps) {
 				if (
 					worktreeChildren?.some(
 						(child) =>
-							child.worktreeBranch?.toLowerCase().includes(query) ||
-							child.name.toLowerCase().includes(query)
+							(child.worktreeBranch && fuzzyMatch(child.worktreeBranch, query)) ||
+							fuzzyMatch(child.name, query)
 					)
 				) {
 					filtered.push(s);

--- a/src/renderer/hooks/input/useInputKeyDown.ts
+++ b/src/renderer/hooks/input/useInputKeyDown.ts
@@ -221,8 +221,12 @@ export function useInputKeyDown(deps: InputKeyDownDeps): InputKeyDownReturn {
 					setSelectedSlashCommandIndex((prev) => Math.max(prev - 1, 0));
 				} else if (e.key === 'Tab' || e.key === 'Enter') {
 					e.preventDefault();
-					if (filteredCommands[selectedSlashCommandIndex]) {
-						setInputValue(filteredCommands[selectedSlashCommandIndex].command);
+					const safeIndex = Math.min(
+						Math.max(0, selectedSlashCommandIndex),
+						Math.max(0, filteredCommands.length - 1)
+					);
+					if (filteredCommands[safeIndex]) {
+						setInputValue(filteredCommands[safeIndex].command);
 						setSlashCommandOpen(false);
 						inputRef.current?.focus();
 					}

--- a/src/renderer/hooks/input/useInputKeyDown.ts
+++ b/src/renderer/hooks/input/useInputKeyDown.ts
@@ -16,7 +16,7 @@ import { useInputContext } from '../../contexts/InputContext';
 import { useSessionStore, selectActiveSession } from '../../stores/sessionStore';
 import { useUIStore } from '../../stores/uiStore';
 import { useSettingsStore } from '../../stores/settingsStore';
-import { fuzzyMatch } from '../../utils/search';
+import { filterAndSortSlashCommands } from '../../utils/search';
 
 // ============================================================================
 // Dependencies interface
@@ -207,17 +207,11 @@ export function useInputKeyDown(deps: InputKeyDownDeps): InputKeyDownReturn {
 			if (slashCommandOpen) {
 				const isTerminalMode = activeSession?.inputMode === 'terminal';
 				const searchTerm = inputValue.toLowerCase().replace(/^\//, '');
-				const filteredCommands = allSlashCommands.filter((cmd) => {
-					if ('terminalOnly' in cmd && cmd.terminalOnly && !isTerminalMode) return false;
-					if ('aiOnly' in cmd && cmd.aiOnly && isTerminalMode) return false;
-					if (!searchTerm) return true;
-					const cmdName = cmd.command.toLowerCase().replace(/^\//, '');
-					return (
-						cmdName.startsWith(searchTerm) ||
-						fuzzyMatch(cmdName, searchTerm) ||
-						(cmd.description ? fuzzyMatch(cmd.description, searchTerm) : false)
-					);
-				});
+				const filteredCommands = filterAndSortSlashCommands(
+					allSlashCommands,
+					searchTerm,
+					isTerminalMode
+				);
 
 				if (e.key === 'ArrowDown') {
 					e.preventDefault();

--- a/src/renderer/hooks/input/useInputKeyDown.ts
+++ b/src/renderer/hooks/input/useInputKeyDown.ts
@@ -16,6 +16,7 @@ import { useInputContext } from '../../contexts/InputContext';
 import { useSessionStore, selectActiveSession } from '../../stores/sessionStore';
 import { useUIStore } from '../../stores/uiStore';
 import { useSettingsStore } from '../../stores/settingsStore';
+import { fuzzyMatch } from '../../utils/search';
 
 // ============================================================================
 // Dependencies interface
@@ -205,10 +206,17 @@ export function useInputKeyDown(deps: InputKeyDownDeps): InputKeyDownReturn {
 			// Handle slash command autocomplete
 			if (slashCommandOpen) {
 				const isTerminalMode = activeSession?.inputMode === 'terminal';
+				const searchTerm = inputValue.toLowerCase().replace(/^\//, '');
 				const filteredCommands = allSlashCommands.filter((cmd) => {
 					if ('terminalOnly' in cmd && cmd.terminalOnly && !isTerminalMode) return false;
 					if ('aiOnly' in cmd && cmd.aiOnly && isTerminalMode) return false;
-					return cmd.command.toLowerCase().startsWith(inputValue.toLowerCase());
+					if (!searchTerm) return true;
+					const cmdName = cmd.command.toLowerCase().replace(/^\//, '');
+					return (
+						cmdName.startsWith(searchTerm) ||
+						fuzzyMatch(cmdName, searchTerm) ||
+						(cmd.description ? fuzzyMatch(cmd.description, searchTerm) : false)
+					);
 				});
 
 				if (e.key === 'ArrowDown') {

--- a/src/renderer/hooks/input/useInputKeyDown.ts
+++ b/src/renderer/hooks/input/useInputKeyDown.ts
@@ -213,6 +213,14 @@ export function useInputKeyDown(deps: InputKeyDownDeps): InputKeyDownReturn {
 					isTerminalMode
 				);
 
+				if (filteredCommands.length === 0) {
+					if (e.key === 'Escape') {
+						e.preventDefault();
+						setSlashCommandOpen(false);
+					}
+					return;
+				}
+
 				if (e.key === 'ArrowDown') {
 					e.preventDefault();
 					setSelectedSlashCommandIndex((prev) => Math.min(prev + 1, filteredCommands.length - 1));

--- a/src/renderer/utils/search.ts
+++ b/src/renderer/utils/search.ts
@@ -144,6 +144,7 @@ export const filterAndSortSlashCommands = <T extends SlashCommandEntry>(
 	isTerminalMode: boolean
 ): T[] => {
 	const scored: { cmd: T; score: number }[] = [];
+	const lowerSearchTerm = searchTerm.toLowerCase();
 	for (const cmd of commands) {
 		if (cmd.terminalOnly && !isTerminalMode) continue;
 		if (cmd.aiOnly && isTerminalMode) continue;
@@ -153,7 +154,7 @@ export const filterAndSortSlashCommands = <T extends SlashCommandEntry>(
 		}
 		const cmdName = cmd.command.toLowerCase().replace(/^\//, '');
 		// Prefix match gets highest priority
-		if (cmdName.startsWith(searchTerm)) {
+		if (cmdName.startsWith(lowerSearchTerm)) {
 			scored.push({ cmd, score: 300 });
 			continue;
 		}


### PR DESCRIPTION
## Summary

- Enable fuzzy matching for session filter in Left Bar (previously exact prefix match only)
- Enable fuzzy matching for slash command autocomplete in input area
- Update test expectations to reflect new fuzzy matching behavior

## Details

Previously, typing `/r` would only match commands starting with "r". Now it matches any command containing "r" anywhere in the name (e.g., `/clear` matches `/r` because "clear" contains "r"). Same improvement applied to the session filter in the Left Bar sidebar.

## Test plan

- [x] Unit test updated for new fuzzy matching behavior
- [x] ESLint clean
- [ ] Manual: type partial text in Left Bar filter, verify fuzzy matches appear
- [ ] Manual: type `/` in input, verify fuzzy autocomplete suggestions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Command autocomplete now uses fuzzy matching with relevance ranking (including descriptions) and respects terminal vs AI-mode visibility.
  * Session list search now uses fuzzy matching across session names, AI tabs, worktrees and branches.
  * Keyboard selection for slash commands improved to reliably pick and insert the best-matched command.

* **Tests**
  * Updated tests to reflect fuzzy-match behavior for slash commands in AI mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->