### PR TITLE
 fix: clamp overflowing context usage display

### DIFF
--- a/src/__tests__/renderer/utils/contextUsage.test.ts
+++ b/src/__tests__/renderer/utils/contextUsage.test.ts
@@ -395,7 +395,7 @@ describe('calculateContextDisplay', () => {
 		expect(result.contextWindow).toBe(0);
 	});
 
-	it('should not fall back when no fallbackPercentage is provided', () => {
+	it('should clamp tokens to the window when accumulated values exceed it without a fallback', () => {
 		const result = calculateContextDisplay(
 			{
 				inputTokens: 50000,
@@ -406,9 +406,8 @@ describe('calculateContextDisplay', () => {
 			'claude-code'
 			// no fallback
 		);
-		// Raw = 1008000 > 200000, but no fallback, so tokens stay at raw value
-		// Percentage is capped at 100%
-		expect(result.tokens).toBe(1008000);
+		// Raw = 1008000 > 200000, but no fallback, so clamp to the configured window
+		expect(result.tokens).toBe(200000);
 		expect(result.percentage).toBe(100);
 	});
 

--- a/src/__tests__/renderer/utils/contextUsage.test.ts
+++ b/src/__tests__/renderer/utils/contextUsage.test.ts
@@ -411,6 +411,21 @@ describe('calculateContextDisplay', () => {
 		expect(result.percentage).toBe(100);
 	});
 
+	it('should clamp fallback percentages above 100 before deriving tokens', () => {
+		const result = calculateContextDisplay(
+			{
+				inputTokens: 50000,
+				cacheReadInputTokens: 758000,
+				cacheCreationInputTokens: 200000,
+			},
+			200000,
+			'claude-code',
+			150
+		);
+		expect(result.tokens).toBe(200000);
+		expect(result.percentage).toBe(100);
+	});
+
 	it('should use Codex semantics (includes output tokens)', () => {
 		const result = calculateContextDisplay(
 			{ inputTokens: 50000, outputTokens: 30000, cacheCreationInputTokens: 20000 },

--- a/src/renderer/utils/contextUsage.ts
+++ b/src/renderer/utils/contextUsage.ts
@@ -168,9 +168,14 @@ export function calculateContextDisplay(
 
 	let tokens = raw;
 	if (raw > contextWindow) {
-		if (fallbackPercentage != null && fallbackPercentage >= 0) {
+		if (
+			fallbackPercentage != null &&
+			Number.isFinite(fallbackPercentage) &&
+			fallbackPercentage >= 0
+		) {
 			// Accumulated multi-tool turn: derive tokens from preserved percentage
-			tokens = Math.round((fallbackPercentage / 100) * contextWindow);
+			const boundedFallback = Math.min(100, fallbackPercentage);
+			tokens = Math.round((boundedFallback / 100) * contextWindow);
 		} else {
 			// We don't have a trustworthy fallback percentage yet, so clamp to the
 			// configured window instead of displaying an impossible token total.

--- a/src/renderer/utils/contextUsage.ts
+++ b/src/renderer/utils/contextUsage.ts
@@ -167,9 +167,15 @@ export function calculateContextDisplay(
 	const raw = calculateContextTokens(usageStats, agentId);
 
 	let tokens = raw;
-	if (raw > contextWindow && fallbackPercentage != null && fallbackPercentage >= 0) {
-		// Accumulated multi-tool turn: derive tokens from preserved percentage
-		tokens = Math.round((fallbackPercentage / 100) * contextWindow);
+	if (raw > contextWindow) {
+		if (fallbackPercentage != null && fallbackPercentage >= 0) {
+			// Accumulated multi-tool turn: derive tokens from preserved percentage
+			tokens = Math.round((fallbackPercentage / 100) * contextWindow);
+		} else {
+			// We don't have a trustworthy fallback percentage yet, so clamp to the
+			// configured window instead of displaying an impossible token total.
+			tokens = contextWindow;
+		}
 	}
 
 	const percentage = tokens <= 0 ? 0 : Math.min(100, Math.round((tokens / contextWindow) * 100));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Ensure token counts are clamped to the configured context window when accumulated tokens exceed the limit; clamp any fallback percentage to 100% before converting to tokens.

- **Tests**
  - Updated coverage to assert clamped token/percentage behavior and added a test for fallback percentages >100%.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->