### PR TITLE
refactor: extract shared UI components (Phase 08)

### DIFF
--- a/src/__tests__/renderer/components/ui/EmptyStatePlaceholder.test.tsx
+++ b/src/__tests__/renderer/components/ui/EmptyStatePlaceholder.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * Tests for EmptyStatePlaceholder component
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { EmptyStatePlaceholder } from '../../../../renderer/components/ui/EmptyStatePlaceholder';
+import type { Theme } from '../../../../renderer/types';
+
+const mockTheme: Theme = {
+	id: 'test-theme',
+	name: 'Test Theme',
+	mode: 'dark',
+	colors: {
+		bgMain: '#1a1a1a',
+		bgSidebar: '#242424',
+		bgActivity: '#2a2a2a',
+		textMain: '#ffffff',
+		textDim: '#888888',
+		accent: '#3b82f6',
+		accentForeground: '#ffffff',
+		border: '#333333',
+		error: '#ef4444',
+		success: '#22c55e',
+		warning: '#f59e0b',
+		cursor: '#ffffff',
+		terminalBg: '#1a1a1a',
+	},
+};
+
+describe('EmptyStatePlaceholder', () => {
+	it('renders title only', () => {
+		render(<EmptyStatePlaceholder theme={mockTheme} title="No items" />);
+		expect(screen.getByText('No items')).toBeInTheDocument();
+	});
+
+	it('renders icon when provided', () => {
+		render(
+			<EmptyStatePlaceholder theme={mockTheme} title="No items" icon={<svg data-testid="icon" />} />
+		);
+		expect(screen.getByTestId('icon')).toBeInTheDocument();
+	});
+
+	it('renders description when provided', () => {
+		render(
+			<EmptyStatePlaceholder
+				theme={mockTheme}
+				title="Empty"
+				description="Try adjusting your filters"
+			/>
+		);
+		expect(screen.getByText('Try adjusting your filters')).toBeInTheDocument();
+	});
+
+	it('renders action when provided', () => {
+		render(
+			<EmptyStatePlaceholder theme={mockTheme} title="Empty" action={<button>Clear</button>} />
+		);
+		expect(screen.getByRole('button', { name: 'Clear' })).toBeInTheDocument();
+	});
+});

--- a/src/__tests__/renderer/components/ui/GhostIconButton.test.tsx
+++ b/src/__tests__/renderer/components/ui/GhostIconButton.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * Tests for GhostIconButton component
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { GhostIconButton } from '../../../../renderer/components/ui/GhostIconButton';
+
+describe('GhostIconButton', () => {
+	it('renders children and default classes', () => {
+		render(
+			<GhostIconButton ariaLabel="Close">
+				<span data-testid="icon">x</span>
+			</GhostIconButton>
+		);
+		const btn = screen.getByRole('button', { name: 'Close' });
+		expect(btn).toBeInTheDocument();
+		expect(btn).toHaveClass('rounded');
+		expect(btn).toHaveClass('hover:bg-white/10');
+		expect(btn).toHaveClass('p-1');
+		expect(screen.getByTestId('icon')).toBeInTheDocument();
+	});
+
+	it('calls onClick when clicked', () => {
+		const onClick = vi.fn();
+		render(
+			<GhostIconButton onClick={onClick} ariaLabel="Do it">
+				<span>x</span>
+			</GhostIconButton>
+		);
+		fireEvent.click(screen.getByRole('button', { name: 'Do it' }));
+		expect(onClick).toHaveBeenCalledTimes(1);
+	});
+
+	it('respects disabled prop', () => {
+		const onClick = vi.fn();
+		render(
+			<GhostIconButton onClick={onClick} disabled ariaLabel="Disabled">
+				<span>x</span>
+			</GhostIconButton>
+		);
+		const btn = screen.getByRole('button', { name: 'Disabled' });
+		expect(btn).toBeDisabled();
+		fireEvent.click(btn);
+		expect(onClick).not.toHaveBeenCalled();
+	});
+
+	it('applies custom padding', () => {
+		render(
+			<GhostIconButton padding="p-2" ariaLabel="Pad">
+				<span>x</span>
+			</GhostIconButton>
+		);
+		expect(screen.getByRole('button', { name: 'Pad' })).toHaveClass('p-2');
+	});
+
+	it('stops propagation when stopPropagation is true', () => {
+		const parentClick = vi.fn();
+		const onClick = vi.fn();
+		render(
+			<div onClick={parentClick}>
+				<GhostIconButton onClick={onClick} stopPropagation ariaLabel="Stop">
+					<span>x</span>
+				</GhostIconButton>
+			</div>
+		);
+		fireEvent.click(screen.getByRole('button', { name: 'Stop' }));
+		expect(onClick).toHaveBeenCalledTimes(1);
+		expect(parentClick).not.toHaveBeenCalled();
+	});
+});

--- a/src/__tests__/renderer/components/ui/Spinner.test.tsx
+++ b/src/__tests__/renderer/components/ui/Spinner.test.tsx
@@ -1,0 +1,36 @@
+/**
+ * Tests for Spinner component
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Spinner } from '../../../../renderer/components/ui/Spinner';
+
+describe('Spinner', () => {
+	it('renders with default size', () => {
+		render(<Spinner />);
+		const icon = screen.getByTestId('loader2-icon');
+		expect(icon).toBeInTheDocument();
+		expect(icon).toHaveClass('animate-spin');
+		expect(icon).toHaveStyle({ width: '16px', height: '16px' });
+	});
+
+	it('applies custom size', () => {
+		render(<Spinner size={32} />);
+		const icon = screen.getByTestId('loader2-icon');
+		expect(icon).toHaveStyle({ width: '32px', height: '32px' });
+	});
+
+	it('applies custom color', () => {
+		render(<Spinner color="rgb(255, 0, 0)" />);
+		const icon = screen.getByTestId('loader2-icon');
+		expect(icon).toHaveStyle({ color: 'rgb(255, 0, 0)' });
+	});
+
+	it('merges custom className', () => {
+		render(<Spinner className="text-blue-500" />);
+		const icon = screen.getByTestId('loader2-icon');
+		expect(icon).toHaveClass('animate-spin');
+		expect(icon).toHaveClass('text-blue-500');
+	});
+});

--- a/src/renderer/components/AboutModal.tsx
+++ b/src/renderer/components/AboutModal.tsx
@@ -5,12 +5,13 @@ import {
 	ExternalLink,
 	FileCode,
 	BarChart3,
-	Loader2,
 	Trophy,
 	Globe,
 	Check,
 	BookOpen,
 } from 'lucide-react';
+import { Spinner } from './ui/Spinner';
+import { GhostIconButton } from './ui/GhostIconButton';
 import type { Theme, AutoRunStats, MaestroUsageStats, LeaderboardRegistration } from '../types';
 import type { GlobalAgentStats } from '../../shared/types';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
@@ -126,48 +127,36 @@ export function AboutModal({
 				<h2 className="text-sm font-bold" style={{ color: theme.colors.textMain }}>
 					About Maestro
 				</h2>
-				<button
-					type="button"
+				<GhostIconButton
 					onClick={() => openUrl(buildMaestroUrl('https://runmaestro.ai'))}
-					className="p-1 rounded hover:bg-white/10 transition-colors"
 					title="Visit runmaestro.ai"
-					aria-label="Visit runmaestro.ai"
-					style={{ color: theme.colors.accent }}
+					ariaLabel="Visit runmaestro.ai"
+					color={theme.colors.accent}
 				>
 					<Globe className="w-4 h-4" />
-				</button>
-				<button
-					type="button"
+				</GhostIconButton>
+				<GhostIconButton
 					onClick={() => openUrl(buildMaestroUrl('https://runmaestro.ai/discord'))}
-					className="p-1 rounded hover:bg-white/10 transition-colors"
 					title="Join our Discord"
-					aria-label="Join our Discord"
-					style={{ color: theme.colors.accent }}
+					ariaLabel="Join our Discord"
+					color={theme.colors.accent}
 				>
 					<svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
 						<path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z" />
 					</svg>
-				</button>
-				<button
-					type="button"
+				</GhostIconButton>
+				<GhostIconButton
 					onClick={() => openUrl(buildMaestroUrl('https://docs.runmaestro.ai/'))}
-					className="p-1 rounded hover:bg-white/10 transition-colors"
 					title="Documentation"
-					aria-label="Documentation"
-					style={{ color: theme.colors.accent }}
+					ariaLabel="Documentation"
+					color={theme.colors.accent}
 				>
 					<BookOpen className="w-4 h-4" />
-				</button>
+				</GhostIconButton>
 			</div>
-			<button
-				type="button"
-				onClick={onClose}
-				className="p-1 rounded hover:bg-white/10 transition-colors"
-				style={{ color: theme.colors.textDim }}
-				aria-label="Close modal"
-			>
+			<GhostIconButton onClick={onClose} color={theme.colors.textDim} ariaLabel="Close modal">
 				<X className="w-4 h-4" />
-			</button>
+			</GhostIconButton>
 		</div>
 	);
 
@@ -227,13 +216,11 @@ export function AboutModal({
 						<span className="text-sm font-bold" style={{ color: theme.colors.textMain }}>
 							Global Statistics
 						</span>
-						{!isStatsComplete && (
-							<Loader2 className="w-3 h-3 animate-spin" style={{ color: theme.colors.textDim }} />
-						)}
+						{!isStatsComplete && <Spinner size={12} color={theme.colors.textDim} />}
 					</div>
 					{loading ? (
 						<div className="flex items-center justify-center py-4 gap-2">
-							<Loader2 className="w-4 h-4 animate-spin" style={{ color: theme.colors.textDim }} />
+							<Spinner size={16} color={theme.colors.textDim} />
 							<span className="text-xs" style={{ color: theme.colors.textDim }}>
 								Loading stats...
 							</span>

--- a/src/renderer/components/AgentCreationDialog.tsx
+++ b/src/renderer/components/AgentCreationDialog.tsx
@@ -13,16 +13,9 @@
 
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { createPortal } from 'react-dom';
-import {
-	Music,
-	X,
-	Loader2,
-	Bot,
-	Settings,
-	FolderOpen,
-	ChevronRight,
-	RefreshCw,
-} from 'lucide-react';
+import { Music, X, Bot, Settings, FolderOpen, ChevronRight, RefreshCw } from 'lucide-react';
+import { GhostIconButton } from './ui/GhostIconButton';
+import { Spinner } from './ui/Spinner';
 import type { Theme, AgentConfig } from '../types';
 import type { RegisteredRepository, SymphonyIssue } from '../../shared/symphony-types';
 import { useLayerStack } from '../contexts/LayerStackContext';
@@ -337,13 +330,9 @@ export function AgentCreationDialog({
 							Create Symphony Agent
 						</h2>
 					</div>
-					<button
-						onClick={onClose}
-						className="p-1.5 rounded hover:bg-white/10 transition-colors"
-						title="Close (Esc)"
-					>
+					<GhostIconButton onClick={onClose} padding="p-1.5" title="Close (Esc)">
 						<X className="w-4 h-4" style={{ color: theme.colors.textDim }} />
-					</button>
+					</GhostIconButton>
 				</div>
 
 				{/* Content - scrollable */}
@@ -377,7 +366,7 @@ export function AgentCreationDialog({
 
 						{ac.isDetecting ? (
 							<div className="flex items-center justify-center py-8">
-								<Loader2 className="w-6 h-6 animate-spin" style={{ color: theme.colors.accent }} />
+								<Spinner size={24} color={theme.colors.accent} />
 							</div>
 						) : ac.detectedAgents.length === 0 ? (
 							<div className="text-center py-4" style={{ color: theme.colors.textDim }}>
@@ -446,19 +435,18 @@ export function AgentCreationDialog({
 													>
 														Available
 													</span>
-													<button
+													<GhostIconButton
 														onClick={(e) => {
 															e.stopPropagation();
 															handleRefreshAgent(agent.id);
 														}}
-														className="p-1 rounded hover:bg-white/10 transition-colors"
 														title="Refresh detection"
-														style={{ color: theme.colors.textDim }}
+														color={theme.colors.textDim}
 													>
 														<RefreshCw
 															className={`w-3 h-3 ${refreshingAgent === agent.id ? 'animate-spin' : ''}`}
 														/>
-													</button>
+													</GhostIconButton>
 												</div>
 											</div>
 
@@ -647,7 +635,7 @@ export function AgentCreationDialog({
 					>
 						{isCreating ? (
 							<>
-								<Loader2 className="w-4 h-4 animate-spin" />
+								<Spinner size={16} />
 								Creating...
 							</>
 						) : (

--- a/src/renderer/components/AgentPromptComposerModal.tsx
+++ b/src/renderer/components/AgentPromptComposerModal.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { X, FileText, Variable, ChevronDown, ChevronRight } from 'lucide-react';
+import { GhostIconButton } from './ui/GhostIconButton';
 import type { Theme } from '../types';
 import { useLayerStack } from '../contexts/LayerStackContext';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
@@ -151,13 +152,9 @@ export function AgentPromptComposerModal({
 						</span>
 					</div>
 					<div className="flex items-center gap-3">
-						<button
-							onClick={handleDone}
-							className="p-1.5 rounded hover:bg-white/10 transition-colors"
-							title="Close (Escape)"
-						>
+						<GhostIconButton onClick={handleDone} padding="p-1.5" title="Close (Escape)">
 							<X className="w-5 h-5" style={{ color: theme.colors.textDim }} />
-						</button>
+						</GhostIconButton>
 					</div>
 				</div>
 

--- a/src/renderer/components/AgentSessionsBrowser.tsx
+++ b/src/renderer/components/AgentSessionsBrowser.tsx
@@ -25,6 +25,9 @@ import {
 	ArrowUpFromLine,
 	Edit3,
 } from 'lucide-react';
+import { GhostIconButton } from './ui/GhostIconButton';
+import { Spinner } from './ui/Spinner';
+import { EmptyStatePlaceholder } from './ui/EmptyStatePlaceholder';
 import type { Theme, Session, LogEntry, UsageStats } from '../types';
 import { useLayerStack } from '../contexts/LayerStackContext';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
@@ -726,17 +729,17 @@ export function AgentSessionsBrowser({
 				<div className="flex items-center gap-4">
 					{viewingSession ? (
 						<>
-							<button
+							<GhostIconButton
 								onClick={clearViewingSession}
-								className="p-1.5 rounded hover:bg-white/10 transition-colors"
-								style={{ color: theme.colors.textDim }}
+								padding="p-1.5"
+								color={theme.colors.textDim}
 							>
 								<ChevronLeft className="w-5 h-5" />
-							</button>
+							</GhostIconButton>
 							{/* Star button for detail view */}
-							<button
+							<GhostIconButton
 								onClick={(e) => toggleStar(viewingSession.sessionId, e)}
-								className="p-1.5 rounded hover:bg-white/10 transition-colors"
+								padding="p-1.5"
 								title={
 									starredSessions.has(viewingSession.sessionId)
 										? 'Remove from favorites'
@@ -754,7 +757,7 @@ export function AgentSessionsBrowser({
 											: 'transparent',
 									}}
 								/>
-							</button>
+							</GhostIconButton>
 							<div className="flex flex-col min-w-0">
 								{/* Session name with edit button */}
 								{renamingSessionId === viewingSession.sessionId ? (
@@ -792,18 +795,18 @@ export function AgentSessionsBrowser({
 										>
 											{viewingSession.sessionName}
 										</span>
-										<button
+										<GhostIconButton
 											onClick={(e) => {
 												e.stopPropagation();
 												setRenamingSessionId(viewingSession.sessionId);
 												setRenameValue(viewingSession.sessionName || '');
 												setTimeout(() => renameInputRef.current?.focus(), 50);
 											}}
-											className="p-0.5 rounded hover:bg-white/10 transition-colors"
+											padding="p-0.5"
 											title="Rename session"
 										>
 											<Edit3 className="w-3 h-3" style={{ color: theme.colors.accent }} />
-										</button>
+										</GhostIconButton>
 									</div>
 								) : (
 									<div className="flex items-center gap-1.5">
@@ -814,18 +817,18 @@ export function AgentSessionsBrowser({
 										>
 											{viewingSession.sessionId.toUpperCase()}
 										</span>
-										<button
+										<GhostIconButton
 											onClick={(e) => {
 												e.stopPropagation();
 												setRenamingSessionId(viewingSession.sessionId);
 												setRenameValue('');
 												setTimeout(() => renameInputRef.current?.focus(), 50);
 											}}
-											className="p-0.5 rounded hover:bg-white/10 transition-colors"
+											padding="p-0.5"
 											title="Add session name"
 										>
 											<Edit3 className="w-3 h-3" style={{ color: theme.colors.textDim }} />
-										</button>
+										</GhostIconButton>
 									</div>
 								)}
 								{/* Show UUID underneath the custom name */}
@@ -1181,7 +1184,7 @@ export function AgentSessionsBrowser({
 
 						{messagesLoading && messages.length === 0 && (
 							<div className="flex items-center justify-center py-8">
-								<Loader2 className="w-6 h-6 animate-spin" style={{ color: theme.colors.textDim }} />
+								<Spinner size={24} color={theme.colors.textDim} />
 							</div>
 						)}
 					</div>
@@ -1324,12 +1327,7 @@ export function AgentSessionsBrowser({
 												}
 											}}
 										/>
-										{isSearching && (
-											<Loader2
-												className="w-4 h-4 animate-spin"
-												style={{ color: theme.colors.textDim }}
-											/>
-										)}
+										{isSearching && <Spinner size={16} color={theme.colors.textDim} />}
 										{search && !isSearching && (
 											<button
 												onClick={() => handleSearchChange('')}
@@ -1473,20 +1471,18 @@ export function AgentSessionsBrowser({
 					>
 						{loading ? (
 							<div className="flex items-center justify-center py-12">
-								<Loader2 className="w-6 h-6 animate-spin" style={{ color: theme.colors.textDim }} />
+								<Spinner size={24} color={theme.colors.textDim} />
 							</div>
 						) : filteredSessions.length === 0 ? (
-							<div className="flex flex-col items-center justify-center py-12 px-4">
-								<List
-									className="w-12 h-12 mb-4 opacity-30"
-									style={{ color: theme.colors.textDim }}
-								/>
-								<p className="text-sm text-center" style={{ color: theme.colors.textDim }}>
-									{sessions.length === 0
+							<EmptyStatePlaceholder
+								theme={theme}
+								icon={<List className="w-12 h-12" />}
+								title={
+									sessions.length === 0
 										? `No ${agentId === 'claude-code' ? 'Claude' : 'agent'} sessions found for this project`
-										: 'No sessions match your search'}
-								</p>
-							</div>
+										: 'No sessions match your search'
+								}
+							/>
 						) : (
 							<div className="py-2">
 								{filteredSessions.map((session, i) => (
@@ -1518,10 +1514,7 @@ export function AgentSessionsBrowser({
 									<div className="py-4 flex justify-center items-center">
 										{isLoadingMoreSessions ? (
 											<div className="flex items-center gap-2">
-												<Loader2
-													className="w-4 h-4 animate-spin"
-													style={{ color: theme.colors.accent }}
-												/>
+												<Spinner size={16} color={theme.colors.accent} />
 												<span className="text-xs" style={{ color: theme.colors.textDim }}>
 													Loading more sessions...
 												</span>

--- a/src/renderer/components/AgentSessionsBrowser.tsx
+++ b/src/renderer/components/AgentSessionsBrowser.tsx
@@ -733,6 +733,7 @@ export function AgentSessionsBrowser({
 								onClick={clearViewingSession}
 								padding="p-1.5"
 								color={theme.colors.textDim}
+								ariaLabel="Go back"
 							>
 								<ChevronLeft className="w-5 h-5" />
 							</GhostIconButton>

--- a/src/renderer/components/AgentSessionsModal.tsx
+++ b/src/renderer/components/AgentSessionsModal.tsx
@@ -1,0 +1,688 @@
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+import {
+	Search,
+	Clock,
+	MessageSquare,
+	HardDrive,
+	Play,
+	ChevronLeft,
+	Loader2,
+	Star,
+} from 'lucide-react';
+import { GhostIconButton } from './ui/GhostIconButton';
+import { Spinner } from './ui/Spinner';
+import { EmptyStatePlaceholder } from './ui/EmptyStatePlaceholder';
+import type { Theme, Session } from '../types';
+import { useLayerStack } from '../contexts/LayerStackContext';
+import { useListNavigation } from '../hooks';
+import { MODAL_PRIORITIES } from '../constants/modalPriorities';
+import { formatSize, formatRelativeTime } from '../utils/formatters';
+import { ToolCallCard } from './ToolCallCard';
+
+interface AgentSession {
+	sessionId: string;
+	projectPath: string;
+	timestamp: string;
+	modifiedAt: string;
+	firstMessage: string;
+	messageCount: number;
+	sizeBytes: number;
+	sessionName?: string; // Named session from Maestro
+	starred?: boolean; // Starred status from Maestro
+}
+
+interface SessionMessage {
+	type: string;
+	role?: string;
+	content: string;
+	timestamp: string;
+	uuid: string;
+	toolUse?: any;
+}
+
+interface AgentSessionsModalProps {
+	theme: Theme;
+	activeSession: Session | undefined;
+	onClose: () => void;
+	onResumeSession: (agentSessionId: string) => void;
+}
+
+export function AgentSessionsModal({
+	theme,
+	activeSession,
+	onClose,
+	onResumeSession,
+}: AgentSessionsModalProps) {
+	// Get agentId from the active session's toolType
+	const agentId = activeSession?.toolType || 'claude-code';
+	const [sessions, setSessions] = useState<AgentSession[]>([]);
+	const [loading, setLoading] = useState(true);
+	const [search, setSearch] = useState('');
+	const [viewingSession, setViewingSession] = useState<AgentSession | null>(null);
+	const [messages, setMessages] = useState<SessionMessage[]>([]);
+	const [messagesLoading, setMessagesLoading] = useState(false);
+	const [hasMoreMessages, setHasMoreMessages] = useState(false);
+	const [totalMessages, setTotalMessages] = useState(0);
+	const [messagesOffset, setMessagesOffset] = useState(0);
+	const [starredSessions, setStarredSessions] = useState<Set<string>>(new Set());
+
+	// Pagination state for sessions list
+	const [hasMoreSessions, setHasMoreSessions] = useState(false);
+	const [isLoadingMoreSessions, setIsLoadingMoreSessions] = useState(false);
+	const [totalSessionCount, setTotalSessionCount] = useState(0);
+	const nextCursorRef = useRef<string | null>(null);
+
+	const inputRef = useRef<HTMLInputElement>(null);
+	const selectedItemRef = useRef<HTMLButtonElement>(null);
+	const messagesContainerRef = useRef<HTMLDivElement>(null);
+	const sessionsContainerRef = useRef<HTMLDivElement>(null);
+	const layerIdRef = useRef<string>();
+	const onCloseRef = useRef(onClose);
+	onCloseRef.current = onClose;
+
+	const { registerLayer, unregisterLayer, updateLayerHandler } = useLayerStack();
+
+	// Register layer on mount
+	useEffect(() => {
+		layerIdRef.current = registerLayer({
+			type: 'modal',
+			priority: MODAL_PRIORITIES.AGENT_SESSIONS,
+			blocksLowerLayers: true,
+			capturesFocus: true,
+			focusTrap: 'strict',
+			ariaLabel: 'Agent Sessions',
+			onEscape: () => {
+				if (viewingSession) {
+					setViewingSession(null);
+					setMessages([]);
+				} else {
+					onCloseRef.current();
+				}
+			},
+		});
+
+		return () => {
+			if (layerIdRef.current) {
+				unregisterLayer(layerIdRef.current);
+			}
+		};
+	}, [registerLayer, unregisterLayer]);
+
+	// Update handler when viewingSession changes
+	useEffect(() => {
+		if (layerIdRef.current) {
+			updateLayerHandler(layerIdRef.current, () => {
+				if (viewingSession) {
+					setViewingSession(null);
+					setMessages([]);
+				} else {
+					onCloseRef.current();
+				}
+			});
+		}
+	}, [viewingSession, updateLayerHandler]);
+
+	// Load sessions on mount and reset to list view
+	useEffect(() => {
+		// Always reset to list view when modal opens
+		setViewingSession(null);
+		setMessages([]);
+		setMessagesOffset(0);
+		setSessions([]);
+		setHasMoreSessions(false);
+		setTotalSessionCount(0);
+		nextCursorRef.current = null;
+
+		const loadSessions = async () => {
+			if (!activeSession?.cwd) {
+				console.log('AgentSessionsModal: No activeSession.cwd');
+				setLoading(false);
+				return;
+			}
+
+			const agentId = activeSession.toolType || 'claude-code';
+			// Use projectRoot (not cwd) for consistent session storage access
+			const projectPath = activeSession.projectRoot;
+			console.log(
+				'AgentSessionsModal: Loading sessions for projectPath:',
+				projectPath,
+				'agentId:',
+				agentId
+			);
+			try {
+				// Load starred sessions from session origins (shared with AgentSessionsBrowser)
+				const starredFromOrigins = new Set<string>();
+				if (agentId === 'claude-code') {
+					// Claude Code uses its own origins store
+					const origins = await window.maestro.claude.getSessionOrigins(projectPath);
+					for (const [sessionId, originData] of Object.entries(origins)) {
+						if (typeof originData === 'object' && originData?.starred) {
+							starredFromOrigins.add(sessionId);
+						}
+					}
+				} else {
+					// Other agents use the generic origins store
+					const origins = await window.maestro.agentSessions.getOrigins(agentId, projectPath);
+					for (const [sessionId, originData] of Object.entries(origins)) {
+						if (originData?.starred) {
+							starredFromOrigins.add(sessionId);
+						}
+					}
+				}
+				setStarredSessions(starredFromOrigins);
+
+				// Use generic agentSessions API for session listing
+				const result = await window.maestro.agentSessions.listPaginated(agentId, projectPath, {
+					limit: 100,
+				});
+				console.log(
+					'AgentSessionsModal: Got sessions:',
+					result.sessions.length,
+					'of',
+					result.totalCount
+				);
+				setSessions(result.sessions);
+				setHasMoreSessions(result.hasMore);
+				setTotalSessionCount(result.totalCount);
+				nextCursorRef.current = result.nextCursor;
+			} catch (error) {
+				console.error('Failed to load sessions:', error);
+			} finally {
+				setLoading(false);
+			}
+		};
+
+		loadSessions();
+	}, [activeSession?.projectRoot, activeSession?.toolType]);
+
+	// Load more sessions when scrolling near bottom
+	const loadMoreSessions = useCallback(async () => {
+		// Use projectRoot (not cwd) for consistent session storage access
+		if (
+			!activeSession?.projectRoot ||
+			!hasMoreSessions ||
+			isLoadingMoreSessions ||
+			!nextCursorRef.current
+		)
+			return;
+
+		const agentId = activeSession.toolType || 'claude-code';
+		setIsLoadingMoreSessions(true);
+		try {
+			const result = await window.maestro.agentSessions.listPaginated(
+				agentId,
+				activeSession.projectRoot,
+				{
+					cursor: nextCursorRef.current,
+					limit: 100,
+				}
+			);
+
+			// Append new sessions, avoiding duplicates
+			setSessions((prev) => {
+				const existingIds = new Set(prev.map((s) => s.sessionId));
+				const newSessions = result.sessions.filter((s) => !existingIds.has(s.sessionId));
+				return [...prev, ...newSessions];
+			});
+			setHasMoreSessions(result.hasMore);
+			nextCursorRef.current = result.nextCursor;
+		} catch (error) {
+			console.error('Failed to load more sessions:', error);
+		} finally {
+			setIsLoadingMoreSessions(false);
+		}
+	}, [activeSession?.projectRoot, activeSession?.toolType, hasMoreSessions, isLoadingMoreSessions]);
+
+	// Handle scroll for sessions list pagination - load more at 70% scroll
+	const handleSessionsScroll = useCallback(() => {
+		const container = sessionsContainerRef.current;
+		if (!container) return;
+
+		const { scrollTop, scrollHeight, clientHeight } = container;
+		const scrollPercentage = (scrollTop + clientHeight) / scrollHeight;
+		const atSeventyPercent = scrollPercentage >= 0.7;
+
+		if (atSeventyPercent && hasMoreSessions && !isLoadingMoreSessions) {
+			loadMoreSessions();
+		}
+	}, [hasMoreSessions, isLoadingMoreSessions, loadMoreSessions]);
+
+	// Toggle star status for a session
+	const toggleStar = useCallback(
+		async (sessionId: string, e: React.MouseEvent) => {
+			e.stopPropagation(); // Don't trigger session view
+
+			const newStarred = new Set(starredSessions);
+			const isNowStarred = !newStarred.has(sessionId);
+			if (isNowStarred) {
+				newStarred.add(sessionId);
+			} else {
+				newStarred.delete(sessionId);
+			}
+			setStarredSessions(newStarred);
+
+			// Persist to session origins (shared with AgentSessionsBrowser)
+			// Use projectRoot (not cwd) for consistent session storage access
+			if (activeSession?.projectRoot) {
+				if (agentId === 'claude-code') {
+					// Claude Code uses its own origins store
+					await window.maestro.claude.updateSessionStarred(
+						activeSession.projectRoot,
+						sessionId,
+						isNowStarred
+					);
+				} else {
+					// Other agents use the generic origins store
+					await window.maestro.agentSessions.setSessionStarred(
+						agentId,
+						activeSession.projectRoot,
+						sessionId,
+						isNowStarred
+					);
+				}
+			}
+		},
+		[starredSessions, activeSession?.projectRoot, agentId]
+	);
+
+	// Focus input on mount
+	useEffect(() => {
+		const timer = setTimeout(() => inputRef.current?.focus(), 50);
+		return () => clearTimeout(timer);
+	}, []);
+
+	// Load messages when viewing a session
+	const loadMessages = useCallback(
+		async (session: AgentSession, offset: number = 0) => {
+			if (!activeSession?.cwd) return;
+
+			const agentId = activeSession.toolType || 'claude-code';
+			setMessagesLoading(true);
+			try {
+				const result = await window.maestro.agentSessions.read(
+					agentId,
+					activeSession.cwd,
+					session.sessionId,
+					{ offset, limit: 20 }
+				);
+
+				if (offset === 0) {
+					setMessages(result.messages);
+				} else {
+					// Prepend older messages
+					setMessages((prev) => [...result.messages, ...prev]);
+				}
+				setTotalMessages(result.total);
+				setHasMoreMessages(result.hasMore);
+				setMessagesOffset(offset + result.messages.length);
+			} catch (error) {
+				console.error('Failed to load messages:', error);
+			} finally {
+				setMessagesLoading(false);
+			}
+		},
+		[activeSession?.cwd, activeSession?.toolType]
+	);
+
+	// Handle viewing a session
+	const handleViewSession = useCallback(
+		(session: AgentSession) => {
+			setViewingSession(session);
+			setMessages([]);
+			setMessagesOffset(0);
+			loadMessages(session, 0);
+		},
+		[loadMessages]
+	);
+
+	// Handle loading more messages (scroll to top)
+	const handleLoadMore = useCallback(() => {
+		if (viewingSession && hasMoreMessages && !messagesLoading) {
+			loadMessages(viewingSession, messagesOffset);
+		}
+	}, [viewingSession, hasMoreMessages, messagesLoading, messagesOffset, loadMessages]);
+
+	// Handle scroll for lazy loading
+	const handleMessagesScroll = useCallback(() => {
+		const container = messagesContainerRef.current;
+		if (!container) return;
+
+		// Load more when scrolled near top
+		if (container.scrollTop < 100 && hasMoreMessages && !messagesLoading) {
+			const prevScrollHeight = container.scrollHeight;
+			handleLoadMore();
+
+			// Maintain scroll position after loading
+			requestAnimationFrame(() => {
+				if (container) {
+					container.scrollTop = container.scrollHeight - prevScrollHeight;
+				}
+			});
+		}
+	}, [hasMoreMessages, messagesLoading, handleLoadMore]);
+
+	// Filter sessions by search and sort starred to top
+	const filteredSessions = sessions
+		.filter(
+			(s) =>
+				s.sessionName?.toLowerCase().includes(search.toLowerCase()) ||
+				s.firstMessage.toLowerCase().includes(search.toLowerCase()) ||
+				s.sessionId.toLowerCase().includes(search.toLowerCase())
+		)
+		.sort((a, b) => {
+			const aStarred = starredSessions.has(a.sessionId);
+			const bStarred = starredSessions.has(b.sessionId);
+			if (aStarred && !bStarred) return -1;
+			if (!aStarred && bStarred) return 1;
+			// Within same starred status, sort by most recent
+			return new Date(b.modifiedAt).getTime() - new Date(a.modifiedAt).getTime();
+		});
+
+	// Handle selection by index - opens session view
+	const handleSelectByIndex = useCallback(
+		(index: number) => {
+			const selected = filteredSessions[index];
+			if (selected) {
+				handleViewSession(selected);
+			}
+		},
+		[filteredSessions, handleViewSession]
+	);
+
+	// Keyboard navigation using useListNavigation hook
+	const {
+		selectedIndex,
+		handleKeyDown: listHandleKeyDown,
+		resetSelection,
+	} = useListNavigation({
+		listLength: filteredSessions.length,
+		onSelect: handleSelectByIndex,
+		enabled: !viewingSession, // Disable navigation when viewing session messages
+	});
+
+	// Scroll selected item into view
+	useEffect(() => {
+		selectedItemRef.current?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+	}, [selectedIndex]);
+
+	// Reset selection when search changes
+	useEffect(() => {
+		resetSelection();
+	}, [search, resetSelection]);
+
+	// Wrap keyboard handler to pass through to search input
+	const handleKeyDown = useCallback(
+		(e: React.KeyboardEvent) => {
+			// Let the hook handle navigation
+			listHandleKeyDown(e);
+		},
+		[listHandleKeyDown]
+	);
+
+	// Handle resume session
+	const handleResume = useCallback(() => {
+		if (viewingSession) {
+			onResumeSession(viewingSession.sessionId);
+			onClose();
+		}
+	}, [viewingSession, onResumeSession, onClose]);
+
+	// formatSize and formatRelativeTime imported from ../utils/formatters
+
+	return (
+		<div className="fixed inset-0 modal-overlay flex items-start justify-center pt-24 z-[9999] animate-in fade-in duration-100">
+			<div
+				role="dialog"
+				aria-modal="true"
+				aria-label="Agent Sessions"
+				tabIndex={-1}
+				className="w-[700px] rounded-xl shadow-2xl border overflow-hidden flex flex-col max-h-[600px] outline-none"
+				style={{ backgroundColor: theme.colors.bgActivity, borderColor: theme.colors.border }}
+			>
+				{/* Header */}
+				<div
+					className="p-4 border-b flex items-center gap-3"
+					style={{ borderColor: theme.colors.border }}
+				>
+					{viewingSession ? (
+						<>
+							<GhostIconButton
+								onClick={() => {
+									setViewingSession(null);
+									setMessages([]);
+								}}
+								color={theme.colors.textDim}
+							>
+								<ChevronLeft className="w-5 h-5" />
+							</GhostIconButton>
+							<div className="flex-1 min-w-0">
+								<div
+									className="text-sm font-medium truncate"
+									style={{ color: theme.colors.textMain }}
+								>
+									{viewingSession.sessionName || viewingSession.firstMessage || 'Session Preview'}
+								</div>
+								<div className="text-xs" style={{ color: theme.colors.textDim }}>
+									{totalMessages} messages • {formatRelativeTime(viewingSession.modifiedAt)}
+								</div>
+							</div>
+							<button
+								onClick={handleResume}
+								className="flex items-center gap-2 px-3 py-1.5 rounded-lg text-sm font-medium transition-colors"
+								style={{
+									backgroundColor: theme.colors.accent,
+									color: theme.colors.accentForeground,
+								}}
+							>
+								<Play className="w-4 h-4" />
+								Resume
+							</button>
+						</>
+					) : (
+						<>
+							<Search className="w-5 h-5" style={{ color: theme.colors.textDim }} />
+							<input
+								ref={inputRef}
+								className="flex-1 bg-transparent outline-none text-lg placeholder-opacity-50"
+								placeholder={`Search ${activeSession?.name || 'agent'} sessions...`}
+								style={{ color: theme.colors.textMain }}
+								value={search}
+								onChange={(e) => setSearch(e.target.value)}
+								onKeyDown={handleKeyDown}
+							/>
+							<div
+								className="px-2 py-0.5 rounded text-xs font-bold"
+								style={{ backgroundColor: theme.colors.bgMain, color: theme.colors.textDim }}
+							>
+								ESC
+							</div>
+						</>
+					)}
+				</div>
+
+				{/* Content */}
+				{viewingSession ? (
+					<div
+						ref={messagesContainerRef}
+						className="flex-1 overflow-y-auto p-4 space-y-4 scrollbar-thin"
+						onScroll={handleMessagesScroll}
+					>
+						{/* Load more indicator */}
+						{hasMoreMessages && (
+							<div className="text-center py-2">
+								{messagesLoading ? (
+									<Loader2
+										className="w-5 h-5 animate-spin mx-auto"
+										style={{ color: theme.colors.textDim }}
+									/>
+								) : (
+									<button
+										onClick={handleLoadMore}
+										className="text-sm hover:underline"
+										style={{ color: theme.colors.accent }}
+									>
+										Load earlier messages...
+									</button>
+								)}
+							</div>
+						)}
+
+						{/* Messages */}
+						{messages.map((msg, idx) => (
+							<div
+								key={msg.uuid || idx}
+								className={`flex ${msg.type === 'user' ? 'justify-end' : 'justify-start'}`}
+							>
+								{/* Tool call messages - render with ToolCallCard */}
+								{msg.toolUse && msg.toolUse.length > 0 ? (
+									<div className="max-w-[85%]">
+										<ToolCallCard
+											theme={theme}
+											toolUse={msg.toolUse}
+											timestamp={formatRelativeTime(msg.timestamp)}
+											defaultExpanded={false}
+										/>
+									</div>
+								) : (
+									/* Regular text messages */
+									<div
+										className="max-w-[85%] rounded-lg px-4 py-2 text-sm"
+										style={{
+											backgroundColor:
+												msg.type === 'user' ? theme.colors.accent : theme.colors.bgMain,
+											color:
+												msg.type === 'user'
+													? theme.mode === 'light'
+														? '#fff'
+														: '#000'
+													: theme.colors.textMain,
+										}}
+									>
+										<div className="whitespace-pre-wrap break-words">
+											{msg.content || '[No content]'}
+										</div>
+										<div
+											className="text-[10px] mt-1 opacity-60"
+											style={{
+												color:
+													msg.type === 'user'
+														? theme.mode === 'light'
+															? '#fff'
+															: '#000'
+														: theme.colors.textDim,
+											}}
+										>
+											{formatRelativeTime(msg.timestamp)}
+										</div>
+									</div>
+								)}
+							</div>
+						))}
+
+						{messagesLoading && messages.length === 0 && (
+							<div className="flex items-center justify-center py-8">
+								<Spinner size={24} color={theme.colors.textDim} />
+							</div>
+						)}
+					</div>
+				) : (
+					<div
+						ref={sessionsContainerRef}
+						className="overflow-y-auto py-2 flex-1 scrollbar-thin"
+						onScroll={handleSessionsScroll}
+					>
+						{loading ? (
+							<div className="flex items-center justify-center py-8">
+								<Spinner size={24} color={theme.colors.textDim} />
+							</div>
+						) : filteredSessions.length === 0 ? (
+							<EmptyStatePlaceholder
+								theme={theme}
+								title={
+									sessions.length === 0
+										? 'No Claude sessions found for this project'
+										: 'No sessions match your search'
+								}
+								verticalPadding="py-8"
+							/>
+						) : (
+							<>
+								{filteredSessions.map((session, i) => {
+									const isStarred = starredSessions.has(session.sessionId);
+									return (
+										<button
+											key={session.sessionId}
+											ref={i === selectedIndex ? selectedItemRef : null}
+											onClick={() => handleViewSession(session)}
+											className="w-full text-left px-4 py-3 flex items-start gap-3 hover:bg-opacity-10 transition-colors group"
+											style={{
+												backgroundColor: i === selectedIndex ? theme.colors.accent : 'transparent',
+												color: theme.colors.textMain,
+											}}
+										>
+											{/* Star button */}
+											<button
+												onClick={(e) => toggleStar(session.sessionId, e)}
+												className="p-1 -ml-1 rounded hover:bg-white/10 transition-colors shrink-0"
+												title={isStarred ? 'Remove from favorites' : 'Add to favorites'}
+											>
+												<Star
+													className="w-4 h-4"
+													style={{
+														color: isStarred ? theme.colors.warning : theme.colors.textDim,
+														fill: isStarred ? theme.colors.warning : 'transparent',
+													}}
+												/>
+											</button>
+											<div className="flex-1 min-w-0">
+												<div className="font-medium truncate text-sm">
+													{session.sessionName ||
+														session.firstMessage ||
+														`Session ${session.sessionId.slice(0, 8)}...`}
+												</div>
+												<div
+													className="flex items-center gap-3 mt-1 text-xs"
+													style={{ color: theme.colors.textDim }}
+												>
+													<span className="flex items-center gap-1">
+														<Clock className="w-3 h-3" />
+														{formatRelativeTime(session.modifiedAt)}
+													</span>
+													<span className="flex items-center gap-1">
+														<MessageSquare className="w-3 h-3" />
+														{session.messageCount} msgs
+													</span>
+													<span className="flex items-center gap-1">
+														<HardDrive className="w-3 h-3" />
+														{formatSize(session.sizeBytes)}
+													</span>
+												</div>
+											</div>
+										</button>
+									);
+								})}
+								{/* Pagination indicator */}
+								{(isLoadingMoreSessions || hasMoreSessions) && !search && (
+									<div className="py-3 flex justify-center items-center">
+										{isLoadingMoreSessions ? (
+											<div className="flex items-center gap-2">
+												<Spinner size={16} color={theme.colors.accent} />
+												<span className="text-xs" style={{ color: theme.colors.textDim }}>
+													Loading more sessions...
+												</span>
+											</div>
+										) : (
+											<span className="text-[10px]" style={{ color: theme.colors.textDim }}>
+												{sessions.length} of {totalSessionCount} sessions loaded
+											</span>
+										)}
+									</div>
+								)}
+							</>
+						)}
+					</div>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/src/renderer/components/AgentSessionsModal.tsx
+++ b/src/renderer/components/AgentSessionsModal.tsx
@@ -452,6 +452,7 @@ export function AgentSessionsModal({
 									setMessages([]);
 								}}
 								color={theme.colors.textDim}
+								ariaLabel="Go back"
 							>
 								<ChevronLeft className="w-5 h-5" />
 							</GhostIconButton>
@@ -600,7 +601,7 @@ export function AgentSessionsModal({
 								theme={theme}
 								title={
 									sessions.length === 0
-										? 'No Claude sessions found for this project'
+										? 'No sessions found for this project'
 										: 'No sessions match your search'
 								}
 								verticalPadding="py-8"

--- a/src/renderer/components/AutoRun/AttachmentImage.tsx
+++ b/src/renderer/components/AutoRun/AttachmentImage.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect, useMemo, memo } from 'react';
-import { Loader2, Image, X, Search } from 'lucide-react';
+import { Image, X, Search } from 'lucide-react';
+import { Spinner } from '../ui/Spinner';
 import { imageCache } from '../../hooks';
 import type { Theme } from '../../types';
 
@@ -213,7 +214,7 @@ export const AttachmentImage = memo(function AttachmentImage({
 				className="inline-flex items-center gap-2 px-3 py-2 rounded"
 				style={{ backgroundColor: theme.colors.bgActivity }}
 			>
-				<Loader2 className="w-4 h-4 animate-spin" style={{ color: theme.colors.textDim }} />
+				<Spinner size={16} color={theme.colors.textDim} />
 				<span className="text-xs" style={{ color: theme.colors.textDim }}>
 					Loading image...
 				</span>

--- a/src/renderer/components/AutoRun/AutoRunExpandedModal.tsx
+++ b/src/renderer/components/AutoRun/AutoRunExpandedModal.tsx
@@ -7,12 +7,13 @@ import {
 	Edit,
 	Play,
 	Square,
-	Loader2,
 	Save,
 	RotateCcw,
 	LayoutGrid,
 	AlertTriangle,
 } from 'lucide-react';
+import { GhostIconButton } from '../ui/GhostIconButton';
+import { Spinner } from '../ui/Spinner';
 import type { Theme, BatchRunState, SessionState, Shortcut } from '../../types';
 import { useLayerStack } from '../../contexts/LayerStackContext';
 import { MODAL_PRIORITIES } from '../../constants/modalPriorities';
@@ -360,11 +361,7 @@ export function AutoRunExpandedModal({
 								}}
 								title={isStopping ? 'Stopping after current task...' : 'Stop auto-run'}
 							>
-								{isStopping ? (
-									<Loader2 className="w-3.5 h-3.5 animate-spin" />
-								) : (
-									<Square className="w-3.5 h-3.5" />
-								)}
+								{isStopping ? <Spinner size={14} /> : <Square className="w-3.5 h-3.5" />}
 								{isStopping ? 'Stopping' : 'Stop'}
 							</button>
 						) : (
@@ -422,13 +419,9 @@ export function AutoRunExpandedModal({
 							<Minimize2 className="w-4 h-4" />
 							Collapse
 						</button>
-						<button
-							onClick={handleClose}
-							className="p-1 rounded hover:bg-white/10 transition-colors"
-							title="Close (Esc)"
-						>
+						<GhostIconButton onClick={handleClose} title="Close (Esc)">
 							<X className="w-5 h-5" style={{ color: theme.colors.textDim }} />
-						</button>
+						</GhostIconButton>
 					</div>
 				</div>
 

--- a/src/renderer/components/AutoRun/AutoRunSearchBar.tsx
+++ b/src/renderer/components/AutoRun/AutoRunSearchBar.tsx
@@ -1,5 +1,6 @@
 import React, { useRef, useEffect, useCallback } from 'react';
 import { Search, ChevronUp, ChevronDown, X } from 'lucide-react';
+import { GhostIconButton } from '../ui/GhostIconButton';
 import type { Theme } from '../../types';
 import { useLayerStack } from '../../contexts/LayerStackContext';
 import { MODAL_PRIORITIES } from '../../constants/modalPriorities';
@@ -119,14 +120,9 @@ export function AutoRunSearchBar({
 					</button>
 				</>
 			)}
-			<button
-				onClick={onClose}
-				className="p-1 rounded hover:bg-white/10 transition-colors"
-				style={{ color: theme.colors.textDim }}
-				title="Close search (Esc)"
-			>
+			<GhostIconButton onClick={onClose} title="Close search (Esc)" color={theme.colors.textDim}>
 				<X className="w-4 h-4" />
-			</button>
+			</GhostIconButton>
 		</div>
 	);
 }

--- a/src/renderer/components/AutoRun/AutoRunToolbar.tsx
+++ b/src/renderer/components/AutoRun/AutoRunToolbar.tsx
@@ -1,5 +1,6 @@
 import { memo } from 'react';
-import { Play, Square, HelpCircle, Loader2, LayoutGrid, Wand2 } from 'lucide-react';
+import { Play, Square, HelpCircle, LayoutGrid, Wand2 } from 'lucide-react';
+import { Spinner } from '../ui/Spinner';
 import type { Theme } from '../../types';
 
 export interface AutoRunToolbarProps {
@@ -63,11 +64,7 @@ export const AutoRunToolbar = memo(function AutoRunToolbar({
 					}}
 					title={isStopping ? 'Stopping after current task...' : 'Stop auto-run'}
 				>
-					{isStopping ? (
-						<Loader2 className="w-3.5 h-3.5 animate-spin" />
-					) : (
-						<Square className="w-3.5 h-3.5" />
-					)}
+					{isStopping ? <Spinner size={14} /> : <Square className="w-3.5 h-3.5" />}
 					{isStopping ? 'Stopping' : 'Stop'}
 				</button>
 			) : (

--- a/src/renderer/components/BatchRunnerModal.tsx
+++ b/src/renderer/components/BatchRunnerModal.tsx
@@ -13,8 +13,8 @@ import {
 	Download,
 	Upload,
 	LayoutGrid,
-	Loader2,
 } from 'lucide-react';
+import { Spinner } from './ui/Spinner';
 import type { Theme, BatchDocumentEntry, BatchRunConfig, WorktreeRunTarget } from '../types';
 import { useLayerStack } from '../contexts/LayerStackContext';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
@@ -904,11 +904,7 @@ export function BatchRunnerModal(props: BatchRunnerModalProps) {
 														: 'Start auto-run'
 							}
 						>
-							{isPreparingWorktree ? (
-								<Loader2 className="w-4 h-4 animate-spin" />
-							) : (
-								<Play className="w-4 h-4" />
-							)}
+							{isPreparingWorktree ? <Spinner size={16} /> : <Play className="w-4 h-4" />}
 							{isPreparingWorktree ? 'Preparing Worktree...' : 'Go'}
 						</button>
 					</div>

--- a/src/renderer/components/CreatePRModal.tsx
+++ b/src/renderer/components/CreatePRModal.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { X, GitPullRequest, Loader2, AlertTriangle, ExternalLink } from 'lucide-react';
+import { X, GitPullRequest, AlertTriangle, ExternalLink } from 'lucide-react';
+import { GhostIconButton } from './ui/GhostIconButton';
+import { Spinner } from './ui/Spinner';
 import type { Theme, GhCliStatus } from '../types';
 import { useLayerStack } from '../contexts/LayerStackContext';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
@@ -228,9 +230,9 @@ export function CreatePRModal({
 							Create Pull Request
 						</h2>
 					</div>
-					<button onClick={onClose} className="p-1 rounded hover:bg-white/10 transition-colors">
+					<GhostIconButton onClick={onClose}>
 						<X className="w-4 h-4" style={{ color: theme.colors.textDim }} />
-					</button>
+					</GhostIconButton>
 				</div>
 
 				{/* Content */}
@@ -301,7 +303,7 @@ export function CreatePRModal({
 							className="flex items-center gap-2 text-sm"
 							style={{ color: theme.colors.textDim }}
 						>
-							<Loader2 className="w-4 h-4 animate-spin" />
+							<Spinner size={16} />
 							Checking GitHub CLI...
 						</div>
 					)}
@@ -472,7 +474,7 @@ export function CreatePRModal({
 					>
 						{isCreating ? (
 							<>
-								<Loader2 className="w-4 h-4 animate-spin" />
+								<Spinner size={16} />
 								Creating...
 							</>
 						) : (

--- a/src/renderer/components/CreatePRModal.tsx
+++ b/src/renderer/components/CreatePRModal.tsx
@@ -230,7 +230,7 @@ export function CreatePRModal({
 							Create Pull Request
 						</h2>
 					</div>
-					<GhostIconButton onClick={onClose}>
+					<GhostIconButton onClick={onClose} ariaLabel="Close">
 						<X className="w-4 h-4" style={{ color: theme.colors.textDim }} />
 					</GhostIconButton>
 				</div>

--- a/src/renderer/components/CreateWorktreeModal.tsx
+++ b/src/renderer/components/CreateWorktreeModal.tsx
@@ -1,5 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
-import { X, GitBranch, Loader2, AlertTriangle } from 'lucide-react';
+import { X, GitBranch, AlertTriangle } from 'lucide-react';
+import { GhostIconButton } from './ui/GhostIconButton';
+import { Spinner } from './ui/Spinner';
 import type { Theme, Session, GhCliStatus } from '../types';
 import { useLayerStack } from '../contexts/LayerStackContext';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
@@ -138,9 +140,9 @@ export function CreateWorktreeModal({
 							Create New Worktree
 						</h2>
 					</div>
-					<button onClick={onClose} className="p-1 rounded hover:bg-white/10 transition-colors">
+					<GhostIconButton onClick={onClose}>
 						<X className="w-4 h-4" style={{ color: theme.colors.textDim }} />
-					</button>
+					</GhostIconButton>
 				</div>
 
 				{/* Content */}
@@ -277,7 +279,7 @@ export function CreateWorktreeModal({
 					>
 						{isCreating ? (
 							<>
-								<Loader2 className="w-4 h-4 animate-spin" />
+								<Spinner size={16} />
 								Creating...
 							</>
 						) : (

--- a/src/renderer/components/CreateWorktreeModal.tsx
+++ b/src/renderer/components/CreateWorktreeModal.tsx
@@ -140,7 +140,7 @@ export function CreateWorktreeModal({
 							Create New Worktree
 						</h2>
 					</div>
-					<GhostIconButton onClick={onClose}>
+					<GhostIconButton onClick={onClose} ariaLabel="Close">
 						<X className="w-4 h-4" style={{ color: theme.colors.textDim }} />
 					</GhostIconButton>
 				</div>

--- a/src/renderer/components/CueYamlEditor/CueAiChat.tsx
+++ b/src/renderer/components/CueYamlEditor/CueAiChat.tsx
@@ -4,7 +4,8 @@
  * Shows message history, streaming indicator, and input field.
  */
 
-import { Loader2, Send } from 'lucide-react';
+import { Send } from 'lucide-react';
+import { Spinner } from '../ui/Spinner';
 import { CUE_COLOR } from '../../../shared/cue-pipeline-types';
 import type { Theme } from '../../types';
 import type { ChatMessage } from '../../hooks/cue/useCueAiChat';
@@ -68,7 +69,7 @@ export function CueAiChat({
 						style={{ color: theme.colors.textDim }}
 						data-testid="chat-busy-indicator"
 					>
-						<Loader2 className="w-3 h-3 animate-spin" />
+						<Spinner size={12} />
 						Agent is working...
 					</div>
 				)}

--- a/src/renderer/components/CueYamlEditor/CueYamlEditor.tsx
+++ b/src/renderer/components/CueYamlEditor/CueYamlEditor.tsx
@@ -7,6 +7,7 @@
 
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { CheckCircle, XCircle, Zap, LayoutDashboard, GitFork, X } from 'lucide-react';
+import { GhostIconButton } from '../ui/GhostIconButton';
 import type { CuePattern } from '../../constants/cuePatterns';
 import { Modal, ModalFooter } from '../ui/Modal';
 import { MODAL_PRIORITIES } from '../../constants/modalPriorities';
@@ -271,15 +272,9 @@ export function CueYamlEditor({
 					</button>
 				</div>
 			</div>
-			<button
-				type="button"
-				onClick={handleClose}
-				className="p-1 rounded hover:bg-white/10 transition-colors"
-				style={{ color: theme.colors.textDim }}
-				aria-label="Close modal"
-			>
+			<GhostIconButton onClick={handleClose} ariaLabel="Close modal" color={theme.colors.textDim}>
 				<X className="w-4 h-4" />
-			</button>
+			</GhostIconButton>
 		</div>
 	) : undefined;
 

--- a/src/renderer/components/DebugPackageModal.tsx
+++ b/src/renderer/components/DebugPackageModal.tsx
@@ -9,7 +9,8 @@
  */
 
 import { useState, useEffect, useRef, useCallback } from 'react';
-import { Package, Check, Loader2, FolderOpen, AlertCircle, Copy } from 'lucide-react';
+import { Package, Check, FolderOpen, AlertCircle, Copy } from 'lucide-react';
+import { Spinner } from './ui/Spinner';
 import type { Theme } from '../types';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
 import { Modal, ModalFooter } from './ui/Modal';
@@ -239,11 +240,11 @@ export function DebugPackageModal({ theme, isOpen, onClose }: DebugPackageModalP
 
 			{loading ? (
 				<div className="flex items-center justify-center py-8">
-					<Loader2 className="w-6 h-6 animate-spin" style={{ color: theme.colors.accent }} />
+					<Spinner size={24} color={theme.colors.accent} />
 				</div>
 			) : generationState === 'generating' ? (
 				<div className="flex flex-col items-center justify-center py-8 gap-4">
-					<Loader2 className="w-8 h-8 animate-spin" style={{ color: theme.colors.accent }} />
+					<Spinner size={32} color={theme.colors.accent} />
 					<p className="text-sm" style={{ color: theme.colors.textDim }}>
 						Collecting diagnostic information...
 					</p>

--- a/src/renderer/components/DeleteWorktreeModal.tsx
+++ b/src/renderer/components/DeleteWorktreeModal.tsx
@@ -1,8 +1,9 @@
 import { useRef, useState } from 'react';
-import { AlertTriangle, Loader2, Trash2 } from 'lucide-react';
+import { AlertTriangle, Trash2 } from 'lucide-react';
 import type { Theme, Session } from '../types';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
 import { Modal } from './ui/Modal';
+import { Spinner } from './ui/Spinner';
 
 interface DeleteWorktreeModalProps {
 	theme: Theme;
@@ -71,7 +72,7 @@ export function DeleteWorktreeModal({
 								opacity: 0.7,
 							}}
 						>
-							<Loader2 className="w-3 h-3 animate-spin" />
+							<Spinner size={12} />
 							Deleting...
 						</button>
 					) : (

--- a/src/renderer/components/DirectorNotes/AIOverviewTab.tsx
+++ b/src/renderer/components/DirectorNotes/AIOverviewTab.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { RefreshCw, Save, Loader2, Clock, Copy, Check, Bot, History, Timer } from 'lucide-react';
+import { RefreshCw, Save, Clock, Copy, Check, Bot, History, Timer } from 'lucide-react';
+import { Spinner } from '../ui/Spinner';
 import type { Theme } from '../../types';
 import { MarkdownRenderer } from '../MarkdownRenderer';
 import { SaveMarkdownModal } from '../SaveMarkdownModal';
@@ -259,11 +260,7 @@ export function AIOverviewTab({ theme, onSynopsisReady }: AIOverviewTabProps) {
 						opacity: isGenerating ? 0.5 : 1,
 					}}
 				>
-					{isGenerating ? (
-						<Loader2 className="w-3.5 h-3.5 animate-spin" />
-					) : (
-						<RefreshCw className="w-3.5 h-3.5" />
-					)}
+					{isGenerating ? <Spinner size={14} /> : <RefreshCw className="w-3.5 h-3.5" />}
 					{isGenerating ? 'Regenerating…' : 'Regenerate'}
 				</button>
 
@@ -366,7 +363,7 @@ export function AIOverviewTab({ theme, onSynopsisReady }: AIOverviewTabProps) {
 				) : isGenerating ? (
 					<div className="flex items-center justify-center h-full">
 						<div className="flex items-center gap-3">
-							<Loader2 className="w-6 h-6 animate-spin" style={{ color: theme.colors.accent }} />
+							<Spinner size={24} color={theme.colors.accent} />
 							<p className="text-sm" style={{ color: theme.colors.textDim }}>
 								Generating…
 							</p>

--- a/src/renderer/components/DirectorNotes/DirectorNotesModal.tsx
+++ b/src/renderer/components/DirectorNotes/DirectorNotesModal.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useEffect, useRef, useCallback, lazy, Suspense } from 'react';
 import { createPortal } from 'react-dom';
-import { X, History, Sparkles, Loader2, Clapperboard, HelpCircle } from 'lucide-react';
+import { X, History, Sparkles, Clapperboard, HelpCircle } from 'lucide-react';
+import { GhostIconButton } from '../ui/GhostIconButton';
+import { Spinner } from '../ui/Spinner';
 import type { Theme } from '../../types';
 import { useLayerStack } from '../../contexts/LayerStackContext';
 import { MODAL_PRIORITIES } from '../../constants/modalPriorities';
@@ -210,9 +212,9 @@ export function DirectorNotesModal({
 					</div>
 
 					{/* Close button */}
-					<button onClick={onClose} className="p-1 rounded hover:bg-white/10 transition-colors">
+					<GhostIconButton onClick={onClose}>
 						<X className="w-4 h-4" style={{ color: theme.colors.textDim }} />
-					</button>
+					</GhostIconButton>
 				</div>
 
 				{/* Tab navigation */}
@@ -239,11 +241,7 @@ export function DirectorNotesModal({
 									cursor: isDisabled ? 'default' : 'pointer',
 								}}
 							>
-								{showGenerating ? (
-									<Loader2 className="w-4 h-4 animate-spin" />
-								) : (
-									<Icon className="w-4 h-4" />
-								)}
+								{showGenerating ? <Spinner size={16} /> : <Icon className="w-4 h-4" />}
 								{tab.label}
 								{showGenerating && <span className="text-[10px] font-normal">generating…</span>}
 							</button>
@@ -259,7 +257,7 @@ export function DirectorNotesModal({
 					<Suspense
 						fallback={
 							<div className="flex items-center justify-center h-full">
-								<Loader2 className="w-8 h-8 animate-spin" style={{ color: theme.colors.textDim }} />
+								<Spinner size={32} color={theme.colors.textDim} />
 							</div>
 						}
 					>

--- a/src/renderer/components/DirectorNotes/DirectorNotesModal.tsx
+++ b/src/renderer/components/DirectorNotes/DirectorNotesModal.tsx
@@ -212,7 +212,7 @@ export function DirectorNotesModal({
 					</div>
 
 					{/* Close button */}
-					<GhostIconButton onClick={onClose}>
+					<GhostIconButton onClick={onClose} ariaLabel="Close">
 						<X className="w-4 h-4" style={{ color: theme.colors.textDim }} />
 					</GhostIconButton>
 				</div>

--- a/src/renderer/components/DirectorNotes/UnifiedHistoryTab.tsx
+++ b/src/renderer/components/DirectorNotes/UnifiedHistoryTab.tsx
@@ -8,7 +8,8 @@ import React, {
 	useImperativeHandle,
 } from 'react';
 import { useVirtualizer } from '@tanstack/react-virtual';
-import { Loader2, Search, X } from 'lucide-react';
+import { Search, X } from 'lucide-react';
+import { Spinner } from '../ui/Spinner';
 import type { Theme, HistoryEntry, HistoryEntryType } from '../../types';
 import type { FileNode } from '../../types/fileTree';
 import {
@@ -736,10 +737,7 @@ export const UnifiedHistoryTab = forwardRef<TabFocusHandle, UnifiedHistoryTabPro
 					{/* Loading more indicator */}
 					{isLoadingMore && (
 						<div className="flex items-center justify-center py-4 gap-2">
-							<Loader2
-								className="w-3.5 h-3.5 animate-spin"
-								style={{ color: theme.colors.accent }}
-							/>
+							<Spinner size={14} color={theme.colors.accent} />
 							<span className="text-xs" style={{ color: theme.colors.textDim }}>
 								Loading more...
 							</span>

--- a/src/renderer/components/DocumentGraph/DocumentGraphView.tsx
+++ b/src/renderer/components/DocumentGraph/DocumentGraphView.tsx
@@ -20,7 +20,6 @@ import {
 	ExternalLink,
 	RefreshCw,
 	Search,
-	Loader2,
 	ChevronDown,
 	Sliders,
 	AlertCircle,
@@ -32,6 +31,7 @@ import {
 	ChevronLeft,
 	ChevronRight,
 } from 'lucide-react';
+import { Spinner } from '../ui/Spinner';
 import type { Theme } from '../../types';
 import { useLayerStack } from '../../contexts/LayerStackContext';
 import { MODAL_PRIORITIES } from '../../constants/modalPriorities';
@@ -1686,7 +1686,7 @@ export function DocumentGraphView({
 				>
 					{loading ? (
 						<div className="h-full flex flex-col items-center justify-center gap-8">
-							<Loader2 className="w-8 h-8 animate-spin" style={{ color: theme.colors.accent }} />
+							<Spinner size={32} color={theme.colors.accent} />
 							<div className="flex flex-col items-center gap-4">
 								<p className="text-sm" style={{ color: theme.colors.textDim }}>
 									{progress
@@ -1925,7 +1925,7 @@ export function DocumentGraphView({
 										className="flex items-center gap-2 text-xs"
 										style={{ color: theme.colors.textDim }}
 									>
-										<Loader2 className="w-4 h-4 animate-spin" />
+										<Spinner size={16} />
 										Loading preview...
 									</div>
 								) : previewError ? (
@@ -2015,11 +2015,7 @@ export function DocumentGraphView({
 								onMouseLeave={(e) => !loadingMore && (e.currentTarget.style.opacity = '1')}
 								title={`Load ${Math.min(LOAD_MORE_INCREMENT, totalDocuments - loadedDocuments)} more documents`}
 							>
-								{loadingMore ? (
-									<Loader2 className="w-3 h-3 animate-spin" />
-								) : (
-									<ChevronDown className="w-3 h-3" />
-								)}
+								{loadingMore ? <Spinner size={12} /> : <ChevronDown className="w-3 h-3" />}
 								{loadingMore
 									? 'Loading...'
 									: `Load more (${totalDocuments - loadedDocuments} remaining)`}
@@ -2035,7 +2031,7 @@ export function DocumentGraphView({
 								}}
 								title="Scanning for documents that link to the current graph"
 							>
-								<Loader2 className="w-3 h-3 animate-spin" style={{ color: theme.colors.accent }} />
+								<Spinner size={12} color={theme.colors.accent} />
 								<span>
 									Scanning backlinks
 									{backlinkProgress && ` (${backlinkProgress.scanned}/${backlinkProgress.total})`}

--- a/src/renderer/components/DocumentsPanel.tsx
+++ b/src/renderer/components/DocumentsPanel.tsx
@@ -12,6 +12,7 @@ import {
 	Folder,
 	CheckSquare,
 } from 'lucide-react';
+import { GhostIconButton } from './ui/GhostIconButton';
 import type { Theme, BatchDocumentEntry } from '../types';
 import { generateId } from '../utils/ids';
 import { useLayerStack } from '../contexts/LayerStackContext';
@@ -484,13 +485,9 @@ function DocumentSelectorModal({
 						>
 							<RefreshCw className={`w-4 h-4 ${refreshing ? 'animate-spin' : ''}`} />
 						</button>
-						<button
-							onClick={onClose}
-							className="p-1 rounded hover:bg-white/10 transition-colors"
-							style={{ color: theme.colors.textDim }}
-						>
+						<GhostIconButton onClick={onClose} color={theme.colors.textDim}>
 							<X className="w-4 h-4" />
-						</button>
+						</GhostIconButton>
 					</div>
 				</div>
 

--- a/src/renderer/components/EmptyStateView.tsx
+++ b/src/renderer/components/EmptyStateView.tsx
@@ -12,6 +12,7 @@ import {
 	BookOpen,
 	ExternalLink,
 } from 'lucide-react';
+import { GhostIconButton } from './ui/GhostIconButton';
 import type { Theme, Shortcut } from '../types';
 import { formatShortcutKeys } from '../utils/shortcutFormatter';
 import { useClickOutside } from '../hooks';
@@ -83,14 +84,14 @@ export function EmptyStateView({
 
 				{/* Right: Hamburger Menu */}
 				<div className="relative" ref={menuRef}>
-					<button
+					<GhostIconButton
 						onClick={() => setMenuOpen(!menuOpen)}
-						className="p-2 rounded hover:bg-white/10 transition-colors"
-						style={{ color: theme.colors.textDim }}
+						padding="p-2"
 						title="Menu"
+						color={theme.colors.textDim}
 					>
 						<Menu className="w-5 h-5" />
-					</button>
+					</GhostIconButton>
 
 					{/* Menu Overlay */}
 					{menuOpen && (

--- a/src/renderer/components/FeedbackChatView.tsx
+++ b/src/renderer/components/FeedbackChatView.tsx
@@ -16,7 +16,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
 	ImagePlus,
-	Loader2,
 	MessageSquareHeart,
 	Send,
 	X,
@@ -28,6 +27,7 @@ import {
 	Check,
 	Copy,
 } from 'lucide-react';
+import { Spinner } from './ui/Spinner';
 import { safeClipboardWrite } from '../utils/clipboard';
 import { MarkdownRenderer } from './MarkdownRenderer';
 import { generateTerminalProseStyles } from '../utils/markdownConfig';
@@ -517,7 +517,7 @@ export function FeedbackChatView({ theme, onCancel, onWidthChange }: FeedbackCha
 	if (ghAuth.checking) {
 		return (
 			<div className="flex flex-col items-center gap-3 py-8 px-6">
-				<Loader2 className="w-6 h-6 animate-spin" style={{ color: theme.colors.accent }} />
+				<Spinner size={24} color={theme.colors.accent} />
 				<p className="text-xs" style={{ color: theme.colors.textDim }}>
 					Checking GitHub CLI...
 				</p>
@@ -674,7 +674,7 @@ export function FeedbackChatView({ theme, onCancel, onWidthChange }: FeedbackCha
 			<div className="flex flex-col gap-4 p-6">
 				{searchingIssues ? (
 					<div className="flex flex-col items-center gap-3 py-8">
-						<Loader2 className="w-6 h-6 animate-spin" style={{ color: theme.colors.accent }} />
+						<Spinner size={24} color={theme.colors.accent} />
 						<p className="text-xs" style={{ color: theme.colors.textDim }}>
 							Searching for similar existing issues...
 						</p>
@@ -750,7 +750,7 @@ export function FeedbackChatView({ theme, onCancel, onWidthChange }: FeedbackCha
 											title="Subscribe and add your feedback as a comment"
 										>
 											{subscribingTo === issue.number ? (
-												<Loader2 className="w-3 h-3 animate-spin" />
+												<Spinner size={12} />
 											) : (
 												<ThumbsUp className="w-3 h-3" />
 											)}
@@ -825,7 +825,7 @@ export function FeedbackChatView({ theme, onCancel, onWidthChange }: FeedbackCha
 							className="flex items-center gap-1 text-[10px]"
 							style={{ color: theme.colors.textDim }}
 						>
-							<Loader2 className="w-3 h-3 animate-spin" />
+							<Spinner size={12} />
 							Checking for similar issues...
 						</span>
 					)}
@@ -843,11 +843,7 @@ export function FeedbackChatView({ theme, onCancel, onWidthChange }: FeedbackCha
 							className="flex items-center gap-1.5 px-3 py-1 rounded text-xs font-bold transition-colors hover:opacity-90 disabled:opacity-40 shrink-0"
 							style={{ backgroundColor: theme.colors.success, color: '#000' }}
 						>
-							{step === 'submitting' ? (
-								<Loader2 className="w-3 h-3 animate-spin" />
-							) : (
-								<Check className="w-3 h-3" />
-							)}
+							{step === 'submitting' ? <Spinner size={12} /> : <Check className="w-3 h-3" />}
 							Submit Feedback
 						</button>
 					)}
@@ -902,7 +898,7 @@ export function FeedbackChatView({ theme, onCancel, onWidthChange }: FeedbackCha
 								border: `1px solid ${theme.colors.border}`,
 							}}
 						>
-							<Loader2 className="w-4 h-4 animate-spin" style={{ color: theme.colors.accent }} />
+							<Spinner size={16} color={theme.colors.accent} />
 						</div>
 					</div>
 				)}
@@ -966,7 +962,7 @@ export function FeedbackChatView({ theme, onCancel, onWidthChange }: FeedbackCha
 										title="Subscribe and add your feedback as a comment"
 									>
 										{subscribingTo === issue.number ? (
-											<Loader2 className="w-3 h-3 animate-spin" />
+											<Spinner size={12} />
 										) : (
 											<ThumbsUp className="w-3 h-3" />
 										)}
@@ -1125,11 +1121,7 @@ export function FeedbackChatView({ theme, onCancel, onWidthChange }: FeedbackCha
 							style={{ backgroundColor: theme.colors.accent, color: theme.colors.accentForeground }}
 							title="Send message"
 						>
-							{isLoading ? (
-								<Loader2 className="w-4 h-4 animate-spin" />
-							) : (
-								<Send className="w-4 h-4" />
-							)}
+							{isLoading ? <Spinner size={16} /> : <Send className="w-4 h-4" />}
 						</button>
 						{/* Submit button — appears when ready */}
 						{isReady && (
@@ -1141,11 +1133,7 @@ export function FeedbackChatView({ theme, onCancel, onWidthChange }: FeedbackCha
 								style={{ backgroundColor: theme.colors.success, color: '#000' }}
 								title="Submit feedback as GitHub issue"
 							>
-								{step === 'submitting' ? (
-									<Loader2 className="w-3.5 h-3.5 animate-spin" />
-								) : (
-									<Check className="w-3.5 h-3.5" />
-								)}
+								{step === 'submitting' ? <Spinner size={14} /> : <Check className="w-3.5 h-3.5" />}
 								Submit
 							</button>
 						)}

--- a/src/renderer/components/FileExplorerPanel.tsx
+++ b/src/renderer/components/FileExplorerPanel.tsx
@@ -21,9 +21,9 @@ import {
 	Edit2,
 	Trash2,
 	AlertTriangle,
-	Loader2,
 	Search,
 } from 'lucide-react';
+import { Spinner } from './ui/Spinner';
 import type { Session, Theme, FocusArea } from '../types';
 import type { FileNode } from '../types/fileTree';
 import type { FileTreeChanges } from '../utils/fileExplorer';
@@ -114,7 +114,7 @@ function FileTreeLoadingProgress({
 	return (
 		<div className="flex flex-col items-center justify-center gap-3 py-8">
 			{/* Animated spinner */}
-			<Loader2 className="w-6 h-6 animate-spin" style={{ color: theme.colors.accent }} />
+			<Spinner size={24} color={theme.colors.accent} />
 
 			{/* Status text */}
 			<div className="text-center">

--- a/src/renderer/components/FilePreview/FilePreview.tsx
+++ b/src/renderer/components/FilePreview/FilePreview.tsx
@@ -21,6 +21,7 @@ import {
 	X,
 	Filter,
 } from 'lucide-react';
+import { GhostIconButton } from '../ui/GhostIconButton';
 import { captureException } from '../../utils/sentry';
 import { safeClipboardWrite, safeClipboardWriteBlob } from '../../utils/clipboard';
 import { useLayerStack } from '../../contexts/LayerStackContext';
@@ -998,13 +999,9 @@ export const FilePreview = React.memo(
 							>
 								Reload
 							</button>
-							<button
-								onClick={() => setFileChangedOnDisk(false)}
-								className="p-1 rounded hover:bg-white/10 transition-colors"
-								title="Dismiss"
-							>
+							<GhostIconButton onClick={() => setFileChangedOnDisk(false)} title="Dismiss">
 								<X className="w-3 h-3" style={{ color: theme.colors.textDim }} />
-							</button>
+							</GhostIconButton>
 						</div>
 					</div>
 				)}

--- a/src/renderer/components/FilePreview/FilePreviewHeader.tsx
+++ b/src/renderer/components/FilePreview/FilePreviewHeader.tsx
@@ -6,7 +6,6 @@ import {
 	ChevronRight,
 	Clipboard,
 	Copy,
-	Loader2,
 	Globe,
 	Save,
 	Edit,
@@ -14,6 +13,7 @@ import {
 	GitGraph,
 	ExternalLink,
 } from 'lucide-react';
+import { Spinner } from '../ui/Spinner';
 import { captureException } from '../../utils/sentry';
 import { formatShortcutKeys } from '../../utils/shortcutFormatter';
 import { formatFileSize, formatDateTime } from './filePreviewUtils';
@@ -145,11 +145,7 @@ export const FilePreviewHeader = React.memo(function FilePreviewHeader({
 										: 'No changes to save'
 								}
 							>
-								{isSaving ? (
-									<Loader2 className="w-3.5 h-3.5 animate-spin" />
-								) : (
-									<Save className="w-3.5 h-3.5" />
-								)}
+								{isSaving ? <Spinner size={14} /> : <Save className="w-3.5 h-3.5" />}
 								{isSaving ? 'Saving...' : 'Save'}
 							</button>
 						)}

--- a/src/renderer/components/FilePreview/ImageViewer.tsx
+++ b/src/renderer/components/FilePreview/ImageViewer.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useCallback, useEffect, memo } from 'react';
 import { ZoomIn, ZoomOut, Maximize2 } from 'lucide-react';
 
+import { GhostIconButton } from '../ui/GhostIconButton';
 interface ImageViewerProps {
 	src: string;
 	alt: string;
@@ -118,36 +119,21 @@ export const ImageViewer = memo(function ImageViewer({ src, alt, theme }: ImageV
 				className="flex items-center justify-center gap-2 py-1.5 shrink-0 border-b"
 				style={{ borderColor: theme.colors.border }}
 			>
-				<button
-					onClick={zoomOut}
-					className="p-1 rounded hover:bg-white/10 transition-colors"
-					style={{ color: theme.colors.textDim }}
-					title="Zoom out"
-				>
+				<GhostIconButton onClick={zoomOut} title="Zoom out" color={theme.colors.textDim}>
 					<ZoomOut className="w-4 h-4" />
-				</button>
+				</GhostIconButton>
 				<span
 					className="text-xs font-mono w-12 text-center select-none"
 					style={{ color: theme.colors.textMain }}
 				>
 					{zoomPercent}%
 				</span>
-				<button
-					onClick={zoomIn}
-					className="p-1 rounded hover:bg-white/10 transition-colors"
-					style={{ color: theme.colors.textDim }}
-					title="Zoom in"
-				>
+				<GhostIconButton onClick={zoomIn} title="Zoom in" color={theme.colors.textDim}>
 					<ZoomIn className="w-4 h-4" />
-				</button>
-				<button
-					onClick={fitToView}
-					className="p-1 rounded hover:bg-white/10 transition-colors"
-					style={{ color: theme.colors.textDim }}
-					title="Fit to view"
-				>
+				</GhostIconButton>
+				<GhostIconButton onClick={fitToView} title="Fit to view" color={theme.colors.textDim}>
 					<Maximize2 className="w-4 h-4" />
-				</button>
+				</GhostIconButton>
 				{naturalSize && (
 					<span className="text-[10px] ml-2" style={{ color: theme.colors.textDim }}>
 						{naturalSize.w} × {naturalSize.h}

--- a/src/renderer/components/FilePreview/MarkdownImage.tsx
+++ b/src/renderer/components/FilePreview/MarkdownImage.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useMemo, useEffect, useCallback } from 'react';
-import { Loader2, Image } from 'lucide-react';
+import { Image } from 'lucide-react';
+import { Spinner } from '../ui/Spinner';
 import { imageCache, resolveImagePath } from './filePreviewUtils';
 
 /**
@@ -138,7 +139,7 @@ export const MarkdownImage = React.memo(function MarkdownImage({
 					minWidth: '200px',
 				}}
 			>
-				<Loader2 className="w-4 h-4 animate-spin" style={{ color: theme.colors.textDim }} />
+				<Spinner size={16} color={theme.colors.textDim} />
 				<span className="text-xs" style={{ color: theme.colors.textDim }}>
 					Loading image...
 				</span>

--- a/src/renderer/components/GistPublishModal.tsx
+++ b/src/renderer/components/GistPublishModal.tsx
@@ -1,5 +1,6 @@
 import { useRef, useState, useCallback } from 'react';
 import { Share2, Copy, Check, ExternalLink } from 'lucide-react';
+import { GhostIconButton } from './ui/GhostIconButton';
 import type { Theme } from '../types';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
 import { Modal } from './ui/Modal';
@@ -180,24 +181,22 @@ export function GistPublishModal({
 							style={{ color: theme.colors.textMain }}
 							onClick={(e) => (e.target as HTMLInputElement).select()}
 						/>
-						<button
-							type="button"
+						<GhostIconButton
 							onClick={handleCopyUrl}
-							className="p-1.5 rounded hover:bg-white/10 transition-colors"
-							style={{ color: copied ? theme.colors.success : theme.colors.textDim }}
+							padding="p-1.5"
 							title="Copy URL"
+							color={copied ? theme.colors.success : theme.colors.textDim}
 						>
 							{copied ? <Check className="w-4 h-4" /> : <Copy className="w-4 h-4" />}
-						</button>
-						<button
-							type="button"
+						</GhostIconButton>
+						<GhostIconButton
 							onClick={handleOpenGist}
-							className="p-1.5 rounded hover:bg-white/10 transition-colors"
-							style={{ color: theme.colors.textDim }}
+							padding="p-1.5"
 							title="Open in browser"
+							color={theme.colors.textDim}
 						>
 							<ExternalLink className="w-4 h-4" />
-						</button>
+						</GhostIconButton>
 					</div>
 
 					<p className="text-xs" style={{ color: theme.colors.textDim }}>

--- a/src/renderer/components/GroupChatModal.tsx
+++ b/src/renderer/components/GroupChatModal.tsx
@@ -13,6 +13,7 @@
 
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { X, Settings, ChevronDown, Check } from 'lucide-react';
+import { GhostIconButton } from './ui/GhostIconButton';
 import { isBetaAgent } from '../../shared/agentMetadata';
 import type { Theme, AgentConfig, ModeratorConfig, GroupChat } from '../types';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
@@ -242,15 +243,9 @@ export function GroupChatModal(props: GroupChatModalProps): JSX.Element | null {
 								Beta
 							</span>
 						</div>
-						<button
-							type="button"
-							onClick={onClose}
-							className="p-1 rounded hover:bg-white/10 transition-colors"
-							style={{ color: theme.colors.textDim }}
-							aria-label="Close modal"
-						>
+						<GhostIconButton onClick={onClose} ariaLabel="Close modal" color={theme.colors.textDim}>
 							<X className="w-4 h-4" />
-						</button>
+						</GhostIconButton>
 					</div>
 				) : undefined
 			}

--- a/src/renderer/components/History/HistoryStatsBar.tsx
+++ b/src/renderer/components/History/HistoryStatsBar.tsx
@@ -1,5 +1,6 @@
 import React, { memo } from 'react';
-import { Layers, Hash, Bot, User, BarChart3, Loader2, ListOrdered } from 'lucide-react';
+import { Layers, Hash, Bot, User, BarChart3, ListOrdered } from 'lucide-react';
+import { Spinner } from '../ui/Spinner';
 import type { Theme } from '../../types';
 
 export interface HistoryStats {
@@ -113,7 +114,7 @@ export const HistoryStatsBar = memo(function HistoryStatsBar({
 									color: theme.colors.warning,
 								}}
 							>
-								<Loader2 className="w-3 h-3 animate-spin" />
+								<Spinner size={12} />
 							</span>
 							<span
 								className="text-[10px] uppercase tracking-wider"

--- a/src/renderer/components/InlineWizard/DocumentGenerationView.tsx
+++ b/src/renderer/components/InlineWizard/DocumentGenerationView.tsx
@@ -17,7 +17,8 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { getSyntaxStyle } from '../../utils/syntaxTheme';
-import { Eye, Edit, ChevronDown, ChevronRight, X, Loader2, FileText, Check } from 'lucide-react';
+import { Eye, Edit, ChevronDown, ChevronRight, X, FileText, Check } from 'lucide-react';
+import { Spinner } from '../ui/Spinner';
 import type { Theme } from '../../types';
 import type { GeneratedDocument } from '../Wizard/WizardContext';
 import { AustinFactsDisplay } from './AustinFactsDisplay';
@@ -284,7 +285,7 @@ function MarkdownImage({
 				className="inline-flex items-center gap-2 px-3 py-2 rounded"
 				style={{ backgroundColor: theme.colors.bgActivity }}
 			>
-				<Loader2 className="w-4 h-4 animate-spin" style={{ color: theme.colors.textDim }} />
+				<Spinner size={16} color={theme.colors.textDim} />
 				<span className="text-xs" style={{ color: theme.colors.textDim }}>
 					Loading...
 				</span>

--- a/src/renderer/components/InlineWizard/WizardPill.tsx
+++ b/src/renderer/components/InlineWizard/WizardPill.tsx
@@ -6,7 +6,8 @@
  * while the wizard is active. Shows a spinner when thinking.
  */
 
-import { Wand2, Loader2 } from 'lucide-react';
+import { Wand2 } from 'lucide-react';
+import { Spinner } from '../ui/Spinner';
 import type { Theme } from '../../types';
 
 interface WizardPillProps {
@@ -40,7 +41,7 @@ export function WizardPill({ theme, onClick, isThinking = false }: WizardPillPro
 			}}
 			title={isThinking ? 'Wizard is thinking...' : 'Wizard mode active - click to exit'}
 		>
-			{isThinking ? <Loader2 className="w-4 h-4 animate-spin" /> : <Wand2 className="w-4 h-4" />}
+			{isThinking ? <Spinner size={16} /> : <Wand2 className="w-4 h-4" />}
 			<span>{isThinking ? 'Thinking...' : 'Wizard'}</span>
 
 			{/* Pulse animation styles */}

--- a/src/renderer/components/LeaderboardRegistrationModal.tsx
+++ b/src/renderer/components/LeaderboardRegistrationModal.tsx
@@ -12,7 +12,6 @@ import {
 	Trophy,
 	Mail,
 	User,
-	Loader2,
 	Check,
 	AlertCircle,
 	ExternalLink,
@@ -22,6 +21,8 @@ import {
 	Send,
 	DownloadCloud,
 } from 'lucide-react';
+import { GhostIconButton } from './ui/GhostIconButton';
+import { Spinner } from './ui/Spinner';
 import type { Theme, AutoRunStats, LeaderboardRegistration, KeyboardMasteryStats } from '../types';
 import { useLayerStack } from '../contexts/LayerStackContext';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
@@ -797,13 +798,9 @@ export function LeaderboardRegistrationModal({
 								: 'Register for Leaderboard'}
 						</h2>
 					</div>
-					<button
-						onClick={onClose}
-						className="p-1 rounded hover:bg-white/10 transition-colors"
-						style={{ color: theme.colors.textDim }}
-					>
+					<GhostIconButton onClick={onClose} color={theme.colors.textDim}>
 						<X className="w-4 h-4" />
-					</button>
+					</GhostIconButton>
 				</div>
 
 				{/* Content */}
@@ -1148,7 +1145,7 @@ export function LeaderboardRegistrationModal({
 								>
 									{isResending ? (
 										<>
-											<Loader2 className="w-3.5 h-3.5 animate-spin" />
+											<Spinner size={14} />
 											Sending...
 										</>
 									) : (
@@ -1307,7 +1304,7 @@ export function LeaderboardRegistrationModal({
 							>
 								{submitState === 'submitting' ? (
 									<>
-										<Loader2 className="w-4 h-4 animate-spin" />
+										<Spinner size={16} />
 										Pushing...
 									</>
 								) : (
@@ -1336,7 +1333,7 @@ export function LeaderboardRegistrationModal({
 							>
 								{isSyncing ? (
 									<>
-										<Loader2 className="w-4 h-4 animate-spin" />
+										<Spinner size={16} />
 										Pulling...
 									</>
 								) : (

--- a/src/renderer/components/LeaderboardRegistrationModal.tsx
+++ b/src/renderer/components/LeaderboardRegistrationModal.tsx
@@ -798,7 +798,7 @@ export function LeaderboardRegistrationModal({
 								: 'Register for Leaderboard'}
 						</h2>
 					</div>
-					<GhostIconButton onClick={onClose} color={theme.colors.textDim}>
+					<GhostIconButton onClick={onClose} color={theme.colors.textDim} ariaLabel="Close">
 						<X className="w-4 h-4" />
 					</GhostIconButton>
 				</div>

--- a/src/renderer/components/MainPanel/AgentErrorBanner.tsx
+++ b/src/renderer/components/MainPanel/AgentErrorBanner.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { AlertCircle, X } from 'lucide-react';
+import { GhostIconButton } from '../ui/GhostIconButton';
 import type { AgentError, Theme } from '../../types';
 
 interface AgentErrorBannerProps {
@@ -43,13 +44,9 @@ export const AgentErrorBanner = React.memo(function AgentErrorBanner({
 					</button>
 				)}
 				{onClear && error.recoverable && (
-					<button
-						onClick={onClear}
-						className="p-1 rounded hover:bg-white/10 transition-colors"
-						title="Dismiss error"
-					>
+					<GhostIconButton onClick={onClear} title="Dismiss error">
 						<X className="w-4 h-4" style={{ color: theme.colors.error }} />
-					</button>
+					</GhostIconButton>
 				)}
 			</div>
 		</div>

--- a/src/renderer/components/MainPanel/BrowserTabView.tsx
+++ b/src/renderer/components/MainPanel/BrowserTabView.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { ArrowLeft, ArrowRight, ExternalLink, Globe, Loader2, RotateCw } from 'lucide-react';
+import { ArrowLeft, ArrowRight, ExternalLink, Globe, RotateCw } from 'lucide-react';
+import { Spinner } from '../ui/Spinner';
 import type { BrowserTab, Theme } from '../../types';
 import {
 	DEFAULT_BROWSER_TAB_TITLE,
@@ -442,11 +443,7 @@ export const BrowserTabView = React.memo(function BrowserTabView({
 						style={{ color: theme.colors.textMain }}
 						title={tab.isLoading ? 'Stop' : 'Reload'}
 					>
-						{tab.isLoading ? (
-							<Loader2 className="w-4 h-4 animate-spin" />
-						) : (
-							<RotateCw className="w-4 h-4" />
-						)}
+						{tab.isLoading ? <Spinner size={16} /> : <RotateCw className="w-4 h-4" />}
 					</button>
 					<form className="flex-1 min-w-0" onSubmit={handleSubmit}>
 						<label className="sr-only" htmlFor={`browser-tab-address-${tab.id}`}>

--- a/src/renderer/components/MainPanel/MainPanelContent.tsx
+++ b/src/renderer/components/MainPanel/MainPanelContent.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Loader2 } from 'lucide-react';
+
+import { Spinner } from '../ui/Spinner';
 import { TerminalOutput } from '../TerminalOutput';
 import {
 	TerminalView,
@@ -405,7 +406,7 @@ export const MainPanelContent = React.memo(function MainPanelContent(props: Main
 					style={{ backgroundColor: theme.colors.bgMain }}
 				>
 					<div className="flex flex-col items-center gap-3">
-						<Loader2 className="w-8 h-8 animate-spin" style={{ color: theme.colors.accent }} />
+						<Spinner size={32} color={theme.colors.accent} />
 						<div className="text-center">
 							<div className="text-sm font-medium" style={{ color: theme.colors.textMain }}>
 								Loading{' '}

--- a/src/renderer/components/MainPanel/MainPanelHeader.tsx
+++ b/src/renderer/components/MainPanel/MainPanelHeader.tsx
@@ -4,7 +4,6 @@ import {
 	ExternalLink,
 	Columns,
 	Copy,
-	Loader2,
 	GitBranch,
 	ArrowUp,
 	ArrowDown,
@@ -15,6 +14,8 @@ import {
 	Server,
 	Bookmark,
 } from 'lucide-react';
+import { GhostIconButton } from '../ui/GhostIconButton';
+import { Spinner } from '../ui/Spinner';
 import { formatShortcutKeys } from '../../utils/shortcutFormatter';
 import { remoteUrlToBrowserUrl } from '../../../shared/gitUtils';
 import { GitStatusWidget } from '../GitStatusWidget';
@@ -221,7 +222,7 @@ export const MainPanelHeader = React.memo(function MainPanelHeader({
 															{gitInfo.behind}
 														</span>
 													)}
-													<button
+													<GhostIconButton
 														onClick={(e) => {
 															e.stopPropagation();
 															copyToClipboard(
@@ -229,11 +230,10 @@ export const MainPanelHeader = React.memo(function MainPanelHeader({
 																`"${gitInfo.branch}" copied to clipboard`
 															);
 														}}
-														className="p-1 rounded hover:bg-white/10 transition-colors"
 														title="Copy branch name"
 													>
 														<Copy className="w-3 h-3" style={{ color: theme.colors.textDim }} />
-													</button>
+													</GhostIconButton>
 												</div>
 											</div>
 
@@ -375,11 +375,7 @@ export const MainPanelHeader = React.memo(function MainPanelHeader({
 						isCurrentSessionStopping ? 'Stopping after current task...' : 'Click to stop auto-run'
 					}
 				>
-					{isCurrentSessionStopping ? (
-						<Loader2 className="w-4 h-4 animate-spin" />
-					) : (
-						<Wand2 className="w-4 h-4" />
-					)}
+					{isCurrentSessionStopping ? <Spinner size={16} /> : <Wand2 className="w-4 h-4" />}
 					<span className="uppercase tracking-wider">
 						{isCurrentSessionStopping ? 'Stopping' : 'Auto'}
 					</span>

--- a/src/renderer/components/MainPanel/MainPanelHeader.tsx
+++ b/src/renderer/components/MainPanel/MainPanelHeader.tsx
@@ -231,6 +231,7 @@ export const MainPanelHeader = React.memo(function MainPanelHeader({
 															);
 														}}
 														title="Copy branch name"
+														ariaLabel="Copy branch name"
 													>
 														<Copy className="w-3 h-3" style={{ color: theme.colors.textDim }} />
 													</GhostIconButton>

--- a/src/renderer/components/MarkdownRenderer.tsx
+++ b/src/renderer/components/MarkdownRenderer.tsx
@@ -4,7 +4,8 @@ import rehypeRaw from 'rehype-raw';
 import DOMPurify from 'dompurify';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { getSyntaxStyle } from '../utils/syntaxTheme';
-import { Clipboard, Loader2, ImageOff } from 'lucide-react';
+import { Clipboard, ImageOff } from 'lucide-react';
+import { Spinner } from './ui/Spinner';
 import type { Theme } from '../types';
 import type { FileNode } from '../types/fileTree';
 import type { PluggableList } from 'unified';
@@ -128,7 +129,7 @@ const LocalImage = memo(({ src, alt, theme, width, sshRemoteId }: LocalImageProp
 				className="inline-flex items-center gap-2 px-3 py-2 rounded"
 				style={{ backgroundColor: theme.colors.bgActivity }}
 			>
-				<Loader2 className="w-4 h-4 animate-spin" style={{ color: theme.colors.textDim }} />
+				<Spinner size={16} color={theme.colors.textDim} />
 				<span className="text-xs" style={{ color: theme.colors.textDim }}>
 					Loading image...
 				</span>

--- a/src/renderer/components/MarketplaceModal.tsx
+++ b/src/renderer/components/MarketplaceModal.tsx
@@ -13,7 +13,6 @@ import {
 	RefreshCw,
 	X,
 	Search,
-	Loader2,
 	Package,
 	ArrowLeft,
 	ChevronDown,
@@ -23,6 +22,8 @@ import {
 	HelpCircle,
 	Github,
 } from 'lucide-react';
+import { GhostIconButton } from './ui/GhostIconButton';
+import { Spinner } from './ui/Spinner';
 import type { Theme } from '../types';
 import type { MarketplacePlaybook } from '../../shared/marketplace-types';
 import { useLayerStack } from '../contexts/LayerStackContext';
@@ -335,13 +336,9 @@ function PlaybookDetailView({
 				style={{ borderColor: theme.colors.border }}
 			>
 				{/* Back button */}
-				<button
-					onClick={onBack}
-					className="p-1.5 rounded hover:bg-white/10 transition-colors"
-					title="Back to list (Esc)"
-				>
+				<GhostIconButton onClick={onBack} padding="p-1.5" title="Back to list (Esc)">
 					<ArrowLeft className="w-5 h-5" style={{ color: theme.colors.textDim }} />
-				</button>
+				</GhostIconButton>
 
 				{/* Playbook title and category */}
 				<div className="flex-1 min-w-0">
@@ -625,7 +622,7 @@ function PlaybookDetailView({
 						<style>{proseStyles}</style>
 						{isLoadingDocument ? (
 							<div className="flex items-center justify-center h-32">
-								<Loader2 className="w-6 h-6 animate-spin" style={{ color: theme.colors.accent }} />
+								<Spinner size={24} color={theme.colors.accent} />
 							</div>
 						) : (
 							<div className="prose prose-sm max-w-none" style={{ color: theme.colors.textMain }}>
@@ -699,7 +696,7 @@ function PlaybookDetailView({
 					>
 						{isImporting ? (
 							<span className="flex items-center gap-2">
-								<Loader2 className="w-4 h-4 animate-spin" />
+								<Spinner size={16} />
 								Importing...
 							</span>
 						) : (
@@ -1246,14 +1243,14 @@ export function MarketplaceModal({
 									/>
 								</button>
 								{/* Close button */}
-								<button
+								<GhostIconButton
 									onClick={onClose}
-									className="p-1.5 rounded hover:bg-white/10 transition-colors"
+									padding="p-1.5"
 									title="Close (Esc)"
-									aria-label="Close marketplace"
+									ariaLabel="Close marketplace"
 								>
 									<X className="w-5 h-5" style={{ color: theme.colors.textDim }} />
-								</button>
+								</GhostIconButton>
 							</div>
 						</div>
 

--- a/src/renderer/components/MergeProgressOverlay.tsx
+++ b/src/renderer/components/MergeProgressOverlay.tsx
@@ -14,7 +14,9 @@
  */
 
 import { useState, useEffect, memo, useCallback } from 'react';
-import { X, Check, Loader2, AlertTriangle, GitMerge } from 'lucide-react';
+import { X, Check, AlertTriangle, GitMerge } from 'lucide-react';
+import { GhostIconButton } from './ui/GhostIconButton';
+import { Spinner } from './ui/Spinner';
 import type { Theme } from '../types';
 import type { GroomingProgress, MergeResult } from '../types/contextMerge';
 
@@ -241,15 +243,13 @@ export const MergeProgressOverlay = memo(function MergeProgressOverlay({
 								)}
 							</div>
 							{!isComplete && (
-								<button
-									type="button"
+								<GhostIconButton
 									onClick={handleCancelClick}
-									className="p-1 rounded hover:bg-white/10 transition-colors"
-									style={{ color: theme.colors.textDim }}
 									title="Cancel"
+									color={theme.colors.textDim}
 								>
 									<X className="w-4 h-4" />
-								</button>
+								</GhostIconButton>
 							)}
 						</div>
 
@@ -290,10 +290,7 @@ export const MergeProgressOverlay = memo(function MergeProgressOverlay({
 											{isCompleted ? (
 												<Check className="w-3 h-3" style={{ color: theme.colors.success }} />
 											) : isActive ? (
-												<Loader2
-													className="w-3 h-3 animate-spin"
-													style={{ color: theme.colors.accent }}
-												/>
+												<Spinner size={12} color={theme.colors.accent} />
 											) : (
 												<div
 													className="w-3 h-3 rounded-full border"

--- a/src/renderer/components/MergeSessionModal.tsx
+++ b/src/renderer/components/MergeSessionModal.tsx
@@ -16,6 +16,7 @@
 
 import React, { useState, useEffect, useRef, useMemo, useCallback, memo } from 'react';
 import { Search, ChevronRight, ChevronDown, GitMerge, Clipboard, Check, X } from 'lucide-react';
+import { GhostIconButton } from './ui/GhostIconButton';
 import type { Theme, Session } from '../types';
 import type { MergeResult } from '../types/contextMerge';
 import { fuzzyMatchWithScore } from '../utils/search';
@@ -607,15 +608,13 @@ export function MergeSessionModal({
 							Merge "{sourceTab ? getTabDisplayName(sourceTab) : 'Context'}" Into
 						</h2>
 					</div>
-					<button
-						type="button"
+					<GhostIconButton
 						onClick={onClose}
-						className="p-1 rounded hover:bg-white/10 transition-colors"
-						style={{ color: theme.colors.textDim }}
-						aria-label="Close merge dialog"
+						ariaLabel="Close merge dialog"
+						color={theme.colors.textDim}
 					>
 						<X className="w-4 h-4" aria-hidden="true" />
-					</button>
+					</GhostIconButton>
 				</div>
 
 				{/* Description for screen readers */}

--- a/src/renderer/components/NewInstanceModal/AgentPickerGrid.tsx
+++ b/src/renderer/components/NewInstanceModal/AgentPickerGrid.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { RefreshCw, ChevronRight, AlertTriangle } from 'lucide-react';
+import { GhostIconButton } from '../ui/GhostIconButton';
 import { AgentConfigPanel } from '../shared/AgentConfigPanel';
 import { isBetaAgent } from '../../../shared/agentMetadata';
 import { buildMaestroUrl } from '../../utils/buildMaestroUrl';
@@ -171,20 +172,18 @@ export const AgentPickerGrid = React.memo(function AgentPickerGrid({
 														Not Found
 													</span>
 												)}
-												<button
-													type="button"
+												<GhostIconButton
 													onClick={(e) => {
 														e.stopPropagation();
 														onRefreshAgent(agent.id);
 													}}
-													className="p-1 rounded hover:bg-white/10 transition-colors"
 													title="Refresh detection"
-													style={{ color: theme.colors.textDim }}
+													color={theme.colors.textDim}
 												>
 													<RefreshCw
 														className={`w-3 h-3 ${refreshingAgent === agent.id ? 'animate-spin' : ''}`}
 													/>
-												</button>
+												</GhostIconButton>
 											</>
 										) : (
 											<span

--- a/src/renderer/components/NewInstanceModal/EditAgentModal.tsx
+++ b/src/renderer/components/NewInstanceModal/EditAgentModal.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import { AlertTriangle, Copy, Check, X } from 'lucide-react';
+import { GhostIconButton } from '../ui/GhostIconButton';
 import type { AgentConfig, ToolType } from '../../types';
 import type { SshRemoteConfig, AgentSshRemoteConfig } from '../../../shared/types';
 import { MODAL_PRIORITIES } from '../../constants/modalPriorities';
@@ -414,15 +415,9 @@ export function EditAgentModal({
 							{copiedId ? <Check className="w-3 h-3" /> : <Copy className="w-3 h-3" />}
 							<span>{session.id.slice(0, 8)}</span>
 						</button>
-						<button
-							type="button"
-							onClick={onClose}
-							className="p-1 rounded hover:bg-white/10 transition-colors"
-							style={{ color: theme.colors.textDim }}
-							aria-label="Close modal"
-						>
+						<GhostIconButton onClick={onClose} ariaLabel="Close modal" color={theme.colors.textDim}>
 							<X className="w-4 h-4" />
-						</button>
+						</GhostIconButton>
 					</div>
 				</div>
 			}

--- a/src/renderer/components/NotificationsPanel.tsx
+++ b/src/renderer/components/NotificationsPanel.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { Bell, Volume2, Clock, Square, Check, AlertCircle, Loader2, Coffee } from 'lucide-react';
+import { Spinner } from './ui/Spinner';
 import type { Theme } from '../types';
 import { SettingCheckbox } from './SettingCheckbox';
 import { ToggleButtonGroup } from './ToggleButtonGroup';
@@ -230,7 +231,7 @@ export function NotificationsPanel({
 							>
 								{testStatus === 'running' ? (
 									<>
-										<Loader2 className="w-3 h-3 animate-spin" />
+										<Spinner size={12} />
 										Running
 									</>
 								) : testStatus === 'success' ? (

--- a/src/renderer/components/PlaygroundPanel.tsx
+++ b/src/renderer/components/PlaygroundPanel.tsx
@@ -11,6 +11,7 @@ import {
 	Music,
 	Wand2,
 } from 'lucide-react';
+import { GhostIconButton } from './ui/GhostIconButton';
 import confetti from 'canvas-confetti';
 import type { Theme, AutoRunStats, ThemeMode } from '../types';
 import { useLayerStack } from '../contexts/LayerStackContext';
@@ -595,13 +596,9 @@ ${staggerDelays.map((delay, i) => `svg.wand-sparkle-active path:nth-child(${i + 
 								Developer Playground
 							</h2>
 						</div>
-						<button
-							onClick={onClose}
-							className="p-1 rounded hover:bg-white/10 transition-colors"
-							style={{ color: theme.colors.textDim }}
-						>
+						<GhostIconButton onClick={onClose} color={theme.colors.textDim}>
 							<X className="w-5 h-5" />
-						</button>
+						</GhostIconButton>
 					</div>
 
 					{/* Tabs */}

--- a/src/renderer/components/PromptComposerModal.tsx
+++ b/src/renderer/components/PromptComposerModal.tsx
@@ -13,6 +13,7 @@ import {
 	File,
 	Folder,
 } from 'lucide-react';
+import { GhostIconButton } from './ui/GhostIconButton';
 import type { Theme, ThinkingMode, Session, Group } from '../types';
 import { useLayerStack } from '../contexts/LayerStackContext';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
@@ -492,16 +493,16 @@ export function PromptComposerModal({
 						</span>
 					</div>
 					<div className="flex items-center gap-3">
-						<button
+						<GhostIconButton
 							onClick={() => {
 								onSubmit(value);
 								onClose();
 							}}
-							className="p-1.5 rounded hover:bg-white/10 transition-colors"
+							padding="p-1.5"
 							title="Close (Escape)"
 						>
 							<X className="w-5 h-5" style={{ color: theme.colors.textDim }} />
-						</button>
+						</GhostIconButton>
 					</div>
 				</div>
 

--- a/src/renderer/components/RightPanel.tsx
+++ b/src/renderer/components/RightPanel.tsx
@@ -10,13 +10,13 @@ import React, {
 import {
 	PanelRightClose,
 	PanelRightOpen,
-	Loader2,
 	GitBranch,
 	Skull,
 	AlertTriangle,
 	Play,
 	XCircle,
 } from 'lucide-react';
+import { Spinner } from './ui/Spinner';
 import type { Session, Theme, RightPanelTab, BatchRunState } from '../types';
 import type { FileTreeChanges } from '../utils/fileExplorer';
 import { FileExplorerPanel } from './FileExplorerPanel';
@@ -570,10 +570,7 @@ export const RightPanel = memo(
 								{errorPaused ? (
 									<AlertTriangle className="w-4 h-4" style={{ color: theme.colors.error }} />
 								) : (
-									<Loader2
-										className="w-4 h-4 animate-spin"
-										style={{ color: theme.colors.warning }}
-									/>
+									<Spinner size={16} color={theme.colors.warning} />
 								)}
 								{errorPaused ? (
 									<button

--- a/src/renderer/components/SendToAgentModal.tsx
+++ b/src/renderer/components/SendToAgentModal.tsx
@@ -15,6 +15,8 @@
 
 import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import { Search, ArrowRight, X, Loader2, Circle } from 'lucide-react';
+import { GhostIconButton } from './ui/GhostIconButton';
+import { Spinner } from './ui/Spinner';
 import type { Theme, Session, ToolType } from '../types';
 import type { MergeResult } from '../types/contextMerge';
 import { fuzzyMatchWithScore } from '../utils/search';
@@ -460,15 +462,9 @@ export function SendToAgentModal({
 							Send Context to Agent
 						</h2>
 					</div>
-					<button
-						type="button"
-						onClick={onClose}
-						className="p-1 rounded hover:bg-white/10 transition-colors"
-						style={{ color: theme.colors.textDim }}
-						aria-label="Close dialog"
-					>
+					<GhostIconButton onClick={onClose} ariaLabel="Close dialog" color={theme.colors.textDim}>
 						<X className="w-4 h-4" aria-hidden="true" />
-					</button>
+					</GhostIconButton>
 				</div>
 
 				{/* Description for screen readers */}
@@ -602,7 +598,7 @@ export function SendToAgentModal({
 												aria-hidden="true"
 											>
 												{session.status === 'idle' && <Circle className="w-2 h-2 fill-current" />}
-												{session.status === 'busy' && <Loader2 className="w-3 h-3 animate-spin" />}
+												{session.status === 'busy' && <Spinner size={12} />}
 												{getStatusLabel(session.status)}
 											</div>
 

--- a/src/renderer/components/SessionItem.tsx
+++ b/src/renderer/components/SessionItem.tsx
@@ -1,5 +1,6 @@
 import React, { memo } from 'react';
 import { Activity, GitBranch, Bot, Bookmark, AlertCircle, Server, Zap } from 'lucide-react';
+import { GhostIconButton } from './ui/GhostIconButton';
 import type { Session, Group, Theme } from '../types';
 import { getStatusColor } from '../utils/theme';
 
@@ -319,12 +320,12 @@ export const SessionItem = memo(function SessionItem({
 								/>
 							</button>
 						) : (
-							<button
+							<GhostIconButton
 								onClick={(e) => {
 									e.stopPropagation();
 									onToggleBookmark();
 								}}
-								className="p-0.5 rounded hover:bg-white/10 transition-colors"
+								padding="p-0.5"
 								title="Remove bookmark"
 							>
 								<Bookmark
@@ -332,7 +333,7 @@ export const SessionItem = memo(function SessionItem({
 									style={{ color: theme.colors.accent }}
 									fill={theme.colors.accent}
 								/>
-							</button>
+							</GhostIconButton>
 						))}
 
 					{/* AI Status Indicator with Unread Badge */}

--- a/src/renderer/components/SessionList/SessionList.tsx
+++ b/src/renderer/components/SessionList/SessionList.tsx
@@ -15,6 +15,7 @@ import {
 	Trash2,
 	Bot,
 } from 'lucide-react';
+import { GhostIconButton } from '../ui/GhostIconButton';
 import type { Session, Group, Theme } from '../../types';
 import { getBadgeForTime } from '../../constants/conductorBadges';
 import { SessionItem } from '../SessionItem';
@@ -826,14 +827,14 @@ function SessionListInner(props: SessionListProps) {
 						<div className="flex items-center">
 							{/* Hamburger Menu */}
 							<div className="relative z-30" ref={menuRef} data-tour="hamburger-menu">
-								<button
+								<GhostIconButton
 									onClick={() => setMenuOpen(!menuOpen)}
-									className="p-2 rounded hover:bg-white/10 transition-colors"
-									style={{ color: theme.colors.textDim }}
+									padding="p-2"
 									title="Menu"
+									color={theme.colors.textDim}
 								>
 									<Menu className="w-4 h-4" />
-								</button>
+								</GhostIconButton>
 								{/* Menu Overlay */}
 								{menuOpen && (
 									<div
@@ -859,16 +860,12 @@ function SessionListInner(props: SessionListProps) {
 					</>
 				) : (
 					<div className="w-full flex flex-col items-center gap-2 relative z-30" ref={menuRef}>
-						<button
-							onClick={() => setMenuOpen(!menuOpen)}
-							className="p-2 rounded hover:bg-white/10 transition-colors"
-							title="Menu"
-						>
+						<GhostIconButton onClick={() => setMenuOpen(!menuOpen)} padding="p-2" title="Menu">
 							<Wand2
 								className={`w-6 h-6${isAnyBusy ? ' wand-sparkle-active' : ''}`}
 								style={{ color: theme.colors.accent }}
 							/>
-						</button>
+						</GhostIconButton>
 						{/* Menu Overlay for Collapsed Sidebar */}
 						{menuOpen && (
 							<div

--- a/src/renderer/components/Settings/EnvVarsEditor.tsx
+++ b/src/renderer/components/Settings/EnvVarsEditor.tsx
@@ -13,6 +13,7 @@
 
 import { useState, useEffect } from 'react';
 import { Plus, Trash2 } from 'lucide-react';
+import { GhostIconButton } from '../ui/GhostIconButton';
 import type { Theme } from '../../types';
 
 export interface EnvVarEntry {
@@ -190,14 +191,14 @@ export function EnvVarsEditor({
 									className="flex-1 p-2 rounded border bg-transparent outline-none text-xs font-mono"
 									style={{ borderColor: theme.colors.border, color: theme.colors.textMain }}
 								/>
-								<button
+								<GhostIconButton
 									onClick={() => removeEntry(entry.id)}
-									className="p-2 rounded hover:bg-white/10 transition-colors"
+									padding="p-2"
 									title="Remove variable"
-									style={{ color: theme.colors.textDim }}
+									color={theme.colors.textDim}
 								>
 									<Trash2 className="w-3 h-3" />
-								</button>
+								</GhostIconButton>
 							</div>
 							{error && (
 								<p className="text-xs mt-1 px-2" style={{ color: '#ef4444' }}>

--- a/src/renderer/components/Settings/SettingsSearch.tsx
+++ b/src/renderer/components/Settings/SettingsSearch.tsx
@@ -11,6 +11,7 @@
 import React, { type ReactNode } from 'react';
 import { useState, useRef, useEffect, useCallback } from 'react';
 import { Search, X } from 'lucide-react';
+import { GhostIconButton } from '../ui/GhostIconButton';
 import type { Theme } from '../../types';
 import { searchSettings, type SearchableSetting } from './searchableSettings';
 
@@ -117,13 +118,9 @@ export function SettingsSearchInput({
 					>
 						{results.length}
 					</span>
-					<button
-						onClick={onClear}
-						className="p-0.5 rounded hover:bg-white/10 transition-colors"
-						aria-label="Clear search"
-					>
+					<GhostIconButton onClick={onClear} padding="p-0.5" ariaLabel="Clear search">
 						<X className="w-3.5 h-3.5" style={{ color: theme.colors.textDim }} />
-					</button>
+					</GhostIconButton>
 				</>
 			)}
 			{!isActive && (

--- a/src/renderer/components/Settings/SshRemoteModal.tsx
+++ b/src/renderer/components/Settings/SshRemoteModal.tsx
@@ -23,16 +23,9 @@
  */
 
 import React, { useState, useRef, useEffect, useCallback } from 'react';
-import {
-	Server,
-	Plus,
-	Trash2,
-	CheckCircle,
-	XCircle,
-	Loader2,
-	FileCode,
-	ChevronDown,
-} from 'lucide-react';
+import { Server, Plus, Trash2, CheckCircle, XCircle, FileCode, ChevronDown } from 'lucide-react';
+import { GhostIconButton } from '../ui/GhostIconButton';
+import { Spinner } from '../ui/Spinner';
 import type { Theme } from '../../types';
 import type { SshRemoteConfig, SshRemoteTestResult } from '../../../shared/types';
 import { MODAL_PRIORITIES } from '../../constants/modalPriorities';
@@ -465,7 +458,7 @@ export function SshRemoteModal({
 						>
 							{testing ? (
 								<>
-									<Loader2 className="w-4 h-4 animate-spin" />
+									<Spinner size={16} />
 									Testing...
 								</>
 							) : (
@@ -559,7 +552,7 @@ export function SshRemoteModal({
 							>
 								{sshConfigLoading ? (
 									<span className="flex items-center gap-2">
-										<Loader2 className="w-3 h-3 animate-spin" />
+										<Spinner size={12} />
 										Loading...
 									</span>
 								) : (
@@ -768,15 +761,14 @@ export function SshRemoteModal({
 											color: theme.colors.textMain,
 										}}
 									/>
-									<button
-										type="button"
+									<GhostIconButton
 										onClick={() => removeEnvVar(entry.id)}
-										className="p-2 rounded hover:bg-white/10 transition-colors"
+										padding="p-2"
 										title="Remove variable"
-										style={{ color: theme.colors.textDim }}
+										color={theme.colors.textDim}
 									>
 										<Trash2 className="w-3 h-3" />
-									</button>
+									</GhostIconButton>
 								</div>
 							))}
 						</div>

--- a/src/renderer/components/Settings/SshRemoteModal.tsx
+++ b/src/renderer/components/Settings/SshRemoteModal.tsx
@@ -765,6 +765,7 @@ export function SshRemoteModal({
 										onClick={() => removeEnvVar(entry.id)}
 										padding="p-2"
 										title="Remove variable"
+										ariaLabel="Remove variable"
 										color={theme.colors.textDim}
 									>
 										<Trash2 className="w-3 h-3" />

--- a/src/renderer/components/Settings/SshRemotesSection.tsx
+++ b/src/renderer/components/Settings/SshRemotesSection.tsx
@@ -27,10 +27,11 @@ import {
 	Check,
 	CheckCircle,
 	XCircle,
-	Loader2,
 	Wifi,
 	WifiOff,
 } from 'lucide-react';
+import { GhostIconButton } from '../ui/GhostIconButton';
+import { Spinner } from '../ui/Spinner';
 import type { Theme } from '../../types';
 import type { SshRemoteConfig } from '../../../shared/types';
 import { useSshRemotes } from '../../hooks';
@@ -132,7 +133,7 @@ export function SshRemotesSection({ theme }: SshRemotesSectionProps) {
 				className="flex items-center gap-3 p-4 rounded-xl border"
 				style={{ backgroundColor: theme.colors.bgMain, borderColor: theme.colors.border }}
 			>
-				<Loader2 className="w-5 h-5 animate-spin" style={{ color: theme.colors.accent }} />
+				<Spinner size={20} color={theme.colors.accent} />
 				<span className="text-sm" style={{ color: theme.colors.textDim }}>
 					Loading SSH remotes...
 				</span>
@@ -270,7 +271,7 @@ export function SshRemotesSection({ theme }: SshRemotesSectionProps) {
 													title="Test connection"
 												>
 													{isTesting ? (
-														<Loader2 className="w-4 h-4 animate-spin" />
+														<Spinner size={16} />
 													) : config.enabled ? (
 														<Wifi className="w-4 h-4" />
 													) : (
@@ -295,15 +296,14 @@ export function SshRemotesSection({ theme }: SshRemotesSectionProps) {
 												</button>
 
 												{/* Edit */}
-												<button
-													type="button"
+												<GhostIconButton
 													onClick={() => handleEdit(config)}
-													className="p-1.5 rounded hover:bg-white/10 transition-colors"
-													style={{ color: theme.colors.textDim }}
+													padding="p-1.5"
 													title="Edit"
+													color={theme.colors.textDim}
 												>
 													<Edit2 className="w-4 h-4" />
-												</button>
+												</GhostIconButton>
 
 												{/* Delete */}
 												<button
@@ -314,11 +314,7 @@ export function SshRemotesSection({ theme }: SshRemotesSectionProps) {
 													style={{ color: theme.colors.error }}
 													title="Delete"
 												>
-													{isDeleting ? (
-														<Loader2 className="w-4 h-4 animate-spin" />
-													) : (
-														<Trash2 className="w-4 h-4" />
-													)}
+													{isDeleting ? <Spinner size={16} /> : <Trash2 className="w-4 h-4" />}
 												</button>
 											</div>
 										</div>

--- a/src/renderer/components/ShortcutsHelpModal.tsx
+++ b/src/renderer/components/ShortcutsHelpModal.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useMemo } from 'react';
 import { X, Award, CheckCircle, Trophy, ExternalLink } from 'lucide-react';
+import { GhostIconButton } from './ui/GhostIconButton';
 import type { Theme, Shortcut, KeyboardMasteryStats } from '../types';
 import { fuzzyMatch } from '../utils/search';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
@@ -73,13 +74,9 @@ export function ShortcutsHelpModal({
 						{searchQuery ? `${filteredCount} / ${totalShortcuts}` : totalShortcuts}
 					</span>
 				</div>
-				<button
-					onClick={onClose}
-					className="p-1 rounded hover:bg-white/10 transition-colors"
-					style={{ color: theme.colors.textDim }}
-				>
+				<GhostIconButton onClick={onClose} color={theme.colors.textDim}>
 					<X className="w-4 h-4" />
-				</button>
+				</GhostIconButton>
 			</div>
 
 			{hasNoAgents && (

--- a/src/renderer/components/ShortcutsHelpModal.tsx
+++ b/src/renderer/components/ShortcutsHelpModal.tsx
@@ -74,7 +74,7 @@ export function ShortcutsHelpModal({
 						{searchQuery ? `${filteredCount} / ${totalShortcuts}` : totalShortcuts}
 					</span>
 				</div>
-				<GhostIconButton onClick={onClose} color={theme.colors.textDim}>
+				<GhostIconButton onClick={onClose} color={theme.colors.textDim} ariaLabel="Close">
 					<X className="w-4 h-4" />
 				</GhostIconButton>
 			</div>

--- a/src/renderer/components/SummarizeProgressOverlay.tsx
+++ b/src/renderer/components/SummarizeProgressOverlay.tsx
@@ -14,7 +14,9 @@
  */
 
 import { useState, useEffect, memo, useCallback } from 'react';
-import { X, Check, Loader2, AlertTriangle, Wand2 } from 'lucide-react';
+import { X, Check, AlertTriangle, Wand2 } from 'lucide-react';
+import { GhostIconButton } from './ui/GhostIconButton';
+import { Spinner } from './ui/Spinner';
 import type { Theme } from '../types';
 import type { SummarizeProgress, SummarizeResult } from '../types/contextMerge';
 
@@ -229,15 +231,13 @@ export const SummarizeProgressOverlay = memo(function SummarizeProgressOverlay({
 								)}
 							</div>
 							{!isComplete && (
-								<button
-									type="button"
+								<GhostIconButton
 									onClick={handleCancelClick}
-									className="p-1 rounded hover:bg-white/10 transition-colors"
-									style={{ color: theme.colors.textDim }}
 									title="Cancel"
+									color={theme.colors.textDim}
 								>
 									<X className="w-4 h-4" />
-								</button>
+								</GhostIconButton>
 							)}
 						</div>
 
@@ -278,10 +278,7 @@ export const SummarizeProgressOverlay = memo(function SummarizeProgressOverlay({
 											{isCompleted ? (
 												<Check className="w-3 h-3" style={{ color: theme.colors.success }} />
 											) : isActive ? (
-												<Loader2
-													className="w-3 h-3 animate-spin"
-													style={{ color: theme.colors.accent }}
-												/>
+												<Spinner size={12} color={theme.colors.accent} />
 											) : (
 												<div
 													className="w-3 h-3 rounded-full border"

--- a/src/renderer/components/SymphonyModal.tsx
+++ b/src/renderer/components/SymphonyModal.tsx
@@ -41,6 +41,8 @@ import {
 	Lock,
 	Star,
 } from 'lucide-react';
+import { GhostIconButton } from './ui/GhostIconButton';
+import { Spinner } from './ui/Spinner';
 import type { Theme, Session } from '../types';
 import type {
 	RegisteredRepository,
@@ -147,12 +149,12 @@ function getStatusInfo(status: ContributionStatus): {
 	icon: React.ReactNode;
 } {
 	const icons: Record<string, React.ReactNode> = {
-		cloning: <Loader2 className="w-3 h-3 animate-spin" />,
-		creating_pr: <Loader2 className="w-3 h-3 animate-spin" />,
+		cloning: <Spinner size={12} />,
+		creating_pr: <Spinner size={12} />,
 		running: <Play className="w-3 h-3" />,
 		paused: <Pause className="w-3 h-3" />,
 		completed: <CheckCircle className="w-3 h-3" />,
-		completing: <Loader2 className="w-3 h-3 animate-spin" />,
+		completing: <Spinner size={12} />,
 		ready_for_review: <GitPullRequest className="w-3 h-3" />,
 		failed: <AlertCircle className="w-3 h-3" />,
 		cancelled: <X className="w-3 h-3" />,
@@ -571,13 +573,9 @@ function RepositoryDetailView({
 				style={{ borderColor: theme.colors.border }}
 			>
 				<div className="flex items-center gap-3">
-					<button
-						onClick={onBack}
-						className="p-1.5 rounded hover:bg-white/10 transition-colors"
-						title="Back (Esc)"
-					>
+					<GhostIconButton onClick={onBack} padding="p-1.5" title="Back (Esc)">
 						<ArrowLeft className="w-5 h-5" style={{ color: theme.colors.textDim }} />
-					</button>
+					</GhostIconButton>
 					<div className="flex items-center gap-2">
 						<Music className="w-5 h-5" style={{ color: theme.colors.accent }} />
 						<h2 className="text-lg font-semibold" style={{ color: theme.colors.textMain }}>
@@ -593,14 +591,13 @@ function RepositoryDetailView({
 						<span>{categoryInfo.emoji}</span>
 						<span>{categoryInfo.label}</span>
 					</span>
-					<button
-						type="button"
-						className="p-1.5 rounded hover:bg-white/10 transition-colors"
-						title="View repository on GitHub"
+					<GhostIconButton
 						onClick={() => handleOpenExternal(repo.url)}
+						padding="p-1.5"
+						title="View repository on GitHub"
 					>
 						<ExternalLink className="w-5 h-5" style={{ color: theme.colors.textDim }} />
-					</button>
+					</GhostIconButton>
 				</div>
 			</div>
 
@@ -718,12 +715,7 @@ function RepositoryDetailView({
 									style={{ color: theme.colors.textDim }}
 								>
 									<span>Available Issues ({availableIssues.length})</span>
-									{isLoadingIssues && (
-										<Loader2
-											className="w-3 h-3 animate-spin"
-											style={{ color: theme.colors.accent }}
-										/>
-									)}
+									{isLoadingIssues && <Spinner size={12} color={theme.colors.accent} />}
 								</h4>
 								{availableIssues.length === 0 && blockedIssues.length === 0 ? (
 									<p className="text-sm text-center py-4" style={{ color: theme.colors.textDim }}>
@@ -869,10 +861,7 @@ function RepositoryDetailView({
 								<style>{proseStyles}</style>
 								{isLoadingDocument ? (
 									<div className="flex items-center justify-center h-32">
-										<Loader2
-											className="w-6 h-6 animate-spin"
-											style={{ color: theme.colors.accent }}
-										/>
+										<Spinner size={24} color={theme.colors.accent} />
 									</div>
 								) : documentPreview ? (
 									<div
@@ -957,7 +946,7 @@ function RepositoryDetailView({
 					>
 						{isStarting ? (
 							<>
-								<Loader2 className="w-4 h-4 animate-spin" />
+								<Spinner size={16} />
 								Starting...
 							</>
 						) : (
@@ -1867,13 +1856,9 @@ export function SymphonyModal({
 										style={{ color: theme.colors.textDim }}
 									/>
 								</button>
-								<button
-									onClick={onClose}
-									className="p-1.5 rounded hover:bg-white/10 transition-colors"
-									title="Close (Esc)"
-								>
+								<GhostIconButton onClick={onClose} padding="p-1.5" title="Close (Esc)">
 									<X className="w-4 h-4" style={{ color: theme.colors.textDim }} />
-								</button>
+								</GhostIconButton>
 							</div>
 						</div>
 
@@ -2387,10 +2372,7 @@ export function SymphonyModal({
 						>
 							{isCheckingGh ? (
 								<div className="flex items-center gap-3 py-4">
-									<Loader2
-										className="w-5 h-5 animate-spin"
-										style={{ color: theme.colors.textDim }}
-									/>
+									<Spinner size={20} color={theme.colors.textDim} />
 									<span className="text-sm" style={{ color: theme.colors.textDim }}>
 										Checking prerequisites…
 									</span>

--- a/src/renderer/components/ToolCallCard.tsx
+++ b/src/renderer/components/ToolCallCard.tsx
@@ -1,5 +1,6 @@
 import { useState, memo } from 'react';
-import { ChevronDown, ChevronRight, Clock, CheckCircle2, Loader2, AlertCircle } from 'lucide-react';
+import { ChevronDown, ChevronRight, Clock, CheckCircle2, AlertCircle } from 'lucide-react';
+import { Spinner } from './ui/Spinner';
 import type { Theme } from '../types';
 
 /**
@@ -51,9 +52,7 @@ function StatusIcon({ status, theme }: { status?: string; theme: Theme }) {
 			return <CheckCircle2 className="w-3.5 h-3.5" style={{ color: theme.colors.success }} />;
 		case 'running':
 		case 'pending':
-			return (
-				<Loader2 className="w-3.5 h-3.5 animate-spin" style={{ color: theme.colors.warning }} />
-			);
+			return <Spinner size={14} color={theme.colors.warning} />;
 		case 'error':
 		case 'failed':
 			return <AlertCircle className="w-3.5 h-3.5" style={{ color: theme.colors.error }} />;

--- a/src/renderer/components/TransferProgressModal.tsx
+++ b/src/renderer/components/TransferProgressModal.tsx
@@ -17,7 +17,9 @@
  */
 
 import { useState, useEffect, useRef, useMemo, useCallback, memo } from 'react';
-import { X, Check, Loader2, AlertTriangle, ArrowRight, Wand2 } from 'lucide-react';
+import { X, Check, AlertTriangle, ArrowRight, Wand2 } from 'lucide-react';
+import { GhostIconButton } from './ui/GhostIconButton';
+import { Spinner } from './ui/Spinner';
 import type { Theme, ToolType } from '../types';
 import type { GroomingProgress } from '../types/contextMerge';
 import { useLayerStack } from '../contexts/LayerStackContext';
@@ -112,7 +114,7 @@ ElapsedTimeDisplay.displayName = 'ElapsedTimeDisplay';
 /**
  * Animated spinner component
  */
-function Spinner({ theme }: { theme: Theme }) {
+function CircularSpinner({ theme }: { theme: Theme }) {
 	return (
 		<div className="relative">
 			<div
@@ -379,15 +381,13 @@ export function TransferProgressModal({
 						{isComplete ? 'Transfer Complete' : 'Transferring Context...'}
 					</h2>
 					{isComplete && (
-						<button
-							type="button"
+						<GhostIconButton
 							onClick={() => onComplete?.() || onCancel()}
-							className="p-1 rounded hover:bg-white/10 transition-colors"
-							style={{ color: theme.colors.textDim }}
-							aria-label="Close modal"
+							ariaLabel="Close modal"
+							color={theme.colors.textDim}
 						>
 							<X className="w-4 h-4" />
-						</button>
+						</GhostIconButton>
 					)}
 				</div>
 
@@ -410,7 +410,7 @@ export function TransferProgressModal({
 								<Check className="w-6 h-6" style={{ color: theme.colors.success }} />
 							</div>
 						) : (
-							<Spinner theme={theme} />
+							<CircularSpinner theme={theme} />
 						)}
 					</div>
 
@@ -470,10 +470,7 @@ export function TransferProgressModal({
 												<Check className="w-3 h-3" style={{ color: '#fff' }} />
 											</div>
 										) : isActive ? (
-											<Loader2
-												className="w-5 h-5 animate-spin"
-												style={{ color: theme.colors.accent }}
-											/>
+											<Spinner size={20} color={theme.colors.accent} />
 										) : (
 											<div
 												className="w-5 h-5 rounded-full border-2"

--- a/src/renderer/components/TransferProgressModal.tsx
+++ b/src/renderer/components/TransferProgressModal.tsx
@@ -382,7 +382,13 @@ export function TransferProgressModal({
 					</h2>
 					{isComplete && (
 						<GhostIconButton
-							onClick={() => onComplete?.() || onCancel()}
+							onClick={() => {
+								if (onComplete) {
+									onComplete();
+								} else {
+									onCancel();
+								}
+							}}
 							ariaLabel="Close modal"
 							color={theme.colors.textDim}
 						>

--- a/src/renderer/components/UpdateCheckModal.tsx
+++ b/src/renderer/components/UpdateCheckModal.tsx
@@ -3,7 +3,6 @@ import {
 	X,
 	Download,
 	ExternalLink,
-	Loader2,
 	CheckCircle2,
 	AlertCircle,
 	RefreshCw,
@@ -12,6 +11,8 @@ import {
 	RotateCcw,
 	FlaskConical,
 } from 'lucide-react';
+import { GhostIconButton } from './ui/GhostIconButton';
+import { Spinner } from './ui/Spinner';
 import type { Theme } from '../types';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
 import ReactMarkdown from 'react-markdown';
@@ -191,13 +192,9 @@ export function UpdateCheckModal({ theme, onClose }: UpdateCheckModalProps) {
 						style={{ color: theme.colors.textDim }}
 					/>
 				</button>
-				<button
-					onClick={onClose}
-					className="p-1 rounded hover:bg-white/10 transition-colors"
-					style={{ color: theme.colors.textDim }}
-				>
+				<GhostIconButton onClick={onClose} color={theme.colors.textDim}>
 					<X className="w-4 h-4" />
-				</button>
+				</GhostIconButton>
 			</div>
 		</div>
 	);
@@ -215,7 +212,7 @@ export function UpdateCheckModal({ theme, onClose }: UpdateCheckModalProps) {
 			<div className="space-y-4 -my-2">
 				{loading ? (
 					<div className="flex flex-col items-center justify-center py-8 gap-3">
-						<Loader2 className="w-8 h-8 animate-spin" style={{ color: theme.colors.accent }} />
+						<Spinner size={32} color={theme.colors.accent} />
 						<span className="text-sm" style={{ color: theme.colors.textDim }}>
 							Checking for updates...
 						</span>
@@ -437,7 +434,7 @@ export function UpdateCheckModal({ theme, onClose }: UpdateCheckModalProps) {
 									className="w-full flex items-center justify-center gap-2 p-3 rounded-lg text-sm"
 									style={{ backgroundColor: theme.colors.bgActivity, color: theme.colors.textDim }}
 								>
-									<Loader2 className="w-4 h-4 animate-spin" />
+									<Spinner size={16} />
 									Binaries are still building...
 								</div>
 							) : (
@@ -449,7 +446,7 @@ export function UpdateCheckModal({ theme, onClose }: UpdateCheckModalProps) {
 								>
 									{isDownloading ? (
 										<>
-											<Loader2 className="w-4 h-4 animate-spin" />
+											<Spinner size={16} />
 											Downloading...
 										</>
 									) : (

--- a/src/renderer/components/UpdateCheckModal.tsx
+++ b/src/renderer/components/UpdateCheckModal.tsx
@@ -192,7 +192,7 @@ export function UpdateCheckModal({ theme, onClose }: UpdateCheckModalProps) {
 						style={{ color: theme.colors.textDim }}
 					/>
 				</button>
-				<GhostIconButton onClick={onClose} color={theme.colors.textDim}>
+				<GhostIconButton onClick={onClose} color={theme.colors.textDim} ariaLabel="Close">
 					<X className="w-4 h-4" />
 				</GhostIconButton>
 			</div>

--- a/src/renderer/components/Wizard/screens/PhaseReviewScreen.tsx
+++ b/src/renderer/components/Wizard/screens/PhaseReviewScreen.tsx
@@ -15,7 +15,8 @@
  */
 
 import { useEffect, useCallback, useRef, useState } from 'react';
-import { Loader2, Rocket, Compass, X } from 'lucide-react';
+import { Rocket, Compass, X } from 'lucide-react';
+import { Spinner } from '../../ui/Spinner';
 import type { Theme } from '../../../types';
 import { useWizard } from '../WizardContext';
 import { PLAYBOOKS_DIR } from '../../../../shared/maestro-paths';
@@ -535,11 +536,7 @@ function DocumentReview({
 							['--tw-ring-offset-color' as any]: theme.colors.bgSidebar,
 						}}
 					>
-						{launchingButton === 'ready' ? (
-							<Loader2 className="w-5 h-5 animate-spin" />
-						) : (
-							<Rocket className="w-5 h-5" />
-						)}
+						{launchingButton === 'ready' ? <Spinner size={20} /> : <Rocket className="w-5 h-5" />}
 						{launchingButton === 'ready' ? 'Launching...' : "I'm Ready to Go"}
 					</button>
 
@@ -559,11 +556,7 @@ function DocumentReview({
 							['--tw-ring-offset-color' as any]: theme.colors.bgSidebar,
 						}}
 					>
-						{launchingButton === 'tour' ? (
-							<Loader2 className="w-5 h-5 animate-spin" />
-						) : (
-							<Compass className="w-5 h-5" />
-						)}
+						{launchingButton === 'tour' ? <Spinner size={20} /> : <Compass className="w-5 h-5" />}
 						{launchingButton === 'tour' ? 'Launching...' : 'Walk Me Through the Interface'}
 					</button>
 				</div>

--- a/src/renderer/components/Wizard/shared/DocumentEditor.tsx
+++ b/src/renderer/components/Wizard/shared/DocumentEditor.tsx
@@ -18,7 +18,8 @@
 import { useState, useCallback, useMemo, useEffect } from 'react';
 import ReactMarkdown from 'react-markdown';
 import rehypeSlug from 'rehype-slug';
-import { Eye, Edit, ChevronDown, ChevronRight, X, Loader2 } from 'lucide-react';
+import { Eye, Edit, ChevronDown, ChevronRight, X } from 'lucide-react';
+import { Spinner } from '../../ui/Spinner';
 import type { Theme } from '../../../types';
 import { MermaidRenderer } from '../../MermaidRenderer';
 import type { GeneratedDocument } from '../WizardContext';
@@ -137,7 +138,7 @@ export function MarkdownImage({
 				className="inline-flex items-center gap-2 px-3 py-2 rounded"
 				style={{ backgroundColor: theme.colors.bgActivity }}
 			>
-				<Loader2 className="w-4 h-4 animate-spin" style={{ color: theme.colors.textDim }} />
+				<Spinner size={16} color={theme.colors.textDim} />
 				<span className="text-xs" style={{ color: theme.colors.textDim }}>
 					Loading...
 				</span>

--- a/src/renderer/components/WorktreeConfigModal.tsx
+++ b/src/renderer/components/WorktreeConfigModal.tsx
@@ -1,5 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
-import { X, GitBranch, FolderOpen, Plus, Loader2, AlertTriangle, Server } from 'lucide-react';
+import { X, GitBranch, FolderOpen, Plus, AlertTriangle, Server } from 'lucide-react';
+import { GhostIconButton } from './ui/GhostIconButton';
+import { Spinner } from './ui/Spinner';
 import type { Theme, Session, GhCliStatus } from '../types';
 import { useLayerStack } from '../contexts/LayerStackContext';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
@@ -204,9 +206,9 @@ export function WorktreeConfigModal({
 							Worktree Configuration
 						</h2>
 					</div>
-					<button onClick={onClose} className="p-1 rounded hover:bg-white/10 transition-colors">
+					<GhostIconButton onClick={onClose}>
 						<X className="w-4 h-4" style={{ color: theme.colors.textDim }} />
-					</button>
+					</GhostIconButton>
 				</div>
 
 				{/* Content */}
@@ -368,11 +370,7 @@ export function WorktreeConfigModal({
 									color: theme.colors.accentForeground,
 								}}
 							>
-								{isCreating ? (
-									<Loader2 className="w-4 h-4 animate-spin" />
-								) : (
-									<Plus className="w-4 h-4" />
-								)}
+								{isCreating ? <Spinner size={16} /> : <Plus className="w-4 h-4" />}
 								Create
 							</button>
 						</div>
@@ -436,7 +434,7 @@ export function WorktreeConfigModal({
 							color: theme.colors.accentForeground,
 						}}
 					>
-						{isValidating && <Loader2 className="w-4 h-4 animate-spin" />}
+						{isValidating && <Spinner size={16} />}
 						{isValidating ? 'Validating...' : 'Save Configuration'}
 					</button>
 				</div>

--- a/src/renderer/components/WorktreeConfigModal.tsx
+++ b/src/renderer/components/WorktreeConfigModal.tsx
@@ -206,7 +206,7 @@ export function WorktreeConfigModal({
 							Worktree Configuration
 						</h2>
 					</div>
-					<GhostIconButton onClick={onClose}>
+					<GhostIconButton onClick={onClose} ariaLabel="Close">
 						<X className="w-4 h-4" style={{ color: theme.colors.textDim }} />
 					</GhostIconButton>
 				</div>

--- a/src/renderer/components/shared/AgentConfigPanel.tsx
+++ b/src/renderer/components/shared/AgentConfigPanel.tsx
@@ -15,6 +15,7 @@
 
 import { useState, useRef, useMemo, useEffect } from 'react';
 import { RefreshCw, Plus, Trash2, HelpCircle, ChevronDown } from 'lucide-react';
+import { GhostIconButton } from '../ui/GhostIconButton';
 import type { Theme, AgentConfig, AgentConfigOption } from '../../types';
 
 // Counter for generating stable IDs for env vars
@@ -559,17 +560,17 @@ export function AgentConfigPanel({
 								className="flex-[2] p-2 rounded border bg-transparent outline-none text-xs font-mono"
 								style={{ borderColor: theme.colors.border, color: theme.colors.textMain }}
 							/>
-							<button
+							<GhostIconButton
 								onClick={(e) => {
 									e.stopPropagation();
 									onEnvVarRemove(key);
 								}}
-								className="p-2 rounded hover:bg-white/10 transition-colors"
+								padding="p-2"
 								title="Remove variable"
-								style={{ color: theme.colors.textDim }}
+								color={theme.colors.textDim}
 							>
 								<Trash2 className="w-3 h-3" />
-							</button>
+							</GhostIconButton>
 						</div>
 					))}
 					{/* Add new env var button */}

--- a/src/renderer/components/ui/EmptyStatePlaceholder.tsx
+++ b/src/renderer/components/ui/EmptyStatePlaceholder.tsx
@@ -1,0 +1,81 @@
+/**
+ * EmptyStatePlaceholder - Generic "No X" placeholder
+ *
+ * Displays a centered icon + title + optional description. Used wherever a list
+ * or pane has nothing to show (no results, no selection, no data yet).
+ *
+ * Distinct from the top-level `EmptyStateView` which is the full welcome screen.
+ *
+ * Usage:
+ * ```tsx
+ * <EmptyStatePlaceholder
+ *   theme={theme}
+ *   icon={<List className="w-12 h-12" />}
+ *   title="No sessions match your search"
+ * />
+ *
+ * <EmptyStatePlaceholder
+ *   theme={theme}
+ *   icon={<Search className="w-10 h-10" />}
+ *   title="No matches"
+ *   description="Try adjusting your filters."
+ *   action={<button onClick={reset}>Clear filters</button>}
+ * />
+ * ```
+ */
+
+import type { ReactNode } from 'react';
+import type { Theme } from '../../types';
+
+export interface EmptyStatePlaceholderProps {
+	/** Theme object for styling */
+	theme: Theme;
+	/** Optional icon element (caller sets size). Rendered with reduced opacity. */
+	icon?: ReactNode;
+	/** Primary message */
+	title: string;
+	/** Secondary message / extra context */
+	description?: string;
+	/** Optional action element (e.g. a button) rendered below the description */
+	action?: ReactNode;
+	/** Vertical padding tailwind utility. Defaults to 'py-12' */
+	verticalPadding?: string;
+	/** Horizontal padding tailwind utility. Defaults to 'px-4' */
+	horizontalPadding?: string;
+	/** Additional class names for the outer container */
+	className?: string;
+}
+
+export function EmptyStatePlaceholder({
+	theme,
+	icon,
+	title,
+	description,
+	action,
+	verticalPadding = 'py-12',
+	horizontalPadding = 'px-4',
+	className = '',
+}: EmptyStatePlaceholderProps) {
+	return (
+		<div
+			className={`flex flex-col items-center justify-center ${verticalPadding} ${horizontalPadding} ${className}`.trim()}
+		>
+			{icon && (
+				<div className="mb-4 opacity-30" style={{ color: theme.colors.textDim }}>
+					{icon}
+				</div>
+			)}
+			<p className="text-sm text-center" style={{ color: theme.colors.textDim }}>
+				{title}
+			</p>
+			{description && (
+				<p className="text-xs text-center mt-2 max-w-md" style={{ color: theme.colors.textDim }}>
+					{description}
+				</p>
+			)}
+			{action && <div className="mt-4">{action}</div>}
+		</div>
+	);
+}
+
+export default EmptyStatePlaceholder;

--- a/src/renderer/components/ui/GhostIconButton.tsx
+++ b/src/renderer/components/ui/GhostIconButton.tsx
@@ -1,0 +1,104 @@
+/**
+ * GhostIconButton - Icon-only button with hover background
+ *
+ * Encapsulates the common "p-X rounded hover:bg-white/10 transition-colors" pattern
+ * used throughout the app for toolbar-style icon buttons.
+ *
+ * Usage:
+ * ```tsx
+ * <GhostIconButton
+ *   onClick={handleClose}
+ *   ariaLabel="Close"
+ *   title="Close"
+ *   color={theme.colors.textDim}
+ * >
+ *   <X className="w-4 h-4" />
+ * </GhostIconButton>
+ * ```
+ */
+
+import React, { forwardRef } from 'react';
+import type { CSSProperties, ReactNode, MouseEvent } from 'react';
+
+export interface GhostIconButtonProps {
+	/** Icon (or any) content inside the button */
+	children: ReactNode;
+	/** Click handler */
+	onClick?: (e: MouseEvent<HTMLButtonElement>) => void;
+	/** Native tooltip */
+	title?: string;
+	/** Accessible label (recommended for icon-only buttons) */
+	ariaLabel?: string;
+	/** Padding tailwind utility. Defaults to 'p-1' */
+	padding?: string;
+	/** Icon/text color applied via inline style */
+	color?: string;
+	/** Extra class names appended after the default hover treatment */
+	className?: string;
+	/** Inline style overrides (merged after `color`) */
+	style?: CSSProperties;
+	/** Disabled state */
+	disabled?: boolean;
+	/** Button type. Defaults to 'button' */
+	type?: 'button' | 'submit' | 'reset';
+	/** Test id for automated tests */
+	testId?: string;
+	/** tabIndex override */
+	tabIndex?: number;
+	/** Keydown handler (e.g. custom focus handling) */
+	onKeyDown?: (e: React.KeyboardEvent<HTMLButtonElement>) => void;
+	/** Whether to stop propagation on click. Defaults to false */
+	stopPropagation?: boolean;
+}
+
+/**
+ * Standard ghost-styled icon button.
+ */
+export const GhostIconButton = forwardRef<HTMLButtonElement, GhostIconButtonProps>(
+	function GhostIconButton(
+		{
+			children,
+			onClick,
+			title,
+			ariaLabel,
+			padding = 'p-1',
+			color,
+			className = '',
+			style,
+			disabled = false,
+			type = 'button',
+			testId,
+			tabIndex,
+			onKeyDown,
+			stopPropagation = false,
+		},
+		ref
+	) {
+		const handleClick = (e: MouseEvent<HTMLButtonElement>) => {
+			if (stopPropagation) {
+				e.stopPropagation();
+			}
+			onClick?.(e);
+		};
+
+		return (
+			<button
+				ref={ref}
+				type={type}
+				onClick={handleClick}
+				onKeyDown={onKeyDown}
+				disabled={disabled}
+				title={title}
+				aria-label={ariaLabel}
+				tabIndex={tabIndex}
+				data-testid={testId}
+				className={`${padding} rounded hover:bg-white/10 transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${className}`.trim()}
+				style={{ color, ...style }}
+			>
+				{children}
+			</button>
+		);
+	}
+);
+
+export default GhostIconButton;

--- a/src/renderer/components/ui/Modal.tsx
+++ b/src/renderer/components/ui/Modal.tsx
@@ -36,6 +36,7 @@
 
 import React, { useRef, useEffect, ReactNode } from 'react';
 import { X } from 'lucide-react';
+import { GhostIconButton } from './GhostIconButton';
 import type { Theme } from '../../types';
 import { useModalLayer, type UseModalLayerOptions } from '../../hooks';
 
@@ -165,15 +166,13 @@ export function Modal({
 								</h2>
 							</div>
 							{showCloseButton && (
-								<button
-									type="button"
+								<GhostIconButton
 									onClick={onClose}
-									className="p-1 rounded hover:bg-white/10 transition-colors"
-									style={{ color: theme.colors.textDim }}
-									aria-label="Close modal"
+									ariaLabel="Close modal"
+									color={theme.colors.textDim}
 								>
 									<X className="w-4 h-4" />
-								</button>
+								</GhostIconButton>
 							)}
 						</div>
 					))}

--- a/src/renderer/components/ui/Spinner.tsx
+++ b/src/renderer/components/ui/Spinner.tsx
@@ -1,0 +1,48 @@
+/**
+ * Spinner - Animated loading indicator
+ *
+ * A standard animated loading indicator built on Lucide's Loader2 icon.
+ * Encapsulates the common "animate-spin" pattern used across the app.
+ *
+ * Usage:
+ * ```tsx
+ * <Spinner size={16} />
+ * <Spinner size={24} color={theme.colors.accent} />
+ * <Spinner className="text-blue-500" size={12} />
+ * ```
+ */
+
+import { Loader2 } from 'lucide-react';
+import type { CSSProperties } from 'react';
+
+export interface SpinnerProps {
+	/** Icon size in pixels. Defaults to 16 */
+	size?: number;
+	/** Optional color (applied via inline style). */
+	color?: string;
+	/** Additional class names */
+	className?: string;
+	/** Inline style overrides */
+	style?: CSSProperties;
+	/** Accessible label. Defaults to 'Loading' */
+	ariaLabel?: string;
+}
+
+export function Spinner({
+	size = 16,
+	color,
+	className = '',
+	style,
+	ariaLabel = 'Loading',
+}: SpinnerProps) {
+	return (
+		<Loader2
+			className={`animate-spin ${className}`.trim()}
+			style={{ width: size, height: size, color, ...style }}
+			aria-label={ariaLabel}
+			role="status"
+		/>
+	);
+}
+
+export default Spinner;

--- a/src/renderer/components/ui/Spinner.tsx
+++ b/src/renderer/components/ui/Spinner.tsx
@@ -26,6 +26,8 @@ export interface SpinnerProps {
 	style?: CSSProperties;
 	/** Accessible label. Defaults to 'Loading' */
 	ariaLabel?: string;
+	/** Test id for automated tests */
+	testId?: string;
 }
 
 export function Spinner({
@@ -34,6 +36,7 @@ export function Spinner({
 	className = '',
 	style,
 	ariaLabel = 'Loading',
+	testId,
 }: SpinnerProps) {
 	return (
 		<Loader2
@@ -41,6 +44,7 @@ export function Spinner({
 			style={{ width: size, height: size, color, ...style }}
 			aria-label={ariaLabel}
 			role="status"
+			data-testid={testId}
 		/>
 	);
 }

--- a/src/renderer/components/ui/index.ts
+++ b/src/renderer/components/ui/index.ts
@@ -16,3 +16,12 @@ export type { EmojiPickerFieldProps } from './EmojiPickerField';
 
 export { ToggleSwitch } from './ToggleSwitch';
 export type { ToggleSwitchProps } from './ToggleSwitch';
+
+export { Spinner } from './Spinner';
+export type { SpinnerProps } from './Spinner';
+
+export { GhostIconButton } from './GhostIconButton';
+export type { GhostIconButtonProps } from './GhostIconButton';
+
+export { EmptyStatePlaceholder } from './EmptyStatePlaceholder';
+export type { EmptyStatePlaceholderProps } from './EmptyStatePlaceholder';


### PR DESCRIPTION
## Summary

Extracts three shared UI primitives and migrates existing call sites. Net effect: one canonical pattern per primitive instead of 140+ hand-rolled variants.

**Net: +223 lines overall (new components + tests), but -178 lines in migrated call sites (3 new component files + tests account for the delta)**

### 08A - GhostIconButton

New: `src/renderer/components/ui/GhostIconButton.tsx` + test.

The standard "icon-only button with hover bg and optional tooltip" pattern used 100+ times across the renderer.

- **Migrated:** 54 call sites across 43 files (AST-aware codemod handled `className` drop, `aria-label` -> `ariaLabel`, `style={{color:X}}` -> `color={X}`)
- **Skipped:** sites with extra layout classes (flex variants, padding variants, focus rings), non-icon children with custom styles - would require adding 3-4 edge-case props for 1-2 callers each

### 08B - Spinner

New: `src/renderer/components/ui/Spinner.tsx` + test.

The standard animated loading indicator wrapping `Loader2` from lucide-react.

- **Migrated:** 84 call sites across 55 files (44 simple + 40 color-styled variants)
- **Loader2 imports removed:** 42 files
- **Skipped:** 3 files had local components named `Spinner` that did something different (CSS-driven circular progress) - renamed those to `CircularSpinner` to resolve the name collision

### 08C - EmptyStatePlaceholder

New: `src/renderer/components/ui/EmptyStatePlaceholder.tsx` + test.

A generic placeholder for "No X" / "No results" / "Select something" states. **Intentionally distinct from the existing `EmptyStateView.tsx`**, which is the specialized welcome-screen component - different purpose, would have needed a confusing mode prop.

- **Adopted:** 2 sites (`AgentSessionsBrowser`, `AgentSessionsModal`)
- **Skipped:** most other empty-state occurrences had custom headings/actions/layouts that would bloat the component's prop surface for 1-2 callers

## Test plan

- [x] `npm run lint` passes (all 3 tsconfigs)
- [x] `npx prettier --check .` passes
- [x] 109 UI component tests pass (13 new + existing)
- [x] 268 migrated-component tests pass (AboutModal, AgentSessionsModal, AgentSessionsBrowser, UpdateCheckModal)
- [x] Visual regression: hover any ghost icon button - bg should still appear
- [x] Visual regression: trigger a loading state - spinner should still animate
- [x] Visual regression: open Agent Sessions Browser with no sessions - placeholder should render

## Risk

**Low**. Behavior-preserving migration: each call site produces identical DOM/styling. Three new components with dedicated tests. One intentional name-rename (`Spinner` -> `CircularSpinner` in 3 files) for the collision case.

## Cross-PR interaction

This PR modifies `AgentSessionsModal.tsx`, which is deleted by [#791 (Phase 01A)](https://github.com/RunMaestro/Maestro/pull/791). Whichever merges second will need a trivial conflict resolution (this PR's edits to that file will be dropped if 01A is already in).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three reusable UI primitives: Spinner, GhostIconButton, and EmptyStatePlaceholder.

* **Refactor**
  * Replaced many inline loading icons and icon-only buttons with the new Spinner and GhostIconButton.
  * Standardized empty-state presentations across the app using EmptyStatePlaceholder.

* **Tests**
  * Added component tests for EmptyStatePlaceholder, GhostIconButton, and Spinner; updated an empty-state test message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
