### PR TITLE
feat: show clickable session ID badge next to Auto Run Active status

### DIFF
--- a/src/renderer/components/RightPanel.tsx
+++ b/src/renderer/components/RightPanel.tsx
@@ -16,6 +16,7 @@ import {
 	AlertTriangle,
 	Play,
 	XCircle,
+	ExternalLink,
 } from 'lucide-react';
 import type { Session, Theme, RightPanelTab, BatchRunState } from '../types';
 import type { FileTreeChanges } from '../utils/fileExplorer';
@@ -100,7 +101,7 @@ interface RightPanelProps {
 	onResumeAfterError?: () => void;
 	onJumpToAgentSession?: (agentSessionId: string) => void;
 	onResumeSession?: (agentSessionId: string) => void;
-	onOpenSessionAsTab?: (agentSessionId: string) => void;
+	onOpenSessionAsTab?: (agentSessionId: string, sessionName?: string) => void;
 
 	// Modal handlers
 	onOpenAboutModal?: () => void;
@@ -404,6 +405,17 @@ export const RightPanel = memo(
 			autoFollowEnabled,
 		};
 
+		// Resolve current agent session ID for the Auto Run badge
+		const batchSessionIds = currentSessionBatchState?.sessionIds;
+		const currentBadgeSessionId =
+			currentSessionBatchState?.currentAgentSessionId ||
+			(batchSessionIds && batchSessionIds.length > 0
+				? batchSessionIds[batchSessionIds.length - 1]
+				: null);
+		const badgeShortId = currentBadgeSessionId
+			? currentBadgeSessionId.split('-')[0].toUpperCase()
+			: null;
+
 		return (
 			<div
 				ref={panelRef}
@@ -596,6 +608,24 @@ export const RightPanel = memo(
 									>
 										{currentSessionBatchState.isStopping ? 'Stopping...' : 'Auto Run Active'}
 									</span>
+								)}
+								{/* Current agent session ID badge — matches history entry style */}
+								{currentBadgeSessionId && onOpenSessionAsTab && (
+									<button
+										onClick={() =>
+											onOpenSessionAsTab(currentBadgeSessionId, `${badgeShortId} (snapshot)`)
+										}
+										className="flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-bold font-mono uppercase transition-colors hover:opacity-80"
+										style={{
+											backgroundColor: theme.colors.accent + '20',
+											color: theme.colors.accent,
+											border: `1px solid ${theme.colors.accent}40`,
+										}}
+										title={`Open session ${currentBadgeSessionId}`}
+									>
+										<span className="truncate">{badgeShortId}</span>
+										<ExternalLink className="w-2.5 h-2.5 flex-shrink-0" />
+									</button>
 								)}
 								{currentSessionBatchState.worktreeActive && (
 									<span title={`Worktree: ${currentSessionBatchState.worktreeBranch || 'active'}`}>

--- a/src/renderer/hooks/agent/useAgentListeners.ts
+++ b/src/renderer/hooks/agent/useAgentListeners.ts
@@ -30,6 +30,7 @@ import { notifyToast } from '../../stores/notificationStore';
 import type { HistoryEntryInput } from './useAgentSessionManagement';
 import { useSessionStore } from '../../stores/sessionStore';
 import { useModalStore } from '../../stores/modalStore';
+import { useBatchStore } from '../../stores/batchStore';
 import { gitService } from '../../services/git';
 import { generateId } from '../../utils/ids';
 import {
@@ -921,6 +922,19 @@ export function useAgentListeners(deps: UseAgentListenersDeps): void {
 		const unsubscribeSessionId = window.maestro.process.onSessionId(
 			async (sessionId: string, agentSessionId: string) => {
 				if (isBatchSession(sessionId)) {
+					// Store the live agent session ID in batch state for UI display
+					const batchMatch = sessionId.match(/^(.+)-batch-\d+$/);
+					if (batchMatch) {
+						const baseSessionId = batchMatch[1];
+						useBatchStore.getState().setBatchRunStates((prev) => {
+							const existing = prev[baseSessionId];
+							if (!existing) return prev;
+							return {
+								...prev,
+								[baseSessionId]: { ...existing, currentAgentSessionId: agentSessionId },
+							};
+						});
+					}
 					return;
 				}
 

--- a/src/renderer/hooks/props/useRightPanelProps.ts
+++ b/src/renderer/hooks/props/useRightPanelProps.ts
@@ -73,7 +73,11 @@ export interface UseRightPanelPropsDeps {
 	handleAbortBatchOnError: () => void;
 	handleResumeAfterError: () => void;
 	handleJumpToAgentSession: (agentSessionId: string) => void;
-	handleResumeSession: (agentSessionId: string) => void;
+	handleResumeSession: (
+		agentSessionId: string,
+		providedMessages?: undefined,
+		sessionName?: string
+	) => void;
 
 	// Modal handlers
 	handleOpenAboutModal: () => void;
@@ -134,7 +138,8 @@ export function useRightPanelProps(deps: UseRightPanelPropsDeps) {
 			onResumeAfterError: deps.handleResumeAfterError,
 			onJumpToAgentSession: deps.handleJumpToAgentSession,
 			onResumeSession: deps.handleResumeSession,
-			onOpenSessionAsTab: deps.handleResumeSession,
+			onOpenSessionAsTab: (agentSessionId: string, sessionName?: string) =>
+				deps.handleResumeSession(agentSessionId, undefined, sessionName),
 
 			// Modal handlers
 			onOpenAboutModal: deps.handleOpenAboutModal,

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -329,6 +329,7 @@ export interface BatchRunState {
 	// Prompt configuration
 	customPrompt?: string; // User's custom prompt if modified
 	sessionIds: string[]; // Claude session IDs from each iteration
+	currentAgentSessionId?: string; // Live agent session ID for the currently running task
 	startTime?: number; // Timestamp when batch run started
 	cumulativeTaskTimeMs?: number; // Sum of actual task durations (most accurate work time measure)
 	accumulatedElapsedMs?: number; // Accumulated active elapsed time (excludes sleep/suspend time)


### PR DESCRIPTION
<img width="1512" height="1012" alt="Bildschirmfoto 2026-04-06 um 20 50 46" src="https://github.com/user-attachments/assets/1d3699a1-70c7-4ecd-a84e-279708eea2ce" />


I have a feature proposal for the people like me that need to see something sometimes, it adds the live session id to the auto run status box, but since everything is a snapshot and not updated live it opens the session with (snapshot) but you can see the last message when something is slow or you're just curious.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Batch run header now shows the current active agent session as a small labeled badge (e.g., "XXXX (snapshot)").
  * Badge is clickable — opens the corresponding session in a new tab and supports providing a custom session name for easier identification.
  * Improved live tracking of which agent session is currently running during batch executions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->