### PR TITLE
fix(files-panel): folder-highlight, find-toggle, dotfiles polish

### DIFF
--- a/src/__tests__/renderer/components/FileExplorerPanel.test.tsx
+++ b/src/__tests__/renderer/components/FileExplorerPanel.test.tsx
@@ -459,6 +459,82 @@ describe('FileExplorerPanel', () => {
 		});
 	});
 
+	describe('Find Button (#759)', () => {
+		it('opens the filter input when clicked while closed', () => {
+			render(<FileExplorerPanel {...defaultProps} fileTreeFilterOpen={false} />);
+			fireEvent.click(screen.getByText('Find'));
+			expect(defaultProps.setFileTreeFilterOpen).toHaveBeenCalledWith(true);
+		});
+
+		it('closes the filter input when clicked while open and empty', () => {
+			render(<FileExplorerPanel {...defaultProps} fileTreeFilterOpen={true} fileTreeFilter="" />);
+			fireEvent.click(screen.getByText('Find'));
+			expect(defaultProps.setFileTreeFilterOpen).toHaveBeenCalledWith(false);
+		});
+
+		it('does not close the filter input when it has a query', () => {
+			render(
+				<FileExplorerPanel {...defaultProps} fileTreeFilterOpen={true} fileTreeFilter="src" />
+			);
+			fireEvent.click(screen.getByText('Find'));
+			expect(defaultProps.setFileTreeFilterOpen).not.toHaveBeenCalledWith(false);
+		});
+	});
+
+	describe('Dotfiles Toggle (#757)', () => {
+		it('hides .maestro when showHiddenFiles is false', () => {
+			const treeWithMaestro = [
+				{ name: '.maestro', type: 'folder' as const, children: [] },
+				{ name: '.git', type: 'folder' as const, children: [] },
+				{ name: 'src', type: 'folder' as const, children: [] },
+			];
+			render(
+				<FileExplorerPanel
+					{...defaultProps}
+					showHiddenFiles={false}
+					filteredFileTree={treeWithMaestro}
+				/>
+			);
+			expect(screen.queryByText('.maestro')).not.toBeInTheDocument();
+			expect(screen.queryByText('.git')).not.toBeInTheDocument();
+			expect(screen.getByText('src')).toBeInTheDocument();
+		});
+
+		it('shows .maestro when showHiddenFiles is true', () => {
+			const treeWithMaestro = [
+				{ name: '.maestro', type: 'folder' as const, children: [] },
+				{ name: 'src', type: 'folder' as const, children: [] },
+			];
+			render(
+				<FileExplorerPanel
+					{...defaultProps}
+					showHiddenFiles={true}
+					filteredFileTree={treeWithMaestro}
+				/>
+			);
+			expect(screen.getByText('.maestro')).toBeInTheDocument();
+			expect(screen.getByText('src')).toBeInTheDocument();
+		});
+
+		it('renders the toggle button labeled "Dotfiles"', () => {
+			render(<FileExplorerPanel {...defaultProps} showHiddenFiles={false} />);
+			expect(screen.getByText('Dotfiles')).toBeInTheDocument();
+			expect(screen.getByTitle('Show dotfiles')).toBeInTheDocument();
+		});
+
+		it('exposes a "Hide dotfiles" tooltip while dotfiles are shown', () => {
+			render(<FileExplorerPanel {...defaultProps} showHiddenFiles={true} />);
+			expect(screen.getByText('Dotfiles')).toBeInTheDocument();
+			expect(screen.getByTitle('Hide dotfiles')).toBeInTheDocument();
+		});
+
+		it('toggles showHiddenFiles when clicked', () => {
+			render(<FileExplorerPanel {...defaultProps} showHiddenFiles={false} />);
+			fireEvent.click(screen.getByText('Dotfiles'));
+			expect(defaultProps.setShowHiddenFiles).toHaveBeenCalledWith(true);
+		});
+	});
+
 	describe('Refresh Button', () => {
 		it('shows default title when no auto-refresh', () => {
 			render(<FileExplorerPanel {...defaultProps} />);
@@ -1012,6 +1088,25 @@ describe('FileExplorerPanel', () => {
 
 			expect(defaultProps.setSelectedFileIndex).toHaveBeenCalled();
 			expect(defaultProps.setActiveFocus).toHaveBeenCalledWith('right');
+		});
+
+		it('sets selectedFileIndex and activeFocus when clicking a folder (#768)', () => {
+			render(<FileExplorerPanel {...defaultProps} />);
+			const folder = screen.getByText('src');
+			fireEvent.click(folder);
+
+			expect(defaultProps.setSelectedFileIndex).toHaveBeenCalled();
+			expect(defaultProps.setActiveFocus).toHaveBeenCalledWith('right');
+			expect(defaultProps.toggleFolder).toHaveBeenCalled();
+		});
+
+		it('does not change focus when clicking a folder while filtering', () => {
+			render(<FileExplorerPanel {...defaultProps} fileTreeFilter="src" />);
+			const folder = screen.getByText('src');
+			fireEvent.click(folder);
+
+			expect(defaultProps.setSelectedFileIndex).toHaveBeenCalled();
+			expect(defaultProps.setActiveFocus).not.toHaveBeenCalled();
 		});
 
 		it('calls handleFileClick on double-click of file', async () => {

--- a/src/renderer/components/FileExplorerPanel.tsx
+++ b/src/renderer/components/FileExplorerPanel.tsx
@@ -965,7 +965,7 @@ function FileExplorerPanelInner(props: FileExplorerPanelProps) {
 			if (!nodes) return [];
 			if (showHiddenFiles) return nodes;
 			return nodes
-				.filter((node) => !node.name.startsWith('.') || node.name === '.maestro')
+				.filter((node) => !node.name.startsWith('.'))
 				.map((node) => ({
 					...node,
 					children: node.children ? filterHiddenFiles(node.children) : undefined,
@@ -1102,17 +1102,16 @@ function FileExplorerPanelInner(props: FileExplorerPanelProps) {
 						}
 					}}
 					onClick={(e) => {
+						setSelectedFileIndex(globalIndex);
+						// Only change focus if not filtering
+						if (fileTreeFilter.length === 0) {
+							setActiveFocus('right');
+						}
 						if (isFolder) {
 							if (e.altKey) {
 								toggleFolderRecursive(fullPath, session.id, setSessions);
 							} else {
 								toggleFolder(fullPath, session.id, setSessions);
-							}
-						} else {
-							setSelectedFileIndex(globalIndex);
-							// Only change focus if not filtering
-							if (fileTreeFilter.length === 0) {
-								setActiveFocus('right');
 							}
 						}
 					}}
@@ -1217,7 +1216,11 @@ function FileExplorerPanelInner(props: FileExplorerPanelProps) {
 					<button
 						onClick={() => {
 							if (fileTreeFilterOpen) {
-								fileTreeFilterInputRef?.current?.focus();
+								if (fileTreeFilter.length === 0) {
+									setFileTreeFilterOpen(false);
+								} else {
+									fileTreeFilterInputRef?.current?.focus();
+								}
 							} else {
 								setFileTreeFilterOpen(true);
 								setTimeout(() => fileTreeFilterInputRef?.current?.focus(), 0);
@@ -1269,7 +1272,7 @@ function FileExplorerPanelInner(props: FileExplorerPanelProps) {
 					>
 						{!compact &&
 							(showHiddenFiles ? <Eye className="w-3 h-3" /> : <EyeOff className="w-3 h-3" />)}
-						{showHiddenFiles ? 'Hide' : 'Show'}
+						Dotfiles
 					</button>
 					{/* Refresh */}
 					<button


### PR DESCRIPTION
## Summary
Three small Files panel polish fixes from in-app feedback:

- **Closes #768** — Folder click now updates `selectedFileIndex` and `activeFocus`, so the keyboard-highlight follows the clicked folder instead of staying stuck on whatever index 0 was. Previously only file clicks updated the index, so the highlight bar drifted away from the user's actual click.
- **Closes #759** — Clicking the Find button while the filter input is open and empty now closes it (toggle behavior). Non-empty queries still refocus instead of closing, preserving the existing path for filtering.
- **Closes #757** — Drop the `.maestro` whitelist from `filterHiddenFiles` so the dotfile toggle truly hides *every* dot-prefixed entry, including `.maestro`. Relabel the button from `Hide`/`Show` to a static `Dotfiles`; the Eye/EyeOff icon plus the tooltip (`Hide dotfiles` / `Show dotfiles`) communicate state, removing the ambiguity called out in the issue.

## Files Changed
- `src/renderer/components/FileExplorerPanel.tsx`
- `src/__tests__/renderer/components/FileExplorerPanel.test.tsx`

## Test plan
- [x] `vitest run src/__tests__/renderer/components/FileExplorerPanel.test.tsx` — 155 PASS / 0 FAIL
- [x] Added folder-click highlight test + filtering-doesn't-change-focus test
- [x] Added `Find Button (#759)` describe (3 cases: open-when-closed, close-when-empty, no-close-with-query)
- [x] Added `Dotfiles Toggle (#757)` describe (5 cases: `.maestro`/`.git` hidden when off, visible when on, label is `Dotfiles`, tooltip text in both states, click toggles `setShowHiddenFiles`)
- [x] `eslint` clean on touched files
- [x] `prettier --check` clean on touched files
- [ ] Manual smoke: click various folders in Files panel and confirm highlight follows; toggle Find on empty input twice; toggle Dotfiles and confirm `.maestro` hides

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for file explorer panel UI controls, including Find button toggle and Dotfiles visibility functionality.

* **Bug Fixes**
  * Fixed hidden-file filtering to consistently exclude all dotfiles, including .maestro directories.
  * Improved Find button behavior: closes the filter overlay when filter is empty, or focuses the input field otherwise.
  * Updated dotfiles toggle button label for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->