### PR TITLE
fix: pass sshRemoteId to watchFolder in wizard document generation

### DIFF
--- a/src/renderer/services/inlineWizardDocumentGeneration.ts
+++ b/src/renderer/services/inlineWizardDocumentGeneration.ts
@@ -843,7 +843,7 @@ export async function generateInlineDocuments(
 				// Set up file watcher for real-time document streaming
 				// The agent writes files directly, and we detect them here
 				window.maestro.autorun
-					.watchFolder(subfolderPath)
+					.watchFolder(subfolderPath, sshRemoteId || undefined)
 					.then((watchResult) => {
 						if (watchResult.success) {
 							console.log('[InlineWizardDocGen] Started watching folder:', subfolderPath);


### PR DESCRIPTION
## Summary

Fixes an issue where the inline wizard fails when generating Auto Run documents for SSH remote projects with the error: `ENOENT: no such file or directory, mkdir '/data'`

## Root Cause

When generating documents via the inline wizard for SSH remote projects, the `watchFolder()` call was not passing the `sshRemoteId` parameter. This caused the autorun handler to treat the remote path as a local path, attempting to create the directory locally (e.g., `/data/`), which doesn't exist on the local machine.

## The Fix

Pass `sshRemoteId` to `watchFolder()` in `src/renderer/services/inlineWizardDocumentGeneration.ts` (line 846):

```typescript
// Before:
.watchFolder(subfolderPath)

// After:
.watchFolder(subfolderPath, sshRemoteId || undefined)
```

## How It Works

The `autorun:watchFolder` handler (`src/main/ipc/handlers/autorun.ts`, lines 779-807) already supports SSH remotes:

- When `sshRemoteId` is provided, it looks up the SSH config and uses `existsRemote()`/`mkdirRemote()` to handle the folder on the remote host
- Returns `{ isRemote: true }` to indicate the UI should use polling (since chokidar can't watch remote directories)

Without the `sshRemoteId`, the handler falls through to the local filesystem branch, causing the ENOENT error.

## Files Changed

- `src/renderer/services/inlineWizardDocumentGeneration.ts` - Added `sshRemoteId` parameter to `watchFolder()` call

## Testing

- [ ] Test document generation with SSH remote project
- [ ] Verify no regression for local projects

## Related Code References

- **Fixed file:** `src/renderer/services/inlineWizardDocumentGeneration.ts` (line 846)
- **Handler:** `src/main/ipc/handlers/autorun.ts` (`watchFolder` handler, lines 779-807)
- **Preload API:** `src/main/preload/autorun.ts` (`watchFolder` signature, lines 82-86)

## Error Context

This error occurred during Step 4 of 5 in the Wizard ("Preparing Playbooks") when using a remote project at `/data/projects/apply-loop` on an SSH host. The file watcher tried to create `/data` locally instead of on the remote host.

## Checklist

- [x] Linting passes
- [x] Single, focused change
- [x] Conventional commit format
- [x] Up to date with upstream main


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for remote folder monitoring during SSH sessions, enabling seamless file watching when connected to remote servers.
  * Automatically checks for and resumes incomplete wizard flows on app startup, prompting users to continue where they left off.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->