### PR TITLE
feat: add GitHub Copilot CLI as first-class agent

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,134 @@
+# Copilot Instructions for Maestro
+
+Maestro is an Electron desktop app for orchestrating multiple AI coding agents (Claude Code, Codex, OpenCode, Factory Droid) with a keyboard-first interface. It uses a dual-process architecture (main + renderer) with strict context isolation.
+
+## Build, Test, and Lint
+
+```bash
+npm run dev              # Dev with hot reload (isolated data, safe alongside production)
+npm run build            # Full production build (main + renderer + web + CLI)
+npm run lint             # TypeScript type checking (renderer, main, cli configs)
+npm run lint:eslint      # ESLint code quality
+npm run test             # Run all unit tests (vitest)
+npm run test:watch       # Watch mode
+npm run format:check     # Check Prettier formatting
+npm run validate:push    # Full pre-push validation (format + lint + eslint + test)
+```
+
+Run a single test file:
+```bash
+npx vitest run src/__tests__/path/to/file.test.ts
+```
+
+Run tests matching a name pattern:
+```bash
+npx vitest run -t "pattern"
+```
+
+Other test suites:
+```bash
+npm run test:e2e           # Playwright end-to-end (requires build first)
+npm run test:integration   # Integration tests
+npm run test:performance   # Performance tests
+```
+
+## Architecture
+
+### Dual-Process (Electron)
+
+- **Main process** (`src/main/`): Node.js backend — process spawning (PTY via `node-pty`), IPC handlers, agent detection, session storage, SQLite via `better-sqlite3`.
+- **Renderer** (`src/renderer/`): React frontend — no Node.js access. Communicates via `window.maestro.*` IPC bridge defined in `preload.ts`.
+- **Preload** (`src/main/preload.ts`): Secure IPC bridge via `contextBridge`. All new IPC must go through here.
+- **Shared** (`src/shared/`): Types and utilities shared across processes.
+- **CLI** (`src/cli/`): Standalone CLI tool (`maestro-cli`) for headless batch automation.
+- **Web** (`src/web/`): Mobile-optimized React app for remote control.
+
+### Agent Model
+
+Each agent runs **two processes simultaneously**: an AI process (suffixed `-ai`) and a terminal process (suffixed `-terminal`). The `Session` interface in code represents an agent (historical naming). Use "agent" in user-facing language; reserve "session" for provider-level conversation contexts.
+
+### IPC Pattern
+
+To add a new IPC capability:
+1. Add handler in `src/main/index.ts` via `ipcMain.handle('namespace:action', ...)`
+2. Expose in `src/main/preload.ts` via `ipcRenderer.invoke()`
+3. Add types to `MaestroAPI` interface in preload.ts
+
+### Key Entry Points
+
+| Task | Files |
+|------|-------|
+| IPC handlers | `src/main/index.ts`, `src/main/preload.ts` |
+| Keyboard shortcuts | `src/renderer/constants/shortcuts.ts`, `App.tsx` |
+| Settings | `src/renderer/hooks/useSettings.ts` |
+| Themes | `src/renderer/constants/themes.ts`, `src/shared/theme-types.ts` |
+| Modal priorities | `src/renderer/constants/modalPriorities.ts` |
+| Agent definitions | `src/shared/agentIds.ts`, `src/main/agents/definitions.ts`, `src/main/agents/capabilities.ts` |
+| Output parsers | `src/main/parsers/`, `src/main/parsers/index.ts` |
+| System prompts | `src/prompts/*.md` |
+
+## Code Conventions
+
+### Formatting & Style
+
+- **Tabs for indentation** in TypeScript/JavaScript (not spaces). JSON/YAML use 2-space indent.
+- Prettier config: tabs, single quotes, trailing commas (es5), 100 char print width.
+- Husky pre-commit hooks auto-format staged files.
+
+### TypeScript
+
+- Strict mode enabled across all configs (`tsconfig.json`, `tsconfig.main.json`, `tsconfig.cli.json`).
+- Three separate tsconfig files: renderer/web/shared, main process, and CLI.
+- `@typescript-eslint/no-explicit-any` is currently `off` (legacy; avoid adding new `any`).
+- `react-hooks/exhaustive-deps` is intentionally `off` — this codebase uses refs to access latest values without causing re-renders.
+
+### React & UI
+
+- Functional components with hooks only.
+- Use Tailwind for layout, **inline styles for theme colors** (e.g., `style={{ color: theme.colors.textMain }}`). Never hardcode hex colors for themed elements.
+- Modals must register with the LayerStack system (don't handle Escape locally).
+- Focus management: use `tabIndex={-1}` + `outline-none` for programmatic focus.
+
+### Settings Pattern
+
+New settings follow a wrapper function pattern:
+1. State with `useState` in `useSettings.ts`
+2. Wrapper function that updates state AND calls `window.maestro.settings.set()`
+3. Load in `useEffect` from `window.maestro.settings.get()`
+
+### Error Handling
+
+- Let unexpected exceptions bubble up — Sentry captures them automatically.
+- Handle only expected/recoverable errors explicitly; re-throw unexpected ones.
+- Use `captureException`/`captureMessage` from `src/main/utils/sentry.ts` for explicit reporting.
+- Use `execFileNoThrow` for external commands (never shell-based execution).
+- Always `spawn()` with `shell: false`.
+
+### SSH Remote Execution
+
+Any feature spawning agent processes **must** support SSH remote execution:
+1. Check `session.sshRemoteConfig?.enabled`
+2. Use `wrapSpawnWithSsh()` from `src/main/utils/ssh-spawn-wrapper.ts`
+3. Use agent's `binaryName` for remote execution (not local paths)
+4. Don't hardcode `claude-code` — respect the configured agent type
+
+### Commit Messages
+
+Use conventional commits: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`.
+
+### Branching
+
+- `main` = stable (odd minor versions, e.g., 0.15.x)
+- `rc` = pre-release (even minor versions, e.g., 0.16.x)
+- Bug fixes → `main`. New features → `rc`.
+
+## Performance
+
+- Memoize expensive computations with `useMemo`; use Maps for O(1) lookups instead of `Array.find()`.
+- Batch IPC calls; use `useBatchedSessionUpdates` for high-frequency updates.
+- Prefer 3-second intervals over 1-second for non-critical polling. Use event-driven updates via IPC when possible.
+- Clean up all timers, event listeners, and subscriptions in `useEffect` cleanup.
+
+## Encore Features (Feature Gating)
+
+Optional features disabled by default. When disabled, they must be completely invisible (no shortcuts, no menu items). Pattern: add flag to `EncoreFeatureFlags` in `src/renderer/types/index.ts`, default to `false` in `useSettings.ts`, gate all UI access points.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -16,16 +16,19 @@ npm run validate:push    # Full pre-push validation (format + lint + eslint + te
 ```
 
 Run a single test file:
+
 ```bash
 npx vitest run src/__tests__/path/to/file.test.ts
 ```
 
 Run tests matching a name pattern:
+
 ```bash
 npx vitest run -t "pattern"
 ```
 
 Other test suites:
+
 ```bash
 npm run test:e2e           # Playwright end-to-end (requires build first)
 npm run test:integration   # Integration tests
@@ -50,22 +53,23 @@ Each agent runs **two processes simultaneously**: an AI process (suffixed `-ai`)
 ### IPC Pattern
 
 To add a new IPC capability:
+
 1. Add handler in `src/main/index.ts` via `ipcMain.handle('namespace:action', ...)`
 2. Expose in `src/main/preload.ts` via `ipcRenderer.invoke()`
 3. Add types to `MaestroAPI` interface in preload.ts
 
 ### Key Entry Points
 
-| Task | Files |
-|------|-------|
-| IPC handlers | `src/main/index.ts`, `src/main/preload.ts` |
-| Keyboard shortcuts | `src/renderer/constants/shortcuts.ts`, `App.tsx` |
-| Settings | `src/renderer/hooks/useSettings.ts` |
-| Themes | `src/renderer/constants/themes.ts`, `src/shared/theme-types.ts` |
-| Modal priorities | `src/renderer/constants/modalPriorities.ts` |
-| Agent definitions | `src/shared/agentIds.ts`, `src/main/agents/definitions.ts`, `src/main/agents/capabilities.ts` |
-| Output parsers | `src/main/parsers/`, `src/main/parsers/index.ts` |
-| System prompts | `src/prompts/*.md` |
+| Task               | Files                                                                                         |
+| ------------------ | --------------------------------------------------------------------------------------------- |
+| IPC handlers       | `src/main/index.ts`, `src/main/preload.ts`                                                    |
+| Keyboard shortcuts | `src/renderer/constants/shortcuts.ts`, `App.tsx`                                              |
+| Settings           | `src/renderer/hooks/useSettings.ts`                                                           |
+| Themes             | `src/renderer/constants/themes.ts`, `src/shared/theme-types.ts`                               |
+| Modal priorities   | `src/renderer/constants/modalPriorities.ts`                                                   |
+| Agent definitions  | `src/shared/agentIds.ts`, `src/main/agents/definitions.ts`, `src/main/agents/capabilities.ts` |
+| Output parsers     | `src/main/parsers/`, `src/main/parsers/index.ts`                                              |
+| System prompts     | `src/prompts/*.md`                                                                            |
 
 ## Code Conventions
 
@@ -92,6 +96,7 @@ To add a new IPC capability:
 ### Settings Pattern
 
 New settings follow a wrapper function pattern:
+
 1. State with `useState` in `useSettings.ts`
 2. Wrapper function that updates state AND calls `window.maestro.settings.set()`
 3. Load in `useEffect` from `window.maestro.settings.get()`
@@ -107,6 +112,7 @@ New settings follow a wrapper function pattern:
 ### SSH Remote Execution
 
 Any feature spawning agent processes **must** support SSH remote execution:
+
 1. Check `session.sshRemoteConfig?.enabled`
 2. Use `wrapSpawnWithSsh()` from `src/main/utils/ssh-spawn-wrapper.ts`
 3. Use agent's `binaryName` for remote execution (not local paths)

--- a/docs/Copilot-CLI-Phase2-Plan.md
+++ b/docs/Copilot-CLI-Phase2-Plan.md
@@ -5,6 +5,7 @@ Use this document to kick off a new session once Phase 1 (core agent integration
 ## Prerequisite: Verify Phase 1
 
 Before starting Phase 2, confirm these work:
+
 1. `copilot` binary detected in Settings → AI Agents
 2. Creating a new Copilot CLI agent session succeeds
 3. Sending a message produces output (parsed from JSONL)
@@ -37,11 +38,13 @@ Update `CopilotCliRawMessage` interface and `transformMessage()` method to match
 **Goal**: Enable browsing/resuming past sessions from the Right Bar.
 
 **Files**:
+
 - New: `src/main/storage/copilot-cli-session-storage.ts`
 - Edit: `src/main/storage/index.ts` — register `CopilotCliSessionStorage`
 - Edit: `src/main/agents/capabilities.ts` — set `supportsSessionStorage: true`
 
 **Implementation**:
+
 1. Investigate session file format at `~/.copilot/session-state/` (may also be `~/.copilot/sessions/`)
 2. Extend `BaseSessionStorage` from `src/main/storage/base-session-storage.ts`
 3. Implement required methods:
@@ -60,10 +63,12 @@ Update `CopilotCliRawMessage` interface and `transformMessage()` method to match
 **Goal**: Show token counts and cost in the UI (MainPanel token display, cost widget).
 
 **Files**:
+
 - Edit: `src/main/parsers/copilot-cli-output-parser.ts` — refine `extractUsageFromRaw()`
 - Edit: `src/main/agents/capabilities.ts` — set `supportsUsageStats: true`, `supportsCostTracking: true`
 
 **Implementation**:
+
 1. From the JSON schema investigation, identify which event carries usage data
 2. Map fields to `ParsedEvent.usage` (inputTokens, outputTokens, cacheReadTokens, costUsd)
 3. If Copilot CLI doesn't report cost directly, leave `supportsCostTracking: false` and only enable `supportsUsageStats: true`
@@ -76,10 +81,12 @@ Update `CopilotCliRawMessage` interface and `transformMessage()` method to match
 **Goal**: Show model reasoning/thinking content in the AI Terminal.
 
 **Files**:
+
 - Edit: `src/main/parsers/copilot-cli-output-parser.ts`
 - Edit: `src/main/agents/capabilities.ts` — set `supportsThinkingDisplay: true`
 
 **Implementation**:
+
 1. Check if Copilot CLI JSON output includes reasoning/thinking tokens (separate from main content)
 2. If yes: emit them as `type: 'text'` with `isPartial: true` (like Codex reasoning items)
 3. If no: leave `supportsThinkingDisplay: false`
@@ -91,10 +98,12 @@ Update `CopilotCliRawMessage` interface and `transformMessage()` method to match
 **Goal**: Restrict the agent to read-only operations for safe analysis.
 
 **Files**:
+
 - Edit: `src/main/agents/definitions.ts` — set `readOnlyArgs` and `readOnlyCliEnforced`
 - Edit: `src/main/agents/capabilities.ts` — set `supportsReadOnlyMode: true`
 
 **Implementation**:
+
 1. Test: `copilot -p "prompt" --deny-tool=write --deny-tool=create --deny-tool=apply_patch --output-format json`
 2. If this reliably prevents file modifications, update the definition:
    ```typescript
@@ -110,10 +119,12 @@ Update `CopilotCliRawMessage` interface and `transformMessage()` method to match
 **Goal**: Allow attaching images/screenshots to prompts.
 
 **Files**:
+
 - Edit: `src/main/agents/definitions.ts` — add `imageArgs`
 - Edit: `src/main/agents/capabilities.ts` — set `supportsImageInput: true`
 
 **Implementation**:
+
 1. Check if Copilot CLI supports image input via `@ filename.png` or a flag like `-i`
 2. If supported via a flag: add `imageArgs: (imagePath: string) => ['--flag', imagePath]`
 3. If supported via stdin/stream-json: set `supportsStreamJsonInput: true` and add `--input-format stream-json` handling
@@ -126,9 +137,11 @@ Update `CopilotCliRawMessage` interface and `transformMessage()` method to match
 **Goal**: Enable inline wizard (structured output conversations) with Copilot CLI.
 
 **Files**:
+
 - Edit: `src/main/agents/capabilities.ts` — set `supportsWizard: true`
 
 **Implementation**:
+
 1. Test sending a structured wizard prompt to Copilot CLI
 2. Verify the agent follows the structured output format (numbered steps, clear sections)
 3. If output quality is sufficient: enable `supportsWizard: true`
@@ -141,9 +154,11 @@ Update `CopilotCliRawMessage` interface and `transformMessage()` method to match
 **Goal**: Allow Copilot CLI agents to serve as group chat moderators.
 
 **Files**:
+
 - Edit: `src/main/agents/capabilities.ts` — set `supportsGroupChatModeration: true`
 
 **Implementation**:
+
 1. Test group chat with Copilot CLI as moderator
 2. Verify it can coordinate between agents, route questions, and synthesize responses
 3. Group chat uses prompt-based coordination, so no code changes needed if quality is sufficient
@@ -155,9 +170,11 @@ Update `CopilotCliRawMessage` interface and `transformMessage()` method to match
 **Goal**: Allow exporting Copilot CLI session context for transfer to other agents.
 
 **Files**:
+
 - Edit: `src/main/agents/capabilities.ts` — set `supportsContextExport: true`
 
 **Implementation**:
+
 - Depends on session storage being implemented first
 - Context export reads session messages and formats them for another agent
 - Once `CopilotCliSessionStorage.readSessionMessages()` works, enable this flag
@@ -169,10 +186,12 @@ Update `CopilotCliRawMessage` interface and `transformMessage()` method to match
 **Goal**: Detect when the agent has finished its response for Auto Run sequencing.
 
 **Files**:
+
 - Edit: `src/main/parsers/copilot-cli-output-parser.ts` — refine `isResultMessage()`
 - Edit: `src/main/agents/capabilities.ts` — set `supportsResultMessages: true`
 
 **Implementation**:
+
 1. From JSON schema investigation, identify the completion signal
 2. Update `transformMessage()` to emit `type: 'result'` for the correct event type
 3. Update `isResultMessage()` to match
@@ -181,26 +200,26 @@ Update `CopilotCliRawMessage` interface and `transformMessage()` method to match
 
 ## Capability Parity Matrix
 
-| Capability | Claude Code | Codex | OpenCode | Factory Droid | Copilot CLI (Phase 1) | Copilot CLI (Target) |
-|---|:---:|:---:|:---:|:---:|:---:|:---:|
-| Resume | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Read-Only | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ |
-| JSON Output | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Session ID | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Image Input | ✅ | ✅ | ✅ | ✅ | ❌ | ❓ |
-| Slash Commands | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ |
-| Session Storage | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Cost Tracking | ✅ | ❌ | ✅ | ❌ | ❌ | ❓ |
-| Usage Stats | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Batch Mode | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Streaming | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Result Messages | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ |
-| Model Selection | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Thinking Display | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ |
-| Context Merge | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Context Export | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ |
-| Wizard | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ |
-| Group Chat Mod | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ |
+| Capability       | Claude Code | Codex | OpenCode | Factory Droid | Copilot CLI (Phase 1) | Copilot CLI (Target) |
+| ---------------- | :---------: | :---: | :------: | :-----------: | :-------------------: | :------------------: |
+| Resume           |     ✅      |  ✅   |    ✅    |      ✅       |          ✅           |          ✅          |
+| Read-Only        |     ✅      |  ✅   |    ✅    |      ✅       |          ❌           |          ✅          |
+| JSON Output      |     ✅      |  ✅   |    ✅    |      ✅       |          ✅           |          ✅          |
+| Session ID       |     ✅      |  ✅   |    ✅    |      ✅       |          ✅           |          ✅          |
+| Image Input      |     ✅      |  ✅   |    ✅    |      ✅       |          ❌           |          ❓          |
+| Slash Commands   |     ✅      |  ❌   |    ❌    |      ❌       |          ✅           |          ✅          |
+| Session Storage  |     ✅      |  ✅   |    ✅    |      ✅       |          ✅           |          ✅          |
+| Cost Tracking    |     ✅      |  ❌   |    ✅    |      ❌       |          ❌           |          ❓          |
+| Usage Stats      |     ✅      |  ✅   |    ✅    |      ✅       |          ✅           |          ✅          |
+| Batch Mode       |     ✅      |  ✅   |    ✅    |      ✅       |          ✅           |          ✅          |
+| Streaming        |     ✅      |  ✅   |    ✅    |      ✅       |          ✅           |          ✅          |
+| Result Messages  |     ✅      |  ❌   |    ✅    |      ✅       |          ✅           |          ✅          |
+| Model Selection  |     ❌      |  ✅   |    ✅    |      ✅       |          ✅           |          ✅          |
+| Thinking Display |     ✅      |  ✅   |    ✅    |      ✅       |          ❌           |          ✅          |
+| Context Merge    |     ✅      |  ✅   |    ✅    |      ✅       |          ✅           |          ✅          |
+| Context Export   |     ✅      |  ✅   |    ✅    |      ✅       |          ❌           |          ✅          |
+| Wizard           |     ✅      |  ✅   |    ✅    |      ❌       |          ❌           |          ✅          |
+| Group Chat Mod   |     ✅      |  ✅   |    ✅    |      ✅       |          ❌           |          ✅          |
 
 ❓ = depends on CLI capability (needs investigation)
 

--- a/docs/Copilot-CLI-Phase2-Plan.md
+++ b/docs/Copilot-CLI-Phase2-Plan.md
@@ -1,0 +1,220 @@
+# Copilot CLI Phase 2: Full Parity Plan
+
+Use this document to kick off a new session once Phase 1 (core agent integration) is verified working. Phase 1 code is already merged — the agent ID, definition, capabilities, output parser, and error patterns are in place.
+
+## Prerequisite: Verify Phase 1
+
+Before starting Phase 2, confirm these work:
+1. `copilot` binary detected in Settings → AI Agents
+2. Creating a new Copilot CLI agent session succeeds
+3. Sending a message produces output (parsed from JSONL)
+4. Session resume via `--resume SESSION-ID` works
+5. Model selection via config option works
+
+If the JSONL output schema doesn't match the parser's assumptions, **fix the parser first** — see "JSON Schema Investigation" below.
+
+---
+
+## JSON Schema Investigation (Do This First)
+
+Run: `copilot -p "Say hello in one sentence" --output-format json --allow-all`
+
+Capture the full output and document the actual JSONL event types. The parser in `src/main/parsers/copilot-cli-output-parser.ts` uses heuristic type matching. Refine it to match the actual schema:
+
+1. What event type contains the session ID? (e.g., `session.started`, `init`, `thread.started`)
+2. What event type contains streaming text? (e.g., `content.delta`, `assistant.message`, `text`)
+3. What event type contains tool calls? (e.g., `tool_use`, `tool.started`, `tool.completed`)
+4. What event type contains usage stats? (e.g., `usage`, `turn.completed`, `stats`)
+5. What event type signals completion? (e.g., `result`, `complete`, `done`)
+6. How are errors structured? (e.g., `{ type: "error", error: { message: "..." } }`)
+
+Update `CopilotCliRawMessage` interface and `transformMessage()` method to match.
+
+---
+
+## Todo: Session Storage Browser
+
+**Goal**: Enable browsing/resuming past sessions from the Right Bar.
+
+**Files**:
+- New: `src/main/storage/copilot-cli-session-storage.ts`
+- Edit: `src/main/storage/index.ts` — register `CopilotCliSessionStorage`
+- Edit: `src/main/agents/capabilities.ts` — set `supportsSessionStorage: true`
+
+**Implementation**:
+1. Investigate session file format at `~/.copilot/session-state/` (may also be `~/.copilot/sessions/`)
+2. Extend `BaseSessionStorage` from `src/main/storage/base-session-storage.ts`
+3. Implement required methods:
+   - `listSessions(projectPath, options)` — list session files, extract metadata (title, date, agent)
+   - `readSessionMessages(projectPath, sessionId, options)` — parse session file into `SessionMessage[]`
+   - `searchSessions(projectPath, query)` — search session content
+   - `getGlobalStats()` — aggregate usage statistics (optional)
+4. Register in `initializeSessionStorages()` in `src/main/storage/index.ts`
+
+**Reference**: Follow `codex-session-storage.ts` or `factory-droid-session-storage.ts` patterns.
+
+---
+
+## Todo: Usage Stats & Cost Tracking
+
+**Goal**: Show token counts and cost in the UI (MainPanel token display, cost widget).
+
+**Files**:
+- Edit: `src/main/parsers/copilot-cli-output-parser.ts` — refine `extractUsageFromRaw()`
+- Edit: `src/main/agents/capabilities.ts` — set `supportsUsageStats: true`, `supportsCostTracking: true`
+
+**Implementation**:
+1. From the JSON schema investigation, identify which event carries usage data
+2. Map fields to `ParsedEvent.usage` (inputTokens, outputTokens, cacheReadTokens, costUsd)
+3. If Copilot CLI doesn't report cost directly, leave `supportsCostTracking: false` and only enable `supportsUsageStats: true`
+4. Context window: parse from JSON events if reported, otherwise use the user's configured value
+
+---
+
+## Todo: Thinking/Reasoning Display
+
+**Goal**: Show model reasoning/thinking content in the AI Terminal.
+
+**Files**:
+- Edit: `src/main/parsers/copilot-cli-output-parser.ts`
+- Edit: `src/main/agents/capabilities.ts` — set `supportsThinkingDisplay: true`
+
+**Implementation**:
+1. Check if Copilot CLI JSON output includes reasoning/thinking tokens (separate from main content)
+2. If yes: emit them as `type: 'text'` with `isPartial: true` (like Codex reasoning items)
+3. If no: leave `supportsThinkingDisplay: false`
+
+---
+
+## Todo: Read-Only Mode
+
+**Goal**: Restrict the agent to read-only operations for safe analysis.
+
+**Files**:
+- Edit: `src/main/agents/definitions.ts` — set `readOnlyArgs` and `readOnlyCliEnforced`
+- Edit: `src/main/agents/capabilities.ts` — set `supportsReadOnlyMode: true`
+
+**Implementation**:
+1. Test: `copilot -p "prompt" --deny-tool=write --deny-tool=create --deny-tool=apply_patch --output-format json`
+2. If this reliably prevents file modifications, update the definition:
+   ```typescript
+   readOnlyArgs: ['--deny-tool=write', '--deny-tool=create', '--deny-tool=apply_patch'],
+   readOnlyCliEnforced: true,
+   ```
+3. If `--deny-tool` doesn't work for read-only, use prompt-only enforcement (leave `readOnlyCliEnforced: false`)
+
+---
+
+## Todo: Image Input
+
+**Goal**: Allow attaching images/screenshots to prompts.
+
+**Files**:
+- Edit: `src/main/agents/definitions.ts` — add `imageArgs`
+- Edit: `src/main/agents/capabilities.ts` — set `supportsImageInput: true`
+
+**Implementation**:
+1. Check if Copilot CLI supports image input via `@ filename.png` or a flag like `-i`
+2. If supported via a flag: add `imageArgs: (imagePath: string) => ['--flag', imagePath]`
+3. If supported via stdin/stream-json: set `supportsStreamJsonInput: true` and add `--input-format stream-json` handling
+4. If not supported: leave `supportsImageInput: false`
+
+---
+
+## Todo: Wizard Support
+
+**Goal**: Enable inline wizard (structured output conversations) with Copilot CLI.
+
+**Files**:
+- Edit: `src/main/agents/capabilities.ts` — set `supportsWizard: true`
+
+**Implementation**:
+1. Test sending a structured wizard prompt to Copilot CLI
+2. Verify the agent follows the structured output format (numbered steps, clear sections)
+3. If output quality is sufficient: enable `supportsWizard: true`
+4. The wizard system is prompt-driven, so no code changes are needed if the agent handles prompts well
+
+---
+
+## Todo: Group Chat Moderation
+
+**Goal**: Allow Copilot CLI agents to serve as group chat moderators.
+
+**Files**:
+- Edit: `src/main/agents/capabilities.ts` — set `supportsGroupChatModeration: true`
+
+**Implementation**:
+1. Test group chat with Copilot CLI as moderator
+2. Verify it can coordinate between agents, route questions, and synthesize responses
+3. Group chat uses prompt-based coordination, so no code changes needed if quality is sufficient
+
+---
+
+## Todo: Context Export
+
+**Goal**: Allow exporting Copilot CLI session context for transfer to other agents.
+
+**Files**:
+- Edit: `src/main/agents/capabilities.ts` — set `supportsContextExport: true`
+
+**Implementation**:
+- Depends on session storage being implemented first
+- Context export reads session messages and formats them for another agent
+- Once `CopilotCliSessionStorage.readSessionMessages()` works, enable this flag
+
+---
+
+## Todo: Result Messages
+
+**Goal**: Detect when the agent has finished its response for Auto Run sequencing.
+
+**Files**:
+- Edit: `src/main/parsers/copilot-cli-output-parser.ts` — refine `isResultMessage()`
+- Edit: `src/main/agents/capabilities.ts` — set `supportsResultMessages: true`
+
+**Implementation**:
+1. From JSON schema investigation, identify the completion signal
+2. Update `transformMessage()` to emit `type: 'result'` for the correct event type
+3. Update `isResultMessage()` to match
+
+---
+
+## Capability Parity Matrix
+
+| Capability | Claude Code | Codex | OpenCode | Factory Droid | Copilot CLI (Phase 1) | Copilot CLI (Target) |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|
+| Resume | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Read-Only | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ |
+| JSON Output | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Session ID | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Image Input | ✅ | ✅ | ✅ | ✅ | ❌ | ❓ |
+| Slash Commands | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ |
+| Session Storage | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ |
+| Cost Tracking | ✅ | ❌ | ✅ | ❌ | ❌ | ❓ |
+| Usage Stats | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ |
+| Batch Mode | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Streaming | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Result Messages | ✅ | ❌ | ✅ | ✅ | ❌ | ✅ |
+| Model Selection | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Thinking Display | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ |
+| Context Merge | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Context Export | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ |
+| Wizard | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ |
+| Group Chat Mod | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ |
+
+❓ = depends on CLI capability (needs investigation)
+
+---
+
+## Suggested Order of Work
+
+1. **JSON Schema Investigation** — must be first; everything else depends on it
+2. **Parser Refinement** — fix parser to match actual schema
+3. **Usage Stats** — quick win, high visibility
+4. **Result Messages** — needed for Auto Run to work properly
+5. **Session Storage** — enables session browsing in Right Bar
+6. **Read-Only Mode** — safety feature
+7. **Thinking Display** — nice-to-have
+8. **Image Input** — if supported by CLI
+9. **Context Export** — depends on session storage
+10. **Wizard + Group Chat** — quality-dependent, test and enable

--- a/docs/Copilot-CLI-Phase2-Plan.md
+++ b/docs/Copilot-CLI-Phase2-Plan.md
@@ -189,12 +189,12 @@ Update `CopilotCliRawMessage` interface and `transformMessage()` method to match
 | Session ID | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Image Input | ✅ | ✅ | ✅ | ✅ | ❌ | ❓ |
 | Slash Commands | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ |
-| Session Storage | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ |
+| Session Storage | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Cost Tracking | ✅ | ❌ | ✅ | ❌ | ❌ | ❓ |
-| Usage Stats | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ |
+| Usage Stats | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Batch Mode | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Streaming | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Result Messages | ✅ | ❌ | ✅ | ✅ | ❌ | ✅ |
+| Result Messages | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ |
 | Model Selection | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Thinking Display | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ |
 | Context Merge | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |

--- a/package-lock.json
+++ b/package-lock.json
@@ -264,7 +264,6 @@
 			"integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.27.1",
 				"@babel/generator": "^7.28.5",
@@ -668,7 +667,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			},
@@ -712,7 +710,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -2286,7 +2283,6 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
 			"integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"engines": {
 				"node": ">=8.0.0"
 			}
@@ -2308,7 +2304,6 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.2.0.tgz",
 			"integrity": "sha512-qRkLWiUEZNAmYapZ7KGS5C4OmBLcP/H2foXeOEaowYCR0wi89fHejrfYfbuLVCMLp/dWZXKvQusdbUEZjERfwQ==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"engines": {
 				"node": "^18.19.0 || >=20.6.0"
 			},
@@ -2321,7 +2316,6 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
 			"integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@opentelemetry/semantic-conventions": "^1.29.0"
 			},
@@ -2337,7 +2331,6 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.208.0.tgz",
 			"integrity": "sha512-Eju0L4qWcQS+oXxi6pgh7zvE2byogAkcsVv0OjHF/97iOz1N/aKE6etSGowYkie+YA1uo6DNwdSxaaNnLvcRlA==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@opentelemetry/api-logs": "0.208.0",
 				"import-in-the-middle": "^2.0.0",
@@ -2725,7 +2718,6 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
 			"integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@opentelemetry/core": "2.2.0",
 				"@opentelemetry/semantic-conventions": "^1.29.0"
@@ -2742,7 +2734,6 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.2.0.tgz",
 			"integrity": "sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@opentelemetry/core": "2.2.0",
 				"@opentelemetry/resources": "2.2.0",
@@ -2760,7 +2751,6 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.38.0.tgz",
 			"integrity": "sha512-kocjix+/sSggfJhwXqClZ3i9Y/MI0fp7b+g7kCRm6psy2dsf8uApTRclwG18h8Avm7C9+fnt+O36PspJ/OzoWg==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"engines": {
 				"node": ">=14"
 			}
@@ -3819,7 +3809,8 @@
 			"resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
 			"integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/@types/babel__core": {
 			"version": "7.20.5",
@@ -4357,7 +4348,6 @@
 			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
 			"integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/prop-types": "*",
 				"csstype": "^3.2.2"
@@ -4369,7 +4359,6 @@
 			"integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"peerDependencies": {
 				"@types/react": "^18.0.0"
 			}
@@ -4495,7 +4484,6 @@
 			"integrity": "sha512-hM5faZwg7aVNa819m/5r7D0h0c9yC4DUlWAOvHAtISdFTc8xB86VmX5Xqabrama3wIPJ/q9RbGS1worb6JfnMg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.50.1",
 				"@typescript-eslint/types": "8.50.1",
@@ -4926,7 +4914,6 @@
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -5008,7 +4995,6 @@
 			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -6012,7 +5998,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.8.25",
 				"caniuse-lite": "^1.0.30001754",
@@ -6495,7 +6480,6 @@
 			"resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.0.3.tgz",
 			"integrity": "sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@chevrotain/cst-dts-gen": "11.0.3",
 				"@chevrotain/gast": "11.0.3",
@@ -7221,7 +7205,6 @@
 			"resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
 			"integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=0.10"
 			}
@@ -7631,7 +7614,6 @@
 			"resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
 			"integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
 			"license": "ISC",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -8129,7 +8111,6 @@
 			"integrity": "sha512-rcJUkMfnJpfCboZoOOPf4L29TRtEieHNOeAbYPWPxlaBw/Z1RKrRA86dOI9rwaI4tQSc/RD82zTNHprfUHXsoQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"app-builder-lib": "24.13.3",
 				"builder-util": "24.13.1",
@@ -8225,7 +8206,8 @@
 			"resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
 			"integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/dompurify": {
 			"version": "3.3.0",
@@ -8369,6 +8351,7 @@
 			"integrity": "sha512-oHkV0iogWfyK+ah9ZIvMDpei1m9ZRpdXcvde1wTpra2U8AFDNNpqJdnin5z+PM1GbQ5BoaKCWas2HSjtR0HwMg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"app-builder-lib": "24.13.3",
 				"archiver": "^5.3.1",
@@ -8382,6 +8365,7 @@
 			"integrity": "sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"archiver-utils": "^2.1.0",
 				"async": "^3.2.4",
@@ -8401,6 +8385,7 @@
 			"integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"glob": "^7.1.4",
 				"graceful-fs": "^4.2.0",
@@ -8423,6 +8408,7 @@
 			"integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"core-util-is": "~1.0.0",
 				"inherits": "~2.0.3",
@@ -8439,6 +8425,7 @@
 			"integrity": "sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"buffer-crc32": "^0.2.13",
 				"crc32-stream": "^4.0.2",
@@ -8455,6 +8442,7 @@
 			"integrity": "sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"crc-32": "^1.2.0",
 				"readable-stream": "^3.4.0"
@@ -8469,6 +8457,7 @@
 			"integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"graceful-fs": "^4.2.0",
 				"jsonfile": "^6.0.1",
@@ -8484,6 +8473,7 @@
 			"integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"universalify": "^2.0.0"
 			},
@@ -8496,7 +8486,8 @@
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/electron-builder-squirrel-windows/node_modules/string_decoder": {
 			"version": "1.1.1",
@@ -8504,6 +8495,7 @@
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"safe-buffer": "~5.1.0"
 			}
@@ -8514,6 +8506,7 @@
 			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">= 10.0.0"
 			}
@@ -8524,6 +8517,7 @@
 			"integrity": "sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"archiver-utils": "^3.0.4",
 				"compress-commons": "^4.1.2",
@@ -8539,6 +8533,7 @@
 			"integrity": "sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"glob": "^7.2.3",
 				"graceful-fs": "^4.2.0",
@@ -9220,7 +9215,6 @@
 			"integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -11140,7 +11134,6 @@
 			"resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
 			"integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
 			"license": "MIT",
-			"peer": true,
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/immer"
@@ -11961,7 +11954,6 @@
 			"integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"jiti": "bin/jiti.js"
 			}
@@ -12431,14 +12423,16 @@
 			"resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
 			"integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/lodash.difference": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
 			"integrity": "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/lodash.escaperegexp": {
 			"version": "4.1.2",
@@ -12451,7 +12445,8 @@
 			"resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
 			"integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/lodash.isequal": {
 			"version": "4.5.0",
@@ -12465,7 +12460,8 @@
 			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
 			"integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/lodash.merge": {
 			"version": "4.6.2",
@@ -12479,7 +12475,8 @@
 			"resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
 			"integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/log-symbols": {
 			"version": "4.1.0",
@@ -12570,6 +12567,7 @@
 			"integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"lz-string": "bin/bin.js"
 			}
@@ -15067,7 +15065,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.11",
 				"picocolors": "^1.1.1",
@@ -15308,6 +15305,7 @@
 			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"ansi-regex": "^5.0.1",
 				"ansi-styles": "^5.0.0",
@@ -15323,6 +15321,7 @@
 			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -15667,7 +15666,6 @@
 			"resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
 			"integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0"
 			},
@@ -15697,7 +15695,6 @@
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
 			"integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0",
 				"scheduler": "^0.23.2"
@@ -15745,7 +15742,6 @@
 			"resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
 			"integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/use-sync-external-store": "^0.0.6",
 				"use-sync-external-store": "^1.4.0"
@@ -15932,8 +15928,7 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
 			"integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/redux-thunk": {
 			"version": "3.1.0",
@@ -17690,7 +17685,6 @@
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -18001,7 +17995,6 @@
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -18375,7 +18368,6 @@
 			"integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.21.3",
 				"postcss": "^8.4.43",
@@ -18881,7 +18873,6 @@
 			"integrity": "sha512-n1RxDp8UJm6N0IbJLQo+yzLZ2sQCDyl1o0LeugbPWf8+8Fttp29GghsQBjYJVmWq3gBFfe9Hs1spR44vovn2wA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@vitest/expect": "4.0.15",
 				"@vitest/mocker": "4.0.15",
@@ -19472,7 +19463,6 @@
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -19486,7 +19476,6 @@
 			"integrity": "sha512-tI2l/nFHC5rLh7+5+o7QjKjSR04ivXDF4jcgV0f/bTQ+OJiITy5S6gaynVsEM+7RqzufMnVbIon6Sr5x1SDYaQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.25.0",
 				"fdir": "^6.5.0",
@@ -20084,7 +20073,6 @@
 			"integrity": "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}

--- a/src/__tests__/main/agents/detector.test.ts
+++ b/src/__tests__/main/agents/detector.test.ts
@@ -278,8 +278,8 @@ describe('agent-detector', () => {
 
 			const agents = await detector.detectAgents();
 
-			// Should have all 8 agents (terminal, claude-code, codex, gemini-cli, qwen3-coder, opencode, factory-droid, aider)
-			expect(agents.length).toBe(8);
+			// Should have all 9 agents (terminal, claude-code, codex, gemini-cli, qwen3-coder, opencode, factory-droid, aider, copilot-cli)
+			expect(agents.length).toBe(9);
 
 			const agentIds = agents.map((a) => a.id);
 			expect(agentIds).toContain('terminal');
@@ -290,6 +290,7 @@ describe('agent-detector', () => {
 			expect(agentIds).toContain('opencode');
 			expect(agentIds).toContain('factory-droid');
 			expect(agentIds).toContain('aider');
+			expect(agentIds).toContain('copilot-cli');
 		});
 
 		it('should mark agents as available when binary is found', async () => {
@@ -924,8 +925,8 @@ describe('agent-detector', () => {
 
 			const result = await detectPromise;
 			expect(result).toBeDefined();
-			// Should have all 8 agents (terminal, claude-code, codex, gemini-cli, qwen3-coder, opencode, factory-droid, aider)
-			expect(result.length).toBe(8);
+			// Should have all 9 agents (terminal, claude-code, codex, gemini-cli, qwen3-coder, opencode, factory-droid, aider, copilot-cli)
+			expect(result.length).toBe(9);
 		});
 
 		it('should handle very long PATH', async () => {

--- a/src/__tests__/main/parsers/copilot-cli-output-parser.test.ts
+++ b/src/__tests__/main/parsers/copilot-cli-output-parser.test.ts
@@ -233,7 +233,10 @@ describe('CopilotCliOutputParser', () => {
 				expect(event?.toolUseBlocks).toHaveLength(1);
 				expect(event?.toolUseBlocks?.[0].name).toBe('view');
 				expect(event?.toolUseBlocks?.[0].id).toBe('tooluse_abc123');
-				expect(event?.toolUseBlocks?.[0].input).toEqual({ path: '/package.json', view_range: [1, 5] });
+				expect(event?.toolUseBlocks?.[0].input).toEqual({
+					path: '/package.json',
+					view_range: [1, 5],
+				});
 			});
 
 			it('should parse message with both text and tool requests', () => {
@@ -266,7 +269,11 @@ describe('CopilotCliOutputParser', () => {
 				parser.parseJsonLine(
 					JSON.stringify({
 						type: 'assistant.message',
-						data: { content: '', toolRequests: [{ toolCallId: 't1', name: 'view', arguments: {} }], outputTokens: 100 },
+						data: {
+							content: '',
+							toolRequests: [{ toolCallId: 't1', name: 'view', arguments: {} }],
+							outputTokens: 100,
+						},
 					})
 				);
 				parser.parseJsonLine(
@@ -537,7 +544,9 @@ describe('CopilotCliOutputParser', () => {
 
 		it('should return null for non-error lines', () => {
 			expect(parser.detectErrorFromLine('')).toBeNull();
-			expect(parser.detectErrorFromLine(JSON.stringify({ type: 'assistant.turn_start' }))).toBeNull();
+			expect(
+				parser.detectErrorFromLine(JSON.stringify({ type: 'assistant.turn_start' }))
+			).toBeNull();
 		});
 	});
 
@@ -585,16 +594,40 @@ describe('CopilotCliOutputParser', () => {
 	describe('full session simulation', () => {
 		it('should correctly parse a complete simple session', () => {
 			const lines = [
-				JSON.stringify({ type: 'session.mcp_server_status_changed', data: { serverName: 'github-mcp-server', status: 'connected' }, ephemeral: true }),
-				JSON.stringify({ type: 'session.mcp_servers_loaded', data: { servers: [] }, ephemeral: true }),
+				JSON.stringify({
+					type: 'session.mcp_server_status_changed',
+					data: { serverName: 'github-mcp-server', status: 'connected' },
+					ephemeral: true,
+				}),
+				JSON.stringify({
+					type: 'session.mcp_servers_loaded',
+					data: { servers: [] },
+					ephemeral: true,
+				}),
 				JSON.stringify({ type: 'session.tools_updated', data: { model: 'claude-opus-4.6' } }),
 				JSON.stringify({ type: 'user.message', data: { content: 'Say hello' } }),
 				JSON.stringify({ type: 'assistant.turn_start', data: { turnId: '0' } }),
-				JSON.stringify({ type: 'assistant.message_delta', data: { deltaContent: 'Hello' }, ephemeral: true }),
-				JSON.stringify({ type: 'assistant.message_delta', data: { deltaContent: ' world!' }, ephemeral: true }),
-				JSON.stringify({ type: 'assistant.message', data: { content: 'Hello world!', toolRequests: [], outputTokens: 5 } }),
+				JSON.stringify({
+					type: 'assistant.message_delta',
+					data: { deltaContent: 'Hello' },
+					ephemeral: true,
+				}),
+				JSON.stringify({
+					type: 'assistant.message_delta',
+					data: { deltaContent: ' world!' },
+					ephemeral: true,
+				}),
+				JSON.stringify({
+					type: 'assistant.message',
+					data: { content: 'Hello world!', toolRequests: [], outputTokens: 5 },
+				}),
 				JSON.stringify({ type: 'assistant.turn_end', data: { turnId: '0' } }),
-				JSON.stringify({ type: 'result', sessionId: 'test-session-id', exitCode: 0, usage: { premiumRequests: 1 } }),
+				JSON.stringify({
+					type: 'result',
+					sessionId: 'test-session-id',
+					exitCode: 0,
+					usage: { premiumRequests: 1 },
+				}),
 			];
 
 			const events = lines.map((l) => parser.parseJsonLine(l)).filter((e) => e !== null);
@@ -636,17 +669,38 @@ describe('CopilotCliOutputParser', () => {
 					type: 'assistant.message',
 					data: {
 						content: '',
-						toolRequests: [{ toolCallId: 'tc1', name: 'view', arguments: { path: '/package.json' } }],
+						toolRequests: [
+							{ toolCallId: 'tc1', name: 'view', arguments: { path: '/package.json' } },
+						],
 						outputTokens: 100,
 					},
 				}),
 				// Tool execution
-				JSON.stringify({ type: 'tool.execution_start', data: { toolCallId: 'tc1', toolName: 'view', arguments: { path: '/package.json' } } }),
-				JSON.stringify({ type: 'tool.execution_complete', data: { toolCallId: 'tc1', toolName: 'view', success: true, result: { content: '{"name":"maestro"}' } } }),
+				JSON.stringify({
+					type: 'tool.execution_start',
+					data: { toolCallId: 'tc1', toolName: 'view', arguments: { path: '/package.json' } },
+				}),
+				JSON.stringify({
+					type: 'tool.execution_complete',
+					data: {
+						toolCallId: 'tc1',
+						toolName: 'view',
+						success: true,
+						result: { content: '{"name":"maestro"}' },
+					},
+				}),
 				// Final response
-				JSON.stringify({ type: 'assistant.message', data: { content: 'The package is named maestro.', toolRequests: [], outputTokens: 20 } }),
+				JSON.stringify({
+					type: 'assistant.message',
+					data: { content: 'The package is named maestro.', toolRequests: [], outputTokens: 20 },
+				}),
 				JSON.stringify({ type: 'assistant.turn_end', data: { turnId: '0' } }),
-				JSON.stringify({ type: 'result', sessionId: 'sess-456', exitCode: 0, usage: { premiumRequests: 2 } }),
+				JSON.stringify({
+					type: 'result',
+					sessionId: 'sess-456',
+					exitCode: 0,
+					usage: { premiumRequests: 2 },
+				}),
 			];
 
 			const events = lines.map((l) => parser.parseJsonLine(l)).filter((e) => e !== null);

--- a/src/__tests__/main/parsers/copilot-cli-output-parser.test.ts
+++ b/src/__tests__/main/parsers/copilot-cli-output-parser.test.ts
@@ -1,0 +1,665 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { CopilotCliOutputParser } from '../../../main/parsers/copilot-cli-output-parser';
+
+describe('CopilotCliOutputParser', () => {
+	let parser: CopilotCliOutputParser;
+
+	beforeEach(() => {
+		parser = new CopilotCliOutputParser();
+	});
+
+	describe('agentId', () => {
+		it('should be copilot-cli', () => {
+			expect(parser.agentId).toBe('copilot-cli');
+		});
+	});
+
+	describe('parseJsonLine', () => {
+		it('should return null for empty lines', () => {
+			expect(parser.parseJsonLine('')).toBeNull();
+			expect(parser.parseJsonLine('  ')).toBeNull();
+			expect(parser.parseJsonLine('\n')).toBeNull();
+		});
+
+		it('should return text event for non-JSON lines', () => {
+			const event = parser.parseJsonLine('not json at all');
+			expect(event).not.toBeNull();
+			expect(event?.type).toBe('text');
+			expect(event?.text).toBe('not json at all');
+		});
+
+		// ================================================================
+		// Session lifecycle events
+		// ================================================================
+
+		describe('session.mcp_server_status_changed', () => {
+			it('should parse as system event', () => {
+				const line = JSON.stringify({
+					type: 'session.mcp_server_status_changed',
+					data: { serverName: 'github-mcp-server', status: 'connected' },
+					id: 'abc-123',
+					timestamp: '2026-04-01T03:03:44.200Z',
+					ephemeral: true,
+				});
+
+				const event = parser.parseJsonLine(line);
+				expect(event).not.toBeNull();
+				expect(event?.type).toBe('system');
+			});
+		});
+
+		describe('session.mcp_servers_loaded', () => {
+			it('should parse as system event', () => {
+				const line = JSON.stringify({
+					type: 'session.mcp_servers_loaded',
+					data: {
+						servers: [
+							{ name: 'github-mcp-server', status: 'connected', source: 'builtin' },
+							{ name: 'playwright', status: 'connected' },
+						],
+					},
+					id: 'def-456',
+					timestamp: '2026-04-01T03:03:49.778Z',
+				});
+
+				const event = parser.parseJsonLine(line);
+				expect(event).not.toBeNull();
+				expect(event?.type).toBe('system');
+			});
+		});
+
+		describe('session.tools_updated', () => {
+			it('should parse as init event (contains model)', () => {
+				const line = JSON.stringify({
+					type: 'session.tools_updated',
+					data: { model: 'claude-opus-4.6-1m' },
+					id: 'ghi-789',
+					timestamp: '2026-04-01T03:03:52.075Z',
+				});
+
+				const event = parser.parseJsonLine(line);
+				expect(event).not.toBeNull();
+				expect(event?.type).toBe('init');
+			});
+		});
+
+		// ================================================================
+		// User message echo
+		// ================================================================
+
+		describe('user.message', () => {
+			it('should parse as system event (not displayed)', () => {
+				const line = JSON.stringify({
+					type: 'user.message',
+					data: {
+						content: 'Say hello in one sentence',
+						transformedContent: 'Say hello in one sentence',
+						attachments: [],
+						interactionId: '963470f1-14f0-4a2f-a7a1-917b13892952',
+					},
+					id: '5e0d517d-b4e9-4b12-a014-4af6eab9606c',
+					timestamp: '2026-04-01T03:03:52.077Z',
+				});
+
+				const event = parser.parseJsonLine(line);
+				expect(event).not.toBeNull();
+				expect(event?.type).toBe('system');
+			});
+		});
+
+		// ================================================================
+		// Assistant turn lifecycle
+		// ================================================================
+
+		describe('assistant.turn_start', () => {
+			it('should parse as system event', () => {
+				const line = JSON.stringify({
+					type: 'assistant.turn_start',
+					data: {
+						turnId: '0',
+						interactionId: '963470f1-14f0-4a2f-a7a1-917b13892952',
+					},
+					id: 'acef7a61-aa5b-418b-9043-fdfd548a2d4f',
+					timestamp: '2026-04-01T03:03:52.092Z',
+				});
+
+				const event = parser.parseJsonLine(line);
+				expect(event).not.toBeNull();
+				expect(event?.type).toBe('system');
+			});
+		});
+
+		describe('assistant.turn_end', () => {
+			it('should parse as system event', () => {
+				const line = JSON.stringify({
+					type: 'assistant.turn_end',
+					data: { turnId: '0' },
+					id: '7cddec97-2495-494f-a680-18382f957161',
+					timestamp: '2026-04-01T03:03:56.131Z',
+				});
+
+				const event = parser.parseJsonLine(line);
+				expect(event).not.toBeNull();
+				expect(event?.type).toBe('system');
+			});
+		});
+
+		// ================================================================
+		// Streaming text (assistant.message_delta)
+		// ================================================================
+
+		describe('assistant.message_delta', () => {
+			it('should parse as partial text event', () => {
+				const line = JSON.stringify({
+					type: 'assistant.message_delta',
+					data: {
+						messageId: 'edaf687e-8934-45ff-929a-4ddc9cf241fc',
+						deltaContent: 'Hello! I am',
+					},
+					id: '7b8c16ea-cd07-40ed-802b-b193a2b1b1ca',
+					timestamp: '2026-04-01T03:03:56.124Z',
+					ephemeral: true,
+				});
+
+				const event = parser.parseJsonLine(line);
+				expect(event).not.toBeNull();
+				expect(event?.type).toBe('text');
+				expect(event?.text).toBe('Hello! I am');
+				expect(event?.isPartial).toBe(true);
+			});
+
+			it('should handle empty deltaContent', () => {
+				const line = JSON.stringify({
+					type: 'assistant.message_delta',
+					data: { messageId: 'msg-1', deltaContent: '' },
+				});
+
+				const event = parser.parseJsonLine(line);
+				expect(event).not.toBeNull();
+				expect(event?.type).toBe('text');
+				expect(event?.text).toBe('');
+				expect(event?.isPartial).toBe(true);
+			});
+		});
+
+		// ================================================================
+		// Complete assistant message
+		// ================================================================
+
+		describe('assistant.message', () => {
+			it('should parse text-only message as result', () => {
+				const line = JSON.stringify({
+					type: 'assistant.message',
+					data: {
+						messageId: 'a23033e4-755f-4283-bc2e-310c9f2ad770',
+						content: 'The version number is **0.15.3**.',
+						toolRequests: [],
+						interactionId: '762eb3c4-f8ed-418b-96f6-cb9c1c97b71b',
+						outputTokens: 14,
+					},
+					id: 'd48a39ac-d6ae-45c3-b423-5e7bd7d036fa',
+					timestamp: '2026-04-01T03:05:27.795Z',
+				});
+
+				const event = parser.parseJsonLine(line);
+				expect(event).not.toBeNull();
+				expect(event?.type).toBe('result');
+				expect(event?.text).toBe('The version number is **0.15.3**.');
+				expect(event?.isPartial).toBe(false);
+			});
+
+			it('should parse tool-request-only message as tool_use with blocks', () => {
+				const line = JSON.stringify({
+					type: 'assistant.message',
+					data: {
+						messageId: '1edb98ee-0bf8-4996-be03-5cb9ed4abe39',
+						content: '',
+						toolRequests: [
+							{
+								toolCallId: 'tooluse_abc123',
+								name: 'view',
+								arguments: { path: '/package.json', view_range: [1, 5] },
+								type: 'function',
+							},
+						],
+						interactionId: '762eb3c4-f8ed-418b-96f6-cb9c1c97b71b',
+						outputTokens: 126,
+					},
+				});
+
+				const event = parser.parseJsonLine(line);
+				expect(event).not.toBeNull();
+				expect(event?.type).toBe('tool_use');
+				expect(event?.toolUseBlocks).toHaveLength(1);
+				expect(event?.toolUseBlocks?.[0].name).toBe('view');
+				expect(event?.toolUseBlocks?.[0].id).toBe('tooluse_abc123');
+				expect(event?.toolUseBlocks?.[0].input).toEqual({ path: '/package.json', view_range: [1, 5] });
+			});
+
+			it('should parse message with both text and tool requests', () => {
+				const line = JSON.stringify({
+					type: 'assistant.message',
+					data: {
+						messageId: 'msg-mixed',
+						content: 'Let me check that file for you.',
+						toolRequests: [
+							{
+								toolCallId: 'tooluse_xyz',
+								name: 'view',
+								arguments: { path: '/src/index.ts' },
+								type: 'function',
+							},
+						],
+						outputTokens: 50,
+					},
+				});
+
+				const event = parser.parseJsonLine(line);
+				expect(event).not.toBeNull();
+				expect(event?.type).toBe('text');
+				expect(event?.text).toBe('Let me check that file for you.');
+				expect(event?.toolUseBlocks).toHaveLength(1);
+			});
+
+			it('should accumulate outputTokens across messages', () => {
+				// Send two messages with outputTokens
+				parser.parseJsonLine(
+					JSON.stringify({
+						type: 'assistant.message',
+						data: { content: '', toolRequests: [{ toolCallId: 't1', name: 'view', arguments: {} }], outputTokens: 100 },
+					})
+				);
+				parser.parseJsonLine(
+					JSON.stringify({
+						type: 'assistant.message',
+						data: { content: 'Done.', toolRequests: [], outputTokens: 50 },
+					})
+				);
+
+				// The result event should have accumulated tokens
+				const resultEvent = parser.parseJsonLine(
+					JSON.stringify({
+						type: 'result',
+						sessionId: 'test-session',
+						exitCode: 0,
+						usage: { premiumRequests: 1, totalApiDurationMs: 1000 },
+					})
+				);
+
+				expect(resultEvent?.type).toBe('usage');
+				expect(resultEvent?.usage?.outputTokens).toBe(150); // 100 + 50
+			});
+		});
+
+		// ================================================================
+		// Tool execution events
+		// ================================================================
+
+		describe('tool.execution_start', () => {
+			it('should parse as tool_use with running status', () => {
+				const line = JSON.stringify({
+					type: 'tool.execution_start',
+					data: {
+						toolCallId: 'tooluse_fYPm7zJkdgOTL9KKwAPj5n',
+						toolName: 'view',
+						arguments: { path: 'C:\\maestro\\Maestro\\package.json', view_range: [1, 5] },
+					},
+					id: '98e359ea-a94e-465f-9fca-5fd553514779',
+					timestamp: '2026-04-01T03:05:24.135Z',
+				});
+
+				const event = parser.parseJsonLine(line);
+				expect(event).not.toBeNull();
+				expect(event?.type).toBe('tool_use');
+				expect(event?.toolName).toBe('view');
+				expect(event?.toolState).toEqual({
+					status: 'running',
+					input: { path: 'C:\\maestro\\Maestro\\package.json', view_range: [1, 5] },
+				});
+			});
+		});
+
+		describe('tool.execution_complete', () => {
+			it('should parse as tool_use with completed status', () => {
+				const line = JSON.stringify({
+					type: 'tool.execution_complete',
+					data: {
+						toolCallId: 'tooluse_fYPm7zJkdgOTL9KKwAPj5n',
+						toolName: 'view',
+						model: 'claude-opus-4.6',
+						success: true,
+						result: {
+							content: '1. {\n2. "name": "maestro",\n3. "version": "0.15.3"',
+							detailedContent: 'diff output...',
+						},
+						toolTelemetry: {},
+					},
+				});
+
+				const event = parser.parseJsonLine(line);
+				expect(event).not.toBeNull();
+				expect(event?.type).toBe('tool_use');
+				expect(event?.toolName).toBe('view');
+				expect(event?.toolState).toEqual({
+					status: 'completed',
+					output: '1. {\n2. "name": "maestro",\n3. "version": "0.15.3"',
+					success: true,
+				});
+			});
+
+			it('should truncate very long tool output', () => {
+				const longOutput = 'x'.repeat(15000);
+				const line = JSON.stringify({
+					type: 'tool.execution_complete',
+					data: {
+						toolCallId: 'tc1',
+						toolName: 'bash',
+						success: true,
+						result: { content: longOutput },
+					},
+				});
+
+				const event = parser.parseJsonLine(line);
+				expect(event?.type).toBe('tool_use');
+				const output = (event?.toolState as { output: string })?.output;
+				expect(output.length).toBeLessThan(longOutput.length);
+				expect(output).toContain('[output truncated');
+			});
+		});
+
+		// ================================================================
+		// Result event (session completion)
+		// ================================================================
+
+		describe('result', () => {
+			it('should parse as usage event with sessionId', () => {
+				const line = JSON.stringify({
+					type: 'result',
+					timestamp: '2026-04-01T03:03:56.134Z',
+					sessionId: '18353c52-1a96-4ce6-ab90-1b99310f746f',
+					exitCode: 0,
+					usage: {
+						premiumRequests: 6,
+						totalApiDurationMs: 3356,
+						sessionDurationMs: 13107,
+						codeChanges: { linesAdded: 0, linesRemoved: 0, filesModified: [] },
+					},
+				});
+
+				const event = parser.parseJsonLine(line);
+				expect(event).not.toBeNull();
+				expect(event?.type).toBe('usage');
+				expect(event?.sessionId).toBe('18353c52-1a96-4ce6-ab90-1b99310f746f');
+			});
+		});
+
+		// ================================================================
+		// Error events
+		// ================================================================
+
+		describe('error events', () => {
+			it('should parse events with error field', () => {
+				const line = JSON.stringify({
+					type: 'error',
+					error: { message: 'Authentication failed', type: 'auth_error' },
+				});
+
+				const event = parser.parseJsonLine(line);
+				expect(event).not.toBeNull();
+				expect(event?.type).toBe('error');
+				expect(event?.text).toBe('Authentication failed');
+			});
+
+			it('should parse error as string', () => {
+				const line = JSON.stringify({
+					type: 'error',
+					error: 'Rate limited',
+				});
+
+				const event = parser.parseJsonLine(line);
+				expect(event?.type).toBe('error');
+				expect(event?.text).toBe('Rate limited');
+			});
+		});
+
+		// ================================================================
+		// Unknown event types
+		// ================================================================
+
+		describe('unknown events', () => {
+			it('should preserve unknown types as system events', () => {
+				const line = JSON.stringify({
+					type: 'some.future.event',
+					data: { foo: 'bar' },
+				});
+
+				const event = parser.parseJsonLine(line);
+				expect(event).not.toBeNull();
+				expect(event?.type).toBe('system');
+			});
+		});
+	});
+
+	// ================================================================
+	// Helper methods
+	// ================================================================
+
+	describe('isResultMessage', () => {
+		it('should return true for result events with text', () => {
+			expect(parser.isResultMessage({ type: 'result', text: 'Hello!' })).toBe(true);
+		});
+
+		it('should return false for result events without text', () => {
+			expect(parser.isResultMessage({ type: 'result' })).toBe(false);
+			expect(parser.isResultMessage({ type: 'result', text: '' })).toBe(false);
+		});
+
+		it('should return false for non-result events', () => {
+			expect(parser.isResultMessage({ type: 'text', text: 'Hello!' })).toBe(false);
+		});
+	});
+
+	describe('extractSessionId', () => {
+		it('should extract sessionId from event', () => {
+			expect(parser.extractSessionId({ type: 'usage', sessionId: 'abc-123' })).toBe('abc-123');
+		});
+
+		it('should return null when no sessionId', () => {
+			expect(parser.extractSessionId({ type: 'text', text: 'hello' })).toBeNull();
+		});
+	});
+
+	describe('extractUsage', () => {
+		it('should extract usage from event', () => {
+			const usage = { inputTokens: 100, outputTokens: 50 };
+			expect(parser.extractUsage({ type: 'usage', usage })).toEqual(usage);
+		});
+
+		it('should return null when no usage', () => {
+			expect(parser.extractUsage({ type: 'text' })).toBeNull();
+		});
+	});
+
+	describe('extractSlashCommands', () => {
+		it('should return null (slash commands not in JSON output)', () => {
+			expect(parser.extractSlashCommands({ type: 'init' })).toBeNull();
+		});
+	});
+
+	// ================================================================
+	// Error detection
+	// ================================================================
+
+	describe('detectErrorFromLine', () => {
+		it('should detect auth errors from JSON', () => {
+			const line = JSON.stringify({
+				type: 'error',
+				error: { message: 'not authenticated' },
+			});
+
+			const error = parser.detectErrorFromLine(line);
+			expect(error).not.toBeNull();
+			expect(error?.type).toBe('auth_expired');
+			expect(error?.agentId).toBe('copilot-cli');
+		});
+
+		it('should detect rate limit errors', () => {
+			const line = JSON.stringify({
+				type: 'error',
+				error: 'rate limit exceeded',
+			});
+
+			const error = parser.detectErrorFromLine(line);
+			expect(error).not.toBeNull();
+			expect(error?.type).toBe('rate_limited');
+		});
+
+		it('should detect errors from plain text (non-JSON)', () => {
+			const error = parser.detectErrorFromLine('copilot: command not found');
+			expect(error).not.toBeNull();
+			expect(error?.type).toBe('agent_crashed');
+		});
+
+		it('should return null for non-error lines', () => {
+			expect(parser.detectErrorFromLine('')).toBeNull();
+			expect(parser.detectErrorFromLine(JSON.stringify({ type: 'assistant.turn_start' }))).toBeNull();
+		});
+	});
+
+	describe('detectErrorFromParsed', () => {
+		it('should detect error from parsed JSON', () => {
+			const error = parser.detectErrorFromParsed({
+				type: 'error',
+				error: { message: 'unauthorized' },
+			});
+
+			expect(error).not.toBeNull();
+			expect(error?.type).toBe('auth_expired');
+		});
+
+		it('should return null for non-error objects', () => {
+			expect(parser.detectErrorFromParsed({ type: 'assistant.message' })).toBeNull();
+			expect(parser.detectErrorFromParsed(null)).toBeNull();
+			expect(parser.detectErrorFromParsed('string')).toBeNull();
+		});
+	});
+
+	describe('detectErrorFromExit', () => {
+		it('should return null for exit code 0', () => {
+			expect(parser.detectErrorFromExit(0, '', '')).toBeNull();
+		});
+
+		it('should detect agent crash for non-zero exit', () => {
+			const error = parser.detectErrorFromExit(1, 'some error', '');
+			expect(error).not.toBeNull();
+			expect(error?.type).toBe('agent_crashed');
+			expect(error?.message).toContain('exited with code 1');
+		});
+
+		it('should detect auth errors from stderr', () => {
+			const error = parser.detectErrorFromExit(1, 'not authenticated', '');
+			expect(error).not.toBeNull();
+			expect(error?.type).toBe('auth_expired');
+		});
+	});
+
+	// ================================================================
+	// End-to-end: full session simulation
+	// ================================================================
+
+	describe('full session simulation', () => {
+		it('should correctly parse a complete simple session', () => {
+			const lines = [
+				JSON.stringify({ type: 'session.mcp_server_status_changed', data: { serverName: 'github-mcp-server', status: 'connected' }, ephemeral: true }),
+				JSON.stringify({ type: 'session.mcp_servers_loaded', data: { servers: [] }, ephemeral: true }),
+				JSON.stringify({ type: 'session.tools_updated', data: { model: 'claude-opus-4.6' } }),
+				JSON.stringify({ type: 'user.message', data: { content: 'Say hello' } }),
+				JSON.stringify({ type: 'assistant.turn_start', data: { turnId: '0' } }),
+				JSON.stringify({ type: 'assistant.message_delta', data: { deltaContent: 'Hello' }, ephemeral: true }),
+				JSON.stringify({ type: 'assistant.message_delta', data: { deltaContent: ' world!' }, ephemeral: true }),
+				JSON.stringify({ type: 'assistant.message', data: { content: 'Hello world!', toolRequests: [], outputTokens: 5 } }),
+				JSON.stringify({ type: 'assistant.turn_end', data: { turnId: '0' } }),
+				JSON.stringify({ type: 'result', sessionId: 'test-session-id', exitCode: 0, usage: { premiumRequests: 1 } }),
+			];
+
+			const events = lines.map((l) => parser.parseJsonLine(l)).filter((e) => e !== null);
+
+			// Should have 10 events
+			expect(events).toHaveLength(10);
+
+			// Check event types in order
+			expect(events[0].type).toBe('system'); // mcp status
+			expect(events[1].type).toBe('system'); // mcp loaded
+			expect(events[2].type).toBe('init'); // tools updated
+			expect(events[3].type).toBe('system'); // user message echo
+			expect(events[4].type).toBe('system'); // turn start
+			expect(events[5].type).toBe('text'); // delta "Hello"
+			expect(events[6].type).toBe('text'); // delta " world!"
+			expect(events[7].type).toBe('result'); // final message
+			expect(events[8].type).toBe('system'); // turn end
+			expect(events[9].type).toBe('usage'); // result with sessionId
+
+			// Verify streaming deltas
+			expect(events[5].text).toBe('Hello');
+			expect(events[5].isPartial).toBe(true);
+			expect(events[6].text).toBe(' world!');
+
+			// Verify result message
+			expect(events[7].text).toBe('Hello world!');
+			expect(events[7].isPartial).toBe(false);
+
+			// Verify session ID from result
+			expect(events[9].sessionId).toBe('test-session-id');
+		});
+
+		it('should correctly parse a session with tool use', () => {
+			const lines = [
+				JSON.stringify({ type: 'session.tools_updated', data: { model: 'claude-opus-4.6' } }),
+				JSON.stringify({ type: 'assistant.turn_start', data: { turnId: '0' } }),
+				// Tool request message (no text content)
+				JSON.stringify({
+					type: 'assistant.message',
+					data: {
+						content: '',
+						toolRequests: [{ toolCallId: 'tc1', name: 'view', arguments: { path: '/package.json' } }],
+						outputTokens: 100,
+					},
+				}),
+				// Tool execution
+				JSON.stringify({ type: 'tool.execution_start', data: { toolCallId: 'tc1', toolName: 'view', arguments: { path: '/package.json' } } }),
+				JSON.stringify({ type: 'tool.execution_complete', data: { toolCallId: 'tc1', toolName: 'view', success: true, result: { content: '{"name":"maestro"}' } } }),
+				// Final response
+				JSON.stringify({ type: 'assistant.message', data: { content: 'The package is named maestro.', toolRequests: [], outputTokens: 20 } }),
+				JSON.stringify({ type: 'assistant.turn_end', data: { turnId: '0' } }),
+				JSON.stringify({ type: 'result', sessionId: 'sess-456', exitCode: 0, usage: { premiumRequests: 2 } }),
+			];
+
+			const events = lines.map((l) => parser.parseJsonLine(l)).filter((e) => e !== null);
+
+			// Find tool events
+			const toolEvents = events.filter((e) => e.type === 'tool_use');
+			expect(toolEvents).toHaveLength(3); // tool request + start + complete
+
+			// Verify tool request from assistant.message
+			expect(toolEvents[0].toolUseBlocks).toHaveLength(1);
+			expect(toolEvents[0].toolUseBlocks?.[0].name).toBe('view');
+
+			// Verify tool start
+			expect(toolEvents[1].toolName).toBe('view');
+			expect((toolEvents[1].toolState as { status: string }).status).toBe('running');
+
+			// Verify tool complete
+			expect(toolEvents[2].toolName).toBe('view');
+			expect((toolEvents[2].toolState as { status: string }).status).toBe('completed');
+
+			// Verify final result
+			const resultEvents = events.filter((e) => e.type === 'result');
+			expect(resultEvents).toHaveLength(1);
+			expect(resultEvents[0].text).toBe('The package is named maestro.');
+
+			// Verify accumulated tokens
+			const usageEvent = events.find((e) => e.type === 'usage');
+			expect(usageEvent?.usage?.outputTokens).toBe(120); // 100 + 20
+		});
+	});
+});

--- a/src/__tests__/main/parsers/copilot-cli-output-parser.test.ts
+++ b/src/__tests__/main/parsers/copilot-cli-output-parser.test.ts
@@ -261,7 +261,7 @@ describe('CopilotCliOutputParser', () => {
 				expect(event?.toolUseBlocks).toHaveLength(1);
 			});
 
-			it('should accumulate outputTokens across messages', () => {
+			it('should accumulate outputTokens across messages and reset on result', () => {
 				// Send two messages with outputTokens
 				parser.parseJsonLine(
 					JSON.stringify({
@@ -282,12 +282,22 @@ describe('CopilotCliOutputParser', () => {
 						type: 'result',
 						sessionId: 'test-session',
 						exitCode: 0,
-						usage: { premiumRequests: 1, totalApiDurationMs: 1000 },
+						usage: { premiumRequests: 1 },
 					})
 				);
 
 				expect(resultEvent?.type).toBe('usage');
 				expect(resultEvent?.usage?.outputTokens).toBe(150); // 100 + 50
+
+				// After result, tokens should be reset for next session
+				const nextResult = parser.parseJsonLine(
+					JSON.stringify({
+						type: 'result',
+						sessionId: 'test-session-2',
+						exitCode: 0,
+					})
+				);
+				expect(nextResult?.usage?.outputTokens).toBe(0); // reset
 			});
 		});
 
@@ -372,24 +382,29 @@ describe('CopilotCliOutputParser', () => {
 		// ================================================================
 
 		describe('result', () => {
-			it('should parse as usage event with sessionId', () => {
+			it('should parse as usage event with sessionId and report tokens even without usage field', () => {
+				// First accumulate some tokens
+				parser.parseJsonLine(
+					JSON.stringify({
+						type: 'assistant.message',
+						data: { content: 'Hello', toolRequests: [], outputTokens: 10 },
+					})
+				);
+
 				const line = JSON.stringify({
 					type: 'result',
 					timestamp: '2026-04-01T03:03:56.134Z',
 					sessionId: '18353c52-1a96-4ce6-ab90-1b99310f746f',
 					exitCode: 0,
-					usage: {
-						premiumRequests: 6,
-						totalApiDurationMs: 3356,
-						sessionDurationMs: 13107,
-						codeChanges: { linesAdded: 0, linesRemoved: 0, filesModified: [] },
-					},
+					// No usage field — tokens should still be reported
 				});
 
 				const event = parser.parseJsonLine(line);
 				expect(event).not.toBeNull();
 				expect(event?.type).toBe('usage');
 				expect(event?.sessionId).toBe('18353c52-1a96-4ce6-ab90-1b99310f746f');
+				expect(event?.usage).not.toBeNull();
+				expect(event?.usage?.outputTokens).toBe(10);
 			});
 		});
 

--- a/src/__tests__/main/parsers/index.test.ts
+++ b/src/__tests__/main/parsers/index.test.ts
@@ -49,21 +49,21 @@ describe('parsers/index', () => {
 			expect(hasOutputParser('factory-droid')).toBe(true);
 		});
 
-		it('should register exactly 4 parsers', () => {
+		it('should register exactly 5 parsers', () => {
 			initializeOutputParsers();
 
 			const parsers = getAllOutputParsers();
-			expect(parsers.length).toBe(4); // Claude, OpenCode, Codex, Factory Droid
+			expect(parsers.length).toBe(5); // Claude, OpenCode, Codex, Factory Droid, Copilot CLI
 		});
 
 		it('should clear existing parsers before registering', () => {
 			// First initialization
 			initializeOutputParsers();
-			expect(getAllOutputParsers().length).toBe(4);
+			expect(getAllOutputParsers().length).toBe(5);
 
-			// Second initialization should still have exactly 4
+			// Second initialization should still have exactly 5
 			initializeOutputParsers();
-			expect(getAllOutputParsers().length).toBe(4);
+			expect(getAllOutputParsers().length).toBe(5);
 		});
 	});
 
@@ -73,7 +73,7 @@ describe('parsers/index', () => {
 
 			ensureParsersInitialized();
 
-			expect(getAllOutputParsers().length).toBe(4);
+			expect(getAllOutputParsers().length).toBe(5);
 		});
 
 		it('should be idempotent after first call', () => {

--- a/src/__tests__/main/process-manager/spawners/ChildProcessSpawner.test.ts
+++ b/src/__tests__/main/process-manager/spawners/ChildProcessSpawner.test.ts
@@ -51,15 +51,19 @@ vi.mock('../../../../main/utils/logger', () => ({
 }));
 
 vi.mock('../../../../main/parsers', () => ({
-	getOutputParser: vi.fn(() => ({
-		agentId: 'claude-code',
-		parseJsonLine: vi.fn(),
-		extractUsage: vi.fn(),
-		extractSessionId: vi.fn(),
-		extractSlashCommands: vi.fn(),
-		isResultMessage: vi.fn(),
-		detectErrorFromLine: vi.fn(),
-	})),
+	getOutputParser: vi.fn((toolType: string) => {
+		// terminal has no output parser
+		if (toolType === 'terminal') return null;
+		return {
+			agentId: toolType,
+			parseJsonLine: vi.fn(),
+			extractUsage: vi.fn(),
+			extractSessionId: vi.fn(),
+			extractSlashCommands: vi.fn(),
+			isResultMessage: vi.fn(),
+			detectErrorFromLine: vi.fn(),
+		};
+	}),
 }));
 
 vi.mock('../../../../main/agents', () => ({
@@ -198,8 +202,10 @@ describe('ChildProcessSpawner', () => {
 
 			// sendPromptViaStdinRaw sends RAW text via stdin, not JSON
 			// So it should NOT set isStreamJsonMode (which is for JSON streaming)
+			// Use terminal toolType (no output parser) to test args-based detection only
 			spawner.spawn(
 				createBaseConfig({
+					toolType: 'terminal',
 					args: ['--print'],
 					sendPromptViaStdinRaw: true,
 					prompt: 'test prompt',
@@ -229,8 +235,10 @@ describe('ChildProcessSpawner', () => {
 		it('should NOT enable stream-json mode for plain args without JSON flags', () => {
 			const { processes, spawner } = createTestContext();
 
+			// Use terminal toolType (no output parser) to test args-based detection only
 			spawner.spawn(
 				createBaseConfig({
+					toolType: 'terminal',
 					args: ['--print', '--verbose'],
 				})
 			);

--- a/src/main/agents/capabilities.ts
+++ b/src/main/agents/capabilities.ts
@@ -385,6 +385,44 @@ export const AGENT_CAPABILITIES: Record<string, AgentCapabilities> = {
 		usesJsonLineOutput: false, // PLACEHOLDER
 		usesCombinedContextWindow: false, // PLACEHOLDER
 	},
+
+	/**
+	 * Copilot CLI - GitHub's agentic coding CLI
+	 * https://github.com/github/copilot-cli
+	 *
+	 * Capabilities based on official CLI command reference documentation.
+	 * Binary: `copilot`. Batch mode: `-p` flag. JSON: `--output-format json` (JSONL).
+	 * Session resume: `--resume SESSION-ID`. YOLO: `--allow-all`.
+	 *
+	 * Phase 1 capabilities are conservative — advanced features (session storage
+	 * browsing, cost tracking, thinking display) will be enabled in Phase 2
+	 * after verifying the JSON output schema.
+	 */
+	'copilot-cli': {
+		supportsResume: true, // --resume SESSION-ID
+		supportsReadOnlyMode: false, // No explicit CLI flag; may use --deny-tool in future
+		supportsJsonOutput: true, // --output-format json (JSONL format)
+		supportsSessionId: true, // sessionId in 'result' event - Verified
+		supportsImageInput: false, // Not documented in CLI reference
+		supportsImageInputOnResume: false,
+		supportsSlashCommands: true, // /help, /compact, /model, /resume, /usage, etc.
+		supportsSessionStorage: true, // ~/.copilot/session-state/<uuid>/ - Verified
+		supportsCostTracking: false, // Uses premium requests model, not per-token cost
+		supportsUsageStats: true, // outputTokens in assistant.message events - Verified
+		supportsBatchMode: true, // -p flag for programmatic execution
+		requiresPromptToStart: true, // Requires -p prompt in batch mode
+		supportsStreaming: true, // assistant.message_delta events - Verified
+		supportsResultMessages: true, // assistant.message with content and no toolRequests - Verified
+		supportsModelSelection: true, // --model flag
+		supportsStreamJsonInput: false, // Not documented
+		supportsThinkingDisplay: false, // No reasoning/thinking events observed
+		supportsContextMerge: true, // Can receive merged context via prompts
+		supportsContextExport: false, // Phase 2: session storage
+		supportsWizard: false, // Phase 2
+		supportsGroupChatModeration: false, // Phase 2
+		usesJsonLineOutput: true, // JSONL output format - Verified
+		usesCombinedContextWindow: false, // Depends on selected model
+	},
 };
 
 /**

--- a/src/main/agents/definitions.ts
+++ b/src/main/agents/definitions.ts
@@ -444,8 +444,7 @@ export const AGENT_DEFINITIONS: AgentDefinition[] = [
 				key: 'model',
 				type: 'text',
 				label: 'Model',
-				description:
-					'Model to use (e.g., "claude-sonnet-4", "gpt-5.1"). Leave empty for default.',
+				description: 'Model to use (e.g., "claude-sonnet-4", "gpt-5.1"). Leave empty for default.',
 				default: '',
 				argBuilder: (value: string) => (value && value.trim() ? ['--model', value.trim()] : []),
 			},

--- a/src/main/agents/definitions.ts
+++ b/src/main/agents/definitions.ts
@@ -96,6 +96,7 @@ export interface AgentConfig {
 	imageArgs?: (imagePath: string) => string[]; // Function to build image attachment args (e.g., ['-i', imagePath] for Codex)
 	promptArgs?: (prompt: string) => string[]; // Function to build prompt args (e.g., ['-p', prompt] for OpenCode)
 	noPromptSeparator?: boolean; // If true, don't add '--' before the prompt in batch mode (OpenCode doesn't support it)
+	sendPromptViaStdinRaw?: boolean; // If true, send prompt via stdin as raw text instead of CLI arg (avoids shell escaping issues with long prompts)
 	defaultEnvVars?: Record<string, string>; // Default environment variables for this agent (merged with user customEnvVars)
 	readOnlyEnvOverrides?: Record<string, string>; // Env var overrides applied in read-only mode (replaces keys from defaultEnvVars)
 	readOnlyCliEnforced?: boolean; // Whether the agent's CLI enforces read-only mode (false = prompt-only enforcement)
@@ -427,10 +428,12 @@ export const AGENT_DEFINITIONS: AgentDefinition[] = [
 		// Model selection
 		modelArgs: (modelId: string) => ['--model', modelId],
 
-		// Prompt is passed via -p flag
-		promptArgs: (prompt: string) => ['-p', prompt],
+		// Prompt: use '-p -' to read from stdin, avoiding shell escaping issues
+		// with long prompts on Windows. The actual prompt text is sent via stdin.
+		promptArgs: () => ['-p', '-'],
+		sendPromptViaStdinRaw: true,
 
-		// -p takes the prompt directly, no separator needed
+		// -p - reads from stdin, no separator needed
 		noPromptSeparator: true,
 
 		defaultEnvVars: {},

--- a/src/main/agents/definitions.ts
+++ b/src/main/agents/definitions.ts
@@ -408,9 +408,10 @@ export const AGENT_DEFINITIONS: AgentDefinition[] = [
 		args: [], // Base args for interactive mode (none)
 		requiresPty: false, // Batch mode uses child process
 
-		// Batch mode: copilot -p "prompt" --output-format json --allow-all
+		// Batch mode: copilot --output-format json --allow-all -p -
+		// '-p -' tells copilot to read the prompt from stdin
 		batchModePrefix: [],
-		batchModeArgs: ['--allow-all'],
+		batchModeArgs: ['--allow-all', '-p', '-'],
 
 		// JSON output for parsing (JSONL format)
 		jsonOutputArgs: ['--output-format', 'json'],
@@ -428,12 +429,10 @@ export const AGENT_DEFINITIONS: AgentDefinition[] = [
 		// Model selection
 		modelArgs: (modelId: string) => ['--model', modelId],
 
-		// Prompt: use '-p -' to read from stdin, avoiding shell escaping issues
-		// with long prompts on Windows. The actual prompt text is sent via stdin.
-		promptArgs: () => ['-p', '-'],
+		// Prompt sent via stdin (avoids shell escaping issues with long prompts on Windows)
 		sendPromptViaStdinRaw: true,
 
-		// -p - reads from stdin, no separator needed
+		// No prompt separator or promptArgs needed — prompt goes via stdin
 		noPromptSeparator: true,
 
 		defaultEnvVars: {},

--- a/src/main/agents/definitions.ts
+++ b/src/main/agents/definitions.ts
@@ -408,10 +408,11 @@ export const AGENT_DEFINITIONS: AgentDefinition[] = [
 		args: [], // Base args for interactive mode (none)
 		requiresPty: false, // Batch mode uses child process
 
-		// Batch mode: copilot --output-format json --allow-all -p -
-		// '-p -' tells copilot to read the prompt from stdin
+		// Batch mode: copilot --output-format json --allow-all
+		// Prompt is sent via stdin (sendPromptViaStdinRaw) - copilot reads
+		// from stdin automatically when no -p flag is provided and stdin is piped.
 		batchModePrefix: [],
-		batchModeArgs: ['--allow-all', '-p', '-'],
+		batchModeArgs: ['--allow-all'],
 
 		// JSON output for parsing (JSONL format)
 		jsonOutputArgs: ['--output-format', 'json'],

--- a/src/main/agents/definitions.ts
+++ b/src/main/agents/definitions.ts
@@ -399,6 +399,63 @@ export const AGENT_DEFINITIONS: AgentDefinition[] = [
 		command: 'aider',
 		args: [], // Base args (placeholder - to be configured when implemented)
 	},
+	{
+		id: 'copilot-cli',
+		name: 'Copilot CLI',
+		binaryName: 'copilot',
+		command: 'copilot',
+		args: [], // Base args for interactive mode (none)
+		requiresPty: false, // Batch mode uses child process
+
+		// Batch mode: copilot -p "prompt" --output-format json --allow-all
+		batchModePrefix: [],
+		batchModeArgs: ['--allow-all'],
+
+		// JSON output for parsing (JSONL format)
+		jsonOutputArgs: ['--output-format', 'json'],
+
+		// Session resume: --resume <id>
+		resumeArgs: (sessionId: string) => ['--resume', sessionId],
+
+		// Read-only mode: not yet CLI-enforced; use prompt-only enforcement
+		readOnlyArgs: [],
+		readOnlyCliEnforced: false,
+
+		// YOLO mode (allow all tools, paths, and URLs)
+		yoloModeArgs: ['--allow-all'],
+
+		// Model selection
+		modelArgs: (modelId: string) => ['--model', modelId],
+
+		// Prompt is passed via -p flag
+		promptArgs: (prompt: string) => ['-p', prompt],
+
+		// -p takes the prompt directly, no separator needed
+		noPromptSeparator: true,
+
+		defaultEnvVars: {},
+
+		// UI config options
+		configOptions: [
+			{
+				key: 'model',
+				type: 'text',
+				label: 'Model',
+				description:
+					'Model to use (e.g., "claude-sonnet-4", "gpt-5.1"). Leave empty for default.',
+				default: '',
+				argBuilder: (value: string) => (value && value.trim() ? ['--model', value.trim()] : []),
+			},
+			{
+				key: 'contextWindow',
+				type: 'number',
+				label: 'Context Window Size',
+				description:
+					'Maximum context window in tokens. Varies by model (e.g., 200000 for Claude/GPT-5, 128000 for GPT-4o).',
+				default: 200000,
+			},
+		],
+	},
 ];
 
 /**

--- a/src/main/ipc/handlers/process.ts
+++ b/src/main/ipc/handlers/process.ts
@@ -518,6 +518,7 @@ export function registerProcessHandlers(deps: ProcessHandlerDependencies): void 
 					imageArgs: agent?.imageArgs, // Function to build image CLI args (for Codex, OpenCode)
 					promptArgs: agent?.promptArgs, // Function to build prompt args (e.g., ['-p', prompt] for OpenCode)
 					noPromptSeparator: agent?.noPromptSeparator, // Some agents don't support '--' before prompt
+					sendPromptViaStdinRaw: agent?.sendPromptViaStdinRaw, // Send prompt via stdin as raw text (avoids shell escaping)
 					// Stats tracking: use cwd as projectPath if not explicitly provided
 					projectPath: config.cwd,
 					// SSH remote context (for SSH-specific error messages)

--- a/src/main/parsers/copilot-cli-output-parser.ts
+++ b/src/main/parsers/copilot-cli-output-parser.ts
@@ -78,10 +78,7 @@ interface CopilotCliToolRequest {
 // ============================================================================
 
 /** Extract a human-readable error message from Copilot CLI's polymorphic error field */
-function extractErrorText(
-	error: CopilotCliMessage['error'],
-	fallback = 'Unknown error'
-): string {
+function extractErrorText(error: CopilotCliMessage['error'], fallback = 'Unknown error'): string {
 	if (typeof error === 'object' && error?.message) return error.message;
 	if (typeof error === 'string') return error;
 	return fallback;

--- a/src/main/parsers/copilot-cli-output-parser.ts
+++ b/src/main/parsers/copilot-cli-output-parser.ts
@@ -269,14 +269,14 @@ export class CopilotCliOutputParser implements AgentOutputParser {
 					raw: msg,
 				};
 
-				// Extract usage stats
-				if (msg.usage) {
-					event.usage = {
-						inputTokens: 0, // Copilot CLI doesn't report input tokens
-						outputTokens: this.accumulatedOutputTokens,
-						// No per-token cost — Copilot uses premium requests model
-					};
-				}
+				// Always report accumulated output tokens, regardless of msg.usage
+				event.usage = {
+					inputTokens: 0,
+					outputTokens: this.accumulatedOutputTokens,
+				};
+
+				// Reset for next session (parser is a singleton)
+				this.accumulatedOutputTokens = 0;
 
 				return event;
 			}

--- a/src/main/parsers/copilot-cli-output-parser.ts
+++ b/src/main/parsers/copilot-cli-output-parser.ts
@@ -1,0 +1,451 @@
+/**
+ * Copilot CLI Output Parser
+ *
+ * Parses JSONL output from GitHub Copilot CLI (`copilot -p "prompt" --output-format json`).
+ *
+ * Verified event types (Copilot CLI v1.x, 2026):
+ *
+ * Session lifecycle:
+ * - session.mcp_server_status_changed: MCP server connection status
+ * - session.mcp_servers_loaded: All MCP servers initialized
+ * - session.tools_updated: Model and tools finalized (contains model name)
+ *
+ * Conversation flow:
+ * - user.message: Echo of user prompt (data.content, data.transformedContent)
+ * - assistant.turn_start: Agent begins processing (data.turnId)
+ * - assistant.message_delta: Streaming text chunk (data.deltaContent, ephemeral)
+ * - assistant.message: Complete message with optional tool requests
+ *     (data.content, data.toolRequests[], data.outputTokens)
+ * - assistant.turn_end: Turn completed (data.turnId)
+ *
+ * Tool execution:
+ * - tool.execution_start: Tool call begins (data.toolName, data.arguments)
+ * - tool.execution_complete: Tool call finished (data.toolName, data.success, data.result)
+ *
+ * Completion:
+ * - result: Session complete (sessionId, exitCode, usage.premiumRequests,
+ *   usage.totalApiDurationMs, usage.sessionDurationMs)
+ *
+ * @see https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-command-reference
+ */
+
+import type { ToolType, AgentError } from '../../shared/types';
+import type { AgentOutputParser, ParsedEvent } from './agent-output-parser';
+import { getErrorPatterns, matchErrorPattern } from './error-patterns';
+
+// ============================================================================
+// Copilot CLI JSONL Types (verified against actual output)
+// ============================================================================
+
+/** Top-level JSONL message envelope */
+interface CopilotCliMessage {
+	type: string;
+	data?: Record<string, unknown>;
+	id?: string;
+	timestamp?: string;
+	parentId?: string;
+	ephemeral?: boolean;
+	// Top-level fields on 'result' event
+	sessionId?: string;
+	exitCode?: number;
+	usage?: CopilotCliUsage;
+	error?: string | { message?: string; type?: string; code?: string };
+}
+
+/** Usage stats from the 'result' event */
+interface CopilotCliUsage {
+	premiumRequests?: number;
+	totalApiDurationMs?: number;
+	sessionDurationMs?: number;
+	codeChanges?: {
+		linesAdded?: number;
+		linesRemoved?: number;
+		filesModified?: string[];
+	};
+}
+
+/** Tool request within assistant.message */
+interface CopilotCliToolRequest {
+	toolCallId: string;
+	name: string;
+	arguments: Record<string, unknown>;
+	type?: string;
+	intentionSummary?: string;
+}
+
+// ============================================================================
+// Helper functions
+// ============================================================================
+
+/** Extract a human-readable error message from Copilot CLI's polymorphic error field */
+function extractErrorText(
+	error: CopilotCliMessage['error'],
+	fallback = 'Unknown error'
+): string {
+	if (typeof error === 'object' && error?.message) return error.message;
+	if (typeof error === 'string') return error;
+	return fallback;
+}
+
+// Maximum length for tool output to prevent oversized log entries
+const MAX_TOOL_OUTPUT_LENGTH = 10000;
+
+// ============================================================================
+// Parser implementation
+// ============================================================================
+
+/**
+ * Copilot CLI Output Parser
+ *
+ * Transforms Copilot CLI's JSONL output into normalized ParsedEvents.
+ * Verified against Copilot CLI output (2026).
+ */
+export class CopilotCliOutputParser implements AgentOutputParser {
+	readonly agentId: ToolType = 'copilot-cli';
+
+	// Accumulate output tokens from assistant.message events for usage reporting
+	private accumulatedOutputTokens = 0;
+
+	/**
+	 * Parse a single JSON line from Copilot CLI output.
+	 */
+	parseJsonLine(line: string): ParsedEvent | null {
+		if (!line.trim()) {
+			return null;
+		}
+
+		try {
+			return this.parseJsonObject(JSON.parse(line));
+		} catch {
+			// Not valid JSON — return as raw text event
+			return {
+				type: 'text',
+				text: line,
+				raw: line,
+			};
+		}
+	}
+
+	/**
+	 * Parse a pre-parsed JSON object into a normalized event.
+	 */
+	parseJsonObject(parsed: unknown): ParsedEvent | null {
+		if (!parsed || typeof parsed !== 'object') {
+			return null;
+		}
+
+		return this.transformMessage(parsed as CopilotCliMessage);
+	}
+
+	/**
+	 * Transform a parsed Copilot CLI message into a normalized ParsedEvent.
+	 */
+	private transformMessage(msg: CopilotCliMessage): ParsedEvent {
+		switch (msg.type) {
+			// ---- Session lifecycle (system events) ----
+
+			case 'session.mcp_server_status_changed':
+			case 'session.mcp_servers_loaded':
+				return { type: 'system', raw: msg };
+
+			case 'session.tools_updated':
+				// Contains model name in data.model — emit as init
+				return { type: 'init', raw: msg };
+
+			// ---- User message echo ----
+
+			case 'user.message':
+				return { type: 'system', raw: msg };
+
+			// ---- Assistant turn lifecycle ----
+
+			case 'assistant.turn_start':
+				return { type: 'system', raw: msg };
+
+			case 'assistant.message_delta': {
+				// Streaming text chunk — data.deltaContent
+				const deltaContent = (msg.data?.deltaContent as string) || '';
+				return {
+					type: 'text',
+					text: deltaContent,
+					isPartial: true,
+					raw: msg,
+				};
+			}
+
+			case 'assistant.message': {
+				// Complete message — may contain text content and/or tool requests
+				const content = (msg.data?.content as string) || '';
+				const toolRequests = (msg.data?.toolRequests as CopilotCliToolRequest[]) || [];
+				const outputTokens = (msg.data?.outputTokens as number) || 0;
+
+				// Track output tokens for usage reporting
+				this.accumulatedOutputTokens += outputTokens;
+
+				// If the message has tool requests but no text, emit tool_use blocks
+				if (toolRequests.length > 0 && !content) {
+					return {
+						type: 'tool_use',
+						toolUseBlocks: toolRequests.map((tr) => ({
+							name: tr.name,
+							id: tr.toolCallId,
+							input: tr.arguments,
+						})),
+						raw: msg,
+					};
+				}
+
+				// If the message has tool requests AND text, emit as text with tool blocks
+				if (toolRequests.length > 0 && content) {
+					return {
+						type: 'text',
+						text: content,
+						toolUseBlocks: toolRequests.map((tr) => ({
+							name: tr.name,
+							id: tr.toolCallId,
+							input: tr.arguments,
+						})),
+						raw: msg,
+					};
+				}
+
+				// Text-only message — this is the agent's response
+				return {
+					type: 'result',
+					text: content,
+					isPartial: false,
+					raw: msg,
+				};
+			}
+
+			case 'assistant.turn_end':
+				return { type: 'system', raw: msg };
+
+			// ---- Tool execution ----
+
+			case 'tool.execution_start': {
+				const toolName = (msg.data?.toolName as string) || undefined;
+				return {
+					type: 'tool_use',
+					toolName,
+					toolState: {
+						status: 'running',
+						input: msg.data?.arguments,
+					},
+					raw: msg,
+				};
+			}
+
+			case 'tool.execution_complete': {
+				const toolName = (msg.data?.toolName as string) || undefined;
+				const result = msg.data?.result as
+					| { content?: string; detailedContent?: string }
+					| undefined;
+				let output = result?.content || '';
+				if (output.length > MAX_TOOL_OUTPUT_LENGTH) {
+					const originalLength = output.length;
+					output =
+						output.substring(0, MAX_TOOL_OUTPUT_LENGTH) +
+						`\n... [output truncated, ${originalLength} chars total]`;
+				}
+				return {
+					type: 'tool_use',
+					toolName,
+					toolState: {
+						status: 'completed',
+						output,
+						success: msg.data?.success,
+					},
+					raw: msg,
+				};
+			}
+
+			// ---- Result (session complete) ----
+
+			case 'result': {
+				const event: ParsedEvent = {
+					type: 'usage',
+					sessionId: msg.sessionId,
+					raw: msg,
+				};
+
+				// Extract usage stats
+				if (msg.usage) {
+					event.usage = {
+						inputTokens: 0, // Copilot CLI doesn't report input tokens
+						outputTokens: this.accumulatedOutputTokens,
+						// No per-token cost — Copilot uses premium requests model
+					};
+				}
+
+				return event;
+			}
+
+			// ---- Error events ----
+
+			default: {
+				// Check for error-like events
+				if (msg.type?.includes('error') || msg.error) {
+					return {
+						type: 'error',
+						text: extractErrorText(msg.error),
+						raw: msg,
+					};
+				}
+
+				// Unknown event type — preserve as system
+				return { type: 'system', raw: msg };
+			}
+		}
+	}
+
+	/**
+	 * Check if an event is a final result message.
+	 * For Copilot CLI, assistant.message events with content and no tool requests
+	 * are result messages.
+	 */
+	isResultMessage(event: ParsedEvent): boolean {
+		return event.type === 'result' && !!event.text;
+	}
+
+	/**
+	 * Extract session ID from an event.
+	 * Copilot CLI provides sessionId in the final 'result' event.
+	 */
+	extractSessionId(event: ParsedEvent): string | null {
+		return event.sessionId || null;
+	}
+
+	/**
+	 * Extract usage statistics from an event.
+	 */
+	extractUsage(event: ParsedEvent): ParsedEvent['usage'] | null {
+		return event.usage || null;
+	}
+
+	/**
+	 * Extract slash commands from an event.
+	 * Copilot CLI supports slash commands interactively, but they're not
+	 * emitted in the JSON output.
+	 */
+	extractSlashCommands(_event: ParsedEvent): string[] | null {
+		return null;
+	}
+
+	/**
+	 * Detect an error from a line of agent output.
+	 */
+	detectErrorFromLine(line: string): AgentError | null {
+		if (!line.trim()) {
+			return null;
+		}
+
+		try {
+			const error = this.detectErrorFromParsed(JSON.parse(line));
+			if (error) {
+				error.raw = { ...(error.raw as Record<string, unknown>), errorLine: line };
+			}
+			return error;
+		} catch {
+			// Not JSON — check plain text against error patterns
+			const patterns = getErrorPatterns(this.agentId);
+			const match = matchErrorPattern(patterns, line);
+			if (match) {
+				return {
+					type: match.type,
+					message: match.message,
+					recoverable: match.recoverable,
+					agentId: this.agentId,
+					timestamp: Date.now(),
+					raw: { errorLine: line },
+				};
+			}
+			return null;
+		}
+	}
+
+	/**
+	 * Detect an error from a pre-parsed JSON object.
+	 */
+	detectErrorFromParsed(parsed: unknown): AgentError | null {
+		if (!parsed || typeof parsed !== 'object') {
+			return null;
+		}
+
+		const obj = parsed as CopilotCliMessage;
+		let errorText: string | null = null;
+		let parsedJson: unknown = null;
+
+		if (obj.type?.includes('error') || obj.error) {
+			parsedJson = parsed;
+			errorText = extractErrorText(obj.error);
+			if (errorText === 'Unknown error') errorText = null;
+		}
+
+		if (!errorText) {
+			return null;
+		}
+
+		const patterns = getErrorPatterns(this.agentId);
+		const match = matchErrorPattern(patterns, errorText);
+
+		if (match) {
+			return {
+				type: match.type,
+				message: match.message,
+				recoverable: match.recoverable,
+				agentId: this.agentId,
+				timestamp: Date.now(),
+				parsedJson,
+			};
+		}
+
+		// Unrecognized error — still report it
+		if (parsedJson) {
+			return {
+				type: 'unknown',
+				message: errorText,
+				recoverable: true,
+				agentId: this.agentId,
+				timestamp: Date.now(),
+				parsedJson,
+			};
+		}
+
+		return null;
+	}
+
+	/**
+	 * Detect an error from process exit information.
+	 */
+	detectErrorFromExit(exitCode: number, stderr: string, stdout: string): AgentError | null {
+		if (exitCode === 0) {
+			return null;
+		}
+
+		const combined = `${stderr}\n${stdout}`;
+		const patterns = getErrorPatterns(this.agentId);
+		const match = matchErrorPattern(patterns, combined);
+
+		if (match) {
+			return {
+				type: match.type,
+				message: match.message,
+				recoverable: match.recoverable,
+				agentId: this.agentId,
+				timestamp: Date.now(),
+				raw: { exitCode, stderr, stdout },
+			};
+		}
+
+		// Non-zero exit with no recognized pattern
+		return {
+			type: 'agent_crashed',
+			message: `Copilot CLI exited with code ${exitCode}`,
+			recoverable: true,
+			agentId: this.agentId,
+			timestamp: Date.now(),
+			raw: { exitCode, stderr, stdout },
+		};
+	}
+}

--- a/src/main/parsers/copilot-cli-output-parser.ts
+++ b/src/main/parsers/copilot-cli-output-parser.ts
@@ -376,7 +376,13 @@ export class CopilotCliOutputParser implements AgentOutputParser {
 		let errorText: string | null = null;
 		let parsedJson: unknown = null;
 
-		if (obj.type?.includes('error') || obj.error) {
+		// Handle session.error events (Copilot CLI format: data.message, data.errorType)
+		if (obj.type === 'session.error' && obj.data) {
+			parsedJson = parsed;
+			errorText = (obj.data.message as string) || null;
+		}
+		// Handle generic error events
+		else if (obj.type?.includes('error') || obj.error) {
 			parsedJson = parsed;
 			errorText = extractErrorText(obj.error);
 			if (errorText === 'Unknown error') errorText = null;
@@ -434,7 +440,7 @@ export class CopilotCliOutputParser implements AgentOutputParser {
 				recoverable: match.recoverable,
 				agentId: this.agentId,
 				timestamp: Date.now(),
-				raw: { exitCode, stderr, stdout },
+				raw: { exitCode },
 			};
 		}
 
@@ -445,7 +451,7 @@ export class CopilotCliOutputParser implements AgentOutputParser {
 			recoverable: true,
 			agentId: this.agentId,
 			timestamp: Date.now(),
-			raw: { exitCode, stderr, stdout },
+			raw: { exitCode },
 		};
 	}
 }

--- a/src/main/parsers/error-patterns.ts
+++ b/src/main/parsers/error-patterns.ts
@@ -856,6 +856,82 @@ export const SSH_ERROR_PATTERNS: AgentErrorPatterns = {
 };
 
 // ============================================================================
+// Copilot CLI Error Patterns
+// ============================================================================
+
+const COPILOT_CLI_ERROR_PATTERNS: AgentErrorPatterns = {
+	auth_expired: [
+		{
+			pattern: /not authenticated|not logged in/i,
+			message: 'Not authenticated. Please run "copilot login" to authenticate.',
+			recoverable: true,
+		},
+		{
+			pattern: /authentication failed/i,
+			message: 'Authentication failed. Please run "copilot login" to re-authenticate.',
+			recoverable: true,
+		},
+		{
+			pattern: /token.*expired|expired.*token/i,
+			message: 'Authentication token expired. Please run "copilot login" to re-authenticate.',
+			recoverable: true,
+		},
+		{
+			pattern: /unauthorized/i,
+			message: 'Unauthorized. Please check your Copilot subscription and credentials.',
+			recoverable: true,
+		},
+	],
+
+	rate_limited: [
+		{
+			pattern: /rate limit|too many requests/i,
+			message: 'Rate limited by GitHub Copilot. Please wait a moment before retrying.',
+			recoverable: true,
+		},
+	],
+
+	network_error: [
+		{
+			pattern: /network error|connection refused|ECONNREFUSED/i,
+			message: 'Network error connecting to Copilot. Check your internet connection.',
+			recoverable: true,
+		},
+		{
+			pattern: /timeout|ETIMEDOUT/i,
+			message: 'Connection timed out. Check your internet connection.',
+			recoverable: true,
+		},
+	],
+
+	token_exhaustion: [
+		{
+			pattern: /context.*too long|context window/i,
+			message: 'Context window exceeded. Please start a new session.',
+			recoverable: true,
+		},
+		{
+			pattern: /maximum.*tokens/i,
+			message: 'Maximum token limit reached. Start a new session.',
+			recoverable: true,
+		},
+	],
+
+	agent_crashed: [
+		{
+			pattern: /model.*not available|model.*not found/i,
+			message: 'The selected model is not available. Try a different model.',
+			recoverable: true,
+		},
+		{
+			pattern: /copilot.*command not found/i,
+			message: 'Copilot CLI not found. Ensure it is installed and in your PATH.',
+			recoverable: false,
+		},
+	],
+};
+
+// ============================================================================
 // Pattern Registry
 // ============================================================================
 
@@ -864,6 +940,7 @@ const patternRegistry = new Map<ToolType, AgentErrorPatterns>([
 	['opencode', OPENCODE_ERROR_PATTERNS],
 	['codex', CODEX_ERROR_PATTERNS],
 	['factory-droid', FACTORY_DROID_ERROR_PATTERNS],
+	['copilot-cli', COPILOT_CLI_ERROR_PATTERNS],
 ]);
 
 /**

--- a/src/main/parsers/index.ts
+++ b/src/main/parsers/index.ts
@@ -54,6 +54,7 @@ import { ClaudeOutputParser } from './claude-output-parser';
 import { OpenCodeOutputParser } from './opencode-output-parser';
 import { CodexOutputParser } from './codex-output-parser';
 import { FactoryDroidOutputParser } from './factory-droid-output-parser';
+import { CopilotCliOutputParser } from './copilot-cli-output-parser';
 import {
 	registerOutputParser,
 	clearParserRegistry,
@@ -66,6 +67,7 @@ export { ClaudeOutputParser } from './claude-output-parser';
 export { OpenCodeOutputParser } from './opencode-output-parser';
 export { CodexOutputParser } from './codex-output-parser';
 export { FactoryDroidOutputParser } from './factory-droid-output-parser';
+export { CopilotCliOutputParser } from './copilot-cli-output-parser';
 
 const LOG_CONTEXT = '[OutputParsers]';
 
@@ -82,6 +84,7 @@ export function initializeOutputParsers(): void {
 	registerOutputParser(new OpenCodeOutputParser());
 	registerOutputParser(new CodexOutputParser());
 	registerOutputParser(new FactoryDroidOutputParser());
+	registerOutputParser(new CopilotCliOutputParser());
 
 	// Log registered parsers for debugging
 	const registeredParsers = getAllOutputParsers().map((p) => p.agentId);

--- a/src/main/process-manager/handlers/StderrHandler.ts
+++ b/src/main/process-manager/handlers/StderrHandler.ts
@@ -115,15 +115,11 @@ export class StderrHandler {
 			if (outputParser && toolType !== 'codex') {
 				// Codex is excluded because it has its own special stderr handling below
 				// that re-emits actual response content from stderr as data.
-				logger.info(
-					'[ProcessManager] Suppressing stderr for JSONL agent',
-					'ProcessManager',
-					{
-						sessionId,
-						toolType,
-						stderrPreview: cleanedStderr.substring(0, 100),
-					}
-				);
+				logger.info('[ProcessManager] Suppressing stderr for JSONL agent', 'ProcessManager', {
+					sessionId,
+					toolType,
+					stderrPreview: cleanedStderr.substring(0, 100),
+				});
 				return;
 			}
 

--- a/src/main/process-manager/handlers/StderrHandler.ts
+++ b/src/main/process-manager/handlers/StderrHandler.ts
@@ -107,6 +107,26 @@ export class StderrHandler {
 				return;
 			}
 
+			// For JSONL agents with output parsers (copilot-cli, codex, opencode,
+			// factory-droid), suppress stderr display. These agents emit MCP server
+			// startup messages, shell profile banners, and other initialization noise
+			// to stderr that should not be shown to the user. Error detection has
+			// already happened above, so real errors are already captured.
+			if (outputParser && toolType !== 'codex') {
+				// Codex is excluded because it has its own special stderr handling below
+				// that re-emits actual response content from stderr as data.
+				logger.debug(
+					'[ProcessManager] Suppressing stderr for JSONL agent',
+					'ProcessManager',
+					{
+						sessionId,
+						toolType,
+						stderrPreview: cleanedStderr.substring(0, 100),
+					}
+				);
+				return;
+			}
+
 			// Codex writes both Rust tracing diagnostics and actual responses to stderr.
 			// Strip tracing lines (e.g. "2026-02-08T04:39:23Z ERROR codex_core::rollout::list: ...")
 			// and the "Reading prompt from stdin..." prefix, then re-emit any remaining

--- a/src/main/process-manager/handlers/StderrHandler.ts
+++ b/src/main/process-manager/handlers/StderrHandler.ts
@@ -115,7 +115,7 @@ export class StderrHandler {
 			if (outputParser && toolType !== 'codex') {
 				// Codex is excluded because it has its own special stderr handling below
 				// that re-emits actual response content from stderr as data.
-				logger.debug(
+				logger.info(
 					'[ProcessManager] Suppressing stderr for JSONL agent',
 					'ProcessManager',
 					{

--- a/src/main/process-manager/handlers/StdoutHandler.ts
+++ b/src/main/process-manager/handlers/StdoutHandler.ts
@@ -236,6 +236,13 @@ export class StdoutHandler {
 			// non-JSON noise from shell profiles or MCP server startup that should
 			// not be displayed to the user.
 			this.bufferManager.emitDataBuffered(sessionId, line);
+		} else {
+			// Suppressed non-JSON line for JSONL agent
+			logger.info('[StdoutHandler] SUPPRESSED non-JSON line for JSONL agent', 'ProcessManager', {
+				sessionId,
+				toolType: managedProcess.toolType,
+				linePreview: line.substring(0, 80),
+			});
 		}
 	}
 

--- a/src/main/process-manager/handlers/StdoutHandler.ts
+++ b/src/main/process-manager/handlers/StdoutHandler.ts
@@ -230,7 +230,11 @@ export class StdoutHandler {
 			} else {
 				this.handleLegacyMessage(sessionId, managedProcess, parsed);
 			}
-		} else {
+		} else if (!outputParser) {
+			// Only emit raw non-JSON lines when there's no output parser.
+			// JSONL agents (copilot-cli, codex, opencode, factory-droid) may output
+			// non-JSON noise from shell profiles or MCP server startup that should
+			// not be displayed to the user.
 			this.bufferManager.emitDataBuffered(sessionId, line);
 		}
 	}

--- a/src/main/process-manager/spawners/ChildProcessSpawner.ts
+++ b/src/main/process-manager/spawners/ChildProcessSpawner.ts
@@ -336,6 +336,10 @@ export class ChildProcessSpawner {
 			// because the SSH command wraps the actual agent command. Without this, the output
 			// parser won't process JSON output from remote agents, causing raw JSON to display.
 			// NOTE: sendPromptViaStdinRaw sends RAW text (not JSON), so it should NOT set isStreamJsonMode
+
+			// Get the output parser for this agent type (needed for isStreamJsonMode check)
+			const outputParser = getOutputParser(toolType) || undefined;
+
 			const argsContain = (pattern: string) => finalArgs.some((arg) => arg.includes(pattern));
 			const isStreamJsonMode =
 				argsContain('stream-json') ||
@@ -343,10 +347,8 @@ export class ChildProcessSpawner {
 				(argsContain('--format') && argsContain('json')) ||
 				(hasImages && !!prompt) ||
 				!!config.sendPromptViaStdin ||
-				!!config.sshStdinScript;
-
-			// Get the output parser for this agent type
-			const outputParser = getOutputParser(toolType) || undefined;
+				!!config.sshStdinScript ||
+				!!outputParser; // Agents with output parsers use streaming JSONL, not batch JSON
 
 			logger.debug('[ProcessManager] Output parser lookup', 'ProcessManager', {
 				sessionId,

--- a/src/main/storage/copilot-cli-session-storage.ts
+++ b/src/main/storage/copilot-cli-session-storage.ts
@@ -66,7 +66,7 @@ function parseWorkspaceYaml(content: string): Record<string, string> {
 		if (match) {
 			const key = match[1];
 			// Prefer single-quoted group (match[2]), fall back to unquoted (match[3])
-			const value = match[2] !== undefined ? match[2].replace(/''/g, "'") : (match[3] || '');
+			const value = match[2] !== undefined ? match[2].replace(/''/g, "'") : match[3] || '';
 			result[key] = value;
 		}
 	}

--- a/src/main/storage/copilot-cli-session-storage.ts
+++ b/src/main/storage/copilot-cli-session-storage.ts
@@ -81,6 +81,11 @@ interface CopilotEvent {
 	timestamp?: string;
 }
 
+/** Validate that a session ID is a UUID to prevent path traversal */
+function isValidSessionId(sessionId: string): boolean {
+	return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(sessionId);
+}
+
 // ============================================================================
 // Session Storage Implementation
 // ============================================================================
@@ -238,6 +243,9 @@ export class CopilotCliSessionStorage extends BaseSessionStorage {
 		options?: SessionReadOptions,
 		_sshConfig?: SshRemoteConfig
 	): Promise<SessionMessagesResult> {
+		if (!isValidSessionId(sessionId)) {
+			return { messages: [], total: 0, hasMore: false };
+		}
 		const sessionDir = path.join(getCopilotSessionDir(), sessionId);
 		const eventsPath = path.join(sessionDir, 'events.jsonl');
 
@@ -293,6 +301,9 @@ export class CopilotCliSessionStorage extends BaseSessionStorage {
 		sessionId: string,
 		_sshConfig?: SshRemoteConfig
 	): string | null {
+		if (!isValidSessionId(sessionId)) {
+			return null;
+		}
 		return path.join(getCopilotSessionDir(), sessionId, 'events.jsonl');
 	}
 
@@ -317,6 +328,9 @@ export class CopilotCliSessionStorage extends BaseSessionStorage {
 		_projectPath: string,
 		_sshConfig?: SshRemoteConfig
 	): Promise<SearchableMessage[]> {
+		if (!isValidSessionId(sessionId)) {
+			return [];
+		}
 		const sessionDir = path.join(getCopilotSessionDir(), sessionId);
 		const eventsPath = path.join(sessionDir, 'events.jsonl');
 

--- a/src/main/storage/copilot-cli-session-storage.ts
+++ b/src/main/storage/copilot-cli-session-storage.ts
@@ -1,0 +1,342 @@
+/**
+ * Copilot CLI Session Storage Implementation
+ *
+ * This module implements the AgentSessionStorage interface for GitHub Copilot CLI.
+ * Copilot CLI stores sessions in ~/.copilot/session-state/ as UUID directories.
+ *
+ * Directory structure:
+ * - ~/.copilot/session-state/<uuid>/workspace.yaml — Session metadata (id, cwd, summary, timestamps)
+ * - ~/.copilot/session-state/<uuid>/events.jsonl — JSONL event history
+ *
+ * workspace.yaml fields:
+ * - id: Session UUID
+ * - cwd: Working directory
+ * - summary: Auto-generated session summary
+ * - created_at: ISO timestamp
+ * - updated_at: ISO timestamp
+ * - summary_count: Number of summaries generated
+ *
+ * events.jsonl types:
+ * - session.start: Session initialization (sessionId, copilotVersion, cwd)
+ * - user.message: User prompt (data.content)
+ * - assistant.message: Agent response (data.content, data.toolRequests, data.outputTokens)
+ * - tool.execution_start / tool.execution_complete: Tool use
+ * - result: Session completion (sessionId, usage)
+ *
+ * Note: Sessions are stored globally (not per-project), but each session's
+ * workspace.yaml contains a `cwd` field for filtering by project path.
+ *
+ * Verified against Copilot CLI session files (2026-04)
+ * @see https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-command-reference
+ */
+
+import path from 'path';
+import os from 'os';
+import fs from 'fs/promises';
+import { logger } from '../utils/logger';
+import { BaseSessionStorage, type SearchableMessage } from './base-session-storage';
+import type {
+	AgentSessionInfo,
+	SessionMessagesResult,
+	SessionReadOptions,
+	SessionMessage,
+} from '../agents';
+import type { ToolType, SshRemoteConfig } from '../../shared/types';
+
+const LOG_CONTEXT = '[CopilotCliSessionStorage]';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/** Get the Copilot CLI session storage base directory */
+function getCopilotSessionDir(): string {
+	return path.join(os.homedir(), '.copilot', 'session-state');
+}
+
+/**
+ * Parse a workspace.yaml file (simple key: value format).
+ * Copilot CLI uses a minimal YAML format that can be parsed without a YAML library.
+ */
+function parseWorkspaceYaml(content: string): Record<string, string> {
+	const result: Record<string, string> = {};
+	for (const line of content.split('\n')) {
+		// Match: key: value (handle quoted values with 'single quotes')
+		const match = line.match(/^(\w+):\s*(?:'((?:[^']|'')*)'|(.*))\s*$/);
+		if (match) {
+			const key = match[1];
+			// Prefer single-quoted group (match[2]), fall back to unquoted (match[3])
+			const value = match[2] !== undefined ? match[2].replace(/''/g, "'") : (match[3] || '');
+			result[key] = value;
+		}
+	}
+	return result;
+}
+
+/** JSONL event from events.jsonl */
+interface CopilotEvent {
+	type: string;
+	id?: string;
+	data?: Record<string, unknown>;
+	timestamp?: string;
+}
+
+// ============================================================================
+// Session Storage Implementation
+// ============================================================================
+
+/**
+ * Copilot CLI Session Storage
+ *
+ * Provides access to Copilot CLI's local session storage at ~/.copilot/session-state/
+ */
+export class CopilotCliSessionStorage extends BaseSessionStorage {
+	readonly agentId: ToolType = 'copilot-cli';
+
+	/**
+	 * Load and parse events from a session's events.jsonl file
+	 */
+	private async loadSessionEvents(eventsPath: string): Promise<CopilotEvent[]> {
+		try {
+			const content = await fs.readFile(eventsPath, 'utf-8');
+			const lines = content
+				.trim()
+				.split('\n')
+				.filter((l) => l.trim());
+			const events: CopilotEvent[] = [];
+
+			for (const line of lines) {
+				try {
+					events.push(JSON.parse(line) as CopilotEvent);
+				} catch {
+					// Skip unparseable lines
+				}
+			}
+			return events;
+		} catch {
+			return [];
+		}
+	}
+
+	/**
+	 * List all Copilot CLI sessions, optionally filtered by project path.
+	 */
+	async listSessions(
+		projectPath: string,
+		_sshConfig?: SshRemoteConfig
+	): Promise<AgentSessionInfo[]> {
+		const sessionBaseDir = getCopilotSessionDir();
+
+		try {
+			await fs.access(sessionBaseDir);
+		} catch {
+			logger.info('No Copilot CLI session-state directory found', LOG_CONTEXT);
+			return [];
+		}
+
+		const entries = await fs.readdir(sessionBaseDir, { withFileTypes: true });
+		const sessions: AgentSessionInfo[] = [];
+
+		// Normalize the project path for comparison
+		const normalizedProjectPath = path.resolve(projectPath).toLowerCase();
+
+		for (const entry of entries) {
+			if (!entry.isDirectory()) continue;
+
+			// UUID directory names
+			const sessionDir = path.join(sessionBaseDir, entry.name);
+			const workspacePath = path.join(sessionDir, 'workspace.yaml');
+
+			try {
+				const yamlContent = await fs.readFile(workspacePath, 'utf-8');
+				const meta = parseWorkspaceYaml(yamlContent);
+
+				// Filter by project path if the session has a cwd
+				if (meta.cwd) {
+					const normalizedCwd = path.resolve(meta.cwd).toLowerCase();
+					if (normalizedCwd !== normalizedProjectPath) {
+						continue;
+					}
+				}
+
+				const sessionId = meta.id || entry.name;
+				const summary = meta.summary || '';
+				const createdAt = meta.created_at || '';
+				const updatedAt = meta.updated_at || createdAt;
+
+				// Try to get first user message from events.jsonl
+				const eventsPath = path.join(sessionDir, 'events.jsonl');
+				const events = await this.loadSessionEvents(eventsPath);
+
+				let firstMessage = summary;
+				let messageCount = 0;
+
+				for (const event of events) {
+					if (event.type === 'user.message' && event.data?.content) {
+						if (!firstMessage) {
+							firstMessage = String(event.data.content).slice(0, 200);
+						}
+						messageCount++;
+					} else if (event.type === 'assistant.message') {
+						messageCount++;
+					}
+				}
+
+				// Get file size for info
+				let sizeBytes = 0;
+				try {
+					const stat = await fs.stat(eventsPath);
+					sizeBytes = stat.size;
+				} catch {
+					// events.jsonl may not exist for empty sessions
+				}
+
+				// Calculate duration from timestamps
+				let durationSeconds = 0;
+				if (createdAt && updatedAt) {
+					const diff = new Date(updatedAt).getTime() - new Date(createdAt).getTime();
+					durationSeconds = Math.max(0, Math.floor(diff / 1000));
+				}
+
+				sessions.push({
+					sessionId,
+					sessionName: summary || undefined,
+					projectPath,
+					timestamp: createdAt,
+					modifiedAt: updatedAt,
+					firstMessage: firstMessage || 'Copilot CLI session',
+					messageCount,
+					sizeBytes,
+					inputTokens: 0,
+					outputTokens: 0,
+					cacheReadTokens: 0,
+					cacheCreationTokens: 0,
+					durationSeconds,
+				});
+			} catch (e) {
+				// Skip sessions with unreadable metadata
+				logger.debug(`Skipping session ${entry.name}: ${e}`, LOG_CONTEXT);
+			}
+		}
+
+		// Sort by modified date (newest first)
+		sessions.sort((a, b) => new Date(b.modifiedAt).getTime() - new Date(a.modifiedAt).getTime());
+
+		logger.info(
+			`Found ${sessions.length} Copilot CLI sessions for project: ${projectPath}`,
+			LOG_CONTEXT
+		);
+		return sessions;
+	}
+
+	/**
+	 * Read messages from a specific session.
+	 */
+	async readSessionMessages(
+		_projectPath: string,
+		sessionId: string,
+		options?: SessionReadOptions,
+		_sshConfig?: SshRemoteConfig
+	): Promise<SessionMessagesResult> {
+		const sessionDir = path.join(getCopilotSessionDir(), sessionId);
+		const eventsPath = path.join(sessionDir, 'events.jsonl');
+
+		const events = await this.loadSessionEvents(eventsPath);
+		if (events.length === 0) {
+			return { messages: [], total: 0, hasMore: false };
+		}
+
+		const messages: SessionMessage[] = [];
+
+		for (const event of events) {
+			if (event.type === 'user.message' && event.data?.content) {
+				messages.push({
+					type: 'user',
+					role: 'user',
+					content: String(event.data.content),
+					timestamp: event.timestamp || '',
+					uuid: event.id || '',
+				});
+			} else if (event.type === 'assistant.message' && event.data) {
+				const content = String(event.data.content || '');
+				if (content) {
+					messages.push({
+						type: 'assistant',
+						role: 'assistant',
+						content,
+						timestamp: event.timestamp || '',
+						uuid: event.id || '',
+					});
+				}
+			}
+		}
+
+		const totalMessages = messages.length;
+
+		// Apply pagination
+		const limit = options?.limit || totalMessages;
+		const offset = options?.offset || 0;
+		const paginatedMessages = messages.slice(offset, offset + limit);
+
+		return {
+			messages: paginatedMessages,
+			total: totalMessages,
+			hasMore: offset + limit < totalMessages,
+		};
+	}
+
+	/**
+	 * Get the file path for a session.
+	 */
+	getSessionPath(
+		_projectPath: string,
+		sessionId: string,
+		_sshConfig?: SshRemoteConfig
+	): string | null {
+		return path.join(getCopilotSessionDir(), sessionId, 'events.jsonl');
+	}
+
+	/**
+	 * Delete a message pair from a session (not supported for Copilot CLI).
+	 */
+	async deleteMessagePair(
+		_projectPath: string,
+		_sessionId: string,
+		_userMessageUuid: string,
+		_fallbackContent?: string,
+		_sshConfig?: SshRemoteConfig
+	): Promise<{ success: boolean; error?: string; linesRemoved?: number }> {
+		return { success: false, error: 'Message deletion not supported for Copilot CLI sessions' };
+	}
+
+	/**
+	 * Load messages in simplified format for search.
+	 */
+	protected async getSearchableMessages(
+		sessionId: string,
+		_projectPath: string,
+		_sshConfig?: SshRemoteConfig
+	): Promise<SearchableMessage[]> {
+		const sessionDir = path.join(getCopilotSessionDir(), sessionId);
+		const eventsPath = path.join(sessionDir, 'events.jsonl');
+
+		const events = await this.loadSessionEvents(eventsPath);
+		const messages: SearchableMessage[] = [];
+
+		for (const event of events) {
+			if (event.type === 'user.message' && event.data?.content) {
+				messages.push({
+					role: 'user',
+					textContent: String(event.data.content),
+				});
+			} else if (event.type === 'assistant.message' && event.data?.content) {
+				messages.push({
+					role: 'assistant',
+					textContent: String(event.data.content),
+				});
+			}
+		}
+
+		return messages;
+	}
+}

--- a/src/main/storage/index.ts
+++ b/src/main/storage/index.ts
@@ -9,6 +9,7 @@ export { ClaudeSessionStorage, ClaudeSessionOriginsData } from './claude-session
 export { OpenCodeSessionStorage } from './opencode-session-storage';
 export { CodexSessionStorage } from './codex-session-storage';
 export { FactoryDroidSessionStorage } from './factory-droid-session-storage';
+export { CopilotCliSessionStorage } from './copilot-cli-session-storage';
 
 import Store from 'electron-store';
 import { registerSessionStorage } from '../agents';
@@ -16,6 +17,7 @@ import { ClaudeSessionStorage, ClaudeSessionOriginsData } from './claude-session
 import { OpenCodeSessionStorage } from './opencode-session-storage';
 import { CodexSessionStorage } from './codex-session-storage';
 import { FactoryDroidSessionStorage } from './factory-droid-session-storage';
+import { CopilotCliSessionStorage } from './copilot-cli-session-storage';
 
 /**
  * Options for initializing session storages
@@ -36,4 +38,5 @@ export function initializeSessionStorages(options?: InitializeSessionStoragesOpt
 	registerSessionStorage(new OpenCodeSessionStorage());
 	registerSessionStorage(new CodexSessionStorage());
 	registerSessionStorage(new FactoryDroidSessionStorage());
+	registerSessionStorage(new CopilotCliSessionStorage());
 }

--- a/src/renderer/components/NewInstanceModal.tsx
+++ b/src/renderer/components/NewInstanceModal.tsx
@@ -77,7 +77,7 @@ interface EditAgentModalProps {
 }
 
 // Supported agents that are fully implemented
-const SUPPORTED_AGENTS = ['claude-code', 'opencode', 'codex', 'factory-droid'];
+const SUPPORTED_AGENTS = ['claude-code', 'opencode', 'codex', 'factory-droid', 'copilot-cli'];
 
 export function NewInstanceModal({
 	isOpen,

--- a/src/renderer/components/Wizard/screens/AgentSelectionScreen.tsx
+++ b/src/renderer/components/Wizard/screens/AgentSelectionScreen.tsx
@@ -95,9 +95,9 @@ export const AGENT_TILES: AgentTile[] = [
 	},
 ];
 
-// Grid dimensions for keyboard navigation (3 cols for 7 items)
+// Grid dimensions for keyboard navigation
 const GRID_COLS = 3;
-const GRID_ROWS = 3;
+const GRID_ROWS = Math.ceil(AGENT_TILES.length / GRID_COLS);
 
 /**
  * Get SVG logo for an agent with brand colors

--- a/src/renderer/components/Wizard/screens/AgentSelectionScreen.tsx
+++ b/src/renderer/components/Wizard/screens/AgentSelectionScreen.tsx
@@ -71,6 +71,13 @@ export const AGENT_TILES: AgentTile[] = [
 		description: "Factory's AI coding assistant",
 		brandColor: '#3B82F6', // Factory blue
 	},
+	{
+		id: 'copilot-cli',
+		name: 'Copilot CLI',
+		supported: true,
+		description: "GitHub's AI coding assistant",
+		brandColor: '#6E40C9', // GitHub purple
+	},
 	// Coming soon agents at the bottom
 	{
 		id: 'gemini-cli',
@@ -88,9 +95,9 @@ export const AGENT_TILES: AgentTile[] = [
 	},
 ];
 
-// Grid dimensions for keyboard navigation (3 cols for 6 items)
+// Grid dimensions for keyboard navigation (3 cols for 7 items)
 const GRID_COLS = 3;
-const GRID_ROWS = 2;
+const GRID_ROWS = 3;
 
 /**
  * Get SVG logo for an agent with brand colors

--- a/src/shared/agentConstants.ts
+++ b/src/shared/agentConstants.ts
@@ -18,6 +18,7 @@ export const DEFAULT_CONTEXT_WINDOWS: Partial<Record<AgentId, number>> = {
 	codex: 200000, // OpenAI o3/o4-mini context window
 	opencode: 128000, // OpenCode (depends on model, 128k is conservative default)
 	'factory-droid': 200000, // Factory Droid (varies by model, defaults to Claude Opus)
+	'copilot-cli': 200000, // Copilot CLI (varies by model, 200k conservative default)
 	terminal: 0, // Terminal has no context window
 };
 

--- a/src/shared/agentIds.ts
+++ b/src/shared/agentIds.ts
@@ -21,6 +21,7 @@ export const AGENT_IDS = [
 	'qwen3-coder',
 	'opencode',
 	'factory-droid',
+	'copilot-cli',
 	'aider',
 ] as const;
 

--- a/src/shared/agentMetadata.ts
+++ b/src/shared/agentMetadata.ts
@@ -20,6 +20,7 @@ export const AGENT_DISPLAY_NAMES: Record<AgentId, string> = {
 	'qwen3-coder': 'Qwen3 Coder',
 	opencode: 'OpenCode',
 	'factory-droid': 'Factory Droid',
+	'copilot-cli': 'Copilot CLI',
 	aider: 'Aider',
 };
 
@@ -42,6 +43,7 @@ export const BETA_AGENTS: ReadonlySet<AgentId> = new Set<AgentId>([
 	'codex',
 	'opencode',
 	'factory-droid',
+	'copilot-cli',
 ]);
 
 /**


### PR DESCRIPTION
## Summary

Adds \copilot-cli\ as a first-class agent in Maestro, on par with Claude Code, Codex, OpenCode, and Factory Droid.

## What's included

**Core integration** (8 modified files, 2 new files):
- Agent ID, definition, capabilities, display name, beta badge, context window
- CLI args: \-p\ (batch), \--output-format json\, \--resume\, \--allow-all\, \--model\
- Config options for model selection and context window size

**Output parser** — verified against actual Copilot CLI JSONL output:
- 11 event types: \session.*\, \ssistant.message_delta\, \ssistant.message\, \	ool.execution_start/complete\, \esult\
- Streaming text display, tool use tracking, session ID extraction, output token accumulation

**Session storage browser** — reads \~/.copilot/session-state/<uuid>/\:
- Parses \workspace.yaml\ for metadata (summary, cwd, timestamps)
- Reads \vents.jsonl\ for message history
- Supports pagination, search, and project path filtering

**Error patterns** — auth failures, rate limiting, network errors, token exhaustion

**UI** — Added to \SUPPORTED_AGENTS\ and wizard agent tiles (no more 'Coming Soon')

## Testing

- TypeScript compiles cleanly across all 3 configs
- Maestro launches, detects \copilot\ binary, registers parser
- Ran \copilot -p ... --output-format json\ to verify JSONL schema matches parser

## Follow-up (Phase 2)

\docs/Copilot-CLI-Phase2-Plan.md\ covers remaining parity items: read-only mode, wizard, group chat moderation.