### PR TITLE
Fix user message alignment mapping and settings option order

### DIFF
--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -2603,8 +2603,8 @@ export const SettingsModal = memo(function SettingsModal(props: SettingsModalPro
 								</div>
 								<ToggleButtonGroup
 									options={[
-										{ value: 'right', label: 'Right' },
 										{ value: 'left', label: 'Left' },
+										{ value: 'right', label: 'Right' },
 									]}
 									value={userMessageAlignment ?? 'right'}
 									onChange={setUserMessageAlignment}

--- a/src/renderer/components/TerminalOutput.tsx
+++ b/src/renderer/components/TerminalOutput.tsx
@@ -365,7 +365,9 @@ const LogItemComponent = memo(
 				: htmlContent;
 
 		const isUserMessage = log.source === 'user';
-		const isReversed = userMessageAlignment === 'right' ? isUserMessage : !isUserMessage;
+		const isReversed = isUserMessage
+			? userMessageAlignment === 'left'
+			: userMessageAlignment === 'right';
 
 		return (
 			<div


### PR DESCRIPTION
## Summary
- Fixes user chat alignment inversion for `userMessageAlignment`.
- Fixes the display settings toggle ordering for message alignment to list `Left` before `Right`.

## Changes
- In `src/renderer/components/TerminalOutput.tsx`, corrected the `isReversed` mapping so:
  - `Right` places user messages on the right.
  - `Left` places user messages on the left.
- In `src/renderer/components/SettingsModal.tsx`, reordered the alignment options so `Left` appears before `Right` in the toggle group.

Closes #492


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved message alignment consistency for clearer message bubble positioning.
  * Reordered settings options for enhanced interface clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->