### PR TITLE
fix: remove noPromptSeparator for OpenCode to prevent slash command errors (#527)

### DIFF
--- a/src/__tests__/main/agents/definitions.test.ts
+++ b/src/__tests__/main/agents/definitions.test.ts
@@ -67,7 +67,8 @@ describe('agent-definitions', () => {
 			expect(opencode).toBeDefined();
 			expect(opencode?.batchModePrefix).toEqual(['run']);
 			expect(opencode?.jsonOutputArgs).toEqual(['--format', 'json']);
-			expect(opencode?.noPromptSeparator).toBe(true);
+			// noPromptSeparator removed: '--' separator prevents yargs from misinterpreting prompt content (#527)
+			expect(opencode?.noPromptSeparator).toBeUndefined();
 		});
 
 		it('should have opencode with default env vars for YOLO mode and disabled question tool', () => {

--- a/src/__tests__/main/agents/detector.test.ts
+++ b/src/__tests__/main/agents/detector.test.ts
@@ -1201,7 +1201,7 @@ describe('agent-detector', () => {
 			expect(opencode?.promptArgs).toBeUndefined();
 		});
 
-		it('should have noPromptSeparator true since prompt is positional arg', async () => {
+		it('should not have noPromptSeparator so -- separator prevents prompt misparse (#527)', async () => {
 			mockExecFileNoThrow.mockImplementation(async (cmd, args) => {
 				if (args[0] === 'opencode') {
 					return { stdout: '/usr/bin/opencode\n', stderr: '', exitCode: 0 };
@@ -1212,9 +1212,9 @@ describe('agent-detector', () => {
 			const agents = await detector.detectAgents();
 			const opencode = agents.find((a) => a.id === 'opencode');
 
-			// OpenCode uses noPromptSeparator: true since prompt is positional
-			// (yargs handles positional args without needing '--' separator)
-			expect(opencode?.noPromptSeparator).toBe(true);
+			// noPromptSeparator removed: '--' separator prevents yargs from
+			// misinterpreting leading '---' in prompts as flags
+			expect(opencode?.noPromptSeparator).toBeUndefined();
 		});
 
 		it('should have correct jsonOutputArgs for JSON streaming', async () => {

--- a/src/main/agents/definitions.ts
+++ b/src/main/agents/definitions.ts
@@ -215,7 +215,8 @@ export const AGENT_DEFINITIONS: AgentDefinition[] = [
 		readOnlyArgs: ['--agent', 'plan'], // Read-only/plan mode
 		modelArgs: (modelId: string) => ['--model', modelId], // Model selection (e.g., 'ollama/qwen3:8b')
 		imageArgs: (imagePath: string) => ['-f', imagePath], // Image/file attachment: opencode run -f /path/to/image.png -- "prompt"
-		noPromptSeparator: true, // OpenCode doesn't need '--' before prompt - yargs handles positional args
+		// Use '--' separator before prompt to prevent yargs from misinterpreting
+		// leading '---' (YAML frontmatter in slash command prompts) as flags (#527)
 		// Default env vars: enable YOLO mode (allow all permissions including external_directory)
 		// Disable the question tool via both methods:
 		// - "question": "deny" in permission block (per OpenCode GitHub issue workaround)


### PR DESCRIPTION
This pull request updates the handling of prompt separators for the `opencode` agent to prevent misinterpretation of prompt content by the argument parser. The main change is the removal of the `noPromptSeparator` property, ensuring that the `--` separator is used before prompts, which avoids issues when prompts contain leading `---` (such as YAML frontmatter).

Agent prompt separator handling:

* Removed the `noPromptSeparator` property from the `opencode` agent definition in `definitions.ts`, so the `--` separator is now always used to prevent yargs from misinterpreting prompt content as flags.
* Updated related tests in `definitions.test.ts` and `detector.test.ts` to reflect the removal of `noPromptSeparator`, verifying it is now `undefined` and documenting the reason for the change (#527) [[1]](diffhunk://#diff-9ed9428b89a4ee163e3efa5052bb55982b81048af262cf47ca5fe5122809412bL70-R71) [[2]](diffhunk://#diff-173fe20748b9435432ecdcdbf47139daf034597bf7382743ae6799995290e802L1204-R1204) [[3]](diffhunk://#diff-173fe20748b9435432ecdcdbf47139daf034597bf7382743ae6799995290e802L1215-R1217).

closes #527

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests & Bug Fixes

* Fixed prompt separator handling in agent configuration to prevent parsing errors
* Updated test expectations to reflect configuration improvements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->