### PR TITLE
feat: add "By Key" shortcut reverse-lookup filter

### DIFF
--- a/src/renderer/components/Settings/tabs/ShortcutsTab.tsx
+++ b/src/renderer/components/Settings/tabs/ShortcutsTab.tsx
@@ -10,6 +10,7 @@ import React, { useState, useRef, useEffect } from 'react';
 import { Search } from 'lucide-react';
 import { useSettings } from '../../../hooks';
 import { formatShortcutKeys } from '../../../utils/shortcutFormatter';
+import { buildKeysFromEvent } from '../../../utils/shortcutRecorder';
 import type { Theme, Shortcut } from '../../../types';
 
 export interface ShortcutsTabProps {
@@ -53,28 +54,8 @@ export function ShortcutsTab({ theme, hasNoAgents, onRecordingChange }: Shortcut
 			return;
 		}
 
-		const keys = [];
-		if (e.metaKey) keys.push('Meta');
-		if (e.ctrlKey) keys.push('Ctrl');
-		if (e.altKey) keys.push('Alt');
-		if (e.shiftKey) keys.push('Shift');
-		if (['Meta', 'Control', 'Alt', 'Shift'].includes(e.key)) return;
-
-		// On macOS, Alt+letter produces special characters (e.g., Alt+L = ¬, Alt+P = π)
-		// Use e.code to get the physical key name when Alt is pressed
-		let mainKey = e.key;
-		if (e.altKey && e.code) {
-			// e.code is like 'KeyL', 'KeyP', 'Digit1', etc.
-			if (e.code.startsWith('Key')) {
-				mainKey = e.code.replace('Key', '').toLowerCase();
-			} else if (e.code.startsWith('Digit')) {
-				mainKey = e.code.replace('Digit', '');
-			} else {
-				// For other keys like Arrow keys, use as-is
-				mainKey = e.key;
-			}
-		}
-		keys.push(mainKey);
+		const keys = buildKeysFromEvent(e);
+		if (!keys) return;
 
 		if (isTabShortcut) {
 			setTabShortcuts({
@@ -100,24 +81,8 @@ export function ShortcutsTab({ theme, hasNoAgents, onRecordingChange }: Shortcut
 			return;
 		}
 
-		const keys = [];
-		if (e.metaKey) keys.push('Meta');
-		if (e.ctrlKey) keys.push('Ctrl');
-		if (e.altKey) keys.push('Alt');
-		if (e.shiftKey) keys.push('Shift');
-		if (['Meta', 'Control', 'Alt', 'Shift'].includes(e.key)) return;
-
-		let mainKey = e.key;
-		if (e.altKey && e.code) {
-			if (e.code.startsWith('Key')) {
-				mainKey = e.code.replace('Key', '').toLowerCase();
-			} else if (e.code.startsWith('Digit')) {
-				mainKey = e.code.replace('Digit', '');
-			} else {
-				mainKey = e.key;
-			}
-		}
-		keys.push(mainKey);
+		const keys = buildKeysFromEvent(e);
+		if (!keys) return;
 
 		setFilterShortcutKeys(keys);
 		setRecordingFilterShortcut(false);
@@ -221,6 +186,7 @@ export function ShortcutsTab({ theme, hasNoAgents, onRecordingChange }: Shortcut
 							handleFilterRecord(e);
 						}
 					}}
+					onBlur={() => setRecordingFilterShortcut(false)}
 					className={`px-3 py-2 rounded border text-xs font-mono whitespace-nowrap text-center transition-colors ${recordingFilterShortcut ? 'ring-2' : ''}`}
 					style={
 						{

--- a/src/renderer/components/Settings/tabs/ShortcutsTab.tsx
+++ b/src/renderer/components/Settings/tabs/ShortcutsTab.tsx
@@ -7,6 +7,7 @@
  */
 
 import React, { useState, useRef, useEffect } from 'react';
+import { Search } from 'lucide-react';
 import { useSettings } from '../../../hooks';
 import { formatShortcutKeys } from '../../../utils/shortcutFormatter';
 import type { Theme, Shortcut } from '../../../types';
@@ -22,12 +23,15 @@ export function ShortcutsTab({ theme, hasNoAgents, onRecordingChange }: Shortcut
 
 	const [recordingId, setRecordingId] = useState<string | null>(null);
 	const [shortcutsFilter, setShortcutsFilter] = useState('');
+	const [recordingFilterShortcut, setRecordingFilterShortcut] = useState(false);
+	const [filterShortcutKeys, setFilterShortcutKeys] = useState<string[]>([]);
 	const shortcutsFilterRef = useRef<HTMLInputElement>(null);
+	const filterShortcutButtonRef = useRef<HTMLButtonElement>(null);
 
 	// Notify parent of recording state changes (for escape handler coordination)
 	useEffect(() => {
-		onRecordingChange?.(!!recordingId);
-	}, [recordingId, onRecordingChange]);
+		onRecordingChange?.(!!recordingId || recordingFilterShortcut);
+	}, [recordingId, recordingFilterShortcut, onRecordingChange]);
 
 	// Auto-focus filter input on mount
 	useEffect(() => {
@@ -86,14 +90,52 @@ export function ShortcutsTab({ theme, hasNoAgents, onRecordingChange }: Shortcut
 		setRecordingId(null);
 	};
 
+	const handleFilterRecord = (e: React.KeyboardEvent) => {
+		e.preventDefault();
+		e.stopPropagation();
+
+		if (e.key === 'Escape') {
+			setRecordingFilterShortcut(false);
+			setFilterShortcutKeys([]);
+			return;
+		}
+
+		const keys = [];
+		if (e.metaKey) keys.push('Meta');
+		if (e.ctrlKey) keys.push('Ctrl');
+		if (e.altKey) keys.push('Alt');
+		if (e.shiftKey) keys.push('Shift');
+		if (['Meta', 'Control', 'Alt', 'Shift'].includes(e.key)) return;
+
+		let mainKey = e.key;
+		if (e.altKey && e.code) {
+			if (e.code.startsWith('Key')) {
+				mainKey = e.code.replace('Key', '').toLowerCase();
+			} else if (e.code.startsWith('Digit')) {
+				mainKey = e.code.replace('Digit', '');
+			} else {
+				mainKey = e.key;
+			}
+		}
+		keys.push(mainKey);
+
+		setFilterShortcutKeys(keys);
+		setRecordingFilterShortcut(false);
+	};
+
 	const allShortcuts = [
 		...Object.values(shortcuts).map((sc) => ({ ...sc, isTabShortcut: false })),
 		...Object.values(tabShortcuts).map((sc) => ({ ...sc, isTabShortcut: true })),
 	];
 	const totalShortcuts = allShortcuts.length;
-	const filteredShortcuts = allShortcuts.filter((sc) =>
-		sc.label.toLowerCase().includes(shortcutsFilter.toLowerCase())
-	);
+	const filteredShortcuts = allShortcuts.filter((sc) => {
+		if (filterShortcutKeys.length > 0) {
+			const sortedFilter = [...filterShortcutKeys].sort().join('+');
+			const sortedKeys = [...sc.keys].sort().join('+');
+			return sortedKeys === sortedFilter;
+		}
+		return sc.label.toLowerCase().includes(shortcutsFilter.toLowerCase());
+	});
 	const filteredCount = filteredShortcuts.length;
 
 	// Group shortcuts by category
@@ -150,24 +192,75 @@ export function ShortcutsTab({ theme, hasNoAgents, onRecordingChange }: Shortcut
 					Note: Most functionality is unavailable until you've created your first agent.
 				</p>
 			)}
-			<div className="flex items-center gap-2 mb-3">
+			<div className="flex items-stretch gap-2 mb-3">
 				<input
 					ref={shortcutsFilterRef}
 					type="text"
 					value={shortcutsFilter}
-					onChange={(e) => setShortcutsFilter(e.target.value)}
+					onChange={(e) => {
+						setShortcutsFilter(e.target.value);
+						setFilterShortcutKeys([]);
+					}}
 					placeholder="Filter shortcuts..."
 					className="flex-1 px-3 py-2 rounded border bg-transparent outline-none text-sm"
 					style={{ borderColor: theme.colors.border, color: theme.colors.textMain }}
 				/>
+				<button
+					ref={filterShortcutButtonRef}
+					onClick={() => {
+						if (filterShortcutKeys.length > 0) {
+							setFilterShortcutKeys([]);
+							setRecordingFilterShortcut(false);
+						} else {
+							setRecordingFilterShortcut(true);
+							filterShortcutButtonRef.current?.focus();
+						}
+					}}
+					onKeyDownCapture={(e) => {
+						if (recordingFilterShortcut) {
+							handleFilterRecord(e);
+						}
+					}}
+					className={`px-3 py-2 rounded border text-xs font-mono whitespace-nowrap text-center transition-colors ${recordingFilterShortcut ? 'ring-2' : ''}`}
+					style={
+						{
+							borderColor:
+								recordingFilterShortcut || filterShortcutKeys.length > 0
+									? theme.colors.accent
+									: theme.colors.border,
+							backgroundColor:
+								recordingFilterShortcut || filterShortcutKeys.length > 0
+									? theme.colors.accentDim
+									: theme.colors.bgActivity,
+							color:
+								recordingFilterShortcut || filterShortcutKeys.length > 0
+									? theme.colors.accent
+									: theme.colors.textDim,
+							'--tw-ring-color': theme.colors.accent,
+						} as React.CSSProperties
+					}
+				>
+					{recordingFilterShortcut ? (
+						'Press keys...'
+					) : filterShortcutKeys.length > 0 ? (
+						formatShortcutKeys(filterShortcutKeys)
+					) : (
+						<span className="flex items-center gap-1">
+							<Search className="w-3 h-3" />
+							By Key
+						</span>
+					)}
+				</button>
 				<span
-					className="text-xs px-2 py-1.5 rounded font-medium"
+					className="text-xs px-2 rounded font-medium flex items-center"
 					style={{
 						backgroundColor: theme.colors.bgActivity,
 						color: theme.colors.textDim,
 					}}
 				>
-					{shortcutsFilter ? `${filteredCount} / ${totalShortcuts}` : totalShortcuts}
+					{shortcutsFilter || filterShortcutKeys.length > 0
+						? `${filteredCount} / ${totalShortcuts}`
+						: totalShortcuts}
 				</span>
 			</div>
 			<p className="text-xs opacity-50 mb-3" style={{ color: theme.colors.textDim }}>

--- a/src/renderer/components/ShortcutsHelpModal.tsx
+++ b/src/renderer/components/ShortcutsHelpModal.tsx
@@ -262,11 +262,11 @@ export function ShortcutsHelpModal({
 			footer={footer}
 			initialFocusRef={searchInputRef}
 		>
-			<div className="space-y-2 max-h-[400px] overflow-y-auto scrollbar-thin -my-2">
+			<div className="space-y-2 max-h-[400px] overflow-y-auto scrollbar-thin scrollbar-track-transparent -mr-6 pr-6 -my-2">
 				{filteredShortcuts.map((sc, i) => {
 					const isUsed = usedShortcutIds.has(sc.id);
 					return (
-						<div key={i} className="flex justify-between items-center text-sm gap-2">
+						<div key={i} className="flex justify-between items-center text-sm gap-4">
 							<div className="flex items-center gap-1.5 min-w-0 flex-1">
 								{keyboardMasteryStats && (
 									<span className="flex-shrink-0 w-4 h-4 flex items-center justify-center">

--- a/src/renderer/components/ShortcutsHelpModal.tsx
+++ b/src/renderer/components/ShortcutsHelpModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useMemo } from 'react';
+import React, { useState, useRef, useMemo, useCallback } from 'react';
 import { X, Award, CheckCircle, Trophy, ExternalLink, Search } from 'lucide-react';
 import { GhostIconButton } from './ui/GhostIconButton';
 import type { Theme, Shortcut, KeyboardMasteryStats } from '../types';
@@ -6,6 +6,7 @@ import { fuzzyMatch } from '../utils/search';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
 import { FIXED_SHORTCUTS } from '../constants/shortcuts';
 import { formatShortcutKeys } from '../utils/shortcutFormatter';
+import { buildKeysFromEvent } from '../utils/shortcutRecorder';
 import { Modal } from './ui/Modal';
 import { KEYBOARD_MASTERY_LEVELS, getLevelForPercentage } from '../constants/keyboardMastery';
 import { openUrl } from '../utils/openUrl';
@@ -33,6 +34,19 @@ export function ShortcutsHelpModal({
 	const [filterShortcutKeys, setFilterShortcutKeys] = useState<string[]>([]);
 	const searchInputRef = useRef<HTMLInputElement>(null);
 	const filterShortcutButtonRef = useRef<HTMLButtonElement>(null);
+	// Ref mirrors recording state so onBeforeClose stays stable for layer registration.
+	const recordingRef = useRef(recordingFilterShortcut);
+	recordingRef.current = recordingFilterShortcut;
+
+	// Block modal close on Escape while recording — instead, cancel the recording.
+	const handleBeforeClose = useCallback(() => {
+		if (recordingRef.current) {
+			setRecordingFilterShortcut(false);
+			setFilterShortcutKeys([]);
+			return false;
+		}
+		return true;
+	}, []);
 
 	// Combine all shortcuts for display and mastery tracking
 	const allShortcuts = useMemo(
@@ -67,24 +81,8 @@ export function ShortcutsHelpModal({
 			return;
 		}
 
-		const keys = [];
-		if (e.metaKey) keys.push('Meta');
-		if (e.ctrlKey) keys.push('Ctrl');
-		if (e.altKey) keys.push('Alt');
-		if (e.shiftKey) keys.push('Shift');
-		if (['Meta', 'Control', 'Alt', 'Shift'].includes(e.key)) return;
-
-		let mainKey = e.key;
-		if (e.altKey && e.code) {
-			if (e.code.startsWith('Key')) {
-				mainKey = e.code.replace('Key', '').toLowerCase();
-			} else if (e.code.startsWith('Digit')) {
-				mainKey = e.code.replace('Digit', '');
-			} else {
-				mainKey = e.key;
-			}
-		}
-		keys.push(mainKey);
+		const keys = buildKeysFromEvent(e);
+		if (!keys) return;
 
 		setFilterShortcutKeys(keys);
 		setRecordingFilterShortcut(false);
@@ -161,6 +159,7 @@ export function ShortcutsHelpModal({
 							handleFilterRecord(e);
 						}
 					}}
+					onBlur={() => setRecordingFilterShortcut(false)}
 					className={`px-3 py-2 rounded border text-xs font-mono whitespace-nowrap text-center transition-colors ${recordingFilterShortcut ? 'ring-2' : ''}`}
 					style={
 						{
@@ -261,6 +260,7 @@ export function ShortcutsHelpModal({
 			customHeader={customHeader}
 			footer={footer}
 			initialFocusRef={searchInputRef}
+			layerOptions={{ onBeforeClose: handleBeforeClose }}
 		>
 			<div className="space-y-2 max-h-[400px] overflow-y-auto scrollbar-thin scrollbar-track-transparent -mr-6 pr-6 -my-2">
 				{filteredShortcuts.map((sc, i) => {

--- a/src/renderer/components/ShortcutsHelpModal.tsx
+++ b/src/renderer/components/ShortcutsHelpModal.tsx
@@ -1,5 +1,5 @@
-import { useState, useRef, useMemo } from 'react';
-import { X, Award, CheckCircle, Trophy, ExternalLink } from 'lucide-react';
+import React, { useState, useRef, useMemo } from 'react';
+import { X, Award, CheckCircle, Trophy, ExternalLink, Search } from 'lucide-react';
 import { GhostIconButton } from './ui/GhostIconButton';
 import type { Theme, Shortcut, KeyboardMasteryStats } from '../types';
 import { fuzzyMatch } from '../utils/search';
@@ -29,7 +29,10 @@ export function ShortcutsHelpModal({
 	keyboardMasteryStats,
 }: ShortcutsHelpModalProps) {
 	const [searchQuery, setSearchQuery] = useState('');
+	const [recordingFilterShortcut, setRecordingFilterShortcut] = useState(false);
+	const [filterShortcutKeys, setFilterShortcutKeys] = useState<string[]>([]);
 	const searchInputRef = useRef<HTMLInputElement>(null);
+	const filterShortcutButtonRef = useRef<HTMLButtonElement>(null);
 
 	// Combine all shortcuts for display and mastery tracking
 	const allShortcuts = useMemo(
@@ -54,8 +57,48 @@ export function ShortcutsHelpModal({
 		return KEYBOARD_MASTERY_LEVELS.find((l) => l.threshold > masteryPercentage);
 	}, [masteryPercentage]);
 	const usedShortcutIds = new Set(keyboardMasteryStats?.usedShortcuts ?? []);
+	const handleFilterRecord = (e: React.KeyboardEvent) => {
+		e.preventDefault();
+		e.stopPropagation();
+
+		if (e.key === 'Escape') {
+			setRecordingFilterShortcut(false);
+			setFilterShortcutKeys([]);
+			return;
+		}
+
+		const keys = [];
+		if (e.metaKey) keys.push('Meta');
+		if (e.ctrlKey) keys.push('Ctrl');
+		if (e.altKey) keys.push('Alt');
+		if (e.shiftKey) keys.push('Shift');
+		if (['Meta', 'Control', 'Alt', 'Shift'].includes(e.key)) return;
+
+		let mainKey = e.key;
+		if (e.altKey && e.code) {
+			if (e.code.startsWith('Key')) {
+				mainKey = e.code.replace('Key', '').toLowerCase();
+			} else if (e.code.startsWith('Digit')) {
+				mainKey = e.code.replace('Digit', '');
+			} else {
+				mainKey = e.key;
+			}
+		}
+		keys.push(mainKey);
+
+		setFilterShortcutKeys(keys);
+		setRecordingFilterShortcut(false);
+	};
+
 	const filteredShortcuts = Object.values(allShortcuts)
-		.filter((sc) => fuzzyMatch(sc.label, searchQuery) || fuzzyMatch(sc.keys.join(' '), searchQuery))
+		.filter((sc) => {
+			if (filterShortcutKeys.length > 0) {
+				const sortedFilter = [...filterShortcutKeys].sort().join('+');
+				const sortedKeys = [...sc.keys].sort().join('+');
+				return sortedKeys === sortedFilter;
+			}
+			return fuzzyMatch(sc.label, searchQuery) || fuzzyMatch(sc.keys.join(' '), searchQuery);
+		})
 		.sort((a, b) => a.label.localeCompare(b.label));
 	const filteredCount = filteredShortcuts.length;
 
@@ -68,10 +111,12 @@ export function ShortcutsHelpModal({
 						Keyboard Shortcuts
 					</h2>
 					<span
-						className="text-xs px-2 py-0.5 rounded"
+						className="text-xs px-2 py-2 rounded"
 						style={{ backgroundColor: theme.colors.bgActivity, color: theme.colors.textDim }}
 					>
-						{searchQuery ? `${filteredCount} / ${totalShortcuts}` : totalShortcuts}
+						{searchQuery || filterShortcutKeys.length > 0
+							? `${filteredCount} / ${totalShortcuts}`
+							: totalShortcuts}
 					</span>
 				</div>
 				<GhostIconButton onClick={onClose} color={theme.colors.textDim} ariaLabel="Close">
@@ -87,15 +132,66 @@ export function ShortcutsHelpModal({
 					Note: Most functionality is unavailable until you've created your first agent.
 				</p>
 			)}
-			<input
-				ref={searchInputRef}
-				type="text"
-				value={searchQuery}
-				onChange={(e) => setSearchQuery(e.target.value)}
-				placeholder="Search shortcuts..."
-				className="w-full px-3 py-2 rounded border bg-transparent outline-none text-sm"
-				style={{ borderColor: theme.colors.border, color: theme.colors.textMain }}
-			/>
+			<div className="flex items-stretch gap-2">
+				<input
+					ref={searchInputRef}
+					type="text"
+					value={searchQuery}
+					onChange={(e) => {
+						setSearchQuery(e.target.value);
+						setFilterShortcutKeys([]);
+					}}
+					placeholder="Search shortcuts..."
+					className="flex-1 px-3 py-2 rounded border bg-transparent outline-none text-sm"
+					style={{ borderColor: theme.colors.border, color: theme.colors.textMain }}
+				/>
+				<button
+					ref={filterShortcutButtonRef}
+					onClick={() => {
+						if (filterShortcutKeys.length > 0) {
+							setFilterShortcutKeys([]);
+							setRecordingFilterShortcut(false);
+						} else {
+							setRecordingFilterShortcut(true);
+							filterShortcutButtonRef.current?.focus();
+						}
+					}}
+					onKeyDownCapture={(e) => {
+						if (recordingFilterShortcut) {
+							handleFilterRecord(e);
+						}
+					}}
+					className={`px-3 py-2 rounded border text-xs font-mono whitespace-nowrap text-center transition-colors ${recordingFilterShortcut ? 'ring-2' : ''}`}
+					style={
+						{
+							borderColor:
+								recordingFilterShortcut || filterShortcutKeys.length > 0
+									? theme.colors.accent
+									: theme.colors.border,
+							backgroundColor:
+								recordingFilterShortcut || filterShortcutKeys.length > 0
+									? theme.colors.accentDim
+									: theme.colors.bgActivity,
+							color:
+								recordingFilterShortcut || filterShortcutKeys.length > 0
+									? theme.colors.accent
+									: theme.colors.textDim,
+							'--tw-ring-color': theme.colors.accent,
+						} as React.CSSProperties
+					}
+				>
+					{recordingFilterShortcut ? (
+						'Press keys...'
+					) : filterShortcutKeys.length > 0 ? (
+						formatShortcutKeys(filterShortcutKeys)
+					) : (
+						<span className="flex items-center gap-1">
+							<Search className="w-3 h-3" />
+							By Key
+						</span>
+					)}
+				</button>
+			</div>
 			<p className="text-xs mt-2" style={{ color: theme.colors.textDim }}>
 				Many shortcuts can be customized from Settings → Shortcuts.
 			</p>

--- a/src/renderer/constants/shortcuts.ts
+++ b/src/renderer/constants/shortcuts.ts
@@ -162,15 +162,6 @@ export const FIXED_SHORTCUTS: Record<string, Shortcut> = {
 	},
 };
 
-// Terminal tab shortcuts
-export const TERMINAL_SHORTCUTS: Record<string, Shortcut> = {
-	newTerminalTab: {
-		id: 'newTerminalTab',
-		label: 'New Terminal Tab',
-		keys: ['Control', 'Shift', '`'],
-	},
-};
-
 // Tab navigation shortcuts (AI mode only)
 export const TAB_SHORTCUTS: Record<string, Shortcut> = {
 	tabSwitcher: { id: 'tabSwitcher', label: 'Tab Switcher', keys: ['Alt', 'Meta', 't'] },

--- a/src/renderer/hooks/keyboard/useKeyboardShortcutHelpers.ts
+++ b/src/renderer/hooks/keyboard/useKeyboardShortcutHelpers.ts
@@ -44,7 +44,7 @@ export function useKeyboardShortcutHelpers(
 	 * - Arrow keys, Backspace, special characters
 	 * - Shift+bracket producing { and } characters
 	 * - Shift+number producing symbol characters (US layout)
-	 * - macOS Alt key producing special characters (uses e.code fallback)
+	 * - Alt-rewritten characters on macOS/AltGr layouts (uses e.code fallback)
 	 */
 	const isShortcut = useCallback(
 		(e: KeyboardEvent, actionId: string): boolean => {
@@ -93,8 +93,9 @@ export function useKeyboardShortcutHelpers(
 			};
 			if (shiftNumberMap[key] === mainKey) return true;
 
-			// For Alt+Meta shortcuts on macOS, e.key produces special characters (e.g., Alt+p = π, Alt+l = ¬)
-			// Use e.code to get the physical key pressed instead
+			// When Alt is held, e.key may be rewritten by the layout (macOS Alt+p = π,
+			// Alt+l = ¬; Windows/Linux AltGr variants). Fall back to e.code for the
+			// physical key. Must stay symmetric with buildKeysFromEvent in shortcutRecorder.ts.
 			if (altPressed && e.code) {
 				const codeKey = e.code.replace('Key', '').toLowerCase();
 				// Map e.code values to key characters for punctuation keys
@@ -152,8 +153,8 @@ export function useKeyboardShortcutHelpers(
 			if (mainKey === ',' && (key === ',' || key === '<')) return true;
 			if (mainKey === '.' && (key === '.' || key === '>')) return true;
 
-			// For Alt+Meta shortcuts on macOS, e.key produces special characters (e.g., Alt+t = †)
-			// Use e.code to get the physical key pressed instead
+			// When Alt is held, e.key may be rewritten by the layout (macOS Alt+t = †;
+			// Windows/Linux AltGr variants). Fall back to e.code for the physical key.
 			if (altPressed && e.code) {
 				const codeKey = e.code.replace('Key', '').toLowerCase();
 				// Map e.code values to key characters for punctuation keys

--- a/src/renderer/utils/shortcutRecorder.ts
+++ b/src/renderer/utils/shortcutRecorder.ts
@@ -4,8 +4,11 @@ import type React from 'react';
  * Build a shortcut key array from a keyboard event.
  * Returns null if only modifier keys are pressed (caller should keep recording).
  *
- * Handles macOS Alt+letter producing special characters (e.g. Alt+L = ¬) by
- * using e.code to recover the physical key name.
+ * When Alt is held, the main key is derived from e.code rather than e.key.
+ * This recovers the physical key name across layouts where Alt rewrites the
+ * character — most notably macOS (Alt+L = ¬, Alt+P = π) but also AltGr-based
+ * layouts on Windows/Linux. Applied unconditionally so recording stays
+ * symmetric with isShortcut's matching path in useKeyboardShortcutHelpers.ts.
  */
 export function buildKeysFromEvent(e: React.KeyboardEvent): string[] | null {
 	if (['Meta', 'Control', 'Alt', 'Shift'].includes(e.key)) return null;

--- a/src/renderer/utils/shortcutRecorder.ts
+++ b/src/renderer/utils/shortcutRecorder.ts
@@ -1,0 +1,29 @@
+import type React from 'react';
+
+/**
+ * Build a shortcut key array from a keyboard event.
+ * Returns null if only modifier keys are pressed (caller should keep recording).
+ *
+ * Handles macOS Alt+letter producing special characters (e.g. Alt+L = ¬) by
+ * using e.code to recover the physical key name.
+ */
+export function buildKeysFromEvent(e: React.KeyboardEvent): string[] | null {
+	if (['Meta', 'Control', 'Alt', 'Shift'].includes(e.key)) return null;
+
+	const keys: string[] = [];
+	if (e.metaKey) keys.push('Meta');
+	if (e.ctrlKey) keys.push('Ctrl');
+	if (e.altKey) keys.push('Alt');
+	if (e.shiftKey) keys.push('Shift');
+
+	let mainKey = e.key;
+	if (e.altKey && e.code) {
+		if (e.code.startsWith('Key')) {
+			mainKey = e.code.replace('Key', '').toLowerCase();
+		} else if (e.code.startsWith('Digit')) {
+			mainKey = e.code.replace('Digit', '');
+		}
+	}
+	keys.push(mainKey);
+	return keys;
+}


### PR DESCRIPTION
## Summary

Adds a "By Key" filter button next to the existing text filter in both the
keyboard shortcuts overview modal (`⌘/`) and the Settings → Shortcuts tab.
Users can press any key combination to find which action it's mapped to,
making it easy to discover conflicts or recall forgotten bindings.

- Reverse-lookup filter: click "By Key", press a combo, and the list narrows
  to shortcuts matching those exact keys (sorted-set comparison)
- Works alongside the existing text filter — entering text clears the key
  filter and vice versa
- Polish: height-aligned the filter input, button, and count badge; pulled
  the scrollbar flush to the modal's right edge; widened row spacing so key
  badges don't crowd labels

## Screenshots

**Shortcuts overview modal — `By Key` button inactive:**

<img width="409" height="689" alt="Bildschirmfoto 2026-04-17 um 08 33 52" src="https://github.com/user-attachments/assets/14c06946-c0dc-4543-aa5a-26345e46ddef" />


**Settings → Shortcuts — `By Key` filter active (recorded combo shown):**

<img width="967" height="729" alt="Bildschirmfoto 2026-04-17 um 08 04 13" src="https://github.com/user-attachments/assets/3c2d922f-4730-4ce2-85f9-33dbe93b06f2" />

## Test plan

- [ ] Open shortcuts help (`⌘/`), click "By Key", press `⌘K` → list narrows to Clear Terminal
- [ ] Type in search box → key filter clears, text filter takes over
- [ ] Same flow in Settings → Shortcuts tab
- [ ] Press `Esc` while recording → cancels without filtering
- [ ] Verify scrollbar sits flush with modal's right edge, no overlap with content
- [ ] Confirm "By Key" recording does NOT count toward keyboard mastery stats


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "By Key" filter to find shortcuts by pressing key combinations (toggle in Shortcuts tab and Help modal); captures and displays "Press keys…" or the formatted keys and updates results count when active.
  * Improved, more consistent key capture/normalization when recording shortcuts.

* **Bug Fixes**
  * Modal prevents accidental close while capturing; Escape or losing focus cancels capture.

* **Chores**
  * Removed the "New Terminal Tab" shortcut.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->