### PR TITLE
fix(history): add cache tokens to displayed input count for Claude (#844)

### DIFF
--- a/src/__tests__/renderer/components/MainPanel.test.tsx
+++ b/src/__tests__/renderer/components/MainPanel.test.tsx
@@ -1885,7 +1885,12 @@ describe('MainPanel', () => {
 
 			await waitFor(() => {
 				expect(screen.getByText('Input Tokens')).toBeInTheDocument();
-				expect(screen.getByText('1,500')).toBeInTheDocument();
+				// Claude reports inputTokens as the uncached delta only, so the
+				// displayed "Input Tokens" value is inputTokens + cacheRead + cacheCreation
+				// = 1500 + 200 + 100 = 1800. See issue #844 / calculateDisplayInputTokens.
+				// Same number also appears in the "Context Tokens" row (which sums the
+				// same three fields), so we expect two matches.
+				expect(screen.getAllByText('1,800')).toHaveLength(2);
 				expect(screen.getByText('Output Tokens')).toBeInTheDocument();
 				expect(screen.getByText('750')).toBeInTheDocument();
 				expect(screen.getByText('Cache Read')).toBeInTheDocument();

--- a/src/__tests__/renderer/utils/contextUsage.test.ts
+++ b/src/__tests__/renderer/utils/contextUsage.test.ts
@@ -7,6 +7,7 @@ import {
 	estimateContextUsage,
 	calculateContextTokens,
 	calculateContextDisplay,
+	calculateDisplayInputTokens,
 	estimateAccumulatedGrowth,
 	DEFAULT_CONTEXT_WINDOWS,
 } from '../../../renderer/utils/contextUsage';
@@ -466,5 +467,63 @@ describe('DEFAULT_CONTEXT_WINDOWS', () => {
 		expect(DEFAULT_CONTEXT_WINDOWS['opencode']).toBe(128000);
 		expect(DEFAULT_CONTEXT_WINDOWS['factory-droid']).toBe(200000);
 		expect(DEFAULT_CONTEXT_WINDOWS['terminal']).toBe(0);
+	});
+});
+
+describe('calculateDisplayInputTokens', () => {
+	// Reproduces the issue #844 scenario: a Claude Code entry whose usage comes
+	// from a resumed session. The new `input_tokens` delta is tiny, but the
+	// conversation actually lives in `cache_read_input_tokens`.
+	it('adds cache tokens back for Claude so resumed conversations do not look empty', () => {
+		const stats: Partial<UsageStats> = {
+			inputTokens: 5,
+			cacheReadInputTokens: 47_382,
+			cacheCreationInputTokens: 1_204,
+		};
+		// Before the fix this displayed as 5 — see issue #844.
+		expect(calculateDisplayInputTokens(stats, 'claude-code')).toBe(48_591);
+	});
+
+	it('treats missing cache fields as zero (older history entries)', () => {
+		expect(calculateDisplayInputTokens({ inputTokens: 1_000 }, 'claude-code')).toBe(1_000);
+	});
+
+	it('defaults to the Claude formula when agentId is omitted', () => {
+		// Safe default: Claude Code is the most common provider, and the fallback
+		// over-counts rather than under-counts if we guess wrong.
+		const stats: Partial<UsageStats> = {
+			inputTokens: 10,
+			cacheReadInputTokens: 500,
+			cacheCreationInputTokens: 100,
+		};
+		expect(calculateDisplayInputTokens(stats)).toBe(610);
+	});
+
+	it('returns inputTokens as-is for Codex (cached tokens already included)', () => {
+		// Per codex-output-parser.ts: cached_input_tokens is a SUBSET of input_tokens.
+		// Adding cacheReadInputTokens would double-count.
+		const stats: Partial<UsageStats> = {
+			inputTokens: 12_000,
+			cacheReadInputTokens: 8_000, // reported for display only; already in inputTokens
+			cacheCreationInputTokens: 0,
+		};
+		expect(calculateDisplayInputTokens(stats, 'codex')).toBe(12_000);
+	});
+
+	it('handles all-zero / empty stats without throwing', () => {
+		expect(calculateDisplayInputTokens({}, 'claude-code')).toBe(0);
+		expect(calculateDisplayInputTokens({}, 'codex')).toBe(0);
+	});
+
+	it('treats unknown agent types as Claude-family', () => {
+		// If a new agent is added and this helper isn't updated, the Claude formula
+		// is the safer default — the worst case is an over-count on a single entry,
+		// not an "abnormally low" under-count that regresses issue #844.
+		const stats: Partial<UsageStats> = {
+			inputTokens: 3,
+			cacheReadInputTokens: 2_000,
+			cacheCreationInputTokens: 50,
+		};
+		expect(calculateDisplayInputTokens(stats, 'brand-new-agent')).toBe(2_053);
 	});
 });

--- a/src/renderer/components/HistoryDetailModal.tsx
+++ b/src/renderer/components/HistoryDetailModal.tsx
@@ -17,7 +17,7 @@ import {
 	AlertTriangle,
 	Server,
 } from 'lucide-react';
-import type { Theme, HistoryEntry } from '../types';
+import type { Theme, HistoryEntry, ToolType } from '../types';
 import type { FileNode } from '../types/fileTree';
 import { useModalLayer } from '../hooks/ui/useModalLayer';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
@@ -26,7 +26,7 @@ import { formatTimestamp } from '../../shared/formatters';
 import { stripAnsiCodes } from '../../shared/stringUtils';
 import { MarkdownRenderer } from './MarkdownRenderer';
 import { generateTerminalProseStyles } from '../utils/markdownConfig';
-import { calculateContextDisplay } from '../utils/contextUsage';
+import { calculateContextDisplay, calculateDisplayInputTokens } from '../utils/contextUsage';
 import { getContextColor } from '../utils/theme';
 import { DoubleCheck } from './History';
 import { safeClipboardWrite } from '../utils/clipboard';
@@ -48,6 +48,12 @@ interface HistoryDetailModalProps {
 	cwd?: string;
 	projectRoot?: string;
 	onFileClick?: (path: string) => void;
+	/**
+	 * Agent identifier (session.toolType) used to display input tokens correctly.
+	 * Claude reports `inputTokens` as the uncached delta only, so we add the cache
+	 * partitions to show the real input size — see calculateDisplayInputTokens.
+	 */
+	agentId?: ToolType;
 }
 
 export function HistoryDetailModal({
@@ -65,6 +71,7 @@ export function HistoryDetailModal({
 	cwd,
 	projectRoot,
 	onFileClick,
+	agentId,
 }: HistoryDetailModalProps) {
 	const onCloseRef = useRef(onClose);
 	onCloseRef.current = onClose;
@@ -483,7 +490,9 @@ export function HistoryDetailModal({
 									<div className="flex items-center gap-3 text-xs font-mono">
 										<span style={{ color: theme.colors.accent }}>
 											<span style={{ color: theme.colors.textDim }}>In:</span>{' '}
-											{(entry.usageStats.inputTokens ?? 0).toLocaleString('en-US')}
+											{calculateDisplayInputTokens(entry.usageStats, agentId).toLocaleString(
+												'en-US'
+											)}
 										</span>
 										<span style={{ color: theme.colors.success }}>
 											<span style={{ color: theme.colors.textDim }}>Out:</span>{' '}

--- a/src/renderer/components/HistoryPanel.tsx
+++ b/src/renderer/components/HistoryPanel.tsx
@@ -692,6 +692,7 @@ export const HistoryPanel = React.memo(
 					<HistoryDetailModal
 						theme={theme}
 						entry={detailModalEntry}
+						agentId={session.toolType}
 						onClose={closeDetailModal}
 						onJumpToAgentSession={onJumpToAgentSession}
 						onResumeSession={onResumeSession}

--- a/src/renderer/components/MainPanel/MainPanelHeader.tsx
+++ b/src/renderer/components/MainPanel/MainPanelHeader.tsx
@@ -25,6 +25,7 @@ import { useUIStore } from '../../stores/uiStore';
 import type { Session, Theme, BatchRunState, AITab } from '../../types';
 import type { AgentCapabilities } from '../../hooks/agent/useAgentCapabilities';
 import { openUrl } from '../../utils/openUrl';
+import { calculateDisplayInputTokens } from '../../utils/contextUsage';
 
 export interface MainPanelHeaderProps {
 	activeSession: Session;
@@ -508,7 +509,10 @@ export const MainPanelHeader = React.memo(function MainPanelHeader({
 														className="text-xs font-mono"
 														style={{ color: theme.colors.textMain }}
 													>
-														{(activeTab?.usageStats?.inputTokens ?? 0).toLocaleString('en-US')}
+														{calculateDisplayInputTokens(
+															activeTab?.usageStats ?? {},
+															activeSession.toolType
+														).toLocaleString('en-US')}
 													</span>
 												</div>
 												<div className="flex justify-between items-center">

--- a/src/renderer/utils/contextUsage.ts
+++ b/src/renderer/utils/contextUsage.ts
@@ -22,6 +22,52 @@ const MAX_GROWTH_PERCENT = 3;
 const MIN_PREV_CONTEXT_FRACTION = 0.05;
 
 /**
+ * Calculate total input tokens for display on a single history entry or tab header.
+ *
+ * Agents partition their input-token accounting differently:
+ *
+ * - **Claude models** report `inputTokens` as the UNCACHED input delta only.
+ *   `cacheReadInputTokens` and `cacheCreationInputTokens` are tracked separately
+ *   and must be ADDED back to reflect the full size of the input that the model
+ *   actually processed. On a resumed session almost all input lands in
+ *   `cacheReadInputTokens`, leaving `inputTokens` at single-digit values that
+ *   look absurd to users (see issue #844).
+ *
+ * - **OpenAI/Codex models** report `inputTokens` inclusive of cached input.
+ *   `cacheReadInputTokens` is reported separately for display only and must
+ *   NOT be double-counted (see codex-output-parser.ts).
+ *
+ * Use this for per-entry / per-tab "input tokens" displays. For the context
+ * window percentage gauge, use `calculateContextTokens` / `calculateContextDisplay`
+ * — those also add `outputTokens` for OpenAI-style combined-limit models.
+ *
+ * @param stats - The usage statistics containing token counts
+ * @param agentId - The agent identifier; defaults to the Claude formula
+ * @returns Total input tokens to show the user
+ */
+export function calculateDisplayInputTokens(
+	stats: {
+		inputTokens?: number;
+		cacheReadInputTokens?: number;
+		cacheCreationInputTokens?: number;
+	},
+	agentId?: ToolType | string
+): number {
+	// OpenAI/Codex: inputTokens already includes cached input, do not add cache fields.
+	if (agentId && COMBINED_CONTEXT_AGENTS.has(agentId as ToolType)) {
+		return stats.inputTokens || 0;
+	}
+
+	// Claude (and unknown agents, as a safe default): inputTokens is uncached only,
+	// add the cache partitions to reflect the real input size.
+	return (
+		(stats.inputTokens || 0) +
+		(stats.cacheReadInputTokens || 0) +
+		(stats.cacheCreationInputTokens || 0)
+	);
+}
+
+/**
  * Calculate total context tokens based on agent-specific semantics.
  *
  * For a single Anthropic API call, the total input context is the sum of:


### PR DESCRIPTION
Fixes #844.

## The bug

Users see abnormally low input / output token counts on history entries — e.g. `In: 5 Out: 6` next to a substantial conversation. Reproduces on SSH, sandbox, and regular sessions.

## Root cause

Claude reports `input_tokens` as the **uncached input delta only**. The rest of the conversation sits in `cache_read_input_tokens` and `cache_creation_input_tokens`. On a resumed session — which backs every synopsis-driven USER history entry, see `spawnBackgroundSynopsis` in `src/renderer/hooks/agent/useAgentExecution.ts` — nearly all input lands in `cache_read_input_tokens`, leaving raw `inputTokens` at 5-ish.

`HistoryDetailModal.tsx:486` and `MainPanelHeader.tsx:511` both displayed that raw field directly:

```tsx
{(entry.usageStats.inputTokens ?? 0).toLocaleString('en-US')}
```

This is the "single-digit numbers" the reporter is seeing. The codebase already has `calculateContextTokens` in `src/renderer/utils/contextUsage.ts` that composes the three fields correctly for the context-window gauge — the display paths just weren't using it.

The `usage-aggregator` docs have called this out from the start (`src/main/parsers/usage-aggregator.ts:48-83`): *"For a single Anthropic API call, the total input context is the sum of `inputTokens + cacheReadInputTokens + cacheCreationInputTokens`."*

## Fix

Added `calculateDisplayInputTokens(stats, agentId?)` next to `calculateContextTokens`:

- **Claude-family** (`claude-code`, `factory-droid`, `opencode`, unknown): `inputTokens + cacheReadInputTokens + cacheCreationInputTokens`.
- **OpenAI/Codex** (members of `COMBINED_CONTEXT_AGENTS`): returns `inputTokens` as-is, because `codex-output-parser.ts:788` documents `cached_input_tokens` as a subset already included in `input_tokens`. Adding it again would double-count.
- **Unknown `agentId`**: defaults to the Claude formula. Safer default — worst case is an over-count on one display, not a repeat of this bug's under-count.

Wired into the two display sites:
- `HistoryDetailModal.tsx` — new optional `agentId?: string` prop.
- `HistoryPanel.tsx` — passes `session.toolType` when instantiating the modal.
- `MainPanelHeader.tsx` — uses `activeSession.toolType`.

Output-token display is **unchanged**; both Claude and Codex report `output_tokens` inclusive of everything that should count (Codex adds reasoning tokens at parse time in `codex-output-parser.ts:782-783`).

## Scope

Intentionally narrow — touches only the two display sites named in the issue.

- `AgentSessionsBrowser.tsx` also shows input/output tokens but sources them from the stats DB aggregation (`agentSessions.ts`), not from `entry.usageStats`. Its values come from a different pipeline and are out of scope for this bug report.
- `TabSwitcherModal.tsx` displays `tab.usageStats.inputTokens + tab.usageStats.outputTokens` — same pattern, but users haven't flagged it and the combined number partially masks the under-count. Left for a follow-up if wanted.
- `DirectorNotes/UnifiedHistoryTab.tsx` instantiates `HistoryDetailModal` without `agentId`. That tab is a cross-session aggregator and has no single `toolType` to pass; the default Claude formula applies. Net effect on that tab: Claude entries display correctly (primary case), Codex entries over-count by the `cacheReadInputTokens` field (minor cosmetic regression, does not reintroduce the reported bug). If this matters, a follow-up can add `toolType` to `HistoryEntry` (schema change + backfill) or pass a session-map lookup; both were too large for this fix.

## What is NOT changed

- `entry.usageStats` as stored in history. Display-only fix.
- `calculateContextTokens` / the context-window gauge.
- Output-token display at either site.
- The synopsis → history path in `useAgentExecution.ts` / `useAgentListeners.ts`.
- The duplicate `calculateContextTokens` between `src/main/parsers/usage-aggregator.ts` and `src/renderer/utils/contextUsage.ts` (separate dedup task).

## Tests

Added 6 cases to `contextUsage.test.ts`:
1. Resumed-session Claude scenario that reproduces #844 (5 input + 47K cache → 48K display).
2. Missing cache fields on older history entries (no crash, no NaN).
3. Default formula when `agentId` is omitted.
4. Codex: returns `inputTokens` as-is, no double-count.
5. All-zero stats.
6. Unknown agent IDs: falls back to the Claude formula (protects against regression if a new agent is added without updating this helper).

## Verification

- `npx tsc --noEmit` — clean
- `npx prettier --check` on touched files — clean
- `npx eslint` on touched files — clean
- `contextUsage.test.ts` — 47 passed (41 existing + 6 new)
- `HistoryDetailModal.test.tsx` — 96 passed
- `HistoryPanel.test.tsx` — 69 passed

## Follow-ups (not in this PR)

- Consider adding `toolType` to `HistoryEntry` so `UnifiedHistoryTab` can pass the right `agentId` per entry.
- Consider applying the same helper to `TabSwitcherModal.tsx` if desired.
- Consider unifying the duplicate `calculateContextTokens` between main and renderer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected displayed "Input Tokens" so counts include cache-related tokens for Claude-family models while keeping other models' displays unchanged; fixes resumed-session and history tooltip inconsistencies.
* **Tests**
  * Updated tests to assert the revised token counts shown in context tooltips and history/detail views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->