### PR TITLE
fix: silence main-process Sentry noise from FS watchers

### DIFF
--- a/src/__tests__/main/history-manager.test.ts
+++ b/src/__tests__/main/history-manager.test.ts
@@ -1170,7 +1170,7 @@ describe('HistoryManager', () => {
 	// ----------------------------------------------------------------
 	describe('startWatching() / stopWatching()', () => {
 		it('should start watching history directory for changes', () => {
-			const mockWatcher = { close: vi.fn() } as unknown as fs.FSWatcher;
+			const mockWatcher = { close: vi.fn(), on: vi.fn() } as unknown as fs.FSWatcher;
 			mockWatch.mockReturnValue(mockWatcher);
 			mockExistsSync.mockReturnValue(true);
 
@@ -1184,7 +1184,7 @@ describe('HistoryManager', () => {
 		});
 
 		it('should create directory if it does not exist before watching', () => {
-			const mockWatcher = { close: vi.fn() } as unknown as fs.FSWatcher;
+			const mockWatcher = { close: vi.fn(), on: vi.fn() } as unknown as fs.FSWatcher;
 			mockWatch.mockReturnValue(mockWatcher);
 			mockExistsSync.mockReturnValue(false);
 
@@ -1196,7 +1196,7 @@ describe('HistoryManager', () => {
 		});
 
 		it('should invoke callback when a .json file changes', () => {
-			const mockWatcher = { close: vi.fn() } as unknown as fs.FSWatcher;
+			const mockWatcher = { close: vi.fn(), on: vi.fn() } as unknown as fs.FSWatcher;
 			let watchCallback: (event: string, filename: string | null) => void = () => {};
 			mockWatch.mockImplementation((_dir: string, cb: unknown) => {
 				watchCallback = cb as (event: string, filename: string | null) => void;
@@ -1214,7 +1214,7 @@ describe('HistoryManager', () => {
 		});
 
 		it('should not invoke callback for non-json files', () => {
-			const mockWatcher = { close: vi.fn() } as unknown as fs.FSWatcher;
+			const mockWatcher = { close: vi.fn(), on: vi.fn() } as unknown as fs.FSWatcher;
 			let watchCallback: (event: string, filename: string | null) => void = () => {};
 			mockWatch.mockImplementation((_dir: string, cb: unknown) => {
 				watchCallback = cb as (event: string, filename: string | null) => void;
@@ -1230,7 +1230,7 @@ describe('HistoryManager', () => {
 		});
 
 		it('should not invoke callback when filename is null', () => {
-			const mockWatcher = { close: vi.fn() } as unknown as fs.FSWatcher;
+			const mockWatcher = { close: vi.fn(), on: vi.fn() } as unknown as fs.FSWatcher;
 			let watchCallback: (event: string, filename: string | null) => void = () => {};
 			mockWatch.mockImplementation((_dir: string, cb: unknown) => {
 				watchCallback = cb as (event: string, filename: string | null) => void;
@@ -1246,7 +1246,7 @@ describe('HistoryManager', () => {
 		});
 
 		it('should not start watching again if already watching', () => {
-			const mockWatcher = { close: vi.fn() } as unknown as fs.FSWatcher;
+			const mockWatcher = { close: vi.fn(), on: vi.fn() } as unknown as fs.FSWatcher;
 			mockWatch.mockReturnValue(mockWatcher);
 			mockExistsSync.mockReturnValue(true);
 
@@ -1257,7 +1257,7 @@ describe('HistoryManager', () => {
 		});
 
 		it('should stop watching and close watcher', () => {
-			const mockWatcher = { close: vi.fn() } as unknown as fs.FSWatcher;
+			const mockWatcher = { close: vi.fn(), on: vi.fn() } as unknown as fs.FSWatcher;
 			mockWatch.mockReturnValue(mockWatcher);
 			mockExistsSync.mockReturnValue(true);
 
@@ -1268,8 +1268,8 @@ describe('HistoryManager', () => {
 		});
 
 		it('should allow re-watching after stop', () => {
-			const mockWatcher1 = { close: vi.fn() } as unknown as fs.FSWatcher;
-			const mockWatcher2 = { close: vi.fn() } as unknown as fs.FSWatcher;
+			const mockWatcher1 = { close: vi.fn(), on: vi.fn() } as unknown as fs.FSWatcher;
+			const mockWatcher2 = { close: vi.fn(), on: vi.fn() } as unknown as fs.FSWatcher;
 			mockWatch.mockReturnValueOnce(mockWatcher1).mockReturnValueOnce(mockWatcher2);
 			mockExistsSync.mockReturnValue(true);
 
@@ -1283,6 +1283,30 @@ describe('HistoryManager', () => {
 		it('should be safe to call stopWatching when not watching', () => {
 			// Should not throw
 			expect(() => manager.stopWatching()).not.toThrow();
+		});
+
+		it('should register an error handler on the watcher to prevent unhandled rejections', () => {
+			const onSpy = vi.fn();
+			const mockWatcher = { close: vi.fn(), on: onSpy } as unknown as fs.FSWatcher;
+			mockWatch.mockReturnValue(mockWatcher);
+			mockExistsSync.mockReturnValue(true);
+
+			manager.startWatching(vi.fn());
+
+			expect(onSpy).toHaveBeenCalledWith('error', expect.any(Function));
+		});
+
+		it('should log and not throw if fs.watch itself throws', () => {
+			mockWatch.mockImplementation(() => {
+				throw new Error('EBUSY: resource busy');
+			});
+			mockExistsSync.mockReturnValue(true);
+
+			expect(() => manager.startWatching(vi.fn())).not.toThrow();
+			expect(logger.warn).toHaveBeenCalledWith(
+				expect.stringContaining('Failed to start history watcher'),
+				expect.any(String)
+			);
 		});
 	});
 

--- a/src/__tests__/main/ipc/handlers/git.test.ts
+++ b/src/__tests__/main/ipc/handlers/git.test.ts
@@ -3978,7 +3978,7 @@ branch refs/heads/bugfix-123
 
 			expect(mockFs.access).toHaveBeenCalledWith('/parent/worktrees');
 			expect(mockChokidar.watch).toHaveBeenCalledWith('/parent/worktrees', {
-				ignored: /(^|[/\\])\../,
+				ignored: [/(^|[/\\])\../, expect.any(RegExp)],
 				persistent: true,
 				ignoreInitial: true,
 				depth: 0,

--- a/src/main/history-manager.ts
+++ b/src/main/history-manager.ts
@@ -493,15 +493,27 @@ export class HistoryManager {
 			fs.mkdirSync(this.historyDir, { recursive: true });
 		}
 
-		this.watcher = fs.watch(this.historyDir, (_eventType, filename) => {
-			if (filename?.endsWith('.json')) {
-				const sessionId = filename.replace('.json', '');
-				logger.debug(`History file changed: ${filename}`, LOG_CONTEXT);
-				onExternalChange(sessionId);
-			}
-		});
+		try {
+			this.watcher = fs.watch(this.historyDir, (_eventType, filename) => {
+				if (filename?.endsWith('.json')) {
+					const sessionId = filename.replace('.json', '');
+					logger.debug(`History file changed: ${filename}`, LOG_CONTEXT);
+					onExternalChange(sessionId);
+				}
+			});
 
-		logger.info('Started watching history directory', LOG_CONTEXT);
+			// Prevent runtime errors (e.g. Windows UNKNOWN, disk unmount) from
+			// becoming unhandled rejections. Swallow to logger; caller stays alive.
+			this.watcher.on('error', (error) => {
+				logger.warn(`History watcher error: ${error.message}`, LOG_CONTEXT);
+			});
+
+			logger.info('Started watching history directory', LOG_CONTEXT);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			logger.warn(`Failed to start history watcher: ${message}`, LOG_CONTEXT);
+			this.watcher = null;
+		}
 	}
 
 	/**

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -208,6 +208,20 @@ if (crashReportingEnabled && !isDevelopment) {
 				tracesSampleRate: 0,
 				// Filter out sensitive data
 				beforeSend(event) {
+					// Drop unfixable Windows drive-root noise: EBUSY/EPERM on always-locked
+					// system files (pagefile.sys, hiberfil.sys, DumpStack.log.tmp, ...) that
+					// show up when users point watchers at C:\ or similar. See MAESTRO-G5/G6.
+					const firstException = event.exception?.values?.[0];
+					const exceptionValue = firstException?.value ?? '';
+					if (
+						/^(EBUSY|EPERM): [^,]+, lstat /i.test(exceptionValue) &&
+						/(pagefile\.sys|hiberfil\.sys|swapfile\.sys|DumpStack\.log|System Volume Information)/i.test(
+							exceptionValue
+						)
+					) {
+						return null;
+					}
+
 					// Remove any potential sensitive data from the event
 					if (event.user) {
 						delete event.user.ip_address;

--- a/src/main/ipc/handlers/autorun.ts
+++ b/src/main/ipc/handlers/autorun.ts
@@ -6,6 +6,7 @@ import Store from 'electron-store';
 import { logger } from '../../utils/logger';
 import { createIpcHandler, CreateHandlerOptions } from '../../utils/ipcHandler';
 import { resolveDirentType } from '../../utils/dirent-utils';
+import { WINDOWS_LOCKED_SYSTEM_FILES } from '../../utils/watcher-ignore';
 import { SshRemoteConfig } from '../../../shared/types';
 import { MaestroSettings } from './persistence';
 import { isWebContentsAvailable } from '../../utils/safe-send';
@@ -845,7 +846,10 @@ export function registerAutorunHandlers(
 
 				// Start watching the folder recursively using chokidar (cross-platform)
 				const watcher = chokidar.watch(folderPath, {
-					ignored: /(^|[/\\])\../, // Ignore dotfiles
+					ignored: [
+						/(^|[/\\])\../, // Ignore dotfiles
+						WINDOWS_LOCKED_SYSTEM_FILES,
+					],
 					persistent: true,
 					ignoreInitial: true, // Don't emit events for existing files on startup
 					depth: 99, // Recursive watching

--- a/src/main/ipc/handlers/documentGraph.ts
+++ b/src/main/ipc/handlers/documentGraph.ts
@@ -3,6 +3,7 @@ import chokidar, { FSWatcher } from 'chokidar';
 import { logger } from '../../utils/logger';
 import { createIpcHandler, CreateHandlerOptions } from '../../utils/ipcHandler';
 import { isWebContentsAvailable } from '../../utils/safe-send';
+import { WINDOWS_LOCKED_SYSTEM_FILES } from '../../utils/watcher-ignore';
 
 const LOG_CONTEXT = '[DocumentGraph]';
 
@@ -153,6 +154,7 @@ export function registerDocumentGraphHandlers(deps: DocumentGraphHandlerDependen
 					/dist/,
 					/build/,
 					/\.git/,
+					WINDOWS_LOCKED_SYSTEM_FILES,
 				],
 				persistent: true,
 				ignoreInitial: true, // Don't emit events for existing files on startup

--- a/src/main/ipc/handlers/git.ts
+++ b/src/main/ipc/handlers/git.ts
@@ -14,6 +14,7 @@ import {
 import { resolveGhPath, getCachedGhStatus, setCachedGhStatus } from '../../utils/cliDetection';
 import { getShellPath } from '../../runtime/getShellPath';
 import { captureMessage } from '../../utils/sentry';
+import { WINDOWS_LOCKED_SYSTEM_FILES } from '../../utils/watcher-ignore';
 import {
 	parseGitBranches,
 	parseGitTags,
@@ -1223,7 +1224,10 @@ export function registerGitHandlers(deps: GitHandlerDependencies): void {
 
 					// Start watching the directory (only top level, not recursive)
 					const watcher = chokidar.watch(worktreePath, {
-						ignored: /(^|[/\\])\../, // Ignore dotfiles
+						ignored: [
+							/(^|[/\\])\../, // Ignore dotfiles
+							WINDOWS_LOCKED_SYSTEM_FILES,
+						],
 						persistent: true,
 						ignoreInitial: true,
 						depth: 0, // Only watch top-level directory changes

--- a/src/main/ipc/handlers/marketplace.ts
+++ b/src/main/ipc/handlers/marketplace.ts
@@ -563,6 +563,12 @@ function setupLocalManifestWatcher(app: App): void {
 			}, WATCHER_DEBOUNCE_MS);
 		});
 
+		// Prevent runtime errors (e.g. Windows UNKNOWN, file removed) from
+		// becoming unhandled rejections.
+		localManifestWatcher.on('error', (error) => {
+			logger.warn(`Local manifest watcher error: ${error.message}`, LOG_CONTEXT);
+		});
+
 		logger.debug('Local manifest file watcher initialized', LOG_CONTEXT);
 	} catch (error) {
 		// File might not exist yet - this is normal

--- a/src/main/utils/watcher-ignore.ts
+++ b/src/main/utils/watcher-ignore.ts
@@ -1,0 +1,18 @@
+/**
+ * Shared ignore patterns for recursive file watchers (chokidar).
+ *
+ * Windows places a handful of always-locked system files at drive roots
+ * (pagefile.sys, hiberfil.sys, swapfile.sys, DumpStack.log.tmp, System
+ * Volume Information). When a user points Maestro at a drive root — or
+ * a path that transitively symlinks to one — chokidar's initial walk
+ * hits `EBUSY: resource busy or locked` on each lstat. See MAESTRO-G5/G6.
+ *
+ * These files can never be meaningfully watched, so skip them everywhere
+ * that builds a recursive watch tree.
+ */
+
+/** Windows drive-root system files that always fail lstat with EBUSY. */
+export const WINDOWS_LOCKED_SYSTEM_FILES: RegExp = new RegExp(
+	'(^|[/\\\\])(pagefile\\.sys|hiberfil\\.sys|swapfile\\.sys|DumpStack\\.log(\\.tmp)?|System Volume Information)$',
+	'i'
+);


### PR DESCRIPTION
## Summary

Triaged the top unresolved main-process Sentry issues and landed fixes for the two that are real bugs on `main`.

- **MAESTRO-9A** — unhandled rejections from `fs.watch()` (14 events; "UNKNOWN: unknown error, watch" on Windows). `history-manager.ts` and `marketplace.ts` created watchers without `.on('error')`, so transient errors escaped as unhandled rejections.
- **MAESTRO-G5/G6** — `EBUSY: resource busy or locked, lstat 'C:\DumpStack.log.tmp'` / `hiberfil.sys` (1,279 events). Users who point a watcher at or near a drive root hit always-locked Windows system files during chokidar's initial walk.

Three other top issues were ruled out (noted in commit body): MAESTRO-87 is from a fork ("semantica" v0.56.1), MAESTRO-B9 is already fixed by `70332d993` (`MAX_SESSION_FILE_SIZE` guard), and MAESTRO-FM lives on the `rc` branch only.

## Changes

- New `src/main/utils/watcher-ignore.ts` exporting a shared `WINDOWS_LOCKED_SYSTEM_FILES` regex (pagefile.sys, hiberfil.sys, swapfile.sys, DumpStack.log[.tmp], System Volume Information).
- Wired the shared ignore into the three recursive chokidar watchers: `documentGraph`, `autorun`, and `git:watchWorktreeDirectory`.
- `history-manager.ts` and `marketplace.ts`: added `try`/`catch` around `fs.watch()` creation plus an `.on('error', ...)` handler that logs via `logger.warn` instead of crashing.
- Sentry `beforeSend` filter in `src/main/index.ts` drops any residual `EBUSY/EPERM lstat` events targeting the locked paths as defense in depth.
- Tests: extended `history-manager.test.ts` for the new error handler and fs.watch-throws fallback; updated the existing FSWatcher mocks to expose `on`; relaxed the `git:watchWorktreeDirectory` ignored-array assertion.

## Test plan

- [x] `npx tsc --noEmit` — no new errors
- [x] `npx vitest run src/__tests__/main/ipc/handlers/git.test.ts` — passes
- [x] Pre-push hook full test suite — passes (was failing on the git-watcher assertion before the test update)
- [ ] Manual: point Auto Run at `C:\` on a Windows box and confirm no EBUSY noise lands in Sentry on the RC channel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * File watchers now handle errors gracefully instead of causing crashes
  * Unhandled errors from filesystem watchers are properly caught and logged
  * Windows system-locked files no longer trigger watcher failures

* **Improvements**
  * Crash reports are now filtered to exclude expected Windows filesystem errors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->