### PR TITLE
fix(cli): capture response from claude-code in maestro-cli send

### DIFF
--- a/src/__tests__/cli/services/agent-spawner.test.ts
+++ b/src/__tests__/cli/services/agent-spawner.test.ts
@@ -1165,6 +1165,33 @@ Some text with [x] in it that's not a checkbox
 			expect(result.response).toBe('Hello world');
 		});
 
+		it('should separate multiple assistant messages with newlines', async () => {
+			const resultPromise = spawnAgent('claude-code', '/project', 'prompt');
+
+			await new Promise((resolve) => setTimeout(resolve, 0));
+
+			mockStdout.emit(
+				'data',
+				Buffer.from(
+					'{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"First part."}]}}\n'
+				)
+			);
+			mockStdout.emit(
+				'data',
+				Buffer.from(
+					'{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Second part."}]}}\n'
+				)
+			);
+			mockStdout.emit('data', Buffer.from('{"type":"result","result":""}\n'));
+			await new Promise((resolve) => setTimeout(resolve, 0));
+			mockChild.emit('close', 0);
+
+			const result = await resultPromise;
+
+			expect(result.success).toBe(true);
+			expect(result.response).toBe('First part.\nSecond part.');
+		});
+
 		it('should ignore non-JSON lines', async () => {
 			const resultPromise = spawnAgent('claude-code', '/project', 'prompt');
 

--- a/src/__tests__/cli/services/agent-spawner.test.ts
+++ b/src/__tests__/cli/services/agent-spawner.test.ts
@@ -1064,6 +1064,107 @@ Some text with [x] in it that's not a checkbox
 			expect(result.response).toBe('Complete');
 		});
 
+		it('should flush buffer on close when last line lacks trailing newline', async () => {
+			const resultPromise = spawnAgent('claude-code', '/project', 'prompt');
+
+			await new Promise((resolve) => setTimeout(resolve, 0));
+
+			// Result line without trailing newline (stays in buffer until close)
+			mockStdout.emit('data', Buffer.from('{"type":"result","result":"Flushed"}'));
+			await new Promise((resolve) => setTimeout(resolve, 0));
+			mockChild.emit('close', 0);
+
+			const result = await resultPromise;
+
+			expect(result.success).toBe(true);
+			expect(result.response).toBe('Flushed');
+		});
+
+		it('should flush buffer with session_id and usage on close', async () => {
+			const resultPromise = spawnAgent('claude-code', '/project', 'prompt');
+
+			await new Promise((resolve) => setTimeout(resolve, 0));
+
+			// Earlier lines with newlines are processed normally
+			mockStdout.emit('data', Buffer.from('{"session_id":"sess-1"}\n'));
+			// Final result without trailing newline
+			mockStdout.emit(
+				'data',
+				Buffer.from('{"type":"result","result":"Done","total_cost_usd":0.05}')
+			);
+			await new Promise((resolve) => setTimeout(resolve, 0));
+			mockChild.emit('close', 0);
+
+			const result = await resultPromise;
+
+			expect(result.success).toBe(true);
+			expect(result.response).toBe('Done');
+			expect(result.agentSessionId).toBe('sess-1');
+		});
+
+		it('should use assistant message text when result field is empty', async () => {
+			const resultPromise = spawnAgent('claude-code', '/project', 'prompt');
+
+			await new Promise((resolve) => setTimeout(resolve, 0));
+
+			// Assistant message with response text (as Claude Code actually emits)
+			mockStdout.emit(
+				'data',
+				Buffer.from(
+					'{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"CLI capture test OK"}]}}\n'
+				)
+			);
+			// Result message with empty result field (matches real Claude Code behavior)
+			mockStdout.emit('data', Buffer.from('{"type":"result","result":"","total_cost_usd":0.02}\n'));
+			await new Promise((resolve) => setTimeout(resolve, 0));
+			mockChild.emit('close', 0);
+
+			const result = await resultPromise;
+
+			expect(result.success).toBe(true);
+			expect(result.response).toBe('CLI capture test OK');
+		});
+
+		it('should prefer result field over assistant text when both present', async () => {
+			const resultPromise = spawnAgent('claude-code', '/project', 'prompt');
+
+			await new Promise((resolve) => setTimeout(resolve, 0));
+
+			mockStdout.emit(
+				'data',
+				Buffer.from(
+					'{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"partial"}]}}\n'
+				)
+			);
+			mockStdout.emit('data', Buffer.from('{"type":"result","result":"Final answer"}\n'));
+			await new Promise((resolve) => setTimeout(resolve, 0));
+			mockChild.emit('close', 0);
+
+			const result = await resultPromise;
+
+			expect(result.success).toBe(true);
+			expect(result.response).toBe('Final answer');
+		});
+
+		it('should handle assistant message with string content', async () => {
+			const resultPromise = spawnAgent('claude-code', '/project', 'prompt');
+
+			await new Promise((resolve) => setTimeout(resolve, 0));
+
+			mockStdout.emit(
+				'data',
+				Buffer.from('{"type":"assistant","message":{"role":"assistant","content":"Hello world"}}\n')
+			);
+			mockStdout.emit('data', Buffer.from('{"type":"result","result":""}\n'));
+			await new Promise((resolve) => setTimeout(resolve, 0));
+			mockChild.emit('close', 0);
+
+			const result = await resultPromise;
+
+			expect(result.success).toBe(true);
+			expect(result.response).toBe('Hello world');
+		});
+
 		it('should ignore non-JSON lines', async () => {
 			const resultPromise = spawnAgent('claude-code', '/project', 'prompt');
 

--- a/src/__tests__/cli/services/agent-spawner.test.ts
+++ b/src/__tests__/cli/services/agent-spawner.test.ts
@@ -1100,6 +1100,7 @@ Some text with [x] in it that's not a checkbox
 			expect(result.success).toBe(true);
 			expect(result.response).toBe('Done');
 			expect(result.agentSessionId).toBe('sess-1');
+			expect(result.usageStats?.totalCostUsd).toBe(0.05);
 		});
 
 		it('should use assistant message text when result field is empty', async () => {

--- a/src/cli/services/agent-spawner.ts
+++ b/src/cli/services/agent-spawner.ts
@@ -223,6 +223,44 @@ async function spawnClaudeAgent(
 		let resultEmitted = false;
 		let sessionIdEmitted = false;
 
+		// Process a single parsed JSON message from Claude Code's stream-json output
+		 
+		const processMessage = (msg: any) => {
+			// Capture result text (only once)
+			if (msg.type === 'result' && msg.result && !resultEmitted) {
+				resultEmitted = true;
+				result = msg.result;
+			}
+
+			// Accumulate text from assistant messages — Claude Code may emit
+			// an empty result field with the actual text in assistant messages
+			if (msg.type === 'assistant' && msg.message?.content) {
+				const content = msg.message.content;
+				if (typeof content === 'string') {
+					if (assistantText) assistantText += '\n';
+					assistantText += content;
+				} else if (Array.isArray(content)) {
+					for (const block of content) {
+						if (block.type === 'text' && block.text) {
+							if (assistantText) assistantText += '\n';
+							assistantText += block.text;
+						}
+					}
+				}
+			}
+
+			// Capture session_id (only once)
+			if (msg.session_id && !sessionIdEmitted) {
+				sessionIdEmitted = true;
+				sessionId = msg.session_id;
+			}
+
+			// Extract usage statistics using shared aggregator
+			if (msg.modelUsage || msg.usage || msg.total_cost_usd !== undefined) {
+				usageStats = aggregateModelUsage(msg.modelUsage, msg.usage || {}, msg.total_cost_usd || 0);
+			}
+		};
+
 		// Handle stdout - parse stream-json format
 		child.stdout?.on('data', (data: Buffer) => {
 			jsonBuffer += data.toString();
@@ -235,44 +273,7 @@ async function spawnClaudeAgent(
 				if (!line.trim()) continue;
 
 				try {
-					const msg = JSON.parse(line);
-
-					// Capture result text — prefer msg.result, fall back to
-					// assistant message content (Claude Code may emit an empty
-					// result field with the actual text in assistant messages)
-					if (msg.type === 'result' && msg.result && !resultEmitted) {
-						resultEmitted = true;
-						result = msg.result;
-					}
-
-					// Accumulate text from assistant messages
-					if (msg.type === 'assistant' && msg.message?.content) {
-						const content = msg.message.content;
-						if (typeof content === 'string') {
-							assistantText += content;
-						} else if (Array.isArray(content)) {
-							for (const block of content) {
-								if (block.type === 'text' && block.text) {
-									assistantText += block.text;
-								}
-							}
-						}
-					}
-
-					// Capture session_id (only once)
-					if (msg.session_id && !sessionIdEmitted) {
-						sessionIdEmitted = true;
-						sessionId = msg.session_id;
-					}
-
-					// Extract usage statistics using shared aggregator
-					if (msg.modelUsage || msg.usage || msg.total_cost_usd !== undefined) {
-						usageStats = aggregateModelUsage(
-							msg.modelUsage,
-							msg.usage || {},
-							msg.total_cost_usd || 0
-						);
-					}
+					processMessage(JSON.parse(line));
 				} catch {
 					// Ignore non-JSON lines
 				}
@@ -293,34 +294,7 @@ async function spawnClaudeAgent(
 			// Flush any remaining data in the JSON buffer (last line may lack trailing \n)
 			if (jsonBuffer.trim()) {
 				try {
-					const msg = JSON.parse(jsonBuffer);
-					if (msg.type === 'result' && msg.result && !resultEmitted) {
-						resultEmitted = true;
-						result = msg.result;
-					}
-					if (msg.type === 'assistant' && msg.message?.content) {
-						const content = msg.message.content;
-						if (typeof content === 'string') {
-							assistantText += content;
-						} else if (Array.isArray(content)) {
-							for (const block of content) {
-								if (block.type === 'text' && block.text) {
-									assistantText += block.text;
-								}
-							}
-						}
-					}
-					if (msg.session_id && !sessionIdEmitted) {
-						sessionIdEmitted = true;
-						sessionId = msg.session_id;
-					}
-					if (msg.modelUsage || msg.usage || msg.total_cost_usd !== undefined) {
-						usageStats = aggregateModelUsage(
-							msg.modelUsage,
-							msg.usage || {},
-							msg.total_cost_usd || 0
-						);
-					}
+					processMessage(JSON.parse(jsonBuffer));
 				} catch {
 					// Ignore non-JSON remnants
 				}
@@ -483,6 +457,36 @@ async function spawnJsonLineAgent(
 		let stderr = '';
 		let errorText: string | undefined;
 
+		// Process a single parsed event from an agent's JSON line output
+		const processEvent = (event: ReturnType<typeof parser.parseJsonLine>) => {
+			if (!event) return;
+
+			if (event.type === 'init' && event.sessionId && !sessionId) {
+				sessionId = event.sessionId;
+			}
+
+			if (event.type === 'result' && event.text) {
+				result = result ? `${result}\n${event.text}` : event.text;
+			}
+
+			if (event.type === 'error' && event.text && !errorText) {
+				errorText = event.text;
+			}
+
+			const usage = parser.extractUsage(event);
+			if (usage) {
+				usageStats = mergeUsageStats(usageStats, {
+					inputTokens: usage.inputTokens || 0,
+					outputTokens: usage.outputTokens || 0,
+					cacheReadTokens: usage.cacheReadTokens || 0,
+					cacheCreationTokens: usage.cacheCreationTokens || 0,
+					costUsd: usage.costUsd || 0,
+					contextWindow: usage.contextWindow || 0,
+					reasoningTokens: usage.reasoningTokens || 0,
+				});
+			}
+		};
+
 		child.stdout?.on('data', (data: Buffer) => {
 			jsonBuffer += data.toString();
 			const lines = jsonBuffer.split('\n');
@@ -490,33 +494,7 @@ async function spawnJsonLineAgent(
 
 			for (const line of lines) {
 				if (!line.trim()) continue;
-				const event = parser.parseJsonLine(line);
-				if (!event) continue;
-
-				if (event.type === 'init' && event.sessionId && !sessionId) {
-					sessionId = event.sessionId;
-				}
-
-				if (event.type === 'result' && event.text) {
-					result = result ? `${result}\n${event.text}` : event.text;
-				}
-
-				if (event.type === 'error' && event.text && !errorText) {
-					errorText = event.text;
-				}
-
-				const usage = parser.extractUsage(event);
-				if (usage) {
-					usageStats = mergeUsageStats(usageStats, {
-						inputTokens: usage.inputTokens || 0,
-						outputTokens: usage.outputTokens || 0,
-						cacheReadTokens: usage.cacheReadTokens || 0,
-						cacheCreationTokens: usage.cacheCreationTokens || 0,
-						costUsd: usage.costUsd || 0,
-						contextWindow: usage.contextWindow || 0,
-						reasoningTokens: usage.reasoningTokens || 0,
-					});
-				}
+				processEvent(parser.parseJsonLine(line));
 			}
 		});
 
@@ -530,30 +508,7 @@ async function spawnJsonLineAgent(
 		child.on('close', (code) => {
 			// Flush any remaining data in the JSON buffer (last line may lack trailing \n)
 			if (jsonBuffer.trim()) {
-				const event = parser.parseJsonLine(jsonBuffer);
-				if (event) {
-					if (event.type === 'init' && event.sessionId && !sessionId) {
-						sessionId = event.sessionId;
-					}
-					if (event.type === 'result' && event.text) {
-						result = result ? `${result}\n${event.text}` : event.text;
-					}
-					if (event.type === 'error' && event.text && !errorText) {
-						errorText = event.text;
-					}
-					const usage = parser.extractUsage(event);
-					if (usage) {
-						usageStats = mergeUsageStats(usageStats, {
-							inputTokens: usage.inputTokens || 0,
-							outputTokens: usage.outputTokens || 0,
-							cacheReadTokens: usage.cacheReadTokens || 0,
-							cacheCreationTokens: usage.cacheCreationTokens || 0,
-							costUsd: usage.costUsd || 0,
-							contextWindow: usage.contextWindow || 0,
-							reasoningTokens: usage.reasoningTokens || 0,
-						});
-					}
-				}
+				processEvent(parser.parseJsonLine(jsonBuffer));
 			}
 
 			if (code === 0 && !errorText) {

--- a/src/cli/services/agent-spawner.ts
+++ b/src/cli/services/agent-spawner.ts
@@ -217,6 +217,7 @@ async function spawnClaudeAgent(
 
 		let jsonBuffer = '';
 		let result: string | undefined;
+		let assistantText = ''; // Accumulate text from assistant messages as fallback
 		let sessionId: string | undefined;
 		let usageStats: UsageStats | undefined;
 		let resultEmitted = false;
@@ -236,10 +237,26 @@ async function spawnClaudeAgent(
 				try {
 					const msg = JSON.parse(line);
 
-					// Capture result (only once)
+					// Capture result text — prefer msg.result, fall back to
+					// assistant message content (Claude Code may emit an empty
+					// result field with the actual text in assistant messages)
 					if (msg.type === 'result' && msg.result && !resultEmitted) {
 						resultEmitted = true;
 						result = msg.result;
+					}
+
+					// Accumulate text from assistant messages
+					if (msg.type === 'assistant' && msg.message?.content) {
+						const content = msg.message.content;
+						if (typeof content === 'string') {
+							assistantText += content;
+						} else if (Array.isArray(content)) {
+							for (const block of content) {
+								if (block.type === 'text' && block.text) {
+									assistantText += block.text;
+								}
+							}
+						}
 					}
 
 					// Capture session_id (only once)
@@ -273,10 +290,49 @@ async function spawnClaudeAgent(
 
 		// Handle completion
 		child.on('close', (code) => {
-			if (code === 0 && result) {
+			// Flush any remaining data in the JSON buffer (last line may lack trailing \n)
+			if (jsonBuffer.trim()) {
+				try {
+					const msg = JSON.parse(jsonBuffer);
+					if (msg.type === 'result' && msg.result && !resultEmitted) {
+						resultEmitted = true;
+						result = msg.result;
+					}
+					if (msg.type === 'assistant' && msg.message?.content) {
+						const content = msg.message.content;
+						if (typeof content === 'string') {
+							assistantText += content;
+						} else if (Array.isArray(content)) {
+							for (const block of content) {
+								if (block.type === 'text' && block.text) {
+									assistantText += block.text;
+								}
+							}
+						}
+					}
+					if (msg.session_id && !sessionIdEmitted) {
+						sessionIdEmitted = true;
+						sessionId = msg.session_id;
+					}
+					if (msg.modelUsage || msg.usage || msg.total_cost_usd !== undefined) {
+						usageStats = aggregateModelUsage(
+							msg.modelUsage,
+							msg.usage || {},
+							msg.total_cost_usd || 0
+						);
+					}
+				} catch {
+					// Ignore non-JSON remnants
+				}
+			}
+
+			// Use accumulated assistant text as fallback when result field is empty
+			const finalResult = result || assistantText || undefined;
+
+			if (code === 0 && finalResult) {
 				resolve({
 					success: true,
-					response: result,
+					response: finalResult,
 					agentSessionId: sessionId,
 					usageStats,
 				});
@@ -472,6 +528,34 @@ async function spawnJsonLineAgent(
 
 		const agentName = def?.name || toolType;
 		child.on('close', (code) => {
+			// Flush any remaining data in the JSON buffer (last line may lack trailing \n)
+			if (jsonBuffer.trim()) {
+				const event = parser.parseJsonLine(jsonBuffer);
+				if (event) {
+					if (event.type === 'init' && event.sessionId && !sessionId) {
+						sessionId = event.sessionId;
+					}
+					if (event.type === 'result' && event.text) {
+						result = result ? `${result}\n${event.text}` : event.text;
+					}
+					if (event.type === 'error' && event.text && !errorText) {
+						errorText = event.text;
+					}
+					const usage = parser.extractUsage(event);
+					if (usage) {
+						usageStats = mergeUsageStats(usageStats, {
+							inputTokens: usage.inputTokens || 0,
+							outputTokens: usage.outputTokens || 0,
+							cacheReadTokens: usage.cacheReadTokens || 0,
+							cacheCreationTokens: usage.cacheCreationTokens || 0,
+							costUsd: usage.costUsd || 0,
+							contextWindow: usage.contextWindow || 0,
+							reasoningTokens: usage.reasoningTokens || 0,
+						});
+					}
+				}
+			}
+
 			if (code === 0 && !errorText) {
 				resolve({ success: true, response: result, agentSessionId: sessionId, usageStats });
 			} else {

--- a/src/cli/services/agent-spawner.ts
+++ b/src/cli/services/agent-spawner.ts
@@ -224,7 +224,7 @@ async function spawnClaudeAgent(
 		let sessionIdEmitted = false;
 
 		// Process a single parsed JSON message from Claude Code's stream-json output
-		 
+
 		const processMessage = (msg: any) => {
 			// Capture result text (only once)
 			if (msg.type === 'result' && msg.result && !resultEmitted) {
@@ -293,10 +293,14 @@ async function spawnClaudeAgent(
 		child.on('close', (code) => {
 			// Flush any remaining data in the JSON buffer (last line may lack trailing \n)
 			if (jsonBuffer.trim()) {
+				let parsed;
 				try {
-					processMessage(JSON.parse(jsonBuffer));
+					parsed = JSON.parse(jsonBuffer);
 				} catch {
 					// Ignore non-JSON remnants
+				}
+				if (parsed) {
+					processMessage(parsed);
 				}
 			}
 


### PR DESCRIPTION
## Summary
- `maestro-cli send` returned `response: null` for claude-code agents because Claude Code emits the response text in `assistant` messages, not in the `result` message's `result` field (which is empty string)
- Now accumulates text from `assistant` messages as a fallback when `result` field is empty
- Also flushes the JSONL buffer on process close to handle output lacking a trailing newline (both `spawnClaudeAgent` and `spawnJsonLineAgent`)

## Test plan
- [x] Unit tests pass (80/80, including 5 new tests for assistant text fallback, string content, result preference, and buffer flush)
- [x] Type-check passes
- [x] Manual e2e test: `maestro-cli send <agent-id> "Respond with exactly: CLI capture test OK"` now returns `success: true` with correct response text

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI stream parsing to flush and parse truncated/non-newline-terminated final JSON chunks.
  * Ensure session ID and usage are captured and aggregated; prefer result field but fall back to assistant text when needed.
  * Handle assistant content as string or array and concatenate multiple assistant messages.

* **Tests**
  * Expanded agent-spawn tests for stdout buffering, final-chunk parsing, response precedence, and usage/session extraction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->