### PR TITLE
fix(cli): disable background tasks for Claude Code batch spawns

### DIFF
--- a/src/__tests__/cli/services/agent-spawner.test.ts
+++ b/src/__tests__/cli/services/agent-spawner.test.ts
@@ -1400,6 +1400,55 @@ Some text with [x] in it that's not a checkbox
 				);
 			}
 		});
+
+		it('should set CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1 for claude-code batch spawns (#861)', async () => {
+			const resultPromise = spawnAgent('claude-code', '/project', 'prompt');
+			await new Promise((resolve) => setTimeout(resolve, 0));
+
+			const [, , options] = mockSpawn.mock.calls[0];
+			expect(options.env.CLAUDE_CODE_DISABLE_BACKGROUND_TASKS).toBe('1');
+
+			mockStdout.emit('data', Buffer.from('{"type":"result","result":"Done"}\n'));
+			mockChild.emit('close', 0);
+			await resultPromise;
+		});
+
+		it('should set CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1 even in read-only mode', async () => {
+			const resultPromise = spawnAgent('claude-code', '/project', 'prompt', undefined, {
+				readOnlyMode: true,
+			});
+			await new Promise((resolve) => setTimeout(resolve, 0));
+
+			const [, , options] = mockSpawn.mock.calls[0];
+			expect(options.env.CLAUDE_CODE_DISABLE_BACKGROUND_TASKS).toBe('1');
+
+			mockStdout.emit('data', Buffer.from('{"type":"result","result":"Done"}\n'));
+			mockChild.emit('close', 0);
+			await resultPromise;
+		});
+
+		it('should let a pre-set CLAUDE_CODE_DISABLE_BACKGROUND_TASKS from shell env win', async () => {
+			const originalValue = process.env.CLAUDE_CODE_DISABLE_BACKGROUND_TASKS;
+			process.env.CLAUDE_CODE_DISABLE_BACKGROUND_TASKS = '0';
+
+			try {
+				const resultPromise = spawnAgent('claude-code', '/project', 'prompt');
+				await new Promise((resolve) => setTimeout(resolve, 0));
+
+				const [, , options] = mockSpawn.mock.calls[0];
+				expect(options.env.CLAUDE_CODE_DISABLE_BACKGROUND_TASKS).toBe('0');
+
+				mockStdout.emit('data', Buffer.from('{"type":"result","result":"Done"}\n'));
+				mockChild.emit('close', 0);
+				await resultPromise;
+			} finally {
+				if (originalValue === undefined) {
+					delete process.env.CLAUDE_CODE_DISABLE_BACKGROUND_TASKS;
+				} else {
+					process.env.CLAUDE_CODE_DISABLE_BACKGROUND_TASKS = originalValue;
+				}
+			}
+		});
 	});
 
 	describe('PATH expansion (via spawnAgent)', () => {

--- a/src/__tests__/main/agents/definitions.test.ts
+++ b/src/__tests__/main/agents/definitions.test.ts
@@ -90,6 +90,15 @@ describe('agent-definitions', () => {
 			expect(config.tools).toBeDefined();
 			expect(config.tools.question).toBe(false);
 		});
+
+		it('should have claude-code with batchModeEnvVars disabling background tasks', () => {
+			// Background tasks in CLI batch mode silently fail because the session exits
+			// before async work completes. batchModeEnvVars is applied only by the CLI
+			// spawners, not by the desktop UI path (see #861).
+			const claudeCode = AGENT_DEFINITIONS.find((def) => def.id === 'claude-code');
+			expect(claudeCode?.batchModeEnvVars).toBeDefined();
+			expect(claudeCode?.batchModeEnvVars?.CLAUDE_CODE_DISABLE_BACKGROUND_TASKS).toBe('1');
+		});
 	});
 
 	describe('getAgentDefinition', () => {

--- a/src/cli/services/agent-spawner.ts
+++ b/src/cli/services/agent-spawner.ts
@@ -176,13 +176,20 @@ async function spawnClaudeAgent(
 ): Promise<AgentResult> {
 	return new Promise((resolve) => {
 		const env = buildExpandedEnv();
+		const def = getAgentDefinition('claude-code');
+
+		// Apply batch-mode-only env vars (shell env wins, matching defaultEnvVars precedence)
+		if (def?.batchModeEnvVars) {
+			for (const k of Object.keys(def.batchModeEnvVars)) {
+				if (!env[k]) env[k] = def.batchModeEnvVars[k];
+			}
+		}
 
 		// Build args: base args + session handling + read-only + prompt
 		const args = [...CLAUDE_ARGS];
 
 		// Apply read-only mode args from centralized agent definitions
 		if (readOnlyMode) {
-			const def = getAgentDefinition('claude-code');
 			if (def?.readOnlyArgs) {
 				args.push(...def.readOnlyArgs);
 			}
@@ -400,6 +407,13 @@ async function spawnJsonLineAgent(
 		if (def?.defaultEnvVars) {
 			for (const k of Object.keys(def.defaultEnvVars)) {
 				if (!env[k]) env[k] = def.defaultEnvVars[k];
+			}
+		}
+
+		// Apply batch-mode-only env vars (shell env wins, matching defaultEnvVars precedence)
+		if (def?.batchModeEnvVars) {
+			for (const k of Object.keys(def.batchModeEnvVars)) {
+				if (!env[k]) env[k] = def.batchModeEnvVars[k];
 			}
 		}
 

--- a/src/main/agents/definitions.ts
+++ b/src/main/agents/definitions.ts
@@ -101,6 +101,7 @@ export interface AgentConfig extends BaseAgentConfig {
 	noPromptSeparator?: boolean; // If true, don't add '--' before the prompt in batch mode (OpenCode doesn't support it)
 	defaultEnvVars?: Record<string, string>; // Default environment variables for this agent (merged with user customEnvVars)
 	readOnlyEnvOverrides?: Record<string, string>; // Env var overrides applied in read-only mode (replaces keys from defaultEnvVars)
+	batchModeEnvVars?: Record<string, string>; // Env vars applied ONLY to CLI batch spawns (maestro-cli send). Not applied to desktop UI or --live path. Use for settings that only make sense in short-lived non-interactive sessions (e.g., disabling background tasks).
 }
 
 /**
@@ -142,6 +143,11 @@ export const AGENT_DEFINITIONS: AgentDefinition[] = [
 		readOnlyArgs: ['--permission-mode', 'plan'], // Read-only/plan mode
 		readOnlyCliEnforced: true, // CLI enforces read-only via --permission-mode plan
 		modelArgs: (modelId: string) => ['--model', modelId], // Model selection: claude --model sonnet
+		// Batch-mode env vars (CLI `maestro-cli send` default path only — not --live, not desktop UI).
+		// Background tasks cannot complete before a short-lived batch session exits, so results are lost (#861).
+		batchModeEnvVars: {
+			CLAUDE_CODE_DISABLE_BACKGROUND_TASKS: '1',
+		},
 		configOptions: [
 			{
 				key: 'model',


### PR DESCRIPTION
Adds a new `batchModeEnvVars` field to agent definitions that is read only by the CLI spawners (spawnClaudeAgent, spawnJsonLineAgent), not by the desktop UI path or --live mode. Populates Claude Code with CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1 so run_in_background tool calls do not silently fail when the short-lived `maestro-cli send` batch session exits before the async task completes.

Shell-env-wins precedence matches the existing defaultEnvVars pattern, so users can still opt out by setting the var in their shell.

The original issues it that maestro-cli requests can cause background tasks to spawn that then never report back and the result is lost.

<img width="1678" height="332" alt="IMG_5030 png" src="https://github.com/user-attachments/assets/fc084711-01df-4152-8e76-d7079524db4a" />

The setting is documented here https://claudelog.com/faqs/what-is-disable-background-tasks-in-claude-code/

But Claude Opus 4.7 couldn't figure it out and had to be carried to the finish line.

<img width="1214" height="626" alt="Bildschirmfoto 2026-04-18 um 17 10 56" src="https://github.com/user-attachments/assets/3837c1f8-f864-4632-8d58-5bac9dae5f61" />

Fixes #861

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced batch mode behavior by disabling background tasks for agent operations during CLI spawning, preventing interference with batch processes. Environment variable configuration respects pre-existing shell settings and ensures consistent batch operation execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->