### PR TITLE
fix: preserve queued app.startup Cue triggers across YAML hot-reloads

### DIFF
--- a/src/__tests__/main/cue/cue-concurrency.test.ts
+++ b/src/__tests__/main/cue/cue-concurrency.test.ts
@@ -551,6 +551,64 @@ describe('CueEngine Concurrency Control', () => {
 			engine.stopAll();
 			engine.stop();
 		});
+
+		it('preserves app.startup events when preserveStartup is true', async () => {
+			// Use a never-resolving onCueRun so the first run stays in-flight
+			const deps = createMockDeps({
+				onCueRun: vi.fn(() => new Promise<CueRunResult>(() => {})),
+			});
+			const config = createMockConfig({
+				settings: {
+					timeout_minutes: 30,
+					timeout_on_fail: 'break',
+					max_concurrent: 1,
+					queue_size: 10,
+				},
+				subscriptions: [
+					{
+						name: 'startup-a',
+						event: 'app.startup',
+						enabled: true,
+						prompt: 'first startup',
+					},
+					{
+						name: 'startup-b',
+						event: 'app.startup',
+						enabled: true,
+						prompt: 'second startup',
+					},
+					{
+						name: 'timer',
+						event: 'time.heartbeat',
+						enabled: true,
+						prompt: 'heartbeat',
+						interval_minutes: 1,
+					},
+				],
+			});
+			mockLoadCueConfig.mockReturnValue(config);
+			const engine = new CueEngine(deps);
+			engine.start(true);
+
+			// Heartbeat fires immediately and takes the slot.
+			// Both startup-a and startup-b are queued (max_concurrent=1).
+			expect(engine.getQueueStatus().get('session-1')).toBe(2);
+
+			// Advance time to queue another heartbeat event
+			vi.advanceTimersByTime(60 * 1000);
+			expect(engine.getQueueStatus().get('session-1')).toBe(3);
+
+			// clearQueue with preserveStartup=true should keep only the 2 startup events
+			engine.clearQueue('session-1', true);
+			expect(engine.getQueueStatus().get('session-1')).toBe(2);
+
+			// clearQueue without preserveStartup should wipe everything
+			engine.clearQueue('session-1');
+			expect(engine.getQueueStatus().size).toBe(0);
+
+			engine.stopAll();
+			engine.stop();
+		});
 	});
 
 	describe('getQueueStatus', () => {

--- a/src/main/cue/cue-engine.ts
+++ b/src/main/cue/cue-engine.ts
@@ -456,8 +456,8 @@ export class CueEngine {
 	}
 
 	/** Clears queued events for a session */
-	clearQueue(sessionId: string): void {
-		this.runManager.clearQueue(sessionId);
+	clearQueue(sessionId: string, preserveStartup = false): void {
+		this.runManager.clearQueue(sessionId, preserveStartup);
 	}
 
 	/**
@@ -781,7 +781,9 @@ export class CueEngine {
 		this.clearFanInState(sessionId);
 
 		// Clean up queued events for this session (prevents stale events after config reload)
-		this.clearQueue(sessionId);
+		// Preserve app.startup events — they are one-time boot intents that should survive
+		// config hot-reloads (e.g., OneDrive touching the YAML file during the boot scan).
+		this.clearQueue(sessionId, /* preserveStartup */ true);
 
 		// Clean up scheduledFiredKeys for this session's subscriptions
 		for (const sub of state.config.subscriptions) {

--- a/src/main/cue/cue-run-manager.ts
+++ b/src/main/cue/cue-run-manager.ts
@@ -76,7 +76,7 @@ export interface CueRunManager {
 	getActiveRunCount(sessionId: string): number;
 	getActiveRunMap(): Map<string, ActiveRun>;
 	getQueueStatus(): Map<string, number>;
-	clearQueue(sessionId: string): void;
+	clearQueue(sessionId: string, preserveStartup?: boolean): void;
 	reset(): void;
 }
 
@@ -424,8 +424,19 @@ export function createCueRunManager(deps: CueRunManagerDeps): CueRunManager {
 			return result;
 		},
 
-		clearQueue(sessionId: string): void {
-			eventQueue.delete(sessionId);
+		clearQueue(sessionId: string, preserveStartup = false): void {
+			if (!preserveStartup) {
+				eventQueue.delete(sessionId);
+				return;
+			}
+			const queue = eventQueue.get(sessionId);
+			if (!queue) return;
+			const kept = queue.filter((e) => e.event.type === 'app.startup');
+			if (kept.length === 0) {
+				eventQueue.delete(sessionId);
+			} else {
+				eventQueue.set(sessionId, kept);
+			}
 		},
 
 		reset(): void {


### PR DESCRIPTION
## Summary
- `teardownSession` was clearing the entire event queue including queued `app.startup` triggers
- When `cue.yaml` lives on a synced drive (e.g. OneDrive), the YAML file watcher fires shortly after boot, calling `refreshSession` → `teardownSession` → `clearQueue`, wiping queued startup subscriptions before they drain
- `clearQueue` now accepts a `preserveStartup` flag so `teardownSession` keeps `app.startup` events while still clearing stale recurring events
- `removeSession` still clears everything (correct for full session removal)

## Test plan
- [x] New test: `preserves app.startup events when preserveStartup is true` in `cue-concurrency.test.ts`
- [x] All 170 existing cue tests pass (concurrency, startup, engine, session-lifecycle, completion-chains, multi-hop-chains)
- [x] TypeScript type-check passes
- [ ] Manual verification: configure 2+ `app.startup` subscriptions on a synced drive, confirm both fire on Maestro restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event queue management to preserve startup events while clearing other queued items during configuration updates and session cleanup.

* **Tests**
  * Added test coverage for event queue clearing behavior with startup event preservation during concurrent operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->