### PR TITLE
feat: add right-click context menu for agent groups

### DIFF
--- a/src/renderer/components/SessionList/GroupContextMenu.tsx
+++ b/src/renderer/components/SessionList/GroupContextMenu.tsx
@@ -1,0 +1,120 @@
+import { useEffect, useRef } from 'react';
+import { Edit3, Trash2, ChevronDown, ChevronRight, Smile } from 'lucide-react';
+import type { Group, Theme } from '../../types';
+import { useClickOutside, useContextMenuPosition } from '../../hooks';
+
+interface GroupContextMenuProps {
+	x: number;
+	y: number;
+	theme: Theme;
+	group: Group;
+	onRename: () => void;
+	onDelete: () => void;
+	onToggleCollapse: () => void;
+	onChangeEmoji: () => void;
+	onDismiss: () => void;
+}
+
+export function GroupContextMenu({
+	x,
+	y,
+	theme,
+	group,
+	onRename,
+	onDelete,
+	onToggleCollapse,
+	onChangeEmoji,
+	onDismiss,
+}: GroupContextMenuProps) {
+	const menuRef = useRef<HTMLDivElement>(null);
+
+	const onDismissRef = useRef(onDismiss);
+	onDismissRef.current = onDismiss;
+
+	useClickOutside(menuRef, onDismiss);
+
+	useEffect(() => {
+		const handleKeyDown = (e: KeyboardEvent) => {
+			if (e.key === 'Escape') {
+				onDismissRef.current();
+			}
+		};
+		document.addEventListener('keydown', handleKeyDown);
+		return () => document.removeEventListener('keydown', handleKeyDown);
+	}, []);
+
+	const { left, top, ready } = useContextMenuPosition(menuRef, x, y);
+
+	return (
+		<div
+			ref={menuRef}
+			className="fixed z-50 py-1 rounded-md shadow-xl border"
+			style={{
+				left,
+				top,
+				opacity: ready ? 1 : 0,
+				backgroundColor: theme.colors.bgSidebar,
+				borderColor: theme.colors.border,
+				minWidth: '160px',
+			}}
+		>
+			<button
+				type="button"
+				onClick={() => {
+					onRename();
+					onDismiss();
+				}}
+				className="w-full text-left px-3 py-1.5 text-xs hover:bg-white/5 transition-colors flex items-center gap-2"
+				style={{ color: theme.colors.textMain }}
+			>
+				<Edit3 className="w-3.5 h-3.5" />
+				Rename
+			</button>
+
+			<button
+				type="button"
+				onClick={() => {
+					onChangeEmoji();
+					onDismiss();
+				}}
+				className="w-full text-left px-3 py-1.5 text-xs hover:bg-white/5 transition-colors flex items-center gap-2"
+				style={{ color: theme.colors.textMain }}
+			>
+				<Smile className="w-3.5 h-3.5" />
+				Change Emoji
+			</button>
+
+			<button
+				type="button"
+				onClick={() => {
+					onToggleCollapse();
+					onDismiss();
+				}}
+				className="w-full text-left px-3 py-1.5 text-xs hover:bg-white/5 transition-colors flex items-center gap-2"
+				style={{ color: theme.colors.textMain }}
+			>
+				{group.collapsed ? (
+					<ChevronDown className="w-3.5 h-3.5" />
+				) : (
+					<ChevronRight className="w-3.5 h-3.5" />
+				)}
+				{group.collapsed ? 'Expand' : 'Collapse'}
+			</button>
+
+			<div className="my-1 border-t" style={{ borderColor: theme.colors.border }} />
+
+			<button
+				type="button"
+				onClick={() => {
+					onDelete();
+					onDismiss();
+				}}
+				className="w-full text-left px-3 py-1.5 text-xs hover:bg-white/5 transition-colors flex items-center gap-2"
+				style={{ color: theme.colors.error }}
+			>
+				<Trash2 className="w-3.5 h-3.5" />
+				Delete Group
+			</button>
+		</div>
+	);
+}

--- a/src/renderer/components/SessionList/SessionList.tsx
+++ b/src/renderer/components/SessionList/SessionList.tsx
@@ -28,6 +28,7 @@ import { useShallow } from 'zustand/react/shallow';
 import { useGroupChatStore } from '../../stores/groupChatStore';
 import { getModalActions } from '../../stores/modalStore';
 import { SessionContextMenu } from './SessionContextMenu';
+import { GroupContextMenu } from './GroupContextMenu';
 import { HamburgerMenuContent } from './HamburgerMenuContent';
 import { CollapsedSessionPill } from './CollapsedSessionPill';
 import { SidebarActions } from './SidebarActions';
@@ -162,6 +163,10 @@ function SessionListInner(props: SessionListProps) {
 		setRenameInstanceValue,
 		setRenameInstanceSessionId,
 		setDuplicatingSessionId,
+		setRenameGroupModalOpen,
+		setRenameGroupId,
+		setRenameGroupValue,
+		setRenameGroupEmoji,
 	} = getModalActions();
 
 	const {
@@ -255,6 +260,16 @@ function SessionListInner(props: SessionListProps) {
 		: null;
 	const menuRef = useRef<HTMLDivElement>(null);
 	const ignoreNextBlurRef = useRef(false);
+
+	// Group context menu state
+	const [groupContextMenu, setGroupContextMenu] = useState<{
+		x: number;
+		y: number;
+		groupId: string;
+	} | null>(null);
+	const groupContextMenuGroup = groupContextMenu
+		? groups.find((g) => g.id === groupContextMenu.groupId)
+		: null;
 
 	// Toggle bookmark for a session - memoized to prevent SessionItem re-renders
 	const toggleBookmark = useCallback(
@@ -891,6 +906,11 @@ function SessionListInner(props: SessionListProps) {
 									}}
 									className="px-3 py-1.5 flex items-center justify-between cursor-pointer hover:bg-opacity-50 group"
 									onClick={() => toggleGroup(group.id)}
+									onContextMenu={(e) => {
+										e.preventDefault();
+										e.stopPropagation();
+										setGroupContextMenu({ x: e.clientX, y: e.clientY, groupId: group.id });
+									}}
 									onDragOver={handleDragOver}
 									onDrop={() => handleDropOnGroup(group.id)}
 								>
@@ -1238,6 +1258,43 @@ function SessionListInner(props: SessionListProps) {
 							? () => onCreateGroupAndMove(contextMenuSession.id)
 							: createNewGroup
 					}
+				/>
+			)}
+
+			{/* Group Context Menu */}
+			{groupContextMenu && groupContextMenuGroup && (
+				<GroupContextMenu
+					x={groupContextMenu.x}
+					y={groupContextMenu.y}
+					theme={theme}
+					group={groupContextMenuGroup}
+					onRename={() => startRenamingGroup(groupContextMenuGroup.id)}
+					onDelete={() => {
+						const groupSessions = sessions.filter((s) => s.groupId === groupContextMenuGroup.id);
+						if (groupSessions.length > 0) {
+							showConfirmation(
+								`Are you sure you want to delete the group "${groupContextMenuGroup.name}"? The ${groupSessions.length} agent(s) inside will be ungrouped.`,
+								() => {
+									setSessions((prev) =>
+										prev.map((s) =>
+											s.groupId === groupContextMenuGroup.id ? { ...s, groupId: undefined } : s
+										)
+									);
+									setGroups((prev) => prev.filter((g) => g.id !== groupContextMenuGroup.id));
+								}
+							);
+						} else {
+							setGroups((prev) => prev.filter((g) => g.id !== groupContextMenuGroup.id));
+						}
+					}}
+					onToggleCollapse={() => toggleGroup(groupContextMenuGroup.id)}
+					onChangeEmoji={() => {
+						setRenameGroupId(groupContextMenuGroup.id);
+						setRenameGroupValue(groupContextMenuGroup.name);
+						setRenameGroupEmoji(groupContextMenuGroup.emoji);
+						setRenameGroupModalOpen(true);
+					}}
+					onDismiss={() => setGroupContextMenu(null)}
 				/>
 			)}
 		</div>


### PR DESCRIPTION
## Summary

- Adds a `GroupContextMenu` component that appears on right-click of group headers in the Left Bar
- Supports **Rename**, **Change Emoji** (opens rename group modal with emoji picker), **Collapse/Expand**, and **Delete Group** actions
- Delete confirms when the group contains agents, ungrouping them before removal
- Follows the existing `SessionContextMenu` pattern (positioning, click-outside dismiss, Escape key)

Closes #746

## Test plan

- [ ] Right-click a group header → context menu appears at cursor position
- [ ] Click "Rename" → inline rename activates on the group name
- [ ] Click "Change Emoji" → rename group modal opens with emoji picker
- [ ] Click "Collapse"/"Expand" → group toggles collapsed state
- [ ] Click "Delete Group" on empty group → group removed immediately
- [ ] Click "Delete Group" on group with agents → confirmation dialog, then agents ungrouped
- [ ] Click outside menu → menu dismisses
- [ ] Press Escape → menu dismisses
- [ ] Menu positions correctly near screen edges (uses `useContextMenuPosition`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Right-click on group headers to access a new context menu.
  * Rename groups, change group emoji, toggle collapse/expand, and delete groups from the context menu.
  * Sessions are automatically ungrouped when their group is deleted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->