### PR TITLE
refactor: consolidate constants and minor dedup (Phase 12)

### DIFF
--- a/src/__tests__/renderer/components/Wizard/WizardIntegration.test.tsx
+++ b/src/__tests__/renderer/components/Wizard/WizardIntegration.test.tsx
@@ -197,7 +197,6 @@ vi.mock('../../../../renderer/components/Wizard/services/phaseGenerator', () => 
 		isGenerationInProgress: vi.fn().mockReturnValue(false),
 		abort: vi.fn(),
 	},
-	AUTO_RUN_FOLDER_NAME: '.maestro/playbooks',
 }));
 
 // Mock theme

--- a/src/__tests__/renderer/hooks/useSessionCrud.test.ts
+++ b/src/__tests__/renderer/hooks/useSessionCrud.test.ts
@@ -41,10 +41,6 @@ vi.mock('../../../renderer/utils/sessionValidation', () => ({
 	validateNewSession: vi.fn(() => ({ valid: true, error: null })),
 }));
 
-vi.mock('../../../renderer/components/Wizard', () => ({
-	AUTO_RUN_FOLDER_NAME: '.maestro/playbooks',
-}));
-
 // ============================================================================
 // Imports (after mocks)
 // ============================================================================

--- a/src/__tests__/renderer/hooks/useSessionRestoration.test.ts
+++ b/src/__tests__/renderer/hooks/useSessionRestoration.test.ts
@@ -23,11 +23,6 @@ vi.mock('../../../renderer/utils/ids', () => ({
 	generateId: vi.fn(() => `mock-id-${++idCounter}`),
 }));
 
-// Mock AUTO_RUN_FOLDER_NAME
-vi.mock('../../../renderer/components/Wizard', () => ({
-	AUTO_RUN_FOLDER_NAME: '.maestro-autorun',
-}));
-
 import { useSessionRestoration } from '../../../renderer/hooks/session/useSessionRestoration';
 import { useSessionStore } from '../../../renderer/stores/sessionStore';
 import { useGroupChatStore } from '../../../renderer/stores/groupChatStore';
@@ -185,7 +180,7 @@ describe('restoreSession — Migration logic', () => {
 			restored = await result.current.restoreSession(session);
 		});
 
-		expect(restored!.autoRunFolderPath).toBe('/projects/myapp/.maestro-autorun');
+		expect(restored!.autoRunFolderPath).toBe('/projects/myapp/.maestro/playbooks');
 	});
 
 	it('sets fileTreeAutoRefreshInterval to 180 when missing', async () => {

--- a/src/__tests__/renderer/hooks/useWizardHandlers.test.ts
+++ b/src/__tests__/renderer/hooks/useWizardHandlers.test.ts
@@ -66,10 +66,6 @@ vi.mock('../../../shared/formatters', () => ({
 	formatRelativeTime: vi.fn(() => '5 minutes ago'),
 }));
 
-vi.mock('../../../renderer/components/Wizard', () => ({
-	AUTO_RUN_FOLDER_NAME: '.maestro/playbooks',
-}));
-
 vi.mock('../../../renderer/components/BatchRunnerModal', () => ({
 	DEFAULT_BATCH_PROMPT: 'Run each task sequentially.',
 }));

--- a/src/__tests__/renderer/utils/existingDocsDetector.test.ts
+++ b/src/__tests__/renderer/utils/existingDocsDetector.test.ts
@@ -10,13 +10,13 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
-	AUTO_RUN_FOLDER_NAME,
 	getAutoRunFolderPath,
 	hasExistingAutoRunDocs,
 	getExistingAutoRunDocs,
 	getExistingAutoRunDocsCount,
 	ExistingDocument,
 } from '../../../renderer/utils/existingDocsDetector';
+import { PLAYBOOKS_DIR } from '../../../shared/maestro-paths';
 
 // Mock window.maestro.autorun API
 const mockAutorunApi = {
@@ -47,9 +47,9 @@ describe('existingDocsDetector', () => {
 		}
 	});
 
-	describe('AUTO_RUN_FOLDER_NAME', () => {
+	describe('PLAYBOOKS_DIR', () => {
 		it('equals ".maestro/playbooks"', () => {
-			expect(AUTO_RUN_FOLDER_NAME).toBe('.maestro/playbooks');
+			expect(PLAYBOOKS_DIR).toBe('.maestro/playbooks');
 		});
 	});
 

--- a/src/renderer/components/DebugWizardModal.tsx
+++ b/src/renderer/components/DebugWizardModal.tsx
@@ -12,7 +12,7 @@ import type { Theme } from '../types';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
 import { Modal, ModalFooter } from './ui/Modal';
 import { useWizard } from './Wizard/WizardContext';
-import { AUTO_RUN_FOLDER_NAME } from './Wizard/services/phaseGenerator';
+import { PLAYBOOKS_DIR } from '../../shared/maestro-paths';
 
 interface DebugWizardModalProps {
 	theme: Theme;
@@ -84,7 +84,7 @@ export function DebugWizardModal({
 
 		try {
 			// Check if Auto Run Docs folder exists
-			const autoRunPath = `${directoryPath}/${AUTO_RUN_FOLDER_NAME}`;
+			const autoRunPath = `${directoryPath}/${PLAYBOOKS_DIR}`;
 
 			let files: string[] = [];
 			try {
@@ -230,7 +230,7 @@ export function DebugWizardModal({
 						</button>
 					</div>
 					<p className="text-xs mt-1" style={{ color: theme.colors.textDim }}>
-						Must contain an "{AUTO_RUN_FOLDER_NAME}" folder with .md files
+						Must contain an "{PLAYBOOKS_DIR}" folder with .md files
 					</p>
 				</div>
 

--- a/src/renderer/components/Wizard/index.ts
+++ b/src/renderer/components/Wizard/index.ts
@@ -11,6 +11,5 @@ export { WizardProvider, useWizard } from './WizardContext';
 export { WizardResumeModal } from './WizardResumeModal';
 export { WizardExitConfirmModal } from './WizardExitConfirmModal';
 export { ScreenReaderAnnouncement, useAnnouncement } from './ScreenReaderAnnouncement';
-export { AUTO_RUN_FOLDER_NAME } from './services/phaseGenerator';
 export type { WizardState, WizardStep, SerializableWizardState } from './WizardContext';
 export type { AnnouncementPoliteness } from './ScreenReaderAnnouncement';

--- a/src/renderer/components/Wizard/screens/ConversationScreen.tsx
+++ b/src/renderer/components/Wizard/screens/ConversationScreen.tsx
@@ -30,7 +30,8 @@ import {
 	createAssistantMessage,
 } from '../services/conversationManager';
 import type { WizardError } from '../services/wizardErrorDetection';
-import { AUTO_RUN_FOLDER_NAME, wizardDebugLogger } from '../services/phaseGenerator';
+import { wizardDebugLogger } from '../services/phaseGenerator';
+import { PLAYBOOKS_DIR } from '../../../../shared/maestro-paths';
 import { getNextFillerPhrase } from '../services/fillerPhrases';
 import { ScreenReaderAnnouncement } from '../ScreenReaderAnnouncement';
 import { formatShortcutKeys } from '../../../utils/shortcutFormatter';
@@ -462,7 +463,7 @@ export function ConversationScreen({
 			}
 
 			try {
-				const autoRunPath = `${state.directoryPath}/${AUTO_RUN_FOLDER_NAME}`;
+				const autoRunPath = `${state.directoryPath}/${PLAYBOOKS_DIR}`;
 				const listResult = await window.maestro.autorun.listDocs(autoRunPath);
 
 				if (!listResult.success || !listResult.files || listResult.files.length === 0) {
@@ -867,7 +868,7 @@ export function ConversationScreen({
 				}
 
 				// Fetch existing docs for the system prompt
-				const autoRunPath = `${state.directoryPath}/${AUTO_RUN_FOLDER_NAME}`;
+				const autoRunPath = `${state.directoryPath}/${PLAYBOOKS_DIR}`;
 				const listResult = await window.maestro.autorun.listDocs(autoRunPath);
 				const existingDocs: ExistingDocument[] = [];
 

--- a/src/renderer/components/Wizard/screens/DirectorySelectionScreen.tsx
+++ b/src/renderer/components/Wizard/screens/DirectorySelectionScreen.tsx
@@ -18,7 +18,7 @@ import type { SshRemoteConfig } from '../../../../shared/types';
 import { useWizard } from '../WizardContext';
 import { ScreenReaderAnnouncement } from '../ScreenReaderAnnouncement';
 import { ExistingDocsModal } from '../ExistingDocsModal';
-import { AUTO_RUN_FOLDER_NAME } from '../services/phaseGenerator';
+import { PLAYBOOKS_DIR } from '../../../../shared/maestro-paths';
 
 interface DirectorySelectionScreenProps {
 	theme: Theme;
@@ -183,7 +183,7 @@ export function DirectorySelectionScreen({ theme }: DirectorySelectionScreenProp
 	const checkForExistingDocs = useCallback(
 		async (dirPath: string): Promise<{ exists: boolean; count: number }> => {
 			try {
-				const autoRunPath = `${dirPath}/${AUTO_RUN_FOLDER_NAME}`;
+				const autoRunPath = `${dirPath}/${PLAYBOOKS_DIR}`;
 				const sshRemoteId = getSshRemoteId();
 				const result = await window.maestro.autorun.listDocs(autoRunPath, sshRemoteId);
 				if (result.success && result.files && result.files.length > 0) {
@@ -369,7 +369,7 @@ export function DirectorySelectionScreen({ theme }: DirectorySelectionScreenProp
 
 		// Check if Auto Run Docs folder exists and has files
 		try {
-			const autoRunPath = `${state.directoryPath}/${AUTO_RUN_FOLDER_NAME}`;
+			const autoRunPath = `${state.directoryPath}/${PLAYBOOKS_DIR}`;
 			const sshRemoteId = getSshRemoteId();
 			const result = await window.maestro.autorun.listDocs(autoRunPath, sshRemoteId);
 			const docs = result.success ? result.files : [];

--- a/src/renderer/components/Wizard/screens/PhaseReviewScreen.tsx
+++ b/src/renderer/components/Wizard/screens/PhaseReviewScreen.tsx
@@ -18,7 +18,7 @@ import { useEffect, useCallback, useRef, useState } from 'react';
 import { Loader2, Rocket, Compass, X } from 'lucide-react';
 import type { Theme } from '../../../types';
 import { useWizard } from '../WizardContext';
-import { AUTO_RUN_FOLDER_NAME } from '../services/phaseGenerator';
+import { PLAYBOOKS_DIR } from '../../../../shared/maestro-paths';
 import { ScreenReaderAnnouncement } from '../ScreenReaderAnnouncement';
 import { DocumentEditor } from '../shared/DocumentEditor';
 import { ToggleSwitch } from '../../ui/ToggleSwitch';
@@ -79,7 +79,7 @@ function DocumentReview({
 
 	const { generatedDocuments, directoryPath, currentDocumentIndex } = state;
 	const currentDoc = generatedDocuments[currentDocumentIndex] || generatedDocuments[0];
-	const folderPath = `${directoryPath}/${AUTO_RUN_FOLDER_NAME}`;
+	const folderPath = `${directoryPath}/${PLAYBOOKS_DIR}`;
 
 	// Local content state for editing - tracks current document
 	const [localContent, setLocalContent] = useState(

--- a/src/renderer/components/Wizard/services/index.ts
+++ b/src/renderer/components/Wizard/services/index.ts
@@ -18,7 +18,6 @@ export {
 export {
 	phaseGenerator,
 	phaseGeneratorUtils,
-	AUTO_RUN_FOLDER_NAME,
 	type GenerationConfig,
 	type GenerationResult,
 	type GenerationCallbacks,

--- a/src/renderer/components/Wizard/services/phaseGenerator.ts
+++ b/src/renderer/components/Wizard/services/phaseGenerator.ts
@@ -148,12 +148,6 @@ interface ParsedDocument {
 import { PLAYBOOKS_DIR } from '../../../../shared/maestro-paths';
 
 /**
- * Default Auto Run folder name.
- * @deprecated Import PLAYBOOKS_DIR from shared/maestro-paths instead.
- */
-export const AUTO_RUN_FOLDER_NAME = PLAYBOOKS_DIR;
-
-/**
  * Sanitize a filename to prevent path traversal attacks.
  * Removes path separators, directory traversal sequences, and other dangerous characters.
  *
@@ -343,9 +337,7 @@ export function generateDocumentGenerationPrompt(config: GenerationConfig): stri
 		.join('\n\n');
 
 	// Build the full Auto Run folder path (including subfolder if specified)
-	const autoRunFolderPath = subfolder
-		? `${AUTO_RUN_FOLDER_NAME}/${subfolder}`
-		: AUTO_RUN_FOLDER_NAME;
+	const autoRunFolderPath = subfolder ? `${PLAYBOOKS_DIR}/${subfolder}` : PLAYBOOKS_DIR;
 
 	// First, handle wizard-specific variables that have different semantics
 	// from the central template system. We do this BEFORE the central function
@@ -724,8 +716,8 @@ class PhaseGenerator {
 				wizardDebugLogger.log('info', 'Checking for documents on disk (parsed docs invalid)');
 				// Build the correct path including subfolder if specified
 				const autoRunPath = config.subfolder
-					? `${config.directoryPath}/${AUTO_RUN_FOLDER_NAME}/${config.subfolder}`
-					: `${config.directoryPath}/${AUTO_RUN_FOLDER_NAME}`;
+					? `${config.directoryPath}/${PLAYBOOKS_DIR}/${config.subfolder}`
+					: `${config.directoryPath}/${PLAYBOOKS_DIR}`;
 				const diskDocs = await this.readDocumentsFromDisk(autoRunPath, sshRemoteId);
 				if (diskDocs.length > 0) {
 					console.log('[PhaseGenerator] Found documents on disk:', diskDocs.length);
@@ -772,7 +764,7 @@ class PhaseGenerator {
 
 			// Convert to GeneratedDocument format
 			// If read from disk, set savedPath since they're already saved
-			const autoRunPath = `${config.directoryPath}/${AUTO_RUN_FOLDER_NAME}`;
+			const autoRunPath = `${config.directoryPath}/${PLAYBOOKS_DIR}`;
 			const generatedDocs: GeneratedDocument[] = documents.map((doc) => ({
 				filename: doc.filename,
 				content: doc.content,
@@ -991,8 +983,8 @@ class PhaseGenerator {
 			// Set up file system watcher for Auto Run Docs folder (including subfolder if specified)
 			// This detects when the agent creates files and resets the timeout
 			const autoRunPath = config.subfolder
-				? `${config.directoryPath}/${AUTO_RUN_FOLDER_NAME}/${config.subfolder}`
-				: `${config.directoryPath}/${AUTO_RUN_FOLDER_NAME}`;
+				? `${config.directoryPath}/${PLAYBOOKS_DIR}/${config.subfolder}`
+				: `${config.directoryPath}/${PLAYBOOKS_DIR}`;
 			wizardDebugLogger.log('info', 'Setting up file watcher', {
 				autoRunPath,
 				subfolder: config.subfolder,
@@ -1275,7 +1267,7 @@ class PhaseGenerator {
 		subfolder?: string,
 		sshRemoteId?: string
 	): Promise<{ success: boolean; savedPaths: string[]; error?: string; subfolderPath?: string }> {
-		const baseAutoRunPath = `${directoryPath}/${AUTO_RUN_FOLDER_NAME}`;
+		const baseAutoRunPath = `${directoryPath}/${PLAYBOOKS_DIR}`;
 		const autoRunPath = subfolder ? `${baseAutoRunPath}/${subfolder}` : baseAutoRunPath;
 		const savedPaths: string[] = [];
 
@@ -1334,7 +1326,7 @@ class PhaseGenerator {
 	 * Get the Auto Run folder path for a directory
 	 */
 	getAutoRunPath(directoryPath: string): string {
-		return `${directoryPath}/${AUTO_RUN_FOLDER_NAME}`;
+		return `${directoryPath}/${PLAYBOOKS_DIR}`;
 	}
 
 	/**
@@ -1364,5 +1356,4 @@ export const phaseGeneratorUtils = {
 	countTasks,
 	validateDocuments,
 	splitIntoPhases,
-	AUTO_RUN_FOLDER_NAME,
 };

--- a/src/renderer/hooks/session/useSessionCrud.ts
+++ b/src/renderer/hooks/session/useSessionCrud.ts
@@ -25,7 +25,7 @@ import { generateId } from '../../utils/ids';
 import { validateNewSession } from '../../utils/sessionValidation';
 import { getTerminalSessionId } from '../../utils/terminalTabHelpers';
 import { gitService } from '../../services/git';
-import { AUTO_RUN_FOLDER_NAME } from '../../components/Wizard';
+import { PLAYBOOKS_DIR } from '../../../shared/maestro-paths';
 
 // ============================================================================
 // Dependencies interface
@@ -262,7 +262,7 @@ export function useSessionCrud(deps: UseSessionCrudDeps): UseSessionCrudReturn {
 					customContextWindow,
 					customProviderPath,
 					sessionSshRemoteConfig,
-					autoRunFolderPath: `${workingDir}/${AUTO_RUN_FOLDER_NAME}`,
+					autoRunFolderPath: `${workingDir}/${PLAYBOOKS_DIR}`,
 				};
 
 				setSessions((prev) => [...prev, newSession]);

--- a/src/renderer/hooks/session/useSessionRestoration.ts
+++ b/src/renderer/hooks/session/useSessionRestoration.ts
@@ -21,7 +21,7 @@ import { gitService } from '../../services/git';
 import { generateId } from '../../utils/ids';
 import { rehydrateBrowserTab } from '../../utils/browserTabPersistence';
 import { getRepairedUnifiedTabOrder } from '../../utils/tabHelpers';
-import { AUTO_RUN_FOLDER_NAME } from '../../components/Wizard';
+import { PLAYBOOKS_DIR } from '../../../shared/maestro-paths';
 
 // ============================================================================
 // Return type
@@ -165,7 +165,7 @@ export function useSessionRestoration(): SessionRestorationReturn {
 			if (!session.autoRunFolderPath && session.projectRoot) {
 				session = {
 					...session,
-					autoRunFolderPath: `${session.projectRoot}/${AUTO_RUN_FOLDER_NAME}`,
+					autoRunFolderPath: `${session.projectRoot}/${PLAYBOOKS_DIR}`,
 				};
 			}
 

--- a/src/renderer/hooks/wizard/useWizardHandlers.ts
+++ b/src/renderer/hooks/wizard/useWizardHandlers.ts
@@ -39,7 +39,7 @@ import { autorunSynopsisPrompt } from '../../../prompts';
 import { parseSynopsis } from '../../../shared/synopsis';
 import { formatRelativeTime } from '../../../shared/formatters';
 import { gitService } from '../../services/git';
-import { AUTO_RUN_FOLDER_NAME } from '../../components/Wizard';
+import { PLAYBOOKS_DIR } from '../../../shared/maestro-paths';
 import { DEFAULT_BATCH_PROMPT } from '../../components/BatchRunnerModal';
 import type { PreviousUIState, UseInlineWizardReturn } from '../batch/useInlineWizard';
 import type { WizardState } from '../../components/Wizard/WizardContext';
@@ -1136,7 +1136,7 @@ export function useWizardHandlers(deps: UseWizardHandlersDeps): UseWizardHandler
 				showThinking: currentDefaults.defaultShowThinking,
 			};
 
-			const autoRunFolderPath = `${directoryPath}/${AUTO_RUN_FOLDER_NAME}`;
+			const autoRunFolderPath = `${directoryPath}/${PLAYBOOKS_DIR}`;
 			const firstDoc = generatedDocuments[0];
 			const autoRunSelectedFile = firstDoc ? firstDoc.filename.replace(/\.md$/, '') : undefined;
 

--- a/src/renderer/services/inlineWizardDocumentGeneration.ts
+++ b/src/renderer/services/inlineWizardDocumentGeneration.ts
@@ -18,14 +18,6 @@ import { wizardDocumentGenerationPrompt, wizardInlineIterateGenerationPrompt } f
 import { substituteTemplateVariables, type TemplateContext } from '../utils/templateVariables';
 import { deriveSshRemoteId } from '../components/Wizard/services/phaseGenerator';
 
-import { PLAYBOOKS_DIR } from '../../shared/maestro-paths';
-
-/**
- * Auto Run folder name constant.
- * @deprecated Import PLAYBOOKS_DIR from shared/maestro-paths instead.
- */
-export const AUTO_RUN_FOLDER_NAME = PLAYBOOKS_DIR;
-
 /**
  * Generation timeout in milliseconds (20 minutes).
  */

--- a/src/renderer/utils/existingDocsDetector.ts
+++ b/src/renderer/utils/existingDocsDetector.ts
@@ -8,11 +8,6 @@
 import { PLAYBOOKS_DIR, LEGACY_PLAYBOOKS_DIR } from '../../shared/maestro-paths';
 
 /**
- * @deprecated Import PLAYBOOKS_DIR from shared/maestro-paths instead.
- */
-export const AUTO_RUN_FOLDER_NAME = PLAYBOOKS_DIR;
-
-/**
  * Represents an existing Auto Run document.
  */
 export interface ExistingDocument {


### PR DESCRIPTION
## Summary

Removes duplicate `AUTO_RUN_FOLDER_NAME` constants and cleans up related wrapper/barrel exports across the wizard / session pipeline.

**Net: -37 lines across 17 files**

### Changes

- 3 previous local definitions of `AUTO_RUN_FOLDER_NAME` now import `PLAYBOOKS_DIR` from `src/shared/maestro-paths.ts`
- Dropped deprecated service wrappers that existed solely to forward to the canonical implementation
- Dropped orphan barrel re-exports from `Wizard/index.ts` and `Wizard/services/index.ts`

### Why this is smaller than the playbook target (~126 lines)

- `DEFAULT_CAPABILITIES` was already consolidated in [Phase 02](https://github.com/RunMaestro/Maestro/pull/811) - double-counted in the original playbook
- CSS class-name extraction was intentionally skipped - most Tailwind utility combos either appear in only 2-3 call sites (not worth a shared module) or are context-dependent (extracting them would force adding a theme/variant prop). Leaving this for a future round once a dedicated design-token system is in place.

## Test plan

- [x] `npm run lint` passes (all 3 tsconfigs)
- [x] `npx prettier --check .` passes
- [x] 262 targeted tests pass (useSessionCrud, useSessionRestoration, useWizardHandlers, existingDocsDetector, WizardIntegration)
- [x] Wizard resumes existing Auto Run docs correctly (uses `PLAYBOOKS_DIR` for the scan)
- [x] Session creation routes to correct `.maestro/playbooks/` directory

## Risk

**Very low**. Pure constant consolidation - same value, different import path.
