### PR TITLE
fix: Auto Run docs directory resolves to worktree path (#584)

### DIFF
--- a/src/__tests__/renderer/hooks/batch/useAutoRunHandlers.worktree.test.ts
+++ b/src/__tests__/renderer/hooks/batch/useAutoRunHandlers.worktree.test.ts
@@ -224,17 +224,18 @@ describe('handleStartBatchRun — worktree dispatch integration', () => {
 			);
 		});
 
-		it('still uses activeSession.autoRunFolderPath for document source', async () => {
+		it('copies queued docs to worktree and uses worktree folder path', async () => {
 			const session = createMockSession({
 				autoRunFolderPath: '/my/autorun/folder',
 			});
 			const deps = createMockDeps();
 
-			// Populate store with target session
+			// Populate store with target session (has its own autoRunFolderPath)
 			const worktreeChild = createMockSession({
 				id: 'worktree-child-99',
 				state: 'idle',
 				parentSessionId: session.id,
+				autoRunFolderPath: '/worktrees/feature/Auto Run Docs',
 			});
 			useSessionStore.setState({
 				sessions: [session, worktreeChild],
@@ -258,9 +259,22 @@ describe('handleStartBatchRun — worktree dispatch integration', () => {
 				await result.current.handleStartBatchRun(config);
 			});
 
-			// folderPath (third arg) comes from the parent session, not the worktree
+			// Docs should be read from parent's folder
+			expect(window.maestro.autorun.readDoc).toHaveBeenCalledWith(
+				'/my/autorun/folder',
+				'Phase 1.md',
+				undefined
+			);
+			// Docs should be written to worktree's folder
+			expect(window.maestro.autorun.writeDoc).toHaveBeenCalledWith(
+				'/worktrees/feature/Auto Run Docs',
+				'Phase 1.md',
+				'',
+				undefined
+			);
+			// Batch run uses the worktree's folder path (where docs were copied)
 			const [, , folderPath] = deps.startBatchRun.mock.calls[0];
-			expect(folderPath).toBe('/my/autorun/folder');
+			expect(folderPath).toBe('/worktrees/feature/Auto Run Docs');
 		});
 
 		it('does not call worktreeSetup for existing-open sessions', async () => {

--- a/src/__tests__/renderer/utils/worktreeSession.test.ts
+++ b/src/__tests__/renderer/utils/worktreeSession.test.ts
@@ -214,6 +214,52 @@ describe('buildWorktreeSession', () => {
 			});
 			expect(session.autoRunFolderPath).toBeUndefined();
 		});
+
+		it('should treat empty string autoRunFolderPath as undefined', () => {
+			const parent = createMockParentSession({
+				autoRunFolderPath: '',
+			});
+			const session = buildWorktreeSession({
+				parentSession: parent,
+				path: '/worktrees/feature-x',
+				name: 'feature-x',
+				defaultSaveToHistory: true,
+				defaultShowThinking: 'off',
+			});
+			expect(session.autoRunFolderPath).toBeUndefined();
+		});
+
+		it('should rebase when autoRunFolderPath equals parent cwd exactly', () => {
+			const parent = createMockParentSession({
+				cwd: '/projects/main',
+				autoRunFolderPath: '/projects/main',
+			});
+			const session = buildWorktreeSession({
+				parentSession: parent,
+				path: '/worktrees/feature-x',
+				name: 'feature-x',
+				defaultSaveToHistory: true,
+				defaultShowThinking: 'off',
+			});
+			expect(session.autoRunFolderPath).toBe('/worktrees/feature-x');
+		});
+
+		it('should handle case-insensitive matching on Windows-style paths', () => {
+			const parent = createMockParentSession({
+				cwd: 'C:\\Users\\Admin\\Software\\Maestro',
+				autoRunFolderPath: 'c:\\users\\admin\\software\\Maestro\\Auto Run Docs',
+			});
+			const session = buildWorktreeSession({
+				parentSession: parent,
+				path: 'C:\\Users\\Admin\\Software\\Maestro-worktree',
+				name: 'worktree',
+				defaultSaveToHistory: true,
+				defaultShowThinking: 'off',
+			});
+			expect(session.autoRunFolderPath).toBe(
+				'C:\\Users\\Admin\\Software\\Maestro-worktree\\Auto Run Docs'
+			);
+		});
 	});
 
 	it('should create initial AI tab with correct settings', () => {

--- a/src/__tests__/renderer/utils/worktreeSession.test.ts
+++ b/src/__tests__/renderer/utils/worktreeSession.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { buildWorktreeSession } from '../../../renderer/utils/worktreeSession';
+import { buildWorktreeSession, isPathUnderRoot } from '../../../renderer/utils/worktreeSession';
 import type { Session } from '../../../renderer/types';
 
 // Mock generateId for deterministic IDs
@@ -259,6 +259,48 @@ describe('buildWorktreeSession', () => {
 			expect(session.autoRunFolderPath).toBe(
 				'C:\\Users\\Admin\\Software\\Maestro-worktree\\Auto Run Docs'
 			);
+		});
+
+		it('should use case-sensitive comparison for Unix paths', () => {
+			const parent = createMockParentSession({
+				cwd: '/Projects/Main',
+				autoRunFolderPath: '/projects/main/Auto Run Docs',
+			});
+			const session = buildWorktreeSession({
+				parentSession: parent,
+				path: '/worktrees/feature-x',
+				name: 'feature-x',
+				defaultSaveToHistory: true,
+				defaultShowThinking: 'off',
+			});
+			// Different case on Unix means different directory - treat as external
+			expect(session.autoRunFolderPath).toBe('/projects/main/Auto Run Docs');
+		});
+	});
+
+	describe('isPathUnderRoot', () => {
+		it('returns true for path under root (Unix)', () => {
+			expect(isPathUnderRoot('/projects/main/Auto Run Docs', '/projects/main')).toBe(true);
+		});
+
+		it('returns true when path equals root', () => {
+			expect(isPathUnderRoot('/projects/main', '/projects/main')).toBe(true);
+		});
+
+		it('returns false for external path', () => {
+			expect(isPathUnderRoot('/other/path', '/projects/main')).toBe(false);
+		});
+
+		it('returns false for partial prefix match', () => {
+			expect(isPathUnderRoot('/projects/main-fork/docs', '/projects/main')).toBe(false);
+		});
+
+		it('handles Windows case-insensitive', () => {
+			expect(isPathUnderRoot('C:\\Users\\Admin\\docs', 'c:\\users\\admin')).toBe(true);
+		});
+
+		it('handles Unix case-sensitive', () => {
+			expect(isPathUnderRoot('/Projects/Main/docs', '/projects/main')).toBe(false);
 		});
 	});
 

--- a/src/__tests__/renderer/utils/worktreeSession.test.ts
+++ b/src/__tests__/renderer/utils/worktreeSession.test.ts
@@ -139,6 +139,83 @@ describe('buildWorktreeSession', () => {
 		expect(session.sessionSshRemoteConfig).toEqual(sshConfig);
 	});
 
+	describe('autoRunFolderPath resolution', () => {
+		it('should rebase absolute path under parent cwd onto worktree cwd', () => {
+			const parent = createMockParentSession({
+				cwd: '/projects/main',
+				autoRunFolderPath: '/projects/main/Auto Run Docs',
+			});
+			const session = buildWorktreeSession({
+				parentSession: parent,
+				path: '/worktrees/feature-x',
+				name: 'feature-x',
+				defaultSaveToHistory: true,
+				defaultShowThinking: 'off',
+			});
+			expect(session.autoRunFolderPath).toBe('/worktrees/feature-x/Auto Run Docs');
+		});
+
+		it('should keep relative path as-is', () => {
+			const parent = createMockParentSession({
+				autoRunFolderPath: 'Auto Run Docs',
+			});
+			const session = buildWorktreeSession({
+				parentSession: parent,
+				path: '/worktrees/feature-x',
+				name: 'feature-x',
+				defaultSaveToHistory: true,
+				defaultShowThinking: 'off',
+			});
+			expect(session.autoRunFolderPath).toBe('Auto Run Docs');
+		});
+
+		it('should keep external absolute path as-is', () => {
+			const parent = createMockParentSession({
+				cwd: '/projects/main',
+				autoRunFolderPath: '/shared/autorun-docs',
+			});
+			const session = buildWorktreeSession({
+				parentSession: parent,
+				path: '/worktrees/feature-x',
+				name: 'feature-x',
+				defaultSaveToHistory: true,
+				defaultShowThinking: 'off',
+			});
+			expect(session.autoRunFolderPath).toBe('/shared/autorun-docs');
+		});
+
+		it('should handle Windows backslash paths', () => {
+			const parent = createMockParentSession({
+				cwd: 'C:\\Users\\Admin\\Software\\Maestro',
+				autoRunFolderPath: 'C:\\Users\\Admin\\Software\\Maestro\\Auto Run Docs',
+			});
+			const session = buildWorktreeSession({
+				parentSession: parent,
+				path: 'C:\\Users\\Admin\\Software\\Maestro-worktree',
+				name: 'worktree',
+				defaultSaveToHistory: true,
+				defaultShowThinking: 'off',
+			});
+			expect(session.autoRunFolderPath).toBe(
+				'C:\\Users\\Admin\\Software\\Maestro-worktree\\Auto Run Docs'
+			);
+		});
+
+		it('should return undefined when parent has no autoRunFolderPath', () => {
+			const parent = createMockParentSession({
+				autoRunFolderPath: undefined,
+			});
+			const session = buildWorktreeSession({
+				parentSession: parent,
+				path: '/worktrees/feature-x',
+				name: 'feature-x',
+				defaultSaveToHistory: true,
+				defaultShowThinking: 'off',
+			});
+			expect(session.autoRunFolderPath).toBeUndefined();
+		});
+	});
+
 	it('should create initial AI tab with correct settings', () => {
 		const parent = createMockParentSession();
 		const session = buildWorktreeSession({

--- a/src/renderer/hooks/batch/useAutoRunHandlers.ts
+++ b/src/renderer/hooks/batch/useAutoRunHandlers.ts
@@ -395,14 +395,27 @@ export function useAutoRunHandlers(
 				}
 			}
 
+			// Resolve the Auto Run folder path for the target session.
+			// When dispatching to a worktree, use the target session's own
+			// autoRunFolderPath (resolved relative to its cwd by buildWorktreeSession).
+			// Fall back to activeSession's path if the target doesn't have one set.
+			let folderPath = activeSession.autoRunFolderPath;
+			if (targetSessionId !== activeSession.id) {
+				const targetSession = useSessionStore
+					.getState()
+					.sessions.find((s) => s.id === targetSessionId);
+				if (targetSession?.autoRunFolderPath) {
+					folderPath = targetSession.autoRunFolderPath;
+				}
+			}
+
 			window.maestro.logger.log('info', 'Starting batch run', 'AutoRunHandlers', {
 				sessionId: targetSessionId,
-				folderPath: activeSession.autoRunFolderPath,
+				folderPath,
 				isWorktreeTarget: targetSessionId !== activeSession.id,
 			});
 			setBatchRunnerModalOpen(false);
-			// Documents stay with the parent session's autoRunFolderPath; execution targets the worktree agent
-			startBatchRun(targetSessionId, config, activeSession.autoRunFolderPath);
+			startBatchRun(targetSessionId, config, folderPath);
 		},
 		[activeSession, startBatchRun, setBatchRunnerModalOpen]
 	);

--- a/src/renderer/hooks/batch/useAutoRunHandlers.ts
+++ b/src/renderer/hooks/batch/useAutoRunHandlers.ts
@@ -218,7 +218,11 @@ export function useAutoRunHandlers(
 		startBatchRun,
 	} = deps;
 
-	// Handler for auto run folder selection from setup modal
+	// Handler for auto run folder selection from setup modal.
+	// Worktree sessions store their own independent Auto Run folder paths -
+	// the selected path is stored directly on activeSession (whichever session
+	// is active), with no parent-session resolution. This is correct because
+	// the user picks the folder relative to the worktree's own working directory.
 	const handleAutoRunFolderSelected = useCallback(
 		async (folderPath: string) => {
 			if (!activeSession) return;

--- a/src/renderer/hooks/batch/useAutoRunHandlers.ts
+++ b/src/renderer/hooks/batch/useAutoRunHandlers.ts
@@ -399,17 +399,57 @@ export function useAutoRunHandlers(
 				}
 			}
 
-			// Resolve the Auto Run folder path for the target session.
-			// When dispatching to a worktree, use the target session's own
-			// autoRunFolderPath (resolved relative to its cwd by buildWorktreeSession).
-			// Fall back to activeSession's path if the target doesn't have one set.
+			// Resolve the folder path for the batch run.
+			// When the user IS on the worktree, activeSession.autoRunFolderPath already
+			// points to the worktree's own directory (set by buildWorktreeSession).
+			// When dispatching from parent to worktree, copy queued docs to the
+			// worktree's Auto Run folder so subsequent runs find them locally.
 			let folderPath = activeSession.autoRunFolderPath;
 			if (targetSessionId !== activeSession.id) {
 				const targetSession = useSessionStore
 					.getState()
 					.sessions.find((s) => s.id === targetSessionId);
-				if (targetSession?.autoRunFolderPath) {
-					folderPath = targetSession.autoRunFolderPath;
+				if (targetSession?.autoRunFolderPath && targetSession.autoRunFolderPath !== folderPath) {
+					const sshRemoteId = getSshRemoteId(activeSession);
+					const destFolder = targetSession.autoRunFolderPath;
+					// Copy only the queued documents from the parent's folder to the worktree
+					let copyFailed = false;
+					await Promise.all(
+						config.documents.map(async (doc) => {
+							try {
+								const readResult = await window.maestro.autorun.readDoc(
+									folderPath,
+									doc.filename + '.md',
+									sshRemoteId
+								);
+								if (readResult.success && readResult.content != null) {
+									await window.maestro.autorun.writeDoc(
+										destFolder,
+										doc.filename + '.md',
+										readResult.content,
+										sshRemoteId
+									);
+								} else {
+									copyFailed = true;
+								}
+							} catch (err) {
+								copyFailed = true;
+								window.maestro.logger.log(
+									'warn',
+									`Failed to copy doc "${doc.filename}" to worktree: ${err instanceof Error ? err.message : String(err)}`,
+									'AutoRunHandlers'
+								);
+							}
+						})
+					);
+					if (copyFailed) {
+						notifyToast({
+							type: 'warning',
+							title: 'Some Documents Failed to Copy',
+							message: 'Not all documents could be copied to the worktree. Check logs for details.',
+						});
+					}
+					folderPath = destFolder;
 				}
 			}
 

--- a/src/renderer/hooks/batch/useAutoRunHandlers.ts
+++ b/src/renderer/hooks/batch/useAutoRunHandlers.ts
@@ -431,6 +431,11 @@ export function useAutoRunHandlers(
 									);
 								} else {
 									copyFailed = true;
+									window.maestro.logger.log(
+										'warn',
+										`Failed to read doc "${doc.filename}" from source folder`,
+										'AutoRunHandlers'
+									);
 								}
 							} catch (err) {
 								copyFailed = true;

--- a/src/renderer/hooks/batch/useBatchProcessor.ts
+++ b/src/renderer/hooks/batch/useBatchProcessor.ts
@@ -604,8 +604,8 @@ export function useBatchProcessor({
 	/**
 	 * Start a batch processing run for a specific session with multi-document support.
 	 * Note: sessionId and folderPath can belong to different sessions when running
-	 * in a worktree — the parent session owns the Auto Run documents (folderPath)
-	 * while the worktree agent (sessionId) executes the tasks.
+	 * in a worktree. The folderPath is resolved from the target session's own
+	 * autoRunFolderPath (rebased onto its cwd) or falls back to the parent's path.
 	 */
 	const startBatchRun = useCallback(
 		async (sessionId: string, config: BatchRunConfig, folderPath: string) => {

--- a/src/renderer/hooks/batch/useBatchProcessor.ts
+++ b/src/renderer/hooks/batch/useBatchProcessor.ts
@@ -604,8 +604,8 @@ export function useBatchProcessor({
 	/**
 	 * Start a batch processing run for a specific session with multi-document support.
 	 * Note: sessionId and folderPath can belong to different sessions when running
-	 * in a worktree. The folderPath is resolved from the target session's own
-	 * autoRunFolderPath (rebased onto its cwd) or falls back to the parent's path.
+	 * in a worktree. Queued docs are copied to the worktree's own Auto Run folder
+	 * before dispatch so subsequent runs find them locally.
 	 */
 	const startBatchRun = useCallback(
 		async (sessionId: string, config: BatchRunConfig, folderPath: string) => {

--- a/src/renderer/hooks/session/useSessionRestoration.ts
+++ b/src/renderer/hooks/session/useSessionRestoration.ts
@@ -20,6 +20,7 @@ import { useGroupChatStore } from '../../stores/groupChatStore';
 import { gitService } from '../../services/git';
 import { generateId } from '../../utils/ids';
 import { AUTO_RUN_FOLDER_NAME } from '../../components/Wizard';
+import { isPathUnderRoot } from '../../utils/worktreeSession';
 
 // ============================================================================
 // Return type
@@ -167,6 +168,22 @@ export function useSessionRestoration(): SessionRestorationReturn {
 					...session,
 					autoRunFolderPath: `${session.projectRoot}/${AUTO_RUN_FOLDER_NAME}`,
 				};
+			}
+
+			// Migration: worktree sessions should use their own Auto Run folder path,
+			// not the parent's. Old sessions inherited the parent's path directly.
+			// Rebase to projectRoot (which is the worktree's cwd) if the current path
+			// doesn't already point there.
+			if (session.parentSessionId && session.autoRunFolderPath && session.projectRoot) {
+				if (!isPathUnderRoot(session.autoRunFolderPath, session.projectRoot)) {
+					console.warn(
+						`[restoreSession] Worktree session autoRunFolderPath was under parent, rebasing to ${session.projectRoot}`
+					);
+					session = {
+						...session,
+						autoRunFolderPath: `${session.projectRoot}/${AUTO_RUN_FOLDER_NAME}`,
+					};
+				}
 			}
 
 			// Migration: ensure fileTreeAutoRefreshInterval is set (default 180s for legacy sessions)

--- a/src/renderer/utils/worktreeSession.ts
+++ b/src/renderer/utils/worktreeSession.ts
@@ -33,6 +33,27 @@ export interface BuildWorktreeSessionParams {
 	worktreeParentPath?: string;
 }
 
+/** Normalize path separators to forward slashes for comparison. */
+const normSep = (p: string) => p.replace(/\\/g, '/');
+
+/**
+ * Check whether `filePath` is located under (or equal to) `root` (platform-aware).
+ * Windows paths use case-insensitive comparison; Unix paths are case-sensitive.
+ */
+export function isPathUnderRoot(filePath: string, root: string): boolean {
+	const normalizedFile = normSep(filePath);
+	const normalizedRoot = normSep(root);
+	const prefix = normalizedRoot.endsWith('/') ? normalizedRoot : normalizedRoot + '/';
+	const isWin = /^[A-Za-z]:/.test(filePath);
+	if (isWin) {
+		return (
+			normalizedFile.toLowerCase() === normalizedRoot.toLowerCase() ||
+			normalizedFile.toLowerCase().startsWith(prefix.toLowerCase())
+		);
+	}
+	return normalizedFile === normalizedRoot || normalizedFile.startsWith(prefix);
+}
+
 /**
  * Resolves the Auto Run folder path for a worktree session.
  *
@@ -47,28 +68,15 @@ function resolveWorktreeAutoRunPath(
 ): string | undefined {
 	if (!parentAutoRunPath) return undefined;
 
-	// Normalize to forward slashes for comparison
-	const norm = (p: string) => p.replace(/\\/g, '/');
-	const normalized = norm(parentAutoRunPath);
-
 	// Check if the path is absolute (Unix / or Windows drive letter)
 	const isAbsolute = /^\/|^[A-Za-z]:[/\\]/.test(parentAutoRunPath);
 	if (!isAbsolute) return parentAutoRunPath;
 
-	// Check if the absolute path is under the parent's cwd
-	// Use case-insensitive comparison for Windows (drive letters, directory names)
-	const normalizedParentCwd = norm(parentCwd);
-	const prefix = normalizedParentCwd.endsWith('/')
-		? normalizedParentCwd
-		: normalizedParentCwd + '/';
-
-	const normalizedLower = normalized.toLowerCase();
-	const parentCwdLower = normalizedParentCwd.toLowerCase();
-	const prefixLower = prefix.toLowerCase();
-
-	if (normalizedLower === parentCwdLower || normalizedLower.startsWith(prefixLower)) {
+	if (isPathUnderRoot(parentAutoRunPath, parentCwd)) {
+		const normalizedParentCwd = normSep(parentCwd);
+		const normalized = normSep(parentAutoRunPath);
 		const relativePart = normalized.slice(normalizedParentCwd.length);
-		const result = norm(worktreeCwd) + relativePart;
+		const result = normSep(worktreeCwd) + relativePart;
 		// Preserve original separator style
 		return parentAutoRunPath.includes('\\') ? result.replace(/\//g, '\\') : result;
 	}

--- a/src/renderer/utils/worktreeSession.ts
+++ b/src/renderer/utils/worktreeSession.ts
@@ -33,6 +33,45 @@ export interface BuildWorktreeSessionParams {
 	worktreeParentPath?: string;
 }
 
+/**
+ * Resolves the Auto Run folder path for a worktree session.
+ *
+ * - Relative paths are kept as-is (they resolve from each session's own cwd).
+ * - Absolute paths under the parent's cwd are rebased onto the worktree's cwd.
+ * - Absolute paths outside the parent's cwd are kept as-is (intentionally external).
+ */
+function resolveWorktreeAutoRunPath(
+	parentAutoRunPath: string | undefined,
+	parentCwd: string,
+	worktreeCwd: string
+): string | undefined {
+	if (!parentAutoRunPath) return undefined;
+
+	// Normalize to forward slashes for comparison
+	const norm = (p: string) => p.replace(/\\/g, '/');
+	const normalized = norm(parentAutoRunPath);
+
+	// Check if the path is absolute (Unix / or Windows drive letter)
+	const isAbsolute = /^\/|^[A-Za-z]:[/\\]/.test(parentAutoRunPath);
+	if (!isAbsolute) return parentAutoRunPath;
+
+	// Check if the absolute path is under the parent's cwd
+	const normalizedParentCwd = norm(parentCwd);
+	const prefix = normalizedParentCwd.endsWith('/')
+		? normalizedParentCwd
+		: normalizedParentCwd + '/';
+
+	if (normalized === normalizedParentCwd || normalized.startsWith(prefix)) {
+		const relativePart = normalized.slice(normalizedParentCwd.length);
+		const result = norm(worktreeCwd) + relativePart;
+		// Preserve original separator style
+		return parentAutoRunPath.includes('\\') ? result.replace(/\//g, '\\') : result;
+	}
+
+	// External absolute path - keep as-is
+	return parentAutoRunPath;
+}
+
 export function buildWorktreeSession(params: BuildWorktreeSessionParams): Session {
 	const newId = generateId();
 	const initialTabId = generateId();
@@ -120,6 +159,12 @@ export function buildWorktreeSession(params: BuildWorktreeSessionParams): Sessio
 		// New model inherits these; legacy does not
 		customContextWindow: isLegacy ? undefined : params.parentSession.customContextWindow,
 		nudgeMessage: isLegacy ? undefined : params.parentSession.nudgeMessage,
-		autoRunFolderPath: isLegacy ? undefined : params.parentSession.autoRunFolderPath,
+		autoRunFolderPath: isLegacy
+			? undefined
+			: resolveWorktreeAutoRunPath(
+					params.parentSession.autoRunFolderPath,
+					params.parentSession.cwd,
+					params.path
+				),
 	} as Session;
 }

--- a/src/renderer/utils/worktreeSession.ts
+++ b/src/renderer/utils/worktreeSession.ts
@@ -44,7 +44,8 @@ export function isPathUnderRoot(filePath: string, root: string): boolean {
 	const normalizedFile = normSep(filePath);
 	const normalizedRoot = normSep(root);
 	const prefix = normalizedRoot.endsWith('/') ? normalizedRoot : normalizedRoot + '/';
-	const isWin = /^[A-Za-z]:/.test(filePath);
+	// Either argument having a drive letter means we're on Windows
+	const isWin = /^[A-Za-z]:/.test(filePath) || /^[A-Za-z]:/.test(root);
 	if (isWin) {
 		return (
 			normalizedFile.toLowerCase() === normalizedRoot.toLowerCase() ||

--- a/src/renderer/utils/worktreeSession.ts
+++ b/src/renderer/utils/worktreeSession.ts
@@ -74,7 +74,8 @@ function resolveWorktreeAutoRunPath(
 	if (!isAbsolute) return parentAutoRunPath;
 
 	if (isPathUnderRoot(parentAutoRunPath, parentCwd)) {
-		const normalizedParentCwd = normSep(parentCwd);
+		// Strip trailing slash for consistent slicing
+		const normalizedParentCwd = normSep(parentCwd).replace(/\/$/, '');
 		const normalized = normSep(parentAutoRunPath);
 		const relativePart = normalized.slice(normalizedParentCwd.length);
 		const result = normSep(worktreeCwd) + relativePart;

--- a/src/renderer/utils/worktreeSession.ts
+++ b/src/renderer/utils/worktreeSession.ts
@@ -56,12 +56,17 @@ function resolveWorktreeAutoRunPath(
 	if (!isAbsolute) return parentAutoRunPath;
 
 	// Check if the absolute path is under the parent's cwd
+	// Use case-insensitive comparison for Windows (drive letters, directory names)
 	const normalizedParentCwd = norm(parentCwd);
 	const prefix = normalizedParentCwd.endsWith('/')
 		? normalizedParentCwd
 		: normalizedParentCwd + '/';
 
-	if (normalized === normalizedParentCwd || normalized.startsWith(prefix)) {
+	const normalizedLower = normalized.toLowerCase();
+	const parentCwdLower = normalizedParentCwd.toLowerCase();
+	const prefixLower = prefix.toLowerCase();
+
+	if (normalizedLower === parentCwdLower || normalizedLower.startsWith(prefixLower)) {
 		const relativePart = normalized.slice(normalizedParentCwd.length);
 		const result = norm(worktreeCwd) + relativePart;
 		// Preserve original separator style


### PR DESCRIPTION
## Summary

- Worktree sessions now resolve `autoRunFolderPath` to their own directory instead of inheriting the parent's path verbatim
- When dispatching a batch run from parent to worktree, queued docs are copied to the worktree's `Auto Run Docs/` folder so subsequent runs find them locally
- Pre-existing worktree sessions (including those created outside Maestro) are migrated on restore to point at their own directory
- Platform-aware path comparison: case-insensitive on Windows, case-sensitive on Unix

## Changes

| File | What |
|------|------|
| `worktreeSession.ts` | Extract `isPathUnderRoot()` helper + `normSep()`, use in `resolveWorktreeAutoRunPath` |
| `useAutoRunHandlers.ts` | Copy-on-dispatch: read queued docs from parent, write to worktree via `Promise.all`. Toast on partial failure |
| `useSessionRestoration.ts` | Migration for stale worktree sessions whose `autoRunFolderPath` points at parent |
| `useBatchProcessor.ts` | Comment update |
| `worktreeSession.test.ts` | 7 new tests: 6 for `isPathUnderRoot`, 1 Unix case-sensitivity for `buildWorktreeSession` |
| `useAutoRunHandlers.worktree.test.ts` | Updated test verifies copy-on-dispatch reads from parent, writes to worktree |

## Test plan

- [x] All 104 existing + new tests pass
- [x] Create a new worktree from parent, dispatch Auto Run - docs should copy to worktree and run succeeds
- [x] Switch to worktree session, start another Auto Run - should read from worktree's own `Auto Run Docs/`
- [x] Restart app with pre-existing worktree session - `autoRunFolderPath` should migrate to worktree's directory
- [x] Worktree created outside Maestro (via `git worktree add`) is discovered with correct path
- [x] Windows backslash paths and mixed-case drive letters handled correctly

closes #584

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Batch runs now copy queued Auto Run documents into a worktree so runs use the worktree’s own Auto Run folder; resolved folder paths are used and warnings shown on sync failures.
  * Worktree sessions automatically rebase/migrate Auto Run folder paths to be rooted in the worktree; path handling is more robust across platforms.
* **Tests**
  * Expanded coverage for worktree path resolution, containment checks, cross-session copying, and platform/path scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->