### PR TITLE
fix: add SIGKILL escalation and deferred cleanup to process kill

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -83,7 +83,7 @@ The major contributions to 0.14.x remain:
 - Leaderboard tracking now works across multiple systems and syncs level from cloud 🏆
 - Agent duplication. Pro tip: Consider a group of unused "Template" agents ✌️
 - New setting to prevent system from going to sleep while agents are active 🛏️
-- The tab menu has a new "Publish as GitHub Gist" option  📝
+- The tab menu has a new "Publish as GitHub Gist" option 📝
 - The tab menu has options to move the tab to the first or last position 🔀
 - [Maestro-Playbooks](https://github.com/pedramamini/Maestro-Playbooks) can now contain non-markdown assets 📙
 - Improved default shell detection 🐚
@@ -112,10 +112,12 @@ Thanks for the contributions: @t1mmen @aejfager @Crumbgrabber @whglaser @b3nw @d
 - TAKE TWO! Fixed Linux ARM64 build architecture contamination issues 🏗️
 
 ### v0.13.1 Changes
+
 - Fixed Linux ARM64 build architecture contamination issues 🏗️
 - Enhanced error handling for Auto Run batch processing 🚨
 
 ### v0.13.0 Changes
+
 - Added a global usage dashboard, data collection begins with this install 🎛️
 - Added a Playbook Exchange for downloading pre-defined Auto Run playbooks from [Maestro-Playbooks](https://github.com/pedramamini/Maestro-Playbooks) 📕
 - Bundled OpenSpec commands for structured change proposals 📝
@@ -139,15 +141,19 @@ Thanks for the contributions: @t1mmen @aejfager @Crumbgrabber @whglaser @b3nw @d
 The big changes in the v0.12.x line are the following three:
 
 ## Show Thinking
-🤔 There is now a toggle to show thinking for the agent, the default for new tabs is off, though this can be changed under Settings > General. The toggle shows next to History and Read-Only. Very similar pattern. This has been the #1 most requested feature, though personally, I don't think I'll use it as I prefer to not see the details of the work, but the results of the work. Just as we work with our colleagues. 
+
+🤔 There is now a toggle to show thinking for the agent, the default for new tabs is off, though this can be changed under Settings > General. The toggle shows next to History and Read-Only. Very similar pattern. This has been the #1 most requested feature, though personally, I don't think I'll use it as I prefer to not see the details of the work, but the results of the work. Just as we work with our colleagues.
 
 ## GitHub Spec-Kit Integration
+
 🎯 Added [GitHub Spec-Kit](https://github.com/github/spec-kit) commands into Maestro with a built in updater to grab the latest prompts from the repository. We do override `/speckit-implement` (the final step) to create Auto Run docs and guide the user through their execution, which thanks to Wortrees from v0.11.x allows us to run in parallel!
 
 ## Context Management Tools
+
 📖 Added context management options from tab right-click menu. You can now compress, merge, and transfer contexts between agents. You will received (configurable) warnings at 60% and 80% context consumption with a hint to compact.
 
 ## Changes Specific to v0.12.3:
+
 - We now have hosted documentation through Mintlify 📚
 - Export any tab conversation as self-contained themed HTML file 📄
 - Publish files as private/public Gists 🌐
@@ -260,6 +266,7 @@ The big changes in the v0.12.x line are the following three:
 Minor bugfixes on top of v0.7.3:
 
 # Onboarding, Wizard, and Tours
+
 - Implemented comprehensive onboarding wizard with integrated tour system 🚀
 - Added project-understanding confidence display to wizard UI 🎨
 - Enhanced keyboard navigation across all wizard screens ⌨️
@@ -267,6 +274,7 @@ Minor bugfixes on top of v0.7.3:
 - Added First Run Celebration modal with confetti animation 🎉
 
 # UI / UX Enhancements
+
 - Added expand-to-fullscreen button for Auto Run interface 🖥️
 - Created dedicated modal component and improved modal priority constants for expanded Auto Run view 📐
 - Enhanced user experience with fullscreen editing capabilities ✨
@@ -276,15 +284,18 @@ Minor bugfixes on top of v0.7.3:
 - Enhanced toast context with agent name for OS notifications 📢
 
 # Auto Run Workflow Improvements
+
 - Created phase document generation for Auto Run workflow 📄
 - Added real-time log streaming to the LogViewer component 📊
 
 # Application Behavior / Core Fixes
+
 - Added validation to prevent nested worktrees inside the main repository 🚫
 - Fixed process manager to properly emit exit events on errors 🔧
 - Fixed process exit handling to ensure proper cleanup 🧹
 
 # Update System
+
 - Implemented automatic update checking on application startup 🚀
 - Added settings toggle for enabling/disabling startup update checks ⚙️
 
@@ -302,6 +313,7 @@ Minor bugfixes on top of v0.7.3:
 **Latest: v0.6.1** | Released December 4, 2025
 
 In this release...
+
 - Added recursive subfolder support for Auto Run markdown files 🗂️
 - Enhanced document tree display with expandable folder navigation 🌳
 - Enabled creating documents in subfolders with path selection 📁
@@ -314,6 +326,7 @@ In this release...
 - Added support for nested folder structures in document management 🏗️
 
 Plus the pre-release ALPHA...
+
 - Template vars now set context in default autorun prompt 🚀
 - Added Enter key support for queued message confirmation dialog ⌨️
 - Kill process capability added to System Process Monitor 💀
@@ -473,6 +486,7 @@ Plus the pre-release ALPHA...
 All releases are available on the [GitHub Releases page](https://github.com/RunMaestro/Maestro/releases).
 
 Maestro is available for:
+
 - **macOS** - Apple Silicon (arm64) and Intel (x64)
 - **Windows** - x64
 - **Linux** - x64 and arm64, AppImage, deb, and rpm packages

--- a/src/__tests__/main/process-manager.test.ts
+++ b/src/__tests__/main/process-manager.test.ts
@@ -523,7 +523,7 @@ describe('process-manager.ts', () => {
 				expect(mockChildProcess.kill).not.toHaveBeenCalled();
 			});
 
-			it('should remove process from map after kill', () => {
+			it('should keep process in map after kill (deferred cleanup on exit)', () => {
 				mockIsWindows.mockReturnValue(true);
 
 				const mockPtyProcess = { kill: vi.fn(), onExit: vi.fn() };
@@ -541,7 +541,10 @@ describe('process-manager.ts', () => {
 
 				processManager.kill('pty-session');
 
-				expect(processManager.get('pty-session')).toBeUndefined();
+				// Process stays in map until exit event fires; kill() no longer
+				// removes it eagerly so the SIGKILL escalation timer can detect
+				// a still-running process.
+				expect(processManager.get('pty-session')).toBeDefined();
 			});
 		});
 	});

--- a/src/main/process-manager/ProcessManager.ts
+++ b/src/main/process-manager/ProcessManager.ts
@@ -191,8 +191,16 @@ export class ProcessManager extends EventEmitter {
 		}
 	}
 
+	/** How long to wait after SIGTERM before escalating to SIGKILL (ms). */
+	private static readonly KILL_ESCALATION_TIMEOUT = 5000;
+
 	/**
-	 * Kill a specific process
+	 * Kill a specific process.
+	 *
+	 * Sends SIGTERM first. If the process doesn't exit within
+	 * KILL_ESCALATION_TIMEOUT, escalates to SIGKILL to guarantee cleanup.
+	 * The process is removed from the tracking map only when it actually exits
+	 * (handled by ExitHandler / PtySpawner), not optimistically up-front.
 	 */
 	kill(sessionId: string): boolean {
 		const process = this.processes.get(sessionId);
@@ -212,6 +220,7 @@ export class ProcessManager extends EventEmitter {
 					this.killWindowsProcessTree(process.pid, sessionId);
 				} else {
 					process.ptyProcess.kill();
+					this.scheduleKillEscalation(sessionId, process.pid);
 				}
 			} else if (process.childProcess) {
 				const pid = process.childProcess.pid;
@@ -226,9 +235,13 @@ export class ProcessManager extends EventEmitter {
 					process.childProcess.kill('SIGTERM');
 				} else {
 					process.childProcess.kill('SIGTERM');
+					this.scheduleKillEscalation(sessionId, pid);
 				}
 			}
-			this.processes.delete(sessionId);
+			// Don't delete from the process map here. The exit handlers
+			// (ExitHandler.handleExit / PtySpawner onExit) already clean up
+			// once the process actually terminates. Removing eagerly caused
+			// Maestro to report "stopped" while the process was still alive.
 			return true;
 		} catch (error) {
 			logger.error('[ProcessManager] Failed to kill process', 'ProcessManager', {
@@ -236,6 +249,47 @@ export class ProcessManager extends EventEmitter {
 				error: String(error),
 			});
 			return false;
+		}
+	}
+
+	/**
+	 * Schedule a SIGKILL escalation if the process doesn't exit after SIGTERM.
+	 * The timer is cancelled automatically if the process exits on its own.
+	 */
+	private scheduleKillEscalation(sessionId: string, pid: number | undefined): void {
+		if (!pid) return;
+
+		const escalationTimer = setTimeout(() => {
+			const stillRunning = this.processes.get(sessionId);
+			if (stillRunning) {
+				logger.warn(
+					'[ProcessManager] Process did not exit after SIGTERM, escalating to SIGKILL',
+					'ProcessManager',
+					{ sessionId, pid }
+				);
+				try {
+					globalThis.process.kill(pid, 'SIGKILL');
+				} catch {
+					// ESRCH = process already gone, which is fine
+					logger.debug(
+						'[ProcessManager] SIGKILL failed (process may already be terminated)',
+						'ProcessManager',
+						{ sessionId, pid }
+					);
+				}
+				// Final cleanup — if exit handler hasn't fired by now, remove manually
+				this.processes.delete(sessionId);
+			}
+		}, ProcessManager.KILL_ESCALATION_TIMEOUT);
+
+		// Cancel escalation if process exits on its own
+		const child = this.processes.get(sessionId)?.childProcess;
+		if (child) {
+			child.once('exit', () => clearTimeout(escalationTimer));
+		}
+		const pty = this.processes.get(sessionId)?.ptyProcess;
+		if (pty) {
+			pty.onExit(() => clearTimeout(escalationTimer));
 		}
 	}
 


### PR DESCRIPTION
## Summary

Closes #733

- **SIGKILL escalation**: `ProcessManager.kill()` now schedules a SIGKILL fallback if the process doesn't exit within 5 seconds of SIGTERM. Previously, a hung process that ignored SIGTERM would survive indefinitely.
- **Deferred process map cleanup**: The process is no longer removed from the tracking map immediately on `kill()`. Instead, it stays until the exit event actually fires (handled by `ExitHandler` / `PtySpawner`), so the escalation timer can detect a still-running process and the UI accurately reflects the process state.

## Test plan

- [x] Existing process-manager tests updated and passing (37/37)
- [x] Type-check clean (`tsc --noEmit` on all configs)
- [x] ESLint clean
- [ ] Manual: start an Auto Run, stop mid-run — verify process dies within 5s
- [ ] Manual: simulate a hung process (e.g., `sleep 999`) — verify SIGKILL fires after timeout

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved process termination reliability with a forced termination fallback when graceful shutdown is unsuccessful.

* **Documentation**
  * Normalized markdown formatting in release notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->