### PR TITLE
Clarify Spec-Kit Prerequisites

### DIFF
--- a/docs/speckit-commands.md
+++ b/docs/speckit-commands.md
@@ -47,6 +47,22 @@ Access Spec-Kit commands via **Settings → AI Commands** tab. Here you can:
 
 Commands marked with a Maestro badge (`/speckit.help`, `/speckit.implement`) are Maestro-specific and not updated from upstream.
 
+## Prerequisites
+
+Maestro does not automatically create the folder structure or scripts required to run Spec-Kit. You’ll need to set these up manually.
+
+Get started: Follow the instructions in the “Get Started” section of the [GitHub Spec-Kit repository](https://github.com/github/spec-kit?tab=readme-ov-file#1-install-specify-cli):
+
+```bash
+# Create new project
+specify init <PROJECT_NAME>
+
+# Or initialize in existing project
+specify init . --ai claude
+# or
+specify init --here --ai claude
+```
+
 ## Core Workflow (Recommended Order)
 
 ### 1. `/speckit.constitution` — Define Project Principles

--- a/src/prompts/speckit/speckit.help.md
+++ b/src/prompts/speckit/speckit.help.md
@@ -13,6 +13,22 @@ Spec-Kit provides a set of AI-powered commands that guide you through a structur
 5. **Generate tasks** - Convert plans into dependency-ordered tasks
 6. **Execute with Auto Run** - Use Maestro's Auto Run to implement tasks
 
+## Prerequisites
+
+Maestro does not automatically create the folder structure or scripts required to run Spec-Kit. You’ll need to set these up manually.
+
+Get started: Follow the instructions in the “Get Started” section of the [GitHub Spec-Kit repository](https://github.com/github/spec-kit?tab=readme-ov-file#1-install-specify-cli):
+
+```bash
+# Create new project
+specify init <PROJECT_NAME>
+
+# Or initialize in existing project
+specify init . --ai claude
+# or
+specify init --here --ai claude
+```
+
 ## Core Workflow (Recommended Order)
 
 ### 1. `/speckit.constitution` - Define Project Principles


### PR DESCRIPTION
I tested Spec-Kit and fell into the trap that when you get started the skills all reference scripts and folders that don't exist yet.

The best option would be to create a /speckit.init command and provide that functionality, but that might be a too complicated endeavor. 

This commit just updates the documentation and help skill to reflect the prerequisites.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new "Prerequisites" section clarifying that Spec-Kit’s folder structure and scripts must be set up manually.
  * Linked to the Spec-Kit “Get started” guide for setup instructions.
  * Provided example initialization commands (for creating a new project and initializing an existing one) and noted alternative flags for initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->