### PR TITLE
fix(cli): create fresh session by default in send command

### DIFF
--- a/src/cli/commands/send.ts
+++ b/src/cli/commands/send.ts
@@ -109,23 +109,10 @@ export async function send(
 		process.exit(1);
 	}
 
-	// Determine which agent session to resume:
-	// 1. Explicit --session flag takes priority
-	// 2. Otherwise, use the active tab's agentSessionId to avoid creating duplicate sessions
-	// 3. If no active tab session exists, spawnAgent creates a fresh isolated session
-	let agentSessionId = options.session;
-	if (!agentSessionId) {
-		const aiTabs = (agent as any).aiTabs as
-			| Array<{ id: string; agentSessionId?: string }>
-			| undefined;
-		const activeTabId = (agent as any).activeTabId as string | undefined;
-		if (aiTabs && activeTabId) {
-			const activeTab = aiTabs.find((t) => t.id === activeTabId);
-			if (activeTab?.agentSessionId) {
-				agentSessionId = activeTab.agentSessionId;
-			}
-		}
-	}
+	// Only resume a session when explicitly requested via --session flag.
+	// Without -s, always create a fresh session to prevent session leakage
+	// when multiple callers (e.g. Discord threads) send concurrently.
+	const agentSessionId = options.session;
 
 	// Spawn agent — spawnAgent handles --resume vs fresh session internally
 	const result = await spawnAgent(agent.toolType, agent.cwd, message, agentSessionId, {


### PR DESCRIPTION
## Summary

- **Breaking change for `maestro-cli send`**: without `-s`, now creates a fresh session instead of resuming the active tab's session
- Fixes session leakage when multiple concurrent callers (e.g. Discord threads) send their first message simultaneously — previously they all landed on the same session
- Resuming a session now requires explicitly passing `-s <sessionId>`

## Test plan

- [ ] `maestro-cli send <agent> "hello"` without `-s` creates a new session (check returned `sessionId` is unique each call)
- [ ] `maestro-cli send <agent> "follow up" -s <id>` correctly resumes the specified session
- [ ] Two concurrent `send` calls without `-s` produce distinct `sessionId` values in their responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The `send` command now strictly requires the `--session` flag to reuse sessions. When the flag is omitted, fresh sessions are created instead of attempting to reuse existing ones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->