### PR TITLE
idea: Adjust slash command fuzzy style to match the new settings search

### DIFF
--- a/src/renderer/components/InputArea.tsx
+++ b/src/renderer/components/InputArea.tsx
@@ -586,8 +586,13 @@ export const InputArea = React.memo(function InputArea(props: InputAreaProps) {
 								}}
 								onMouseEnter={() => setSelectedSlashCommandIndex(idx)}
 							>
-								<div className="font-mono text-sm leading-tight">
-									{highlightSlashCommand(cmd.command, inputValueLower.replace(/^\//, ''))}
+								<div className="font-mono text-sm">
+									{highlightSlashCommand(
+										cmd.command,
+										inputValueLower.replace(/^\//, ''),
+										theme.colors.accent,
+										idx === safeSelectedIndex
+									)}
 								</div>
 								<div className="text-[11px] opacity-70 leading-tight">{cmd.description}</div>
 							</button>

--- a/src/renderer/utils/search.ts
+++ b/src/renderer/utils/search.ts
@@ -221,9 +221,17 @@ export const filterSlashCommands = <T extends SlashCommandLike>(
 
 /**
  * Render a slash command with fuzzy-matched characters highlighted.
- * Returns a React node: plain string when no query, spans with bold/dim otherwise.
+ * Matched characters use accent color + semibold (matching Settings search style).
+ * When selected, unmatched characters are dimmed so matches stand out on the
+ * accent background.
+ * Returns a React node: plain string when no query, spans otherwise.
  */
-export const highlightSlashCommand = (command: string, query: string): React.ReactNode => {
+export const highlightSlashCommand = (
+	command: string,
+	query: string,
+	accentColor?: string,
+	isSelected?: boolean
+): React.ReactNode => {
 	if (!query) return command;
 	const indices = new Set(
 		fuzzyMatchWithIndices(command.slice(1).toLowerCase(), query, '.').map((i) => i + 1)
@@ -234,7 +242,11 @@ export const highlightSlashCommand = (command: string, query: string): React.Rea
 			'span',
 			{
 				key: i,
-				style: indices.has(i) ? { fontWeight: 700 } : { opacity: 0.8 },
+				style: indices.has(i)
+					? { color: isSelected ? undefined : accentColor, fontWeight: isSelected ? 800 : 600 }
+					: isSelected
+						? { opacity: 0.6 }
+						: undefined,
 			},
 			ch
 		)

--- a/src/web/mobile/SlashCommandAutocomplete.tsx
+++ b/src/web/mobile/SlashCommandAutocomplete.tsx
@@ -291,7 +291,9 @@ export function SlashCommandAutocomplete({
 								cmd.command,
 								inputValue && inputValue.startsWith('/')
 									? (inputValue || '').toLowerCase().replace(/^\//, '')
-									: ''
+									: '',
+								colors.accent,
+								isSelected
 							)}
 						</div>
 						{/* Command description */}


### PR DESCRIPTION
<img width="326" height="171" alt="Bildschirmfoto 2026-04-05 um 18 14 14" src="https://github.com/user-attachments/assets/b91a0ebe-4278-444b-b3ac-432db7f2eaa5" />

I don't know maybe it it too many colors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced slash-command autocomplete with dynamic theme-aware styling. Matched and unmatched characters now display contextually based on selection state and the active theme's accent color. Font weights and opacity levels adjust accordingly, providing improved visual distinction during command navigation and selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->