### PR TITLE
fix(symphony): use resolveGhPath() for gh CLI detection

### DIFF
--- a/src/__tests__/main/ipc/handlers/symphony.test.ts
+++ b/src/__tests__/main/ipc/handlers/symphony.test.ts
@@ -47,6 +47,11 @@ vi.mock('../../../../main/utils/symphony-fork', () => ({
 	ensureForkSetup: vi.fn(),
 }));
 
+// Mock cliDetection — resolveGhPath returns 'gh' so existing assertions still match
+vi.mock('../../../../main/utils/cliDetection', () => ({
+	resolveGhPath: vi.fn().mockResolvedValue('gh'),
+}));
+
 // Mock the logger
 vi.mock('../../../../main/utils/logger', () => ({
 	logger: {

--- a/src/__tests__/main/services/symphony-runner.test.ts
+++ b/src/__tests__/main/services/symphony-runner.test.ts
@@ -38,6 +38,11 @@ vi.mock('../../../main/utils/symphony-fork', () => ({
 	ensureForkSetup: vi.fn(),
 }));
 
+// Mock cliDetection — resolveGhPath returns 'gh' so existing assertions still match
+vi.mock('../../../main/utils/cliDetection', () => ({
+	resolveGhPath: vi.fn().mockResolvedValue('gh'),
+}));
+
 // Mock global fetch
 const mockFetch = vi.fn();
 global.fetch = mockFetch;

--- a/src/__tests__/main/utils/symphony-fork.test.ts
+++ b/src/__tests__/main/utils/symphony-fork.test.ts
@@ -20,6 +20,10 @@ vi.mock('../../../main/agents/path-prober', () => ({
 	getExpandedEnv: () => ({ PATH: '/usr/bin' }),
 }));
 
+vi.mock('../../../main/utils/cliDetection', () => ({
+	resolveGhPath: vi.fn().mockResolvedValue('gh'),
+}));
+
 import { ensureForkSetup } from '../../../main/utils/symphony-fork';
 
 function ok(stdout: string): ExecResult {

--- a/src/main/agents/path-prober.ts
+++ b/src/main/agents/path-prober.ts
@@ -97,6 +97,8 @@ export function getExpandedEnv(): NodeJS.ProcessEnv {
 			path.join(process.env.ChocolateyInstall || 'C:\\ProgramData\\chocolatey', 'bin'),
 			// Go binaries (some tools installed via 'go install')
 			path.join(home, 'go', 'bin'),
+			// GitHub CLI (official MSI installer)
+			path.join(programFiles, 'GitHub CLI'),
 			// Windows system paths
 			path.join(process.env.SystemRoot || 'C:\\Windows', 'System32'),
 			path.join(process.env.SystemRoot || 'C:\\Windows'),
@@ -316,6 +318,19 @@ function getWindowsKnownPaths(binaryName: string): string[] {
 			// pip installation
 			...pythonScripts('aider'),
 		],
+		gh: [
+			// GitHub CLI official installer (MSI)
+			path.join(programFiles, 'GitHub CLI', 'gh.exe'),
+			// Winget installation
+			...wingetLinks('gh'),
+			// Scoop installation
+			path.join(home, 'scoop', 'shims', 'gh.exe'),
+			path.join(home, 'scoop', 'apps', 'gh', 'current', 'bin', 'gh.exe'),
+			// Chocolatey installation
+			path.join(process.env.ChocolateyInstall || 'C:\\ProgramData\\chocolatey', 'bin', 'gh.exe'),
+			// User local bin
+			...localBin('gh'),
+		],
 	};
 
 	return knownPaths[binaryName] || [];
@@ -425,6 +440,16 @@ function getUnixKnownPaths(binaryName: string): string[] {
 			...homebrew('aider'),
 			// Node version managers (in case installed via npm)
 			...nodeVersionManagers('aider'),
+		],
+		gh: [
+			// Homebrew (Apple Silicon + Intel)
+			...homebrew('gh'),
+			// User local bin (manual install, pipx, etc.)
+			...localBin('gh'),
+			// Conda / Mamba
+			path.join(home, 'bin', 'gh'),
+			// Linuxbrew
+			'/home/linuxbrew/.linuxbrew/bin/gh',
 		],
 	};
 

--- a/src/main/agents/path-prober.ts
+++ b/src/main/agents/path-prober.ts
@@ -446,7 +446,7 @@ function getUnixKnownPaths(binaryName: string): string[] {
 			...homebrew('gh'),
 			// User local bin (manual install, pipx, etc.)
 			...localBin('gh'),
-			// Conda / Mamba
+			// User bin directory
 			path.join(home, 'bin', 'gh'),
 			// Linuxbrew
 			'/home/linuxbrew/.linuxbrew/bin/gh',

--- a/src/main/ipc/handlers/symphony.ts
+++ b/src/main/ipc/handlers/symphony.ts
@@ -20,6 +20,7 @@ import type { SessionsData, StoredSession, MaestroSettings } from '../../stores/
 import { createIpcHandler, CreateHandlerOptions } from '../../utils/ipcHandler';
 import { execFileNoThrow } from '../../utils/execFile';
 import { getExpandedEnv } from '../../agents/path-prober';
+import { resolveGhPath } from '../../utils/cliDetection';
 import { ensureForkSetup } from '../../utils/symphony-fork';
 import {
 	SYMPHONY_REGISTRY_URL,
@@ -730,7 +731,8 @@ async function createBranch(
  * Check if gh CLI is authenticated.
  */
 async function checkGhAuthentication(): Promise<{ authenticated: boolean; error?: string }> {
-	const result = await execFileNoThrow('gh', ['auth', 'status'], undefined, getExpandedEnv());
+	const ghCommand = await resolveGhPath();
+	const result = await execFileNoThrow(ghCommand, ['auth', 'status'], undefined, getExpandedEnv());
 	if (result.exitCode !== 0) {
 		// gh auth status outputs to stderr even on success for some info
 		const output = result.stderr + result.stdout;
@@ -847,7 +849,8 @@ async function createDraftPR(
 		prArgs.push('--repo', upstreamSlug);
 	}
 
-	const prResult = await execFileNoThrow('gh', prArgs, repoPath, getExpandedEnv());
+	const ghCommand = await resolveGhPath();
+	const prResult = await execFileNoThrow(ghCommand, prArgs, repoPath, getExpandedEnv());
 
 	if (prResult.exitCode !== 0) {
 		// If PR creation failed after push, try to delete the remote branch.
@@ -874,11 +877,12 @@ async function markPRReady(
 	prNumber: number,
 	upstreamSlug?: string
 ): Promise<{ success: boolean; error?: string }> {
+	const ghCommand = await resolveGhPath();
 	const args = ['pr', 'ready', String(prNumber)];
 	if (upstreamSlug) {
 		args.push('--repo', upstreamSlug);
 	}
-	const result = await execFileNoThrow('gh', args, repoPath, getExpandedEnv());
+	const result = await execFileNoThrow(ghCommand, args, repoPath, getExpandedEnv());
 
 	if (result.exitCode !== 0) {
 		return { success: false, error: result.stderr };
@@ -1001,11 +1005,12 @@ This pull request was created using [Maestro Symphony](https://runmaestro.ai/sym
 ---
 *Powered by [Maestro](https://runmaestro.ai) • [Learn about Symphony](https://docs.runmaestro.ai/symphony)*`;
 
+	const ghCommand = await resolveGhPath();
 	const commentArgs = ['pr', 'comment', String(prNumber), '--body', commentBody];
 	if (upstreamSlug) {
 		commentArgs.push('--repo', upstreamSlug);
 	}
-	const result = await execFileNoThrow('gh', commentArgs, repoPath, getExpandedEnv());
+	const result = await execFileNoThrow(ghCommand, commentArgs, repoPath, getExpandedEnv());
 
 	if (result.exitCode !== 0) {
 		return { success: false, error: result.stderr };

--- a/src/main/services/symphony-runner.ts
+++ b/src/main/services/symphony-runner.ts
@@ -9,6 +9,7 @@ import fs from 'fs/promises';
 import { logger } from '../utils/logger';
 import { execFileNoThrow } from '../utils/execFile';
 import { ensureForkSetup } from '../utils/symphony-fork';
+import { resolveGhPath } from '../utils/cliDetection';
 import type { DocumentReference } from '../../shared/symphony-types';
 import { PLAYBOOKS_DIR } from '../../shared/maestro-paths';
 
@@ -141,7 +142,8 @@ Closes #${issueNumber}
 		args.push('--head', `${forkOwner}:${branchName}`);
 	}
 
-	const result = await execFileNoThrow('gh', args, localPath);
+	const ghCommand = await resolveGhPath();
+	const result = await execFileNoThrow(ghCommand, args, localPath);
 
 	if (result.exitCode !== 0) {
 		return { success: false, error: `PR creation failed: ${result.stderr}` };
@@ -369,9 +371,10 @@ Processed all Auto Run documents for: ${issueTitle}`;
 	}
 
 	// Convert draft to ready for review
+	const ghCommand = await resolveGhPath();
 	const readyArgs = ['pr', 'ready', prNumber.toString()];
 	if (upstreamSlug) readyArgs.push('--repo', upstreamSlug);
-	const readyResult = await execFileNoThrow('gh', readyArgs, localPath);
+	const readyResult = await execFileNoThrow(ghCommand, readyArgs, localPath);
 	if (readyResult.exitCode !== 0) {
 		return { success: false, error: `Failed to mark PR ready: ${readyResult.stderr}` };
 	}
@@ -391,12 +394,12 @@ Closes #${issueNumber}
 
 	const editArgs = ['pr', 'edit', prNumber.toString(), '--body', body];
 	if (upstreamSlug) editArgs.push('--repo', upstreamSlug);
-	await execFileNoThrow('gh', editArgs, localPath);
+	await execFileNoThrow(ghCommand, editArgs, localPath);
 
 	// Get final PR URL
 	const viewArgs = ['pr', 'view', prNumber.toString(), '--json', 'url', '-q', '.url'];
 	if (upstreamSlug) viewArgs.push('--repo', upstreamSlug);
-	const prInfoResult = await execFileNoThrow('gh', viewArgs, localPath);
+	const prInfoResult = await execFileNoThrow(ghCommand, viewArgs, localPath);
 
 	return {
 		success: true,
@@ -414,6 +417,7 @@ export async function cancelContribution(
 	upstreamSlug?: string
 ): Promise<{ success: boolean; error?: string }> {
 	// Close the draft PR
+	const ghCommand = await resolveGhPath();
 	const closeArgs = ['pr', 'close', prNumber.toString()];
 	if (!upstreamSlug) {
 		// Only delete branch for non-fork PRs — cross-fork delete-branch fails due to permissions
@@ -421,7 +425,7 @@ export async function cancelContribution(
 	} else {
 		closeArgs.push('--repo', upstreamSlug);
 	}
-	const closeResult = await execFileNoThrow('gh', closeArgs, localPath);
+	const closeResult = await execFileNoThrow(ghCommand, closeArgs, localPath);
 	if (closeResult.exitCode !== 0) {
 		logger.warn('Failed to close PR', LOG_CONTEXT, { prNumber, error: closeResult.stderr });
 		return {

--- a/src/main/utils/execFile.ts
+++ b/src/main/utils/execFile.ts
@@ -52,6 +52,7 @@ export function needsWindowsShell(command: string): boolean {
 	// Use regex to handle both Unix (/) and Windows (\) path separators
 	const knownExeCommands = new Set([
 		'git',
+		'gh',
 		'node',
 		'npm',
 		'npx',

--- a/src/main/utils/symphony-fork.ts
+++ b/src/main/utils/symphony-fork.ts
@@ -1,6 +1,7 @@
 import { execFileNoThrow } from './execFile';
 import { logger } from './logger';
 import { getExpandedEnv } from '../agents/path-prober';
+import { resolveGhPath } from './cliDetection';
 
 const LOG_CONTEXT = '[SymphonyFork]';
 
@@ -20,10 +21,16 @@ export async function ensureForkSetup(
 	repoSlug: string
 ): Promise<ForkSetupResult> {
 	const env = getExpandedEnv();
+	const ghCommand = await resolveGhPath();
 
 	// 1. Get authenticated GitHub user
 	logger.info('Checking GitHub authentication', LOG_CONTEXT);
-	const userResult = await execFileNoThrow('gh', ['api', 'user', '--jq', '.login'], undefined, env);
+	const userResult = await execFileNoThrow(
+		ghCommand,
+		['api', 'user', '--jq', '.login'],
+		undefined,
+		env
+	);
 	if (userResult.exitCode !== 0) {
 		logger.error('GitHub CLI not authenticated', LOG_CONTEXT, { stderr: userResult.stderr });
 		return { isFork: false, error: 'GitHub CLI not authenticated' };
@@ -40,7 +47,7 @@ export async function ensureForkSetup(
 	// 3. Check push access
 	logger.info(`Checking push access to ${repoSlug}`, LOG_CONTEXT);
 	const accessResult = await execFileNoThrow(
-		'gh',
+		ghCommand,
 		['api', `repos/${repoSlug}`, '--jq', '.permissions.push'],
 		undefined,
 		env
@@ -53,7 +60,7 @@ export async function ensureForkSetup(
 	// 4. Fork the repo (idempotent)
 	logger.info(`Forking ${repoSlug}`, LOG_CONTEXT);
 	const forkResult = await execFileNoThrow(
-		'gh',
+		ghCommand,
 		['repo', 'fork', repoSlug, '--clone=false'],
 		undefined,
 		env
@@ -72,7 +79,7 @@ export async function ensureForkSetup(
 	const forkSlug = `${ghUser}/${repoName}`;
 	logger.info(`Getting clone URL for ${forkSlug}`, LOG_CONTEXT);
 	const urlResult = await execFileNoThrow(
-		'gh',
+		ghCommand,
 		['api', `repos/${forkSlug}`, '--jq', '.clone_url'],
 		undefined,
 		env

--- a/src/shared/pathUtils.ts
+++ b/src/shared/pathUtils.ts
@@ -362,6 +362,8 @@ export function buildExpandedPath(customPaths?: string[]): string {
 			path.join(process.env.ChocolateyInstall || 'C:\\ProgramData\\chocolatey', 'bin'),
 			// Go binaries
 			path.join(home, 'go', 'bin'),
+			// GitHub CLI (official MSI installer)
+			path.join(programFiles, 'GitHub CLI'),
 			// Windows system paths
 			path.join(systemRoot, 'System32'),
 			path.join(systemRoot),
@@ -381,6 +383,7 @@ export function buildExpandedPath(customPaths?: string[]): string {
 			`${home}/bin`, // User bin directory
 			`${home}/.claude/local`, // Claude local install location
 			`${home}/.opencode/bin`, // OpenCode installer default location
+			'/home/linuxbrew/.linuxbrew/bin', // Linuxbrew
 			'/usr/bin',
 			'/bin',
 			'/usr/sbin',


### PR DESCRIPTION
## Summary
- Add `gh` to `knownExeCommands` in `execFile.ts` so Windows doesn't force unnecessary shell execution
- Add `gh` known installation paths for Windows (MSI installer, Winget, Scoop, Chocolatey) and Unix (Homebrew, local bin, Linuxbrew) to the path prober
- Add GitHub CLI MSI install directory to the expanded env PATH
- Replace all bare `'gh'` calls in `symphony-fork.ts`, `symphony-runner.ts`, and `symphony.ts` IPC handler with `resolveGhPath()` — matching the pattern already used by `git.ts` and `cue-github-poller.ts`
- Update test mocks for `cliDetection` in affected test files

## Context
Symphony features called `execFileNoThrow('gh', ...)` directly, bypassing the existing `resolveGhPath()` utility from `cliDetection.ts`. This meant `gh` CLI was not found when installed in non-standard locations because:
1. `gh` was missing from `knownExeCommands`, forcing shell execution on Windows
2. No known installation paths existed for `gh` in the path prober
3. The detection/caching infrastructure in `cliDetection.ts` was unused by Symphony

Other features like `git.ts` IPC handlers and the Cue GitHub poller already used `resolveGhPath()` correctly.

## Test plan
- [x] All existing `execFile.ts` tests pass (27/27)
- [x] All existing `path-prober.ts` tests pass (24/24)
- [x] All existing `symphony-fork.ts` tests pass (9/9)
- [x] All existing `symphony-runner.ts` tests pass (71/71)
- [x] All existing `symphony.ts` IPC handler tests pass (219/219)
- [x] TypeScript type-check passes (`tsconfig.main.json`, `tsconfig.lint.json`, `tsconfig.cli.json`)
- [x] Pre-commit hooks (prettier + eslint) pass on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Broader GitHub CLI detection across common install methods on Windows and Unix for more reliable CLI usage.

* **Bug Fixes**
  * CLI invocations now dynamically use the detected gh executable and run without an unnecessary shell on Windows, improving consistency and reliability.

* **Tests**
  * Added test mocks to stabilize CLI-related test behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->