### PR TITLE
Drag and drop improvements

### DIFF
--- a/src/__tests__/renderer/hooks/useInputHandlers.test.ts
+++ b/src/__tests__/renderer/hooks/useInputHandlers.test.ts
@@ -180,7 +180,7 @@ function createMockDeps(overrides: Partial<UseInputHandlersDeps> = {}): UseInput
 		terminalOutputRef: { current: { focus: vi.fn() } } as any,
 		fileTreeKeyboardNavRef: { current: false },
 		dragCounterRef: { current: 0 },
-		setIsDraggingImage: vi.fn(),
+		setIsDraggingFile: vi.fn(),
 		getBatchState: vi.fn().mockReturnValue(createDefaultBatchState()),
 		activeBatchRunState: createDefaultBatchState(),
 		processQueuedItemRef: { current: null },
@@ -967,7 +967,7 @@ describe('useInputHandlers', () => {
 			});
 
 			expect(deps.dragCounterRef.current).toBe(0);
-			expect(deps.setIsDraggingImage).toHaveBeenCalledWith(false);
+			expect(deps.setIsDraggingFile).toHaveBeenCalledWith(false);
 		});
 
 		it('ignores drops in terminal mode', () => {

--- a/src/__tests__/renderer/hooks/useInputHandlers.test.ts
+++ b/src/__tests__/renderer/hooks/useInputHandlers.test.ts
@@ -957,6 +957,7 @@ describe('useInputHandlers', () => {
 			const dropEvent = {
 				preventDefault: vi.fn(),
 				dataTransfer: {
+					getData: () => '',
 					files: { length: 0 } as any,
 				},
 			} as unknown as React.DragEvent;
@@ -981,6 +982,7 @@ describe('useInputHandlers', () => {
 			const dropEvent = {
 				preventDefault: vi.fn(),
 				dataTransfer: {
+					getData: () => '',
 					files: {
 						length: 1,
 						0: { type: 'image/png' },
@@ -1013,6 +1015,7 @@ describe('useInputHandlers', () => {
 			const dropEvent = {
 				preventDefault: vi.fn(),
 				dataTransfer: {
+					getData: () => '',
 					files: {
 						length: 1,
 						0: mockFile,
@@ -1542,6 +1545,7 @@ describe('useInputHandlers', () => {
 			const dropEvent = {
 				preventDefault: vi.fn(),
 				dataTransfer: {
+					getData: () => '',
 					files: {
 						length: 2,
 						0: { type: 'application/pdf', name: 'doc.pdf' },
@@ -1587,6 +1591,7 @@ describe('useInputHandlers', () => {
 				const dropEvent = {
 					preventDefault: vi.fn(),
 					dataTransfer: {
+						getData: () => '',
 						files: {
 							length: 2,
 							0: { type: 'image/png', name: 'img1.png' },
@@ -1608,6 +1613,75 @@ describe('useInputHandlers', () => {
 			} finally {
 				global.FileReader = originalFileReader;
 			}
+		});
+
+		it('inserts @<path> into AI input when dropping an internal Files-panel drag', () => {
+			const deps = createMockDeps();
+			const { result } = renderHook(() => useInputHandlers(deps));
+
+			const dropEvent = {
+				preventDefault: vi.fn(),
+				dataTransfer: {
+					getData: (type: string) =>
+						type === 'application/x-maestro-file-path' ? 'src/main/index.ts' : '',
+					files: { length: 0 } as any,
+				},
+			} as unknown as React.DragEvent;
+
+			act(() => {
+				result.current.handleDrop(dropEvent);
+			});
+
+			expect(result.current.inputValue).toBe('@src/main/index.ts ');
+		});
+
+		it('appends @<path> with a separating space when input already has content', () => {
+			const deps = createMockDeps();
+			const { result } = renderHook(() => useInputHandlers(deps));
+
+			act(() => {
+				result.current.setInputValue('look at');
+			});
+
+			const dropEvent = {
+				preventDefault: vi.fn(),
+				dataTransfer: {
+					getData: (type: string) =>
+						type === 'application/x-maestro-file-path' ? 'README.md' : '',
+					files: { length: 0 } as any,
+				},
+			} as unknown as React.DragEvent;
+
+			act(() => {
+				result.current.handleDrop(dropEvent);
+			});
+
+			expect(result.current.inputValue).toBe('look at @README.md ');
+		});
+
+		it('ignores internal Files-panel drag when group chat is active', () => {
+			useGroupChatStore.setState({
+				activeGroupChatId: 'group-1',
+				setGroupChatStagedImages: vi.fn(),
+			} as any);
+
+			const deps = createMockDeps();
+			const { result } = renderHook(() => useInputHandlers(deps));
+
+			const dropEvent = {
+				preventDefault: vi.fn(),
+				dataTransfer: {
+					getData: (type: string) =>
+						type === 'application/x-maestro-file-path' ? 'src/main/index.ts' : '',
+					files: { length: 0 } as any,
+				},
+			} as unknown as React.DragEvent;
+
+			act(() => {
+				result.current.handleDrop(dropEvent);
+			});
+
+			expect(result.current.inputValue).toBe('');
 		});
 	});
 

--- a/src/__tests__/renderer/hooks/useInputHandlers.test.ts
+++ b/src/__tests__/renderer/hooks/useInputHandlers.test.ts
@@ -1683,6 +1683,253 @@ describe('useInputHandlers', () => {
 
 			expect(result.current.inputValue).toBe('');
 		});
+
+		it('inserts @<relative-path> when an external file inside the project is dropped in AI mode', () => {
+			const deps = createMockDeps();
+			const { result } = renderHook(() => useInputHandlers(deps));
+
+			const dropEvent = {
+				preventDefault: vi.fn(),
+				dataTransfer: {
+					getData: () => '',
+					files: {
+						length: 1,
+						0: { type: 'text/plain', name: 'README.md', path: '/test/docs/README.md' },
+					} as any,
+				},
+			} as unknown as React.DragEvent;
+
+			act(() => {
+				result.current.handleDrop(dropEvent);
+			});
+
+			expect(result.current.inputValue).toBe('@docs/README.md ');
+		});
+
+		it('inserts an absolute @<path> when an external file outside the project is dropped', () => {
+			const deps = createMockDeps();
+			const { result } = renderHook(() => useInputHandlers(deps));
+
+			const dropEvent = {
+				preventDefault: vi.fn(),
+				dataTransfer: {
+					getData: () => '',
+					files: {
+						length: 1,
+						0: { type: '', name: 'notes', path: '/Users/somebody/notes' },
+					} as any,
+				},
+			} as unknown as React.DragEvent;
+
+			act(() => {
+				result.current.handleDrop(dropEvent);
+			});
+
+			expect(result.current.inputValue).toBe('@/Users/somebody/notes ');
+		});
+
+		it('joins multiple external file drops with spaces', () => {
+			const deps = createMockDeps();
+			const { result } = renderHook(() => useInputHandlers(deps));
+
+			const dropEvent = {
+				preventDefault: vi.fn(),
+				dataTransfer: {
+					getData: () => '',
+					files: {
+						length: 2,
+						0: { type: 'text/plain', name: 'a.ts', path: '/test/src/a.ts' },
+						1: { type: '', name: 'docs', path: '/test/docs' },
+					} as any,
+				},
+			} as unknown as React.DragEvent;
+
+			act(() => {
+				result.current.handleDrop(dropEvent);
+			});
+
+			expect(result.current.inputValue).toBe('@src/a.ts @docs ');
+		});
+
+		it('updates group chat draftMessage when external files are dropped during group chat', () => {
+			const initialChat = {
+				id: 'group-1',
+				name: 'g',
+				draftMessage: '',
+				participants: [],
+				messages: [],
+			};
+			const setGroupChats = vi.fn((updater: any) => {
+				const next = typeof updater === 'function' ? updater([initialChat as any]) : updater;
+				useGroupChatStore.setState({ groupChats: next } as any);
+			});
+			useGroupChatStore.setState({
+				activeGroupChatId: 'group-1',
+				groupChats: [initialChat as any],
+				setGroupChats,
+				setGroupChatStagedImages: vi.fn(),
+			} as any);
+
+			const deps = createMockDeps();
+			const { result } = renderHook(() => useInputHandlers(deps));
+
+			const dropEvent = {
+				preventDefault: vi.fn(),
+				dataTransfer: {
+					getData: () => '',
+					files: {
+						length: 1,
+						0: { type: 'text/plain', name: 'a.ts', path: '/test/src/a.ts' },
+					} as any,
+				},
+			} as unknown as React.DragEvent;
+
+			act(() => {
+				result.current.handleDrop(dropEvent);
+			});
+
+			expect(setGroupChats).toHaveBeenCalled();
+			const updated = useGroupChatStore.getState().groupChats[0];
+			expect(updated.draftMessage).toBe('@src/a.ts ');
+		});
+
+		it('appends to existing group chat draft with a separating space', () => {
+			const initialChat = {
+				id: 'group-1',
+				name: 'g',
+				draftMessage: 'check',
+				participants: [],
+				messages: [],
+			};
+			const setGroupChats = vi.fn((updater: any) => {
+				const next =
+					typeof updater === 'function'
+						? updater(useGroupChatStore.getState().groupChats)
+						: updater;
+				useGroupChatStore.setState({ groupChats: next } as any);
+			});
+			useGroupChatStore.setState({
+				activeGroupChatId: 'group-1',
+				groupChats: [initialChat as any],
+				setGroupChats,
+				setGroupChatStagedImages: vi.fn(),
+			} as any);
+
+			const deps = createMockDeps();
+			const { result } = renderHook(() => useInputHandlers(deps));
+
+			const dropEvent = {
+				preventDefault: vi.fn(),
+				dataTransfer: {
+					getData: () => '',
+					files: {
+						length: 1,
+						0: { type: 'text/plain', name: 'README.md', path: '/test/README.md' },
+					} as any,
+				},
+			} as unknown as React.DragEvent;
+
+			act(() => {
+				result.current.handleDrop(dropEvent);
+			});
+
+			const updated = useGroupChatStore.getState().groupChats[0];
+			expect(updated.draftMessage).toBe('check @README.md ');
+		});
+
+		it('ignores files without a path (browser-only drops have no fs path)', () => {
+			const deps = createMockDeps();
+			const { result } = renderHook(() => useInputHandlers(deps));
+
+			const dropEvent = {
+				preventDefault: vi.fn(),
+				dataTransfer: {
+					getData: () => '',
+					files: {
+						length: 1,
+						0: { type: 'text/plain', name: 'pasted.txt' },
+					} as any,
+				},
+			} as unknown as React.DragEvent;
+
+			act(() => {
+				result.current.handleDrop(dropEvent);
+			});
+
+			expect(result.current.inputValue).toBe('');
+		});
+
+		it('relativizes a Windows-style backslash path inside a Windows-style project root', () => {
+			useSessionStore.setState({
+				sessions: [
+					createMockSession({
+						projectRoot: 'C:\\Users\\Alice\\proj',
+						fullPath: 'C:\\Users\\Alice\\proj',
+					}),
+				],
+				activeSessionId: 'session-1',
+			} as any);
+			const deps = createMockDeps();
+			const { result } = renderHook(() => useInputHandlers(deps));
+
+			const dropEvent = {
+				preventDefault: vi.fn(),
+				dataTransfer: {
+					getData: () => '',
+					files: {
+						length: 1,
+						0: {
+							type: 'text/plain',
+							name: 'index.ts',
+							path: 'C:\\Users\\Alice\\proj\\src\\index.ts',
+						},
+					} as any,
+				},
+			} as unknown as React.DragEvent;
+
+			act(() => {
+				result.current.handleDrop(dropEvent);
+			});
+
+			expect(result.current.inputValue).toBe('@src/index.ts ');
+		});
+
+		it('falls back to the absolute (forward-slash) path when Windows casing does not match', () => {
+			useSessionStore.setState({
+				sessions: [
+					createMockSession({
+						projectRoot: 'C:\\Users\\Alice\\proj',
+						fullPath: 'C:\\Users\\Alice\\proj',
+					}),
+				],
+				activeSessionId: 'session-1',
+			} as any);
+			const deps = createMockDeps();
+			const { result } = renderHook(() => useInputHandlers(deps));
+
+			const dropEvent = {
+				preventDefault: vi.fn(),
+				dataTransfer: {
+					getData: () => '',
+					files: {
+						length: 1,
+						0: {
+							type: 'text/plain',
+							name: 'index.ts',
+							path: 'c:\\users\\alice\\proj\\src\\index.ts',
+						},
+					} as any,
+				},
+			} as unknown as React.DragEvent;
+
+			act(() => {
+				result.current.handleDrop(dropEvent);
+			});
+
+			// Casing differs from projectRoot — relative match must NOT fire.
+			// The path is still emitted, just absolute, slash-normalised.
+			expect(result.current.inputValue).toBe('@c:/users/alice/proj/src/index.ts ');
+		});
 	});
 
 	// ========================================================================

--- a/src/__tests__/renderer/hooks/useInputHandlers.test.ts
+++ b/src/__tests__/renderer/hooks/useInputHandlers.test.ts
@@ -1859,6 +1859,84 @@ describe('useInputHandlers', () => {
 			expect(result.current.inputValue).toBe('');
 		});
 
+		it('stages an image when an image path is dragged from the Files panel', async () => {
+			const dataUrl = 'data:image/png;base64,FAKEPNG';
+			vi.mocked(window.maestro.fs.readFile).mockResolvedValueOnce(dataUrl);
+
+			const deps = createMockDeps();
+			const { result } = renderHook(() => useInputHandlers(deps));
+
+			const dropEvent = {
+				preventDefault: vi.fn(),
+				dataTransfer: {
+					getData: (type: string) =>
+						type === 'application/x-maestro-file-path' ? 'assets/logo.png' : '',
+					files: { length: 0 } as any,
+				},
+			} as unknown as React.DragEvent;
+
+			await act(async () => {
+				result.current.handleDrop(dropEvent);
+				await Promise.resolve();
+				await Promise.resolve();
+			});
+
+			expect(window.maestro.fs.readFile).toHaveBeenCalledWith('/test/assets/logo.png', undefined);
+			const sessions = useSessionStore.getState().sessions;
+			const tab = sessions[0].aiTabs.find((t: any) => t.id === 'tab-1');
+			expect(tab?.stagedImages).toEqual([dataUrl]);
+			// Image staging path must NOT also insert an @-mention.
+			expect(result.current.inputValue).toBe('');
+		});
+
+		it('does not stage anything when the IPC returns a non-data-url string for an image path', async () => {
+			vi.mocked(window.maestro.fs.readFile).mockResolvedValueOnce('not a data url');
+
+			const deps = createMockDeps();
+			const { result } = renderHook(() => useInputHandlers(deps));
+
+			const dropEvent = {
+				preventDefault: vi.fn(),
+				dataTransfer: {
+					getData: (type: string) =>
+						type === 'application/x-maestro-file-path' ? 'assets/logo.png' : '',
+					files: { length: 0 } as any,
+				},
+			} as unknown as React.DragEvent;
+
+			await act(async () => {
+				result.current.handleDrop(dropEvent);
+				await Promise.resolve();
+				await Promise.resolve();
+			});
+
+			const sessions = useSessionStore.getState().sessions;
+			const tab = sessions[0].aiTabs.find((t: any) => t.id === 'tab-1');
+			expect(tab?.stagedImages ?? []).toEqual([]);
+			expect(result.current.inputValue).toBe('');
+		});
+
+		it('still inserts @<path> for non-image extensions dragged from the Files panel', () => {
+			const deps = createMockDeps();
+			const { result } = renderHook(() => useInputHandlers(deps));
+
+			const dropEvent = {
+				preventDefault: vi.fn(),
+				dataTransfer: {
+					getData: (type: string) =>
+						type === 'application/x-maestro-file-path' ? 'src/util.ts' : '',
+					files: { length: 0 } as any,
+				},
+			} as unknown as React.DragEvent;
+
+			act(() => {
+				result.current.handleDrop(dropEvent);
+			});
+
+			expect(result.current.inputValue).toBe('@src/util.ts ');
+			expect(window.maestro.fs.readFile).not.toHaveBeenCalled();
+		});
+
 		it('relativizes a Windows-style backslash path inside a Windows-style project root', () => {
 			useSessionStore.setState({
 				sessions: [

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -2566,14 +2566,14 @@ function MaestroConsoleInner() {
 				onDragOver={handleImageDragOver}
 				onDrop={handleDrop}
 			>
-				{/* Image Drop Overlay */}
+				{/* External File Drop Overlay */}
 				{isDraggingImage && (
 					<div
 						className="fixed inset-0 z-[9999] pointer-events-none flex items-center justify-center"
 						style={{ backgroundColor: `${theme.colors.accent}20` }}
 					>
 						<div
-							className="pointer-events-none rounded-xl border-2 border-dashed p-8 flex flex-col items-center gap-4"
+							className="pointer-events-none rounded-xl border-2 border-dashed p-8 flex flex-col items-center gap-3"
 							style={{
 								borderColor: theme.colors.accent,
 								backgroundColor: `${theme.colors.bgMain}ee`,
@@ -2595,6 +2595,9 @@ function MaestroConsoleInner() {
 							</svg>
 							<span className="text-lg font-medium" style={{ color: theme.colors.textMain }}>
 								Drop image to attach
+							</span>
+							<span className="text-sm" style={{ color: theme.colors.textDim }}>
+								or drop a file or folder to insert as @reference
 							</span>
 						</div>
 					</div>

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -979,11 +979,11 @@ function MaestroConsoleInner() {
 
 	// --- APP HANDLERS (drag, file, folder operations) ---
 	const {
-		handleImageDragEnter,
-		handleImageDragLeave,
-		handleImageDragOver,
-		isDraggingImage,
-		setIsDraggingImage,
+		handleFileDragEnter,
+		handleFileDragLeave,
+		handleFileDragOver,
+		isDraggingFile,
+		setIsDraggingFile,
 		dragCounterRef,
 		handleFileClick,
 		updateSessionWorkingDirectory,
@@ -1437,7 +1437,7 @@ function MaestroConsoleInner() {
 		terminalOutputRef,
 		fileTreeKeyboardNavRef,
 		dragCounterRef,
-		setIsDraggingImage,
+		setIsDraggingFile,
 		getBatchState,
 		activeBatchRunState,
 		processQueuedItemRef,
@@ -2561,16 +2561,23 @@ function MaestroConsoleInner() {
 					fontFamily: fontFamily,
 					fontSize: `${fontSize}px`,
 				}}
-				onDragEnter={handleImageDragEnter}
-				onDragLeave={handleImageDragLeave}
-				onDragOver={handleImageDragOver}
+				onDragEnter={handleFileDragEnter}
+				onDragLeave={handleFileDragLeave}
+				onDragOver={handleFileDragOver}
 				onDrop={handleDrop}
 			>
 				{/* External File Drop Overlay */}
-				{isDraggingImage && (
+				{isDraggingFile && (
 					<div
-						className="fixed inset-0 z-[9999] pointer-events-none flex items-center justify-center"
+						className="fixed inset-0 z-[9999] flex items-center justify-center cursor-pointer"
 						style={{ backgroundColor: `${theme.colors.accent}20` }}
+						onClick={() => {
+							// Escape hatch: if the overlay ever gets stuck (drag canceled in
+							// a way that didn't fire dragend or dragleave), clicking it
+							// resets the drag state.
+							dragCounterRef.current = 0;
+							setIsDraggingFile(false);
+						}}
 					>
 						<div
 							className="pointer-events-none rounded-xl border-2 border-dashed p-8 flex flex-col items-center gap-3"
@@ -2594,10 +2601,10 @@ function MaestroConsoleInner() {
 								/>
 							</svg>
 							<span className="text-lg font-medium" style={{ color: theme.colors.textMain }}>
-								Drop image to attach
+								Drop file or folder
 							</span>
 							<span className="text-sm" style={{ color: theme.colors.textDim }}>
-								or drop a file or folder to insert as @reference
+								Images attach as thumbnails. Anything else becomes an @reference.
 							</span>
 						</div>
 					</div>

--- a/src/renderer/components/FileExplorerPanel.tsx
+++ b/src/renderer/components/FileExplorerPanel.tsx
@@ -1095,6 +1095,11 @@ function FileExplorerPanelInner(props: FileExplorerPanelProps) {
 								? 'rgba(255,255,255,0.1)'
 								: undefined,
 					}}
+					draggable
+					onDragStart={(e) => {
+						e.dataTransfer.setData('application/x-maestro-file-path', fullPath);
+						e.dataTransfer.effectAllowed = 'copy';
+					}}
 					onMouseDown={(e) => {
 						// Prevent focus from leaving the filter input when filtering
 						if (fileTreeFilter.length > 0) {

--- a/src/renderer/components/FileExplorerPanel.tsx
+++ b/src/renderer/components/FileExplorerPanel.tsx
@@ -1193,8 +1193,24 @@ function FileExplorerPanelInner(props: FileExplorerPanelProps) {
 		]
 	);
 
+	// Swallow drag-enter/leave that propagate to the app-level overlay handler
+	// while a Files-panel drag is moving WITHIN the panel itself. Otherwise the
+	// drop overlay flashes on every row-to-row transition because each child
+	// element fires dragenter/dragleave that bumps the app-level counter.
+	// External (OS) file drags still bubble normally so the overlay shows when
+	// the cursor is over the file panel during a Finder/Explorer drag.
+	const handleInternalDragBubble = (e: React.DragEvent) => {
+		if (e.dataTransfer.types.includes('application/x-maestro-file-path')) {
+			e.stopPropagation();
+		}
+	};
+
 	return (
-		<div className="flex flex-col h-full relative">
+		<div
+			className="flex flex-col h-full relative"
+			onDragEnter={handleInternalDragBubble}
+			onDragLeave={handleInternalDragBubble}
+		>
 			{/* File Tree Filter */}
 			{fileTreeFilterOpen && (
 				<div className="mb-3 pt-4">

--- a/src/renderer/hooks/input/useInputHandlers.ts
+++ b/src/renderer/hooks/input/useInputHandlers.ts
@@ -564,6 +564,21 @@ export function useInputHandlers(deps: UseInputHandlersDeps): UseInputHandlersRe
 			const isGroupChatActive = !!activeGroupChatId;
 			const isDirectAIMode = activeSession && activeSession.inputMode === 'ai';
 
+			// Internal drag from the Files panel — insert as @<path> in the AI input.
+			// Phase 1: AI mode only; group chat is excluded.
+			const internalPath = e.dataTransfer.getData('application/x-maestro-file-path');
+			if (internalPath) {
+				if (isGroupChatActive || !isDirectAIMode) return;
+				const mention = `@${internalPath}`;
+				setInputValue((prev) => {
+					if (!prev) return mention + ' ';
+					const needsSpace = !/\s$/.test(prev);
+					return prev + (needsSpace ? ' ' : '') + mention + ' ';
+				});
+				inputRef.current?.focus();
+				return;
+			}
+
 			if (!isGroupChatActive && !isDirectAIMode) return;
 
 			const files = e.dataTransfer.files;

--- a/src/renderer/hooks/input/useInputHandlers.ts
+++ b/src/renderer/hooks/input/useInputHandlers.ts
@@ -67,7 +67,7 @@ export interface UseInputHandlersDeps {
 	/** Drag counter ref for image drop handling */
 	dragCounterRef: React.MutableRefObject<number>;
 	/** Set dragging image state */
-	setIsDraggingImage: (value: boolean) => void;
+	setIsDraggingFile: (value: boolean) => void;
 
 	// From useBatchHandlers
 	/** Get batch state for a specific session */
@@ -162,7 +162,7 @@ export function useInputHandlers(deps: UseInputHandlersDeps): UseInputHandlersRe
 		terminalOutputRef,
 		fileTreeKeyboardNavRef,
 		dragCounterRef,
-		setIsDraggingImage,
+		setIsDraggingFile,
 		getBatchState,
 		activeBatchRunState,
 		processQueuedItemRef,
@@ -611,7 +611,7 @@ export function useInputHandlers(deps: UseInputHandlersDeps): UseInputHandlersRe
 		(e: React.DragEvent) => {
 			e.preventDefault();
 			dragCounterRef.current = 0;
-			setIsDraggingImage(false);
+			setIsDraggingFile(false);
 
 			const isGroupChatActive = !!activeGroupChatId;
 			const isDirectAIMode = activeSession && activeSession.inputMode === 'ai';
@@ -624,24 +624,34 @@ export function useInputHandlers(deps: UseInputHandlersDeps): UseInputHandlersRe
 				if (isGroupChatActive || !isDirectAIMode) return;
 
 				if (isImagePath(internalPath)) {
-					const treeRoot = activeSession?.projectRoot ?? activeSession?.fullPath;
+					// `internalPath` is built by FileExplorerPanel relative to
+					// `session.fullPath` (see TreeRow's `${session.fullPath}/${fullPath}`),
+					// so resolve against fullPath first to stay consistent with the
+					// explorer's own absolute-path construction.
+					const treeRoot = activeSession?.fullPath ?? activeSession?.projectRoot;
 					if (!treeRoot) return;
 					const absolutePath = `${treeRoot}/${internalPath}`;
 					const sshRemoteId =
 						activeSession?.sshRemoteId ??
 						activeSession?.sessionSshRemoteConfig?.remoteId ??
 						undefined;
-					void window.maestro.fs.readFile(absolutePath, sshRemoteId).then((content) => {
-						if (typeof content !== 'string' || !content.startsWith('data:image/')) return;
-						setStagedImages((prev) => {
-							if (prev.includes(content)) {
-								setSuccessFlashNotification('Duplicate image ignored');
-								setTimeout(() => setSuccessFlashNotification(null), 2000);
-								return prev;
-							}
-							return [...prev, content];
+					void window.maestro.fs
+						.readFile(absolutePath, sshRemoteId)
+						.then((content) => {
+							if (typeof content !== 'string' || !content.startsWith('data:image/')) return;
+							setStagedImages((prev) => {
+								if (prev.includes(content)) {
+									setSuccessFlashNotification('Duplicate image ignored');
+									setTimeout(() => setSuccessFlashNotification(null), 2000);
+									return prev;
+								}
+								return [...prev, content];
+							});
+						})
+						.catch(() => {
+							setSuccessFlashNotification('Could not read image file');
+							setTimeout(() => setSuccessFlashNotification(null), 2000);
 						});
-					});
 					return;
 				}
 

--- a/src/renderer/hooks/input/useInputHandlers.ts
+++ b/src/renderer/hooks/input/useInputHandlers.ts
@@ -657,7 +657,7 @@ export function useInputHandlers(deps: UseInputHandlersDeps): UseInputHandlersRe
 					};
 					reader.readAsDataURL(file);
 				} else {
-					// Phase 2: external non-image file or folder — collect path for @-mention.
+					// External non-image file or folder — collect path for @-mention.
 					const filePath = (file as File & { path?: string }).path;
 					if (filePath) {
 						externalPaths.push(toMentionPath(filePath, projectRoot));

--- a/src/renderer/hooks/input/useInputHandlers.ts
+++ b/src/renderer/hooks/input/useInputHandlers.ts
@@ -30,6 +30,23 @@ import { useAtMentionCompletion, type AtMentionSuggestion } from './useAtMention
 import { useInputProcessing } from './useInputProcessing';
 import { useInputKeyDown } from './useInputKeyDown';
 
+/**
+ * Convert an absolute filesystem path into the form used inside an `@` mention:
+ * if it sits inside `projectRoot`, return the relative path; otherwise return
+ * the absolute path unchanged. Forward-slash normalised so Windows drops still
+ * produce a clean mention.
+ */
+function toMentionPath(absolutePath: string, projectRoot?: string): string {
+	const norm = absolutePath.replace(/\\/g, '/');
+	if (!projectRoot) return norm;
+	const root = projectRoot.replace(/\\/g, '/').replace(/\/+$/, '');
+	if (norm === root) return '.';
+	if (norm.startsWith(root + '/')) {
+		return norm.slice(root.length + 1);
+	}
+	return norm;
+}
+
 // ============================================================================
 // Dependencies interface
 // ============================================================================
@@ -555,6 +572,35 @@ export function useInputHandlers(deps: UseInputHandlersDeps): UseInputHandlersRe
 		[activeGroupChatId, activeSession, setInputValue, setStagedImages]
 	);
 
+	const appendMentionsToAiInput = useCallback(
+		(paths: string[]) => {
+			if (paths.length === 0) return;
+			const joined = paths.map((p) => `@${p}`).join(' ');
+			setInputValue((prev) => {
+				if (!prev) return joined + ' ';
+				const sep = /\s$/.test(prev) ? '' : ' ';
+				return prev + sep + joined + ' ';
+			});
+		},
+		[setInputValue]
+	);
+
+	const appendMentionsToGroupChatDraft = useCallback((paths: string[]) => {
+		if (paths.length === 0) return;
+		const joined = paths.map((p) => `@${p}`).join(' ');
+		const { activeGroupChatId: chatId, setGroupChats } = useGroupChatStore.getState();
+		if (!chatId) return;
+		setGroupChats((prev) =>
+			prev.map((c) => {
+				if (c.id !== chatId) return c;
+				const current = c.draftMessage ?? '';
+				const sep = current && !/\s$/.test(current) ? ' ' : '';
+				const next = current ? current + sep + joined + ' ' : joined + ' ';
+				return { ...c, draftMessage: next };
+			})
+		);
+	}, []);
+
 	const handleDrop = useCallback(
 		(e: React.DragEvent) => {
 			e.preventDefault();
@@ -564,17 +610,13 @@ export function useInputHandlers(deps: UseInputHandlersDeps): UseInputHandlersRe
 			const isGroupChatActive = !!activeGroupChatId;
 			const isDirectAIMode = activeSession && activeSession.inputMode === 'ai';
 
-			// Internal drag from the Files panel — insert as @<path> in the AI input.
-			// Phase 1: AI mode only; group chat is excluded.
+			// Files-panel drag: image files are staged as image attachments;
+			// other files/folders are inserted as @<path> in the AI input.
+			// AI mode only; group chat is excluded.
 			const internalPath = e.dataTransfer.getData('application/x-maestro-file-path');
 			if (internalPath) {
 				if (isGroupChatActive || !isDirectAIMode) return;
-				const mention = `@${internalPath}`;
-				setInputValue((prev) => {
-					if (!prev) return mention + ' ';
-					const needsSpace = !/\s$/.test(prev);
-					return prev + (needsSpace ? ' ' : '') + mention + ' ';
-				});
+				appendMentionsToAiInput([internalPath]);
 				inputRef.current?.focus();
 				return;
 			}
@@ -582,9 +624,12 @@ export function useInputHandlers(deps: UseInputHandlersDeps): UseInputHandlersRe
 			if (!isGroupChatActive && !isDirectAIMode) return;
 
 			const files = e.dataTransfer.files;
+			const externalPaths: string[] = [];
+			const projectRoot = activeSession?.projectRoot ?? activeSession?.fullPath;
 
 			for (let i = 0; i < files.length; i++) {
-				if (files[i].type.startsWith('image/')) {
+				const file = files[i];
+				if (file.type.startsWith('image/')) {
 					const reader = new FileReader();
 					reader.onload = (event) => {
 						if (event.target?.result) {
@@ -610,11 +655,32 @@ export function useInputHandlers(deps: UseInputHandlersDeps): UseInputHandlersRe
 							}
 						}
 					};
-					reader.readAsDataURL(files[i]);
+					reader.readAsDataURL(file);
+				} else {
+					// Phase 2: external non-image file or folder — collect path for @-mention.
+					const filePath = (file as File & { path?: string }).path;
+					if (filePath) {
+						externalPaths.push(toMentionPath(filePath, projectRoot));
+					}
+				}
+			}
+
+			if (externalPaths.length > 0) {
+				if (isGroupChatActive) {
+					appendMentionsToGroupChatDraft(externalPaths);
+				} else if (isDirectAIMode) {
+					appendMentionsToAiInput(externalPaths);
+					inputRef.current?.focus();
 				}
 			}
 		},
-		[activeGroupChatId, activeSession, setStagedImages]
+		[
+			activeGroupChatId,
+			activeSession,
+			setStagedImages,
+			appendMentionsToAiInput,
+			appendMentionsToGroupChatDraft,
+		]
 	);
 
 	// ====================================================================

--- a/src/renderer/hooks/input/useInputHandlers.ts
+++ b/src/renderer/hooks/input/useInputHandlers.ts
@@ -29,6 +29,12 @@ import type { TabCompletionSuggestion } from './useTabCompletion';
 import { useAtMentionCompletion, type AtMentionSuggestion } from './useAtMentionCompletion';
 import { useInputProcessing } from './useInputProcessing';
 import { useInputKeyDown } from './useInputKeyDown';
+import { IMAGE_EXTENSIONS } from '../../utils/fileExplorerIcons/shared';
+
+function isImagePath(path: string): boolean {
+	const ext = path.toLowerCase().split('.').pop();
+	return ext ? IMAGE_EXTENSIONS.has(ext) : false;
+}
 
 /**
  * Convert an absolute filesystem path into the form used inside an `@` mention:
@@ -616,6 +622,29 @@ export function useInputHandlers(deps: UseInputHandlersDeps): UseInputHandlersRe
 			const internalPath = e.dataTransfer.getData('application/x-maestro-file-path');
 			if (internalPath) {
 				if (isGroupChatActive || !isDirectAIMode) return;
+
+				if (isImagePath(internalPath)) {
+					const treeRoot = activeSession?.projectRoot ?? activeSession?.fullPath;
+					if (!treeRoot) return;
+					const absolutePath = `${treeRoot}/${internalPath}`;
+					const sshRemoteId =
+						activeSession?.sshRemoteId ??
+						activeSession?.sessionSshRemoteConfig?.remoteId ??
+						undefined;
+					void window.maestro.fs.readFile(absolutePath, sshRemoteId).then((content) => {
+						if (typeof content !== 'string' || !content.startsWith('data:image/')) return;
+						setStagedImages((prev) => {
+							if (prev.includes(content)) {
+								setSuccessFlashNotification('Duplicate image ignored');
+								setTimeout(() => setSuccessFlashNotification(null), 2000);
+								return prev;
+							}
+							return [...prev, content];
+						});
+					});
+					return;
+				}
+
 				appendMentionsToAiInput([internalPath]);
 				inputRef.current?.focus();
 				return;

--- a/src/renderer/hooks/ui/useAppHandlers.ts
+++ b/src/renderer/hooks/ui/useAppHandlers.ts
@@ -55,15 +55,15 @@ export interface UseAppHandlersDeps {
 export interface UseAppHandlersReturn {
 	// Drag handlers
 	/** Handle drag enter for image drop zone */
-	handleImageDragEnter: (e: React.DragEvent) => void;
+	handleFileDragEnter: (e: React.DragEvent) => void;
 	/** Handle drag leave for image drop zone */
-	handleImageDragLeave: (e: React.DragEvent) => void;
+	handleFileDragLeave: (e: React.DragEvent) => void;
 	/** Handle drag over for image drop zone */
-	handleImageDragOver: (e: React.DragEvent) => void;
+	handleFileDragOver: (e: React.DragEvent) => void;
 	/** Whether an image is currently being dragged over the app */
-	isDraggingImage: boolean;
+	isDraggingFile: boolean;
 	/** Setter for drag state (used by drop handler) */
-	setIsDraggingImage: React.Dispatch<React.SetStateAction<boolean>>;
+	setIsDraggingFile: React.Dispatch<React.SetStateAction<boolean>>;
 	/** Ref to drag counter for drop handler */
 	dragCounterRef: React.MutableRefObject<number>;
 
@@ -163,33 +163,37 @@ export function useAppHandlers(deps: UseAppHandlersDeps): UseAppHandlersReturn {
 	} = deps;
 
 	// --- DRAG STATE ---
-	const [isDraggingImage, setIsDraggingImage] = useState(false);
+	const [isDraggingFile, setIsDraggingFile] = useState(false);
 	const dragCounterRef = useRef(0);
 
 	// --- DRAG HANDLERS ---
 
-	const handleImageDragEnter = useCallback((e: React.DragEvent) => {
+	const handleFileDragEnter = useCallback((e: React.DragEvent) => {
 		e.preventDefault();
 		e.stopPropagation();
 		dragCounterRef.current++;
-		// Check if dragging files that include images
-		if (e.dataTransfer.types.includes('Files')) {
-			setIsDraggingImage(true);
+		// Show the overlay for either OS-level file drags ("Files") or internal
+		// drags from the Files panel (which only carry the custom MIME type).
+		if (
+			e.dataTransfer.types.includes('Files') ||
+			e.dataTransfer.types.includes('application/x-maestro-file-path')
+		) {
+			setIsDraggingFile(true);
 		}
 	}, []);
 
-	const handleImageDragLeave = useCallback((e: React.DragEvent) => {
+	const handleFileDragLeave = useCallback((e: React.DragEvent) => {
 		e.preventDefault();
 		e.stopPropagation();
 		dragCounterRef.current--;
 		// Only hide overlay when all nested elements have been left
 		if (dragCounterRef.current <= 0) {
 			dragCounterRef.current = 0;
-			setIsDraggingImage(false);
+			setIsDraggingFile(false);
 		}
 	}, []);
 
-	const handleImageDragOver = useCallback((e: React.DragEvent) => {
+	const handleFileDragOver = useCallback((e: React.DragEvent) => {
 		e.preventDefault();
 		e.stopPropagation();
 	}, []);
@@ -202,7 +206,7 @@ export function useAppHandlers(deps: UseAppHandlersDeps): UseAppHandlersReturn {
 	useEffect(() => {
 		const handleDragEnd = () => {
 			dragCounterRef.current = 0;
-			setIsDraggingImage(false);
+			setIsDraggingFile(false);
 		};
 
 		const handleDocumentDragOver = (e: DragEvent) => {
@@ -214,17 +218,46 @@ export function useAppHandlers(deps: UseAppHandlersDeps): UseAppHandlersReturn {
 			handleDragEnd();
 		};
 
+		// Escape during a drag doesn't reliably fire `dragend` for OS-initiated
+		// drags in Chromium/Electron, leaving the overlay stuck. Catch ESC
+		// directly as a fallback.
+		const handleKeyDown = (e: KeyboardEvent) => {
+			if (e.key === 'Escape' && dragCounterRef.current > 0) {
+				handleDragEnd();
+			}
+		};
+
+		// When the cursor leaves the window entirely during an external drag,
+		// any subsequent ESC/drop happens outside our event scope. Detect this
+		// via a `dragleave` whose relatedTarget is null OR whose coordinates are
+		// at/past the viewport edge, and reset the overlay state proactively.
+		const handleDocumentDragLeave = (e: DragEvent) => {
+			const leftWindow =
+				e.relatedTarget === null ||
+				e.clientX <= 0 ||
+				e.clientY <= 0 ||
+				e.clientX >= window.innerWidth ||
+				e.clientY >= window.innerHeight;
+			if (leftWindow) {
+				handleDragEnd();
+			}
+		};
+
 		// dragend fires when the drag operation ends (drop or cancel)
 		document.addEventListener('dragend', handleDragEnd);
 		// Use capture phase for dragover/drop so they fire BEFORE React handlers that call stopPropagation().
 		// This ensures preventDefault() is called at document level even when element handlers stop bubbling.
 		document.addEventListener('dragover', handleDocumentDragOver, { capture: true });
 		document.addEventListener('drop', handleDocumentDrop, { capture: true });
+		document.addEventListener('keydown', handleKeyDown);
+		document.addEventListener('dragleave', handleDocumentDragLeave);
 
 		return () => {
 			document.removeEventListener('dragend', handleDragEnd);
 			document.removeEventListener('dragover', handleDocumentDragOver, { capture: true });
 			document.removeEventListener('drop', handleDocumentDrop, { capture: true });
+			document.removeEventListener('keydown', handleKeyDown);
+			document.removeEventListener('dragleave', handleDocumentDragLeave);
 		};
 	}, []);
 
@@ -420,11 +453,11 @@ export function useAppHandlers(deps: UseAppHandlersDeps): UseAppHandlersReturn {
 
 	return {
 		// Drag handlers
-		handleImageDragEnter,
-		handleImageDragLeave,
-		handleImageDragOver,
-		isDraggingImage,
-		setIsDraggingImage,
+		handleFileDragEnter,
+		handleFileDragLeave,
+		handleFileDragOver,
+		isDraggingFile,
+		setIsDraggingFile,
 		dragCounterRef,
 
 		// File handlers


### PR DESCRIPTION
<img width="1401" height="899" alt="Bildschirmfoto 2026-04-25 um 07 36 35" src="https://github.com/user-attachments/assets/b3b97e4e-e821-4b1d-b6e7-efe85a68e63d" />

I am working on some more drag and drop functionality:
* From the file panel -> drag on chat for @ mentions
* From outside app -> drag on chat or group chat for @mention relative or absolute if not in the project directory
* Image from file panel -> drag on chat insert as attachment with thumbnail 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dragging files from the explorer or dropping external files/folders inserts @references into messages or stages images for upload.
  * File drops now respect group-chat drafts vs AI input, inserting mentions into the correct input.

* **UI/UX Improvements**
  * Overlay wording clarified to “Drop file or folder” with guidance about thumbnails vs @references.
  * Overlay is clickable to dismiss if it becomes stuck.

* **Tests**
  * Expanded drag-and-drop test coverage for many drop scenarios and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->