### PR TITLE
fix: stop button not working on Windows for Claude Code agents

### DIFF
--- a/src/main/process-manager/ProcessManager.ts
+++ b/src/main/process-manager/ProcessManager.ts
@@ -139,7 +139,7 @@ export class ProcessManager extends EventEmitter {
 				if (isWindows()) {
 					// On Windows, child.kill('SIGINT') is unreliable for shell-spawned
 					// processes. Write Ctrl+C to stdin as a gentle interrupt instead.
-					if (child.stdin && !child.stdin.destroyed) {
+					if (child.stdin && !child.stdin.destroyed && !child.stdin.writableEnded) {
 						child.stdin.write('\x03');
 						logger.debug(
 							'[ProcessManager] Wrote Ctrl+C to stdin for Windows interrupt',
@@ -210,6 +210,13 @@ export class ProcessManager extends EventEmitter {
 				const pid = process.childProcess.pid;
 				if (isWindows() && pid) {
 					this.killWindowsProcessTree(pid, sessionId);
+				} else if (isWindows()) {
+					logger.warn(
+						'[ProcessManager] pid unavailable for Windows taskkill, falling back to SIGTERM',
+						'ProcessManager',
+						{ sessionId }
+					);
+					process.childProcess.kill('SIGTERM');
 				} else {
 					process.childProcess.kill('SIGTERM');
 				}


### PR DESCRIPTION
On Windows, child.kill('SIGINT') is unreliable for shell-spawned processes (This may be honored for users who specify a different terminal). The signal is silently ignored, leaving the agent running when users click stop.

Changes:
- interrupt(): Write Ctrl+C (\x03) to stdin on Windows instead of SIGINT, with 2-second escalation to kill() if the process doesn't exit
- kill(): Use taskkill /pid /t /f on Windows to terminate the entire process tree instead of SIGTERM, which doesn't reliably kill shell-spawned children
- Use execFile with args array (async, no shell) to avoid command injection and main thread blocking
- Add logging for Windows interrupt paths for debuggability

Unix/macOS behavior is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved process termination on Windows: attempts a graceful interrupt via console input when available before escalating to forced termination.
  * Better handling for child processes across platforms with clearer escalation flow and fallback to forceful kill when interrupts fail.
  * Enhanced logging and messaging for interrupt vs. kill actions to make shutdown behavior more transparent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->