### PR TITLE
fix: prevent SSH error pattern false positives on agent response text

### DIFF
--- a/src/__tests__/main/process-manager/handlers/ExitHandler.test.ts
+++ b/src/__tests__/main/process-manager/handlers/ExitHandler.test.ts
@@ -44,6 +44,7 @@ vi.mock('../../../../main/process-manager/utils/imageUtils', () => ({
 
 import { ExitHandler } from '../../../../main/process-manager/handlers/ExitHandler';
 import { DataBufferManager } from '../../../../main/process-manager/handlers/DataBufferManager';
+import { matchSshErrorPattern } from '../../../../main/parsers/error-patterns';
 import type { ManagedProcess } from '../../../../main/process-manager/types';
 import type { AgentOutputParser, ParsedEvent } from '../../../../main/parsers';
 
@@ -319,6 +320,80 @@ describe('ExitHandler', () => {
 			exitHandler.handleExit('unknown-session', 1);
 
 			expect(exitEvents).toEqual([{ sessionId: 'unknown-session', code: 1 }]);
+		});
+	});
+
+	describe('SSH error pattern false-positive prevention', () => {
+		it('should only check stderr for SSH patterns, not stdout', () => {
+			const mockedMatchSsh = vi.mocked(matchSshErrorPattern);
+			mockedMatchSsh.mockReturnValue(null);
+
+			const proc = createMockProcess({
+				sshRemoteId: 'remote-1',
+				// stdout contains JSONL with response text that mentions "command not found"
+				stdoutBuffer:
+					'{"type":"assistant","message":{"content":[{"text":"bash: opencode: command not found"}]}}\n',
+				stderrBuffer: 'Warning: something harmless',
+			});
+			processes.set('test-session', proc);
+
+			exitHandler.handleExit('test-session', 1);
+
+			// Should be called with stderr only, NOT the combined stdout+stderr
+			expect(mockedMatchSsh).toHaveBeenCalledWith('Warning: something harmless');
+
+			mockedMatchSsh.mockReset();
+		});
+
+		it('should NOT false-positive when agent response text contains SSH error keywords', () => {
+			const mockedMatchSsh = vi.mocked(matchSshErrorPattern);
+			// Return null — no SSH error in stderr
+			mockedMatchSsh.mockReturnValue(null);
+
+			const proc = createMockProcess({
+				sshRemoteId: 'remote-1',
+				stdoutBuffer:
+					'{"type":"result","result":"The pattern bash:.*opencode.*command not found matches shell errors"}\n',
+				stderrBuffer: '',
+			});
+			processes.set('test-session', proc);
+
+			const errors: unknown[] = [];
+			emitter.on('agent-error', (...args: unknown[]) => errors.push(args));
+
+			exitHandler.handleExit('test-session', 1);
+
+			// matchSshErrorPattern should receive empty stderr, not the stdout with response text
+			expect(mockedMatchSsh).toHaveBeenCalledWith('');
+			expect(errors).toHaveLength(0);
+
+			mockedMatchSsh.mockReset();
+		});
+
+		it('should detect real SSH errors from stderr', () => {
+			const mockedMatchSsh = vi.mocked(matchSshErrorPattern);
+			mockedMatchSsh.mockReturnValue({
+				type: 'agent_crashed',
+				message: 'OpenCode command not found.',
+				recoverable: false,
+			});
+
+			const proc = createMockProcess({
+				sshRemoteId: 'remote-1',
+				stdoutBuffer: '',
+				stderrBuffer: 'bash: opencode: command not found',
+			});
+			processes.set('test-session', proc);
+
+			const errors: Array<[string, unknown]> = [];
+			emitter.on('agent-error', (sid: string, err: unknown) => errors.push([sid, err]));
+
+			exitHandler.handleExit('test-session', 1);
+
+			expect(mockedMatchSsh).toHaveBeenCalledWith('bash: opencode: command not found');
+			expect(errors).toHaveLength(1);
+
+			mockedMatchSsh.mockReset();
 		});
 	});
 });

--- a/src/__tests__/main/process-manager/handlers/StdoutHandler.test.ts
+++ b/src/__tests__/main/process-manager/handlers/StdoutHandler.test.ts
@@ -48,6 +48,7 @@ vi.mock('../../../../main/parsers/error-patterns', () => ({
 // ── Imports (after mocks) ──────────────────────────────────────────────────
 
 import { StdoutHandler } from '../../../../main/process-manager/handlers/StdoutHandler';
+import { matchSshErrorPattern } from '../../../../main/parsers/error-patterns';
 import type { ManagedProcess } from '../../../../main/process-manager/types';
 
 // ── Helpers ────────────────────────────────────────────────────────────────
@@ -1584,5 +1585,96 @@ describe('StdoutHandler — single JSON parse per line', () => {
 		// Should fall back to line-based detection since JSON.parse fails
 		expect(mockParser.detectErrorFromLine).toHaveBeenCalledTimes(1);
 		expect(mockParser.detectErrorFromParsed).not.toHaveBeenCalled();
+	});
+
+	describe('SSH error pattern false-positive prevention', () => {
+		it('should NOT check SSH patterns on valid JSON lines (prevents false positives from response text)', () => {
+			const mockedMatchSsh = vi.mocked(matchSshErrorPattern);
+			mockedMatchSsh.mockReturnValue({
+				type: 'agent_crashed',
+				message: 'OpenCode command not found.',
+				recoverable: false,
+			});
+
+			const mockParser = {
+				agentId: 'claude-code',
+				parseJsonLine: vi.fn(() => null),
+				parseJsonObject: vi.fn(() => ({
+					type: 'text',
+					text: 'response with opencode command not found',
+				})),
+				isResultMessage: vi.fn(() => false),
+				extractSessionId: vi.fn(() => null),
+				extractUsage: vi.fn(() => null),
+				extractSlashCommands: vi.fn(() => null),
+				detectErrorFromLine: vi.fn(() => null),
+				detectErrorFromParsed: vi.fn(() => null),
+				detectErrorFromExit: vi.fn(() => null),
+			};
+
+			const { handler, sessionId, emitter } = createTestContext({
+				isStreamJsonMode: true,
+				toolType: 'claude-code',
+				outputParser: mockParser as any,
+				sshRemoteId: 'remote-1',
+			});
+
+			const errors: unknown[] = [];
+			emitter.on('agent-error', (...args: unknown[]) => errors.push(args));
+
+			// Send a valid JSON line whose text content would match SSH error patterns
+			const jsonLine = JSON.stringify({
+				type: 'assistant',
+				message: { content: [{ text: 'bash: opencode: command not found' }] },
+			});
+			handler.handleData(sessionId, jsonLine + '\n');
+
+			// SSH pattern check should NOT have been called for a valid JSON line
+			expect(mockedMatchSsh).not.toHaveBeenCalled();
+			expect(errors).toHaveLength(0);
+
+			mockedMatchSsh.mockReset();
+		});
+
+		it('should check SSH patterns on non-JSON lines for SSH sessions', () => {
+			const mockedMatchSsh = vi.mocked(matchSshErrorPattern);
+			mockedMatchSsh.mockReturnValue({
+				type: 'agent_crashed',
+				message: 'OpenCode command not found.',
+				recoverable: false,
+			});
+
+			const mockParser = {
+				agentId: 'claude-code',
+				parseJsonLine: vi.fn(() => null),
+				parseJsonObject: vi.fn(() => null),
+				isResultMessage: vi.fn(() => false),
+				extractSessionId: vi.fn(() => null),
+				extractUsage: vi.fn(() => null),
+				extractSlashCommands: vi.fn(() => null),
+				detectErrorFromLine: vi.fn(() => null),
+				detectErrorFromParsed: vi.fn(() => null),
+				detectErrorFromExit: vi.fn(() => null),
+			};
+
+			const { handler, sessionId, emitter } = createTestContext({
+				isStreamJsonMode: true,
+				toolType: 'claude-code',
+				outputParser: mockParser as any,
+				sshRemoteId: 'remote-1',
+			});
+
+			const errors: Array<[string, unknown]> = [];
+			emitter.on('agent-error', (sid: string, err: unknown) => errors.push([sid, err]));
+
+			// Send a plain text line (not JSON) — this is a real SSH error
+			handler.handleData(sessionId, 'bash: opencode: command not found\n');
+
+			// SSH pattern check SHOULD be called for non-JSON lines
+			expect(mockedMatchSsh).toHaveBeenCalledWith('bash: opencode: command not found');
+			expect(errors).toHaveLength(1);
+
+			mockedMatchSsh.mockReset();
+		});
 	});
 });

--- a/src/main/process-manager/handlers/ExitHandler.ts
+++ b/src/main/process-manager/handlers/ExitHandler.ts
@@ -140,10 +140,12 @@ export class ExitHandler {
 			managedProcess.sshRemoteId &&
 			(code !== 0 || managedProcess.stderrBuffer)
 		) {
-			// SSH errors can appear in stdout OR stderr, so check both
+			// Only check stderr for SSH errors — NOT stdout.
+			// Stdout contains structured JSONL agent output whose text content (e.g.,
+			// assistant messages quoting shell commands) can false-positive match SSH
+			// error patterns like "command not found". Real SSH transport errors appear
+			// on stderr (shell init failures, connection drops, missing binaries).
 			const stderrToCheck = managedProcess.stderrBuffer || '';
-			const stdoutToCheck = managedProcess.stdoutBuffer || managedProcess.streamedText || '';
-			const combinedOutput = `${stdoutToCheck}\n${stderrToCheck}`;
 
 			// Log detailed info before SSH error check to help debug shell parse errors
 			logger.info('[ProcessManager] Checking for SSH errors at exit', 'ProcessManager', {
@@ -152,11 +154,9 @@ export class ExitHandler {
 				sshRemoteId: managedProcess.sshRemoteId,
 				stderrLength: stderrToCheck.length,
 				stderrPreview: stderrToCheck.substring(0, 300),
-				stdoutLength: stdoutToCheck.length,
-				combinedLength: combinedOutput.length,
 			});
 
-			const sshError = matchSshErrorPattern(combinedOutput);
+			const sshError = matchSshErrorPattern(stderrToCheck);
 			if (sshError) {
 				managedProcess.errorEmitted = true;
 				const agentError: AgentError = {
@@ -169,7 +169,6 @@ export class ExitHandler {
 					raw: {
 						exitCode: code,
 						stderr: stderrToCheck,
-						stdout: stdoutToCheck.substring(0, 1000), // Truncate for log size
 					},
 				};
 				// Log at INFO level so it's visible in system logs
@@ -178,7 +177,6 @@ export class ExitHandler {
 					exitCode: code,
 					errorType: sshError.type,
 					errorMessage: sshError.message,
-					stdoutPreview: stdoutToCheck.substring(0, 500),
 					stderrPreview: stderrToCheck.substring(0, 500),
 				});
 				this.emitter.emit('agent-error', sessionId, agentError);
@@ -191,7 +189,6 @@ export class ExitHandler {
 						sessionId,
 						exitCode: code,
 						sshRemoteId: managedProcess.sshRemoteId,
-						stdoutPreview: stdoutToCheck.substring(0, 500),
 						stderrPreview: stderrToCheck.substring(0, 500),
 					}
 				);

--- a/src/main/process-manager/handlers/StdoutHandler.ts
+++ b/src/main/process-manager/handlers/StdoutHandler.ts
@@ -200,7 +200,10 @@ export class StdoutHandler {
 		}
 
 		// ── SSH error detection (line-based — SSH patterns are plain text) ──
-		if (!managedProcess.errorEmitted && managedProcess.sshRemoteId) {
+		// Only check non-JSON lines. Valid JSON lines contain structured agent output
+		// (e.g., assistant messages) whose text content can false-positive match SSH
+		// error patterns like "command not found" when the agent quotes shell commands.
+		if (!managedProcess.errorEmitted && managedProcess.sshRemoteId && parsed === null) {
 			const sshError = matchSshErrorPattern(line);
 			if (sshError) {
 				managedProcess.errorEmitted = true;


### PR DESCRIPTION
## Summary
- **StdoutHandler**: SSH error patterns are now only checked against non-JSON lines. Valid JSONL lines contain structured agent output (assistant messages, results) whose text content could false-positive match patterns like `bash:.*opencode.*command not found` when the agent quoted shell commands or error patterns in its response.
- **ExitHandler**: SSH error check at exit now only scans `stderr`, not the combined `stdout+stderr`. Stdout contains all accumulated JSONL which includes the full agent response — scanning it caused false positives when response text mentioned SSH error keywords.
- Added test coverage for SSH error pattern false-positive prevention in both handlers.

## Root Cause
When running over SSH (`sshRemoteId` set), error patterns were matched against raw JSONL lines and combined output buffers. The `.*` wildcards in patterns like `/bash:.*opencode.*command not found/i` matched across the JSON structure, hitting keywords embedded in the agent's response text. This caused the entire response to be classified as an SSH `agent_crashed` error.

## Test plan
- [x] Scoped tests pass (61/61)
- [x] Type check passes (pre-existing errors unrelated to changes)
- [x] Prettier clean
- [ ] Verify SSH sessions no longer false-positive on agent responses containing error keywords
- [ ] Verify real SSH errors (e.g., missing binary on remote) are still correctly detected via stderr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced SSH error detection accuracy to reduce false positives
  * Fixed issue where JSON-formatted responses could incorrectly trigger SSH error detection

* **Tests**
  * Added comprehensive test coverage for SSH error pattern detection and false-positive prevention scenarios
  * Verified proper handling of SSH-related errors across different output types

<!-- end of auto-generated comment: release notes by coderabbit.ai -->