### PR TITLE
feat(feedback): Add feedback system with modal, command palette, and IPC integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -264,7 +264,6 @@
 			"integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.27.1",
 				"@babel/generator": "^7.28.5",
@@ -668,7 +667,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			},
@@ -712,7 +710,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -2286,7 +2283,6 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
 			"integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"engines": {
 				"node": ">=8.0.0"
 			}
@@ -2308,7 +2304,6 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.2.0.tgz",
 			"integrity": "sha512-qRkLWiUEZNAmYapZ7KGS5C4OmBLcP/H2foXeOEaowYCR0wi89fHejrfYfbuLVCMLp/dWZXKvQusdbUEZjERfwQ==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"engines": {
 				"node": "^18.19.0 || >=20.6.0"
 			},
@@ -2321,7 +2316,6 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
 			"integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@opentelemetry/semantic-conventions": "^1.29.0"
 			},
@@ -2337,7 +2331,6 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.208.0.tgz",
 			"integrity": "sha512-Eju0L4qWcQS+oXxi6pgh7zvE2byogAkcsVv0OjHF/97iOz1N/aKE6etSGowYkie+YA1uo6DNwdSxaaNnLvcRlA==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@opentelemetry/api-logs": "0.208.0",
 				"import-in-the-middle": "^2.0.0",
@@ -2725,7 +2718,6 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
 			"integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@opentelemetry/core": "2.2.0",
 				"@opentelemetry/semantic-conventions": "^1.29.0"
@@ -2742,7 +2734,6 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.2.0.tgz",
 			"integrity": "sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@opentelemetry/core": "2.2.0",
 				"@opentelemetry/resources": "2.2.0",
@@ -2760,7 +2751,6 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.38.0.tgz",
 			"integrity": "sha512-kocjix+/sSggfJhwXqClZ3i9Y/MI0fp7b+g7kCRm6psy2dsf8uApTRclwG18h8Avm7C9+fnt+O36PspJ/OzoWg==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"engines": {
 				"node": ">=14"
 			}
@@ -3819,7 +3809,8 @@
 			"resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
 			"integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/@types/babel__core": {
 			"version": "7.20.5",
@@ -4357,7 +4348,6 @@
 			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
 			"integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/prop-types": "*",
 				"csstype": "^3.2.2"
@@ -4369,7 +4359,6 @@
 			"integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"peerDependencies": {
 				"@types/react": "^18.0.0"
 			}
@@ -4495,7 +4484,6 @@
 			"integrity": "sha512-hM5faZwg7aVNa819m/5r7D0h0c9yC4DUlWAOvHAtISdFTc8xB86VmX5Xqabrama3wIPJ/q9RbGS1worb6JfnMg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.50.1",
 				"@typescript-eslint/types": "8.50.1",
@@ -4926,7 +4914,6 @@
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -5008,7 +4995,6 @@
 			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -6012,7 +5998,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.8.25",
 				"caniuse-lite": "^1.0.30001754",
@@ -6495,7 +6480,6 @@
 			"resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.0.3.tgz",
 			"integrity": "sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@chevrotain/cst-dts-gen": "11.0.3",
 				"@chevrotain/gast": "11.0.3",
@@ -7221,7 +7205,6 @@
 			"resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
 			"integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=0.10"
 			}
@@ -7631,7 +7614,6 @@
 			"resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
 			"integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
 			"license": "ISC",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -8129,7 +8111,6 @@
 			"integrity": "sha512-rcJUkMfnJpfCboZoOOPf4L29TRtEieHNOeAbYPWPxlaBw/Z1RKrRA86dOI9rwaI4tQSc/RD82zTNHprfUHXsoQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"app-builder-lib": "24.13.3",
 				"builder-util": "24.13.1",
@@ -8225,7 +8206,8 @@
 			"resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
 			"integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/dompurify": {
 			"version": "3.3.0",
@@ -8369,6 +8351,7 @@
 			"integrity": "sha512-oHkV0iogWfyK+ah9ZIvMDpei1m9ZRpdXcvde1wTpra2U8AFDNNpqJdnin5z+PM1GbQ5BoaKCWas2HSjtR0HwMg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"app-builder-lib": "24.13.3",
 				"archiver": "^5.3.1",
@@ -8382,6 +8365,7 @@
 			"integrity": "sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"archiver-utils": "^2.1.0",
 				"async": "^3.2.4",
@@ -8401,6 +8385,7 @@
 			"integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"glob": "^7.1.4",
 				"graceful-fs": "^4.2.0",
@@ -8423,6 +8408,7 @@
 			"integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"core-util-is": "~1.0.0",
 				"inherits": "~2.0.3",
@@ -8439,6 +8425,7 @@
 			"integrity": "sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"buffer-crc32": "^0.2.13",
 				"crc32-stream": "^4.0.2",
@@ -8455,6 +8442,7 @@
 			"integrity": "sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"crc-32": "^1.2.0",
 				"readable-stream": "^3.4.0"
@@ -8469,6 +8457,7 @@
 			"integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"graceful-fs": "^4.2.0",
 				"jsonfile": "^6.0.1",
@@ -8484,6 +8473,7 @@
 			"integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"universalify": "^2.0.0"
 			},
@@ -8496,7 +8486,8 @@
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/electron-builder-squirrel-windows/node_modules/string_decoder": {
 			"version": "1.1.1",
@@ -8504,6 +8495,7 @@
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"safe-buffer": "~5.1.0"
 			}
@@ -8514,6 +8506,7 @@
 			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">= 10.0.0"
 			}
@@ -8524,6 +8517,7 @@
 			"integrity": "sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"archiver-utils": "^3.0.4",
 				"compress-commons": "^4.1.2",
@@ -8539,6 +8533,7 @@
 			"integrity": "sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"glob": "^7.2.3",
 				"graceful-fs": "^4.2.0",
@@ -9220,7 +9215,6 @@
 			"integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -11140,7 +11134,6 @@
 			"resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
 			"integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
 			"license": "MIT",
-			"peer": true,
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/immer"
@@ -11961,7 +11954,6 @@
 			"integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"jiti": "bin/jiti.js"
 			}
@@ -12431,14 +12423,16 @@
 			"resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
 			"integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/lodash.difference": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
 			"integrity": "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/lodash.escaperegexp": {
 			"version": "4.1.2",
@@ -12451,7 +12445,8 @@
 			"resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
 			"integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/lodash.isequal": {
 			"version": "4.5.0",
@@ -12465,7 +12460,8 @@
 			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
 			"integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/lodash.merge": {
 			"version": "4.6.2",
@@ -12479,7 +12475,8 @@
 			"resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
 			"integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/log-symbols": {
 			"version": "4.1.0",
@@ -12570,6 +12567,7 @@
 			"integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"lz-string": "bin/bin.js"
 			}
@@ -15067,7 +15065,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.11",
 				"picocolors": "^1.1.1",
@@ -15308,6 +15305,7 @@
 			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"ansi-regex": "^5.0.1",
 				"ansi-styles": "^5.0.0",
@@ -15323,6 +15321,7 @@
 			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -15667,7 +15666,6 @@
 			"resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
 			"integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0"
 			},
@@ -15697,7 +15695,6 @@
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
 			"integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0",
 				"scheduler": "^0.23.2"
@@ -15745,7 +15742,6 @@
 			"resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
 			"integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/use-sync-external-store": "^0.0.6",
 				"use-sync-external-store": "^1.4.0"
@@ -15932,8 +15928,7 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
 			"integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/redux-thunk": {
 			"version": "3.1.0",
@@ -17690,7 +17685,6 @@
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -18001,7 +17995,6 @@
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -18375,7 +18368,6 @@
 			"integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.21.3",
 				"postcss": "^8.4.43",
@@ -18881,7 +18873,6 @@
 			"integrity": "sha512-n1RxDp8UJm6N0IbJLQo+yzLZ2sQCDyl1o0LeugbPWf8+8Fttp29GghsQBjYJVmWq3gBFfe9Hs1spR44vovn2wA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@vitest/expect": "4.0.15",
 				"@vitest/mocker": "4.0.15",
@@ -19472,7 +19463,6 @@
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -19486,7 +19476,6 @@
 			"integrity": "sha512-tI2l/nFHC5rLh7+5+o7QjKjSR04ivXDF4jcgV0f/bTQ+OJiITy5S6gaynVsEM+7RqzufMnVbIon6Sr5x1SDYaQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.25.0",
 				"fdir": "^6.5.0",
@@ -20084,7 +20073,6 @@
 			"integrity": "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}

--- a/src/__tests__/main/ipc/handlers/feedback.test.ts
+++ b/src/__tests__/main/ipc/handlers/feedback.test.ts
@@ -161,7 +161,7 @@ describe('feedback IPC handlers', () => {
 			expect(result).toEqual({ success: true });
 			expect(mockProcessManager.write).toHaveBeenCalledWith(
 				'session-1',
-				expect.stringContaining('Great app!')
+				'Please file this feedback on GitHub: Great app!\n'
 			);
 		});
 
@@ -169,7 +169,7 @@ describe('feedback IPC handlers', () => {
 			await callSubmit({ sessionId: 'session-1', feedbackText: 'Fix the bug please' });
 
 			const writtenPrompt: string = mockProcessManager.write.mock.calls[0][1];
-			expect(writtenPrompt).toContain('Fix the bug please');
+			expect(writtenPrompt).toBe('Please file this feedback on GitHub: Fix the bug please\n');
 		});
 
 		it('returns failure when process manager is unavailable', async () => {
@@ -243,6 +243,30 @@ describe('feedback IPC handlers', () => {
 
 			expect(result).toEqual({ success: false, error: expect.any(String) });
 			expect(mockProcessManager.write).not.toHaveBeenCalled();
+		});
+
+		it('returns failure and does not write when sessionId is whitespace only', async () => {
+			const result = await handlers.get('feedback:submit')!(null, {
+				sessionId: '  ',
+				feedbackText: 'Some feedback',
+			});
+
+			expect(result).toEqual({ success: false, error: expect.any(String) });
+			expect(mockProcessManager.write).not.toHaveBeenCalled();
+		});
+
+		it('accepts feedbackText of exactly 5000 characters', async () => {
+			const feedbackText = 'a'.repeat(5000);
+			const result = await handlers.get('feedback:submit')!(null, {
+				sessionId: 'session-1',
+				feedbackText,
+			});
+
+			expect(result).toEqual({ success: true });
+			expect(mockProcessManager.write).toHaveBeenCalledWith(
+				'session-1',
+				`Please file this feedback on GitHub: ${'a'.repeat(5000)}\n`
+			);
 		});
 	});
 });

--- a/src/__tests__/main/ipc/handlers/feedback.test.ts
+++ b/src/__tests__/main/ipc/handlers/feedback.test.ts
@@ -195,5 +195,54 @@ describe('feedback IPC handlers', () => {
 
 			expect(result).toEqual({ success: false, error: expect.any(String) });
 		});
+
+		it('returns failure and does not write when sessionId is empty', async () => {
+			const result = await handlers.get('feedback:submit')!(null, {
+				sessionId: '',
+				feedbackText: 'Some feedback',
+			});
+
+			expect(result).toEqual({ success: false, error: expect.any(String) });
+			expect(mockProcessManager.write).not.toHaveBeenCalled();
+		});
+
+		it('returns failure and does not write when sessionId is missing', async () => {
+			const result = await handlers.get('feedback:submit')!(null, {
+				feedbackText: 'Some feedback',
+			});
+
+			expect(result).toEqual({ success: false, error: expect.any(String) });
+			expect(mockProcessManager.write).not.toHaveBeenCalled();
+		});
+
+		it('returns failure and does not write when feedbackText is empty', async () => {
+			const result = await handlers.get('feedback:submit')!(null, {
+				sessionId: 'session-1',
+				feedbackText: '',
+			});
+
+			expect(result).toEqual({ success: false, error: expect.any(String) });
+			expect(mockProcessManager.write).not.toHaveBeenCalled();
+		});
+
+		it('returns failure and does not write when feedbackText is whitespace only', async () => {
+			const result = await handlers.get('feedback:submit')!(null, {
+				sessionId: 'session-1',
+				feedbackText: '   ',
+			});
+
+			expect(result).toEqual({ success: false, error: expect.any(String) });
+			expect(mockProcessManager.write).not.toHaveBeenCalled();
+		});
+
+		it('returns failure and does not write when feedbackText exceeds 5000 characters', async () => {
+			const result = await handlers.get('feedback:submit')!(null, {
+				sessionId: 'session-1',
+				feedbackText: 'a'.repeat(5001),
+			});
+
+			expect(result).toEqual({ success: false, error: expect.any(String) });
+			expect(mockProcessManager.write).not.toHaveBeenCalled();
+		});
 	});
 });

--- a/src/__tests__/main/ipc/handlers/feedback.test.ts
+++ b/src/__tests__/main/ipc/handlers/feedback.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Tests for the Feedback IPC handlers
+ *
+ * These tests verify:
+ * - GitHub CLI auth checking (installed/authenticated states)
+ * - Caching behavior for gh auth status
+ * - Feedback submission via process manager write()
+ * - Error cases: process manager unavailable, write() failure
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ipcMain } from 'electron';
+import { registerFeedbackHandlers } from '../../../../main/ipc/handlers/feedback';
+
+// Mock electron's ipcMain
+vi.mock('electron', () => ({
+	ipcMain: {
+		handle: vi.fn(),
+		removeHandler: vi.fn(),
+	},
+}));
+
+// Mock cliDetection utilities
+const mockIsGhInstalled = vi.fn();
+const mockGetExpandedEnv = vi.fn().mockReturnValue({});
+const mockGetCachedGhStatus = vi.fn().mockReturnValue(null);
+const mockSetCachedGhStatus = vi.fn();
+
+vi.mock('../../../../main/utils/cliDetection', () => ({
+	isGhInstalled: (...args: any[]) => mockIsGhInstalled(...args),
+	getExpandedEnv: (...args: any[]) => mockGetExpandedEnv(...args),
+	getCachedGhStatus: (...args: any[]) => mockGetCachedGhStatus(...args),
+	setCachedGhStatus: (...args: any[]) => mockSetCachedGhStatus(...args),
+}));
+
+// Mock execFileNoThrow
+const mockExecFileNoThrow = vi.fn();
+
+vi.mock('../../../../main/utils/execFile', () => ({
+	execFileNoThrow: (...args: any[]) => mockExecFileNoThrow(...args),
+}));
+
+// Mock logger
+vi.mock('../../../../main/utils/logger', () => ({
+	logger: {
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+		debug: vi.fn(),
+	},
+}));
+
+// Mock prompts
+vi.mock('../../../../../prompts', () => ({
+	feedbackPrompt: 'Please file this feedback on GitHub: {{FEEDBACK}}',
+}));
+
+describe('feedback IPC handlers', () => {
+	let handlers: Map<string, Function>;
+	let mockProcessManager: any;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+
+		mockGetCachedGhStatus.mockReturnValue(null);
+		mockGetExpandedEnv.mockReturnValue({});
+
+		mockProcessManager = {
+			write: vi.fn().mockReturnValue(true),
+		};
+
+		// Capture registered handlers
+		handlers = new Map();
+		vi.mocked(ipcMain.handle).mockImplementation((channel, handler) => {
+			handlers.set(channel, handler as Function);
+		});
+
+		registerFeedbackHandlers({
+			getProcessManager: () => mockProcessManager,
+		});
+	});
+
+	describe('registration', () => {
+		it('should register all feedback handlers', () => {
+			expect(handlers.has('feedback:check-gh-auth')).toBe(true);
+			expect(handlers.has('feedback:submit')).toBe(true);
+		});
+	});
+
+	describe('feedback:check-gh-auth', () => {
+		const callCheckAuth = () => handlers.get('feedback:check-gh-auth')!(null);
+
+		it('returns authenticated: true when gh is installed and authenticated', async () => {
+			mockIsGhInstalled.mockResolvedValue(true);
+			mockExecFileNoThrow.mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' });
+
+			const result = await callCheckAuth();
+
+			expect(result).toEqual({ authenticated: true });
+			expect(mockSetCachedGhStatus).toHaveBeenCalledWith(true, true);
+		});
+
+		it('returns authenticated: false with message when gh is not installed', async () => {
+			mockIsGhInstalled.mockResolvedValue(false);
+
+			const result = await callCheckAuth();
+
+			expect(result.authenticated).toBe(false);
+			expect(result.message).toContain('not installed');
+			expect(mockSetCachedGhStatus).toHaveBeenCalledWith(false, false);
+		});
+
+		it('returns authenticated: false with message when gh auth check fails', async () => {
+			mockIsGhInstalled.mockResolvedValue(true);
+			mockExecFileNoThrow.mockResolvedValue({ exitCode: 1, stdout: '', stderr: 'not logged in' });
+
+			const result = await callCheckAuth();
+
+			expect(result.authenticated).toBe(false);
+			expect(result.message).toContain('not authenticated');
+			expect(mockSetCachedGhStatus).toHaveBeenCalledWith(true, false);
+		});
+
+		it('returns cached result when cache is available (installed + authenticated)', async () => {
+			mockGetCachedGhStatus.mockReturnValue({ installed: true, authenticated: true });
+
+			const result = await callCheckAuth();
+
+			expect(result).toEqual({ authenticated: true });
+			expect(mockIsGhInstalled).not.toHaveBeenCalled();
+		});
+
+		it('returns cached not-installed result without calling isGhInstalled', async () => {
+			mockGetCachedGhStatus.mockReturnValue({ installed: false, authenticated: false });
+
+			const result = await callCheckAuth();
+
+			expect(result.authenticated).toBe(false);
+			expect(result.message).toContain('not installed');
+			expect(mockIsGhInstalled).not.toHaveBeenCalled();
+		});
+
+		it('returns cached not-authenticated result without calling isGhInstalled', async () => {
+			mockGetCachedGhStatus.mockReturnValue({ installed: true, authenticated: false });
+
+			const result = await callCheckAuth();
+
+			expect(result.authenticated).toBe(false);
+			expect(result.message).toContain('not authenticated');
+			expect(mockIsGhInstalled).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('feedback:submit', () => {
+		const callSubmit = (params: { sessionId: string; feedbackText: string }) =>
+			handlers.get('feedback:submit')!(null, params);
+
+		it('writes constructed prompt to session and returns success', async () => {
+			const result = await callSubmit({ sessionId: 'session-1', feedbackText: 'Great app!' });
+
+			expect(result).toEqual({ success: true });
+			expect(mockProcessManager.write).toHaveBeenCalledWith(
+				'session-1',
+				expect.stringContaining('Great app!')
+			);
+		});
+
+		it('includes feedback text in the constructed prompt', async () => {
+			await callSubmit({ sessionId: 'session-1', feedbackText: 'Fix the bug please' });
+
+			const writtenPrompt: string = mockProcessManager.write.mock.calls[0][1];
+			expect(writtenPrompt).toContain('Fix the bug please');
+		});
+
+		it('returns failure when process manager is unavailable', async () => {
+			registerFeedbackHandlers({ getProcessManager: () => null });
+			const newHandlers = new Map<string, Function>();
+			vi.mocked(ipcMain.handle).mockImplementation((channel, handler) => {
+				newHandlers.set(channel, handler as Function);
+			});
+			// Re-register with null process manager
+			handlers = newHandlers;
+			registerFeedbackHandlers({ getProcessManager: () => null });
+
+			const result = await handlers.get('feedback:submit')!(null, {
+				sessionId: 'session-1',
+				feedbackText: 'test',
+			});
+
+			expect(result).toEqual({ success: false, error: expect.any(String) });
+		});
+
+		it('returns failure when write() returns false (agent exited)', async () => {
+			mockProcessManager.write.mockReturnValue(false);
+
+			const result = await callSubmit({ sessionId: 'dead-session', feedbackText: 'test' });
+
+			expect(result).toEqual({ success: false, error: expect.any(String) });
+		});
+	});
+});

--- a/src/__tests__/main/ipc/handlers/feedback.test.ts
+++ b/src/__tests__/main/ipc/handlers/feedback.test.ts
@@ -51,7 +51,7 @@ vi.mock('../../../../main/utils/logger', () => ({
 }));
 
 // Mock prompts
-vi.mock('../../../../../prompts', () => ({
+vi.mock('../../../../prompts', () => ({
 	feedbackPrompt: 'Please file this feedback on GitHub: {{FEEDBACK}}',
 }));
 
@@ -173,12 +173,10 @@ describe('feedback IPC handlers', () => {
 		});
 
 		it('returns failure when process manager is unavailable', async () => {
-			registerFeedbackHandlers({ getProcessManager: () => null });
 			const newHandlers = new Map<string, Function>();
 			vi.mocked(ipcMain.handle).mockImplementation((channel, handler) => {
 				newHandlers.set(channel, handler as Function);
 			});
-			// Re-register with null process manager
 			handlers = newHandlers;
 			registerFeedbackHandlers({ getProcessManager: () => null });
 

--- a/src/__tests__/renderer/components/AboutModal.test.tsx
+++ b/src/__tests__/renderer/components/AboutModal.test.tsx
@@ -62,6 +62,22 @@ vi.mock('lucide-react', () => ({
 			📖
 		</span>
 	),
+	MessageSquarePlus: ({
+		className,
+		style,
+	}: {
+		className?: string;
+		style?: React.CSSProperties;
+	}) => (
+		<span data-testid="message-square-plus-icon" className={className} style={style}>
+			💬
+		</span>
+	),
+	ArrowLeft: ({ className, style }: { className?: string; style?: React.CSSProperties }) => (
+		<span data-testid="arrow-left-icon" className={className} style={style}>
+			←
+		</span>
+	),
 }));
 
 // Mock the avatar import

--- a/src/main/ipc/handlers/feedback.ts
+++ b/src/main/ipc/handlers/feedback.ts
@@ -25,9 +25,7 @@ import type { ProcessManager } from '../../process-manager';
 
 const LOG_CONTEXT = '[Feedback]';
 
-const handlerOpts = (
-	operation: string
-): Pick<CreateHandlerOptions, 'context' | 'operation'> => ({
+const handlerOpts = (operation: string): Pick<CreateHandlerOptions, 'context' | 'operation'> => ({
 	context: LOG_CONTEXT,
 	operation,
 });

--- a/src/main/ipc/handlers/feedback.ts
+++ b/src/main/ipc/handlers/feedback.ts
@@ -99,8 +99,17 @@ export function registerFeedbackHandlers(deps: FeedbackHandlerDependencies): voi
 		'feedback:submit',
 		withIpcErrorLogging(
 			handlerOpts('submit'),
-			async (params: { sessionId: string; feedbackText: string }) => {
-				const { sessionId, feedbackText } = params;
+			async (params: { sessionId?: unknown; feedbackText?: unknown }) => {
+				const sessionId = typeof params?.sessionId === 'string' ? params.sessionId.trim() : '';
+				const feedbackText =
+					typeof params?.feedbackText === 'string' ? params.feedbackText.trim() : '';
+
+				if (!sessionId) {
+					return { success: false, error: 'Invalid session id' };
+				}
+				if (!feedbackText || feedbackText.length > 5000) {
+					return { success: false, error: 'Feedback must be between 1 and 5,000 characters' };
+				}
 
 				const processManager = getProcessManager();
 				if (!processManager) {

--- a/src/main/ipc/handlers/feedback.ts
+++ b/src/main/ipc/handlers/feedback.ts
@@ -1,0 +1,126 @@
+/**
+ * Feedback IPC Handlers
+ *
+ * This module provides IPC handlers for the Send Feedback feature.
+ * It checks GitHub CLI authentication and submits user feedback
+ * by sending a structured prompt to the selected agent.
+ *
+ * Usage:
+ * - window.maestro.feedback.checkGhAuth()
+ * - window.maestro.feedback.submit(sessionId, feedbackText)
+ */
+
+import { ipcMain } from 'electron';
+import { logger } from '../../utils/logger';
+import { withIpcErrorLogging, CreateHandlerOptions } from '../../utils/ipcHandler';
+import {
+	isGhInstalled,
+	getExpandedEnv,
+	getCachedGhStatus,
+	setCachedGhStatus,
+} from '../../utils/cliDetection';
+import { execFileNoThrow } from '../../utils/execFile';
+import { feedbackPrompt } from '../../../prompts';
+import type { ProcessManager } from '../../process-manager';
+
+const LOG_CONTEXT = '[Feedback]';
+
+const handlerOpts = (
+	operation: string
+): Pick<CreateHandlerOptions, 'context' | 'operation'> => ({
+	context: LOG_CONTEXT,
+	operation,
+});
+
+/**
+ * Dependencies required for feedback handler registration
+ */
+export interface FeedbackHandlerDependencies {
+	getProcessManager: () => ProcessManager | null;
+}
+
+/**
+ * Register all Feedback-related IPC handlers.
+ *
+ * - feedback:check-gh-auth: checks if gh CLI is installed and authenticated
+ * - feedback:submit: sends feedback prompt to the selected agent session
+ */
+export function registerFeedbackHandlers(deps: FeedbackHandlerDependencies): void {
+	const { getProcessManager } = deps;
+
+	// Check if GitHub CLI is installed and authenticated
+	ipcMain.handle(
+		'feedback:check-gh-auth',
+		withIpcErrorLogging(handlerOpts('check-gh-auth'), async () => {
+			// Check cache first (60-second TTL is managed by cliDetection)
+			const cached = getCachedGhStatus();
+			if (cached !== null) {
+				logger.debug('Using cached gh auth status', LOG_CONTEXT, cached);
+				if (!cached.installed) {
+					return {
+						authenticated: false,
+						message: 'GitHub CLI (gh) is not installed. Install it from https://cli.github.com',
+					};
+				}
+				if (!cached.authenticated) {
+					return {
+						authenticated: false,
+						message: 'GitHub CLI is not authenticated. Run "gh auth login" in your terminal.',
+					};
+				}
+				return { authenticated: true };
+			}
+
+			const installed = await isGhInstalled();
+			if (!installed) {
+				setCachedGhStatus(false, false);
+				return {
+					authenticated: false,
+					message: 'GitHub CLI (gh) is not installed. Install it from https://cli.github.com',
+				};
+			}
+
+			const result = await execFileNoThrow('gh', ['auth', 'status'], undefined, getExpandedEnv());
+			const authenticated = result.exitCode === 0;
+			setCachedGhStatus(true, authenticated);
+
+			if (!authenticated) {
+				logger.debug('gh auth check failed', LOG_CONTEXT, { stderr: result.stderr });
+				return {
+					authenticated: false,
+					message: 'GitHub CLI is not authenticated. Run "gh auth login" in your terminal.',
+				};
+			}
+
+			return { authenticated: true };
+		})
+	);
+
+	// Submit feedback by writing the prompt to the selected agent session
+	ipcMain.handle(
+		'feedback:submit',
+		withIpcErrorLogging(
+			handlerOpts('submit'),
+			async (params: { sessionId: string; feedbackText: string }) => {
+				const { sessionId, feedbackText } = params;
+
+				const processManager = getProcessManager();
+				if (!processManager) {
+					logger.error('Process manager not available for feedback submit', LOG_CONTEXT);
+					return { success: false, error: 'Agent process not available' };
+				}
+
+				const constructedPrompt = feedbackPrompt.replace('{{FEEDBACK}}', feedbackText);
+				const wrote = processManager.write(sessionId, constructedPrompt + '\n');
+
+				if (!wrote) {
+					logger.error('write() returned false for feedback session', LOG_CONTEXT, { sessionId });
+					return { success: false, error: 'Agent process not available' };
+				}
+
+				logger.info('Feedback prompt sent to agent session', LOG_CONTEXT, { sessionId });
+				return { success: true };
+			}
+		)
+	);
+}

--- a/src/main/ipc/handlers/index.ts
+++ b/src/main/ipc/handlers/index.ts
@@ -53,6 +53,7 @@ import { registerAgentErrorHandlers } from './agent-error';
 import { registerTabNamingHandlers, TabNamingHandlerDependencies } from './tabNaming';
 import { registerDirectorNotesHandlers, DirectorNotesHandlerDependencies } from './director-notes';
 import { registerWakatimeHandlers } from './wakatime';
+import { registerFeedbackHandlers, FeedbackHandlerDependencies } from './feedback';
 import { AgentDetector } from '../../agents';
 import { ProcessManager } from '../../process-manager';
 import { WebServer } from '../../web-server';
@@ -97,6 +98,8 @@ export type { TabNamingHandlerDependencies };
 export { registerDirectorNotesHandlers };
 export type { DirectorNotesHandlerDependencies };
 export { registerWakatimeHandlers };
+export { registerFeedbackHandlers };
+export type { FeedbackHandlerDependencies };
 export type { AgentsHandlerDependencies };
 export type { ProcessHandlerDependencies };
 export type { PersistenceHandlerDependencies };
@@ -281,6 +284,10 @@ export function registerAllHandlers(deps: HandlerDependencies): void {
 		getProcessManager: deps.getProcessManager,
 		getAgentDetector: deps.getAgentDetector,
 		agentConfigsStore: deps.agentConfigsStore,
+	});
+	// Register feedback handlers (GitHub issue creation via agent)
+	registerFeedbackHandlers({
+		getProcessManager: deps.getProcessManager,
 	});
 	// Setup logger event forwarding to renderer
 	setupLoggerEventForwarding(deps.getMainWindow);

--- a/src/main/preload/feedback.ts
+++ b/src/main/preload/feedback.ts
@@ -1,0 +1,37 @@
+/**
+ * Preload API for the Send Feedback feature
+ *
+ * Provides the window.maestro.feedback namespace for:
+ * - Checking GitHub CLI authentication status
+ * - Submitting user feedback via the selected agent session
+ */
+
+import { ipcRenderer } from 'electron';
+
+/**
+ * Creates the feedback API object for preload exposure
+ */
+export function createFeedbackApi() {
+	return {
+		/**
+		 * Check if GitHub CLI is installed and authenticated.
+		 * Result is cached for 60 seconds.
+		 */
+		checkGhAuth: (): Promise<{ authenticated: boolean; message?: string }> =>
+			ipcRenderer.invoke('feedback:check-gh-auth'),
+
+		/**
+		 * Submit feedback by sending a structured prompt to the selected agent session.
+		 */
+		submit: (
+			sessionId: string,
+			feedbackText: string
+		): Promise<{ success: boolean; error?: string }> =>
+			ipcRenderer.invoke('feedback:submit', { sessionId, feedbackText }),
+	};
+}
+
+/**
+ * TypeScript type for the feedback API
+ */
+export type FeedbackApi = ReturnType<typeof createFeedbackApi>;

--- a/src/main/preload/index.ts
+++ b/src/main/preload/index.ts
@@ -50,6 +50,7 @@ import { createSymphonyApi } from './symphony';
 import { createTabNamingApi } from './tabNaming';
 import { createDirectorNotesApi } from './directorNotes';
 import { createWakatimeApi } from './wakatime';
+import { createFeedbackApi } from './feedback';
 
 // Expose protected methods that allow the renderer process to use
 // the ipcRenderer without exposing the entire object
@@ -191,6 +192,9 @@ contextBridge.exposeInMainWorld('maestro', {
 
 	// WakaTime API (CLI check, API key validation)
 	wakatime: createWakatimeApi(),
+
+	// Feedback API (Send Feedback feature)
+	feedback: createFeedbackApi(),
 });
 
 // Re-export factory functions for external consumers (e.g., tests)
@@ -264,6 +268,8 @@ export {
 	createDirectorNotesApi,
 	// WakaTime
 	createWakatimeApi,
+	// Feedback
+	createFeedbackApi,
 };
 
 // Re-export types for TypeScript consumers
@@ -472,3 +478,7 @@ export type {
 	// From wakatime
 	WakatimeApi,
 } from './wakatime';
+export type {
+	// From feedback
+	FeedbackApi,
+} from './feedback';

--- a/src/prompts/feedback.md
+++ b/src/prompts/feedback.md
@@ -1,8 +1,8 @@
 The user has submitted the following feedback about Maestro:
 
 ---
-{{FEEDBACK}}
----
+
+## {{FEEDBACK}}
 
 Your job is to turn this raw feedback into a well-structured GitHub issue on RunMaestro/Maestro. Do not ask for clarification — work with what is provided.
 
@@ -21,12 +21,15 @@ Your job is to turn this raw feedback into a well-structured GitHub issue on Run
      - **Additional Context** — anything else relevant
 
 3. **Ensure the label exists** — run this command first:
+
    ```
    gh label create "Maestro-feedback" --repo RunMaestro/Maestro --description "User feedback submitted via Maestro" --color "0E8A16"
    ```
+
    If the label already exists, this command will fail — that's fine, continue.
 
 4. **Create the issue**:
+
    ```
    gh issue create --repo RunMaestro/Maestro --label "Maestro-feedback" --title "TITLE" --body "BODY"
    ```

--- a/src/prompts/feedback.md
+++ b/src/prompts/feedback.md
@@ -1,0 +1,34 @@
+The user has submitted the following feedback about Maestro:
+
+---
+{{FEEDBACK}}
+---
+
+Your job is to turn this raw feedback into a well-structured GitHub issue on RunMaestro/Maestro. Do not ask for clarification — work with what is provided.
+
+## Steps
+
+1. **Classify** the feedback into one of these types: Bug, Feature, Improvement, or Feedback.
+
+2. **Draft the issue**:
+   - Title: prefix with the type, e.g. `Bug: ...`, `Feature: ...`, `Improvement: ...`, `Feedback: ...`
+   - Body: use these sections as appropriate:
+     - **Description** — concise summary of the issue or request
+     - **Steps to Reproduce** — (bugs only) numbered steps to trigger the problem
+     - **Expected Behavior** — what should happen
+     - **Current Behavior** — what actually happens (bugs only)
+     - **Proposed Solution** — (features/improvements) suggested approach
+     - **Additional Context** — anything else relevant
+
+3. **Ensure the label exists** — run this command first:
+   ```
+   gh label create "Maestro-feedback" --repo RunMaestro/Maestro --description "User feedback submitted via Maestro" --color "0E8A16"
+   ```
+   If the label already exists, this command will fail — that's fine, continue.
+
+4. **Create the issue**:
+   ```
+   gh issue create --repo RunMaestro/Maestro --label "Maestro-feedback" --title "TITLE" --body "BODY"
+   ```
+
+5. **Output the issue URL** when done so the user can follow it.

--- a/src/prompts/feedback.md
+++ b/src/prompts/feedback.md
@@ -22,7 +22,7 @@ Your job is to turn this raw feedback into a well-structured GitHub issue on Run
 
 3. **Ensure the label exists** — run this command first:
 
-   ```
+   ```bash
    gh label create "Maestro-feedback" --repo RunMaestro/Maestro --description "User feedback submitted via Maestro" --color "0E8A16"
    ```
 
@@ -30,7 +30,7 @@ Your job is to turn this raw feedback into a well-structured GitHub issue on Run
 
 4. **Create the issue**:
 
-   ```
+   ```bash
    gh issue create --repo RunMaestro/Maestro --label "Maestro-feedback" --title "TITLE" --body "BODY"
    ```
 

--- a/src/prompts/index.ts
+++ b/src/prompts/index.ts
@@ -48,4 +48,7 @@ export {
 
 	// Director's Notes
 	directorNotesPrompt,
+
+	// Feedback
+	feedbackPrompt,
 } from '../generated/prompts';

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -228,6 +228,9 @@ function MaestroConsoleInner() {
 		// About Modal
 		aboutModalOpen,
 		setAboutModalOpen,
+		// Feedback Modal
+		feedbackModalOpen,
+		setFeedbackModalOpen,
 		// Update Check Modal
 		setUpdateCheckModalOpen,
 		// standingOvationData, firstRunCelebrationData — now self-sourced in AppOverlays (Tier 1A)
@@ -908,6 +911,8 @@ function MaestroConsoleInner() {
 		handleOpenAboutModal,
 		handleOpenBatchRunner,
 		handleOpenMarketplace,
+		handleOpenFeedbackModal,
+		handleCloseFeedbackModal,
 		handleEditAgent,
 		handleOpenCreatePRSession,
 		handleStartTour,
@@ -2592,6 +2597,8 @@ function MaestroConsoleInner() {
 					hasNoAgents={hasNoAgents}
 					keyboardMasteryStats={keyboardMasteryStats}
 					onCloseAboutModal={handleCloseAboutModal}
+					feedbackModalOpen={feedbackModalOpen}
+					onCloseFeedbackModal={handleCloseFeedbackModal}
 					autoRunStats={autoRunStats}
 					usageStats={usageStats}
 					handsOnTimeMs={totalActiveTimeMs}
@@ -2675,6 +2682,7 @@ function MaestroConsoleInner() {
 					setSettingsTab={setSettingsTab}
 					setShortcutsHelpOpen={setShortcutsHelpOpen}
 					setAboutModalOpen={setAboutModalOpen}
+					setFeedbackModalOpen={setFeedbackModalOpen}
 					setLogViewerOpen={setLogViewerOpen}
 					setProcessMonitorOpen={setProcessMonitorOpen}
 					setUsageDashboardOpen={setUsageDashboardOpen}

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -911,7 +911,6 @@ function MaestroConsoleInner() {
 		handleOpenAboutModal,
 		handleOpenBatchRunner,
 		handleOpenMarketplace,
-		handleOpenFeedbackModal,
 		handleCloseFeedbackModal,
 		handleEditAgent,
 		handleOpenCreatePRSession,

--- a/src/renderer/components/AboutModal.tsx
+++ b/src/renderer/components/AboutModal.tsx
@@ -13,7 +13,13 @@ import {
 	MessageSquarePlus,
 	ArrowLeft,
 } from 'lucide-react';
-import type { Theme, AutoRunStats, MaestroUsageStats, LeaderboardRegistration, Session } from '../types';
+import type {
+	Theme,
+	AutoRunStats,
+	MaestroUsageStats,
+	LeaderboardRegistration,
+	Session,
+} from '../types';
 import { FeedbackView } from './FeedbackView';
 import type { GlobalAgentStats } from '../../shared/types';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
@@ -236,292 +242,294 @@ export function AboutModal({
 					}}
 				/>
 			) : (
-			<div className="space-y-4">
-				{/* Logo and Title */}
-				<div className="flex items-center gap-4">
-					<Wand2 className="w-12 h-12" style={{ color: theme.colors.accent }} />
-					<div>
-						<div className="flex items-baseline gap-2">
-							<h1
-								className="text-2xl font-bold tracking-widest"
-								style={{ color: theme.colors.textMain }}
-							>
-								MAESTRO
-							</h1>
-							<span className="text-xs font-mono" style={{ color: theme.colors.textDim }}>
-								v{__APP_VERSION__}
-								{__COMMIT_HASH__ && ` (${__COMMIT_HASH__})`}
-							</span>
-						</div>
-						<p className="text-xs opacity-70" style={{ color: theme.colors.textDim }}>
-							Agent Orchestration Command Center
-						</p>
-					</div>
-				</div>
-
-				{/* Achievements Section */}
-				<AchievementCard
-					theme={theme}
-					autoRunStats={autoRunStats}
-					globalStats={globalStats}
-					usageStats={usageStats}
-					handsOnTimeMs={handsOnTimeMs}
-					leaderboardRegistration={leaderboardRegistration}
-					onEscapeWithBadgeOpen={(handler) => {
-						badgeEscapeHandlerRef.current = handler;
-					}}
-				/>
-
-				{/* Global Usage Stats - show loading or stats from all Claude projects */}
-				<div
-					className="p-4 rounded border"
-					style={{ borderColor: theme.colors.border, backgroundColor: theme.colors.bgActivity }}
-				>
-					<div className="flex items-center gap-2 mb-3">
-						<BarChart3 className="w-4 h-4" style={{ color: theme.colors.accent }} />
-						<span className="text-sm font-bold" style={{ color: theme.colors.textMain }}>
-							Global Statistics
-						</span>
-						{!isStatsComplete && (
-							<Loader2 className="w-3 h-3 animate-spin" style={{ color: theme.colors.textDim }} />
-						)}
-					</div>
-					{loading ? (
-						<div className="flex items-center justify-center py-4 gap-2">
-							<Loader2 className="w-4 h-4 animate-spin" style={{ color: theme.colors.textDim }} />
-							<span className="text-xs" style={{ color: theme.colors.textDim }}>
-								Loading stats...
-							</span>
-						</div>
-					) : globalStats ? (
-						<div className="space-y-3 text-xs">
-							{/* Totals Grid */}
-							<div className="grid grid-cols-2 gap-3">
-								{/* Sessions & Messages */}
-								<div className="flex justify-between">
-									<span style={{ color: theme.colors.textDim }}>Sessions</span>
-									<span className="font-mono font-bold" style={{ color: theme.colors.textMain }}>
-										{formatTokensCompact(globalStats.totalSessions)}
-									</span>
-								</div>
-								<div className="flex justify-between">
-									<span style={{ color: theme.colors.textDim }}>Messages</span>
-									<span className="font-mono font-bold" style={{ color: theme.colors.textMain }}>
-										{formatTokensCompact(globalStats.totalMessages)}
-									</span>
-								</div>
-
-								{/* Tokens */}
-								<div className="flex justify-between">
-									<span style={{ color: theme.colors.textDim }}>Input Tokens</span>
-									<span className="font-mono font-bold" style={{ color: theme.colors.textMain }}>
-										{formatTokensCompact(globalStats.totalInputTokens)}
-									</span>
-								</div>
-								<div className="flex justify-between">
-									<span style={{ color: theme.colors.textDim }}>Output Tokens</span>
-									<span className="font-mono font-bold" style={{ color: theme.colors.textMain }}>
-										{formatTokensCompact(globalStats.totalOutputTokens)}
-									</span>
-								</div>
-
-								{/* Cache Tokens (if any) */}
-								{(globalStats.totalCacheReadTokens > 0 ||
-									globalStats.totalCacheCreationTokens > 0) && (
-									<>
-										<div className="flex justify-between">
-											<span style={{ color: theme.colors.textDim }}>Cache Read</span>
-											<span
-												className="font-mono font-bold"
-												style={{ color: theme.colors.textMain }}
-											>
-												{formatTokensCompact(globalStats.totalCacheReadTokens)}
-											</span>
-										</div>
-										<div className="flex justify-between">
-											<span style={{ color: theme.colors.textDim }}>Cache Creation</span>
-											<span
-												className="font-mono font-bold"
-												style={{ color: theme.colors.textMain }}
-											>
-												{formatTokensCompact(globalStats.totalCacheCreationTokens)}
-											</span>
-										</div>
-									</>
-								)}
-
-								{/* Active Time & Total Cost - show cost only if we have cost data */}
-								{(handsOnTimeMs > 0 || globalStats.hasCostData) && (
-									<div
-										className="flex justify-between col-span-2 pt-2 border-t"
-										style={{ borderColor: theme.colors.border }}
-									>
-										{handsOnTimeMs > 0 && (
-											<span style={{ color: theme.colors.textDim }}>
-												Hands-on Time: {formatDuration(handsOnTimeMs)}
-											</span>
-										)}
-										{!handsOnTimeMs && globalStats.hasCostData && (
-											<span style={{ color: theme.colors.textDim }}>Total Cost</span>
-										)}
-										{globalStats.hasCostData && (
-											<span
-												className={`font-mono font-bold ${!isStatsComplete ? 'animate-pulse' : ''}`}
-												style={{ color: theme.colors.success }}
-											>
-												$
-												{(globalStats.totalCostUsd ?? 0).toLocaleString('en-US', {
-													minimumFractionDigits: 2,
-													maximumFractionDigits: 2,
-												})}
-											</span>
-										)}
-									</div>
-								)}
-							</div>
-						</div>
-					) : (
-						<div className="text-xs text-center py-2" style={{ color: theme.colors.textDim }}>
-							No sessions found
-						</div>
-					)}
-				</div>
-
-				{/* Action Links */}
-				<div className="flex gap-2">
-					{/* Project Link */}
-					<button
-						onClick={() =>
-							window.maestro.shell.openExternal('https://github.com/RunMaestro/Maestro')
-						}
-						className="flex-1 flex items-center justify-between p-3 rounded border hover:bg-white/5 transition-colors"
-						style={{ borderColor: theme.colors.border }}
-					>
-						<div className="flex items-center gap-2">
-							<FileCode className="w-4 h-4" style={{ color: theme.colors.accent }} />
-							<span className="text-sm font-medium" style={{ color: theme.colors.textMain }}>
-								GitHub
-							</span>
-						</div>
-						<ExternalLink className="w-4 h-4" style={{ color: theme.colors.textDim }} />
-					</button>
-
-					{/* Leaderboard Registration */}
-					{onOpenLeaderboardRegistration && (
-						<button
-							onClick={onOpenLeaderboardRegistration}
-							className="flex-1 flex items-center justify-between p-3 rounded border hover:bg-white/5 transition-colors"
-							style={{
-								borderColor: isLeaderboardRegistered ? theme.colors.success : theme.colors.accent,
-								backgroundColor: isLeaderboardRegistered ? `${theme.colors.success}10` : undefined,
-							}}
-						>
-							<div className="flex items-center gap-2">
-								<Trophy
-									className="w-4 h-4"
-									style={{ color: isLeaderboardRegistered ? theme.colors.success : '#FFD700' }}
-								/>
-								<span className="text-sm font-medium" style={{ color: theme.colors.textMain }}>
-									{isLeaderboardRegistered ? 'Leaderboard' : 'Join Leaderboard'}
+				<div className="space-y-4">
+					{/* Logo and Title */}
+					<div className="flex items-center gap-4">
+						<Wand2 className="w-12 h-12" style={{ color: theme.colors.accent }} />
+						<div>
+							<div className="flex items-baseline gap-2">
+								<h1
+									className="text-2xl font-bold tracking-widest"
+									style={{ color: theme.colors.textMain }}
+								>
+									MAESTRO
+								</h1>
+								<span className="text-xs font-mono" style={{ color: theme.colors.textDim }}>
+									v{__APP_VERSION__}
+									{__COMMIT_HASH__ && ` (${__COMMIT_HASH__})`}
 								</span>
 							</div>
-							{isLeaderboardRegistered ? (
-								<Check className="w-4 h-4" style={{ color: theme.colors.success }} />
-							) : (
-								<ExternalLink className="w-4 h-4" style={{ color: theme.colors.textDim }} />
-							)}
-						</button>
-					)}
-				</div>
-
-				{/* Divider */}
-				<div className="border-t" style={{ borderColor: theme.colors.border }} />
-
-				{/* Creator Section - side by side layout */}
-				<div
-					className="flex items-center gap-4 p-3 rounded border"
-					style={{ borderColor: theme.colors.border, backgroundColor: theme.colors.bgActivity }}
-				>
-					{/* Left side - Creator info */}
-					<div className="flex items-center gap-3 flex-1">
-						<img
-							src={pedramAvatar}
-							alt="Pedram Amini"
-							className="w-12 h-12 rounded-full border-2"
-							style={{ borderColor: theme.colors.accent }}
-						/>
-						<div>
-							<div className="text-sm font-bold" style={{ color: theme.colors.textMain }}>
-								Pedram Amini
-							</div>
-							<div className="text-xs opacity-70 mb-1" style={{ color: theme.colors.textDim }}>
-								Founder, Hacker, Investor, Advisor
-							</div>
-							<div className="flex items-center gap-2 text-xs">
-								<button
-									onClick={() =>
-										window.maestro.shell.openExternal('https://github.com/pedramamini')
-									}
-									className="inline-flex items-center gap-1 hover:underline cursor-pointer"
-									style={{
-										color: theme.colors.accent,
-										background: 'none',
-										border: 'none',
-										padding: 0,
-									}}
-								>
-									GitHub
-								</button>
-								<span style={{ color: theme.colors.textDim }}>·</span>
-								<button
-									onClick={() =>
-										window.maestro.shell.openExternal('https://www.linkedin.com/in/pedramamini/')
-									}
-									className="inline-flex items-center gap-1 hover:underline cursor-pointer"
-									style={{
-										color: theme.colors.accent,
-										background: 'none',
-										border: 'none',
-										padding: 0,
-									}}
-								>
-									LinkedIn
-								</button>
-							</div>
+							<p className="text-xs opacity-70" style={{ color: theme.colors.textDim }}>
+								Agent Orchestration Command Center
+							</p>
 						</div>
 					</div>
 
-					{/* Vertical divider */}
-					<div className="h-14 w-px" style={{ backgroundColor: theme.colors.border }} />
+					{/* Achievements Section */}
+					<AchievementCard
+						theme={theme}
+						autoRunStats={autoRunStats}
+						globalStats={globalStats}
+						usageStats={usageStats}
+						handsOnTimeMs={handsOnTimeMs}
+						leaderboardRegistration={leaderboardRegistration}
+						onEscapeWithBadgeOpen={(handler) => {
+							badgeEscapeHandlerRef.current = handler;
+						}}
+					/>
 
-					{/* Right side - Made in Austin */}
-					<div className="flex flex-col items-center justify-center px-2">
-						<span className="text-xs mb-2" style={{ color: theme.colors.textDim }}>
-							Made in Austin, TX
-						</span>
-						{/* Texas Flag - Lone Star Flag */}
+					{/* Global Usage Stats - show loading or stats from all Claude projects */}
+					<div
+						className="p-4 rounded border"
+						style={{ borderColor: theme.colors.border, backgroundColor: theme.colors.bgActivity }}
+					>
+						<div className="flex items-center gap-2 mb-3">
+							<BarChart3 className="w-4 h-4" style={{ color: theme.colors.accent }} />
+							<span className="text-sm font-bold" style={{ color: theme.colors.textMain }}>
+								Global Statistics
+							</span>
+							{!isStatsComplete && (
+								<Loader2 className="w-3 h-3 animate-spin" style={{ color: theme.colors.textDim }} />
+							)}
+						</div>
+						{loading ? (
+							<div className="flex items-center justify-center py-4 gap-2">
+								<Loader2 className="w-4 h-4 animate-spin" style={{ color: theme.colors.textDim }} />
+								<span className="text-xs" style={{ color: theme.colors.textDim }}>
+									Loading stats...
+								</span>
+							</div>
+						) : globalStats ? (
+							<div className="space-y-3 text-xs">
+								{/* Totals Grid */}
+								<div className="grid grid-cols-2 gap-3">
+									{/* Sessions & Messages */}
+									<div className="flex justify-between">
+										<span style={{ color: theme.colors.textDim }}>Sessions</span>
+										<span className="font-mono font-bold" style={{ color: theme.colors.textMain }}>
+											{formatTokensCompact(globalStats.totalSessions)}
+										</span>
+									</div>
+									<div className="flex justify-between">
+										<span style={{ color: theme.colors.textDim }}>Messages</span>
+										<span className="font-mono font-bold" style={{ color: theme.colors.textMain }}>
+											{formatTokensCompact(globalStats.totalMessages)}
+										</span>
+									</div>
+
+									{/* Tokens */}
+									<div className="flex justify-between">
+										<span style={{ color: theme.colors.textDim }}>Input Tokens</span>
+										<span className="font-mono font-bold" style={{ color: theme.colors.textMain }}>
+											{formatTokensCompact(globalStats.totalInputTokens)}
+										</span>
+									</div>
+									<div className="flex justify-between">
+										<span style={{ color: theme.colors.textDim }}>Output Tokens</span>
+										<span className="font-mono font-bold" style={{ color: theme.colors.textMain }}>
+											{formatTokensCompact(globalStats.totalOutputTokens)}
+										</span>
+									</div>
+
+									{/* Cache Tokens (if any) */}
+									{(globalStats.totalCacheReadTokens > 0 ||
+										globalStats.totalCacheCreationTokens > 0) && (
+										<>
+											<div className="flex justify-between">
+												<span style={{ color: theme.colors.textDim }}>Cache Read</span>
+												<span
+													className="font-mono font-bold"
+													style={{ color: theme.colors.textMain }}
+												>
+													{formatTokensCompact(globalStats.totalCacheReadTokens)}
+												</span>
+											</div>
+											<div className="flex justify-between">
+												<span style={{ color: theme.colors.textDim }}>Cache Creation</span>
+												<span
+													className="font-mono font-bold"
+													style={{ color: theme.colors.textMain }}
+												>
+													{formatTokensCompact(globalStats.totalCacheCreationTokens)}
+												</span>
+											</div>
+										</>
+									)}
+
+									{/* Active Time & Total Cost - show cost only if we have cost data */}
+									{(handsOnTimeMs > 0 || globalStats.hasCostData) && (
+										<div
+											className="flex justify-between col-span-2 pt-2 border-t"
+											style={{ borderColor: theme.colors.border }}
+										>
+											{handsOnTimeMs > 0 && (
+												<span style={{ color: theme.colors.textDim }}>
+													Hands-on Time: {formatDuration(handsOnTimeMs)}
+												</span>
+											)}
+											{!handsOnTimeMs && globalStats.hasCostData && (
+												<span style={{ color: theme.colors.textDim }}>Total Cost</span>
+											)}
+											{globalStats.hasCostData && (
+												<span
+													className={`font-mono font-bold ${!isStatsComplete ? 'animate-pulse' : ''}`}
+													style={{ color: theme.colors.success }}
+												>
+													$
+													{(globalStats.totalCostUsd ?? 0).toLocaleString('en-US', {
+														minimumFractionDigits: 2,
+														maximumFractionDigits: 2,
+													})}
+												</span>
+											)}
+										</div>
+									)}
+								</div>
+							</div>
+						) : (
+							<div className="text-xs text-center py-2" style={{ color: theme.colors.textDim }}>
+								No sessions found
+							</div>
+						)}
+					</div>
+
+					{/* Action Links */}
+					<div className="flex gap-2">
+						{/* Project Link */}
 						<button
-							onClick={() => window.maestro.shell.openExternal('https://www.sanjacsaloon.com')}
-							className="hover:opacity-100 transition-opacity cursor-pointer"
-							style={{ background: 'none', border: 'none', padding: 0 }}
+							onClick={() =>
+								window.maestro.shell.openExternal('https://github.com/RunMaestro/Maestro')
+							}
+							className="flex-1 flex items-center justify-between p-3 rounded border hover:bg-white/5 transition-colors"
+							style={{ borderColor: theme.colors.border }}
 						>
-							<svg viewBox="0 0 150 100" className="w-10 h-7" style={{ opacity: 0.7 }}>
-								{/* Blue vertical stripe */}
-								<rect x="0" y="0" width="50" height="100" fill="#002868" />
-								{/* White horizontal stripe */}
-								<rect x="50" y="0" width="100" height="50" fill="#FFFFFF" />
-								{/* Red horizontal stripe */}
-								<rect x="50" y="50" width="100" height="50" fill="#BF0A30" />
-								{/* White five-pointed star */}
-								<polygon
-									points="25,15 29.5,30 45,30 32.5,40 37,55 25,45 13,55 17.5,40 5,30 20.5,30"
-									fill="#FFFFFF"
-								/>
-							</svg>
+							<div className="flex items-center gap-2">
+								<FileCode className="w-4 h-4" style={{ color: theme.colors.accent }} />
+								<span className="text-sm font-medium" style={{ color: theme.colors.textMain }}>
+									GitHub
+								</span>
+							</div>
+							<ExternalLink className="w-4 h-4" style={{ color: theme.colors.textDim }} />
 						</button>
+
+						{/* Leaderboard Registration */}
+						{onOpenLeaderboardRegistration && (
+							<button
+								onClick={onOpenLeaderboardRegistration}
+								className="flex-1 flex items-center justify-between p-3 rounded border hover:bg-white/5 transition-colors"
+								style={{
+									borderColor: isLeaderboardRegistered ? theme.colors.success : theme.colors.accent,
+									backgroundColor: isLeaderboardRegistered
+										? `${theme.colors.success}10`
+										: undefined,
+								}}
+							>
+								<div className="flex items-center gap-2">
+									<Trophy
+										className="w-4 h-4"
+										style={{ color: isLeaderboardRegistered ? theme.colors.success : '#FFD700' }}
+									/>
+									<span className="text-sm font-medium" style={{ color: theme.colors.textMain }}>
+										{isLeaderboardRegistered ? 'Leaderboard' : 'Join Leaderboard'}
+									</span>
+								</div>
+								{isLeaderboardRegistered ? (
+									<Check className="w-4 h-4" style={{ color: theme.colors.success }} />
+								) : (
+									<ExternalLink className="w-4 h-4" style={{ color: theme.colors.textDim }} />
+								)}
+							</button>
+						)}
+					</div>
+
+					{/* Divider */}
+					<div className="border-t" style={{ borderColor: theme.colors.border }} />
+
+					{/* Creator Section - side by side layout */}
+					<div
+						className="flex items-center gap-4 p-3 rounded border"
+						style={{ borderColor: theme.colors.border, backgroundColor: theme.colors.bgActivity }}
+					>
+						{/* Left side - Creator info */}
+						<div className="flex items-center gap-3 flex-1">
+							<img
+								src={pedramAvatar}
+								alt="Pedram Amini"
+								className="w-12 h-12 rounded-full border-2"
+								style={{ borderColor: theme.colors.accent }}
+							/>
+							<div>
+								<div className="text-sm font-bold" style={{ color: theme.colors.textMain }}>
+									Pedram Amini
+								</div>
+								<div className="text-xs opacity-70 mb-1" style={{ color: theme.colors.textDim }}>
+									Founder, Hacker, Investor, Advisor
+								</div>
+								<div className="flex items-center gap-2 text-xs">
+									<button
+										onClick={() =>
+											window.maestro.shell.openExternal('https://github.com/pedramamini')
+										}
+										className="inline-flex items-center gap-1 hover:underline cursor-pointer"
+										style={{
+											color: theme.colors.accent,
+											background: 'none',
+											border: 'none',
+											padding: 0,
+										}}
+									>
+										GitHub
+									</button>
+									<span style={{ color: theme.colors.textDim }}>·</span>
+									<button
+										onClick={() =>
+											window.maestro.shell.openExternal('https://www.linkedin.com/in/pedramamini/')
+										}
+										className="inline-flex items-center gap-1 hover:underline cursor-pointer"
+										style={{
+											color: theme.colors.accent,
+											background: 'none',
+											border: 'none',
+											padding: 0,
+										}}
+									>
+										LinkedIn
+									</button>
+								</div>
+							</div>
+						</div>
+
+						{/* Vertical divider */}
+						<div className="h-14 w-px" style={{ backgroundColor: theme.colors.border }} />
+
+						{/* Right side - Made in Austin */}
+						<div className="flex flex-col items-center justify-center px-2">
+							<span className="text-xs mb-2" style={{ color: theme.colors.textDim }}>
+								Made in Austin, TX
+							</span>
+							{/* Texas Flag - Lone Star Flag */}
+							<button
+								onClick={() => window.maestro.shell.openExternal('https://www.sanjacsaloon.com')}
+								className="hover:opacity-100 transition-opacity cursor-pointer"
+								style={{ background: 'none', border: 'none', padding: 0 }}
+							>
+								<svg viewBox="0 0 150 100" className="w-10 h-7" style={{ opacity: 0.7 }}>
+									{/* Blue vertical stripe */}
+									<rect x="0" y="0" width="50" height="100" fill="#002868" />
+									{/* White horizontal stripe */}
+									<rect x="50" y="0" width="100" height="50" fill="#FFFFFF" />
+									{/* Red horizontal stripe */}
+									<rect x="50" y="50" width="100" height="50" fill="#BF0A30" />
+									{/* White five-pointed star */}
+									<polygon
+										points="25,15 29.5,30 45,30 32.5,40 37,55 25,45 13,55 17.5,40 5,30 20.5,30"
+										fill="#FFFFFF"
+									/>
+								</svg>
+							</button>
+						</div>
 					</div>
 				</div>
-			</div>
 			)}
 		</Modal>
 	);

--- a/src/renderer/components/AboutModal.tsx
+++ b/src/renderer/components/AboutModal.tsx
@@ -10,8 +10,11 @@ import {
 	Globe,
 	Check,
 	BookOpen,
+	MessageSquarePlus,
+	ArrowLeft,
 } from 'lucide-react';
-import type { Theme, AutoRunStats, MaestroUsageStats, LeaderboardRegistration } from '../types';
+import type { Theme, AutoRunStats, MaestroUsageStats, LeaderboardRegistration, Session } from '../types';
+import { FeedbackView } from './FeedbackView';
 import type { GlobalAgentStats } from '../../shared/types';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
 import pedramAvatar from '../assets/pedram-avatar.png';
@@ -29,6 +32,8 @@ interface AboutModalProps {
 	onOpenLeaderboardRegistration?: () => void;
 	isLeaderboardRegistered?: boolean;
 	leaderboardRegistration?: LeaderboardRegistration | null;
+	sessions: Session[];
+	onSwitchToSession: (sessionId: string) => void;
 }
 
 export function AboutModal({
@@ -40,10 +45,13 @@ export function AboutModal({
 	onOpenLeaderboardRegistration,
 	isLeaderboardRegistered,
 	leaderboardRegistration,
+	sessions,
+	onSwitchToSession,
 }: AboutModalProps) {
 	const [globalStats, setGlobalStats] = useState<GlobalAgentStats | null>(null);
 	const [loading, setLoading] = useState(true);
 	const [isStatsComplete, setIsStatsComplete] = useState(false);
+	const [view, setView] = useState<'about' | 'feedback'>('about');
 	const badgeEscapeHandlerRef = useRef<(() => boolean) | null>(null);
 
 	// Use ref to avoid re-registering layer when onClose changes
@@ -106,6 +114,11 @@ export function AboutModal({
 	// Custom escape handler that checks for badge overlay first
 	// Uses refs to avoid dependency changes that would cause infinite loops
 	const handleEscape = useCallback(() => {
+		// If in feedback view, go back to about
+		if (view === 'feedback') {
+			setView('about');
+			return;
+		}
 		// If badge overlay is open, close it first
 		if (badgeEscapeHandlerRef.current) {
 			badgeEscapeHandlerRef.current();
@@ -113,56 +126,94 @@ export function AboutModal({
 		}
 		// Otherwise close the modal
 		onCloseRef.current();
-	}, []); // No dependencies - uses refs
+	}, [view]);
 
-	// Custom header with Globe and Discord buttons (includes close button)
-	const customHeader = (
-		<div
-			className="p-4 border-b flex items-center justify-between shrink-0"
-			style={{ borderColor: theme.colors.border }}
-		>
-			<div className="flex items-center gap-2">
-				<h2 className="text-sm font-bold" style={{ color: theme.colors.textMain }}>
-					About Maestro
-				</h2>
+	// Custom header — differs between about and feedback views
+	const customHeader =
+		view === 'feedback' ? (
+			<div
+				className="p-4 border-b flex items-center justify-between shrink-0"
+				style={{ borderColor: theme.colors.border }}
+			>
+				<div className="flex items-center gap-2">
+					<button
+						type="button"
+						onClick={() => setView('about')}
+						className="p-1 rounded hover:bg-white/10 transition-colors"
+						title="Back to About"
+						style={{ color: theme.colors.accent }}
+					>
+						<ArrowLeft className="w-4 h-4" />
+					</button>
+					<h2 className="text-sm font-bold" style={{ color: theme.colors.textMain }}>
+						Send Feedback
+					</h2>
+				</div>
 				<button
-					onClick={() => window.maestro.shell.openExternal('https://runmaestro.ai')}
+					type="button"
+					onClick={onClose}
 					className="p-1 rounded hover:bg-white/10 transition-colors"
-					title="Visit runmaestro.ai"
-					style={{ color: theme.colors.accent }}
+					style={{ color: theme.colors.textDim }}
+					aria-label="Close modal"
 				>
-					<Globe className="w-4 h-4" />
-				</button>
-				<button
-					onClick={() => window.maestro.shell.openExternal('https://runmaestro.ai/discord')}
-					className="p-1 rounded hover:bg-white/10 transition-colors"
-					title="Join our Discord"
-					style={{ color: theme.colors.accent }}
-				>
-					<svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
-						<path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z" />
-					</svg>
-				</button>
-				<button
-					onClick={() => window.maestro.shell.openExternal('https://docs.runmaestro.ai/')}
-					className="p-1 rounded hover:bg-white/10 transition-colors"
-					title="Documentation"
-					style={{ color: theme.colors.accent }}
-				>
-					<BookOpen className="w-4 h-4" />
+					<X className="w-4 h-4" />
 				</button>
 			</div>
-			<button
-				type="button"
-				onClick={onClose}
-				className="p-1 rounded hover:bg-white/10 transition-colors"
-				style={{ color: theme.colors.textDim }}
-				aria-label="Close modal"
+		) : (
+			<div
+				className="p-4 border-b flex items-center justify-between shrink-0"
+				style={{ borderColor: theme.colors.border }}
 			>
-				<X className="w-4 h-4" />
-			</button>
-		</div>
-	);
+				<div className="flex items-center gap-2">
+					<h2 className="text-sm font-bold" style={{ color: theme.colors.textMain }}>
+						About Maestro
+					</h2>
+					<button
+						onClick={() => window.maestro.shell.openExternal('https://runmaestro.ai')}
+						className="p-1 rounded hover:bg-white/10 transition-colors"
+						title="Visit runmaestro.ai"
+						style={{ color: theme.colors.accent }}
+					>
+						<Globe className="w-4 h-4" />
+					</button>
+					<button
+						onClick={() => window.maestro.shell.openExternal('https://runmaestro.ai/discord')}
+						className="p-1 rounded hover:bg-white/10 transition-colors"
+						title="Join our Discord"
+						style={{ color: theme.colors.accent }}
+					>
+						<svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
+							<path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z" />
+						</svg>
+					</button>
+					<button
+						onClick={() => window.maestro.shell.openExternal('https://docs.runmaestro.ai/')}
+						className="p-1 rounded hover:bg-white/10 transition-colors"
+						title="Documentation"
+						style={{ color: theme.colors.accent }}
+					>
+						<BookOpen className="w-4 h-4" />
+					</button>
+					<button
+						onClick={() => setView('feedback')}
+						className="p-1 rounded hover:bg-white/10 transition-colors"
+						title="Send Feedback"
+						style={{ color: theme.colors.accent }}
+					>
+						<MessageSquarePlus className="w-4 h-4" />
+					</button>
+				</div>
+				<button
+					type="button"
+					onClick={onClose}
+					className="p-1 rounded hover:bg-white/10 transition-colors"
+					style={{ color: theme.colors.textDim }}
+					aria-label="Close modal"
+				>
+					<X className="w-4 h-4" />
+				</button>
+			</div>
+		);
 
 	return (
 		<Modal
@@ -174,6 +225,17 @@ export function AboutModal({
 			customHeader={customHeader}
 			showHeader={true}
 		>
+			{view === 'feedback' ? (
+				<FeedbackView
+					theme={theme}
+					sessions={sessions}
+					onCancel={() => setView('about')}
+					onSubmitSuccess={(sid) => {
+						onSwitchToSession(sid);
+						onClose();
+					}}
+				/>
+			) : (
 			<div className="space-y-4">
 				{/* Logo and Title */}
 				<div className="flex items-center gap-4">
@@ -460,6 +522,7 @@ export function AboutModal({
 					</div>
 				</div>
 			</div>
+			)}
 		</Modal>
 	);
 }

--- a/src/renderer/components/AboutModal.tsx
+++ b/src/renderer/components/AboutModal.tsx
@@ -147,6 +147,7 @@ export function AboutModal({
 						onClick={() => setView('about')}
 						className="p-1 rounded hover:bg-white/10 transition-colors"
 						title="Back to About"
+						aria-label="Back to About"
 						style={{ color: theme.colors.accent }}
 					>
 						<ArrowLeft className="w-4 h-4" />
@@ -175,17 +176,21 @@ export function AboutModal({
 						About Maestro
 					</h2>
 					<button
+						type="button"
 						onClick={() => window.maestro.shell.openExternal('https://runmaestro.ai')}
 						className="p-1 rounded hover:bg-white/10 transition-colors"
 						title="Visit runmaestro.ai"
+						aria-label="Visit runmaestro.ai"
 						style={{ color: theme.colors.accent }}
 					>
 						<Globe className="w-4 h-4" />
 					</button>
 					<button
+						type="button"
 						onClick={() => window.maestro.shell.openExternal('https://runmaestro.ai/discord')}
 						className="p-1 rounded hover:bg-white/10 transition-colors"
 						title="Join our Discord"
+						aria-label="Join our Discord"
 						style={{ color: theme.colors.accent }}
 					>
 						<svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
@@ -193,17 +198,21 @@ export function AboutModal({
 						</svg>
 					</button>
 					<button
+						type="button"
 						onClick={() => window.maestro.shell.openExternal('https://docs.runmaestro.ai/')}
 						className="p-1 rounded hover:bg-white/10 transition-colors"
 						title="Documentation"
+						aria-label="Open documentation"
 						style={{ color: theme.colors.accent }}
 					>
 						<BookOpen className="w-4 h-4" />
 					</button>
 					<button
+						type="button"
 						onClick={() => setView('feedback')}
 						className="p-1 rounded hover:bg-white/10 transition-colors"
 						title="Send Feedback"
+						aria-label="Send Feedback"
 						style={{ color: theme.colors.accent }}
 					>
 						<MessageSquarePlus className="w-4 h-4" />

--- a/src/renderer/components/AppModals.tsx
+++ b/src/renderer/components/AppModals.tsx
@@ -50,6 +50,7 @@ import type { GroomingProgress, MergeResult } from '../types/contextMerge';
 
 // Info/Display Modal Components
 import { AboutModal } from './AboutModal';
+import { FeedbackModal } from './FeedbackModal';
 import { ShortcutsHelpModal } from './ShortcutsHelpModal';
 import { UpdateCheckModal } from './UpdateCheckModal';
 
@@ -162,6 +163,10 @@ export interface AppInfoModalsProps {
 	defaultStatsTimeRange?: 'day' | 'week' | 'month' | 'year' | 'all';
 	/** Enable colorblind-friendly colors for dashboard charts */
 	colorBlindMode?: boolean;
+
+	// Feedback Modal
+	feedbackModalOpen: boolean;
+	onCloseFeedbackModal: () => void;
 }
 
 /**
@@ -196,6 +201,9 @@ export const AppInfoModals = memo(function AppInfoModals({
 	isLeaderboardRegistered,
 	leaderboardRegistration,
 	onSwitchToSession,
+	// Feedback Modal
+	feedbackModalOpen,
+	onCloseFeedbackModal,
 	// Update Check Modal
 	updateCheckModalOpen,
 	onCloseUpdateCheckModal,
@@ -224,6 +232,16 @@ export const AppInfoModals = memo(function AppInfoModals({
 					onClose={onCloseShortcutsHelp}
 					hasNoAgents={hasNoAgents}
 					keyboardMasteryStats={keyboardMasteryStats}
+				/>
+			)}
+
+			{/* --- FEEDBACK MODAL --- */}
+			{feedbackModalOpen && (
+				<FeedbackModal
+					theme={theme}
+					sessions={sessions}
+					onClose={onCloseFeedbackModal}
+					onSwitchToSession={onSwitchToSession}
 				/>
 			)}
 
@@ -797,6 +815,7 @@ export interface AppUtilityModalsProps {
 	setSettingsTab: (tab: SettingsTab) => void;
 	setShortcutsHelpOpen: (open: boolean) => void;
 	setAboutModalOpen: (open: boolean) => void;
+	setFeedbackModalOpen: (open: boolean) => void;
 	setLogViewerOpen: (open: boolean) => void;
 	setProcessMonitorOpen: (open: boolean) => void;
 	setUsageDashboardOpen: (open: boolean) => void;
@@ -1010,6 +1029,7 @@ export const AppUtilityModals = memo(function AppUtilityModals({
 	setSettingsTab,
 	setShortcutsHelpOpen,
 	setAboutModalOpen,
+	setFeedbackModalOpen,
 	setLogViewerOpen,
 	setProcessMonitorOpen,
 	setUsageDashboardOpen,
@@ -1172,6 +1192,7 @@ export const AppUtilityModals = memo(function AppUtilityModals({
 					setSettingsTab={setSettingsTab}
 					setShortcutsHelpOpen={setShortcutsHelpOpen}
 					setAboutModalOpen={setAboutModalOpen}
+					setFeedbackModalOpen={setFeedbackModalOpen}
 					setLogViewerOpen={setLogViewerOpen}
 					setProcessMonitorOpen={setProcessMonitorOpen}
 					setUsageDashboardOpen={setUsageDashboardOpen}
@@ -1810,6 +1831,8 @@ export interface AppModalsProps {
 	defaultStatsTimeRange?: 'day' | 'week' | 'month' | 'year' | 'all';
 	/** Enable colorblind-friendly colors for dashboard charts */
 	colorBlindMode?: boolean;
+	feedbackModalOpen: boolean;
+	onCloseFeedbackModal: () => void;
 
 	// --- AppConfirmModals props ---
 	confirmModalMessage: string;
@@ -1918,6 +1941,7 @@ export interface AppModalsProps {
 	setSettingsTab: (tab: SettingsTab) => void;
 	setShortcutsHelpOpen: (open: boolean) => void;
 	setAboutModalOpen: (open: boolean) => void;
+	setFeedbackModalOpen: (open: boolean) => void;
 	setLogViewerOpen: (open: boolean) => void;
 	setProcessMonitorOpen: (open: boolean) => void;
 	setUsageDashboardOpen: (open: boolean) => void;
@@ -2226,6 +2250,8 @@ export const AppModals = memo(function AppModals(props: AppModalsProps) {
 		onCloseUsageDashboard,
 		defaultStatsTimeRange,
 		colorBlindMode,
+		feedbackModalOpen,
+		onCloseFeedbackModal,
 		// Confirm modals
 		confirmModalMessage,
 		confirmModalOnConfirm,
@@ -2297,6 +2323,7 @@ export const AppModals = memo(function AppModals(props: AppModalsProps) {
 		setSettingsTab,
 		setShortcutsHelpOpen,
 		setAboutModalOpen,
+		setFeedbackModalOpen,
 		setLogViewerOpen,
 		setProcessMonitorOpen,
 		setUsageDashboardOpen,
@@ -2486,6 +2513,8 @@ export const AppModals = memo(function AppModals(props: AppModalsProps) {
 				defaultStatsTimeRange={defaultStatsTimeRange}
 				colorBlindMode={colorBlindMode}
 				onSwitchToSession={setActiveSessionId}
+				feedbackModalOpen={feedbackModalOpen}
+				onCloseFeedbackModal={onCloseFeedbackModal}
 			/>
 
 			{/* Confirmation Modals */}
@@ -2605,6 +2634,7 @@ export const AppModals = memo(function AppModals(props: AppModalsProps) {
 				setSettingsTab={setSettingsTab}
 				setShortcutsHelpOpen={setShortcutsHelpOpen}
 				setAboutModalOpen={setAboutModalOpen}
+				setFeedbackModalOpen={setFeedbackModalOpen}
 				setLogViewerOpen={setLogViewerOpen}
 				setProcessMonitorOpen={setProcessMonitorOpen}
 				setUsageDashboardOpen={setUsageDashboardOpen}

--- a/src/renderer/components/AppModals.tsx
+++ b/src/renderer/components/AppModals.tsx
@@ -140,6 +140,7 @@ export interface AppInfoModalsProps {
 	onOpenLeaderboardRegistration: () => void;
 	isLeaderboardRegistered: boolean;
 	leaderboardRegistration?: LeaderboardRegistration | null;
+	onSwitchToSession: (sessionId: string) => void;
 
 	// Update Check Modal
 	updateCheckModalOpen: boolean;
@@ -194,6 +195,7 @@ export const AppInfoModals = memo(function AppInfoModals({
 	onOpenLeaderboardRegistration,
 	isLeaderboardRegistered,
 	leaderboardRegistration,
+	onSwitchToSession,
 	// Update Check Modal
 	updateCheckModalOpen,
 	onCloseUpdateCheckModal,
@@ -236,6 +238,8 @@ export const AppInfoModals = memo(function AppInfoModals({
 					onOpenLeaderboardRegistration={onOpenLeaderboardRegistration}
 					isLeaderboardRegistered={isLeaderboardRegistered}
 					leaderboardRegistration={leaderboardRegistration}
+					sessions={sessions}
+					onSwitchToSession={onSwitchToSession}
 				/>
 			)}
 
@@ -2481,6 +2485,7 @@ export const AppModals = memo(function AppModals(props: AppModalsProps) {
 				onCloseUsageDashboard={onCloseUsageDashboard}
 				defaultStatsTimeRange={defaultStatsTimeRange}
 				colorBlindMode={colorBlindMode}
+				onSwitchToSession={setActiveSessionId}
 			/>
 
 			{/* Confirmation Modals */}

--- a/src/renderer/components/FeedbackModal.tsx
+++ b/src/renderer/components/FeedbackModal.tsx
@@ -1,0 +1,33 @@
+import type { Theme, Session } from '../types';
+import { Modal } from './ui/Modal';
+import { FeedbackView } from './FeedbackView';
+import { MODAL_PRIORITIES } from '../constants/modalPriorities';
+
+interface FeedbackModalProps {
+	theme: Theme;
+	sessions: Session[];
+	onClose: () => void;
+	onSwitchToSession: (sessionId: string) => void;
+}
+
+export function FeedbackModal({ theme, sessions, onClose, onSwitchToSession }: FeedbackModalProps) {
+	return (
+		<Modal
+			theme={theme}
+			title="Send Feedback"
+			priority={MODAL_PRIORITIES.FEEDBACK}
+			onClose={onClose}
+			width={450}
+		>
+			<FeedbackView
+				theme={theme}
+				sessions={sessions}
+				onCancel={onClose}
+				onSubmitSuccess={(sid) => {
+					onSwitchToSession(sid);
+					onClose();
+				}}
+			/>
+		</Modal>
+	);
+}

--- a/src/renderer/components/FeedbackView.tsx
+++ b/src/renderer/components/FeedbackView.tsx
@@ -61,9 +61,7 @@ export function FeedbackView({ theme, sessions, onCancel, onSubmitSuccess }: Fee
 		if (result.success) {
 			onSubmitSuccess(selectedSessionId);
 		} else {
-			setSubmitError(
-				'The selected agent is no longer running. Please select another agent.'
-			);
+			setSubmitError('The selected agent is no longer running. Please select another agent.');
 			setSubmitting(false);
 		}
 	}, [selectedSessionId, feedbackText, checkAuth, onSubmitSuccess]);
@@ -81,10 +79,7 @@ export function FeedbackView({ theme, sessions, onCancel, onSubmitSuccess }: Fee
 	if (authChecking) {
 		return (
 			<div className="flex items-center justify-center py-12">
-				<Loader2
-					className="w-4 h-4 animate-spin"
-					style={{ color: theme.colors.textDim }}
-				/>
+				<Loader2 className="w-4 h-4 animate-spin" style={{ color: theme.colors.textDim }} />
 			</div>
 		);
 	}
@@ -133,10 +128,7 @@ export function FeedbackView({ theme, sessions, onCancel, onSubmitSuccess }: Fee
 
 	const isDisabled = !!authError;
 	const canSubmit =
-		!isDisabled &&
-		!submitting &&
-		feedbackText.trim().length > 0 &&
-		selectedSessionId.length > 0;
+		!isDisabled && !submitting && feedbackText.trim().length > 0 && selectedSessionId.length > 0;
 
 	const charCount = feedbackText.length;
 	const formattedCount = charCount.toLocaleString();
@@ -161,10 +153,7 @@ export function FeedbackView({ theme, sessions, onCancel, onSubmitSuccess }: Fee
 			<div className={isDisabled ? 'opacity-40 pointer-events-none' : ''}>
 				{/* Agent selector */}
 				<div className="mb-3">
-					<label
-						className="block text-xs font-medium mb-1"
-						style={{ color: theme.colors.textDim }}
-					>
+					<label className="block text-xs font-medium mb-1" style={{ color: theme.colors.textDim }}>
 						Agent to file feedback from
 					</label>
 					<select
@@ -179,11 +168,7 @@ export function FeedbackView({ theme, sessions, onCancel, onSubmitSuccess }: Fee
 						}}
 					>
 						{runningSessions.map((s) => (
-							<option
-								key={s.id}
-								value={s.id}
-								style={{ backgroundColor: theme.colors.bgActivity }}
-							>
+							<option key={s.id} value={s.id} style={{ backgroundColor: theme.colors.bgActivity }}>
 								{s.name} ({s.toolType})
 							</option>
 						))}
@@ -192,10 +177,7 @@ export function FeedbackView({ theme, sessions, onCancel, onSubmitSuccess }: Fee
 
 				{/* Feedback textarea */}
 				<div className="mb-1">
-					<label
-						className="block text-xs font-medium mb-1"
-						style={{ color: theme.colors.textDim }}
-					>
+					<label className="block text-xs font-medium mb-1" style={{ color: theme.colors.textDim }}>
 						Feedback
 					</label>
 					<textarea

--- a/src/renderer/components/FeedbackView.tsx
+++ b/src/renderer/components/FeedbackView.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { Loader2 } from 'lucide-react';
 import type { Theme, Session } from '../types';
 
@@ -61,7 +61,9 @@ export function FeedbackView({ theme, sessions, onCancel, onSubmitSuccess }: Fee
 		if (result.success) {
 			onSubmitSuccess(selectedSessionId);
 		} else {
-			setSubmitError(result.error ?? 'Submission failed. Please try again.');
+			setSubmitError(
+				'The selected agent is no longer running. Please select another agent.'
+			);
 			setSubmitting(false);
 		}
 	}, [selectedSessionId, feedbackText, checkAuth, onSubmitSuccess]);
@@ -80,9 +82,51 @@ export function FeedbackView({ theme, sessions, onCancel, onSubmitSuccess }: Fee
 		return (
 			<div className="flex items-center justify-center py-12">
 				<Loader2
-					className="w-6 h-6 animate-spin"
+					className="w-4 h-4 animate-spin"
 					style={{ color: theme.colors.textDim }}
 				/>
+			</div>
+		);
+	}
+
+	// No running agents — show placeholder message instead of form
+	if (runningSessions.length === 0) {
+		return (
+			<div className="space-y-4">
+				<div
+					className="text-xs px-3 py-3 rounded border text-center"
+					style={{
+						color: theme.colors.textDim,
+						borderColor: theme.colors.border,
+					}}
+				>
+					No running agents available. Start an agent first, then try again.
+				</div>
+				<div className="flex justify-end gap-2 pt-1">
+					<button
+						type="button"
+						onClick={onCancel}
+						className="px-3 py-1.5 rounded text-xs border transition-colors hover:bg-white/5"
+						style={{
+							color: theme.colors.textDim,
+							borderColor: theme.colors.border,
+						}}
+					>
+						Cancel
+					</button>
+					<button
+						type="button"
+						disabled
+						className="px-3 py-1.5 rounded text-xs flex items-center gap-1.5 transition-colors"
+						style={{
+							color: theme.colors.textDim,
+							backgroundColor: theme.colors.border,
+							cursor: 'not-allowed',
+						}}
+					>
+						Send Feedback
+					</button>
+				</div>
 			</div>
 		);
 	}
@@ -92,8 +136,10 @@ export function FeedbackView({ theme, sessions, onCancel, onSubmitSuccess }: Fee
 		!isDisabled &&
 		!submitting &&
 		feedbackText.trim().length > 0 &&
-		selectedSessionId.length > 0 &&
-		runningSessions.length > 0;
+		selectedSessionId.length > 0;
+
+	const charCount = feedbackText.length;
+	const formattedCount = charCount.toLocaleString();
 
 	return (
 		<div className="space-y-4">
@@ -124,7 +170,7 @@ export function FeedbackView({ theme, sessions, onCancel, onSubmitSuccess }: Fee
 					<select
 						value={selectedSessionId}
 						onChange={(e) => setSelectedSessionId(e.target.value)}
-						disabled={submitting || runningSessions.length === 0}
+						disabled={submitting}
 						className="w-full px-2 py-1.5 rounded text-xs border bg-transparent outline-none"
 						style={{
 							color: theme.colors.textMain,
@@ -132,21 +178,15 @@ export function FeedbackView({ theme, sessions, onCancel, onSubmitSuccess }: Fee
 							backgroundColor: 'transparent',
 						}}
 					>
-						{runningSessions.length === 0 ? (
-							<option value="" disabled>
-								No running agents — start one first
+						{runningSessions.map((s) => (
+							<option
+								key={s.id}
+								value={s.id}
+								style={{ backgroundColor: theme.colors.bgActivity }}
+							>
+								{s.name} ({s.toolType})
 							</option>
-						) : (
-							runningSessions.map((s) => (
-								<option
-									key={s.id}
-									value={s.id}
-									style={{ backgroundColor: theme.colors.bgActivity }}
-								>
-									{s.name} ({s.toolType})
-								</option>
-							))
-						)}
+						))}
 					</select>
 				</div>
 
@@ -176,17 +216,14 @@ export function FeedbackView({ theme, sessions, onCancel, onSubmitSuccess }: Fee
 							minHeight: '120px',
 						}}
 					/>
-					{feedbackText.length > 4000 && (
+					{charCount > 4000 && (
 						<div
 							className="text-xs text-right mt-0.5"
 							style={{
-								color:
-									feedbackText.length >= 5000
-										? theme.colors.error
-										: theme.colors.textDim,
+								color: charCount >= 5000 ? theme.colors.error : theme.colors.textDim,
 							}}
 						>
-							{feedbackText.length} / 5000
+							{formattedCount} / 5,000
 						</div>
 					)}
 				</div>
@@ -231,7 +268,7 @@ export function FeedbackView({ theme, sessions, onCancel, onSubmitSuccess }: Fee
 						cursor: canSubmit ? 'pointer' : 'not-allowed',
 					}}
 				>
-					{submitting && <Loader2 className="w-3 h-3 animate-spin" />}
+					{submitting && <Loader2 className="w-4 h-4 animate-spin" />}
 					Send Feedback
 				</button>
 			</div>

--- a/src/renderer/components/FeedbackView.tsx
+++ b/src/renderer/components/FeedbackView.tsx
@@ -1,0 +1,240 @@
+import { useState, useEffect, useCallback } from 'react';
+import { Loader2 } from 'lucide-react';
+import type { Theme, Session } from '../types';
+
+interface FeedbackViewProps {
+	theme: Theme;
+	sessions: Session[];
+	onCancel: () => void;
+	onSubmitSuccess: (sessionId: string) => void;
+}
+
+export function FeedbackView({ theme, sessions, onCancel, onSubmitSuccess }: FeedbackViewProps) {
+	const [authChecking, setAuthChecking] = useState(true);
+	const [authError, setAuthError] = useState<string | null>(null);
+	const [selectedSessionId, setSelectedSessionId] = useState('');
+	const [feedbackText, setFeedbackText] = useState('');
+	const [submitting, setSubmitting] = useState(false);
+	const [submitError, setSubmitError] = useState<string | null>(null);
+
+	// Sessions that have an active agent process
+	const runningSessions = sessions.filter(
+		(s) => s.state === 'idle' || s.state === 'busy' || s.state === 'waiting_input'
+	);
+
+	useEffect(() => {
+		// Auto-select the first running session
+		if (runningSessions.length > 0 && !selectedSessionId) {
+			setSelectedSessionId(runningSessions[0].id);
+		}
+	}, [runningSessions, selectedSessionId]);
+
+	const checkAuth = useCallback(async (): Promise<boolean> => {
+		const result = await window.maestro.feedback.checkGhAuth();
+		if (!result.authenticated) {
+			setAuthError(result.message ?? 'GitHub CLI authentication required.');
+			return false;
+		}
+		setAuthError(null);
+		return true;
+	}, []);
+
+	useEffect(() => {
+		setAuthChecking(true);
+		checkAuth().finally(() => setAuthChecking(false));
+	}, [checkAuth]);
+
+	const handleSubmit = useCallback(async () => {
+		if (!selectedSessionId || !feedbackText.trim()) return;
+
+		setSubmitting(true);
+		setSubmitError(null);
+
+		// Pre-submit auth re-check
+		const stillAuthed = await checkAuth();
+		if (!stillAuthed) {
+			setSubmitting(false);
+			return;
+		}
+
+		const result = await window.maestro.feedback.submit(selectedSessionId, feedbackText.trim());
+		if (result.success) {
+			onSubmitSuccess(selectedSessionId);
+		} else {
+			setSubmitError(result.error ?? 'Submission failed. Please try again.');
+			setSubmitting(false);
+		}
+	}, [selectedSessionId, feedbackText, checkAuth, onSubmitSuccess]);
+
+	const handleTextareaKeyDown = useCallback(
+		(e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+			if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+				e.preventDefault();
+				handleSubmit();
+			}
+		},
+		[handleSubmit]
+	);
+
+	if (authChecking) {
+		return (
+			<div className="flex items-center justify-center py-12">
+				<Loader2
+					className="w-6 h-6 animate-spin"
+					style={{ color: theme.colors.textDim }}
+				/>
+			</div>
+		);
+	}
+
+	const isDisabled = !!authError;
+	const canSubmit =
+		!isDisabled &&
+		!submitting &&
+		feedbackText.trim().length > 0 &&
+		selectedSessionId.length > 0 &&
+		runningSessions.length > 0;
+
+	return (
+		<div className="space-y-4">
+			{/* Auth error banner */}
+			{authError && (
+				<div
+					className="text-xs px-3 py-2 rounded border"
+					style={{
+						color: theme.colors.warning,
+						borderColor: theme.colors.warning,
+						backgroundColor: `${theme.colors.warning}15`,
+					}}
+				>
+					{authError}
+				</div>
+			)}
+
+			{/* Form fields — ghosted when auth fails */}
+			<div className={isDisabled ? 'opacity-40 pointer-events-none' : ''}>
+				{/* Agent selector */}
+				<div className="mb-3">
+					<label
+						className="block text-xs font-medium mb-1"
+						style={{ color: theme.colors.textDim }}
+					>
+						Agent to file feedback from
+					</label>
+					<select
+						value={selectedSessionId}
+						onChange={(e) => setSelectedSessionId(e.target.value)}
+						disabled={submitting || runningSessions.length === 0}
+						className="w-full px-2 py-1.5 rounded text-xs border bg-transparent outline-none"
+						style={{
+							color: theme.colors.textMain,
+							borderColor: theme.colors.border,
+							backgroundColor: 'transparent',
+						}}
+					>
+						{runningSessions.length === 0 ? (
+							<option value="" disabled>
+								No running agents — start one first
+							</option>
+						) : (
+							runningSessions.map((s) => (
+								<option
+									key={s.id}
+									value={s.id}
+									style={{ backgroundColor: theme.colors.bgActivity }}
+								>
+									{s.name} ({s.toolType})
+								</option>
+							))
+						)}
+					</select>
+				</div>
+
+				{/* Feedback textarea */}
+				<div className="mb-1">
+					<label
+						className="block text-xs font-medium mb-1"
+						style={{ color: theme.colors.textDim }}
+					>
+						Feedback
+					</label>
+					<textarea
+						value={feedbackText}
+						onChange={(e) => {
+							if (e.target.value.length <= 5000) {
+								setFeedbackText(e.target.value);
+							}
+						}}
+						onKeyDown={handleTextareaKeyDown}
+						disabled={submitting}
+						placeholder="Describe the bug, feature request, or feedback..."
+						className="w-full px-3 py-2 rounded text-xs border bg-transparent outline-none resize-none"
+						style={{
+							color: theme.colors.textMain,
+							borderColor: theme.colors.border,
+							backgroundColor: 'transparent',
+							minHeight: '120px',
+						}}
+					/>
+					{feedbackText.length > 4000 && (
+						<div
+							className="text-xs text-right mt-0.5"
+							style={{
+								color:
+									feedbackText.length >= 5000
+										? theme.colors.error
+										: theme.colors.textDim,
+							}}
+						>
+							{feedbackText.length} / 5000
+						</div>
+					)}
+				</div>
+			</div>
+
+			{/* Submit error */}
+			{submitError && (
+				<div
+					className="text-xs px-3 py-2 rounded border"
+					style={{
+						color: theme.colors.error,
+						borderColor: theme.colors.error,
+						backgroundColor: `${theme.colors.error}15`,
+					}}
+				>
+					{submitError}
+				</div>
+			)}
+
+			{/* Footer */}
+			<div className="flex justify-end gap-2 pt-1">
+				<button
+					type="button"
+					onClick={onCancel}
+					disabled={submitting}
+					className="px-3 py-1.5 rounded text-xs border transition-colors hover:bg-white/5"
+					style={{
+						color: theme.colors.textDim,
+						borderColor: theme.colors.border,
+					}}
+				>
+					Cancel
+				</button>
+				<button
+					type="button"
+					onClick={handleSubmit}
+					disabled={!canSubmit}
+					className="px-3 py-1.5 rounded text-xs flex items-center gap-1.5 transition-colors"
+					style={{
+						color: canSubmit ? theme.colors.bgActivity : theme.colors.textDim,
+						backgroundColor: canSubmit ? theme.colors.accent : theme.colors.border,
+						cursor: canSubmit ? 'pointer' : 'not-allowed',
+					}}
+				>
+					{submitting && <Loader2 className="w-3 h-3 animate-spin" />}
+					Send Feedback
+				</button>
+			</div>
+		</div>
+	);
+}

--- a/src/renderer/components/FeedbackView.tsx
+++ b/src/renderer/components/FeedbackView.tsx
@@ -1,6 +1,7 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { Loader2 } from 'lucide-react';
 import type { Theme, Session } from '../types';
+import { captureException } from '../utils/sentry';
 
 interface FeedbackViewProps {
 	theme: Theme;
@@ -18,8 +19,12 @@ export function FeedbackView({ theme, sessions, onCancel, onSubmitSuccess }: Fee
 	const [submitError, setSubmitError] = useState<string | null>(null);
 
 	// Sessions that have an active agent process
-	const runningSessions = sessions.filter(
-		(s) => s.state === 'idle' || s.state === 'busy' || s.state === 'waiting_input'
+	const runningSessions = useMemo(
+		() =>
+			sessions.filter(
+				(s) => s.state === 'idle' || s.state === 'busy' || s.state === 'waiting_input'
+			),
+		[sessions]
 	);
 
 	useEffect(() => {
@@ -30,13 +35,19 @@ export function FeedbackView({ theme, sessions, onCancel, onSubmitSuccess }: Fee
 	}, [runningSessions, selectedSessionId]);
 
 	const checkAuth = useCallback(async (): Promise<boolean> => {
-		const result = await window.maestro.feedback.checkGhAuth();
-		if (!result.authenticated) {
-			setAuthError(result.message ?? 'GitHub CLI authentication required.');
+		try {
+			const result = await window.maestro.feedback.checkGhAuth();
+			if (!result.authenticated) {
+				setAuthError(result.message ?? 'GitHub CLI authentication required.');
+				return false;
+			}
+			setAuthError(null);
+			return true;
+		} catch (error) {
+			captureException(error, { extra: { context: 'FeedbackView.checkAuth' } });
+			setAuthError('Unable to verify GitHub CLI authentication. Please try again.');
 			return false;
 		}
-		setAuthError(null);
-		return true;
 	}, []);
 
 	useEffect(() => {
@@ -50,18 +61,23 @@ export function FeedbackView({ theme, sessions, onCancel, onSubmitSuccess }: Fee
 		setSubmitting(true);
 		setSubmitError(null);
 
-		// Pre-submit auth re-check
-		const stillAuthed = await checkAuth();
-		if (!stillAuthed) {
-			setSubmitting(false);
-			return;
-		}
+		try {
+			// Pre-submit auth re-check
+			const stillAuthed = await checkAuth();
+			if (!stillAuthed) return;
 
-		const result = await window.maestro.feedback.submit(selectedSessionId, feedbackText.trim());
-		if (result.success) {
-			onSubmitSuccess(selectedSessionId);
-		} else {
-			setSubmitError('The selected agent is no longer running. Please select another agent.');
+			const result = await window.maestro.feedback.submit(selectedSessionId, feedbackText.trim());
+			if (result.success) {
+				onSubmitSuccess(selectedSessionId);
+				return;
+			}
+			setSubmitError(
+				result.error ?? 'The selected agent is no longer running. Please select another agent.'
+			);
+		} catch (error) {
+			captureException(error, { extra: { context: 'FeedbackView.handleSubmit' } });
+			setSubmitError('Unable to send feedback. Please try again.');
+		} finally {
 			setSubmitting(false);
 		}
 	}, [selectedSessionId, feedbackText, checkAuth, onSubmitSuccess]);

--- a/src/renderer/components/QuickActionsModal.tsx
+++ b/src/renderer/components/QuickActionsModal.tsx
@@ -49,6 +49,7 @@ interface QuickActionsModalProps {
 	setSettingsTab: (tab: SettingsTab) => void;
 	setShortcutsHelpOpen: (open: boolean) => void;
 	setAboutModalOpen: (open: boolean) => void;
+	setFeedbackModalOpen?: (open: boolean) => void;
 	setLogViewerOpen: (open: boolean) => void;
 	setProcessMonitorOpen: (open: boolean) => void;
 	setUsageDashboardOpen: (open: boolean) => void;
@@ -152,6 +153,7 @@ export const QuickActionsModal = memo(function QuickActionsModal(props: QuickAct
 		setSettingsTab,
 		setShortcutsHelpOpen,
 		setAboutModalOpen,
+		setFeedbackModalOpen,
 		setLogViewerOpen,
 		setProcessMonitorOpen,
 		setUsageDashboardOpen,
@@ -877,6 +879,15 @@ export const QuickActionsModal = memo(function QuickActionsModal(props: QuickAct
 			label: 'About Maestro',
 			action: () => {
 				setAboutModalOpen(true);
+				setQuickActionOpen(false);
+			},
+		},
+		{
+			id: 'feedback',
+			label: 'Send Feedback',
+			subtext: 'Report a bug or suggest a feature via GitHub',
+			action: () => {
+				setFeedbackModalOpen?.(true);
 				setQuickActionOpen(false);
 			},
 		},

--- a/src/renderer/components/QuickActionsModal.tsx
+++ b/src/renderer/components/QuickActionsModal.tsx
@@ -882,15 +882,19 @@ export const QuickActionsModal = memo(function QuickActionsModal(props: QuickAct
 				setQuickActionOpen(false);
 			},
 		},
-		{
-			id: 'feedback',
-			label: 'Send Feedback',
-			subtext: 'Report a bug or suggest a feature via GitHub',
-			action: () => {
-				setFeedbackModalOpen?.(true);
-				setQuickActionOpen(false);
-			},
-		},
+		...(setFeedbackModalOpen
+			? [
+					{
+						id: 'feedback',
+						label: 'Send Feedback',
+						subtext: 'Report a bug or suggest a feature via GitHub',
+						action: () => {
+							setFeedbackModalOpen(true);
+							setQuickActionOpen(false);
+						},
+					},
+				]
+			: []),
 		{
 			id: 'website',
 			label: 'Maestro Website',

--- a/src/renderer/constants/modalPriorities.ts
+++ b/src/renderer/constants/modalPriorities.ts
@@ -188,6 +188,9 @@ export const MODAL_PRIORITIES = {
 	/** About/info modal */
 	ABOUT: 600,
 
+	/** Feedback modal */
+	FEEDBACK: 595,
+
 	/** Update check modal */
 	UPDATE_CHECK: 610,
 

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -2732,6 +2732,15 @@ interface MaestroAPI {
 		checkCli: () => Promise<{ available: boolean; version?: string }>;
 		validateApiKey: (key: string) => Promise<{ valid: boolean }>;
 	};
+
+	// Feedback API (Send Feedback feature)
+	feedback: {
+		checkGhAuth: () => Promise<{ authenticated: boolean; message?: string }>;
+		submit: (
+			sessionId: string,
+			feedbackText: string
+		) => Promise<{ success: boolean; error?: string }>;
+	};
 }
 
 declare global {

--- a/src/renderer/hooks/modal/useModalHandlers.ts
+++ b/src/renderer/hooks/modal/useModalHandlers.ts
@@ -91,6 +91,8 @@ export interface ModalHandlersReturn {
 	handleOpenAboutModal: () => void;
 	handleOpenBatchRunner: () => void;
 	handleOpenMarketplace: () => void;
+	handleOpenFeedbackModal: () => void;
+	handleCloseFeedbackModal: () => void;
 
 	// Session list openers
 	handleEditAgent: (session: Session) => void;
@@ -459,6 +461,14 @@ export function useModalHandlers(
 
 	const handleOpenAboutModal = useCallback(() => {
 		getModalActions().setAboutModalOpen(true);
+	}, []);
+
+	const handleOpenFeedbackModal = useCallback(() => {
+		getModalActions().setFeedbackModalOpen(true);
+	}, []);
+
+	const handleCloseFeedbackModal = useCallback(() => {
+		getModalActions().setFeedbackModalOpen(false);
 	}, []);
 
 	const handleOpenBatchRunner = useCallback(() => {
@@ -913,6 +923,8 @@ export function useModalHandlers(
 		handleOpenAboutModal,
 		handleOpenBatchRunner,
 		handleOpenMarketplace,
+		handleOpenFeedbackModal,
+		handleCloseFeedbackModal,
 
 		// Session list openers
 		handleEditAgent,

--- a/src/renderer/stores/modalStore.ts
+++ b/src/renderer/stores/modalStore.ts
@@ -519,7 +519,8 @@ export function getModalActions() {
 		setAboutModalOpen: (open: boolean) => (open ? openModal('about') : closeModal('about')),
 
 		// Feedback Modal
-		setFeedbackModalOpen: (open: boolean) => (open ? openModal('feedback') : closeModal('feedback')),
+		setFeedbackModalOpen: (open: boolean) =>
+			open ? openModal('feedback') : closeModal('feedback'),
 
 		// Update Check Modal
 		setUpdateCheckModalOpen: (open: boolean) =>

--- a/src/renderer/stores/modalStore.ts
+++ b/src/renderer/stores/modalStore.ts
@@ -220,7 +220,9 @@ export type ModalId =
 	// Platform Warnings
 	| 'windowsWarning'
 	// Director's Notes
-	| 'directorNotes';
+	| 'directorNotes'
+	// Feedback
+	| 'feedback';
 
 /**
  * Type mapping from ModalId to its data type.
@@ -515,6 +517,9 @@ export function getModalActions() {
 
 		// About Modal
 		setAboutModalOpen: (open: boolean) => (open ? openModal('about') : closeModal('about')),
+
+		// Feedback Modal
+		setFeedbackModalOpen: (open: boolean) => (open ? openModal('feedback') : closeModal('feedback')),
 
 		// Update Check Modal
 		setUpdateCheckModalOpen: (open: boolean) =>
@@ -850,6 +855,7 @@ export function useModalActions() {
 	const symphonyModalOpen = useModalStore(selectModalOpen('symphony'));
 	const windowsWarningModalOpen = useModalStore(selectModalOpen('windowsWarning'));
 	const directorNotesOpen = useModalStore(selectModalOpen('directorNotes'));
+	const feedbackModalOpen = useModalStore(selectModalOpen('feedback'));
 
 	// Get stable actions
 	const actions = getModalActions();
@@ -1017,6 +1023,9 @@ export function useModalActions() {
 
 		// Director's Notes Modal
 		directorNotesOpen,
+
+		// Feedback Modal
+		feedbackModalOpen,
 
 		// Lightbox ref replacements (now stored as data)
 		lightboxIsGroupChat: lightboxData?.isGroupChat ?? false,


### PR DESCRIPTION
## Summary

- Adds a `FeedbackView` shared content component and `FeedbackModal` for standalone access
- Integrates feedback icon and view-switching into `AboutModal`
- Wires up feedback via Command Palette and IPC handler with full TypeScript types
- Adds system prompt template for feedback, handler tests, and Prettier formatting pass

## Test plan

- [ ] Open Command Palette → "Send Feedback" opens `FeedbackModal`
- [ ] Open About modal → feedback icon switches to `FeedbackView`
- [ ] Submit feedback form → IPC handler receives and processes the payload
- [ ] Lint, type-check, and test suite pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Send Feedback modal: compose feedback (5,000 char limit, live counter), select a running agent session, submit, and auto-switch to the session on success.
  * Feedback integrated into About modal, Quick Actions, app modals, and escape/back behavior; GitHub CLI auth is checked before submit and a preload API exposes feedback methods to the renderer.
  * New prompt templates format feedback into a GitHub issue.

* **Tests**
  * Added tests covering auth checks, caching, submission flows, validation, and failure cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->