### PR TITLE
Fix AutoRun CLI-IPC: document path resolution and add agent flag to AutoRun

### DIFF
--- a/src/__tests__/cli/commands/auto-run.test.ts
+++ b/src/__tests__/cli/commands/auto-run.test.ts
@@ -317,6 +317,18 @@ describe('auto-run command', () => {
 		expect(resolveAgentId).toHaveBeenCalledWith('session-123');
 	});
 
+	it('should handle resolveAgentId throwing with clean error message', async () => {
+		vi.mocked(existsSync).mockReturnValue(true);
+		vi.mocked(resolveAgentId).mockImplementationOnce(() => {
+			throw new Error('Agent not found');
+		});
+
+		await autoRun(['/path/to/doc.md'], { agent: 'bad-id' });
+
+		expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('Agent not found'));
+		expect(processExitSpy).toHaveBeenCalledWith(1);
+	});
+
 	it('should error when server returns failure', async () => {
 		vi.mocked(existsSync).mockReturnValue(true);
 		vi.mocked(resolveAgentId).mockReturnValue('agent-123');

--- a/src/__tests__/cli/commands/auto-run.test.ts
+++ b/src/__tests__/cli/commands/auto-run.test.ts
@@ -48,7 +48,7 @@ describe('auto-run command', () => {
 
 	it('should configure auto-run with valid document paths', async () => {
 		vi.mocked(existsSync).mockReturnValue(true);
-		vi.mocked(resolveSessionId).mockReturnValue('session-123');
+		vi.mocked(resolveAgentId).mockReturnValue('agent-123');
 		vi.mocked(withMaestroClient).mockImplementation(async (action) => {
 			const mockClient = {
 				sendCommand: vi.fn().mockResolvedValue({
@@ -59,9 +59,9 @@ describe('auto-run command', () => {
 			return action(mockClient as never);
 		});
 
-		await autoRun(['/path/to/doc1.md', '/path/to/doc2.md'], { session: 'session-123' });
+		await autoRun(['/path/to/doc1.md', '/path/to/doc2.md'], { agent: 'agent-123' });
 
-		expect(resolveSessionId).toHaveBeenCalledWith({ session: 'session-123' });
+		expect(resolveAgentId).toHaveBeenCalledWith('agent-123');
 		expect(consoleSpy).toHaveBeenCalledWith(
 			expect.stringContaining('Auto-run configured with 2 documents')
 		);
@@ -99,7 +99,7 @@ describe('auto-run command', () => {
 
 	it('should send saveAsPlaybook when --save-as is provided', async () => {
 		vi.mocked(existsSync).mockReturnValue(true);
-		vi.mocked(resolveSessionId).mockReturnValue('session-123');
+		vi.mocked(resolveAgentId).mockReturnValue('agent-123');
 
 		let sentMessage: Record<string, unknown> | undefined;
 		vi.mocked(withMaestroClient).mockImplementation(async (action) => {
@@ -116,7 +116,7 @@ describe('auto-run command', () => {
 			return action(mockClient as never);
 		});
 
-		await autoRun(['/path/to/doc.md'], { saveAs: 'My Playbook', session: 'session-123' });
+		await autoRun(['/path/to/doc.md'], { saveAs: 'My Playbook', agent: 'agent-123' });
 
 		expect(sentMessage).toBeDefined();
 		expect(sentMessage!.saveAsPlaybook).toBe('My Playbook');
@@ -127,7 +127,7 @@ describe('auto-run command', () => {
 
 	it('should send launch: true when --launch is provided', async () => {
 		vi.mocked(existsSync).mockReturnValue(true);
-		vi.mocked(resolveSessionId).mockReturnValue('session-123');
+		vi.mocked(resolveAgentId).mockReturnValue('agent-123');
 
 		let sentMessage: Record<string, unknown> | undefined;
 		vi.mocked(withMaestroClient).mockImplementation(async (action) => {
@@ -143,7 +143,7 @@ describe('auto-run command', () => {
 			return action(mockClient as never);
 		});
 
-		await autoRun(['/path/to/doc.md'], { launch: true, session: 'session-123' });
+		await autoRun(['/path/to/doc.md'], { launch: true, agent: 'agent-123' });
 
 		expect(sentMessage).toBeDefined();
 		expect(sentMessage!.launch).toBe(true);
@@ -154,7 +154,7 @@ describe('auto-run command', () => {
 
 	it('should send loop config when --loop is provided', async () => {
 		vi.mocked(existsSync).mockReturnValue(true);
-		vi.mocked(resolveSessionId).mockReturnValue('session-123');
+		vi.mocked(resolveAgentId).mockReturnValue('agent-123');
 
 		let sentMessage: Record<string, unknown> | undefined;
 		vi.mocked(withMaestroClient).mockImplementation(async (action) => {
@@ -170,7 +170,7 @@ describe('auto-run command', () => {
 			return action(mockClient as never);
 		});
 
-		await autoRun(['/path/to/doc.md'], { loop: true, session: 'session-123' });
+		await autoRun(['/path/to/doc.md'], { loop: true, agent: 'agent-123' });
 
 		expect(sentMessage).toBeDefined();
 		expect(sentMessage!.loopEnabled).toBe(true);
@@ -178,7 +178,7 @@ describe('auto-run command', () => {
 
 	it('should send loop config with --max-loops', async () => {
 		vi.mocked(existsSync).mockReturnValue(true);
-		vi.mocked(resolveSessionId).mockReturnValue('session-123');
+		vi.mocked(resolveAgentId).mockReturnValue('agent-123');
 
 		let sentMessage: Record<string, unknown> | undefined;
 		vi.mocked(withMaestroClient).mockImplementation(async (action) => {
@@ -194,7 +194,7 @@ describe('auto-run command', () => {
 			return action(mockClient as never);
 		});
 
-		await autoRun(['/path/to/doc.md'], { maxLoops: '5', session: 'session-123' });
+		await autoRun(['/path/to/doc.md'], { maxLoops: '5', agent: 'agent-123' });
 
 		expect(sentMessage).toBeDefined();
 		expect(sentMessage!.loopEnabled).toBe(true);
@@ -214,7 +214,7 @@ describe('auto-run command', () => {
 
 	it('should set resetOnCompletion on documents when flag is provided', async () => {
 		vi.mocked(existsSync).mockReturnValue(true);
-		vi.mocked(resolveSessionId).mockReturnValue('session-123');
+		vi.mocked(resolveAgentId).mockReturnValue('agent-123');
 
 		let sentMessage: Record<string, unknown> | undefined;
 		vi.mocked(withMaestroClient).mockImplementation(async (action) => {
@@ -232,7 +232,7 @@ describe('auto-run command', () => {
 
 		await autoRun(['/path/to/doc.md'], {
 			resetOnCompletion: true,
-			session: 'session-123',
+			agent: 'agent-123',
 		});
 
 		expect(sentMessage).toBeDefined();
@@ -242,10 +242,10 @@ describe('auto-run command', () => {
 
 	it('should error gracefully when Maestro app is not running', async () => {
 		vi.mocked(existsSync).mockReturnValue(true);
-		vi.mocked(resolveSessionId).mockReturnValue('session-123');
+		vi.mocked(resolveAgentId).mockReturnValue('agent-123');
 		vi.mocked(withMaestroClient).mockRejectedValue(new Error('Maestro desktop app is not running'));
 
-		await autoRun(['/path/to/doc.md'], { session: 'session-123' });
+		await autoRun(['/path/to/doc.md'], { agent: 'agent-123' });
 
 		expect(consoleErrorSpy).toHaveBeenCalledWith(
 			expect.stringContaining('Maestro desktop app is not running')
@@ -296,15 +296,14 @@ describe('auto-run command', () => {
 		expect(resolveSessionId).not.toHaveBeenCalled();
 	});
 
-	it('should error when server returns failure', async () => {
+	it('should show deprecation warning when --session is used', async () => {
 		vi.mocked(existsSync).mockReturnValue(true);
-		vi.mocked(resolveSessionId).mockReturnValue('session-123');
+		vi.mocked(resolveAgentId).mockReturnValue('session-123');
 		vi.mocked(withMaestroClient).mockImplementation(async (action) => {
 			const mockClient = {
 				sendCommand: vi.fn().mockResolvedValue({
 					type: 'configure_auto_run_result',
-					success: false,
-					error: 'Session not found',
+					success: true,
 				}),
 			};
 			return action(mockClient as never);
@@ -312,7 +311,29 @@ describe('auto-run command', () => {
 
 		await autoRun(['/path/to/doc.md'], { session: 'session-123' });
 
-		expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('Session not found'));
+		expect(consoleErrorSpy).toHaveBeenCalledWith(
+			expect.stringContaining('--session is deprecated')
+		);
+		expect(resolveAgentId).toHaveBeenCalledWith('session-123');
+	});
+
+	it('should error when server returns failure', async () => {
+		vi.mocked(existsSync).mockReturnValue(true);
+		vi.mocked(resolveAgentId).mockReturnValue('agent-123');
+		vi.mocked(withMaestroClient).mockImplementation(async (action) => {
+			const mockClient = {
+				sendCommand: vi.fn().mockResolvedValue({
+					type: 'configure_auto_run_result',
+					success: false,
+					error: 'Agent not found',
+				}),
+			};
+			return action(mockClient as never);
+		});
+
+		await autoRun(['/path/to/doc.md'], { agent: 'agent-123' });
+
+		expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('Agent not found'));
 		expect(processExitSpy).toHaveBeenCalledWith(1);
 	});
 });

--- a/src/__tests__/cli/commands/auto-run.test.ts
+++ b/src/__tests__/cli/commands/auto-run.test.ts
@@ -313,9 +313,7 @@ describe('auto-run command', () => {
 
 		await autoRun(['/path/to/doc.md'], { session: 'session-123' });
 
-		expect(consoleWarnSpy).toHaveBeenCalledWith(
-			expect.stringContaining('--session is deprecated')
-		);
+		expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('--session is deprecated'));
 		expect(resolveAgentId).toHaveBeenCalledWith('session-123');
 	});
 

--- a/src/__tests__/cli/commands/auto-run.test.ts
+++ b/src/__tests__/cli/commands/auto-run.test.ts
@@ -24,8 +24,14 @@ vi.mock('../../../cli/services/maestro-client', () => ({
 	resolveSessionId: vi.fn(),
 }));
 
+// Mock storage (for resolveAgentId)
+vi.mock('../../../cli/services/storage', () => ({
+	resolveAgentId: vi.fn(),
+}));
+
 import { autoRun } from '../../../cli/commands/auto-run';
 import { withMaestroClient, resolveSessionId } from '../../../cli/services/maestro-client';
+import { resolveAgentId } from '../../../cli/services/storage';
 import { existsSync } from 'fs';
 
 describe('auto-run command', () => {
@@ -245,6 +251,49 @@ describe('auto-run command', () => {
 			expect.stringContaining('Maestro desktop app is not running')
 		);
 		expect(processExitSpy).toHaveBeenCalledWith(1);
+	});
+
+	it('should use resolveAgentId when --agent is provided', async () => {
+		vi.mocked(existsSync).mockReturnValue(true);
+		vi.mocked(resolveAgentId).mockReturnValue('full-agent-uuid-123');
+		vi.mocked(withMaestroClient).mockImplementation(async (action) => {
+			const mockClient = {
+				sendCommand: vi.fn().mockResolvedValue({
+					type: 'configure_auto_run_result',
+					success: true,
+				}),
+			};
+			return action(mockClient as never);
+		});
+
+		await autoRun(['/path/to/doc.md'], { agent: 'full-ag' });
+
+		expect(resolveAgentId).toHaveBeenCalledWith('full-ag');
+		expect(resolveSessionId).not.toHaveBeenCalled();
+		expect(consoleSpy).toHaveBeenCalledWith(
+			expect.stringContaining('Auto-run configured with 1 document')
+		);
+	});
+
+	it('should prefer --agent over --session when both provided', async () => {
+		vi.mocked(existsSync).mockReturnValue(true);
+		vi.mocked(resolveAgentId).mockReturnValue('agent-uuid-456');
+		vi.mocked(withMaestroClient).mockImplementation(async (action) => {
+			const mockClient = {
+				sendCommand: vi.fn().mockImplementation((msg) => {
+					return Promise.resolve({
+						type: 'configure_auto_run_result',
+						success: true,
+					});
+				}),
+			};
+			return action(mockClient as never);
+		});
+
+		await autoRun(['/path/to/doc.md'], { agent: 'agent-uuid', session: 'session-789' });
+
+		expect(resolveAgentId).toHaveBeenCalledWith('agent-uuid');
+		expect(resolveSessionId).not.toHaveBeenCalled();
 	});
 
 	it('should error when server returns failure', async () => {

--- a/src/__tests__/cli/commands/auto-run.test.ts
+++ b/src/__tests__/cli/commands/auto-run.test.ts
@@ -37,12 +37,14 @@ import { existsSync } from 'fs';
 describe('auto-run command', () => {
 	let consoleSpy: MockInstance;
 	let consoleErrorSpy: MockInstance;
+	let consoleWarnSpy: MockInstance;
 	let processExitSpy: MockInstance;
 
 	beforeEach(() => {
 		vi.clearAllMocks();
 		consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 		consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+		consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 		processExitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
 	});
 
@@ -311,7 +313,7 @@ describe('auto-run command', () => {
 
 		await autoRun(['/path/to/doc.md'], { session: 'session-123' });
 
-		expect(consoleErrorSpy).toHaveBeenCalledWith(
+		expect(consoleWarnSpy).toHaveBeenCalledWith(
 			expect.stringContaining('--session is deprecated')
 		);
 		expect(resolveAgentId).toHaveBeenCalledWith('session-123');

--- a/src/__tests__/shared/templateVariables.test.ts
+++ b/src/__tests__/shared/templateVariables.test.ts
@@ -65,6 +65,7 @@ describe('TEMPLATE_VARIABLES constant', () => {
 
 	it('should include key agent variables', () => {
 		const variables = TEMPLATE_VARIABLES.map((v) => v.variable);
+		expect(variables).toContain('{{AGENT_ID}}');
 		expect(variables).toContain('{{AGENT_NAME}}');
 		expect(variables).toContain('{{AGENT_PATH}}');
 		expect(variables).toContain('{{AGENT_GROUP}}');
@@ -169,6 +170,14 @@ describe('substituteTemplateVariables', () => {
 	});
 
 	describe('Agent Variables', () => {
+		it('should replace {{AGENT_ID}} with session.id', () => {
+			const context = createTestContext({
+				session: createTestSession({ id: 'agent-uuid-abc-123' }),
+			});
+			const result = substituteTemplateVariables('ID: {{AGENT_ID}}', context);
+			expect(result).toBe('ID: agent-uuid-abc-123');
+		});
+
 		it('should replace {{AGENT_NAME}} with session.name', () => {
 			const context = createTestContext({
 				session: createTestSession({ name: 'Agent Alpha' }),

--- a/src/cli/commands/auto-run.ts
+++ b/src/cli/commands/auto-run.ts
@@ -3,8 +3,10 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { withMaestroClient, resolveSessionId } from '../services/maestro-client';
+import { resolveAgentId } from '../services/storage';
 
 interface AutoRunOptions {
+	agent?: string;
 	session?: string;
 	prompt?: string;
 	loop?: boolean;
@@ -38,7 +40,12 @@ export async function autoRun(docs: string[], options: AutoRunOptions): Promise<
 		resolvedPaths.push(absolutePath);
 	}
 
-	const sessionId = resolveSessionId(options);
+	let sessionId: string;
+	if (options.agent) {
+		sessionId = resolveAgentId(options.agent);
+	} else {
+		sessionId = resolveSessionId(options);
+	}
 
 	const documents = resolvedPaths.map((d) => ({
 		filename: d,

--- a/src/cli/commands/auto-run.ts
+++ b/src/cli/commands/auto-run.ts
@@ -40,11 +40,16 @@ export async function autoRun(docs: string[], options: AutoRunOptions): Promise<
 		resolvedPaths.push(absolutePath);
 	}
 
+	if (options.session) {
+		console.error('Warning: --session is deprecated for auto-run, use --agent instead');
+	}
+
 	let sessionId: string;
-	if (options.agent) {
-		sessionId = resolveAgentId(options.agent);
+	const agentId = options.agent || options.session;
+	if (agentId) {
+		sessionId = resolveAgentId(agentId);
 	} else {
-		sessionId = resolveSessionId(options);
+		sessionId = resolveSessionId({});
 	}
 
 	const documents = resolvedPaths.map((d) => ({

--- a/src/cli/commands/auto-run.ts
+++ b/src/cli/commands/auto-run.ts
@@ -41,13 +41,18 @@ export async function autoRun(docs: string[], options: AutoRunOptions): Promise<
 	}
 
 	if (options.session) {
-		console.error('Warning: --session is deprecated for auto-run, use --agent instead');
+		console.warn('Warning: --session is deprecated for auto-run, use --agent instead');
 	}
 
 	let sessionId: string;
 	const agentId = options.agent || options.session;
 	if (agentId) {
-		sessionId = resolveAgentId(agentId);
+		try {
+			sessionId = resolveAgentId(agentId);
+		} catch (error) {
+			console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+			process.exit(1);
+		}
 	} else {
 		sessionId = resolveSessionId({});
 	}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -142,6 +142,7 @@ program
 	.command('auto-run <docs...>')
 	.description('Configure and optionally launch an auto-run with documents')
 	.option('-s, --session <id>', 'Target session (defaults to active)')
+	.option('-a, --agent <id>', 'Target agent by ID (use "maestro-cli list agents" to find IDs)')
 	.option('-p, --prompt <text>', 'Custom prompt for the auto-run')
 	.option('--loop', 'Enable looping')
 	.option('--max-loops <n>', 'Maximum loop count (implies --loop)')

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -141,7 +141,7 @@ program
 program
 	.command('auto-run <docs...>')
 	.description('Configure and optionally launch an auto-run with documents')
-	.option('-s, --session <id>', 'Target session (defaults to active)')
+	.option('-s, --session <id>', '[deprecated: use --agent] Target agent by ID')
 	.option('-a, --agent <id>', 'Target agent by ID (use "maestro-cli list agents" to find IDs)')
 	.option('-p, --prompt <text>', 'Custom prompt for the auto-run')
 	.option('--loop', 'Enable looping')

--- a/src/prompts/maestro-system-prompt.md
+++ b/src/prompts/maestro-system-prompt.md
@@ -110,7 +110,7 @@ To set up and optionally launch an auto-run with documents you've created:
 maestro-cli auto-run doc1.md doc2.md [--agent <id>] [--prompt "Custom instructions"] [--launch] [--save-as "My Playbook"]
 ```
 
-**Important:** When launching an auto-run via CLI, always pass `--agent {{AGENT_ID}}` to ensure the correct agent executes the run. Without `--agent`, the CLI picks an arbitrary agent. You can find your Agent ID in the Session Information section above.
+**Important:** When launching an auto-run via CLI, always pass `--agent {{AGENT_ID}}` to ensure the correct agent executes the run. Without `--agent`, the CLI selects the first available agent, which may not be the one you intended. You can find your Agent ID in the Session Information section above.
 
 Example using your own agent:
 

--- a/src/prompts/maestro-system-prompt.md
+++ b/src/prompts/maestro-system-prompt.md
@@ -17,6 +17,7 @@ Maestro is an Electron desktop application for managing multiple AI coding assis
 ## Session Information
 
 - **Agent Name:** {{AGENT_NAME}}
+- **Agent ID:** {{AGENT_ID}}
 - **Agent Type:** {{TOOL_TYPE}}
 - **Working Directory:** {{AGENT_PATH}}
 - **Current Directory:** {{CWD}}
@@ -106,8 +107,17 @@ maestro-cli refresh-auto-run [--session <id>]
 To set up and optionally launch an auto-run with documents you've created:
 
 ```bash
-maestro-cli auto-run doc1.md doc2.md [--prompt "Custom instructions"] [--launch] [--save-as "My Playbook"]
+maestro-cli auto-run doc1.md doc2.md [--agent <id>] [--prompt "Custom instructions"] [--launch] [--save-as "My Playbook"]
 ```
+
+**Important:** When launching an auto-run via CLI, always pass `--agent {{AGENT_ID}}` to ensure the correct agent executes the run. Without `--agent`, the CLI picks an arbitrary agent. You can find your Agent ID in the Session Information section above.
+
+Example using your own agent:
+```bash
+maestro-cli auto-run phase-01.md phase-02.md --agent {{AGENT_ID}} --launch
+```
+
+To discover other agents' IDs: `maestro-cli list agents`
 
 ### Check Maestro Status
 

--- a/src/prompts/maestro-system-prompt.md
+++ b/src/prompts/maestro-system-prompt.md
@@ -113,6 +113,7 @@ maestro-cli auto-run doc1.md doc2.md [--agent <id>] [--prompt "Custom instructio
 **Important:** When launching an auto-run via CLI, always pass `--agent {{AGENT_ID}}` to ensure the correct agent executes the run. Without `--agent`, the CLI picks an arbitrary agent. You can find your Agent ID in the Session Information section above.
 
 Example using your own agent:
+
 ```bash
 maestro-cli auto-run phase-01.md phase-02.md --agent {{AGENT_ID}} --launch
 ```

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1870,7 +1870,8 @@ function MaestroConsoleInner() {
 							// Normalize separators to forward slash for comparison
 							const normalized = name.replace(/\\/g, '/');
 							const normalizedFolder = (folderPath || '').replace(/\\/g, '/');
-							if (normalizedFolder && normalized.startsWith(normalizedFolder + '/')) {
+							// Case-insensitive prefix check for cross-platform compatibility (e.g., Windows drive letters)
+							if (normalizedFolder && normalized.toLowerCase().startsWith(normalizedFolder.toLowerCase() + '/')) {
 								name = normalized.substring(normalizedFolder.length + 1);
 							} else {
 								// Fallback for paths not under folderPath: use basename only

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1870,8 +1870,10 @@ function MaestroConsoleInner() {
 							// Normalize separators to forward slash for comparison
 							const normalized = name.replace(/\\/g, '/');
 							const normalizedFolder = (folderPath || '').replace(/\\/g, '/');
-							// Case-insensitive prefix check for cross-platform compatibility (e.g., Windows drive letters)
-							if (normalizedFolder && normalized.toLowerCase().startsWith(normalizedFolder.toLowerCase() + '/')) {
+							// Case-insensitive prefix check for cross-platform compatibility (Windows drive letters)
+							const normalizedLower = normalized.toLowerCase();
+							const folderLower = normalizedFolder.toLowerCase();
+							if (normalizedFolder && normalizedLower.startsWith(folderLower + '/')) {
 								name = normalized.substring(normalizedFolder.length + 1);
 							} else {
 								// Fallback for paths not under folderPath: use basename only

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1872,9 +1872,6 @@ function MaestroConsoleInner() {
 							const normalizedFolder = (folderPath || '').replace(/\\/g, '/');
 							if (normalizedFolder && normalized.startsWith(normalizedFolder + '/')) {
 								name = normalized.substring(normalizedFolder.length + 1);
-							} else if (normalizedFolder && normalized.startsWith(normalizedFolder)) {
-								name = normalized.substring(normalizedFolder.length);
-								if (name.startsWith('/')) name = name.substring(1);
 							} else {
 								// Fallback for paths not under folderPath: use basename only
 								const lastSlash = Math.max(name.lastIndexOf('/'), name.lastIndexOf('\\'));

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1862,15 +1862,24 @@ function MaestroConsoleInner() {
 
 					const documents = (config.documents || []).map(
 						(doc: { filename: string; resetOnCompletion?: boolean }) => {
-							// Extract just the basename without .md extension.
-							// CLI sends full absolute paths (e.g., "/path/to/Auto Run Docs/temp.md")
-							// but the batch processor expects just the stem (e.g., "temp").
-							let name = doc.filename;
-							const lastSlash = Math.max(name.lastIndexOf('/'), name.lastIndexOf('\\'));
-							if (lastSlash >= 0) {
-								name = name.substring(lastSlash + 1);
+							// Compute path relative to the session's autoRunFolderPath.
+							// CLI sends full absolute paths (e.g., "/path/to/Auto Run Docs/subdir/temp.md")
+							// but the batch processor expects the path relative to folderPath without .md
+							// (e.g., "subdir/temp").
+							let name = doc.filename.replace(/\.md$/i, '');
+							// Normalize separators to forward slash for comparison
+							const normalized = name.replace(/\\/g, '/');
+							const normalizedFolder = (folderPath || '').replace(/\\/g, '/');
+							if (normalizedFolder && normalized.startsWith(normalizedFolder + '/')) {
+								name = normalized.substring(normalizedFolder.length + 1);
+							} else if (normalizedFolder && normalized.startsWith(normalizedFolder)) {
+								name = normalized.substring(normalizedFolder.length);
+								if (name.startsWith('/')) name = name.substring(1);
+							} else {
+								// Fallback for paths not under folderPath: use basename only
+								const lastSlash = Math.max(name.lastIndexOf('/'), name.lastIndexOf('\\'));
+								if (lastSlash >= 0) name = name.substring(lastSlash + 1);
 							}
-							name = name.replace(/\.md$/, '');
 							return {
 								id: generateId(),
 								filename: name,

--- a/src/renderer/components/InlineWizard/DocumentGenerationView.tsx
+++ b/src/renderer/components/InlineWizard/DocumentGenerationView.tsx
@@ -65,8 +65,7 @@ export interface DocumentGenerationViewProps {
 /**
  * Document selector dropdown for switching between generated documents
  */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-function DocumentSelector({
+export function DocumentSelector({
 	documents,
 	selectedIndex,
 	onSelect,
@@ -314,8 +313,7 @@ function MarkdownImage({
 /**
  * Document editor component with edit/preview modes
  */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-function DocumentEditor({
+export function DocumentEditor({
 	content,
 	onContentChange,
 	mode,

--- a/src/shared/templateVariables.ts
+++ b/src/shared/templateVariables.ts
@@ -9,6 +9,7 @@ import { buildSessionDeepLink, buildGroupDeepLink } from './deep-link-urls';
  *   {{CONDUCTOR_PROFILE}} - User's About Me profile (from Settings → General)
  *
  * Agent Variables:
+ *   {{AGENT_ID}}          - Agent UUID (Maestro agent identifier, for CLI commands)
  *   {{AGENT_NAME}}        - Agent name
  *   {{AGENT_PATH}}        - Agent home directory path (full path to project)
  *   {{AGENT_GROUP}}       - Agent's group name (if grouped)
@@ -166,6 +167,7 @@ export interface TemplateContext {
 export const TEMPLATE_VARIABLES = [
 	{ variable: '{{AGENT_DEEP_LINK}}', description: 'Deep link to this agent (maestro://)' },
 	{ variable: '{{AGENT_GROUP}}', description: 'Agent group name' },
+	{ variable: '{{AGENT_ID}}', description: 'Agent UUID (for CLI targeting)' },
 	{ variable: '{{CONDUCTOR_PROFILE}}', description: "Conductor's About Me profile" },
 	{ variable: '{{AGENT_HISTORY_PATH}}', description: 'History file path (task recall)' },
 	{ variable: '{{AGENT_NAME}}', description: 'Agent name' },
@@ -295,6 +297,7 @@ export function substituteTemplateVariables(template: string, context: TemplateC
 		CONDUCTOR_PROFILE: conductorProfile || '',
 
 		// Agent variables
+		AGENT_ID: session.id,
 		AGENT_NAME: session.name,
 		AGENT_PATH: session.fullPath || session.projectRoot || session.cwd,
 		AGENT_GROUP: groupName || '',


### PR DESCRIPTION
This pull request is a follow-up on the IPC-CLI Bridge and related code to use agent IDs instead of session IDs for auto-run commands, introduces the `{{AGENT_ID}}` template variable, and improves path handling for auto-run documents. It also adds deprecation warnings for the old `--session` flag and ensures backward compatibility. The changes are focused on making agent targeting more explicit and robust for both CLI and template usage.

**Agent targeting and CLI improvements:**
* Updated `auto-run` command to use `--agent` instead of `--session`, with `--session` now deprecated and triggering a warning; `resolveAgentId` is used for agent lookup, and preference is given to `--agent` when both options are provided. [[1]](diffhunk://#diff-dcbc60b64bd541e28213b66656e4ce23557eb6b6b4d948f28a57ca163c335f6aL41-R53) [[2]](diffhunk://#diff-4432be59cf955237386851c1eac92c6e5224fb65f46c4ba3baead51456760dabL239-R336) [[3]](diffhunk://#diff-2304ffbbb1cb4987906a47b08b7c3b590fc542f4247b733844049776fd8591f2L144-R145)
* Added comprehensive tests to verify agent targeting, deprecation warnings, and correct error handling when agents are not found or Maestro is not running. [[1]](diffhunk://#diff-4432be59cf955237386851c1eac92c6e5224fb65f46c4ba3baead51456760dabR27-R34) [[2]](diffhunk://#diff-4432be59cf955237386851c1eac92c6e5224fb65f46c4ba3baead51456760dabL45-R51) [[3]](diffhunk://#diff-4432be59cf955237386851c1eac92c6e5224fb65f46c4ba3baead51456760dabL56-R64) [[4]](diffhunk://#diff-4432be59cf955237386851c1eac92c6e5224fb65f46c4ba3baead51456760dabL96-R102) [[5]](diffhunk://#diff-4432be59cf955237386851c1eac92c6e5224fb65f46c4ba3baead51456760dabL113-R119) [[6]](diffhunk://#diff-4432be59cf955237386851c1eac92c6e5224fb65f46c4ba3baead51456760dabL124-R130) [[7]](diffhunk://#diff-4432be59cf955237386851c1eac92c6e5224fb65f46c4ba3baead51456760dabL140-R146) [[8]](diffhunk://#diff-4432be59cf955237386851c1eac92c6e5224fb65f46c4ba3baead51456760dabL151-R157) [[9]](diffhunk://#diff-4432be59cf955237386851c1eac92c6e5224fb65f46c4ba3baead51456760dabL167-R181) [[10]](diffhunk://#diff-4432be59cf955237386851c1eac92c6e5224fb65f46c4ba3baead51456760dabL191-R197) [[11]](diffhunk://#diff-4432be59cf955237386851c1eac92c6e5224fb65f46c4ba3baead51456760dabL211-R217) [[12]](diffhunk://#diff-4432be59cf955237386851c1eac92c6e5224fb65f46c4ba3baead51456760dabL229-R235) [[13]](diffhunk://#diff-4432be59cf955237386851c1eac92c6e5224fb65f46c4ba3baead51456760dabL239-R336)

**Template variable additions:**
* Introduced `{{AGENT_ID}}` as a template variable, with documentation and test coverage for its substitution. [[1]](diffhunk://#diff-49b4a92e44db3179f91f462a6d250e893c4aeebd3a73a31d6c704b60e008d369R12) [[2]](diffhunk://#diff-49b4a92e44db3179f91f462a6d250e893c4aeebd3a73a31d6c704b60e008d369R170) [[3]](diffhunk://#diff-49b4a92e44db3179f91f462a6d250e893c4aeebd3a73a31d6c704b60e008d369R300) [[4]](diffhunk://#diff-ec2061094562d09dc058df9266791a31326900b5b2ef16fd4151e6d7dc0d0f93R68) [[5]](diffhunk://#diff-ec2061094562d09dc058df9266791a31326900b5b2ef16fd4151e6d7dc0d0f93R173-R180)
* Updated system prompt documentation to include `{{AGENT_ID}}` and provided CLI usage instructions highlighting the importance of passing the agent ID. [[1]](diffhunk://#diff-9cbf519dfc8daa927bad2c5233538ab351995370ea1c179090de238ad51d5ad6R20) [[2]](diffhunk://#diff-9cbf519dfc8daa927bad2c5233538ab351995370ea1c179090de238ad51d5ad6L109-R121)

**Path handling improvements:**
* Improved path normalization for auto-run documents in the renderer, ensuring paths are relative to the agent's folder and correctly stripped of `.md` extensions.

**Backward compatibility and user guidance:**
* Maintained support for `--session` with deprecation warning and updated error messages to reference agents instead of sessions. [[1]](diffhunk://#diff-4432be59cf955237386851c1eac92c6e5224fb65f46c4ba3baead51456760dabL239-R336) [[2]](diffhunk://#diff-dcbc60b64bd541e28213b66656e4ce23557eb6b6b4d948f28a57ca163c335f6aL41-R53) [[3]](diffhunk://#diff-2304ffbbb1cb4987906a47b08b7c3b590fc542f4247b733844049776fd8591f2L144-R145) [[4]](diffhunk://#diff-4432be59cf955237386851c1eac92c6e5224fb65f46c4ba3baead51456760dabL239-R336)

**Documentation updates:**
* Enhanced CLI and system prompt documentation to clarify agent targeting and provide examples for discovering agent IDs. [[1]](diffhunk://#diff-9cbf519dfc8daa927bad2c5233538ab351995370ea1c179090de238ad51d5ad6L109-R121) [[2]](diffhunk://#diff-49b4a92e44db3179f91f462a6d250e893c4aeebd3a73a31d6c704b60e008d369R12)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--agent` option to target specific agents by ID in auto-run workflows
  * Introduced {{AGENT_ID}} template variable for substitution within auto-run documents

* **Documentation**
  * Enhanced system prompt documentation with agent-targeting guidance and usage examples

* **Deprecations**
  * `--session` option is now deprecated; migrate to the `--agent` option instead
  * Deprecation warning displayed when using `--session`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->