### PR TITLE
fix(ssh): broaden remote agent detection PATH + use POSIX command -v

### DIFF
--- a/src/__tests__/main/ipc/handlers/agents.test.ts
+++ b/src/__tests__/main/ipc/handlers/agents.test.ts
@@ -290,6 +290,88 @@ describe('agents IPC handlers', () => {
 			expect(result[0].configOptions[0].argBuilder).toBeUndefined();
 			expect(result[0].configOptions[0].key).toBe('test');
 		});
+
+		describe('SSH remote detection (issue #878)', () => {
+			let mockSettingsStore: {
+				get: ReturnType<typeof vi.fn>;
+				set: ReturnType<typeof vi.fn>;
+			};
+
+			beforeEach(() => {
+				mockSettingsStore = {
+					get: vi.fn().mockReturnValue([
+						{
+							id: 'remote-1',
+							host: 'dev.example.com',
+							username: 'dev',
+							port: 22,
+							enabled: true,
+						},
+					]),
+					set: vi.fn(),
+				};
+
+				handlers.clear();
+				registerAgentsHandlers({
+					...deps,
+					settingsStore: mockSettingsStore as any,
+				});
+
+				vi.mocked(buildSshCommand).mockResolvedValue({
+					command: 'ssh',
+					args: ['-o', 'BatchMode=yes', 'dev@dev.example.com', 'mock'],
+				});
+			});
+
+			it("uses POSIX 'command -v' (not 'which') to probe each agent binary", async () => {
+				vi.mocked(execFileNoThrow).mockResolvedValue({
+					exitCode: 0,
+					stdout: '/home/dev/.local/bin/claude\n',
+					stderr: '',
+				});
+
+				const handler = handlers.get('agents:detect');
+				await handler!({} as any, 'remote-1');
+
+				// Every probe should invoke 'command -v <binary>', never 'which'
+				const calls = vi.mocked(buildSshCommand).mock.calls;
+				expect(calls.length).toBeGreaterThan(0);
+				for (const [, options] of calls) {
+					expect(options.command).toBe('command');
+					expect(options.args[0]).toBe('-v');
+				}
+			});
+
+			it('marks the agent available and records the resolved remote path', async () => {
+				vi.mocked(execFileNoThrow).mockResolvedValue({
+					exitCode: 0,
+					stdout: '/home/dev/.claude/local/claude\n',
+					stderr: '',
+				});
+
+				const handler = handlers.get('agents:detect');
+				const result = await handler!({} as any, 'remote-1');
+
+				const claude = result.find((a: any) => a.id === 'claude-code');
+				expect(claude.available).toBe(true);
+				expect(claude.path).toBe('/home/dev/.claude/local/claude');
+			});
+
+			it('marks the agent unavailable when command -v exits non-zero', async () => {
+				vi.mocked(execFileNoThrow).mockResolvedValue({
+					exitCode: 1,
+					stdout: '',
+					stderr: '',
+				});
+
+				const handler = handlers.get('agents:detect');
+				const result = await handler!({} as any, 'remote-1');
+
+				const claude = result.find((a: any) => a.id === 'claude-code');
+				expect(claude.available).toBe(false);
+				expect(claude.path).toBeUndefined();
+			});
+		});
 	});
 
 	describe('agents:get', () => {

--- a/src/__tests__/main/utils/ssh-command-builder.test.ts
+++ b/src/__tests__/main/utils/ssh-command-builder.test.ts
@@ -334,6 +334,26 @@ describe('ssh-command-builder', () => {
 			expect(lastArg).not.toContain('&& cd'); // cd comes after PATH setup if present
 		});
 
+		it('includes common agent install locations in PATH wrapper (issue #878)', async () => {
+			const result = await buildSshCommand(baseConfig, {
+				command: 'command',
+				args: ['-v', 'claude'],
+			});
+
+			const lastArg = result.args[result.args.length - 1];
+			expect(lastArg).toContain('export PATH=');
+			expect(lastArg).toContain('$HOME/.local/bin');
+			expect(lastArg).toContain('$HOME/.opencode/bin');
+			expect(lastArg).toContain('$HOME/.claude/local');
+			expect(lastArg).toContain('$HOME/go/bin');
+			expect(lastArg).toContain('$HOME/.bun/bin');
+			expect(lastArg).toContain('$HOME/.deno/bin');
+			expect(lastArg).toContain('$HOME/.nix-profile/bin');
+			expect(lastArg).toContain('/usr/local/bin');
+			expect(lastArg).toContain('/opt/homebrew/bin');
+			expect(lastArg).toContain('/snap/bin');
+		});
+
 		it('includes the remote command as the last argument', async () => {
 			const result = await buildSshCommand(baseConfig, {
 				command: 'claude',
@@ -702,8 +722,17 @@ describe('ssh-command-builder', () => {
 
 			expect(result.stdinScript).toBeDefined();
 			expect(result.stdinScript).toContain('export PATH=');
-			expect(result.stdinScript).toContain('.local/bin');
+			// Common install locations (regression coverage for issue #878)
+			expect(result.stdinScript).toContain('$HOME/.local/bin');
+			expect(result.stdinScript).toContain('$HOME/.opencode/bin');
+			expect(result.stdinScript).toContain('$HOME/.claude/local');
+			expect(result.stdinScript).toContain('$HOME/go/bin');
+			expect(result.stdinScript).toContain('$HOME/.bun/bin');
+			expect(result.stdinScript).toContain('$HOME/.deno/bin');
+			expect(result.stdinScript).toContain('$HOME/.nix-profile/bin');
+			expect(result.stdinScript).toContain('/usr/local/bin');
 			expect(result.stdinScript).toContain('/opt/homebrew/bin');
+			expect(result.stdinScript).toContain('/snap/bin');
 		});
 
 		it('includes cd command in stdin script when cwd provided', async () => {

--- a/src/main/ipc/handlers/agents.ts
+++ b/src/main/ipc/handlers/agents.ts
@@ -211,7 +211,7 @@ function stripAgentFunctions(agent: any) {
 
 /**
  * Detect agents on a remote SSH host.
- * Uses 'which' command over SSH to check for agent binaries.
+ * Uses POSIX 'command -v' over SSH to check for agent binaries.
  * Includes a timeout to handle unreachable hosts gracefully.
  */
 async function detectAgentsRemote(sshRemote: SshRemoteConfig): Promise<any[]> {
@@ -223,10 +223,13 @@ async function detectAgentsRemote(sshRemote: SshRemoteConfig): Promise<any[]> {
 	let connectionError: string | undefined;
 
 	for (const agentDef of AGENT_DEFINITIONS) {
-		// Build SSH command to check for the binary using 'which'
+		// Build SSH command to check for the binary using POSIX 'command -v'.
+		// Preferred over 'which' because it's a shell builtin (no PATH lookup needed),
+		// avoids /usr/bin/which on hosts without it, and behaves consistently across
+		// bash/dash/zsh. The command runs inside /bin/bash via buildSshCommand().
 		const remoteOptions: RemoteCommandOptions = {
-			command: 'which',
-			args: [agentDef.binaryName],
+			command: 'command',
+			args: ['-v', agentDef.binaryName],
 		};
 
 		try {
@@ -792,10 +795,11 @@ export function registerAgentsHandlers(deps: AgentsHandlerDependencies): void {
 					throw new Error(`Unknown agent: ${agentId}`);
 				}
 
-				// Build SSH command to check for the binary using 'which'
+				// Build SSH command to check for the binary using POSIX 'command -v'.
+				// See detectAgentsRemote() for rationale.
 				const remoteOptions: RemoteCommandOptions = {
-					command: 'which',
-					args: [agentDef.binaryName],
+					command: 'command',
+					args: ['-v', agentDef.binaryName],
 				};
 
 				try {

--- a/src/main/utils/ssh-command-builder.ts
+++ b/src/main/utils/ssh-command-builder.ts
@@ -21,10 +21,16 @@ import { parseDataUrl, buildImagePromptPrefix } from '../process-manager/utils/i
 const BASE_SSH_PATH_DIRS = [
 	'$HOME/.local/bin',
 	'$HOME/.opencode/bin',
+	'$HOME/.claude/local',
 	'$HOME/bin',
 	'/usr/local/bin',
 	'/opt/homebrew/bin',
 	'$HOME/.cargo/bin',
+	'$HOME/go/bin',
+	'$HOME/.bun/bin',
+	'$HOME/.deno/bin',
+	'$HOME/.nix-profile/bin',
+	'/snap/bin',
 ];
 
 /**
@@ -626,10 +632,16 @@ export async function buildSshCommand(
 	// We prepend common binary locations to PATH:
 	// - ~/.local/bin: Claude Code, pip --user installs
 	// - ~/.opencode/bin: OpenCode installer default location
+	// - ~/.claude/local: Claude Code local-install layout (auto-update bundle)
 	// - ~/bin: User scripts
 	// - /usr/local/bin: Homebrew on Intel Mac, manual installs
 	// - /opt/homebrew/bin: Homebrew on Apple Silicon
 	// - ~/.cargo/bin: Rust tools
+	// - ~/go/bin: Go default GOBIN (Factory Droid and other Go-based CLIs)
+	// - ~/.bun/bin: Bun runtime + bunx-installed CLIs
+	// - ~/.deno/bin: Deno-installed CLIs
+	// - ~/.nix-profile/bin: Nix user profile binaries
+	// - /snap/bin: Linux snap-installed binaries
 	// Plus dynamic detection of Node version managers (nvm, fnm, volta, mise, asdf, n)
 	// to find npm-installed CLIs like codex, claude, etc.
 	//


### PR DESCRIPTION
## Summary

Fixes #878. SSH remote agent detection failed for users whose agent binary lived in an install directory that wasn't in `BASE_SSH_PATH_DIRS` (e.g. Claude Code's local-install layout under `~/.claude/local`, or any Go-based CLI under `~/go/bin`).

Two changes:

1. **Extend `BASE_SSH_PATH_DIRS`** (`src/main/utils/ssh-command-builder.ts`) with the install locations the issue cites plus a few other common ones found in the wild:
   - `~/.claude/local` — Claude Code local-install / auto-update bundle
   - `~/go/bin` — Go default `GOBIN` (Factory Droid and other Go-based CLIs)
   - `~/.bun/bin` — Bun + bunx-installed CLIs
   - `~/.deno/bin` — Deno-installed CLIs
   - `~/.nix-profile/bin` — Nix user profile binaries
   - `/snap/bin` — Linux snap-installed binaries

   `~/.local/bin` (the path the reporter reproduced with) was already covered.

2. **Swap `which` → POSIX `command -v`** in both `detectAgentsRemote()` and the `agents:get` SSH path (`src/main/ipc/handlers/agents.ts`). `command -v` is a shell builtin (no PATH lookup needed, no dependency on `/usr/bin/which` being installed), and behaves consistently across bash/dash/zsh. The probe already runs inside `/bin/bash --norc --noprofile -c '...'` via `buildSshCommand()`, so the builtin resolves correctly.

The reporter's claim that `which` is invoked against a minimal SSH non-login PATH is no longer accurate as of the current `rc` — `buildSshCommand()` wraps every remote command in a bash invocation that prepends a curated PATH. But the curated list was missing the install locations they hit, so the symptom is real.

## Test plan

- [x] `vitest run src/__tests__/main/utils/ssh-command-builder.test.ts` — extended PATH-coverage test asserts every new entry appears in both the bash `-c` wrapper and the stdin script.
- [x] `vitest run src/__tests__/main/ipc/handlers/agents.test.ts` — new `SSH remote detection (issue #878)` block exercises `agents:detect` with an `sshRemoteId` and verifies (a) every probe uses `command -v` rather than `which`, (b) the resolved path is parsed and surfaced, (c) non-zero exit marks the agent unavailable.
- [x] `prettier --check` and `eslint` clean on all touched files.
- [ ] Manual SSH detection against a remote with `claude` installed under `~/.claude/local/claude` (recommended for the reporter to confirm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SSH remote agent detection to properly search additional common installation paths where agent binaries may be located (e.g., package manager directories).
  * Improved remote agent availability resolution over SSH connections with more robust binary location detection methods.

* **Tests**
  * Added comprehensive test suite validating SSH remote agent detection and installation path resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->