### PR TITLE
feat: AI input history navigation with up/down arrow keys

### DIFF
--- a/src/__tests__/renderer/hooks/useInputKeyDown.test.ts
+++ b/src/__tests__/renderer/hooks/useInputKeyDown.test.ts
@@ -70,6 +70,9 @@ function createMockDeps(overrides: Partial<InputKeyDownDeps> = {}): InputKeyDown
 		getTabCompletionSuggestions: vi.fn().mockReturnValue([]),
 		inputRef: { current: { focus: vi.fn(), blur: vi.fn() } } as any,
 		terminalOutputRef: { current: { focus: vi.fn() } } as any,
+		navigateHistoryBack: vi.fn().mockReturnValue(null),
+		navigateHistoryForward: vi.fn().mockReturnValue(null),
+		isNavigatingHistory: vi.fn().mockReturnValue(false),
 		...overrides,
 	};
 }

--- a/src/renderer/components/GroupChatInput.tsx
+++ b/src/renderer/components/GroupChatInput.tsx
@@ -134,6 +134,11 @@ export const GroupChatInput = React.memo(function GroupChatInput({
 	const selectedMentionRef = useRef<HTMLButtonElement>(null);
 	const prevGroupChatIdRef = useRef(groupChatId);
 
+	// In-memory message history for up/down arrow navigation
+	const inputHistoryRef = useRef<string[]>([]);
+	const historyIndexRef = useRef<number>(-1);
+	const historyDraftRef = useRef<string>('');
+
 	// Build list of mentionable items: groups first, then individual agents
 	// Groups expand into all their member @mentions when selected
 	const mentionItems = useMemo(() => {
@@ -222,7 +227,15 @@ export const GroupChatInput = React.memo(function GroupChatInput({
 	const handleSend = useCallback(() => {
 		// Allow sending even when busy - messages will be queued in App.tsx
 		if (message.trim()) {
-			onSend(message.trim(), stagedImages.length > 0 ? stagedImages : undefined, readOnlyMode);
+			const trimmed = message.trim();
+			// Record to in-memory history (skip consecutive duplicates)
+			if (inputHistoryRef.current[inputHistoryRef.current.length - 1] !== trimmed) {
+				inputHistoryRef.current.push(trimmed);
+				if (inputHistoryRef.current.length > 100) inputHistoryRef.current.shift();
+			}
+			historyIndexRef.current = -1;
+			historyDraftRef.current = '';
+			onSend(trimmed, stagedImages.length > 0 ? stagedImages : undefined, readOnlyMode);
 			setMessage('');
 			setStagedImages([]);
 			onDraftChange?.('');
@@ -290,6 +303,72 @@ export const GroupChatInput = React.memo(function GroupChatInput({
 				}
 			}
 
+			// ArrowUp at position 0: navigate to previous sent message
+			if (e.key === 'ArrowUp') {
+				const textarea = inputRef.current;
+				if (textarea?.selectionStart === 0) {
+					const history = inputHistoryRef.current;
+					if (history.length > 0) {
+						const currentIndex = historyIndexRef.current;
+						let newIndex: number;
+						if (currentIndex === -1) {
+							// Start navigating — save current draft
+							historyDraftRef.current = textarea.value;
+							newIndex = history.length - 1;
+						} else if (currentIndex > 0) {
+							newIndex = currentIndex - 1;
+						} else {
+							// Already at oldest
+							return;
+						}
+						historyIndexRef.current = newIndex;
+						e.preventDefault();
+						setMessage(history[newIndex]);
+						// Keep cursor at 0 so next ArrowUp immediately triggers again
+						requestAnimationFrame(() => {
+							if (inputRef.current) {
+								inputRef.current.selectionStart = 0;
+								inputRef.current.selectionEnd = 0;
+							}
+						});
+					}
+					return;
+				}
+			}
+
+			// ArrowDown while navigating: go forward, restore draft at the end
+			if (e.key === 'ArrowDown' && historyIndexRef.current !== -1) {
+				const history = inputHistoryRef.current;
+				const currentIndex = historyIndexRef.current;
+				e.preventDefault();
+				if (currentIndex < history.length - 1) {
+					const newIndex = currentIndex + 1;
+					historyIndexRef.current = newIndex;
+					setMessage(history[newIndex]);
+					// Still navigating: keep cursor at 0 so ArrowUp/Down continue to work
+					requestAnimationFrame(() => {
+						if (inputRef.current) {
+							inputRef.current.selectionStart = 0;
+							inputRef.current.selectionEnd = 0;
+						}
+					});
+				} else {
+					// At newest — restore the saved draft
+					const draft = historyDraftRef.current;
+					historyIndexRef.current = -1;
+					historyDraftRef.current = '';
+					setMessage(draft);
+					// Draft restored: move cursor to end for normal editing
+					requestAnimationFrame(() => {
+						if (inputRef.current) {
+							inputRef.current.selectionStart = draft.length;
+							inputRef.current.selectionEnd = draft.length;
+						}
+					});
+				}
+				return;
+			}
+
 			// Handle send based on enterToSend setting (plain Enter, no modifier)
 			if (enterToSend) {
 				if (e.key === 'Enter' && !e.shiftKey) {
@@ -308,6 +387,7 @@ export const GroupChatInput = React.memo(function GroupChatInput({
 			setReadOnlyMode,
 			stagedImages,
 			onOpenLightbox,
+			inputRef,
 		]
 	);
 

--- a/src/renderer/hooks/input/index.ts
+++ b/src/renderer/hooks/input/index.ts
@@ -43,3 +43,7 @@ export type { UseInputHandlersDeps, UseInputHandlersReturn } from './useInputHan
 // Input mode toggle (Tier 3A)
 export { useInputMode } from './useInputMode';
 export type { UseInputModeDeps, UseInputModeReturn } from './useInputMode';
+
+// AI message history navigation (up/down arrow)
+export { useAIMessageHistory } from './useAIMessageHistory';
+export type { UseAIMessageHistoryReturn } from './useAIMessageHistory';

--- a/src/renderer/hooks/input/useAIMessageHistory.ts
+++ b/src/renderer/hooks/input/useAIMessageHistory.ts
@@ -1,0 +1,123 @@
+/**
+ * useAIMessageHistory — in-memory, per-session AI input history navigation.
+ *
+ * Implements terminal-style up/down arrow history for the AI chat input:
+ * - ArrowUp at position 0 navigates to the previous sent message
+ * - ArrowDown walks forward, restoring the saved draft at the end
+ * - The current draft is preserved when navigation starts and restored
+ *   when the user returns to the bottom of the history stack
+ * - History is scoped per session and lives only for the app session
+ *   (not persisted across restarts)
+ */
+
+import { useRef, useCallback } from 'react';
+
+const MAX_HISTORY_SIZE = 100;
+
+export interface UseAIMessageHistoryReturn {
+	/**
+	 * Navigate to the previous message in history.
+	 * Saves `currentValue` as draft on first call (index was -1).
+	 * Returns the message to display, or null if already at the oldest entry.
+	 */
+	navigateBack: (sessionId: string, currentValue: string) => string | null;
+	/**
+	 * Navigate to the next message in history.
+	 * Returns the message to display, or the saved draft when reaching the end.
+	 * Returns null if not currently navigating.
+	 */
+	navigateForward: (sessionId: string) => string | null;
+	/**
+	 * Record a sent message into the history for the given session.
+	 * Skips empty strings and consecutive duplicates.
+	 * Resets the navigation index back to -1.
+	 */
+	recordMessage: (sessionId: string, message: string) => void;
+	/**
+	 * Returns true when the user is mid-navigation (index !== -1).
+	 * Used to decide whether ArrowDown should be intercepted.
+	 */
+	isNavigating: (sessionId: string) => boolean;
+}
+
+export function useAIMessageHistory(): UseAIMessageHistoryReturn {
+	// Per-session arrays of sent messages (oldest → newest)
+	const historyRef = useRef<Map<string, string[]>>(new Map());
+	// Per-session current navigation index (-1 = current draft, not navigating)
+	const indexRef = useRef<Map<string, number>>(new Map());
+	// Per-session saved draft (the text that was in the input when navigation started)
+	const draftRef = useRef<Map<string, string>>(new Map());
+
+	const getHistory = (sessionId: string): string[] => {
+		if (!historyRef.current.has(sessionId)) {
+			historyRef.current.set(sessionId, []);
+		}
+		return historyRef.current.get(sessionId)!;
+	};
+
+	const getIndex = (sessionId: string): number => {
+		return indexRef.current.get(sessionId) ?? -1;
+	};
+
+	const recordMessage = useCallback((sessionId: string, message: string) => {
+		const trimmed = message.trim();
+		if (!trimmed) return;
+		const history = getHistory(sessionId);
+		// Skip consecutive duplicate
+		if (history[history.length - 1] === trimmed) return;
+		history.push(trimmed);
+		if (history.length > MAX_HISTORY_SIZE) history.shift();
+		// Reset navigation state on send
+		indexRef.current.set(sessionId, -1);
+		draftRef.current.delete(sessionId);
+	}, []);
+
+	const navigateBack = useCallback((sessionId: string, currentValue: string): string | null => {
+		const history = getHistory(sessionId);
+		if (history.length === 0) return null;
+
+		const currentIndex = getIndex(sessionId);
+
+		if (currentIndex === -1) {
+			// First ArrowUp — save the current draft and jump to newest history entry
+			draftRef.current.set(sessionId, currentValue);
+			const newIndex = history.length - 1;
+			indexRef.current.set(sessionId, newIndex);
+			return history[newIndex];
+		} else if (currentIndex > 0) {
+			// Step further back
+			const newIndex = currentIndex - 1;
+			indexRef.current.set(sessionId, newIndex);
+			return history[newIndex];
+		}
+
+		// Already at the oldest entry — do not move
+		return null;
+	}, []);
+
+	const navigateForward = useCallback((sessionId: string): string | null => {
+		const currentIndex = getIndex(sessionId);
+		if (currentIndex === -1) return null; // Not navigating
+
+		const history = getHistory(sessionId);
+
+		if (currentIndex < history.length - 1) {
+			// Step forward
+			const newIndex = currentIndex + 1;
+			indexRef.current.set(sessionId, newIndex);
+			return history[newIndex];
+		} else {
+			// At the newest entry — restore the saved draft
+			const draft = draftRef.current.get(sessionId) ?? '';
+			indexRef.current.set(sessionId, -1);
+			draftRef.current.delete(sessionId);
+			return draft;
+		}
+	}, []);
+
+	const isNavigating = useCallback((sessionId: string): boolean => {
+		return getIndex(sessionId) !== -1;
+	}, []);
+
+	return { navigateBack, navigateForward, recordMessage, isNavigating };
+}

--- a/src/renderer/hooks/input/useInputHandlers.ts
+++ b/src/renderer/hooks/input/useInputHandlers.ts
@@ -29,6 +29,7 @@ import type { TabCompletionSuggestion } from './useTabCompletion';
 import { useAtMentionCompletion, type AtMentionSuggestion } from './useAtMentionCompletion';
 import { useInputProcessing } from './useInputProcessing';
 import { useInputKeyDown } from './useInputKeyDown';
+import { useAIMessageHistory } from './useAIMessageHistory';
 
 // ============================================================================
 // Dependencies interface
@@ -262,6 +263,14 @@ export function useInputHandlers(deps: UseInputHandlersDeps): UseInputHandlersRe
 	// Sub-hook calls
 	// ====================================================================
 
+	// AI input history (in-memory, per-session)
+	const {
+		navigateBack: navigateHistoryBack,
+		navigateForward: navigateHistoryForward,
+		recordMessage: recordMessageToHistory,
+		isNavigating: isNavigatingHistory,
+	} = useAIMessageHistory();
+
 	// Input sync handlers
 	const { syncAiInputToSession, syncTerminalInputToSession } = useInputSync(activeSession, {
 		setSessions,
@@ -420,6 +429,7 @@ export function useInputHandlers(deps: UseInputHandlersDeps): UseInputHandlersRe
 		onSkillsCommand: handleSkillsCommand,
 		automaticTabNamingEnabled,
 		conductorProfile,
+		recordMessageToHistory,
 	});
 
 	// processInputRef — maintained for access in memoized callbacks without stale closures
@@ -445,6 +455,9 @@ export function useInputHandlers(deps: UseInputHandlersDeps): UseInputHandlersRe
 		getTabCompletionSuggestions,
 		inputRef,
 		terminalOutputRef,
+		navigateHistoryBack,
+		navigateHistoryForward,
+		isNavigatingHistory,
 	});
 
 	// ====================================================================

--- a/src/renderer/hooks/input/useInputKeyDown.ts
+++ b/src/renderer/hooks/input/useInputKeyDown.ts
@@ -48,6 +48,12 @@ export interface InputKeyDownDeps {
 	inputRef: React.RefObject<HTMLTextAreaElement | null>;
 	/** Ref to the terminal output container */
 	terminalOutputRef: React.RefObject<HTMLDivElement | null>;
+	/** Navigate backward in AI message history (returns value to set, or null if no-op) */
+	navigateHistoryBack: (sessionId: string, currentValue: string) => string | null;
+	/** Navigate forward in AI message history (returns value to set, or null if not navigating) */
+	navigateHistoryForward: (sessionId: string) => string | null;
+	/** Returns true when the user is mid-navigation (so ArrowDown can be intercepted) */
+	isNavigatingHistory: (sessionId: string) => boolean;
 }
 
 // ============================================================================
@@ -74,6 +80,9 @@ export function useInputKeyDown(deps: InputKeyDownDeps): InputKeyDownReturn {
 		getTabCompletionSuggestions,
 		inputRef,
 		terminalOutputRef,
+		navigateHistoryBack,
+		navigateHistoryForward,
+		isNavigatingHistory,
 	} = deps;
 
 	// --- InputContext state (completion dropdowns) ---
@@ -299,6 +308,41 @@ export function useInputKeyDown(deps: InputKeyDownDeps): InputKeyDownReturn {
 					setCommandHistoryOpen(true);
 					setCommandHistoryFilter(inputValue);
 					setCommandHistorySelectedIndex(0);
+				} else if (activeSession?.inputMode === 'ai') {
+					const textarea = inputRef.current;
+					if (textarea?.selectionStart === 0) {
+						const prev = navigateHistoryBack(activeSession.id, inputValue);
+						if (prev !== null) {
+							e.preventDefault();
+							setInputValue(prev);
+							// Keep cursor at position 0 so the next ArrowUp immediately
+							// triggers another history step without a wasted press
+							requestAnimationFrame(() => {
+								if (inputRef.current) {
+									inputRef.current.selectionStart = 0;
+									inputRef.current.selectionEnd = 0;
+								}
+							});
+						}
+					}
+				}
+			} else if (e.key === 'ArrowDown') {
+				if (activeSession?.inputMode === 'ai' && isNavigatingHistory(activeSession.id)) {
+					e.preventDefault();
+					const next = navigateHistoryForward(activeSession.id);
+					if (next !== null) {
+						setInputValue(next);
+						// Still navigating: keep cursor at 0 so ArrowUp/Down continue to work
+						// Draft restored (index back to -1): move cursor to end for normal editing
+						const stillNavigating = isNavigatingHistory(activeSession.id);
+						requestAnimationFrame(() => {
+							if (inputRef.current) {
+								const pos = stillNavigating ? 0 : next.length;
+								inputRef.current.selectionStart = pos;
+								inputRef.current.selectionEnd = pos;
+							}
+						});
+					}
 				}
 			} else if (e.key === 'Tab') {
 				e.preventDefault();
@@ -354,6 +398,9 @@ export function useInputKeyDown(deps: InputKeyDownDeps): InputKeyDownReturn {
 			setCommandHistoryOpen,
 			setCommandHistoryFilter,
 			setCommandHistorySelectedIndex,
+			navigateHistoryBack,
+			navigateHistoryForward,
+			isNavigatingHistory,
 		]
 	);
 

--- a/src/renderer/hooks/input/useInputProcessing.ts
+++ b/src/renderer/hooks/input/useInputProcessing.ts
@@ -78,6 +78,8 @@ export interface UseInputProcessingDeps {
 	automaticTabNamingEnabled?: boolean;
 	/** Conductor profile (user's About Me from settings) */
 	conductorProfile?: string;
+	/** Record a sent AI message into the in-memory per-session history */
+	recordMessageToHistory?: (sessionId: string, message: string) => void;
 }
 
 /**
@@ -140,6 +142,7 @@ export function useInputProcessing(deps: UseInputProcessingDeps): UseInputProces
 		onSkillsCommand,
 		automaticTabNamingEnabled,
 		conductorProfile,
+		recordMessageToHistory,
 	} = deps;
 
 	// Ref for the processInput function so external code can access the latest version
@@ -388,6 +391,9 @@ export function useInputProcessing(deps: UseInputProcessingDeps): UseInputProces
 				// Capture staged images before clearing
 				const imagesToSend = stagedImages.length > 0 ? [...stagedImages] : undefined;
 
+				// Record to history before clearing
+				recordMessageToHistory?.(activeSessionId, effectiveInputValue);
+
 				// Clear input
 				setInputValue('');
 				setStagedImages([]);
@@ -493,6 +499,9 @@ export function useInputProcessing(deps: UseInputProcessingDeps): UseInputProces
 							};
 						})
 					);
+
+					// Record to history before clearing
+					recordMessageToHistory?.(activeSessionId, effectiveInputValue);
 
 					// Clear input
 					setInputValue('');
@@ -871,6 +880,11 @@ export function useInputProcessing(deps: UseInputProcessingDeps): UseInputProces
 			// Use effectiveInputValue (without nudge) since nudge should be hidden from UI
 			window.maestro.web.broadcastUserInput(activeSession.id, effectiveInputValue, currentMode);
 
+			// Record AI messages to in-memory input history (excludes terminal commands)
+			if (currentMode === 'ai') {
+				recordMessageToHistory?.(activeSessionId, effectiveInputValue);
+			}
+
 			setInputValue('');
 			setStagedImages([]);
 
@@ -1228,6 +1242,7 @@ export function useInputProcessing(deps: UseInputProcessingDeps): UseInputProces
 			flushBatchedUpdates,
 			onHistoryCommand,
 			onWizardCommand,
+			recordMessageToHistory,
 		]
 	);
 


### PR DESCRIPTION
## Summary

- Pressing **↑** at the beginning of the AI chat input cycles through previously sent messages (oldest → newest)
- Pressing **↓** walks forward through history, restoring your unsaved draft when you reach the end
- Works in both the main AI input and Group Chat input

## Behavior

- History is **per-session** and **in-memory** (cleared on app restart)
- Capped at 100 entries; consecutive duplicate messages are skipped
- The current unsaved draft is preserved when navigation starts and restored on the way back down
- Terminal mode is unaffected — it retains its existing command history modal

## Implementation

New `useAIMessageHistory` hook manages per-session history state via `Map` refs (no React state, no re-renders). Hooked into `useInputProcessing` to record messages at send time (AI mode only — wizard, queue, and direct send paths). Navigation is handled in `useInputKeyDown` for the main input and inline refs in `GroupChatInput` for group chat.
