### PR TITLE
fix: show tool call details and fix text routing for OpenCode thinking

### DIFF
--- a/src/__tests__/main/parsers/opencode-output-parser.test.ts
+++ b/src/__tests__/main/parsers/opencode-output-parser.test.ts
@@ -29,7 +29,7 @@ describe('OpenCodeOutputParser', () => {
 			expect(event?.sessionId).toBe('oc-sess-123');
 		});
 
-		it('should parse text messages as partial text', () => {
+		it('should parse text messages as result (final response, not streaming)', () => {
 			const line = JSON.stringify({
 				type: 'text',
 				sessionID: 'oc-sess-123',
@@ -40,10 +40,10 @@ describe('OpenCodeOutputParser', () => {
 
 			const event = parser.parseJsonLine(line);
 			expect(event).not.toBeNull();
-			expect(event?.type).toBe('text');
+			expect(event?.type).toBe('result');
 			expect(event?.text).toBe('Analyzing your code...');
 			expect(event?.sessionId).toBe('oc-sess-123');
-			expect(event?.isPartial).toBe(true);
+			expect(event?.isPartial).toBeUndefined();
 		});
 
 		it('should parse tool_use messages', () => {
@@ -73,8 +73,9 @@ describe('OpenCodeOutputParser', () => {
 			expect(event?.sessionId).toBe('oc-sess-123');
 		});
 
-		it('should parse step_finish messages with reason "stop" as result', () => {
+		it('should parse step_finish messages with reason "stop" as system (usage only)', () => {
 			// Actual OpenCode format: reason and tokens in part
+			// step_finish is now always system — result text comes from the preceding text event
 			const line = JSON.stringify({
 				type: 'step_finish',
 				sessionID: 'oc-sess-123',
@@ -92,7 +93,7 @@ describe('OpenCodeOutputParser', () => {
 
 			const event = parser.parseJsonLine(line);
 			expect(event).not.toBeNull();
-			expect(event?.type).toBe('result');
+			expect(event?.type).toBe('system');
 			expect(event?.sessionId).toBe('oc-sess-123');
 			expect(event?.usage?.inputTokens).toBe(500);
 			expect(event?.usage?.outputTokens).toBe(200);
@@ -163,15 +164,21 @@ describe('OpenCodeOutputParser', () => {
 	});
 
 	describe('isResultMessage', () => {
-		it('should return true for step_finish events with reason "stop"', () => {
-			const resultEvent = parser.parseJsonLine(
-				JSON.stringify({ type: 'step_finish', part: { reason: 'stop' } })
+		it('should return true for text events (final response)', () => {
+			const textEvent = parser.parseJsonLine(
+				JSON.stringify({ type: 'text', part: { text: 'Here is the answer' } })
 			);
-			expect(resultEvent).not.toBeNull();
-			expect(parser.isResultMessage(resultEvent!)).toBe(true);
+			expect(textEvent).not.toBeNull();
+			expect(parser.isResultMessage(textEvent!)).toBe(true);
 		});
 
-		it('should return false for step_finish events with reason "tool-calls"', () => {
+		it('should return false for step_finish events (usage-only, not result)', () => {
+			const stopEvent = parser.parseJsonLine(
+				JSON.stringify({ type: 'step_finish', part: { reason: 'stop' } })
+			);
+			expect(stopEvent).not.toBeNull();
+			expect(parser.isResultMessage(stopEvent!)).toBe(false);
+
 			const toolCallsEvent = parser.parseJsonLine(
 				JSON.stringify({ type: 'step_finish', part: { reason: 'tool-calls' } })
 			);
@@ -186,11 +193,11 @@ describe('OpenCodeOutputParser', () => {
 			expect(initEvent).not.toBeNull();
 			expect(parser.isResultMessage(initEvent!)).toBe(false);
 
-			const textEvent = parser.parseJsonLine(
-				JSON.stringify({ type: 'text', part: { text: 'hi' } })
+			const toolEvent = parser.parseJsonLine(
+				JSON.stringify({ type: 'tool_use', part: { tool: 'bash' } })
 			);
-			expect(textEvent).not.toBeNull();
-			expect(parser.isResultMessage(textEvent!)).toBe(false);
+			expect(toolEvent).not.toBeNull();
+			expect(parser.isResultMessage(toolEvent!)).toBe(false);
 		});
 	});
 
@@ -282,23 +289,23 @@ describe('OpenCodeOutputParser', () => {
 			expect(event?.sessionId).toBe('sess-123');
 		});
 
-		it('should handle step_finish with reason "stop"', () => {
+		it('should handle step_finish with reason "stop" as system', () => {
 			const event = parser.parseJsonLine(
 				JSON.stringify({ type: 'step_finish', sessionID: 'sess-123', part: { reason: 'stop' } })
 			);
-			expect(event?.type).toBe('result');
+			expect(event?.type).toBe('system');
 			expect(event?.sessionId).toBe('sess-123');
 		});
 
 		it('should handle missing part.text', () => {
 			const event = parser.parseJsonLine(JSON.stringify({ type: 'text', part: {} }));
-			expect(event?.type).toBe('text');
+			expect(event?.type).toBe('result');
 			expect(event?.text).toBe('');
 		});
 
 		it('should handle missing part entirely', () => {
 			const event = parser.parseJsonLine(JSON.stringify({ type: 'text' }));
-			expect(event?.type).toBe('text');
+			expect(event?.type).toBe('result');
 			expect(event?.text).toBe('');
 		});
 

--- a/src/main/parsers/opencode-output-parser.ts
+++ b/src/main/parsers/opencode-output-parser.ts
@@ -154,13 +154,15 @@ export class OpenCodeOutputParser implements AgentOutputParser {
 			};
 		}
 
-		// Handle text messages (streaming content)
+		// Handle text messages (final response content)
+		// OpenCode sends text as a single complete event (not streamed chunks) —
+		// time.start === time.end in practice. Emitting as 'result' ensures it flows
+		// through the result path and does NOT appear as thinking-stream content.
 		if (msg.type === 'text') {
 			return {
-				type: 'text',
+				type: 'result',
 				text: msg.part?.text || '',
 				sessionId: msg.sessionID,
-				isPartial: true,
 				raw: msg,
 			};
 		}
@@ -179,13 +181,11 @@ export class OpenCodeOutputParser implements AgentOutputParser {
 
 		// Handle step_finish messages (step completion with token stats)
 		// part.reason indicates: "stop" (final), "tool-calls" (more work), "error"
+		// NOTE: The actual response text arrives in a 'text' event (type: 'result') BEFORE
+		// step_finish. step_finish is used only for usage stats, not for result emission.
 		if (msg.type === 'step_finish') {
-			// Only mark as "result" if reason is "stop" (final response)
-			// "tool-calls" means more work is coming, so treat as system event
-			const isFinalResult = msg.part?.reason === 'stop';
-
 			const event: ParsedEvent = {
-				type: isFinalResult ? 'result' : 'system',
+				type: 'system',
 				sessionId: msg.sessionID,
 				raw: msg,
 			};

--- a/src/renderer/components/TerminalOutput.tsx
+++ b/src/renderer/components/TerminalOutput.tsx
@@ -549,6 +549,7 @@ const LogItemComponent = memo(
 								? safeCommand(toolInput.command) ||
 									safeStr(toolInput.pattern) ||
 									safeStr(toolInput.file_path) ||
+									safeStr(toolInput.filePath) || // OpenCode read tool
 									safeStr(toolInput.query) ||
 									safeStr(toolInput.description) || // Task tool
 									safeStr(toolInput.prompt) || // Task tool fallback


### PR DESCRIPTION
This pull request updates the OpenCode output parsing logic and its associated tests to align with recent changes in the OpenCode protocol. The main changes ensure that text messages are treated as final results (not streamed), and that `step_finish` events are now used only for usage statistics, not for emitting result content. This improves the accuracy of parsing and downstream handling of OpenCode agent responses.

**Test and parser logic updates:**

* Text messages are now parsed and emitted as `result` events (final response, not streaming), with the `isPartial` property removed. (`src/__tests__/main/parsers/opencode-output-parser.test.ts`, `src/main/parsers/opencode-output-parser.ts`) [[1]](diffhunk://#diff-c7d0f040af8a3d76221d643a25ee8f8a302e769d95d76413a3fa49dbf2b5e07aL32-R32) [[2]](diffhunk://#diff-c7d0f040af8a3d76221d643a25ee8f8a302e769d95d76413a3fa49dbf2b5e07aL43-R46) [[3]](diffhunk://#diff-926b13f710645a3d9ce8c79875d3ae6e5da59b0c56fe460fb2666a9b1e5ef17dL157-L163)
* `step_finish` messages with reason `"stop"` are now parsed as `system` events for usage stats only; they do not emit result content. All related tests have been updated to reflect this change. (`src/__tests__/main/parsers/opencode-output-parser.test.ts`, `src/main/parsers/opencode-output-parser.ts`) [[1]](diffhunk://#diff-c7d0f040af8a3d76221d643a25ee8f8a302e769d95d76413a3fa49dbf2b5e07aL76-R78) [[2]](diffhunk://#diff-c7d0f040af8a3d76221d643a25ee8f8a302e769d95d76413a3fa49dbf2b5e07aL95-R96) [[3]](diffhunk://#diff-c7d0f040af8a3d76221d643a25ee8f8a302e769d95d76413a3fa49dbf2b5e07aL285-R308) [[4]](diffhunk://#diff-926b13f710645a3d9ce8c79875d3ae6e5da59b0c56fe460fb2666a9b1e5ef17dR184-R188)
* The `isResultMessage` logic now returns `true` only for text events (final responses), and `false` for `step_finish` events, clarifying result emission semantics in tests. (`src/__tests__/main/parsers/opencode-output-parser.test.ts`) [[1]](diffhunk://#diff-c7d0f040af8a3d76221d643a25ee8f8a302e769d95d76413a3fa49dbf2b5e07aL166-R181) [[2]](diffhunk://#diff-c7d0f040af8a3d76221d643a25ee8f8a302e769d95d76413a3fa49dbf2b5e07aL189-R200)

**Renderer update:**

* Added support for the `filePath` property in tool input rendering, improving compatibility with the OpenCode read tool. (`src/renderer/components/TerminalOutput.tsx`)…g stream

- OpenCode text events are final responses (not streaming chunks), so emit them as 'result' instead of 'text' with isPartial:true. This prevents the response from appearing incorrectly as thinking-stream content.
- step_finish now always emits 'system' (usage stats only); result text comes from the preceding text event.
- Add filePath (camelCase) to tool detail extraction so OpenCode's read tool shows the file path in the thinking stream display.
- Update tests to reflect the corrected OpenCode output parsing behavior.

closes #477 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event type classification to properly distinguish between result and system events in message parsing. This ensures more accurate handling of different message categories throughout the application.
  
* **New Features**
  * Enhanced tool detail information display to include file path references, providing better context when viewing tool operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->