### PR TITLE
fix(group-chat): pass global shell env vars to moderator/participant spawns

### DIFF
--- a/src/__tests__/main/group-chat/group-chat-router.test.ts
+++ b/src/__tests__/main/group-chat/group-chat-router.test.ts
@@ -47,10 +47,14 @@ vi.mock('../../../main/utils/ssh-spawn-wrapper', () => ({
 }));
 
 // Mock stores/getters: router reads global shellEnvVars via getSettingsStore().
-// Return an empty settings store so spawns receive an empty shellEnvVars map.
+// The mock is driven by `mockedShellEnvVars` so individual tests can assert the
+// value actually flows through to processManager.spawn() and (for SSH) into
+// wrapSpawnWithSsh's customEnvVars input.
+let mockedShellEnvVars: Record<string, string> = {};
 vi.mock('../../../main/stores/getters', () => ({
 	getSettingsStore: () => ({
-		get: (_key: string, defaultValue: unknown) => defaultValue,
+		get: (key: string, defaultValue: unknown) =>
+			key === 'shellEnvVars' ? mockedShellEnvVars : defaultValue,
 	}),
 }));
 
@@ -101,6 +105,9 @@ describe('group-chat-router', () => {
 
 		// Set the mock userData path to our test directory
 		mockUserDataPath = testDir;
+
+		// Reset the global-settings shell env mock between tests
+		mockedShellEnvVars = {};
 
 		// Create a fresh mock for each test
 		mockProcessManager = {
@@ -1055,6 +1062,132 @@ describe('group-chat-router', () => {
 
 			// SSH wrapper should NOT be called for local sessions
 			expect(mockWrapSpawnWithSsh).not.toHaveBeenCalled();
+		});
+	});
+
+	// ===========================================================================
+	// Global shell env vars from Settings → Shell Configuration must flow into
+	// moderator / participant spawns for the local path, and must be merged into
+	// customEnvVars (per-agent takes precedence) for the SSH path so they reach
+	// the remote agent via the SSH stdin script.
+	// ===========================================================================
+	describe('global shell env vars forwarded to spawns', () => {
+		it('moderator spawn receives globally-configured shellEnvVars', async () => {
+			mockedShellEnvVars = { ANTHROPIC_API_KEY: 'sentinel-moderator-key' };
+			const chat = await createTestChatWithModerator('Moderator ShellEnv Test');
+
+			await routeUserMessage(chat.id, 'Hello', mockProcessManager, mockAgentDetector);
+
+			expect(mockProcessManager.spawn).toHaveBeenCalledWith(
+				expect.objectContaining({
+					shellEnvVars: { ANTHROPIC_API_KEY: 'sentinel-moderator-key' },
+				})
+			);
+		});
+
+		it('participant spawn receives globally-configured shellEnvVars', async () => {
+			mockedShellEnvVars = { ANTHROPIC_API_KEY: 'sentinel-participant-key' };
+			const chat = await createTestChatWithModerator('Participant ShellEnv Test');
+			await addParticipant(chat.id, 'Client', 'claude-code', mockProcessManager);
+
+			mockProcessManager.spawn.mockClear();
+
+			await routeModeratorResponse(
+				chat.id,
+				'@Client please help',
+				mockProcessManager,
+				mockAgentDetector
+			);
+
+			const participantSpawn = mockProcessManager.spawn.mock.calls.find((call) =>
+				call[0].prompt?.includes('please help')
+			);
+			expect(participantSpawn).toBeDefined();
+			expect(participantSpawn![0]).toEqual(
+				expect.objectContaining({
+					shellEnvVars: { ANTHROPIC_API_KEY: 'sentinel-participant-key' },
+				})
+			);
+		});
+
+		it('SSH participant spawn merges shellEnvVars into customEnvVars with per-agent precedence', async () => {
+			// SSH wrapper strips customEnvVars after embedding them into the remote script,
+			// so assertions target the INPUT to wrapSpawnWithSsh — that's where globals must land.
+			mockedShellEnvVars = {
+				ANTHROPIC_API_KEY: 'sentinel-global-key',
+				GLOBAL_ONLY: 'global-value',
+			};
+
+			mockWrapSpawnWithSsh.mockResolvedValue({
+				command: 'ssh',
+				args: ['user@pedtome.local', 'claude', '--print'],
+				cwd: '/home/user/project',
+				prompt: 'test prompt',
+				customEnvVars: undefined,
+				sshRemoteUsed: { name: 'PedTome' },
+			});
+			const mockSshStore = {
+				getSshRemotes: vi
+					.fn()
+					.mockReturnValue([
+						{ id: 'remote-1', name: 'PedTome', host: 'pedtome.local', user: 'user' },
+					]),
+			};
+			const sshRemoteConfig = {
+				enabled: true,
+				remoteId: 'remote-1',
+				workingDirOverride: '/home/user/project',
+			};
+
+			const chat = await createTestChatWithModerator('SSH Participant ShellEnv Test');
+
+			// Session-level override: should win over the global sentinel for the same key.
+			const sshSession: SessionInfo = {
+				id: 'ses-ssh-shellenv',
+				name: 'SSHWorker',
+				toolType: 'claude-code',
+				cwd: '/home/user/project',
+				sshRemoteName: 'PedTome',
+				sshRemoteConfig,
+				customEnvVars: { ANTHROPIC_API_KEY: 'per-agent-override' },
+			};
+			setGetSessionsCallback(() => [sshSession]);
+			setSshStore(mockSshStore);
+
+			await addParticipant(
+				chat.id,
+				'SSHWorker',
+				'claude-code',
+				mockProcessManager,
+				'/home/user/project',
+				mockAgentDetector,
+				{},
+				undefined,
+				{ sshRemoteName: 'PedTome', sshRemoteConfig },
+				mockSshStore
+			);
+
+			mockWrapSpawnWithSsh.mockClear();
+
+			await routeModeratorResponse(
+				chat.id,
+				'@SSHWorker implement the feature',
+				mockProcessManager,
+				mockAgentDetector
+			);
+
+			expect(mockWrapSpawnWithSsh).toHaveBeenCalledWith(
+				expect.objectContaining({
+					customEnvVars: {
+						GLOBAL_ONLY: 'global-value',
+						ANTHROPIC_API_KEY: 'per-agent-override',
+					},
+				}),
+				sshRemoteConfig,
+				mockSshStore
+			);
+
+			mockWrapSpawnWithSsh.mockReset();
 		});
 	});
 });

--- a/src/__tests__/main/group-chat/group-chat-router.test.ts
+++ b/src/__tests__/main/group-chat/group-chat-router.test.ts
@@ -46,6 +46,14 @@ vi.mock('../../../main/utils/ssh-spawn-wrapper', () => ({
 	wrapSpawnWithSsh: (...args: unknown[]) => mockWrapSpawnWithSsh(...args),
 }));
 
+// Mock stores/getters: router reads global shellEnvVars via getSettingsStore().
+// Return an empty settings store so spawns receive an empty shellEnvVars map.
+vi.mock('../../../main/stores/getters', () => ({
+	getSettingsStore: () => ({
+		get: (_key: string, defaultValue: unknown) => defaultValue,
+	}),
+}));
+
 import {
 	extractMentions,
 	extractAllMentions,

--- a/src/main/group-chat/group-chat-moderator.ts
+++ b/src/main/group-chat/group-chat-moderator.ts
@@ -28,6 +28,8 @@ export interface IProcessManager {
 		readOnlyMode?: boolean;
 		prompt?: string;
 		customEnvVars?: Record<string, string>;
+		/** Global shell env vars from Settings → Shell Configuration (merged by envBuilder). */
+		shellEnvVars?: Record<string, string>;
 		contextWindow?: number;
 		promptArgs?: (prompt: string) => string[];
 		noPromptSeparator?: boolean;

--- a/src/main/group-chat/group-chat-router.ts
+++ b/src/main/group-chat/group-chat-router.ts
@@ -69,6 +69,19 @@ function getGlobalShellEnvVars(): Record<string, string> {
 }
 
 /**
+ * Merge global shell env vars with per-agent custom env vars, with per-agent
+ * taking precedence. Used before calling `wrapSpawnWithSsh()` so that the
+ * global vars are embedded into the remote SSH stdin script — otherwise they
+ * would only land on the local ssh client process and never reach the remote
+ * agent. Mirrors `ipc/handlers/process.ts:437`.
+ */
+function mergeGlobalShellWithCustomEnv(
+	customEnvVars: Record<string, string> | undefined
+): Record<string, string> {
+	return { ...getGlobalShellEnvVars(), ...(customEnvVars || {}) };
+}
+
+/**
  * Session info for matching @mentions to available Maestro sessions.
  */
 export interface SessionInfo {
@@ -783,9 +796,7 @@ ${message}`;
 							args: finalArgs,
 							cwd: os.homedir(),
 							prompt: fullPrompt,
-							customEnvVars:
-								configResolution.effectiveCustomEnvVars ??
-								getCustomEnvVarsCallback?.(chat.moderatorAgentId),
+							customEnvVars: mergeGlobalShellWithCustomEnv(spawnEnvVars),
 							promptArgs: agent.promptArgs,
 							noPromptSeparator: agent.noPromptSeparator,
 							agentBinaryName: agent.binaryName,
@@ -1273,9 +1284,7 @@ export async function routeModeratorResponse(
 							args: spawnArgs,
 							cwd,
 							prompt: participantPrompt,
-							customEnvVars:
-								configResolution.effectiveCustomEnvVars ??
-								getCustomEnvVarsCallback?.(participant.agentId),
+							customEnvVars: mergeGlobalShellWithCustomEnv(finalSpawnEnvVars),
 							promptArgs: agent.promptArgs,
 							noPromptSeparator: agent.noPromptSeparator,
 							agentBinaryName: agent.binaryName,
@@ -1695,9 +1704,7 @@ Review the agent responses above. Either:
 					args: finalArgs,
 					cwd: os.homedir(),
 					prompt: synthesisPrompt,
-					customEnvVars:
-						configResolution.effectiveCustomEnvVars ??
-						getCustomEnvVarsCallback?.(chat.moderatorAgentId),
+					customEnvVars: mergeGlobalShellWithCustomEnv(spawnEnvVars),
 					promptArgs: agent.promptArgs,
 					noPromptSeparator: agent.noPromptSeparator,
 					agentBinaryName: agent.binaryName,
@@ -1897,7 +1904,7 @@ export async function respawnParticipantWithRecovery(
 				args: finalSpawnArgs,
 				cwd,
 				prompt: fullPrompt,
-				customEnvVars: finalSpawnEnvVars,
+				customEnvVars: mergeGlobalShellWithCustomEnv(finalSpawnEnvVars),
 				promptArgs: agent.promptArgs,
 				noPromptSeparator: agent.noPromptSeparator,
 				agentBinaryName: agent.binaryName,

--- a/src/main/group-chat/group-chat-router.ts
+++ b/src/main/group-chat/group-chat-router.ts
@@ -48,6 +48,7 @@ import { groupChatParticipantRequestPrompt } from '../../prompts';
 import { wrapSpawnWithSsh } from '../utils/ssh-spawn-wrapper';
 import type { SshRemoteSettingsStore } from '../utils/ssh-remote-resolver';
 import { setGetCustomShellPathCallback, getWindowsSpawnConfig } from './group-chat-config';
+import { getSettingsStore } from '../stores/getters';
 
 // Import emitters from IPC handlers (will be populated after handlers are registered)
 import { groupChatEmitters } from '../ipc/handlers/groupChat';
@@ -56,6 +57,16 @@ const LOG_CONTEXT = '[GroupChatRouter]';
 
 // Re-export setGetCustomShellPathCallback for index.ts to use
 export { setGetCustomShellPathCallback };
+
+/**
+ * Read global shell env vars from Settings → Shell Configuration.
+ * Mirrors the individual-chat path in `ipc/handlers/process.ts` so that
+ * group-chat moderator / participant / synthesis / recovery spawns receive
+ * the same merged environment.
+ */
+function getGlobalShellEnvVars(): Record<string, string> {
+	return getSettingsStore().get('shellEnvVars', {}) as Record<string, string>;
+}
 
 /**
  * Session info for matching @mentions to available Maestro sessions.
@@ -813,6 +824,7 @@ ${message}`;
 					prompt: spawnPrompt,
 					contextWindow: getContextWindowValue(agent, agentConfigValues),
 					customEnvVars: spawnEnvVars,
+					shellEnvVars: getGlobalShellEnvVars(),
 					promptArgs: agent.promptArgs,
 					noPromptSeparator: agent.noPromptSeparator,
 					shell: spawnShell,
@@ -1304,6 +1316,7 @@ export async function routeModeratorResponse(
 					prompt: finalSpawnPrompt,
 					contextWindow: getContextWindowValue(agent, agentConfigValues),
 					customEnvVars: finalSpawnEnvVars,
+					shellEnvVars: getGlobalShellEnvVars(),
 					promptArgs: agent.promptArgs,
 					noPromptSeparator: agent.noPromptSeparator,
 					shell: finalSpawnShell,
@@ -1723,6 +1736,7 @@ Review the agent responses above. Either:
 			prompt: spawnPrompt,
 			contextWindow: getContextWindowValue(agent, agentConfigValues),
 			customEnvVars: spawnEnvVars,
+			shellEnvVars: getGlobalShellEnvVars(),
 			promptArgs: agent.promptArgs,
 			noPromptSeparator: agent.noPromptSeparator,
 			shell: winConfig.shell,
@@ -1921,6 +1935,7 @@ export async function respawnParticipantWithRecovery(
 		prompt: finalSpawnPrompt,
 		contextWindow: getContextWindowValue(agent, agentConfigValues),
 		customEnvVars: finalSpawnEnvVars,
+		shellEnvVars: getGlobalShellEnvVars(),
 		promptArgs: agent.promptArgs,
 		noPromptSeparator: agent.noPromptSeparator,
 		shell: finalSpawnShell,

--- a/src/main/ipc/handlers/groupChat.ts
+++ b/src/main/ipc/handlers/groupChat.ts
@@ -136,8 +136,15 @@ interface GenericProcessManager {
 		readOnlyMode?: boolean;
 		prompt?: string;
 		customEnvVars?: Record<string, string>;
+		/** Global shell env vars from Settings → Shell Configuration (merged by envBuilder). */
+		shellEnvVars?: Record<string, string>;
 		contextWindow?: number;
+		promptArgs?: (prompt: string) => string[];
 		noPromptSeparator?: boolean;
+		shell?: string;
+		runInShell?: boolean;
+		sendPromptViaStdin?: boolean;
+		sendPromptViaStdinRaw?: boolean;
 	}): { pid: number; success: boolean };
 	write(sessionId: string, data: string): boolean;
 	kill(sessionId: string): boolean;


### PR DESCRIPTION
Fixes #886.

## Summary

Group Chat spawns in `group-chat-router.ts` were calling `processManager.spawn()` without `shellEnvVars`, so environment variables set in **Settings → Shell Configuration → Global Environment Variables** were not merged into the child process environment. Individual (1-on-1) chats go through `ipc/handlers/process.ts` which already passes `shellEnvVars` correctly, so this bug only affected Group Chats.

In practice, users relying on a globally-configured `ANTHROPIC_API_KEY` (or `ANTHROPIC_AUTH_TOKEN` / `ANTHROPIC_BASE_URL`) saw the moderator immediately fail with a synthetic auth-failed stub from the Claude CLI:

```json
{ "model": "<synthetic>", "error": "authentication_failed" }
```

because `envBuilder.ts` strips `CLAUDECODE` / `CLAUDE_CODE_*` / `ELECTRON_*` and the merged `shellEnvVars` layer was missing, so the CLI launched with no credentials.

## Changes

- `src/main/group-chat/group-chat-router.ts`
  - Add `getGlobalShellEnvVars()` helper that reads from `getSettingsStore()` (mirrors `ipc/handlers/process.ts:230`).
  - Pass `shellEnvVars: getGlobalShellEnvVars()` at all **four** `processManager.spawn()` sites: moderator (initial routing), participant, moderator synthesis, and participant recovery.
- `src/main/group-chat/group-chat-moderator.ts`
  - Add optional `shellEnvVars?: Record<string, string>` to the `IProcessManager.spawn` config type so the router's calls typecheck. Matches the existing `ProcessConfig.shellEnvVars` field.
- `src/__tests__/main/group-chat/group-chat-router.test.ts`
  - Mock `stores/getters` so the router tests don't blow up on uninitialized stores (the 17 spawn-path tests previously passed because the router never called `getSettingsStore()`; now they need it stubbed).

## Test plan

- [x] `npm run lint` — clean
- [x] `npx vitest run src/__tests__/main/group-chat/group-chat-router.test.ts` — 61/61 pass
- [x] `npx vitest run` (full suite) — 22521/22522 pass; the single failure (`stats/integration.test.ts > electron-rebuild verification for better-sqlite3`) is a native-module env check unrelated to this change and fails on `main` in environments where `electron-rebuild`'s gyp build can't complete.
- [ ] Manual: set `ANTHROPIC_API_KEY` in Settings → Shell Configuration, start a Group Chat with Claude Code as moderator, confirm moderator responds without `authentication_failed`.

## Notes

- This is the class of bug catalogued in #317 ("Centralized Process Spawning") — the group-chat spawn sites were apparently missed in that pass. A follow-up centralizing all eight spawn sites behind a single helper would prevent recurrence, but I've kept this PR scoped to the minimal behavioural fix.
- Precedence preserved: `customEnvVars` (per-agent / per-moderator) still wins over `shellEnvVars` (global) per `envBuilder.ts:199-238`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added targeted tests to verify propagation and merging of global shell environment variables into group-chat spawn flows, with per-test isolation to prevent state leakage.

* **Refactor**
  * Consistently apply globally configured shell environment variables across moderator, synthesis, and participant subprocesses; per-session custom variables take precedence on conflict.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->