### PR TITLE
fix(quit): add safety timeout to prevent app lingering on Windows (#623)

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -96,7 +96,7 @@ The major contributions to 0.14.x remain:
 - Leaderboard tracking now works across multiple systems and syncs level from cloud 🏆
 - Agent duplication. Pro tip: Consider a group of unused "Template" agents ✌️
 - New setting to prevent system from going to sleep while agents are active 🛏️
-- The tab menu has a new "Publish as GitHub Gist" option  📝
+- The tab menu has a new "Publish as GitHub Gist" option 📝
 - The tab menu has options to move the tab to the first or last position 🔀
 - [Maestro-Playbooks](https://github.com/pedramamini/Maestro-Playbooks) can now contain non-markdown assets 📙
 - Improved default shell detection 🐚
@@ -125,10 +125,12 @@ Thanks for the contributions: @t1mmen @aejfager @Crumbgrabber @whglaser @b3nw @d
 - TAKE TWO! Fixed Linux ARM64 build architecture contamination issues 🏗️
 
 ### v0.13.1 Changes
+
 - Fixed Linux ARM64 build architecture contamination issues 🏗️
 - Enhanced error handling for Auto Run batch processing 🚨
 
 ### v0.13.0 Changes
+
 - Added a global usage dashboard, data collection begins with this install 🎛️
 - Added a Playbook Exchange for downloading pre-defined Auto Run playbooks from [Maestro-Playbooks](https://github.com/pedramamini/Maestro-Playbooks) 📕
 - Bundled OpenSpec commands for structured change proposals 📝
@@ -152,15 +154,19 @@ Thanks for the contributions: @t1mmen @aejfager @Crumbgrabber @whglaser @b3nw @d
 The big changes in the v0.12.x line are the following three:
 
 ## Show Thinking
-🤔 There is now a toggle to show thinking for the agent, the default for new tabs is off, though this can be changed under Settings > General. The toggle shows next to History and Read-Only. Very similar pattern. This has been the #1 most requested feature, though personally, I don't think I'll use it as I prefer to not see the details of the work, but the results of the work. Just as we work with our colleagues. 
+
+🤔 There is now a toggle to show thinking for the agent, the default for new tabs is off, though this can be changed under Settings > General. The toggle shows next to History and Read-Only. Very similar pattern. This has been the #1 most requested feature, though personally, I don't think I'll use it as I prefer to not see the details of the work, but the results of the work. Just as we work with our colleagues.
 
 ## GitHub Spec-Kit Integration
+
 🎯 Added [GitHub Spec-Kit](https://github.com/github/spec-kit) commands into Maestro with a built in updater to grab the latest prompts from the repository. We do override `/speckit-implement` (the final step) to create Auto Run docs and guide the user through their execution, which thanks to Wortrees from v0.11.x allows us to run in parallel!
 
 ## Context Management Tools
+
 📖 Added context management options from tab right-click menu. You can now compress, merge, and transfer contexts between agents. You will received (configurable) warnings at 60% and 80% context consumption with a hint to compact.
 
 ## Changes Specific to v0.12.3:
+
 - We now have hosted documentation through Mintlify 📚
 - Export any tab conversation as self-contained themed HTML file 📄
 - Publish files as private/public Gists 🌐
@@ -273,6 +279,7 @@ The big changes in the v0.12.x line are the following three:
 Minor bugfixes on top of v0.7.3:
 
 # Onboarding, Wizard, and Tours
+
 - Implemented comprehensive onboarding wizard with integrated tour system 🚀
 - Added project-understanding confidence display to wizard UI 🎨
 - Enhanced keyboard navigation across all wizard screens ⌨️
@@ -280,6 +287,7 @@ Minor bugfixes on top of v0.7.3:
 - Added First Run Celebration modal with confetti animation 🎉
 
 # UI / UX Enhancements
+
 - Added expand-to-fullscreen button for Auto Run interface 🖥️
 - Created dedicated modal component and improved modal priority constants for expanded Auto Run view 📐
 - Enhanced user experience with fullscreen editing capabilities ✨
@@ -289,15 +297,18 @@ Minor bugfixes on top of v0.7.3:
 - Enhanced toast context with agent name for OS notifications 📢
 
 # Auto Run Workflow Improvements
+
 - Created phase document generation for Auto Run workflow 📄
 - Added real-time log streaming to the LogViewer component 📊
 
 # Application Behavior / Core Fixes
+
 - Added validation to prevent nested worktrees inside the main repository 🚫
 - Fixed process manager to properly emit exit events on errors 🔧
 - Fixed process exit handling to ensure proper cleanup 🧹
 
 # Update System
+
 - Implemented automatic update checking on application startup 🚀
 - Added settings toggle for enabling/disabling startup update checks ⚙️
 
@@ -315,6 +326,7 @@ Minor bugfixes on top of v0.7.3:
 **Latest: v0.6.1** | Released December 4, 2025
 
 In this release...
+
 - Added recursive subfolder support for Auto Run markdown files 🗂️
 - Enhanced document tree display with expandable folder navigation 🌳
 - Enabled creating documents in subfolders with path selection 📁
@@ -327,6 +339,7 @@ In this release...
 - Added support for nested folder structures in document management 🏗️
 
 Plus the pre-release ALPHA...
+
 - Template vars now set context in default autorun prompt 🚀
 - Added Enter key support for queued message confirmation dialog ⌨️
 - Kill process capability added to System Process Monitor 💀
@@ -486,6 +499,7 @@ Plus the pre-release ALPHA...
 All releases are available on the [GitHub Releases page](https://github.com/RunMaestro/Maestro/releases).
 
 Maestro is available for:
+
 - **macOS** - Apple Silicon (arm64) and Intel (x64)
 - **Windows** - x64
 - **Linux** - x64 and arm64, AppImage, deb, and rpm packages

--- a/src/__tests__/main/app-lifecycle/quit-handler.test.ts
+++ b/src/__tests__/main/app-lifecycle/quit-handler.test.ts
@@ -58,6 +58,13 @@ vi.mock('../../../main/tunnel-manager', () => ({
 	},
 }));
 
+// Mock power-manager for the typeof import
+vi.mock('../../../main/power-manager', () => ({
+	powerManager: {
+		clearAllReasons: vi.fn(),
+	},
+}));
+
 describe('app-lifecycle/quit-handler', () => {
 	let mockMainWindow: {
 		isDestroyed: ReturnType<typeof vi.fn>;
@@ -76,6 +83,10 @@ describe('app-lifecycle/quit-handler', () => {
 		stop: ReturnType<typeof vi.fn>;
 	};
 
+	let mockPowerManager: {
+		clearAllReasons: ReturnType<typeof vi.fn>;
+	};
+
 	let deps: {
 		getMainWindow: ReturnType<typeof vi.fn>;
 		getProcessManager: ReturnType<typeof vi.fn>;
@@ -86,6 +97,8 @@ describe('app-lifecycle/quit-handler', () => {
 		cleanupAllGroomingSessions: ReturnType<typeof vi.fn>;
 		closeStatsDB: ReturnType<typeof vi.fn>;
 		stopCliWatcher: ReturnType<typeof vi.fn>;
+		powerManager: typeof mockPowerManager;
+		stopSessionCleanup: ReturnType<typeof vi.fn>;
 	};
 
 	beforeEach(() => {
@@ -109,6 +122,9 @@ describe('app-lifecycle/quit-handler', () => {
 		mockTunnelManager = {
 			stop: vi.fn().mockResolvedValue(undefined),
 		};
+		mockPowerManager = {
+			clearAllReasons: vi.fn(),
+		};
 
 		deps = {
 			getMainWindow: vi.fn().mockReturnValue(mockMainWindow),
@@ -120,6 +136,8 @@ describe('app-lifecycle/quit-handler', () => {
 			cleanupAllGroomingSessions: vi.fn().mockResolvedValue(undefined),
 			closeStatsDB: vi.fn(),
 			stopCliWatcher: vi.fn(),
+			powerManager: mockPowerManager,
+			stopSessionCleanup: vi.fn(),
 		};
 	});
 
@@ -280,6 +298,8 @@ describe('app-lifecycle/quit-handler', () => {
 			// Should perform cleanup
 			expect(mockHistoryManager.stopWatching).toHaveBeenCalled();
 			expect(deps.stopCliWatcher).toHaveBeenCalled();
+			expect(deps.stopSessionCleanup).toHaveBeenCalled();
+			expect(mockPowerManager.clearAllReasons).toHaveBeenCalled();
 			expect(mockProcessManager.killAll).toHaveBeenCalled();
 			expect(mockTunnelManager.stop).toHaveBeenCalled();
 			expect(mockWebServer.stop).toHaveBeenCalled();

--- a/src/main/app-lifecycle/quit-handler.ts
+++ b/src/main/app-lifecycle/quit-handler.ts
@@ -10,6 +10,14 @@ import type { WebServer } from '../web-server';
 import { tunnelManager as tunnelManagerInstance } from '../tunnel-manager';
 import type { HistoryManager } from '../history-manager';
 import { isWebContentsAvailable } from '../utils/safe-send';
+import { powerManager as powerManagerInstance } from '../power-manager';
+
+/**
+ * Safety timeout for quit confirmation from the renderer.
+ * If the renderer doesn't respond within this time (e.g., window already closing,
+ * renderer crashed), force-quit to prevent the app from lingering in the background.
+ */
+const QUIT_CONFIRMATION_TIMEOUT_MS = 3000;
 
 /** Dependencies for quit handler */
 export interface QuitHandlerDependencies {
@@ -31,6 +39,10 @@ export interface QuitHandlerDependencies {
 	closeStatsDB: () => void;
 	/** Function to stop CLI watcher (optional, may not be started yet) */
 	stopCliWatcher?: () => void;
+	/** Power manager instance for clearing sleep prevention on shutdown */
+	powerManager: typeof powerManagerInstance;
+	/** Function to stop group chat moderator cleanup interval */
+	stopSessionCleanup?: () => void;
 }
 
 /** Quit handler state */
@@ -39,6 +51,8 @@ interface QuitHandlerState {
 	quitConfirmed: boolean;
 	/** Whether we're currently waiting for quit confirmation from renderer */
 	isRequestingConfirmation: boolean;
+	/** Safety timeout for quit confirmation — forces quit if renderer never responds */
+	confirmationTimeout: ReturnType<typeof setTimeout> | null;
 }
 
 /** Quit handler instance */
@@ -75,11 +89,14 @@ export function createQuitHandler(deps: QuitHandlerDependencies): QuitHandler {
 		cleanupAllGroomingSessions,
 		closeStatsDB,
 		stopCliWatcher,
+		powerManager,
+		stopSessionCleanup,
 	} = deps;
 
 	const state: QuitHandlerState = {
 		quitConfirmed: false,
 		isRequestingConfirmation: false,
+		confirmationTimeout: null,
 	};
 
 	return {
@@ -87,6 +104,7 @@ export function createQuitHandler(deps: QuitHandlerDependencies): QuitHandler {
 			// Handle quit confirmation from renderer
 			ipcMain.on('app:quitConfirmed', () => {
 				logger.info('Quit confirmed by renderer', 'Window');
+				clearConfirmationTimeout();
 				state.isRequestingConfirmation = false;
 				state.quitConfirmed = true;
 				app.quit();
@@ -95,6 +113,7 @@ export function createQuitHandler(deps: QuitHandlerDependencies): QuitHandler {
 			// Handle quit cancellation (user declined)
 			ipcMain.on('app:quitCancelled', () => {
 				logger.info('Quit cancelled by renderer', 'Window');
+				clearConfirmationTimeout();
 				state.isRequestingConfirmation = false;
 				// Nothing to do - app stays running
 			});
@@ -122,6 +141,21 @@ export function createQuitHandler(deps: QuitHandlerDependencies): QuitHandler {
 						state.isRequestingConfirmation = true;
 						logger.info('Requesting quit confirmation from renderer', 'Window');
 						mainWindow.webContents.send('app:requestQuitConfirmation');
+
+						// Safety timeout: if the renderer never responds (e.g., window is mid-teardown,
+						// renderer crashed, or webContents is in a transitional state), force-quit to
+						// prevent the app from lingering in the background with no window (issue #623).
+						state.confirmationTimeout = setTimeout(() => {
+							if (state.isRequestingConfirmation) {
+								logger.warn(
+									'Quit confirmation timed out — renderer did not respond, forcing quit',
+									'Window'
+								);
+								state.isRequestingConfirmation = false;
+								state.quitConfirmed = true;
+								app.quit();
+							}
+						}, QUIT_CONFIRMATION_TIMEOUT_MS);
 					} else {
 						// No window, just quit
 						state.quitConfirmed = true;
@@ -142,6 +176,14 @@ export function createQuitHandler(deps: QuitHandlerDependencies): QuitHandler {
 		},
 	};
 
+	/** Clears the quit confirmation safety timeout if active. */
+	function clearConfirmationTimeout(): void {
+		if (state.confirmationTimeout) {
+			clearTimeout(state.confirmationTimeout);
+			state.confirmationTimeout = null;
+		}
+	}
+
 	/**
 	 * Performs cleanup operations before app quits.
 	 * Called synchronously from before-quit, so async operations are fire-and-forget.
@@ -156,6 +198,14 @@ export function createQuitHandler(deps: QuitHandlerDependencies): QuitHandler {
 		if (stopCliWatcher) {
 			stopCliWatcher();
 		}
+
+		// Stop group chat moderator cleanup interval
+		if (stopSessionCleanup) {
+			stopSessionCleanup();
+		}
+
+		// Clear power save blocker to release OS-level sleep prevention state
+		powerManager.clearAllReasons();
 
 		// Clean up active grooming sessions (context merge/transfer operations)
 		const processManager = getProcessManager();

--- a/src/main/app-lifecycle/quit-handler.ts
+++ b/src/main/app-lifecycle/quit-handler.ts
@@ -17,7 +17,7 @@ import { powerManager as powerManagerInstance } from '../power-manager';
  * If the renderer doesn't respond within this time (e.g., window already closing,
  * renderer crashed), force-quit to prevent the app from lingering in the background.
  */
-const QUIT_CONFIRMATION_TIMEOUT_MS = 3000;
+const QUIT_CONFIRMATION_TIMEOUT_MS = 5000;
 
 /** Dependencies for quit handler */
 export interface QuitHandlerDependencies {

--- a/src/main/app-lifecycle/quit-handler.ts
+++ b/src/main/app-lifecycle/quit-handler.ts
@@ -139,12 +139,11 @@ export function createQuitHandler(deps: QuitHandlerDependencies): QuitHandler {
 					// Ask renderer to check for busy agents
 					if (isWebContentsAvailable(mainWindow)) {
 						state.isRequestingConfirmation = true;
-						logger.info('Requesting quit confirmation from renderer', 'Window');
-						mainWindow.webContents.send('app:requestQuitConfirmation');
 
-						// Safety timeout: if the renderer never responds (e.g., window is mid-teardown,
-						// renderer crashed, or webContents is in a transitional state), force-quit to
-						// prevent the app from lingering in the background with no window (issue #623).
+						// Arm safety timeout BEFORE send() so it's always active even if
+						// send() throws (e.g., renderer disposed between the availability
+						// check and the actual IPC call). Prevents the app from lingering
+						// in the background with no window (issue #623).
 						state.confirmationTimeout = setTimeout(() => {
 							if (state.isRequestingConfirmation) {
 								logger.warn(
@@ -156,6 +155,9 @@ export function createQuitHandler(deps: QuitHandlerDependencies): QuitHandler {
 								app.quit();
 							}
 						}, QUIT_CONFIRMATION_TIMEOUT_MS);
+
+						logger.info('Requesting quit confirmation from renderer', 'Window');
+						mainWindow.webContents.send('app:requestQuitConfirmation');
 					} else {
 						// No window, just quit
 						state.quitConfirmed = true;

--- a/src/main/app-lifecycle/quit-handler.ts
+++ b/src/main/app-lifecycle/quit-handler.ts
@@ -174,6 +174,7 @@ export function createQuitHandler(deps: QuitHandlerDependencies): QuitHandler {
 		isQuitConfirmed: () => state.quitConfirmed,
 
 		confirmQuit: () => {
+			clearConfirmationTimeout();
 			state.quitConfirmed = true;
 		},
 	};

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -75,6 +75,7 @@ import {
 } from './group-chat/group-chat-router';
 import { createSshRemoteStoreAdapter } from './utils/ssh-remote-resolver';
 import { updateParticipant, loadGroupChat, updateGroupChat } from './group-chat/group-chat-storage';
+import { stopSessionCleanup } from './group-chat/group-chat-moderator';
 import { needsSessionRecovery, initiateSessionRecovery } from './group-chat/session-recovery';
 import { initializeSessionStorages } from './storage';
 import { initializeOutputParsers } from './parsers';
@@ -441,6 +442,8 @@ const quitHandler = createQuitHandler({
 	cleanupAllGroomingSessions,
 	closeStatsDB,
 	stopCliWatcher: () => cliWatcher.stop(),
+	powerManager,
+	stopSessionCleanup,
 });
 quitHandler.setup();
 


### PR DESCRIPTION
## Summary
- Adds a 3-second safety timeout to the quit confirmation flow so that if the renderer never responds (e.g., window mid-teardown, renderer crashed, or webContents in a transitional state), the app force-quits instead of lingering in the background with no window (issue #623)
- Clears the safety timeout when the renderer does respond (confirmed or cancelled)
- Also cleans up power save blocker and group chat moderator interval during shutdown to prevent stale OS-level state

## Test plan
- [x] Verified fix works on Windows — app no longer lingers after closing
- [x] Updated `quit-handler.test.ts` with mocks for `powerManager` and `stopSessionCleanup`
- [x] Existing quit handler tests pass with new dependencies

Fixes #623

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Added a 5-second quit-confirmation safety timeout to avoid hangs when the renderer doesn't respond.
  * Shutdown now runs session cleanup and clears system sleep-prevention state so the app exits more reliably and frees resources.
* **Tests**
  * Updated tests to cover the confirmation timeout and expanded shutdown cleanup behavior.
* **Documentation**
  * Normalized formatting in release notes documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->