### PR TITLE
feat: add auto-run folder support to CLI create-agent

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -178,29 +178,31 @@ maestro-cli create-agent "Full Config" -d /workspace \
 	--context-window 200000 \
 	--provider-path /custom/provider \
 	--ssh-remote <remote-id> \
-	--ssh-cwd /remote/workdir
+	--ssh-cwd /remote/workdir \
+	--auto-run-folder ~/playbooks/full-config
 
 # Remove an agent
 maestro-cli remove-agent <agent-id>
 ```
 
-| Flag                              | Description                                              | Default       |
-| --------------------------------- | -------------------------------------------------------- | ------------- |
-| `-d, --cwd <path>`                | Working directory for the agent (required)               | —             |
-| `-t, --type <type>`               | Agent type (claude-code, codex, opencode, factory-droid) | `claude-code` |
-| `-g, --group <id>`                | Group ID to assign the agent to                          | —             |
-| `--nudge <message>`               | Nudge message appended to every user message             | —             |
-| `--new-session-message <message>` | Message prefixed to first message in new sessions        | —             |
-| `--custom-path <path>`            | Custom binary path for the agent CLI                     | —             |
-| `--custom-args <args>`            | Custom CLI arguments                                     | —             |
-| `--env <KEY=VALUE>`               | Environment variable (repeatable)                        | —             |
-| `--model <model>`                 | Model override (e.g., sonnet, opus)                      | —             |
-| `--effort <level>`                | Effort/reasoning level override                          | —             |
-| `--context-window <size>`         | Context window size in tokens                            | —             |
-| `--provider-path <path>`          | Custom provider path                                     | —             |
-| `--ssh-remote <id>`               | SSH remote ID for remote execution                       | —             |
-| `--ssh-cwd <path>`                | Working directory override on the SSH remote             | —             |
-| `--json`                          | Machine-readable JSON output                             | —             |
+| Flag                              | Description                                              | Default                    |
+| --------------------------------- | -------------------------------------------------------- | -------------------------- |
+| `-d, --cwd <path>`                | Working directory for the agent (required)               | —                          |
+| `-t, --type <type>`               | Agent type (claude-code, codex, opencode, factory-droid) | `claude-code`              |
+| `-g, --group <id>`                | Group ID to assign the agent to                          | —                          |
+| `--nudge <message>`               | Nudge message appended to every user message             | —                          |
+| `--new-session-message <message>` | Message prefixed to first message in new sessions        | —                          |
+| `--custom-path <path>`            | Custom binary path for the agent CLI                     | —                          |
+| `--custom-args <args>`            | Custom CLI arguments                                     | —                          |
+| `--env <KEY=VALUE>`               | Environment variable (repeatable)                        | —                          |
+| `--model <model>`                 | Model override (e.g., sonnet, opus)                      | —                          |
+| `--effort <level>`                | Effort/reasoning level override                          | —                          |
+| `--context-window <size>`         | Context window size in tokens                            | —                          |
+| `--provider-path <path>`          | Custom provider path                                     | —                          |
+| `--ssh-remote <id>`               | SSH remote ID for remote execution                       | —                          |
+| `--ssh-cwd <path>`                | Working directory override on the SSH remote             | —                          |
+| `--auto-run-folder <path>`        | Auto Run / playbooks folder for this agent               | `<cwd>/.maestro/playbooks` |
+| `--json`                          | Machine-readable JSON output                             | —                          |
 
 ### Listing Resources
 

--- a/src/__tests__/cli/services/storage.test.ts
+++ b/src/__tests__/cli/services/storage.test.ts
@@ -90,6 +90,10 @@ describe('storage service', () => {
 		vi.clearAllMocks();
 		// Reset environment
 		process.env = { ...originalEnv };
+		// Strip MAESTRO_USER_DATA if set in the test runner's shell — getConfigDir()
+		// honors it as an override, so leaving it set would shadow the mocked
+		// homedir/platform paths these tests assert against.
+		delete process.env.MAESTRO_USER_DATA;
 		// Default to macOS
 		vi.mocked(os.platform).mockReturnValue('darwin');
 		vi.mocked(os.homedir).mockReturnValue('/Users/testuser');

--- a/src/__tests__/shared/cli-server-discovery.test.ts
+++ b/src/__tests__/shared/cli-server-discovery.test.ts
@@ -62,8 +62,15 @@ describe('cli-server-discovery', () => {
 		startedAt: 1700000000000,
 	};
 
+	let savedUserDataEnv: string | undefined;
+
 	beforeEach(() => {
 		vi.clearAllMocks();
+
+		// Ensure MAESTRO_USER_DATA from the test runner's environment doesn't
+		// leak into platform-default tests; individual tests opt in by setting it.
+		savedUserDataEnv = process.env.MAESTRO_USER_DATA;
+		delete process.env.MAESTRO_USER_DATA;
 
 		// Default mock implementations
 		mockOs.platform.mockReturnValue('darwin');
@@ -78,6 +85,11 @@ describe('cli-server-discovery', () => {
 
 	afterEach(() => {
 		vi.restoreAllMocks();
+		if (savedUserDataEnv === undefined) {
+			delete process.env.MAESTRO_USER_DATA;
+		} else {
+			process.env.MAESTRO_USER_DATA = savedUserDataEnv;
+		}
 	});
 
 	describe('getConfigDir (internal via path construction)', () => {
@@ -183,6 +195,50 @@ describe('cli-server-discovery', () => {
 					delete process.env.XDG_CONFIG_HOME;
 				} else {
 					process.env.XDG_CONFIG_HOME = originalXdg;
+				}
+			}
+		});
+
+		it('should honor MAESTRO_USER_DATA override over platform default', () => {
+			mockOs.platform.mockReturnValue('darwin');
+			mockOs.homedir.mockReturnValue('/Users/testuser');
+			const originalUserData = process.env.MAESTRO_USER_DATA;
+			process.env.MAESTRO_USER_DATA = '/Users/testuser/Library/Application Support/maestro-dev';
+
+			try {
+				readCliServerInfo();
+
+				expect(mockFs.readFileSync).toHaveBeenCalledWith(
+					path.join('/Users/testuser/Library/Application Support/maestro-dev', 'cli-server.json'),
+					'utf-8'
+				);
+			} finally {
+				if (originalUserData === undefined) {
+					delete process.env.MAESTRO_USER_DATA;
+				} else {
+					process.env.MAESTRO_USER_DATA = originalUserData;
+				}
+			}
+		});
+
+		it('should resolve relative MAESTRO_USER_DATA to absolute path', () => {
+			mockOs.platform.mockReturnValue('darwin');
+			mockOs.homedir.mockReturnValue('/Users/testuser');
+			const originalUserData = process.env.MAESTRO_USER_DATA;
+			process.env.MAESTRO_USER_DATA = './relative-data-dir';
+
+			try {
+				readCliServerInfo();
+
+				expect(mockFs.readFileSync).toHaveBeenCalledWith(
+					path.join(path.resolve('./relative-data-dir'), 'cli-server.json'),
+					'utf-8'
+				);
+			} finally {
+				if (originalUserData === undefined) {
+					delete process.env.MAESTRO_USER_DATA;
+				} else {
+					process.env.MAESTRO_USER_DATA = originalUserData;
 				}
 			}
 		});

--- a/src/cli/commands/create-agent.ts
+++ b/src/cli/commands/create-agent.ts
@@ -22,6 +22,7 @@ interface CreateAgentOptions {
 	providerPath?: string;
 	sshRemote?: string;
 	sshCwd?: string;
+	autoRunFolder?: string;
 	json?: boolean;
 }
 
@@ -104,6 +105,7 @@ export async function createAgent(name: string, options: CreateAgentOptions): Pr
 	if (customContextWindow !== undefined) payload.customContextWindow = customContextWindow;
 	if (options.providerPath) payload.customProviderPath = options.providerPath;
 	if (sessionSshRemoteConfig) payload.sessionSshRemoteConfig = sessionSshRemoteConfig;
+	if (options.autoRunFolder) payload.autoRunFolderPath = path.resolve(options.autoRunFolder);
 
 	try {
 		const result = await withMaestroClient(async (client) => {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -289,6 +289,10 @@ program
 	.option('--provider-path <path>', 'Custom provider path')
 	.option('--ssh-remote <id>', 'SSH remote ID for remote execution')
 	.option('--ssh-cwd <path>', 'Working directory override on SSH remote')
+	.option(
+		'--auto-run-folder <path>',
+		'Path to the agent Auto Run / playbooks folder (overrides the default <cwd>/.maestro/playbooks)'
+	)
 	.option('--json', 'Output as JSON (for scripting)')
 	.action(createAgent);
 

--- a/src/cli/services/storage.ts
+++ b/src/cli/services/storage.ts
@@ -18,6 +18,10 @@ import {
 
 // Get the Maestro config directory path
 function getConfigDir(): string {
+	// Allow overriding the data directory (e.g. for dev mode: maestro-dev)
+	if (process.env.MAESTRO_USER_DATA) {
+		return path.resolve(process.env.MAESTRO_USER_DATA);
+	}
 	const platform = os.platform();
 	const home = os.homedir();
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -168,6 +168,12 @@ if (isDevelopment && !DEMO_MODE && !process.env.USE_PROD_DATA) {
 	console.log(`[DEV MODE] Using production data directory: ${app.getPath('userData')}`);
 }
 
+// Publish the resolved userData path so shared/cli-server-discovery.ts (used by
+// both this main process and the maestro-cli) writes/reads the discovery file
+// in the same data directory the app actually uses. Without this, dev and prod
+// would clobber each other's cli-server.json at the hardcoded platform default.
+process.env.MAESTRO_USER_DATA = app.getPath('userData');
+
 // ============================================================================
 // Store Initialization (after userData path is configured)
 // ============================================================================

--- a/src/main/web-server/WebServer.ts
+++ b/src/main/web-server/WebServer.ts
@@ -89,6 +89,7 @@ import type {
 	DeleteGroupCallback,
 	MoveSessionToGroupCallback,
 	CreateSessionCallback,
+	CreateSessionConfig,
 	DeleteSessionCallback,
 	RenameSessionCallback,
 	GetGitStatusCallback,
@@ -781,8 +782,13 @@ export class WebServer {
 			deleteGroup: async (groupId: string) => this.callbackRegistry.deleteGroup(groupId),
 			moveSessionToGroup: async (sessionId: string, groupId: string | null) =>
 				this.callbackRegistry.moveSessionToGroup(sessionId, groupId),
-			createSession: async (name: string, toolType: string, cwd: string, groupId?: string) =>
-				this.callbackRegistry.createSession(name, toolType, cwd, groupId),
+			createSession: async (
+				name: string,
+				toolType: string,
+				cwd: string,
+				groupId?: string,
+				config?: CreateSessionConfig
+			) => this.callbackRegistry.createSession(name, toolType, cwd, groupId, config),
 			deleteSession: async (sessionId: string) => this.callbackRegistry.deleteSession(sessionId),
 			renameSession: async (sessionId: string, newName: string) =>
 				this.callbackRegistry.renameSession(sessionId, newName),

--- a/src/main/web-server/handlers/messageHandlers.ts
+++ b/src/main/web-server/handlers/messageHandlers.ts
@@ -2007,6 +2007,8 @@ export class WebSocketMessageHandler {
 			config.sessionSshRemoteConfig =
 				message.sessionSshRemoteConfig as CreateSessionConfig['sessionSshRemoteConfig'];
 		}
+		// autoRunFolderPath can be set outside of the agent's cwd (no confinement needed)
+		if (message.autoRunFolderPath) config.autoRunFolderPath = message.autoRunFolderPath as string;
 		const hasConfig = Object.keys(config).length > 0;
 
 		this.callbacks

--- a/src/main/web-server/types.ts
+++ b/src/main/web-server/types.ts
@@ -511,6 +511,7 @@ export interface CreateSessionConfig {
 		remoteId: string | null;
 		workingDirOverride?: string;
 	};
+	autoRunFolderPath?: string;
 }
 
 export type CreateSessionCallback = (

--- a/src/prompts/_maestro-cli.md
+++ b/src/prompts/_maestro-cli.md
@@ -181,7 +181,8 @@ Lifecycle management of Maestro agents and remote-execution targets.
 {{MAESTRO_CLI_PATH}} create-agent <name> --cwd <path> [-t, --type <agent-type>] [-g, --group <id>] \
     [--nudge <message>] [--new-session-message <message>] [--custom-path <path>] \
     [--custom-args <args>] [--env KEY=VALUE]... [--model <model>] [--effort <level>] \
-    [--context-window <size>] [--ssh-remote <id>] [--ssh-cwd <path>] [--json]
+    [--context-window <size>] [--ssh-remote <id>] [--ssh-cwd <path>] \
+    [--auto-run-folder <path>] [--json]
 {{MAESTRO_CLI_PATH}} remove-agent <agent-id> [--json]
 
 # SSH remotes (used by agents that execute on a remote host)

--- a/src/renderer/hooks/remote/useAppRemoteEventListeners.ts
+++ b/src/renderer/hooks/remote/useAppRemoteEventListeners.ts
@@ -21,6 +21,7 @@ import {
 } from '../../utils/terminalTabHelpers';
 import type { Session, AITab, ToolType, Group, BatchRunConfig, BrowserTab } from '../../types';
 import { logger } from '../../utils/logger';
+import { DEFAULT_BATCH_PROMPT } from '../batch/batchUtils';
 
 // ============================================================================
 // Dependencies interface
@@ -316,9 +317,15 @@ export function useAppRemoteEventListeners(deps: UseAppRemoteEventListenersDeps)
 							}
 						: undefined;
 
+				// CLI/web callers omit prompt → fall back to the default Auto Run prompt
+				// template (autorun-default.md), matching what BatchRunnerModal does for
+				// GUI launches. An empty string here propagates as undefined through
+				// useBatchProcessor → useDocumentProcessor → spawn, causing claude
+				// `--print` to exit 1 with "Input must be provided either through stdin
+				// or as a prompt argument".
 				const batchConfig: BatchRunConfig = {
 					documents,
-					prompt: config.prompt || '',
+					prompt: config.prompt || DEFAULT_BATCH_PROMPT,
 					loopEnabled: config.loopEnabled || false,
 					maxLoops: config.maxLoops,
 					...(worktree ? { worktree } : {}),

--- a/src/renderer/hooks/remote/useAppRemoteEventListeners.ts
+++ b/src/renderer/hooks/remote/useAppRemoteEventListeners.ts
@@ -555,6 +555,9 @@ export function useAppRemoteEventListeners(deps: UseAppRemoteEventListenersDeps)
 					sessionSshRemoteConfig:
 						config.sessionSshRemoteConfig as Session['sessionSshRemoteConfig'],
 				}),
+				...(config?.autoRunFolderPath && {
+					autoRunFolderPath: config.autoRunFolderPath as string,
+				}),
 			};
 
 			setSessions((prev: Session[]) => [...prev, newSession]);

--- a/src/shared/cli-server-discovery.ts
+++ b/src/shared/cli-server-discovery.ts
@@ -22,6 +22,13 @@ interface CliServerInfo {
 
 // Get the Maestro config directory path (lowercase "maestro")
 function getConfigDir(): string {
+	// Allow overriding the data directory (e.g. for dev mode: maestro-dev).
+	// Matches the override honored by src/cli/services/storage.ts so the CLI's
+	// discovery file lookup tracks the same data directory as its session reads.
+	if (process.env.MAESTRO_USER_DATA) {
+		return path.resolve(process.env.MAESTRO_USER_DATA);
+	}
+
 	const platform = os.platform();
 	const home = os.homedir();
 


### PR DESCRIPTION
# feat: add auto-run folder support to CLI create-agent

## Summary

This PR adds support for configuring an agent-specific Auto Run / playbooks folder from the CLI and fixes data-directory discovery so the CLI and Electron app consistently read/write files from the same Maestro user data directory.

The main functional changes are:

- Adds `--auto-run-folder <path>` to `maestro-cli create-agent`.
- Propagates `autoRunFolderPath` through CLI session creation, web server handling, and renderer session state.
- Introduces `MAESTRO_USER_DATA` as an override for CLI storage and CLI server discovery paths.
- Sets `MAESTRO_USER_DATA` from Electron’s resolved `app.getPath('userData')` so dev/prod data directories do not clobber each other.
- Updates docs, CLI prompt help, and tests.

## Files Changed

### `docs/cli.md`

Updated the `create-agent` documentation to include the new `--auto-run-folder` option.

The full config example now includes:

```sh
--auto-run-folder ~/playbooks/full-config
```

The options table now documents:

```md
| `--auto-run-folder <path>` | Auto Run / playbooks folder for this agent | `<cwd>/.maestro/playbooks` |
```

### `src/cli/index.ts`

Added a new CLI option to `create-agent`:

```ts
.option(
	'--auto-run-folder <path>',
	'Path to the agent Auto Run / playbooks folder (overrides the default <cwd>/.maestro/playbooks)'
)
```

This exposes the new agent configuration from the command line.

### `src/cli/commands/create-agent.ts`

Extended `CreateAgentOptions` with `autoRunFolder`:

```ts
autoRunFolder?: string;
```

When provided, the path is resolved to an absolute path and sent in the create-session payload:

```ts
if (options.autoRunFolder) payload.autoRunFolderPath = path.resolve(options.autoRunFolder);
```

### `src/main/web-server/types.ts`

Extended `CreateSessionConfig` to support an optional Auto Run folder path:

```ts
autoRunFolderPath?: string;
```

This allows the value to be passed through the existing session creation config pipeline.

### `src/main/web-server/WebServer.ts`

Updated the `createSession` callback wiring to accept and forward the optional session config:

```ts
createSession: async (
	name: string,
	toolType: string,
	cwd: string,
	groupId?: string,
	config?: CreateSessionConfig
) => this.callbackRegistry.createSession(name, toolType, cwd, groupId, config),
```

Previously, the web server callback only forwarded `name`, `toolType`, `cwd`, and `groupId`, which would have dropped additional session configuration.

### `src/main/web-server/handlers/messageHandlers.ts`

Added handling for `autoRunFolderPath` in create-agent/session messages:

```ts
if (message.autoRunFolderPath) config.autoRunFolderPath = message.autoRunFolderPath as string;
```

The comment explicitly notes that the Auto Run folder may live outside the agent cwd:

```ts
// autoRunFolderPath can be set outside of the agent's cwd (no confinement needed)
```

### `src/renderer/hooks/remote/useAppRemoteEventListeners.ts`

Updated remote session creation handling so `autoRunFolderPath` is preserved in renderer state:

```ts
...(config?.autoRunFolderPath && {
	autoRunFolderPath: config.autoRunFolderPath as string,
}),
```

### `src/main/index.ts`

Sets `MAESTRO_USER_DATA` to the Electron app’s resolved `userData` path:

```ts
process.env.MAESTRO_USER_DATA = app.getPath('userData');
```

This ensures shared CLI server discovery logic uses the same data directory that the app is actually using, including dev-mode paths such as `maestro-dev`.

### `src/cli/services/storage.ts`

Updated CLI storage path resolution to honor `MAESTRO_USER_DATA`:

```ts
if (process.env.MAESTRO_USER_DATA) {
	return path.resolve(process.env.MAESTRO_USER_DATA);
}
```

This allows CLI storage to be redirected to the same configured app data directory instead of always using platform defaults.

### `src/shared/cli-server-discovery.ts`

Updated CLI server discovery path resolution to also honor `MAESTRO_USER_DATA`:

```ts
if (process.env.MAESTRO_USER_DATA) {
	return path.resolve(process.env.MAESTRO_USER_DATA);
}
```

This keeps discovery file lookup aligned with CLI storage behavior.

### `src/__tests__/cli/services/storage.test.ts`

Updated test setup to delete any inherited `MAESTRO_USER_DATA` value before each test:

```ts
delete process.env.MAESTRO_USER_DATA;
```

This prevents a shell-level environment variable from shadowing mocked platform and homedir values.

### `src/__tests__/shared/cli-server-discovery.test.ts`

Added environment isolation around `MAESTRO_USER_DATA` and added tests verifying that:

- `MAESTRO_USER_DATA` overrides the platform-default config path.
- Relative `MAESTRO_USER_DATA` values are resolved to absolute paths.

Example assertion:

```ts
expect(mockFs.readFileSync).toHaveBeenCalledWith(
	path.join(path.resolve('./relative-data-dir'), 'cli-server.json'),
	'utf-8'
);
```

### `src/prompts/_maestro-cli.md`

Updated the embedded Maestro CLI usage prompt to include the new option:

```md
[--auto-run-folder <path>] [--json]
```

## Code Changes

### New `--auto-run-folder` CLI option

The CLI now accepts an optional Auto Run / playbooks folder when creating an agent:

```ts
.option(
	'--auto-run-folder <path>',
	'Path to the agent Auto Run / playbooks folder (overrides the default <cwd>/.maestro/playbooks)'
)
```

The value is normalized to an absolute path before being sent to the app:

```ts
if (options.autoRunFolder) payload.autoRunFolderPath = path.resolve(options.autoRunFolder);
```

### Auto Run folder propagation through session creation

The session config type now includes:

```ts
autoRunFolderPath?: string;
```

The web server message handler reads it from incoming messages:

```ts
if (message.autoRunFolderPath) config.autoRunFolderPath = message.autoRunFolderPath as string;
```

The renderer stores it on newly-created sessions:

```ts
...(config?.autoRunFolderPath && {
	autoRunFolderPath: config.autoRunFolderPath as string,
}),
```

### User data directory override via `MAESTRO_USER_DATA`

Both CLI storage and CLI server discovery now support a shared data directory override:

```ts
if (process.env.MAESTRO_USER_DATA) {
	return path.resolve(process.env.MAESTRO_USER_DATA);
}
```

The Electron main process publishes its resolved user data path to that variable:

```ts
process.env.MAESTRO_USER_DATA = app.getPath('userData');
```

This ensures that shared code writes files such as `cli-server.json` into the same directory the app is configured to use.

## Reason for Changes

### Agent-specific Auto Run folder support

Before this change, agents created through the CLI used the default Auto Run / playbooks folder derived from the agent cwd. This made it difficult to point an agent at a shared or external playbooks directory.

The new `--auto-run-folder` flag allows callers to explicitly configure the playbooks folder during agent creation.

### Consistent dev/prod CLI server discovery

The shared CLI server discovery logic previously used hardcoded platform defaults. In development mode, the Electron app may use a different user data path such as `maestro-dev`, while the CLI discovery code would still look at the default production-like directory.

That could cause dev and prod sessions to clobber each other’s `cli-server.json`, or cause the CLI to fail to discover the running app server.

By setting and honoring `MAESTRO_USER_DATA`, the app and CLI now agree on the active data directory.

## Impact of Changes

- CLI-created agents can now use custom Auto Run / playbooks directories.
- Relative `--auto-run-folder` values are resolved to absolute paths by the CLI before being sent to the app.
- Dev and prod data directories are better isolated.
- CLI server discovery should be more reliable when the app uses a non-default `userData` path.
- Tests are more robust in environments where `MAESTRO_USER_DATA` is set externally.

## Test Plan

The following areas should be tested:

1. **Create an agent with a custom Auto Run folder**

   ```sh
   maestro-cli create-agent "Playbook Agent" \
     --cwd /tmp/project \
     --auto-run-folder ~/playbooks/project
   ```

   Verify that the created session has the expected `autoRunFolderPath`.

2. **Create an agent without `--auto-run-folder`**

   ```sh
   maestro-cli create-agent "Default Agent" --cwd /tmp/project
   ```

   Verify that the default playbooks folder behavior remains unchanged.

3. **Relative Auto Run folder path**

   ```sh
   maestro-cli create-agent "Relative Playbooks" \
     --cwd /tmp/project \
     --auto-run-folder ./playbooks
   ```

   Verify that the path is stored as an absolute path.

4. **Development mode CLI discovery**

   Start the app in development mode and verify that `cli-server.json` is written under the app’s resolved dev `userData` directory instead of the production/default directory.

5. **Environment override**

   Run CLI operations with `MAESTRO_USER_DATA` explicitly set and confirm storage and server discovery use that path.

6. **Automated tests**

   Run the affected test suites:

   ```sh
   npm test -- storage.test.ts
   npm test -- cli-server-discovery.test.ts
   ```

## Additional Notes

- `autoRunFolderPath` is intentionally not confined to the agent cwd. This allows shared playbook directories and external automation folders.
- `MAESTRO_USER_DATA` is resolved with `path.resolve`, so relative overrides become absolute paths.
- Test setup now clears inherited `MAESTRO_USER_DATA` values to avoid nondeterministic behavior in CI or local shells.
- Potential issue to monitor: because `autoRunFolderPath` can point outside the agent cwd, any code that reads from or writes to that folder should continue to treat it as user-controlled input and avoid unsafe assumptions about path locality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New --auto-run-folder option for creating agents; sessions and launches can use a custom playbook folder.
  * App startup now exposes a unified user-data path so CLI and app share the same config/storage location.

* **Behavior Changes**
  * Remote batch launches use a default batch prompt when none provided.
  
* **Documentation**
  * CLI docs updated to document the new option.

* **Tests**
  * Added/updated tests for env-based config directory and auto-run behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->