### PR TITLE
feat(cli): honor session config overrides + SSH remote when spawning agents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -363,6 +363,18 @@ if (sshStore && session.sshRemoteConfig?.enabled) {
 - The correct agent type is used (don't hardcode `claude-code`)
 - Custom agent configuration (customPath, customArgs, customEnvVars) is passed through
 - Agent's `binaryName` is used for remote execution (not local paths)
+- When the user enabled SSH but the configured remote can't be resolved, **fail
+  loudly** instead of silently running locally — the user explicitly opted into
+  SSH and their prompt shouldn't leak to the local machine (see
+  `sshUnresolvedFailure()` in `src/cli/services/agent-spawner.ts` for the CLI's
+  version of this).
+
+**CLI parity:** The CLI (`src/cli/services/agent-spawner.ts`) spawns agent
+processes for batch/playbook automation and honors the same SSH wrapping and
+agent-config overrides as the desktop app. When adding new CLI spawn sites,
+thread `sessionSshRemoteConfig`, `customArgs`, `customEnvVars`, `customModel`,
+`customEffort` through to `spawnAgent(...)`. The CLI loads `ssh-spawn-wrapper`
+via dynamic `import()` so the SSH chain stays out of the local hot path.
 
 See [[CLAUDE-PATTERNS.md]] for detailed SSH patterns.
 

--- a/docs/agent-guides/CLI-PLAYBOOKS.md
+++ b/docs/agent-guides/CLI-PLAYBOOKS.md
@@ -397,13 +397,23 @@ Codex, OpenCode, and Factory Droid use the shared `AgentOutputParser` interface 
 
 ### CLI vs Desktop Spawning
 
-The CLI spawner is simpler than the desktop process manager:
+The CLI spawner is simpler than the desktop process manager but honors the same
+per-agent/per-session overrides that users configure in the desktop app:
 
-- No SSH wrapping (remote execution not supported)
-- No custom model, args, or env var overrides
-- No PTY (uses plain child_process spawn)
-- No real-time output streaming to UI
-- Designed for headless batch execution
+- **Honored**: custom binary path, custom CLI args, custom env vars, custom model,
+  custom effort/reasoning — all merged via `applyAgentConfigOverrides()` just
+  like the desktop (`session` wins over `agent config` wins over defaults).
+- **Honored**: SSH remote execution — when `sessionSshRemoteConfig.enabled` is
+  true, the spawn is wrapped via `wrapSpawnWithSsh()` (dynamic import so the
+  SSH chain stays out of the local hot path). If the configured remote can't
+  be resolved, the CLI returns a clear error instead of silently falling back
+  to local — users who opt into SSH don't want their prompt leaking locally.
+- **Not applicable**: PTY (CLI uses plain `child_process.spawn`), real-time
+  output streaming to UI.
+
+See `src/cli/services/agent-spawner.ts` — the `resolveAgentOverrides()` helper
+and `maybeWrapSpawnWithSsh()` are the CLI-side equivalents of the desktop
+`process:spawn` IPC handler's override + SSH wrapping logic.
 
 ---
 

--- a/src/__tests__/cli/services/agent-spawner.test.ts
+++ b/src/__tests__/cli/services/agent-spawner.test.ts
@@ -1754,16 +1754,18 @@ Some text with [x] in it that's not a checkbox
 			const prev = process.env.MAESTRO_TEST_ENV;
 			process.env.MAESTRO_TEST_ENV = 'from-shell';
 
-			const p = spawnAgent('claude-code', '/p', 'hi', undefined, {
-				customEnvVars: { MAESTRO_TEST_ENV: 'from-session' },
-			});
-			await driveSpawnToCompletion(p, 0, CLAUDE_OK());
+			try {
+				const p = spawnAgent('claude-code', '/p', 'hi', undefined, {
+					customEnvVars: { MAESTRO_TEST_ENV: 'from-session' },
+				});
+				await driveSpawnToCompletion(p, 0, CLAUDE_OK());
 
-			const { options } = spawnCall();
-			expect(options.env.MAESTRO_TEST_ENV).toBe('from-session');
-
-			if (prev === undefined) delete process.env.MAESTRO_TEST_ENV;
-			else process.env.MAESTRO_TEST_ENV = prev;
+				const { options } = spawnCall();
+				expect(options.env.MAESTRO_TEST_ENV).toBe('from-session');
+			} finally {
+				if (prev === undefined) delete process.env.MAESTRO_TEST_ENV;
+				else process.env.MAESTRO_TEST_ENV = prev;
+			}
 		});
 
 		it('session customEnvVars wins over agent-level customEnvVars', async () => {

--- a/src/__tests__/cli/services/agent-spawner.test.ts
+++ b/src/__tests__/cli/services/agent-spawner.test.ts
@@ -23,6 +23,7 @@ import { EventEmitter } from 'events';
 const mockSpawn = vi.fn();
 const mockStdin = {
 	end: vi.fn(),
+	write: vi.fn(),
 };
 const mockStdout = new EventEmitter();
 const mockStderr = new EventEmitter();
@@ -93,8 +94,18 @@ vi.mock('os', async () => {
 
 // Mock storage service
 const mockGetAgentCustomPath = vi.fn();
+const mockReadAgentConfig = vi.fn<(toolType: string) => Record<string, unknown>>(() => ({}));
+const mockReadSshRemotes = vi.fn<() => unknown[]>(() => []);
 vi.mock('../../../cli/services/storage', () => ({
 	getAgentCustomPath: (...args: unknown[]) => mockGetAgentCustomPath(...args),
+	readAgentConfig: (toolType: string) => mockReadAgentConfig(toolType),
+	readSshRemotes: () => mockReadSshRemotes(),
+}));
+
+// Mock SSH wrapper so SSH tests don't need real ssh/bash on the test machine
+const mockWrapSpawnWithSsh = vi.fn();
+vi.mock('../../../main/utils/ssh-spawn-wrapper', () => ({
+	wrapSpawnWithSsh: (...args: unknown[]) => mockWrapSpawnWithSsh(...args),
 }));
 
 import {
@@ -118,6 +129,9 @@ describe('agent-spawner', () => {
 		mockStderr.removeAllListeners();
 		(mockChild as EventEmitter).removeAllListeners();
 		mockGetAgentCustomPath.mockReturnValue(undefined);
+		mockReadAgentConfig.mockReturnValue({});
+		mockReadSshRemotes.mockReturnValue([]);
+		mockWrapSpawnWithSsh.mockReset();
 	});
 
 	afterEach(() => {
@@ -1618,6 +1632,418 @@ Some text with [x] in it that's not a checkbox
 			expect(fs.promises.access).not.toHaveBeenCalled();
 
 			Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+		});
+	});
+
+	// ========================================================================
+	// Config override + SSH remote tests
+	// ========================================================================
+	//
+	// These tests cover the CLI's agent-config override path
+	// (applyAgentConfigOverrides) and the SSH remote wrapper integration.
+	//
+	// The spawn flow is driven by fake events on mockChild so we can assert
+	// on the *inputs* to spawn() (command, args, env) without running anything.
+	// runSpawn() schedules a "close" event on the next tick so the promise
+	// resolves; tests call it before awaiting the spawnAgent promise.
+
+	/** Yield to the microtask queue so spawn() runs and event listeners attach. */
+	const yieldTick = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+	/**
+	 * Wait until mockSpawn has been called at least `minCalls` times, or until
+	 * the per-poll attempts run out. First-run dynamic imports (ssh-spawn-wrapper)
+	 * can take several ticks, so we poll rather than assume spawn fires quickly.
+	 */
+	async function waitForSpawnCall(minCalls = 1, attempts = 50): Promise<void> {
+		for (let i = 0; i < attempts; i++) {
+			if (mockSpawn.mock.calls.length >= minCalls) return;
+			await yieldTick();
+		}
+	}
+
+	/**
+	 * Drive a spawnAgent promise to resolution. Waits for spawn to be called
+	 * (guarantees listeners are attached), emits stdout data, then emits a
+	 * close event. Returns the agent result.
+	 */
+	async function driveSpawnToCompletion(
+		resultPromise: Promise<AgentResult>,
+		code = 0,
+		output = ''
+	): Promise<AgentResult> {
+		// Race the spawn call against a soft timeout so tests that legitimately
+		// never call spawn (e.g., SSH hard-fail path) still resolve quickly via
+		// the promise they're awaiting rather than hanging here.
+		await Promise.race([waitForSpawnCall(), resultPromise.then(() => {})]);
+		if (mockSpawn.mock.calls.length > 0) {
+			if (output) mockStdout.emit('data', Buffer.from(output));
+			await yieldTick();
+			(mockChild as EventEmitter).emit('close', code);
+		}
+		return resultPromise;
+	}
+
+	/** Grab the (command, args, options) triple passed to spawn(). */
+	function spawnCall(): { command: string; args: string[]; options: { env: NodeJS.ProcessEnv } } {
+		expect(mockSpawn).toHaveBeenCalled();
+		const [command, args, options] = mockSpawn.mock.calls[0] as [
+			string,
+			string[],
+			{ env: NodeJS.ProcessEnv },
+		];
+		return { command, args, options };
+	}
+
+	const CLAUDE_OK = () => JSON.stringify({ type: 'result', result: 'ok' }) + '\n';
+	const CODEX_INIT = () => JSON.stringify({ type: 'task_started' }) + '\n';
+
+	describe('spawnAgent: local config overrides', () => {
+		beforeEach(() => {
+			mockSpawn.mockReturnValue(mockChild);
+		});
+
+		it('appends session customArgs to Claude spawn', async () => {
+			const p = spawnAgent('claude-code', '/p', 'hi', undefined, {
+				customArgs: '--verbose-extra --flag',
+			});
+			const result = await driveSpawnToCompletion(p, 0, CLAUDE_OK());
+
+			expect(result.success).toBe(true);
+			const { args } = spawnCall();
+			expect(args).toContain('--verbose-extra');
+			expect(args).toContain('--flag');
+		});
+
+		it('shell-quote-parses session customArgs (preserves spaces inside quotes)', async () => {
+			const p = spawnAgent('claude-code', '/p', 'hi', undefined, {
+				customArgs: '--foo "has spaces" --bar',
+			});
+			await driveSpawnToCompletion(p, 0, CLAUDE_OK());
+
+			const { args } = spawnCall();
+			expect(args).toContain('--foo');
+			expect(args).toContain('has spaces');
+			expect(args).toContain('--bar');
+		});
+
+		it('reads customArgs from agent-level config when session customArgs is not set', async () => {
+			mockReadAgentConfig.mockReturnValue({ customArgs: '--from-agent-config' });
+
+			const p = spawnAgent('claude-code', '/p', 'hi');
+			await driveSpawnToCompletion(p, 0, CLAUDE_OK());
+
+			const { args } = spawnCall();
+			expect(args).toContain('--from-agent-config');
+		});
+
+		it('session customArgs overrides agent-level customArgs', async () => {
+			mockReadAgentConfig.mockReturnValue({ customArgs: '--agent-level' });
+
+			const p = spawnAgent('claude-code', '/p', 'hi', undefined, {
+				customArgs: '--session-level',
+			});
+			await driveSpawnToCompletion(p, 0, CLAUDE_OK());
+
+			const { args } = spawnCall();
+			expect(args).toContain('--session-level');
+			expect(args).not.toContain('--agent-level');
+		});
+
+		it('applies session customEnvVars to local spawn env (wins over shell env)', async () => {
+			const prev = process.env.MAESTRO_TEST_ENV;
+			process.env.MAESTRO_TEST_ENV = 'from-shell';
+
+			const p = spawnAgent('claude-code', '/p', 'hi', undefined, {
+				customEnvVars: { MAESTRO_TEST_ENV: 'from-session' },
+			});
+			await driveSpawnToCompletion(p, 0, CLAUDE_OK());
+
+			const { options } = spawnCall();
+			expect(options.env.MAESTRO_TEST_ENV).toBe('from-session');
+
+			if (prev === undefined) delete process.env.MAESTRO_TEST_ENV;
+			else process.env.MAESTRO_TEST_ENV = prev;
+		});
+
+		it('session customEnvVars wins over agent-level customEnvVars', async () => {
+			mockReadAgentConfig.mockReturnValue({
+				customEnvVars: { MAESTRO_TEST_LAYER: 'agent' },
+			});
+
+			const p = spawnAgent('claude-code', '/p', 'hi', undefined, {
+				customEnvVars: { MAESTRO_TEST_LAYER: 'session' },
+			});
+			await driveSpawnToCompletion(p, 0, CLAUDE_OK());
+
+			const { options } = spawnCall();
+			expect(options.env.MAESTRO_TEST_LAYER).toBe('session');
+		});
+
+		it('applies customModel via configOptions argBuilder for Claude', async () => {
+			const p = spawnAgent('claude-code', '/p', 'hi', undefined, { customModel: 'opus' });
+			await driveSpawnToCompletion(p, 0, CLAUDE_OK());
+
+			const { args } = spawnCall();
+			const modelIdx = args.indexOf('--model');
+			expect(modelIdx).toBeGreaterThanOrEqual(0);
+			expect(args[modelIdx + 1]).toBe('opus');
+		});
+
+		it('applies customModel for Codex (JSON-line agent)', async () => {
+			const p = spawnAgent('codex', '/p', 'hi', undefined, { customModel: 'gpt-5.3-codex' });
+			await driveSpawnToCompletion(p, 0, CODEX_INIT());
+
+			const { args } = spawnCall();
+			const modelIdx = args.indexOf('-m');
+			expect(modelIdx).toBeGreaterThanOrEqual(0);
+			expect(args[modelIdx + 1]).toBe('gpt-5.3-codex');
+		});
+
+		it('does not add --model when customModel is empty', async () => {
+			const p = spawnAgent('claude-code', '/p', 'hi');
+			await driveSpawnToCompletion(p, 0, CLAUDE_OK());
+
+			const { args } = spawnCall();
+			expect(args).not.toContain('--model');
+		});
+	});
+
+	describe('spawnAgent: SSH integration', () => {
+		beforeEach(() => {
+			mockSpawn.mockReturnValue(mockChild);
+		});
+
+		const sshWrapResult = (
+			overrides: Partial<{
+				command: string;
+				args: string[];
+				cwd: string;
+				customEnvVars: Record<string, string> | undefined;
+				sshStdinScript: string | undefined;
+				sshRemoteUsed: { id: string; name: string; host: string } | null;
+			}> = {}
+		) => ({
+			command: 'ssh',
+			args: ['remotehost', 'claude --print -- hi'],
+			cwd: '/home/user',
+			customEnvVars: undefined,
+			prompt: undefined,
+			sshStdinScript: undefined,
+			sshRemoteUsed: { id: 'r1', name: 'r1', host: 'remotehost' },
+			...overrides,
+		});
+
+		it('does NOT invoke the SSH wrapper when sshRemoteConfig is undefined', async () => {
+			const p = spawnAgent('claude-code', '/p', 'hi');
+			await driveSpawnToCompletion(p, 0, CLAUDE_OK());
+
+			expect(mockWrapSpawnWithSsh).not.toHaveBeenCalled();
+			const { command } = spawnCall();
+			expect(command).not.toBe('ssh');
+		});
+
+		it('does NOT invoke the SSH wrapper when sshRemoteConfig.enabled is false', async () => {
+			const p = spawnAgent('claude-code', '/p', 'hi', undefined, {
+				sshRemoteConfig: { enabled: false, remoteId: null },
+			});
+			await driveSpawnToCompletion(p, 0, CLAUDE_OK());
+
+			expect(mockWrapSpawnWithSsh).not.toHaveBeenCalled();
+		});
+
+		it('invokes the SSH wrapper and replaces command/args when remote resolves', async () => {
+			mockWrapSpawnWithSsh.mockResolvedValue(sshWrapResult());
+
+			const p = spawnAgent('claude-code', '/p', 'hi', undefined, {
+				sshRemoteConfig: { enabled: true, remoteId: 'r1' },
+			});
+			const result = await driveSpawnToCompletion(p, 0, CLAUDE_OK());
+
+			expect(result.success).toBe(true);
+			expect(mockWrapSpawnWithSsh).toHaveBeenCalledTimes(1);
+			const { command, args } = spawnCall();
+			expect(command).toBe('ssh');
+			expect(args).toEqual(['remotehost', 'claude --print -- hi']);
+		});
+
+		it('writes sshStdinScript to child.stdin when large-prompt passthrough is used', async () => {
+			const script = '#!/bin/bash\nexec claude --print\nbig prompt here';
+			mockWrapSpawnWithSsh.mockResolvedValue(
+				sshWrapResult({ args: ['remotehost', '/bin/bash'], sshStdinScript: script })
+			);
+
+			const p = spawnAgent('claude-code', '/p', 'hi', undefined, {
+				sshRemoteConfig: { enabled: true, remoteId: 'r1' },
+			});
+			await driveSpawnToCompletion(p, 0, CLAUDE_OK());
+
+			expect(mockStdin.write).toHaveBeenCalledWith(script);
+			expect(mockStdin.end).toHaveBeenCalled();
+			// write() must run BEFORE end() (first call of write precedes first end)
+			expect(mockStdin.write.mock.invocationCallOrder[0]).toBeLessThan(
+				mockStdin.end.mock.invocationCallOrder[0]
+			);
+		});
+
+		it('does NOT write to stdin when running locally (no sshStdinScript)', async () => {
+			const p = spawnAgent('claude-code', '/p', 'hi');
+			await driveSpawnToCompletion(p, 0, CLAUDE_OK());
+
+			expect(mockStdin.write).not.toHaveBeenCalled();
+			expect(mockStdin.end).toHaveBeenCalled();
+		});
+
+		it('returns a clear error when SSH is enabled but the remote is unresolvable', async () => {
+			mockWrapSpawnWithSsh.mockResolvedValue(
+				sshWrapResult({ command: 'claude', args: [], cwd: '/p', sshRemoteUsed: null })
+			);
+
+			const result = await spawnAgent('claude-code', '/p', 'hi', undefined, {
+				sshRemoteConfig: { enabled: true, remoteId: 'missing-remote' },
+			});
+
+			expect(result.success).toBe(false);
+			expect(result.error).toMatch(/SSH remote execution is enabled/i);
+			expect(result.error).toMatch(/could not be resolved/i);
+			expect(result.error).toContain('missing-remote');
+			// Must not fall through to a local spawn — user explicitly opted into SSH
+			expect(mockSpawn).not.toHaveBeenCalled();
+		});
+
+		it('hard-fails for JSON-line agents (Codex) when SSH remote is unresolvable', async () => {
+			mockWrapSpawnWithSsh.mockResolvedValue(
+				sshWrapResult({ command: 'codex', args: [], cwd: '/p', sshRemoteUsed: null })
+			);
+
+			const result = await spawnAgent('codex', '/p', 'hi', undefined, {
+				sshRemoteConfig: { enabled: true, remoteId: 'gone' },
+			});
+
+			expect(result.success).toBe(false);
+			expect(result.error).toMatch(/could not be resolved/);
+			expect(mockSpawn).not.toHaveBeenCalled();
+		});
+
+		it('forwards agent binaryName (not local path) to the SSH wrapper', async () => {
+			mockGetAgentCustomPath.mockReturnValue('/opt/local/claude');
+			mockWrapSpawnWithSsh.mockResolvedValue(sshWrapResult({ args: ['remotehost'] }));
+
+			const p = spawnAgent('claude-code', '/p', 'hi', undefined, {
+				sshRemoteConfig: { enabled: true, remoteId: 'r1' },
+			});
+			await driveSpawnToCompletion(p, 0, CLAUDE_OK());
+
+			const [wrapConfig] = mockWrapSpawnWithSsh.mock.calls[0] as [
+				{ agentBinaryName?: string; command: string },
+			];
+			expect(wrapConfig.agentBinaryName).toBe('claude');
+			// local `command` may be a resolved path, but agentBinaryName is what
+			// the wrapper actually uses for the remote invocation.
+		});
+
+		it('passes session customArgs through to the SSH wrapper (baseline args include them)', async () => {
+			mockWrapSpawnWithSsh.mockResolvedValue(sshWrapResult({ args: ['remotehost'] }));
+
+			const p = spawnAgent('claude-code', '/p', 'hi', undefined, {
+				sshRemoteConfig: { enabled: true, remoteId: 'r1' },
+				customArgs: '--ssh-injected-flag',
+			});
+			await driveSpawnToCompletion(p, 0, CLAUDE_OK());
+
+			const [wrapConfig] = mockWrapSpawnWithSsh.mock.calls[0] as [{ args: string[] }];
+			expect(wrapConfig.args).toContain('--ssh-injected-flag');
+		});
+
+		it('passes session customEnvVars through to the SSH wrapper (env reaches remote host)', async () => {
+			mockWrapSpawnWithSsh.mockResolvedValue(sshWrapResult({ args: ['remotehost'] }));
+
+			const p = spawnAgent('claude-code', '/p', 'hi', undefined, {
+				sshRemoteConfig: { enabled: true, remoteId: 'r1' },
+				customEnvVars: { REMOTE_TOKEN: 'abc' },
+			});
+			await driveSpawnToCompletion(p, 0, CLAUDE_OK());
+
+			const [wrapConfig] = mockWrapSpawnWithSsh.mock.calls[0] as [
+				{ customEnvVars?: Record<string, string> },
+			];
+			expect(wrapConfig.customEnvVars).toBeDefined();
+			expect(wrapConfig.customEnvVars!.REMOTE_TOKEN).toBe('abc');
+		});
+	});
+
+	describe('spawnAgent: regression', () => {
+		beforeEach(() => {
+			mockSpawn.mockReturnValue(mockChild);
+		});
+
+		it('Claude spawn without any options still includes base stream-json flags', async () => {
+			const p = spawnAgent('claude-code', '/p', 'hi');
+			await driveSpawnToCompletion(p, 0, CLAUDE_OK());
+
+			const { args } = spawnCall();
+			expect(args).toContain('--print');
+			expect(args).toContain('--verbose');
+			expect(args).toContain('--output-format');
+			expect(args).toContain('stream-json');
+			expect(args).toContain('--dangerously-skip-permissions');
+			// prompt is appended as positional after '--'
+			const sep = args.indexOf('--');
+			expect(sep).toBeGreaterThan(0);
+			expect(args[sep + 1]).toBe('hi');
+		});
+
+		it('Claude read-only mode uses --permission-mode plan instead of --dangerously-skip-permissions', async () => {
+			const p = spawnAgent('claude-code', '/p', 'hi', undefined, { readOnlyMode: true });
+			await driveSpawnToCompletion(p, 0, CLAUDE_OK());
+
+			const { args } = spawnCall();
+			expect(args).toContain('--permission-mode');
+			expect(args).toContain('plan');
+			expect(args).not.toContain('--dangerously-skip-permissions');
+		});
+
+		it('Claude resumes existing agent session when agentSessionId is provided', async () => {
+			const p = spawnAgent('claude-code', '/p', 'hi', 'agent-session-xyz');
+			await driveSpawnToCompletion(p, 0, CLAUDE_OK());
+
+			const { args } = spawnCall();
+			expect(args).toContain('--resume');
+			expect(args).toContain('agent-session-xyz');
+			// no --session-id should be injected when resuming
+			expect(args).not.toContain('--session-id');
+		});
+
+		it('Claude generates fresh --session-id when no agentSessionId is provided', async () => {
+			const p = spawnAgent('claude-code', '/p', 'hi');
+			await driveSpawnToCompletion(p, 0, CLAUDE_OK());
+
+			const { args } = spawnCall();
+			const idx = args.indexOf('--session-id');
+			expect(idx).toBeGreaterThanOrEqual(0);
+			expect(args[idx + 1]).toMatch(/^[0-9a-f-]{36}$/);
+		});
+
+		it('Codex spawn preserves working-dir flag and resume args', async () => {
+			const p = spawnAgent('codex', '/working', 'hi', 'codex-thread-123');
+			await driveSpawnToCompletion(p, 0, CODEX_INIT());
+
+			const { args } = spawnCall();
+			expect(args).toContain('exec');
+			expect(args).toContain('--json');
+			// Codex takes -C <dir> for working directory
+			const c = args.indexOf('-C');
+			expect(c).toBeGreaterThanOrEqual(0);
+			expect(args[c + 1]).toBe('/working');
+			// resume args are ['resume', '<id>']
+			expect(args).toContain('resume');
+			expect(args).toContain('codex-thread-123');
+		});
+
+		it('unsupported agent type returns a failure result', async () => {
+			const result = await spawnAgent('terminal' as never, '/p', 'hi');
+			expect(result.success).toBe(false);
+			expect(result.error).toMatch(/Unsupported agent type/);
 		});
 	});
 });

--- a/src/__tests__/cli/services/agent-spawner.test.ts
+++ b/src/__tests__/cli/services/agent-spawner.test.ts
@@ -1780,6 +1780,43 @@ Some text with [x] in it that's not a checkbox
 			expect(options.env.MAESTRO_TEST_LAYER).toBe('session');
 		});
 
+		it('shell env wins over agent defaultEnvVars when user has no customEnvVars', async () => {
+			// Regression: agent.defaultEnvVars must NOT silently override a value
+			// the shell already exports. OpenCode has OPENCODE_CONFIG_CONTENT in
+			// its defaultEnvVars — if the shell sets it, that shell value should
+			// survive to the spawned process.
+			const prev = process.env.OPENCODE_CONFIG_CONTENT;
+			process.env.OPENCODE_CONFIG_CONTENT = 'shell-wins';
+
+			try {
+				const p = spawnAgent('opencode', '/p', 'hi');
+				await driveSpawnToCompletion(p, 0);
+
+				const { options } = spawnCall();
+				expect(options.env.OPENCODE_CONFIG_CONTENT).toBe('shell-wins');
+			} finally {
+				if (prev === undefined) delete process.env.OPENCODE_CONFIG_CONTENT;
+				else process.env.OPENCODE_CONFIG_CONTENT = prev;
+			}
+		});
+
+		it('agent defaultEnvVars is applied when the shell has not set it', async () => {
+			// Complements the "shell wins" test: when the shell does NOT export
+			// the key, the agent default must still reach the spawned process.
+			const prev = process.env.OPENCODE_CONFIG_CONTENT;
+			delete process.env.OPENCODE_CONFIG_CONTENT;
+
+			try {
+				const p = spawnAgent('opencode', '/p', 'hi');
+				await driveSpawnToCompletion(p, 0);
+
+				const { options } = spawnCall();
+				expect(options.env.OPENCODE_CONFIG_CONTENT).toContain('"permission"');
+			} finally {
+				if (prev !== undefined) process.env.OPENCODE_CONFIG_CONTENT = prev;
+			}
+		});
+
 		it('applies customModel via configOptions argBuilder for Claude', async () => {
 			const p = spawnAgent('claude-code', '/p', 'hi', undefined, { customModel: 'opus' });
 			await driveSpawnToCompletion(p, 0, CLAUDE_OK());
@@ -1969,6 +2006,24 @@ Some text with [x] in it that's not a checkbox
 			];
 			expect(wrapConfig.customEnvVars).toBeDefined();
 			expect(wrapConfig.customEnvVars!.REMOTE_TOKEN).toBe('abc');
+		});
+
+		it('forwards agent defaultEnvVars to the SSH wrapper even without user customEnvVars', async () => {
+			// Defaults must still reach the remote host (which has no shell env
+			// to fall back on). Session customEnvVars is omitted here — we're
+			// asserting that the default-only path survived the env-layer fix.
+			mockWrapSpawnWithSsh.mockResolvedValue(sshWrapResult({ args: ['remotehost'] }));
+
+			const p = spawnAgent('opencode', '/p', 'hi', undefined, {
+				sshRemoteConfig: { enabled: true, remoteId: 'r1' },
+			});
+			await driveSpawnToCompletion(p, 0);
+
+			const [wrapConfig] = mockWrapSpawnWithSsh.mock.calls[0] as [
+				{ customEnvVars?: Record<string, string> },
+			];
+			expect(wrapConfig.customEnvVars).toBeDefined();
+			expect(wrapConfig.customEnvVars!.OPENCODE_CONFIG_CONTENT).toContain('"permission"');
 		});
 	});
 

--- a/src/cli/commands/send.ts
+++ b/src/cli/commands/send.ts
@@ -192,6 +192,10 @@ export async function send(
 	const result = await spawnAgent(agent.toolType, agent.cwd, message, agentSessionId, {
 		readOnlyMode: options.readOnly,
 		customModel: agent.customModel,
+		customEffort: agent.customEffort,
+		customArgs: agent.customArgs,
+		customEnvVars: agent.customEnvVars,
+		sshRemoteConfig: agent.sessionSshRemoteConfig,
 	});
 	const response = buildResponse(agentId, agent.name, result, agent.toolType);
 

--- a/src/cli/services/agent-spawner.ts
+++ b/src/cli/services/agent-spawner.ts
@@ -1,9 +1,9 @@
 // Agent spawner service for CLI
 // Spawns agent CLIs and parses their output
 
-import { spawn, SpawnOptions } from 'child_process';
+import { spawn, SpawnOptions, ChildProcess } from 'child_process';
 import * as fs from 'fs';
-import type { ToolType, UsageStats } from '../../shared/types';
+import type { AgentSshRemoteConfig, ToolType, UsageStats } from '../../shared/types';
 import type { AgentOutputParser } from '../../main/parsers/agent-output-parser';
 import { CodexOutputParser } from '../../main/parsers/codex-output-parser';
 import { OpenCodeOutputParser } from '../../main/parsers/opencode-output-parser';
@@ -11,10 +11,93 @@ import { FactoryDroidOutputParser } from '../../main/parsers/factory-droid-outpu
 import { aggregateModelUsage } from '../../main/parsers/usage-aggregator';
 import { getAgentDefinition } from '../../main/agents/definitions';
 import { hasCapability } from '../../main/agents/capabilities';
-import { getAgentCustomPath } from './storage';
+import { getAgentCustomPath, readAgentConfig, readSshRemotes } from './storage';
 import { generateUUID } from '../../shared/uuid';
 import { buildExpandedPath, buildExpandedEnv } from '../../shared/pathUtils';
 import { isWindows, getWhichCommand } from '../../shared/platformDetection';
+import { applyAgentConfigOverrides } from '../../main/utils/agent-args';
+
+// Types from the SSH wrapper are imported type-only so no runtime module load
+// happens for non-SSH sessions — the SSH chain pulls in execFile/which helpers
+// that aren't needed when a session runs locally. The wrapSpawnWithSsh
+// implementation is dynamically imported inside maybeWrapSpawnWithSsh().
+type SshSpawnWrapConfig = import('../../main/utils/ssh-spawn-wrapper').SshSpawnWrapConfig;
+type SshSpawnWrapResult = import('../../main/utils/ssh-spawn-wrapper').SshSpawnWrapResult;
+
+async function maybeWrapSpawnWithSsh(
+	config: SshSpawnWrapConfig,
+	sshConfig: AgentSshRemoteConfig
+): Promise<SshSpawnWrapResult> {
+	const { wrapSpawnWithSsh } = await import('../../main/utils/ssh-spawn-wrapper');
+	return wrapSpawnWithSsh(config, sshConfig, { getSshRemotes: () => readSshRemotes() });
+}
+
+/**
+ * Finalize child stdin for a spawned agent. When SSH stdin passthrough is in
+ * effect, write the pre-built script before closing; otherwise just close.
+ */
+function finalizeAgentStdin(child: ChildProcess, sshStdinScript?: string): void {
+	if (sshStdinScript) {
+		child.stdin?.write(sshStdinScript);
+	}
+	child.stdin?.end();
+}
+
+type SpawnOverrides = Pick<
+	SpawnAgentOptions,
+	'customModel' | 'customEffort' | 'customArgs' | 'customEnvVars'
+>;
+
+/**
+ * Resolve agent-level + session-level overrides and produce final args plus
+ * the effective customEnvVars. Mirrors what the desktop process handler does
+ * in `applyAgentConfigOverrides()` so CLI-spawned agents honor the same
+ * custom model / effort / args / env vars as the desktop app.
+ */
+function resolveAgentOverrides(
+	toolType: ToolType,
+	def: ReturnType<typeof getAgentDefinition>,
+	baseArgs: string[],
+	overrides: SpawnOverrides
+): { args: string[]; effectiveCustomEnvVars?: Record<string, string> } {
+	const agentConfigValues = readAgentConfig(toolType);
+	const result = applyAgentConfigOverrides(def ?? null, baseArgs, {
+		agentConfigValues,
+		sessionCustomModel: overrides.customModel,
+		sessionCustomEffort: overrides.customEffort,
+		sessionCustomArgs: overrides.customArgs,
+		sessionCustomEnvVars: overrides.customEnvVars,
+	});
+	return { args: result.args, effectiveCustomEnvVars: result.effectiveCustomEnvVars };
+}
+
+/**
+ * Merge user-level env vars over an existing env record. Agent defaults are
+ * preserved only when the shell didn't already set them — matches today's CLI
+ * precedence so users can still shadow built-in agent defaults from the shell.
+ * User-configured vars (agent-level customEnvVars + session customEnvVars)
+ * unconditionally override, because the user explicitly opted into them.
+ */
+function applyEnvLayers(
+	env: NodeJS.ProcessEnv,
+	agentDefaults: Record<string, string> | undefined,
+	batchDefaults: Record<string, string> | undefined,
+	userEnvVars: Record<string, string> | undefined,
+	readOnlyOverrides: Record<string, string> | undefined
+): void {
+	if (agentDefaults) {
+		for (const [k, v] of Object.entries(agentDefaults)) {
+			if (!env[k]) env[k] = v;
+		}
+	}
+	if (batchDefaults) {
+		for (const [k, v] of Object.entries(batchDefaults)) {
+			if (!env[k]) env[k] = v;
+		}
+	}
+	if (userEnvVars) Object.assign(env, userEnvVars);
+	if (readOnlyOverrides) Object.assign(env, readOnlyOverrides);
+}
 
 // Claude Code arguments for batch mode (stream-json format)
 const CLAUDE_ARGS = ['--print', '--verbose', '--output-format', 'stream-json'];
@@ -160,10 +243,9 @@ export const getDroidCommand = () => getAgentCommand('factory-droid');
 /**
  * Spawn Claude Code with a prompt and return the result.
  *
- * NOTE: CLI spawner does not apply applyAgentConfigOverrides() or SSH wrapping.
- * Designed for headless batch execution without access to the Electron settings
- * store or per-session agent configuration. Custom model, args, env vars, and
- * SSH remote execution are not supported in CLI mode.
+ * Honors the same agent-level and session-level overrides as the desktop app:
+ * custom model, effort, CLI args, env vars, and SSH remote execution. Custom
+ * binary path is applied via getAgentCommand()/detectAgent().
  *
  * Claude uses a unique JSON format (stream-json) that differs from the
  * AgentOutputParser interface used by other agents, so it has its own spawner.
@@ -172,55 +254,86 @@ async function spawnClaudeAgent(
 	cwd: string,
 	prompt: string,
 	agentSessionId?: string,
-	readOnlyMode?: boolean
+	readOnlyMode?: boolean,
+	sshRemoteConfig?: AgentSshRemoteConfig,
+	overrides: SpawnOverrides = {}
 ): Promise<AgentResult> {
+	const env = buildExpandedEnv();
+	const def = getAgentDefinition('claude-code');
+
+	// Build args WITHOUT the prompt — the prompt is appended below for local
+	// execution or embedded into the SSH wrapper for remote execution.
+	const preOverrideArgs = [...CLAUDE_ARGS];
+
+	if (readOnlyMode) {
+		if (def?.readOnlyArgs) preOverrideArgs.push(...def.readOnlyArgs);
+	} else {
+		preOverrideArgs.push(...CLAUDE_YOLO_ARGS);
+	}
+
+	if (agentSessionId) {
+		preOverrideArgs.push('--resume', agentSessionId);
+	} else {
+		// Force a fresh, isolated session for each task execution
+		// This prevents context bleeding between tasks in Auto Run
+		preOverrideArgs.push('--session-id', generateUUID());
+	}
+
+	// Layer agent-level + session-level overrides (model, effort, customArgs)
+	// and compute the effective user-facing env vars.
+	const { args: baseArgs, effectiveCustomEnvVars } = resolveAgentOverrides(
+		'claude-code',
+		def,
+		preOverrideArgs,
+		overrides
+	);
+
+	// Build local env: defaults (shell wins) + batch-mode defaults (shell wins)
+	// + user env vars (override shell) + read-only overrides (always).
+	applyEnvLayers(
+		env,
+		def?.defaultEnvVars,
+		def?.batchModeEnvVars,
+		effectiveCustomEnvVars,
+		readOnlyMode ? def?.readOnlyEnvOverrides : undefined
+	);
+
+	const claudeCommand = getAgentCommand('claude-code');
+
+	// SSH-wrap if a remote is configured; otherwise append prompt locally.
+	// Claude uses '-- <prompt>' positional form — the default in wrapSpawnWithSsh.
+	let spawnCommand = claudeCommand;
+	let spawnArgs: string[] = [...baseArgs, '--', prompt];
+	let spawnCwd = cwd;
+	let spawnEnv: NodeJS.ProcessEnv = env;
+	let sshStdinScript: string | undefined;
+
+	if (sshRemoteConfig?.enabled) {
+		const wrapped = await maybeWrapSpawnWithSsh(
+			{
+				command: claudeCommand,
+				args: baseArgs,
+				cwd,
+				prompt,
+				customEnvVars: buildSshEnvForRemote(def, readOnlyMode, effectiveCustomEnvVars),
+				agentBinaryName: def?.binaryName,
+			},
+			sshRemoteConfig
+		);
+		if (!wrapped.sshRemoteUsed) {
+			return sshUnresolvedFailure(sshRemoteConfig);
+		}
+		({ spawnCommand, spawnArgs, spawnCwd, spawnEnv, sshStdinScript } = applySshWrapResult(wrapped));
+	}
+
 	return new Promise((resolve) => {
-		const env = buildExpandedEnv();
-		const def = getAgentDefinition('claude-code');
-
-		// Apply batch-mode-only env vars (shell env wins, matching defaultEnvVars precedence)
-		if (def?.batchModeEnvVars) {
-			for (const k of Object.keys(def.batchModeEnvVars)) {
-				if (!env[k]) env[k] = def.batchModeEnvVars[k];
-			}
-		}
-
-		// Build args: base args + session handling + read-only + prompt
-		const args = [...CLAUDE_ARGS];
-
-		// Apply read-only mode args from centralized agent definitions
-		if (readOnlyMode) {
-			if (def?.readOnlyArgs) {
-				args.push(...def.readOnlyArgs);
-			}
-			if (def?.readOnlyEnvOverrides) {
-				Object.assign(env, def.readOnlyEnvOverrides);
-			}
-		} else {
-			// Only bypass permissions in non-read-only mode
-			args.push(...CLAUDE_YOLO_ARGS);
-		}
-
-		if (agentSessionId) {
-			// Resume an existing session (e.g., for synopsis generation)
-			args.push('--resume', agentSessionId);
-		} else {
-			// Force a fresh, isolated session for each task execution
-			// This prevents context bleeding between tasks in Auto Run
-			args.push('--session-id', generateUUID());
-		}
-
-		// Add prompt as positional argument
-		args.push('--', prompt);
-
 		const options: SpawnOptions = {
-			cwd,
-			env,
+			cwd: spawnCwd,
+			env: spawnEnv,
 			stdio: ['pipe', 'pipe', 'pipe'],
 		};
 
-		const claudeCommand = getAgentCommand('claude-code');
-		const child = spawn(claudeCommand, args, options);
+		const child = spawn(spawnCommand, spawnArgs, options);
 
 		let jsonBuffer = '';
 		let result: string | undefined;
@@ -293,8 +406,7 @@ async function spawnClaudeAgent(
 			stderr += data.toString();
 		});
 
-		// Close stdin immediately
-		child.stdin?.end();
+		finalizeAgentStdin(child, sshStdinScript);
 
 		// Handle completion
 		child.on('close', (code) => {
@@ -338,6 +450,64 @@ async function spawnClaudeAgent(
 			});
 		});
 	});
+}
+
+/**
+ * Build the env-vars record to forward to an SSH remote. Includes agent
+ * defaults, batch-mode defaults, user-configured vars (merged already inside
+ * effectiveCustomEnvVars from applyAgentConfigOverrides), and read-only
+ * overrides when applicable. Local process.env is NOT forwarded — the remote
+ * host has its own environment.
+ */
+function buildSshEnvForRemote(
+	def: ReturnType<typeof getAgentDefinition>,
+	readOnlyMode: boolean | undefined,
+	effectiveCustomEnvVars: Record<string, string> | undefined
+): Record<string, string> | undefined {
+	const out: Record<string, string> = {};
+	if (def?.defaultEnvVars) Object.assign(out, def.defaultEnvVars);
+	if (def?.batchModeEnvVars) Object.assign(out, def.batchModeEnvVars);
+	if (effectiveCustomEnvVars) Object.assign(out, effectiveCustomEnvVars);
+	if (readOnlyMode && def?.readOnlyEnvOverrides) Object.assign(out, def.readOnlyEnvOverrides);
+	return Object.keys(out).length > 0 ? out : undefined;
+}
+
+/**
+ * Return an AgentResult that tells the caller the configured SSH remote
+ * couldn't be resolved. Fails loudly instead of silently running locally —
+ * when the user explicitly enabled SSH, they don't want their prompt leaking
+ * onto the local machine if the remote is misconfigured.
+ */
+function sshUnresolvedFailure(sshRemoteConfig: AgentSshRemoteConfig): AgentResult {
+	const remoteLabel = sshRemoteConfig.remoteId ? ` "${sshRemoteConfig.remoteId}"` : '';
+	return {
+		success: false,
+		error:
+			`SSH remote execution is enabled for this session but the configured ` +
+			`remote${remoteLabel} could not be resolved. Check that the remote exists, ` +
+			`is enabled, and that the session's remoteId points at a valid SSH remote.`,
+	};
+}
+
+/**
+ * Apply a successful SSH wrap result to our local spawn state. The local ssh
+ * client inherits process.env (for SSH_AUTH_SOCK, etc.); the remote's own
+ * env vars travel inside the wrapped command or stdin script.
+ */
+function applySshWrapResult(wrapped: SshSpawnWrapResult): {
+	spawnCommand: string;
+	spawnArgs: string[];
+	spawnCwd: string;
+	spawnEnv: NodeJS.ProcessEnv;
+	sshStdinScript: string | undefined;
+} {
+	return {
+		spawnCommand: wrapped.command,
+		spawnArgs: wrapped.args,
+		spawnCwd: wrapped.cwd,
+		spawnEnv: { ...process.env },
+		sshStdinScript: wrapped.sshStdinScript,
+	};
 }
 
 function mergeUsageStats(
@@ -388,8 +558,9 @@ function createParser(toolType: ToolType): AgentOutputParser {
  * Generic spawner for agents that use JSON line output parsed via AgentOutputParser.
  * Handles Codex, OpenCode, Factory Droid, and any future agents with the same pattern.
  *
- * NOTE: Same limitations as spawnClaudeAgent — no applyAgentConfigOverrides()
- * or SSH wrapping in CLI mode.
+ * Honors the same agent-level and session-level overrides as the desktop app:
+ * custom model, effort, CLI args, env vars, and SSH remote execution. Custom
+ * binary path is applied via getAgentCommand()/detectAgent().
  */
 async function spawnJsonLineAgent(
 	toolType: ToolType,
@@ -397,75 +568,99 @@ async function spawnJsonLineAgent(
 	prompt: string,
 	agentSessionId?: string,
 	readOnlyMode?: boolean,
-	customModel?: string
+	sshRemoteConfig?: AgentSshRemoteConfig,
+	overrides: SpawnOverrides = {}
 ): Promise<AgentResult> {
+	const env = buildExpandedEnv();
+	const def = getAgentDefinition(toolType);
+
+	// Build args from agent definition (without the prompt or model/customArgs —
+	// those come from applyAgentConfigOverrides via configOptions).
+	const preOverrideArgs: string[] = [];
+	if (def?.batchModePrefix) preOverrideArgs.push(...def.batchModePrefix);
+
+	// In read-only mode, filter out YOLO/bypass args from batchModeArgs
+	// (they override read-only flags). In normal mode, apply all batchModeArgs.
+	// Skip filtering for agents without CLI-level read-only enforcement
+	// (e.g., Gemini CLI needs -y to avoid interactive prompts that hang with closed stdin).
+	if (def?.batchModeArgs) {
+		if (readOnlyMode && def.readOnlyCliEnforced !== false && def.yoloModeArgs?.length) {
+			const yoloSet = new Set(def.yoloModeArgs);
+			preOverrideArgs.push(...def.batchModeArgs.filter((a) => !yoloSet.has(a)));
+		} else {
+			preOverrideArgs.push(...def.batchModeArgs);
+		}
+	}
+
+	if (def?.jsonOutputArgs) preOverrideArgs.push(...def.jsonOutputArgs);
+	if (readOnlyMode && def?.readOnlyArgs) preOverrideArgs.push(...def.readOnlyArgs);
+
+	if (agentSessionId && def?.resumeArgs) {
+		preOverrideArgs.push(...def.resumeArgs(agentSessionId));
+	}
+
+	// Codex requires explicit working directory arg (other agents use process cwd)
+	if (toolType === 'codex' && def?.workingDirArgs) {
+		preOverrideArgs.push(...def.workingDirArgs(cwd));
+	}
+
+	// Layer agent-level + session-level overrides (model, effort, customArgs)
+	// and compute the effective user-facing env vars.
+	const { args: baseArgs, effectiveCustomEnvVars } = resolveAgentOverrides(
+		toolType,
+		def,
+		preOverrideArgs,
+		overrides
+	);
+
+	applyEnvLayers(
+		env,
+		def?.defaultEnvVars,
+		def?.batchModeEnvVars,
+		effectiveCustomEnvVars,
+		readOnlyMode ? def?.readOnlyEnvOverrides : undefined
+	);
+
+	const noPromptSeparator = !!def?.noPromptSeparator;
+
+	// Local prompt embedding mirrors wrapSpawnWithSsh's default behavior
+	const localArgs = noPromptSeparator ? [...baseArgs, prompt] : [...baseArgs, '--', prompt];
+
+	const agentCommand = getAgentCommand(toolType);
+
+	let spawnCommand = agentCommand;
+	let spawnArgs = localArgs;
+	let spawnCwd = cwd;
+	let spawnEnv: NodeJS.ProcessEnv = env;
+	let sshStdinScript: string | undefined;
+
+	if (sshRemoteConfig?.enabled) {
+		const wrapped = await maybeWrapSpawnWithSsh(
+			{
+				command: agentCommand,
+				args: baseArgs,
+				cwd,
+				prompt,
+				customEnvVars: buildSshEnvForRemote(def, readOnlyMode, effectiveCustomEnvVars),
+				agentBinaryName: def?.binaryName,
+				noPromptSeparator,
+			},
+			sshRemoteConfig
+		);
+		if (!wrapped.sshRemoteUsed) {
+			return sshUnresolvedFailure(sshRemoteConfig);
+		}
+		({ spawnCommand, spawnArgs, spawnCwd, spawnEnv, sshStdinScript } = applySshWrapResult(wrapped));
+	}
+
 	return new Promise((resolve) => {
-		const env = buildExpandedEnv();
-		const def = getAgentDefinition(toolType);
-
-		// Apply default env vars from agent definition
-		if (def?.defaultEnvVars) {
-			for (const k of Object.keys(def.defaultEnvVars)) {
-				if (!env[k]) env[k] = def.defaultEnvVars[k];
-			}
-		}
-
-		// Apply batch-mode-only env vars (shell env wins, matching defaultEnvVars precedence)
-		if (def?.batchModeEnvVars) {
-			for (const k of Object.keys(def.batchModeEnvVars)) {
-				if (!env[k]) env[k] = def.batchModeEnvVars[k];
-			}
-		}
-
-		// Apply read-only mode env overrides from agent definition
-		if (readOnlyMode && def?.readOnlyEnvOverrides) {
-			Object.assign(env, def.readOnlyEnvOverrides);
-		}
-
-		// Build args from agent definition
-		const args: string[] = [];
-		if (def?.batchModePrefix) args.push(...def.batchModePrefix);
-
-		// In read-only mode, filter out YOLO/bypass args from batchModeArgs
-		// (they override read-only flags). In normal mode, apply all batchModeArgs.
-		// Skip filtering for agents without CLI-level read-only enforcement
-		// (e.g., Gemini CLI needs -y to avoid interactive prompts that hang with closed stdin).
-		if (def?.batchModeArgs) {
-			if (readOnlyMode && def.readOnlyCliEnforced !== false && def.yoloModeArgs?.length) {
-				const yoloSet = new Set(def.yoloModeArgs);
-				args.push(...def.batchModeArgs.filter((a) => !yoloSet.has(a)));
-			} else {
-				args.push(...def.batchModeArgs);
-			}
-		}
-
-		if (def?.jsonOutputArgs) args.push(...def.jsonOutputArgs);
-		if (readOnlyMode && def?.readOnlyArgs) args.push(...def.readOnlyArgs);
-		if (customModel && def?.modelArgs) args.push(...def.modelArgs(customModel));
-
-		if (agentSessionId && def?.resumeArgs) {
-			args.push(...def.resumeArgs(agentSessionId));
-		}
-
-		// Codex requires explicit working directory arg (other agents use process cwd)
-		if (toolType === 'codex' && def?.workingDirArgs) {
-			args.push(...def.workingDirArgs(cwd));
-		}
-
-		// Add prompt (with or without '--' separator depending on agent)
-		if (!def?.noPromptSeparator) {
-			args.push('--');
-		}
-		args.push(prompt);
-
 		const options: SpawnOptions = {
-			cwd,
-			env,
+			cwd: spawnCwd,
+			env: spawnEnv,
 			stdio: ['pipe', 'pipe', 'pipe'],
 		};
 
-		const agentCommand = getAgentCommand(toolType);
-		const child = spawn(agentCommand, args, options);
+		const child = spawn(spawnCommand, spawnArgs, options);
 
 		const parser = createParser(toolType);
 		let jsonBuffer = '';
@@ -520,7 +715,7 @@ async function spawnJsonLineAgent(
 			stderr += data.toString();
 		});
 
-		child.stdin?.end();
+		finalizeAgentStdin(child, sshStdinScript);
 
 		const agentName = def?.name || toolType;
 		child.on('close', (code) => {
@@ -548,15 +743,31 @@ async function spawnJsonLineAgent(
 }
 
 /**
- * Options for spawning an agent via CLI
+ * Options for spawning an agent via CLI.
+ *
+ * Session-level overrides take precedence over the agent-level config read
+ * from `maestro-agent-configs.json`. Pass the session values directly here —
+ * the spawner merges agent + session overrides via applyAgentConfigOverrides().
  */
 export interface SpawnAgentOptions {
 	/** Resume an existing agent session */
 	agentSessionId?: string;
 	/** Run in read-only/plan mode (uses centralized agent definitions for provider-specific flags) */
 	readOnlyMode?: boolean;
-	/** Custom model ID from agent config (e.g., 'github-copilot/gpt-5-mini') */
+	/** Per-session model override (wins over agent-level model). */
 	customModel?: string;
+	/** Per-session effort/reasoning override (wins over agent-level). */
+	customEffort?: string;
+	/** Per-session extra CLI args (shell-quote aware, appended after built-in args). */
+	customArgs?: string;
+	/** Per-session env vars merged over agent-level customEnvVars and agent defaults. */
+	customEnvVars?: Record<string, string>;
+	/**
+	 * Per-session SSH remote config. When `enabled`, the spawn is wrapped with
+	 * ssh so the agent runs on the remote host. Required for parity with the
+	 * desktop app when sessions are configured for SSH remote execution.
+	 */
+	sshRemoteConfig?: AgentSshRemoteConfig;
 }
 
 /**
@@ -570,14 +781,28 @@ export async function spawnAgent(
 	options?: SpawnAgentOptions
 ): Promise<AgentResult> {
 	const readOnly = options?.readOnlyMode;
-	const customModel = options?.customModel;
+	const sshRemoteConfig = options?.sshRemoteConfig;
+	const overrides: SpawnOverrides = {
+		customModel: options?.customModel,
+		customEffort: options?.customEffort,
+		customArgs: options?.customArgs,
+		customEnvVars: options?.customEnvVars,
+	};
 
 	if (toolType === 'claude-code') {
-		return spawnClaudeAgent(cwd, prompt, agentSessionId, readOnly);
+		return spawnClaudeAgent(cwd, prompt, agentSessionId, readOnly, sshRemoteConfig, overrides);
 	}
 
 	if (hasCapability(toolType, 'usesJsonLineOutput')) {
-		return spawnJsonLineAgent(toolType, cwd, prompt, agentSessionId, readOnly, customModel);
+		return spawnJsonLineAgent(
+			toolType,
+			cwd,
+			prompt,
+			agentSessionId,
+			readOnly,
+			sshRemoteConfig,
+			overrides
+		);
 	}
 
 	return {

--- a/src/cli/services/agent-spawner.ts
+++ b/src/cli/services/agent-spawner.ts
@@ -50,16 +50,22 @@ type SpawnOverrides = Pick<
 
 /**
  * Resolve agent-level + session-level overrides and produce final args plus
- * the effective customEnvVars. Mirrors what the desktop process handler does
- * in `applyAgentConfigOverrides()` so CLI-spawned agents honor the same
+ * the user-configured customEnvVars. Mirrors what the desktop process handler
+ * does in `applyAgentConfigOverrides()` so CLI-spawned agents honor the same
  * custom model / effort / args / env vars as the desktop app.
+ *
+ * Note: `applyAgentConfigOverrides().effectiveCustomEnvVars` folds agent
+ * `defaultEnvVars` into its return value. We deliberately strip that here —
+ * defaults are layered separately by `applyEnvLayers()` and
+ * `buildSshEnvForRemote()` with "shell wins" semantics, and treating them as
+ * user overrides would clobber explicit shell env.
  */
 function resolveAgentOverrides(
 	toolType: ToolType,
 	def: ReturnType<typeof getAgentDefinition>,
 	baseArgs: string[],
 	overrides: SpawnOverrides
-): { args: string[]; effectiveCustomEnvVars?: Record<string, string> } {
+): { args: string[]; userCustomEnvVars?: Record<string, string> } {
 	const agentConfigValues = readAgentConfig(toolType);
 	const result = applyAgentConfigOverrides(def ?? null, baseArgs, {
 		agentConfigValues,
@@ -68,7 +74,10 @@ function resolveAgentOverrides(
 		sessionCustomArgs: overrides.customArgs,
 		sessionCustomEnvVars: overrides.customEnvVars,
 	});
-	return { args: result.args, effectiveCustomEnvVars: result.effectiveCustomEnvVars };
+	const userCustomEnvVars =
+		overrides.customEnvVars ??
+		(agentConfigValues.customEnvVars as Record<string, string> | undefined);
+	return { args: result.args, userCustomEnvVars };
 }
 
 /**
@@ -280,8 +289,8 @@ async function spawnClaudeAgent(
 	}
 
 	// Layer agent-level + session-level overrides (model, effort, customArgs)
-	// and compute the effective user-facing env vars.
-	const { args: baseArgs, effectiveCustomEnvVars } = resolveAgentOverrides(
+	// and extract the user-configured env vars (agent + session customEnvVars).
+	const { args: baseArgs, userCustomEnvVars } = resolveAgentOverrides(
 		'claude-code',
 		def,
 		preOverrideArgs,
@@ -294,7 +303,7 @@ async function spawnClaudeAgent(
 		env,
 		def?.defaultEnvVars,
 		def?.batchModeEnvVars,
-		effectiveCustomEnvVars,
+		userCustomEnvVars,
 		readOnlyMode ? def?.readOnlyEnvOverrides : undefined
 	);
 
@@ -315,7 +324,7 @@ async function spawnClaudeAgent(
 				args: baseArgs,
 				cwd,
 				prompt,
-				customEnvVars: buildSshEnvForRemote(def, readOnlyMode, effectiveCustomEnvVars),
+				customEnvVars: buildSshEnvForRemote(def, readOnlyMode, userCustomEnvVars),
 				agentBinaryName: def?.binaryName,
 			},
 			sshRemoteConfig
@@ -453,21 +462,21 @@ async function spawnClaudeAgent(
 }
 
 /**
- * Build the env-vars record to forward to an SSH remote. Includes agent
- * defaults, batch-mode defaults, user-configured vars (merged already inside
- * effectiveCustomEnvVars from applyAgentConfigOverrides), and read-only
- * overrides when applicable. Local process.env is NOT forwarded — the remote
- * host has its own environment.
+ * Build the env-vars record to forward to an SSH remote. Layered in the same
+ * order as the local env path: agent defaults < batch-mode defaults <
+ * user-configured vars (agent-level customEnvVars or session customEnvVars) <
+ * read-only overrides. Local process.env is NOT forwarded — the remote host
+ * has its own environment.
  */
 function buildSshEnvForRemote(
 	def: ReturnType<typeof getAgentDefinition>,
 	readOnlyMode: boolean | undefined,
-	effectiveCustomEnvVars: Record<string, string> | undefined
+	userCustomEnvVars: Record<string, string> | undefined
 ): Record<string, string> | undefined {
 	const out: Record<string, string> = {};
 	if (def?.defaultEnvVars) Object.assign(out, def.defaultEnvVars);
 	if (def?.batchModeEnvVars) Object.assign(out, def.batchModeEnvVars);
-	if (effectiveCustomEnvVars) Object.assign(out, effectiveCustomEnvVars);
+	if (userCustomEnvVars) Object.assign(out, userCustomEnvVars);
 	if (readOnlyMode && def?.readOnlyEnvOverrides) Object.assign(out, def.readOnlyEnvOverrides);
 	return Object.keys(out).length > 0 ? out : undefined;
 }
@@ -605,8 +614,8 @@ async function spawnJsonLineAgent(
 	}
 
 	// Layer agent-level + session-level overrides (model, effort, customArgs)
-	// and compute the effective user-facing env vars.
-	const { args: baseArgs, effectiveCustomEnvVars } = resolveAgentOverrides(
+	// and extract the user-configured env vars (agent + session customEnvVars).
+	const { args: baseArgs, userCustomEnvVars } = resolveAgentOverrides(
 		toolType,
 		def,
 		preOverrideArgs,
@@ -617,7 +626,7 @@ async function spawnJsonLineAgent(
 		env,
 		def?.defaultEnvVars,
 		def?.batchModeEnvVars,
-		effectiveCustomEnvVars,
+		userCustomEnvVars,
 		readOnlyMode ? def?.readOnlyEnvOverrides : undefined
 	);
 
@@ -641,7 +650,7 @@ async function spawnJsonLineAgent(
 				args: baseArgs,
 				cwd,
 				prompt,
-				customEnvVars: buildSshEnvForRemote(def, readOnlyMode, effectiveCustomEnvVars),
+				customEnvVars: buildSshEnvForRemote(def, readOnlyMode, userCustomEnvVars),
 				agentBinaryName: def?.binaryName,
 				noPromptSeparator,
 			},

--- a/src/cli/services/batch-processor.ts
+++ b/src/cli/services/batch-processor.ts
@@ -441,6 +441,10 @@ export async function* runPlaybook(
 					// Spawn agent with combined prompt + document
 					const result = await spawnAgent(session.toolType, session.cwd, finalPrompt, undefined, {
 						customModel: session.customModel,
+						customEffort: session.customEffort,
+						customArgs: session.customArgs,
+						customEnvVars: session.customEnvVars,
+						sshRemoteConfig: session.sessionSshRemoteConfig,
 					});
 
 					const elapsedMs = Date.now() - taskStartTime;
@@ -479,7 +483,13 @@ export async function* runPlaybook(
 							session.cwd,
 							await getCliPrompt(PROMPT_IDS.AUTORUN_SYNOPSIS),
 							result.agentSessionId,
-							{ customModel: session.customModel }
+							{
+								customModel: session.customModel,
+								customEffort: session.customEffort,
+								customArgs: session.customArgs,
+								customEnvVars: session.customEnvVars,
+								sshRemoteConfig: session.sessionSshRemoteConfig,
+							}
 						);
 
 						if (synopsisResult.success && synopsisResult.response) {

--- a/src/main/utils/agent-args.ts
+++ b/src/main/utils/agent-args.ts
@@ -1,5 +1,9 @@
-import type { AgentConfig } from '../agents';
+import type { AgentConfig, AgentDefinition } from '../agents';
 import { logger } from './logger';
+
+/** Fields applyAgentConfigOverrides actually reads. Accepting this narrower
+ * shape lets CLI callers pass AgentDefinition (no capabilities/available). */
+type AgentConfigOverridable = Pick<AgentConfig, 'configOptions' | 'defaultEnvVars'>;
 
 const LOG_CONTEXT = '[AgentArgs]';
 
@@ -121,7 +125,7 @@ export function buildAgentArgs(
 }
 
 export function applyAgentConfigOverrides(
-	agent: AgentConfig | null | undefined,
+	agent: AgentConfigOverridable | AgentDefinition | AgentConfig | null | undefined,
 	baseArgs: string[],
 	overrides: AgentConfigOverrides
 ): AgentConfigResolution {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -162,8 +162,16 @@ export interface SessionInfo {
 	cwd: string;
 	projectRoot: string;
 	autoRunFolderPath?: string;
+	/** Per-session model override (wins over agent-level `model` config option). */
 	customModel?: string;
+	/** Per-session effort/reasoning override (wins over agent-level config). */
 	customEffort?: string;
+	/** Per-session extra CLI args appended to the spawn. Space-separated, shell-quote aware. */
+	customArgs?: string;
+	/** Per-session env vars merged over agent-level customEnvVars and agent defaults. */
+	customEnvVars?: Record<string, string>;
+	/** Per-session SSH remote config — when enabled, CLI spawns via SSH. */
+	sessionSshRemoteConfig?: AgentSshRemoteConfig;
 }
 
 // Usage statistics from AI agent CLI (Claude Code, Codex, etc.)


### PR DESCRIPTION
## Summary

The CLI (`maestro send`, `maestro run-playbook`) previously spawned agents locally and silently ignored per-agent/per-session configuration set in the desktop app — `customArgs`, `customEnvVars`, `customModel`, `customEffort`, and `sessionSshRemoteConfig` were all dropped at the CLI boundary.

This was called out as a CLAUDE.md violation for SSH, and a silent capability gap for everything else. This PR brings the CLI to parity with the desktop `process:spawn` handler.

- **Config overrides**: every CLI spawn now runs through `applyAgentConfigOverrides()` (the same merger the desktop uses), so customArgs, customEnvVars, customModel, and customEffort are all honored with session → agent-config → defaults precedence.
- **SSH remote execution**: loaded lazily via `await import()` so the local spawn path never pulls in `execFile`/`which` helpers. Users can now run playbooks against remote-configured agents.
- **Hard-fail on unresolvable remote**: when `sshRemoteConfig.enabled` is true but the remote can't be resolved, the CLI returns a clear error instead of silently falling back to local. A user who opts into SSH doesn't want their prompt leaking onto the controller's machine if the config is wrong.
- **Env-var precedence fix** (follow-up `01938078c`): agent `defaultEnvVars` were being returned as part of `effectiveCustomEnvVars` and then `Object.assign`'d unconditionally over `process.env`, clobbering shell-exported values. `resolveAgentOverrides()` now returns only the truly user-configured overrides; defaults are layered separately with "shell wins" semantics.

## Changes

- `SessionInfo` extended with `customArgs`, `customEnvVars`, `sessionSshRemoteConfig` so the CLI can read what the desktop persists.
- `spawnAgent()` refactored: builds pre-override args, then calls `applyAgentConfigOverrides()` to merge configs; removes the now-redundant explicit `def.modelArgs()` call.
- `applyAgentConfigOverrides` signature loosened to accept `AgentDefinition` (narrower type the CLI has on hand — the function only reads `configOptions`/`defaultEnvVars`).
- New `resolveAgentOverrides()`, `applyEnvLayers()`, `buildSshEnvForRemote()`, `sshUnresolvedFailure()` helpers in `agent-spawner.ts`.
- `send.ts` and `batch-processor.ts` (task run + synopsis) thread all overrides through to `spawnAgent`.

## Tests

- **28 new tests** covering session/agent-level customArgs and customEnvVars precedence, shell-quote parsing, customModel flow via configOptions (Claude + Codex), SSH wrapper invocation, stdin passthrough for large prompts, hard-fail on unresolvable remote, baseline stream-json flags, read-only mode, resume vs fresh session, Codex working-dir/resume args, plus three regression tests locking in the env-var precedence fix (shell > agent defaults, defaults fill blanks, defaults still reach SSH remote).
- **Full CLI suite: 721/721 tests passing.**

## Docs

- `CLAUDE.md` SSH section now documents CLI parity and the hard-fail expectation.
- `docs/agent-guides/CLI-PLAYBOOKS.md` "CLI vs Desktop Spawning" section corrected to reflect what is and isn't honored.

## Test plan

### Automated

- [x] `tsc -p tsconfig.cli.json --noEmit` clean
- [x] `tsc -p tsconfig.main.json --noEmit` clean (pre-existing unrelated `js-yaml`/`picomatch` warnings only)
- [x] `eslint src/` exit 0
- [x] `prettier --check` clean on all edited files
- [x] `vitest run src/__tests__/cli` — 721/721 pass

### Manual verification — 2026-04-24, Linux

End-to-end run against this branch's freshly-built CLI in an isolated sandbox (`XDG_CONFIG_HOME` redirect to a scratch dir — production Maestro config untouched), using a shim "Claude" that logged actual argv/cwd/env per spawn, and a real SSH remote for the remote-execution scenarios. All ten scenarios pass.

| # | Scenario | Pass signal | Result |
|---|---|---|---|
| A | Session `customArgs` threaded through | argv contains `--foo`, `has spaces`, `--bar` (shell-quote parsed) | ✅ |
| B1 | Session `customEnvVars` win over shell env | `TEST_USER_VAR=from-session` in spawn env, shell had `from-shell` | ✅ |
| B2 | Shell env wins over agent `defaultEnvVars` *(regression fix)* | `OPENCODE_CONFIG_CONTENT=shell-set-value` survives spawn | ✅ |
| B3 | Agent `defaultEnvVars` fill in when shell absent | opencode's JSON default reaches the spawn env | ✅ |
| C | Session `customModel` applied | `--model opus` in argv | ✅ |
| F1 | Session-level beats agent-level `customArgs` | `--from-session` in argv, `--from-agent` absent | ✅ |
| F2 | Agent-level `customArgs` applied when session absent | `--from-agent` in argv | ✅ |
| D | SSH enabled + valid remote | `Wrapping spawn with SSH remote execution` log, full remote `ssh ... claude ...` dispatched, real response + usage stats returned; local spawn log empty | ✅ |
| D+ | Session `customEnvVars` reach SSH remote | `PR888_REMOTE_CANARY='reached-the-remote' claude ...` visible in dispatched `remoteCommand` | ✅ |
| E | SSH enabled + unresolvable remote → hard-fail, **no prompt leak** | CLI returns `success:false` with exact expected error; local spawn log empty — prompt "sensitive prompt that must not leak locally" never reached the local machine | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session-level overrides for custom CLI args, env vars, model and effort now apply consistently to all agent runs (including follow-ups).
  * CLI playbooks gain SSH remote execution support with dynamic SSH wrapper loading.

* **Bug Fixes**
  * CLI now fails explicitly when a configured SSH remote cannot be resolved instead of silently falling back to local execution.

* **Documentation**
  * Updated guidance for CLI playbooks and SSH/agent configuration parity.

* **Tests**
  * Expanded tests for spawn options, SSH behavior, stdin passthrough, and regression cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
