### PR TITLE
fix: clean remote CLI control sequence leaks

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+# Run repo-wide validation before allowing a push.
+# This keeps formatting, type checks, and ESLint green before CI sees the branch.
+npm run validate:push

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 # Run repo-wide validation before allowing a push.
-# This keeps formatting, type checks, and ESLint green before CI sees the branch.
+# This mirrors the main CI gate: prompts, repo-wide Prettier, type checks, ESLint, and tests.
 npm run validate:push

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ After refactoring: identify now-unreachable code, list it explicitly, ask "Shoul
 
 ### Validate Before Push
 
-Before pushing any branch, re-run the relevant formatting, lint, and type-check commands for the changes you made. Fix any issues those commands surface, include the fixes in the branch, and only then push or update the PR.
+Before pushing any branch, re-run the relevant formatting, lint, type-check, and test commands for the changes you made. Fix any issues those commands surface, include the fixes in the branch, and only then push or update the PR.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,10 @@ Touch only what's asked. Do NOT: remove comments you don't understand, "clean up
 
 After refactoring: identify now-unreachable code, list it explicitly, ask "Should I remove these now-unused elements: [list]?" Don't leave corpses. Don't delete without asking.
 
+### Validate Before Push
+
+Before pushing any branch, re-run the relevant formatting, lint, and type-check commands for the changes you made. Fix any issues those commands surface, include the fixes in the branch, and only then push or update the PR.
+
 ---
 
 ## Standardized Vernacular

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
 		"format:all": "prettier --write .",
 		"format:check": "prettier --check \"src/**/*.{ts,tsx}\"",
 		"format:check:all": "prettier --check .",
+		"validate:push": "npm run build:prompts && npm run format:check:all && npm run lint && npm run lint:eslint",
 		"test": "vitest run",
 		"test:watch": "vitest",
 		"test:coverage": "vitest run --coverage",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
 		"format:all": "prettier --write .",
 		"format:check": "prettier --check \"src/**/*.{ts,tsx}\"",
 		"format:check:all": "prettier --check .",
-		"validate:push": "npm run build:prompts && npm run format:check:all && npm run lint && npm run lint:eslint",
+		"validate:push": "npm run build:prompts && npm run format:check:all && npm run lint && npm run lint:eslint && npm run test",
 		"test": "vitest run",
 		"test:watch": "vitest",
 		"test:coverage": "vitest run --coverage",

--- a/src/__tests__/main/agents/session-storage.test.ts
+++ b/src/__tests__/main/agents/session-storage.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import path from 'path';
 import type Store from 'electron-store';
 import type { ClaudeSessionOriginsData } from '../../../main/storage/claude-session-storage';
 import {
@@ -15,6 +16,26 @@ import {
 	clearStorageRegistry,
 } from '../../../main/agents';
 import type { ToolType } from '../../../shared/types';
+
+vi.mock('os', async () => {
+	const actual = await vi.importActual<typeof import('os')>('os');
+	const mocked = {
+		...actual,
+		homedir: vi.fn(() => '/tmp/maestro-session-storage-home'),
+	};
+	return {
+		...mocked,
+		default: mocked,
+	};
+});
+
+vi.mock('electron', () => ({
+	app: {
+		getPath: vi.fn(() =>
+			path.join('/tmp/maestro-session-storage-home', 'Library', 'Application Support', 'Maestro')
+		),
+	},
+}));
 
 // Mock storage implementation for testing
 class MockSessionStorage implements AgentSessionStorage {

--- a/src/__tests__/main/process-manager/handlers/StdoutHandler.test.ts
+++ b/src/__tests__/main/process-manager/handlers/StdoutHandler.test.ts
@@ -132,6 +132,16 @@ describe('StdoutHandler', () => {
 			expect(bufferManager.emitDataBuffered).toHaveBeenCalledWith(sessionId, 'Hello, world!');
 		});
 
+		it('should strip leaked terminal mode sequences in plain text mode', () => {
+			const { handler, bufferManager, sessionId } = createTestContext({
+				isStreamJsonMode: false,
+				isBatchMode: false,
+			});
+
+			handler.handleData(sessionId, '\x1b[?1h\x1b=Hello, remote world!');
+			expect(bufferManager.emitDataBuffered).toHaveBeenCalledWith(sessionId, 'Hello, remote world!');
+		});
+
 		it('should accumulate to jsonBuffer in batch mode', () => {
 			const { handler, bufferManager, sessionId, proc } = createTestContext({
 				isBatchMode: true,
@@ -154,6 +164,23 @@ describe('StdoutHandler', () => {
 			// to the catch block and be emitted via bufferManager
 			handler.handleData(sessionId, 'plain text output\n');
 			expect(bufferManager.emitDataBuffered).toHaveBeenCalledWith(sessionId, 'plain text output');
+		});
+
+		it('should strip terminal mode sequences before parsing stream JSON lines', () => {
+			const { handler, bufferManager, sessionId } = createTestContext({
+				isStreamJsonMode: true,
+				outputParser: undefined,
+			});
+
+			handler.handleData(
+				sessionId,
+				'\x1b[?1h\x1b={"type":"result","result":"Recovered remote output"}\n'
+			);
+
+			expect(bufferManager.emitDataBuffered).toHaveBeenCalledWith(
+				sessionId,
+				'Recovered remote output'
+			);
 		});
 
 		it('should buffer incomplete lines in stream JSON mode until newline arrives', () => {

--- a/src/__tests__/main/process-manager/handlers/StdoutHandler.test.ts
+++ b/src/__tests__/main/process-manager/handlers/StdoutHandler.test.ts
@@ -139,7 +139,10 @@ describe('StdoutHandler', () => {
 			});
 
 			handler.handleData(sessionId, '\x1b[?1h\x1b=Hello, remote world!');
-			expect(bufferManager.emitDataBuffered).toHaveBeenCalledWith(sessionId, 'Hello, remote world!');
+			expect(bufferManager.emitDataBuffered).toHaveBeenCalledWith(
+				sessionId,
+				'Hello, remote world!'
+			);
 		});
 
 		it('should accumulate to jsonBuffer in batch mode', () => {

--- a/src/__tests__/main/utils/ssh-command-builder.test.ts
+++ b/src/__tests__/main/utils/ssh-command-builder.test.ts
@@ -682,15 +682,16 @@ describe('ssh-command-builder', () => {
 		 * - The prompt is NEVER parsed by any shell - it flows through as raw bytes
 		 */
 
-		it('returns ssh command with /bin/bash as remote command', async () => {
+		it('returns ssh command with non-interactive bash as remote command', async () => {
 			const result = await buildSshCommandWithStdin(baseConfig, {
 				command: 'opencode',
 				args: ['run', '--format', 'json'],
 			});
 
 			expect(result.command).toBe('ssh');
-			// Last arg should be /bin/bash (the remote command)
-			expect(result.args[result.args.length - 1]).toBe('/bin/bash');
+			expect(result.args).toEqual(
+				expect.arrayContaining(['/bin/bash', '--norc', '--noprofile', '-s'])
+			);
 		});
 
 		it('includes PATH setup in stdin script', async () => {

--- a/src/__tests__/main/utils/stripAnsi.test.ts
+++ b/src/__tests__/main/utils/stripAnsi.test.ts
@@ -12,6 +12,11 @@ describe('stripAnsi', () => {
 		expect(stripAnsi('\x1b[1;32mbold green\x1b[0m')).toBe('bold green');
 	});
 
+	it('strips DEC private-mode and keypad control sequences', () => {
+		const input = '\x1b[?1h\x1b=\x1b[?2004hready\x1b[?2004l\x1b>';
+		expect(stripAnsi(input)).toBe('ready');
+	});
+
 	it('strips iTerm2 shell integration OSC sequences - real world example', () => {
 		// Real-world example from SSH with interactive shell
 		// The sequences are: ]1337;RemoteHost=..., ]1337;CurrentDir=..., ]1337;ShellIntegrationVersion=...;shell=zsh

--- a/src/__tests__/main/utils/terminalFilter.test.ts
+++ b/src/__tests__/main/utils/terminalFilter.test.ts
@@ -108,12 +108,16 @@ describe('terminalFilter', () => {
 				expect(result).toBe('visible');
 			});
 
-			it('should preserve DECSET/DECRST private mode sequences with ?', () => {
-				// The current implementation does NOT remove private mode sequences (with ?)
-				// This is intentional to preserve certain terminal features
+			it('should remove DECSET/DECRST private mode sequences with ?', () => {
 				const input = '\x1b[?25hvisible\x1b[?25l';
 				const result = stripControlSequences(input);
-				expect(result).toBe('\x1b[?25hvisible\x1b[?25l');
+				expect(result).toBe('visible');
+			});
+
+			it('should remove application keypad mode toggles', () => {
+				const input = '\x1b[?1h\x1b=ready\x1b>';
+				const result = stripControlSequences(input);
+				expect(result).toBe('ready');
 			});
 
 			it('should remove soft cursor sequences (p)', () => {
@@ -541,6 +545,12 @@ describe('terminalFilter', () => {
 				const input = 'overwrite\rtext';
 				const result = stripAllAnsiCodes(input);
 				expect(result).toBe('overwrite\rtext');
+			});
+
+			it('should remove DEC private mode and keypad control sequences', () => {
+				const input = '\x1b[?1h\x1b=\x1b[?2004hready\x1b[?2004l\x1b>';
+				const result = stripAllAnsiCodes(input);
+				expect(result).toBe('ready');
 			});
 		});
 

--- a/src/__tests__/shared/stringUtils.test.ts
+++ b/src/__tests__/shared/stringUtils.test.ts
@@ -117,6 +117,11 @@ describe('stripAnsiCodes', () => {
 		expect(stripAnsiCodes('\x1b[mText')).toBe('Text');
 	});
 
+	it('should strip DEC private mode and keypad control sequences', () => {
+		const input = '\x1b[?1h\x1b=\x1b[?2004hRemote ready\x1b[?2004l\x1b>';
+		expect(stripAnsiCodes(input)).toBe('Remote ready');
+	});
+
 	it('should preserve unicode characters', () => {
 		expect(stripAnsiCodes('\x1b[32m🚀 Rocket\x1b[0m')).toBe('🚀 Rocket');
 		expect(stripAnsiCodes('\x1b[31m日本語\x1b[0m')).toBe('日本語');

--- a/src/main/process-manager/handlers/StdoutHandler.ts
+++ b/src/main/process-manager/handlers/StdoutHandler.ts
@@ -2,6 +2,7 @@
 
 import { EventEmitter } from 'events';
 import { logger } from '../../utils/logger';
+import { stripAllAnsiCodes } from '../../utils/terminalFilter';
 import { appendToBuffer } from '../utils/bufferUtils';
 import { aggregateModelUsage, type ModelStats } from '../../parsers/usage-aggregator';
 import { matchSshErrorPattern } from '../../parsers/error-patterns';
@@ -118,18 +119,23 @@ export class StdoutHandler {
 		const managedProcess = this.processes.get(sessionId);
 		if (!managedProcess) return;
 
+		// SSH-launched agent CLIs can leak terminal mode switches like ESC[?1h ESC=
+		// before their real output. Strip non-printing control bytes before parsing.
+		const cleanedOutput = stripAllAnsiCodes(output);
+		if (!cleanedOutput) return;
+
 		const { isStreamJsonMode, isBatchMode } = managedProcess;
 
 		if (isStreamJsonMode) {
-			this.handleStreamJsonData(sessionId, managedProcess, output);
+			this.handleStreamJsonData(sessionId, managedProcess, cleanedOutput);
 		} else if (isBatchMode) {
-			managedProcess.jsonBuffer = (managedProcess.jsonBuffer || '') + output;
+			managedProcess.jsonBuffer = (managedProcess.jsonBuffer || '') + cleanedOutput;
 			logger.debug('[ProcessManager] Accumulated JSON buffer', 'ProcessManager', {
 				sessionId,
 				bufferLength: managedProcess.jsonBuffer.length,
 			});
 		} else {
-			this.bufferManager.emitDataBuffered(sessionId, output);
+			this.bufferManager.emitDataBuffered(sessionId, cleanedOutput);
 		}
 	}
 

--- a/src/main/utils/ssh-command-builder.ts
+++ b/src/main/utils/ssh-command-builder.ts
@@ -335,8 +335,9 @@ export async function buildSshCommandWithStdin(
 		args.push(config.host);
 	}
 
-	// The remote command is just /bin/bash - it will read the script from stdin
-	args.push('/bin/bash');
+	// Run bash without rc/profile files so remote shell init can't inject control
+	// sequences into the agent stream before the script executes.
+	args.push('/bin/bash', '--norc', '--noprofile', '-s');
 
 	// Build the script to send via stdin
 	const scriptLines: string[] = [];

--- a/src/main/utils/stripAnsi.ts
+++ b/src/main/utils/stripAnsi.ts
@@ -10,8 +10,11 @@
  * as the remote shell's .bashrc/.zshrc may emit shell integration escape sequences.
  */
 
-// Match ANSI escape sequences: ESC[ followed by parameters and a letter
-const ANSI_ESCAPE_PATTERN = /\x1b\[[0-9;]*[a-zA-Z]/g;
+// Match ANSI CSI sequences, including DEC private-mode toggles like ESC[?1h
+const ANSI_ESCAPE_PATTERN = /\x1b\[[0-?]*[ -/]*[@-~]/g;
+
+// Match standalone keypad/application mode toggles like ESC= and ESC>
+const ESC_TOGGLE_PATTERN = /\x1b[=>]/g;
 
 // Match OSC sequences: ESC] followed by content until BEL (\x07) or ST (ESC\)
 // This handles iTerm2 shell integration sequences like ]1337;RemoteHost=...
@@ -47,5 +50,6 @@ export function stripAnsi(str: string): string {
 		.replace(BARE_OSC_WITH_BEL, '')
 		.replace(ITERM2_OSC_WITH_NEXT, '')
 		.replace(ITERM2_OSC_LAST, '')
+		.replace(ESC_TOGGLE_PATTERN, '')
 		.replace(ANSI_ESCAPE_PATTERN, '');
 }

--- a/src/main/utils/terminalFilter.ts
+++ b/src/main/utils/terminalFilter.ts
@@ -92,11 +92,14 @@ export function stripControlSequences(
 	// Examples: window title changes, hyperlinks, custom sequences
 	cleaned = cleaned.replace(/\x1b\][^\x07\x1b]*(\x07|\x1b\\)/g, '');
 
-	// Remove CSI (Control Sequence Introducer) sequences that aren't color codes
-	// Format: ESC [ ... letter
-	// Keep: SGR color codes (end with 'm')
-	// Remove: cursor movement, scrolling, etc.
-	cleaned = cleaned.replace(/\x1b\[[\d;]*[A-KSTfHJhlp]/gi, '');
+	// Remove CSI (Control Sequence Introducer) sequences that aren't color codes.
+	// This also strips DEC private-mode toggles like ESC[?1h and bracketed paste.
+	cleaned = cleaned.replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, (sequence) =>
+		sequence.endsWith('m') ? sequence : ''
+	);
+
+	// Remove standalone escape sequences used for keypad/application mode switching.
+	cleaned = cleaned.replace(/\x1b[=>]/g, '');
 
 	// Remove shell integration markers (VSCode, iTerm2, etc.)
 	// Format: ESC ] 133 ; ... BEL/ST
@@ -164,13 +167,12 @@ export function stripControlSequences(
  */
 export function stripAllAnsiCodes(text: string): string {
 	// Remove all ANSI escape sequences including color codes
-	// Format: ESC [ ... m (SGR sequences for colors/styles)
-	// Format: ESC [ ... other letters (cursor, scrolling, etc.)
+	// Format: ESC [ ... final byte (CSI sequences, including DEC private modes)
 	// Format: ESC ] ... BEL/ST (OSC sequences)
 	return text
-		.replace(/\x1b\[[0-9;]*m/g, '') // SGR color/style codes
-		.replace(/\x1b\[[\d;]*[A-Za-z]/g, '') // Other CSI sequences
+		.replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, '') // All CSI sequences
 		.replace(/\x1b\][^\x07\x1b]*(\x07|\x1b\\)/g, '') // OSC sequences
+		.replace(/\x1b[=>]/g, '') // Keypad/application mode toggles
 		.replace(/\x1b[()][AB012]/g, '') // Character set selection
 		.replace(/\x07/g, '') // BEL character
 		.replace(/[\x00-\x08\x0B-\x0C\x0E-\x1A\x1C-\x1F]/g, ''); // Other control chars

--- a/src/shared/stringUtils.ts
+++ b/src/shared/stringUtils.ts
@@ -34,10 +34,11 @@
  * ```
  */
 export function stripAnsiCodes(text: string): string {
-	// Matches ANSI escape sequences: ESC[ followed by params and command letter
-	// ESC is \x1b (decimal 27), followed by [ and then zero or more params
-	// (digits or semicolons) ending with a letter command
-	let result = text.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, '');
+	// Matches ANSI CSI sequences, including DEC private modes like ESC[?1h.
+	let result = text.replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, '');
+
+	// Remove standalone keypad/application mode toggles used by interactive CLIs.
+	result = result.replace(/\x1b[=>]/g, '');
 
 	// Remove OSC sequences WITH ESC prefix: ESC ] ... (BEL or ST)
 	// Common patterns: window title, hyperlinks, shell integration


### PR DESCRIPTION
## Summary
- run SSH stdin-script sessions under non-interactive bash (--norc --noprofile -s) so remote shell init cannot inject control bytes into agent output
- strip leaked non-printing terminal control sequences from child-process agent stdout before Maestro buffers or parses it
- expand ANSI/control-sequence helpers and regression tests to cover DEC private-mode and keypad toggles like ESC[?1h and ESC=

## Testing
- ./node_modules/.bin/vitest run src/__tests__/main/utils/terminalFilter.test.ts src/__tests__/shared/stringUtils.test.ts src/__tests__/main/utils/stripAnsi.test.ts src/__tests__/main/process-manager/handlers/StdoutHandler.test.ts src/__tests__/main/utils/ssh-command-builder.test.ts src/__tests__/main/ipc/handlers/process.test.ts
- npm run build:prompts
- ./node_modules/.bin/tsc -p tsconfig.main.json --noEmit

## Root Cause
Remote CLI sessions launched through the SSH stdin-script path could leak terminal mode control sequences such as ESC[?1h ESC= into stdout before JSON/plaintext parsing. Those bytes were not stripped on the child-process path, so Remote Access could surface dead output or fail to parse the first agent event.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stdout handling now strips additional ANSI/terminal control sequences before parsing or emitting output.

* **Improvements**
  * Remote SSH invocation runs non-interactive bash to avoid loading remote rc/profile files.

* **Tests**
  * Added and updated tests covering DEC private-mode, keypad toggles, and other control sequences to improve coverage.

* **Chores**
  * Added a pre-push validation hook and a validate:push script to run build, format, lint, and tests before pushing.

* **Documentation**
  * Guidance added to re-run formatting, linting, type checks, and tests before pushing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->