### PR TITLE
fix(ui): restore z-20 on main panel header to prevent popover clipping

### DIFF
--- a/src/renderer/components/MainPanel/MainPanelHeader.tsx
+++ b/src/renderer/components/MainPanel/MainPanelHeader.tsx
@@ -93,7 +93,7 @@ export const MainPanelHeader = React.memo(function MainPanelHeader({
 	return (
 		<div
 			ref={headerRef}
-			className={`header-container h-16 border-b flex items-center justify-between px-6 shrink-0 relative ${isCurrentSessionAutoMode ? 'header-auto-mode' : ''}`}
+			className={`header-container h-16 border-b flex items-center justify-between px-6 shrink-0 relative z-20 ${isCurrentSessionAutoMode ? 'header-auto-mode' : ''}`}
 			style={{
 				borderColor: theme.colors.border,
 				backgroundColor: theme.colors.bgSidebar,


### PR DESCRIPTION
## Summary

- Restores `z-20` on the main panel header container that was removed in commit [`4d01c32e`](https://github.com/RunMaestro/Maestro/commit/4d01c32ec14ce4ae9c57f7a3ce8739b98a3d810b) (`fix: remove main header z-index`, Apr 9 2026)
- Fixes the Context Details popover being rendered behind the chat / AI log area when clicking the CONTEXT button
- One-line change in `src/renderer/components/MainPanel/MainPanelHeader.tsx`

## Regression details

The Context Details popover inside the header is declared as:

```tsx
<div className="absolute top-full right-0 pt-2 w-64 z-50 pointer-events-auto">
```

Its local `z-50` only ranks it among siblings inside the header's stacking context. Before `4d01c32e`, the header container itself carried `z-20`, which established a stacking context elevated above the sibling main content area. After that commit, the header no longer creates a stacking context, so when the popover drops below the header's 64 px height (`top-full`), it is rendered underneath the positioned chat / AI log view.

**Symptom:** clicking the CONTEXT button shows only the very top of the "Context Details" panel at the edge of the header; the rest of the popover is hidden behind the chat area.

Restoring `z-20` on the header re-elevates the header's stacking context so its absolute descendants render above the sibling main content area, matching the pre-April-9 behavior. The tooltip's own `z-50` remains, so nothing else regresses.

## Test plan

- [ ] Open the app, start any AI session
- [ ] Click the CONTEXT button in the top header
- [ ] Verify the full Context Details popover renders above the chat area (Input Tokens, Output Tokens, Cache rows all visible)
- [ ] Hover away and confirm the popover dismisses cleanly
- [ ] Confirm the header itself still renders in the expected position and no other elements are visually affected by the restored z-20

## Alternative considered

A more robust long-term fix would be to render the popover via a React portal so it escapes all parent stacking contexts. That is a larger change and out of scope for this regression fix, but is the recommended direction if similar issues surface for other in-header popovers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the main panel header's stacking order to ensure it displays at the correct layer relative to other elements on the screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->