### PR TITLE
feat: add CLI trigger sourceAgentId, cli_output pipeline node, and cue list command

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -555,6 +555,58 @@ maestro-cli status
 
 Returns the app version, uptime, and connection status.
 
+## Cue Automation
+
+Interact with Maestro Cue subscriptions directly from the command line.
+
+### Listing Subscriptions
+
+List all Cue subscriptions across all agents:
+
+```bash
+maestro-cli cue list
+
+# JSON output (for scripting)
+maestro-cli cue list --json
+```
+
+Shows each subscription's name, event type, agent, enabled status, and last trigger time.
+
+### Triggering a Subscription
+
+Manually trigger a Cue subscription by name, bypassing its normal event conditions:
+
+```bash
+# Trigger a subscription
+maestro-cli cue trigger <subscription-name>
+
+# Trigger with a custom prompt (overrides the configured prompt)
+maestro-cli cue trigger <subscription-name> --prompt "Deploy to staging only"
+
+# JSON output (for scripting)
+maestro-cli cue trigger <subscription-name> --json
+```
+
+| Flag                  | Description                                          |
+| --------------------- | ---------------------------------------------------- |
+| `-p, --prompt <text>` | Override the subscription's configured prompt        |
+| `--json`              | Output as JSON (for scripting and CI/CD integration) |
+
+The `--prompt` flag is especially useful for `cli.trigger` subscriptions, where the prompt text is available in the subscription's template as `{{CUE_CLI_PROMPT}}`.
+
+**Examples:**
+
+```bash
+# Trigger a review pipeline after finishing work
+maestro-cli cue trigger "code-review" --prompt "Review the changes in the auth module"
+
+# Trigger a deploy from CI
+maestro-cli cue trigger "deploy" --prompt "Deploy commit abc123 to production" --json
+
+# Re-run a failed automation
+maestro-cli cue trigger "lint-on-save"
+```
+
 ## Scheduling with Cron
 
 ```bash
@@ -576,6 +628,7 @@ This means agents can:
 - **Refresh the file tree** after creating or modifying files
 - **Configure and launch auto-runs** with documents they create
 - **Send messages** to other agents for inter-agent coordination
+- **Discover Cue subscriptions** with `cue list` and **trigger automation pipelines** with `cue trigger`
 
 When a user asks an agent to change a Maestro setting, the agent can use the CLI directly rather than instructing the user to navigate the settings modal. Changes take effect instantly.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -587,10 +587,11 @@ maestro-cli cue trigger <subscription-name> --prompt "Deploy to staging only"
 maestro-cli cue trigger <subscription-name> --json
 ```
 
-| Flag                  | Description                                          |
-| --------------------- | ---------------------------------------------------- |
-| `-p, --prompt <text>` | Override the subscription's configured prompt        |
-| `--json`              | Output as JSON (for scripting and CI/CD integration) |
+| Flag                     | Description                                                          |
+| ------------------------ | -------------------------------------------------------------------- |
+| `-p, --prompt <text>`    | Override the subscription's configured prompt                        |
+| `--source-agent-id <id>` | Identify the originating agent (populates `{{CUE_SOURCE_AGENT_ID}}`) |
+| `--json`                 | Output as JSON (for scripting and CI/CD integration)                 |
 
 The `--prompt` flag is especially useful for `cli.trigger` subscriptions, where the prompt text is available in the subscription's template as `{{CUE_CLI_PROMPT}}`.
 

--- a/docs/maestro-cue-configuration.md
+++ b/docs/maestro-cue-configuration.md
@@ -65,7 +65,7 @@ Each subscription is a trigger-prompt pairing. When the trigger fires, Cue sends
 | Field    | Type   | Description                                                                   |
 | -------- | ------ | ----------------------------------------------------------------------------- |
 | `name`   | string | Unique identifier. Used in logs, history, and as a reference in chains        |
-| `event`  | string | One of the eight [event types](./maestro-cue-events)                          |
+| `event`  | string | One of the nine [event types](./maestro-cue-events)                           |
 | `prompt` | string | The prompt to send as inline text. Required unless `prompt_file` is specified |
 
 <Note>

--- a/docs/maestro-cue-configuration.md
+++ b/docs/maestro-cue-configuration.md
@@ -268,7 +268,7 @@ The engine validates your YAML on every load. Common validation errors:
 | Error                                   | Fix                                                          |
 | --------------------------------------- | ------------------------------------------------------------ |
 | `"name" is required`                    | Every subscription needs a unique `name` field               |
-| `"event" is required`                   | Specify one of the eight event types                         |
+| `"event" is required`                   | Specify one of the nine event types                          |
 | `"prompt" is required`                  | Provide inline text or a file path                           |
 | `"interval_minutes" is required`        | `time.heartbeat` events must specify a positive interval     |
 | `"schedule_times" is required`          | `time.scheduled` events must have at least one `HH:MM` time  |

--- a/docs/maestro-cue-events.md
+++ b/docs/maestro-cue-events.md
@@ -412,3 +412,59 @@ Same as `github.pull_request`, except:
 | `{{CUE_GH_ASSIGNEES}}` | Comma-separated assignee logins | `alice, bob` |
 
 The branch-specific variables (`{{CUE_GH_BRANCH}}`, `{{CUE_GH_BASE_BRANCH}}`) are not available for issues.
+
+---
+
+## cli.trigger
+
+Fires only when explicitly triggered from the command line via `maestro-cli cue trigger <name>`. Unlike other event types, `cli.trigger` has no background watcher or poller — it waits for a manual invocation.
+
+**No additional fields required** — just `name`, `event`, `prompt`, and optionally `enabled`.
+
+**Behavior:**
+
+- Does nothing on its own — only fires when you run `maestro-cli cue trigger <subscription-name>`
+- Supports an optional `--prompt` flag to override or supply the prompt at invocation time
+- The override text is available in the prompt template as `{{CUE_CLI_PROMPT}}`
+- Ideal for deployment scripts, CI/CD integration, on-demand reviews, or ad-hoc automation
+
+**Example:**
+
+```yaml
+subscriptions:
+  - name: deploy
+    event: cli.trigger
+    prompt: |
+      Run the deployment pipeline for the current branch.
+
+      Additional instructions: {{CUE_CLI_PROMPT}}
+    enabled: true
+```
+
+**Triggering from the command line:**
+
+```bash
+# Basic trigger — uses the configured prompt as-is
+maestro-cli cue trigger deploy
+
+# With a prompt override — {{CUE_CLI_PROMPT}} receives this text
+maestro-cli cue trigger deploy --prompt "Deploy to staging only"
+
+# JSON output for scripting
+maestro-cli cue trigger deploy --json
+```
+
+**Discovering available subscriptions:**
+
+```bash
+# List all subscriptions across agents
+maestro-cli cue list
+```
+
+**Payload fields:**
+
+| Variable               | Description                                 | Example             |
+| ---------------------- | ------------------------------------------- | ------------------- |
+| `{{CUE_CLI_PROMPT}}`   | Prompt text passed via `--prompt` flag      | `Deploy to staging` |
+| `{{CUE_TRIGGER_NAME}}` | Name of the subscription that was triggered | `deploy`            |
+| `{{CUE_EVENT_TYPE}}`   | Always `cli.trigger`                        | `cli.trigger`       |

--- a/docs/maestro-cue-events.md
+++ b/docs/maestro-cue-events.md
@@ -1,10 +1,10 @@
 ---
 title: Cue Event Types
-description: Detailed reference for all eight Maestro Cue event types with configuration, payloads, and examples.
+description: Detailed reference for all nine Maestro Cue event types with configuration, payloads, and examples.
 icon: calendar-check
 ---
 
-Cue supports eight event types. Each type watches for a different kind of activity and produces a payload that can be injected into prompts via [template variables](./maestro-cue-advanced#template-variables).
+Cue supports nine event types. Each type watches for a different kind of activity and produces a payload that can be injected into prompts via [template variables](./maestro-cue-advanced#template-variables).
 
 ## app.startup
 

--- a/docs/maestro-cue-examples.md
+++ b/docs/maestro-cue-examples.md
@@ -538,3 +538,86 @@ subscriptions:
       If the output says "NO_ACTIVITY", respond with "Nothing to summarize."
       Otherwise, create a concise executive summary of the development activity.
 ```
+
+---
+
+## CLI-Triggered Code Review
+
+Set up an on-demand code review that agents or CI can trigger from the command line.
+
+**Agents needed:** `reviewer`
+
+The `reviewer` agent's `.maestro/cue.yaml`:
+
+```yaml
+subscriptions:
+  - name: code-review
+    event: cli.trigger
+    label: Code Review
+    prompt: |
+      Review the current git diff and provide feedback.
+
+      {{CUE_CLI_PROMPT}}
+
+      Steps:
+      1. Run `git diff` to see the changes
+      2. Check for correctness, security issues, and style
+      3. Summarize what changed and flag any concerns
+    enabled: true
+```
+
+**Triggering:**
+
+```bash
+# Basic review using the configured prompt
+maestro-cli cue trigger code-review
+
+# Review with specific focus
+maestro-cli cue trigger code-review --prompt "Focus on the auth module changes"
+```
+
+---
+
+## CI/CD Deploy Pipeline
+
+Trigger a deploy from CI or scripts, passing the environment as the prompt.
+
+**Agents needed:** `deployer`
+
+The `deployer` agent's `.maestro/cue.yaml`:
+
+```yaml
+subscriptions:
+  - name: deploy
+    event: cli.trigger
+    label: Deploy
+    prompt: |
+      Deploy the current branch.
+      Target: {{CUE_CLI_PROMPT}}
+
+      1. Run the test suite
+      2. Build the project
+      3. Deploy to the specified environment
+      4. Verify the deployment is healthy
+    enabled: true
+
+  - name: post-deploy-verify
+    event: agent.completed
+    source_session: 'deployer'
+    filter:
+      triggeredBy: 'deploy'
+      status: completed
+    prompt: |
+      The deploy just finished. Run smoke tests and verify the deployment is healthy.
+      Report any issues immediately.
+```
+
+**Triggering from CI:**
+
+```bash
+# From a CI pipeline
+maestro-cli cue trigger deploy --prompt "staging" --json
+
+# From a release script
+maestro-cli cue trigger deploy --prompt "production"
+```

--- a/docs/maestro-cue.md
+++ b/docs/maestro-cue.md
@@ -20,6 +20,7 @@ A few examples of what you can automate with Cue:
 - **Triage new GitHub PRs** — poll for new pull requests and prompt an agent to review the diff
 - **Track TODO progress** — scan markdown files for unchecked tasks and prompt an agent to work on the next one
 - **Fan out deployments** — when a build completes, trigger multiple deploy agents simultaneously
+- **Trigger from the CLI** — run `maestro-cli cue trigger` to fire a subscription on demand from scripts, CI/CD, or other agents
 
 ## Enabling Cue
 
@@ -139,7 +140,7 @@ Cue is configured via a `.maestro/cue.yaml` file placed inside the `.maestro/` d
 
 ## Event Types
 
-Cue supports eight event types that trigger subscriptions:
+Cue supports nine event types that trigger subscriptions:
 
 | Event Type            | Trigger                             | Key Fields                        |
 | --------------------- | ----------------------------------- | --------------------------------- |
@@ -151,6 +152,7 @@ Cue supports eight event types that trigger subscriptions:
 | `task.pending`        | Unchecked markdown tasks found      | `watch` (glob pattern)            |
 | `github.pull_request` | New PR opened on GitHub             | `repo` (optional)                 |
 | `github.issue`        | New issue opened on GitHub          | `repo` (optional)                 |
+| `cli.trigger`         | Manual trigger via `maestro-cli`    | —                                 |
 
 See [Event Types](./maestro-cue-events) for detailed documentation and examples for each type.
 
@@ -203,6 +205,7 @@ Filter by CUE entries in the History panel or in Director's Notes (when both Enc
 
 - **GitHub CLI (`gh`)** — Required only for `github.pull_request` and `github.issue` events. Must be installed and authenticated (`gh auth login`).
 - **File watching** — `file.changed` and `task.pending` events use filesystem watchers. No additional dependencies required.
+- **CLI triggers** — `cli.trigger` events require `maestro-cli` to be installed. See the [CLI documentation](./cli#cue-automation) for setup.
 
 ## Tips
 

--- a/src/__tests__/cli/commands/cue-trigger.test.ts
+++ b/src/__tests__/cli/commands/cue-trigger.test.ts
@@ -1,0 +1,200 @@
+/**
+ * @file cue-trigger.test.ts
+ * @description Tests for the cue-trigger CLI command
+ *
+ * Tests the cue-trigger command's sourceAgentId handling:
+ * - sourceAgentId is included in the WebSocket message payload
+ * - sourceAgentId is included in JSON output when --json is set
+ * - sourceAgentId is omitted from JSON output when not provided
+ */
+
+import { describe, it, expect, vi, beforeEach, type MockInstance } from 'vitest';
+
+// Mock maestro-client
+vi.mock('../../../cli/services/maestro-client', () => ({
+	withMaestroClient: vi.fn(),
+}));
+
+import { cueTrigger } from '../../../cli/commands/cue-trigger';
+import { withMaestroClient } from '../../../cli/services/maestro-client';
+
+describe('cueTrigger command', () => {
+	let consoleSpy: MockInstance;
+	let consoleErrorSpy: MockInstance;
+	let processExitSpy: MockInstance;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+		consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+		processExitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+	});
+
+	describe('sourceAgentId in WebSocket message', () => {
+		it('should include sourceAgentId in the WebSocket command payload', async () => {
+			let capturedMessage: Record<string, unknown> | undefined;
+			vi.mocked(withMaestroClient).mockImplementation(async (fn) => {
+				const mockClient = {
+					sendCommand: vi.fn().mockImplementation((msg: Record<string, unknown>) => {
+						capturedMessage = msg;
+						return {
+							type: 'trigger_cue_subscription_result',
+							success: true,
+							subscriptionName: 'my-sub',
+						};
+					}),
+				};
+				return fn(mockClient as any);
+			});
+
+			await cueTrigger('my-sub', { sourceAgentId: 'agent-xyz-123' });
+
+			expect(capturedMessage).toBeDefined();
+			expect(capturedMessage!.type).toBe('trigger_cue_subscription');
+			expect(capturedMessage!.subscriptionName).toBe('my-sub');
+			expect(capturedMessage!.sourceAgentId).toBe('agent-xyz-123');
+		});
+
+		it('should include prompt alongside sourceAgentId in WebSocket payload', async () => {
+			let capturedMessage: Record<string, unknown> | undefined;
+			vi.mocked(withMaestroClient).mockImplementation(async (fn) => {
+				const mockClient = {
+					sendCommand: vi.fn().mockImplementation((msg: Record<string, unknown>) => {
+						capturedMessage = msg;
+						return {
+							type: 'trigger_cue_subscription_result',
+							success: true,
+							subscriptionName: 'my-sub',
+						};
+					}),
+				};
+				return fn(mockClient as any);
+			});
+
+			await cueTrigger('my-sub', { prompt: 'custom prompt', sourceAgentId: 'agent-abc' });
+
+			expect(capturedMessage!.prompt).toBe('custom prompt');
+			expect(capturedMessage!.sourceAgentId).toBe('agent-abc');
+		});
+
+		it('should send undefined sourceAgentId when not provided', async () => {
+			let capturedMessage: Record<string, unknown> | undefined;
+			vi.mocked(withMaestroClient).mockImplementation(async (fn) => {
+				const mockClient = {
+					sendCommand: vi.fn().mockImplementation((msg: Record<string, unknown>) => {
+						capturedMessage = msg;
+						return {
+							type: 'trigger_cue_subscription_result',
+							success: true,
+							subscriptionName: 'my-sub',
+						};
+					}),
+				};
+				return fn(mockClient as any);
+			});
+
+			await cueTrigger('my-sub', {});
+
+			expect(capturedMessage!.sourceAgentId).toBeUndefined();
+		});
+	});
+
+	describe('sourceAgentId in JSON output', () => {
+		it('should include sourceAgentId in JSON output when --json and --source-agent-id are set', async () => {
+			vi.mocked(withMaestroClient).mockImplementation(async (fn) => {
+				const mockClient = {
+					sendCommand: vi.fn().mockResolvedValue({
+						type: 'trigger_cue_subscription_result',
+						success: true,
+						subscriptionName: 'my-sub',
+					}),
+				};
+				return fn(mockClient as any);
+			});
+
+			await cueTrigger('my-sub', { json: true, sourceAgentId: 'agent-xyz-123' });
+
+			expect(consoleSpy).toHaveBeenCalledTimes(1);
+			const output = JSON.parse(consoleSpy.mock.calls[0][0]);
+			expect(output.type).toBe('trigger_result');
+			expect(output.success).toBe(true);
+			expect(output.subscriptionName).toBe('my-sub');
+			expect(output.sourceAgentId).toBe('agent-xyz-123');
+		});
+
+		it('should omit sourceAgentId from JSON output when not provided', async () => {
+			vi.mocked(withMaestroClient).mockImplementation(async (fn) => {
+				const mockClient = {
+					sendCommand: vi.fn().mockResolvedValue({
+						type: 'trigger_cue_subscription_result',
+						success: true,
+						subscriptionName: 'my-sub',
+					}),
+				};
+				return fn(mockClient as any);
+			});
+
+			await cueTrigger('my-sub', { json: true });
+
+			const output = JSON.parse(consoleSpy.mock.calls[0][0]);
+			expect(output).not.toHaveProperty('sourceAgentId');
+		});
+
+		it('should include sourceAgentId in error JSON output on failure', async () => {
+			vi.mocked(withMaestroClient).mockImplementation(async (fn) => {
+				const mockClient = {
+					sendCommand: vi.fn().mockResolvedValue({
+						type: 'trigger_cue_subscription_result',
+						success: false,
+						subscriptionName: 'my-sub',
+						error: 'Subscription not found',
+					}),
+				};
+				return fn(mockClient as any);
+			});
+
+			await cueTrigger('my-sub', { json: true, sourceAgentId: 'agent-abc' });
+
+			const output = JSON.parse(consoleSpy.mock.calls[0][0]);
+			expect(output.success).toBe(false);
+			expect(output.sourceAgentId).toBe('agent-abc');
+			expect(output.error).toBe('Subscription not found');
+		});
+	});
+
+	describe('non-JSON output', () => {
+		it('should print success message without mentioning sourceAgentId', async () => {
+			vi.mocked(withMaestroClient).mockImplementation(async (fn) => {
+				const mockClient = {
+					sendCommand: vi.fn().mockResolvedValue({
+						type: 'trigger_cue_subscription_result',
+						success: true,
+						subscriptionName: 'my-sub',
+					}),
+				};
+				return fn(mockClient as any);
+			});
+
+			await cueTrigger('my-sub', { sourceAgentId: 'agent-xyz' });
+
+			expect(consoleSpy).toHaveBeenCalledWith(
+				expect.stringContaining('Triggered Cue subscription "my-sub"')
+			);
+		});
+	});
+
+	describe('error handling', () => {
+		it('should handle connection errors with JSON output', async () => {
+			vi.mocked(withMaestroClient).mockRejectedValue(
+				new Error('Maestro desktop app is not running')
+			);
+
+			await cueTrigger('my-sub', { json: true, sourceAgentId: 'agent-xyz' });
+
+			const output = JSON.parse(consoleSpy.mock.calls[0][0]);
+			expect(output.type).toBe('error');
+			expect(output.error).toBe('Maestro desktop app is not running');
+			expect(processExitSpy).toHaveBeenCalledWith(1);
+		});
+	});
+});

--- a/src/__tests__/cli/commands/send.test.ts
+++ b/src/__tests__/cli/commands/send.test.ts
@@ -13,6 +13,11 @@
 import { describe, it, expect, vi, beforeEach, type MockInstance } from 'vitest';
 import type { SessionInfo } from '../../../shared/types';
 
+// Mock maestro-client
+vi.mock('../../../cli/services/maestro-client', () => ({
+	withMaestroClient: vi.fn(),
+}));
+
 // Mock agent-spawner
 vi.mock('../../../cli/services/agent-spawner', () => ({
 	spawnAgent: vi.fn(),
@@ -44,6 +49,7 @@ vi.mock('../../../main/agents/definitions', () => ({
 }));
 
 import { send } from '../../../cli/commands/send';
+import { withMaestroClient } from '../../../cli/services/maestro-client';
 import { spawnAgent, detectAgent } from '../../../cli/services/agent-spawner';
 import { resolveAgentId, getSessionById } from '../../../cli/services/storage';
 import { estimateContextUsage } from '../../../main/parsers/usage-aggregator';
@@ -300,5 +306,77 @@ describe('send command', () => {
 		const output = JSON.parse(consoleSpy.mock.calls[0][0]);
 		expect(output.success).toBe(true);
 		expect(output.usage).toBeNull();
+	});
+
+	describe('--live mode', () => {
+		it('should send send_command WebSocket message via withMaestroClient', async () => {
+			const mockSendCommand = vi.fn().mockResolvedValue({ type: 'command_result' });
+			vi.mocked(withMaestroClient).mockImplementation(async (action) => {
+				const mockClient = { sendCommand: mockSendCommand };
+				return action(mockClient as never);
+			});
+
+			await send('my-agent-id', 'Hello live', { live: true });
+
+			expect(mockSendCommand).toHaveBeenCalledWith(
+				{ type: 'send_command', sessionId: 'my-agent-id', command: 'Hello live', inputMode: 'ai' },
+				'command_result'
+			);
+
+			const output = JSON.parse(consoleSpy.mock.calls[0][0]);
+			expect(output.success).toBe(true);
+			expect(output.agentId).toBe('my-agent-id');
+			expect(output.agentName).toBe('live');
+			expect(output.sessionId).toBeNull();
+			expect(output.response).toBeNull();
+			expect(output.usage).toBeNull();
+			expect(processExitSpy).not.toHaveBeenCalled();
+		});
+
+		it('should error when --live is combined with --session', async () => {
+			await send('my-agent-id', 'Hello', { live: true, session: 'some-session' });
+
+			const output = JSON.parse(consoleSpy.mock.calls[0][0]);
+			expect(output.success).toBe(false);
+			expect(output.code).toBe('INVALID_OPTIONS');
+			expect(output.error).toBe('--live cannot be combined with --session or --read-only');
+			expect(processExitSpy).toHaveBeenCalledWith(1);
+		});
+
+		it('should error when --live is combined with --read-only', async () => {
+			await send('my-agent-id', 'Hello', { live: true, readOnly: true });
+
+			const output = JSON.parse(consoleSpy.mock.calls[0][0]);
+			expect(output.success).toBe(false);
+			expect(output.code).toBe('INVALID_OPTIONS');
+			expect(output.error).toBe('--live cannot be combined with --session or --read-only');
+			expect(processExitSpy).toHaveBeenCalledWith(1);
+		});
+
+		it('should produce MAESTRO_NOT_RUNNING error when connection fails', async () => {
+			vi.mocked(withMaestroClient).mockRejectedValue(new Error('Connection refused'));
+
+			await send('my-agent-id', 'Hello', { live: true });
+
+			const output = JSON.parse(consoleSpy.mock.calls[0][0]);
+			expect(output.success).toBe(false);
+			expect(output.code).toBe('MAESTRO_NOT_RUNNING');
+			expect(output.error).toBe('Maestro desktop is not running or not reachable');
+			expect(processExitSpy).toHaveBeenCalledWith(1);
+		});
+
+		it('should not call agent resolution or spawn in --live mode', async () => {
+			vi.mocked(withMaestroClient).mockImplementation(async (action) => {
+				const mockClient = { sendCommand: vi.fn().mockResolvedValue({ type: 'command_result' }) };
+				return action(mockClient as never);
+			});
+
+			await send('my-agent-id', 'Hello live', { live: true });
+
+			expect(resolveAgentId).not.toHaveBeenCalled();
+			expect(getSessionById).not.toHaveBeenCalled();
+			expect(detectAgent).not.toHaveBeenCalled();
+			expect(spawnAgent).not.toHaveBeenCalled();
+		});
 	});
 });

--- a/src/__tests__/cli/commands/send.test.ts
+++ b/src/__tests__/cli/commands/send.test.ts
@@ -365,6 +365,17 @@ describe('send command', () => {
 			expect(processExitSpy).toHaveBeenCalledWith(1);
 		});
 
+		it('should produce SESSION_NOT_FOUND error when session is unknown', async () => {
+			vi.mocked(withMaestroClient).mockRejectedValue(new Error('Unknown session ID'));
+
+			await send('bad-session-id', 'Hello', { live: true });
+
+			const output = JSON.parse(consoleSpy.mock.calls[0][0]);
+			expect(output.success).toBe(false);
+			expect(output.code).toBe('SESSION_NOT_FOUND');
+			expect(processExitSpy).toHaveBeenCalledWith(1);
+		});
+
 		it('should not call agent resolution or spawn in --live mode', async () => {
 			vi.mocked(withMaestroClient).mockImplementation(async (action) => {
 				const mockClient = { sendCommand: vi.fn().mockResolvedValue({ type: 'command_result' }) };

--- a/src/__tests__/main/cue/cue-engine.test.ts
+++ b/src/__tests__/main/cue/cue-engine.test.ts
@@ -2986,4 +2986,125 @@ describe('CueEngine', () => {
 			engine.stop();
 		});
 	});
+
+	describe('triggerSubscription with sourceAgentId', () => {
+		it('should include sourceAgentId in the event payload', () => {
+			const config = createMockConfig({
+				subscriptions: [
+					{
+						name: 'test-sub',
+						event: 'cli.trigger',
+						enabled: true,
+						prompt: 'Do the thing',
+					},
+				],
+			});
+			mockLoadCueConfig.mockReturnValue(config);
+
+			const deps = createMockDeps();
+			const engine = new CueEngine(deps);
+			engine.start();
+
+			const result = engine.triggerSubscription('test-sub', undefined, 'agent-xyz-123');
+			expect(result).toBe(true);
+
+			// Verify the event passed to onCueRun contains sourceAgentId in payload
+			expect(deps.onCueRun).toHaveBeenCalledWith(
+				expect.objectContaining({
+					event: expect.objectContaining({
+						payload: expect.objectContaining({
+							manual: true,
+							sourceAgentId: 'agent-xyz-123',
+						}),
+					}),
+				})
+			);
+
+			engine.stop();
+		});
+
+		it('should not include sourceAgentId in event payload when not provided', () => {
+			const config = createMockConfig({
+				subscriptions: [
+					{
+						name: 'test-sub',
+						event: 'cli.trigger',
+						enabled: true,
+						prompt: 'Do the thing',
+					},
+				],
+			});
+			mockLoadCueConfig.mockReturnValue(config);
+
+			const deps = createMockDeps();
+			const engine = new CueEngine(deps);
+			engine.start();
+
+			engine.triggerSubscription('test-sub');
+
+			expect(deps.onCueRun).toHaveBeenCalledWith(
+				expect.objectContaining({
+					event: expect.objectContaining({
+						payload: expect.objectContaining({
+							manual: true,
+						}),
+					}),
+				})
+			);
+			// Verify sourceAgentId is NOT in the payload
+			const callArgs = (deps.onCueRun as ReturnType<typeof vi.fn>).mock.calls[0][0];
+			expect(callArgs.event.payload).not.toHaveProperty('sourceAgentId');
+
+			engine.stop();
+		});
+
+		it('should include both sourceAgentId and cliPrompt in event payload', () => {
+			const config = createMockConfig({
+				subscriptions: [
+					{
+						name: 'test-sub',
+						event: 'cli.trigger',
+						enabled: true,
+						prompt: 'Default prompt',
+					},
+				],
+			});
+			mockLoadCueConfig.mockReturnValue(config);
+
+			const deps = createMockDeps();
+			const engine = new CueEngine(deps);
+			engine.start();
+
+			engine.triggerSubscription('test-sub', 'override prompt', 'agent-abc');
+
+			expect(deps.onCueRun).toHaveBeenCalledWith(
+				expect.objectContaining({
+					event: expect.objectContaining({
+						payload: expect.objectContaining({
+							manual: true,
+							sourceAgentId: 'agent-abc',
+							cliPrompt: 'override prompt',
+						}),
+					}),
+				})
+			);
+
+			engine.stop();
+		});
+
+		it('should return false when subscription is not found', () => {
+			const config = createMockConfig({ subscriptions: [] });
+			mockLoadCueConfig.mockReturnValue(config);
+
+			const deps = createMockDeps();
+			const engine = new CueEngine(deps);
+			engine.start();
+
+			const result = engine.triggerSubscription('nonexistent', undefined, 'agent-xyz');
+			expect(result).toBe(false);
+			expect(deps.onCueRun).not.toHaveBeenCalled();
+
+			engine.stop();
+		});
+	});
 });

--- a/src/__tests__/main/cue/cue-ipc-handlers.test.ts
+++ b/src/__tests__/main/cue/cue-ipc-handlers.test.ts
@@ -467,6 +467,58 @@ describe('Cue IPC Handlers', () => {
 		});
 	});
 
+	describe('cue:triggerSubscription', () => {
+		it('should pass subscriptionName to engine.triggerSubscription()', async () => {
+			const handler = registerAndGetHandler('cue:triggerSubscription');
+			await handler(null, { subscriptionName: 'my-sub' });
+			expect(mockEngine.triggerSubscription).toHaveBeenCalledWith('my-sub', undefined, undefined);
+		});
+
+		it('should pass prompt to engine.triggerSubscription()', async () => {
+			const handler = registerAndGetHandler('cue:triggerSubscription');
+			await handler(null, { subscriptionName: 'my-sub', prompt: 'custom prompt' });
+			expect(mockEngine.triggerSubscription).toHaveBeenCalledWith(
+				'my-sub',
+				'custom prompt',
+				undefined
+			);
+		});
+
+		it('should pass sourceAgentId to engine.triggerSubscription()', async () => {
+			const handler = registerAndGetHandler('cue:triggerSubscription');
+			await handler(null, {
+				subscriptionName: 'my-sub',
+				sourceAgentId: 'agent-xyz-123',
+			});
+			expect(mockEngine.triggerSubscription).toHaveBeenCalledWith(
+				'my-sub',
+				undefined,
+				'agent-xyz-123'
+			);
+		});
+
+		it('should pass both prompt and sourceAgentId to engine.triggerSubscription()', async () => {
+			const handler = registerAndGetHandler('cue:triggerSubscription');
+			await handler(null, {
+				subscriptionName: 'my-sub',
+				prompt: 'override prompt',
+				sourceAgentId: 'agent-abc',
+			});
+			expect(mockEngine.triggerSubscription).toHaveBeenCalledWith(
+				'my-sub',
+				'override prompt',
+				'agent-abc'
+			);
+		});
+
+		it('should return the boolean result from engine', async () => {
+			mockEngine.triggerSubscription.mockReturnValue(false);
+			const handler = registerAndGetHandler('cue:triggerSubscription');
+			const result = await handler(null, { subscriptionName: 'nonexistent' });
+			expect(result).toBe(false);
+		});
+	});
+
 	describe('cue:loadPipelineLayout', () => {
 		it('should return layout when file exists', async () => {
 			const layout = {

--- a/src/__tests__/main/cue/cue-process-lifecycle.test.ts
+++ b/src/__tests__/main/cue/cue-process-lifecycle.test.ts
@@ -359,6 +359,43 @@ describe('cue-process-lifecycle', () => {
 
 				expect(result.stdout).toBe('Parsed output');
 			});
+
+			it('falls back to assistant text when result text is empty', async () => {
+				mockGetOutputParser.mockReturnValue({
+					parseJsonLine: (line: string) => {
+						try {
+							const msg = JSON.parse(line);
+							if (msg.type === 'result') {
+								return { type: 'result', text: msg.result || '' };
+							}
+							if (msg.type === 'assistant') {
+								return { type: 'text', text: msg.text, isPartial: true };
+							}
+							return { type: 'system', raw: msg };
+						} catch {
+							return { type: 'text', text: line };
+						}
+					},
+				} as any);
+
+				const lines = [
+					JSON.stringify({ type: 'assistant', text: 'Hello from the agent' }),
+					JSON.stringify({ type: 'result', result: '' }),
+				].join('\n');
+
+				const resultPromise = runProcess(
+					'run-1',
+					createSpec(),
+					createOptions({ toolType: 'claude-code' })
+				);
+				await vi.advanceTimersByTimeAsync(0);
+
+				mockChild.stdout.emit('data', lines);
+				mockChild.emit('close', 0);
+				const result = await resultPromise;
+
+				expect(result.stdout).toBe('Hello from the agent');
+			});
 		});
 
 		describe('stderr cleaning (benign noise filter)', () => {

--- a/src/__tests__/main/cue/cue-run-manager.test.ts
+++ b/src/__tests__/main/cue/cue-run-manager.test.ts
@@ -24,6 +24,33 @@ vi.mock('../../../main/utils/sentry', () => ({
 	captureException: (...args: unknown[]) => mockCaptureException(...args),
 }));
 
+// Track calls to the promisified execFile.
+// We provide a real callback-style function so `promisify(execFile)` works,
+// and capture calls via a separate spy for assertions.
+const { mockExecFileAsync, execFileMock } = vi.hoisted(() => {
+	const mockExecFileAsync = vi.fn<(cmd: string, args: string[]) => Promise<{ stdout: string; stderr: string }>>();
+	mockExecFileAsync.mockResolvedValue({ stdout: '{}', stderr: '' });
+
+	// A callback-style function whose promisified form delegates to mockExecFileAsync
+	const execFileMock = vi.fn(function execFile(
+		cmd: string,
+		args: string[],
+		cb: (err: Error | null, stdout: string, stderr: string) => void
+	) {
+		mockExecFileAsync(cmd, args).then(
+			(result) => cb(null, result.stdout, result.stderr),
+			(err) => cb(err instanceof Error ? err : new Error(String(err)), '', '')
+		);
+	});
+
+	return { mockExecFileAsync, execFileMock };
+});
+
+vi.mock('child_process', () => ({
+	default: { execFile: execFileMock },
+	execFile: execFileMock,
+}));
+
 let uuidCounter = 0;
 vi.mock('crypto', () => ({
 	randomUUID: vi.fn(() => `run-${++uuidCounter}`),
@@ -807,6 +834,166 @@ describe('createCueRunManager', () => {
 			manager.stopRun(runId);
 
 			expect(manager.getActiveRunCount('session-1')).toBe(1);
+		});
+	});
+
+	describe('Phase 3: CLI Output delivery', () => {
+		beforeEach(() => {
+			mockExecFileAsync.mockResolvedValue({ stdout: '{}', stderr: '' });
+		});
+
+		it('triggers execFile with correct arguments when run succeeds', async () => {
+			const deps = createDeps();
+			const manager = createCueRunManager(deps);
+
+			manager.execute(
+				'session-1',
+				'prompt',
+				createEvent(),
+				'test-sub',
+				undefined, // outputPrompt
+				undefined, // chainDepth
+				{ target: 'agent-42' }
+			);
+			await vi.advanceTimersByTimeAsync(0);
+
+			expect(mockExecFileAsync).toHaveBeenCalledTimes(1);
+			expect(mockExecFileAsync).toHaveBeenCalledWith(
+				'maestro-cli',
+				['send', 'agent-42', 'output', '--live', '--json']
+			);
+		});
+
+		it('is skipped when run fails', async () => {
+			const deps = createDeps({
+				onCueRun: vi.fn(async () => makeResult({ status: 'failed', exitCode: 1 })),
+			});
+			const manager = createCueRunManager(deps);
+
+			manager.execute(
+				'session-1',
+				'prompt',
+				createEvent(),
+				'test-sub',
+				undefined,
+				undefined,
+				{ target: 'agent-42' }
+			);
+			await vi.advanceTimersByTimeAsync(0);
+
+			expect(mockExecFileAsync).not.toHaveBeenCalled();
+		});
+
+		it('delivery failure does not change run status', async () => {
+			mockExecFileAsync.mockRejectedValue(new Error('Connection refused'));
+			const deps = createDeps();
+			const manager = createCueRunManager(deps);
+
+			manager.execute(
+				'session-1',
+				'prompt',
+				createEvent(),
+				'test-sub',
+				undefined,
+				undefined,
+				{ target: 'agent-42' }
+			);
+			await vi.advanceTimersByTimeAsync(0);
+
+			// Run still completes successfully despite CLI output failure
+			expect(deps.onRunCompleted).toHaveBeenCalledWith(
+				'session-1',
+				expect.objectContaining({ status: 'completed' }),
+				'test-sub',
+				undefined
+			);
+			// Warning is logged
+			expect(deps.onLog).toHaveBeenCalledWith(
+				'warn',
+				expect.stringContaining('CLI output delivery failed')
+			);
+		});
+
+		it('substitutes template variables in target before execution', async () => {
+			const deps = createDeps();
+			const manager = createCueRunManager(deps);
+			const event = createEvent({
+				payload: { sourceAgentId: 'resolved-agent-99' },
+			});
+
+			manager.execute(
+				'session-1',
+				'prompt',
+				event,
+				'test-sub',
+				undefined,
+				undefined,
+				{ target: '{{CUE_SOURCE_AGENT_ID}}' }
+			);
+			await vi.advanceTimersByTimeAsync(0);
+
+			expect(mockExecFileAsync).toHaveBeenCalledTimes(1);
+			// The template variable should be resolved to the event payload value
+			expect(mockExecFileAsync).toHaveBeenCalledWith(
+				'maestro-cli',
+				['send', 'resolved-agent-99', 'output', '--live', '--json']
+			);
+		});
+
+		it('is not called when cliOutput is not provided', async () => {
+			const deps = createDeps();
+			const manager = createCueRunManager(deps);
+
+			// No cliOutput argument
+			manager.execute('session-1', 'prompt', createEvent(), 'test-sub');
+			await vi.advanceTimersByTimeAsync(0);
+
+			expect(mockExecFileAsync).not.toHaveBeenCalled();
+		});
+
+		it('truncates stdout to 100,000 characters', async () => {
+			const longOutput = 'x'.repeat(150_000);
+			const deps = createDeps({
+				onCueRun: vi.fn(async () => makeResult({ stdout: longOutput })),
+			});
+			const manager = createCueRunManager(deps);
+
+			manager.execute(
+				'session-1',
+				'prompt',
+				createEvent(),
+				'test-sub',
+				undefined,
+				undefined,
+				{ target: 'agent-42' }
+			);
+			await vi.advanceTimersByTimeAsync(0);
+
+			expect(mockExecFileAsync).toHaveBeenCalledTimes(1);
+			const passedArgs = mockExecFileAsync.mock.calls[0][1] as string[];
+			// The stdout argument (index 2) should be truncated to 100k chars
+			expect(passedArgs[2].length).toBe(100_000);
+		});
+
+		it('logs success message on delivery', async () => {
+			const deps = createDeps();
+			const manager = createCueRunManager(deps);
+
+			manager.execute(
+				'session-1',
+				'prompt',
+				createEvent(),
+				'test-sub',
+				undefined,
+				undefined,
+				{ target: 'agent-42' }
+			);
+			await vi.advanceTimersByTimeAsync(0);
+
+			expect(deps.onLog).toHaveBeenCalledWith(
+				'cue',
+				expect.stringContaining('CLI output delivered to agent-42')
+			);
 		});
 	});
 });

--- a/src/__tests__/main/cue/cue-run-manager.test.ts
+++ b/src/__tests__/main/cue/cue-run-manager.test.ts
@@ -28,16 +28,29 @@ vi.mock('../../../main/utils/sentry', () => ({
 // We provide a real callback-style function so `promisify(execFile)` works,
 // and capture calls via a separate spy for assertions.
 const { mockExecFileAsync, execFileMock } = vi.hoisted(() => {
-	const mockExecFileAsync = vi.fn<(cmd: string, args: string[]) => Promise<{ stdout: string; stderr: string }>>();
+	const mockExecFileAsync =
+		vi.fn<
+			(
+				cmd: string,
+				args: string[],
+				options?: Record<string, unknown>
+			) => Promise<{ stdout: string; stderr: string }>
+		>();
 	mockExecFileAsync.mockResolvedValue({ stdout: '{}', stderr: '' });
 
 	// A callback-style function whose promisified form delegates to mockExecFileAsync
+	// Handles both (cmd, args, cb) and (cmd, args, options, cb) signatures
 	const execFileMock = vi.fn(function execFile(
 		cmd: string,
 		args: string[],
-		cb: (err: Error | null, stdout: string, stderr: string) => void
+		optionsOrCb:
+			| Record<string, unknown>
+			| ((err: Error | null, stdout: string, stderr: string) => void),
+		maybeCb?: (err: Error | null, stdout: string, stderr: string) => void
 	) {
-		mockExecFileAsync(cmd, args).then(
+		const cb = typeof optionsOrCb === 'function' ? optionsOrCb : maybeCb!;
+		const options = typeof optionsOrCb === 'function' ? undefined : optionsOrCb;
+		mockExecFileAsync(cmd, args, options).then(
 			(result) => cb(null, result.stdout, result.stderr),
 			(err) => cb(err instanceof Error ? err : new Error(String(err)), '', '')
 		);
@@ -49,6 +62,10 @@ const { mockExecFileAsync, execFileMock } = vi.hoisted(() => {
 vi.mock('child_process', () => ({
 	default: { execFile: execFileMock },
 	execFile: execFileMock,
+}));
+
+vi.mock('../../../main/runtime/getShellPath', () => ({
+	getShellPath: vi.fn().mockResolvedValue('/usr/bin:/usr/local/bin'),
 }));
 
 let uuidCounter = 0;
@@ -860,7 +877,28 @@ describe('createCueRunManager', () => {
 			expect(mockExecFileAsync).toHaveBeenCalledTimes(1);
 			expect(mockExecFileAsync).toHaveBeenCalledWith(
 				'maestro-cli',
-				['send', 'agent-42', 'output', '--live', '--json']
+				['send', 'agent-42', 'output', '--live'],
+				expect.objectContaining({
+					env: expect.objectContaining({ PATH: expect.any(String) }),
+					timeout: 30_000,
+				})
+			);
+		});
+
+		it('skips delivery when target resolves to empty string', async () => {
+			const deps = createDeps();
+			const manager = createCueRunManager(deps);
+			const event = createEvent({ payload: {} });
+
+			manager.execute('session-1', 'prompt', event, 'test-sub', undefined, undefined, {
+				target: '{{CUE_SOURCE_AGENT_ID}}',
+			});
+			await vi.advanceTimersByTimeAsync(0);
+
+			expect(mockExecFileAsync).not.toHaveBeenCalled();
+			expect(deps.onLog).toHaveBeenCalledWith(
+				'warn',
+				expect.stringContaining('target resolved to empty string')
 			);
 		});
 
@@ -870,15 +908,9 @@ describe('createCueRunManager', () => {
 			});
 			const manager = createCueRunManager(deps);
 
-			manager.execute(
-				'session-1',
-				'prompt',
-				createEvent(),
-				'test-sub',
-				undefined,
-				undefined,
-				{ target: 'agent-42' }
-			);
+			manager.execute('session-1', 'prompt', createEvent(), 'test-sub', undefined, undefined, {
+				target: 'agent-42',
+			});
 			await vi.advanceTimersByTimeAsync(0);
 
 			expect(mockExecFileAsync).not.toHaveBeenCalled();
@@ -889,25 +921,17 @@ describe('createCueRunManager', () => {
 			const deps = createDeps();
 			const manager = createCueRunManager(deps);
 
-			manager.execute(
-				'session-1',
-				'prompt',
-				createEvent(),
-				'test-sub',
-				undefined,
-				undefined,
-				{ target: 'agent-42' }
-			);
+			manager.execute('session-1', 'prompt', createEvent(), 'test-sub', undefined, undefined, {
+				target: 'agent-42',
+			});
 			await vi.advanceTimersByTimeAsync(0);
 
-			// Run still completes successfully despite CLI output failure
 			expect(deps.onRunCompleted).toHaveBeenCalledWith(
 				'session-1',
 				expect.objectContaining({ status: 'completed' }),
 				'test-sub',
 				undefined
 			);
-			// Warning is logged
 			expect(deps.onLog).toHaveBeenCalledWith(
 				'warn',
 				expect.stringContaining('CLI output delivery failed')
@@ -921,22 +945,16 @@ describe('createCueRunManager', () => {
 				payload: { sourceAgentId: 'resolved-agent-99' },
 			});
 
-			manager.execute(
-				'session-1',
-				'prompt',
-				event,
-				'test-sub',
-				undefined,
-				undefined,
-				{ target: '{{CUE_SOURCE_AGENT_ID}}' }
-			);
+			manager.execute('session-1', 'prompt', event, 'test-sub', undefined, undefined, {
+				target: '{{CUE_SOURCE_AGENT_ID}}',
+			});
 			await vi.advanceTimersByTimeAsync(0);
 
 			expect(mockExecFileAsync).toHaveBeenCalledTimes(1);
-			// The template variable should be resolved to the event payload value
 			expect(mockExecFileAsync).toHaveBeenCalledWith(
 				'maestro-cli',
-				['send', 'resolved-agent-99', 'output', '--live', '--json']
+				['send', 'resolved-agent-99', 'output', '--live'],
+				expect.objectContaining({ env: expect.objectContaining({ PATH: expect.any(String) }) })
 			);
 		});
 
@@ -944,7 +962,6 @@ describe('createCueRunManager', () => {
 			const deps = createDeps();
 			const manager = createCueRunManager(deps);
 
-			// No cliOutput argument
 			manager.execute('session-1', 'prompt', createEvent(), 'test-sub');
 			await vi.advanceTimersByTimeAsync(0);
 
@@ -958,20 +975,13 @@ describe('createCueRunManager', () => {
 			});
 			const manager = createCueRunManager(deps);
 
-			manager.execute(
-				'session-1',
-				'prompt',
-				createEvent(),
-				'test-sub',
-				undefined,
-				undefined,
-				{ target: 'agent-42' }
-			);
+			manager.execute('session-1', 'prompt', createEvent(), 'test-sub', undefined, undefined, {
+				target: 'agent-42',
+			});
 			await vi.advanceTimersByTimeAsync(0);
 
 			expect(mockExecFileAsync).toHaveBeenCalledTimes(1);
 			const passedArgs = mockExecFileAsync.mock.calls[0][1] as string[];
-			// The stdout argument (index 2) should be truncated to 100k chars
 			expect(passedArgs[2].length).toBe(100_000);
 		});
 
@@ -979,21 +989,29 @@ describe('createCueRunManager', () => {
 			const deps = createDeps();
 			const manager = createCueRunManager(deps);
 
-			manager.execute(
-				'session-1',
-				'prompt',
-				createEvent(),
-				'test-sub',
-				undefined,
-				undefined,
-				{ target: 'agent-42' }
-			);
+			manager.execute('session-1', 'prompt', createEvent(), 'test-sub', undefined, undefined, {
+				target: 'agent-42',
+			});
 			await vi.advanceTimersByTimeAsync(0);
 
 			expect(deps.onLog).toHaveBeenCalledWith(
 				'cue',
 				expect.stringContaining('CLI output delivered to agent-42')
 			);
+		});
+
+		it('logs Phase 3 skipped when run status is not completed', async () => {
+			const deps = createDeps({
+				onCueRun: vi.fn(async () => makeResult({ status: 'failed', exitCode: 1 })),
+			});
+			const manager = createCueRunManager(deps);
+
+			manager.execute('session-1', 'prompt', createEvent(), 'test-sub', undefined, undefined, {
+				target: 'agent-42',
+			});
+			await vi.advanceTimersByTimeAsync(0);
+
+			expect(deps.onLog).toHaveBeenCalledWith('cue', expect.stringContaining('Phase 3 skipped'));
 		});
 	});
 });

--- a/src/__tests__/main/cue/cue-run-manager.test.ts
+++ b/src/__tests__/main/cue/cue-run-manager.test.ts
@@ -24,48 +24,21 @@ vi.mock('../../../main/utils/sentry', () => ({
 	captureException: (...args: unknown[]) => mockCaptureException(...args),
 }));
 
-// Track calls to the promisified execFile.
-// We provide a real callback-style function so `promisify(execFile)` works,
-// and capture calls via a separate spy for assertions.
-const { mockExecFileAsync, execFileMock } = vi.hoisted(() => {
-	const mockExecFileAsync =
-		vi.fn<
-			(
-				cmd: string,
-				args: string[],
-				options?: Record<string, unknown>
-			) => Promise<{ stdout: string; stderr: string }>
-		>();
-	mockExecFileAsync.mockResolvedValue({ stdout: '{}', stderr: '' });
+// Mock execFileNoThrow for Phase 3 CLI output delivery
+const mockExecFileNoThrow =
+	vi.fn<
+		(
+			cmd: string,
+			args?: string[],
+			cwd?: string,
+			options?: Record<string, unknown>
+		) => Promise<{ stdout: string; stderr: string; exitCode: number | string }>
+	>();
+mockExecFileNoThrow.mockResolvedValue({ stdout: '{}', stderr: '', exitCode: 0 });
 
-	// A callback-style function whose promisified form delegates to mockExecFileAsync
-	// Handles both (cmd, args, cb) and (cmd, args, options, cb) signatures
-	const execFileMock = vi.fn(function execFile(
-		cmd: string,
-		args: string[],
-		optionsOrCb:
-			| Record<string, unknown>
-			| ((err: Error | null, stdout: string, stderr: string) => void),
-		maybeCb?: (err: Error | null, stdout: string, stderr: string) => void
-	) {
-		const cb = typeof optionsOrCb === 'function' ? optionsOrCb : maybeCb!;
-		const options = typeof optionsOrCb === 'function' ? undefined : optionsOrCb;
-		mockExecFileAsync(cmd, args, options).then(
-			(result) => cb(null, result.stdout, result.stderr),
-			(err) => cb(err instanceof Error ? err : new Error(String(err)), '', '')
-		);
-	});
-
-	return { mockExecFileAsync, execFileMock };
-});
-
-vi.mock('child_process', () => ({
-	default: { execFile: execFileMock },
-	execFile: execFileMock,
-}));
-
-vi.mock('../../../main/runtime/getShellPath', () => ({
-	getShellPath: vi.fn().mockResolvedValue('/usr/bin:/usr/local/bin'),
+vi.mock('../../../main/utils/execFile', () => ({
+	execFileNoThrow: (...args: unknown[]) =>
+		mockExecFileNoThrow(...(args as Parameters<typeof mockExecFileNoThrow>)),
 }));
 
 let uuidCounter = 0;
@@ -856,7 +829,7 @@ describe('createCueRunManager', () => {
 
 	describe('Phase 3: CLI Output delivery', () => {
 		beforeEach(() => {
-			mockExecFileAsync.mockResolvedValue({ stdout: '{}', stderr: '' });
+			mockExecFileNoThrow.mockResolvedValue({ stdout: '{}', stderr: '', exitCode: 0 });
 		});
 
 		it('triggers execFile with correct arguments when run succeeds', async () => {
@@ -874,14 +847,12 @@ describe('createCueRunManager', () => {
 			);
 			await vi.advanceTimersByTimeAsync(0);
 
-			expect(mockExecFileAsync).toHaveBeenCalledTimes(1);
-			expect(mockExecFileAsync).toHaveBeenCalledWith(
-				'node',
-				['/opt/Maestro/resources/maestro-cli.js', 'send', 'agent-42', 'output', '--live'],
-				expect.objectContaining({
-					env: expect.objectContaining({ PATH: expect.any(String) }),
-					timeout: 30_000,
-				})
+			expect(mockExecFileNoThrow).toHaveBeenCalledTimes(1);
+			expect(mockExecFileNoThrow).toHaveBeenCalledWith(
+				process.execPath,
+				expect.arrayContaining(['send', 'agent-42', 'output', '--live']),
+				undefined,
+				{ timeout: 30_000 }
 			);
 		});
 
@@ -895,7 +866,7 @@ describe('createCueRunManager', () => {
 			});
 			await vi.advanceTimersByTimeAsync(0);
 
-			expect(mockExecFileAsync).not.toHaveBeenCalled();
+			expect(mockExecFileNoThrow).not.toHaveBeenCalled();
 			expect(deps.onLog).toHaveBeenCalledWith(
 				'warn',
 				expect.stringContaining('target resolved to empty string')
@@ -913,11 +884,15 @@ describe('createCueRunManager', () => {
 			});
 			await vi.advanceTimersByTimeAsync(0);
 
-			expect(mockExecFileAsync).not.toHaveBeenCalled();
+			expect(mockExecFileNoThrow).not.toHaveBeenCalled();
 		});
 
 		it('delivery failure does not change run status', async () => {
-			mockExecFileAsync.mockRejectedValue(new Error('Connection refused'));
+			mockExecFileNoThrow.mockResolvedValue({
+				stdout: '',
+				stderr: 'Connection refused',
+				exitCode: 1,
+			});
 			const deps = createDeps();
 			const manager = createCueRunManager(deps);
 
@@ -951,11 +926,12 @@ describe('createCueRunManager', () => {
 			});
 			await vi.advanceTimersByTimeAsync(0);
 
-			expect(mockExecFileAsync).toHaveBeenCalledTimes(1);
-			expect(mockExecFileAsync).toHaveBeenCalledWith(
-				'node',
-				['/opt/Maestro/resources/maestro-cli.js', 'send', 'resolved-agent-99', 'output', '--live'],
-				expect.objectContaining({ env: expect.objectContaining({ PATH: expect.any(String) }) })
+			expect(mockExecFileNoThrow).toHaveBeenCalledTimes(1);
+			expect(mockExecFileNoThrow).toHaveBeenCalledWith(
+				process.execPath,
+				expect.arrayContaining(['send', 'resolved-agent-99', 'output', '--live']),
+				undefined,
+				{ timeout: 30_000 }
 			);
 		});
 
@@ -966,7 +942,7 @@ describe('createCueRunManager', () => {
 			manager.execute('session-1', 'prompt', createEvent(), 'test-sub');
 			await vi.advanceTimersByTimeAsync(0);
 
-			expect(mockExecFileAsync).not.toHaveBeenCalled();
+			expect(mockExecFileNoThrow).not.toHaveBeenCalled();
 		});
 
 		it('truncates stdout to 100,000 characters', async () => {
@@ -981,10 +957,11 @@ describe('createCueRunManager', () => {
 			});
 			await vi.advanceTimersByTimeAsync(0);
 
-			expect(mockExecFileAsync).toHaveBeenCalledTimes(1);
-			const passedArgs = mockExecFileAsync.mock.calls[0][1] as string[];
-			// Args: [cli.js path, 'send', target, truncated output, '--live']
-			expect(passedArgs[3].length).toBe(100_000);
+			expect(mockExecFileNoThrow).toHaveBeenCalledTimes(1);
+			const passedArgs = mockExecFileNoThrow.mock.calls[0][1] as string[];
+			// Args: [cli.js, 'send', target, truncated output, '--live']
+			const outputArg = passedArgs.find((a) => a.length > 1000);
+			expect(outputArg?.length).toBe(100_000);
 		});
 
 		it('logs success message on delivery', async () => {

--- a/src/__tests__/main/cue/cue-run-manager.test.ts
+++ b/src/__tests__/main/cue/cue-run-manager.test.ts
@@ -876,8 +876,8 @@ describe('createCueRunManager', () => {
 
 			expect(mockExecFileAsync).toHaveBeenCalledTimes(1);
 			expect(mockExecFileAsync).toHaveBeenCalledWith(
-				'maestro-cli',
-				['send', 'agent-42', 'output', '--live'],
+				'node',
+				['/opt/Maestro/resources/maestro-cli.js', 'send', 'agent-42', 'output', '--live'],
 				expect.objectContaining({
 					env: expect.objectContaining({ PATH: expect.any(String) }),
 					timeout: 30_000,
@@ -942,6 +942,7 @@ describe('createCueRunManager', () => {
 			const deps = createDeps();
 			const manager = createCueRunManager(deps);
 			const event = createEvent({
+				type: 'cli.trigger',
 				payload: { sourceAgentId: 'resolved-agent-99' },
 			});
 
@@ -952,8 +953,8 @@ describe('createCueRunManager', () => {
 
 			expect(mockExecFileAsync).toHaveBeenCalledTimes(1);
 			expect(mockExecFileAsync).toHaveBeenCalledWith(
-				'maestro-cli',
-				['send', 'resolved-agent-99', 'output', '--live'],
+				'node',
+				['/opt/Maestro/resources/maestro-cli.js', 'send', 'resolved-agent-99', 'output', '--live'],
 				expect.objectContaining({ env: expect.objectContaining({ PATH: expect.any(String) }) })
 			);
 		});
@@ -982,7 +983,8 @@ describe('createCueRunManager', () => {
 
 			expect(mockExecFileAsync).toHaveBeenCalledTimes(1);
 			const passedArgs = mockExecFileAsync.mock.calls[0][1] as string[];
-			expect(passedArgs[2].length).toBe(100_000);
+			// Args: [cli.js path, 'send', target, truncated output, '--live']
+			expect(passedArgs[3].length).toBe(100_000);
 		});
 
 		it('logs success message on delivery', async () => {

--- a/src/__tests__/main/utils/agent-args.test.ts
+++ b/src/__tests__/main/utils/agent-args.test.ts
@@ -88,7 +88,7 @@ describe('buildAgentArgs', () => {
 	// -- jsonOutputArgs --
 	it('adds jsonOutputArgs when not already present', () => {
 		const agent = makeAgent({ jsonOutputArgs: ['--format', 'json'] });
-		const result = buildAgentArgs(agent, { baseArgs: ['--print'] });
+		const result = buildAgentArgs(agent, { baseArgs: ['--print'], prompt: 'test' });
 		expect(result).toEqual(['--print', '--format', 'json']);
 	});
 
@@ -96,9 +96,16 @@ describe('buildAgentArgs', () => {
 		const agent = makeAgent({ jsonOutputArgs: ['--format', 'json'] });
 		const result = buildAgentArgs(agent, {
 			baseArgs: ['--print', '--format', 'stream'],
+			prompt: 'test',
 		});
 		// '--format' is already in baseArgs, so jsonOutputArgs should not be added
 		expect(result).toEqual(['--print', '--format', 'stream']);
+	});
+
+	it('skips jsonOutputArgs when prompt is empty', () => {
+		const agent = makeAgent({ jsonOutputArgs: ['--format', 'json'] });
+		const result = buildAgentArgs(agent, { baseArgs: ['--print'] });
+		expect(result).toEqual(['--print']);
 	});
 
 	// -- workingDirArgs --
@@ -365,7 +372,7 @@ describe('buildAgentArgs', () => {
 	it('does not mutate the original baseArgs array', () => {
 		const baseArgs = ['--print'];
 		const agent = makeAgent({ jsonOutputArgs: ['--format', 'json'] });
-		buildAgentArgs(agent, { baseArgs });
+		buildAgentArgs(agent, { baseArgs, prompt: 'test' });
 		expect(baseArgs).toEqual(['--print']);
 	});
 

--- a/src/__tests__/main/utils/agent-args.test.ts
+++ b/src/__tests__/main/utils/agent-args.test.ts
@@ -104,7 +104,7 @@ describe('buildAgentArgs', () => {
 
 	it('skips jsonOutputArgs when prompt is empty', () => {
 		const agent = makeAgent({ jsonOutputArgs: ['--format', 'json'] });
-		const result = buildAgentArgs(agent, { baseArgs: ['--print'] });
+		const result = buildAgentArgs(agent, { baseArgs: ['--print'], prompt: '' });
 		expect(result).toEqual(['--print']);
 	});
 

--- a/src/__tests__/main/web-server/handlers/messageHandlers.test.ts
+++ b/src/__tests__/main/web-server/handlers/messageHandlers.test.ts
@@ -116,6 +116,7 @@ function createMockCallbacks(): MessageHandlerCallbacks {
 		getCueSubscriptions: vi.fn().mockResolvedValue([]),
 		toggleCueSubscription: vi.fn().mockResolvedValue(true),
 		getCueActivity: vi.fn().mockResolvedValue([]),
+		triggerCueSubscription: vi.fn().mockResolvedValue(true),
 		getUsageDashboard: vi.fn().mockResolvedValue({}),
 		getAchievements: vi.fn().mockResolvedValue([]),
 		writeToTerminal: vi.fn().mockReturnValue(true),
@@ -1111,6 +1112,84 @@ describe('WebSocketMessageHandler', () => {
 			const response = JSON.parse((client.socket.send as any).mock.calls[0][0]);
 			expect(response.type).toBe('terminal_resize_result');
 			expect(response.success).toBe(true);
+		});
+	});
+
+	describe('Trigger Cue Subscription (sourceAgentId)', () => {
+		it('should pass sourceAgentId through to triggerCueSubscription callback', async () => {
+			handler.handleMessage(client, {
+				type: 'trigger_cue_subscription',
+				subscriptionName: 'my-sub',
+				sourceAgentId: 'agent-xyz-123',
+			});
+
+			await vi.waitFor(() => {
+				expect(callbacks.triggerCueSubscription).toHaveBeenCalledWith(
+					'my-sub',
+					undefined,
+					'agent-xyz-123'
+				);
+			});
+		});
+
+		it('should pass prompt and sourceAgentId together', async () => {
+			handler.handleMessage(client, {
+				type: 'trigger_cue_subscription',
+				subscriptionName: 'my-sub',
+				prompt: 'custom prompt',
+				sourceAgentId: 'agent-abc',
+			});
+
+			await vi.waitFor(() => {
+				expect(callbacks.triggerCueSubscription).toHaveBeenCalledWith(
+					'my-sub',
+					'custom prompt',
+					'agent-abc'
+				);
+			});
+		});
+
+		it('should pass undefined sourceAgentId when not provided', async () => {
+			handler.handleMessage(client, {
+				type: 'trigger_cue_subscription',
+				subscriptionName: 'my-sub',
+			});
+
+			await vi.waitFor(() => {
+				expect(callbacks.triggerCueSubscription).toHaveBeenCalledWith(
+					'my-sub',
+					undefined,
+					undefined
+				);
+			});
+		});
+
+		it('should return trigger_cue_subscription_result on success', async () => {
+			handler.handleMessage(client, {
+				type: 'trigger_cue_subscription',
+				subscriptionName: 'my-sub',
+				sourceAgentId: 'agent-xyz',
+			});
+
+			await vi.waitFor(() => {
+				expect(client.socket.send).toHaveBeenCalled();
+			});
+
+			const response = JSON.parse((client.socket.send as any).mock.calls[0][0]);
+			expect(response.type).toBe('trigger_cue_subscription_result');
+			expect(response.success).toBe(true);
+			expect(response.subscriptionName).toBe('my-sub');
+		});
+
+		it('should reject missing subscriptionName', () => {
+			handler.handleMessage(client, {
+				type: 'trigger_cue_subscription',
+				sourceAgentId: 'agent-xyz',
+			});
+
+			const response = JSON.parse((client.socket.send as any).mock.calls[0][0]);
+			expect(response.type).toBe('error');
+			expect(callbacks.triggerCueSubscription).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/src/__tests__/main/web-server/managers/CallbackRegistry.test.ts
+++ b/src/__tests__/main/web-server/managers/CallbackRegistry.test.ts
@@ -656,6 +656,25 @@ describe('CallbackRegistry', () => {
 			expect(sessionsCallback).toHaveBeenCalledTimes(1);
 		});
 
+		it('triggerCueSubscription() returns false when no callback set', async () => {
+			expect(await registry.triggerCueSubscription('my-sub')).toBe(false);
+		});
+
+		it('triggerCueSubscription() passes sourceAgentId through to callback', async () => {
+			const callback = vi.fn().mockResolvedValue(true);
+			registry.setTriggerCueSubscriptionCallback(callback);
+			const result = await registry.triggerCueSubscription('my-sub', 'prompt', 'agent-xyz-123');
+			expect(result).toBe(true);
+			expect(callback).toHaveBeenCalledWith('my-sub', 'prompt', 'agent-xyz-123');
+		});
+
+		it('triggerCueSubscription() passes undefined sourceAgentId when not provided', async () => {
+			const callback = vi.fn().mockResolvedValue(true);
+			registry.setTriggerCueSubscriptionCallback(callback);
+			await registry.triggerCueSubscription('my-sub');
+			expect(callback).toHaveBeenCalledWith('my-sub', undefined, undefined);
+		});
+
 		it('multiple callbacks can be set and work independently', async () => {
 			const sessionsCallback = vi.fn().mockReturnValue([{ id: 's1' }]);
 			const themeCallback = vi.fn().mockReturnValue({ name: 'dark' });

--- a/src/__tests__/renderer/components/CuePipelineEditor/drawers/AgentDrawer.test.tsx
+++ b/src/__tests__/renderer/components/CuePipelineEditor/drawers/AgentDrawer.test.tsx
@@ -143,16 +143,20 @@ describe('AgentDrawer', () => {
 		);
 
 		// Verify group order: Alpha before Zeta, Ungrouped last
+		// Filter out the "Output" section header which also uses uppercase styling
 		const groupHeaders = container.querySelectorAll('[style*="text-transform: uppercase"]');
-		const headerTexts = Array.from(groupHeaders).map((el) => el.textContent);
+		const headerTexts = Array.from(groupHeaders)
+			.map((el) => el.textContent)
+			.filter((t) => t !== 'Output');
 		expect(headerTexts).toEqual(['🅰️ Alpha', '⚡ Zeta', 'Ungrouped']);
 
 		// Verify agent order within each group by checking DOM order
 		// Each draggable row: <div draggable> > <svg(Bot)> > <div(flex)> > <div(name)> + <div(toolType)>
 		// The name is in the first div child with fontWeight:500
-		const agentNames = Array.from(container.querySelectorAll('[draggable="true"]')).map(
-			(el) => el.querySelector('[style*="font-weight: 500"]')?.textContent
-		);
+		// Filter out the CLI Output node which is also draggable
+		const agentNames = Array.from(container.querySelectorAll('[draggable="true"]'))
+			.map((el) => el.querySelector('[style*="font-weight: 500"]')?.textContent)
+			.filter((name) => name !== 'CLI Output');
 		expect(agentNames).toEqual(['Alice', 'Charlie', 'Bravo', 'Delta', 'Echo']);
 	});
 

--- a/src/__tests__/renderer/components/ProcessMonitor.test.tsx
+++ b/src/__tests__/renderer/components/ProcessMonitor.test.tsx
@@ -448,11 +448,9 @@ describe('ProcessMonitor', () => {
 			render(<ProcessMonitor theme={theme} sessions={[session]} groups={[]} onClose={onClose} />);
 
 			await waitFor(() => {
-				expect(screen.queryByText('Loading processes...')).not.toBeInTheDocument();
+				expect(screen.getByText('UNGROUPED AGENTS')).toBeInTheDocument();
+				expect(screen.getByText('Test Session')).toBeInTheDocument();
 			});
-
-			expect(screen.getByText('UNGROUPED AGENTS')).toBeInTheDocument();
-			expect(screen.getByText('Test Session')).toBeInTheDocument();
 		});
 
 		it('should display grouped sessions with processes', async () => {
@@ -467,11 +465,9 @@ describe('ProcessMonitor', () => {
 			);
 
 			await waitFor(() => {
-				expect(screen.queryByText('Loading processes...')).not.toBeInTheDocument();
+				expect(screen.getByText('Test Group')).toBeInTheDocument();
+				expect(screen.getByText('Test Session')).toBeInTheDocument();
 			});
-
-			expect(screen.getByText('Test Group')).toBeInTheDocument();
-			expect(screen.getByText('Test Session')).toBeInTheDocument();
 		});
 
 		it('should show session count in group', async () => {

--- a/src/__tests__/renderer/services/cue.test.ts
+++ b/src/__tests__/renderer/services/cue.test.ts
@@ -212,8 +212,10 @@ describe('cueService — write methods', () => {
 
 	it('triggerSubscription — passes args and rethrows on error', async () => {
 		mockCue.triggerSubscription.mockRejectedValue(new Error('IPC fail'));
-		await expect(cueService.triggerSubscription('sub-1', 'prompt')).rejects.toThrow('IPC fail');
-		expect(mockCue.triggerSubscription).toHaveBeenCalledWith('sub-1', 'prompt');
+		await expect(cueService.triggerSubscription('sub-1', 'prompt', 'agent-1')).rejects.toThrow(
+			'IPC fail'
+		);
+		expect(mockCue.triggerSubscription).toHaveBeenCalledWith('sub-1', 'prompt', 'agent-1');
 	});
 
 	it('refreshSession — passes args and rethrows on error', async () => {

--- a/src/__tests__/shared/templateVariables.test.ts
+++ b/src/__tests__/shared/templateVariables.test.ts
@@ -838,6 +838,22 @@ describe('substituteTemplateVariables', () => {
 			expect(result).toBe('completed exit=0 dur=15000 by=lint-on-save');
 		});
 
+		it('should replace {{CUE_SOURCE_AGENT_ID}} when sourceAgentId is set', () => {
+			const context = createTestContext({
+				cue: {
+					sourceAgentId: 'agent-abc-123',
+				},
+			});
+			const result = substituteTemplateVariables('Target: {{CUE_SOURCE_AGENT_ID}}', context);
+			expect(result).toBe('Target: agent-abc-123');
+		});
+
+		it('should replace {{CUE_SOURCE_AGENT_ID}} with empty string when not set', () => {
+			const context = createTestContext({ cue: {} });
+			const result = substituteTemplateVariables('Target: {{CUE_SOURCE_AGENT_ID}}', context);
+			expect(result).toBe('Target: ');
+		});
+
 		it('should default missing cue variables to empty string', () => {
 			const context = createTestContext({ cue: {} });
 			const result = substituteTemplateVariables(

--- a/src/cli/commands/cue-list.ts
+++ b/src/cli/commands/cue-list.ts
@@ -1,0 +1,88 @@
+// Cue list command - list all Cue subscriptions across agents
+
+import { withMaestroClient } from '../services/maestro-client';
+
+interface CueListOptions {
+	json?: boolean;
+}
+
+interface CueSubscription {
+	id: string;
+	name: string;
+	eventType: string;
+	pattern?: string;
+	schedule?: string;
+	sessionId: string;
+	sessionName: string;
+	enabled: boolean;
+	lastTriggered?: number;
+	triggerCount: number;
+}
+
+export async function cueList(options: CueListOptions): Promise<void> {
+	try {
+		const result = await withMaestroClient(async (client) => {
+			return client.sendCommand<{
+				type: string;
+				subscriptions: CueSubscription[];
+			}>(
+				{
+					type: 'get_cue_subscriptions',
+				},
+				'cue_subscriptions'
+			);
+		});
+
+		const subs = result.subscriptions ?? [];
+
+		if (options.json) {
+			console.log(JSON.stringify(subs, null, 2));
+		} else if (subs.length === 0) {
+			console.log('No Cue subscriptions found.');
+		} else {
+			const lines: string[] = [];
+			lines.push(`Cue Subscriptions (${subs.length}):\n`);
+
+			for (const sub of subs) {
+				const status = sub.enabled ? '✓' : '✗';
+				const triggered = sub.lastTriggered
+					? `last: ${formatTimeAgo(sub.lastTriggered)}`
+					: 'never triggered';
+				lines.push(`  ${status}  ${sub.name}`);
+				lines.push(`     event: ${sub.eventType}  |  agent: ${sub.sessionName}  |  ${triggered}`);
+				if (sub.pattern) {
+					lines.push(`     pattern: ${sub.pattern}`);
+				}
+				if (sub.schedule) {
+					lines.push(`     schedule: ${sub.schedule}`);
+				}
+				lines.push('');
+			}
+
+			console.log(lines.join('\n'));
+		}
+	} catch (error) {
+		if (options.json) {
+			console.log(
+				JSON.stringify({
+					type: 'error',
+					error: error instanceof Error ? error.message : String(error),
+				})
+			);
+		} else {
+			console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+		}
+		process.exit(1);
+	}
+}
+
+function formatTimeAgo(timestamp: number): string {
+	const diff = Date.now() - timestamp;
+	const minutes = Math.floor(diff / 60000);
+	if (minutes < 1) return 'just now';
+	if (minutes < 60) return `${minutes}m ago`;
+	const hours = Math.floor(minutes / 60);
+	if (hours < 24) return `${hours}h ago`;
+	const days = Math.floor(hours / 24);
+	return `${days}d ago`;
+}

--- a/src/cli/commands/cue-trigger.ts
+++ b/src/cli/commands/cue-trigger.ts
@@ -5,6 +5,7 @@ import { withMaestroClient } from '../services/maestro-client';
 interface CueTriggerOptions {
 	prompt?: string;
 	json?: boolean;
+	sourceAgentId?: string;
 }
 
 export async function cueTrigger(
@@ -23,6 +24,7 @@ export async function cueTrigger(
 					type: 'trigger_cue_subscription',
 					subscriptionName,
 					prompt: options.prompt,
+					sourceAgentId: options.sourceAgentId,
 				},
 				'trigger_cue_subscription_result'
 			);
@@ -35,6 +37,7 @@ export async function cueTrigger(
 					success: result.success,
 					subscriptionName,
 					...(options.prompt !== undefined ? { prompt: options.prompt } : {}),
+					...(options.sourceAgentId !== undefined ? { sourceAgentId: options.sourceAgentId } : {}),
 					...(result.error ? { error: result.error } : {}),
 				})
 			);

--- a/src/cli/commands/send.ts
+++ b/src/cli/commands/send.ts
@@ -12,6 +12,7 @@ interface SendOptions {
 	session?: string;
 	readOnly?: boolean;
 	tab?: boolean;
+	live?: boolean;
 }
 
 interface SendResponse {
@@ -75,6 +76,35 @@ export async function send(
 	message: string,
 	options: SendOptions
 ): Promise<void> {
+	// --live mode: route message through Maestro desktop tab
+	if (options.live) {
+		if (options.session || options.readOnly) {
+			emitErrorJson('--live cannot be combined with --session or --read-only', 'INVALID_OPTIONS');
+			process.exit(1);
+		}
+		try {
+			await withMaestroClient(async (client) => {
+				await client.sendCommand(
+					{ type: 'send_command', sessionId: agentIdArg, command: message, inputMode: 'ai' },
+					'command_result'
+				);
+			});
+			const response: SendResponse = {
+				agentId: agentIdArg,
+				agentName: 'live',
+				sessionId: null,
+				response: null,
+				success: true,
+				usage: null,
+			};
+			console.log(JSON.stringify(response, null, 2));
+		} catch {
+			emitErrorJson('Maestro desktop is not running or not reachable', 'MAESTRO_NOT_RUNNING');
+			process.exit(1);
+		}
+		return;
+	}
+
 	// Resolve agent ID (supports partial IDs)
 	let agentId: string;
 	try {

--- a/src/cli/commands/send.ts
+++ b/src/cli/commands/send.ts
@@ -109,8 +109,14 @@ export async function send(
 				lowerMsg.includes('etimedout')
 			) {
 				emitErrorJson('Maestro desktop is not running or not reachable', 'MAESTRO_NOT_RUNNING');
+			} else if (
+				lowerMsg.includes('session not found') ||
+				lowerMsg.includes('no such session') ||
+				lowerMsg.includes('unknown session')
+			) {
+				emitErrorJson(`Session not found: ${agentIdArg}`, 'SESSION_NOT_FOUND');
 			} else {
-				emitErrorJson(`Session not found or command failed: ${agentIdArg}`, 'SESSION_NOT_FOUND');
+				emitErrorJson(`Command failed: ${msg}`, 'COMMAND_FAILED');
 			}
 			process.exit(1);
 		}

--- a/src/cli/commands/send.ts
+++ b/src/cli/commands/send.ts
@@ -98,8 +98,20 @@ export async function send(
 				usage: null,
 			};
 			console.log(JSON.stringify(response, null, 2));
-		} catch {
-			emitErrorJson('Maestro desktop is not running or not reachable', 'MAESTRO_NOT_RUNNING');
+		} catch (error) {
+			const msg = error instanceof Error ? error.message : String(error);
+			const lowerMsg = msg.toLowerCase();
+			if (
+				lowerMsg.includes('econnrefused') ||
+				lowerMsg.includes('connection refused') ||
+				lowerMsg.includes('websocket') ||
+				lowerMsg.includes('enotfound') ||
+				lowerMsg.includes('etimedout')
+			) {
+				emitErrorJson('Maestro desktop is not running or not reachable', 'MAESTRO_NOT_RUNNING');
+			} else {
+				emitErrorJson(`Session not found or command failed: ${agentIdArg}`, 'SESSION_NOT_FOUND');
+			}
 			process.exit(1);
 		}
 		return;

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -19,6 +19,7 @@ import { refreshAutoRun } from './commands/refresh-auto-run';
 import { status } from './commands/status';
 import { autoRun } from './commands/auto-run';
 import { cueTrigger } from './commands/cue-trigger';
+import { cueList } from './commands/cue-list';
 import { createAgent } from './commands/create-agent';
 import { removeAgent } from './commands/remove-agent';
 import { listSshRemotes } from './commands/list-ssh-remotes';
@@ -185,6 +186,7 @@ cue
 	.option('--json', 'Output as JSON (for scripting)')
 	.action(cueTrigger);
 
+<<<<<<< HEAD
 // Director's Notes commands
 const directorNotes = program
 	.command('director-notes')
@@ -207,6 +209,13 @@ directorNotes
 	.option('-f, --format <type>', 'Output format: json, markdown, text (default: text)')
 	.option('--json', 'Output as JSON (shorthand for --format json)')
 	.action(directorNotesSynopsis);
+=======
+cue
+	.command('list')
+	.description('List all Cue subscriptions across agents')
+	.option('--json', 'Output as JSON (for scripting)')
+	.action(cueList);
+>>>>>>> dc6377aa9 (feat: add cue list command, wire triggerSubscription callback, and document cli.trigger)
 
 // Status command - check if Maestro desktop app is running and reachable
 program

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -188,7 +188,12 @@ cue
 	.option('--source-agent-id <id>', 'Agent ID to pass as source context for write-back')
 	.action(cueTrigger);
 
-<<<<<<< HEAD
+cue
+	.command('list')
+	.description('List all Cue subscriptions across agents')
+	.option('--json', 'Output as JSON (for scripting)')
+	.action(cueList);
+
 // Director's Notes commands
 const directorNotes = program
 	.command('director-notes')
@@ -211,13 +216,6 @@ directorNotes
 	.option('-f, --format <type>', 'Output format: json, markdown, text (default: text)')
 	.option('--json', 'Output as JSON (shorthand for --format json)')
 	.action(directorNotesSynopsis);
-=======
-cue
-	.command('list')
-	.description('List all Cue subscriptions across agents')
-	.option('--json', 'Output as JSON (for scripting)')
-	.action(cueList);
->>>>>>> dc6377aa9 (feat: add cue list command, wire triggerSubscription callback, and document cli.trigger)
 
 // Status command - check if Maestro desktop app is running and reachable
 program

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -139,6 +139,7 @@ program
 	.option('-s, --session <id>', 'Resume an existing agent session (for multi-turn conversations)')
 	.option('-r, --read-only', 'Run in read-only/plan mode (agent cannot modify files)')
 	.option('-t, --tab', 'Open/focus the session tab in Maestro desktop')
+	.option('-l, --live', 'Send message through Maestro desktop (appears in tab)')
 	.action(send);
 
 // Open file command - open a file in the Maestro desktop app
@@ -184,6 +185,7 @@ cue
 	.description('Manually trigger a Cue subscription by name')
 	.option('-p, --prompt <text>', 'Override the subscription prompt with custom text')
 	.option('--json', 'Output as JSON (for scripting)')
+	.option('--source-agent-id <id>', 'Agent ID to pass as source context for write-back')
 	.action(cueTrigger);
 
 <<<<<<< HEAD

--- a/src/main/cue/config/cue-config-normalizer.ts
+++ b/src/main/cue/config/cue-config-normalizer.ts
@@ -140,7 +140,8 @@ function normalizeSubscription(
 				? (sub.forward_output_from as string[])
 				: undefined,
 		cli_output:
-			typeof sub.cli_output === 'object' && sub.cli_output !== null &&
+			typeof sub.cli_output === 'object' &&
+			sub.cli_output !== null &&
 			typeof (sub.cli_output as Record<string, unknown>).target === 'string' &&
 			((sub.cli_output as Record<string, unknown>).target as string).trim() !== ''
 				? { target: String((sub.cli_output as Record<string, unknown>).target) }

--- a/src/main/cue/config/cue-config-normalizer.ts
+++ b/src/main/cue/config/cue-config-normalizer.ts
@@ -139,6 +139,12 @@ function normalizeSubscription(
 			sub.forward_output_from.every((value: unknown) => typeof value === 'string')
 				? (sub.forward_output_from as string[])
 				: undefined,
+		cli_output:
+			typeof sub.cli_output === 'object' && sub.cli_output !== null &&
+			typeof (sub.cli_output as Record<string, unknown>).target === 'string' &&
+			((sub.cli_output as Record<string, unknown>).target as string).trim() !== ''
+				? { target: String((sub.cli_output as Record<string, unknown>).target) }
+				: undefined,
 	};
 }
 

--- a/src/main/cue/config/cue-config-normalizer.ts
+++ b/src/main/cue/config/cue-config-normalizer.ts
@@ -144,7 +144,7 @@ function normalizeSubscription(
 			sub.cli_output !== null &&
 			typeof (sub.cli_output as Record<string, unknown>).target === 'string' &&
 			((sub.cli_output as Record<string, unknown>).target as string).trim() !== ''
-				? { target: String((sub.cli_output as Record<string, unknown>).target) }
+				? { target: String((sub.cli_output as Record<string, unknown>).target).trim() }
 				: undefined,
 	};
 }

--- a/src/main/cue/cue-dispatch-service.ts
+++ b/src/main/cue/cue-dispatch-service.ts
@@ -91,7 +91,15 @@ export function createCueDispatchService(deps: CueDispatchServiceDeps): CueDispa
 				deps.onLog('warn', `[CUE] "${sub.name}" has no prompt — skipping dispatch`);
 				return;
 			}
-			deps.executeRun(ownerSessionId, prompt, event, sub.name, sub.output_prompt, chainDepth, sub.cli_output);
+			deps.executeRun(
+				ownerSessionId,
+				prompt,
+				event,
+				sub.name,
+				sub.output_prompt,
+				chainDepth,
+				sub.cli_output
+			);
 		},
 	};
 }

--- a/src/main/cue/cue-dispatch-service.ts
+++ b/src/main/cue/cue-dispatch-service.ts
@@ -10,7 +10,8 @@ export interface CueDispatchServiceDeps {
 		event: CueEvent,
 		subscriptionName: string,
 		outputPrompt?: string,
-		chainDepth?: number
+		chainDepth?: number,
+		cliOutput?: { target: string }
 	) => void;
 	onLog: (level: MainLogLevel, message: string, data?: unknown) => void;
 }
@@ -78,7 +79,8 @@ export function createCueDispatchService(deps: CueDispatchServiceDeps): CueDispa
 						fanOutEvent,
 						sub.name,
 						sub.output_prompt,
-						chainDepth
+						chainDepth,
+						sub.cli_output
 					);
 				}
 				return;
@@ -89,7 +91,7 @@ export function createCueDispatchService(deps: CueDispatchServiceDeps): CueDispa
 				deps.onLog('warn', `[CUE] "${sub.name}" has no prompt — skipping dispatch`);
 				return;
 			}
-			deps.executeRun(ownerSessionId, prompt, event, sub.name, sub.output_prompt, chainDepth);
+			deps.executeRun(ownerSessionId, prompt, event, sub.name, sub.output_prompt, chainDepth, sub.cli_output);
 		},
 	};
 }

--- a/src/main/cue/cue-engine.ts
+++ b/src/main/cue/cue-engine.ts
@@ -139,7 +139,15 @@ export class CueEngine {
 		});
 		this.dispatchService = createCueDispatchService({
 			getSessions: deps.getSessions,
-			executeRun: (sessionId, prompt, event, subscriptionName, outputPrompt, chainDepth, cliOutput) => {
+			executeRun: (
+				sessionId,
+				prompt,
+				event,
+				subscriptionName,
+				outputPrompt,
+				chainDepth,
+				cliOutput
+			) => {
 				this.runManager.execute(
 					sessionId,
 					prompt,
@@ -376,7 +384,11 @@ export class CueEngine {
 	 * Creates a synthetic event and dispatches through the normal execution path.
 	 * Returns true if the subscription was found and triggered.
 	 */
-	triggerSubscription(subscriptionName: string, promptOverride?: string, sourceAgentId?: string): boolean {
+	triggerSubscription(
+		subscriptionName: string,
+		promptOverride?: string,
+		sourceAgentId?: string
+	): boolean {
 		for (const [sessionId, state] of this.registry.snapshot()) {
 			for (const sub of state.config.subscriptions) {
 				if (sub.name !== subscriptionName) continue;

--- a/src/main/cue/cue-engine.ts
+++ b/src/main/cue/cue-engine.ts
@@ -375,7 +375,7 @@ export class CueEngine {
 	 * Creates a synthetic event and dispatches through the normal execution path.
 	 * Returns true if the subscription was found and triggered.
 	 */
-	triggerSubscription(subscriptionName: string, promptOverride?: string): boolean {
+	triggerSubscription(subscriptionName: string, promptOverride?: string, sourceAgentId?: string): boolean {
 		for (const [sessionId, state] of this.registry.snapshot()) {
 			for (const sub of state.config.subscriptions) {
 				if (sub.name !== subscriptionName) continue;
@@ -383,6 +383,7 @@ export class CueEngine {
 
 				const event = createCueEvent(sub.event, sub.name, {
 					manual: true,
+					...(sourceAgentId ? { sourceAgentId } : {}),
 					...(promptOverride ? { cliPrompt: promptOverride } : {}),
 				});
 

--- a/src/main/cue/cue-engine.ts
+++ b/src/main/cue/cue-engine.ts
@@ -139,14 +139,15 @@ export class CueEngine {
 		});
 		this.dispatchService = createCueDispatchService({
 			getSessions: deps.getSessions,
-			executeRun: (sessionId, prompt, event, subscriptionName, outputPrompt, chainDepth) => {
+			executeRun: (sessionId, prompt, event, subscriptionName, outputPrompt, chainDepth, cliOutput) => {
 				this.runManager.execute(
 					sessionId,
 					prompt,
 					event,
 					subscriptionName,
 					outputPrompt,
-					chainDepth
+					chainDepth,
+					cliOutput
 				);
 			},
 			onLog: deps.onLog,

--- a/src/main/cue/cue-process-lifecycle.ts
+++ b/src/main/cue/cue-process-lifecycle.ts
@@ -70,8 +70,10 @@ const activeProcesses = new Map<string, CueActiveProcess>();
 /**
  * Extract clean human-readable text from agent stdout.
  * For agents that output JSON/NDJSON (like OpenCode --format json), parses each
- * line and collects text from 'result' events. Falls back to raw stdout when no
- * parser is available or no result-text events are found (e.g. plain-text agents).
+ * line and collects text from 'result' events. When 'result' events have empty
+ * text (e.g. Claude Code sometimes returns result:""), falls back to collecting
+ * text from 'assistant' (partial) events. Falls back to raw stdout when no
+ * parser is available or no text events are found (e.g. plain-text agents).
  */
 function extractCleanStdout(rawStdout: string, toolType: string): string {
 	if (!rawStdout.trim()) {
@@ -83,16 +85,21 @@ function extractCleanStdout(rawStdout: string, toolType: string): string {
 		return rawStdout;
 	}
 
-	const textParts: string[] = [];
+	const resultParts: string[] = [];
+	const assistantParts: string[] = [];
 	for (const line of rawStdout.split('\n')) {
 		if (!line.trim()) continue;
 		const event = parser.parseJsonLine(line);
 		if (event?.type === 'result' && event.text) {
-			textParts.push(event.text);
+			resultParts.push(event.text);
+		} else if (event?.type === 'text' && event.isPartial && event.text) {
+			assistantParts.push(event.text);
 		}
 	}
 
-	return textParts.length > 0 ? textParts.join('\n') : rawStdout;
+	if (resultParts.length > 0) return resultParts.join('\n');
+	if (assistantParts.length > 0) return assistantParts.join('\n');
+	return rawStdout;
 }
 
 /**

--- a/src/main/cue/cue-process-lifecycle.ts
+++ b/src/main/cue/cue-process-lifecycle.ts
@@ -86,19 +86,30 @@ function extractCleanStdout(rawStdout: string, toolType: string): string {
 	}
 
 	const resultParts: string[] = [];
-	const assistantParts: string[] = [];
+	const assistantTextByMessage = new Map<string, string>();
+	const assistantTextWithoutId: string[] = [];
 	for (const line of rawStdout.split('\n')) {
 		if (!line.trim()) continue;
 		const event = parser.parseJsonLine(line);
 		if (event?.type === 'result' && event.text) {
 			resultParts.push(event.text);
 		} else if (event?.type === 'text' && event.isPartial && event.text) {
-			assistantParts.push(event.text);
+			const raw = event.raw as { message?: { id?: string } } | undefined;
+			const msgId = raw?.message?.id;
+			if (msgId) {
+				const existing = assistantTextByMessage.get(msgId) ?? '';
+				if (event.text.length > existing.length) {
+					assistantTextByMessage.set(msgId, event.text);
+				}
+			} else {
+				assistantTextWithoutId.push(event.text);
+			}
 		}
 	}
 
 	if (resultParts.length > 0) return resultParts.join('\n');
-	if (assistantParts.length > 0) return assistantParts.join('\n');
+	const deduped = [...assistantTextByMessage.values(), ...assistantTextWithoutId];
+	if (deduped.length > 0) return deduped.join('\n');
 	return rawStdout;
 }
 

--- a/src/main/cue/cue-run-manager.ts
+++ b/src/main/cue/cue-run-manager.ts
@@ -19,6 +19,7 @@ import { execFile } from 'child_process';
 import { promisify } from 'util';
 import { captureException } from '../utils/sentry';
 import { substituteTemplateVariables, type TemplateContext } from '../../shared/templateVariables';
+import { getShellPath } from '../runtime/getShellPath';
 
 /** Phase of a run in the state machine: running → stopping | finished */
 export type RunPhase = 'running' | 'stopping' | 'finished';
@@ -295,6 +296,10 @@ export function createCueRunManager(deps: CueRunManagerDeps): CueRunManager {
 
 			// Phase 3: CLI Output delivery — shell out to maestro-cli send --live
 			if (cliOutput && result.status === 'completed') {
+				deps.onLog(
+					'cue',
+					`[CUE] "${subscriptionName}" Phase 3: delivering CLI output to target="${cliOutput.target}" (stdout length=${result.stdout.length})`
+				);
 				try {
 					const execFileAsync = promisify(execFile);
 					// Build a minimal template context for variable substitution in the target
@@ -308,9 +313,27 @@ export function createCueRunManager(deps: CueRunManagerDeps): CueRunManager {
 						cue: event.payload as TemplateContext['cue'],
 					};
 					const resolvedTarget = substituteTemplateVariables(cliOutput.target, templateContext);
-					const truncatedOutput = result.stdout.substring(0, 100_000);
-					await execFileAsync('maestro-cli', ['send', resolvedTarget, truncatedOutput, '--live', '--json']);
-					deps.onLog('cue', `[CUE] "${subscriptionName}" CLI output delivered to ${resolvedTarget}`);
+					if (!resolvedTarget || resolvedTarget.trim() === '') {
+						deps.onLog(
+							'warn',
+							`[CUE] "${subscriptionName}" CLI output target resolved to empty string (raw="${cliOutput.target}") — skipping delivery`
+						);
+					} else {
+						const truncatedOutput = result.stdout.substring(0, 100_000);
+						const shellPath = await getShellPath();
+						await execFileAsync(
+							'maestro-cli',
+							['send', resolvedTarget, truncatedOutput, '--live'],
+							{
+								env: { ...process.env, PATH: shellPath || process.env.PATH },
+								timeout: 30_000,
+							}
+						);
+						deps.onLog(
+							'cue',
+							`[CUE] "${subscriptionName}" CLI output delivered to ${resolvedTarget}`
+						);
+					}
 				} catch (cliError) {
 					deps.onLog(
 						'warn',
@@ -318,6 +341,11 @@ export function createCueRunManager(deps: CueRunManagerDeps): CueRunManager {
 					);
 					// Non-fatal — don't change result.status
 				}
+			} else if (cliOutput && result.status !== 'completed') {
+				deps.onLog(
+					'cue',
+					`[CUE] "${subscriptionName}" Phase 3 skipped: run status="${result.status}" (not completed)`
+				);
 			}
 		} catch (error) {
 			if (!activeRuns.has(runId)) {
@@ -414,7 +442,15 @@ export function createCueRunManager(deps: CueRunManagerDeps): CueRunManager {
 
 			// Slot available — dispatch immediately
 			activeRunCount.set(sessionId, currentCount + 1);
-			doExecuteCueRun(sessionId, prompt, event, subscriptionName, outputPrompt, chainDepth, cliOutput);
+			doExecuteCueRun(
+				sessionId,
+				prompt,
+				event,
+				subscriptionName,
+				outputPrompt,
+				chainDepth,
+				cliOutput
+			);
 		},
 
 		stopRun(runId: string): boolean {

--- a/src/main/cue/cue-run-manager.ts
+++ b/src/main/cue/cue-run-manager.ts
@@ -15,16 +15,10 @@ import type { MainLogLevel } from '../../shared/logger-types';
 import type { CueEvent, CueRunResult, CueSettings, CueSubscription } from './cue-types';
 import { updateCueEventStatus, safeRecordCueEvent, safeUpdateCueEventStatus } from './cue-db';
 import { SOURCE_OUTPUT_MAX_CHARS } from './cue-fan-in-tracker';
-import { execFile } from 'child_process';
-import { promisify } from 'util';
 import { captureException } from '../utils/sentry';
-import {
-	substituteTemplateVariables,
-	getMaestroCLIPath,
-	type TemplateContext,
-} from '../../shared/templateVariables';
+import { execFileNoThrow } from '../utils/execFile';
+import { substituteTemplateVariables, type TemplateContext } from '../../shared/templateVariables';
 import { buildCueTemplateContext } from './cue-template-context-builder';
-import { getShellPath } from '../runtime/getShellPath';
 
 /** Phase of a run in the state machine: running → stopping | finished */
 export type RunPhase = 'running' | 'stopping' | 'finished';
@@ -306,7 +300,6 @@ export function createCueRunManager(deps: CueRunManagerDeps): CueRunManager {
 					`[CUE] "${subscriptionName}" Phase 3: delivering CLI output to target="${cliOutput.target}" (stdout length=${result.stdout.length})`
 				);
 				try {
-					const execFileAsync = promisify(execFile);
 					const cueContext = buildCueTemplateContext(
 						event,
 						{ name: subscriptionName, event: event.type, enabled: true, prompt: '' },
@@ -329,29 +322,34 @@ export function createCueRunManager(deps: CueRunManagerDeps): CueRunManager {
 						);
 					} else {
 						const truncatedOutput = result.stdout.substring(0, 100_000);
-						const shellPath = await getShellPath();
-						const cliPath = getMaestroCLIPath();
-						const [cliCmd, ...cliBaseArgs] = cliPath.split(/\s+/);
-						const cleanArgs = cliBaseArgs.map((a) => a.replace(/^"|"$/g, ''));
-						await execFileAsync(
-							cliCmd,
-							[...cleanArgs, 'send', resolvedTarget, truncatedOutput, '--live'],
-							{
-								env: { ...process.env, PATH: shellPath || process.env.PATH },
-								timeout: 30_000,
-							}
+						const cliScriptPath = require('path').join(
+							process.resourcesPath ?? '',
+							'maestro-cli.js'
 						);
+						const cliResult = await execFileNoThrow(
+							process.execPath,
+							[cliScriptPath, 'send', resolvedTarget, truncatedOutput, '--live'],
+							undefined,
+							{ timeout: 30_000 }
+						);
+						if (cliResult.exitCode !== 0) {
+							throw new Error(`CLI exited with code ${cliResult.exitCode}: ${cliResult.stderr}`);
+						}
 						deps.onLog(
 							'cue',
 							`[CUE] "${subscriptionName}" CLI output delivered to ${resolvedTarget}`
 						);
 					}
 				} catch (cliError) {
+					captureException(cliError, {
+						operation: 'cue:cliOutputDelivery',
+						subscriptionName,
+						target: cliOutput.target,
+					});
 					deps.onLog(
 						'warn',
 						`[CUE] "${subscriptionName}" CLI output delivery failed: ${cliError instanceof Error ? cliError.message : String(cliError)}`
 					);
-					// Non-fatal — don't change result.status
 				}
 			} else if (cliOutput && result.status !== 'completed') {
 				deps.onLog(

--- a/src/main/cue/cue-run-manager.ts
+++ b/src/main/cue/cue-run-manager.ts
@@ -15,7 +15,10 @@ import type { MainLogLevel } from '../../shared/logger-types';
 import type { CueEvent, CueRunResult, CueSettings, CueSubscription } from './cue-types';
 import { updateCueEventStatus, safeRecordCueEvent, safeUpdateCueEventStatus } from './cue-db';
 import { SOURCE_OUTPUT_MAX_CHARS } from './cue-fan-in-tracker';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
 import { captureException } from '../utils/sentry';
+import { substituteTemplateVariables, type TemplateContext } from '../../shared/templateVariables';
 
 /** Phase of a run in the state machine: running → stopping | finished */
 export type RunPhase = 'running' | 'stopping' | 'finished';
@@ -38,6 +41,7 @@ export interface QueuedEvent {
 	subscriptionName: string;
 	queuedAt: number;
 	chainDepth?: number;
+	cliOutput?: { target: string };
 }
 
 export interface CueRunManagerDeps {
@@ -75,7 +79,8 @@ export interface CueRunManager {
 		event: CueEvent,
 		subscriptionName: string,
 		outputPrompt?: string,
-		chainDepth?: number
+		chainDepth?: number,
+		cliOutput?: { target: string }
 	): void;
 	stopRun(runId: string): boolean;
 	stopAll(): void;
@@ -143,7 +148,8 @@ export function createCueRunManager(deps: CueRunManagerDeps): CueRunManager {
 				entry.event,
 				entry.subscriptionName,
 				entry.outputPrompt,
-				entry.chainDepth
+				entry.chainDepth,
+				entry.cliOutput
 			);
 		}
 
@@ -159,7 +165,8 @@ export function createCueRunManager(deps: CueRunManagerDeps): CueRunManager {
 		event: CueEvent,
 		subscriptionName: string,
 		outputPrompt?: string,
-		chainDepth?: number
+		chainDepth?: number,
+		cliOutput?: { target: string }
 	): Promise<void> {
 		const sessionName = getSessionName(sessionId);
 		const settings = deps.getSessionSettings(sessionId);
@@ -285,6 +292,33 @@ export function createCueRunManager(deps: CueRunManagerDeps): CueRunManager {
 					);
 				}
 			}
+
+			// Phase 3: CLI Output delivery — shell out to maestro-cli send --live
+			if (cliOutput && result.status === 'completed') {
+				try {
+					const execFileAsync = promisify(execFile);
+					// Build a minimal template context for variable substitution in the target
+					const templateContext: TemplateContext = {
+						session: {
+							id: sessionId,
+							name: sessionName,
+							toolType: '',
+							cwd: '',
+						},
+						cue: event.payload as TemplateContext['cue'],
+					};
+					const resolvedTarget = substituteTemplateVariables(cliOutput.target, templateContext);
+					const truncatedOutput = result.stdout.substring(0, 100_000);
+					await execFileAsync('maestro-cli', ['send', resolvedTarget, truncatedOutput, '--live', '--json']);
+					deps.onLog('cue', `[CUE] "${subscriptionName}" CLI output delivered to ${resolvedTarget}`);
+				} catch (cliError) {
+					deps.onLog(
+						'warn',
+						`[CUE] "${subscriptionName}" CLI output delivery failed: ${cliError instanceof Error ? cliError.message : String(cliError)}`
+					);
+					// Non-fatal — don't change result.status
+				}
+			}
 		} catch (error) {
 			if (!activeRuns.has(runId)) {
 				return;
@@ -338,7 +372,8 @@ export function createCueRunManager(deps: CueRunManagerDeps): CueRunManager {
 			event: CueEvent,
 			subscriptionName: string,
 			outputPrompt?: string,
-			chainDepth?: number
+			chainDepth?: number,
+			cliOutput?: { target: string }
 		): void {
 			const settings = deps.getSessionSettings(sessionId);
 			const maxConcurrent = settings?.max_concurrent ?? 1;
@@ -367,6 +402,7 @@ export function createCueRunManager(deps: CueRunManagerDeps): CueRunManager {
 					subscriptionName,
 					queuedAt: Date.now(),
 					chainDepth,
+					cliOutput,
 				});
 
 				deps.onLog(
@@ -378,7 +414,7 @@ export function createCueRunManager(deps: CueRunManagerDeps): CueRunManager {
 
 			// Slot available — dispatch immediately
 			activeRunCount.set(sessionId, currentCount + 1);
-			doExecuteCueRun(sessionId, prompt, event, subscriptionName, outputPrompt, chainDepth);
+			doExecuteCueRun(sessionId, prompt, event, subscriptionName, outputPrompt, chainDepth, cliOutput);
 		},
 
 		stopRun(runId: string): boolean {

--- a/src/main/cue/cue-run-manager.ts
+++ b/src/main/cue/cue-run-manager.ts
@@ -18,7 +18,12 @@ import { SOURCE_OUTPUT_MAX_CHARS } from './cue-fan-in-tracker';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
 import { captureException } from '../utils/sentry';
-import { substituteTemplateVariables, type TemplateContext } from '../../shared/templateVariables';
+import {
+	substituteTemplateVariables,
+	getMaestroCLIPath,
+	type TemplateContext,
+} from '../../shared/templateVariables';
+import { buildCueTemplateContext } from './cue-template-context-builder';
 import { getShellPath } from '../runtime/getShellPath';
 
 /** Phase of a run in the state machine: running → stopping | finished */
@@ -302,7 +307,11 @@ export function createCueRunManager(deps: CueRunManagerDeps): CueRunManager {
 				);
 				try {
 					const execFileAsync = promisify(execFile);
-					// Build a minimal template context for variable substitution in the target
+					const cueContext = buildCueTemplateContext(
+						event,
+						{ name: subscriptionName, event: event.type, enabled: true, prompt: '' },
+						runId
+					);
 					const templateContext: TemplateContext = {
 						session: {
 							id: sessionId,
@@ -310,7 +319,7 @@ export function createCueRunManager(deps: CueRunManagerDeps): CueRunManager {
 							toolType: '',
 							cwd: '',
 						},
-						cue: event.payload as TemplateContext['cue'],
+						cue: cueContext,
 					};
 					const resolvedTarget = substituteTemplateVariables(cliOutput.target, templateContext);
 					if (!resolvedTarget || resolvedTarget.trim() === '') {
@@ -321,9 +330,12 @@ export function createCueRunManager(deps: CueRunManagerDeps): CueRunManager {
 					} else {
 						const truncatedOutput = result.stdout.substring(0, 100_000);
 						const shellPath = await getShellPath();
+						const cliPath = getMaestroCLIPath();
+						const [cliCmd, ...cliBaseArgs] = cliPath.split(/\s+/);
+						const cleanArgs = cliBaseArgs.map((a) => a.replace(/^"|"$/g, ''));
 						await execFileAsync(
-							'maestro-cli',
-							['send', resolvedTarget, truncatedOutput, '--live'],
+							cliCmd,
+							[...cleanArgs, 'send', resolvedTarget, truncatedOutput, '--live'],
 							{
 								env: { ...process.env, PATH: shellPath || process.env.PATH },
 								timeout: 30_000,

--- a/src/main/cue/cue-template-context-builder.ts
+++ b/src/main/cue/cue-template-context-builder.ts
@@ -107,6 +107,7 @@ enricherRegistry.set('github.issue', (event) => buildGitHubContext(event));
 /** cli.trigger enricher — adds CLI-specific fields. */
 enricherRegistry.set('cli.trigger', (event) => ({
 	cliPrompt: String(event.payload.cliPrompt ?? ''),
+	sourceAgentId: String(event.payload.sourceAgentId ?? ''),
 }));
 
 // ─── Public API ──────────────────────────────────────────────────────────────

--- a/src/main/cue/cue-template-context-builder.ts
+++ b/src/main/cue/cue-template-context-builder.ts
@@ -104,7 +104,7 @@ function buildGitHubContext(event: CueEvent): Record<string, string> {
 enricherRegistry.set('github.pull_request', (event) => buildGitHubContext(event));
 enricherRegistry.set('github.issue', (event) => buildGitHubContext(event));
 
-/** cli.trigger enricher — adds CLI prompt override field. */
+/** cli.trigger enricher — adds CLI-specific fields. */
 enricherRegistry.set('cli.trigger', (event) => ({
 	cliPrompt: String(event.payload.cliPrompt ?? ''),
 }));

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -320,6 +320,10 @@ const createWebServer = createWebServerFactory({
 	groupsStore,
 	getMainWindow: () => mainWindow,
 	getProcessManager: () => processManager,
+	triggerCueSubscription: (subscriptionName, prompt, sourceAgentId) => {
+		if (!cueEngine) return false;
+		return cueEngine.triggerSubscription(subscriptionName, prompt, sourceAgentId);
+	},
 });
 
 // createWindow is now handled by windowManager (Phase 4 refactoring)

--- a/src/main/ipc/handlers/cue.ts
+++ b/src/main/ipc/handlers/cue.ts
@@ -144,8 +144,16 @@ export function registerCueHandlers(deps: CueHandlerDependencies): void {
 		'cue:triggerSubscription',
 		withIpcErrorLogging(
 			handlerOpts('triggerSubscription'),
-			async (options: { subscriptionName: string; prompt?: string; sourceAgentId?: string }): Promise<boolean> => {
-				return requireEngine().triggerSubscription(options.subscriptionName, options.prompt, options.sourceAgentId);
+			async (options: {
+				subscriptionName: string;
+				prompt?: string;
+				sourceAgentId?: string;
+			}): Promise<boolean> => {
+				return requireEngine().triggerSubscription(
+					options.subscriptionName,
+					options.prompt,
+					options.sourceAgentId
+				);
 			}
 		)
 	);

--- a/src/main/ipc/handlers/cue.ts
+++ b/src/main/ipc/handlers/cue.ts
@@ -144,8 +144,8 @@ export function registerCueHandlers(deps: CueHandlerDependencies): void {
 		'cue:triggerSubscription',
 		withIpcErrorLogging(
 			handlerOpts('triggerSubscription'),
-			async (options: { subscriptionName: string; prompt?: string }): Promise<boolean> => {
-				return requireEngine().triggerSubscription(options.subscriptionName, options.prompt);
+			async (options: { subscriptionName: string; prompt?: string; sourceAgentId?: string }): Promise<boolean> => {
+				return requireEngine().triggerSubscription(options.subscriptionName, options.prompt, options.sourceAgentId);
 			}
 		)
 	);

--- a/src/main/preload/cue.ts
+++ b/src/main/preload/cue.ts
@@ -60,7 +60,11 @@ export function createCueApi() {
 		stopAll: (): Promise<void> => ipcRenderer.invoke('cue:stopAll'),
 
 		// Manually trigger a subscription by name (Run Now), with optional prompt override
-		triggerSubscription: (subscriptionName: string, prompt?: string, sourceAgentId?: string): Promise<boolean> =>
+		triggerSubscription: (
+			subscriptionName: string,
+			prompt?: string,
+			sourceAgentId?: string
+		): Promise<boolean> =>
 			ipcRenderer.invoke('cue:triggerSubscription', { subscriptionName, prompt, sourceAgentId }),
 
 		// Get queue status per session

--- a/src/main/preload/cue.ts
+++ b/src/main/preload/cue.ts
@@ -60,8 +60,8 @@ export function createCueApi() {
 		stopAll: (): Promise<void> => ipcRenderer.invoke('cue:stopAll'),
 
 		// Manually trigger a subscription by name (Run Now), with optional prompt override
-		triggerSubscription: (subscriptionName: string, prompt?: string): Promise<boolean> =>
-			ipcRenderer.invoke('cue:triggerSubscription', { subscriptionName, prompt }),
+		triggerSubscription: (subscriptionName: string, prompt?: string, sourceAgentId?: string): Promise<boolean> =>
+			ipcRenderer.invoke('cue:triggerSubscription', { subscriptionName, prompt, sourceAgentId }),
 
 		// Get queue status per session
 		getQueueStatus: (): Promise<Record<string, number>> => ipcRenderer.invoke('cue:getQueueStatus'),

--- a/src/main/preload/process.ts
+++ b/src/main/preload/process.ts
@@ -1092,17 +1092,19 @@ export function createProcessApi() {
 			callback: (
 				subscriptionName: string,
 				prompt: string | undefined,
-				responseChannel: string
+				responseChannel: string,
+				sourceAgentId: string | undefined
 			) => void
 		): (() => void) => {
 			const handler = (
 				_: unknown,
 				subscriptionName: string,
 				prompt: string | undefined,
-				responseChannel: string
+				responseChannel: string,
+				sourceAgentId: string | undefined
 			) => {
 				try {
-					Promise.resolve(callback(subscriptionName, prompt, responseChannel)).catch(() => {
+					Promise.resolve(callback(subscriptionName, prompt, responseChannel, sourceAgentId)).catch(() => {
 						ipcRenderer.send(responseChannel, false);
 					});
 				} catch {

--- a/src/main/preload/process.ts
+++ b/src/main/preload/process.ts
@@ -1104,9 +1104,11 @@ export function createProcessApi() {
 				sourceAgentId: string | undefined
 			) => {
 				try {
-					Promise.resolve(callback(subscriptionName, prompt, responseChannel, sourceAgentId)).catch(() => {
-						ipcRenderer.send(responseChannel, false);
-					});
+					Promise.resolve(callback(subscriptionName, prompt, responseChannel, sourceAgentId)).catch(
+						() => {
+							ipcRenderer.send(responseChannel, false);
+						}
+					);
 				} catch {
 					ipcRenderer.send(responseChannel, false);
 				}

--- a/src/main/preload/process.ts
+++ b/src/main/preload/process.ts
@@ -1105,11 +1105,13 @@ export function createProcessApi() {
 			) => {
 				try {
 					Promise.resolve(callback(subscriptionName, prompt, responseChannel, sourceAgentId)).catch(
-						() => {
+						(error) => {
+							console.error('[Cue] Remote trigger callback failed:', error);
 							ipcRenderer.send(responseChannel, false);
 						}
 					);
-				} catch {
+				} catch (error) {
+					console.error('[Cue] Remote trigger callback threw:', error);
 					ipcRenderer.send(responseChannel, false);
 				}
 			};

--- a/src/main/utils/agent-args.ts
+++ b/src/main/utils/agent-args.ts
@@ -67,7 +67,11 @@ export function buildAgentArgs(
 		}
 	}
 
-	if (agent.jsonOutputArgs && !finalArgs.some((arg) => agent.jsonOutputArgs!.includes(arg))) {
+	if (
+		agent.jsonOutputArgs &&
+		options.prompt &&
+		!finalArgs.some((arg) => agent.jsonOutputArgs!.includes(arg))
+	) {
 		finalArgs = [...finalArgs, ...agent.jsonOutputArgs];
 	}
 

--- a/src/main/web-server/WebServer.ts
+++ b/src/main/web-server/WebServer.ts
@@ -104,6 +104,7 @@ import type {
 	ToggleCueSubscriptionCallback,
 	TriggerCueSubscriptionCallback,
 	GetCueActivityCallback,
+	TriggerCueSubscriptionCallback,
 	CueActivityEntry,
 	CueSubscriptionInfo,
 	GetUsageDashboardCallback,
@@ -549,6 +550,10 @@ export class WebServer {
 		this.callbackRegistry.setGetCueActivityCallback(callback);
 	}
 
+	setTriggerCueSubscriptionCallback(callback: TriggerCueSubscriptionCallback): void {
+		this.callbackRegistry.setTriggerCueSubscriptionCallback(callback);
+	}
+
 	setGetUsageDashboardCallback(callback: GetUsageDashboardCallback): void {
 		this.callbackRegistry.setGetUsageDashboardCallback(callback);
 	}
@@ -779,6 +784,8 @@ export class WebServer {
 				this.callbackRegistry.toggleCueSubscription(subscriptionId, enabled),
 			getCueActivity: async (sessionId?: string, limit?: number) =>
 				this.callbackRegistry.getCueActivity(sessionId, limit),
+			triggerCueSubscription: async (subscriptionName: string, prompt?: string) =>
+				this.callbackRegistry.triggerCueSubscription(subscriptionName, prompt),
 			getUsageDashboard: async (timeRange: 'day' | 'week' | 'month' | 'all') =>
 				this.callbackRegistry.getUsageDashboard(timeRange),
 			getAchievements: async () => this.callbackRegistry.getAchievements(),

--- a/src/main/web-server/WebServer.ts
+++ b/src/main/web-server/WebServer.ts
@@ -104,7 +104,6 @@ import type {
 	ToggleCueSubscriptionCallback,
 	TriggerCueSubscriptionCallback,
 	GetCueActivityCallback,
-	TriggerCueSubscriptionCallback,
 	CueActivityEntry,
 	CueSubscriptionInfo,
 	GetUsageDashboardCallback,
@@ -548,10 +547,6 @@ export class WebServer {
 
 	setGetCueActivityCallback(callback: GetCueActivityCallback): void {
 		this.callbackRegistry.setGetCueActivityCallback(callback);
-	}
-
-	setTriggerCueSubscriptionCallback(callback: TriggerCueSubscriptionCallback): void {
-		this.callbackRegistry.setTriggerCueSubscriptionCallback(callback);
 	}
 
 	setGetUsageDashboardCallback(callback: GetUsageDashboardCallback): void {

--- a/src/main/web-server/WebServer.ts
+++ b/src/main/web-server/WebServer.ts
@@ -784,8 +784,11 @@ export class WebServer {
 				this.callbackRegistry.toggleCueSubscription(subscriptionId, enabled),
 			getCueActivity: async (sessionId?: string, limit?: number) =>
 				this.callbackRegistry.getCueActivity(sessionId, limit),
-			triggerCueSubscription: async (subscriptionName: string, prompt?: string) =>
-				this.callbackRegistry.triggerCueSubscription(subscriptionName, prompt),
+			triggerCueSubscription: async (
+				subscriptionName: string,
+				prompt?: string,
+				sourceAgentId?: string
+			) => this.callbackRegistry.triggerCueSubscription(subscriptionName, prompt, sourceAgentId),
 			getUsageDashboard: async (timeRange: 'day' | 'week' | 'month' | 'all') =>
 				this.callbackRegistry.getUsageDashboard(timeRange),
 			getAchievements: async () => this.callbackRegistry.getAchievements(),

--- a/src/main/web-server/handlers/messageHandlers.ts
+++ b/src/main/web-server/handlers/messageHandlers.ts
@@ -178,7 +178,7 @@ export interface MessageHandlerCallbacks {
 	getCueSubscriptions: (sessionId?: string) => Promise<CueSubscriptionInfo[]>;
 	toggleCueSubscription: (subscriptionId: string, enabled: boolean) => Promise<boolean>;
 	getCueActivity: (sessionId?: string, limit?: number) => Promise<CueActivityEntry[]>;
-	triggerCueSubscription: (subscriptionName: string, prompt?: string) => Promise<boolean>;
+	triggerCueSubscription: (subscriptionName: string, prompt?: string, sourceAgentId?: string) => Promise<boolean>;
 	getUsageDashboard: (timeRange: 'day' | 'week' | 'month' | 'all') => Promise<UsageDashboardData>;
 	getAchievements: () => Promise<AchievementData[]>;
 	generateDirectorNotesSynopsis: (
@@ -2369,8 +2369,10 @@ export class WebSocketMessageHandler {
 			return;
 		}
 
+		const sourceAgentId = message.sourceAgentId as string | undefined;
+
 		this.callbacks
-			.triggerCueSubscription(subscriptionName, prompt as string | undefined)
+			.triggerCueSubscription(subscriptionName, prompt as string | undefined, sourceAgentId)
 			.then((success) => {
 				this.send(client, {
 					type: 'trigger_cue_subscription_result',

--- a/src/main/web-server/handlers/messageHandlers.ts
+++ b/src/main/web-server/handlers/messageHandlers.ts
@@ -178,7 +178,11 @@ export interface MessageHandlerCallbacks {
 	getCueSubscriptions: (sessionId?: string) => Promise<CueSubscriptionInfo[]>;
 	toggleCueSubscription: (subscriptionId: string, enabled: boolean) => Promise<boolean>;
 	getCueActivity: (sessionId?: string, limit?: number) => Promise<CueActivityEntry[]>;
-	triggerCueSubscription: (subscriptionName: string, prompt?: string, sourceAgentId?: string) => Promise<boolean>;
+	triggerCueSubscription: (
+		subscriptionName: string,
+		prompt?: string,
+		sourceAgentId?: string
+	) => Promise<boolean>;
 	getUsageDashboard: (timeRange: 'day' | 'week' | 'month' | 'all') => Promise<UsageDashboardData>;
 	getAchievements: () => Promise<AchievementData[]>;
 	generateDirectorNotesSynopsis: (

--- a/src/main/web-server/handlers/messageHandlers.ts
+++ b/src/main/web-server/handlers/messageHandlers.ts
@@ -2373,7 +2373,12 @@ export class WebSocketMessageHandler {
 			return;
 		}
 
-		const sourceAgentId = message.sourceAgentId as string | undefined;
+		const rawSourceAgentId = message.sourceAgentId;
+		if (rawSourceAgentId !== undefined && typeof rawSourceAgentId !== 'string') {
+			this.sendError(client, 'Invalid sourceAgentId: must be a string when provided');
+			return;
+		}
+		const sourceAgentId = rawSourceAgentId as string | undefined;
 
 		this.callbacks
 			.triggerCueSubscription(subscriptionName, prompt as string | undefined, sourceAgentId)

--- a/src/main/web-server/managers/CallbackRegistry.ts
+++ b/src/main/web-server/managers/CallbackRegistry.ts
@@ -459,7 +459,11 @@ export class CallbackRegistry {
 		return this.callbacks.getCueActivity(sessionId, limit);
 	}
 
-	async triggerCueSubscription(subscriptionName: string, prompt?: string, sourceAgentId?: string): Promise<boolean> {
+	async triggerCueSubscription(
+		subscriptionName: string,
+		prompt?: string,
+		sourceAgentId?: string
+	): Promise<boolean> {
 		if (!this.callbacks.triggerCueSubscription) return false;
 		return this.callbacks.triggerCueSubscription(subscriptionName, prompt, sourceAgentId);
 	}

--- a/src/main/web-server/managers/CallbackRegistry.ts
+++ b/src/main/web-server/managers/CallbackRegistry.ts
@@ -459,9 +459,9 @@ export class CallbackRegistry {
 		return this.callbacks.getCueActivity(sessionId, limit);
 	}
 
-	async triggerCueSubscription(subscriptionName: string, prompt?: string): Promise<boolean> {
+	async triggerCueSubscription(subscriptionName: string, prompt?: string, sourceAgentId?: string): Promise<boolean> {
 		if (!this.callbacks.triggerCueSubscription) return false;
-		return this.callbacks.triggerCueSubscription(subscriptionName, prompt);
+		return this.callbacks.triggerCueSubscription(subscriptionName, prompt, sourceAgentId);
 	}
 
 	async getUsageDashboard(

--- a/src/main/web-server/types.ts
+++ b/src/main/web-server/types.ts
@@ -613,7 +613,8 @@ export type GetCueActivityCallback = (
 ) => Promise<CueActivityEntry[]>;
 export type TriggerCueSubscriptionCallback = (
 	subscriptionName: string,
-	prompt?: string
+	prompt?: string,
+	sourceAgentId?: string
 ) => Promise<boolean>;
 
 // =============================================================================

--- a/src/main/web-server/web-server-factory.ts
+++ b/src/main/web-server/web-server-factory.ts
@@ -1706,7 +1706,7 @@ export function createWebServerFactory(deps: WebServerFactoryDependencies) {
 		});
 
 		// Trigger a Cue subscription by name — uses IPC request-response pattern
-		server.setTriggerCueSubscriptionCallback(async (subscriptionName: string, prompt?: string) => {
+		server.setTriggerCueSubscriptionCallback(async (subscriptionName: string, prompt?: string, sourceAgentId?: string) => {
 			const mainWindow = getMainWindow();
 			if (!mainWindow) {
 				logger.warn('mainWindow is null for triggerCueSubscription', 'WebServer');
@@ -1737,7 +1737,8 @@ export function createWebServerFactory(deps: WebServerFactoryDependencies) {
 					'remote:triggerCueSubscription',
 					subscriptionName,
 					prompt,
-					responseChannel
+					responseChannel,
+					sourceAgentId
 				);
 
 				timeoutId = setTimeout(() => {

--- a/src/main/web-server/web-server-factory.ts
+++ b/src/main/web-server/web-server-factory.ts
@@ -41,6 +41,12 @@ export interface WebServerFactoryDependencies {
 	getMainWindow: () => BrowserWindow | null;
 	/** Function to get the process manager reference */
 	getProcessManager: () => ProcessManager | null;
+	/** Direct CUE subscription trigger — bypasses renderer IPC round-trip */
+	triggerCueSubscription?: (
+		subscriptionName: string,
+		prompt?: string,
+		sourceAgentId?: string
+	) => boolean;
 }
 
 /**
@@ -1705,54 +1711,18 @@ export function createWebServerFactory(deps: WebServerFactoryDependencies) {
 			});
 		});
 
-		// Trigger a Cue subscription by name — uses IPC request-response pattern
-		server.setTriggerCueSubscriptionCallback(async (subscriptionName: string, prompt?: string, sourceAgentId?: string) => {
-			const mainWindow = getMainWindow();
-			if (!mainWindow) {
-				logger.warn('mainWindow is null for triggerCueSubscription', 'WebServer');
-				return false;
-			}
-
-			return new Promise((resolve) => {
-				const responseChannel = `remote:triggerCueSubscription:response:${randomUUID()}`;
-				let resolved = false;
-				// eslint-disable-next-line prefer-const -- circular ref: handleResponse clears the timeout, timeout references resolved
-				let timeoutId: ReturnType<typeof setTimeout> | undefined;
-
-				const handleResponse = (_event: Electron.IpcMainEvent, result: any) => {
-					if (resolved) return;
-					resolved = true;
-					if (timeoutId) clearTimeout(timeoutId);
-					resolve(result ?? false);
-				};
-
-				ipcMain.once(responseChannel, handleResponse);
-				if (!isWebContentsAvailable(mainWindow)) {
-					logger.warn('webContents is not available for triggerCueSubscription', 'WebServer');
-					ipcMain.removeListener(responseChannel, handleResponse);
-					resolve(false);
-					return;
+		// Trigger a Cue subscription by name — calls engine directly in the main process.
+		// Previous implementation routed through the renderer via IPC round-trip, which
+		// caused sourceAgentId to be dropped during Electron IPC serialization.
+		server.setTriggerCueSubscriptionCallback(
+			async (subscriptionName: string, prompt?: string, sourceAgentId?: string) => {
+				if (!deps.triggerCueSubscription) {
+					logger.warn('triggerCueSubscription dependency not available', 'WebServer');
+					return false;
 				}
-				mainWindow.webContents.send(
-					'remote:triggerCueSubscription',
-					subscriptionName,
-					prompt,
-					responseChannel,
-					sourceAgentId
-				);
-
-				timeoutId = setTimeout(() => {
-					if (resolved) return;
-					resolved = true;
-					ipcMain.removeListener(responseChannel, handleResponse);
-					logger.warn(
-						`triggerCueSubscription callback timed out for ${subscriptionName}`,
-						'WebServer'
-					);
-					resolve(false);
-				}, 10000);
-			});
-		});
+				return deps.triggerCueSubscription(subscriptionName, prompt, sourceAgentId);
+			}
+		);
 
 		// ============ Usage Dashboard & Achievements Callbacks ============
 

--- a/src/prompts/maestro-system-prompt.md
+++ b/src/prompts/maestro-system-prompt.md
@@ -326,6 +326,18 @@ Send a message to another agent and receive a JSON response. Useful for inter-ag
 {{MAESTRO_CLI_PATH}} show playbook <id>
 ```
 
+### Cue Automation
+
+```bash
+# List all Cue subscriptions across agents
+{{MAESTRO_CLI_PATH}} cue list [--json]
+
+# Trigger a Cue subscription by name (fires immediately, bypassing its normal event)
+{{MAESTRO_CLI_PATH}} cue trigger <subscription-name> [-p, --prompt <text>] [--json]
+```
+
+Use `cue list` to discover available subscriptions. Use `cue trigger` to fire one on demand — for example, to kick off a review pipeline after finishing your work, or to chain into a deployment step. The optional `--prompt` flag overrides the subscription's configured prompt with custom text.
+
 ### Playbook Operations
 
 ```bash

--- a/src/prompts/maestro-system-prompt.md
+++ b/src/prompts/maestro-system-prompt.md
@@ -333,10 +333,10 @@ Send a message to another agent and receive a JSON response. Useful for inter-ag
 {{MAESTRO_CLI_PATH}} cue list [--json]
 
 # Trigger a Cue subscription by name (fires immediately, bypassing its normal event)
-{{MAESTRO_CLI_PATH}} cue trigger <subscription-name> [-p, --prompt <text>] [--json]
+{{MAESTRO_CLI_PATH}} cue trigger <subscription-name> [-p, --prompt <text>] [--source-agent-id <id>] [--json]
 ```
 
-Use `cue list` to discover available subscriptions. Use `cue trigger` to fire one on demand — for example, to kick off a review pipeline after finishing your work, or to chain into a deployment step. The optional `--prompt` flag overrides the subscription's configured prompt with custom text.
+Use `cue list` to discover available subscriptions. Use `cue trigger` to fire one on demand — for example, to kick off a review pipeline after finishing your work, or to chain into a deployment step. The optional `--prompt` flag overrides the subscription's configured prompt with custom text. Pass `--source-agent-id {{AGENT_ID}}` so pipelines with `cli_output` can route results back to you.
 
 ### Playbook Operations
 

--- a/src/renderer/components/CuePipelineEditor/PipelineCanvas.tsx
+++ b/src/renderer/components/CuePipelineEditor/PipelineCanvas.tsx
@@ -32,6 +32,7 @@ import type {
 import type { CueSettings } from '../../../shared/cue';
 import { TriggerNode, type TriggerNodeDataProps } from './nodes/TriggerNode';
 import { AgentNode, type AgentNodeDataProps } from './nodes/AgentNode';
+import { CliOutputNode } from './nodes/CliOutputNode';
 import { edgeTypes } from './edges/PipelineEdge';
 import { TriggerDrawer } from './drawers/TriggerDrawer';
 import { AgentDrawer } from './drawers/AgentDrawer';
@@ -43,6 +44,7 @@ import { EVENT_COLORS } from './cueEventConstants';
 const nodeTypes = {
 	trigger: TriggerNode,
 	agent: AgentNode,
+	cli_output: CliOutputNode,
 };
 
 export interface PipelineCanvasProps {
@@ -293,6 +295,9 @@ export const PipelineCanvas = React.memo(function PipelineCanvas({
 						if (node.type === 'agent') {
 							const data = node.data as AgentNodeDataProps;
 							return data.pipelineColor ?? theme.colors.accent;
+						}
+						if (node.type === 'cli_output') {
+							return theme.colors.textDim;
 						}
 						return theme.colors.accent;
 					}}

--- a/src/renderer/components/CuePipelineEditor/PipelineContextMenu.tsx
+++ b/src/renderer/components/CuePipelineEditor/PipelineContextMenu.tsx
@@ -13,7 +13,7 @@ export interface ContextMenuState {
 	y: number;
 	nodeId: string;
 	pipelineId: string;
-	nodeType: 'trigger' | 'agent';
+	nodeType: 'trigger' | 'agent' | 'cli_output';
 }
 
 export interface PipelineContextMenuProps {

--- a/src/renderer/components/CuePipelineEditor/drawers/AgentDrawer.tsx
+++ b/src/renderer/components/CuePipelineEditor/drawers/AgentDrawer.tsx
@@ -1,5 +1,5 @@
 import { memo, useState, useMemo, useRef, useEffect } from 'react';
-import { Bot, Search, X } from 'lucide-react';
+import { Bot, Search, Terminal, X } from 'lucide-react';
 import type { Theme } from '../../../types';
 
 export interface AgentSessionInfo {
@@ -283,6 +283,74 @@ export const AgentDrawer = memo(function AgentDrawer({
 					>
 						{search ? 'No agents match' : 'No agents available'}
 					</div>
+				)}
+
+				{/* CLI Output node */}
+				{!search && (
+					<>
+						<div
+							style={{
+								height: 1,
+								backgroundColor: theme.colors.border,
+								margin: '8px 4px',
+							}}
+						/>
+						<div
+							style={{
+								color: theme.colors.textDim,
+								fontSize: 10,
+								fontWeight: 600,
+								textTransform: 'uppercase',
+								letterSpacing: '0.05em',
+								padding: '4px 4px 4px',
+							}}
+						>
+							Output
+						</div>
+						<div
+							draggable
+							onDragStart={(e) => {
+								e.dataTransfer.setData(
+									'application/cue-pipeline',
+									JSON.stringify({ type: 'cli_output' })
+								);
+								e.dataTransfer.effectAllowed = 'move';
+							}}
+							style={{
+								display: 'flex',
+								alignItems: 'center',
+								gap: 8,
+								padding: '8px 10px',
+								marginBottom: 4,
+								borderRadius: 6,
+								backgroundColor: theme.colors.bgActivity,
+								cursor: 'grab',
+								transition: 'filter 0.15s',
+							}}
+							onMouseEnter={(e) => {
+								(e.currentTarget as HTMLElement).style.filter = 'brightness(1.2)';
+							}}
+							onMouseLeave={(e) => {
+								(e.currentTarget as HTMLElement).style.filter = 'brightness(1)';
+							}}
+						>
+							<Terminal size={14} style={{ color: theme.colors.textDim, flexShrink: 0 }} />
+							<div style={{ flex: 1, minWidth: 0 }}>
+								<div
+									style={{
+										color: theme.colors.textMain,
+										fontSize: 12,
+										fontWeight: 500,
+									}}
+								>
+									CLI Output
+								</div>
+								<div style={{ color: theme.colors.textDim, fontSize: 10 }}>
+									Route agent output to a session via CLI
+								</div>
+							</div>
+						</div>
+					</>
 				)}
 			</div>
 		</div>

--- a/src/renderer/components/CuePipelineEditor/drawers/AgentDrawer.tsx
+++ b/src/renderer/components/CuePipelineEditor/drawers/AgentDrawer.tsx
@@ -286,7 +286,7 @@ export const AgentDrawer = memo(function AgentDrawer({
 				)}
 
 				{/* CLI Output node */}
-				{!search && (
+				{!search.trim() && (
 					<>
 						<div
 							style={{

--- a/src/renderer/components/CuePipelineEditor/nodes/CliOutputNode.tsx
+++ b/src/renderer/components/CuePipelineEditor/nodes/CliOutputNode.tsx
@@ -1,0 +1,158 @@
+import { memo } from 'react';
+import { Handle, Position, type NodeProps } from 'reactflow';
+import { Terminal, GripVertical, Settings } from 'lucide-react';
+import type { Theme } from '../../../types';
+
+export interface CliOutputNodeDataProps {
+	compositeId: string;
+	target: string;
+	pipelineColor: string;
+	pipelineCount: number;
+	pipelineColors: string[];
+	onConfigure?: (compositeId: string) => void;
+	theme?: Theme;
+}
+
+export const CliOutputNode = memo(function CliOutputNode({
+	data,
+	selected,
+}: NodeProps<CliOutputNodeDataProps>) {
+	const theme = data.theme;
+	const accentColor = data.pipelineColor;
+
+	return (
+		<div
+			style={{
+				minWidth: 160,
+				maxWidth: 280,
+				height: 64,
+				borderRadius: 8,
+				willChange: 'transform',
+				backgroundColor: theme?.colors.bgMain ?? '#1e1e2e',
+				border: `2px solid ${selected ? accentColor : (theme?.colors.border ?? '#333')}`,
+				boxShadow: selected ? `0 4px 16px ${accentColor}30` : '0 2px 8px rgba(0,0,0,0.3)',
+				animation: selected ? 'pipeline-node-pulse 2s ease-in-out infinite' : undefined,
+				['--node-color-40' as string]: `${accentColor}40`,
+				['--node-color-60' as string]: `${accentColor}60`,
+				['--node-color-30' as string]: `${accentColor}30`,
+				display: 'flex',
+				flexDirection: 'row',
+				overflow: 'visible',
+				cursor: 'default',
+				transition: 'border-color 0.15s, box-shadow 0.15s',
+				position: 'relative',
+				opacity: 0.9,
+			}}
+		>
+			{/* Drag handle */}
+			<div
+				className="drag-handle"
+				style={{
+					width: 28,
+					display: 'flex',
+					alignItems: 'center',
+					justifyContent: 'center',
+					cursor: 'grab',
+					color: theme?.colors.textDim ?? '#555',
+					flexShrink: 0,
+					backgroundColor: `${accentColor}80`,
+					borderRadius: '6px 0 0 6px',
+					transition: 'color 0.15s, filter 0.15s',
+				}}
+				onMouseEnter={(e) => {
+					e.currentTarget.style.color = theme?.colors.accentForeground ?? '#fff';
+					e.currentTarget.style.filter = 'brightness(1.3)';
+				}}
+				onMouseLeave={(e) => {
+					e.currentTarget.style.color = theme?.colors.textDim ?? '#555';
+					e.currentTarget.style.filter = 'brightness(1)';
+				}}
+				title="Drag to move"
+			>
+				<GripVertical size={14} />
+			</div>
+
+			{/* Content */}
+			<div
+				style={{
+					flex: 1,
+					display: 'flex',
+					flexDirection: 'column',
+					justifyContent: 'center',
+					padding: '6px 10px',
+					overflow: 'hidden',
+				}}
+			>
+				<div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+					<Terminal
+						size={13}
+						style={{ color: theme?.colors.textDim ?? '#9ca3af', flexShrink: 0 }}
+					/>
+					<span
+						style={{
+							color: theme?.colors.textMain ?? '#e4e4e7',
+							fontSize: 12,
+							fontWeight: 600,
+							whiteSpace: 'nowrap',
+						}}
+					>
+						CLI Output
+					</span>
+				</div>
+				<span
+					style={{
+						color: theme?.colors.textDim ?? '#6b7280',
+						fontSize: 10,
+						marginTop: 2,
+						overflow: 'hidden',
+						textOverflow: 'ellipsis',
+						whiteSpace: 'nowrap',
+					}}
+				>
+					{data.target || 'No target'}
+				</span>
+			</div>
+
+			{/* Gear icon */}
+			<div
+				onClick={(e) => {
+					e.stopPropagation();
+					data.onConfigure?.(data.compositeId);
+				}}
+				style={{
+					display: 'flex',
+					alignItems: 'center',
+					justifyContent: 'center',
+					cursor: 'pointer',
+					color: selected ? accentColor : (theme?.colors.textDim ?? '#555'),
+					flexShrink: 0,
+					padding: '0 6px',
+					marginRight: 10,
+					borderRadius: 4,
+					transition: 'color 0.15s',
+				}}
+				onMouseEnter={(e) => (e.currentTarget.style.color = accentColor)}
+				onMouseLeave={(e) =>
+					(e.currentTarget.style.color = selected ? accentColor : (theme?.colors.textDim ?? '#555'))
+				}
+				title="Configure"
+			>
+				<Settings size={13} />
+			</div>
+
+			<Handle
+				type="target"
+				position={Position.Left}
+				style={{
+					backgroundColor: accentColor,
+					border: `3px solid ${theme?.colors.bgMain ?? '#1e1e2e'}`,
+					boxShadow: `0 0 0 2px ${accentColor}`,
+					width: 14,
+					height: 14,
+					zIndex: 10,
+					left: -7,
+				}}
+			/>
+		</div>
+	);
+});

--- a/src/renderer/components/CuePipelineEditor/panels/CliOutputConfigPanel.tsx
+++ b/src/renderer/components/CuePipelineEditor/panels/CliOutputConfigPanel.tsx
@@ -31,12 +31,9 @@ export function CliOutputConfigPanel({
 		setTarget(data.target || '');
 	}, [data.target]);
 
-	const { debouncedCallback: debouncedSave } = useDebouncedCallback(
-		(value: unknown) => {
-			onUpdateNode(nodeId, { target: value as string });
-		},
-		300
-	);
+	const { debouncedCallback: debouncedSave } = useDebouncedCallback((value: unknown) => {
+		onUpdateNode(nodeId, { target: value as string });
+	}, 300);
 
 	const handleTargetChange = useCallback(
 		(e: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/renderer/components/CuePipelineEditor/panels/CliOutputConfigPanel.tsx
+++ b/src/renderer/components/CuePipelineEditor/panels/CliOutputConfigPanel.tsx
@@ -1,0 +1,82 @@
+/**
+ * CliOutputConfigPanel — Configuration panel for CLI Output nodes in the pipeline.
+ *
+ * Allows configuring the target session ID (or template variable) for
+ * routing agent output via `maestro-cli send --live`.
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import type { Theme } from '../../../types';
+import type { CliOutputNodeData } from '../../../../shared/cue-pipeline-types';
+import { useDebouncedCallback } from '../../../hooks/utils';
+import { getInputStyle, getLabelStyle } from './triggers/triggerConfigStyles';
+
+interface CliOutputConfigPanelProps {
+	nodeId: string;
+	data: CliOutputNodeData;
+	theme: Theme;
+	onUpdateNode: (nodeId: string, data: Partial<CliOutputNodeData>) => void;
+	expanded?: boolean;
+}
+
+export function CliOutputConfigPanel({
+	nodeId,
+	data,
+	theme,
+	onUpdateNode,
+}: CliOutputConfigPanelProps) {
+	const [target, setTarget] = useState(data.target || '');
+
+	useEffect(() => {
+		setTarget(data.target || '');
+	}, [data.target]);
+
+	const debouncedSave = useDebouncedCallback(
+		(value: string) => {
+			onUpdateNode(nodeId, { target: value });
+		},
+		300,
+		[nodeId, onUpdateNode]
+	);
+
+	const handleTargetChange = useCallback(
+		(e: React.ChangeEvent<HTMLInputElement>) => {
+			const value = e.target.value;
+			setTarget(value);
+			debouncedSave(value);
+		},
+		[debouncedSave]
+	);
+
+	return (
+		<div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+			<div>
+				<label style={getLabelStyle(theme)}>Target</label>
+				<input
+					type="text"
+					value={target}
+					onChange={handleTargetChange}
+					placeholder="{{CUE_SOURCE_AGENT_ID}}"
+					style={{
+						...getInputStyle(theme),
+						width: '100%',
+						fontFamily: 'monospace',
+						fontSize: 12,
+					}}
+				/>
+				<span
+					style={{
+						display: 'block',
+						marginTop: 4,
+						fontSize: 11,
+						color: theme.colors.textDim,
+						lineHeight: 1.4,
+					}}
+				>
+					Session ID to send output to via <code style={{ fontSize: 10 }}>maestro-cli send --live</code>.
+					Use <code style={{ fontSize: 10 }}>{'{{CUE_SOURCE_AGENT_ID}}'}</code> for cli.trigger events.
+				</span>
+			</div>
+		</div>
+	);
+}

--- a/src/renderer/components/CuePipelineEditor/panels/CliOutputConfigPanel.tsx
+++ b/src/renderer/components/CuePipelineEditor/panels/CliOutputConfigPanel.tsx
@@ -31,12 +31,11 @@ export function CliOutputConfigPanel({
 		setTarget(data.target || '');
 	}, [data.target]);
 
-	const debouncedSave = useDebouncedCallback(
-		(value: string) => {
-			onUpdateNode(nodeId, { target: value });
+	const { debouncedCallback: debouncedSave } = useDebouncedCallback(
+		(value: unknown) => {
+			onUpdateNode(nodeId, { target: value as string });
 		},
-		300,
-		[nodeId, onUpdateNode]
+		300
 	);
 
 	const handleTargetChange = useCallback(
@@ -73,8 +72,9 @@ export function CliOutputConfigPanel({
 						lineHeight: 1.4,
 					}}
 				>
-					Session ID to send output to via <code style={{ fontSize: 10 }}>maestro-cli send --live</code>.
-					Use <code style={{ fontSize: 10 }}>{'{{CUE_SOURCE_AGENT_ID}}'}</code> for cli.trigger events.
+					Session ID to send output to via{' '}
+					<code style={{ fontSize: 10 }}>maestro-cli send --live</code>. Use{' '}
+					<code style={{ fontSize: 10 }}>{'{{CUE_SOURCE_AGENT_ID}}'}</code> for cli.trigger events.
 				</span>
 			</div>
 		</div>

--- a/src/renderer/components/CuePipelineEditor/panels/NodeConfigPanel.tsx
+++ b/src/renderer/components/CuePipelineEditor/panels/NodeConfigPanel.tsx
@@ -303,7 +303,9 @@ export function NodeConfigPanel({
 						nodeId={selectedNode.id}
 						data={selectedNode.data as CliOutputNodeData}
 						theme={theme}
-						onUpdateNode={onUpdateNode as unknown as (nodeId: string, data: Partial<CliOutputNodeData>) => void}
+						onUpdateNode={
+							onUpdateNode as unknown as (nodeId: string, data: Partial<CliOutputNodeData>) => void
+						}
 						expanded={expanded}
 					/>
 				)}

--- a/src/renderer/components/CuePipelineEditor/panels/NodeConfigPanel.tsx
+++ b/src/renderer/components/CuePipelineEditor/panels/NodeConfigPanel.tsx
@@ -303,7 +303,7 @@ export function NodeConfigPanel({
 						nodeId={selectedNode.id}
 						data={selectedNode.data as CliOutputNodeData}
 						theme={theme}
-						onUpdateNode={onUpdateNode}
+						onUpdateNode={onUpdateNode as unknown as (nodeId: string, data: Partial<CliOutputNodeData>) => void}
 						expanded={expanded}
 					/>
 				)}

--- a/src/renderer/components/CuePipelineEditor/panels/NodeConfigPanel.tsx
+++ b/src/renderer/components/CuePipelineEditor/panels/NodeConfigPanel.tsx
@@ -13,6 +13,7 @@ import type {
 	PipelineEdge,
 	TriggerNodeData,
 	AgentNodeData,
+	CliOutputNodeData,
 	CuePipeline,
 	IncomingTriggerEdgeInfo,
 	IncomingAgentEdgeInfo,
@@ -20,6 +21,7 @@ import type {
 import { EVENT_ICONS, EVENT_LABELS } from '../cueEventConstants';
 import { TriggerConfig } from './triggers';
 import { AgentConfigPanel } from './AgentConfigPanel';
+import { CliOutputConfigPanel } from './CliOutputConfigPanel';
 
 export type { IncomingTriggerEdgeInfo } from '../../../../shared/cue-pipeline-types';
 
@@ -80,8 +82,10 @@ export function NodeConfigPanel({
 	if (!isVisible) return null;
 
 	const isTrigger = selectedNode.type === 'trigger';
+	const isCliOutput = selectedNode.type === 'cli_output';
 	const triggerData = isTrigger ? (selectedNode.data as TriggerNodeData) : null;
-	const agentData = !isTrigger ? (selectedNode.data as AgentNodeData) : null;
+	const agentData = !isTrigger && !isCliOutput ? (selectedNode.data as AgentNodeData) : null;
+	const cliOutputData = isCliOutput ? (selectedNode.data as CliOutputNodeData) : null;
 
 	const Icon = triggerData ? (EVENT_ICONS[triggerData.eventType] ?? Zap) : null;
 	const ExpandIcon = expanded ? ChevronsDown : ChevronsUp;
@@ -108,6 +112,7 @@ export function NodeConfigPanel({
 		// Collapsed mode stays compact — the content wrapper scrolls when
 		// upstream-sources / fan-in cards don't fit. Expanded mode (80%) is
 		// where the user gets full breathing room.
+		if (isCliOutput) return 200;
 		const base = hasUpstreamAgents ? 300 : 280;
 		const fanInBoost = hasFanIn ? 60 : 0;
 		const triggerBoost = hasMultipleTriggers ? Math.min(120, (triggerEdgeCount - 1) * 60) : 0;
@@ -173,7 +178,25 @@ export function NodeConfigPanel({
 							</span>
 						</>
 					)}
-					{!isTrigger && agentData && (
+					{isCliOutput && (
+						<>
+							<span style={{ color: theme.colors.textMain, fontSize: 13, fontWeight: 600 }}>
+								CLI Output
+							</span>
+							<span
+								style={{
+									fontSize: 10,
+									color: theme.colors.textDim,
+									backgroundColor: theme.colors.bgActivity,
+									padding: '1px 6px',
+									borderRadius: 4,
+								}}
+							>
+								{cliOutputData?.target || 'No target'}
+							</span>
+						</>
+					)}
+					{!isTrigger && !isCliOutput && agentData && (
 						<>
 							<span style={{ color: theme.colors.textMain, fontSize: 13, fontWeight: 600 }}>
 								{agentData.sessionName}
@@ -275,7 +298,16 @@ export function NodeConfigPanel({
 				{isTrigger && (
 					<TriggerConfig node={selectedNode} theme={theme} onUpdateNode={onUpdateNode} />
 				)}
-				{!isTrigger && (
+				{isCliOutput && (
+					<CliOutputConfigPanel
+						nodeId={selectedNode.id}
+						data={selectedNode.data as CliOutputNodeData}
+						theme={theme}
+						onUpdateNode={onUpdateNode}
+						expanded={expanded}
+					/>
+				)}
+				{!isTrigger && !isCliOutput && (
 					<AgentConfigPanel
 						node={selectedNode}
 						theme={theme}

--- a/src/renderer/components/CuePipelineEditor/utils/pipelineGraph.ts
+++ b/src/renderer/components/CuePipelineEditor/utils/pipelineGraph.ts
@@ -10,10 +10,12 @@ import type {
 	CuePipelineState,
 	TriggerNodeData,
 	AgentNodeData,
+	CliOutputNodeData,
 } from '../../../../shared/cue-pipeline-types';
 import type { Theme } from '../../../../shared/theme-types';
 import type { TriggerNodeDataProps } from '../nodes/TriggerNode';
 import type { AgentNodeDataProps } from '../nodes/AgentNode';
+import type { CliOutputNodeDataProps } from '../nodes/CliOutputNode';
 import type { PipelineEdgeData } from '../edges/PipelineEdge';
 
 // ─── Trigger config summary ──────────────────────────────────────────────────
@@ -199,7 +201,7 @@ export function convertToReactFlowNodes(
 					data: nodeData,
 					dragHandle: '.drag-handle',
 				});
-			} else {
+			} else if (pNode.type === 'agent') {
 				const agentData = pNode.data as AgentNodeData;
 				const pipelineColors = agentPipelineMap.get(agentData.sessionId) ?? [pipeline.color];
 				const hasOutgoingEdge = pipeline.edges.some((e) => e.source === pNode.id);
@@ -233,6 +235,24 @@ export function convertToReactFlowNodes(
 				nodes.push({
 					id: compositeId,
 					type: 'agent',
+					position: { x: pNode.position.x, y: pNode.position.y + yOffset },
+					data: nodeData,
+					dragHandle: '.drag-handle',
+				});
+			} else if (pNode.type === 'cli_output') {
+				const cliData = pNode.data as CliOutputNodeData;
+				const nodeData: CliOutputNodeDataProps = {
+					compositeId,
+					target: cliData.target,
+					pipelineColor: pipeline.color,
+					pipelineCount: 1,
+					pipelineColors: [pipeline.color],
+					onConfigure: onConfigureNode,
+					theme,
+				};
+				nodes.push({
+					id: compositeId,
+					type: 'cli_output',
 					position: { x: pNode.position.x, y: pNode.position.y + yOffset },
 					data: nodeData,
 					dragHandle: '.drag-handle',

--- a/src/renderer/components/CuePipelineEditor/utils/pipelineToYaml.ts
+++ b/src/renderer/components/CuePipelineEditor/utils/pipelineToYaml.ts
@@ -14,6 +14,7 @@ import type {
 	PipelineEdge,
 	TriggerNodeData,
 	AgentNodeData,
+	CliOutputNodeData,
 } from '../../../../shared/cue-pipeline-types';
 import type { CueSubscription, CueSettings } from '../../../../shared/cue';
 import { cuePromptFilePath } from '../../../../shared/maestro-paths';
@@ -62,6 +63,25 @@ function buildAdjacency(pipeline: CuePipeline): {
 
 function findTriggerNodes(pipeline: CuePipeline): PipelineNode[] {
 	return pipeline.nodes.filter((n) => n.type === 'trigger');
+}
+
+/**
+ * Finds a cli_output node connected to the given agent node via an outgoing edge.
+ * Returns the CliOutputNodeData if found, otherwise undefined.
+ */
+function findCliOutputForAgent(
+	agentId: string,
+	outgoing: Map<string, PipelineEdge[]>,
+	nodeMap: Map<string, PipelineNode>
+): CliOutputNodeData | undefined {
+	const edges = outgoing.get(agentId) ?? [];
+	for (const edge of edges) {
+		const target = nodeMap.get(edge.target);
+		if (target?.type === 'cli_output') {
+			return target.data as CliOutputNodeData;
+		}
+	}
+	return undefined;
 }
 
 function getEdgeModeComment(edge: PipelineEdge): string | null {
@@ -160,6 +180,13 @@ export function pipelineToYamlSubscriptions(pipeline: CuePipeline): CueSubscript
 			const triggerEdge = triggerOutgoing.find((e) => e.target === agent.id);
 			sub.prompt = triggerEdge?.prompt ?? agentData.inputPrompt ?? '';
 			if (agentData.outputPrompt) sub.output_prompt = agentData.outputPrompt;
+
+			// Check for cli_output node connected to this agent
+			const cliOutput = findCliOutputForAgent(agent.id, outgoing, nodeMap);
+			if (cliOutput) {
+				sub.cli_output = { target: cliOutput.target };
+			}
+
 			subscriptions.push(sub);
 			visited.add(agent.id);
 
@@ -258,6 +285,12 @@ function buildChain(
 				: (targetData.inputPrompt ?? ''),
 			output_prompt: targetData.outputPrompt || undefined,
 		};
+
+		// Check for cli_output node connected to this agent
+		const cliOutput = findCliOutputForAgent(target.id, outgoing, nodeMap);
+		if (cliOutput) {
+			sub.cli_output = { target: cliOutput.target };
+		}
 
 		if (incomingAgentEdges.length > 1) {
 			// Fan-in: multiple source sessions
@@ -361,6 +394,7 @@ export function pipelinesToYaml(
 				record.fan_in_timeout_on_fail = sub.fan_in_timeout_on_fail;
 			if (sub.include_output_from != null) record.include_output_from = sub.include_output_from;
 			if (sub.forward_output_from != null) record.forward_output_from = sub.forward_output_from;
+			if (sub.cli_output != null) record.cli_output = sub.cli_output;
 
 			// Save prompts as external files.
 			// Use sub.name as the suffix key so multiple triggers targeting the same agent

--- a/src/renderer/components/CuePipelineEditor/utils/yamlToPipeline.ts
+++ b/src/renderer/components/CuePipelineEditor/utils/yamlToPipeline.ts
@@ -11,6 +11,7 @@ import type {
 	PipelineEdge,
 	TriggerNodeData,
 	AgentNodeData,
+	CliOutputNodeData,
 	CueEventType,
 	EdgeMode,
 } from '../../../../shared/cue-pipeline-types';
@@ -44,6 +45,7 @@ interface GraphSessionInput {
 		fan_in_timeout_on_fail?: 'break' | 'continue';
 		include_output_from?: string[];
 		forward_output_from?: string[];
+		cli_output?: { target: string };
 	}>;
 }
 
@@ -455,6 +457,37 @@ export function subscriptionsToPipelines(
 						edge.forwardOutput = true;
 					}
 					edges.push(edge);
+				}
+			}
+		}
+
+		// After all nodes and edges are created, add cli_output nodes for subscriptions
+		// that have a cli_output field. Position them after the last agent in the chain.
+		for (const sub of sorted) {
+			if (sub.cli_output?.target) {
+				// Find the agent node this cli_output belongs to
+				const targetSessionName = findTargetSession(sub, subs, sessions);
+				const agentNode = targetSessionName ? sessionToNode.get(targetSessionName) : undefined;
+				if (agentNode) {
+					const cliOutputId = `cli-output-${nodeMap.size}`;
+					const cliOutputNode: PipelineNode = {
+						id: cliOutputId,
+						type: 'cli_output',
+						position: {
+							x: agentNode.position.x + LAYOUT.stepSpacing,
+							y: agentNode.position.y,
+						},
+						data: {
+							target: sub.cli_output.target,
+						} as CliOutputNodeData,
+					};
+					nodeMap.set(cliOutputId, cliOutputNode);
+					edges.push({
+						id: `edge-${edgeCount++}`,
+						source: agentNode.id,
+						target: cliOutputId,
+						mode: 'pass' as EdgeMode,
+					});
 				}
 			}
 		}

--- a/src/renderer/components/InputArea.tsx
+++ b/src/renderer/components/InputArea.tsx
@@ -41,6 +41,7 @@ import { useAgentCapabilities, useScrollIntoView } from '../hooks';
 import { getProviderDisplayName } from '../utils/sessionValidation';
 import { filterSlashCommands, highlightSlashCommand } from '../utils/search';
 import { getReadOnlyModeLabel, getReadOnlyModeTooltip } from '../../shared/agentMetadata';
+import { highlightSlashCommand } from '../utils/search';
 
 interface SlashCommand {
 	command: string;

--- a/src/renderer/components/InputArea.tsx
+++ b/src/renderer/components/InputArea.tsx
@@ -41,7 +41,6 @@ import { useAgentCapabilities, useScrollIntoView } from '../hooks';
 import { getProviderDisplayName } from '../utils/sessionValidation';
 import { filterSlashCommands, highlightSlashCommand } from '../utils/search';
 import { getReadOnlyModeLabel, getReadOnlyModeTooltip } from '../../shared/agentMetadata';
-import { highlightSlashCommand } from '../utils/search';
 
 interface SlashCommand {
 	command: string;

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -3067,7 +3067,11 @@ interface MaestroAPI {
 		disable: () => Promise<void>;
 		stopRun: (runId: string) => Promise<boolean>;
 		stopAll: () => Promise<void>;
-		triggerSubscription: (subscriptionName: string, prompt?: string, sourceAgentId?: string) => Promise<boolean>;
+		triggerSubscription: (
+			subscriptionName: string,
+			prompt?: string,
+			sourceAgentId?: string
+		) => Promise<boolean>;
 		getQueueStatus: () => Promise<Record<string, number>>;
 		refreshSession: (sessionId: string, projectRoot: string) => Promise<void>;
 		removeSession: (sessionId: string) => Promise<void>;

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -473,7 +473,8 @@ interface MaestroAPI {
 			callback: (
 				subscriptionName: string,
 				prompt: string | undefined,
-				responseChannel: string
+				responseChannel: string,
+				sourceAgentId: string | undefined
 			) => void
 		) => () => void;
 		sendRemoteTriggerCueSubscriptionResponse: (responseChannel: string, result: unknown) => void;
@@ -3066,7 +3067,7 @@ interface MaestroAPI {
 		disable: () => Promise<void>;
 		stopRun: (runId: string) => Promise<boolean>;
 		stopAll: () => Promise<void>;
-		triggerSubscription: (subscriptionName: string, prompt?: string) => Promise<boolean>;
+		triggerSubscription: (subscriptionName: string, prompt?: string, sourceAgentId?: string) => Promise<boolean>;
 		getQueueStatus: () => Promise<Record<string, number>>;
 		refreshSession: (sessionId: string, projectRoot: string) => Promise<void>;
 		removeSession: (sessionId: string) => Promise<void>;

--- a/src/renderer/hooks/keyboard/useMainKeyboardHandler.ts
+++ b/src/renderer/hooks/keyboard/useMainKeyboardHandler.ts
@@ -1063,6 +1063,27 @@ export function useMainKeyboardHandler(): UseMainKeyboardHandlerReturn {
 			if (document.activeElement?.tagName === 'WEBVIEW') {
 				(document.activeElement as HTMLElement).blur();
 			}
+
+			// Handle browser address bar focus directly: build a synthetic event
+			// for isTabShortcut matching, then focus the address bar without
+			// re-dispatching through the main handler (which may be blocked
+			// by the overlay/modal shortcut guard).
+			const ctx = keyboardHandlerRef.current;
+			if (ctx?.activeSession?.activeBrowserTabId) {
+				const probe = new KeyboardEvent('keydown', {
+					key: input.key,
+					code: input.code,
+					metaKey: input.meta,
+					ctrlKey: input.control,
+					altKey: input.alt,
+					shiftKey: input.shift,
+				});
+				if (ctx.isTabShortcut(probe, 'focusBrowserAddress')) {
+					ctx.mainPanelRef?.current?.focusBrowserAddressBar();
+					return;
+				}
+			}
+
 			window.dispatchEvent(
 				new KeyboardEvent('keydown', {
 					key: input.key,

--- a/src/renderer/hooks/remote/useRemoteIntegration.ts
+++ b/src/renderer/hooks/remote/useRemoteIntegration.ts
@@ -893,7 +893,11 @@ export function useRemoteIntegration(deps: UseRemoteIntegrationDeps): UseRemoteI
 				sourceAgentId?: string
 			) => {
 				try {
-					const result = await cueService.triggerSubscription(subscriptionName, prompt, sourceAgentId);
+					const result = await cueService.triggerSubscription(
+						subscriptionName,
+						prompt,
+						sourceAgentId
+					);
 					window.maestro.process.sendRemoteTriggerCueSubscriptionResponse(responseChannel, result);
 				} catch (error) {
 					console.error('[Remote Cue Trigger] Failed:', subscriptionName, error);

--- a/src/renderer/hooks/remote/useRemoteIntegration.ts
+++ b/src/renderer/hooks/remote/useRemoteIntegration.ts
@@ -892,10 +892,6 @@ export function useRemoteIntegration(deps: UseRemoteIntegrationDeps): UseRemoteI
 					window.maestro.process.sendRemoteTriggerCueSubscriptionResponse(responseChannel, result);
 				} catch (error) {
 					console.error('[Remote Cue Trigger] Failed:', subscriptionName, error);
-					// Never send the raw prompt to telemetry — remote-triggered
-					// Cue prompts can carry user-authored content with PII or
-					// secrets. Send length/presence so we can correlate failures
-					// against payload size without leaking the body.
 					captureException(error, {
 						extra: {
 							context: 'remoteTriggerCueSubscription',

--- a/src/renderer/hooks/remote/useRemoteIntegration.ts
+++ b/src/renderer/hooks/remote/useRemoteIntegration.ts
@@ -886,7 +886,12 @@ export function useRemoteIntegration(deps: UseRemoteIntegrationDeps): UseRemoteI
 	// Handle remote trigger Cue subscription requests (from web/CLI clients)
 	useEffect(() => {
 		const unsubscribe = window.maestro.process.onRemoteTriggerCueSubscription(
-			async (subscriptionName: string, prompt: string | undefined, responseChannel: string, sourceAgentId?: string) => {
+			async (
+				subscriptionName: string,
+				prompt: string | undefined,
+				responseChannel: string,
+				sourceAgentId?: string
+			) => {
 				try {
 					const result = await cueService.triggerSubscription(subscriptionName, prompt, sourceAgentId);
 					window.maestro.process.sendRemoteTriggerCueSubscriptionResponse(responseChannel, result);

--- a/src/renderer/hooks/remote/useRemoteIntegration.ts
+++ b/src/renderer/hooks/remote/useRemoteIntegration.ts
@@ -886,9 +886,9 @@ export function useRemoteIntegration(deps: UseRemoteIntegrationDeps): UseRemoteI
 	// Handle remote trigger Cue subscription requests (from web/CLI clients)
 	useEffect(() => {
 		const unsubscribe = window.maestro.process.onRemoteTriggerCueSubscription(
-			async (subscriptionName: string, prompt: string | undefined, responseChannel: string) => {
+			async (subscriptionName: string, prompt: string | undefined, responseChannel: string, sourceAgentId?: string) => {
 				try {
-					const result = await cueService.triggerSubscription(subscriptionName, prompt);
+					const result = await cueService.triggerSubscription(subscriptionName, prompt, sourceAgentId);
 					window.maestro.process.sendRemoteTriggerCueSubscriptionResponse(responseChannel, result);
 				} catch (error) {
 					console.error('[Remote Cue Trigger] Failed:', subscriptionName, error);

--- a/src/renderer/hooks/useCue.ts
+++ b/src/renderer/hooks/useCue.ts
@@ -14,7 +14,11 @@ export interface UseCueReturn {
 	disable: () => Promise<void>;
 	stopRun: (runId: string) => Promise<void>;
 	stopAll: () => Promise<void>;
-	triggerSubscription: (subscriptionName: string) => Promise<void>;
+	triggerSubscription: (
+		subscriptionName: string,
+		prompt?: string,
+		sourceAgentId?: string
+	) => Promise<void>;
 	refresh: () => Promise<void>;
 }
 
@@ -88,8 +92,8 @@ export function useCue(): UseCueReturn {
 	}, [refresh]);
 
 	const triggerSubscription = useCallback(
-		async (subscriptionName: string) => {
-			await cueService.triggerSubscription(subscriptionName);
+		async (subscriptionName: string, prompt?: string, sourceAgentId?: string) => {
+			await cueService.triggerSubscription(subscriptionName, prompt, sourceAgentId);
 			await refresh();
 		},
 		[refresh]

--- a/src/renderer/services/cue.ts
+++ b/src/renderer/services/cue.ts
@@ -138,9 +138,13 @@ export const cueService = {
 		});
 	},
 
-	async triggerSubscription(subscriptionName: string, prompt?: string): Promise<boolean> {
+	async triggerSubscription(
+		subscriptionName: string,
+		prompt?: string,
+		sourceAgentId?: string
+	): Promise<boolean> {
 		return createIpcMethod({
-			call: () => window.maestro.cue.triggerSubscription(subscriptionName, prompt),
+			call: () => window.maestro.cue.triggerSubscription(subscriptionName, prompt, sourceAgentId),
 			errorContext: 'Cue triggerSubscription',
 			rethrow: true,
 		});

--- a/src/shared/cue-pipeline-types.ts
+++ b/src/shared/cue-pipeline-types.ts
@@ -70,13 +70,17 @@ export interface AgentNodeData {
 	fanInTimeoutOnFail?: 'break' | 'continue';
 }
 
-type PipelineNodeType = 'trigger' | 'agent';
+export interface CliOutputNodeData {
+	target: string;
+}
+
+export type PipelineNodeType = 'trigger' | 'agent' | 'cli_output';
 
 export interface PipelineNode {
 	id: string;
 	type: PipelineNodeType;
 	position: PipelineNodePosition;
-	data: TriggerNodeData | AgentNodeData;
+	data: TriggerNodeData | AgentNodeData | CliOutputNodeData;
 }
 
 export interface PipelineEdge {

--- a/src/shared/cue/contracts.ts
+++ b/src/shared/cue/contracts.ts
@@ -88,6 +88,9 @@ export interface CueSubscription {
 	 *  agents later in the chain can access it via per-source template variables
 	 *  like {{CUE_OUTPUT_<NAME>}}. */
 	forward_output_from?: string[];
+	cli_output?: {
+		target: string;
+	};
 }
 
 /** Global Cue settings */

--- a/src/shared/templateVariables.ts
+++ b/src/shared/templateVariables.ts
@@ -202,6 +202,7 @@ export interface TemplateContext {
 		ghMergedAt?: string;
 		// CLI trigger fields (cli.trigger)
 		cliPrompt?: string;
+		sourceAgentId?: string;
 	};
 }
 
@@ -223,6 +224,11 @@ export const TEMPLATE_VARIABLES = [
 	{
 		variable: '{{CUE_CLI_PROMPT}}',
 		description: 'CLI prompt override (cli.trigger events)',
+		cueOnly: true,
+	},
+	{
+		variable: '{{CUE_SOURCE_AGENT_ID}}',
+		description: 'Source agent ID passed via --source-agent-id (cli.trigger events)',
 		cueOnly: true,
 	},
 	{ variable: '{{CUE_EVENT_TIMESTAMP}}', description: 'Cue event timestamp', cueOnly: true },
@@ -448,6 +454,7 @@ export function substituteTemplateVariables(template: string, context: TemplateC
 		CUE_GH_ASSIGNEES: context.cue?.ghAssignees || '',
 		CUE_GH_MERGED_AT: context.cue?.ghMergedAt || '',
 		CUE_CLI_PROMPT: context.cue?.cliPrompt || '',
+		CUE_SOURCE_AGENT_ID: context.cue?.sourceAgentId || '',
 	};
 
 	// Add dynamic per-source output variables from the Cue context.

--- a/src/shared/templateVariables.ts
+++ b/src/shared/templateVariables.ts
@@ -92,6 +92,7 @@ import { buildSessionDeepLink, buildGroupDeepLink } from './deep-link-urls';
  *   {{CUE_GH_ASSIGNEES}}    - Comma-separated assignees (github.issue events)
  *
  *   {{CUE_CLI_PROMPT}}      - Prompt text passed via --prompt flag (cli.trigger events)
+ *   {{CUE_SOURCE_AGENT_ID}} - Source agent ID passed via --source-agent-id (cli.trigger events)
  */
 
 /**
@@ -115,7 +116,7 @@ function getCurrentPlatform(): string {
  * The CLI is bundled as a JS file inside the Maestro application package,
  * so the returned value includes the `node` invocation with the full path.
  */
-function getMaestroCLIPath(): string {
+export function getMaestroCLIPath(): string {
 	const platform = getCurrentPlatform();
 	switch (platform) {
 		case 'darwin':


### PR DESCRIPTION
## Summary

- Adds `--source-agent-id` flag to `maestro-cli cue trigger` for passing source context through the IPC chain, enabling write-back to originating agents
- Adds `cli_output` node type to the Cue pipeline editor, allowing pipelines to route output back to CLI callers
- Adds `maestro-cli cue list` command for listing available Cue subscriptions
- Adds `--live` flag to `maestro-cli send` command
- Adds `CUE_SOURCE_AGENT_ID` template variable for use in Cue subscription prompts
- Refactors WebServer with CallbackRegistry and modular message handlers

## Changed Files (65 files, +2170/-54)

**CLI commands:** `cue-trigger.ts`, `cue-list.ts`, `send.ts`, `cli/index.ts`
**Cue engine:** `cue-engine.ts`, `cue-run-manager.ts`, `cue-dispatch-service.ts`, `cue-process-lifecycle.ts`, `cue-template-context-builder.ts`
**Pipeline editor:** `CliOutputNode.tsx`, `CliOutputConfigPanel.tsx`, `AgentDrawer.tsx`, `pipelineToYaml.ts`, `yamlToPipeline.ts`, `pipelineGraph.ts`
**Web server:** `WebServer.ts`, `messageHandlers.ts`, `CallbackRegistry.ts`, `web-server-factory.ts`
**IPC/preload:** `index.ts`, `cue.ts`, `process.ts`
**Shared types:** `cue-pipeline-types.ts`, `contracts.ts`, `templateVariables.ts`
**Documentation:** `cli.md`, `maestro-cue-events.md`, `maestro-cue-examples.md`

## Test plan

- [x] Tests for `cue trigger` CLI command with `--source-agent-id` and `--json` flags
- [x] Tests for `send` command `--live` flag
- [x] Tests for `CUE_SOURCE_AGENT_ID` template variable substitution
- [x] Tests for sourceAgentId flow through IPC chain
- [x] Tests for CLI Output Phase 3 execution in cue-run-manager
- [x] Tests for CallbackRegistry and message handlers
- [x] Tests for pipeline edge validation with cli_output nodes
- [x] Type checking passes (`npm run lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * maestro-cli: added "cue list" (with --json) and enhanced "cue trigger" (with --prompt and --source-agent-id)
  * New event type: cli.trigger for manual CLI-invoked automations
  * CLI output delivery: route run output via maestro-cli send --live to a configured target
  * New template vars: {{CUE_TRIGGER_NAME}}, {{CUE_CLI_PROMPT}}, {{CUE_SOURCE_AGENT_ID}}, {{CUE_EVENT_TYPE}}
  * Visual editor: CLI Output node and configuration UI

* **Documentation**
  * Added CLI docs, examples, and workflows (code review, CI/CD) for cue listing and triggering
<!-- end of auto-generated comment: release notes by coderabbit.ai -->