### PR TITLE
Enable OpenCode and Droid in Maestro CLI

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -77,7 +77,7 @@ On failure, `success` is `false` and an `error` field is included:
 
 Error codes: `AGENT_NOT_FOUND`, `AGENT_UNSUPPORTED`, `CLAUDE_NOT_FOUND`, `CODEX_NOT_FOUND`, `OPENCODE_NOT_FOUND`, `DROID_NOT_FOUND`.
 
-Supported agent types: `claude-code`, `codex`, `opencode`, `factory-droid`.
+Supported agent types: `claude-code`, `codex`, `opencode`, `factory-droid`. The `send` command supports all four.
 
 ### Listing Sessions
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -241,5 +241,5 @@ The `send` command always outputs JSON (no `--json` flag needed).
 
 ## Requirements
 
-- At least one AI agent CLI must be installed in PATH or set via customPath (Claude Code, Codex, OpenCode, or Factory Droid)
+- At least one AI agent CLI must be installed in PATH, set via customPath, or configured via sshRemoteConfig (Claude Code, Codex, OpenCode, or Factory Droid — can run on an SSH remote host)
 - Maestro config files must exist (created automatically when you use the GUI)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -241,5 +241,5 @@ The `send` command always outputs JSON (no `--json` flag needed).
 
 ## Requirements
 
-- At least one AI agent CLI must be installed and in PATH (Claude Code, Codex, or OpenCode)
+- At least one AI agent CLI must be installed and in PATH (Claude Code, Codex, OpenCode, or Factory Droid)
 - Maestro config files must exist (created automatically when you use the GUI)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -241,5 +241,5 @@ The `send` command always outputs JSON (no `--json` flag needed).
 
 ## Requirements
 
-- At least one AI agent CLI must be installed and in PATH (Claude Code, Codex, OpenCode, or Factory Droid)
+- At least one AI agent CLI must be installed in PATH or set via customPath (Claude Code, Codex, OpenCode, or Factory Droid)
 - Maestro config files must exist (created automatically when you use the GUI)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -75,9 +75,9 @@ On failure, `success` is `false` and an `error` field is included:
 }
 ```
 
-Error codes: `AGENT_NOT_FOUND`, `AGENT_UNSUPPORTED`, `CLAUDE_NOT_FOUND`, `CODEX_NOT_FOUND`.
+Error codes: `AGENT_NOT_FOUND`, `AGENT_UNSUPPORTED`, `CLAUDE_NOT_FOUND`, `CODEX_NOT_FOUND`, `OPENCODE_NOT_FOUND`, `DROID_NOT_FOUND`.
 
-Supported agent types: `claude-code`, `codex`.
+Supported agent types: `claude-code`, `codex`, `opencode`, `factory-droid`.
 
 ### Listing Sessions
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "maestro",
-	"version": "0.15.0",
+	"version": "0.15.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "maestro",
-			"version": "0.15.0",
+			"version": "0.15.1",
 			"hasInstallScript": true,
 			"license": "AGPL 3.0",
 			"dependencies": {

--- a/src/__tests__/cli/commands/send.test.ts
+++ b/src/__tests__/cli/commands/send.test.ts
@@ -81,6 +81,7 @@ describe('send command', () => {
 			'claude-code',
 			'/path/to/project',
 			'Hello world',
+			undefined,
 			undefined
 		);
 		expect(consoleSpy).toHaveBeenCalledTimes(1);
@@ -128,7 +129,8 @@ describe('send command', () => {
 			'claude-code',
 			'/path/to/project',
 			'Continue from before',
-			'session-xyz-789'
+			'session-xyz-789',
+			undefined
 		);
 
 		const output = JSON.parse(consoleSpy.mock.calls[0][0]);
@@ -153,6 +155,7 @@ describe('send command', () => {
 			'claude-code',
 			'/custom/project/path',
 			'Do something',
+			undefined,
 			undefined
 		);
 	});
@@ -173,7 +176,13 @@ describe('send command', () => {
 
 		expect(detectCodex).toHaveBeenCalled();
 		expect(detectClaude).not.toHaveBeenCalled();
-		expect(spawnAgent).toHaveBeenCalledWith('codex', expect.any(String), 'Use codex', undefined);
+		expect(spawnAgent).toHaveBeenCalledWith(
+			'codex',
+			expect.any(String),
+			'Use codex',
+			undefined,
+			undefined
+		);
 	});
 
 	it('should exit with error when agent ID is not found', async () => {

--- a/src/__tests__/cli/services/agent-spawner.test.ts
+++ b/src/__tests__/cli/services/agent-spawner.test.ts
@@ -843,7 +843,7 @@ Some text with [x] in it that's not a checkbox
 		});
 	});
 
-		describe('spawnAgent', () => {
+	describe('spawnAgent', () => {
 		beforeEach(() => {
 			mockSpawn.mockReturnValue(mockChild);
 		});

--- a/src/__tests__/cli/services/agent-spawner.test.ts
+++ b/src/__tests__/cli/services/agent-spawner.test.ts
@@ -680,6 +680,102 @@ Some text with [x] in it that's not a checkbox
 		});
 	});
 
+	describe('detectOpenCode', () => {
+		beforeEach(() => {
+			vi.resetModules();
+		});
+
+		it('should detect OpenCode via PATH detection', async () => {
+			mockGetAgentCustomPath.mockReturnValue(undefined);
+			mockSpawn.mockReturnValue(mockChild);
+
+			const { detectOpenCode: freshDetectOpenCode } =
+				await import('../../../cli/services/agent-spawner');
+
+			const resultPromise = freshDetectOpenCode();
+
+			await new Promise((resolve) => setTimeout(resolve, 0));
+			mockStdout.emit('data', Buffer.from('/usr/local/bin/opencode\n'));
+			await new Promise((resolve) => setTimeout(resolve, 0));
+			mockChild.emit('close', 0);
+
+			const result = await resultPromise;
+
+			expect(result.available).toBe(true);
+			expect(result.path).toBe('/usr/local/bin/opencode');
+			expect(result.source).toBe('path');
+		});
+
+		it('should preserve cached source when override matches cached path', async () => {
+			mockGetAgentCustomPath.mockReturnValue(undefined);
+			mockSpawn.mockReturnValue(mockChild);
+
+			const { detectOpenCode: freshDetectOpenCode } =
+				await import('../../../cli/services/agent-spawner');
+
+			const resultPromise = freshDetectOpenCode();
+
+			await new Promise((resolve) => setTimeout(resolve, 0));
+			mockStdout.emit('data', Buffer.from('/usr/local/bin/opencode\n'));
+			await new Promise((resolve) => setTimeout(resolve, 0));
+			mockChild.emit('close', 0);
+
+			const result1 = await resultPromise;
+			expect(result1.source).toBe('path');
+
+			const result2 = await freshDetectOpenCode('/usr/local/bin/opencode');
+			expect(result2.source).toBe('path');
+		});
+	});
+
+	describe('detectDroid', () => {
+		beforeEach(() => {
+			vi.resetModules();
+		});
+
+		it('should detect Factory Droid via PATH detection', async () => {
+			mockGetAgentCustomPath.mockReturnValue(undefined);
+			mockSpawn.mockReturnValue(mockChild);
+
+			const { detectDroid: freshDetectDroid } =
+				await import('../../../cli/services/agent-spawner');
+
+			const resultPromise = freshDetectDroid();
+
+			await new Promise((resolve) => setTimeout(resolve, 0));
+			mockStdout.emit('data', Buffer.from('/usr/local/bin/droid\n'));
+			await new Promise((resolve) => setTimeout(resolve, 0));
+			mockChild.emit('close', 0);
+
+			const result = await resultPromise;
+
+			expect(result.available).toBe(true);
+			expect(result.path).toBe('/usr/local/bin/droid');
+			expect(result.source).toBe('path');
+		});
+
+		it('should preserve cached source when override matches cached path', async () => {
+			mockGetAgentCustomPath.mockReturnValue(undefined);
+			mockSpawn.mockReturnValue(mockChild);
+
+			const { detectDroid: freshDetectDroid } =
+				await import('../../../cli/services/agent-spawner');
+
+			const resultPromise = freshDetectDroid();
+
+			await new Promise((resolve) => setTimeout(resolve, 0));
+			mockStdout.emit('data', Buffer.from('/usr/local/bin/droid\n'));
+			await new Promise((resolve) => setTimeout(resolve, 0));
+			mockChild.emit('close', 0);
+
+			const result1 = await resultPromise;
+			expect(result1.source).toBe('path');
+
+			const result2 = await freshDetectDroid('/usr/local/bin/droid');
+			expect(result2.source).toBe('path');
+		});
+	});
+
 	describe('spawnAgent', () => {
 		beforeEach(() => {
 			mockSpawn.mockReturnValue(mockChild);

--- a/src/__tests__/cli/services/agent-spawner.test.ts
+++ b/src/__tests__/cli/services/agent-spawner.test.ts
@@ -737,8 +737,7 @@ Some text with [x] in it that's not a checkbox
 			mockGetAgentCustomPath.mockReturnValue(undefined);
 			mockSpawn.mockReturnValue(mockChild);
 
-			const { detectDroid: freshDetectDroid } =
-				await import('../../../cli/services/agent-spawner');
+			const { detectDroid: freshDetectDroid } = await import('../../../cli/services/agent-spawner');
 
 			const resultPromise = freshDetectDroid();
 
@@ -758,8 +757,7 @@ Some text with [x] in it that's not a checkbox
 			mockGetAgentCustomPath.mockReturnValue(undefined);
 			mockSpawn.mockReturnValue(mockChild);
 
-			const { detectDroid: freshDetectDroid } =
-				await import('../../../cli/services/agent-spawner');
+			const { detectDroid: freshDetectDroid } = await import('../../../cli/services/agent-spawner');
 
 			const resultPromise = freshDetectDroid();
 

--- a/src/__tests__/cli/services/agent-spawner.test.ts
+++ b/src/__tests__/cli/services/agent-spawner.test.ts
@@ -87,9 +87,11 @@ vi.mock('os', () => ({
 // Mock storage service
 const mockGetAgentCustomPath = vi.fn();
 const mockGetAgentConfigValues = vi.fn(() => ({}));
+const mockReadSshRemotes = vi.fn(() => []);
 vi.mock('../../../cli/services/storage', () => ({
 	getAgentCustomPath: (...args: unknown[]) => mockGetAgentCustomPath(...args),
 	getAgentConfigValues: (...args: unknown[]) => mockGetAgentConfigValues(...args),
+	readSshRemotes: (...args: unknown[]) => mockReadSshRemotes(...args),
 }));
 
 import {

--- a/src/__tests__/cli/services/agent-spawner.test.ts
+++ b/src/__tests__/cli/services/agent-spawner.test.ts
@@ -35,11 +35,28 @@ const mockChild = Object.assign(new EventEmitter(), {
 // Mock child_process before imports
 vi.mock('child_process', async (importOriginal) => {
 	const actual = await importOriginal<typeof import('child_process')>();
+	const actualDefault = (
+		actual as typeof import('child_process') & {
+			default?: typeof import('child_process');
+		}
+	).default;
+	const execFile =
+		actual.execFile ??
+		actualDefault?.execFile ??
+		((...args: unknown[]) => {
+			const callback = args[args.length - 1];
+			if (typeof callback === 'function') {
+				callback(null, '', '');
+			}
+		});
 	return {
 		...actual,
+		execFile,
 		spawn: (...args: unknown[]) => mockSpawn(...args),
 		default: {
+			...(actualDefault ?? {}),
 			...actual,
+			execFile,
 			spawn: (...args: unknown[]) => mockSpawn(...args),
 		},
 	};

--- a/src/__tests__/cli/services/agent-spawner.test.ts
+++ b/src/__tests__/cli/services/agent-spawner.test.ts
@@ -18,6 +18,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { EventEmitter } from 'events';
+import type { AgentSshRemoteConfig } from '../../../shared/types';
 
 // Create mock spawn function at module level
 const mockSpawn = vi.fn();
@@ -88,10 +89,23 @@ vi.mock('os', () => ({
 const mockGetAgentCustomPath = vi.fn();
 const mockGetAgentConfigValues = vi.fn(() => ({}));
 const mockReadSshRemotes = vi.fn(() => []);
+
+const mockWrapSpawnWithSsh = vi.fn(async () => ({
+	command: 'wrapped-cmd',
+	args: ['wrapped-arg-1', 'wrapped-arg-2'],
+	cwd: '/wrapped',
+	customEnvVars: undefined,
+	prompt: undefined,
+	sshRemoteUsed: null,
+}));
 vi.mock('../../../cli/services/storage', () => ({
 	getAgentCustomPath: (...args: unknown[]) => mockGetAgentCustomPath(...args),
 	getAgentConfigValues: (...args: unknown[]) => mockGetAgentConfigValues(...args),
 	readSshRemotes: (...args: unknown[]) => mockReadSshRemotes(...args),
+}));
+
+vi.mock('../../../main/utils/ssh-spawn-wrapper', () => ({
+	wrapSpawnWithSsh: (...args: unknown[]) => mockWrapSpawnWithSsh(...args),
 }));
 
 import {
@@ -725,6 +739,25 @@ Some text with [x] in it that's not a checkbox
 			expect(result.source).toBe('path');
 		});
 
+		it('should short-circuit to remote availability when SSH is enabled', async () => {
+			const sshRemoteConfig: AgentSshRemoteConfig = {
+				enabled: true,
+				remoteId: 'remote-opencode',
+			};
+			mockGetAgentCustomPath.mockReturnValue(undefined);
+			mockSpawn.mockReturnValue(mockChild);
+
+			vi.resetModules();
+			const { detectOpenCode: freshDetectOpenCode } =
+				await import('../../../cli/services/agent-spawner');
+
+			const result = await freshDetectOpenCode('/custom/opencode', sshRemoteConfig);
+
+			expect(result.available).toBe(true);
+			expect(result.path).toBeUndefined();
+			expect(result.source).toBe('settings');
+		});
+
 		it('should preserve cached source when override matches cached path', async () => {
 			mockGetAgentCustomPath.mockReturnValue(undefined);
 			mockSpawn.mockReturnValue(mockChild);
@@ -772,6 +805,23 @@ Some text with [x] in it that's not a checkbox
 			expect(result.source).toBe('path');
 		});
 
+		it('should short-circuit to remote availability when SSH is enabled', async () => {
+			const sshRemoteConfig: AgentSshRemoteConfig = {
+				enabled: true,
+				remoteId: 'remote-droid',
+			};
+			mockGetAgentCustomPath.mockReturnValue(undefined);
+			mockSpawn.mockReturnValue(mockChild);
+
+			const { detectDroid: freshDetectDroid } = await import('../../../cli/services/agent-spawner');
+
+			const result = await freshDetectDroid('/custom/droid', sshRemoteConfig);
+
+			expect(result.available).toBe(true);
+			expect(result.path).toBeUndefined();
+			expect(result.source).toBe('settings');
+		});
+
 		it('should preserve cached source when override matches cached path', async () => {
 			mockGetAgentCustomPath.mockReturnValue(undefined);
 			mockSpawn.mockReturnValue(mockChild);
@@ -793,7 +843,7 @@ Some text with [x] in it that's not a checkbox
 		});
 	});
 
-	describe('spawnAgent', () => {
+		describe('spawnAgent', () => {
 		beforeEach(() => {
 			mockSpawn.mockReturnValue(mockChild);
 		});
@@ -1263,6 +1313,80 @@ Some text with [x] in it that's not a checkbox
 			mockStdout.emit('data', Buffer.from('{"type":"result","result":"Done"}\n'));
 			mockChild.emit('close', 0);
 			await resultPromise;
+		});
+
+		it('should wrap OpenCode spawn with SSH when enabled', async () => {
+			const sshRemoteConfig: AgentSshRemoteConfig = {
+				enabled: true,
+				remoteId: 'remote-opencode',
+			};
+			mockWrapSpawnWithSsh.mockClear();
+
+			const resultPromise = spawnAgent(
+				'opencode',
+				'/project/path',
+				'OpenCode remote task',
+				undefined,
+				{ sshRemoteConfig }
+			);
+
+			await new Promise((resolve) => setTimeout(resolve, 0));
+
+			expect(mockWrapSpawnWithSsh).toHaveBeenCalledTimes(1);
+			const [config, configSshRemote, configStore] = mockWrapSpawnWithSsh.mock.calls[0];
+
+			expect(config).toMatchObject({
+				command: expect.any(String),
+				args: expect.any(Array),
+				cwd: '/project/path',
+			});
+			expect(configSshRemote).toEqual(sshRemoteConfig);
+			expect(configStore).toEqual({
+				getSshRemotes: expect.any(Function),
+			});
+
+			mockStdout.emit('data', Buffer.from('{"type":"result","text":"OpenCode done"}\n'));
+			mockChild.emit('close', 0);
+
+			const result = await resultPromise;
+			expect(result.success).toBe(true);
+		});
+
+		it('should wrap Factory Droid spawn with SSH when enabled', async () => {
+			const sshRemoteConfig: AgentSshRemoteConfig = {
+				enabled: true,
+				remoteId: 'remote-droid',
+			};
+			mockWrapSpawnWithSsh.mockClear();
+
+			const resultPromise = spawnAgent(
+				'factory-droid',
+				'/project/path',
+				'Droid remote task',
+				undefined,
+				{ sshRemoteConfig }
+			);
+
+			await new Promise((resolve) => setTimeout(resolve, 0));
+
+			expect(mockWrapSpawnWithSsh).toHaveBeenCalledTimes(1);
+			const [config, configSshRemote, configStore] = mockWrapSpawnWithSsh.mock.calls[0];
+
+			expect(config).toMatchObject({
+				command: expect.any(String),
+				args: expect.any(Array),
+				cwd: '/project/path',
+			});
+			expect(configSshRemote).toEqual(sshRemoteConfig);
+			expect(configStore).toEqual({
+				getSshRemotes: expect.any(Function),
+			});
+
+			mockStdout.emit('data', Buffer.from('{"type":"result","text":"Droid done"}\n'));
+			mockChild.emit('close', 0);
+
+			const result = await resultPromise;
+			expect(result.success).toBe(true);
 		});
 
 		it('should include user home paths', async () => {

--- a/src/__tests__/cli/services/agent-spawner.test.ts
+++ b/src/__tests__/cli/services/agent-spawner.test.ts
@@ -69,8 +69,10 @@ vi.mock('os', () => ({
 
 // Mock storage service
 const mockGetAgentCustomPath = vi.fn();
+const mockGetAgentConfigValues = vi.fn(() => ({}));
 vi.mock('../../../cli/services/storage', () => ({
 	getAgentCustomPath: (...args: unknown[]) => mockGetAgentCustomPath(...args),
+	getAgentConfigValues: (...args: unknown[]) => mockGetAgentConfigValues(...args),
 }));
 
 import {

--- a/src/cli/commands/run-playbook.ts
+++ b/src/cli/commands/run-playbook.ts
@@ -149,7 +149,7 @@ export async function runPlaybook(playbookId: string, options: RunPlaybookOption
 
 		// Check if agent CLI is available
 		if (agent.toolType === 'codex') {
-			const codex = await detectCodex(agent.customPath);
+			const codex = await detectCodex(agent.customPath, agent.sshRemoteConfig);
 			if (!codex.available) {
 				if (useJson) {
 					emitError('Codex CLI not found. Please install codex CLI.', 'CODEX_NOT_FOUND');
@@ -159,7 +159,7 @@ export async function runPlaybook(playbookId: string, options: RunPlaybookOption
 				process.exit(1);
 			}
 		} else if (agent.toolType === 'claude-code') {
-			const claude = await detectClaude(agent.customPath);
+			const claude = await detectClaude(agent.customPath, agent.sshRemoteConfig);
 			if (!claude.available) {
 				if (useJson) {
 					emitError('Claude Code not found. Please install claude-code CLI.', 'CLAUDE_NOT_FOUND');
@@ -169,7 +169,7 @@ export async function runPlaybook(playbookId: string, options: RunPlaybookOption
 				process.exit(1);
 			}
 		} else if (agent.toolType === 'opencode') {
-			const opencode = await detectOpenCode(agent.customPath);
+			const opencode = await detectOpenCode(agent.customPath, agent.sshRemoteConfig);
 			if (!opencode.available) {
 				if (useJson) {
 					emitError('OpenCode CLI not found. Please install opencode CLI.', 'OPENCODE_NOT_FOUND');
@@ -179,7 +179,7 @@ export async function runPlaybook(playbookId: string, options: RunPlaybookOption
 				process.exit(1);
 			}
 		} else if (agent.toolType === 'factory-droid') {
-			const droid = await detectDroid(agent.customPath);
+			const droid = await detectDroid(agent.customPath, agent.sshRemoteConfig);
 			if (!droid.available) {
 				if (useJson) {
 					emitError('Factory Droid CLI not found. Please install droid CLI.', 'DROID_NOT_FOUND');

--- a/src/cli/commands/run-playbook.ts
+++ b/src/cli/commands/run-playbook.ts
@@ -4,7 +4,7 @@
 import { getSessionById } from '../services/storage';
 import { findPlaybookById } from '../services/playbooks';
 import { runPlaybook as executePlaybook } from '../services/batch-processor';
-import { detectClaude, detectCodex } from '../services/agent-spawner';
+import { detectClaude, detectCodex, detectOpenCode, detectDroid } from '../services/agent-spawner';
 import { emitError } from '../output/jsonl';
 import {
 	formatRunEvent,
@@ -149,7 +149,7 @@ export async function runPlaybook(playbookId: string, options: RunPlaybookOption
 
 		// Check if agent CLI is available
 		if (agent.toolType === 'codex') {
-			const codex = await detectCodex();
+			const codex = await detectCodex(agent.customPath);
 			if (!codex.available) {
 				if (useJson) {
 					emitError('Codex CLI not found. Please install codex CLI.', 'CODEX_NOT_FOUND');
@@ -159,12 +159,32 @@ export async function runPlaybook(playbookId: string, options: RunPlaybookOption
 				process.exit(1);
 			}
 		} else if (agent.toolType === 'claude-code') {
-			const claude = await detectClaude();
+			const claude = await detectClaude(agent.customPath);
 			if (!claude.available) {
 				if (useJson) {
 					emitError('Claude Code not found. Please install claude-code CLI.', 'CLAUDE_NOT_FOUND');
 				} else {
 					console.error(formatError('Claude Code not found. Please install claude-code CLI.'));
+				}
+				process.exit(1);
+			}
+		} else if (agent.toolType === 'opencode') {
+			const opencode = await detectOpenCode(agent.customPath);
+			if (!opencode.available) {
+				if (useJson) {
+					emitError('OpenCode CLI not found. Please install opencode CLI.', 'OPENCODE_NOT_FOUND');
+				} else {
+					console.error(formatError('OpenCode CLI not found. Please install opencode CLI.'));
+				}
+				process.exit(1);
+			}
+		} else if (agent.toolType === 'factory-droid') {
+			const droid = await detectDroid(agent.customPath);
+			if (!droid.available) {
+				if (useJson) {
+					emitError('Factory Droid CLI not found. Please install droid CLI.', 'DROID_NOT_FOUND');
+				} else {
+					console.error(formatError('Factory Droid CLI not found. Please install droid CLI.'));
 				}
 				process.exit(1);
 			}

--- a/src/cli/commands/send.ts
+++ b/src/cli/commands/send.ts
@@ -8,6 +8,7 @@ import {
 	detectOpenCode,
 	detectDroid,
 	type AgentResult,
+	type AgentSpawnOverrides,
 } from '../services/agent-spawner';
 import { resolveAgentId, getSessionById } from '../services/storage';
 import { estimateContextUsage } from '../../main/parsers/usage-aggregator';
@@ -143,26 +144,30 @@ export async function send(
 		}
 	}
 
-	const hasOverrides =
-		agent.customPath !== undefined ||
-		agent.customArgs !== undefined ||
-		agent.customEnvVars !== undefined ||
-		agent.customModel !== undefined ||
-		agent.sshRemoteConfig !== undefined;
-	const overrides = hasOverrides
-		? {
-				customPath: agent.customPath,
-				customArgs: agent.customArgs,
-				customEnvVars: agent.customEnvVars,
-				customModel: agent.customModel,
-				sshRemoteConfig: agent.sshRemoteConfig,
-			}
-		: undefined;
+	const overrides: AgentSpawnOverrides | undefined = (() => {
+		const next: AgentSpawnOverrides = {};
+
+		if (agent.customPath !== undefined) {
+			next.customPath = agent.customPath;
+		}
+		if (agent.customArgs !== undefined) {
+			next.customArgs = agent.customArgs;
+		}
+		if (agent.customEnvVars !== undefined) {
+			next.customEnvVars = agent.customEnvVars;
+		}
+		if (agent.customModel !== undefined) {
+			next.customModel = agent.customModel;
+		}
+		if (agent.sshRemoteConfig !== undefined) {
+			next.sshRemoteConfig = agent.sshRemoteConfig;
+		}
+
+		return Object.keys(next).length === 0 ? undefined : next;
+	})();
 
 	// Spawn agent — spawnAgent handles --resume vs --session-id internally
-	const result = overrides
-		? await spawnAgent(agent.toolType, agent.cwd, message, options.session, overrides)
-		: await spawnAgent(agent.toolType, agent.cwd, message, options.session);
+	const result = await spawnAgent(agent.toolType, agent.cwd, message, options.session, overrides);
 	const response = buildResponse(agentId, agent.name, result, agent.toolType);
 
 	console.log(JSON.stringify(response, null, 2));

--- a/src/cli/commands/send.ts
+++ b/src/cli/commands/send.ts
@@ -96,9 +96,7 @@ export async function send(
 	}
 
 	const ssh =
-		agent.sshRemoteConfig && agent.sshRemoteConfig.enabled
-			? agent.sshRemoteConfig
-			: undefined;
+		agent.sshRemoteConfig && agent.sshRemoteConfig.enabled ? agent.sshRemoteConfig : undefined;
 
 	// Validate agent type is supported for CLI spawning
 	const supportedTypes: ToolType[] = ['claude-code', 'codex', 'opencode', 'factory-droid'];

--- a/src/cli/commands/send.ts
+++ b/src/cli/commands/send.ts
@@ -106,7 +106,7 @@ export async function send(
 
 	// Verify agent CLI is available
 	if (agent.toolType === 'claude-code') {
-		const claude = await detectClaude(agent.customPath);
+		const claude = await detectClaude(agent.customPath, agent.sshRemoteConfig);
 		if (!claude.available) {
 			emitErrorJson(
 				'Claude Code CLI not found. Install with: npm install -g @anthropic-ai/claude-code',
@@ -115,7 +115,7 @@ export async function send(
 			process.exit(1);
 		}
 	} else if (agent.toolType === 'codex') {
-		const codex = await detectCodex(agent.customPath);
+		const codex = await detectCodex(agent.customPath, agent.sshRemoteConfig);
 		if (!codex.available) {
 			emitErrorJson(
 				'Codex CLI not found. Install with: npm install -g @openai/codex',
@@ -124,7 +124,7 @@ export async function send(
 			process.exit(1);
 		}
 	} else if (agent.toolType === 'opencode') {
-		const opencode = await detectOpenCode(agent.customPath);
+		const opencode = await detectOpenCode(agent.customPath, agent.sshRemoteConfig);
 		if (!opencode.available) {
 			emitErrorJson(
 				'OpenCode CLI not found. Install with: npm install -g opencode',
@@ -133,7 +133,7 @@ export async function send(
 			process.exit(1);
 		}
 	} else if (agent.toolType === 'factory-droid') {
-		const droid = await detectDroid(agent.customPath);
+		const droid = await detectDroid(agent.customPath, agent.sshRemoteConfig);
 		if (!droid.available) {
 			emitErrorJson(
 				'Factory Droid CLI not found. Install with: https://factory.ai/product/cli',
@@ -147,13 +147,15 @@ export async function send(
 		agent.customPath !== undefined ||
 		agent.customArgs !== undefined ||
 		agent.customEnvVars !== undefined ||
-		agent.customModel !== undefined;
+		agent.customModel !== undefined ||
+		agent.sshRemoteConfig !== undefined;
 	const overrides = hasOverrides
 		? {
 				customPath: agent.customPath,
 				customArgs: agent.customArgs,
 				customEnvVars: agent.customEnvVars,
 				customModel: agent.customModel,
+				sshRemoteConfig: agent.sshRemoteConfig,
 			}
 		: undefined;
 

--- a/src/cli/commands/send.ts
+++ b/src/cli/commands/send.ts
@@ -154,7 +154,7 @@ export async function send(
 				customArgs: agent.customArgs,
 				customEnvVars: agent.customEnvVars,
 				customModel: agent.customModel,
-		  }
+			}
 		: undefined;
 
 	// Spawn agent — spawnAgent handles --resume vs --session-id internally

--- a/src/cli/commands/send.ts
+++ b/src/cli/commands/send.ts
@@ -1,7 +1,14 @@
 // Send command - send a message to an agent and get a JSON response
 // Requires a Maestro agent ID. Optionally resumes an existing agent session.
 
-import { spawnAgent, detectClaude, detectCodex, type AgentResult } from '../services/agent-spawner';
+import {
+	spawnAgent,
+	detectClaude,
+	detectCodex,
+	detectOpenCode,
+	detectDroid,
+	type AgentResult,
+} from '../services/agent-spawner';
 import { resolveAgentId, getSessionById } from '../services/storage';
 import { estimateContextUsage } from '../../main/parsers/usage-aggregator';
 import type { ToolType } from '../../shared/types';
@@ -88,7 +95,7 @@ export async function send(
 	}
 
 	// Validate agent type is supported for CLI spawning
-	const supportedTypes: ToolType[] = ['claude-code', 'codex'];
+	const supportedTypes: ToolType[] = ['claude-code', 'codex', 'opencode', 'factory-droid'];
 	if (!supportedTypes.includes(agent.toolType)) {
 		emitErrorJson(
 			`Agent type "${agent.toolType}" is not supported for send mode. Supported: ${supportedTypes.join(', ')}`,
@@ -99,7 +106,7 @@ export async function send(
 
 	// Verify agent CLI is available
 	if (agent.toolType === 'claude-code') {
-		const claude = await detectClaude();
+		const claude = await detectClaude(agent.customPath);
 		if (!claude.available) {
 			emitErrorJson(
 				'Claude Code CLI not found. Install with: npm install -g @anthropic-ai/claude-code',
@@ -108,7 +115,7 @@ export async function send(
 			process.exit(1);
 		}
 	} else if (agent.toolType === 'codex') {
-		const codex = await detectCodex();
+		const codex = await detectCodex(agent.customPath);
 		if (!codex.available) {
 			emitErrorJson(
 				'Codex CLI not found. Install with: npm install -g @openai/codex',
@@ -116,10 +123,33 @@ export async function send(
 			);
 			process.exit(1);
 		}
+	} else if (agent.toolType === 'opencode') {
+		const opencode = await detectOpenCode(agent.customPath);
+		if (!opencode.available) {
+			emitErrorJson(
+				'OpenCode CLI not found. Install with: npm install -g opencode',
+				'OPENCODE_NOT_FOUND'
+			);
+			process.exit(1);
+		}
+	} else if (agent.toolType === 'factory-droid') {
+		const droid = await detectDroid(agent.customPath);
+		if (!droid.available) {
+			emitErrorJson(
+				'Factory Droid CLI not found. Install with: https://factory.ai/product/cli',
+				'DROID_NOT_FOUND'
+			);
+			process.exit(1);
+		}
 	}
 
 	// Spawn agent — spawnAgent handles --resume vs --session-id internally
-	const result = await spawnAgent(agent.toolType, agent.cwd, message, options.session);
+	const result = await spawnAgent(agent.toolType, agent.cwd, message, options.session, {
+		customPath: agent.customPath,
+		customArgs: agent.customArgs,
+		customEnvVars: agent.customEnvVars,
+		customModel: agent.customModel,
+	});
 	const response = buildResponse(agentId, agent.name, result, agent.toolType);
 
 	console.log(JSON.stringify(response, null, 2));

--- a/src/cli/commands/send.ts
+++ b/src/cli/commands/send.ts
@@ -143,13 +143,24 @@ export async function send(
 		}
 	}
 
+	const hasOverrides =
+		agent.customPath !== undefined ||
+		agent.customArgs !== undefined ||
+		agent.customEnvVars !== undefined ||
+		agent.customModel !== undefined;
+	const overrides = hasOverrides
+		? {
+				customPath: agent.customPath,
+				customArgs: agent.customArgs,
+				customEnvVars: agent.customEnvVars,
+				customModel: agent.customModel,
+		  }
+		: undefined;
+
 	// Spawn agent — spawnAgent handles --resume vs --session-id internally
-	const result = await spawnAgent(agent.toolType, agent.cwd, message, options.session, {
-		customPath: agent.customPath,
-		customArgs: agent.customArgs,
-		customEnvVars: agent.customEnvVars,
-		customModel: agent.customModel,
-	});
+	const result = overrides
+		? await spawnAgent(agent.toolType, agent.cwd, message, options.session, overrides)
+		: await spawnAgent(agent.toolType, agent.cwd, message, options.session);
 	const response = buildResponse(agentId, agent.name, result, agent.toolType);
 
 	console.log(JSON.stringify(response, null, 2));

--- a/src/cli/commands/send.ts
+++ b/src/cli/commands/send.ts
@@ -95,6 +95,11 @@ export async function send(
 		process.exit(1);
 	}
 
+	const ssh =
+		agent.sshRemoteConfig && agent.sshRemoteConfig.enabled
+			? agent.sshRemoteConfig
+			: undefined;
+
 	// Validate agent type is supported for CLI spawning
 	const supportedTypes: ToolType[] = ['claude-code', 'codex', 'opencode', 'factory-droid'];
 	if (!supportedTypes.includes(agent.toolType)) {
@@ -107,7 +112,7 @@ export async function send(
 
 	// Verify agent CLI is available
 	if (agent.toolType === 'claude-code') {
-		const claude = await detectClaude(agent.customPath, agent.sshRemoteConfig);
+		const claude = await detectClaude(agent.customPath, ssh);
 		if (!claude.available) {
 			emitErrorJson(
 				'Claude Code CLI not found. Install with: npm install -g @anthropic-ai/claude-code',
@@ -116,7 +121,7 @@ export async function send(
 			process.exit(1);
 		}
 	} else if (agent.toolType === 'codex') {
-		const codex = await detectCodex(agent.customPath, agent.sshRemoteConfig);
+		const codex = await detectCodex(agent.customPath, ssh);
 		if (!codex.available) {
 			emitErrorJson(
 				'Codex CLI not found. Install with: npm install -g @openai/codex',
@@ -125,7 +130,7 @@ export async function send(
 			process.exit(1);
 		}
 	} else if (agent.toolType === 'opencode') {
-		const opencode = await detectOpenCode(agent.customPath, agent.sshRemoteConfig);
+		const opencode = await detectOpenCode(agent.customPath, ssh);
 		if (!opencode.available) {
 			emitErrorJson(
 				'OpenCode CLI not found. Install with: npm install -g opencode',
@@ -134,7 +139,7 @@ export async function send(
 			process.exit(1);
 		}
 	} else if (agent.toolType === 'factory-droid') {
-		const droid = await detectDroid(agent.customPath, agent.sshRemoteConfig);
+		const droid = await detectDroid(agent.customPath, ssh);
 		if (!droid.available) {
 			emitErrorJson(
 				'Factory Droid CLI not found. Install with: https://factory.ai/product/cli',
@@ -159,8 +164,8 @@ export async function send(
 		if (agent.customModel !== undefined) {
 			next.customModel = agent.customModel;
 		}
-		if (agent.sshRemoteConfig !== undefined) {
-			next.sshRemoteConfig = agent.sshRemoteConfig;
+		if (ssh !== undefined) {
+			next.sshRemoteConfig = ssh;
 		}
 
 		return Object.keys(next).length === 0 ? undefined : next;

--- a/src/cli/services/agent-spawner.ts
+++ b/src/cli/services/agent-spawner.ts
@@ -254,6 +254,13 @@ export async function detectOpenCode(customPathOverride?: string): Promise<{
 	source?: 'settings' | 'path';
 }> {
 	if (customPathOverride) {
+		if (cachedOpenCodePath?.path === customPathOverride) {
+			return {
+				available: true,
+				path: cachedOpenCodePath.path,
+				source: cachedOpenCodePath.source,
+			};
+		}
 		if (await isExecutable(customPathOverride)) {
 			cachedOpenCodePath = { path: customPathOverride, source: 'settings' };
 			return { available: true, path: customPathOverride, source: 'settings' };
@@ -301,6 +308,13 @@ export async function detectDroid(customPathOverride?: string): Promise<{
 	source?: 'settings' | 'path';
 }> {
 	if (customPathOverride) {
+		if (cachedDroidPath?.path === customPathOverride) {
+			return {
+				available: true,
+				path: cachedDroidPath.path,
+				source: cachedDroidPath.source,
+			};
+		}
 		if (await isExecutable(customPathOverride)) {
 			cachedDroidPath = { path: customPathOverride, source: 'settings' };
 			return { available: true, path: customPathOverride, source: 'settings' };
@@ -897,6 +911,7 @@ export async function spawnAgent(
 	agentSessionId?: string,
 	overrides?: AgentSpawnOverrides
 ): Promise<AgentResult> {
+	// Claude + Codex have bespoke spawners; OpenCode + Factory Droid share the streaming JSON path.
 	if (toolType === 'codex') {
 		return spawnCodexAgent(cwd, prompt, agentSessionId, overrides);
 	}

--- a/src/cli/services/agent-spawner.ts
+++ b/src/cli/services/agent-spawner.ts
@@ -171,7 +171,6 @@ export async function detectClaude(
 	}
 	if (customPathOverride) {
 		if (await isExecutable(customPathOverride)) {
-			cachedClaudePath = { path: customPathOverride, source: 'settings' };
 			return { available: true, path: customPathOverride, source: 'settings' };
 		}
 		console.error(
@@ -228,7 +227,6 @@ export async function detectCodex(
 	}
 	if (customPathOverride) {
 		if (await isExecutable(customPathOverride)) {
-			cachedCodexPath = { path: customPathOverride, source: 'settings' };
 			return { available: true, path: customPathOverride, source: 'settings' };
 		}
 		console.error(
@@ -280,15 +278,7 @@ export async function detectOpenCode(
 		return { available: true, source: 'settings' };
 	}
 	if (customPathOverride) {
-		if (cachedOpenCodePath?.path === customPathOverride) {
-			return {
-				available: true,
-				path: cachedOpenCodePath.path,
-				source: cachedOpenCodePath.source,
-			};
-		}
 		if (await isExecutable(customPathOverride)) {
-			cachedOpenCodePath = { path: customPathOverride, source: 'settings' };
 			return { available: true, path: customPathOverride, source: 'settings' };
 		}
 		console.error(
@@ -340,15 +330,7 @@ export async function detectDroid(
 		return { available: true, source: 'settings' };
 	}
 	if (customPathOverride) {
-		if (cachedDroidPath?.path === customPathOverride) {
-			return {
-				available: true,
-				path: cachedDroidPath.path,
-				source: cachedDroidPath.source,
-			};
-		}
 		if (await isExecutable(customPathOverride)) {
-			cachedDroidPath = { path: customPathOverride, source: 'settings' };
 			return { available: true, path: customPathOverride, source: 'settings' };
 		}
 		console.error(
@@ -868,6 +850,7 @@ async function spawnCodexAgent(
 	let spawnEnv = env;
 
 	if (overrides?.sshRemoteConfig) {
+		spawnCommand = agentDef?.binaryName ?? getCodexCommand();
 		const sshWrapped = await wrapSpawnWithSsh(
 			{
 				command: spawnCommand,

--- a/src/cli/services/agent-spawner.ts
+++ b/src/cli/services/agent-spawner.ts
@@ -3,7 +3,7 @@
 
 import { spawn, SpawnOptions } from 'child_process';
 import * as fs from 'fs';
-import type { ToolType, UsageStats } from '../../shared/types';
+import type { ToolType, UsageStats, AgentSshRemoteConfig } from '../../shared/types';
 import { CodexOutputParser } from '../../main/parsers/codex-output-parser';
 import { OpenCodeOutputParser } from '../../main/parsers/opencode-output-parser';
 import { FactoryDroidOutputParser } from '../../main/parsers/factory-droid-output-parser';
@@ -14,10 +14,11 @@ import {
 	buildAgentArgs,
 	getContextWindowValue,
 } from '../../main/utils/agent-args';
-import { getAgentConfigValues, getAgentCustomPath } from './storage';
+import { getAgentConfigValues, getAgentCustomPath, readSshRemotes } from './storage';
 import { generateUUID } from '../../shared/uuid';
 import { buildExpandedPath, buildExpandedEnv } from '../../shared/pathUtils';
 import { isWindows, getWhichCommand } from '../../shared/platformDetection';
+import { wrapSpawnWithSsh } from '../../main/utils/ssh-spawn-wrapper';
 
 // Claude Code default command and arguments (same as Electron app)
 const CLAUDE_DEFAULT_COMMAND = 'claude';
@@ -72,6 +73,13 @@ export interface AgentSpawnOverrides {
 	customArgs?: string;
 	customEnvVars?: Record<string, string>;
 	customModel?: string;
+	sshRemoteConfig?: AgentSshRemoteConfig;
+}
+
+function getCliSshRemoteStore() {
+	return {
+		getSshRemotes: () => readSshRemotes(),
+	};
 }
 
 /**
@@ -150,11 +158,17 @@ async function findCodexInPath(): Promise<string | undefined> {
  * Check if Claude Code is available
  * First checks for a custom path in settings, then falls back to PATH detection
  */
-export async function detectClaude(customPathOverride?: string): Promise<{
+export async function detectClaude(
+	customPathOverride?: string,
+	sshRemoteConfig?: AgentSshRemoteConfig
+): Promise<{
 	available: boolean;
 	path?: string;
 	source?: 'settings' | 'path';
 }> {
+	if (sshRemoteConfig?.enabled) {
+		return { available: true, source: 'settings' };
+	}
 	if (customPathOverride) {
 		if (await isExecutable(customPathOverride)) {
 			cachedClaudePath = { path: customPathOverride, source: 'settings' };
@@ -201,11 +215,17 @@ export async function detectClaude(customPathOverride?: string): Promise<{
  * Check if Codex CLI is available
  * First checks for a custom path in settings, then falls back to PATH detection
  */
-export async function detectCodex(customPathOverride?: string): Promise<{
+export async function detectCodex(
+	customPathOverride?: string,
+	sshRemoteConfig?: AgentSshRemoteConfig
+): Promise<{
 	available: boolean;
 	path?: string;
 	source?: 'settings' | 'path';
 }> {
+	if (sshRemoteConfig?.enabled) {
+		return { available: true, source: 'settings' };
+	}
 	if (customPathOverride) {
 		if (await isExecutable(customPathOverride)) {
 			cachedCodexPath = { path: customPathOverride, source: 'settings' };
@@ -248,11 +268,17 @@ export async function detectCodex(customPathOverride?: string): Promise<{
  * Check if OpenCode CLI is available
  * First checks for a custom path in settings, then falls back to PATH detection
  */
-export async function detectOpenCode(customPathOverride?: string): Promise<{
+export async function detectOpenCode(
+	customPathOverride?: string,
+	sshRemoteConfig?: AgentSshRemoteConfig
+): Promise<{
 	available: boolean;
 	path?: string;
 	source?: 'settings' | 'path';
 }> {
+	if (sshRemoteConfig?.enabled) {
+		return { available: true, source: 'settings' };
+	}
 	if (customPathOverride) {
 		if (cachedOpenCodePath?.path === customPathOverride) {
 			return {
@@ -302,11 +328,17 @@ export async function detectOpenCode(customPathOverride?: string): Promise<{
  * Check if Factory Droid CLI is available
  * First checks for a custom path in settings, then falls back to PATH detection
  */
-export async function detectDroid(customPathOverride?: string): Promise<{
+export async function detectDroid(
+	customPathOverride?: string,
+	sshRemoteConfig?: AgentSshRemoteConfig
+): Promise<{
 	available: boolean;
 	path?: string;
 	source?: 'settings' | 'path';
 }> {
+	if (sshRemoteConfig?.enabled) {
+		return { available: true, source: 'settings' };
+	}
 	if (customPathOverride) {
 		if (cachedDroidPath?.path === customPathOverride) {
 			return {
@@ -397,8 +429,8 @@ export function getDroidCommand(customPath?: string): string {
 /**
  * Spawn Claude Code with a prompt and return the result.
  *
- * NOTE: CLI spawner does not support SSH wrapping and does not use the Electron
- * settingsStore/global shell env, but session overrides (model, args, env vars,
+ * NOTE: CLI spawner can SSH-wrap when sshRemoteConfig is provided, but it does not use
+ * the Electron settingsStore/global shell env. Session overrides (model, args, env vars,
  * and custom CLI path) are still applied via applyAgentConfigOverrides().
  */
 async function spawnClaudeAgent(
@@ -407,50 +439,71 @@ async function spawnClaudeAgent(
 	agentSessionId?: string,
 	overrides?: AgentSpawnOverrides
 ): Promise<AgentResult> {
-	return new Promise((resolve) => {
-		const agentDef = getAgentDefinition('claude-code');
-		const agentConfigValues = getAgentConfigValues('claude-code') as Record<string, any>;
+	const agentDef = getAgentDefinition('claude-code');
+	const agentConfigValues = getAgentConfigValues('claude-code') as Record<string, any>;
 
-		// Build args: base args + session handling (prompt appended after overrides)
-		const baseArgs = [...CLAUDE_ARGS];
+	// Build args: base args + session handling (prompt appended after overrides)
+	const baseArgs = [...CLAUDE_ARGS];
 
-		if (agentSessionId) {
-			// Resume an existing session (e.g., for synopsis generation)
-			baseArgs.push('--resume', agentSessionId);
-		} else {
-			// Force a fresh, isolated session for each task execution
-			// This prevents context bleeding between tasks in Auto Run
-			baseArgs.push('--session-id', generateUUID());
+	if (agentSessionId) {
+		// Resume an existing session (e.g., for synopsis generation)
+		baseArgs.push('--resume', agentSessionId);
+	} else {
+		// Force a fresh, isolated session for each task execution
+		// This prevents context bleeding between tasks in Auto Run
+		baseArgs.push('--session-id', generateUUID());
+	}
+
+	const { args: resolvedArgs, effectiveCustomEnvVars } = applyAgentConfigOverrides(
+		agentDef,
+		baseArgs,
+		{
+			agentConfigValues,
+			sessionCustomModel: overrides?.customModel,
+			sessionCustomArgs: overrides?.customArgs,
+			sessionCustomEnvVars: overrides?.customEnvVars,
 		}
+	);
 
-		const { args: resolvedArgs, effectiveCustomEnvVars } = applyAgentConfigOverrides(
-			agentDef,
-			baseArgs,
+	// Add prompt as positional argument after overrides
+	const args = [...resolvedArgs, '--', prompt];
+
+	// Note: CLI agent spawner doesn't have access to settingsStore with global shell env vars.
+	// For CLI, we rely on the environment that Maestro itself is running in.
+	// Global shell env vars are primarily used by the desktop app's process manager.
+	const env = buildExpandedEnv(effectiveCustomEnvVars);
+
+	let spawnCommand = getClaudeCommand(overrides?.customPath);
+	let spawnArgs = args;
+	let spawnCwd = cwd;
+	let spawnEnv = env;
+
+	if (overrides?.sshRemoteConfig) {
+		const sshWrapped = await wrapSpawnWithSsh(
 			{
-				agentConfigValues,
-				sessionCustomModel: overrides?.customModel,
-				sessionCustomArgs: overrides?.customArgs,
-				sessionCustomEnvVars: overrides?.customEnvVars,
-			}
+				command: spawnCommand,
+				args: spawnArgs,
+				cwd,
+				customEnvVars: effectiveCustomEnvVars,
+				agentBinaryName: agentDef?.binaryName,
+			},
+			overrides.sshRemoteConfig,
+			getCliSshRemoteStore()
 		);
+		spawnCommand = sshWrapped.command;
+		spawnArgs = sshWrapped.args;
+		spawnCwd = sshWrapped.cwd;
+		spawnEnv = buildExpandedEnv(sshWrapped.customEnvVars);
+	}
 
-		// Add prompt as positional argument after overrides
-		const args = [...resolvedArgs, '--', prompt];
-
-		// Note: CLI agent spawner doesn't have access to settingsStore with global shell env vars.
-		// For CLI, we rely on the environment that Maestro itself is running in.
-		// Global shell env vars are primarily used by the desktop app's process manager.
-		const env = buildExpandedEnv(effectiveCustomEnvVars);
-
+	return new Promise((resolve) => {
 		const options: SpawnOptions = {
-			cwd,
-			env,
+			cwd: spawnCwd,
+			env: spawnEnv,
 			stdio: ['pipe', 'pipe', 'pipe'],
 		};
 
-		// Use the resolved Claude path (from settings or PATH detection)
-		const claudeCommand = getClaudeCommand(overrides?.customPath);
-		const child = spawn(claudeCommand, args, options);
+		const child = spawn(spawnCommand, spawnArgs, options);
 
 		let jsonBuffer = '';
 		let result: string | undefined;
@@ -584,7 +637,7 @@ type StreamJsonParser = {
 		| undefined;
 };
 
-function spawnStreamingAgent(
+async function spawnStreamingAgent(
 	toolType: 'opencode' | 'factory-droid',
 	cwd: string,
 	prompt: string,
@@ -594,23 +647,46 @@ function spawnStreamingAgent(
 	createParser: () => StreamJsonParser,
 	agentLabel: string
 ): Promise<AgentResult> {
-	return new Promise((resolve) => {
-		const { args, env, contextWindow } = resolveAgentInvocation(
-			toolType,
-			cwd,
-			prompt,
-			agentSessionId,
-			overrides
-		);
+	const { args, env, contextWindow, effectiveCustomEnvVars } = resolveAgentInvocation(
+		toolType,
+		cwd,
+		prompt,
+		agentSessionId,
+		overrides
+	);
+	const agentDef = getAgentDefinition(toolType);
 
+	let spawnCommand = commandGetter(overrides?.customPath);
+	let spawnArgs = args;
+	let spawnCwd = cwd;
+	let spawnEnv = env;
+
+	if (overrides?.sshRemoteConfig) {
+		const sshWrapped = await wrapSpawnWithSsh(
+			{
+				command: spawnCommand,
+				args: spawnArgs,
+				cwd,
+				customEnvVars: effectiveCustomEnvVars,
+				agentBinaryName: agentDef?.binaryName,
+			},
+			overrides.sshRemoteConfig,
+			getCliSshRemoteStore()
+		);
+		spawnCommand = sshWrapped.command;
+		spawnArgs = sshWrapped.args;
+		spawnCwd = sshWrapped.cwd;
+		spawnEnv = buildExpandedEnv(sshWrapped.customEnvVars);
+	}
+
+	return new Promise((resolve) => {
 		const options: SpawnOptions = {
-			cwd,
-			env,
+			cwd: spawnCwd,
+			env: spawnEnv,
 			stdio: ['pipe', 'pipe', 'pipe'],
 		};
 
-		const agentCommand = commandGetter(overrides?.customPath);
-		const child = spawn(agentCommand, args, options);
+		const child = spawn(spawnCommand, spawnArgs, options);
 
 		const parser = createParser();
 		let jsonBuffer = '';
@@ -705,6 +781,7 @@ function resolveAgentInvocation(
 	args: string[];
 	env: NodeJS.ProcessEnv;
 	contextWindow: number;
+	effectiveCustomEnvVars?: Record<string, string>;
 } {
 	const agentDef = getAgentDefinition(toolType);
 	const agentConfigValues = getAgentConfigValues(toolType) as Record<string, any>;
@@ -736,14 +813,14 @@ function resolveAgentInvocation(
 	const env = buildExpandedEnv(effectiveCustomEnvVars);
 	const contextWindow = getContextWindowValue(agentDef, agentConfigValues);
 
-	return { args: finalArgs, env, contextWindow };
+	return { args: finalArgs, env, contextWindow, effectiveCustomEnvVars };
 }
 
 /**
  * Spawn Codex with a prompt and return the result.
  *
- * NOTE: Same limitations as spawnClaudeAgent (no SSH wrapping and no global
- * settingsStore); per-session overrides are still applied.
+ * NOTE: Same limitations as spawnClaudeAgent (no global settingsStore); per-session
+ * overrides are still applied.
  */
 async function spawnCodexAgent(
 	cwd: string,
@@ -751,43 +828,65 @@ async function spawnCodexAgent(
 	agentSessionId?: string,
 	overrides?: AgentSpawnOverrides
 ): Promise<AgentResult> {
-	return new Promise((resolve) => {
-		const agentDef = getAgentDefinition('codex');
-		const agentConfigValues = getAgentConfigValues('codex') as Record<string, any>;
+	const agentDef = getAgentDefinition('codex');
+	const agentConfigValues = getAgentConfigValues('codex') as Record<string, any>;
 
-		const baseArgs = [...CODEX_ARGS];
-		baseArgs.push('-C', cwd);
+	const baseArgs = [...CODEX_ARGS];
+	baseArgs.push('-C', cwd);
 
-		if (agentSessionId) {
-			baseArgs.push('resume', agentSessionId);
+	if (agentSessionId) {
+		baseArgs.push('resume', agentSessionId);
+	}
+
+	const { args: resolvedArgs, effectiveCustomEnvVars } = applyAgentConfigOverrides(
+		agentDef,
+		baseArgs,
+		{
+			agentConfigValues,
+			sessionCustomModel: overrides?.customModel,
+			sessionCustomArgs: overrides?.customArgs,
+			sessionCustomEnvVars: overrides?.customEnvVars,
 		}
+	);
 
-		const { args: resolvedArgs, effectiveCustomEnvVars } = applyAgentConfigOverrides(
-			agentDef,
-			baseArgs,
+	const args = [...resolvedArgs, '--', prompt];
+
+	// Note: CLI agent spawner doesn't have access to settingsStore with global shell env vars.
+	// For CLI, we rely on the environment that Maestro itself is running in.
+	// Global shell env vars are primarily used by the desktop app's process manager.
+	const env = buildExpandedEnv(effectiveCustomEnvVars);
+
+	let spawnCommand = getCodexCommand(overrides?.customPath);
+	let spawnArgs = args;
+	let spawnCwd = cwd;
+	let spawnEnv = env;
+
+	if (overrides?.sshRemoteConfig) {
+		const sshWrapped = await wrapSpawnWithSsh(
 			{
-				agentConfigValues,
-				sessionCustomModel: overrides?.customModel,
-				sessionCustomArgs: overrides?.customArgs,
-				sessionCustomEnvVars: overrides?.customEnvVars,
-			}
+				command: spawnCommand,
+				args: spawnArgs,
+				cwd,
+				customEnvVars: effectiveCustomEnvVars,
+				agentBinaryName: agentDef?.binaryName,
+			},
+			overrides.sshRemoteConfig,
+			getCliSshRemoteStore()
 		);
+		spawnCommand = sshWrapped.command;
+		spawnArgs = sshWrapped.args;
+		spawnCwd = sshWrapped.cwd;
+		spawnEnv = buildExpandedEnv(sshWrapped.customEnvVars);
+	}
 
-		const args = [...resolvedArgs, '--', prompt];
-
-		// Note: CLI agent spawner doesn't have access to settingsStore with global shell env vars.
-		// For CLI, we rely on the environment that Maestro itself is running in.
-		// Global shell env vars are primarily used by the desktop app's process manager.
-		const env = buildExpandedEnv(effectiveCustomEnvVars);
-
+	return new Promise((resolve) => {
 		const options: SpawnOptions = {
-			cwd,
-			env,
+			cwd: spawnCwd,
+			env: spawnEnv,
 			stdio: ['pipe', 'pipe', 'pipe'],
 		};
 
-		const codexCommand = getCodexCommand(overrides?.customPath);
-		const child = spawn(codexCommand, args, options);
+		const child = spawn(spawnCommand, spawnArgs, options);
 
 		const parser = new CodexOutputParser();
 		let jsonBuffer = '';

--- a/src/cli/services/agent-spawner.ts
+++ b/src/cli/services/agent-spawner.ts
@@ -473,7 +473,10 @@ async function spawnClaudeAgent(
 	// Global shell env vars are primarily used by the desktop app's process manager.
 	const env = buildExpandedEnv(effectiveCustomEnvVars);
 
-	let spawnCommand = getClaudeCommand(overrides?.customPath);
+	let spawnCommand =
+		overrides?.sshRemoteConfig && !overrides?.customPath && agentDef?.binaryName
+			? agentDef.binaryName
+			: getClaudeCommand(overrides?.customPath);
 	let spawnArgs = args;
 	let spawnCwd = cwd;
 	let spawnEnv = env;
@@ -656,7 +659,10 @@ async function spawnStreamingAgent(
 	);
 	const agentDef = getAgentDefinition(toolType);
 
-	let spawnCommand = commandGetter(overrides?.customPath);
+	let spawnCommand =
+		overrides?.sshRemoteConfig && !overrides?.customPath && agentDef?.binaryName
+			? agentDef.binaryName
+			: commandGetter(overrides?.customPath);
 	let spawnArgs = args;
 	let spawnCwd = cwd;
 	let spawnEnv = env;

--- a/src/cli/services/agent-spawner.ts
+++ b/src/cli/services/agent-spawner.ts
@@ -328,7 +328,10 @@ export async function detectDroid(
  * Get the resolved Claude command/path for spawning
  * Uses cached path from detectClaude() or falls back to default command
  */
-export function getClaudeCommand(): string {
+export function getClaudeCommand(customPath?: string): string {
+	if (customPath && customPath.trim()) {
+		return customPath;
+	}
 	return cachedClaudePath || CLAUDE_DEFAULT_COMMAND;
 }
 
@@ -336,21 +339,30 @@ export function getClaudeCommand(): string {
  * Get the resolved Codex command/path for spawning
  * Uses cached path from detectCodex() or falls back to default command
  */
-export function getCodexCommand(): string {
+export function getCodexCommand(customPath?: string): string {
+	if (customPath && customPath.trim()) {
+		return customPath;
+	}
 	return cachedCodexPath || CODEX_DEFAULT_COMMAND;
 }
 
 /**
  * Get the resolved OpenCode command/path for spawning
  */
-export function getOpenCodeCommand(): string {
+export function getOpenCodeCommand(customPath?: string): string {
+	if (customPath && customPath.trim()) {
+		return customPath;
+	}
 	return cachedOpenCodePath || OPENCODE_DEFAULT_COMMAND;
 }
 
 /**
  * Get the resolved Factory Droid command/path for spawning
  */
-export function getDroidCommand(): string {
+export function getDroidCommand(customPath?: string): string {
+	if (customPath && customPath.trim()) {
+		return customPath;
+	}
 	return cachedDroidPath || DROID_DEFAULT_COMMAND;
 }
 
@@ -360,28 +372,43 @@ export function getDroidCommand(): string {
 async function spawnClaudeAgent(
 	cwd: string,
 	prompt: string,
-	agentSessionId?: string
+	agentSessionId?: string,
+	overrides?: AgentSpawnOverrides
 ): Promise<AgentResult> {
 	return new Promise((resolve) => {
-		// Note: CLI agent spawner doesn't have access to settingsStore with global shell env vars.
-		// For CLI, we rely on the environment that Maestro itself is running in.
-		// Global shell env vars are primarily used by the desktop app's process manager.
-		const env = buildExpandedEnv();
+		const agentDef = getAgentDefinition('claude-code');
+		const agentConfigValues = getAgentConfigValues('claude-code') as Record<string, any>;
 
-		// Build args: base args + session handling + prompt
-		const args = [...CLAUDE_ARGS];
+		// Build args: base args + session handling (prompt appended after overrides)
+		const baseArgs = [...CLAUDE_ARGS];
 
 		if (agentSessionId) {
 			// Resume an existing session (e.g., for synopsis generation)
-			args.push('--resume', agentSessionId);
+			baseArgs.push('--resume', agentSessionId);
 		} else {
 			// Force a fresh, isolated session for each task execution
 			// This prevents context bleeding between tasks in Auto Run
-			args.push('--session-id', generateUUID());
+			baseArgs.push('--session-id', generateUUID());
 		}
 
-		// Add prompt as positional argument
-		args.push('--', prompt);
+		const { args: resolvedArgs, effectiveCustomEnvVars } = applyAgentConfigOverrides(
+			agentDef,
+			baseArgs,
+			{
+				agentConfigValues,
+				sessionCustomModel: overrides?.customModel,
+				sessionCustomArgs: overrides?.customArgs,
+				sessionCustomEnvVars: overrides?.customEnvVars,
+			}
+		);
+
+		// Add prompt as positional argument after overrides
+		const args = [...resolvedArgs, '--', prompt];
+
+		// Note: CLI agent spawner doesn't have access to settingsStore with global shell env vars.
+		// For CLI, we rely on the environment that Maestro itself is running in.
+		// Global shell env vars are primarily used by the desktop app's process manager.
+		const env = buildExpandedEnv(effectiveCustomEnvVars);
 
 		const options: SpawnOptions = {
 			cwd,
@@ -390,7 +417,7 @@ async function spawnClaudeAgent(
 		};
 
 		// Use the resolved Claude path (from settings or PATH detection)
-		const claudeCommand = getClaudeCommand();
+		const claudeCommand = getClaudeCommand(overrides?.customPath);
 		const child = spawn(claudeCommand, args, options);
 
 		let jsonBuffer = '';
@@ -557,22 +584,37 @@ function resolveAgentInvocation(
 async function spawnCodexAgent(
 	cwd: string,
 	prompt: string,
-	agentSessionId?: string
+	agentSessionId?: string,
+	overrides?: AgentSpawnOverrides
 ): Promise<AgentResult> {
 	return new Promise((resolve) => {
+		const agentDef = getAgentDefinition('codex');
+		const agentConfigValues = getAgentConfigValues('codex') as Record<string, any>;
+
+		const baseArgs = [...CODEX_ARGS];
+		baseArgs.push('-C', cwd);
+
+		if (agentSessionId) {
+			baseArgs.push('resume', agentSessionId);
+		}
+
+		const { args: resolvedArgs, effectiveCustomEnvVars } = applyAgentConfigOverrides(
+			agentDef,
+			baseArgs,
+			{
+				agentConfigValues,
+				sessionCustomModel: overrides?.customModel,
+				sessionCustomArgs: overrides?.customArgs,
+				sessionCustomEnvVars: overrides?.customEnvVars,
+			}
+		);
+
+		const args = [...resolvedArgs, '--', prompt];
+
 		// Note: CLI agent spawner doesn't have access to settingsStore with global shell env vars.
 		// For CLI, we rely on the environment that Maestro itself is running in.
 		// Global shell env vars are primarily used by the desktop app's process manager.
-		const env = buildExpandedEnv();
-
-		const args = [...CODEX_ARGS];
-		args.push('-C', cwd);
-
-		if (agentSessionId) {
-			args.push('resume', agentSessionId);
-		}
-
-		args.push('--', prompt);
+		const env = buildExpandedEnv(effectiveCustomEnvVars);
 
 		const options: SpawnOptions = {
 			cwd,
@@ -580,7 +622,7 @@ async function spawnCodexAgent(
 			stdio: ['pipe', 'pipe', 'pipe'],
 		};
 
-		const codexCommand = getCodexCommand();
+		const codexCommand = getCodexCommand(overrides?.customPath);
 		const child = spawn(codexCommand, args, options);
 
 		const parser = new CodexOutputParser();
@@ -677,7 +719,7 @@ async function spawnOpenCodeAgent(
 			stdio: ['pipe', 'pipe', 'pipe'],
 		};
 
-		const opencodeCommand = getOpenCodeCommand();
+		const opencodeCommand = getOpenCodeCommand(overrides?.customPath);
 		const child = spawn(opencodeCommand, args, options);
 
 		const parser = new OpenCodeOutputParser();
@@ -787,7 +829,7 @@ async function spawnFactoryDroidAgent(
 			stdio: ['pipe', 'pipe', 'pipe'],
 		};
 
-		const droidCommand = getDroidCommand();
+		const droidCommand = getDroidCommand(overrides?.customPath);
 		const child = spawn(droidCommand, args, options);
 
 		const parser = new FactoryDroidOutputParser();
@@ -884,11 +926,11 @@ export async function spawnAgent(
 	overrides?: AgentSpawnOverrides
 ): Promise<AgentResult> {
 	if (toolType === 'codex') {
-		return spawnCodexAgent(cwd, prompt, agentSessionId);
+		return spawnCodexAgent(cwd, prompt, agentSessionId, overrides);
 	}
 
 	if (toolType === 'claude-code') {
-		return spawnClaudeAgent(cwd, prompt, agentSessionId);
+		return spawnClaudeAgent(cwd, prompt, agentSessionId, overrides);
 	}
 
 	if (toolType === 'opencode') {

--- a/src/cli/services/agent-spawner.ts
+++ b/src/cli/services/agent-spawner.ts
@@ -387,10 +387,9 @@ export function getDroidCommand(customPath?: string): string {
 /**
  * Spawn Claude Code with a prompt and return the result.
  *
- * NOTE: CLI spawner does not apply applyAgentConfigOverrides() or SSH wrapping.
- * Designed for headless batch execution without access to the Electron settings
- * store or per-session agent configuration. Custom model, args, env vars, and
- * SSH remote execution are not supported in CLI mode.
+ * NOTE: CLI spawner does not support SSH wrapping and does not use the Electron
+ * settingsStore/global shell env, but session overrides (model, args, env vars,
+ * and custom CLI path) are still applied via applyAgentConfigOverrides().
  */
 async function spawnClaudeAgent(
 	cwd: string,
@@ -733,8 +732,8 @@ function resolveAgentInvocation(
 /**
  * Spawn Codex with a prompt and return the result.
  *
- * NOTE: Same limitations as spawnClaudeAgent — no applyAgentConfigOverrides()
- * or SSH wrapping in CLI mode.
+ * NOTE: Same limitations as spawnClaudeAgent (no SSH wrapping and no global
+ * settingsStore); per-session overrides are still applied.
  */
 async function spawnCodexAgent(
 	cwd: string,

--- a/src/cli/services/agent-spawner.ts
+++ b/src/cli/services/agent-spawner.ts
@@ -1,12 +1,16 @@
 // Agent spawner service for CLI
-// Spawns agent CLIs (Claude Code, Codex) and parses their output
+// Spawns agent CLIs (Claude Code, Codex, OpenCode, Factory Droid) and parses their output
 
 import { spawn, SpawnOptions } from 'child_process';
 import * as fs from 'fs';
 import type { ToolType, UsageStats } from '../../shared/types';
 import { CodexOutputParser } from '../../main/parsers/codex-output-parser';
+import { OpenCodeOutputParser } from '../../main/parsers/opencode-output-parser';
+import { FactoryDroidOutputParser } from '../../main/parsers/factory-droid-output-parser';
 import { aggregateModelUsage } from '../../main/parsers/usage-aggregator';
-import { getAgentCustomPath } from './storage';
+import { getAgentDefinition } from '../../main/agents/definitions';
+import { applyAgentConfigOverrides, buildAgentArgs, getContextWindowValue } from '../../main/utils/agent-args';
+import { getAgentConfigValues, getAgentCustomPath } from './storage';
 import { generateUUID } from '../../shared/uuid';
 import { buildExpandedPath, buildExpandedEnv } from '../../shared/pathUtils';
 import { isWindows, getWhichCommand } from '../../shared/platformDetection';
@@ -36,6 +40,18 @@ const CODEX_ARGS = [
 // Cached Codex path (resolved once at startup)
 let cachedCodexPath: string | null = null;
 
+// OpenCode default command
+const OPENCODE_DEFAULT_COMMAND = 'opencode';
+
+// Cached OpenCode path (resolved once at startup)
+let cachedOpenCodePath: string | null = null;
+
+// Factory Droid default command
+const DROID_DEFAULT_COMMAND = 'droid';
+
+// Cached Factory Droid path (resolved once at startup)
+let cachedDroidPath: string | null = null;
+
 // Result from spawning an agent
 export interface AgentResult {
 	success: boolean;
@@ -43,6 +59,13 @@ export interface AgentResult {
 	agentSessionId?: string;
 	usageStats?: UsageStats;
 	error?: string;
+}
+
+export interface AgentSpawnOverrides {
+	customPath?: string;
+	customArgs?: string;
+	customEnvVars?: Record<string, string>;
+	customModel?: string;
 }
 
 /**
@@ -75,14 +98,14 @@ async function isExecutable(filePath: string): Promise<boolean> {
 }
 
 /**
- * Find Claude in PATH using 'which' command
+ * Find a command in PATH using 'which' command
  */
-async function findClaudeInPath(): Promise<string | undefined> {
+async function findCommandInPath(commandName: string): Promise<string | undefined> {
 	return new Promise((resolve) => {
 		const env = { ...process.env, PATH: getExpandedPath() };
 		const command = getWhichCommand();
 
-		const proc = spawn(command, [CLAUDE_DEFAULT_COMMAND], { env });
+		const proc = spawn(command, [commandName], { env });
 		let stdout = '';
 
 		proc.stdout?.on('data', (data) => {
@@ -101,46 +124,43 @@ async function findClaudeInPath(): Promise<string | undefined> {
 			resolve(undefined);
 		});
 	});
+}
+
+/**
+ * Find Claude in PATH using 'which' command
+ */
+async function findClaudeInPath(): Promise<string | undefined> {
+	return findCommandInPath(CLAUDE_DEFAULT_COMMAND);
 }
 
 /**
  * Find Codex in PATH using 'which' command
  */
 async function findCodexInPath(): Promise<string | undefined> {
-	return new Promise((resolve) => {
-		const env = { ...process.env, PATH: getExpandedPath() };
-		const command = getWhichCommand();
-
-		const proc = spawn(command, [CODEX_DEFAULT_COMMAND], { env });
-		let stdout = '';
-
-		proc.stdout?.on('data', (data) => {
-			stdout += data.toString();
-		});
-
-		proc.on('close', (code) => {
-			if (code === 0 && stdout.trim()) {
-				resolve(stdout.trim().split('\n')[0]); // First match
-			} else {
-				resolve(undefined);
-			}
-		});
-
-		proc.on('error', () => {
-			resolve(undefined);
-		});
-	});
+	return findCommandInPath(CODEX_DEFAULT_COMMAND);
 }
 
 /**
  * Check if Claude Code is available
  * First checks for a custom path in settings, then falls back to PATH detection
  */
-export async function detectClaude(): Promise<{
+export async function detectClaude(
+	customPathOverride?: string
+): Promise<{
 	available: boolean;
 	path?: string;
 	source?: 'settings' | 'path';
 }> {
+	if (customPathOverride) {
+		if (await isExecutable(customPathOverride)) {
+			cachedClaudePath = customPathOverride;
+			return { available: true, path: customPathOverride, source: 'settings' };
+		}
+		console.error(
+			`Warning: Custom Claude path "${customPathOverride}" is not executable, falling back to PATH detection`
+		);
+	}
+
 	// Return cached result if available
 	if (cachedClaudePath) {
 		return { available: true, path: cachedClaudePath, source: 'settings' };
@@ -173,11 +193,23 @@ export async function detectClaude(): Promise<{
  * Check if Codex CLI is available
  * First checks for a custom path in settings, then falls back to PATH detection
  */
-export async function detectCodex(): Promise<{
+export async function detectCodex(
+	customPathOverride?: string
+): Promise<{
 	available: boolean;
 	path?: string;
 	source?: 'settings' | 'path';
 }> {
+	if (customPathOverride) {
+		if (await isExecutable(customPathOverride)) {
+			cachedCodexPath = customPathOverride;
+			return { available: true, path: customPathOverride, source: 'settings' };
+		}
+		console.error(
+			`Warning: Custom Codex path "${customPathOverride}" is not executable, falling back to PATH detection`
+		);
+	}
+
 	if (cachedCodexPath) {
 		return { available: true, path: cachedCodexPath, source: 'settings' };
 	}
@@ -203,6 +235,96 @@ export async function detectCodex(): Promise<{
 }
 
 /**
+ * Check if OpenCode CLI is available
+ * First checks for a custom path in settings, then falls back to PATH detection
+ */
+export async function detectOpenCode(
+	customPathOverride?: string
+): Promise<{
+	available: boolean;
+	path?: string;
+	source?: 'settings' | 'path';
+}> {
+	if (customPathOverride) {
+		if (await isExecutable(customPathOverride)) {
+			cachedOpenCodePath = customPathOverride;
+			return { available: true, path: customPathOverride, source: 'settings' };
+		}
+		console.error(
+			`Warning: Custom OpenCode path "${customPathOverride}" is not executable, falling back to PATH detection`
+		);
+	}
+
+	if (cachedOpenCodePath) {
+		return { available: true, path: cachedOpenCodePath, source: 'settings' };
+	}
+
+	const customPath = getAgentCustomPath('opencode');
+	if (customPath) {
+		if (await isExecutable(customPath)) {
+			cachedOpenCodePath = customPath;
+			return { available: true, path: customPath, source: 'settings' };
+		}
+		console.error(
+			`Warning: Custom OpenCode path "${customPath}" is not executable, falling back to PATH detection`
+		);
+	}
+
+	const pathResult = await findCommandInPath(OPENCODE_DEFAULT_COMMAND);
+	if (pathResult) {
+		cachedOpenCodePath = pathResult;
+		return { available: true, path: pathResult, source: 'path' };
+	}
+
+	return { available: false };
+}
+
+/**
+ * Check if Factory Droid CLI is available
+ * First checks for a custom path in settings, then falls back to PATH detection
+ */
+export async function detectDroid(
+	customPathOverride?: string
+): Promise<{
+	available: boolean;
+	path?: string;
+	source?: 'settings' | 'path';
+}> {
+	if (customPathOverride) {
+		if (await isExecutable(customPathOverride)) {
+			cachedDroidPath = customPathOverride;
+			return { available: true, path: customPathOverride, source: 'settings' };
+		}
+		console.error(
+			`Warning: Custom Droid path "${customPathOverride}" is not executable, falling back to PATH detection`
+		);
+	}
+
+	if (cachedDroidPath) {
+		return { available: true, path: cachedDroidPath, source: 'settings' };
+	}
+
+	const customPath = getAgentCustomPath('factory-droid');
+	if (customPath) {
+		if (await isExecutable(customPath)) {
+			cachedDroidPath = customPath;
+			return { available: true, path: customPath, source: 'settings' };
+		}
+		console.error(
+			`Warning: Custom Droid path "${customPath}" is not executable, falling back to PATH detection`
+		);
+	}
+
+	const pathResult = await findCommandInPath(DROID_DEFAULT_COMMAND);
+	if (pathResult) {
+		cachedDroidPath = pathResult;
+		return { available: true, path: pathResult, source: 'path' };
+	}
+
+	return { available: false };
+}
+
+/**
  * Get the resolved Claude command/path for spawning
  * Uses cached path from detectClaude() or falls back to default command
  */
@@ -216,6 +338,20 @@ export function getClaudeCommand(): string {
  */
 export function getCodexCommand(): string {
 	return cachedCodexPath || CODEX_DEFAULT_COMMAND;
+}
+
+/**
+ * Get the resolved OpenCode command/path for spawning
+ */
+export function getOpenCodeCommand(): string {
+	return cachedOpenCodePath || OPENCODE_DEFAULT_COMMAND;
+}
+
+/**
+ * Get the resolved Factory Droid command/path for spawning
+ */
+export function getDroidCommand(): string {
+	return cachedDroidPath || DROID_DEFAULT_COMMAND;
 }
 
 /**
@@ -371,6 +507,50 @@ function mergeUsageStats(
 	return merged;
 }
 
+function resolveAgentInvocation(
+	toolType: ToolType,
+	cwd: string,
+	prompt: string,
+	agentSessionId: string | undefined,
+	overrides?: AgentSpawnOverrides
+): {
+	args: string[];
+	env: NodeJS.ProcessEnv;
+	contextWindow: number;
+} {
+	const agentDef = getAgentDefinition(toolType);
+	const agentConfigValues = getAgentConfigValues(toolType) as Record<string, any>;
+
+	const baseArgs = buildAgentArgs(agentDef, {
+		baseArgs: [],
+		prompt,
+		cwd,
+		agentSessionId,
+	});
+
+	const { args: resolvedArgs, effectiveCustomEnvVars } = applyAgentConfigOverrides(
+		agentDef,
+		baseArgs,
+		{
+			agentConfigValues,
+			sessionCustomModel: overrides?.customModel,
+			sessionCustomArgs: overrides?.customArgs,
+			sessionCustomEnvVars: overrides?.customEnvVars,
+		}
+	);
+
+	const finalArgs = [...resolvedArgs];
+	if (!agentDef?.noPromptSeparator) {
+		finalArgs.push('--');
+	}
+	finalArgs.push(prompt);
+
+	const env = buildExpandedEnv(effectiveCustomEnvVars);
+	const contextWindow = getContextWindowValue(agentDef, agentConfigValues);
+
+	return { args: finalArgs, env, contextWindow };
+}
+
 /**
  * Spawn Codex with a prompt and return the result
  */
@@ -474,13 +654,234 @@ async function spawnCodexAgent(
 }
 
 /**
+ * Spawn OpenCode with a prompt and return the result
+ */
+async function spawnOpenCodeAgent(
+	cwd: string,
+	prompt: string,
+	agentSessionId?: string,
+	overrides?: AgentSpawnOverrides
+): Promise<AgentResult> {
+	return new Promise((resolve) => {
+		const { args, env, contextWindow } = resolveAgentInvocation(
+			'opencode',
+			cwd,
+			prompt,
+			agentSessionId,
+			overrides
+		);
+
+		const options: SpawnOptions = {
+			cwd,
+			env,
+			stdio: ['pipe', 'pipe', 'pipe'],
+		};
+
+		const opencodeCommand = getOpenCodeCommand();
+		const child = spawn(opencodeCommand, args, options);
+
+		const parser = new OpenCodeOutputParser();
+		let jsonBuffer = '';
+		let result: string | undefined;
+		let sessionId: string | undefined;
+		let usageStats: UsageStats | undefined;
+		let stderr = '';
+		let errorText: string | undefined;
+
+		child.stdout?.on('data', (data: Buffer) => {
+			jsonBuffer += data.toString();
+			const lines = jsonBuffer.split('\n');
+			jsonBuffer = lines.pop() || '';
+
+			for (const line of lines) {
+				if (!line.trim()) continue;
+				const event = parser.parseJsonLine(line);
+				if (!event) continue;
+
+				const extractedSessionId = parser.extractSessionId(event);
+				if (extractedSessionId && !sessionId) {
+					sessionId = extractedSessionId;
+				}
+
+				if (parser.isResultMessage(event) && event.text) {
+					result = result ? `${result}\n${event.text}` : event.text;
+				}
+
+				if (event.type === 'error' && event.text && !errorText) {
+					errorText = event.text;
+				}
+
+				const usage = parser.extractUsage(event);
+				if (usage) {
+					usageStats = mergeUsageStats(usageStats, {
+						inputTokens: usage.inputTokens,
+						outputTokens: usage.outputTokens,
+						cacheReadTokens: usage.cacheReadTokens,
+						cacheCreationTokens: usage.cacheCreationTokens,
+						costUsd: usage.costUsd,
+						contextWindow: usage.contextWindow,
+						reasoningTokens: usage.reasoningTokens,
+					});
+				}
+			}
+		});
+
+		child.stderr?.on('data', (data: Buffer) => {
+			stderr += data.toString();
+		});
+
+		child.stdin?.end();
+
+		child.on('close', (code) => {
+			if (usageStats && (!usageStats.contextWindow || usageStats.contextWindow === 0)) {
+				usageStats.contextWindow = contextWindow;
+			}
+
+			if (code === 0 && !errorText) {
+				resolve({
+					success: true,
+					response: result,
+					agentSessionId: sessionId,
+					usageStats,
+				});
+			} else {
+				resolve({
+					success: false,
+					error: errorText || stderr || `Process exited with code ${code}`,
+					agentSessionId: sessionId,
+					usageStats,
+				});
+			}
+		});
+
+		child.on('error', (error) => {
+			resolve({
+				success: false,
+				error: `Failed to spawn OpenCode: ${error.message}`,
+			});
+		});
+	});
+}
+
+/**
+ * Spawn Factory Droid with a prompt and return the result
+ */
+async function spawnFactoryDroidAgent(
+	cwd: string,
+	prompt: string,
+	agentSessionId?: string,
+	overrides?: AgentSpawnOverrides
+): Promise<AgentResult> {
+	return new Promise((resolve) => {
+		const { args, env, contextWindow } = resolveAgentInvocation(
+			'factory-droid',
+			cwd,
+			prompt,
+			agentSessionId,
+			overrides
+		);
+
+		const options: SpawnOptions = {
+			cwd,
+			env,
+			stdio: ['pipe', 'pipe', 'pipe'],
+		};
+
+		const droidCommand = getDroidCommand();
+		const child = spawn(droidCommand, args, options);
+
+		const parser = new FactoryDroidOutputParser();
+		let jsonBuffer = '';
+		let result: string | undefined;
+		let sessionId: string | undefined;
+		let usageStats: UsageStats | undefined;
+		let stderr = '';
+		let errorText: string | undefined;
+
+		child.stdout?.on('data', (data: Buffer) => {
+			jsonBuffer += data.toString();
+			const lines = jsonBuffer.split('\n');
+			jsonBuffer = lines.pop() || '';
+
+			for (const line of lines) {
+				if (!line.trim()) continue;
+				const event = parser.parseJsonLine(line);
+				if (!event) continue;
+
+				const extractedSessionId = parser.extractSessionId(event);
+				if (extractedSessionId && !sessionId) {
+					sessionId = extractedSessionId;
+				}
+
+				if (parser.isResultMessage(event) && event.text) {
+					result = result ? `${result}\n${event.text}` : event.text;
+				}
+
+				if (event.type === 'error' && event.text && !errorText) {
+					errorText = event.text;
+				}
+
+				const usage = parser.extractUsage(event);
+				if (usage) {
+					usageStats = mergeUsageStats(usageStats, {
+						inputTokens: usage.inputTokens,
+						outputTokens: usage.outputTokens,
+						cacheReadTokens: usage.cacheReadTokens,
+						cacheCreationTokens: usage.cacheCreationTokens,
+						costUsd: usage.costUsd,
+						contextWindow: usage.contextWindow,
+						reasoningTokens: usage.reasoningTokens,
+					});
+				}
+			}
+		});
+
+		child.stderr?.on('data', (data: Buffer) => {
+			stderr += data.toString();
+		});
+
+		child.stdin?.end();
+
+		child.on('close', (code) => {
+			if (usageStats && (!usageStats.contextWindow || usageStats.contextWindow === 0)) {
+				usageStats.contextWindow = contextWindow;
+			}
+
+			if (code === 0 && !errorText) {
+				resolve({
+					success: true,
+					response: result,
+					agentSessionId: sessionId,
+					usageStats,
+				});
+			} else {
+				resolve({
+					success: false,
+					error: errorText || stderr || `Process exited with code ${code}`,
+					agentSessionId: sessionId,
+					usageStats,
+				});
+			}
+		});
+
+		child.on('error', (error) => {
+			resolve({
+				success: false,
+				error: `Failed to spawn Factory Droid: ${error.message}`,
+			});
+		});
+	});
+}
+
+/**
  * Spawn an agent with a prompt and return the result
  */
 export async function spawnAgent(
 	toolType: ToolType,
 	cwd: string,
 	prompt: string,
-	agentSessionId?: string
+	agentSessionId?: string,
+	overrides?: AgentSpawnOverrides
 ): Promise<AgentResult> {
 	if (toolType === 'codex') {
 		return spawnCodexAgent(cwd, prompt, agentSessionId);
@@ -488,6 +889,14 @@ export async function spawnAgent(
 
 	if (toolType === 'claude-code') {
 		return spawnClaudeAgent(cwd, prompt, agentSessionId);
+	}
+
+	if (toolType === 'opencode') {
+		return spawnOpenCodeAgent(cwd, prompt, agentSessionId, overrides);
+	}
+
+	if (toolType === 'factory-droid') {
+		return spawnFactoryDroidAgent(cwd, prompt, agentSessionId, overrides);
 	}
 
 	return {

--- a/src/cli/services/agent-spawner.ts
+++ b/src/cli/services/agent-spawner.ts
@@ -9,7 +9,11 @@ import { OpenCodeOutputParser } from '../../main/parsers/opencode-output-parser'
 import { FactoryDroidOutputParser } from '../../main/parsers/factory-droid-output-parser';
 import { aggregateModelUsage } from '../../main/parsers/usage-aggregator';
 import { getAgentDefinition } from '../../main/agents/definitions';
-import { applyAgentConfigOverrides, buildAgentArgs, getContextWindowValue } from '../../main/utils/agent-args';
+import {
+	applyAgentConfigOverrides,
+	buildAgentArgs,
+	getContextWindowValue,
+} from '../../main/utils/agent-args';
 import { getAgentConfigValues, getAgentCustomPath } from './storage';
 import { generateUUID } from '../../shared/uuid';
 import { buildExpandedPath, buildExpandedEnv } from '../../shared/pathUtils';
@@ -146,9 +150,7 @@ async function findCodexInPath(): Promise<string | undefined> {
  * Check if Claude Code is available
  * First checks for a custom path in settings, then falls back to PATH detection
  */
-export async function detectClaude(
-	customPathOverride?: string
-): Promise<{
+export async function detectClaude(customPathOverride?: string): Promise<{
 	available: boolean;
 	path?: string;
 	source?: 'settings' | 'path';
@@ -199,9 +201,7 @@ export async function detectClaude(
  * Check if Codex CLI is available
  * First checks for a custom path in settings, then falls back to PATH detection
  */
-export async function detectCodex(
-	customPathOverride?: string
-): Promise<{
+export async function detectCodex(customPathOverride?: string): Promise<{
 	available: boolean;
 	path?: string;
 	source?: 'settings' | 'path';
@@ -248,9 +248,7 @@ export async function detectCodex(
  * Check if OpenCode CLI is available
  * First checks for a custom path in settings, then falls back to PATH detection
  */
-export async function detectOpenCode(
-	customPathOverride?: string
-): Promise<{
+export async function detectOpenCode(customPathOverride?: string): Promise<{
 	available: boolean;
 	path?: string;
 	source?: 'settings' | 'path';
@@ -297,9 +295,7 @@ export async function detectOpenCode(
  * Check if Factory Droid CLI is available
  * First checks for a custom path in settings, then falls back to PATH detection
  */
-export async function detectDroid(
-	customPathOverride?: string
-): Promise<{
+export async function detectDroid(customPathOverride?: string): Promise<{
 	available: boolean;
 	path?: string;
 	source?: 'settings' | 'path';

--- a/src/cli/services/agent-spawner.ts
+++ b/src/cli/services/agent-spawner.ts
@@ -25,8 +25,10 @@ const CLAUDE_ARGS = [
 	'--dangerously-skip-permissions',
 ];
 
+type CachedPath = { path: string; source: 'settings' | 'path' };
+
 // Cached Claude path (resolved once at startup)
-let cachedClaudePath: string | null = null;
+let cachedClaudePath: CachedPath | null = null;
 
 // Codex default command and arguments (batch mode)
 const CODEX_DEFAULT_COMMAND = 'codex';
@@ -38,19 +40,19 @@ const CODEX_ARGS = [
 ];
 
 // Cached Codex path (resolved once at startup)
-let cachedCodexPath: string | null = null;
+let cachedCodexPath: CachedPath | null = null;
 
 // OpenCode default command
 const OPENCODE_DEFAULT_COMMAND = 'opencode';
 
 // Cached OpenCode path (resolved once at startup)
-let cachedOpenCodePath: string | null = null;
+let cachedOpenCodePath: CachedPath | null = null;
 
 // Factory Droid default command
 const DROID_DEFAULT_COMMAND = 'droid';
 
 // Cached Factory Droid path (resolved once at startup)
-let cachedDroidPath: string | null = null;
+let cachedDroidPath: CachedPath | null = null;
 
 // Result from spawning an agent
 export interface AgentResult {
@@ -153,7 +155,7 @@ export async function detectClaude(
 }> {
 	if (customPathOverride) {
 		if (await isExecutable(customPathOverride)) {
-			cachedClaudePath = customPathOverride;
+			cachedClaudePath = { path: customPathOverride, source: 'settings' };
 			return { available: true, path: customPathOverride, source: 'settings' };
 		}
 		console.error(
@@ -163,14 +165,18 @@ export async function detectClaude(
 
 	// Return cached result if available
 	if (cachedClaudePath) {
-		return { available: true, path: cachedClaudePath, source: 'settings' };
+		return {
+			available: true,
+			path: cachedClaudePath.path,
+			source: cachedClaudePath.source,
+		};
 	}
 
 	// 1. Check for custom path in settings (same settings as desktop app)
 	const customPath = getAgentCustomPath('claude-code');
 	if (customPath) {
 		if (await isExecutable(customPath)) {
-			cachedClaudePath = customPath;
+			cachedClaudePath = { path: customPath, source: 'settings' };
 			return { available: true, path: customPath, source: 'settings' };
 		}
 		// Custom path is set but invalid - warn but continue to PATH detection
@@ -182,7 +188,7 @@ export async function detectClaude(
 	// 2. Fall back to PATH detection
 	const pathResult = await findClaudeInPath();
 	if (pathResult) {
-		cachedClaudePath = pathResult;
+		cachedClaudePath = { path: pathResult, source: 'path' };
 		return { available: true, path: pathResult, source: 'path' };
 	}
 
@@ -202,7 +208,7 @@ export async function detectCodex(
 }> {
 	if (customPathOverride) {
 		if (await isExecutable(customPathOverride)) {
-			cachedCodexPath = customPathOverride;
+			cachedCodexPath = { path: customPathOverride, source: 'settings' };
 			return { available: true, path: customPathOverride, source: 'settings' };
 		}
 		console.error(
@@ -211,13 +217,17 @@ export async function detectCodex(
 	}
 
 	if (cachedCodexPath) {
-		return { available: true, path: cachedCodexPath, source: 'settings' };
+		return {
+			available: true,
+			path: cachedCodexPath.path,
+			source: cachedCodexPath.source,
+		};
 	}
 
 	const customPath = getAgentCustomPath('codex');
 	if (customPath) {
 		if (await isExecutable(customPath)) {
-			cachedCodexPath = customPath;
+			cachedCodexPath = { path: customPath, source: 'settings' };
 			return { available: true, path: customPath, source: 'settings' };
 		}
 		console.error(
@@ -227,7 +237,7 @@ export async function detectCodex(
 
 	const pathResult = await findCodexInPath();
 	if (pathResult) {
-		cachedCodexPath = pathResult;
+		cachedCodexPath = { path: pathResult, source: 'path' };
 		return { available: true, path: pathResult, source: 'path' };
 	}
 
@@ -247,7 +257,7 @@ export async function detectOpenCode(
 }> {
 	if (customPathOverride) {
 		if (await isExecutable(customPathOverride)) {
-			cachedOpenCodePath = customPathOverride;
+			cachedOpenCodePath = { path: customPathOverride, source: 'settings' };
 			return { available: true, path: customPathOverride, source: 'settings' };
 		}
 		console.error(
@@ -256,13 +266,17 @@ export async function detectOpenCode(
 	}
 
 	if (cachedOpenCodePath) {
-		return { available: true, path: cachedOpenCodePath, source: 'settings' };
+		return {
+			available: true,
+			path: cachedOpenCodePath.path,
+			source: cachedOpenCodePath.source,
+		};
 	}
 
 	const customPath = getAgentCustomPath('opencode');
 	if (customPath) {
 		if (await isExecutable(customPath)) {
-			cachedOpenCodePath = customPath;
+			cachedOpenCodePath = { path: customPath, source: 'settings' };
 			return { available: true, path: customPath, source: 'settings' };
 		}
 		console.error(
@@ -272,7 +286,7 @@ export async function detectOpenCode(
 
 	const pathResult = await findCommandInPath(OPENCODE_DEFAULT_COMMAND);
 	if (pathResult) {
-		cachedOpenCodePath = pathResult;
+		cachedOpenCodePath = { path: pathResult, source: 'path' };
 		return { available: true, path: pathResult, source: 'path' };
 	}
 
@@ -292,7 +306,7 @@ export async function detectDroid(
 }> {
 	if (customPathOverride) {
 		if (await isExecutable(customPathOverride)) {
-			cachedDroidPath = customPathOverride;
+			cachedDroidPath = { path: customPathOverride, source: 'settings' };
 			return { available: true, path: customPathOverride, source: 'settings' };
 		}
 		console.error(
@@ -301,13 +315,17 @@ export async function detectDroid(
 	}
 
 	if (cachedDroidPath) {
-		return { available: true, path: cachedDroidPath, source: 'settings' };
+		return {
+			available: true,
+			path: cachedDroidPath.path,
+			source: cachedDroidPath.source,
+		};
 	}
 
 	const customPath = getAgentCustomPath('factory-droid');
 	if (customPath) {
 		if (await isExecutable(customPath)) {
-			cachedDroidPath = customPath;
+			cachedDroidPath = { path: customPath, source: 'settings' };
 			return { available: true, path: customPath, source: 'settings' };
 		}
 		console.error(
@@ -317,7 +335,7 @@ export async function detectDroid(
 
 	const pathResult = await findCommandInPath(DROID_DEFAULT_COMMAND);
 	if (pathResult) {
-		cachedDroidPath = pathResult;
+		cachedDroidPath = { path: pathResult, source: 'path' };
 		return { available: true, path: pathResult, source: 'path' };
 	}
 
@@ -332,7 +350,7 @@ export function getClaudeCommand(customPath?: string): string {
 	if (customPath && customPath.trim()) {
 		return customPath;
 	}
-	return cachedClaudePath || CLAUDE_DEFAULT_COMMAND;
+	return cachedClaudePath?.path || CLAUDE_DEFAULT_COMMAND;
 }
 
 /**
@@ -343,7 +361,7 @@ export function getCodexCommand(customPath?: string): string {
 	if (customPath && customPath.trim()) {
 		return customPath;
 	}
-	return cachedCodexPath || CODEX_DEFAULT_COMMAND;
+	return cachedCodexPath?.path || CODEX_DEFAULT_COMMAND;
 }
 
 /**
@@ -353,7 +371,7 @@ export function getOpenCodeCommand(customPath?: string): string {
 	if (customPath && customPath.trim()) {
 		return customPath;
 	}
-	return cachedOpenCodePath || OPENCODE_DEFAULT_COMMAND;
+	return cachedOpenCodePath?.path || OPENCODE_DEFAULT_COMMAND;
 }
 
 /**
@@ -363,7 +381,7 @@ export function getDroidCommand(customPath?: string): string {
 	if (customPath && customPath.trim()) {
 		return customPath;
 	}
-	return cachedDroidPath || DROID_DEFAULT_COMMAND;
+	return cachedDroidPath?.path || DROID_DEFAULT_COMMAND;
 }
 
 /**
@@ -532,6 +550,135 @@ function mergeUsageStats(
 	}
 
 	return merged;
+}
+
+type StreamJsonParser = {
+	parseJsonLine: (line: string) => any | null;
+	extractSessionId: (event: any) => string | null | undefined;
+	isResultMessage: (event: any) => boolean;
+	extractUsage: (event: any) =>
+		| {
+				inputTokens: number;
+				outputTokens: number;
+				cacheReadTokens?: number;
+				cacheCreationTokens?: number;
+				costUsd?: number;
+				contextWindow?: number;
+				reasoningTokens?: number;
+		  }
+		| null
+		| undefined;
+};
+
+function spawnStreamingAgent(
+	toolType: 'opencode' | 'factory-droid',
+	cwd: string,
+	prompt: string,
+	agentSessionId: string | undefined,
+	overrides: AgentSpawnOverrides | undefined,
+	commandGetter: (customPath?: string) => string,
+	createParser: () => StreamJsonParser,
+	agentLabel: string
+): Promise<AgentResult> {
+	return new Promise((resolve) => {
+		const { args, env, contextWindow } = resolveAgentInvocation(
+			toolType,
+			cwd,
+			prompt,
+			agentSessionId,
+			overrides
+		);
+
+		const options: SpawnOptions = {
+			cwd,
+			env,
+			stdio: ['pipe', 'pipe', 'pipe'],
+		};
+
+		const agentCommand = commandGetter(overrides?.customPath);
+		const child = spawn(agentCommand, args, options);
+
+		const parser = createParser();
+		let jsonBuffer = '';
+		let result: string | undefined;
+		let sessionId: string | undefined;
+		let usageStats: UsageStats | undefined;
+		let stderr = '';
+		let errorText: string | undefined;
+
+		child.stdout?.on('data', (data: Buffer) => {
+			jsonBuffer += data.toString();
+			const lines = jsonBuffer.split('\n');
+			jsonBuffer = lines.pop() || '';
+
+			for (const line of lines) {
+				if (!line.trim()) continue;
+				const event = parser.parseJsonLine(line);
+				if (!event) continue;
+
+				const extractedSessionId = parser.extractSessionId(event);
+				if (extractedSessionId && !sessionId) {
+					sessionId = extractedSessionId;
+				}
+
+				if (parser.isResultMessage(event) && event.text) {
+					result = result ? `${result}\n${event.text}` : event.text;
+				}
+
+				if (event.type === 'error' && event.text && !errorText) {
+					errorText = event.text;
+				}
+
+				const usage = parser.extractUsage(event);
+				if (usage) {
+					usageStats = mergeUsageStats(usageStats, {
+						inputTokens: usage.inputTokens,
+						outputTokens: usage.outputTokens,
+						cacheReadTokens: usage.cacheReadTokens,
+						cacheCreationTokens: usage.cacheCreationTokens,
+						costUsd: usage.costUsd,
+						contextWindow: usage.contextWindow,
+						reasoningTokens: usage.reasoningTokens,
+					});
+				}
+			}
+		});
+
+		child.stderr?.on('data', (data: Buffer) => {
+			stderr += data.toString();
+		});
+
+		child.stdin?.end();
+
+		child.on('close', (code) => {
+			if (usageStats && (!usageStats.contextWindow || usageStats.contextWindow === 0)) {
+				usageStats.contextWindow = contextWindow;
+			}
+
+			if (code === 0 && !errorText) {
+				resolve({
+					success: true,
+					response: result,
+					agentSessionId: sessionId,
+					usageStats,
+				});
+			} else {
+				resolve({
+					success: false,
+					error: errorText || stderr || `Process exited with code ${code}`,
+					agentSessionId: sessionId,
+					usageStats,
+				});
+			}
+		});
+
+		child.on('error', (error) => {
+			resolve({
+				success: false,
+				error: `Failed to spawn ${agentLabel}: ${error.message}`,
+			});
+		});
+	});
 }
 
 function resolveAgentInvocation(
@@ -704,105 +851,16 @@ async function spawnOpenCodeAgent(
 	agentSessionId?: string,
 	overrides?: AgentSpawnOverrides
 ): Promise<AgentResult> {
-	return new Promise((resolve) => {
-		const { args, env, contextWindow } = resolveAgentInvocation(
-			'opencode',
-			cwd,
-			prompt,
-			agentSessionId,
-			overrides
-		);
-
-		const options: SpawnOptions = {
-			cwd,
-			env,
-			stdio: ['pipe', 'pipe', 'pipe'],
-		};
-
-		const opencodeCommand = getOpenCodeCommand(overrides?.customPath);
-		const child = spawn(opencodeCommand, args, options);
-
-		const parser = new OpenCodeOutputParser();
-		let jsonBuffer = '';
-		let result: string | undefined;
-		let sessionId: string | undefined;
-		let usageStats: UsageStats | undefined;
-		let stderr = '';
-		let errorText: string | undefined;
-
-		child.stdout?.on('data', (data: Buffer) => {
-			jsonBuffer += data.toString();
-			const lines = jsonBuffer.split('\n');
-			jsonBuffer = lines.pop() || '';
-
-			for (const line of lines) {
-				if (!line.trim()) continue;
-				const event = parser.parseJsonLine(line);
-				if (!event) continue;
-
-				const extractedSessionId = parser.extractSessionId(event);
-				if (extractedSessionId && !sessionId) {
-					sessionId = extractedSessionId;
-				}
-
-				if (parser.isResultMessage(event) && event.text) {
-					result = result ? `${result}\n${event.text}` : event.text;
-				}
-
-				if (event.type === 'error' && event.text && !errorText) {
-					errorText = event.text;
-				}
-
-				const usage = parser.extractUsage(event);
-				if (usage) {
-					usageStats = mergeUsageStats(usageStats, {
-						inputTokens: usage.inputTokens,
-						outputTokens: usage.outputTokens,
-						cacheReadTokens: usage.cacheReadTokens,
-						cacheCreationTokens: usage.cacheCreationTokens,
-						costUsd: usage.costUsd,
-						contextWindow: usage.contextWindow,
-						reasoningTokens: usage.reasoningTokens,
-					});
-				}
-			}
-		});
-
-		child.stderr?.on('data', (data: Buffer) => {
-			stderr += data.toString();
-		});
-
-		child.stdin?.end();
-
-		child.on('close', (code) => {
-			if (usageStats && (!usageStats.contextWindow || usageStats.contextWindow === 0)) {
-				usageStats.contextWindow = contextWindow;
-			}
-
-			if (code === 0 && !errorText) {
-				resolve({
-					success: true,
-					response: result,
-					agentSessionId: sessionId,
-					usageStats,
-				});
-			} else {
-				resolve({
-					success: false,
-					error: errorText || stderr || `Process exited with code ${code}`,
-					agentSessionId: sessionId,
-					usageStats,
-				});
-			}
-		});
-
-		child.on('error', (error) => {
-			resolve({
-				success: false,
-				error: `Failed to spawn OpenCode: ${error.message}`,
-			});
-		});
-	});
+	return spawnStreamingAgent(
+		'opencode',
+		cwd,
+		prompt,
+		agentSessionId,
+		overrides,
+		getOpenCodeCommand,
+		() => new OpenCodeOutputParser(),
+		'OpenCode'
+	);
 }
 
 /**
@@ -814,105 +872,16 @@ async function spawnFactoryDroidAgent(
 	agentSessionId?: string,
 	overrides?: AgentSpawnOverrides
 ): Promise<AgentResult> {
-	return new Promise((resolve) => {
-		const { args, env, contextWindow } = resolveAgentInvocation(
-			'factory-droid',
-			cwd,
-			prompt,
-			agentSessionId,
-			overrides
-		);
-
-		const options: SpawnOptions = {
-			cwd,
-			env,
-			stdio: ['pipe', 'pipe', 'pipe'],
-		};
-
-		const droidCommand = getDroidCommand(overrides?.customPath);
-		const child = spawn(droidCommand, args, options);
-
-		const parser = new FactoryDroidOutputParser();
-		let jsonBuffer = '';
-		let result: string | undefined;
-		let sessionId: string | undefined;
-		let usageStats: UsageStats | undefined;
-		let stderr = '';
-		let errorText: string | undefined;
-
-		child.stdout?.on('data', (data: Buffer) => {
-			jsonBuffer += data.toString();
-			const lines = jsonBuffer.split('\n');
-			jsonBuffer = lines.pop() || '';
-
-			for (const line of lines) {
-				if (!line.trim()) continue;
-				const event = parser.parseJsonLine(line);
-				if (!event) continue;
-
-				const extractedSessionId = parser.extractSessionId(event);
-				if (extractedSessionId && !sessionId) {
-					sessionId = extractedSessionId;
-				}
-
-				if (parser.isResultMessage(event) && event.text) {
-					result = result ? `${result}\n${event.text}` : event.text;
-				}
-
-				if (event.type === 'error' && event.text && !errorText) {
-					errorText = event.text;
-				}
-
-				const usage = parser.extractUsage(event);
-				if (usage) {
-					usageStats = mergeUsageStats(usageStats, {
-						inputTokens: usage.inputTokens,
-						outputTokens: usage.outputTokens,
-						cacheReadTokens: usage.cacheReadTokens,
-						cacheCreationTokens: usage.cacheCreationTokens,
-						costUsd: usage.costUsd,
-						contextWindow: usage.contextWindow,
-						reasoningTokens: usage.reasoningTokens,
-					});
-				}
-			}
-		});
-
-		child.stderr?.on('data', (data: Buffer) => {
-			stderr += data.toString();
-		});
-
-		child.stdin?.end();
-
-		child.on('close', (code) => {
-			if (usageStats && (!usageStats.contextWindow || usageStats.contextWindow === 0)) {
-				usageStats.contextWindow = contextWindow;
-			}
-
-			if (code === 0 && !errorText) {
-				resolve({
-					success: true,
-					response: result,
-					agentSessionId: sessionId,
-					usageStats,
-				});
-			} else {
-				resolve({
-					success: false,
-					error: errorText || stderr || `Process exited with code ${code}`,
-					agentSessionId: sessionId,
-					usageStats,
-				});
-			}
-		});
-
-		child.on('error', (error) => {
-			resolve({
-				success: false,
-				error: `Failed to spawn Factory Droid: ${error.message}`,
-			});
-		});
-	});
+	return spawnStreamingAgent(
+		'factory-droid',
+		cwd,
+		prompt,
+		agentSessionId,
+		overrides,
+		getDroidCommand,
+		() => new FactoryDroidOutputParser(),
+		'Factory Droid'
+	);
 }
 
 /**

--- a/src/cli/services/agent-spawner.ts
+++ b/src/cli/services/agent-spawner.ts
@@ -844,13 +844,14 @@ async function spawnCodexAgent(
 	// Global shell env vars are primarily used by the desktop app's process manager.
 	const env = buildExpandedEnv(effectiveCustomEnvVars);
 
-	let spawnCommand = getCodexCommand(overrides?.customPath);
+	let spawnCommand = !overrides?.customPath
+		? agentDef?.binaryName || getCodexCommand()
+		: getCodexCommand(overrides?.customPath);
 	let spawnArgs = args;
 	let spawnCwd = cwd;
 	let spawnEnv = env;
 
 	if (overrides?.sshRemoteConfig) {
-		spawnCommand = agentDef?.binaryName ?? getCodexCommand();
 		const sshWrapped = await wrapSpawnWithSsh(
 			{
 				command: spawnCommand,

--- a/src/cli/services/batch-processor.ts
+++ b/src/cli/services/batch-processor.ts
@@ -2,7 +2,13 @@
 // Executes playbooks and yields JSONL events
 
 import { execFileSync } from 'child_process';
-import type { Playbook, SessionInfo, UsageStats, HistoryEntry, AgentSshRemoteConfig } from '../../shared/types';
+import type {
+	Playbook,
+	SessionInfo,
+	UsageStats,
+	HistoryEntry,
+	AgentSshRemoteConfig,
+} from '../../shared/types';
 import type { JsonlEvent } from '../output/jsonl';
 import {
 	spawnAgent,

--- a/src/cli/services/batch-processor.ts
+++ b/src/cli/services/batch-processor.ts
@@ -444,6 +444,7 @@ export async function* runPlaybook(
 					customArgs: session.customArgs,
 					customEnvVars: session.customEnvVars,
 					customModel: session.customModel,
+					sshRemoteConfig: session.sshRemoteConfig,
 				};
 				const result = await spawnAgent(
 					session.toolType,

--- a/src/cli/services/batch-processor.ts
+++ b/src/cli/services/batch-processor.ts
@@ -445,7 +445,13 @@ export async function* runPlaybook(
 					customEnvVars: session.customEnvVars,
 					customModel: session.customModel,
 				};
-				const result = await spawnAgent(session.toolType, session.cwd, finalPrompt, undefined, spawnOverrides);
+				const result = await spawnAgent(
+					session.toolType,
+					session.cwd,
+					finalPrompt,
+					undefined,
+					spawnOverrides
+				);
 
 				const elapsedMs = Date.now() - taskStartTime;
 

--- a/src/cli/services/batch-processor.ts
+++ b/src/cli/services/batch-processor.ts
@@ -439,7 +439,13 @@ export async function* runPlaybook(
 				}
 
 				// Spawn agent with combined prompt + document
-				const result = await spawnAgent(session.toolType, session.cwd, finalPrompt);
+				const spawnOverrides = {
+					customPath: session.customPath,
+					customArgs: session.customArgs,
+					customEnvVars: session.customEnvVars,
+					customModel: session.customModel,
+				};
+				const result = await spawnAgent(session.toolType, session.cwd, finalPrompt, undefined, spawnOverrides);
 
 				const elapsedMs = Date.now() - taskStartTime;
 
@@ -476,7 +482,8 @@ export async function* runPlaybook(
 						session.toolType,
 						session.cwd,
 						BATCH_SYNOPSIS_PROMPT,
-						result.agentSessionId
+						result.agentSessionId,
+						spawnOverrides
 					);
 
 					if (synopsisResult.success && synopsisResult.response) {

--- a/src/cli/services/batch-processor.ts
+++ b/src/cli/services/batch-processor.ts
@@ -2,7 +2,7 @@
 // Executes playbooks and yields JSONL events
 
 import { execFileSync } from 'child_process';
-import type { Playbook, SessionInfo, UsageStats, HistoryEntry } from '../../shared/types';
+import type { Playbook, SessionInfo, UsageStats, HistoryEntry, AgentSshRemoteConfig } from '../../shared/types';
 import type { JsonlEvent } from '../output/jsonl';
 import {
 	spawnAgent,
@@ -439,13 +439,21 @@ export async function* runPlaybook(
 				}
 
 				// Spawn agent with combined prompt + document
-				const spawnOverrides = {
+				const spawnOverrides: {
+					customPath?: string;
+					customArgs?: string;
+					customEnvVars?: Record<string, string>;
+					customModel?: string;
+					sshRemoteConfig?: AgentSshRemoteConfig;
+				} = {
 					customPath: session.customPath,
 					customArgs: session.customArgs,
 					customEnvVars: session.customEnvVars,
 					customModel: session.customModel,
-					sshRemoteConfig: session.sshRemoteConfig,
 				};
+				if (!session.sshRemoteConfig?.enabled) {
+					spawnOverrides.sshRemoteConfig = session.sshRemoteConfig;
+				}
 				const result = await spawnAgent(
 					session.toolType,
 					session.cwd,

--- a/src/cli/services/storage.ts
+++ b/src/cli/services/storage.ts
@@ -4,7 +4,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import type { Group, SessionInfo, HistoryEntry } from '../../shared/types';
+import type { Group, SessionInfo, HistoryEntry, SshRemoteConfig } from '../../shared/types';
 import {
 	HISTORY_VERSION,
 	MAX_ENTRIES_PER_SESSION,
@@ -216,6 +216,15 @@ export function readHistoryPaginated(options?: {
 export function readSettings(): SettingsStore {
 	const data = readStoreFile<SettingsStore>('maestro-settings.json');
 	return data || {};
+}
+
+/**
+ * Read SSH remote configurations from settings storage
+ */
+export function readSshRemotes(): SshRemoteConfig[] {
+	const settings = readSettings();
+	const remotes = settings.sshRemotes;
+	return Array.isArray(remotes) ? (remotes as SshRemoteConfig[]) : [];
 }
 
 /**

--- a/src/cli/services/storage.ts
+++ b/src/cli/services/storage.ts
@@ -241,6 +241,14 @@ export function getAgentCustomPath(agentId: string): string | undefined {
 }
 
 /**
+ * Get stored agent config values for a specific agent (e.g., customArgs, customEnvVars, model)
+ */
+export function getAgentConfigValues(agentId: string): Record<string, unknown> {
+	const configs = readAgentConfigs();
+	return configs[agentId] || {};
+}
+
+/**
  * Resolve a partial ID to a full ID
  * Returns: { id, ambiguous, matches }
  * - If exact match found, returns that ID

--- a/src/main/utils/agent-args.ts
+++ b/src/main/utils/agent-args.ts
@@ -1,4 +1,6 @@
-import type { AgentConfig } from '../agents';
+import type { AgentConfig, AgentDefinition } from '../agents';
+
+type AgentArgsConfig = AgentConfig | AgentDefinition | null | undefined;
 
 type BuildAgentArgsOptions = {
 	baseArgs: string[];
@@ -40,7 +42,7 @@ function parseCustomArgs(customArgs?: string): string[] {
 }
 
 export function buildAgentArgs(
-	agent: AgentConfig | null | undefined,
+	agent: AgentArgsConfig,
 	options: BuildAgentArgsOptions
 ): string[] {
 	let finalArgs = [...options.baseArgs];
@@ -99,7 +101,7 @@ export function buildAgentArgs(
 }
 
 export function applyAgentConfigOverrides(
-	agent: AgentConfig | null | undefined,
+	agent: AgentArgsConfig,
 	baseArgs: string[],
 	overrides: AgentConfigOverrides
 ): AgentConfigResolution {
@@ -186,7 +188,7 @@ export function applyAgentConfigOverrides(
 }
 
 export function getContextWindowValue(
-	agent: AgentConfig | null | undefined,
+	agent: AgentArgsConfig,
 	agentConfigValues: Record<string, any>,
 	sessionCustomContextWindow?: number
 ): number {

--- a/src/main/utils/agent-args.ts
+++ b/src/main/utils/agent-args.ts
@@ -41,10 +41,7 @@ function parseCustomArgs(customArgs?: string): string[] {
 	});
 }
 
-export function buildAgentArgs(
-	agent: AgentArgsConfig,
-	options: BuildAgentArgsOptions
-): string[] {
+export function buildAgentArgs(agent: AgentArgsConfig, options: BuildAgentArgsOptions): string[] {
 	let finalArgs = [...options.baseArgs];
 
 	if (!agent) {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -32,6 +32,7 @@ export interface SessionInfo {
 	customArgs?: string;
 	customEnvVars?: Record<string, string>;
 	customModel?: string;
+	sshRemoteConfig?: AgentSshRemoteConfig;
 }
 
 // Usage statistics from AI agent CLI (Claude Code, Codex, etc.)

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -28,6 +28,10 @@ export interface SessionInfo {
 	cwd: string;
 	projectRoot: string;
 	autoRunFolderPath?: string;
+	customPath?: string;
+	customArgs?: string;
+	customEnvVars?: Record<string, string>;
+	customModel?: string;
 }
 
 // Usage statistics from AI agent CLI (Claude Code, Codex, etc.)


### PR DESCRIPTION
This pull request extends CLI agent support by adding compatibility for two new agent types, `opencode` and `factory-droid`, alongside existing ones. It updates error handling, agent detection logic, and configuration management to accommodate these new agents. The changes also ensure that custom agent configuration values are passed through all relevant code paths.

**Agent support and error handling:**

* Added support for `opencode` and `factory-droid` agent types in both the `run-playbook` and `send` CLI commands, including detection logic and error handling for missing CLIs. [[1]](diffhunk://#diff-c41995d2bf79316ebeb246d6221bf03080d1586016a077e0f7135a89883b6071L7-R7) [[2]](diffhunk://#diff-37c7004e79ee78e9202976af97d54ac21042d4db92d5094cac6e783b2365e97bL91-R98) [[3]](diffhunk://#diff-c41995d2bf79316ebeb246d6221bf03080d1586016a077e0f7135a89883b6071R171-R190) [[4]](diffhunk://#diff-37c7004e79ee78e9202976af97d54ac21042d4db92d5094cac6e783b2365e97bL111-R152)
* Updated the documented list of supported agent types and error codes in `docs/cli.md` to include `OPENCODE_NOT_FOUND` and `DROID_NOT_FOUND`.

**Agent configuration management:**

* Ensured that custom agent configuration values (`customPath`, `customArgs`, `customEnvVars`, `customModel`) are passed to agent detection and spawning functions throughout the CLI codebase. [[1]](diffhunk://#diff-c41995d2bf79316ebeb246d6221bf03080d1586016a077e0f7135a89883b6071L152-R152) [[2]](diffhunk://#diff-c41995d2bf79316ebeb246d6221bf03080d1586016a077e0f7135a89883b6071L162-R162) [[3]](diffhunk://#diff-37c7004e79ee78e9202976af97d54ac21042d4db92d5094cac6e783b2365e97bL102-R109) [[4]](diffhunk://#diff-5772b7b2aa6017cd939296dcfbeb847708b3bb60a145d83602897dbac517a789L442-R448) [[5]](diffhunk://#diff-5772b7b2aa6017cd939296dcfbeb847708b3bb60a145d83602897dbac517a789L479-R486)
* Added a new helper function `getAgentConfigValues` in `src/cli/services/storage.ts` to retrieve stored config values for agents.
* Updated the `SessionInfo` interface to include new fields for custom agent configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for OpenCode and Factory Droid agents; per-session overrides (custom path, args, env, model) and SSH remote execution.
  * CLI commands to list SSH remote targets and retrieve stored agent configuration values.
* **Improvements**
  * Detection and spawn flows now honor per-invocation overrides across send, playbook, batch, and synopsis runs.
* **Documentation**
  * CLI docs updated; new error codes for missing OpenCode/Factory Droid.
* **Tests**
  * Added detection, SSH, and config-retrieval tests and mocks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->