### PR TITLE
Fix cloudflared tunnel URL not detected (QUIC protocol bug)

### DIFF
--- a/src/__tests__/main/tunnel-manager.test.ts
+++ b/src/__tests__/main/tunnel-manager.test.ts
@@ -268,6 +268,30 @@ describe('TunnelManager', () => {
 			mockProcess.emit('exit', 0);
 		});
 
+		it('spawns with --protocol http2 to avoid QUIC URL output bug', async () => {
+			tunnelManager.start(3000);
+			await new Promise((resolve) => setImmediate(resolve));
+
+			expect(mocks.mockSpawn).toHaveBeenCalledWith(
+				expect.any(String),
+				expect.arrayContaining(['--protocol', 'http2'])
+			);
+
+			mockProcess.emit('exit', 0);
+		});
+
+		it('extracts URL from stdout as fallback', async () => {
+			const startPromise = tunnelManager.start(3000);
+			await new Promise((resolve) => setImmediate(resolve));
+
+			// Emit URL on stdout instead of stderr
+			mockProcess.stdout.emit('data', Buffer.from('https://test-fallback.trycloudflare.com'));
+			const result = await startPromise;
+
+			expect(result.success).toBe(true);
+			expect(result.url).toBe('https://test-fallback.trycloudflare.com');
+		});
+
 		it('passes different ports correctly', async () => {
 			tunnelManager.start(9000);
 			await new Promise((resolve) => setImmediate(resolve));

--- a/src/main/tunnel-manager.ts
+++ b/src/main/tunnel-manager.ts
@@ -54,7 +54,7 @@ class TunnelManager {
 			]);
 
 			let resolved = false;
-			let stderrBuffer = '';
+			let outputBuffer = '';
 
 			// Timeout after 30 seconds
 			const timeout = setTimeout(() => {
@@ -68,15 +68,17 @@ class TunnelManager {
 
 			const handleOutput = (data: Buffer) => {
 				const output = data.toString();
-				stderrBuffer += output;
+				outputBuffer += output;
 				logger.info(`cloudflared output: ${output}`, 'TunnelManager');
 
 				// Look for the trycloudflare.com URL in accumulated buffer
-				const urlMatch = stderrBuffer.match(/https:\/\/[a-z0-9-]+\.trycloudflare\.com/i);
+				const urlMatch = outputBuffer.match(/https:\/\/[a-z0-9-]+\.trycloudflare\.com/i);
 				if (urlMatch && !resolved) {
 					this.url = urlMatch[0];
 					clearTimeout(timeout);
 					resolved = true;
+					this.process?.stderr?.off('data', handleOutput);
+					this.process?.stdout?.off('data', handleOutput);
 					logger.info(`Tunnel established: ${this.url}`, 'TunnelManager');
 					resolve({ success: true, url: this.url });
 				}

--- a/src/main/tunnel-manager.ts
+++ b/src/main/tunnel-manager.ts
@@ -45,7 +45,13 @@ class TunnelManager {
 				'TunnelManager'
 			);
 
-			this.process = spawn(cloudflaredBinary, ['tunnel', '--url', `http://localhost:${port}`]);
+			this.process = spawn(cloudflaredBinary, [
+				'tunnel',
+				'--url',
+				`http://localhost:${port}`,
+				'--protocol',
+				'http2',
+			]);
 
 			let resolved = false;
 			let stderrBuffer = '';
@@ -60,9 +66,7 @@ class TunnelManager {
 				}
 			}, 30000);
 
-			// Cloudflare outputs the URL to stderr
-			// Accumulate buffer in case URL is split across chunks
-			this.process.stderr?.on('data', (data: Buffer) => {
+			const handleOutput = (data: Buffer) => {
 				const output = data.toString();
 				stderrBuffer += output;
 				logger.info(`cloudflared output: ${output}`, 'TunnelManager');
@@ -76,7 +80,11 @@ class TunnelManager {
 					logger.info(`Tunnel established: ${this.url}`, 'TunnelManager');
 					resolve({ success: true, url: this.url });
 				}
-			});
+			};
+
+			// cloudflared outputs the URL to stderr, but also listen on stdout as a fallback
+			this.process.stderr?.on('data', handleOutput);
+			this.process.stdout?.on('data', handleOutput);
 
 			this.process.on('error', (err) => {
 				clearTimeout(timeout);


### PR DESCRIPTION
## Summary
- cloudflared 2026.3.0 with default QUIC protocol hangs at "Requesting new quick Tunnel" and never outputs the tunnel URL to stderr, causing the Remote Control toggle to time out after 30s
- Forces `--protocol http2` which reliably prints the URL within seconds
- Also listens on stdout in addition to stderr as a future-proofing fallback

## Test plan
- [x] Existing 22 tunnel-manager tests still pass
- [x] Added test for `--protocol http2` spawn arg
- [x] Added test for stdout URL extraction fallback
- [x] All 24 tests pass
- [x] Type check, prettier, eslint clean
- [x] Manual: Toggle Remote Control switch in Live overlay, verify tunnel URL appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests covering tunnel startup behavior and URL detection from different output streams.

* **Improvements**
  * Improved tunnel URL detection to monitor multiple output channels for greater reliability.
  * Updated tunnel protocol configuration for more robust connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->