### PR TITLE
fix: reconcile remote tunnel status

### DIFF
--- a/src/__tests__/main/tunnel-manager.test.ts
+++ b/src/__tests__/main/tunnel-manager.test.ts
@@ -328,5 +328,20 @@ describe('TunnelManager', () => {
 			expect('url' in status).toBe(true);
 			expect('error' in status).toBe(true);
 		});
+
+		it('preserves an error after unexpected exit post-connect', async () => {
+			const startPromise = tunnelManager.start(3000);
+			await new Promise((resolve) => setImmediate(resolve));
+
+			mockProcess.stderr.emit('data', Buffer.from('https://abc.trycloudflare.com'));
+			await startPromise;
+
+			mockProcess.emit('exit', 1);
+
+			const status = tunnelManager.getStatus();
+			expect(status.isRunning).toBe(false);
+			expect(status.url).toBe('https://abc.trycloudflare.com');
+			expect(status.error).toContain('cloudflared exited unexpectedly');
+		});
 	});
 });

--- a/src/__tests__/main/web-server/WebServer.test.ts
+++ b/src/__tests__/main/web-server/WebServer.test.ts
@@ -2,7 +2,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
 import os from 'os';
 import path from 'path';
+import { captureException } from '../../../main/utils/sentry';
 import { WebServer } from '../../../main/web-server/WebServer';
+
+vi.mock('../../../main/utils/sentry', () => ({
+	captureException: vi.fn(),
+}));
 
 describe('WebServer web asset resolution', () => {
 	let tempRoot: string;
@@ -14,6 +19,7 @@ describe('WebServer web asset resolution', () => {
 
 	afterEach(() => {
 		vi.restoreAllMocks();
+		vi.clearAllMocks();
 		rmSync(tempRoot, { recursive: true, force: true });
 	});
 
@@ -34,5 +40,21 @@ describe('WebServer web asset resolution', () => {
 		const server = new WebServer(0);
 
 		expect((server as any).webAssetsPath).toBeNull();
+	});
+
+	it('reports and rethrows unexpected asset inspection failures', () => {
+		const distWebDir = path.join(tempRoot, 'dist', 'web');
+		const indexPath = path.join(distWebDir, 'index.html');
+		mkdirSync(indexPath, { recursive: true });
+
+		expect(() => new WebServer(0)).toThrow();
+
+		const [[capturedError, captureContext]] = vi.mocked(captureException).mock.calls;
+		expect((capturedError as NodeJS.ErrnoException).code).toBe('EISDIR');
+		expect(captureContext).toEqual({
+			operation: 'webServer:isServableWebAssetsPath',
+			candidatePath: distWebDir,
+			indexPath,
+		});
 	});
 });

--- a/src/__tests__/main/web-server/WebServer.test.ts
+++ b/src/__tests__/main/web-server/WebServer.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import os from 'os';
+import path from 'path';
+import { WebServer } from '../../../main/web-server/WebServer';
+
+describe('WebServer web asset resolution', () => {
+	let tempRoot: string;
+
+	beforeEach(() => {
+		tempRoot = mkdtempSync(path.join(os.tmpdir(), 'maestro-web-assets-'));
+		vi.spyOn(process, 'cwd').mockReturnValue(tempRoot);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		rmSync(tempRoot, { recursive: true, force: true });
+	});
+
+	it('prefers built dist/web assets over the source web index', () => {
+		const distWebDir = path.join(tempRoot, 'dist', 'web');
+		mkdirSync(distWebDir, { recursive: true });
+		writeFileSync(
+			path.join(distWebDir, 'index.html'),
+			'<script type="module" src="./assets/main.js"></script>'
+		);
+
+		const server = new WebServer(0);
+
+		expect((server as any).webAssetsPath).toBe(distWebDir);
+	});
+
+	it('rejects source web assets that still reference /main.tsx when no built bundle exists', () => {
+		const server = new WebServer(0);
+
+		expect((server as any).webAssetsPath).toBeNull();
+	});
+});

--- a/src/__tests__/renderer/components/SessionList.test.tsx
+++ b/src/__tests__/renderer/components/SessionList.test.tsx
@@ -259,6 +259,7 @@ describe('SessionList', () => {
 			isCloudflaredInstalled: vi.fn().mockResolvedValue(true),
 			start: vi.fn().mockResolvedValue({ success: true, url: 'https://tunnel.example.com' }),
 			stop: vi.fn().mockResolvedValue(undefined),
+			getStatus: vi.fn().mockResolvedValue({ isRunning: false, url: null, error: null }),
 		};
 	});
 
@@ -2127,6 +2128,7 @@ describe('SessionList', () => {
 				isCloudflaredInstalled: mockIsInstalled,
 				start: vi.fn().mockResolvedValue({ success: true, url: 'https://tunnel.example.com' }),
 				stop: vi.fn().mockResolvedValue(undefined),
+				getStatus: vi.fn().mockResolvedValue({ isRunning: false, url: null, error: null }),
 			};
 
 			useUIStore.setState({ leftSidebarOpen: true });
@@ -2150,6 +2152,7 @@ describe('SessionList', () => {
 				isCloudflaredInstalled: mockIsInstalled,
 				start: vi.fn(),
 				stop: vi.fn(),
+				getStatus: vi.fn().mockResolvedValue({ isRunning: false, url: null, error: null }),
 			};
 
 			useUIStore.setState({ leftSidebarOpen: true });
@@ -2174,6 +2177,11 @@ describe('SessionList', () => {
 				isCloudflaredInstalled: vi.fn().mockResolvedValue(true),
 				start: mockStart,
 				stop: vi.fn(),
+				getStatus: vi.fn().mockResolvedValue({
+					isRunning: true,
+					url: 'https://tunnel.example.com',
+					error: null,
+				}),
 			};
 
 			useUIStore.setState({ leftSidebarOpen: true });
@@ -2209,6 +2217,11 @@ describe('SessionList', () => {
 				isCloudflaredInstalled: vi.fn().mockResolvedValue(true),
 				start: mockStart,
 				stop: mockStop,
+				getStatus: vi.fn().mockResolvedValue({
+					isRunning: true,
+					url: 'https://tunnel.example.com',
+					error: null,
+				}),
 			};
 
 			useUIStore.setState({ leftSidebarOpen: true });
@@ -2246,6 +2259,11 @@ describe('SessionList', () => {
 				isCloudflaredInstalled: vi.fn().mockResolvedValue(true),
 				start: mockStart,
 				stop: vi.fn(),
+				getStatus: vi.fn().mockResolvedValue({
+					isRunning: false,
+					url: null,
+					error: 'Connection failed',
+				}),
 			};
 
 			useUIStore.setState({ leftSidebarOpen: true });
@@ -2273,6 +2291,7 @@ describe('SessionList', () => {
 				isCloudflaredInstalled: vi.fn().mockResolvedValue(true),
 				start: mockStart,
 				stop: vi.fn(),
+				getStatus: vi.fn().mockRejectedValue(new Error('Network error')),
 			};
 
 			useUIStore.setState({ leftSidebarOpen: true });
@@ -2302,6 +2321,11 @@ describe('SessionList', () => {
 				isCloudflaredInstalled: vi.fn().mockResolvedValue(true),
 				start: mockStart,
 				stop: vi.fn(),
+				getStatus: vi.fn().mockResolvedValue({
+					isRunning: true,
+					url: 'https://tunnel.example.com',
+					error: null,
+				}),
 			};
 
 			useUIStore.setState({ leftSidebarOpen: true });
@@ -2331,6 +2355,11 @@ describe('SessionList', () => {
 				isCloudflaredInstalled: vi.fn().mockResolvedValue(true),
 				start: mockStart,
 				stop: vi.fn(),
+				getStatus: vi.fn().mockResolvedValue({
+					isRunning: true,
+					url: 'https://tunnel.example.com',
+					error: null,
+				}),
 			};
 
 			useUIStore.setState({ leftSidebarOpen: true });
@@ -2368,6 +2397,11 @@ describe('SessionList', () => {
 				isCloudflaredInstalled: vi.fn().mockResolvedValue(true),
 				start: mockStart,
 				stop: vi.fn(),
+				getStatus: vi.fn().mockResolvedValue({
+					isRunning: true,
+					url: 'https://tunnel.example.com',
+					error: null,
+				}),
 			};
 
 			useUIStore.setState({ leftSidebarOpen: true });
@@ -2402,6 +2436,11 @@ describe('SessionList', () => {
 				isCloudflaredInstalled: vi.fn().mockResolvedValue(true),
 				start: mockStart,
 				stop: vi.fn(),
+				getStatus: vi.fn().mockResolvedValue({
+					isRunning: true,
+					url: 'https://tunnel.example.com',
+					error: null,
+				}),
 			};
 
 			useUIStore.setState({ leftSidebarOpen: true });
@@ -3054,6 +3093,7 @@ describe('SessionList', () => {
 				isCloudflaredInstalled: vi.fn().mockResolvedValue(true),
 				start: vi.fn(),
 				stop: vi.fn(),
+				getStatus: vi.fn().mockResolvedValue({ isRunning: false, url: null, error: null }),
 			};
 
 			useUIStore.setState({ leftSidebarOpen: true });
@@ -3080,6 +3120,11 @@ describe('SessionList', () => {
 				isCloudflaredInstalled: vi.fn().mockResolvedValue(true),
 				start: mockStart,
 				stop: vi.fn(),
+				getStatus: vi.fn().mockResolvedValue({
+					isRunning: true,
+					url: 'https://tunnel.example.com',
+					error: null,
+				}),
 			};
 
 			useUIStore.setState({ leftSidebarOpen: true });

--- a/src/__tests__/renderer/components/SessionList/LiveOverlayPanel.test.tsx
+++ b/src/__tests__/renderer/components/SessionList/LiveOverlayPanel.test.tsx
@@ -20,6 +20,9 @@ vi.mock('../../../../renderer/utils/clipboard', () => ({
 	shell: {
 		openExternal: vi.fn(),
 	},
+	tunnel: {
+		getStatus: vi.fn().mockResolvedValue({ isRunning: false, url: null, error: null }),
+	},
 };
 
 const mockTheme: Theme = {
@@ -75,6 +78,11 @@ function createDefaultProps(overrides: Partial<Parameters<typeof LiveOverlayPane
 describe('LiveOverlayPanel', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		(window as any).maestro.tunnel.getStatus.mockResolvedValue({
+			isRunning: false,
+			url: null,
+			error: null,
+		});
 	});
 
 	// -----------------------------------------------------------------------
@@ -181,6 +189,25 @@ describe('LiveOverlayPanel', () => {
 		it('shows disconnect title when tunnel is connected', () => {
 			render(<LiveOverlayPanel {...createDefaultProps({ tunnelStatus: 'connected' })} />);
 			expect(screen.getByTitle('Disable remote control')).toBeTruthy();
+		});
+
+		it('keeps connected state when tunnel status confirms process is running', () => {
+			(window as any).maestro.tunnel.getStatus.mockResolvedValue({
+				isRunning: true,
+				url: 'https://tunnel.example.com',
+				error: null,
+			});
+
+			render(
+				<LiveOverlayPanel
+					{...createDefaultProps({
+						tunnelStatus: 'connected',
+						tunnelUrl: 'https://tunnel.example.com',
+					})}
+				/>
+			);
+
+			expect(screen.getByText(/Remote tunnel active/)).toBeTruthy();
 		});
 	});
 

--- a/src/main/tunnel-manager.ts
+++ b/src/main/tunnel-manager.ts
@@ -18,6 +18,7 @@ class TunnelManager {
 	private process: ChildProcess | null = null;
 	private url: string | null = null;
 	private error: string | null = null;
+	private stopping = false;
 
 	async start(port: number): Promise<TunnelResult> {
 		// Validate port number
@@ -37,6 +38,7 @@ class TunnelManager {
 		const cloudflaredBinary = getCloudflaredPath() || 'cloudflared';
 
 		return new Promise((resolve) => {
+			this.stopping = false;
 			logger.info(
 				`Starting cloudflared tunnel for port ${port} using ${cloudflaredBinary}`,
 				'TunnelManager'
@@ -92,10 +94,14 @@ class TunnelManager {
 					clearTimeout(timeout);
 					this.error = `cloudflared exited unexpectedly (code ${code})`;
 					resolve({ success: false, error: this.error });
+				} else if (!this.stopping) {
+					this.error = `cloudflared exited unexpectedly (code ${code})`;
+					logger.error(this.error, 'TunnelManager');
 				}
 				// Only clear process reference on exit, not URL
 				// URL is cleared explicitly in stop() to preserve it for display
 				this.process = null;
+				this.stopping = false;
 			});
 		});
 	}
@@ -103,6 +109,7 @@ class TunnelManager {
 	async stop(): Promise<void> {
 		if (this.process) {
 			logger.info('Stopping tunnel', 'TunnelManager');
+			this.stopping = true;
 			const proc = this.process;
 			proc.kill('SIGTERM');
 
@@ -126,6 +133,7 @@ class TunnelManager {
 
 			this.process = null;
 		}
+		this.stopping = false;
 		this.url = null;
 		this.error = null;
 	}

--- a/src/main/web-server/WebServer.ts
+++ b/src/main/web-server/WebServer.ts
@@ -31,6 +31,7 @@ import path from 'path';
 import { existsSync, readFileSync } from 'fs';
 import { getLocalIpAddressSync } from '../utils/networkUtils';
 import { logger } from '../utils/logger';
+import { captureException } from '../utils/sentry';
 import { WebSocketMessageHandler } from './handlers';
 import { BroadcastService } from './services';
 import { ApiRoutes, StaticRoutes, WsRoute } from './routes';
@@ -203,8 +204,19 @@ export class WebServer {
 				html.includes('src="/main.tsx"') || html.includes("src='/main.tsx'");
 			return !referencesDevEntrypoint;
 		} catch (error) {
-			logger.warn(`Failed to inspect web assets at ${candidatePath}: ${error}`, LOG_CONTEXT);
-			return false;
+			const err = error as NodeJS.ErrnoException;
+			if (err.code === 'ENOENT') {
+				logger.warn(`Web assets disappeared while inspecting ${candidatePath}`, LOG_CONTEXT);
+				return false;
+			}
+
+			logger.error(`Failed to inspect web assets at ${candidatePath}`, LOG_CONTEXT, error);
+			captureException(error, {
+				operation: 'webServer:isServableWebAssetsPath',
+				candidatePath,
+				indexPath,
+			});
+			throw error;
 		}
 	}
 

--- a/src/main/web-server/WebServer.ts
+++ b/src/main/web-server/WebServer.ts
@@ -28,7 +28,7 @@ import fastifyStatic from '@fastify/static';
 import { FastifyInstance, FastifyRequest } from 'fastify';
 import { randomUUID } from 'crypto';
 import path from 'path';
-import { existsSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import { getLocalIpAddressSync } from '../utils/networkUtils';
 import { logger } from '../utils/logger';
 import { WebSocketMessageHandler } from './handlers';
@@ -165,16 +165,16 @@ export class WebServer {
 	private resolveWebAssetsPath(): string | null {
 		// Try multiple locations for the web assets
 		const possiblePaths = [
-			// Production: relative to the compiled main process
-			path.join(__dirname, '..', '..', 'web'),
 			// Development: from project root
 			path.join(process.cwd(), 'dist', 'web'),
+			// Production: relative to the compiled main process
+			path.join(__dirname, '..', '..', 'web'),
 			// Alternative: relative to __dirname going up to dist
 			path.join(__dirname, '..', 'web'),
 		];
 
 		for (const p of possiblePaths) {
-			if (existsSync(path.join(p, 'index.html'))) {
+			if (this.isServableWebAssetsPath(p)) {
 				logger.debug(`Web assets found at: ${p}`, LOG_CONTEXT);
 				return p;
 			}
@@ -185,6 +185,27 @@ export class WebServer {
 			LOG_CONTEXT
 		);
 		return null;
+	}
+
+	/**
+	 * Only serve built web assets. Source `src/web/index.html` references `/main.tsx`,
+	 * which the embedded Fastify server cannot compile or serve.
+	 */
+	private isServableWebAssetsPath(candidatePath: string): boolean {
+		const indexPath = path.join(candidatePath, 'index.html');
+		if (!existsSync(indexPath)) {
+			return false;
+		}
+
+		try {
+			const html = readFileSync(indexPath, 'utf-8');
+			const referencesDevEntrypoint =
+				html.includes('src="/main.tsx"') || html.includes("src='/main.tsx'");
+			return !referencesDevEntrypoint;
+		} catch (error) {
+			logger.warn(`Failed to inspect web assets at ${candidatePath}: ${error}`, LOG_CONTEXT);
+			return false;
+		}
 	}
 
 	// ============ Live Session Management (Delegated to LiveSessionManager) ============

--- a/src/renderer/hooks/remote/useLiveOverlay.ts
+++ b/src/renderer/hooks/remote/useLiveOverlay.ts
@@ -117,6 +117,56 @@ export function useLiveOverlay(isLiveMode: boolean): UseLiveOverlayReturn {
 		}
 	}, [isLiveMode]);
 
+	// Keep tunnel UI aligned with the actual cloudflared process state.
+	useEffect(() => {
+		if (!isLiveMode || (tunnelStatus !== 'starting' && tunnelStatus !== 'connected')) {
+			return;
+		}
+
+		let cancelled = false;
+		const syncStatus = async () => {
+			try {
+				const status = await window.maestro.tunnel.getStatus();
+				if (cancelled) return;
+
+				if (status.isRunning && status.url) {
+					setTunnelStatus('connected');
+					setTunnelUrl(status.url);
+					setTunnelError(null);
+					return;
+				}
+
+				if (status.error) {
+					setTunnelStatus('error');
+					setTunnelError(status.error);
+				} else {
+					setTunnelStatus('off');
+				}
+				setTunnelUrl(null);
+				setActiveUrlTab('local');
+			} catch (error) {
+				if (cancelled) return;
+				setTunnelStatus('error');
+				setTunnelError(error instanceof Error ? error.message : 'Failed to read tunnel status');
+				setTunnelUrl(null);
+				setActiveUrlTab('local');
+			}
+		};
+
+		void syncStatus();
+		const intervalId = window.setInterval(
+			() => {
+				void syncStatus();
+			},
+			tunnelStatus === 'starting' ? 500 : 2000
+		);
+
+		return () => {
+			cancelled = true;
+			window.clearInterval(intervalId);
+		};
+	}, [isLiveMode, tunnelStatus]);
+
 	// Handle tunnel toggle (start/stop remote access)
 	const handleTunnelToggle = useCallback(async () => {
 		if (tunnelStatus === 'connected') {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live tunnel polling with adaptive intervals (500ms during startup, 2000ms when active) and improved state updates/cancellation.
  * Web asset resolution now inspects HTML content to avoid serving dev entrypoints and reports inspection errors.

* **Bug Fixes**
  * Tunnel shutdown logic avoids spurious error reports on intentional stops and preserves emitted tunnel URL after unexpected exits.

* **Tests**
  * Expanded test coverage for tunnel lifecycle, UI tunnel states, and web-asset resolution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->