### PR TITLE
Security: Predictable UUID generation using Math.random()

### DIFF
--- a/src/shared/uuid.ts
+++ b/src/shared/uuid.ts
@@ -1,16 +1,26 @@
 /**
  * Simple UUID v4 generator.
  *
- * Generates RFC 4122 compliant version 4 UUIDs using Math.random().
- * This is suitable for non-cryptographic purposes like session IDs
- * and history entry IDs.
+ * Generates RFC 4122 compliant version 4 UUIDs using a cryptographically
+ * secure random number source.
  *
  * @returns A UUID v4 string (e.g., "550e8400-e29b-41d4-a716-446655440000")
  */
 export function generateUUID(): string {
-	return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
-		const r = (Math.random() * 16) | 0;
-		const v = c === 'x' ? r : (r & 0x3) | 0x8;
-		return v.toString(16);
-	});
+	const cryptoObject = (globalThis as any).crypto;
+	if (cryptoObject?.randomUUID) {
+		return cryptoObject.randomUUID();
+	}
+
+	if (!cryptoObject?.getRandomValues) {
+		throw new Error('Secure UUID generation is not supported in this environment');
+	}
+
+	const bytes = new Uint8Array(16);
+	cryptoObject.getRandomValues(bytes);
+	bytes[6] = (bytes[6] & 0x0f) | 0x40;
+	bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+	const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('');
+	return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
 }


### PR DESCRIPTION
## Problem

The UUID helper uses `Math.random()` to generate v4-like IDs. `Math.random()` is not cryptographically secure and can be predicted in some environments. If these IDs are used for anything security-sensitive (session identifiers, authorization references, reset tokens, etc.), an attacker could potentially guess valid IDs.

**Severity**: `medium`
**File**: `src/shared/uuid.ts`

## Solution

Replace the implementation with a CSPRNG-backed generator, e.g. `crypto.randomUUID()` (or `crypto.getRandomValues` fallback). Keep non-crypto IDs clearly separated from any identifier used in trust or access-control decisions.

## Changes

- `src/shared/uuid.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced UUID generation to use cryptographically secure random sources instead of non-cryptographic methods.
  * UUID generation now throws an error when secure randomness APIs are unavailable in the environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->