### PR TITLE
fix(quit): use taskkill tree-kill for PTY processes on Windows

### DIFF
--- a/src/__tests__/main/process-manager.test.ts
+++ b/src/__tests__/main/process-manager.test.ts
@@ -22,6 +22,17 @@ vi.mock('../../main/utils/logger', () => ({
 	},
 }));
 
+// Mock platform detection — delegates to process.platform by default so
+// pre-existing tests that override process.platform still work. Kill-method
+// tests override via mockReturnValueOnce / mockReturnValue.
+const { mockIsWindows } = vi.hoisted(() => ({
+	mockIsWindows: vi.fn<() => boolean>().mockImplementation(() => process.platform === 'win32'),
+}));
+
+vi.mock('../../shared/platformDetection', () => ({
+	isWindows: () => mockIsWindows(),
+}));
+
 import * as fs from 'fs';
 
 import {
@@ -427,6 +438,110 @@ describe('process-manager.ts', () => {
 			it('should return null for unknown session', () => {
 				const event = processManager.parseLine('non-existent-session', '{"type":"test"}');
 				expect(event).toBeNull();
+			});
+		});
+
+		describe('kill method — Windows PTY tree kill', () => {
+			let killWindowsTreeSpy: ReturnType<typeof vi.spyOn>;
+
+			beforeEach(() => {
+				// Spy on the private killWindowsProcessTree method
+				killWindowsTreeSpy = vi
+					.spyOn(ProcessManager.prototype as never, 'killWindowsProcessTree' as never)
+					.mockImplementation(() => {});
+			});
+
+			afterEach(() => {
+				mockIsWindows.mockImplementation(() => process.platform === 'win32');
+				killWindowsTreeSpy.mockRestore();
+			});
+
+			it('should use taskkill tree-kill for PTY processes on Windows', () => {
+				mockIsWindows.mockReturnValue(true);
+
+				const mockPtyProcess = { kill: vi.fn(), onExit: vi.fn() };
+				const processes = (processManager as unknown as { processes: Map<string, unknown> })
+					.processes;
+				processes.set('pty-session', {
+					sessionId: 'pty-session',
+					toolType: 'terminal',
+					ptyProcess: mockPtyProcess,
+					isTerminal: true,
+					pid: 12345,
+					cwd: '/tmp',
+					startTime: Date.now(),
+				});
+
+				processManager.kill('pty-session');
+
+				// Should use taskkill tree-kill, NOT node-pty's kill
+				expect(killWindowsTreeSpy).toHaveBeenCalledWith(12345, 'pty-session');
+				expect(mockPtyProcess.kill).not.toHaveBeenCalled();
+			});
+
+			it('should use ptyProcess.kill() for PTY processes on non-Windows', () => {
+				mockIsWindows.mockReturnValue(false);
+
+				const mockPtyProcess = { kill: vi.fn(), onExit: vi.fn() };
+				const processes = (processManager as unknown as { processes: Map<string, unknown> })
+					.processes;
+				processes.set('pty-session', {
+					sessionId: 'pty-session',
+					toolType: 'terminal',
+					ptyProcess: mockPtyProcess,
+					isTerminal: true,
+					pid: 12345,
+					cwd: '/tmp',
+					startTime: Date.now(),
+				});
+
+				processManager.kill('pty-session');
+
+				expect(mockPtyProcess.kill).toHaveBeenCalled();
+				expect(killWindowsTreeSpy).not.toHaveBeenCalled();
+			});
+
+			it('should use taskkill tree-kill for child processes on Windows', () => {
+				mockIsWindows.mockReturnValue(true);
+
+				const mockChildProcess = { kill: vi.fn(), pid: 99999 };
+				const processes = (processManager as unknown as { processes: Map<string, unknown> })
+					.processes;
+				processes.set('child-session', {
+					sessionId: 'child-session',
+					toolType: 'claude-code',
+					childProcess: mockChildProcess,
+					isTerminal: false,
+					pid: 99999,
+					cwd: '/tmp',
+					startTime: Date.now(),
+				});
+
+				processManager.kill('child-session');
+
+				expect(killWindowsTreeSpy).toHaveBeenCalledWith(99999, 'child-session');
+				expect(mockChildProcess.kill).not.toHaveBeenCalled();
+			});
+
+			it('should remove process from map after kill', () => {
+				mockIsWindows.mockReturnValue(true);
+
+				const mockPtyProcess = { kill: vi.fn(), onExit: vi.fn() };
+				const processes = (processManager as unknown as { processes: Map<string, unknown> })
+					.processes;
+				processes.set('pty-session', {
+					sessionId: 'pty-session',
+					toolType: 'terminal',
+					ptyProcess: mockPtyProcess,
+					isTerminal: true,
+					pid: 12345,
+					cwd: '/tmp',
+					startTime: Date.now(),
+				});
+
+				processManager.kill('pty-session');
+
+				expect(processManager.get('pty-session')).toBeUndefined();
 			});
 		});
 	});

--- a/src/main/process-manager/ProcessManager.ts
+++ b/src/main/process-manager/ProcessManager.ts
@@ -205,7 +205,14 @@ export class ProcessManager extends EventEmitter {
 			this.bufferManager.flushDataBuffer(sessionId);
 
 			if (process.isTerminal && process.ptyProcess) {
-				process.ptyProcess.kill();
+				if (isWindows() && process.pid) {
+					// On Windows, node-pty's kill() only terminates the direct ConPTY
+					// child (the shell), not grandchild processes it spawned (e.g., dev
+					// servers, watchers). Use taskkill /t /f to kill the entire tree.
+					this.killWindowsProcessTree(process.pid, sessionId);
+				} else {
+					process.ptyProcess.kill();
+				}
 			} else if (process.childProcess) {
 				const pid = process.childProcess.pid;
 				if (isWindows() && pid) {


### PR DESCRIPTION
Re-submission of #708 (was merged prematurely before CI/review completed, then reverted in 2bc1d27b).

## Summary
- On Windows, PTY processes (terminal sessions) were only killed via node-pty's `kill()`, which terminates the direct ConPTY child (shell) but **not** grandchild processes (dev servers, watchers, etc.)
- Child processes already used `taskkill /t /f` for tree-kill, but the PTY path was missed — this caused orphaned processes in Task Manager after quitting Maestro, preventing relaunch
- Now both PTY and child processes route through `killWindowsProcessTree()` on Windows, ensuring the entire process tree is terminated

## Test plan
- [x] Added 4 new tests in `process-manager.test.ts` covering:
  - PTY processes use `killWindowsProcessTree` on Windows (not `ptyProcess.kill()`)
  - PTY processes use `ptyProcess.kill()` on non-Windows (unchanged behavior)
  - Child processes still use `killWindowsProcessTree` on Windows
  - Process is removed from tracking map after kill
- [x] All 37 process-manager tests pass
- [x] All 21 quit-handler tests pass
- [x] Manual verification on Windows: quit Maestro with active terminal sessions, confirm no orphaned processes in Task Manager

Fixes lingering processes from #623 that #677 did not fully address.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced terminal process termination on Windows systems to use platform-specific methods, ensuring proper cleanup of pseudo-terminal sessions and better resource management across different operating systems.

* **Tests**
  * Added comprehensive test coverage for process termination scenarios on Windows and non-Windows platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->