### PR TITLE
fix: clear stale agentSessionId on session_not_found loop

### DIFF
--- a/src/__tests__/renderer/hooks/useAgentListeners.test.ts
+++ b/src/__tests__/renderer/hooks/useAgentListeners.test.ts
@@ -691,6 +691,39 @@ describe('useAgentListeners', () => {
 			expect(agentErrorOpen).toBe(false);
 		});
 
+		it('clears agentSessionId on session_not_found so next prompt starts fresh', () => {
+			const deps = createMockDeps();
+			const tab = createMockTab({
+				id: 'tab-1',
+				agentSessionId: 'stale-session-abc123',
+			});
+			const session = createMockSession({
+				id: 'sess-1',
+				state: 'busy',
+				aiTabs: [tab],
+				activeTabId: 'tab-1',
+				agentSessionId: 'stale-session-abc123',
+			});
+			useSessionStore.setState({
+				sessions: [session],
+				activeSessionId: 'sess-1',
+			});
+
+			renderHook(() => useAgentListeners(deps));
+
+			onAgentErrorHandler?.('sess-1-ai-tab-1', {
+				...baseError,
+				type: 'session_not_found',
+			});
+
+			const updated = useSessionStore.getState().sessions.find((s) => s.id === 'sess-1');
+			const updatedTab = updated?.aiTabs.find((t) => t.id === 'tab-1');
+			// Tab-level agentSessionId must be cleared
+			expect(updatedTab?.agentSessionId).toBeUndefined();
+			// Session-level agentSessionId must also be cleared
+			expect(updated?.agentSessionId).toBeUndefined();
+		});
+
 		it('appends error log entry to the target tab', () => {
 			const deps = createMockDeps();
 			const tab = createMockTab({ id: 'tab-1', logs: [] });

--- a/src/renderer/hooks/agent/useAgentListeners.ts
+++ b/src/renderer/hooks/agent/useAgentListeners.ts
@@ -1211,6 +1211,10 @@ export function useAgentListeners(deps: UseAgentListenersDeps): void {
 												...tab,
 												logs: [...tab.logs, errorLogEntry],
 												agentError: isSessionNotFound ? undefined : agentError,
+												// Clear stale agentSessionId so the next prompt
+												// starts a fresh session instead of trying to
+												// --resume the deleted one (infinite loop).
+												...(isSessionNotFound ? { agentSessionId: undefined } : {}),
 											}
 										: tab
 								)
@@ -1220,6 +1224,8 @@ export function useAgentListeners(deps: UseAgentListenersDeps): void {
 							return {
 								...s,
 								aiTabs: updatedAiTabs,
+								// Also clear session-level agentSessionId
+								agentSessionId: undefined,
 							};
 						}
 


### PR DESCRIPTION
## Summary

- When a Claude session expires or is deleted, the stale `agentSessionId` was never cleared — every subsequent prompt tried `--resume` with the dead ID, received `session_not_found`, and looped endlessly
- Now clears `agentSessionId` at both tab and session level on `session_not_found` errors, so the next prompt starts a fresh session automatically

## Test plan

- [x] Unit test added: verifies `agentSessionId` is cleared at both tab and session level on `session_not_found`
- [ ] End-to-end: let a Claude session expire, send a new prompt — should recover without manual intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Session identifiers are now properly cleared when a session-not-found error occurs, ensuring correct state management and proper cleanup for subsequent interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->