### PR TITLE
feat: default worktree directory to parent of agent's cwd

### DIFF
--- a/src/renderer/components/WorktreeConfigModal.tsx
+++ b/src/renderer/components/WorktreeConfigModal.tsx
@@ -17,7 +17,8 @@ interface WorktreeConfigModalProps {
 
 /** Get parent directory from a path (works with both / and \ separators) */
 function getParentDir(path: string): string {
-	return path.replace(/[/\\][^/\\]+$/, '');
+	const parent = path.replace(/[/\\][^/\\]+$/, '');
+	return parent || path; // keep original if we're already at root
 }
 
 /**
@@ -63,7 +64,7 @@ export function WorktreeConfigModal({
 	const [isCreating, setIsCreating] = useState(false);
 	const [isValidating, setIsValidating] = useState(false);
 	const [error, setError] = useState<string | null>(null);
-	const canDisable = !!(session.worktreeConfig?.basePath || basePath.trim());
+	const canDisable = !!session.worktreeConfig?.basePath;
 
 	// gh CLI status
 	const [ghCliStatus, setGhCliStatus] = useState<GhCliStatus | null>(null);
@@ -98,7 +99,7 @@ export function WorktreeConfigModal({
 			setNewBranchName('');
 			setError(null);
 		}
-	}, [isOpen, session.worktreeConfig]);
+	}, [isOpen, session.worktreeConfig, session.cwd]);
 
 	const checkGhCli = async () => {
 		try {


### PR DESCRIPTION
Summary

  - Default the worktree base directory to the parent of the agent's working directory instead of leaving it empty        
  - Extract getParentDir helper to eliminate duplicated path regex logic
  - Previously, you were required to enter a path for the worktree even if you wanted the logical default to apply, this provides the parent as a default path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Worktree configuration modal now defaults the base path to the parent directory of the agent's current working directory when no existing worktree is configured, offering a more intuitive starting point.
  * Modal open/reset and enable/disable behavior updated to consistently use the session cwd-derived default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->