### PR TITLE
feat: add SQLite session reading support for OpenCode v1.2+

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -110,7 +110,7 @@ The major contributions to 0.14.x remain:
 - Leaderboard tracking now works across multiple systems and syncs level from cloud 🏆
 - Agent duplication. Pro tip: Consider a group of unused "Template" agents ✌️
 - New setting to prevent system from going to sleep while agents are active 🛏️
-- The tab menu has a new "Publish as GitHub Gist" option  📝
+- The tab menu has a new "Publish as GitHub Gist" option 📝
 - The tab menu has options to move the tab to the first or last position 🔀
 - [Maestro-Playbooks](https://github.com/pedramamini/Maestro-Playbooks) can now contain non-markdown assets 📙
 - Improved default shell detection 🐚
@@ -139,10 +139,12 @@ Thanks for the contributions: @t1mmen @aejfager @Crumbgrabber @whglaser @b3nw @d
 - TAKE TWO! Fixed Linux ARM64 build architecture contamination issues 🏗️
 
 ### v0.13.1 Changes
+
 - Fixed Linux ARM64 build architecture contamination issues 🏗️
 - Enhanced error handling for Auto Run batch processing 🚨
 
 ### v0.13.0 Changes
+
 - Added a global usage dashboard, data collection begins with this install 🎛️
 - Added a Playbook Exchange for downloading pre-defined Auto Run playbooks from [Maestro-Playbooks](https://github.com/pedramamini/Maestro-Playbooks) 📕
 - Bundled OpenSpec commands for structured change proposals 📝
@@ -166,15 +168,19 @@ Thanks for the contributions: @t1mmen @aejfager @Crumbgrabber @whglaser @b3nw @d
 The big changes in the v0.12.x line are the following three:
 
 ## Show Thinking
-🤔 There is now a toggle to show thinking for the agent, the default for new tabs is off, though this can be changed under Settings > General. The toggle shows next to History and Read-Only. Very similar pattern. This has been the #1 most requested feature, though personally, I don't think I'll use it as I prefer to not see the details of the work, but the results of the work. Just as we work with our colleagues. 
+
+🤔 There is now a toggle to show thinking for the agent, the default for new tabs is off, though this can be changed under Settings > General. The toggle shows next to History and Read-Only. Very similar pattern. This has been the #1 most requested feature, though personally, I don't think I'll use it as I prefer to not see the details of the work, but the results of the work. Just as we work with our colleagues.
 
 ## GitHub Spec-Kit Integration
+
 🎯 Added [GitHub Spec-Kit](https://github.com/github/spec-kit) commands into Maestro with a built in updater to grab the latest prompts from the repository. We do override `/speckit-implement` (the final step) to create Auto Run docs and guide the user through their execution, which thanks to Wortrees from v0.11.x allows us to run in parallel!
 
 ## Context Management Tools
+
 📖 Added context management options from tab right-click menu. You can now compress, merge, and transfer contexts between agents. You will received (configurable) warnings at 60% and 80% context consumption with a hint to compact.
 
 ## Changes Specific to v0.12.3:
+
 - We now have hosted documentation through Mintlify 📚
 - Export any tab conversation as self-contained themed HTML file 📄
 - Publish files as private/public Gists 🌐
@@ -287,6 +293,7 @@ The big changes in the v0.12.x line are the following three:
 Minor bugfixes on top of v0.7.3:
 
 # Onboarding, Wizard, and Tours
+
 - Implemented comprehensive onboarding wizard with integrated tour system 🚀
 - Added project-understanding confidence display to wizard UI 🎨
 - Enhanced keyboard navigation across all wizard screens ⌨️
@@ -294,6 +301,7 @@ Minor bugfixes on top of v0.7.3:
 - Added First Run Celebration modal with confetti animation 🎉
 
 # UI / UX Enhancements
+
 - Added expand-to-fullscreen button for Auto Run interface 🖥️
 - Created dedicated modal component and improved modal priority constants for expanded Auto Run view 📐
 - Enhanced user experience with fullscreen editing capabilities ✨
@@ -303,15 +311,18 @@ Minor bugfixes on top of v0.7.3:
 - Enhanced toast context with agent name for OS notifications 📢
 
 # Auto Run Workflow Improvements
+
 - Created phase document generation for Auto Run workflow 📄
 - Added real-time log streaming to the LogViewer component 📊
 
 # Application Behavior / Core Fixes
+
 - Added validation to prevent nested worktrees inside the main repository 🚫
 - Fixed process manager to properly emit exit events on errors 🔧
 - Fixed process exit handling to ensure proper cleanup 🧹
 
 # Update System
+
 - Implemented automatic update checking on application startup 🚀
 - Added settings toggle for enabling/disabling startup update checks ⚙️
 
@@ -329,6 +340,7 @@ Minor bugfixes on top of v0.7.3:
 **Latest: v0.6.1** | Released December 4, 2025
 
 In this release...
+
 - Added recursive subfolder support for Auto Run markdown files 🗂️
 - Enhanced document tree display with expandable folder navigation 🌳
 - Enabled creating documents in subfolders with path selection 📁
@@ -341,6 +353,7 @@ In this release...
 - Added support for nested folder structures in document management 🏗️
 
 Plus the pre-release ALPHA...
+
 - Template vars now set context in default autorun prompt 🚀
 - Added Enter key support for queued message confirmation dialog ⌨️
 - Kill process capability added to System Process Monitor 💀
@@ -500,6 +513,7 @@ Plus the pre-release ALPHA...
 All releases are available on the [GitHub Releases page](https://github.com/RunMaestro/Maestro/releases).
 
 Maestro is available for:
+
 - **macOS** - Apple Silicon (arm64) and Intel (x64)
 - **Windows** - x64
 - **Linux** - x64 and arm64, AppImage, deb, and rpm packages

--- a/src/main/storage/opencode-session-storage.ts
+++ b/src/main/storage/opencode-session-storage.ts
@@ -38,6 +38,9 @@ import { isWindows } from '../../shared/platformDetection';
 
 const LOG_CONTEXT = '[OpenCodeSessionStorage]';
 
+/** Regex matching one or more trailing path separators (platform-aware) */
+const TRAILING_SEP_RE = new RegExp(`${path.sep.replace('\\', '\\\\')}+$`);
+
 /**
  * Get OpenCode data base directory (platform-specific)
  * - Linux/macOS: ~/.local/share/opencode
@@ -220,15 +223,18 @@ interface SqlitePartData {
  * Returns null if the database file doesn't exist.
  */
 function openOpenCodeDb(dbPath: string = OPENCODE_DB_PATH): Database.Database | null {
+	if (!fsSync.existsSync(dbPath)) {
+		return null;
+	}
 	try {
-		if (!fsSync.existsSync(dbPath)) {
-			return null;
-		}
 		const db = new Database(dbPath, { readonly: true, fileMustExist: true });
 		return db;
 	} catch (error) {
-		logger.warn(`Failed to open OpenCode SQLite database: ${error}`, LOG_CONTEXT);
-		return null;
+		logger.warn(`${LOG_CONTEXT} Failed to open OpenCode SQLite database at ${dbPath}: ${error}`);
+		captureException(error instanceof Error ? error : new Error(String(error)), {
+			extra: { dbPath },
+		});
+		throw error;
 	}
 }
 
@@ -395,8 +401,8 @@ export class OpenCodeSessionStorage extends BaseSessionStorage {
 
 		const projectFiles = await listJsonFiles(projectDir);
 
-		// Normalize project path for comparison (resolve and remove trailing slashes)
-		const normalizedPath = path.resolve(projectPath).replace(/\/+$/, '');
+		// Normalize project path for comparison (resolve and remove trailing separators)
+		const normalizedPath = path.resolve(projectPath).replace(TRAILING_SEP_RE, '');
 		logger.info(`Looking for OpenCode project for path: ${normalizedPath}`, LOG_CONTEXT);
 
 		for (const file of projectFiles) {
@@ -407,7 +413,7 @@ export class OpenCodeSessionStorage extends BaseSessionStorage {
 			if (!projectData?.worktree) continue;
 
 			// Normalize stored path the same way
-			const storedPath = path.resolve(projectData.worktree).replace(/\/+$/, '');
+			const storedPath = path.resolve(projectData.worktree).replace(TRAILING_SEP_RE, '');
 
 			// Exact match
 			if (storedPath === normalizedPath) {
@@ -420,8 +426,8 @@ export class OpenCodeSessionStorage extends BaseSessionStorage {
 
 			// Check if one is a subdirectory of the other (handles worktree subdirs)
 			if (
-				normalizedPath.startsWith(storedPath + '/') ||
-				storedPath.startsWith(normalizedPath + '/')
+				normalizedPath.startsWith(storedPath + path.sep) ||
+				storedPath.startsWith(normalizedPath + path.sep)
 			) {
 				logger.info(
 					`Found OpenCode project (subdirectory match): ${projectData.id} for path: ${normalizedPath}`,
@@ -748,7 +754,7 @@ export class OpenCodeSessionStorage extends BaseSessionStorage {
 				return null;
 			}
 
-			const normalizedPath = path.resolve(projectPath).replace(/\/+$/, '');
+			const normalizedPath = path.resolve(projectPath).replace(TRAILING_SEP_RE, '');
 
 			// Find matching project(s) — exact match or subdirectory match
 			const projects = db.prepare('SELECT id, worktree FROM project').all() as Array<{
@@ -765,11 +771,11 @@ export class OpenCodeSessionStorage extends BaseSessionStorage {
 					hasGlobalProject = true;
 					continue;
 				}
-				const storedPath = path.resolve(proj.worktree).replace(/\/+$/, '');
+				const storedPath = path.resolve(proj.worktree).replace(TRAILING_SEP_RE, '');
 				if (
 					storedPath === normalizedPath ||
-					normalizedPath.startsWith(storedPath + '/') ||
-					storedPath.startsWith(normalizedPath + '/')
+					normalizedPath.startsWith(storedPath + path.sep) ||
+					storedPath.startsWith(normalizedPath + path.sep)
 				) {
 					matchingProjectIds.push(proj.id);
 				}
@@ -793,7 +799,7 @@ export class OpenCodeSessionStorage extends BaseSessionStorage {
 					.prepare(
 						"SELECT id, project_id, directory, title, version, time_created, time_updated, summary_additions, summary_deletions, summary_files FROM session WHERE project_id = 'global' AND (directory = ? OR directory LIKE ? ESCAPE '\\') ORDER BY time_updated DESC"
 					)
-					.all(normalizedPath, escapedPath + '/%') as SqliteSessionRow[];
+					.all(normalizedPath, escapedPath + path.sep + '%') as SqliteSessionRow[];
 				if (globalSessions.length > 0) {
 					const existingIds = new Set(sessions.map((s) => s.id));
 					for (const gs of globalSessions) {
@@ -803,6 +809,9 @@ export class OpenCodeSessionStorage extends BaseSessionStorage {
 					}
 				}
 			}
+
+			// Re-sort after merging global sessions so newest come first
+			sessions.sort((a, b) => b.time_updated - a.time_updated);
 
 			if (sessions.length === 0) {
 				logger.info(`No OpenCode sessions found in SQLite for: ${normalizedPath}`, LOG_CONTEXT);

--- a/src/main/storage/opencode-session-storage.ts
+++ b/src/main/storage/opencode-session-storage.ts
@@ -2,13 +2,12 @@
  * OpenCode Session Storage Implementation
  *
  * This module implements the AgentSessionStorage interface for OpenCode.
- * OpenCode stores sessions as JSON files in ~/.local/share/opencode/storage/
  *
- * Directory structure:
- * - project/     - Project metadata (SHA1 hash of path as ID)
- * - session/{projectID}/ - Session metadata per project
- * - message/{sessionID}/ - Messages per session
- * - part/{messageID}/    - Message parts (text, tool, reasoning)
+ * OpenCode v1.2+ stores sessions in SQLite at ~/.local/share/opencode/opencode.db
+ * Older versions used JSON files at ~/.local/share/opencode/storage/
+ *
+ * This implementation reads from SQLite first, falls back to JSON for pre-v1.2
+ * installs, and deduplicates sessions when both sources exist (migration period).
  *
  * Session IDs: Format is `ses_{base62}` (e.g., ses_4d585107dffeO9bO3HvMdvLYyC)
  * Project IDs: SHA1 hash of the project path
@@ -21,7 +20,9 @@
 import path from 'path';
 import os from 'os';
 import fs from 'fs/promises';
+import fsSync from 'fs';
 import { createHash } from 'crypto';
+import Database from 'better-sqlite3';
 import { logger } from '../utils/logger';
 import { captureException } from '../utils/sentry';
 import { readFileRemote, readDirRemote, statRemote } from '../utils/remote-fs';
@@ -38,19 +39,34 @@ import { isWindows } from '../../shared/platformDetection';
 const LOG_CONTEXT = '[OpenCodeSessionStorage]';
 
 /**
- * Get OpenCode storage base directory (platform-specific)
- * - Linux/macOS: ~/.local/share/opencode/storage
- * - Windows: %APPDATA%\opencode\storage
+ * Get OpenCode data base directory (platform-specific)
+ * - Linux/macOS: ~/.local/share/opencode
+ * - Windows: %APPDATA%\opencode
  */
-function getOpenCodeStorageDir(): string {
+function getOpenCodeDataDir(): string {
 	if (isWindows()) {
 		const appData = process.env.APPDATA || path.join(os.homedir(), 'AppData', 'Roaming');
-		return path.join(appData, 'opencode', 'storage');
+		return path.join(appData, 'opencode');
 	}
-	return path.join(os.homedir(), '.local', 'share', 'opencode', 'storage');
+	return path.join(os.homedir(), '.local', 'share', 'opencode');
+}
+
+/**
+ * Get OpenCode JSON storage directory (pre-v1.2)
+ */
+function getOpenCodeStorageDir(): string {
+	return path.join(getOpenCodeDataDir(), 'storage');
+}
+
+/**
+ * Get OpenCode SQLite database path (v1.2+)
+ */
+function getOpenCodeDbPath(): string {
+	return path.join(getOpenCodeDataDir(), 'opencode.db');
 }
 
 const OPENCODE_STORAGE_DIR = getOpenCodeStorageDir();
+const OPENCODE_DB_PATH = getOpenCodeDbPath();
 
 /**
  * OpenCode project metadata structure
@@ -133,6 +149,113 @@ interface OpenCodePart {
 	};
 }
 
+// ─── SQLite row types (v1.2+) ────────────────────────────────────────────────
+
+/**
+ * Raw row from the SQLite `session` table
+ */
+interface SqliteSessionRow {
+	id: string;
+	project_id: string;
+	directory: string;
+	title: string;
+	version: string;
+	time_created: number; // Unix ms
+	time_updated: number; // Unix ms
+	summary_additions: number | null;
+	summary_deletions: number | null;
+	summary_files: number | null;
+}
+
+/**
+ * Raw row from the SQLite `message` table
+ * The `data` column is a JSON blob containing role, model, tokens, cost, etc.
+ */
+interface SqliteMessageRow {
+	id: string;
+	session_id: string;
+	time_created: number;
+	time_updated: number;
+	data: string; // JSON blob
+}
+
+/**
+ * Parsed message data from the SQLite `data` JSON blob
+ */
+interface SqliteMessageData {
+	role?: 'user' | 'assistant';
+	modelID?: string;
+	providerID?: string;
+	agent?: string;
+	tokens?: {
+		input?: number;
+		output?: number;
+		reasoning?: number;
+		cache?: {
+			read?: number;
+			write?: number;
+		};
+	};
+	cost?: number;
+}
+
+/**
+ * Parsed part data from the SQLite `data` JSON blob
+ */
+interface SqlitePartData {
+	type?: 'text' | 'reasoning' | 'tool' | 'step-start' | 'step-finish';
+	text?: string;
+	tool?: string;
+	state?: {
+		status?: string;
+		input?: unknown;
+		output?: unknown;
+	};
+}
+
+// ─── SQLite helpers ──────────────────────────────────────────────────────────
+
+/**
+ * Open the OpenCode SQLite database in read-only mode.
+ * Returns null if the database file doesn't exist.
+ */
+function openOpenCodeDb(dbPath: string = OPENCODE_DB_PATH): Database.Database | null {
+	try {
+		if (!fsSync.existsSync(dbPath)) {
+			return null;
+		}
+		const db = new Database(dbPath, { readonly: true, fileMustExist: true });
+		db.pragma('journal_mode = WAL');
+		return db;
+	} catch (error) {
+		logger.warn(`Failed to open OpenCode SQLite database: ${error}`, LOG_CONTEXT);
+		return null;
+	}
+}
+
+/**
+ * Safely parse a JSON string, returning null on failure
+ */
+function safeJsonParse<T>(json: string): T | null {
+	try {
+		return JSON.parse(json) as T;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Check if a table exists in a SQLite database
+ */
+function tableExists(db: Database.Database, tableName: string): boolean {
+	const row = db
+		.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name=?")
+		.get(tableName) as { name: string } | undefined;
+	return !!row;
+}
+
+// ─── Shared helpers ──────────────────────────────────────────────────────────
+
 /**
  * Generate the project ID hash from a path (SHA1)
  */
@@ -202,7 +325,8 @@ async function listJsonFilesRemote(dirPath: string, sshConfig: SshRemoteConfig):
 /**
  * OpenCode Session Storage Implementation
  *
- * Provides access to OpenCode's local session storage at ~/.local/share/opencode/storage/
+ * Reads from SQLite (v1.2+) with JSON file fallback (pre-v1.2).
+ * During migration periods, both sources are merged with dedup by session ID.
  */
 export class OpenCodeSessionStorage extends BaseSessionStorage {
 	readonly agentId: ToolType = 'opencode';
@@ -610,19 +734,353 @@ export class OpenCodeSessionStorage extends BaseSessionStorage {
 		return textParts.join(' ').trim();
 	}
 
+	// ─── SQLite-based methods (OpenCode v1.2+) ──────────────────────────────
+
+	/**
+	 * List sessions from SQLite database for a given project path.
+	 * Returns null if the database doesn't exist or lacks the expected schema.
+	 */
+	private listSessionsSqlite(projectPath: string): AgentSessionInfo[] | null {
+		const db = openOpenCodeDb();
+		if (!db) return null;
+
+		try {
+			if (!tableExists(db, 'session') || !tableExists(db, 'project')) {
+				return null;
+			}
+
+			const normalizedPath = path.resolve(projectPath).replace(/\/+$/, '');
+
+			// Find matching project(s) — exact match or subdirectory match
+			const projects = db.prepare('SELECT id, worktree FROM project').all() as Array<{
+				id: string;
+				worktree: string;
+			}>;
+
+			const matchingProjectIds: string[] = [];
+			let hasGlobalProject = false;
+			for (const proj of projects) {
+				// Skip the 'global' project (worktree '/') from project-level matching —
+				// it matches everything. Its sessions are filtered by directory below.
+				if (proj.id === 'global') {
+					hasGlobalProject = true;
+					continue;
+				}
+				const storedPath = path.resolve(proj.worktree).replace(/\/+$/, '');
+				if (
+					storedPath === normalizedPath ||
+					normalizedPath.startsWith(storedPath + '/') ||
+					storedPath.startsWith(normalizedPath + '/')
+				) {
+					matchingProjectIds.push(proj.id);
+				}
+			}
+
+			// Collect sessions from matching dedicated projects
+			let sessions: SqliteSessionRow[] = [];
+			if (matchingProjectIds.length > 0) {
+				const placeholders = matchingProjectIds.map(() => '?').join(',');
+				sessions = db
+					.prepare(
+						`SELECT id, project_id, directory, title, version, time_created, time_updated, summary_additions, summary_deletions, summary_files FROM session WHERE project_id IN (${placeholders}) ORDER BY time_updated DESC`
+					)
+					.all(...matchingProjectIds) as SqliteSessionRow[];
+			}
+
+			// Also include global project sessions that match by directory field
+			if (hasGlobalProject) {
+				const globalSessions = db
+					.prepare(
+						"SELECT id, project_id, directory, title, version, time_created, time_updated, summary_additions, summary_deletions, summary_files FROM session WHERE project_id = 'global' AND (directory = ? OR directory LIKE ?) ORDER BY time_updated DESC"
+					)
+					.all(normalizedPath, normalizedPath + '/%') as SqliteSessionRow[];
+				if (globalSessions.length > 0) {
+					const existingIds = new Set(sessions.map((s) => s.id));
+					for (const gs of globalSessions) {
+						if (!existingIds.has(gs.id)) {
+							sessions.push(gs);
+						}
+					}
+				}
+			}
+
+			if (sessions.length === 0) {
+				logger.info(`No OpenCode sessions found in SQLite for: ${normalizedPath}`, LOG_CONTEXT);
+				return [];
+			}
+
+			logger.info(
+				`Found ${sessions.length} OpenCode sessions in SQLite for: ${normalizedPath}`,
+				LOG_CONTEXT
+			);
+
+			return this.convertSqliteSessionRows(sessions, projectPath, db);
+		} catch (error) {
+			logger.warn(`Error reading OpenCode SQLite database: ${error}`, LOG_CONTEXT);
+			return null;
+		} finally {
+			db.close();
+		}
+	}
+
+	/**
+	 * Convert SQLite session rows to AgentSessionInfo array, loading message stats
+	 */
+	private convertSqliteSessionRows(
+		rows: SqliteSessionRow[],
+		projectPath: string,
+		db: Database.Database
+	): AgentSessionInfo[] {
+		const hasMessageTable = tableExists(db, 'message');
+		const hasPartTable = tableExists(db, 'part');
+		const sessions: AgentSessionInfo[] = [];
+
+		for (const row of rows) {
+			let messageCount = 0;
+			let totalInputTokens = 0;
+			let totalOutputTokens = 0;
+			let totalCacheReadTokens = 0;
+			let totalCacheWriteTokens = 0;
+			let totalCost = 0;
+			let firstMessage = row.title || '';
+			let durationSeconds = 0;
+
+			if (hasMessageTable) {
+				const messages = db
+					.prepare(
+						'SELECT id, data, time_created FROM message WHERE session_id = ? ORDER BY time_created ASC'
+					)
+					.all(row.id) as Array<{ id: string; data: string; time_created: number }>;
+
+				messageCount = messages.length;
+
+				if (messages.length >= 2) {
+					const first = messages[0].time_created;
+					const last = messages[messages.length - 1].time_created;
+					if (first && last) {
+						durationSeconds = Math.max(0, Math.floor((last - first) / 1000));
+					}
+				}
+
+				// Aggregate stats and find preview message
+				let foundPreview = false;
+				for (const msg of messages) {
+					const data = safeJsonParse<SqliteMessageData>(msg.data);
+					if (!data) continue;
+
+					if (data.tokens) {
+						totalInputTokens += data.tokens.input || 0;
+						totalOutputTokens += data.tokens.output || 0;
+						totalCacheReadTokens += data.tokens.cache?.read || 0;
+						totalCacheWriteTokens += data.tokens.cache?.write || 0;
+					}
+					if (data.cost) {
+						totalCost += data.cost;
+					}
+
+					// Get preview from first assistant message with text
+					if (!foundPreview && data.role === 'assistant' && hasPartTable) {
+						const parts = db
+							.prepare('SELECT data FROM part WHERE message_id = ? ORDER BY time_created ASC')
+							.all(msg.id) as Array<{ data: string }>;
+						for (const part of parts) {
+							const partData = safeJsonParse<SqlitePartData>(part.data);
+							if (partData?.type === 'text' && partData.text?.trim()) {
+								firstMessage = partData.text;
+								foundPreview = true;
+								break;
+							}
+						}
+					}
+
+					// Fall back to first user message if no assistant text found
+					if (!foundPreview && data.role === 'user' && hasPartTable) {
+						const parts = db
+							.prepare('SELECT data FROM part WHERE message_id = ? ORDER BY time_created ASC')
+							.all(msg.id) as Array<{ data: string }>;
+						for (const part of parts) {
+							const partData = safeJsonParse<SqlitePartData>(part.data);
+							if (partData?.type === 'text' && partData.text?.trim()) {
+								firstMessage = partData.text;
+								break;
+							}
+						}
+					}
+				}
+			}
+
+			const createdAt = row.time_created
+				? new Date(row.time_created).toISOString()
+				: new Date().toISOString();
+			const updatedAt = row.time_updated ? new Date(row.time_updated).toISOString() : createdAt;
+
+			sessions.push({
+				sessionId: row.id,
+				projectPath,
+				timestamp: createdAt,
+				modifiedAt: updatedAt,
+				firstMessage: firstMessage.slice(0, 200),
+				messageCount,
+				sizeBytes: 0,
+				costUsd: totalCost,
+				inputTokens: totalInputTokens,
+				outputTokens: totalOutputTokens,
+				cacheReadTokens: totalCacheReadTokens,
+				cacheCreationTokens: totalCacheWriteTokens,
+				durationSeconds,
+			});
+		}
+
+		return sessions;
+	}
+
+	/**
+	 * Load messages for a session from SQLite.
+	 * Returns null if the database doesn't exist or lacks the expected schema.
+	 */
+	private loadSessionMessagesSqlite(sessionId: string): {
+		messages: OpenCodeMessage[];
+		parts: Map<string, OpenCodePart[]>;
+		totalInputTokens: number;
+		totalOutputTokens: number;
+		totalCacheReadTokens: number;
+		totalCacheWriteTokens: number;
+		totalCost: number;
+	} | null {
+		const db = openOpenCodeDb();
+		if (!db) return null;
+
+		try {
+			if (!tableExists(db, 'message')) return null;
+
+			const messageRows = db
+				.prepare(
+					'SELECT id, session_id, time_created, time_updated, data FROM message WHERE session_id = ? ORDER BY time_created ASC'
+				)
+				.all(sessionId) as SqliteMessageRow[];
+
+			if (messageRows.length === 0) return null;
+
+			const hasPartTable = tableExists(db, 'part');
+			const messages: OpenCodeMessage[] = [];
+			const parts = new Map<string, OpenCodePart[]>();
+			let totalInputTokens = 0;
+			let totalOutputTokens = 0;
+			let totalCacheReadTokens = 0;
+			let totalCacheWriteTokens = 0;
+			let totalCost = 0;
+
+			for (const row of messageRows) {
+				const data = safeJsonParse<SqliteMessageData>(row.data);
+				if (!data) continue;
+
+				const msg: OpenCodeMessage = {
+					id: row.id,
+					sessionID: sessionId,
+					role: data.role || 'user',
+					time: { created: row.time_created },
+					tokens: data.tokens,
+					cost: data.cost,
+				};
+				messages.push(msg);
+
+				if (data.tokens) {
+					totalInputTokens += data.tokens.input || 0;
+					totalOutputTokens += data.tokens.output || 0;
+					totalCacheReadTokens += data.tokens.cache?.read || 0;
+					totalCacheWriteTokens += data.tokens.cache?.write || 0;
+				}
+				if (data.cost) {
+					totalCost += data.cost;
+				}
+
+				// Load parts from SQLite
+				if (hasPartTable) {
+					const partRows = db
+						.prepare('SELECT id, data FROM part WHERE message_id = ? ORDER BY time_created ASC')
+						.all(row.id) as Array<{ id: string; data: string }>;
+
+					const messageParts: OpenCodePart[] = [];
+					for (const partRow of partRows) {
+						const partData = safeJsonParse<SqlitePartData>(partRow.data);
+						if (partData) {
+							messageParts.push({
+								id: partRow.id,
+								messageID: row.id,
+								type: partData.type || 'text',
+								text: partData.text,
+								tool: partData.tool,
+								state: partData.state,
+							});
+						}
+					}
+					parts.set(row.id, messageParts);
+				}
+			}
+
+			return {
+				messages,
+				parts,
+				totalInputTokens,
+				totalOutputTokens,
+				totalCacheReadTokens,
+				totalCacheWriteTokens,
+				totalCost,
+			};
+		} catch (error) {
+			logger.warn(`Error loading messages from OpenCode SQLite: ${error}`, LOG_CONTEXT);
+			return null;
+		} finally {
+			db.close();
+		}
+	}
+
+	// ─── Merged listing (SQLite + JSON) ─────────────────────────────────────
+
 	async listSessions(
 		projectPath: string,
 		sshConfig?: SshRemoteConfig
 	): Promise<AgentSessionInfo[]> {
-		// Use SSH remote access if config provided
+		// Use SSH remote access if config provided (JSON only for SSH — no remote SQLite)
 		if (sshConfig) {
 			return this.listSessionsRemote(projectPath, sshConfig);
 		}
 
+		// Try SQLite first (v1.2+), then fall back to JSON, merge and dedup
+		const sqliteSessions = this.listSessionsSqlite(projectPath);
+		const jsonSessions = await this.listSessionsJson(projectPath);
+
+		if (sqliteSessions && sqliteSessions.length > 0) {
+			if (jsonSessions.length > 0) {
+				// Merge: SQLite is authoritative, add JSON-only sessions
+				const sqliteIds = new Set(sqliteSessions.map((s) => s.sessionId));
+				const merged = [...sqliteSessions];
+				for (const jsonSession of jsonSessions) {
+					if (!sqliteIds.has(jsonSession.sessionId)) {
+						merged.push(jsonSession);
+					}
+				}
+				merged.sort((a, b) => new Date(b.modifiedAt).getTime() - new Date(a.modifiedAt).getTime());
+				logger.info(
+					`Merged ${sqliteSessions.length} SQLite + ${merged.length - sqliteSessions.length} JSON-only sessions for: ${projectPath}`,
+					LOG_CONTEXT
+				);
+				return merged;
+			}
+			return sqliteSessions;
+		}
+
+		// SQLite unavailable or empty — use JSON results
+		return jsonSessions;
+	}
+
+	/**
+	 * List sessions from JSON files (pre-v1.2 format)
+	 */
+	private async listSessionsJson(projectPath: string): Promise<AgentSessionInfo[]> {
 		const projectId = await this.findProjectId(projectPath);
 
 		if (!projectId) {
-			logger.info(`No OpenCode project found for path: ${projectPath}`, LOG_CONTEXT);
 			return [];
 		}
 
@@ -634,7 +1092,6 @@ export class OpenCodeSessionStorage extends BaseSessionStorage {
 		try {
 			await fs.access(sessionDir);
 		} catch {
-			logger.info(`No OpenCode sessions directory for project: ${projectPath}`, LOG_CONTEXT);
 			return [];
 		}
 
@@ -731,10 +1188,12 @@ export class OpenCodeSessionStorage extends BaseSessionStorage {
 		// Sort by modified date (newest first)
 		sessions.sort((a, b) => new Date(b.modifiedAt).getTime() - new Date(a.modifiedAt).getTime());
 
-		logger.info(
-			`Found ${sessions.length} OpenCode sessions for project: ${projectPath}`,
-			LOG_CONTEXT
-		);
+		if (sessions.length > 0) {
+			logger.info(
+				`Found ${sessions.length} OpenCode sessions (JSON) for: ${projectPath}`,
+				LOG_CONTEXT
+			);
+		}
 		return sessions;
 	}
 
@@ -872,9 +1331,22 @@ export class OpenCodeSessionStorage extends BaseSessionStorage {
 		options?: SessionReadOptions,
 		sshConfig?: SshRemoteConfig
 	): Promise<SessionMessagesResult> {
-		const { messages, parts } = sshConfig
-			? await this.loadSessionMessagesRemote(sessionId, sshConfig)
-			: await this.loadSessionMessages(sessionId);
+		// Try SQLite first for local sessions, fall back to JSON
+		let loaded: {
+			messages: OpenCodeMessage[];
+			parts: Map<string, OpenCodePart[]>;
+		} | null = null;
+
+		if (sshConfig) {
+			loaded = await this.loadSessionMessagesRemote(sessionId, sshConfig);
+		} else {
+			loaded = this.loadSessionMessagesSqlite(sessionId);
+			if (!loaded) {
+				loaded = await this.loadSessionMessages(sessionId);
+			}
+		}
+
+		const { messages, parts } = loaded;
 
 		const sessionMessages: SessionMessage[] = [];
 
@@ -911,9 +1383,22 @@ export class OpenCodeSessionStorage extends BaseSessionStorage {
 		_projectPath: string,
 		sshConfig?: SshRemoteConfig
 	): Promise<SearchableMessage[]> {
-		const { messages, parts } = sshConfig
-			? await this.loadSessionMessagesRemote(sessionId, sshConfig)
-			: await this.loadSessionMessages(sessionId);
+		// Try SQLite first for local sessions, fall back to JSON
+		let loaded: {
+			messages: OpenCodeMessage[];
+			parts: Map<string, OpenCodePart[]>;
+		} | null = null;
+
+		if (sshConfig) {
+			loaded = await this.loadSessionMessagesRemote(sessionId, sshConfig);
+		} else {
+			loaded = this.loadSessionMessagesSqlite(sessionId);
+			if (!loaded) {
+				loaded = await this.loadSessionMessages(sessionId);
+			}
+		}
+
+		const { messages, parts } = loaded;
 
 		return messages
 			.filter((msg) => msg.role === 'user' || msg.role === 'assistant')
@@ -929,11 +1414,14 @@ export class OpenCodeSessionStorage extends BaseSessionStorage {
 		sessionId: string,
 		sshConfig?: SshRemoteConfig
 	): string | null {
-		// OpenCode uses a more complex structure with multiple directories
-		// Return the message directory as the "session path"
 		if (sshConfig) {
 			return this.getRemoteMessageDir(sessionId);
 		}
+		// For SQLite-backed sessions, return the database path
+		if (fsSync.existsSync(OPENCODE_DB_PATH)) {
+			return OPENCODE_DB_PATH;
+		}
+		// Fallback to JSON message directory
 		return this.getMessageDir(sessionId);
 	}
 
@@ -951,7 +1439,21 @@ export class OpenCodeSessionStorage extends BaseSessionStorage {
 		}
 
 		try {
-			// Load all messages for the session
+			// Check if this session exists in SQLite — deletion not supported for SQLite sessions
+			// (we open the DB read-only and shouldn't modify OpenCode's database)
+			const sqliteResult = this.loadSessionMessagesSqlite(sessionId);
+			if (sqliteResult && sqliteResult.messages.length > 0) {
+				logger.warn(
+					'Delete message pair not supported for SQLite-backed OpenCode sessions',
+					LOG_CONTEXT
+				);
+				return {
+					success: false,
+					error: 'Delete not supported for OpenCode v1.2+ SQLite sessions',
+				};
+			}
+
+			// Load all messages for the session (JSON files)
 			const { messages, parts } = await this.loadSessionMessages(sessionId);
 
 			if (messages.length === 0) {

--- a/src/main/storage/opencode-session-storage.ts
+++ b/src/main/storage/opencode-session-storage.ts
@@ -960,17 +960,25 @@ export class OpenCodeSessionStorage extends BaseSessionStorage {
 				)
 				.all(sessionId) as SqliteMessageRow[];
 
-			// Session exists in SQLite but has no messages yet — return empty result
 			if (messageRows.length === 0) {
-				return {
-					messages: [],
-					parts: new Map(),
-					totalInputTokens: 0,
-					totalOutputTokens: 0,
-					totalCacheReadTokens: 0,
-					totalCacheWriteTokens: 0,
-					totalCost: 0,
-				};
+				// Verify session actually exists in SQLite before blocking JSON fallback
+				if (tableExists(db, 'session')) {
+					const sessionExists = db
+						.prepare('SELECT 1 FROM session WHERE id = ? LIMIT 1')
+						.get(sessionId);
+					if (sessionExists) {
+						return {
+							messages: [],
+							parts: new Map(),
+							totalInputTokens: 0,
+							totalOutputTokens: 0,
+							totalCacheReadTokens: 0,
+							totalCacheWriteTokens: 0,
+							totalCost: 0,
+						};
+					}
+				}
+				return null;
 			}
 
 			const hasPartTable = tableExists(db, 'part');

--- a/src/main/storage/opencode-session-storage.ts
+++ b/src/main/storage/opencode-session-storage.ts
@@ -1464,7 +1464,7 @@ export class OpenCodeSessionStorage extends BaseSessionStorage {
 			// Check if this session exists in SQLite — deletion not supported for SQLite sessions
 			// (we open the DB read-only and shouldn't modify OpenCode's database)
 			const sqliteResult = this.loadSessionMessagesSqlite(sessionId);
-			if (sqliteResult && sqliteResult.messages.length > 0) {
+			if (sqliteResult) {
 				logger.warn(
 					'Delete message pair not supported for SQLite-backed OpenCode sessions',
 					LOG_CONTEXT

--- a/src/main/storage/opencode-session-storage.ts
+++ b/src/main/storage/opencode-session-storage.ts
@@ -225,7 +225,6 @@ function openOpenCodeDb(dbPath: string = OPENCODE_DB_PATH): Database.Database | 
 			return null;
 		}
 		const db = new Database(dbPath, { readonly: true, fileMustExist: true });
-		db.pragma('journal_mode = WAL');
 		return db;
 	} catch (error) {
 		logger.warn(`Failed to open OpenCode SQLite database: ${error}`, LOG_CONTEXT);
@@ -789,11 +788,12 @@ export class OpenCodeSessionStorage extends BaseSessionStorage {
 
 			// Also include global project sessions that match by directory field
 			if (hasGlobalProject) {
+				const escapedPath = normalizedPath.replace(/[%_\\]/g, '\\$&');
 				const globalSessions = db
 					.prepare(
-						"SELECT id, project_id, directory, title, version, time_created, time_updated, summary_additions, summary_deletions, summary_files FROM session WHERE project_id = 'global' AND (directory = ? OR directory LIKE ?) ORDER BY time_updated DESC"
+						"SELECT id, project_id, directory, title, version, time_created, time_updated, summary_additions, summary_deletions, summary_files FROM session WHERE project_id = 'global' AND (directory = ? OR directory LIKE ? ESCAPE '\\') ORDER BY time_updated DESC"
 					)
-					.all(normalizedPath, normalizedPath + '/%') as SqliteSessionRow[];
+					.all(normalizedPath, escapedPath + '/%') as SqliteSessionRow[];
 				if (globalSessions.length > 0) {
 					const existingIds = new Set(sessions.map((s) => s.id));
 					for (const gs of globalSessions) {
@@ -902,6 +902,7 @@ export class OpenCodeSessionStorage extends BaseSessionStorage {
 							const partData = safeJsonParse<SqlitePartData>(part.data);
 							if (partData?.type === 'text' && partData.text?.trim()) {
 								firstMessage = partData.text;
+								foundPreview = true;
 								break;
 							}
 						}
@@ -959,7 +960,18 @@ export class OpenCodeSessionStorage extends BaseSessionStorage {
 				)
 				.all(sessionId) as SqliteMessageRow[];
 
-			if (messageRows.length === 0) return null;
+			// Session exists in SQLite but has no messages yet — return empty result
+			if (messageRows.length === 0) {
+				return {
+					messages: [],
+					parts: new Map(),
+					totalInputTokens: 0,
+					totalOutputTokens: 0,
+					totalCacheReadTokens: 0,
+					totalCacheWriteTokens: 0,
+					totalCost: 0,
+				};
+			}
 
 			const hasPartTable = tableExists(db, 'part');
 			const messages: OpenCodeMessage[] = [];
@@ -1417,9 +1429,19 @@ export class OpenCodeSessionStorage extends BaseSessionStorage {
 		if (sshConfig) {
 			return this.getRemoteMessageDir(sessionId);
 		}
-		// For SQLite-backed sessions, return the database path
+		// Check if session exists in SQLite before returning DB path
 		if (fsSync.existsSync(OPENCODE_DB_PATH)) {
-			return OPENCODE_DB_PATH;
+			const db = openOpenCodeDb();
+			if (db) {
+				try {
+					const exists = tableExists(db, 'session')
+						? db.prepare('SELECT 1 FROM session WHERE id = ? LIMIT 1').get(sessionId)
+						: null;
+					if (exists) return OPENCODE_DB_PATH;
+				} finally {
+					db.close();
+				}
+			}
 		}
 		// Fallback to JSON message directory
 		return this.getMessageDir(sessionId);

--- a/src/main/storage/opencode-session-storage.ts
+++ b/src/main/storage/opencode-session-storage.ts
@@ -259,6 +259,17 @@ function tableExists(db: Database.Database, tableName: string): boolean {
 	return !!row;
 }
 
+/**
+ * Check if an error is an expected SQLite schema/migration issue (e.g., missing tables)
+ * that should be swallowed, as opposed to unexpected errors that should reach Sentry.
+ */
+function isExpectedSqliteError(error: unknown): boolean {
+	const message = error instanceof Error ? error.message : String(error);
+	return /no such table|no such column|SQLITE_ERROR|database is locked|database disk image is malformed/.test(
+		message
+	);
+}
+
 // ─── Shared helpers ──────────────────────────────────────────────────────────
 
 /**
@@ -536,14 +547,14 @@ export class OpenCodeSessionStorage extends BaseSessionStorage {
 	private sessionMatchesPath(sessionDirectory: string | undefined, projectPath: string): boolean {
 		if (!sessionDirectory) return false;
 
-		const normalizedSessionDir = path.resolve(sessionDirectory).replace(/\/+$/, '');
-		const normalizedProjectPath = path.resolve(projectPath).replace(/\/+$/, '');
+		const normalizedSessionDir = path.resolve(sessionDirectory).replace(TRAILING_SEP_RE, '');
+		const normalizedProjectPath = path.resolve(projectPath).replace(TRAILING_SEP_RE, '');
 
 		// Exact match
 		if (normalizedSessionDir === normalizedProjectPath) return true;
 
 		// Session is in a subdirectory of the project
-		if (normalizedSessionDir.startsWith(normalizedProjectPath + '/')) return true;
+		if (normalizedSessionDir.startsWith(normalizedProjectPath + path.sep)) return true;
 
 		return false;
 	}
@@ -825,8 +836,13 @@ export class OpenCodeSessionStorage extends BaseSessionStorage {
 
 			return this.convertSqliteSessionRows(sessions, projectPath, db);
 		} catch (error) {
-			logger.warn(`Error reading OpenCode SQLite database: ${error}`, LOG_CONTEXT);
-			return null;
+			if (isExpectedSqliteError(error)) {
+				logger.warn(`Error reading OpenCode SQLite database: ${error}`, LOG_CONTEXT);
+				return null;
+			}
+			logger.error(`Unexpected error reading OpenCode SQLite database: ${error}`, LOG_CONTEXT);
+			captureException(error instanceof Error ? error : new Error(String(error)));
+			throw error;
 		} finally {
 			db.close();
 		}
@@ -873,6 +889,7 @@ export class OpenCodeSessionStorage extends BaseSessionStorage {
 
 				// Aggregate stats and find preview message
 				let foundPreview = false;
+				let candidateUserPreview: string | undefined;
 				for (const msg of messages) {
 					const data = safeJsonParse<SqliteMessageData>(msg.data);
 					if (!data) continue;
@@ -887,7 +904,7 @@ export class OpenCodeSessionStorage extends BaseSessionStorage {
 						totalCost += data.cost;
 					}
 
-					// Get preview from first assistant message with text
+					// Get preview from first assistant message with text (preferred)
 					if (!foundPreview && data.role === 'assistant' && hasPartTable) {
 						const parts = db
 							.prepare('SELECT data FROM part WHERE message_id = ? ORDER BY time_created ASC')
@@ -902,20 +919,24 @@ export class OpenCodeSessionStorage extends BaseSessionStorage {
 						}
 					}
 
-					// Fall back to first user message if no assistant text found
-					if (!foundPreview && data.role === 'user' && hasPartTable) {
+					// Collect first user message as fallback candidate (don't set foundPreview)
+					if (!candidateUserPreview && data.role === 'user' && hasPartTable) {
 						const parts = db
 							.prepare('SELECT data FROM part WHERE message_id = ? ORDER BY time_created ASC')
 							.all(msg.id) as Array<{ data: string }>;
 						for (const part of parts) {
 							const partData = safeJsonParse<SqlitePartData>(part.data);
 							if (partData?.type === 'text' && partData.text?.trim()) {
-								firstMessage = partData.text;
-								foundPreview = true;
+								candidateUserPreview = partData.text;
 								break;
 							}
 						}
 					}
+				}
+
+				// Fall back to user preview if no assistant text was found
+				if (!foundPreview && candidateUserPreview) {
+					firstMessage = candidateUserPreview;
 				}
 			}
 
@@ -1057,8 +1078,13 @@ export class OpenCodeSessionStorage extends BaseSessionStorage {
 				totalCost,
 			};
 		} catch (error) {
-			logger.warn(`Error loading messages from OpenCode SQLite: ${error}`, LOG_CONTEXT);
-			return null;
+			if (isExpectedSqliteError(error)) {
+				logger.warn(`Error loading messages from OpenCode SQLite: ${error}`, LOG_CONTEXT);
+				return null;
+			}
+			logger.error(`Unexpected error loading messages from OpenCode SQLite: ${error}`, LOG_CONTEXT);
+			captureException(error instanceof Error ? error : new Error(String(error)));
+			throw error;
 		} finally {
 			db.close();
 		}


### PR DESCRIPTION
## Summary

- Adds SQLite session reading support for OpenCode v1.2+, which switched from JSON files to a SQLite database for session storage
- Implements dual-format detection: automatically reads from SQLite when available, falls back to legacy JSON format
- Parses OpenCode's SQLite schema to extract sessions, messages, and tool calls into Maestro's session model

## Test plan

- [x] Verify OpenCode v1.2+ sessions are detected and loaded from SQLite database
- [x] Verify legacy JSON-based OpenCode sessions still load correctly
- [x] Verify graceful fallback when neither format is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SQLite-backed session storage with automatic JSON fallback; merged session listings now include aggregated message/part totals.

* **Bug Fixes**
  * Prevent deletion of database-backed sessions; JSON-backed deletion unchanged.
  * Read operations prefer SQLite with JSON fallback; SSH-remote sessions remain JSON-only.
  * Session paths and logs now indicate whether a session is from SQLite or JSON.

* **Documentation**
  * Reformatted release notes for clarity; no content changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->