### PR TITLE
tab: enforce deterministic model arg and improve tab-name extraction (opencode)

### DIFF
--- a/src/__tests__/main/ipc/handlers/tabNaming.test.ts
+++ b/src/__tests__/main/ipc/handlers/tabNaming.test.ts
@@ -479,9 +479,10 @@ describe('Tab Naming IPC Handlers', () => {
 			expect(result).toBeNull();
 		});
 
-		it('filters out lines starting with quotes (example inputs)', async () => {
-			// Lines starting with quotes are filtered as they typically represent
-			// example inputs in the prompt, not actual tab names
+		it('unquotes fully-wrapped quoted output (e.g. agent wraps name in quotes)', async () => {
+			// extractTabName accepts fully-wrapped quoted strings and strips the quotes.
+			// A line like `"Quoted Tab Name"` is kept (isWrappedQuoted = true) and
+			// returned as 'Quoted Tab Name' — only partially-quoted lines are discarded.
 			let onDataCallback: ((sessionId: string, data: string) => void) | undefined;
 			let onExitCallback: ((sessionId: string) => void) | undefined;
 
@@ -502,13 +503,13 @@ describe('Tab Naming IPC Handlers', () => {
 				expect(mockProcessManager.spawn).toHaveBeenCalled();
 			});
 
-			// Simulate output with quotes - lines starting with " are filtered
+			// Fully-wrapped quoted output: the agent wraps the tab name in quotes.
+			// extractTabName unquotes and returns the inner string.
 			onDataCallback?.('tab-naming-mock-uuid-1234', '"Quoted Tab Name"');
 			onExitCallback?.('tab-naming-mock-uuid-1234');
 
 			const result = await resultPromise;
-			// Lines starting with quotes are filtered out as example inputs
-			expect(result).toBeNull();
+			expect(result).toBe('Quoted Tab Name');
 		});
 
 		it('removes trailing quotes from tab names', async () => {

--- a/src/__tests__/main/ipc/handlers/tabNaming.test.ts
+++ b/src/__tests__/main/ipc/handlers/tabNaming.test.ts
@@ -59,7 +59,7 @@ vi.mock('../../../../main/utils/ssh-remote-resolver', () => ({
 }));
 
 vi.mock('../../../../main/utils/ssh-command-builder', () => ({
-	buildSshCommand: vi.fn(),
+	buildSshCommandWithStdin: vi.fn(),
 }));
 
 // Capture registered handlers
@@ -543,7 +543,8 @@ describe('Tab Naming IPC Handlers', () => {
 		it('uses stdin for prompt when SSH remote is configured', async () => {
 			// Import and mock the SSH utilities
 			const { getSshRemoteConfig } = await import('../../../../main/utils/ssh-remote-resolver');
-			const { buildSshCommand } = await import('../../../../main/utils/ssh-command-builder');
+			const { buildSshCommandWithStdin } =
+				await import('../../../../main/utils/ssh-command-builder');
 
 			// Mock SSH config resolution to return a valid config
 			(getSshRemoteConfig as Mock).mockReturnValue({
@@ -555,25 +556,13 @@ describe('Tab Naming IPC Handlers', () => {
 				source: 'session',
 			});
 
-			// Mock buildSshCommand to return SSH-wrapped command
-			(buildSshCommand as Mock).mockResolvedValue({
+			// Mock buildSshCommandWithStdin to return SSH-wrapped command
+			(buildSshCommandWithStdin as Mock).mockResolvedValue({
 				command: '/usr/bin/ssh',
-				args: [
-					'-o',
-					'BatchMode=yes',
-					'test.example.com',
-					'claude --print --input-format stream-json',
-				],
+				args: ['-o', 'BatchMode=yes', 'test.example.com', '/bin/bash'],
+				stdinScript:
+					'export PATH=...\nexec claude run --format json\nHelp me with SSH remote feature',
 			});
-
-			// Update mock agent to support stream-json input
-			const mockAgentWithStreamJson: AgentConfig = {
-				...mockClaudeAgent,
-				capabilities: {
-					supportsStreamJsonInput: true,
-				},
-			};
-			mockAgentDetector.getAgent.mockResolvedValue(mockAgentWithStreamJson);
 
 			let onDataCallback: ((sessionId: string, data: string) => void) | undefined;
 			let onExitCallback: ((sessionId: string) => void) | undefined;
@@ -599,18 +588,18 @@ describe('Tab Naming IPC Handlers', () => {
 				expect(mockProcessManager.spawn).toHaveBeenCalled();
 			});
 
-			// Verify spawn was called with sendPromptViaStdin flag
+			// Verify spawn was called with sshStdinScript
 			expect(mockProcessManager.spawn).toHaveBeenCalledWith(
 				expect.objectContaining({
-					sendPromptViaStdin: true,
+					sshStdinScript: expect.any(String),
 				})
 			);
 
-			// Verify buildSshCommand was called with useStdin option
-			expect(buildSshCommand).toHaveBeenCalledWith(
+			// Verify buildSshCommandWithStdin was called with stdinInput (the prompt)
+			expect(buildSshCommandWithStdin).toHaveBeenCalledWith(
 				expect.anything(),
 				expect.objectContaining({
-					useStdin: true,
+					stdinInput: expect.any(String),
 				})
 			);
 

--- a/src/main/agents/definitions.ts
+++ b/src/main/agents/definitions.ts
@@ -97,6 +97,8 @@ export interface AgentConfig {
 	noPromptSeparator?: boolean; // If true, don't add '--' before the prompt in batch mode (OpenCode doesn't support it)
 	defaultEnvVars?: Record<string, string>; // Default environment variables for this agent (merged with user customEnvVars)
 	readOnlyEnvOverrides?: Record<string, string>; // Env var overrides applied in read-only mode (replaces keys from defaultEnvVars)
+	// Optional default model id discovered from the agent's local config or binary
+	defaultModel?: string;
 }
 
 /**

--- a/src/main/ipc/handlers/tabNaming.ts
+++ b/src/main/ipc/handlers/tabNaming.ts
@@ -177,10 +177,11 @@ export function registerTabNamingHandlers(deps: TabNamingHandlerDependencies): v
 						// modelId intentionally omitted — applyAgentConfigOverrides is the single source of model injection
 					});
 
-					// Apply config overrides from store (other overrides such as customArgs/env)
+					// Apply config overrides from store (customArgs/env only).
+					// Do NOT pass sessionCustomModel here so modelSource reflects the true origin
+					// (agent-config or default). resolvedModelId is applied explicitly below.
 					const configResolution = applyAgentConfigOverrides(agent, finalArgs, {
 						agentConfigValues,
-						sessionCustomModel: resolvedModelId,
 					});
 					finalArgs = configResolution.args;
 
@@ -191,7 +192,7 @@ export function registerTabNamingHandlers(deps: TabNamingHandlerDependencies): v
 						agentType: config.agentType,
 						modelSource: configResolution.modelSource,
 						agentConfigModel: agentConfigValues?.model,
-						finalArgsPreview: finalArgs.slice(0, 40),
+						resolvedModelId,
 					});
 
 					// Canonicalize model flags: strip all existing --model/-m tokens before the
@@ -341,12 +342,9 @@ export function registerTabNamingHandlers(deps: TabNamingHandlerDependencies): v
 									agentType: config.agentType,
 									agentConfigModel: agentConfigValues?.model,
 									resolvedModelId,
-									finalArgsPreview: finalArgs.slice(0, 40),
-									promptPreview: fullPrompt
-										? `${String(fullPrompt).slice(0, 200)}${String(fullPrompt).length > 200 ? '...' : ''}`
-										: undefined,
-									rawOutputPreview: `${String(output).slice(0, 200)}${String(output).length > 200 ? '...' : ''}`,
-									rawOutputLength: String(output).length,
+									finalArgsCount: finalArgs.length,
+									promptLength: String(fullPrompt).length,
+									outputLength: String(output).length,
 								});
 								// Detect obviously generic outputs to surface in logs
 								const genericRegex =
@@ -384,10 +382,9 @@ export function registerTabNamingHandlers(deps: TabNamingHandlerDependencies): v
 						// (kept in console.debug for diagnosis only)
 						safeDebug('[TabNaming] About to spawn with final args', {
 							sessionId,
-							command,
-							cwd,
+							agentType: config.agentType,
 							hasSshStdinScript: !!sshStdinScript,
-							finalArgsDetail: finalArgs.map((a) => ({ value: a, type: typeof a })),
+							finalArgsCount: finalArgs.length,
 						});
 
 						processManager.spawn({

--- a/src/main/ipc/handlers/tabNaming.ts
+++ b/src/main/ipc/handlers/tabNaming.ts
@@ -307,17 +307,17 @@ export function registerTabNamingHandlers(deps: TabNamingHandlerDependencies): v
 					}
 
 					// Final safety sanitization: ensure args are all plain strings
-					try {
-						const nonStringItems = finalArgs.filter((a) => typeof a !== 'string');
-						if (nonStringItems.length > 0) {
+					const nonStringItems = finalArgs.filter((a) => typeof a !== 'string');
+					if (nonStringItems.length > 0) {
+						finalArgs = finalArgs.filter((a) => typeof a === 'string');
+						try {
 							safeDebug('[TabNaming] Removing non-string args before spawn', {
 								sessionId,
 								removed: nonStringItems.map((i) => ({ typeof: typeof i, preview: String(i) })),
 							});
-							finalArgs = finalArgs.filter((a) => typeof a === 'string');
+						} catch {
+							// swallow logging errors
 						}
-					} catch (err) {
-						// swallow safety log errors
 					}
 
 					// Create a promise that resolves when we get the tab name
@@ -373,15 +373,16 @@ export function registerTabNamingHandlers(deps: TabNamingHandlerDependencies): v
 								const genericRegex =
 									/^("|')?\s*(coding task|task tab name|task tab|coding task tab|task name)\b/i;
 								if (genericRegex.test(String(output))) {
-									console.warn(
+									logger.warn(
 										'[TabNaming] Agent returned a generic tab name candidate; consider adjusting prompt or model',
+										LOG_CONTEXT,
 										{
 											sessionId,
 											detected: String(output).trim().slice(0, 80),
 										}
 									);
 								}
-							} catch (err) {
+							} catch {
 								// swallow logging errors
 							}
 
@@ -401,19 +402,15 @@ export function registerTabNamingHandlers(deps: TabNamingHandlerDependencies): v
 						// Spawn the process
 						// When using SSH with stdin, pass the flag so ChildProcessSpawner
 						// sends the prompt via stdin instead of command line args
-						try {
-							// Debug: log full finalArgs array and types just before spawn
-							// (kept in console.debug for diagnosis only)
-							safeDebug('[TabNaming] About to spawn with final args', {
-								sessionId,
-								command,
-								cwd,
-								sendPromptViaStdin: shouldSendPromptViaStdin,
-								finalArgsDetail: finalArgs.map((a) => ({ value: a, type: typeof a })),
-							});
-						} catch (err) {
-							// ignore logging failures
-						}
+						// Debug: log full finalArgs array and types just before spawn
+						// (kept in console.debug for diagnosis only)
+						safeDebug('[TabNaming] About to spawn with final args', {
+							sessionId,
+							command,
+							cwd,
+							sendPromptViaStdin: shouldSendPromptViaStdin,
+							finalArgsDetail: finalArgs.map((a) => ({ value: a, type: typeof a })),
+						});
 
 						processManager.spawn({
 							sessionId,

--- a/src/main/ipc/handlers/tabNaming.ts
+++ b/src/main/ipc/handlers/tabNaming.ts
@@ -213,11 +213,17 @@ export function registerTabNamingHandlers(deps: TabNamingHandlerDependencies): v
 								continue; // drop explicit --model=value
 							}
 							if (a === '--model') {
-								i++; // drop flag + value
+								// Only consume the next token as a value if it exists and looks like a value (not a flag)
+								if (i + 1 < prefix.length && typeof prefix[i + 1] === 'string' && !String(prefix[i + 1]).startsWith('-')) {
+									i++;
+								}
 								continue;
 							}
-							if (a === '-m' && i + 1 < prefix.length) {
-								i++; // drop short form + value
+							if (a === '-m') {
+								// Only consume the next token as a value if it exists and looks like a value (not a flag)
+								if (i + 1 < prefix.length && typeof prefix[i + 1] === 'string' && !String(prefix[i + 1]).startsWith('-')) {
+									i++;
+								}
 								continue;
 							}
 						}
@@ -228,18 +234,15 @@ export function registerTabNamingHandlers(deps: TabNamingHandlerDependencies): v
 					// agent-config > agent-default precedence. Use agent.modelArgs() when available
 					// so each agent gets its own flag style.
 					if (resolvedModelId) {
-						const sanitized = resolvedModelId.replace(/\/+$/, '').trim();
-						if (sanitized) {
-							const modelArgTokens = agent.modelArgs
-								? agent.modelArgs(sanitized)
-								: [`--model=${sanitized}`];
-							filteredPrefix.push(...modelArgTokens);
-							safeDebug('[TabNaming] Injected canonical model flag for spawn', {
-								sessionId,
-								modelLength: sanitized.length,
-								tokenCount: modelArgTokens.length,
-							});
-						}
+						const modelArgTokens = agent.modelArgs
+							? agent.modelArgs(resolvedModelId)
+							: [`--model=${resolvedModelId}`];
+						filteredPrefix.push(...modelArgTokens);
+						safeDebug('[TabNaming] Injected canonical model flag for spawn', {
+							sessionId,
+							modelLength: resolvedModelId.length,
+							tokenCount: modelArgTokens.length,
+						});
 					}
 
 					finalArgs = [...filteredPrefix, ...suffix];

--- a/src/main/ipc/handlers/tabNaming.ts
+++ b/src/main/ipc/handlers/tabNaming.ts
@@ -236,8 +236,8 @@ export function registerTabNamingHandlers(deps: TabNamingHandlerDependencies): v
 							filteredPrefix.push(...modelArgTokens);
 							safeDebug('[TabNaming] Injected canonical model flag for spawn', {
 								sessionId,
-								model: sanitized,
-								tokens: modelArgTokens,
+								modelLength: sanitized.length,
+								tokenCount: modelArgTokens.length,
 							});
 						}
 					}
@@ -290,14 +290,10 @@ export function registerTabNamingHandlers(deps: TabNamingHandlerDependencies): v
 					const nonStringItems = finalArgs.filter((a) => typeof a !== 'string');
 					if (nonStringItems.length > 0) {
 						finalArgs = finalArgs.filter((a) => typeof a === 'string');
-						try {
-							safeDebug('[TabNaming] Removing non-string args before spawn', {
-								sessionId,
-								removed: nonStringItems.map((i) => ({ typeof: typeof i, preview: String(i) })),
-							});
-						} catch {
-							// swallow logging errors
-						}
+						safeDebug('[TabNaming] Removing non-string args before spawn', {
+							sessionId,
+							removedCount: nonStringItems.length,
+						});
 					}
 
 					// Create a promise that resolves when we get the tab name
@@ -355,7 +351,7 @@ export function registerTabNamingHandlers(deps: TabNamingHandlerDependencies): v
 										LOG_CONTEXT,
 										{
 											sessionId,
-											detected: String(output).trim().slice(0, 80),
+											outputLength: String(output).length,
 										}
 									);
 								}

--- a/src/main/ipc/handlers/tabNaming.ts
+++ b/src/main/ipc/handlers/tabNaming.ts
@@ -20,7 +20,7 @@ import {
 } from '../../utils/ipcHandler';
 import { buildAgentArgs, applyAgentConfigOverrides } from '../../utils/agent-args';
 import { getSshRemoteConfig, createSshRemoteStoreAdapter } from '../../utils/ssh-remote-resolver';
-import { buildSshCommand } from '../../utils/ssh-command-builder';
+import { buildSshCommandWithStdin } from '../../utils/ssh-command-builder';
 import { tabNamingPrompt } from '../../../prompts';
 import type { ProcessManager } from '../../process-manager';
 import type { AgentDetector } from '../../agents';
@@ -174,7 +174,7 @@ export function registerTabNamingHandlers(deps: TabNamingHandlerDependencies): v
 						prompt: fullPrompt,
 						cwd: config.cwd,
 						readOnlyMode: true, // Always read-only since we're not modifying anything
-						modelId: resolvedModelId,
+						// modelId intentionally omitted — applyAgentConfigOverrides is the single source of model injection
 					});
 
 					// Apply config overrides from store (other overrides such as customArgs/env)
@@ -253,10 +253,10 @@ export function registerTabNamingHandlers(deps: TabNamingHandlerDependencies): v
 							: undefined;
 
 					// Handle SSH remote execution if configured
-					// IMPORTANT: For SSH, we must send the prompt via stdin to avoid shell escaping issues.
-					// The prompt contains special characters that break when passed through multiple layers
-					// of shell escaping (local spawn -> SSH -> remote zsh -> bash -c).
-					let shouldSendPromptViaStdin = false;
+					// Use stdin-based execution to completely bypass shell escaping issues.
+					// The prompt contains special characters that break when passed through multiple
+					// layers of shell escaping (local spawn -> SSH -> remote bash -c).
+					let sshStdinScript: string | undefined;
 					if (config.sessionSshRemoteConfig?.enabled && config.sessionSshRemoteConfig.remoteId) {
 						const sshStoreAdapter = createSshRemoteStoreAdapter(settingsStore);
 						const sshResult = getSshRemoteConfig(sshStoreAdapter, {
@@ -269,38 +269,17 @@ export function registerTabNamingHandlers(deps: TabNamingHandlerDependencies): v
 							const remoteCommand = agent.command;
 							const remoteCwd = config.sessionSshRemoteConfig.workingDirOverride || config.cwd;
 
-							// For agents that support stream-json input, use stdin for the prompt
-							// This completely avoids shell escaping issues with multi-layer SSH commands
-							const agentSupportsStreamJson = agent.capabilities?.supportsStreamJsonInput ?? false;
-							if (agentSupportsStreamJson) {
-								// Add --input-format stream-json to args so agent reads from stdin
-								const inputFormatIdx = finalArgs.indexOf('--input-format');
-								const hasStreamJsonInput =
-									inputFormatIdx !== -1 && finalArgs[inputFormatIdx + 1] === 'stream-json';
-								if (!hasStreamJsonInput) {
-									finalArgs = [...finalArgs, '--input-format', 'stream-json'];
-								}
-								shouldSendPromptViaStdin = true;
-								logger.debug(
-									'Using stdin for tab naming prompt in SSH remote execution',
-									LOG_CONTEXT,
-									{
-										sessionId,
-										promptLength: fullPrompt.length,
-										agentSupportsStreamJson,
-									}
-								);
-							}
-
-							const sshCommand = await buildSshCommand(sshResult.config, {
+							const sshCommand = await buildSshCommandWithStdin(sshResult.config, {
 								command: remoteCommand,
 								args: finalArgs,
 								cwd: remoteCwd,
 								env: customEnvVars,
-								useStdin: shouldSendPromptViaStdin,
+								// Pass the prompt via stdin so it's never parsed by any shell layer
+								stdinInput: fullPrompt,
 							});
 							command = sshCommand.command;
 							finalArgs = sshCommand.args;
+							sshStdinScript = sshCommand.stdinScript;
 							// Local cwd is not used for SSH commands - the command runs on remote
 							cwd = process.cwd();
 						}
@@ -400,15 +379,14 @@ export function registerTabNamingHandlers(deps: TabNamingHandlerDependencies): v
 						processManager.on('exit', onExit);
 
 						// Spawn the process
-						// When using SSH with stdin, pass the flag so ChildProcessSpawner
-						// sends the prompt via stdin instead of command line args
+						// For SSH, sshStdinScript contains the full bash script + prompt
 						// Debug: log full finalArgs array and types just before spawn
 						// (kept in console.debug for diagnosis only)
 						safeDebug('[TabNaming] About to spawn with final args', {
 							sessionId,
 							command,
 							cwd,
-							sendPromptViaStdin: shouldSendPromptViaStdin,
+							hasSshStdinScript: !!sshStdinScript,
 							finalArgsDetail: finalArgs.map((a) => ({ value: a, type: typeof a })),
 						});
 
@@ -420,7 +398,7 @@ export function registerTabNamingHandlers(deps: TabNamingHandlerDependencies): v
 							args: finalArgs,
 							prompt: fullPrompt,
 							customEnvVars,
-							sendPromptViaStdin: shouldSendPromptViaStdin,
+							sshStdinScript,
 						});
 					});
 				} catch (error) {

--- a/src/main/preload/tabNaming.ts
+++ b/src/main/preload/tabNaming.ts
@@ -17,6 +17,8 @@ export interface TabNamingConfig {
 	agentType: string;
 	/** Working directory for the session */
 	cwd: string;
+	/** Optional session-level model override */
+	sessionCustomModel?: string;
 	/** Optional SSH remote configuration */
 	sessionSshRemoteConfig?: {
 		enabled: boolean;

--- a/src/main/process-manager/spawners/ChildProcessSpawner.ts
+++ b/src/main/process-manager/spawners/ChildProcessSpawner.ts
@@ -87,7 +87,11 @@ export class ChildProcessSpawner {
 		const argsHaveInputStreamJson = args.some(
 			(arg, i) => arg === 'stream-json' && i > 0 && args[i - 1] === '--input-format'
 		);
-		const promptViaStdin = sendPromptViaStdin || sendPromptViaStdinRaw || argsHaveInputStreamJson;
+		const promptViaStdin =
+			sendPromptViaStdin ||
+			sendPromptViaStdinRaw ||
+			argsHaveInputStreamJson ||
+			!!config.sshStdinScript;
 
 		// Build final args based on batch mode and images
 		// Track whether the prompt was added to CLI args (used later to decide stdin behavior)

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -2598,6 +2598,7 @@ interface MaestroAPI {
 			userMessage: string;
 			agentType: string;
 			cwd: string;
+			sessionCustomModel?: string;
 			sessionSshRemoteConfig?: {
 				enabled: boolean;
 				remoteId: string | null;

--- a/src/renderer/hooks/input/useInputProcessing.ts
+++ b/src/renderer/hooks/input/useInputProcessing.ts
@@ -709,6 +709,7 @@ export function useInputProcessing(deps: UseInputProcessingDeps): UseInputProces
 							userMessage: effectiveInputValue,
 							agentType: activeSession.toolType,
 							cwd: activeSession.cwd,
+							sessionCustomModel: activeSession.customModel,
 							sessionSshRemoteConfig: activeSession.sessionSshRemoteConfig,
 						})
 						.then((generatedName) => {


### PR DESCRIPTION
This pull request makes significant improvements to the tab naming logic for agent-based sessions, focusing on more robust and predictable model resolution, enhanced argument sanitization, and improved debugging and logging. The changes ensure that the correct model is used for tab naming, prevent invalid or duplicate CLI arguments, and provide better diagnostics for troubleshooting tab naming quality.

**Model Resolution and Argument Handling:**
- Improved the logic for resolving the model ID used in tab naming by strictly preferring (in order): session override, agent config (only if it looks like a valid provider/model), then the agent's default model. The resolved model ID is sanitized to remove trailing slashes and empty values.
- Enhanced argument sanitization by filtering out non-string arguments, deduplicating `--model` flags, converting them to a single `--model=<value>` form, and ensuring only valid model values are passed to the agent CLI. Also, the canonical model flag is injected just before process spawn.

**Debugging and Logging Enhancements:**
- Added detailed debug logging throughout the tab naming process, including resolved model information, argument lists before spawning, and final model values. This aids in diagnosing issues with model selection and argument construction. [[1]](diffhunk://#diff-cf74649048a1af237cb7d5d0410e3aa69a1c9db8c70af0d4fabb4f925be988caR125-R237) [[2]](diffhunk://#diff-cf74649048a1af237cb7d5d0410e3aa69a1c9db8c70af0d4fabb4f925be988caR292-R425) [[3]](diffhunk://#diff-cf74649048a1af237cb7d5d0410e3aa69a1c9db8c70af0d4fabb4f925be988caR509-R523)
- Logged the raw output from the agent before tab name extraction, and added warnings when the agent returns generic or low-quality tab names, helping to identify and address prompt/model issues.

**Tab Name Extraction Improvements:**
- Updated the tab name extraction logic to allow quoted single-line outputs and to apply filtering rules to the unquoted value, making extraction more robust to agent output formatting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session-level model override and per-agent default model support for tab naming; model flags are canonicalized during execution.

* **Bug Fixes**
  * Deterministic model resolution and sanitization to prevent malformed executions.
  * Safer SSH stdin routing so prompts are reliably sent for remote runs.
  * Final-argument sanitization to avoid non-string values.

* **Improvements**
  * Enhanced diagnostics/logging for model resolution, argument construction and spawn details.
  * Better detection/filtering of quoted or spurious outputs when extracting tab names.

* **Tests**
  * Updated tests to cover stdin-driven SSH flow and revised unquoting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->