### PR TITLE
refactor: unify SpecKit/OpenSpec command management (Phase 06)

### DIFF
--- a/src/__tests__/main/openspec-manager.test.ts
+++ b/src/__tests__/main/openspec-manager.test.ts
@@ -39,6 +39,13 @@ vi.mock('../../main/utils/logger', () => ({
 	},
 }));
 
+/** Create a Node.js-style ENOENT error with .code property */
+function enoent(): NodeJS.ErrnoException {
+	const err = new Error('ENOENT: no such file or directory') as NodeJS.ErrnoException;
+	err.code = 'ENOENT';
+	return err;
+}
+
 // Import the module after mocks are set up
 import {
 	getOpenSpecMetadata,
@@ -74,12 +81,12 @@ describe('openspec-manager', () => {
 			vi.mocked(fs.readFile).mockImplementation(async (filePath) => {
 				const pathStr = filePath.toString();
 				if (pathStr.includes('openspec-customizations.json')) {
-					throw new Error('ENOENT');
+					throw enoent();
 				}
 				if (pathStr.includes('metadata.json')) {
 					return JSON.stringify(mockMetadata);
 				}
-				throw new Error('ENOENT');
+				throw enoent();
 			});
 
 			const metadata = await getOpenSpecMetadata();
@@ -103,7 +110,7 @@ describe('openspec-manager', () => {
 						prompts: {},
 					});
 				}
-				throw new Error('ENOENT');
+				throw enoent();
 			});
 
 			const metadata = await getOpenSpecMetadata();
@@ -112,7 +119,7 @@ describe('openspec-manager', () => {
 		});
 
 		it('should return default metadata when no files exist', async () => {
-			vi.mocked(fs.readFile).mockRejectedValue(new Error('ENOENT'));
+			vi.mocked(fs.readFile).mockRejectedValue(enoent());
 
 			const metadata = await getOpenSpecMetadata();
 
@@ -129,15 +136,15 @@ describe('openspec-manager', () => {
 			vi.mocked(fs.readFile).mockImplementation(async (filePath) => {
 				const pathStr = filePath.toString();
 				if (pathStr.includes('openspec-customizations.json')) {
-					throw new Error('ENOENT');
+					throw enoent();
 				}
 				if (pathStr.includes('openspec-prompts')) {
-					throw new Error('ENOENT');
+					throw enoent();
 				}
 				if (pathStr.endsWith('.md')) {
 					return mockBundledPrompt;
 				}
-				throw new Error('ENOENT');
+				throw enoent();
 			});
 
 			const commands = await getOpenSpecPrompts();
@@ -154,15 +161,15 @@ describe('openspec-manager', () => {
 			vi.mocked(fs.readFile).mockImplementation(async (filePath) => {
 				const pathStr = filePath.toString();
 				if (pathStr.includes('openspec-customizations.json')) {
-					throw new Error('ENOENT');
+					throw enoent();
 				}
 				if (pathStr.includes('openspec-prompts')) {
-					throw new Error('ENOENT');
+					throw enoent();
 				}
 				if (pathStr.endsWith('.md')) {
 					return mockBundledPrompt;
 				}
-				throw new Error('ENOENT');
+				throw enoent();
 			});
 
 			const commands = await getOpenSpecPrompts();
@@ -182,15 +189,15 @@ describe('openspec-manager', () => {
 			vi.mocked(fs.readFile).mockImplementation(async (filePath) => {
 				const pathStr = filePath.toString();
 				if (pathStr.includes('openspec-customizations.json')) {
-					throw new Error('ENOENT');
+					throw enoent();
 				}
 				if (pathStr.includes('openspec-prompts')) {
-					throw new Error('ENOENT');
+					throw enoent();
 				}
 				if (pathStr.endsWith('.md')) {
 					return mockBundledPrompt;
 				}
-				throw new Error('ENOENT');
+				throw enoent();
 			});
 
 			const commands = await getOpenSpecPrompts();
@@ -222,12 +229,12 @@ describe('openspec-manager', () => {
 					});
 				}
 				if (pathStr.includes('openspec-prompts')) {
-					throw new Error('ENOENT');
+					throw enoent();
 				}
 				if (pathStr.endsWith('.md')) {
 					return mockBundledPrompt;
 				}
-				throw new Error('ENOENT');
+				throw enoent();
 			});
 
 			const commands = await getOpenSpecPrompts();
@@ -245,12 +252,12 @@ describe('openspec-manager', () => {
 			vi.mocked(fs.readFile).mockImplementation(async (filePath) => {
 				const pathStr = filePath.toString();
 				if (pathStr.includes('openspec-customizations.json')) {
-					throw new Error('ENOENT');
+					throw enoent();
 				}
 				if (pathStr.includes('metadata.json')) {
 					return JSON.stringify(mockMetadata);
 				}
-				throw new Error('ENOENT');
+				throw enoent();
 			});
 			vi.mocked(fs.writeFile).mockResolvedValue(undefined);
 
@@ -282,7 +289,7 @@ describe('openspec-manager', () => {
 				if (pathStr.includes('openspec-customizations.json')) {
 					return JSON.stringify(existingCustomizations);
 				}
-				throw new Error('ENOENT');
+				throw enoent();
 			});
 			vi.mocked(fs.writeFile).mockResolvedValue(undefined);
 
@@ -314,12 +321,12 @@ describe('openspec-manager', () => {
 					return JSON.stringify(customizations);
 				}
 				if (pathStr.includes('openspec-prompts')) {
-					throw new Error('ENOENT');
+					throw enoent();
 				}
 				if (pathStr.endsWith('.md')) {
 					return mockBundledPrompt;
 				}
-				throw new Error('ENOENT');
+				throw enoent();
 			});
 			vi.mocked(fs.writeFile).mockResolvedValue(undefined);
 
@@ -337,15 +344,15 @@ describe('openspec-manager', () => {
 			vi.mocked(fs.readFile).mockImplementation(async (filePath) => {
 				const pathStr = filePath.toString();
 				if (pathStr.includes('openspec-customizations.json')) {
-					throw new Error('ENOENT');
+					throw enoent();
 				}
 				if (pathStr.includes('openspec-prompts')) {
-					throw new Error('ENOENT');
+					throw enoent();
 				}
 				if (pathStr.endsWith('.md')) {
-					throw new Error('ENOENT');
+					throw enoent();
 				}
-				throw new Error('ENOENT');
+				throw enoent();
 			});
 
 			await expect(resetOpenSpecPrompt('nonexistent')).rejects.toThrow('Unknown openspec command');
@@ -357,15 +364,15 @@ describe('openspec-manager', () => {
 			vi.mocked(fs.readFile).mockImplementation(async (filePath) => {
 				const pathStr = filePath.toString();
 				if (pathStr.includes('openspec-customizations.json')) {
-					throw new Error('ENOENT');
+					throw enoent();
 				}
 				if (pathStr.includes('openspec-prompts')) {
-					throw new Error('ENOENT');
+					throw enoent();
 				}
 				if (pathStr.endsWith('.md')) {
 					return mockBundledPrompt;
 				}
-				throw new Error('ENOENT');
+				throw enoent();
 			});
 
 			const command = await getOpenSpecCommand('proposal');
@@ -379,15 +386,15 @@ describe('openspec-manager', () => {
 			vi.mocked(fs.readFile).mockImplementation(async (filePath) => {
 				const pathStr = filePath.toString();
 				if (pathStr.includes('openspec-customizations.json')) {
-					throw new Error('ENOENT');
+					throw enoent();
 				}
 				if (pathStr.includes('openspec-prompts')) {
-					throw new Error('ENOENT');
+					throw enoent();
 				}
 				if (pathStr.endsWith('.md')) {
 					return mockBundledPrompt;
 				}
-				throw new Error('ENOENT');
+				throw enoent();
 			});
 
 			const command = await getOpenSpecCommand('nonexistent');
@@ -401,15 +408,15 @@ describe('openspec-manager', () => {
 			vi.mocked(fs.readFile).mockImplementation(async (filePath) => {
 				const pathStr = filePath.toString();
 				if (pathStr.includes('openspec-customizations.json')) {
-					throw new Error('ENOENT');
+					throw enoent();
 				}
 				if (pathStr.includes('openspec-prompts')) {
-					throw new Error('ENOENT');
+					throw enoent();
 				}
 				if (pathStr.endsWith('.md')) {
 					return mockBundledPrompt;
 				}
-				throw new Error('ENOENT');
+				throw enoent();
 			});
 
 			const command = await getOpenSpecCommandBySlash('/openspec.proposal');
@@ -423,15 +430,15 @@ describe('openspec-manager', () => {
 			vi.mocked(fs.readFile).mockImplementation(async (filePath) => {
 				const pathStr = filePath.toString();
 				if (pathStr.includes('openspec-customizations.json')) {
-					throw new Error('ENOENT');
+					throw enoent();
 				}
 				if (pathStr.includes('openspec-prompts')) {
-					throw new Error('ENOENT');
+					throw enoent();
 				}
 				if (pathStr.endsWith('.md')) {
 					return mockBundledPrompt;
 				}
-				throw new Error('ENOENT');
+				throw enoent();
 			});
 
 			const command = await getOpenSpecCommandBySlash('/openspec.nonexistent');
@@ -447,20 +454,20 @@ describe('openspec-manager', () => {
 			vi.mocked(fs.readFile).mockImplementation(async (filePath) => {
 				const pathStr = filePath.toString();
 				if (pathStr.includes('openspec-customizations.json')) {
-					throw new Error('ENOENT');
+					throw enoent();
 				}
 				// User prompts directory (downloaded updates)
 				if (pathStr.includes('openspec-prompts') && pathStr.includes('openspec.proposal.md')) {
 					return userPromptContent;
 				}
 				if (pathStr.includes('openspec-prompts')) {
-					throw new Error('ENOENT');
+					throw enoent();
 				}
 				// Bundled prompts (fallback)
 				if (pathStr.endsWith('.md')) {
 					return mockBundledPrompt;
 				}
-				throw new Error('ENOENT');
+				throw enoent();
 			});
 
 			const commands = await getOpenSpecPrompts();
@@ -473,7 +480,7 @@ describe('openspec-manager', () => {
 			vi.mocked(fs.readFile).mockImplementation(async (filePath) => {
 				const pathStr = filePath.toString();
 				if (pathStr.includes('openspec-customizations.json')) {
-					throw new Error('ENOENT');
+					throw enoent();
 				}
 				if (pathStr.includes('openspec-prompts')) {
 					return '# Should not be used for custom commands';
@@ -481,7 +488,7 @@ describe('openspec-manager', () => {
 				if (pathStr.endsWith('.md')) {
 					return mockBundledPrompt;
 				}
-				throw new Error('ENOENT');
+				throw enoent();
 			});
 
 			const commands = await getOpenSpecPrompts();

--- a/src/main/openspec-manager.ts
+++ b/src/main/openspec-manager.ts
@@ -12,17 +12,26 @@
  * - Archive → Move completed work to archive after deployment
  *
  * Source: https://github.com/Fission-AI/OpenSpec
+ *
+ * The common load/save/reset/getBySlash logic lives in spec-command-manager.ts.
+ * This module provides the OpenSpec specific configuration and the AGENTS.md
+ * section-parsing refresh strategy.
  */
 
 import fs from 'fs/promises';
 import path from 'path';
-import { app } from 'electron';
 import { logger } from './utils/logger';
+import {
+	createSpecCommandManager,
+	SpecCommand,
+	SpecCommandDefinition,
+	SpecMetadata,
+} from './spec-command-manager';
 
 const LOG_CONTEXT = '[OpenSpec]';
 
 // All bundled OpenSpec commands with their metadata
-const OPENSPEC_COMMANDS = [
+const OPENSPEC_COMMANDS: readonly SpecCommandDefinition[] = [
 	{
 		id: 'help',
 		command: '/openspec.help',
@@ -55,258 +64,57 @@ const OPENSPEC_COMMANDS = [
 	},
 ] as const;
 
-export interface OpenSpecCommand {
-	id: string;
-	command: string;
-	description: string;
-	prompt: string;
-	isCustom: boolean;
-	isModified: boolean;
-}
+// OpenSpec specific public types are aliases over the shared shape.
+export type OpenSpecCommand = SpecCommand;
+export type OpenSpecMetadata = SpecMetadata;
 
-export interface OpenSpecMetadata {
-	lastRefreshed: string;
-	commitSha: string;
-	sourceVersion: string;
-	sourceUrl: string;
-}
-
-interface StoredPrompt {
-	content: string;
-	isModified: boolean;
-	modifiedAt?: string;
-}
-
-interface StoredData {
-	metadata: OpenSpecMetadata;
-	prompts: Record<string, StoredPrompt>;
-}
-
-/**
- * Get path to user's OpenSpec customizations file
- */
-function getUserDataPath(): string {
-	return path.join(app.getPath('userData'), 'openspec-customizations.json');
-}
-
-/**
- * Load user customizations from disk
- */
-async function loadUserCustomizations(): Promise<StoredData | null> {
-	try {
-		const content = await fs.readFile(getUserDataPath(), 'utf-8');
-		return JSON.parse(content);
-	} catch {
-		return null;
-	}
-}
-
-/**
- * Save user customizations to disk
- */
-async function saveUserCustomizations(data: StoredData): Promise<void> {
-	await fs.writeFile(getUserDataPath(), JSON.stringify(data, null, 2), 'utf-8');
-}
-
-/**
- * Get the path to bundled prompts directory
- * In development, this is src/prompts/openspec
- * In production, this is in the app resources
- */
-function getBundledPromptsPath(): string {
-	if (app.isPackaged) {
-		return path.join(process.resourcesPath, 'prompts', 'openspec');
-	}
-	// In development, use the source directory
-	return path.join(__dirname, '..', '..', 'src', 'prompts', 'openspec');
-}
-
-/**
- * Get the user data directory for storing downloaded OpenSpec prompts
- */
-function getUserPromptsPath(): string {
-	return path.join(app.getPath('userData'), 'openspec-prompts');
-}
-
-/**
- * Get bundled prompts by reading from disk
- * Checks user prompts directory first (for downloaded updates), then falls back to bundled
- */
-async function getBundledPrompts(): Promise<
-	Record<string, { prompt: string; description: string; isCustom: boolean }>
-> {
-	const bundledPromptsDir = getBundledPromptsPath();
-	const userPromptsDir = getUserPromptsPath();
-	const result: Record<string, { prompt: string; description: string; isCustom: boolean }> = {};
-
-	for (const cmd of OPENSPEC_COMMANDS) {
-		// For custom commands, always use bundled
-		if (cmd.isCustom) {
-			try {
-				const promptPath = path.join(bundledPromptsDir, `openspec.${cmd.id}.md`);
-				const prompt = await fs.readFile(promptPath, 'utf-8');
-				result[cmd.id] = {
-					prompt,
-					description: cmd.description,
-					isCustom: cmd.isCustom,
-				};
-			} catch (error) {
-				logger.warn(`Failed to load bundled prompt for ${cmd.id}: ${error}`, LOG_CONTEXT);
-				result[cmd.id] = {
-					prompt: `# ${cmd.id}\n\nPrompt not available.`,
-					description: cmd.description,
-					isCustom: cmd.isCustom,
-				};
-			}
-			continue;
-		}
-
-		// For upstream commands, check user prompts directory first (downloaded updates)
-		try {
-			const userPromptPath = path.join(userPromptsDir, `openspec.${cmd.id}.md`);
-			const prompt = await fs.readFile(userPromptPath, 'utf-8');
-			result[cmd.id] = {
-				prompt,
-				description: cmd.description,
-				isCustom: cmd.isCustom,
-			};
-			continue;
-		} catch {
-			// User prompt not found, try bundled
-		}
-
-		// Fall back to bundled prompts
-		try {
-			const promptPath = path.join(bundledPromptsDir, `openspec.${cmd.id}.md`);
-			const prompt = await fs.readFile(promptPath, 'utf-8');
-			result[cmd.id] = {
-				prompt,
-				description: cmd.description,
-				isCustom: cmd.isCustom,
-			};
-		} catch (error) {
-			logger.warn(`Failed to load bundled prompt for ${cmd.id}: ${error}`, LOG_CONTEXT);
-			result[cmd.id] = {
-				prompt: `# ${cmd.id}\n\nPrompt not available.`,
-				description: cmd.description,
-				isCustom: cmd.isCustom,
-			};
-		}
-	}
-
-	return result;
-}
-
-/**
- * Get bundled metadata by reading from disk
- * Checks user prompts directory first (for downloaded updates), then falls back to bundled
- */
-async function getBundledMetadata(): Promise<OpenSpecMetadata> {
-	const bundledPromptsDir = getBundledPromptsPath();
-	const userPromptsDir = getUserPromptsPath();
-
-	// Check user prompts directory first (downloaded updates)
-	try {
-		const userMetadataPath = path.join(userPromptsDir, 'metadata.json');
-		const content = await fs.readFile(userMetadataPath, 'utf-8');
-		return JSON.parse(content);
-	} catch {
-		// User metadata not found, try bundled
-	}
-
-	// Fall back to bundled metadata
-	try {
-		const metadataPath = path.join(bundledPromptsDir, 'metadata.json');
-		const content = await fs.readFile(metadataPath, 'utf-8');
-		return JSON.parse(content);
-	} catch {
-		// Return default metadata if file doesn't exist
-		return {
-			lastRefreshed: '2026-01-12T00:00:00Z',
-			commitSha: 'v0.19.0',
-			sourceVersion: '0.19.0',
-			sourceUrl: 'https://github.com/Fission-AI/OpenSpec',
-		};
-	}
-}
+const manager = createSpecCommandManager({
+	logContext: LOG_CONTEXT,
+	filePrefix: 'openspec',
+	bundledDirName: 'openspec',
+	customizationsFileName: 'openspec-customizations.json',
+	userPromptsDirName: 'openspec-prompts',
+	commands: OPENSPEC_COMMANDS,
+	defaultMetadata: {
+		lastRefreshed: '2026-01-12T00:00:00Z',
+		commitSha: 'v0.19.0',
+		sourceVersion: '0.19.0',
+		sourceUrl: 'https://github.com/Fission-AI/OpenSpec',
+	},
+});
 
 /**
  * Get current OpenSpec metadata
  */
-export async function getOpenSpecMetadata(): Promise<OpenSpecMetadata> {
-	const customizations = await loadUserCustomizations();
-	if (customizations?.metadata) {
-		return customizations.metadata;
-	}
-	return getBundledMetadata();
-}
+export const getOpenSpecMetadata = (): Promise<OpenSpecMetadata> => manager.getMetadata();
 
 /**
  * Get all OpenSpec prompts (bundled defaults merged with user customizations)
  */
-export async function getOpenSpecPrompts(): Promise<OpenSpecCommand[]> {
-	const bundled = await getBundledPrompts();
-	const customizations = await loadUserCustomizations();
-
-	const commands: OpenSpecCommand[] = [];
-
-	for (const [id, data] of Object.entries(bundled)) {
-		const customPrompt = customizations?.prompts?.[id];
-		const isModified = customPrompt?.isModified ?? false;
-		const prompt = isModified && customPrompt ? customPrompt.content : data.prompt;
-
-		commands.push({
-			id,
-			command: `/openspec.${id}`,
-			description: data.description,
-			prompt,
-			isCustom: data.isCustom,
-			isModified,
-		});
-	}
-
-	return commands;
-}
+export const getOpenSpecPrompts = (): Promise<OpenSpecCommand[]> => manager.getPrompts();
 
 /**
  * Save user's edit to an OpenSpec prompt
  */
-export async function saveOpenSpecPrompt(id: string, content: string): Promise<void> {
-	const customizations = (await loadUserCustomizations()) ?? {
-		metadata: await getBundledMetadata(),
-		prompts: {},
-	};
-
-	customizations.prompts[id] = {
-		content,
-		isModified: true,
-		modifiedAt: new Date().toISOString(),
-	};
-
-	await saveUserCustomizations(customizations);
-	logger.info(`Saved customization for openspec.${id}`, LOG_CONTEXT);
-}
+export const saveOpenSpecPrompt = (id: string, content: string): Promise<void> =>
+	manager.savePrompt(id, content);
 
 /**
  * Reset an OpenSpec prompt to its bundled default
  */
-export async function resetOpenSpecPrompt(id: string): Promise<string> {
-	const bundled = await getBundledPrompts();
-	const defaultPrompt = bundled[id];
+export const resetOpenSpecPrompt = (id: string): Promise<string> => manager.resetPrompt(id);
 
-	if (!defaultPrompt) {
-		throw new Error(`Unknown openspec command: ${id}`);
-	}
+/**
+ * Get a single OpenSpec command by ID
+ */
+export const getOpenSpecCommand = (id: string): Promise<OpenSpecCommand | null> =>
+	manager.getCommand(id);
 
-	const customizations = await loadUserCustomizations();
-	if (customizations?.prompts?.[id]) {
-		delete customizations.prompts[id];
-		await saveUserCustomizations(customizations);
-		logger.info(`Reset openspec.${id} to bundled default`, LOG_CONTEXT);
-	}
-
-	return defaultPrompt.prompt;
-}
+/**
+ * Get an OpenSpec command by its slash command string (e.g., "/openspec.proposal")
+ */
+export const getOpenSpecCommandBySlash = (slashCommand: string): Promise<OpenSpecCommand | null> =>
+	manager.getCommandBySlash(slashCommand);
 
 /**
  * Upstream commands to fetch (we skip custom commands like 'help' and 'implement')
@@ -409,7 +217,7 @@ export async function refreshOpenSpecPrompts(): Promise<OpenSpecMetadata> {
 	);
 
 	// Create user prompts directory
-	const userPromptsDir = getUserPromptsPath();
+	const userPromptsDir = manager.getUserPromptsPath();
 	await fs.mkdir(userPromptsDir, { recursive: true });
 
 	// Save extracted prompts
@@ -440,32 +248,14 @@ export async function refreshOpenSpecPrompts(): Promise<OpenSpecMetadata> {
 	);
 
 	// Also save to customizations file for compatibility
-	const customizations = (await loadUserCustomizations()) ?? {
+	const customizations = (await manager.loadUserCustomizations()) ?? {
 		metadata: newMetadata,
 		prompts: {},
 	};
 	customizations.metadata = newMetadata;
-	await saveUserCustomizations(customizations);
+	await manager.saveUserCustomizations(customizations);
 
 	logger.info(`Refreshed OpenSpec prompts to ${version}`, LOG_CONTEXT);
 
 	return newMetadata;
-}
-
-/**
- * Get a single OpenSpec command by ID
- */
-export async function getOpenSpecCommand(id: string): Promise<OpenSpecCommand | null> {
-	const commands = await getOpenSpecPrompts();
-	return commands.find((cmd) => cmd.id === id) ?? null;
-}
-
-/**
- * Get an OpenSpec command by its slash command string (e.g., "/openspec.proposal")
- */
-export async function getOpenSpecCommandBySlash(
-	slashCommand: string
-): Promise<OpenSpecCommand | null> {
-	const commands = await getOpenSpecPrompts();
-	return commands.find((cmd) => cmd.command === slashCommand) ?? null;
 }

--- a/src/main/openspec-manager.ts
+++ b/src/main/openspec-manager.ts
@@ -34,31 +34,26 @@ const LOG_CONTEXT = '[OpenSpec]';
 const OPENSPEC_COMMANDS: readonly SpecCommandDefinition[] = [
 	{
 		id: 'help',
-		command: '/openspec.help',
 		description: 'Learn how to use OpenSpec with Maestro',
 		isCustom: true,
 	},
 	{
 		id: 'proposal',
-		command: '/openspec.proposal',
 		description: 'Create a change proposal with specs, tasks, and optional design docs',
 		isCustom: false,
 	},
 	{
 		id: 'apply',
-		command: '/openspec.apply',
 		description: 'Implement an approved change proposal by executing tasks',
 		isCustom: false,
 	},
 	{
 		id: 'archive',
-		command: '/openspec.archive',
 		description: 'Archive a completed change after deployment',
 		isCustom: false,
 	},
 	{
 		id: 'implement',
-		command: '/openspec.implement',
 		description: 'Convert OpenSpec tasks to Maestro Auto Run documents',
 		isCustom: true,
 	},

--- a/src/main/spec-command-manager.ts
+++ b/src/main/spec-command-manager.ts
@@ -1,0 +1,313 @@
+/**
+ * Spec Command Manager (Shared Base)
+ *
+ * Shared implementation for managing bundled command prompts with support for:
+ * - Loading bundled prompts from src/prompts/{specDir}/
+ * - Checking user prompts directory first (downloaded updates), then bundled fallback
+ * - User customization with ability to reset to defaults
+ * - Refresh hook for fetching latest prompts from an upstream source
+ *
+ * Used by both the SpecKit and OpenSpec managers. Each wrapper provides its own
+ * config (command list, file paths, source URL, refresh strategy) and this module
+ * implements the common logic.
+ */
+
+import fs from 'fs/promises';
+import path from 'path';
+import { app } from 'electron';
+import { logger } from './utils/logger';
+
+export interface SpecCommandDefinition {
+	id: string;
+	command: string;
+	description: string;
+	isCustom: boolean;
+}
+
+export interface SpecCommand {
+	id: string;
+	command: string;
+	description: string;
+	prompt: string;
+	isCustom: boolean;
+	isModified: boolean;
+}
+
+export interface SpecMetadata {
+	lastRefreshed: string;
+	commitSha: string;
+	sourceVersion: string;
+	sourceUrl: string;
+}
+
+interface StoredPrompt {
+	content: string;
+	isModified: boolean;
+	modifiedAt?: string;
+}
+
+interface StoredData {
+	metadata: SpecMetadata;
+	prompts: Record<string, StoredPrompt>;
+}
+
+/**
+ * Configuration for a spec command manager instance.
+ * Provides the per-source values that differentiate SpecKit from OpenSpec.
+ */
+export interface SpecCommandManagerConfig {
+	/** Log context prefix, e.g. '[SpecKit]' or '[OpenSpec]'. */
+	logContext: string;
+	/**
+	 * Prefix used in filenames and slash commands (e.g. 'speckit' or 'openspec').
+	 * Prompt files are named `${filePrefix}.${id}.md`. Slash commands are `/${filePrefix}.${id}`.
+	 */
+	filePrefix: string;
+	/** Subdirectory name under src/prompts/ and process.resourcesPath/prompts/. */
+	bundledDirName: string;
+	/** Filename for the user customizations JSON file in userData. */
+	customizationsFileName: string;
+	/** Directory name for the user prompts directory (downloaded updates) in userData. */
+	userPromptsDirName: string;
+	/** The set of commands supported by this manager. */
+	commands: readonly SpecCommandDefinition[];
+	/** Default metadata returned if neither user nor bundled metadata files exist. */
+	defaultMetadata: SpecMetadata;
+}
+
+/**
+ * Public API surface returned by createSpecCommandManager().
+ */
+export interface SpecCommandManager {
+	getMetadata(): Promise<SpecMetadata>;
+	getPrompts(): Promise<SpecCommand[]>;
+	savePrompt(id: string, content: string): Promise<void>;
+	resetPrompt(id: string): Promise<string>;
+	getCommand(id: string): Promise<SpecCommand | null>;
+	getCommandBySlash(slashCommand: string): Promise<SpecCommand | null>;
+	/** Helpers used by refresh implementations. */
+	getUserPromptsPath(): string;
+	loadUserCustomizations(): Promise<StoredData | null>;
+	saveUserCustomizations(data: StoredData): Promise<void>;
+	getBundledMetadata(): Promise<SpecMetadata>;
+}
+
+/**
+ * Factory that creates a spec command manager bound to the given config.
+ */
+export function createSpecCommandManager(config: SpecCommandManagerConfig): SpecCommandManager {
+	const {
+		logContext,
+		filePrefix,
+		bundledDirName,
+		customizationsFileName,
+		userPromptsDirName,
+		commands,
+		defaultMetadata,
+	} = config;
+
+	function getUserDataPath(): string {
+		return path.join(app.getPath('userData'), customizationsFileName);
+	}
+
+	async function loadUserCustomizations(): Promise<StoredData | null> {
+		try {
+			const content = await fs.readFile(getUserDataPath(), 'utf-8');
+			return JSON.parse(content);
+		} catch {
+			return null;
+		}
+	}
+
+	async function saveUserCustomizations(data: StoredData): Promise<void> {
+		await fs.writeFile(getUserDataPath(), JSON.stringify(data, null, 2), 'utf-8');
+	}
+
+	function getBundledPromptsPath(): string {
+		if (app.isPackaged) {
+			return path.join(process.resourcesPath, 'prompts', bundledDirName);
+		}
+		return path.join(__dirname, '..', '..', 'src', 'prompts', bundledDirName);
+	}
+
+	function getUserPromptsPath(): string {
+		return path.join(app.getPath('userData'), userPromptsDirName);
+	}
+
+	async function getBundledPrompts(): Promise<
+		Record<string, { prompt: string; description: string; isCustom: boolean }>
+	> {
+		const bundledPromptsDir = getBundledPromptsPath();
+		const userPromptsDir = getUserPromptsPath();
+		const result: Record<string, { prompt: string; description: string; isCustom: boolean }> = {};
+
+		for (const cmd of commands) {
+			// For custom commands, always use bundled
+			if (cmd.isCustom) {
+				try {
+					const promptPath = path.join(bundledPromptsDir, `${filePrefix}.${cmd.id}.md`);
+					const prompt = await fs.readFile(promptPath, 'utf-8');
+					result[cmd.id] = {
+						prompt,
+						description: cmd.description,
+						isCustom: cmd.isCustom,
+					};
+				} catch (error) {
+					logger.warn(`Failed to load bundled prompt for ${cmd.id}: ${error}`, logContext);
+					result[cmd.id] = {
+						prompt: `# ${cmd.id}\n\nPrompt not available.`,
+						description: cmd.description,
+						isCustom: cmd.isCustom,
+					};
+				}
+				continue;
+			}
+
+			// For upstream commands, check user prompts directory first (downloaded updates)
+			try {
+				const userPromptPath = path.join(userPromptsDir, `${filePrefix}.${cmd.id}.md`);
+				const prompt = await fs.readFile(userPromptPath, 'utf-8');
+				result[cmd.id] = {
+					prompt,
+					description: cmd.description,
+					isCustom: cmd.isCustom,
+				};
+				continue;
+			} catch {
+				// User prompt not found, try bundled
+			}
+
+			// Fall back to bundled prompts
+			try {
+				const promptPath = path.join(bundledPromptsDir, `${filePrefix}.${cmd.id}.md`);
+				const prompt = await fs.readFile(promptPath, 'utf-8');
+				result[cmd.id] = {
+					prompt,
+					description: cmd.description,
+					isCustom: cmd.isCustom,
+				};
+			} catch (error) {
+				logger.warn(`Failed to load bundled prompt for ${cmd.id}: ${error}`, logContext);
+				result[cmd.id] = {
+					prompt: `# ${cmd.id}\n\nPrompt not available.`,
+					description: cmd.description,
+					isCustom: cmd.isCustom,
+				};
+			}
+		}
+
+		return result;
+	}
+
+	async function getBundledMetadata(): Promise<SpecMetadata> {
+		const bundledPromptsDir = getBundledPromptsPath();
+		const userPromptsDir = getUserPromptsPath();
+
+		// Check user prompts directory first (downloaded updates)
+		try {
+			const userMetadataPath = path.join(userPromptsDir, 'metadata.json');
+			const content = await fs.readFile(userMetadataPath, 'utf-8');
+			return JSON.parse(content);
+		} catch {
+			// User metadata not found, try bundled
+		}
+
+		// Fall back to bundled metadata
+		try {
+			const metadataPath = path.join(bundledPromptsDir, 'metadata.json');
+			const content = await fs.readFile(metadataPath, 'utf-8');
+			return JSON.parse(content);
+		} catch {
+			return { ...defaultMetadata };
+		}
+	}
+
+	async function getMetadata(): Promise<SpecMetadata> {
+		const customizations = await loadUserCustomizations();
+		if (customizations?.metadata) {
+			return customizations.metadata;
+		}
+		return getBundledMetadata();
+	}
+
+	async function getPrompts(): Promise<SpecCommand[]> {
+		const bundled = await getBundledPrompts();
+		const customizations = await loadUserCustomizations();
+
+		const result: SpecCommand[] = [];
+
+		for (const [id, data] of Object.entries(bundled)) {
+			const customPrompt = customizations?.prompts?.[id];
+			const isModified = customPrompt?.isModified ?? false;
+			const prompt = isModified && customPrompt ? customPrompt.content : data.prompt;
+
+			result.push({
+				id,
+				command: `/${filePrefix}.${id}`,
+				description: data.description,
+				prompt,
+				isCustom: data.isCustom,
+				isModified,
+			});
+		}
+
+		return result;
+	}
+
+	async function savePrompt(id: string, content: string): Promise<void> {
+		const customizations = (await loadUserCustomizations()) ?? {
+			metadata: await getBundledMetadata(),
+			prompts: {},
+		};
+
+		customizations.prompts[id] = {
+			content,
+			isModified: true,
+			modifiedAt: new Date().toISOString(),
+		};
+
+		await saveUserCustomizations(customizations);
+		logger.info(`Saved customization for ${filePrefix}.${id}`, logContext);
+	}
+
+	async function resetPrompt(id: string): Promise<string> {
+		const bundled = await getBundledPrompts();
+		const defaultPrompt = bundled[id];
+
+		if (!defaultPrompt) {
+			throw new Error(`Unknown ${filePrefix} command: ${id}`);
+		}
+
+		const customizations = await loadUserCustomizations();
+		if (customizations?.prompts?.[id]) {
+			delete customizations.prompts[id];
+			await saveUserCustomizations(customizations);
+			logger.info(`Reset ${filePrefix}.${id} to bundled default`, logContext);
+		}
+
+		return defaultPrompt.prompt;
+	}
+
+	async function getCommand(id: string): Promise<SpecCommand | null> {
+		const all = await getPrompts();
+		return all.find((cmd) => cmd.id === id) ?? null;
+	}
+
+	async function getCommandBySlash(slashCommand: string): Promise<SpecCommand | null> {
+		const all = await getPrompts();
+		return all.find((cmd) => cmd.command === slashCommand) ?? null;
+	}
+
+	return {
+		getMetadata,
+		getPrompts,
+		savePrompt,
+		resetPrompt,
+		getCommand,
+		getCommandBySlash,
+		getUserPromptsPath,
+		loadUserCustomizations,
+		saveUserCustomizations,
+		getBundledMetadata,
+	};
+}

--- a/src/main/spec-command-manager.ts
+++ b/src/main/spec-command-manager.ts
@@ -19,7 +19,6 @@ import { logger } from './utils/logger';
 
 export interface SpecCommandDefinition {
 	id: string;
-	command: string;
 	description: string;
 	isCustom: boolean;
 }
@@ -40,13 +39,13 @@ export interface SpecMetadata {
 	sourceUrl: string;
 }
 
-interface StoredPrompt {
+export interface StoredPrompt {
 	content: string;
 	isModified: boolean;
 	modifiedAt?: string;
 }
 
-interface StoredData {
+export interface StoredData {
 	metadata: SpecMetadata;
 	prompts: Record<string, StoredPrompt>;
 }
@@ -114,7 +113,8 @@ export function createSpecCommandManager(config: SpecCommandManagerConfig): Spec
 		try {
 			const content = await fs.readFile(getUserDataPath(), 'utf-8');
 			return JSON.parse(content);
-		} catch {
+		} catch (error: unknown) {
+			if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
 			return null;
 		}
 	}
@@ -173,7 +173,8 @@ export function createSpecCommandManager(config: SpecCommandManagerConfig): Spec
 					isCustom: cmd.isCustom,
 				};
 				continue;
-			} catch {
+			} catch (error: unknown) {
+				if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
 				// User prompt not found, try bundled
 			}
 
@@ -208,7 +209,8 @@ export function createSpecCommandManager(config: SpecCommandManagerConfig): Spec
 			const userMetadataPath = path.join(userPromptsDir, 'metadata.json');
 			const content = await fs.readFile(userMetadataPath, 'utf-8');
 			return JSON.parse(content);
-		} catch {
+		} catch (error: unknown) {
+			if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
 			// User metadata not found, try bundled
 		}
 
@@ -217,7 +219,8 @@ export function createSpecCommandManager(config: SpecCommandManagerConfig): Spec
 			const metadataPath = path.join(bundledPromptsDir, 'metadata.json');
 			const content = await fs.readFile(metadataPath, 'utf-8');
 			return JSON.parse(content);
-		} catch {
+		} catch (error: unknown) {
+			if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
 			return { ...defaultMetadata };
 		}
 	}

--- a/src/main/speckit-manager.ts
+++ b/src/main/speckit-manager.ts
@@ -5,6 +5,10 @@
  * - Loading bundled prompts from src/prompts/speckit/
  * - Fetching updates from GitHub's spec-kit repository
  * - User customization with ability to reset to defaults
+ *
+ * The common load/save/reset/getBySlash logic lives in spec-command-manager.ts.
+ * This module provides the SpecKit specific configuration and the GitHub release
+ * ZIP refresh strategy.
  */
 
 import fs from 'fs/promises';
@@ -15,13 +19,19 @@ import https from 'https';
 import { exec } from 'child_process';
 import { promisify } from 'util';
 import { logger } from './utils/logger';
+import {
+	createSpecCommandManager,
+	SpecCommand,
+	SpecCommandDefinition,
+	SpecMetadata,
+} from './spec-command-manager';
 
 const execAsync = promisify(exec);
 
 const LOG_CONTEXT = '[SpecKit]';
 
 // All bundled spec-kit commands with their metadata
-const SPECKIT_COMMANDS = [
+const SPECKIT_COMMANDS: readonly SpecCommandDefinition[] = [
 	{
 		id: 'help',
 		command: '/speckit.help',
@@ -84,258 +94,57 @@ const SPECKIT_COMMANDS = [
 	},
 ] as const;
 
-export interface SpecKitCommand {
-	id: string;
-	command: string;
-	description: string;
-	prompt: string;
-	isCustom: boolean;
-	isModified: boolean;
-}
+// SpecKit specific public types are aliases over the shared shape.
+export type SpecKitCommand = SpecCommand;
+export type SpecKitMetadata = SpecMetadata;
 
-export interface SpecKitMetadata {
-	lastRefreshed: string;
-	commitSha: string;
-	sourceVersion: string;
-	sourceUrl: string;
-}
-
-interface StoredPrompt {
-	content: string;
-	isModified: boolean;
-	modifiedAt?: string;
-}
-
-interface StoredData {
-	metadata: SpecKitMetadata;
-	prompts: Record<string, StoredPrompt>;
-}
-
-/**
- * Get path to user's speckit customizations file
- */
-function getUserDataPath(): string {
-	return path.join(app.getPath('userData'), 'speckit-customizations.json');
-}
-
-/**
- * Load user customizations from disk
- */
-async function loadUserCustomizations(): Promise<StoredData | null> {
-	try {
-		const content = await fs.readFile(getUserDataPath(), 'utf-8');
-		return JSON.parse(content);
-	} catch {
-		return null;
-	}
-}
-
-/**
- * Save user customizations to disk
- */
-async function saveUserCustomizations(data: StoredData): Promise<void> {
-	await fs.writeFile(getUserDataPath(), JSON.stringify(data, null, 2), 'utf-8');
-}
-
-/**
- * Get the path to bundled prompts directory
- * In development, this is src/prompts/speckit
- * In production, this is in the app resources
- */
-function getBundledPromptsPath(): string {
-	if (app.isPackaged) {
-		return path.join(process.resourcesPath, 'prompts', 'speckit');
-	}
-	// In development, use the source directory
-	return path.join(__dirname, '..', '..', 'src', 'prompts', 'speckit');
-}
-
-/**
- * Get the user data directory for storing downloaded spec-kit prompts
- */
-function getUserPromptsPath(): string {
-	return path.join(app.getPath('userData'), 'speckit-prompts');
-}
-
-/**
- * Get bundled prompts by reading from disk
- * Checks user prompts directory first (for downloaded updates), then falls back to bundled
- */
-async function getBundledPrompts(): Promise<
-	Record<string, { prompt: string; description: string; isCustom: boolean }>
-> {
-	const bundledPromptsDir = getBundledPromptsPath();
-	const userPromptsDir = getUserPromptsPath();
-	const result: Record<string, { prompt: string; description: string; isCustom: boolean }> = {};
-
-	for (const cmd of SPECKIT_COMMANDS) {
-		// For custom commands, always use bundled
-		if (cmd.isCustom) {
-			try {
-				const promptPath = path.join(bundledPromptsDir, `speckit.${cmd.id}.md`);
-				const prompt = await fs.readFile(promptPath, 'utf-8');
-				result[cmd.id] = {
-					prompt,
-					description: cmd.description,
-					isCustom: cmd.isCustom,
-				};
-			} catch (error) {
-				logger.warn(`Failed to load bundled prompt for ${cmd.id}: ${error}`, LOG_CONTEXT);
-				result[cmd.id] = {
-					prompt: `# ${cmd.id}\n\nPrompt not available.`,
-					description: cmd.description,
-					isCustom: cmd.isCustom,
-				};
-			}
-			continue;
-		}
-
-		// For upstream commands, check user prompts directory first (downloaded updates)
-		try {
-			const userPromptPath = path.join(userPromptsDir, `speckit.${cmd.id}.md`);
-			const prompt = await fs.readFile(userPromptPath, 'utf-8');
-			result[cmd.id] = {
-				prompt,
-				description: cmd.description,
-				isCustom: cmd.isCustom,
-			};
-			continue;
-		} catch {
-			// User prompt not found, try bundled
-		}
-
-		// Fall back to bundled prompts
-		try {
-			const promptPath = path.join(bundledPromptsDir, `speckit.${cmd.id}.md`);
-			const prompt = await fs.readFile(promptPath, 'utf-8');
-			result[cmd.id] = {
-				prompt,
-				description: cmd.description,
-				isCustom: cmd.isCustom,
-			};
-		} catch (error) {
-			logger.warn(`Failed to load bundled prompt for ${cmd.id}: ${error}`, LOG_CONTEXT);
-			result[cmd.id] = {
-				prompt: `# ${cmd.id}\n\nPrompt not available.`,
-				description: cmd.description,
-				isCustom: cmd.isCustom,
-			};
-		}
-	}
-
-	return result;
-}
-
-/**
- * Get bundled metadata by reading from disk
- * Checks user prompts directory first (for downloaded updates), then falls back to bundled
- */
-async function getBundledMetadata(): Promise<SpecKitMetadata> {
-	const bundledPromptsDir = getBundledPromptsPath();
-	const userPromptsDir = getUserPromptsPath();
-
-	// Check user prompts directory first (downloaded updates)
-	try {
-		const userMetadataPath = path.join(userPromptsDir, 'metadata.json');
-		const content = await fs.readFile(userMetadataPath, 'utf-8');
-		return JSON.parse(content);
-	} catch {
-		// User metadata not found, try bundled
-	}
-
-	// Fall back to bundled metadata
-	try {
-		const metadataPath = path.join(bundledPromptsDir, 'metadata.json');
-		const content = await fs.readFile(metadataPath, 'utf-8');
-		return JSON.parse(content);
-	} catch {
-		// Return default metadata if file doesn't exist
-		return {
-			lastRefreshed: '2024-01-01T00:00:00Z',
-			commitSha: 'bundled',
-			sourceVersion: '0.0.90',
-			sourceUrl: 'https://github.com/github/spec-kit',
-		};
-	}
-}
+const manager = createSpecCommandManager({
+	logContext: LOG_CONTEXT,
+	filePrefix: 'speckit',
+	bundledDirName: 'speckit',
+	customizationsFileName: 'speckit-customizations.json',
+	userPromptsDirName: 'speckit-prompts',
+	commands: SPECKIT_COMMANDS,
+	defaultMetadata: {
+		lastRefreshed: '2024-01-01T00:00:00Z',
+		commitSha: 'bundled',
+		sourceVersion: '0.0.90',
+		sourceUrl: 'https://github.com/github/spec-kit',
+	},
+});
 
 /**
  * Get current spec-kit metadata
  */
-export async function getSpeckitMetadata(): Promise<SpecKitMetadata> {
-	const customizations = await loadUserCustomizations();
-	if (customizations?.metadata) {
-		return customizations.metadata;
-	}
-	return getBundledMetadata();
-}
+export const getSpeckitMetadata = (): Promise<SpecKitMetadata> => manager.getMetadata();
 
 /**
  * Get all spec-kit prompts (bundled defaults merged with user customizations)
  */
-export async function getSpeckitPrompts(): Promise<SpecKitCommand[]> {
-	const bundled = await getBundledPrompts();
-	const customizations = await loadUserCustomizations();
-
-	const commands: SpecKitCommand[] = [];
-
-	for (const [id, data] of Object.entries(bundled)) {
-		const customPrompt = customizations?.prompts?.[id];
-		const isModified = customPrompt?.isModified ?? false;
-		const prompt = isModified && customPrompt ? customPrompt.content : data.prompt;
-
-		commands.push({
-			id,
-			command: `/speckit.${id}`,
-			description: data.description,
-			prompt,
-			isCustom: data.isCustom,
-			isModified,
-		});
-	}
-
-	return commands;
-}
+export const getSpeckitPrompts = (): Promise<SpecKitCommand[]> => manager.getPrompts();
 
 /**
  * Save user's edit to a spec-kit prompt
  */
-export async function saveSpeckitPrompt(id: string, content: string): Promise<void> {
-	const customizations = (await loadUserCustomizations()) ?? {
-		metadata: await getBundledMetadata(),
-		prompts: {},
-	};
-
-	customizations.prompts[id] = {
-		content,
-		isModified: true,
-		modifiedAt: new Date().toISOString(),
-	};
-
-	await saveUserCustomizations(customizations);
-	logger.info(`Saved customization for speckit.${id}`, LOG_CONTEXT);
-}
+export const saveSpeckitPrompt = (id: string, content: string): Promise<void> =>
+	manager.savePrompt(id, content);
 
 /**
  * Reset a spec-kit prompt to its bundled default
  */
-export async function resetSpeckitPrompt(id: string): Promise<string> {
-	const bundled = await getBundledPrompts();
-	const defaultPrompt = bundled[id];
+export const resetSpeckitPrompt = (id: string): Promise<string> => manager.resetPrompt(id);
 
-	if (!defaultPrompt) {
-		throw new Error(`Unknown speckit command: ${id}`);
-	}
+/**
+ * Get a single spec-kit command by ID
+ */
+export const getSpeckitCommand = (id: string): Promise<SpecKitCommand | null> =>
+	manager.getCommand(id);
 
-	const customizations = await loadUserCustomizations();
-	if (customizations?.prompts?.[id]) {
-		delete customizations.prompts[id];
-		await saveUserCustomizations(customizations);
-		logger.info(`Reset speckit.${id} to bundled default`, LOG_CONTEXT);
-	}
-
-	return defaultPrompt.prompt;
-}
+/**
+ * Get a spec-kit command by its slash command string (e.g., "/speckit.constitution")
+ */
+export const getSpeckitCommandBySlash = (slashCommand: string): Promise<SpecKitCommand | null> =>
+	manager.getCommandBySlash(slashCommand);
 
 /**
  * Download a file from a URL using https
@@ -445,11 +254,10 @@ export async function refreshSpeckitPrompts(): Promise<SpecKitMetadata> {
 		}
 
 		// Create user prompts directory
-		const userPromptsDir = getUserPromptsPath();
+		const userPromptsDir = manager.getUserPromptsPath();
 		await fs.mkdir(userPromptsDir, { recursive: true });
 
 		// Extract and save each prompt
-		const extractedPrompts: Record<string, string> = {};
 		for (const filePath of promptFiles) {
 			const fileName = path.basename(filePath, '.md');
 			// Skip files not in our upstream list
@@ -464,7 +272,6 @@ export async function refreshSpeckitPrompts(): Promise<SpecKitMetadata> {
 			const extractedPath = path.join(tempExtractDir, path.basename(filePath));
 			try {
 				const content = await fs.readFile(extractedPath, 'utf8');
-				extractedPrompts[fileName] = content;
 
 				// Save to user prompts directory
 				const destPath = path.join(userPromptsDir, `speckit.${fileName}.md`);
@@ -491,12 +298,12 @@ export async function refreshSpeckitPrompts(): Promise<SpecKitMetadata> {
 		);
 
 		// Also save to customizations file for compatibility
-		const customizations = (await loadUserCustomizations()) ?? {
+		const customizations = (await manager.loadUserCustomizations()) ?? {
 			metadata: newMetadata,
 			prompts: {},
 		};
 		customizations.metadata = newMetadata;
-		await saveUserCustomizations(customizations);
+		await manager.saveUserCustomizations(customizations);
 
 		logger.info(`Refreshed spec-kit prompts to ${version}`, LOG_CONTEXT);
 
@@ -509,22 +316,4 @@ export async function refreshSpeckitPrompts(): Promise<SpecKitMetadata> {
 			// Ignore cleanup errors
 		}
 	}
-}
-
-/**
- * Get a single spec-kit command by ID
- */
-export async function getSpeckitCommand(id: string): Promise<SpecKitCommand | null> {
-	const commands = await getSpeckitPrompts();
-	return commands.find((cmd) => cmd.id === id) ?? null;
-}
-
-/**
- * Get a spec-kit command by its slash command string (e.g., "/speckit.constitution")
- */
-export async function getSpeckitCommandBySlash(
-	slashCommand: string
-): Promise<SpecKitCommand | null> {
-	const commands = await getSpeckitPrompts();
-	return commands.find((cmd) => cmd.command === slashCommand) ?? null;
 }

--- a/src/main/speckit-manager.ts
+++ b/src/main/speckit-manager.ts
@@ -34,61 +34,51 @@ const LOG_CONTEXT = '[SpecKit]';
 const SPECKIT_COMMANDS: readonly SpecCommandDefinition[] = [
 	{
 		id: 'help',
-		command: '/speckit.help',
 		description: 'Learn how to use spec-kit with Maestro',
 		isCustom: true,
 	},
 	{
 		id: 'constitution',
-		command: '/speckit.constitution',
 		description: 'Create or update the project constitution',
 		isCustom: false,
 	},
 	{
 		id: 'specify',
-		command: '/speckit.specify',
 		description: 'Create or update feature specification',
 		isCustom: false,
 	},
 	{
 		id: 'clarify',
-		command: '/speckit.clarify',
 		description: 'Identify underspecified areas and ask clarification questions',
 		isCustom: false,
 	},
 	{
 		id: 'plan',
-		command: '/speckit.plan',
 		description: 'Execute implementation planning workflow',
 		isCustom: false,
 	},
 	{
 		id: 'tasks',
-		command: '/speckit.tasks',
 		description: 'Generate actionable, dependency-ordered tasks',
 		isCustom: false,
 	},
 	{
 		id: 'analyze',
-		command: '/speckit.analyze',
 		description: 'Cross-artifact consistency and quality analysis',
 		isCustom: false,
 	},
 	{
 		id: 'checklist',
-		command: '/speckit.checklist',
 		description: 'Generate custom checklist for feature',
 		isCustom: false,
 	},
 	{
 		id: 'taskstoissues',
-		command: '/speckit.taskstoissues',
 		description: 'Convert tasks to GitHub issues',
 		isCustom: false,
 	},
 	{
 		id: 'implement',
-		command: '/speckit.implement',
 		description: 'Execute tasks using Maestro Auto Run with worktree support',
 		isCustom: true,
 	},


### PR DESCRIPTION
## Summary

Extracts shared command management logic from `speckit-manager.ts` and `openspec-manager.ts` into a new `src/main/spec-command-manager.ts` factory. Both managers now delegate common operations (prompt CRUD, customization tracking, metadata caching) to the shared base while keeping their phase-specific refresh strategies.

**Net: -108 lines across 3 files (1003 -> 895)**

### Shared base

New: `src/main/spec-command-manager.ts` (313 lines)
- Factory `createSpecCommandManager(config)` returning `{ getMetadata, getPrompts, getCommand, getCommandBySlash, savePrompt, resetPrompt }`
- Types: `SpecCommand`, `SpecMetadata`, `SpecCommandDefinition`
- Handles on-disk customization tracking, default vs. modified state, slash command lookup

### Refactored managers

- `src/main/speckit-manager.ts`: 531 -> 319 lines. Keeps SpecKit-specific **GitHub release ZIP + unzip** refresh strategy for pulling commands from the spec-kit repo.
- `src/main/openspec-manager.ts`: 472 -> 261 lines. Keeps OpenSpec-specific **AGENTS.md section-parsing** refresh strategy for pulling commands from the openspec repo.

All public exports (`SpecKitCommand`, `OpenSpecCommand`, `getSpeckitMetadata`, `getOpenSpecMetadata`, etc.) are preserved so existing consumers keep working with zero changes.

## IPC handlers preserved unchanged

Verified all 12 handlers still registered with identical channel names:

- `speckit:getMetadata`, `speckit:getPrompts`, `speckit:getCommand`, `speckit:savePrompt`, `speckit:resetPrompt`, `speckit:refresh`
- `openspec:getMetadata`, `openspec:getPrompts`, `openspec:getCommand`, `openspec:savePrompt`, `openspec:resetPrompt`, `openspec:refresh`

IPC handler files (`src/main/ipc/handlers/speckit.ts`, `openspec.ts`) were intentionally NOT unified - they already delegate to their managers, and unifying them would require a generic handler factory that adds boilerplate without meaningful savings, at the cost of making the external IPC channel registration harder to read.

## Test plan

- [x] `npm run lint` passes clean (all 3 tsconfigs)
- [x] All SpecKit + OpenSpec tests pass (30 tests across openspec-manager and openspec IPC handlers)
- [x] SpecKit command picker loads prompts correctly
- [x] OpenSpec command picker loads prompts correctly
- [x] Customize a SpecKit prompt, verify it saves to `.speckit/` and `modified` flag updates
- [x] Customize an OpenSpec prompt, verify it saves to `.openspec/` and `modified` flag updates
- [x] Reset a customized prompt in both
- [x] Refresh from GitHub in both (pulls latest release)

## Risk

**Medium**. Both managers' refresh strategies (GitHub ZIP vs. AGENTS.md parsing) are preserved as-is; only CRUD + metadata caching was lifted. Existing integration tests (30 pass) cover the delegation paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated command/prompt management into a shared manager for consistent behavior across command sets.
  * Unified public APIs to delegate to the shared manager, improving bundled prompt resolution, user customization persistence, reset-to-default, and slash-command lookups.
* **Tests**
  * Improved tests to more accurately simulate missing-file (ENOENT) filesystem behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
