### PR TITLE
Autorun settings

### DIFF
--- a/src/__tests__/renderer/hooks/useSymphonyContribution.test.ts
+++ b/src/__tests__/renderer/hooks/useSymphonyContribution.test.ts
@@ -58,9 +58,13 @@ vi.mock('../../../renderer/stores/modalStore', async () => {
 	};
 });
 
-vi.mock('../../../renderer/components/BatchRunnerModal', () => ({
-	DEFAULT_BATCH_PROMPT: 'mock-default-batch-prompt',
-}));
+vi.mock('../../../renderer/hooks/batch/batchUtils', async () => {
+	const actual = await vi.importActual('../../../renderer/hooks/batch/batchUtils');
+	return {
+		...actual,
+		getEffectiveAutoRunPrompt: () => 'mock-default-batch-prompt',
+	};
+});
 
 // ============================================================================
 // Imports (after mocks)

--- a/src/__tests__/renderer/hooks/useWizardHandlers.test.ts
+++ b/src/__tests__/renderer/hooks/useWizardHandlers.test.ts
@@ -70,9 +70,13 @@ vi.mock('../../../renderer/components/Wizard', () => ({
 	AUTO_RUN_FOLDER_NAME: '.maestro/playbooks',
 }));
 
-vi.mock('../../../renderer/components/BatchRunnerModal', () => ({
-	DEFAULT_BATCH_PROMPT: 'Run each task sequentially.',
-}));
+vi.mock('../../../renderer/hooks/batch/batchUtils', async () => {
+	const actual = await vi.importActual('../../../renderer/hooks/batch/batchUtils');
+	return {
+		...actual,
+		getEffectiveAutoRunPrompt: () => 'Run each task sequentially.',
+	};
+});
 
 import { useWizardHandlers } from '../../../renderer/hooks/wizard/useWizardHandlers';
 import type { UseWizardHandlersDeps } from '../../../renderer/hooks/wizard/useWizardHandlers';

--- a/src/renderer/components/BatchRunnerModal.tsx
+++ b/src/renderer/components/BatchRunnerModal.tsx
@@ -29,7 +29,7 @@ import { useUIStore } from '../stores/uiStore';
 import { getModalActions } from '../stores/modalStore';
 import {
 	usePlaybookManagement,
-	DEFAULT_BATCH_PROMPT,
+	getEffectiveAutoRunPrompt,
 	validateAgentPromptHasTaskReference,
 } from '../hooks';
 import { generateId } from '../utils/ids';
@@ -153,14 +153,15 @@ export function BatchRunnerModal(props: BatchRunnerModalProps) {
 	const initialMaxLoopsRef = useRef<number | null>(null);
 
 	// Prompt state
-	const [prompt, setPrompt] = useState(initialPrompt || DEFAULT_BATCH_PROMPT);
+	const effectiveDefault = getEffectiveAutoRunPrompt();
+	const [prompt, setPrompt] = useState(initialPrompt || effectiveDefault);
 	const [variablesExpanded, setVariablesExpanded] = useState(false);
 	const [savedPrompt, setSavedPrompt] = useState(initialPrompt || '');
 	const [promptComposerOpen, setPromptComposerOpen] = useState(false);
 	const textareaRef = useRef<HTMLTextAreaElement>(null);
 
 	// Track initial prompt for dirty checking
-	const initialPromptRef = useRef(initialPrompt || DEFAULT_BATCH_PROMPT);
+	const initialPromptRef = useRef(initialPrompt || effectiveDefault);
 
 	// Compute if there are unsaved configuration changes
 	// This checks if documents, loop settings, or prompt have changed from initial values
@@ -353,7 +354,7 @@ export function BatchRunnerModal(props: BatchRunnerModalProps) {
 
 	const handleReset = () => {
 		showConfirmation('Reset the prompt to the default? Your customizations will be lost.', () => {
-			setPrompt(DEFAULT_BATCH_PROMPT);
+			setPrompt(getEffectiveAutoRunPrompt());
 		});
 	};
 
@@ -405,8 +406,8 @@ export function BatchRunnerModal(props: BatchRunnerModalProps) {
 		}
 	};
 
-	const isModified = prompt !== DEFAULT_BATCH_PROMPT;
-	const hasUnsavedChanges = prompt !== savedPrompt && prompt !== DEFAULT_BATCH_PROMPT;
+	const isModified = prompt !== effectiveDefault;
+	const hasUnsavedChanges = prompt !== savedPrompt && prompt !== effectiveDefault;
 
 	return (
 		<div

--- a/src/renderer/components/Settings/SettingsModal.tsx
+++ b/src/renderer/components/Settings/SettingsModal.tsx
@@ -16,6 +16,7 @@ import {
 } from 'lucide-react';
 import { useSettings } from '../../hooks';
 import { autorunDefaultPrompt } from '../../../prompts';
+import { validateAgentPromptHasTaskReference } from '../../hooks/batch/batchUtils';
 import type { Theme, LLMProvider } from '../../types';
 import { useLayerStack } from '../../contexts/LayerStackContext';
 import { MODAL_PRIORITIES } from '../../constants/modalPriorities';
@@ -679,64 +680,73 @@ export const SettingsModal = memo(function SettingsModal(props: SettingsModalPro
 							</div>
 						)}
 
-						{activeTab === 'autorun' && (
-							<div className="space-y-5">
-								<div>
-									<div className="flex items-center justify-between mb-1">
-										<h3
-											className="text-sm font-bold uppercase tracking-wider"
-											style={{ color: theme.colors.textMain }}
-										>
-											Custom Default Prompt
-										</h3>
-										<button
-											onClick={() => {
-												if (autoRunDefaultPromptOverride) {
-													setAutoRunDefaultPromptOverride('');
-												} else {
-													setAutoRunDefaultPromptOverride(autorunDefaultPrompt);
-												}
-											}}
-											className="relative w-10 h-5 rounded-full transition-colors flex-shrink-0"
-											style={{
-												backgroundColor: autoRunDefaultPromptOverride
-													? theme.colors.accent
-													: theme.colors.bgActivity,
-											}}
-											role="switch"
-											aria-checked={!!autoRunDefaultPromptOverride}
-											aria-label="Override default Auto Run prompt"
-										>
-											<span
-												className={`absolute left-0 top-0.5 w-4 h-4 rounded-full bg-white transition-transform ${
-													autoRunDefaultPromptOverride ? 'translate-x-5' : 'translate-x-0.5'
-												}`}
+						{activeTab === 'autorun' &&
+							(() => {
+								const hasOverride = !!autoRunDefaultPromptOverride?.trim();
+								return (
+									<div className="space-y-5">
+										<div>
+											<div className="flex items-center justify-between mb-1">
+												<h3
+													className="text-sm font-bold uppercase tracking-wider"
+													style={{ color: theme.colors.textMain }}
+												>
+													Custom Default Prompt
+												</h3>
+												<button
+													onClick={() => {
+														if (hasOverride) {
+															setAutoRunDefaultPromptOverride('');
+														} else {
+															setAutoRunDefaultPromptOverride(autorunDefaultPrompt);
+														}
+													}}
+													className="relative w-10 h-5 rounded-full transition-colors flex-shrink-0"
+													style={{
+														backgroundColor: hasOverride
+															? theme.colors.accent
+															: theme.colors.bgActivity,
+													}}
+													role="switch"
+													aria-checked={hasOverride}
+													aria-label="Override default Auto Run prompt"
+												>
+													<span
+														className={`absolute left-0 top-0.5 w-4 h-4 rounded-full bg-white transition-transform ${
+															hasOverride ? 'translate-x-5' : 'translate-x-0.5'
+														}`}
+													/>
+												</button>
+											</div>
+											<p className="text-xs mb-3" style={{ color: theme.colors.textDim }}>
+												{hasOverride
+													? "Your custom prompt is active for all Auto Run / Playbook executions that don't have a per-playbook prompt. Turn off to revert to the built-in default."
+													: 'The built-in default prompt is shown below (read-only). Turn on to customize it globally for all Auto Run / Playbook executions.'}
+											</p>
+											<textarea
+												value={hasOverride ? autoRunDefaultPromptOverride : autorunDefaultPrompt}
+												onChange={(e) => setAutoRunDefaultPromptOverride(e.target.value)}
+												readOnly={!hasOverride}
+												className="w-full p-3 rounded border bg-transparent outline-none resize-vertical text-sm font-mono"
+												style={{
+													borderColor: theme.colors.border,
+													color: hasOverride ? theme.colors.textMain : theme.colors.textDim,
+													minHeight: '300px',
+													opacity: hasOverride ? 1 : 0.7,
+												}}
+												rows={16}
 											/>
-										</button>
+											{hasOverride &&
+												!validateAgentPromptHasTaskReference(autoRunDefaultPromptOverride) && (
+													<p className="text-xs mt-1" style={{ color: theme.colors.error }}>
+														Warning: prompt does not reference Markdown tasks. Auto Run will be
+														disabled until checkbox syntax (e.g. - [ ]) is added.
+													</p>
+												)}
+										</div>
 									</div>
-									<p className="text-xs mb-3" style={{ color: theme.colors.textDim }}>
-										{autoRunDefaultPromptOverride
-											? "Your custom prompt is active for all Auto Run / Playbook executions that don't have a per-playbook prompt. Turn off to revert to the built-in default."
-											: 'The built-in default prompt is shown below (read-only). Turn on to customize it globally for all Auto Run / Playbook executions.'}
-									</p>
-									<textarea
-										value={autoRunDefaultPromptOverride || autorunDefaultPrompt}
-										onChange={(e) => setAutoRunDefaultPromptOverride(e.target.value)}
-										readOnly={!autoRunDefaultPromptOverride}
-										className="w-full p-3 rounded border bg-transparent outline-none resize-vertical text-sm font-mono"
-										style={{
-											borderColor: theme.colors.border,
-											color: autoRunDefaultPromptOverride
-												? theme.colors.textMain
-												: theme.colors.textDim,
-											minHeight: '300px',
-											opacity: autoRunDefaultPromptOverride ? 1 : 0.7,
-										}}
-										rows={16}
-									/>
-								</div>
-							</div>
-						)}
+								);
+							})()}
 
 						{activeTab === 'ssh' && (
 							<div className="space-y-5">

--- a/src/renderer/components/Settings/SettingsModal.tsx
+++ b/src/renderer/components/Settings/SettingsModal.tsx
@@ -12,8 +12,10 @@ import {
 	Monitor,
 	Globe,
 	Users,
+	Play,
 } from 'lucide-react';
 import { useSettings } from '../../hooks';
+import { autorunDefaultPrompt } from '../../../prompts';
 import type { Theme, LLMProvider } from '../../types';
 import { useLayerStack } from '../../contexts/LayerStackContext';
 import { MODAL_PRIORITIES } from '../../constants/modalPriorities';
@@ -52,6 +54,7 @@ interface SettingsModalProps {
 		| 'notifications'
 		| 'aicommands'
 		| 'groupchat'
+		| 'autorun'
 		| 'ssh'
 		| 'environment'
 		| 'encore';
@@ -103,6 +106,9 @@ export const SettingsModal = memo(function SettingsModal(props: SettingsModalPro
 		// Group Chat settings
 		moderatorStandingInstructions,
 		setModeratorStandingInstructions,
+		// Auto Run settings
+		autoRunDefaultPromptOverride,
+		setAutoRunDefaultPromptOverride,
 	} = useSettings();
 
 	const [activeTab, setActiveTab] = useState<
@@ -114,6 +120,7 @@ export const SettingsModal = memo(function SettingsModal(props: SettingsModalPro
 		| 'notifications'
 		| 'aicommands'
 		| 'groupchat'
+		| 'autorun'
 		| 'ssh'
 		| 'environment'
 		| 'encore'
@@ -210,6 +217,7 @@ export const SettingsModal = memo(function SettingsModal(props: SettingsModalPro
 				| 'notifications'
 				| 'aicommands'
 				| 'groupchat'
+				| 'autorun'
 				| 'ssh'
 				| 'environment'
 				| 'encore'
@@ -223,6 +231,7 @@ export const SettingsModal = memo(function SettingsModal(props: SettingsModalPro
 						'notifications',
 						'aicommands',
 						'groupchat',
+						'autorun',
 						'ssh',
 						'environment',
 						'encore',
@@ -235,6 +244,7 @@ export const SettingsModal = memo(function SettingsModal(props: SettingsModalPro
 						'notifications',
 						'aicommands',
 						'groupchat',
+						'autorun',
 						'ssh',
 						'environment',
 						'encore',
@@ -385,6 +395,7 @@ export const SettingsModal = memo(function SettingsModal(props: SettingsModalPro
 		{ id: 'notifications', label: 'Notifications', icon: Bell },
 		{ id: 'aicommands', label: 'AI Commands', icon: Cpu },
 		{ id: 'groupchat', label: 'Group Chat', icon: Users },
+		{ id: 'autorun', label: 'Auto Run', icon: Play },
 		{ id: 'ssh', label: 'SSH Hosts', icon: Server },
 		{ id: 'environment', label: 'Environment', icon: Globe },
 		{ id: 'encore', label: 'Encore Features', icon: FlaskConical },
@@ -664,6 +675,65 @@ export const SettingsModal = memo(function SettingsModal(props: SettingsModalPro
 									<div className="text-xs mt-1 text-right" style={{ color: theme.colors.textDim }}>
 										{moderatorStandingInstructions.length} / 2000
 									</div>
+								</div>
+							</div>
+						)}
+
+						{activeTab === 'autorun' && (
+							<div className="space-y-5">
+								<div>
+									<div className="flex items-center justify-between mb-1">
+										<h3
+											className="text-sm font-bold uppercase tracking-wider"
+											style={{ color: theme.colors.textMain }}
+										>
+											Custom Default Prompt
+										</h3>
+										<button
+											onClick={() => {
+												if (autoRunDefaultPromptOverride) {
+													setAutoRunDefaultPromptOverride('');
+												} else {
+													setAutoRunDefaultPromptOverride(autorunDefaultPrompt);
+												}
+											}}
+											className="relative w-10 h-5 rounded-full transition-colors flex-shrink-0"
+											style={{
+												backgroundColor: autoRunDefaultPromptOverride
+													? theme.colors.accent
+													: theme.colors.bgActivity,
+											}}
+											role="switch"
+											aria-checked={!!autoRunDefaultPromptOverride}
+											aria-label="Override default Auto Run prompt"
+										>
+											<span
+												className={`absolute left-0 top-0.5 w-4 h-4 rounded-full bg-white transition-transform ${
+													autoRunDefaultPromptOverride ? 'translate-x-5' : 'translate-x-0.5'
+												}`}
+											/>
+										</button>
+									</div>
+									<p className="text-xs mb-3" style={{ color: theme.colors.textDim }}>
+										{autoRunDefaultPromptOverride
+											? "Your custom prompt is active for all Auto Run / Playbook executions that don't have a per-playbook prompt. Turn off to revert to the built-in default."
+											: 'The built-in default prompt is shown below (read-only). Turn on to customize it globally for all Auto Run / Playbook executions.'}
+									</p>
+									<textarea
+										value={autoRunDefaultPromptOverride || autorunDefaultPrompt}
+										onChange={(e) => setAutoRunDefaultPromptOverride(e.target.value)}
+										readOnly={!autoRunDefaultPromptOverride}
+										className="w-full p-3 rounded border bg-transparent outline-none resize-vertical text-sm font-mono"
+										style={{
+											borderColor: theme.colors.border,
+											color: autoRunDefaultPromptOverride
+												? theme.colors.textMain
+												: theme.colors.textDim,
+											minHeight: '300px',
+											opacity: autoRunDefaultPromptOverride ? 1 : 0.7,
+										}}
+										rows={16}
+									/>
 								</div>
 							</div>
 						)}

--- a/src/renderer/hooks/batch/batchUtils.ts
+++ b/src/renderer/hooks/batch/batchUtils.ts
@@ -14,7 +14,7 @@ export const DEFAULT_BATCH_PROMPT = autorunDefaultPrompt;
  * Settings if one exists, otherwise the built-in default.
  */
 export function getEffectiveAutoRunPrompt(): string {
-	const override = useSettingsStore.getState().autoRunDefaultPromptOverride;
+	const override = useSettingsStore.getState().autoRunDefaultPromptOverride?.trim();
 	return override || autorunDefaultPrompt;
 }
 

--- a/src/renderer/hooks/batch/batchUtils.ts
+++ b/src/renderer/hooks/batch/batchUtils.ts
@@ -4,9 +4,19 @@
  */
 
 import { autorunDefaultPrompt } from '../../../prompts';
+import { useSettingsStore } from '../../stores/settingsStore';
 
-// Default batch processing prompt (exported for use by BatchRunnerModal and playbook management)
+// Built-in default prompt (used for comparison / reset)
 export const DEFAULT_BATCH_PROMPT = autorunDefaultPrompt;
+
+/**
+ * Returns the effective Auto Run prompt — the user's global override from
+ * Settings if one exists, otherwise the built-in default.
+ */
+export function getEffectiveAutoRunPrompt(): string {
+	const override = useSettingsStore.getState().autoRunDefaultPromptOverride;
+	return override || autorunDefaultPrompt;
+}
 
 // Regex to count unchecked markdown checkboxes: - [ ] task (also * [ ])
 const UNCHECKED_TASK_REGEX = /^[\s]*[-*]\s*\[\s*\]\s*.+$/gm;

--- a/src/renderer/hooks/batch/index.ts
+++ b/src/renderer/hooks/batch/index.ts
@@ -11,6 +11,7 @@ export {
 	countCheckedTasks,
 	uncheckAllTasks,
 	DEFAULT_BATCH_PROMPT,
+	getEffectiveAutoRunPrompt,
 	validateAgentPromptHasTaskReference,
 } from './batchUtils';
 

--- a/src/renderer/hooks/batch/usePlaybookManagement.ts
+++ b/src/renderer/hooks/batch/usePlaybookManagement.ts
@@ -25,7 +25,7 @@ import { generateId } from '../../utils/ids';
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { useClickOutside } from '../ui';
 import type { Playbook, BatchDocumentEntry } from '../../types';
-import { DEFAULT_BATCH_PROMPT } from './batchUtils';
+import { getEffectiveAutoRunPrompt } from './batchUtils';
 
 /**
  * Configuration passed to the hook for modification detection
@@ -186,7 +186,9 @@ export function usePlaybookManagement(
 			// Apply configuration through callback
 			// Note: Worktree settings are no longer managed here - see WorktreeConfigModal
 			// Fall back to default prompt if playbook has no/empty agent prompt
-			const effectivePrompt = playbook.prompt?.trim() ? playbook.prompt : DEFAULT_BATCH_PROMPT;
+			const effectivePrompt = playbook.prompt?.trim()
+				? playbook.prompt
+				: getEffectiveAutoRunPrompt();
 
 			onApplyPlaybook({
 				documents: entries,

--- a/src/renderer/hooks/settings/useSettings.ts
+++ b/src/renderer/hooks/settings/useSettings.ts
@@ -321,6 +321,10 @@ export interface UseSettingsReturn {
 	// Group Chat settings
 	moderatorStandingInstructions: string;
 	setModeratorStandingInstructions: (value: string) => void;
+
+	// Auto Run settings
+	autoRunDefaultPromptOverride: string;
+	setAutoRunDefaultPromptOverride: (value: string) => void;
 }
 
 export function useSettings(): UseSettingsReturn {

--- a/src/renderer/hooks/symphony/useSymphonyContribution.ts
+++ b/src/renderer/hooks/symphony/useSymphonyContribution.ts
@@ -22,7 +22,7 @@ import { generateId } from '../../utils/ids';
 import { validateNewSession } from '../../utils/sessionValidation';
 import { gitService } from '../../services/git';
 import { notifyToast } from '../../stores/notificationStore';
-import { DEFAULT_BATCH_PROMPT } from '../../components/BatchRunnerModal';
+import { getEffectiveAutoRunPrompt } from '../../hooks/batch/batchUtils';
 
 // ============================================================================
 // Dependencies interface
@@ -244,7 +244,7 @@ export function useSymphonyContribution(
 						resetOnCompletion: false,
 						isDuplicate: false,
 					})),
-					prompt: DEFAULT_BATCH_PROMPT,
+					prompt: getEffectiveAutoRunPrompt(),
 					loopEnabled: false,
 				};
 

--- a/src/renderer/hooks/wizard/useWizardHandlers.ts
+++ b/src/renderer/hooks/wizard/useWizardHandlers.ts
@@ -40,7 +40,7 @@ import { parseSynopsis } from '../../../shared/synopsis';
 import { formatRelativeTime } from '../../../shared/formatters';
 import { gitService } from '../../services/git';
 import { AUTO_RUN_FOLDER_NAME } from '../../components/Wizard';
-import { DEFAULT_BATCH_PROMPT } from '../../components/BatchRunnerModal';
+import { getEffectiveAutoRunPrompt } from '../batch/batchUtils';
 import type { PreviousUIState, UseInlineWizardReturn } from '../batch/useInlineWizard';
 import type { WizardState } from '../../components/Wizard/WizardContext';
 import type { HistoryEntryInput } from '../agent/useAgentSessionManagement';
@@ -1228,7 +1228,7 @@ export function useWizardHandlers(deps: UseWizardHandlersDeps): UseWizardHandler
 						resetOnCompletion: false,
 						isDuplicate: false,
 					})),
-					prompt: DEFAULT_BATCH_PROMPT,
+					prompt: getEffectiveAutoRunPrompt(),
 					loopEnabled: false,
 				};
 

--- a/src/renderer/stores/settingsStore.ts
+++ b/src/renderer/stores/settingsStore.ts
@@ -263,6 +263,7 @@ export interface SettingsStoreState {
 	useNativeTitleBar: boolean;
 	autoHideMenuBar: boolean;
 	moderatorStandingInstructions: string;
+	autoRunDefaultPromptOverride: string;
 }
 
 export interface SettingsStoreActions {
@@ -340,6 +341,7 @@ export interface SettingsStoreActions {
 	setUseNativeTitleBar: (value: boolean) => void;
 	setAutoHideMenuBar: (value: boolean) => void;
 	setModeratorStandingInstructions: (value: string) => void;
+	setAutoRunDefaultPromptOverride: (value: string) => void;
 
 	// Async setters
 	setLogLevel: (value: string) => Promise<void>;
@@ -497,6 +499,7 @@ export const useSettingsStore = create<SettingsStore>()((set, get) => {
 		useNativeTitleBar: isWindowsPlatform(),
 		autoHideMenuBar: false,
 		moderatorStandingInstructions: '',
+		autoRunDefaultPromptOverride: '',
 
 		// ============================================================================
 		// Simple Setters
@@ -933,6 +936,11 @@ export const useSettingsStore = create<SettingsStore>()((set, get) => {
 			const trimmed = value.slice(0, 2000);
 			set({ moderatorStandingInstructions: trimmed });
 			window.maestro.settings.set('moderatorStandingInstructions', trimmed);
+		},
+
+		setAutoRunDefaultPromptOverride: (value) => {
+			set({ autoRunDefaultPromptOverride: value });
+			window.maestro.settings.set('autoRunDefaultPromptOverride', value);
 		},
 
 		// ============================================================================
@@ -1868,6 +1876,9 @@ export async function loadAllSettings(): Promise<void> {
 		if (allSettings['moderatorStandingInstructions'] !== undefined)
 			patch.moderatorStandingInstructions = allSettings['moderatorStandingInstructions'] as string;
 
+		if (allSettings['autoRunDefaultPromptOverride'] !== undefined)
+			patch.autoRunDefaultPromptOverride = allSettings['autoRunDefaultPromptOverride'] as string;
+
 		// Apply the entire patch in one setState call
 		patch.settingsLoaded = true;
 		useSettingsStore.setState(patch);
@@ -1988,5 +1999,6 @@ export function getSettingsActions() {
 		setUseNativeTitleBar: state.setUseNativeTitleBar,
 		setAutoHideMenuBar: state.setAutoHideMenuBar,
 		setModeratorStandingInstructions: state.setModeratorStandingInstructions,
+		setAutoRunDefaultPromptOverride: state.setAutoRunDefaultPromptOverride,
 	};
 }


### PR DESCRIPTION
<img width="1354" height="1046" alt="Bildschirmfoto 2026-04-09 um 21 38 12" src="https://github.com/user-attachments/assets/a6fc5c0d-3180-477f-be31-2ba394e2d5f5" />
<img width="1354" height="1046" alt="Bildschirmfoto 2026-04-09 um 21 38 07" src="https://github.com/user-attachments/assets/7ab04513-5724-47c0-87d2-2889511c44d1" />

Overwrite the default autorun prompt for all future agents and agents that don't have a customized prompt already.

My use case it removing the default push to github which takes 10 minutes for some projects, I am looking at you Maestro ;-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "Auto Run" Settings tab to enable, edit, and persist a custom default batch-run prompt with validation.

* **Improvements**
  * Batch Runner, auto-start runs, and wizard/playbook flows now use the computed default prompt from settings (so customized prompts are respected everywhere).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->