### PR TITLE
fix: close feedback success modal when opening issue link

### DIFF
--- a/src/renderer/components/FeedbackChatView.tsx
+++ b/src/renderer/components/FeedbackChatView.tsx
@@ -650,7 +650,10 @@ export function FeedbackChatView({ theme, onCancel, onWidthChange }: FeedbackCha
 						</button>
 						<button
 							type="button"
-							onClick={() => openUrl(createdIssueUrl)}
+							onClick={() => {
+								openUrl(createdIssueUrl);
+								onCancel();
+							}}
 							className="p-1 rounded transition-colors hover:bg-white/10 shrink-0"
 							style={{ color: theme.colors.textDim }}
 							title="Open in browser"


### PR DESCRIPTION
## Summary
- The "Open in browser" (outbound link) button on the feedback success view called `openUrl(createdIssueUrl)` but never dismissed the modal, so the modal stayed in the foreground over the newly opened browser tab and focus never landed on the new tab.
- Now also call `onCancel()` after `openUrl(...)` so the modal closes and the user lands on the freshly opened issue tab (Maestro browser tab or system browser, per the global `useSystemBrowser` setting).

closes #892

## Test plan
- [ ] Submit a feedback issue end-to-end with the global setting set to "open URLs in Maestro browser tabs" and click the outbound-link icon on the success view — confirm the modal closes and the new browser tab is focused with the issue URL.
- [ ] Repeat with the global setting set to system browser — confirm the modal closes and the issue opens in the external browser.
- [ ] Confirm the existing copy-URL button still copies and does not close the modal.
- [ ] `npm run lint` and `npm run test -- FeedbackChatView` still pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The "Open in browser" button now closes the feedback dialog after opening the issue, providing a smoother user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->