### PR TITLE
fix: absolute-position AI tab Bionify button

### DIFF
--- a/src/__tests__/renderer/components/TerminalOutput.test.tsx
+++ b/src/__tests__/renderer/components/TerminalOutput.test.tsx
@@ -1342,6 +1342,31 @@ describe('TerminalOutput', () => {
 			expect(screen.getByTitle('Disable Bionify for this tab')).toBeInTheDocument();
 		});
 
+		it('absolutely positions the Bionify button in the top-right of AI response cards', () => {
+			const logs: LogEntry[] = [
+				createLogEntry({ text: '# Heading\n\nReadable information block', source: 'stdout' }),
+			];
+
+			const session = createDefaultSession({
+				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				activeTabId: 'tab-1',
+			});
+
+			render(
+				<TerminalOutput
+					{...createDefaultProps({
+						session,
+						markdownEditMode: false,
+					})}
+				/>
+			);
+
+			const bionifyButton = screen.getByTitle('Enable Bionify for this tab');
+			expect(bionifyButton).toHaveClass('absolute');
+			expect(bionifyButton).toHaveClass('top-2');
+			expect(bionifyButton).toHaveClass('right-2');
+		});
+
 		it('calls setMarkdownEditMode when toggle is clicked', async () => {
 			const setMarkdownEditMode = vi.fn();
 			const logs: LogEntry[] = [createLogEntry({ text: '# Heading', source: 'stdout' })];

--- a/src/renderer/components/TerminalOutput.tsx
+++ b/src/renderer/components/TerminalOutput.tsx
@@ -373,6 +373,7 @@ const LogItemComponent = memo(
 		const isReversed = isUserMessage
 			? userMessageAlignment === 'left'
 			: userMessageAlignment === 'right';
+		const showBionifyTabToggle = log.source !== 'user' && isAIMode && !markdownEditMode;
 
 		return (
 			<div
@@ -407,7 +408,7 @@ const LogItemComponent = memo(
 					})()}
 				</div>
 				<div
-					className={`flex-1 min-w-0 p-4 pb-10 rounded-xl border ${isReversed ? 'rounded-tr-none' : 'rounded-tl-none'} relative overflow-hidden`}
+					className={`flex-1 min-w-0 p-4 pb-10 ${showBionifyTabToggle ? 'pr-14' : ''} rounded-xl border ${isReversed ? 'rounded-tr-none' : 'rounded-tl-none'} relative overflow-hidden`}
 					style={{
 						backgroundColor: isUserMessage
 							? isAIMode
@@ -426,6 +427,19 @@ const LogItemComponent = memo(
 									: theme.colors.border,
 					}}
 				>
+					{showBionifyTabToggle && (
+						<button
+							onClick={onToggleBionifyReadingMode}
+							className="absolute top-2 right-2 z-10 p-1.5 rounded opacity-0 group-hover:opacity-50 hover:!opacity-100"
+							style={{ color: bionifyReadingMode ? theme.colors.accent : theme.colors.textDim }}
+							title={
+								bionifyReadingMode ? 'Disable Bionify for this tab' : 'Enable Bionify for this tab'
+							}
+							aria-pressed={bionifyReadingMode}
+						>
+							<span className="text-[12px] font-black leading-none">{BIONIFY_BUTTON_LABEL}</span>
+						</button>
+					)}
 					{/* Local filter icon for system output only */}
 					{log.source !== 'user' && isTerminal && (
 						<div className="absolute top-2 right-2 flex items-center gap-2">
@@ -842,21 +856,6 @@ const LogItemComponent = memo(
 								}
 							>
 								{markdownEditMode ? <Eye className="w-4 h-4" /> : <FileText className="w-4 h-4" />}
-							</button>
-						)}
-						{log.source !== 'user' && isAIMode && !markdownEditMode && (
-							<button
-								onClick={onToggleBionifyReadingMode}
-								className="p-1.5 rounded opacity-0 group-hover:opacity-50 hover:!opacity-100"
-								style={{ color: bionifyReadingMode ? theme.colors.accent : theme.colors.textDim }}
-								title={
-									bionifyReadingMode
-										? 'Disable Bionify for this tab'
-										: 'Enable Bionify for this tab'
-								}
-								aria-pressed={bionifyReadingMode}
-							>
-								<span className="text-[12px] font-black leading-none">{BIONIFY_BUTTON_LABEL}</span>
 							</button>
 						)}
 						{/* Replay button for user messages in AI mode */}


### PR DESCRIPTION
## Summary

Hotfix for the desktop AI chat tab Bionify toggle.

- Moves the local `B` Bionify button out of normal layout flow in `TerminalOutput`.
- Absolutely positions it in the top-right of AI response cards so it no longer shifts/crops content at the top of the message box.
- Adds a focused regression test to lock in the positioning contract.

## Verification

- `npm run build:prompts`
- `npx vitest run src/__tests__/renderer/components/TerminalOutput.test.tsx`
- `npm run lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * The "Enable Bionify for this tab" button has been repositioned to the top-right corner of AI response cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->