### PR TITLE
fix: correct zustand useShallow import path in AppModals

### DIFF
--- a/src/renderer/components/AppModals.tsx
+++ b/src/renderer/components/AppModals.tsx
@@ -21,7 +21,7 @@
  */
 
 import React, { lazy, Suspense, memo, useMemo } from 'react';
-import { useShallow } from 'zustand/shallow';
+import { useShallow } from 'zustand/react/shallow';
 import { useSessionStore } from '../stores/sessionStore';
 import { useGroupChatStore } from '../stores/groupChatStore';
 import { useModalStore } from '../stores/modalStore';


### PR DESCRIPTION
## Summary
- Fixed incorrect `useShallow` import path in `AppModals.tsx` from `zustand/shallow` to `zustand/react/shallow`
- The wrong path caused `useShallow` to resolve as `unknown` in zustand 4.5.x, cascading into 30+ type errors on destructured modal properties

## Test plan
- [x] `npm run lint` passes
- [x] `npm run lint:eslint` passes
- [x] `npm run test` passes (508 files, 21,547 tests, 0 failures)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal module dependencies for improved code organization.

---

**Note:** This release contains internal maintenance updates with no user-visible changes or new features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->