### PR TITLE
fix(worktrees): open existing worktree when branch is already attached

### DIFF
--- a/src/__tests__/main/ipc/handlers/git.test.ts
+++ b/src/__tests__/main/ipc/handlers/git.test.ts
@@ -2359,8 +2359,103 @@ export function Component() {
 			});
 		});
 
-		it('should handle git worktree creation failure', async () => {
+		it('should recover when branch is already checked out at another worktree', async () => {
 			// Mock fs.access to throw (path doesn't exist)
+			const fsPromises = await import('fs/promises');
+			vi.mocked(fsPromises.default.access).mockRejectedValue(new Error('ENOENT'));
+
+			vi.mocked(execFile.execFileNoThrow)
+				.mockResolvedValueOnce({
+					// git rev-parse --verify branchName (branch exists)
+					stdout: 'abc123456789',
+					stderr: '',
+					exitCode: 0,
+				})
+				.mockResolvedValueOnce({
+					// git worktree add fails because branch already attached elsewhere
+					stdout: '',
+					stderr: "fatal: 'feature-branch' is already checked out at '/existing/wt/feature-branch'",
+					exitCode: 128,
+				})
+				.mockResolvedValueOnce({
+					// findLocalWorktreeForBranch → git worktree list --porcelain
+					stdout: [
+						'worktree /main/repo',
+						'HEAD aaa',
+						'branch refs/heads/main',
+						'',
+						'worktree /existing/wt/feature-branch',
+						'HEAD bbb',
+						'branch refs/heads/feature-branch',
+						'',
+					].join('\n'),
+					stderr: '',
+					exitCode: 0,
+				});
+
+			const handler = handlers.get('git:worktreeSetup');
+			const result = await handler!(
+				{} as any,
+				'/main/repo',
+				'/worktrees/feature',
+				'feature-branch'
+			);
+
+			expect(result).toEqual({
+				success: true,
+				created: false,
+				alreadyExisted: true,
+				existingPath: '/existing/wt/feature-branch',
+				currentBranch: 'feature-branch',
+				requestedBranch: 'feature-branch',
+				branchMismatch: false,
+			});
+			expect(execFile.execFileNoThrow).toHaveBeenCalledWith(
+				'git',
+				['worktree', 'list', '--porcelain'],
+				'/main/repo'
+			);
+		});
+
+		it('should still surface error when branch is "already used" but porcelain lookup yields no match', async () => {
+			const fsPromises = await import('fs/promises');
+			vi.mocked(fsPromises.default.access).mockRejectedValue(new Error('ENOENT'));
+
+			vi.mocked(execFile.execFileNoThrow)
+				.mockResolvedValueOnce({
+					// git rev-parse --verify branchName (branch exists)
+					stdout: 'abc123',
+					stderr: '',
+					exitCode: 0,
+				})
+				.mockResolvedValueOnce({
+					// git worktree add fails
+					stdout: '',
+					stderr: "fatal: 'feature-branch' is already used by worktree at '/gone'",
+					exitCode: 128,
+				})
+				.mockResolvedValueOnce({
+					// porcelain returns nothing matching
+					stdout: 'worktree /main/repo\nHEAD aaa\nbranch refs/heads/main\n',
+					stderr: '',
+					exitCode: 0,
+				});
+
+			const handler = handlers.get('git:worktreeSetup');
+			const result = await handler!(
+				{} as any,
+				'/main/repo',
+				'/worktrees/feature',
+				'feature-branch'
+			);
+
+			expect(result).toEqual({
+				success: false,
+				error: "fatal: 'feature-branch' is already used by worktree at '/gone'",
+			});
+		});
+
+		it('should surface unrelated git worktree creation failures unchanged', async () => {
 			const fsPromises = await import('fs/promises');
 			vi.mocked(fsPromises.default.access).mockRejectedValue(new Error('ENOENT'));
 
@@ -2372,9 +2467,9 @@ export function Component() {
 					exitCode: 128,
 				})
 				.mockResolvedValueOnce({
-					// git worktree add -b fails
+					// git worktree add -b fails for an unrelated reason
 					stdout: '',
-					stderr: "fatal: 'feature-branch' is already checked out at '/other/path'",
+					stderr: 'fatal: permission denied',
 					exitCode: 128,
 				});
 
@@ -2388,8 +2483,14 @@ export function Component() {
 
 			expect(result).toEqual({
 				success: false,
-				error: "fatal: 'feature-branch' is already checked out at '/other/path'",
+				error: 'fatal: permission denied',
 			});
+			// porcelain lookup must NOT run for non-"already used" errors
+			expect(execFile.execFileNoThrow).not.toHaveBeenCalledWith(
+				'git',
+				['worktree', 'list', '--porcelain'],
+				'/main/repo'
+			);
 		});
 	});
 

--- a/src/__tests__/main/ipc/handlers/git.test.ts
+++ b/src/__tests__/main/ipc/handlers/git.test.ts
@@ -2360,9 +2360,14 @@ export function Component() {
 		});
 
 		it('should recover when branch is already checked out at another worktree', async () => {
-			// Mock fs.access to throw (path doesn't exist)
+			// fs.access is called twice:
+			//  1) for the requested /worktrees/feature path (must reject — doesn't exist)
+			//  2) for the recovered /existing/wt/feature-branch path (must resolve — does exist)
 			const fsPromises = await import('fs/promises');
-			vi.mocked(fsPromises.default.access).mockRejectedValue(new Error('ENOENT'));
+			vi.mocked(fsPromises.default.access).mockImplementation(async (p: any) => {
+				if (String(p) === '/existing/wt/feature-branch') return undefined;
+				throw new Error('ENOENT');
+			});
 
 			vi.mocked(execFile.execFileNoThrow)
 				.mockResolvedValueOnce({
@@ -2415,6 +2420,53 @@ export function Component() {
 				['worktree', 'list', '--porcelain'],
 				'/main/repo'
 			);
+		});
+
+		it('should fall through to error when porcelain returns a stale worktree path that no longer exists on disk', async () => {
+			// fs.access rejects → recovered path is stale, treat as no match
+			const fsPromises = await import('fs/promises');
+			vi.mocked(fsPromises.default.access).mockRejectedValue(new Error('ENOENT'));
+
+			vi.mocked(execFile.execFileNoThrow)
+				.mockResolvedValueOnce({
+					stdout: 'abc123',
+					stderr: '',
+					exitCode: 0,
+				})
+				.mockResolvedValueOnce({
+					stdout: '',
+					stderr: "fatal: 'feature-branch' is already checked out at '/stale/path'",
+					exitCode: 128,
+				})
+				.mockResolvedValueOnce({
+					// porcelain returns the stale path
+					stdout: [
+						'worktree /main/repo',
+						'HEAD aaa',
+						'branch refs/heads/main',
+						'',
+						'worktree /stale/path',
+						'HEAD bbb',
+						'branch refs/heads/feature-branch',
+						'',
+					].join('\n'),
+					stderr: '',
+					exitCode: 0,
+				});
+
+			const handler = handlers.get('git:worktreeSetup');
+			const result = await handler!(
+				{} as any,
+				'/main/repo',
+				'/worktrees/feature',
+				'feature-branch'
+			);
+
+			expect(result).toEqual({
+				success: false,
+				error: "fatal: 'feature-branch' is already checked out at '/stale/path'",
+			});
+			expect(fsPromises.default.access).toHaveBeenCalledWith('/stale/path');
 		});
 
 		it('should still surface error when branch is "already used" but porcelain lookup yields no match', async () => {

--- a/src/__tests__/main/utils/remote-git.test.ts
+++ b/src/__tests__/main/utils/remote-git.test.ts
@@ -918,6 +918,63 @@ describe('remote-git.ts', () => {
 			expect(result.success).toBe(true);
 			expect(result.data!.branchMismatch).toBe(false);
 		});
+
+		it('should recover when remote branch is already checked out at another worktree', async () => {
+			// Check nested
+			mockExecFileNoThrow.mockResolvedValueOnce(successResult('/a\n/b\n'));
+			// Check path exists
+			mockExecFileNoThrow.mockResolvedValueOnce(successResult('NOT_EXISTS'));
+			// Branch exists
+			mockExecFileNoThrow.mockResolvedValueOnce(successResult('abc\n'));
+			// git worktree add fails because branch already attached
+			mockExecFileNoThrow.mockResolvedValueOnce(
+				failResult("fatal: 'feature' is already checked out at '/existing/wt/feature'", 128)
+			);
+			// findRemoteWorktreeForBranch → git worktree list --porcelain
+			mockExecFileNoThrow.mockResolvedValueOnce(
+				successResult(
+					[
+						'worktree /a',
+						'HEAD aaa',
+						'branch refs/heads/main',
+						'',
+						'worktree /existing/wt/feature',
+						'HEAD bbb',
+						'branch refs/heads/feature',
+						'',
+					].join('\n')
+				)
+			);
+
+			const result = await worktreeSetupRemote('/a', '/b', 'feature', sshRemote);
+
+			expect(result.success).toBe(true);
+			expect(result.data!.success).toBe(true);
+			expect(result.data!.created).toBe(false);
+			expect(result.data!.alreadyExisted).toBe(true);
+			expect(result.data!.existingPath).toBe('/existing/wt/feature');
+			expect(result.data!.currentBranch).toBe('feature');
+			expect(result.data!.branchMismatch).toBe(false);
+		});
+
+		it('should still report error when "already used" but porcelain has no match', async () => {
+			mockExecFileNoThrow.mockResolvedValueOnce(successResult('/a\n/b\n'));
+			mockExecFileNoThrow.mockResolvedValueOnce(successResult('NOT_EXISTS'));
+			mockExecFileNoThrow.mockResolvedValueOnce(successResult('abc\n'));
+			mockExecFileNoThrow.mockResolvedValueOnce(
+				failResult("fatal: 'feature' is already used by worktree at '/gone'", 128)
+			);
+			// porcelain returns nothing matching
+			mockExecFileNoThrow.mockResolvedValueOnce(
+				successResult('worktree /a\nHEAD aaa\nbranch refs/heads/main\n')
+			);
+
+			const result = await worktreeSetupRemote('/a', '/b', 'feature', sshRemote);
+
+			expect(result.success).toBe(true);
+			expect(result.data!.success).toBe(false);
+			expect(result.data!.error).toContain('already used');
+		});
 	});
 
 	// =========================================================================

--- a/src/__tests__/main/utils/remote-git.test.ts
+++ b/src/__tests__/main/utils/remote-git.test.ts
@@ -945,6 +945,8 @@ describe('remote-git.ts', () => {
 					].join('\n')
 				)
 			);
+			// findRemoteWorktreeForBranch → test -d (path exists on remote)
+			mockExecFileNoThrow.mockResolvedValueOnce(successResult('EXISTS'));
 
 			const result = await worktreeSetupRemote('/a', '/b', 'feature', sshRemote);
 
@@ -955,6 +957,38 @@ describe('remote-git.ts', () => {
 			expect(result.data!.existingPath).toBe('/existing/wt/feature');
 			expect(result.data!.currentBranch).toBe('feature');
 			expect(result.data!.branchMismatch).toBe(false);
+		});
+
+		it('should fall through to error when porcelain returns a stale remote worktree path', async () => {
+			mockExecFileNoThrow.mockResolvedValueOnce(successResult('/a\n/b\n'));
+			mockExecFileNoThrow.mockResolvedValueOnce(successResult('NOT_EXISTS'));
+			mockExecFileNoThrow.mockResolvedValueOnce(successResult('abc\n'));
+			mockExecFileNoThrow.mockResolvedValueOnce(
+				failResult("fatal: 'feature' is already checked out at '/stale'", 128)
+			);
+			// porcelain still has a stale registration
+			mockExecFileNoThrow.mockResolvedValueOnce(
+				successResult(
+					[
+						'worktree /a',
+						'HEAD aaa',
+						'branch refs/heads/main',
+						'',
+						'worktree /stale',
+						'HEAD bbb',
+						'branch refs/heads/feature',
+						'',
+					].join('\n')
+				)
+			);
+			// test -d on remote → MISSING (stale)
+			mockExecFileNoThrow.mockResolvedValueOnce(successResult('MISSING'));
+
+			const result = await worktreeSetupRemote('/a', '/b', 'feature', sshRemote);
+
+			expect(result.success).toBe(true);
+			expect(result.data!.success).toBe(false);
+			expect(result.data!.error).toContain('already checked out');
 		});
 
 		it('should still report error when "already used" but porcelain has no match', async () => {

--- a/src/__tests__/renderer/hooks/batch/useAutoRunHandlers.worktree.test.ts
+++ b/src/__tests__/renderer/hooks/batch/useAutoRunHandlers.worktree.test.ts
@@ -673,6 +673,107 @@ describe('handleStartBatchRun — worktree dispatch integration', () => {
 			const parent = sessions.find((s) => s.id === 'parent-session-1');
 			expect(parent?.worktreesExpanded).toBe(true);
 		});
+
+		it('uses existingPath and dispatches when branch is already attached to a worktree', async () => {
+			const session = createMockSession();
+			const deps = createMockDeps();
+
+			vi.mocked(window.maestro.git.worktreeSetup).mockResolvedValue({
+				success: true,
+				created: false,
+				alreadyExisted: true,
+				existingPath: '/projects/other/already-attached',
+				currentBranch: 'already-attached',
+				requestedBranch: 'already-attached',
+				branchMismatch: false,
+			});
+			vi.mocked(gitService.getBranches).mockResolvedValue(['main']);
+
+			const config: BatchRunConfig = {
+				documents: baseDocuments,
+				prompt: 'Go',
+				loopEnabled: false,
+				worktreeTarget: {
+					mode: 'create-new',
+					newBranchName: 'already-attached',
+					baseBranch: 'main',
+					createPROnCompletion: false,
+				},
+			};
+
+			const { result } = renderHook(() => useAutoRunHandlers(session, deps));
+
+			await act(async () => {
+				await result.current.handleStartBatchRun(config);
+			});
+
+			// Session was added against the resolved existing path, not the requested one
+			const sessions = useSessionStore.getState().sessions;
+			const newSession = sessions.find((s) => s.worktreeBranch === 'already-attached');
+			expect(newSession).toBeDefined();
+			expect(newSession!.cwd).toBe('/projects/other/already-attached');
+
+			// Batch run was dispatched against the new session, not blocked
+			expect(deps.startBatchRun).toHaveBeenCalledOnce();
+			expect(notifyToast).toHaveBeenCalledWith(
+				expect.objectContaining({
+					type: 'info',
+					title: 'Worktree Already Existed',
+				})
+			);
+		});
+
+		it('reuses existing session when alreadyExisted path matches an open session', async () => {
+			const session = createMockSession();
+			const deps = createMockDeps();
+
+			const existingChild = {
+				...session,
+				id: 'wt-existing',
+				cwd: '/projects/other/feat',
+				worktreeBranch: 'feat',
+				parentSessionId: session.id,
+			};
+			useSessionStore.setState({
+				sessions: [session, existingChild as any],
+				activeSessionId: session.id,
+			} as any);
+
+			vi.mocked(window.maestro.git.worktreeSetup).mockResolvedValue({
+				success: true,
+				created: false,
+				alreadyExisted: true,
+				existingPath: '/projects/other/feat',
+				currentBranch: 'feat',
+				requestedBranch: 'feat',
+				branchMismatch: false,
+			});
+			vi.mocked(gitService.getBranches).mockResolvedValue(['main']);
+
+			const config: BatchRunConfig = {
+				documents: baseDocuments,
+				prompt: 'Go',
+				loopEnabled: false,
+				worktreeTarget: {
+					mode: 'create-new',
+					newBranchName: 'feat',
+					baseBranch: 'main',
+					createPROnCompletion: false,
+				},
+			};
+
+			const { result } = renderHook(() => useAutoRunHandlers(session, deps));
+
+			await act(async () => {
+				await result.current.handleStartBatchRun(config);
+			});
+
+			// No new session was added — count stays at 2
+			expect(useSessionStore.getState().sessions.length).toBe(2);
+			// Batch run dispatched against the existing session
+			expect(deps.startBatchRun).toHaveBeenCalledOnce();
+			expect(deps.startBatchRun.mock.calls[0][0]).toBe('wt-existing');
+		});
 	});
 
 	// -----------------------------------------------------------------------

--- a/src/__tests__/renderer/hooks/batch/useAutoRunHandlers.worktree.test.ts
+++ b/src/__tests__/renderer/hooks/batch/useAutoRunHandlers.worktree.test.ts
@@ -775,6 +775,60 @@ describe('handleStartBatchRun — worktree dispatch integration', () => {
 			expect(deps.startBatchRun.mock.calls[0][0]).toBe('wt-existing');
 		});
 
+		it('reuses existing session via projectRoot match even when child cwd has drifted into a subdir', async () => {
+			const session = createMockSession();
+			const deps = createMockDeps();
+
+			// Child session has cd'd into a subdirectory of the worktree, so its
+			// cwd no longer matches the worktree root. projectRoot still does.
+			const existingChild = {
+				...session,
+				id: 'wt-existing',
+				cwd: '/projects/other/feat/src/components',
+				projectRoot: '/projects/other/feat',
+				worktreeBranch: 'feat',
+				parentSessionId: session.id,
+			};
+			useSessionStore.setState({
+				sessions: [session, existingChild as any],
+				activeSessionId: session.id,
+			} as any);
+
+			vi.mocked(window.maestro.git.worktreeSetup).mockResolvedValue({
+				success: true,
+				created: false,
+				alreadyExisted: true,
+				existingPath: '/projects/other/feat',
+				currentBranch: 'feat',
+				requestedBranch: 'feat',
+				branchMismatch: false,
+			});
+			vi.mocked(gitService.getBranches).mockResolvedValue(['main']);
+
+			const config: BatchRunConfig = {
+				documents: baseDocuments,
+				prompt: 'Go',
+				loopEnabled: false,
+				worktreeTarget: {
+					mode: 'create-new',
+					newBranchName: 'feat',
+					baseBranch: 'main',
+					createPROnCompletion: false,
+				},
+			};
+
+			const { result } = renderHook(() => useAutoRunHandlers(session, deps));
+
+			await act(async () => {
+				await result.current.handleStartBatchRun(config);
+			});
+
+			// projectRoot match should reuse the existing session — no duplicate.
+			expect(useSessionStore.getState().sessions.length).toBe(2);
+			expect(deps.startBatchRun).toHaveBeenCalledOnce();
+			expect(deps.startBatchRun.mock.calls[0][0]).toBe('wt-existing');
+		});
+
 		it('reuses existing session when paths differ only by trailing slash / duplicate separators', async () => {
 			const session = createMockSession();
 			const deps = createMockDeps();

--- a/src/__tests__/renderer/hooks/batch/useAutoRunHandlers.worktree.test.ts
+++ b/src/__tests__/renderer/hooks/batch/useAutoRunHandlers.worktree.test.ts
@@ -775,6 +775,66 @@ describe('handleStartBatchRun — worktree dispatch integration', () => {
 			expect(deps.startBatchRun.mock.calls[0][0]).toBe('wt-existing');
 		});
 
+		it('aborts dispatch when reused session is busy or connecting', async () => {
+			const session = createMockSession();
+			const deps = createMockDeps();
+
+			// Existing worktree session is mid-run (state === 'busy').
+			const busyChild = {
+				...session,
+				id: 'wt-busy',
+				cwd: '/projects/other/feat',
+				projectRoot: '/projects/other/feat',
+				worktreeBranch: 'feat',
+				parentSessionId: session.id,
+				state: 'busy',
+			};
+			useSessionStore.setState({
+				sessions: [session, busyChild as any],
+				activeSessionId: session.id,
+			} as any);
+
+			vi.mocked(window.maestro.git.worktreeSetup).mockResolvedValue({
+				success: true,
+				created: false,
+				alreadyExisted: true,
+				existingPath: '/projects/other/feat',
+				currentBranch: 'feat',
+				requestedBranch: 'feat',
+				branchMismatch: false,
+			});
+			vi.mocked(gitService.getBranches).mockResolvedValue(['main']);
+
+			const config: BatchRunConfig = {
+				documents: baseDocuments,
+				prompt: 'Go',
+				loopEnabled: false,
+				worktreeTarget: {
+					mode: 'create-new',
+					newBranchName: 'feat',
+					baseBranch: 'main',
+					createPROnCompletion: false,
+				},
+			};
+
+			const { result } = renderHook(() => useAutoRunHandlers(session, deps));
+
+			await act(async () => {
+				await result.current.handleStartBatchRun(config);
+			});
+
+			// No dispatch — busy guard fired.
+			expect(deps.startBatchRun).not.toHaveBeenCalled();
+			expect(notifyToast).toHaveBeenCalledWith(
+				expect.objectContaining({
+					type: 'warning',
+					title: 'Target Agent Busy',
+				})
+			);
+			// No new session built either.
+			expect(useSessionStore.getState().sessions.length).toBe(2);
+		});
+
 		it('reuses existing session via projectRoot match even when child cwd has drifted into a subdir', async () => {
 			const session = createMockSession();
 			const deps = createMockDeps();

--- a/src/__tests__/renderer/hooks/batch/useAutoRunHandlers.worktree.test.ts
+++ b/src/__tests__/renderer/hooks/batch/useAutoRunHandlers.worktree.test.ts
@@ -774,6 +774,59 @@ describe('handleStartBatchRun — worktree dispatch integration', () => {
 			expect(deps.startBatchRun).toHaveBeenCalledOnce();
 			expect(deps.startBatchRun.mock.calls[0][0]).toBe('wt-existing');
 		});
+
+		it('reuses existing session when paths differ only by trailing slash / duplicate separators', async () => {
+			const session = createMockSession();
+			const deps = createMockDeps();
+
+			// Open child session has a trailing slash + duplicate separator that
+			// raw equality wouldn't match against the resolved existingPath.
+			const existingChild = {
+				...session,
+				id: 'wt-existing',
+				cwd: '/projects/other//feat/',
+				worktreeBranch: 'feat',
+				parentSessionId: session.id,
+			};
+			useSessionStore.setState({
+				sessions: [session, existingChild as any],
+				activeSessionId: session.id,
+			} as any);
+
+			vi.mocked(window.maestro.git.worktreeSetup).mockResolvedValue({
+				success: true,
+				created: false,
+				alreadyExisted: true,
+				existingPath: '/projects/other/feat',
+				currentBranch: 'feat',
+				requestedBranch: 'feat',
+				branchMismatch: false,
+			});
+			vi.mocked(gitService.getBranches).mockResolvedValue(['main']);
+
+			const config: BatchRunConfig = {
+				documents: baseDocuments,
+				prompt: 'Go',
+				loopEnabled: false,
+				worktreeTarget: {
+					mode: 'create-new',
+					newBranchName: 'feat',
+					baseBranch: 'main',
+					createPROnCompletion: false,
+				},
+			};
+
+			const { result } = renderHook(() => useAutoRunHandlers(session, deps));
+
+			await act(async () => {
+				await result.current.handleStartBatchRun(config);
+			});
+
+			// Normalized comparison should find the existing session — no duplicate.
+			expect(useSessionStore.getState().sessions.length).toBe(2);
+			expect(deps.startBatchRun).toHaveBeenCalledOnce();
+			expect(deps.startBatchRun.mock.calls[0][0]).toBe('wt-existing');
+		});
 	});
 
 	// -----------------------------------------------------------------------

--- a/src/__tests__/renderer/hooks/useWorktreeHandlers.test.ts
+++ b/src/__tests__/renderer/hooks/useWorktreeHandlers.test.ts
@@ -666,6 +666,80 @@ describe('handleCreateWorktreeFromConfig', () => {
 			})
 		);
 	});
+
+	it('opens existing worktree path when branch is already attached elsewhere', async () => {
+		useSessionStore.setState({
+			sessions: [mockParentSession],
+			activeSessionId: 'parent-1',
+		} as any);
+
+		mockGit.worktreeSetup.mockResolvedValueOnce({
+			success: true,
+			created: false,
+			alreadyExisted: true,
+			existingPath: '/projects/other/feature-new',
+			currentBranch: 'feature-new',
+			requestedBranch: 'feature-new',
+			branchMismatch: false,
+		});
+
+		const { result } = renderHook(() => useWorktreeHandlers());
+
+		await act(async () => {
+			await result.current.handleCreateWorktreeFromConfig('feature-new', '/projects/worktrees');
+		});
+
+		const sessions = useSessionStore.getState().sessions;
+		const created = sessions.find((s) => s.worktreeBranch === 'feature-new');
+		expect(created).toBeDefined();
+		// Session must point at the resolved existing path, not the requested one
+		expect(created?.cwd).toBe('/projects/other/feature-new');
+		expect(notifyToast).toHaveBeenCalledWith(
+			expect.objectContaining({
+				type: 'info',
+				title: 'Worktree Already Existed',
+			})
+		);
+	});
+
+	it('focuses existing session and skips duplicate when branch is already open in Maestro', async () => {
+		const existingChild = createChildSession({
+			id: 'child-existing',
+			cwd: '/projects/other/feature-new',
+			worktreeBranch: 'feature-new',
+		});
+
+		useSessionStore.setState({
+			sessions: [mockParentSession, existingChild],
+			activeSessionId: 'parent-1',
+		} as any);
+
+		mockGit.worktreeSetup.mockResolvedValueOnce({
+			success: true,
+			created: false,
+			alreadyExisted: true,
+			existingPath: '/projects/other/feature-new',
+			currentBranch: 'feature-new',
+			requestedBranch: 'feature-new',
+			branchMismatch: false,
+		});
+
+		const { result } = renderHook(() => useWorktreeHandlers());
+
+		await act(async () => {
+			await result.current.handleCreateWorktreeFromConfig('feature-new', '/projects/worktrees');
+		});
+
+		// No new session was added — count stays at 2
+		expect(useSessionStore.getState().sessions.length).toBe(2);
+		expect(useSessionStore.getState().activeSessionId).toBe('child-existing');
+		expect(notifyToast).toHaveBeenCalledWith(
+			expect.objectContaining({
+				type: 'info',
+				title: 'Worktree Already Open',
+			})
+		);
+	});
 });
 
 // ============================================================================

--- a/src/__tests__/renderer/hooks/useWorktreeHandlers.test.ts
+++ b/src/__tests__/renderer/hooks/useWorktreeHandlers.test.ts
@@ -740,6 +740,48 @@ describe('handleCreateWorktreeFromConfig', () => {
 			})
 		);
 	});
+
+	it('focuses existing session via projectRoot match even when cwd has drifted into a subdir', async () => {
+		// Child session has navigated into a subdirectory of the worktree.
+		// The recovery flow must still detect the open session via projectRoot,
+		// not cwd, otherwise it builds a duplicate session for the same worktree.
+		const existingChild = createChildSession({
+			id: 'child-drifted',
+			cwd: '/projects/other/feature-new/src/components',
+			projectRoot: '/projects/other/feature-new',
+			worktreeBranch: 'feature-new',
+		});
+
+		useSessionStore.setState({
+			sessions: [mockParentSession, existingChild],
+			activeSessionId: 'parent-1',
+		} as any);
+
+		mockGit.worktreeSetup.mockResolvedValueOnce({
+			success: true,
+			created: false,
+			alreadyExisted: true,
+			existingPath: '/projects/other/feature-new',
+			currentBranch: 'feature-new',
+			requestedBranch: 'feature-new',
+			branchMismatch: false,
+		});
+
+		const { result } = renderHook(() => useWorktreeHandlers());
+
+		await act(async () => {
+			await result.current.handleCreateWorktreeFromConfig('feature-new', '/projects/worktrees');
+		});
+
+		expect(useSessionStore.getState().sessions.length).toBe(2);
+		expect(useSessionStore.getState().activeSessionId).toBe('child-drifted');
+		expect(notifyToast).toHaveBeenCalledWith(
+			expect.objectContaining({
+				type: 'info',
+				title: 'Worktree Already Open',
+			})
+		);
+	});
 });
 
 // ============================================================================

--- a/src/__tests__/shared/gitUtils.test.ts
+++ b/src/__tests__/shared/gitUtils.test.ts
@@ -13,6 +13,8 @@ import {
 	remoteUrlToBrowserUrl,
 	isImageFile,
 	getImageMimeType,
+	isWorktreeAlreadyUsedError,
+	parseWorktreePathForBranch,
 } from '../../shared/gitUtils';
 
 describe('gitUtils', () => {
@@ -307,6 +309,78 @@ describe('gitUtils', () => {
 			expect(getImageMimeType('webp')).toBe('image/webp');
 			expect(getImageMimeType('ico')).toBe('image/ico');
 			expect(getImageMimeType('bmp')).toBe('image/bmp');
+		});
+	});
+
+	describe('isWorktreeAlreadyUsedError', () => {
+		it('detects modern git "already checked out" message', () => {
+			expect(
+				isWorktreeAlreadyUsedError(
+					"fatal: 'fix/files-panel-polish' is already checked out at '/home/chris/code/wt/fix/files-panel-polish'"
+				)
+			).toBe(true);
+		});
+
+		it('detects legacy "already used by worktree" message', () => {
+			expect(
+				isWorktreeAlreadyUsedError(
+					"fatal: 'main' is already used by worktree at '/home/chris/code/repo'"
+				)
+			).toBe(true);
+		});
+
+		it('is case insensitive', () => {
+			expect(isWorktreeAlreadyUsedError("FATAL: 'b' IS ALREADY CHECKED OUT AT '/x'")).toBe(true);
+		});
+
+		it('returns false for unrelated errors', () => {
+			expect(isWorktreeAlreadyUsedError('fatal: not a git repository')).toBe(false);
+			expect(isWorktreeAlreadyUsedError("fatal: '/x' already exists")).toBe(false);
+			expect(isWorktreeAlreadyUsedError('')).toBe(false);
+		});
+	});
+
+	describe('parseWorktreePathForBranch', () => {
+		const sample = [
+			'worktree /home/chris/code/repo',
+			'HEAD abc123',
+			'branch refs/heads/main',
+			'',
+			'worktree /home/chris/code/wt/fix/files-panel-polish',
+			'HEAD def456',
+			'branch refs/heads/fix/files-panel-polish',
+			'',
+			'worktree /home/chris/code/wt/detached',
+			'HEAD 789abc',
+			'detached',
+		].join('\n');
+
+		it('returns the worktree path for a matching branch', () => {
+			expect(parseWorktreePathForBranch(sample, 'fix/files-panel-polish')).toBe(
+				'/home/chris/code/wt/fix/files-panel-polish'
+			);
+		});
+
+		it('returns the worktree path for the main repo branch', () => {
+			expect(parseWorktreePathForBranch(sample, 'main')).toBe('/home/chris/code/repo');
+		});
+
+		it('returns null when the branch is not found', () => {
+			expect(parseWorktreePathForBranch(sample, 'nope')).toBeNull();
+		});
+
+		it('skips detached worktrees', () => {
+			expect(parseWorktreePathForBranch(sample, 'detached')).toBeNull();
+		});
+
+		it('handles CRLF line endings', () => {
+			const crlf = sample.replace(/\n/g, '\r\n');
+			expect(parseWorktreePathForBranch(crlf, 'main')).toBe('/home/chris/code/repo');
+		});
+
+		it('returns null for empty input', () => {
+			expect(parseWorktreePathForBranch('', 'main')).toBeNull();
+			expect(parseWorktreePathForBranch(sample, '')).toBeNull();
 		});
 	});
 });

--- a/src/main/ipc/handlers/git.ts
+++ b/src/main/ipc/handlers/git.ts
@@ -22,6 +22,8 @@ import {
 	countUncommittedChanges,
 	isImageFile,
 	getImageMimeType,
+	isWorktreeAlreadyUsedError,
+	parseWorktreePathForBranch,
 } from '../../../shared/gitUtils';
 import {
 	worktreeInfoRemote,
@@ -58,6 +60,27 @@ const handlerOpts = (operation: string, logSuccess = false): CreateHandlerOption
 	operation,
 	logSuccess,
 });
+
+/**
+ * Look up the worktree path currently checked out on the given branch
+ * by running `git worktree list --porcelain` against the local repo.
+ *
+ * Used to recover from `git worktree add` failures with the "already used /
+ * already checked out" error: instead of bubbling up an opaque error, we
+ * return the existing worktree path so callers can open it as a session.
+ *
+ * @returns Absolute worktree path, or null if not found
+ */
+async function findLocalWorktreeForBranch(
+	mainRepoCwd: string,
+	branchName: string
+): Promise<string | null> {
+	const result = await execFileNoThrow('git', ['worktree', 'list', '--porcelain'], mainRepoCwd);
+	if (result.exitCode !== 0) return null;
+	return parseWorktreePathForBranch(result.stdout, branchName);
+}
+
+const isAlreadyUsedError = isWorktreeAlreadyUsedError;
 
 /**
  * Register all Git-related IPC handlers.
@@ -680,6 +703,24 @@ export function registerGitHandlers(_deps: GitHandlerDependencies): void {
 				}
 
 				if (createResult.exitCode !== 0) {
+					// Recover from "already used / already checked out" — the branch is
+					// already registered with another worktree on disk. Resolve that path
+					// from `git worktree list --porcelain` so the caller can open it.
+					const errMsg = createResult.stderr || '';
+					if (isAlreadyUsedError(errMsg)) {
+						const existingPath = await findLocalWorktreeForBranch(mainRepoCwd, branchName);
+						if (existingPath) {
+							return {
+								success: true,
+								created: false,
+								alreadyExisted: true,
+								existingPath,
+								currentBranch: branchName,
+								requestedBranch: branchName,
+								branchMismatch: false,
+							};
+						}
+					}
 					return { success: false, error: createResult.stderr || 'Failed to create worktree' };
 				}
 

--- a/src/main/ipc/handlers/git.ts
+++ b/src/main/ipc/handlers/git.ts
@@ -91,8 +91,6 @@ async function findLocalWorktreeForBranch(
 	}
 }
 
-const isAlreadyUsedError = isWorktreeAlreadyUsedError;
-
 /**
  * Register all Git-related IPC handlers.
  *
@@ -718,7 +716,7 @@ export function registerGitHandlers(_deps: GitHandlerDependencies): void {
 					// already registered with another worktree on disk. Resolve that path
 					// from `git worktree list --porcelain` so the caller can open it.
 					const errMsg = createResult.stderr || '';
-					if (isAlreadyUsedError(errMsg)) {
+					if (isWorktreeAlreadyUsedError(errMsg)) {
 						const existingPath = await findLocalWorktreeForBranch(mainRepoCwd, branchName);
 						if (existingPath) {
 							return {

--- a/src/main/ipc/handlers/git.ts
+++ b/src/main/ipc/handlers/git.ts
@@ -69,7 +69,11 @@ const handlerOpts = (operation: string, logSuccess = false): CreateHandlerOption
  * already checked out" error: instead of bubbling up an opaque error, we
  * return the existing worktree path so callers can open it as a session.
  *
- * @returns Absolute worktree path, or null if not found
+ * Stale registrations (where the directory was deleted manually without
+ * `git worktree prune`) are filtered out by an `fs.access` check so callers
+ * never get a path that points at nothing.
+ *
+ * @returns Absolute worktree path, or null if not found / stale
  */
 async function findLocalWorktreeForBranch(
 	mainRepoCwd: string,
@@ -77,7 +81,14 @@ async function findLocalWorktreeForBranch(
 ): Promise<string | null> {
 	const result = await execFileNoThrow('git', ['worktree', 'list', '--porcelain'], mainRepoCwd);
 	if (result.exitCode !== 0) return null;
-	return parseWorktreePathForBranch(result.stdout, branchName);
+	const existingPath = parseWorktreePathForBranch(result.stdout, branchName);
+	if (!existingPath) return null;
+	try {
+		await fs.access(existingPath);
+		return existingPath;
+	} catch {
+		return null;
+	}
 }
 
 const isAlreadyUsedError = isWorktreeAlreadyUsedError;

--- a/src/main/preload/git.ts
+++ b/src/main/preload/git.ts
@@ -237,6 +237,10 @@ export function createGitApi() {
 			currentBranch?: string;
 			requestedBranch?: string;
 			branchMismatch?: boolean;
+			/** True when the branch was already attached to a worktree on disk. */
+			alreadyExisted?: boolean;
+			/** Path of the existing worktree when alreadyExisted is true. */
+			existingPath?: string;
 			error?: string;
 		}> =>
 			ipcRenderer.invoke('git:worktreeSetup', mainRepoCwd, worktreePath, branchName, sshRemoteId),

--- a/src/main/preload/git.ts
+++ b/src/main/preload/git.ts
@@ -77,6 +77,37 @@ export interface WorktreeRemovedData {
 }
 
 /**
+ * Result of the `git.worktreeSetup` IPC.
+ *
+ * Shared between the preload bridge and the renderer global declaration so
+ * the contract stays in one place.
+ *
+ * Named `GitWorktreeSetupResult` to avoid colliding with the higher-level
+ * `WorktreeSetupResult` exported from `renderer/hooks/batch/useWorktreeManager`.
+ */
+export interface GitWorktreeSetupResult {
+	success: boolean;
+	created?: boolean;
+	currentBranch?: string;
+	requestedBranch?: string;
+	branchMismatch?: boolean;
+	/** True when the branch was already attached to a worktree on disk. */
+	alreadyExisted?: boolean;
+	/** Path of the existing worktree when alreadyExisted is true. */
+	existingPath?: string;
+	error?: string;
+}
+
+/**
+ * Result of the `git.worktreeCheckout` IPC.
+ */
+export interface GitWorktreeCheckoutResult {
+	success: boolean;
+	hasUncommittedChanges: boolean;
+	error?: string;
+}
+
+/**
  * Creates the git API object for preload exposure
  */
 export function createGitApi() {
@@ -231,18 +262,7 @@ export function createGitApi() {
 			worktreePath: string,
 			branchName: string,
 			sshRemoteId?: string
-		): Promise<{
-			success: boolean;
-			created?: boolean;
-			currentBranch?: string;
-			requestedBranch?: string;
-			branchMismatch?: boolean;
-			/** True when the branch was already attached to a worktree on disk. */
-			alreadyExisted?: boolean;
-			/** Path of the existing worktree when alreadyExisted is true. */
-			existingPath?: string;
-			error?: string;
-		}> =>
+		): Promise<GitWorktreeSetupResult> =>
 			ipcRenderer.invoke('git:worktreeSetup', mainRepoCwd, worktreePath, branchName, sshRemoteId),
 
 		/**
@@ -253,11 +273,7 @@ export function createGitApi() {
 			branchName: string,
 			createIfMissing: boolean,
 			sshRemoteId?: string
-		): Promise<{
-			success: boolean;
-			hasUncommittedChanges: boolean;
-			error?: string;
-		}> =>
+		): Promise<GitWorktreeCheckoutResult> =>
 			ipcRenderer.invoke(
 				'git:worktreeCheckout',
 				worktreePath,

--- a/src/main/utils/remote-git.ts
+++ b/src/main/utils/remote-git.ts
@@ -12,6 +12,7 @@ import { SshRemoteConfig } from '../../shared/types';
 import { execFileNoThrow, ExecResult } from './execFile';
 import { buildSshCommand, RemoteCommandOptions } from './ssh-command-builder';
 import { logger } from './logger';
+import { isWorktreeAlreadyUsedError, parseWorktreePathForBranch } from '../../shared/gitUtils';
 
 const LOG_CONTEXT = '[RemoteGit]';
 
@@ -268,6 +269,29 @@ export interface RemoteWorktreeSetupResult extends Record<string, unknown> {
 	currentBranch?: string;
 	requestedBranch?: string;
 	branchMismatch?: boolean;
+	/** True when the branch was already attached to a worktree on disk. */
+	alreadyExisted?: boolean;
+	/** Path of the existing worktree when alreadyExisted is true. */
+	existingPath?: string;
+}
+
+/**
+ * Look up the worktree path currently checked out on the given branch by
+ * running `git worktree list --porcelain` against the remote main repo.
+ *
+ * @returns Absolute worktree path on the remote, or null if not found
+ */
+async function findRemoteWorktreeForBranch(
+	mainRepoCwd: string,
+	branchName: string,
+	sshRemote: SshRemoteConfig
+): Promise<string | null> {
+	const result = await execGitRemote(['worktree', 'list', '--porcelain'], {
+		sshRemote,
+		remoteCwd: mainRepoCwd,
+	});
+	if (result.exitCode !== 0) return null;
+	return parseWorktreePathForBranch(result.stdout, branchName);
 }
 
 /**
@@ -428,6 +452,27 @@ export async function worktreeSetupRemote(
 	}
 
 	if (createResult.exitCode !== 0) {
+		// Recover from "already used / already checked out" — the branch is
+		// attached to another worktree on the remote. Resolve that path so
+		// callers can open it instead of surfacing an opaque error.
+		const errMsg = createResult.stderr || '';
+		if (isWorktreeAlreadyUsedError(errMsg)) {
+			const existingPath = await findRemoteWorktreeForBranch(mainRepoCwd, branchName, sshRemote);
+			if (existingPath) {
+				return {
+					success: true,
+					data: {
+						success: true,
+						created: false,
+						alreadyExisted: true,
+						existingPath,
+						currentBranch: branchName,
+						requestedBranch: branchName,
+						branchMismatch: false,
+					},
+				};
+			}
+		}
 		return {
 			success: true,
 			data: {

--- a/src/main/utils/remote-git.ts
+++ b/src/main/utils/remote-git.ts
@@ -279,7 +279,11 @@ export interface RemoteWorktreeSetupResult extends Record<string, unknown> {
  * Look up the worktree path currently checked out on the given branch by
  * running `git worktree list --porcelain` against the remote main repo.
  *
- * @returns Absolute worktree path on the remote, or null if not found
+ * Stale registrations (where the directory was removed manually without
+ * `git worktree prune`) are filtered out by a `test -d` check on the remote
+ * so callers never get a path that points at nothing.
+ *
+ * @returns Absolute worktree path on the remote, or null if not found / stale
  */
 async function findRemoteWorktreeForBranch(
 	mainRepoCwd: string,
@@ -291,7 +295,16 @@ async function findRemoteWorktreeForBranch(
 		remoteCwd: mainRepoCwd,
 	});
 	if (result.exitCode !== 0) return null;
-	return parseWorktreePathForBranch(result.stdout, branchName);
+	const existingPath = parseWorktreePathForBranch(result.stdout, branchName);
+	if (!existingPath) return null;
+	const existsResult = await execRemoteShellCommand(
+		`test -d '${existingPath}' && echo EXISTS || echo MISSING`,
+		sshRemote
+	);
+	if (existsResult.exitCode !== 0 || !existsResult.stdout.includes('EXISTS')) {
+		return null;
+	}
+	return existingPath;
 }
 
 /**
@@ -458,6 +471,10 @@ export async function worktreeSetupRemote(
 		const errMsg = createResult.stderr || '';
 		if (isWorktreeAlreadyUsedError(errMsg)) {
 			const existingPath = await findRemoteWorktreeForBranch(mainRepoCwd, branchName, sshRemote);
+			logger.debug(
+				`Worktree-already-used recovery: branch=${branchName} host=${sshRemote.host} existingPath=${existingPath ?? '<none>'}`,
+				LOG_CONTEXT
+			);
 			if (existingPath) {
 				return {
 					success: true,

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -666,6 +666,10 @@ interface MaestroAPI {
 			currentBranch?: string;
 			requestedBranch?: string;
 			branchMismatch?: boolean;
+			/** True when the branch was already attached to a worktree on disk. */
+			alreadyExisted?: boolean;
+			/** Path of the existing worktree when alreadyExisted is true. */
+			existingPath?: string;
 			error?: string;
 		}>;
 		worktreeCheckout: (

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -152,6 +152,7 @@ type GroupChatData = {
 import type { CueGraphSession, CueRunResult, CueSessionStatus, CueSettings } from '../shared/cue';
 import type { CueLogPayload } from '../shared/cue-log-types';
 import type { MaestroCliStatus, MaestroCliInstallResult } from '../shared/maestro-cli';
+import type { GitWorktreeSetupResult, GitWorktreeCheckoutResult } from '../main/preload/git';
 
 interface MaestroAPI {
 	// Context merging API (for session context transfer and grooming)
@@ -660,28 +661,13 @@ interface MaestroAPI {
 			worktreePath: string,
 			branchName: string,
 			sshRemoteId?: string
-		) => Promise<{
-			success: boolean;
-			created?: boolean;
-			currentBranch?: string;
-			requestedBranch?: string;
-			branchMismatch?: boolean;
-			/** True when the branch was already attached to a worktree on disk. */
-			alreadyExisted?: boolean;
-			/** Path of the existing worktree when alreadyExisted is true. */
-			existingPath?: string;
-			error?: string;
-		}>;
+		) => Promise<GitWorktreeSetupResult>;
 		worktreeCheckout: (
 			worktreePath: string,
 			branchName: string,
 			createIfMissing: boolean,
 			sshRemoteId?: string
-		) => Promise<{
-			success: boolean;
-			hasUncommittedChanges: boolean;
-			error?: string;
-		}>;
+		) => Promise<GitWorktreeCheckoutResult>;
 		createPR: (
 			worktreePath: string,
 			baseBranch: string,

--- a/src/renderer/hooks/batch/useAutoRunHandlers.ts
+++ b/src/renderer/hooks/batch/useAutoRunHandlers.ts
@@ -19,6 +19,20 @@ function normalizePath(p: string): string {
 }
 
 /**
+ * Match a session against a worktree root path. We check both `projectRoot`
+ * (the stable worktree root captured at session creation) and `cwd` (which
+ * may drift if the user `cd`s into a subdirectory of the worktree). Without
+ * the projectRoot fallback, a child session that has navigated into a subdir
+ * is missed and the recovery flow builds a duplicate session for the same
+ * worktree.
+ */
+function sessionMatchesWorktreeRoot(session: Session, normalizedRoot: string): boolean {
+	if (session.projectRoot && normalizePath(session.projectRoot) === normalizedRoot) return true;
+	if (session.cwd && normalizePath(session.cwd) === normalizedRoot) return true;
+	return false;
+}
+
+/**
  * Tree node structure for Auto Run document tree
  */
 export interface AutoRunTreeNode {
@@ -169,7 +183,7 @@ async function spawnWorktreeAgentAndDispatch(
 	const normalizedWorktreePath = normalizePath(worktreePath);
 	const existingSession = useSessionStore
 		.getState()
-		.sessions.find((s) => normalizePath(s.cwd) === normalizedWorktreePath);
+		.sessions.find((s) => sessionMatchesWorktreeRoot(s, normalizedWorktreePath));
 
 	// Step 3: Fetch git info for the worktree
 	let gitBranches: string[] | undefined;

--- a/src/renderer/hooks/batch/useAutoRunHandlers.ts
+++ b/src/renderer/hooks/batch/useAutoRunHandlers.ts
@@ -139,11 +139,29 @@ async function spawnWorktreeAgentAndDispatch(
 			});
 			return null;
 		}
+		// If the branch was already attached to another worktree on disk, the main
+		// process resolved its path and returned it. Open that worktree instead of
+		// the requested path so the user isn't blocked by a stale registration.
+		if (result.alreadyExisted && result.existingPath) {
+			clearRecentlyCreatedWorktreePath(worktreePath);
+			worktreePath = result.existingPath;
+			notifyToast({
+				type: 'info',
+				title: 'Worktree Already Existed',
+				message: `Opened existing worktree at ${worktreePath}`,
+			});
+		}
 	} else {
 		// existing-closed: worktree already on disk
 		worktreePath = target.worktreePath!;
 		branchName = worktreePath.split('/').pop() || 'worktree';
 	}
+
+	// If a session for this worktree path already exists (e.g., the resolved
+	// existing worktree is already open in Maestro), reuse it instead of
+	// building a duplicate. We still fall through to populate config.worktree
+	// below so PR creation continues to work.
+	const existingSession = useSessionStore.getState().sessions.find((s) => s.cwd === worktreePath);
 
 	// Step 3: Fetch git info for the worktree
 	let gitBranches: string[] | undefined;
@@ -159,25 +177,31 @@ async function spawnWorktreeAgentAndDispatch(
 		branchName = gitBranches[0];
 	}
 
-	// Step 4: Build the session
-	const { defaultSaveToHistory, defaultShowThinking } = useSettingsStore.getState();
-	const newSession = buildWorktreeSession({
-		parentSession,
-		path: worktreePath,
-		branch: branchName,
-		name: branchName,
-		gitBranches,
-		defaultSaveToHistory,
-		defaultShowThinking,
-	});
+	let dispatchSessionId: string;
+	if (existingSession) {
+		dispatchSessionId = existingSession.id;
+	} else {
+		// Step 4: Build the session
+		const { defaultSaveToHistory, defaultShowThinking } = useSettingsStore.getState();
+		const newSession = buildWorktreeSession({
+			parentSession,
+			path: worktreePath,
+			branch: branchName,
+			name: branchName,
+			gitBranches,
+			defaultSaveToHistory,
+			defaultShowThinking,
+		});
 
-	// Step 5: Add session to store and expand parent's worktrees
-	useSessionStore
-		.getState()
-		.setSessions((prev) => [
-			...prev.map((s) => (s.id === parentSession.id ? { ...s, worktreesExpanded: true } : s)),
-			newSession,
-		]);
+		// Step 5: Add session to store and expand parent's worktrees
+		useSessionStore
+			.getState()
+			.setSessions((prev) => [
+				...prev.map((s) => (s.id === parentSession.id ? { ...s, worktreesExpanded: true } : s)),
+				newSession,
+			]);
+		dispatchSessionId = newSession.id;
+	}
 
 	// Step 6: Populate config.worktree for PR creation if requested
 	if (target.createPROnCompletion) {
@@ -190,7 +214,7 @@ async function spawnWorktreeAgentAndDispatch(
 		};
 	}
 
-	return newSession.id;
+	return dispatchSessionId;
 }
 
 /**

--- a/src/renderer/hooks/batch/useAutoRunHandlers.ts
+++ b/src/renderer/hooks/batch/useAutoRunHandlers.ts
@@ -201,6 +201,18 @@ async function spawnWorktreeAgentAndDispatch(
 
 	let dispatchSessionId: string;
 	if (existingSession) {
+		// Mirror the existing-open guard (handleStartBatchRun line ~392): refuse
+		// to dispatch onto an in-flight agent. Without this, a recovery into a
+		// busy worktree session silently queues the batch on top of an active
+		// run.
+		if (existingSession.state === 'busy' || existingSession.state === 'connecting') {
+			notifyToast({
+				type: 'warning',
+				title: 'Target Agent Busy',
+				message: 'Existing worktree agent is busy. Please try again.',
+			});
+			return null;
+		}
 		dispatchSessionId = existingSession.id;
 	} else {
 		// Step 4: Build the session

--- a/src/renderer/hooks/batch/useAutoRunHandlers.ts
+++ b/src/renderer/hooks/batch/useAutoRunHandlers.ts
@@ -13,6 +13,11 @@ import { captureException } from '../../utils/sentry';
 import { countMarkdownTasks } from './batchUtils';
 import { logger } from '../../utils/logger';
 
+/** Normalize file path for comparison: convert backslashes to forward slashes, collapse duplicate slashes, and remove trailing slash. */
+function normalizePath(p: string): string {
+	return p.replace(/\\/g, '/').replace(/\/+/g, '/').replace(/\/$/, '');
+}
+
 /**
  * Tree node structure for Auto Run document tree
  */
@@ -161,7 +166,10 @@ async function spawnWorktreeAgentAndDispatch(
 	// existing worktree is already open in Maestro), reuse it instead of
 	// building a duplicate. We still fall through to populate config.worktree
 	// below so PR creation continues to work.
-	const existingSession = useSessionStore.getState().sessions.find((s) => s.cwd === worktreePath);
+	const normalizedWorktreePath = normalizePath(worktreePath);
+	const existingSession = useSessionStore
+		.getState()
+		.sessions.find((s) => normalizePath(s.cwd) === normalizedWorktreePath);
 
 	// Step 3: Fetch git info for the worktree
 	let gitBranches: string[] | undefined;

--- a/src/renderer/hooks/worktree/useWorktreeHandlers.ts
+++ b/src/renderer/hooks/worktree/useWorktreeHandlers.ts
@@ -324,12 +324,41 @@ export function useWorktreeHandlers(): WorktreeHandlersReturn {
 					throw new Error(result.error || 'Failed to create worktree');
 				}
 
+				// If the branch was already attached to another worktree on disk,
+				// open that existing path instead of failing the user's flow.
+				const actualPath = result.existingPath || worktreePath;
+				const reusedExisting = !!result.alreadyExisted && !!result.existingPath;
+
+				// If we ended up using a different path, drop the original mark and
+				// avoid re-marking — there was nothing newly created on disk to race with.
+				if (reusedExisting) {
+					recentlyCreatedWorktreePathsRef.current.delete(normalizedCreatedPath);
+				}
+
 				// Fetch git info for the worktree (pass SSH remote ID for remote sessions)
-				const gitInfo = await fetchGitInfo(worktreePath, sshRemoteId);
+				const gitInfo = await fetchGitInfo(actualPath, sshRemoteId);
+
+				// If a session for the existing worktree path already exists, focus it
+				// and skip the duplicate creation.
+				if (reusedExisting) {
+					const normalizedActual = normalizePath(actualPath);
+					const existingSession = useSessionStore
+						.getState()
+						.sessions.find((s) => normalizePath(s.cwd) === normalizedActual);
+					if (existingSession) {
+						useSessionStore.getState().setActiveSessionId(existingSession.id);
+						notifyToast({
+							type: 'info',
+							title: 'Worktree Already Open',
+							message: branchName,
+						});
+						return;
+					}
+				}
 
 				const worktreeSession = buildWorktreeSession({
 					parentSession: activeSession,
-					path: worktreePath,
+					path: actualPath,
 					branch: branchName,
 					name: branchName,
 					defaultSaveToHistory: savToHist,
@@ -349,9 +378,9 @@ export function useWorktreeHandlers(): WorktreeHandlersReturn {
 				useSessionStore.getState().setActiveSessionId(worktreeSession.id);
 
 				notifyToast({
-					type: 'success',
-					title: 'Worktree Created',
-					message: branchName,
+					type: reusedExisting ? 'info' : 'success',
+					title: reusedExisting ? 'Worktree Already Existed' : 'Worktree Created',
+					message: reusedExisting ? `Opened existing worktree at ${actualPath}` : branchName,
 				});
 			} catch (err) {
 				recentlyCreatedWorktreePathsRef.current.delete(normalizedCreatedPath);
@@ -410,12 +439,39 @@ export function useWorktreeHandlers(): WorktreeHandlersReturn {
 				throw new Error(result.error || 'Failed to create worktree');
 			}
 
+			// If the branch was already attached to another worktree on disk,
+			// open that existing path instead of failing the user's flow.
+			const actualPath = result.existingPath || worktreePath;
+			const reusedExisting = !!result.alreadyExisted && !!result.existingPath;
+
+			if (reusedExisting) {
+				recentlyCreatedWorktreePathsRef.current.delete(normalizedCreatedPath);
+			}
+
+			// If a session for the existing worktree path already exists, focus it
+			// and skip the duplicate creation.
+			if (reusedExisting) {
+				const normalizedActual = normalizePath(actualPath);
+				const existingSession = useSessionStore
+					.getState()
+					.sessions.find((s) => normalizePath(s.cwd) === normalizedActual);
+				if (existingSession) {
+					useSessionStore.getState().setActiveSessionId(existingSession.id);
+					notifyToast({
+						type: 'info',
+						title: 'Worktree Already Open',
+						message: branchName,
+					});
+					return;
+				}
+			}
+
 			// Fetch git info for the worktree (pass SSH remote ID for remote sessions)
-			const gitInfo = await fetchGitInfo(worktreePath, sshRemoteId);
+			const gitInfo = await fetchGitInfo(actualPath, sshRemoteId);
 
 			const worktreeSession = buildWorktreeSession({
 				parentSession: createWtSession,
-				path: worktreePath,
+				path: actualPath,
 				branch: branchName,
 				name: branchName,
 				defaultSaveToHistory: savToHist,
@@ -441,9 +497,9 @@ export function useWorktreeHandlers(): WorktreeHandlersReturn {
 			useSessionStore.getState().setActiveSessionId(worktreeSession.id);
 
 			notifyToast({
-				type: 'success',
-				title: 'Worktree Created',
-				message: branchName,
+				type: reusedExisting ? 'info' : 'success',
+				title: reusedExisting ? 'Worktree Already Existed' : 'Worktree Created',
+				message: reusedExisting ? `Opened existing worktree at ${actualPath}` : branchName,
 			});
 		} catch (err) {
 			recentlyCreatedWorktreePathsRef.current.delete(normalizedCreatedPath);

--- a/src/renderer/hooks/worktree/useWorktreeHandlers.ts
+++ b/src/renderer/hooks/worktree/useWorktreeHandlers.ts
@@ -88,6 +88,20 @@ function normalizePath(p: string): string {
 	return p.replace(/\\/g, '/').replace(/\/+/g, '/').replace(/\/$/, '');
 }
 
+/**
+ * Match a session against a worktree root path. We check both `projectRoot`
+ * (the stable worktree root captured at session creation) and `cwd` (which
+ * may drift if the user `cd`s into a subdirectory of the worktree). Without
+ * the projectRoot fallback, a child session that has navigated into a subdir
+ * is missed and the recovery flow builds a duplicate session for the same
+ * worktree.
+ */
+function sessionMatchesWorktreeRoot(session: Session, normalizedRoot: string): boolean {
+	if (session.projectRoot && normalizePath(session.projectRoot) === normalizedRoot) return true;
+	if (session.cwd && normalizePath(session.cwd) === normalizedRoot) return true;
+	return false;
+}
+
 // buildWorktreeSession and BuildWorktreeSessionParams are imported from ../../utils/worktreeSession
 
 // ============================================================================
@@ -342,7 +356,7 @@ export function useWorktreeHandlers(): WorktreeHandlersReturn {
 					const normalizedActual = normalizePath(actualPath);
 					const existingSession = useSessionStore
 						.getState()
-						.sessions.find((s) => normalizePath(s.cwd) === normalizedActual);
+						.sessions.find((s) => sessionMatchesWorktreeRoot(s, normalizedActual));
 					if (existingSession) {
 						useSessionStore.getState().setActiveSessionId(existingSession.id);
 						notifyToast({
@@ -455,7 +469,7 @@ export function useWorktreeHandlers(): WorktreeHandlersReturn {
 				const normalizedActual = normalizePath(actualPath);
 				const existingSession = useSessionStore
 					.getState()
-					.sessions.find((s) => normalizePath(s.cwd) === normalizedActual);
+					.sessions.find((s) => sessionMatchesWorktreeRoot(s, normalizedActual));
 				if (existingSession) {
 					useSessionStore.getState().setActiveSessionId(existingSession.id);
 					notifyToast({

--- a/src/renderer/hooks/worktree/useWorktreeHandlers.ts
+++ b/src/renderer/hooks/worktree/useWorktreeHandlers.ts
@@ -335,11 +335,9 @@ export function useWorktreeHandlers(): WorktreeHandlersReturn {
 					recentlyCreatedWorktreePathsRef.current.delete(normalizedCreatedPath);
 				}
 
-				// Fetch git info for the worktree (pass SSH remote ID for remote sessions)
-				const gitInfo = await fetchGitInfo(actualPath, sshRemoteId);
-
 				// If a session for the existing worktree path already exists, focus it
-				// and skip the duplicate creation.
+				// and skip the duplicate creation. Done before fetchGitInfo so we don't
+				// pay for an unnecessary git round-trip when there's nothing to build.
 				if (reusedExisting) {
 					const normalizedActual = normalizePath(actualPath);
 					const existingSession = useSessionStore
@@ -355,6 +353,9 @@ export function useWorktreeHandlers(): WorktreeHandlersReturn {
 						return;
 					}
 				}
+
+				// Fetch git info for the worktree (pass SSH remote ID for remote sessions)
+				const gitInfo = await fetchGitInfo(actualPath, sshRemoteId);
 
 				const worktreeSession = buildWorktreeSession({
 					parentSession: activeSession,

--- a/src/shared/gitUtils.ts
+++ b/src/shared/gitUtils.ts
@@ -285,6 +285,59 @@ export function remoteUrlToBrowserUrl(remoteUrl: string): string | null {
 }
 
 /**
+ * Detect git's "branch is already used / already checked out" stderr message
+ * emitted by `git worktree add` when the requested branch is already attached
+ * to another worktree on disk.
+ *
+ * Modern git: `fatal: '<branch>' is already checked out at '<path>'`
+ * Older git:  `fatal: '<branch>' is already used by worktree at '<path>'`
+ *
+ * @param stderr - Raw stderr from `git worktree add`
+ * @returns True if the error indicates the branch is already attached elsewhere
+ */
+export function isWorktreeAlreadyUsedError(stderr: string): boolean {
+	if (!stderr) return false;
+	return /is already (used by worktree|checked out) at/i.test(stderr);
+}
+
+/**
+ * Parse `git worktree list --porcelain` output and return the absolute path
+ * of the worktree currently checked out on the given branch, or null.
+ *
+ * Porcelain blocks look like:
+ *   worktree /abs/path
+ *   HEAD <sha>
+ *   branch refs/heads/<branch>
+ *
+ * Detached worktrees lack a `branch` line and are skipped.
+ *
+ * @param stdout - Raw stdout from `git worktree list --porcelain`
+ * @param branchName - Branch to look up (without refs/heads/ prefix)
+ * @returns Absolute worktree path, or null if no match
+ */
+export function parseWorktreePathForBranch(stdout: string, branchName: string): string | null {
+	if (!stdout || !branchName) return null;
+	const blocks = stdout.split(/\r?\n\r?\n/);
+	for (const block of blocks) {
+		const lines = block.split(/\r?\n/);
+		let wtPath: string | null = null;
+		let branch: string | null = null;
+		for (const line of lines) {
+			if (line.startsWith('worktree ')) {
+				wtPath = line.slice('worktree '.length).trim();
+			} else if (line.startsWith('branch ')) {
+				branch = line
+					.slice('branch '.length)
+					.trim()
+					.replace(/^refs\/heads\//, '');
+			}
+		}
+		if (wtPath && branch === branchName) return wtPath;
+	}
+	return null;
+}
+
+/**
  * Common image file extensions for git file handling
  */
 const GIT_IMAGE_EXTENSIONS = ['png', 'jpg', 'jpeg', 'gif', 'bmp', 'webp', 'svg', 'ico'];


### PR DESCRIPTION
## Summary

When `git worktree add` fails because the branch is already attached to another worktree on disk (e.g., a stale registration that survives disk/UI cleanup), Maestro currently surfaces an opaque \"Failed to Create Worktree\" toast and there's no path to recover. This change resolves the existing worktree path via `git worktree list --porcelain` and opens it as a session instead, with a clear \"Worktree Already Existed\" toast.

- Detects the \"already used / already checked out\" stderr in `worktreeSetup` (local + SSH) and resolves the existing path from porcelain output.
- Threads `alreadyExisted` / `existingPath` through the IPC result type (`preload/git.ts`, `renderer/global.d.ts`).
- Renderer flows (`handleCreateWorktreeFromConfig`, `handleCreateWorktree`, Auto Run `spawnWorktreeAgentAndDispatch`) open or focus the resolved worktree, reusing an already-open child session when one matches and keeping `createPROnCompletion` config intact.

## Behavior

| Scenario | Before | After |
|---|---|---|
| User clicks Create New Worktree, branch already attached at another path | \"Failed to Create Worktree\" toast, blocked | Session opened against the existing path with info toast |
| Existing worktree already open as a child session | \"Failed to Create Worktree\" toast | Existing session focused, no duplicate created |
| Unrelated `git worktree add` failure (permission, etc.) | Error toast | Error toast (unchanged — porcelain lookup is skipped) |

## Test plan

- [x] `npx vitest run` for: `shared/gitUtils.test.ts`, `main/ipc/handlers/git.test.ts`, `main/utils/remote-git.test.ts`, `renderer/hooks/useWorktreeHandlers.test.ts`, `renderer/hooks/batch/useAutoRunHandlers.worktree.test.ts`, `renderer/hooks/useAutoRunHandlers.test.ts`, `main/preload/git.test.ts` — 426 passing.
- [x] New tests cover: porcelain parser (CRLF, detached worktrees, multiple branches), \"already used\" detection (modern + legacy + case-insensitive), local + SSH alreadyExisted recovery, porcelain miss falls through to error toast, unrelated git failures don't trigger porcelain lookup, renderer paths build sessions against `existingPath`, dedup against an already-open session.
- [x] `npm run lint` — 0 new TypeScript errors in changed files (the 34 pre-existing `@xterm/*` / `js-yaml` errors also exist on `main` and are unrelated).
- [x] Prettier check clean across all changed files.
- [x] Manual: in a repo with a stale worktree registration, open Create New Worktree with that branch name and confirm the existing worktree opens as a session.

## Notes

The companion bug \"all worktree children disappear after app restart\" was investigated but is out of scope here — it likely lives in `useWorktreeHandlers.scanWorktreeConfigs` stale-removal logic (`useWorktreeHandlers.ts:545-553`) when the parent's `worktreeConfig.basePath` is missing/mismatched. Tracking separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery when creating a worktree already checked out elsewhere (local or remote): the app can reuse the existing worktree and avoid surfacing failures.
  * Ignored stale worktree locations to prevent incorrect recovery.

* **New Features**
  * Prevent duplicate sessions by detecting and reusing already-open worktree-backed sessions.
  * Added info toasts: “Worktree Already Existed” and “Worktree Already Open”.

* **Chores**
  * Standardized API return shapes for worktree operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->