### PR TITLE
fix: Windows process cleanup for Cue and tunnel on shutdown

### DIFF
--- a/src/__tests__/main/app-lifecycle/quit-handler.test.ts
+++ b/src/__tests__/main/app-lifecycle/quit-handler.test.ts
@@ -65,6 +65,12 @@ vi.mock('../../../main/power-manager', () => ({
 	},
 }));
 
+// Mock cue-executor to avoid pulling in agent/parser/SSH dependencies
+const mockStopAllCueRuns = vi.fn();
+vi.mock('../../../main/cue/cue-executor', () => ({
+	stopAllCueRuns: (...args: unknown[]) => mockStopAllCueRuns(...args),
+}));
+
 describe('app-lifecycle/quit-handler', () => {
 	let mockMainWindow: {
 		isDestroyed: ReturnType<typeof vi.fn>;
@@ -299,11 +305,15 @@ describe('app-lifecycle/quit-handler', () => {
 			expect(mockHistoryManager.stopWatching).toHaveBeenCalled();
 			expect(deps.stopCliWatcher).toHaveBeenCalled();
 			expect(deps.stopSessionCleanup).toHaveBeenCalled();
+			// Cue processes (tracked separately) must be killed before ProcessManager.killAll
+			expect(mockStopAllCueRuns).toHaveBeenCalled();
 			expect(mockProcessManager.killAll).toHaveBeenCalled();
+			const cueOrder = mockStopAllCueRuns.mock.invocationCallOrder[0];
+			const killOrder = mockProcessManager.killAll.mock.invocationCallOrder[0];
+			expect(cueOrder).toBeLessThan(killOrder);
 			// clearAllReasons must be called AFTER killAll to prevent late process
 			// output from re-arming the sleep blocker
 			expect(mockPowerManager.clearAllReasons).toHaveBeenCalled();
-			const killOrder = mockProcessManager.killAll.mock.invocationCallOrder[0];
 			const clearOrder = mockPowerManager.clearAllReasons.mock.invocationCallOrder[0];
 			expect(killOrder).toBeLessThan(clearOrder);
 			expect(mockTunnelManager.stop).toHaveBeenCalled();

--- a/src/__tests__/main/cue/cue-executor.test.ts
+++ b/src/__tests__/main/cue/cue-executor.test.ts
@@ -115,6 +115,8 @@ class MockChildProcess extends EventEmitter {
 	stdout = new EventEmitter();
 	stderr = new EventEmitter();
 	killed = false;
+	exitCode: number | null = null;
+	signalCode: string | null = null;
 
 	kill(signal?: string) {
 		this.killed = true;

--- a/src/__tests__/main/process-manager.test.ts
+++ b/src/__tests__/main/process-manager.test.ts
@@ -579,7 +579,7 @@ describe('process-manager.ts', () => {
 
 				processManager.kill('pty-session');
 
-				expect(killWindowsTreeSpy).toHaveBeenCalledWith(12345, 'pty-session');
+				expect(killWindowsTreeSpy).toHaveBeenCalledWith(12345, 'pty-session', false);
 				expect(mockPtyProcess.kill).not.toHaveBeenCalled();
 			});
 
@@ -623,7 +623,7 @@ describe('process-manager.ts', () => {
 
 				processManager.kill('child-session');
 
-				expect(killWindowsTreeSpy).toHaveBeenCalledWith(99999, 'child-session');
+				expect(killWindowsTreeSpy).toHaveBeenCalledWith(99999, 'child-session', false);
 				expect(mockChildProcess.kill).not.toHaveBeenCalled();
 			});
 
@@ -692,9 +692,9 @@ describe('process-manager.ts', () => {
 			it('should kill all processes even when kill() deletes from the map', () => {
 				const kills: string[] = [];
 				const originalKill = processManager.kill.bind(processManager);
-				processManager.kill = (sessionId: string) => {
+				processManager.kill = (sessionId: string, opts?: { sync?: boolean }) => {
 					kills.push(sessionId);
-					return originalKill(sessionId);
+					return originalKill(sessionId, opts);
 				};
 
 				const processes = (processManager as any).processes as Map<string, any>;
@@ -721,6 +721,33 @@ describe('process-manager.ts', () => {
 
 				expect(kills).toEqual(expect.arrayContaining(['a', 'b', 'c']));
 				expect(kills).toHaveLength(3);
+			});
+
+			it('should pass sync: true to kill() so Windows taskkill blocks until complete', () => {
+				const killSpy = vi.spyOn(processManager, 'kill');
+
+				const processes = (processManager as any).processes as Map<string, any>;
+				processes.set('sync-test', {
+					sessionId: 'sync-test',
+					toolType: 'terminal',
+					isTerminal: true,
+					pid: 1,
+					cwd: '/tmp',
+					startTime: Date.now(),
+					ptyProcess: {
+						pid: 1,
+						kill: vi.fn(),
+						onExit: vi.fn(),
+						onData: vi.fn(),
+						write: vi.fn(),
+						resize: vi.fn(),
+					},
+				});
+
+				processManager.killAll();
+
+				expect(killSpy).toHaveBeenCalledWith('sync-test', { sync: true });
+				killSpy.mockRestore();
 			});
 		});
 	});

--- a/src/main/app-lifecycle/quit-handler.ts
+++ b/src/main/app-lifecycle/quit-handler.ts
@@ -11,6 +11,7 @@ import { tunnelManager as tunnelManagerInstance } from '../tunnel-manager';
 import type { HistoryManager } from '../history-manager';
 import { isWebContentsAvailable } from '../utils/safe-send';
 import { deleteCliServerInfo } from '../../shared/cli-server-discovery';
+import { stopAllCueRuns } from '../cue/cue-executor';
 import { powerManager as powerManagerInstance } from '../power-manager';
 
 /**
@@ -226,6 +227,10 @@ export function createQuitHandler(deps: QuitHandlerDependencies): QuitHandler {
 				logger.error(`Error cleaning up grooming sessions: ${err}`, 'Shutdown');
 			});
 		}
+
+		// Kill all active Cue processes (tracked separately from ProcessManager)
+		logger.info('Killing active Cue processes', 'Shutdown');
+		stopAllCueRuns();
 
 		// Clean up all running processes
 		logger.info('Killing all running processes', 'Shutdown');

--- a/src/main/cue/cue-executor.ts
+++ b/src/main/cue/cue-executor.ts
@@ -20,6 +20,7 @@ import type { SshRemoteSettingsStore } from '../utils/ssh-remote-resolver';
 import {
 	runProcess,
 	stopProcess,
+	stopAllProcesses,
 	getActiveProcessMap,
 	getProcessList,
 } from './cue-process-lifecycle';
@@ -146,6 +147,14 @@ export async function executeCuePrompt(config: CueExecutionConfig): Promise<CueR
  */
 export function stopCueRun(runId: string): boolean {
 	return stopProcess(runId);
+}
+
+/**
+ * Stop all active Cue processes. Called during application shutdown to prevent
+ * orphaned processes surviving after the main Electron process exits.
+ */
+export function stopAllCueRuns(): void {
+	stopAllProcesses();
 }
 
 /**

--- a/src/main/cue/cue-process-lifecycle.ts
+++ b/src/main/cue/cue-process-lifecycle.ts
@@ -100,8 +100,16 @@ function extractCleanStdout(rawStdout: string, toolType: string): string {
  */
 function killCueProcess(child: ChildProcess): void {
 	if (isWindows() && child.pid) {
-		execFile('taskkill', ['/pid', String(child.pid), '/t', '/f'], () => {
-			// taskkill returns non-zero if the process is already dead, which is fine
+		execFile('taskkill', ['/pid', String(child.pid), '/t', '/f'], (error) => {
+			if (!error) return;
+			const msg = error.message.toLowerCase();
+			const alreadyStopped = msg.includes('not found') || msg.includes('no running instance');
+			if (alreadyStopped) return;
+
+			captureException(error, {
+				operation: 'cue:taskkill',
+				pid: child.pid,
+			});
 		});
 	} else {
 		child.kill('SIGTERM');

--- a/src/main/cue/cue-process-lifecycle.ts
+++ b/src/main/cue/cue-process-lifecycle.ts
@@ -8,7 +8,7 @@
  * it receives a fully resolved SpawnSpec and executes it.
  */
 
-import { spawn, execFile, type ChildProcess } from 'child_process';
+import { spawn, execFile, execFileSync, type ChildProcess } from 'child_process';
 import type { CueRunStatus } from './cue-types';
 import type { SpawnSpec } from './cue-spawn-builder';
 import type { ToolType } from '../../shared/types';
@@ -98,19 +98,31 @@ function extractCleanStdout(rawStdout: string, toolType: string): string {
  * Kill a Cue child process, using taskkill on Windows to terminate the entire
  * process tree (POSIX signals don't work for shell-spawned processes on Windows).
  */
-function killCueProcess(child: ChildProcess): void {
+function killCueProcess(child: ChildProcess, sync = false): void {
 	if (isWindows() && child.pid) {
-		execFile('taskkill', ['/pid', String(child.pid), '/t', '/f'], (error) => {
-			if (!error) return;
-			const msg = error.message.toLowerCase();
-			const alreadyStopped = msg.includes('not found') || msg.includes('no running instance');
-			if (alreadyStopped) return;
+		if (sync) {
+			// During shutdown, block until taskkill completes so the process tree
+			// is actually dead before Electron exits.
+			try {
+				execFileSync('taskkill', ['/pid', String(child.pid), '/t', '/f'], {
+					timeout: 5000,
+				});
+			} catch {
+				// taskkill returns non-zero if the process is already dead, which is fine
+			}
+		} else {
+			execFile('taskkill', ['/pid', String(child.pid), '/t', '/f'], (error) => {
+				if (!error) return;
+				const msg = error.message.toLowerCase();
+				const alreadyStopped = msg.includes('not found') || msg.includes('no running instance');
+				if (alreadyStopped) return;
 
-			captureException(error, {
-				operation: 'cue:taskkill',
-				pid: child.pid,
+				captureException(error, {
+					operation: 'cue:taskkill',
+					pid: child.pid,
+				});
 			});
-		});
+		}
 	} else {
 		child.kill('SIGTERM');
 
@@ -266,7 +278,8 @@ export function stopProcess(runId: string): boolean {
  */
 export function stopAllProcesses(): void {
 	for (const [runId, entry] of activeProcesses) {
-		killCueProcess(entry.child);
+		// Use sync kills so process trees are dead before the app exits.
+		killCueProcess(entry.child, true);
 		activeProcesses.delete(runId);
 	}
 }

--- a/src/main/cue/cue-process-lifecycle.ts
+++ b/src/main/cue/cue-process-lifecycle.ts
@@ -8,12 +8,13 @@
  * it receives a fully resolved SpawnSpec and executes it.
  */
 
-import { spawn, type ChildProcess } from 'child_process';
+import { spawn, execFile, type ChildProcess } from 'child_process';
 import type { CueRunStatus } from './cue-types';
 import type { SpawnSpec } from './cue-spawn-builder';
 import type { ToolType } from '../../shared/types';
 import { getOutputParser } from '../parsers';
 import { captureException } from '../utils/sentry';
+import { isWindows } from '../../shared/platformDetection';
 
 const SIGKILL_DELAY_MS = 5000;
 
@@ -93,6 +94,27 @@ function extractCleanStdout(rawStdout: string, toolType: string): string {
 	return textParts.length > 0 ? textParts.join('\n') : rawStdout;
 }
 
+/**
+ * Kill a Cue child process, using taskkill on Windows to terminate the entire
+ * process tree (POSIX signals don't work for shell-spawned processes on Windows).
+ */
+function killCueProcess(child: ChildProcess): void {
+	if (isWindows() && child.pid) {
+		execFile('taskkill', ['/pid', String(child.pid), '/t', '/f'], () => {
+			// taskkill returns non-zero if the process is already dead, which is fine
+		});
+	} else {
+		child.kill('SIGTERM');
+
+		// Escalate to SIGKILL after delay — only if the process hasn't actually exited.
+		setTimeout(() => {
+			if (child.exitCode === null && child.signalCode === null) {
+				child.kill('SIGKILL');
+			}
+		}, SIGKILL_DELAY_MS);
+	}
+}
+
 // ─── Public API ─────────────���─────────────────────────���──────────────────────
 
 /**
@@ -140,7 +162,6 @@ export function runProcess(
 		let stderr = '';
 		let settled = false;
 		let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
-		let killTimer: ReturnType<typeof setTimeout> | undefined;
 
 		const finish = (status: CueRunStatus, exitCode: number | null) => {
 			if (settled) return;
@@ -148,7 +169,6 @@ export function runProcess(
 
 			activeProcesses.delete(runId);
 			if (timeoutTimer) clearTimeout(timeoutTimer);
-			if (killTimer) clearTimeout(killTimer);
 
 			resolve({
 				stdout: extractCleanStdout(stdout, toolType),
@@ -201,21 +221,14 @@ export function runProcess(
 			child.stdin?.end();
 		}
 
-		// Enforce timeout with SIGTERM → SIGKILL escalation
+		// Enforce timeout — use platform-appropriate kill
 		if (timeoutMs > 0) {
 			timeoutTimer = setTimeout(() => {
 				if (settled) return;
-				onLog('cue', `[CUE] Run ${runId} timed out after ${timeoutMs}ms, sending SIGTERM`);
-				child.kill('SIGTERM');
+				onLog('cue', `[CUE] Run ${runId} timed out after ${timeoutMs}ms, killing process`);
+				killCueProcess(child);
 
-				// Escalate to SIGKILL after delay
-				killTimer = setTimeout(() => {
-					if (settled) return;
-					onLog('cue', `[CUE] Run ${runId} still alive, sending SIGKILL`);
-					child.kill('SIGKILL');
-				}, SIGKILL_DELAY_MS);
-
-				// If the process exits after SIGTERM, mark as timeout
+				// If the process exits after kill, mark as timeout
 				child.removeAllListeners('close');
 				child.on('close', (code) => {
 					finish('timeout', code);
@@ -227,7 +240,7 @@ export function runProcess(
 
 /**
  * Stop a running Cue process by runId.
- * Sends SIGTERM, then SIGKILL after 5 seconds.
+ * On Windows uses taskkill /t /f; on POSIX sends SIGTERM then SIGKILL after 5s.
  *
  * @returns true if the process was found and signaled, false if not found
  */
@@ -235,16 +248,19 @@ export function stopProcess(runId: string): boolean {
 	const entry = activeProcesses.get(runId);
 	if (!entry) return false;
 
-	entry.child.kill('SIGTERM');
-
-	// Escalate to SIGKILL after delay — only if the process hasn't actually exited.
-	setTimeout(() => {
-		if (entry.child.exitCode === null && entry.child.signalCode === null) {
-			entry.child.kill('SIGKILL');
-		}
-	}, SIGKILL_DELAY_MS);
-
+	killCueProcess(entry.child);
 	return true;
+}
+
+/**
+ * Stop all active Cue processes. Called during application shutdown to prevent
+ * orphaned processes surviving after the main Electron process exits.
+ */
+export function stopAllProcesses(): void {
+	for (const [runId, entry] of activeProcesses) {
+		killCueProcess(entry.child);
+		activeProcesses.delete(runId);
+	}
 }
 
 /**

--- a/src/main/process-manager/ProcessManager.ts
+++ b/src/main/process-manager/ProcessManager.ts
@@ -1,7 +1,7 @@
 // src/main/process-manager/ProcessManager.ts
 
 import { EventEmitter } from 'events';
-import { execFile } from 'child_process';
+import { execFile, execFileSync } from 'child_process';
 import type {
 	ProcessConfig,
 	ManagedProcess,
@@ -218,7 +218,7 @@ export class ProcessManager extends EventEmitter {
 	 * the tracking map immediately so that a replacement can be spawned, but the
 	 * escalation timer keeps a reference to ensure the OS-level process dies.
 	 */
-	kill(sessionId: string): boolean {
+	kill(sessionId: string, { sync = false }: { sync?: boolean } = {}): boolean {
 		const proc = this.processes.get(sessionId);
 		if (!proc) return false;
 
@@ -233,7 +233,7 @@ export class ProcessManager extends EventEmitter {
 					// On Windows, node-pty's kill() only terminates the direct ConPTY
 					// child (the shell), not grandchild processes it spawned (e.g., dev
 					// servers, watchers). Use taskkill /t /f to kill the entire tree.
-					this.killWindowsProcessTree(proc.pid, sessionId);
+					this.killWindowsProcessTree(proc.pid, sessionId, sync);
 				} else {
 					const ptyProc = proc.ptyProcess;
 					const pid = proc.pid;
@@ -267,7 +267,7 @@ export class ProcessManager extends EventEmitter {
 			} else if (proc.childProcess) {
 				const pid = proc.childProcess.pid;
 				if (isWindows() && pid) {
-					this.killWindowsProcessTree(pid, sessionId);
+					this.killWindowsProcessTree(pid, sessionId, sync);
 				} else if (isWindows()) {
 					logger.warn(
 						'[ProcessManager] pid unavailable for Windows taskkill, falling back to SIGTERM',
@@ -295,22 +295,34 @@ export class ProcessManager extends EventEmitter {
 	 * This is necessary because POSIX signals (SIGINT/SIGTERM) don't reliably
 	 * terminate shell-spawned processes on Windows.
 	 */
-	private killWindowsProcessTree(pid: number, sessionId: string): void {
+	private killWindowsProcessTree(pid: number, sessionId: string, sync = false): void {
 		logger.info(
 			'[ProcessManager] Using taskkill to terminate process tree on Windows',
 			'ProcessManager',
-			{ sessionId, pid }
+			{ sessionId, pid, sync }
 		);
-		execFile('taskkill', ['/pid', String(pid), '/t', '/f'], (error) => {
-			if (error) {
+		if (sync) {
+			// During shutdown, block until taskkill completes so the process tree
+			// is actually dead before Electron exits.
+			try {
+				execFileSync('taskkill', ['/pid', String(pid), '/t', '/f'], {
+					timeout: 5000,
+				});
+			} catch {
 				// taskkill returns non-zero if the process is already dead, which is fine
-				logger.debug(
-					'[ProcessManager] taskkill exited with error (process may already be terminated)',
-					'ProcessManager',
-					{ sessionId, pid, error: String(error) }
-				);
 			}
-		});
+		} else {
+			execFile('taskkill', ['/pid', String(pid), '/t', '/f'], (error) => {
+				if (error) {
+					// taskkill returns non-zero if the process is already dead, which is fine
+					logger.debug(
+						'[ProcessManager] taskkill exited with error (process may already be terminated)',
+						'ProcessManager',
+						{ sessionId, pid, error: String(error) }
+					);
+				}
+			});
+		}
 	}
 
 	/**
@@ -320,7 +332,10 @@ export class ProcessManager extends EventEmitter {
 	killAll(): void {
 		const sessionIds = [...this.processes.keys()];
 		for (const sessionId of sessionIds) {
-			this.kill(sessionId);
+			// Use sync kills so process trees are dead before the app exits.
+			// On Windows this blocks briefly per process (taskkill is fast),
+			// on POSIX this has no effect (SIGTERM is already non-blocking).
+			this.kill(sessionId, { sync: true });
 		}
 	}
 

--- a/src/main/tunnel-manager.ts
+++ b/src/main/tunnel-manager.ts
@@ -1,4 +1,4 @@
-import { ChildProcess, spawn, execFile } from 'child_process';
+import { ChildProcess, spawn, execFileSync } from 'child_process';
 import { logger } from './utils/logger';
 import { getCloudflaredPath, isCloudflaredInstalled } from './utils/cliDetection';
 import { isWindows } from '../shared/platformDetection';
@@ -115,10 +115,15 @@ class TunnelManager {
 
 			if (isWindows() && proc.pid) {
 				// On Windows, POSIX signals don't terminate process trees.
-				// Use taskkill /t /f to kill the cloudflared process and its children.
-				execFile('taskkill', ['/pid', String(proc.pid), '/t', '/f'], () => {
+				// Use taskkill /t /f synchronously to ensure the process tree is
+				// dead before the app exits (stop() is called during shutdown).
+				try {
+					execFileSync('taskkill', ['/pid', String(proc.pid), '/t', '/f'], {
+						timeout: 5000,
+					});
+				} catch {
 					// taskkill returns non-zero if the process is already dead, which is fine
-				});
+				}
 			} else {
 				proc.kill('SIGTERM');
 			}

--- a/src/main/tunnel-manager.ts
+++ b/src/main/tunnel-manager.ts
@@ -1,6 +1,7 @@
-import { ChildProcess, spawn } from 'child_process';
+import { ChildProcess, spawn, execFile } from 'child_process';
 import { logger } from './utils/logger';
 import { getCloudflaredPath, isCloudflaredInstalled } from './utils/cliDetection';
+import { isWindows } from '../shared/platformDetection';
 
 export interface TunnelStatus {
 	isRunning: boolean;
@@ -111,16 +112,27 @@ class TunnelManager {
 			logger.info('Stopping tunnel', 'TunnelManager');
 			this.stopping = true;
 			const proc = this.process;
-			proc.kill('SIGTERM');
+
+			if (isWindows() && proc.pid) {
+				// On Windows, POSIX signals don't terminate process trees.
+				// Use taskkill /t /f to kill the cloudflared process and its children.
+				execFile('taskkill', ['/pid', String(proc.pid), '/t', '/f'], () => {
+					// taskkill returns non-zero if the process is already dead, which is fine
+				});
+			} else {
+				proc.kill('SIGTERM');
+			}
 
 			// Wait for process to exit with timeout
 			await new Promise<void>((resolve) => {
 				const timeout = setTimeout(() => {
-					// Force kill if SIGTERM didn't work
-					try {
-						proc.kill('SIGKILL');
-					} catch {
-						// Process may already be dead
+					// Force kill if SIGTERM didn't work (POSIX only; Windows already used taskkill)
+					if (!isWindows()) {
+						try {
+							proc.kill('SIGKILL');
+						} catch {
+							// Process may already be dead
+						}
 					}
 					resolve();
 				}, 3000);


### PR DESCRIPTION
## Summary
- **Cue processes survive shutdown**: `performCleanup()` calls `processManager.killAll()` but Cue processes are tracked separately in `cue-executor.ts`'s `activeProcesses` map — they were never killed on quit. Added `stopAllCueRuns()` and call it during shutdown.
- **Cue executor uses SIGTERM/SIGKILL on Windows**: `stopCueRun()` and timeout enforcement sent POSIX signals which don't terminate process trees on Windows. Added `killCueProcess()` helper that uses `taskkill /t /f` on Windows.
- **Tunnel manager uses SIGTERM/SIGKILL on Windows**: `TunnelManager.stop()` sent POSIX signals. Now uses `taskkill /t /f` on Windows for the `cloudflared` process tree.

## Changes
| File | Change |
|------|--------|
| `src/main/cue/cue-executor.ts` | Added `killCueProcess()` (Windows: taskkill, POSIX: SIGTERM→SIGKILL), `stopAllCueRuns()` export, refactored `stopCueRun()` and timeout to use it |
| `src/main/tunnel-manager.ts` | `stop()` now uses `taskkill /t /f` on Windows instead of SIGTERM/SIGKILL |
| `src/main/app-lifecycle/quit-handler.ts` | `performCleanup()` now calls `stopAllCueRuns()` before `killAll()` |

## Test plan
- [x] TypeScript type check passes
- [x] All 48 cue-executor tests pass
- [x] All 21 tunnel-manager tests pass
- [x] All 21 quit-handler tests pass
- [x] Prettier formatting clean
- [ ] Manual: verify on Windows that closing Maestro with active Cue runs leaves no orphaned processes in Task Manager

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Shutdown now reliably stops all active background runs before killing remaining processes and uses platform-aware termination to avoid lingering processes on Windows and POSIX.
  * Bulk termination now ensures Windows process trees are synchronously terminated during shutdown.

* **Tests**
  * Updated lifecycle and process tests to verify background runs are stopped prior to general process-kill steps and to validate termination ordering and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->