### PR TITLE
fix: open-issue cleanup (readDirRemote tolerance, Claude skills on WSL, Python 3.12 guard)

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
 		"package:linux": "node scripts/set-version.mjs npm run build && node scripts/set-version.mjs electron-builder --linux",
 		"start": "electron .",
 		"clean": "rm -rf dist release node_modules/.vite",
+		"preinstall": "node scripts/check-python.mjs",
 		"prepare": "node scripts/setup-git-hooks.mjs",
 		"postinstall": "electron-rebuild -f -w node-pty,better-sqlite3",
 		"lint": "tsc -p tsconfig.lint.json && tsc -p tsconfig.main.json --noEmit && tsc -p tsconfig.cli.json --noEmit",

--- a/scripts/check-python.mjs
+++ b/scripts/check-python.mjs
@@ -1,0 +1,74 @@
+// Warn early if the Python that node-gyp will pick up is 3.12+ without
+// `setuptools` installed. node-gyp (pulled in transitively by better-sqlite3
+// and node-pty) still imports `distutils`, which was removed from the
+// standard library in Python 3.12 — so `npm install` dies with
+// `ModuleNotFoundError: No module named 'distutils'` during the postinstall
+// electron-rebuild step. See https://github.com/RunMaestro/Maestro/issues/170.
+
+import { spawnSync } from 'node:child_process';
+
+const skip =
+	process.env.MAESTRO_SKIP_PYTHON_CHECK === '1' || process.env.MAESTRO_SKIP_PYTHON_CHECK === 'true';
+if (skip) process.exit(0);
+
+const candidate = process.env.PYTHON || process.env.npm_config_python || 'python3';
+
+function resolvePython() {
+	const bins = candidate === 'python' ? ['python'] : [candidate, 'python'];
+	for (const bin of bins) {
+		const probe = spawnSync(bin, ['--version'], { stdio: 'pipe', encoding: 'utf8' });
+		if (probe.error || probe.status !== 0) continue;
+		const raw = (probe.stdout || probe.stderr || '').trim();
+		const match = raw.match(/Python (\d+)\.(\d+)/);
+		if (!match) continue;
+		return { bin, major: Number(match[1]), minor: Number(match[2]), raw };
+	}
+	return null;
+}
+
+const python = resolvePython();
+if (!python) {
+	// No Python found — let node-gyp raise its own error if it actually needs one.
+	process.exit(0);
+}
+
+// distutils was removed in Python 3.12; node-gyp's vendored gyp still imports it.
+const needsDistutilsWorkaround = python.major > 3 || (python.major === 3 && python.minor >= 12);
+if (!needsDistutilsWorkaround) process.exit(0);
+
+const hasSetuptools = spawnSync(python.bin, ['-c', 'import setuptools'], {
+	stdio: 'pipe',
+	encoding: 'utf8',
+});
+// Treat "setuptools present" AND spawn failures (status === null from a
+// transient EAGAIN, sandbox, or binary-gone-away) as non-problems: the
+// advisory is best-effort and we'd rather stay silent than misattribute
+// a spawn error to a missing module.
+if (hasSetuptools.error || hasSetuptools.status === null || hasSetuptools.status === 0) {
+	process.exit(0);
+}
+
+const reset = '\x1b[0m';
+const yellow = '\x1b[33m';
+const bold = '\x1b[1m';
+// eslint-disable-next-line no-console
+console.warn(
+	[
+		'',
+		`${yellow}${bold}[maestro] Python toolchain warning${reset}`,
+		`  Detected ${python.raw} at '${python.bin}', but \`setuptools\` is not installed.`,
+		`  node-gyp (via better-sqlite3 / node-pty) still imports \`distutils\`, which was`,
+		`  removed from Python's standard library in 3.12 — your install is likely to fail`,
+		`  during the electron-rebuild postinstall step with:`,
+		`    ModuleNotFoundError: No module named 'distutils'`,
+		'',
+		`  Fix it with one of:`,
+		`    ${bold}${python.bin} -m pip install setuptools${reset}`,
+		`    ${bold}uv venv -p 3.11 && source .venv/bin/activate${reset}   (use Python 3.11)`,
+		'',
+		`  Set MAESTRO_SKIP_PYTHON_CHECK=1 to silence this check.`,
+		'',
+	].join('\n')
+);
+// Warn only — don't block installs for users who know what they're doing.
+process.exit(0);

--- a/src/__tests__/main/ipc/handlers/agents.test.ts
+++ b/src/__tests__/main/ipc/handlers/agents.test.ts
@@ -1142,6 +1142,130 @@ describe('agents IPC handlers', () => {
 			expect(result).toEqual([{ name: '/help' }, { name: '/compact' }, { name: '/clear' }]);
 		});
 
+		it('enriches Claude skill commands with descriptions from SKILL.md frontmatter', async () => {
+			const mockAgent = {
+				id: 'claude-code',
+				available: true,
+				path: '/usr/bin/claude',
+				command: 'claude',
+			};
+			mockAgentDetector.getAgent.mockResolvedValue(mockAgent);
+
+			const initMessage = JSON.stringify({
+				type: 'system',
+				subtype: 'init',
+				slash_commands: ['/Research', '/help'],
+			});
+
+			vi.mocked(fs.existsSync).mockReturnValue(true);
+			vi.mocked(execFileNoThrow).mockResolvedValue({
+				stdout: initMessage + '\n',
+				stderr: '',
+				exitCode: 0,
+			});
+
+			// Project-level skill directory lists Research; user-level has nothing.
+			vi.mocked(fs.promises.readdir).mockImplementation(async (dir: any) => {
+				if (String(dir) === '/test/project/.claude/skills') {
+					return [{ name: 'Research', isDirectory: () => true }] as any;
+				}
+				const enoent = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+				throw enoent;
+			});
+			vi.mocked(fs.promises.readFile).mockImplementation(async (filePath: any) => {
+				const p = String(filePath);
+				// Canonical uppercase SKILL.md is what Claude Code actually writes.
+				if (p === '/test/project/.claude/skills/Research/SKILL.md') {
+					return '---\nname: Research\ndescription: Deep literature review\n---\n\nBody';
+				}
+				const enoent = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+				throw enoent;
+			});
+
+			const handler = handlers.get('agents:discoverSlashCommands');
+			const result = await handler!({} as any, 'claude-code', '/test/project');
+
+			expect(result).toEqual([
+				{ name: '/Research', description: 'Deep literature review' },
+				{ name: '/help' }, // built-in, no skill file → no description
+			]);
+		});
+
+		it('ignores a "description:" line that appears in the body (not the frontmatter)', async () => {
+			const mockAgent = {
+				id: 'claude-code',
+				available: true,
+				path: '/usr/bin/claude',
+				command: 'claude',
+			};
+			mockAgentDetector.getAgent.mockResolvedValue(mockAgent);
+
+			vi.mocked(fs.existsSync).mockReturnValue(true);
+			vi.mocked(execFileNoThrow).mockResolvedValue({
+				stdout:
+					JSON.stringify({
+						type: 'system',
+						subtype: 'init',
+						slash_commands: ['/Research'],
+					}) + '\n',
+				stderr: '',
+				exitCode: 0,
+			});
+
+			vi.mocked(fs.promises.readdir).mockImplementation(async (dir: any) => {
+				if (String(dir) === '/test/project/.claude/skills') {
+					return [{ name: 'Research', isDirectory: () => true }] as any;
+				}
+				const enoent = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+				throw enoent;
+			});
+			vi.mocked(fs.promises.readFile).mockImplementation(async (filePath: any) => {
+				const p = String(filePath);
+				// Frontmatter has no description; body contains a misleading
+				// "description:" line that must NOT be picked up.
+				if (p === '/test/project/.claude/skills/Research/SKILL.md') {
+					return '---\nname: Research\n---\n\nSee description: this is body text.';
+				}
+				const enoent = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+				throw enoent;
+			});
+
+			const handler = handlers.get('agents:discoverSlashCommands');
+			const result = await handler!({} as any, 'claude-code', '/test/project');
+
+			expect(result).toEqual([{ name: '/Research' }]);
+		});
+
+		it('falls back to names-only when skill enrichment fails, preserving slash commands', async () => {
+			const mockAgent = {
+				id: 'claude-code',
+				available: true,
+				path: '/usr/bin/claude',
+				command: 'claude',
+			};
+			mockAgentDetector.getAgent.mockResolvedValue(mockAgent);
+
+			vi.mocked(fs.existsSync).mockReturnValue(true);
+			vi.mocked(execFileNoThrow).mockResolvedValue({
+				stdout:
+					JSON.stringify({ type: 'system', subtype: 'init', slash_commands: ['/x', '/y'] }) + '\n',
+				stderr: '',
+				exitCode: 0,
+			});
+
+			// An unexpected failure on the skills dir (e.g. EACCES) should
+			// NOT tear down the slash-command list — enrichment is
+			// best-effort. The error is still captured by Sentry inside
+			// discoverSlashCommands; the list itself survives.
+			vi.mocked(fs.promises.readdir).mockImplementation(async () => {
+				throw Object.assign(new Error('permission denied'), { code: 'EACCES' });
+			});
+
+			const handler = handlers.get('agents:discoverSlashCommands');
+			const result = await handler!({} as any, 'claude-code', '/test/project');
+			expect(result).toEqual([{ name: '/x' }, { name: '/y' }]);
+		});
+
 		it('should use custom path if provided', async () => {
 			const mockAgent = {
 				id: 'claude-code',

--- a/src/__tests__/main/ipc/handlers/claude.test.ts
+++ b/src/__tests__/main/ipc/handlers/claude.test.ts
@@ -2100,4 +2100,106 @@ not valid json at all
 			});
 		});
 	});
+
+	describe('claude:getSkills', () => {
+		it('finds skills via SKILL.md on case-sensitive filesystems (Linux/WSL)', async () => {
+			const fs = await import('fs/promises');
+
+			// Simulate a case-sensitive filesystem: SKILL.md exists, skill.md does not.
+			// Only the project-level skills directory has entries; user dir is empty.
+			vi.mocked(fs.default.readdir).mockImplementation(async (dir: any) => {
+				if (String(dir) === '/test/project/.claude/skills') {
+					return [{ name: 'Research', isDirectory: () => true }] as any;
+				}
+				return [] as any;
+			});
+			vi.mocked(fs.default.readFile).mockImplementation(async (filePath: any) => {
+				const p = String(filePath);
+				if (p === '/test/project/.claude/skills/Research/SKILL.md') {
+					return '---\nname: Research\ndescription: Deep literature review\n---\n\nBody';
+				}
+				const enoent: NodeJS.ErrnoException = Object.assign(new Error('ENOENT'), {
+					code: 'ENOENT',
+				});
+				throw enoent;
+			});
+
+			const handler = handlers.get('claude:getSkills');
+			const result = await handler!({} as any, '/test/project');
+
+			expect(result).toHaveLength(1);
+			expect(result[0]).toMatchObject({
+				name: 'Research',
+				description: 'Deep literature review',
+				source: 'project',
+			});
+		});
+
+		it('propagates non-ENOENT filesystem errors from scanSkillsDir', async () => {
+			const fs = await import('fs/promises');
+
+			// A permission error on the skills directory must NOT be silently
+			// swallowed — it should propagate so Sentry captures it.
+			vi.mocked(fs.default.readdir).mockImplementation(async () => {
+				throw Object.assign(new Error('permission denied'), { code: 'EACCES' });
+			});
+
+			const handler = handlers.get('claude:getSkills');
+			await expect(handler!({} as any, '/test/project')).rejects.toMatchObject({
+				code: 'EACCES',
+			});
+		});
+
+		it('propagates non-ENOENT filesystem errors from parseSkillFile', async () => {
+			const fs = await import('fs/promises');
+
+			vi.mocked(fs.default.readdir).mockImplementation(async (dir: any) => {
+				if (String(dir) === '/test/project/.claude/skills') {
+					return [{ name: 'Locked', isDirectory: () => true }] as any;
+				}
+				return [] as any;
+			});
+			// The skill dir lists fine but SKILL.md is locked — this must
+			// surface, not be silently dropped as "skill not found".
+			vi.mocked(fs.default.readFile).mockImplementation(async () => {
+				throw Object.assign(new Error('IO error'), { code: 'EIO' });
+			});
+
+			const handler = handlers.get('claude:getSkills');
+			await expect(handler!({} as any, '/test/project')).rejects.toMatchObject({
+				code: 'EIO',
+			});
+		});
+
+		it('falls back to lowercase skill.md for legacy layouts', async () => {
+			const fs = await import('fs/promises');
+
+			vi.mocked(fs.default.readdir).mockImplementation(async (dir: any) => {
+				if (String(dir) === '/test/project/.claude/skills') {
+					return [{ name: 'Legacy', isDirectory: () => true }] as any;
+				}
+				return [] as any;
+			});
+			vi.mocked(fs.default.readFile).mockImplementation(async (filePath: any) => {
+				const p = String(filePath);
+				// Only lowercase skill.md exists
+				if (p === '/test/project/.claude/skills/Legacy/skill.md') {
+					return '---\ndescription: Legacy skill\n---\n\nBody';
+				}
+				const enoent: NodeJS.ErrnoException = Object.assign(new Error('ENOENT'), {
+					code: 'ENOENT',
+				});
+				throw enoent;
+			});
+
+			const handler = handlers.get('claude:getSkills');
+			const result = await handler!({} as any, '/test/project');
+
+			expect(result).toHaveLength(1);
+			expect(result[0]).toMatchObject({
+				name: 'Legacy',
+				description: 'Legacy skill',
+			});
+		});
+	});
 });

--- a/src/__tests__/renderer/hooks/useWizardHandlers.test.ts
+++ b/src/__tests__/renderer/hooks/useWizardHandlers.test.ts
@@ -328,6 +328,29 @@ describe('useWizardHandlers', () => {
 			);
 		});
 
+		it('preserves skill description returned from discoverSlashCommands', async () => {
+			const session = createMockSession({ agentCommands: undefined });
+			useSessionStore.setState({ sessions: [session], activeSessionId: 'session-1' });
+
+			(window as any).maestro.agents.discoverSlashCommands.mockResolvedValue([
+				{ name: 'Research', description: 'Deep literature review' },
+			]);
+
+			const deps = createMockDeps();
+			renderHook(() => useWizardHandlers(deps));
+
+			await act(async () => {
+				await new Promise((r) => setTimeout(r, 50));
+			});
+
+			const updatedSession = useSessionStore.getState().sessions[0];
+			expect(updatedSession.agentCommands).toEqual(
+				expect.arrayContaining([
+					{ command: '/Research', description: 'Deep literature review', prompt: undefined },
+				])
+			);
+		});
+
 		it('skips discovery if agentCommands already populated', async () => {
 			const session = createMockSession({
 				agentCommands: [{ command: '/existing', description: 'Existing' }],

--- a/src/main/ipc/handlers/agents.ts
+++ b/src/main/ipc/handlers/agents.ts
@@ -1,6 +1,7 @@
 import { ipcMain } from 'electron';
 import Store from 'electron-store';
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import type { AgentConfigsData } from '../../stores/types';
 import {
@@ -60,6 +61,79 @@ const handlerOpts = (
 interface DiscoveredCommand {
 	name: string;
 	prompt?: string; // .md file content for custom commands; absent for built-ins
+	description?: string; // frontmatter description for Claude Code skills; absent otherwise
+}
+
+/**
+ * Read descriptions for Claude Code skills from disk.
+ *
+ * Claude Code emits skill names via its init message but without descriptions,
+ * so we read the frontmatter from each skill's SKILL.md (with skill.md fallback
+ * for legacy layouts). Project-local skills take precedence over user-level skills.
+ *
+ * Returns a map of skill directory name → description. Names with no description
+ * frontmatter are omitted rather than returned as empty strings, so the renderer
+ * can fall back to its built-in description table.
+ */
+async function readClaudeSkillDescriptions(cwd: string): Promise<Map<string, string>> {
+	const descriptions = new Map<string, string>();
+	const homeDir = os.homedir();
+	const skillDirs = [
+		path.join(cwd, '.claude', 'skills'), // project-local (wins)
+		path.join(homeDir, '.claude', 'skills'), // user-level
+	];
+
+	// Extract the YAML frontmatter block from a file so we don't pick up a
+	// body line that happens to start with "description:". Matches the
+	// bounded parser used by scanSkillsDir in claude.ts.
+	const extractFrontmatter = (content: string): string | null => {
+		const trimmed = content.trimStart();
+		if (!trimmed.startsWith('---')) return null;
+		const endIndex = trimmed.indexOf('\n---', 3);
+		if (endIndex === -1) return null;
+		return trimmed.slice(3, endIndex);
+	};
+
+	for (const dir of skillDirs) {
+		let entries: fs.Dirent[];
+		try {
+			entries = await fs.promises.readdir(dir, { withFileTypes: true });
+		} catch (error) {
+			// Missing skills directory is the norm — skip. Anything else
+			// (permission errors, IO errors) should surface to Sentry.
+			if (isMissingEntryError(error)) continue;
+			throw error;
+		}
+		if (!Array.isArray(entries)) continue;
+		for (const entry of entries) {
+			if (!entry.isDirectory()) continue;
+			if (descriptions.has(entry.name)) continue; // project-local already set
+			for (const candidate of ['SKILL.md', 'skill.md']) {
+				let content: string;
+				try {
+					content = await fs.promises.readFile(path.join(dir, entry.name, candidate), 'utf-8');
+				} catch (error) {
+					if (isMissingEntryError(error)) continue;
+					throw error;
+				}
+				const frontmatter = extractFrontmatter(content);
+				if (frontmatter) {
+					const match = frontmatter.match(/^description:\s*(.+)$/m);
+					if (match) {
+						descriptions.set(entry.name, match[1].trim().replace(/^["']|["']$/g, ''));
+					}
+				}
+				break;
+			}
+		}
+	}
+
+	return descriptions;
+}
+
+function isMissingEntryError(error: unknown): boolean {
+	const code = (error as NodeJS.ErrnoException | undefined)?.code;
+	return code === 'ENOENT' || code === 'ENOTDIR';
 }
 
 async function discoverOpenCodeSlashCommands(cwd: string): Promise<DiscoveredCommand[]> {
@@ -1296,7 +1370,26 @@ export function registerAgentsHandlers(deps: AgentsHandlerDependencies): void {
 									`Discovered ${msg.slash_commands.length} slash commands for ${agentId}`,
 									LOG_CONTEXT
 								);
-								return (msg.slash_commands as string[]).map((name: string) => ({ name }));
+								// Description enrichment is best-effort: a permission/IO
+								// error on the skills dir shouldn't lose the user's
+								// entire slash-command list. Capture the exception for
+								// Sentry and fall back to names-only.
+								let skillDescriptions = new Map<string, string>();
+								try {
+									skillDescriptions = await readClaudeSkillDescriptions(cwd);
+								} catch (err) {
+									void captureException(err);
+									logger.warn(
+										`Skill description enrichment failed; returning slash commands without descriptions`,
+										LOG_CONTEXT,
+										{ error: String(err) }
+									);
+								}
+								return (msg.slash_commands as string[]).map((name: string) => {
+									const lookupKey = name.startsWith('/') ? name.slice(1) : name;
+									const description = skillDescriptions.get(lookupKey);
+									return description ? { name, description } : { name };
+								});
 							}
 						} catch {
 							// Not valid JSON, skip

--- a/src/main/ipc/handlers/claude.ts
+++ b/src/main/ipc/handlers/claude.ts
@@ -1596,6 +1596,14 @@ export function registerClaudeHandlers(deps: ClaudeHandlerDependencies): void {
 					source: 'project' | 'user';
 				}> = [];
 
+				// Only treat "missing entry" filesystem errors as "no skill here";
+				// propagate permission/IO errors to the outer IPC handler so
+				// Sentry captures them instead of silently dropping skills.
+				const isMissingEntryError = (error: unknown): boolean => {
+					const code = (error as NodeJS.ErrnoException | undefined)?.code;
+					return code === 'ENOENT' || code === 'ENOTDIR';
+				};
+
 				/**
 				 * Parses a skill.md file to extract name, description, and token count.
 				 * Skills use YAML frontmatter with 'name' and 'description' fields.
@@ -1651,28 +1659,37 @@ export function registerClaudeHandlers(deps: ClaudeHandlerDependencies): void {
 						const tokenCount = Math.round(content.length / 4);
 
 						return { name, description, tokenCount, source };
-					} catch {
-						return null;
+					} catch (error) {
+						if (isMissingEntryError(error)) return null;
+						throw error;
 					}
 				};
 
 				/**
-				 * Scans a skills directory for skill.md files
+				 * Scans a skills directory for SKILL.md files. Claude Code writes the
+				 * canonical uppercase name; on case-insensitive filesystems
+				 * (Windows NTFS, default macOS APFS) `skill.md` happens to match,
+				 * but on case-sensitive filesystems (Linux, WSL) it does not — so
+				 * try the canonical name first and fall back to lowercase.
 				 */
 				const scanSkillsDir = async (dir: string, source: 'project' | 'user') => {
+					let entries;
 					try {
-						const entries = await fs.readdir(dir, { withFileTypes: true });
-						for (const entry of entries) {
-							if (entry.isDirectory()) {
-								const skillPath = path.join(dir, entry.name, 'skill.md');
-								const skill = await parseSkillFile(skillPath, entry.name, source);
-								if (skill) {
-									skills.push(skill);
-								}
+						entries = await fs.readdir(dir, { withFileTypes: true });
+					} catch (error) {
+						if (isMissingEntryError(error)) return;
+						throw error;
+					}
+					for (const entry of entries) {
+						if (!entry.isDirectory()) continue;
+						for (const candidate of ['SKILL.md', 'skill.md']) {
+							const skillPath = path.join(dir, entry.name, candidate);
+							const skill = await parseSkillFile(skillPath, entry.name, source);
+							if (skill) {
+								skills.push(skill);
+								break;
 							}
 						}
-					} catch {
-						// Directory doesn't exist or isn't readable
 					}
 				};
 

--- a/src/main/preload/agents.ts
+++ b/src/main/preload/agents.ts
@@ -152,14 +152,15 @@ export function createAgentsApi() {
 
 		/**
 		 * Discover available slash commands for an agent.
-		 * Returns objects with name and optional prompt for all agents.
+		 * Returns objects with name, optional prompt (OpenCode custom commands),
+		 * and optional description (Claude Code skill frontmatter).
 		 */
 		discoverSlashCommands: (
 			agentId: string,
 			cwd: string,
 			customPath?: string,
 			sshRemoteId?: string
-		): Promise<{ name: string; prompt?: string }[] | null> =>
+		): Promise<{ name: string; prompt?: string; description?: string }[] | null> =>
 			ipcRenderer.invoke('agents:discoverSlashCommands', agentId, cwd, customPath, sshRemoteId),
 	};
 }

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -867,7 +867,7 @@ interface MaestroAPI {
 			cwd: string,
 			customPath?: string,
 			sshRemoteId?: string
-		) => Promise<{ name: string; prompt?: string }[] | null>;
+		) => Promise<{ name: string; prompt?: string; description?: string }[] | null>;
 	};
 	// Agent Sessions API - all methods accept optional sshRemoteId for SSH remote session storage access
 	agentSessions: {

--- a/src/renderer/hooks/wizard/useWizardHandlers.ts
+++ b/src/renderer/hooks/wizard/useWizardHandlers.ts
@@ -266,7 +266,8 @@ export function useWizardHandlers(deps: UseWizardHandlersDeps): UseWizardHandler
 
 				const agentCommandObjects = (agentSlashCommands ?? []).map((cmd) => ({
 					command: cmd.name.startsWith('/') ? cmd.name : `/${cmd.name}`,
-					description: getSlashCommandDescription(cmd.name, currentSession.toolType),
+					description:
+						cmd.description ?? getSlashCommandDescription(cmd.name, currentSession.toolType),
 					prompt: cmd.prompt,
 				}));
 
@@ -741,7 +742,7 @@ export function useWizardHandlers(deps: UseWizardHandlersDeps): UseWizardHandler
 			let skillsMessage: string;
 			if (skills.length === 0) {
 				skillsMessage =
-					'## Skills\n\nNo Claude Code skills were found in this project.\n\nTo add skills, create `.claude/skills/<skill-name>/skill.md` files in your project.';
+					'## Skills\n\nNo Claude Code skills were found in this project.\n\nTo add skills, create `.claude/skills/<skill-name>/SKILL.md` files in your project.';
 			} else {
 				const formatTokenCount = (tokens: number): string => {
 					if (tokens >= 1000) {


### PR DESCRIPTION
## Summary

Three small, independent fixes picked off the open-issue backlog.

### 1. Claude Code skill descriptions on case-sensitive filesystems — #706
Claude Code writes `SKILL.md` (canonical uppercase). The existing `scanSkillsDir` only looked for `skill.md`, so on Linux/WSL the lookup silently failed and the UI fell back to the generic "Agent command" label. Fixed by:

- `scanSkillsDir` (`src/main/ipc/handlers/claude.ts`) now tries `SKILL.md` first and falls back to `skill.md` for legacy layouts.
- `agents:discoverSlashCommands` (`src/main/ipc/handlers/agents.ts`) now enriches Claude's reported `slash_commands` list with the description read from each matching skill's frontmatter, via a new `readClaudeSkillDescriptions()` helper.
- The IPC return type gets an optional `description` field (`src/main/preload/agents.ts`, `src/renderer/global.d.ts`).
- `useWizardHandlers` (`src/renderer/hooks/wizard/useWizardHandlers.ts`) prefers the disk-derived description when present, falling back to the built-in table otherwise. The `/skills` empty-state message now documents the canonical `SKILL.md` name.

### 2. Python 3.12 install-time guard — #170
node-gyp (pulled in transitively by `better-sqlite3` and `node-pty`) still imports `distutils`, which was removed from Python's stdlib in 3.12 — so `npm install` dies during the `electron-rebuild` postinstall step with `ModuleNotFoundError: No module named 'distutils'`. Added a non-blocking `preinstall` check (`scripts/check-python.mjs`, wired in `package.json`) that warns early when the resolved Python is ≥3.12 without `setuptools`, pointing to the two known workarounds. Silenceable with `MAESTRO_SKIP_PYTHON_CHECK=1`.

### 3. SSH `readDirRemote` exit-code handling (review follow-ups from closed PR #885)
Two commits responding to review feedback on #885:

- **`fix(ssh): readDirRemote succeeds when symlink-scan for-loop exits non-zero`** — the remote command ends with a `for` loop probing for symlinks-to-dirs; when no such symlink exists the final `[ -L "$f" ]` returns non-zero and becomes the SSH command's exit code. With stderr silenced, the caller only saw Node's generic "Command failed" boilerplate despite valid `ls` output. Fixed on both sides: `|| true` on the symlink scan, plus a defense-in-depth tolerance in `readDirRemote` that accepts a non-zero exit when the `__SYMDIR__` marker is present.
- **`fix(ssh): narrow readDirRemote marker-based success override`** — the initial tolerance was too wide (any non-zero exit with `__SYMDIR__` in stdout was accepted). Narrowed to the specific known for-loop-tail shape: exit 1, marker present, no `__LS_ERROR__`, empty stderr — so a real SSH/transport failure still propagates.

## Also closes
- **#187** (Windows cloudflared detection) — closed as duplicate of #159.
- **#298** (MCP Desktop Commander on Windows) — closed as a by-design batch-mode limitation.

## Test plan
- [x] `npx prettier --check` on all touched files — clean
- [x] `npx eslint` on modified source files — clean
- [x] `npx vitest run` scoped to `claude.test.ts`, `agents.test.ts`, `useWizardHandlers.test.ts` — **215/215 passing**
- [x] Added regression tests:
  - `claude.test.ts`: skill discovery via `SKILL.md` (primary) and `skill.md` (legacy fallback)
  - `agents.test.ts`: `discoverSlashCommands` enriches skill commands with frontmatter description
  - `useWizardHandlers.test.ts`: IPC-returned description survives through to the session's `agentCommands`
  - `readDirRemote` regression tests (in prior SSH commits) covering non-zero-exit-with-valid-stdout, non-empty-stderr, and non-1-exit-code paths
- [x] Manually verified `scripts/check-python.mjs` fires the warning on Python 3.12.3 without `setuptools` and exits 0; also verified `MAESTRO_SKIP_PYTHON_CHECK=1` silences it

## Regression notes
- On case-insensitive filesystems (Windows NTFS, default macOS APFS) both `SKILL.md` and `skill.md` resolve to the same file, so behaviour is unchanged there.
- `useWizardHandlers` uses `cmd.description ?? getSlashCommandDescription(...)` — when `description` is absent the old lookup-table behaviour is preserved, so non-skill slash commands are unaffected.
- The preinstall script only warns; it never blocks install, so users who explicitly choose to run an unsupported Python aren't forced off it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Slash commands can show descriptions extracted from skill metadata.
  * Added an advisory pre-install Python compatibility check (skippable via env var).

* **Improvements**
  * Skill discovery now prefers canonical uppercase SKILL.md with fallback and better case-sensitive handling.
  * Better messaging guiding creation/location of skill metadata.

* **Bug Fixes**
  * More robust error handling during skill scans (non-missing IO errors surface appropriately).

* **Tests**
  * Added unit tests covering skill discovery, description enrichment, and persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->