### PR TITLE
fix: SSH terminal tabs fail to spawn on remote hosts

### DIFF
--- a/src/__tests__/main/ipc/handlers/process.test.ts
+++ b/src/__tests__/main/ipc/handlers/process.test.ts
@@ -1058,21 +1058,29 @@ describe('process IPC handlers', () => {
 				},
 			});
 
-			expect(mockProcessManager.spawn).toHaveBeenCalledWith(
-				expect.objectContaining({
-					command: 'ssh',
-					args: expect.arrayContaining([
-						'devuser@dev.example.com',
-						'-o',
-						'StrictHostKeyChecking=accept-new',
-						'-o',
-						'ConnectTimeout=10',
-						'-o',
-						'ClearAllForwardings=yes',
-					]),
-					toolType: 'terminal',
-				})
-			);
+			const spawnCall = mockProcessManager.spawn.mock.calls[0][0];
+			expect(spawnCall.command).toBe('ssh');
+			expect(spawnCall.toolType).toBe('terminal');
+			const args: string[] = spawnCall.args;
+
+			// Verify SSH options appear before destination and in correct paired order
+			const hostIndex = args.indexOf('devuser@dev.example.com');
+			expect(hostIndex).toBeGreaterThan(0);
+
+			const expectedOptions = [
+				['StrictHostKeyChecking=accept-new'],
+				['ConnectTimeout=10'],
+				['ClearAllForwardings=yes'],
+			];
+			let lastOptionIndex = -1;
+			for (const [value] of expectedOptions) {
+				const oIndex = args.indexOf('-o', lastOptionIndex + 1);
+				expect(oIndex).toBeGreaterThan(lastOptionIndex);
+				expect(oIndex).toBeLessThan(hostIndex);
+				expect(args[oIndex + 1]).toBe(value);
+				lastOptionIndex = oIndex + 1;
+			}
+
 			expect(mockProcessManager.spawnTerminalTab).not.toHaveBeenCalled();
 			expect(result).toEqual({ pid: 5001, success: true });
 		});

--- a/src/__tests__/main/ipc/handlers/process.test.ts
+++ b/src/__tests__/main/ipc/handlers/process.test.ts
@@ -1061,7 +1061,15 @@ describe('process IPC handlers', () => {
 			expect(mockProcessManager.spawn).toHaveBeenCalledWith(
 				expect.objectContaining({
 					command: 'ssh',
-					args: expect.arrayContaining(['devuser@dev.example.com']),
+					args: expect.arrayContaining([
+						'devuser@dev.example.com',
+						'-o',
+						'StrictHostKeyChecking=accept-new',
+						'-o',
+						'ConnectTimeout=10',
+						'-o',
+						'ClearAllForwardings=yes',
+					]),
 					toolType: 'terminal',
 				})
 			);
@@ -1094,10 +1102,13 @@ describe('process IPC handlers', () => {
 			const hostIndex = spawnCall.args.indexOf('devuser@dev.example.com');
 			expect(tIndex).toBeGreaterThanOrEqual(0);
 			expect(tIndex).toBeLessThan(hostIndex);
-			// Remote command to cd and exec shell must be the last arg
+			// Destination must appear before the remote command
 			const lastArg = spawnCall.args[spawnCall.args.length - 1];
 			expect(lastArg).toContain('/remote/project');
 			expect(lastArg).toContain('exec $SHELL');
+			// SSH options must be present
+			expect(spawnCall.args).toContain('StrictHostKeyChecking=accept-new');
+			expect(spawnCall.args).toContain('ConnectTimeout=10');
 		});
 
 		it('should include port flag for non-default SSH port', async () => {
@@ -1119,6 +1130,9 @@ describe('process IPC handlers', () => {
 			const portIndex = spawnCall.args.indexOf('-p');
 			expect(portIndex).toBeGreaterThanOrEqual(0);
 			expect(spawnCall.args[portIndex + 1]).toBe('2222');
+			// Port must appear before destination
+			const hostIndex = spawnCall.args.indexOf('devuser@dev.example.com');
+			expect(portIndex).toBeLessThan(hostIndex);
 		});
 
 		it('should include identity file flag when privateKeyPath is set', async () => {
@@ -1139,6 +1153,9 @@ describe('process IPC handlers', () => {
 			const keyIndex = spawnCall.args.indexOf('-i');
 			expect(keyIndex).toBeGreaterThanOrEqual(0);
 			expect(spawnCall.args[keyIndex + 1]).toBe('~/.ssh/id_ed25519');
+			// Identity file must appear before destination
+			const hostIndex = spawnCall.args.indexOf('devuser@dev.example.com');
+			expect(keyIndex).toBeLessThan(hostIndex);
 		});
 
 		it('should return failure when SSH is enabled but remote config not found', async () => {

--- a/src/__tests__/main/ipc/handlers/process.test.ts
+++ b/src/__tests__/main/ipc/handlers/process.test.ts
@@ -191,6 +191,11 @@ vi.mock('../../../../main/utils/ssh-command-builder', () => ({
 	}),
 }));
 
+// Mock cliDetection to provide a resolved SSH path
+vi.mock('../../../../main/utils/cliDetection', () => ({
+	resolveSshPath: vi.fn().mockResolvedValue('ssh'),
+}));
+
 describe('process IPC handlers', () => {
 	let handlers: Map<string, Function>;
 	let mockProcessManager: {

--- a/src/__tests__/main/ipc/handlers/process.test.ts
+++ b/src/__tests__/main/ipc/handlers/process.test.ts
@@ -1154,6 +1154,53 @@ describe('process IPC handlers', () => {
 			expect(lastArg).toBe('cd \'/tmp/$(whoami)\' && exec "$SHELL"');
 		});
 
+		it('should expand tilde in workingDirOverride for remote shell', async () => {
+			mockSettingsStore.get.mockImplementation((key: string, defaultValue: unknown) => {
+				if (key === 'sshRemotes') return [mockSshRemoteForTerminal];
+				return defaultValue;
+			});
+			mockProcessManager.spawn.mockReturnValue({ pid: 5011, success: true });
+
+			const handler = handlers.get('process:spawnTerminalTab');
+			await handler!({} as any, {
+				sessionId: 'session-1-terminal-tab-1',
+				cwd: '/local/project',
+				sessionSshRemoteConfig: {
+					enabled: true,
+					remoteId: 'remote-1',
+					workingDirOverride: '~/project',
+				},
+			});
+
+			const spawnCall = mockProcessManager.spawn.mock.calls[0][0];
+			const lastArg = spawnCall.args[spawnCall.args.length - 1];
+			// Tilde must expand via $HOME, not be single-quoted (which suppresses expansion)
+			expect(lastArg).toBe('cd "$HOME"/\'project\' && exec "$SHELL"');
+		});
+
+		it('should handle bare tilde workingDirOverride', async () => {
+			mockSettingsStore.get.mockImplementation((key: string, defaultValue: unknown) => {
+				if (key === 'sshRemotes') return [mockSshRemoteForTerminal];
+				return defaultValue;
+			});
+			mockProcessManager.spawn.mockReturnValue({ pid: 5012, success: true });
+
+			const handler = handlers.get('process:spawnTerminalTab');
+			await handler!({} as any, {
+				sessionId: 'session-1-terminal-tab-1',
+				cwd: '/local/project',
+				sessionSshRemoteConfig: {
+					enabled: true,
+					remoteId: 'remote-1',
+					workingDirOverride: '~',
+				},
+			});
+
+			const spawnCall = mockProcessManager.spawn.mock.calls[0][0];
+			const lastArg = spawnCall.args[spawnCall.args.length - 1];
+			expect(lastArg).toBe('cd "$HOME" && exec "$SHELL"');
+		});
+
 		it('should include port flag for non-default SSH port', async () => {
 			const remoteWithPort = { ...mockSshRemoteForTerminal, port: 2222 };
 			mockSettingsStore.get.mockImplementation((key: string, defaultValue: unknown) => {

--- a/src/__tests__/main/ipc/handlers/process.test.ts
+++ b/src/__tests__/main/ipc/handlers/process.test.ts
@@ -1104,11 +1104,36 @@ describe('process IPC handlers', () => {
 			expect(tIndex).toBeLessThan(hostIndex);
 			// Destination must appear before the remote command
 			const lastArg = spawnCall.args[spawnCall.args.length - 1];
-			expect(lastArg).toContain('/remote/project');
-			expect(lastArg).toContain('exec $SHELL');
+			// Path must be shell-escaped (single-quoted) to prevent injection
+			expect(lastArg).toBe('cd \'/remote/project\' && exec "$SHELL"');
+			expect(lastArg).toContain('exec "$SHELL"');
 			// SSH options must be present
 			expect(spawnCall.args).toContain('StrictHostKeyChecking=accept-new');
 			expect(spawnCall.args).toContain('ConnectTimeout=10');
+		});
+
+		it('should shell-escape workingDirOverride to prevent injection', async () => {
+			mockSettingsStore.get.mockImplementation((key: string, defaultValue: unknown) => {
+				if (key === 'sshRemotes') return [mockSshRemoteForTerminal];
+				return defaultValue;
+			});
+			mockProcessManager.spawn.mockReturnValue({ pid: 5010, success: true });
+
+			const handler = handlers.get('process:spawnTerminalTab');
+			await handler!({} as any, {
+				sessionId: 'session-1-terminal-tab-1',
+				cwd: '/local/project',
+				sessionSshRemoteConfig: {
+					enabled: true,
+					remoteId: 'remote-1',
+					workingDirOverride: '/tmp/$(whoami)',
+				},
+			});
+
+			const spawnCall = mockProcessManager.spawn.mock.calls[0][0];
+			const lastArg = spawnCall.args[spawnCall.args.length - 1];
+			// Single-quoted path prevents command substitution
+			expect(lastArg).toBe('cd \'/tmp/$(whoami)\' && exec "$SHELL"');
 		});
 
 		it('should include port flag for non-default SSH port', async () => {

--- a/src/__tests__/main/ipc/handlers/process.test.ts
+++ b/src/__tests__/main/ipc/handlers/process.test.ts
@@ -1081,11 +1081,16 @@ describe('process IPC handlers', () => {
 				lastOptionIndex = oIndex + 1;
 			}
 
+			// -t must appear before the destination for all SSH terminal sessions
+			const tIndex = args.indexOf('-t');
+			expect(tIndex).toBeGreaterThanOrEqual(0);
+			expect(tIndex).toBeLessThan(hostIndex);
+
 			expect(mockProcessManager.spawnTerminalTab).not.toHaveBeenCalled();
 			expect(result).toEqual({ pid: 5001, success: true });
 		});
 
-		it('should add -t flag and remote cd command when workingDirOverride is set', async () => {
+		it('should add remote cd command when workingDirOverride is set', async () => {
 			mockSettingsStore.get.mockImplementation((key: string, defaultValue: unknown) => {
 				if (key === 'sshRemotes') return [mockSshRemoteForTerminal];
 				return defaultValue;
@@ -1166,6 +1171,10 @@ describe('process IPC handlers', () => {
 			// Port must appear before destination
 			const hostIndex = spawnCall.args.indexOf('devuser@dev.example.com');
 			expect(portIndex).toBeLessThan(hostIndex);
+			// -t must appear before destination
+			const tIndex = spawnCall.args.indexOf('-t');
+			expect(tIndex).toBeGreaterThanOrEqual(0);
+			expect(tIndex).toBeLessThan(hostIndex);
 		});
 
 		it('should include identity file flag when privateKeyPath is set', async () => {
@@ -1189,6 +1198,10 @@ describe('process IPC handlers', () => {
 			// Identity file must appear before destination
 			const hostIndex = spawnCall.args.indexOf('devuser@dev.example.com');
 			expect(keyIndex).toBeLessThan(hostIndex);
+			// -t must appear before destination
+			const tIndex = spawnCall.args.indexOf('-t');
+			expect(tIndex).toBeGreaterThanOrEqual(0);
+			expect(tIndex).toBeLessThan(hostIndex);
 		});
 
 		it('should return failure when SSH is enabled but remote config not found', async () => {

--- a/src/main/ipc/handlers/process.ts
+++ b/src/main/ipc/handlers/process.ts
@@ -880,22 +880,36 @@ export function registerProcessHandlers(deps: ProcessHandlerDependencies): void 
 							hasWorkingDirOverride: !!config.sessionSshRemoteConfig.workingDirOverride,
 						});
 						// For SSH terminal tabs we spawn ssh interactively so xterm.js can interact
-						const sshArgs = [
-							sshResult.config.username
-								? `${sshResult.config.username}@${sshResult.config.host}`
-								: sshResult.config.host,
-						];
-						if (sshResult.config.port && sshResult.config.port !== 22) {
-							sshArgs.unshift('-p', String(sshResult.config.port));
-						}
+						const sshArgs: string[] = [];
+
+						// SSH options for reliable connection (consistent with SshRemoteManager)
+						sshArgs.push('-o', 'StrictHostKeyChecking=accept-new');
+						sshArgs.push('-o', 'ConnectTimeout=10');
+						sshArgs.push('-o', 'ClearAllForwardings=yes');
+
 						if (sshResult.config.privateKeyPath) {
-							sshArgs.unshift('-i', sshResult.config.privateKeyPath);
+							sshArgs.push('-i', sshResult.config.privateKeyPath);
 						}
+						if (sshResult.config.port && sshResult.config.port !== 22) {
+							sshArgs.push('-p', String(sshResult.config.port));
+						}
+
 						// If workingDirOverride is set, cd to that directory after connecting.
 						// -t forces PTY allocation (required when passing a remote command).
 						const workingDirOverride = config.sessionSshRemoteConfig.workingDirOverride;
 						if (workingDirOverride) {
-							sshArgs.unshift('-t');
+							sshArgs.push('-t');
+						}
+
+						// Destination: user@host or just host
+						sshArgs.push(
+							sshResult.config.username
+								? `${sshResult.config.username}@${sshResult.config.host}`
+								: sshResult.config.host
+						);
+
+						// Remote command (must come after destination)
+						if (workingDirOverride) {
 							sshArgs.push(`cd ${JSON.stringify(workingDirOverride)} && exec $SHELL`);
 						}
 						return processManager.spawn({

--- a/src/main/ipc/handlers/process.ts
+++ b/src/main/ipc/handlers/process.ts
@@ -911,7 +911,13 @@ export function registerProcessHandlers(deps: ProcessHandlerDependencies): void 
 
 						// Remote command (must come after destination)
 						if (workingDirOverride) {
-							sshArgs.push(`cd ${shellEscape(workingDirOverride)} && exec "$SHELL"`);
+							// Handle leading ~ by using $HOME outside of quotes so the remote shell expands it
+							const cdPath = workingDirOverride.startsWith('~/')
+								? `"$HOME"/${shellEscape(workingDirOverride.slice(2))}`
+								: workingDirOverride === '~'
+									? '"$HOME"'
+									: shellEscape(workingDirOverride);
+							sshArgs.push(`cd ${cdPath} && exec "$SHELL"`);
 						}
 						return processManager.spawn({
 							sessionId: config.sessionId,

--- a/src/main/ipc/handlers/process.ts
+++ b/src/main/ipc/handlers/process.ts
@@ -895,12 +895,11 @@ export function registerProcessHandlers(deps: ProcessHandlerDependencies): void 
 							sshArgs.push('-p', String(sshResult.config.port));
 						}
 
-						// If workingDirOverride is set, cd to that directory after connecting.
-						// -t forces PTY allocation (required when passing a remote command).
+						// -t forces PTY allocation, required for interactive SSH terminals
+						// regardless of whether a remote command is specified.
+						sshArgs.push('-t');
+
 						const workingDirOverride = config.sessionSshRemoteConfig.workingDirOverride;
-						if (workingDirOverride) {
-							sshArgs.push('-t');
-						}
 
 						// Destination: user@host or just host
 						sshArgs.push(

--- a/src/main/ipc/handlers/process.ts
+++ b/src/main/ipc/handlers/process.ts
@@ -27,6 +27,7 @@ import { buildSshCommandWithStdin } from '../../utils/ssh-command-builder';
 import { buildStreamJsonMessage } from '../../process-manager/utils/streamJsonBuilder';
 import { getWindowsShellForAgentExecution } from '../../process-manager/utils/shellEscape';
 import { buildExpandedEnv } from '../../../shared/pathUtils';
+import { resolveSshPath } from '../../utils/cliDetection';
 import type { SshRemoteConfig } from '../../../shared/types';
 import { powerManager } from '../../power-manager';
 import { MaestroSettings } from './persistence';
@@ -916,7 +917,7 @@ export function registerProcessHandlers(deps: ProcessHandlerDependencies): void 
 							sessionId: config.sessionId,
 							toolType: 'terminal',
 							cwd: os.homedir(),
-							command: 'ssh',
+							command: await resolveSshPath(),
 							args: sshArgs,
 							shellEnvVars: mergedEnvVars,
 							cols: config.cols || 80,

--- a/src/main/ipc/handlers/process.ts
+++ b/src/main/ipc/handlers/process.ts
@@ -22,6 +22,7 @@ import {
 	CreateHandlerOptions,
 } from '../../utils/ipcHandler';
 import { getSshRemoteConfig, createSshRemoteStoreAdapter } from '../../utils/ssh-remote-resolver';
+import { shellEscape } from '../../utils/shell-escape';
 import { buildSshCommandWithStdin } from '../../utils/ssh-command-builder';
 import { buildStreamJsonMessage } from '../../process-manager/utils/streamJsonBuilder';
 import { getWindowsShellForAgentExecution } from '../../process-manager/utils/shellEscape';
@@ -910,7 +911,7 @@ export function registerProcessHandlers(deps: ProcessHandlerDependencies): void 
 
 						// Remote command (must come after destination)
 						if (workingDirOverride) {
-							sshArgs.push(`cd ${JSON.stringify(workingDirOverride)} && exec $SHELL`);
+							sshArgs.push(`cd ${shellEscape(workingDirOverride)} && exec "$SHELL"`);
 						}
 						return processManager.spawn({
 							sessionId: config.sessionId,

--- a/src/renderer/components/MainPanel/MainPanelHeader.tsx
+++ b/src/renderer/components/MainPanel/MainPanelHeader.tsx
@@ -93,7 +93,7 @@ export const MainPanelHeader = React.memo(function MainPanelHeader({
 	return (
 		<div
 			ref={headerRef}
-			className={`header-container h-16 border-b flex items-center justify-between px-6 shrink-0 relative ${isCurrentSessionAutoMode ? 'header-auto-mode' : ''}`}
+			className={`header-container h-16 border-b flex items-center justify-between px-6 shrink-0 relative z-20 ${isCurrentSessionAutoMode ? 'header-auto-mode' : ''}`}
 			style={{
 				borderColor: theme.colors.border,
 				backgroundColor: theme.colors.bgSidebar,

--- a/src/renderer/components/TerminalView.tsx
+++ b/src/renderer/components/TerminalView.tsx
@@ -88,10 +88,13 @@ export const TerminalView = memo(
 		// triggers many tabs at once) into a single toast with a count.
 		const notifySpawnFailure = useCallback((message: string) => {
 			spawnFailureCountRef.current++;
-			// Keep the most recent message; prefer SSH-specific messages over generic ones
-			if (!spawnFailureLastMessageRef.current) {
-				spawnFailureLastMessageRef.current = message;
-			} else if (message.startsWith('SSH ')) {
+			// Always store the most recent message, but never let a non-SSH message
+			// overwrite an SSH-specific one (SSH messages take precedence).
+			if (
+				!spawnFailureLastMessageRef.current ||
+				message.startsWith('SSH ') ||
+				!spawnFailureLastMessageRef.current.startsWith('SSH ')
+			) {
 				spawnFailureLastMessageRef.current = message;
 			}
 			if (spawnFailureTimerRef.current) {

--- a/src/renderer/components/TerminalView.tsx
+++ b/src/renderer/components/TerminalView.tsx
@@ -150,19 +150,25 @@ export const TerminalView = memo(
 				// Build effective SSH config: prefer explicit sessionSshRemoteConfig, then fall back
 				// to sshRemoteId which is set after an AI agent connects. Without this fallback,
 				// terminal tabs under running SSH agents spawn locally instead of on the remote host.
+				//
+				// workingDirOverride must be a REMOTE path. session.remoteCwd is the tracked remote
+				// working directory; sessionSshRemoteConfig.workingDirOverride is the user-configured
+				// remote project root. session.cwd is LOCAL and must NOT be used here — it would
+				// cause `cd "/local/path"` on the remote, which fails and exits SSH immediately.
 				const effectiveSshConfig = session.sessionSshRemoteConfig?.enabled
 					? {
 							...session.sessionSshRemoteConfig,
 							workingDirOverride:
-								session.sessionSshRemoteConfig.workingDirOverride || session.cwd || undefined,
+								session.sessionSshRemoteConfig.workingDirOverride || session.remoteCwd || undefined,
 						}
 					: session.sshRemoteId
 						? {
 								enabled: true,
 								remoteId: session.sshRemoteId,
-								// Use session.cwd as the remote working directory so the terminal starts
-								// in the project directory rather than the remote home directory.
-								workingDirOverride: session.cwd || undefined,
+								workingDirOverride:
+									session.remoteCwd ||
+									session.sessionSshRemoteConfig?.workingDirOverride ||
+									undefined,
 							}
 						: undefined;
 
@@ -184,7 +190,9 @@ export const TerminalView = memo(
 							// Spawn failed — close the tab and notify via batched toast
 							setTimeout(() => closeTerminalTab(tabId), 0);
 							notifySpawnFailure(
-								'The shell process could not be started. Check system PTY availability.'
+								effectiveSshConfig?.enabled
+									? 'SSH terminal could not be started. Check that the SSH remote is enabled and reachable.'
+									: 'The shell process could not be started. Check system PTY availability.'
 							);
 						}
 					})
@@ -209,6 +217,7 @@ export const TerminalView = memo(
 			[
 				session.id,
 				session.cwd,
+				session.remoteCwd,
 				session.sessionSshRemoteConfig,
 				session.sshRemoteId,
 				defaultShell,

--- a/src/renderer/components/TerminalView.tsx
+++ b/src/renderer/components/TerminalView.tsx
@@ -76,6 +76,7 @@ export const TerminalView = memo(
 		// Dedup spawn-failure toasts: batch rapid failures into a single notification
 		const spawnFailureCountRef = useRef(0);
 		const spawnFailureTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+		const spawnFailureLastMessageRef = useRef<string | null>(null);
 		// Stable refs for callback props — prevents spawnPtyForTab from getting a new
 		// identity on every render, which would re-trigger the spawn useEffect in a loop.
 		const onTabPidChangeRef = useRef(onTabPidChange);
@@ -87,20 +88,26 @@ export const TerminalView = memo(
 		// triggers many tabs at once) into a single toast with a count.
 		const notifySpawnFailure = useCallback((message: string) => {
 			spawnFailureCountRef.current++;
+			// Keep the most recent message; prefer SSH-specific messages over generic ones
+			if (!spawnFailureLastMessageRef.current) {
+				spawnFailureLastMessageRef.current = message;
+			} else if (message.startsWith('SSH ')) {
+				spawnFailureLastMessageRef.current = message;
+			}
 			if (spawnFailureTimerRef.current) {
 				clearTimeout(spawnFailureTimerRef.current);
 			}
 			spawnFailureTimerRef.current = setTimeout(() => {
 				const count = spawnFailureCountRef.current;
+				const lastMessage = spawnFailureLastMessageRef.current ?? message;
 				spawnFailureCountRef.current = 0;
+				spawnFailureLastMessageRef.current = null;
 				spawnFailureTimerRef.current = null;
 				notifyToast({
 					type: 'error',
 					title: count > 1 ? `Failed to start ${count} terminals` : 'Failed to start terminal',
 					message:
-						count > 1
-							? `${count} shell processes could not be started. Check system PTY availability.`
-							: message,
+						count > 1 ? `${count} terminals could not be started. ${lastMessage}` : lastMessage,
 				});
 			}, 200);
 		}, []);


### PR DESCRIPTION
## Summary
- **workingDirOverride used local path**: `session.cwd` (local) was used instead of `session.remoteCwd` for the SSH `cd` command, causing the remote shell to fail on a nonexistent path and exit immediately
- **Missing SSH options**: Terminal SSH path lacked `StrictHostKeyChecking=accept-new`, `ConnectTimeout=10`, and `ClearAllForwardings=yes` that all other SSH code paths include
- **Misleading error message**: "Check system PTY availability" now shows an SSH-specific message when the failure is SSH-related

## Test plan
- [x] Updated `process:spawnTerminalTab` SSH tests to verify new SSH options and arg ordering
- [x] All 61 process handler tests pass
- [ ] Manual: open terminal tab on SSH-configured agent, verify it connects to remote host
- [ ] Manual: verify terminal opens in correct remote working directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable SSH terminal launches: fixed SSH argument ordering, always allocate a PTY (-t), include stability options, and ensure identity/port flags appear before the destination.
  * Safer remote working-directory handling: improved escaping, exact remote-cd formatting, and correct tilde (~) expansion to prevent injection.
  * Spawn-failure toasts now retain the most relevant SSH error and show clearer remote-specific guidance; remote cwd selection made more consistent.

* **Tests**
  * Strengthened SSH spawn tests for exact argument ordering, quoting/escaping, tilde handling, non-default port/identity, and injection prevention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->