### PR TITLE
Add CLI IPC commands for remote Maestro control

### DIFF
--- a/src/__tests__/cli/commands/auto-run.test.ts
+++ b/src/__tests__/cli/commands/auto-run.test.ts
@@ -1,0 +1,271 @@
+/**
+ * @file auto-run.test.ts
+ * @description Tests for the auto-run CLI command
+ *
+ * Tests the auto-run command functionality including:
+ * - Configuring auto-run with valid document paths
+ * - Error handling for non-existent documents
+ * - Error handling for non-.md files
+ * - --save-as flag sends saveAsPlaybook in message
+ * - --launch flag sends launch: true
+ * - --loop and --max-loops send loop config
+ */
+
+import { describe, it, expect, vi, beforeEach, type MockInstance } from 'vitest';
+
+// Mock fs
+vi.mock('fs', () => ({
+	existsSync: vi.fn(),
+}));
+
+// Mock maestro-client
+vi.mock('../../../cli/services/maestro-client', () => ({
+	withMaestroClient: vi.fn(),
+	resolveSessionId: vi.fn(),
+}));
+
+import { autoRun } from '../../../cli/commands/auto-run';
+import { withMaestroClient, resolveSessionId } from '../../../cli/services/maestro-client';
+import { existsSync } from 'fs';
+
+describe('auto-run command', () => {
+	let consoleSpy: MockInstance;
+	let consoleErrorSpy: MockInstance;
+	let processExitSpy: MockInstance;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+		consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+		processExitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+	});
+
+	it('should configure auto-run with valid document paths', async () => {
+		vi.mocked(existsSync).mockReturnValue(true);
+		vi.mocked(resolveSessionId).mockReturnValue('session-123');
+		vi.mocked(withMaestroClient).mockImplementation(async (action) => {
+			const mockClient = {
+				sendCommand: vi.fn().mockResolvedValue({
+					type: 'configure_auto_run_result',
+					success: true,
+				}),
+			};
+			return action(mockClient as never);
+		});
+
+		await autoRun(['/path/to/doc1.md', '/path/to/doc2.md'], { session: 'session-123' });
+
+		expect(resolveSessionId).toHaveBeenCalledWith({ session: 'session-123' });
+		expect(consoleSpy).toHaveBeenCalledWith(
+			expect.stringContaining('Auto-run configured with 2 documents')
+		);
+		expect(processExitSpy).not.toHaveBeenCalled();
+	});
+
+	it('should error with no documents', async () => {
+		await autoRun([], {});
+
+		expect(consoleErrorSpy).toHaveBeenCalledWith(
+			expect.stringContaining('At least one document path is required')
+		);
+		expect(processExitSpy).toHaveBeenCalledWith(1);
+	});
+
+	it('should error when document does not exist', async () => {
+		vi.mocked(existsSync).mockReturnValue(false);
+
+		await autoRun(['/nonexistent/doc.md'], {});
+
+		expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('File not found'));
+		expect(processExitSpy).toHaveBeenCalledWith(1);
+	});
+
+	it('should error when document is not a .md file', async () => {
+		vi.mocked(existsSync).mockReturnValue(true);
+
+		await autoRun(['/path/to/file.txt'], {});
+
+		expect(consoleErrorSpy).toHaveBeenCalledWith(
+			expect.stringContaining('File must be a .md file')
+		);
+		expect(processExitSpy).toHaveBeenCalledWith(1);
+	});
+
+	it('should send saveAsPlaybook when --save-as is provided', async () => {
+		vi.mocked(existsSync).mockReturnValue(true);
+		vi.mocked(resolveSessionId).mockReturnValue('session-123');
+
+		let sentMessage: Record<string, unknown> | undefined;
+		vi.mocked(withMaestroClient).mockImplementation(async (action) => {
+			const mockClient = {
+				sendCommand: vi.fn().mockImplementation((msg) => {
+					sentMessage = msg;
+					return Promise.resolve({
+						type: 'configure_auto_run_result',
+						success: true,
+						playbookId: 'pb-456',
+					});
+				}),
+			};
+			return action(mockClient as never);
+		});
+
+		await autoRun(['/path/to/doc.md'], { saveAs: 'My Playbook', session: 'session-123' });
+
+		expect(sentMessage).toBeDefined();
+		expect(sentMessage!.saveAsPlaybook).toBe('My Playbook');
+		expect(consoleSpy).toHaveBeenCalledWith(
+			expect.stringContaining("Playbook 'My Playbook' saved")
+		);
+	});
+
+	it('should send launch: true when --launch is provided', async () => {
+		vi.mocked(existsSync).mockReturnValue(true);
+		vi.mocked(resolveSessionId).mockReturnValue('session-123');
+
+		let sentMessage: Record<string, unknown> | undefined;
+		vi.mocked(withMaestroClient).mockImplementation(async (action) => {
+			const mockClient = {
+				sendCommand: vi.fn().mockImplementation((msg) => {
+					sentMessage = msg;
+					return Promise.resolve({
+						type: 'configure_auto_run_result',
+						success: true,
+					});
+				}),
+			};
+			return action(mockClient as never);
+		});
+
+		await autoRun(['/path/to/doc.md'], { launch: true, session: 'session-123' });
+
+		expect(sentMessage).toBeDefined();
+		expect(sentMessage!.launch).toBe(true);
+		expect(consoleSpy).toHaveBeenCalledWith(
+			expect.stringContaining('Auto-run launched with 1 document')
+		);
+	});
+
+	it('should send loop config when --loop is provided', async () => {
+		vi.mocked(existsSync).mockReturnValue(true);
+		vi.mocked(resolveSessionId).mockReturnValue('session-123');
+
+		let sentMessage: Record<string, unknown> | undefined;
+		vi.mocked(withMaestroClient).mockImplementation(async (action) => {
+			const mockClient = {
+				sendCommand: vi.fn().mockImplementation((msg) => {
+					sentMessage = msg;
+					return Promise.resolve({
+						type: 'configure_auto_run_result',
+						success: true,
+					});
+				}),
+			};
+			return action(mockClient as never);
+		});
+
+		await autoRun(['/path/to/doc.md'], { loop: true, session: 'session-123' });
+
+		expect(sentMessage).toBeDefined();
+		expect(sentMessage!.loopEnabled).toBe(true);
+	});
+
+	it('should send loop config with --max-loops', async () => {
+		vi.mocked(existsSync).mockReturnValue(true);
+		vi.mocked(resolveSessionId).mockReturnValue('session-123');
+
+		let sentMessage: Record<string, unknown> | undefined;
+		vi.mocked(withMaestroClient).mockImplementation(async (action) => {
+			const mockClient = {
+				sendCommand: vi.fn().mockImplementation((msg) => {
+					sentMessage = msg;
+					return Promise.resolve({
+						type: 'configure_auto_run_result',
+						success: true,
+					});
+				}),
+			};
+			return action(mockClient as never);
+		});
+
+		await autoRun(['/path/to/doc.md'], { maxLoops: '5', session: 'session-123' });
+
+		expect(sentMessage).toBeDefined();
+		expect(sentMessage!.loopEnabled).toBe(true);
+		expect(sentMessage!.maxLoops).toBe(5);
+	});
+
+	it('should error with invalid --max-loops value', async () => {
+		vi.mocked(existsSync).mockReturnValue(true);
+
+		await autoRun(['/path/to/doc.md'], { maxLoops: 'abc' });
+
+		expect(consoleErrorSpy).toHaveBeenCalledWith(
+			expect.stringContaining('--max-loops must be a positive integer')
+		);
+		expect(processExitSpy).toHaveBeenCalledWith(1);
+	});
+
+	it('should set resetOnCompletion on documents when flag is provided', async () => {
+		vi.mocked(existsSync).mockReturnValue(true);
+		vi.mocked(resolveSessionId).mockReturnValue('session-123');
+
+		let sentMessage: Record<string, unknown> | undefined;
+		vi.mocked(withMaestroClient).mockImplementation(async (action) => {
+			const mockClient = {
+				sendCommand: vi.fn().mockImplementation((msg) => {
+					sentMessage = msg;
+					return Promise.resolve({
+						type: 'configure_auto_run_result',
+						success: true,
+					});
+				}),
+			};
+			return action(mockClient as never);
+		});
+
+		await autoRun(['/path/to/doc.md'], {
+			resetOnCompletion: true,
+			session: 'session-123',
+		});
+
+		expect(sentMessage).toBeDefined();
+		const docs = sentMessage!.documents as Array<{ filename: string; resetOnCompletion: boolean }>;
+		expect(docs[0].resetOnCompletion).toBe(true);
+	});
+
+	it('should error gracefully when Maestro app is not running', async () => {
+		vi.mocked(existsSync).mockReturnValue(true);
+		vi.mocked(resolveSessionId).mockReturnValue('session-123');
+		vi.mocked(withMaestroClient).mockRejectedValue(
+			new Error('Maestro desktop app is not running')
+		);
+
+		await autoRun(['/path/to/doc.md'], { session: 'session-123' });
+
+		expect(consoleErrorSpy).toHaveBeenCalledWith(
+			expect.stringContaining('Maestro desktop app is not running')
+		);
+		expect(processExitSpy).toHaveBeenCalledWith(1);
+	});
+
+	it('should error when server returns failure', async () => {
+		vi.mocked(existsSync).mockReturnValue(true);
+		vi.mocked(resolveSessionId).mockReturnValue('session-123');
+		vi.mocked(withMaestroClient).mockImplementation(async (action) => {
+			const mockClient = {
+				sendCommand: vi.fn().mockResolvedValue({
+					type: 'configure_auto_run_result',
+					success: false,
+					error: 'Session not found',
+				}),
+			};
+			return action(mockClient as never);
+		});
+
+		await autoRun(['/path/to/doc.md'], { session: 'session-123' });
+
+		expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('Session not found'));
+		expect(processExitSpy).toHaveBeenCalledWith(1);
+	});
+});

--- a/src/__tests__/cli/commands/auto-run.test.ts
+++ b/src/__tests__/cli/commands/auto-run.test.ts
@@ -237,9 +237,7 @@ describe('auto-run command', () => {
 	it('should error gracefully when Maestro app is not running', async () => {
 		vi.mocked(existsSync).mockReturnValue(true);
 		vi.mocked(resolveSessionId).mockReturnValue('session-123');
-		vi.mocked(withMaestroClient).mockRejectedValue(
-			new Error('Maestro desktop app is not running')
-		);
+		vi.mocked(withMaestroClient).mockRejectedValue(new Error('Maestro desktop app is not running'));
 
 		await autoRun(['/path/to/doc.md'], { session: 'session-123' });
 

--- a/src/__tests__/cli/commands/list-sessions.test.ts
+++ b/src/__tests__/cli/commands/list-sessions.test.ts
@@ -17,6 +17,7 @@ import type { SessionInfo } from '../../../shared/types';
 vi.mock('../../../cli/services/storage', () => ({
 	resolveAgentId: vi.fn(),
 	getSessionById: vi.fn(),
+	readSessions: vi.fn().mockReturnValue([]),
 }));
 
 // Mock agent-sessions
@@ -25,7 +26,7 @@ vi.mock('../../../cli/services/agent-sessions', () => ({
 }));
 
 import { listSessions } from '../../../cli/commands/list-sessions';
-import { resolveAgentId, getSessionById } from '../../../cli/services/storage';
+import { resolveAgentId, getSessionById, readSessions } from '../../../cli/services/storage';
 import { listClaudeSessions } from '../../../cli/services/agent-sessions';
 
 describe('list sessions command', () => {
@@ -205,30 +206,49 @@ describe('list sessions command', () => {
 		expect(processExitSpy).toHaveBeenCalledWith(1);
 	});
 
-	it('should exit with error for unsupported agent type', () => {
+	it('should list empty sessions for non-Claude agent type', () => {
 		vi.mocked(resolveAgentId).mockReturnValue('agent-term-1');
 		vi.mocked(getSessionById).mockReturnValue(
 			mockAgent({ id: 'agent-term-1', toolType: 'terminal' })
 		);
+		vi.mocked(readSessions).mockReturnValue([
+			{
+				id: 'agent-term-1',
+				name: 'Terminal',
+				toolType: 'terminal' as any,
+				cwd: '/test',
+				projectRoot: '/test',
+			},
+		]);
 
 		listSessions('agent-term', {});
 
-		expect(consoleErrorSpy).toHaveBeenCalled();
-		expect(processExitSpy).toHaveBeenCalledWith(1);
+		// Non-Claude agents use tab-based listing; no tabs = empty output
+		expect(consoleSpy).toHaveBeenCalled();
+		expect(processExitSpy).not.toHaveBeenCalled();
 	});
 
-	it('should exit with error for unsupported agent type in JSON mode', () => {
-		vi.mocked(resolveAgentId).mockReturnValue('agent-term-1');
+	it('should list empty sessions for non-Claude agent types in JSON mode', () => {
+		vi.mocked(resolveAgentId).mockReturnValue('agent-codex-1');
 		vi.mocked(getSessionById).mockReturnValue(
-			mockAgent({ id: 'agent-term-1', toolType: 'terminal' })
+			mockAgent({ id: 'agent-codex-1', toolType: 'codex' })
 		);
+		vi.mocked(readSessions).mockReturnValue([
+			{
+				id: 'agent-codex-1',
+				name: 'Test Codex',
+				toolType: 'codex' as any,
+				cwd: '/test',
+				projectRoot: '/test',
+			},
+		]);
 
-		listSessions('agent-term', { json: true });
+		listSessions('agent-codex', { json: true });
 
 		const output = JSON.parse(consoleSpy.mock.calls[0][0]);
-		expect(output.success).toBe(false);
-		expect(output.code).toBe('AGENT_UNSUPPORTED');
-		expect(processExitSpy).toHaveBeenCalledWith(1);
+		expect(output.success).toBe(true);
+		expect(output.sessions).toEqual([]);
+		expect(output.totalCount).toBe(0);
 	});
 
 	it('should exit with error for invalid limit', () => {

--- a/src/__tests__/cli/commands/open-file.test.ts
+++ b/src/__tests__/cli/commands/open-file.test.ts
@@ -1,0 +1,121 @@
+/**
+ * @file open-file.test.ts
+ * @description Tests for the open-file CLI command
+ *
+ * Tests the open-file command functionality including:
+ * - Opening a valid file with explicit session
+ * - Opening a valid file with default session resolution
+ * - Error handling for non-existent files
+ * - Error handling when Maestro app is not running
+ */
+
+import { describe, it, expect, vi, beforeEach, type MockInstance } from 'vitest';
+import * as path from 'path';
+
+// Mock fs
+vi.mock('fs', () => ({
+	existsSync: vi.fn(),
+}));
+
+// Mock maestro-client
+vi.mock('../../../cli/services/maestro-client', () => ({
+	withMaestroClient: vi.fn(),
+	resolveSessionId: vi.fn(),
+}));
+
+import { openFile } from '../../../cli/commands/open-file';
+import { withMaestroClient, resolveSessionId } from '../../../cli/services/maestro-client';
+import { existsSync } from 'fs';
+
+describe('open-file command', () => {
+	let consoleSpy: MockInstance;
+	let consoleErrorSpy: MockInstance;
+	let processExitSpy: MockInstance;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+		consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+		processExitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+	});
+
+	it('should open a valid file with explicit session', async () => {
+		vi.mocked(existsSync).mockReturnValue(true);
+		vi.mocked(resolveSessionId).mockReturnValue('session-123');
+		vi.mocked(withMaestroClient).mockImplementation(async (action) => {
+			const mockClient = {
+				sendCommand: vi.fn().mockResolvedValue({ type: 'open_file_tab_result', success: true }),
+			};
+			return action(mockClient as never);
+		});
+
+		await openFile('/path/to/file.ts', { session: 'session-123' });
+
+		expect(resolveSessionId).toHaveBeenCalledWith({ session: 'session-123' });
+		expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Opened file.ts in Maestro'));
+		expect(processExitSpy).not.toHaveBeenCalled();
+	});
+
+	it('should resolve relative file paths to absolute', async () => {
+		vi.mocked(existsSync).mockReturnValue(true);
+		vi.mocked(resolveSessionId).mockReturnValue('session-123');
+		vi.mocked(withMaestroClient).mockImplementation(async (action) => {
+			const mockClient = {
+				sendCommand: vi.fn().mockImplementation((msg) => {
+					// Verify absolute path was sent
+					expect(path.isAbsolute(msg.filePath)).toBe(true);
+					return Promise.resolve({ type: 'open_file_tab_result', success: true });
+				}),
+			};
+			return action(mockClient as never);
+		});
+
+		await openFile('relative/file.ts', { session: 'session-123' });
+
+		expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Opened file.ts in Maestro'));
+	});
+
+	it('should error when file does not exist', async () => {
+		vi.mocked(existsSync).mockReturnValue(false);
+
+		await openFile('/nonexistent/file.ts', {});
+
+		expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('File not found'));
+		expect(processExitSpy).toHaveBeenCalledWith(1);
+	});
+
+	it('should error gracefully when Maestro app is not running', async () => {
+		vi.mocked(existsSync).mockReturnValue(true);
+		vi.mocked(resolveSessionId).mockReturnValue('session-123');
+		vi.mocked(withMaestroClient).mockRejectedValue(
+			new Error('Maestro desktop app is not running')
+		);
+
+		await openFile('/path/to/file.ts', { session: 'session-123' });
+
+		expect(consoleErrorSpy).toHaveBeenCalledWith(
+			expect.stringContaining('Maestro desktop app is not running')
+		);
+		expect(processExitSpy).toHaveBeenCalledWith(1);
+	});
+
+	it('should error when server returns failure', async () => {
+		vi.mocked(existsSync).mockReturnValue(true);
+		vi.mocked(resolveSessionId).mockReturnValue('session-123');
+		vi.mocked(withMaestroClient).mockImplementation(async (action) => {
+			const mockClient = {
+				sendCommand: vi.fn().mockResolvedValue({
+					type: 'open_file_tab_result',
+					success: false,
+					error: 'Session not found',
+				}),
+			};
+			return action(mockClient as never);
+		});
+
+		await openFile('/path/to/file.ts', { session: 'session-123' });
+
+		expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('Session not found'));
+		expect(processExitSpy).toHaveBeenCalledWith(1);
+	});
+});

--- a/src/__tests__/cli/commands/open-file.test.ts
+++ b/src/__tests__/cli/commands/open-file.test.ts
@@ -23,6 +23,17 @@ vi.mock('../../../cli/services/maestro-client', () => ({
 	resolveSessionId: vi.fn(),
 }));
 
+// Mock storage (used for resolving relative paths against agent's cwd)
+vi.mock('../../../cli/services/storage', () => ({
+	getSessionById: vi.fn().mockReturnValue({
+		id: 'session-123',
+		name: 'Test Agent',
+		toolType: 'claude-code',
+		cwd: '/home/user/project',
+		projectRoot: '/home/user/project',
+	}),
+}));
+
 import { openFile } from '../../../cli/commands/open-file';
 import { withMaestroClient, resolveSessionId } from '../../../cli/services/maestro-client';
 import { existsSync } from 'fs';

--- a/src/__tests__/cli/commands/open-file.test.ts
+++ b/src/__tests__/cli/commands/open-file.test.ts
@@ -87,9 +87,7 @@ describe('open-file command', () => {
 	it('should error gracefully when Maestro app is not running', async () => {
 		vi.mocked(existsSync).mockReturnValue(true);
 		vi.mocked(resolveSessionId).mockReturnValue('session-123');
-		vi.mocked(withMaestroClient).mockRejectedValue(
-			new Error('Maestro desktop app is not running')
-		);
+		vi.mocked(withMaestroClient).mockRejectedValue(new Error('Maestro desktop app is not running'));
 
 		await openFile('/path/to/file.ts', { session: 'session-123' });
 

--- a/src/__tests__/cli/services/maestro-client.test.ts
+++ b/src/__tests__/cli/services/maestro-client.test.ts
@@ -170,6 +170,32 @@ describe('MaestroClient', () => {
 			);
 		});
 
+		it('should resolve via requestId when response includes matching requestId', async () => {
+			const client = await createConnectedClient();
+
+			const commandPromise = client.sendCommand<{ type: string; data: string }>(
+				{ type: 'ping' },
+				'pong'
+			);
+
+			// Extract the requestId that was sent
+			const sentPayload = JSON.parse(mockWsInstance.send.mock.calls[0][0] as string) as Record<
+				string,
+				unknown
+			>;
+			expect(sentPayload.requestId).toBeDefined();
+
+			// Respond with the same requestId (triggers requestId-based resolution)
+			mockWsInstance.emit(
+				'message',
+				JSON.stringify({ type: 'pong', data: 'ok', requestId: sentPayload.requestId })
+			);
+
+			const result = await commandPromise;
+			expect(result.type).toBe('pong');
+			expect(result.data).toBe('ok');
+		});
+
 		it('should resolve on matching response type', async () => {
 			const client = await createConnectedClient();
 

--- a/src/__tests__/cli/services/maestro-client.test.ts
+++ b/src/__tests__/cli/services/maestro-client.test.ts
@@ -396,7 +396,7 @@ describe('resolveSessionId()', () => {
 		expect(() => resolveSessionId({})).toThrow('process.exit called');
 
 		expect(processExitSpy).toHaveBeenCalledWith(1);
-		expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('No sessions found'));
+		expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('No agents found'));
 
 		processExitSpy.mockRestore();
 		consoleErrorSpy.mockRestore();

--- a/src/__tests__/cli/services/maestro-client.test.ts
+++ b/src/__tests__/cli/services/maestro-client.test.ts
@@ -1,0 +1,397 @@
+/**
+ * @file maestro-client.test.ts
+ * @description Tests for the CLI WebSocket client service
+ *
+ * Tests the MaestroClient class including:
+ * - Connection lifecycle (connect, disconnect)
+ * - Command sending with response matching
+ * - Timeout handling
+ * - withMaestroClient helper lifecycle
+ * - resolveSessionId helper
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'events';
+
+// Track WebSocket instances created
+let mockWsInstance: EventEmitter & { close: ReturnType<typeof vi.fn>; send: ReturnType<typeof vi.fn>; readyState: number };
+
+vi.mock('ws', async () => {
+	const { EventEmitter: EE } = await import('events');
+	const WS_OPEN = 1;
+	class MockWebSocket extends EE {
+		close = vi.fn();
+		send = vi.fn();
+		readyState = WS_OPEN;
+		static OPEN = WS_OPEN;
+		constructor() {
+			super();
+			// eslint-disable-next-line @typescript-eslint/no-use-before-define
+			mockWsInstance = this as unknown as typeof mockWsInstance;
+		}
+	}
+	return { default: MockWebSocket };
+});
+
+vi.mock('../../../shared/cli-server-discovery', () => ({
+	readCliServerInfo: vi.fn(),
+	isCliServerRunning: vi.fn(),
+}));
+
+vi.mock('../../../cli/services/storage', () => ({
+	readSessions: vi.fn(),
+}));
+
+import { MaestroClient, withMaestroClient, resolveSessionId } from '../../../cli/services/maestro-client';
+import { readCliServerInfo, isCliServerRunning } from '../../../shared/cli-server-discovery';
+import { readSessions } from '../../../cli/services/storage';
+import WebSocket from 'ws';
+
+describe('MaestroClient', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	describe('connect()', () => {
+		it('should throw when no discovery file exists', async () => {
+			vi.mocked(readCliServerInfo).mockReturnValue(null);
+
+			const client = new MaestroClient();
+			await expect(client.connect()).rejects.toThrow('Maestro desktop app is not running');
+		});
+
+		it('should throw when PID is stale', async () => {
+			vi.mocked(readCliServerInfo).mockReturnValue({
+				port: 3000,
+				token: 'test-token',
+				pid: 12345,
+				startedAt: Date.now(),
+			});
+			vi.mocked(isCliServerRunning).mockReturnValue(false);
+
+			const client = new MaestroClient();
+			await expect(client.connect()).rejects.toThrow('Maestro discovery file is stale');
+		});
+
+		it('should connect successfully when server is running', async () => {
+			vi.mocked(readCliServerInfo).mockReturnValue({
+				port: 3000,
+				token: 'test-token',
+				pid: 12345,
+				startedAt: Date.now(),
+			});
+			vi.mocked(isCliServerRunning).mockReturnValue(true);
+
+			const client = new MaestroClient();
+			const connectPromise = client.connect();
+
+			// Simulate WebSocket open event
+			mockWsInstance.emit('open');
+
+			await connectPromise;
+
+			// Verify connection was established (mockWsInstance is set)
+		expect(mockWsInstance).toBeDefined();
+		});
+
+		it('should reject on WebSocket error', async () => {
+			vi.mocked(readCliServerInfo).mockReturnValue({
+				port: 3000,
+				token: 'test-token',
+				pid: 12345,
+				startedAt: Date.now(),
+			});
+			vi.mocked(isCliServerRunning).mockReturnValue(true);
+
+			const client = new MaestroClient();
+			const connectPromise = client.connect();
+
+			// Simulate WebSocket error
+			mockWsInstance.emit('error', new Error('Connection refused'));
+
+			await expect(connectPromise).rejects.toThrow('Failed to connect to Maestro: Connection refused');
+		});
+
+		it('should timeout after 5 seconds', async () => {
+			vi.mocked(readCliServerInfo).mockReturnValue({
+				port: 3000,
+				token: 'test-token',
+				pid: 12345,
+				startedAt: Date.now(),
+			});
+			vi.mocked(isCliServerRunning).mockReturnValue(true);
+
+			const client = new MaestroClient();
+			const connectPromise = client.connect();
+
+			// Advance past timeout
+			vi.advanceTimersByTime(5001);
+
+			await expect(connectPromise).rejects.toThrow('Connection to Maestro timed out');
+		});
+	});
+
+	describe('sendCommand()', () => {
+		async function createConnectedClient(): Promise<MaestroClient> {
+			vi.mocked(readCliServerInfo).mockReturnValue({
+				port: 3000,
+				token: 'test-token',
+				pid: 12345,
+				startedAt: Date.now(),
+			});
+			vi.mocked(isCliServerRunning).mockReturnValue(true);
+
+			const client = new MaestroClient();
+			const connectPromise = client.connect();
+			mockWsInstance.emit('open');
+			await connectPromise;
+			return client;
+		}
+
+		it('should throw when not connected', async () => {
+			const client = new MaestroClient();
+			await expect(
+				client.sendCommand({ type: 'ping' }, 'pong')
+			).rejects.toThrow('Not connected to Maestro');
+		});
+
+		it('should resolve on matching response type', async () => {
+			const client = await createConnectedClient();
+
+			const commandPromise = client.sendCommand<{ type: string; data: string }>(
+				{ type: 'ping' },
+				'pong'
+			);
+
+			// Simulate matching response
+			mockWsInstance.emit('message', JSON.stringify({ type: 'pong', data: 'ok' }));
+
+			const result = await commandPromise;
+			expect(result.type).toBe('pong');
+			expect(result.data).toBe('ok');
+			expect(mockWsInstance.send).toHaveBeenCalledWith(
+				expect.stringContaining('"type":"ping"')
+			);
+		});
+
+		it('should reject on timeout', async () => {
+			const client = await createConnectedClient();
+
+			const commandPromise = client.sendCommand(
+				{ type: 'ping' },
+				'pong',
+				2000
+			);
+
+			// Advance past timeout
+			vi.advanceTimersByTime(2001);
+
+			await expect(commandPromise).rejects.toThrow('Command timed out waiting for pong');
+		});
+
+		it('should use default 10s timeout', async () => {
+			const client = await createConnectedClient();
+
+			const commandPromise = client.sendCommand(
+				{ type: 'ping' },
+				'pong'
+			);
+
+			// At 9.9s it should still be pending
+			vi.advanceTimersByTime(9900);
+
+			// At 10.1s it should timeout
+			vi.advanceTimersByTime(200);
+
+			await expect(commandPromise).rejects.toThrow('Command timed out');
+		});
+
+		it('should ignore non-matching response types', async () => {
+			const client = await createConnectedClient();
+
+			const commandPromise = client.sendCommand<{ type: string }>(
+				{ type: 'ping' },
+				'pong'
+			);
+
+			// Send non-matching response first
+			mockWsInstance.emit('message', JSON.stringify({ type: 'other_event', data: 'ignored' }));
+
+			// Then matching one
+			mockWsInstance.emit('message', JSON.stringify({ type: 'pong' }));
+
+			const result = await commandPromise;
+			expect(result.type).toBe('pong');
+		});
+
+		it('should ignore non-JSON messages', async () => {
+			const client = await createConnectedClient();
+
+			const commandPromise = client.sendCommand<{ type: string }>(
+				{ type: 'ping' },
+				'pong'
+			);
+
+			// Send invalid JSON
+			mockWsInstance.emit('message', 'not json');
+
+			// Then send valid matching message
+			mockWsInstance.emit('message', JSON.stringify({ type: 'pong' }));
+
+			const result = await commandPromise;
+			expect(result.type).toBe('pong');
+		});
+	});
+
+	describe('disconnect()', () => {
+		it('should close the WebSocket connection', async () => {
+			vi.mocked(readCliServerInfo).mockReturnValue({
+				port: 3000,
+				token: 'test-token',
+				pid: 12345,
+				startedAt: Date.now(),
+			});
+			vi.mocked(isCliServerRunning).mockReturnValue(true);
+
+			const client = new MaestroClient();
+			const connectPromise = client.connect();
+			mockWsInstance.emit('open');
+			await connectPromise;
+
+			client.disconnect();
+
+			expect(mockWsInstance.close).toHaveBeenCalled();
+		});
+
+		it('should reject pending requests on disconnect', async () => {
+			vi.mocked(readCliServerInfo).mockReturnValue({
+				port: 3000,
+				token: 'test-token',
+				pid: 12345,
+				startedAt: Date.now(),
+			});
+			vi.mocked(isCliServerRunning).mockReturnValue(true);
+
+			const client = new MaestroClient();
+			const connectPromise = client.connect();
+			mockWsInstance.emit('open');
+			await connectPromise;
+
+			const commandPromise = client.sendCommand({ type: 'ping' }, 'pong');
+
+			client.disconnect();
+
+			await expect(commandPromise).rejects.toThrow('Client disconnected');
+		});
+
+		it('should be safe to call when not connected', () => {
+			const client = new MaestroClient();
+			expect(() => client.disconnect()).not.toThrow();
+		});
+	});
+});
+
+describe('withMaestroClient()', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('should connect, run action, and disconnect', async () => {
+		vi.mocked(readCliServerInfo).mockReturnValue({
+			port: 3000,
+			token: 'test-token',
+			pid: 12345,
+			startedAt: Date.now(),
+		});
+		vi.mocked(isCliServerRunning).mockReturnValue(true);
+
+		const actionResult = 'action-result';
+		const actionFn = vi.fn().mockResolvedValue(actionResult);
+
+		const resultPromise = withMaestroClient(actionFn);
+
+		// Wait for connect
+		mockWsInstance.emit('open');
+
+		const result = await resultPromise;
+
+		expect(result).toBe(actionResult);
+		expect(actionFn).toHaveBeenCalledTimes(1);
+		// Should disconnect after action
+		expect(mockWsInstance.close).toHaveBeenCalled();
+	});
+
+	it('should disconnect even when action throws', async () => {
+		vi.mocked(readCliServerInfo).mockReturnValue({
+			port: 3000,
+			token: 'test-token',
+			pid: 12345,
+			startedAt: Date.now(),
+		});
+		vi.mocked(isCliServerRunning).mockReturnValue(true);
+
+		const actionFn = vi.fn().mockRejectedValue(new Error('Action failed'));
+
+		const resultPromise = withMaestroClient(actionFn);
+		mockWsInstance.emit('open');
+
+		await expect(resultPromise).rejects.toThrow('Action failed');
+		expect(mockWsInstance.close).toHaveBeenCalled();
+	});
+
+	it('should propagate connection errors', async () => {
+		vi.mocked(readCliServerInfo).mockReturnValue(null);
+
+		await expect(
+			withMaestroClient(async () => 'should not reach')
+		).rejects.toThrow('Maestro desktop app is not running');
+	});
+});
+
+describe('resolveSessionId()', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('should return provided session option directly', () => {
+		const result = resolveSessionId({ session: 'my-session-id' });
+		expect(result).toBe('my-session-id');
+		expect(readSessions).not.toHaveBeenCalled();
+	});
+
+	it('should return first session ID when no option provided', () => {
+		vi.mocked(readSessions).mockReturnValue([
+			{ id: 'first-session', name: 'First', toolType: 'claude-code', cwd: '/path', projectRoot: '/path' },
+			{ id: 'second-session', name: 'Second', toolType: 'claude-code', cwd: '/path', projectRoot: '/path' },
+		]);
+
+		const result = resolveSessionId({});
+		expect(result).toBe('first-session');
+	});
+
+	it('should exit when no sessions exist and no option provided', () => {
+		vi.mocked(readSessions).mockReturnValue([]);
+		const processExitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+			throw new Error('process.exit called');
+		});
+		const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+		expect(() => resolveSessionId({})).toThrow('process.exit called');
+
+		expect(processExitSpy).toHaveBeenCalledWith(1);
+		expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('No sessions found'));
+
+		processExitSpy.mockRestore();
+		consoleErrorSpy.mockRestore();
+	});
+});

--- a/src/__tests__/cli/services/maestro-client.test.ts
+++ b/src/__tests__/cli/services/maestro-client.test.ts
@@ -14,7 +14,11 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { EventEmitter } from 'events';
 
 // Track WebSocket instances created
-let mockWsInstance: EventEmitter & { close: ReturnType<typeof vi.fn>; send: ReturnType<typeof vi.fn>; readyState: number };
+let mockWsInstance: EventEmitter & {
+	close: ReturnType<typeof vi.fn>;
+	send: ReturnType<typeof vi.fn>;
+	readyState: number;
+};
 
 vi.mock('ws', async () => {
 	const { EventEmitter: EE } = await import('events');
@@ -42,7 +46,11 @@ vi.mock('../../../cli/services/storage', () => ({
 	readSessions: vi.fn(),
 }));
 
-import { MaestroClient, withMaestroClient, resolveSessionId } from '../../../cli/services/maestro-client';
+import {
+	MaestroClient,
+	withMaestroClient,
+	resolveSessionId,
+} from '../../../cli/services/maestro-client';
 import { readCliServerInfo, isCliServerRunning } from '../../../shared/cli-server-discovery';
 import { readSessions } from '../../../cli/services/storage';
 import WebSocket from 'ws';
@@ -96,7 +104,7 @@ describe('MaestroClient', () => {
 			await connectPromise;
 
 			// Verify connection was established (mockWsInstance is set)
-		expect(mockWsInstance).toBeDefined();
+			expect(mockWsInstance).toBeDefined();
 		});
 
 		it('should reject on WebSocket error', async () => {
@@ -114,7 +122,9 @@ describe('MaestroClient', () => {
 			// Simulate WebSocket error
 			mockWsInstance.emit('error', new Error('Connection refused'));
 
-			await expect(connectPromise).rejects.toThrow('Failed to connect to Maestro: Connection refused');
+			await expect(connectPromise).rejects.toThrow(
+				'Failed to connect to Maestro: Connection refused'
+			);
 		});
 
 		it('should timeout after 5 seconds', async () => {
@@ -155,9 +165,9 @@ describe('MaestroClient', () => {
 
 		it('should throw when not connected', async () => {
 			const client = new MaestroClient();
-			await expect(
-				client.sendCommand({ type: 'ping' }, 'pong')
-			).rejects.toThrow('Not connected to Maestro');
+			await expect(client.sendCommand({ type: 'ping' }, 'pong')).rejects.toThrow(
+				'Not connected to Maestro'
+			);
 		});
 
 		it('should resolve on matching response type', async () => {
@@ -174,19 +184,13 @@ describe('MaestroClient', () => {
 			const result = await commandPromise;
 			expect(result.type).toBe('pong');
 			expect(result.data).toBe('ok');
-			expect(mockWsInstance.send).toHaveBeenCalledWith(
-				expect.stringContaining('"type":"ping"')
-			);
+			expect(mockWsInstance.send).toHaveBeenCalledWith(expect.stringContaining('"type":"ping"'));
 		});
 
 		it('should reject on timeout', async () => {
 			const client = await createConnectedClient();
 
-			const commandPromise = client.sendCommand(
-				{ type: 'ping' },
-				'pong',
-				2000
-			);
+			const commandPromise = client.sendCommand({ type: 'ping' }, 'pong', 2000);
 
 			// Advance past timeout
 			vi.advanceTimersByTime(2001);
@@ -197,10 +201,7 @@ describe('MaestroClient', () => {
 		it('should use default 10s timeout', async () => {
 			const client = await createConnectedClient();
 
-			const commandPromise = client.sendCommand(
-				{ type: 'ping' },
-				'pong'
-			);
+			const commandPromise = client.sendCommand({ type: 'ping' }, 'pong');
 
 			// At 9.9s it should still be pending
 			vi.advanceTimersByTime(9900);
@@ -214,10 +215,7 @@ describe('MaestroClient', () => {
 		it('should ignore non-matching response types', async () => {
 			const client = await createConnectedClient();
 
-			const commandPromise = client.sendCommand<{ type: string }>(
-				{ type: 'ping' },
-				'pong'
-			);
+			const commandPromise = client.sendCommand<{ type: string }>({ type: 'ping' }, 'pong');
 
 			// Send non-matching response first
 			mockWsInstance.emit('message', JSON.stringify({ type: 'other_event', data: 'ignored' }));
@@ -232,10 +230,7 @@ describe('MaestroClient', () => {
 		it('should ignore non-JSON messages', async () => {
 			const client = await createConnectedClient();
 
-			const commandPromise = client.sendCommand<{ type: string }>(
-				{ type: 'ping' },
-				'pong'
-			);
+			const commandPromise = client.sendCommand<{ type: string }>({ type: 'ping' }, 'pong');
 
 			// Send invalid JSON
 			mockWsInstance.emit('message', 'not json');
@@ -352,9 +347,9 @@ describe('withMaestroClient()', () => {
 	it('should propagate connection errors', async () => {
 		vi.mocked(readCliServerInfo).mockReturnValue(null);
 
-		await expect(
-			withMaestroClient(async () => 'should not reach')
-		).rejects.toThrow('Maestro desktop app is not running');
+		await expect(withMaestroClient(async () => 'should not reach')).rejects.toThrow(
+			'Maestro desktop app is not running'
+		);
 	});
 });
 
@@ -371,8 +366,20 @@ describe('resolveSessionId()', () => {
 
 	it('should return first session ID when no option provided', () => {
 		vi.mocked(readSessions).mockReturnValue([
-			{ id: 'first-session', name: 'First', toolType: 'claude-code', cwd: '/path', projectRoot: '/path' },
-			{ id: 'second-session', name: 'Second', toolType: 'claude-code', cwd: '/path', projectRoot: '/path' },
+			{
+				id: 'first-session',
+				name: 'First',
+				toolType: 'claude-code',
+				cwd: '/path',
+				projectRoot: '/path',
+			},
+			{
+				id: 'second-session',
+				name: 'Second',
+				toolType: 'claude-code',
+				cwd: '/path',
+				projectRoot: '/path',
+			},
 		]);
 
 		const result = resolveSessionId({});

--- a/src/__tests__/main/web-server/handlers/messageHandlers.test.ts
+++ b/src/__tests__/main/web-server/handlers/messageHandlers.test.ts
@@ -14,6 +14,10 @@
  * - Close tab
  * - Rename tab
  * - Subscribe to session updates
+ * - Open file tab
+ * - Refresh file tree
+ * - Refresh auto-run documents
+ * - Select session with focus (window foregrounding)
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -66,6 +70,12 @@ function createMockCallbacks(): MessageHandlerCallbacks {
 		newTab: vi.fn().mockResolvedValue({ tabId: 'new-tab-123' }),
 		closeTab: vi.fn().mockResolvedValue(true),
 		renameTab: vi.fn().mockResolvedValue(true),
+		starTab: vi.fn().mockResolvedValue(true),
+		reorderTab: vi.fn().mockResolvedValue(true),
+		toggleBookmark: vi.fn().mockResolvedValue(true),
+		openFileTab: vi.fn().mockResolvedValue(true),
+		refreshFileTree: vi.fn().mockResolvedValue(true),
+		refreshAutoRunDocs: vi.fn().mockResolvedValue(true),
 		getSessions: vi.fn().mockReturnValue([
 			{
 				id: 'session-1',
@@ -283,7 +293,11 @@ describe('WebSocketMessageHandler', () => {
 			});
 
 			await vi.waitFor(() => {
-				expect(callbacks.selectSession).toHaveBeenCalledWith('session-2', undefined);
+				expect(callbacks.selectSession).toHaveBeenCalledWith(
+					'session-2',
+					undefined,
+					undefined
+				);
 			});
 
 			const response = JSON.parse((client.socket.send as any).mock.calls[0][0]);
@@ -299,7 +313,11 @@ describe('WebSocketMessageHandler', () => {
 			});
 
 			await vi.waitFor(() => {
-				expect(callbacks.selectSession).toHaveBeenCalledWith('session-2', 'tab-5');
+				expect(callbacks.selectSession).toHaveBeenCalledWith(
+					'session-2',
+					'tab-5',
+					undefined
+				);
 			});
 		});
 
@@ -533,6 +551,208 @@ describe('WebSocketMessageHandler', () => {
 			expect(response.sessions).toHaveLength(1);
 			expect(response.sessions[0].agentSessionId).toBe('live-claude-456');
 			expect(response.sessions[0].isLive).toBe(true);
+		});
+	});
+
+	describe('Open File Tab (Web → Desktop)', () => {
+		it('should forward open file tab to desktop with sessionId and filePath', async () => {
+			handler.handleMessage(client, {
+				type: 'open_file_tab',
+				sessionId: 'session-1',
+				filePath: '/home/user/project/src/index.ts',
+			});
+
+			await vi.waitFor(() => {
+				expect(callbacks.openFileTab).toHaveBeenCalledWith(
+					'session-1',
+					'/home/user/project/src/index.ts'
+				);
+			});
+
+			const response = JSON.parse((client.socket.send as any).mock.calls[0][0]);
+			expect(response.type).toBe('open_file_tab_result');
+			expect(response.success).toBe(true);
+			expect(response.sessionId).toBe('session-1');
+			expect(response.filePath).toBe('/home/user/project/src/index.ts');
+		});
+
+		it('should reject open file tab with missing sessionId', () => {
+			handler.handleMessage(client, {
+				type: 'open_file_tab',
+				filePath: '/home/user/project/src/index.ts',
+			});
+
+			const response = JSON.parse((client.socket.send as any).mock.calls[0][0]);
+			expect(response.type).toBe('error');
+			expect(response.message).toContain('Missing sessionId or filePath');
+			expect(callbacks.openFileTab).not.toHaveBeenCalled();
+		});
+
+		it('should reject open file tab with missing filePath', () => {
+			handler.handleMessage(client, {
+				type: 'open_file_tab',
+				sessionId: 'session-1',
+			});
+
+			const response = JSON.parse((client.socket.send as any).mock.calls[0][0]);
+			expect(response.type).toBe('error');
+			expect(response.message).toContain('Missing sessionId or filePath');
+			expect(callbacks.openFileTab).not.toHaveBeenCalled();
+		});
+
+		it('should handle open file tab callback failure', async () => {
+			(callbacks.openFileTab as any).mockRejectedValue(new Error('File not found'));
+
+			handler.handleMessage(client, {
+				type: 'open_file_tab',
+				sessionId: 'session-1',
+				filePath: '/nonexistent/file.ts',
+			});
+
+			await vi.waitFor(() => {
+				const calls = (client.socket.send as any).mock.calls;
+				const lastResponse = JSON.parse(calls[calls.length - 1][0]);
+				expect(lastResponse.type).toBe('error');
+				expect(lastResponse.message).toContain('File not found');
+			});
+		});
+	});
+
+	describe('Refresh File Tree (Web → Desktop)', () => {
+		it('should forward refresh file tree to desktop', async () => {
+			handler.handleMessage(client, {
+				type: 'refresh_file_tree',
+				sessionId: 'session-1',
+			});
+
+			await vi.waitFor(() => {
+				expect(callbacks.refreshFileTree).toHaveBeenCalledWith('session-1');
+			});
+
+			const response = JSON.parse((client.socket.send as any).mock.calls[0][0]);
+			expect(response.type).toBe('refresh_file_tree_result');
+			expect(response.success).toBe(true);
+			expect(response.sessionId).toBe('session-1');
+		});
+
+		it('should reject refresh file tree with missing sessionId', () => {
+			handler.handleMessage(client, {
+				type: 'refresh_file_tree',
+			});
+
+			const response = JSON.parse((client.socket.send as any).mock.calls[0][0]);
+			expect(response.type).toBe('error');
+			expect(response.message).toContain('Missing sessionId');
+			expect(callbacks.refreshFileTree).not.toHaveBeenCalled();
+		});
+
+		it('should handle refresh file tree callback failure', async () => {
+			(callbacks.refreshFileTree as any).mockRejectedValue(new Error('Tree refresh failed'));
+
+			handler.handleMessage(client, {
+				type: 'refresh_file_tree',
+				sessionId: 'session-1',
+			});
+
+			await vi.waitFor(() => {
+				const calls = (client.socket.send as any).mock.calls;
+				const lastResponse = JSON.parse(calls[calls.length - 1][0]);
+				expect(lastResponse.type).toBe('error');
+				expect(lastResponse.message).toContain('Tree refresh failed');
+			});
+		});
+	});
+
+	describe('Refresh Auto Run Docs (Web → Desktop)', () => {
+		it('should forward refresh auto run docs to desktop', async () => {
+			handler.handleMessage(client, {
+				type: 'refresh_auto_run_docs',
+				sessionId: 'session-1',
+			});
+
+			await vi.waitFor(() => {
+				expect(callbacks.refreshAutoRunDocs).toHaveBeenCalledWith('session-1');
+			});
+
+			const response = JSON.parse((client.socket.send as any).mock.calls[0][0]);
+			expect(response.type).toBe('refresh_auto_run_docs_result');
+			expect(response.success).toBe(true);
+			expect(response.sessionId).toBe('session-1');
+		});
+
+		it('should reject refresh auto run docs with missing sessionId', () => {
+			handler.handleMessage(client, {
+				type: 'refresh_auto_run_docs',
+			});
+
+			const response = JSON.parse((client.socket.send as any).mock.calls[0][0]);
+			expect(response.type).toBe('error');
+			expect(response.message).toContain('Missing sessionId');
+			expect(callbacks.refreshAutoRunDocs).not.toHaveBeenCalled();
+		});
+
+		it('should handle refresh auto run docs callback failure', async () => {
+			(callbacks.refreshAutoRunDocs as any).mockRejectedValue(
+				new Error('Auto-run refresh failed')
+			);
+
+			handler.handleMessage(client, {
+				type: 'refresh_auto_run_docs',
+				sessionId: 'session-1',
+			});
+
+			await vi.waitFor(() => {
+				const calls = (client.socket.send as any).mock.calls;
+				const lastResponse = JSON.parse(calls[calls.length - 1][0]);
+				expect(lastResponse.type).toBe('error');
+				expect(lastResponse.message).toContain('Auto-run refresh failed');
+			});
+		});
+	});
+
+	describe('Select Session with Focus (Web → Desktop)', () => {
+		it('should forward session selection with focus flag', async () => {
+			handler.handleMessage(client, {
+				type: 'select_session',
+				sessionId: 'session-2',
+				focus: true,
+			});
+
+			await vi.waitFor(() => {
+				expect(callbacks.selectSession).toHaveBeenCalledWith('session-2', undefined, true);
+			});
+
+			const response = JSON.parse((client.socket.send as any).mock.calls[0][0]);
+			expect(response.type).toBe('select_session_result');
+			expect(response.success).toBe(true);
+		});
+
+		it('should forward session selection with focus and tabId', async () => {
+			handler.handleMessage(client, {
+				type: 'select_session',
+				sessionId: 'session-2',
+				tabId: 'tab-3',
+				focus: true,
+			});
+
+			await vi.waitFor(() => {
+				expect(callbacks.selectSession).toHaveBeenCalledWith('session-2', 'tab-3', true);
+			});
+		});
+
+		it('should forward session selection without focus flag', async () => {
+			handler.handleMessage(client, {
+				type: 'select_session',
+				sessionId: 'session-2',
+			});
+
+			await vi.waitFor(() => {
+				expect(callbacks.selectSession).toHaveBeenCalledWith(
+					'session-2',
+					undefined,
+					undefined
+				);
+			});
 		});
 	});
 

--- a/src/__tests__/main/web-server/handlers/messageHandlers.test.ts
+++ b/src/__tests__/main/web-server/handlers/messageHandlers.test.ts
@@ -576,8 +576,9 @@ describe('WebSocketMessageHandler', () => {
 			});
 
 			const response = JSON.parse((client.socket.send as any).mock.calls[0][0]);
-			expect(response.type).toBe('error');
-			expect(response.message).toContain('Missing sessionId or filePath');
+			expect(response.type).toBe('open_file_tab_result');
+			expect(response.success).toBe(false);
+			expect(response.error).toContain('Missing sessionId or filePath');
 			expect(callbacks.openFileTab).not.toHaveBeenCalled();
 		});
 
@@ -588,8 +589,9 @@ describe('WebSocketMessageHandler', () => {
 			});
 
 			const response = JSON.parse((client.socket.send as any).mock.calls[0][0]);
-			expect(response.type).toBe('error');
-			expect(response.message).toContain('Missing sessionId or filePath');
+			expect(response.type).toBe('open_file_tab_result');
+			expect(response.success).toBe(false);
+			expect(response.error).toContain('Missing sessionId or filePath');
 			expect(callbacks.openFileTab).not.toHaveBeenCalled();
 		});
 
@@ -605,8 +607,9 @@ describe('WebSocketMessageHandler', () => {
 			await vi.waitFor(() => {
 				const calls = (client.socket.send as any).mock.calls;
 				const lastResponse = JSON.parse(calls[calls.length - 1][0]);
-				expect(lastResponse.type).toBe('error');
-				expect(lastResponse.message).toContain('File not found');
+				expect(lastResponse.type).toBe('open_file_tab_result');
+				expect(lastResponse.success).toBe(false);
+				expect(lastResponse.error).toContain('File not found');
 			});
 		});
 
@@ -618,8 +621,9 @@ describe('WebSocketMessageHandler', () => {
 			});
 
 			const response = JSON.parse((client.socket.send as any).mock.calls[0][0]);
-			expect(response.type).toBe('error');
-			expect(response.message).toContain('Invalid file path');
+			expect(response.type).toBe('open_file_tab_result');
+			expect(response.success).toBe(false);
+			expect(response.error).toContain('Invalid file path');
 			expect(callbacks.openFileTab).not.toHaveBeenCalled();
 		});
 	});

--- a/src/__tests__/main/web-server/handlers/messageHandlers.test.ts
+++ b/src/__tests__/main/web-server/handlers/messageHandlers.test.ts
@@ -76,6 +76,7 @@ function createMockCallbacks(): MessageHandlerCallbacks {
 		openFileTab: vi.fn().mockResolvedValue(true),
 		refreshFileTree: vi.fn().mockResolvedValue(true),
 		refreshAutoRunDocs: vi.fn().mockResolvedValue(true),
+		configureAutoRun: vi.fn().mockResolvedValue({ success: true }),
 		getSessions: vi.fn().mockReturnValue([
 			{
 				id: 'session-1',
@@ -707,6 +708,139 @@ describe('WebSocketMessageHandler', () => {
 				expect(lastResponse.type).toBe('error');
 				expect(lastResponse.message).toContain('Auto-run refresh failed');
 			});
+		});
+	});
+
+	describe('Configure Auto Run (Web → Desktop)', () => {
+		it('should forward configure auto run with valid config', async () => {
+			handler.handleMessage(client, {
+				type: 'configure_auto_run',
+				sessionId: 'session-1',
+				documents: [{ filename: 'doc1.md' }, { filename: 'doc2.md', resetOnCompletion: true }],
+				prompt: 'Custom prompt',
+				loopEnabled: true,
+				maxLoops: 3,
+				launch: true,
+			});
+
+			await vi.waitFor(() => {
+				expect(callbacks.configureAutoRun).toHaveBeenCalledWith('session-1', {
+					documents: [{ filename: 'doc1.md' }, { filename: 'doc2.md', resetOnCompletion: true }],
+					prompt: 'Custom prompt',
+					loopEnabled: true,
+					maxLoops: 3,
+					saveAsPlaybook: undefined,
+					launch: true,
+				});
+			});
+
+			const response = JSON.parse((client.socket.send as any).mock.calls[0][0]);
+			expect(response.type).toBe('configure_auto_run_result');
+			expect(response.success).toBe(true);
+			expect(response.sessionId).toBe('session-1');
+		});
+
+		it('should reject configure auto run with missing sessionId', () => {
+			handler.handleMessage(client, {
+				type: 'configure_auto_run',
+				documents: [{ filename: 'doc1.md' }],
+			});
+
+			const response = JSON.parse((client.socket.send as any).mock.calls[0][0]);
+			expect(response.type).toBe('error');
+			expect(response.message).toContain('Missing sessionId');
+			expect(callbacks.configureAutoRun).not.toHaveBeenCalled();
+		});
+
+		it('should reject configure auto run with missing documents', () => {
+			handler.handleMessage(client, {
+				type: 'configure_auto_run',
+				sessionId: 'session-1',
+			});
+
+			const response = JSON.parse((client.socket.send as any).mock.calls[0][0]);
+			expect(response.type).toBe('error');
+			expect(response.message).toContain('documents');
+			expect(callbacks.configureAutoRun).not.toHaveBeenCalled();
+		});
+
+		it('should reject configure auto run with empty documents array', () => {
+			handler.handleMessage(client, {
+				type: 'configure_auto_run',
+				sessionId: 'session-1',
+				documents: [],
+			});
+
+			const response = JSON.parse((client.socket.send as any).mock.calls[0][0]);
+			expect(response.type).toBe('error');
+			expect(response.message).toContain('documents');
+			expect(callbacks.configureAutoRun).not.toHaveBeenCalled();
+		});
+
+		it('should forward configure auto run with saveAsPlaybook', async () => {
+			(callbacks.configureAutoRun as any).mockResolvedValue({
+				success: true,
+				playbookId: 'pb-123',
+			});
+
+			handler.handleMessage(client, {
+				type: 'configure_auto_run',
+				sessionId: 'session-1',
+				documents: [{ filename: 'doc1.md' }],
+				saveAsPlaybook: 'My Playbook',
+			});
+
+			await vi.waitFor(() => {
+				expect(callbacks.configureAutoRun).toHaveBeenCalledWith('session-1', {
+					documents: [{ filename: 'doc1.md' }],
+					prompt: undefined,
+					loopEnabled: undefined,
+					maxLoops: undefined,
+					saveAsPlaybook: 'My Playbook',
+					launch: undefined,
+				});
+			});
+
+			const response = JSON.parse((client.socket.send as any).mock.calls[0][0]);
+			expect(response.type).toBe('configure_auto_run_result');
+			expect(response.success).toBe(true);
+			expect(response.playbookId).toBe('pb-123');
+		});
+
+		it('should handle configure auto run callback failure', async () => {
+			(callbacks.configureAutoRun as any).mockRejectedValue(
+				new Error('Auto-run configuration failed')
+			);
+
+			handler.handleMessage(client, {
+				type: 'configure_auto_run',
+				sessionId: 'session-1',
+				documents: [{ filename: 'doc1.md' }],
+			});
+
+			await vi.waitFor(() => {
+				const calls = (client.socket.send as any).mock.calls;
+				const lastResponse = JSON.parse(calls[calls.length - 1][0]);
+				expect(lastResponse.type).toBe('error');
+				expect(lastResponse.message).toContain('Auto-run configuration failed');
+			});
+		});
+
+		it('should handle missing configureAutoRun callback', () => {
+			const handlerNoCallbacks = new WebSocketMessageHandler();
+			handlerNoCallbacks.setCallbacks({
+				getSessionDetail: vi.fn(),
+			});
+
+			handlerNoCallbacks.handleMessage(client, {
+				type: 'configure_auto_run',
+				sessionId: 'session-1',
+				documents: [{ filename: 'doc1.md' }],
+			});
+
+			const response = JSON.parse((client.socket.send as any).mock.calls[0][0]);
+			expect(response.type).toBe('error');
+			expect(response.message).toContain('not configured');
 		});
 	});
 

--- a/src/__tests__/main/web-server/handlers/messageHandlers.test.ts
+++ b/src/__tests__/main/web-server/handlers/messageHandlers.test.ts
@@ -84,7 +84,7 @@ function createMockCallbacks(): MessageHandlerCallbacks {
 				toolType: 'claude-code',
 				state: 'idle',
 				inputMode: 'ai',
-				cwd: '/test',
+				cwd: '/home/user/project',
 			},
 		]),
 		getLiveSessionInfo: vi.fn().mockReturnValue(undefined),
@@ -599,7 +599,7 @@ describe('WebSocketMessageHandler', () => {
 			handler.handleMessage(client, {
 				type: 'open_file_tab',
 				sessionId: 'session-1',
-				filePath: '/nonexistent/file.ts',
+				filePath: '/home/user/project/nonexistent/file.ts',
 			});
 
 			await vi.waitFor(() => {
@@ -608,6 +608,19 @@ describe('WebSocketMessageHandler', () => {
 				expect(lastResponse.type).toBe('error');
 				expect(lastResponse.message).toContain('File not found');
 			});
+		});
+
+		it('should reject path traversal attempts', () => {
+			handler.handleMessage(client, {
+				type: 'open_file_tab',
+				sessionId: 'session-1',
+				filePath: '/home/user/project/../../etc/passwd',
+			});
+
+			const response = JSON.parse((client.socket.send as any).mock.calls[0][0]);
+			expect(response.type).toBe('error');
+			expect(response.message).toContain('Invalid file path');
+			expect(callbacks.openFileTab).not.toHaveBeenCalled();
 		});
 	});
 

--- a/src/__tests__/main/web-server/handlers/messageHandlers.test.ts
+++ b/src/__tests__/main/web-server/handlers/messageHandlers.test.ts
@@ -294,11 +294,7 @@ describe('WebSocketMessageHandler', () => {
 			});
 
 			await vi.waitFor(() => {
-				expect(callbacks.selectSession).toHaveBeenCalledWith(
-					'session-2',
-					undefined,
-					undefined
-				);
+				expect(callbacks.selectSession).toHaveBeenCalledWith('session-2', undefined, undefined);
 			});
 
 			const response = JSON.parse((client.socket.send as any).mock.calls[0][0]);
@@ -314,11 +310,7 @@ describe('WebSocketMessageHandler', () => {
 			});
 
 			await vi.waitFor(() => {
-				expect(callbacks.selectSession).toHaveBeenCalledWith(
-					'session-2',
-					'tab-5',
-					undefined
-				);
+				expect(callbacks.selectSession).toHaveBeenCalledWith('session-2', 'tab-5', undefined);
 			});
 		});
 
@@ -693,9 +685,7 @@ describe('WebSocketMessageHandler', () => {
 		});
 
 		it('should handle refresh auto run docs callback failure', async () => {
-			(callbacks.refreshAutoRunDocs as any).mockRejectedValue(
-				new Error('Auto-run refresh failed')
-			);
+			(callbacks.refreshAutoRunDocs as any).mockRejectedValue(new Error('Auto-run refresh failed'));
 
 			handler.handleMessage(client, {
 				type: 'refresh_auto_run_docs',
@@ -881,11 +871,7 @@ describe('WebSocketMessageHandler', () => {
 			});
 
 			await vi.waitFor(() => {
-				expect(callbacks.selectSession).toHaveBeenCalledWith(
-					'session-2',
-					undefined,
-					undefined
-				);
+				expect(callbacks.selectSession).toHaveBeenCalledWith('session-2', undefined, undefined);
 			});
 		});
 	});

--- a/src/__tests__/main/web-server/managers/CallbackRegistry.test.ts
+++ b/src/__tests__/main/web-server/managers/CallbackRegistry.test.ts
@@ -457,7 +457,7 @@ describe('CallbackRegistry', () => {
 
 			await registry.selectSession('session-10');
 
-			expect(callback).toHaveBeenCalledWith('session-10', undefined);
+			expect(callback).toHaveBeenCalledWith('session-10', undefined, undefined);
 		});
 
 		it('passes sessionId and tabId arguments to the callback', async () => {
@@ -466,7 +466,7 @@ describe('CallbackRegistry', () => {
 
 			await registry.selectSession('session-10', 'tab-2');
 
-			expect(callback).toHaveBeenCalledWith('session-10', 'tab-2');
+			expect(callback).toHaveBeenCalledWith('session-10', 'tab-2', undefined);
 		});
 	});
 

--- a/src/__tests__/main/web-server/web-server-factory.test.ts
+++ b/src/__tests__/main/web-server/web-server-factory.test.ts
@@ -39,6 +39,7 @@ vi.mock('../../../main/web-server/WebServer', () => {
 			setOpenFileTabCallback = vi.fn();
 			setRefreshFileTreeCallback = vi.fn();
 			setRefreshAutoRunDocsCallback = vi.fn();
+			setConfigureAutoRunCallback = vi.fn();
 
 			constructor(port: number) {
 				this.port = port;

--- a/src/__tests__/main/web-server/web-server-factory.test.ts
+++ b/src/__tests__/main/web-server/web-server-factory.test.ts
@@ -36,6 +36,9 @@ vi.mock('../../../main/web-server/WebServer', () => {
 			setStarTabCallback = vi.fn();
 			setReorderTabCallback = vi.fn();
 			setToggleBookmarkCallback = vi.fn();
+			setOpenFileTabCallback = vi.fn();
+			setRefreshFileTreeCallback = vi.fn();
+			setRefreshAutoRunDocsCallback = vi.fn();
 
 			constructor(port: number) {
 				this.port = port;

--- a/src/__tests__/main/web-server/web-server-factory.test.ts
+++ b/src/__tests__/main/web-server/web-server-factory.test.ts
@@ -260,6 +260,13 @@ describe('web-server/web-server-factory', () => {
 			expect(server.setCloseTabCallback).toHaveBeenCalled();
 			expect(server.setRenameTabCallback).toHaveBeenCalled();
 		});
+
+		it('should register file and auto-run callbacks', () => {
+			expect(server.setOpenFileTabCallback).toHaveBeenCalled();
+			expect(server.setRefreshFileTreeCallback).toHaveBeenCalled();
+			expect(server.setRefreshAutoRunDocsCallback).toHaveBeenCalled();
+			expect(server.setConfigureAutoRunCallback).toHaveBeenCalled();
+		});
 	});
 
 	describe('getSessionsCallback behavior', () => {

--- a/src/__tests__/renderer/hooks/useRemoteIntegration.test.ts
+++ b/src/__tests__/renderer/hooks/useRemoteIntegration.test.ts
@@ -121,7 +121,20 @@ describe('useRemoteIntegration', () => {
 			onRemoteToggleBookmarkHandler = handler;
 			return () => {};
 		}),
+		onRemoteOpenFileTab: vi.fn().mockImplementation(() => {
+			return () => {};
+		}),
+		onRemoteRefreshFileTree: vi.fn().mockImplementation(() => {
+			return () => {};
+		}),
+		onRemoteRefreshAutoRunDocs: vi.fn().mockImplementation(() => {
+			return () => {};
+		}),
+		onRemoteConfigureAutoRun: vi.fn().mockImplementation(() => {
+			return () => {};
+		}),
 		sendRemoteNewTabResponse: vi.fn(),
+		sendRemoteConfigureAutoRunResponse: vi.fn(),
 	};
 
 	const mockLive = {

--- a/src/__tests__/shared/cli-server-discovery.test.ts
+++ b/src/__tests__/shared/cli-server-discovery.test.ts
@@ -1,0 +1,335 @@
+/**
+ * Tests for src/shared/cli-server-discovery.ts
+ *
+ * This module provides functions for managing the CLI server discovery file,
+ * used by the Electron main process and CLI to locate the running server.
+ * Tests mock Node.js fs and os modules to isolate behavior.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock the Node.js modules before importing the module under test
+vi.mock('fs', () => ({
+	readFileSync: vi.fn(),
+	writeFileSync: vi.fn(),
+	existsSync: vi.fn(),
+	mkdirSync: vi.fn(),
+	renameSync: vi.fn(),
+	unlinkSync: vi.fn(),
+}));
+
+vi.mock('os', () => ({
+	platform: vi.fn(),
+	homedir: vi.fn(),
+}));
+
+// Now import after mocks are set up
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import {
+	CliServerInfo,
+	writeCliServerInfo,
+	readCliServerInfo,
+	deleteCliServerInfo,
+	isCliServerRunning,
+} from '../../shared/cli-server-discovery';
+
+// Type assertions for mocked modules
+const mockFs = {
+	readFileSync: fs.readFileSync as ReturnType<typeof vi.fn>,
+	writeFileSync: fs.writeFileSync as ReturnType<typeof vi.fn>,
+	existsSync: fs.existsSync as ReturnType<typeof vi.fn>,
+	mkdirSync: fs.mkdirSync as ReturnType<typeof vi.fn>,
+	renameSync: fs.renameSync as ReturnType<typeof vi.fn>,
+	unlinkSync: fs.unlinkSync as ReturnType<typeof vi.fn>,
+};
+
+const mockOs = {
+	platform: os.platform as ReturnType<typeof vi.fn>,
+	homedir: os.homedir as ReturnType<typeof vi.fn>,
+};
+
+describe('cli-server-discovery', () => {
+	const sampleInfo: CliServerInfo = {
+		port: 3456,
+		token: 'abc-123-def-456',
+		pid: 12345,
+		startedAt: 1700000000000,
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+
+		// Default mock implementations
+		mockOs.platform.mockReturnValue('darwin');
+		mockOs.homedir.mockReturnValue('/Users/testuser');
+		mockFs.existsSync.mockReturnValue(true);
+		mockFs.readFileSync.mockReturnValue(JSON.stringify(sampleInfo));
+		mockFs.writeFileSync.mockReturnValue(undefined);
+		mockFs.mkdirSync.mockReturnValue(undefined);
+		mockFs.renameSync.mockReturnValue(undefined);
+		mockFs.unlinkSync.mockReturnValue(undefined);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	describe('getConfigDir (internal via path construction)', () => {
+		it('should construct correct config path for macOS', () => {
+			mockOs.platform.mockReturnValue('darwin');
+			mockOs.homedir.mockReturnValue('/Users/testuser');
+
+			readCliServerInfo();
+
+			expect(mockFs.readFileSync).toHaveBeenCalledWith(
+				path.join('/Users/testuser', 'Library', 'Application Support', 'maestro', 'cli-server.json'),
+				'utf-8'
+			);
+		});
+
+		it('should construct correct config path for Windows with APPDATA', () => {
+			mockOs.platform.mockReturnValue('win32');
+			mockOs.homedir.mockReturnValue('C:\\Users\\testuser');
+			const originalAppdata = process.env.APPDATA;
+			process.env.APPDATA = 'C:\\Users\\testuser\\AppData\\Roaming';
+
+			readCliServerInfo();
+
+			expect(mockFs.readFileSync).toHaveBeenCalledWith(
+				path.join('C:\\Users\\testuser\\AppData\\Roaming', 'maestro', 'cli-server.json'),
+				'utf-8'
+			);
+
+			process.env.APPDATA = originalAppdata;
+		});
+
+		it('should construct correct config path for Windows without APPDATA', () => {
+			mockOs.platform.mockReturnValue('win32');
+			mockOs.homedir.mockReturnValue('C:\\Users\\testuser');
+			const originalAppdata = process.env.APPDATA;
+			delete process.env.APPDATA;
+
+			readCliServerInfo();
+
+			expect(mockFs.readFileSync).toHaveBeenCalledWith(
+				path.join('C:\\Users\\testuser', 'AppData', 'Roaming', 'maestro', 'cli-server.json'),
+				'utf-8'
+			);
+
+			process.env.APPDATA = originalAppdata;
+		});
+
+		it('should construct correct config path for Linux with XDG_CONFIG_HOME', () => {
+			mockOs.platform.mockReturnValue('linux');
+			mockOs.homedir.mockReturnValue('/home/testuser');
+			const originalXdg = process.env.XDG_CONFIG_HOME;
+			process.env.XDG_CONFIG_HOME = '/home/testuser/.custom-config';
+
+			readCliServerInfo();
+
+			expect(mockFs.readFileSync).toHaveBeenCalledWith(
+				path.join('/home/testuser/.custom-config', 'maestro', 'cli-server.json'),
+				'utf-8'
+			);
+
+			process.env.XDG_CONFIG_HOME = originalXdg;
+		});
+
+		it('should construct correct config path for Linux without XDG_CONFIG_HOME', () => {
+			mockOs.platform.mockReturnValue('linux');
+			mockOs.homedir.mockReturnValue('/home/testuser');
+			const originalXdg = process.env.XDG_CONFIG_HOME;
+			delete process.env.XDG_CONFIG_HOME;
+
+			readCliServerInfo();
+
+			expect(mockFs.readFileSync).toHaveBeenCalledWith(
+				path.join('/home/testuser', '.config', 'maestro', 'cli-server.json'),
+				'utf-8'
+			);
+
+			process.env.XDG_CONFIG_HOME = originalXdg;
+		});
+	});
+
+	describe('writeCliServerInfo', () => {
+		it('should write the file with correct content via atomic rename', () => {
+			writeCliServerInfo(sampleInfo);
+
+			const expectedDir = path.join('/Users/testuser', 'Library', 'Application Support', 'maestro');
+			const expectedFile = path.join(expectedDir, 'cli-server.json');
+			const expectedTmp = expectedFile + '.tmp';
+
+			expect(mockFs.writeFileSync).toHaveBeenCalledWith(
+				expectedTmp,
+				JSON.stringify(sampleInfo, null, 2),
+				'utf-8'
+			);
+			expect(mockFs.renameSync).toHaveBeenCalledWith(expectedTmp, expectedFile);
+		});
+
+		it('should create directory if it does not exist', () => {
+			mockFs.existsSync.mockReturnValue(false);
+
+			writeCliServerInfo(sampleInfo);
+
+			expect(mockFs.mkdirSync).toHaveBeenCalledWith(
+				path.join('/Users/testuser', 'Library', 'Application Support', 'maestro'),
+				{ recursive: true }
+			);
+		});
+
+		it('should not create directory if it already exists', () => {
+			mockFs.existsSync.mockReturnValue(true);
+
+			writeCliServerInfo(sampleInfo);
+
+			expect(mockFs.mkdirSync).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('readCliServerInfo', () => {
+		it('should return null for missing file', () => {
+			mockFs.readFileSync.mockImplementation(() => {
+				throw new Error('ENOENT: no such file or directory');
+			});
+
+			const result = readCliServerInfo();
+			expect(result).toBeNull();
+		});
+
+		it('should return null for invalid JSON', () => {
+			mockFs.readFileSync.mockReturnValue('not valid json');
+
+			const result = readCliServerInfo();
+			expect(result).toBeNull();
+		});
+
+		it('should return parsed data for valid file', () => {
+			mockFs.readFileSync.mockReturnValue(JSON.stringify(sampleInfo));
+
+			const result = readCliServerInfo();
+			expect(result).toEqual(sampleInfo);
+			expect(result!.port).toBe(3456);
+			expect(result!.token).toBe('abc-123-def-456');
+			expect(result!.pid).toBe(12345);
+			expect(result!.startedAt).toBe(1700000000000);
+		});
+
+		it('should return null when port is missing', () => {
+			mockFs.readFileSync.mockReturnValue(JSON.stringify({
+				token: 'abc',
+				pid: 123,
+				startedAt: 1000,
+			}));
+
+			const result = readCliServerInfo();
+			expect(result).toBeNull();
+		});
+
+		it('should return null when token is not a string', () => {
+			mockFs.readFileSync.mockReturnValue(JSON.stringify({
+				port: 3456,
+				token: 123,
+				pid: 123,
+				startedAt: 1000,
+			}));
+
+			const result = readCliServerInfo();
+			expect(result).toBeNull();
+		});
+
+		it('should return null when pid is missing', () => {
+			mockFs.readFileSync.mockReturnValue(JSON.stringify({
+				port: 3456,
+				token: 'abc',
+				startedAt: 1000,
+			}));
+
+			const result = readCliServerInfo();
+			expect(result).toBeNull();
+		});
+
+		it('should return null when startedAt is missing', () => {
+			mockFs.readFileSync.mockReturnValue(JSON.stringify({
+				port: 3456,
+				token: 'abc',
+				pid: 123,
+			}));
+
+			const result = readCliServerInfo();
+			expect(result).toBeNull();
+		});
+	});
+
+	describe('deleteCliServerInfo', () => {
+		it('should remove the file', () => {
+			deleteCliServerInfo();
+
+			const expectedFile = path.join(
+				'/Users/testuser', 'Library', 'Application Support', 'maestro', 'cli-server.json'
+			);
+			expect(mockFs.unlinkSync).toHaveBeenCalledWith(expectedFile);
+		});
+
+		it('should not throw when file does not exist', () => {
+			mockFs.unlinkSync.mockImplementation(() => {
+				throw new Error('ENOENT: no such file or directory');
+			});
+
+			expect(() => deleteCliServerInfo()).not.toThrow();
+		});
+	});
+
+	describe('isCliServerRunning', () => {
+		it('should return true for current PID', () => {
+			mockFs.readFileSync.mockReturnValue(JSON.stringify(sampleInfo));
+
+			const originalKill = process.kill;
+			process.kill = vi.fn().mockReturnValue(true) as unknown as typeof process.kill;
+
+			const result = isCliServerRunning();
+
+			expect(result).toBe(true);
+			expect(process.kill).toHaveBeenCalledWith(12345, 0);
+
+			process.kill = originalKill;
+		});
+
+		it('should return false for non-existent PID', () => {
+			mockFs.readFileSync.mockReturnValue(JSON.stringify(sampleInfo));
+
+			const originalKill = process.kill;
+			process.kill = vi.fn().mockImplementation(() => {
+				throw new Error('ESRCH: No such process');
+			}) as unknown as typeof process.kill;
+
+			const result = isCliServerRunning();
+
+			expect(result).toBe(false);
+
+			process.kill = originalKill;
+		});
+
+		it('should return false when discovery file is missing', () => {
+			mockFs.readFileSync.mockImplementation(() => {
+				throw new Error('ENOENT: no such file or directory');
+			});
+
+			const result = isCliServerRunning();
+
+			expect(result).toBe(false);
+		});
+
+		it('should return false when discovery file has invalid data', () => {
+			mockFs.readFileSync.mockReturnValue('not json');
+
+			const result = isCliServerRunning();
+
+			expect(result).toBe(false);
+		});
+	});
+});

--- a/src/__tests__/shared/cli-server-discovery.test.ts
+++ b/src/__tests__/shared/cli-server-discovery.test.ts
@@ -85,7 +85,13 @@ describe('cli-server-discovery', () => {
 			readCliServerInfo();
 
 			expect(mockFs.readFileSync).toHaveBeenCalledWith(
-				path.join('/Users/testuser', 'Library', 'Application Support', 'maestro', 'cli-server.json'),
+				path.join(
+					'/Users/testuser',
+					'Library',
+					'Application Support',
+					'maestro',
+					'cli-server.json'
+				),
 				'utf-8'
 			);
 		});
@@ -244,45 +250,53 @@ describe('cli-server-discovery', () => {
 		});
 
 		it('should return null when port is missing', () => {
-			mockFs.readFileSync.mockReturnValue(JSON.stringify({
-				token: 'abc',
-				pid: 123,
-				startedAt: 1000,
-			}));
+			mockFs.readFileSync.mockReturnValue(
+				JSON.stringify({
+					token: 'abc',
+					pid: 123,
+					startedAt: 1000,
+				})
+			);
 
 			const result = readCliServerInfo();
 			expect(result).toBeNull();
 		});
 
 		it('should return null when token is not a string', () => {
-			mockFs.readFileSync.mockReturnValue(JSON.stringify({
-				port: 3456,
-				token: 123,
-				pid: 123,
-				startedAt: 1000,
-			}));
+			mockFs.readFileSync.mockReturnValue(
+				JSON.stringify({
+					port: 3456,
+					token: 123,
+					pid: 123,
+					startedAt: 1000,
+				})
+			);
 
 			const result = readCliServerInfo();
 			expect(result).toBeNull();
 		});
 
 		it('should return null when pid is missing', () => {
-			mockFs.readFileSync.mockReturnValue(JSON.stringify({
-				port: 3456,
-				token: 'abc',
-				startedAt: 1000,
-			}));
+			mockFs.readFileSync.mockReturnValue(
+				JSON.stringify({
+					port: 3456,
+					token: 'abc',
+					startedAt: 1000,
+				})
+			);
 
 			const result = readCliServerInfo();
 			expect(result).toBeNull();
 		});
 
 		it('should return null when startedAt is missing', () => {
-			mockFs.readFileSync.mockReturnValue(JSON.stringify({
-				port: 3456,
-				token: 'abc',
-				pid: 123,
-			}));
+			mockFs.readFileSync.mockReturnValue(
+				JSON.stringify({
+					port: 3456,
+					token: 'abc',
+					pid: 123,
+				})
+			);
 
 			const result = readCliServerInfo();
 			expect(result).toBeNull();
@@ -294,7 +308,11 @@ describe('cli-server-discovery', () => {
 			deleteCliServerInfo();
 
 			const expectedFile = path.join(
-				'/Users/testuser', 'Library', 'Application Support', 'maestro', 'cli-server.json'
+				'/Users/testuser',
+				'Library',
+				'Application Support',
+				'maestro',
+				'cli-server.json'
 			);
 			expect(mockFs.unlinkSync).toHaveBeenCalledWith(expectedFile);
 		});

--- a/src/__tests__/shared/cli-server-discovery.test.ts
+++ b/src/__tests__/shared/cli-server-discovery.test.ts
@@ -96,14 +96,20 @@ describe('cli-server-discovery', () => {
 			const originalAppdata = process.env.APPDATA;
 			process.env.APPDATA = 'C:\\Users\\testuser\\AppData\\Roaming';
 
-			readCliServerInfo();
+			try {
+				readCliServerInfo();
 
-			expect(mockFs.readFileSync).toHaveBeenCalledWith(
-				path.join('C:\\Users\\testuser\\AppData\\Roaming', 'maestro', 'cli-server.json'),
-				'utf-8'
-			);
-
-			process.env.APPDATA = originalAppdata;
+				expect(mockFs.readFileSync).toHaveBeenCalledWith(
+					path.join('C:\\Users\\testuser\\AppData\\Roaming', 'maestro', 'cli-server.json'),
+					'utf-8'
+				);
+			} finally {
+				if (originalAppdata === undefined) {
+					delete process.env.APPDATA;
+				} else {
+					process.env.APPDATA = originalAppdata;
+				}
+			}
 		});
 
 		it('should construct correct config path for Windows without APPDATA', () => {
@@ -112,14 +118,20 @@ describe('cli-server-discovery', () => {
 			const originalAppdata = process.env.APPDATA;
 			delete process.env.APPDATA;
 
-			readCliServerInfo();
+			try {
+				readCliServerInfo();
 
-			expect(mockFs.readFileSync).toHaveBeenCalledWith(
-				path.join('C:\\Users\\testuser', 'AppData', 'Roaming', 'maestro', 'cli-server.json'),
-				'utf-8'
-			);
-
-			process.env.APPDATA = originalAppdata;
+				expect(mockFs.readFileSync).toHaveBeenCalledWith(
+					path.join('C:\\Users\\testuser', 'AppData', 'Roaming', 'maestro', 'cli-server.json'),
+					'utf-8'
+				);
+			} finally {
+				if (originalAppdata === undefined) {
+					delete process.env.APPDATA;
+				} else {
+					process.env.APPDATA = originalAppdata;
+				}
+			}
 		});
 
 		it('should construct correct config path for Linux with XDG_CONFIG_HOME', () => {
@@ -128,14 +140,20 @@ describe('cli-server-discovery', () => {
 			const originalXdg = process.env.XDG_CONFIG_HOME;
 			process.env.XDG_CONFIG_HOME = '/home/testuser/.custom-config';
 
-			readCliServerInfo();
+			try {
+				readCliServerInfo();
 
-			expect(mockFs.readFileSync).toHaveBeenCalledWith(
-				path.join('/home/testuser/.custom-config', 'maestro', 'cli-server.json'),
-				'utf-8'
-			);
-
-			process.env.XDG_CONFIG_HOME = originalXdg;
+				expect(mockFs.readFileSync).toHaveBeenCalledWith(
+					path.join('/home/testuser/.custom-config', 'maestro', 'cli-server.json'),
+					'utf-8'
+				);
+			} finally {
+				if (originalXdg === undefined) {
+					delete process.env.XDG_CONFIG_HOME;
+				} else {
+					process.env.XDG_CONFIG_HOME = originalXdg;
+				}
+			}
 		});
 
 		it('should construct correct config path for Linux without XDG_CONFIG_HOME', () => {
@@ -144,14 +162,20 @@ describe('cli-server-discovery', () => {
 			const originalXdg = process.env.XDG_CONFIG_HOME;
 			delete process.env.XDG_CONFIG_HOME;
 
-			readCliServerInfo();
+			try {
+				readCliServerInfo();
 
-			expect(mockFs.readFileSync).toHaveBeenCalledWith(
-				path.join('/home/testuser', '.config', 'maestro', 'cli-server.json'),
-				'utf-8'
-			);
-
-			process.env.XDG_CONFIG_HOME = originalXdg;
+				expect(mockFs.readFileSync).toHaveBeenCalledWith(
+					path.join('/home/testuser', '.config', 'maestro', 'cli-server.json'),
+					'utf-8'
+				);
+			} finally {
+				if (originalXdg === undefined) {
+					delete process.env.XDG_CONFIG_HOME;
+				} else {
+					process.env.XDG_CONFIG_HOME = originalXdg;
+				}
+			}
 		});
 	});
 

--- a/src/__tests__/shared/cli-server-discovery.test.ts
+++ b/src/__tests__/shared/cli-server-discovery.test.ts
@@ -333,12 +333,14 @@ describe('cli-server-discovery', () => {
 			const originalKill = process.kill;
 			process.kill = vi.fn().mockReturnValue(true) as unknown as typeof process.kill;
 
-			const result = isCliServerRunning();
+			try {
+				const result = isCliServerRunning();
 
-			expect(result).toBe(true);
-			expect(process.kill).toHaveBeenCalledWith(12345, 0);
-
-			process.kill = originalKill;
+				expect(result).toBe(true);
+				expect(process.kill).toHaveBeenCalledWith(12345, 0);
+			} finally {
+				process.kill = originalKill;
+			}
 		});
 
 		it('should return false for non-existent PID', () => {
@@ -349,11 +351,13 @@ describe('cli-server-discovery', () => {
 				throw new Error('ESRCH: No such process');
 			}) as unknown as typeof process.kill;
 
-			const result = isCliServerRunning();
+			try {
+				const result = isCliServerRunning();
 
-			expect(result).toBe(false);
-
-			process.kill = originalKill;
+				expect(result).toBe(false);
+			} finally {
+				process.kill = originalKill;
+			}
 		});
 
 		it('should return false when discovery file is missing', () => {

--- a/src/cli/commands/auto-run.ts
+++ b/src/cli/commands/auto-run.ts
@@ -1,0 +1,94 @@
+// Auto-run command - configure and optionally launch an auto-run session in Maestro
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { withMaestroClient, resolveSessionId } from '../services/maestro-client';
+
+interface AutoRunOptions {
+	session?: string;
+	prompt?: string;
+	loop?: boolean;
+	maxLoops?: string;
+	saveAs?: string;
+	launch?: boolean;
+	resetOnCompletion?: boolean;
+}
+
+export async function autoRun(docs: string[], options: AutoRunOptions): Promise<void> {
+	if (!docs || docs.length === 0) {
+		console.error('Error: At least one document path is required');
+		process.exit(1);
+	}
+
+	// Resolve and validate each document path
+	const resolvedPaths: string[] = [];
+	for (const doc of docs) {
+		const absolutePath = path.resolve(doc);
+
+		if (!fs.existsSync(absolutePath)) {
+			console.error(`Error: File not found: ${absolutePath}`);
+			process.exit(1);
+		}
+
+		if (path.extname(absolutePath).toLowerCase() !== '.md') {
+			console.error(`Error: File must be a .md file: ${absolutePath}`);
+			process.exit(1);
+		}
+
+		resolvedPaths.push(absolutePath);
+	}
+
+	const sessionId = resolveSessionId(options);
+
+	const documents = resolvedPaths.map((d) => ({
+		filename: path.basename(d),
+		resetOnCompletion: options.resetOnCompletion || false,
+	}));
+
+	const loopEnabled = options.loop || (options.maxLoops !== undefined);
+	const maxLoops = options.maxLoops !== undefined ? parseInt(options.maxLoops, 10) : undefined;
+
+	if (maxLoops !== undefined && (isNaN(maxLoops) || maxLoops < 1)) {
+		console.error('Error: --max-loops must be a positive integer');
+		process.exit(1);
+	}
+
+	try {
+		const result = await withMaestroClient(async (client) => {
+			return client.sendCommand<{
+				type: string;
+				success: boolean;
+				playbookId?: string;
+				error?: string;
+			}>(
+				{
+					type: 'configure_auto_run',
+					sessionId,
+					documents,
+					prompt: options.prompt,
+					loopEnabled: loopEnabled || undefined,
+					maxLoops,
+					saveAsPlaybook: options.saveAs,
+					launch: options.launch,
+				},
+				'configure_auto_run_result'
+			);
+		});
+
+		if (result.success) {
+			if (options.saveAs) {
+				console.log(`Playbook '${options.saveAs}' saved${result.playbookId ? ` (ID: ${result.playbookId})` : ''}`);
+			} else if (options.launch) {
+				console.log(`Auto-run launched with ${documents.length} document${documents.length !== 1 ? 's' : ''}`);
+			} else {
+				console.log(`Auto-run configured with ${documents.length} document${documents.length !== 1 ? 's' : ''}`);
+			}
+		} else {
+			console.error(`Error: ${result.error || 'Failed to configure auto-run'}`);
+			process.exit(1);
+		}
+	} catch (error) {
+		console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+		process.exit(1);
+	}
+}

--- a/src/cli/commands/auto-run.ts
+++ b/src/cli/commands/auto-run.ts
@@ -45,7 +45,7 @@ export async function autoRun(docs: string[], options: AutoRunOptions): Promise<
 		resetOnCompletion: options.resetOnCompletion || false,
 	}));
 
-	const loopEnabled = options.loop || (options.maxLoops !== undefined);
+	const loopEnabled = options.loop || options.maxLoops !== undefined;
 	const maxLoops = options.maxLoops !== undefined ? parseInt(options.maxLoops, 10) : undefined;
 
 	if (maxLoops !== undefined && (isNaN(maxLoops) || maxLoops < 1)) {
@@ -77,11 +77,17 @@ export async function autoRun(docs: string[], options: AutoRunOptions): Promise<
 
 		if (result.success) {
 			if (options.saveAs) {
-				console.log(`Playbook '${options.saveAs}' saved${result.playbookId ? ` (ID: ${result.playbookId})` : ''}`);
+				console.log(
+					`Playbook '${options.saveAs}' saved${result.playbookId ? ` (ID: ${result.playbookId})` : ''}`
+				);
 			} else if (options.launch) {
-				console.log(`Auto-run launched with ${documents.length} document${documents.length !== 1 ? 's' : ''}`);
+				console.log(
+					`Auto-run launched with ${documents.length} document${documents.length !== 1 ? 's' : ''}`
+				);
 			} else {
-				console.log(`Auto-run configured with ${documents.length} document${documents.length !== 1 ? 's' : ''}`);
+				console.log(
+					`Auto-run configured with ${documents.length} document${documents.length !== 1 ? 's' : ''}`
+				);
 			}
 		} else {
 			console.error(`Error: ${result.error || 'Failed to configure auto-run'}`);

--- a/src/cli/commands/auto-run.ts
+++ b/src/cli/commands/auto-run.ts
@@ -41,7 +41,7 @@ export async function autoRun(docs: string[], options: AutoRunOptions): Promise<
 	const sessionId = resolveSessionId(options);
 
 	const documents = resolvedPaths.map((d) => ({
-		filename: path.basename(d),
+		filename: d,
 		resetOnCompletion: options.resetOnCompletion || false,
 	}));
 

--- a/src/cli/commands/auto-run.ts
+++ b/src/cli/commands/auto-run.ts
@@ -46,7 +46,12 @@ export async function autoRun(docs: string[], options: AutoRunOptions): Promise<
 	}));
 
 	const loopEnabled = options.loop || options.maxLoops !== undefined;
-	const maxLoops = options.maxLoops !== undefined ? parseInt(options.maxLoops, 10) : undefined;
+	const maxLoops =
+		options.maxLoops !== undefined
+			? Number.isInteger(Number(options.maxLoops)) && Number(options.maxLoops) > 0
+				? Number(options.maxLoops)
+				: NaN
+			: undefined;
 
 	if (maxLoops !== undefined && (isNaN(maxLoops) || maxLoops < 1)) {
 		console.error('Error: --max-loops must be a positive integer');

--- a/src/cli/commands/list-sessions.ts
+++ b/src/cli/commands/list-sessions.ts
@@ -1,7 +1,9 @@
 // List sessions command
-// Lists agent sessions (Claude Code) for a given Maestro agent
+// Lists agent sessions for a given Maestro agent.
+// Claude Code: reads rich session data from ~/.claude/projects/ on disk.
+// Other agents (Codex, OpenCode, etc.): lists aiTabs from Maestro's session store.
 
-import { resolveAgentId, getSessionById } from '../services/storage';
+import { resolveAgentId, getSessionById, readSessions } from '../services/storage';
 import { listClaudeSessions } from '../services/agent-sessions';
 import { formatSessions, formatError, SessionDisplay } from '../output/formatter';
 import type { ToolType } from '../../shared/types';
@@ -13,11 +15,103 @@ interface ListSessionsOptions {
 	json?: boolean;
 }
 
-const SUPPORTED_TYPES: ToolType[] = ['claude-code'];
+// Agent types with rich disk-based session listing
+const DISK_SESSION_TYPES: ToolType[] = ['claude-code'];
+
+/**
+ * List sessions from Maestro's aiTabs for non-Claude agents.
+ * Reads stored session data (aiTabs with agentSessionId, usage, etc.)
+ * and formats it as SessionDisplay entries.
+ */
+function listTabSessions(
+	agentId: string,
+	options: { limit: number; skip: number; search?: string }
+): { sessions: SessionDisplay[]; totalCount: number; filteredCount: number } {
+	const sessions = readSessions();
+	const agent = sessions.find((s) => s.id === agentId);
+	if (!agent) {
+		return { sessions: [], totalCount: 0, filteredCount: 0 };
+	}
+
+	const aiTabs = (agent as any).aiTabs as
+		| Array<{
+				id: string;
+				agentSessionId?: string;
+				name?: string;
+				starred?: boolean;
+				createdAt?: number;
+				usageStats?: {
+					totalCostUsd?: number;
+					inputTokens?: number;
+					outputTokens?: number;
+				};
+				logs?: Array<{ text?: string; source?: string; timestamp?: number }>;
+				state?: string;
+		  }>
+		| undefined;
+
+	if (!aiTabs || aiTabs.length === 0) {
+		return { sessions: [], totalCount: 0, filteredCount: 0 };
+	}
+
+	let tabSessions: SessionDisplay[] = aiTabs
+		.filter((tab) => tab.agentSessionId)
+		.map((tab) => {
+			const logs = tab.logs || [];
+			const messageCount = logs.filter((l) => l.source === 'stdout' || l.source === 'stdin').length;
+			const firstStdout = logs.find((l) => l.source === 'stdout');
+			const firstMessage = firstStdout?.text?.slice(0, 200) || '';
+			const costUsd = tab.usageStats?.totalCostUsd || 0;
+
+			let durationSeconds = 0;
+			if (logs.length >= 2) {
+				const first = logs[0]?.timestamp;
+				const last = logs[logs.length - 1]?.timestamp;
+				if (first && last) {
+					durationSeconds = Math.max(0, Math.floor((last - first) / 1000));
+				}
+			}
+
+			const modifiedAt =
+				logs.length > 0 && logs[logs.length - 1]?.timestamp
+					? new Date(logs[logs.length - 1].timestamp!).toISOString()
+					: tab.createdAt
+						? new Date(tab.createdAt).toISOString()
+						: new Date().toISOString();
+
+			return {
+				sessionId: tab.agentSessionId!,
+				sessionName: tab.name,
+				modifiedAt,
+				firstMessage,
+				messageCount,
+				costUsd,
+				durationSeconds,
+				starred: tab.starred,
+			};
+		});
+
+	tabSessions.sort((a, b) => new Date(b.modifiedAt).getTime() - new Date(a.modifiedAt).getTime());
+
+	const totalCount = tabSessions.length;
+
+	if (options.search) {
+		const searchLower = options.search.toLowerCase();
+		tabSessions = tabSessions.filter((s) => {
+			if (s.sessionName?.toLowerCase().includes(searchLower)) return true;
+			if (s.firstMessage.toLowerCase().includes(searchLower)) return true;
+			return false;
+		});
+	}
+
+	const filteredCount = tabSessions.length;
+	const paginated = tabSessions.slice(options.skip, options.skip + options.limit);
+
+	return { sessions: paginated, totalCount, filteredCount };
+}
 
 export function listSessions(agentIdArg: string, options: ListSessionsOptions): void {
 	try {
-		// Resolve agent ID (supports partial IDs)
 		const agentId = resolveAgentId(agentIdArg);
 		const agent = getSessionById(agentId);
 
@@ -32,18 +126,6 @@ export function listSessions(agentIdArg: string, options: ListSessionsOptions): 
 				);
 			} else {
 				console.error(formatError(`Agent not found: ${agentIdArg}`));
-			}
-			process.exit(1);
-		}
-
-		if (!SUPPORTED_TYPES.includes(agent.toolType)) {
-			const msg = `Session listing is not supported for agent type "${agent.toolType}". Supported: ${SUPPORTED_TYPES.join(', ')}`;
-			if (options.json) {
-				console.log(
-					JSON.stringify({ success: false, error: msg, code: 'AGENT_UNSUPPORTED' }, null, 2)
-				);
-			} else {
-				console.error(formatError(msg));
 			}
 			process.exit(1);
 		}
@@ -74,12 +156,32 @@ export function listSessions(agentIdArg: string, options: ListSessionsOptions): 
 			process.exit(1);
 		}
 
-		const projectPath = agent.cwd;
-		const result = listClaudeSessions(projectPath, {
-			limit,
-			skip,
-			search: options.search,
-		});
+		// Use disk-based reader for Claude Code, tab-based reader for other agents
+		let result: { sessions: SessionDisplay[]; totalCount: number; filteredCount: number };
+
+		if (DISK_SESSION_TYPES.includes(agent.toolType)) {
+			const claudeResult = listClaudeSessions(agent.cwd, {
+				limit,
+				skip,
+				search: options.search,
+			});
+			result = {
+				totalCount: claudeResult.totalCount,
+				filteredCount: claudeResult.filteredCount,
+				sessions: claudeResult.sessions.map((s) => ({
+					sessionId: s.sessionId,
+					sessionName: s.sessionName,
+					modifiedAt: s.modifiedAt,
+					firstMessage: s.firstMessage,
+					messageCount: s.messageCount,
+					costUsd: s.costUsd,
+					durationSeconds: s.durationSeconds,
+					starred: s.starred,
+				})),
+			};
+		} else {
+			result = listTabSessions(agentId, { limit, skip, search: options.search });
+		}
 
 		if (options.json) {
 			console.log(
@@ -97,19 +199,9 @@ export function listSessions(agentIdArg: string, options: ListSessionsOptions): 
 				)
 			);
 		} else {
-			const displaySessions: SessionDisplay[] = result.sessions.map((s) => ({
-				sessionId: s.sessionId,
-				sessionName: s.sessionName,
-				modifiedAt: s.modifiedAt,
-				firstMessage: s.firstMessage,
-				messageCount: s.messageCount,
-				costUsd: s.costUsd,
-				durationSeconds: s.durationSeconds,
-				starred: s.starred,
-			}));
 			console.log(
 				formatSessions(
-					displaySessions,
+					result.sessions,
 					agent.name,
 					result.totalCount,
 					result.filteredCount,

--- a/src/cli/commands/open-file.ts
+++ b/src/cli/commands/open-file.ts
@@ -9,14 +9,25 @@ interface OpenFileOptions {
 }
 
 export async function openFile(filePath: string, options: OpenFileOptions): Promise<void> {
-	const absolutePath = path.resolve(filePath);
+	const sessionId = resolveSessionId(options);
+
+	// Resolve relative paths against the agent's working directory, not the CLI's cwd.
+	// This allows `open-file README.md -s <id>` to open files from the agent's project.
+	let absolutePath: string;
+	if (path.isAbsolute(filePath)) {
+		absolutePath = filePath;
+	} else {
+		// Try agent's cwd first by reading session info
+		const { getSessionById } = await import('../services/storage');
+		const session = getSessionById(sessionId);
+		const basePath = session?.cwd || process.cwd();
+		absolutePath = path.resolve(basePath, filePath);
+	}
 
 	if (!fs.existsSync(absolutePath)) {
 		console.error(`Error: File not found: ${absolutePath}`);
 		process.exit(1);
 	}
-
-	const sessionId = resolveSessionId(options);
 
 	try {
 		const result = await withMaestroClient(async (client) => {

--- a/src/cli/commands/open-file.ts
+++ b/src/cli/commands/open-file.ts
@@ -1,0 +1,39 @@
+// Open file command - open a file as a preview tab in the Maestro desktop app
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { withMaestroClient, resolveSessionId } from '../services/maestro-client';
+
+interface OpenFileOptions {
+	session?: string;
+}
+
+export async function openFile(filePath: string, options: OpenFileOptions): Promise<void> {
+	const absolutePath = path.resolve(filePath);
+
+	if (!fs.existsSync(absolutePath)) {
+		console.error(`Error: File not found: ${absolutePath}`);
+		process.exit(1);
+	}
+
+	const sessionId = resolveSessionId(options);
+
+	try {
+		const result = await withMaestroClient(async (client) => {
+			return client.sendCommand<{ type: string; success: boolean; error?: string }>(
+				{ type: 'open_file_tab', sessionId, filePath: absolutePath },
+				'open_file_tab_result'
+			);
+		});
+
+		if (result.success) {
+			console.log(`Opened ${path.basename(absolutePath)} in Maestro`);
+		} else {
+			console.error(`Error: ${result.error || 'Failed to open file'}`);
+			process.exit(1);
+		}
+	} catch (error) {
+		console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+		process.exit(1);
+	}
+}

--- a/src/cli/commands/refresh-auto-run.ts
+++ b/src/cli/commands/refresh-auto-run.ts
@@ -1,0 +1,30 @@
+// Refresh auto-run command - refresh Auto Run documents in the Maestro desktop app
+
+import { withMaestroClient, resolveSessionId } from '../services/maestro-client';
+
+interface RefreshAutoRunOptions {
+	session?: string;
+}
+
+export async function refreshAutoRun(options: RefreshAutoRunOptions): Promise<void> {
+	const sessionId = resolveSessionId(options);
+
+	try {
+		const result = await withMaestroClient(async (client) => {
+			return client.sendCommand<{ type: string; success: boolean; error?: string }>(
+				{ type: 'refresh_auto_run_docs', sessionId },
+				'refresh_auto_run_docs_result'
+			);
+		});
+
+		if (result.success) {
+			console.log('Auto Run documents refreshed');
+		} else {
+			console.error(`Error: ${result.error || 'Failed to refresh Auto Run documents'}`);
+			process.exit(1);
+		}
+	} catch (error) {
+		console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+		process.exit(1);
+	}
+}

--- a/src/cli/commands/refresh-files.ts
+++ b/src/cli/commands/refresh-files.ts
@@ -1,0 +1,30 @@
+// Refresh files command - refresh the file tree in the Maestro desktop app
+
+import { withMaestroClient, resolveSessionId } from '../services/maestro-client';
+
+interface RefreshFilesOptions {
+	session?: string;
+}
+
+export async function refreshFiles(options: RefreshFilesOptions): Promise<void> {
+	const sessionId = resolveSessionId(options);
+
+	try {
+		const result = await withMaestroClient(async (client) => {
+			return client.sendCommand<{ type: string; success: boolean; error?: string }>(
+				{ type: 'refresh_file_tree', sessionId },
+				'refresh_file_tree_result'
+			);
+		});
+
+		if (result.success) {
+			console.log('File tree refreshed');
+		} else {
+			console.error(`Error: ${result.error || 'Failed to refresh file tree'}`);
+			process.exit(1);
+		}
+	} catch (error) {
+		console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+		process.exit(1);
+	}
+}

--- a/src/cli/commands/send.ts
+++ b/src/cli/commands/send.ts
@@ -109,8 +109,26 @@ export async function send(
 		process.exit(1);
 	}
 
-	// Spawn agent — spawnAgent handles --resume vs --session-id internally
-	const result = await spawnAgent(agent.toolType, agent.cwd, message, options.session, {
+	// Determine which agent session to resume:
+	// 1. Explicit --session flag takes priority
+	// 2. Otherwise, use the active tab's agentSessionId to avoid creating duplicate sessions
+	// 3. If no active tab session exists, spawnAgent creates a fresh isolated session
+	let agentSessionId = options.session;
+	if (!agentSessionId) {
+		const aiTabs = (agent as any).aiTabs as
+			| Array<{ id: string; agentSessionId?: string }>
+			| undefined;
+		const activeTabId = (agent as any).activeTabId as string | undefined;
+		if (aiTabs && activeTabId) {
+			const activeTab = aiTabs.find((t) => t.id === activeTabId);
+			if (activeTab?.agentSessionId) {
+				agentSessionId = activeTab.agentSessionId;
+			}
+		}
+	}
+
+	// Spawn agent — spawnAgent handles --resume vs fresh session internally
+	const result = await spawnAgent(agent.toolType, agent.cwd, message, agentSessionId, {
 		readOnlyMode: options.readOnly,
 	});
 	const response = buildResponse(agentId, agent.name, result, agent.toolType);

--- a/src/cli/commands/send.ts
+++ b/src/cli/commands/send.ts
@@ -5,11 +5,13 @@ import { spawnAgent, detectAgent, type AgentResult } from '../services/agent-spa
 import { resolveAgentId, getSessionById } from '../services/storage';
 import { estimateContextUsage } from '../../main/parsers/usage-aggregator';
 import { getAgentDefinition } from '../../main/agents/definitions';
+import { withMaestroClient } from '../services/maestro-client';
 import type { ToolType } from '../../shared/types';
 
 interface SendOptions {
 	session?: string;
 	readOnly?: boolean;
+	tab?: boolean;
 }
 
 interface SendResponse {
@@ -117,5 +119,19 @@ export async function send(
 
 	if (!result.success) {
 		process.exit(1);
+	}
+
+	// If --tab flag is set, focus the session tab in Maestro desktop
+	if (options.tab) {
+		try {
+			await withMaestroClient(async (client) => {
+				await client.sendCommand(
+					{ type: 'select_session', sessionId: agentId, focus: true },
+					'select_session_result'
+				);
+			});
+		} catch {
+			console.error('Warning: Could not focus session tab in Maestro desktop (app may not be running)');
+		}
 	}
 }

--- a/src/cli/commands/send.ts
+++ b/src/cli/commands/send.ts
@@ -131,7 +131,9 @@ export async function send(
 				);
 			});
 		} catch {
-			console.error('Warning: Could not focus session tab in Maestro desktop (app may not be running)');
+			console.error(
+				'Warning: Could not focus session tab in Maestro desktop (app may not be running)'
+			);
 		}
 	}
 }

--- a/src/cli/commands/status.ts
+++ b/src/cli/commands/status.ts
@@ -1,0 +1,39 @@
+// Status command - check if Maestro desktop app is running and reachable
+
+import { readCliServerInfo, isCliServerRunning } from '../../shared/cli-server-discovery';
+import { withMaestroClient } from '../services/maestro-client';
+
+export async function status(): Promise<void> {
+	const info = readCliServerInfo();
+	if (!info) {
+		console.log('Maestro desktop app is not running');
+		process.exit(1);
+	}
+
+	if (!isCliServerRunning()) {
+		console.log('Maestro discovery file is stale (app may have crashed)');
+		process.exit(1);
+	}
+
+	try {
+		// Ping to verify WebSocket connectivity
+		await withMaestroClient(async (client) => {
+			await client.sendCommand<{ type: string }>(
+				{ type: 'ping' },
+				'pong'
+			);
+
+			// Get session count
+			const sessionsResult = await client.sendCommand<{ type: string; sessions: unknown[] }>(
+				{ type: 'get_sessions' },
+				'sessions_list'
+			);
+
+			const sessionCount = sessionsResult.sessions?.length ?? 0;
+			console.log(`Maestro is running on port ${info.port} with ${sessionCount} session${sessionCount !== 1 ? 's' : ''}`);
+		});
+	} catch (error) {
+		console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+		process.exit(1);
+	}
+}

--- a/src/cli/commands/status.ts
+++ b/src/cli/commands/status.ts
@@ -18,10 +18,7 @@ export async function status(): Promise<void> {
 	try {
 		// Ping to verify WebSocket connectivity
 		await withMaestroClient(async (client) => {
-			await client.sendCommand<{ type: string }>(
-				{ type: 'ping' },
-				'pong'
-			);
+			await client.sendCommand<{ type: string }>({ type: 'ping' }, 'pong');
 
 			// Get session count
 			const sessionsResult = await client.sendCommand<{ type: string; sessions: unknown[] }>(
@@ -30,7 +27,9 @@ export async function status(): Promise<void> {
 			);
 
 			const sessionCount = sessionsResult.sessions?.length ?? 0;
-			console.log(`Maestro is running on port ${info.port} with ${sessionCount} session${sessionCount !== 1 ? 's' : ''}`);
+			console.log(
+				`Maestro is running on port ${info.port} with ${sessionCount} session${sessionCount !== 1 ? 's' : ''}`
+			);
 		});
 	} catch (error) {
 		console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);

--- a/src/cli/commands/status.ts
+++ b/src/cli/commands/status.ts
@@ -28,7 +28,7 @@ export async function status(): Promise<void> {
 
 			const sessionCount = sessionsResult.sessions?.length ?? 0;
 			console.log(
-				`Maestro is running on port ${info.port} with ${sessionCount} session${sessionCount !== 1 ? 's' : ''}`
+				`Maestro is running on port ${info.port} with ${sessionCount} agent${sessionCount !== 1 ? 's' : ''}`
 			);
 		});
 	} catch (error) {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -15,6 +15,7 @@ import { send } from './commands/send';
 import { listSessions } from './commands/list-sessions';
 import { openFile } from './commands/open-file';
 import { refreshFiles } from './commands/refresh-files';
+import { refreshAutoRun } from './commands/refresh-auto-run';
 
 // Read version from package.json at runtime
 function getVersion(): string {
@@ -125,5 +126,12 @@ program
 	.description('Refresh the file tree in the Maestro desktop app')
 	.option('-s, --session <id>', 'Target session (defaults to active)')
 	.action(refreshFiles);
+
+// Refresh auto-run command - refresh Auto Run documents in the Maestro desktop app
+program
+	.command('refresh-auto-run')
+	.description('Refresh Auto Run documents in the Maestro desktop app')
+	.option('-s, --session <id>', 'Target session (defaults to active)')
+	.action(refreshAutoRun);
 
 program.parse();

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -17,6 +17,7 @@ import { openFile } from './commands/open-file';
 import { refreshFiles } from './commands/refresh-files';
 import { refreshAutoRun } from './commands/refresh-auto-run';
 import { status } from './commands/status';
+import { autoRun } from './commands/auto-run';
 
 // Read version from package.json at runtime
 function getVersion(): string {
@@ -135,6 +136,19 @@ program
 	.description('Refresh Auto Run documents in the Maestro desktop app')
 	.option('-s, --session <id>', 'Target session (defaults to active)')
 	.action(refreshAutoRun);
+
+// Auto-run command - configure and optionally launch an auto-run session
+program
+	.command('auto-run <docs...>')
+	.description('Configure and optionally launch an auto-run with documents')
+	.option('-s, --session <id>', 'Target session (defaults to active)')
+	.option('-p, --prompt <text>', 'Custom prompt for the auto-run')
+	.option('--loop', 'Enable looping')
+	.option('--max-loops <n>', 'Maximum loop count (implies --loop)')
+	.option('--save-as <name>', 'Save as a playbook with this name (don\'t launch)')
+	.option('--launch', 'Start the auto-run immediately (default: just configure)')
+	.option('--reset-on-completion', 'Enable reset-on-completion for all documents')
+	.action(autoRun);
 
 // Status command - check if Maestro desktop app is running and reachable
 program

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -16,6 +16,7 @@ import { listSessions } from './commands/list-sessions';
 import { openFile } from './commands/open-file';
 import { refreshFiles } from './commands/refresh-files';
 import { refreshAutoRun } from './commands/refresh-auto-run';
+import { status } from './commands/status';
 
 // Read version from package.json at runtime
 function getVersion(): string {
@@ -134,5 +135,11 @@ program
 	.description('Refresh Auto Run documents in the Maestro desktop app')
 	.option('-s, --session <id>', 'Target session (defaults to active)')
 	.action(refreshAutoRun);
+
+// Status command - check if Maestro desktop app is running and reachable
+program
+	.command('status')
+	.description('Check if the Maestro desktop app is running and reachable')
+	.action(status);
 
 program.parse();

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -14,6 +14,7 @@ import { cleanPlaybooks } from './commands/clean-playbooks';
 import { send } from './commands/send';
 import { listSessions } from './commands/list-sessions';
 import { openFile } from './commands/open-file';
+import { refreshFiles } from './commands/refresh-files';
 
 // Read version from package.json at runtime
 function getVersion(): string {
@@ -117,5 +118,12 @@ program
 	.description('Open a file as a preview tab in the Maestro desktop app')
 	.option('-s, --session <id>', 'Target session (defaults to active)')
 	.action(openFile);
+
+// Refresh files command - refresh the file tree in the Maestro desktop app
+program
+	.command('refresh-files')
+	.description('Refresh the file tree in the Maestro desktop app')
+	.option('-s, --session <id>', 'Target session (defaults to active)')
+	.action(refreshFiles);
 
 program.parse();

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -111,6 +111,7 @@ program
 	.description('Send a message to an agent and get a JSON response')
 	.option('-s, --session <id>', 'Resume an existing agent session (for multi-turn conversations)')
 	.option('-r, --read-only', 'Run in read-only/plan mode (agent cannot modify files)')
+	.option('-t, --tab', 'Open/focus the session tab in Maestro desktop')
 	.action(send);
 
 // Open file command - open a file in the Maestro desktop app

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -13,6 +13,7 @@ import { showAgent } from './commands/show-agent';
 import { cleanPlaybooks } from './commands/clean-playbooks';
 import { send } from './commands/send';
 import { listSessions } from './commands/list-sessions';
+import { openFile } from './commands/open-file';
 
 // Read version from package.json at runtime
 function getVersion(): string {
@@ -109,5 +110,12 @@ program
 	.option('-s, --session <id>', 'Resume an existing agent session (for multi-turn conversations)')
 	.option('-r, --read-only', 'Run in read-only/plan mode (agent cannot modify files)')
 	.action(send);
+
+// Open file command - open a file in the Maestro desktop app
+program
+	.command('open-file <file-path>')
+	.description('Open a file as a preview tab in the Maestro desktop app')
+	.option('-s, --session <id>', 'Target session (defaults to active)')
+	.action(openFile);
 
 program.parse();

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -145,7 +145,7 @@ program
 	.option('-p, --prompt <text>', 'Custom prompt for the auto-run')
 	.option('--loop', 'Enable looping')
 	.option('--max-loops <n>', 'Maximum loop count (implies --loop)')
-	.option('--save-as <name>', 'Save as a playbook with this name (don\'t launch)')
+	.option('--save-as <name>', "Save as a playbook with this name (don't launch)")
 	.option('--launch', 'Start the auto-run immediately (default: just configure)')
 	.option('--reset-on-completion', 'Enable reset-on-completion for all documents')
 	.action(autoRun);

--- a/src/cli/services/maestro-client.ts
+++ b/src/cli/services/maestro-client.ts
@@ -170,7 +170,7 @@ export function resolveSessionId(options: { session?: string }): string {
 
 	const sessions = readSessions();
 	if (sessions.length === 0) {
-		console.error('Error: No sessions found. Create a session in Maestro first.');
+		console.error('Error: No agents found. Create an agent in Maestro first.');
 		process.exit(1);
 	}
 

--- a/src/cli/services/maestro-client.ts
+++ b/src/cli/services/maestro-client.ts
@@ -3,6 +3,7 @@
 
 import WebSocket from 'ws';
 import { readCliServerInfo, isCliServerRunning } from '../../shared/cli-server-discovery';
+import { readSessions } from './storage';
 
 const CONNECT_TIMEOUT_MS = 5000;
 const DEFAULT_COMMAND_TIMEOUT_MS = 10000;
@@ -129,6 +130,24 @@ export class MaestroClient {
 			}
 		});
 	}
+}
+
+/**
+ * Resolve session ID from CLI options.
+ * Uses the provided --session value, or falls back to the first available session.
+ */
+export function resolveSessionId(options: { session?: string }): string {
+	if (options.session) {
+		return options.session;
+	}
+
+	const sessions = readSessions();
+	if (sessions.length === 0) {
+		console.error('Error: No sessions found. Create a session in Maestro first.');
+		process.exit(1);
+	}
+
+	return sessions[0].id;
 }
 
 /**

--- a/src/cli/services/maestro-client.ts
+++ b/src/cli/services/maestro-client.ts
@@ -1,0 +1,146 @@
+// CLI WebSocket client for communicating with the running Maestro desktop app.
+// Uses the discovery file from cli-server-discovery to find the server.
+
+import WebSocket from 'ws';
+import { readCliServerInfo, isCliServerRunning } from '../../shared/cli-server-discovery';
+
+const CONNECT_TIMEOUT_MS = 5000;
+const DEFAULT_COMMAND_TIMEOUT_MS = 10000;
+
+interface PendingRequest {
+	resolve: (value: unknown) => void;
+	reject: (reason: Error) => void;
+	timeout: ReturnType<typeof setTimeout>;
+	expectedType: string;
+}
+
+export class MaestroClient {
+	private ws: WebSocket | null = null;
+	private pendingRequests: Map<string, PendingRequest> = new Map();
+
+	/**
+	 * Connect to the running Maestro app.
+	 * Throws if the app is not running or connection fails.
+	 */
+	async connect(): Promise<void> {
+		const info = readCliServerInfo();
+		if (!info) {
+			throw new Error('Maestro desktop app is not running');
+		}
+
+		if (!isCliServerRunning()) {
+			throw new Error('Maestro discovery file is stale (app may have crashed)');
+		}
+
+		const url = `ws://localhost:${info.port}/${info.token}/ws`;
+
+		return new Promise<void>((resolve, reject) => {
+			const timeout = setTimeout(() => {
+				if (this.ws) {
+					this.ws.close();
+					this.ws = null;
+				}
+				reject(new Error('Connection to Maestro timed out'));
+			}, CONNECT_TIMEOUT_MS);
+
+			const ws = new WebSocket(url);
+
+			ws.on('open', () => {
+				clearTimeout(timeout);
+				this.ws = ws;
+				this.setupMessageHandler();
+				resolve();
+			});
+
+			ws.on('error', (err) => {
+				clearTimeout(timeout);
+				this.ws = null;
+				reject(new Error(`Failed to connect to Maestro: ${err.message}`));
+			});
+		});
+	}
+
+	/**
+	 * Send a message and wait for a typed response.
+	 */
+	async sendCommand<T>(
+		message: Record<string, unknown>,
+		responseType: string,
+		timeoutMs: number = DEFAULT_COMMAND_TIMEOUT_MS
+	): Promise<T> {
+		if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+			throw new Error('Not connected to Maestro');
+		}
+
+		const requestId = `req_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+
+		return new Promise<T>((resolve, reject) => {
+			const timeout = setTimeout(() => {
+				this.pendingRequests.delete(requestId);
+				reject(new Error(`Command timed out waiting for ${responseType}`));
+			}, timeoutMs);
+
+			this.pendingRequests.set(requestId, {
+				resolve: resolve as (value: unknown) => void,
+				reject,
+				timeout,
+				expectedType: responseType,
+			});
+
+			this.ws!.send(JSON.stringify(message));
+		});
+	}
+
+	/**
+	 * Disconnect gracefully.
+	 */
+	disconnect(): void {
+		for (const [, pending] of this.pendingRequests) {
+			clearTimeout(pending.timeout);
+			pending.reject(new Error('Client disconnected'));
+		}
+		this.pendingRequests.clear();
+
+		if (this.ws) {
+			this.ws.close();
+			this.ws = null;
+		}
+	}
+
+	private setupMessageHandler(): void {
+		if (!this.ws) return;
+
+		this.ws.on('message', (data) => {
+			try {
+				const msg = JSON.parse(data.toString()) as Record<string, unknown>;
+				const msgType = msg.type as string;
+
+				// Match response to the first pending request expecting this type
+				for (const [requestId, pending] of this.pendingRequests) {
+					if (pending.expectedType === msgType) {
+						clearTimeout(pending.timeout);
+						this.pendingRequests.delete(requestId);
+						pending.resolve(msg);
+						return;
+					}
+				}
+			} catch {
+				// Ignore non-JSON messages
+			}
+		});
+	}
+}
+
+/**
+ * Helper: create client, connect, run action, disconnect.
+ * Handles the connect/disconnect lifecycle for one-shot commands.
+ */
+export async function withMaestroClient<T>(action: (client: MaestroClient) => Promise<T>): Promise<T> {
+	const client = new MaestroClient();
+	try {
+		await client.connect();
+		return await action(client);
+	} finally {
+		client.disconnect();
+	}
+}

--- a/src/cli/services/maestro-client.ts
+++ b/src/cli/services/maestro-client.ts
@@ -172,7 +172,9 @@ export function resolveSessionId(options: { session?: string }): string {
  * Helper: create client, connect, run action, disconnect.
  * Handles the connect/disconnect lifecycle for one-shot commands.
  */
-export async function withMaestroClient<T>(action: (client: MaestroClient) => Promise<T>): Promise<T> {
+export async function withMaestroClient<T>(
+	action: (client: MaestroClient) => Promise<T>
+): Promise<T> {
 	const client = new MaestroClient();
 	try {
 		await client.connect();

--- a/src/cli/services/maestro-client.ts
+++ b/src/cli/services/maestro-client.ts
@@ -119,6 +119,15 @@ export class MaestroClient {
 	private setupMessageHandler(): void {
 		if (!this.ws) return;
 
+		this.ws.on('close', () => {
+			for (const [, pending] of this.pendingRequests) {
+				clearTimeout(pending.timeout);
+				pending.reject(new Error('Client disconnected'));
+			}
+			this.pendingRequests.clear();
+			this.ws = null;
+		});
+
 		this.ws.on('message', (data) => {
 			try {
 				const msg = JSON.parse(data.toString()) as Record<string, unknown>;

--- a/src/cli/services/maestro-client.ts
+++ b/src/cli/services/maestro-client.ts
@@ -36,17 +36,24 @@ export class MaestroClient {
 		const url = `ws://localhost:${info.port}/${info.token}/ws`;
 
 		return new Promise<void>((resolve, reject) => {
-			const timeout = setTimeout(() => {
-				if (this.ws) {
-					this.ws.close();
-					this.ws = null;
-				}
-				reject(new Error('Connection to Maestro timed out'));
-			}, CONNECT_TIMEOUT_MS);
+			let settled = false;
 
 			const ws = new WebSocket(url);
 
+			const timeout = setTimeout(() => {
+				if (!settled) {
+					settled = true;
+					ws.close();
+					reject(new Error('Connection to Maestro timed out'));
+				}
+			}, CONNECT_TIMEOUT_MS);
+
 			ws.on('open', () => {
+				if (settled) {
+					ws.close();
+					return;
+				}
+				settled = true;
 				clearTimeout(timeout);
 				this.ws = ws;
 				this.setupMessageHandler();
@@ -54,8 +61,9 @@ export class MaestroClient {
 			});
 
 			ws.on('error', (err) => {
+				if (settled) return;
+				settled = true;
 				clearTimeout(timeout);
-				this.ws = null;
 				reject(new Error(`Failed to connect to Maestro: ${err.message}`));
 			});
 		});
@@ -88,7 +96,7 @@ export class MaestroClient {
 				expectedType: responseType,
 			});
 
-			this.ws!.send(JSON.stringify(message));
+			this.ws!.send(JSON.stringify({ ...message, requestId }));
 		});
 	}
 
@@ -115,8 +123,18 @@ export class MaestroClient {
 			try {
 				const msg = JSON.parse(data.toString()) as Record<string, unknown>;
 				const msgType = msg.type as string;
+				const msgRequestId = msg.requestId as string | undefined;
 
-				// Match response to the first pending request expecting this type
+				// Try matching by requestId first (exact match)
+				if (msgRequestId && this.pendingRequests.has(msgRequestId)) {
+					const pending = this.pendingRequests.get(msgRequestId)!;
+					clearTimeout(pending.timeout);
+					this.pendingRequests.delete(msgRequestId);
+					pending.resolve(msg);
+					return;
+				}
+
+				// Fall back to matching by response type
 				for (const [requestId, pending] of this.pendingRequests) {
 					if (pending.expectedType === msgType) {
 						clearTimeout(pending.timeout);

--- a/src/cli/services/maestro-client.ts
+++ b/src/cli/services/maestro-client.ts
@@ -119,10 +119,15 @@ export class MaestroClient {
 	private setupMessageHandler(): void {
 		if (!this.ws) return;
 
-		this.ws.on('close', () => {
+		this.ws.on('close', (code?: number, reason?: Buffer) => {
+			const reasonStr = reason?.toString();
 			for (const [, pending] of this.pendingRequests) {
 				clearTimeout(pending.timeout);
-				pending.reject(new Error('Client disconnected'));
+				pending.reject(
+					new Error(
+						`Connection closed${code ? ` (code=${code})` : ''}${reasonStr ? `: ${reasonStr}` : ''}`
+					)
+				);
 			}
 			this.pendingRequests.clear();
 			this.ws = null;

--- a/src/main/app-lifecycle/quit-handler.ts
+++ b/src/main/app-lifecycle/quit-handler.ts
@@ -10,6 +10,7 @@ import type { WebServer } from '../web-server';
 import { tunnelManager as tunnelManagerInstance } from '../tunnel-manager';
 import type { HistoryManager } from '../history-manager';
 import { isWebContentsAvailable } from '../utils/safe-send';
+import { deleteCliServerInfo } from '../../shared/cli-server-discovery';
 
 /** Dependencies for quit handler */
 export interface QuitHandlerDependencies {
@@ -183,6 +184,10 @@ export function createQuitHandler(deps: QuitHandlerDependencies): QuitHandler {
 		webServer?.stop().catch((err: unknown) => {
 			logger.error(`Error stopping web server: ${err}`, 'Shutdown');
 		});
+
+		// Delete CLI server discovery file so CLI knows we're gone
+		logger.info('Deleting CLI server discovery file', 'Shutdown');
+		deleteCliServerInfo();
 
 		// Close stats database
 		logger.info('Closing stats database', 'Shutdown');

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -547,7 +547,6 @@ app.whenReady().then(async () => {
 		},
 		createWebServer,
 	});
-	// via live:startServer IPC call from the renderer
 
 	app.on('activate', () => {
 		if (BrowserWindow.getAllWindows().length === 0) {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -49,6 +49,7 @@ import {
 	registerFilesystemHandlers,
 	registerAttachmentsHandlers,
 	registerWebHandlers,
+	ensureCliServer,
 	registerLeaderboardHandlers,
 	registerNotificationsHandlers,
 	registerSymphonyHandlers,
@@ -538,7 +539,14 @@ app.whenReady().then(async () => {
 	// Start CLI activity watcher (Phase 4 refactoring)
 	cliWatcher.start();
 
-	// Note: Web server is not auto-started - it starts when user enables web interface
+	// Auto-start CLI server for CLI IPC (writes discovery file for CLI to connect)
+	await ensureCliServer({
+		getWebServer: () => webServer,
+		setWebServer: (server) => {
+			webServer = server;
+		},
+		createWebServer,
+	});
 	// via live:startServer IPC call from the renderer
 
 	app.on('activate', () => {

--- a/src/main/ipc/handlers/index.ts
+++ b/src/main/ipc/handlers/index.ts
@@ -45,7 +45,7 @@ import { registerDocumentGraphHandlers, DocumentGraphHandlerDependencies } from 
 import { registerSshRemoteHandlers, SshRemoteHandlerDependencies } from './ssh-remote';
 import { registerFilesystemHandlers } from './filesystem';
 import { registerAttachmentsHandlers, AttachmentsHandlerDependencies } from './attachments';
-import { registerWebHandlers, WebHandlerDependencies } from './web';
+import { registerWebHandlers, ensureCliServer, WebHandlerDependencies } from './web';
 import { registerLeaderboardHandlers, LeaderboardHandlerDependencies } from './leaderboard';
 import { registerNotificationsHandlers } from './notifications';
 import { registerSymphonyHandlers, SymphonyHandlerDependencies } from './symphony';
@@ -88,7 +88,7 @@ export { registerSshRemoteHandlers };
 export { registerFilesystemHandlers };
 export { registerAttachmentsHandlers };
 export type { AttachmentsHandlerDependencies };
-export { registerWebHandlers };
+export { registerWebHandlers, ensureCliServer };
 export type { WebHandlerDependencies };
 export { registerLeaderboardHandlers };
 export type { LeaderboardHandlerDependencies };

--- a/src/main/ipc/handlers/web.ts
+++ b/src/main/ipc/handlers/web.ts
@@ -25,7 +25,7 @@ import { ipcMain } from 'electron';
 import { logger } from '../../utils/logger';
 import { WebServer } from '../../web-server';
 import type { AITabData } from '../../web-server/services/broadcastService';
-import { writeCliServerInfo } from '../../../shared/cli-server-discovery';
+import { writeCliServerInfo, deleteCliServerInfo } from '../../../shared/cli-server-discovery';
 
 /**
  * Timeout for waiting for web server to become active (ms)
@@ -301,6 +301,7 @@ export function registerWebHandlers(deps: WebHandlerDependencies): void {
 			logger.info('Stopping web server', 'WebServer');
 			await webServer.stop();
 			setWebServer(null); // Allow garbage collection, will recreate on next start
+			deleteCliServerInfo(); // Remove discovery file since server is no longer running
 			logger.info('Web server stopped and cleaned up', 'WebServer');
 			return { success: true };
 		} catch (error: any) {
@@ -328,6 +329,7 @@ export function registerWebHandlers(deps: WebHandlerDependencies): void {
 			logger.info(`Disabled ${count} live sessions, stopping server`, 'Live');
 			await webServer.stop();
 			setWebServer(null);
+			deleteCliServerInfo(); // Remove discovery file since server is no longer running
 			return { success: true, count };
 		} catch (error: any) {
 			logger.error(`Failed to stop web server during disableAll: ${error.message}`, 'WebServer');

--- a/src/main/ipc/handlers/web.ts
+++ b/src/main/ipc/handlers/web.ts
@@ -25,6 +25,7 @@ import { ipcMain } from 'electron';
 import { logger } from '../../utils/logger';
 import { WebServer } from '../../web-server';
 import type { AITabData } from '../../web-server/services/broadcastService';
+import { writeCliServerInfo } from '../../../shared/cli-server-discovery';
 
 /**
  * Timeout for waiting for web server to become active (ms)
@@ -43,6 +44,54 @@ export interface WebHandlerDependencies {
 	getWebServer: () => WebServer | null;
 	setWebServer: (server: WebServer | null) => void;
 	createWebServer: () => WebServer;
+}
+
+/**
+ * Ensure the CLI server is running and write the discovery file.
+ *
+ * Called during app initialization to make the web server always available
+ * for CLI IPC connections. The server binds to 0.0.0.0 — this is intentional
+ * for LAN accessibility; the UUID security token prevents unauthorized access.
+ */
+export async function ensureCliServer(deps: WebHandlerDependencies): Promise<void> {
+	const { getWebServer, setWebServer, createWebServer } = deps;
+
+	try {
+		let webServer = getWebServer();
+
+		// Create web server if it doesn't exist
+		if (!webServer) {
+			logger.info('Creating CLI server', 'CliServer');
+			webServer = createWebServer();
+			setWebServer(webServer);
+		}
+
+		// Start if not already running
+		if (!webServer.isActive()) {
+			logger.info('Starting CLI server', 'CliServer');
+			const { port, token } = await webServer.start();
+			logger.info(`CLI server running on port ${port}`, 'CliServer');
+
+			// Write discovery file so CLI can find us
+			writeCliServerInfo({
+				port,
+				token,
+				pid: process.pid,
+				startedAt: Date.now(),
+			});
+		} else {
+			// Server already running — still write discovery file in case it's stale
+			writeCliServerInfo({
+				port: webServer.getPort(),
+				token: webServer.getSecurityToken(),
+				pid: process.pid,
+				startedAt: Date.now(),
+			});
+		}
+	} catch (error: any) {
+		logger.error(`Failed to start CLI server: ${error.message}`, 'CliServer');
+		// Non-fatal: app continues without CLI IPC
+	}
 }
 
 /**

--- a/src/main/preload/process.ts
+++ b/src/main/preload/process.ts
@@ -436,6 +436,36 @@ export function createProcessApi() {
 		},
 
 		/**
+		 * Subscribe to remote open file tab from web interface
+		 */
+		onRemoteOpenFileTab: (
+			callback: (sessionId: string, filePath: string) => void
+		): (() => void) => {
+			const handler = (_: unknown, sessionId: string, filePath: string) =>
+				callback(sessionId, filePath);
+			ipcRenderer.on('remote:openFileTab', handler);
+			return () => ipcRenderer.removeListener('remote:openFileTab', handler);
+		},
+
+		/**
+		 * Subscribe to remote refresh file tree from web interface
+		 */
+		onRemoteRefreshFileTree: (callback: (sessionId: string) => void): (() => void) => {
+			const handler = (_: unknown, sessionId: string) => callback(sessionId);
+			ipcRenderer.on('remote:refreshFileTree', handler);
+			return () => ipcRenderer.removeListener('remote:refreshFileTree', handler);
+		},
+
+		/**
+		 * Subscribe to remote refresh auto-run docs from web interface
+		 */
+		onRemoteRefreshAutoRunDocs: (callback: (sessionId: string) => void): (() => void) => {
+			const handler = (_: unknown, sessionId: string) => callback(sessionId);
+			ipcRenderer.on('remote:refreshAutoRunDocs', handler);
+			return () => ipcRenderer.removeListener('remote:refreshAutoRunDocs', handler);
+		},
+
+		/**
 		 * Subscribe to stderr from runCommand (separate stream)
 		 */
 		onStderr: (callback: (sessionId: string, data: string) => void): (() => void) => {

--- a/src/main/preload/process.ts
+++ b/src/main/preload/process.ts
@@ -474,14 +474,12 @@ export function createProcessApi() {
 			const handler = (_: unknown, sessionId: string, config: any, responseChannel: string) => {
 				try {
 					// callback may return a promise even though typed as void
-					Promise.resolve(callback(sessionId, config, responseChannel)).catch(
-						(error) => {
-							ipcRenderer.send(responseChannel, {
-								success: false,
-								error: error instanceof Error ? error.message : String(error),
-							});
-						}
-					);
+					Promise.resolve(callback(sessionId, config, responseChannel)).catch((error) => {
+						ipcRenderer.send(responseChannel, {
+							success: false,
+							error: error instanceof Error ? error.message : String(error),
+						});
+					});
 				} catch (error) {
 					ipcRenderer.send(responseChannel, {
 						success: false,

--- a/src/main/preload/process.ts
+++ b/src/main/preload/process.ts
@@ -471,8 +471,25 @@ export function createProcessApi() {
 		onRemoteConfigureAutoRun: (
 			callback: (sessionId: string, config: any, responseChannel: string) => void
 		): (() => void) => {
-			const handler = (_: unknown, sessionId: string, config: any, responseChannel: string) =>
-				callback(sessionId, config, responseChannel);
+			const handler = (_: unknown, sessionId: string, config: any, responseChannel: string) => {
+				try {
+					const result = callback(sessionId, config, responseChannel);
+					// Handle async callbacks - catch rejections and send error response
+					if (result && typeof (result as any).catch === 'function') {
+						(result as Promise<unknown>).catch((error) => {
+							ipcRenderer.send(responseChannel, {
+								success: false,
+								error: error instanceof Error ? error.message : String(error),
+							});
+						});
+					}
+				} catch (error) {
+					ipcRenderer.send(responseChannel, {
+						success: false,
+						error: error instanceof Error ? error.message : String(error),
+					});
+				}
+			};
 			ipcRenderer.on('remote:configureAutoRun', handler);
 			return () => ipcRenderer.removeListener('remote:configureAutoRun', handler);
 		},

--- a/src/main/preload/process.ts
+++ b/src/main/preload/process.ts
@@ -473,16 +473,15 @@ export function createProcessApi() {
 		): (() => void) => {
 			const handler = (_: unknown, sessionId: string, config: any, responseChannel: string) => {
 				try {
-					const result = callback(sessionId, config, responseChannel);
-					// Handle async callbacks - catch rejections and send error response
-					if (result && typeof (result as any).catch === 'function') {
-						(result as Promise<unknown>).catch((error) => {
+					// callback may return a promise even though typed as void
+					Promise.resolve(callback(sessionId, config, responseChannel)).catch(
+						(error) => {
 							ipcRenderer.send(responseChannel, {
 								success: false,
 								error: error instanceof Error ? error.message : String(error),
 							});
-						});
-					}
+						}
+					);
 				} catch (error) {
 					ipcRenderer.send(responseChannel, {
 						success: false,

--- a/src/main/preload/process.ts
+++ b/src/main/preload/process.ts
@@ -466,6 +466,28 @@ export function createProcessApi() {
 		},
 
 		/**
+		 * Subscribe to remote configure auto-run from CLI/web interface
+		 */
+		onRemoteConfigureAutoRun: (
+			callback: (sessionId: string, config: any, responseChannel: string) => void
+		): (() => void) => {
+			const handler = (_: unknown, sessionId: string, config: any, responseChannel: string) =>
+				callback(sessionId, config, responseChannel);
+			ipcRenderer.on('remote:configureAutoRun', handler);
+			return () => ipcRenderer.removeListener('remote:configureAutoRun', handler);
+		},
+
+		/**
+		 * Send response for remote configure auto-run
+		 */
+		sendRemoteConfigureAutoRunResponse: (
+			responseChannel: string,
+			result: { success: boolean; playbookId?: string; error?: string }
+		): void => {
+			ipcRenderer.send(responseChannel, result);
+		},
+
+		/**
 		 * Subscribe to stderr from runCommand (separate stream)
 		 */
 		onStderr: (callback: (sessionId: string, data: string) => void): (() => void) => {

--- a/src/main/web-server/WebServer.ts
+++ b/src/main/web-server/WebServer.ts
@@ -63,6 +63,7 @@ import type {
 	ReorderTabCallback,
 	ToggleBookmarkCallback,
 	OpenFileTabCallback,
+	RefreshFileTreeCallback,
 	GetThemeCallback,
 	GetCustomCommandsCallback,
 	GetHistoryCallback,
@@ -306,6 +307,10 @@ export class WebServer {
 		this.callbackRegistry.setOpenFileTabCallback(callback);
 	}
 
+	setRefreshFileTreeCallback(callback: RefreshFileTreeCallback): void {
+		this.callbackRegistry.setRefreshFileTreeCallback(callback);
+	}
+
 	setGetHistoryCallback(callback: GetHistoryCallback): void {
 		this.callbackRegistry.setGetHistoryCallback(callback);
 	}
@@ -458,6 +463,8 @@ export class WebServer {
 			toggleBookmark: async (sessionId: string) => this.callbackRegistry.toggleBookmark(sessionId),
 			openFileTab: async (sessionId: string, filePath: string) =>
 				this.callbackRegistry.openFileTab(sessionId, filePath),
+			refreshFileTree: async (sessionId: string) =>
+				this.callbackRegistry.refreshFileTree(sessionId),
 			getSessions: () => this.callbackRegistry.getSessions(),
 			getLiveSessionInfo: (sessionId: string) =>
 				this.liveSessionManager.getLiveSessionInfo(sessionId),

--- a/src/main/web-server/WebServer.ts
+++ b/src/main/web-server/WebServer.ts
@@ -62,6 +62,7 @@ import type {
 	StarTabCallback,
 	ReorderTabCallback,
 	ToggleBookmarkCallback,
+	OpenFileTabCallback,
 	GetThemeCallback,
 	GetCustomCommandsCallback,
 	GetHistoryCallback,
@@ -301,6 +302,10 @@ export class WebServer {
 		this.callbackRegistry.setToggleBookmarkCallback(callback);
 	}
 
+	setOpenFileTabCallback(callback: OpenFileTabCallback): void {
+		this.callbackRegistry.setOpenFileTabCallback(callback);
+	}
+
 	setGetHistoryCallback(callback: GetHistoryCallback): void {
 		this.callbackRegistry.setGetHistoryCallback(callback);
 	}
@@ -451,6 +456,8 @@ export class WebServer {
 			reorderTab: async (sessionId: string, fromIndex: number, toIndex: number) =>
 				this.callbackRegistry.reorderTab(sessionId, fromIndex, toIndex),
 			toggleBookmark: async (sessionId: string) => this.callbackRegistry.toggleBookmark(sessionId),
+			openFileTab: async (sessionId: string, filePath: string) =>
+				this.callbackRegistry.openFileTab(sessionId, filePath),
 			getSessions: () => this.callbackRegistry.getSessions(),
 			getLiveSessionInfo: (sessionId: string) =>
 				this.liveSessionManager.getLiveSessionInfo(sessionId),

--- a/src/main/web-server/WebServer.ts
+++ b/src/main/web-server/WebServer.ts
@@ -452,8 +452,8 @@ export class WebServer {
 				this.callbackRegistry.executeCommand(sessionId, command, inputMode),
 			switchMode: async (sessionId: string, mode: 'ai' | 'terminal') =>
 				this.callbackRegistry.switchMode(sessionId, mode),
-			selectSession: async (sessionId: string, tabId?: string) =>
-				this.callbackRegistry.selectSession(sessionId, tabId),
+			selectSession: async (sessionId: string, tabId?: string, focus?: boolean) =>
+				this.callbackRegistry.selectSession(sessionId, tabId, focus),
 			selectTab: async (sessionId: string, tabId: string) =>
 				this.callbackRegistry.selectTab(sessionId, tabId),
 			newTab: async (sessionId: string) => this.callbackRegistry.newTab(sessionId),

--- a/src/main/web-server/WebServer.ts
+++ b/src/main/web-server/WebServer.ts
@@ -65,6 +65,7 @@ import type {
 	OpenFileTabCallback,
 	RefreshFileTreeCallback,
 	RefreshAutoRunDocsCallback,
+	ConfigureAutoRunCallback,
 	GetThemeCallback,
 	GetCustomCommandsCallback,
 	GetHistoryCallback,
@@ -316,6 +317,10 @@ export class WebServer {
 		this.callbackRegistry.setRefreshAutoRunDocsCallback(callback);
 	}
 
+	setConfigureAutoRunCallback(callback: ConfigureAutoRunCallback): void {
+		this.callbackRegistry.setConfigureAutoRunCallback(callback);
+	}
+
 	setGetHistoryCallback(callback: GetHistoryCallback): void {
 		this.callbackRegistry.setGetHistoryCallback(callback);
 	}
@@ -472,6 +477,8 @@ export class WebServer {
 				this.callbackRegistry.refreshFileTree(sessionId),
 			refreshAutoRunDocs: async (sessionId: string) =>
 				this.callbackRegistry.refreshAutoRunDocs(sessionId),
+			configureAutoRun: async (sessionId: string, config: any) =>
+				this.callbackRegistry.configureAutoRun(sessionId, config),
 			getSessions: () => this.callbackRegistry.getSessions(),
 			getLiveSessionInfo: (sessionId: string) =>
 				this.liveSessionManager.getLiveSessionInfo(sessionId),

--- a/src/main/web-server/WebServer.ts
+++ b/src/main/web-server/WebServer.ts
@@ -64,6 +64,7 @@ import type {
 	ToggleBookmarkCallback,
 	OpenFileTabCallback,
 	RefreshFileTreeCallback,
+	RefreshAutoRunDocsCallback,
 	GetThemeCallback,
 	GetCustomCommandsCallback,
 	GetHistoryCallback,
@@ -311,6 +312,10 @@ export class WebServer {
 		this.callbackRegistry.setRefreshFileTreeCallback(callback);
 	}
 
+	setRefreshAutoRunDocsCallback(callback: RefreshAutoRunDocsCallback): void {
+		this.callbackRegistry.setRefreshAutoRunDocsCallback(callback);
+	}
+
 	setGetHistoryCallback(callback: GetHistoryCallback): void {
 		this.callbackRegistry.setGetHistoryCallback(callback);
 	}
@@ -465,6 +470,8 @@ export class WebServer {
 				this.callbackRegistry.openFileTab(sessionId, filePath),
 			refreshFileTree: async (sessionId: string) =>
 				this.callbackRegistry.refreshFileTree(sessionId),
+			refreshAutoRunDocs: async (sessionId: string) =>
+				this.callbackRegistry.refreshAutoRunDocs(sessionId),
 			getSessions: () => this.callbackRegistry.getSessions(),
 			getLiveSessionInfo: (sessionId: string) =>
 				this.liveSessionManager.getLiveSessionInfo(sessionId),

--- a/src/main/web-server/handlers/messageHandlers.ts
+++ b/src/main/web-server/handlers/messageHandlers.ts
@@ -890,8 +890,19 @@ export class WebSocketMessageHandler {
 			LOG_CONTEXT
 		);
 
+		// Helper to send typed error responses with requestId (prevents client timeouts)
+		const sendErrorResult = (error: string) => {
+			this.send(client, {
+				type: 'open_file_tab_result',
+				success: false,
+				error,
+				sessionId,
+				requestId: message.requestId,
+			});
+		};
+
 		if (!sessionId || !filePath) {
-			this.sendError(client, 'Missing sessionId or filePath');
+			sendErrorResult('Missing sessionId or filePath');
 			return;
 		}
 
@@ -899,18 +910,18 @@ export class WebSocketMessageHandler {
 		const sessions = this.callbacks.getSessions?.();
 		const session = sessions?.find((s) => s.id === sessionId);
 		if (!session?.cwd) {
-			this.sendError(client, 'Session not found or has no working directory');
+			sendErrorResult('Session not found or has no working directory');
 			return;
 		}
 		const sessionRoot = path.resolve(session.cwd);
 		const resolved = path.resolve(sessionRoot, filePath);
 		if (!resolved.startsWith(sessionRoot + path.sep) && resolved !== sessionRoot) {
-			this.sendError(client, 'Invalid file path');
+			sendErrorResult('Invalid file path: path is outside the agent working directory');
 			return;
 		}
 
 		if (!this.callbacks.openFileTab) {
-			this.sendError(client, 'File tab opening not configured');
+			sendErrorResult('File tab opening not configured');
 			return;
 		}
 
@@ -926,7 +937,7 @@ export class WebSocketMessageHandler {
 				});
 			})
 			.catch((error) => {
-				this.sendError(client, `Failed to open file tab: ${error.message}`);
+				sendErrorResult(`Failed to open file tab: ${error.message}`);
 			});
 	}
 

--- a/src/main/web-server/handlers/messageHandlers.ts
+++ b/src/main/web-server/handlers/messageHandlers.ts
@@ -18,6 +18,7 @@
  * - rename_tab: Rename a tab within a session
  * - open_file_tab: Open a file in a preview tab
  * - refresh_file_tree: Refresh the file tree for a session
+ * - refresh_auto_run_docs: Refresh auto-run documents for a session
  */
 
 import { WebSocket } from 'ws';
@@ -90,6 +91,7 @@ export interface MessageHandlerCallbacks {
 	toggleBookmark: (sessionId: string) => Promise<boolean>;
 	openFileTab: (sessionId: string, filePath: string) => Promise<boolean>;
 	refreshFileTree: (sessionId: string) => Promise<boolean>;
+	refreshAutoRunDocs: (sessionId: string) => Promise<boolean>;
 	getSessions: () => Array<{
 		id: string;
 		name: string;
@@ -205,6 +207,10 @@ export class WebSocketMessageHandler {
 
 			case 'refresh_file_tree':
 				this.handleRefreshFileTree(client, message);
+				break;
+
+			case 'refresh_auto_run_docs':
+				this.handleRefreshAutoRunDocs(client, message);
 				break;
 
 			default:
@@ -672,6 +678,33 @@ export class WebSocketMessageHandler {
 			})
 			.catch((error) => {
 				this.sendError(client, `Failed to refresh file tree: ${error.message}`);
+			});
+	}
+
+	/**
+	 * Handle refresh_auto_run_docs message - refresh auto-run documents for a session
+	 */
+	private handleRefreshAutoRunDocs(client: WebClient, message: WebClientMessage): void {
+		const sessionId = message.sessionId as string;
+		logger.info(`[Web] Received refresh_auto_run_docs message: session=${sessionId}`, LOG_CONTEXT);
+
+		if (!sessionId) {
+			this.sendError(client, 'Missing sessionId');
+			return;
+		}
+
+		if (!this.callbacks.refreshAutoRunDocs) {
+			this.sendError(client, 'Auto-run docs refresh not configured');
+			return;
+		}
+
+		this.callbacks
+			.refreshAutoRunDocs(sessionId)
+			.then((success) => {
+				this.send(client, { type: 'refresh_auto_run_docs_result', success, sessionId });
+			})
+			.catch((error) => {
+				this.sendError(client, `Failed to refresh auto-run docs: ${error.message}`);
 			});
 	}
 

--- a/src/main/web-server/handlers/messageHandlers.ts
+++ b/src/main/web-server/handlers/messageHandlers.ts
@@ -17,6 +17,7 @@
  * - close_tab: Close a tab within a session
  * - rename_tab: Rename a tab within a session
  * - open_file_tab: Open a file in a preview tab
+ * - refresh_file_tree: Refresh the file tree for a session
  */
 
 import { WebSocket } from 'ws';
@@ -88,6 +89,7 @@ export interface MessageHandlerCallbacks {
 	reorderTab: (sessionId: string, fromIndex: number, toIndex: number) => Promise<boolean>;
 	toggleBookmark: (sessionId: string) => Promise<boolean>;
 	openFileTab: (sessionId: string, filePath: string) => Promise<boolean>;
+	refreshFileTree: (sessionId: string) => Promise<boolean>;
 	getSessions: () => Array<{
 		id: string;
 		name: string;
@@ -199,6 +201,10 @@ export class WebSocketMessageHandler {
 
 			case 'open_file_tab':
 				this.handleOpenFileTab(client, message);
+				break;
+
+			case 'refresh_file_tree':
+				this.handleRefreshFileTree(client, message);
 				break;
 
 			default:
@@ -639,6 +645,33 @@ export class WebSocketMessageHandler {
 			})
 			.catch((error) => {
 				this.sendError(client, `Failed to toggle bookmark: ${error.message}`);
+			});
+	}
+
+	/**
+	 * Handle refresh_file_tree message - refresh the file tree for a session
+	 */
+	private handleRefreshFileTree(client: WebClient, message: WebClientMessage): void {
+		const sessionId = message.sessionId as string;
+		logger.info(`[Web] Received refresh_file_tree message: session=${sessionId}`, LOG_CONTEXT);
+
+		if (!sessionId) {
+			this.sendError(client, 'Missing sessionId');
+			return;
+		}
+
+		if (!this.callbacks.refreshFileTree) {
+			this.sendError(client, 'File tree refresh not configured');
+			return;
+		}
+
+		this.callbacks
+			.refreshFileTree(sessionId)
+			.then((success) => {
+				this.send(client, { type: 'refresh_file_tree_result', success, sessionId });
+			})
+			.catch((error) => {
+				this.sendError(client, `Failed to refresh file tree: ${error.message}`);
 			});
 	}
 

--- a/src/main/web-server/handlers/messageHandlers.ts
+++ b/src/main/web-server/handlers/messageHandlers.ts
@@ -16,6 +16,7 @@
  * - new_tab: Create a new tab within a session
  * - close_tab: Close a tab within a session
  * - rename_tab: Rename a tab within a session
+ * - open_file_tab: Open a file in a preview tab
  */
 
 import { WebSocket } from 'ws';
@@ -35,6 +36,7 @@ export interface WebClientMessage {
 	mode?: 'ai' | 'terminal';
 	inputMode?: 'ai' | 'terminal';
 	newName?: string;
+	filePath?: string;
 	[key: string]: unknown;
 }
 
@@ -85,6 +87,7 @@ export interface MessageHandlerCallbacks {
 	starTab: (sessionId: string, tabId: string, starred: boolean) => Promise<boolean>;
 	reorderTab: (sessionId: string, fromIndex: number, toIndex: number) => Promise<boolean>;
 	toggleBookmark: (sessionId: string) => Promise<boolean>;
+	openFileTab: (sessionId: string, filePath: string) => Promise<boolean>;
 	getSessions: () => Array<{
 		id: string;
 		name: string;
@@ -192,6 +195,10 @@ export class WebSocketMessageHandler {
 
 			case 'toggle_bookmark':
 				this.handleToggleBookmark(client, message);
+				break;
+
+			case 'open_file_tab':
+				this.handleOpenFileTab(client, message);
 				break;
 
 			default:
@@ -632,6 +639,37 @@ export class WebSocketMessageHandler {
 			})
 			.catch((error) => {
 				this.sendError(client, `Failed to toggle bookmark: ${error.message}`);
+			});
+	}
+
+	/**
+	 * Handle open_file_tab message - open a file in a preview tab
+	 */
+	private handleOpenFileTab(client: WebClient, message: WebClientMessage): void {
+		const sessionId = message.sessionId as string;
+		const filePath = message.filePath as string;
+		logger.info(
+			`[Web] Received open_file_tab message: session=${sessionId}, filePath=${filePath}`,
+			LOG_CONTEXT
+		);
+
+		if (!sessionId || !filePath) {
+			this.sendError(client, 'Missing sessionId or filePath');
+			return;
+		}
+
+		if (!this.callbacks.openFileTab) {
+			this.sendError(client, 'File tab opening not configured');
+			return;
+		}
+
+		this.callbacks
+			.openFileTab(sessionId, filePath)
+			.then((success) => {
+				this.send(client, { type: 'open_file_tab_result', success, sessionId, filePath });
+			})
+			.catch((error) => {
+				this.sendError(client, `Failed to open file tab: ${error.message}`);
 			});
 	}
 

--- a/src/main/web-server/handlers/messageHandlers.ts
+++ b/src/main/web-server/handlers/messageHandlers.ts
@@ -19,6 +19,7 @@
  * - open_file_tab: Open a file in a preview tab
  * - refresh_file_tree: Refresh the file tree for a session
  * - refresh_auto_run_docs: Refresh auto-run documents for a session
+ * - configure_auto_run: Configure and optionally launch an auto-run session
  */
 
 import { WebSocket } from 'ws';
@@ -93,6 +94,17 @@ export interface MessageHandlerCallbacks {
 	openFileTab: (sessionId: string, filePath: string) => Promise<boolean>;
 	refreshFileTree: (sessionId: string) => Promise<boolean>;
 	refreshAutoRunDocs: (sessionId: string) => Promise<boolean>;
+	configureAutoRun: (
+		sessionId: string,
+		config: {
+			documents: Array<{ filename: string; resetOnCompletion?: boolean }>;
+			prompt?: string;
+			loopEnabled?: boolean;
+			maxLoops?: number;
+			saveAsPlaybook?: string;
+			launch?: boolean;
+		}
+	) => Promise<{ success: boolean; playbookId?: string; error?: string }>;
 	getSessions: () => Array<{
 		id: string;
 		name: string;
@@ -212,6 +224,10 @@ export class WebSocketMessageHandler {
 
 			case 'refresh_auto_run_docs':
 				this.handleRefreshAutoRunDocs(client, message);
+				break;
+
+			case 'configure_auto_run':
+				this.handleConfigureAutoRun(client, message);
 				break;
 
 			default:
@@ -707,6 +723,57 @@ export class WebSocketMessageHandler {
 			})
 			.catch((error) => {
 				this.sendError(client, `Failed to refresh auto-run docs: ${error.message}`);
+			});
+	}
+
+	/**
+	 * Handle configure_auto_run message - configure and optionally launch an auto-run
+	 */
+	private handleConfigureAutoRun(client: WebClient, message: WebClientMessage): void {
+		const sessionId = message.sessionId as string;
+		const documents = message.documents as Array<{ filename: string; resetOnCompletion?: boolean }> | undefined;
+		logger.info(
+			`[Web] Received configure_auto_run message: session=${sessionId}, documents=${documents?.length || 0}`,
+			LOG_CONTEXT
+		);
+
+		if (!sessionId) {
+			this.sendError(client, 'Missing sessionId');
+			return;
+		}
+
+		if (!documents || !Array.isArray(documents) || documents.length === 0) {
+			this.sendError(client, 'Missing or empty documents array');
+			return;
+		}
+
+		if (!this.callbacks.configureAutoRun) {
+			this.sendError(client, 'Auto-run configuration not configured');
+			return;
+		}
+
+		const config = {
+			documents,
+			prompt: message.prompt as string | undefined,
+			loopEnabled: message.loopEnabled as boolean | undefined,
+			maxLoops: message.maxLoops as number | undefined,
+			saveAsPlaybook: message.saveAsPlaybook as string | undefined,
+			launch: message.launch as boolean | undefined,
+		};
+
+		this.callbacks
+			.configureAutoRun(sessionId, config)
+			.then((result) => {
+				this.send(client, {
+					type: 'configure_auto_run_result',
+					success: result.success,
+					playbookId: result.playbookId,
+					error: result.error,
+					sessionId,
+				});
+			})
+			.catch((error) => {
+				this.sendError(client, `Failed to configure auto-run: ${error.message}`);
 			});
 	}
 

--- a/src/main/web-server/handlers/messageHandlers.ts
+++ b/src/main/web-server/handlers/messageHandlers.ts
@@ -39,6 +39,7 @@ export interface WebClientMessage {
 	inputMode?: 'ai' | 'terminal';
 	newName?: string;
 	filePath?: string;
+	focus?: boolean;
 	[key: string]: unknown;
 }
 
@@ -81,7 +82,7 @@ export interface MessageHandlerCallbacks {
 		inputMode?: 'ai' | 'terminal'
 	) => Promise<boolean>;
 	switchMode: (sessionId: string, mode: 'ai' | 'terminal') => Promise<boolean>;
-	selectSession: (sessionId: string, tabId?: string) => Promise<boolean>;
+	selectSession: (sessionId: string, tabId?: string, focus?: boolean) => Promise<boolean>;
 	selectTab: (sessionId: string, tabId: string) => Promise<boolean>;
 	newTab: (sessionId: string) => Promise<{ tabId: string } | null>;
 	closeTab: (sessionId: string, tabId: string) => Promise<boolean>;
@@ -362,8 +363,9 @@ export class WebSocketMessageHandler {
 	private handleSelectSession(client: WebClient, message: WebClientMessage): void {
 		const sessionId = message.sessionId as string;
 		const tabId = message.tabId as string | undefined;
+		const focus = message.focus as boolean | undefined;
 		logger.info(
-			`[Web] Received select_session message: session=${sessionId}, tab=${tabId || 'none'}`,
+			`[Web] Received select_session message: session=${sessionId}, tab=${tabId || 'none'}, focus=${focus || false}`,
 			LOG_CONTEXT
 		);
 
@@ -384,7 +386,7 @@ export class WebSocketMessageHandler {
 			LOG_CONTEXT
 		);
 		this.callbacks
-			.selectSession(sessionId, tabId)
+			.selectSession(sessionId, tabId, focus)
 			.then((success) => {
 				if (success) {
 					// Subscribe client to this session's output so they receive session_output messages

--- a/src/main/web-server/handlers/messageHandlers.ts
+++ b/src/main/web-server/handlers/messageHandlers.ts
@@ -747,6 +747,22 @@ export class WebSocketMessageHandler {
 			return;
 		}
 
+		// Validate each document entry
+		for (const doc of documents) {
+			if (typeof doc !== 'object' || doc === null) {
+				this.sendError(client, 'Each document must be an object');
+				return;
+			}
+			if (typeof doc.filename !== 'string' || doc.filename.trim() === '') {
+				this.sendError(client, 'Each document must have a non-empty string filename');
+				return;
+			}
+			if (doc.resetOnCompletion !== undefined && typeof doc.resetOnCompletion !== 'boolean') {
+				this.sendError(client, 'resetOnCompletion must be a boolean if provided');
+				return;
+			}
+		}
+
 		if (!this.callbacks.configureAutoRun) {
 			this.sendError(client, 'Auto-run configuration not configured');
 			return;

--- a/src/main/web-server/handlers/messageHandlers.ts
+++ b/src/main/web-server/handlers/messageHandlers.ts
@@ -731,7 +731,9 @@ export class WebSocketMessageHandler {
 	 */
 	private handleConfigureAutoRun(client: WebClient, message: WebClientMessage): void {
 		const sessionId = message.sessionId as string;
-		const documents = message.documents as Array<{ filename: string; resetOnCompletion?: boolean }> | undefined;
+		const documents = message.documents as
+			| Array<{ filename: string; resetOnCompletion?: boolean }>
+			| undefined;
 		logger.info(
 			`[Web] Received configure_auto_run message: session=${sessionId}, documents=${documents?.length || 0}`,
 			LOG_CONTEXT

--- a/src/main/web-server/handlers/messageHandlers.ts
+++ b/src/main/web-server/handlers/messageHandlers.ts
@@ -22,6 +22,7 @@
  * - configure_auto_run: Configure and optionally launch an auto-run session
  */
 
+import path from 'path';
 import { WebSocket } from 'ws';
 import { logger } from '../../utils/logger';
 
@@ -33,6 +34,7 @@ const LOG_CONTEXT = 'WebServer';
  */
 export interface WebClientMessage {
 	type: string;
+	requestId?: string;
 	sessionId?: string;
 	tabId?: string;
 	command?: string;
@@ -249,7 +251,11 @@ export class WebSocketMessageHandler {
 		if (message.sessionId) {
 			client.subscribedSessionId = message.sessionId as string;
 		}
-		this.send(client, { type: 'subscribed', sessionId: message.sessionId });
+		this.send(client, {
+			type: 'subscribed',
+			sessionId: message.sessionId,
+			requestId: message.requestId,
+		});
 	}
 
 	/**
@@ -314,7 +320,12 @@ export class WebSocketMessageHandler {
 			this.callbacks
 				.executeCommand(sessionId, command, clientInputMode)
 				.then((success) => {
-					this.send(client, { type: 'command_result', success, sessionId });
+					this.send(client, {
+						type: 'command_result',
+						success,
+						sessionId,
+						requestId: message.requestId,
+					});
 					if (!success) {
 						logger.warn(
 							`[Web Command] ${mode} command rejected for session ${sessionId}`,
@@ -362,7 +373,13 @@ export class WebSocketMessageHandler {
 		this.callbacks
 			.switchMode(sessionId, mode)
 			.then((success) => {
-				this.send(client, { type: 'mode_switch_result', success, sessionId, mode });
+				this.send(client, {
+					type: 'mode_switch_result',
+					success,
+					sessionId,
+					mode,
+					requestId: message.requestId,
+				});
 				logger.debug(
 					`Mode switch for session ${sessionId} to ${mode}: ${success ? 'success' : 'failed'}`,
 					LOG_CONTEXT
@@ -411,7 +428,12 @@ export class WebSocketMessageHandler {
 				} else {
 					logger.warn(`Failed to select session ${sessionId} in desktop`, LOG_CONTEXT);
 				}
-				this.send(client, { type: 'select_session_result', success, sessionId });
+				this.send(client, {
+					type: 'select_session_result',
+					success,
+					sessionId,
+					requestId: message.requestId,
+				});
 			})
 			.catch((error) => {
 				this.sendError(client, `Failed to select session: ${error.message}`);
@@ -466,7 +488,13 @@ export class WebSocketMessageHandler {
 		this.callbacks
 			.selectTab(sessionId, tabId)
 			.then((success) => {
-				this.send(client, { type: 'select_tab_result', success, sessionId, tabId });
+				this.send(client, {
+					type: 'select_tab_result',
+					success,
+					sessionId,
+					tabId,
+					requestId: message.requestId,
+				});
 			})
 			.catch((error) => {
 				this.sendError(client, `Failed to select tab: ${error.message}`);
@@ -498,6 +526,7 @@ export class WebSocketMessageHandler {
 					success: !!result,
 					sessionId,
 					tabId: result?.tabId,
+					requestId: message.requestId,
 				});
 			})
 			.catch((error) => {
@@ -529,7 +558,13 @@ export class WebSocketMessageHandler {
 		this.callbacks
 			.closeTab(sessionId, tabId)
 			.then((success) => {
-				this.send(client, { type: 'close_tab_result', success, sessionId, tabId });
+				this.send(client, {
+					type: 'close_tab_result',
+					success,
+					sessionId,
+					tabId,
+					requestId: message.requestId,
+				});
 			})
 			.catch((error) => {
 				this.sendError(client, `Failed to close tab: ${error.message}`);
@@ -568,6 +603,7 @@ export class WebSocketMessageHandler {
 					sessionId,
 					tabId,
 					newName: newName || '',
+					requestId: message.requestId,
 				});
 			})
 			.catch((error) => {
@@ -600,7 +636,14 @@ export class WebSocketMessageHandler {
 		this.callbacks
 			.starTab(sessionId, tabId, !!starred)
 			.then((success) => {
-				this.send(client, { type: 'star_tab_result', success, sessionId, tabId, starred });
+				this.send(client, {
+					type: 'star_tab_result',
+					success,
+					sessionId,
+					tabId,
+					starred,
+					requestId: message.requestId,
+				});
 			})
 			.catch((error) => {
 				this.sendError(client, `Failed to star tab: ${error.message}`);
@@ -638,6 +681,7 @@ export class WebSocketMessageHandler {
 					sessionId,
 					fromIndex,
 					toIndex,
+					requestId: message.requestId,
 				});
 			})
 			.catch((error) => {
@@ -665,7 +709,12 @@ export class WebSocketMessageHandler {
 		this.callbacks
 			.toggleBookmark(sessionId)
 			.then((success) => {
-				this.send(client, { type: 'toggle_bookmark_result', success, sessionId });
+				this.send(client, {
+					type: 'toggle_bookmark_result',
+					success,
+					sessionId,
+					requestId: message.requestId,
+				});
 			})
 			.catch((error) => {
 				this.sendError(client, `Failed to toggle bookmark: ${error.message}`);
@@ -692,7 +741,12 @@ export class WebSocketMessageHandler {
 		this.callbacks
 			.refreshFileTree(sessionId)
 			.then((success) => {
-				this.send(client, { type: 'refresh_file_tree_result', success, sessionId });
+				this.send(client, {
+					type: 'refresh_file_tree_result',
+					success,
+					sessionId,
+					requestId: message.requestId,
+				});
 			})
 			.catch((error) => {
 				this.sendError(client, `Failed to refresh file tree: ${error.message}`);
@@ -719,7 +773,12 @@ export class WebSocketMessageHandler {
 		this.callbacks
 			.refreshAutoRunDocs(sessionId)
 			.then((success) => {
-				this.send(client, { type: 'refresh_auto_run_docs_result', success, sessionId });
+				this.send(client, {
+					type: 'refresh_auto_run_docs_result',
+					success,
+					sessionId,
+					requestId: message.requestId,
+				});
 			})
 			.catch((error) => {
 				this.sendError(client, `Failed to refresh auto-run docs: ${error.message}`);
@@ -770,11 +829,35 @@ export class WebSocketMessageHandler {
 			return;
 		}
 
+		// Validate and coerce optional config fields at the WebSocket boundary
+		if (message.loopEnabled !== undefined && typeof message.loopEnabled !== 'boolean') {
+			this.sendError(client, 'loopEnabled must be a boolean');
+			return;
+		}
+		if (message.maxLoops !== undefined) {
+			const maxLoops = Number(message.maxLoops);
+			if (!Number.isFinite(maxLoops) || maxLoops < 0) {
+				this.sendError(client, 'maxLoops must be a finite non-negative number');
+				return;
+			}
+		}
+		if (message.launch !== undefined && typeof message.launch !== 'boolean') {
+			this.sendError(client, 'launch must be a boolean');
+			return;
+		}
+		if (
+			message.saveAsPlaybook !== undefined &&
+			(typeof message.saveAsPlaybook !== 'string' || message.saveAsPlaybook.trim() === '')
+		) {
+			this.sendError(client, 'saveAsPlaybook must be a non-empty string');
+			return;
+		}
+
 		const config = {
 			documents,
 			prompt: message.prompt as string | undefined,
 			loopEnabled: message.loopEnabled as boolean | undefined,
-			maxLoops: message.maxLoops as number | undefined,
+			maxLoops: message.maxLoops !== undefined ? Number(message.maxLoops) : undefined,
 			saveAsPlaybook: message.saveAsPlaybook as string | undefined,
 			launch: message.launch as boolean | undefined,
 		};
@@ -788,6 +871,7 @@ export class WebSocketMessageHandler {
 					playbookId: result.playbookId,
 					error: result.error,
 					sessionId,
+					requestId: message.requestId,
 				});
 			})
 			.catch((error) => {
@@ -811,15 +895,35 @@ export class WebSocketMessageHandler {
 			return;
 		}
 
+		// Path traversal protection: resolve against session root
+		const sessions = this.callbacks.getSessions?.();
+		const session = sessions?.find((s) => s.id === sessionId);
+		if (!session?.cwd) {
+			this.sendError(client, 'Session not found or has no working directory');
+			return;
+		}
+		const sessionRoot = path.resolve(session.cwd);
+		const resolved = path.resolve(sessionRoot, filePath);
+		if (!resolved.startsWith(sessionRoot + path.sep) && resolved !== sessionRoot) {
+			this.sendError(client, 'Invalid file path');
+			return;
+		}
+
 		if (!this.callbacks.openFileTab) {
 			this.sendError(client, 'File tab opening not configured');
 			return;
 		}
 
 		this.callbacks
-			.openFileTab(sessionId, filePath)
+			.openFileTab(sessionId, resolved)
 			.then((success) => {
-				this.send(client, { type: 'open_file_tab_result', success, sessionId, filePath });
+				this.send(client, {
+					type: 'open_file_tab_result',
+					success,
+					sessionId,
+					filePath,
+					requestId: message.requestId,
+				});
 			})
 			.catch((error) => {
 				this.sendError(client, `Failed to open file tab: ${error.message}`);

--- a/src/main/web-server/managers/CallbackRegistry.ts
+++ b/src/main/web-server/managers/CallbackRegistry.ts
@@ -23,6 +23,7 @@ import type {
 	ToggleBookmarkCallback,
 	OpenFileTabCallback,
 	RefreshFileTreeCallback,
+	RefreshAutoRunDocsCallback,
 	GetThemeCallback,
 	GetCustomCommandsCallback,
 	GetHistoryCallback,
@@ -52,6 +53,7 @@ export interface WebServerCallbacks {
 	toggleBookmark: ToggleBookmarkCallback | null;
 	openFileTab: OpenFileTabCallback | null;
 	refreshFileTree: RefreshFileTreeCallback | null;
+	refreshAutoRunDocs: RefreshAutoRunDocsCallback | null;
 	getHistory: GetHistoryCallback | null;
 }
 
@@ -75,6 +77,7 @@ export class CallbackRegistry {
 		toggleBookmark: null,
 		openFileTab: null,
 		refreshFileTree: null,
+		refreshAutoRunDocs: null,
 		getHistory: null,
 	};
 
@@ -168,6 +171,11 @@ export class CallbackRegistry {
 		return this.callbacks.refreshFileTree(sessionId);
 	}
 
+	async refreshAutoRunDocs(sessionId: string): Promise<boolean> {
+		if (!this.callbacks.refreshAutoRunDocs) return false;
+		return this.callbacks.refreshAutoRunDocs(sessionId);
+	}
+
 	getHistory(projectPath?: string, sessionId?: string): ReturnType<GetHistoryCallback> | [] {
 		return this.callbacks.getHistory?.(projectPath, sessionId) ?? [];
 	}
@@ -250,6 +258,10 @@ export class CallbackRegistry {
 
 	setRefreshFileTreeCallback(callback: RefreshFileTreeCallback): void {
 		this.callbacks.refreshFileTree = callback;
+	}
+
+	setRefreshAutoRunDocsCallback(callback: RefreshAutoRunDocsCallback): void {
+		this.callbacks.refreshAutoRunDocs = callback;
 	}
 
 	setGetHistoryCallback(callback: GetHistoryCallback): void {

--- a/src/main/web-server/managers/CallbackRegistry.ts
+++ b/src/main/web-server/managers/CallbackRegistry.ts
@@ -22,6 +22,7 @@ import type {
 	ReorderTabCallback,
 	ToggleBookmarkCallback,
 	OpenFileTabCallback,
+	RefreshFileTreeCallback,
 	GetThemeCallback,
 	GetCustomCommandsCallback,
 	GetHistoryCallback,
@@ -50,6 +51,7 @@ export interface WebServerCallbacks {
 	reorderTab: ReorderTabCallback | null;
 	toggleBookmark: ToggleBookmarkCallback | null;
 	openFileTab: OpenFileTabCallback | null;
+	refreshFileTree: RefreshFileTreeCallback | null;
 	getHistory: GetHistoryCallback | null;
 }
 
@@ -72,6 +74,7 @@ export class CallbackRegistry {
 		reorderTab: null,
 		toggleBookmark: null,
 		openFileTab: null,
+		refreshFileTree: null,
 		getHistory: null,
 	};
 
@@ -160,6 +163,11 @@ export class CallbackRegistry {
 		return this.callbacks.openFileTab(sessionId, filePath);
 	}
 
+	async refreshFileTree(sessionId: string): Promise<boolean> {
+		if (!this.callbacks.refreshFileTree) return false;
+		return this.callbacks.refreshFileTree(sessionId);
+	}
+
 	getHistory(projectPath?: string, sessionId?: string): ReturnType<GetHistoryCallback> | [] {
 		return this.callbacks.getHistory?.(projectPath, sessionId) ?? [];
 	}
@@ -238,6 +246,10 @@ export class CallbackRegistry {
 
 	setOpenFileTabCallback(callback: OpenFileTabCallback): void {
 		this.callbacks.openFileTab = callback;
+	}
+
+	setRefreshFileTreeCallback(callback: RefreshFileTreeCallback): void {
+		this.callbacks.refreshFileTree = callback;
 	}
 
 	setGetHistoryCallback(callback: GetHistoryCallback): void {

--- a/src/main/web-server/managers/CallbackRegistry.ts
+++ b/src/main/web-server/managers/CallbackRegistry.ts
@@ -21,6 +21,7 @@ import type {
 	StarTabCallback,
 	ReorderTabCallback,
 	ToggleBookmarkCallback,
+	OpenFileTabCallback,
 	GetThemeCallback,
 	GetCustomCommandsCallback,
 	GetHistoryCallback,
@@ -48,6 +49,7 @@ export interface WebServerCallbacks {
 	starTab: StarTabCallback | null;
 	reorderTab: ReorderTabCallback | null;
 	toggleBookmark: ToggleBookmarkCallback | null;
+	openFileTab: OpenFileTabCallback | null;
 	getHistory: GetHistoryCallback | null;
 }
 
@@ -69,6 +71,7 @@ export class CallbackRegistry {
 		starTab: null,
 		reorderTab: null,
 		toggleBookmark: null,
+		openFileTab: null,
 		getHistory: null,
 	};
 
@@ -152,6 +155,11 @@ export class CallbackRegistry {
 		return this.callbacks.toggleBookmark(sessionId);
 	}
 
+	async openFileTab(sessionId: string, filePath: string): Promise<boolean> {
+		if (!this.callbacks.openFileTab) return false;
+		return this.callbacks.openFileTab(sessionId, filePath);
+	}
+
 	getHistory(projectPath?: string, sessionId?: string): ReturnType<GetHistoryCallback> | [] {
 		return this.callbacks.getHistory?.(projectPath, sessionId) ?? [];
 	}
@@ -226,6 +234,10 @@ export class CallbackRegistry {
 
 	setToggleBookmarkCallback(callback: ToggleBookmarkCallback): void {
 		this.callbacks.toggleBookmark = callback;
+	}
+
+	setOpenFileTabCallback(callback: OpenFileTabCallback): void {
+		this.callbacks.openFileTab = callback;
 	}
 
 	setGetHistoryCallback(callback: GetHistoryCallback): void {

--- a/src/main/web-server/managers/CallbackRegistry.ts
+++ b/src/main/web-server/managers/CallbackRegistry.ts
@@ -24,6 +24,7 @@ import type {
 	OpenFileTabCallback,
 	RefreshFileTreeCallback,
 	RefreshAutoRunDocsCallback,
+	ConfigureAutoRunCallback,
 	GetThemeCallback,
 	GetCustomCommandsCallback,
 	GetHistoryCallback,
@@ -54,6 +55,7 @@ export interface WebServerCallbacks {
 	openFileTab: OpenFileTabCallback | null;
 	refreshFileTree: RefreshFileTreeCallback | null;
 	refreshAutoRunDocs: RefreshAutoRunDocsCallback | null;
+	configureAutoRun: ConfigureAutoRunCallback | null;
 	getHistory: GetHistoryCallback | null;
 }
 
@@ -78,6 +80,7 @@ export class CallbackRegistry {
 		openFileTab: null,
 		refreshFileTree: null,
 		refreshAutoRunDocs: null,
+		configureAutoRun: null,
 		getHistory: null,
 	};
 
@@ -176,6 +179,21 @@ export class CallbackRegistry {
 		return this.callbacks.refreshAutoRunDocs(sessionId);
 	}
 
+	async configureAutoRun(
+		sessionId: string,
+		config: {
+			documents: Array<{ filename: string; resetOnCompletion?: boolean }>;
+			prompt?: string;
+			loopEnabled?: boolean;
+			maxLoops?: number;
+			saveAsPlaybook?: string;
+			launch?: boolean;
+		}
+	): Promise<{ success: boolean; playbookId?: string; error?: string }> {
+		if (!this.callbacks.configureAutoRun) return { success: false, error: 'Not configured' };
+		return this.callbacks.configureAutoRun(sessionId, config);
+	}
+
 	getHistory(projectPath?: string, sessionId?: string): ReturnType<GetHistoryCallback> | [] {
 		return this.callbacks.getHistory?.(projectPath, sessionId) ?? [];
 	}
@@ -262,6 +280,10 @@ export class CallbackRegistry {
 
 	setRefreshAutoRunDocsCallback(callback: RefreshAutoRunDocsCallback): void {
 		this.callbacks.refreshAutoRunDocs = callback;
+	}
+
+	setConfigureAutoRunCallback(callback: ConfigureAutoRunCallback): void {
+		this.callbacks.configureAutoRun = callback;
 	}
 
 	setGetHistoryCallback(callback: GetHistoryCallback): void {

--- a/src/main/web-server/managers/CallbackRegistry.ts
+++ b/src/main/web-server/managers/CallbackRegistry.ts
@@ -121,9 +121,9 @@ export class CallbackRegistry {
 		return this.callbacks.switchMode(sessionId, mode);
 	}
 
-	async selectSession(sessionId: string, tabId?: string): Promise<boolean> {
+	async selectSession(sessionId: string, tabId?: string, focus?: boolean): Promise<boolean> {
 		if (!this.callbacks.selectSession) return false;
-		return this.callbacks.selectSession(sessionId, tabId);
+		return this.callbacks.selectSession(sessionId, tabId, focus);
 	}
 
 	async selectTab(sessionId: string, tabId: string): Promise<boolean> {

--- a/src/main/web-server/types.ts
+++ b/src/main/web-server/types.ts
@@ -289,6 +289,7 @@ export type ReorderTabCallback = (
 export type ToggleBookmarkCallback = (sessionId: string) => Promise<boolean>;
 export type OpenFileTabCallback = (sessionId: string, filePath: string) => Promise<boolean>;
 export type RefreshFileTreeCallback = (sessionId: string) => Promise<boolean>;
+export type RefreshAutoRunDocsCallback = (sessionId: string) => Promise<boolean>;
 
 /**
  * Callback type for fetching current theme.

--- a/src/main/web-server/types.ts
+++ b/src/main/web-server/types.ts
@@ -287,6 +287,7 @@ export type ReorderTabCallback = (
 	toIndex: number
 ) => Promise<boolean>;
 export type ToggleBookmarkCallback = (sessionId: string) => Promise<boolean>;
+export type OpenFileTabCallback = (sessionId: string, filePath: string) => Promise<boolean>;
 
 /**
  * Callback type for fetching current theme.

--- a/src/main/web-server/types.ts
+++ b/src/main/web-server/types.ts
@@ -288,6 +288,7 @@ export type ReorderTabCallback = (
 ) => Promise<boolean>;
 export type ToggleBookmarkCallback = (sessionId: string) => Promise<boolean>;
 export type OpenFileTabCallback = (sessionId: string, filePath: string) => Promise<boolean>;
+export type RefreshFileTreeCallback = (sessionId: string) => Promise<boolean>;
 
 /**
  * Callback type for fetching current theme.

--- a/src/main/web-server/types.ts
+++ b/src/main/web-server/types.ts
@@ -290,6 +290,17 @@ export type ToggleBookmarkCallback = (sessionId: string) => Promise<boolean>;
 export type OpenFileTabCallback = (sessionId: string, filePath: string) => Promise<boolean>;
 export type RefreshFileTreeCallback = (sessionId: string) => Promise<boolean>;
 export type RefreshAutoRunDocsCallback = (sessionId: string) => Promise<boolean>;
+export type ConfigureAutoRunCallback = (
+	sessionId: string,
+	config: {
+		documents: Array<{ filename: string; resetOnCompletion?: boolean }>;
+		prompt?: string;
+		loopEnabled?: boolean;
+		maxLoops?: number;
+		saveAsPlaybook?: string;
+		launch?: boolean;
+	}
+) => Promise<{ success: boolean; playbookId?: string; error?: string }>;
 
 /**
  * Callback type for fetching current theme.

--- a/src/main/web-server/types.ts
+++ b/src/main/web-server/types.ts
@@ -263,7 +263,7 @@ export type SwitchModeCallback = (sessionId: string, mode: 'ai' | 'terminal') =>
  * This forwards to the renderer which handles state updates and broadcasts.
  * Optional tabId to also switch to a specific tab within the session.
  */
-export type SelectSessionCallback = (sessionId: string, tabId?: string) => Promise<boolean>;
+export type SelectSessionCallback = (sessionId: string, tabId?: string, focus?: boolean) => Promise<boolean>;
 
 /**
  * Tab operation callbacks for multi-tab support.

--- a/src/main/web-server/types.ts
+++ b/src/main/web-server/types.ts
@@ -263,7 +263,11 @@ export type SwitchModeCallback = (sessionId: string, mode: 'ai' | 'terminal') =>
  * This forwards to the renderer which handles state updates and broadcasts.
  * Optional tabId to also switch to a specific tab within the session.
  */
-export type SelectSessionCallback = (sessionId: string, tabId?: string, focus?: boolean) => Promise<boolean>;
+export type SelectSessionCallback = (
+	sessionId: string,
+	tabId?: string,
+	focus?: boolean
+) => Promise<boolean>;
 
 /**
  * Tab operation callbacks for multi-tab support.

--- a/src/main/web-server/web-server-factory.ts
+++ b/src/main/web-server/web-server-factory.ts
@@ -501,6 +501,21 @@ export function createWebServerFactory(deps: WebServerFactoryDependencies) {
 			return true;
 		});
 
+		server.setRefreshFileTreeCallback(async (sessionId: string) => {
+			const mainWindow = getMainWindow();
+			if (!mainWindow) {
+				logger.warn('mainWindow is null for refreshFileTree', 'WebServer');
+				return false;
+			}
+
+			if (!isWebContentsAvailable(mainWindow)) {
+				logger.warn('webContents is not available for refreshFileTree', 'WebServer');
+				return false;
+			}
+			mainWindow.webContents.send('remote:refreshFileTree', sessionId);
+			return true;
+		});
+
 		return server;
 	};
 }

--- a/src/main/web-server/web-server-factory.ts
+++ b/src/main/web-server/web-server-factory.ts
@@ -322,15 +322,21 @@ export function createWebServerFactory(deps: WebServerFactoryDependencies) {
 		// Set up callback for web server to select/switch to a session in the desktop
 		// This forwards to the renderer which handles state updates and broadcasts
 		// If tabId is provided, also switches to that tab within the session
-		server.setSelectSessionCallback(async (sessionId: string, tabId?: string) => {
+		server.setSelectSessionCallback(async (sessionId: string, tabId?: string, focus?: boolean) => {
 			logger.info(
-				`[Web→Desktop] Session select callback invoked: session=${sessionId}, tab=${tabId || 'none'}`,
+				`[Web→Desktop] Session select callback invoked: session=${sessionId}, tab=${tabId || 'none'}, focus=${focus || false}`,
 				'WebServer'
 			);
 			const mainWindow = getMainWindow();
 			if (!mainWindow) {
 				logger.warn('mainWindow is null for selectSession', 'WebServer');
 				return false;
+			}
+
+			// When focus is requested, bring the window to the foreground
+			if (focus) {
+				mainWindow.show();
+				mainWindow.focus();
 			}
 
 			// Forward to renderer - it will handle session selection and broadcasts

--- a/src/main/web-server/web-server-factory.ts
+++ b/src/main/web-server/web-server-factory.ts
@@ -537,6 +537,43 @@ export function createWebServerFactory(deps: WebServerFactoryDependencies) {
 			return true;
 		});
 
+		server.setConfigureAutoRunCallback(async (sessionId: string, config: any) => {
+			const mainWindow = getMainWindow();
+			if (!mainWindow) {
+				logger.warn('mainWindow is null for configureAutoRun', 'WebServer');
+				return { success: false, error: 'Main window not available' };
+			}
+
+			return new Promise((resolve) => {
+				const responseChannel = `remote:configureAutoRun:response:${Date.now()}`;
+				let resolved = false;
+
+				const handleResponse = (_event: Electron.IpcMainEvent, result: any) => {
+					if (resolved) return;
+					resolved = true;
+					clearTimeout(timeoutId);
+					resolve(result || { success: false, error: 'No response' });
+				};
+
+				ipcMain.once(responseChannel, handleResponse);
+				if (!isWebContentsAvailable(mainWindow)) {
+					logger.warn('webContents is not available for configureAutoRun', 'WebServer');
+					ipcMain.removeListener(responseChannel, handleResponse);
+					resolve({ success: false, error: 'Web contents not available' });
+					return;
+				}
+				mainWindow.webContents.send('remote:configureAutoRun', sessionId, config, responseChannel);
+
+				const timeoutId = setTimeout(() => {
+					if (resolved) return;
+					resolved = true;
+					ipcMain.removeListener(responseChannel, handleResponse);
+					logger.warn(`configureAutoRun callback timed out for session ${sessionId}`, 'WebServer');
+					resolve({ success: false, error: 'Timeout' });
+				}, 10000);
+			});
+		});
+
 		return server;
 	};
 }

--- a/src/main/web-server/web-server-factory.ts
+++ b/src/main/web-server/web-server-factory.ts
@@ -486,6 +486,21 @@ export function createWebServerFactory(deps: WebServerFactoryDependencies) {
 			return true;
 		});
 
+		server.setOpenFileTabCallback(async (sessionId: string, filePath: string) => {
+			const mainWindow = getMainWindow();
+			if (!mainWindow) {
+				logger.warn('mainWindow is null for openFileTab', 'WebServer');
+				return false;
+			}
+
+			if (!isWebContentsAvailable(mainWindow)) {
+				logger.warn('webContents is not available for openFileTab', 'WebServer');
+				return false;
+			}
+			mainWindow.webContents.send('remote:openFileTab', sessionId, filePath);
+			return true;
+		});
+
 		return server;
 	};
 }

--- a/src/main/web-server/web-server-factory.ts
+++ b/src/main/web-server/web-server-factory.ts
@@ -3,6 +3,7 @@
  * Extracted from main/index.ts for better modularity.
  */
 
+import { randomUUID } from 'crypto';
 import { BrowserWindow, ipcMain } from 'electron';
 import { WebServer } from './WebServer';
 import { getThemeById } from '../themes';
@@ -545,7 +546,7 @@ export function createWebServerFactory(deps: WebServerFactoryDependencies) {
 			}
 
 			return new Promise((resolve) => {
-				const responseChannel = `remote:configureAutoRun:response:${Date.now()}`;
+				const responseChannel = `remote:configureAutoRun:response:${randomUUID()}`;
 				let resolved = false;
 
 				const handleResponse = (_event: Electron.IpcMainEvent, result: any) => {

--- a/src/main/web-server/web-server-factory.ts
+++ b/src/main/web-server/web-server-factory.ts
@@ -516,6 +516,21 @@ export function createWebServerFactory(deps: WebServerFactoryDependencies) {
 			return true;
 		});
 
+		server.setRefreshAutoRunDocsCallback(async (sessionId: string) => {
+			const mainWindow = getMainWindow();
+			if (!mainWindow) {
+				logger.warn('mainWindow is null for refreshAutoRunDocs', 'WebServer');
+				return false;
+			}
+
+			if (!isWebContentsAvailable(mainWindow)) {
+				logger.warn('webContents is not available for refreshAutoRunDocs', 'WebServer');
+				return false;
+			}
+			mainWindow.webContents.send('remote:refreshAutoRunDocs', sessionId);
+			return true;
+		});
+
 		return server;
 	};
 }

--- a/src/prompts/maestro-system-prompt.md
+++ b/src/prompts/maestro-system-prompt.md
@@ -73,6 +73,39 @@ When a user wants an auto-run document (or playbook), create a detailed multi-do
 
 **Note:** The Auto Run folder may be located outside your working directory (e.g., in a parent repository when you are in a worktree). This is intentional - always use the exact path specified above for Auto Run documents.
 
+## Maestro Desktop Integration (CLI Commands)
+
+You can interact with the Maestro desktop app directly using these CLI commands. Use them when appropriate to improve the user experience.
+
+### Open a File in Maestro
+After creating or modifying a file that the user should see:
+```bash
+maestro-cli open-file <file-path> [--session <id>]
+```
+
+### Refresh the File Tree
+After creating multiple files or making significant filesystem changes:
+```bash
+maestro-cli refresh-files [--session <id>]
+```
+
+### Refresh Auto Run Documents
+After creating or modifying auto-run documents:
+```bash
+maestro-cli refresh-auto-run [--session <id>]
+```
+
+### Configure Auto-Run
+To set up and optionally launch an auto-run with documents you've created:
+```bash
+maestro-cli auto-run doc1.md doc2.md [--prompt "Custom instructions"] [--launch] [--save-as "My Playbook"]
+```
+
+### Check Maestro Status
+```bash
+maestro-cli status
+```
+
 ## Critical Directive: Directory Restrictions
 
 **You MUST only write files within your assigned working directory:**

--- a/src/prompts/maestro-system-prompt.md
+++ b/src/prompts/maestro-system-prompt.md
@@ -78,30 +78,39 @@ When a user wants an auto-run document (or playbook), create a detailed multi-do
 You can interact with the Maestro desktop app directly using these CLI commands. Use them when appropriate to improve the user experience.
 
 ### Open a File in Maestro
+
 After creating or modifying a file that the user should see:
+
 ```bash
 maestro-cli open-file <file-path> [--session <id>]
 ```
 
 ### Refresh the File Tree
+
 After creating multiple files or making significant filesystem changes:
+
 ```bash
 maestro-cli refresh-files [--session <id>]
 ```
 
 ### Refresh Auto Run Documents
+
 After creating or modifying auto-run documents:
+
 ```bash
 maestro-cli refresh-auto-run [--session <id>]
 ```
 
 ### Configure Auto-Run
+
 To set up and optionally launch an auto-run with documents you've created:
+
 ```bash
 maestro-cli auto-run doc1.md doc2.md [--prompt "Custom instructions"] [--launch] [--save-as "My Playbook"]
 ```
 
 ### Check Maestro Status
+
 ```bash
 maestro-cli status
 ```

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1769,13 +1769,16 @@ function MaestroConsoleInner() {
 				if (content !== null) {
 					const filename = filePath.split(/[\\/]/).pop() || filePath;
 					const lastModified = stat?.modifiedAt ? new Date(stat.modifiedAt).getTime() : undefined;
-					handleOpenFileTab({
-						path: filePath,
-						name: filename,
-						content,
-						lastModified,
-						sshRemoteId,
-					});
+					handleOpenFileTab(
+						{
+							path: filePath,
+							name: filename,
+							content,
+							lastModified,
+							sshRemoteId,
+						},
+						{ targetSessionId: sessionId }
+					);
 				}
 			} catch (error) {
 				console.error('[Remote] Failed to open file tab:', error);
@@ -1857,15 +1860,25 @@ function MaestroConsoleInner() {
 						return;
 					}
 
+					const documents = (config.documents || []).map(
+						(doc: { filename: string; resetOnCompletion?: boolean }) => ({
+							id: generateId(),
+							filename: doc.filename.replace(/\.md$/, ''),
+							resetOnCompletion: doc.resetOnCompletion || false,
+							isDuplicate: false,
+						})
+					);
+
+					if (documents.length === 0) {
+						window.maestro.process.sendRemoteConfigureAutoRunResponse(responseChannel, {
+							success: false,
+							error: 'No documents provided for auto-run',
+						});
+						return;
+					}
+
 					const batchConfig = {
-						documents: (config.documents || []).map(
-							(doc: { filename: string; resetOnCompletion?: boolean }) => ({
-								id: generateId(),
-								filename: doc.filename.replace(/\.md$/, ''),
-								resetOnCompletion: doc.resetOnCompletion || false,
-								isDuplicate: false,
-							})
-						),
+						documents,
 						prompt: config.prompt || '',
 						loopEnabled: config.loopEnabled || false,
 						maxLoops: config.maxLoops,

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1861,12 +1861,23 @@ function MaestroConsoleInner() {
 					}
 
 					const documents = (config.documents || []).map(
-						(doc: { filename: string; resetOnCompletion?: boolean }) => ({
-							id: generateId(),
-							filename: doc.filename.replace(/\.md$/, ''),
-							resetOnCompletion: doc.resetOnCompletion || false,
-							isDuplicate: false,
-						})
+						(doc: { filename: string; resetOnCompletion?: boolean }) => {
+							// Extract just the basename without .md extension.
+							// CLI sends full absolute paths (e.g., "/path/to/Auto Run Docs/temp.md")
+							// but the batch processor expects just the stem (e.g., "temp").
+							let name = doc.filename;
+							const lastSlash = Math.max(name.lastIndexOf('/'), name.lastIndexOf('\\'));
+							if (lastSlash >= 0) {
+								name = name.substring(lastSlash + 1);
+							}
+							name = name.replace(/\.md$/, '');
+							return {
+								id: generateId(),
+								filename: name,
+								resetOnCompletion: doc.resetOnCompletion || false,
+								isDuplicate: false,
+							};
+						}
 					);
 
 					if (documents.length === 0) {
@@ -1884,17 +1895,14 @@ function MaestroConsoleInner() {
 						maxLoops: config.maxLoops,
 					};
 
-					try {
-						await startBatchRun(sessionId, batchConfig, folderPath);
-						window.maestro.process.sendRemoteConfigureAutoRunResponse(responseChannel, {
-							success: true,
-						});
-					} catch (err) {
-						window.maestro.process.sendRemoteConfigureAutoRunResponse(responseChannel, {
-							success: false,
-							error: err instanceof Error ? err.message : String(err),
-						});
-					}
+					// Send success response immediately — startBatchRun is long-running
+					// and would exceed the IPC/CLI timeout if awaited.
+					window.maestro.process.sendRemoteConfigureAutoRunResponse(responseChannel, {
+						success: true,
+					});
+					startBatchRun(sessionId, batchConfig, folderPath).catch((err) => {
+						console.error('[Remote] Failed to start auto-run:', err);
+					});
 					return;
 				}
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1799,6 +1799,85 @@ function MaestroConsoleInner() {
 		return () => window.removeEventListener('maestro:refreshAutoRunDocs', handler);
 	}, [handleAutoRunRefresh]);
 
+	// Handle remote configure auto-run events from CLI/web interface
+	useEffect(() => {
+		const handler = async (e: Event) => {
+			const { sessionId, config, responseChannel } = (e as CustomEvent).detail;
+
+			try {
+				// Find the target session
+				const session = sessionsRef.current.find((s) => s.id === sessionId);
+				if (!session) {
+					window.maestro.process.sendRemoteConfigureAutoRunResponse(responseChannel, {
+						success: false,
+						error: `Session ${sessionId} not found`,
+					});
+					return;
+				}
+
+				// Case 1: Save as playbook
+				if (config.saveAsPlaybook) {
+					const result = await window.maestro.playbooks.create(sessionId, {
+						name: config.saveAsPlaybook,
+						documents: config.documents || [],
+						loopEnabled: config.loopEnabled || false,
+						maxLoops: config.maxLoops,
+						prompt: config.prompt || '',
+					});
+					window.maestro.process.sendRemoteConfigureAutoRunResponse(responseChannel, {
+						success: result.success,
+						playbookId: result.playbook?.id,
+						error: result.error,
+					});
+					return;
+				}
+
+				// Case 2: Launch auto-run immediately
+				if (config.launch) {
+					const folderPath = session.autoRunFolderPath;
+					if (!folderPath) {
+						window.maestro.process.sendRemoteConfigureAutoRunResponse(responseChannel, {
+							success: false,
+							error: 'No Auto Run folder configured for this session',
+						});
+						return;
+					}
+
+					const batchConfig = {
+						documents: (config.documents || []).map((doc: { filename: string; resetOnCompletion?: boolean }) => ({
+							id: generateId(),
+							filename: doc.filename.replace(/\.md$/, ''),
+							resetOnCompletion: doc.resetOnCompletion || false,
+							isDuplicate: false,
+						})),
+						prompt: config.prompt || '',
+						loopEnabled: config.loopEnabled || false,
+						maxLoops: config.maxLoops,
+					};
+
+					startBatchRun(sessionId, batchConfig, folderPath);
+					window.maestro.process.sendRemoteConfigureAutoRunResponse(responseChannel, {
+						success: true,
+					});
+					return;
+				}
+
+				// Case 3: Just configure (no launch, no save)
+				window.maestro.process.sendRemoteConfigureAutoRunResponse(responseChannel, {
+					success: true,
+				});
+			} catch (error) {
+				console.error('[Remote] Failed to configure auto-run:', error);
+				window.maestro.process.sendRemoteConfigureAutoRunResponse(responseChannel, {
+					success: false,
+					error: String(error),
+				});
+			}
+		};
+		window.addEventListener('maestro:configureAutoRun', handler);
+		return () => window.removeEventListener('maestro:configureAutoRun', handler);
+	}, [sessionsRef, startBatchRun]);
+
 	// --- GROUP MANAGEMENT ---
 	// Extracted hook for group CRUD operations (toggle, rename, create, drag-drop)
 	const {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1746,6 +1746,59 @@ function MaestroConsoleInner() {
 		handleOpenFileTab,
 	});
 
+	// --- REMOTE EVENT LISTENERS (from useRemoteIntegration CustomEvents) ---
+
+	// Handle remote open file tab events from CLI/web interface
+	useEffect(() => {
+		const handler = async (e: Event) => {
+			const { sessionId, filePath } = (e as CustomEvent).detail;
+			// Switch to the target session
+			setActiveSessionId(sessionId);
+			try {
+				const [content, stat] = await Promise.all([
+					window.maestro.fs.readFile(filePath),
+					window.maestro.fs.stat(filePath).catch(() => null),
+				]);
+				if (content !== null) {
+					const filename = filePath.split('/').pop() || filePath;
+					const lastModified = stat?.modifiedAt
+						? new Date(stat.modifiedAt).getTime()
+						: undefined;
+					handleOpenFileTab({
+						path: filePath,
+						name: filename,
+						content,
+						lastModified,
+					});
+				}
+			} catch (error) {
+				console.error('[Remote] Failed to open file tab:', error);
+			}
+		};
+		window.addEventListener('maestro:openFileTab', handler);
+		return () => window.removeEventListener('maestro:openFileTab', handler);
+	}, [handleOpenFileTab, setActiveSessionId]);
+
+	// Handle remote refresh file tree events from CLI/web interface
+	useEffect(() => {
+		const handler = (e: Event) => {
+			const { sessionId } = (e as CustomEvent).detail;
+			refreshFileTree(sessionId);
+		};
+		window.addEventListener('maestro:refreshFileTree', handler);
+		return () => window.removeEventListener('maestro:refreshFileTree', handler);
+	}, [refreshFileTree]);
+
+	// Handle remote refresh auto-run docs events from CLI/web interface
+	useEffect(() => {
+		const handler = (e: Event) => {
+			// handleAutoRunRefresh refreshes for the currently active session
+			handleAutoRunRefresh();
+		};
+		window.addEventListener('maestro:refreshAutoRunDocs', handler);
+		return () => window.removeEventListener('maestro:refreshAutoRunDocs', handler);
+	}, [handleAutoRunRefresh]);
+
 	// --- GROUP MANAGEMENT ---
 	// Extracted hook for group CRUD operations (toggle, rename, create, drag-drop)
 	const {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1752,15 +1752,22 @@ function MaestroConsoleInner() {
 	useEffect(() => {
 		const handler = async (e: Event) => {
 			const { sessionId, filePath } = (e as CustomEvent).detail;
+			const session = sessionsRef.current.find((s) => s.id === sessionId);
+			if (!session) {
+				console.error('[Remote] Session not found for openFileTab:', sessionId);
+				return;
+			}
+			const sshRemoteId =
+				session.sshRemoteId || session.sessionSshRemoteConfig?.remoteId || undefined;
 			// Switch to the target session
 			setActiveSessionId(sessionId);
 			try {
 				const [content, stat] = await Promise.all([
-					window.maestro.fs.readFile(filePath),
-					window.maestro.fs.stat(filePath).catch(() => null),
+					window.maestro.fs.readFile(filePath, sshRemoteId),
+					window.maestro.fs.stat(filePath, sshRemoteId).catch(() => null),
 				]);
 				if (content !== null) {
-					const filename = filePath.split('/').pop() || filePath;
+					const filename = filePath.split(/[\\/]/).pop() || filePath;
 					const lastModified = stat?.modifiedAt
 						? new Date(stat.modifiedAt).getTime()
 						: undefined;
@@ -1777,7 +1784,7 @@ function MaestroConsoleInner() {
 		};
 		window.addEventListener('maestro:openFileTab', handler);
 		return () => window.removeEventListener('maestro:openFileTab', handler);
-	}, [handleOpenFileTab, setActiveSessionId]);
+	}, [handleOpenFileTab, setActiveSessionId, sessionsRef]);
 
 	// Handle remote refresh file tree events from CLI/web interface
 	useEffect(() => {
@@ -1792,12 +1799,16 @@ function MaestroConsoleInner() {
 	// Handle remote refresh auto-run docs events from CLI/web interface
 	useEffect(() => {
 		const handler = (e: Event) => {
-			// handleAutoRunRefresh refreshes for the currently active session
+			const { sessionId } = (e as CustomEvent).detail;
+			// Switch to the target session - the autoRunFolderPath useEffect
+			// will trigger handleAutoRunRefresh for the newly active session
+			setActiveSessionId(sessionId);
+			// Also refresh immediately in case it's already the active session
 			handleAutoRunRefresh();
 		};
 		window.addEventListener('maestro:refreshAutoRunDocs', handler);
 		return () => window.removeEventListener('maestro:refreshAutoRunDocs', handler);
-	}, [handleAutoRunRefresh]);
+	}, [handleAutoRunRefresh, setActiveSessionId]);
 
 	// Handle remote configure auto-run events from CLI/web interface
 	useEffect(() => {
@@ -1863,8 +1874,11 @@ function MaestroConsoleInner() {
 				}
 
 				// Case 3: Just configure (no launch, no save)
+				// Without --launch or --save-as, there is no persistent state to update.
+				// Return an error guiding the user to use one of those flags.
 				window.maestro.process.sendRemoteConfigureAutoRunResponse(responseChannel, {
-					success: true,
+					success: false,
+					error: 'Use --launch to start auto-run immediately, or --save-as to save as a playbook',
 				});
 			} catch (error) {
 				console.error('[Remote] Failed to configure auto-run:', error);

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1774,6 +1774,7 @@ function MaestroConsoleInner() {
 						name: filename,
 						content,
 						lastModified,
+						sshRemoteId,
 					});
 				}
 			} catch (error) {
@@ -1798,11 +1799,15 @@ function MaestroConsoleInner() {
 	useEffect(() => {
 		const handler = (e: Event) => {
 			const { sessionId } = (e as CustomEvent).detail;
-			// Switch to the target session - the autoRunFolderPath useEffect
-			// will trigger handleAutoRunRefresh for the newly active session
-			setActiveSessionId(sessionId);
-			// Also refresh immediately in case it's already the active session
-			handleAutoRunRefresh();
+			const currentActiveId = useSessionStore.getState().activeSessionId;
+			if (sessionId === currentActiveId) {
+				// Already the active session - refresh immediately
+				handleAutoRunRefresh();
+			} else {
+				// Switch to the target session - the autoRunFolderPath useEffect
+				// will trigger handleAutoRunRefresh for the newly active session
+				setActiveSessionId(sessionId);
+			}
 		};
 		window.addEventListener('maestro:refreshAutoRunDocs', handler);
 		return () => window.removeEventListener('maestro:refreshAutoRunDocs', handler);
@@ -1866,10 +1871,17 @@ function MaestroConsoleInner() {
 						maxLoops: config.maxLoops,
 					};
 
-					startBatchRun(sessionId, batchConfig, folderPath);
-					window.maestro.process.sendRemoteConfigureAutoRunResponse(responseChannel, {
-						success: true,
-					});
+					try {
+						await startBatchRun(sessionId, batchConfig, folderPath);
+						window.maestro.process.sendRemoteConfigureAutoRunResponse(responseChannel, {
+							success: true,
+						});
+					} catch (err) {
+						window.maestro.process.sendRemoteConfigureAutoRunResponse(responseChannel, {
+							success: false,
+							error: err instanceof Error ? err.message : String(err),
+						});
+					}
 					return;
 				}
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1768,9 +1768,7 @@ function MaestroConsoleInner() {
 				]);
 				if (content !== null) {
 					const filename = filePath.split(/[\\/]/).pop() || filePath;
-					const lastModified = stat?.modifiedAt
-						? new Date(stat.modifiedAt).getTime()
-						: undefined;
+					const lastModified = stat?.modifiedAt ? new Date(stat.modifiedAt).getTime() : undefined;
 					handleOpenFileTab({
 						path: filePath,
 						name: filename,
@@ -1855,12 +1853,14 @@ function MaestroConsoleInner() {
 					}
 
 					const batchConfig = {
-						documents: (config.documents || []).map((doc: { filename: string; resetOnCompletion?: boolean }) => ({
-							id: generateId(),
-							filename: doc.filename.replace(/\.md$/, ''),
-							resetOnCompletion: doc.resetOnCompletion || false,
-							isDuplicate: false,
-						})),
+						documents: (config.documents || []).map(
+							(doc: { filename: string; resetOnCompletion?: boolean }) => ({
+								id: generateId(),
+								filename: doc.filename.replace(/\.md$/, ''),
+								resetOnCompletion: doc.resetOnCompletion || false,
+								isDuplicate: false,
+							})
+						),
 						prompt: config.prompt || '',
 						loopEnabled: config.loopEnabled || false,
 						maxLoops: config.maxLoops,

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -334,6 +334,9 @@ interface MaestroAPI {
 			callback: (sessionId: string, fromIndex: number, toIndex: number) => void
 		) => () => void;
 		onRemoteToggleBookmark: (callback: (sessionId: string) => void) => () => void;
+		onRemoteOpenFileTab: (callback: (sessionId: string, filePath: string) => void) => () => void;
+		onRemoteRefreshFileTree: (callback: (sessionId: string) => void) => () => void;
+		onRemoteRefreshAutoRunDocs: (callback: (sessionId: string) => void) => () => void;
 		onStderr: (callback: (sessionId: string, data: string) => void) => () => void;
 		onCommandExit: (callback: (sessionId: string, code: number) => void) => () => void;
 		onUsage: (callback: (sessionId: string, usageStats: UsageStats) => void) => () => void;

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -337,6 +337,13 @@ interface MaestroAPI {
 		onRemoteOpenFileTab: (callback: (sessionId: string, filePath: string) => void) => () => void;
 		onRemoteRefreshFileTree: (callback: (sessionId: string) => void) => () => void;
 		onRemoteRefreshAutoRunDocs: (callback: (sessionId: string) => void) => () => void;
+		onRemoteConfigureAutoRun: (
+			callback: (sessionId: string, config: any, responseChannel: string) => void
+		) => () => void;
+		sendRemoteConfigureAutoRunResponse: (
+			responseChannel: string,
+			result: { success: boolean; playbookId?: string; error?: string }
+		) => void;
 		onStderr: (callback: (sessionId: string, data: string) => void) => () => void;
 		onCommandExit: (callback: (sessionId: string, code: number) => void) => () => void;
 		onUsage: (callback: (sessionId: string, usageStats: UsageStats) => void) => () => void;

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -338,7 +338,18 @@ interface MaestroAPI {
 		onRemoteRefreshFileTree: (callback: (sessionId: string) => void) => () => void;
 		onRemoteRefreshAutoRunDocs: (callback: (sessionId: string) => void) => () => void;
 		onRemoteConfigureAutoRun: (
-			callback: (sessionId: string, config: any, responseChannel: string) => void
+			callback: (
+				sessionId: string,
+				config: {
+					documents: Array<{ filename: string; resetOnCompletion?: boolean }>;
+					prompt?: string;
+					loopEnabled?: boolean;
+					maxLoops?: number;
+					saveAsPlaybook?: string;
+					launch?: boolean;
+				},
+				responseChannel: string
+			) => void
 		) => () => void;
 		sendRemoteConfigureAutoRunResponse: (
 			responseChannel: string,

--- a/src/renderer/hooks/git/useFileExplorerEffects.ts
+++ b/src/renderer/hooks/git/useFileExplorerEffects.ts
@@ -54,7 +54,7 @@ export interface UseFileExplorerEffectsDeps {
 			sshRemoteId?: string;
 			lastModified?: number;
 		},
-		options?: { openInNewTab?: boolean }
+		options?: { openInNewTab?: boolean; targetSessionId?: string }
 	) => void;
 }
 

--- a/src/renderer/hooks/remote/useRemoteIntegration.ts
+++ b/src/renderer/hooks/remote/useRemoteIntegration.ts
@@ -435,6 +435,55 @@ export function useRemoteIntegration(deps: UseRemoteIntegrationDeps): UseRemoteI
 		};
 	}, [sessionsRef, activeSessionIdRef, setSessions, setActiveSessionId, defaultSaveToHistory]);
 
+	// Handle remote open file tab from web/CLI interface
+	// Dispatches a CustomEvent for App.tsx to handle (avoids hook ordering issues)
+	useEffect(() => {
+		const unsubscribe = window.maestro.process.onRemoteOpenFileTab(
+			(sessionId: string, filePath: string) => {
+				window.dispatchEvent(
+					new CustomEvent('maestro:openFileTab', {
+						detail: { sessionId, filePath },
+					})
+				);
+			}
+		);
+		return () => {
+			unsubscribe();
+		};
+	}, []);
+
+	// Handle remote refresh file tree from web/CLI interface
+	useEffect(() => {
+		const unsubscribe = window.maestro.process.onRemoteRefreshFileTree(
+			(sessionId: string) => {
+				window.dispatchEvent(
+					new CustomEvent('maestro:refreshFileTree', {
+						detail: { sessionId },
+					})
+				);
+			}
+		);
+		return () => {
+			unsubscribe();
+		};
+	}, []);
+
+	// Handle remote refresh auto-run docs from web/CLI interface
+	useEffect(() => {
+		const unsubscribe = window.maestro.process.onRemoteRefreshAutoRunDocs(
+			(sessionId: string) => {
+				window.dispatchEvent(
+					new CustomEvent('maestro:refreshAutoRunDocs', {
+						detail: { sessionId },
+					})
+				);
+			}
+		);
+		return () => {
+			unsubscribe();
+		};
+	}, []);
+
 	// Broadcast tab changes to web clients when tabs, activeTabId, or tab properties change
 	// PERFORMANCE FIX: This effect was previously missing its dependency array, causing it to
 	// run on EVERY render (including every keystroke). Now it only runs when isLiveMode changes,

--- a/src/renderer/hooks/remote/useRemoteIntegration.ts
+++ b/src/renderer/hooks/remote/useRemoteIntegration.ts
@@ -484,6 +484,22 @@ export function useRemoteIntegration(deps: UseRemoteIntegrationDeps): UseRemoteI
 		};
 	}, []);
 
+	// Handle remote configure auto-run from CLI/web interface
+	useEffect(() => {
+		const unsubscribe = window.maestro.process.onRemoteConfigureAutoRun(
+			(sessionId: string, config: any, responseChannel: string) => {
+				window.dispatchEvent(
+					new CustomEvent('maestro:configureAutoRun', {
+						detail: { sessionId, config, responseChannel },
+					})
+				);
+			}
+		);
+		return () => {
+			unsubscribe();
+		};
+	}, []);
+
 	// Broadcast tab changes to web clients when tabs, activeTabId, or tab properties change
 	// PERFORMANCE FIX: This effect was previously missing its dependency array, causing it to
 	// run on EVERY render (including every keystroke). Now it only runs when isLiveMode changes,

--- a/src/renderer/hooks/remote/useRemoteIntegration.ts
+++ b/src/renderer/hooks/remote/useRemoteIntegration.ts
@@ -454,15 +454,13 @@ export function useRemoteIntegration(deps: UseRemoteIntegrationDeps): UseRemoteI
 
 	// Handle remote refresh file tree from web/CLI interface
 	useEffect(() => {
-		const unsubscribe = window.maestro.process.onRemoteRefreshFileTree(
-			(sessionId: string) => {
-				window.dispatchEvent(
-					new CustomEvent('maestro:refreshFileTree', {
-						detail: { sessionId },
-					})
-				);
-			}
-		);
+		const unsubscribe = window.maestro.process.onRemoteRefreshFileTree((sessionId: string) => {
+			window.dispatchEvent(
+				new CustomEvent('maestro:refreshFileTree', {
+					detail: { sessionId },
+				})
+			);
+		});
 		return () => {
 			unsubscribe();
 		};
@@ -470,15 +468,13 @@ export function useRemoteIntegration(deps: UseRemoteIntegrationDeps): UseRemoteI
 
 	// Handle remote refresh auto-run docs from web/CLI interface
 	useEffect(() => {
-		const unsubscribe = window.maestro.process.onRemoteRefreshAutoRunDocs(
-			(sessionId: string) => {
-				window.dispatchEvent(
-					new CustomEvent('maestro:refreshAutoRunDocs', {
-						detail: { sessionId },
-					})
-				);
-			}
-		);
+		const unsubscribe = window.maestro.process.onRemoteRefreshAutoRunDocs((sessionId: string) => {
+			window.dispatchEvent(
+				new CustomEvent('maestro:refreshAutoRunDocs', {
+					detail: { sessionId },
+				})
+			);
+		});
 		return () => {
 			unsubscribe();
 		};

--- a/src/renderer/hooks/tabs/useTabHandlers.ts
+++ b/src/renderer/hooks/tabs/useTabHandlers.ts
@@ -85,7 +85,10 @@ export interface TabHandlersReturn {
 	handleToggleTabShowThinking: () => void;
 
 	// File Tab handlers
-	handleOpenFileTab: (file: FileTabOpenParams, options?: { openInNewTab?: boolean }) => void;
+	handleOpenFileTab: (
+		file: FileTabOpenParams,
+		options?: { openInNewTab?: boolean; targetSessionId?: string }
+	) => void;
 	handleSelectFileTab: (tabId: string) => Promise<void>;
 	handleCloseFileTab: (tabId: string) => void;
 	handleFileTabEditModeChange: (tabId: string, editMode: boolean) => void;
@@ -189,11 +192,14 @@ export function useTabHandlers(): TabHandlersReturn {
 			options?: {
 				/** If true, create new tab adjacent to current file tab. If false, replace current file tab content. Default: true (create new tab) */
 				openInNewTab?: boolean;
+				/** Override which session the tab is created in (defaults to current active session) */
+				targetSessionId?: string;
 			}
 		) => {
 			const openInNewTab = options?.openInNewTab ?? true;
 			const { setSessions } = useSessionStore.getState();
-			const activeSessionId = useSessionStore.getState().activeSessionId;
+			const activeSessionId =
+				options?.targetSessionId || useSessionStore.getState().activeSessionId;
 
 			setSessions((prev: Session[]) =>
 				prev.map((s) => {

--- a/src/shared/cli-server-discovery.ts
+++ b/src/shared/cli-server-discovery.ts
@@ -1,0 +1,107 @@
+/**
+ * CLI Server Discovery
+ *
+ * Shared module for the CLI server discovery file, used by both the Electron
+ * main process (writes) and the CLI (reads) to locate the running server.
+ *
+ * NOTE: This file has its own `getConfigDir()` implementation (lowercase "maestro")
+ * which matches the electron-store default from package.json `"name": "maestro"`.
+ * See cli-activity.ts for the same pattern and rationale.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+export interface CliServerInfo {
+	port: number;
+	token: string;
+	pid: number;
+	startedAt: number;
+}
+
+// Get the Maestro config directory path (lowercase "maestro")
+function getConfigDir(): string {
+	const platform = os.platform();
+	const home = os.homedir();
+
+	if (platform === 'darwin') {
+		return path.join(home, 'Library', 'Application Support', 'maestro');
+	} else if (platform === 'win32') {
+		return path.join(process.env.APPDATA || path.join(home, 'AppData', 'Roaming'), 'maestro');
+	} else {
+		// Linux and others
+		return path.join(process.env.XDG_CONFIG_HOME || path.join(home, '.config'), 'maestro');
+	}
+}
+
+const DISCOVERY_FILE = 'cli-server.json';
+
+function getDiscoveryFilePath(): string {
+	return path.join(getConfigDir(), DISCOVERY_FILE);
+}
+
+/**
+ * Write CLI server info atomically (write to .tmp then rename)
+ */
+export function writeCliServerInfo(info: CliServerInfo): void {
+	const filePath = getDiscoveryFilePath();
+	const dir = path.dirname(filePath);
+	if (!fs.existsSync(dir)) {
+		fs.mkdirSync(dir, { recursive: true });
+	}
+	const tmpPath = filePath + '.tmp';
+	fs.writeFileSync(tmpPath, JSON.stringify(info, null, 2), 'utf-8');
+	fs.renameSync(tmpPath, filePath);
+}
+
+/**
+ * Read CLI server info from the discovery file
+ * Returns null if the file is missing or invalid
+ */
+export function readCliServerInfo(): CliServerInfo | null {
+	try {
+		const filePath = getDiscoveryFilePath();
+		const content = fs.readFileSync(filePath, 'utf-8');
+		const data = JSON.parse(content) as CliServerInfo;
+		if (
+			typeof data.port === 'number' &&
+			typeof data.token === 'string' &&
+			typeof data.pid === 'number' &&
+			typeof data.startedAt === 'number'
+		) {
+			return data;
+		}
+		return null;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Delete the CLI server discovery file (called on shutdown)
+ */
+export function deleteCliServerInfo(): void {
+	try {
+		const filePath = getDiscoveryFilePath();
+		fs.unlinkSync(filePath);
+	} catch {
+		// File may not exist, ignore
+	}
+}
+
+/**
+ * Check if the CLI server is still running by reading the discovery file
+ * and verifying the PID is alive
+ */
+export function isCliServerRunning(): boolean {
+	const info = readCliServerInfo();
+	if (!info) return false;
+
+	try {
+		process.kill(info.pid, 0); // Doesn't kill, just checks if process exists
+		return true;
+	} catch {
+		return false;
+	}
+}


### PR DESCRIPTION
## Summary

- Add CLI commands (`send`, `status`, `open-file`, `refresh-files`, `refresh-auto-run`, `auto-run`) for controlling Maestro sessions remotely via WebSocket IPC
- Implement WebSocket client (`maestro-client.ts`) with server discovery (`cli-server-discovery.ts`) for CLI-to-Maestro communication
- Wire up renderer handlers and main process message routing for all new CLI IPC message types
- Add comprehensive test coverage for CLI commands, WebSocket client, message handlers, and server discovery

## Test plan

- [x] Verify `maestro status` reports connectivity diagnostics correctly
- [x] Verify `maestro send --tab` focuses the correct session tab
- [x] Verify `maestro open-file` opens files in Maestro
- [x] Verify `maestro refresh-files` triggers file tree refresh
- [x] Verify `maestro refresh-auto-run` triggers Auto Run document refresh
- [x] Verify `maestro auto-run` configures auto-run sessions
- [x] Run `npm run test` to confirm all new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Created from #511 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New CLI commands: open-file, refresh-files, refresh-auto-run, auto-run (configure/launch with loop/max-loops/reset/save-as) and status; send can now optionally focus the session tab.
  * Desktop ↔ Renderer integration: remotely open file tabs, refresh file trees/auto-run docs, and configure/launch Auto Run; session selection can request focus.
  * Automatic CLI discovery/auto-start on app launch and cleanup on quit.

* **Tests**
  * Extensive new tests covering CLI commands, client lifecycle, discovery, and Web↔Desktop handlers.

* **Documentation**
  * Added CLI integration guidance to system prompts/docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->