### PR TITLE
feat: Enable alt/option + click to expand and collapse subdirectories recursively in the file browser

### DIFF
--- a/src/__tests__/integration/AutoRunRightPanel.test.tsx
+++ b/src/__tests__/integration/AutoRunRightPanel.test.tsx
@@ -267,6 +267,7 @@ const RightPanelTestWrapper = ({
 				fileTreeContainerRef={fileTreeContainerRef}
 				fileTreeFilterInputRef={fileTreeFilterInputRef}
 				toggleFolder={() => {}}
+				toggleFolderRecursive={() => {}}
 				handleFileClick={async () => {}}
 				expandAllFolders={() => {}}
 				collapseAllFolders={() => {}}
@@ -384,6 +385,7 @@ describe('Auto Run + RightPanel Integration', () => {
 								fileTreeContainerRef={fileTreeContainerRef}
 								fileTreeFilterInputRef={fileTreeFilterInputRef}
 								toggleFolder={() => {}}
+								toggleFolderRecursive={() => {}}
 								handleFileClick={async () => {}}
 								expandAllFolders={() => {}}
 								collapseAllFolders={() => {}}
@@ -723,6 +725,7 @@ describe('Auto Run + RightPanel Integration', () => {
 							fileTreeContainerRef={fileTreeContainerRef}
 							fileTreeFilterInputRef={fileTreeFilterInputRef}
 							toggleFolder={() => {}}
+							toggleFolderRecursive={() => {}}
 							handleFileClick={async () => {}}
 							expandAllFolders={() => {}}
 							collapseAllFolders={() => {}}
@@ -835,6 +838,7 @@ describe('Auto Run + RightPanel Integration', () => {
 								fileTreeContainerRef={fileTreeContainerRef}
 								fileTreeFilterInputRef={fileTreeFilterInputRef}
 								toggleFolder={() => {}}
+								toggleFolderRecursive={() => {}}
 								handleFileClick={async () => {}}
 								expandAllFolders={() => {}}
 								collapseAllFolders={() => {}}
@@ -905,6 +909,7 @@ describe('Auto Run + RightPanel Integration', () => {
 						fileTreeContainerRef={fileTreeContainerRef}
 						fileTreeFilterInputRef={fileTreeFilterInputRef}
 						toggleFolder={() => {}}
+						toggleFolderRecursive={() => {}}
 						handleFileClick={async () => {}}
 						expandAllFolders={() => {}}
 						collapseAllFolders={() => {}}
@@ -988,6 +993,7 @@ describe('Auto Run + RightPanel Integration', () => {
 						fileTreeContainerRef={fileTreeContainerRef}
 						fileTreeFilterInputRef={fileTreeFilterInputRef}
 						toggleFolder={() => {}}
+						toggleFolderRecursive={() => {}}
 						handleFileClick={async () => {}}
 						expandAllFolders={() => {}}
 						collapseAllFolders={() => {}}
@@ -1095,6 +1101,7 @@ describe('Auto Run + RightPanel Integration', () => {
 								fileTreeContainerRef={fileTreeContainerRef}
 								fileTreeFilterInputRef={fileTreeFilterInputRef}
 								toggleFolder={() => {}}
+								toggleFolderRecursive={() => {}}
 								handleFileClick={async () => {}}
 								expandAllFolders={() => {}}
 								collapseAllFolders={() => {}}
@@ -1183,6 +1190,7 @@ describe('Auto Run + RightPanel Integration', () => {
 								fileTreeContainerRef={fileTreeContainerRef}
 								fileTreeFilterInputRef={fileTreeFilterInputRef}
 								toggleFolder={() => {}}
+								toggleFolderRecursive={() => {}}
 								handleFileClick={async () => {}}
 								expandAllFolders={() => {}}
 								collapseAllFolders={() => {}}
@@ -1256,6 +1264,7 @@ describe('Auto Run + RightPanel Integration', () => {
 					fileTreeContainerRef={fileTreeContainerRef}
 					fileTreeFilterInputRef={fileTreeFilterInputRef}
 					toggleFolder={() => {}}
+					toggleFolderRecursive={() => {}}
 					handleFileClick={async () => {}}
 					expandAllFolders={() => {}}
 					collapseAllFolders={() => {}}
@@ -1364,6 +1373,7 @@ describe('Auto Run + RightPanel Integration', () => {
 					fileTreeContainerRef={fileTreeContainerRef}
 					fileTreeFilterInputRef={fileTreeFilterInputRef}
 					toggleFolder={() => {}}
+					toggleFolderRecursive={() => {}}
 					handleFileClick={async () => {}}
 					expandAllFolders={() => {}}
 					collapseAllFolders={() => {}}
@@ -1444,6 +1454,7 @@ describe('Auto Run + RightPanel Integration', () => {
 							fileTreeContainerRef={fileTreeContainerRef}
 							fileTreeFilterInputRef={fileTreeFilterInputRef}
 							toggleFolder={() => {}}
+							toggleFolderRecursive={() => {}}
 							handleFileClick={async () => {}}
 							expandAllFolders={() => {}}
 							collapseAllFolders={() => {}}

--- a/src/__tests__/renderer/components/FileExplorerPanel.test.tsx
+++ b/src/__tests__/renderer/components/FileExplorerPanel.test.tsx
@@ -287,6 +287,7 @@ describe('FileExplorerPanel', () => {
 			fileTreeContainerRef: React.createRef<HTMLDivElement>(),
 			fileTreeFilterInputRef: React.createRef<HTMLInputElement>(),
 			toggleFolder: vi.fn(),
+			toggleFolderRecursive: vi.fn(),
 			handleFileClick: vi.fn().mockResolvedValue(undefined),
 			expandAllFolders: vi.fn(),
 			collapseAllFolders: vi.fn(),
@@ -988,6 +989,20 @@ describe('FileExplorerPanel', () => {
 				'session-1',
 				expect.any(Function)
 			);
+			expect(defaultProps.toggleFolderRecursive).not.toHaveBeenCalled();
+		});
+
+		it('calls toggleFolderRecursive on Alt+click of a folder', () => {
+			render(<FileExplorerPanel {...defaultProps} />);
+			const srcFolder = screen.getByText('src');
+			fireEvent.click(srcFolder, { altKey: true });
+
+			expect(defaultProps.toggleFolderRecursive).toHaveBeenCalledWith(
+				'src',
+				'session-1',
+				expect.any(Function)
+			);
+			expect(defaultProps.toggleFolder).not.toHaveBeenCalled();
 		});
 
 		it('sets selectedFileIndex and activeFocus when clicking a file', () => {

--- a/src/__tests__/renderer/components/RightPanel.test.tsx
+++ b/src/__tests__/renderer/components/RightPanel.test.tsx
@@ -130,6 +130,7 @@ describe('RightPanel', () => {
 		fileTreeContainerRef: { current: null } as React.RefObject<HTMLDivElement>,
 		fileTreeFilterInputRef: { current: null } as React.RefObject<HTMLInputElement>,
 		toggleFolder: vi.fn(),
+		toggleFolderRecursive: vi.fn(),
 		handleFileClick: vi.fn(),
 		expandAllFolders: vi.fn(),
 		collapseAllFolders: vi.fn(),

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -988,6 +988,7 @@ function MaestroConsoleInner() {
 		handleFileClick,
 		updateSessionWorkingDirectory,
 		toggleFolder,
+		toggleFolderRecursive,
 		expandAllFolders,
 		collapseAllFolders,
 	} = useAppHandlers({
@@ -2506,6 +2507,7 @@ function MaestroConsoleInner() {
 
 		// File explorer handlers
 		toggleFolder,
+		toggleFolderRecursive,
 		handleFileClick,
 		expandAllFolders,
 		collapseAllFolders,

--- a/src/renderer/components/FileExplorerPanel.tsx
+++ b/src/renderer/components/FileExplorerPanel.tsx
@@ -1081,6 +1081,7 @@ function FileExplorerPanelInner(props: FileExplorerPanelProps) {
 			return (
 				<div
 					data-file-index={globalIndex}
+					title={isFolder ? 'Alt/Option+click to expand or collapse all subfolders' : undefined}
 					className={`absolute top-0 left-0 w-full flex items-center gap-2 py-1 text-xs cursor-pointer hover:bg-white/5 px-2 rounded transition-colors border-l-2 select-none min-w-0 ${isSelected ? 'bg-white/10' : ''}`}
 					style={{
 						height: `${virtualRow.size}px`,

--- a/src/renderer/components/FileExplorerPanel.tsx
+++ b/src/renderer/components/FileExplorerPanel.tsx
@@ -435,6 +435,11 @@ interface FileExplorerPanelProps {
 		activeSessionId: string,
 		setSessions: React.Dispatch<React.SetStateAction<Session[]>>
 	) => void;
+	toggleFolderRecursive: (
+		path: string,
+		activeSessionId: string,
+		setSessions: React.Dispatch<React.SetStateAction<Session[]>>
+	) => void;
 	handleFileClick: (node: FileNode, path: string, activeSession: Session) => Promise<void>;
 	expandAllFolders: (
 		activeSessionId: string,
@@ -481,6 +486,7 @@ function FileExplorerPanelInner(props: FileExplorerPanelProps) {
 		setActiveFocus,
 		fileTreeFilterInputRef,
 		toggleFolder,
+		toggleFolderRecursive,
 		handleFileClick,
 		expandAllFolders,
 		collapseAllFolders,
@@ -1094,9 +1100,13 @@ function FileExplorerPanelInner(props: FileExplorerPanelProps) {
 							e.preventDefault();
 						}
 					}}
-					onClick={() => {
+					onClick={(e) => {
 						if (isFolder) {
-							toggleFolder(fullPath, session.id, setSessions);
+							if (e.altKey) {
+								toggleFolderRecursive(fullPath, session.id, setSessions);
+							} else {
+								toggleFolder(fullPath, session.id, setSessions);
+							}
 						} else {
 							setSelectedFileIndex(globalIndex);
 							// Only change focus if not filtering
@@ -1166,6 +1176,7 @@ function FileExplorerPanelInner(props: FileExplorerPanelProps) {
 			selectedFileIndex,
 			theme,
 			toggleFolder,
+			toggleFolderRecursive,
 			setSessions,
 			setSelectedFileIndex,
 			setActiveFocus,

--- a/src/renderer/components/RightPanel.tsx
+++ b/src/renderer/components/RightPanel.tsx
@@ -59,6 +59,11 @@ interface RightPanelProps {
 		activeSessionId: string,
 		setSessions: React.Dispatch<React.SetStateAction<Session[]>>
 	) => void;
+	toggleFolderRecursive: (
+		path: string,
+		activeSessionId: string,
+		setSessions: React.Dispatch<React.SetStateAction<Session[]>>
+	) => void;
 	handleFileClick: (node: FileNode, path: string, activeSession: Session) => Promise<void>;
 	expandAllFolders: (
 		activeSessionId: string,
@@ -164,6 +169,7 @@ export const RightPanel = memo(
 			fileTreeContainerRef,
 			fileTreeFilterInputRef,
 			toggleFolder,
+			toggleFolderRecursive,
 			handleFileClick,
 			expandAllFolders,
 			collapseAllFolders,
@@ -514,6 +520,7 @@ export const RightPanel = memo(
 							setActiveFocus={setActiveFocus}
 							fileTreeFilterInputRef={fileTreeFilterInputRef}
 							toggleFolder={toggleFolder}
+							toggleFolderRecursive={toggleFolderRecursive}
 							handleFileClick={handleFileClick}
 							expandAllFolders={expandAllFolders}
 							collapseAllFolders={collapseAllFolders}

--- a/src/renderer/hooks/props/useRightPanelProps.ts
+++ b/src/renderer/hooks/props/useRightPanelProps.ts
@@ -40,6 +40,11 @@ export interface UseRightPanelPropsDeps {
 		activeSessionId: string,
 		setSessions: React.Dispatch<React.SetStateAction<Session[]>>
 	) => void;
+	toggleFolderRecursive: (
+		path: string,
+		activeSessionId: string,
+		setSessions: React.Dispatch<React.SetStateAction<Session[]>>
+	) => void;
 	handleFileClick: (node: FileNode, path: string, activeSession: Session) => Promise<void>;
 	expandAllFolders: (
 		activeSessionId: string,
@@ -122,6 +127,7 @@ export function useRightPanelProps(deps: UseRightPanelPropsDeps) {
 
 			// File explorer handlers
 			toggleFolder: deps.toggleFolder,
+			toggleFolderRecursive: deps.toggleFolderRecursive,
 			handleFileClick: deps.handleFileClick,
 			expandAllFolders: deps.expandAllFolders,
 			collapseAllFolders: deps.collapseAllFolders,
@@ -177,6 +183,7 @@ export function useRightPanelProps(deps: UseRightPanelPropsDeps) {
 			// Stable callbacks
 			deps.handleSetActiveRightTab,
 			deps.toggleFolder,
+			deps.toggleFolderRecursive,
 			deps.handleFileClick,
 			deps.expandAllFolders,
 			deps.collapseAllFolders,

--- a/src/renderer/hooks/ui/useAppHandlers.ts
+++ b/src/renderer/hooks/ui/useAppHandlers.ts
@@ -1,6 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { Session, FocusArea } from '../../types';
-import { shouldOpenExternally, getAllFolderPaths } from '../../utils/fileExplorer';
+import {
+	shouldOpenExternally,
+	getAllFolderPaths,
+	type FileTreeNode,
+} from '../../utils/fileExplorer';
 import type { FileNode } from '../../types/fileTree';
 import { useModalStore } from '../../stores/modalStore';
 import { useFileExplorerStore } from '../../stores/fileExplorerStore';
@@ -93,6 +97,45 @@ export interface UseAppHandlersReturn {
 		sessionId: string,
 		setSessions: React.Dispatch<React.SetStateAction<Session[]>>
 	) => void;
+}
+
+/**
+ * Collect all descendant folder paths under a given set of nodes.
+ */
+function collectDescendantFolders(nodes: FileTreeNode[], currentPath: string): string[] {
+	const result: string[] = [];
+	for (const node of nodes) {
+		const fullPath = currentPath ? `${currentPath}/${node.name}` : node.name;
+		if (node.type === 'folder') {
+			result.push(fullPath);
+			if (node.children) {
+				result.push(...collectDescendantFolders(node.children, fullPath));
+			}
+		}
+	}
+	return result;
+}
+
+/**
+ * Find a folder by targetPath in the tree and return it plus all descendant folder paths.
+ */
+function findSubtreeFolders(
+	nodes: FileTreeNode[],
+	currentPath: string,
+	targetPath: string
+): string[] | null {
+	for (const node of nodes) {
+		const fullPath = currentPath ? `${currentPath}/${node.name}` : node.name;
+		if (fullPath === targetPath && node.type === 'folder') {
+			const descendants = node.children ? collectDescendantFolders(node.children, fullPath) : [];
+			return [fullPath, ...descendants];
+		}
+		if (node.type === 'folder' && node.children && targetPath.startsWith(fullPath + '/')) {
+			const found = findSubtreeFolders(node.children, fullPath, targetPath);
+			if (found) return found;
+		}
+	}
+	return null;
 }
 
 /**
@@ -326,57 +369,13 @@ export function useAppHandlers(deps: UseAppHandlersDeps): UseAppHandlersReturn {
 					if (!s.fileExplorerExpanded || !s.fileTree) return s;
 					const expanded = new Set(s.fileExplorerExpanded);
 					const isCurrentlyExpanded = expanded.has(path);
-
-					// Find the node at this path and collect all descendant folder paths
-					const collectDescendantFolders = (
-						nodes: typeof s.fileTree,
-						currentPath: string
-					): string[] => {
-						const result: string[] = [];
-						for (const node of nodes!) {
-							const fullPath = currentPath ? `${currentPath}/${node.name}` : node.name;
-							if (node.type === 'folder') {
-								result.push(fullPath);
-								if (node.children) {
-									result.push(...collectDescendantFolders(node.children, fullPath));
-								}
-							}
-						}
-						return result;
-					};
-
-					// Find the subtree starting at the target path
-					const findSubtreeFolders = (
-						nodes: typeof s.fileTree,
-						currentPath: string
-					): string[] | null => {
-						for (const node of nodes!) {
-							const fullPath = currentPath ? `${currentPath}/${node.name}` : node.name;
-							if (fullPath === path && node.type === 'folder') {
-								// Found the target - collect all descendants
-								const descendants = node.children
-									? collectDescendantFolders(node.children, fullPath)
-									: [];
-								return [fullPath, ...descendants];
-							}
-							if (node.type === 'folder' && node.children && path.startsWith(fullPath + '/')) {
-								// Recurse into this folder
-								const found = findSubtreeFolders(node.children, fullPath);
-								if (found) return found;
-							}
-						}
-						return null;
-					};
-
-					const allPaths = findSubtreeFolders(s.fileTree, '') || [path];
+					const allPaths = findSubtreeFolders(s.fileTree, '', path) || [path];
 
 					if (isCurrentlyExpanded) {
-						// Collapse: remove the folder and all descendants
 						for (const p of allPaths) {
 							expanded.delete(p);
 						}
 					} else {
-						// Expand: add the folder and all descendants
 						for (const p of allPaths) {
 							expanded.add(p);
 						}

--- a/src/renderer/hooks/ui/useAppHandlers.ts
+++ b/src/renderer/hooks/ui/useAppHandlers.ts
@@ -76,6 +76,12 @@ export interface UseAppHandlersReturn {
 		sessionId: string,
 		setSessions: React.Dispatch<React.SetStateAction<Session[]>>
 	) => void;
+	/** Toggle folder and all descendants (Alt+Click) */
+	toggleFolderRecursive: (
+		path: string,
+		sessionId: string,
+		setSessions: React.Dispatch<React.SetStateAction<Session[]>>
+	) => void;
 	/** Expand all folders in file tree */
 	expandAllFolders: (
 		sessionId: string,
@@ -303,6 +309,86 @@ export function useAppHandlers(deps: UseAppHandlersDeps): UseAppHandlersReturn {
 		[]
 	);
 
+	/**
+	 * Toggle a folder and all its descendant folders (Alt+Click behavior).
+	 * If the folder is currently expanded, collapse it and all descendants.
+	 * If collapsed, expand it and all descendants.
+	 */
+	const toggleFolderRecursive = useCallback(
+		(
+			path: string,
+			sessionId: string,
+			setSessionsFn: React.Dispatch<React.SetStateAction<Session[]>>
+		) => {
+			setSessionsFn((prev) =>
+				prev.map((s) => {
+					if (s.id !== sessionId) return s;
+					if (!s.fileExplorerExpanded || !s.fileTree) return s;
+					const expanded = new Set(s.fileExplorerExpanded);
+					const isCurrentlyExpanded = expanded.has(path);
+
+					// Find the node at this path and collect all descendant folder paths
+					const collectDescendantFolders = (
+						nodes: typeof s.fileTree,
+						currentPath: string
+					): string[] => {
+						const result: string[] = [];
+						for (const node of nodes!) {
+							const fullPath = currentPath ? `${currentPath}/${node.name}` : node.name;
+							if (node.type === 'folder') {
+								result.push(fullPath);
+								if (node.children) {
+									result.push(...collectDescendantFolders(node.children, fullPath));
+								}
+							}
+						}
+						return result;
+					};
+
+					// Find the subtree starting at the target path
+					const findSubtreeFolders = (
+						nodes: typeof s.fileTree,
+						currentPath: string
+					): string[] | null => {
+						for (const node of nodes!) {
+							const fullPath = currentPath ? `${currentPath}/${node.name}` : node.name;
+							if (fullPath === path && node.type === 'folder') {
+								// Found the target - collect all descendants
+								const descendants = node.children
+									? collectDescendantFolders(node.children, fullPath)
+									: [];
+								return [fullPath, ...descendants];
+							}
+							if (node.type === 'folder' && node.children && path.startsWith(fullPath + '/')) {
+								// Recurse into this folder
+								const found = findSubtreeFolders(node.children, fullPath);
+								if (found) return found;
+							}
+						}
+						return null;
+					};
+
+					const allPaths = findSubtreeFolders(s.fileTree, '') || [path];
+
+					if (isCurrentlyExpanded) {
+						// Collapse: remove the folder and all descendants
+						for (const p of allPaths) {
+							expanded.delete(p);
+						}
+					} else {
+						// Expand: add the folder and all descendants
+						for (const p of allPaths) {
+							expanded.add(p);
+						}
+					}
+
+					return { ...s, fileExplorerExpanded: Array.from(expanded) };
+				})
+			);
+		},
+		[]
+	);
+
 	const expandAllFolders = useCallback(
 		(
 			sessionId: string,
@@ -348,6 +434,7 @@ export function useAppHandlers(deps: UseAppHandlersDeps): UseAppHandlersReturn {
 
 		// Folder handlers
 		toggleFolder,
+		toggleFolderRecursive,
 		expandAllFolders,
 		collapseAllFolders,
 	};


### PR DESCRIPTION
Just adding a small shortcut in the middle of the collapse and expand all button

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hold Alt and click a folder to recursively expand or collapse that folder and all descendant subfolders.
  * Recursive toggle is available from the file explorer and the right-side panel for faster navigation of deep directories.
  * Regular click still toggles a single folder; Alt‑click performs the recursive action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->