### PR TITLE
[codex] Polish slash commands, PlayBooks labels, and sidebar menu layering

### DIFF
--- a/src/__tests__/renderer/components/InputArea.test.tsx
+++ b/src/__tests__/renderer/components/InputArea.test.tsx
@@ -696,7 +696,7 @@ describe('InputArea', () => {
 
 			// The second command (/help) should have accent background
 			// Find the parent div that has the background style (px-4 py-3 class)
-			const helpCmd = screen.getByText('/help').closest('.px-4');
+			const helpCmd = screen.getByText('/help').closest('button');
 			expect(helpCmd).toHaveStyle({ backgroundColor: mockTheme.colors.accent });
 		});
 
@@ -709,7 +709,7 @@ describe('InputArea', () => {
 			});
 			render(<InputArea {...props} />);
 
-			const helpCmd = screen.getByText('/help').closest('.px-4');
+			const helpCmd = screen.getByText('/help').closest('button');
 			fireEvent.mouseEnter(helpCmd!);
 
 			expect(setSelectedSlashCommandIndex).toHaveBeenCalledWith(1);
@@ -728,7 +728,7 @@ describe('InputArea', () => {
 			});
 			render(<InputArea {...props} />);
 
-			const clearCmd = screen.getByText('/clear').closest('.px-4');
+			const clearCmd = screen.getByText('/clear').closest('button');
 			fireEvent.doubleClick(clearCmd!);
 
 			expect(setInputValue).toHaveBeenCalledWith('/clear');
@@ -812,7 +812,7 @@ describe('InputArea', () => {
 			});
 			render(<InputArea {...props} />);
 
-			const helpCmd = screen.getByText('/help').closest('.px-4');
+			const helpCmd = screen.getByText('/help').closest('button');
 			fireEvent.click(helpCmd!);
 
 			// Single click should update selection
@@ -842,11 +842,11 @@ describe('InputArea', () => {
 			render(<InputArea {...props} />);
 
 			// The second item (/help) should NOT have accent background since index 0 is selected
-			const helpCmd = screen.getByText('/help').closest('.px-4');
+			const helpCmd = screen.getByText('/help').closest('button');
 			// Unselected items don't have the accent color background
 			expect(helpCmd).not.toHaveStyle({ backgroundColor: mockTheme.colors.accent });
 			// First item (selected) should have accent background
-			const clearCmd = screen.getByText('/clear').closest('.px-4');
+			const clearCmd = screen.getByText('/clear').closest('button');
 			expect(clearCmd).toHaveStyle({ backgroundColor: mockTheme.colors.accent });
 		});
 

--- a/src/renderer/components/AutoRun.tsx
+++ b/src/renderer/components/AutoRun.tsx
@@ -1761,7 +1761,7 @@ const AutoRunInner = forwardRef<AutoRunHandle, AutoRunProps>(function AutoRunInn
 							Run
 						</button>
 					)}
-					{/* Playbook Exchange button */}
+					{/* PlayBooks button */}
 					{onOpenMarketplace && (
 						<button
 							onClick={onOpenMarketplace}
@@ -1771,10 +1771,10 @@ const AutoRunInner = forwardRef<AutoRunHandle, AutoRunProps>(function AutoRunInn
 								border: `1px solid ${theme.colors.accent}40`,
 								backgroundColor: `${theme.colors.accent}15`,
 							}}
-							title="Browse Playbook Exchange - discover and share community playbooks"
+							title="Browse PlayBooks - discover and share community playbooks"
 						>
 							<LayoutGrid className="w-3.5 h-3.5" />
-							<span className="text-xs font-medium">Exchange</span>
+							<span className="text-xs font-medium">PlayBooks</span>
 						</button>
 					)}
 					{/* Launch Wizard button */}

--- a/src/renderer/components/AutoRunExpandedModal.tsx
+++ b/src/renderer/components/AutoRunExpandedModal.tsx
@@ -401,7 +401,7 @@ export function AutoRunExpandedModal({
 								Run
 							</button>
 						)}
-						{/* Exchange button */}
+						{/* PlayBooks button */}
 						{onOpenMarketplace && (
 							<button
 								onClick={onOpenMarketplace}
@@ -411,10 +411,10 @@ export function AutoRunExpandedModal({
 									border: `1px solid ${theme.colors.accent}`,
 									backgroundColor: `${theme.colors.accent}15`,
 								}}
-								title="Browse Playbook Exchange - discover and share community playbooks"
+								title="Browse PlayBooks - discover and share community playbooks"
 							>
 								<LayoutGrid className="w-3.5 h-3.5" />
-								Exchange
+								PlayBooks
 							</button>
 						)}
 					</div>

--- a/src/renderer/components/InputArea.tsx
+++ b/src/renderer/components/InputArea.tsx
@@ -501,7 +501,7 @@ export const InputArea = React.memo(function InputArea(props: InputAreaProps) {
 					style={{ backgroundColor: theme.colors.bgSidebar, borderColor: theme.colors.border }}
 				>
 					<div
-						className="overflow-y-auto max-h-64 scrollbar-thin"
+						className="overflow-y-auto max-h-80 scrollbar-thin"
 						style={{ overscrollBehavior: 'contain' }}
 					>
 						{filteredSlashCommands.map((cmd, idx) => (
@@ -509,7 +509,7 @@ export const InputArea = React.memo(function InputArea(props: InputAreaProps) {
 								type="button"
 								key={cmd.command}
 								ref={(el) => (slashCommandItemRefs.current[idx] = el)}
-								className={`w-full px-4 py-3 text-left transition-colors ${
+								className={`w-full px-3 py-2 text-left transition-colors ${
 									idx === safeSelectedIndex ? 'font-semibold' : ''
 								}`}
 								style={{
@@ -528,8 +528,8 @@ export const InputArea = React.memo(function InputArea(props: InputAreaProps) {
 								}}
 								onMouseEnter={() => setSelectedSlashCommandIndex(idx)}
 							>
-								<div className="font-mono text-sm">{cmd.command}</div>
-								<div className="text-xs opacity-70 mt-0.5">{cmd.description}</div>
+								<div className="font-mono text-sm leading-tight">{cmd.command}</div>
+								<div className="text-[11px] opacity-70 mt-0.5 leading-tight">{cmd.description}</div>
 							</button>
 						))}
 					</div>

--- a/src/renderer/components/InputArea.tsx
+++ b/src/renderer/components/InputArea.tsx
@@ -501,7 +501,7 @@ export const InputArea = React.memo(function InputArea(props: InputAreaProps) {
 					style={{ backgroundColor: theme.colors.bgSidebar, borderColor: theme.colors.border }}
 				>
 					<div
-						className="overflow-y-auto max-h-80 scrollbar-thin"
+						className="overflow-y-auto max-h-96 scrollbar-thin"
 						style={{ overscrollBehavior: 'contain' }}
 					>
 						{filteredSlashCommands.map((cmd, idx) => (
@@ -509,7 +509,7 @@ export const InputArea = React.memo(function InputArea(props: InputAreaProps) {
 								type="button"
 								key={cmd.command}
 								ref={(el) => (slashCommandItemRefs.current[idx] = el)}
-								className={`w-full px-3 py-2 text-left transition-colors ${
+								className={`w-full px-3 py-1 text-left transition-colors ${
 									idx === safeSelectedIndex ? 'font-semibold' : ''
 								}`}
 								style={{
@@ -529,7 +529,7 @@ export const InputArea = React.memo(function InputArea(props: InputAreaProps) {
 								onMouseEnter={() => setSelectedSlashCommandIndex(idx)}
 							>
 								<div className="font-mono text-sm leading-tight">{cmd.command}</div>
-								<div className="text-[11px] opacity-70 mt-0.5 leading-tight">{cmd.description}</div>
+								<div className="text-[11px] opacity-70 leading-tight">{cmd.description}</div>
 							</button>
 						))}
 					</div>

--- a/src/renderer/components/MainPanel.tsx
+++ b/src/renderer/components/MainPanel.tsx
@@ -855,7 +855,7 @@ export const MainPanel = React.memo(
 						{!isMobileLandscape && (
 							<div
 								ref={headerRef}
-								className={`header-container h-16 border-b flex items-center justify-between px-6 shrink-0 relative z-20 ${isCurrentSessionAutoMode ? 'header-auto-mode' : ''}`}
+								className={`header-container h-16 border-b flex items-center justify-between px-6 shrink-0 relative ${isCurrentSessionAutoMode ? 'header-auto-mode' : ''}`}
 								style={{
 									borderColor: theme.colors.border,
 									backgroundColor: theme.colors.bgSidebar,

--- a/src/renderer/components/SessionList/SessionList.tsx
+++ b/src/renderer/components/SessionList/SessionList.tsx
@@ -730,7 +730,7 @@ function SessionListInner(props: SessionListProps) {
 							{/* Menu Overlay */}
 							{menuOpen && (
 								<div
-									className="absolute top-full left-0 mt-2 w-72 rounded-lg shadow-2xl z-[100] overflow-y-auto scrollbar-thin"
+									className="absolute top-full left-0 -mt-px w-72 rounded-lg shadow-2xl z-[100] overflow-y-auto scrollbar-thin"
 									data-tour="hamburger-menu-contents"
 									style={{
 										backgroundColor: theme.colors.bgSidebar,
@@ -764,7 +764,7 @@ function SessionListInner(props: SessionListProps) {
 						{/* Menu Overlay for Collapsed Sidebar */}
 						{menuOpen && (
 							<div
-								className="absolute top-full left-0 mt-2 w-72 rounded-lg shadow-2xl z-[100] overflow-y-auto scrollbar-thin"
+								className="absolute top-full left-0 -mt-px w-72 rounded-lg shadow-2xl z-[100] overflow-y-auto scrollbar-thin"
 								style={{
 									backgroundColor: theme.colors.bgSidebar,
 									border: `1px solid ${theme.colors.border}`,

--- a/src/renderer/components/SessionList/SessionList.tsx
+++ b/src/renderer/components/SessionList/SessionList.tsx
@@ -718,7 +718,7 @@ function SessionListInner(props: SessionListProps) {
 							</div>
 						</div>
 						{/* Hamburger Menu */}
-						<div className="relative z-10" ref={menuRef} data-tour="hamburger-menu">
+						<div className="relative z-30" ref={menuRef} data-tour="hamburger-menu">
 							<button
 								onClick={() => setMenuOpen(!menuOpen)}
 								className="p-2 rounded hover:bg-white/10 transition-colors"
@@ -730,7 +730,7 @@ function SessionListInner(props: SessionListProps) {
 							{/* Menu Overlay */}
 							{menuOpen && (
 								<div
-									className="absolute top-full left-0 mt-2 w-72 rounded-lg shadow-2xl z-50 overflow-y-auto scrollbar-thin"
+									className="absolute top-full left-0 mt-2 w-72 rounded-lg shadow-2xl z-[100] overflow-y-auto scrollbar-thin"
 									data-tour="hamburger-menu-contents"
 									style={{
 										backgroundColor: theme.colors.bgSidebar,
@@ -750,7 +750,7 @@ function SessionListInner(props: SessionListProps) {
 						</div>
 					</>
 				) : (
-					<div className="w-full flex flex-col items-center gap-2 relative" ref={menuRef}>
+					<div className="w-full flex flex-col items-center gap-2 relative z-30" ref={menuRef}>
 						<button
 							onClick={() => setMenuOpen(!menuOpen)}
 							className="p-2 rounded hover:bg-white/10 transition-colors"
@@ -764,7 +764,7 @@ function SessionListInner(props: SessionListProps) {
 						{/* Menu Overlay for Collapsed Sidebar */}
 						{menuOpen && (
 							<div
-								className="absolute top-full left-0 mt-2 w-72 rounded-lg shadow-2xl z-50 overflow-y-auto scrollbar-thin"
+								className="absolute top-full left-0 mt-2 w-72 rounded-lg shadow-2xl z-[100] overflow-y-auto scrollbar-thin"
 								style={{
 									backgroundColor: theme.colors.bgSidebar,
 									border: `1px solid ${theme.colors.border}`,


### PR DESCRIPTION
## Summary
- make the slash command picker denser and taller so more commands fit without scrolling
- rename the Auto Run `Exchange` buttons to `PlayBooks`
- raise the left sidebar hamburger menu overlay above the chat title bar

## Issues
- Closes #761
- Closes #764
- Closes #767

## Validation
- targeted `eslint` on touched files
- `git diff --check`
- note: repo-wide `tsc -p tsconfig.lint.json --noEmit` previously failed on missing generated prompts before unrelated regeneration work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Renamed marketplace controls from "Playbook Exchange"/"Exchange" to "PlayBooks"
  * Refined autocomplete dropdown UI: increased max height, tightened spacing and typography, reduced command padding
  * Adjusted header and menu layering and overlay placement via z-index and positioning tweaks

* **Tests**
  * Updated slash-command autocomplete test selectors and event targeting for more reliable assertions and interactions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->