### PR TITLE
fix: Fix race condition where the model picker dropdown shows models from the wrong agent type (e.g. OpenCode/Copilot models appearing in a Claude Code session)

### DIFF
--- a/src/renderer/components/MainPanel/MainPanel.tsx
+++ b/src/renderer/components/MainPanel/MainPanel.tsx
@@ -255,33 +255,58 @@ export const MainPanel = React.memo(
 			[setLogViewerOpen, setActiveSessionId, setSessions]
 		);
 
-		// Fetch available models, effort levels, and agent defaults when agent type changes
+		// Fetch available models, effort levels, and agent defaults when session or agent type changes.
+		// The stale flag prevents a slow response from an earlier session overwriting
+		// the values for the current one (race between consecutive async fetches).
 		useEffect(() => {
 			if (!activeSession?.toolType) return;
+			let stale = false;
 			const agentId = activeSession.toolType;
+
+			// Clear immediately so stale values from the previous session
+			// are never shown while the new fetch is in flight.
+			setPillModels([]);
+			setPillEfforts([]);
+			setAgentDefaultModel('');
+			setAgentDefaultEffort('');
+
 			// Fetch models
 			window.maestro.agents
 				.getModels(agentId)
-				.then(setPillModels)
-				.catch(() => setPillModels([]));
+				.then((m) => {
+					if (!stale) setPillModels(m);
+				})
+				.catch(() => {
+					if (!stale) setPillModels([]);
+				});
 			// Fetch effort options — use the effort-related config key for this agent
 			const effortKey = agentId === 'codex' ? 'reasoningEffort' : 'effort';
 			window.maestro.agents
 				.getConfigOptions(agentId, effortKey)
-				.then(setPillEfforts)
-				.catch(() => setPillEfforts([]));
+				.then((o) => {
+					if (!stale) setPillEfforts(o);
+				})
+				.catch(() => {
+					if (!stale) setPillEfforts([]);
+				});
 			// Fetch agent-level config for default model/effort
 			window.maestro.agents
 				.getConfig(agentId)
 				.then((config) => {
+					if (stale) return;
 					setAgentDefaultModel(config?.model || '');
 					setAgentDefaultEffort(config?.effort || config?.reasoningEffort || '');
 				})
 				.catch(() => {
+					if (stale) return;
 					setAgentDefaultModel('');
 					setAgentDefaultEffort('');
 				});
-		}, [activeSession?.toolType]);
+
+			return () => {
+				stale = true;
+			};
+		}, [activeSession?.id, activeSession?.toolType]);
 
 		// Resolved current model/effort: session override > agent config > empty
 		const resolvedModel = activeSession?.customModel || agentDefaultModel;


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                                                                    
   
  - Fix race condition where the model picker dropdown shows models from the wrong agent type (e.g. OpenCode/Copilot models appearing in a Claude Code session)                                                                                
  - On startup, `selectActiveSession` briefly falls back to `sessions[0]` before the active session ID is hydrated — if `sessions[0]` is a different agent type, its model fetch can resolve late and overwrite the correct models           
  - Add stale-closure guard, clear pill values immediately on switch, and include `activeSession.id` in the dependency array                                                                                                                   
                                                                                                                                                                                                                                             
  ## Root cause                                                                                                                                                                                                                                
                                                                                                                                                                                                                                             
  The `useEffect` that fetches available models depended only on `activeSession?.toolType`. During startup or rapid session switches, two async `getModels()` calls could be in flight simultaneously. The slower one (from the                
  previous/fallback session) would resolve last and silently overwrite the model list with models from the wrong agent.
                                                                                                                                                                                                                                               
  Concrete repro: `sessions[0]` is OpenCode → selector falls back to it before hydration → OpenCode model fetch starts → active session hydrates to Claude Code → Claude model fetch starts and resolves → OpenCode fetch resolves late and    
  overwrites with `opencode/*` and `github-copilot/*` models.
                                                                                                                                                                                                                                               
  ## Changes                                                                                                                                                                                                                                 

  - Clear `pillModels`, `pillEfforts`, and agent defaults immediately when the session changes (no stale UI while fetch is in flight)
  - Wrap all `.then()` callbacks in a `stale` flag guard set by the effect cleanup
  - Add `activeSession?.id` to the dependency array so the effect re-runs on every session switch, not just agent type changes                                                                                                                 
   
  ## Test plan                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                             
  - [ ] Switch rapidly between OpenCode and Claude Code sessions — model picker should always show only the active agent's models                                                                                                              
  - [ ] Restart app with an OpenCode session as `sessions[0]` and a Claude session as the last-active — Claude session should show only Claude models after hydration
  - [ ] Model picker should briefly show empty (no dropdown) during fetch, never stale models from another agent  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* **Improved session switching reliability** – Fixed an issue where data from previous sessions could briefly display when switching between active sessions. The app now properly clears and refreshes all session-related settings and models when you change sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->