### PR TITLE
[codex] Fix files panel feedback regressions

### DIFF
--- a/src/__tests__/renderer/components/FileExplorerPanel.test.tsx
+++ b/src/__tests__/renderer/components/FileExplorerPanel.test.tsx
@@ -1021,13 +1021,7 @@ describe('FileExplorerPanel', () => {
 		});
 
 		it('closes an empty file search when clicking Find files again', () => {
-			render(
-				<FileExplorerPanel
-					{...defaultProps}
-					fileTreeFilterOpen={true}
-					fileTreeFilter=""
-				/>
-			);
+			render(<FileExplorerPanel {...defaultProps} fileTreeFilterOpen={true} fileTreeFilter="" />);
 			const searchButton = screen.getByTitle('Close file search');
 			fireEvent.click(searchButton);
 

--- a/src/__tests__/renderer/components/FileExplorerPanel.test.tsx
+++ b/src/__tests__/renderer/components/FileExplorerPanel.test.tsx
@@ -91,6 +91,11 @@ vi.mock('lucide-react', () => ({
 			🔃
 		</span>
 	),
+	Search: ({ className, style }: { className?: string; style?: React.CSSProperties }) => (
+		<span data-testid="search-icon" className={className} style={style}>
+			🔎
+		</span>
+	),
 	Edit2: ({ className, style }: { className?: string; style?: React.CSSProperties }) => (
 		<span data-testid="edit2-icon" className={className} style={style}>
 			✏️
@@ -442,6 +447,11 @@ describe('FileExplorerPanel', () => {
 		it('renders refresh button', () => {
 			render(<FileExplorerPanel {...defaultProps} />);
 			expect(screen.getByTestId('refresh-icon')).toBeInTheDocument();
+		});
+
+		it('renders file search button with clear label', () => {
+			render(<FileExplorerPanel {...defaultProps} />);
+			expect(screen.getByTitle('Find files')).toBeInTheDocument();
 		});
 
 		it('renders expand all button with correct title', () => {
@@ -1006,6 +1016,23 @@ describe('FileExplorerPanel', () => {
 				'session-1',
 				expect.any(Function)
 			);
+			expect(defaultProps.setSelectedFileIndex).toHaveBeenCalledWith(expect.any(Number));
+			expect(defaultProps.setActiveFocus).toHaveBeenCalledWith('right');
+		});
+
+		it('closes an empty file search when clicking Find files again', () => {
+			render(
+				<FileExplorerPanel
+					{...defaultProps}
+					fileTreeFilterOpen={true}
+					fileTreeFilter=""
+				/>
+			);
+			const searchButton = screen.getByTitle('Close file search');
+			fireEvent.click(searchButton);
+
+			expect(defaultProps.setFileTreeFilter).toHaveBeenCalledWith('');
+			expect(defaultProps.setFileTreeFilterOpen).toHaveBeenCalledWith(false);
 		});
 
 		it('sets selectedFileIndex and activeFocus when clicking a file', () => {
@@ -1108,6 +1135,24 @@ describe('FileExplorerPanel', () => {
 			const item = container.querySelector('[data-file-index="0"]');
 			// When on different tab, should not have accent color
 			expect(item).not.toHaveStyle({ borderLeftColor: mockTheme.colors.accent });
+		});
+	});
+
+	describe('Hidden Files Toggle', () => {
+		it('hides .maestro when hidden files are off', () => {
+			render(
+				<FileExplorerPanel
+					{...defaultProps}
+					filteredFileTree={[
+						{ name: '.maestro', type: 'folder', children: [] },
+						{ name: 'visible', type: 'file' },
+					]}
+					showHiddenFiles={false}
+				/>
+			);
+
+			expect(screen.queryByText('.maestro')).not.toBeInTheDocument();
+			expect(screen.getByText('visible')).toBeInTheDocument();
 		});
 	});
 

--- a/src/__tests__/renderer/hooks/useFileExplorerEffects.test.ts
+++ b/src/__tests__/renderer/hooks/useFileExplorerEffects.test.ts
@@ -450,6 +450,7 @@ describe('useFileExplorerEffects', () => {
 			useSettingsStore.setState({ showHiddenFiles: false } as any);
 
 			const tree: FileNode[] = [
+				{ name: '.maestro', type: 'folder', children: [] },
 				{ name: '.hidden', type: 'folder', children: [] },
 				{ name: 'visible', type: 'folder', children: [] },
 			];
@@ -469,6 +470,7 @@ describe('useFileExplorerEffects', () => {
 			// flattenTree should be called with filtered tree (no .hidden)
 			const calledTree = vi.mocked(flattenTree).mock.calls[0]?.[0];
 			expect(calledTree).toBeDefined();
+			expect(calledTree?.some((n: any) => n.name === '.maestro')).toBe(false);
 			expect(calledTree?.some((n: any) => n.name === '.hidden')).toBe(false);
 			expect(calledTree?.some((n: any) => n.name === 'visible')).toBe(true);
 		});
@@ -1023,6 +1025,7 @@ describe('useFileExplorerEffects', () => {
 			useSettingsStore.setState({ showHiddenFiles: true } as any);
 
 			const tree: FileNode[] = [
+				{ name: '.maestro', type: 'folder', children: [] },
 				{ name: '.hidden', type: 'folder', children: [] },
 				{ name: 'visible', type: 'folder', children: [] },
 			];
@@ -1042,6 +1045,7 @@ describe('useFileExplorerEffects', () => {
 			// flattenTree should be called with ALL files (including .hidden)
 			const calledTree = vi.mocked(flattenTree).mock.calls[0]?.[0];
 			expect(calledTree).toBeDefined();
+			expect(calledTree?.some((n: any) => n.name === '.maestro')).toBe(true);
 			expect(calledTree?.some((n: any) => n.name === '.hidden')).toBe(true);
 			expect(calledTree?.some((n: any) => n.name === 'visible')).toBe(true);
 		});
@@ -1137,6 +1141,7 @@ describe('useFileExplorerEffects', () => {
 					name: 'src',
 					type: 'folder',
 					children: [
+						{ name: '.maestro', type: 'folder' },
 						{ name: '.env', type: 'file' },
 						{ name: 'index.ts', type: 'file' },
 					],
@@ -1160,6 +1165,7 @@ describe('useFileExplorerEffects', () => {
 			const srcFolder = calledTree?.find((n: any) => n.name === 'src');
 			expect(srcFolder).toBeDefined();
 			// Its children should not include '.env'
+			expect(srcFolder?.children?.some((n: any) => n.name === '.maestro')).toBe(false);
 			expect(srcFolder?.children?.some((n: any) => n.name === '.env')).toBe(false);
 			expect(srcFolder?.children?.some((n: any) => n.name === 'index.ts')).toBe(true);
 		});

--- a/src/__tests__/renderer/hooks/useMainKeyboardHandler.test.ts
+++ b/src/__tests__/renderer/hooks/useMainKeyboardHandler.test.ts
@@ -122,6 +122,59 @@ describe('useMainKeyboardHandler', () => {
 		});
 	});
 
+	describe('files panel search toggle', () => {
+		it('should close the empty files search when Cmd+F is pressed again', () => {
+			const { result } = renderHook(() => useMainKeyboardHandler());
+			const setFileTreeFilter = vi.fn();
+			const setFileTreeFilterOpen = vi.fn();
+			result.current.keyboardHandlerRef.current = createMockContext({
+				activeFocus: 'right',
+				activeRightTab: 'files',
+				fileTreeFilterOpen: true,
+				fileTreeFilter: '',
+				setFileTreeFilter,
+				setFileTreeFilterOpen,
+			});
+
+			act(() => {
+				window.dispatchEvent(
+					new KeyboardEvent('keydown', {
+						key: 'f',
+						metaKey: true,
+						bubbles: true,
+					})
+				);
+			});
+
+			expect(setFileTreeFilter).toHaveBeenCalledWith('');
+			expect(setFileTreeFilterOpen).toHaveBeenCalledWith(false);
+		});
+
+		it('should open files search when Cmd+F is pressed and the filter is closed', () => {
+			const { result } = renderHook(() => useMainKeyboardHandler());
+			const setFileTreeFilterOpen = vi.fn();
+			result.current.keyboardHandlerRef.current = createMockContext({
+				activeFocus: 'right',
+				activeRightTab: 'files',
+				fileTreeFilterOpen: false,
+				fileTreeFilter: '',
+				setFileTreeFilterOpen,
+			});
+
+			act(() => {
+				window.dispatchEvent(
+					new KeyboardEvent('keydown', {
+						key: 'f',
+						metaKey: true,
+						bubbles: true,
+					})
+				);
+			});
+
+			expect(setFileTreeFilterOpen).toHaveBeenCalledWith(true);
+		});
+	});
+
 	describe('showSessionJumpNumbers state', () => {
 		it('should show badges when Alt+Cmd are pressed together', () => {
 			const { result } = renderHook(() => useMainKeyboardHandler());

--- a/src/renderer/components/FileExplorerPanel.tsx
+++ b/src/renderer/components/FileExplorerPanel.tsx
@@ -17,6 +17,7 @@ import {
 	GitBranch,
 	Clock,
 	RotateCw,
+	Search,
 	FileText,
 	Edit2,
 	Trash2,
@@ -858,7 +859,7 @@ function FileExplorerPanelInner(props: FileExplorerPanelProps) {
 			if (!nodes) return [];
 			if (showHiddenFiles) return nodes;
 			return nodes
-				.filter((node) => !node.name.startsWith('.') || node.name === '.maestro')
+				.filter((node) => !node.name.startsWith('.'))
 				.map((node) => ({
 					...node,
 					children: node.children ? filterHiddenFiles(node.children) : undefined,
@@ -992,6 +993,8 @@ function FileExplorerPanelInner(props: FileExplorerPanelProps) {
 					}}
 					onClick={() => {
 						if (isFolder) {
+							setSelectedFileIndex(globalIndex);
+							setActiveFocus('right');
 							toggleFolder(fullPath, session.id, setSessions);
 						} else {
 							setSelectedFileIndex(globalIndex);
@@ -1144,9 +1147,30 @@ function FileExplorerPanelInner(props: FileExplorerPanelProps) {
 						</button>
 					)}
 					<button
+						onClick={() => {
+							setActiveFocus('right');
+							if (fileTreeFilterOpen && fileTreeFilter.trim().length === 0) {
+								setFileTreeFilter('');
+								setFileTreeFilterOpen(false);
+								return;
+							}
+							fileTreeFilterInputRef?.current?.focus();
+							fileTreeFilterInputRef?.current?.select();
+							setFileTreeFilterOpen(true);
+						}}
+						className="p-1 rounded hover:bg-white/10 transition-colors"
+						title={fileTreeFilterOpen ? 'Close file search' : 'Find files'}
+						style={{
+							color: fileTreeFilterOpen ? theme.colors.accent : theme.colors.textDim,
+							backgroundColor: fileTreeFilterOpen ? `${theme.colors.accent}20` : 'transparent',
+						}}
+					>
+						<Search className="w-3.5 h-3.5" />
+					</button>
+					<button
 						onClick={() => setShowHiddenFiles(!showHiddenFiles)}
 						className="p-1 rounded hover:bg-white/10 transition-colors"
-						title={showHiddenFiles ? 'Hide dotfiles' : 'Show dotfiles'}
+						title={showHiddenFiles ? 'Hide hidden files' : 'Show hidden files'}
 						style={{
 							color: showHiddenFiles ? theme.colors.accent : theme.colors.textDim,
 							backgroundColor: showHiddenFiles ? `${theme.colors.accent}20` : 'transparent',

--- a/src/renderer/hooks/git/useFileExplorerEffects.ts
+++ b/src/renderer/hooks/git/useFileExplorerEffects.ts
@@ -213,7 +213,7 @@ export function useFileExplorerEffects(
 		const filterHiddenFiles = (nodes: FileNode[]): FileNode[] => {
 			if (showHiddenFiles) return nodes;
 			return nodes
-				.filter((node) => !node.name.startsWith('.') || node.name === '.maestro')
+				.filter((node) => !node.name.startsWith('.'))
 				.map((node) => ({
 					...node,
 					children: node.children ? filterHiddenFiles(node.children) : undefined,

--- a/src/renderer/hooks/keyboard/useMainKeyboardHandler.ts
+++ b/src/renderer/hooks/keyboard/useMainKeyboardHandler.ts
@@ -795,7 +795,16 @@ export function useMainKeyboardHandler(): UseMainKeyboardHandlerReturn {
 			if (e.key === 'f' && (e.metaKey || e.ctrlKey) && !e.shiftKey) {
 				if (ctx.activeFocus === 'right' && ctx.activeRightTab === 'files') {
 					e.preventDefault();
-					ctx.setFileTreeFilterOpen(true);
+					const fileTreeFilter = typeof ctx.fileTreeFilter === 'string' ? ctx.fileTreeFilter : '';
+					if (ctx.fileTreeFilterOpen && fileTreeFilter.trim().length === 0) {
+						ctx.setFileTreeFilter('');
+						ctx.setFileTreeFilterOpen(false);
+					} else if (!ctx.fileTreeFilterOpen) {
+						ctx.setFileTreeFilterOpen(true);
+					} else {
+						ctx.fileTreeFilterInputRef?.current?.focus();
+						ctx.fileTreeFilterInputRef?.current?.select?.();
+					}
 					trackShortcut('filterFiles');
 				} else if (ctx.activeFocus === 'sidebar') {
 					// Sidebar filter - handled by SessionList component, just track here


### PR DESCRIPTION
## Summary
- hide `.maestro` alongside other hidden paths when hidden files are off
- make the files-panel search toggle close when the filter is empty and refocus when already open
- update folder click selection so the active highlight follows the folder that was actually clicked

## Issues
- Closes #757
- Closes #759
- Closes #768

## Validation
- `npx vitest run --reporter=dot src/__tests__/renderer/components/FileExplorerPanel.test.tsx src/__tests__/renderer/hooks/useFileExplorerEffects.test.ts src/__tests__/renderer/hooks/useMainKeyboardHandler.test.ts`
- `npm run lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added file search functionality to the file explorer panel with a dedicated search icon button.
  * Added Cmd+F keyboard shortcut to toggle file search in the files panel.
  * Improved hidden files filtering to consistently exclude all dotfiles.

* **Tests**
  * Added test coverage for file explorer search functionality and keyboard shortcuts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->