### PR TITLE
refactor: migrate to canonical shared hooks (Phase 09)

### DIFF
--- a/src/renderer/components/MarketplaceModal.tsx
+++ b/src/renderer/components/MarketplaceModal.tsx
@@ -28,6 +28,7 @@ import type { MarketplacePlaybook } from '../../shared/marketplace-types';
 import { useLayerStack } from '../contexts/LayerStackContext';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
 import { useMarketplace } from '../hooks/batch/useMarketplace';
+import { useEventListener } from '../hooks/utils/useEventListener';
 import {
 	REMARK_GFM_PLUGINS,
 	generateProseStyles,
@@ -245,43 +246,39 @@ function PlaybookDetailView({
 
 	// Keyboard shortcuts for scrolling the document preview
 	// OPT+Up/Down: page up/down, CMD+Up/Down: home/end
-	useEffect(() => {
-		const handleKeyDown = (e: KeyboardEvent) => {
-			const scrollContainer = previewScrollRef.current;
-			if (!scrollContainer) return;
+	useEventListener('keydown', (event: Event) => {
+		const e = event as KeyboardEvent;
+		const scrollContainer = previewScrollRef.current;
+		if (!scrollContainer) return;
 
-			// Don't handle if typing in an input
-			if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) {
-				return;
+		// Don't handle if typing in an input
+		if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) {
+			return;
+		}
+
+		const pageHeight = scrollContainer.clientHeight * 0.9; // 90% of visible height
+
+		// CMD+Up/Down: Home/End
+		if (e.metaKey && !e.altKey && !e.shiftKey) {
+			if (e.key === 'ArrowUp') {
+				e.preventDefault();
+				scrollContainer.scrollTo({ top: 0, behavior: 'smooth' });
+			} else if (e.key === 'ArrowDown') {
+				e.preventDefault();
+				scrollContainer.scrollTo({ top: scrollContainer.scrollHeight, behavior: 'smooth' });
 			}
-
-			const pageHeight = scrollContainer.clientHeight * 0.9; // 90% of visible height
-
-			// CMD+Up/Down: Home/End
-			if (e.metaKey && !e.altKey && !e.shiftKey) {
-				if (e.key === 'ArrowUp') {
-					e.preventDefault();
-					scrollContainer.scrollTo({ top: 0, behavior: 'smooth' });
-				} else if (e.key === 'ArrowDown') {
-					e.preventDefault();
-					scrollContainer.scrollTo({ top: scrollContainer.scrollHeight, behavior: 'smooth' });
-				}
+		}
+		// OPT+Up/Down: Page up/down
+		else if (e.altKey && !e.metaKey && !e.shiftKey) {
+			if (e.key === 'ArrowUp') {
+				e.preventDefault();
+				scrollContainer.scrollBy({ top: -pageHeight, behavior: 'smooth' });
+			} else if (e.key === 'ArrowDown') {
+				e.preventDefault();
+				scrollContainer.scrollBy({ top: pageHeight, behavior: 'smooth' });
 			}
-			// OPT+Up/Down: Page up/down
-			else if (e.altKey && !e.metaKey && !e.shiftKey) {
-				if (e.key === 'ArrowUp') {
-					e.preventDefault();
-					scrollContainer.scrollBy({ top: -pageHeight, behavior: 'smooth' });
-				} else if (e.key === 'ArrowDown') {
-					e.preventDefault();
-					scrollContainer.scrollBy({ top: pageHeight, behavior: 'smooth' });
-				}
-			}
-		};
-
-		window.addEventListener('keydown', handleKeyDown);
-		return () => window.removeEventListener('keydown', handleKeyDown);
-	}, []);
+		}
+	});
 
 	// Generate prose styles scoped to marketplace panel
 	const proseStyles = useMemo(

--- a/src/renderer/components/SessionList/SessionList.tsx
+++ b/src/renderer/components/SessionList/SessionList.tsx
@@ -36,6 +36,7 @@ import { SkinnySidebar } from './SkinnySidebar';
 import { LiveOverlayPanel } from './LiveOverlayPanel';
 import { useSessionCategories } from '../../hooks/session/useSessionCategories';
 import { useSessionFilterMode } from '../../hooks/session/useSessionFilterMode';
+import { useEventListener } from '../../hooks/utils/useEventListener';
 
 // ============================================================================
 // SessionContextMenu - Right-click context menu for session items
@@ -405,26 +406,21 @@ function SessionListInner(props: SessionListProps) {
 	}, [liveOverlayOpen, menuOpen]);
 
 	// Listen for tour UI actions to control hamburger menu state
-	useEffect(() => {
-		const handleTourAction = (event: Event) => {
-			const customEvent = event as CustomEvent<{ type: string; value?: string }>;
-			const { type } = customEvent.detail;
+	useEventListener('tour:action', (event: Event) => {
+		const customEvent = event as CustomEvent<{ type: string; value?: string }>;
+		const { type } = customEvent.detail;
 
-			switch (type) {
-				case 'openHamburgerMenu':
-					setMenuOpen(true);
-					break;
-				case 'closeHamburgerMenu':
-					setMenuOpen(false);
-					break;
-				default:
-					break;
-			}
-		};
-
-		window.addEventListener('tour:action', handleTourAction);
-		return () => window.removeEventListener('tour:action', handleTourAction);
-	}, []);
+		switch (type) {
+			case 'openHamburgerMenu':
+				setMenuOpen(true);
+				break;
+			case 'closeHamburgerMenu':
+				setMenuOpen(false);
+				break;
+			default:
+				break;
+		}
+	});
 
 	// Get git file change counts per session from focused context
 	// Using useGitFileStatus instead of full useGitStatus reduces re-renders

--- a/src/renderer/hooks/session/useHandsOnTimeTracker.ts
+++ b/src/renderer/hooks/session/useHandsOnTimeTracker.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useCallback } from 'react';
 import { subscribeToActivity } from '../../utils/activityBus';
+import { useEventListener } from '../utils/useEventListener';
 
 const ACTIVITY_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes of inactivity = idle
 const TICK_INTERVAL_MS = 1000; // Update every second
@@ -121,20 +122,12 @@ export function useHandsOnTimeTracker(addTotalActiveTimeMs: (delta: number) => v
 	}, [stopInterval, persistAccumulatedTime]);
 
 	// Persist on beforeunload (app closing)
-	useEffect(() => {
-		const handleBeforeUnload = () => {
-			// Synchronous - can't use async here
-			if (accumulatedTimeRef.current > 0) {
-				const timeToAdd = accumulatedTimeRef.current;
-				accumulatedTimeRef.current = 0;
-				addTotalActiveTimeMsRef.current(timeToAdd);
-			}
-		};
-
-		window.addEventListener('beforeunload', handleBeforeUnload);
-
-		return () => {
-			window.removeEventListener('beforeunload', handleBeforeUnload);
-		};
-	}, []);
+	useEventListener('beforeunload', () => {
+		// Synchronous - can't use async here
+		if (accumulatedTimeRef.current > 0) {
+			const timeToAdd = accumulatedTimeRef.current;
+			accumulatedTimeRef.current = 0;
+			addTotalActiveTimeMsRef.current(timeToAdd);
+		}
+	});
 }

--- a/src/renderer/hooks/ui/useTourActions.ts
+++ b/src/renderer/hooks/ui/useTourActions.ts
@@ -9,9 +9,9 @@
  * Reads from: uiStore (setActiveRightTab, setRightPanelOpen)
  */
 
-import { useEffect } from 'react';
 import type { RightPanelTab } from '../../types';
 import { useUIStore } from '../../stores/uiStore';
+import { useEventListener } from '../utils/useEventListener';
 
 // ============================================================================
 // Hook implementation
@@ -21,33 +21,28 @@ export function useTourActions(): void {
 	// --- Store actions (stable via getState) ---
 	const { setActiveRightTab, setRightPanelOpen } = useUIStore.getState();
 
-	useEffect(() => {
-		const handleTourAction = (event: Event) => {
-			const customEvent = event as CustomEvent<{
-				type: string;
-				value?: string;
-			}>;
-			const { type, value } = customEvent.detail;
+	useEventListener('tour:action', (event: Event) => {
+		const customEvent = event as CustomEvent<{
+			type: string;
+			value?: string;
+		}>;
+		const { type, value } = customEvent.detail;
 
-			switch (type) {
-				case 'setRightTab':
-					if (value === 'files' || value === 'history' || value === 'autorun') {
-						setActiveRightTab(value as RightPanelTab);
-					}
-					break;
-				case 'openRightPanel':
-					setRightPanelOpen(true);
-					break;
-				case 'closeRightPanel':
-					setRightPanelOpen(false);
-					break;
-				// hamburger menu actions are handled by SessionList.tsx
-				default:
-					break;
-			}
-		};
-
-		window.addEventListener('tour:action', handleTourAction);
-		return () => window.removeEventListener('tour:action', handleTourAction);
-	}, []);
+		switch (type) {
+			case 'setRightTab':
+				if (value === 'files' || value === 'history' || value === 'autorun') {
+					setActiveRightTab(value as RightPanelTab);
+				}
+				break;
+			case 'openRightPanel':
+				setRightPanelOpen(true);
+				break;
+			case 'closeRightPanel':
+				setRightPanelOpen(false);
+				break;
+			// hamburger menu actions are handled by SessionList.tsx
+			default:
+				break;
+		}
+	});
 }


### PR DESCRIPTION
## Summary

Migrates a conservative subset of hook patterns to canonical shared hooks. **This phase is intentionally narrow** - most call sites had semantic subtleties that would have caused regressions if blindly replaced.

**Net: -19 lines across 4 files**

### 09A - useEventListener migrations (4 sites)

Replaced raw `addEventListener` / `removeEventListener` pairs with the canonical `useEventListener` hook from `src/renderer/hooks/utils/useEventListener.ts`:

- `src/renderer/hooks/ui/useTourActions.ts` - `tour:action` event
- `src/renderer/components/SessionList/SessionList.tsx` - `tour:action` event
- `src/renderer/hooks/session/useHandsOnTimeTracker.ts` - `beforeunload` event
- `src/renderer/components/MarketplaceModal.tsx` - `keydown` event in PlaybookDetailView

### 09A - useFocusAfterRender migrations (0 sites)

**Intentionally zero** - the canonical hook uses `useLayoutEffect` with NO dep array and re-runs every render while its `condition` is true. Replacing the common `useEffect(() => { setTimeout(() => ref.current?.focus(), 50); }, [])` pattern would cause the focus to be re-stolen on every subsequent render, breaking the app.

The one legitimate use of the canonical hook (transition-triggered focus in `App.tsx`) is already wired up.

### 09B - (0 sites migrated)

**`useActiveSession()` semantic gap**: `selectActiveSession` falls back to `state.sessions[0]` when there's no active session; inline `sessions.find(s => s.id === activeSessionId)` returns `undefined`. Blindly migrating all ~28 call sites would surface stale-session data instead of the "no active session" branch the components rely on for modal/UI routing.

**Debounce/throttle misfits**: Every hand-rolled debounce/throttle in the codebase has a reason the canonical hook doesn't fit - `useAutoRunUndo` uses dep-scoped cleanup, `useSessionDebounce` keys timers per-session, `useTabHoverOverlay` shares timers for open/close, `useThemeStyles` uses RAF-batched per-element tracking, `GitStatusWidget` uses bidirectional clear.

### Sites intentionally skipped in 09A

- Conditional registration on `isOpen` or `capture: true` / `passive: true` options (canonical hook doesn't support listener options) - DirectorNotesModal, SettingsSearch, NewInstanceModal, EditAgentModal, PhaseReviewScreen, UsageDashboardModal, LayerStackContext, activityBus, useThemeStyles, useRemoteHandlers
- Multi-event handlers or handlers paired with initial imperative calls - useMobileLandscape, useTour, TabBar

## Test plan

- [ ] `npm run lint` passes (all 3 tsconfigs)
- [ ] `npx prettier --check .` passes
- [ ] 312 targeted hook tests pass
- [ ] Tour events still fire
- [ ] Marketplace playbook detail keyboard shortcuts work
- [ ] beforeunload handler fires (active-time tracking)

## Risk

**Very low**. 4 behavior-preserving migrations, no component changes.

## Note

The playbook target was ~490 lines. The delta reflects an honest audit of the hook surface area rather than optimistic projections - many of the ~490 lines estimate come from call sites whose semantics don't map cleanly to the canonical hooks, and forcing them would regress UX. Leaving those deliberately unmigrated until a larger hook API surface (listener options, custom fallbacks) is designed.