### PR TITLE
refactor: consolidate createMockTab test factories (Phase 03D)

### DIFF
--- a/src/__tests__/helpers/index.ts
+++ b/src/__tests__/helpers/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Barrel export for shared test helpers.
+ *
+ * Import from here in tests to avoid duplicating factory definitions
+ * across many test files.
+ */
+
+export { createMockAITab, createMockFileTab } from './mockTab';

--- a/src/__tests__/helpers/mockTab.ts
+++ b/src/__tests__/helpers/mockTab.ts
@@ -1,0 +1,56 @@
+/**
+ * Shared test factories for tab mocks.
+ *
+ * Use these factories in tests instead of hand-rolling local `createMockTab`
+ * or `createMockAITab` helpers. The defaults cover all required fields on
+ * `AITab` / `FilePreviewTab`; pass overrides for any fields your test exercises.
+ *
+ * If your test depends on a specific default (e.g. a non-null `agentSessionId`
+ * or pre-seeded `logs`), pass it explicitly via `overrides` at the call site
+ * rather than adding project-wide drift to the defaults below.
+ */
+
+import type { AITab, FilePreviewTab } from '../../renderer/types';
+
+/**
+ * Create a mock `AITab` with sensible defaults for all required fields.
+ *
+ * Defaults: idle state, null agentSessionId, null name, empty logs,
+ * empty inputValue, empty stagedImages, fresh createdAt timestamp.
+ *
+ * Tests that need a specific non-default value should pass it via `overrides`.
+ */
+export function createMockAITab(overrides: Partial<AITab> = {}): AITab {
+	return {
+		id: 'tab-1',
+		agentSessionId: null,
+		name: null,
+		starred: false,
+		logs: [],
+		inputValue: '',
+		stagedImages: [],
+		createdAt: Date.now(),
+		state: 'idle',
+		...overrides,
+	} as AITab;
+}
+
+/**
+ * Create a mock `FilePreviewTab` with sensible defaults for all required fields.
+ */
+export function createMockFileTab(overrides: Partial<FilePreviewTab> = {}): FilePreviewTab {
+	return {
+		id: 'file-tab-1',
+		path: '/test/file.ts',
+		name: 'file',
+		extension: '.ts',
+		content: '// test content',
+		scrollTop: 0,
+		searchQuery: '',
+		editMode: false,
+		editContent: undefined,
+		createdAt: Date.now(),
+		lastModified: Date.now(),
+		...overrides,
+	} as FilePreviewTab;
+}

--- a/src/__tests__/renderer/components/MergeSessionModal.test.tsx
+++ b/src/__tests__/renderer/components/MergeSessionModal.test.tsx
@@ -25,6 +25,7 @@ import { render, screen, fireEvent, waitFor, within } from '@testing-library/rea
 import { MergeSessionModal } from '../../../renderer/components/MergeSessionModal';
 import { LayerStackProvider } from '../../../renderer/contexts/LayerStackContext';
 import type { Theme, Session, AITab, ToolType } from '../../../renderer/types';
+import { createMockAITab } from '../../helpers/mockTab';
 
 // Create a test theme
 const testTheme: Theme = {
@@ -48,19 +49,14 @@ const testTheme: Theme = {
 	},
 };
 
-// Create a mock tab
+// Create a mock tab (positional signature thin wrapper over shared factory)
 function createMockTab(id: string, logs: any[] = [], name?: string): AITab {
-	return {
+	return createMockAITab({
 		id,
 		name: name || `Tab ${id}`,
 		agentSessionId: `session-${id}`,
-		starred: false,
 		logs,
-		inputValue: '',
-		stagedImages: [],
-		createdAt: Date.now(),
-		state: 'idle',
-	};
+	});
 }
 
 // Create a mock session

--- a/src/__tests__/renderer/components/ThinkingStatusPill.test.tsx
+++ b/src/__tests__/renderer/components/ThinkingStatusPill.test.tsx
@@ -16,6 +16,7 @@ import { render, screen, fireEvent, act, waitFor } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ThinkingStatusPill } from '../../../renderer/components/ThinkingStatusPill';
 import type { Session, Theme, BatchRunState, AITab, ThinkingItem } from '../../../renderer/types';
+import { createMockAITab as createBaseMockAITab } from '../../helpers/mockTab';
 
 // Mock theme for tests
 const mockTheme: Theme = {
@@ -63,20 +64,12 @@ function createMockSession(overrides: Partial<Session> = {}): Session {
 	};
 }
 
-// Helper to create a mock AITab
+// Helper to create a mock AITab with component-specific defaults (non-null name).
 function createMockAITab(overrides: Partial<AITab> = {}): AITab {
-	return {
-		id: 'tab-1',
+	return createBaseMockAITab({
 		name: 'Tab 1',
-		state: 'idle',
-		agentSessionId: null,
-		starred: false,
-		logs: [],
-		inputValue: '',
-		stagedImages: [],
-		createdAt: Date.now(),
 		...overrides,
-	};
+	});
 }
 
 // Helper to create a busy/thinking session

--- a/src/__tests__/renderer/hooks/useAgentExecution.test.ts
+++ b/src/__tests__/renderer/hooks/useAgentExecution.test.ts
@@ -2,20 +2,14 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { useAgentExecution } from '../../../renderer/hooks';
 import type { Session, AITab, UsageStats, QueuedItem } from '../../../renderer/types';
+import { createMockAITab } from '../../helpers/mockTab';
 
-const createMockTab = (overrides: Partial<AITab> = {}): AITab => ({
-	id: 'tab-1',
-	agentSessionId: null,
-	name: null,
-	starred: false,
-	logs: [],
-	inputValue: '',
-	stagedImages: [],
-	createdAt: 1700000000000,
-	state: 'idle',
-	saveToHistory: true,
-	...overrides,
-});
+const createMockTab = (overrides: Partial<AITab> = {}): AITab =>
+	createMockAITab({
+		createdAt: 1700000000000,
+		saveToHistory: true,
+		...overrides,
+	});
 
 const createMockSession = (overrides: Partial<Session> = {}): Session => {
 	const baseTab = createMockTab();

--- a/src/__tests__/renderer/hooks/useAgentListeners.test.ts
+++ b/src/__tests__/renderer/hooks/useAgentListeners.test.ts
@@ -18,25 +18,18 @@ import { useSessionStore } from '../../../renderer/stores/sessionStore';
 import { useModalStore } from '../../../renderer/stores/modalStore';
 import { useGroupChatStore } from '../../../renderer/stores/groupChatStore';
 import type { Session, AITab, AgentError } from '../../../renderer/types';
+import { createMockAITab } from '../../helpers/mockTab';
 
 // ============================================================================
 // Helpers
 // ============================================================================
 
 function createMockTab(overrides: Partial<AITab> = {}): AITab {
-	return {
-		id: 'tab-1',
-		agentSessionId: null,
-		name: null,
-		starred: false,
-		logs: [],
-		inputValue: '',
-		stagedImages: [],
+	return createMockAITab({
 		createdAt: 1700000000000,
-		state: 'idle' as const,
 		saveToHistory: true,
 		...overrides,
-	};
+	});
 }
 
 function createMockSession(overrides: Partial<Session> = {}): Session {

--- a/src/__tests__/renderer/hooks/useAgentSessionManagement.test.ts
+++ b/src/__tests__/renderer/hooks/useAgentSessionManagement.test.ts
@@ -4,14 +4,13 @@ import type { RefObject } from 'react';
 import { useAgentSessionManagement } from '../../../renderer/hooks';
 import type { Session, AITab, LogEntry } from '../../../renderer/types';
 import type { RightPanelHandle } from '../../../renderer/components/RightPanel';
+import { createMockAITab } from '../../helpers/mockTab';
 
 type MaestroHistoryApi = typeof window.maestro.history;
 
 type MaestroAgentSessionsApi = typeof window.maestro.agentSessions;
 
 type MaestroClaudeApi = typeof window.maestro.claude;
-
-import { createMockAITab } from '../../helpers/mockTab';
 
 const createMockTab = (overrides: Partial<AITab> = {}): AITab =>
 	createMockAITab({

--- a/src/__tests__/renderer/hooks/useAgentSessionManagement.test.ts
+++ b/src/__tests__/renderer/hooks/useAgentSessionManagement.test.ts
@@ -11,19 +11,14 @@ type MaestroAgentSessionsApi = typeof window.maestro.agentSessions;
 
 type MaestroClaudeApi = typeof window.maestro.claude;
 
-const createMockTab = (overrides: Partial<AITab> = {}): AITab => ({
-	id: 'tab-1',
-	agentSessionId: null,
-	name: null,
-	starred: false,
-	logs: [],
-	inputValue: '',
-	stagedImages: [],
-	createdAt: 1700000000000,
-	state: 'idle',
-	saveToHistory: true,
-	...overrides,
-});
+import { createMockAITab } from '../../helpers/mockTab';
+
+const createMockTab = (overrides: Partial<AITab> = {}): AITab =>
+	createMockAITab({
+		createdAt: 1700000000000,
+		saveToHistory: true,
+		...overrides,
+	});
 
 const createMockSession = (overrides: Partial<Session> = {}): Session => {
 	const baseTab = createMockTab();

--- a/src/__tests__/renderer/hooks/useInputProcessing.test.ts
+++ b/src/__tests__/renderer/hooks/useInputProcessing.test.ts
@@ -25,21 +25,15 @@ import type {
 	BatchRunState,
 	QueuedItem,
 } from '../../../renderer/types';
+import { createMockAITab } from '../../helpers/mockTab';
 
 // Create a mock AITab
-const createMockTab = (overrides: Partial<AITab> = {}): AITab => ({
-	id: 'tab-1',
-	agentSessionId: null,
-	name: null,
-	starred: false,
-	logs: [],
-	inputValue: '',
-	stagedImages: [],
-	createdAt: 1700000000000,
-	state: 'idle',
-	saveToHistory: true,
-	...overrides,
-});
+const createMockTab = (overrides: Partial<AITab> = {}): AITab =>
+	createMockAITab({
+		createdAt: 1700000000000,
+		saveToHistory: true,
+		...overrides,
+	});
 
 // Create a mock Session
 const createMockSession = (overrides: Partial<Session> = {}): Session => {

--- a/src/__tests__/renderer/hooks/useMergeSession.test.ts
+++ b/src/__tests__/renderer/hooks/useMergeSession.test.ts
@@ -7,6 +7,7 @@ import {
 	__resetMergeInProgress,
 } from '../../../renderer/hooks';
 import type { Session, AITab, LogEntry, ToolType } from '../../../renderer/types';
+import { createMockAITab } from '../../helpers/mockTab';
 import type { MergeOptions } from '../../../renderer/components/MergeSessionModal';
 import * as contextGroomer from '../../../renderer/services/contextGroomer';
 
@@ -82,20 +83,15 @@ vi.mock('../../../renderer/utils/tabHelpers', () => ({
 	getActiveTab: vi.fn((session) => session.aiTabs?.[0] || null),
 }));
 
-// Create a mock tab with logs
+// Create a mock tab with logs (positional signature thin wrapper over shared factory)
 function createMockTab(id: string, logs: LogEntry[] = [], name?: string): AITab {
-	return {
+	return createMockAITab({
 		id,
 		name: name || `Tab ${id}`,
 		agentSessionId: `session-${id}`,
-		starred: false,
 		logs,
-		inputValue: '',
-		stagedImages: [],
-		createdAt: Date.now(),
-		state: 'idle',
 		saveToHistory: true,
-	};
+	});
 }
 
 // Create a minimal session for testing

--- a/src/__tests__/renderer/hooks/useModalHandlers.test.ts
+++ b/src/__tests__/renderer/hooks/useModalHandlers.test.ts
@@ -28,6 +28,7 @@ import { useAgentStore } from '../../../renderer/stores/agentStore';
 import { useAgentErrorRecovery } from '../../../renderer/hooks/agent/useAgentErrorRecovery';
 import { gitService } from '../../../renderer/services/git';
 import type { Session, AITab } from '../../../renderer/types';
+import { createMockAITab as createBaseMockAITab } from '../../helpers/mockTab';
 
 // ============================================================================
 // Helpers
@@ -80,20 +81,11 @@ function createMockSession(overrides: Partial<Session> = {}): Session {
 }
 
 function createMockAITab(overrides: Partial<AITab> = {}): AITab {
-	return {
-		id: overrides.id ?? 'tab-1',
-		agentSessionId: overrides.agentSessionId ?? null,
-		name: overrides.name ?? null,
-		starred: false,
-		logs: [],
-		inputValue: '',
-		stagedImages: [],
-		createdAt: Date.now(),
-		state: 'idle',
+	return createBaseMockAITab({
 		hasUnread: false,
 		isAtBottom: true,
 		...overrides,
-	} as AITab;
+	});
 }
 
 // ============================================================================

--- a/src/__tests__/renderer/hooks/useRemoteIntegration.test.ts
+++ b/src/__tests__/renderer/hooks/useRemoteIntegration.test.ts
@@ -2,20 +2,14 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useRemoteIntegration } from '../../../renderer/hooks';
 import type { Session, AITab } from '../../../renderer/types';
+import { createMockAITab } from '../../helpers/mockTab';
 
-const createMockTab = (overrides: Partial<AITab> = {}): AITab => ({
-	id: 'tab-1',
-	agentSessionId: null,
-	name: null,
-	starred: false,
-	logs: [],
-	inputValue: '',
-	stagedImages: [],
-	createdAt: 1700000000000,
-	state: 'idle',
-	saveToHistory: true,
-	...overrides,
-});
+const createMockTab = (overrides: Partial<AITab> = {}): AITab =>
+	createMockAITab({
+		createdAt: 1700000000000,
+		saveToHistory: true,
+		...overrides,
+	});
 
 const createMockSession = (overrides: Partial<Session> = {}): Session => {
 	const baseTab = createMockTab();

--- a/src/__tests__/renderer/hooks/useSendToAgent.test.ts
+++ b/src/__tests__/renderer/hooks/useSendToAgent.test.ts
@@ -7,6 +7,7 @@ import {
 } from '../../../renderer/hooks';
 import type { Session, AITab, LogEntry, ToolType } from '../../../renderer/types';
 import type { SendToAgentOptions } from '../../../renderer/components/SendToAgentModal';
+import { createMockAITab } from '../../helpers/mockTab';
 import * as contextGroomer from '../../../renderer/services/contextGroomer';
 
 // Mock the context grooming service
@@ -85,18 +86,13 @@ vi.mock('../../../renderer/utils/tabHelpers', () => ({
 
 // Create a mock tab
 function createMockTab(id: string, logs: LogEntry[] = []): AITab {
-	return {
+	return createMockAITab({
 		id,
 		name: `Tab ${id}`,
 		agentSessionId: `session-${id}`,
-		starred: false,
 		logs,
-		inputValue: '',
-		stagedImages: [],
-		createdAt: Date.now(),
-		state: 'idle',
 		saveToHistory: true,
-	};
+	});
 }
 
 // Create a minimal session for testing

--- a/src/__tests__/renderer/hooks/useSessionLifecycle.test.ts
+++ b/src/__tests__/renderer/hooks/useSessionLifecycle.test.ts
@@ -24,27 +24,11 @@ import { useSessionStore } from '../../../renderer/stores/sessionStore';
 import { useModalStore } from '../../../renderer/stores/modalStore';
 import { useUIStore } from '../../../renderer/stores/uiStore';
 import type { Session, AITab } from '../../../renderer/types';
+import { createMockAITab } from '../../helpers/mockTab';
 
 // ============================================================================
 // Test Helpers
 // ============================================================================
-
-function createMockAITab(overrides: Partial<AITab> = {}): AITab {
-	return {
-		id: 'tab-1',
-		agentSessionId: null,
-		name: null,
-		starred: false,
-		logs: [],
-		inputValue: '',
-		stagedImages: [],
-		createdAt: Date.now(),
-		state: 'idle' as const,
-		hasUnread: false,
-		isAtBottom: true,
-		...overrides,
-	} as AITab;
-}
 
 function createMockSession(overrides: Partial<Session> = {}): Session {
 	return {

--- a/src/__tests__/renderer/hooks/useSummarizeHandler.test.ts
+++ b/src/__tests__/renderer/hooks/useSummarizeHandler.test.ts
@@ -65,28 +65,23 @@ import { createTabAtPosition } from '../../../renderer/utils/tabHelpers';
 import { useOperationStore } from '../../../renderer/stores/operationStore';
 import { useSessionStore } from '../../../renderer/stores/sessionStore';
 import type { Session, AITab } from '../../../renderer/types';
+import { createMockAITab } from '../../helpers/mockTab';
 
 // ============================================================================
 // Helpers
 // ============================================================================
 
 function createMockTab(overrides: Partial<AITab> = {}): AITab {
-	return {
-		id: 'tab-1',
+	return createMockAITab({
 		agentSessionId: 'agent-session-1',
 		name: 'Tab 1',
-		starred: false,
 		logs: [
 			{ id: 'log-1', timestamp: Date.now(), source: 'user', text: 'hello' },
 			{ id: 'log-2', timestamp: Date.now(), source: 'assistant', text: 'world' },
 		],
-		inputValue: '',
-		stagedImages: [],
-		createdAt: Date.now(),
-		state: 'idle',
 		saveToHistory: true,
 		...overrides,
-	} as AITab;
+	});
 }
 
 function createMockSession(overrides: Partial<Session> = {}): Session {

--- a/src/__tests__/renderer/hooks/useTabExportHandlers.test.ts
+++ b/src/__tests__/renderer/hooks/useTabExportHandlers.test.ts
@@ -54,6 +54,7 @@ import {
 	type UseTabExportHandlersDeps,
 } from '../../../renderer/hooks/tabs/useTabExportHandlers';
 import type { Session, AITab, LogEntry, Theme } from '../../../renderer/types';
+import { createMockAITab } from '../../helpers/mockTab';
 
 // ============================================================================
 // Helpers
@@ -70,21 +71,15 @@ function createLogEntry(overrides: Partial<LogEntry> = {}): LogEntry {
 }
 
 function createMockTab(overrides: Partial<AITab> = {}): AITab {
-	return {
-		id: 'tab-1',
+	return createMockAITab({
 		agentSessionId: 'agent-session-abc123',
 		name: 'My Tab',
-		starred: false,
 		logs: [
 			createLogEntry({ source: 'user', text: 'Hello' }),
 			createLogEntry({ source: 'ai', text: 'World' }),
 		],
-		inputValue: '',
-		stagedImages: [],
-		createdAt: Date.now(),
-		state: 'idle',
 		...overrides,
-	} as AITab;
+	});
 }
 
 function createMockSession(overrides: Partial<Session> = {}): Session {

--- a/src/__tests__/renderer/hooks/useTabHandlers.test.ts
+++ b/src/__tests__/renderer/hooks/useTabHandlers.test.ts
@@ -12,6 +12,10 @@ import { useSessionStore } from '../../../renderer/stores/sessionStore';
 import { useModalStore } from '../../../renderer/stores/modalStore';
 import { useSettingsStore } from '../../../renderer/stores/settingsStore';
 import type { Session, AITab, BrowserTab, FilePreviewTab } from '../../../renderer/types';
+import {
+	createMockAITab as createBaseMockAITab,
+	createMockFileTab as createBaseMockFileTab,
+} from '../../helpers/mockTab';
 
 // ============================================================================
 // window.maestro is mocked globally in src/__tests__/setup.ts
@@ -24,39 +28,23 @@ import type { Session, AITab, BrowserTab, FilePreviewTab } from '../../../render
 
 function createMockAITab(overrides: Partial<AITab> = {}): AITab {
 	const id = overrides.id ?? `tab-${Math.random().toString(36).slice(2, 8)}`;
-	return {
+	return createBaseMockAITab({
 		id,
-		agentSessionId: null,
-		name: overrides.name ?? null,
-		starred: false,
-		logs: [],
-		inputValue: '',
-		stagedImages: [],
-		createdAt: Date.now(),
-		state: 'idle',
 		hasUnread: false,
 		isAtBottom: true,
 		...overrides,
-	} as AITab;
+	});
 }
 
 function createMockFileTab(overrides: Partial<FilePreviewTab> = {}): FilePreviewTab {
 	const id = overrides.id ?? `file-${Math.random().toString(36).slice(2, 8)}`;
-	return {
+	return createBaseMockFileTab({
 		id,
 		path: overrides.path ?? `/test/${id}.ts`,
 		name: overrides.name ?? id,
-		extension: overrides.extension ?? '.ts',
-		content: overrides.content ?? 'test content',
-		scrollTop: 0,
-		searchQuery: '',
-		editMode: false,
-		editContent: undefined,
-		createdAt: Date.now(),
-		lastModified: Date.now(),
 		isLoading: false,
 		...overrides,
-	} as FilePreviewTab;
+	});
 }
 
 function createMockBrowserTab(overrides: Partial<BrowserTab> = {}): BrowserTab {

--- a/src/__tests__/renderer/hooks/useWizardHandlers.test.ts
+++ b/src/__tests__/renderer/hooks/useWizardHandlers.test.ts
@@ -85,25 +85,21 @@ import { gitService } from '../../../renderer/services/git';
 import { validateNewSession } from '../../../renderer/utils/sessionValidation';
 import { parseSynopsis } from '../../../shared/synopsis';
 import type { Session, AITab } from '../../../renderer/types';
+import { createMockAITab } from '../../helpers/mockTab';
 
 // ============================================================================
 // Test Helpers
 // ============================================================================
 
-const createMockTab = (overrides: Partial<AITab> = {}): AITab => ({
-	id: 'tab-1',
-	agentSessionId: 'agent-session-1',
-	name: 'Tab 1',
-	starred: false,
-	logs: [],
-	inputValue: '',
-	stagedImages: [],
-	createdAt: Date.now() - 60000,
-	state: 'idle',
-	saveToHistory: true,
-	showThinking: 'off',
-	...overrides,
-});
+const createMockTab = (overrides: Partial<AITab> = {}): AITab =>
+	createMockAITab({
+		agentSessionId: 'agent-session-1',
+		name: 'Tab 1',
+		createdAt: Date.now() - 60000,
+		saveToHistory: true,
+		showThinking: 'off',
+		...overrides,
+	});
 
 const createMockSession = (overrides: Partial<Session> = {}): Session =>
 	({

--- a/src/__tests__/renderer/stores/tabStore.test.ts
+++ b/src/__tests__/renderer/stores/tabStore.test.ts
@@ -15,6 +15,10 @@ import {
 } from '../../../renderer/stores/tabStore';
 import { useSessionStore } from '../../../renderer/stores/sessionStore';
 import type { Session, AITab, FilePreviewTab, TerminalTab } from '../../../renderer/types';
+import {
+	createMockAITab as createBaseMockAITab,
+	createMockFileTab as createBaseMockFileTab,
+} from '../../helpers/mockTab';
 
 // ============================================================================
 // Test Helpers
@@ -22,38 +26,22 @@ import type { Session, AITab, FilePreviewTab, TerminalTab } from '../../../rende
 
 function createMockAITab(overrides: Partial<AITab> = {}): AITab {
 	const id = overrides.id ?? `tab-${Math.random().toString(36).slice(2, 8)}`;
-	return {
+	return createBaseMockAITab({
 		id,
-		agentSessionId: null,
-		name: overrides.name ?? null,
-		starred: false,
-		logs: [],
-		inputValue: '',
-		stagedImages: [],
-		createdAt: Date.now(),
-		state: 'idle',
 		hasUnread: false,
 		isAtBottom: true,
 		...overrides,
-	} as AITab;
+	});
 }
 
 function createMockFileTab(overrides: Partial<FilePreviewTab> = {}): FilePreviewTab {
 	const id = overrides.id ?? `file-${Math.random().toString(36).slice(2, 8)}`;
-	return {
+	return createBaseMockFileTab({
 		id,
 		path: overrides.path ?? `/test/${id}.ts`,
 		name: overrides.name ?? id,
-		extension: overrides.extension ?? '.ts',
-		content: overrides.content ?? 'test content',
-		scrollTop: 0,
-		searchQuery: '',
-		editMode: false,
-		editContent: undefined,
-		createdAt: Date.now(),
-		lastModified: Date.now(),
 		...overrides,
-	} as FilePreviewTab;
+	});
 }
 
 function createMockSession(overrides: Partial<Session> = {}): Session {

--- a/src/__tests__/renderer/utils/contextExtractor.test.ts
+++ b/src/__tests__/renderer/utils/contextExtractor.test.ts
@@ -11,6 +11,7 @@ import {
 } from '../../../renderer/utils/contextExtractor';
 import type { AITab, LogEntry, Session } from '../../../renderer/types';
 import type { ContextSource } from '../../../renderer/types/contextMerge';
+import { createMockAITab } from '../../helpers/mockTab';
 
 // Mock window.maestro for extractStoredSessionContext tests
 const mockAgentSessionsRead = vi.fn();
@@ -59,18 +60,12 @@ function createMockSession(overrides: Partial<Session> = {}): Session {
 
 // Helper to create a mock tab
 function createMockTab(overrides: Partial<AITab> = {}): AITab {
-	return {
+	return createMockAITab({
 		id: 'tab-123',
 		agentSessionId: 'agent-session-456',
 		name: 'Test Tab',
-		starred: false,
-		logs: [],
-		inputValue: '',
-		stagedImages: [],
-		createdAt: Date.now(),
-		state: 'idle',
 		...overrides,
-	};
+	});
 }
 
 // Helper to create a mock log entry

--- a/src/__tests__/renderer/utils/tabExport.test.ts
+++ b/src/__tests__/renderer/utils/tabExport.test.ts
@@ -9,6 +9,7 @@ vi.mock('marked', () => ({
 
 import { generateTabExportHtml } from '../../../renderer/utils/tabExport';
 import type { AITab, LogEntry, Theme } from '../../../renderer/types';
+import { createMockAITab } from '../../helpers/mockTab';
 
 // Mock theme for testing
 const mockTheme: Theme = {
@@ -49,18 +50,13 @@ function createLogEntry(overrides?: Partial<LogEntry>): LogEntry {
 }
 
 function createMockTab(overrides?: Partial<AITab>): AITab {
-	return {
+	return createMockAITab({
 		id: 'tab-001',
 		agentSessionId: 'abc12345-def6-7890-ghij-klmnopqrstuv',
 		name: 'Test Tab',
-		starred: false,
-		logs: [],
-		inputValue: '',
-		stagedImages: [],
 		createdAt: 1703116800000, // 2023-12-21T00:00:00.000Z
-		state: 'idle',
 		...overrides,
-	};
+	});
 }
 
 describe('tabExport', () => {

--- a/src/__tests__/renderer/utils/tabHelpers.test.ts
+++ b/src/__tests__/renderer/utils/tabHelpers.test.ts
@@ -66,6 +66,10 @@ import type {
 	ClosedTabEntry,
 	FilePreviewTab,
 } from '../../../renderer/types';
+import {
+	createMockAITab as createMockTab,
+	createMockFileTab,
+} from '../../helpers/mockTab';
 
 // Mock the generateId function to return predictable IDs
 vi.mock('../../../renderer/utils/ids', () => ({
@@ -113,39 +117,6 @@ function createMockSession(overrides: Partial<Session> = {}): Session {
 	};
 }
 
-// Helper to create a minimal AITab for testing
-function createMockTab(overrides: Partial<AITab> = {}): AITab {
-	return {
-		id: 'tab-1',
-		agentSessionId: null,
-		name: null,
-		starred: false,
-		logs: [],
-		inputValue: '',
-		stagedImages: [],
-		createdAt: Date.now(),
-		state: 'idle',
-		...overrides,
-	};
-}
-
-// Helper to create a minimal FilePreviewTab for testing
-function createMockFileTab(overrides: Partial<FilePreviewTab> = {}): FilePreviewTab {
-	return {
-		id: 'file-tab-1',
-		path: '/test/file.ts',
-		name: 'file',
-		extension: '.ts',
-		content: '// test content',
-		scrollTop: 0,
-		searchQuery: '',
-		editMode: false,
-		editContent: undefined,
-		createdAt: Date.now(),
-		lastModified: Date.now(),
-		...overrides,
-	};
-}
 
 function createMockBrowserTab(overrides: Record<string, unknown> = {}) {
 	return {

--- a/src/__tests__/renderer/utils/tabHelpers.test.ts
+++ b/src/__tests__/renderer/utils/tabHelpers.test.ts
@@ -66,10 +66,7 @@ import type {
 	ClosedTabEntry,
 	FilePreviewTab,
 } from '../../../renderer/types';
-import {
-	createMockAITab as createMockTab,
-	createMockFileTab,
-} from '../../helpers/mockTab';
+import { createMockAITab as createMockTab, createMockFileTab } from '../../helpers/mockTab';
 
 // Mock the generateId function to return predictable IDs
 vi.mock('../../../renderer/utils/ids', () => ({
@@ -116,7 +113,6 @@ function createMockSession(overrides: Partial<Session> = {}): Session {
 		...overrides,
 	};
 }
-
 
 function createMockBrowserTab(overrides: Record<string, unknown> = {}) {
 	return {


### PR DESCRIPTION
## Summary

**Test-only change. Zero production risk.**

Introduces `createMockAITab` and `createMockFileTab` factories at `src/__tests__/helpers/mockTab.ts`. Replaces per-file tab factory definitions across 19 test files.

**Net: -85 lines across 21 files**

Files migrated: 14 hook tests, 4 util/store tests, 2 component tests. One file skipped (broadcastService - uses different `AITabData` shape).

## Test plan

- [x] `npm run lint` passes clean
- [x] Hook / util / tab tests pass

## Risk

**Zero** - no production code changes.
