### PR TITLE
feat: Add fuzzy search for slash commands

### DIFF
--- a/src/__tests__/renderer/utils/search.test.ts
+++ b/src/__tests__/renderer/utils/search.test.ts
@@ -512,36 +512,51 @@ describe('search utils', () => {
 		});
 
 		it('returns correct indices for fuzzy match across dot boundary', () => {
-			const indices = fuzzyMatchWithIndices('speckit.plan', 'splan');
+			// With '.' as extra boundary, "splan" should match s(0) then p(7) at ".plan" boundary
+			const indices = fuzzyMatchWithIndices('speckit.plan', 'splan', '.');
 			expect(indices).toHaveLength(5);
 			expect(indices[0]).toBe(0); // s
+			expect(indices[1]).toBe(8); // p (after dot, not index 1)
+		});
+
+		it('falls back to greedy when no boundary match exists', () => {
+			const indices = fuzzyMatchWithIndices('abcdef', 'ace');
+			expect(indices).toEqual([0, 2, 4]);
 		});
 
 		it('returns empty array when query is longer than text', () => {
 			expect(fuzzyMatchWithIndices('hi', 'history')).toEqual([]);
 		});
+
+		it('falls back to greedy when boundary choice would prevent remaining match', () => {
+			// "aa" in "ab.a": boundary 'a' is at index 3 (after '.'), but picking it
+			// for qi=0 leaves no chars for qi=1. Should fall back to index 0.
+			const indices = fuzzyMatchWithIndices('ab.a', 'aa', '.');
+			expect(indices).toEqual([0, 3]);
+		});
 	});
 
 	describe('slash command fuzzy matching', () => {
 		it('matches boundary-anchored abbreviation (splan → speckit.plan)', () => {
-			expect(fuzzyMatchWithScore('speckit.plan', 'splan').matches).toBe(true);
+			expect(fuzzyMatchWithScore('speckit.plan', 'splan', '.').matches).toBe(true);
 		});
 
 		it('ranks prefix match above fuzzy match', () => {
-			const prefix = fuzzyMatchWithScore('speckit.plan', 'spec');
-			const fuzzy = fuzzyMatchWithScore('speckit.plan', 'splan');
+			const prefix = fuzzyMatchWithScore('speckit.plan', 'spec', '.');
+			const fuzzy = fuzzyMatchWithScore('speckit.plan', 'splan', '.');
 			expect(prefix.score).toBeGreaterThan(fuzzy.score);
 		});
 
 		it('matches across dot boundaries', () => {
-			expect(fuzzyMatchWithScore('openspec.plan', 'oplan').matches).toBe(true);
-			expect(fuzzyMatchWithScore('speckit.list', 'slist').matches).toBe(true);
+			expect(fuzzyMatchWithScore('openspec.plan', 'oplan', '.').matches).toBe(true);
+			expect(fuzzyMatchWithScore('speckit.list', 'slist', '.').matches).toBe(true);
 		});
 
-		it('gives dot boundary bonus', () => {
-			const dotBoundary = fuzzyMatchWithScore('hello.world', 'w');
-			const midWord = fuzzyMatchWithScore('hewollo', 'w');
-			expect(dotBoundary.score).toBeGreaterThan(midWord.score);
+		it('gives dot boundary bonus only when opted in', () => {
+			const withDot = fuzzyMatchWithScore('hello.world', 'w', '.');
+			const withoutDot = fuzzyMatchWithScore('hello.world', 'w');
+			expect(withDot.score).toBeGreaterThan(withoutDot.score);
 		});
+
 	});
 });

--- a/src/renderer/components/InputArea.tsx
+++ b/src/renderer/components/InputArea.tsx
@@ -324,16 +324,17 @@ export const InputArea = React.memo(function InputArea(props: InputAreaProps) {
 			.filter((cmd) => {
 				if (cmd.terminalOnly && !isTerminalMode) return false;
 				if (cmd.aiOnly && isTerminalMode) return false;
-				if (!query) return true;
-				return fuzzyMatchWithScore(cmd.command.slice(1), query).matches;
+				return true;
 			})
-			.sort((a, b) => {
-				if (!query) return 0;
-				return (
-					fuzzyMatchWithScore(b.command.slice(1), query).score -
-					fuzzyMatchWithScore(a.command.slice(1), query).score
-				);
-			});
+			.map((cmd) => {
+				const { matches, score } = query
+					? fuzzyMatchWithScore(cmd.command.slice(1), query, '.')
+					: { matches: true, score: 0 };
+				return { cmd, matches, score };
+			})
+			.filter(({ matches }) => matches)
+			.sort((a, b) => b.score - a.score)
+			.map(({ cmd }) => cmd);
 	}, [slashCommands, isTerminalMode, inputValueLower]);
 
 	// Ensure selectedSlashCommandIndex is valid for the filtered list
@@ -541,7 +542,7 @@ export const InputArea = React.memo(function InputArea(props: InputAreaProps) {
 										if (!query) return cmd.command;
 										// Match indices on the part after "/", then offset by 1 for the "/"
 										const indices = new Set(
-											fuzzyMatchWithIndices(cmd.command.slice(1).toLowerCase(), query).map(
+											fuzzyMatchWithIndices(cmd.command.slice(1).toLowerCase(), query, '.').map(
 												(i) => i + 1
 											)
 										);

--- a/src/renderer/hooks/input/useInputKeyDown.ts
+++ b/src/renderer/hooks/input/useInputKeyDown.ts
@@ -211,16 +211,17 @@ export function useInputKeyDown(deps: InputKeyDownDeps): InputKeyDownReturn {
 					.filter((cmd) => {
 						if ('terminalOnly' in cmd && cmd.terminalOnly && !isTerminalMode) return false;
 						if ('aiOnly' in cmd && cmd.aiOnly && isTerminalMode) return false;
-						if (!query) return true;
-						return fuzzyMatchWithScore(cmd.command.slice(1), query).matches;
+						return true;
 					})
-					.sort((a, b) => {
-						if (!query) return 0;
-						return (
-							fuzzyMatchWithScore(b.command.slice(1), query).score -
-							fuzzyMatchWithScore(a.command.slice(1), query).score
-						);
-					});
+					.map((cmd) => {
+						const { matches, score } = query
+							? fuzzyMatchWithScore(cmd.command.slice(1), query, '.')
+							: { matches: true, score: 0 };
+						return { cmd, matches, score };
+					})
+					.filter(({ matches }) => matches)
+					.sort((a, b) => b.score - a.score)
+					.map(({ cmd }) => cmd);
 
 				if (e.key === 'ArrowDown') {
 					e.preventDefault();
@@ -230,8 +231,9 @@ export function useInputKeyDown(deps: InputKeyDownDeps): InputKeyDownReturn {
 					setSelectedSlashCommandIndex((prev) => Math.max(prev - 1, 0));
 				} else if (e.key === 'Tab' || e.key === 'Enter') {
 					e.preventDefault();
-					if (filteredCommands[selectedSlashCommandIndex]) {
-						setInputValue(filteredCommands[selectedSlashCommandIndex].command);
+					const clampedIndex = Math.min(selectedSlashCommandIndex, filteredCommands.length - 1);
+					if (clampedIndex >= 0 && filteredCommands[clampedIndex]) {
+						setInputValue(filteredCommands[clampedIndex].command);
 						setSlashCommandOpen(false);
 						inputRef.current?.focus();
 					}

--- a/src/renderer/utils/search.ts
+++ b/src/renderer/utils/search.ts
@@ -40,7 +40,11 @@ export const fuzzyMatch = (text: string, query: string): boolean => {
  * @param query - The search query
  * @returns FuzzyMatchResult with matches boolean and score for ranking
  */
-export const fuzzyMatchWithScore = (text: string, query: string): FuzzyMatchResult => {
+export const fuzzyMatchWithScore = (
+	text: string,
+	query: string,
+	extraBoundaryChars?: string
+): FuzzyMatchResult => {
 	if (!query) {
 		return { matches: true, score: 0 };
 	}
@@ -74,14 +78,14 @@ export const fuzzyMatchWithScore = (text: string, query: string): FuzzyMatchResu
 				score += 5;
 			}
 
-			// Bonus for match at word boundary (after space, dash, underscore, dot, or start)
+			// Bonus for match at word boundary (after space, dash, underscore, or start)
 			if (
 				i === 0 ||
 				text[i - 1] === ' ' ||
 				text[i - 1] === '-' ||
 				text[i - 1] === '_' ||
 				text[i - 1] === '/' ||
-				text[i - 1] === '.'
+				(extraBoundaryChars && extraBoundaryChars.includes(text[i - 1]))
 			) {
 				score += 8;
 			}
@@ -120,23 +124,59 @@ export const fuzzyMatchWithScore = (text: string, query: string): FuzzyMatchResu
 };
 
 /**
- * Returns the indices in `text` that match `query` as a fuzzy subsequence.
- * Uses the same greedy left-to-right algorithm as fuzzyMatch.
+ * Returns the indices in `text` that match `query` as a fuzzy subsequence,
+ * preferring boundary-anchored positions (after separator chars).
  * Returns empty array if no match.
  */
-export const fuzzyMatchWithIndices = (text: string, query: string): number[] => {
+export const fuzzyMatchWithIndices = (
+	text: string,
+	query: string,
+	extraBoundaryChars?: string
+): number[] => {
 	if (!query || query.length > text.length) return [];
 
 	const lowerText = text.toLowerCase();
 	const lowerQuery = query.toLowerCase();
+	const defaultBoundary = ' -_/';
+	const boundaryChars = extraBoundaryChars ? defaultBoundary + extraBoundaryChars : defaultBoundary;
+
+	const isBoundary = (i: number) => i === 0 || boundaryChars.includes(text[i - 1]);
+
+	// Check if lowerQuery[from..] is a subsequence of lowerText[after..]
+	const canMatchRest = (after: number, from: number): boolean => {
+		let q = from;
+		for (let j = after; j < lowerText.length && q < lowerQuery.length; j++) {
+			if (lowerText[j] === lowerQuery[q]) q++;
+		}
+		return q === lowerQuery.length;
+	};
+
+	// For each query char, prefer a boundary-anchored position, but only if
+	// the remaining query can still be matched after that position.
 	const indices: number[] = [];
 	let qi = 0;
+	let ti = 0;
 
-	for (let i = 0; i < lowerText.length && qi < lowerQuery.length; i++) {
-		if (lowerText[i] === lowerQuery[qi]) {
-			indices.push(i);
-			qi++;
+	while (qi < lowerQuery.length && ti < lowerText.length) {
+		let firstMatch = -1;
+		let boundaryMatch = -1;
+
+		for (let j = ti; j < lowerText.length; j++) {
+			if (lowerText[j] === lowerQuery[qi]) {
+				if (firstMatch === -1) firstMatch = j;
+				if (isBoundary(j) && canMatchRest(j + 1, qi + 1)) {
+					boundaryMatch = j;
+					break;
+				}
+			}
 		}
+
+		if (firstMatch === -1) return []; // no match possible
+
+		const chosen = boundaryMatch !== -1 ? boundaryMatch : firstMatch;
+		indices.push(chosen);
+		ti = chosen + 1;
+		qi++;
 	}
 
 	return qi === lowerQuery.length ? indices : [];

--- a/src/web/mobile/SlashCommandAutocomplete.tsx
+++ b/src/web/mobile/SlashCommandAutocomplete.tsx
@@ -94,28 +94,31 @@ export function SlashCommandAutocomplete({
 	const containerRef = useRef<HTMLDivElement>(null);
 
 	// Filter commands based on input and mode (fuzzy matching)
+	const shouldFuzzyFilter = inputValue && inputValue.startsWith('/');
 	const filteredCommands = useMemo(() => {
 		const query = (inputValue || '').toLowerCase().replace(/^\//, '');
 		return commands
 			.filter((cmd) => {
 				if (cmd.terminalOnly && inputMode !== 'terminal') return false;
 				if (cmd.aiOnly && inputMode === 'terminal') return false;
-				if (!inputValue || !inputValue.startsWith('/') || !query) return true;
-				return fuzzyMatchWithScore(cmd.command.slice(1), query).matches;
+				return true;
 			})
-			.sort((a, b) => {
-				if (!query) return 0;
-				return (
-					fuzzyMatchWithScore(b.command.slice(1), query).score -
-					fuzzyMatchWithScore(a.command.slice(1), query).score
-				);
-			});
-	}, [commands, inputMode, inputValue]);
+			.map((cmd) => {
+				const { matches, score } =
+					shouldFuzzyFilter && query
+						? fuzzyMatchWithScore(cmd.command.slice(1), query, '.')
+						: { matches: true, score: 0 };
+				return { cmd, matches, score };
+			})
+			.filter(({ matches }) => matches)
+			.sort((a, b) => b.score - a.score)
+			.map(({ cmd }) => cmd);
+	}, [commands, inputMode, inputValue, shouldFuzzyFilter]);
 
 	// Clamp selectedIndex to valid range when filtered list changes
 	useEffect(() => {
 		if (filteredCommands.length > 0 && selectedIndex >= filteredCommands.length) {
-			onSelectedIndexChange?.(0);
+			onSelectedIndexChange?.(filteredCommands.length - 1);
 		}
 	}, [filteredCommands.length, selectedIndex, onSelectedIndexChange]);
 
@@ -303,7 +306,9 @@ export function SlashCommandAutocomplete({
 								const query = (inputValue || '').toLowerCase().replace(/^\//, '');
 								if (!query) return cmd.command;
 								const indices = new Set(
-									fuzzyMatchWithIndices(cmd.command.slice(1).toLowerCase(), query).map((i) => i + 1)
+									fuzzyMatchWithIndices(cmd.command.slice(1).toLowerCase(), query, '.').map(
+										(i) => i + 1
+									)
 								);
 								if (indices.size === 0) return cmd.command;
 								return Array.from(cmd.command).map((ch, i) =>


### PR DESCRIPTION
<img width="761" height="349" alt="Fuzzy slash command matching in action" src="https://github.com/user-attachments/assets/a031aee5-427c-4887-8393-f1aa189ee2b9" />

Hi, I enjoy your project! 

I wanted to add fuzzy search to the slash command for skills after having to type the speckit[dot] prefix way too many times. 

I reused the fuzzy search used by the @ command to filter files. I made a styling that in my opinion should fit all themes but I am happy to change it to whatever or even no highlighting at all like the @ command". 

I haven't looked into the performance of the fuzzy scoring but the number of skills should be reasonable and it uses the same fuzzy search used by the @ command!


I hope you like it!

Florian

## Summary

- **Fuzzy matching for slash commands**: Type abbreviations like `/splan` to match `/speckit.plan`, `/ohelp` to match `/openspec.help`, etc. Uses the same `fuzzyMatchWithScore` engine that powers `@` mention file completion.
- **Match highlighting**: Matched characters render in bold with non-matched characters slightly dimmed (80% opacity), giving clear visual feedback on what's matching.
- **Sorted by relevance**: Results are ranked by match quality — exact prefixes first, then boundary-anchored matches, then general subsequences.
- Added `.` as a word boundary character in `fuzzyMatchWithScore`, so dot-separated command names (e.g., `speckit.plan`) get proper boundary bonuses.
- Added `fuzzyMatchWithIndices` utility to `search.ts` for highlight rendering.
- Applied consistently across desktop (`InputArea.tsx`, `useInputKeyDown.ts`) and mobile (`SlashCommandAutocomplete.tsx`).

## Test plan

- [x] Tests added to `search.test.ts` covering fuzzy matching for slash commands and `fuzzyMatchWithIndices`
- [x] Type `/splan` → should show `/speckit.plan` with `s`, `p`, `l`, `a`, `n` bolded
- [x] Type `/hist` → should show `/history` as top match (prefix still works)
- [x] Type `/` → should show all commands (no filter)
- [x] Arrow keys and Tab/Enter selection still work correctly
- [x] Verify on mobile web interface

## Mobile version

<img width="610" height="273" alt="Fuzzy slash command matching in action mobile" src="https://github.com/user-attachments/assets/fba7e353-e74c-4a2d-9451-c4e395305007" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Slash command autocomplete now uses fuzzy matching, highlights matched characters, and ranks results by relevance.
  * Tab/Enter selection is more robust to list changes, preventing out-of-bounds selection.

* **Improvements**
  * Boundary-aware matching with optional dot support improves cross-boundary and abbreviation matches.
  * Empty input (or just "/") now surfaces available commands while still respecting mode restrictions.

* **Tests**
  * Added tests covering match indices, empty/non-match cases, boundary behavior, scoring, and ranking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->