### PR TITLE
fix: detect and recover from silent session resume failure

### DIFF
--- a/src/__tests__/renderer/hooks/useAgentListeners.test.ts
+++ b/src/__tests__/renderer/hooks/useAgentListeners.test.ts
@@ -608,6 +608,14 @@ describe('useAgentListeners', () => {
 				id: 'tab-1',
 				agentSessionId: 'old-session-id',
 				awaitingSessionId: false,
+				usageStats: {
+					inputTokens: 100,
+					outputTokens: 50,
+					cacheReadInputTokens: 0,
+					cacheCreationInputTokens: 0,
+					totalCostUsd: 0.001,
+					contextWindow: 200000,
+				},
 			});
 			const session = createMockSession({
 				id: 'sess-1',
@@ -668,6 +676,11 @@ describe('useAgentListeners', () => {
 			const updated = useSessionStore.getState().sessions.find((s) => s.id === 'sess-1');
 			const updatedTab = updated?.aiTabs.find((t) => t.id === 'tab-1');
 			expect(updatedTab?.agentSessionId).toBe('same-session-id');
+			// Should NOT add a resume-failure log entry
+			const hasResumeFailureLog = !!updatedTab?.logs.some((l) =>
+				l.text.includes('Session resume failed')
+			);
+			expect(hasResumeFailureLog).toBe(false);
 		});
 
 		it('preserves context gauge when resume succeeds', () => {

--- a/src/__tests__/renderer/hooks/useAgentListeners.test.ts
+++ b/src/__tests__/renderer/hooks/useAgentListeners.test.ts
@@ -168,7 +168,6 @@ function createMockBatchedUpdater(): BatchedUpdater {
 		markUnread: vi.fn(),
 		updateUsage: vi.fn(),
 		updateContextUsage: vi.fn(),
-		resetContextUsage: vi.fn(),
 		updateCycleBytes: vi.fn(),
 		updateCycleTokens: vi.fn(),
 	};
@@ -638,7 +637,7 @@ describe('useAgentListeners', () => {
 			);
 			expect(resumeLog).toBeDefined();
 			// Should reset context usage
-			expect(deps.batchedUpdater.resetContextUsage).toHaveBeenCalledWith('sess-1', 0);
+			expect(deps.batchedUpdater.updateContextUsage).toHaveBeenCalledWith('sess-1', 0);
 		});
 
 		it('does not warn on resume success (same session ID returned)', () => {
@@ -664,7 +663,7 @@ describe('useAgentListeners', () => {
 			onSessionIdHandler?.('sess-1-ai-tab-1', 'same-session-id');
 
 			// Should NOT reset context usage
-			expect(deps.batchedUpdater.resetContextUsage).not.toHaveBeenCalled();
+			expect(deps.batchedUpdater.updateContextUsage).not.toHaveBeenCalled();
 			// Session ID should remain unchanged
 			const updated = useSessionStore.getState().sessions.find((s) => s.id === 'sess-1');
 			const updatedTab = updated?.aiTabs.find((t) => t.id === 'tab-1');
@@ -695,7 +694,7 @@ describe('useAgentListeners', () => {
 			onSessionIdHandler?.('sess-1-ai-tab-1', 'existing-session');
 
 			// Context usage should NOT be reset
-			expect(deps.batchedUpdater.resetContextUsage).not.toHaveBeenCalled();
+			expect(deps.batchedUpdater.updateContextUsage).not.toHaveBeenCalled();
 			const updated = useSessionStore.getState().sessions.find((s) => s.id === 'sess-1');
 			expect(updated?.contextUsage).toBe(48);
 		});

--- a/src/__tests__/renderer/hooks/useAgentListeners.test.ts
+++ b/src/__tests__/renderer/hooks/useAgentListeners.test.ts
@@ -168,6 +168,7 @@ function createMockBatchedUpdater(): BatchedUpdater {
 		markUnread: vi.fn(),
 		updateUsage: vi.fn(),
 		updateContextUsage: vi.fn(),
+		resetContextUsage: vi.fn(),
 		updateCycleBytes: vi.fn(),
 		updateCycleTokens: vi.fn(),
 	};
@@ -600,6 +601,103 @@ describe('useAgentListeners', () => {
 			onSessionIdHandler?.('sess-1-batch-0-ai', 'agent-session-abc');
 
 			expect(window.maestro.agentSessions.registerSessionOrigin).not.toHaveBeenCalled();
+		});
+
+		it('detects resume failure when agent returns a different session ID', () => {
+			const deps = createMockDeps();
+			const tab = createMockTab({
+				id: 'tab-1',
+				agentSessionId: 'old-session-id',
+				awaitingSessionId: false,
+			});
+			const session = createMockSession({
+				id: 'sess-1',
+				aiTabs: [tab],
+				activeTabId: 'tab-1',
+			});
+			useSessionStore.setState({
+				sessions: [session],
+				activeSessionId: 'sess-1',
+			});
+
+			renderHook(() => useAgentListeners(deps));
+
+			// Agent returns a DIFFERENT session ID → resume failed
+			onSessionIdHandler?.('sess-1-ai-tab-1', 'new-session-id');
+
+			const updated = useSessionStore.getState().sessions.find((s) => s.id === 'sess-1');
+			const updatedTab = updated?.aiTabs.find((t) => t.id === 'tab-1');
+
+			// Should accept the new session ID (not keep the stale one)
+			expect(updatedTab?.agentSessionId).toBe('new-session-id');
+			// Should clear usage stats
+			expect(updatedTab?.usageStats).toBeUndefined();
+			// Should add a system log entry about resume failure
+			const resumeLog = updatedTab?.logs.find((l) =>
+				l.text.includes('Session resume failed')
+			);
+			expect(resumeLog).toBeDefined();
+			// Should reset context usage
+			expect(deps.batchedUpdater.resetContextUsage).toHaveBeenCalledWith('sess-1', 0);
+		});
+
+		it('does not warn on resume success (same session ID returned)', () => {
+			const deps = createMockDeps();
+			const tab = createMockTab({
+				id: 'tab-1',
+				agentSessionId: 'same-session-id',
+				awaitingSessionId: false,
+			});
+			const session = createMockSession({
+				id: 'sess-1',
+				aiTabs: [tab],
+				activeTabId: 'tab-1',
+			});
+			useSessionStore.setState({
+				sessions: [session],
+				activeSessionId: 'sess-1',
+			});
+
+			renderHook(() => useAgentListeners(deps));
+
+			// Agent returns the SAME session ID → resume succeeded
+			onSessionIdHandler?.('sess-1-ai-tab-1', 'same-session-id');
+
+			// Should NOT reset context usage
+			expect(deps.batchedUpdater.resetContextUsage).not.toHaveBeenCalled();
+			// Session ID should remain unchanged
+			const updated = useSessionStore.getState().sessions.find((s) => s.id === 'sess-1');
+			const updatedTab = updated?.aiTabs.find((t) => t.id === 'tab-1');
+			expect(updatedTab?.agentSessionId).toBe('same-session-id');
+		});
+
+		it('preserves context gauge when resume succeeds', () => {
+			const deps = createMockDeps();
+			const tab = createMockTab({
+				id: 'tab-1',
+				agentSessionId: 'existing-session',
+				awaitingSessionId: false,
+			});
+			const session = createMockSession({
+				id: 'sess-1',
+				aiTabs: [tab],
+				activeTabId: 'tab-1',
+				contextUsage: 48,
+			});
+			useSessionStore.setState({
+				sessions: [session],
+				activeSessionId: 'sess-1',
+			});
+
+			renderHook(() => useAgentListeners(deps));
+
+			// Same session ID → resume succeeded
+			onSessionIdHandler?.('sess-1-ai-tab-1', 'existing-session');
+
+			// Context usage should NOT be reset
+			expect(deps.batchedUpdater.resetContextUsage).not.toHaveBeenCalled();
+			const updated = useSessionStore.getState().sessions.find((s) => s.id === 'sess-1');
+			expect(updated?.contextUsage).toBe(48);
 		});
 	});
 

--- a/src/renderer/hooks/agent/useAgentListeners.ts
+++ b/src/renderer/hooks/agent/useAgentListeners.ts
@@ -68,7 +68,6 @@ export interface BatchedUpdater {
 	markUnread: (sessionId: string, tabId: string, unread: boolean) => void;
 	updateUsage: (sessionId: string, tabId: string | null, usage: UsageStats) => void;
 	updateContextUsage: (sessionId: string, percentage: number) => void;
-	resetContextUsage: (sessionId: string, percentage: number) => void;
 	updateCycleBytes: (sessionId: string, bytes: number) => void;
 	updateCycleTokens: (sessionId: string, tokens: number) => void;
 }
@@ -913,8 +912,6 @@ export function useAgentListeners(deps: UseAgentListenersDeps): void {
 				const actualSessionId = parsed.actualSessionId;
 				const tabId = parsed.tabId ?? undefined;
 
-				// Track whether a resume failure was detected inside setSessions
-				// so we can fire side-effects (toast, context reset) afterwards.
 				let resumeFailureDetected = false;
 
 				setSessions((prev) => {
@@ -947,8 +944,6 @@ export function useAgentListeners(deps: UseAgentListenersDeps): void {
 							return { ...s, agentSessionId };
 						}
 
-						// Detect resume failure: tab had a session ID but agent returned a different one.
-						// This means --resume failed silently and the agent started a fresh session.
 						// Accept the new ID to prevent a death spiral of failed resumes.
 						if (targetTab.agentSessionId && targetTab.agentSessionId !== agentSessionId) {
 							console.warn(
@@ -1007,9 +1002,8 @@ export function useAgentListeners(deps: UseAgentListenersDeps): void {
 					});
 				});
 
-				// Fire side-effects outside the state updater
 				if (resumeFailureDetected) {
-					deps.batchedUpdater.resetContextUsage(actualSessionId, 0);
+					deps.batchedUpdater.updateContextUsage(actualSessionId, 0);
 					notifyToast({
 						type: 'warning',
 						title: 'Session Resume Failed',

--- a/src/renderer/hooks/agent/useAgentListeners.ts
+++ b/src/renderer/hooks/agent/useAgentListeners.ts
@@ -68,6 +68,7 @@ export interface BatchedUpdater {
 	markUnread: (sessionId: string, tabId: string, unread: boolean) => void;
 	updateUsage: (sessionId: string, tabId: string | null, usage: UsageStats) => void;
 	updateContextUsage: (sessionId: string, percentage: number) => void;
+	resetContextUsage: (sessionId: string, percentage: number) => void;
 	updateCycleBytes: (sessionId: string, bytes: number) => void;
 	updateCycleTokens: (sessionId: string, tokens: number) => void;
 }
@@ -912,6 +913,10 @@ export function useAgentListeners(deps: UseAgentListenersDeps): void {
 				const actualSessionId = parsed.actualSessionId;
 				const tabId = parsed.tabId ?? undefined;
 
+				// Track whether a resume failure was detected inside setSessions
+				// so we can fire side-effects (toast, context reset) afterwards.
+				let resumeFailureDetected = false;
+
 				setSessions((prev) => {
 					const session = prev.find((s) => s.id === actualSessionId);
 					if (!session) return prev;
@@ -942,8 +947,45 @@ export function useAgentListeners(deps: UseAgentListenersDeps): void {
 							return { ...s, agentSessionId };
 						}
 
+						// Detect resume failure: tab had a session ID but agent returned a different one.
+						// This means --resume failed silently and the agent started a fresh session.
+						// Accept the new ID to prevent a death spiral of failed resumes.
 						if (targetTab.agentSessionId && targetTab.agentSessionId !== agentSessionId) {
-							return s;
+							console.warn(
+								'[onSessionId] Session resume failed — agent returned a new session ID',
+								{
+									expected: targetTab.agentSessionId,
+									received: agentSessionId,
+									tabId: targetTab.id,
+									sessionId: actualSessionId,
+								}
+							);
+
+							resumeFailureDetected = true;
+
+							const resumeFailLog: LogEntry = {
+								id: generateId(),
+								timestamp: Date.now(),
+								source: 'system',
+								text: '⚠️ Session resume failed — agent started a new session. Previous context was lost.',
+							};
+
+							const updatedAiTabs = s.aiTabs.map((tab) => {
+								if (tab.id !== targetTab.id) return tab;
+								return {
+									...tab,
+									agentSessionId,
+									awaitingSessionId: false,
+									usageStats: undefined,
+									logs: [...tab.logs, resumeFailLog],
+								};
+							});
+
+							return {
+								...s,
+								aiTabs: updatedAiTabs,
+								agentSessionId,
+							};
 						}
 
 						const updatedAiTabs = s.aiTabs.map((tab) => {
@@ -964,6 +1006,17 @@ export function useAgentListeners(deps: UseAgentListenersDeps): void {
 						};
 					});
 				});
+
+				// Fire side-effects outside the state updater
+				if (resumeFailureDetected) {
+					deps.batchedUpdater.resetContextUsage(actualSessionId, 0);
+					notifyToast({
+						type: 'warning',
+						title: 'Session Resume Failed',
+						message: 'Agent started a new session. Previous context was lost.',
+						sessionId: actualSessionId,
+					});
+				}
 			}
 		);
 

--- a/src/renderer/hooks/input/useInputProcessing.ts
+++ b/src/renderer/hooks/input/useInputProcessing.ts
@@ -870,6 +870,19 @@ export function useInputProcessing(deps: UseInputProcessingDeps): UseInputProces
 						// Use the ACTIVE TAB's agentSessionId (not the deprecated session-level one)
 						const freshActiveTab = getActiveTab(freshSession);
 						const tabAgentSessionId = freshActiveTab?.agentSessionId;
+
+						// Guard: warn if spawning without a session ID for a tab that has prior logs
+						if (!tabAgentSessionId && freshActiveTab?.logs && freshActiveTab.logs.length > 0) {
+							console.warn(
+								'[InputProcessing] Spawning batch agent without agentSessionId for tab with existing logs',
+								{
+									tabId: freshActiveTab.id,
+									logCount: freshActiveTab.logs.length,
+									sessionId: activeSessionId,
+								}
+							);
+						}
+
 						// Check CURRENT session's Auto Run state (not any session's) and respect worktree bypass
 						const currentSessionBatchState = getBatchState(activeSessionId);
 						const isAutoRunReadOnly =

--- a/src/renderer/hooks/input/useInputProcessing.ts
+++ b/src/renderer/hooks/input/useInputProcessing.ts
@@ -871,7 +871,6 @@ export function useInputProcessing(deps: UseInputProcessingDeps): UseInputProces
 						const freshActiveTab = getActiveTab(freshSession);
 						const tabAgentSessionId = freshActiveTab?.agentSessionId;
 
-						// Guard: warn if spawning without a session ID for a tab that has prior logs
 						if (!tabAgentSessionId && freshActiveTab?.logs && freshActiveTab.logs.length > 0) {
 							console.warn(
 								'[InputProcessing] Spawning batch agent without agentSessionId for tab with existing logs',


### PR DESCRIPTION
## Summary

Fixes #773 — Chat loses context mid-session when the batch-mode `--resume` flag silently fails.

## Root Cause

Each user message spawns a new `claude` process with `--resume <agentSessionId>`. When the session ID becomes stale (server-side expiry, state loss, restart), `--resume` fails silently and the agent starts fresh. The old code **rejected** the new session ID, keeping the stale one — creating a permanent death spiral where every subsequent message also lost context.

## Changes

### Detection & Recovery (`useAgentListeners.ts`)
- When agent returns a different session ID than expected, accept the new one (breaks death spiral)
- Clear stale `usageStats` and reset context gauge to 0%
- Add system log entry warning about context loss
- Fire toast notification to alert the user

### Spawn Guard (`useInputProcessing.ts`)
- Console warning when spawning batch agent without `agentSessionId` for a tab with existing logs

### Tests (`useAgentListeners.test.ts`)
- Resume failure detection (accepts new ID, clears stats, logs warning)
- No false positives on successful resume (same ID returned)
- Context gauge preservation on successful resume

## Test Results

- 22,453 tests pass
- Build succeeds
- Lint clean

## Files Changed

| File | Lines |
|------|-------|
| `src/renderer/hooks/agent/useAgentListeners.ts` | +55, -1 |
| `src/renderer/hooks/input/useInputProcessing.ts` | +13 |
| `src/__tests__/renderer/hooks/useAgentListeners.test.ts` | +98 |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session resume failure detection with a warning toast notifying users when previous context is lost during session recovery.
  * Session usage data and context are now properly reset when a session resume fails.

* **Tests**
  * Extended test coverage for agent listener behavior across session resume success and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->