### PR TITLE
fix(ssh): readDirRemote fails on dirs without symlinks (for-loop exit regression)

### DIFF
--- a/src/__tests__/main/utils/remote-fs.test.ts
+++ b/src/__tests__/main/utils/remote-fs.test.ts
@@ -204,6 +204,34 @@ describe('remote-fs', () => {
 			const remoteCommand = call[call.length - 1];
 			expect(remoteCommand).toMatch(/done 2>\/dev\/null \|\| true$/);
 		});
+
+		// The marker-based tolerance is intentionally narrow — anything that
+		// doesn't match the known for-loop-tail shape must still surface as
+		// a failure so we don't silently swallow SSH/transport errors.
+		it('propagates failure when marker is present but stderr is non-empty', async () => {
+			const deps = createMockDeps({
+				stdout: 'src/\n__SYMDIR__\n',
+				stderr: 'ssh: connect to host X port 22: Connection refused',
+				exitCode: 1,
+			});
+
+			const result = await readDirRemote('/home/user/project', baseConfig, deps);
+
+			expect(result.success).toBe(false);
+			expect(result.error).toContain('Connection refused');
+		});
+
+		it('propagates failure when marker is present but exit code is not 1', async () => {
+			const deps = createMockDeps({
+				stdout: 'src/\n__SYMDIR__\n',
+				stderr: '',
+				exitCode: 255, // typical ssh transport failure
+			});
+
+			const result = await readDirRemote('/home/user/project', baseConfig, deps);
+
+			expect(result.success).toBe(false);
+		});
 	});
 
 	describe('readFileRemote', () => {

--- a/src/__tests__/main/utils/remote-fs.test.ts
+++ b/src/__tests__/main/utils/remote-fs.test.ts
@@ -168,6 +168,42 @@ describe('remote-fs', () => {
 			// Path should be properly escaped in the command
 			expect(remoteCommand).toContain("'/path/with spaces/and'\\''quotes'");
 		});
+
+		// Regression: when the target directory contains no symlink-to-dir
+		// entries, the trailing `for` loop's last `[ -L "$f" ]` test returns
+		// non-zero, which becomes the overall exit code of the remote command.
+		// Before the `|| true` fix, readDirRemote treated a successful `ls` as
+		// a failure (stderr is swallowed by `2>/dev/null`, so the only signal
+		// was Node's "Command failed" boilerplate). See PR description.
+		it('still succeeds when for-loop tail exits non-zero but ls output is valid', async () => {
+			const deps = createMockDeps({
+				stdout: 'src/\npackage.json\n__SYMDIR__\n',
+				stderr: '',
+				exitCode: 1,
+			});
+
+			const result = await readDirRemote('/home/user/project', baseConfig, deps);
+
+			expect(result.success).toBe(true);
+			expect(result.data).toEqual([
+				{ name: 'src', isDirectory: true, isSymlink: false },
+				{ name: 'package.json', isDirectory: false, isSymlink: false },
+			]);
+		});
+
+		it('appends "|| true" to the symlink scan so the pipeline cannot exit non-zero', async () => {
+			const deps = createMockDeps({
+				stdout: 'file.txt\n__SYMDIR__\n',
+				stderr: '',
+				exitCode: 0,
+			});
+
+			await readDirRemote('/some/dir', baseConfig, deps);
+
+			const call = (deps.execSsh as any).mock.calls[0][1];
+			const remoteCommand = call[call.length - 1];
+			expect(remoteCommand).toMatch(/done 2>\/dev\/null \|\| true$/);
+		});
 	});
 
 	describe('readFileRemote', () => {

--- a/src/main/utils/remote-fs.ts
+++ b/src/main/utils/remote-fs.ts
@@ -229,10 +229,14 @@ export async function readDirRemote(
 	// We avoid a plain "/.*" because it matches "." and ".." on most shells.
 	// Unmatched globs are passed literally, but [ -L ] fails on them so nothing
 	// spurious is printed. Errors are redirected to /dev/null regardless.
+	// The trailing `|| true` keeps the remote command's exit code 0 even when
+	// the final iteration's `[ -L ]` test fails (i.e. no symlink-to-dir
+	// entries) — otherwise the whole SSH invocation exits non-zero and the
+	// caller treats a successful `ls` as a failure.
 	const escapedPath = shellEscape(dirPath);
 	const symlinkScan =
 		`for f in ${escapedPath}/* ${escapedPath}/.[!.]* ${escapedPath}/..?*; ` +
-		`do [ -L "$f" ] && [ -d "$f" ] && basename "$f"; done 2>/dev/null`;
+		`do [ -L "$f" ] && [ -d "$f" ] && basename "$f"; done 2>/dev/null || true`;
 	const remoteCommand =
 		`ls -1AF --color=never ${escapedPath} 2>/dev/null || echo "__LS_ERROR__"; ` +
 		`echo "__SYMDIR__"; ` +
@@ -240,7 +244,13 @@ export async function readDirRemote(
 
 	const result = await execRemoteCommand(sshRemote, remoteCommand, deps);
 
-	if (result.exitCode !== 0 && !result.stdout.includes('__LS_ERROR__')) {
+	// The presence of the __SYMDIR__ marker means the pipeline reached the
+	// symlink scan, which implies `ls` already ran to completion (or emitted
+	// __LS_ERROR__). Treat that as success from a transport standpoint even
+	// if the final `for` loop produced a non-zero exit — see the `|| true`
+	// comment above, and the regression test covering this case.
+	const reachedSymlinkMarker = result.stdout.includes('__SYMDIR__');
+	if (result.exitCode !== 0 && !result.stdout.includes('__LS_ERROR__') && !reachedSymlinkMarker) {
 		return {
 			success: false,
 			error: result.stderr || `ls failed with exit code ${result.exitCode}`,

--- a/src/main/utils/remote-fs.ts
+++ b/src/main/utils/remote-fs.ts
@@ -244,13 +244,21 @@ export async function readDirRemote(
 
 	const result = await execRemoteCommand(sshRemote, remoteCommand, deps);
 
-	// The presence of the __SYMDIR__ marker means the pipeline reached the
-	// symlink scan, which implies `ls` already ran to completion (or emitted
-	// __LS_ERROR__). Treat that as success from a transport standpoint even
-	// if the final `for` loop produced a non-zero exit — see the `|| true`
-	// comment above, and the regression test covering this case.
+	// Defense-in-depth for the for-loop-tail regression: even with `|| true`
+	// in place, tolerate the specific known shape (exit 1, no stderr, marker
+	// present) so an accidental future shell-command regression surfaces as
+	// degraded output rather than a blank error wall. Anything else — a real
+	// transport failure, a different exit code, or any stderr — still
+	// propagates so we don't silently swallow SSH/network issues.
 	const reachedSymlinkMarker = result.stdout.includes('__SYMDIR__');
-	if (result.exitCode !== 0 && !result.stdout.includes('__LS_ERROR__') && !reachedSymlinkMarker) {
+	const hasLsErrorMarker = result.stdout.includes('__LS_ERROR__');
+	const toleratedSymlinkScanExit =
+		result.exitCode === 1 &&
+		reachedSymlinkMarker &&
+		!hasLsErrorMarker &&
+		result.stderr.trim() === '';
+
+	if (result.exitCode !== 0 && !hasLsErrorMarker && !toleratedSymlinkScanExit) {
 		return {
 			success: false,
 			error: result.stderr || `ls failed with exit code ${result.exitCode}`,


### PR DESCRIPTION
## Summary

- **Regression introduced by #??? (`ea95a418c`, Apr 13)** — *fix: resolve symlinks in Files panel and Auto Run folder tree*. `readDirRemote` appends a `for` loop that probes each entry for symlink-to-dir status; when the target dir has no such entries the loop's last `[ -L "\$f" ]` test returns non-zero, becoming the overall SSH exit code. Because every stderr is silenced by `2>/dev/null`, the caller only saw Node's generic ``Command failed: <cmd>`` even though `ls` output was valid. Surfaced in production as `fs:readDir` errors opening the Files panel on remote containers that host only regular directories (e.g. `/home/` with a single user dir).
- **Fix**: append `|| true` to the symlink scan so a successful `ls` can't be masked by the for-loop tail; additionally accept a non-zero exit as long as `__SYMDIR__` is present in stdout (defense-in-depth — existing tests mock `execSsh` with `exitCode: 0`, so this regression was invisible to CI).
- **Tests**: regression case asserting `success: true` when stdout is valid but `exitCode === 1`, plus a shape assertion that the emitted remote command ends with `done 2>/dev/null || true`.

## Reproduction

```sh
bash -c 'ls -1AF --color=never /home/ 2>/dev/null || echo "__LS_ERROR__"; echo "__SYMDIR__"; for f in /home/* /home/.[!.]* /home/..?*; do [ -L "\$f" ] && [ -d "\$f" ] && basename "\$f"; done 2>/dev/null; echo "EXIT=\$?"'
# EXIT=1   (without the patch)
# EXIT=0   (with `|| true`)
```

## Test plan

- [x] `npx vitest run src/__tests__/main/utils/remote-fs.test.ts` (55 passed)
- [x] `npx vitest run src/__tests__/main/ipc/handlers/filesystem.test.ts` (43 passed)
- [x] `npx vitest run src/__tests__/main/ipc/handlers/autorun.test.ts` (84 passed)
- [x] `npx prettier --check` on touched files
- [x] `npm run lint:eslint` on touched files (no errors)
- [ ] Manual: open Files panel against an SSH remote whose target dir has no symlink-to-dir entries; confirm listing renders instead of surfacing ``Error invoking remote method 'fs:readDir': Error: Command failed: …``

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a regression in remote directory reads involving symlinked targets so valid listings no longer fail when the remote scan produces a tolerated non-zero exit status; operations still fail appropriately when real errors are detected.

* **Tests**
  * Added tests covering symlink-related remote directory reads, ensuring parsing succeeds for tolerated exit scenarios and failures are preserved for genuine errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->