### PR TITLE
fix: add OPENCODE_CLI_RUN_MODE env var to prevent Auto Run hang with oh-my-opencode plugin

### DIFF
--- a/src/main/agents/definitions.ts
+++ b/src/main/agents/definitions.ts
@@ -221,7 +221,12 @@ export const AGENT_DEFINITIONS: AgentDefinition[] = [
 		// - "question": false in tools block (original approach)
 		// The question tool waits for stdin input which hangs batch mode
 		// Users can override by setting customEnvVars in agent config
+		//
+		// OPENCODE_CLI_RUN_MODE: Signals to plugins (e.g., oh-my-opencode) that OpenCode is
+		// running in headless/batch mode. Without this, plugins may override permission settings
+		// and re-enable the question tool, causing Auto Run to hang indefinitely. See #338.
 		defaultEnvVars: {
+			OPENCODE_CLI_RUN_MODE: 'true',
 			OPENCODE_CONFIG_CONTENT:
 				'{"permission":{"*":"allow","external_directory":"allow","question":"deny"},"tools":{"question":false}}',
 		},


### PR DESCRIPTION
## Summary

Fixes #338 — addresses the root cause of OpenCode agent hanging silently during Auto Run when the [oh-my-opencode](https://github.com/nicepkg/oh-my-opencode) plugin is installed.

## Problem

When oh-my-opencode plugin is present, it checks `process.env.OPENCODE_CLI_RUN_MODE` to determine question tool permissions:

```javascript
// oh-my-opencode/dist/index.js:75452-75453
const isCliRunMode = process.env.OPENCODE_CLI_RUN_MODE === "true";
const questionPermission = isCliRunMode ? "deny" : "allow";
```

Without `OPENCODE_CLI_RUN_MODE` set, the plugin overrides Maestro's `question: "deny"` config (set via `OPENCODE_CONFIG_CONTENT`) with `question: "allow"` at runtime. This causes the agent to prompt for stdin input during Auto Run, hanging indefinitely with no progress indication or timeout.

## Fix

Add `OPENCODE_CLI_RUN_MODE: 'true'` to OpenCode's `defaultEnvVars` in agent definitions. This signals to the plugin that OpenCode is running in headless/batch mode, preserving the `question: "deny"` permission.

**Changes:** 1 line addition + explanatory comments in `src/main/agents/definitions.ts`

## Why This Works

| `OPENCODE_CLI_RUN_MODE` | Plugin behavior | Result |
|---|---|---|
| Not set (current) | Sets `question: "allow"` | Agent hangs waiting for stdin |
| `"true"` (this fix) | Sets `question: "deny"` | Agent runs without blocking |

- **Safe for environments without the plugin** — the env var has no effect when oh-my-opencode is not installed
- **Doesn't conflict with existing config** — works alongside `OPENCODE_CONFIG_CONTENT` which already sets `question: "deny"`

## Testing

- [x] `npm run lint` (tsc) — passes
- [x] `npm run lint:eslint` — passes  
- [x] `npx vitest run` (envBuilder tests, 37 tests) — all pass
- [x] Verified against oh-my-opencode v3.9.0 source code
- [x] Manually tested in production environment (OpenCode v1.2.15 + oh-my-opencode + Maestro v0.14.5) with `customEnvVars` workaround — confirmed the fix resolves the hang

## Scope Note

This PR addresses the plugin interaction root cause of #338. The broader issue (no timeout/progress indication for any hung agent) may warrant a separate enhancement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for headless/batch operation mode signaling to plugins, enabling them to adapt behavior when running in automated environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->