### PR TITLE
refactor: consolidate modal layer and group chat spawn (Phase 10)

### DIFF
--- a/src/__tests__/renderer/components/CueModal.test.tsx
+++ b/src/__tests__/renderer/components/CueModal.test.tsx
@@ -25,6 +25,7 @@ vi.mock('../../../renderer/contexts/LayerStackContext', () => ({
 	useLayerStack: () => ({
 		registerLayer: mockRegisterLayer,
 		unregisterLayer: mockUnregisterLayer,
+		updateLayerHandler: vi.fn(),
 	}),
 }));
 

--- a/src/__tests__/renderer/components/DocumentGraph/DocumentGraphView.test.tsx
+++ b/src/__tests__/renderer/components/DocumentGraph/DocumentGraphView.test.tsx
@@ -51,6 +51,7 @@ vi.mock('../../../../renderer/contexts/LayerStackContext', () => ({
 	useLayerStack: () => ({
 		registerLayer: vi.fn(() => 'mock-layer-id'),
 		unregisterLayer: vi.fn(),
+		updateLayerHandler: vi.fn(),
 	}),
 	LayerStackProvider: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
 }));

--- a/src/__tests__/renderer/components/ExecutionQueueBrowser.test.tsx
+++ b/src/__tests__/renderer/components/ExecutionQueueBrowser.test.tsx
@@ -19,6 +19,7 @@ vi.mock('../../../renderer/contexts/LayerStackContext', () => ({
 	useLayerStack: () => ({
 		registerLayer: mockRegisterLayer,
 		unregisterLayer: mockUnregisterLayer,
+		updateLayerHandler: vi.fn(),
 	}),
 }));
 

--- a/src/__tests__/renderer/components/LeaderboardRegistrationModal.test.tsx
+++ b/src/__tests__/renderer/components/LeaderboardRegistrationModal.test.tsx
@@ -17,6 +17,7 @@ vi.mock('../../../renderer/contexts/LayerStackContext', () => ({
 	useLayerStack: () => ({
 		registerLayer: mockRegisterLayer,
 		unregisterLayer: mockUnregisterLayer,
+		updateLayerHandler: vi.fn(),
 	}),
 }));
 

--- a/src/__tests__/renderer/components/NewInstanceModal.test.tsx
+++ b/src/__tests__/renderer/components/NewInstanceModal.test.tsx
@@ -1283,7 +1283,18 @@ describe('NewInstanceModal', () => {
 				/>
 			);
 
-			expect(mockUpdateLayerHandler).toHaveBeenCalledWith('layer-new-instance-123', newOnClose);
+			// useModalLayer wraps onEscape in a stable closure (`() => onEscapeRef.current()`)
+			// to avoid re-registering the layer on every render. The handler still routes to
+			// the latest onClose via ref - we just verify update was called with our layer id.
+			expect(mockUpdateLayerHandler).toHaveBeenCalledWith(
+				'layer-new-instance-123',
+				expect.any(Function)
+			);
+			// Trigger the latest registered escape handler and verify it calls the new onClose
+			const lastCall =
+				mockUpdateLayerHandler.mock.calls[mockUpdateLayerHandler.mock.calls.length - 1];
+			(lastCall[1] as () => void)();
+			expect(newOnClose).toHaveBeenCalledTimes(1);
 		});
 	});
 

--- a/src/__tests__/renderer/components/SettingsModal.test.tsx
+++ b/src/__tests__/renderer/components/SettingsModal.test.tsx
@@ -1596,6 +1596,7 @@ describe('SettingsModal', () => {
 					return 'layer-123';
 				}),
 				unregisterLayer: vi.fn(),
+				updateLayerHandler: vi.fn(),
 				getTopLayer: vi.fn(),
 				closeTopLayer: vi.fn(),
 				getLayers: vi.fn(),

--- a/src/__tests__/renderer/components/UsageDashboard/responsive-layout.test.tsx
+++ b/src/__tests__/renderer/components/UsageDashboard/responsive-layout.test.tsx
@@ -63,6 +63,7 @@ vi.mock('../../../../renderer/contexts/LayerStackContext', () => ({
 	useLayerStack: () => ({
 		registerLayer: vi.fn(() => 'layer-123'),
 		unregisterLayer: vi.fn(),
+		updateLayerHandler: vi.fn(),
 	}),
 }));
 

--- a/src/__tests__/renderer/components/UsageDashboard/state-transition-animations.test.tsx
+++ b/src/__tests__/renderer/components/UsageDashboard/state-transition-animations.test.tsx
@@ -63,6 +63,7 @@ vi.mock('../../../../renderer/contexts/LayerStackContext', () => ({
 	useLayerStack: () => ({
 		registerLayer: vi.fn(() => 'layer-123'),
 		unregisterLayer: vi.fn(),
+		updateLayerHandler: vi.fn(),
 	}),
 }));
 

--- a/src/__tests__/renderer/components/UsageDashboardModal.test.tsx
+++ b/src/__tests__/renderer/components/UsageDashboardModal.test.tsx
@@ -64,6 +64,7 @@ vi.mock('../../../renderer/contexts/LayerStackContext', () => ({
 	useLayerStack: () => ({
 		registerLayer: mockRegisterLayer,
 		unregisterLayer: mockUnregisterLayer,
+		updateLayerHandler: vi.fn(),
 	}),
 }));
 

--- a/src/main/group-chat/group-chat-router.ts
+++ b/src/main/group-chat/group-chat-router.ts
@@ -40,13 +40,8 @@ import { AgentDetector } from '../agents';
 import { powerManager } from '../power-manager';
 import { logger } from '../utils/logger';
 import { captureException } from '../utils/sentry';
-import {
-	buildAgentArgs,
-	applyAgentConfigOverrides,
-	getContextWindowValue,
-} from '../utils/agent-args';
+import { buildAgentArgs, applyAgentConfigOverrides } from '../utils/agent-args';
 import { getPrompt } from '../prompt-manager';
-import { wrapSpawnWithSsh } from '../utils/ssh-spawn-wrapper';
 import type { SshRemoteSettingsStore } from '../utils/ssh-remote-resolver';
 import { setGetCustomShellPathCallback } from './group-chat-config';
 import { spawnGroupChatAgent } from './spawnGroupChatAgent';

--- a/src/main/group-chat/group-chat-router.ts
+++ b/src/main/group-chat/group-chat-router.ts
@@ -48,7 +48,8 @@ import {
 import { getPrompt } from '../prompt-manager';
 import { wrapSpawnWithSsh } from '../utils/ssh-spawn-wrapper';
 import type { SshRemoteSettingsStore } from '../utils/ssh-remote-resolver';
-import { setGetCustomShellPathCallback, getWindowsSpawnConfig } from './group-chat-config';
+import { setGetCustomShellPathCallback } from './group-chat-config';
+import { spawnGroupChatAgent } from './spawnGroupChatAgent';
 
 // Import emitters from IPC handlers (will be populated after handlers are registered)
 import { groupChatEmitters } from '../ipc/handlers/groupChat';
@@ -824,76 +825,23 @@ ${readOnly ? 'READ-ONLY MODE is active. You and all participants can only inspec
 				// Add power block reason to prevent sleep during group chat activity
 				powerManager.addBlockReason(`groupchat:${groupChatId}`);
 
-				// Prepare spawn config with potential SSH wrapping
-				let spawnCommand = command;
-				let spawnArgs = finalArgs;
-				let spawnCwd = os.homedir();
-				let spawnPrompt: string | undefined = fullPrompt;
-				let spawnEnvVars =
-					configResolution.effectiveCustomEnvVars ??
-					getCustomEnvVarsCallback?.(chat.moderatorAgentId);
-				let spawnShell: string | undefined;
-				let spawnRunInShell = false;
-				let spawnSshStdinScript: string | undefined;
-
-				// Apply SSH wrapping if configured
-				if (sshStore && chat.moderatorConfig?.sshRemoteConfig) {
-					console.log(`[GroupChat:Debug] Applying SSH wrapping for moderator...`);
-					const sshWrapped = await wrapSpawnWithSsh(
-						{
-							command,
-							args: finalArgs,
-							cwd: os.homedir(),
-							prompt: fullPrompt,
-							customEnvVars:
-								configResolution.effectiveCustomEnvVars ??
-								getCustomEnvVarsCallback?.(chat.moderatorAgentId),
-							promptArgs: agent.promptArgs,
-							noPromptSeparator: agent.noPromptSeparator,
-							agentBinaryName: agent.binaryName,
-						},
-						chat.moderatorConfig.sshRemoteConfig,
-						sshStore
-					);
-					spawnCommand = sshWrapped.command;
-					spawnArgs = sshWrapped.args;
-					spawnCwd = sshWrapped.cwd;
-					spawnPrompt = sshWrapped.prompt;
-					spawnEnvVars = sshWrapped.customEnvVars;
-					spawnSshStdinScript = sshWrapped.sshStdinScript;
-					if (sshWrapped.sshRemoteUsed) {
-						console.log(`[GroupChat:Debug] SSH remote used: ${sshWrapped.sshRemoteUsed.name}`);
-					}
-				}
-
-				// Get Windows-specific spawn config (shell, stdin mode) - handles SSH exclusion
-				const winConfig = getWindowsSpawnConfig(
-					chat.moderatorAgentId,
-					chat.moderatorConfig?.sshRemoteConfig
-				);
-				if (winConfig.shell) {
-					spawnShell = winConfig.shell;
-					spawnRunInShell = winConfig.runInShell;
-					console.log(`[GroupChat:Debug] Windows shell config: ${winConfig.shell}`);
-				}
-
-				const spawnResult = processManager.spawn({
+				const spawnResult = await spawnGroupChatAgent({
 					sessionId,
-					toolType: chat.moderatorAgentId,
-					cwd: spawnCwd,
-					command: spawnCommand,
-					args: spawnArgs,
+					agentId: chat.moderatorAgentId,
+					agent,
+					command,
+					args: finalArgs,
+					cwd: os.homedir(),
+					prompt: fullPrompt,
+					customEnvVars:
+						configResolution.effectiveCustomEnvVars ??
+						getCustomEnvVarsCallback?.(chat.moderatorAgentId),
+					agentConfigValues,
+					sshRemoteConfig: chat.moderatorConfig?.sshRemoteConfig,
+					sshStore,
+					processManager,
 					readOnlyMode: true,
-					prompt: spawnPrompt,
-					contextWindow: getContextWindowValue(agent, agentConfigValues),
-					customEnvVars: spawnEnvVars,
-					promptArgs: agent.promptArgs,
-					noPromptSeparator: agent.noPromptSeparator,
-					shell: spawnShell,
-					runInShell: spawnRunInShell,
-					sendPromptViaStdin: winConfig.sendPromptViaStdin,
-					sendPromptViaStdinRaw: winConfig.sendPromptViaStdinRaw,
-					sshStdinScript: spawnSshStdinScript,
+					debugLabel: 'moderator',
 				});
 
 				console.log(`[GroupChat:Debug] Spawn result: ${JSON.stringify(spawnResult)}`);
@@ -1314,80 +1262,23 @@ export async function routeModeratorResponse(
 					`[GroupChat:Debug] CustomEnvVars: ${JSON.stringify(configResolution.effectiveCustomEnvVars || {})}`
 				);
 
-				// Prepare spawn config with potential SSH wrapping
-				let finalSpawnCommand = spawnCommand;
-				let finalSpawnArgs = spawnArgs;
-				let finalSpawnCwd = cwd;
-				let finalSpawnPrompt: string | undefined = participantPrompt;
-				let finalSpawnEnvVars =
-					configResolution.effectiveCustomEnvVars ??
-					getCustomEnvVarsCallback?.(participant.agentId);
-				let finalSpawnShell: string | undefined;
-				let finalSpawnRunInShell = false;
-				let finalSshStdinScript: string | undefined;
-
-				// Apply SSH wrapping if configured for this session
-				if (sshStore && matchingSession?.sshRemoteConfig) {
-					console.log(
-						`[GroupChat:Debug] Applying SSH wrapping for participant ${participantName}...`
-					);
-					const sshWrapped = await wrapSpawnWithSsh(
-						{
-							command: spawnCommand,
-							args: spawnArgs,
-							cwd,
-							prompt: participantPrompt,
-							customEnvVars:
-								configResolution.effectiveCustomEnvVars ??
-								getCustomEnvVarsCallback?.(participant.agentId),
-							promptArgs: agent.promptArgs,
-							noPromptSeparator: agent.noPromptSeparator,
-							agentBinaryName: agent.binaryName,
-						},
-						matchingSession.sshRemoteConfig,
-						sshStore
-					);
-					finalSpawnCommand = sshWrapped.command;
-					finalSpawnArgs = sshWrapped.args;
-					finalSpawnCwd = sshWrapped.cwd;
-					finalSpawnPrompt = sshWrapped.prompt;
-					finalSpawnEnvVars = sshWrapped.customEnvVars;
-					finalSshStdinScript = sshWrapped.sshStdinScript;
-					if (sshWrapped.sshRemoteUsed) {
-						console.log(`[GroupChat:Debug] SSH remote used: ${sshWrapped.sshRemoteUsed.name}`);
-					}
-				}
-
-				// Get Windows-specific spawn config (shell, stdin mode) - handles SSH exclusion
-				const winConfig = getWindowsSpawnConfig(
-					participant.agentId,
-					matchingSession?.sshRemoteConfig
-				);
-				if (winConfig.shell) {
-					finalSpawnShell = winConfig.shell;
-					finalSpawnRunInShell = winConfig.runInShell;
-					console.log(
-						`[GroupChat:Debug] Windows shell config for ${participantName}: ${winConfig.shell}`
-					);
-				}
-
-				const spawnResult = processManager.spawn({
+				const spawnResult = await spawnGroupChatAgent({
 					sessionId,
-					toolType: participant.agentId,
-					cwd: finalSpawnCwd,
-					command: finalSpawnCommand,
-					args: finalSpawnArgs,
+					agentId: participant.agentId,
+					agent,
+					command: spawnCommand,
+					args: spawnArgs,
+					cwd,
+					prompt: participantPrompt,
+					customEnvVars:
+						configResolution.effectiveCustomEnvVars ??
+						getCustomEnvVarsCallback?.(participant.agentId),
+					agentConfigValues,
+					sshRemoteConfig: matchingSession?.sshRemoteConfig,
+					sshStore,
+					processManager,
 					readOnlyMode: readOnly ?? false, // Propagate read-only mode from caller
-					prompt: finalSpawnPrompt,
-					contextWindow: getContextWindowValue(agent, agentConfigValues),
-					customEnvVars: finalSpawnEnvVars,
-					promptArgs: agent.promptArgs,
-					noPromptSeparator: agent.noPromptSeparator,
-					shell: finalSpawnShell,
-					runInShell: finalSpawnRunInShell,
-					sendPromptViaStdin: winConfig.sendPromptViaStdin,
-					sendPromptViaStdinRaw: winConfig.sendPromptViaStdinRaw,
-					sshStdinScript: finalSshStdinScript,
+					debugLabel: `participant: ${participantName}`,
 				});
 
 				console.log(
@@ -1742,73 +1633,23 @@ Review the agent responses above. Either:
 		// Start moderator timeout to prevent indefinite hanging
 		setModeratorResponseTimeout(groupChatId);
 
-		// Prepare spawn config variables (may be overridden by SSH wrapping)
-		let spawnCommand = command;
-		let spawnArgs = finalArgs;
-		let spawnCwd = os.homedir();
-		let spawnPrompt: string | undefined = synthesisPrompt;
-		let spawnEnvVars =
-			configResolution.effectiveCustomEnvVars ?? getCustomEnvVarsCallback?.(chat.moderatorAgentId);
-		let spawnSshStdinScript: string | undefined;
-
-		// Apply SSH wrapping if configured
-		if (sshStore && chat.moderatorConfig?.sshRemoteConfig) {
-			console.log(`[GroupChat:Debug] Applying SSH wrapping for synthesis moderator...`);
-			const sshWrapped = await wrapSpawnWithSsh(
-				{
-					command,
-					args: finalArgs,
-					cwd: os.homedir(),
-					prompt: synthesisPrompt,
-					customEnvVars:
-						configResolution.effectiveCustomEnvVars ??
-						getCustomEnvVarsCallback?.(chat.moderatorAgentId),
-					promptArgs: agent.promptArgs,
-					noPromptSeparator: agent.noPromptSeparator,
-					agentBinaryName: agent.binaryName,
-				},
-				chat.moderatorConfig.sshRemoteConfig,
-				sshStore
-			);
-			spawnCommand = sshWrapped.command;
-			spawnArgs = sshWrapped.args;
-			spawnCwd = sshWrapped.cwd;
-			spawnPrompt = sshWrapped.prompt;
-			spawnEnvVars = sshWrapped.customEnvVars;
-			spawnSshStdinScript = sshWrapped.sshStdinScript;
-			if (sshWrapped.sshRemoteUsed) {
-				console.log(
-					`[GroupChat:Debug] SSH remote used for synthesis: ${sshWrapped.sshRemoteUsed.name}`
-				);
-			}
-		}
-
-		// Get Windows-specific spawn config (shell, stdin mode) - handles SSH exclusion
-		const winConfig = getWindowsSpawnConfig(
-			chat.moderatorAgentId,
-			chat.moderatorConfig?.sshRemoteConfig
-		);
-		if (winConfig.shell) {
-			console.log(`[GroupChat:Debug] Windows shell config for synthesis: ${winConfig.shell}`);
-		}
-
-		const spawnResult = processManager.spawn({
+		const spawnResult = await spawnGroupChatAgent({
 			sessionId,
-			toolType: chat.moderatorAgentId,
-			cwd: spawnCwd,
-			command: spawnCommand,
-			args: spawnArgs,
+			agentId: chat.moderatorAgentId,
+			agent,
+			command,
+			args: finalArgs,
+			cwd: os.homedir(),
+			prompt: synthesisPrompt,
+			customEnvVars:
+				configResolution.effectiveCustomEnvVars ??
+				getCustomEnvVarsCallback?.(chat.moderatorAgentId),
+			agentConfigValues,
+			sshRemoteConfig: chat.moderatorConfig?.sshRemoteConfig,
+			sshStore,
+			processManager,
 			readOnlyMode: true,
-			prompt: spawnPrompt,
-			contextWindow: getContextWindowValue(agent, agentConfigValues),
-			customEnvVars: spawnEnvVars,
-			promptArgs: agent.promptArgs,
-			noPromptSeparator: agent.noPromptSeparator,
-			shell: winConfig.shell,
-			runInShell: winConfig.runInShell,
-			sendPromptViaStdin: winConfig.sendPromptViaStdin,
-			sendPromptViaStdinRaw: winConfig.sendPromptViaStdinRaw,
-			sshStdinScript: spawnSshStdinScript,
+			debugLabel: 'synthesis moderator',
 		});
 
 		console.log(`[GroupChat:Debug] Synthesis spawn result: ${JSON.stringify(spawnResult)}`);
@@ -1942,74 +1783,24 @@ export async function respawnParticipantWithRecovery(
 	groupChatEmitters.emitParticipantState?.(groupChatId, participantName, 'working');
 
 	// Spawn the recovery process — with SSH wrapping if configured
-	let finalSpawnCommand = agent.path || agent.command;
-	let finalSpawnArgs = configResolution.args;
-	let finalSpawnCwd = cwd;
-	let finalSpawnPrompt: string | undefined = fullPrompt;
-	let finalSpawnEnvVars =
-		configResolution.effectiveCustomEnvVars ?? getCustomEnvVarsCallback?.(participant.agentId);
-	let finalSpawnShell: string | undefined;
-	let finalSpawnRunInShell = false;
-	let finalSshStdinScript: string | undefined;
+	console.log(`[GroupChat:Debug] Recovery spawn command: ${agent.path || agent.command}`);
+	console.log(`[GroupChat:Debug] Recovery spawn args count: ${configResolution.args.length}`);
 
-	console.log(`[GroupChat:Debug] Recovery spawn command: ${finalSpawnCommand}`);
-	console.log(`[GroupChat:Debug] Recovery spawn args count: ${finalSpawnArgs.length}`);
-
-	// Apply SSH wrapping if configured for this session
-	if (sshStore && matchingSession?.sshRemoteConfig) {
-		console.log(`[GroupChat:Debug] Applying SSH wrapping for recovery of ${participantName}...`);
-		const sshWrapped = await wrapSpawnWithSsh(
-			{
-				command: finalSpawnCommand,
-				args: finalSpawnArgs,
-				cwd,
-				prompt: fullPrompt,
-				customEnvVars: finalSpawnEnvVars,
-				promptArgs: agent.promptArgs,
-				noPromptSeparator: agent.noPromptSeparator,
-				agentBinaryName: agent.binaryName,
-			},
-			matchingSession.sshRemoteConfig,
-			sshStore
-		);
-		finalSpawnCommand = sshWrapped.command;
-		finalSpawnArgs = sshWrapped.args;
-		finalSpawnCwd = sshWrapped.cwd;
-		finalSpawnPrompt = sshWrapped.prompt;
-		finalSpawnEnvVars = sshWrapped.customEnvVars;
-		finalSshStdinScript = sshWrapped.sshStdinScript;
-		if (sshWrapped.sshRemoteUsed) {
-			console.log(
-				`[GroupChat:Debug] SSH remote used for recovery: ${sshWrapped.sshRemoteUsed.name}`
-			);
-		}
-	}
-
-	// Get Windows-specific spawn config (shell, stdin mode) - handles SSH exclusion
-	const winConfig = getWindowsSpawnConfig(participant.agentId, matchingSession?.sshRemoteConfig);
-	if (winConfig.shell) {
-		finalSpawnShell = winConfig.shell;
-		finalSpawnRunInShell = winConfig.runInShell;
-		console.log(`[GroupChat:Debug] Windows shell config for recovery: ${winConfig.shell}`);
-	}
-
-	const spawnResult = processManager.spawn({
+	const spawnResult = await spawnGroupChatAgent({
 		sessionId,
-		toolType: participant.agentId,
-		cwd: finalSpawnCwd,
-		command: finalSpawnCommand,
-		args: finalSpawnArgs,
+		agentId: participant.agentId,
+		agent,
+		args: configResolution.args,
+		cwd,
+		prompt: fullPrompt,
+		customEnvVars:
+			configResolution.effectiveCustomEnvVars ?? getCustomEnvVarsCallback?.(participant.agentId),
+		agentConfigValues,
+		sshRemoteConfig: matchingSession?.sshRemoteConfig,
+		sshStore,
+		processManager,
 		readOnlyMode: readOnly ?? false,
-		prompt: finalSpawnPrompt,
-		contextWindow: getContextWindowValue(agent, agentConfigValues),
-		customEnvVars: finalSpawnEnvVars,
-		promptArgs: agent.promptArgs,
-		noPromptSeparator: agent.noPromptSeparator,
-		shell: finalSpawnShell,
-		runInShell: finalSpawnRunInShell,
-		sendPromptViaStdin: winConfig.sendPromptViaStdin,
-		sendPromptViaStdinRaw: winConfig.sendPromptViaStdinRaw,
-		sshStdinScript: finalSshStdinScript,
+		debugLabel: `recovery of ${participantName}`,
 	});
 
 	console.log(`[GroupChat:Debug] Recovery spawn result: ${JSON.stringify(spawnResult)}`);

--- a/src/main/group-chat/spawnGroupChatAgent.ts
+++ b/src/main/group-chat/spawnGroupChatAgent.ts
@@ -95,6 +95,9 @@ export async function spawnGroupChatAgent(
 	let spawnSshStdinScript: string | undefined;
 
 	// Apply SSH wrapping if configured
+	if (sshRemoteConfig?.enabled && !sshStore) {
+		throw new Error(`SSH remote is enabled but sshStore is not available for ${debugLabel ?? sessionId}`);
+	}
 	if (sshStore && sshRemoteConfig?.enabled) {
 		if (debugLabel) {
 			console.log(`[GroupChat:Debug] Applying SSH wrapping for ${debugLabel}...`);

--- a/src/main/group-chat/spawnGroupChatAgent.ts
+++ b/src/main/group-chat/spawnGroupChatAgent.ts
@@ -1,0 +1,155 @@
+/**
+ * @file spawnGroupChatAgent.ts
+ * @description Centralized spawn helper for Group Chat agent processes.
+ *
+ * Every spawn site in the Group Chat router (moderator, participant, synthesis,
+ * recovery) follows the same pattern: maybe SSH-wrap the command, apply
+ * Windows-specific shell/stdin config, then call `processManager.spawn`. This
+ * helper consolidates that sequence so each call site only needs to describe
+ * the semantic spawn intent rather than repeat the mechanics.
+ */
+
+import { IProcessManager } from './group-chat-moderator';
+import { getContextWindowValue } from '../utils/agent-args';
+import { wrapSpawnWithSsh } from '../utils/ssh-spawn-wrapper';
+import type { SshRemoteSettingsStore } from '../utils/ssh-remote-resolver';
+import { getWindowsSpawnConfig } from './group-chat-config';
+import type { AgentConfig } from '../agents/definitions';
+import type { AgentSshRemoteConfig } from '../../shared/types';
+
+export interface SpawnGroupChatAgentConfig {
+	/** Stable session id for the process manager */
+	sessionId: string;
+	/** Agent id (e.g. 'claude-code', 'codex') - used as `toolType` */
+	agentId: string;
+	/** Resolved agent definition */
+	agent: AgentConfig;
+	/** Base command - defaults to agent.path ?? agent.command */
+	command?: string;
+	/** Fully-formed args (after buildAgentArgs + any extras) */
+	args: string[];
+	/** Working directory */
+	cwd: string;
+	/** Prompt to send (via CLI arg or stdin) */
+	prompt?: string;
+	/** Resolved custom env vars to inject */
+	customEnvVars?: Record<string, string>;
+	/** Agent config values (used for context window resolution) */
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	agentConfigValues?: Record<string, any>;
+	/** SSH remote config (from chat moderator or matching session); null/undefined = local */
+	sshRemoteConfig?: AgentSshRemoteConfig | null;
+	/** SSH settings store (required when sshRemoteConfig is active) */
+	sshStore?: SshRemoteSettingsStore | null;
+	/** Process manager to invoke */
+	processManager: IProcessManager;
+	/** Whether the spawned process is read-only (moderator / synthesis = true) */
+	readOnlyMode?: boolean;
+	/** Optional label for debug logs (e.g. 'moderator', 'participant: Alice') */
+	debugLabel?: string;
+}
+
+export interface SpawnGroupChatAgentResult {
+	pid: number;
+	success: boolean;
+}
+
+/**
+ * Spawn a Group Chat agent process with SSH + Windows shell handling applied.
+ *
+ * The helper:
+ * 1. Optionally wraps the command with SSH (when `sshRemoteConfig.enabled`)
+ * 2. Applies Windows-specific shell/stdin config (skipped for SSH)
+ * 3. Calls `processManager.spawn` with the resolved config
+ *
+ * All four legacy call sites (moderator, participant, synthesis, recovery) used
+ * this exact sequence with only cosmetic differences - see git history for the
+ * inline versions this replaces.
+ */
+export async function spawnGroupChatAgent(
+	config: SpawnGroupChatAgentConfig
+): Promise<SpawnGroupChatAgentResult> {
+	const {
+		sessionId,
+		agentId,
+		agent,
+		args,
+		cwd,
+		prompt,
+		customEnvVars,
+		agentConfigValues,
+		sshRemoteConfig,
+		sshStore,
+		processManager,
+		readOnlyMode = false,
+		debugLabel,
+	} = config;
+
+	const baseCommand = config.command ?? agent.path ?? agent.command;
+
+	let spawnCommand = baseCommand;
+	let spawnArgs = args;
+	let spawnCwd = cwd;
+	let spawnPrompt: string | undefined = prompt;
+	let spawnEnvVars = customEnvVars;
+	let spawnSshStdinScript: string | undefined;
+
+	// Apply SSH wrapping if configured
+	if (sshStore && sshRemoteConfig?.enabled) {
+		if (debugLabel) {
+			console.log(`[GroupChat:Debug] Applying SSH wrapping for ${debugLabel}...`);
+		}
+		const sshWrapped = await wrapSpawnWithSsh(
+			{
+				command: baseCommand,
+				args,
+				cwd,
+				prompt,
+				customEnvVars,
+				promptArgs: agent.promptArgs,
+				noPromptSeparator: agent.noPromptSeparator,
+				agentBinaryName: agent.binaryName,
+			},
+			sshRemoteConfig,
+			sshStore
+		);
+		spawnCommand = sshWrapped.command;
+		spawnArgs = sshWrapped.args;
+		spawnCwd = sshWrapped.cwd;
+		spawnPrompt = sshWrapped.prompt;
+		spawnEnvVars = sshWrapped.customEnvVars;
+		spawnSshStdinScript = sshWrapped.sshStdinScript;
+		if (sshWrapped.sshRemoteUsed && debugLabel) {
+			console.log(
+				`[GroupChat:Debug] SSH remote used for ${debugLabel}: ${sshWrapped.sshRemoteUsed.name}`
+			);
+		}
+	}
+
+	// Get Windows-specific spawn config (shell, stdin mode) - skipped for SSH
+	const winConfig = getWindowsSpawnConfig(agentId, sshRemoteConfig ?? undefined);
+	if (winConfig.shell && debugLabel) {
+		console.log(`[GroupChat:Debug] Windows shell config for ${debugLabel}: ${winConfig.shell}`);
+	}
+
+	const spawnResult = processManager.spawn({
+		sessionId,
+		toolType: agentId,
+		cwd: spawnCwd,
+		command: spawnCommand,
+		args: spawnArgs,
+		readOnlyMode,
+		prompt: spawnPrompt,
+		contextWindow: getContextWindowValue(agent, agentConfigValues ?? {}),
+		customEnvVars: spawnEnvVars,
+		promptArgs: agent.promptArgs,
+		noPromptSeparator: agent.noPromptSeparator,
+		shell: winConfig.shell,
+		runInShell: winConfig.runInShell,
+		sendPromptViaStdin: winConfig.sendPromptViaStdin,
+		sendPromptViaStdinRaw: winConfig.sendPromptViaStdinRaw,
+		sshStdinScript: spawnSshStdinScript,
+	});
+
+	return spawnResult;
+}

--- a/src/main/group-chat/spawnGroupChatAgent.ts
+++ b/src/main/group-chat/spawnGroupChatAgent.ts
@@ -96,7 +96,9 @@ export async function spawnGroupChatAgent(
 
 	// Apply SSH wrapping if configured
 	if (sshRemoteConfig?.enabled && !sshStore) {
-		throw new Error(`SSH remote is enabled but sshStore is not available for ${debugLabel ?? sessionId}`);
+		throw new Error(
+			`SSH remote is enabled but sshStore is not available for ${debugLabel ?? sessionId}`
+		);
 	}
 	if (sshStore && sshRemoteConfig?.enabled) {
 		if (debugLabel) {

--- a/src/renderer/components/AgentCreationDialog.tsx
+++ b/src/renderer/components/AgentCreationDialog.tsx
@@ -25,7 +25,7 @@ import {
 } from 'lucide-react';
 import type { Theme, AgentConfig } from '../types';
 import type { RegisteredRepository, SymphonyIssue } from '../../shared/symphony-types';
-import { useLayerStack } from '../contexts/LayerStackContext';
+import { useModalLayer } from '../hooks/ui/useModalLayer';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
 import { AgentConfigPanel } from './shared/AgentConfigPanel';
 import { useAgentConfiguration } from '../hooks/agent/useAgentConfiguration';
@@ -77,9 +77,15 @@ export function AgentCreationDialog({
 	issue,
 	onCreateAgent,
 }: AgentCreationDialogProps) {
-	const { registerLayer, unregisterLayer } = useLayerStack();
 	const onCloseRef = useRef(onClose);
 	onCloseRef.current = onClose;
+
+	useModalLayer(
+		MODAL_PRIORITIES.SYMPHONY_AGENT_CREATION ?? 711,
+		'Create Agent for Symphony Contribution',
+		() => onCloseRef.current(),
+		{ enabled: isOpen }
+	);
 
 	// Filter function: only agents that support batch mode (required for Symphony)
 	const symphonyAgentFilter = useCallback((agent: AgentConfig) => {
@@ -223,22 +229,6 @@ export function AgentCreationDialog({
 		},
 		[ac.refreshAgent]
 	);
-
-	// Layer stack registration
-	useEffect(() => {
-		if (isOpen) {
-			const id = registerLayer({
-				type: 'modal',
-				priority: MODAL_PRIORITIES.SYMPHONY_AGENT_CREATION ?? 711,
-				blocksLowerLayers: true,
-				capturesFocus: true,
-				focusTrap: 'strict',
-				ariaLabel: 'Create Agent for Symphony Contribution',
-				onEscape: () => onCloseRef.current(),
-			});
-			return () => unregisterLayer(id);
-		}
-	}, [isOpen, registerLayer, unregisterLayer]);
 
 	// Handle folder selection
 	const handleSelectFolder = useCallback(async () => {

--- a/src/renderer/components/AgentPromptComposerModal.tsx
+++ b/src/renderer/components/AgentPromptComposerModal.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { X, FileText, Variable, ChevronDown, ChevronRight } from 'lucide-react';
 import type { Theme } from '../types';
-import { useLayerStack } from '../contexts/LayerStackContext';
+import { useModalLayer } from '../hooks/ui/useModalLayer';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
 import { TEMPLATE_VARIABLES } from '../utils/templateVariables';
 import { useTemplateAutocomplete } from '../hooks';
@@ -26,7 +26,6 @@ export function AgentPromptComposerModal({
 	const [value, setValue] = useState(initialValue);
 	const [variablesExpanded, setVariablesExpanded] = useState(false);
 	const textareaRef = useRef<HTMLTextAreaElement>(null);
-	const { registerLayer, unregisterLayer } = useLayerStack();
 	const onCloseRef = useRef(onClose);
 	onCloseRef.current = onClose;
 	const onSubmitRef = useRef(onSubmit);
@@ -67,28 +66,21 @@ export function AgentPromptComposerModal({
 	}, [isOpen]);
 
 	// Register with layer stack for Escape handling
-	useEffect(() => {
-		if (isOpen) {
-			const id = registerLayer({
-				type: 'modal',
-				priority: MODAL_PRIORITIES.AGENT_PROMPT_COMPOSER,
-				blocksLowerLayers: true,
-				capturesFocus: true,
-				focusTrap: 'strict',
-				onEscape: () => {
-					// If autocomplete is open, close it instead of the modal
-					if (autocompleteState.isOpen) {
-						closeAutocomplete();
-						return;
-					}
-					// Save the current value back before closing
-					onSubmitRef.current(valueRef.current);
-					onCloseRef.current();
-				},
-			});
-			return () => unregisterLayer(id);
-		}
-	}, [isOpen, registerLayer, unregisterLayer, autocompleteState.isOpen, closeAutocomplete]);
+	useModalLayer(
+		MODAL_PRIORITIES.AGENT_PROMPT_COMPOSER,
+		undefined,
+		() => {
+			// If autocomplete is open, close it instead of the modal
+			if (autocompleteState.isOpen) {
+				closeAutocomplete();
+				return;
+			}
+			// Save the current value back before closing
+			onSubmitRef.current(valueRef.current);
+			onCloseRef.current();
+		},
+		{ enabled: isOpen }
+	);
 
 	if (!isOpen) return null;
 

--- a/src/renderer/components/AgentSessionsBrowser.tsx
+++ b/src/renderer/components/AgentSessionsBrowser.tsx
@@ -26,7 +26,7 @@ import {
 	Edit3,
 } from 'lucide-react';
 import type { Theme, Session, LogEntry, UsageStats } from '../types';
-import { useLayerStack } from '../contexts/LayerStackContext';
+import { useModalLayer } from '../hooks/ui/useModalLayer';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
 import { SessionActivityGraph, type ActivityEntry } from './SessionActivityGraph';
 import { SessionListItem } from './SessionListItem';
@@ -176,14 +176,11 @@ export function AgentSessionsBrowser({
 	const selectedItemRef = useRef<HTMLButtonElement>(null);
 	const searchModeDropdownRef = useRef<HTMLDivElement>(null);
 	const searchTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-	const layerIdRef = useRef<string>();
 	const onCloseRef = useRef(onClose);
 	onCloseRef.current = onClose;
 	const viewingSessionRef = useRef(viewingSession);
 	viewingSessionRef.current = viewingSession;
 	const autoJumpedRef = useRef<string | null>(null); // Track which session we've auto-jumped to
-
-	const { registerLayer, unregisterLayer, updateLayerHandler } = useLayerStack();
 
 	const handleSearchChange = useCallback((value: string) => {
 		setSearch(value);
@@ -196,43 +193,19 @@ export function AgentSessionsBrowser({
 	}, [clearViewingSession]);
 
 	// Register layer on mount for Escape key handling
-	useEffect(() => {
-		layerIdRef.current = registerLayer({
-			type: 'modal',
-			priority: MODAL_PRIORITIES.AGENT_SESSIONS,
-			blocksLowerLayers: true,
-			capturesFocus: true,
-			focusTrap: 'lenient',
-			ariaLabel: 'Agent Sessions Browser',
-			onEscape: () => {
-				// If viewing a session detail, go back to list; otherwise close the panel
-				if (viewingSessionRef.current) {
-					clearViewingSession();
-				} else {
-					onCloseRef.current();
-				}
-			},
-		});
-
-		return () => {
-			if (layerIdRef.current) {
-				unregisterLayer(layerIdRef.current);
+	useModalLayer(
+		MODAL_PRIORITIES.AGENT_SESSIONS,
+		'Agent Sessions Browser',
+		() => {
+			// If viewing a session detail, go back to list; otherwise close the panel
+			if (viewingSessionRef.current) {
+				clearViewingSession();
+			} else {
+				onCloseRef.current();
 			}
-		};
-	}, [registerLayer, unregisterLayer, clearViewingSession]);
-
-	// Update handler when viewingSession changes
-	useEffect(() => {
-		if (layerIdRef.current) {
-			updateLayerHandler(layerIdRef.current, () => {
-				if (viewingSessionRef.current) {
-					clearViewingSession();
-				} else {
-					onCloseRef.current();
-				}
-			});
-		}
-	}, [viewingSession, updateLayerHandler, clearViewingSession]);
+		},
+		{ focusTrap: 'lenient' }
+	);
 
 	// Restore focus and scroll position when returning from detail view to list view
 	const prevViewingSessionRef = useRef<ClaudeSession | null>(null);

--- a/src/renderer/components/AutoRun/AutoRunExpandedModal.tsx
+++ b/src/renderer/components/AutoRun/AutoRunExpandedModal.tsx
@@ -14,7 +14,7 @@ import {
 	AlertTriangle,
 } from 'lucide-react';
 import type { Theme, BatchRunState, SessionState, Shortcut } from '../../types';
-import { useLayerStack } from '../../contexts/LayerStackContext';
+import { useModalLayer } from '../../hooks/ui/useModalLayer';
 import { MODAL_PRIORITIES } from '../../constants/modalPriorities';
 import { AutoRun } from './AutoRun';
 import type { AutoRunHandle } from './types';
@@ -93,8 +93,6 @@ export function AutoRunExpandedModal({
 	onOpenMarketplace,
 	...autoRunProps
 }: AutoRunExpandedModalProps) {
-	const { registerLayer, unregisterLayer, updateLayerHandler } = useLayerStack();
-	const layerIdRef = useRef<string>();
 	const onCloseRef = useRef(onClose);
 	const handleCloseRef = useRef<() => void>(() => {});
 	const autoRunRef = useRef<AutoRunHandle>(null);
@@ -177,35 +175,9 @@ export function AutoRunExpandedModal({
 		onClose();
 	}, [handleRevert, onClose]);
 
-	// Register layer on mount
-	useEffect(() => {
-		const id = registerLayer({
-			type: 'modal',
-			priority: MODAL_PRIORITIES.AUTORUN_EXPANDED,
-			blocksLowerLayers: true,
-			capturesFocus: true,
-			focusTrap: 'strict',
-			onEscape: () => {
-				handleCloseRef.current();
-			},
-		});
-		layerIdRef.current = id;
-
-		return () => {
-			if (layerIdRef.current) {
-				unregisterLayer(layerIdRef.current);
-			}
-		};
-	}, [registerLayer, unregisterLayer]);
-
-	// Keep escape handler up to date
-	useEffect(() => {
-		if (layerIdRef.current) {
-			updateLayerHandler(layerIdRef.current, () => {
-				handleCloseRef.current();
-			});
-		}
-	}, [handleClose, updateLayerHandler]);
+	useModalLayer(MODAL_PRIORITIES.AUTORUN_EXPANDED, undefined, () => {
+		handleCloseRef.current();
+	});
 
 	// Focus the AutoRun component on mount
 	useEffect(() => {

--- a/src/renderer/components/AutoRun/AutoRunLightbox.tsx
+++ b/src/renderer/components/AutoRun/AutoRunLightbox.tsx
@@ -55,8 +55,11 @@ export const AutoRunLightbox = memo(
 		const onCloseRef = useRef(onClose);
 		onCloseRef.current = onClose;
 
-		// Determine if lightbox is visible
-		const isVisible = Boolean(lightboxFilename);
+		// Determine if lightbox is visible and has a renderable image
+		const lightboxImageUrl =
+			lightboxExternalUrl ||
+			(lightboxFilename ? attachmentPreviews.get(lightboxFilename) : undefined);
+		const isVisible = Boolean(lightboxFilename && lightboxImageUrl);
 
 		// Register with layer stack when lightbox is visible
 		// This ensures Escape closes the lightbox first before the expanded modal

--- a/src/renderer/components/AutoRun/AutoRunLightbox.tsx
+++ b/src/renderer/components/AutoRun/AutoRunLightbox.tsx
@@ -1,9 +1,9 @@
-import React, { useState, useCallback, memo, useEffect, useRef } from 'react';
+import React, { useState, useCallback, memo, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { X, ChevronLeft, ChevronRight, Copy, Check, Trash2, FileText } from 'lucide-react';
 import type { Theme } from '../../types';
 import { formatShortcutKeys } from '../../utils/shortcutFormatter';
-import { useLayerStack } from '../../contexts/LayerStackContext';
+import { useModalLayer } from '../../hooks/ui/useModalLayer';
 import { MODAL_PRIORITIES } from '../../constants/modalPriorities';
 import { ConfirmModal } from '../ConfirmModal';
 import { safeClipboardWrite, safeClipboardWriteImage } from '../../utils/clipboard';
@@ -52,8 +52,6 @@ export const AutoRunLightbox = memo(
 		const [copied, setCopied] = useState(false);
 		const [copiedMarkdown, setCopiedMarkdown] = useState(false);
 		const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
-		const { registerLayer, unregisterLayer, updateLayerHandler } = useLayerStack();
-		const layerIdRef = useRef<string>();
 		const onCloseRef = useRef(onClose);
 		onCloseRef.current = onClose;
 
@@ -62,36 +60,14 @@ export const AutoRunLightbox = memo(
 
 		// Register with layer stack when lightbox is visible
 		// This ensures Escape closes the lightbox first before the expanded modal
-		useEffect(() => {
-			if (isVisible) {
-				const id = registerLayer({
-					type: 'modal',
-					priority: MODAL_PRIORITIES.AUTORUN_LIGHTBOX,
-					blocksLowerLayers: true,
-					capturesFocus: true,
-					focusTrap: 'lenient',
-					onEscape: () => {
-						onCloseRef.current();
-					},
-				});
-				layerIdRef.current = id;
-
-				return () => {
-					if (layerIdRef.current) {
-						unregisterLayer(layerIdRef.current);
-					}
-				};
-			}
-		}, [isVisible, registerLayer, unregisterLayer]);
-
-		// Keep escape handler up to date
-		useEffect(() => {
-			if (layerIdRef.current) {
-				updateLayerHandler(layerIdRef.current, () => {
-					onCloseRef.current();
-				});
-			}
-		}, [onClose, updateLayerHandler]);
+		useModalLayer(
+			MODAL_PRIORITIES.AUTORUN_LIGHTBOX,
+			undefined,
+			() => {
+				onCloseRef.current();
+			},
+			{ focusTrap: 'lenient', enabled: isVisible }
+		);
 
 		// Calculate current index and navigation availability
 		const currentIndex = lightboxFilename ? attachmentsList.indexOf(lightboxFilename) : -1;

--- a/src/renderer/components/AutoRun/AutoRunSearchBar.tsx
+++ b/src/renderer/components/AutoRun/AutoRunSearchBar.tsx
@@ -1,7 +1,7 @@
 import React, { useRef, useEffect, useCallback } from 'react';
 import { Search, ChevronUp, ChevronDown, X } from 'lucide-react';
 import type { Theme } from '../../types';
-import { useLayerStack } from '../../contexts/LayerStackContext';
+import { useModalLayer } from '../../hooks/ui/useModalLayer';
 import { MODAL_PRIORITIES } from '../../constants/modalPriorities';
 
 export interface AutoRunSearchBarProps {
@@ -37,22 +37,12 @@ export function AutoRunSearchBar({
 	onClose,
 }: AutoRunSearchBarProps) {
 	const searchInputRef = useRef<HTMLInputElement>(null);
-	const { registerLayer, unregisterLayer } = useLayerStack();
-	const onCloseRef = useRef(onClose);
-	onCloseRef.current = onClose;
 
 	// Register with layer stack so Escape closes search before modal
-	useEffect(() => {
-		const id = registerLayer({
-			type: 'modal',
-			priority: MODAL_PRIORITIES.AUTORUN_SEARCH,
-			blocksLowerLayers: false,
-			capturesFocus: true,
-			focusTrap: 'lenient',
-			onEscape: () => onCloseRef.current(),
-		});
-		return () => unregisterLayer(id);
-	}, [registerLayer, unregisterLayer]);
+	useModalLayer(MODAL_PRIORITIES.AUTORUN_SEARCH, undefined, onClose, {
+		blocksLowerLayers: false,
+		focusTrap: 'lenient',
+	});
 
 	// Auto-focus the search input when the component mounts
 	useEffect(() => {

--- a/src/renderer/components/BatchRunnerModal.tsx
+++ b/src/renderer/components/BatchRunnerModal.tsx
@@ -16,7 +16,7 @@ import {
 	Loader2,
 } from 'lucide-react';
 import type { Theme, BatchDocumentEntry, BatchRunConfig, WorktreeRunTarget } from '../types';
-import { useLayerStack } from '../contexts/LayerStackContext';
+import { useModalLayer } from '../hooks/ui/useModalLayer';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
 import { TEMPLATE_VARIABLES } from '../utils/templateVariables';
 import { PlaybookDeleteConfirmModal } from './PlaybookDeleteConfirmModal';
@@ -248,9 +248,6 @@ export function BatchRunnerModal(props: BatchRunnerModalProps) {
 		onApplyPlaybook: handleApplyPlaybook,
 	});
 
-	const { registerLayer, unregisterLayer, updateLayerHandler } = useLayerStack();
-	const layerIdRef = useRef<string>();
-
 	// Use ref for getDocumentTaskCount to avoid dependency issues
 	const getDocumentTaskCountRef = useRef(getDocumentTaskCount);
 	getDocumentTaskCountRef.current = getDocumentTaskCount;
@@ -291,60 +288,15 @@ export function BatchRunnerModal(props: BatchRunnerModalProps) {
 	const hasValidPrompt = validateAgentPromptHasTaskReference(prompt);
 	const isPromptEmpty = !prompt || !prompt.trim();
 
-	// Register layer on mount
-	useEffect(() => {
-		const id = registerLayer({
-			type: 'modal',
-			priority: MODAL_PRIORITIES.BATCH_RUNNER,
-			blocksLowerLayers: true,
-			capturesFocus: true,
-			focusTrap: 'strict',
-			onEscape: () => {
-				if (showDeleteConfirmModal) {
-					handleCancelDeletePlaybook();
-				} else if (showSavePlaybookModal) {
-					setShowSavePlaybookModal(false);
-				} else {
-					handleCloseWithConfirmation();
-				}
-			},
-		});
-		layerIdRef.current = id;
-
-		return () => {
-			if (layerIdRef.current) {
-				unregisterLayer(layerIdRef.current);
-			}
-		};
-	}, [
-		registerLayer,
-		unregisterLayer,
-		showSavePlaybookModal,
-		showDeleteConfirmModal,
-		handleCancelDeletePlaybook,
-		handleCloseWithConfirmation,
-	]);
-
-	// Update handler when dependencies change
-	useEffect(() => {
-		if (layerIdRef.current) {
-			updateLayerHandler(layerIdRef.current, () => {
-				if (showDeleteConfirmModal) {
-					handleCancelDeletePlaybook();
-				} else if (showSavePlaybookModal) {
-					setShowSavePlaybookModal(false);
-				} else {
-					handleCloseWithConfirmation();
-				}
-			});
+	useModalLayer(MODAL_PRIORITIES.BATCH_RUNNER, undefined, () => {
+		if (showDeleteConfirmModal) {
+			handleCancelDeletePlaybook();
+		} else if (showSavePlaybookModal) {
+			setShowSavePlaybookModal(false);
+		} else {
+			handleCloseWithConfirmation();
 		}
-	}, [
-		handleCloseWithConfirmation,
-		updateLayerHandler,
-		showSavePlaybookModal,
-		showDeleteConfirmModal,
-		handleCancelDeletePlaybook,
-	]);
+	});
 
 	// Focus textarea on mount
 	useEffect(() => {

--- a/src/renderer/components/CreatePRModal.tsx
+++ b/src/renderer/components/CreatePRModal.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { X, GitPullRequest, Loader2, AlertTriangle, ExternalLink } from 'lucide-react';
 import type { Theme, GhCliStatus } from '../types';
-import { useLayerStack } from '../contexts/LayerStackContext';
+import { useModalLayer } from '../hooks/ui/useModalLayer';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
 import { openUrl } from '../utils/openUrl';
 
@@ -85,9 +85,13 @@ export function CreatePRModal({
 	availableBranches,
 	onPRCreated,
 }: CreatePRModalProps) {
-	const { registerLayer, unregisterLayer } = useLayerStack();
 	const onCloseRef = useRef(onClose);
 	onCloseRef.current = onClose;
+
+	useModalLayer(MODAL_PRIORITIES.CREATE_PR, undefined, () => onCloseRef.current(), {
+		focusTrap: 'lenient',
+		enabled: isOpen,
+	});
 
 	// Form state
 	const [targetBranch, setTargetBranch] = useState('main');
@@ -100,21 +104,6 @@ export function CreatePRModal({
 	const [error, setError] = useState<string | null>(null);
 	const [hasUncommittedChanges, setHasUncommittedChanges] = useState(false);
 	const [uncommittedCount, setUncommittedCount] = useState(0);
-
-	// Register with layer stack for Escape handling
-	useEffect(() => {
-		if (isOpen) {
-			const id = registerLayer({
-				type: 'modal',
-				priority: MODAL_PRIORITIES.CREATE_PR,
-				onEscape: () => onCloseRef.current(),
-				blocksLowerLayers: true,
-				capturesFocus: true,
-				focusTrap: 'lenient',
-			});
-			return () => unregisterLayer(id);
-		}
-	}, [isOpen, registerLayer, unregisterLayer]);
 
 	// Check gh CLI status and uncommitted changes on mount
 	useEffect(() => {

--- a/src/renderer/components/CreateWorktreeModal.tsx
+++ b/src/renderer/components/CreateWorktreeModal.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
 import { X, GitBranch, Loader2, AlertTriangle } from 'lucide-react';
 import type { Theme, Session, GhCliStatus } from '../types';
-import { useLayerStack } from '../contexts/LayerStackContext';
+import { useModalLayer } from '../hooks/ui/useModalLayer';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
 import { openUrl } from '../utils/openUrl';
 
@@ -26,9 +26,13 @@ export function CreateWorktreeModal({
 	session,
 	onCreateWorktree,
 }: CreateWorktreeModalProps) {
-	const { registerLayer, unregisterLayer } = useLayerStack();
 	const onCloseRef = useRef(onClose);
 	onCloseRef.current = onClose;
+
+	useModalLayer(MODAL_PRIORITIES.CREATE_WORKTREE, undefined, () => onCloseRef.current(), {
+		focusTrap: 'lenient',
+		enabled: isOpen,
+	});
 
 	// Form state
 	const [branchName, setBranchName] = useState('');
@@ -40,21 +44,6 @@ export function CreateWorktreeModal({
 
 	// Input ref for auto-focus
 	const inputRef = useRef<HTMLInputElement>(null);
-
-	// Register with layer stack for Escape handling
-	useEffect(() => {
-		if (isOpen) {
-			const id = registerLayer({
-				type: 'modal',
-				priority: MODAL_PRIORITIES.CREATE_WORKTREE,
-				onEscape: () => onCloseRef.current(),
-				blocksLowerLayers: true,
-				capturesFocus: true,
-				focusTrap: 'lenient',
-			});
-			return () => unregisterLayer(id);
-		}
-	}, [isOpen, registerLayer, unregisterLayer]);
 
 	// Check gh CLI status and reset state on open
 	useEffect(() => {

--- a/src/renderer/components/CueModal/CueModal.tsx
+++ b/src/renderer/components/CueModal/CueModal.tsx
@@ -13,7 +13,7 @@
 import { useEffect, useMemo, useRef, useState, useCallback } from 'react';
 import { createPortal } from 'react-dom';
 import type { Theme } from '../../types';
-import { useLayerStack } from '../../contexts/LayerStackContext';
+import { useModalLayer } from '../../hooks/ui/useModalLayer';
 import { MODAL_PRIORITIES } from '../../constants/modalPriorities';
 import { useCue } from '../../hooks/useCue';
 import type { CueSessionStatus } from '../../hooks/useCue';
@@ -37,8 +37,6 @@ export interface CueModalProps {
 }
 
 export function CueModal({ theme, onClose, cueShortcutKeys }: CueModalProps) {
-	const { registerLayer, unregisterLayer } = useLayerStack();
-	const layerIdRef = useRef<string>();
 	const onCloseRef = useRef(onClose);
 	onCloseRef.current = onClose;
 
@@ -89,37 +87,20 @@ export function CueModal({ theme, onClose, cueShortcutKeys }: CueModalProps) {
 	const showHelpRef = useRef(false);
 	showHelpRef.current = showHelp;
 
-	// Register layer on mount
-	useEffect(() => {
-		const id = registerLayer({
-			type: 'modal',
-			priority: MODAL_PRIORITIES.CUE_MODAL,
-			blocksLowerLayers: true,
-			capturesFocus: true,
-			focusTrap: 'strict',
-			onEscape: () => {
-				if (showHelpRef.current) {
-					setShowHelp(false);
-					return;
-				}
-				if (useCueDirtyStore.getState().pipelineDirty) {
-					getModalActions().showConfirmation(
-						'You have unsaved changes in the pipeline editor. Discard and close?',
-						() => onCloseRef.current()
-					);
-					return;
-				}
-				onCloseRef.current();
-			},
-		});
-		layerIdRef.current = id;
-
-		return () => {
-			if (layerIdRef.current) {
-				unregisterLayer(layerIdRef.current);
-			}
-		};
-	}, [registerLayer, unregisterLayer]);
+	useModalLayer(MODAL_PRIORITIES.CUE_MODAL, undefined, () => {
+		if (showHelpRef.current) {
+			setShowHelp(false);
+			return;
+		}
+		if (useCueDirtyStore.getState().pipelineDirty) {
+			getModalActions().showConfirmation(
+				'You have unsaved changes in the pipeline editor. Discard and close?',
+				() => onCloseRef.current()
+			);
+			return;
+		}
+		onCloseRef.current();
+	});
 
 	// Read initial tab from modal data (e.g., when navigating from YAML editor)
 	const cueModalData = useModalStore(selectModalData('cueModal'));

--- a/src/renderer/components/DirectorNotes/DirectorNotesModal.tsx
+++ b/src/renderer/components/DirectorNotes/DirectorNotesModal.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef, useCallback, lazy, Suspense } from 
 import { createPortal } from 'react-dom';
 import { X, History, Sparkles, Loader2, Clapperboard, HelpCircle } from 'lucide-react';
 import type { Theme } from '../../types';
-import { useLayerStack } from '../../contexts/LayerStackContext';
+import { useModalLayer } from '../../hooks/ui/useModalLayer';
 import { MODAL_PRIORITIES } from '../../constants/modalPriorities';
 import { OverviewTab, type TabFocusHandle } from './OverviewTab';
 import { hasCachedSynopsis } from './AIOverviewTab';
@@ -50,8 +50,6 @@ export function DirectorNotesModal({
 	const [overviewGenerating, setOverviewGenerating] = useState(false);
 
 	// Layer stack registration for Escape handling
-	const { registerLayer, unregisterLayer } = useLayerStack();
-	const layerIdRef = useRef<string>();
 	const modalRef = useRef<HTMLDivElement>(null);
 
 	// Tab content refs for focus management
@@ -82,29 +80,22 @@ export function DirectorNotesModal({
 	activeTabRef.current = activeTab;
 
 	// Register modal layer
-	useEffect(() => {
-		layerIdRef.current = registerLayer({
-			type: 'modal',
-			priority: MODAL_PRIORITIES.DIRECTOR_NOTES,
-			blocksLowerLayers: true,
-			capturesFocus: true,
-			focusTrap: 'lenient',
-			onEscape: () => {
-				// Delegate Escape to the active tab first (e.g. to close search)
-				const tabRef =
-					activeTabRef.current === 'history'
-						? historyTabRef
-						: activeTabRef.current === 'overview'
-							? overviewTabRef
-							: null;
-				if (tabRef?.current?.onEscape?.()) return;
-				onCloseRef.current();
-			},
-		});
-		return () => {
-			if (layerIdRef.current) unregisterLayer(layerIdRef.current);
-		};
-	}, [registerLayer, unregisterLayer]);
+	useModalLayer(
+		MODAL_PRIORITIES.DIRECTOR_NOTES,
+		undefined,
+		() => {
+			// Delegate Escape to the active tab first (e.g. to close search)
+			const tabRef =
+				activeTabRef.current === 'history'
+					? historyTabRef
+					: activeTabRef.current === 'overview'
+						? overviewTabRef
+						: null;
+			if (tabRef?.current?.onEscape?.()) return;
+			onCloseRef.current();
+		},
+		{ focusTrap: 'lenient' }
+	);
 
 	// Focus the active tab content when tab changes (including initial mount)
 	useEffect(() => {

--- a/src/renderer/components/DocumentGraph/DocumentGraphView.tsx
+++ b/src/renderer/components/DocumentGraph/DocumentGraphView.tsx
@@ -34,6 +34,7 @@ import {
 } from 'lucide-react';
 import type { Theme } from '../../types';
 import { useLayerStack } from '../../contexts/LayerStackContext';
+import { useModalLayer } from '../../hooks/ui/useModalLayer';
 import { MODAL_PRIORITIES } from '../../constants/modalPriorities';
 import { Modal, ModalFooter } from '../ui/Modal';
 import { useDebouncedCallback } from '../../hooks/utils';
@@ -353,19 +354,10 @@ export function DocumentGraphView({
 	/**
 	 * Register with layer stack for Escape handling
 	 */
-	useEffect(() => {
-		if (isOpen) {
-			const id = registerLayer({
-				type: 'modal',
-				priority: MODAL_PRIORITIES.DOCUMENT_GRAPH,
-				blocksLowerLayers: true,
-				capturesFocus: true,
-				focusTrap: 'lenient',
-				onEscape: handleEscapeRequest,
-			});
-			return () => unregisterLayer(id);
-		}
-	}, [isOpen, registerLayer, unregisterLayer, handleEscapeRequest]);
+	useModalLayer(MODAL_PRIORITIES.DOCUMENT_GRAPH, undefined, handleEscapeRequest, {
+		focusTrap: 'lenient',
+		enabled: isOpen,
+	});
 
 	/**
 	 * Register depth slider dropdown with layer stack when open

--- a/src/renderer/components/DocumentsPanel.tsx
+++ b/src/renderer/components/DocumentsPanel.tsx
@@ -14,7 +14,7 @@ import {
 } from 'lucide-react';
 import type { Theme, BatchDocumentEntry } from '../types';
 import { generateId } from '../utils/ids';
-import { useLayerStack } from '../contexts/LayerStackContext';
+import { useModalLayer } from '../hooks/ui/useModalLayer';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
 import { formatMetaKey } from '../utils/shortcutFormatter';
 
@@ -66,25 +66,12 @@ function DocumentSelectorModal({
 	onRefresh,
 }: DocumentSelectorModalProps) {
 	// Layer stack for escape handling
-	const { registerLayer, unregisterLayer } = useLayerStack();
 	const onCloseRef = useRef(onClose);
 	onCloseRef.current = onClose;
 
-	// Register with layer stack for escape handling
-	useEffect(() => {
-		const id = registerLayer({
-			type: 'modal',
-			priority: MODAL_PRIORITIES.DOCUMENT_SELECTOR,
-			blocksLowerLayers: true,
-			capturesFocus: true,
-			focusTrap: 'strict',
-			ariaLabel: 'Select Documents',
-			onEscape: () => {
-				onCloseRef.current();
-			},
-		});
-		return () => unregisterLayer(id);
-	}, [registerLayer, unregisterLayer]);
+	useModalLayer(MODAL_PRIORITIES.DOCUMENT_SELECTOR, 'Select Documents', () => {
+		onCloseRef.current();
+	});
 
 	// Pre-select currently added documents
 	const [selectedDocs, setSelectedDocs] = useState<Set<string>>(() => {

--- a/src/renderer/components/ExecutionQueueBrowser.tsx
+++ b/src/renderer/components/ExecutionQueueBrowser.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { X, MessageSquare, Command, Trash2, Clock, Folder, FolderOpen } from 'lucide-react';
-import { useLayerStack } from '../contexts/LayerStackContext';
+import { useModalLayer } from '../hooks/ui/useModalLayer';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
 import type { Session, Theme, QueuedItem } from '../types';
 
@@ -43,9 +43,15 @@ export function ExecutionQueueBrowser({
 	const [viewMode, setViewMode] = useState<'current' | 'global'>('current');
 	const [dragState, setDragState] = useState<DragState | null>(null);
 	const [dropIndicator, setDropIndicator] = useState<DropIndicator | null>(null);
-	const { registerLayer, unregisterLayer } = useLayerStack();
 	const onCloseRef = useRef(onClose);
 	onCloseRef.current = onClose;
+
+	useModalLayer(
+		MODAL_PRIORITIES.EXECUTION_QUEUE_BROWSER || 50,
+		undefined,
+		() => onCloseRef.current(),
+		{ enabled: isOpen }
+	);
 
 	// Drag handlers
 	const handleDragStart = (sessionId: string, itemId: string, index: number) => {
@@ -79,21 +85,6 @@ export function ExecutionQueueBrowser({
 		setDragState(null);
 		setDropIndicator(null);
 	};
-
-	// Register with layer stack for proper escape handling
-	useEffect(() => {
-		if (isOpen) {
-			const id = registerLayer({
-				type: 'modal',
-				priority: MODAL_PRIORITIES.EXECUTION_QUEUE_BROWSER || 50,
-				blocksLowerLayers: true,
-				capturesFocus: true,
-				focusTrap: 'strict',
-				onEscape: () => onCloseRef.current(),
-			});
-			return () => unregisterLayer(id);
-		}
-	}, [isOpen, registerLayer, unregisterLayer]);
 
 	if (!isOpen) return null;
 

--- a/src/renderer/components/FileSearchModal.tsx
+++ b/src/renderer/components/FileSearchModal.tsx
@@ -4,7 +4,7 @@ import { useVirtualizer } from '@tanstack/react-virtual';
 import type { Theme, Shortcut } from '../types';
 import type { FileNode } from '../types/fileTree';
 import { fuzzyMatchWithScore } from '../utils/search';
-import { useLayerStack } from '../contexts/LayerStackContext';
+import { useModalLayer } from '../hooks/ui/useModalLayer';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
 import { formatShortcutKeys } from '../utils/shortcutFormatter';
 
@@ -217,7 +217,6 @@ export function FileSearchModal({
 	const [viewMode, setViewMode] = useState<ViewMode>('visible');
 	const inputRef = useRef<HTMLInputElement>(null);
 	const scrollContainerRef = useRef<HTMLDivElement>(null);
-	const layerIdRef = useRef<string>();
 	const onCloseRef = useRef(onClose);
 
 	const handleSearchChange = useCallback((value: string) => {
@@ -235,35 +234,9 @@ export function FileSearchModal({
 		onCloseRef.current = onClose;
 	});
 
-	const { registerLayer, unregisterLayer, updateLayerHandler } = useLayerStack();
-
-	// Register layer on mount
-	useEffect(() => {
-		layerIdRef.current = registerLayer({
-			type: 'modal',
-			priority: MODAL_PRIORITIES.FUZZY_FILE_SEARCH,
-			blocksLowerLayers: true,
-			capturesFocus: true,
-			focusTrap: 'strict',
-			ariaLabel: 'Fuzzy File Search',
-			onEscape: () => onCloseRef.current(),
-		});
-
-		return () => {
-			if (layerIdRef.current) {
-				unregisterLayer(layerIdRef.current);
-			}
-		};
-	}, [registerLayer, unregisterLayer]);
-
-	// Update handler when onClose changes
-	useEffect(() => {
-		if (layerIdRef.current) {
-			updateLayerHandler(layerIdRef.current, () => {
-				onCloseRef.current();
-			});
-		}
-	}, [updateLayerHandler]);
+	useModalLayer(MODAL_PRIORITIES.FUZZY_FILE_SEARCH, 'Fuzzy File Search', () =>
+		onCloseRef.current()
+	);
 
 	// Focus input on mount
 	useEffect(() => {

--- a/src/renderer/components/FirstRunCelebration.tsx
+++ b/src/renderer/components/FirstRunCelebration.tsx
@@ -21,7 +21,7 @@ import {
 } from 'lucide-react';
 import confetti from 'canvas-confetti';
 import type { Theme } from '../types';
-import { useLayerStack } from '../contexts/LayerStackContext';
+import { useModalLayer } from '../hooks/ui/useModalLayer';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
 import { formatShortcutKeys } from '../utils/shortcutFormatter';
 
@@ -99,8 +99,6 @@ export function FirstRunCelebration({
 	disableConfetti = false,
 }: FirstRunCelebrationProps): JSX.Element {
 	const containerRef = useRef<HTMLDivElement>(null);
-	const { registerLayer, unregisterLayer, updateLayerHandler } = useLayerStack();
-	const layerIdRef = useRef<string>();
 	const onCloseRef = useRef(onClose);
 	onCloseRef.current = onClose;
 
@@ -211,33 +209,16 @@ export function FirstRunCelebration({
 	}, [handleClose]);
 
 	// Register with layer stack
-	useEffect(() => {
-		const id = registerLayer({
-			type: 'modal',
-			priority: MODAL_PRIORITIES.STANDING_OVATION, // Use same high priority as standing ovation
-			blocksLowerLayers: true,
-			capturesFocus: true,
-			focusTrap: 'strict',
-			ariaLabel: 'First Auto Run Celebration',
-			onEscape: () => handleClose(),
-		});
-		layerIdRef.current = id;
+	useModalLayer(
+		MODAL_PRIORITIES.STANDING_OVATION, // Use same high priority as standing ovation
+		'First Auto Run Celebration',
+		handleClose
+	);
 
+	// Focus container on mount
+	useEffect(() => {
 		containerRef.current?.focus();
-
-		return () => {
-			if (layerIdRef.current) {
-				unregisterLayer(layerIdRef.current);
-			}
-		};
-	}, [registerLayer, unregisterLayer, handleClose]);
-
-	// Update escape handler when handleClose changes
-	useEffect(() => {
-		if (layerIdRef.current) {
-			updateLayerHandler(layerIdRef.current, handleClose);
-		}
-	}, [updateLayerHandler, handleClose]);
+	}, []);
 
 	return (
 		<>

--- a/src/renderer/components/GitDiffViewer.tsx
+++ b/src/renderer/components/GitDiffViewer.tsx
@@ -3,7 +3,7 @@ import { Diff, Hunk } from 'react-diff-view';
 import { Plus, Minus, ImageIcon } from 'lucide-react';
 import type { Theme } from '../types';
 import { parseGitDiff, getFileName, getDiffStats } from '../utils/gitDiffParser';
-import { useLayerStack } from '../contexts/LayerStackContext';
+import { useModalLayer } from '../hooks/ui/useModalLayer';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
 import { ImageDiffViewer } from './ImageDiffViewer';
 import { generateDiffViewStyles } from '../utils/markdownConfig';
@@ -24,8 +24,6 @@ export const GitDiffViewer = memo(function GitDiffViewer({
 }: GitDiffViewerProps) {
 	const [activeTab, setActiveTab] = useState(0);
 	const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
-	const { registerLayer, unregisterLayer, updateLayerHandler } = useLayerStack();
-	const layerIdRef = useRef<string>();
 
 	// Store onClose in ref to avoid re-registering layer on every parent re-render
 	const onCloseRef = useRef(onClose);
@@ -37,30 +35,9 @@ export const GitDiffViewer = memo(function GitDiffViewer({
 	// Register layer on mount
 	// Note: Using 'modal' type so App.tsx blocks all shortcuts and lets this component
 	// handle its own Cmd+Shift+[] for tab navigation
-	useEffect(() => {
-		layerIdRef.current = registerLayer({
-			type: 'modal',
-			priority: MODAL_PRIORITIES.GIT_DIFF,
-			blocksLowerLayers: true,
-			capturesFocus: true,
-			focusTrap: 'lenient',
-			ariaLabel: 'Git Diff Preview',
-			onEscape: () => onCloseRef.current(),
-		});
-
-		return () => {
-			if (layerIdRef.current) {
-				unregisterLayer(layerIdRef.current);
-			}
-		};
-	}, [registerLayer, unregisterLayer]); // Removed onClose from deps
-
-	// Update handler when dependencies change (not really needed since onClose uses ref)
-	useEffect(() => {
-		if (layerIdRef.current) {
-			updateLayerHandler(layerIdRef.current, () => onCloseRef.current());
-		}
-	}, [updateLayerHandler]);
+	useModalLayer(MODAL_PRIORITIES.GIT_DIFF, 'Git Diff Preview', () => onCloseRef.current(), {
+		focusTrap: 'lenient',
+	});
 
 	// Auto-scroll to active tab when it changes
 	useEffect(() => {

--- a/src/renderer/components/GitLogViewer.tsx
+++ b/src/renderer/components/GitLogViewer.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo, useEffect, useRef, useCallback, memo } from 'react';
 import { GitCommit, GitBranch, Tag } from 'lucide-react';
 import type { Theme } from '../types';
-import { useLayerStack } from '../contexts/LayerStackContext';
+import { useModalLayer } from '../hooks/ui/useModalLayer';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
 import { Diff, Hunk } from 'react-diff-view';
 import { parseGitDiff } from '../utils/gitDiffParser';
@@ -51,9 +51,6 @@ export const GitLogViewer = memo(function GitLogViewer({
 		enablePageNavigation: true,
 		pageSize: 10,
 	});
-
-	const { registerLayer, unregisterLayer, updateLayerHandler } = useLayerStack();
-	const layerIdRef = useRef<string>();
 
 	const onCloseRef = useRef(onClose);
 	onCloseRef.current = onClose;
@@ -111,31 +108,9 @@ export const GitLogViewer = memo(function GitLogViewer({
 		}
 	}, [selectedIndex, entries, loadCommitDiff]);
 
-	// Register with layer stack
-	useEffect(() => {
-		layerIdRef.current = registerLayer({
-			type: 'modal',
-			priority: MODAL_PRIORITIES.GIT_LOG,
-			blocksLowerLayers: true,
-			capturesFocus: true,
-			focusTrap: 'lenient',
-			ariaLabel: 'Git Log Viewer',
-			onEscape: () => onCloseRef.current(),
-		});
-
-		return () => {
-			if (layerIdRef.current) {
-				unregisterLayer(layerIdRef.current);
-			}
-		};
-	}, [registerLayer, unregisterLayer]);
-
-	// Update handler when dependencies change
-	useEffect(() => {
-		if (layerIdRef.current) {
-			updateLayerHandler(layerIdRef.current, () => onCloseRef.current());
-		}
-	}, [updateLayerHandler]);
+	useModalLayer(MODAL_PRIORITIES.GIT_LOG, 'Git Log Viewer', () => onCloseRef.current(), {
+		focusTrap: 'lenient',
+	});
 
 	// Scroll selected item into view
 	useEffect(() => {

--- a/src/renderer/components/HistoryDetailModal.tsx
+++ b/src/renderer/components/HistoryDetailModal.tsx
@@ -19,7 +19,7 @@ import {
 } from 'lucide-react';
 import type { Theme, HistoryEntry } from '../types';
 import type { FileNode } from '../types/fileTree';
-import { useLayerStack } from '../contexts/LayerStackContext';
+import { useModalLayer } from '../hooks/ui/useModalLayer';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
 import { formatElapsedTime } from '../utils/formatters';
 import { stripAnsiCodes } from '../../shared/stringUtils';
@@ -65,8 +65,6 @@ export function HistoryDetailModal({
 	projectRoot,
 	onFileClick,
 }: HistoryDetailModalProps) {
-	const { registerLayer, unregisterLayer, updateLayerHandler } = useLayerStack();
-	const layerIdRef = useRef<string>();
 	const onCloseRef = useRef(onClose);
 	onCloseRef.current = onClose;
 	const [copiedSessionId, setCopiedSessionId] = useState(false);
@@ -99,35 +97,9 @@ export function HistoryDetailModal({
 		}
 	}, [hasNext, filteredEntries, currentIndex, onNavigate]);
 
-	// Register layer on mount
-	useEffect(() => {
-		const id = registerLayer({
-			type: 'modal',
-			priority: MODAL_PRIORITIES.CONFIRM, // Use same priority as confirm modal
-			blocksLowerLayers: true,
-			capturesFocus: true,
-			focusTrap: 'strict',
-			onEscape: () => {
-				onCloseRef.current();
-			},
-		});
-		layerIdRef.current = id;
-
-		return () => {
-			if (layerIdRef.current) {
-				unregisterLayer(layerIdRef.current);
-			}
-		};
-	}, [registerLayer, unregisterLayer]);
-
-	// Keep escape handler up to date
-	useEffect(() => {
-		if (layerIdRef.current) {
-			updateLayerHandler(layerIdRef.current, () => {
-				onCloseRef.current();
-			});
-		}
-	}, [onClose, updateLayerHandler]);
+	useModalLayer(MODAL_PRIORITIES.CONFIRM, undefined, () => {
+		onCloseRef.current();
+	});
 
 	// Focus delete button when confirmation modal appears
 	useEffect(() => {

--- a/src/renderer/components/HistoryDetailModal.tsx
+++ b/src/renderer/components/HistoryDetailModal.tsx
@@ -98,6 +98,10 @@ export function HistoryDetailModal({
 	}, [hasNext, filteredEntries, currentIndex, onNavigate]);
 
 	useModalLayer(MODAL_PRIORITIES.CONFIRM, undefined, () => {
+		if (showDeleteConfirm) {
+			setShowDeleteConfirm(false);
+			return;
+		}
 		onCloseRef.current();
 	});
 

--- a/src/renderer/components/InlineWizard/WizardExitConfirmDialog.tsx
+++ b/src/renderer/components/InlineWizard/WizardExitConfirmDialog.tsx
@@ -8,7 +8,7 @@
 import { useEffect, useRef } from 'react';
 import { AlertCircle } from 'lucide-react';
 import type { Theme } from '../../types';
-import { useLayerStack } from '../../contexts/LayerStackContext';
+import { useModalLayer } from '../../hooks/ui/useModalLayer';
 import { MODAL_PRIORITIES } from '../../constants/modalPriorities';
 
 interface WizardExitConfirmDialogProps {
@@ -31,8 +31,6 @@ export function WizardExitConfirmDialog({
 	onConfirm,
 	onCancel,
 }: WizardExitConfirmDialogProps): JSX.Element {
-	const { registerLayer, unregisterLayer, updateLayerHandler } = useLayerStack();
-	const layerIdRef = useRef<string>();
 	const cancelButtonRef = useRef<HTMLButtonElement>(null);
 	const onCancelRef = useRef(onCancel);
 	onCancelRef.current = onCancel;
@@ -42,31 +40,9 @@ export function WizardExitConfirmDialog({
 		cancelButtonRef.current?.focus();
 	}, []);
 
-	// Register with layer stack
-	useEffect(() => {
-		const id = registerLayer({
-			type: 'modal',
-			priority: MODAL_PRIORITIES.INLINE_WIZARD_EXIT_CONFIRM,
-			blocksLowerLayers: true,
-			capturesFocus: true,
-			focusTrap: 'strict',
-			ariaLabel: 'Confirm Exit Wizard',
-			onEscape: () => onCancelRef.current(),
-		});
-		layerIdRef.current = id;
-		return () => {
-			if (layerIdRef.current) {
-				unregisterLayer(layerIdRef.current);
-			}
-		};
-	}, [registerLayer, unregisterLayer]);
-
-	// Update escape handler when onCancel changes
-	useEffect(() => {
-		if (layerIdRef.current) {
-			updateLayerHandler(layerIdRef.current, () => onCancelRef.current());
-		}
-	}, [onCancel, updateLayerHandler]);
+	useModalLayer(MODAL_PRIORITIES.INLINE_WIZARD_EXIT_CONFIRM, 'Confirm Exit Wizard', () =>
+		onCancelRef.current()
+	);
 
 	// Handle keyboard navigation
 	const handleKeyDown = (e: React.KeyboardEvent) => {

--- a/src/renderer/components/KeyboardMasteryCelebration.tsx
+++ b/src/renderer/components/KeyboardMasteryCelebration.tsx
@@ -10,7 +10,7 @@ import { useEffect, useRef, useCallback, useState, useMemo } from 'react';
 import { Keyboard, Trophy, Sparkles } from 'lucide-react';
 import confetti from 'canvas-confetti';
 import type { Theme, Shortcut } from '../types';
-import { useLayerStack } from '../contexts/LayerStackContext';
+import { useModalLayer } from '../hooks/ui/useModalLayer';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
 import { KEYBOARD_MASTERY_LEVELS } from '../constants/keyboardMastery';
 import { DEFAULT_SHORTCUTS } from '../constants/shortcuts';
@@ -67,8 +67,6 @@ export function KeyboardMasteryCelebration({
 	disableConfetti = false,
 }: KeyboardMasteryCelebrationProps): JSX.Element {
 	const containerRef = useRef<HTMLDivElement>(null);
-	const { registerLayer, unregisterLayer, updateLayerHandler } = useLayerStack();
-	const layerIdRef = useRef<string>();
 	const onCloseRef = useRef(onClose);
 	onCloseRef.current = onClose;
 
@@ -180,33 +178,14 @@ export function KeyboardMasteryCelebration({
 	}, []); // Empty deps - handler reads from ref
 
 	// Register with layer stack
-	useEffect(() => {
-		const id = registerLayer({
-			type: 'modal',
-			priority: MODAL_PRIORITIES.KEYBOARD_MASTERY,
-			blocksLowerLayers: true,
-			capturesFocus: true,
-			focusTrap: 'strict',
-			ariaLabel: 'Keyboard Mastery Level Up Celebration',
-			onEscape: () => handleCloseRef.current(),
-		});
-		layerIdRef.current = id;
+	useModalLayer(MODAL_PRIORITIES.KEYBOARD_MASTERY, 'Keyboard Mastery Level Up Celebration', () =>
+		handleCloseRef.current()
+	);
 
+	// Focus container on mount
+	useEffect(() => {
 		containerRef.current?.focus();
-
-		return () => {
-			if (layerIdRef.current) {
-				unregisterLayer(layerIdRef.current);
-			}
-		};
-	}, [registerLayer, unregisterLayer]);
-
-	// Update escape handler when handleClose changes
-	useEffect(() => {
-		if (layerIdRef.current) {
-			updateLayerHandler(layerIdRef.current, handleClose);
-		}
-	}, [updateLayerHandler, handleClose]);
+	}, []);
 
 	// Get next level info for encouragement message
 	const nextLevel =

--- a/src/renderer/components/LeaderboardRegistrationModal.tsx
+++ b/src/renderer/components/LeaderboardRegistrationModal.tsx
@@ -23,7 +23,7 @@ import {
 	DownloadCloud,
 } from 'lucide-react';
 import type { Theme, AutoRunStats, LeaderboardRegistration, KeyboardMasteryStats } from '../types';
-import { useLayerStack } from '../contexts/LayerStackContext';
+import { useModalLayer } from '../hooks/ui/useModalLayer';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
 import { getBadgeForTime } from '../constants/conductorBadges';
 import { KEYBOARD_MASTERY_LEVELS } from '../constants/keyboardMastery';
@@ -132,8 +132,9 @@ export function LeaderboardRegistrationModal({
 	onOptOut,
 	onSyncStats,
 }: LeaderboardRegistrationModalProps) {
-	const { registerLayer, unregisterLayer } = useLayerStack();
-	const layerIdRef = useRef<string>();
+	useModalLayer(MODAL_PRIORITIES.LEADERBOARD_REGISTRATION, 'Register for Leaderboard', () =>
+		onCloseRef.current()
+	);
 	const containerRef = useRef<HTMLDivElement>(null);
 	const onCloseRef = useRef(onClose);
 	onCloseRef.current = onClose;
@@ -737,27 +738,10 @@ export function LeaderboardRegistrationModal({
 		setSuccessMessage('You have opted out of the leaderboard. Your local stats are preserved.');
 	}, [onOptOut]);
 
-	// Register layer on mount
+	// Focus container on mount
 	useEffect(() => {
-		const id = registerLayer({
-			type: 'modal',
-			priority: MODAL_PRIORITIES.LEADERBOARD_REGISTRATION,
-			blocksLowerLayers: true,
-			capturesFocus: true,
-			focusTrap: 'strict',
-			ariaLabel: 'Register for Leaderboard',
-			onEscape: () => onCloseRef.current(),
-		});
-		layerIdRef.current = id;
-
 		containerRef.current?.focus();
-
-		return () => {
-			if (layerIdRef.current) {
-				unregisterLayer(layerIdRef.current);
-			}
-		};
-	}, [registerLayer, unregisterLayer]);
+	}, []);
 
 	// Handle Enter key for form submission
 	const handleKeyDown = useCallback(

--- a/src/renderer/components/LogViewer.tsx
+++ b/src/renderer/components/LogViewer.tsx
@@ -15,7 +15,7 @@ import {
 import type { Theme } from '../types';
 import { formatShortcutKeys } from '../utils/shortcutFormatter';
 import { useThrottledCallback } from '../hooks';
-import { useLayerStack } from '../contexts/LayerStackContext';
+import { useModalLayer } from '../hooks/ui/useModalLayer';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
 import { safeClipboardWrite } from '../utils/clipboard';
 import { ConfirmModal } from './ConfirmModal';
@@ -132,13 +132,10 @@ export function LogViewer({
 	const searchInputRef = useRef<HTMLInputElement>(null);
 	const containerRef = useRef<HTMLDivElement>(null);
 	const scrollTargetRef = useRef<HTMLDivElement | null>(null);
-	const layerIdRef = useRef<string>();
 
 	// Store onClose in ref to avoid re-registering layer when callback identity changes
 	const onCloseRef = useRef(onClose);
 	onCloseRef.current = onClose;
-
-	const { registerLayer, unregisterLayer, updateLayerHandler } = useLayerStack();
 
 	const toggleDataExpanded = (index: number) => {
 		setExpandedData((prev) => {
@@ -235,46 +232,20 @@ export function LogViewer({
 
 	// Register layer on mount
 	// Note: Using 'modal' type because LogViewer blocks all shortcuts (like the original modalOpen check)
-	useEffect(() => {
-		layerIdRef.current = registerLayer({
-			type: 'modal',
-			priority: MODAL_PRIORITIES.LOG_VIEWER,
-			blocksLowerLayers: true,
-			capturesFocus: true,
-			focusTrap: 'lenient',
-			ariaLabel: 'System Log Viewer',
-			onEscape: () => {
-				if (searchOpen) {
-					setSearchOpen(false);
-					setSearchQuery('');
-					containerRef.current?.focus();
-				} else {
-					onCloseRef.current();
-				}
-			},
-		});
-
-		return () => {
-			if (layerIdRef.current) {
-				unregisterLayer(layerIdRef.current);
+	useModalLayer(
+		MODAL_PRIORITIES.LOG_VIEWER,
+		'System Log Viewer',
+		() => {
+			if (searchOpen) {
+				setSearchOpen(false);
+				setSearchQuery('');
+				containerRef.current?.focus();
+			} else {
+				onCloseRef.current();
 			}
-		};
-	}, [registerLayer, unregisterLayer]); // Note: onClose NOT in deps (using ref)
-
-	// Update layer handler when dependencies change
-	useEffect(() => {
-		if (layerIdRef.current) {
-			updateLayerHandler(layerIdRef.current, () => {
-				if (searchOpen) {
-					setSearchOpen(false);
-					setSearchQuery('');
-					containerRef.current?.focus();
-				} else {
-					onCloseRef.current();
-				}
-			});
-		}
-	}, [searchOpen, updateLayerHandler]); // Note: onClose NOT in deps (using ref)
+		},
+		{ focusTrap: 'lenient' }
+	);
 
 	// Auto-focus container on mount for keyboard navigation
 	useEffect(() => {

--- a/src/renderer/components/MarketplaceModal.tsx
+++ b/src/renderer/components/MarketplaceModal.tsx
@@ -25,7 +25,7 @@ import {
 } from 'lucide-react';
 import type { Theme } from '../types';
 import type { MarketplacePlaybook } from '../../shared/marketplace-types';
-import { useLayerStack } from '../contexts/LayerStackContext';
+import { useModalLayer } from '../hooks/ui/useModalLayer';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
 import { useMarketplace } from '../hooks/batch/useMarketplace';
 import {
@@ -732,7 +732,6 @@ export function MarketplaceModal({
 	onImportComplete,
 }: MarketplaceModalProps) {
 	// Layer stack for escape handling
-	const { registerLayer, unregisterLayer } = useLayerStack();
 	const onCloseRef = useRef(onClose);
 	onCloseRef.current = onClose;
 
@@ -821,28 +820,20 @@ export function MarketplaceModal({
 	handleBackToListRef.current = handleBackToList;
 
 	// Register with layer stack for escape handling
-	useEffect(() => {
-		if (isOpen) {
-			const id = registerLayer({
-				type: 'modal',
-				priority: MODAL_PRIORITIES.MARKETPLACE,
-				blocksLowerLayers: true,
-				capturesFocus: true,
-				focusTrap: 'strict',
-				ariaLabel: 'Playbook Exchange',
-				onEscape: () => {
-					if (showHelpRef.current) {
-						setShowHelp(false);
-					} else if (showDetailViewRef.current) {
-						handleBackToListRef.current();
-					} else {
-						onCloseRef.current();
-					}
-				},
-			});
-			return () => unregisterLayer(id);
-		}
-	}, [isOpen, registerLayer, unregisterLayer]);
+	useModalLayer(
+		MODAL_PRIORITIES.MARKETPLACE,
+		'Playbook Exchange',
+		() => {
+			if (showHelpRef.current) {
+				setShowHelp(false);
+			} else if (showDetailViewRef.current) {
+				handleBackToListRef.current();
+			} else {
+				onCloseRef.current();
+			}
+		},
+		{ enabled: isOpen }
+	);
 
 	// Focus search input when modal opens
 	useEffect(() => {

--- a/src/renderer/components/MergeSessionModal.tsx
+++ b/src/renderer/components/MergeSessionModal.tsx
@@ -19,7 +19,7 @@ import { Search, ChevronRight, ChevronDown, GitMerge, Clipboard, Check, X } from
 import type { Theme, Session } from '../types';
 import type { MergeResult } from '../types/contextMerge';
 import { fuzzyMatchWithScore } from '../utils/search';
-import { useLayerStack } from '../contexts/LayerStackContext';
+import { useModalLayer } from '../hooks/ui/useModalLayer';
 import { useListNavigation } from '../hooks';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
 import { formatTokensCompact } from '../utils/formatters';
@@ -182,7 +182,6 @@ export function MergeSessionModal({
 
 	// Refs
 	const inputRef = useRef<HTMLInputElement>(null);
-	const layerIdRef = useRef<string>();
 	const onCloseRef = useRef(onClose);
 	const scrollContainerRef = useRef<HTMLDivElement>(null);
 	const selectedItemRef = useRef<HTMLButtonElement>(null);
@@ -192,35 +191,13 @@ export function MergeSessionModal({
 		onCloseRef.current = onClose;
 	});
 
-	const { registerLayer, unregisterLayer, updateLayerHandler } = useLayerStack();
-
 	// Register layer on mount
-	useEffect(() => {
-		if (!isOpen) return;
-
-		layerIdRef.current = registerLayer({
-			type: 'modal',
-			priority: MODAL_PRIORITIES.MERGE_SESSION,
-			blocksLowerLayers: true,
-			capturesFocus: true,
-			focusTrap: 'strict',
-			ariaLabel: 'Merge Session Contexts',
-			onEscape: () => onCloseRef.current(),
-		});
-
-		return () => {
-			if (layerIdRef.current) {
-				unregisterLayer(layerIdRef.current);
-			}
-		};
-	}, [isOpen, registerLayer, unregisterLayer]);
-
-	// Update handler when onClose changes
-	useEffect(() => {
-		if (layerIdRef.current) {
-			updateLayerHandler(layerIdRef.current, () => onCloseRef.current());
-		}
-	}, [updateLayerHandler]);
+	useModalLayer(
+		MODAL_PRIORITIES.MERGE_SESSION,
+		'Merge Session Contexts',
+		() => onCloseRef.current(),
+		{ enabled: isOpen }
+	);
 
 	// Focus input on mount
 	useEffect(() => {

--- a/src/renderer/components/PlaygroundPanel.tsx
+++ b/src/renderer/components/PlaygroundPanel.tsx
@@ -13,7 +13,7 @@ import {
 } from 'lucide-react';
 import confetti from 'canvas-confetti';
 import type { Theme, AutoRunStats, ThemeMode } from '../types';
-import { useLayerStack } from '../contexts/LayerStackContext';
+import { useModalLayer } from '../hooks/ui/useModalLayer';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
 import { AchievementCard } from './AchievementCard';
 import { StandingOvationOverlay } from './StandingOvationOverlay';
@@ -105,8 +105,6 @@ const DEFAULT_CONFETTI_COLORS = [
 ];
 
 export function PlaygroundPanel({ theme, themeMode, onClose }: PlaygroundPanelProps) {
-	const { registerLayer, unregisterLayer, updateLayerHandler } = useLayerStack();
-	const layerIdRef = useRef<string>();
 	const containerRef = useRef<HTMLDivElement>(null);
 	const onCloseRef = useRef(onClose);
 
@@ -185,32 +183,16 @@ export function PlaygroundPanel({ theme, themeMode, onClose }: PlaygroundPanelPr
 	}, []);
 
 	// Register layer on mount
+	useModalLayer(
+		MODAL_PRIORITIES.STANDING_OVATION - 1, // Just below standing ovation
+		'Developer Playground',
+		() => onCloseRef.current()
+	);
+
+	// Focus container on mount
 	useEffect(() => {
-		const id = registerLayer({
-			type: 'modal',
-			priority: MODAL_PRIORITIES.STANDING_OVATION - 1, // Just below standing ovation
-			blocksLowerLayers: true,
-			capturesFocus: true,
-			focusTrap: 'strict',
-			ariaLabel: 'Developer Playground',
-			onEscape: () => onCloseRef.current(),
-		});
-		layerIdRef.current = id;
 		containerRef.current?.focus();
-
-		return () => {
-			if (layerIdRef.current) {
-				unregisterLayer(layerIdRef.current);
-			}
-		};
-	}, [registerLayer, unregisterLayer]);
-
-	// Update handler when dependencies change
-	useEffect(() => {
-		if (layerIdRef.current) {
-			updateLayerHandler(layerIdRef.current, () => onCloseRef.current());
-		}
-	}, [updateLayerHandler]);
+	}, []);
 
 	// Build mock AutoRunStats
 	const mockAutoRunStats: AutoRunStats = {

--- a/src/renderer/components/ProcessMonitor.tsx
+++ b/src/renderer/components/ProcessMonitor.tsx
@@ -18,7 +18,7 @@ import {
 	Tag,
 } from 'lucide-react';
 import type { Session, Group, Theme, GroupChat } from '../types';
-import { useLayerStack } from '../contexts/LayerStackContext';
+import { useModalLayer } from '../hooks/ui/useModalLayer';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
 
 interface ProcessMonitorProps {
@@ -158,8 +158,6 @@ export function ProcessMonitor(props: ProcessMonitorProps) {
 	const selectedNodeRef = useRef<HTMLButtonElement | HTMLDivElement>(null);
 	const killConfirmRef = useRef<HTMLDivElement>(null);
 	const detailViewRef = useRef<HTMLDivElement>(null);
-	const { registerLayer, unregisterLayer, updateLayerHandler } = useLayerStack();
-	const layerIdRef = useRef<string>();
 
 	// Fetch active processes from ProcessManager
 	const fetchActiveProcesses = useCallback(async (showRefresh = false) => {
@@ -211,34 +209,14 @@ export function ProcessMonitor(props: ProcessMonitorProps) {
 	}, [killConfirmProcessId]);
 
 	// Register layer on mount
-	useEffect(() => {
-		const layerId = registerLayer({
-			type: 'modal',
-			priority: MODAL_PRIORITIES.PROCESS_MONITOR,
-			blocksLowerLayers: true,
-			capturesFocus: true,
-			focusTrap: 'strict',
-			ariaLabel: 'System Processes',
-			onEscape: () => {},
-		});
-		layerIdRef.current = layerId;
-		return () => unregisterLayer(layerId);
-	}, [registerLayer, unregisterLayer]);
-
-	// Update handler when onClose or detailView changes
 	// If in detail view, Escape goes back to list; otherwise closes the modal
-	useEffect(() => {
-		if (layerIdRef.current) {
-			const handleEscape = () => {
-				if (detailView) {
-					setDetailView(null);
-				} else {
-					onClose();
-				}
-			};
-			updateLayerHandler(layerIdRef.current, handleEscape);
+	useModalLayer(MODAL_PRIORITIES.PROCESS_MONITOR, 'System Processes', () => {
+		if (detailView) {
+			setDetailView(null);
+		} else {
+			onClose();
 		}
-	}, [onClose, detailView, updateLayerHandler]);
+	});
 
 	// Fetch processes on mount and poll for updates
 	useEffect(() => {

--- a/src/renderer/components/PromptComposerModal.tsx
+++ b/src/renderer/components/PromptComposerModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState, useMemo, useCallback } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
 	X,
 	PenLine,

--- a/src/renderer/components/PromptComposerModal.tsx
+++ b/src/renderer/components/PromptComposerModal.tsx
@@ -14,7 +14,7 @@ import {
 	Folder,
 } from 'lucide-react';
 import type { Theme, ThinkingMode, Session, Group } from '../types';
-import { useLayerStack } from '../contexts/LayerStackContext';
+import { useModalLayer } from '../hooks/ui/useModalLayer';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
 import { estimateTokenCount } from '../../shared/formatters';
 import { getReadOnlyModeLabel, getReadOnlyModeTooltip } from '../../shared/agentMetadata';
@@ -110,7 +110,6 @@ export function PromptComposerModal({
 	const fileInputRef = useRef<HTMLInputElement>(null);
 	const mentionListRef = useRef<HTMLDivElement>(null);
 	const selectedMentionRef = useRef<HTMLButtonElement>(null);
-	const { registerLayer, unregisterLayer } = useLayerStack();
 	const hasAgentMentions = sessions != null && sessions.length > 0;
 
 	// File @mention completion (same as InputArea)
@@ -147,28 +146,21 @@ export function PromptComposerModal({
 	}, [isOpen]);
 
 	// Register with layer stack for Escape handling
-	useEffect(() => {
-		if (isOpen) {
-			const id = registerLayer({
-				type: 'modal',
-				priority: MODAL_PRIORITIES.PROMPT_COMPOSER,
-				blocksLowerLayers: true,
-				capturesFocus: true,
-				focusTrap: 'strict',
-				onEscape: () => {
-					// If mention dropdown is open, close it instead of the modal
-					if (showMentionsRef.current) {
-						setShowMentions(false);
-						return;
-					}
-					// Save the current value back before closing
-					onSubmitRef.current(valueRef.current);
-					onCloseRef.current();
-				},
-			});
-			return () => unregisterLayer(id);
-		}
-	}, [isOpen, registerLayer, unregisterLayer]);
+	useModalLayer(
+		MODAL_PRIORITIES.PROMPT_COMPOSER,
+		undefined,
+		() => {
+			// If mention dropdown is open, close it instead of the modal
+			if (showMentionsRef.current) {
+				setShowMentions(false);
+				return;
+			}
+			// Save the current value back before closing
+			onSubmitRef.current(valueRef.current);
+			onCloseRef.current();
+		},
+		{ enabled: isOpen }
+	);
 
 	// Build agent/group mentionable items (group chat mode)
 	const agentMentionItems = useMemo(() => {

--- a/src/renderer/components/QuickActionsModal.tsx
+++ b/src/renderer/components/QuickActionsModal.tsx
@@ -2,7 +2,7 @@ import React, { memo, useState, useEffect, useRef, useCallback } from 'react';
 import { Search } from 'lucide-react';
 import type { Session, Group, Theme, Shortcut, RightPanelTab, SettingsTab } from '../types';
 import type { GroupChat } from '../../shared/group-chat-types';
-import { useLayerStack } from '../contexts/LayerStackContext';
+import { useModalLayer } from '../hooks/ui/useModalLayer';
 import { notifyToast } from '../stores/notificationStore';
 import { useModalStore } from '../stores/modalStore';
 import { QUICK_ACTION_PROMPTS } from '../../shared/promptDefinitions';
@@ -257,10 +257,7 @@ export const QuickActionsModal = memo(function QuickActionsModal(props: QuickAct
 	const inputRef = useRef<HTMLInputElement>(null);
 	const selectedItemRef = useRef<HTMLButtonElement>(null);
 	const scrollContainerRef = useRef<HTMLDivElement>(null);
-	const layerIdRef = useRef<string>();
 	const modalRef = useRef<HTMLDivElement>(null);
-
-	const { registerLayer, unregisterLayer, updateLayerHandler } = useLayerStack();
 	const activeSession = sessions.find((s) => s.id === activeSessionId);
 
 	// Compute the active tab's position in the unified tab order for command palette conditions.
@@ -296,44 +293,15 @@ export const QuickActionsModal = memo(function QuickActionsModal(props: QuickAct
 	})();
 	const unifiedTabCount = activeSession?.unifiedTabOrder?.length ?? 0;
 
-	// Register layer on mount (handler will be updated by separate effect)
-	useEffect(() => {
-		layerIdRef.current = registerLayer({
-			type: 'modal',
-			priority: MODAL_PRIORITIES.QUICK_ACTION,
-			blocksLowerLayers: true,
-			capturesFocus: true,
-			focusTrap: 'strict',
-			ariaLabel: 'Quick Actions',
-			onEscape: () => setQuickActionOpen(false), // Initial handler, updated below
-		});
-
-		return () => {
-			if (layerIdRef.current) {
-				unregisterLayer(layerIdRef.current);
-			}
-		};
-	}, [registerLayer, unregisterLayer, setQuickActionOpen]);
-
-	// Update handler when mode changes - use a ref-based approach to avoid stale closure
-	const handleEscapeRef = useRef<() => void>(() => setQuickActionOpen(false));
-	useEffect(() => {
-		handleEscapeRef.current = () => {
-			// Handle escape based on current mode
-			if (mode === 'move-to-group') {
-				setMode('main');
-				// Note: Selection will be reset by the search/mode change useEffect
-			} else {
-				setQuickActionOpen(false);
-			}
-		};
-	}, [mode, setQuickActionOpen]);
-
-	useEffect(() => {
-		if (layerIdRef.current) {
-			updateLayerHandler(layerIdRef.current, () => handleEscapeRef.current());
+	// Register layer on mount - escape behavior depends on current mode
+	useModalLayer(MODAL_PRIORITIES.QUICK_ACTION, 'Quick Actions', () => {
+		if (mode === 'move-to-group') {
+			setMode('main');
+			// Note: Selection will be reset by the search/mode change useEffect
+		} else {
+			setQuickActionOpen(false);
 		}
-	}, [updateLayerHandler]);
+	});
 
 	// Focus input on mount
 	useEffect(() => {

--- a/src/renderer/components/QuitConfirmModal.tsx
+++ b/src/renderer/components/QuitConfirmModal.tsx
@@ -9,7 +9,7 @@
 import { useEffect, useRef } from 'react';
 import { AlertTriangle } from 'lucide-react';
 import type { Theme } from '../types';
-import { useLayerStack } from '../contexts/LayerStackContext';
+import { useModalLayer } from '../hooks/ui/useModalLayer';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
 
 interface QuitConfirmModalProps {
@@ -40,42 +40,14 @@ export function QuitConfirmModal({
 	onConfirmQuit,
 	onCancel,
 }: QuitConfirmModalProps): JSX.Element {
-	const { registerLayer, unregisterLayer, updateLayerHandler } = useLayerStack();
-	const layerIdRef = useRef<string>();
 	const cancelButtonRef = useRef<HTMLButtonElement>(null);
-	const onCancelRef = useRef(onCancel);
-	onCancelRef.current = onCancel;
+
+	useModalLayer(MODAL_PRIORITIES.QUIT_CONFIRM, 'Confirm Quit Application', onCancel);
 
 	// Focus Cancel button on mount (safer default action)
 	useEffect(() => {
 		cancelButtonRef.current?.focus();
 	}, []);
-
-	// Register with layer stack
-	useEffect(() => {
-		const id = registerLayer({
-			type: 'modal',
-			priority: MODAL_PRIORITIES.QUIT_CONFIRM,
-			blocksLowerLayers: true,
-			capturesFocus: true,
-			focusTrap: 'strict',
-			ariaLabel: 'Confirm Quit Application',
-			onEscape: () => onCancelRef.current(),
-		});
-		layerIdRef.current = id;
-		return () => {
-			if (layerIdRef.current) {
-				unregisterLayer(layerIdRef.current);
-			}
-		};
-	}, [registerLayer, unregisterLayer]);
-
-	// Update escape handler when onCancel changes
-	useEffect(() => {
-		if (layerIdRef.current) {
-			updateLayerHandler(layerIdRef.current, () => onCancelRef.current());
-		}
-	}, [onCancel, updateLayerHandler]);
 
 	// Handle keyboard navigation
 	const handleKeyDown = (e: React.KeyboardEvent) => {

--- a/src/renderer/components/SendToAgentModal.tsx
+++ b/src/renderer/components/SendToAgentModal.tsx
@@ -18,7 +18,7 @@ import { Search, ArrowRight, X, Loader2, Circle } from 'lucide-react';
 import type { Theme, Session, ToolType } from '../types';
 import type { MergeResult } from '../types/contextMerge';
 import { fuzzyMatchWithScore } from '../utils/search';
-import { useLayerStack } from '../contexts/LayerStackContext';
+import { useModalLayer } from '../hooks/ui/useModalLayer';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
 import { formatTokensCompact } from '../utils/formatters';
 import { getAgentIcon } from '../constants/agentIcons';
@@ -148,7 +148,6 @@ export function SendToAgentModal({
 
 	// Refs
 	const inputRef = useRef<HTMLInputElement>(null);
-	const layerIdRef = useRef<string>();
 	const onCloseRef = useRef(onClose);
 	const selectedItemRef = useRef<HTMLButtonElement>(null);
 
@@ -162,35 +161,13 @@ export function SendToAgentModal({
 		setSelectedIndex(0);
 	}, []);
 
-	const { registerLayer, unregisterLayer, updateLayerHandler } = useLayerStack();
-
 	// Register layer on mount
-	useEffect(() => {
-		if (!isOpen) return;
-
-		layerIdRef.current = registerLayer({
-			type: 'modal',
-			priority: MODAL_PRIORITIES.SEND_TO_AGENT,
-			blocksLowerLayers: true,
-			capturesFocus: true,
-			focusTrap: 'strict',
-			ariaLabel: 'Send Context to Agent',
-			onEscape: () => onCloseRef.current(),
-		});
-
-		return () => {
-			if (layerIdRef.current) {
-				unregisterLayer(layerIdRef.current);
-			}
-		};
-	}, [isOpen, registerLayer, unregisterLayer]);
-
-	// Update handler when onClose changes
-	useEffect(() => {
-		if (layerIdRef.current) {
-			updateLayerHandler(layerIdRef.current, () => onCloseRef.current());
-		}
-	}, [updateLayerHandler]);
+	useModalLayer(
+		MODAL_PRIORITIES.SEND_TO_AGENT,
+		'Send Context to Agent',
+		() => onCloseRef.current(),
+		{ enabled: isOpen }
+	);
 
 	// Focus input on mount
 	useEffect(() => {

--- a/src/renderer/components/Settings/SettingsModal.tsx
+++ b/src/renderer/components/Settings/SettingsModal.tsx
@@ -15,7 +15,7 @@ import {
 } from 'lucide-react';
 import { useSettings } from '../../hooks';
 import type { Theme, LLMProvider } from '../../types';
-import { useLayerStack } from '../../contexts/LayerStackContext';
+import { useModalLayer } from '../../hooks/ui/useModalLayer';
 import { MODAL_PRIORITIES } from '../../constants/modalPriorities';
 import { AICommandsPanel } from '../AICommandsPanel';
 import { MaestroPromptsTab } from './tabs/MaestroPromptsTab';
@@ -158,8 +158,6 @@ export const SettingsModal = memo(function SettingsModal(props: SettingsModalPro
 	);
 
 	// Layer stack integration
-	const { registerLayer, unregisterLayer } = useLayerStack();
-	const layerIdRef = useRef<string>();
 	const isRecordingShortcutRef = useRef(false);
 	const promptsEscapeHandlerRef = useRef<(() => boolean) | null>(null);
 
@@ -175,33 +173,18 @@ export const SettingsModal = memo(function SettingsModal(props: SettingsModalPro
 	onCloseRef.current = onClose;
 
 	// Register layer when modal opens
-	useEffect(() => {
-		if (!isOpen) return;
-
-		const id = registerLayer({
-			type: 'modal',
-			priority: MODAL_PRIORITIES.SETTINGS,
-			blocksLowerLayers: true,
-			capturesFocus: true,
-			focusTrap: 'strict',
-			ariaLabel: 'Settings',
-			onEscape: () => {
-				// If recording a shortcut, ShortcutsTab handles its own escape via onKeyDownCapture
-				if (isRecordingShortcutRef.current) return;
-				// Let prompts tab handle layered escape (help → expanded → list → close)
-				if (promptsEscapeHandlerRef.current?.()) return;
-				onCloseRef.current();
-			},
-		});
-
-		layerIdRef.current = id;
-
-		return () => {
-			if (layerIdRef.current) {
-				unregisterLayer(layerIdRef.current);
-			}
-		};
-	}, [isOpen, registerLayer, unregisterLayer]); // Removed onClose from deps
+	useModalLayer(
+		MODAL_PRIORITIES.SETTINGS,
+		'Settings',
+		() => {
+			// If recording a shortcut, ShortcutsTab handles its own escape via onKeyDownCapture
+			if (isRecordingShortcutRef.current) return;
+			// Let prompts tab handle layered escape (help -> expanded -> list -> close)
+			if (promptsEscapeHandlerRef.current?.()) return;
+			onCloseRef.current();
+		},
+		{ enabled: isOpen }
+	);
 
 	// Tab navigation with Cmd+Shift+[ and ]
 	useEffect(() => {

--- a/src/renderer/components/StandingOvationOverlay.tsx
+++ b/src/renderer/components/StandingOvationOverlay.tsx
@@ -3,7 +3,7 @@ import { ExternalLink, Trophy, Clock, Star, Share2, Copy, Download, Check } from
 import confetti from 'canvas-confetti';
 import type { Theme, ThemeMode } from '../types';
 import type { ConductorBadge } from '../constants/conductorBadges';
-import { useLayerStack } from '../contexts/LayerStackContext';
+import { useModalLayer } from '../hooks/ui/useModalLayer';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
 import { AnimatedMaestro } from './MaestroSilhouette';
 import {
@@ -44,8 +44,6 @@ export function StandingOvationOverlay({
 	isLeaderboardRegistered,
 	disableConfetti = false,
 }: StandingOvationOverlayProps) {
-	const { registerLayer, unregisterLayer, updateLayerHandler } = useLayerStack();
-	const layerIdRef = useRef<string>();
 	const containerRef = useRef<HTMLDivElement>(null);
 	const onCloseRef = useRef(onClose);
 	onCloseRef.current = onClose;
@@ -144,37 +142,19 @@ export function StandingOvationOverlay({
 	}, [isClosing, onClose, fireConfetti]);
 
 	// Register with layer stack
+	useModalLayer(MODAL_PRIORITIES.STANDING_OVATION, 'Standing Ovation Achievement', () =>
+		handleCloseRef.current()
+	);
+
+	// Focus container on mount
 	useEffect(() => {
-		const id = registerLayer({
-			type: 'modal',
-			priority: MODAL_PRIORITIES.STANDING_OVATION,
-			blocksLowerLayers: true,
-			capturesFocus: true,
-			focusTrap: 'strict',
-			ariaLabel: 'Standing Ovation Achievement',
-			onEscape: () => handleCloseRef.current(),
-		});
-		layerIdRef.current = id;
-
 		containerRef.current?.focus();
-
-		return () => {
-			if (layerIdRef.current) {
-				unregisterLayer(layerIdRef.current);
-			}
-		};
-	}, [registerLayer, unregisterLayer]);
+	}, []);
 
 	// Update close handler ref when handleTakeABow changes
 	useEffect(() => {
 		handleCloseRef.current = handleTakeABow;
 	}, [handleTakeABow]);
-
-	useEffect(() => {
-		if (layerIdRef.current) {
-			updateLayerHandler(layerIdRef.current, () => handleCloseRef.current());
-		}
-	}, [updateLayerHandler]);
 
 	// Generate shareable achievement card as canvas using theme colors
 	const generateShareImage = useCallback(async (): Promise<HTMLCanvasElement> => {

--- a/src/renderer/components/SymphonyModal.tsx
+++ b/src/renderer/components/SymphonyModal.tsx
@@ -1651,9 +1651,10 @@ export function SymphonyModal({
 				return;
 			}
 
-			// Escape from search returns focus to grid
+			// Escape from search returns focus to grid (stop propagation to prevent modal close)
 			if (e.key === 'Escape' && e.target instanceof HTMLInputElement) {
 				e.preventDefault();
+				e.stopPropagation();
 				(e.target as HTMLInputElement).blur();
 				tileGridRef.current?.focus();
 				return;

--- a/src/renderer/components/SymphonyModal.tsx
+++ b/src/renderer/components/SymphonyModal.tsx
@@ -51,7 +51,7 @@ import type {
 } from '../../shared/symphony-types';
 import { SYMPHONY_CATEGORIES, SYMPHONY_BLOCKING_LABEL } from '../../shared/symphony-constants';
 import { COLORBLIND_AGENT_PALETTE } from '../constants/colorblindPalettes';
-import { useLayerStack } from '../contexts/LayerStackContext';
+import { useModalLayer } from '../hooks/ui/useModalLayer';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
 import { useSymphony } from '../hooks/symphony';
 import { useContributorStats, type Achievement } from '../hooks/symphony/useContributorStats';
@@ -1317,7 +1317,6 @@ export function SymphonyModal({
 	sessions,
 	onSelectSession,
 }: SymphonyModalProps) {
-	const { registerLayer, unregisterLayer } = useLayerStack();
 	const onCloseRef = useRef(onClose);
 	onCloseRef.current = onClose;
 
@@ -1413,28 +1412,20 @@ export function SymphonyModal({
 	handleBackRef.current = handleBack;
 
 	// Layer stack
-	useEffect(() => {
-		if (isOpen) {
-			const id = registerLayer({
-				type: 'modal',
-				priority: MODAL_PRIORITIES.SYMPHONY ?? 710,
-				blocksLowerLayers: true,
-				capturesFocus: true,
-				focusTrap: 'strict',
-				ariaLabel: 'Maestro Symphony',
-				onEscape: () => {
-					if (showHelpRef.current) {
-						setShowHelp(false);
-					} else if (showDetailViewRef.current) {
-						handleBackRef.current();
-					} else {
-						onCloseRef.current();
-					}
-				},
-			});
-			return () => unregisterLayer(id);
-		}
-	}, [isOpen, registerLayer, unregisterLayer]);
+	useModalLayer(
+		MODAL_PRIORITIES.SYMPHONY ?? 710,
+		'Maestro Symphony',
+		() => {
+			if (showHelpRef.current) {
+				setShowHelp(false);
+			} else if (showDetailViewRef.current) {
+				handleBackRef.current();
+			} else {
+				onCloseRef.current();
+			}
+		},
+		{ enabled: isOpen }
+	);
 
 	// Focus tile grid for keyboard navigation (keyboard-first design)
 	useEffect(() => {

--- a/src/renderer/components/TabSwitcherModal.tsx
+++ b/src/renderer/components/TabSwitcherModal.tsx
@@ -10,7 +10,7 @@ import type {
 	ToolType,
 } from '../types';
 import { fuzzyMatchWithScore } from '../utils/search';
-import { useLayerStack } from '../contexts/LayerStackContext';
+import { useModalLayer } from '../hooks/ui/useModalLayer';
 import { useListNavigation } from '../hooks';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
 import { getContextColor } from '../utils/theme';
@@ -221,7 +221,6 @@ export function TabSwitcherModal({
 	const inputRef = useRef<HTMLInputElement>(null);
 	const selectedItemRef = useRef<HTMLButtonElement>(null);
 	const scrollContainerRef = useRef<HTMLDivElement>(null);
-	const layerIdRef = useRef<string>();
 	const onCloseRef = useRef(onClose);
 
 	const handleSearchChange = useCallback((value: string) => {
@@ -241,35 +240,7 @@ export function TabSwitcherModal({
 		onCloseRef.current = onClose;
 	});
 
-	const { registerLayer, unregisterLayer, updateLayerHandler } = useLayerStack();
-
-	// Register layer on mount
-	useEffect(() => {
-		layerIdRef.current = registerLayer({
-			type: 'modal',
-			priority: MODAL_PRIORITIES.TAB_SWITCHER,
-			blocksLowerLayers: true,
-			capturesFocus: true,
-			focusTrap: 'strict',
-			ariaLabel: 'Tab Switcher',
-			onEscape: () => onCloseRef.current(),
-		});
-
-		return () => {
-			if (layerIdRef.current) {
-				unregisterLayer(layerIdRef.current);
-			}
-		};
-	}, [registerLayer, unregisterLayer]);
-
-	// Update handler when onClose changes
-	useEffect(() => {
-		if (layerIdRef.current) {
-			updateLayerHandler(layerIdRef.current, () => {
-				onCloseRef.current();
-			});
-		}
-	}, [updateLayerHandler]);
+	useModalLayer(MODAL_PRIORITIES.TAB_SWITCHER, 'Tab Switcher', () => onCloseRef.current());
 
 	// Focus input on mount
 	useEffect(() => {

--- a/src/renderer/components/TransferProgressModal.tsx
+++ b/src/renderer/components/TransferProgressModal.tsx
@@ -20,7 +20,7 @@ import { useState, useEffect, useRef, useMemo, useCallback, memo } from 'react';
 import { X, Check, Loader2, AlertTriangle, ArrowRight, Wand2 } from 'lucide-react';
 import type { Theme, ToolType } from '../types';
 import type { GroomingProgress } from '../types/contextMerge';
-import { useLayerStack } from '../contexts/LayerStackContext';
+import { useModalLayer } from '../hooks/ui/useModalLayer';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
 import { getAgentDisplayName } from '../services/contextGroomer';
 
@@ -258,8 +258,6 @@ export function TransferProgressModal({
 	const [showCancelConfirm, setShowCancelConfirm] = useState(false);
 
 	// Layer stack registration
-	const { registerLayer, unregisterLayer, updateLayerHandler } = useLayerStack();
-	const layerIdRef = useRef<string>();
 	const onCancelRef = useRef(onCancel);
 	const onCompleteRef = useRef(onComplete);
 
@@ -286,32 +284,9 @@ export function TransferProgressModal({
 	}, [progress.stage]);
 
 	// Register layer on mount
-	useEffect(() => {
-		if (!isOpen) return;
-
-		layerIdRef.current = registerLayer({
-			type: 'modal',
-			priority: MODAL_PRIORITIES.TRANSFER_PROGRESS,
-			blocksLowerLayers: true,
-			capturesFocus: true,
-			focusTrap: 'strict',
-			ariaLabel: 'Transfer Progress',
-			onEscape: handleEscape,
-		});
-
-		return () => {
-			if (layerIdRef.current) {
-				unregisterLayer(layerIdRef.current);
-			}
-		};
-	}, [isOpen, registerLayer, unregisterLayer, handleEscape]);
-
-	// Update handler when callbacks change
-	useEffect(() => {
-		if (layerIdRef.current) {
-			updateLayerHandler(layerIdRef.current, handleEscape);
-		}
-	}, [updateLayerHandler, handleEscape]);
+	useModalLayer(MODAL_PRIORITIES.TRANSFER_PROGRESS, 'Transfer Progress', handleEscape, {
+		enabled: isOpen,
+	});
 
 	// Get the current stage index
 	const currentStageIndex = useMemo(() => {

--- a/src/renderer/components/UsageDashboard/UsageDashboardModal.tsx
+++ b/src/renderer/components/UsageDashboard/UsageDashboardModal.tsx
@@ -33,7 +33,7 @@ import { EmptyState } from './EmptyState';
 import { DashboardSkeleton } from './ChartSkeletons';
 import { ChartErrorBoundary } from './ChartErrorBoundary';
 import type { Theme, Session } from '../../types';
-import { useLayerStack } from '../../contexts/LayerStackContext';
+import { useModalLayer } from '../../hooks/ui/useModalLayer';
 import { MODAL_PRIORITIES } from '../../constants/modalPriorities';
 import { getRendererPerfMetrics } from '../../utils/logger';
 import { PERFORMANCE_THRESHOLDS } from '../../../shared/performance-metrics';
@@ -165,7 +165,6 @@ export function UsageDashboardModal({
 	const contentRef = useRef<HTMLDivElement>(null);
 	const tabsRef = useRef<HTMLDivElement>(null);
 	const sectionRefs = useRef<Map<SectionId, HTMLDivElement>>(new Map());
-	const { registerLayer, unregisterLayer } = useLayerStack();
 	const onCloseRef = useRef(onClose);
 	onCloseRef.current = onClose;
 	const viewModeRef = useRef(viewMode);
@@ -179,19 +178,10 @@ export function UsageDashboardModal({
 	}, [isOpen, defaultTimeRange]);
 
 	// Register with layer stack for proper Escape handling
-	useEffect(() => {
-		if (isOpen) {
-			const id = registerLayer({
-				type: 'modal',
-				priority: MODAL_PRIORITIES.USAGE_DASHBOARD,
-				blocksLowerLayers: true,
-				capturesFocus: true,
-				focusTrap: 'lenient',
-				onEscape: () => onCloseRef.current(),
-			});
-			return () => unregisterLayer(id);
-		}
-	}, [isOpen, registerLayer, unregisterLayer]);
+	useModalLayer(MODAL_PRIORITIES.USAGE_DASHBOARD, undefined, () => onCloseRef.current(), {
+		focusTrap: 'lenient',
+		enabled: isOpen,
+	});
 
 	// Fetch stats data when range changes
 	const fetchStats = useCallback(

--- a/src/renderer/components/Wizard/ExistingAutoRunDocsModal.tsx
+++ b/src/renderer/components/Wizard/ExistingAutoRunDocsModal.tsx
@@ -10,7 +10,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { Trash2, BookOpen, FolderOpen, AlertTriangle, FileText } from 'lucide-react';
 import type { Theme } from '../../types';
-import { useLayerStack } from '../../contexts/LayerStackContext';
+import { useModalLayer } from '../../hooks/ui/useModalLayer';
 import { MODAL_PRIORITIES } from '../../constants/modalPriorities';
 
 interface ExistingAutoRunDocsModalProps {
@@ -30,8 +30,6 @@ export function ExistingAutoRunDocsModal({
 	onContinuePlanning,
 	onCancel,
 }: ExistingAutoRunDocsModalProps) {
-	const { registerLayer, unregisterLayer, updateLayerHandler } = useLayerStack();
-	const layerIdRef = useRef<string>();
 	const continueButtonRef = useRef<HTMLButtonElement>(null);
 	const [focusedButton, setFocusedButton] = useState<'continue' | 'fresh'>('continue');
 	const [isDeleting, setIsDeleting] = useState(false);
@@ -41,31 +39,11 @@ export function ExistingAutoRunDocsModal({
 		continueButtonRef.current?.focus();
 	}, []);
 
-	// Register layer on mount
-	useEffect(() => {
-		const id = registerLayer({
-			type: 'modal',
-			priority: MODAL_PRIORITIES.EXISTING_AUTORUN_DOCS,
-			blocksLowerLayers: true,
-			capturesFocus: true,
-			focusTrap: 'strict',
-			ariaLabel: 'Existing Playbook Documents Detected',
-			onEscape: onCancel,
-		});
-		layerIdRef.current = id;
-		return () => {
-			if (layerIdRef.current) {
-				unregisterLayer(layerIdRef.current);
-			}
-		};
-	}, [registerLayer, unregisterLayer]);
-
-	// Update handler when dependencies change
-	useEffect(() => {
-		if (layerIdRef.current) {
-			updateLayerHandler(layerIdRef.current, onCancel);
-		}
-	}, [onCancel, updateLayerHandler]);
+	useModalLayer(
+		MODAL_PRIORITIES.EXISTING_AUTORUN_DOCS,
+		'Existing Playbook Documents Detected',
+		onCancel
+	);
 
 	// Handle keyboard navigation between buttons
 	const handleKeyDown = (e: React.KeyboardEvent) => {

--- a/src/renderer/components/Wizard/ExistingDocsModal.tsx
+++ b/src/renderer/components/Wizard/ExistingDocsModal.tsx
@@ -10,7 +10,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { FileText, Trash2, ArrowRight } from 'lucide-react';
 import type { Theme } from '../../types';
-import { useLayerStack } from '../../contexts/LayerStackContext';
+import { useModalLayer } from '../../hooks/ui/useModalLayer';
 import { MODAL_PRIORITIES } from '../../constants/modalPriorities';
 
 interface ExistingDocsModalProps {
@@ -38,8 +38,6 @@ export function ExistingDocsModal({
 	onContinue,
 	onCancel,
 }: ExistingDocsModalProps): JSX.Element {
-	const { registerLayer, unregisterLayer, updateLayerHandler } = useLayerStack();
-	const layerIdRef = useRef<string>();
 	const continueButtonRef = useRef<HTMLButtonElement>(null);
 	const onCancelRef = useRef(onCancel);
 	onCancelRef.current = onCancel;
@@ -52,31 +50,9 @@ export function ExistingDocsModal({
 		continueButtonRef.current?.focus();
 	}, []);
 
-	// Register with layer stack
-	useEffect(() => {
-		const id = registerLayer({
-			type: 'modal',
-			priority: MODAL_PRIORITIES.EXISTING_AUTORUN_DOCS,
-			blocksLowerLayers: true,
-			capturesFocus: true,
-			focusTrap: 'strict',
-			ariaLabel: 'Existing Playbook Documents Found',
-			onEscape: () => onCancelRef.current(),
-		});
-		layerIdRef.current = id;
-		return () => {
-			if (layerIdRef.current) {
-				unregisterLayer(layerIdRef.current);
-			}
-		};
-	}, [registerLayer, unregisterLayer]);
-
-	// Update escape handler when onCancel changes
-	useEffect(() => {
-		if (layerIdRef.current) {
-			updateLayerHandler(layerIdRef.current, () => onCancelRef.current());
-		}
-	}, [onCancel, updateLayerHandler]);
+	useModalLayer(MODAL_PRIORITIES.EXISTING_AUTORUN_DOCS, 'Existing Playbook Documents Found', () =>
+		onCancelRef.current()
+	);
 
 	// Handle keyboard navigation
 	const handleKeyDown = (e: React.KeyboardEvent) => {

--- a/src/renderer/components/Wizard/ExistingDocsModal.tsx
+++ b/src/renderer/components/Wizard/ExistingDocsModal.tsx
@@ -56,8 +56,8 @@ export function ExistingDocsModal({
 
 	// Handle keyboard navigation
 	const handleKeyDown = (e: React.KeyboardEvent) => {
-		if (e.key === 'Tab') {
-			// Let natural tab flow work
+		if (e.key === 'Tab' || e.key === 'Escape') {
+			// Let Tab flow naturally, let Escape reach the layer stack
 			return;
 		}
 		e.stopPropagation();

--- a/src/renderer/components/Wizard/MaestroWizard.tsx
+++ b/src/renderer/components/Wizard/MaestroWizard.tsx
@@ -14,7 +14,7 @@ import {
 	INDEX_TO_STEP,
 	type WizardStep,
 } from './WizardContext';
-import { useLayerStack } from '../../contexts/LayerStackContext';
+import { useModalLayer } from '../../hooks/ui/useModalLayer';
 import { MODAL_PRIORITIES } from '../../constants/modalPriorities';
 import { WizardExitConfirmModal } from './WizardExitConfirmModal';
 import { ScreenReaderAnnouncement } from './ScreenReaderAnnouncement';
@@ -110,8 +110,6 @@ export function MaestroWizard({
 		goToStep,
 		getCurrentStepNumber,
 	} = useWizard();
-
-	const { registerLayer, unregisterLayer } = useLayerStack();
 
 	// State for exit confirmation modal
 	const [showExitConfirm, setShowExitConfirm] = useState(false);
@@ -275,20 +273,9 @@ export function MaestroWizard({
 	}, [state.isOpen, displayedStep, isTransitioning]);
 
 	// Register with layer stack for Escape handling
-	useEffect(() => {
-		if (state.isOpen && !showExitConfirm) {
-			const id = registerLayer({
-				type: 'modal',
-				priority: MODAL_PRIORITIES.WIZARD,
-				blocksLowerLayers: true,
-				capturesFocus: true,
-				focusTrap: 'strict',
-				ariaLabel: 'Setup Wizard',
-				onEscape: handleCloseRequest,
-			});
-			return () => unregisterLayer(id);
-		}
-	}, [state.isOpen, showExitConfirm, registerLayer, unregisterLayer, handleCloseRequest]);
+	useModalLayer(MODAL_PRIORITIES.WIZARD, 'Setup Wizard', handleCloseRequest, {
+		enabled: state.isOpen && !showExitConfirm,
+	});
 
 	// Capture-phase handler for global shortcuts that should work anywhere in the modal
 	// This ensures Cmd+Shift+K (thinking toggle) works even when focus is on header elements

--- a/src/renderer/components/Wizard/WizardExitConfirmModal.tsx
+++ b/src/renderer/components/Wizard/WizardExitConfirmModal.tsx
@@ -9,7 +9,7 @@
 import { useEffect, useRef } from 'react';
 import { AlertCircle } from 'lucide-react';
 import type { Theme } from '../../types';
-import { useLayerStack } from '../../contexts/LayerStackContext';
+import { useModalLayer } from '../../hooks/ui/useModalLayer';
 import { MODAL_PRIORITIES } from '../../constants/modalPriorities';
 
 interface WizardExitConfirmModalProps {
@@ -40,42 +40,14 @@ export function WizardExitConfirmModal({
 	onCancel,
 	onQuitWithoutSaving,
 }: WizardExitConfirmModalProps): JSX.Element {
-	const { registerLayer, unregisterLayer, updateLayerHandler } = useLayerStack();
-	const layerIdRef = useRef<string>();
 	const stayButtonRef = useRef<HTMLButtonElement>(null);
-	const onCancelRef = useRef(onCancel);
-	onCancelRef.current = onCancel;
+
+	useModalLayer(MODAL_PRIORITIES.WIZARD_EXIT_CONFIRM, 'Confirm Exit Setup Wizard', onCancel);
 
 	// Focus "Stay" button on mount (safer default action)
 	useEffect(() => {
 		stayButtonRef.current?.focus();
 	}, []);
-
-	// Register with layer stack
-	useEffect(() => {
-		const id = registerLayer({
-			type: 'modal',
-			priority: MODAL_PRIORITIES.WIZARD_EXIT_CONFIRM,
-			blocksLowerLayers: true,
-			capturesFocus: true,
-			focusTrap: 'strict',
-			ariaLabel: 'Confirm Exit Setup Wizard',
-			onEscape: () => onCancelRef.current(),
-		});
-		layerIdRef.current = id;
-		return () => {
-			if (layerIdRef.current) {
-				unregisterLayer(layerIdRef.current);
-			}
-		};
-	}, [registerLayer, unregisterLayer]);
-
-	// Update escape handler when onCancel changes
-	useEffect(() => {
-		if (layerIdRef.current) {
-			updateLayerHandler(layerIdRef.current, () => onCancelRef.current());
-		}
-	}, [onCancel, updateLayerHandler]);
 
 	// Handle keyboard navigation
 	const handleKeyDown = (e: React.KeyboardEvent) => {

--- a/src/renderer/components/Wizard/WizardResumeModal.tsx
+++ b/src/renderer/components/Wizard/WizardResumeModal.tsx
@@ -8,7 +8,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { RefreshCw, RotateCcw, FolderOpen, AlertTriangle, Bot } from 'lucide-react';
 import type { Theme, AgentConfig } from '../../types';
-import { useLayerStack } from '../../contexts/LayerStackContext';
+import { useModalLayer } from '../../hooks/ui/useModalLayer';
 import { MODAL_PRIORITIES } from '../../constants/modalPriorities';
 import type { SerializableWizardState, WizardStep } from './WizardContext';
 import { STEP_INDEX, WIZARD_TOTAL_STEPS } from './WizardContext';
@@ -55,8 +55,7 @@ export function WizardResumeModal({
 	onStartFresh,
 	onClose,
 }: WizardResumeModalProps) {
-	const { registerLayer, unregisterLayer, updateLayerHandler } = useLayerStack();
-	const layerIdRef = useRef<string>();
+	useModalLayer(MODAL_PRIORITIES.WIZARD_RESUME, 'Resume Setup Wizard', onClose);
 	const resumeButtonRef = useRef<HTMLButtonElement>(null);
 	const [focusedButton, setFocusedButton] = useState<'resume' | 'fresh'>('resume');
 	const [directoryValid, setDirectoryValid] = useState<boolean | null>(null);
@@ -127,32 +126,6 @@ export function WizardResumeModal({
 	useEffect(() => {
 		resumeButtonRef.current?.focus();
 	}, []);
-
-	// Register layer on mount
-	useEffect(() => {
-		const id = registerLayer({
-			type: 'modal',
-			priority: MODAL_PRIORITIES.WIZARD_RESUME,
-			blocksLowerLayers: true,
-			capturesFocus: true,
-			focusTrap: 'strict',
-			ariaLabel: 'Resume Setup Wizard',
-			onEscape: onClose,
-		});
-		layerIdRef.current = id;
-		return () => {
-			if (layerIdRef.current) {
-				unregisterLayer(layerIdRef.current);
-			}
-		};
-	}, [registerLayer, unregisterLayer]);
-
-	// Update handler when dependencies change
-	useEffect(() => {
-		if (layerIdRef.current) {
-			updateLayerHandler(layerIdRef.current, onClose);
-		}
-	}, [onClose, updateLayerHandler]);
 
 	// Handle resume click with validation status
 	const handleResume = () => {

--- a/src/renderer/components/Wizard/tour/TourOverlay.tsx
+++ b/src/renderer/components/Wizard/tour/TourOverlay.tsx
@@ -11,7 +11,7 @@
 
 import { useEffect, useCallback, useRef, useState } from 'react';
 import type { Theme, Shortcut } from '../../../types';
-import { useLayerStack } from '../../../contexts/LayerStackContext';
+import { useModalLayer } from '../../../hooks/ui/useModalLayer';
 import { MODAL_PRIORITIES } from '../../../constants/modalPriorities';
 import { TourStep } from './TourStep';
 import { TourWelcome } from './TourWelcome';
@@ -96,8 +96,6 @@ export function TourOverlay({
 	onTourComplete,
 	onTourSkip,
 }: TourOverlayProps): JSX.Element | null {
-	const { registerLayer, unregisterLayer } = useLayerStack();
-
 	// Track whether we're showing the welcome screen (before tour steps)
 	const [showWelcome, setShowWelcome] = useState(true);
 
@@ -244,19 +242,10 @@ export function TourOverlay({
 	}, [isOpen, handleKeyDown]);
 
 	// Register with layer stack for proper focus management
-	useEffect(() => {
-		if (isOpen) {
-			const id = registerLayer({
-				type: 'modal',
-				priority: MODAL_PRIORITIES.TOUR,
-				blocksLowerLayers: true,
-				capturesFocus: true,
-				focusTrap: 'lenient',
-				onEscape: skipTour,
-			});
-			return () => unregisterLayer(id);
-		}
-	}, [isOpen, registerLayer, unregisterLayer, skipTour]);
+	useModalLayer(MODAL_PRIORITIES.TOUR, undefined, skipTour, {
+		focusTrap: 'lenient',
+		enabled: isOpen,
+	});
 
 	// Don't render if not open
 	if (!isOpen) {

--- a/src/renderer/components/Wizard/tour/TourOverlay.tsx
+++ b/src/renderer/components/Wizard/tour/TourOverlay.tsx
@@ -209,8 +209,7 @@ export function TourOverlay({
 					}
 					break;
 				case 'Escape':
-					e.preventDefault();
-					skipTour();
+					// Handled by useModalLayer - don't duplicate here
 					break;
 				case 'ArrowRight':
 				case 'ArrowDown':

--- a/src/renderer/hooks/ui/useModalLayer.ts
+++ b/src/renderer/hooks/ui/useModalLayer.ts
@@ -45,6 +45,12 @@ export interface UseModalLayerOptions {
 	blocksLowerLayers?: boolean;
 	/** Whether this layer captures keyboard focus. Defaults to true */
 	capturesFocus?: boolean;
+	/**
+	 * Whether the layer should be registered. Defaults to true.
+	 * Set to `false` (e.g. when `!isOpen`) to skip registration without
+	 * unmounting the host component.
+	 */
+	enabled?: boolean;
 }
 
 /**
@@ -70,7 +76,7 @@ export interface UseModalLayerOptions {
  */
 export function useModalLayer(
 	priority: number,
-	ariaLabel: string,
+	ariaLabel: string | undefined,
 	onEscape: () => void,
 	options: UseModalLayerOptions = {}
 ): void {
@@ -80,13 +86,20 @@ export function useModalLayer(
 		focusTrap = 'strict',
 		blocksLowerLayers = true,
 		capturesFocus = true,
+		enabled = true,
 	} = options;
 
 	const { registerLayer, unregisterLayer, updateLayerHandler } = useLayerStack();
 	const layerIdRef = useRef<string>();
+	const onEscapeRef = useRef(onEscape);
+	onEscapeRef.current = onEscape;
 
-	// Register layer on mount
+	// Register layer on mount (and re-register when `enabled` flips)
 	useEffect(() => {
+		if (!enabled) {
+			return;
+		}
+
 		const id = registerLayer({
 			type: 'modal',
 			priority,
@@ -96,16 +109,18 @@ export function useModalLayer(
 			ariaLabel,
 			isDirty,
 			onBeforeClose,
-			onEscape,
+			onEscape: () => onEscapeRef.current(),
 		});
 		layerIdRef.current = id;
 
 		return () => {
 			if (layerIdRef.current) {
 				unregisterLayer(layerIdRef.current);
+				layerIdRef.current = undefined;
 			}
 		};
 	}, [
+		enabled,
 		registerLayer,
 		unregisterLayer,
 		priority,
@@ -120,7 +135,7 @@ export function useModalLayer(
 	// Update handler when onEscape changes (without re-registering)
 	useEffect(() => {
 		if (layerIdRef.current) {
-			updateLayerHandler(layerIdRef.current, onEscape);
+			updateLayerHandler(layerIdRef.current, () => onEscapeRef.current());
 		}
 	}, [onEscape, updateLayerHandler]);
 }


### PR DESCRIPTION
## Summary

Two structural consolidations:

- **10A**: migrate 47 modals to the canonical `useModalLayer` hook, replacing manual `registerLayer`/`unregisterLayer` boilerplate and hand-rolled Escape handlers
- **10B**: extract `spawnGroupChatAgent` helper that encapsulates SSH wrap + Windows shell/stdin handling + process spawn, consolidating 4 near-identical spawn sites

**Net: 58 files, -954 lines (exceeds the ~328-line playbook target)**

### 10A - Modal layer migration

**Hook enhancement** (`src/renderer/hooks/ui/useModalLayer.ts`):
- Added optional `enabled` flag
- Switched to a stable ref-based escape closure so re-registration is no longer needed when `onEscape` callback identity changes

**Migrated 47 call sites across 46 files** to `useModalLayer(priority, ariaLabel, onEscape, options?)`:
AgentCreationDialog, AgentPromptComposerModal, AgentSessionsBrowser, AgentSessionsModal, AutoRunExpandedModal, AutoRunLightbox, AutoRunSearchBar, BatchRunnerModal, CreatePRModal, CreateWorktreeModal, CueModal, DirectorNotesModal, DocumentGraphView, DocumentsPanel, ExecutionQueueBrowser, FileSearchModal, FirstRunCelebration, GitDiffViewer, GitLogViewer, HistoryDetailModal, WizardExitConfirmDialog, KeyboardMasteryCelebration, LeaderboardRegistrationModal, LogViewer, MarketplaceModal, MergeProgressModal, MergeSessionModal, PlaygroundPanel, ProcessMonitor, PromptComposerModal, QuickActionsModal, QuitConfirmModal, SendToAgentModal, SettingsModal, StandingOvationOverlay, SummarizeProgressModal, SymphonyModal, TabSwitcherModal, TransferProgressModal, UsageDashboardModal, ExistingAutoRunDocsModal, ExistingDocsModal, MaestroWizard, WizardExitConfirmModal, WizardResumeModal, TourOverlay.

**Sites skipped (9):** overlay-type registrations (`type: 'overlay'` / `allowClickOutside`) in DocumentGraph dropdowns, FileExplorerPanel, FilePreview, LightboxModal, TerminalOutput, TerminalSearchBar. The canonical hook hardcodes `type: 'modal'`; these need a separate variant.

**Test mock updates:** 9 test files had their `useLayerStack` mock extended with `updateLayerHandler`; one NewInstanceModal assertion was rewritten to verify behavior (escape routes to latest `onClose`) instead of handler identity.

### 10B - Group chat spawn helper

**New:** `src/main/group-chat/spawnGroupChatAgent.ts` (~155 lines) encapsulates:
- SSH remote config wrapping
- Windows shell + stdin command building
- `processManager.spawn` invocation

**Consolidated 4 call sites** in `group-chat-router.ts`: moderator spawn, participant spawn, synthesis spawn, recovery spawn. Each collapsed ~60 lines of imperative code to a single helper call.

**Store `resolve()` consolidation:** not applicable - no widespread duplication exists.

## Test plan

- [ ] `npm run lint` passes (all 3 tsconfigs)
- [ ] `npx prettier --check .` passes
- [ ] 366 targeted tests pass (useModalLayer, AppModals, group-chat)
- [ ] 540+ migrated-modal tests pass
- [ ] Press Escape in any migrated modal - it closes (layer stack routes escape correctly)
- [ ] Open nested modals - layer priority still respected
- [ ] Spawn a group chat moderator and a participant - both start correctly on local and SSH remote

## Risk

**Medium**. Modal layer touches keyboard routing across the app. 540+ tests cover the migrated paths and all are green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved modal-layer test mocks to reflect updated modal handler behavior for more reliable modal-related tests.

* **Refactor**
  * Consolidated modal lifecycle, Escape and focus handling into a unified hook for more consistent, predictable modal behavior across the UI.

* **Chores**
  * Introduced a centralized agent process spawn helper to streamline and harden agent startup and recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->