### PR TITLE
feat: Unified Inbox with Focus Mode (Encore Feature)

### DIFF
--- a/src/__tests__/renderer/components/AgentInbox/AgentInbox.test.tsx
+++ b/src/__tests__/renderer/components/AgentInbox/AgentInbox.test.tsx
@@ -1,0 +1,511 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, within, act } from '@testing-library/react';
+import type { Theme, Session, Group } from '../../../../renderer/types';
+import type { InboxItem } from '../../../../renderer/types/agent-inbox';
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before component imports
+// ---------------------------------------------------------------------------
+
+vi.mock('../../../../renderer/contexts/LayerStackContext', () => ({
+	useLayerStack: () => ({
+		registerLayer: vi.fn(() => 'layer-inbox'),
+		unregisterLayer: vi.fn(),
+		updateLayerHandler: vi.fn(),
+	}),
+}));
+
+vi.mock('../../../../renderer/constants/modalPriorities', () => ({
+	MODAL_PRIORITIES: { AGENT_INBOX: 555 },
+}));
+
+const mockUpdateAgentInboxData = vi.fn();
+vi.mock('../../../../renderer/stores/modalStore', () => ({
+	useModalStore: vi.fn(() => null),
+	selectModalData: vi.fn(() => () => null),
+	getModalActions: () => ({
+		updateAgentInboxData: mockUpdateAgentInboxData,
+	}),
+}));
+
+vi.mock('../../../../renderer/utils/formatters', () => ({
+	formatRelativeTime: vi.fn(() => '2m ago'),
+}));
+
+vi.mock('../../../../renderer/utils/shortcutFormatter', () => ({
+	formatShortcutKeys: vi.fn((keys: string[]) => keys.join('+')),
+	isMacOS: vi.fn(() => false),
+}));
+
+vi.mock('../../../../renderer/utils/markdownConfig', () => ({
+	generateTerminalProseStyles: vi.fn(() => ''),
+}));
+
+// Mock MarkdownRenderer used in FocusModeView (named export)
+vi.mock('../../../../renderer/components/MarkdownRenderer', () => ({
+	MarkdownRenderer: ({ content }: { content: string }) => (
+		<span data-testid="markdown">{content}</span>
+	),
+}));
+
+// Mock @tanstack/react-virtual — return virtual items matching the item count
+vi.mock('@tanstack/react-virtual', () => ({
+	useVirtualizer: (opts: { count: number }) => ({
+		getVirtualItems: () =>
+			Array.from({ length: Math.min(opts.count, 50) }, (_, i) => ({
+				index: i,
+				start: i * 132,
+				size: 132,
+				key: `virtual-${i}`,
+			})),
+		getTotalSize: () => opts.count * 132,
+		scrollToIndex: vi.fn(),
+		measureElement: vi.fn(),
+	}),
+}));
+
+// ---------------------------------------------------------------------------
+// Import component AFTER mocks
+// ---------------------------------------------------------------------------
+import AgentInbox from '../../../../renderer/components/AgentInbox';
+
+// ---------------------------------------------------------------------------
+// Factories
+// ---------------------------------------------------------------------------
+
+const mockTheme: Theme = {
+	id: 'dark',
+	name: 'Dark',
+	mode: 'dark',
+	colors: {
+		bgMain: '#1a1a2e',
+		bgSidebar: '#16213e',
+		bgActivity: '#0f3460',
+		bgTerminal: '#1a1a2e',
+		textMain: '#eaeaea',
+		textDim: '#888',
+		accent: '#e94560',
+		accentForeground: '#ffffff',
+		error: '#ff6b6b',
+		border: '#333',
+		success: '#4ecdc4',
+		warning: '#ffd93d',
+		terminalCursor: '#e94560',
+	},
+};
+
+const makeTab = (overrides: Record<string, unknown> = {}) => ({
+	id: `tab-${Math.random().toString(36).slice(2, 8)}`,
+	agentSessionId: null,
+	name: null,
+	starred: false,
+	logs: [{ id: 'log-1', timestamp: Date.now(), source: 'ai' as const, text: 'Hello world' }],
+	inputValue: '',
+	stagedImages: [],
+	createdAt: 1000,
+	state: 'idle' as const,
+	hasUnread: true,
+	...overrides,
+});
+
+const makeSession = (overrides: Partial<Session> = {}): Session =>
+	({
+		id: `s-${Math.random().toString(36).slice(2, 8)}`,
+		name: 'Agent Alpha',
+		toolType: 'claude-code',
+		state: 'idle',
+		cwd: '/test',
+		fullPath: '/test',
+		projectRoot: '/test',
+		port: 0,
+		aiPid: 0,
+		terminalPid: 0,
+		inputMode: 'ai',
+		aiTabs: [makeTab()],
+		activeTabId: 'default-tab',
+		closedTabHistory: [],
+		aiLogs: [],
+		shellLogs: [],
+		workLog: [],
+		executionQueue: [],
+		contextUsage: 0,
+		isGitRepo: false,
+		changedFiles: [],
+		fileTree: [],
+		fileExplorerExpanded: [],
+		fileExplorerScrollPos: 0,
+		isLive: false,
+		...overrides,
+	}) as unknown as Session;
+
+const makeGroup = (overrides: Partial<Group> = {}): Group => ({
+	id: `g-${Math.random().toString(36).slice(2, 8)}`,
+	name: 'Group',
+	emoji: '',
+	collapsed: false,
+	...overrides,
+});
+
+// Default props factory
+const createDefaultProps = (overrides: Record<string, unknown> = {}) => ({
+	theme: mockTheme,
+	sessions: [] as Session[],
+	groups: [] as Group[],
+	onClose: vi.fn(),
+	onNavigateToSession: vi.fn(),
+	onQuickReply: vi.fn(),
+	onOpenAndReply: vi.fn(),
+	onMarkAsRead: vi.fn(),
+	onToggleThinking: vi.fn(),
+	...overrides,
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('AgentInbox', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		// Mock requestAnimationFrame for auto-focus
+		vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+			cb(0);
+			return 0;
+		});
+		vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	// ====================================================================
+	// 1. List mode renders inbox items
+	// ====================================================================
+
+	describe('list mode rendering', () => {
+		it('renders the dialog with correct ARIA attributes', () => {
+			const props = createDefaultProps();
+			render(<AgentInbox {...props} />);
+
+			const dialog = screen.getByRole('dialog');
+			expect(dialog).toBeInTheDocument();
+			expect(dialog).toHaveAttribute('aria-modal', 'true');
+			expect(dialog).toHaveAttribute('aria-label', 'Unified Inbox');
+		});
+
+		it('renders inbox items from sessions', () => {
+			const tab1 = makeTab({ id: 't1', hasUnread: true });
+			const tab2 = makeTab({ id: 't2', hasUnread: true });
+			const s1 = makeSession({ id: 's1', name: 'Agent One', aiTabs: [tab1] });
+			const s2 = makeSession({ id: 's2', name: 'Agent Two', aiTabs: [tab2] });
+
+			const props = createDefaultProps({ sessions: [s1, s2] });
+			render(<AgentInbox {...props} />);
+
+			// Items render with role="option"
+			const options = screen.getAllByRole('option');
+			expect(options.length).toBeGreaterThanOrEqual(2);
+		});
+
+		it('renders empty state when no sessions match filter', () => {
+			const tab = makeTab({ id: 't1', hasUnread: false });
+			const session = makeSession({ id: 's1', aiTabs: [tab] });
+
+			// Default filter is 'unread' — a session with no unread tabs shows empty
+			const props = createDefaultProps({ sessions: [session] });
+			render(<AgentInbox {...props} />);
+
+			const emptyState = screen.getByTestId('inbox-empty-state');
+			expect(emptyState).toBeInTheDocument();
+		});
+
+		it('renders session names in item cards', () => {
+			const tab = makeTab({ id: 't1', hasUnread: true });
+			const session = makeSession({ id: 's1', name: 'Claude Worker', aiTabs: [tab] });
+
+			const props = createDefaultProps({ sessions: [session] });
+			render(<AgentInbox {...props} />);
+
+			expect(screen.getByText('Claude Worker')).toBeInTheDocument();
+		});
+	});
+
+	// ====================================================================
+	// 2. Filter pills change visible items
+	// ====================================================================
+
+	describe('filter pills', () => {
+		it('renders filter segmented control with All/Unread/Read/Starred options', () => {
+			const props = createDefaultProps();
+			render(<AgentInbox {...props} />);
+
+			const filterControl = screen.getByLabelText('Filter agents');
+			expect(within(filterControl).getByText('All')).toBeInTheDocument();
+			expect(within(filterControl).getByText('Unread')).toBeInTheDocument();
+			expect(within(filterControl).getByText('Read')).toBeInTheDocument();
+			expect(within(filterControl).getByText('Starred')).toBeInTheDocument();
+		});
+
+		it('clicking "All" filter shows all items (unread + read)', () => {
+			const tabUnread = makeTab({ id: 't1', hasUnread: true });
+			const tabRead = makeTab({ id: 't2', hasUnread: false });
+			const s1 = makeSession({ id: 's1', name: 'Unread Agent', aiTabs: [tabUnread] });
+			const s2 = makeSession({ id: 's2', name: 'Read Agent', aiTabs: [tabRead] });
+
+			const props = createDefaultProps({ sessions: [s1, s2] });
+			render(<AgentInbox {...props} />);
+
+			// Default filter is 'unread' — only unread tab shows
+			const optionsBefore = screen.getAllByRole('option');
+			expect(optionsBefore).toHaveLength(1);
+
+			// Click 'All' filter (scoped to filter control)
+			const filterControl = screen.getByLabelText('Filter agents');
+			fireEvent.click(within(filterControl).getByText('All'));
+
+			// Now both should be visible
+			const optionsAfter = screen.getAllByRole('option');
+			expect(optionsAfter).toHaveLength(2);
+		});
+
+		it('clicking "Starred" filter shows only starred items', () => {
+			const tabStarred = makeTab({ id: 't1', hasUnread: true, starred: true });
+			const tabNormal = makeTab({ id: 't2', hasUnread: true, starred: false });
+			const s1 = makeSession({ id: 's1', name: 'Starred', aiTabs: [tabStarred] });
+			const s2 = makeSession({ id: 's2', name: 'Normal', aiTabs: [tabNormal] });
+
+			const props = createDefaultProps({ sessions: [s1, s2] });
+			render(<AgentInbox {...props} />);
+
+			// Click 'Starred' filter (scoped to filter control)
+			const filterControl = screen.getByLabelText('Filter agents');
+			fireEvent.click(within(filterControl).getByText('Starred'));
+
+			const options = screen.getAllByRole('option');
+			expect(options).toHaveLength(1);
+		});
+
+		it('clicking "Read" filter shows only non-unread items', () => {
+			const tabUnread = makeTab({ id: 't1', hasUnread: true });
+			const tabRead = makeTab({ id: 't2', hasUnread: false });
+			const session = makeSession({ id: 's1', aiTabs: [tabUnread, tabRead] });
+
+			const props = createDefaultProps({ sessions: [session] });
+			render(<AgentInbox {...props} />);
+
+			// Click 'Read' filter (scoped to filter control)
+			const filterControl = screen.getByLabelText('Filter agents');
+			fireEvent.click(within(filterControl).getByText('Read'));
+
+			const options = screen.getAllByRole('option');
+			expect(options).toHaveLength(1);
+		});
+	});
+
+	// ====================================================================
+	// 3. Keyboard navigation (up/down arrows, Enter to select)
+	// ====================================================================
+
+	describe('keyboard navigation', () => {
+		it('ArrowDown moves selection to next item', () => {
+			const tab1 = makeTab({ id: 't1', hasUnread: true });
+			const tab2 = makeTab({ id: 't2', hasUnread: true });
+			const s1 = makeSession({ id: 's1', name: 'First', aiTabs: [tab1] });
+			const s2 = makeSession({ id: 's2', name: 'Second', aiTabs: [tab2] });
+
+			const props = createDefaultProps({ sessions: [s1, s2] });
+			render(<AgentInbox {...props} />);
+
+			const listbox = screen.getByRole('listbox');
+
+			// First item should be selected initially
+			const optionsBefore = screen.getAllByRole('option');
+			expect(optionsBefore[0]).toHaveAttribute('aria-selected', 'true');
+
+			// Press ArrowDown on the listbox
+			fireEvent.keyDown(listbox, { key: 'ArrowDown' });
+
+			// Second item should now be selected
+			const optionsAfter = screen.getAllByRole('option');
+			expect(optionsAfter[1]).toHaveAttribute('aria-selected', 'true');
+		});
+
+		it('ArrowUp moves selection to previous item', () => {
+			const tab1 = makeTab({ id: 't1', hasUnread: true });
+			const tab2 = makeTab({ id: 't2', hasUnread: true });
+			const s1 = makeSession({ id: 's1', name: 'First', aiTabs: [tab1] });
+			const s2 = makeSession({ id: 's2', name: 'Second', aiTabs: [tab2] });
+
+			const props = createDefaultProps({ sessions: [s1, s2] });
+			render(<AgentInbox {...props} />);
+
+			const listbox = screen.getByRole('listbox');
+
+			// Move down first, then up
+			fireEvent.keyDown(listbox, { key: 'ArrowDown' });
+			fireEvent.keyDown(listbox, { key: 'ArrowUp' });
+
+			const options = screen.getAllByRole('option');
+			expect(options[0]).toHaveAttribute('aria-selected', 'true');
+		});
+
+		it('Enter on an item calls onNavigateToSession and onClose', () => {
+			const tab = makeTab({ id: 't1', hasUnread: true });
+			const session = makeSession({ id: 's1', name: 'Agent', aiTabs: [tab] });
+
+			const onNavigate = vi.fn();
+			const onClose = vi.fn();
+			const props = createDefaultProps({
+				sessions: [session],
+				onNavigateToSession: onNavigate,
+				onClose,
+			});
+			render(<AgentInbox {...props} />);
+
+			const listbox = screen.getByRole('listbox');
+			fireEvent.keyDown(listbox, { key: 'Enter' });
+
+			expect(onNavigate).toHaveBeenCalledWith('s1', 't1');
+			expect(onClose).toHaveBeenCalled();
+		});
+	});
+
+	// ====================================================================
+	// 4. Escape closes the modal
+	// ====================================================================
+
+	describe('Escape closes modal', () => {
+		it('clicking overlay background calls onClose', () => {
+			const onClose = vi.fn();
+			const props = createDefaultProps({ onClose });
+			render(<AgentInbox {...props} />);
+
+			// The overlay is the outermost div with modal-overlay class
+			const overlay = screen.getByRole('dialog').parentElement!;
+			fireEvent.click(overlay);
+
+			expect(onClose).toHaveBeenCalledTimes(1);
+		});
+
+		it('clicking close button calls onClose', () => {
+			const tab = makeTab({ id: 't1', hasUnread: true });
+			const session = makeSession({ id: 's1', aiTabs: [tab] });
+			const onClose = vi.fn();
+			const props = createDefaultProps({ sessions: [session], onClose });
+			render(<AgentInbox {...props} />);
+
+			// Close button has title="Close (Esc)"
+			const closeBtn = screen.getByTitle('Close (Esc)');
+			fireEvent.click(closeBtn);
+
+			expect(onClose).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	// ====================================================================
+	// 5. Focus mode entry (Enter or double-click)
+	// ====================================================================
+
+	describe('focus mode entry', () => {
+		it('pressing F enters focus mode', () => {
+			const tab = makeTab({ id: 't1', hasUnread: true });
+			const session = makeSession({ id: 's1', name: 'Agent', aiTabs: [tab] });
+
+			const props = createDefaultProps({ sessions: [session] });
+			render(<AgentInbox {...props} />);
+
+			const dialog = screen.getByRole('dialog');
+
+			// Press F on the dialog container to enter focus mode
+			fireEvent.keyDown(dialog, { key: 'f' });
+
+			// In focus mode, the listbox disappears and focus view renders
+			// We can detect focus mode by checking for the reply textarea
+			const textarea = screen.queryByLabelText('Reply to agent');
+			expect(textarea).toBeInTheDocument();
+		});
+
+		it('double-clicking an item enters focus mode', () => {
+			const tab = makeTab({ id: 't1', hasUnread: true });
+			const session = makeSession({ id: 's1', name: 'Agent', aiTabs: [tab] });
+
+			const props = createDefaultProps({ sessions: [session] });
+			render(<AgentInbox {...props} />);
+
+			// Double-click the first option
+			const option = screen.getByRole('option');
+			fireEvent.doubleClick(option);
+
+			// Should enter focus mode — reply textarea appears
+			const textarea = screen.queryByLabelText('Reply to agent');
+			expect(textarea).toBeInTheDocument();
+		});
+
+		it('Escape in focus mode returns to list mode', () => {
+			const tab = makeTab({ id: 't1', hasUnread: true });
+			const session = makeSession({ id: 's1', name: 'Agent', aiTabs: [tab] });
+
+			const props = createDefaultProps({ sessions: [session] });
+			render(<AgentInbox {...props} />);
+
+			const dialog = screen.getByRole('dialog');
+
+			// Enter focus mode
+			fireEvent.keyDown(dialog, { key: 'f' });
+			expect(screen.queryByLabelText('Reply to agent')).toBeInTheDocument();
+
+			// Press Escape — should go back to list mode, not close
+			fireEvent.keyDown(dialog, { key: 'Escape' });
+
+			// Listbox should be back
+			const listbox = screen.queryByRole('listbox');
+			expect(listbox).toBeInTheDocument();
+		});
+
+		it('Backspace in focus mode (not in textarea) returns to list mode', () => {
+			const tab = makeTab({ id: 't1', hasUnread: true });
+			const session = makeSession({ id: 's1', name: 'Agent', aiTabs: [tab] });
+
+			const props = createDefaultProps({ sessions: [session] });
+			render(<AgentInbox {...props} />);
+
+			const dialog = screen.getByRole('dialog');
+
+			// Enter focus mode
+			fireEvent.keyDown(dialog, { key: 'f' });
+			expect(screen.queryByLabelText('Reply to agent')).toBeInTheDocument();
+
+			// Focus the dialog container (not textarea) before pressing Backspace
+			dialog.focus();
+
+			// Press Backspace while dialog itself is focused (not textarea)
+			fireEvent.keyDown(dialog, { key: 'Backspace' });
+
+			// Should return to list mode
+			const listbox = screen.queryByRole('listbox');
+			expect(listbox).toBeInTheDocument();
+		});
+	});
+
+	// ====================================================================
+	// 6. Reply sends input to correct tab (simpler assertion)
+	// ====================================================================
+
+	describe('reply in focus mode', () => {
+		it('renders reply textarea in focus mode', () => {
+			const tab = makeTab({ id: 't1', hasUnread: true });
+			const session = makeSession({ id: 's1', name: 'Agent', aiTabs: [tab] });
+
+			const props = createDefaultProps({ sessions: [session] });
+			render(<AgentInbox {...props} />);
+
+			const dialog = screen.getByRole('dialog');
+			fireEvent.keyDown(dialog, { key: 'f' });
+
+			const textarea = screen.getByLabelText('Reply to agent');
+			expect(textarea).toBeInTheDocument();
+			expect(textarea.tagName).toBe('TEXTAREA');
+		});
+	});
+});

--- a/src/__tests__/renderer/hooks/useAgentInbox.test.ts
+++ b/src/__tests__/renderer/hooks/useAgentInbox.test.ts
@@ -1,0 +1,384 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import {
+	useAgentInbox,
+	truncate,
+	generateSmartSummary,
+} from '../../../renderer/hooks/useAgentInbox';
+import type { Session, Group } from '../../../renderer/types';
+import type { InboxFilterMode, InboxSortMode } from '../../../renderer/types/agent-inbox';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Minimal AITab factory. Fields not relevant to inbox are given sensible defaults. */
+const makeTab = (overrides: Record<string, unknown> = {}) => ({
+	id: `tab-${Math.random().toString(36).slice(2, 8)}`,
+	agentSessionId: null,
+	name: null,
+	starred: false,
+	logs: [],
+	inputValue: '',
+	stagedImages: [],
+	createdAt: 1000,
+	state: 'idle' as const,
+	hasUnread: false,
+	...overrides,
+});
+
+/** Minimal Session factory. Only fields consumed by useAgentInbox need real values. */
+const makeSession = (overrides: Partial<Session> = {}): Session =>
+	({
+		id: `s-${Math.random().toString(36).slice(2, 8)}`,
+		name: 'Agent A',
+		toolType: 'claude-code',
+		state: 'idle',
+		cwd: '/test',
+		fullPath: '/test',
+		projectRoot: '/test',
+		port: 0,
+		aiPid: 0,
+		terminalPid: 0,
+		inputMode: 'ai',
+		aiTabs: [makeTab()],
+		activeTabId: 'default-tab',
+		closedTabHistory: [],
+		aiLogs: [],
+		shellLogs: [],
+		workLog: [],
+		executionQueue: [],
+		contextUsage: 0,
+		isGitRepo: false,
+		changedFiles: [],
+		fileTree: [],
+		fileExplorerExpanded: [],
+		fileExplorerScrollPos: 0,
+		isLive: false,
+		...overrides,
+	}) as unknown as Session;
+
+const makeGroup = (overrides: Partial<Group> = {}): Group => ({
+	id: `g-${Math.random().toString(36).slice(2, 8)}`,
+	name: 'Group',
+	emoji: '',
+	collapsed: false,
+	...overrides,
+});
+
+// ---------------------------------------------------------------------------
+// truncate()
+// ---------------------------------------------------------------------------
+
+describe('truncate', () => {
+	it('returns short text unchanged', () => {
+		expect(truncate('hello')).toBe('hello');
+	});
+
+	it('returns text exactly at MAX_MESSAGE_LENGTH unchanged', () => {
+		const text = 'a'.repeat(90);
+		expect(truncate(text)).toBe(text);
+	});
+
+	it('truncates text longer than 90 chars with ellipsis', () => {
+		const text = 'a'.repeat(100);
+		const result = truncate(text);
+		expect(result.length).toBe(90);
+		expect(result.endsWith('...')).toBe(true);
+		// 90 - 3 (ellipsis) = 87 'a' chars
+		expect(result).toBe('a'.repeat(87) + '...');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// generateSmartSummary()
+// ---------------------------------------------------------------------------
+
+describe('generateSmartSummary', () => {
+	it('returns default message for empty logs', () => {
+		expect(generateSmartSummary([], 'idle')).toBe('No activity yet');
+	});
+
+	it('returns default message for undefined logs', () => {
+		expect(generateSmartSummary(undefined, 'idle')).toBe('No activity yet');
+	});
+
+	it('prefixes with "Waiting:" when session is waiting_input', () => {
+		const logs = [
+			{ id: '1', timestamp: 1000, source: 'ai' as const, text: 'What should I do next?' },
+		];
+		const result = generateSmartSummary(logs, 'waiting_input');
+		expect(result.startsWith('Waiting: ')).toBe(true);
+		expect(result).toContain('What should I do next?');
+	});
+
+	it('shows question directly when AI message ends with "?"', () => {
+		const logs = [{ id: '1', timestamp: 1000, source: 'ai' as const, text: 'Shall I proceed?' }];
+		const result = generateSmartSummary(logs, 'idle');
+		expect(result).toBe('Shall I proceed?');
+	});
+
+	it('prefixes with "Done:" for AI statement', () => {
+		const logs = [
+			{ id: '1', timestamp: 1000, source: 'ai' as const, text: 'Refactored the module.' },
+		];
+		const result = generateSmartSummary(logs, 'idle');
+		expect(result).toBe('Done: Refactored the module.');
+	});
+
+	it('falls back to last log text when no AI source found', () => {
+		const logs = [
+			{ id: '1', timestamp: 1000, source: 'user' as const, text: 'Fix the bug please' },
+		];
+		const result = generateSmartSummary(logs, 'idle');
+		expect(result).toBe('Fix the bug please');
+	});
+
+	it('truncates long summaries', () => {
+		const longText = 'A'.repeat(200);
+		const logs = [{ id: '1', timestamp: 1000, source: 'ai' as const, text: longText }];
+		const result = generateSmartSummary(logs, 'idle');
+		expect(result.length).toBe(90);
+		expect(result.endsWith('...')).toBe(true);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// useAgentInbox — Filter Logic
+// ---------------------------------------------------------------------------
+
+describe('useAgentInbox — filter logic', () => {
+	it('filter "all" returns every tab from every session', () => {
+		const tab1 = makeTab({ id: 't1', hasUnread: true });
+		const tab2 = makeTab({ id: 't2', hasUnread: false });
+		const session = makeSession({ id: 's1', aiTabs: [tab1, tab2] });
+
+		const { result } = renderHook(() => useAgentInbox([session], [], 'all', 'newest'));
+		expect(result.current).toHaveLength(2);
+	});
+
+	it('filter "unread" returns only unread items', () => {
+		const tab1 = makeTab({ id: 't1', hasUnread: true });
+		const tab2 = makeTab({ id: 't2', hasUnread: false });
+		const session = makeSession({ id: 's1', aiTabs: [tab1, tab2] });
+
+		const { result } = renderHook(() => useAgentInbox([session], [], 'unread', 'newest'));
+		expect(result.current).toHaveLength(1);
+		expect(result.current[0].tabId).toBe('t1');
+		expect(result.current[0].hasUnread).toBe(true);
+	});
+
+	it('filter "read" returns only non-unread items', () => {
+		const tab1 = makeTab({ id: 't1', hasUnread: true });
+		const tab2 = makeTab({ id: 't2', hasUnread: false });
+		const session = makeSession({ id: 's1', aiTabs: [tab1, tab2] });
+
+		const { result } = renderHook(() => useAgentInbox([session], [], 'read', 'newest'));
+		expect(result.current).toHaveLength(1);
+		expect(result.current[0].tabId).toBe('t2');
+		expect(result.current[0].hasUnread).toBe(false);
+	});
+
+	it('filter "starred" returns only starred items', () => {
+		const tab1 = makeTab({ id: 't1', starred: true });
+		const tab2 = makeTab({ id: 't2', starred: false });
+		const session = makeSession({ id: 's1', aiTabs: [tab1, tab2] });
+
+		const { result } = renderHook(() => useAgentInbox([session], [], 'starred', 'newest'));
+		expect(result.current).toHaveLength(1);
+		expect(result.current[0].tabId).toBe('t1');
+		expect(result.current[0].starred).toBe(true);
+	});
+
+	it('skips sessions with falsy id', () => {
+		const session = makeSession({ id: '', aiTabs: [makeTab({ hasUnread: true })] });
+
+		const { result } = renderHook(() => useAgentInbox([session], [], 'all', 'newest'));
+		expect(result.current).toHaveLength(0);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// useAgentInbox — Sort Logic
+// ---------------------------------------------------------------------------
+
+describe('useAgentInbox — sort logic', () => {
+	const now = Date.now();
+
+	it('sort "newest" orders by timestamp descending', () => {
+		const tab1 = makeTab({
+			id: 't1',
+			logs: [{ id: '1', timestamp: now - 1000, source: 'ai', text: 'a' }],
+		});
+		const tab2 = makeTab({
+			id: 't2',
+			logs: [{ id: '2', timestamp: now, source: 'ai', text: 'b' }],
+		});
+		const session = makeSession({ id: 's1', aiTabs: [tab1, tab2] });
+
+		const { result } = renderHook(() => useAgentInbox([session], [], 'all', 'newest'));
+		expect(result.current[0].tabId).toBe('t2');
+		expect(result.current[1].tabId).toBe('t1');
+	});
+
+	it('sort "oldest" orders by timestamp ascending', () => {
+		const tab1 = makeTab({
+			id: 't1',
+			logs: [{ id: '1', timestamp: now - 1000, source: 'ai', text: 'a' }],
+		});
+		const tab2 = makeTab({
+			id: 't2',
+			logs: [{ id: '2', timestamp: now, source: 'ai', text: 'b' }],
+		});
+		const session = makeSession({ id: 's1', aiTabs: [tab1, tab2] });
+
+		const { result } = renderHook(() => useAgentInbox([session], [], 'all', 'oldest'));
+		expect(result.current[0].tabId).toBe('t1');
+		expect(result.current[1].tabId).toBe('t2');
+	});
+
+	it('sort "grouped" groups by groupName then by timestamp within group', () => {
+		const groupA = makeGroup({ id: 'gA', name: 'Alpha' });
+		const groupB = makeGroup({ id: 'gB', name: 'Beta' });
+
+		const tab1 = makeTab({
+			id: 't1',
+			logs: [{ id: '1', timestamp: now - 2000, source: 'ai', text: 'a' }],
+		});
+		const tab2 = makeTab({
+			id: 't2',
+			logs: [{ id: '2', timestamp: now, source: 'ai', text: 'b' }],
+		});
+		const tab3 = makeTab({
+			id: 't3',
+			logs: [{ id: '3', timestamp: now - 1000, source: 'ai', text: 'c' }],
+		});
+
+		const sessionAlpha = makeSession({ id: 's1', name: 'S1', groupId: 'gA', aiTabs: [tab1] });
+		const sessionBeta1 = makeSession({ id: 's2', name: 'S2', groupId: 'gB', aiTabs: [tab2] });
+		const sessionBeta2 = makeSession({ id: 's3', name: 'S3', groupId: 'gB', aiTabs: [tab3] });
+
+		const { result } = renderHook(() =>
+			useAgentInbox([sessionAlpha, sessionBeta1, sessionBeta2], [groupA, groupB], 'all', 'grouped')
+		);
+
+		// Alpha group first, then Beta
+		expect(result.current[0].groupName).toBe('Alpha');
+		// Beta items sorted by newest first within group
+		expect(result.current[1].groupName).toBe('Beta');
+		expect(result.current[1].tabId).toBe('t2'); // newer
+		expect(result.current[2].groupName).toBe('Beta');
+		expect(result.current[2].tabId).toBe('t3'); // older
+	});
+
+	it('sort "grouped" puts ungrouped items last', () => {
+		const groupA = makeGroup({ id: 'gA', name: 'Alpha' });
+		const tabGrouped = makeTab({ id: 't1' });
+		const tabUngrouped = makeTab({ id: 't2' });
+
+		const s1 = makeSession({ id: 's1', groupId: 'gA', aiTabs: [tabGrouped] });
+		const s2 = makeSession({ id: 's2', aiTabs: [tabUngrouped] });
+
+		const { result } = renderHook(() => useAgentInbox([s1, s2], [groupA], 'all', 'grouped'));
+
+		expect(result.current[0].groupName).toBe('Alpha');
+		expect(result.current[1].groupName).toBeUndefined();
+	});
+
+	it('sort "byAgent" groups by sessionId, not sessionName', () => {
+		// Two sessions with same name but different IDs
+		const tab1 = makeTab({ id: 't1', hasUnread: true });
+		const tab2 = makeTab({ id: 't2', hasUnread: false });
+		const s1 = makeSession({ id: 'agent-aaa', name: 'Same Name', aiTabs: [tab1] });
+		const s2 = makeSession({ id: 'agent-bbb', name: 'Same Name', aiTabs: [tab2] });
+
+		const { result } = renderHook(() => useAgentInbox([s1, s2], [], 'all', 'byAgent'));
+
+		// agent-aaa has unread (1) so it should come first
+		expect(result.current[0].sessionId).toBe('agent-aaa');
+		expect(result.current[1].sessionId).toBe('agent-bbb');
+	});
+
+	it('sort "byAgent" puts agents with unreads first', () => {
+		const tabUnread = makeTab({ id: 't1', hasUnread: true });
+		const tabRead = makeTab({ id: 't2', hasUnread: false });
+		const sNoUnread = makeSession({ id: 'agent-zzz', name: 'Alpha', aiTabs: [tabRead] });
+		const sWithUnread = makeSession({ id: 'agent-aaa', name: 'Zulu', aiTabs: [tabUnread] });
+
+		const { result } = renderHook(() =>
+			useAgentInbox([sNoUnread, sWithUnread], [], 'all', 'byAgent')
+		);
+
+		// Agent with unread comes first regardless of alphabetical name
+		expect(result.current[0].sessionId).toBe('agent-aaa');
+		expect(result.current[1].sessionId).toBe('agent-zzz');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// useAgentInbox — Summary Truncation
+// ---------------------------------------------------------------------------
+
+describe('useAgentInbox — summary truncation', () => {
+	it('truncates lastMessage to 90 characters', () => {
+		const longMessage = 'X'.repeat(200);
+		const tab = makeTab({
+			id: 't1',
+			logs: [{ id: '1', timestamp: 1000, source: 'ai', text: longMessage }],
+		});
+		const session = makeSession({ id: 's1', aiTabs: [tab] });
+
+		const { result } = renderHook(() => useAgentInbox([session], [], 'all', 'newest'));
+		expect(result.current[0].lastMessage.length).toBe(90);
+		expect(result.current[0].lastMessage.endsWith('...')).toBe(true);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// useAgentInbox — Timestamp Fallback
+// ---------------------------------------------------------------------------
+
+describe('useAgentInbox — timestamp fallback', () => {
+	it('uses last log timestamp when available', () => {
+		const tab = makeTab({
+			id: 't1',
+			logs: [{ id: '1', timestamp: 42000, source: 'ai', text: 'hi' }],
+		});
+		const session = makeSession({ id: 's1', aiTabs: [tab] });
+
+		const { result } = renderHook(() => useAgentInbox([session], [], 'all', 'newest'));
+		expect(result.current[0].timestamp).toBe(42000);
+	});
+
+	it('falls back to tab createdAt when logs are empty', () => {
+		const tab = makeTab({ id: 't1', logs: [], createdAt: 99000 });
+		const session = makeSession({ id: 's1', aiTabs: [tab] });
+
+		const { result } = renderHook(() => useAgentInbox([session], [], 'all', 'newest'));
+		expect(result.current[0].timestamp).toBe(99000);
+	});
+
+	it('falls back to Date.now() when log timestamp and createdAt are invalid', () => {
+		const before = Date.now();
+		const tab = makeTab({ id: 't1', logs: [], createdAt: 0 });
+		const session = makeSession({ id: 's1', aiTabs: [tab] });
+
+		const { result } = renderHook(() => useAgentInbox([session], [], 'all', 'newest'));
+		const after = Date.now();
+
+		expect(result.current[0].timestamp).toBeGreaterThanOrEqual(before);
+		expect(result.current[0].timestamp).toBeLessThanOrEqual(after);
+	});
+
+	it('skips non-finite log timestamps and falls back', () => {
+		const tab = makeTab({
+			id: 't1',
+			logs: [{ id: '1', timestamp: NaN, source: 'ai', text: 'hi' }],
+			createdAt: 55000,
+		});
+		const session = makeSession({ id: 's1', aiTabs: [tab] });
+
+		const { result } = renderHook(() => useAgentInbox([session], [], 'all', 'newest'));
+		expect(result.current[0].timestamp).toBe(55000);
+	});
+});

--- a/src/__tests__/renderer/stores/modalStore.test.ts
+++ b/src/__tests__/renderer/stores/modalStore.test.ts
@@ -192,12 +192,13 @@ describe('modalStore', () => {
 			expect(data?.allowDelete).toBe(true);
 		});
 
-		it('does nothing for unopened modals', () => {
-			const { updateModalData, getData } = useModalStore.getState();
+		it('stores data even for unopened modals', () => {
+			const { updateModalData, getData, isOpen } = useModalStore.getState();
 
 			updateModalData('settings', { tab: 'general' });
 
-			expect(getData('settings')).toBeUndefined();
+			expect(getData('settings')).toEqual({ tab: 'general' });
+			expect(isOpen('settings')).toBe(false);
 		});
 
 		it('does not change open state', () => {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -3859,6 +3859,7 @@ function MaestroConsoleInner() {
 					onOpenDirectorNotes={
 						encoreFeatures.directorNotes ? () => setDirectorNotesOpen(true) : undefined
 					}
+					onOpenAgentInbox={encoreFeatures.unifiedInbox ? () => setAgentInboxOpen(true) : undefined}
 					autoScrollAiMode={autoScrollAiMode}
 					setAutoScrollAiMode={setAutoScrollAiMode}
 					tabSwitcherOpen={tabSwitcherOpen}

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -41,6 +41,7 @@ const DocumentGraphView = lazy(() =>
 const DirectorNotesModal = lazy(() =>
 	import('./components/DirectorNotes').then((m) => ({ default: m.DirectorNotesModal }))
 );
+const AgentInbox = lazy(() => import('./components/AgentInbox'));
 
 // Re-import the type for SymphonyContributionData (types don't need lazy loading)
 import type { SymphonyContributionData } from './components/SymphonyModal';
@@ -344,6 +345,9 @@ function MaestroConsoleInner() {
 		// Director's Notes Modal
 		directorNotesOpen,
 		setDirectorNotesOpen,
+		// Agent Inbox Modal
+		agentInboxOpen,
+		setAgentInboxOpen,
 	} = useModalActions();
 
 	// --- MOBILE LANDSCAPE MODE (reading-only view) ---
@@ -1372,6 +1376,149 @@ function MaestroConsoleInner() {
 		}
 	}, [activeSession?.id, handleResumeSession]);
 
+	// --- AGENT INBOX SESSION NAVIGATION ---
+	// Close inbox modal and switch to the target agent session
+	const handleAgentInboxNavigateToSession = useCallback(
+		(sessionId: string, tabId?: string) => {
+			setAgentInboxOpen(false);
+			setActiveSessionId(sessionId);
+			if (tabId) {
+				setSessions((prev) =>
+					prev.map((s) =>
+						s.id === sessionId
+							? { ...s, activeTabId: tabId, activeFileTabId: null, inputMode: 'ai' as const }
+							: s
+					)
+				);
+			}
+		},
+		[setAgentInboxOpen, setActiveSessionId, setSessions]
+	);
+
+	// Ref for processInput — populated after useInputHandlers (declared later in component).
+	// Handlers below close over this ref so they always call the latest version.
+	const inboxProcessInputRef = useRef<(text?: string) => void>(() => {});
+	const [pendingInboxQuickReply, setPendingInboxQuickReply] = useState<{
+		targetSessionId: string;
+		previousActiveSessionId: string | null;
+		text: string;
+	} | null>(null);
+
+	// Flush pending quick-reply once target session is active (deterministic, no RAF timing chain).
+	useEffect(() => {
+		if (!pendingInboxQuickReply) return;
+		if (activeSession?.id !== pendingInboxQuickReply.targetSessionId) return;
+
+		inboxProcessInputRef.current(pendingInboxQuickReply.text);
+		const previousActiveSessionId = pendingInboxQuickReply.previousActiveSessionId;
+		setPendingInboxQuickReply(null);
+
+		if (
+			previousActiveSessionId &&
+			previousActiveSessionId !== pendingInboxQuickReply.targetSessionId
+		) {
+			queueMicrotask(() => {
+				setActiveSessionId(previousActiveSessionId);
+			});
+		}
+	}, [pendingInboxQuickReply, activeSession?.id, setActiveSessionId]);
+
+	// Agent Inbox: Quick Reply — sends text to target session/tab via processInput
+	const handleAgentInboxQuickReply = useCallback(
+		(sessionId: string, tabId: string, text: string) => {
+			// Save current active session so we can restore it after sending.
+			const previousActiveSessionId = activeSessionIdRef.current;
+
+			// Activate the target tab and mark as read (processInput adds the user log entry)
+			setSessions((prev) =>
+				prev.map((s) => {
+					if (s.id !== sessionId) return s;
+					return {
+						...s,
+						activeTabId: tabId,
+						activeFileTabId: null,
+						inputMode: 'ai' as const,
+						aiTabs: s.aiTabs.map((t) => (t.id === tabId ? { ...t, hasUnread: false } : t)),
+					};
+				})
+			);
+
+			// Switch to target session and let the effect above send once state is committed.
+			setPendingInboxQuickReply({
+				targetSessionId: sessionId,
+				previousActiveSessionId,
+				text,
+			});
+			setActiveSessionId(sessionId);
+		},
+		[setSessions, setActiveSessionId, activeSessionIdRef]
+	);
+
+	// Agent Inbox: Open & Reply — navigates to session with pre-filled input
+	const handleAgentInboxOpenAndReply = useCallback(
+		(sessionId: string, tabId: string, text: string) => {
+			setActiveSessionId(sessionId);
+			setSessions((prev) =>
+				prev.map((s) => {
+					if (s.id !== sessionId) return s;
+					return {
+						...s,
+						activeTabId: tabId,
+						activeFileTabId: null,
+						inputMode: 'ai' as const,
+						aiTabs: s.aiTabs.map((t) =>
+							t.id === tabId ? { ...t, inputValue: text, hasUnread: false } : t
+						),
+					};
+				})
+			);
+			setAgentInboxOpen(false);
+		},
+		[setActiveSessionId, setSessions, setAgentInboxOpen]
+	);
+
+	// Agent Inbox: Mark as Read — dismiss unread badge without replying
+	const handleAgentInboxMarkAsRead = useCallback(
+		(sessionId: string, tabId: string) => {
+			setSessions((prev) =>
+				prev.map((s) => {
+					if (s.id !== sessionId) return s;
+					return {
+						...s,
+						aiTabs: s.aiTabs.map((t) => (t.id === tabId ? { ...t, hasUnread: false } : t)),
+					};
+				})
+			);
+		},
+		[setSessions]
+	);
+
+	// Agent Inbox: Toggle thinking mode on a specific tab
+	const handleAgentInboxToggleThinking = useCallback(
+		(sessionId: string, tabId: string, mode: ThinkingMode) => {
+			setSessions((prev) =>
+				prev.map((s) => {
+					if (s.id !== sessionId) return s;
+					return {
+						...s,
+						aiTabs: s.aiTabs.map((t) => {
+							if (t.id !== tabId) return t;
+							if (mode === 'off') {
+								return {
+									...t,
+									showThinking: 'off',
+									logs: t.logs.filter((l) => l.source !== 'thinking' && l.source !== 'tool'),
+								};
+							}
+							return { ...t, showThinking: mode };
+						}),
+					};
+				})
+			);
+		},
+		[setSessions]
+	);
+
 	// --- BATCH HANDLERS (Auto Run processing, quit confirmation, error handling) ---
 	const {
 		startBatchRun,
@@ -1589,6 +1736,9 @@ function MaestroConsoleInner() {
 		sessionsRef,
 		activeSessionIdRef,
 	});
+
+	// Bind the ref so Inbox Quick Reply handlers always call the latest processInput.
+	inboxProcessInputRef.current = processInput;
 
 	// This is used by context transfer to automatically send the transferred context to the agent
 	useEffect(() => {
@@ -3009,6 +3159,7 @@ function MaestroConsoleInner() {
 		setMarketplaceModalOpen,
 		setSymphonyModalOpen,
 		setDirectorNotesOpen,
+		setAgentInboxOpen: encoreFeatures.unifiedInbox ? setAgentInboxOpen : undefined,
 		encoreFeatures,
 		setShowNewGroupChatModal,
 		deleteGroupChatWithConfirmation,
@@ -4099,6 +4250,23 @@ function MaestroConsoleInner() {
 							onFileClick={(path: string) =>
 								handleFileClick({ name: path.split('/').pop() || path, type: 'file' }, path)
 							}
+						/>
+					</Suspense>
+				)}
+
+				{/* --- AGENT INBOX MODAL (lazy-loaded, Encore Feature) --- */}
+				{encoreFeatures.unifiedInbox && agentInboxOpen && (
+					<Suspense fallback={null}>
+						<AgentInbox
+							sessions={sessions}
+							groups={groups}
+							theme={theme}
+							onClose={() => setAgentInboxOpen(false)}
+							onNavigateToSession={handleAgentInboxNavigateToSession}
+							onQuickReply={handleAgentInboxQuickReply}
+							onOpenAndReply={handleAgentInboxOpenAndReply}
+							onMarkAsRead={handleAgentInboxMarkAsRead}
+							onToggleThinking={handleAgentInboxToggleThinking}
 						/>
 					</Suspense>
 				)}

--- a/src/renderer/components/AgentInbox/FocusModeView.tsx
+++ b/src/renderer/components/AgentInbox/FocusModeView.tsx
@@ -732,18 +732,18 @@ export default function FocusModeView({
 	const [replyText, setReplyText] = useState('');
 	const replyInputRef = useRef<HTMLTextAreaElement>(null);
 
-	// Auto-focus reply input when entering focus mode or switching items
+	// Auto-focus reply input when entering focus mode or switching items.
+	// Double rAF ensures focus fires after the browser paints the new item.
 	useEffect(() => {
-		const rafId = requestAnimationFrame(() => {
-			replyInputRef.current?.focus();
+		let innerRafId: number | undefined;
+		const outerRafId = requestAnimationFrame(() => {
+			innerRafId = requestAnimationFrame(() => {
+				replyInputRef.current?.focus();
+			});
 		});
-		// Fallback for heavy render frames where the first focus attempt loses timing.
-		const timeoutId = window.setTimeout(() => {
-			replyInputRef.current?.focus();
-		}, 60);
 		return () => {
-			cancelAnimationFrame(rafId);
-			window.clearTimeout(timeoutId);
+			cancelAnimationFrame(outerRafId);
+			if (innerRafId !== undefined) cancelAnimationFrame(innerRafId);
 		};
 	}, [item.sessionId, item.tabId]);
 

--- a/src/renderer/components/AgentInbox/FocusModeView.tsx
+++ b/src/renderer/components/AgentInbox/FocusModeView.tsx
@@ -1,0 +1,1218 @@
+import { useMemo, useRef, useEffect, useState, useCallback } from 'react';
+import {
+	ArrowLeft,
+	X,
+	Bot,
+	User,
+	ArrowUp,
+	ExternalLink,
+	ChevronLeft,
+	ChevronRight,
+	ChevronDown,
+	Eye,
+	Brain,
+	Pin,
+	FileText,
+} from 'lucide-react';
+import type { Theme, Session, LogEntry, ThinkingMode } from '../../types';
+import type { InboxItem, InboxFilterMode, InboxSortMode } from '../../types/agent-inbox';
+import { STATUS_LABELS, STATUS_COLORS } from '../../types/agent-inbox';
+import { resolveContextUsageColor } from './InboxListView';
+import { formatRelativeTime } from '../../utils/formatters';
+import { MarkdownRenderer } from '../MarkdownRenderer';
+import { generateTerminalProseStyles } from '../../utils/markdownConfig';
+
+/* POLISH-04 Token Audit (@architect)
+ * Line 166: bgSidebar in user bubble color-mix — CORRECT (chrome blend for user messages)
+ * Line 210: bgActivity for AI bubble — CORRECT (content)
+ * Line 429: bgSidebar for sidebar group header — CORRECT (chrome)
+ * Line 722: bgSidebar for focus header — CORRECT (chrome)
+ * Line 818: bgActivity for subheader info bar — CORRECT (content)
+ * Line 904: bgSidebar for sidebar bg — CORRECT (chrome)
+ * Line 1025: bgActivity → bgMain (textarea is nested input, needs contrast)
+ * All other usages: CORRECT
+ */
+
+/* POLISH-03 Design Spec (@ux-design-expert)
+ * BUBBLES:
+ * - All corners: rounded-xl (uniform, no sharp edges)
+ * - Padding: p-4 (remove pb-10 hack)
+ * - Timestamp: inline flex row below content, text-[10px] textDim opacity 0.6, justify-end mt-2
+ * - Left border: user = 3px solid success, AI = 3px solid accent
+ * - Max width: 85% (unchanged)
+ *
+ * SIDEBAR ITEMS:
+ * - Height: 48px (was 36px)
+ * - Layout: status dot + vertical(name, preview) + indicators
+ * - Preview: text-[10px] truncate, textDim opacity 0.5, max 60 chars, strip markdown
+ * - Indicators: alignSelf flex-start, marginTop 2
+ */
+
+// @architect: lastMessage available via InboxItem type (agent-inbox.ts:13) — sidebar scroll OK at 48px (overflow-y-auto, no max-height constraint)
+
+const MAX_LOG_ENTRIES = 50;
+
+function FocusLogEntry({
+	log,
+	theme,
+	showRawMarkdown,
+	onToggleRaw,
+}: {
+	log: LogEntry;
+	theme: Theme;
+	showRawMarkdown: boolean;
+	onToggleRaw: () => void;
+}) {
+	const isUser = log.source === 'user';
+	const isAI = log.source === 'ai' || log.source === 'stdout';
+	const isThinking = log.source === 'thinking';
+	const isTool = log.source === 'tool';
+
+	// Thinking entry — left border accent + badge
+	if (isThinking) {
+		return (
+			<div
+				className="px-4 py-2 text-sm font-mono border-l-2"
+				style={{
+					color: theme.colors.textMain,
+					borderColor: theme.colors.accent,
+				}}
+			>
+				<div className="flex items-center gap-2 mb-1">
+					<span
+						className="text-[10px] px-1.5 py-0.5 rounded"
+						style={{
+							backgroundColor: `${theme.colors.accent}30`,
+							color: theme.colors.accent,
+						}}
+					>
+						thinking
+					</span>
+					<span className="text-xs" style={{ color: theme.colors.textDim, opacity: 0.7 }}>
+						{formatRelativeTime(log.timestamp)}
+					</span>
+				</div>
+				<div
+					style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word', fontSize: 13, lineHeight: 1.5 }}
+				>
+					{log.text}
+				</div>
+			</div>
+		);
+	}
+
+	// Tool entry — compact badge with status
+	if (isTool) {
+		const toolInput = (log.metadata as any)?.toolState?.input as
+			| Record<string, unknown>
+			| undefined;
+		const safeStr = (v: unknown): string | null => (typeof v === 'string' ? v : null);
+		const toolDetail = toolInput
+			? safeStr(toolInput.command) ||
+				safeStr(toolInput.pattern) ||
+				safeStr(toolInput.file_path) ||
+				safeStr(toolInput.query) ||
+				safeStr(toolInput.description) ||
+				safeStr(toolInput.prompt) ||
+				safeStr(toolInput.task_id) ||
+				null
+			: null;
+		const toolStatus = (log.metadata as any)?.toolState?.status as string | undefined;
+
+		return (
+			<div
+				className="px-4 py-1.5 text-xs font-mono border-l-2"
+				style={{
+					color: theme.colors.textMain,
+					borderColor: theme.colors.accent,
+				}}
+			>
+				<div className="flex items-start gap-2">
+					<span
+						className="px-1.5 py-0.5 rounded shrink-0"
+						style={{
+							backgroundColor: `${theme.colors.accent}30`,
+							color: theme.colors.accent,
+						}}
+					>
+						{log.text}
+					</span>
+					{toolStatus === 'running' && (
+						<span className="animate-pulse shrink-0 pt-0.5" style={{ color: theme.colors.warning }}>
+							●
+						</span>
+					)}
+					{toolStatus === 'completed' && (
+						<span className="shrink-0 pt-0.5" style={{ color: theme.colors.success }}>
+							✓
+						</span>
+					)}
+					{toolDetail && (
+						<span
+							className="opacity-70 break-words whitespace-pre-wrap"
+							style={{ color: theme.colors.textMain }}
+						>
+							{toolDetail}
+						</span>
+					)}
+				</div>
+			</div>
+		);
+	}
+
+	// User entry — right-aligned with User icon
+	if (isUser) {
+		return (
+			<div className="flex gap-2" style={{ flexDirection: 'row-reverse' }}>
+				<div
+					className="flex-shrink-0 w-6 h-6 rounded-full flex items-center justify-center"
+					style={{ backgroundColor: `${theme.colors.success}20` }}
+				>
+					<User className="w-3.5 h-3.5" style={{ color: theme.colors.success }} />
+				</div>
+				<div
+					className="flex-1 min-w-0 p-4 rounded-xl border overflow-hidden text-sm"
+					style={{
+						backgroundColor: `color-mix(in srgb, ${theme.colors.accent} 20%, ${theme.colors.bgSidebar})`,
+						borderColor: `${theme.colors.accent}40`,
+						color: theme.colors.textMain,
+						maxWidth: '85%',
+						borderLeft: `3px solid ${theme.colors.success}`,
+					}}
+				>
+					<div
+						style={{
+							whiteSpace: 'pre-wrap',
+							wordBreak: 'break-word',
+							fontSize: 13,
+							lineHeight: 1.5,
+						}}
+					>
+						{log.text}
+					</div>
+					<div className="flex justify-end mt-2">
+						<span className="text-[10px]" style={{ color: theme.colors.textDim, opacity: 0.6 }}>
+							{formatRelativeTime(log.timestamp)}
+						</span>
+					</div>
+				</div>
+			</div>
+		);
+	}
+
+	// AI / stdout entry — left-aligned with Bot icon + markdown
+	if (isAI) {
+		const handleCopy = (text: string) => {
+			navigator.clipboard.writeText(text).catch(() => {});
+		};
+
+		return (
+			<div className="flex gap-2 group">
+				<div
+					className="flex-shrink-0 w-6 h-6 rounded-full flex items-center justify-center"
+					style={{ backgroundColor: `${theme.colors.accent}20` }}
+				>
+					<Bot className="w-3.5 h-3.5" style={{ color: theme.colors.accent }} />
+				</div>
+				<div
+					className="flex-1 min-w-0 p-4 rounded-xl border overflow-hidden text-sm"
+					style={{
+						backgroundColor: theme.colors.bgActivity,
+						borderColor: theme.colors.border,
+						color: theme.colors.textMain,
+						borderLeft: `3px solid ${theme.colors.accent}`,
+					}}
+				>
+					{/* Raw/rendered toggle */}
+					<div className="flex justify-end">
+						<button
+							onClick={onToggleRaw}
+							className="p-1 rounded opacity-0 group-hover:opacity-50 hover:!opacity-100 transition-opacity"
+							style={{ color: showRawMarkdown ? theme.colors.accent : theme.colors.textDim }}
+							title={showRawMarkdown ? 'Show formatted' : 'Show plain text'}
+						>
+							{showRawMarkdown ? (
+								<Eye className="w-3.5 h-3.5" />
+							) : (
+								<FileText className="w-3.5 h-3.5" />
+							)}
+						</button>
+					</div>
+
+					{showRawMarkdown ? (
+						<div
+							style={{
+								whiteSpace: 'pre-wrap',
+								wordBreak: 'break-word',
+								fontSize: 13,
+								lineHeight: 1.5,
+							}}
+						>
+							{log.text}
+						</div>
+					) : (
+						<MarkdownRenderer content={log.text} theme={theme} onCopy={handleCopy} />
+					)}
+
+					<div className="flex justify-end mt-2">
+						<span className="text-[10px]" style={{ color: theme.colors.textDim, opacity: 0.6 }}>
+							{formatRelativeTime(log.timestamp)}
+						</span>
+					</div>
+				</div>
+			</div>
+		);
+	}
+
+	// Fallback — should not reach here given the filter
+	return null;
+}
+
+interface FocusModeViewProps {
+	theme: Theme;
+	item: InboxItem;
+	items: InboxItem[]; // Full filtered+sorted list for prev/next
+	sessions: Session[]; // For accessing AITab.logs
+	currentIndex: number; // Position of item in items[]
+	enterToSendAI?: boolean; // false = Cmd+Enter sends, true = Enter sends
+	filterMode?: InboxFilterMode;
+	setFilterMode?: (mode: InboxFilterMode) => void;
+	sortMode?: InboxSortMode;
+	onClose: () => void; // Close the entire modal
+	onExitFocus: () => void; // Return to list view
+	onNavigateItem: (index: number) => void; // Jump to item at index
+	onNavigateToSession?: (sessionId: string, tabId?: string) => void;
+	onQuickReply?: (sessionId: string, tabId: string, text: string) => void;
+	onOpenAndReply?: (sessionId: string, tabId: string, text: string) => void;
+	onMarkAsRead?: (sessionId: string, tabId: string) => void;
+	onToggleThinking?: (sessionId: string, tabId: string, mode: ThinkingMode) => void;
+}
+
+// Maps STATUS_COLORS key to actual hex from theme
+function resolveStatusColor(state: InboxItem['state'], theme: Theme): string {
+	const colorKey = STATUS_COLORS[state];
+	const colorMap: Record<string, string> = {
+		success: theme.colors.success,
+		warning: theme.colors.warning,
+		error: theme.colors.error,
+		info: theme.colors.accent,
+		textMuted: theme.colors.textDim,
+	};
+	return colorMap[colorKey] ?? theme.colors.textDim;
+}
+
+// ============================================================================
+// Compact filter control for sidebar
+// ============================================================================
+const FILTER_OPTIONS: { value: InboxFilterMode; label: string }[] = [
+	{ value: 'all', label: 'All' },
+	{ value: 'unread', label: 'Unread' },
+	{ value: 'starred', label: 'Starred' },
+];
+
+function SidebarFilter({
+	value,
+	onChange,
+	theme,
+}: {
+	value: InboxFilterMode;
+	onChange: (v: InboxFilterMode) => void;
+	theme: Theme;
+}) {
+	return (
+		<div className="flex items-center gap-1.5">
+			{FILTER_OPTIONS.map((opt) => {
+				const isActive = value === opt.value;
+				return (
+					<button
+						key={opt.value}
+						onClick={() => onChange(opt.value)}
+						className="text-[11px] px-2.5 py-1 rounded-full cursor-pointer transition-all"
+						style={{
+							backgroundColor: isActive ? `${theme.colors.accent}25` : 'transparent',
+							color: isActive ? theme.colors.accentText : theme.colors.textDim,
+							border: isActive ? `1px solid ${theme.colors.accent}50` : '1px solid transparent',
+							outline: 'none',
+							opacity: isActive ? 1 : 0.6,
+						}}
+					>
+						{opt.label}
+					</button>
+				);
+			})}
+		</div>
+	);
+}
+
+// ============================================================================
+// FocusSidebar — condensed navigable list of inbox items with agent grouping
+// ============================================================================
+function FocusSidebar({
+	items,
+	currentIndex,
+	theme,
+	sortMode,
+	filterMode,
+	setFilterMode,
+	onNavigateItem,
+}: {
+	items: InboxItem[];
+	currentIndex: number;
+	theme: Theme;
+	sortMode?: InboxSortMode;
+	filterMode?: InboxFilterMode;
+	setFilterMode?: (mode: InboxFilterMode) => void;
+	onNavigateItem: (index: number) => void;
+}) {
+	const currentRowRef = useRef<HTMLDivElement>(null);
+	const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
+
+	// Auto-scroll to keep the current item visible
+	useEffect(() => {
+		currentRowRef.current?.scrollIntoView({ block: 'nearest' });
+	}, [currentIndex]);
+
+	// Build grouped rows — always group by agent/group to avoid duplicate headers
+	const rows = useMemo(() => {
+		const effectiveSort = sortMode ?? 'newest';
+		const useGroupName = effectiveSort === 'grouped';
+
+		// Collect items per unique group key, preserving original index
+		const groupMap = new Map<
+			string,
+			{ groupName: string; items: { item: InboxItem; index: number }[] }
+		>();
+		const groupOrder: string[] = [];
+		items.forEach((itm, idx) => {
+			const groupKey = useGroupName ? (itm.groupName ?? 'Ungrouped') : itm.sessionId;
+			const groupName = useGroupName ? (itm.groupName ?? 'Ungrouped') : itm.sessionName;
+			if (!groupMap.has(groupKey)) {
+				groupMap.set(groupKey, { groupName, items: [] });
+				groupOrder.push(groupKey);
+			}
+			groupMap.get(groupKey)!.items.push({ item: itm, index: idx });
+		});
+
+		const result: (
+			| { type: 'header'; groupKey: string; groupName: string; count: number }
+			| { type: 'item'; item: InboxItem; index: number }
+		)[] = [];
+		for (const groupKey of groupOrder) {
+			const group = groupMap.get(groupKey)!;
+			result.push({
+				type: 'header',
+				groupKey,
+				groupName: group.groupName,
+				count: group.items.length,
+			});
+			for (const entry of group.items) {
+				result.push({ type: 'item', item: entry.item, index: entry.index });
+			}
+		}
+		return result;
+	}, [items, sortMode]);
+
+	return (
+		<div className="flex flex-col">
+			{/* Filter control header */}
+			{filterMode !== undefined && setFilterMode && (
+				<div
+					className="flex items-center justify-center px-2 py-2 border-b"
+					style={{ borderColor: theme.colors.border }}
+				>
+					<SidebarFilter value={filterMode} onChange={setFilterMode} theme={theme} />
+				</div>
+			)}
+			{/* Item list */}
+			<div className="flex-1 overflow-y-auto py-1">
+				{(() => {
+					let activeGroup: string | null = null;
+					return rows.map((row, rowIdx) => {
+						if (row.type === 'header') {
+							activeGroup = row.groupKey;
+							return (
+								<div
+									key={`header-${row.groupKey}-${rowIdx}`}
+									tabIndex={0}
+									role="option"
+									aria-selected={false}
+									onClick={() => {
+										setCollapsedGroups((prev) => {
+											const next = new Set(prev);
+											if (next.has(row.groupKey)) next.delete(row.groupKey);
+											else next.add(row.groupKey);
+											return next;
+										});
+									}}
+									onKeyDown={(e) => {
+										if (e.key === 'Enter' || e.key === ' ') {
+											e.preventDefault();
+											setCollapsedGroups((prev) => {
+												const next = new Set(prev);
+												if (next.has(row.groupKey)) next.delete(row.groupKey);
+												else next.add(row.groupKey);
+												return next;
+											});
+										}
+									}}
+									className="flex items-center gap-1.5 px-3 py-1.5 text-[10px] uppercase tracking-wider cursor-pointer"
+									style={{
+										color: theme.colors.textDim,
+										fontWeight: 600,
+										backgroundColor: theme.colors.bgSidebar,
+									}}
+								>
+									{collapsedGroups.has(row.groupKey) ? (
+										<ChevronRight className="w-3 h-3" />
+									) : (
+										<ChevronDown className="w-3 h-3" />
+									)}
+									{row.groupName}
+									<span style={{ color: theme.colors.textDim, opacity: 0.5, marginLeft: 'auto' }}>
+										{row.type === 'header' ? row.count : 0}
+									</span>
+								</div>
+							);
+						}
+
+						// Skip items in collapsed groups
+						if (activeGroup && collapsedGroups.has(activeGroup)) return null;
+
+						const itm = row.item;
+						const idx = row.index;
+						const isCurrent = idx === currentIndex;
+						const statusColor = resolveStatusColor(itm.state, theme);
+
+						const previewText = itm.lastMessage
+							? itm.lastMessage.replace(/[#*`>]/g, '').slice(0, 60)
+							: '';
+
+						return (
+							<div
+								key={`${itm.sessionId}-${itm.tabId}`}
+								ref={isCurrent ? currentRowRef : undefined}
+								tabIndex={0}
+								role="option"
+								aria-selected={isCurrent}
+								onClick={() => onNavigateItem(idx)}
+								onKeyDown={(e) => {
+									if (e.key === 'Enter' || e.key === ' ') {
+										e.preventDefault();
+										onNavigateItem(idx);
+									}
+								}}
+								className="flex items-center gap-2 px-3 cursor-pointer transition-colors"
+								style={{
+									height: 48,
+									backgroundColor: isCurrent ? `${theme.colors.accent}15` : 'transparent',
+									borderLeft: isCurrent
+										? `2px solid ${theme.colors.accent}`
+										: '2px solid transparent',
+								}}
+								onMouseEnter={(e) => {
+									if (!isCurrent)
+										e.currentTarget.style.backgroundColor = `${theme.colors.accent}08`;
+								}}
+								onMouseLeave={(e) => {
+									if (!isCurrent) e.currentTarget.style.backgroundColor = 'transparent';
+								}}
+								onFocus={(e) => {
+									if (!isCurrent)
+										e.currentTarget.style.backgroundColor = `${theme.colors.accent}08`;
+								}}
+								onBlur={(e) => {
+									if (!isCurrent) e.currentTarget.style.backgroundColor = 'transparent';
+								}}
+							>
+								{/* Status dot */}
+								<span
+									className="flex-shrink-0"
+									style={{
+										width: 6,
+										height: 6,
+										borderRadius: '50%',
+										backgroundColor: statusColor,
+									}}
+								/>
+								{/* Name + preview vertical stack */}
+								<div className="flex-1 flex flex-col gap-0.5 min-w-0">
+									<span
+										className="text-xs truncate"
+										style={{
+											color: isCurrent ? theme.colors.textMain : theme.colors.textDim,
+											fontWeight: isCurrent ? 600 : 400,
+										}}
+									>
+										{itm.tabName || 'Tab'}
+									</span>
+									{previewText && (
+										<span
+											className="text-[10px] truncate"
+											style={{ color: theme.colors.textDim, opacity: 0.5 }}
+										>
+											{previewText}
+										</span>
+									)}
+								</div>
+								{/* Indicators: unread */}
+								{itm.hasUnread && (
+									<span
+										className="flex-shrink-0"
+										style={{
+											width: 6,
+											height: 6,
+											borderRadius: '50%',
+											backgroundColor: theme.colors.accent,
+											alignSelf: 'flex-start',
+											marginTop: 2,
+										}}
+									/>
+								)}
+							</div>
+						);
+					});
+				})()}
+			</div>
+		</div>
+	);
+}
+
+export default function FocusModeView({
+	theme,
+	item,
+	items,
+	sessions,
+	currentIndex,
+	enterToSendAI,
+	filterMode,
+	setFilterMode,
+	sortMode,
+	onClose,
+	onExitFocus,
+	onNavigateItem,
+	onQuickReply,
+	onOpenAndReply,
+	onMarkAsRead: _onMarkAsRead,
+	onToggleThinking,
+}: FocusModeViewProps) {
+	const statusColor = resolveStatusColor(item.state, theme);
+	const hasValidContext = item.contextUsage !== undefined && !isNaN(item.contextUsage);
+
+	// ---- Resizable sidebar ----
+	const [sidebarWidth, setSidebarWidth] = useState(220);
+	const isResizingRef = useRef(false);
+	const resizeCleanupRef = useRef<(() => void) | null>(null);
+
+	// Unmount safety: clean up resize listeners if component unmounts mid-drag
+	useEffect(() => {
+		return () => {
+			resizeCleanupRef.current?.();
+			resizeCleanupRef.current = null;
+		};
+	}, []);
+
+	const handleResizeStart = useCallback(
+		(e: React.MouseEvent) => {
+			e.preventDefault();
+			isResizingRef.current = true;
+			const startX = e.clientX;
+			const startWidth = sidebarWidth;
+
+			const onMouseMove = (ev: MouseEvent) => {
+				if (!isResizingRef.current) return;
+				const newWidth = Math.max(160, Math.min(400, startWidth + (ev.clientX - startX)));
+				setSidebarWidth(newWidth);
+			};
+
+			const cleanup = () => {
+				isResizingRef.current = false;
+				document.removeEventListener('mousemove', onMouseMove);
+				document.removeEventListener('mouseup', onMouseUp);
+				document.body.style.cursor = '';
+				document.body.style.userSelect = '';
+				resizeCleanupRef.current = null;
+			};
+
+			const onMouseUp = () => {
+				cleanup();
+			};
+
+			resizeCleanupRef.current = cleanup;
+			document.addEventListener('mousemove', onMouseMove);
+			document.addEventListener('mouseup', onMouseUp);
+			document.body.style.cursor = 'col-resize';
+			document.body.style.userSelect = 'none';
+		},
+		[sidebarWidth]
+	);
+	const contextColor = hasValidContext
+		? resolveContextUsageColor(item.contextUsage!, theme)
+		: undefined;
+
+	// Truncate helper
+	const truncate = (str: string, max: number) =>
+		str.length > max ? str.slice(0, max) + '...' : str;
+
+	// Session existence check (session may be deleted while focus mode is open)
+	const sessionExists = sessions.some((s) => s.id === item.sessionId);
+
+	// ---- Thinking toggle state (3-state: off → on → sticky → off) ----
+	// Read showThinking from the actual tab property (synced with main app)
+	const showThinking: ThinkingMode = useMemo(() => {
+		const session = sessions.find((s) => s.id === item.sessionId);
+		if (!session) return 'off';
+		const tab = session.aiTabs.find((t) => t.id === item.tabId);
+		return tab?.showThinking ?? 'off';
+	}, [sessions, item.sessionId, item.tabId]);
+
+	const cycleThinking = useCallback(() => {
+		const nextMode: ThinkingMode =
+			showThinking === 'off' ? 'on' : showThinking === 'on' ? 'sticky' : 'off';
+		if (onToggleThinking) {
+			onToggleThinking(item.sessionId, item.tabId, nextMode);
+		}
+	}, [showThinking, item.sessionId, item.tabId, onToggleThinking]);
+
+	// ---- Raw markdown toggle (per-session, not per-log) ----
+	const [showRawMarkdown, setShowRawMarkdown] = useState(false);
+
+	// Compute conversation tail — last N renderable log entries
+	const logs = useMemo(() => {
+		const session = sessions.find((s) => s.id === item.sessionId);
+		if (!session) return [];
+		const tab = session.aiTabs.find((t) => t.id === item.tabId);
+		if (!tab) return [];
+		// Include all renderable log types
+		const relevant = tab.logs.filter(
+			(log) =>
+				log.source === 'ai' ||
+				log.source === 'stdout' ||
+				log.source === 'user' ||
+				log.source === 'thinking' ||
+				log.source === 'tool'
+		);
+		// Take last N entries
+		return relevant.slice(-MAX_LOG_ENTRIES);
+	}, [sessions, item.sessionId, item.tabId]);
+
+	// Filter out thinking/tool when toggle is off
+	const visibleLogs = useMemo(() => {
+		if (showThinking !== 'off') return logs;
+		return logs.filter((log) => log.source !== 'thinking' && log.source !== 'tool');
+	}, [logs, showThinking]);
+
+	// Memoized prose styles — same as TerminalOutput, scoped to .focus-mode-prose
+	const proseStyles = useMemo(
+		() => generateTerminalProseStyles(theme, '.focus-mode-prose'),
+		[theme]
+	);
+
+	// Auto-scroll to bottom ONLY if user is near bottom (within 150px) or item changed
+	const scrollRef = useRef<HTMLDivElement>(null);
+	const prevScrollItemRef = useRef<string>('');
+
+	useEffect(() => {
+		if (!scrollRef.current) return;
+		const el = scrollRef.current;
+		const itemKey = `${item.sessionId}:${item.tabId}`;
+		const isNewItem = prevScrollItemRef.current !== itemKey;
+		if (isNewItem) {
+			prevScrollItemRef.current = itemKey;
+			el.scrollTop = el.scrollHeight;
+			return;
+		}
+		// Only auto-scroll if user is near bottom
+		const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+		if (distanceFromBottom < 150) {
+			el.scrollTop = el.scrollHeight;
+		}
+	}, [visibleLogs, item.sessionId, item.tabId]);
+
+	// ---- Reply state ----
+	const [replyText, setReplyText] = useState('');
+	const replyInputRef = useRef<HTMLTextAreaElement>(null);
+
+	// Auto-focus reply input when entering focus mode or switching items
+	useEffect(() => {
+		const rafId = requestAnimationFrame(() => {
+			replyInputRef.current?.focus();
+		});
+		// Fallback for heavy render frames where the first focus attempt loses timing.
+		const timeoutId = window.setTimeout(() => {
+			replyInputRef.current?.focus();
+		}, 60);
+		return () => {
+			cancelAnimationFrame(rafId);
+			window.clearTimeout(timeoutId);
+		};
+	}, [item.sessionId, item.tabId]);
+
+	// Reset reply text when item changes (prev/next navigation)
+	useEffect(() => {
+		setReplyText('');
+	}, [item.sessionId, item.tabId]);
+
+	const handleQuickReply = useCallback(() => {
+		const text = replyText.trim();
+		if (!text) return;
+		if (onQuickReply) {
+			onQuickReply(item.sessionId, item.tabId, text);
+		}
+		setReplyText('');
+	}, [replyText, item, onQuickReply]);
+
+	const handleOpenAndReply = useCallback(() => {
+		const text = replyText.trim();
+		if (!text) return;
+		if (onOpenAndReply) {
+			onOpenAndReply(item.sessionId, item.tabId, text);
+		}
+	}, [replyText, item, onOpenAndReply]);
+
+	// ---- Smooth transition on item change ----
+	const [isTransitioning, setIsTransitioning] = useState(false);
+	const prevItemRef = useRef<string>(`${item.sessionId}-${item.tabId}`);
+
+	useEffect(() => {
+		const currentKey = `${item.sessionId}-${item.tabId}`;
+		if (prevItemRef.current !== currentKey) {
+			setIsTransitioning(true);
+			const timer = setTimeout(() => setIsTransitioning(false), 150);
+			prevItemRef.current = currentKey;
+			return () => clearTimeout(timer);
+		}
+	}, [item.sessionId, item.tabId]);
+
+	// Mark as read only on explicit interaction (reply), not on view.
+	// This preserves the Unread filter — items stay unread until the user acts.
+
+	return (
+		<div className="flex flex-col flex-1" style={{ minHeight: 0 }}>
+			{/* Header bar */}
+			<div
+				className="flex items-center px-4 py-3 border-b"
+				style={{
+					backgroundColor: theme.colors.bgSidebar,
+					borderColor: theme.colors.border,
+				}}
+			>
+				{/* Left: Back button */}
+				<button
+					aria-label="Return to inbox list"
+					onClick={onExitFocus}
+					className="flex items-center gap-1.5 text-sm font-medium"
+					style={{
+						background: 'transparent',
+						border: 'none',
+						cursor: 'pointer',
+						color: theme.colors.textDim,
+						padding: 0,
+					}}
+					onMouseEnter={(e) => (e.currentTarget.style.color = theme.colors.textMain)}
+					onMouseLeave={(e) => (e.currentTarget.style.color = theme.colors.textDim)}
+				>
+					<ArrowLeft style={{ width: 16, height: 16 }} />
+					<span>Inbox</span>
+				</button>
+
+				{/* Center: GROUP | Agent name · tab */}
+				<div
+					className="flex-1 flex items-center justify-center gap-1"
+					style={{ overflow: 'hidden' }}
+				>
+					{item.groupName && (
+						<>
+							<span
+								className="text-xs"
+								style={{
+									color: theme.colors.textDim,
+									whiteSpace: 'nowrap',
+									textTransform: 'uppercase',
+									letterSpacing: '0.5px',
+								}}
+							>
+								{item.groupName}
+							</span>
+							<span className="text-xs" style={{ color: theme.colors.textDim, padding: '0 4px' }}>
+								|
+							</span>
+						</>
+					)}
+					<span
+						className="text-lg font-semibold"
+						style={{
+							color: theme.colors.textMain,
+							whiteSpace: 'nowrap',
+							overflow: 'hidden',
+							textOverflow: 'ellipsis',
+						}}
+					>
+						{truncate(item.sessionName, 30)}
+					</span>
+					{item.tabName && (
+						<>
+							<span className="text-xs" style={{ color: theme.colors.textDim }}>
+								·
+							</span>
+							<span
+								className="text-xs"
+								style={{
+									color: theme.colors.textDim,
+									whiteSpace: 'nowrap',
+									overflow: 'hidden',
+									textOverflow: 'ellipsis',
+								}}
+							>
+								{item.tabName}
+							</span>
+						</>
+					)}
+					{/* TODO: cost badge — needs InboxItem.cost field */}
+				</div>
+
+				{/* Right: Close button */}
+				<button
+					onClick={onClose}
+					className="p-1.5 rounded"
+					style={{ color: theme.colors.textDim }}
+					onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = `${theme.colors.accent}20`)}
+					onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = 'transparent')}
+					title="Close (Esc)"
+				>
+					<X className="w-4 h-4" />
+				</button>
+			</div>
+
+			{/* Subheader info bar — 32px */}
+			<div
+				className="flex items-center justify-end px-4 py-2 gap-3 text-xs border-b"
+				style={{
+					borderColor: theme.colors.border,
+					backgroundColor: theme.colors.bgActivity,
+					color: theme.colors.textDim,
+				}}
+			>
+				{item.gitBranch && (
+					<span
+						className="px-1.5 py-0.5 rounded"
+						style={{
+							fontFamily: "'SF Mono', 'Menlo', monospace",
+							backgroundColor: `${theme.colors.border}40`,
+							color: theme.colors.textDim,
+						}}
+					>
+						{truncate(item.gitBranch, 25)}
+					</span>
+				)}
+				{hasValidContext && (
+					<span style={{ color: contextColor }}>Context: {item.contextUsage}%</span>
+				)}
+				<span
+					style={{
+						padding: '1px 8px',
+						borderRadius: 10,
+						backgroundColor: `${statusColor}20`,
+						color: statusColor,
+						whiteSpace: 'nowrap',
+					}}
+				>
+					{STATUS_LABELS[item.state]}
+				</span>
+				{/* Thinking toggle — 3-state: off → on → sticky → off */}
+				<button
+					onClick={cycleThinking}
+					className={`flex items-center gap-1.5 text-[10px] px-2 py-1 rounded-full cursor-pointer transition-all ${
+						showThinking !== 'off' ? '' : 'opacity-40 hover:opacity-70'
+					}`}
+					style={{
+						backgroundColor:
+							showThinking === 'sticky'
+								? `${theme.colors.warning}30`
+								: showThinking === 'on'
+									? `${theme.colors.accentText}25`
+									: 'transparent',
+						color:
+							showThinking === 'sticky'
+								? theme.colors.warning
+								: showThinking === 'on'
+									? theme.colors.accentText
+									: theme.colors.textDim,
+						border:
+							showThinking === 'sticky'
+								? `1px solid ${theme.colors.warning}50`
+								: showThinking === 'on'
+									? `1px solid ${theme.colors.accentText}50`
+									: '1px solid transparent',
+					}}
+					title={
+						showThinking === 'off'
+							? 'Show Thinking - Click to stream AI reasoning'
+							: showThinking === 'on'
+								? 'Thinking (temporary) - Click for sticky mode'
+								: 'Thinking (sticky) - Click to turn off'
+					}
+				>
+					<Brain className="w-3 h-3" />
+					<span>Thinking</span>
+					{showThinking === 'sticky' && <Pin className="w-2.5 h-2.5" />}
+				</button>
+			</div>
+
+			{/* Prose styles for markdown rendering — injected once at container level */}
+			<style>{proseStyles}</style>
+
+			{/* Two-column layout: sidebar + main content */}
+			<div className="flex flex-1" style={{ minHeight: 0 }}>
+				{/* Sidebar mini-list */}
+				<div
+					className="flex-shrink-0 overflow-y-auto"
+					style={{
+						width: sidebarWidth,
+						borderColor: theme.colors.border,
+						backgroundColor: theme.colors.bgSidebar,
+					}}
+					data-testid="focus-sidebar"
+				>
+					<FocusSidebar
+						items={items}
+						currentIndex={currentIndex}
+						theme={theme}
+						sortMode={sortMode}
+						filterMode={filterMode}
+						setFilterMode={setFilterMode}
+						onNavigateItem={onNavigateItem}
+					/>
+				</div>
+
+				{/* Resize handle */}
+				<div
+					onMouseDown={handleResizeStart}
+					style={{
+						width: 4,
+						cursor: 'col-resize',
+						backgroundColor: 'transparent',
+						borderRight: `1px solid ${theme.colors.border}`,
+						flexShrink: 0,
+					}}
+					onMouseEnter={(e) => {
+						e.currentTarget.style.backgroundColor = `${theme.colors.accent}30`;
+					}}
+					onMouseLeave={(e) => {
+						if (!isResizingRef.current) {
+							e.currentTarget.style.backgroundColor = 'transparent';
+						}
+					}}
+				/>
+
+				{/* Main content: conversation body + reply input */}
+				<div className="flex-1 flex flex-col" style={{ minWidth: 0, minHeight: 0 }}>
+					{/* Body — conversation tail */}
+					{!sessionExists ? (
+						<div
+							className="flex-1 flex items-center justify-center"
+							style={{ color: theme.colors.textDim }}
+						>
+							<span className="text-sm">Agent no longer available</span>
+						</div>
+					) : (
+						<div
+							ref={scrollRef}
+							role="log"
+							aria-label="Agent conversation"
+							className="focus-mode-prose flex-1 overflow-y-auto p-4"
+							style={{
+								minHeight: 0,
+								opacity: isTransitioning ? 0.3 : 1,
+								transition: 'opacity 150ms ease',
+							}}
+						>
+							{visibleLogs.length === 0 ? (
+								<div
+									className="flex items-center justify-center h-full"
+									style={{ color: theme.colors.textDim }}
+								>
+									<span className="text-sm">No conversation yet</span>
+								</div>
+							) : (
+								<div className="flex flex-col gap-3">
+									{visibleLogs.map((log) => (
+										<FocusLogEntry
+											key={log.id}
+											log={log}
+											theme={theme}
+											showRawMarkdown={showRawMarkdown}
+											onToggleRaw={() => setShowRawMarkdown((v) => !v)}
+										/>
+									))}
+								</div>
+							)}
+						</div>
+					)}
+
+					{/* Reply input bar */}
+					<div
+						className="flex items-center gap-2 px-4 py-3 border-t"
+						style={{ borderColor: theme.colors.border }}
+					>
+						<textarea
+							ref={replyInputRef}
+							value={replyText}
+							onChange={(e) => setReplyText(e.target.value)}
+							onKeyDown={(e) => {
+								if (e.key === 'Enter') {
+									if (enterToSendAI) {
+										// Enter sends, Shift+Enter = Open & Reply
+										if (!e.shiftKey && !e.metaKey) {
+											e.preventDefault();
+											handleQuickReply();
+										} else if (e.shiftKey && !e.metaKey) {
+											e.preventDefault();
+											handleOpenAndReply();
+										}
+									} else {
+										// Cmd+Enter sends, Shift+Enter = Open & Reply
+										if (e.metaKey && !e.shiftKey) {
+											e.preventDefault();
+											handleQuickReply();
+										} else if (e.shiftKey && !e.metaKey) {
+											e.preventDefault();
+											handleOpenAndReply();
+										}
+									}
+									e.stopPropagation();
+									return;
+								}
+								// CRITICAL: Prevent focus-mode keyboard shortcuts from firing while typing
+								e.stopPropagation();
+							}}
+							placeholder="Reply to agent..."
+							rows={1}
+							aria-label="Reply to agent"
+							className="flex-1 resize-none rounded-lg px-3 py-2 text-sm outline-none"
+							style={{
+								backgroundColor: theme.colors.bgMain, // token: bgSidebar=chrome | bgActivity=content | bgMain=nested
+								color: theme.colors.textMain,
+								border: `1px solid ${theme.colors.border}`,
+								minHeight: 36,
+								maxHeight: 80,
+							}}
+							onInput={(e) => {
+								// Auto-resize textarea
+								const target = e.target as HTMLTextAreaElement;
+								target.style.height = 'auto';
+								target.style.height = Math.min(target.scrollHeight, 80) + 'px';
+							}}
+						/>
+						{/* Quick Reply button (primary) */}
+						<button
+							onClick={handleQuickReply}
+							disabled={!replyText.trim()}
+							className="p-2 rounded-lg transition-colors flex-shrink-0"
+							style={{
+								backgroundColor: replyText.trim()
+									? theme.colors.accent
+									: `${theme.colors.accent}30`,
+								color: replyText.trim() ? theme.colors.accentForeground : theme.colors.textDim,
+								cursor: replyText.trim() ? 'pointer' : 'default',
+							}}
+							title={enterToSendAI ? 'Quick reply (Enter)' : 'Quick reply (⌘Enter)'}
+						>
+							<ArrowUp className="w-4 h-4" />
+						</button>
+						{/* Open & Reply button (secondary) */}
+						<button
+							onClick={handleOpenAndReply}
+							disabled={!replyText.trim()}
+							className="p-1.5 rounded-lg transition-colors flex-shrink-0 text-xs"
+							style={{
+								border: `1px solid ${theme.colors.border}`,
+								color: replyText.trim() ? theme.colors.textMain : theme.colors.textDim,
+								backgroundColor: 'transparent',
+								cursor: replyText.trim() ? 'pointer' : 'default',
+								opacity: replyText.trim() ? 1 : 0.5,
+							}}
+							title="Open session & reply (Shift+Enter)"
+						>
+							<ExternalLink className="w-3.5 h-3.5" />
+						</button>
+					</div>
+				</div>
+			</div>
+
+			{/* Footer — 44px */}
+			<div
+				className="flex items-center justify-between px-4 border-t"
+				style={{
+					height: 44,
+					borderColor: theme.colors.border,
+				}}
+			>
+				{/* Prev button */}
+				<button
+					onClick={() => onNavigateItem((currentIndex - 1 + items.length) % items.length)}
+					disabled={items.length <= 1}
+					aria-disabled={items.length <= 1 ? 'true' : undefined}
+					className="flex items-center gap-1 text-xs px-3 py-1.5 rounded transition-colors"
+					style={{
+						border: `1px solid ${theme.colors.border}`,
+						color: items.length > 1 ? theme.colors.textMain : theme.colors.textDim,
+						backgroundColor: 'transparent',
+						cursor: items.length > 1 ? 'pointer' : 'default',
+						opacity: items.length <= 1 ? 0.4 : 1,
+					}}
+					onMouseEnter={(e) => {
+						if (items.length > 1)
+							e.currentTarget.style.backgroundColor = `${theme.colors.accent}10`;
+					}}
+					onMouseLeave={(e) => {
+						e.currentTarget.style.backgroundColor = 'transparent';
+					}}
+					title="Previous item (⌘←)"
+				>
+					<ChevronLeft className="w-3 h-3" />
+					Prev
+				</button>
+
+				{/* Center: counter + keyboard hints */}
+				<div className="flex flex-col items-center gap-0.5">
+					<span
+						aria-live="polite"
+						className="text-sm font-medium"
+						style={{ color: theme.colors.textMain }}
+					>
+						{currentIndex + 1} / {items.length}
+					</span>
+					<span className="text-xs" style={{ color: theme.colors.textDim, opacity: 0.6 }}>
+						⌘←→ Navigate · Esc Back
+					</span>
+				</div>
+
+				{/* Next button */}
+				<button
+					onClick={() => onNavigateItem((currentIndex + 1) % items.length)}
+					disabled={items.length <= 1}
+					aria-disabled={items.length <= 1 ? 'true' : undefined}
+					className="flex items-center gap-1 text-xs px-3 py-1.5 rounded transition-colors"
+					style={{
+						border: `1px solid ${theme.colors.border}`,
+						color: items.length > 1 ? theme.colors.textMain : theme.colors.textDim,
+						backgroundColor: 'transparent',
+						cursor: items.length > 1 ? 'pointer' : 'default',
+						opacity: items.length <= 1 ? 0.4 : 1,
+					}}
+					onMouseEnter={(e) => {
+						if (items.length > 1)
+							e.currentTarget.style.backgroundColor = `${theme.colors.accent}10`;
+					}}
+					onMouseLeave={(e) => {
+						e.currentTarget.style.backgroundColor = 'transparent';
+					}}
+					title="Next item (⌘→)"
+				>
+					Next
+					<ChevronRight className="w-3 h-3" />
+				</button>
+			</div>
+		</div>
+	);
+}

--- a/src/renderer/components/AgentInbox/InboxListView.tsx
+++ b/src/renderer/components/AgentInbox/InboxListView.tsx
@@ -1,0 +1,1296 @@
+import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
+import { useVirtualizer } from '@tanstack/react-virtual';
+import { X, CheckCircle, ChevronDown, ChevronRight, Maximize2, Minimize2, Bot } from 'lucide-react';
+import type { Theme, SessionState } from '../../types';
+import type { InboxItem, InboxFilterMode, InboxSortMode } from '../../types/agent-inbox';
+import { STATUS_LABELS, STATUS_COLORS } from '../../types/agent-inbox';
+import { formatRelativeTime } from '../../utils/formatters';
+import { formatShortcutKeys } from '../../utils/shortcutFormatter';
+import { getModalActions } from '../../stores/modalStore';
+
+interface InboxListViewProps {
+	theme: Theme;
+	items: InboxItem[];
+	selectedIndex: number;
+	setSelectedIndex: React.Dispatch<React.SetStateAction<number>>;
+	filterMode: InboxFilterMode;
+	setFilterMode: (mode: InboxFilterMode) => void;
+	sortMode: InboxSortMode;
+	setSortMode: (mode: InboxSortMode) => void;
+	onClose: () => void;
+	onNavigateToSession?: (sessionId: string, tabId?: string) => void;
+	onEnterFocus: (item: InboxItem) => void;
+	containerRef: React.RefObject<HTMLDivElement | null>;
+	keyDownRef?: React.MutableRefObject<((e: React.KeyboardEvent) => void) | null>;
+	isExpanded: boolean;
+	onToggleExpanded: (expanded: boolean | ((prev: boolean) => boolean)) => void;
+}
+
+const ITEM_HEIGHT = 132;
+const GROUP_HEADER_HEIGHT = 36;
+const MODAL_HEADER_HEIGHT = 80;
+const MODAL_FOOTER_HEIGHT = 36;
+const STATS_BAR_HEIGHT = 32;
+
+// ============================================================================
+// Empty state messages per filter mode
+// ============================================================================
+const EMPTY_STATE_MESSAGES: Record<InboxFilterMode, { text: string; showIcon: boolean }> = {
+	all: { text: 'No active agents to show.', showIcon: true },
+	unread: { text: 'No unread agents.', showIcon: false },
+	read: { text: 'No read agents with activity.', showIcon: false },
+	starred: { text: 'No starred agents.', showIcon: false },
+};
+
+// ============================================================================
+// Grouped list model: interleaves group headers with items when sort = 'grouped'
+// ============================================================================
+type ListRow =
+	| { type: 'header'; groupKey: string; groupName: string }
+	| { type: 'item'; item: InboxItem; index: number };
+
+function buildRows(items: InboxItem[], sortMode: InboxSortMode): ListRow[] {
+	if (sortMode !== 'grouped' && sortMode !== 'byAgent') {
+		return items.map((item, index) => ({ type: 'item' as const, item, index }));
+	}
+	const rows: ListRow[] = [];
+	let lastGroupKey: string | null = null;
+	let itemIndex = 0;
+	for (const item of items) {
+		// For 'grouped': group by Left Bar group name
+		// For 'byAgent': group by sessionId (unique) and display sessionName
+		const groupKey = sortMode === 'byAgent' ? item.sessionId : (item.groupName ?? 'Ungrouped');
+		const groupName = sortMode === 'byAgent' ? item.sessionName : (item.groupName ?? 'Ungrouped');
+		if (groupKey !== lastGroupKey) {
+			rows.push({ type: 'header', groupKey, groupName });
+			lastGroupKey = groupKey;
+		}
+		rows.push({ type: 'item', item, index: itemIndex });
+		itemIndex++;
+	}
+	return rows;
+}
+
+// ============================================================================
+// STATUS color resolver — maps STATUS_COLORS key to actual hex
+// ============================================================================
+function resolveStatusColor(state: SessionState, theme: Theme): string {
+	const colorKey = STATUS_COLORS[state];
+	const colorMap: Record<string, string> = {
+		success: theme.colors.success,
+		warning: theme.colors.warning,
+		error: theme.colors.error,
+		info: theme.colors.accent,
+		textMuted: theme.colors.textDim,
+	};
+	return colorMap[colorKey] ?? theme.colors.textDim;
+}
+
+// ============================================================================
+// Context usage color resolver — green/orange/red thresholds
+// ============================================================================
+export function resolveContextUsageColor(percentage: number, theme: Theme): string {
+	if (percentage >= 80) return theme.colors.error;
+	if (percentage >= 60) return theme.colors.warning;
+	return theme.colors.success;
+}
+
+// ============================================================================
+// InboxItemCard — rendered inside each row
+// ============================================================================
+function InboxItemCardContent({
+	item,
+	theme,
+	isSelected,
+	onClick,
+	onDoubleClick,
+}: {
+	item: InboxItem;
+	theme: Theme;
+	isSelected: boolean;
+	onClick: () => void;
+	onDoubleClick?: () => void;
+}) {
+	const statusColor = resolveStatusColor(item.state, theme);
+	const hasValidContext = item.contextUsage !== undefined && !isNaN(item.contextUsage);
+	const contextColor = hasValidContext
+		? resolveContextUsageColor(item.contextUsage!, theme)
+		: undefined;
+
+	return (
+		<div
+			role="option"
+			aria-selected={isSelected}
+			id={`inbox-item-${item.sessionId}-${item.tabId}`}
+			tabIndex={isSelected ? 0 : -1}
+			onClick={onClick}
+			onDoubleClick={onDoubleClick}
+			style={{
+				height: ITEM_HEIGHT - 12,
+				borderRadius: 8,
+				cursor: 'pointer',
+				backgroundColor: isSelected ? `${theme.colors.accent}15` : 'transparent',
+				display: 'flex',
+				flexDirection: 'column',
+				justifyContent: 'space-between',
+				overflow: 'hidden',
+				position: 'relative',
+			}}
+			onFocus={(e) => {
+				e.currentTarget.style.outline = `2px solid ${theme.colors.accent}`;
+				e.currentTarget.style.outlineOffset = '-2px';
+			}}
+			onBlur={(e) => {
+				e.currentTarget.style.outline = 'none';
+			}}
+		>
+			{/* Card content — horizontal flex with agent icon + details */}
+			<div
+				style={{
+					padding: '12px 16px',
+					display: 'flex',
+					alignItems: 'center',
+					gap: 10,
+					flex: 1,
+				}}
+			>
+				{/* Agent icon */}
+				<div
+					style={{
+						width: 28,
+						height: 28,
+						borderRadius: 6,
+						display: 'flex',
+						alignItems: 'center',
+						justifyContent: 'center',
+						backgroundColor: `${theme.colors.accent}15`,
+						flexShrink: 0,
+					}}
+				>
+					<Bot style={{ width: 14, height: 14, color: theme.colors.accent }} />
+				</div>
+				{/* Card details */}
+				<div
+					style={{
+						display: 'flex',
+						flexDirection: 'column',
+						justifyContent: 'center',
+						gap: 6,
+						flex: 1,
+						minWidth: 0,
+					}}
+				>
+					{/* Row 1: GROUP | session | tab    timestamp */}
+					<div style={{ display: 'flex', alignItems: 'center', gap: 0 }}>
+						{item.groupName && (
+							<>
+								<span
+									style={{
+										fontSize: 12,
+										color: theme.colors.textDim,
+										whiteSpace: 'nowrap',
+										textTransform: 'uppercase',
+										letterSpacing: '0.5px',
+									}}
+								>
+									{item.groupName}
+								</span>
+								<span style={{ fontSize: 12, color: theme.colors.textDim, padding: '0 6px' }}>
+									|
+								</span>
+							</>
+						)}
+						<span
+							style={{
+								fontSize: 14,
+								fontWeight: 600,
+								color: theme.colors.textMain,
+								overflow: 'hidden',
+								textOverflow: 'ellipsis',
+								whiteSpace: 'nowrap',
+								flex: 1,
+							}}
+						>
+							{item.sessionName}
+							{item.tabName && (
+								<>
+									<span
+										style={{
+											fontSize: 12,
+											color: theme.colors.textDim,
+											padding: '0 6px',
+											fontWeight: 400,
+										}}
+									>
+										|
+									</span>
+									<span style={{ fontWeight: 400, color: theme.colors.textDim }}>
+										{item.tabName}
+									</span>
+								</>
+							)}
+						</span>
+						<span
+							style={{
+								fontSize: 12,
+								color: theme.colors.textDim,
+								whiteSpace: 'nowrap',
+								flexShrink: 0,
+							}}
+						>
+							{formatRelativeTime(item.timestamp)}
+						</span>
+					</div>
+
+					{/* Row 2: last message (2-line clamp) */}
+					<div
+						style={{
+							fontSize: 12,
+							color: theme.colors.textDim,
+							overflow: 'hidden',
+							display: '-webkit-box',
+							WebkitLineClamp: 2,
+							WebkitBoxOrient: 'vertical' as const,
+							lineHeight: '1.4',
+						}}
+					>
+						{item.lastMessage}
+					</div>
+
+					{/* Row 3: badges */}
+					<div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+						{item.gitBranch && (
+							<span
+								data-testid="git-branch-badge"
+								style={{
+									fontSize: 11,
+									fontFamily: "'SF Mono', 'Menlo', monospace",
+									padding: '1px 6px',
+									borderRadius: 4,
+									backgroundColor: `${theme.colors.accent}15`,
+									color: theme.colors.accent,
+									whiteSpace: 'nowrap',
+									overflow: 'hidden',
+									textOverflow: 'ellipsis',
+									maxWidth: 200,
+								}}
+							>
+								⎇{' '}
+								{item.gitBranch.length > 25 ? item.gitBranch.slice(0, 25) + '...' : item.gitBranch}
+							</span>
+						)}
+						<span
+							data-testid="context-usage-text"
+							style={{
+								fontSize: 11,
+								color: hasValidContext ? contextColor : theme.colors.textDim,
+							}}
+						>
+							{hasValidContext ? `Context: ${item.contextUsage}%` : 'Context: \u2014'}
+						</span>
+						<span
+							style={{
+								fontSize: 11,
+								padding: '1px 8px',
+								borderRadius: 10,
+								backgroundColor: `${statusColor}20`,
+								color: statusColor,
+								whiteSpace: 'nowrap',
+							}}
+						>
+							{STATUS_LABELS[item.state]}
+						</span>
+					</div>
+				</div>
+			</div>
+
+			{/* Context usage bar — 4px at bottom of card */}
+			{hasValidContext && (
+				<div
+					data-testid="context-usage-bar"
+					title={`Context window: ${item.contextUsage}% used`}
+					style={{
+						height: 4,
+						width: '100%',
+						backgroundColor: `${theme.colors.border}40`,
+						flexShrink: 0,
+					}}
+				>
+					<div
+						style={{
+							height: '100%',
+							width: `${Math.min(Math.max(item.contextUsage!, 0), 100)}%`,
+							backgroundColor: contextColor,
+							borderRadius: item.contextUsage! >= 100 ? 0 : '0 2px 2px 0',
+							transition: 'width 0.3s ease',
+						}}
+					/>
+				</div>
+			)}
+		</div>
+	);
+}
+
+// ============================================================================
+// SegmentedControl
+// ============================================================================
+interface SegmentedControlProps<T extends string> {
+	options: { value: T; label: string }[];
+	value: T;
+	onChange: (value: T) => void;
+	theme: Theme;
+	ariaLabel?: string;
+}
+
+function SegmentedControl<T extends string>({
+	options,
+	value,
+	onChange,
+	theme,
+	ariaLabel,
+}: SegmentedControlProps<T>) {
+	return (
+		<div
+			aria-label={ariaLabel}
+			style={{
+				display: 'inline-flex',
+				gap: 2,
+				borderRadius: 8,
+			}}
+		>
+			{options.map((opt) => {
+				const isActive = value === opt.value;
+				return (
+					<button
+						key={opt.value}
+						aria-pressed={isActive}
+						onClick={() => onChange(opt.value)}
+						style={{
+							padding: '4px 12px',
+							fontSize: 12,
+							border: 'none',
+							borderRadius: 8,
+							cursor: 'pointer',
+							transition: 'background 150ms ease',
+							backgroundColor: isActive ? `${theme.colors.accent}20` : 'transparent',
+							color: isActive ? theme.colors.accent : theme.colors.textDim,
+							outline: 'none',
+						}}
+						onMouseEnter={(e) => {
+							if (!isActive) {
+								e.currentTarget.style.backgroundColor = `${theme.colors.accent}10`;
+							}
+						}}
+						onMouseLeave={(e) => {
+							if (!isActive) {
+								e.currentTarget.style.backgroundColor = 'transparent';
+							}
+						}}
+						onFocus={(e) => {
+							e.currentTarget.style.outline = `2px solid ${theme.colors.accent}`;
+							e.currentTarget.style.outlineOffset = '-2px';
+						}}
+						onBlur={(e) => {
+							e.currentTarget.style.outline = 'none';
+						}}
+					>
+						{opt.label}
+					</button>
+				);
+			})}
+		</div>
+	);
+}
+
+// ============================================================================
+// InboxStatsStrip — compact 32px metric bar between header and list
+// ============================================================================
+function InboxStatsStrip({ items, theme }: { items: InboxItem[]; theme: Theme }) {
+	const stats = useMemo(() => {
+		const uniqueAgents = new Set(items.map((i) => i.sessionId)).size;
+		const unread = items.filter((i) => i.hasUnread).length;
+		const needsInput = items.filter((i) => i.state === 'waiting_input').length;
+		const highContext = items.filter(
+			(i) => i.contextUsage !== undefined && i.contextUsage >= 80
+		).length;
+		return { uniqueAgents, unread, needsInput, highContext };
+	}, [items]);
+
+	const metrics = [
+		{ label: 'Agents', value: stats.uniqueAgents },
+		{ label: 'Unread', value: stats.unread },
+		{ label: 'Needs Input', value: stats.needsInput },
+		{ label: 'Context \u226580%', value: stats.highContext },
+	];
+
+	return (
+		<div
+			className="flex items-center gap-4 px-6 py-1 border-b text-xs"
+			style={{
+				height: STATS_BAR_HEIGHT,
+				backgroundColor: theme.colors.bgActivity,
+				borderColor: theme.colors.border,
+			}}
+		>
+			{metrics.map((m) => (
+				<span key={m.label} className="flex items-center gap-1">
+					<span
+						style={{
+							color: theme.colors.textDim,
+							textTransform: 'uppercase',
+							letterSpacing: '0.5px',
+						}}
+					>
+						{m.label}
+					</span>
+					<span style={{ color: theme.colors.textMain, fontWeight: 600, marginLeft: 4 }}>
+						{m.value}
+					</span>
+				</span>
+			))}
+		</div>
+	);
+}
+
+// ============================================================================
+// Human-readable agent display names for group headers
+// ============================================================================
+const TOOL_TYPE_LABELS: Record<string, string> = {
+	'claude-code': 'Claude Code',
+	codex: 'Codex',
+	opencode: 'OpenCode',
+	'factory-droid': 'Factory Droid',
+	terminal: 'Terminal',
+};
+
+// ============================================================================
+// InboxListView Component
+// ============================================================================
+const SORT_OPTIONS: { value: InboxSortMode; label: string }[] = [
+	{ value: 'newest', label: 'Newest' },
+	{ value: 'oldest', label: 'Oldest' },
+	{ value: 'grouped', label: 'Grouped' },
+	{ value: 'byAgent', label: 'By Agent' },
+];
+
+const FILTER_OPTIONS: { value: InboxFilterMode; label: string }[] = [
+	{ value: 'all', label: 'All' },
+	{ value: 'unread', label: 'Unread' },
+	{ value: 'read', label: 'Read' },
+	{ value: 'starred', label: 'Starred' },
+];
+
+// Track the identity of the selected row so we can re-find it after rows change
+type RowIdentity =
+	| { type: 'header'; groupKey: string }
+	| { type: 'item'; sessionId: string; tabId: string };
+
+export default function InboxListView({
+	theme,
+	items,
+	selectedIndex,
+	setSelectedIndex,
+	filterMode,
+	setFilterMode,
+	sortMode,
+	setSortMode,
+	onClose,
+	onNavigateToSession,
+	onEnterFocus,
+	containerRef,
+	keyDownRef,
+	isExpanded,
+	onToggleExpanded,
+}: InboxListViewProps) {
+	const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
+
+	// Initial mount flag — enables staggered entrance animation only on first render
+	const [isInitialMount, setIsInitialMount] = useState(true);
+	useEffect(() => {
+		const timer = setTimeout(() => setIsInitialMount(false), 600);
+		return () => clearTimeout(timer);
+	}, []);
+
+	// Write state changes back to modalStore for persistence
+	useEffect(() => {
+		const { updateAgentInboxData } = getModalActions();
+		updateAgentInboxData({ filterMode, sortMode, isExpanded });
+	}, [filterMode, sortMode, isExpanded]);
+
+	const toggleGroup = useCallback((groupKey: string) => {
+		setCollapsedGroups((prev) => {
+			const next = new Set(prev);
+			if (next.has(groupKey)) {
+				next.delete(groupKey);
+			} else {
+				next.add(groupKey);
+			}
+			return next;
+		});
+	}, []);
+
+	// Auto-collapse zero-unread agents ONLY on initial transition into byAgent mode.
+	// After that, manual toggles are preserved — items changes do NOT reset collapse state.
+	const prevSortModeRef = useRef(sortMode);
+	useEffect(() => {
+		const prev = prevSortModeRef.current;
+		prevSortModeRef.current = sortMode;
+
+		if (sortMode === 'byAgent' && prev !== 'byAgent') {
+			const agentUnreads = new Map<string, number>();
+			for (const item of items) {
+				const count = agentUnreads.get(item.sessionId) ?? 0;
+				agentUnreads.set(item.sessionId, count + (item.hasUnread ? 1 : 0));
+			}
+			const toCollapse = new Set<string>();
+			for (const [agent, count] of agentUnreads) {
+				if (count === 0) toCollapse.add(agent);
+			}
+			setCollapsedGroups(toCollapse);
+		} else if (sortMode !== 'byAgent' && prev === 'byAgent') {
+			setCollapsedGroups(new Set());
+		}
+	}, [sortMode, items]);
+
+	const allRows = useMemo(() => buildRows(items, sortMode), [items, sortMode]);
+	const rows = useMemo(() => {
+		if ((sortMode !== 'grouped' && sortMode !== 'byAgent') || collapsedGroups.size === 0)
+			return allRows;
+		return allRows.filter((row) => {
+			if (row.type === 'header') return true;
+			const collapseKey =
+				sortMode === 'byAgent' ? row.item.sessionId : (row.item.groupName ?? 'Ungrouped');
+			return !collapsedGroups.has(collapseKey);
+		});
+	}, [allRows, collapsedGroups, sortMode]);
+
+	// Map from row index to visible-item-number (1-based, only for item rows)
+	// Also build reverse map: visibleItemNumber -> row index (for Cmd+N)
+	const { visibleItemNumbers, visibleItemByNumber } = useMemo(() => {
+		const numbers = new Map<number, number>(); // rowIndex -> 1-based visible number
+		const byNumber = new Map<number, number>(); // 1-based visible number -> rowIndex
+		let counter = 0;
+		for (let i = 0; i < rows.length; i++) {
+			if (rows[i].type === 'item') {
+				counter++;
+				numbers.set(i, counter);
+				byNumber.set(counter, i);
+			}
+		}
+		return { visibleItemNumbers: numbers, visibleItemByNumber: byNumber };
+	}, [rows]);
+
+	// ============================================================================
+	// Row-based navigation — navigates over rows (headers + items), no useListNavigation
+	// ============================================================================
+	// Initialize to first item row (skip leading headers)
+	const firstItemRow = useMemo(() => {
+		for (let i = 0; i < rows.length; i++) {
+			if (rows[i].type === 'item') return i;
+		}
+		return 0;
+	}, [rows]);
+	const [selectedRowIndex, setSelectedRowIndex] = useState(firstItemRow);
+	const selectedRowIdentityRef = useRef<RowIdentity | null>(null);
+
+	// Keep the identity ref in sync with selectedRowIndex
+	useEffect(() => {
+		const row = rows[selectedRowIndex];
+		if (!row) {
+			selectedRowIdentityRef.current = null;
+			return;
+		}
+		if (row.type === 'header') {
+			selectedRowIdentityRef.current = { type: 'header', groupKey: row.groupKey };
+		} else {
+			selectedRowIdentityRef.current = {
+				type: 'item',
+				sessionId: row.item.sessionId,
+				tabId: row.item.tabId,
+			};
+		}
+	}, [selectedRowIndex, rows]);
+
+	// Ref to the scrollable list container
+	const scrollContainerRef = useRef<HTMLDivElement>(null);
+	const headerRef = useRef<HTMLDivElement>(null);
+
+	// Stabilize selectedRowIndex after rows change (collapse/expand/filter)
+	useEffect(() => {
+		if (rows.length === 0) {
+			setSelectedRowIndex(0);
+			return;
+		}
+
+		const identity = selectedRowIdentityRef.current;
+		if (!identity) return;
+
+		// Check if the current index still points at the same identity
+		const currentRow = rows[selectedRowIndex];
+		if (currentRow) {
+			if (
+				identity.type === 'header' &&
+				currentRow.type === 'header' &&
+				currentRow.groupKey === identity.groupKey
+			) {
+				return; // Still correct
+			}
+			if (
+				identity.type === 'item' &&
+				currentRow.type === 'item' &&
+				currentRow.item.sessionId === identity.sessionId &&
+				currentRow.item.tabId === identity.tabId
+			) {
+				return; // Still correct
+			}
+		}
+
+		// Identity drifted — search for the old identity in the new rows
+		for (let i = 0; i < rows.length; i++) {
+			const r = rows[i];
+			if (identity.type === 'header' && r.type === 'header' && r.groupKey === identity.groupKey) {
+				setSelectedRowIndex(i);
+				return;
+			}
+			if (
+				identity.type === 'item' &&
+				r.type === 'item' &&
+				r.item.sessionId === identity.sessionId &&
+				r.item.tabId === identity.tabId
+			) {
+				setSelectedRowIndex(i);
+				return;
+			}
+		}
+
+		// Old identity no longer in rows (collapsed away) — find nearest item or clamp
+		const clamped = Math.min(selectedRowIndex, rows.length - 1);
+		// Search downward from clamped position for an item row
+		for (let i = clamped; i < rows.length; i++) {
+			if (rows[i].type === 'item') {
+				setSelectedRowIndex(i);
+				return;
+			}
+		}
+		// Search upward
+		for (let i = clamped - 1; i >= 0; i--) {
+			if (rows[i].type === 'item') {
+				setSelectedRowIndex(i);
+				return;
+			}
+		}
+		// Only headers remain — select the first header
+		setSelectedRowIndex(0);
+	}, [rows, selectedRowIndex]);
+
+	// When sort mode or filter mode changes, reset selection to first item row
+	const prevSortForResetRef = useRef(sortMode);
+	const prevFilterForResetRef = useRef(filterMode);
+	useEffect(() => {
+		if (sortMode !== prevSortForResetRef.current || filterMode !== prevFilterForResetRef.current) {
+			prevSortForResetRef.current = sortMode;
+			prevFilterForResetRef.current = filterMode;
+			for (let i = 0; i < rows.length; i++) {
+				if (rows[i].type === 'item') {
+					setSelectedRowIndex(i);
+					return;
+				}
+			}
+			setSelectedRowIndex(0);
+		}
+	}, [sortMode, filterMode, rows]);
+
+	// Sync selectedRowIndex -> parent selectedIndex (used by Focus Mode entry)
+	useEffect(() => {
+		const row = rows[selectedRowIndex];
+		if (!row) return;
+
+		if (row.type === 'item') {
+			setSelectedIndex(row.index);
+			return;
+		}
+
+		// Header selected — find nearest item below, then above
+		for (let i = selectedRowIndex + 1; i < rows.length; i++) {
+			const r = rows[i];
+			if (r.type === 'header') break; // hit next group, stop
+			if (r.type === 'item') {
+				setSelectedIndex(r.index);
+				return;
+			}
+		}
+		// No item below in same group — search upward
+		for (let i = selectedRowIndex - 1; i >= 0; i--) {
+			const r = rows[i];
+			if (r.type === 'item') {
+				setSelectedIndex(r.index);
+				return;
+			}
+		}
+	}, [selectedRowIndex, rows, setSelectedIndex]);
+
+	// Guard: ensure parent selectedIndex points to a visible item after collapse
+	useEffect(() => {
+		if (rows.length === 0) return;
+		const visibleItemIndexes = new Set(
+			rows.filter((row) => row.type === 'item').map((row) => row.index)
+		);
+		if (!visibleItemIndexes.has(selectedIndex)) {
+			const firstItemRow = rows.find((row) => row.type === 'item');
+			if (firstItemRow && firstItemRow.type === 'item') {
+				setSelectedIndex(firstItemRow.index);
+			}
+		}
+	}, [rows, selectedIndex, setSelectedIndex]);
+
+	// Row height getter for variable-size rows
+	const getRowHeight = useCallback(
+		(index: number): number => {
+			const row = rows[index];
+			if (!row) return ITEM_HEIGHT;
+			return row.type === 'header' ? GROUP_HEADER_HEIGHT : ITEM_HEIGHT;
+		},
+		[rows]
+	);
+
+	// Calculate list height
+	const listHeight = useMemo(() => {
+		if (typeof window === 'undefined') return 400;
+		if (isExpanded) {
+			return Math.min(
+				window.innerHeight * 0.85 -
+					MODAL_HEADER_HEIGHT -
+					MODAL_FOOTER_HEIGHT -
+					STATS_BAR_HEIGHT -
+					80,
+				1000
+			);
+		}
+		return Math.min(
+			window.innerHeight * 0.8 - MODAL_HEADER_HEIGHT - MODAL_FOOTER_HEIGHT - STATS_BAR_HEIGHT - 80,
+			700
+		);
+	}, [isExpanded]);
+
+	// Virtualizer
+	const virtualizer = useVirtualizer({
+		count: rows.length,
+		getScrollElement: () => scrollContainerRef.current,
+		estimateSize: getRowHeight,
+		overscan: 5,
+	});
+
+	// Scroll to selected row
+	useEffect(() => {
+		if (rows.length > 0 && selectedRowIndex < rows.length) {
+			virtualizer.scrollToIndex(selectedRowIndex, { align: 'auto' });
+		}
+	}, [selectedRowIndex, rows.length, virtualizer]);
+
+	const handleNavigate = useCallback(
+		(item: InboxItem) => {
+			if (onNavigateToSession) {
+				onNavigateToSession(item.sessionId, item.tabId);
+			}
+			onClose();
+		},
+		[onNavigateToSession, onClose]
+	);
+
+	// Get the selected item's element ID for aria-activedescendant
+	const selectedItemId = useMemo(() => {
+		const row = rows[selectedRowIndex];
+		if (!row || row.type !== 'item') return undefined;
+		return `inbox-item-${row.item.sessionId}-${row.item.tabId}`;
+	}, [rows, selectedRowIndex]);
+
+	// Collect focusable header elements for Tab cycling
+	const getHeaderFocusables = useCallback((): HTMLElement[] => {
+		if (!headerRef.current) return [];
+		return Array.from(headerRef.current.querySelectorAll<HTMLElement>('button, [tabindex="0"]'));
+	}, []);
+
+	// Row-based keyboard handler — arrows navigate rows (headers + items)
+	const handleKeyDown = useCallback(
+		(e: React.KeyboardEvent) => {
+			// Tab cycling for header controls
+			if (e.key === 'Tab') {
+				const focusables = getHeaderFocusables();
+				if (focusables.length === 0) return;
+				const active = document.activeElement;
+				const focusIdx = focusables.indexOf(active as HTMLElement);
+
+				if (e.shiftKey) {
+					if (focusIdx <= 0) {
+						e.preventDefault();
+						containerRef.current?.focus();
+					} else {
+						e.preventDefault();
+						focusables[focusIdx - 1].focus();
+					}
+				} else {
+					if (focusIdx === -1) {
+						e.preventDefault();
+						focusables[0].focus();
+					} else if (focusIdx >= focusables.length - 1) {
+						e.preventDefault();
+						containerRef.current?.focus();
+					} else {
+						e.preventDefault();
+						focusables[focusIdx + 1].focus();
+					}
+				}
+				return;
+			}
+
+			// Arrow navigation over rows (headers + items)
+			if (e.key === 'ArrowDown') {
+				e.preventDefault();
+				if (rows.length === 0) return;
+				setSelectedRowIndex((prev) => Math.min(prev + 1, rows.length - 1));
+				return;
+			}
+			if (e.key === 'ArrowUp') {
+				e.preventDefault();
+				if (rows.length === 0) return;
+				setSelectedRowIndex((prev) => Math.max(prev - 1, 0));
+				return;
+			}
+
+			// T / Enter on a header → toggle group
+			// Enter on an item → navigate to session
+			if (e.key === 'Enter') {
+				e.preventDefault();
+				const row = rows[selectedRowIndex];
+				if (!row) return;
+				if (row.type === 'header') {
+					toggleGroup(row.groupKey);
+				} else {
+					handleNavigate(row.item);
+				}
+				return;
+			}
+
+			// T to toggle group (works on headers AND items)
+			if ((e.key === 't' || e.key === 'T') && !e.metaKey && !e.ctrlKey && !e.altKey) {
+				if (sortMode === 'grouped' || sortMode === 'byAgent') {
+					e.preventDefault();
+					const row = rows[selectedRowIndex];
+					if (!row) return;
+					if (row.type === 'header') {
+						toggleGroup(row.groupKey);
+					} else {
+						const groupKey =
+							sortMode === 'byAgent' ? row.item.sessionId : (row.item.groupName ?? 'Ungrouped');
+						toggleGroup(groupKey);
+					}
+				}
+				return;
+			}
+
+			// Cmd/Ctrl+1-9, 0 hotkeys for quick select (visible-item based)
+			if (
+				(e.metaKey || e.ctrlKey) &&
+				['1', '2', '3', '4', '5', '6', '7', '8', '9', '0'].includes(e.key)
+			) {
+				e.preventDefault();
+				const number = e.key === '0' ? 10 : parseInt(e.key);
+				const targetRowIndex = visibleItemByNumber.get(number);
+				if (targetRowIndex !== undefined) {
+					const targetRow = rows[targetRowIndex];
+					if (targetRow && targetRow.type === 'item') {
+						handleNavigate(targetRow.item);
+					}
+				}
+				return;
+			}
+		},
+		[
+			getHeaderFocusables,
+			containerRef,
+			rows,
+			selectedRowIndex,
+			sortMode,
+			visibleItemByNumber,
+			toggleGroup,
+			handleNavigate,
+		]
+	);
+
+	// Expose keyboard handler to shell via ref
+	useEffect(() => {
+		if (keyDownRef) keyDownRef.current = handleKeyDown;
+		return () => {
+			if (keyDownRef) keyDownRef.current = null;
+		};
+	}, [keyDownRef, handleKeyDown]);
+
+	const actionCount = items.length;
+
+	// Filter-aware count label
+	const countLabel =
+		filterMode === 'unread'
+			? `${actionCount} unread`
+			: filterMode === 'starred'
+				? `${actionCount} starred`
+				: filterMode === 'read'
+					? `${actionCount} read`
+					: `${actionCount} need action`;
+
+	return (
+		<>
+			{/* Header — 80px, two rows */}
+			<div
+				ref={headerRef}
+				className="px-4 py-3 border-b"
+				style={{
+					height: MODAL_HEADER_HEIGHT,
+					backgroundColor: theme.colors.bgSidebar,
+					borderColor: theme.colors.border,
+					display: 'flex',
+					flexDirection: 'column',
+					justifyContent: 'center',
+					gap: 8,
+				}}
+			>
+				{/* Header row 1: title + badge + close */}
+				<div className="flex items-center justify-between">
+					<div className="flex items-center gap-2">
+						<Bot className="w-5 h-5" style={{ color: theme.colors.accent }} />
+						<h2 className="text-lg font-semibold" style={{ color: theme.colors.textMain }}>
+							Unified Inbox
+						</h2>
+						<span
+							aria-live="polite"
+							className="text-xs px-2 py-0.5 rounded-full"
+							style={{
+								backgroundColor: `${theme.colors.accent}20`,
+								color: theme.colors.accent,
+							}}
+						>
+							{countLabel}
+						</span>
+					</div>
+					<div className="flex items-center gap-2">
+						<button
+							onClick={() => {
+								if (items.length > 0 && items[selectedIndex]) {
+									onEnterFocus(items[selectedIndex]);
+								}
+							}}
+							disabled={items.length === 0}
+							className="text-xs px-2.5 py-1 rounded transition-colors"
+							style={{
+								backgroundColor: items.length > 0 ? `${theme.colors.accent}15` : 'transparent',
+								color: items.length > 0 ? theme.colors.accent : theme.colors.textDim,
+								cursor: items.length > 0 ? 'pointer' : 'default',
+								opacity: items.length === 0 ? 0.5 : 1,
+							}}
+							onMouseEnter={(e) => {
+								if (items.length > 0) {
+									e.currentTarget.style.backgroundColor = `${theme.colors.accent}25`;
+								}
+							}}
+							onMouseLeave={(e) => {
+								if (items.length > 0) {
+									e.currentTarget.style.backgroundColor = `${theme.colors.accent}15`;
+								}
+							}}
+							title="Enter Focus Mode (F)"
+						>
+							Focus ▶
+						</button>
+						<button
+							onClick={() => onToggleExpanded((prev) => !prev)}
+							className="p-1.5 rounded"
+							style={{ color: theme.colors.textDim }}
+							onMouseEnter={(e) =>
+								(e.currentTarget.style.backgroundColor = `${theme.colors.accent}20`)
+							}
+							onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = 'transparent')}
+							title={isExpanded ? 'Collapse' : 'Expand'}
+							aria-label={isExpanded ? 'Collapse modal' : 'Expand modal'}
+						>
+							{isExpanded ? <Minimize2 className="w-4 h-4" /> : <Maximize2 className="w-4 h-4" />}
+						</button>
+						<button
+							onClick={onClose}
+							className="p-1.5 rounded"
+							style={{ color: theme.colors.textDim }}
+							onMouseEnter={(e) =>
+								(e.currentTarget.style.backgroundColor = `${theme.colors.accent}20`)
+							}
+							onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = 'transparent')}
+							onFocus={(e) => {
+								e.currentTarget.style.outline = `2px solid ${theme.colors.accent}`;
+							}}
+							onBlur={(e) => {
+								e.currentTarget.style.outline = 'none';
+							}}
+							title="Close (Esc)"
+						>
+							<X className="w-4 h-4" />
+						</button>
+					</div>
+				</div>
+				{/* Header row 2: sort + filter controls */}
+				<div className="flex items-center justify-between">
+					<SegmentedControl
+						options={SORT_OPTIONS}
+						value={sortMode}
+						onChange={setSortMode}
+						theme={theme}
+						ariaLabel="Sort agents"
+					/>
+					<SegmentedControl
+						options={FILTER_OPTIONS}
+						value={filterMode}
+						onChange={setFilterMode}
+						theme={theme}
+						ariaLabel="Filter agents"
+					/>
+				</div>
+			</div>
+
+			{/* Stats strip — 32px aggregate metrics */}
+			<InboxStatsStrip items={items} theme={theme} />
+
+			{/* Body — virtualized list */}
+			<div
+				role="listbox"
+				tabIndex={0}
+				onKeyDown={handleKeyDown}
+				aria-activedescendant={selectedItemId}
+				aria-label="Inbox items"
+				className="outline-none"
+				style={{ flex: 1, overflow: 'hidden' }}
+				onFocus={(e) => {
+					e.currentTarget.style.outline = `2px solid ${theme.colors.accent}`;
+					e.currentTarget.style.outlineOffset = '-2px';
+				}}
+				onBlur={(e) => {
+					e.currentTarget.style.outline = 'none';
+				}}
+			>
+				{rows.length === 0 ? (
+					<div
+						data-testid="inbox-empty-state"
+						className="flex flex-col items-center justify-center gap-3"
+						style={{ height: listHeight, color: theme.colors.textDim }}
+					>
+						{EMPTY_STATE_MESSAGES[filterMode].showIcon && (
+							<CheckCircle
+								data-testid="inbox-empty-icon"
+								style={{
+									width: 32,
+									height: 32,
+									color: theme.colors.textDim,
+									opacity: 0.5,
+								}}
+							/>
+						)}
+						<span
+							style={{
+								fontSize: 14,
+								color: theme.colors.textDim,
+								maxWidth: 280,
+								textAlign: 'center',
+							}}
+						>
+							{EMPTY_STATE_MESSAGES[filterMode].text}
+						</span>
+					</div>
+				) : (
+					<div
+						ref={scrollContainerRef}
+						style={{
+							height: listHeight,
+							overflow: 'auto',
+						}}
+					>
+						<div
+							style={{
+								height: `${virtualizer.getTotalSize()}px`,
+								width: '100%',
+								position: 'relative',
+							}}
+						>
+							{virtualizer.getVirtualItems().map((virtualRow) => {
+								const row = rows[virtualRow.index];
+								if (!row) return null;
+								const isRowSelected = virtualRow.index === selectedRowIndex;
+
+								if (row.type === 'header') {
+									const isCollapsed = collapsedGroups.has(row.groupKey);
+
+									// For byAgent mode: derive agent type label and unread count from subsequent rows
+									let agentToolType: string | undefined;
+									let unreadCount = 0;
+									if (sortMode === 'byAgent') {
+										for (let i = virtualRow.index + 1; i < rows.length; i++) {
+											const r = rows[i];
+											if (r.type === 'header') break;
+											if (r.type === 'item') {
+												if (!agentToolType) agentToolType = r.item.toolType;
+												if (r.item.hasUnread) unreadCount++;
+											}
+										}
+									}
+
+									return (
+										<button
+											type="button"
+											key={`header-${row.groupKey}`}
+											className="outline-none"
+											style={{
+												position: 'absolute',
+												top: 0,
+												left: 0,
+												width: '100%',
+												height: `${virtualRow.size}px`,
+												transform: `translateY(${virtualRow.start}px)`,
+												display: 'flex',
+												alignItems: 'center',
+												paddingLeft: 16,
+												paddingRight: 16,
+												fontSize: 13,
+												fontWeight: 600,
+												color: isRowSelected ? theme.colors.accent : theme.colors.textDim,
+												letterSpacing: '0.5px',
+												textTransform: 'uppercase',
+												borderBottom: `2px solid ${theme.colors.border}40`,
+												borderLeft: isRowSelected
+													? `3px solid ${theme.colors.accent}`
+													: '3px solid transparent',
+												backgroundColor: isRowSelected ? `${theme.colors.accent}10` : 'transparent',
+												cursor: 'pointer',
+												borderTop: 'none',
+												borderRight: 'none',
+												textAlign: 'left',
+											}}
+											onClick={() => toggleGroup(row.groupKey)}
+											onKeyDown={(e) => {
+												if (e.key === 'Enter' || e.key === ' ') {
+													e.preventDefault();
+													toggleGroup(row.groupKey);
+												}
+											}}
+										>
+											{isCollapsed ? (
+												<ChevronRight
+													style={{ width: 14, height: 14, marginRight: 4, flexShrink: 0 }}
+												/>
+											) : (
+												<ChevronDown
+													style={{ width: 14, height: 14, marginRight: 4, flexShrink: 0 }}
+												/>
+											)}
+											{row.groupName}
+											{sortMode === 'byAgent' && agentToolType && (
+												<span
+													style={{
+														fontSize: 11,
+														color: theme.colors.textDim,
+														fontWeight: 400,
+														marginLeft: 4,
+													}}
+												>
+													({TOOL_TYPE_LABELS[agentToolType] ?? agentToolType})
+												</span>
+											)}
+											{sortMode === 'byAgent' && unreadCount > 0 && (
+												<span
+													style={{
+														fontSize: 11,
+														marginLeft: 'auto',
+														padding: '1px 6px',
+														borderRadius: 10,
+														backgroundColor: theme.colors.warning + '20',
+														color: theme.colors.warning,
+													}}
+												>
+													{unreadCount} unread
+												</span>
+											)}
+										</button>
+									);
+								}
+
+								const isLastRow = virtualRow.index === rows.length - 1;
+								const visibleNum = visibleItemNumbers.get(virtualRow.index);
+								const showNumber = visibleNum !== undefined && visibleNum >= 1 && visibleNum <= 10;
+								const numberBadge = visibleNum === 10 ? 0 : visibleNum;
+
+								// Stagger animation: only on initial mount, capped at 300ms (10 items)
+								const animationDelay = isInitialMount
+									? `${Math.min(virtualRow.index * 30, 300)}ms`
+									: undefined;
+
+								return (
+									<div
+										key={`item-${row.item.sessionId}-${row.item.tabId}`}
+										className={isInitialMount ? 'inbox-card-enter' : undefined}
+										style={{
+											position: 'absolute',
+											top: 0,
+											left: 0,
+											width: '100%',
+											height: `${virtualRow.size}px`,
+											transform: `translateY(${virtualRow.start}px)`,
+											paddingLeft: 16,
+											paddingRight: 16,
+											paddingTop: 6,
+											paddingBottom: 6,
+											borderBottom: isLastRow ? undefined : `1px solid ${theme.colors.border}40`,
+											animationDelay,
+										}}
+									>
+										<div style={{ display: 'flex', alignItems: 'center', gap: 8, height: '100%' }}>
+											{showNumber ? (
+												<div
+													className="flex-shrink-0 w-5 h-5 rounded flex items-center justify-center text-xs font-bold"
+													style={{
+														backgroundColor: theme.colors.bgMain,
+														color: theme.colors.textDim,
+														border: `1px solid ${theme.colors.border}`,
+													}}
+													data-testid="number-badge"
+												>
+													{numberBadge}
+												</div>
+											) : (
+												<div className="flex-shrink-0 w-5 h-5" />
+											)}
+											<div style={{ flex: 1, minWidth: 0 }}>
+												<InboxItemCardContent
+													item={row.item}
+													theme={theme}
+													isSelected={isRowSelected}
+													onClick={() => handleNavigate(row.item)}
+													onDoubleClick={() => onEnterFocus(row.item)}
+												/>
+											</div>
+										</div>
+									</div>
+								);
+							})}
+						</div>
+					</div>
+				)}
+			</div>
+
+			{/* Footer — 36px */}
+			<div
+				className="flex items-center justify-between px-4 py-2 border-t text-xs"
+				style={{
+					height: MODAL_FOOTER_HEIGHT,
+					borderColor: theme.colors.border,
+					color: theme.colors.textDim,
+				}}
+			>
+				<span>{countLabel}</span>
+				<span>{`↑↓ navigate • ${sortMode === 'grouped' || sortMode === 'byAgent' ? 'T collapse • ' : ''}F focus • Enter open • ${formatShortcutKeys(['Meta'])}1-9 quick select • Esc close`}</span>
+			</div>
+		</>
+	);
+}

--- a/src/renderer/components/AgentInbox/index.tsx
+++ b/src/renderer/components/AgentInbox/index.tsx
@@ -1,0 +1,366 @@
+/* POLISH-04 Token Audit (@architect)
+ * Line 267: bgActivity for dialog container — CORRECT (content)
+ * All other usages: CORRECT
+ */
+
+import { useState, useEffect, useRef, useCallback } from 'react';
+import InboxListView from './InboxListView';
+import FocusModeView from './FocusModeView';
+import type { Theme, Session, Group, ThinkingMode } from '../../types';
+import type {
+	InboxItem,
+	InboxViewMode,
+	InboxFilterMode,
+	InboxSortMode,
+} from '../../types/agent-inbox';
+import { useModalLayer } from '../../hooks/ui/useModalLayer';
+import { MODAL_PRIORITIES } from '../../constants/modalPriorities';
+import { useModalStore, selectModalData } from '../../stores/modalStore';
+import { useAgentInbox } from '../../hooks/useAgentInbox';
+
+// Re-export so existing test imports don't break
+export { resolveContextUsageColor } from './InboxListView';
+
+interface AgentInboxProps {
+	theme: Theme;
+	sessions: Session[];
+	groups: Group[];
+	enterToSendAI?: boolean;
+	onClose: () => void;
+	onNavigateToSession?: (sessionId: string, tabId?: string) => void;
+	onQuickReply?: (sessionId: string, tabId: string, text: string) => void;
+	onOpenAndReply?: (sessionId: string, tabId: string, text: string) => void;
+	onMarkAsRead?: (sessionId: string, tabId: string) => void;
+	onToggleThinking?: (sessionId: string, tabId: string, mode: ThinkingMode) => void;
+}
+
+export default function AgentInbox({
+	theme,
+	sessions,
+	groups,
+	enterToSendAI,
+	onClose,
+	onNavigateToSession,
+	onQuickReply,
+	onOpenAndReply,
+	onMarkAsRead,
+	onToggleThinking,
+}: AgentInboxProps) {
+	// ---- Focus restoration ----
+	// Capture trigger element synchronously during initial render (before child effects)
+	const triggerRef = useRef<HTMLElement | null>(
+		document.activeElement instanceof HTMLElement ? document.activeElement : null
+	);
+
+	const handleClose = useCallback(() => {
+		const trigger = triggerRef.current;
+		onClose();
+		// Schedule focus restoration after React unmounts the modal.
+		// No cleanup needed — the RAF fires once post-unmount and is harmless if trigger is gone.
+		requestAnimationFrame(() => {
+			trigger?.focus();
+		});
+	}, [onClose]);
+
+	// ---- View mode state ----
+	const [viewMode, setViewMode] = useState<InboxViewMode>('list');
+	const [focusIndex, setFocusIndex] = useState(0);
+	const [selectedIndex, setSelectedIndex] = useState(0);
+
+	// ---- Filter/sort state (lifted from InboxListView for shared access) ----
+	const inboxData = useModalStore(selectModalData('agentInbox'));
+	const [filterMode, setFilterMode] = useState<InboxFilterMode>(
+		(inboxData?.filterMode as InboxFilterMode) ?? 'unread'
+	);
+	const [sortMode, setSortMode] = useState<InboxSortMode>(
+		(inboxData?.sortMode as InboxSortMode) ?? 'newest'
+	);
+
+	// ---- Compute live items (used in list mode) ----
+	const liveItems = useAgentInbox(sessions, groups, filterMode, sortMode);
+
+	// ---- Frozen snapshot for Focus Mode ----
+	// Simple ref-based approach: freeze item order on entry, resolve against live data
+	// for real-time updates (logs, status), but keep the ORDER stable.
+	const frozenOrderRef = useRef<{ sessionId: string; tabId: string }[]>([]);
+
+	// Resolve frozen order against live items (live data, frozen order)
+	const resolveFrozenItems = useCallback(
+		(frozen: { sessionId: string; tabId: string }[]): InboxItem[] => {
+			const liveMap = new Map<string, InboxItem>();
+			for (const item of liveItems) {
+				liveMap.set(`${item.sessionId}:${item.tabId}`, item);
+			}
+			const resolved: InboxItem[] = [];
+			for (const key of frozen) {
+				const live = liveMap.get(`${key.sessionId}:${key.tabId}`);
+				if (live) resolved.push(live);
+			}
+			return resolved.length > 0 ? resolved : liveItems;
+		},
+		[liveItems]
+	);
+
+	// Items: in focus mode use frozen-order resolved against live data, else live
+	const items =
+		viewMode === 'focus' && frozenOrderRef.current.length > 0
+			? resolveFrozenItems(frozenOrderRef.current)
+			: liveItems;
+
+	const handleSetFilterMode = useCallback(
+		(mode: InboxFilterMode) => {
+			setFilterMode(mode);
+			if (viewMode === 'focus') {
+				// Re-snapshot: resolve new filter results immediately
+				// We need a render with the new filterMode first, so defer the snapshot
+				frozenOrderRef.current = [];
+				setFocusIndex(0);
+			}
+		},
+		[viewMode]
+	);
+
+	const handleExitFocus = useCallback(() => {
+		setViewMode('list');
+		frozenOrderRef.current = [];
+	}, []);
+
+	// Re-snapshot after filter change empties the ref (needs liveItems from new filter)
+	useEffect(() => {
+		if (viewMode === 'focus' && frozenOrderRef.current.length === 0 && liveItems.length > 0) {
+			frozenOrderRef.current = liveItems.map((i) => ({
+				sessionId: i.sessionId,
+				tabId: i.tabId,
+			}));
+		}
+	}, [viewMode, liveItems]);
+
+	// ---- Edge case: items shrink while in focus mode ----
+	useEffect(() => {
+		if (viewMode === 'focus' && items.length > 0 && focusIndex >= items.length) {
+			setFocusIndex(items.length - 1);
+		}
+	}, [items.length, focusIndex, viewMode]);
+
+	const handleEnterFocus = useCallback(
+		(item: InboxItem) => {
+			const idx = liveItems.findIndex(
+				(i) => i.sessionId === item.sessionId && i.tabId === item.tabId
+			);
+			setFocusIndex(idx >= 0 ? idx : 0);
+			// Freeze current order as simple identity pairs
+			frozenOrderRef.current = liveItems.map((i) => ({
+				sessionId: i.sessionId,
+				tabId: i.tabId,
+			}));
+			setViewMode('focus');
+		},
+		[liveItems]
+	);
+
+	// ---- Navigate item wrapper ----
+	const handleNavigateItem = useCallback((idx: number) => {
+		setFocusIndex(idx);
+	}, []);
+
+	// ---- Layer stack: viewMode-aware Escape ----
+	const handleLayerEscape = useCallback(() => {
+		if (viewMode === 'focus') {
+			handleExitFocus();
+		} else {
+			handleClose();
+		}
+	}, [viewMode, handleExitFocus, handleClose]);
+
+	useModalLayer(MODAL_PRIORITIES.AGENT_INBOX, 'Unified Inbox', handleLayerEscape);
+
+	// ---- Container ref for keyboard focus ----
+	const containerRef = useRef<HTMLDivElement>(null);
+
+	// Auto-focus container on mount for immediate keyboard navigation
+	useEffect(() => {
+		const raf = requestAnimationFrame(() => {
+			containerRef.current?.focus();
+		});
+		return () => cancelAnimationFrame(raf);
+	}, []);
+
+	// ---- Expanded state (lifted to shell for dialog width control) ----
+	const [isExpanded, setIsExpanded] = useState(inboxData?.isExpanded ?? false);
+
+	// ---- Compute dialog dimensions (focus mode or expanded → wide) ----
+	const isWide = isExpanded || viewMode === 'focus';
+	const expandedWidth = Math.min(
+		typeof window !== 'undefined' ? window.innerWidth * 0.92 : 1400,
+		1400
+	);
+	const dialogWidth = viewMode === 'focus' ? expandedWidth : isWide ? expandedWidth : 780;
+	const dialogHeight = viewMode === 'focus' ? '85vh' : undefined;
+	const dialogMaxHeight = viewMode === 'focus' ? undefined : isWide ? '90vh' : '80vh';
+
+	// ---- Keyboard handler ref from InboxListView ----
+	const listKeyDownRef = useRef<((e: React.KeyboardEvent) => void) | null>(null);
+
+	// ---- CAPTURE phase: Cmd+[/] must fire BEFORE textarea consumes the event ----
+	const handleCaptureKeyDown = useCallback(
+		(e: React.KeyboardEvent) => {
+			if (viewMode !== 'focus') return;
+			if ((e.metaKey || e.ctrlKey) && (e.key === '[' || e.key === ']')) {
+				e.preventDefault();
+				e.stopPropagation();
+				if (items.length > 1) {
+					setFocusIndex((prev) =>
+						e.key === '[' ? Math.max(prev - 1, 0) : Math.min(prev + 1, items.length - 1)
+					);
+				}
+			}
+		},
+		[viewMode, items]
+	);
+
+	// ---- BUBBLE phase: all other keyboard shortcuts ----
+	const handleShellKeyDown = useCallback(
+		(e: React.KeyboardEvent) => {
+			if (viewMode === 'focus') {
+				switch (e.key) {
+					case 'Escape':
+						e.preventDefault();
+						e.stopPropagation();
+						handleExitFocus();
+						return;
+					case 'Backspace':
+					case 'b':
+					case 'B':
+						// Guard: only exit if NOT typing in the reply textarea
+						if (document.activeElement?.tagName !== 'TEXTAREA') {
+							e.preventDefault();
+							handleExitFocus();
+						}
+						return;
+				}
+				return;
+			}
+
+			// List mode: F to enter focus
+			if ((e.key === 'f' || e.key === 'F') && !e.metaKey && !e.ctrlKey && !e.altKey) {
+				e.preventDefault();
+				if (items.length > 0 && items[selectedIndex]) {
+					handleEnterFocus(items[selectedIndex]);
+				}
+				return;
+			}
+
+			// Delegate only when the shell container itself is focused.
+			// Avoid re-processing events already handled inside InboxListView.
+			if (
+				viewMode === 'list' &&
+				listKeyDownRef.current &&
+				!e.defaultPrevented &&
+				e.target === e.currentTarget
+			) {
+				e.stopPropagation();
+				listKeyDownRef.current(e);
+			}
+		},
+		[viewMode, items, selectedIndex, handleEnterFocus, handleExitFocus]
+	);
+
+	return (
+		<div
+			className="fixed inset-0 modal-overlay flex items-center justify-center z-[9999] animate-in fade-in duration-100"
+			onClick={handleClose}
+		>
+			<div
+				ref={containerRef}
+				tabIndex={-1}
+				role="dialog"
+				aria-modal="true"
+				aria-label="Unified Inbox"
+				className="rounded-xl shadow-2xl border overflow-hidden flex flex-col outline-none"
+				style={{
+					backgroundColor: theme.colors.bgActivity,
+					borderColor: theme.colors.border,
+					width: dialogWidth,
+					maxWidth: '95vw',
+					height: dialogHeight,
+					maxHeight: dialogMaxHeight,
+					transition: 'width 200ms ease, height 200ms ease, max-height 200ms ease',
+				}}
+				onClick={(e) => e.stopPropagation()}
+				onKeyDownCapture={handleCaptureKeyDown}
+				onKeyDown={handleShellKeyDown}
+				onFocus={() => {}}
+				onBlur={() => {}}
+			>
+				<div className="flex-1 flex flex-col overflow-hidden" style={{ minHeight: 0 }}>
+					{viewMode === 'list' ? (
+						<InboxListView
+							theme={theme}
+							items={items}
+							selectedIndex={selectedIndex}
+							setSelectedIndex={setSelectedIndex}
+							filterMode={filterMode}
+							setFilterMode={handleSetFilterMode}
+							sortMode={sortMode}
+							setSortMode={setSortMode}
+							onClose={handleClose}
+							onNavigateToSession={onNavigateToSession}
+							onEnterFocus={handleEnterFocus}
+							containerRef={containerRef}
+							keyDownRef={listKeyDownRef}
+							isExpanded={isExpanded}
+							onToggleExpanded={setIsExpanded}
+						/>
+					) : items[focusIndex] ? (
+						<FocusModeView
+							theme={theme}
+							item={items[focusIndex]}
+							items={items}
+							sessions={sessions}
+							currentIndex={focusIndex}
+							enterToSendAI={enterToSendAI}
+							filterMode={filterMode}
+							setFilterMode={handleSetFilterMode}
+							sortMode={sortMode}
+							onClose={handleClose}
+							onExitFocus={handleExitFocus}
+							onNavigateItem={handleNavigateItem}
+							onNavigateToSession={onNavigateToSession}
+							onQuickReply={onQuickReply}
+							onOpenAndReply={onOpenAndReply}
+							onMarkAsRead={onMarkAsRead}
+							onToggleThinking={onToggleThinking}
+						/>
+					) : (
+						<div
+							style={{ color: theme.colors.textDim, padding: 40, textAlign: 'center' }}
+							className="flex flex-col items-center gap-3"
+						>
+							<span className="text-sm">
+								{filterMode === 'unread'
+									? 'No unread items'
+									: filterMode === 'starred'
+										? 'No starred items'
+										: 'No items to focus on'}
+							</span>
+							{filterMode !== 'all' && (
+								<button
+									onClick={() => handleSetFilterMode('all')}
+									className="text-xs px-3 py-1.5 rounded-full"
+									style={{
+										backgroundColor: `${theme.colors.accent}20`,
+										color: theme.colors.accent,
+										border: 'none',
+										cursor: 'pointer',
+									}}
+								>
+									Show all items
+								</button>
+							)}
+						</div>
+					)}
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/src/renderer/components/AppModals.tsx
+++ b/src/renderer/components/AppModals.tsx
@@ -859,6 +859,9 @@ export interface AppUtilityModalsProps {
 	// Director's Notes
 	onOpenDirectorNotes?: () => void;
 
+	// Unified Inbox
+	onOpenAgentInbox?: () => void;
+
 	// Auto-scroll
 	autoScrollAiMode?: boolean;
 	setAutoScrollAiMode?: (value: boolean) => void;
@@ -1060,6 +1063,8 @@ export const AppUtilityModals = memo(function AppUtilityModals({
 	onOpenSymphony,
 	// Director's Notes
 	onOpenDirectorNotes,
+	// Unified Inbox
+	onOpenAgentInbox,
 	// Auto-scroll
 	autoScrollAiMode,
 	setAutoScrollAiMode,
@@ -1218,6 +1223,7 @@ export const AppUtilityModals = memo(function AppUtilityModals({
 					onOpenLastDocumentGraph={onOpenLastDocumentGraph}
 					onOpenSymphony={onOpenSymphony}
 					onOpenDirectorNotes={onOpenDirectorNotes}
+					onOpenAgentInbox={onOpenAgentInbox}
 					autoScrollAiMode={autoScrollAiMode}
 					setAutoScrollAiMode={setAutoScrollAiMode}
 				/>
@@ -2013,6 +2019,8 @@ export interface AppModalsProps {
 	onOpenSymphony?: () => void;
 	// Director's Notes
 	onOpenDirectorNotes?: () => void;
+	// Unified Inbox
+	onOpenAgentInbox?: () => void;
 	// Auto-scroll
 	autoScrollAiMode?: boolean;
 	setAutoScrollAiMode?: (value: boolean) => void;
@@ -2337,6 +2345,8 @@ export const AppModals = memo(function AppModals(props: AppModalsProps) {
 		onOpenSymphony,
 		// Director's Notes
 		onOpenDirectorNotes,
+		// Unified Inbox
+		onOpenAgentInbox,
 		// Auto-scroll
 		autoScrollAiMode,
 		setAutoScrollAiMode,
@@ -2651,6 +2661,7 @@ export const AppModals = memo(function AppModals(props: AppModalsProps) {
 				onOpenMarketplace={onOpenMarketplace}
 				onOpenSymphony={onOpenSymphony}
 				onOpenDirectorNotes={onOpenDirectorNotes}
+				onOpenAgentInbox={onOpenAgentInbox}
 				autoScrollAiMode={autoScrollAiMode}
 				setAutoScrollAiMode={setAutoScrollAiMode}
 				tabSwitcherOpen={tabSwitcherOpen}

--- a/src/renderer/components/QuickActionsModal.tsx
+++ b/src/renderer/components/QuickActionsModal.tsx
@@ -117,6 +117,8 @@ interface QuickActionsModalProps {
 	onOpenSymphony?: () => void;
 	// Director's Notes
 	onOpenDirectorNotes?: () => void;
+	// Unified Inbox
+	onOpenAgentInbox?: () => void;
 	// Auto-scroll
 	autoScrollAiMode?: boolean;
 	setAutoScrollAiMode?: (value: boolean) => void;
@@ -204,6 +206,7 @@ export const QuickActionsModal = memo(function QuickActionsModal(props: QuickAct
 		onOpenLastDocumentGraph,
 		onOpenSymphony,
 		onOpenDirectorNotes,
+		onOpenAgentInbox,
 		autoScrollAiMode,
 		setAutoScrollAiMode,
 	} = props;
@@ -1029,6 +1032,21 @@ export const QuickActionsModal = memo(function QuickActionsModal(props: QuickAct
 						subtext: 'View unified history and AI synopsis across all sessions',
 						action: () => {
 							onOpenDirectorNotes();
+							setQuickActionOpen(false);
+						},
+					},
+				]
+			: []),
+		// Unified Inbox - centralized agent conversations
+		...(onOpenAgentInbox
+			? [
+					{
+						id: 'agentInbox',
+						label: 'Unified Inbox',
+						shortcut: shortcuts.agentInbox,
+						subtext: 'Centralized view of all agent conversations with Focus Mode',
+						action: () => {
+							onOpenAgentInbox();
 							setQuickActionOpen(false);
 						},
 					},

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -37,6 +37,7 @@ import {
 	Clapperboard,
 	HelpCircle,
 	AppWindow,
+	Inbox,
 } from 'lucide-react';
 import { useSettings } from '../hooks';
 import type {
@@ -3637,6 +3638,75 @@ export const SettingsModal = memo(function SettingsModal(props: SettingsModalPro
 											</div>
 										);
 									})()}
+							</div>
+
+							{/* Unified Inbox Feature Section */}
+							<div
+								className="rounded-lg border"
+								style={{
+									borderColor: encoreFeatures.unifiedInbox
+										? theme.colors.accent
+										: theme.colors.border,
+									backgroundColor: encoreFeatures.unifiedInbox
+										? `${theme.colors.accent}08`
+										: 'transparent',
+								}}
+							>
+								<div className="w-full flex items-center justify-between p-4">
+									<div className="flex items-center gap-3">
+										<Inbox
+											className="w-5 h-5"
+											style={{
+												color: encoreFeatures.unifiedInbox
+													? theme.colors.accent
+													: theme.colors.textDim,
+											}}
+										/>
+										<div>
+											<div
+												className="text-sm font-bold flex items-center gap-2"
+												style={{ color: theme.colors.textMain }}
+											>
+												Unified Inbox
+												<span
+													className="px-1.5 py-0.5 rounded text-[9px] font-bold uppercase"
+													style={{
+														backgroundColor: theme.colors.warning + '30',
+														color: theme.colors.warning,
+													}}
+												>
+													Beta
+												</span>
+											</div>
+											<div className="text-xs mt-0.5" style={{ color: theme.colors.textDim }}>
+												Cross-agent inbox to triage and reply to all active conversations (Alt+I)
+											</div>
+										</div>
+									</div>
+									<button
+										role="switch"
+										aria-checked={encoreFeatures.unifiedInbox}
+										onClick={(e) => {
+											e.stopPropagation();
+											setEncoreFeatures({
+												...encoreFeatures,
+												unifiedInbox: !encoreFeatures.unifiedInbox,
+											});
+										}}
+										className="relative w-10 h-5 rounded-full transition-colors flex-shrink-0"
+										style={{
+											backgroundColor: encoreFeatures.unifiedInbox
+												? theme.colors.accent
+												: theme.colors.bgActivity,
+										}}
+									>
+										<span
+											className={`absolute left-0 top-0.5 w-4 h-4 rounded-full bg-white transition-transform ${
+												encoreFeatures.unifiedInbox ? 'translate-x-5' : 'translate-x-0.5'
+											}`}
+										/>
+									</button>
+								</div>
 							</div>
 						</div>
 					)}

--- a/src/renderer/constants/modalPriorities.ts
+++ b/src/renderer/constants/modalPriorities.ts
@@ -191,6 +191,9 @@ export const MODAL_PRIORITIES = {
 	/** Update check modal */
 	UPDATE_CHECK: 610,
 
+	/** Unified Inbox modal — agent inbox with focus mode */
+	AGENT_INBOX: 555,
+
 	/** Process monitor modal */
 	PROCESS_MONITOR: 550,
 

--- a/src/renderer/constants/shortcuts.ts
+++ b/src/renderer/constants/shortcuts.ts
@@ -78,6 +78,7 @@ export const DEFAULT_SHORTCUTS: Record<string, Shortcut> = {
 		label: "Director's Notes",
 		keys: ['Meta', 'Shift', 'o'],
 	},
+	agentInbox: { id: 'agentInbox', label: 'Unified Inbox', keys: ['Alt', 'i'] },
 };
 
 // Non-editable shortcuts (displayed in help but not configurable)

--- a/src/renderer/hooks/keyboard/useMainKeyboardHandler.ts
+++ b/src/renderer/hooks/keyboard/useMainKeyboardHandler.ts
@@ -420,6 +420,14 @@ export function useMainKeyboardHandler(): UseMainKeyboardHandlerReturn {
 				e.preventDefault();
 				ctx.setDirectorNotesOpen?.(true);
 				trackShortcut('directorNotes');
+			} else if (
+				ctx.isShortcut(e, 'agentInbox') &&
+				ctx.encoreFeatures?.unifiedInbox &&
+				ctx.setAgentInboxOpen
+			) {
+				e.preventDefault();
+				ctx.setAgentInboxOpen(true);
+				trackShortcut('agentInbox');
 			} else if (ctx.isShortcut(e, 'jumpToBottom')) {
 				e.preventDefault();
 				// Jump to the bottom of the current main panel output (AI logs or terminal output)

--- a/src/renderer/hooks/useAgentInbox.ts
+++ b/src/renderer/hooks/useAgentInbox.ts
@@ -1,0 +1,234 @@
+import { useMemo } from 'react';
+import type { Session, Group } from '../types';
+import type { InboxItem, InboxFilterMode, InboxSortMode } from '../types/agent-inbox';
+import { getTabDisplayName } from '../utils/tabDisplayName';
+
+const MAX_MESSAGE_LENGTH = 90;
+const DEFAULT_MESSAGE = 'No activity yet';
+const ELLIPSIS = '...';
+
+/**
+ * Determines whether a session/tab combination should be included
+ * based on the current filter mode.
+ */
+function matchesFilter(
+	sessionState: Session['state'],
+	hasUnread: boolean,
+	filterMode: InboxFilterMode,
+	isStarred: boolean
+): boolean {
+	switch (filterMode) {
+		case 'all':
+			return true;
+		case 'unread':
+			return hasUnread === true;
+		case 'read':
+			return hasUnread === false;
+		case 'starred':
+			return isStarred === true;
+		default:
+			return false;
+	}
+}
+
+/**
+ * Truncates text to MAX_MESSAGE_LENGTH with ellipsis.
+ */
+export function truncate(text: string): string {
+	if (text.length <= MAX_MESSAGE_LENGTH) return text;
+	const maxWithoutEllipsis = Math.max(0, MAX_MESSAGE_LENGTH - ELLIPSIS.length);
+	return text.slice(0, maxWithoutEllipsis) + ELLIPSIS;
+}
+
+/**
+ * Extracts the first sentence from text (up to the first period, exclamation, or newline).
+ */
+function firstSentence(text: string): string {
+	const match = text.match(/^[^.!?\n]+[.!?]?/);
+	return match ? match[0].trim() : text.trim();
+}
+
+/**
+ * Generates a 1-line smart summary from a tab's logs and session state.
+ *
+ * Rules:
+ * - waiting_input: "Waiting: " + last AI message snippet
+ * - Last AI message ends with "?": show the question directly
+ * - Last AI message is a statement: "Done: " + first sentence
+ * - Empty logs: "No activity yet"
+ */
+export function generateSmartSummary(
+	logs: Session['aiLogs'] | undefined,
+	sessionState: Session['state']
+): string {
+	const safeLogs = logs ?? [];
+	if (safeLogs.length === 0) return DEFAULT_MESSAGE;
+
+	// Look at the last 3 entries to find the most recent AI message
+	const recentLogs = safeLogs.slice(-3);
+	let lastAiText: string | undefined;
+	for (let i = recentLogs.length - 1; i >= 0; i--) {
+		const entry = recentLogs[i];
+		if (!entry?.text) continue;
+		if (entry.source === 'ai') {
+			lastAiText = entry.text.trim();
+			break;
+		}
+	}
+
+	// If session is waiting for input, prefix with "Waiting: "
+	if (sessionState === 'waiting_input') {
+		if (lastAiText) return truncate('Waiting: ' + lastAiText);
+		return truncate('Waiting: awaiting your response');
+	}
+
+	// If we found an AI message
+	if (lastAiText) {
+		// If it ends with a question mark, show the question directly
+		if (lastAiText.endsWith('?')) return truncate(lastAiText);
+		// Statement — prefix with "Done: " + first sentence
+		return truncate('Done: ' + firstSentence(lastAiText));
+	}
+
+	// Fallback: use last log entry text regardless of source
+	const lastLog = safeLogs[safeLogs.length - 1];
+	if (lastLog?.text) return truncate(lastLog.text);
+
+	return DEFAULT_MESSAGE;
+}
+
+/**
+ * Derives a valid timestamp from available data.
+ * Falls back through: last log entry → tab createdAt → Date.now()
+ */
+function deriveTimestamp(logs: Session['aiLogs'] | undefined, tabCreatedAt: number): number {
+	// Try last log entry timestamp
+	if (logs && logs.length > 0) {
+		const lastTs = logs[logs.length - 1]?.timestamp;
+		if (lastTs && Number.isFinite(lastTs) && lastTs > 0) return lastTs;
+	}
+	// Try tab createdAt
+	if (Number.isFinite(tabCreatedAt) && tabCreatedAt > 0) return tabCreatedAt;
+	// Fallback
+	return Date.now();
+}
+
+/**
+ * Sorts InboxItems based on the selected sort mode.
+ */
+function sortItems(items: InboxItem[], sortMode: InboxSortMode): InboxItem[] {
+	const sorted = [...items];
+	switch (sortMode) {
+		case 'newest':
+			sorted.sort((a, b) => b.timestamp - a.timestamp);
+			break;
+		case 'oldest':
+			sorted.sort((a, b) => a.timestamp - b.timestamp);
+			break;
+		case 'grouped':
+			sorted.sort((a, b) => {
+				// Ungrouped (no groupName) goes last
+				const aGroup = a.groupName ?? '\uffff';
+				const bGroup = b.groupName ?? '\uffff';
+				const groupCompare = aGroup.localeCompare(bGroup);
+				if (groupCompare !== 0) return groupCompare;
+				// Within same group, sort by timestamp descending
+				return b.timestamp - a.timestamp;
+			});
+			break;
+		case 'byAgent': {
+			// Step 1: Group items by sessionId (unique) — sessionName is display-only
+			const agentGroups = new Map<string, { label: string; items: InboxItem[] }>();
+			for (const item of sorted) {
+				const key = item.sessionId;
+				if (!agentGroups.has(key)) agentGroups.set(key, { label: item.sessionName, items: [] });
+				agentGroups.get(key)!.items.push(item);
+			}
+
+			// Step 2: Pre-compute metadata per group
+			const groupMeta: { key: string; label: string; unreadCount: number; items: InboxItem[] }[] =
+				[];
+			for (const [key, group] of agentGroups) {
+				const unreadCount = group.items.filter((i) => i.hasUnread).length;
+				// Sort items within group: newest first
+				group.items.sort((a, b) => b.timestamp - a.timestamp);
+				groupMeta.push({ key, label: group.label, unreadCount, items: group.items });
+			}
+
+			// Step 3: Sort groups — unreads first (by count desc), then zero-unreads (alphabetical by label)
+			groupMeta.sort((a, b) => {
+				if (a.unreadCount > 0 && b.unreadCount === 0) return -1;
+				if (a.unreadCount === 0 && b.unreadCount > 0) return 1;
+				if (a.unreadCount > 0 && b.unreadCount > 0) return b.unreadCount - a.unreadCount;
+				return a.label.localeCompare(b.label);
+			});
+
+			// Step 4: Flatten back
+			sorted.length = 0;
+			for (const group of groupMeta) {
+				sorted.push(...group.items);
+			}
+			break;
+		}
+	}
+	return sorted;
+}
+
+/**
+ * Data aggregation hook for Agent Inbox.
+ *
+ * Iterates all sessions and their AI tabs, filters based on session state
+ * and tab unread status, then sorts the resulting InboxItems.
+ *
+ * Uses useMemo with exact dependency values (not refs) to prevent stale data.
+ */
+export function useAgentInbox(
+	sessions: Session[],
+	groups: Group[],
+	filterMode: InboxFilterMode,
+	sortMode: InboxSortMode
+): InboxItem[] {
+	return useMemo(() => {
+		// Build group lookup map for O(1) access
+		const groupMap = new Map<string, Group>();
+		for (const group of groups) {
+			groupMap.set(group.id, group);
+		}
+
+		const items: InboxItem[] = [];
+
+		for (const session of sessions) {
+			// Skip sessions with falsy id
+			if (!session.id) continue;
+
+			const tabs = session.aiTabs ?? [];
+
+			for (const tab of tabs) {
+				const hasUnread = tab.hasUnread === true;
+
+				if (!matchesFilter(session.state, hasUnread, filterMode, tab.starred === true)) continue;
+
+				const parentGroup = session.groupId ? groupMap.get(session.groupId) : undefined;
+
+				items.push({
+					sessionId: session.id,
+					tabId: tab.id,
+					groupId: session.groupId ?? undefined,
+					groupName: parentGroup?.name ?? undefined,
+					sessionName: session.name,
+					tabName: getTabDisplayName(tab),
+					toolType: session.toolType,
+					gitBranch: session.worktreeBranch ?? undefined,
+					contextUsage: session.contextUsage ?? undefined,
+					lastMessage: generateSmartSummary(tab.logs, session.state),
+					timestamp: deriveTimestamp(tab.logs, tab.createdAt),
+					state: session.state,
+					hasUnread,
+					starred: tab.starred === true,
+				});
+			}
+		}
+
+		return sortItems(items, sortMode);
+	}, [sessions, groups, filterMode, sortMode]);
+}

--- a/src/renderer/stores/settingsStore.ts
+++ b/src/renderer/stores/settingsStore.ts
@@ -109,6 +109,7 @@ export const DEFAULT_ONBOARDING_STATS: OnboardingStats = {
 
 export const DEFAULT_ENCORE_FEATURES: EncoreFeatureFlags = {
 	directorNotes: false,
+	unifiedInbox: false,
 };
 
 export const DEFAULT_DIRECTOR_NOTES_SETTINGS: DirectorNotesSettings = {

--- a/src/renderer/types/agent-inbox.ts
+++ b/src/renderer/types/agent-inbox.ts
@@ -1,0 +1,47 @@
+import type { SessionState } from './index';
+
+export interface InboxItem {
+	sessionId: string;
+	tabId: string;
+	groupId?: string;
+	groupName?: string;
+	sessionName: string;
+	tabName?: string;
+	toolType: string;
+	gitBranch?: string;
+	contextUsage?: number; // 0-100, undefined = unknown
+	lastMessage: string; // truncated to 90 chars
+	timestamp: number; // Unix ms, must be validated > 0
+	state: SessionState;
+	hasUnread: boolean;
+	starred?: boolean;
+}
+
+/** UI labels: "Newest", "Oldest", "Grouped", "By Agent" */
+export type InboxSortMode = 'newest' | 'oldest' | 'grouped' | 'byAgent';
+
+/** UI labels: "All", "Unread", "Read", "Starred" */
+export type InboxFilterMode = 'all' | 'unread' | 'read' | 'starred';
+
+/** Human-readable status badges */
+export const STATUS_LABELS: Record<SessionState, string> = {
+	idle: 'Ready',
+	waiting_input: 'Needs Input',
+	busy: 'Processing',
+	connecting: 'Connecting',
+	error: 'Error',
+};
+
+// Note: Values are not keyof ThemeColors — 'info' and 'textMuted' are resolved
+// through a local colorMap in resolveStatusColor(), not direct ThemeColors keys.
+/** Status badge color keys (map to theme.colors.* via resolveStatusColor()) */
+export const STATUS_COLORS: Record<SessionState, string> = {
+	idle: 'success',
+	waiting_input: 'warning',
+	busy: 'info',
+	connecting: 'textMuted',
+	error: 'error',
+};
+
+/** View mode inside the AgentInbox modal */
+export type InboxViewMode = 'list' | 'focus';

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -905,6 +905,7 @@ export interface LeaderboardSubmitResponse {
 // Each key is a feature ID, value indicates whether it's enabled
 export interface EncoreFeatureFlags {
 	directorNotes: boolean;
+	unifiedInbox: boolean;
 }
 
 // Director's Notes settings for synopsis generation

--- a/src/renderer/utils/tabDisplayName.ts
+++ b/src/renderer/utils/tabDisplayName.ts
@@ -1,0 +1,40 @@
+import type { AITab } from '../types';
+
+/**
+ * Get the display name for a tab.
+ * Priority: name > truncated session ID > "New Session"
+ *
+ * Handles different agent session ID formats:
+ * - Claude UUID: "abc123-def456-ghi789" → "ABC123" (first octet)
+ * - OpenCode: "SES_4BCDFE8C5FFE4KC1UV9NSMYEDB" → "SES_4BCD" (prefix + 4 chars)
+ * - Codex: "thread_abc123..." → "THR_ABC1" (prefix + 4 chars)
+ */
+export function getTabDisplayName(tab: Pick<AITab, 'name' | 'agentSessionId'>): string {
+	if (tab.name) {
+		return tab.name;
+	}
+	if (tab.agentSessionId) {
+		const id = tab.agentSessionId;
+
+		// OpenCode format: ses_XXXX... or SES_XXXX...
+		if (id.toLowerCase().startsWith('ses_')) {
+			// Return "SES_" + first 4 chars of the ID portion
+			return `SES_${id.slice(4, 8).toUpperCase()}`;
+		}
+
+		// Codex format: thread_XXXX...
+		if (id.toLowerCase().startsWith('thread_')) {
+			// Return "THR_" + first 4 chars of the ID portion
+			return `THR_${id.slice(7, 11).toUpperCase()}`;
+		}
+
+		// Claude UUID format: has dashes, return first octet
+		if (id.includes('-')) {
+			return id.split('-')[0].toUpperCase();
+		}
+
+		// Generic fallback: first 8 chars uppercase
+		return id.slice(0, 8).toUpperCase();
+	}
+	return 'New Session';
+}


### PR DESCRIPTION
## Summary

Adds a fully gated Unified Inbox feature behind the `encoreFeatures.unifiedInbox` flag (disabled by default). The inbox aggregates the latest messages from all active agents into a single, keyboard-navigable overlay with focus mode for deep-dive reading and inline replies.

### Key changes:
- **6 new source files**: `AgentInbox/index.tsx`, `InboxListView.tsx`, `FocusModeView.tsx`, `useAgentInbox.ts`, `agent-inbox.ts` types, `tabDisplayName.ts` utility
- **App.tsx integration**: lazy import, 5 handler functions, ref binding, conditional rendering
- **Keyboard shortcut**: `Alt+I` opens inbox (triple-gated: shortcut match + feature flag + setter exists)
- **Command palette**: Unified Inbox wired into `Cmd+K` quick actions with encore gating
- **Settings UI**: Toggle added to SettingsModal Encore section with ARIA attributes
- **Modal system**: `agentInbox` registered in modalStore with `AgentInboxModalData` type

### Fixes applied from review branches:
- **Race condition**: Resize observer cleanup prevents stale layout after unmount
- **Resize leak**: Observer properly disconnected on component teardown
- **Group keys**: Sort-by-agent uses `sessionId` (stable) not `sessionName` (mutable)
- **Duplicate logs**: Deduplication guard prevents repeated console entries
- **AI mode forcing**: Focus mode no longer forces terminal mode switch
- **ARIA compliance**: Proper roles, labels, and keyboard navigation attributes
- **Performance**: `useMemo`/`useCallback` on filters, sorts, and derived data; double-rAF focus instead of setTimeout hack

### Test coverage:
- `useAgentInbox.test.ts`: 26 tests (filters, sorts, truncation, timestamp fallback)
- `AgentInbox.test.tsx`: 18 tests (render, filter pills, keyboard nav, escape, focus mode, reply)
- `modalStore.test.ts`: Updated 1 test to reflect new `updateModalData` behavior (stores data on unopened modals)

## Test plan

- [ ] Enable `unifiedInbox` in Settings > Encore and verify `Alt+I` opens the inbox
- [ ] Verify inbox shows latest messages from all active agents
- [ ] Test filter pills: all, unread, read, starred
- [ ] Test sort modes: newest, oldest, grouped, by agent
- [ ] Enter focus mode (Enter/double-click) and verify message thread display
- [ ] Test reply input sends to correct agent tab
- [ ] Verify `Escape` closes inbox and returns focus to previous element
- [ ] Verify `Cmd+K` shows "Open Unified Inbox" when feature is enabled
- [ ] Verify inbox is completely invisible when feature flag is disabled
- [ ] Run `npm run test` — all non-baseline failures should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Unified Inbox feature with dual list and focus modes for managing conversations
  * Filtering options: All, Unread, Read, Starred
  * Sorting options: Newest, Oldest, Grouped, By Agent
  * Focus mode for detailed conversation view with reply composer
  * Keyboard shortcut (Alt+I) and quick action access for unified inbox
  * Context usage indicators and thinking mode toggle
  * Settings toggle to enable/disable unified inbox

* **Tests**
  * Comprehensive test coverage for inbox components, hooks, and modal state management
<!-- end of auto-generated comment: release notes by coderabbit.ai -->