### PR TITLE
fix(cli): inline version at build time so production CLI reports correct version

### DIFF
--- a/scripts/build-cli.mjs
+++ b/scripts/build-cli.mjs
@@ -17,6 +17,9 @@ const rootDir = path.resolve(__dirname, '..');
 
 const outfile = path.join(rootDir, 'dist/cli/maestro-cli.js');
 
+const pkgJson = JSON.parse(fs.readFileSync(path.join(rootDir, 'package.json'), 'utf8'));
+const cliVersion = pkgJson.version;
+
 /**
  * esbuild plugin to handle .md?raw imports (Vite-style raw imports)
  * Converts the file contents to a string export
@@ -59,6 +62,9 @@ async function build() {
 			// Note: shebang is already in src/cli/index.ts, no banner needed
 			external: [],
 			plugins: [rawMdPlugin],
+			define: {
+				__MAESTRO_CLI_VERSION__: JSON.stringify(cliVersion),
+			},
 		});
 
 		// Make the output executable

--- a/scripts/build-cli.mjs
+++ b/scripts/build-cli.mjs
@@ -19,6 +19,9 @@ const outfile = path.join(rootDir, 'dist/cli/maestro-cli.js');
 
 const pkgJson = JSON.parse(fs.readFileSync(path.join(rootDir, 'package.json'), 'utf8'));
 const cliVersion = pkgJson.version;
+if (typeof cliVersion !== 'string' || cliVersion.length === 0) {
+	throw new Error('Cannot build CLI: package.json is missing a valid "version" field');
+}
 
 /**
  * esbuild plugin to handle .md?raw imports (Vite-style raw imports)

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -3,8 +3,6 @@
 // Command-line interface for Maestro
 
 import { Command } from 'commander';
-import * as fs from 'fs';
-import * as path from 'path';
 import { listGroups } from './commands/list-groups';
 import { listAgents } from './commands/list-agents';
 import { listPlaybooks } from './commands/list-playbooks';
@@ -41,21 +39,15 @@ import {
 } from './commands/settings-agent';
 import { promptsGet, promptsList } from './commands/prompts-get';
 
-// Read version from package.json at runtime
-function getVersion(): string {
-	try {
-		// When bundled, __dirname points to dist/cli, so go up to project root
-		const packagePath = path.resolve(__dirname, '../../package.json');
-		const packageJson = JSON.parse(fs.readFileSync(packagePath, 'utf-8'));
-		return packageJson.version;
-	} catch {
-		return '0.0.0';
-	}
-}
+// Injected at build time by scripts/build-cli.mjs via esbuild `define`
+declare const __MAESTRO_CLI_VERSION__: string;
 
 const program = new Command();
 
-program.name('maestro-cli').description('Command-line interface for Maestro').version(getVersion());
+program
+	.name('maestro-cli')
+	.description('Command-line interface for Maestro')
+	.version(__MAESTRO_CLI_VERSION__);
 
 // List commands
 const list = program.command('list').description('List resources');

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -39,15 +39,16 @@ import {
 } from './commands/settings-agent';
 import { promptsGet, promptsList } from './commands/prompts-get';
 
-// Injected at build time by scripts/build-cli.mjs via esbuild `define`
+// Injected at build time by scripts/build-cli.mjs via esbuild `define`.
+// The typeof guard keeps non-esbuild execution paths (ts-node, plain tsc output) from
+// throwing a ReferenceError; in those paths the constant is never substituted.
 declare const __MAESTRO_CLI_VERSION__: string;
+const cliVersion: string =
+	typeof __MAESTRO_CLI_VERSION__ !== 'undefined' ? __MAESTRO_CLI_VERSION__ : '0.0.0-dev';
 
 const program = new Command();
 
-program
-	.name('maestro-cli')
-	.description('Command-line interface for Maestro')
-	.version(__MAESTRO_CLI_VERSION__);
+program.name('maestro-cli').description('Command-line interface for Maestro').version(cliVersion);
 
 // List commands
 const list = program.command('list').description('List resources');


### PR DESCRIPTION
## Summary

- `src/cli/index.ts` read the version at runtime via `path.resolve(__dirname, '../../package.json')`. That works in dev (`dist/cli/../../package.json` → repo root) but fails in production: the bundle ships to `/opt/Maestro/resources/maestro-cli.js`, so the relative path resolves to `/package.json`, the read throws, and the catch block returns `'0.0.0'` — which is what users saw from `maestro-cli --version` and in the Settings UI's installed-version field.
- Fix: inject the version via esbuild `define` in `scripts/build-cli.mjs` so it becomes a string literal in the bundle. No more runtime file reads, no more dev/prod path drift.

## Test plan

- [x] `node scripts/build-cli.mjs` — bundle builds cleanly
- [x] `node dist/cli/maestro-cli.js --version` → `0.16.13-RC`
- [x] Repointed local shim at the new bundle; `maestro-cli --version` reports `0.16.13-RC` (was `0.0.0`)
- [x] `tsc -p tsconfig.cli.json --noEmit` clean
- [x] Prettier clean on touched files
- [x] After merge & release: install via Settings UI and confirm `maestro-cli --version` matches `app.getVersion()` reported in Settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CLI now includes a validated, build-time embedded version so the displayed version is consistent.
  * When a version is unavailable, the CLI falls back to a clear dev-version indicator.
  * Build process tightened to ensure version correctness is enforced during packaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->