### PR TITLE
fix: resolve multiple Sentry crash patterns from production

### DIFF
--- a/src/__tests__/main/ipc/handlers/debug.test.ts
+++ b/src/__tests__/main/ipc/handlers/debug.test.ts
@@ -26,6 +26,9 @@ vi.mock('electron', () => ({
 	dialog: {
 		showSaveDialog: vi.fn(),
 	},
+	app: {
+		getPath: vi.fn().mockReturnValue('/Users/test/Desktop'),
+	},
 	BrowserWindow: vi.fn(),
 }));
 
@@ -33,6 +36,7 @@ vi.mock('electron', () => ({
 vi.mock('path', () => ({
 	default: {
 		dirname: vi.fn(),
+		join: vi.fn((...args: string[]) => args.join('/')),
 	},
 }));
 

--- a/src/__tests__/main/ipc/handlers/system.test.ts
+++ b/src/__tests__/main/ipc/handlers/system.test.ts
@@ -586,6 +586,36 @@ describe('system IPC handlers', () => {
 				'Unexpected Electron internal failure'
 			);
 		});
+
+		it('should redirect absolute file paths to openPath', async () => {
+			vi.mocked(fsSync.existsSync).mockReturnValue(true);
+			vi.mocked(shell.openPath).mockResolvedValue('');
+
+			const handler = handlers.get('shell:openExternal');
+			await handler!({} as any, '/Users/test/workspace/src/app.tsx');
+
+			expect(shell.openExternal).not.toHaveBeenCalled();
+			expect(shell.openPath).toHaveBeenCalledWith('/Users/test/workspace/src/app.tsx');
+		});
+
+		it('should throw for non-existent absolute file paths', async () => {
+			vi.mocked(fsSync.existsSync).mockReturnValue(false);
+
+			const handler = handlers.get('shell:openExternal');
+			await expect(handler!({} as any, '/nonexistent/path.tsx')).rejects.toThrow(
+				'Path does not exist'
+			);
+		});
+
+		it('should silently ignore relative paths like LICENSE or ./README.md', async () => {
+			const handler = handlers.get('shell:openExternal');
+
+			await expect(handler!({} as any, 'LICENSE')).resolves.toBeUndefined();
+			await expect(handler!({} as any, './README.md')).resolves.toBeUndefined();
+			await expect(handler!({} as any, 'vscode/**')).resolves.toBeUndefined();
+			expect(shell.openExternal).not.toHaveBeenCalled();
+			expect(shell.openPath).not.toHaveBeenCalled();
+		});
 	});
 
 	describe('shell:showItemInFolder', () => {

--- a/src/main/group-chat/group-chat-storage.ts
+++ b/src/main/group-chat/group-chat-storage.ts
@@ -57,11 +57,25 @@ function enqueueWrite<T>(chatId: string, fn: () => Promise<T>): Promise<T> {
  * Atomically write JSON content to a file by writing to a temp file first,
  * then renaming. rename() is atomic on POSIX and effectively atomic on NTFS.
  * This prevents partial/corrupt reads if the process crashes mid-write.
+ * Retries on EPERM/EBUSY errors (Windows file locks from OneDrive/antivirus).
  */
 async function atomicWriteJson(filePath: string, data: unknown): Promise<void> {
 	const tmp = filePath + '.tmp';
 	await fs.writeFile(tmp, JSON.stringify(data, null, 2), 'utf-8');
-	await fs.rename(tmp, filePath);
+	const maxRetries = 3;
+	for (let attempt = 0; attempt <= maxRetries; attempt++) {
+		try {
+			await fs.rename(tmp, filePath);
+			return;
+		} catch (err) {
+			const code = (err as NodeJS.ErrnoException).code;
+			if ((code === 'EPERM' || code === 'EBUSY') && attempt < maxRetries) {
+				await new Promise((resolve) => setTimeout(resolve, 100 * Math.pow(2, attempt)));
+				continue;
+			}
+			throw err;
+		}
+	}
 }
 
 /**

--- a/src/main/ipc/handlers/debug.ts
+++ b/src/main/ipc/handlers/debug.ts
@@ -5,7 +5,7 @@
  * These packages contain sanitized diagnostic information for bug analysis.
  */
 
-import { ipcMain, dialog, BrowserWindow } from 'electron';
+import { ipcMain, dialog, BrowserWindow, app } from 'electron';
 import path from 'path';
 import Store from 'electron-store';
 import { logger } from '../../utils/logger';
@@ -78,7 +78,7 @@ export function registerDebugHandlers(deps: DebugHandlerDependencies): void {
 			// Show save dialog
 			const result = await dialog.showSaveDialog(mainWindow, {
 				title: 'Save Debug Package',
-				defaultPath: defaultFilename,
+				defaultPath: path.join(app.getPath('desktop'), defaultFilename),
 				filters: [{ name: 'Zip Files', extensions: ['zip'] }],
 			});
 

--- a/src/main/ipc/handlers/system.ts
+++ b/src/main/ipc/handlers/system.ts
@@ -200,7 +200,20 @@ export function registerSystemHandlers(deps: SystemHandlerDependencies): void {
 		try {
 			parsed = new URL(url);
 		} catch {
-			throw new Error(`Invalid URL: ${url}`);
+			// Detect absolute file paths and redirect to openPath — Fixes MAESTRO-FN/FA/F4
+			if (path.isAbsolute(url)) {
+				if (fsSync.existsSync(url)) {
+					const errorMessage = await shell.openPath(url);
+					if (errorMessage) {
+						throw new Error(errorMessage);
+					}
+					return;
+				}
+				throw new Error(`Path does not exist: ${url}`);
+			}
+			// Relative paths (LICENSE, ./README.md, vscode/**) are not actionable — log and return
+			logger.warn(`Ignored non-URL string passed to openExternal: "${url}"`, 'Shell');
+			return;
 		}
 		// Redirect file:// URLs to shell.openPath instead of rejecting — Fixes MAESTRO-9M
 		if (parsed.protocol === 'file:') {

--- a/src/renderer/components/MainPanel.tsx
+++ b/src/renderer/components/MainPanel.tsx
@@ -1698,7 +1698,7 @@ export const MainPanel = React.memo(
 											onReplayMessage={props.onReplayMessage}
 											fileTree={props.fileTree}
 											cwd={
-												activeSession.cwd.startsWith(activeSession.fullPath)
+												activeSession.cwd?.startsWith(activeSession.fullPath)
 													? activeSession.cwd.slice(activeSession.fullPath.length + 1)
 													: ''
 											}


### PR DESCRIPTION
## Summary

Fixes 4 crash patterns identified from Sentry production telemetry (~40+ total events):

- **MAESTRO-BT/E2** (24 events): `TypeError: Cannot read properties of undefined (reading 'startsWith')` — added optional chaining for `activeSession.cwd?.startsWith()` in MainPanel
- **MAESTRO-FN/FA/F4/E5/E3/EX** (6+ events): `shell:openExternal: Invalid URL` — absolute file paths now redirect to `openPath`, relative paths (LICENSE, ./README.md) silently ignored instead of throwing
- **MAESTRO-FE** (8 events): `EPERM: operation not permitted, rename` on Windows — added retry with exponential backoff to `atomicWriteJson` for file locks from OneDrive/antivirus
- **MAESTRO-F0/F1** (2 events): `EROFS: read-only file system` — debug zip save dialog now defaults to Desktop instead of bare filename

Also confirmed **MAESTRO-ES** (`usageDashboardOpen`) and **MAESTRO-ET** (`visualOrchestratorOpen`) are already fixed in current code.

## Test plan

- [x] All 22,445 existing tests pass
- [x] Added tests for absolute file path redirect in openExternal
- [x] Added tests for relative path silent ignore in openExternal
- [x] Added test for non-existent absolute path rejection
- [x] Updated debug test mock to include `app.getPath` and `path.join`
- [x] TypeScript type checks pass
- [x] Lint and format checks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced file opening to support local file paths alongside URLs.

* **Bug Fixes**
  * Fixed potential crash when session working directory is undefined.
  * Improved reliability of file save operations on Windows with retry logic.
  * Set default save location to Desktop for better user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->