### PR TITLE
fix(terminal): unblock OpenCode TUI and fix zsh PATH for claude/codex

### DIFF
--- a/src/__tests__/main/process-manager/runners/LocalCommandRunner.test.ts
+++ b/src/__tests__/main/process-manager/runners/LocalCommandRunner.test.ts
@@ -1,12 +1,12 @@
 import { EventEmitter } from 'events';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { mockPtySpawn, mockResolveShellPath, mockBuildInteractiveShellArgs, mockBuildUnixBasePath } =
+const { mockPtySpawn, mockResolveShellPath, mockBuildInteractiveShellArgs, mockBuildExpandedPath } =
 	vi.hoisted(() => ({
 		mockPtySpawn: vi.fn(),
 		mockResolveShellPath: vi.fn(),
 		mockBuildInteractiveShellArgs: vi.fn(),
-		mockBuildUnixBasePath: vi.fn(),
+		mockBuildExpandedPath: vi.fn(),
 	}));
 
 vi.mock('node-pty', () => ({
@@ -28,9 +28,13 @@ vi.mock('../../../../main/process-manager/utils/pathResolver', () => ({
 	buildWrappedCommand: vi.fn(),
 }));
 
-vi.mock('../../../../main/process-manager/utils/envBuilder', () => ({
-	buildUnixBasePath: mockBuildUnixBasePath,
-}));
+vi.mock('../../../../shared/pathUtils', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('../../../../shared/pathUtils')>();
+	return {
+		...actual,
+		buildExpandedPath: mockBuildExpandedPath,
+	};
+});
 
 vi.mock('../../../../shared/platformDetection', () => ({
 	isWindows: vi.fn(() => false),
@@ -43,7 +47,7 @@ describe('LocalCommandRunner', () => {
 		vi.clearAllMocks();
 		mockResolveShellPath.mockReturnValue('/bin/zsh');
 		mockBuildInteractiveShellArgs.mockReturnValue(['-l', '-i', '-c', 'ls']);
-		mockBuildUnixBasePath.mockReturnValue('/usr/bin:/bin');
+		mockBuildExpandedPath.mockReturnValue('/usr/bin:/bin');
 	});
 
 	it('resolves and emits stderr when PTY spawn throws', async () => {

--- a/src/main/process-manager/runners/LocalCommandRunner.ts
+++ b/src/main/process-manager/runners/LocalCommandRunner.ts
@@ -7,7 +7,7 @@ import { EventEmitter } from 'events';
 import * as pty from 'node-pty';
 import { logger } from '../../utils/logger';
 import type { CommandResult } from '../types';
-import { buildUnixBasePath } from '../utils/envBuilder';
+import { buildExpandedPath } from '../../../shared/pathUtils';
 import {
 	resolveShellPath,
 	buildInteractiveShellArgs,
@@ -78,15 +78,20 @@ export class LocalCommandRunner {
 					TERM: 'xterm-256color',
 				};
 			} else {
-				// Unix: Use minimal env - shell startup files handle PATH setup
-				const basePath = buildUnixBasePath();
+				// Unix: Use an expanded PATH so commands can reach user install
+				// locations (~/.local/bin, ~/.claude/local, ~/.opencode/bin, etc.)
+				// even when the interactive shell doesn't source an rc file that
+				// extends PATH. Matches buildPtyTerminalEnv()'s behavior for
+				// consistency between PTY terminal tabs and single runCommand
+				// invocations — a minimal-config zsh shouldn't see different
+				// resolution between the two paths.
 				env = {
 					HOME: process.env.HOME,
 					USER: process.env.USER,
 					SHELL: process.env.SHELL,
 					TERM: 'xterm-256color',
 					LANG: process.env.LANG || 'en_US.UTF-8',
-					PATH: basePath,
+					PATH: buildExpandedPath(),
 				};
 			}
 

--- a/src/main/process-manager/utils/__tests__/envBuilder.test.ts
+++ b/src/main/process-manager/utils/__tests__/envBuilder.test.ts
@@ -478,6 +478,28 @@ describe('envBuilder - Global Environment Variables', () => {
 			}
 		});
 
+		it('should include common user install locations in PATH on Unix', () => {
+			const originalPlatform = process.platform;
+			Object.defineProperty(process, 'platform', { value: 'linux' });
+
+			try {
+				process.env.PATH = '/usr/bin:/bin';
+				const env = buildPtyTerminalEnv({});
+				const pathParts = (env.PATH as string).split(path.delimiter);
+				const home = os.homedir();
+
+				// These directories must be in PATH so tools installed by the user
+				// (claude, codex, opencode installers) are reachable without relying
+				// on the shell sourcing an rc file to extend PATH. Regression test
+				// for zsh-without-.zshrc yielding `command not found`.
+				expect(pathParts).toContain(`${home}/.local/bin`);
+				expect(pathParts).toContain(`${home}/.opencode/bin`);
+				expect(pathParts).toContain(`${home}/.claude/local`);
+			} finally {
+				Object.defineProperty(process, 'platform', { value: originalPlatform });
+			}
+		});
+
 		it('should strip Electron/IDE variables from PTY environment on Unix', () => {
 			const originalPlatform = process.platform;
 			Object.defineProperty(process, 'platform', { value: 'linux' });

--- a/src/main/process-manager/utils/envBuilder.ts
+++ b/src/main/process-manager/utils/envBuilder.ts
@@ -71,12 +71,18 @@ export function buildPtyTerminalEnv(shellEnvVars?: Record<string, string>): Node
 			TERM: 'xterm-256color',
 		};
 	} else {
-		const basePath = buildUnixBasePath();
+		// Use the full expanded PATH so common user install locations
+		// (~/.local/bin, ~/.claude/local, ~/.opencode/bin, Homebrew, npm-global, etc.)
+		// are available even when the user's shell doesn't source an rc file that
+		// augments PATH. bash falls through to .bashrc for login+interactive on
+		// Debian, but zsh only sources .zprofile/.zshrc if they exist — users
+		// without those would otherwise see `command not found` for tools like
+		// `claude` and `codex` that live in ~/.local/bin.
 		env = {
 			...process.env,
 			TERM: 'xterm-256color',
 			LANG: process.env.LANG || 'en_US.UTF-8',
-			PATH: basePath,
+			PATH: buildExpandedPath(),
 		};
 		for (const key of STRIPPED_ENV_VARS) {
 			delete env[key];

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -66,18 +66,40 @@ export default defineConfig(({ mode }) => ({
 		rollupOptions: {
 			// Prevent esbuild from re-minifying xterm's pre-minified code.
 			// Double-minification corrupts variable scoping in requestMode(),
-			// causing "ReferenceError: e is not defined" at runtime.
-			plugins: [
-				{
-					name: 'skip-xterm-minify',
-					renderChunk(code, chunk) {
-						if (chunk.name === 'vendor-xterm') {
-							return { code, map: null };
-						}
-						return null;
+			// causing a "ReferenceError: <letter> is not defined" throw inside
+			// xterm.js's CSI parser when a TUI sends a DECRQM query (CSI ? N $ p).
+			// The throw poisons the parser state, so all subsequent output and
+			// user keystrokes are dropped — the terminal tab appears frozen
+			// (seen with OpenCode on Linux and vim on macOS).
+			//
+			// Vite's esbuild-transpile minifier runs as an `enforce: 'post'`
+			// renderChunk hook, so a plain renderChunk returning the input
+			// unchanged is a no-op. Capture the pre-minify chunk code at
+			// regular renderChunk order, then overwrite the final chunk in
+			// generateBundle (which fires after every renderChunk hook,
+			// including the minifier).
+			plugins: (() => {
+				const xtermPreMinifyCache = new Map<string, string>();
+				return [
+					{
+						name: 'skip-xterm-minify',
+						renderChunk(code, chunk) {
+							if (chunk.name === 'vendor-xterm') {
+								xtermPreMinifyCache.set(chunk.name, code);
+							}
+							return null;
+						},
+						generateBundle(_options, bundle) {
+							for (const asset of Object.values(bundle)) {
+								if (asset.type === 'chunk' && xtermPreMinifyCache.has(asset.name)) {
+									asset.code = xtermPreMinifyCache.get(asset.name)!;
+								}
+							}
+							xtermPreMinifyCache.clear();
+						},
 					},
-				},
-			],
+				];
+			})(),
 			output: {
 				// Manual chunking for better caching and code splitting
 				manualChunks: (id) => {


### PR DESCRIPTION
## Summary

Two related fixes that together make the Maestro Terminal tab actually usable for running CLI agents (`opencode`, `claude`, `codex`):

1. **`fix(build): actually skip esbuild re-minification of xterm.js core`** — stops the production `vendor-xterm` chunk from double-minifying `@xterm/xterm@6.0.0`'s pre-minified core. The prior `skip-xterm-minify` plugin was a no-op because its `renderChunk` hook had no `enforce` order, so Vite's `enforce: 'post'` esbuild-transpile minifier ran afterward and mangled the `requestMode` DECRQM handler. At runtime this threw `ReferenceError: <letter> is not defined` the first time a TUI sent `CSI ? N $ p`, poisoning the parser and freezing the tab (dead output + dead keystrokes). Replaced with a capture/restore pair: `renderChunk` caches the pre-minify `vendor-xterm` code, `generateBundle` writes it back after every `renderChunk` hook.

2. **`fix(terminal): include user install locations in PTY PATH`** — PTY terminal tabs overrode `PATH` with a narrow `buildUnixBasePath()` (version-manager bins + `/opt/homebrew:/usr/local:/usr/bin`). `opencode` worked because it's reachable via nvm; `claude` (symlink → `~/.local/share/claude/versions/…`) and `codex` (ELF in `~/.local/bin`) were unreachable. Bash hid this because Debian's `bash -l -i` sources `.bashrc`; zsh only sources `.zprofile`/`.zshrc` when present, so zsh users saw `command not found`. Switched to `buildExpandedPath()` — same canonical dev PATH that child-process agents already use — which backfills `~/.local/bin`, `~/.claude/local`, `~/.opencode/bin`, npm-global, Homebrew, etc. Shell rc files still run and their customizations still win.

## Repro (before)

In a Maestro Terminal tab on Linux:
- `opencode` → TUI renders for an instant, cursor hides, then hard freeze — Ctrl+C ignored, no echo. DevTools shows `ReferenceError: i is not defined at xd.requestMode`.
- On zsh: `claude` / `codex` → `command not found` despite being installed.

`opencode run "hi"` (batch mode, skips xterm.js) worked; VS Code's integrated terminal (also xterm.js) also worked, confirming the break was in our Vite bundle rather than xterm.js upstream.

## Test plan

- [x] Run targeted unit tests in scope: `envBuilder.test.ts` (44/44 pass, includes new `should include common user install locations in PATH on Unix`), `process-manager.test.ts` (43/43 pass), `LocalCommandRunner.test.ts` (1/1 pass).
- [x] `prettier --check` + `eslint` clean on the three touched files.
- [x] Built the renderer (`npx vite build`) and diff'd the emitted `vendor-xterm-*.js` `requestMode` against upstream `node_modules/@xterm/xterm/lib/xterm.mjs` — byte-equivalent.
- [x] Manual reproduction fixed on Linux: `opencode`, `claude`, `codex` all launch and stay interactive in both bash and zsh terminal tabs.
- [ ] Reviewer: confirm on macOS — the same DECRQM crash path was suspected for the `vim` hang tracked in a sibling worktree; this change should resolve it.

## Risk notes

- The PATH change is additive; it only widens what's reachable from a minimal-config shell. Users' own rc-file `export PATH=...` still runs and still takes precedence.
- The Vite plugin replaces the chunk content in `generateBundle`; Rollup's content-hashed filename is computed from the pre-restore code, so the hash may not reflect the final bytes. Acceptable because a rebuild always reproduces the same restored content — cache-busting stays sound within a given build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unix terminal environment now sources PATH from the shared expanded-path utility, improving consistency for spawned shells.

* **Chores**
  * Adjusted build tooling to preserve the terminal vendor chunk during packaging for more reliable runtime behavior.

* **Tests**
  * Added Unix-specific test coverage to verify terminal PATH includes user-local bin locations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->