### PR TITLE
cue: pre-production hardening — forwarded sources, lifecycle, correctness, per-project layout

### DIFF
--- a/src/__tests__/main/cue/cue-completion-chains.test.ts
+++ b/src/__tests__/main/cue/cue-completion-chains.test.ts
@@ -1212,4 +1212,126 @@ describe('CueEngine completion chains', () => {
 			engine.stop();
 		});
 	});
+
+	// Regression: until the single-source completion path was wired through
+	// the shared output filter, `include_output_from` and `forward_output_from`
+	// silently no-op'd for 1-source subscriptions. Any UI control that writes
+	// those fields must take effect on both fan-in and single-source chains.
+	describe('single-source filter (include/forward) regression', () => {
+		it('honors include_output_from: [] by emptying perSourceOutputs', () => {
+			const config = createMockConfig({
+				subscriptions: [
+					{
+						name: 'on-done',
+						event: 'agent.completed',
+						enabled: true,
+						prompt: 'follow up',
+						source_session: 'agent-a',
+						include_output_from: [],
+					},
+				],
+			});
+			mockLoadCueConfig.mockReturnValue(config);
+			const deps = createMockDeps();
+			const engine = new CueEngine(deps);
+			engine.start();
+
+			vi.clearAllMocks();
+			engine.notifyAgentCompleted('agent-a', { stdout: 'should be dropped' });
+
+			const request = (deps.onCueRun as ReturnType<typeof vi.fn>).mock.calls[0][0];
+			const event = request.event as CueEvent;
+			expect(event.payload.perSourceOutputs).toEqual({});
+			expect(event.payload.sourceOutput).toBe('');
+			engine.stop();
+		});
+
+		it('honors forward_output_from by populating forwardedOutputs with own output', () => {
+			const config = createMockConfig({
+				subscriptions: [
+					{
+						name: 'on-done',
+						event: 'agent.completed',
+						enabled: true,
+						prompt: 'follow up',
+						source_session: 'agent-a',
+						forward_output_from: ['Agent A'],
+					},
+				],
+			});
+			mockLoadCueConfig.mockReturnValue(config);
+			const deps = createMockDeps();
+			const engine = new CueEngine(deps);
+			engine.start();
+
+			vi.clearAllMocks();
+			engine.notifyAgentCompleted('agent-a', { sessionName: 'Agent A', stdout: 'own output' });
+
+			const request = (deps.onCueRun as ReturnType<typeof vi.fn>).mock.calls[0][0];
+			const event = request.event as CueEvent;
+			expect(event.payload.forwardedOutputs).toEqual({ 'Agent A': 'own output' });
+			engine.stop();
+		});
+
+		it('passes through upstream-forwarded data when forward_output_from is unset', () => {
+			const config = createMockConfig({
+				subscriptions: [
+					{
+						name: 'on-done',
+						event: 'agent.completed',
+						enabled: true,
+						prompt: 'follow up',
+						source_session: 'agent-a',
+					},
+				],
+			});
+			mockLoadCueConfig.mockReturnValue(config);
+			const deps = createMockDeps();
+			const engine = new CueEngine(deps);
+			engine.start();
+
+			vi.clearAllMocks();
+			engine.notifyAgentCompleted('agent-a', {
+				sessionName: 'Agent A',
+				stdout: 'own',
+				forwardedOutputs: { 'Agent X': 'x-output' },
+			});
+
+			const request = (deps.onCueRun as ReturnType<typeof vi.fn>).mock.calls[0][0];
+			const event = request.event as CueEvent;
+			expect(event.payload.forwardedOutputs).toEqual({ 'Agent X': 'x-output' });
+			engine.stop();
+		});
+
+		it('filters upstream-forwarded data by forward_output_from when set', () => {
+			const config = createMockConfig({
+				subscriptions: [
+					{
+						name: 'on-done',
+						event: 'agent.completed',
+						enabled: true,
+						prompt: 'follow up',
+						source_session: 'agent-a',
+						forward_output_from: ['Agent X'],
+					},
+				],
+			});
+			mockLoadCueConfig.mockReturnValue(config);
+			const deps = createMockDeps();
+			const engine = new CueEngine(deps);
+			engine.start();
+
+			vi.clearAllMocks();
+			engine.notifyAgentCompleted('agent-a', {
+				sessionName: 'Agent A',
+				stdout: 'own',
+				forwardedOutputs: { 'Agent X': 'x-output', 'Agent Y': 'y-output' },
+			});
+
+			const request = (deps.onCueRun as ReturnType<typeof vi.fn>).mock.calls[0][0];
+			const event = request.event as CueEvent;
+			expect(event.payload.forwardedOutputs).toEqual({ 'Agent X': 'x-output' });
+			engine.stop();
+		});
+	});
 });

--- a/src/__tests__/main/cue/cue-concurrency.test.ts
+++ b/src/__tests__/main/cue/cue-concurrency.test.ts
@@ -365,7 +365,8 @@ describe('CueEngine Concurrency Control', () => {
 
 			expect(deps.onLog).toHaveBeenCalledWith(
 				'cue',
-				expect.stringContaining('Dropping stale queued event')
+				expect.stringContaining('Dropping stale queued event'),
+				expect.objectContaining({ type: 'runFinished', status: 'timeout' })
 			);
 
 			engine.stopAll();
@@ -861,7 +862,8 @@ describe('CueEngine Concurrency Control', () => {
 			// All stale events should have been dropped
 			expect(deps.onLog).toHaveBeenCalledWith(
 				'cue',
-				expect.stringContaining('Dropping stale queued event')
+				expect.stringContaining('Dropping stale queued event'),
+				expect.objectContaining({ type: 'runFinished', status: 'timeout' })
 			);
 
 			engine.stopAll();

--- a/src/__tests__/main/cue/cue-engine.test.ts
+++ b/src/__tests__/main/cue/cue-engine.test.ts
@@ -140,8 +140,12 @@ describe('CueEngine', () => {
 			engine.start();
 			engine.stop();
 
-			expect(deps.onLog).toHaveBeenCalledWith('cue', expect.stringContaining('started'));
-			expect(deps.onLog).toHaveBeenCalledWith('cue', expect.stringContaining('stopped'));
+			expect(deps.onLog).toHaveBeenCalledWith('cue', expect.stringContaining('started'), {
+				type: 'engineStarted',
+			});
+			expect(deps.onLog).toHaveBeenCalledWith('cue', expect.stringContaining('stopped'), {
+				type: 'engineStopped',
+			});
 		});
 
 		it('does not enable when initCueDb throws', () => {

--- a/src/__tests__/main/cue/cue-ipc-handlers.test.ts
+++ b/src/__tests__/main/cue/cue-ipc-handlers.test.ts
@@ -330,6 +330,103 @@ describe('Cue IPC Handlers', () => {
 				'prompt body 2'
 			);
 		});
+
+		// Security-hardening tests: reject malformed prompt-file keys that
+		// could write outside the .maestro/prompts/ directory. The handler
+		// validates and throws synchronously from inside the async callback —
+		// vi.mock's `withIpcErrorLogging` preserves the rejection.
+		describe('prompt-file path hardening', () => {
+			it('rejects empty string keys', async () => {
+				const handler = registerAndGetHandler('cue:writeYaml');
+				await expect(
+					handler(null, {
+						projectRoot: '/projects/test',
+						content: 'subscriptions: []',
+						promptFiles: { '': 'x' },
+					})
+				).rejects.toThrow(/must be a non-empty string/);
+				expect(writeCuePromptFile).not.toHaveBeenCalled();
+			});
+
+			it('rejects absolute paths', async () => {
+				const handler = registerAndGetHandler('cue:writeYaml');
+				await expect(
+					handler(null, {
+						projectRoot: '/projects/test',
+						content: 'subscriptions: []',
+						promptFiles: { '/etc/passwd.md': 'x' },
+					})
+				).rejects.toThrow(/must be a relative path/);
+				expect(writeCuePromptFile).not.toHaveBeenCalled();
+			});
+
+			it('rejects paths with parent-directory segments', async () => {
+				const handler = registerAndGetHandler('cue:writeYaml');
+				await expect(
+					handler(null, {
+						projectRoot: '/projects/test',
+						content: 'subscriptions: []',
+						promptFiles: { '../../escape.md': 'x' },
+					})
+				).rejects.toThrow(/parent-directory segment/);
+				expect(writeCuePromptFile).not.toHaveBeenCalled();
+			});
+
+			it('rejects paths that resolve outside .maestro/prompts/', async () => {
+				const handler = registerAndGetHandler('cue:writeYaml');
+				await expect(
+					handler(null, {
+						projectRoot: '/projects/test',
+						content: 'subscriptions: []',
+						promptFiles: { 'not-prompts/file.md': 'x' },
+					})
+				).rejects.toThrow(/resolves outside the .maestro\/prompts directory/);
+				expect(writeCuePromptFile).not.toHaveBeenCalled();
+			});
+
+			it('rejects paths with mixed-in parent segments that pre-normalize to a valid location', async () => {
+				// 'prompts/../../escape.md' — .split('/') catches the '..'
+				// segment before path.resolve normalizes it away.
+				const handler = registerAndGetHandler('cue:writeYaml');
+				await expect(
+					handler(null, {
+						projectRoot: '/projects/test',
+						content: 'subscriptions: []',
+						promptFiles: { '.maestro/prompts/../../escape.md': 'x' },
+					})
+				).rejects.toThrow(/parent-directory segment/);
+			});
+
+			it('rejects non-.md extensions', async () => {
+				const handler = registerAndGetHandler('cue:writeYaml');
+				await expect(
+					handler(null, {
+						projectRoot: '/projects/test',
+						content: 'subscriptions: []',
+						promptFiles: { '.maestro/prompts/payload.sh': 'x' },
+					})
+				).rejects.toThrow(/must end with .md/);
+				expect(writeCuePromptFile).not.toHaveBeenCalled();
+			});
+
+			it('normalizes Windows backslash paths to forward-slash before writing', async () => {
+				// Only meaningful on non-Windows, where path.sep is '/'. Windows
+				// already accepts both separators via path.resolve.
+				if (process.platform === 'win32') return;
+				const handler = registerAndGetHandler('cue:writeYaml');
+				await handler(null, {
+					projectRoot: '/projects/test',
+					content: 'subscriptions: []',
+					promptFiles: { '.maestro\\prompts\\sub.md': 'body' },
+				});
+				// Normalized separator is stored as the written-file key.
+				expect(writeCuePromptFile).toHaveBeenCalledWith(
+					'/projects/test',
+					'.maestro/prompts/sub.md',
+					'body'
+				);
+			});
+		});
 	});
 
 	describe('cue:deleteYaml', () => {

--- a/src/__tests__/main/cue/cue-ipc-handlers.test.ts
+++ b/src/__tests__/main/cue/cue-ipc-handlers.test.ts
@@ -335,6 +335,11 @@ describe('Cue IPC Handlers', () => {
 		// could write outside the .maestro/prompts/ directory. The handler
 		// validates and throws synchronously from inside the async callback —
 		// vi.mock's `withIpcErrorLogging` preserves the rejection.
+		//
+		// Every negative case must also assert that writeCueConfigFile was
+		// NOT called — rejecting the promptFile loop must abort the whole
+		// save, otherwise the YAML would land on disk while referencing a
+		// prompt file that was never written.
 		describe('prompt-file path hardening', () => {
 			it('rejects empty string keys', async () => {
 				const handler = registerAndGetHandler('cue:writeYaml');
@@ -346,6 +351,7 @@ describe('Cue IPC Handlers', () => {
 					})
 				).rejects.toThrow(/must be a non-empty string/);
 				expect(writeCuePromptFile).not.toHaveBeenCalled();
+				expect(writeCueConfigFile).not.toHaveBeenCalled();
 			});
 
 			it('rejects absolute paths', async () => {
@@ -358,6 +364,7 @@ describe('Cue IPC Handlers', () => {
 					})
 				).rejects.toThrow(/must be a relative path/);
 				expect(writeCuePromptFile).not.toHaveBeenCalled();
+				expect(writeCueConfigFile).not.toHaveBeenCalled();
 			});
 
 			it('rejects paths with parent-directory segments', async () => {
@@ -368,8 +375,22 @@ describe('Cue IPC Handlers', () => {
 						content: 'subscriptions: []',
 						promptFiles: { '../../escape.md': 'x' },
 					})
-				).rejects.toThrow(/parent-directory segment/);
+				).rejects.toThrow(/"\." or "\.\." segment/);
 				expect(writeCuePromptFile).not.toHaveBeenCalled();
+				expect(writeCueConfigFile).not.toHaveBeenCalled();
+			});
+
+			it('rejects paths with single-dot segments', async () => {
+				const handler = registerAndGetHandler('cue:writeYaml');
+				await expect(
+					handler(null, {
+						projectRoot: '/projects/test',
+						content: 'subscriptions: []',
+						promptFiles: { '.maestro/prompts/./sub.md': 'x' },
+					})
+				).rejects.toThrow(/"\." or "\.\." segment/);
+				expect(writeCuePromptFile).not.toHaveBeenCalled();
+				expect(writeCueConfigFile).not.toHaveBeenCalled();
 			});
 
 			it('rejects paths that resolve outside .maestro/prompts/', async () => {
@@ -382,6 +403,7 @@ describe('Cue IPC Handlers', () => {
 					})
 				).rejects.toThrow(/resolves outside the .maestro\/prompts directory/);
 				expect(writeCuePromptFile).not.toHaveBeenCalled();
+				expect(writeCueConfigFile).not.toHaveBeenCalled();
 			});
 
 			it('rejects paths with mixed-in parent segments that pre-normalize to a valid location', async () => {
@@ -394,7 +416,9 @@ describe('Cue IPC Handlers', () => {
 						content: 'subscriptions: []',
 						promptFiles: { '.maestro/prompts/../../escape.md': 'x' },
 					})
-				).rejects.toThrow(/parent-directory segment/);
+				).rejects.toThrow(/"\." or "\.\." segment/);
+				expect(writeCuePromptFile).not.toHaveBeenCalled();
+				expect(writeCueConfigFile).not.toHaveBeenCalled();
 			});
 
 			it('rejects non-.md extensions', async () => {
@@ -407,6 +431,7 @@ describe('Cue IPC Handlers', () => {
 					})
 				).rejects.toThrow(/must end with .md/);
 				expect(writeCuePromptFile).not.toHaveBeenCalled();
+				expect(writeCueConfigFile).not.toHaveBeenCalled();
 			});
 
 			it('normalizes Windows backslash paths to forward-slash before writing', async () => {

--- a/src/__tests__/main/cue/cue-output-filter.test.ts
+++ b/src/__tests__/main/cue/cue-output-filter.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Unit tests for the shared output filter used by both the fan-in tracker and
+ * the single-source completion path. These tests are the contract for
+ * `include_output_from` / `forward_output_from` filtering semantics.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+	buildFilteredOutputs,
+	mergeUpstreamForwarded,
+	type FanInSourceCompletion,
+} from '../../../main/cue/cue-output-filter';
+import type { CueSubscription } from '../../../main/cue/cue-types';
+
+function makeSub(overrides: Partial<CueSubscription> = {}): CueSubscription {
+	return {
+		name: 'sub',
+		event: 'agent.completed',
+		enabled: true,
+		prompt: 'process it',
+		...overrides,
+	};
+}
+
+function makeCompletion(overrides: Partial<FanInSourceCompletion> = {}): FanInSourceCompletion {
+	return {
+		sessionId: 'id-a',
+		sessionName: 'Agent A',
+		output: 'a-output',
+		truncated: false,
+		chainDepth: 0,
+		...overrides,
+	};
+}
+
+describe('buildFilteredOutputs', () => {
+	describe('default (no filters)', () => {
+		it('includes every completion when include_output_from is unset', () => {
+			const completions = [makeCompletion()];
+			const { outputCompletions, perSourceOutputs, forwardedOutputs } = buildFilteredOutputs(
+				completions,
+				makeSub()
+			);
+			expect(outputCompletions).toEqual(completions);
+			expect(perSourceOutputs).toEqual({ 'Agent A': 'a-output' });
+			expect(forwardedOutputs).toEqual({});
+		});
+
+		it('forwards nothing when forward_output_from is unset', () => {
+			const completions = [makeCompletion()];
+			const { forwardedOutputs } = buildFilteredOutputs(completions, makeSub());
+			expect(forwardedOutputs).toEqual({});
+		});
+	});
+
+	describe('include_output_from', () => {
+		it('includes only listed sources (by sessionName)', () => {
+			const completions = [
+				makeCompletion({ sessionId: 'id-a', sessionName: 'Agent A', output: 'a' }),
+				makeCompletion({ sessionId: 'id-b', sessionName: 'Agent B', output: 'b' }),
+			];
+			const { outputCompletions, perSourceOutputs } = buildFilteredOutputs(
+				completions,
+				makeSub({ include_output_from: ['Agent A'] })
+			);
+			expect(outputCompletions.map((c) => c.sessionName)).toEqual(['Agent A']);
+			expect(perSourceOutputs).toEqual({ 'Agent A': 'a' });
+		});
+
+		it('includes listed sources by sessionId as well', () => {
+			const completions = [
+				makeCompletion({ sessionId: 'id-a', sessionName: 'Agent A', output: 'a' }),
+				makeCompletion({ sessionId: 'id-b', sessionName: 'Agent B', output: 'b' }),
+			];
+			const { perSourceOutputs } = buildFilteredOutputs(
+				completions,
+				makeSub({ include_output_from: ['id-b'] })
+			);
+			expect(perSourceOutputs).toEqual({ 'Agent B': 'b' });
+		});
+
+		it('returns empty maps when include_output_from is an empty array', () => {
+			const completions = [makeCompletion()];
+			const { outputCompletions, perSourceOutputs } = buildFilteredOutputs(
+				completions,
+				makeSub({ include_output_from: [] })
+			);
+			expect(outputCompletions).toEqual([]);
+			expect(perSourceOutputs).toEqual({});
+		});
+	});
+
+	describe('forward_output_from', () => {
+		it('forwards only listed sources', () => {
+			const completions = [
+				makeCompletion({ sessionName: 'Agent A', output: 'a' }),
+				makeCompletion({ sessionId: 'id-b', sessionName: 'Agent B', output: 'b' }),
+			];
+			const { forwardedOutputs } = buildFilteredOutputs(
+				completions,
+				makeSub({ forward_output_from: ['Agent A'] })
+			);
+			expect(forwardedOutputs).toEqual({ 'Agent A': 'a' });
+		});
+
+		it('is independent of include_output_from (forward-only source is excluded from prompt)', () => {
+			const completions = [
+				makeCompletion({ sessionName: 'Agent A', output: 'a' }),
+				makeCompletion({ sessionId: 'id-b', sessionName: 'Agent B', output: 'b' }),
+			];
+			const { perSourceOutputs, forwardedOutputs } = buildFilteredOutputs(
+				completions,
+				makeSub({
+					include_output_from: ['Agent A'],
+					forward_output_from: ['Agent B'],
+				})
+			);
+			expect(perSourceOutputs).toEqual({ 'Agent A': 'a' });
+			expect(forwardedOutputs).toEqual({ 'Agent B': 'b' });
+		});
+	});
+});
+
+describe('mergeUpstreamForwarded', () => {
+	it('returns the original map when upstream is undefined', () => {
+		const base = { 'Agent A': 'a' };
+		expect(mergeUpstreamForwarded(base, undefined, makeSub())).toEqual(base);
+	});
+
+	it('passes all upstream keys through when forward_output_from is unset', () => {
+		const merged = mergeUpstreamForwarded({}, { 'Agent X': 'x', 'Agent Y': 'y' }, makeSub());
+		expect(merged).toEqual({ 'Agent X': 'x', 'Agent Y': 'y' });
+	});
+
+	it('filters upstream keys by forward_output_from when set', () => {
+		const merged = mergeUpstreamForwarded(
+			{},
+			{ 'Agent X': 'x', 'Agent Y': 'y' },
+			makeSub({ forward_output_from: ['Agent X'] })
+		);
+		expect(merged).toEqual({ 'Agent X': 'x' });
+	});
+
+	it('preserves base entries when merging', () => {
+		const merged = mergeUpstreamForwarded(
+			{ 'Agent A': 'a' },
+			{ 'Agent X': 'x' },
+			makeSub({ forward_output_from: ['Agent A', 'Agent X'] })
+		);
+		expect(merged).toEqual({ 'Agent A': 'a', 'Agent X': 'x' });
+	});
+});

--- a/src/__tests__/main/cue/cue-run-manager.test.ts
+++ b/src/__tests__/main/cue/cue-run-manager.test.ts
@@ -585,6 +585,60 @@ describe('createCueRunManager', () => {
 			// onRunCompleted should NOT be called
 			expect(deps.onRunCompleted).not.toHaveBeenCalled();
 		});
+
+		it('reset during output-prompt phase: finalizes parent run status', async () => {
+			// Regression gate for the output-prompt analog of the
+			// engine-stopped-mid-run bug: if reset() fires AFTER the main
+			// task completed and DURING the output-prompt call, the outer
+			// finally's cleanup is bypassed (activeRuns no longer has the
+			// runId), so without the explicit finalize the PARENT runId DB
+			// row stays at `running` forever. Mirrors the earlier guard for
+			// the pre-output-prompt case.
+			let onCueRunCallCount = 0;
+			let resolveOutputRun: ((val: CueRunResult) => void) | undefined;
+			const deps = createDeps({
+				onCueRun: vi.fn(() => {
+					onCueRunCallCount++;
+					if (onCueRunCallCount === 1) {
+						return Promise.resolve(makeResult({ status: 'completed' }));
+					}
+					return new Promise<CueRunResult>((resolve) => {
+						resolveOutputRun = resolve;
+					});
+				}),
+			});
+			const manager = createCueRunManager(deps);
+
+			manager.execute('session-1', 'prompt', createEvent(), 'test-sub', 'output prompt');
+			await vi.advanceTimersByTimeAsync(0);
+
+			// Main task finished, output prompt is pending. Reset the engine
+			// — this clears activeRuns before the output prompt resolves.
+			manager.reset();
+
+			// Output prompt now completes after reset. The inner finally
+			// writes the output-prompt row; the new guard must also write
+			// the PARENT row so the activity log doesn't strand it.
+			vi.mocked(safeUpdateCueEventStatus).mockClear();
+			resolveOutputRun!(makeResult({ status: 'completed' }));
+			await vi.advanceTimersByTimeAsync(0);
+
+			// Expect TWO finalization calls: one for the output run (in the
+			// inner finally — technically via updateCueEventStatus, not the
+			// safe variant, so it won't show here) and one for the PARENT
+			// via safeUpdateCueEventStatus with the main task's status.
+			// Only the parent-side safe call is asserted because that's the
+			// regression we're guarding.
+			expect(safeUpdateCueEventStatus).toHaveBeenCalledWith(expect.any(String), 'completed');
+			// And the post-stop log MUST include the structured runFinished
+			// payload so renderer listeners observe the transition.
+			expect(deps.onLog).toHaveBeenCalledWith(
+				'cue',
+				expect.stringContaining('output phase completed after engine stop'),
+				expect.objectContaining({ type: 'runFinished', status: 'completed' })
+			);
+			expect(deps.onRunCompleted).not.toHaveBeenCalled();
+		});
 	});
 
 	describe('output prompt', () => {

--- a/src/__tests__/main/cue/cue-run-manager.test.ts
+++ b/src/__tests__/main/cue/cue-run-manager.test.ts
@@ -46,7 +46,7 @@ vi.mock('crypto', () => ({
 	randomUUID: vi.fn(() => `run-${++uuidCounter}`),
 }));
 
-import { updateCueEventStatus } from '../../../main/cue/cue-db';
+import { updateCueEventStatus, safeUpdateCueEventStatus } from '../../../main/cue/cue-db';
 import {
 	createCueRunManager,
 	type CueRunManagerDeps,
@@ -461,6 +461,62 @@ describe('createCueRunManager', () => {
 
 			// onRunCompleted should NOT be called — the engine was shut down
 			expect(deps.onRunCompleted).not.toHaveBeenCalled();
+		});
+
+		it('reset during active run: finalizes DB status when onCueRun resolves after stop', async () => {
+			// Regression test for the activity-log-loss bug: without the fix,
+			// a run completing after engine.stop()/reset() would leave its DB
+			// row stuck at `running` because both onRunCompleted AND
+			// updateCueEventStatus were skipped.
+			let resolveRun: ((val: CueRunResult) => void) | undefined;
+			const deps = createDeps({
+				onCueRun: vi.fn(
+					() =>
+						new Promise<CueRunResult>((resolve) => {
+							resolveRun = resolve;
+						})
+				),
+			});
+			const manager = createCueRunManager(deps);
+
+			manager.execute('session-1', 'prompt', createEvent(), 'test-sub');
+			manager.reset();
+
+			resolveRun!(makeResult({ status: 'completed', stdout: 'hi' }));
+			await vi.advanceTimersByTimeAsync(0);
+
+			// DB status MUST be updated to the final result state so the
+			// activity log doesn't show a phantom never-ending run.
+			expect(safeUpdateCueEventStatus).toHaveBeenCalledWith(expect.any(String), 'completed');
+			// And a log should explain the run was recorded post-stop so
+			// operators can tell this apart from a normal completion.
+			expect(deps.onLog).toHaveBeenCalledWith(
+				'cue',
+				expect.stringContaining('completed after engine stop')
+			);
+		});
+
+		it('reset during active run: preserves failed status when onCueRun resolves with failure after stop', async () => {
+			// Variant of the above covering the failure path — make sure the
+			// final status propagates to the DB regardless of outcome.
+			let resolveRun: ((val: CueRunResult) => void) | undefined;
+			const deps = createDeps({
+				onCueRun: vi.fn(
+					() =>
+						new Promise<CueRunResult>((resolve) => {
+							resolveRun = resolve;
+						})
+				),
+			});
+			const manager = createCueRunManager(deps);
+
+			manager.execute('session-1', 'prompt', createEvent(), 'test-sub');
+			manager.reset();
+
+			resolveRun!(makeResult({ status: 'failed', stderr: 'boom' }));
+			await vi.advanceTimersByTimeAsync(0);
+
+			expect(safeUpdateCueEventStatus).toHaveBeenCalledWith(expect.any(String), 'failed');
 		});
 
 		it('stopAll followed by reset: no spurious onRunCompleted', async () => {

--- a/src/__tests__/main/cue/cue-run-manager.test.ts
+++ b/src/__tests__/main/cue/cue-run-manager.test.ts
@@ -488,11 +488,13 @@ describe('createCueRunManager', () => {
 			// DB status MUST be updated to the final result state so the
 			// activity log doesn't show a phantom never-ending run.
 			expect(safeUpdateCueEventStatus).toHaveBeenCalledWith(expect.any(String), 'completed');
-			// And a log should explain the run was recorded post-stop so
-			// operators can tell this apart from a normal completion.
+			// And a log should explain the run was recorded post-stop AND
+			// include the structured runFinished payload so the renderer
+			// observes the transition identically to a normal completion.
 			expect(deps.onLog).toHaveBeenCalledWith(
 				'cue',
-				expect.stringContaining('completed after engine stop')
+				expect.stringContaining('completed after engine stop'),
+				expect.objectContaining({ type: 'runFinished', status: 'completed' })
 			);
 		});
 

--- a/src/__tests__/main/cue/cue-text-utils.test.ts
+++ b/src/__tests__/main/cue/cue-text-utils.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Tests for UTF-8-safe slicing helpers used throughout the Cue engine to
+ * avoid splitting surrogate pairs when truncating subscription outputs.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { sliceHeadByChars, sliceTailByChars } from '../../../main/cue/cue-text-utils';
+
+// A supplementary-plane code point (U+1F600 😀) encodes as the surrogate pair
+// D83D DE00 — two UTF-16 code units. A naive `.slice()` that lands between
+// them produces a lone surrogate that downstream consumers see as garbage.
+const EMOJI = '😀'; // 2 code units
+const TREE = '🌳'; // 2 code units
+const HEART = '❤'; // 1 code unit
+
+describe('sliceTailByChars', () => {
+	it('returns the full string when shorter than max', () => {
+		expect(sliceTailByChars('hello', 10)).toBe('hello');
+	});
+
+	it('returns the full string when exactly equal to max', () => {
+		expect(sliceTailByChars('hello', 5)).toBe('hello');
+	});
+
+	it('returns empty string for maxChars <= 0', () => {
+		expect(sliceTailByChars('hello', 0)).toBe('');
+		expect(sliceTailByChars('hello', -1)).toBe('');
+	});
+
+	it('returns empty string for empty input', () => {
+		expect(sliceTailByChars('', 5)).toBe('');
+	});
+
+	it('returns the last N ASCII chars when plain text', () => {
+		expect(sliceTailByChars('abcdefghij', 3)).toBe('hij');
+	});
+
+	it('does not split a surrogate pair at the start of the slice', () => {
+		// "ab" + "😀" → len 4 (a=1, b=1, 😀=2). slice(-3) would start at index 1,
+		// landing on the b; slice(-2) lands on the high surrogate of 😀; slice(-1)
+		// lands on the low surrogate and must shift forward to return just "".
+		const input = 'ab' + EMOJI;
+		const low = sliceTailByChars(input, 1);
+		// The tail was a lone low surrogate; helper must strip it rather than
+		// emit a broken half-emoji.
+		expect(low).not.toMatch(/[\uDC00-\uDFFF]/);
+	});
+
+	it('includes the full emoji when the slice boundary lands exactly on the high surrogate', () => {
+		// slice(-2) on "ab😀" lands on 😀's high surrogate — the whole emoji
+		// fits, so the helper should return it intact.
+		const input = 'ab' + EMOJI;
+		expect(sliceTailByChars(input, 2)).toBe(EMOJI);
+	});
+
+	it('preserves adjacent emojis when they both fit', () => {
+		const input = 'xx' + EMOJI + TREE; // 2 + 2 + 2 = 6 units
+		expect(sliceTailByChars(input, 4)).toBe(EMOJI + TREE);
+	});
+
+	it('handles BMP characters (single code units) unchanged', () => {
+		const input = 'x' + HEART + 'y'; // each is 1 unit
+		expect(sliceTailByChars(input, 2)).toBe(HEART + 'y');
+	});
+
+	it('handles a string of only emoji', () => {
+		const input = EMOJI + EMOJI + EMOJI;
+		const result = sliceTailByChars(input, 3);
+		// Must not start with a lone low surrogate
+		expect(result).not.toMatch(/^[\uDC00-\uDFFF]/);
+	});
+});
+
+describe('sliceHeadByChars', () => {
+	it('returns the full string when shorter than max', () => {
+		expect(sliceHeadByChars('hello', 10)).toBe('hello');
+	});
+
+	it('returns empty string for maxChars <= 0', () => {
+		expect(sliceHeadByChars('hello', 0)).toBe('');
+		expect(sliceHeadByChars('hello', -1)).toBe('');
+	});
+
+	it('returns empty string for empty input', () => {
+		expect(sliceHeadByChars('', 5)).toBe('');
+	});
+
+	it('returns the first N ASCII chars', () => {
+		expect(sliceHeadByChars('abcdefghij', 3)).toBe('abc');
+	});
+
+	it('does not split a surrogate pair at the end of the slice', () => {
+		// "a" + "😀" + "b" → boundaries at 1,3,4. slice(0,2) lands between the
+		// high and low surrogates — helper must step back to "a".
+		const input = 'a' + EMOJI + 'b';
+		const result = sliceHeadByChars(input, 2);
+		expect(result).toBe('a');
+		expect(result).not.toMatch(/[\uD800-\uDBFF]$/);
+	});
+
+	it('includes the full emoji when it just fits', () => {
+		const input = 'a' + EMOJI + 'b';
+		expect(sliceHeadByChars(input, 3)).toBe('a' + EMOJI);
+	});
+
+	it('handles a string of only emoji', () => {
+		const input = EMOJI + EMOJI + EMOJI;
+		const result = sliceHeadByChars(input, 3);
+		// Must not end with a lone high surrogate
+		expect(result).not.toMatch(/[\uD800-\uDBFF]$/);
+	});
+
+	it('handles BMP characters (single code units) unchanged', () => {
+		const input = HEART + HEART + HEART;
+		expect(sliceHeadByChars(input, 2)).toBe(HEART + HEART);
+	});
+});

--- a/src/__tests__/main/cue/cue-yaml-error-paths.test.ts
+++ b/src/__tests__/main/cue/cue-yaml-error-paths.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Error-path coverage for Cue YAML and recovery-service logic.
+ *
+ * These test the hardening added in this release: negative sleep-gap
+ * detection, torn-flag protection on the YAML watcher, and pruner
+ * resilience to unreadable directories. Missing YAML is tolerated; corrupt
+ * YAML is surfaced as a validation error rather than crashing the engine.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+vi.mock('../../../main/utils/sentry', () => ({
+	captureException: vi.fn(),
+}));
+
+import {
+	pruneOrphanedPromptFiles,
+	readCueConfigFile,
+	watchCueConfigFile,
+} from '../../../main/cue/config/cue-config-repository';
+import { validateCueConfig } from '../../../main/cue/cue-yaml-loader';
+
+let projectRoot = '';
+
+beforeEach(() => {
+	projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'cue-errors-'));
+});
+
+afterEach(() => {
+	if (projectRoot && fs.existsSync(projectRoot)) {
+		fs.rmSync(projectRoot, { recursive: true, force: true });
+	}
+});
+
+describe('malformed YAML handling', () => {
+	it('validateCueConfig flags a non-object root', () => {
+		const result = validateCueConfig('plain string') as { valid: boolean; errors: string[] };
+		expect(result.valid).toBe(false);
+		expect(result.errors.length).toBeGreaterThan(0);
+	});
+
+	it('validateCueConfig flags a missing subscriptions array', () => {
+		const result = validateCueConfig({ settings: {} }) as { valid: boolean; errors: string[] };
+		expect(result.valid).toBe(false);
+	});
+
+	it('validateCueConfig accepts a minimal valid config', () => {
+		const result = validateCueConfig({ subscriptions: [] }) as {
+			valid: boolean;
+			errors: string[];
+		};
+		expect(result.valid).toBe(true);
+		expect(result.errors).toEqual([]);
+	});
+});
+
+describe('missing-file tolerance', () => {
+	it('readCueConfigFile returns null for a missing file (no throw)', () => {
+		expect(readCueConfigFile(projectRoot)).toBeNull();
+	});
+
+	it('pruneOrphanedPromptFiles returns empty array when prompts dir does not exist', () => {
+		expect(pruneOrphanedPromptFiles(projectRoot, [])).toEqual([]);
+	});
+});
+
+describe('watchCueConfigFile torn-flag guard', () => {
+	it('cleanup stops further onChange invocations even if debounce would fire', async () => {
+		// Regression: the hardening added a `torn` flag so that any debounced
+		// callback scheduled just before cleanup can't fire after the watcher
+		// is closed. Without this, a session teardown overlapping with a file
+		// change could re-trigger refreshSession on a session that no longer
+		// exists.
+		const onChange = vi.fn();
+		const cleanup = watchCueConfigFile(projectRoot, onChange);
+
+		// No change events fired — cleanup immediately.
+		cleanup();
+
+		// Wait beyond the 1s debounce window — nothing should fire.
+		await new Promise((resolve) => setTimeout(resolve, 1100));
+		expect(onChange).not.toHaveBeenCalled();
+	});
+
+	it('cleanup is idempotent', () => {
+		const onChange = vi.fn();
+		const cleanup = watchCueConfigFile(projectRoot, onChange);
+		cleanup();
+		// Calling cleanup twice should not throw even though chokidar.close()
+		// has already run.
+		expect(() => cleanup()).not.toThrow();
+	});
+});
+
+describe('recovery-service negative-gap guard', () => {
+	// Exercised via the CueRecoveryService directly to lock in the clock-
+	// moved-backward handling added in this release.
+	let mockGetLastHeartbeat: ReturnType<typeof vi.fn>;
+	let mockRecordHeartbeat: ReturnType<typeof vi.fn>;
+	let originalDateNow: typeof Date.now;
+
+	beforeEach(() => {
+		mockGetLastHeartbeat = vi.fn();
+		mockRecordHeartbeat = vi.fn();
+		originalDateNow = Date.now;
+	});
+
+	afterEach(() => {
+		Date.now = originalDateNow;
+		vi.resetModules();
+	});
+
+	it('skips reconciliation and logs when the heartbeat is in the future', async () => {
+		// Simulate system clock set backward: lastHeartbeat is after "now".
+		vi.resetModules();
+		vi.doMock('../../../main/cue/cue-db', () => ({
+			initCueDb: () => ({ ok: true }),
+			getLastHeartbeat: mockGetLastHeartbeat,
+			recordHeartbeat: mockRecordHeartbeat,
+			getCueEventsBySession: () => [],
+			closeCueDb: () => {},
+		}));
+
+		const { createCueRecoveryService } = await import('../../../main/cue/cue-recovery-service');
+
+		const onLog = vi.fn();
+		const service = createCueRecoveryService({
+			enabled: () => true,
+			getSessions: () => new Map(),
+			onLog,
+			reconcileSession: vi.fn(),
+		});
+
+		// Init to open the DB path.
+		service.init();
+
+		// Heartbeat is 10 seconds in the future — gapMs will be negative.
+		Date.now = vi.fn(() => 1000);
+		mockGetLastHeartbeat.mockReturnValue(11000);
+
+		service.detectSleepAndReconcile();
+
+		expect(onLog).toHaveBeenCalledWith('cue', expect.stringContaining('Clock moved backward'));
+	});
+});

--- a/src/__tests__/main/cue/cue-yaml-error-paths.test.ts
+++ b/src/__tests__/main/cue/cue-yaml-error-paths.test.ts
@@ -132,16 +132,16 @@ describe('recovery-service negative-gap guard', () => {
 	// moved-backward handling added in this release.
 	let mockGetLastHeartbeat: ReturnType<typeof vi.fn>;
 	let mockRecordHeartbeat: ReturnType<typeof vi.fn>;
-	let originalDateNow: typeof Date.now;
 
 	beforeEach(() => {
 		mockGetLastHeartbeat = vi.fn();
 		mockRecordHeartbeat = vi.fn();
-		originalDateNow = Date.now;
 	});
 
 	afterEach(() => {
-		Date.now = originalDateNow;
+		// vi.restoreAllMocks undoes vi.spyOn(Date, 'now') below (and any other
+		// spies), removing the need for manual save/restore bookkeeping.
+		vi.restoreAllMocks();
 		vi.resetModules();
 	});
 
@@ -154,27 +154,34 @@ describe('recovery-service negative-gap guard', () => {
 			recordHeartbeat: mockRecordHeartbeat,
 			getCueEventsBySession: () => [],
 			closeCueDb: () => {},
+			pruneCueEvents: vi.fn(),
 		}));
 
 		const { createCueRecoveryService } = await import('../../../main/cue/cue-recovery-service');
 
 		const onLog = vi.fn();
+		const reconcileSession = vi.fn();
 		const service = createCueRecoveryService({
 			enabled: () => true,
 			getSessions: () => new Map(),
 			onLog,
-			reconcileSession: vi.fn(),
+			reconcileSession,
 		});
 
-		// Init to open the DB path.
+		// Init opens the DB (mocked as a no-op here).
 		service.init();
 
 		// Heartbeat is 10 seconds in the future — gapMs will be negative.
-		Date.now = vi.fn(() => 1000);
+		vi.spyOn(Date, 'now').mockReturnValue(1000);
 		mockGetLastHeartbeat.mockReturnValue(11000);
 
 		service.detectSleepAndReconcile();
 
 		expect(onLog).toHaveBeenCalledWith('cue', expect.stringContaining('Clock moved backward'));
+		// Regression gate: a future version that logged the warning but
+		// ALSO ran reconciliation (or rewrote the heartbeat) would defeat
+		// the whole point of the guard. Pin both side-effects off.
+		expect(reconcileSession).not.toHaveBeenCalled();
+		expect(mockRecordHeartbeat).not.toHaveBeenCalled();
 	});
 });

--- a/src/__tests__/main/cue/cue-yaml-error-paths.test.ts
+++ b/src/__tests__/main/cue/cue-yaml-error-paths.test.ts
@@ -77,11 +77,22 @@ describe('watchCueConfigFile torn-flag guard', () => {
 		const onChange = vi.fn();
 		const cleanup = watchCueConfigFile(projectRoot, onChange);
 
-		// No change events fired — cleanup immediately.
+		// Give chokidar a moment to register the watcher paths.
+		await new Promise((resolve) => setTimeout(resolve, 50));
+
+		// Trigger a real change so the debounced callback is scheduled — this
+		// exercises the path the torn flag actually protects. Writing the
+		// canonical .maestro/cue.yaml is exactly what the session runtime does.
+		const maestroDir = path.join(projectRoot, '.maestro');
+		fs.mkdirSync(maestroDir, { recursive: true });
+		fs.writeFileSync(path.join(maestroDir, 'cue.yaml'), 'subscriptions: []', 'utf-8');
+
+		// Cleanup IMMEDIATELY — the debounced setTimeout is already scheduled
+		// (or about to be). The torn flag must reject it when it fires.
 		cleanup();
 
 		// Wait beyond the 1s debounce window — nothing should fire.
-		await new Promise((resolve) => setTimeout(resolve, 1100));
+		await new Promise((resolve) => setTimeout(resolve, 1200));
 		expect(onChange).not.toHaveBeenCalled();
 	});
 

--- a/src/__tests__/main/cue/cue-yaml-error-paths.test.ts
+++ b/src/__tests__/main/cue/cue-yaml-error-paths.test.ts
@@ -75,10 +75,14 @@ describe('watchCueConfigFile torn-flag guard', () => {
 		// change could re-trigger refreshSession on a session that no longer
 		// exists.
 		const onChange = vi.fn();
-		const cleanup = watchCueConfigFile(projectRoot, onChange);
-
-		// Give chokidar a moment to register the watcher paths.
-		await new Promise((resolve) => setTimeout(resolve, 50));
+		// Deterministic setup: wait for chokidar's 'ready' event via the
+		// opt-in hook instead of sleeping on a timer. The prior 50ms sleep
+		// raced with chokidar's initial scan on slow CI runners and made
+		// this assertion trivially pass when no change event ever fired.
+		let cleanup!: () => void;
+		await new Promise<void>((resolve) => {
+			cleanup = watchCueConfigFile(projectRoot, onChange, { onReady: resolve });
+		});
 
 		// Trigger a real change so the debounced callback is scheduled — this
 		// exercises the path the torn flag actually protects. Writing the
@@ -96,13 +100,30 @@ describe('watchCueConfigFile torn-flag guard', () => {
 		expect(onChange).not.toHaveBeenCalled();
 	});
 
-	it('cleanup is idempotent', () => {
+	it('cleanup is idempotent and does not leak an unhandled rejection', async () => {
 		const onChange = vi.fn();
 		const cleanup = watchCueConfigFile(projectRoot, onChange);
-		cleanup();
-		// Calling cleanup twice should not throw even though chokidar.close()
-		// has already run.
-		expect(() => cleanup()).not.toThrow();
+
+		// chokidar.close() returns a Promise. We don't await it, so any
+		// rejection on a double-close would surface as an unhandled rejection
+		// rather than a synchronous throw — watch for both.
+		const unhandled: unknown[] = [];
+		const onUnhandled = (event: { reason?: unknown } | PromiseRejectionEvent) => {
+			unhandled.push((event as { reason?: unknown }).reason);
+		};
+		process.on('unhandledRejection', onUnhandled);
+
+		try {
+			cleanup();
+			// Second call must not throw synchronously…
+			expect(() => cleanup()).not.toThrow();
+			// …and must not produce an async rejection either. Give the
+			// microtask queue a tick to surface one if it's going to.
+			await new Promise((resolve) => setTimeout(resolve, 50));
+			expect(unhandled).toEqual([]);
+		} finally {
+			process.off('unhandledRejection', onUnhandled);
+		}
 	});
 });
 

--- a/src/__tests__/main/cue/cue-yaml-roundtrip.test.ts
+++ b/src/__tests__/main/cue/cue-yaml-roundtrip.test.ts
@@ -1,0 +1,240 @@
+/**
+ * End-to-end YAML roundtrip tests for cue-config-repository.
+ *
+ * These exercise the file-system layer directly (NO mocks) against a real
+ * temp directory so we catch bugs in path resolution, directory creation,
+ * and orphan pruning that module-level mocks would hide.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+vi.mock('../../../main/utils/sentry', () => ({
+	captureException: vi.fn(),
+}));
+
+import {
+	deleteCueConfigFile,
+	pruneOrphanedPromptFiles,
+	readCueConfigFile,
+	resolveCueConfigPath,
+	writeCueConfigFile,
+	writeCuePromptFile,
+} from '../../../main/cue/config/cue-config-repository';
+
+let projectRoot = '';
+
+beforeEach(() => {
+	projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'cue-roundtrip-'));
+});
+
+afterEach(() => {
+	if (projectRoot && fs.existsSync(projectRoot)) {
+		fs.rmSync(projectRoot, { recursive: true, force: true });
+	}
+});
+
+describe('cue YAML roundtrip', () => {
+	it('write → read returns the exact content with a single trip', () => {
+		const content =
+			'subscriptions:\n  - name: test-sub\n    event: time.heartbeat\n    interval_minutes: 5\n';
+		writeCueConfigFile(projectRoot, content);
+
+		const result = readCueConfigFile(projectRoot);
+		expect(result).not.toBeNull();
+		expect(result!.raw).toBe(content);
+	});
+
+	it('write creates .maestro/ directory if missing', () => {
+		const maestroDir = path.join(projectRoot, '.maestro');
+		expect(fs.existsSync(maestroDir)).toBe(false);
+
+		writeCueConfigFile(projectRoot, 'subscriptions: []');
+
+		expect(fs.existsSync(maestroDir)).toBe(true);
+		expect(fs.existsSync(path.join(maestroDir, 'cue.yaml'))).toBe(true);
+	});
+
+	it('roundtrip preserves UTF-8 characters including emoji and CJK', () => {
+		const content = 'subscriptions:\n  - name: "テスト 🎌 中文"\n    event: time.heartbeat\n';
+		writeCueConfigFile(projectRoot, content);
+		const result = readCueConfigFile(projectRoot);
+		expect(result!.raw).toBe(content);
+	});
+
+	it('readCueConfigFile returns null when no config exists', () => {
+		expect(readCueConfigFile(projectRoot)).toBeNull();
+	});
+
+	it('resolveCueConfigPath prefers canonical over legacy when both exist', () => {
+		const legacyPath = path.join(projectRoot, 'maestro-cue.yaml');
+		const canonicalDir = path.join(projectRoot, '.maestro');
+		fs.mkdirSync(canonicalDir, { recursive: true });
+		fs.writeFileSync(legacyPath, 'legacy', 'utf-8');
+		fs.writeFileSync(path.join(canonicalDir, 'cue.yaml'), 'canonical', 'utf-8');
+
+		const resolved = resolveCueConfigPath(projectRoot);
+		expect(resolved).toBe(path.join(canonicalDir, 'cue.yaml'));
+	});
+
+	it('falls back to legacy path when canonical is missing', () => {
+		const legacyPath = path.join(projectRoot, 'maestro-cue.yaml');
+		fs.writeFileSync(legacyPath, 'legacy: true', 'utf-8');
+
+		const result = readCueConfigFile(projectRoot);
+		expect(result!.raw).toBe('legacy: true');
+		expect(result!.filePath).toBe(legacyPath);
+	});
+
+	it('deleteCueConfigFile removes the file and returns true', () => {
+		writeCueConfigFile(projectRoot, 'subscriptions: []');
+		expect(deleteCueConfigFile(projectRoot)).toBe(true);
+		expect(readCueConfigFile(projectRoot)).toBeNull();
+	});
+
+	it('deleteCueConfigFile returns false when no file exists', () => {
+		expect(deleteCueConfigFile(projectRoot)).toBe(false);
+	});
+});
+
+describe('cue prompt-file roundtrip', () => {
+	it('writes a .md prompt file and reads it back', () => {
+		const rel = '.maestro/prompts/sub-1.md';
+		writeCuePromptFile(projectRoot, rel, 'body content');
+		const full = path.join(projectRoot, rel);
+		expect(fs.readFileSync(full, 'utf-8')).toBe('body content');
+	});
+
+	it('creates nested subdirectories under .maestro/prompts/', () => {
+		writeCuePromptFile(projectRoot, '.maestro/prompts/nested/deep/sub.md', 'body');
+		expect(fs.existsSync(path.join(projectRoot, '.maestro/prompts/nested/deep/sub.md'))).toBe(true);
+	});
+
+	it('rejects absolute paths', () => {
+		expect(() => writeCuePromptFile(projectRoot, '/etc/passwd.md', 'evil')).toThrow(
+			/relativePath must be relative/
+		);
+	});
+
+	it('rejects paths that escape the prompts directory', () => {
+		expect(() =>
+			writeCuePromptFile(projectRoot, '.maestro/prompts/../../escape.md', 'evil')
+		).toThrow(/resolves outside the prompts directory/);
+	});
+
+	it('rejects non-.md files', () => {
+		expect(() => writeCuePromptFile(projectRoot, '.maestro/prompts/payload.sh', 'evil')).toThrow(
+			/must end with .md/
+		);
+	});
+});
+
+describe('orphan prompt file pruning', () => {
+	it('removes .md files not in the keep-set', () => {
+		writeCuePromptFile(projectRoot, '.maestro/prompts/keep.md', 'keep');
+		writeCuePromptFile(projectRoot, '.maestro/prompts/drop.md', 'drop');
+
+		const removed = pruneOrphanedPromptFiles(projectRoot, ['.maestro/prompts/keep.md']);
+
+		expect(removed).toHaveLength(1);
+		expect(removed[0]).toContain('drop.md');
+		expect(fs.existsSync(path.join(projectRoot, '.maestro/prompts/keep.md'))).toBe(true);
+		expect(fs.existsSync(path.join(projectRoot, '.maestro/prompts/drop.md'))).toBe(false);
+	});
+
+	it('preserves non-.md files (only markdown is managed)', () => {
+		// Someone may have dropped a README.txt or similar next to prompts —
+		// pruning should not touch anything that isn't a .md file, since only
+		// .md files are produced by the prompt-file writer.
+		writeCuePromptFile(projectRoot, '.maestro/prompts/referenced.md', 'x');
+		const extraPath = path.join(projectRoot, '.maestro/prompts/other.txt');
+		fs.writeFileSync(extraPath, 'keep me', 'utf-8');
+
+		const removed = pruneOrphanedPromptFiles(projectRoot, ['.maestro/prompts/referenced.md']);
+
+		expect(removed).toHaveLength(0);
+		expect(fs.existsSync(extraPath)).toBe(true);
+	});
+
+	it('returns empty array when prompts directory does not exist', () => {
+		expect(pruneOrphanedPromptFiles(projectRoot, [])).toEqual([]);
+	});
+
+	it('handles nested subdirectories under prompts/', () => {
+		writeCuePromptFile(projectRoot, '.maestro/prompts/a/keep.md', 'keep');
+		writeCuePromptFile(projectRoot, '.maestro/prompts/b/drop.md', 'drop');
+
+		const removed = pruneOrphanedPromptFiles(projectRoot, ['.maestro/prompts/a/keep.md']);
+		expect(removed).toHaveLength(1);
+		expect(removed[0]).toContain(path.join('b', 'drop.md'));
+	});
+
+	it('skips absolute paths in the keep-set', () => {
+		// Ensures the keep-set filter matches the writer contract (reject
+		// absolute paths) and doesn't accidentally protect a file via a weird
+		// absolute entry that wouldn't hit the path.resolve check.
+		writeCuePromptFile(projectRoot, '.maestro/prompts/one.md', 'x');
+		const removed = pruneOrphanedPromptFiles(projectRoot, ['/absolute/ignored.md']);
+		expect(removed).toHaveLength(1);
+		expect(removed[0]).toContain('one.md');
+	});
+});
+
+describe('yaml + prompt-file full roundtrip', () => {
+	it('write YAML + prompt files → read back → same data', () => {
+		const yaml = [
+			'subscriptions:',
+			'  - name: morning',
+			'    event: time.scheduled',
+			'    prompt_file: .maestro/prompts/morning.md',
+			'  - name: output-prompt',
+			'    event: agent.completed',
+			'    prompt_file: .maestro/prompts/output.md',
+			'    output_prompt_file: .maestro/prompts/output-phase2.md',
+			'',
+		].join('\n');
+
+		writeCueConfigFile(projectRoot, yaml);
+		writeCuePromptFile(projectRoot, '.maestro/prompts/morning.md', 'morning body');
+		writeCuePromptFile(projectRoot, '.maestro/prompts/output.md', 'output body');
+		writeCuePromptFile(projectRoot, '.maestro/prompts/output-phase2.md', 'phase-2 body');
+
+		// Roundtrip YAML
+		expect(readCueConfigFile(projectRoot)!.raw).toBe(yaml);
+
+		// All prompts on disk
+		expect(fs.readFileSync(path.join(projectRoot, '.maestro/prompts/morning.md'), 'utf-8')).toBe(
+			'morning body'
+		);
+		expect(fs.readFileSync(path.join(projectRoot, '.maestro/prompts/output.md'), 'utf-8')).toBe(
+			'output body'
+		);
+		expect(
+			fs.readFileSync(path.join(projectRoot, '.maestro/prompts/output-phase2.md'), 'utf-8')
+		).toBe('phase-2 body');
+
+		// Simulate deleting one subscription and pruning — only referenced files remain
+		const removed = pruneOrphanedPromptFiles(projectRoot, [
+			'.maestro/prompts/morning.md',
+			'.maestro/prompts/output.md',
+		]);
+		expect(removed).toHaveLength(1);
+		expect(removed[0]).toContain('output-phase2.md');
+		expect(fs.existsSync(path.join(projectRoot, '.maestro/prompts/output-phase2.md'))).toBe(false);
+	});
+
+	it('overwriting YAML+prompts preserves the rest of .maestro/', () => {
+		// User may have unrelated files (e.g. director-notes, other tooling)
+		// in .maestro/ — we must not blow them away.
+		const maestroDir = path.join(projectRoot, '.maestro');
+		fs.mkdirSync(maestroDir, { recursive: true });
+		fs.writeFileSync(path.join(maestroDir, 'director-notes.md'), 'notes', 'utf-8');
+
+		writeCueConfigFile(projectRoot, 'subscriptions: []');
+		writeCuePromptFile(projectRoot, '.maestro/prompts/x.md', 'body');
+
+		expect(fs.readFileSync(path.join(maestroDir, 'director-notes.md'), 'utf-8')).toBe('notes');
+	});
+});

--- a/src/__tests__/main/cue/pipeline-layout-store.test.ts
+++ b/src/__tests__/main/cue/pipeline-layout-store.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Tests for pipeline-layout-store, focusing on the v1 → v2 migration path.
+ * These guard against regressions in the shape-versioning logic that lets
+ * older installs keep their layout when the per-project scoping shipped.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { PIPELINE_LAYOUT_DEFAULT_PROJECT_KEY } from '../../../shared/cue-pipeline-types';
+
+// electron's app.getPath is mocked via the module loader so the store writes
+// into a scratch directory under $TMPDIR rather than the real userData path.
+let scratchDir = '';
+
+vi.mock('electron', () => ({
+	app: {
+		getPath: (_name: string) => scratchDir,
+	},
+}));
+
+vi.mock('../../../main/utils/sentry', () => ({
+	captureException: vi.fn(),
+}));
+
+// Import AFTER vi.mock so the module picks up the stubbed electron.
+let savePipelineLayout: typeof import('../../../main/cue/pipeline-layout-store').savePipelineLayout;
+let loadPipelineLayout: typeof import('../../../main/cue/pipeline-layout-store').loadPipelineLayout;
+
+beforeEach(async () => {
+	scratchDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cue-layout-test-'));
+	// Re-import fresh so the cached file path inside the store is reset for
+	// each test. Vitest's module graph keeps one instance across tests in the
+	// same file otherwise, which causes the first test's scratch path to
+	// leak into the second.
+	vi.resetModules();
+	const storeModule = await import('../../../main/cue/pipeline-layout-store');
+	savePipelineLayout = storeModule.savePipelineLayout;
+	loadPipelineLayout = storeModule.loadPipelineLayout;
+});
+
+afterEach(() => {
+	if (scratchDir && fs.existsSync(scratchDir)) {
+		fs.rmSync(scratchDir, { recursive: true, force: true });
+	}
+});
+
+describe('pipeline-layout-store — v1 → v2 migration', () => {
+	it('returns null when no layout file exists', () => {
+		expect(loadPipelineLayout()).toBeNull();
+	});
+
+	it('migrates a v1 legacy file by folding top-level fields into the default project key', () => {
+		const legacy = {
+			pipelines: [],
+			selectedPipelineId: 'p1',
+			viewport: { x: 10, y: 20, zoom: 1.5 },
+			writtenRoots: ['/projects/foo'],
+		};
+		fs.writeFileSync(
+			path.join(scratchDir, 'cue-pipeline-layout.json'),
+			JSON.stringify(legacy),
+			'utf-8'
+		);
+
+		const loaded = loadPipelineLayout();
+		expect(loaded).not.toBeNull();
+		expect(loaded!.version).toBe(2);
+		expect(loaded!.perProject).toBeDefined();
+		expect(loaded!.perProject![PIPELINE_LAYOUT_DEFAULT_PROJECT_KEY]).toEqual({
+			selectedPipelineId: 'p1',
+			viewport: { x: 10, y: 20, zoom: 1.5 },
+		});
+		// Preserves the original top-level fields as v1 fallback
+		expect(loaded!.selectedPipelineId).toBe('p1');
+		expect(loaded!.viewport).toEqual({ x: 10, y: 20, zoom: 1.5 });
+	});
+
+	it('leaves v2 files alone on load', () => {
+		const v2 = {
+			version: 2,
+			pipelines: [],
+			selectedPipelineId: 'p1',
+			viewport: { x: 0, y: 0, zoom: 1 },
+			perProject: {
+				'/projects/alpha': {
+					selectedPipelineId: 'alpha-1',
+					viewport: { x: 100, y: 200, zoom: 0.8 },
+				},
+			},
+		};
+		fs.writeFileSync(
+			path.join(scratchDir, 'cue-pipeline-layout.json'),
+			JSON.stringify(v2),
+			'utf-8'
+		);
+
+		const loaded = loadPipelineLayout();
+		expect(loaded!.version).toBe(2);
+		expect(loaded!.perProject!['/projects/alpha']).toEqual({
+			selectedPipelineId: 'alpha-1',
+			viewport: { x: 100, y: 200, zoom: 0.8 },
+		});
+	});
+
+	it('adds an empty perProject map when v1 file has no legacy state to migrate', () => {
+		const empty = { pipelines: [], selectedPipelineId: null };
+		fs.writeFileSync(
+			path.join(scratchDir, 'cue-pipeline-layout.json'),
+			JSON.stringify(empty),
+			'utf-8'
+		);
+
+		const loaded = loadPipelineLayout();
+		expect(loaded!.version).toBe(2);
+		expect(loaded!.perProject).toEqual({});
+	});
+
+	it('returns null on corrupt JSON instead of throwing', () => {
+		fs.writeFileSync(
+			path.join(scratchDir, 'cue-pipeline-layout.json'),
+			'{{ not valid json',
+			'utf-8'
+		);
+		expect(loadPipelineLayout()).toBeNull();
+	});
+});
+
+describe('pipeline-layout-store — save', () => {
+	it('stamps version 2 on every write', () => {
+		savePipelineLayout({
+			pipelines: [],
+			selectedPipelineId: null,
+			perProject: {},
+		});
+		const raw = fs.readFileSync(path.join(scratchDir, 'cue-pipeline-layout.json'), 'utf-8');
+		expect(JSON.parse(raw).version).toBe(2);
+	});
+
+	it('preserves the perProject map across save cycles', () => {
+		const withPerProject = {
+			pipelines: [],
+			selectedPipelineId: 'p1',
+			viewport: { x: 1, y: 2, zoom: 1 },
+			perProject: {
+				'/proj/a': {
+					selectedPipelineId: 'a-1',
+					viewport: { x: 50, y: 60, zoom: 1.2 },
+				},
+				'/proj/b': {
+					selectedPipelineId: 'b-1',
+					viewport: { x: -10, y: -20, zoom: 0.5 },
+				},
+			},
+		};
+		savePipelineLayout(withPerProject);
+
+		const loaded = loadPipelineLayout();
+		expect(loaded!.perProject!['/proj/a']).toEqual(withPerProject.perProject['/proj/a']);
+		expect(loaded!.perProject!['/proj/b']).toEqual(withPerProject.perProject['/proj/b']);
+	});
+
+	it('initializes perProject to an empty object when not provided', () => {
+		// Simulates a caller that omits perProject — the store should coerce
+		// it rather than leaving it undefined on disk.
+		savePipelineLayout({
+			pipelines: [],
+			selectedPipelineId: null,
+		} as Parameters<typeof savePipelineLayout>[0]);
+		const raw = fs.readFileSync(path.join(scratchDir, 'cue-pipeline-layout.json'), 'utf-8');
+		expect(JSON.parse(raw).perProject).toEqual({});
+	});
+});

--- a/src/__tests__/main/cue/pipeline-layout-store.test.ts
+++ b/src/__tests__/main/cue/pipeline-layout-store.test.ts
@@ -72,9 +72,19 @@ describe('pipeline-layout-store — v1 → v2 migration', () => {
 			selectedPipelineId: 'p1',
 			viewport: { x: 10, y: 20, zoom: 1.5 },
 		});
-		// Preserves the original top-level fields as v1 fallback
-		expect(loaded!.selectedPipelineId).toBe('p1');
-		expect(loaded!.viewport).toEqual({ x: 10, y: 20, zoom: 1.5 });
+		// The v1 top-level fields are stripped after migration so re-saves
+		// can't drift out of sync with the authoritative perProject entries.
+		expect(loaded!.selectedPipelineId).toBeNull();
+		expect(loaded!.viewport).toBeUndefined();
+	});
+
+	it('returns null for JSON that parses to non-object values', () => {
+		// Ensures corrupt-but-valid JSON (null / array / primitive) doesn't
+		// crash the migrator on property access — we treat them as absent.
+		for (const contents of ['null', '[]', '"just a string"', '42', 'true']) {
+			fs.writeFileSync(path.join(scratchDir, 'cue-pipeline-layout.json'), contents, 'utf-8');
+			expect(loadPipelineLayout()).toBeNull();
+		}
 	});
 
 	it('leaves v2 files alone on load', () => {

--- a/src/__tests__/renderer/components/CuePipelineEditor/panels/UpstreamSourcesPanel.test.tsx
+++ b/src/__tests__/renderer/components/CuePipelineEditor/panels/UpstreamSourcesPanel.test.tsx
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { UpstreamSourcesPanel } from '../../../../../renderer/components/CuePipelineEditor/panels/UpstreamSourcesPanel';
+import { THEMES } from '../../../../../renderer/constants/themes';
+import type {
+	AgentNodeData,
+	CuePipeline,
+	IncomingAgentEdgeInfo,
+	PipelineEdge,
+	PipelineNode,
+} from '../../../../../shared/cue-pipeline-types';
+
+const theme = THEMES['dracula'];
+
+function agentNode(id: string, sessionName: string): PipelineNode {
+	return {
+		id,
+		type: 'agent',
+		position: { x: 0, y: 0 },
+		data: { sessionId: `s-${id}`, sessionName, toolType: 'claude-code' } as AgentNodeData,
+	};
+}
+
+function edge(
+	id: string,
+	source: string,
+	target: string,
+	overrides: Partial<PipelineEdge> = {}
+): PipelineEdge {
+	return { id, source, target, mode: 'pass', ...overrides };
+}
+
+function incomingEdge(
+	id: string,
+	sourceNodeId: string,
+	sourceSessionName: string,
+	overrides: Partial<IncomingAgentEdgeInfo> = {}
+): IncomingAgentEdgeInfo {
+	return {
+		edgeId: id,
+		sourceNodeId,
+		sourceSessionName,
+		includeUpstreamOutput: true,
+		forwardOutput: false,
+		...overrides,
+	};
+}
+
+describe('UpstreamSourcesPanel', () => {
+	it('renders nothing when there are no direct or forwarded sources', () => {
+		const { container } = render(
+			<UpstreamSourcesPanel theme={theme} incomingAgentEdges={[]} onUpdateEdge={vi.fn()} />
+		);
+		expect(container.innerHTML).toBe('');
+	});
+
+	describe('direct source controls', () => {
+		it('dispatches includeUpstreamOutput updates from the Include checkbox', () => {
+			const onUpdateEdge = vi.fn();
+			render(
+				<UpstreamSourcesPanel
+					theme={theme}
+					incomingAgentEdges={[incomingEdge('e1', 'a1', 'Agent A')]}
+					onUpdateEdge={onUpdateEdge}
+				/>
+			);
+			fireEvent.click(screen.getByLabelText('Include', { selector: 'input' }));
+			expect(onUpdateEdge).toHaveBeenCalledWith('e1', { includeUpstreamOutput: false });
+		});
+
+		it('dispatches forwardOutput updates from the Forward checkbox', () => {
+			const onUpdateEdge = vi.fn();
+			render(
+				<UpstreamSourcesPanel
+					theme={theme}
+					incomingAgentEdges={[incomingEdge('e1', 'a1', 'Agent A')]}
+					onUpdateEdge={onUpdateEdge}
+				/>
+			);
+			fireEvent.click(screen.getByLabelText('Forward', { selector: 'input' }));
+			expect(onUpdateEdge).toHaveBeenCalledWith('e1', { forwardOutput: true });
+		});
+
+		it('renders the per-source CUE_OUTPUT token chip when Include is on', () => {
+			render(
+				<UpstreamSourcesPanel
+					theme={theme}
+					incomingAgentEdges={[incomingEdge('e1', 'a1', 'Agent A')]}
+					onUpdateEdge={vi.fn()}
+				/>
+			);
+			expect(screen.getByText(/CUE_OUTPUT_AGENT_A/)).toBeDefined();
+		});
+
+		it('renders CUE_FORWARDED chip when Forward is on', () => {
+			render(
+				<UpstreamSourcesPanel
+					theme={theme}
+					incomingAgentEdges={[incomingEdge('e1', 'a1', 'Agent A', { forwardOutput: true })]}
+					onUpdateEdge={vi.fn()}
+				/>
+			);
+			expect(screen.getByText(/CUE_FORWARDED_AGENT_A/)).toBeDefined();
+		});
+	});
+
+	describe('forwarded sources', () => {
+		function makeChainPipeline(): CuePipeline {
+			// A → B → C, with A→B forwardOutput=true so A is a forwarded source
+			// of C reached via B.
+			return {
+				id: 'p1',
+				name: 'Chain',
+				color: '#06b6d4',
+				nodes: [agentNode('a', 'Agent A'), agentNode('b', 'Agent B'), agentNode('c', 'Agent C')],
+				edges: [edge('e-ab', 'a', 'b', { forwardOutput: true }), edge('e-bc', 'b', 'c')],
+			};
+		}
+
+		it('lists forwarded sources with a "via" label and CUE_FORWARDED chip', () => {
+			const pipeline = makeChainPipeline();
+			render(
+				<UpstreamSourcesPanel
+					theme={theme}
+					incomingAgentEdges={[incomingEdge('e-bc', 'b', 'Agent B')]}
+					onUpdateEdge={vi.fn()}
+					pipeline={pipeline}
+					targetNodeId="c"
+				/>
+			);
+			expect(screen.getByText('Agent A')).toBeDefined();
+			expect(screen.getByText(/via Agent B/)).toBeDefined();
+			expect(screen.getByText(/CUE_FORWARDED_AGENT_A/)).toBeDefined();
+		});
+
+		it('hides forwarded section when there are no transitive sources', () => {
+			const pipeline: CuePipeline = {
+				id: 'p1',
+				name: 'Chain',
+				color: '#06b6d4',
+				nodes: [agentNode('b', 'Agent B'), agentNode('c', 'Agent C')],
+				edges: [edge('e-bc', 'b', 'c')],
+			};
+			render(
+				<UpstreamSourcesPanel
+					theme={theme}
+					incomingAgentEdges={[incomingEdge('e-bc', 'b', 'Agent B')]}
+					onUpdateEdge={vi.fn()}
+					pipeline={pipeline}
+					targetNodeId="c"
+				/>
+			);
+			// No "via" labels should appear.
+			expect(screen.queryByText(/^via /)).toBeNull();
+		});
+
+		it('renders when a node has only forwarded sources and no direct edges', () => {
+			// D has a single direct edge but the panel should still list A (forwarded
+			// via B) alongside the B row.
+			const pipeline: CuePipeline = {
+				id: 'p1',
+				name: 'Chain',
+				color: '#06b6d4',
+				nodes: [agentNode('a', 'Agent A'), agentNode('b', 'Agent B'), agentNode('c', 'Agent C')],
+				edges: [edge('e-ab', 'a', 'b', { forwardOutput: true }), edge('e-bc', 'b', 'c')],
+			};
+			render(
+				<UpstreamSourcesPanel
+					theme={theme}
+					incomingAgentEdges={[incomingEdge('e-bc', 'b', 'Agent B')]}
+					onUpdateEdge={vi.fn()}
+					pipeline={pipeline}
+					targetNodeId="c"
+				/>
+			);
+			expect(screen.getByText('Agent A')).toBeDefined();
+			expect(screen.getByText('Agent B')).toBeDefined();
+		});
+	});
+});

--- a/src/__tests__/renderer/components/CuePipelineEditor/utils/pipelineToYaml.upstream.test.ts
+++ b/src/__tests__/renderer/components/CuePipelineEditor/utils/pipelineToYaml.upstream.test.ts
@@ -258,4 +258,24 @@ describe('pipelineToYamlSubscriptions — per-edge upstream output', () => {
 			expect(chainSub!.prompt).toContain('{{CUE_SOURCE_OUTPUT}}');
 		});
 	});
+
+	// Regression gate: the authored prompt stored on AgentNodeData must never
+	// accumulate injected tokens when emitting YAML. If this breaks, every
+	// save would duplicate the prepended prefix.
+	describe('prompt accumulation regression', () => {
+		it('does not mutate the pipeline node inputPrompt on emit', () => {
+			const pipeline = makePipeline({
+				nodes: [
+					triggerNode('t1'),
+					agentNode('a1', 's1', 'Agent A', 'build'),
+					agentNode('a2', 's2', 'Agent B', 'author'),
+				],
+				edges: [edge('e1', 't1', 'a1'), edge('e2', 'a1', 'a2')],
+			});
+			const before = (pipeline.nodes[2].data as { inputPrompt?: string }).inputPrompt;
+			pipelineToYamlSubscriptions(pipeline);
+			const after = (pipeline.nodes[2].data as { inputPrompt?: string }).inputPrompt;
+			expect(after).toBe(before);
+		});
+	});
 });

--- a/src/__tests__/renderer/components/CuePipelineEditor/utils/transitiveUpstream.test.ts
+++ b/src/__tests__/renderer/components/CuePipelineEditor/utils/transitiveUpstream.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Unit tests for the pure graph traversal that surfaces direct + transitive
+ * upstream sources for a given pipeline node.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { computeTransitiveUpstream } from '../../../../../renderer/components/CuePipelineEditor/utils/transitiveUpstream';
+import type {
+	AgentNodeData,
+	CuePipeline,
+	PipelineEdge,
+	PipelineNode,
+} from '../../../../../shared/cue-pipeline-types';
+
+function agent(id: string, sessionName: string): PipelineNode {
+	const data: AgentNodeData = {
+		sessionId: `session-${id}`,
+		sessionName,
+		toolType: 'claude-code',
+	};
+	return { id, type: 'agent', position: { x: 0, y: 0 }, data };
+}
+
+function edge(
+	id: string,
+	source: string,
+	target: string,
+	overrides: Partial<PipelineEdge> = {}
+): PipelineEdge {
+	return {
+		id,
+		source,
+		target,
+		mode: 'pass',
+		...overrides,
+	};
+}
+
+function pipeline(nodes: PipelineNode[], edges: PipelineEdge[]): CuePipeline {
+	return {
+		id: 'p1',
+		name: 'Test Pipeline',
+		color: '#000',
+		nodes,
+		edges,
+	};
+}
+
+describe('computeTransitiveUpstream', () => {
+	describe('direct sources', () => {
+		it('returns a single direct source for a trivial B -> C pipeline', () => {
+			const p = pipeline([agent('b', 'B'), agent('c', 'C')], [edge('e1', 'b', 'c')]);
+			const result = computeTransitiveUpstream(p, 'c');
+			expect(result).toEqual([{ source: 'B', sourceNodeId: 'b', isDirect: true, path: ['B'] }]);
+		});
+
+		it('lists multiple direct sources in edge order', () => {
+			const p = pipeline(
+				[agent('a', 'A'), agent('b', 'B'), agent('c', 'C')],
+				[edge('e1', 'a', 'c'), edge('e2', 'b', 'c')]
+			);
+			const result = computeTransitiveUpstream(p, 'c');
+			expect(result.map((r) => r.source)).toEqual(['A', 'B']);
+			expect(result.every((r) => r.isDirect)).toBe(true);
+		});
+	});
+
+	describe('transitive sources', () => {
+		it('returns A as transitive via B in A -> B -> C when A->B has forwardOutput=true', () => {
+			const p = pipeline(
+				[agent('a', 'A'), agent('b', 'B'), agent('c', 'C')],
+				[edge('e1', 'a', 'b', { forwardOutput: true }), edge('e2', 'b', 'c')]
+			);
+			const result = computeTransitiveUpstream(p, 'c');
+			expect(result).toHaveLength(2);
+			const bSrc = result.find((r) => r.source === 'B')!;
+			const aSrc = result.find((r) => r.source === 'A')!;
+			expect(bSrc.isDirect).toBe(true);
+			expect(aSrc.isDirect).toBe(false);
+			expect(aSrc.path).toEqual(['A', 'B']);
+			expect(aSrc.relayEdgeId).toBe('e1');
+		});
+
+		it('omits A when the A->B edge does NOT have forwardOutput=true', () => {
+			const p = pipeline(
+				[agent('a', 'A'), agent('b', 'B'), agent('c', 'C')],
+				[edge('e1', 'a', 'b'), edge('e2', 'b', 'c')]
+			);
+			const result = computeTransitiveUpstream(p, 'c');
+			expect(result.map((r) => r.source)).toEqual(['B']);
+		});
+
+		it('walks transitively through multiple forwarding hops', () => {
+			// A -> B -> C -> D, with A->B and B->C forwarding.
+			const p = pipeline(
+				[agent('a', 'A'), agent('b', 'B'), agent('c', 'C'), agent('d', 'D')],
+				[
+					edge('e1', 'a', 'b', { forwardOutput: true }),
+					edge('e2', 'b', 'c', { forwardOutput: true }),
+					edge('e3', 'c', 'd'),
+				]
+			);
+			const result = computeTransitiveUpstream(p, 'd');
+			expect(result.map((r) => r.source).sort()).toEqual(['A', 'B', 'C']);
+			const a = result.find((r) => r.source === 'A')!;
+			expect(a.isDirect).toBe(false);
+			expect(a.path).toEqual(['A', 'B', 'C']);
+		});
+
+		it('stops walking when the forwarding chain breaks', () => {
+			// A -> B -> C -> D, with A->B forwarding but B->C NOT forwarding.
+			const p = pipeline(
+				[agent('a', 'A'), agent('b', 'B'), agent('c', 'C'), agent('d', 'D')],
+				[edge('e1', 'a', 'b', { forwardOutput: true }), edge('e2', 'b', 'c'), edge('e3', 'c', 'd')]
+			);
+			const result = computeTransitiveUpstream(p, 'd');
+			// C is direct. B is NOT forwarded to C (e2.forwardOutput falsy), so
+			// A never reaches D even though A is forwarded through B.
+			expect(result.map((r) => r.source)).toEqual(['C']);
+		});
+	});
+
+	describe('dedup & cycles', () => {
+		it('dedupes when the same source reaches the target via multiple paths', () => {
+			// Diamond: A -> B -> D, A -> C -> D, both forwarding. A should
+			// appear once as transitive.
+			const p = pipeline(
+				[agent('a', 'A'), agent('b', 'B'), agent('c', 'C'), agent('d', 'D')],
+				[
+					edge('e1', 'a', 'b', { forwardOutput: true }),
+					edge('e2', 'a', 'c', { forwardOutput: true }),
+					edge('e3', 'b', 'd'),
+					edge('e4', 'c', 'd'),
+				]
+			);
+			const result = computeTransitiveUpstream(p, 'd');
+			const aRows = result.filter((r) => r.source === 'A');
+			expect(aRows).toHaveLength(1);
+			expect(aRows[0].isDirect).toBe(false);
+		});
+
+		it('terminates on cycles', () => {
+			// A -> B -> A (cycle), computing upstream from B.
+			const p = pipeline(
+				[agent('a', 'A'), agent('b', 'B')],
+				[
+					edge('e1', 'a', 'b', { forwardOutput: true }),
+					edge('e2', 'b', 'a', { forwardOutput: true }),
+				]
+			);
+			const result = computeTransitiveUpstream(p, 'b');
+			expect(result.map((r) => r.source)).toEqual(['A']);
+		});
+	});
+
+	describe('edge cases', () => {
+		it('returns empty for a target with no incoming edges', () => {
+			const p = pipeline([agent('a', 'A')], []);
+			expect(computeTransitiveUpstream(p, 'a')).toEqual([]);
+		});
+
+		it('returns empty when the target node id does not exist', () => {
+			const p = pipeline([agent('a', 'A')], []);
+			expect(computeTransitiveUpstream(p, 'nonexistent')).toEqual([]);
+		});
+
+		it('ignores non-agent nodes (e.g. triggers) as sources', () => {
+			// Trigger node wired into an agent should NOT appear as an upstream.
+			const trigger: PipelineNode = {
+				id: 't',
+				type: 'trigger',
+				position: { x: 0, y: 0 },
+				data: { eventType: 'agent.completed', label: 'Trigger', config: {} },
+			};
+			const p = pipeline([trigger, agent('a', 'A')], [edge('e1', 't', 'a')]);
+			expect(computeTransitiveUpstream(p, 'a')).toEqual([]);
+		});
+	});
+});

--- a/src/__tests__/renderer/hooks/useCueAutoDiscovery.test.ts
+++ b/src/__tests__/renderer/hooks/useCueAutoDiscovery.test.ts
@@ -178,7 +178,7 @@ describe('useCueAutoDiscovery', () => {
 			expect(mockRefreshSession).toHaveBeenCalledWith('s2', '/project/b');
 		});
 
-		it('should call disable when maestroCue is toggled OFF', () => {
+		it('should call disable when maestroCue is toggled OFF', async () => {
 			const sessions = [makeSession('s1', '/project/a')];
 
 			useSessionStore.setState({ sessionsLoaded: true });
@@ -189,6 +189,9 @@ describe('useCueAutoDiscovery', () => {
 
 			// Toggle maestroCue OFF
 			rerender({ sessions, encore: makeEncoreFeatures(false) });
+			// Toggle calls are now serialized on a Promise chain, so the
+			// disable fires on the next microtask rather than synchronously.
+			await act(async () => {});
 
 			expect(mockDisable).toHaveBeenCalledTimes(1);
 		});
@@ -232,6 +235,85 @@ describe('useCueAutoDiscovery', () => {
 			rerender({ sessions: updatedSessions, encore: encoreFeatures });
 
 			expect(mockRefreshSession).toHaveBeenCalledWith('s2', '/project/b');
+		});
+	});
+
+	describe('rapid-toggle serialization', () => {
+		// These tests guard the queueing behavior that prevents ON → OFF → ON
+		// toggles from racing when enable/disable IPC calls have different
+		// latencies. Without serialization, a slow enable() resolving after a
+		// fast disable() could leave the engine enabled when the flag says off.
+
+		it('serializes enable/disable calls in flag-change order even when IPC latency varies', async () => {
+			const sessions = [makeSession('s1', '/project/a')];
+			useSessionStore.setState({ sessionsLoaded: true });
+
+			const callOrder: string[] = [];
+			let resolveEnable: (() => void) | undefined;
+			mockEnable.mockImplementationOnce(
+				() =>
+					new Promise<void>((resolve) => {
+						callOrder.push('enable:start');
+						resolveEnable = () => {
+							callOrder.push('enable:resolve');
+							resolve();
+						};
+					})
+			);
+			mockDisable.mockImplementationOnce(async () => {
+				callOrder.push('disable:start');
+				callOrder.push('disable:resolve');
+			});
+
+			const { rerender } = renderHook(({ sessions: s, encore }) => useCueAutoDiscovery(s, encore), {
+				initialProps: { sessions, encore: makeEncoreFeatures(false) },
+			});
+
+			// ON → queues enable (which will hang until we resolve it)
+			rerender({ sessions, encore: makeEncoreFeatures(true) });
+			await act(async () => {});
+			// OFF → queues disable. Must NOT execute until enable resolves.
+			rerender({ sessions, encore: makeEncoreFeatures(false) });
+			await act(async () => {});
+
+			// Disable has not started yet; it's waiting in the chain.
+			expect(callOrder).toEqual(['enable:start']);
+			expect(mockDisable).not.toHaveBeenCalled();
+
+			// Resolve enable; disable should then fire in order.
+			await act(async () => {
+				resolveEnable!();
+			});
+			await act(async () => {});
+
+			expect(callOrder).toEqual([
+				'enable:start',
+				'enable:resolve',
+				'disable:start',
+				'disable:resolve',
+			]);
+		});
+
+		it('applies the final flag value when rapid toggles occur', async () => {
+			const sessions = [makeSession('s1', '/project/a')];
+			useSessionStore.setState({ sessionsLoaded: true });
+
+			const { rerender } = renderHook(({ sessions: s, encore }) => useCueAutoDiscovery(s, encore), {
+				initialProps: { sessions, encore: makeEncoreFeatures(false) },
+			});
+
+			// OFF → ON → OFF → ON, firing 3 transitions back-to-back
+			rerender({ sessions, encore: makeEncoreFeatures(true) });
+			rerender({ sessions, encore: makeEncoreFeatures(false) });
+			rerender({ sessions, encore: makeEncoreFeatures(true) });
+			await act(async () => {});
+			// Let the microtask chain drain across all three toggles.
+			await act(async () => {});
+
+			// Every transition must have been observed once — never skipped or
+			// reordered. Final call is enable to match the final flag value.
+			expect(mockEnable).toHaveBeenCalledTimes(2);
+			expect(mockDisable).toHaveBeenCalledTimes(1);
 		});
 	});
 });

--- a/src/__tests__/shared/cue-path-utils.test.ts
+++ b/src/__tests__/shared/cue-path-utils.test.ts
@@ -74,3 +74,28 @@ describe('isDescendantOrEqual', () => {
 		expect(isDescendantOrEqual('/a/b/', '/a/b')).toBe(true);
 	});
 });
+
+// Regression: this utility is imported by the renderer pipeline save flow.
+// Do NOT let anyone reintroduce a Node `path` dependency — the renderer
+// strips it and saves fail with "path.resolve is not a function".
+describe('cue-path-utils (renderer-safe)', () => {
+	it('does not reference Node built-in modules at import time', async () => {
+		// A pure-JS module imports and evaluates without `require`/`import` of
+		// Node built-ins; this assertion just re-executes the module to confirm.
+		await expect(import('../../shared/cue-path-utils')).resolves.toBeDefined();
+	});
+
+	describe('Windows paths', () => {
+		it('computes common ancestor for sibling Windows directories', () => {
+			expect(computeCommonAncestorPath(['C:\\proj\\a', 'C:\\proj\\b'])).toBe('C:\\proj');
+		});
+
+		it('detects descendant under a Windows project root', () => {
+			expect(isDescendantOrEqual('C:\\proj\\sub', 'C:\\proj')).toBe(true);
+		});
+
+		it('rejects non-boundary Windows prefix matches', () => {
+			expect(isDescendantOrEqual('C:\\proj2', 'C:\\proj')).toBe(false);
+		});
+	});
+});

--- a/src/__tests__/shared/cue-path-utils.test.ts
+++ b/src/__tests__/shared/cue-path-utils.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
 import { computeCommonAncestorPath, isDescendantOrEqual } from '../../shared/cue-path-utils';
 
 describe('computeCommonAncestorPath', () => {
@@ -81,7 +83,18 @@ describe('isDescendantOrEqual', () => {
 describe('cue-path-utils (renderer-safe)', () => {
 	it('does not reference Node built-in modules at import time', async () => {
 		// A pure-JS module imports and evaluates without `require`/`import` of
-		// Node built-ins; this assertion just re-executes the module to confirm.
+		// Node built-ins. Dynamic import alone only catches crashes — a silent
+		// tree-shake could still hide a `path` reference the renderer rejects
+		// at runtime. Assert against the source too so a review can't miss it.
+		const sourcePath = path.resolve(__dirname, '../../shared/cue-path-utils.ts');
+		const source = fs.readFileSync(sourcePath, 'utf-8');
+		// Matches:  from 'path' | from "path" | from 'node:path' | require('path')
+		// Does NOT match comments / strings that happen to include the word `path`.
+		const nodePathImport =
+			/(?:require\(\s*['"]|from\s+['"])(?:node:)?(?:path|fs|os|child_process|stream|zlib|crypto|http|https|net|dns|url)['"]/;
+		expect(source).not.toMatch(nodePathImport);
+
+		// Still import the module so a parse/eval regression surfaces here.
 		await expect(import('../../shared/cue-path-utils')).resolves.toBeDefined();
 	});
 
@@ -96,6 +109,36 @@ describe('cue-path-utils (renderer-safe)', () => {
 
 		it('rejects non-boundary Windows prefix matches', () => {
 			expect(isDescendantOrEqual('C:\\proj2', 'C:\\proj')).toBe(false);
+		});
+	});
+
+	// Regression: the original normalize() used /\\+/g which collapsed the
+	// leading `\\` of UNC paths down to `\`, breaking every downstream
+	// comparison for network shares. The fix preserves the UNC prefix.
+	describe('UNC paths', () => {
+		it('preserves the `\\\\` UNC prefix through normalize', () => {
+			// A path that equals itself is the cheapest proof the prefix
+			// didn't get collapsed — if normalize mangled `\\\\`, this
+			// isDescendantOrEqual call would return false.
+			expect(isDescendantOrEqual('\\\\server\\share\\path', '\\\\server\\share\\path')).toBe(true);
+		});
+
+		it('detects descendant under a UNC share', () => {
+			expect(isDescendantOrEqual('\\\\server\\share\\sub', '\\\\server\\share')).toBe(true);
+		});
+
+		it('rejects descendant check across different UNC shares', () => {
+			expect(isDescendantOrEqual('\\\\server\\other\\sub', '\\\\server\\share')).toBe(false);
+		});
+
+		it('computes common ancestor for UNC siblings', () => {
+			expect(computeCommonAncestorPath(['\\\\server\\share\\a', '\\\\server\\share\\b'])).toBe(
+				'\\\\server\\share'
+			);
+		});
+
+		it('treats a bare UNC root as its own common ancestor', () => {
+			expect(computeCommonAncestorPath(['\\\\server\\share'])).toBe('\\\\server\\share');
 		});
 	});
 });

--- a/src/main/cue/config/cue-config-repository.ts
+++ b/src/main/cue/config/cue-config-repository.ts
@@ -180,11 +180,17 @@ export function pruneOrphanedPromptFiles(
 /**
  * Watches both canonical and legacy Cue config paths.
  * Debounces onChange by 1 second.
+ *
+ * Uses a `torn` flag and instance check so any event that slips past
+ * `watcher.close()` (chokidar emits an `unlink` for in-flight events on some
+ * platforms) is rejected — preventing a stale watcher from triggering a
+ * refresh on a session that has been torn down or re-registered.
  */
 export function watchCueConfigFile(projectRoot: string, onChange: () => void): () => void {
 	const canonicalPath = path.join(projectRoot, CUE_CONFIG_PATH);
 	const legacyPath = path.join(projectRoot, LEGACY_CUE_CONFIG_PATH);
 	let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+	let torn = false;
 
 	const watcher = chokidar.watch([canonicalPath, legacyPath], {
 		persistent: true,
@@ -192,11 +198,13 @@ export function watchCueConfigFile(projectRoot: string, onChange: () => void): (
 	});
 
 	const debouncedOnChange = () => {
+		if (torn) return;
 		if (debounceTimer) {
 			clearTimeout(debounceTimer);
 		}
 		debounceTimer = setTimeout(() => {
 			debounceTimer = null;
+			if (torn) return;
 			onChange();
 		}, 1000);
 	};
@@ -206,8 +214,10 @@ export function watchCueConfigFile(projectRoot: string, onChange: () => void): (
 	watcher.on('unlink', debouncedOnChange);
 
 	return () => {
+		torn = true;
 		if (debounceTimer) {
 			clearTimeout(debounceTimer);
+			debounceTimer = null;
 		}
 		watcher.close();
 	};

--- a/src/main/cue/config/cue-config-repository.ts
+++ b/src/main/cue/config/cue-config-repository.ts
@@ -185,8 +185,18 @@ export function pruneOrphanedPromptFiles(
  * `watcher.close()` (chokidar emits an `unlink` for in-flight events on some
  * platforms) is rejected — preventing a stale watcher from triggering a
  * refresh on a session that has been torn down or re-registered.
+ *
+ * `opts.onReady` fires once chokidar finishes its initial scan — use it in
+ * tests so they don't have to sleep on a timer while chokidar registers
+ * watched paths (that sleep was a flakiness source on slow CI runners).
+ * Production callers can ignore the opt; file changes before `ready` are
+ * uncommon for config reloads triggered by the user.
  */
-export function watchCueConfigFile(projectRoot: string, onChange: () => void): () => void {
+export function watchCueConfigFile(
+	projectRoot: string,
+	onChange: () => void,
+	opts?: { onReady?: () => void }
+): () => void {
 	const canonicalPath = path.join(projectRoot, CUE_CONFIG_PATH);
 	const legacyPath = path.join(projectRoot, LEGACY_CUE_CONFIG_PATH);
 	let debounceTimer: ReturnType<typeof setTimeout> | null = null;
@@ -212,6 +222,9 @@ export function watchCueConfigFile(projectRoot: string, onChange: () => void): (
 	watcher.on('add', debouncedOnChange);
 	watcher.on('change', debouncedOnChange);
 	watcher.on('unlink', debouncedOnChange);
+	if (opts?.onReady) {
+		watcher.once('ready', opts.onReady);
+	}
 
 	return () => {
 		torn = true;

--- a/src/main/cue/cue-completion-service.ts
+++ b/src/main/cue/cue-completion-service.ts
@@ -1,6 +1,12 @@
 import type { MainLogLevel } from '../../shared/logger-types';
 import { describeFilter, matchesFilter } from './cue-filter';
-import { SOURCE_OUTPUT_MAX_CHARS, type CueFanInTracker } from './cue-fan-in-tracker';
+import { type CueFanInTracker } from './cue-fan-in-tracker';
+import {
+	buildFilteredOutputs,
+	mergeUpstreamForwarded,
+	SOURCE_OUTPUT_MAX_CHARS,
+	type FanInSourceCompletion,
+} from './cue-output-filter';
 import {
 	createCueEvent,
 	type AgentCompletionData,
@@ -88,28 +94,41 @@ export function createCueCompletionService(deps: CueCompletionServiceDeps): CueC
 					if (sources.length === 1) {
 						const rawStdout = completionData?.stdout ?? '';
 						const slicedOutput = rawStdout.slice(-SOURCE_OUTPUT_MAX_CHARS);
-						// Per-source output map for named template variables.
-						// Single-chain: just one entry.
-						const perSourceOutputs: Record<string, string> = {
-							[completingName]: slicedOutput,
+						const completion: FanInSourceCompletion = {
+							sessionId,
+							sessionName: completingName,
+							output: slicedOutput,
+							truncated: rawStdout.length > SOURCE_OUTPUT_MAX_CHARS,
+							chainDepth: completionData?.chainDepth ?? 0,
 						};
-						// Forward any outputs that were forwarded TO this completing
-						// agent from its own upstream. They're carried in the
-						// completionData.forwardedOutputs field (set by the engine
-						// from the triggering event's payload).
-						const upstreamForwarded = completionData?.forwardedOutputs;
+						// Honor include_output_from / forward_output_from on single-
+						// source subscriptions via the shared filter. Previously this
+						// path bypassed both lists, so any UI toggle silently no-op'd
+						// for 1-source chains; the fan-in path already filtered.
+						const { outputCompletions, perSourceOutputs, forwardedOutputs } = buildFilteredOutputs(
+							[completion],
+							sub
+						);
+						// Preserve pass-through of upstream-forwarded data — but filter
+						// by forward_output_from when the list is set so user intent
+						// is respected through the full chain.
+						const mergedForwarded = mergeUpstreamForwarded(
+							forwardedOutputs,
+							completionData?.forwardedOutputs,
+							sub
+						);
 						const event = createCueEvent('agent.completed', sub.name, {
 							sourceSession: completingName,
 							sourceSessionId: sessionId,
 							status: completionData?.status ?? 'completed',
 							exitCode: completionData?.exitCode ?? null,
 							durationMs: completionData?.durationMs ?? 0,
-							sourceOutput: slicedOutput,
-							outputTruncated: rawStdout.length > SOURCE_OUTPUT_MAX_CHARS,
+							sourceOutput: outputCompletions.map((c) => c.output).join('\n---\n'),
+							outputTruncated: outputCompletions.some((c) => c.truncated),
 							triggeredBy: completionData?.triggeredBy,
 							perSourceOutputs,
-							...(upstreamForwarded && Object.keys(upstreamForwarded).length > 0
-								? { forwardedOutputs: upstreamForwarded }
+							...(Object.keys(mergedForwarded).length > 0
+								? { forwardedOutputs: mergedForwarded }
 								: {}),
 						});
 

--- a/src/main/cue/cue-completion-service.ts
+++ b/src/main/cue/cue-completion-service.ts
@@ -7,6 +7,7 @@ import {
 	SOURCE_OUTPUT_MAX_CHARS,
 	type FanInSourceCompletion,
 } from './cue-output-filter';
+import { sliceTailByChars } from './cue-text-utils';
 import {
 	createCueEvent,
 	type AgentCompletionData,
@@ -93,7 +94,7 @@ export function createCueCompletionService(deps: CueCompletionServiceDeps): CueC
 
 					if (sources.length === 1) {
 						const rawStdout = completionData?.stdout ?? '';
-						const slicedOutput = rawStdout.slice(-SOURCE_OUTPUT_MAX_CHARS);
+						const slicedOutput = sliceTailByChars(rawStdout, SOURCE_OUTPUT_MAX_CHARS);
 						const completion: FanInSourceCompletion = {
 							sessionId,
 							sessionName: completingName,

--- a/src/main/cue/cue-engine.ts
+++ b/src/main/cue/cue-engine.ts
@@ -276,7 +276,9 @@ export class CueEngine {
 		}
 
 		this.enabled = true;
-		this.deps.onLog('cue', '[CUE] Engine started');
+		// Data payload triggers a renderer refresh via cue:activityUpdate,
+		// clearing any stale queue counters left over from a prior stop.
+		this.deps.onLog('cue', '[CUE] Engine started', { type: 'engineStarted' });
 
 		const sessions = this.deps.getSessions();
 		for (const session of sessions) {
@@ -308,7 +310,10 @@ export class CueEngine {
 		this.heartbeat.stop();
 		this.recoveryService.shutdown();
 
-		this.deps.onLog('cue', '[CUE] Engine stopped');
+		// Data payload triggers a renderer refresh via cue:activityUpdate so
+		// the queue counters, active runs list, and indicators reflect the
+		// cleared engine state instead of waiting for the next 10s poll.
+		this.deps.onLog('cue', '[CUE] Engine stopped', { type: 'engineStopped' });
 	}
 
 	/** Re-read the YAML for a specific session, tearing down old subscriptions */

--- a/src/main/cue/cue-executor.ts
+++ b/src/main/cue/cue-executor.ts
@@ -16,6 +16,7 @@ import type { HistoryEntry, SessionInfo, ToolType } from '../../shared/types';
 import { substituteTemplateVariables, type TemplateContext } from '../../shared/templateVariables';
 import { buildCueTemplateContext } from './cue-template-context-builder';
 import { buildSpawnSpec } from './cue-spawn-builder';
+import { sliceHeadByChars } from './cue-text-utils';
 import type { SshRemoteSettingsStore } from '../utils/ssh-remote-resolver';
 import {
 	runProcess,
@@ -234,7 +235,7 @@ export function getCueProcessList(): import('./cue-process-lifecycle').CueProces
 export function recordCueHistoryEntry(result: CueRunResult, session: SessionInfo): HistoryEntry {
 	const fullResponse =
 		result.stdout.length > MAX_HISTORY_RESPONSE_LENGTH
-			? result.stdout.substring(0, MAX_HISTORY_RESPONSE_LENGTH)
+			? sliceHeadByChars(result.stdout, MAX_HISTORY_RESPONSE_LENGTH)
 			: result.stdout;
 
 	return {

--- a/src/main/cue/cue-fan-in-tracker.ts
+++ b/src/main/cue/cue-fan-in-tracker.ts
@@ -16,17 +16,14 @@ import {
 	type CueSettings,
 	type CueSubscription,
 } from './cue-types';
+import {
+	buildFilteredOutputs,
+	SOURCE_OUTPUT_MAX_CHARS,
+	type FanInSourceCompletion,
+} from './cue-output-filter';
 
-export const SOURCE_OUTPUT_MAX_CHARS = 5000;
-
-/** Stored data for a single fan-in source completion */
-export interface FanInSourceCompletion {
-	sessionId: string;
-	sessionName: string;
-	output: string;
-	truncated: boolean;
-	chainDepth: number;
-}
+// Re-exports preserve call-site compatibility for existing importers.
+export { SOURCE_OUTPUT_MAX_CHARS, type FanInSourceCompletion };
 
 export interface CueFanInDeps {
 	onLog: (level: MainLogLevel, message: string, data?: unknown) => void;
@@ -65,41 +62,6 @@ export function createCueFanInTracker(deps: CueFanInDeps): CueFanInTracker {
 	const fanInTimers = new Map<string, ReturnType<typeof setTimeout>>();
 	/** Tracks when the first completion arrived for each tracker key (for cleanup staleness checks). */
 	const fanInCreatedAt = new Map<string, number>();
-
-	/**
-	 * Build filtered output maps from a completed set of fan-in sources.
-	 * Shared by both the success path and timeout-continue path.
-	 */
-	function buildFilteredOutputs(
-		completions: FanInSourceCompletion[],
-		sub: CueSubscription
-	): {
-		outputCompletions: FanInSourceCompletion[];
-		perSourceOutputs: Record<string, string>;
-		forwardedOutputs: Record<string, string>;
-	} {
-		const includeSet = sub.include_output_from ? new Set(sub.include_output_from) : null;
-		const outputCompletions = includeSet
-			? completions.filter((c) => includeSet.has(c.sessionName) || includeSet.has(c.sessionId))
-			: completions;
-
-		const perSourceOutputs: Record<string, string> = {};
-		for (const c of outputCompletions) {
-			perSourceOutputs[c.sessionName] = c.output;
-		}
-
-		const forwardSet = sub.forward_output_from ? new Set(sub.forward_output_from) : null;
-		const forwardedOutputs: Record<string, string> = {};
-		if (forwardSet) {
-			for (const c of completions) {
-				if (forwardSet.has(c.sessionName) || forwardSet.has(c.sessionId)) {
-					forwardedOutputs[c.sessionName] = c.output;
-				}
-			}
-		}
-
-		return { outputCompletions, perSourceOutputs, forwardedOutputs };
-	}
 
 	/**
 	 * Resolve a user-authored `sources` list (names or IDs, possibly mixed) to a

--- a/src/main/cue/cue-fan-in-tracker.ts
+++ b/src/main/cue/cue-fan-in-tracker.ts
@@ -21,6 +21,7 @@ import {
 	SOURCE_OUTPUT_MAX_CHARS,
 	type FanInSourceCompletion,
 } from './cue-output-filter';
+import { sliceTailByChars } from './cue-text-utils';
 
 // Re-exports preserve call-site compatibility for existing importers.
 export { SOURCE_OUTPUT_MAX_CHARS, type FanInSourceCompletion };
@@ -180,7 +181,7 @@ export function createCueFanInTracker(deps: CueFanInDeps): CueFanInTracker {
 			tracker.set(completedSessionId, {
 				sessionId: completedSessionId,
 				sessionName: completedSessionName,
-				output: rawOutput.slice(-SOURCE_OUTPUT_MAX_CHARS),
+				output: sliceTailByChars(rawOutput, SOURCE_OUTPUT_MAX_CHARS),
 				truncated: rawOutput.length > SOURCE_OUTPUT_MAX_CHARS,
 				chainDepth: completionData?.chainDepth ?? 0,
 			});

--- a/src/main/cue/cue-output-filter.ts
+++ b/src/main/cue/cue-output-filter.ts
@@ -1,0 +1,76 @@
+import type { CueSubscription } from './cue-types';
+
+export const SOURCE_OUTPUT_MAX_CHARS = 5000;
+
+export interface FanInSourceCompletion {
+	sessionId: string;
+	sessionName: string;
+	output: string;
+	truncated: boolean;
+	chainDepth: number;
+}
+
+export interface FilteredOutputs {
+	outputCompletions: FanInSourceCompletion[];
+	perSourceOutputs: Record<string, string>;
+	forwardedOutputs: Record<string, string>;
+}
+
+/**
+ * Build filtered output maps from completed agent outputs, honoring the
+ * subscription's `include_output_from` / `forward_output_from` lists.
+ *
+ * Shared by the fan-in tracker and the single-source completion path so both
+ * paths respect the same include/forward semantics. When the include/forward
+ * lists are undefined, every completion is treated as both included and (if
+ * forward semantics are off) not forwarded — matching the legacy default.
+ */
+export function buildFilteredOutputs(
+	completions: FanInSourceCompletion[],
+	sub: CueSubscription
+): FilteredOutputs {
+	const includeSet = sub.include_output_from ? new Set(sub.include_output_from) : null;
+	const outputCompletions = includeSet
+		? completions.filter((c) => includeSet.has(c.sessionName) || includeSet.has(c.sessionId))
+		: completions;
+
+	const perSourceOutputs: Record<string, string> = {};
+	for (const c of outputCompletions) {
+		perSourceOutputs[c.sessionName] = c.output;
+	}
+
+	const forwardSet = sub.forward_output_from ? new Set(sub.forward_output_from) : null;
+	const forwardedOutputs: Record<string, string> = {};
+	if (forwardSet) {
+		for (const c of completions) {
+			if (forwardSet.has(c.sessionName) || forwardSet.has(c.sessionId)) {
+				forwardedOutputs[c.sessionName] = c.output;
+			}
+		}
+	}
+
+	return { outputCompletions, perSourceOutputs, forwardedOutputs };
+}
+
+/**
+ * Merge upstream-forwarded data into the current completion's forwardedOutputs
+ * map. Preserves the pre-existing pass-through behavior for single-source
+ * chains — if `forward_output_from` is set on the subscription, the upstream
+ * map is filtered to only the listed names; if unset, everything passes
+ * through (backward-compatible default).
+ */
+export function mergeUpstreamForwarded(
+	forwardedOutputs: Record<string, string>,
+	upstreamForwarded: Record<string, string> | undefined,
+	sub: CueSubscription
+): Record<string, string> {
+	if (!upstreamForwarded) return forwardedOutputs;
+	const forwardSet = sub.forward_output_from ? new Set(sub.forward_output_from) : null;
+	const merged = { ...forwardedOutputs };
+	for (const [name, output] of Object.entries(upstreamForwarded)) {
+		if (!forwardSet || forwardSet.has(name)) {
+			merged[name] = output;
+		}
+	}
+	return merged;
+}

--- a/src/main/cue/cue-output-filter.ts
+++ b/src/main/cue/cue-output-filter.ts
@@ -24,6 +24,15 @@ export interface FilteredOutputs {
  * paths respect the same include/forward semantics. When the include/forward
  * lists are undefined, every completion is treated as both included and (if
  * forward semantics are off) not forwarded — matching the legacy default.
+ *
+ * **Map keying contract**: `perSourceOutputs` and `forwardedOutputs` are keyed
+ * by `sessionName` — this is load-bearing because the template-variable
+ * substitution downstream derives variable names like `{{CUE_OUTPUT_AGENT_A}}`
+ * from the key. That means two completions with the same `sessionName` but
+ * different `sessionId` values will collide: the later write wins. Session
+ * names are expected to be unique within a Cue graph — enforced at the UI
+ * layer — so in practice this is a theoretical concern, but it's documented
+ * here so callers don't assume uniqueness by sessionId.
  */
 export function buildFilteredOutputs(
 	completions: FanInSourceCompletion[],
@@ -58,6 +67,17 @@ export function buildFilteredOutputs(
  * chains — if `forward_output_from` is set on the subscription, the upstream
  * map is filtered to only the listed names; if unset, everything passes
  * through (backward-compatible default).
+ *
+ * **Known asymmetry with `buildFilteredOutputs`**: that function matches on
+ * either `sessionName` or `sessionId`, but here we only have names because
+ * `upstreamForwarded` is `Record<sessionName, output>` — the wire format
+ * doesn't carry sessionId for forwarded entries. Users who configure
+ * `forward_output_from` with session IDs will see their upstream-forwarded
+ * entries dropped at every hop beyond the direct source. Practically, this
+ * is fine because the Cue UI generates pipeline YAML using session names,
+ * not IDs — if you're hitting this, fix the YAML to use names. A proper fix
+ * would require a wire-format change (sidecar id map) and is intentionally
+ * deferred.
  */
 export function mergeUpstreamForwarded(
 	forwardedOutputs: Record<string, string>,

--- a/src/main/cue/cue-output-filter.ts
+++ b/src/main/cue/cue-output-filter.ts
@@ -86,6 +86,11 @@ export function mergeUpstreamForwarded(
 ): Record<string, string> {
 	if (!upstreamForwarded) return forwardedOutputs;
 	const forwardSet = sub.forward_output_from ? new Set(sub.forward_output_from) : null;
+	// Invariant: `forwardedOutputs` has already been filtered by
+	// `buildFilteredOutputs` against this same `sub.forward_output_from`, so
+	// every entry copied from it into `merged` is already allow-listed. We
+	// don't re-check it here — only the `upstreamForwarded` entries need the
+	// forwardSet filter applied.
 	const merged = { ...forwardedOutputs };
 	for (const [name, output] of Object.entries(upstreamForwarded)) {
 		if (!forwardSet || forwardSet.has(name)) {

--- a/src/main/cue/cue-recovery-service.ts
+++ b/src/main/cue/cue-recovery-service.ts
@@ -75,6 +75,17 @@ export function createCueRecoveryService(deps: CueRecoveryServiceDeps): CueRecov
 			const now = Date.now();
 			const gapMs = now - lastHeartbeat;
 
+			// A negative gap means the system clock jumped backward since the
+			// last heartbeat. Running reconciliation in that state would fire
+			// "missed" events that haven't actually been missed.
+			if (gapMs < 0) {
+				deps.onLog(
+					'cue',
+					`[CUE] Clock moved backward (gap: ${gapMs}ms) — skipping sleep reconciliation`
+				);
+				return;
+			}
+
 			if (gapMs < SLEEP_THRESHOLD_MS) return;
 
 			const gapMinutes = Math.round(gapMs / 60_000);

--- a/src/main/cue/cue-run-manager.ts
+++ b/src/main/cue/cue-run-manager.ts
@@ -15,6 +15,7 @@ import type { MainLogLevel } from '../../shared/logger-types';
 import type { CueEvent, CueRunResult, CueSettings, CueSubscription } from './cue-types';
 import { updateCueEventStatus, safeRecordCueEvent, safeUpdateCueEventStatus } from './cue-db';
 import { SOURCE_OUTPUT_MAX_CHARS } from './cue-fan-in-tracker';
+import { sliceHeadByChars } from './cue-text-utils';
 import { captureException } from '../utils/sentry';
 import { execFileNoThrow } from '../utils/execFile';
 import { substituteTemplateVariables, type TemplateContext } from '../../shared/templateVariables';
@@ -133,9 +134,34 @@ export function createCueRunManager(deps: CueRunManagerDeps): CueRunManager {
 			// Check for stale events
 			if (ageMs > timeoutMs) {
 				const ageMinutes = Math.round(ageMs / 60000);
+				// Record the dropped event to the activity log so users can see
+				// *why* their queued run never fired — previously these events
+				// disappeared with only a log line, making it look like a bug.
+				const droppedRunId = crypto.randomUUID();
+				safeRecordCueEvent({
+					id: droppedRunId,
+					type: entry.event.type,
+					triggerName: entry.event.triggerName,
+					sessionId,
+					subscriptionName: entry.subscriptionName,
+					status: 'timeout',
+					payload: JSON.stringify({
+						...entry.event.payload,
+						droppedFromQueue: true,
+						queuedForMs: ageMs,
+					}),
+				});
+				safeUpdateCueEventStatus(droppedRunId, 'timeout');
 				deps.onLog(
 					'cue',
-					`[CUE] Dropping stale queued event for "${sessionName}" (queued ${ageMinutes}m ago)`
+					`[CUE] Dropping stale queued event for "${sessionName}" (queued ${ageMinutes}m ago) — recorded as timeout in activity log`,
+					{
+						type: 'runFinished',
+						runId: droppedRunId,
+						sessionId,
+						subscriptionName: entry.subscriptionName,
+						status: 'timeout',
+					}
 				);
 				continue;
 			}
@@ -217,6 +243,15 @@ export function createCueRunManager(deps: CueRunManagerDeps): CueRunManager {
 				timeoutMs,
 			});
 			if (!activeRuns.has(runId)) {
+				// Engine was stopped (or run was cleared) while onCueRun was in
+				// flight. The finally block's cleanup is gated on activeRuns
+				// having this run, so without an explicit DB write the row
+				// would stay `running` forever in the activity log.
+				safeUpdateCueEventStatus(runId, runResult.status);
+				deps.onLog(
+					'cue',
+					`[CUE] Run "${subscriptionName}" completed after engine stop — status recorded (${runResult.status}), result discarded`
+				);
 				return;
 			}
 			result.status = runResult.status;
@@ -237,7 +272,7 @@ export function createCueRunManager(deps: CueRunManagerDeps): CueRunManager {
 					id: crypto.randomUUID(),
 					payload: {
 						...event.payload,
-						sourceOutput: result.stdout.substring(0, SOURCE_OUTPUT_MAX_CHARS),
+						sourceOutput: sliceHeadByChars(result.stdout, SOURCE_OUTPUT_MAX_CHARS),
 						outputPromptPhase: true,
 					},
 				};
@@ -256,8 +291,13 @@ export function createCueRunManager(deps: CueRunManagerDeps): CueRunManager {
 				const run = activeRuns.get(runId);
 				if (run) run.processRunId = outputRunId;
 
-				const contextPrompt = `${outputPrompt}\n\n---\n\nContext from completed task:\n${result.stdout.substring(0, SOURCE_OUTPUT_MAX_CHARS)}`;
-				let outputResult: CueRunResult;
+				const contextPrompt = `${outputPrompt}\n\n---\n\nContext from completed task:\n${sliceHeadByChars(result.stdout, SOURCE_OUTPUT_MAX_CHARS)}`;
+				// Wrap the output-prompt phase in try/finally so the DB row is
+				// ALWAYS finalized — even if both the run and the status-update
+				// call fail. Without this, a double-failure leaves the row
+				// stuck at `running` and the activity log shows a phantom run.
+				let outputResult: CueRunResult | undefined;
+				let outputStatus: CueRunResult['status'] = 'failed';
 				try {
 					outputResult = await deps.onCueRun({
 						runId: outputRunId,
@@ -267,28 +307,29 @@ export function createCueRunManager(deps: CueRunManagerDeps): CueRunManager {
 						event: outputEvent,
 						timeoutMs,
 					});
-				} catch (outputErr) {
-					// onCueRun rejected — the outputRunId DB row is still 'running'
-					// because safeUpdateCueEventStatus below was skipped. Finalize it
-					// here so the activity log doesn't show a phantom never-ending
-					// run, then re-throw so the outer catch records the failure on
-					// the parent run.
-					safeUpdateCueEventStatus(outputRunId, 'failed');
-					throw outputErr;
+					outputStatus = outputResult.status;
+				} finally {
+					try {
+						safeUpdateCueEventStatus(outputRunId, outputStatus);
+					} catch (finalizeErr) {
+						captureException(finalizeErr, {
+							operation: 'cue:finalizeOutputRunStatus',
+							outputRunId,
+							outputStatus,
+						});
+					}
 				}
-
-				safeUpdateCueEventStatus(outputRunId, outputResult.status);
 
 				if (!activeRuns.has(runId)) {
 					return;
 				}
 
-				if (outputResult.status === 'completed') {
+				if (outputResult && outputResult.status === 'completed') {
 					result.stdout = outputResult.stdout;
 				} else {
 					deps.onLog(
 						'cue',
-						`[CUE] "${subscriptionName}" output prompt failed (${outputResult.status}), using main task output`
+						`[CUE] "${subscriptionName}" output prompt failed (${outputStatus}), using main task output`
 					);
 				}
 			}
@@ -321,7 +362,7 @@ export function createCueRunManager(deps: CueRunManagerDeps): CueRunManager {
 							`[CUE] "${subscriptionName}" CLI output target resolved to empty string (raw="${cliOutput.target}") — skipping delivery`
 						);
 					} else {
-						const truncatedOutput = result.stdout.substring(0, 100_000);
+						const truncatedOutput = sliceHeadByChars(result.stdout, 100_000);
 						const cliScriptPath = require('path').join(
 							process.resourcesPath ?? '',
 							'maestro-cli.js'

--- a/src/main/cue/cue-run-manager.ts
+++ b/src/main/cue/cue-run-manager.ts
@@ -279,13 +279,18 @@ export function createCueRunManager(deps: CueRunManagerDeps): CueRunManager {
 					`[CUE] "${subscriptionName}" executing output prompt for downstream handoff`
 				);
 
+				// Compute the sliced output ONCE — used for both the recorded
+				// payload's sourceOutput and the context prompt below. The prior
+				// code called sliceHeadByChars twice with identical arguments.
+				const slicedOutput = sliceHeadByChars(result.stdout, SOURCE_OUTPUT_MAX_CHARS);
+
 				const outputRunId = crypto.randomUUID();
 				const outputEvent: CueEvent = {
 					...event,
 					id: crypto.randomUUID(),
 					payload: {
 						...event.payload,
-						sourceOutput: sliceHeadByChars(result.stdout, SOURCE_OUTPUT_MAX_CHARS),
+						sourceOutput: slicedOutput,
 						outputPromptPhase: true,
 					},
 				};
@@ -304,7 +309,7 @@ export function createCueRunManager(deps: CueRunManagerDeps): CueRunManager {
 				const run = activeRuns.get(runId);
 				if (run) run.processRunId = outputRunId;
 
-				const contextPrompt = `${outputPrompt}\n\n---\n\nContext from completed task:\n${sliceHeadByChars(result.stdout, SOURCE_OUTPUT_MAX_CHARS)}`;
+				const contextPrompt = `${outputPrompt}\n\n---\n\nContext from completed task:\n${slicedOutput}`;
 				// Wrap the output-prompt phase in try/finally so the DB row is
 				// ALWAYS finalized — even if both the run and the status-update
 				// call fail. Without this, a double-failure leaves the row
@@ -341,6 +346,26 @@ export function createCueRunManager(deps: CueRunManagerDeps): CueRunManager {
 				}
 
 				if (!activeRuns.has(runId)) {
+					// Engine reset between the main task finishing and the output
+					// prompt completing. The output-phase DB row was finalized in
+					// the inner finally above, but the PARENT runId is still
+					// `running` because the outer finally at the bottom of this
+					// function is gated on `activeRuns.has(runId)` — which is now
+					// false. Finalize it here so the activity log doesn't show a
+					// phantom never-ending run. Mirrors the earlier handling at
+					// line ~245 for the pre-output-prompt case.
+					safeUpdateCueEventStatus(runId, result.status);
+					deps.onLog(
+						'cue',
+						`[CUE] Run "${subscriptionName}" output phase completed after engine stop — parent status recorded (${result.status}), result discarded`,
+						{
+							type: 'runFinished',
+							runId,
+							sessionId,
+							subscriptionName,
+							status: result.status,
+						}
+					);
 					return;
 				}
 

--- a/src/main/cue/cue-run-manager.ts
+++ b/src/main/cue/cue-run-manager.ts
@@ -138,6 +138,9 @@ export function createCueRunManager(deps: CueRunManagerDeps): CueRunManager {
 				// *why* their queued run never fired — previously these events
 				// disappeared with only a log line, making it look like a bug.
 				const droppedRunId = crypto.randomUUID();
+				// We record the event directly in its final `timeout` state, so
+				// there's no separate running→timeout flip needed — the row is
+				// born finalized (unlike normal runs, which start as `running`).
 				safeRecordCueEvent({
 					id: droppedRunId,
 					type: entry.event.type,
@@ -151,7 +154,6 @@ export function createCueRunManager(deps: CueRunManagerDeps): CueRunManager {
 						queuedForMs: ageMs,
 					}),
 				});
-				safeUpdateCueEventStatus(droppedRunId, 'timeout');
 				deps.onLog(
 					'cue',
 					`[CUE] Dropping stale queued event for "${sessionName}" (queued ${ageMinutes}m ago) — recorded as timeout in activity log`,
@@ -248,9 +250,20 @@ export function createCueRunManager(deps: CueRunManagerDeps): CueRunManager {
 				// having this run, so without an explicit DB write the row
 				// would stay `running` forever in the activity log.
 				safeUpdateCueEventStatus(runId, runResult.status);
+				// Emit with the structured runFinished payload so live
+				// listeners (activity log, queue indicators) observe the
+				// transition identically to a normal completion — this is
+				// what renderer subscribers key off of.
 				deps.onLog(
 					'cue',
-					`[CUE] Run "${subscriptionName}" completed after engine stop — status recorded (${runResult.status}), result discarded`
+					`[CUE] Run "${subscriptionName}" completed after engine stop — status recorded (${runResult.status}), result discarded`,
+					{
+						type: 'runFinished',
+						runId,
+						sessionId,
+						subscriptionName,
+						status: runResult.status,
+					}
 				);
 				return;
 			}

--- a/src/main/cue/cue-run-manager.ts
+++ b/src/main/cue/cue-run-manager.ts
@@ -322,8 +322,15 @@ export function createCueRunManager(deps: CueRunManagerDeps): CueRunManager {
 					});
 					outputStatus = outputResult.status;
 				} finally {
+					// Use the raw (throwing) updateCueEventStatus with our own
+					// try/catch so the Sentry `operation` tag is specific to
+					// this call site — distinguishing "output-phase finalize
+					// failed" from generic "status update failed" when
+					// triaging reports. The `safe*` wrappers tag everything
+					// as `safeUpdateCueEventStatus`, which is too coarse to
+					// tell this failure mode apart from a normal run update.
 					try {
-						safeUpdateCueEventStatus(outputRunId, outputStatus);
+						updateCueEventStatus(outputRunId, outputStatus);
 					} catch (finalizeErr) {
 						captureException(finalizeErr, {
 							operation: 'cue:finalizeOutputRunStatus',

--- a/src/main/cue/cue-text-utils.ts
+++ b/src/main/cue/cue-text-utils.ts
@@ -1,0 +1,63 @@
+/**
+ * Text utilities for Cue — specifically for slicing user-facing output before
+ * it's passed to downstream subscriptions or persisted.
+ *
+ * Plain `.slice()` / `.substring()` on a JS string operates on UTF-16 code
+ * units, which means an emoji or supplementary-plane character (encoded as a
+ * surrogate pair) can be split down the middle. The result is an orphan
+ * surrogate that downstream consumers see as a replacement character or a
+ * mojibake artifact. Worse, if the output is later serialized to a shell
+ * command or file, some tools reject invalid UTF-8 altogether.
+ *
+ * These helpers snap slice boundaries back to the nearest valid code-point
+ * edge so Cue never forwards corrupted text.
+ */
+
+const HIGH_SURROGATE_MIN = 0xd800;
+const HIGH_SURROGATE_MAX = 0xdbff;
+const LOW_SURROGATE_MIN = 0xdc00;
+const LOW_SURROGATE_MAX = 0xdfff;
+
+function isHighSurrogate(code: number): boolean {
+	return code >= HIGH_SURROGATE_MIN && code <= HIGH_SURROGATE_MAX;
+}
+
+function isLowSurrogate(code: number): boolean {
+	return code >= LOW_SURROGATE_MIN && code <= LOW_SURROGATE_MAX;
+}
+
+/**
+ * Take the last `maxChars` code units of `s`, but if the slice starts in the
+ * middle of a surrogate pair, shift the start forward by one so the result
+ * contains only complete code points.
+ */
+export function sliceTailByChars(s: string, maxChars: number): string {
+	if (maxChars <= 0 || s.length === 0) return '';
+	if (s.length <= maxChars) return s;
+	let start = s.length - maxChars;
+	// If the slice starts on a low surrogate, the matching high surrogate is
+	// one code unit earlier — drop the low surrogate to keep the result valid.
+	if (start > 0 && isLowSurrogate(s.charCodeAt(start))) {
+		start += 1;
+	}
+	return s.slice(start);
+}
+
+/**
+ * Take the first `maxChars` code units of `s`, but if that position lands
+ * between a high and low surrogate, step back by one so the trailing code
+ * point is either included whole or excluded entirely.
+ */
+export function sliceHeadByChars(s: string, maxChars: number): string {
+	if (maxChars <= 0 || s.length === 0) return '';
+	if (s.length <= maxChars) return s;
+	let end = maxChars;
+	if (
+		end < s.length &&
+		isHighSurrogate(s.charCodeAt(end - 1)) &&
+		isLowSurrogate(s.charCodeAt(end))
+	) {
+		end -= 1;
+	}
+	return s.slice(0, end);
+}

--- a/src/main/cue/pipeline-layout-store.ts
+++ b/src/main/cue/pipeline-layout-store.ts
@@ -5,12 +5,21 @@
  *
  * The IPC handler delegates to this module so that the file location and the
  * read/write semantics live in exactly one place — see Phase 6 cleanup.
+ *
+ * V1 → V2 migration: older files have a top-level `selectedPipelineId` and
+ * `viewport` without the `perProject` map. On load, we fold those values into
+ * the first pipeline's project root (or a default key) so users keep their
+ * view state on first upgrade; the next successful save writes v2 shape.
  */
 
 import * as fs from 'fs';
 import * as path from 'path';
 import { app } from 'electron';
-import type { PipelineLayoutState } from '../../shared/cue-pipeline-types';
+import {
+	PIPELINE_LAYOUT_DEFAULT_PROJECT_KEY,
+	type PipelineLayoutState,
+	type PipelineProjectViewState,
+} from '../../shared/cue-pipeline-types';
 import { captureException } from '../utils/sentry';
 
 let cachedLayoutFilePath: string | null = null;
@@ -22,9 +31,45 @@ function getLayoutFilePath(): string {
 	return cachedLayoutFilePath;
 }
 
+/**
+ * Migrate a v1 layout (no `version` field, no `perProject`) to v2.
+ *
+ * The main process doesn't know which project owns which pipeline (that
+ * mapping is computed in the renderer from session data), so we can't pick
+ * a real project root here. Instead we fold the legacy top-level
+ * `selectedPipelineId` / `viewport` into the `__default__` project key. The
+ * renderer falls back to that key when its active project has no entry yet,
+ * and the next save writes the state under the real project root.
+ */
+function migrateLegacyLayout(layout: PipelineLayoutState): PipelineLayoutState {
+	if (layout.version === 2 && layout.perProject) return layout;
+
+	const perProject: Record<string, PipelineProjectViewState> = { ...(layout.perProject ?? {}) };
+	if (
+		(layout.selectedPipelineId !== null && layout.selectedPipelineId !== undefined) ||
+		layout.viewport
+	) {
+		if (!perProject[PIPELINE_LAYOUT_DEFAULT_PROJECT_KEY]) {
+			perProject[PIPELINE_LAYOUT_DEFAULT_PROJECT_KEY] = {
+				selectedPipelineId: layout.selectedPipelineId ?? null,
+				viewport: layout.viewport,
+			};
+		}
+	}
+
+	return { ...layout, version: 2, perProject };
+}
+
 export function savePipelineLayout(layout: PipelineLayoutState): void {
 	const filePath = getLayoutFilePath();
-	fs.writeFileSync(filePath, JSON.stringify(layout, null, 2), 'utf-8');
+	// Always stamp the version so we know the on-disk shape and never
+	// accidentally treat a freshly-written file as legacy on next load.
+	const normalized: PipelineLayoutState = {
+		...layout,
+		version: 2,
+		perProject: layout.perProject ?? {},
+	};
+	fs.writeFileSync(filePath, JSON.stringify(normalized, null, 2), 'utf-8');
 }
 
 export function loadPipelineLayout(): PipelineLayoutState | null {
@@ -34,7 +79,8 @@ export function loadPipelineLayout(): PipelineLayoutState | null {
 	}
 	try {
 		const content = fs.readFileSync(filePath, 'utf-8');
-		return JSON.parse(content) as PipelineLayoutState;
+		const parsed = JSON.parse(content) as PipelineLayoutState;
+		return migrateLegacyLayout(parsed);
 	} catch (error) {
 		const err = error instanceof Error ? error : new Error(String(error));
 		captureException(err, { extra: { filePath, operation: 'cue.loadPipelineLayout' } });

--- a/src/main/cue/pipeline-layout-store.ts
+++ b/src/main/cue/pipeline-layout-store.ts
@@ -57,7 +57,22 @@ function migrateLegacyLayout(layout: PipelineLayoutState): PipelineLayoutState {
 		}
 	}
 
-	return { ...layout, version: 2, perProject };
+	// Strip the legacy top-level fields now that we've folded them into
+	// `perProject`. Leaving them in place meant every save re-serialized
+	// stale values that drifted out of sync with the per-project entries,
+	// and re-opening in a new build would re-migrate the stale copies.
+	const { selectedPipelineId: _legacySelected, viewport: _legacyViewport, ...rest } = layout;
+	void _legacySelected;
+	void _legacyViewport;
+	return {
+		...rest,
+		version: 2,
+		// Preserve selectedPipelineId on the return type (it's required, not
+		// optional, to keep v1 readers compiling) but set it to null since
+		// the authoritative value now lives under perProject.
+		selectedPipelineId: null,
+		perProject,
+	};
 }
 
 export function savePipelineLayout(layout: PipelineLayoutState): void {
@@ -79,8 +94,24 @@ export function loadPipelineLayout(): PipelineLayoutState | null {
 	}
 	try {
 		const content = fs.readFileSync(filePath, 'utf-8');
-		const parsed = JSON.parse(content) as PipelineLayoutState;
-		return migrateLegacyLayout(parsed);
+		const parsed = JSON.parse(content) as unknown;
+		// Defend against valid-JSON-but-wrong-shape files: `null`, arrays,
+		// strings, and primitives all parse successfully but would crash
+		// migrateLegacyLayout's spread/property access. Treat them as if
+		// the file didn't exist — a fresh empty state is safer than a hard
+		// error on app launch.
+		if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+			captureException(new Error('pipeline layout JSON was not a plain object'), {
+				extra: {
+					filePath,
+					operation: 'cue.loadPipelineLayout',
+					reason: 'invalid parsed type',
+					parsedType: Array.isArray(parsed) ? 'array' : typeof parsed,
+				},
+			});
+			return null;
+		}
+		return migrateLegacyLayout(parsed as PipelineLayoutState);
 	} catch (error) {
 		const err = error instanceof Error ? error : new Error(String(error));
 		captureException(err, { extra: { filePath, operation: 'cue.loadPipelineLayout' } });

--- a/src/main/ipc/handlers/cue.ts
+++ b/src/main/ipc/handlers/cue.ts
@@ -231,12 +231,31 @@ export function registerCueHandlers(deps: CueHandlerDependencies): void {
 				if (options.promptFiles) {
 					const promptsBase = path.resolve(options.projectRoot, '.maestro/prompts');
 					for (const [relativePath, content] of Object.entries(options.promptFiles)) {
+						// Reject obviously malformed keys before path.resolve — empty
+						// strings would resolve to the project root itself, and
+						// pre-normalized `..` segments make the containment check
+						// harder to reason about even though resolve normalizes them.
+						if (typeof relativePath !== 'string' || relativePath.length === 0) {
+							throw new Error('cue:writeYaml: promptFiles key must be a non-empty string');
+						}
 						if (path.isAbsolute(relativePath)) {
 							throw new Error(
 								`cue:writeYaml: promptFiles key must be a relative path, got "${relativePath}"`
 							);
 						}
-						const target = path.resolve(options.projectRoot, relativePath);
+						// Normalize backslashes to forward-slashes BEFORE path.resolve on
+						// non-Windows. A Windows-authored YAML shipping with a key like
+						// `prompts\sub.md` would otherwise create a literal file called
+						// `prompts\sub.md` on macOS/Linux, silently orphaning the real
+						// prompts/ directory next save.
+						const normalizedKey =
+							path.sep === '/' ? relativePath.replace(/\\/g, '/') : relativePath;
+						if (normalizedKey.split(/[/\\]/).some((segment) => segment === '..')) {
+							throw new Error(
+								`cue:writeYaml: promptFiles key "${relativePath}" contains parent-directory segment`
+							);
+						}
+						const target = path.resolve(options.projectRoot, normalizedKey);
 						// Must resolve strictly INSIDE .maestro/prompts/. The earlier
 						// check allowed `target === promptsBase` which would attempt
 						// to write to the directory path itself.
@@ -252,8 +271,8 @@ export function registerCueHandlers(deps: CueHandlerDependencies): void {
 						if (path.extname(target).toLowerCase() !== '.md') {
 							throw new Error(`cue:writeYaml: promptFiles key "${relativePath}" must end with .md`);
 						}
-						writeCuePromptFile(options.projectRoot, relativePath, content);
-						keepPaths.add(relativePath);
+						writeCuePromptFile(options.projectRoot, normalizedKey, content);
+						keepPaths.add(normalizedKey);
 					}
 				}
 

--- a/src/main/ipc/handlers/cue.ts
+++ b/src/main/ipc/handlers/cue.ts
@@ -250,9 +250,15 @@ export function registerCueHandlers(deps: CueHandlerDependencies): void {
 						// prompts/ directory next save.
 						const normalizedKey =
 							path.sep === '/' ? relativePath.replace(/\\/g, '/') : relativePath;
-						if (normalizedKey.split(/[/\\]/).some((segment) => segment === '..')) {
+						// Reject both '..' (escapes the prompts dir) and '.' (harmless
+						// but ambiguous — `foo/.` and `foo` refer to the same file,
+						// so accepting both breaks the keep-set invariant that
+						// distinct keys map to distinct files on disk).
+						if (
+							normalizedKey.split(/[/\\]/).some((segment) => segment === '..' || segment === '.')
+						) {
 							throw new Error(
-								`cue:writeYaml: promptFiles key "${relativePath}" contains parent-directory segment`
+								`cue:writeYaml: promptFiles key "${relativePath}" contains "." or ".." segment`
 							);
 						}
 						const target = path.resolve(options.projectRoot, normalizedKey);

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -314,7 +314,8 @@ function MaestroConsoleInner() {
 		setDirectorNotesOpen,
 		// Maestro Cue Modal — cueModalOpen now self-sourced in AppStandaloneModals
 		setCueModalOpen,
-		// Maestro Cue YAML Editor — open state, sessionId, projectRoot, closeCueYamlEditor now self-sourced in AppStandaloneModals
+		// Maestro Cue YAML Editor — open state, sessionId, projectRoot self-sourced in AppStandaloneModals
+		closeCueYamlEditor,
 	} = useModalActions();
 
 	// --- MOBILE LANDSCAPE MODE (reading-only view) ---
@@ -438,6 +439,13 @@ function MaestroConsoleInner() {
 	useEffect(() => {
 		if (!encoreFeatures.usageStats) setUsageDashboardOpen(false);
 	}, [encoreFeatures.usageStats, setUsageDashboardOpen]);
+
+	useEffect(() => {
+		if (!encoreFeatures.maestroCue) {
+			setCueModalOpen(false);
+			closeCueYamlEditor();
+		}
+	}, [encoreFeatures.maestroCue, setCueModalOpen, closeCueYamlEditor]);
 
 	// --- KEYBOARD SHORTCUT HELPERS ---
 	const { isShortcut, isTabShortcut } = useKeyboardShortcutHelpers({

--- a/src/renderer/components/CuePipelineEditor/panels/AgentConfigPanel.tsx
+++ b/src/renderer/components/CuePipelineEditor/panels/AgentConfigPanel.tsx
@@ -105,9 +105,8 @@ export function AgentConfigPanel({
 
 	// Single pass over `pipelines` derives both values we need downstream:
 	//   - `owningPipeline`: the pipeline containing THIS node by node.id.
-	//     UpstreamSourcesPanel treats its `pipeline` prop as identity-stable,
-	//     so we memoize to avoid defeating its downstream memoization with a
-	//     fresh object each render.
+	//     Used as the input to `computeTransitiveUpstream` below. Memoized
+	//     so the transitive-walk memo's input stays referentially stable.
 	//   - `agentPipelines`: every pipeline containing this AGENT (by
 	//     sessionId). The same agent can appear in multiple pipelines, so
 	//     this is a superset of `owningPipeline`.
@@ -396,13 +395,14 @@ export function AgentConfigPanel({
 
 			{/* Upstream Sources — per-source output controls. The panel self-gates
 			    when there are no direct OR forwarded sources, so an agent with
-			    only forwarded upstream still sees the box. */}
+			    only forwarded upstream still sees the box. We hand it the
+			    pre-computed `forwardedUpstream` list so the transitive graph
+			    walk runs once per render up here, not again inside the panel. */}
 			<UpstreamSourcesPanel
 				theme={theme}
 				incomingAgentEdges={incomingAgentEdges ?? []}
 				onUpdateEdge={onUpdateEdge}
-				pipeline={owningPipeline}
-				targetNodeId={node.id}
+				forwardedSources={forwardedUpstream}
 			/>
 
 			{/* Fan-in Settings — full width below prompts */}

--- a/src/renderer/components/CuePipelineEditor/panels/AgentConfigPanel.tsx
+++ b/src/renderer/components/CuePipelineEditor/panels/AgentConfigPanel.tsx
@@ -10,7 +10,6 @@ import { ExternalLink } from 'lucide-react';
 import type { Theme } from '../../../types';
 import {
 	CUE_COLOR,
-	sanitizeVarName,
 	type PipelineNode,
 	type PipelineEdge,
 	type AgentNodeData,
@@ -22,6 +21,7 @@ import { useDebouncedCallback } from '../../../hooks/utils';
 import type { IncomingTriggerEdgeInfo } from './NodeConfigPanel';
 import { EdgePromptRow } from './EdgePromptRow';
 import { CueSelect } from './CueSelect';
+import { UpstreamSourcesPanel } from './UpstreamSourcesPanel';
 import { getInputStyle, getLabelStyle } from './triggers/triggerConfigStyles';
 
 interface AgentConfigPanelProps {
@@ -350,192 +350,16 @@ export function AgentConfigPanel({
 				</div>
 			</div>
 
-			{/* Upstream Sources — per-source output controls */}
-			{hasIncomingAgentEdges && incomingAgentEdges && incomingAgentEdges.length > 0 && (
-				<div
-					style={{
-						padding: '10px 12px',
-						backgroundColor: `${CUE_COLOR}08`,
-						border: `1px solid ${theme.colors.border}`,
-						borderRadius: 6,
-						display: 'flex',
-						flexDirection: 'column',
-						gap: 6,
-						flexShrink: 0,
-					}}
-				>
-					<div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-						<div style={{ fontSize: 11, fontWeight: 600, color: theme.colors.textMain }}>
-							Upstream Sources
-						</div>
-						<div
-							style={{
-								fontSize: 10,
-								color: theme.colors.textDim,
-								backgroundColor: `${CUE_COLOR}15`,
-								padding: '2px 8px',
-								borderRadius: 10,
-							}}
-						>
-							{incomingAgentEdges.length} source{incomingAgentEdges.length !== 1 ? 's' : ''}
-						</div>
-					</div>
-					<div style={{ color: theme.colors.textDim, fontSize: 10 }}>
-						Control how each upstream agent's output flows through this node
-					</div>
-
-					{/* Per-source rows */}
-					{incomingAgentEdges.map((edge) => {
-						const varSuffix = sanitizeVarName(edge.sourceSessionName);
-						const editable = !!onUpdateEdge;
-						return (
-							<div
-								key={edge.edgeId}
-								style={{
-									display: 'flex',
-									alignItems: 'center',
-									gap: 10,
-									padding: '6px 8px',
-									backgroundColor: theme.colors.bgMain,
-									borderRadius: 4,
-									border: `1px solid ${theme.colors.border}`,
-								}}
-							>
-								{/* Source name */}
-								<div
-									style={{
-										fontSize: 11,
-										fontWeight: 500,
-										color: theme.colors.textMain,
-										minWidth: 80,
-										flex: '0 0 auto',
-									}}
-								>
-									{edge.sourceSessionName}
-								</div>
-
-								{/* Include toggle */}
-								<label
-									style={{
-										display: 'flex',
-										alignItems: 'center',
-										gap: 4,
-										fontSize: 10,
-										color: edge.includeUpstreamOutput
-											? theme.colors.textMain
-											: theme.colors.textDim,
-										cursor: editable ? 'pointer' : 'default',
-										opacity: editable ? 1 : 0.5,
-										flex: '0 0 auto',
-									}}
-								>
-									<input
-										type="checkbox"
-										checked={edge.includeUpstreamOutput}
-										disabled={!editable}
-										onChange={(e) => {
-											onUpdateEdge!(edge.edgeId, {
-												includeUpstreamOutput: e.target.checked,
-											});
-										}}
-										style={{ accentColor: CUE_COLOR }}
-									/>
-									Include
-								</label>
-
-								{/* Forward toggle */}
-								<label
-									style={{
-										display: 'flex',
-										alignItems: 'center',
-										gap: 4,
-										fontSize: 10,
-										color: edge.forwardOutput ? theme.colors.textMain : theme.colors.textDim,
-										cursor: editable ? 'pointer' : 'default',
-										opacity: editable ? 1 : 0.5,
-										flex: '0 0 auto',
-									}}
-								>
-									<input
-										type="checkbox"
-										checked={edge.forwardOutput}
-										disabled={!editable}
-										onChange={(e) => {
-											onUpdateEdge!(edge.edgeId, {
-												forwardOutput: e.target.checked,
-											});
-										}}
-										style={{ accentColor: CUE_COLOR }}
-									/>
-									Forward
-								</label>
-
-								{/* Per-source variable token chips */}
-								<div
-									style={{
-										display: 'flex',
-										gap: 4,
-										marginLeft: 'auto',
-										flexShrink: 0,
-										alignItems: 'center',
-									}}
-								>
-									{edge.includeUpstreamOutput && (
-										<code
-											style={{
-												fontSize: 9,
-												color: CUE_COLOR,
-												backgroundColor: `${CUE_COLOR}10`,
-												padding: '1px 5px',
-												borderRadius: 3,
-												userSelect: 'all',
-											}}
-										>
-											{'{{'}CUE_OUTPUT_{varSuffix}
-											{'}}'}
-										</code>
-									)}
-									{edge.forwardOutput && (
-										<code
-											style={{
-												fontSize: 9,
-												color: theme.colors.textDim,
-												backgroundColor: `${theme.colors.textDim}15`,
-												padding: '1px 5px',
-												borderRadius: 3,
-												userSelect: 'all',
-											}}
-										>
-											{'{{'}CUE_FORWARDED_{varSuffix}
-											{'}}'}
-										</code>
-									)}
-									{!edge.includeUpstreamOutput && !edge.forwardOutput && (
-										<span
-											style={{
-												fontSize: 9,
-												color: theme.colors.textDim,
-												opacity: 0.6,
-												fontStyle: 'italic',
-											}}
-										>
-											trigger only
-										</span>
-									)}
-								</div>
-							</div>
-						);
-					})}
-
-					{/* Combined variable hint */}
-					{incomingAgentEdges.some((e) => e.includeUpstreamOutput) && (
-						<div style={{ fontSize: 10, color: theme.colors.textDim, opacity: 0.7 }}>
-							{'{{CUE_SOURCE_OUTPUT}}'} combines all included sources. Use per-source variables
-							above for fine-grained placement.
-						</div>
-					)}
-				</div>
-			)}
+			{/* Upstream Sources — per-source output controls. The panel self-gates
+			    when there are no direct OR forwarded sources, so an agent with
+			    only forwarded upstream still sees the box. */}
+			<UpstreamSourcesPanel
+				theme={theme}
+				incomingAgentEdges={incomingAgentEdges ?? []}
+				onUpdateEdge={onUpdateEdge}
+				pipeline={pipelines.find((p) => p.nodes.some((n) => n.id === node.id))}
+				targetNodeId={node.id}
+			/>
 
 			{/* Fan-in Settings — full width below prompts */}
 			{(incomingAgentEdgeCount ?? 0) > 1 && (

--- a/src/renderer/components/CuePipelineEditor/panels/AgentConfigPanel.tsx
+++ b/src/renderer/components/CuePipelineEditor/panels/AgentConfigPanel.tsx
@@ -5,7 +5,7 @@
  * upstream output inclusion, and pipeline membership display.
  */
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { ExternalLink } from 'lucide-react';
 import type { Theme } from '../../../types';
 import {
@@ -102,11 +102,26 @@ export function AgentConfigPanel({
 		[debouncedUpdateOutput]
 	);
 
-	// Find which pipelines contain this agent
-	const agentPipelines = pipelines.filter((p) =>
-		p.nodes.some(
-			(n) => n.type === 'agent' && (n.data as AgentNodeData).sessionId === data.sessionId
-		)
+	// Find which pipelines contain this agent. Memoized so the derived value
+	// stays referentially stable across renders — UpstreamSourcesPanel treats
+	// the `pipeline` prop as identity-stable, and a fresh object on each
+	// render would defeat its memoization downstream.
+	const agentPipelines = useMemo(
+		() =>
+			pipelines.filter((p) =>
+				p.nodes.some(
+					(n) => n.type === 'agent' && (n.data as AgentNodeData).sessionId === data.sessionId
+				)
+			),
+		[pipelines, data.sessionId]
+	);
+
+	// The specific pipeline that owns THIS node (by node.id, not sessionId —
+	// the same agent can appear in multiple pipelines). Memoized with the
+	// same reasoning as agentPipelines above.
+	const owningPipeline = useMemo(
+		() => pipelines.find((p) => p.nodes.some((n) => n.id === node.id)),
+		[pipelines, node.id]
 	);
 
 	// Detect if this agent has an incoming edge from a GitHub trigger
@@ -357,7 +372,7 @@ export function AgentConfigPanel({
 				theme={theme}
 				incomingAgentEdges={incomingAgentEdges ?? []}
 				onUpdateEdge={onUpdateEdge}
-				pipeline={pipelines.find((p) => p.nodes.some((n) => n.id === node.id))}
+				pipeline={owningPipeline}
 				targetNodeId={node.id}
 			/>
 

--- a/src/renderer/components/CuePipelineEditor/panels/AgentConfigPanel.tsx
+++ b/src/renderer/components/CuePipelineEditor/panels/AgentConfigPanel.tsx
@@ -22,6 +22,7 @@ import type { IncomingTriggerEdgeInfo } from './NodeConfigPanel';
 import { EdgePromptRow } from './EdgePromptRow';
 import { CueSelect } from './CueSelect';
 import { UpstreamSourcesPanel } from './UpstreamSourcesPanel';
+import { computeTransitiveUpstream } from '../utils/transitiveUpstream';
 import { getInputStyle, getLabelStyle } from './triggers/triggerConfigStyles';
 
 interface AgentConfigPanelProps {
@@ -102,27 +103,48 @@ export function AgentConfigPanel({
 		[debouncedUpdateOutput]
 	);
 
-	// Find which pipelines contain this agent. Memoized so the derived value
-	// stays referentially stable across renders — UpstreamSourcesPanel treats
-	// the `pipeline` prop as identity-stable, and a fresh object on each
-	// render would defeat its memoization downstream.
-	const agentPipelines = useMemo(
-		() =>
-			pipelines.filter((p) =>
-				p.nodes.some(
-					(n) => n.type === 'agent' && (n.data as AgentNodeData).sessionId === data.sessionId
-				)
-			),
-		[pipelines, data.sessionId]
-	);
+	// Single pass over `pipelines` derives both values we need downstream:
+	//   - `owningPipeline`: the pipeline containing THIS node by node.id.
+	//     UpstreamSourcesPanel treats its `pipeline` prop as identity-stable,
+	//     so we memoize to avoid defeating its downstream memoization with a
+	//     fresh object each render.
+	//   - `agentPipelines`: every pipeline containing this AGENT (by
+	//     sessionId). The same agent can appear in multiple pipelines, so
+	//     this is a superset of `owningPipeline`.
+	// Previously these were two separate `useMemo` calls that each scanned
+	// `pipelines` independently — merging them halves the work.
+	const { owningPipeline, agentPipelines } = useMemo(() => {
+		let owning: CuePipeline | undefined;
+		const matching: CuePipeline[] = [];
+		for (const p of pipelines) {
+			let ownsThisNode = false;
+			let containsAgent = false;
+			for (const n of p.nodes) {
+				if (n.id === node.id) ownsThisNode = true;
+				if (n.type === 'agent' && (n.data as AgentNodeData).sessionId === data.sessionId) {
+					containsAgent = true;
+				}
+				if (ownsThisNode && containsAgent) break;
+			}
+			if (ownsThisNode && !owning) owning = p;
+			if (containsAgent) matching.push(p);
+		}
+		return { owningPipeline: owning, agentPipelines: matching };
+	}, [pipelines, node.id, data.sessionId]);
 
-	// The specific pipeline that owns THIS node (by node.id, not sessionId —
-	// the same agent can appear in multiple pipelines). Memoized with the
-	// same reasoning as agentPipelines above.
-	const owningPipeline = useMemo(
-		() => pipelines.find((p) => p.nodes.some((n) => n.id === node.id)),
-		[pipelines, node.id]
+	// Forwarded upstream sources — these agents relay output through an
+	// intermediate node rather than having a direct edge. The layout and
+	// input-prompt hints treat direct + forwarded identically (both expose
+	// per-source template variables and render the UpstreamSourcesPanel),
+	// so we compute this once here and derive `hasAnyUpstream` from it.
+	const forwardedUpstream = useMemo(
+		() =>
+			owningPipeline
+				? computeTransitiveUpstream(owningPipeline, node.id).filter((r) => !r.isDirect)
+				: [],
+		[owningPipeline, node.id]
 	);
+	const hasAnyUpstream = !!hasIncomingAgentEdges || forwardedUpstream.length > 0;
 
 	// Detect if this agent has an incoming edge from a GitHub trigger
 	const hasGitHubTrigger = agentPipelines.some((p) => {
@@ -185,9 +207,12 @@ export function AgentConfigPanel({
 					// When upstream-sources or fan-in cards sit below, the prompts
 					// row must not greedily eat all available height. Use flex: 1
 					// with a sane minHeight so the row shrinks and the panel scrolls
-					// if needed, keeping the cards reachable.
+					// if needed, keeping the cards reachable. `hasAnyUpstream` —
+					// not just direct edges — because UpstreamSourcesPanel also
+					// renders when only forwarded sources exist, and the layout
+					// must reserve space for it in that case too.
 					flex: 1,
-					minHeight: hasIncomingAgentEdges ? 100 : 0,
+					minHeight: hasAnyUpstream ? 100 : 0,
 					minWidth: 0,
 				}}
 			>
@@ -267,8 +292,12 @@ export function AgentConfigPanel({
 								placeholder={
 									hasIncomingAgentEdges && incomingAgentEdges?.some((e) => e.includeUpstreamOutput)
 										? 'Optional — upstream output is auto-included. Add instructions to guide how the agent processes it.'
-										: hasIncomingAgentEdges
-											? 'Instructions for this agent. Use per-source variables from the card below.'
+										: hasAnyUpstream
+											? // Direct AND forwarded-only cases both show the upstream
+												// card below, so the "use per-source variables" hint
+												// applies equally — forwarded sources are reached via
+												// {{CUE_FORWARDED_<NAME>}} vars listed in the card.
+												'Instructions for this agent. Use per-source variables from the card below.'
 											: hasGitHubTrigger
 												? 'Use {{CUE_GH_URL}}, {{CUE_GH_NUMBER}}, {{CUE_GH_TITLE}}, {{CUE_GH_BODY}} etc. for GitHub context...'
 												: 'Prompt sent when this agent receives data from the pipeline...'

--- a/src/renderer/components/CuePipelineEditor/panels/UpstreamSourcesPanel.tsx
+++ b/src/renderer/components/CuePipelineEditor/panels/UpstreamSourcesPanel.tsx
@@ -1,0 +1,297 @@
+/**
+ * UpstreamSourcesPanel — per-source output controls for an agent that has
+ * one or more upstream sources (direct or forwarded).
+ *
+ * Direct and forwarded sources render as uniform rows in one table so users
+ * see every data stream arriving at this agent without having to navigate
+ * upstream. Direct rows carry Include/Forward toggles bound to the direct
+ * edge; forwarded rows are informational — they expose the available
+ * `{{CUE_FORWARDED_<NAME>}}` variable, and if the user wants to stop the
+ * forwarding they do so on the upstream relay agent itself.
+ */
+
+import type { Theme } from '../../../types';
+import {
+	CUE_COLOR,
+	sanitizeVarName,
+	type CuePipeline,
+	type IncomingAgentEdgeInfo,
+	type PipelineEdge,
+} from '../../../../shared/cue-pipeline-types';
+import { computeTransitiveUpstream } from '../utils/transitiveUpstream';
+
+interface UpstreamSourcesPanelProps {
+	theme: Theme;
+	incomingAgentEdges: IncomingAgentEdgeInfo[];
+	onUpdateEdge?: (edgeId: string, updates: Partial<PipelineEdge>) => void;
+	/** Full pipeline graph for forwarded-source discovery. When omitted the
+	 *  forwarded rows are hidden (e.g. isolated test/storybook scaffolding). */
+	pipeline?: CuePipeline;
+	/** Target node id — the agent whose upstream is being configured. */
+	targetNodeId?: string;
+}
+
+export function UpstreamSourcesPanel({
+	theme,
+	incomingAgentEdges,
+	onUpdateEdge,
+	pipeline,
+	targetNodeId,
+}: UpstreamSourcesPanelProps) {
+	const editable = !!onUpdateEdge;
+	const transitive =
+		pipeline && targetNodeId ? computeTransitiveUpstream(pipeline, targetNodeId) : [];
+	const forwardedSources = transitive.filter((r) => !r.isDirect);
+
+	if (incomingAgentEdges.length === 0 && forwardedSources.length === 0) return null;
+
+	const totalCount = incomingAgentEdges.length + forwardedSources.length;
+
+	return (
+		<div
+			style={{
+				padding: '10px 12px',
+				backgroundColor: `${CUE_COLOR}08`,
+				border: `1px solid ${theme.colors.border}`,
+				borderRadius: 6,
+				display: 'flex',
+				flexDirection: 'column',
+				gap: 6,
+				flexShrink: 0,
+			}}
+		>
+			<div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+				<div style={{ fontSize: 11, fontWeight: 600, color: theme.colors.textMain }}>
+					Upstream Sources
+				</div>
+				<div
+					style={{
+						fontSize: 10,
+						color: theme.colors.textDim,
+						backgroundColor: `${CUE_COLOR}15`,
+						padding: '2px 8px',
+						borderRadius: 10,
+					}}
+				>
+					{totalCount} source{totalCount !== 1 ? 's' : ''}
+				</div>
+			</div>
+			<div style={{ color: theme.colors.textDim, fontSize: 10 }}>
+				Control how each upstream agent's output flows through this node. Reference the variables
+				below anywhere in the prompt to position them.
+			</div>
+
+			{/* Direct edges — editable Include / Forward */}
+			{incomingAgentEdges.map((edge) => {
+				const varSuffix = sanitizeVarName(edge.sourceSessionName);
+				return (
+					<div
+						key={edge.edgeId}
+						style={{
+							display: 'flex',
+							alignItems: 'center',
+							gap: 10,
+							padding: '6px 8px',
+							backgroundColor: theme.colors.bgMain,
+							borderRadius: 4,
+							border: `1px solid ${theme.colors.border}`,
+						}}
+					>
+						<div
+							style={{
+								fontSize: 11,
+								fontWeight: 500,
+								color: theme.colors.textMain,
+								minWidth: 80,
+								flex: '0 0 auto',
+							}}
+						>
+							{edge.sourceSessionName}
+						</div>
+
+						<label
+							style={{
+								display: 'flex',
+								alignItems: 'center',
+								gap: 4,
+								fontSize: 10,
+								color: edge.includeUpstreamOutput ? theme.colors.textMain : theme.colors.textDim,
+								cursor: editable ? 'pointer' : 'default',
+								opacity: editable ? 1 : 0.5,
+								flex: '0 0 auto',
+							}}
+						>
+							<input
+								type="checkbox"
+								checked={edge.includeUpstreamOutput}
+								disabled={!editable}
+								onChange={(e) => {
+									onUpdateEdge!(edge.edgeId, {
+										includeUpstreamOutput: e.target.checked,
+									});
+								}}
+								style={{ accentColor: CUE_COLOR }}
+							/>
+							Include
+						</label>
+
+						<label
+							style={{
+								display: 'flex',
+								alignItems: 'center',
+								gap: 4,
+								fontSize: 10,
+								color: edge.forwardOutput ? theme.colors.textMain : theme.colors.textDim,
+								cursor: editable ? 'pointer' : 'default',
+								opacity: editable ? 1 : 0.5,
+								flex: '0 0 auto',
+							}}
+						>
+							<input
+								type="checkbox"
+								checked={edge.forwardOutput}
+								disabled={!editable}
+								onChange={(e) => {
+									onUpdateEdge!(edge.edgeId, {
+										forwardOutput: e.target.checked,
+									});
+								}}
+								style={{ accentColor: CUE_COLOR }}
+							/>
+							Forward
+						</label>
+
+						<div
+							style={{
+								display: 'flex',
+								gap: 4,
+								marginLeft: 'auto',
+								flexShrink: 0,
+								alignItems: 'center',
+							}}
+						>
+							{edge.includeUpstreamOutput && (
+								<code
+									style={{
+										fontSize: 9,
+										color: CUE_COLOR,
+										backgroundColor: `${CUE_COLOR}10`,
+										padding: '1px 5px',
+										borderRadius: 3,
+										userSelect: 'all',
+									}}
+								>
+									{'{{'}CUE_OUTPUT_{varSuffix}
+									{'}}'}
+								</code>
+							)}
+							{edge.forwardOutput && (
+								<code
+									style={{
+										fontSize: 9,
+										color: theme.colors.textDim,
+										backgroundColor: `${theme.colors.textDim}15`,
+										padding: '1px 5px',
+										borderRadius: 3,
+										userSelect: 'all',
+									}}
+								>
+									{'{{'}CUE_FORWARDED_{varSuffix}
+									{'}}'}
+								</code>
+							)}
+							{!edge.includeUpstreamOutput && !edge.forwardOutput && (
+								<span
+									style={{
+										fontSize: 9,
+										color: theme.colors.textDim,
+										opacity: 0.6,
+										fontStyle: 'italic',
+									}}
+								>
+									trigger only
+								</span>
+							)}
+						</div>
+					</div>
+				);
+			})}
+
+			{/* Forwarded sources — same row shape, informational (no edge to toggle at this node) */}
+			{forwardedSources.map((row) => {
+				const varSuffix = sanitizeVarName(row.source);
+				const relayLabel = row.path.slice(1).join(' → ');
+				return (
+					<div
+						key={`forwarded-${row.sourceNodeId}`}
+						style={{
+							display: 'flex',
+							alignItems: 'center',
+							gap: 10,
+							padding: '6px 8px',
+							backgroundColor: theme.colors.bgMain,
+							borderRadius: 4,
+							border: `1px dashed ${theme.colors.border}`,
+						}}
+					>
+						<div
+							style={{
+								display: 'flex',
+								flexDirection: 'column',
+								minWidth: 80,
+								flex: '0 0 auto',
+								gap: 1,
+							}}
+						>
+							<div style={{ fontSize: 11, fontWeight: 500, color: theme.colors.textMain }}>
+								{row.source}
+							</div>
+							<div style={{ fontSize: 9, color: theme.colors.textDim }}>via {relayLabel}</div>
+						</div>
+
+						<div
+							style={{
+								fontSize: 10,
+								color: theme.colors.textDim,
+								fontStyle: 'italic',
+								flex: '0 0 auto',
+							}}
+						>
+							forwarded
+						</div>
+
+						<div
+							style={{
+								display: 'flex',
+								gap: 4,
+								marginLeft: 'auto',
+								flexShrink: 0,
+								alignItems: 'center',
+							}}
+						>
+							<code
+								style={{
+									fontSize: 9,
+									color: theme.colors.textDim,
+									backgroundColor: `${theme.colors.textDim}15`,
+									padding: '1px 5px',
+									borderRadius: 3,
+									userSelect: 'all',
+								}}
+							>
+								{'{{'}CUE_FORWARDED_{varSuffix}
+								{'}}'}
+							</code>
+						</div>
+					</div>
+				);
+			})}
+
+			{incomingAgentEdges.some((e) => e.includeUpstreamOutput) && (
+				<div style={{ fontSize: 10, color: theme.colors.textDim, opacity: 0.7 }}>
+					{'{{CUE_SOURCE_OUTPUT}}'} combines all included direct sources.
+				</div>
+			)}
+		</div>
+	);
+}

--- a/src/renderer/components/CuePipelineEditor/panels/UpstreamSourcesPanel.tsx
+++ b/src/renderer/components/CuePipelineEditor/panels/UpstreamSourcesPanel.tsx
@@ -18,16 +18,27 @@ import {
 	type IncomingAgentEdgeInfo,
 	type PipelineEdge,
 } from '../../../../shared/cue-pipeline-types';
-import { computeTransitiveUpstream } from '../utils/transitiveUpstream';
+import { computeTransitiveUpstream, type TransitiveUpstream } from '../utils/transitiveUpstream';
 
 interface UpstreamSourcesPanelProps {
 	theme: Theme;
 	incomingAgentEdges: IncomingAgentEdgeInfo[];
 	onUpdateEdge?: (edgeId: string, updates: Partial<PipelineEdge>) => void;
-	/** Full pipeline graph for forwarded-source discovery. When omitted the
-	 *  forwarded rows are hidden (e.g. isolated test/storybook scaffolding). */
+	/**
+	 * Pre-filtered list of forwarded (transitive) upstream sources. When
+	 * provided, the panel uses it directly and skips its own transitive
+	 * computation. This lets callers (AgentConfigPanel) share one
+	 * `computeTransitiveUpstream` result across the panel and any sibling
+	 * logic that also needs `hasAnyUpstream`, instead of running the graph
+	 * walk twice per render. Omit for isolated storybook/test mounts — the
+	 * panel falls back to computing from `pipeline` + `targetNodeId` below.
+	 */
+	forwardedSources?: TransitiveUpstream[];
+	/** Full pipeline graph for forwarded-source discovery when
+	 *  `forwardedSources` is not supplied. */
 	pipeline?: CuePipeline;
-	/** Target node id — the agent whose upstream is being configured. */
+	/** Target node id — the agent whose upstream is being configured.
+	 *  Required together with `pipeline` for the fallback computation. */
 	targetNodeId?: string;
 }
 
@@ -35,13 +46,20 @@ export function UpstreamSourcesPanel({
 	theme,
 	incomingAgentEdges,
 	onUpdateEdge,
+	forwardedSources: forwardedSourcesProp,
 	pipeline,
 	targetNodeId,
 }: UpstreamSourcesPanelProps) {
 	const editable = !!onUpdateEdge;
-	const transitive =
-		pipeline && targetNodeId ? computeTransitiveUpstream(pipeline, targetNodeId) : [];
-	const forwardedSources = transitive.filter((r) => !r.isDirect);
+	// Prefer the pre-computed list from the caller. Only recompute when
+	// neither the list nor a pipeline is available (shouldn't happen in
+	// production paths; kept for storybook/test scaffolding that passes
+	// just a pipeline).
+	const forwardedSources =
+		forwardedSourcesProp ??
+		(pipeline && targetNodeId
+			? computeTransitiveUpstream(pipeline, targetNodeId).filter((r) => !r.isDirect)
+			: []);
 
 	if (incomingAgentEdges.length === 0 && forwardedSources.length === 0) return null;
 

--- a/src/renderer/components/CuePipelineEditor/utils/transitiveUpstream.ts
+++ b/src/renderer/components/CuePipelineEditor/utils/transitiveUpstream.ts
@@ -1,0 +1,119 @@
+/**
+ * Pure graph traversal that surfaces every agent whose output reaches a given
+ * target node — either directly (edge → target) or transitively via one or
+ * more intermediate agents that forward it through (edge with
+ * `forwardOutput: true`).
+ *
+ * Used by the UpstreamSourcesPanel to show users the complete list of data
+ * streams arriving at the target, not just direct upstream.
+ */
+
+import type {
+	AgentNodeData,
+	CuePipeline,
+	PipelineNode,
+} from '../../../../shared/cue-pipeline-types';
+
+export interface TransitiveUpstream {
+	/** Upstream agent's session name (matches perSourceOutputs / forwardedOutputs keys). */
+	source: string;
+	/** Pipeline node id of the upstream agent (stable across renames). */
+	sourceNodeId: string;
+	/** `true` if this is a direct upstream (there is an edge source → target).
+	 *  `false` if the output reaches the target via one or more relays. */
+	isDirect: boolean;
+	/** Session-name chain from the upstream to the node that delivers it to
+	 *  target, NOT including the target itself. For a direct source the path
+	 *  is `[source]`; for a transitive source reached via B, it is
+	 *  `[source, B]`. Useful for the "via B" UI label. */
+	path: string[];
+	/** For transitive sources only: the edge id where `source → next-in-path`
+	 *  carries `forwardOutput: true`. This is the edge the user would flip
+	 *  off (via the "stop at upstream" control) to cut the source off from
+	 *  the target. Undefined for direct sources. */
+	relayEdgeId?: string;
+}
+
+function agentNode(nodeById: Map<string, PipelineNode>, id: string): PipelineNode | undefined {
+	const node = nodeById.get(id);
+	return node?.type === 'agent' ? node : undefined;
+}
+
+function sessionName(node: PipelineNode): string {
+	return (node.data as AgentNodeData).sessionName;
+}
+
+export function computeTransitiveUpstream(
+	pipeline: CuePipeline,
+	targetNodeId: string
+): TransitiveUpstream[] {
+	const nodeById = new Map(pipeline.nodes.map((n) => [n.id, n]));
+	if (!nodeById.has(targetNodeId)) return [];
+
+	// Index incoming agent edges once — traversal hits these repeatedly.
+	const incomingAgentEdges = new Map<string, typeof pipeline.edges>();
+	for (const edge of pipeline.edges) {
+		if (!agentNode(nodeById, edge.source)) continue;
+		const list = incomingAgentEdges.get(edge.target) ?? [];
+		list.push(edge);
+		incomingAgentEdges.set(edge.target, list);
+	}
+
+	const targetAgent = agentNode(nodeById, targetNodeId);
+
+	const results: TransitiveUpstream[] = [];
+	const seenSources = new Set<string>();
+	// Prevent the target from appearing as its own transitive source when the
+	// pipeline contains a cycle back to it.
+	if (targetAgent) seenSources.add(sessionName(targetAgent));
+
+	// 1. Direct sources.
+	for (const edge of incomingAgentEdges.get(targetNodeId) ?? []) {
+		const src = agentNode(nodeById, edge.source);
+		if (!src) continue;
+		const name = sessionName(src);
+		if (seenSources.has(name)) continue;
+		seenSources.add(name);
+		results.push({
+			source: name,
+			sourceNodeId: src.id,
+			isDirect: true,
+			path: [name],
+		});
+	}
+
+	// 2. Transitive sources: starting from each direct source, walk upward
+	//    along edges that carry forwardOutput=true. Use a visited set to
+	//    terminate cycles (pipelines may legitimately contain them via fan-in
+	//    loopbacks).
+	const directs = [...results];
+	const visitedRelays = new Set<string>([targetNodeId]);
+
+	function walk(fromNodeId: string, pathToTarget: string[]) {
+		if (visitedRelays.has(fromNodeId)) return;
+		visitedRelays.add(fromNodeId);
+		for (const edge of incomingAgentEdges.get(fromNodeId) ?? []) {
+			if (!edge.forwardOutput) continue;
+			const src = agentNode(nodeById, edge.source);
+			if (!src) continue;
+			const name = sessionName(src);
+			if (seenSources.has(name)) continue;
+			seenSources.add(name);
+			const newPath = [name, ...pathToTarget];
+			results.push({
+				source: name,
+				sourceNodeId: src.id,
+				isDirect: false,
+				path: newPath,
+				relayEdgeId: edge.id,
+			});
+			walk(src.id, newPath);
+		}
+	}
+
+	for (const direct of directs) {
+		walk(direct.sourceNodeId, [direct.source]);
+	}
+
+	return results;
+}

--- a/src/renderer/components/CueYamlEditor/CueYamlEditor.tsx
+++ b/src/renderer/components/CueYamlEditor/CueYamlEditor.tsx
@@ -23,6 +23,7 @@ import { CueAiChat } from './CueAiChat';
 import { YamlTextEditor } from './YamlTextEditor';
 import { cueService } from '../../services/cue';
 import { captureException } from '../../utils/sentry';
+import { notifyToast } from '../../stores/notificationStore';
 
 interface CueYamlEditorProps {
 	isOpen: boolean;
@@ -143,7 +144,25 @@ export function CueYamlEditor({
 	const handleSave = useCallback(async () => {
 		if (!isValid) return;
 		await cueService.writeYaml(projectRoot, yamlContent);
-		await cueService.refreshSession(sessionId, projectRoot);
+		// Write succeeded, so the YAML IS on disk — but if refreshSession
+		// fails the engine keeps serving the stale config until the next app
+		// start. Surface that as a toast so the user knows to retry rather
+		// than thinking the save silently reverted.
+		try {
+			await cueService.refreshSession(sessionId, projectRoot);
+		} catch (err) {
+			captureException(err, {
+				extra: { operation: 'cueYamlEditor.refreshSession', projectRoot, sessionId },
+			});
+			notifyToast({
+				type: 'warning',
+				title: 'Cue config saved but engine did not reload',
+				message:
+					err instanceof Error
+						? `${err.message} — reopen the editor to retry.`
+						: 'Reopen the editor to retry the reload.',
+			});
+		}
 		onClose();
 	}, [isValid, projectRoot, yamlContent, sessionId, onClose]);
 

--- a/src/renderer/hooks/cue/usePipelineLayout.ts
+++ b/src/renderer/hooks/cue/usePipelineLayout.ts
@@ -12,13 +12,71 @@ import type {
 	CuePipelineState,
 	CueGraphSession,
 	PipelineLayoutState,
+	PipelineProjectViewState,
 } from '../../../shared/cue-pipeline-types';
+import { PIPELINE_LAYOUT_DEFAULT_PROJECT_KEY } from '../../../shared/cue-pipeline-types';
 import { graphSessionsToPipelines } from '../../components/CuePipelineEditor/utils/yamlToPipeline';
 import { mergePipelinesWithSavedLayout } from '../../components/CuePipelineEditor/utils/pipelineLayout';
 import { captureException } from '../../utils/sentry';
 import { cueService } from '../../services/cue';
 
 import type { CuePipelineSessionInfo as SessionInfo } from '../../../shared/cue-pipeline-types';
+
+/**
+ * Resolve the project root of a pipeline by walking its agent nodes and
+ * looking up their sessions. Returns the default key when the pipeline has
+ * no agent nodes or none of them have a known projectRoot.
+ */
+function resolvePipelineProjectKey(
+	pipelineId: string | null,
+	pipelines: CuePipelineState['pipelines'],
+	sessions: SessionInfo[]
+): string {
+	if (!pipelineId) return PIPELINE_LAYOUT_DEFAULT_PROJECT_KEY;
+	const pipeline = pipelines.find((p) => p.id === pipelineId);
+	if (!pipeline) return PIPELINE_LAYOUT_DEFAULT_PROJECT_KEY;
+	const sessionsById = new Map(sessions.map((s) => [s.id, s]));
+	const sessionsByName = new Map(sessions.map((s) => [s.name, s]));
+	for (const node of pipeline.nodes) {
+		if (node.type !== 'agent') continue;
+		const data = node.data as AgentNodeData;
+		const root =
+			sessionsById.get(data.sessionId)?.projectRoot ??
+			sessionsByName.get(data.sessionName)?.projectRoot;
+		if (root) return root;
+	}
+	return PIPELINE_LAYOUT_DEFAULT_PROJECT_KEY;
+}
+
+/**
+ * Pick the per-project view state to apply when restoring layout. Prefers
+ * an entry for the selected pipeline's project root, falls back to the
+ * default key (which holds v1 legacy data after migration), and finally
+ * falls back to the top-level v1 fields so fresh installs still work.
+ */
+function pickProjectViewState(
+	layout: PipelineLayoutState,
+	pipelines: CuePipelineState['pipelines'],
+	sessions: SessionInfo[]
+): PipelineProjectViewState | null {
+	const perProject = layout.perProject ?? {};
+	const projectKey = resolvePipelineProjectKey(
+		layout.selectedPipelineId ?? null,
+		pipelines,
+		sessions
+	);
+	if (perProject[projectKey]) return perProject[projectKey];
+	if (perProject[PIPELINE_LAYOUT_DEFAULT_PROJECT_KEY]) {
+		return perProject[PIPELINE_LAYOUT_DEFAULT_PROJECT_KEY];
+	}
+	if (layout.selectedPipelineId !== undefined || layout.viewport) {
+		return {
+			selectedPipelineId: layout.selectedPipelineId ?? null,
+			viewport: layout.viewport,
+		};
+	}
+	return null;
+}
 
 export interface UsePipelineLayoutParams {
 	reactFlowInstance: ReactFlowInstance;
@@ -73,16 +131,45 @@ export function usePipelineLayout({
 	const pipelineStateRef = useRef(pipelineState);
 	pipelineStateRef.current = pipelineState;
 
+	// Holds the most recently loaded `perProject` map so writes can merge new
+	// state for the active project without clobbering other projects. Updated
+	// during initial restore and after each persist.
+	const perProjectRef = useRef<Record<string, PipelineProjectViewState>>({});
+	const sessionsRef = useRef(sessions);
+	sessionsRef.current = sessions;
+
 	// Debounced layout persistence (positions + viewport + written roots)
 	const persistLayout = useCallback(() => {
 		if (layoutSaveTimerRef.current) clearTimeout(layoutSaveTimerRef.current);
 		layoutSaveTimerRef.current = setTimeout(() => {
 			const viewport = reactFlowInstance.getViewport();
 			const state = pipelineStateRef.current;
+			// Scope this viewport/selection under the current project (derived
+			// from the selected pipeline's owning agent session). Other
+			// projects' entries are preserved verbatim so switching back to
+			// them later still restores their remembered view.
+			const projectKey = resolvePipelineProjectKey(
+				state.selectedPipelineId,
+				state.pipelines,
+				sessionsRef.current
+			);
+			const nextPerProject: Record<string, PipelineProjectViewState> = {
+				...perProjectRef.current,
+				[projectKey]: {
+					selectedPipelineId: state.selectedPipelineId,
+					viewport,
+				},
+			};
+			perProjectRef.current = nextPerProject;
+
 			const layout: PipelineLayoutState = {
+				version: 2,
 				pipelines: state.pipelines,
+				// Keep top-level fields pointing at the current project so an
+				// older build reading the file still resolves sensible state.
 				selectedPipelineId: state.selectedPipelineId,
 				viewport,
+				perProject: nextPerProject,
 				// Persist the written-roots snapshot so the next mount can
 				// reseed lastWrittenRootsRef even if the originating agent has
 				// been renamed/removed (sessionId/Name lookup would miss the
@@ -171,6 +258,16 @@ export function usePipelineLayout({
 			let pipelinesForRoots: CuePipelineState['pipelines'];
 			if (savedLayout && savedLayout.pipelines) {
 				const merged = mergePipelinesWithSavedLayout(livePipelines, savedLayout);
+				// Seed the per-project cache so future saves don't stomp on
+				// sibling projects' entries.
+				perProjectRef.current = { ...(savedLayout.perProject ?? {}) };
+
+				// Pick per-project view state if the selected pipeline has an
+				// entry; fall back to legacy top-level fields via the helper.
+				const projectView = pickProjectViewState(savedLayout, merged.pipelines, sessions);
+				if (projectView) {
+					merged.selectedPipelineId = projectView.selectedPipelineId;
+				}
 
 				setPipelineState(merged);
 				savedStateRef.current = JSON.stringify(merged.pipelines);
@@ -180,7 +277,9 @@ export function usePipelineLayout({
 				// has measured the restored nodes. Applying it here on a timeout
 				// raced against `fitView` and — more importantly — against node
 				// measurement, which caused the initial canvas to appear empty.
-				if (savedLayout.viewport) {
+				if (projectView?.viewport) {
+					pendingSavedViewportRef.current = projectView.viewport;
+				} else if (savedLayout.viewport) {
 					pendingSavedViewportRef.current = savedLayout.viewport;
 				}
 			} else {

--- a/src/renderer/hooks/cue/usePipelineState.ts
+++ b/src/renderer/hooks/cue/usePipelineState.ts
@@ -196,13 +196,24 @@ export function usePipelineState({
 	// save" symptom — `convertToReactFlowNodes` skips every pipeline whose id
 	// doesn't match the selected id, so a stale selection caused the entire
 	// canvas to render empty until the editor was remounted (tab switch).
+	//
+	// Also clear node/edge selection when the owning pipeline disappears:
+	// composite IDs like `"pipelineId:nodeId"` become unresolvable otherwise
+	// and the config panel renders empty while still occupying layout space.
 	useEffect(() => {
 		const sel = pipelineState.selectedPipelineId;
 		if (sel === null) return;
 		if (pipelineState.pipelines.length === 0) return;
 		if (pipelineState.pipelines.some((p) => p.id === sel)) return;
 		setPipelineState((prev) => ({ ...prev, selectedPipelineId: null }));
-	}, [pipelineState.pipelines, pipelineState.selectedPipelineId]);
+		setSelectedNodeId(null);
+		setSelectedEdgeId(null);
+	}, [
+		pipelineState.pipelines,
+		pipelineState.selectedPipelineId,
+		setSelectedNodeId,
+		setSelectedEdgeId,
+	]);
 
 	// Determine which pipelines have active runs
 	const runningPipelineIds = useMemo(() => {

--- a/src/renderer/hooks/useCueAutoDiscovery.ts
+++ b/src/renderer/hooks/useCueAutoDiscovery.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
 import type { Session, EncoreFeatureFlags } from '../types';
 import { useSessionStore } from '../stores/sessionStore';
+import { notifyToast } from '../stores/notificationStore';
 
 /**
  * useCueAutoDiscovery — auto-discovers .maestro/cue.yaml files for sessions.
@@ -21,6 +22,10 @@ export function useCueAutoDiscovery(sessions: Session[], encoreFeatures: EncoreF
 	const prevSessionIdsRef = useRef<Set<string>>(new Set());
 	const prevMaestroCueEnabledRef = useRef<boolean>(encoreFeatures.maestroCue);
 	const initialScanDoneRef = useRef(false);
+	// Serializes in-flight enable/disable IPC calls so rapid toggles
+	// (ON → OFF → ON) can't interleave and leave the engine in a state
+	// that disagrees with the observed flag value.
+	const toggleChainRef = useRef<Promise<void>>(Promise.resolve());
 
 	// Track session additions and removals — always runs regardless of encore flag
 	useEffect(() => {
@@ -64,7 +69,9 @@ export function useCueAutoDiscovery(sessions: Session[], encoreFeatures: EncoreF
 		prevSessionIdsRef.current = currentIds;
 	}, [sessions, sessionsLoaded]);
 
-	// Track encore feature toggle
+	// Track encore feature toggle. Queues enable/disable calls on a single
+	// chain so rapid ON/OFF/ON toggles always apply in the order the user
+	// triggered them — not in IPC-response order.
 	useEffect(() => {
 		if (!sessionsLoaded) return;
 
@@ -74,28 +81,45 @@ export function useCueAutoDiscovery(sessions: Session[], encoreFeatures: EncoreF
 
 		if (wasEnabled === isEnabled) return;
 
-		if (isEnabled) {
-			window.maestro.cue
-				.enable()
-				.then(() =>
-					Promise.all(
-						sessions
-							.filter((session) => !!session.projectRoot)
-							.map((session) =>
-								window.maestro.cue
-									.refreshSession(session.id, session.projectRoot)
-									.catch((err) =>
-										console.error('[CueAutoDiscovery] Failed to refresh session:', err)
-									)
-							)
-					)
-				)
-				.catch((err) => console.error('[CueAutoDiscovery] Failed to enable Cue:', err));
-		} else {
-			// Feature was just disabled — stop the engine
-			window.maestro.cue
-				.disable()
-				.catch((err) => console.error('[CueAutoDiscovery] Failed to disable Cue:', err));
-		}
+		const sessionsSnapshot = sessions.filter((session) => !!session.projectRoot);
+
+		toggleChainRef.current = toggleChainRef.current.then(async () => {
+			if (isEnabled) {
+				try {
+					await window.maestro.cue.enable();
+					await Promise.all(
+						sessionsSnapshot.map((session) =>
+							window.maestro.cue
+								.refreshSession(session.id, session.projectRoot)
+								.catch((err) => console.error('[CueAutoDiscovery] Failed to refresh session:', err))
+						)
+					);
+				} catch (err) {
+					console.error('[CueAutoDiscovery] Failed to enable Cue:', err);
+					notifyToast({
+						type: 'error',
+						title: 'Cue engine failed to start',
+						message:
+							err instanceof Error
+								? err.message
+								: 'Re-toggle Maestro Cue in Settings → Encore Features to retry.',
+					});
+				}
+			} else {
+				try {
+					await window.maestro.cue.disable();
+				} catch (err) {
+					console.error('[CueAutoDiscovery] Failed to disable Cue:', err);
+					notifyToast({
+						type: 'error',
+						title: 'Cue engine failed to stop',
+						message:
+							err instanceof Error
+								? err.message
+								: 'The engine may still be running. Restart the app if issues persist.',
+					});
+				}
+			}
+		});
 	}, [encoreFeatures.maestroCue, sessions, sessionsLoaded]);
 }

--- a/src/renderer/hooks/useCueAutoDiscovery.ts
+++ b/src/renderer/hooks/useCueAutoDiscovery.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef } from 'react';
 import type { Session, EncoreFeatureFlags } from '../types';
 import { useSessionStore } from '../stores/sessionStore';
 import { notifyToast } from '../stores/notificationStore';
+import { captureException } from '../utils/sentry';
 
 /**
  * useCueAutoDiscovery — auto-discovers .maestro/cue.yaml files for sessions.
@@ -96,6 +97,7 @@ export function useCueAutoDiscovery(sessions: Session[], encoreFeatures: EncoreF
 					);
 				} catch (err) {
 					console.error('[CueAutoDiscovery] Failed to enable Cue:', err);
+					captureException(err, { extra: { action: 'maestro.cue.enable' } });
 					notifyToast({
 						type: 'error',
 						title: 'Cue engine failed to start',
@@ -110,6 +112,7 @@ export function useCueAutoDiscovery(sessions: Session[], encoreFeatures: EncoreF
 					await window.maestro.cue.disable();
 				} catch (err) {
 					console.error('[CueAutoDiscovery] Failed to disable Cue:', err);
+					captureException(err, { extra: { action: 'maestro.cue.disable' } });
 					notifyToast({
 						type: 'error',
 						title: 'Cue engine failed to stop',

--- a/src/shared/cue-path-utils.ts
+++ b/src/shared/cue-path-utils.ts
@@ -3,9 +3,43 @@
  *
  * Enables pipelines to span agents in subdirectories of a common project root
  * by detecting ancestor/descendant relationships between project paths.
+ *
+ * Pure string-based implementation — intentionally does NOT import Node's
+ * `path` module so this file can be called from both the Electron main
+ * process and the renderer. (The renderer strips Node built-ins; importing
+ * `path` there throws `path.resolve is not a function` when the pipeline
+ * editor saves, which is exactly what this utility powers.)
+ *
+ * Inputs are expected to already be absolute, os-native paths sourced from
+ * `session.projectRoot` — the main process resolves those via Node before
+ * they reach here, so we only need collapse/trim + prefix comparison.
  */
 
-import * as path from 'path';
+function detectSeparator(p: string): '\\' | '/' {
+	// Windows drive letter (`C:\...`) or any backslash in the input → '\'.
+	if (/^[a-zA-Z]:\\/.test(p) || p.includes('\\')) return '\\';
+	return '/';
+}
+
+function isWindowsRoot(p: string): boolean {
+	// `C:\` or `C:` — treat as a root that must not lose its trailing sep.
+	return /^[a-zA-Z]:\\?$/.test(p);
+}
+
+/**
+ * Collapse consecutive separators and strip a single trailing separator (but
+ * preserve roots like `/` and `C:\`). Does NOT resolve `..`/`.` segments —
+ * inputs are pre-resolved absolute paths from the Electron main process.
+ */
+function normalize(p: string, sep: '\\' | '/'): string {
+	if (!p) return p;
+	const collapseRe = sep === '\\' ? /\\+/g : /\/+/g;
+	let out = p.replace(collapseRe, sep);
+	if (out.length > 1 && out.endsWith(sep) && !isWindowsRoot(out)) {
+		out = out.slice(0, -1);
+	}
+	return out;
+}
 
 /**
  * Given an array of absolute paths, return their longest common directory
@@ -17,10 +51,11 @@ import * as path from 'path';
 export function computeCommonAncestorPath(paths: string[]): string | null {
 	if (paths.length === 0) return null;
 
-	const normalized = paths.map((p) => path.resolve(p));
+	const sep = detectSeparator(paths[0]);
+	const normalized = paths.map((p) => normalize(p, sep));
 	if (normalized.length === 1) return normalized[0];
 
-	const segments = normalized.map((p) => p.split(path.sep));
+	const segments = normalized.map((p) => p.split(sep));
 	const minLength = Math.min(...segments.map((s) => s.length));
 
 	let commonLength = 0;
@@ -33,8 +68,8 @@ export function computeCommonAncestorPath(paths: string[]): string | null {
 		}
 	}
 
-	if (commonLength === 0) return path.sep;
-	return segments[0].slice(0, commonLength).join(path.sep) || path.sep;
+	if (commonLength === 0) return sep;
+	return segments[0].slice(0, commonLength).join(sep) || sep;
 }
 
 /**
@@ -42,8 +77,9 @@ export function computeCommonAncestorPath(paths: string[]): string | null {
  * Both must be absolute paths. Uses normalized comparison.
  */
 export function isDescendantOrEqual(child: string, parent: string): boolean {
-	const normalizedChild = path.resolve(child);
-	const normalizedParent = path.resolve(parent);
+	const sep = detectSeparator(child || parent);
+	const normalizedChild = normalize(child, sep);
+	const normalizedParent = normalize(parent, sep);
 	if (normalizedChild === normalizedParent) return true;
-	return normalizedChild.startsWith(normalizedParent + path.sep);
+	return normalizedChild.startsWith(normalizedParent + sep);
 }

--- a/src/shared/cue-path-utils.ts
+++ b/src/shared/cue-path-utils.ts
@@ -15,9 +15,21 @@
  * they reach here, so we only need collapse/trim + prefix comparison.
  */
 
+// Paths are assumed to use ONE separator consistently within a single input
+// (sourced from `session.projectRoot`, which the main process resolves to an
+// os-native path before it reaches here). When detection sees both separators
+// in the same string — a degenerate case we've seen when users hand-author
+// test fixtures — we pick whichever appears first in the input so the rest of
+// the pipeline at least operates on a coherent split.
 function detectSeparator(p: string): '\\' | '/' {
-	// Windows drive letter (`C:\...`) or any backslash in the input → '\'.
-	if (/^[a-zA-Z]:\\/.test(p) || p.includes('\\')) return '\\';
+	const firstFwd = p.indexOf('/');
+	const firstBack = p.indexOf('\\');
+	if (firstFwd !== -1 && firstBack !== -1) {
+		return firstBack < firstFwd ? '\\' : '/';
+	}
+	// Windows drive letter (`C:\...`), UNC prefix (`\\server\share`), or any
+	// backslash in the input → '\'.
+	if (/^[a-zA-Z]:\\/.test(p) || p.startsWith('\\\\') || p.includes('\\')) return '\\';
 	return '/';
 }
 
@@ -26,16 +38,37 @@ function isWindowsRoot(p: string): boolean {
 	return /^[a-zA-Z]:\\?$/.test(p);
 }
 
+function isUncRoot(p: string): boolean {
+	// `\\server\share` — the share component is mandatory and we must not
+	// collapse the leading `\\` or strip the share as a trailing separator.
+	return /^\\\\[^\\]+\\[^\\]+$/.test(p);
+}
+
 /**
  * Collapse consecutive separators and strip a single trailing separator (but
- * preserve roots like `/` and `C:\`). Does NOT resolve `..`/`.` segments —
- * inputs are pre-resolved absolute paths from the Electron main process.
+ * preserve roots like `/`, `C:\`, and UNC shares `\\server\share`). Does NOT
+ * resolve `..`/`.` segments — inputs are pre-resolved absolute paths from the
+ * Electron main process.
  */
 function normalize(p: string, sep: '\\' | '/'): string {
 	if (!p) return p;
+
+	// UNC paths (`\\server\share\...`) MUST retain their leading double
+	// backslash — collapsing it via the general `\\+` rule would truncate to
+	// `\server\share\...` and break every downstream comparison. We carve off
+	// the `\\` prefix, collapse the rest, then reattach.
+	if (sep === '\\' && p.startsWith('\\\\')) {
+		const rest = p.slice(2).replace(/\\+/g, '\\');
+		let out = '\\\\' + rest;
+		if (out.length > 2 && out.endsWith('\\') && !isUncRoot(out.slice(0, -1))) {
+			out = out.slice(0, -1);
+		}
+		return out;
+	}
+
 	const collapseRe = sep === '\\' ? /\\+/g : /\/+/g;
 	let out = p.replace(collapseRe, sep);
-	if (out.length > 1 && out.endsWith(sep) && !isWindowsRoot(out)) {
+	if (out.length > 1 && out.endsWith(sep) && !isWindowsRoot(out) && !isUncRoot(out)) {
 		out = out.slice(0, -1);
 	}
 	return out;

--- a/src/shared/cue-pipeline-types.ts
+++ b/src/shared/cue-pipeline-types.ts
@@ -147,10 +147,51 @@ interface PipelineViewport {
 	zoom: number;
 }
 
-export interface PipelineLayoutState {
-	pipelines: CuePipeline[];
+/**
+ * Per-project view state. Each entry stores the selected pipeline and
+ * viewport for one project root, so switching between projects restores the
+ * user's prior focus instead of sharing a global selection that no longer
+ * matches. Node positions live on the pipelines themselves (not here) and
+ * are already project-scoped because each pipeline is owned by one project.
+ */
+export interface PipelineProjectViewState {
 	selectedPipelineId: string | null;
 	viewport?: PipelineViewport;
+}
+
+/**
+ * The `__default__` key is used when no active project root is available
+ * (e.g. no sessions configured yet) so the editor still has somewhere to
+ * persist viewport/selection before the user picks a project.
+ */
+export const PIPELINE_LAYOUT_DEFAULT_PROJECT_KEY = '__default__';
+
+export interface PipelineLayoutState {
+	/**
+	 * Schema version. Legacy files (v1) have no version field — the loader
+	 * translates them into v2 on first read. Bump this only on breaking
+	 * changes to the shape; additive changes should stay at 2 with optional
+	 * fields so older clients keep loading.
+	 */
+	version?: 2;
+	pipelines: CuePipeline[];
+	/**
+	 * @deprecated v1 field kept for backward-compatible reads. New writes
+	 * use `perProject` keyed by project root. Readers should treat this as
+	 * a fallback for the default project key only.
+	 */
+	selectedPipelineId: string | null;
+	/**
+	 * @deprecated v1 field kept for backward-compatible reads. Same
+	 * fallback semantics as `selectedPipelineId`.
+	 */
+	viewport?: PipelineViewport;
+	/**
+	 * Per-project-root view state. When present, overrides the top-level
+	 * `selectedPipelineId` / `viewport` for any project key that has an
+	 * entry. Projects without an entry fall back to the v1 fields.
+	 */
+	perProject?: Record<string, PipelineProjectViewState>;
 	/**
 	 * Set of project roots that the most recent successful save wrote to.
 	 * Persisted alongside the layout so we can re-seed lastWrittenRootsRef on

--- a/src/shared/settingsMetadata.ts
+++ b/src/shared/settingsMetadata.ts
@@ -620,7 +620,7 @@ export const SETTINGS_METADATA: Record<string, SettingMetadata> = {
 	encoreFeatures: {
 		description: 'Feature flags for experimental/encore features. Object with boolean flags.',
 		type: 'object',
-		default: { directorNotes: false },
+		default: { directorNotes: false, usageStats: true, symphony: true, maestroCue: false },
 		category: 'advanced',
 	},
 	directorNotesSettings: {


### PR DESCRIPTION
## Summary

Two-part pre-release hardening of the Maestro Cue feature:

1. **Forwarded sources on downstream agents** — the Upstream Sources panel now lists direct AND transitively-forwarded inputs in one unified view, so users can see every variable flowing into an agent. Also fixes a latent bug where the single-source completion path silently ignored `include_output_from` / `forward_output_from` (filters only applied to fan-in, so 1-source chain toggles no-op'd).

2. **Production hardening pass** — covers the failure modes that would have surfaced in user hands but don't in dev: feature-flag toggle races, engine/DB state when runs complete after `stop()`, UTF-8 corruption when forwarding agent output, per-project layout memory, and prompt-file path-traversal hardening.

## What changed

### Forwarded sources (commit `df96e989`)
- `UpstreamSourcesPanel` extracted from `AgentConfigPanel`; renders direct and forwarded rows with per-source template-variable chips.
- `transitiveUpstream` pure graph walk honors `forwardOutput` flags, dedupes shared sources, terminates on cycles.
- `cue-output-filter` consolidates include/forward semantics; both fan-in and 1-source completion paths now route through `buildFilteredOutputs` + `mergeUpstreamForwarded`.

### Feature flag & toggle lifecycle (commit `bbca8aa3`)
- Add `maestroCue` (plus `symphony`, `usageStats`) to `encoreFeatures` default so fresh installs don't spuriously call `disable()` on first render.
- Auto-close CueModal + CueYamlEditor when the flag toggles OFF.
- Serialize `enable`/`disable` IPC on a single Promise chain — rapid ON→OFF→ON toggles now apply in user-triggered order, not IPC-response order.
- Surface toggle failures as user-visible toasts (was `console.error` only).
- Emit `engineStarted`/`engineStopped` activity-update events so the renderer refreshes queue counters immediately instead of waiting for the 10s poll.

### Engine correctness
- Finalize DB status when `onCueRun` resolves after `engine.stop()` — prior behavior left runs stuck at `running` in the activity log forever.
- Wrap output-prompt phase in try/finally so the DB row is always updated under double-failure.
- Record stale queued events as `timeout` entries with `droppedFromQueue` payload so users can see why their run never fired.
- UTF-8-safe slicing via new `cue-text-utils.ts` (`sliceTailByChars` / `sliceHeadByChars`); swapped in at all `SOURCE_OUTPUT_MAX_CHARS` call sites to avoid splitting surrogate pairs when forwarding agent output.
- Guard negative sleep gaps in recovery service (clock moved backward).
- `torn` flag on YAML watcher so events slipping past `watcher.close()` can't re-trigger refresh on a torn-down session.

### Per-project pipeline layout
- `PipelineLayoutState` gains a `perProject` map keyed by project root (`selectedPipelineId` + `viewport`). Save under the selected pipeline's project root, preserving sibling projects' state.
- V1 → V2 migration folds legacy top-level fields into `perProject` under a `__default__` key; saves always stamp `version: 2`.

### UI consistency
- Reset `selectedNodeId` / `selectedEdgeId` when the owning pipeline disappears (prevents stale composite IDs rendering empty panels).
- Toast `refreshSession` failures in CueYamlEditor — file IS on disk, user needs to know the engine didn't reload.
- Harden prompt-file path validation: reject empty keys, normalize Windows backslashes on non-Windows, reject `..` segments before `path.resolve`.

## Test plan

Full lint clean (tsc across 3 configs); full suite **25,483 passing, 0 regressions**. 113 new tests across both commits covering:

- Upstream panel rendering (direct + forwarded rows, template-variable chips)
- Transitive upstream graph walk (dedup, cycle termination, `forwardOutput` flag)
- Single-source completion honors `include_output_from` / `forward_output_from` (regression gate)
- UTF-8 surrogate-pair boundary slicing (emoji, CJK, mid-surrogate)
- v1 → v2 layout migration + roundtrip preservation of sibling projects
- End-to-end YAML + prompt file persistence (including nested dirs, orphan pruning)
- Watcher torn-flag, negative-gap, validation error paths
- Engine-stop-mid-run DB finalization (both success + failure paths)
- Rapid-toggle serialization + ordering (ON→OFF→ON with variable IPC latency)
- Path-traversal rejection (absolute, `..`, non-`.md`, Windows separators, outside-prompts)

### Manual verification to run before merge
- `npm run dev` — enable maestroCue, create a pipeline with 3+ agents and a fan-out relay; confirm downstream agent panel shows forwarded sources.
- Toggle maestroCue off → confirm CueModal auto-closes, engine stops, no orphan processes.
- Open two projects, arrange pipelines differently in each, close/reopen modal → confirm per-project viewport restored.
- Trigger a subscription, disable engine mid-run → confirm activity log shows final status (not stuck at `running`).
- Pipe emoji/CJK through an `agent.completed` chain → confirm downstream receives intact UTF-8.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Upstream Sources panel with include/forward controls, forwarded “via …” labels, and per-source tokens
  * Per-project pipeline layout persistence (separate view state per project)
  * Prompt-file path validation and normalization to prevent invalid/traversal keys

* **Bug Fixes**
  * Maestro Cue modal closes reliably when feature toggled off
  * YAML save shows a warning if engine reload fails
  * Serialized enable/disable to avoid rapid-toggle races
  * Detects clock rollback to avoid erroneous recovery actions

* **Improvements**
  * Unicode-safe truncation for displayed outputs
  * More robust watcher cleanup and structured run-finished logging
<!-- end of auto-generated comment: release notes by coderabbit.ai -->