### PR TITLE
feat: Persist and restore active session id (resume in last open sess…

### DIFF
--- a/src/__tests__/main/ipc/handlers/persistence.test.ts
+++ b/src/__tests__/main/ipc/handlers/persistence.test.ts
@@ -141,6 +141,8 @@ describe('persistence IPC handlers', () => {
 				'settings:set',
 				'settings:getAll',
 				'sessions:getAll',
+				'sessions:getActiveSessionId',
+				'sessions:setActiveSessionId',
 				'sessions:setAll',
 				'groups:getAll',
 				'groups:setAll',
@@ -151,6 +153,24 @@ describe('persistence IPC handlers', () => {
 				expect(handlers.has(channel)).toBe(true);
 			}
 			expect(handlers.size).toBe(expectedChannels.length);
+		});
+	});
+
+	describe('sessions:getActiveSessionId', () => {
+		it('should return empty string when no active session is set', async () => {
+			mockSessionsStore.get.mockReturnValue('');
+			const handler = handlers.get('sessions:getActiveSessionId');
+			const result = await handler!({} as any);
+			expect(mockSessionsStore.get).toHaveBeenCalledWith('activeSessionId', '');
+			expect(result).toBe('');
+		});
+	});
+
+	describe('sessions:setActiveSessionId', () => {
+		it('should persist and retrieve an active session ID', async () => {
+			const setHandler = handlers.get('sessions:setActiveSessionId');
+			await setHandler!({} as any, 'test-session-123');
+			expect(mockSessionsStore.set).toHaveBeenCalledWith('activeSessionId', 'test-session-123');
 		});
 	});
 

--- a/src/__tests__/renderer/hooks/useSessionRestoration.test.ts
+++ b/src/__tests__/renderer/hooks/useSessionRestoration.test.ts
@@ -134,7 +134,11 @@ beforeEach(() => {
 	if (!(window as any).maestro) {
 		(window as any).maestro = {};
 	}
-	(window as any).maestro.sessions = { getAll: mockGetAll };
+	(window as any).maestro.sessions = {
+		getAll: mockGetAll,
+		getActiveSessionId: vi.fn().mockResolvedValue(''),
+		setActiveSessionId: vi.fn(),
+	};
 	(window as any).maestro.groups = { getAll: mockGroupsGetAll };
 	(window as any).maestro.groupChat = { list: mockGroupChatList };
 	(window as any).maestro.agents = {
@@ -978,6 +982,25 @@ describe('Session & Group loading effect', () => {
 		});
 
 		expect(useSessionStore.getState().activeSessionId).toBe('real-1');
+	});
+
+	it('restores persisted activeSessionId from disk', async () => {
+		useSessionStore.setState({ activeSessionId: '' } as any);
+		const session1 = createMockSession({ id: 'sess-1' });
+		const session2 = createMockSession({ id: 'sess-2' });
+		mockGetAll.mockResolvedValueOnce([session1, session2]);
+		// Mock the persisted active session ID to be the second session
+		(window as any).maestro.sessions.getActiveSessionId = vi.fn().mockResolvedValue('sess-2');
+
+		renderHook(() => useSessionRestoration());
+
+		await act(async () => {
+			await new Promise((r) => setTimeout(r, 50));
+		});
+
+		expect(useSessionStore.getState().activeSessionId).toBe('sess-2');
+		// Reset mock
+		(window as any).maestro.sessions.getActiveSessionId = vi.fn().mockResolvedValue('');
 	});
 
 	it('keeps activeSessionId when it matches a loaded session', async () => {

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -212,6 +212,8 @@ const mockMaestro = {
 		get: vi.fn().mockResolvedValue([]),
 		save: vi.fn().mockResolvedValue(undefined),
 		setAll: vi.fn().mockResolvedValue(undefined),
+		getActiveSessionId: vi.fn().mockResolvedValue(''),
+		setActiveSessionId: vi.fn().mockResolvedValue(undefined),
 	},
 	groups: {
 		get: vi.fn().mockResolvedValue([]),

--- a/src/main/ipc/handlers/persistence.ts
+++ b/src/main/ipc/handlers/persistence.ts
@@ -96,6 +96,14 @@ export function registerPersistenceHandlers(deps: PersistenceHandlerDependencies
 		return sessions;
 	});
 
+	ipcMain.handle('sessions:getActiveSessionId', async () => {
+		return sessionsStore.get('activeSessionId', '');
+	});
+
+	ipcMain.handle('sessions:setActiveSessionId', async (_, id: string) => {
+		sessionsStore.set('activeSessionId', id);
+	});
+
 	ipcMain.handle('sessions:setAll', async (_, sessions: StoredSession[]) => {
 		// Get previous sessions to detect changes
 		const previousSessions = sessionsStore.get('sessions', []);

--- a/src/main/preload/settings.ts
+++ b/src/main/preload/settings.ts
@@ -36,6 +36,8 @@ export function createSessionsApi() {
 	return {
 		getAll: () => ipcRenderer.invoke('sessions:getAll'),
 		setAll: (sessions: StoredSession[]) => ipcRenderer.invoke('sessions:setAll', sessions),
+		getActiveSessionId: () => ipcRenderer.invoke('sessions:getActiveSessionId') as Promise<string>,
+		setActiveSessionId: (id: string) => ipcRenderer.invoke('sessions:setActiveSessionId', id),
 	};
 }
 

--- a/src/main/stores/types.ts
+++ b/src/main/stores/types.ts
@@ -88,6 +88,7 @@ export interface MaestroSettings {
 
 export interface SessionsData {
 	sessions: StoredSession[];
+	activeSessionId?: string;
 }
 
 // ============================================================================

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -254,6 +254,8 @@ interface MaestroAPI {
 	sessions: {
 		getAll: () => Promise<any[]>;
 		setAll: (sessions: any[]) => Promise<boolean>;
+		getActiveSessionId: () => Promise<string>;
+		setActiveSessionId: (id: string) => Promise<void>;
 	};
 	groups: {
 		getAll: () => Promise<any[]>;

--- a/src/renderer/hooks/session/useSessionRestoration.ts
+++ b/src/renderer/hooks/session/useSessionRestoration.ts
@@ -48,10 +48,8 @@ export function useSessionRestoration(): SessionRestorationReturn {
 	// useCallback/useEffect without appearing in dependency arrays. Zustand
 	// store actions returned by getState() are stable singletons that never
 	// change, so the empty deps array is intentional.
-	const { setSessions, setGroups, setActiveSessionId, setSessionsLoaded } = useMemo(
-		() => useSessionStore.getState(),
-		[]
-	);
+	const { setSessions, setGroups, setActiveSessionId, hydrateActiveSessionId, setSessionsLoaded } =
+		useMemo(() => useSessionStore.getState(), []);
 	const { setGroupChats } = useMemo(() => useGroupChatStore.getState(), []);
 
 	// --- initialLoadComplete proxy ref ---
@@ -430,12 +428,14 @@ export function useSessionRestoration(): SessionRestorationReturn {
 					const restoredSessions = await Promise.all(savedSessions.map((s) => restoreSession(s)));
 					setSessions(restoredSessions);
 
-					// Set active session to first session if current activeSessionId is invalid
-					const activeSessionId = useSessionStore.getState().activeSessionId;
-					if (
-						restoredSessions.length > 0 &&
-						!restoredSessions.find((s) => s.id === activeSessionId)
-					) {
+					// Restore persisted active session ID, falling back to first session.
+					const savedActiveSessionId = await window.maestro.sessions.getActiveSessionId();
+					if (savedActiveSessionId && restoredSessions.find((s) => s.id === savedActiveSessionId)) {
+						// Saved ID is valid — hydrate locally without writing back to disk
+						hydrateActiveSessionId(savedActiveSessionId);
+					} else if (restoredSessions[0]?.id) {
+						// Saved ID is stale or missing — persist the fallback so it
+						// doesn't retry the invalid ID on next launch
 						setActiveSessionId(restoredSessions[0].id);
 					}
 

--- a/src/renderer/stores/sessionStore.ts
+++ b/src/renderer/stores/sessionStore.ts
@@ -72,6 +72,12 @@ export interface SessionStoreActions {
 	setActiveSessionId: (id: string) => void;
 
 	/**
+	 * Set the active session ID from persisted state on startup.
+	 * Updates local state only — does not write back to disk.
+	 */
+	hydrateActiveSessionId: (id: string) => void;
+
+	/**
 	 * Set the active session ID without resetting cycle position.
 	 * Used internally by session cycling (Cmd+J/K).
 	 */
@@ -198,7 +204,16 @@ export const useSessionStore = create<SessionStore>()((set) => ({
 		}),
 
 	// Active session
-	setActiveSessionId: (id) => set({ activeSessionId: id, cyclePosition: -1 }),
+	setActiveSessionId: (id) => {
+		set({ activeSessionId: id, cyclePosition: -1 });
+		// Fire-and-forget: persist to disk for restore on next launch.
+		// Not awaited — UI state must update synchronously; if the write
+		// fails the only consequence is the session won't be pre-selected
+		// on next launch (falls back to first session).
+		window.maestro?.sessions?.setActiveSessionId(id);
+	},
+
+	hydrateActiveSessionId: (id) => set({ activeSessionId: id, cyclePosition: -1 }),
 
 	setActiveSessionIdInternal: (v) =>
 		set((s) => ({ activeSessionId: resolve(v, s.activeSessionId) })),


### PR DESCRIPTION
Before:

Maestro would always start with session [0] from maestro-sessions.json

After:

Persist `activeSessionId` in the maestro-sessions.json and resume the last open session when Maestro launches, ignore when not found.

`{
	"sessions": [...],
	"activeSessionId": "c97dca4d-172f-471e-880c-7e694c59f9f4"
}`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The app now persists and restores the active session across launches, reactivating your last valid session and falling back to a sensible default when needed.

* **Refactor**
  * Active-session selection now prefers the persisted value when valid and synchronizes state with the host when it changes.

* **Tests**
  * Updated tests to cover active-session persistence, restoration, and IPC handler behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->