### PR TITLE
fix: prevent left sidebar from hiding agents below the fold

### DIFF
--- a/src/renderer/components/SessionList/SessionList.tsx
+++ b/src/renderer/components/SessionList/SessionList.tsx
@@ -856,7 +856,7 @@ function SessionListInner(props: SessionListProps) {
 			{/* SIDEBAR CONTENT: EXPANDED */}
 			{leftSidebarOpen ? (
 				<div
-					className="flex-1 overflow-y-auto py-2 select-none scrollbar-thin flex flex-col"
+					className="flex-1 min-h-0 overflow-y-auto py-2 select-none scrollbar-thin"
 					data-tour="session-list"
 				>
 					{/* Session Filter */}

--- a/src/renderer/components/SessionList/SidebarActions.tsx
+++ b/src/renderer/components/SessionList/SidebarActions.tsx
@@ -35,7 +35,7 @@ export const SidebarActions = memo(function SidebarActions({
 
 	return (
 		<div
-			className="p-2 border-t flex gap-2 items-center"
+			className="p-2 border-t flex gap-2 items-center shrink-0"
 			style={{ borderColor: theme.colors.border }}
 		>
 			<button

--- a/src/renderer/components/SessionList/SkinnySidebar.tsx
+++ b/src/renderer/components/SessionList/SkinnySidebar.tsx
@@ -29,7 +29,7 @@ export const SkinnySidebar = memo(function SkinnySidebar({
 	handleContextMenu,
 }: SkinnySidebarProps) {
 	return (
-		<div className="flex-1 flex flex-col items-center py-4 gap-2 overflow-y-auto overflow-x-visible no-scrollbar">
+		<div className="flex-1 min-h-0 flex flex-col items-center py-4 gap-2 overflow-y-auto overflow-x-visible no-scrollbar">
 			{sortedSessions.map((session) => {
 				const isInBatch = activeBatchSessionIds.includes(session.id);
 				const hasUnreadTabs = session.aiTabs?.some((tab) => tab.hasUnread);

--- a/src/renderer/hooks/session/useSessionCategories.ts
+++ b/src/renderer/hooks/session/useSessionCategories.ts
@@ -68,6 +68,8 @@ export function useSessionCategories(
 	);
 
 	// Consolidated session categorization and sorting - computed in a single pass
+	const groupIds = useMemo(() => new Set(groups.map((g) => g.id)), [groups]);
+
 	const sessionCategories = useMemo(() => {
 		// Step 1: Filter sessions based on search query and unread filter
 		const query = sessionFilter?.toLowerCase() ?? '';
@@ -129,7 +131,7 @@ export function useSessionCategories(
 			if (s.bookmarked) {
 				bookmarked.push(s);
 			}
-			if (s.groupId) {
+			if (s.groupId && groupIds.has(s.groupId)) {
 				const list = groupedMap.get(s.groupId);
 				if (list) {
 					list.push(s);
@@ -168,7 +170,14 @@ export function useSessionCategories(
 			sortedUngroupedParent,
 			sortedGrouped,
 		};
-	}, [sessionFilter, showUnreadAgentsOnly, activeSessionId, sessions, worktreeChildrenByParentId]);
+	}, [
+		sessionFilter,
+		showUnreadAgentsOnly,
+		activeSessionId,
+		sessions,
+		worktreeChildrenByParentId,
+		groupIds,
+	]);
 
 	const sortedGroups = useMemo(
 		() => [...groups].sort((a, b) => compareSessionNames(a.name, b.name)),

--- a/src/web/mobile/LeftPanel.tsx
+++ b/src/web/mobile/LeftPanel.tsx
@@ -395,9 +395,11 @@ export function LeftPanel({
 				<div
 					style={{
 						flex: 1,
+						minHeight: 0,
 						overflowY: 'auto',
 						overflowX: 'hidden',
 						padding: '6px',
+						paddingBottom: 'calc(80px + env(safe-area-inset-bottom))',
 					}}
 				>
 					{sessions.length === 0 && (


### PR DESCRIPTION
## Summary
- **Web UI**: Add `paddingBottom` to the LeftPanel scroll container to compensate for the fixed-position `CommandInputBar` that overlaps the bottom ~80px of the viewport. The main content area already had this compensation but the LeftPanel didn't, causing bottom agents to be unreachable when groups were collapsed.
- **Desktop**: Add `min-h-0` to sidebar scroll containers for proper flex overflow, `shrink-0` to the SidebarActions footer.
- **Both**: Guard against orphaned `groupId` references so agents whose group was deleted still appear in the ungrouped section.

## Test plan
- [x] Open web UI, create several agents across multiple groups
- [x] Collapse the bottom group — verify it remains visible and scrollable
- [x] Expand/collapse various groups — verify all agents are always reachable
- [x] Delete a group and verify its agents appear under "Ungrouped"
- [x] Check desktop sidebar scrolling with many agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar scrolling and layout behavior for better performance.
  * Enhanced session categorization to correctly organize sessions by groups.
  * Fixed mobile view spacing and scrolling viewport sizing for improved usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->