### PR TITLE
fix: instructions for troubleshooting missing fonts in WSL

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -214,15 +214,16 @@ For new projects, always clone to the Linux filesystem from the start.
 
 The Interface Font picker in the Settings dialog asks Linux fontconfig what fonts exist in the WSL environment. It is not querying native Windows fonts directly; it's using `fc-list` to resolve them, which by default only sees Linux-side fonts. To see Windows fonts, you need to teach fontconfig about `/mnt/c/Windows/Fonts`, then rebuild the font cache. Some fonts may also be stored in the user's `AppData\Local` folder.
 
-To fix, update `fontconfig`'s configuration in WSL, replacing `YOUR_USERNAME` accordingly:
+To fix, update `fontconfig`'s configuration in WSL, replacing `$USER` accordingly:
 
-```mkdir -p ~/.config/fontconfig/conf.d
+```bash
+mkdir -p ~/.config/fontconfig/conf.d
 cat > ~/.config/fontconfig/conf.d/50-windows-fonts.conf <<'EOF'
 <?xml version="1.0"?>
 <!DOCTYPE fontconfig SYSTEM "fonts.dtd">
 <fontconfig>
   <dir>/mnt/c/Windows/Fonts</dir>
-  <dir>/mnt/c/Users/YOUR_USERNAME/AppData/Local/Microsoft/Windows/Fonts</dir>
+  <dir>/mnt/c/Users/$USER/AppData/Local/Microsoft/Windows/Fonts</dir>
 </fontconfig>
 EOF
 ```


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new "Fonts not found" troubleshooting subsection under WSL2 Issues (Windows) explaining that the Interface Font picker relies on Linux fontconfig, and providing steps to include Windows font directories in WSL's font configuration and rebuild the font cache to restore font visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->