### PR TITLE
feat: add Winamp vibe theme

### DIFF
--- a/src/__tests__/renderer/constants/themes.test.ts
+++ b/src/__tests__/renderer/constants/themes.test.ts
@@ -51,12 +51,12 @@ describe('THEMES constant', () => {
 			}
 		});
 
-		it('should have exactly 18 themes (sync check with ThemeId type)', () => {
+		it('should have exactly 19 themes (sync check with ThemeId type)', () => {
 			// This count should match the number of IDs in ThemeId union type.
 			// If a new theme is added to THEMES without updating ThemeId, TypeScript errors.
 			// If ThemeId is updated without adding to isValidThemeId array, other tests fail.
 			// This test serves as an explicit reminder when themes are added/removed.
-			expect(themeIds.length).toBe(18);
+			expect(themeIds.length).toBe(19);
 		});
 
 		it('should have theme.id matching its key', () => {

--- a/src/shared/theme-types.ts
+++ b/src/shared/theme-types.ts
@@ -30,6 +30,7 @@ export type ThemeId =
 	| 'maestros-choice'
 	| 'dre-synth'
 	| 'inquest'
+	| 'winamp'
 	| 'custom';
 
 /**
@@ -129,6 +130,7 @@ export function isValidThemeId(id: string): id is ThemeId {
 		'maestros-choice',
 		'dre-synth',
 		'inquest',
+		'winamp',
 		'custom',
 	];
 	return validIds.includes(id as ThemeId);

--- a/src/shared/themes.ts
+++ b/src/shared/themes.ts
@@ -353,6 +353,27 @@ const dreSynthAnsi: AnsiPalette = {
 	selection: 'rgba(0, 255, 204, 0.3)',
 };
 
+/** Winamp (vibe) — retro media player ANSI palette */
+const winampAnsi: AnsiPalette = {
+	ansiBlack: '#1a1a1a',
+	ansiRed: '#ff5555',
+	ansiGreen: '#00e000',
+	ansiYellow: '#ffff00',
+	ansiBlue: '#4a4a4a',
+	ansiMagenta: '#ff8924',
+	ansiCyan: '#8a8a62',
+	ansiWhite: '#cccccc',
+	ansiBrightBlack: '#3a3a3a',
+	ansiBrightRed: '#ff6666',
+	ansiBrightGreen: '#33ff33',
+	ansiBrightYellow: '#ffff55',
+	ansiBrightBlue: '#666666',
+	ansiBrightMagenta: '#ffaa55',
+	ansiBrightCyan: '#aaaa77',
+	ansiBrightWhite: '#ffffff',
+	selection: 'rgba(255, 137, 36, 0.3)',
+};
+
 /** InQuest (vibe) — high-contrast red/black ANSI palette */
 const inquestAnsi: AnsiPalette = {
 	ansiBlack: '#0a0a0a',
@@ -732,6 +753,27 @@ export const THEMES: Record<ThemeId, Theme> = {
 			warning: '#cc0033',
 			error: '#cc0033',
 			...inquestAnsi,
+		},
+	},
+	winamp: {
+		id: 'winamp',
+		name: 'Winamp',
+		mode: 'vibe',
+		colors: {
+			bgMain: '#232323',
+			bgSidebar: '#1a1a1a',
+			bgActivity: '#3a3a3a',
+			border: '#4a4a4a',
+			textMain: '#00e000',
+			textDim: '#8a8a62',
+			accent: '#ff8924',
+			accentDim: 'rgba(255, 137, 36, 0.2)',
+			accentText: '#ffff00',
+			accentForeground: '#1a1a1a',
+			success: '#00e000',
+			warning: '#ff8924',
+			error: '#ff5555',
+			...winampAnsi,
 		},
 	},
 	// Custom theme - user-configurable, defaults to Dracula


### PR DESCRIPTION
## Summary
- Add new "Winamp" vibe theme inspired by the classic Winamp media player aesthetic
- Green LED ticker text (`#00e000`), orange playlist accent (`#ff8924`), yellow current-track highlight (`#ffff00`) on a dark charcoal body
- Includes full ANSI 16-color terminal palette

## Test plan
- [x] Theme count assertion updated (18 → 19)
- [x] All 24,542 tests pass
- [x] TypeScript lint clean across all tsconfig targets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "Winamp" theme with a curated color palette and vibe mode styling, now available for selection in the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->