### PR TITLE
fix(parsers): don't treat Claude Code api_retry events as errors

### DIFF
--- a/src/__tests__/main/parsers/claude-output-parser.test.ts
+++ b/src/__tests__/main/parsers/claude-output-parser.test.ts
@@ -642,6 +642,33 @@ describe('ClaudeOutputParser', () => {
 			const error = parser.detectErrorFromLine(line);
 			expect(error?.parsedJson).toBeDefined();
 		});
+
+		it('should NOT treat system api_retry events as errors', () => {
+			// Claude Code emits these when retrying HTTP 429/529; the turn ultimately
+			// succeeds. The `error` field here is a retry-category tag, not a failure.
+			const line = JSON.stringify({
+				type: 'system',
+				subtype: 'api_retry',
+				attempt: 1,
+				max_retries: 10,
+				retry_delay_ms: 549.5,
+				error_status: 529,
+				error: 'rate_limit',
+				session_id: 'b63e648d-360f-44b7-a9b0-6dc63b609241',
+				uuid: '1b397bb3-2e6f-4821-8547-e026d8d11817',
+			});
+			expect(parser.detectErrorFromLine(line)).toBeNull();
+		});
+
+		it('should NOT treat system init events as errors even if they carry an error field', () => {
+			const line = JSON.stringify({
+				type: 'system',
+				subtype: 'init',
+				session_id: 'abc',
+				error: 'something',
+			});
+			expect(parser.detectErrorFromLine(line)).toBeNull();
+		});
 	});
 
 	describe('detectErrorFromExit', () => {

--- a/src/main/parsers/claude-output-parser.ts
+++ b/src/main/parsers/claude-output-parser.ts
@@ -382,6 +382,16 @@ export class ClaudeOutputParser implements AgentOutputParser {
 		}
 
 		const obj = parsed as Record<string, unknown>;
+
+		// system/* events (api_retry, init, etc.) are control-plane messages, not
+		// assistant-turn failures. api_retry in particular carries `error: "rate_limit"`
+		// as a retry-category tag for HTTP 429/529 and similar transient conditions
+		// that Claude Code will automatically retry. Treating them as errors would
+		// flag a still-streaming (and ultimately successful) response as failed.
+		if (obj.type === 'system') {
+			return null;
+		}
+
 		let errorText: string | null = null;
 		let parsedJson: unknown = null;
 


### PR DESCRIPTION
## Summary

Claude Code emits `type: \"system\", subtype: \"api_retry\"` JSONL lines with an `error` field tagging the retry category (e.g. `\"error\": \"rate_limit\"` for HTTP 429/529) whenever it retries a transient upstream failure. The turn ultimately streams in and completes, but `ClaudeOutputParser.detectErrorFromParsed`'s catch-all `else if (obj.error)` branch was matching these retry events and synthesizing an `AgentError`, so the assistant response rendered as a red \"Error\" card in the chat UI even though nothing had actually failed.

## Observed payload

```json
{
  \"type\": \"system\",
  \"subtype\": \"api_retry\",
  \"attempt\": 1,
  \"max_retries\": 10,
  \"retry_delay_ms\": 549.5,
  \"error_status\": 529,
  \"error\": \"rate_limit\"
}
```

Note: HTTP 529 here is Anthropic's _\"Overloaded\"_ signal (API-wide capacity shedding), not a per-account rate limit — but Claude Code tags 429s, 529s, and similar transients under a single `rate_limit` retry-category label. Either way, these are retryable control-plane events, not turn failures.

## Fix

Short-circuit `detectErrorFromParsed` on `type === 'system'` so init, api_retry, and future system/* subtypes can carry metadata fields (including `error`) without being misclassified. Terminal errors still flow through the existing `type: 'error'` and `type: 'turn.failed'` branches, which are handled earlier in the same method.

## Test plan

- [x] `npx vitest run src/__tests__/main/parsers/claude-output-parser.test.ts` — 59 passed (2 new regression cases: the exact field payload above + a `system/init` variant with an `error` field)
- [x] `npx tsc --noEmit` — no new errors in touched files (pre-existing xterm/js-yaml declaration errors are unrelated)
- [x] `npx eslint src/main/parsers/claude-output-parser.ts` — clean
- [x] `npx prettier --check` on touched files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * System control-plane events (API retries, initialization messages) are no longer incorrectly flagged as errors, preventing false error reports during transient conditions.

* **Tests**
  * Added comprehensive unit tests verifying that system events are properly ignored during error detection, ensuring they are not mistakenly treated as failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->