### PR TITLE
[codex] Remove Codex beta badges and fix Agent Sessions since date

### DIFF
--- a/src/__tests__/renderer/components/AgentSessionsBrowser.test.tsx
+++ b/src/__tests__/renderer/components/AgentSessionsBrowser.test.tsx
@@ -726,8 +726,12 @@ describe('AgentSessionsBrowser', () => {
 				await vi.runAllTimersAsync();
 			});
 
-			expect(screen.getByText(`Since ${new Date(createdAt).toLocaleDateString()}`)).toBeInTheDocument();
-			expect(screen.queryByText(`Since ${new Date(oldestTimestamp).toLocaleDateString()}`)).toBeNull();
+			expect(
+				screen.getByText(`Since ${new Date(createdAt).toLocaleDateString()}`)
+			).toBeInTheDocument();
+			expect(
+				screen.queryByText(`Since ${new Date(oldestTimestamp).toLocaleDateString()}`)
+			).toBeNull();
 		});
 
 		it('ignores stats updates for different project paths', async () => {

--- a/src/__tests__/renderer/components/AgentSessionsBrowser.test.tsx
+++ b/src/__tests__/renderer/components/AgentSessionsBrowser.test.tsx
@@ -76,6 +76,7 @@ const defaultTheme: Theme = {
 interface ClaudeSession {
 	sessionId: string;
 	projectPath: string;
+	createdAt: number;
 	timestamp: string;
 	modifiedAt: string;
 	firstMessage: string;
@@ -105,6 +106,7 @@ interface SessionMessage {
 const createMockClaudeSession = (overrides: Partial<ClaudeSession> = {}): ClaudeSession => ({
 	sessionId: `d02d0bd6-${Math.random().toString(36).substr(2, 6)}-4a01-9123-456789abcdef`,
 	projectPath: '/path/to/project',
+	createdAt: Date.parse('2025-01-15T09:00:00Z'),
 	timestamp: '2025-01-15T10:00:00Z',
 	modifiedAt: '2025-01-15T11:30:00Z',
 	firstMessage: 'Help me with this code',
@@ -133,6 +135,7 @@ const createMockActiveSession = (overrides: Partial<Session> = {}): Session => (
 	id: 'session-1',
 	name: 'Test Project',
 	toolType: 'claude-code',
+	createdAt: Date.parse('2025-01-15T08:30:00Z'),
 	state: 'idle',
 	inputMode: 'ai',
 	cwd: '/path/to/project',
@@ -688,8 +691,10 @@ describe('AgentSessionsBrowser', () => {
 			expect(statsText).toHaveClass('animate-pulse');
 		});
 
-		it('shows oldest session date', async () => {
+		it('shows the active session creation date in the since label', async () => {
 			const sessions = [createMockClaudeSession()];
+			const createdAt = Date.parse('2026-04-09T12:00:00Z');
+			const oldestTimestamp = '2024-06-15T00:00:00Z';
 			vi.mocked(window.maestro.agentSessions.listPaginated).mockResolvedValue({
 				sessions,
 				hasMore: false,
@@ -698,7 +703,13 @@ describe('AgentSessionsBrowser', () => {
 			});
 
 			await act(async () => {
-				renderWithProvider(<AgentSessionsBrowser {...createDefaultProps()} />);
+				renderWithProvider(
+					<AgentSessionsBrowser
+						{...createDefaultProps({
+							activeSession: createMockActiveSession({ createdAt }),
+						})}
+					/>
+				);
 				await vi.runAllTimersAsync();
 			});
 
@@ -709,13 +720,14 @@ describe('AgentSessionsBrowser', () => {
 					totalMessages: 10,
 					totalCostUsd: 0.5,
 					totalSizeBytes: 5000,
-					oldestTimestamp: '2024-06-15T00:00:00Z',
+					oldestTimestamp,
 					isComplete: true,
 				});
 				await vi.runAllTimersAsync();
 			});
 
-			expect(screen.getByText(/Since/i)).toBeInTheDocument();
+			expect(screen.getByText(`Since ${new Date(createdAt).toLocaleDateString()}`)).toBeInTheDocument();
+			expect(screen.queryByText(`Since ${new Date(oldestTimestamp).toLocaleDateString()}`)).toBeNull();
 		});
 
 		it('ignores stats updates for different project paths', async () => {

--- a/src/__tests__/renderer/components/GroupChatModals.test.tsx
+++ b/src/__tests__/renderer/components/GroupChatModals.test.tsx
@@ -228,9 +228,9 @@ describe('GroupChatModal', () => {
 
 			// Verify all agents appear as options
 			expect(screen.getByRole('option', { name: /Claude Code/i })).toBeInTheDocument();
-			expect(screen.getByRole('option', { name: /Codex.*Beta/i })).toBeInTheDocument();
 			expect(screen.getByRole('option', { name: /OpenCode.*Beta/i })).toBeInTheDocument();
 			expect(screen.getByRole('option', { name: /Factory Droid.*Beta/i })).toBeInTheDocument();
+			expect(screen.getByRole('option', { name: /^Codex$/i })).toBeInTheDocument();
 		});
 	});
 

--- a/src/__tests__/renderer/components/Settings/tabs/EncoreTab.test.tsx
+++ b/src/__tests__/renderer/components/Settings/tabs/EncoreTab.test.tsx
@@ -309,7 +309,7 @@ describe('EncoreTab', () => {
 			expect(options[0]).toHaveValue('claude-code');
 			expect(options[0]).toHaveTextContent('Claude Code');
 			expect(options[1]).toHaveValue('codex');
-			expect(options[1]).toHaveTextContent('Codex (Beta)');
+			expect(options[1]).toHaveTextContent('Codex');
 		});
 
 		it('should call setDirectorNotesSettings on provider change', async () => {

--- a/src/__tests__/shared/agentMetadata.test.ts
+++ b/src/__tests__/shared/agentMetadata.test.ts
@@ -76,9 +76,9 @@ describe('agentMetadata', () => {
 		});
 
 		it('should contain the expected beta agents', () => {
-			expect(BETA_AGENTS.has('codex')).toBe(true);
 			expect(BETA_AGENTS.has('opencode')).toBe(true);
 			expect(BETA_AGENTS.has('factory-droid')).toBe(true);
+			expect(BETA_AGENTS.has('codex')).toBe(false);
 		});
 
 		it('should not contain non-beta agents', () => {
@@ -98,12 +98,12 @@ describe('agentMetadata', () => {
 
 	describe('isBetaAgent', () => {
 		it('should return true for beta agents', () => {
-			expect(isBetaAgent('codex')).toBe(true);
 			expect(isBetaAgent('opencode')).toBe(true);
 			expect(isBetaAgent('factory-droid')).toBe(true);
 		});
 
 		it('should return false for non-beta agents', () => {
+			expect(isBetaAgent('codex')).toBe(false);
 			expect(isBetaAgent('claude-code')).toBe(false);
 			expect(isBetaAgent('terminal')).toBe(false);
 		});

--- a/src/renderer/components/AgentSessionsBrowser.tsx
+++ b/src/renderer/components/AgentSessionsBrowser.tsx
@@ -547,6 +547,11 @@ export function AgentSessionsBrowser({
 		};
 	}, [aggregateStats]);
 
+	const sessionSinceDate =
+		typeof activeSession?.createdAt === 'number' && activeSession.createdAt > 0
+			? new Date(activeSession.createdAt)
+			: stats.oldestSession;
+
 	// Keyboard navigation
 	const handleKeyDown = (e: React.KeyboardEvent) => {
 		if (viewingSession) {
@@ -1242,11 +1247,11 @@ export function AgentSessionsBrowser({
 									</span>
 								</div>
 							)}
-							{stats.oldestSession && (
+							{sessionSinceDate && (
 								<div className="flex items-center gap-2">
 									<Clock className="w-4 h-4" style={{ color: theme.colors.textDim }} />
 									<span className="text-xs font-medium" style={{ color: theme.colors.textDim }}>
-										Since {stats.oldestSession.toLocaleDateString()}
+										Since {sessionSinceDate.toLocaleDateString()}
 									</span>
 								</div>
 							)}

--- a/src/renderer/hooks/session/useSessionCrud.ts
+++ b/src/renderer/hooks/session/useSessionCrud.ts
@@ -211,6 +211,7 @@ export function useSessionCrud(deps: UseSessionCrudDeps): UseSessionCrudReturn {
 					cwd: workingDir,
 					fullPath: workingDir,
 					projectRoot: workingDir,
+					createdAt: Date.now(),
 					isGitRepo,
 					gitBranches,
 					gitTags,

--- a/src/renderer/hooks/symphony/useSymphonyContribution.ts
+++ b/src/renderer/hooks/symphony/useSymphonyContribution.ts
@@ -137,6 +137,7 @@ export function useSymphonyContribution(
 				cwd: data.localPath,
 				fullPath: data.localPath,
 				projectRoot: data.localPath,
+				createdAt: Date.now(),
 				isGitRepo,
 				gitBranches,
 				gitTags,

--- a/src/renderer/hooks/wizard/useWizardHandlers.ts
+++ b/src/renderer/hooks/wizard/useWizardHandlers.ts
@@ -1132,6 +1132,7 @@ export function useWizardHandlers(deps: UseWizardHandlersDeps): UseWizardHandler
 				cwd: directoryPath,
 				fullPath: directoryPath,
 				projectRoot: directoryPath,
+				createdAt: Date.now(),
 				isGitRepo,
 				gitBranches,
 				gitTags,

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -511,6 +511,7 @@ export interface Session {
 	cwd: string;
 	fullPath: string;
 	projectRoot: string; // The initial working directory (never changes, used for Claude session storage)
+	createdAt: number; // Timestamp when the session was created
 	aiLogs: LogEntry[];
 	shellLogs: LogEntry[];
 	workLog: WorkLogItem[];

--- a/src/renderer/utils/tabHelpers.ts
+++ b/src/renderer/utils/tabHelpers.ts
@@ -1678,6 +1678,7 @@ export function createMergedSession(
 		cwd: projectRoot,
 		fullPath: projectRoot,
 		projectRoot, // Never changes, used for session storage
+		createdAt: Date.now(),
 		isGitRepo: false, // Will be updated by caller if needed
 		aiLogs: [], // Deprecated - logs are in aiTabs
 		shellLogs: [

--- a/src/renderer/utils/worktreeSession.ts
+++ b/src/renderer/utils/worktreeSession.ts
@@ -61,6 +61,7 @@ export function buildWorktreeSession(params: BuildWorktreeSessionParams): Sessio
 		cwd: params.path,
 		fullPath: params.path,
 		projectRoot: params.path,
+		createdAt: Date.now(),
 		isGitRepo: true,
 		gitBranches: params.gitBranches,
 		gitTags: params.gitTags,

--- a/src/shared/agentMetadata.ts
+++ b/src/shared/agentMetadata.ts
@@ -65,7 +65,6 @@ export function getReadOnlyModeTooltip(agentId: AgentId | string): string {
  * Used to render "(Beta)" badges throughout the UI.
  */
 export const BETA_AGENTS: ReadonlySet<AgentId> = new Set<AgentId>([
-	'codex',
 	'opencode',
 	'factory-droid',
 ]);

--- a/src/shared/agentMetadata.ts
+++ b/src/shared/agentMetadata.ts
@@ -64,10 +64,7 @@ export function getReadOnlyModeTooltip(agentId: AgentId | string): string {
  * Agents currently in beta/experimental status.
  * Used to render "(Beta)" badges throughout the UI.
  */
-export const BETA_AGENTS: ReadonlySet<AgentId> = new Set<AgentId>([
-	'opencode',
-	'factory-droid',
-]);
+export const BETA_AGENTS: ReadonlySet<AgentId> = new Set<AgentId>(['opencode', 'factory-droid']);
 
 /**
  * Check whether an agent is in beta status.


### PR DESCRIPTION
## Summary
- remove `Codex` from the shared beta-agent set so the beta badge disappears anywhere that metadata is rendered
- show the active agent's creation date in the Agent Sessions header `Since` label instead of the oldest provider session in the project
- align session creation helpers and tests with the creation-date based header behavior

## Issues
- Closes #760
- Closes #765

## Validation
- `npm run build:prompts`
- `npm test -- src/__tests__/shared/agentMetadata.test.ts src/__tests__/renderer/components/Settings/tabs/EncoreTab.test.tsx src/__tests__/renderer/components/GroupChatModals.test.tsx src/__tests__/renderer/components/AgentSessionsBrowser.test.tsx`
- `npm run lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Sessions now capture creation timestamps to improve session history tracking.
  * The "Since" label now displays the active session's creation date instead of the oldest session timestamp.

* **Changes**
  * Codex agent is no longer labeled as beta.

* **Tests**
  * Updated test expectations for session creation timestamp display and Codex agent classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->