### PR TITLE
[codex] restore repo git hooks and ignore local worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ TEMP-REFACTORING-PLAN.md
 TEMP-REFACTORING-PLAN-2.md
 Auto\ Run\ Docs/
 Work\ Trees/
+.worktrees/
 community-data/
 .mcp.json
 specs/

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,6 +2,7 @@ dist/
 release/
 node_modules/
 coverage/
+.worktrees/
 *.min.js
 .gitignore
 src/renderer/assets/file-explorer-rich-icons/*.svg

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -83,7 +83,7 @@ The major contributions to 0.14.x remain:
 - Leaderboard tracking now works across multiple systems and syncs level from cloud 🏆
 - Agent duplication. Pro tip: Consider a group of unused "Template" agents ✌️
 - New setting to prevent system from going to sleep while agents are active 🛏️
-- The tab menu has a new "Publish as GitHub Gist" option  📝
+- The tab menu has a new "Publish as GitHub Gist" option 📝
 - The tab menu has options to move the tab to the first or last position 🔀
 - [Maestro-Playbooks](https://github.com/pedramamini/Maestro-Playbooks) can now contain non-markdown assets 📙
 - Improved default shell detection 🐚
@@ -112,10 +112,12 @@ Thanks for the contributions: @t1mmen @aejfager @Crumbgrabber @whglaser @b3nw @d
 - TAKE TWO! Fixed Linux ARM64 build architecture contamination issues 🏗️
 
 ### v0.13.1 Changes
+
 - Fixed Linux ARM64 build architecture contamination issues 🏗️
 - Enhanced error handling for Auto Run batch processing 🚨
 
 ### v0.13.0 Changes
+
 - Added a global usage dashboard, data collection begins with this install 🎛️
 - Added a Playbook Exchange for downloading pre-defined Auto Run playbooks from [Maestro-Playbooks](https://github.com/pedramamini/Maestro-Playbooks) 📕
 - Bundled OpenSpec commands for structured change proposals 📝
@@ -139,15 +141,19 @@ Thanks for the contributions: @t1mmen @aejfager @Crumbgrabber @whglaser @b3nw @d
 The big changes in the v0.12.x line are the following three:
 
 ## Show Thinking
-🤔 There is now a toggle to show thinking for the agent, the default for new tabs is off, though this can be changed under Settings > General. The toggle shows next to History and Read-Only. Very similar pattern. This has been the #1 most requested feature, though personally, I don't think I'll use it as I prefer to not see the details of the work, but the results of the work. Just as we work with our colleagues. 
+
+🤔 There is now a toggle to show thinking for the agent, the default for new tabs is off, though this can be changed under Settings > General. The toggle shows next to History and Read-Only. Very similar pattern. This has been the #1 most requested feature, though personally, I don't think I'll use it as I prefer to not see the details of the work, but the results of the work. Just as we work with our colleagues.
 
 ## GitHub Spec-Kit Integration
+
 🎯 Added [GitHub Spec-Kit](https://github.com/github/spec-kit) commands into Maestro with a built in updater to grab the latest prompts from the repository. We do override `/speckit-implement` (the final step) to create Auto Run docs and guide the user through their execution, which thanks to Wortrees from v0.11.x allows us to run in parallel!
 
 ## Context Management Tools
+
 📖 Added context management options from tab right-click menu. You can now compress, merge, and transfer contexts between agents. You will received (configurable) warnings at 60% and 80% context consumption with a hint to compact.
 
 ## Changes Specific to v0.12.3:
+
 - We now have hosted documentation through Mintlify 📚
 - Export any tab conversation as self-contained themed HTML file 📄
 - Publish files as private/public Gists 🌐
@@ -260,6 +266,7 @@ The big changes in the v0.12.x line are the following three:
 Minor bugfixes on top of v0.7.3:
 
 # Onboarding, Wizard, and Tours
+
 - Implemented comprehensive onboarding wizard with integrated tour system 🚀
 - Added project-understanding confidence display to wizard UI 🎨
 - Enhanced keyboard navigation across all wizard screens ⌨️
@@ -267,6 +274,7 @@ Minor bugfixes on top of v0.7.3:
 - Added First Run Celebration modal with confetti animation 🎉
 
 # UI / UX Enhancements
+
 - Added expand-to-fullscreen button for Auto Run interface 🖥️
 - Created dedicated modal component and improved modal priority constants for expanded Auto Run view 📐
 - Enhanced user experience with fullscreen editing capabilities ✨
@@ -276,15 +284,18 @@ Minor bugfixes on top of v0.7.3:
 - Enhanced toast context with agent name for OS notifications 📢
 
 # Auto Run Workflow Improvements
+
 - Created phase document generation for Auto Run workflow 📄
 - Added real-time log streaming to the LogViewer component 📊
 
 # Application Behavior / Core Fixes
+
 - Added validation to prevent nested worktrees inside the main repository 🚫
 - Fixed process manager to properly emit exit events on errors 🔧
 - Fixed process exit handling to ensure proper cleanup 🧹
 
 # Update System
+
 - Implemented automatic update checking on application startup 🚀
 - Added settings toggle for enabling/disabling startup update checks ⚙️
 
@@ -302,6 +313,7 @@ Minor bugfixes on top of v0.7.3:
 **Latest: v0.6.1** | Released December 4, 2025
 
 In this release...
+
 - Added recursive subfolder support for Auto Run markdown files 🗂️
 - Enhanced document tree display with expandable folder navigation 🌳
 - Enabled creating documents in subfolders with path selection 📁
@@ -314,6 +326,7 @@ In this release...
 - Added support for nested folder structures in document management 🏗️
 
 Plus the pre-release ALPHA...
+
 - Template vars now set context in default autorun prompt 🚀
 - Added Enter key support for queued message confirmation dialog ⌨️
 - Kill process capability added to System Process Monitor 💀
@@ -473,6 +486,7 @@ Plus the pre-release ALPHA...
 All releases are available on the [GitHub Releases page](https://github.com/RunMaestro/Maestro/releases).
 
 Maestro is available for:
+
 - **macOS** - Apple Silicon (arm64) and Intel (x64)
 - **Windows** - x64
 - **Linux** - x64 and arm64, AppImage, deb, and rpm packages

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"package:linux": "node scripts/set-version.mjs npm run build && node scripts/set-version.mjs electron-builder --linux",
 		"start": "electron .",
 		"clean": "rm -rf dist release node_modules/.vite",
-		"prepare": "husky || true",
+		"prepare": "node scripts/setup-git-hooks.mjs",
 		"postinstall": "electron-rebuild -f -w node-pty,better-sqlite3",
 		"lint": "tsc -p tsconfig.lint.json && tsc -p tsconfig.main.json --noEmit && tsc -p tsconfig.cli.json --noEmit",
 		"lint:eslint": "eslint src/",

--- a/scripts/setup-git-hooks.mjs
+++ b/scripts/setup-git-hooks.mjs
@@ -1,0 +1,33 @@
+import { existsSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+
+function runGit(args) {
+	const result = spawnSync('git', args, { stdio: 'pipe', encoding: 'utf8' });
+	if (result.error) throw result.error;
+	if (result.status !== 0) {
+		throw new Error(result.stderr.trim() || `git ${args.join(' ')} failed`);
+	}
+	return result.stdout.trim();
+}
+
+function getGitConfig(key) {
+	const result = spawnSync('git', ['config', '--get', key], { stdio: 'pipe', encoding: 'utf8' });
+	if (result.error) throw result.error;
+	if (result.status !== 0) return '';
+	return result.stdout.trim();
+}
+
+if (!existsSync('.git')) {
+	console.log('[setup-git-hooks] Skipping hook installation because .git is not present.');
+	process.exit(0);
+}
+
+const desiredHooksPath = '.husky';
+const currentHooksPath = getGitConfig('core.hooksPath');
+
+if (currentHooksPath !== desiredHooksPath) {
+	runGit(['config', 'core.hooksPath', desiredHooksPath]);
+	console.log(`[setup-git-hooks] Set core.hooksPath=${desiredHooksPath}`);
+} else {
+	console.log(`[setup-git-hooks] core.hooksPath already set to ${desiredHooksPath}`);
+}

--- a/src/__tests__/main/stats/integration.test.ts
+++ b/src/__tests__/main/stats/integration.test.ts
@@ -890,16 +890,12 @@ describe('electron-rebuild verification for better-sqlite3', () => {
 		it('should have better-sqlite3 native binding in expected location', async () => {
 			const fs = await import('node:fs');
 			const path = await import('node:path');
+			const betterSqlitePackagePath = require.resolve('better-sqlite3/package.json');
+			const betterSqliteDir = path.dirname(betterSqlitePackagePath);
 
 			// Check if the native binding exists in build/Release (compiled location)
 			const nativeModulePath = path.join(
-				__dirname,
-				'..',
-				'..',
-				'..',
-				'..',
-				'node_modules',
-				'better-sqlite3',
+				betterSqliteDir,
 				'build',
 				'Release',
 				'better_sqlite3.node'
@@ -912,16 +908,7 @@ describe('electron-rebuild verification for better-sqlite3', () => {
 			// If the native module doesn't exist, check if there's a prebuilt binary
 			if (!exists) {
 				// Check for prebuilt binaries in the bin directory
-				const binDir = path.join(
-					__dirname,
-					'..',
-					'..',
-					'..',
-					'..',
-					'node_modules',
-					'better-sqlite3',
-					'bin'
-				);
+				const binDir = path.join(betterSqliteDir, 'bin');
 
 				if (fs.existsSync(binDir)) {
 					const binContents = fs.readdirSync(binDir);
@@ -937,17 +924,10 @@ describe('electron-rebuild verification for better-sqlite3', () => {
 		it('should verify binding.gyp exists for native compilation', async () => {
 			const fs = await import('node:fs');
 			const path = await import('node:path');
+			const betterSqlitePackagePath = require.resolve('better-sqlite3/package.json');
+			const betterSqliteDir = path.dirname(betterSqlitePackagePath);
 
-			const bindingGypPath = path.join(
-				__dirname,
-				'..',
-				'..',
-				'..',
-				'..',
-				'node_modules',
-				'better-sqlite3',
-				'binding.gyp'
-			);
+			const bindingGypPath = path.join(betterSqliteDir, 'binding.gyp');
 
 			// binding.gyp is required for node-gyp compilation
 			expect(fs.existsSync(bindingGypPath)).toBe(true);


### PR DESCRIPTION
## What changed

- restore repository git-hook setup during `npm prepare` by replacing the no-op Husky prepare step with `scripts/setup-git-hooks.mjs`
- automatically set `core.hooksPath` to `.husky` when the checkout has a `.git` directory
- ignore `.worktrees/` in both Git and Prettier so local worktree folders do not pollute status or formatting checks
- make the `better-sqlite3` integration test resolve the package location dynamically instead of assuming a fixed top-level `node_modules` path
- update `docs/releases.md` alongside the branch changes

## Why

This restores repo-local hook behavior in worktree-oriented checkouts and removes local worktree noise from repository tooling. The test adjustment also makes native-module verification more robust in non-standard install layouts.

## Impact

- hook-based validation runs more reliably after install/prepare
- local worktree directories are excluded from Git and Prettier churn
- stats integration tests are less brittle across workspace layouts

## Validation

- `npm run build:prompts`
- `npm run format:check:all`
- `npm run lint`
- `npm run lint:eslint`
- `npm run test`

## Notes

`npm run lint:eslint` completed with one non-blocking warning in `src/main/web-server/web-server-factory.ts` for an unused `e` parameter.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reformatted release notes for improved consistency and readability.

* **Chores**
  * Enhanced Git hooks configuration setup process.
  * Updated ignore patterns to exclude development tooling paths from version control and code formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->