### PR TITLE
fix: include node version manager paths in agent child process PATH

### DIFF
--- a/src/__tests__/cli/services/agent-spawner.test.ts
+++ b/src/__tests__/cli/services/agent-spawner.test.ts
@@ -50,13 +50,16 @@ vi.mock('fs', async (importOriginal) => {
 	const actual = await importOriginal<typeof import('fs')>();
 	return {
 		...actual,
+		existsSync: actual.existsSync,
 		readFileSync: vi.fn(),
 		writeFileSync: vi.fn(),
 		promises: {
+			...actual.promises,
 			stat: vi.fn(),
 			access: vi.fn(),
 		},
 		constants: {
+			...actual.constants,
 			X_OK: 1,
 		},
 	};

--- a/src/__tests__/cli/services/agent-spawner.test.ts
+++ b/src/__tests__/cli/services/agent-spawner.test.ts
@@ -45,12 +45,15 @@ vi.mock('child_process', async (importOriginal) => {
 	};
 });
 
-// Mock fs module
+// Mock fs module — existsSync must be a deterministic mock (not the real one)
+// so that detectNodeVersionManagerBinPaths() doesn't probe the host filesystem,
+// keeping tests host-independent.
 vi.mock('fs', async (importOriginal) => {
 	const actual = await importOriginal<typeof import('fs')>();
 	return {
 		...actual,
-		existsSync: actual.existsSync,
+		existsSync: vi.fn(() => false),
+		readdirSync: vi.fn(() => []),
 		readFileSync: vi.fn(),
 		writeFileSync: vi.fn(),
 		promises: {

--- a/src/shared/pathUtils.ts
+++ b/src/shared/pathUtils.ts
@@ -395,6 +395,15 @@ export function buildExpandedPath(customPaths?: string[]): string {
 		}
 	}
 
+	// Add Node version manager paths (nvm, fnm, volta, mise, asdf, n)
+	// These are critical for agents spawned as child processes to find node/npm
+	const versionManagerPaths = detectNodeVersionManagerBinPaths();
+	for (const p of versionManagerPaths) {
+		if (!pathParts.includes(p)) {
+			pathParts.unshift(p);
+		}
+	}
+
 	// Add standard additional paths
 	for (const p of additionalPaths) {
 		if (!pathParts.includes(p)) {

--- a/src/shared/pathUtils.ts
+++ b/src/shared/pathUtils.ts
@@ -395,17 +395,18 @@ export function buildExpandedPath(customPaths?: string[]): string {
 		}
 	}
 
-	// Add Node version manager paths (nvm, fnm, volta, mise, asdf, n)
-	// These are critical for agents spawned as child processes to find node/npm
-	const versionManagerPaths = detectNodeVersionManagerBinPaths();
-	for (const p of versionManagerPaths) {
+	// Add standard additional paths
+	for (const p of additionalPaths) {
 		if (!pathParts.includes(p)) {
 			pathParts.unshift(p);
 		}
 	}
 
-	// Add standard additional paths
-	for (const p of additionalPaths) {
+	// Add Node version manager paths (nvm, fnm, volta, mise, asdf, n) LAST
+	// so they land at the front of PATH via unshift, ensuring version manager
+	// binaries take priority over system-installed Node in /usr/local/bin etc.
+	const versionManagerPaths = detectNodeVersionManagerBinPaths();
+	for (const p of versionManagerPaths) {
 		if (!pathParts.includes(p)) {
 			pathParts.unshift(p);
 		}


### PR DESCRIPTION
This pull request adds a crucial enhancement to the `buildExpandedPath` function in `src/shared/pathUtils.ts`. The change ensures that paths from popular Node version managers are included at the beginning of the PATH, which is important for agents spawned as child processes to reliably locate the correct Node.js and npm binaries.

Node version manager support:

* The function now detects and prepends binary paths from Node version managers (such as nvm, fnm, volta, mise, asdf, n) to the PATH, improving compatibility and reliability for child processes that require Node.js tools.buildExpandedPath() was missing detectNodeVersionManagerBinPaths() calls, so agents spawned as child processes couldn't find node/npm from nvm/fnm/ volta/mise/asdf/n. Only PTY terminal sessions had these paths via buildUnixBasePath(). Now all callers of buildExpandedPath() get version manager paths cross-platform.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and prioritization of Node version manager binaries (nvm, fnm, Volta, Mise, asdf, n) so tools from those managers are preferred over system-installed Node, reducing version conflicts and ensuring commands run with the expected Node runtime.

* **Tests**
  * Hardened tests by isolating filesystem checks to avoid probing the host filesystem, making related tests deterministic and more reliable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->