### PR TITLE
fix: add OpenCode slash command discovery and execution support

### DIFF
--- a/src/__tests__/main/ipc/handlers/agents.test.ts
+++ b/src/__tests__/main/ipc/handlers/agents.test.ts
@@ -1075,7 +1075,23 @@ describe('agents IPC handlers', () => {
 			expect(execFileNoThrow).toHaveBeenCalledWith('/custom/claude', expect.any(Array), '/test');
 		});
 
-		it('should return null for non-Claude Code agents', async () => {
+		it('should return null for unsupported agents', async () => {
+			const mockAgent = {
+				id: 'codex',
+				available: true,
+				path: '/usr/bin/codex',
+			};
+
+			mockAgentDetector.getAgent.mockResolvedValue(mockAgent);
+
+			const handler = handlers.get('agents:discoverSlashCommands');
+			const result = await handler!({} as any, 'codex', '/test');
+
+			expect(result).toBeNull();
+			expect(execFileNoThrow).not.toHaveBeenCalled();
+		});
+
+		it('should return built-in commands for opencode', async () => {
 			const mockAgent = {
 				id: 'opencode',
 				available: true,
@@ -1087,7 +1103,9 @@ describe('agents IPC handlers', () => {
 			const handler = handlers.get('agents:discoverSlashCommands');
 			const result = await handler!({} as any, 'opencode', '/test');
 
-			expect(result).toBeNull();
+			expect(result).toEqual(
+				expect.arrayContaining(['init', 'review', 'undo', 'redo', 'share', 'help', 'models'])
+			);
 			expect(execFileNoThrow).not.toHaveBeenCalled();
 		});
 

--- a/src/__tests__/main/ipc/handlers/agents.test.ts
+++ b/src/__tests__/main/ipc/handlers/agents.test.ts
@@ -1095,7 +1095,7 @@ describe('agents IPC handlers', () => {
 			expect(execFileNoThrow).not.toHaveBeenCalled();
 		});
 
-		it('should return built-in commands for opencode', async () => {
+		it('should return empty array when no custom commands exist for opencode', async () => {
 			const mockAgent = {
 				id: 'opencode',
 				available: true,
@@ -1112,13 +1112,12 @@ describe('agents IPC handlers', () => {
 			const handler = handlers.get('agents:discoverSlashCommands');
 			const result = await handler!({} as any, 'opencode', '/test');
 
-			expect(result).toEqual(
-				expect.arrayContaining(['init', 'review', 'undo', 'redo', 'share', 'help', 'models'])
-			);
+			// No built-in commands — only custom .md commands are discoverable
+			expect(result).toEqual([]);
 			expect(execFileNoThrow).not.toHaveBeenCalled();
 		});
 
-		it('should discover opencode commands from project .opencode/commands/*.md', async () => {
+		it('should discover opencode commands from project .opencode/commands/*.md with prompt content', async () => {
 			const mockAgent = {
 				id: 'opencode',
 				available: true,
@@ -1135,17 +1134,86 @@ describe('agents IPC handlers', () => {
 				}
 				throw enoent;
 			});
-			vi.mocked(fs.promises.readFile).mockRejectedValue(enoent);
+			vi.mocked(fs.promises.readFile).mockImplementation(async (filePath) => {
+				const p = String(filePath);
+				if (p.endsWith('deploy.md')) return 'Deploy the application to production';
+				if (p.endsWith('lint.md')) return 'Run linting on the codebase';
+				throw enoent;
+			});
 
 			const handler = handlers.get('agents:discoverSlashCommands');
 			const result = await handler!({} as any, 'opencode', '/test');
 
-			expect(result).toContain('deploy');
-			expect(result).toContain('lint');
+			const names = result.map((c: any) => c.name);
+			expect(names).toContain('deploy');
+			expect(names).toContain('lint');
 			// Non-.md files should be ignored
-			expect(result).not.toContain('README.txt');
-			// Built-ins should still be present
-			expect(result).toContain('init');
+			expect(names).not.toContain('README.txt');
+			// Custom commands should have prompt content
+			const deployCmd = result.find((c: any) => c.name === 'deploy');
+			expect(deployCmd.prompt).toBe('Deploy the application to production');
+		});
+
+		it('should discover opencode commands from ~/.opencode/commands/ (home directory)', async () => {
+			const mockAgent = {
+				id: 'opencode',
+				available: true,
+				path: '/usr/bin/opencode',
+			};
+
+			mockAgentDetector.getAgent.mockResolvedValue(mockAgent);
+
+			const enoent = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+			const homeDir = require('os').homedir();
+			vi.mocked(fs.promises.readdir).mockImplementation(async (dir) => {
+				if (String(dir) === `${homeDir}/.opencode/commands`) {
+					return ['octest.md'] as any;
+				}
+				throw enoent;
+			});
+			vi.mocked(fs.promises.readFile).mockImplementation(async (filePath) => {
+				const p = String(filePath);
+				if (p.endsWith('octest.md')) return 'Report your status.';
+				throw enoent;
+			});
+
+			const handler = handlers.get('agents:discoverSlashCommands');
+			const result = await handler!({} as any, 'opencode', '/test');
+
+			const names = result.map((c: any) => c.name);
+			expect(names).toContain('octest');
+			const octest = result.find((c: any) => c.name === 'octest');
+			expect(octest.prompt).toBe('Report your status.');
+		});
+
+		it('should strip YAML frontmatter from command .md files', async () => {
+			const mockAgent = {
+				id: 'opencode',
+				available: true,
+				path: '/usr/bin/opencode',
+			};
+
+			mockAgentDetector.getAgent.mockResolvedValue(mockAgent);
+
+			const enoent = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+			vi.mocked(fs.promises.readdir).mockImplementation(async (dir) => {
+				if (String(dir).includes('/test/.opencode/commands')) {
+					return ['deploy.md'] as any;
+				}
+				throw enoent;
+			});
+			vi.mocked(fs.promises.readFile).mockImplementation(async (filePath) => {
+				const p = String(filePath);
+				if (p.endsWith('deploy.md'))
+					return '---\ndescription: Deploy cmd\nagent: build\n---\n\nDeploy the app.';
+				throw enoent;
+			});
+
+			const handler = handlers.get('agents:discoverSlashCommands');
+			const result = await handler!({} as any, 'opencode', '/test');
+
+			const deployCmd = result.find((c: any) => c.name === 'deploy');
+			expect(deployCmd.prompt).toBe('Deploy the app.');
 		});
 
 		it('should discover opencode commands from opencode.json config', async () => {
@@ -1161,7 +1229,7 @@ describe('agents IPC handlers', () => {
 			vi.mocked(fs.promises.readdir).mockRejectedValue(enoent);
 			vi.mocked(fs.promises.readFile).mockImplementation(async (filePath) => {
 				if (String(filePath).includes('/test/opencode.json')) {
-					return JSON.stringify({ command: { 'my-cmd': { description: 'test' } } });
+					return JSON.stringify({ command: { 'my-cmd': { prompt: 'Do the thing' } } });
 				}
 				throw enoent;
 			});
@@ -1169,8 +1237,11 @@ describe('agents IPC handlers', () => {
 			const handler = handlers.get('agents:discoverSlashCommands');
 			const result = await handler!({} as any, 'opencode', '/test');
 
-			expect(result).toContain('my-cmd');
-			expect(result).toContain('init');
+			const names = result.map((c: any) => c.name);
+			expect(names).toContain('my-cmd');
+			// Config commands should have prompt content
+			const myCmd = result.find((c: any) => c.name === 'my-cmd');
+			expect(myCmd.prompt).toBe('Do the thing');
 		});
 
 		it('should ignore array values in opencode.json command property', async () => {
@@ -1194,14 +1265,11 @@ describe('agents IPC handlers', () => {
 			const handler = handlers.get('agents:discoverSlashCommands');
 			const result = await handler!({} as any, 'opencode', '/test');
 
-			// Should only have built-in commands (array config ignored)
-			expect(result).toEqual(
-				expect.arrayContaining(['init', 'review', 'undo', 'redo', 'share', 'help', 'models'])
-			);
-			expect(result).not.toContain('not');
+			// Array config ignored, no built-ins — result should be empty
+			expect(result).toEqual([]);
 		});
 
-		it('should gracefully handle malformed opencode.json and still return built-in commands', async () => {
+		it('should gracefully handle malformed opencode.json and return empty array', async () => {
 			const mockAgent = {
 				id: 'opencode',
 				available: true,
@@ -1222,10 +1290,8 @@ describe('agents IPC handlers', () => {
 			const handler = handlers.get('agents:discoverSlashCommands');
 			const result = await handler!({} as any, 'opencode', '/test');
 
-			// Malformed JSON should be skipped gracefully — built-ins still present
-			expect(result).toEqual(
-				expect.arrayContaining(['init', 'review', 'undo', 'redo', 'share', 'help', 'models'])
-			);
+			// Malformed JSON skipped gracefully, no built-ins — empty result
+			expect(result).toEqual([]);
 		});
 
 		it('should rethrow non-ENOENT errors for opencode discovery', async () => {

--- a/src/__tests__/main/ipc/handlers/agents.test.ts
+++ b/src/__tests__/main/ipc/handlers/agents.test.ts
@@ -1294,6 +1294,42 @@ describe('agents IPC handlers', () => {
 			expect(result).toEqual([]);
 		});
 
+		it('should honor OPENCODE_CONFIG env var for config discovery', async () => {
+			const mockAgent = {
+				id: 'opencode',
+				available: true,
+				path: '/usr/bin/opencode',
+			};
+
+			mockAgentDetector.getAgent.mockResolvedValue(mockAgent);
+
+			const originalEnv = process.env.OPENCODE_CONFIG;
+			process.env.OPENCODE_CONFIG = '/custom/path/opencode.json';
+
+			const enoent = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+			vi.mocked(fs.promises.readdir).mockRejectedValue(enoent);
+			vi.mocked(fs.promises.readFile).mockImplementation(async (filePath) => {
+				if (String(filePath) === '/custom/path/opencode.json') {
+					return JSON.stringify({ command: { 'env-cmd': { prompt: 'From env config' } } });
+				}
+				throw enoent;
+			});
+
+			const handler = handlers.get('agents:discoverSlashCommands');
+			const result = await handler!({} as any, 'opencode', '/test');
+
+			const envCmd = result.find((c: any) => c.name === 'env-cmd');
+			expect(envCmd).toBeDefined();
+			expect(envCmd.prompt).toBe('From env config');
+
+			// Restore env
+			if (originalEnv === undefined) {
+				delete process.env.OPENCODE_CONFIG;
+			} else {
+				process.env.OPENCODE_CONFIG = originalEnv;
+			}
+		});
+
 		it('should rethrow non-ENOENT errors for opencode discovery', async () => {
 			const mockAgent = {
 				id: 'opencode',

--- a/src/__tests__/main/ipc/handlers/agents.test.ts
+++ b/src/__tests__/main/ipc/handlers/agents.test.ts
@@ -1201,6 +1201,33 @@ describe('agents IPC handlers', () => {
 			expect(result).not.toContain('not');
 		});
 
+		it('should gracefully handle malformed opencode.json and still return built-in commands', async () => {
+			const mockAgent = {
+				id: 'opencode',
+				available: true,
+				path: '/usr/bin/opencode',
+			};
+
+			mockAgentDetector.getAgent.mockResolvedValue(mockAgent);
+
+			const enoent = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+			vi.mocked(fs.promises.readdir).mockRejectedValue(enoent);
+			vi.mocked(fs.promises.readFile).mockImplementation(async (filePath) => {
+				if (String(filePath).includes('/test/opencode.json')) {
+					return '{ invalid json, }';
+				}
+				throw enoent;
+			});
+
+			const handler = handlers.get('agents:discoverSlashCommands');
+			const result = await handler!({} as any, 'opencode', '/test');
+
+			// Malformed JSON should be skipped gracefully — built-ins still present
+			expect(result).toEqual(
+				expect.arrayContaining(['init', 'review', 'undo', 'redo', 'share', 'help', 'models'])
+			);
+		});
+
 		it('should rethrow non-ENOENT errors for opencode discovery', async () => {
 			const mockAgent = {
 				id: 'opencode',

--- a/src/__tests__/main/ipc/handlers/agents.test.ts
+++ b/src/__tests__/main/ipc/handlers/agents.test.ts
@@ -67,6 +67,10 @@ vi.mock('../../../../main/utils/execFile', () => ({
 // Mock fs
 vi.mock('fs', () => ({
 	existsSync: vi.fn(),
+	promises: {
+		readdir: vi.fn(),
+		readFile: vi.fn(),
+	},
 }));
 
 // Mock ssh-command-builder for remote model discovery tests
@@ -1100,6 +1104,11 @@ describe('agents IPC handlers', () => {
 
 			mockAgentDetector.getAgent.mockResolvedValue(mockAgent);
 
+			// All disk reads return ENOENT (no custom commands)
+			const enoent = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+			vi.mocked(fs.promises.readdir).mockRejectedValue(enoent);
+			vi.mocked(fs.promises.readFile).mockRejectedValue(enoent);
+
 			const handler = handlers.get('agents:discoverSlashCommands');
 			const result = await handler!({} as any, 'opencode', '/test');
 
@@ -1107,6 +1116,109 @@ describe('agents IPC handlers', () => {
 				expect.arrayContaining(['init', 'review', 'undo', 'redo', 'share', 'help', 'models'])
 			);
 			expect(execFileNoThrow).not.toHaveBeenCalled();
+		});
+
+		it('should discover opencode commands from project .opencode/commands/*.md', async () => {
+			const mockAgent = {
+				id: 'opencode',
+				available: true,
+				path: '/usr/bin/opencode',
+			};
+
+			mockAgentDetector.getAgent.mockResolvedValue(mockAgent);
+
+			const enoent = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+			// Project commands dir has custom .md files
+			vi.mocked(fs.promises.readdir).mockImplementation(async (dir) => {
+				if (String(dir).includes('/test/.opencode/commands')) {
+					return ['deploy.md', 'lint.md', 'README.txt'] as any;
+				}
+				throw enoent;
+			});
+			vi.mocked(fs.promises.readFile).mockRejectedValue(enoent);
+
+			const handler = handlers.get('agents:discoverSlashCommands');
+			const result = await handler!({} as any, 'opencode', '/test');
+
+			expect(result).toContain('deploy');
+			expect(result).toContain('lint');
+			// Non-.md files should be ignored
+			expect(result).not.toContain('README.txt');
+			// Built-ins should still be present
+			expect(result).toContain('init');
+		});
+
+		it('should discover opencode commands from opencode.json config', async () => {
+			const mockAgent = {
+				id: 'opencode',
+				available: true,
+				path: '/usr/bin/opencode',
+			};
+
+			mockAgentDetector.getAgent.mockResolvedValue(mockAgent);
+
+			const enoent = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+			vi.mocked(fs.promises.readdir).mockRejectedValue(enoent);
+			vi.mocked(fs.promises.readFile).mockImplementation(async (filePath) => {
+				if (String(filePath).includes('/test/opencode.json')) {
+					return JSON.stringify({ command: { 'my-cmd': { description: 'test' } } });
+				}
+				throw enoent;
+			});
+
+			const handler = handlers.get('agents:discoverSlashCommands');
+			const result = await handler!({} as any, 'opencode', '/test');
+
+			expect(result).toContain('my-cmd');
+			expect(result).toContain('init');
+		});
+
+		it('should ignore array values in opencode.json command property', async () => {
+			const mockAgent = {
+				id: 'opencode',
+				available: true,
+				path: '/usr/bin/opencode',
+			};
+
+			mockAgentDetector.getAgent.mockResolvedValue(mockAgent);
+
+			const enoent = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+			vi.mocked(fs.promises.readdir).mockRejectedValue(enoent);
+			vi.mocked(fs.promises.readFile).mockImplementation(async (filePath) => {
+				if (String(filePath).includes('/test/opencode.json')) {
+					return JSON.stringify({ command: ['not', 'an', 'object'] });
+				}
+				throw enoent;
+			});
+
+			const handler = handlers.get('agents:discoverSlashCommands');
+			const result = await handler!({} as any, 'opencode', '/test');
+
+			// Should only have built-in commands (array config ignored)
+			expect(result).toEqual(
+				expect.arrayContaining(['init', 'review', 'undo', 'redo', 'share', 'help', 'models'])
+			);
+			expect(result).not.toContain('not');
+		});
+
+		it('should rethrow non-ENOENT errors for opencode discovery', async () => {
+			const mockAgent = {
+				id: 'opencode',
+				available: true,
+				path: '/usr/bin/opencode',
+			};
+
+			mockAgentDetector.getAgent.mockResolvedValue(mockAgent);
+
+			// Permission error (not ENOENT)
+			const permError = Object.assign(new Error('EACCES'), { code: 'EACCES' });
+			vi.mocked(fs.promises.readdir).mockRejectedValue(permError);
+			vi.mocked(fs.promises.readFile).mockRejectedValue(
+				Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+			);
+
+			const handler = handlers.get('agents:discoverSlashCommands');
+			await expect(handler!({} as any, 'opencode', '/test')).rejects.toThrow('EACCES');
 		});
 
 		it('should return null when agent is not available', async () => {

--- a/src/main/agents/capabilities.ts
+++ b/src/main/agents/capabilities.ts
@@ -302,7 +302,7 @@ export const AGENT_CAPABILITIES: Record<string, AgentCapabilities> = {
 		supportsSessionId: true, // sessionID in JSON output (camelCase) - Verified
 		supportsImageInput: true, // -f, --file flag documented - Documented
 		supportsImageInputOnResume: true, // -f flag works with --session flag - Documented
-		supportsSlashCommands: false, // Not investigated
+		supportsSlashCommands: true, // Built-in + custom commands via .opencode/commands/ and opencode.json
 		supportsSessionStorage: true, // ~/.local/share/opencode/storage/ (JSON files) - Verified
 		supportsCostTracking: true, // part.cost in step_finish events - Verified
 		supportsUsageStats: true, // part.tokens in step_finish events - Verified

--- a/src/main/ipc/handlers/agents.ts
+++ b/src/main/ipc/handlers/agents.ts
@@ -6,7 +6,7 @@ import * as os from 'os';
 import { AgentDetector, AGENT_DEFINITIONS, getAgentCapabilities } from '../../agents';
 import { execFileNoThrow } from '../../utils/execFile';
 import { logger } from '../../utils/logger';
-import { getWhichCommand } from '../../../shared/platformDetection';
+import { getWhichCommand, isWindows } from '../../../shared/platformDetection';
 import {
 	withIpcErrorLogging,
 	requireDependency,
@@ -36,7 +36,10 @@ const handlerOpts = (
  * 1. Project-local custom commands: .opencode/commands/*.md
  * 2. User-global custom commands: ~/.opencode/commands/*.md
  * 3. XDG custom commands: $XDG_CONFIG_HOME/opencode/commands/*.md
- * 4. Config-based commands: opencode.json "command" property (project, home, XDG)
+ * 4. Config-based commands from opencode.json "command" property, resolved
+ *    platform-aware: OPENCODE_CONFIG env var (if set), then project-local,
+ *    then platform-specific locations (POSIX: ~/.opencode/, ~/.config/opencode/;
+ *    Windows: %LOCALAPPDATA%/opencode/)
  *
  * Built-in commands (init, review, undo, redo, share, help, models) are excluded
  * because they only work in OpenCode's interactive TUI mode — they have no prompt
@@ -124,17 +127,43 @@ async function discoverOpenCodeSlashCommands(cwd: string): Promise<DiscoveredCom
 	};
 
 	// OpenCode home directory (e.g., ~/.opencode/) — used for global commands and config
-	const opencodeHome = path.join(os.homedir(), '.opencode');
+	const home = os.homedir();
+	const opencodeHome = path.join(home, '.opencode');
 
 	// Project-local directories take priority (read first), then global locations
 	await addCommandsFromDir(path.join(cwd, '.opencode', 'commands'));
 	await addCommandsFromDir(path.join(opencodeHome, 'commands'));
 	await addCommandsFromDir(path.join(globalConfigBase, 'opencode', 'commands'));
 
-	// Config files (project-local first, then home, then XDG)
-	await addCommandsFromConfig(path.join(cwd, 'opencode.json'));
-	await addCommandsFromConfig(path.join(opencodeHome, 'opencode.json'));
-	await addCommandsFromConfig(path.join(globalConfigBase, 'opencode', 'opencode.json'));
+	// Build platform-aware config file paths in precedence order.
+	// Honor OPENCODE_CONFIG env var first (explicit user override), then probe
+	// platform-specific locations matching OpenCode's own resolution logic.
+	const configPaths: string[] = [];
+
+	if (process.env.OPENCODE_CONFIG) {
+		configPaths.push(process.env.OPENCODE_CONFIG);
+	}
+
+	if (isWindows()) {
+		const localAppData = process.env.LOCALAPPDATA || path.join(home, 'AppData', 'Local');
+		configPaths.push(
+			path.join(cwd, 'opencode.json'),
+			path.join(localAppData, 'opencode', 'opencode.json'),
+			path.join(home, '.opencode.json'),
+			path.join(opencodeHome, 'opencode.json')
+		);
+	} else {
+		configPaths.push(
+			path.join(cwd, 'opencode.json'),
+			path.join(opencodeHome, 'opencode.json'),
+			path.join(home, '.opencode.json'),
+			path.join(globalConfigBase, 'opencode', 'opencode.json')
+		);
+	}
+
+	for (const configPath of configPaths) {
+		await addCommandsFromConfig(configPath);
+	}
 
 	const commandList = Array.from(commands.values());
 	logger.info(`Discovered ${commandList.length} OpenCode slash commands`, LOG_CONTEXT);

--- a/src/main/ipc/handlers/agents.ts
+++ b/src/main/ipc/handlers/agents.ts
@@ -29,39 +29,63 @@ const handlerOpts = (
 	operation,
 });
 
-// OpenCode built-in slash commands (always available)
-const OPENCODE_BUILTIN_COMMANDS = ['init', 'review', 'undo', 'redo', 'share', 'help', 'models'];
-
 /**
  * Discover OpenCode slash commands by reading from disk.
  *
- * OpenCode commands come from three sources:
- * 1. Built-in commands (init, review, undo, redo, share, help, models)
- * 2. Project-local custom commands: .opencode/commands/*.md
- * 3. Global custom commands: $XDG_CONFIG_HOME/opencode/commands/*.md
- * 4. Config-based commands: opencode.json "command" property
+ * OpenCode commands come from these sources (checked in priority order):
+ * 1. Project-local custom commands: .opencode/commands/*.md
+ * 2. User-global custom commands: ~/.opencode/commands/*.md
+ * 3. XDG custom commands: $XDG_CONFIG_HOME/opencode/commands/*.md
+ * 4. Config-based commands: opencode.json "command" property (project, home, XDG)
+ *
+ * Built-in commands (init, review, undo, redo, share, help, models) are excluded
+ * because they only work in OpenCode's interactive TUI mode — they have no prompt
+ * .md file and cannot be executed via batch mode (`opencode run`).
  *
  * Unlike Claude Code (which emits commands via init event), OpenCode commands
  * are statically defined on disk and can be discovered without spawning the agent.
  */
-async function discoverOpenCodeSlashCommands(cwd: string): Promise<string[]> {
-	const commands = new Set<string>(OPENCODE_BUILTIN_COMMANDS);
+interface DiscoveredCommand {
+	name: string;
+	prompt?: string; // .md file content for custom commands; absent for built-ins
+}
+
+async function discoverOpenCodeSlashCommands(cwd: string): Promise<DiscoveredCommand[]> {
+	const commands = new Map<string, DiscoveredCommand>();
 	const globalConfigBase = process.env.XDG_CONFIG_HOME || path.join(os.homedir(), '.config');
 
-	// Helper: read .md filenames from a commands directory
+	// Strip YAML frontmatter (---\n...\n---) from command file content,
+	// returning only the body text that serves as the prompt.
+	const stripFrontmatter = (content: string): string => {
+		const trimmed = content.trimStart();
+		if (!trimmed.startsWith('---')) return content;
+		const endIndex = trimmed.indexOf('\n---', 3);
+		if (endIndex === -1) return content;
+		return trimmed.slice(endIndex + 4).trim();
+	};
+
+	// Helper: read .md files from a commands directory (name + content)
 	const addCommandsFromDir = async (dir: string) => {
+		let files: string[];
 		try {
-			const files = await fs.promises.readdir(dir);
-			for (const file of files) {
-				if (file.endsWith('.md')) {
-					commands.add(file.replace(/\.md$/, ''));
-				}
-			}
+			files = await fs.promises.readdir(dir);
 		} catch (error: any) {
 			if (error?.code === 'ENOENT') {
 				logger.debug(`OpenCode commands directory not found: ${dir}`, LOG_CONTEXT);
-			} else {
-				throw error;
+				return;
+			}
+			throw error;
+		}
+		for (const file of files) {
+			if (!file.endsWith('.md')) continue;
+			const name = file.replace(/\.md$/, '');
+			if (commands.has(name)) continue; // project-local wins over global
+			try {
+				const raw = await fs.promises.readFile(path.join(dir, file), 'utf-8');
+				const prompt = stripFrontmatter(raw);
+				commands.set(name, { name, prompt: prompt || undefined });
+			} catch (error: any) {
+				if (error?.code !== 'ENOENT') throw error;
 			}
 		}
 	};
@@ -86,21 +110,33 @@ async function discoverOpenCodeSlashCommands(cwd: string): Promise<string[]> {
 			return;
 		}
 		if (config.command && typeof config.command === 'object' && !Array.isArray(config.command)) {
-			for (const name of Object.keys(config.command)) {
-				commands.add(name);
+			for (const [name, value] of Object.entries(config.command)) {
+				if (commands.has(name)) continue;
+				const prompt =
+					typeof value === 'string'
+						? value
+						: typeof (value as any)?.prompt === 'string'
+							? (value as any).prompt
+							: undefined;
+				commands.set(name, { name, prompt });
 			}
 		}
 	};
 
-	// Read all four sources concurrently
-	await Promise.all([
-		addCommandsFromDir(path.join(cwd, '.opencode', 'commands')),
-		addCommandsFromDir(path.join(globalConfigBase, 'opencode', 'commands')),
-		addCommandsFromConfig(path.join(cwd, 'opencode.json')),
-		addCommandsFromConfig(path.join(globalConfigBase, 'opencode', 'opencode.json')),
-	]);
+	// OpenCode home directory (e.g., ~/.opencode/) — used for global commands and config
+	const opencodeHome = path.join(os.homedir(), '.opencode');
 
-	const commandList = Array.from(commands);
+	// Project-local directories take priority (read first), then global locations
+	await addCommandsFromDir(path.join(cwd, '.opencode', 'commands'));
+	await addCommandsFromDir(path.join(opencodeHome, 'commands'));
+	await addCommandsFromDir(path.join(globalConfigBase, 'opencode', 'commands'));
+
+	// Config files (project-local first, then home, then XDG)
+	await addCommandsFromConfig(path.join(cwd, 'opencode.json'));
+	await addCommandsFromConfig(path.join(opencodeHome, 'opencode.json'));
+	await addCommandsFromConfig(path.join(globalConfigBase, 'opencode', 'opencode.json'));
+
+	const commandList = Array.from(commands.values());
 	logger.info(`Discovered ${commandList.length} OpenCode slash commands`, LOG_CONTEXT);
 	return commandList;
 }

--- a/src/main/ipc/handlers/agents.ts
+++ b/src/main/ipc/handlers/agents.ts
@@ -1,6 +1,8 @@
 import { ipcMain } from 'electron';
 import Store from 'electron-store';
 import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
 import { AgentDetector, AGENT_DEFINITIONS, getAgentCapabilities } from '../../agents';
 import { execFileNoThrow } from '../../utils/execFile';
 import { logger } from '../../utils/logger';
@@ -26,6 +28,97 @@ const handlerOpts = (
 	context,
 	operation,
 });
+
+// OpenCode built-in slash commands (always available)
+const OPENCODE_BUILTIN_COMMANDS = ['init', 'review', 'undo', 'redo', 'share', 'help', 'models'];
+
+/**
+ * Discover OpenCode slash commands by reading from disk.
+ *
+ * OpenCode commands come from three sources:
+ * 1. Built-in commands (init, review, undo, redo, share, help, models)
+ * 2. Project-local custom commands: .opencode/commands/*.md
+ * 3. Global custom commands: ~/.config/opencode/commands/*.md
+ * 4. Config-based commands: opencode.json "command" property
+ *
+ * Unlike Claude Code (which emits commands via init event), OpenCode commands
+ * are statically defined on disk and can be discovered without spawning the agent.
+ */
+function discoverOpenCodeSlashCommands(cwd: string): string[] {
+	const commands = new Set<string>(OPENCODE_BUILTIN_COMMANDS);
+
+	// Project-local custom commands: .opencode/commands/*.md
+	const projectCommandsDir = path.join(cwd, '.opencode', 'commands');
+	try {
+		if (fs.existsSync(projectCommandsDir)) {
+			const files = fs.readdirSync(projectCommandsDir);
+			for (const file of files) {
+				if (file.endsWith('.md')) {
+					commands.add(file.replace(/\.md$/, ''));
+				}
+			}
+		}
+	} catch (error) {
+		logger.debug(`Failed to read project OpenCode commands from ${projectCommandsDir}`, LOG_CONTEXT, {
+			error: String(error),
+		});
+	}
+
+	// Global custom commands: ~/.config/opencode/commands/*.md
+	const globalCommandsDir = path.join(os.homedir(), '.config', 'opencode', 'commands');
+	try {
+		if (fs.existsSync(globalCommandsDir)) {
+			const files = fs.readdirSync(globalCommandsDir);
+			for (const file of files) {
+				if (file.endsWith('.md')) {
+					commands.add(file.replace(/\.md$/, ''));
+				}
+			}
+		}
+	} catch (error) {
+		logger.debug(`Failed to read global OpenCode commands from ${globalCommandsDir}`, LOG_CONTEXT, {
+			error: String(error),
+		});
+	}
+
+	// Config-based commands: opencode.json "command" property (project-level)
+	const projectConfigPath = path.join(cwd, 'opencode.json');
+	try {
+		if (fs.existsSync(projectConfigPath)) {
+			const config = JSON.parse(fs.readFileSync(projectConfigPath, 'utf-8'));
+			if (config.command && typeof config.command === 'object') {
+				for (const name of Object.keys(config.command)) {
+					commands.add(name);
+				}
+			}
+		}
+	} catch (error) {
+		logger.debug(`Failed to read OpenCode config from ${projectConfigPath}`, LOG_CONTEXT, {
+			error: String(error),
+		});
+	}
+
+	// Config-based commands: global opencode.json
+	const globalConfigPath = path.join(os.homedir(), '.config', 'opencode', 'opencode.json');
+	try {
+		if (fs.existsSync(globalConfigPath)) {
+			const config = JSON.parse(fs.readFileSync(globalConfigPath, 'utf-8'));
+			if (config.command && typeof config.command === 'object') {
+				for (const name of Object.keys(config.command)) {
+					commands.add(name);
+				}
+			}
+		}
+	} catch (error) {
+		logger.debug(`Failed to read global OpenCode config from ${globalConfigPath}`, LOG_CONTEXT, {
+			error: String(error),
+		});
+	}
+
+	const commandList = Array.from(commands);
+	logger.info(`Discovered ${commandList.length} OpenCode slash commands`, LOG_CONTEXT);
+	return commandList;
+}
 
 /**
  * Interface for agent configuration store data
@@ -850,7 +943,11 @@ export function registerAgentsHandlers(deps: AgentsHandlerDependencies): void {
 					return null;
 				}
 
-				// Only Claude Code supports slash command discovery via init message
+				// Agent-specific discovery paths
+				if (agentId === 'opencode') {
+					return discoverOpenCodeSlashCommands(cwd);
+				}
+
 				if (agentId !== 'claude-code') {
 					logger.debug(`Agent ${agentId} does not support slash command discovery`, LOG_CONTEXT);
 					return null;

--- a/src/main/ipc/handlers/agents.ts
+++ b/src/main/ipc/handlers/agents.ts
@@ -38,82 +38,60 @@ const OPENCODE_BUILTIN_COMMANDS = ['init', 'review', 'undo', 'redo', 'share', 'h
  * OpenCode commands come from three sources:
  * 1. Built-in commands (init, review, undo, redo, share, help, models)
  * 2. Project-local custom commands: .opencode/commands/*.md
- * 3. Global custom commands: ~/.config/opencode/commands/*.md
+ * 3. Global custom commands: $XDG_CONFIG_HOME/opencode/commands/*.md
  * 4. Config-based commands: opencode.json "command" property
  *
  * Unlike Claude Code (which emits commands via init event), OpenCode commands
  * are statically defined on disk and can be discovered without spawning the agent.
  */
-function discoverOpenCodeSlashCommands(cwd: string): string[] {
+async function discoverOpenCodeSlashCommands(cwd: string): Promise<string[]> {
 	const commands = new Set<string>(OPENCODE_BUILTIN_COMMANDS);
+	const globalConfigBase = process.env.XDG_CONFIG_HOME || path.join(os.homedir(), '.config');
 
-	// Project-local custom commands: .opencode/commands/*.md
-	const projectCommandsDir = path.join(cwd, '.opencode', 'commands');
-	try {
-		if (fs.existsSync(projectCommandsDir)) {
-			const files = fs.readdirSync(projectCommandsDir);
+	// Helper: read .md filenames from a commands directory
+	const addCommandsFromDir = async (dir: string) => {
+		try {
+			const files = await fs.promises.readdir(dir);
 			for (const file of files) {
 				if (file.endsWith('.md')) {
 					commands.add(file.replace(/\.md$/, ''));
 				}
 			}
-		}
-	} catch (error) {
-		logger.debug(`Failed to read project OpenCode commands from ${projectCommandsDir}`, LOG_CONTEXT, {
-			error: String(error),
-		});
-	}
-
-	// Global custom commands: ~/.config/opencode/commands/*.md
-	const globalCommandsDir = path.join(os.homedir(), '.config', 'opencode', 'commands');
-	try {
-		if (fs.existsSync(globalCommandsDir)) {
-			const files = fs.readdirSync(globalCommandsDir);
-			for (const file of files) {
-				if (file.endsWith('.md')) {
-					commands.add(file.replace(/\.md$/, ''));
-				}
+		} catch (error: any) {
+			if (error?.code === 'ENOENT') {
+				logger.debug(`OpenCode commands directory not found: ${dir}`, LOG_CONTEXT);
+			} else {
+				throw error;
 			}
 		}
-	} catch (error) {
-		logger.debug(`Failed to read global OpenCode commands from ${globalCommandsDir}`, LOG_CONTEXT, {
-			error: String(error),
-		});
-	}
+	};
 
-	// Config-based commands: opencode.json "command" property (project-level)
-	const projectConfigPath = path.join(cwd, 'opencode.json');
-	try {
-		if (fs.existsSync(projectConfigPath)) {
-			const config = JSON.parse(fs.readFileSync(projectConfigPath, 'utf-8'));
+	// Helper: read command names from an opencode.json config file
+	const addCommandsFromConfig = async (configPath: string) => {
+		try {
+			const content = await fs.promises.readFile(configPath, 'utf-8');
+			const config = JSON.parse(content);
 			if (config.command && typeof config.command === 'object' && !Array.isArray(config.command)) {
 				for (const name of Object.keys(config.command)) {
 					commands.add(name);
 				}
 			}
-		}
-	} catch (error) {
-		logger.debug(`Failed to read OpenCode config from ${projectConfigPath}`, LOG_CONTEXT, {
-			error: String(error),
-		});
-	}
-
-	// Config-based commands: global opencode.json
-	const globalConfigPath = path.join(os.homedir(), '.config', 'opencode', 'opencode.json');
-	try {
-		if (fs.existsSync(globalConfigPath)) {
-			const config = JSON.parse(fs.readFileSync(globalConfigPath, 'utf-8'));
-			if (config.command && typeof config.command === 'object' && !Array.isArray(config.command)) {
-				for (const name of Object.keys(config.command)) {
-					commands.add(name);
-				}
+		} catch (error: any) {
+			if (error?.code === 'ENOENT') {
+				logger.debug(`OpenCode config not found: ${configPath}`, LOG_CONTEXT);
+			} else {
+				throw error;
 			}
 		}
-	} catch (error) {
-		logger.debug(`Failed to read global OpenCode config from ${globalConfigPath}`, LOG_CONTEXT, {
-			error: String(error),
-		});
-	}
+	};
+
+	// Read all four sources concurrently
+	await Promise.all([
+		addCommandsFromDir(path.join(cwd, '.opencode', 'commands')),
+		addCommandsFromDir(path.join(globalConfigBase, 'opencode', 'commands')),
+		addCommandsFromConfig(path.join(cwd, 'opencode.json')),
+		addCommandsFromConfig(path.join(globalConfigBase, 'opencode', 'opencode.json')),
+	]);
 
 	const commandList = Array.from(commands);
 	logger.info(`Discovered ${commandList.length} OpenCode slash commands`, LOG_CONTEXT);

--- a/src/main/ipc/handlers/agents.ts
+++ b/src/main/ipc/handlers/agents.ts
@@ -130,10 +130,17 @@ async function discoverOpenCodeSlashCommands(cwd: string): Promise<DiscoveredCom
 	const home = os.homedir();
 	const opencodeHome = path.join(home, '.opencode');
 
-	// Project-local directories take priority (read first), then global locations
+	// Project-local directories take priority (read first), then global locations.
+	// Global command directory is platform-specific to avoid ENOENT noise on Windows.
 	await addCommandsFromDir(path.join(cwd, '.opencode', 'commands'));
 	await addCommandsFromDir(path.join(opencodeHome, 'commands'));
-	await addCommandsFromDir(path.join(globalConfigBase, 'opencode', 'commands'));
+
+	if (isWindows()) {
+		const localAppData = process.env.LOCALAPPDATA || path.join(home, 'AppData', 'Local');
+		await addCommandsFromDir(path.join(localAppData, 'opencode', 'commands'));
+	} else {
+		await addCommandsFromDir(path.join(globalConfigBase, 'opencode', 'commands'));
+	}
 
 	// Build platform-aware config file paths in precedence order.
 	// Honor OPENCODE_CONFIG env var first (explicit user override), then probe

--- a/src/main/ipc/handlers/agents.ts
+++ b/src/main/ipc/handlers/agents.ts
@@ -68,19 +68,26 @@ async function discoverOpenCodeSlashCommands(cwd: string): Promise<string[]> {
 
 	// Helper: read command names from an opencode.json config file
 	const addCommandsFromConfig = async (configPath: string) => {
+		let content: string;
 		try {
-			const content = await fs.promises.readFile(configPath, 'utf-8');
-			const config = JSON.parse(content);
-			if (config.command && typeof config.command === 'object' && !Array.isArray(config.command)) {
-				for (const name of Object.keys(config.command)) {
-					commands.add(name);
-				}
-			}
+			content = await fs.promises.readFile(configPath, 'utf-8');
 		} catch (error: any) {
 			if (error?.code === 'ENOENT') {
 				logger.debug(`OpenCode config not found: ${configPath}`, LOG_CONTEXT);
-			} else {
-				throw error;
+				return;
+			}
+			throw error;
+		}
+		let config: any;
+		try {
+			config = JSON.parse(content);
+		} catch {
+			logger.warn(`OpenCode config has invalid JSON, skipping: ${configPath}`, LOG_CONTEXT);
+			return;
+		}
+		if (config.command && typeof config.command === 'object' && !Array.isArray(config.command)) {
+			for (const name of Object.keys(config.command)) {
+				commands.add(name);
 			}
 		}
 	};

--- a/src/main/ipc/handlers/agents.ts
+++ b/src/main/ipc/handlers/agents.ts
@@ -86,7 +86,7 @@ function discoverOpenCodeSlashCommands(cwd: string): string[] {
 	try {
 		if (fs.existsSync(projectConfigPath)) {
 			const config = JSON.parse(fs.readFileSync(projectConfigPath, 'utf-8'));
-			if (config.command && typeof config.command === 'object') {
+			if (config.command && typeof config.command === 'object' && !Array.isArray(config.command)) {
 				for (const name of Object.keys(config.command)) {
 					commands.add(name);
 				}
@@ -103,7 +103,7 @@ function discoverOpenCodeSlashCommands(cwd: string): string[] {
 	try {
 		if (fs.existsSync(globalConfigPath)) {
 			const config = JSON.parse(fs.readFileSync(globalConfigPath, 'utf-8'));
-			if (config.command && typeof config.command === 'object') {
+			if (config.command && typeof config.command === 'object' && !Array.isArray(config.command)) {
 				for (const name of Object.keys(config.command)) {
 					commands.add(name);
 				}

--- a/src/main/preload/agents.ts
+++ b/src/main/preload/agents.ts
@@ -171,14 +171,14 @@ export function createAgentsApi() {
 			ipcRenderer.invoke('agents:getModels', agentId, forceRefresh, sshRemoteId),
 
 		/**
-		 * Discover available slash commands for an agent by spawning it briefly
-		 * Returns array of command names (e.g., ['compact', 'help', 'my-custom-command'])
+		 * Discover available slash commands for an agent.
+		 * Returns command names (strings) for Claude Code, or objects with name+prompt for OpenCode.
 		 */
 		discoverSlashCommands: (
 			agentId: string,
 			cwd: string,
 			customPath?: string
-		): Promise<string[] | null> =>
+		): Promise<(string | { name: string; prompt?: string })[] | null> =>
 			ipcRenderer.invoke('agents:discoverSlashCommands', agentId, cwd, customPath),
 	};
 }

--- a/src/renderer/constants/app.ts
+++ b/src/renderer/constants/app.ts
@@ -89,16 +89,44 @@ export const CLAUDE_BUILTIN_COMMANDS: Record<string, string> = {
 };
 
 /**
- * Get description for Claude Code slash commands
- * Built-in commands have known descriptions, custom ones use a generic description
+ * Built-in OpenCode slash commands with their descriptions
  */
-export function getSlashCommandDescription(cmd: string): string {
+export const OPENCODE_BUILTIN_COMMANDS: Record<string, string> = {
+	init: 'Create or update AGENTS.md for the project',
+	review: 'Review changes (commit, branch, or PR)',
+	undo: 'Revert changes made by OpenCode',
+	redo: 'Restore previously undone changes',
+	share: 'Create a shareable link to the conversation',
+	help: 'List available commands',
+	models: 'Switch models interactively',
+};
+
+/**
+ * Agent-specific built-in command maps, keyed by agent ID
+ */
+const AGENT_BUILTIN_COMMANDS: Record<string, Record<string, string>> = {
+	'claude-code': CLAUDE_BUILTIN_COMMANDS,
+	opencode: OPENCODE_BUILTIN_COMMANDS,
+};
+
+/**
+ * Get description for agent slash commands.
+ * Checks all known agent built-in command maps, then falls back to generic description.
+ */
+export function getSlashCommandDescription(cmd: string, agentId?: string): string {
 	// Remove leading slash if present
 	const cmdName = cmd.startsWith('/') ? cmd.slice(1) : cmd;
 
-	// Check for built-in command
-	if (CLAUDE_BUILTIN_COMMANDS[cmdName]) {
-		return CLAUDE_BUILTIN_COMMANDS[cmdName];
+	// If a specific agent is provided, check that agent's commands first
+	if (agentId && AGENT_BUILTIN_COMMANDS[agentId]?.[cmdName]) {
+		return AGENT_BUILTIN_COMMANDS[agentId][cmdName];
+	}
+
+	// Check all agent command maps (for backwards compatibility when agentId is not provided)
+	for (const commands of Object.values(AGENT_BUILTIN_COMMANDS)) {
+		if (commands[cmdName]) {
+			return commands[cmdName];
+		}
 	}
 
 	// For plugin commands (e.g., "plugin-name:command"), use the full name as description hint
@@ -108,5 +136,5 @@ export function getSlashCommandDescription(cmd: string): string {
 	}
 
 	// Generic description for unknown commands
-	return 'Claude Code command';
+	return 'Agent command';
 }

--- a/src/renderer/constants/app.ts
+++ b/src/renderer/constants/app.ts
@@ -122,10 +122,12 @@ export function getSlashCommandDescription(cmd: string, agentId?: string): strin
 		return AGENT_BUILTIN_COMMANDS[agentId][cmdName];
 	}
 
-	// Check all agent command maps (for backwards compatibility when agentId is not provided)
-	for (const commands of Object.values(AGENT_BUILTIN_COMMANDS)) {
-		if (commands[cmdName]) {
-			return commands[cmdName];
+	// Check all agent command maps only when no specific agent was requested
+	if (!agentId) {
+		for (const commands of Object.values(AGENT_BUILTIN_COMMANDS)) {
+			if (commands[cmdName]) {
+				return commands[cmdName];
+			}
 		}
 	}
 

--- a/src/renderer/hooks/agent/useAgentListeners.ts
+++ b/src/renderer/hooks/agent/useAgentListeners.ts
@@ -980,14 +980,13 @@ export function useAgentListeners(deps: UseAgentListenersDeps): void {
 			(sessionId: string, slashCommands: string[]) => {
 				const actualSessionId = parseSessionId(sessionId).baseSessionId;
 
-				const commands = slashCommands.map((cmd) => ({
-					command: cmd.startsWith('/') ? cmd : `/${cmd}`,
-					description: getSlashCommandDescription(cmd),
-				}));
-
 				setSessions((prev) =>
 					prev.map((s) => {
 						if (s.id !== actualSessionId) return s;
+						const commands = slashCommands.map((cmd) => ({
+							command: cmd.startsWith('/') ? cmd : `/${cmd}`,
+							description: getSlashCommandDescription(cmd, s.toolType),
+						}));
 						return { ...s, agentCommands: commands };
 					})
 				);

--- a/src/renderer/hooks/agent/useAgentListeners.ts
+++ b/src/renderer/hooks/agent/useAgentListeners.ts
@@ -983,11 +983,19 @@ export function useAgentListeners(deps: UseAgentListenersDeps): void {
 				setSessions((prev) =>
 					prev.map((s) => {
 						if (s.id !== actualSessionId) return s;
-						const commands = slashCommands.map((cmd) => ({
+						const newCommands = slashCommands.map((cmd) => ({
 							command: cmd.startsWith('/') ? cmd : `/${cmd}`,
 							description: getSlashCommandDescription(cmd, s.toolType),
 						}));
-						return { ...s, agentCommands: commands };
+						// Merge with existing commands, preserving prompt data from
+						// disk-discovered commands (e.g., OpenCode .md files)
+						const existingByName = new Map((s.agentCommands || []).map((c) => [c.command, c]));
+						for (const cmd of newCommands) {
+							if (!existingByName.has(cmd.command)) {
+								existingByName.set(cmd.command, cmd);
+							}
+						}
+						return { ...s, agentCommands: Array.from(existingByName.values()) };
 					})
 				);
 			}

--- a/src/renderer/hooks/input/useInputProcessing.ts
+++ b/src/renderer/hooks/input/useInputProcessing.ts
@@ -223,7 +223,19 @@ export function useInputProcessing(deps: UseInputProcessingDeps): UseInputProces
 					const commandArgs =
 						firstSpaceIndex === -1 ? '' : commandText.substring(firstSpaceIndex + 1).trim();
 
-					const matchingCustomCommand = customAICommands.find((cmd) => cmd.command === baseCommand);
+					// Check custom AI commands first, then agent-discovered commands with prompts
+					const matchingAgentCommand = activeSession.agentCommands?.find(
+						(cmd) => cmd.command === baseCommand && cmd.prompt
+					);
+					const matchingCustomCommand =
+						customAICommands.find((cmd) => cmd.command === baseCommand) ||
+						(matchingAgentCommand
+							? {
+									command: matchingAgentCommand.command,
+									description: matchingAgentCommand.description,
+									prompt: matchingAgentCommand.prompt!,
+								}
+							: undefined);
 					if (matchingCustomCommand) {
 						// Execute the custom AI command by sending its prompt
 						setInputValue('');

--- a/src/renderer/hooks/wizard/useWizardHandlers.ts
+++ b/src/renderer/hooks/wizard/useWizardHandlers.ts
@@ -242,7 +242,7 @@ export function useWizardHandlers(deps: UseWizardHandlersDeps): UseWizardHandler
 
 				const agentCommandObjects = ((agentSlashCommands || []) as string[]).map((cmd) => ({
 					command: cmd.startsWith('/') ? cmd : `/${cmd}`,
-					description: getSlashCommandDescription(cmd),
+					description: getSlashCommandDescription(cmd, currentSession.toolType),
 				}));
 
 				if (agentCommandObjects.length > 0) {

--- a/src/renderer/hooks/wizard/useWizardHandlers.ts
+++ b/src/renderer/hooks/wizard/useWizardHandlers.ts
@@ -188,8 +188,8 @@ export function useWizardHandlers(deps: UseWizardHandlersDeps): UseWizardHandler
 		let cancelled = false;
 
 		const mergeCommands = (
-			existing: { command: string; description: string }[],
-			newCmds: { command: string; description: string }[]
+			existing: { command: string; description: string; prompt?: string }[],
+			newCmds: { command: string; description: string; prompt?: string }[]
 		) => {
 			const merged = [...existing];
 			for (const cmd of newCmds) {
@@ -233,17 +233,24 @@ export function useWizardHandlers(deps: UseWizardHandlersDeps): UseWizardHandler
 
 		const discoverAgentCommands = async () => {
 			try {
-				const agentSlashCommands = await (window as any).maestro.agents.discoverSlashCommands(
+				const agentSlashCommands = await window.maestro.agents.discoverSlashCommands(
 					currentSession.toolType,
 					currentSession.cwd,
 					currentSession.customPath
 				);
 				if (cancelled) return;
 
-				const agentCommandObjects = ((agentSlashCommands || []) as string[]).map((cmd) => ({
-					command: cmd.startsWith('/') ? cmd : `/${cmd}`,
-					description: getSlashCommandDescription(cmd, currentSession.toolType),
-				}));
+				const agentCommandObjects = (
+					agentSlashCommands ?? ([] as (string | { name: string; prompt?: string })[])
+				).map((cmd) => {
+					const name = typeof cmd === 'string' ? cmd : cmd.name;
+					const prompt = typeof cmd === 'string' ? undefined : cmd.prompt;
+					return {
+						command: name.startsWith('/') ? name : `/${name}`,
+						description: getSlashCommandDescription(name, currentSession.toolType),
+						prompt,
+					};
+				});
 
 				if (agentCommandObjects.length > 0) {
 					useSessionStore.getState().setSessions((prev) =>

--- a/src/renderer/hooks/wizard/useWizardHandlers.ts
+++ b/src/renderer/hooks/wizard/useWizardHandlers.ts
@@ -180,7 +180,7 @@ export function useWizardHandlers(deps: UseWizardHandlersDeps): UseWizardHandler
 			.getState()
 			.sessions.find((s) => s.id === activeSession?.id);
 		if (!currentSession) return;
-		if (currentSession.toolType !== 'claude-code') return;
+		if (currentSession.toolType !== 'claude-code' && currentSession.toolType !== 'opencode') return;
 		if (currentSession.agentCommands && currentSession.agentCommands.length > 0) return;
 
 		const sessionId = currentSession.id;
@@ -264,7 +264,9 @@ export function useWizardHandlers(deps: UseWizardHandlersDeps): UseWizardHandler
 			}
 		};
 
-		fetchCustomCommands();
+		if (currentSession.toolType === 'claude-code') {
+			fetchCustomCommands();
+		}
 		discoverAgentCommands();
 
 		return () => {

--- a/src/renderer/stores/agentStore.ts
+++ b/src/renderer/stores/agentStore.ts
@@ -353,10 +353,21 @@ export const useAgentStore = create<AgentStore>()((set, get) => ({
 				});
 			} else if (item.type === 'command' && item.command) {
 				// Process a slash command - find matching command
+				// Check user-defined commands first, then agent-discovered commands with prompts
+				const agentCmd = session.agentCommands?.find(
+					(cmd) => cmd.command === item.command && cmd.prompt
+				);
 				const matchingCommand =
 					deps.customAICommands.find((cmd) => cmd.command === item.command) ||
 					deps.speckitCommands.find((cmd) => cmd.command === item.command) ||
-					deps.openspecCommands.find((cmd) => cmd.command === item.command);
+					deps.openspecCommands.find((cmd) => cmd.command === item.command) ||
+					(agentCmd
+						? {
+								command: agentCmd.command,
+								description: agentCmd.description,
+								prompt: agentCmd.prompt!,
+							}
+						: undefined);
 
 				if (matchingCommand) {
 					let gitBranch: string | undefined;

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -616,7 +616,7 @@ export interface Session {
 	// Active time tracking - cumulative milliseconds of active use
 	activeTimeMs: number;
 	// Agent slash commands available for this session (fetched per session based on cwd)
-	agentCommands?: { command: string; description: string }[];
+	agentCommands?: { command: string; description: string; prompt?: string }[];
 	// Bookmark flag - bookmarked sessions appear in a dedicated section at the top
 	bookmarked?: boolean;
 	// Pending AI command that will trigger a synopsis on completion (e.g., '/commit')


### PR DESCRIPTION
## Summary

- Enables OpenCode slash command discovery by reading commands from disk (`.opencode/commands/*.md`, `~/.config/opencode/commands/*.md`, and `opencode.json` config)
- Sets `supportsSlashCommands: true` for OpenCode agent so commands appear in autocomplete
- Makes `getSlashCommandDescription()` agent-aware to provide correct descriptions per agent

Closes #552

## Changes

| File | Change |
|------|--------|
| `src/main/agents/capabilities.ts` | Flip `supportsSlashCommands` to `true` for opencode |
| `src/main/ipc/handlers/agents.ts` | Add `discoverOpenCodeSlashCommands()` — disk-based discovery from 3 sources (built-in, project-local, global + config) |
| `src/renderer/constants/app.ts` | Add `OPENCODE_BUILTIN_COMMANDS` descriptions, make `getSlashCommandDescription()` agent-aware |
| `src/renderer/hooks/agent/useAgentListeners.ts` | Pass `toolType` to `getSlashCommandDescription()` |
| `src/renderer/hooks/wizard/useWizardHandlers.ts` | Pass `toolType` to `getSlashCommandDescription()` |

## How it works

Unlike Claude Code (which discovers commands via `system/init` JSON event), OpenCode stores commands on disk:
1. **Built-in**: `init`, `review`, `undo`, `redo`, `share`, `help`, `models`
2. **Project-local**: `.opencode/commands/<name>.md` files
3. **Global**: `~/.config/opencode/commands/<name>.md` files
4. **Config**: `opencode.json` → `command` property

The discovery function reads all three sources and returns a unified command list, matching Claude Code's end-to-end pipeline (discover → autocomplete → execute).

## Test plan

- [ ] Create an OpenCode session in Maestro and verify slash commands appear in autocomplete
- [ ] Add a custom `.opencode/commands/test.md` file and verify it's discovered
- [ ] Verify Claude Code slash commands still work unchanged
- [ ] Verify Codex sessions (no slash commands) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OpenCode now exposes built-in slash commands: init, review, undo, redo, share, help, models.
  * Automatic discovery of custom OpenCode slash commands from project/global command files and opencode.json.

* **Improvements**
  * Command descriptions are resolved per agent/tool for accurate help and UI display.
  * Slash-command discovery runs for both Claude Code and OpenCode where applicable.

* **Tests**
  * Expanded tests covering OpenCode discovery, parsing, error paths, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->