### PR TITLE
fix(cli): write CLI discovery file when web server is restarted

### DIFF
--- a/src/__tests__/main/ipc/handlers/web.test.ts
+++ b/src/__tests__/main/ipc/handlers/web.test.ts
@@ -56,6 +56,7 @@ describe('web handlers', () => {
 			broadcastSessionStateChange: vi.fn(),
 			getWebClientCount: vi.fn().mockReturnValue(1),
 			getSecurityToken: vi.fn().mockReturnValue('mock-security-token'),
+			getPort: vi.fn().mockReturnValue(8080),
 			start: vi.fn().mockResolvedValue({ port: 8080, url: 'http://localhost:8080' }),
 			stop: vi.fn().mockResolvedValue(undefined),
 		};

--- a/src/main/ipc/handlers/web.ts
+++ b/src/main/ipc/handlers/web.ts
@@ -280,12 +280,27 @@ export function registerWebHandlers(deps: WebHandlerDependencies): void {
 			// Start if not already running
 			if (!webServer.isActive()) {
 				logger.info('Starting web server', 'WebServer');
-				const { port, url } = await webServer.start();
+				const { port, token, url } = await webServer.start();
 				logger.info(`Web server running at ${url} (port ${port})`, 'WebServer');
+
+				// Refresh CLI discovery file so the CLI can reconnect after a
+				// stop/start cycle (ensureCliServer only runs once at app launch).
+				writeCliServerInfo({
+					port,
+					token,
+					pid: process.pid,
+					startedAt: Date.now(),
+				});
 				return { success: true, url };
 			}
 
-			// Already running
+			// Already running — refresh discovery file in case it's stale
+			writeCliServerInfo({
+				port: webServer.getPort(),
+				token: webServer.getSecurityToken(),
+				pid: process.pid,
+				startedAt: Date.now(),
+			});
 			return { success: true, url: webServer.getSecureUrl() };
 		} catch (error: any) {
 			logger.error(`Failed to start web server: ${error.message}`, 'WebServer');


### PR DESCRIPTION
## Summary

- `ensureCliServer()` only runs once at app launch, so when the web server is stopped and restarted via the UI (`live:stopServer` → `live:startServer`), `cli-server.json` stays deleted and `maestro-cli` permanently reports "Maestro desktop app is not running" until the app itself is restarted.
- Mirror `ensureCliServer`'s write inside `live:startServer` for both the newly-started and already-running paths so the discovery file is always refreshed when the server comes back up.

Fixes #859

## Test plan

- [ ] Launch Maestro → verify `~/Library/Application Support/maestro/cli-server.json` exists.
- [ ] `maestro-cli status` / `maestro-cli open-file <path>` succeed.
- [ ] Stop the web server from the UI → verify `cli-server.json` is deleted and `maestro-cli` reports "not running" (expected).
- [ ] Start the web server again from the UI → verify `cli-server.json` is rewritten with the new port/token and `maestro-cli open-file` succeeds without restarting the app.
- [ ] `npm run lint` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Web server startup now captures and persistently stores security token alongside port and start metadata for discovery.
  * CLI discovery information is refreshed on every access when the server is already running, improving consistency of reported server state.

* **Tests**
  * Updated test mocks to align with the server interface used by the handler.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->