### PR TITLE
refactor: consolidate AgentCapabilities to single canonical type (Phase 02)

### DIFF
--- a/src/main/agents/capabilities.ts
+++ b/src/main/agents/capabilities.ts
@@ -7,120 +7,17 @@
  * - Handle agent differences in a consistent way
  *
  * When adding a new agent, define its capabilities here.
+ *
+ * The AgentCapabilities interface and DEFAULT_CAPABILITIES constant are
+ * defined canonically in src/shared/types.ts and re-exported here so that
+ * existing `from './capabilities'` imports keep working.
  */
 
-/**
- * Capability flags that determine what features are available for each agent.
- */
-export interface AgentCapabilities {
-	/** Agent supports resuming existing sessions (e.g., --resume flag) */
-	supportsResume: boolean;
+import type { AgentCapabilities } from '../../shared/types';
+import { DEFAULT_CAPABILITIES } from '../../shared/types';
 
-	/** Agent supports read-only/plan mode (e.g., --permission-mode plan) */
-	supportsReadOnlyMode: boolean;
-
-	/** Agent outputs JSON-formatted responses (for parsing) */
-	supportsJsonOutput: boolean;
-
-	/** Agent provides a session ID for conversation continuity */
-	supportsSessionId: boolean;
-
-	/** Agent can accept image inputs (screenshots, diagrams, etc.) */
-	supportsImageInput: boolean;
-
-	/** Agent can accept image inputs when resuming an existing session */
-	supportsImageInputOnResume: boolean;
-
-	/** Agent supports slash commands (e.g., /help, /compact) */
-	supportsSlashCommands: boolean;
-
-	/** Agent stores session history in a discoverable location */
-	supportsSessionStorage: boolean;
-
-	/** Agent provides cost/pricing information */
-	supportsCostTracking: boolean;
-
-	/** Agent provides token usage statistics */
-	supportsUsageStats: boolean;
-
-	/** Agent supports batch/headless mode (non-interactive) */
-	supportsBatchMode: boolean;
-
-	/** Agent requires a prompt to start (no eager spawn on session creation) */
-	requiresPromptToStart: boolean;
-
-	/** Agent streams responses in real-time */
-	supportsStreaming: boolean;
-
-	/** Agent provides distinct "result" messages when done */
-	supportsResultMessages: boolean;
-
-	/** Agent supports selecting different models (e.g., --model flag) */
-	supportsModelSelection: boolean;
-
-	/** Agent supports --input-format stream-json for image input via stdin */
-	supportsStreamJsonInput: boolean;
-
-	/** Agent emits streaming thinking/reasoning content that can be displayed */
-	supportsThinkingDisplay: boolean;
-
-	/** Agent can receive merged context from other sessions/tabs */
-	supportsContextMerge: boolean;
-
-	/** Agent can export its context for transfer to other sessions/agents */
-	supportsContextExport: boolean;
-
-	/** Agent supports inline wizard structured output conversations */
-	supportsWizard: boolean;
-
-	/** Agent can serve as a group chat moderator */
-	supportsGroupChatModeration: boolean;
-
-	/** Agent uses JSON line (JSONL) output format in CLI batch mode */
-	usesJsonLineOutput: boolean;
-
-	/** Agent uses a combined input+output context window (vs separate limits) */
-	usesCombinedContextWindow: boolean;
-
-	/** Agent supports --append-system-prompt for separate system prompt delivery */
-	supportsAppendSystemPrompt: boolean;
-
-	/** How images should be handled on resume when -i flag is not available.
-	 * 'prompt-embed': Save images to temp files and embed file paths in the prompt text.
-	 * undefined: Use default image handling (or no special resume handling needed). */
-	imageResumeMode?: 'prompt-embed';
-}
-
-/**
- * Default capabilities - safe defaults for unknown agents.
- * All capabilities disabled by default (conservative approach).
- */
-export const DEFAULT_CAPABILITIES: AgentCapabilities = {
-	supportsResume: false,
-	supportsReadOnlyMode: false,
-	supportsJsonOutput: false,
-	supportsSessionId: false,
-	supportsImageInput: false,
-	supportsImageInputOnResume: false,
-	supportsSlashCommands: false,
-	supportsSessionStorage: false,
-	supportsCostTracking: false,
-	supportsUsageStats: false,
-	supportsBatchMode: false,
-	requiresPromptToStart: false,
-	supportsStreaming: false,
-	supportsResultMessages: false,
-	supportsModelSelection: false,
-	supportsStreamJsonInput: false,
-	supportsThinkingDisplay: false,
-	supportsContextMerge: false,
-	supportsContextExport: false,
-	supportsWizard: false,
-	supportsGroupChatModeration: false,
-	usesJsonLineOutput: false,
-	usesCombinedContextWindow: false,
-	supportsAppendSystemPrompt: false,
-};
+export type { AgentCapabilities };
+export { DEFAULT_CAPABILITIES };
 
 /**
  * Capability definitions for each supported agent.

--- a/src/main/preload/agents.ts
+++ b/src/main/preload/agents.ts
@@ -10,28 +10,9 @@
 
 import { ipcRenderer } from 'electron';
 
-/**
- * Capability flags that determine what features are available for each agent.
- * This is a simplified version for the renderer - full definition in agent-capabilities.ts
- */
-export interface AgentCapabilities {
-	supportsResume: boolean;
-	supportsReadOnlyMode: boolean;
-	supportsJsonOutput: boolean;
-	supportsSessionId: boolean;
-	supportsImageInput: boolean;
-	supportsImageInputOnResume: boolean;
-	supportsSlashCommands: boolean;
-	supportsSessionStorage: boolean;
-	supportsCostTracking: boolean;
-	supportsUsageStats: boolean;
-	supportsBatchMode: boolean;
-	requiresPromptToStart: boolean;
-	supportsStreaming: boolean;
-	supportsResultMessages: boolean;
-	supportsModelSelection: boolean;
-	supportsStreamJsonInput: boolean;
-}
+import type { AgentCapabilities } from '../../shared/types';
+
+export type { AgentCapabilities };
 
 /**
  * Agent configuration

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -87,32 +87,7 @@ interface AgentConfigOption {
 	options?: string[];
 }
 
-interface AgentCapabilities {
-	supportsResume: boolean;
-	supportsReadOnlyMode: boolean;
-	supportsJsonOutput: boolean;
-	supportsSessionId: boolean;
-	supportsImageInput: boolean;
-	supportsImageInputOnResume: boolean;
-	supportsSlashCommands: boolean;
-	supportsSessionStorage: boolean;
-	supportsCostTracking: boolean;
-	supportsUsageStats: boolean;
-	supportsBatchMode: boolean;
-	requiresPromptToStart: boolean;
-	supportsStreaming: boolean;
-	supportsResultMessages: boolean;
-	supportsModelSelection: boolean;
-	supportsStreamJsonInput: boolean;
-	supportsThinkingDisplay: boolean;
-	supportsContextMerge: boolean;
-	supportsContextExport: boolean;
-	supportsWizard: boolean;
-	supportsGroupChatModeration: boolean;
-	usesJsonLineOutput: boolean;
-	usesCombinedContextWindow: boolean;
-	supportsAppendSystemPrompt: boolean;
-}
+type AgentCapabilities = import('../shared/types').AgentCapabilities;
 
 interface AgentConfig {
 	id: string;
@@ -128,32 +103,6 @@ interface AgentConfig {
 	yoloModeArgs?: string[];
 	readOnlyCliEnforced?: boolean;
 	capabilities?: AgentCapabilities;
-}
-
-interface AgentCapabilities {
-	supportsResume: boolean;
-	supportsReadOnlyMode: boolean;
-	supportsJsonOutput: boolean;
-	supportsSessionId: boolean;
-	supportsImageInput: boolean;
-	supportsImageInputOnResume: boolean;
-	supportsSlashCommands: boolean;
-	supportsSessionStorage: boolean;
-	supportsCostTracking: boolean;
-	supportsUsageStats: boolean;
-	supportsBatchMode: boolean;
-	requiresPromptToStart: boolean;
-	supportsStreaming: boolean;
-	supportsResultMessages: boolean;
-	supportsModelSelection: boolean;
-	supportsStreamJsonInput: boolean;
-	supportsContextMerge: boolean;
-	supportsContextExport: boolean;
-	supportsWizard: boolean;
-	supportsGroupChatModeration: boolean;
-	usesJsonLineOutput: boolean;
-	usesCombinedContextWindow: boolean;
-	supportsAppendSystemPrompt: boolean;
 }
 
 interface DirectoryEntry {

--- a/src/renderer/hooks/agent/useAgentCapabilities.ts
+++ b/src/renderer/hooks/agent/useAgentCapabilities.ts
@@ -133,7 +133,7 @@ export function useAgentCapabilities(
  */
 export function hasCapabilityCached(agentId: string, capability: keyof AgentCapabilities): boolean {
 	const cached = capabilitiesCache.get(agentId);
-	if (!cached) return DEFAULT_CAPABILITIES[capability] as boolean;
+	if (!cached) return !!DEFAULT_CAPABILITIES[capability];
 	return !!cached[capability];
 }
 

--- a/src/renderer/hooks/agent/useAgentCapabilities.ts
+++ b/src/renderer/hooks/agent/useAgentCapabilities.ts
@@ -7,114 +7,11 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import type { ToolType } from '../../types';
+import type { AgentCapabilities } from '../../../shared/types';
+import { DEFAULT_CAPABILITIES } from '../../../shared/types';
 
-/**
- * Capability flags that determine what features are available for each agent.
- */
-export interface AgentCapabilities {
-	/** Agent supports resuming existing sessions (e.g., --resume flag) */
-	supportsResume: boolean;
-
-	/** Agent supports read-only/plan mode (e.g., --permission-mode plan) */
-	supportsReadOnlyMode: boolean;
-
-	/** Agent outputs JSON-formatted responses (for parsing) */
-	supportsJsonOutput: boolean;
-
-	/** Agent provides a session ID for conversation continuity */
-	supportsSessionId: boolean;
-
-	/** Agent can accept image inputs (screenshots, diagrams, etc.) */
-	supportsImageInput: boolean;
-
-	/** Agent can accept image inputs when resuming an existing session */
-	supportsImageInputOnResume: boolean;
-
-	/** Agent supports slash commands (e.g., /help, /compact) */
-	supportsSlashCommands: boolean;
-
-	/** Agent stores session history in a discoverable location */
-	supportsSessionStorage: boolean;
-
-	/** Agent provides cost/pricing information */
-	supportsCostTracking: boolean;
-
-	/** Agent provides token usage statistics */
-	supportsUsageStats: boolean;
-
-	/** Agent supports batch/headless mode (non-interactive) */
-	supportsBatchMode: boolean;
-
-	/** Agent requires a prompt to start (no eager spawn on session creation) */
-	requiresPromptToStart: boolean;
-
-	/** Agent streams responses in real-time */
-	supportsStreaming: boolean;
-
-	/** Agent provides distinct "result" messages when done */
-	supportsResultMessages: boolean;
-
-	/** Agent supports selecting different models (e.g., --model flag) */
-	supportsModelSelection: boolean;
-
-	/** Agent supports --input-format stream-json for image input via stdin */
-	supportsStreamJsonInput: boolean;
-
-	/** Agent emits streaming thinking/reasoning content that can be displayed */
-	supportsThinkingDisplay: boolean;
-
-	/** Agent can receive merged context from other sessions/tabs */
-	supportsContextMerge: boolean;
-
-	/** Agent can export its context for transfer to other sessions/agents */
-	supportsContextExport: boolean;
-
-	/** Agent supports inline wizard structured output conversations */
-	supportsWizard: boolean;
-
-	/** Agent can serve as a group chat moderator */
-	supportsGroupChatModeration: boolean;
-
-	/** Agent uses JSON line (JSONL) output format in CLI batch mode */
-	usesJsonLineOutput: boolean;
-
-	/** Agent uses a combined input+output context window (vs separate limits) */
-	usesCombinedContextWindow: boolean;
-
-	/** Agent supports --append-system-prompt for separate system prompt delivery */
-	supportsAppendSystemPrompt: boolean;
-}
-
-/**
- * Default capabilities - safe defaults for unknown agents.
- * All capabilities disabled by default (conservative approach).
- */
-export const DEFAULT_CAPABILITIES: AgentCapabilities = {
-	supportsResume: false,
-	supportsReadOnlyMode: false,
-	supportsJsonOutput: false,
-	supportsSessionId: false,
-	supportsImageInput: false,
-	supportsImageInputOnResume: false,
-	supportsSlashCommands: false,
-	supportsSessionStorage: false,
-	supportsCostTracking: false,
-	supportsUsageStats: false,
-	supportsBatchMode: false,
-	requiresPromptToStart: false,
-	supportsStreaming: false,
-	supportsResultMessages: false,
-	supportsModelSelection: false,
-	supportsStreamJsonInput: false,
-	supportsThinkingDisplay: false,
-	supportsContextMerge: false,
-	supportsContextExport: false,
-	supportsWizard: false,
-	supportsGroupChatModeration: false,
-	usesJsonLineOutput: false,
-	usesCombinedContextWindow: false,
-	supportsAppendSystemPrompt: false,
-};
+export type { AgentCapabilities };
+export { DEFAULT_CAPABILITIES };
 
 /**
  * Return type for useAgentCapabilities hook.
@@ -211,7 +108,7 @@ export function useAgentCapabilities(
 	// Helper to check a specific capability
 	const hasCapability = useCallback(
 		(capability: keyof AgentCapabilities): boolean => {
-			return capabilities[capability];
+			return !!capabilities[capability];
 		},
 		[capabilities]
 	);

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -1,5 +1,7 @@
 // Type definitions for Maestro renderer
 
+import type { AgentCapabilities } from '../../shared/types';
+
 // Re-export context merge types
 export * from './contextMerge';
 
@@ -775,7 +777,6 @@ export interface AgentConfigOption {
 	argBuilder?: (value: any) => string[];
 }
 
-import type { AgentCapabilities } from '../../shared/types';
 export type { AgentCapabilities };
 
 export interface AgentConfig {

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -775,32 +775,8 @@ export interface AgentConfigOption {
 	argBuilder?: (value: any) => string[];
 }
 
-export interface AgentCapabilities {
-	supportsResume: boolean;
-	supportsReadOnlyMode: boolean;
-	supportsJsonOutput: boolean;
-	supportsSessionId: boolean;
-	supportsImageInput: boolean;
-	supportsImageInputOnResume: boolean;
-	supportsSlashCommands: boolean;
-	supportsSessionStorage: boolean;
-	supportsCostTracking: boolean;
-	supportsUsageStats: boolean;
-	supportsBatchMode: boolean;
-	requiresPromptToStart: boolean;
-	supportsStreaming: boolean;
-	supportsResultMessages: boolean;
-	supportsModelSelection?: boolean;
-	supportsStreamJsonInput?: boolean;
-	supportsThinkingDisplay?: boolean;
-	supportsContextMerge?: boolean;
-	supportsContextExport?: boolean;
-	supportsWizard?: boolean;
-	supportsGroupChatModeration?: boolean;
-	usesJsonLineOutput?: boolean;
-	usesCombinedContextWindow?: boolean;
-	supportsAppendSystemPrompt?: boolean;
-}
+import type { AgentCapabilities } from '../../shared/types';
+export type { AgentCapabilities };
 
 export interface AgentConfig {
 	id: string;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -19,6 +19,125 @@ export type ToolType = import('./agentIds').AgentId;
  */
 export type ThinkingMode = 'off' | 'on' | 'sticky';
 
+/**
+ * Capability flags that determine what features are available for each agent.
+ *
+ * This is the single canonical definition. All other AgentCapabilities types
+ * across the codebase must import from here to avoid drift and type-shadowing
+ * bugs.
+ */
+export interface AgentCapabilities {
+	/** Agent supports resuming existing sessions (e.g., --resume flag) */
+	supportsResume: boolean;
+
+	/** Agent supports read-only/plan mode (e.g., --permission-mode plan) */
+	supportsReadOnlyMode: boolean;
+
+	/** Agent outputs JSON-formatted responses (for parsing) */
+	supportsJsonOutput: boolean;
+
+	/** Agent provides a session ID for conversation continuity */
+	supportsSessionId: boolean;
+
+	/** Agent can accept image inputs (screenshots, diagrams, etc.) */
+	supportsImageInput: boolean;
+
+	/** Agent can accept image inputs when resuming an existing session */
+	supportsImageInputOnResume: boolean;
+
+	/** Agent supports slash commands (e.g., /help, /compact) */
+	supportsSlashCommands: boolean;
+
+	/** Agent stores session history in a discoverable location */
+	supportsSessionStorage: boolean;
+
+	/** Agent provides cost/pricing information */
+	supportsCostTracking: boolean;
+
+	/** Agent provides token usage statistics */
+	supportsUsageStats: boolean;
+
+	/** Agent supports batch/headless mode (non-interactive) */
+	supportsBatchMode: boolean;
+
+	/** Agent requires a prompt to start (no eager spawn on session creation) */
+	requiresPromptToStart: boolean;
+
+	/** Agent streams responses in real-time */
+	supportsStreaming: boolean;
+
+	/** Agent provides distinct "result" messages when done */
+	supportsResultMessages: boolean;
+
+	/** Agent supports selecting different models (e.g., --model flag) */
+	supportsModelSelection: boolean;
+
+	/** Agent supports --input-format stream-json for image input via stdin */
+	supportsStreamJsonInput: boolean;
+
+	/** Agent emits streaming thinking/reasoning content that can be displayed */
+	supportsThinkingDisplay: boolean;
+
+	/** Agent can receive merged context from other sessions/tabs */
+	supportsContextMerge: boolean;
+
+	/** Agent can export its context for transfer to other sessions/agents */
+	supportsContextExport: boolean;
+
+	/** Agent supports inline wizard structured output conversations */
+	supportsWizard: boolean;
+
+	/** Agent can serve as a group chat moderator */
+	supportsGroupChatModeration: boolean;
+
+	/** Agent uses JSON line (JSONL) output format in CLI batch mode */
+	usesJsonLineOutput: boolean;
+
+	/** Agent uses a combined input+output context window (vs separate limits) */
+	usesCombinedContextWindow: boolean;
+
+	/** Agent supports --append-system-prompt for separate system prompt delivery */
+	supportsAppendSystemPrompt: boolean;
+
+	/**
+	 * How images should be handled on resume when -i flag is not available.
+	 * 'prompt-embed': Save images to temp files and embed file paths in the prompt text.
+	 * undefined: Use default image handling (or no special resume handling needed).
+	 */
+	imageResumeMode?: 'prompt-embed';
+}
+
+/**
+ * Default capabilities - safe defaults for unknown agents.
+ * All capabilities disabled by default (conservative approach).
+ */
+export const DEFAULT_CAPABILITIES: AgentCapabilities = {
+	supportsResume: false,
+	supportsReadOnlyMode: false,
+	supportsJsonOutput: false,
+	supportsSessionId: false,
+	supportsImageInput: false,
+	supportsImageInputOnResume: false,
+	supportsSlashCommands: false,
+	supportsSessionStorage: false,
+	supportsCostTracking: false,
+	supportsUsageStats: false,
+	supportsBatchMode: false,
+	requiresPromptToStart: false,
+	supportsStreaming: false,
+	supportsResultMessages: false,
+	supportsModelSelection: false,
+	supportsStreamJsonInput: false,
+	supportsThinkingDisplay: false,
+	supportsContextMerge: false,
+	supportsContextExport: false,
+	supportsWizard: false,
+	supportsGroupChatModeration: false,
+	usesJsonLineOutput: false,
+	usesCombinedContextWindow: false,
+	supportsAppendSystemPrompt: false,
+};
+
 // Session group
 export interface Group {
 	id: string;


### PR DESCRIPTION
## Summary

Fixes a type-shadowing bug in `src/renderer/global.d.ts` where `AgentCapabilities` was declared **twice in the same file** (lines 61 and 104), causing the second declaration to silently override the first. The second declaration was missing `supportsThinkingDisplay`.

Consolidates all 6 duplicate `AgentCapabilities` definitions into a single canonical interface in `src/shared/types.ts` along with a canonical `DEFAULT_CAPABILITIES` constant. The canonical shape is a strict superset of every prior definition.

**Net: -181 lines across 6 files**

Files updated:
- `src/shared/types.ts` - added canonical interface + DEFAULT_CAPABILITIES
- `src/main/agents/capabilities.ts` - re-exports from shared
- `src/main/preload/agents.ts` - re-exports from shared
- `src/renderer/global.d.ts` - both duplicates replaced with single `import()` alias
- `src/renderer/types/index.ts` - re-exports from shared
- `src/renderer/hooks/agent/useAgentCapabilities.ts` - re-exports from shared, adds `!!` coercion in `hasCapability` since canonical type includes `imageResumeMode?: 'prompt-embed'`

## Test plan

- [ ] `npm run lint` passes (all 3 tsconfigs) - this is where the bug was previously hidden
- [ ] 228 capability-related tests pass (capabilities, agent-completeness, detector, useAgentCapabilities, useAvailableAgents, ipc/agents)
- [ ] Claude Code capabilities: resume, read-only, images, slash commands, model selection, thinking
- [ ] Codex capabilities: batch mode, JSON output
- [ ] OpenCode plan mode
- [ ] Factory Droid batch mode

## Risk

**Medium** - types touch main + renderer + preload boundary. Canonical is a strict superset so no existing code loses fields. Bug-fix side effect: runtime behavior around `hasCapability('imageResumeMode')` now correctly returns a boolean.

## Note on merge ordering

Has minor overlap with Phase 05 (#TBD) - both add re-exports of types in `renderer/types/index.ts`. When one merges, the other will need a trivial rebase to dedupe the re-export lines. Recommend merging Phase 02 first as it's the bug fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated agent capability type definitions and default values into a centralized shared module, reducing duplication across the codebase while preserving all existing exported functionality and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
