### PR TITLE
fix: prevent model picker race condition when switching agent types

### DIFF
--- a/src/__tests__/renderer/components/MainPanel.test.tsx
+++ b/src/__tests__/renderer/components/MainPanel.test.tsx
@@ -3471,4 +3471,88 @@ describe('MainPanel', () => {
 			expect(screen.queryByTestId('terminal-view-session-1')).not.toBeInTheDocument();
 		});
 	});
+
+	describe('Model/effort pill race condition', () => {
+		it('should discard stale model responses when switching agent types', async () => {
+			// Simulate: OpenCode model discovery (slow subprocess) resolves AFTER
+			// Claude model discovery (fast file read) when switching agents.
+			// Without the stale flag fix, the late OpenCode response would overwrite
+			// Claude's model list, showing wrong models in the picker.
+
+			let resolveOpenCodeModels!: (models: string[]) => void;
+			const openCodeModelsPromise = new Promise<string[]>((resolve) => {
+				resolveOpenCodeModels = resolve;
+			});
+
+			const claudeModels = ['sonnet', 'opus', 'haiku'];
+			const openCodeModels = ['github-copilot/gpt-5-mini', 'ollama/llama3:8b'];
+
+			// Start with OpenCode session
+			const openCodeSession = createSession({
+				id: 'session-opencode',
+				toolType: 'opencode' as any,
+				name: 'OpenCode Session',
+			});
+
+			setCapabilitiesCache('opencode', {
+				supportsResume: false,
+				supportsReadOnlyMode: true,
+				supportsJsonOutput: true,
+				supportsSessionId: true,
+				supportsImageInput: false,
+				supportsImageInputOnResume: false,
+				supportsSlashCommands: true,
+				supportsSessionStorage: false,
+				supportsCostTracking: false,
+				supportsUsageStats: false,
+				supportsBatchMode: true,
+				requiresPromptToStart: false,
+				supportsStreaming: true,
+				supportsResultMessages: true,
+				supportsModelSelection: true,
+				supportsStreamJsonInput: false,
+			});
+
+			// Mock getModels: OpenCode returns a slow promise, Claude returns immediately
+			vi.mocked(window.maestro.agents.getModels).mockImplementation((agentId: string) => {
+				if (agentId === 'opencode') return openCodeModelsPromise;
+				if (agentId === 'claude-code') return Promise.resolve(claudeModels);
+				return Promise.resolve([]);
+			});
+			vi.mocked(window.maestro.agents.getConfigOptions).mockResolvedValue([]);
+			vi.mocked(window.maestro.agents.getConfig).mockResolvedValue({});
+
+			useSessionStore.setState({ sessions: [openCodeSession] });
+
+			// Render with OpenCode session — triggers getModels('opencode') which is pending
+			const { rerender } = render(<MainPanel {...defaultProps} activeSession={openCodeSession} />);
+
+			// Switch to Claude session — triggers getModels('claude-code') which resolves fast
+			const claudeSession = createSession({
+				id: 'session-claude',
+				toolType: 'claude-code',
+				name: 'Claude Session',
+			});
+			useSessionStore.setState({ sessions: [claudeSession] });
+
+			await act(async () => {
+				rerender(<MainPanel {...defaultProps} activeSession={claudeSession} />);
+			});
+
+			// Wait for Claude models to be applied
+			await waitFor(() => {
+				expect(vi.mocked(window.maestro.agents.getModels)).toHaveBeenCalledWith('claude-code');
+			});
+
+			// Now resolve the stale OpenCode models (arriving late)
+			await act(async () => {
+				resolveOpenCodeModels(openCodeModels);
+			});
+
+			// The stale OpenCode models should NOT appear — Claude models should persist.
+			// getModels was called for both agents
+			expect(vi.mocked(window.maestro.agents.getModels)).toHaveBeenCalledWith('opencode');
+			expect(vi.mocked(window.maestro.agents.getModels)).toHaveBeenCalledWith('claude-code');
+		});
+	});
 });

--- a/src/__tests__/renderer/components/MainPanel.test.tsx
+++ b/src/__tests__/renderer/components/MainPanel.test.tsx
@@ -78,10 +78,17 @@ vi.mock('../../../renderer/components/TerminalOutput', () => ({
 }));
 
 vi.mock('../../../renderer/components/InputArea', () => ({
-	InputArea: (props: { session: { name: string }; onInputFocus: () => void }) => {
+	InputArea: (props: {
+		session: { name: string };
+		onInputFocus: () => void;
+		availableModels?: string[];
+	}) => {
 		return React.createElement(
 			'div',
-			{ 'data-testid': 'input-area' },
+			{
+				'data-testid': 'input-area',
+				'data-available-models': JSON.stringify(props.availableModels ?? []),
+			},
 			React.createElement('input', { 'data-testid': 'input-field', onFocus: props.onInputFocus }),
 			`Input for ${props.session?.name}`
 		);
@@ -3549,10 +3556,17 @@ describe('MainPanel', () => {
 				resolveOpenCodeModels(openCodeModels);
 			});
 
-			// The stale OpenCode models should NOT appear — Claude models should persist.
-			// getModels was called for both agents
+			// Both IPC calls should have fired
 			expect(vi.mocked(window.maestro.agents.getModels)).toHaveBeenCalledWith('opencode');
 			expect(vi.mocked(window.maestro.agents.getModels)).toHaveBeenCalledWith('claude-code');
+
+			// The stale OpenCode models should NOT appear — Claude models should persist.
+			// Verify via the data attribute exposed by the InputArea mock.
+			await waitFor(() => {
+				const inputArea = screen.getByTestId('input-area');
+				const models = JSON.parse(inputArea.getAttribute('data-available-models') || '[]');
+				expect(models).toEqual(claudeModels);
+			});
 		});
 	});
 });

--- a/src/renderer/components/MainPanel/MainPanel.tsx
+++ b/src/renderer/components/MainPanel/MainPanel.tsx
@@ -249,32 +249,49 @@ export const MainPanel = React.memo(
 			[setLogViewerOpen, setActiveSessionId, setSessions]
 		);
 
-		// Fetch available models, effort levels, and agent defaults when agent type changes
+		// Fetch available models, effort levels, and agent defaults when agent type changes.
+		// Uses a stale flag to prevent race conditions when switching between agents —
+		// without this, a slow response (e.g., `opencode models` subprocess) from the
+		// previous agent can overwrite the current agent's model list.
 		useEffect(() => {
 			if (!activeSession?.toolType) return;
+			let stale = false;
 			const agentId = activeSession.toolType;
 			// Fetch models
 			window.maestro.agents
 				.getModels(agentId)
-				.then(setPillModels)
-				.catch(() => setPillModels([]));
+				.then((models) => {
+					if (!stale) setPillModels(models);
+				})
+				.catch(() => {
+					if (!stale) setPillModels([]);
+				});
 			// Fetch effort options — use the effort-related config key for this agent
 			const effortKey = agentId === 'codex' ? 'reasoningEffort' : 'effort';
 			window.maestro.agents
 				.getConfigOptions(agentId, effortKey)
-				.then(setPillEfforts)
-				.catch(() => setPillEfforts([]));
+				.then((efforts) => {
+					if (!stale) setPillEfforts(efforts);
+				})
+				.catch(() => {
+					if (!stale) setPillEfforts([]);
+				});
 			// Fetch agent-level config for default model/effort
 			window.maestro.agents
 				.getConfig(agentId)
 				.then((config) => {
+					if (stale) return;
 					setAgentDefaultModel(config?.model || '');
 					setAgentDefaultEffort(config?.effort || config?.reasoningEffort || '');
 				})
 				.catch(() => {
+					if (stale) return;
 					setAgentDefaultModel('');
 					setAgentDefaultEffort('');
 				});
+			return () => {
+				stale = true;
+			};
 		}, [activeSession?.toolType]);
 
 		// Resolved current model/effort: session override > agent config > empty


### PR DESCRIPTION
## Summary
- Fixed race condition in `MainPanel.tsx` model/effort pill fetching where stale async responses from a previous agent could overwrite the current agent's model list
- Added stale flag with cleanup function to the `useEffect` that fetches models, effort options, and agent defaults
- Added test verifying that late-arriving model responses from a superseded agent are discarded

## Root Cause
When switching between agents (e.g., OpenCode → Claude), the `useEffect` fired async calls for both. OpenCode's model discovery (`opencode models` subprocess) is slower than Claude's (local file read), so the stale OpenCode response could resolve last and overwrite Claude's model list — causing OpenCode models like `github-copilot/gpt-5-mini` to appear in a Claude-only session.

## Test plan
- [x] Added test: `Model/effort pill race condition > should discard stale model responses when switching agent types`
- [x] All 135 MainPanel tests pass
- [x] TypeScript type check clean
- [x] ESLint clean
- [x] Prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented stale in-flight model requests from overwriting the current agent's model/effort selections when switching agent types, improving model-list stability.

* **Tests**
  * Added test coverage that simulates agent switching and verifies model loading race conditions are handled correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->