### PR TITLE
Security: Remote script injection over insecure HTTP in renderer devtools connector

### DIFF
--- a/src/renderer/public/devtools-connect.js
+++ b/src/renderer/public/devtools-connect.js
@@ -1,6 +1,6 @@
 // React DevTools: connects to standalone react-devtools app (npm install -g react-devtools)
 // Only attempts connection in dev mode (Vite serves on localhost:5173)
-if (window.location.hostname === 'localhost') {
+if (window.location.hostname === 'localhost' && window.localStorage.getItem('MAESTRO_ENABLE_DEVTOOLS_CONNECT') === 'true') {
 	var script = document.createElement('script');
 	script.src = 'http://localhost:8097';
 	script.async = false;


### PR DESCRIPTION
## Problem

The renderer conditionally injects a script from `http://localhost:8097` without integrity verification. Any local process binding to that port can execute arbitrary JavaScript in the renderer context when hostname is `localhost`. This increases risk during development and can be abused on compromised developer machines.

**Severity**: `low`
**File**: `src/renderer/public/devtools-connect.js`

## Solution

Gate this logic behind an explicit development flag (e.g. `import.meta.env.DEV`), and avoid runtime remote script injection where possible. Prefer bundler/dev-only tooling hooks instead of loading arbitrary HTTP scripts at runtime.

## Changes

- `src/renderer/public/devtools-connect.js` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened devtools connection security by requiring explicit opt-in alongside localhost verification to prevent unintended activation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->