### PR TITLE
refactor: migrate to canonical shared hooks (Phase 09)

### DIFF
--- a/src/renderer/components/MarketplaceModal.tsx
+++ b/src/renderer/components/MarketplaceModal.tsx
@@ -28,6 +28,7 @@ import type { MarketplacePlaybook } from '../../shared/marketplace-types';
 import { useLayerStack } from '../contexts/LayerStackContext';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
 import { useMarketplace } from '../hooks/batch/useMarketplace';
+import { useEventListener } from '../hooks/utils/useEventListener';
 import {
 	REMARK_GFM_PLUGINS,
 	generateProseStyles,
@@ -246,43 +247,39 @@ function PlaybookDetailView({
 
 	// Keyboard shortcuts for scrolling the document preview
 	// OPT+Up/Down: page up/down, CMD+Up/Down: home/end
-	useEffect(() => {
-		const handleKeyDown = (e: KeyboardEvent) => {
-			const scrollContainer = previewScrollRef.current;
-			if (!scrollContainer) return;
+	useEventListener('keydown', (event: Event) => {
+		const e = event as KeyboardEvent;
+		const scrollContainer = previewScrollRef.current;
+		if (!scrollContainer) return;
 
-			// Don't handle if typing in an input
-			if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) {
-				return;
+		// Don't handle if typing in an input
+		if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) {
+			return;
+		}
+
+		const pageHeight = scrollContainer.clientHeight * 0.9; // 90% of visible height
+
+		// CMD+Up/Down: Home/End
+		if (e.metaKey && !e.altKey && !e.shiftKey) {
+			if (e.key === 'ArrowUp') {
+				e.preventDefault();
+				scrollContainer.scrollTo({ top: 0, behavior: 'smooth' });
+			} else if (e.key === 'ArrowDown') {
+				e.preventDefault();
+				scrollContainer.scrollTo({ top: scrollContainer.scrollHeight, behavior: 'smooth' });
 			}
-
-			const pageHeight = scrollContainer.clientHeight * 0.9; // 90% of visible height
-
-			// CMD+Up/Down: Home/End
-			if (e.metaKey && !e.altKey && !e.shiftKey) {
-				if (e.key === 'ArrowUp') {
-					e.preventDefault();
-					scrollContainer.scrollTo({ top: 0, behavior: 'smooth' });
-				} else if (e.key === 'ArrowDown') {
-					e.preventDefault();
-					scrollContainer.scrollTo({ top: scrollContainer.scrollHeight, behavior: 'smooth' });
-				}
+		}
+		// OPT+Up/Down: Page up/down
+		else if (e.altKey && !e.metaKey && !e.shiftKey) {
+			if (e.key === 'ArrowUp') {
+				e.preventDefault();
+				scrollContainer.scrollBy({ top: -pageHeight, behavior: 'smooth' });
+			} else if (e.key === 'ArrowDown') {
+				e.preventDefault();
+				scrollContainer.scrollBy({ top: pageHeight, behavior: 'smooth' });
 			}
-			// OPT+Up/Down: Page up/down
-			else if (e.altKey && !e.metaKey && !e.shiftKey) {
-				if (e.key === 'ArrowUp') {
-					e.preventDefault();
-					scrollContainer.scrollBy({ top: -pageHeight, behavior: 'smooth' });
-				} else if (e.key === 'ArrowDown') {
-					e.preventDefault();
-					scrollContainer.scrollBy({ top: pageHeight, behavior: 'smooth' });
-				}
-			}
-		};
-
-		window.addEventListener('keydown', handleKeyDown);
-		return () => window.removeEventListener('keydown', handleKeyDown);
-	}, []);
+		}
+	});
 
 	// Generate prose styles scoped to marketplace panel
 	const proseStyles = useMemo(

--- a/src/renderer/components/SessionList/SessionList.tsx
+++ b/src/renderer/components/SessionList/SessionList.tsx
@@ -38,6 +38,7 @@ import { useSessionCategories } from '../../hooks/session/useSessionCategories';
 import { useSessionFilterMode } from '../../hooks/session/useSessionFilterMode';
 import { cueService } from '../../services/cue';
 import { captureException } from '../../utils/sentry';
+import { useEventListener } from '../../hooks/utils/useEventListener';
 
 // ============================================================================
 // SessionContextMenu - Right-click context menu for session items
@@ -411,26 +412,21 @@ function SessionListInner(props: SessionListProps) {
 	}, [liveOverlayOpen, menuOpen]);
 
 	// Listen for tour UI actions to control hamburger menu state
-	useEffect(() => {
-		const handleTourAction = (event: Event) => {
-			const customEvent = event as CustomEvent<{ type: string; value?: string }>;
-			const { type } = customEvent.detail;
+	useEventListener('tour:action', (event: Event) => {
+		const customEvent = event as CustomEvent<{ type: string; value?: string }>;
+		const { type } = customEvent.detail;
 
-			switch (type) {
-				case 'openHamburgerMenu':
-					setMenuOpen(true);
-					break;
-				case 'closeHamburgerMenu':
-					setMenuOpen(false);
-					break;
-				default:
-					break;
-			}
-		};
-
-		window.addEventListener('tour:action', handleTourAction);
-		return () => window.removeEventListener('tour:action', handleTourAction);
-	}, []);
+		switch (type) {
+			case 'openHamburgerMenu':
+				setMenuOpen(true);
+				break;
+			case 'closeHamburgerMenu':
+				setMenuOpen(false);
+				break;
+			default:
+				break;
+		}
+	});
 
 	// Get git file change counts per session from focused context
 	// Using useGitFileStatus instead of full useGitStatus reduces re-renders

--- a/src/renderer/hooks/session/useHandsOnTimeTracker.ts
+++ b/src/renderer/hooks/session/useHandsOnTimeTracker.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useCallback } from 'react';
 import { subscribeToActivity } from '../../utils/activityBus';
+import { useEventListener } from '../utils/useEventListener';
 
 const ACTIVITY_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes of inactivity = idle
 const TICK_INTERVAL_MS = 1000; // Update every second
@@ -121,20 +122,12 @@ export function useHandsOnTimeTracker(addTotalActiveTimeMs: (delta: number) => v
 	}, [stopInterval, persistAccumulatedTime]);
 
 	// Persist on beforeunload (app closing)
-	useEffect(() => {
-		const handleBeforeUnload = () => {
-			// Synchronous - can't use async here
-			if (accumulatedTimeRef.current > 0) {
-				const timeToAdd = accumulatedTimeRef.current;
-				accumulatedTimeRef.current = 0;
-				addTotalActiveTimeMsRef.current(timeToAdd);
-			}
-		};
-
-		window.addEventListener('beforeunload', handleBeforeUnload);
-
-		return () => {
-			window.removeEventListener('beforeunload', handleBeforeUnload);
-		};
-	}, []);
+	useEventListener('beforeunload', () => {
+		// Synchronous - can't use async here
+		if (accumulatedTimeRef.current > 0) {
+			const timeToAdd = accumulatedTimeRef.current;
+			accumulatedTimeRef.current = 0;
+			addTotalActiveTimeMsRef.current(timeToAdd);
+		}
+	});
 }

--- a/src/renderer/hooks/ui/useTourActions.ts
+++ b/src/renderer/hooks/ui/useTourActions.ts
@@ -11,11 +11,11 @@
  * Reads from: sessionStore (active session), tabStore (selectTab)
  */
 
-import { useEffect } from 'react';
 import type { RightPanelTab } from '../../types';
 import { useUIStore } from '../../stores/uiStore';
 import { selectActiveSession, useSessionStore } from '../../stores/sessionStore';
 import { useTabStore } from '../../stores/tabStore';
+import { useEventListener } from '../utils/useEventListener';
 
 // ============================================================================
 // Hook implementation
@@ -25,51 +25,46 @@ export function useTourActions(): void {
 	// --- Store actions (stable via getState) ---
 	const { setActiveRightTab, setRightPanelOpen } = useUIStore.getState();
 
-	useEffect(() => {
-		const handleTourAction = (event: Event) => {
-			const customEvent = event as CustomEvent<{
-				type: string;
-				value?: string;
-			}>;
-			const { type, value } = customEvent.detail;
+	useEventListener('tour:action', (event: Event) => {
+		const customEvent = event as CustomEvent<{
+			type: string;
+			value?: string;
+		}>;
+		const { type, value } = customEvent.detail;
 
-			switch (type) {
-				case 'setRightTab':
-					if (value === 'files' || value === 'history' || value === 'autorun') {
-						setActiveRightTab(value as RightPanelTab);
-					}
-					break;
-				case 'openRightPanel':
-					setRightPanelOpen(true);
-					break;
-				case 'closeRightPanel':
-					setRightPanelOpen(false);
-					break;
-				case 'ensureAiTab': {
-					const session = selectActiveSession(useSessionStore.getState());
-					if (!session) break;
-					// Already on an AI tab in AI mode — nothing to do
-					if (
-						session.inputMode === 'ai' &&
-						!session.activeBrowserTabId &&
-						!session.activeTerminalTabId
-					) {
-						break;
-					}
-					// Switch to the current AI tab (or first available)
-					const targetTabId = session.activeTabId || session.aiTabs?.[0]?.id;
-					if (targetTabId) {
-						useTabStore.getState().selectTab(targetTabId);
-					}
+		switch (type) {
+			case 'setRightTab':
+				if (value === 'files' || value === 'history' || value === 'autorun') {
+					setActiveRightTab(value as RightPanelTab);
+				}
+				break;
+			case 'openRightPanel':
+				setRightPanelOpen(true);
+				break;
+			case 'closeRightPanel':
+				setRightPanelOpen(false);
+				break;
+			case 'ensureAiTab': {
+				const session = selectActiveSession(useSessionStore.getState());
+				if (!session) break;
+				// Already on an AI tab in AI mode - nothing to do
+				if (
+					session.inputMode === 'ai' &&
+					!session.activeBrowserTabId &&
+					!session.activeTerminalTabId
+				) {
 					break;
 				}
-				// hamburger menu actions are handled by SessionList.tsx
-				default:
-					break;
+				// Switch to the current AI tab (or first available)
+				const targetTabId = session.activeTabId || session.aiTabs?.[0]?.id;
+				if (targetTabId) {
+					useTabStore.getState().selectTab(targetTabId);
+				}
+				break;
 			}
-		};
-
-		window.addEventListener('tour:action', handleTourAction);
-		return () => window.removeEventListener('tour:action', handleTourAction);
-	}, []);
+			// hamburger menu actions are handled by SessionList.tsx
+			default:
+				break;
+		}
+	});
 }


### PR DESCRIPTION
## Summary

Migrates a conservative subset of hook patterns to canonical shared hooks. **This phase is intentionally narrow** - most call sites had semantic subtleties that would have caused regressions if blindly replaced.

**Net: -19 lines across 4 files**

### 09A - useEventListener migrations (4 sites)

Replaced raw `addEventListener` / `removeEventListener` pairs with the canonical `useEventListener` hook from `src/renderer/hooks/utils/useEventListener.ts`:

- `useTourActions.ts` - `tour:action` event
- `SessionList.tsx` - `tour:action` event
- `useHandsOnTimeTracker.ts` - `beforeunload` event
- `MarketplaceModal.tsx` - `keydown` event in PlaybookDetailView

### 09A - useFocusAfterRender migrations (0 sites)

**Intentionally zero** - the canonical hook uses `useLayoutEffect` with NO dep array and re-runs every render while its `condition` is true. Replacing the common `useEffect(() => { setTimeout(() => ref.current?.focus(), 50); }, [])` pattern would cause the focus to be re-stolen on every subsequent render, breaking the app.

### 09B - (0 sites migrated)

**`useActiveSession()` semantic gap**: `selectActiveSession` falls back to `state.sessions[0]` when there's no active session; inline `sessions.find` returns `undefined`. Blindly migrating would surface stale-session data instead of the "no active session" branch.

**Debounce/throttle misfits**: Every hand-rolled debounce/throttle has a reason the canonical hook doesn't fit.

Supersedes #823 (accidentally closed during rebase).

## Test plan

- [ ] `npm run lint` passes (all 3 tsconfigs)
- [ ] `npx prettier --check .` passes
- [ ] Tour events still fire
- [ ] Marketplace playbook detail keyboard shortcuts work
- [ ] beforeunload handler fires (active-time tracking)

## Risk

**Very low**. 4 behavior-preserving migrations, no component changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized event listener handling across the app (preview keyboard shortcuts, tour actions, session menu toggles, and session time tracking). Behavior is unchanged; no visible impact to users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
