### PR TITLE
fix: Group chat: Plan mode can not be exited #602

### DIFF
--- a/src/main/group-chat/group-chat-router.ts
+++ b/src/main/group-chat/group-chat-router.ts
@@ -479,7 +479,10 @@ ${participantContext}${availableSessionsContext}
 ${historyContext}
 
 ## User Request${readOnly ? ' (READ-ONLY MODE - do not make changes)' : ''}:
-${message}${imageContext}`;
+${message}${imageContext}
+
+## Execution Mode:
+${readOnly ? 'READ-ONLY MODE is active. You and all participants can only inspect, analyze, and plan — no file changes allowed.' : 'Participants have FULL READ-WRITE access and can create, modify, and delete files. You are in read-only/plan mode yourself, so delegate all file changes to participants. When the user asks for implementation, specs, or file creation, delegate those tasks to the appropriate participants — they can execute.'}`;
 
 			// Get the base args from the agent configuration
 			const args = [...agent.args];
@@ -516,7 +519,9 @@ ${message}${imageContext}`;
 			console.log(`[GroupChat:Debug] Tool Type: ${chat.moderatorAgentId}`);
 			console.log(`[GroupChat:Debug] CWD: ${os.homedir()}`);
 			console.log(`[GroupChat:Debug] Command: ${command}`);
-			console.log(`[GroupChat:Debug] ReadOnly: true`);
+			console.log(
+				`[GroupChat:Debug] ReadOnly: true (moderator always read-only), participants readOnly: ${readOnly ?? false}`
+			);
 
 			// Spawn the moderator process in batch mode
 			try {


### PR DESCRIPTION
Fix for Group chat: Plan mode can not be exited #602

<img width="1836" height="1138" alt="readonly off" src="https://github.com/user-attachments/assets/689b2daf-94a8-4b19-8919-e980ca24aeb8" />
<img width="1836" height="1138" alt="readonly on" src="https://github.com/user-attachments/assets/47edef9c-e981-4691-9064-01b3ecf42817" />
<img width="1512" height="1012" alt="file created" src="https://github.com/user-attachments/assets/b0686370-89ad-49a0-b5a9-7ea59d9bb101" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Features**
  * Group chat moderator now clarifies execution modes based on settings. When read-only, participants can inspect and plan without file modifications; when enabled, participants gain full read-write access for executing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->