### PR TITLE
fix: resolve symlinks in Files panel and Auto Run folder tree

### DIFF
--- a/src/__tests__/main/ipc/handlers/autorun.test.ts
+++ b/src/__tests__/main/ipc/handlers/autorun.test.ts
@@ -408,6 +408,103 @@ describe('autorun IPC handlers', () => {
 			expect(result.tree).toHaveLength(2);
 		});
 
+		it('should include symlinked .md files as documents', async () => {
+			vi.mocked(fs.stat).mockImplementation((p: any) => {
+				// First call: the top-level folder. Subsequent calls: symlink resolution.
+				if (p === '/test/folder') {
+					return Promise.resolve({ isDirectory: () => true, isFile: () => false } as any);
+				}
+				// Symlink target is a file
+				return Promise.resolve({ isDirectory: () => false, isFile: () => true } as any);
+			});
+
+			vi.mocked(fs.readdir).mockResolvedValue([
+				{
+					name: 'linked-doc.md',
+					isDirectory: () => false,
+					isFile: () => false,
+					isSymbolicLink: () => true,
+				},
+				{
+					name: 'real.md',
+					isDirectory: () => false,
+					isFile: () => true,
+					isSymbolicLink: () => false,
+				},
+			] as any);
+
+			const handler = handlers.get('autorun:listDocs');
+			const result = await handler!({} as any, '/test/folder');
+
+			expect(result.success).toBe(true);
+			expect(result.files).toEqual(['linked-doc', 'real']);
+		});
+
+		it('should recurse into symlinked folders containing .md files', async () => {
+			vi.mocked(fs.stat).mockImplementation((p: any) => {
+				if (p === '/test/folder') {
+					return Promise.resolve({ isDirectory: () => true, isFile: () => false } as any);
+				}
+				// Symlink target is a directory
+				return Promise.resolve({ isDirectory: () => true, isFile: () => false } as any);
+			});
+
+			// Root contains a symlinked folder; the folder contains nested.md
+			vi.mocked(fs.readdir)
+				.mockResolvedValueOnce([
+					{
+						name: 'linked-folder',
+						isDirectory: () => false,
+						isFile: () => false,
+						isSymbolicLink: () => true,
+					},
+				] as any)
+				.mockResolvedValueOnce([
+					{
+						name: 'nested.md',
+						isDirectory: () => false,
+						isFile: () => true,
+						isSymbolicLink: () => false,
+					},
+				] as any);
+
+			const handler = handlers.get('autorun:listDocs');
+			const result = await handler!({} as any, '/test/folder');
+
+			expect(result.success).toBe(true);
+			expect(result.files).toContain('linked-folder/nested');
+		});
+
+		it('should skip broken symlinks silently', async () => {
+			vi.mocked(fs.stat).mockImplementation((p: any) => {
+				if (p === '/test/folder') {
+					return Promise.resolve({ isDirectory: () => true, isFile: () => false } as any);
+				}
+				return Promise.reject(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
+			});
+
+			vi.mocked(fs.readdir).mockResolvedValue([
+				{
+					name: 'broken',
+					isDirectory: () => false,
+					isFile: () => false,
+					isSymbolicLink: () => true,
+				},
+				{
+					name: 'real.md',
+					isDirectory: () => false,
+					isFile: () => true,
+					isSymbolicLink: () => false,
+				},
+			] as any);
+
+			const handler = handlers.get('autorun:listDocs');
+			const result = await handler!({} as any, '/test/folder');
+
+			expect(result.success).toBe(true);
+			expect(result.files).toEqual(['real']);
+		});
+
 		it('should exclude dotfiles', async () => {
 			vi.mocked(fs.stat).mockResolvedValue({
 				isDirectory: () => true,

--- a/src/__tests__/main/ipc/handlers/autorun.test.ts
+++ b/src/__tests__/main/ipc/handlers/autorun.test.ts
@@ -231,8 +231,18 @@ describe('autorun IPC handlers', () => {
 
 			// Mock readdir to return markdown files
 			vi.mocked(fs.readdir).mockResolvedValue([
-				{ name: 'doc1.md', isDirectory: () => false, isFile: () => true },
-				{ name: 'doc2.md', isDirectory: () => false, isFile: () => true },
+				{
+					name: 'doc1.md',
+					isDirectory: () => false,
+					isFile: () => true,
+					isSymbolicLink: () => false,
+				},
+				{
+					name: 'doc2.md',
+					isDirectory: () => false,
+					isFile: () => true,
+					isSymbolicLink: () => false,
+				},
 			] as any);
 
 			const handler = handlers.get('autorun:listDocs');
@@ -252,10 +262,30 @@ describe('autorun IPC handlers', () => {
 			} as any);
 
 			vi.mocked(fs.readdir).mockResolvedValue([
-				{ name: 'doc1.md', isDirectory: () => false, isFile: () => true },
-				{ name: 'readme.txt', isDirectory: () => false, isFile: () => true },
-				{ name: 'image.png', isDirectory: () => false, isFile: () => true },
-				{ name: 'doc2.MD', isDirectory: () => false, isFile: () => true },
+				{
+					name: 'doc1.md',
+					isDirectory: () => false,
+					isFile: () => true,
+					isSymbolicLink: () => false,
+				},
+				{
+					name: 'readme.txt',
+					isDirectory: () => false,
+					isFile: () => true,
+					isSymbolicLink: () => false,
+				},
+				{
+					name: 'image.png',
+					isDirectory: () => false,
+					isFile: () => true,
+					isSymbolicLink: () => false,
+				},
+				{
+					name: 'doc2.MD',
+					isDirectory: () => false,
+					isFile: () => true,
+					isSymbolicLink: () => false,
+				},
 			] as any);
 
 			const handler = handlers.get('autorun:listDocs');
@@ -311,9 +341,24 @@ describe('autorun IPC handlers', () => {
 			} as any);
 
 			vi.mocked(fs.readdir).mockResolvedValue([
-				{ name: 'zebra.md', isDirectory: () => false, isFile: () => true },
-				{ name: 'alpha.md', isDirectory: () => false, isFile: () => true },
-				{ name: 'Beta.md', isDirectory: () => false, isFile: () => true },
+				{
+					name: 'zebra.md',
+					isDirectory: () => false,
+					isFile: () => true,
+					isSymbolicLink: () => false,
+				},
+				{
+					name: 'alpha.md',
+					isDirectory: () => false,
+					isFile: () => true,
+					isSymbolicLink: () => false,
+				},
+				{
+					name: 'Beta.md',
+					isDirectory: () => false,
+					isFile: () => true,
+					isSymbolicLink: () => false,
+				},
 			] as any);
 
 			const handler = handlers.get('autorun:listDocs');
@@ -332,11 +377,26 @@ describe('autorun IPC handlers', () => {
 			// First call for root, second for subfolder
 			vi.mocked(fs.readdir)
 				.mockResolvedValueOnce([
-					{ name: 'subfolder', isDirectory: () => true, isFile: () => false },
-					{ name: 'root.md', isDirectory: () => false, isFile: () => true },
+					{
+						name: 'subfolder',
+						isDirectory: () => true,
+						isFile: () => false,
+						isSymbolicLink: () => false,
+					},
+					{
+						name: 'root.md',
+						isDirectory: () => false,
+						isFile: () => true,
+						isSymbolicLink: () => false,
+					},
 				] as any)
 				.mockResolvedValueOnce([
-					{ name: 'nested.md', isDirectory: () => false, isFile: () => true },
+					{
+						name: 'nested.md',
+						isDirectory: () => false,
+						isFile: () => true,
+						isSymbolicLink: () => false,
+					},
 				] as any);
 
 			const handler = handlers.get('autorun:listDocs');
@@ -355,8 +415,18 @@ describe('autorun IPC handlers', () => {
 			} as any);
 
 			vi.mocked(fs.readdir).mockResolvedValue([
-				{ name: '.hidden.md', isDirectory: () => false, isFile: () => true },
-				{ name: 'visible.md', isDirectory: () => false, isFile: () => true },
+				{
+					name: '.hidden.md',
+					isDirectory: () => false,
+					isFile: () => true,
+					isSymbolicLink: () => false,
+				},
+				{
+					name: 'visible.md',
+					isDirectory: () => false,
+					isFile: () => true,
+					isSymbolicLink: () => false,
+				},
 			] as any);
 
 			const handler = handlers.get('autorun:listDocs');
@@ -375,7 +445,12 @@ describe('autorun IPC handlers', () => {
 			} as any);
 
 			vi.mocked(fs.readdir).mockResolvedValue([
-				{ name: 'doc1.md', isDirectory: () => false, isFile: () => true },
+				{
+					name: 'doc1.md',
+					isDirectory: () => false,
+					isFile: () => true,
+					isSymbolicLink: () => false,
+				},
 			] as any);
 
 			const handler = handlers.get('autorun:hasDocuments');
@@ -407,8 +482,18 @@ describe('autorun IPC handlers', () => {
 			} as any);
 
 			vi.mocked(fs.readdir).mockResolvedValue([
-				{ name: 'image.png', isDirectory: () => false, isFile: () => true },
-				{ name: 'readme.txt', isDirectory: () => false, isFile: () => true },
+				{
+					name: 'image.png',
+					isDirectory: () => false,
+					isFile: () => true,
+					isSymbolicLink: () => false,
+				},
+				{
+					name: 'readme.txt',
+					isDirectory: () => false,
+					isFile: () => true,
+					isSymbolicLink: () => false,
+				},
 			] as any);
 
 			const handler = handlers.get('autorun:hasDocuments');
@@ -450,10 +535,20 @@ describe('autorun IPC handlers', () => {
 			// First call for root (no .md), second for subfolder (has .md)
 			vi.mocked(fs.readdir)
 				.mockResolvedValueOnce([
-					{ name: 'subfolder', isDirectory: () => true, isFile: () => false },
+					{
+						name: 'subfolder',
+						isDirectory: () => true,
+						isFile: () => false,
+						isSymbolicLink: () => false,
+					},
 				] as any)
 				.mockResolvedValueOnce([
-					{ name: 'nested.md', isDirectory: () => false, isFile: () => true },
+					{
+						name: 'nested.md',
+						isDirectory: () => false,
+						isFile: () => true,
+						isSymbolicLink: () => false,
+					},
 				] as any);
 
 			const handler = handlers.get('autorun:hasDocuments');
@@ -470,8 +565,13 @@ describe('autorun IPC handlers', () => {
 			} as any);
 
 			vi.mocked(fs.readdir).mockResolvedValue([
-				{ name: '.hidden.md', isDirectory: () => false, isFile: () => true },
-				{ name: '.git', isDirectory: () => true, isFile: () => false },
+				{
+					name: '.hidden.md',
+					isDirectory: () => false,
+					isFile: () => true,
+					isSymbolicLink: () => false,
+				},
+				{ name: '.git', isDirectory: () => true, isFile: () => false, isSymbolicLink: () => false },
 			] as any);
 
 			const handler = handlers.get('autorun:hasDocuments');
@@ -488,7 +588,12 @@ describe('autorun IPC handlers', () => {
 			} as any);
 
 			vi.mocked(fs.readdir).mockResolvedValue([
-				{ name: 'doc1.MD', isDirectory: () => false, isFile: () => true },
+				{
+					name: 'doc1.MD',
+					isDirectory: () => false,
+					isFile: () => true,
+					isSymbolicLink: () => false,
+				},
 			] as any);
 
 			const handler = handlers.get('autorun:hasDocuments');
@@ -506,8 +611,18 @@ describe('autorun IPC handlers', () => {
 
 			// Root has a .md file, so we shouldn't recurse into subfolder
 			vi.mocked(fs.readdir).mockResolvedValue([
-				{ name: 'first.md', isDirectory: () => false, isFile: () => true },
-				{ name: 'subfolder', isDirectory: () => true, isFile: () => false },
+				{
+					name: 'first.md',
+					isDirectory: () => false,
+					isFile: () => true,
+					isSymbolicLink: () => false,
+				},
+				{
+					name: 'subfolder',
+					isDirectory: () => true,
+					isFile: () => false,
+					isSymbolicLink: () => false,
+				},
 			] as any);
 
 			const handler = handlers.get('autorun:hasDocuments');
@@ -1052,9 +1167,24 @@ describe('autorun IPC handlers', () => {
 				isDirectory: () => true,
 			} as any);
 			vi.mocked(fs.readdir).mockResolvedValue([
-				{ name: 'doc1.backup.md', isDirectory: () => false, isFile: () => true },
-				{ name: 'doc2.backup.md', isDirectory: () => false, isFile: () => true },
-				{ name: 'doc3.md', isDirectory: () => false, isFile: () => true },
+				{
+					name: 'doc1.backup.md',
+					isDirectory: () => false,
+					isFile: () => true,
+					isSymbolicLink: () => false,
+				},
+				{
+					name: 'doc2.backup.md',
+					isDirectory: () => false,
+					isFile: () => true,
+					isSymbolicLink: () => false,
+				},
+				{
+					name: 'doc3.md',
+					isDirectory: () => false,
+					isFile: () => true,
+					isSymbolicLink: () => false,
+				},
 			] as any);
 			vi.mocked(fs.unlink).mockResolvedValue(undefined);
 
@@ -1071,7 +1201,12 @@ describe('autorun IPC handlers', () => {
 				isDirectory: () => true,
 			} as any);
 			vi.mocked(fs.readdir).mockResolvedValue([
-				{ name: 'doc1.md', isDirectory: () => false, isFile: () => true },
+				{
+					name: 'doc1.md',
+					isDirectory: () => false,
+					isFile: () => true,
+					isSymbolicLink: () => false,
+				},
 			] as any);
 
 			const handler = handlers.get('autorun:deleteBackups');
@@ -1088,11 +1223,26 @@ describe('autorun IPC handlers', () => {
 			} as any);
 			vi.mocked(fs.readdir)
 				.mockResolvedValueOnce([
-					{ name: 'doc1.backup.md', isDirectory: () => false, isFile: () => true },
-					{ name: 'subfolder', isDirectory: () => true, isFile: () => false },
+					{
+						name: 'doc1.backup.md',
+						isDirectory: () => false,
+						isFile: () => true,
+						isSymbolicLink: () => false,
+					},
+					{
+						name: 'subfolder',
+						isDirectory: () => true,
+						isFile: () => false,
+						isSymbolicLink: () => false,
+					},
 				] as any)
 				.mockResolvedValueOnce([
-					{ name: 'nested.backup.md', isDirectory: () => false, isFile: () => true },
+					{
+						name: 'nested.backup.md',
+						isDirectory: () => false,
+						isFile: () => true,
+						isSymbolicLink: () => false,
+					},
 				] as any);
 			vi.mocked(fs.unlink).mockResolvedValue(undefined);
 

--- a/src/__tests__/main/ipc/handlers/filesystem.test.ts
+++ b/src/__tests__/main/ipc/handlers/filesystem.test.ts
@@ -169,6 +169,72 @@ describe('filesystem handlers', () => {
 			);
 		});
 
+		it('should resolve symlinks pointing to directories', async () => {
+			const mockEntries = [
+				{
+					name: 'linked-folder',
+					isDirectory: () => false,
+					isFile: () => false,
+					isSymbolicLink: () => true,
+				},
+			];
+			vi.mocked(fs.readdir).mockResolvedValue(mockEntries as any);
+			vi.mocked(fs.stat).mockResolvedValue({
+				isDirectory: () => true,
+				isFile: () => false,
+			} as any);
+
+			const handler = registeredHandlers.get('fs:readDir');
+			const result = await handler!({}, '/test/path');
+
+			expect(fs.stat).toHaveBeenCalledWith(expect.stringContaining('linked-folder'));
+			expect(result).toHaveLength(1);
+			expect(result[0].name).toBe('linked-folder');
+			expect(result[0].isDirectory).toBe(true);
+			expect(result[0].isFile).toBe(false);
+		});
+
+		it('should resolve symlinks pointing to regular files', async () => {
+			const mockEntries = [
+				{
+					name: 'linked-doc.md',
+					isDirectory: () => false,
+					isFile: () => false,
+					isSymbolicLink: () => true,
+				},
+			];
+			vi.mocked(fs.readdir).mockResolvedValue(mockEntries as any);
+			vi.mocked(fs.stat).mockResolvedValue({
+				isDirectory: () => false,
+				isFile: () => true,
+			} as any);
+
+			const handler = registeredHandlers.get('fs:readDir');
+			const result = await handler!({}, '/test/path');
+
+			expect(result[0].isDirectory).toBe(false);
+			expect(result[0].isFile).toBe(true);
+		});
+
+		it('should surface broken symlinks as files so they remain visible', async () => {
+			const mockEntries = [
+				{
+					name: 'broken-link',
+					isDirectory: () => false,
+					isFile: () => false,
+					isSymbolicLink: () => true,
+				},
+			];
+			vi.mocked(fs.readdir).mockResolvedValue(mockEntries as any);
+			vi.mocked(fs.stat).mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
+
+			const handler = registeredHandlers.get('fs:readDir');
+			const result = await handler!({}, '/test/path');
+
+			expect(result[0].isDirectory).toBe(false);
+			expect(result[0].isFile).toBe(true);
+		});
+
 		it('should normalize local entry names to NFC Unicode form', async () => {
 			const nfdName = 'caf\u00e9'.normalize('NFD');
 			const nfcName = 'caf\u00e9'.normalize('NFC');
@@ -385,6 +451,60 @@ describe('filesystem handlers', () => {
 			const result = await handler!({}, '/test/folder');
 
 			expect(result).toEqual({ fileCount: 2, folderCount: 1 });
+		});
+
+		it('should count symlinked folders as folders and recurse into them', async () => {
+			// Root: one file, one symlinked folder. Symlinked folder contains one file.
+			vi.mocked(fs.readdir)
+				.mockResolvedValueOnce([
+					{
+						name: 'file1.txt',
+						isDirectory: () => false,
+						isFile: () => true,
+						isSymbolicLink: () => false,
+					},
+					{
+						name: 'linked-folder',
+						isDirectory: () => false,
+						isFile: () => false,
+						isSymbolicLink: () => true,
+					},
+				] as any)
+				.mockResolvedValueOnce([
+					{
+						name: 'nested.txt',
+						isDirectory: () => false,
+						isFile: () => true,
+						isSymbolicLink: () => false,
+					},
+				] as any);
+			// fs.stat is only called for the symlink
+			vi.mocked(fs.stat).mockResolvedValue({
+				isDirectory: () => true,
+				isFile: () => false,
+			} as any);
+
+			const handler = registeredHandlers.get('fs:countItems');
+			const result = await handler!({}, '/test/folder');
+
+			expect(result).toEqual({ fileCount: 2, folderCount: 1 });
+		});
+
+		it('should count broken symlinks as files', async () => {
+			vi.mocked(fs.readdir).mockResolvedValueOnce([
+				{
+					name: 'broken',
+					isDirectory: () => false,
+					isFile: () => false,
+					isSymbolicLink: () => true,
+				},
+			] as any);
+			vi.mocked(fs.stat).mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
+
+			const handler = registeredHandlers.get('fs:countItems');
+			const result = await handler!({}, '/test/folder');
+
+			expect(result).toEqual({ fileCount: 1, folderCount: 0 });
 		});
 
 		it('should count items in remote directory via SSH', async () => {

--- a/src/__tests__/main/ipc/handlers/filesystem.test.ts
+++ b/src/__tests__/main/ipc/handlers/filesystem.test.ts
@@ -111,8 +111,18 @@ describe('filesystem handlers', () => {
 	describe('fs:readDir', () => {
 		it('should read local directory entries', async () => {
 			const mockEntries = [
-				{ name: 'file1.txt', isDirectory: () => false, isFile: () => true },
-				{ name: 'folder1', isDirectory: () => true, isFile: () => false },
+				{
+					name: 'file1.txt',
+					isDirectory: () => false,
+					isFile: () => true,
+					isSymbolicLink: () => false,
+				},
+				{
+					name: 'folder1',
+					isDirectory: () => true,
+					isFile: () => false,
+					isSymbolicLink: () => false,
+				},
 			];
 			vi.mocked(fs.readdir).mockResolvedValue(mockEntries as any);
 
@@ -165,7 +175,14 @@ describe('filesystem handlers', () => {
 			// Verify precondition: the names are different byte sequences
 			expect(nfdName).not.toBe(nfcName);
 
-			const mockEntries = [{ name: nfdName, isDirectory: () => false, isFile: () => true }];
+			const mockEntries = [
+				{
+					name: nfdName,
+					isDirectory: () => false,
+					isFile: () => true,
+					isSymbolicLink: () => false,
+				},
+			];
 			vi.mocked(fs.readdir).mockResolvedValue(mockEntries as any);
 
 			const handler = registeredHandlers.get('fs:readDir');
@@ -357,10 +374,12 @@ describe('filesystem handlers', () => {
 			// Mock a simple directory structure
 			vi.mocked(fs.readdir)
 				.mockResolvedValueOnce([
-					{ name: 'file1.txt', isDirectory: () => false },
-					{ name: 'subfolder', isDirectory: () => true },
+					{ name: 'file1.txt', isDirectory: () => false, isSymbolicLink: () => false },
+					{ name: 'subfolder', isDirectory: () => true, isSymbolicLink: () => false },
 				] as any)
-				.mockResolvedValueOnce([{ name: 'file2.txt', isDirectory: () => false }] as any);
+				.mockResolvedValueOnce([
+					{ name: 'file2.txt', isDirectory: () => false, isSymbolicLink: () => false },
+				] as any);
 
 			const handler = registeredHandlers.get('fs:countItems');
 			const result = await handler!({}, '/test/folder');

--- a/src/__tests__/main/ipc/handlers/filesystem.test.ts
+++ b/src/__tests__/main/ipc/handlers/filesystem.test.ts
@@ -440,11 +440,26 @@ describe('filesystem handlers', () => {
 			// Mock a simple directory structure
 			vi.mocked(fs.readdir)
 				.mockResolvedValueOnce([
-					{ name: 'file1.txt', isDirectory: () => false, isSymbolicLink: () => false },
-					{ name: 'subfolder', isDirectory: () => true, isSymbolicLink: () => false },
+					{
+						name: 'file1.txt',
+						isDirectory: () => false,
+						isFile: () => true,
+						isSymbolicLink: () => false,
+					},
+					{
+						name: 'subfolder',
+						isDirectory: () => true,
+						isFile: () => false,
+						isSymbolicLink: () => false,
+					},
 				] as any)
 				.mockResolvedValueOnce([
-					{ name: 'file2.txt', isDirectory: () => false, isSymbolicLink: () => false },
+					{
+						name: 'file2.txt',
+						isDirectory: () => false,
+						isFile: () => true,
+						isSymbolicLink: () => false,
+					},
 				] as any);
 
 			const handler = registeredHandlers.get('fs:countItems');

--- a/src/__tests__/main/utils/dirent-utils.test.ts
+++ b/src/__tests__/main/utils/dirent-utils.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('fs/promises', () => ({
+	default: {
+		stat: vi.fn(),
+	},
+}));
+
+import fs from 'fs/promises';
+import { resolveDirentType, readDirWithResolvedTypes } from '../../../main/utils/dirent-utils';
+
+// Helper to build a Dirent-like object with the flags we care about
+function makeDirent(opts: {
+	name: string;
+	isDir?: boolean;
+	isFile?: boolean;
+	isSymlink?: boolean;
+}) {
+	return {
+		name: opts.name,
+		isDirectory: () => opts.isDir ?? false,
+		isFile: () => opts.isFile ?? false,
+		isSymbolicLink: () => opts.isSymlink ?? false,
+	} as any;
+}
+
+describe('resolveDirentType', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('returns dir/file flags directly for non-symlink entries', async () => {
+		const dir = makeDirent({ name: 'folder', isDir: true });
+		const file = makeDirent({ name: 'readme.md', isFile: true });
+
+		expect(await resolveDirentType(dir, '/x/folder')).toEqual({
+			isDirectory: true,
+			isFile: false,
+			isBrokenSymlink: false,
+		});
+		expect(await resolveDirentType(file, '/x/readme.md')).toEqual({
+			isDirectory: false,
+			isFile: true,
+			isBrokenSymlink: false,
+		});
+		// Non-symlinks never touch the filesystem
+		expect(fs.stat).not.toHaveBeenCalled();
+	});
+
+	it('resolves a symlink that targets a directory', async () => {
+		vi.mocked(fs.stat).mockResolvedValue({
+			isDirectory: () => true,
+			isFile: () => false,
+		} as any);
+
+		const entry = makeDirent({ name: 'linked-folder', isSymlink: true });
+		const result = await resolveDirentType(entry, '/x/linked-folder');
+
+		expect(fs.stat).toHaveBeenCalledWith('/x/linked-folder');
+		expect(result).toEqual({
+			isDirectory: true,
+			isFile: false,
+			isBrokenSymlink: false,
+		});
+	});
+
+	it('resolves a symlink that targets a regular file', async () => {
+		vi.mocked(fs.stat).mockResolvedValue({
+			isDirectory: () => false,
+			isFile: () => true,
+		} as any);
+
+		const entry = makeDirent({ name: 'linked-doc.md', isSymlink: true });
+		const result = await resolveDirentType(entry, '/x/linked-doc.md');
+
+		expect(result).toEqual({
+			isDirectory: false,
+			isFile: true,
+			isBrokenSymlink: false,
+		});
+	});
+
+	it('flags broken symlinks (fs.stat fails) without throwing', async () => {
+		vi.mocked(fs.stat).mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
+
+		const entry = makeDirent({ name: 'broken', isSymlink: true });
+		const result = await resolveDirentType(entry, '/x/broken');
+
+		expect(result).toEqual({
+			isDirectory: false,
+			isFile: false,
+			isBrokenSymlink: true,
+		});
+	});
+});
+
+describe('readDirWithResolvedTypes', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('resolves mixed regular + symlink entries and returns full paths', async () => {
+		// Simulate readdir returning: a directory, a file, a symlink-to-dir, and a broken symlink.
+		const readdirSpy = vi
+			.spyOn(fs, 'readdir')
+			.mockResolvedValue([
+				makeDirent({ name: 'src', isDir: true }),
+				makeDirent({ name: 'readme.md', isFile: true }),
+				makeDirent({ name: 'linked-lib', isSymlink: true }),
+				makeDirent({ name: 'dangling', isSymlink: true }),
+			] as any);
+
+		vi.mocked(fs.stat).mockImplementation((p: any) => {
+			if (p === '/proj/linked-lib') {
+				return Promise.resolve({
+					isDirectory: () => true,
+					isFile: () => false,
+				} as any);
+			}
+			return Promise.reject(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
+		});
+
+		const result = await readDirWithResolvedTypes('/proj');
+
+		expect(readdirSpy).toHaveBeenCalledWith('/proj', { withFileTypes: true });
+		expect(result).toEqual([
+			{
+				name: 'src',
+				fullPath: expect.stringContaining('src'),
+				isDirectory: true,
+				isFile: false,
+				isBrokenSymlink: false,
+			},
+			{
+				name: 'readme.md',
+				fullPath: expect.stringContaining('readme.md'),
+				isDirectory: false,
+				isFile: true,
+				isBrokenSymlink: false,
+			},
+			{
+				name: 'linked-lib',
+				fullPath: expect.stringContaining('linked-lib'),
+				isDirectory: true,
+				isFile: false,
+				isBrokenSymlink: false,
+			},
+			{
+				name: 'dangling',
+				fullPath: expect.stringContaining('dangling'),
+				isDirectory: false,
+				isFile: false,
+				isBrokenSymlink: true,
+			},
+		]);
+	});
+});

--- a/src/__tests__/main/utils/dirent-utils.test.ts
+++ b/src/__tests__/main/utils/dirent-utils.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 vi.mock('fs/promises', () => ({
 	default: {
 		stat: vi.fn(),
+		readdir: vi.fn(),
 	},
 }));
 
@@ -101,14 +102,12 @@ describe('readDirWithResolvedTypes', () => {
 
 	it('resolves mixed regular + symlink entries and returns full paths', async () => {
 		// Simulate readdir returning: a directory, a file, a symlink-to-dir, and a broken symlink.
-		const readdirSpy = vi
-			.spyOn(fs, 'readdir')
-			.mockResolvedValue([
-				makeDirent({ name: 'src', isDir: true }),
-				makeDirent({ name: 'readme.md', isFile: true }),
-				makeDirent({ name: 'linked-lib', isSymlink: true }),
-				makeDirent({ name: 'dangling', isSymlink: true }),
-			] as any);
+		vi.mocked(fs.readdir).mockResolvedValue([
+			makeDirent({ name: 'src', isDir: true }),
+			makeDirent({ name: 'readme.md', isFile: true }),
+			makeDirent({ name: 'linked-lib', isSymlink: true }),
+			makeDirent({ name: 'dangling', isSymlink: true }),
+		] as any);
 
 		vi.mocked(fs.stat).mockImplementation((p: any) => {
 			if (p === '/proj/linked-lib') {
@@ -122,7 +121,7 @@ describe('readDirWithResolvedTypes', () => {
 
 		const result = await readDirWithResolvedTypes('/proj');
 
-		expect(readdirSpy).toHaveBeenCalledWith('/proj', { withFileTypes: true });
+		expect(fs.readdir).toHaveBeenCalledWith('/proj', { withFileTypes: true });
 		expect(result).toEqual([
 			{
 				name: 'src',

--- a/src/__tests__/renderer/components/DocumentGraph/graphDataBuilder.test.ts
+++ b/src/__tests__/renderer/components/DocumentGraph/graphDataBuilder.test.ts
@@ -238,6 +238,44 @@ describe('graphDataBuilder', () => {
 			const uniqueIds = new Set(nodeIds);
 			expect(nodeIds.length).toBe(uniqueIds.size);
 		});
+
+		it('should terminate directory scan when symlink cycle would recurse forever', async () => {
+			// Simulate a cycle: /test always reports a "loop" subdir that resolves
+			// back to /test. Without depth protection this recurses indefinitely.
+			const cyclicReadDir = vi.fn().mockImplementation(async (dirPath: string) => [
+				{
+					name: 'entry.md',
+					isDirectory: false,
+					path: `${dirPath.replace(/\/$/, '')}/entry.md`,
+				},
+				{
+					name: 'loop',
+					isDirectory: true,
+					// Always points back to the root, as a symlink cycle would
+					path: '/test',
+				},
+			]);
+
+			vi.stubGlobal('window', {
+				maestro: {
+					fs: {
+						readDir: cyclicReadDir,
+						readFile: vi.fn().mockResolvedValue('# entry\n'),
+						stat: vi.fn().mockResolvedValue({ size: 10, modifiedAt: '2024-01-01T00:00:00.000Z' }),
+					},
+				},
+			});
+
+			// The call must complete — depth cap prevents runaway recursion
+			const result = await buildGraphData({
+				rootPath: '/test',
+				focusFile: 'entry.md',
+			});
+
+			expect(result.nodes.length).toBeGreaterThan(0);
+			// readDir should be called a bounded number of times (depth cap is 10)
+			expect(cyclicReadDir.mock.calls.length).toBeLessThanOrEqual(12);
+		});
 	});
 
 	describe('cross-directory wiki link resolution', () => {

--- a/src/main/ipc/handlers/autorun.ts
+++ b/src/main/ipc/handlers/autorun.ts
@@ -5,6 +5,7 @@ import chokidar, { FSWatcher } from 'chokidar';
 import Store from 'electron-store';
 import { logger } from '../../utils/logger';
 import { createIpcHandler, CreateHandlerOptions } from '../../utils/ipcHandler';
+import { resolveDirentType } from '../../utils/dirent-utils';
 import { SshRemoteConfig } from '../../../shared/types';
 import { MaestroSettings } from './persistence';
 import { isWebContentsAvailable } from '../../utils/safe-send';
@@ -79,24 +80,16 @@ async function scanDirectory(dirPath: string, relativePath: string = ''): Promis
 	const entries = await fs.readdir(dirPath, { withFileTypes: true });
 	const nodes: TreeNode[] = [];
 
-	// Resolve symlinks: determine actual target type for each entry
+	// Resolve symlinks so symlinked folders/files are classified by target type.
+	// Broken symlinks are skipped (they can't contribute .md files).
 	const resolved = await Promise.all(
 		entries
 			.filter((entry) => !entry.name.startsWith('.'))
 			.map(async (entry) => {
-				let isDir = entry.isDirectory();
-				let isFile = entry.isFile();
-				if (entry.isSymbolicLink()) {
-					try {
-						const targetStat = await fs.stat(path.join(dirPath, entry.name));
-						isDir = targetStat.isDirectory();
-						isFile = targetStat.isFile();
-					} catch {
-						// Broken symlink — skip
-						return null;
-					}
-				}
-				return { name: entry.name, isDir, isFile };
+				const fullPath = path.join(dirPath, entry.name);
+				const type = await resolveDirentType(entry, fullPath);
+				if (type.isBrokenSymlink) return null;
+				return { name: entry.name, isDir: type.isDirectory, isFile: type.isFile };
 			})
 	);
 	const validEntries = resolved.filter((e): e is NonNullable<typeof e> => e !== null);
@@ -239,14 +232,17 @@ async function checkForMarkdownFiles(dirPath: string): Promise<boolean> {
 			continue;
 		}
 
-		if (entry.isFile() && entry.name.toLowerCase().endsWith('.md')) {
+		const fullPath = path.join(dirPath, entry.name);
+		const resolved = await resolveDirentType(entry, fullPath);
+
+		if (resolved.isFile && entry.name.toLowerCase().endsWith('.md')) {
 			// Found a markdown file - return immediately
 			return true;
 		}
 
-		if (entry.isDirectory()) {
-			// Recursively check subdirectory
-			const hasFiles = await checkForMarkdownFiles(path.join(dirPath, entry.name));
+		if (resolved.isDirectory) {
+			// Recursively check subdirectory (follows symlinked folders)
+			const hasFiles = await checkForMarkdownFiles(fullPath);
 			if (hasFiles) {
 				return true;
 			}

--- a/src/main/ipc/handlers/autorun.ts
+++ b/src/main/ipc/handlers/autorun.ts
@@ -79,19 +79,39 @@ async function scanDirectory(dirPath: string, relativePath: string = ''): Promis
 	const entries = await fs.readdir(dirPath, { withFileTypes: true });
 	const nodes: TreeNode[] = [];
 
+	// Resolve symlinks: determine actual target type for each entry
+	const resolved = await Promise.all(
+		entries
+			.filter((entry) => !entry.name.startsWith('.'))
+			.map(async (entry) => {
+				let isDir = entry.isDirectory();
+				let isFile = entry.isFile();
+				if (entry.isSymbolicLink()) {
+					try {
+						const targetStat = await fs.stat(path.join(dirPath, entry.name));
+						isDir = targetStat.isDirectory();
+						isFile = targetStat.isFile();
+					} catch {
+						// Broken symlink — skip
+						return null;
+					}
+				}
+				return { name: entry.name, isDir, isFile };
+			})
+	);
+	const validEntries = resolved.filter((e): e is NonNullable<typeof e> => e !== null);
+
 	// Sort entries: folders first, then files, both alphabetically
-	const sortedEntries = entries
-		.filter((entry) => !entry.name.startsWith('.'))
-		.sort((a, b) => {
-			if (a.isDirectory() && !b.isDirectory()) return -1;
-			if (!a.isDirectory() && b.isDirectory()) return 1;
-			return a.name.toLowerCase().localeCompare(b.name.toLowerCase());
-		});
+	const sortedEntries = validEntries.sort((a, b) => {
+		if (a.isDir && !b.isDir) return -1;
+		if (!a.isDir && b.isDir) return 1;
+		return a.name.toLowerCase().localeCompare(b.name.toLowerCase());
+	});
 
 	for (const entry of sortedEntries) {
 		const entryRelativePath = relativePath ? `${relativePath}/${entry.name}` : entry.name;
 
-		if (entry.isDirectory()) {
+		if (entry.isDir) {
 			// Recursively scan subdirectory
 			const children = await scanDirectory(path.join(dirPath, entry.name), entryRelativePath);
 			// Only include folders that contain .md files (directly or in subfolders)
@@ -103,7 +123,7 @@ async function scanDirectory(dirPath: string, relativePath: string = ''): Promis
 					children,
 				});
 			}
-		} else if (entry.isFile() && entry.name.toLowerCase().endsWith('.md')) {
+		} else if (entry.isFile && entry.name.toLowerCase().endsWith('.md')) {
 			// Add .md file (without extension in name, but keep in path)
 			nodes.push({
 				name: entry.name.slice(0, -3),
@@ -162,7 +182,7 @@ async function scanDirectoryRemote(
 					children,
 				});
 			}
-		} else if (!entry.isDirectory && !entry.isSymlink && entry.name.toLowerCase().endsWith('.md')) {
+		} else if (!entry.isDirectory && entry.name.toLowerCase().endsWith('.md')) {
 			// Add .md file (without extension in name, but keep in path)
 			nodes.push({
 				name: entry.name.slice(0, -3),
@@ -672,8 +692,8 @@ export function registerAutorunHandlers(
 					// Filter files that start with the docName prefix
 					const images = dirResult.data
 						.filter((entry) => {
-							// Only include files (not directories or symlinks)
-							if (entry.isDirectory || entry.isSymlink) {
+							// Only include files (not directories)
+							if (entry.isDirectory) {
 								return false;
 							}
 							// Check if filename starts with docName-
@@ -1206,8 +1226,8 @@ export function registerAutorunHandlers(
 						for (const entry of dirResult.data) {
 							const entryPath = `${dirPath}/${entry.name}`;
 
-							if (entry.isDirectory && !entry.isSymlink) {
-								// Recurse into subdirectory
+							if (entry.isDirectory) {
+								// Recurse into subdirectory (including symlinked dirs)
 								deleted += await deleteBackupsRemoteRecursive(entryPath);
 							} else if (!entry.isDirectory && entry.name.endsWith('.backup.md')) {
 								// Delete backup file

--- a/src/main/ipc/handlers/filesystem.ts
+++ b/src/main/ipc/handlers/filesystem.ts
@@ -102,13 +102,14 @@ export function registerFilesystemHandlers(): void {
 			if (!result.success) {
 				throw new Error(result.error || 'Failed to read remote directory');
 			}
-			// Map remote entries to match local format (isFile derived from !isDirectory && !isSymlink)
+			// Map remote entries to match local format
 			// Include full path for recursive directory scanning (e.g., document graph)
 			// Use POSIX path joining for remote paths (always forward slashes)
+			// Symlinks with isDirectory=true have already been resolved by readDirRemote
 			return result.data!.map((entry) => ({
 				name: entry.name.normalize('NFC'),
 				isDirectory: entry.isDirectory,
-				isFile: !entry.isDirectory && !entry.isSymlink,
+				isFile: !entry.isDirectory,
 				// Preserve raw filesystem name in path for correct remote operations
 				path: dirPath.endsWith('/') ? `${dirPath}${entry.name}` : `${dirPath}/${entry.name}`,
 			}));
@@ -118,13 +119,32 @@ export function registerFilesystemHandlers(): void {
 		const entries = await fs.readdir(dirPath, { withFileTypes: true });
 		// Convert Dirent objects to plain objects for IPC serialization
 		// Include full path for recursive directory scanning (e.g., document graph)
-		return entries.map((entry: any) => ({
-			name: entry.name.normalize('NFC'),
-			isDirectory: entry.isDirectory(),
-			isFile: entry.isFile(),
-			// Preserve raw filesystem name in path for correct local operations
-			path: path.join(dirPath, entry.name),
-		}));
+		// Resolve symlinks via fs.stat() so symlinked dirs/files are properly classified
+		return Promise.all(
+			entries.map(async (entry: any) => {
+				const fullPath = path.join(dirPath, entry.name);
+				let isDirectory = entry.isDirectory();
+				let isFile = entry.isFile();
+
+				if (entry.isSymbolicLink()) {
+					try {
+						const targetStat = await fs.stat(fullPath);
+						isDirectory = targetStat.isDirectory();
+						isFile = targetStat.isFile();
+					} catch {
+						// Broken symlink — treat as file so it still appears
+						isFile = true;
+					}
+				}
+
+				return {
+					name: entry.name.normalize('NFC'),
+					isDirectory,
+					isFile,
+					path: fullPath,
+				};
+			})
+		);
 	});
 
 	// Read file contents (supports SSH remote, with image base64 encoding)

--- a/src/main/ipc/handlers/filesystem.ts
+++ b/src/main/ipc/handlers/filesystem.ts
@@ -32,6 +32,7 @@ import {
 	deleteRemote,
 	countItemsRemote,
 } from '../../utils/remote-fs';
+import { resolveDirentType } from '../../utils/dirent-utils';
 import { getSshRemoteById } from '../../stores';
 
 /**
@@ -121,26 +122,14 @@ export function registerFilesystemHandlers(): void {
 		// Include full path for recursive directory scanning (e.g., document graph)
 		// Resolve symlinks via fs.stat() so symlinked dirs/files are properly classified
 		return Promise.all(
-			entries.map(async (entry: any) => {
+			entries.map(async (entry) => {
 				const fullPath = path.join(dirPath, entry.name);
-				let isDirectory = entry.isDirectory();
-				let isFile = entry.isFile();
-
-				if (entry.isSymbolicLink()) {
-					try {
-						const targetStat = await fs.stat(fullPath);
-						isDirectory = targetStat.isDirectory();
-						isFile = targetStat.isFile();
-					} catch {
-						// Broken symlink — treat as file so it still appears
-						isFile = true;
-					}
-				}
-
+				const resolved = await resolveDirentType(entry, fullPath);
 				return {
 					name: entry.name.normalize('NFC'),
-					isDirectory,
-					isFile,
+					isDirectory: resolved.isDirectory,
+					// Broken symlinks are shown as files so they still appear in the browser
+					isFile: resolved.isFile || resolved.isBrokenSymlink,
 					path: fullPath,
 				};
 			})
@@ -418,19 +407,13 @@ export function registerFilesystemHandlers(): void {
 			const countRecursive = async (dir: string) => {
 				const entries = await fs.readdir(dir, { withFileTypes: true });
 				for (const entry of entries) {
-					let isDir = entry.isDirectory();
-					if (entry.isSymbolicLink()) {
-						try {
-							const targetStat = await fs.stat(path.join(dir, entry.name));
-							isDir = targetStat.isDirectory();
-						} catch {
-							// Broken symlink — count as file
-						}
-					}
-					if (isDir) {
+					const fullPath = path.join(dir, entry.name);
+					const resolved = await resolveDirentType(entry, fullPath);
+					if (resolved.isDirectory) {
 						folderCount++;
-						await countRecursive(path.join(dir, entry.name));
+						await countRecursive(fullPath);
 					} else {
+						// Files, symlinks-to-files, and broken symlinks all count as files
 						fileCount++;
 					}
 				}

--- a/src/main/ipc/handlers/filesystem.ts
+++ b/src/main/ipc/handlers/filesystem.ts
@@ -418,7 +418,16 @@ export function registerFilesystemHandlers(): void {
 			const countRecursive = async (dir: string) => {
 				const entries = await fs.readdir(dir, { withFileTypes: true });
 				for (const entry of entries) {
-					if (entry.isDirectory()) {
+					let isDir = entry.isDirectory();
+					if (entry.isSymbolicLink()) {
+						try {
+							const targetStat = await fs.stat(path.join(dir, entry.name));
+							isDir = targetStat.isDirectory();
+						} catch {
+							// Broken symlink — count as file
+						}
+					}
+					if (isDir) {
 						folderCount++;
 						await countRecursive(path.join(dir, entry.name));
 					} else {

--- a/src/main/utils/dirent-utils.ts
+++ b/src/main/utils/dirent-utils.ts
@@ -1,0 +1,83 @@
+/**
+ * Dirent helpers for working with `fs.readdir({ withFileTypes: true })` entries.
+ *
+ * `Dirent.isDirectory()` and `Dirent.isFile()` return `false` for symbolic links,
+ * so symlinks are silently dropped when callers filter on those flags. These
+ * helpers resolve the link target via `fs.stat()` so symlinks get classified as
+ * the kind of entry they point to.
+ */
+
+import type { Dirent } from 'fs';
+import fs from 'fs/promises';
+import path from 'path';
+
+/**
+ * Resolved type information for a directory entry, with symlinks followed.
+ */
+export interface ResolvedDirentType {
+	/** True if the entry (or its symlink target) is a directory. */
+	isDirectory: boolean;
+	/** True if the entry (or its symlink target) is a regular file. */
+	isFile: boolean;
+	/**
+	 * True if the entry is a symlink whose target could not be stat'd
+	 * (broken link, permission denied, etc.). `isDirectory` and `isFile`
+	 * will both be `false` in this case — callers decide how to present
+	 * broken links (skip, treat as file, treat as error).
+	 */
+	isBrokenSymlink: boolean;
+}
+
+/**
+ * Resolve a Dirent's type, following symlinks so symlinked files/directories
+ * are classified by their target rather than being dropped.
+ *
+ * @param entry A Dirent from `fs.readdir(dir, { withFileTypes: true })`
+ * @param fullPath The absolute path to the entry (needed to stat the target)
+ */
+export async function resolveDirentType(
+	entry: Dirent,
+	fullPath: string
+): Promise<ResolvedDirentType> {
+	if (!entry.isSymbolicLink()) {
+		return {
+			isDirectory: entry.isDirectory(),
+			isFile: entry.isFile(),
+			isBrokenSymlink: false,
+		};
+	}
+
+	try {
+		const targetStat = await fs.stat(fullPath);
+		return {
+			isDirectory: targetStat.isDirectory(),
+			isFile: targetStat.isFile(),
+			isBrokenSymlink: false,
+		};
+	} catch {
+		return {
+			isDirectory: false,
+			isFile: false,
+			isBrokenSymlink: true,
+		};
+	}
+}
+
+/**
+ * Read a directory and return entries with symlink-resolved type info.
+ * Convenience wrapper that combines `fs.readdir` with `resolveDirentType`.
+ *
+ * @param dirPath Directory to read
+ */
+export async function readDirWithResolvedTypes(
+	dirPath: string
+): Promise<Array<ResolvedDirentType & { name: string; fullPath: string }>> {
+	const entries = await fs.readdir(dirPath, { withFileTypes: true });
+	return Promise.all(
+		entries.map(async (entry) => {
+			const fullPath = path.join(dirPath, entry.name);
+			const resolved = await resolveDirentType(entry, fullPath);
+			return { name: entry.name, fullPath, ...resolved };
+		})
+	);
+}

--- a/src/main/utils/remote-fs.ts
+++ b/src/main/utils/remote-fs.ts
@@ -221,11 +221,22 @@ export async function readDirRemote(
 	// A second command identifies symlinks whose targets are directories so
 	// that consumers can recurse into them.  The marker line __SYMDIR__
 	// separates the two outputs.
+	//
+	// Glob patterns used for the symlink scan:
+	//   /*          — non-dotfiles
+	//   /.[!.]*     — dotfiles (one leading dot), excluding the "." entry
+	//   /..?*       — names starting with ".." followed by more chars, excluding ".."
+	// We avoid a plain "/.*" because it matches "." and ".." on most shells.
+	// Unmatched globs are passed literally, but [ -L ] fails on them so nothing
+	// spurious is printed. Errors are redirected to /dev/null regardless.
 	const escapedPath = shellEscape(dirPath);
+	const symlinkScan =
+		`for f in ${escapedPath}/* ${escapedPath}/.[!.]* ${escapedPath}/..?*; ` +
+		`do [ -L "$f" ] && [ -d "$f" ] && basename "$f"; done 2>/dev/null`;
 	const remoteCommand =
 		`ls -1AF --color=never ${escapedPath} 2>/dev/null || echo "__LS_ERROR__"; ` +
 		`echo "__SYMDIR__"; ` +
-		`for f in ${escapedPath}/* ${escapedPath}/.*; do [ -L "$f" ] && [ -d "$f" ] && basename "$f"; done 2>/dev/null`;
+		symlinkScan;
 
 	const result = await execRemoteCommand(sshRemote, remoteCommand, deps);
 

--- a/src/main/utils/remote-fs.ts
+++ b/src/main/utils/remote-fs.ts
@@ -217,8 +217,15 @@ export async function readDirRemote(
 	// -F: Append indicator (/ for dirs, @ for symlinks, * for executables)
 	// --color=never: Disable color codes in output
 	// We avoid -l because parsing long format is complex and locale-dependent
+	//
+	// A second command identifies symlinks whose targets are directories so
+	// that consumers can recurse into them.  The marker line __SYMDIR__
+	// separates the two outputs.
 	const escapedPath = shellEscape(dirPath);
-	const remoteCommand = `ls -1AF --color=never ${escapedPath} 2>/dev/null || echo "__LS_ERROR__"`;
+	const remoteCommand =
+		`ls -1AF --color=never ${escapedPath} 2>/dev/null || echo "__LS_ERROR__"; ` +
+		`echo "__SYMDIR__"; ` +
+		`for f in ${escapedPath}/* ${escapedPath}/.*; do [ -L "$f" ] && [ -d "$f" ] && basename "$f"; done 2>/dev/null`;
 
 	const result = await execRemoteCommand(sshRemote, remoteCommand, deps);
 
@@ -229,8 +236,13 @@ export async function readDirRemote(
 		};
 	}
 
+	// Split output at the marker to separate ls output from symlink-dir list
+	const parts = result.stdout.split('__SYMDIR__');
+	const lsOutput = parts[0].trim();
+	const symlinkDirNames = new Set((parts[1] || '').trim().split('\n').filter(Boolean));
+
 	// Check for our error marker
-	if (result.stdout.trim() === '__LS_ERROR__') {
+	if (lsOutput === '__LS_ERROR__') {
 		return {
 			success: false,
 			error: `Directory not found or not accessible: ${dirPath}`,
@@ -238,7 +250,7 @@ export async function readDirRemote(
 	}
 
 	const entries: RemoteDirEntry[] = [];
-	const lines = result.stdout.trim().split('\n').filter(Boolean);
+	const lines = lsOutput.split('\n').filter(Boolean);
 
 	for (const line of lines) {
 		if (!line || line === '__LS_ERROR__') continue;
@@ -254,6 +266,10 @@ export async function readDirRemote(
 		} else if (name.endsWith('@')) {
 			name = name.slice(0, -1);
 			isSymlink = true;
+			// Resolve symlink: if the target is a directory, mark it as such
+			if (symlinkDirNames.has(name)) {
+				isDirectory = true;
+			}
 		} else if (name.endsWith('*')) {
 			// Executable file - remove the indicator
 			name = name.slice(0, -1);

--- a/src/renderer/components/DocumentGraph/graphDataBuilder.ts
+++ b/src/renderer/components/DocumentGraph/graphDataBuilder.ts
@@ -318,6 +318,13 @@ interface LinkIndexEntry {
 }
 
 /**
+ * Maximum directory-scan depth. Matches `loadFileTree` in fileExplorer.ts and
+ * guards against infinite recursion through symlink cycles (e.g. `a/link → a`),
+ * which can occur once `fs:readDir` resolves symlinked dirs as directories.
+ */
+const SCAN_MAX_DEPTH = 10;
+
+/**
  * Recursively scan a directory for all markdown files.
  * @param rootPath - Root directory to scan
  * @param onProgress - Optional callback for progress updates (reports number of directories scanned)
@@ -333,9 +340,17 @@ async function scanMarkdownFiles(
 	let directoriesScanned = 0;
 	let isRootDirectory = true;
 
-	async function scanDir(currentPath: string, relativePath: string): Promise<void> {
+	async function scanDir(currentPath: string, relativePath: string, depth: number): Promise<void> {
 		const isRoot = isRootDirectory;
 		isRootDirectory = false;
+
+		if (depth >= SCAN_MAX_DEPTH) {
+			// Bail out rather than risk an infinite loop through a symlink cycle.
+			console.warn(
+				`scanMarkdownFiles: reached max depth ${SCAN_MAX_DEPTH} at ${currentPath}; stopping recursion`
+			);
+			return;
+		}
 
 		try {
 			const entries = await window.maestro.fs.readDir(currentPath, sshRemoteId);
@@ -363,7 +378,7 @@ async function scanMarkdownFiles(
 				const entryRelativePath = relativePath ? `${relativePath}/${entry.name}` : entry.name;
 
 				if (entry.isDirectory) {
-					await scanDir(fullPath, entryRelativePath);
+					await scanDir(fullPath, entryRelativePath, depth + 1);
 				} else if (entry.name.toLowerCase().endsWith('.md')) {
 					markdownFiles.push(entryRelativePath);
 				}
@@ -380,7 +395,7 @@ async function scanMarkdownFiles(
 		}
 	}
 
-	await scanDir(rootPath, '');
+	await scanDir(rootPath, '', 0);
 	return markdownFiles;
 }
 


### PR DESCRIPTION
## Summary

- Symlinked subdirectories and files are now correctly resolved in the Files panel (Right Bar) and Auto Run document tree
- `Dirent.isDirectory()`/`isFile()` return `false` for symlinks — we now check `isSymbolicLink()` and follow with `fs.stat()` to determine the actual target type
- Remote (SSH) path: augmented the `ls -1AF` command in `readDirRemote` to also identify symlinks whose targets are directories, so they can be recursed into
- Removed overly-strict `!entry.isSymlink` guards in Auto Run that excluded symlinked `.md` files and prevented recursion into symlinked directories
- Fixed `fs:countItems` to also follow symlinks when counting items recursively

Closes #829

## Test plan

- [ ] Create a symlinked subdirectory inside a project (`ln -s /some/path ./project/linked-dir`)
- [ ] Open Maestro → Right Bar → Files tab: verify `linked-dir` appears and is expandable
- [ ] Place `.md` files inside the symlinked directory
- [ ] Set the project as an Auto Run folder: verify documents inside the symlinked directory are discovered
- [ ] Verify broken symlinks don't crash the file listing (should appear as files or be skipped)
- [ ] Verify existing tests pass (22,451 tests passing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved symbolic-link handling across directory scans, listings, image discovery, counting, and backup removal — symlinked files and folders are now resolved, recursed into when appropriate, and broken symlinks are gracefully skipped; markdown and image detection now include valid symlinked files. Added recursion depth protection to avoid infinite loops from directory cycles.

* **Tests**
  * Added and updated tests for symlink resolution, broken-symlink behavior, recursion, and cycle protection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->