### PR TITLE
refactor(cue): decompose executor into SRP modules and fix run manager race conditions

### DIFF
--- a/src/__tests__/main/cue/cue-process-lifecycle.test.ts
+++ b/src/__tests__/main/cue/cue-process-lifecycle.test.ts
@@ -1,0 +1,454 @@
+/**
+ * Tests for the Cue Process Lifecycle module.
+ *
+ * Verifies process spawning, stdio capture, timeout enforcement with
+ * SIGTERM → SIGKILL escalation, active process tracking, and stop logic.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'events';
+import type { ChildProcess } from 'child_process';
+import type { SpawnSpec } from '../../../main/cue/cue-spawn-builder';
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+
+// Mock parsers — default returns null (no parser)
+const mockGetOutputParser = vi.fn(() => null as any);
+vi.mock('../../../main/parsers', () => ({
+	getOutputParser: (...args: unknown[]) => mockGetOutputParser(...args),
+}));
+
+// Mock child_process.spawn
+class MockChildProcess extends EventEmitter {
+	pid = 12345;
+	exitCode: number | null = null;
+	signalCode: string | null = null;
+	stdin = {
+		write: vi.fn(),
+		end: vi.fn(),
+	};
+	stdout = new EventEmitter();
+	stderr = new EventEmitter();
+	killed = false;
+
+	kill(signal?: string) {
+		this.killed = true;
+		return true;
+	}
+
+	constructor() {
+		super();
+		(this.stdout as any).setEncoding = vi.fn();
+		(this.stderr as any).setEncoding = vi.fn();
+	}
+}
+
+let mockChild: MockChildProcess;
+const mockSpawn = vi.fn(() => {
+	mockChild = new MockChildProcess();
+	return mockChild as unknown as ChildProcess;
+});
+
+vi.mock('child_process', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('child_process')>();
+	return {
+		...actual,
+		spawn: (...args: unknown[]) => mockSpawn(...args),
+		default: {
+			...actual,
+			spawn: (...args: unknown[]) => mockSpawn(...args),
+		},
+	};
+});
+
+// Must import after mocks
+import {
+	runProcess,
+	stopProcess,
+	getActiveProcessMap,
+	getProcessList,
+} from '../../../main/cue/cue-process-lifecycle';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function createSpec(overrides: Partial<SpawnSpec> = {}): SpawnSpec {
+	return {
+		command: 'claude',
+		args: ['--print', '--', 'test prompt'],
+		cwd: '/projects/test',
+		env: { PATH: '/usr/bin' },
+		...overrides,
+	};
+}
+
+function createOptions(overrides = {}) {
+	return {
+		toolType: 'claude-code',
+		timeoutMs: 30000,
+		onLog: vi.fn(),
+		...overrides,
+	};
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('cue-process-lifecycle', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.useFakeTimers();
+		getActiveProcessMap().clear();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	describe('runProcess', () => {
+		it('spawns process with correct command, args, and cwd', async () => {
+			const spec = createSpec();
+			const resultPromise = runProcess('run-1', spec, createOptions());
+			await vi.advanceTimersByTimeAsync(0);
+
+			expect(mockSpawn).toHaveBeenCalledWith(
+				'claude',
+				['--print', '--', 'test prompt'],
+				expect.objectContaining({
+					cwd: '/projects/test',
+					stdio: ['pipe', 'pipe', 'pipe'],
+				})
+			);
+
+			mockChild.emit('close', 0);
+			await resultPromise;
+		});
+
+		it('captures stdout and returns it in result', async () => {
+			const resultPromise = runProcess('run-1', createSpec(), createOptions());
+			await vi.advanceTimersByTimeAsync(0);
+
+			mockChild.stdout.emit('data', 'Hello ');
+			mockChild.stdout.emit('data', 'world');
+			mockChild.emit('close', 0);
+
+			const result = await resultPromise;
+			expect(result.stdout).toBe('Hello world');
+		});
+
+		it('captures stderr and returns it in result', async () => {
+			const resultPromise = runProcess('run-1', createSpec(), createOptions());
+			await vi.advanceTimersByTimeAsync(0);
+
+			mockChild.stderr.emit('data', 'Warning: something');
+			mockChild.emit('close', 0);
+
+			const result = await resultPromise;
+			expect(result.stderr).toBe('Warning: something');
+		});
+
+		it('returns completed status on exit code 0', async () => {
+			const resultPromise = runProcess('run-1', createSpec(), createOptions());
+			await vi.advanceTimersByTimeAsync(0);
+
+			mockChild.emit('close', 0);
+			const result = await resultPromise;
+
+			expect(result.status).toBe('completed');
+			expect(result.exitCode).toBe(0);
+		});
+
+		it('returns failed status on non-zero exit code', async () => {
+			const resultPromise = runProcess('run-1', createSpec(), createOptions());
+			await vi.advanceTimersByTimeAsync(0);
+
+			mockChild.emit('close', 1);
+			const result = await resultPromise;
+
+			expect(result.status).toBe('failed');
+			expect(result.exitCode).toBe(1);
+		});
+
+		it('handles spawn errors gracefully', async () => {
+			const resultPromise = runProcess('run-1', createSpec(), createOptions());
+			await vi.advanceTimersByTimeAsync(0);
+
+			mockChild.emit('error', new Error('spawn ENOENT'));
+			const result = await resultPromise;
+
+			expect(result.status).toBe('failed');
+			expect(result.stderr).toContain('Spawn error: spawn ENOENT');
+			expect(result.exitCode).toBeNull();
+		});
+
+		it('tracks the process in activeProcesses while running', async () => {
+			const resultPromise = runProcess('tracked-run', createSpec(), createOptions());
+			await vi.advanceTimersByTimeAsync(0);
+
+			expect(getActiveProcessMap().has('tracked-run')).toBe(true);
+
+			mockChild.emit('close', 0);
+			await resultPromise;
+
+			expect(getActiveProcessMap().has('tracked-run')).toBe(false);
+		});
+
+		it('closes stdin for local execution', async () => {
+			const resultPromise = runProcess('run-1', createSpec(), createOptions());
+			await vi.advanceTimersByTimeAsync(0);
+
+			expect(mockChild.stdin.end).toHaveBeenCalled();
+
+			mockChild.emit('close', 0);
+			await resultPromise;
+		});
+
+		describe('stdin modes', () => {
+			it('writes sshStdinScript to stdin for SSH stdin-script mode', async () => {
+				const spec = createSpec({ sshStdinScript: '#!/bin/bash\nclaude "prompt"' });
+				const resultPromise = runProcess(
+					'run-1',
+					spec,
+					createOptions({
+						sshRemoteEnabled: true,
+						sshStdinScript: '#!/bin/bash\nclaude "prompt"',
+					})
+				);
+				await vi.advanceTimersByTimeAsync(0);
+
+				expect(mockChild.stdin.write).toHaveBeenCalledWith('#!/bin/bash\nclaude "prompt"');
+				expect(mockChild.stdin.end).toHaveBeenCalled();
+
+				mockChild.emit('close', 0);
+				await resultPromise;
+			});
+
+			it('writes stdinPrompt to stdin for SSH prompt mode', async () => {
+				const spec = createSpec({ stdinPrompt: 'large prompt' });
+				const resultPromise = runProcess(
+					'run-1',
+					spec,
+					createOptions({
+						sshRemoteEnabled: true,
+						stdinPrompt: 'large prompt',
+					})
+				);
+				await vi.advanceTimersByTimeAsync(0);
+
+				expect(mockChild.stdin.write).toHaveBeenCalledWith('large prompt');
+				expect(mockChild.stdin.end).toHaveBeenCalled();
+
+				mockChild.emit('close', 0);
+				await resultPromise;
+			});
+		});
+
+		describe('timeout enforcement', () => {
+			it('sends SIGTERM when timeout expires', async () => {
+				const resultPromise = runProcess('run-1', createSpec(), createOptions({ timeoutMs: 5000 }));
+				await vi.advanceTimersByTimeAsync(0);
+
+				const childKill = vi.spyOn(mockChild, 'kill');
+
+				await vi.advanceTimersByTimeAsync(5000);
+				expect(childKill).toHaveBeenCalledWith('SIGTERM');
+
+				mockChild.emit('close', null);
+				const result = await resultPromise;
+				expect(result.status).toBe('timeout');
+			});
+
+			it('escalates to SIGKILL after SIGTERM + delay', async () => {
+				const resultPromise = runProcess('run-1', createSpec(), createOptions({ timeoutMs: 5000 }));
+				await vi.advanceTimersByTimeAsync(0);
+
+				const childKill = vi.spyOn(mockChild, 'kill');
+
+				await vi.advanceTimersByTimeAsync(5000);
+				expect(childKill).toHaveBeenCalledWith('SIGTERM');
+
+				mockChild.killed = false;
+				await vi.advanceTimersByTimeAsync(5000);
+				expect(childKill).toHaveBeenCalledWith('SIGKILL');
+
+				mockChild.emit('close', null);
+				await resultPromise;
+			});
+
+			it('does not timeout when timeoutMs is 0', async () => {
+				const resultPromise = runProcess('run-1', createSpec(), createOptions({ timeoutMs: 0 }));
+				await vi.advanceTimersByTimeAsync(0);
+
+				const childKill = vi.spyOn(mockChild, 'kill');
+
+				await vi.advanceTimersByTimeAsync(60000);
+				expect(childKill).not.toHaveBeenCalled();
+
+				mockChild.emit('close', 0);
+				await resultPromise;
+			});
+
+			it('logs timeout messages', async () => {
+				const onLog = vi.fn();
+				const resultPromise = runProcess(
+					'run-1',
+					createSpec(),
+					createOptions({
+						timeoutMs: 5000,
+						onLog,
+					})
+				);
+				await vi.advanceTimersByTimeAsync(0);
+
+				await vi.advanceTimersByTimeAsync(5000);
+
+				expect(onLog).toHaveBeenCalledWith('cue', expect.stringContaining('timed out'));
+
+				mockChild.emit('close', null);
+				await resultPromise;
+			});
+		});
+
+		describe('output parsing', () => {
+			it('returns raw stdout when no parser is registered', async () => {
+				mockGetOutputParser.mockReturnValue(null);
+
+				const resultPromise = runProcess('run-1', createSpec(), createOptions());
+				await vi.advanceTimersByTimeAsync(0);
+
+				mockChild.stdout.emit('data', 'plain text output\n');
+				mockChild.emit('close', 0);
+				const result = await resultPromise;
+
+				expect(result.stdout).toBe('plain text output\n');
+			});
+
+			it('extracts result-event text when parser is available', async () => {
+				mockGetOutputParser.mockReturnValue({
+					parseJsonLine: (line: string) => {
+						try {
+							const msg = JSON.parse(line);
+							if (msg.type === 'text') {
+								return { type: 'result', text: msg.part?.text || '' };
+							}
+							return { type: 'system', raw: msg };
+						} catch {
+							return { type: 'text', text: line };
+						}
+					},
+				} as any);
+
+				const ndjson = JSON.stringify({ type: 'text', part: { text: 'Parsed output' } });
+
+				const resultPromise = runProcess(
+					'run-1',
+					createSpec(),
+					createOptions({ toolType: 'opencode' })
+				);
+				await vi.advanceTimersByTimeAsync(0);
+
+				mockChild.stdout.emit('data', ndjson);
+				mockChild.emit('close', 0);
+				const result = await resultPromise;
+
+				expect(result.stdout).toBe('Parsed output');
+			});
+		});
+	});
+
+	describe('stopProcess', () => {
+		it('returns false for unknown runId', () => {
+			expect(stopProcess('nonexistent')).toBe(false);
+		});
+
+		it('sends SIGTERM to a running process', async () => {
+			const resultPromise = runProcess('stop-test', createSpec(), createOptions());
+			await vi.advanceTimersByTimeAsync(0);
+
+			const childKill = vi.spyOn(mockChild, 'kill');
+
+			const stopped = stopProcess('stop-test');
+			expect(stopped).toBe(true);
+			expect(childKill).toHaveBeenCalledWith('SIGTERM');
+
+			mockChild.emit('close', null);
+			await resultPromise;
+		});
+
+		it('escalates to SIGKILL after delay if process survives SIGTERM', async () => {
+			const resultPromise = runProcess('stop-test', createSpec(), createOptions());
+			await vi.advanceTimersByTimeAsync(0);
+
+			const childKill = vi.spyOn(mockChild, 'kill');
+
+			stopProcess('stop-test');
+			expect(childKill).toHaveBeenCalledWith('SIGTERM');
+
+			// Process hasn't exited — SIGKILL should fire after delay
+			await vi.advanceTimersByTimeAsync(5000);
+			expect(childKill).toHaveBeenCalledWith('SIGKILL');
+
+			mockChild.emit('close', null);
+			await resultPromise;
+		});
+	});
+
+	describe('getProcessList', () => {
+		it('returns empty array when no active processes', () => {
+			expect(getProcessList()).toEqual([]);
+		});
+
+		it('returns process info during active run', async () => {
+			const resultPromise = runProcess('list-test', createSpec(), createOptions());
+			await vi.advanceTimersByTimeAsync(0);
+
+			const list = getProcessList();
+			expect(list).toHaveLength(1);
+			expect(list[0].runId).toBe('list-test');
+			expect(list[0].pid).toBe(12345);
+			expect(list[0].toolType).toBe('claude-code');
+			expect(list[0].cwd).toBe('/projects/test');
+			expect(list[0].command).toBe('claude');
+			expect(Array.isArray(list[0].args)).toBe(true);
+			expect(typeof list[0].startTime).toBe('number');
+
+			mockChild.emit('close', 0);
+			await resultPromise;
+		});
+
+		it('excludes completed processes', async () => {
+			const resultPromise = runProcess('completed-run', createSpec(), createOptions());
+			await vi.advanceTimersByTimeAsync(0);
+
+			expect(getProcessList().some((p) => p.runId === 'completed-run')).toBe(true);
+
+			mockChild.emit('close', 0);
+			await resultPromise;
+
+			expect(getProcessList().some((p) => p.runId === 'completed-run')).toBe(false);
+		});
+	});
+
+	describe('settled guard', () => {
+		it('ignores duplicate close events', async () => {
+			const resultPromise = runProcess('run-1', createSpec(), createOptions());
+			await vi.advanceTimersByTimeAsync(0);
+
+			mockChild.emit('close', 0);
+			mockChild.emit('close', 1); // duplicate — should be ignored
+			const result = await resultPromise;
+
+			expect(result.status).toBe('completed');
+			expect(result.exitCode).toBe(0);
+		});
+
+		it('ignores error after close', async () => {
+			const resultPromise = runProcess('run-1', createSpec(), createOptions());
+			await vi.advanceTimersByTimeAsync(0);
+
+			mockChild.emit('close', 0);
+			mockChild.emit('error', new Error('late error')); // should be ignored
+			const result = await resultPromise;
+
+			expect(result.status).toBe('completed');
+		});
+	});
+});

--- a/src/__tests__/main/cue/cue-process-lifecycle.test.ts
+++ b/src/__tests__/main/cue/cue-process-lifecycle.test.ts
@@ -18,6 +18,12 @@ vi.mock('../../../main/parsers', () => ({
 	getOutputParser: (...args: unknown[]) => mockGetOutputParser(...args),
 }));
 
+// Mock Sentry
+const mockCaptureException = vi.fn();
+vi.mock('../../../main/utils/sentry', () => ({
+	captureException: (...args: unknown[]) => mockCaptureException(...args),
+}));
+
 // Mock child_process.spawn
 class MockChildProcess extends EventEmitter {
 	pid = 12345;
@@ -424,6 +430,37 @@ describe('cue-process-lifecycle', () => {
 			await resultPromise;
 
 			expect(getProcessList().some((p) => p.runId === 'completed-run')).toBe(false);
+		});
+	});
+
+	describe('Sentry error reporting', () => {
+		it('reports synchronous spawn failure to Sentry', async () => {
+			mockSpawn.mockImplementationOnce(() => {
+				throw new Error('spawn EPERM');
+			});
+
+			const result = await runProcess('run-1', createSpec(), createOptions());
+
+			expect(result.status).toBe('failed');
+			expect(result.stderr).toContain('Spawn error: spawn EPERM');
+			expect(mockCaptureException).toHaveBeenCalledWith(
+				expect.objectContaining({ message: 'spawn EPERM' }),
+				expect.objectContaining({ operation: 'cue:spawn', runId: 'run-1' })
+			);
+		});
+
+		it('reports async child process error to Sentry', async () => {
+			const resultPromise = runProcess('run-1', createSpec(), createOptions());
+			await vi.advanceTimersByTimeAsync(0);
+
+			const spawnError = new Error('spawn ENOENT');
+			mockChild.emit('error', spawnError);
+			await resultPromise;
+
+			expect(mockCaptureException).toHaveBeenCalledWith(
+				spawnError,
+				expect.objectContaining({ operation: 'cue:childProcess:error', runId: 'run-1' })
+			);
 		});
 	});
 

--- a/src/__tests__/main/cue/cue-run-manager.test.ts
+++ b/src/__tests__/main/cue/cue-run-manager.test.ts
@@ -17,6 +17,11 @@ vi.mock('../../../main/cue/cue-db', () => ({
 	updateCueEventStatus: vi.fn(),
 }));
 
+const mockCaptureException = vi.fn();
+vi.mock('../../../main/utils/sentry', () => ({
+	captureException: (...args: unknown[]) => mockCaptureException(...args),
+}));
+
 let uuidCounter = 0;
 vi.mock('crypto', () => ({
 	randomUUID: vi.fn(() => `run-${++uuidCounter}`),
@@ -673,6 +678,97 @@ describe('createCueRunManager', () => {
 			manager.stopRun(runId);
 
 			expect(abortSpy).toHaveBeenCalled();
+		});
+	});
+
+	describe('output prompt process stop targeting', () => {
+		it('stopRun calls onStopCueRun with output prompt runId when in output phase', async () => {
+			let onCueRunCallCount = 0;
+			const deps = createDeps({
+				onCueRun: vi.fn(() => {
+					onCueRunCallCount++;
+					if (onCueRunCallCount === 1) {
+						return Promise.resolve(makeResult());
+					}
+					// Output prompt — never resolves
+					return new Promise<CueRunResult>(() => {});
+				}),
+			});
+			const manager = createCueRunManager(deps);
+
+			manager.execute('session-1', 'prompt', createEvent(), 'test-sub', 'output prompt');
+			await vi.advanceTimersByTimeAsync(0);
+
+			// Main task completed, output prompt is running
+			expect(deps.onCueRun).toHaveBeenCalledTimes(2);
+			const runId = [...manager.getActiveRunMap().keys()][0];
+
+			manager.stopRun(runId);
+
+			// Should have called onStopCueRun for both the parent and output process
+			expect(deps.onStopCueRun).toHaveBeenCalledTimes(2);
+			expect(deps.onStopCueRun).toHaveBeenCalledWith(runId);
+			// The output prompt's runId is the second UUID generated (run-2 is the parent, run-3 is the outputEvent id, run-4... let's check)
+			// UUIDs: run-1 = parent runId, run-2 = outputRunId, run-3 = outputEvent.id
+			// Actually: the parent run generates run-1 (runId), then outputRunId = run-2, outputEvent.id = run-3
+			const outputRunId = (deps.onStopCueRun as ReturnType<typeof vi.fn>).mock.calls[1][0];
+			expect(outputRunId).not.toBe(runId);
+		});
+
+		it('stopRun does not double-call onStopCueRun when not in output phase', () => {
+			const deps = createDeps({ onCueRun: vi.fn(() => new Promise(() => {})) });
+			const manager = createCueRunManager(deps);
+
+			manager.execute('session-1', 'prompt', createEvent(), 'test-sub');
+			const runId = manager.getActiveRuns()[0].runId;
+
+			manager.stopRun(runId);
+
+			// Only one call since no output prompt phase
+			expect(deps.onStopCueRun).toHaveBeenCalledTimes(1);
+			expect(deps.onStopCueRun).toHaveBeenCalledWith(runId);
+		});
+	});
+
+	describe('DB error Sentry reporting', () => {
+		it('reports updateCueEventStatus failure to Sentry on stop', () => {
+			const dbError = new Error('SQLITE_BUSY');
+			(updateCueEventStatus as ReturnType<typeof vi.fn>).mockImplementationOnce(() => {
+				throw dbError;
+			});
+			const deps = createDeps({ onCueRun: vi.fn(() => new Promise(() => {})) });
+			const manager = createCueRunManager(deps);
+
+			manager.execute('session-1', 'prompt', createEvent(), 'test-sub');
+			const runId = manager.getActiveRuns()[0].runId;
+
+			manager.stopRun(runId);
+
+			expect(mockCaptureException).toHaveBeenCalledWith(
+				dbError,
+				expect.objectContaining({ operation: 'cue:updateEventStatus', runId, status: 'stopped' })
+			);
+			expect(deps.onLog).toHaveBeenCalledWith(
+				'warn',
+				expect.stringContaining('Failed to update DB status')
+			);
+		});
+
+		it('reports updateCueEventStatus failure to Sentry on natural completion', async () => {
+			const dbError = new Error('SQLITE_CORRUPT');
+			(updateCueEventStatus as ReturnType<typeof vi.fn>).mockImplementationOnce(() => {
+				throw dbError;
+			});
+			const deps = createDeps();
+			const manager = createCueRunManager(deps);
+
+			manager.execute('session-1', 'prompt', createEvent(), 'test-sub');
+			await vi.advanceTimersByTimeAsync(0);
+
+			expect(mockCaptureException).toHaveBeenCalledWith(
+				dbError,
+				expect.objectContaining({ operation: 'cue:updateEventStatus', status: 'completed' })
+			);
 		});
 	});
 

--- a/src/__tests__/main/cue/cue-run-manager.test.ts
+++ b/src/__tests__/main/cue/cue-run-manager.test.ts
@@ -1,0 +1,714 @@
+/**
+ * Tests for the Cue Run Manager — direct unit tests for concurrency control,
+ * phase state machine, queue management, and run lifecycle.
+ *
+ * These tests exercise createCueRunManager() directly (not through CueEngine),
+ * giving fine-grained control over the run lifecycle and enabling targeted
+ * race-condition and state machine tests.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { CueEvent, CueRunResult, CueSettings } from '../../../main/cue/cue-types';
+
+// ─── Mocks ──────────────────────────────────────────���────────────────────────
+
+vi.mock('../../../main/cue/cue-db', () => ({
+	recordCueEvent: vi.fn(),
+	updateCueEventStatus: vi.fn(),
+}));
+
+let uuidCounter = 0;
+vi.mock('crypto', () => ({
+	randomUUID: vi.fn(() => `run-${++uuidCounter}`),
+}));
+
+import { updateCueEventStatus } from '../../../main/cue/cue-db';
+import {
+	createCueRunManager,
+	type CueRunManagerDeps,
+	type ActiveRun,
+} from '../../../main/cue/cue-run-manager';
+
+// ─── Helpers ─────────────────────────────────────���──────────────────────���────
+
+function createEvent(overrides: Partial<CueEvent> = {}): CueEvent {
+	return {
+		id: 'evt-1',
+		type: 'time.heartbeat',
+		timestamp: new Date().toISOString(),
+		triggerName: 'test',
+		payload: {},
+		...overrides,
+	};
+}
+
+function makeResult(overrides: Partial<CueRunResult> = {}): CueRunResult {
+	return {
+		runId: 'r1',
+		sessionId: 'session-1',
+		sessionName: 'Test Session',
+		subscriptionName: 'test-sub',
+		event: createEvent(),
+		status: 'completed',
+		stdout: 'output',
+		stderr: '',
+		exitCode: 0,
+		durationMs: 100,
+		startedAt: new Date().toISOString(),
+		endedAt: new Date().toISOString(),
+		...overrides,
+	};
+}
+
+const defaultSettings: CueSettings = {
+	timeout_minutes: 30,
+	timeout_on_fail: 'break',
+	max_concurrent: 1,
+	queue_size: 10,
+};
+
+function createDeps(overrides: Partial<CueRunManagerDeps> = {}): CueRunManagerDeps {
+	return {
+		getSessions: vi.fn(() => [{ id: 'session-1', name: 'Test Session' }]),
+		getSessionSettings: vi.fn(() => defaultSettings),
+		onCueRun: vi.fn(async () => makeResult()),
+		onStopCueRun: vi.fn(() => true),
+		onLog: vi.fn(),
+		onRunCompleted: vi.fn(),
+		onRunStopped: vi.fn(),
+		onPreventSleep: vi.fn(),
+		onAllowSleep: vi.fn(),
+		...overrides,
+	};
+}
+
+// ─── Tests ────────────────────��────────────────────────────────��─────────────
+
+describe('createCueRunManager', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.useFakeTimers();
+		uuidCounter = 0;
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	describe('phase state machine', () => {
+		it('creates run with phase "running"', () => {
+			const deps = createDeps({ onCueRun: vi.fn(() => new Promise(() => {})) });
+			const manager = createCueRunManager(deps);
+
+			manager.execute('session-1', 'prompt', createEvent(), 'test-sub');
+
+			const runMap = manager.getActiveRunMap();
+			const run = [...runMap.values()][0];
+			expect(run.phase).toBe('running');
+		});
+
+		it('stopRun transitions phase to "stopping" then removes from activeRuns', () => {
+			const deps = createDeps({ onCueRun: vi.fn(() => new Promise(() => {})) });
+			const manager = createCueRunManager(deps);
+
+			manager.execute('session-1', 'prompt', createEvent(), 'test-sub');
+			const runId = manager.getActiveRuns()[0].runId;
+
+			const stopped = manager.stopRun(runId);
+			expect(stopped).toBe(true);
+			// Run should be removed from activeRuns after stopRun
+			expect(manager.getActiveRunMap().has(runId)).toBe(false);
+		});
+
+		it('stopRun returns false for unknown runId', () => {
+			const manager = createCueRunManager(createDeps());
+			expect(manager.stopRun('nonexistent')).toBe(false);
+		});
+
+		it('double stopRun returns false on second call', () => {
+			const deps = createDeps({ onCueRun: vi.fn(() => new Promise(() => {})) });
+			const manager = createCueRunManager(deps);
+
+			manager.execute('session-1', 'prompt', createEvent(), 'test-sub');
+			const runId = manager.getActiveRuns()[0].runId;
+
+			expect(manager.stopRun(runId)).toBe(true);
+			expect(manager.stopRun(runId)).toBe(false);
+		});
+
+		it('natural completion transitions through finished phase', async () => {
+			const deps = createDeps();
+			const manager = createCueRunManager(deps);
+
+			manager.execute('session-1', 'prompt', createEvent(), 'test-sub');
+			await vi.advanceTimersByTimeAsync(0);
+
+			// After natural completion, run should be removed
+			expect(manager.getActiveRunMap().size).toBe(0);
+			expect(deps.onRunCompleted).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe('run lifecycle', () => {
+		it('calls onRunCompleted on successful completion', async () => {
+			const deps = createDeps();
+			const manager = createCueRunManager(deps);
+
+			manager.execute('session-1', 'prompt', createEvent(), 'test-sub');
+			await vi.advanceTimersByTimeAsync(0);
+
+			expect(deps.onRunCompleted).toHaveBeenCalledWith(
+				'session-1',
+				expect.objectContaining({ status: 'completed' }),
+				'test-sub',
+				undefined
+			);
+		});
+
+		it('calls onRunCompleted with failed status on failure', async () => {
+			const deps = createDeps({
+				onCueRun: vi.fn(async () => makeResult({ status: 'failed', exitCode: 1 })),
+			});
+			const manager = createCueRunManager(deps);
+
+			manager.execute('session-1', 'prompt', createEvent(), 'test-sub');
+			await vi.advanceTimersByTimeAsync(0);
+
+			expect(deps.onRunCompleted).toHaveBeenCalledWith(
+				'session-1',
+				expect.objectContaining({ status: 'failed' }),
+				'test-sub',
+				undefined
+			);
+		});
+
+		it('calls onRunCompleted with failed status on exception', async () => {
+			const deps = createDeps({
+				onCueRun: vi.fn(async () => {
+					throw new Error('spawn ENOENT');
+				}),
+			});
+			const manager = createCueRunManager(deps);
+
+			manager.execute('session-1', 'prompt', createEvent(), 'test-sub');
+			await vi.advanceTimersByTimeAsync(0);
+
+			expect(deps.onRunCompleted).toHaveBeenCalledWith(
+				'session-1',
+				expect.objectContaining({
+					status: 'failed',
+					stderr: 'spawn ENOENT',
+				}),
+				'test-sub',
+				undefined
+			);
+		});
+
+		it('calls onRunStopped on manual stop', () => {
+			const deps = createDeps({ onCueRun: vi.fn(() => new Promise(() => {})) });
+			const manager = createCueRunManager(deps);
+
+			manager.execute('session-1', 'prompt', createEvent(), 'test-sub');
+			const runId = manager.getActiveRuns()[0].runId;
+
+			manager.stopRun(runId);
+
+			expect(deps.onRunStopped).toHaveBeenCalledWith(
+				expect.objectContaining({ status: 'stopped', runId })
+			);
+			// onRunCompleted should NOT be called for stopped runs
+			expect(deps.onRunCompleted).not.toHaveBeenCalled();
+		});
+
+		it('sets endedAt and durationMs on stop', () => {
+			const deps = createDeps({ onCueRun: vi.fn(() => new Promise(() => {})) });
+			const manager = createCueRunManager(deps);
+
+			manager.execute('session-1', 'prompt', createEvent(), 'test-sub');
+			const runId = manager.getActiveRuns()[0].runId;
+
+			manager.stopRun(runId);
+
+			const stoppedResult = (deps.onRunStopped as ReturnType<typeof vi.fn>).mock.calls[0][0];
+			expect(stoppedResult.endedAt).toBeTruthy();
+			expect(typeof stoppedResult.durationMs).toBe('number');
+		});
+
+		it('passes chainDepth through to onRunCompleted', async () => {
+			const deps = createDeps();
+			const manager = createCueRunManager(deps);
+
+			manager.execute('session-1', 'prompt', createEvent(), 'test-sub', undefined, 3);
+			await vi.advanceTimersByTimeAsync(0);
+
+			expect(deps.onRunCompleted).toHaveBeenCalledWith(
+				'session-1',
+				expect.anything(),
+				'test-sub',
+				3
+			);
+		});
+
+		it('cleans up from activeRuns after natural completion', async () => {
+			let resolveRun: ((val: CueRunResult) => void) | undefined;
+			const deps = createDeps({
+				onCueRun: vi.fn(
+					() =>
+						new Promise<CueRunResult>((resolve) => {
+							resolveRun = resolve;
+						})
+				),
+			});
+			const manager = createCueRunManager(deps);
+
+			manager.execute('session-1', 'prompt', createEvent(), 'test-sub');
+			expect(manager.getActiveRunMap().size).toBe(1);
+
+			resolveRun!(makeResult());
+			await vi.advanceTimersByTimeAsync(0);
+
+			expect(manager.getActiveRunMap().size).toBe(0);
+		});
+	});
+
+	describe('sleep prevention', () => {
+		it('calls onPreventSleep when run starts', () => {
+			const deps = createDeps({ onCueRun: vi.fn(() => new Promise(() => {})) });
+			const manager = createCueRunManager(deps);
+
+			manager.execute('session-1', 'prompt', createEvent(), 'test-sub');
+
+			expect(deps.onPreventSleep).toHaveBeenCalledWith('cue:run:run-1');
+		});
+
+		it('calls onAllowSleep on natural completion', async () => {
+			const deps = createDeps();
+			const manager = createCueRunManager(deps);
+
+			manager.execute('session-1', 'prompt', createEvent(), 'test-sub');
+			await vi.advanceTimersByTimeAsync(0);
+
+			expect(deps.onAllowSleep).toHaveBeenCalledWith('cue:run:run-1');
+		});
+
+		it('calls onAllowSleep eagerly on stop', () => {
+			const deps = createDeps({ onCueRun: vi.fn(() => new Promise(() => {})) });
+			const manager = createCueRunManager(deps);
+
+			manager.execute('session-1', 'prompt', createEvent(), 'test-sub');
+			const runId = manager.getActiveRuns()[0].runId;
+
+			manager.stopRun(runId);
+
+			expect(deps.onAllowSleep).toHaveBeenCalledWith(`cue:run:${runId}`);
+		});
+	});
+
+	describe('concurrency and queue management', () => {
+		it('frees concurrency slot on natural completion', async () => {
+			let resolveRun: ((val: CueRunResult) => void) | undefined;
+			const deps = createDeps({
+				onCueRun: vi.fn(
+					() =>
+						new Promise<CueRunResult>((resolve) => {
+							resolveRun = resolve;
+						})
+				),
+			});
+			const manager = createCueRunManager(deps);
+
+			// First run takes the slot
+			manager.execute('session-1', 'prompt', createEvent(), 'sub-1');
+
+			// Second run should be queued
+			manager.execute('session-1', 'prompt', createEvent(), 'sub-2');
+			expect(manager.getQueueStatus().get('session-1')).toBe(1);
+			expect(deps.onCueRun).toHaveBeenCalledTimes(1);
+
+			// Complete first run -> queue should drain
+			resolveRun!(makeResult());
+			await vi.advanceTimersByTimeAsync(0);
+
+			expect(deps.onCueRun).toHaveBeenCalledTimes(2);
+			expect(manager.getQueueStatus().size).toBe(0);
+		});
+
+		it('frees concurrency slot eagerly on stop', () => {
+			const deps = createDeps({
+				onCueRun: vi.fn(() => new Promise(() => {})),
+			});
+			const manager = createCueRunManager(deps);
+
+			// First run takes the slot
+			manager.execute('session-1', 'prompt', createEvent(), 'sub-1');
+
+			// Second run should be queued
+			manager.execute('session-1', 'prompt', createEvent(), 'sub-2');
+			expect(deps.onCueRun).toHaveBeenCalledTimes(1);
+
+			// Stop first run -> slot freed, queue drains immediately
+			const runId = manager.getActiveRuns()[0].runId;
+			manager.stopRun(runId);
+
+			expect(deps.onCueRun).toHaveBeenCalledTimes(2);
+			expect(manager.getQueueStatus().size).toBe(0);
+		});
+
+		it('does not double-decrement count when stop followed by finally', async () => {
+			let resolveRun: ((val: CueRunResult) => void) | undefined;
+			const deps = createDeps({
+				getSessionSettings: vi.fn(() => ({ ...defaultSettings, max_concurrent: 2 })),
+				onCueRun: vi.fn(
+					() =>
+						new Promise<CueRunResult>((resolve) => {
+							resolveRun = resolve;
+						})
+				),
+			});
+			const manager = createCueRunManager(deps);
+
+			// Start two runs (both fit in max_concurrent=2)
+			manager.execute('session-1', 'prompt', createEvent(), 'sub-1');
+			manager.execute('session-1', 'prompt', createEvent(), 'sub-2');
+			expect(deps.onCueRun).toHaveBeenCalledTimes(2);
+
+			// Stop the first run
+			const firstRunId = manager.getActiveRuns()[0].runId;
+			manager.stopRun(firstRunId);
+
+			// Now resolve the stopped run's promise (simulating process exit)
+			// The finally block should bail out since the run is already removed
+			resolveRun!(makeResult());
+			await vi.advanceTimersByTimeAsync(0);
+
+			// Queue a third run — it should dispatch immediately because only 1 slot is occupied
+			manager.execute('session-1', 'prompt', createEvent(), 'sub-3');
+			expect(deps.onCueRun).toHaveBeenCalledTimes(3);
+		});
+	});
+
+	describe('DB recording', () => {
+		it('updates DB status on natural completion', async () => {
+			const deps = createDeps();
+			const manager = createCueRunManager(deps);
+
+			manager.execute('session-1', 'prompt', createEvent(), 'test-sub');
+			await vi.advanceTimersByTimeAsync(0);
+
+			expect(updateCueEventStatus).toHaveBeenCalledWith('run-1', 'completed');
+		});
+
+		it('updates DB status to stopped on manual stop', () => {
+			const deps = createDeps({ onCueRun: vi.fn(() => new Promise(() => {})) });
+			const manager = createCueRunManager(deps);
+
+			manager.execute('session-1', 'prompt', createEvent(), 'test-sub');
+			const runId = manager.getActiveRuns()[0].runId;
+
+			manager.stopRun(runId);
+
+			expect(updateCueEventStatus).toHaveBeenCalledWith(runId, 'stopped');
+		});
+	});
+
+	describe('race conditions', () => {
+		it('reset during active run: finally does not trigger onRunCompleted', async () => {
+			let resolveRun: ((val: CueRunResult) => void) | undefined;
+			const deps = createDeps({
+				onCueRun: vi.fn(
+					() =>
+						new Promise<CueRunResult>((resolve) => {
+							resolveRun = resolve;
+						})
+				),
+			});
+			const manager = createCueRunManager(deps);
+
+			manager.execute('session-1', 'prompt', createEvent(), 'test-sub');
+			expect(manager.getActiveRunMap().size).toBe(1);
+
+			// Reset clears everything (simulates engine.stop())
+			manager.reset();
+			expect(manager.getActiveRunMap().size).toBe(0);
+
+			// Now the onCueRun promise resolves — the finally block should bail out
+			resolveRun!(makeResult());
+			await vi.advanceTimersByTimeAsync(0);
+
+			// onRunCompleted should NOT be called — the engine was shut down
+			expect(deps.onRunCompleted).not.toHaveBeenCalled();
+		});
+
+		it('stopAll followed by reset: no spurious onRunCompleted', async () => {
+			let resolveRun: ((val: CueRunResult) => void) | undefined;
+			const deps = createDeps({
+				onCueRun: vi.fn(
+					() =>
+						new Promise<CueRunResult>((resolve) => {
+							resolveRun = resolve;
+						})
+				),
+			});
+			const manager = createCueRunManager(deps);
+
+			manager.execute('session-1', 'prompt', createEvent(), 'test-sub');
+			manager.stopAll();
+			manager.reset();
+
+			// Process finally exits
+			resolveRun!(makeResult());
+			await vi.advanceTimersByTimeAsync(0);
+
+			// Only onRunStopped should have been called (from stopAll/stopRun),
+			// NOT onRunCompleted (from finally)
+			expect(deps.onRunStopped).toHaveBeenCalledTimes(1);
+			expect(deps.onRunCompleted).not.toHaveBeenCalled();
+		});
+
+		it('stop during output prompt phase skips second run result', async () => {
+			let onCueRunCallCount = 0;
+			let resolveSecondRun: ((val: CueRunResult) => void) | undefined;
+			const deps = createDeps({
+				onCueRun: vi.fn(() => {
+					onCueRunCallCount++;
+					if (onCueRunCallCount === 1) {
+						// First call (main task) resolves immediately
+						return Promise.resolve(makeResult());
+					}
+					// Second call (output prompt) — we'll stop during this
+					return new Promise<CueRunResult>((resolve) => {
+						resolveSecondRun = resolve;
+					});
+				}),
+			});
+			const manager = createCueRunManager(deps);
+
+			manager.execute('session-1', 'prompt', createEvent(), 'test-sub', 'output prompt');
+			await vi.advanceTimersByTimeAsync(0);
+
+			// At this point: main task completed, output prompt is running
+			expect(deps.onCueRun).toHaveBeenCalledTimes(2);
+			expect(manager.getActiveRunMap().size).toBe(1);
+
+			// Stop the run while output prompt is in-flight
+			const runId = [...manager.getActiveRunMap().keys()][0];
+			manager.stopRun(runId);
+
+			expect(deps.onRunStopped).toHaveBeenCalledTimes(1);
+
+			// Output prompt resolves after stop — should be ignored
+			resolveSecondRun!(makeResult({ stdout: 'output prompt result' }));
+			await vi.advanceTimersByTimeAsync(0);
+
+			// onRunCompleted should NOT be called
+			expect(deps.onRunCompleted).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('output prompt', () => {
+		it('executes output prompt when main task completes successfully', async () => {
+			const deps = createDeps();
+			const manager = createCueRunManager(deps);
+
+			manager.execute('session-1', 'prompt', createEvent(), 'test-sub', 'follow-up prompt');
+			await vi.advanceTimersByTimeAsync(0);
+
+			// Should have called onCueRun twice: main + output
+			expect(deps.onCueRun).toHaveBeenCalledTimes(2);
+			expect(deps.onCueRun).toHaveBeenCalledWith(
+				expect.objectContaining({ subscriptionName: 'test-sub:output' })
+			);
+		});
+
+		it('skips output prompt when main task fails', async () => {
+			const deps = createDeps({
+				onCueRun: vi.fn(async () => makeResult({ status: 'failed' })),
+			});
+			const manager = createCueRunManager(deps);
+
+			manager.execute('session-1', 'prompt', createEvent(), 'test-sub', 'follow-up prompt');
+			await vi.advanceTimersByTimeAsync(0);
+
+			// Only main task should be called
+			expect(deps.onCueRun).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe('stopAll', () => {
+		it('stops all active runs', () => {
+			const deps = createDeps({
+				getSessionSettings: vi.fn(() => ({ ...defaultSettings, max_concurrent: 3 })),
+				onCueRun: vi.fn(() => new Promise(() => {})),
+			});
+			const manager = createCueRunManager(deps);
+
+			manager.execute('session-1', 'prompt', createEvent(), 'sub-1');
+			manager.execute('session-1', 'prompt', createEvent(), 'sub-2');
+			manager.execute('session-1', 'prompt', createEvent(), 'sub-3');
+			expect(manager.getActiveRuns()).toHaveLength(3);
+
+			manager.stopAll();
+
+			expect(manager.getActiveRuns()).toHaveLength(0);
+			expect(deps.onRunStopped).toHaveBeenCalledTimes(3);
+		});
+
+		it('clears event queue', () => {
+			const deps = createDeps({
+				onCueRun: vi.fn(() => new Promise(() => {})),
+			});
+			const manager = createCueRunManager(deps);
+
+			manager.execute('session-1', 'prompt', createEvent(), 'sub-1');
+			manager.execute('session-1', 'prompt', createEvent(), 'sub-2');
+			expect(manager.getQueueStatus().get('session-1')).toBe(1);
+
+			manager.stopAll();
+
+			expect(manager.getQueueStatus().size).toBe(0);
+		});
+	});
+
+	describe('reset', () => {
+		it('releases sleep blocks for all active runs', () => {
+			const deps = createDeps({
+				getSessionSettings: vi.fn(() => ({ ...defaultSettings, max_concurrent: 2 })),
+				onCueRun: vi.fn(() => new Promise(() => {})),
+			});
+			const manager = createCueRunManager(deps);
+
+			manager.execute('session-1', 'prompt', createEvent(), 'sub-1');
+			manager.execute('session-1', 'prompt', createEvent(), 'sub-2');
+
+			manager.reset();
+
+			// Should have called onAllowSleep for both runs
+			expect(deps.onAllowSleep).toHaveBeenCalledTimes(2);
+		});
+
+		it('clears all internal state', () => {
+			const deps = createDeps({
+				onCueRun: vi.fn(() => new Promise(() => {})),
+			});
+			const manager = createCueRunManager(deps);
+
+			manager.execute('session-1', 'prompt', createEvent(), 'sub-1');
+			manager.execute('session-1', 'prompt', createEvent(), 'sub-2');
+
+			manager.reset();
+
+			expect(manager.getActiveRuns()).toHaveLength(0);
+			expect(manager.getActiveRunMap().size).toBe(0);
+			expect(manager.getQueueStatus().size).toBe(0);
+		});
+	});
+
+	describe('logging', () => {
+		it('logs run started on dispatch', () => {
+			const deps = createDeps({ onCueRun: vi.fn(() => new Promise(() => {})) });
+			const manager = createCueRunManager(deps);
+
+			manager.execute('session-1', 'prompt', createEvent(), 'test-sub');
+
+			expect(deps.onLog).toHaveBeenCalledWith(
+				'cue',
+				expect.stringContaining('Run started: test-sub'),
+				expect.objectContaining({ type: 'runStarted' })
+			);
+		});
+
+		it('logs run finished on natural completion', async () => {
+			const deps = createDeps();
+			const manager = createCueRunManager(deps);
+
+			manager.execute('session-1', 'prompt', createEvent(), 'test-sub');
+			await vi.advanceTimersByTimeAsync(0);
+
+			expect(deps.onLog).toHaveBeenCalledWith(
+				'cue',
+				expect.stringContaining('Run finished: test-sub (completed)'),
+				expect.objectContaining({ type: 'runFinished' })
+			);
+		});
+
+		it('logs run stopped on manual stop', () => {
+			const deps = createDeps({ onCueRun: vi.fn(() => new Promise(() => {})) });
+			const manager = createCueRunManager(deps);
+
+			manager.execute('session-1', 'prompt', createEvent(), 'test-sub');
+			const runId = manager.getActiveRuns()[0].runId;
+
+			manager.stopRun(runId);
+
+			expect(deps.onLog).toHaveBeenCalledWith(
+				'cue',
+				expect.stringContaining('Run stopped:'),
+				expect.objectContaining({ type: 'runStopped' })
+			);
+		});
+	});
+
+	describe('process signaling', () => {
+		it('calls onStopCueRun when stopping a run', () => {
+			const deps = createDeps({ onCueRun: vi.fn(() => new Promise(() => {})) });
+			const manager = createCueRunManager(deps);
+
+			manager.execute('session-1', 'prompt', createEvent(), 'test-sub');
+			const runId = manager.getActiveRuns()[0].runId;
+
+			manager.stopRun(runId);
+
+			expect(deps.onStopCueRun).toHaveBeenCalledWith(runId);
+		});
+
+		it('aborts the AbortController on stop', () => {
+			const deps = createDeps({ onCueRun: vi.fn(() => new Promise(() => {})) });
+			const manager = createCueRunManager(deps);
+
+			manager.execute('session-1', 'prompt', createEvent(), 'test-sub');
+			const runId = [...manager.getActiveRunMap().keys()][0];
+			const run = manager.getActiveRunMap().get(runId)!;
+			const abortSpy = vi.spyOn(run.abortController!, 'abort');
+
+			manager.stopRun(runId);
+
+			expect(abortSpy).toHaveBeenCalled();
+		});
+	});
+
+	describe('getActiveRunCount', () => {
+		it('returns 0 for unknown session', () => {
+			const manager = createCueRunManager(createDeps());
+			expect(manager.getActiveRunCount('unknown')).toBe(0);
+		});
+
+		it('returns correct count for active runs', () => {
+			const deps = createDeps({
+				getSessionSettings: vi.fn(() => ({ ...defaultSettings, max_concurrent: 3 })),
+				onCueRun: vi.fn(() => new Promise(() => {})),
+			});
+			const manager = createCueRunManager(deps);
+
+			manager.execute('session-1', 'prompt', createEvent(), 'sub-1');
+			manager.execute('session-1', 'prompt', createEvent(), 'sub-2');
+
+			expect(manager.getActiveRunCount('session-1')).toBe(2);
+		});
+
+		it('decrements after stopRun', () => {
+			const deps = createDeps({
+				getSessionSettings: vi.fn(() => ({ ...defaultSettings, max_concurrent: 3 })),
+				onCueRun: vi.fn(() => new Promise(() => {})),
+			});
+			const manager = createCueRunManager(deps);
+
+			manager.execute('session-1', 'prompt', createEvent(), 'sub-1');
+			manager.execute('session-1', 'prompt', createEvent(), 'sub-2');
+			const runId = manager.getActiveRuns()[0].runId;
+
+			manager.stopRun(runId);
+
+			expect(manager.getActiveRunCount('session-1')).toBe(1);
+		});
+	});
+});

--- a/src/__tests__/main/cue/cue-spawn-builder.test.ts
+++ b/src/__tests__/main/cue/cue-spawn-builder.test.ts
@@ -1,0 +1,356 @@
+/**
+ * Tests for the Cue Spawn Builder.
+ *
+ * Verifies spawn spec construction: agent definition lookup, arg building,
+ * config overrides, SSH wrapping, and prompt appending.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { CueExecutionConfig } from '../../../main/cue/cue-executor';
+import type { CueEvent, CueSubscription } from '../../../main/cue/cue-types';
+import type { SessionInfo } from '../../../shared/types';
+import type { TemplateContext } from '../../../shared/templateVariables';
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+
+const mockGetAgentDefinition = vi.fn();
+const mockGetAgentCapabilities = vi.fn(() => ({
+	supportsResume: true,
+	supportsReadOnlyMode: true,
+	supportsJsonOutput: true,
+	supportsSessionId: true,
+	supportsImageInput: false,
+	supportsImageInputOnResume: false,
+	supportsSlashCommands: true,
+	supportsSessionStorage: true,
+	supportsCostTracking: true,
+	supportsContextUsage: true,
+	supportsThinking: false,
+	supportsStdin: false,
+	supportsRawStdin: false,
+	supportsModelSelection: false,
+	supportsModelDiscovery: false,
+	supportsBatchMode: true,
+	supportsYoloMode: true,
+	supportsExitCodes: true,
+	supportsWorkingDir: false,
+}));
+
+vi.mock('../../../main/agents', () => ({
+	getAgentDefinition: (...args: unknown[]) => mockGetAgentDefinition(...args),
+	getAgentCapabilities: (...args: unknown[]) => mockGetAgentCapabilities(...args),
+}));
+
+const mockBuildAgentArgs = vi.fn((_agent: unknown, _opts: unknown) => ['--print', '--verbose']);
+const mockApplyOverrides = vi.fn((_agent: unknown, args: string[], _overrides: unknown) => ({
+	args,
+	effectiveCustomEnvVars: undefined,
+	customArgsSource: 'none' as const,
+	customEnvSource: 'none' as const,
+	modelSource: 'default' as const,
+}));
+
+vi.mock('../../../main/utils/agent-args', () => ({
+	buildAgentArgs: (...args: unknown[]) => mockBuildAgentArgs(...args),
+	applyAgentConfigOverrides: (...args: unknown[]) => mockApplyOverrides(...args),
+}));
+
+const mockWrapSpawnWithSsh = vi.fn();
+vi.mock('../../../main/utils/ssh-spawn-wrapper', () => ({
+	wrapSpawnWithSsh: (...args: unknown[]) => mockWrapSpawnWithSsh(...args),
+}));
+
+// Must import after mocks
+import { buildSpawnSpec } from '../../../main/cue/cue-spawn-builder';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const defaultAgentDef = {
+	id: 'claude-code',
+	name: 'Claude Code',
+	binaryName: 'claude',
+	command: 'claude',
+	args: ['--print', '--verbose'],
+};
+
+function createConfig(overrides: Partial<CueExecutionConfig> = {}): CueExecutionConfig {
+	return {
+		runId: 'run-1',
+		session: {
+			id: 'session-1',
+			name: 'Test',
+			toolType: 'claude-code',
+			cwd: '/projects/test',
+			projectRoot: '/projects/test',
+		} as SessionInfo,
+		subscription: {
+			name: 'test-sub',
+			event: 'file.changed',
+			enabled: true,
+			prompt: 'test',
+		} as CueSubscription,
+		event: {
+			id: 'evt-1',
+			type: 'file.changed',
+			timestamp: '2026-01-01T00:00:00.000Z',
+			triggerName: 'test',
+			payload: {},
+		} as CueEvent,
+		promptPath: 'test prompt',
+		toolType: 'claude-code',
+		projectRoot: '/projects/test',
+		templateContext: {} as TemplateContext,
+		timeoutMs: 30000,
+		onLog: vi.fn(),
+		...overrides,
+	};
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('cue-spawn-builder', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockGetAgentDefinition.mockReturnValue(defaultAgentDef);
+	});
+
+	describe('buildSpawnSpec', () => {
+		it('returns error for unknown agent type', async () => {
+			mockGetAgentDefinition.mockReturnValue(undefined);
+
+			const result = await buildSpawnSpec(createConfig({ toolType: 'nonexistent' }), 'prompt');
+
+			expect(result.ok).toBe(false);
+			if (!result.ok) {
+				expect(result.message).toContain('Unknown agent type: nonexistent');
+			}
+		});
+
+		it('builds spec with correct command and cwd for local execution', async () => {
+			const result = await buildSpawnSpec(createConfig(), 'hello world');
+
+			expect(result.ok).toBe(true);
+			if (result.ok) {
+				expect(result.spec.command).toBe('claude');
+				expect(result.spec.cwd).toBe('/projects/test');
+			}
+		});
+
+		it('uses custom path when provided', async () => {
+			const result = await buildSpawnSpec(createConfig({ customPath: '/custom/claude' }), 'prompt');
+
+			expect(result.ok).toBe(true);
+			if (result.ok) {
+				expect(result.spec.command).toBe('/custom/claude');
+			}
+		});
+
+		it('appends -- then prompt for default agents (no promptArgs/noPromptSeparator)', async () => {
+			const result = await buildSpawnSpec(createConfig(), 'Hello world');
+
+			expect(result.ok).toBe(true);
+			if (result.ok) {
+				const args = result.spec.args;
+				expect(args[args.length - 2]).toBe('--');
+				expect(args[args.length - 1]).toBe('Hello world');
+			}
+		});
+
+		it('uses promptArgs when agent provides it', async () => {
+			mockGetAgentDefinition.mockReturnValue({
+				...defaultAgentDef,
+				promptArgs: (p: string) => ['-p', p],
+			});
+
+			const result = await buildSpawnSpec(createConfig(), 'Hello world');
+
+			expect(result.ok).toBe(true);
+			if (result.ok) {
+				const pIdx = result.spec.args.indexOf('-p');
+				expect(pIdx).toBeGreaterThan(-1);
+				expect(result.spec.args[pIdx + 1]).toBe('Hello world');
+			}
+		});
+
+		it('appends prompt directly when noPromptSeparator is true', async () => {
+			mockGetAgentDefinition.mockReturnValue({
+				...defaultAgentDef,
+				noPromptSeparator: true,
+			});
+
+			const result = await buildSpawnSpec(createConfig(), 'Hello world');
+
+			expect(result.ok).toBe(true);
+			if (result.ok) {
+				const args = result.spec.args;
+				expect(args[args.length - 1]).toBe('Hello world');
+				expect(args[args.length - 2]).not.toBe('--');
+			}
+		});
+
+		it('calls buildAgentArgs with yoloMode: true', async () => {
+			await buildSpawnSpec(createConfig(), 'prompt');
+
+			expect(mockBuildAgentArgs).toHaveBeenCalledWith(
+				expect.objectContaining({ id: 'claude-code' }),
+				expect.objectContaining({ yoloMode: true })
+			);
+		});
+
+		it('passes config overrides through applyAgentConfigOverrides', async () => {
+			const config = createConfig({
+				customModel: 'claude-4-opus',
+				customArgs: '--max-tokens 1000',
+				customEnvVars: { API_KEY: 'test' },
+			});
+
+			await buildSpawnSpec(config, 'prompt');
+
+			expect(mockApplyOverrides).toHaveBeenCalledWith(
+				expect.anything(),
+				expect.any(Array),
+				expect.objectContaining({
+					sessionCustomModel: 'claude-4-opus',
+					sessionCustomArgs: '--max-tokens 1000',
+					sessionCustomEnvVars: { API_KEY: 'test' },
+				})
+			);
+		});
+
+		it('includes process.env in the spec env', async () => {
+			const result = await buildSpawnSpec(createConfig(), 'prompt');
+
+			expect(result.ok).toBe(true);
+			if (result.ok) {
+				// process.env.PATH should be present
+				expect(result.spec.env.PATH).toBeDefined();
+			}
+		});
+
+		describe('SSH execution', () => {
+			it('calls wrapSpawnWithSsh when SSH is enabled', async () => {
+				const mockSshStore = { getSshRemotes: vi.fn(() => []) };
+
+				mockWrapSpawnWithSsh.mockResolvedValue({
+					command: 'ssh',
+					args: ['user@host', 'claude', '--print'],
+					cwd: '/Users/test',
+					customEnvVars: undefined,
+					prompt: undefined,
+					sshRemoteUsed: { id: 'remote-1', name: 'Server', host: 'host.example.com' },
+				});
+
+				const result = await buildSpawnSpec(
+					createConfig({
+						sshRemoteConfig: { enabled: true, remoteId: 'remote-1' },
+						sshStore: mockSshStore,
+					}),
+					'prompt'
+				);
+
+				expect(mockWrapSpawnWithSsh).toHaveBeenCalledWith(
+					expect.objectContaining({
+						command: 'claude',
+						agentBinaryName: 'claude',
+					}),
+					{ enabled: true, remoteId: 'remote-1' },
+					mockSshStore
+				);
+
+				expect(result.ok).toBe(true);
+				if (result.ok) {
+					expect(result.spec.command).toBe('ssh');
+					expect(result.spec.cwd).toBe('/Users/test');
+					expect(result.spec.sshRemoteUsed).toEqual({
+						id: 'remote-1',
+						name: 'Server',
+						host: 'host.example.com',
+					});
+				}
+			});
+
+			it('does not append prompt to args for SSH mode (wrapper handles it)', async () => {
+				const mockSshStore = { getSshRemotes: vi.fn(() => []) };
+
+				mockWrapSpawnWithSsh.mockResolvedValue({
+					command: 'ssh',
+					args: ['user@host', 'claude', '--', 'Hello world'],
+					cwd: '/Users/test',
+					customEnvVars: undefined,
+					prompt: undefined,
+					sshRemoteUsed: { id: 'r1', name: 'S', host: 'h' },
+				});
+
+				const result = await buildSpawnSpec(
+					createConfig({
+						sshRemoteConfig: { enabled: true, remoteId: 'r1' },
+						sshStore: mockSshStore,
+					}),
+					'Hello world'
+				);
+
+				expect(result.ok).toBe(true);
+				if (result.ok) {
+					// Only one occurrence of the prompt (from SSH wrapper)
+					const promptOccurrences = result.spec.args.filter((a) =>
+						a.includes('Hello world')
+					).length;
+					expect(promptOccurrences).toBe(1);
+				}
+			});
+
+			it('passes sshStdinScript through when SSH returns it', async () => {
+				const mockSshStore = { getSshRemotes: vi.fn(() => []) };
+
+				mockWrapSpawnWithSsh.mockResolvedValue({
+					command: 'ssh',
+					args: ['user@host'],
+					cwd: '/Users/test',
+					customEnvVars: undefined,
+					prompt: undefined,
+					sshStdinScript: '#!/bin/bash\nclaude "test prompt"',
+					sshRemoteUsed: { id: 'r1', name: 'S', host: 'h' },
+				});
+
+				const result = await buildSpawnSpec(
+					createConfig({
+						sshRemoteConfig: { enabled: true, remoteId: 'r1' },
+						sshStore: mockSshStore,
+					}),
+					'test prompt'
+				);
+
+				expect(result.ok).toBe(true);
+				if (result.ok) {
+					expect(result.spec.sshStdinScript).toBe('#!/bin/bash\nclaude "test prompt"');
+				}
+			});
+
+			it('passes stdinPrompt through when SSH returns prompt for stdin delivery', async () => {
+				const mockSshStore = { getSshRemotes: vi.fn(() => []) };
+
+				mockWrapSpawnWithSsh.mockResolvedValue({
+					command: 'ssh',
+					args: ['user@host'],
+					cwd: '/Users/test',
+					customEnvVars: undefined,
+					prompt: 'large prompt content',
+					sshRemoteUsed: { id: 'r1', name: 'S', host: 'h' },
+				});
+
+				const result = await buildSpawnSpec(
+					createConfig({
+						sshRemoteConfig: { enabled: true, remoteId: 'r1' },
+						sshStore: mockSshStore,
+					}),
+					'large prompt content'
+				);
+
+				expect(result.ok).toBe(true);
+				if (result.ok) {
+					expect(result.spec.stdinPrompt).toBe('large prompt content');
+				}
+			});
+		});
+	});
+});

--- a/src/__tests__/main/cue/cue-spawn-builder.test.ts
+++ b/src/__tests__/main/cue/cue-spawn-builder.test.ts
@@ -218,12 +218,17 @@ describe('cue-spawn-builder', () => {
 		});
 
 		it('includes process.env in the spec env', async () => {
-			const result = await buildSpawnSpec(createConfig(), 'prompt');
+			// Seed a unique env var to avoid platform-fragile assertions (e.g. PATH)
+			process.env.__CUE_SPAWN_TEST__ = 'test-value';
+			try {
+				const result = await buildSpawnSpec(createConfig(), 'prompt');
 
-			expect(result.ok).toBe(true);
-			if (result.ok) {
-				// process.env.PATH should be present
-				expect(result.spec.env.PATH).toBeDefined();
+				expect(result.ok).toBe(true);
+				if (result.ok) {
+					expect(result.spec.env.__CUE_SPAWN_TEST__).toBe('test-value');
+				}
+			} finally {
+				delete process.env.__CUE_SPAWN_TEST__;
 			}
 		});
 

--- a/src/__tests__/main/cue/cue-spawn-builder.test.ts
+++ b/src/__tests__/main/cue/cue-spawn-builder.test.ts
@@ -351,6 +351,25 @@ describe('cue-spawn-builder', () => {
 					expect(result.spec.stdinPrompt).toBe('large prompt content');
 				}
 			});
+
+			it('still appends prompt when SSH is enabled but sshStore is missing', async () => {
+				// SSH enabled in config, but no sshStore → SSH wrapping skipped
+				// Prompt should still be appended for local fallback
+				const result = await buildSpawnSpec(
+					createConfig({
+						sshRemoteConfig: { enabled: true, remoteId: 'r1' },
+						// sshStore deliberately omitted
+					}),
+					'Hello world'
+				);
+
+				expect(result.ok).toBe(true);
+				if (result.ok) {
+					const args = result.spec.args;
+					expect(args[args.length - 1]).toBe('Hello world');
+					expect(mockWrapSpawnWithSsh).not.toHaveBeenCalled();
+				}
+			});
 		});
 	});
 });

--- a/src/__tests__/main/cue/cue-template-context-builder.test.ts
+++ b/src/__tests__/main/cue/cue-template-context-builder.test.ts
@@ -1,0 +1,313 @@
+/**
+ * Tests for the Cue Template Context Builder.
+ *
+ * Verifies the enricher registry correctly maps event payloads to
+ * templateContext.cue fields for all event types.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildCueTemplateContext } from '../../../main/cue/cue-template-context-builder';
+import type { CueEvent, CueSubscription } from '../../../main/cue/cue-types';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function createEvent(overrides: Partial<CueEvent> = {}): CueEvent {
+	return {
+		id: 'evt-1',
+		type: 'file.changed',
+		timestamp: '2026-03-01T00:00:00.000Z',
+		triggerName: 'test-trigger',
+		payload: {},
+		...overrides,
+	};
+}
+
+function createSubscription(overrides: Partial<CueSubscription> = {}): CueSubscription {
+	return {
+		name: 'test-sub',
+		event: 'file.changed',
+		enabled: true,
+		prompt: 'test prompt',
+		...overrides,
+	};
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('cue-template-context-builder', () => {
+	describe('base enricher (all event types)', () => {
+		it('populates common fields from event metadata', () => {
+			const event = createEvent({
+				type: 'time.heartbeat',
+				timestamp: '2026-04-10T12:00:00.000Z',
+			});
+			const sub = createSubscription({ name: 'heartbeat-check' });
+
+			const ctx = buildCueTemplateContext(event, sub, 'run-abc');
+
+			expect(ctx.eventType).toBe('time.heartbeat');
+			expect(ctx.eventTimestamp).toBe('2026-04-10T12:00:00.000Z');
+			expect(ctx.triggerName).toBe('heartbeat-check');
+			expect(ctx.runId).toBe('run-abc');
+		});
+
+		it('populates file fields from payload', () => {
+			const event = createEvent({
+				payload: {
+					path: '/project/src/app.ts',
+					filename: 'app.ts',
+					directory: '/project/src',
+					extension: '.ts',
+					changeType: 'change',
+				},
+			});
+
+			const ctx = buildCueTemplateContext(event, createSubscription(), 'run-1');
+
+			expect(ctx.filePath).toBe('/project/src/app.ts');
+			expect(ctx.fileName).toBe('app.ts');
+			expect(ctx.fileDir).toBe('/project/src');
+			expect(ctx.fileExt).toBe('.ts');
+			expect(ctx.fileChangeType).toBe('change');
+		});
+
+		it('populates agent.completed source fields from payload', () => {
+			const event = createEvent({
+				type: 'agent.completed',
+				payload: {
+					sourceSession: 'builder',
+					sourceOutput: 'Build OK',
+					status: 'completed',
+					exitCode: 0,
+					durationMs: 5000,
+					triggeredBy: 'file-watch',
+				},
+			});
+
+			const ctx = buildCueTemplateContext(event, createSubscription(), 'run-1');
+
+			expect(ctx.sourceSession).toBe('builder');
+			expect(ctx.sourceOutput).toBe('Build OK');
+			expect(ctx.sourceStatus).toBe('completed');
+			expect(ctx.sourceExitCode).toBe('0');
+			expect(ctx.sourceDuration).toBe('5000');
+			expect(ctx.sourceTriggeredBy).toBe('file-watch');
+		});
+
+		it('defaults all fields to empty string when payload is empty', () => {
+			const event = createEvent({ payload: {} });
+
+			const ctx = buildCueTemplateContext(event, createSubscription(), 'run-1');
+
+			expect(ctx.filePath).toBe('');
+			expect(ctx.fileName).toBe('');
+			expect(ctx.fileDir).toBe('');
+			expect(ctx.fileExt).toBe('');
+			expect(ctx.fileChangeType).toBe('');
+			expect(ctx.sourceSession).toBe('');
+			expect(ctx.sourceOutput).toBe('');
+			expect(ctx.sourceStatus).toBe('');
+			expect(ctx.sourceExitCode).toBe('');
+			expect(ctx.sourceDuration).toBe('');
+			expect(ctx.sourceTriggeredBy).toBe('');
+		});
+	});
+
+	describe('task.pending enricher', () => {
+		it('populates task-specific fields', () => {
+			const event = createEvent({
+				type: 'task.pending',
+				payload: {
+					path: '/project/TODO.md',
+					filename: 'TODO.md',
+					directory: '/project',
+					taskCount: 3,
+					taskList: '- [ ] Task 1\n- [ ] Task 2\n- [ ] Task 3',
+					content: '# TODO\n- [ ] Task 1\n- [ ] Task 2\n- [ ] Task 3',
+				},
+			});
+
+			const ctx = buildCueTemplateContext(event, createSubscription(), 'run-1');
+
+			expect(ctx.taskFile).toBe('/project/TODO.md');
+			expect(ctx.taskFileName).toBe('TODO.md');
+			expect(ctx.taskFileDir).toBe('/project');
+			expect(ctx.taskCount).toBe('3');
+			expect(ctx.taskList).toBe('- [ ] Task 1\n- [ ] Task 2\n- [ ] Task 3');
+			expect(ctx.taskContent).toBe('# TODO\n- [ ] Task 1\n- [ ] Task 2\n- [ ] Task 3');
+		});
+
+		it('preserves base cue fields alongside task fields', () => {
+			const event = createEvent({
+				type: 'task.pending',
+				timestamp: '2026-04-10T15:00:00.000Z',
+				payload: { taskCount: 1, taskList: '- [ ] One' },
+			});
+			const sub = createSubscription({ name: 'task-watcher' });
+
+			const ctx = buildCueTemplateContext(event, sub, 'run-2');
+
+			// Base fields present
+			expect(ctx.eventType).toBe('task.pending');
+			expect(ctx.triggerName).toBe('task-watcher');
+			expect(ctx.runId).toBe('run-2');
+			// Task fields present
+			expect(ctx.taskCount).toBe('1');
+		});
+
+		it('defaults task fields to empty/zero when payload is missing', () => {
+			const event = createEvent({ type: 'task.pending', payload: {} });
+
+			const ctx = buildCueTemplateContext(event, createSubscription(), 'run-1');
+
+			expect(ctx.taskFile).toBe('');
+			expect(ctx.taskFileName).toBe('');
+			expect(ctx.taskFileDir).toBe('');
+			expect(ctx.taskCount).toBe('0');
+			expect(ctx.taskList).toBe('');
+			expect(ctx.taskContent).toBe('');
+		});
+	});
+
+	describe('github.pull_request enricher', () => {
+		it('populates GitHub PR fields', () => {
+			const event = createEvent({
+				type: 'github.pull_request',
+				payload: {
+					type: 'pull_request',
+					number: 42,
+					title: 'Add feature X',
+					author: 'octocat',
+					url: 'https://github.com/owner/repo/pull/42',
+					body: 'This PR adds feature X',
+					labels: 'enhancement,review-needed',
+					state: 'open',
+					repo: 'owner/repo',
+					head_branch: 'feature-x',
+					base_branch: 'main',
+					assignees: 'dev1',
+					merged_at: '',
+				},
+			});
+
+			const ctx = buildCueTemplateContext(event, createSubscription(), 'run-1');
+
+			expect(ctx.ghType).toBe('pull_request');
+			expect(ctx.ghNumber).toBe('42');
+			expect(ctx.ghTitle).toBe('Add feature X');
+			expect(ctx.ghAuthor).toBe('octocat');
+			expect(ctx.ghUrl).toBe('https://github.com/owner/repo/pull/42');
+			expect(ctx.ghBody).toBe('This PR adds feature X');
+			expect(ctx.ghLabels).toBe('enhancement,review-needed');
+			expect(ctx.ghState).toBe('open');
+			expect(ctx.ghRepo).toBe('owner/repo');
+			expect(ctx.ghBranch).toBe('feature-x');
+			expect(ctx.ghBaseBranch).toBe('main');
+			expect(ctx.ghAssignees).toBe('dev1');
+			expect(ctx.ghMergedAt).toBe('');
+		});
+
+		it('preserves base cue fields alongside GitHub fields', () => {
+			const event = createEvent({
+				type: 'github.pull_request',
+				payload: { number: 1, title: 'Test' },
+			});
+
+			const ctx = buildCueTemplateContext(event, createSubscription(), 'run-1');
+
+			expect(ctx.eventType).toBe('github.pull_request');
+			expect(ctx.ghNumber).toBe('1');
+		});
+	});
+
+	describe('github.issue enricher', () => {
+		it('populates GitHub issue fields', () => {
+			const event = createEvent({
+				type: 'github.issue',
+				payload: {
+					type: 'issue',
+					number: 99,
+					title: 'Bug report',
+					author: 'user1',
+					url: 'https://github.com/owner/repo/issues/99',
+					body: 'Found a bug',
+					labels: 'bug',
+					state: 'open',
+					repo: 'owner/repo',
+					assignees: 'dev1,dev2',
+				},
+			});
+
+			const ctx = buildCueTemplateContext(event, createSubscription(), 'run-1');
+
+			expect(ctx.ghType).toBe('issue');
+			expect(ctx.ghNumber).toBe('99');
+			expect(ctx.ghTitle).toBe('Bug report');
+			expect(ctx.ghAssignees).toBe('dev1,dev2');
+			// head_branch / base_branch not in payload → empty string
+			expect(ctx.ghBranch).toBe('');
+			expect(ctx.ghBaseBranch).toBe('');
+		});
+	});
+
+	describe('unknown event types', () => {
+		it('still returns base fields for unregistered event types', () => {
+			const event = createEvent({
+				type: 'app.startup' as any,
+				timestamp: '2026-04-10T08:00:00.000Z',
+			});
+			const sub = createSubscription({ name: 'boot-task' });
+
+			const ctx = buildCueTemplateContext(event, sub, 'run-5');
+
+			// Base fields always populated
+			expect(ctx.eventType).toBe('app.startup');
+			expect(ctx.triggerName).toBe('boot-task');
+			expect(ctx.runId).toBe('run-5');
+			// No event-specific enricher for app.startup, so no extra fields
+			expect(ctx.taskFile).toBeUndefined();
+			expect(ctx.ghType).toBeUndefined();
+		});
+
+		it('handles time.heartbeat (no specific enricher) gracefully', () => {
+			const event = createEvent({ type: 'time.heartbeat', payload: {} });
+
+			const ctx = buildCueTemplateContext(event, createSubscription(), 'run-1');
+
+			expect(ctx.eventType).toBe('time.heartbeat');
+			expect(ctx.filePath).toBe('');
+		});
+
+		it('handles time.scheduled (no specific enricher) gracefully', () => {
+			const event = createEvent({ type: 'time.scheduled', payload: {} });
+
+			const ctx = buildCueTemplateContext(event, createSubscription(), 'run-1');
+
+			expect(ctx.eventType).toBe('time.scheduled');
+		});
+	});
+
+	describe('edge cases', () => {
+		it('coerces numeric payload values to strings', () => {
+			const event = createEvent({
+				type: 'agent.completed',
+				payload: { exitCode: 137, durationMs: 0 },
+			});
+
+			const ctx = buildCueTemplateContext(event, createSubscription(), 'run-1');
+
+			expect(ctx.sourceExitCode).toBe('137');
+			expect(ctx.sourceDuration).toBe('0');
+		});
+
+		it('coerces boolean payload values to strings', () => {
+			const event = createEvent({
+				payload: { status: false as any },
+			});
+
+			const ctx = buildCueTemplateContext(event, createSubscription(), 'run-1');
+
+			expect(ctx.sourceStatus).toBe('false');
+		});
+	});
+});

--- a/src/main/cue/cue-executor.ts
+++ b/src/main/cue/cue-executor.ts
@@ -1,23 +1,31 @@
 /**
- * Cue Executor — spawns background agent processes when Cue triggers fire.
+ * Cue Executor — orchestrates background agent process execution when Cue
+ * triggers fire.
  *
- * Reads prompt files, substitutes Cue-specific template variables, spawns the
- * agent process, captures output, enforces timeouts, and records history entries.
- * Follows the same spawn pattern as Auto Run (via process:spawn IPC handler).
+ * Thin orchestrator that composes three single-responsibility modules:
+ * - CueTemplateContextBuilder: builds templateContext.cue from event payload
+ * - CueSpawnBuilder: constructs a SpawnSpec from session/agent/SSH config
+ * - CueProcessLifecycle: spawns the process, captures output, enforces timeout
+ *
+ * Also contains recordCueHistoryEntry (pure data transformation).
  */
 
-import { spawn, type ChildProcess } from 'child_process';
 import * as crypto from 'crypto';
-import type { CueEvent, CueRunResult, CueRunStatus, CueSubscription } from './cue-types';
-import type { HistoryEntry, SessionInfo, ToolType } from '../../shared/types';
+import type { CueRunResult, CueSubscription } from './cue-types';
+import type { HistoryEntry, SessionInfo } from '../../shared/types';
 import { substituteTemplateVariables, type TemplateContext } from '../../shared/templateVariables';
-import { getAgentDefinition, getAgentCapabilities } from '../agents';
-import { buildAgentArgs, applyAgentConfigOverrides } from '../utils/agent-args';
-import { wrapSpawnWithSsh, type SshSpawnWrapConfig } from '../utils/ssh-spawn-wrapper';
-import type { SshRemoteSettingsStore } from '../utils/ssh-remote-resolver';
-import { getOutputParser } from '../parsers';
+import { buildCueTemplateContext } from './cue-template-context-builder';
+import { buildSpawnSpec } from './cue-spawn-builder';
+import {
+	runProcess,
+	stopProcess,
+	getActiveProcessMap,
+	getProcessList,
+} from './cue-process-lifecycle';
+// Re-export types that external consumers use
+export type { CueProcessInfo } from './cue-process-lifecycle';
+export type { SpawnSpec } from './cue-spawn-builder';
 
-const SIGKILL_DELAY_MS = 5000;
 const MAX_HISTORY_RESPONSE_LENGTH = 10000;
 
 /** Configuration for executing a Cue-triggered prompt */
@@ -25,7 +33,7 @@ export interface CueExecutionConfig {
 	runId: string;
 	session: SessionInfo;
 	subscription: CueSubscription;
-	event: CueEvent;
+	event: import('./cue-types').CueEvent;
 	promptPath: string;
 	toolType: string;
 	projectRoot: string;
@@ -39,75 +47,15 @@ export interface CueExecutionConfig {
 	customEffort?: string;
 	onLog: (level: string, message: string) => void;
 	/** Optional SSH settings store for SSH remote execution */
-	sshStore?: SshRemoteSettingsStore;
+	sshStore?: import('../utils/ssh-remote-resolver').SshRemoteSettingsStore;
 	/** Optional agent-level config values (from agent config store) */
 	agentConfigValues?: Record<string, unknown>;
-}
-
-/** Metadata stored alongside each active Cue process */
-interface CueActiveProcess {
-	child: ChildProcess;
-	command: string;
-	args: string[];
-	cwd: string;
-	toolType: string;
-	startTime: number;
-}
-
-/** Serializable process info for the Process Monitor */
-export interface CueProcessInfo {
-	runId: string;
-	pid: number;
-	command: string;
-	args: string[];
-	cwd: string;
-	toolType: string;
-	startTime: number;
-}
-
-/** Map of active Cue processes by runId */
-const activeProcesses = new Map<string, CueActiveProcess>();
-
-/**
- * Extract clean human-readable text from agent stdout.
- * For agents that output JSON/NDJSON (like OpenCode --format json), parses each
- * line and collects text from 'result' events. Falls back to raw stdout when no
- * parser is available or no result-text events are found (e.g. plain-text agents).
- */
-function extractCleanStdout(rawStdout: string, toolType: string): string {
-	if (!rawStdout.trim()) {
-		return rawStdout;
-	}
-
-	const parser = getOutputParser(toolType as ToolType);
-	if (!parser) {
-		return rawStdout;
-	}
-
-	const textParts: string[] = [];
-	for (const line of rawStdout.split('\n')) {
-		if (!line.trim()) continue;
-		const event = parser.parseJsonLine(line);
-		if (event?.type === 'result' && event.text) {
-			textParts.push(event.text);
-		}
-	}
-
-	return textParts.length > 0 ? textParts.join('\n') : rawStdout;
 }
 
 /**
  * Execute a Cue-triggered prompt by spawning an agent process.
  *
- * Steps:
- * 1. Resolve and read the prompt file
- * 2. Populate template context with Cue event data
- * 3. Substitute template variables
- * 4. Build agent spawn args (same pattern as process:spawn)
- * 5. Apply SSH wrapping if configured
- * 6. Spawn the process, capture stdout/stderr
- * 7. Enforce timeout with SIGTERM → SIGKILL escalation
- * 8. Return CueRunResult
+ * Orchestrates: template context → variable substitution → spawn spec → process.
  */
 export async function executeCuePrompt(config: CueExecutionConfig): Promise<CueRunResult> {
 	const {
@@ -116,376 +64,111 @@ export async function executeCuePrompt(config: CueExecutionConfig): Promise<CueR
 		subscription,
 		event,
 		promptPath,
-		toolType,
-		projectRoot,
 		templateContext,
 		timeoutMs,
 		sshRemoteConfig,
-		customPath,
-		customArgs,
-		customEnvVars,
-		customModel,
-		customEffort,
 		onLog,
-		sshStore,
-		agentConfigValues,
 	} = config;
 
 	const startedAt = new Date().toISOString();
 	const startTime = Date.now();
 
-	// 1. Resolve prompt: the normalizer (cue-config-normalizer.ts) already resolved
-	// prompt_file → file contents at config load time, so promptPath is the inline
-	// prompt content (or empty string if the prompt_file failed to load — surfaced as
-	// a warning at session init time in cue-session-runtime-service.ts).
-	const promptContent = promptPath;
-	const trimmedPrompt = promptContent?.trim();
+	// Helper to build a failed result
+	const failedResult = (message: string): CueRunResult => ({
+		runId,
+		sessionId: session.id,
+		sessionName: session.name,
+		subscriptionName: subscription.name,
+		event,
+		status: 'failed',
+		stdout: '',
+		stderr: message,
+		exitCode: null,
+		durationMs: Date.now() - startTime,
+		startedAt,
+		endedAt: new Date().toISOString(),
+	});
+
+	// 1. Validate prompt content
+	const trimmedPrompt = promptPath?.trim();
 	if (!trimmedPrompt) {
 		const message = `Cue subscription "${subscription.name}" has no prompt content (prompt_file may have failed to load at config time)`;
 		onLog('error', message);
-		return {
-			runId,
-			sessionId: session.id,
-			sessionName: session.name,
-			subscriptionName: subscription.name,
-			event,
-			status: 'failed',
-			stdout: '',
-			stderr: message,
-			exitCode: null,
-			durationMs: Date.now() - startTime,
-			startedAt,
-			endedAt: new Date().toISOString(),
-		};
+		return failedResult(message);
 	}
 
-	// 3. Populate the template context with Cue event data
-	templateContext.cue = {
-		eventType: event.type,
-		eventTimestamp: event.timestamp,
-		triggerName: subscription.name,
+	// 2. Build template context and substitute variables
+	templateContext.cue = buildCueTemplateContext(event, subscription, runId);
+	const substitutedPrompt = substituteTemplateVariables(promptPath, templateContext);
+
+	// 3. Build spawn spec (agent args, SSH wrapping, etc.)
+	const buildResult = await buildSpawnSpec(config, substitutedPrompt);
+	if (!buildResult.ok) {
+		onLog('error', buildResult.message);
+		return failedResult(buildResult.message);
+	}
+
+	const { spec } = buildResult;
+
+	// Log SSH remote usage
+	if (spec.sshRemoteUsed) {
+		onLog('cue', `[CUE] Using SSH remote: ${spec.sshRemoteUsed.name || spec.sshRemoteUsed.host}`);
+	}
+
+	// 4. Execute the process
+	onLog(
+		'cue',
+		`[CUE] Executing run ${runId}: "${subscription.name}" → ${spec.command} (${event.type})`
+	);
+
+	const processResult = await runProcess(runId, spec, {
+		toolType: config.toolType,
+		timeoutMs,
+		sshRemoteEnabled: sshRemoteConfig?.enabled,
+		sshStdinScript: spec.sshStdinScript,
+		stdinPrompt: spec.stdinPrompt,
+		onLog,
+	});
+
+	// 5. Assemble final result
+	return {
 		runId,
-		filePath: String(event.payload.path ?? ''),
-		fileName: String(event.payload.filename ?? ''),
-		fileDir: String(event.payload.directory ?? ''),
-		fileExt: String(event.payload.extension ?? ''),
-		fileChangeType: String(event.payload.changeType ?? ''),
-		sourceSession: String(event.payload.sourceSession ?? ''),
-		sourceOutput: String(event.payload.sourceOutput ?? ''),
-		sourceStatus: String(event.payload.status ?? ''),
-		sourceExitCode: String(event.payload.exitCode ?? ''),
-		sourceDuration: String(event.payload.durationMs ?? ''),
-		sourceTriggeredBy: String(event.payload.triggeredBy ?? ''),
+		sessionId: session.id,
+		sessionName: session.name,
+		subscriptionName: subscription.name,
+		event,
+		status: processResult.status,
+		stdout: processResult.stdout,
+		stderr: processResult.stderr,
+		exitCode: processResult.exitCode,
+		durationMs: Date.now() - startTime,
+		startedAt,
+		endedAt: new Date().toISOString(),
 	};
-
-	// Populate task.pending-specific template context
-	if (event.type === 'task.pending') {
-		templateContext.cue = {
-			...templateContext.cue,
-			taskFile: String(event.payload.path ?? ''),
-			taskFileName: String(event.payload.filename ?? ''),
-			taskFileDir: String(event.payload.directory ?? ''),
-			taskCount: String(event.payload.taskCount ?? '0'),
-			taskList: String(event.payload.taskList ?? ''),
-			taskContent: String(event.payload.content ?? ''),
-		};
-	}
-
-	// Populate GitHub-specific template context
-	if (event.type === 'github.pull_request' || event.type === 'github.issue') {
-		templateContext.cue = {
-			...templateContext.cue,
-			ghType: String(event.payload.type ?? ''),
-			ghNumber: String(event.payload.number ?? ''),
-			ghTitle: String(event.payload.title ?? ''),
-			ghAuthor: String(event.payload.author ?? ''),
-			ghUrl: String(event.payload.url ?? ''),
-			ghBody: String(event.payload.body ?? ''),
-			ghLabels: String(event.payload.labels ?? ''),
-			ghState: String(event.payload.state ?? ''),
-			ghRepo: String(event.payload.repo ?? ''),
-			ghBranch: String(event.payload.head_branch ?? ''),
-			ghBaseBranch: String(event.payload.base_branch ?? ''),
-			ghAssignees: String(event.payload.assignees ?? ''),
-			ghMergedAt: String(event.payload.merged_at ?? ''),
-		};
-	}
-
-	// 4. Substitute template variables
-	const substitutedPrompt = substituteTemplateVariables(promptContent, templateContext);
-
-	// 5. Look up agent definition and build args
-	const agentDef = getAgentDefinition(toolType);
-	if (!agentDef) {
-		const message = `Unknown agent type: ${toolType}`;
-		onLog('error', message);
-		return {
-			runId,
-			sessionId: session.id,
-			sessionName: session.name,
-			subscriptionName: subscription.name,
-			event,
-			status: 'failed',
-			stdout: '',
-			stderr: message,
-			exitCode: null,
-			durationMs: Date.now() - startTime,
-			startedAt,
-			endedAt: new Date().toISOString(),
-		};
-	}
-
-	// Build args following the same pipeline as process:spawn
-	// Cast to AgentConfig-like shape with available/path/capabilities for buildAgentArgs
-	const agentConfig = {
-		...agentDef,
-		available: true,
-		path: customPath || agentDef.command,
-		capabilities: getAgentCapabilities(toolType),
-	};
-
-	let finalArgs = buildAgentArgs(agentConfig, {
-		baseArgs: agentDef.args,
-		prompt: substitutedPrompt,
-		cwd: projectRoot,
-		yoloMode: true, // Cue runs always use YOLO mode like Auto Run
-	});
-
-	// Apply config overrides (custom model, custom args, custom env vars)
-	const configResolution = applyAgentConfigOverrides(agentConfig, finalArgs, {
-		agentConfigValues: (agentConfigValues ?? {}) as Record<string, any>,
-		sessionCustomModel: customModel,
-		sessionCustomEffort: customEffort,
-		sessionCustomArgs: customArgs,
-		sessionCustomEnvVars: customEnvVars,
-	});
-	finalArgs = configResolution.args;
-	const effectiveEnvVars = configResolution.effectiveCustomEnvVars;
-
-	// Determine the command to use
-	let command = customPath || agentDef.command;
-
-	// 6. Apply SSH wrapping if configured.
-	// For SSH: wrapSpawnWithSsh appends the prompt itself (via promptArgs/noPromptSeparator/'--, prompt').
-	//          Pass finalArgs WITHOUT the prompt so the wrapper handles it cleanly.
-	// For local: append the prompt below after the SSH check (same logic as ChildProcessSpawner).
-	let spawnArgs = finalArgs;
-	let spawnCwd = projectRoot;
-	let spawnEnvVars = effectiveEnvVars;
-	let prompt: string | undefined = substitutedPrompt;
-	let sshStdinScript: string | undefined;
-
-	if (sshRemoteConfig?.enabled && sshStore) {
-		const sshWrapConfig: SshSpawnWrapConfig = {
-			command,
-			args: finalArgs, // No prompt yet — wrapSpawnWithSsh appends it via config.prompt
-			cwd: projectRoot,
-			prompt: substitutedPrompt,
-			customEnvVars: effectiveEnvVars,
-			agentBinaryName: agentDef.binaryName,
-			promptArgs: agentDef.promptArgs,
-			noPromptSeparator: agentDef.noPromptSeparator,
-		};
-
-		const sshResult = await wrapSpawnWithSsh(sshWrapConfig, sshRemoteConfig, sshStore);
-		command = sshResult.command;
-		spawnArgs = sshResult.args;
-		spawnCwd = sshResult.cwd;
-		spawnEnvVars = sshResult.customEnvVars;
-		prompt = sshResult.prompt;
-		sshStdinScript = sshResult.sshStdinScript;
-
-		if (sshResult.sshRemoteUsed) {
-			onLog(
-				'cue',
-				`[CUE] Using SSH remote: ${sshResult.sshRemoteUsed.name || sshResult.sshRemoteUsed.host}`
-			);
-		}
-	}
-
-	// For local execution: append prompt as a positional CLI argument.
-	// SSH mode skips this — wrapSpawnWithSsh already embedded the prompt in spawnArgs.
-	// Mirrors ChildProcessSpawner logic: promptArgs > noPromptSeparator > '--' separator.
-	if (!sshRemoteConfig?.enabled) {
-		if (agentDef.promptArgs) {
-			spawnArgs = [...spawnArgs, ...agentDef.promptArgs(substitutedPrompt)];
-		} else if (agentDef.noPromptSeparator) {
-			spawnArgs = [...spawnArgs, substitutedPrompt];
-		} else {
-			spawnArgs = [...spawnArgs, '--', substitutedPrompt];
-		}
-	}
-
-	// 7. Spawn the process
-	onLog('cue', `[CUE] Executing run ${runId}: "${subscription.name}" → ${command} (${event.type})`);
-
-	return new Promise<CueRunResult>((resolve) => {
-		const env = {
-			...process.env,
-			...(spawnEnvVars || {}),
-		};
-
-		const child = spawn(command, spawnArgs, {
-			cwd: spawnCwd,
-			env,
-			stdio: ['pipe', 'pipe', 'pipe'],
-		});
-
-		activeProcesses.set(runId, {
-			child,
-			command,
-			args: spawnArgs,
-			cwd: spawnCwd,
-			toolType,
-			startTime: Date.now(),
-		});
-
-		let stdout = '';
-		let stderr = '';
-		let settled = false;
-		let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
-		let killTimer: ReturnType<typeof setTimeout> | undefined;
-
-		const finish = (status: CueRunStatus, exitCode: number | null) => {
-			if (settled) return;
-			settled = true;
-
-			activeProcesses.delete(runId);
-			if (timeoutTimer) clearTimeout(timeoutTimer);
-			if (killTimer) clearTimeout(killTimer);
-
-			resolve({
-				runId,
-				sessionId: session.id,
-				sessionName: session.name,
-				subscriptionName: subscription.name,
-				event,
-				status,
-				stdout: extractCleanStdout(stdout, toolType),
-				stderr,
-				exitCode,
-				durationMs: Date.now() - startTime,
-				startedAt,
-				endedAt: new Date().toISOString(),
-			});
-		};
-
-		// Capture stdout
-		child.stdout?.setEncoding('utf8');
-		child.stdout?.on('data', (data: string) => {
-			stdout += data;
-		});
-
-		// Capture stderr
-		child.stderr?.setEncoding('utf8');
-		child.stderr?.on('data', (data: string) => {
-			stderr += data;
-		});
-
-		// Handle process exit
-		child.on('close', (code) => {
-			const status: CueRunStatus = code === 0 ? 'completed' : 'failed';
-			finish(status, code);
-		});
-
-		// Handle spawn errors
-		child.on('error', (error) => {
-			stderr += `\nSpawn error: ${error.message}`;
-			finish('failed', null);
-		});
-
-		// Write prompt to stdin if not embedded in args
-		// For agents with promptArgs (like OpenCode -p), the prompt is in the args
-		// For others (like Claude --print), if prompt was passed via args separator, skip stdin
-		// When SSH wrapping returns a prompt, it means "send via stdin"
-		if (sshStdinScript && sshRemoteConfig?.enabled) {
-			// SSH stdin script mode — send the full bash script (includes prompt) via stdin
-			child.stdin?.write(sshStdinScript);
-			child.stdin?.end();
-		} else if (prompt && sshRemoteConfig?.enabled) {
-			// SSH small prompt mode — send raw prompt via stdin
-			child.stdin?.write(prompt);
-			child.stdin?.end();
-		} else {
-			// Local mode — prompt is already in the args (via buildAgentArgs)
-			child.stdin?.end();
-		}
-
-		// 8. Enforce timeout
-		if (timeoutMs > 0) {
-			timeoutTimer = setTimeout(() => {
-				if (settled) return;
-				onLog('cue', `[CUE] Run ${runId} timed out after ${timeoutMs}ms, sending SIGTERM`);
-				child.kill('SIGTERM');
-
-				// Escalate to SIGKILL after delay
-				killTimer = setTimeout(() => {
-					if (settled) return;
-					onLog('cue', `[CUE] Run ${runId} still alive, sending SIGKILL`);
-					child.kill('SIGKILL');
-				}, SIGKILL_DELAY_MS);
-
-				// If the process exits after SIGTERM, mark as timeout
-				child.removeAllListeners('close');
-				child.on('close', (code) => {
-					finish('timeout', code);
-				});
-			}, timeoutMs);
-		}
-	});
 }
 
 /**
  * Stop a running Cue process by runId.
- * Sends SIGTERM, then SIGKILL after 5 seconds.
- *
- * @returns true if the process was found and signaled, false if not found
+ * Delegates to the process lifecycle module.
  */
 export function stopCueRun(runId: string): boolean {
-	const entry = activeProcesses.get(runId);
-	if (!entry) return false;
-
-	entry.child.kill('SIGTERM');
-
-	// Escalate to SIGKILL after delay — only if the process hasn't actually exited.
-	// Check both exitCode and signalCode: either being non-null means the child has
-	// terminated. This avoids sending SIGKILL to a recycled PID.
-	setTimeout(() => {
-		if (entry.child.exitCode === null && entry.child.signalCode === null) {
-			entry.child.kill('SIGKILL');
-		}
-	}, SIGKILL_DELAY_MS);
-
-	return true;
+	return stopProcess(runId);
 }
 
 /**
  * Get the map of currently active processes (for testing/monitoring).
+ * Delegates to the process lifecycle module.
  */
-export function getActiveProcesses(): Map<string, CueActiveProcess> {
-	return activeProcesses;
+export function getActiveProcesses(): Map<string, any> {
+	return getActiveProcessMap();
 }
 
 /**
  * Get serializable info about active Cue processes (for Process Monitor).
- * Filters out entries where the process PID is unavailable (spawn failure).
+ * Delegates to the process lifecycle module.
  */
-export function getCueProcessList(): CueProcessInfo[] {
-	const result: CueProcessInfo[] = [];
-	for (const [runId, entry] of activeProcesses) {
-		if (entry.child.pid) {
-			result.push({
-				runId,
-				pid: entry.child.pid,
-				command: entry.command,
-				args: entry.args,
-				cwd: entry.cwd,
-				toolType: entry.toolType,
-				startTime: entry.startTime,
-			});
-		}
-	}
-	return result;
+export function getCueProcessList(): import('./cue-process-lifecycle').CueProcessInfo[] {
+	return getProcessList();
 }
 
 /**

--- a/src/main/cue/cue-executor.ts
+++ b/src/main/cue/cue-executor.ts
@@ -58,17 +58,8 @@ export interface CueExecutionConfig {
  * Orchestrates: template context → variable substitution → spawn spec → process.
  */
 export async function executeCuePrompt(config: CueExecutionConfig): Promise<CueRunResult> {
-	const {
-		runId,
-		session,
-		subscription,
-		event,
-		promptPath,
-		templateContext,
-		timeoutMs,
-		sshRemoteConfig,
-		onLog,
-	} = config;
+	const { runId, session, subscription, event, promptPath, templateContext, timeoutMs, onLog } =
+		config;
 
 	const startedAt = new Date().toISOString();
 	const startTime = Date.now();
@@ -121,12 +112,13 @@ export async function executeCuePrompt(config: CueExecutionConfig): Promise<CueR
 		`[CUE] Executing run ${runId}: "${subscription.name}" → ${spec.command} (${event.type})`
 	);
 
+	const sshActuallyUsed = !!spec.sshRemoteUsed;
 	const processResult = await runProcess(runId, spec, {
 		toolType: config.toolType,
 		timeoutMs,
-		sshRemoteEnabled: sshRemoteConfig?.enabled,
-		sshStdinScript: spec.sshStdinScript,
-		stdinPrompt: spec.stdinPrompt,
+		sshRemoteEnabled: sshActuallyUsed,
+		sshStdinScript: sshActuallyUsed ? spec.sshStdinScript : undefined,
+		stdinPrompt: sshActuallyUsed ? spec.stdinPrompt : undefined,
 		onLog,
 	});
 

--- a/src/main/cue/cue-executor.ts
+++ b/src/main/cue/cue-executor.ts
@@ -11,11 +11,12 @@
  */
 
 import * as crypto from 'crypto';
-import type { CueRunResult, CueSubscription } from './cue-types';
+import type { CueEvent, CueRunResult, CueSubscription } from './cue-types';
 import type { HistoryEntry, SessionInfo } from '../../shared/types';
 import { substituteTemplateVariables, type TemplateContext } from '../../shared/templateVariables';
 import { buildCueTemplateContext } from './cue-template-context-builder';
 import { buildSpawnSpec } from './cue-spawn-builder';
+import type { SshRemoteSettingsStore } from '../utils/ssh-remote-resolver';
 import {
 	runProcess,
 	stopProcess,
@@ -33,7 +34,7 @@ export interface CueExecutionConfig {
 	runId: string;
 	session: SessionInfo;
 	subscription: CueSubscription;
-	event: import('./cue-types').CueEvent;
+	event: CueEvent;
 	promptPath: string;
 	toolType: string;
 	projectRoot: string;
@@ -47,7 +48,7 @@ export interface CueExecutionConfig {
 	customEffort?: string;
 	onLog: (level: string, message: string) => void;
 	/** Optional SSH settings store for SSH remote execution */
-	sshStore?: import('../utils/ssh-remote-resolver').SshRemoteSettingsStore;
+	sshStore?: SshRemoteSettingsStore;
 	/** Optional agent-level config values (from agent config store) */
 	agentConfigValues?: Record<string, unknown>;
 }

--- a/src/main/cue/cue-executor.ts
+++ b/src/main/cue/cue-executor.ts
@@ -99,7 +99,7 @@ export async function executeCuePrompt(config: CueExecutionConfig): Promise<CueR
 
 	// 2. Build template context and substitute variables
 	templateContext.cue = buildCueTemplateContext(event, subscription, runId);
-	const substitutedPrompt = substituteTemplateVariables(promptPath, templateContext);
+	const substitutedPrompt = substituteTemplateVariables(trimmedPrompt, templateContext);
 
 	// 3. Build spawn spec (agent args, SSH wrapping, etc.)
 	const buildResult = await buildSpawnSpec(config, substitutedPrompt);
@@ -159,7 +159,7 @@ export function stopCueRun(runId: string): boolean {
  * Get the map of currently active processes (for testing/monitoring).
  * Delegates to the process lifecycle module.
  */
-export function getActiveProcesses(): Map<string, any> {
+export function getActiveProcesses(): ReturnType<typeof getActiveProcessMap> {
 	return getActiveProcessMap();
 }
 

--- a/src/main/cue/cue-process-lifecycle.ts
+++ b/src/main/cue/cue-process-lifecycle.ts
@@ -1,0 +1,259 @@
+/**
+ * Cue Process Lifecycle — spawns child processes, manages stdio capture,
+ * enforces timeout with SIGTERM → SIGKILL escalation, and tracks active
+ * processes for the Process Monitor.
+ *
+ * Single responsibility: process spawning and lifecycle management.
+ * Does NOT know about template variables, agent definitions, or SSH —
+ * it receives a fully resolved SpawnSpec and executes it.
+ */
+
+import { spawn, type ChildProcess } from 'child_process';
+import type { CueRunStatus } from './cue-types';
+import type { SpawnSpec } from './cue-spawn-builder';
+import type { ToolType } from '../../shared/types';
+import { getOutputParser } from '../parsers';
+
+const SIGKILL_DELAY_MS = 5000;
+
+// ─── Types ──────���────────────────────────────────────────────────────────────
+
+/** Metadata stored alongside each active Cue process */
+interface CueActiveProcess {
+	child: ChildProcess;
+	command: string;
+	args: string[];
+	cwd: string;
+	toolType: string;
+	startTime: number;
+}
+
+/** Serializable process info for the Process Monitor */
+export interface CueProcessInfo {
+	runId: string;
+	pid: number;
+	command: string;
+	args: string[];
+	cwd: string;
+	toolType: string;
+	startTime: number;
+}
+
+/** Result of a process execution */
+export interface ProcessRunResult {
+	stdout: string;
+	stderr: string;
+	exitCode: number | null;
+	status: CueRunStatus;
+}
+
+/** Options controlling process execution */
+export interface ProcessRunOptions {
+	toolType: string;
+	timeoutMs: number;
+	sshRemoteEnabled?: boolean;
+	sshStdinScript?: string;
+	stdinPrompt?: string;
+	onLog: (level: string, message: string) => void;
+}
+
+// ─── Module State ────────────────────────────────────────────────────────────
+
+/** Map of active Cue processes by runId */
+const activeProcesses = new Map<string, CueActiveProcess>();
+
+// ─── Internal Helpers ─────────��──────────────────────────────────────────────
+
+/**
+ * Extract clean human-readable text from agent stdout.
+ * For agents that output JSON/NDJSON (like OpenCode --format json), parses each
+ * line and collects text from 'result' events. Falls back to raw stdout when no
+ * parser is available or no result-text events are found (e.g. plain-text agents).
+ */
+function extractCleanStdout(rawStdout: string, toolType: string): string {
+	if (!rawStdout.trim()) {
+		return rawStdout;
+	}
+
+	const parser = getOutputParser(toolType as ToolType);
+	if (!parser) {
+		return rawStdout;
+	}
+
+	const textParts: string[] = [];
+	for (const line of rawStdout.split('\n')) {
+		if (!line.trim()) continue;
+		const event = parser.parseJsonLine(line);
+		if (event?.type === 'result' && event.text) {
+			textParts.push(event.text);
+		}
+	}
+
+	return textParts.length > 0 ? textParts.join('\n') : rawStdout;
+}
+
+// ─── Public API ─────────────���─────────────────────────���──────────────────────
+
+/**
+ * Spawn a process from a SpawnSpec, capture stdio, and enforce timeout.
+ *
+ * Returns a promise that resolves with the process result when the child
+ * exits (or is killed due to timeout).
+ */
+export function runProcess(
+	runId: string,
+	spec: SpawnSpec,
+	options: ProcessRunOptions
+): Promise<ProcessRunResult> {
+	const { toolType, timeoutMs, sshRemoteEnabled, sshStdinScript, stdinPrompt, onLog } = options;
+
+	return new Promise<ProcessRunResult>((resolve) => {
+		const child = spawn(spec.command, spec.args, {
+			cwd: spec.cwd,
+			env: spec.env,
+			stdio: ['pipe', 'pipe', 'pipe'],
+		});
+
+		activeProcesses.set(runId, {
+			child,
+			command: spec.command,
+			args: spec.args,
+			cwd: spec.cwd,
+			toolType,
+			startTime: Date.now(),
+		});
+
+		let stdout = '';
+		let stderr = '';
+		let settled = false;
+		let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
+		let killTimer: ReturnType<typeof setTimeout> | undefined;
+
+		const finish = (status: CueRunStatus, exitCode: number | null) => {
+			if (settled) return;
+			settled = true;
+
+			activeProcesses.delete(runId);
+			if (timeoutTimer) clearTimeout(timeoutTimer);
+			if (killTimer) clearTimeout(killTimer);
+
+			resolve({
+				stdout: extractCleanStdout(stdout, toolType),
+				stderr,
+				exitCode,
+				status,
+			});
+		};
+
+		// Capture stdout
+		child.stdout?.setEncoding('utf8');
+		child.stdout?.on('data', (data: string) => {
+			stdout += data;
+		});
+
+		// Capture stderr
+		child.stderr?.setEncoding('utf8');
+		child.stderr?.on('data', (data: string) => {
+			stderr += data;
+		});
+
+		// Handle process exit
+		child.on('close', (code) => {
+			const status: CueRunStatus = code === 0 ? 'completed' : 'failed';
+			finish(status, code);
+		});
+
+		// Handle spawn errors
+		child.on('error', (error) => {
+			stderr += `\nSpawn error: ${error.message}`;
+			finish('failed', null);
+		});
+
+		// Write to stdin based on execution mode
+		if (sshStdinScript && sshRemoteEnabled) {
+			// SSH stdin script mode — send the full bash script via stdin
+			child.stdin?.write(sshStdinScript);
+			child.stdin?.end();
+		} else if (stdinPrompt && sshRemoteEnabled) {
+			// SSH small prompt mode — send raw prompt via stdin
+			child.stdin?.write(stdinPrompt);
+			child.stdin?.end();
+		} else {
+			// Local mode — prompt is already in the args
+			child.stdin?.end();
+		}
+
+		// Enforce timeout with SIGTERM → SIGKILL escalation
+		if (timeoutMs > 0) {
+			timeoutTimer = setTimeout(() => {
+				if (settled) return;
+				onLog('cue', `[CUE] Run ${runId} timed out after ${timeoutMs}ms, sending SIGTERM`);
+				child.kill('SIGTERM');
+
+				// Escalate to SIGKILL after delay
+				killTimer = setTimeout(() => {
+					if (settled) return;
+					onLog('cue', `[CUE] Run ${runId} still alive, sending SIGKILL`);
+					child.kill('SIGKILL');
+				}, SIGKILL_DELAY_MS);
+
+				// If the process exits after SIGTERM, mark as timeout
+				child.removeAllListeners('close');
+				child.on('close', (code) => {
+					finish('timeout', code);
+				});
+			}, timeoutMs);
+		}
+	});
+}
+
+/**
+ * Stop a running Cue process by runId.
+ * Sends SIGTERM, then SIGKILL after 5 seconds.
+ *
+ * @returns true if the process was found and signaled, false if not found
+ */
+export function stopProcess(runId: string): boolean {
+	const entry = activeProcesses.get(runId);
+	if (!entry) return false;
+
+	entry.child.kill('SIGTERM');
+
+	// Escalate to SIGKILL after delay — only if the process hasn't actually exited.
+	setTimeout(() => {
+		if (entry.child.exitCode === null && entry.child.signalCode === null) {
+			entry.child.kill('SIGKILL');
+		}
+	}, SIGKILL_DELAY_MS);
+
+	return true;
+}
+
+/**
+ * Get the map of currently active processes (for testing/monitoring).
+ */
+export function getActiveProcessMap(): Map<string, CueActiveProcess> {
+	return activeProcesses;
+}
+
+/**
+ * Get serializable info about active Cue processes (for Process Monitor).
+ * Filters out entries where the process PID is unavailable (spawn failure).
+ */
+export function getProcessList(): CueProcessInfo[] {
+	const result: CueProcessInfo[] = [];
+	for (const [runId, entry] of activeProcesses) {
+		if (entry.child.pid) {
+			result.push({
+				runId,
+				pid: entry.child.pid,
+				command: entry.command,
+				args: entry.args,
+				cwd: entry.cwd,
+				toolType: entry.toolType,
+				startTime: entry.startTime,
+			});
+		}
+	}
+	return result;
+}

--- a/src/main/cue/cue-process-lifecycle.ts
+++ b/src/main/cue/cue-process-lifecycle.ts
@@ -13,6 +13,7 @@ import type { CueRunStatus } from './cue-types';
 import type { SpawnSpec } from './cue-spawn-builder';
 import type { ToolType } from '../../shared/types';
 import { getOutputParser } from '../parsers';
+import { captureException } from '../utils/sentry';
 
 const SIGKILL_DELAY_MS = 5000;
 
@@ -108,11 +109,23 @@ export function runProcess(
 	const { toolType, timeoutMs, sshRemoteEnabled, sshStdinScript, stdinPrompt, onLog } = options;
 
 	return new Promise<ProcessRunResult>((resolve) => {
-		const child = spawn(spec.command, spec.args, {
-			cwd: spec.cwd,
-			env: spec.env,
-			stdio: ['pipe', 'pipe', 'pipe'],
-		});
+		let child: ChildProcess;
+		try {
+			child = spawn(spec.command, spec.args, {
+				cwd: spec.cwd,
+				env: spec.env,
+				stdio: ['pipe', 'pipe', 'pipe'],
+			});
+		} catch (err) {
+			captureException(err, { operation: 'cue:spawn', runId, command: spec.command });
+			resolve({
+				stdout: '',
+				stderr: `Spawn error: ${err instanceof Error ? err.message : String(err)}`,
+				exitCode: null,
+				status: 'failed',
+			});
+			return;
+		}
 
 		activeProcesses.set(runId, {
 			child,
@@ -163,8 +176,13 @@ export function runProcess(
 			finish(status, code);
 		});
 
-		// Handle spawn errors
+		// Handle spawn errors (async — e.g. ENOENT after spawn returns)
 		child.on('error', (error) => {
+			captureException(error, {
+				operation: 'cue:childProcess:error',
+				runId,
+				command: spec.command,
+			});
 			stderr += `\nSpawn error: ${error.message}`;
 			finish('failed', null);
 		});

--- a/src/main/cue/cue-run-manager.ts
+++ b/src/main/cue/cue-run-manager.ts
@@ -16,10 +16,14 @@ import type { CueEvent, CueRunResult, CueSettings, CueSubscription } from './cue
 import { recordCueEvent, updateCueEventStatus } from './cue-db';
 import { SOURCE_OUTPUT_MAX_CHARS } from './cue-fan-in-tracker';
 
+/** Phase of a run in the state machine: running → stopping | finished */
+export type RunPhase = 'running' | 'stopping' | 'finished';
+
 /** Active run tracking */
 export interface ActiveRun {
 	result: CueRunResult;
 	abortController?: AbortController;
+	phase: RunPhase;
 }
 
 /** A queued event waiting for a concurrency slot */
@@ -84,10 +88,22 @@ export function createCueRunManager(deps: CueRunManagerDeps): CueRunManager {
 	const activeRuns = new Map<string, ActiveRun>();
 	const activeRunCount = new Map<string, number>();
 	const eventQueue = new Map<string, QueuedEvent[]>();
-	const manuallyStoppedRuns = new Set<string>();
 
 	function getSessionName(sessionId: string): string {
 		return deps.getSessions().find((s) => s.id === sessionId)?.name ?? sessionId;
+	}
+
+	/**
+	 * Attempt a phase transition on an active run.
+	 * Returns the previous phase on success, or null if invalid
+	 * (run not found, already finished, or already in target phase).
+	 */
+	function transitionRun(runId: string, toPhase: 'stopping' | 'finished'): RunPhase | null {
+		const run = activeRuns.get(runId);
+		if (!run || run.phase === 'finished' || run.phase === toPhase) return null;
+		const from = run.phase;
+		run.phase = toPhase;
+		return from;
 	}
 
 	function drainQueue(sessionId: string): void {
@@ -162,7 +178,7 @@ export function createCueRunManager(deps: CueRunManagerDeps): CueRunManager {
 			endedAt: '',
 		};
 
-		activeRuns.set(runId, { result, abortController });
+		activeRuns.set(runId, { result, abortController, phase: 'running' });
 		deps.onPreventSleep?.(`cue:run:${runId}`);
 		const timeoutMs = (settings?.timeout_minutes ?? 30) * 60 * 1000;
 		try {
@@ -194,7 +210,7 @@ export function createCueRunManager(deps: CueRunManagerDeps): CueRunManager {
 				event,
 				timeoutMs,
 			});
-			if (manuallyStoppedRuns.has(runId)) {
+			if (!activeRuns.has(runId)) {
 				return;
 			}
 			result.status = runResult.status;
@@ -250,7 +266,7 @@ export function createCueRunManager(deps: CueRunManagerDeps): CueRunManager {
 					// Non-fatal if DB is unavailable
 				}
 
-				if (manuallyStoppedRuns.has(runId)) {
+				if (!activeRuns.has(runId)) {
 					return;
 				}
 
@@ -264,38 +280,27 @@ export function createCueRunManager(deps: CueRunManagerDeps): CueRunManager {
 				}
 			}
 		} catch (error) {
-			if (manuallyStoppedRuns.has(runId)) {
+			if (!activeRuns.has(runId)) {
 				return;
 			}
 			result.status = 'failed';
 			result.stderr = error instanceof Error ? error.message : String(error);
 		} finally {
-			result.endedAt = new Date().toISOString();
-			result.durationMs = Date.now() - new Date(result.startedAt).getTime();
-			activeRuns.delete(runId);
+			// Only clean up if the run is still tracked. If it was already removed
+			// (by stopRun or reset), that caller handled its own cleanup.
+			if (activeRuns.has(runId)) {
+				// Natural completion — set final timing and perform all cleanup
+				result.endedAt = new Date().toISOString();
+				result.durationMs = Date.now() - new Date(result.startedAt).getTime();
 
-			const wasManuallyStopped = manuallyStoppedRuns.has(runId);
-
-			// Only release sleep block here for non-stopped runs — stopRun already released eagerly
-			if (!wasManuallyStopped) {
+				transitionRun(runId, 'finished');
+				activeRuns.delete(runId);
 				deps.onAllowSleep?.(`cue:run:${runId}`);
-			}
 
-			// Only decrement here for non-stopped runs — stopRun already decremented eagerly
-			if (!wasManuallyStopped) {
 				const count = activeRunCount.get(sessionId) ?? 1;
 				activeRunCount.set(sessionId, Math.max(0, count - 1));
 				drainQueue(sessionId);
-			}
 
-			if (wasManuallyStopped) {
-				try {
-					updateCueEventStatus(runId, 'stopped');
-				} catch {
-					// Non-fatal if DB is unavailable
-				}
-				manuallyStoppedRuns.delete(runId);
-			} else {
 				try {
 					updateCueEventStatus(runId, result.status);
 				} catch {
@@ -366,25 +371,37 @@ export function createCueRunManager(deps: CueRunManagerDeps): CueRunManager {
 		},
 
 		stopRun(runId: string): boolean {
-			const run = activeRuns.get(runId);
-			if (!run) return false;
+			// Phase-validated transition: only running → stopping is valid
+			const prevPhase = transitionRun(runId, 'stopping');
+			if (prevPhase === null) return false;
 
-			manuallyStoppedRuns.add(runId);
+			const run = activeRuns.get(runId)!;
+
+			// Signal the process to stop
 			deps.onStopCueRun?.(runId);
 			run.abortController?.abort();
+
+			// Finalize the result for immediate UI feedback
 			run.result.status = 'stopped';
 			run.result.endedAt = new Date().toISOString();
 			run.result.durationMs = Date.now() - new Date(run.result.startedAt).getTime();
 
+			// Remove from activeRuns — the finally block in doExecuteCueRun
+			// sees this and skips its own cleanup (single ownership).
 			activeRuns.delete(runId);
 			deps.onAllowSleep?.(`cue:run:${runId}`);
 
-			// Free the concurrency slot immediately so queued events can proceed.
-			// The finally block in doExecuteCueRun skips its decrement for manually stopped runs.
+			// Free the concurrency slot immediately so queued events can proceed
 			const count = activeRunCount.get(run.result.sessionId) ?? 1;
 			activeRunCount.set(run.result.sessionId, Math.max(0, count - 1));
 			drainQueue(run.result.sessionId);
 
+			// Record final status in DB and notify
+			try {
+				updateCueEventStatus(runId, 'stopped');
+			} catch {
+				// Non-fatal if DB is unavailable
+			}
 			deps.onRunStopped(run.result);
 			deps.onLog('cue', `[CUE] Run stopped: ${runId}`, {
 				type: 'runStopped',
@@ -446,7 +463,6 @@ export function createCueRunManager(deps: CueRunManagerDeps): CueRunManager {
 			activeRuns.clear();
 			activeRunCount.clear();
 			eventQueue.clear();
-			manuallyStoppedRuns.clear();
 		},
 	};
 }

--- a/src/main/cue/cue-run-manager.ts
+++ b/src/main/cue/cue-run-manager.ts
@@ -15,6 +15,7 @@ import type { MainLogLevel } from '../../shared/logger-types';
 import type { CueEvent, CueRunResult, CueSettings, CueSubscription } from './cue-types';
 import { recordCueEvent, updateCueEventStatus } from './cue-db';
 import { SOURCE_OUTPUT_MAX_CHARS } from './cue-fan-in-tracker';
+import { captureException } from '../utils/sentry';
 
 /** Phase of a run in the state machine: running → stopping | finished */
 export type RunPhase = 'running' | 'stopping' | 'finished';
@@ -24,6 +25,8 @@ export interface ActiveRun {
 	result: CueRunResult;
 	abortController?: AbortController;
 	phase: RunPhase;
+	/** The runId of the currently executing child process (differs from result.runId during output prompt phase) */
+	processRunId?: string;
 }
 
 /** A queued event waiting for a concurrency slot */
@@ -250,6 +253,10 @@ export function createCueRunManager(deps: CueRunManagerDeps): CueRunManager {
 					// Non-fatal if DB is unavailable
 				}
 
+				// Track the output prompt's process ID so stopRun can kill it
+				const run = activeRuns.get(runId);
+				if (run) run.processRunId = outputRunId;
+
 				const contextPrompt = `${outputPrompt}\n\n---\n\nContext from completed task:\n${result.stdout.substring(0, SOURCE_OUTPUT_MAX_CHARS)}`;
 				const outputResult = await deps.onCueRun({
 					runId: outputRunId,
@@ -303,8 +310,13 @@ export function createCueRunManager(deps: CueRunManagerDeps): CueRunManager {
 
 				try {
 					updateCueEventStatus(runId, result.status);
-				} catch {
-					// Non-fatal if DB is unavailable
+				} catch (err) {
+					deps.onLog('warn', `[CUE] Failed to update DB status for run ${runId}`);
+					captureException(err, {
+						operation: 'cue:updateEventStatus',
+						runId,
+						status: result.status,
+					});
 				}
 				deps.onLog('cue', `[CUE] Run finished: ${subscriptionName} (${result.status})`, {
 					type: 'runFinished',
@@ -377,8 +389,12 @@ export function createCueRunManager(deps: CueRunManagerDeps): CueRunManager {
 
 			const run = activeRuns.get(runId)!;
 
-			// Signal the process to stop
+			// Signal the process to stop — kill the currently executing child process.
+			// During output prompt phase, processRunId differs from the parent runId.
 			deps.onStopCueRun?.(runId);
+			if (run.processRunId && run.processRunId !== runId) {
+				deps.onStopCueRun?.(run.processRunId);
+			}
 			run.abortController?.abort();
 
 			// Finalize the result for immediate UI feedback
@@ -399,8 +415,9 @@ export function createCueRunManager(deps: CueRunManagerDeps): CueRunManager {
 			// Record final status in DB and notify
 			try {
 				updateCueEventStatus(runId, 'stopped');
-			} catch {
-				// Non-fatal if DB is unavailable
+			} catch (err) {
+				deps.onLog('warn', `[CUE] Failed to update DB status for stopped run ${runId}`);
+				captureException(err, { operation: 'cue:updateEventStatus', runId, status: 'stopped' });
 			}
 			deps.onRunStopped(run.result);
 			deps.onLog('cue', `[CUE] Run stopped: ${runId}`, {

--- a/src/main/cue/cue-spawn-builder.ts
+++ b/src/main/cue/cue-spawn-builder.ts
@@ -1,0 +1,168 @@
+/**
+ * Cue Spawn Builder — constructs a fully resolved spawn specification
+ * from a CueExecutionConfig.
+ *
+ * Single responsibility: given session/agent/prompt/SSH config, produce a
+ * SpawnSpec (command, args, cwd, env, stdin data). No side effects beyond
+ * the async SSH resolution.
+ */
+
+import type { CueExecutionConfig } from './cue-executor';
+import { getAgentDefinition, getAgentCapabilities } from '../agents';
+import { buildAgentArgs, applyAgentConfigOverrides } from '../utils/agent-args';
+import { wrapSpawnWithSsh, type SshSpawnWrapConfig } from '../utils/ssh-spawn-wrapper';
+
+// ─── Types ──────���────────────────────────────────────────────────────────────
+
+/** Fully resolved spawn specification — everything needed to call spawn(). */
+export interface SpawnSpec {
+	command: string;
+	args: string[];
+	cwd: string;
+	env: Record<string, string>;
+	/** For SSH stdin-script mode: full bash script to send via stdin */
+	sshStdinScript?: string;
+	/** For SSH small-prompt mode: raw prompt to send via stdin */
+	stdinPrompt?: string;
+	/** Whether SSH remote execution was actually used */
+	sshRemoteUsed?: { name?: string; host: string };
+}
+
+/** Error result when the spawn spec cannot be built (e.g. unknown agent). */
+export interface SpawnBuildError {
+	ok: false;
+	message: string;
+}
+
+/** Successful build result. */
+export interface SpawnBuildSuccess {
+	ok: true;
+	spec: SpawnSpec;
+}
+
+export type SpawnBuildResult = SpawnBuildSuccess | SpawnBuildError;
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+
+/**
+ * Build a SpawnSpec from the given execution config.
+ *
+ * Follows the same pipeline as `process:spawn` IPC handler:
+ * 1. Look up agent definition and capabilities
+ * 2. Build base args via buildAgentArgs
+ * 3. Apply config overrides (custom model, args, env)
+ * 4. Apply SSH wrapping if enabled
+ * 5. Append prompt to args for local execution
+ */
+export async function buildSpawnSpec(
+	config: CueExecutionConfig,
+	substitutedPrompt: string
+): Promise<SpawnBuildResult> {
+	const {
+		toolType,
+		projectRoot,
+		sshRemoteConfig,
+		customPath,
+		customArgs,
+		customEnvVars,
+		customModel,
+		customEffort,
+		sshStore,
+		agentConfigValues,
+	} = config;
+
+	// 1. Look up agent definition
+	const agentDef = getAgentDefinition(toolType);
+	if (!agentDef) {
+		return { ok: false, message: `Unknown agent type: ${toolType}` };
+	}
+
+	// 2. Build args following the same pipeline as process:spawn
+	const agentConfig = {
+		...agentDef,
+		available: true,
+		path: customPath || agentDef.command,
+		capabilities: getAgentCapabilities(toolType),
+	};
+
+	let finalArgs = buildAgentArgs(agentConfig, {
+		baseArgs: agentDef.args,
+		prompt: substitutedPrompt,
+		cwd: projectRoot,
+		yoloMode: true, // Cue runs always use YOLO mode like Auto Run
+	});
+
+	// 3. Apply config overrides (custom model, custom args, custom env vars)
+	const configResolution = applyAgentConfigOverrides(agentConfig, finalArgs, {
+		agentConfigValues: (agentConfigValues ?? {}) as Record<string, any>,
+		sessionCustomModel: customModel,
+		sessionCustomEffort: customEffort,
+		sessionCustomArgs: customArgs,
+		sessionCustomEnvVars: customEnvVars,
+	});
+	finalArgs = configResolution.args;
+	const effectiveEnvVars = configResolution.effectiveCustomEnvVars;
+
+	// Determine command
+	let command = customPath || agentDef.command;
+	let spawnArgs = finalArgs;
+	let spawnCwd = projectRoot;
+	let spawnEnvVars = effectiveEnvVars;
+	let sshStdinScript: string | undefined;
+	let stdinPrompt: string | undefined;
+	let sshRemoteUsed: SpawnSpec['sshRemoteUsed'];
+
+	// 4. Apply SSH wrapping if configured
+	if (sshRemoteConfig?.enabled && sshStore) {
+		const sshWrapConfig: SshSpawnWrapConfig = {
+			command,
+			args: finalArgs,
+			cwd: projectRoot,
+			prompt: substitutedPrompt,
+			customEnvVars: effectiveEnvVars,
+			agentBinaryName: agentDef.binaryName,
+			promptArgs: agentDef.promptArgs,
+			noPromptSeparator: agentDef.noPromptSeparator,
+		};
+
+		const sshResult = await wrapSpawnWithSsh(sshWrapConfig, sshRemoteConfig, sshStore);
+		command = sshResult.command;
+		spawnArgs = sshResult.args;
+		spawnCwd = sshResult.cwd;
+		spawnEnvVars = sshResult.customEnvVars;
+		sshStdinScript = sshResult.sshStdinScript;
+		stdinPrompt = sshResult.prompt;
+
+		if (sshResult.sshRemoteUsed) {
+			sshRemoteUsed = sshResult.sshRemoteUsed;
+		}
+	}
+
+	// 5. For local execution: append prompt as a positional CLI argument.
+	// SSH mode skips this — wrapSpawnWithSsh already embedded the prompt.
+	if (!sshRemoteConfig?.enabled) {
+		if (agentDef.promptArgs) {
+			spawnArgs = [...spawnArgs, ...agentDef.promptArgs(substitutedPrompt)];
+		} else if (agentDef.noPromptSeparator) {
+			spawnArgs = [...spawnArgs, substitutedPrompt];
+		} else {
+			spawnArgs = [...spawnArgs, '--', substitutedPrompt];
+		}
+	}
+
+	return {
+		ok: true,
+		spec: {
+			command,
+			args: spawnArgs,
+			cwd: spawnCwd,
+			env: {
+				...process.env,
+				...(spawnEnvVars || {}),
+			} as Record<string, string>,
+			sshStdinScript,
+			stdinPrompt,
+			sshRemoteUsed,
+		},
+	};
+}

--- a/src/main/cue/cue-spawn-builder.ts
+++ b/src/main/cue/cue-spawn-builder.ts
@@ -138,9 +138,10 @@ export async function buildSpawnSpec(
 		}
 	}
 
-	// 5. For local execution: append prompt as a positional CLI argument.
-	// SSH mode skips this — wrapSpawnWithSsh already embedded the prompt.
-	if (!sshRemoteConfig?.enabled) {
+	// 5. Append prompt as a positional CLI argument when the SSH wrapper
+	// was NOT actually used. If sshRemoteConfig.enabled is true but sshStore
+	// was missing, SSH wrapping was skipped so we still need to append.
+	if (!sshRemoteUsed) {
 		if (agentDef.promptArgs) {
 			spawnArgs = [...spawnArgs, ...agentDef.promptArgs(substitutedPrompt)];
 		} else if (agentDef.noPromptSeparator) {

--- a/src/main/cue/cue-template-context-builder.ts
+++ b/src/main/cue/cue-template-context-builder.ts
@@ -1,0 +1,114 @@
+/**
+ * Cue Template Context Builder — builds the `templateContext.cue` object
+ * from a CueEvent's payload using an enricher registry pattern.
+ *
+ * Each event type registers an enricher function that maps payload fields
+ * to template context keys. Adding a new event type requires only adding
+ * one enricher entry — no changes to the executor or engine.
+ */
+
+import type { CueEvent, CueSubscription } from './cue-types';
+import type { CueEventType } from '../../shared/cue/contracts';
+import type { TemplateContext } from '../../shared/templateVariables';
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+/** A function that extracts template context fields from an event payload. */
+type CueContextEnricher = (
+	event: CueEvent,
+	subscription: CueSubscription,
+	runId: string
+) => Record<string, string>;
+
+/** The cue sub-object of TemplateContext */
+export type CueTemplateContext = NonNullable<TemplateContext['cue']>;
+
+// ─── Enricher Registry ───────────────────────────────────────────────────────
+
+/**
+ * Registry of enricher functions keyed by event type.
+ * The special key '*' runs for every event type (base fields).
+ */
+const enricherRegistry = new Map<CueEventType | '*', CueContextEnricher>();
+
+/** Base enricher — runs for all event types. Populates common fields. */
+enricherRegistry.set('*', (event, subscription, runId) => ({
+	eventType: event.type,
+	eventTimestamp: event.timestamp,
+	triggerName: subscription.name,
+	runId,
+	filePath: String(event.payload.path ?? ''),
+	fileName: String(event.payload.filename ?? ''),
+	fileDir: String(event.payload.directory ?? ''),
+	fileExt: String(event.payload.extension ?? ''),
+	fileChangeType: String(event.payload.changeType ?? ''),
+	sourceSession: String(event.payload.sourceSession ?? ''),
+	sourceOutput: String(event.payload.sourceOutput ?? ''),
+	sourceStatus: String(event.payload.status ?? ''),
+	sourceExitCode: String(event.payload.exitCode ?? ''),
+	sourceDuration: String(event.payload.durationMs ?? ''),
+	sourceTriggeredBy: String(event.payload.triggeredBy ?? ''),
+}));
+
+/** task.pending enricher — adds task-specific fields. */
+enricherRegistry.set('task.pending', (event) => ({
+	taskFile: String(event.payload.path ?? ''),
+	taskFileName: String(event.payload.filename ?? ''),
+	taskFileDir: String(event.payload.directory ?? ''),
+	taskCount: String(event.payload.taskCount ?? '0'),
+	taskList: String(event.payload.taskList ?? ''),
+	taskContent: String(event.payload.content ?? ''),
+}));
+
+/** Shared GitHub enricher for both pull_request and issue events. */
+function buildGitHubContext(event: CueEvent): Record<string, string> {
+	return {
+		ghType: String(event.payload.type ?? ''),
+		ghNumber: String(event.payload.number ?? ''),
+		ghTitle: String(event.payload.title ?? ''),
+		ghAuthor: String(event.payload.author ?? ''),
+		ghUrl: String(event.payload.url ?? ''),
+		ghBody: String(event.payload.body ?? ''),
+		ghLabels: String(event.payload.labels ?? ''),
+		ghState: String(event.payload.state ?? ''),
+		ghRepo: String(event.payload.repo ?? ''),
+		ghBranch: String(event.payload.head_branch ?? ''),
+		ghBaseBranch: String(event.payload.base_branch ?? ''),
+		ghAssignees: String(event.payload.assignees ?? ''),
+		ghMergedAt: String(event.payload.merged_at ?? ''),
+	};
+}
+
+enricherRegistry.set('github.pull_request', (event) => buildGitHubContext(event));
+enricherRegistry.set('github.issue', (event) => buildGitHubContext(event));
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+
+/**
+ * Build the `templateContext.cue` object for a given event.
+ *
+ * Applies the base ('*') enricher first, then the event-type-specific enricher
+ * if one exists. The result is a flat Record<string, string> that maps to
+ * CUE_* template variables via substituteTemplateVariables.
+ */
+export function buildCueTemplateContext(
+	event: CueEvent,
+	subscription: CueSubscription,
+	runId: string
+): CueTemplateContext {
+	let context: Record<string, string> = {};
+
+	// Apply base enricher (always runs)
+	const baseEnricher = enricherRegistry.get('*');
+	if (baseEnricher) {
+		context = { ...context, ...baseEnricher(event, subscription, runId) };
+	}
+
+	// Apply event-type-specific enricher (if registered)
+	const specificEnricher = enricherRegistry.get(event.type as CueEventType);
+	if (specificEnricher) {
+		context = { ...context, ...specificEnricher(event, subscription, runId) };
+	}
+
+	return context as CueTemplateContext;
+}


### PR DESCRIPTION
## Summary

### CueExecutor Decomposition (521 → 170 lines, −67%)

The `cue-executor.ts` module mixed four concerns: template variable population, agent spawn preparation, process lifecycle management, and history recording. This PR decomposes it into three focused modules with the executor as a thin orchestrator.

**`cue-template-context-builder.ts` (105 lines)** — Builds `templateContext.cue` from event payloads using an enricher registry pattern (`Map<CueEventType | '*', EnricherFn>`). The `'*'` enricher produces 15 common fields (eventType, triggerName, runId, file/source fields). Dedicated enrichers handle `task.pending` (6 task fields), `github.pull_request`, and `github.issue` (13 GitHub fields via shared helper). Adding a new event type requires one enricher entry — no changes to executor or engine.

**`cue-spawn-builder.ts` (155 lines)** — Pure async transformation: `CueExecutionConfig` + substituted prompt → `SpawnSpec`. Handles agent definition lookup, `buildAgentArgs`, `applyAgentConfigOverrides`, SSH wrapping via `wrapSpawnWithSsh`, and prompt appending (supporting `--` separator, `promptArgs`, and `noPromptSeparator` modes). Returns a discriminated union (`{ ok: true, spec }` | `{ ok: false, message }`) for type-safe error handling.

**`cue-process-lifecycle.ts` (237 lines)** — Spawns child processes, manages stdio capture, enforces timeouts with SIGTERM → SIGKILL escalation (5s grace period), and tracks active processes for the Process Monitor. Owns the module-level `activeProcesses` Map, the settled guard pattern (prevents duplicate close/error resolution), and output parser integration.

**Refactored `cue-executor.ts` (170 lines)** — Thin orchestrator: validate prompt → build template context → substitute variables → build spawn spec → run process → assemble `CueRunResult`. Re-exports `CueProcessInfo` and `SpawnSpec` for backwards compatibility. All delegation wrappers (`stopCueRun`, `getActiveProcesses`, `getCueProcessList`) preserved — zero changes to `src/main/index.ts` or any other consumer.

### Run Manager State Machine Fix

**Problem:** `stopRun()` and the `finally` block of `doExecuteCueRun` both independently managed the "run is done" transition via a `manuallyStoppedRuns` Set. This caused two bugs:

1. **Spurious chain propagation after engine shutdown** — `reset()` (called by `engine.stop()`) cleared `activeRuns` and `manuallyStoppedRuns`, but the `finally` block of still-running promises would execute afterward, calling `onRunCompleted` and triggering downstream agent.completed chains even though the engine was shut down.

2. **No double-stop protection** — Calling `stopRun()` twice on the same run would add it to `manuallyStoppedRuns` again and attempt to signal/delete/decrement a second time.

**Fix:** Replaced `manuallyStoppedRuns` Set with an explicit `RunPhase` type (`'running' | 'stopping' | 'finished'`) on `ActiveRun`, with a `transitionRun(runId, toPhase)` helper that validates transitions and returns the previous phase (or `null` for invalid transitions).

- `stopRun()` calls `transitionRun(runId, 'stopping')` — returns `false` if the run doesn't exist or is already stopping/finished. It is now fully self-contained: transition → signal kill → set result → delete from activeRuns → release sleep → free concurrency slot → drain queue → DB update → notify → log.
- The `finally` block uses `activeRuns.has(runId)` as its guard: if the run was already removed (by `stopRun` or `reset`), it skips all cleanup entirely. Only natural completions flow through the finally path.
- `stopRun` now also records `updateCueEventStatus(runId, 'stopped')` directly, rather than deferring to the finally block. This makes DB status consistent regardless of when the promise resolves.

## Test plan

- **cue-template-context-builder.test.ts** (15 tests) — enricher registry for all event types (`file.changed`, `task.pending`, `github.pull_request`, `github.issue`, `time.heartbeat`, `time.scheduled`, `agent.completed`), empty payload defaults, numeric/boolean coercion, unknown event type graceful handling
- **cue-spawn-builder.test.ts** (13 tests) — unknown agent error, correct command/cwd, custom path, prompt appending modes (`--` separator, `promptArgs`, `noPromptSeparator`), yoloMode flag, config overrides passthrough, process.env inclusion, SSH execution (wrapSpawnWithSsh call, no double-append, sshStdinScript, stdinPrompt passthrough)
- **cue-process-lifecycle.test.ts** (24 tests) — spawn with correct args, stdout/stderr capture, completed/failed status, spawn errors, activeProcesses tracking, stdin close, SSH stdin modes, timeout SIGTERM/SIGKILL escalation with logging, no timeout when 0, output parsing (raw and parsed via parser registry), stopProcess (unknown/known/SIGKILL escalation), getProcessList (empty/active/completed), settled guard (duplicate close, error after close)
- **cue-run-manager.test.ts** (37 tests) — phase state machine (running→stopping, running→finished, double-stop rejection), run lifecycle (onRunCompleted on success/failure/exception, onRunStopped on manual stop, chainDepth passthrough, endedAt/durationMs on stop), sleep prevention (onPreventSleep on start, onAllowSleep on completion and stop), concurrency (slot release on natural completion and stop, no double-decrement when stop followed by finally), DB recording (status update on completion and stop), race conditions (reset during active run, stopAll+reset, stop during output prompt phase), output prompt (execution on success, skip on failure), stopAll/reset (stops all runs, clears queue, releases sleep blocks), logging (runStarted/runFinished/runStopped structured events), process signaling (onStopCueRun call, AbortController abort), getActiveRunCount accuracy
- All 729 pre-existing cue backend tests pass unchanged (766 total)
- All 471 renderer cue tests pass unchanged
- `npm run lint` — 0 type errors across all 3 tsconfig files
- `npm run lint:eslint` — 0 errors on all changed files
- Manual: open Cue Modal → trigger subscription → verify activity log entry
- Manual: start a run → click Stop → verify it stops cleanly and queued events dispatch
- Manual: toggle Cue off while runs are active → verify no errors in system log and no spurious chain triggers
- Manual: trigger an agent.completed chain → verify downstream subscription fires correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added broad end-to-end and unit tests covering process lifecycle, run manager, spawn spec logic, and template-context generation.

* **Refactor**
  * Split execution into modular components and centralized process lifecycle with clearer run-phase state handling.

* **New Features**
  * Improved timeout escalation (TERM→KILL), richer process metadata for monitoring, enhanced SSH/stdin/prompt behavior, and more robust template-context enrichment for events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->