### PR TITLE
fix: `Cmd+Left/Right` tab shortcuts broken when sidebar has focus — scroll jumps instead

### DIFF
--- a/src/renderer/hooks/keyboard/useKeyboardNavigation.ts
+++ b/src/renderer/hooks/keyboard/useKeyboardNavigation.ts
@@ -137,10 +137,12 @@ export function useKeyboardNavigation(
 				return false;
 			}
 
-			// Skip if Alt+Cmd+Arrow is pressed (layout toggle shortcut)
-			const isToggleLayoutShortcut =
-				e.altKey && (e.metaKey || e.ctrlKey) && (e.key === 'ArrowLeft' || e.key === 'ArrowRight');
-			if (isToggleLayoutShortcut) return false;
+			// Skip if Cmd/Ctrl+Arrow is pressed (with or without Alt) — could be a user-configured
+			// tab navigation shortcut (e.g. Cmd+Left/Right) or layout toggle (Alt+Cmd+Arrow).
+			// Plain ArrowLeft/Right (no modifiers) is reserved for group collapse/expand.
+			const isModifiedArrow =
+				(e.metaKey || e.ctrlKey) && (e.key === 'ArrowLeft' || e.key === 'ArrowRight');
+			if (isModifiedArrow) return false;
 
 			// Only handle arrow keys and space
 			if (!['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', ' '].includes(e.key)) {


### PR DESCRIPTION
## Summary

- `Cmd+Left/Right Arrow` configured as previous/next tab shortcuts had no effect when the sidebar had focus — groups collapsed/expanded instead

## Root Cause

`handleSidebarNavigation` in `useKeyboardNavigation.ts` was catching all `ArrowLeft`/`ArrowRight` events when the sidebar had focus, regardless of modifier keys. Only `Alt+Cmd+Arrow` was previously excluded. The handler called `preventDefault()` and returned `true`, preventing the `nextTab`/`prevTab` shortcut handlers from ever being reached.

## Fix

Broadened the guard in `handleSidebarNavigation` to skip any `Cmd/Ctrl+Arrow` combination (with or without Alt). Plain `ArrowLeft`/`ArrowRight` (no modifiers) still handles group collapse/expand in the sidebar.

## Test plan

- [ ] Configure "Next Tab" → `Cmd+Right Arrow`, "Previous Tab" → `Cmd+Left Arrow`
- [ ] Click an agent in the sidebar to give it focus
- [ ] Press `Cmd+Right Arrow` — should navigate to next tab, not collapse a group
- [ ] Press `Cmd+Left Arrow` — should navigate to previous tab, not collapse a group
- [ ] Plain `ArrowLeft`/`ArrowRight` (no Cmd) still collapses/expands groups in sidebar
- [ ] `Alt+Cmd+Arrow` still toggles layout as expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined sidebar arrow-key keyboard navigation behavior when using Cmd/Ctrl modifier keys for more consistent shortcut handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->