### PR TITLE
fix(cue): seed lastWrittenRootsRef with per-pipeline write roots (#847)

### DIFF
--- a/src/__tests__/renderer/components/CuePipelineEditor/utils/pipelineRoots.test.ts
+++ b/src/__tests__/renderer/components/CuePipelineEditor/utils/pipelineRoots.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Tests for resolvePipelineWriteRoot / resolvePipelinesWriteRoots.
+ *
+ * These match handleSave's partitioning rules so that `lastWrittenRootsRef`
+ * stays in sync with where YAMLs actually live. The cross-directory cases
+ * are the regression test for #847 (deleted pipeline reappears because the
+ * common-ancestor write root was never seeded into previousRoots).
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+	resolvePipelineWriteRoot,
+	resolvePipelinesWriteRoots,
+} from '../../../../../renderer/components/CuePipelineEditor/utils/pipelineRoots';
+import type {
+	AgentNodeData,
+	CuePipeline,
+	CuePipelineSessionInfo as SessionInfo,
+} from '../../../../../shared/cue-pipeline-types';
+
+type SessionRootInfo = Pick<SessionInfo, 'projectRoot'>;
+
+function makeAgentNode(sessionId: string, sessionName: string): CuePipeline['nodes'][number] {
+	return {
+		id: `agent-${sessionId}`,
+		type: 'agent',
+		position: { x: 0, y: 0 },
+		data: {
+			sessionId,
+			sessionName,
+			toolType: 'claude-code',
+			inputPrompt: '',
+		} as AgentNodeData,
+	};
+}
+
+function makePipeline(agents: Array<{ sessionId: string; sessionName: string }>): CuePipeline {
+	return {
+		id: 'p1',
+		name: 'test',
+		color: '#06b6d4',
+		nodes: [
+			{
+				id: 'trigger-1',
+				type: 'trigger',
+				position: { x: 0, y: 0 },
+				data: { eventType: 'time.heartbeat', label: 'Timer', config: {} },
+			},
+			...agents.map((a) => makeAgentNode(a.sessionId, a.sessionName)),
+		],
+		edges: [],
+	};
+}
+
+function mapBy<T>(entries: Array<[string, T]>): ReadonlyMap<string, T> {
+	return new Map(entries);
+}
+
+describe('resolvePipelineWriteRoot', () => {
+	describe('single-root pipelines', () => {
+		it('returns the common root when all agents share one project root', () => {
+			const pipeline = makePipeline([
+				{ sessionId: 's1', sessionName: 'alpha' },
+				{ sessionId: 's2', sessionName: 'beta' },
+			]);
+			const byId = mapBy<SessionRootInfo>([
+				['s1', { projectRoot: '/workspace/proj' }],
+				['s2', { projectRoot: '/workspace/proj' }],
+			]);
+			expect(resolvePipelineWriteRoot(pipeline, byId, new Map())).toBe('/workspace/proj');
+		});
+
+		it('falls back to sessionName when sessionId is not found', () => {
+			const pipeline = makePipeline([{ sessionId: 'missing', sessionName: 'alpha' }]);
+			const byName = mapBy<SessionRootInfo>([['alpha', { projectRoot: '/workspace/proj' }]]);
+			expect(resolvePipelineWriteRoot(pipeline, new Map(), byName)).toBe('/workspace/proj');
+		});
+
+		it('prefers sessionId over sessionName when both are present', () => {
+			const pipeline = makePipeline([{ sessionId: 's1', sessionName: 'alpha' }]);
+			const byId = mapBy<SessionRootInfo>([['s1', { projectRoot: '/via-id' }]]);
+			const byName = mapBy<SessionRootInfo>([['alpha', { projectRoot: '/via-name' }]]);
+			expect(resolvePipelineWriteRoot(pipeline, byId, byName)).toBe('/via-id');
+		});
+	});
+
+	describe('cross-directory pipelines (regression for #847)', () => {
+		it('collapses to common ancestor when agents span subdirectories', () => {
+			// The #847 scenario: pipeline's YAML lives at /project, not at
+			// /project/a or /project/Digest. Previously the load-time loop
+			// added the two sub-roots and missed /project — so a delete+save
+			// could not clear the stale YAML.
+			const pipeline = makePipeline([
+				{ sessionId: 's1', sessionName: 'frontend' },
+				{ sessionId: 's2', sessionName: 'digest' },
+			]);
+			const byId = mapBy<SessionRootInfo>([
+				['s1', { projectRoot: '/project/frontend' }],
+				['s2', { projectRoot: '/project/Digest' }],
+			]);
+			expect(resolvePipelineWriteRoot(pipeline, byId, new Map())).toBe('/project');
+		});
+
+		it('returns null when agent roots span unrelated trees', () => {
+			// handleSave rejects "agents span unrelated project roots" — we must
+			// not seed a write-root we would never actually write to. Two paths
+			// whose only shared prefix is filesystem root `/` fail the
+			// isDescendantOrEqual check (since `/workspace/projA` does not start
+			// with `//`), so the helper returns null — matching handleSave.
+			const pipeline = makePipeline([
+				{ sessionId: 's1', sessionName: 'alpha' },
+				{ sessionId: 's2', sessionName: 'beta' },
+			]);
+			const byId = mapBy<SessionRootInfo>([
+				['s1', { projectRoot: '/workspace/projA' }],
+				['s2', { projectRoot: '/other/projB' }],
+			]);
+			expect(resolvePipelineWriteRoot(pipeline, byId, new Map())).toBeNull();
+		});
+	});
+
+	describe('unresolvable pipelines', () => {
+		it('returns null for an empty pipeline (no agents)', () => {
+			const pipeline: CuePipeline = {
+				id: 'empty',
+				name: 'empty',
+				color: '#06b6d4',
+				nodes: [],
+				edges: [],
+			};
+			expect(resolvePipelineWriteRoot(pipeline, new Map(), new Map())).toBeNull();
+		});
+
+		it('returns null when no agent resolves to a session with a projectRoot', () => {
+			const pipeline = makePipeline([{ sessionId: 'missing', sessionName: 'gone' }]);
+			expect(resolvePipelineWriteRoot(pipeline, new Map(), new Map())).toBeNull();
+		});
+
+		it('returns null when any agent is unresolvable (missingRoot parity with handleSave)', () => {
+			// handleSave aborts the partition step for a pipeline with any
+			// unresolvable agent; we mirror that so we do not seed a root the
+			// save flow would never actually write to.
+			const pipeline = makePipeline([
+				{ sessionId: 's1', sessionName: 'alpha' },
+				{ sessionId: 'missing', sessionName: 'gone' },
+			]);
+			const byId = mapBy<SessionRootInfo>([['s1', { projectRoot: '/workspace/proj' }]]);
+			expect(resolvePipelineWriteRoot(pipeline, byId, new Map())).toBeNull();
+		});
+
+		it('returns null when projectRoot is undefined on the resolved session', () => {
+			const pipeline = makePipeline([{ sessionId: 's1', sessionName: 'alpha' }]);
+			const byId = mapBy<SessionRootInfo>([['s1', { projectRoot: undefined }]]);
+			expect(resolvePipelineWriteRoot(pipeline, byId, new Map())).toBeNull();
+		});
+
+		it('treats empty-string sessionId/sessionName as unresolvable (defensive guard)', () => {
+			// A stray `''` key in the session maps must not accidentally resolve an
+			// agent whose identifiers are empty.
+			const pipeline = makePipeline([{ sessionId: '', sessionName: '' }]);
+			const byId = mapBy<SessionRootInfo>([['', { projectRoot: '/should-not-match' }]]);
+			const byName = mapBy<SessionRootInfo>([['', { projectRoot: '/also-should-not-match' }]]);
+			expect(resolvePipelineWriteRoot(pipeline, byId, byName)).toBeNull();
+		});
+	});
+});
+
+describe('resolvePipelinesWriteRoots', () => {
+	it('unions distinct write roots across multiple pipelines', () => {
+		const p1 = { ...makePipeline([{ sessionId: 's1', sessionName: 'alpha' }]), id: 'p1' };
+		const p2 = { ...makePipeline([{ sessionId: 's2', sessionName: 'beta' }]), id: 'p2' };
+		const byId = mapBy<SessionRootInfo>([
+			['s1', { projectRoot: '/projA' }],
+			['s2', { projectRoot: '/projB' }],
+		]);
+		const roots = resolvePipelinesWriteRoots([p1, p2], byId, new Map());
+		expect(roots).toEqual(new Set(['/projA', '/projB']));
+	});
+
+	it('collapses duplicate roots to a single entry', () => {
+		const p1 = { ...makePipeline([{ sessionId: 's1', sessionName: 'alpha' }]), id: 'p1' };
+		const p2 = { ...makePipeline([{ sessionId: 's2', sessionName: 'beta' }]), id: 'p2' };
+		const byId = mapBy<SessionRootInfo>([
+			['s1', { projectRoot: '/projA' }],
+			['s2', { projectRoot: '/projA' }],
+		]);
+		const roots = resolvePipelinesWriteRoots([p1, p2], byId, new Map());
+		expect(roots).toEqual(new Set(['/projA']));
+	});
+
+	it('skips pipelines that do not resolve to a single write root', () => {
+		const resolvable = { ...makePipeline([{ sessionId: 's1', sessionName: 'alpha' }]), id: 'p1' };
+		const empty: CuePipeline = {
+			id: 'p2',
+			name: 'empty',
+			color: '#06b6d4',
+			nodes: [],
+			edges: [],
+		};
+		const unresolvable = {
+			...makePipeline([{ sessionId: 'missing', sessionName: 'gone' }]),
+			id: 'p3',
+		};
+		const byId = mapBy<SessionRootInfo>([['s1', { projectRoot: '/projA' }]]);
+		const roots = resolvePipelinesWriteRoots([resolvable, empty, unresolvable], byId, new Map());
+		expect(roots).toEqual(new Set(['/projA']));
+	});
+
+	it('returns the common ancestor (not individual sub-roots) for cross-directory pipelines', () => {
+		// Direct regression test for #847: the set MUST include '/project'
+		// (where the YAML actually lives) and must NOT include the per-agent
+		// subdirectories.
+		const pipeline = makePipeline([
+			{ sessionId: 's1', sessionName: 'frontend' },
+			{ sessionId: 's2', sessionName: 'digest' },
+		]);
+		const byId = mapBy<SessionRootInfo>([
+			['s1', { projectRoot: '/project/frontend' }],
+			['s2', { projectRoot: '/project/Digest' }],
+		]);
+		const roots = resolvePipelinesWriteRoots([pipeline], byId, new Map());
+		expect(roots).toEqual(new Set(['/project']));
+		expect(roots.has('/project/frontend')).toBe(false);
+		expect(roots.has('/project/Digest')).toBe(false);
+	});
+});

--- a/src/renderer/components/CuePipelineEditor/utils/pipelineRoots.ts
+++ b/src/renderer/components/CuePipelineEditor/utils/pipelineRoots.ts
@@ -1,0 +1,103 @@
+/**
+ * Resolve which .maestro/cue.yaml a pipeline belongs to.
+ *
+ * Every pipeline must live in exactly one project root's cue.yaml — that
+ * invariant is enforced by handleSave (see usePipelinePersistence) and is
+ * what keeps deleted pipelines from reappearing via mirrored YAMLs.
+ *
+ * `lastWrittenRootsRef` (see usePipelineLayout) needs to know those
+ * per-pipeline write roots so the save loop can clear the right YAML when
+ * the user deletes a pipeline. This helper is the single source of truth for
+ * that mapping and MUST stay in sync with handleSave's happy-path
+ * partitioning.
+ */
+
+import type {
+	AgentNodeData,
+	CuePipeline,
+	CuePipelineSessionInfo as SessionInfo,
+} from '../../../../shared/cue-pipeline-types';
+import { computeCommonAncestorPath, isDescendantOrEqual } from '../../../../shared/cue-path-utils';
+
+/** Subset of SessionInfo this module relies on. */
+type SessionRootInfo = Pick<SessionInfo, 'projectRoot'>;
+
+/**
+ * Resolve the single project root that a pipeline's YAML would be written to.
+ *
+ * Rules — matching handleSave's happy-path partitioning:
+ *
+ * - All agents resolve to the same root → that root.
+ * - Agents span multiple roots that share a common ancestor (every agent
+ *   root is a descendant of it) → the common ancestor. Enables the
+ *   cross-directory pipeline support added in PR #845.
+ * - Any agent unresolvable, no agents at all, or roots spanning unrelated
+ *   trees → `null`. handleSave would reject such a pipeline as a validation
+ *   error, so no YAML is written for it and we must not seed a root for it.
+ *
+ * Agents are resolved by `sessionId` first (stable across renames), then by
+ * `sessionName` as a fallback for pipelines loaded from older YAML that
+ * referenced agents purely by name.
+ */
+export function resolvePipelineWriteRoot(
+	pipeline: Pick<CuePipeline, 'nodes'>,
+	sessionsById: ReadonlyMap<string, SessionRootInfo>,
+	sessionsByName: ReadonlyMap<string, SessionRootInfo>
+): string | null {
+	const agents = pipeline.nodes.filter((n) => n.type === 'agent');
+	if (agents.length === 0) return null;
+
+	const roots = new Set<string>();
+	let missingRoot = false;
+	for (const agent of agents) {
+		const data = agent.data as AgentNodeData;
+		// Guard against empty-string sessionId / sessionName so a stray `''`
+		// key in the session maps can't accidentally resolve an agent that
+		// should have been treated as missing.
+		const byId = data.sessionId ? sessionsById.get(data.sessionId) : undefined;
+		const byName =
+			!byId?.projectRoot && data.sessionName ? sessionsByName.get(data.sessionName) : undefined;
+		const root = byId?.projectRoot ?? byName?.projectRoot;
+		if (root) {
+			roots.add(root);
+		} else {
+			missingRoot = true;
+		}
+	}
+
+	if (roots.size === 0) return null;
+
+	// Partial resolution (some agents missing) mirrors handleSave's behavior:
+	// the pipeline would be rejected for missingRoot, so we don't seed a root.
+	if (missingRoot) return null;
+
+	if (roots.size === 1) return [...roots][0];
+
+	// Multi-root: collapse to common ancestor only when every agent root is
+	// actually a descendant of it — otherwise handleSave rejects the pipeline
+	// for spanning unrelated project trees.
+	// (computeCommonAncestorPath only returns null for empty input; with
+	// roots.size >= 2 here the real unrelated-trees guard is `allDescendants`.)
+	const commonRoot = computeCommonAncestorPath([...roots]);
+	if (commonRoot === null) return null;
+	const allDescendants = [...roots].every((r) => isDescendantOrEqual(r, commonRoot));
+	return allDescendants ? commonRoot : null;
+}
+
+/**
+ * Resolve write roots for every pipeline in a list, returning the set of
+ * distinct roots. Skips pipelines that don't resolve to a single write root
+ * (see `resolvePipelineWriteRoot`).
+ */
+export function resolvePipelinesWriteRoots(
+	pipelines: ReadonlyArray<Pick<CuePipeline, 'nodes'>>,
+	sessionsById: ReadonlyMap<string, SessionRootInfo>,
+	sessionsByName: ReadonlyMap<string, SessionRootInfo>
+): Set<string> {
+	const roots = new Set<string>();
+	for (const pipeline of pipelines) {
+		const root = resolvePipelineWriteRoot(pipeline, sessionsById, sessionsByName);
+		if (root) roots.add(root);
+	}
+	return roots;
+}

--- a/src/renderer/hooks/cue/usePipelineLayout.ts
+++ b/src/renderer/hooks/cue/usePipelineLayout.ts
@@ -17,6 +17,7 @@ import type {
 import { PIPELINE_LAYOUT_DEFAULT_PROJECT_KEY } from '../../../shared/cue-pipeline-types';
 import { graphSessionsToPipelines } from '../../components/CuePipelineEditor/utils/yamlToPipeline';
 import { mergePipelinesWithSavedLayout } from '../../components/CuePipelineEditor/utils/pipelineLayout';
+import { resolvePipelinesWriteRoots } from '../../components/CuePipelineEditor/utils/pipelineRoots';
 import { captureException } from '../../utils/sentry';
 import { cueService } from '../../services/cue';
 
@@ -293,10 +294,14 @@ export function usePipelineLayout({
 			//      authoritative even when the originating agent has since been
 			//      renamed or deleted (the session lookup below would miss it
 			//      in that case, leaving stale YAML at that root uncleared).
-			//   2. Session-resolved roots from the just-loaded pipelines —
-			//      catches any roots that aren't in writtenRoots yet (e.g.
-			//      first-ever editor open with pre-existing pipelines, or
-			//      writtenRoots was cleared/missing on disk).
+			//   2. Per-pipeline WRITE roots derived from the just-loaded pipelines
+			//      via the same rules handleSave uses to partition pipelines by
+			//      project root. This is the cross-directory fix for #847: when
+			//      a pipeline's agents span subdirectories, its YAML lives at
+			//      their common ancestor — we seed that ancestor here so the
+			//      next delete+save can clear it. Seeding each individual agent
+			//      root (as this loop used to) would both miss the ancestor AND
+			//      create stray empty cue.yaml files at sub-paths on delete.
 			const loadedRoots = new Set<string>();
 			if (savedLayout?.writtenRoots && Array.isArray(savedLayout.writtenRoots)) {
 				for (const root of savedLayout.writtenRoots) {
@@ -305,17 +310,24 @@ export function usePipelineLayout({
 					}
 				}
 			}
-			const sessionsById = new Map(sessions.map((s) => [s.id, s]));
-			const sessionsByName = new Map(sessions.map((s) => [s.name, s]));
-			for (const pipeline of pipelinesForRoots) {
-				for (const node of pipeline.nodes) {
-					if (node.type !== 'agent') continue;
-					const data = node.data as AgentNodeData;
-					const root =
-						sessionsById.get(data.sessionId)?.projectRoot ??
-						sessionsByName.get(data.sessionName)?.projectRoot;
-					if (root) loadedRoots.add(root);
-				}
+			// Build lookup maps with first-wins semantics on duplicate names, matching
+			// handleSave's rule (usePipelinePersistence.ts:120-125). Last-wins via
+			// `new Map(sessions.map(...))` could pick a different projectRoot than
+			// handleSave will actually write to, defeating the parity invariant that
+			// is the whole point of `resolvePipelinesWriteRoots`.
+			const sessionsById = new Map<string, SessionInfo>();
+			const sessionsByName = new Map<string, SessionInfo>();
+			for (const s of sessions) {
+				sessionsById.set(s.id, s);
+				if (!sessionsByName.has(s.name)) sessionsByName.set(s.name, s);
+			}
+			const writeRoots = resolvePipelinesWriteRoots(
+				pipelinesForRoots,
+				sessionsById,
+				sessionsByName
+			);
+			for (const root of writeRoots) {
+				loadedRoots.add(root);
 			}
 			lastWrittenRootsRef.current = loadedRoots;
 


### PR DESCRIPTION
Fixes #847.

## The bug

A Cue Scenario deleted via the X button in the dropdown, with Save clicked, reappears after closing and reopening the Cue view.

## Root cause

PR #845 added cross-directory pipeline support. When a pipeline's agents span subdirectories (e.g. `/project/a` and `/project/Digest`), `handleSave` resolves their common ancestor (`/project`) and writes ONE YAML at `/project/.maestro/cue.yaml`.

The load path in `usePipelineLayout.ts:201-220` was still seeding `lastWrittenRootsRef` with **each agent's individual `projectRoot`** — so the common ancestor where the YAML actually lives was missing from the set.

That set becomes `previousRoots` in `handleSave`'s clear loop (`usePipelinePersistence.ts:254`). On delete+save:

- `currentRoots = {}` — the deleted pipeline had no survivors at its root.
- `previousRoots = {/project/a, /project/Digest}` — missing `/project`.
- The loop writes empty YAML only at the two subdirectory paths; the real YAML at `/project/.maestro/cue.yaml` is never touched.
- On reopen, `getGraphData()` still reports the pipeline from `/project/.maestro/cue.yaml`, so the "deleted" pipeline reappears.

The same mis-seeding had a secondary effect: on every delete+save, the clear loop was also writing empty `cue.yaml` files at the subdirectory roots that were never actually write targets, creating stray config files at sub-paths.

## Fix

Extract the write-root resolution into a shared pure helper `resolvePipelineWriteRoot` (`src/renderer/components/CuePipelineEditor/utils/pipelineRoots.ts`) mirroring `handleSave`'s happy-path partitioning:

- Single shared root across all agents → that root.
- Multiple roots sharing a common ancestor where every agent root is a descendant → the common ancestor.
- Otherwise (no agents, any unresolvable, unrelated trees) → `null`.

Use `resolvePipelinesWriteRoots` in `usePipelineLayout.ts`'s load-time seeding in place of the per-agent-root loop. The persisted `savedLayout.writtenRoots` union is preserved as the authoritative source when agents have since been renamed or deleted.

### Walkthrough after the fix (the #847 repro)

1. Pipeline at `/project/.maestro/cue.yaml` with agents in `/project/a` and `/project/Digest`.
2. User opens Cue view. Load seeds `loadedRoots` with:
   - `savedLayout.writtenRoots` (previously saved: `{/project}`, or empty if never saved via the new version).
   - Helper-resolved write roots: `{/project}` (common ancestor of the two sub-directories).
   - Net `previousRoots ⊇ {/project}`.
3. User clicks X → confirm → Save. `currentRoots = {}`. `previousRoots = {/project}`. The loop writes empty YAML at `/project/.maestro/cue.yaml`.
4. Engine refresh clears the subscriptions; `onSaveSuccess → refreshGraphData` re-reads.
5. User closes + reopens: `getGraphData()` finds no pipeline. ✓

## Scope

- `handleSave`'s inline partitioning is left unchanged — it carries three branches of error reporting (`unresolvedPipelines`, "agents span unrelated project roots", missing root) that the helper intentionally does not replicate. A doc comment on the helper calls out the invariant it must stay in sync with.
- No change to on-disk YAML format, layout storage schema, or the IPC surface.
- No change to the dashboard or runtime Cue engine.

## What is NOT changed

- The Cue engine / subscription runtime.
- `handleSave` itself (its partitioning still correct — the bug was only on the load side).
- `writeYaml` / `readYaml` IPC handlers.
- Cross-directory pipeline behavior from #845 — this fix only completes the symmetry.

## Tests

13 new cases in `pipelineRoots.test.ts`:

- Single-root: shared root across agents; sessionName fallback; sessionId-preferred-over-sessionName.
- Cross-directory (the #847 regression): collapses to common ancestor; returns null for unrelated trees (handleSave rejection parity).
- Unresolvable: empty pipeline, all agents missing, partial missing (`missingRoot` parity with handleSave), undefined `projectRoot`.
- Set-level `resolvePipelinesWriteRoots`: union of distinct roots, dedup of identical roots, skip unresolvable, cross-directory explicit assertion that individual sub-roots are NOT in the set.

## Verification

- `npx tsc --noEmit` — clean
- `npx prettier --check` on touched files — clean
- `npx eslint` on touched files — clean
- `pipelineRoots.test.ts` — 13 passed (new)
- All 347 Cue pipeline editor utility tests pass (23 files)
- All 209 cue hook tests pass (13 files)

## Manual test notes for reviewers

With the debug package from #847, the repro flow is:

1. Create a pipeline whose agents span at least two subdirectories of a common project root (or open an existing one in that shape).
2. Save. Close the Cue view.
3. Reopen. Click X on the pipeline in the dropdown. Confirm. Click Save.
4. Close + reopen the Cue view.

On `rc`: the pipeline reappears.
With this PR: it stays gone, and no stray empty `cue.yaml` files appear under the sub-directories.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Pipeline write-root logic centralized: pipelines now resolve to a single write root when possible, prefer stable session identifiers with a sensible name fallback, and collapse per-agent subdirectories to a common ancestor to avoid fragmented writes; persisted roots are reseeded from these derived per-pipeline roots.

* **Tests**
  * Added comprehensive tests for single- and multi-pipeline resolution, identifier/name fallback and precedence, common-ancestor behavior across directories, deduplication, and unresolvable failure cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->