### PR TITLE
feat(cli): add `dispatch` command, deprecate `send --live` (PR1)

### DIFF
--- a/src/__tests__/cli/commands/dispatch.test.ts
+++ b/src/__tests__/cli/commands/dispatch.test.ts
@@ -117,6 +117,41 @@ describe('dispatch command', () => {
 			expect(output.tabId).toBe('tab-fresh-42');
 			expect(output.sessionId).toBe('tab-fresh-42');
 		});
+
+		it('emits NEW_TAB_NO_ID when the desktop acks --new-tab without a tabId', async () => {
+			// --new-tab's contract is to surface a fresh tab id for chaining.
+			// If the desktop omits it (older build / race), we must fail loudly
+			// with a dedicated code rather than returning `tabId: null` from a
+			// "successful" response — downstream consumers (Maestro-Discord,
+			// Cue) need to distinguish this from a generic command failure.
+			vi.mocked(resolveAgentId).mockReturnValue('agent-abc-123');
+			const mockSendCommand = vi.fn().mockResolvedValue({
+				type: 'new_ai_tab_with_prompt_result',
+				success: true,
+			});
+			vi.mocked(withMaestroClient).mockImplementation(async (action) => {
+				const mockClient = { sendCommand: mockSendCommand };
+				return action(mockClient as never);
+			});
+
+			await dispatch('agent-abc', 'Open a new conversation', { newTab: true });
+
+			const output = JSON.parse(consoleSpy.mock.calls[0][0]);
+			expect(output.success).toBe(false);
+			expect(output.code).toBe('NEW_TAB_NO_ID');
+			expect(processExitSpy).toHaveBeenCalledWith(1);
+		});
+
+		it('rejects --new-tab combined with --force as INVALID_OPTIONS (a new tab is never busy)', async () => {
+			await dispatch('agent-abc', 'Hello', { newTab: true, force: true });
+
+			const output = JSON.parse(consoleSpy.mock.calls[0][0]);
+			expect(output.success).toBe(false);
+			expect(output.code).toBe('INVALID_OPTIONS');
+			expect(output.error).toContain('--new-tab cannot be combined with --force');
+			expect(processExitSpy).toHaveBeenCalledWith(1);
+			expect(withMaestroClient).not.toHaveBeenCalled();
+		});
 	});
 
 	describe('--session <tabId> flow', () => {

--- a/src/__tests__/cli/commands/dispatch.test.ts
+++ b/src/__tests__/cli/commands/dispatch.test.ts
@@ -237,6 +237,26 @@ describe('dispatch command', () => {
 			expect(processExitSpy).toHaveBeenCalledWith(1);
 		});
 
+		// MaestroClient throws three distinct error strings before any WebSocket
+		// activity. They must map to MAESTRO_NOT_RUNNING — not COMMAND_FAILED —
+		// so downstream consumers (Maestro-Discord, Cue) can distinguish "app
+		// down" from "command rejected" via the error code.
+		it.each([
+			['Maestro desktop app is not running'],
+			['Maestro discovery file is stale (app may have crashed)'],
+			['Not connected to Maestro'],
+		])('maps MaestroClient error "%s" to MAESTRO_NOT_RUNNING', async (errorMessage) => {
+			vi.mocked(resolveAgentId).mockReturnValue('agent-abc-123');
+			vi.mocked(withMaestroClient).mockRejectedValue(new Error(errorMessage));
+
+			await dispatch('agent-abc', 'Hello', {});
+
+			const output = JSON.parse(consoleSpy.mock.calls[0][0]);
+			expect(output.success).toBe(false);
+			expect(output.code).toBe('MAESTRO_NOT_RUNNING');
+			expect(processExitSpy).toHaveBeenCalledWith(1);
+		});
+
 		it('maps unknown-session errors to SESSION_NOT_FOUND', async () => {
 			vi.mocked(resolveAgentId).mockReturnValue('bad-session-id');
 			vi.mocked(withMaestroClient).mockRejectedValue(new Error('Unknown session ID'));

--- a/src/__tests__/cli/commands/dispatch.test.ts
+++ b/src/__tests__/cli/commands/dispatch.test.ts
@@ -1,0 +1,303 @@
+/**
+ * @file dispatch.test.ts
+ * @description Tests for the new `maestro-cli dispatch` command
+ *
+ * `dispatch` is the dedicated desktop-handoff verb introduced in PR1 of the
+ * CLI surface refactor. It splits the desktop-handoff half of `send --live`
+ * into a standalone command that returns addressable tab/session IDs so
+ * external consumers (Maestro-Discord, Cue) can address the same tab on
+ * follow-up calls.
+ */
+
+import { describe, it, expect, vi, beforeEach, type MockInstance } from 'vitest';
+
+vi.mock('../../../cli/services/maestro-client', () => ({
+	withMaestroClient: vi.fn(),
+}));
+
+vi.mock('../../../cli/services/storage', () => ({
+	resolveAgentId: vi.fn(),
+	readSettingValue: vi.fn(),
+}));
+
+import { dispatch, runDispatch } from '../../../cli/commands/dispatch';
+import { withMaestroClient } from '../../../cli/services/maestro-client';
+import { resolveAgentId, readSettingValue } from '../../../cli/services/storage';
+
+describe('dispatch command', () => {
+	let consoleSpy: MockInstance;
+	let processExitSpy: MockInstance;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+		processExitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+	});
+
+	describe('default (active tab) flow', () => {
+		it('sends send_command with no tabId and surfaces the desktop-supplied tabId', async () => {
+			vi.mocked(resolveAgentId).mockReturnValue('agent-abc-123');
+			const mockSendCommand = vi.fn().mockResolvedValue({
+				type: 'command_result',
+				success: true,
+				tabId: 'tab-active-99',
+			});
+			vi.mocked(withMaestroClient).mockImplementation(async (action) => {
+				const mockClient = { sendCommand: mockSendCommand };
+				return action(mockClient as never);
+			});
+
+			await dispatch('agent-abc', 'Hello world', {});
+
+			expect(mockSendCommand).toHaveBeenCalledWith(
+				{
+					type: 'send_command',
+					sessionId: 'agent-abc-123',
+					command: 'Hello world',
+					inputMode: 'ai',
+				},
+				'command_result'
+			);
+
+			const output = JSON.parse(consoleSpy.mock.calls[0][0]);
+			expect(output).toEqual({
+				success: true,
+				agentId: 'agent-abc-123',
+				sessionId: 'tab-active-99',
+				tabId: 'tab-active-99',
+			});
+			expect(processExitSpy).not.toHaveBeenCalled();
+		});
+
+		it('returns null tab/session IDs when the desktop omits tabId (no active tab)', async () => {
+			vi.mocked(resolveAgentId).mockReturnValue('agent-abc-123');
+			const mockSendCommand = vi.fn().mockResolvedValue({
+				type: 'command_result',
+				success: true,
+			});
+			vi.mocked(withMaestroClient).mockImplementation(async (action) => {
+				const mockClient = { sendCommand: mockSendCommand };
+				return action(mockClient as never);
+			});
+
+			await dispatch('agent-abc', 'Hello world', {});
+
+			const output = JSON.parse(consoleSpy.mock.calls[0][0]);
+			expect(output.tabId).toBeNull();
+			expect(output.sessionId).toBeNull();
+		});
+	});
+
+	describe('--new-tab flow', () => {
+		it('sends new_ai_tab_with_prompt and returns the freshly-created tabId', async () => {
+			vi.mocked(resolveAgentId).mockReturnValue('agent-abc-123');
+			const mockSendCommand = vi.fn().mockResolvedValue({
+				type: 'new_ai_tab_with_prompt_result',
+				success: true,
+				tabId: 'tab-fresh-42',
+			});
+			vi.mocked(withMaestroClient).mockImplementation(async (action) => {
+				const mockClient = { sendCommand: mockSendCommand };
+				return action(mockClient as never);
+			});
+
+			await dispatch('agent-abc', 'Open a new conversation', { newTab: true });
+
+			expect(mockSendCommand).toHaveBeenCalledWith(
+				{
+					type: 'new_ai_tab_with_prompt',
+					sessionId: 'agent-abc-123',
+					prompt: 'Open a new conversation',
+				},
+				'new_ai_tab_with_prompt_result'
+			);
+
+			const output = JSON.parse(consoleSpy.mock.calls[0][0]);
+			expect(output.success).toBe(true);
+			expect(output.tabId).toBe('tab-fresh-42');
+			expect(output.sessionId).toBe('tab-fresh-42');
+		});
+	});
+
+	describe('--session <tabId> flow', () => {
+		it('forwards the requested tabId in send_command so the desktop targets that tab', async () => {
+			vi.mocked(resolveAgentId).mockReturnValue('agent-abc-123');
+			const mockSendCommand = vi.fn().mockResolvedValue({
+				type: 'command_result',
+				success: true,
+				tabId: 'tab-xyz',
+			});
+			vi.mocked(withMaestroClient).mockImplementation(async (action) => {
+				const mockClient = { sendCommand: mockSendCommand };
+				return action(mockClient as never);
+			});
+
+			await dispatch('agent-abc', 'Follow up', { session: 'tab-xyz' });
+
+			expect(mockSendCommand).toHaveBeenCalledWith(
+				{
+					type: 'send_command',
+					sessionId: 'agent-abc-123',
+					command: 'Follow up',
+					inputMode: 'ai',
+					tabId: 'tab-xyz',
+				},
+				'command_result'
+			);
+
+			const output = JSON.parse(consoleSpy.mock.calls[0][0]);
+			expect(output.tabId).toBe('tab-xyz');
+		});
+
+		it('falls back to the caller-supplied tabId when the desktop response omits it', async () => {
+			// An older desktop build (or a shape change) may not echo tabId
+			// back. The CLI should still report the tabId the caller asked for
+			// so chained dispatches keep working without relying on the desktop.
+			vi.mocked(resolveAgentId).mockReturnValue('agent-abc-123');
+			const mockSendCommand = vi.fn().mockResolvedValue({
+				type: 'command_result',
+				success: true,
+			});
+			vi.mocked(withMaestroClient).mockImplementation(async (action) => {
+				const mockClient = { sendCommand: mockSendCommand };
+				return action(mockClient as never);
+			});
+
+			await dispatch('agent-abc', 'Follow up', { session: 'tab-xyz' });
+
+			const output = JSON.parse(consoleSpy.mock.calls[0][0]);
+			expect(output.tabId).toBe('tab-xyz');
+		});
+
+		it('rejects --session combined with --new-tab as INVALID_OPTIONS', async () => {
+			await dispatch('agent-abc', 'Hello', { newTab: true, session: 'tab-xyz' });
+
+			const output = JSON.parse(consoleSpy.mock.calls[0][0]);
+			expect(output.success).toBe(false);
+			expect(output.code).toBe('INVALID_OPTIONS');
+			expect(output.error).toBe('--new-tab cannot be combined with --session');
+			expect(processExitSpy).toHaveBeenCalledWith(1);
+			expect(withMaestroClient).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('--force flag', () => {
+		it('includes force=true in the payload when allowConcurrentSend is enabled', async () => {
+			vi.mocked(resolveAgentId).mockReturnValue('agent-abc-123');
+			vi.mocked(readSettingValue).mockReturnValue(true);
+			const mockSendCommand = vi.fn().mockResolvedValue({
+				type: 'command_result',
+				success: true,
+				tabId: 'tab-active',
+			});
+			vi.mocked(withMaestroClient).mockImplementation(async (action) => {
+				const mockClient = { sendCommand: mockSendCommand };
+				return action(mockClient as never);
+			});
+
+			await dispatch('agent-abc', 'Concurrent message', { force: true });
+
+			expect(readSettingValue).toHaveBeenCalledWith('allowConcurrentSend');
+			expect(mockSendCommand).toHaveBeenCalledWith(
+				{
+					type: 'send_command',
+					sessionId: 'agent-abc-123',
+					command: 'Concurrent message',
+					inputMode: 'ai',
+					force: true,
+				},
+				'command_result'
+			);
+		});
+
+		it('emits FORCE_NOT_ALLOWED when allowConcurrentSend is disabled', async () => {
+			vi.mocked(resolveAgentId).mockReturnValue('agent-abc-123');
+			vi.mocked(readSettingValue).mockReturnValue(false);
+
+			await dispatch('agent-abc', 'Concurrent message', { force: true });
+
+			const output = JSON.parse(consoleSpy.mock.calls[0][0]);
+			expect(output.success).toBe(false);
+			expect(output.code).toBe('FORCE_NOT_ALLOWED');
+			expect(processExitSpy).toHaveBeenCalledWith(1);
+			expect(withMaestroClient).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('error mapping', () => {
+		it('maps connection errors to MAESTRO_NOT_RUNNING', async () => {
+			vi.mocked(resolveAgentId).mockReturnValue('agent-abc-123');
+			vi.mocked(withMaestroClient).mockRejectedValue(new Error('ECONNREFUSED'));
+
+			await dispatch('agent-abc', 'Hello', {});
+
+			const output = JSON.parse(consoleSpy.mock.calls[0][0]);
+			expect(output.success).toBe(false);
+			expect(output.code).toBe('MAESTRO_NOT_RUNNING');
+			expect(processExitSpy).toHaveBeenCalledWith(1);
+		});
+
+		it('maps unknown-session errors to SESSION_NOT_FOUND', async () => {
+			vi.mocked(resolveAgentId).mockReturnValue('bad-session-id');
+			vi.mocked(withMaestroClient).mockRejectedValue(new Error('Unknown session ID'));
+
+			await dispatch('bad-session-id', 'Hello', {});
+
+			const output = JSON.parse(consoleSpy.mock.calls[0][0]);
+			expect(output.success).toBe(false);
+			expect(output.code).toBe('SESSION_NOT_FOUND');
+		});
+
+		it('maps agent resolution failures to AGENT_NOT_FOUND', async () => {
+			vi.mocked(resolveAgentId).mockImplementation(() => {
+				throw new Error('No agent matching "bogus"');
+			});
+
+			await dispatch('bogus', 'Hello', {});
+
+			const output = JSON.parse(consoleSpy.mock.calls[0][0]);
+			expect(output.success).toBe(false);
+			expect(output.code).toBe('AGENT_NOT_FOUND');
+			expect(output.error).toBe('No agent matching "bogus"');
+			expect(withMaestroClient).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('runDispatch (programmatic API)', () => {
+		// runDispatch is exported so `send --live` can delegate to it during
+		// the deprecation window without re-shelling. The legacy `send --live`
+		// integration is covered in send.test.ts; here we just confirm the
+		// programmatic shape returns rather than calling process.exit.
+		it('returns a structured success result without exiting the process', async () => {
+			vi.mocked(resolveAgentId).mockReturnValue('agent-abc-123');
+			const mockSendCommand = vi.fn().mockResolvedValue({
+				type: 'command_result',
+				success: true,
+				tabId: 'tab-active-1',
+			});
+			vi.mocked(withMaestroClient).mockImplementation(async (action) => {
+				const mockClient = { sendCommand: mockSendCommand };
+				return action(mockClient as never);
+			});
+
+			const result = await runDispatch('agent-abc', 'Hello', {});
+
+			expect(result.success).toBe(true);
+			expect(result.agentId).toBe('agent-abc-123');
+			expect(result.tabId).toBe('tab-active-1');
+			expect(result.sessionId).toBe('tab-active-1');
+			expect(processExitSpy).not.toHaveBeenCalled();
+		});
+
+		it('returns a structured failure result on validation errors without exiting', async () => {
+			const result = await runDispatch('agent-abc', 'Hello', {
+				newTab: true,
+				session: 'tab-xyz',
+			});
+
+			expect(result.success).toBe(false);
+			expect(result.code).toBe('INVALID_OPTIONS');
+			expect(processExitSpy).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/src/__tests__/cli/commands/send.test.ts
+++ b/src/__tests__/cli/commands/send.test.ts
@@ -544,5 +544,52 @@ describe('send command', () => {
 			expect(detectAgent).not.toHaveBeenCalled();
 			expect(spawnAgent).not.toHaveBeenCalled();
 		});
+
+		it('emits a stderr deprecation notice on every --live invocation', async () => {
+			// `send --live` is retained as a hidden alias for `dispatch` during
+			// the deprecation window. The notice goes to stderr so JSON-parsing
+			// callers reading stdout aren't broken by the new line.
+			vi.mocked(resolveAgentId).mockReturnValue('agent-abc-123');
+			vi.mocked(withMaestroClient).mockImplementation(async (action) => {
+				const mockClient = { sendCommand: vi.fn().mockResolvedValue({ type: 'command_result' }) };
+				return action(mockClient as never);
+			});
+			const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+			await send('my-agent-id', 'Hello live', { live: true });
+
+			const stderrText = stderrSpy.mock.calls.map((call) => String(call[0])).join('');
+			expect(stderrText).toMatch(/deprecated/i);
+			expect(stderrText).toMatch(/dispatch/);
+
+			stderrSpy.mockRestore();
+		});
+
+		it('preserves the legacy SendResponse shape (agentName="live", null fields) so existing scripts keep parsing', async () => {
+			vi.mocked(resolveAgentId).mockReturnValue('agent-abc-123');
+			vi.mocked(withMaestroClient).mockImplementation(async (action) => {
+				const mockClient = {
+					sendCommand: vi
+						.fn()
+						.mockResolvedValue({ type: 'command_result', success: true, tabId: 'tab-99' }),
+				};
+				return action(mockClient as never);
+			});
+
+			await send('my-agent-id', 'Hello live', { live: true });
+
+			const output = JSON.parse(consoleSpy.mock.calls[0][0]);
+			// PR1 surfaces tabId in `dispatch` output but `send --live` keeps
+			// the historic shape — sessionId stays null and agentName stays
+			// "live" so downstream parsers don't break mid-deprecation window.
+			expect(output).toEqual({
+				agentId: 'agent-abc-123',
+				agentName: 'live',
+				sessionId: null,
+				response: null,
+				success: true,
+				usage: null,
+			});
+		});
 	});
 });

--- a/src/__tests__/main/cue/cue-cli-executor.test.ts
+++ b/src/__tests__/main/cue/cue-cli-executor.test.ts
@@ -122,7 +122,7 @@ describe('cue-cli-executor', () => {
 		vi.clearAllMocks();
 	});
 
-	it('substitutes {{CUE_FROM_AGENT}} in target before invoking maestro-cli send', async () => {
+	it('substitutes {{CUE_FROM_AGENT}} in target before invoking maestro-cli dispatch', async () => {
 		const config = createConfig();
 		const promise = executeCueCli(config as any);
 		// Let the microtask scheduler register the close handler before we emit.
@@ -133,10 +133,13 @@ describe('cue-cli-executor', () => {
 		expect(mockSpawn).toHaveBeenCalledTimes(1);
 		const args = mockSpawn.mock.calls[0][1] as string[];
 		expect(args[0]).toContain('maestro-cli.js');
-		expect(args[1]).toBe('send');
+		// PR1: Cue migrated from `send --live` to the dedicated `dispatch` verb.
+		// `dispatch` accepts the same positional args (target, message) without
+		// the `--live` flag, since "live" is now its only mode.
+		expect(args[1]).toBe('dispatch');
 		expect(args[2]).toBe('session-research'); // CUE_FROM_AGENT resolved from sourceSessionId
 		expect(args[3]).toBe('computed answer = 42');
-		expect(args[4]).toBe('--live');
+		expect(args).toHaveLength(4);
 		expect(result.status).toBe('completed');
 	});
 

--- a/src/__tests__/main/preload/process.test.ts
+++ b/src/__tests__/main/preload/process.test.ts
@@ -274,13 +274,36 @@ describe('Process Preload API', () => {
 	});
 
 	describe('onRemoteCommand', () => {
-		it('should register listener and invoke callback with all parameters', () => {
+		it('should register listener and invoke callback with all parameters including tabId', () => {
 			const callback = vi.fn();
 			let registeredHandler: (
 				event: unknown,
 				sessionId: string,
 				command: string,
-				inputMode?: 'ai' | 'terminal'
+				inputMode?: 'ai' | 'terminal',
+				tabId?: string
+			) => void;
+
+			mockOn.mockImplementation((channel: string, handler: typeof registeredHandler) => {
+				if (channel === 'remote:executeCommand') {
+					registeredHandler = handler;
+				}
+			});
+
+			api.onRemoteCommand(callback);
+			registeredHandler!({}, 'session-123', 'test command', 'ai', 'tab-7');
+
+			expect(callback).toHaveBeenCalledWith('session-123', 'test command', 'ai', 'tab-7');
+		});
+
+		it('forwards undefined tabId when the IPC sender omits it (legacy callers)', () => {
+			const callback = vi.fn();
+			let registeredHandler: (
+				event: unknown,
+				sessionId: string,
+				command: string,
+				inputMode?: 'ai' | 'terminal',
+				tabId?: string
 			) => void;
 
 			mockOn.mockImplementation((channel: string, handler: typeof registeredHandler) => {
@@ -292,7 +315,7 @@ describe('Process Preload API', () => {
 			api.onRemoteCommand(callback);
 			registeredHandler!({}, 'session-123', 'test command', 'ai');
 
-			expect(callback).toHaveBeenCalledWith('session-123', 'test command', 'ai');
+			expect(callback).toHaveBeenCalledWith('session-123', 'test command', 'ai', undefined);
 		});
 	});
 });

--- a/src/__tests__/main/preload/process.test.ts
+++ b/src/__tests__/main/preload/process.test.ts
@@ -274,14 +274,15 @@ describe('Process Preload API', () => {
 	});
 
 	describe('onRemoteCommand', () => {
-		it('should register listener and invoke callback with all parameters including tabId', () => {
+		it('should register listener and invoke callback with all parameters including tabId and force', () => {
 			const callback = vi.fn();
 			let registeredHandler: (
 				event: unknown,
 				sessionId: string,
 				command: string,
 				inputMode?: 'ai' | 'terminal',
-				tabId?: string
+				tabId?: string,
+				force?: boolean
 			) => void;
 
 			mockOn.mockImplementation((channel: string, handler: typeof registeredHandler) => {
@@ -291,19 +292,20 @@ describe('Process Preload API', () => {
 			});
 
 			api.onRemoteCommand(callback);
-			registeredHandler!({}, 'session-123', 'test command', 'ai', 'tab-7');
+			registeredHandler!({}, 'session-123', 'test command', 'ai', 'tab-7', true);
 
-			expect(callback).toHaveBeenCalledWith('session-123', 'test command', 'ai', 'tab-7');
+			expect(callback).toHaveBeenCalledWith('session-123', 'test command', 'ai', 'tab-7', true);
 		});
 
-		it('forwards undefined tabId when the IPC sender omits it (legacy callers)', () => {
+		it('forwards undefined tabId/force when the IPC sender omits them (legacy callers)', () => {
 			const callback = vi.fn();
 			let registeredHandler: (
 				event: unknown,
 				sessionId: string,
 				command: string,
 				inputMode?: 'ai' | 'terminal',
-				tabId?: string
+				tabId?: string,
+				force?: boolean
 			) => void;
 
 			mockOn.mockImplementation((channel: string, handler: typeof registeredHandler) => {
@@ -315,7 +317,13 @@ describe('Process Preload API', () => {
 			api.onRemoteCommand(callback);
 			registeredHandler!({}, 'session-123', 'test command', 'ai');
 
-			expect(callback).toHaveBeenCalledWith('session-123', 'test command', 'ai', undefined);
+			expect(callback).toHaveBeenCalledWith(
+				'session-123',
+				'test command',
+				'ai',
+				undefined,
+				undefined
+			);
 		});
 	});
 });

--- a/src/__tests__/main/web-server/handlers/messageHandlers.test.ts
+++ b/src/__tests__/main/web-server/handlers/messageHandlers.test.ts
@@ -189,7 +189,8 @@ describe('WebSocketMessageHandler', () => {
 					'session-1',
 					'Hello Claude!',
 					'ai',
-					undefined
+					undefined,
+					false
 				);
 			});
 
@@ -211,7 +212,8 @@ describe('WebSocketMessageHandler', () => {
 					'session-1',
 					'ls -la',
 					'terminal',
-					undefined
+					undefined,
+					false
 				);
 			});
 		});
@@ -231,11 +233,12 @@ describe('WebSocketMessageHandler', () => {
 			expect(callbacks.executeCommand).not.toHaveBeenCalled();
 		});
 
-		it('surfaces the active tabId in command_result so `dispatch` can chain to the same tab', async () => {
-			// `getSessionDetail` is the source of truth for activeTabId. The
-			// handler echoes it back in command_result whenever no explicit
-			// tabId was supplied — that's what `dispatch <agent> <prompt>`
-			// (no --session) relies on to surface an addressable id.
+		it('omits tabId from command_result on the no-tabId path so callers do not chain to a stale snapshot', async () => {
+			// The server's `activeTabId` snapshot can diverge from the renderer's
+			// actual write target if the user switches tabs between IPC send and
+			// receive. Echoing it would mislead `dispatch --session <returnedTabId>`
+			// callers chaining a follow-up. We only echo when the caller passed an
+			// explicit, authoritative tabId.
 			(callbacks.getSessionDetail as any).mockReturnValue({
 				state: 'idle',
 				inputMode: 'ai',
@@ -256,7 +259,7 @@ describe('WebSocketMessageHandler', () => {
 			const response = JSON.parse((client.socket.send as any).mock.calls[0][0]);
 			expect(response.type).toBe('command_result');
 			expect(response.success).toBe(true);
-			expect(response.tabId).toBe('tab-active-77');
+			expect(response.tabId).toBeUndefined();
 		});
 
 		it('forwards an explicit tabId to the executeCommand callback and echoes it in command_result', async () => {
@@ -273,7 +276,8 @@ describe('WebSocketMessageHandler', () => {
 					'session-1',
 					'Hello',
 					'ai',
-					'tab-explicit'
+					'tab-explicit',
+					false
 				);
 			});
 
@@ -298,7 +302,8 @@ describe('WebSocketMessageHandler', () => {
 					'session-1',
 					'concurrent write',
 					'ai',
-					undefined
+					undefined,
+					true
 				);
 			});
 

--- a/src/__tests__/main/web-server/handlers/messageHandlers.test.ts
+++ b/src/__tests__/main/web-server/handlers/messageHandlers.test.ts
@@ -80,7 +80,7 @@ function createMockCallbacks(): MessageHandlerCallbacks {
 		refreshFileTree: vi.fn().mockResolvedValue(true),
 		openBrowserTab: vi.fn().mockResolvedValue(true),
 		openTerminalTab: vi.fn().mockResolvedValue(true),
-		newAITabWithPrompt: vi.fn().mockResolvedValue(true),
+		newAITabWithPrompt: vi.fn().mockResolvedValue({ success: true, tabId: 'tab-mock-123' }),
 		refreshAutoRunDocs: vi.fn().mockResolvedValue(true),
 		configureAutoRun: vi.fn().mockResolvedValue({ success: true }),
 		getSessions: vi.fn().mockReturnValue([
@@ -185,7 +185,12 @@ describe('WebSocketMessageHandler', () => {
 
 			// Wait for async callback
 			await vi.waitFor(() => {
-				expect(callbacks.executeCommand).toHaveBeenCalledWith('session-1', 'Hello Claude!', 'ai');
+				expect(callbacks.executeCommand).toHaveBeenCalledWith(
+					'session-1',
+					'Hello Claude!',
+					'ai',
+					undefined
+				);
 			});
 
 			const response = JSON.parse((client.socket.send as any).mock.calls[0][0]);
@@ -202,7 +207,12 @@ describe('WebSocketMessageHandler', () => {
 			});
 
 			await vi.waitFor(() => {
-				expect(callbacks.executeCommand).toHaveBeenCalledWith('session-1', 'ls -la', 'terminal');
+				expect(callbacks.executeCommand).toHaveBeenCalledWith(
+					'session-1',
+					'ls -la',
+					'terminal',
+					undefined
+				);
 			});
 		});
 
@@ -221,6 +231,57 @@ describe('WebSocketMessageHandler', () => {
 			expect(callbacks.executeCommand).not.toHaveBeenCalled();
 		});
 
+		it('surfaces the active tabId in command_result so `dispatch` can chain to the same tab', async () => {
+			// `getSessionDetail` is the source of truth for activeTabId. The
+			// handler echoes it back in command_result whenever no explicit
+			// tabId was supplied — that's what `dispatch <agent> <prompt>`
+			// (no --session) relies on to surface an addressable id.
+			(callbacks.getSessionDetail as any).mockReturnValue({
+				state: 'idle',
+				inputMode: 'ai',
+				activeTabId: 'tab-active-77',
+			});
+
+			handler.handleMessage(client, {
+				type: 'send_command',
+				sessionId: 'session-1',
+				command: 'Hello',
+				inputMode: 'ai',
+			});
+
+			await vi.waitFor(() => {
+				expect(callbacks.executeCommand).toHaveBeenCalled();
+			});
+
+			const response = JSON.parse((client.socket.send as any).mock.calls[0][0]);
+			expect(response.type).toBe('command_result');
+			expect(response.success).toBe(true);
+			expect(response.tabId).toBe('tab-active-77');
+		});
+
+		it('forwards an explicit tabId to the executeCommand callback and echoes it in command_result', async () => {
+			handler.handleMessage(client, {
+				type: 'send_command',
+				sessionId: 'session-1',
+				command: 'Hello',
+				inputMode: 'ai',
+				tabId: 'tab-explicit',
+			});
+
+			await vi.waitFor(() => {
+				expect(callbacks.executeCommand).toHaveBeenCalledWith(
+					'session-1',
+					'Hello',
+					'ai',
+					'tab-explicit'
+				);
+			});
+
+			const response = JSON.parse((client.socket.send as any).mock.calls[0][0]);
+			expect(response.type).toBe('command_result');
+			expect(response.tabId).toBe('tab-explicit');
+		});
+
 		it('should bypass busy guard and forward command when force=true', async () => {
 			(callbacks.getSessionDetail as any).mockReturnValue({ state: 'busy', inputMode: 'ai' });
 
@@ -236,7 +297,8 @@ describe('WebSocketMessageHandler', () => {
 				expect(callbacks.executeCommand).toHaveBeenCalledWith(
 					'session-1',
 					'concurrent write',
-					'ai'
+					'ai',
+					undefined
 				);
 			});
 
@@ -1006,6 +1068,9 @@ describe('WebSocketMessageHandler', () => {
 			expect(response.type).toBe('new_ai_tab_with_prompt_result');
 			expect(response.success).toBe(true);
 			expect(response.sessionId).toBe('session-1');
+			// PR1: surface the freshly-created tabId so `dispatch --new-tab`
+			// can return an addressable id without owning a persistent channel.
+			expect(response.tabId).toBe('tab-mock-123');
 		});
 
 		it('should reject missing sessionId', () => {

--- a/src/__tests__/main/web-server/managers/CallbackRegistry.test.ts
+++ b/src/__tests__/main/web-server/managers/CallbackRegistry.test.ts
@@ -367,7 +367,7 @@ describe('CallbackRegistry', () => {
 
 			await registry.executeCommand('session-5', 'npm test');
 
-			expect(callback).toHaveBeenCalledWith('session-5', 'npm test', undefined);
+			expect(callback).toHaveBeenCalledWith('session-5', 'npm test', undefined, undefined);
 		});
 
 		it('passes inputMode argument to the callback', async () => {
@@ -376,7 +376,7 @@ describe('CallbackRegistry', () => {
 
 			await registry.executeCommand('session-5', 'npm test', 'terminal');
 
-			expect(callback).toHaveBeenCalledWith('session-5', 'npm test', 'terminal');
+			expect(callback).toHaveBeenCalledWith('session-5', 'npm test', 'terminal', undefined);
 		});
 
 		it('passes ai inputMode argument to the callback', async () => {
@@ -385,7 +385,16 @@ describe('CallbackRegistry', () => {
 
 			await registry.executeCommand('session-5', 'explain this code', 'ai');
 
-			expect(callback).toHaveBeenCalledWith('session-5', 'explain this code', 'ai');
+			expect(callback).toHaveBeenCalledWith('session-5', 'explain this code', 'ai', undefined);
+		});
+
+		it('passes tabId argument to the callback so callers (`dispatch --session`) can target a specific tab', async () => {
+			const callback = vi.fn().mockResolvedValue(true);
+			registry.setExecuteCommandCallback(callback);
+
+			await registry.executeCommand('session-5', 'follow up', 'ai', 'tab-xyz');
+
+			expect(callback).toHaveBeenCalledWith('session-5', 'follow up', 'ai', 'tab-xyz');
 		});
 	});
 

--- a/src/__tests__/main/web-server/managers/CallbackRegistry.test.ts
+++ b/src/__tests__/main/web-server/managers/CallbackRegistry.test.ts
@@ -367,7 +367,13 @@ describe('CallbackRegistry', () => {
 
 			await registry.executeCommand('session-5', 'npm test');
 
-			expect(callback).toHaveBeenCalledWith('session-5', 'npm test', undefined, undefined);
+			expect(callback).toHaveBeenCalledWith(
+				'session-5',
+				'npm test',
+				undefined,
+				undefined,
+				undefined
+			);
 		});
 
 		it('passes inputMode argument to the callback', async () => {
@@ -376,7 +382,13 @@ describe('CallbackRegistry', () => {
 
 			await registry.executeCommand('session-5', 'npm test', 'terminal');
 
-			expect(callback).toHaveBeenCalledWith('session-5', 'npm test', 'terminal', undefined);
+			expect(callback).toHaveBeenCalledWith(
+				'session-5',
+				'npm test',
+				'terminal',
+				undefined,
+				undefined
+			);
 		});
 
 		it('passes ai inputMode argument to the callback', async () => {
@@ -385,7 +397,13 @@ describe('CallbackRegistry', () => {
 
 			await registry.executeCommand('session-5', 'explain this code', 'ai');
 
-			expect(callback).toHaveBeenCalledWith('session-5', 'explain this code', 'ai', undefined);
+			expect(callback).toHaveBeenCalledWith(
+				'session-5',
+				'explain this code',
+				'ai',
+				undefined,
+				undefined
+			);
 		});
 
 		it('passes tabId argument to the callback so callers (`dispatch --session`) can target a specific tab', async () => {
@@ -394,7 +412,16 @@ describe('CallbackRegistry', () => {
 
 			await registry.executeCommand('session-5', 'follow up', 'ai', 'tab-xyz');
 
-			expect(callback).toHaveBeenCalledWith('session-5', 'follow up', 'ai', 'tab-xyz');
+			expect(callback).toHaveBeenCalledWith('session-5', 'follow up', 'ai', 'tab-xyz', undefined);
+		});
+
+		it('passes force argument to the callback so `dispatch --force` survives the WebSocket boundary', async () => {
+			const callback = vi.fn().mockResolvedValue(true);
+			registry.setExecuteCommandCallback(callback);
+
+			await registry.executeCommand('session-5', 'concurrent write', 'ai', undefined, true);
+
+			expect(callback).toHaveBeenCalledWith('session-5', 'concurrent write', 'ai', undefined, true);
 		});
 	});
 

--- a/src/__tests__/main/web-server/web-server-factory.test.ts
+++ b/src/__tests__/main/web-server/web-server-factory.test.ts
@@ -479,7 +479,7 @@ describe('web-server/web-server-factory', () => {
 			expect(logger.warn).toHaveBeenCalled();
 		});
 
-		it('should send command to renderer', async () => {
+		it('should send command to renderer (omitting tabId routes to active tab)', async () => {
 			const createWebServer = createWebServerFactory(deps);
 			const server = createWebServer();
 
@@ -493,7 +493,27 @@ describe('web-server/web-server-factory', () => {
 				'remote:executeCommand',
 				'session-1',
 				'test command',
-				'ai'
+				'ai',
+				undefined
+			);
+		});
+
+		it('forwards tabId to the renderer so `dispatch --session <tabId>` writes into the requested tab', async () => {
+			const createWebServer = createWebServerFactory(deps);
+			const server = createWebServer();
+
+			const setExecuteCallback = server.setExecuteCommandCallback as ReturnType<typeof vi.fn>;
+			const callback = setExecuteCallback.mock.calls[0][0];
+
+			const result = await callback('session-1', 'follow up', 'ai', 'tab-7');
+
+			expect(result).toBe(true);
+			expect(mockWebContents.send).toHaveBeenCalledWith(
+				'remote:executeCommand',
+				'session-1',
+				'follow up',
+				'ai',
+				'tab-7'
 			);
 		});
 	});

--- a/src/__tests__/main/web-server/web-server-factory.test.ts
+++ b/src/__tests__/main/web-server/web-server-factory.test.ts
@@ -494,6 +494,7 @@ describe('web-server/web-server-factory', () => {
 				'session-1',
 				'test command',
 				'ai',
+				undefined,
 				undefined
 			);
 		});
@@ -513,8 +514,47 @@ describe('web-server/web-server-factory', () => {
 				'session-1',
 				'follow up',
 				'ai',
-				'tab-7'
+				'tab-7',
+				undefined
 			);
+		});
+
+		it('forwards force=true to the renderer so `dispatch --force` bypasses the renderer busy guard', async () => {
+			const createWebServer = createWebServerFactory(deps);
+			const server = createWebServer();
+
+			const setExecuteCallback = server.setExecuteCommandCallback as ReturnType<typeof vi.fn>;
+			const callback = setExecuteCallback.mock.calls[0][0];
+
+			const result = await callback('session-1', 'concurrent write', 'ai', undefined, true);
+
+			expect(result).toBe(true);
+			expect(mockWebContents.send).toHaveBeenCalledWith(
+				'remote:executeCommand',
+				'session-1',
+				'concurrent write',
+				'ai',
+				undefined,
+				true
+			);
+		});
+
+		it('does not log raw command text at info level (info shows length only)', async () => {
+			const createWebServer = createWebServerFactory(deps);
+			const server = createWebServer();
+
+			const setExecuteCallback = server.setExecuteCommandCallback as ReturnType<typeof vi.fn>;
+			const callback = setExecuteCallback.mock.calls[0][0];
+
+			await callback('session-1', 'super-secret-token-do-not-leak', 'ai');
+
+			const infoCalls = (logger.info as ReturnType<typeof vi.fn>).mock.calls;
+			const forwardingInfoCall = infoCalls.find(
+				(c: unknown[]) => typeof c[0] === 'string' && c[0].includes('[Web → Renderer]')
+			);
+			expect(forwardingInfoCall).toBeDefined();
+			expect(forwardingInfoCall?.[0]).not.toContain('super-secret-token-do-not-leak');
+			expect(forwardingInfoCall?.[0]).toContain('CommandLength: 30');
 		});
 	});
 

--- a/src/__tests__/renderer/hooks/useRemoteIntegration.test.ts
+++ b/src/__tests__/renderer/hooks/useRemoteIntegration.test.ts
@@ -310,7 +310,12 @@ describe('useRemoteIntegration', () => {
 			expect(dispatchEventSpy).toHaveBeenCalledWith(
 				expect.objectContaining({
 					type: 'maestro:remoteCommand',
-					detail: { sessionId: 'session-1', command: 'test command', inputMode: 'ai' },
+					detail: {
+						sessionId: 'session-1',
+						command: 'test command',
+						inputMode: 'ai',
+						tabId: undefined,
+					},
 				})
 			);
 
@@ -611,7 +616,7 @@ describe('useRemoteIntegration', () => {
 	});
 
 	describe('remote new AI tab with prompt', () => {
-		it('creates tab, dispatches remoteCommand, and acks true on idle session', () => {
+		it('creates tab, dispatches remoteCommand, and acks true with the new tab id on idle session', () => {
 			const session = createMockSession({ id: 'session-1', state: 'idle' });
 			const deps = createDeps({ sessions: [session] });
 			const dispatchEventSpy = vi.spyOn(window, 'dispatchEvent');
@@ -624,13 +629,27 @@ describe('useRemoteIntegration', () => {
 
 			expect(deps.setSessions).toHaveBeenCalled();
 			expect(deps.setActiveSessionId).toHaveBeenCalledWith('session-1');
+			// The dispatched event carries the freshly-created tabId so
+			// useRemoteHandlers writes into the new tab even if the user
+			// switches active tabs while the event is in flight.
 			expect(dispatchEventSpy).toHaveBeenCalledWith(
 				expect.objectContaining({
 					type: 'maestro:remoteCommand',
-					detail: { sessionId: 'session-1', command: 'Hello', inputMode: 'ai' },
+					detail: expect.objectContaining({
+						sessionId: 'session-1',
+						command: 'Hello',
+						inputMode: 'ai',
+						tabId: expect.any(String),
+					}),
 				})
 			);
-			expect(mockProcess.sendRemoteNewAITabWithPromptResponse).toHaveBeenCalledWith('chan-1', true);
+			// The renderer surfaces the new tab id through the IPC ack so
+			// `maestro-cli dispatch --new-tab` can return an addressable id.
+			expect(mockProcess.sendRemoteNewAITabWithPromptResponse).toHaveBeenCalledWith(
+				'chan-1',
+				true,
+				expect.any(String)
+			);
 
 			dispatchEventSpy.mockRestore();
 		});

--- a/src/__tests__/renderer/hooks/useRemoteIntegration.test.ts
+++ b/src/__tests__/renderer/hooks/useRemoteIntegration.test.ts
@@ -315,7 +315,30 @@ describe('useRemoteIntegration', () => {
 						command: 'test command',
 						inputMode: 'ai',
 						tabId: undefined,
+						force: undefined,
 					},
+				})
+			);
+
+			dispatchEventSpy.mockRestore();
+		});
+
+		it('forwards force=true so `dispatch --force` survives the IPC boundary into the renderer', () => {
+			const session = createMockSession({ id: 'session-1', state: 'busy' });
+			const deps = createDeps({ sessions: [session] });
+			const dispatchEventSpy = vi.spyOn(window, 'dispatchEvent');
+
+			renderHook(() => useRemoteIntegration(deps));
+
+			act(() => {
+				onRemoteCommandHandler?.('session-1', 'concurrent', 'ai', undefined, true);
+			});
+
+			// busy guard is bypassed when force=true
+			expect(dispatchEventSpy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					type: 'maestro:remoteCommand',
+					detail: expect.objectContaining({ force: true }),
 				})
 			);
 

--- a/src/cli/commands/dispatch.ts
+++ b/src/cli/commands/dispatch.ts
@@ -47,6 +47,18 @@ export async function runDispatch(
 		};
 	}
 
+	// `--new-tab --force` is meaningless — a freshly created tab can never be
+	// busy, so the bypass-busy semantics of --force don't apply. Reject the
+	// combo rather than silently ignoring --force, which would mismatch the
+	// help text and confuse callers debugging why nothing is being bypassed.
+	if (options.newTab && options.force) {
+		return {
+			success: false,
+			error: '--new-tab cannot be combined with --force (a new tab is never busy)',
+			code: 'INVALID_OPTIONS',
+		};
+	}
+
 	// --force is gated by the `allowConcurrentSend` setting. It's off by default
 	// because concurrent writes can interleave responses in the target tab.
 	if (options.force) {
@@ -78,6 +90,15 @@ export async function runDispatch(
 					{ type: 'new_ai_tab_with_prompt', sessionId: agentId, prompt: message },
 					'new_ai_tab_with_prompt_result'
 				);
+				// `--new-tab`'s sole purpose is to surface a fresh tab id for
+				// chaining (`dispatch --session <tabId>`). If the desktop acked
+				// without one (older build / race), fail loudly with a dedicated
+				// code so consumers (Maestro-Discord, Cue) can distinguish this
+				// from a generic command failure instead of silently returning
+				// `tabId: null` from a "successful" response.
+				if (!result.tabId) {
+					throw new Error('NEW_TAB_NO_ID: new_ai_tab_with_prompt acknowledged without a tabId');
+				}
 				return result.tabId;
 			}
 			const result = await client.sendCommand<{ tabId?: string }>(
@@ -139,6 +160,14 @@ export async function runDispatch(
 				success: false,
 				error: `Session not found: ${agentId}`,
 				code: 'SESSION_NOT_FOUND',
+			};
+		}
+		if (msg.startsWith('NEW_TAB_NO_ID:')) {
+			return {
+				success: false,
+				error:
+					'Maestro desktop acknowledged --new-tab without returning a tab id (cannot chain dispatch)',
+				code: 'NEW_TAB_NO_ID',
 			};
 		}
 		return {

--- a/src/cli/commands/dispatch.ts
+++ b/src/cli/commands/dispatch.ts
@@ -1,0 +1,167 @@
+// Dispatch command — hand off a prompt to the Maestro desktop app and return
+// addressable tab/session IDs. Splits the desktop-handoff half of `send --live`
+// into a standalone verb so callers (Maestro-Discord, Cue) can address the same
+// tab on follow-up calls without owning a persistent channel.
+
+import { resolveAgentId, readSettingValue } from '../services/storage';
+import { withMaestroClient } from '../services/maestro-client';
+import { getSettingDefault } from '../../shared/settingsMetadata';
+
+export interface DispatchOptions {
+	newTab?: boolean;
+	/** Tab id within the target agent. Mutually exclusive with --new-tab. */
+	session?: string;
+	force?: boolean;
+}
+
+export interface DispatchResponse {
+	success: boolean;
+	agentId?: string;
+	/** Tab id the prompt was delivered to. Identical to `tabId` — the duplicate
+	 *  field is kept so polling consumers can use either name. */
+	sessionId?: string | null;
+	tabId?: string | null;
+	error?: string;
+	code?: string;
+}
+
+function emitErrorJson(error: string, code: string): void {
+	console.log(JSON.stringify({ success: false, error, code }, null, 2));
+}
+
+/**
+ * Run the dispatch flow. Exported separately from the CLI action so
+ * `send --live` can delegate here during the deprecation window without
+ * duplicating logic or re-shelling out.
+ */
+export async function runDispatch(
+	agentIdArg: string,
+	message: string,
+	options: DispatchOptions
+): Promise<DispatchResponse> {
+	if (options.newTab && options.session) {
+		return {
+			success: false,
+			error: '--new-tab cannot be combined with --session',
+			code: 'INVALID_OPTIONS',
+		};
+	}
+
+	// --force is gated by the `allowConcurrentSend` setting. It's off by default
+	// because concurrent writes can interleave responses in the target tab.
+	if (options.force) {
+		const stored = readSettingValue('allowConcurrentSend');
+		const allowConcurrentSend =
+			stored === undefined ? (getSettingDefault('allowConcurrentSend') as boolean) : stored;
+		if (allowConcurrentSend !== true) {
+			return {
+				success: false,
+				error:
+					'--force is disabled. Enable it with: maestro-cli settings set allowConcurrentSend true',
+				code: 'FORCE_NOT_ALLOWED',
+			};
+		}
+	}
+
+	let agentId: string;
+	try {
+		agentId = resolveAgentId(agentIdArg);
+	} catch (error) {
+		const msg = error instanceof Error ? error.message : 'Unknown error';
+		return { success: false, error: msg, code: 'AGENT_NOT_FOUND' };
+	}
+
+	try {
+		const tabId = await withMaestroClient(async (client) => {
+			if (options.newTab) {
+				const result = await client.sendCommand<{ tabId?: string }>(
+					{ type: 'new_ai_tab_with_prompt', sessionId: agentId, prompt: message },
+					'new_ai_tab_with_prompt_result'
+				);
+				return result.tabId;
+			}
+			const result = await client.sendCommand<{ tabId?: string }>(
+				{
+					type: 'send_command',
+					sessionId: agentId,
+					command: message,
+					inputMode: 'ai',
+					...(options.session ? { tabId: options.session } : {}),
+					...(options.force ? { force: true } : {}),
+				},
+				'command_result'
+			);
+			return result.tabId;
+		});
+		// `--session <tabId>` is the authoritative target; the desktop handler
+		// echoes it back when we pass one. If the desktop omitted it (older
+		// build / no active tab known), fall back to the value the caller
+		// supplied so callers can still chain dispatches deterministically.
+		const resolvedTabId = tabId ?? options.session ?? null;
+		return {
+			success: true,
+			agentId,
+			sessionId: resolvedTabId,
+			tabId: resolvedTabId,
+		};
+	} catch (error) {
+		const msg = error instanceof Error ? error.message : String(error);
+		const lowerMsg = msg.toLowerCase();
+		if (
+			lowerMsg.includes('econnrefused') ||
+			lowerMsg.includes('connection refused') ||
+			lowerMsg.includes('websocket') ||
+			lowerMsg.includes('enotfound') ||
+			lowerMsg.includes('etimedout')
+		) {
+			return {
+				success: false,
+				error: 'Maestro desktop is not running or not reachable',
+				code: 'MAESTRO_NOT_RUNNING',
+			};
+		}
+		if (
+			lowerMsg.includes('session not found') ||
+			lowerMsg.includes('no such session') ||
+			lowerMsg.includes('unknown session')
+		) {
+			return {
+				success: false,
+				error: `Session not found: ${agentId}`,
+				code: 'SESSION_NOT_FOUND',
+			};
+		}
+		return {
+			success: false,
+			error: `Command failed: ${msg}`,
+			code: 'COMMAND_FAILED',
+		};
+	}
+}
+
+export async function dispatch(
+	agentIdArg: string,
+	message: string,
+	options: DispatchOptions
+): Promise<void> {
+	const result = await runDispatch(agentIdArg, message, options);
+
+	if (!result.success) {
+		emitErrorJson(result.error ?? 'Unknown error', result.code ?? 'UNKNOWN');
+		process.exit(1);
+		return;
+	}
+
+	console.log(
+		JSON.stringify(
+			{
+				success: true,
+				agentId: result.agentId,
+				sessionId: result.sessionId,
+				tabId: result.tabId,
+			},
+			null,
+			2
+		)
+	);
+}

--- a/src/cli/commands/dispatch.ts
+++ b/src/cli/commands/dispatch.ts
@@ -107,12 +107,22 @@ export async function runDispatch(
 	} catch (error) {
 		const msg = error instanceof Error ? error.message : String(error);
 		const lowerMsg = msg.toLowerCase();
+		// Map MaestroClient's own throw messages alongside socket-level ones.
+		// MaestroClient throws three distinct strings before any WebSocket
+		// activity ("Maestro desktop app is not running", "Maestro discovery
+		// file is stale (app may have crashed)", "Not connected to Maestro");
+		// without these, those errors fall through to COMMAND_FAILED and break
+		// the error-code contract downstream consumers (Maestro-Discord, Cue)
+		// rely on to distinguish "app down" from "command rejected".
 		if (
 			lowerMsg.includes('econnrefused') ||
 			lowerMsg.includes('connection refused') ||
 			lowerMsg.includes('websocket') ||
 			lowerMsg.includes('enotfound') ||
-			lowerMsg.includes('etimedout')
+			lowerMsg.includes('etimedout') ||
+			lowerMsg.includes('maestro desktop app is not running') ||
+			lowerMsg.includes('discovery file is stale') ||
+			lowerMsg.includes('not connected to maestro')
 		) {
 			return {
 				success: false,

--- a/src/cli/commands/send.ts
+++ b/src/cli/commands/send.ts
@@ -2,11 +2,11 @@
 // Requires a Maestro agent ID. Optionally resumes an existing agent session.
 
 import { spawnAgent, detectAgent, type AgentResult } from '../services/agent-spawner';
-import { resolveAgentId, getSessionById, readSettingValue } from '../services/storage';
+import { resolveAgentId, getSessionById } from '../services/storage';
 import { estimateContextUsage } from '../../main/parsers/usage-aggregator';
 import { getAgentDefinition } from '../../main/agents/definitions';
 import { withMaestroClient } from '../services/maestro-client';
-import { getSettingDefault } from '../../shared/settingsMetadata';
+import { runDispatch } from './dispatch';
 import type { ToolType } from '../../shared/types';
 
 interface SendOptions {
@@ -92,90 +92,41 @@ export async function send(
 		process.exit(1);
 	}
 
-	// --force is gated by the `allowConcurrentSend` setting. It's off by default
-	// because concurrent writes can interleave responses in the target tab.
-	if (options.force) {
-		const stored = readSettingValue('allowConcurrentSend');
-		const allowConcurrentSend =
-			stored === undefined ? (getSettingDefault('allowConcurrentSend') as boolean) : stored;
-		if (allowConcurrentSend !== true) {
-			emitErrorJson(
-				'--force is disabled. Enable it with: maestro-cli settings set allowConcurrentSend true',
-				'FORCE_NOT_ALLOWED'
-			);
-			process.exit(1);
-		}
-	}
-
-	// --live mode: route message through Maestro desktop tab
+	// --live mode: hidden alias for `dispatch` during the deprecation window.
+	// Delegates to runDispatch so behavior stays in lockstep, but preserves the
+	// legacy SendResponse shape so existing scripts keep parsing successfully.
 	if (options.live) {
 		if (options.session || options.readOnly) {
 			emitErrorJson('--live cannot be combined with --session or --read-only', 'INVALID_OPTIONS');
 			process.exit(1);
 		}
-		// Resolve agent ID early so partial IDs produce the CLI's normal
-		// "ambiguous / not found" error rather than a confusing server-side one.
-		let liveAgentId: string;
-		try {
-			liveAgentId = resolveAgentId(agentIdArg);
-		} catch (error) {
-			const msg = error instanceof Error ? error.message : 'Unknown error';
-			emitErrorJson(msg, 'AGENT_NOT_FOUND');
+		// Print the deprecation notice to stderr (not stdout) so JSON-parsing
+		// callers don't break. Notice goes out before the dispatch runs so
+		// users see it even if dispatch fails.
+		process.stderr.write(
+			'maestro-cli: `send --live` is deprecated and will be removed in a future release; use `maestro-cli dispatch` instead.\n'
+		);
+		const result = await runDispatch(agentIdArg, message, {
+			newTab: options.newTab,
+			force: options.force,
+		});
+		if (!result.success) {
+			emitErrorJson(result.error ?? 'Unknown error', result.code ?? 'UNKNOWN');
 			process.exit(1);
+			return;
 		}
-		try {
-			await withMaestroClient(async (client) => {
-				if (options.newTab) {
-					// Atomic: create a new AI tab, focus it, and dispatch the prompt
-					await client.sendCommand(
-						{ type: 'new_ai_tab_with_prompt', sessionId: liveAgentId, prompt: message },
-						'new_ai_tab_with_prompt_result'
-					);
-				} else {
-					// Write into the agent's currently-active AI tab
-					await client.sendCommand(
-						{
-							type: 'send_command',
-							sessionId: liveAgentId,
-							command: message,
-							inputMode: 'ai',
-							...(options.force ? { force: true } : {}),
-						},
-						'command_result'
-					);
-				}
-			});
-			const response: SendResponse = {
-				agentId: liveAgentId,
-				agentName: 'live',
-				sessionId: null,
-				response: null,
-				success: true,
-				usage: null,
-			};
-			console.log(JSON.stringify(response, null, 2));
-		} catch (error) {
-			const msg = error instanceof Error ? error.message : String(error);
-			const lowerMsg = msg.toLowerCase();
-			if (
-				lowerMsg.includes('econnrefused') ||
-				lowerMsg.includes('connection refused') ||
-				lowerMsg.includes('websocket') ||
-				lowerMsg.includes('enotfound') ||
-				lowerMsg.includes('etimedout')
-			) {
-				emitErrorJson('Maestro desktop is not running or not reachable', 'MAESTRO_NOT_RUNNING');
-			} else if (
-				lowerMsg.includes('session not found') ||
-				lowerMsg.includes('no such session') ||
-				lowerMsg.includes('unknown session')
-			) {
-				emitErrorJson(`Session not found: ${liveAgentId}`, 'SESSION_NOT_FOUND');
-			} else {
-				emitErrorJson(`Command failed: ${msg}`, 'COMMAND_FAILED');
-			}
-			process.exit(1);
-		}
+		// Preserve the historical `send --live` response shape: agentName is
+		// the literal "live", sessionId/response/usage are null. Existing
+		// scripts that grep these fields keep working unchanged.
+		const response: SendResponse = {
+			agentId: result.agentId ?? '',
+			agentName: 'live',
+			sessionId: null,
+			response: null,
+			success: true,
+			usage: null,
+		};
+		console.log(JSON.stringify(response, null, 2));
 		return;
 	}
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -183,7 +183,7 @@ program
 	)
 	.option(
 		'-f, --force',
-		'Bypass the busy-state guard when writing to a busy tab; requires allowConcurrentSend'
+		'Bypass the busy-state guard when writing to a busy tab; requires allowConcurrentSend (cannot be combined with --new-tab — a fresh tab is never busy)'
 	)
 	.action(dispatch);
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2,7 +2,7 @@
 // Maestro CLI
 // Command-line interface for Maestro
 
-import { Command } from 'commander';
+import { Command, Option } from 'commander';
 import * as fs from 'fs';
 import * as path from 'path';
 import { listGroups } from './commands/list-groups';
@@ -138,19 +138,33 @@ clean
 	.action(cleanPlaybooks);
 
 // Send command - run an agent locally and return its response synchronously.
-// `--live` is retained as a hidden alias for `dispatch` during the deprecation
-// window; new callers should use `maestro-cli dispatch` instead.
+// `--live`, `--new-tab`, and `--force` are retained as hidden aliases for
+// `dispatch` during the deprecation window; new callers should use
+// `maestro-cli dispatch` instead. Hiding them from `--help` keeps new users
+// off the deprecated path while still parsing the flags from existing scripts.
 program
 	.command('send <agent-id> <message>')
 	.description('Send a message to an agent and get a JSON response')
 	.option('-s, --session <id>', 'Resume an existing agent session (for multi-turn conversations)')
 	.option('-r, --read-only', 'Run in read-only/plan mode (agent cannot modify files)')
 	.option('-t, --tab', 'Open/focus the session tab in Maestro desktop')
-	.option('-l, --live', 'Send message through Maestro desktop (deprecated: use `dispatch`)')
-	.option('--new-tab', 'Create a new AI tab instead of writing to the active one (requires --live)')
-	.option(
-		'-f, --force',
-		'Bypass the busy-state guard when writing to the active tab (requires --live); enables concurrent writes to a single agent'
+	.addOption(
+		new Option(
+			'-l, --live',
+			'Send message through Maestro desktop (deprecated: use `dispatch`)'
+		).hideHelp()
+	)
+	.addOption(
+		new Option(
+			'--new-tab',
+			'Create a new AI tab instead of writing to the active one (deprecated: use `dispatch --new-tab`)'
+		).hideHelp()
+	)
+	.addOption(
+		new Option(
+			'-f, --force',
+			'Bypass the busy-state guard when writing to the active tab (deprecated: use `dispatch --force`)'
+		).hideHelp()
 	)
 	.action(send);
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -12,6 +12,7 @@ import { showPlaybook } from './commands/show-playbook';
 import { showAgent } from './commands/show-agent';
 import { cleanPlaybooks } from './commands/clean-playbooks';
 import { send } from './commands/send';
+import { dispatch } from './commands/dispatch';
 import { listSessions } from './commands/list-sessions';
 import { openFile } from './commands/open-file';
 import { openBrowser } from './commands/open-browser';
@@ -136,20 +137,41 @@ clean
 	.option('--json', 'Output as JSON (for scripting)')
 	.action(cleanPlaybooks);
 
-// Send command - send a message to an agent and get a JSON response
+// Send command - run an agent locally and return its response synchronously.
+// `--live` is retained as a hidden alias for `dispatch` during the deprecation
+// window; new callers should use `maestro-cli dispatch` instead.
 program
 	.command('send <agent-id> <message>')
 	.description('Send a message to an agent and get a JSON response')
 	.option('-s, --session <id>', 'Resume an existing agent session (for multi-turn conversations)')
 	.option('-r, --read-only', 'Run in read-only/plan mode (agent cannot modify files)')
 	.option('-t, --tab', 'Open/focus the session tab in Maestro desktop')
-	.option('-l, --live', 'Send message through Maestro desktop (appears in tab)')
+	.option('-l, --live', 'Send message through Maestro desktop (deprecated: use `dispatch`)')
 	.option('--new-tab', 'Create a new AI tab instead of writing to the active one (requires --live)')
 	.option(
 		'-f, --force',
 		'Bypass the busy-state guard when writing to the active tab (requires --live); enables concurrent writes to a single agent'
 	)
 	.action(send);
+
+// Dispatch command - hand a prompt to the desktop and return tab/session ID.
+// Splits the desktop-handoff half of `send --live` into a dedicated verb so
+// callers can address the same tab again without owning a persistent channel.
+program
+	.command('dispatch <agent-id> <message>')
+	.description(
+		'Dispatch a prompt to an agent in the Maestro desktop app and return its tab/session ID'
+	)
+	.option('--new-tab', 'Create a fresh AI tab and dispatch the prompt into it')
+	.option(
+		'-s, --session <id>',
+		'Target an existing tab by its tab id (mutually exclusive with --new-tab)'
+	)
+	.option(
+		'-f, --force',
+		'Bypass the busy-state guard when writing to a busy tab; requires allowConcurrentSend'
+	)
+	.action(dispatch);
 
 // Open file command - open a file in the Maestro desktop app
 program

--- a/src/main/cue/cue-cli-executor.ts
+++ b/src/main/cue/cue-cli-executor.ts
@@ -2,13 +2,17 @@
  * Cue CLI Executor — runs an `action: command` subscription whose
  * `command.mode` is `'cli'`.
  *
- * Currently supports one maestro-cli sub-command, `send`, which delivers a
- * message to a target session via `maestro-cli send <target> <message> --live`.
- * Both `target` and `message` (default: `{{CUE_SOURCE_OUTPUT}}`) go through
- * Cue template substitution before spawning. The same low-level
- * {@link runMaestroCliSend} helper backs the legacy `cli_output` Phase 3
- * post-completion side effect in `cue-run-manager.ts` so both paths share
- * one implementation.
+ * Delivers a message to a target session via
+ * `maestro-cli dispatch <target> <message>`. Both `target` and `message`
+ * (default: `{{CUE_SOURCE_OUTPUT}}`) go through Cue template substitution
+ * before spawning. The same low-level {@link runMaestroCliSend} helper
+ * backs the legacy `cli_output` Phase 3 post-completion side effect in
+ * `cue-run-manager.ts` so both paths share one implementation.
+ *
+ * Historically this called `maestro-cli send <target> <message> --live`;
+ * `--live` was renamed to the dedicated `dispatch` verb in PR1 of the CLI
+ * surface refactor. The desktop `send_command` WebSocket message that
+ * underlies the dispatch is unchanged, so behavior is identical.
  */
 
 import * as fs from 'fs';
@@ -138,7 +142,7 @@ function killCliProcess(child: ChildProcess, sync = false): void {
 }
 
 /**
- * Spawn `node maestro-cli.js send <target> <message> --live`. Used by both the
+ * Spawn `node maestro-cli.js dispatch <target> <message>`. Used by both the
  * primary cli executor and the legacy cli_output Phase 3 path. When `runId`
  * is provided, the child is registered in {@link activeCliProcesses} so
  * {@link stopCueCliRun} can cancel it on user stop.
@@ -156,7 +160,7 @@ export async function runMaestroCliSend(
 	return new Promise<CliSendResult>((resolve) => {
 		let child: ChildProcess;
 		try {
-			child = spawn(process.execPath, [cliScriptPath, 'send', target, truncated, '--live'], {
+			child = spawn(process.execPath, [cliScriptPath, 'dispatch', target, truncated], {
 				stdio: ['ignore', 'pipe', 'pipe'],
 				// In packaged Electron, `process.execPath` is the app binary, not
 				// Node — without this flag the spawn would launch the app instead
@@ -321,7 +325,7 @@ export async function executeCueCli(config: CueCliExecutionConfig): Promise<CueR
 
 	onLog(
 		'cue',
-		`[CUE] Executing cli run ${runId}: "${subscription.name}" → maestro-cli send ${resolvedTarget} (message length=${resolvedMessage.length})`
+		`[CUE] Executing cli run ${runId}: "${subscription.name}" → maestro-cli dispatch ${resolvedTarget} (message length=${resolvedMessage.length})`
 	);
 
 	try {
@@ -342,15 +346,15 @@ export async function executeCueCli(config: CueCliExecutionConfig): Promise<CueR
 		if (result.timedOut) {
 			onLog(
 				'warn',
-				`[CUE] "${subscription.name}" cli send timed out after ${clampedTimeout}ms — process killed`
+				`[CUE] "${subscription.name}" cli dispatch timed out after ${clampedTimeout}ms — process killed`
 			);
 		} else if (!result.ok) {
 			onLog(
 				'warn',
-				`[CUE] "${subscription.name}" cli send failed: exit=${result.exitCode} stderr=${result.stderr.slice(0, 500)}`
+				`[CUE] "${subscription.name}" cli dispatch failed: exit=${result.exitCode} stderr=${result.stderr.slice(0, 500)}`
 			);
 		} else {
-			onLog('cue', `[CUE] "${subscription.name}" cli send delivered to ${resolvedTarget}`);
+			onLog('cue', `[CUE] "${subscription.name}" cli dispatch delivered to ${resolvedTarget}`);
 		}
 		// CueRunResult only carries numeric exit codes; spawn-failure string codes
 		// (ENOENT etc.) are reported in stderr and surface as exitCode=null.
@@ -375,7 +379,7 @@ export async function executeCueCli(config: CueCliExecutionConfig): Promise<CueR
 			subscription: subscription.name,
 			target: resolvedTarget,
 		});
-		const message = `cli send threw: ${err instanceof Error ? err.message : String(err)}`;
+		const message = `cli dispatch threw: ${err instanceof Error ? err.message : String(err)}`;
 		onLog('warn', `[CUE] "${subscription.name}" ${message}`);
 		return failedResult(message);
 	}

--- a/src/main/preload/process.ts
+++ b/src/main/preload/process.ts
@@ -296,22 +296,29 @@ export function createProcessApi() {
 		 * inputMode is optional - if provided, renderer should use it instead of session state
 		 */
 		onRemoteCommand: (
-			callback: (sessionId: string, command: string, inputMode?: 'ai' | 'terminal') => void
+			callback: (
+				sessionId: string,
+				command: string,
+				inputMode?: 'ai' | 'terminal',
+				tabId?: string
+			) => void
 		): (() => void) => {
 			log('Registering onRemoteCommand listener');
 			const handler = (
 				_: unknown,
 				sessionId: string,
 				command: string,
-				inputMode?: 'ai' | 'terminal'
+				inputMode?: 'ai' | 'terminal',
+				tabId?: string
 			) => {
 				log('Received remote:executeCommand IPC', {
 					sessionId,
 					commandPreview: command?.substring(0, 50),
 					inputMode,
+					tabId,
 				});
 				try {
-					callback(sessionId, command, inputMode);
+					callback(sessionId, command, inputMode, tabId);
 				} catch (error) {
 					ipcRenderer.invoke(
 						'logger:log',
@@ -559,10 +566,17 @@ export function createProcessApi() {
 		},
 
 		/**
-		 * Send response for remote "new AI tab with prompt"
+		 * Send response for remote "new AI tab with prompt".
+		 * `tabId` is the id of the freshly-created tab — surfaced so
+		 * `maestro-cli dispatch --new-tab` can return an addressable id to its
+		 * caller without owning a persistent channel.
 		 */
-		sendRemoteNewAITabWithPromptResponse: (responseChannel: string, success: boolean): void => {
-			ipcRenderer.send(responseChannel, success);
+		sendRemoteNewAITabWithPromptResponse: (
+			responseChannel: string,
+			success: boolean,
+			tabId?: string
+		): void => {
+			ipcRenderer.send(responseChannel, { success, tabId });
 		},
 
 		/**

--- a/src/main/preload/process.ts
+++ b/src/main/preload/process.ts
@@ -300,7 +300,8 @@ export function createProcessApi() {
 				sessionId: string,
 				command: string,
 				inputMode?: 'ai' | 'terminal',
-				tabId?: string
+				tabId?: string,
+				force?: boolean
 			) => void
 		): (() => void) => {
 			log('Registering onRemoteCommand listener');
@@ -309,16 +310,18 @@ export function createProcessApi() {
 				sessionId: string,
 				command: string,
 				inputMode?: 'ai' | 'terminal',
-				tabId?: string
+				tabId?: string,
+				force?: boolean
 			) => {
 				log('Received remote:executeCommand IPC', {
 					sessionId,
 					commandPreview: command?.substring(0, 50),
 					inputMode,
 					tabId,
+					force,
 				});
 				try {
-					callback(sessionId, command, inputMode, tabId);
+					callback(sessionId, command, inputMode, tabId, force);
 				} catch (error) {
 					ipcRenderer.invoke(
 						'logger:log',

--- a/src/main/web-server/WebServer.ts
+++ b/src/main/web-server/WebServer.ts
@@ -726,8 +726,12 @@ export class WebServer {
 	private setupMessageHandlerCallbacks(): void {
 		this.messageHandler.setCallbacks({
 			getSessionDetail: (sessionId: string) => this.callbackRegistry.getSessionDetail(sessionId),
-			executeCommand: async (sessionId: string, command: string, inputMode?: 'ai' | 'terminal') =>
-				this.callbackRegistry.executeCommand(sessionId, command, inputMode),
+			executeCommand: async (
+				sessionId: string,
+				command: string,
+				inputMode?: 'ai' | 'terminal',
+				tabId?: string
+			) => this.callbackRegistry.executeCommand(sessionId, command, inputMode, tabId),
 			switchMode: async (sessionId: string, mode: 'ai' | 'terminal') =>
 				this.callbackRegistry.switchMode(sessionId, mode),
 			selectSession: async (sessionId: string, tabId?: string, focus?: boolean) =>

--- a/src/main/web-server/WebServer.ts
+++ b/src/main/web-server/WebServer.ts
@@ -730,8 +730,9 @@ export class WebServer {
 				sessionId: string,
 				command: string,
 				inputMode?: 'ai' | 'terminal',
-				tabId?: string
-			) => this.callbackRegistry.executeCommand(sessionId, command, inputMode, tabId),
+				tabId?: string,
+				force?: boolean
+			) => this.callbackRegistry.executeCommand(sessionId, command, inputMode, tabId, force),
 			switchMode: async (sessionId: string, mode: 'ai' | 'terminal') =>
 				this.callbackRegistry.switchMode(sessionId, mode),
 			selectSession: async (sessionId: string, tabId?: string, focus?: boolean) =>

--- a/src/main/web-server/handlers/messageHandlers.ts
+++ b/src/main/web-server/handlers/messageHandlers.ts
@@ -114,7 +114,8 @@ export interface MessageHandlerCallbacks {
 		sessionId: string,
 		command: string,
 		inputMode?: 'ai' | 'terminal',
-		tabId?: string
+		tabId?: string,
+		force?: boolean
 	) => Promise<boolean>;
 	switchMode: (sessionId: string, mode: 'ai' | 'terminal') => Promise<boolean>;
 	selectSession: (sessionId: string, tabId?: string, focus?: boolean) => Promise<boolean>;
@@ -576,18 +577,23 @@ export class WebSocketMessageHandler {
 			LOG_CONTEXT
 		);
 
-		// Resolve which tab the command will target. If the caller passed an
-		// explicit tabId we echo it back; otherwise fall back to the session's
-		// current activeTabId (legacy active-tab behavior). The renderer applies
-		// the same fallback when handling the dispatched event.
-		const resolvedTabId = requestedTabId ?? sessionDetail.activeTabId;
+		// Only echo a tabId in command_result when the caller passed one
+		// explicitly. Returning the server's snapshot of `activeTabId` for the
+		// no-tabId path would lie when the user switches active tabs between
+		// the IPC send and IPC receive — callers chaining `dispatch --session
+		// <returnedTabId>` would think they are continuing a conversation that
+		// actually went to a different tab. For deterministic addressing,
+		// callers should use `dispatch --new-tab` (returns the new tabId from
+		// the renderer ack) and then `dispatch --session <tabId>` (echoes back
+		// the caller-supplied authoritative tabId).
+		const resolvedTabId = requestedTabId;
 
 		// Route ALL commands through the renderer for consistent handling
 		// The renderer handles both AI and terminal modes, updating UI and state
 		// Pass clientInputMode so renderer uses the web's intended mode
 		if (this.callbacks.executeCommand) {
 			this.callbacks
-				.executeCommand(sessionId, command, clientInputMode, requestedTabId)
+				.executeCommand(sessionId, command, clientInputMode, requestedTabId, force)
 				.then((success) => {
 					this.send(client, {
 						type: 'command_result',

--- a/src/main/web-server/handlers/messageHandlers.ts
+++ b/src/main/web-server/handlers/messageHandlers.ts
@@ -91,6 +91,9 @@ export interface SessionDetailForHandler {
 	inputMode: string;
 	agentSessionId?: string;
 	cwd?: string;
+	/** Currently active AI tab id; surfaced in send_command responses so callers
+	 *  (`maestro-cli dispatch`) can address the same tab on follow-up calls. */
+	activeTabId?: string;
 }
 
 /**
@@ -110,7 +113,8 @@ export interface MessageHandlerCallbacks {
 	executeCommand: (
 		sessionId: string,
 		command: string,
-		inputMode?: 'ai' | 'terminal'
+		inputMode?: 'ai' | 'terminal',
+		tabId?: string
 	) => Promise<boolean>;
 	switchMode: (sessionId: string, mode: 'ai' | 'terminal') => Promise<boolean>;
 	selectSession: (sessionId: string, tabId?: string, focus?: boolean) => Promise<boolean>;
@@ -128,7 +132,10 @@ export interface MessageHandlerCallbacks {
 		sessionId: string,
 		config: { cwd?: string; shell?: string; name?: string | null }
 	) => Promise<boolean>;
-	newAITabWithPrompt: (sessionId: string, prompt: string) => Promise<boolean>;
+	newAITabWithPrompt: (
+		sessionId: string,
+		prompt: string
+	) => Promise<{ success: boolean; tabId?: string }>;
 	refreshAutoRunDocs: (sessionId: string) => Promise<boolean>;
 	configureAutoRun: (
 		sessionId: string,
@@ -510,9 +517,13 @@ export class WebSocketMessageHandler {
 		const command = message.command as string;
 		// inputMode from web client - use this instead of server state to avoid sync issues
 		const clientInputMode = message.inputMode as 'ai' | 'terminal' | undefined;
+		// Optional explicit tab target. When omitted, the renderer falls back to
+		// the active tab (legacy `send --live` behavior). Used by
+		// `maestro-cli dispatch --session <tabId>` to address a specific tab.
+		const requestedTabId = typeof message.tabId === 'string' ? message.tabId : undefined;
 		// force=true bypasses the busy-state guard below, allowing callers to
 		// dispatch concurrent writes to an already-running agent. Used by
-		// `maestro-cli send --live --force`.
+		// `maestro-cli dispatch --force`.
 		const force = message.force === true;
 
 		logger.info(
@@ -565,17 +576,24 @@ export class WebSocketMessageHandler {
 			LOG_CONTEXT
 		);
 
+		// Resolve which tab the command will target. If the caller passed an
+		// explicit tabId we echo it back; otherwise fall back to the session's
+		// current activeTabId (legacy active-tab behavior). The renderer applies
+		// the same fallback when handling the dispatched event.
+		const resolvedTabId = requestedTabId ?? sessionDetail.activeTabId;
+
 		// Route ALL commands through the renderer for consistent handling
 		// The renderer handles both AI and terminal modes, updating UI and state
 		// Pass clientInputMode so renderer uses the web's intended mode
 		if (this.callbacks.executeCommand) {
 			this.callbacks
-				.executeCommand(sessionId, command, clientInputMode)
+				.executeCommand(sessionId, command, clientInputMode, requestedTabId)
 				.then((success) => {
 					this.send(client, {
 						type: 'command_result',
 						success,
 						sessionId,
+						...(resolvedTabId ? { tabId: resolvedTabId } : {}),
 						requestId: message.requestId,
 					});
 					if (!success) {
@@ -1659,11 +1677,12 @@ export class WebSocketMessageHandler {
 
 		this.callbacks
 			.newAITabWithPrompt(sessionId, prompt)
-			.then((success) => {
+			.then((result) => {
 				this.send(client, {
 					type: 'new_ai_tab_with_prompt_result',
-					success,
+					success: result.success,
 					sessionId,
+					...(result.tabId ? { tabId: result.tabId } : {}),
 					requestId: message.requestId,
 				});
 			})

--- a/src/main/web-server/managers/CallbackRegistry.ts
+++ b/src/main/web-server/managers/CallbackRegistry.ts
@@ -231,10 +231,11 @@ export class CallbackRegistry {
 	async executeCommand(
 		sessionId: string,
 		command: string,
-		inputMode?: 'ai' | 'terminal'
+		inputMode?: 'ai' | 'terminal',
+		tabId?: string
 	): Promise<boolean> {
 		if (!this.callbacks.executeCommand) return false;
-		return this.callbacks.executeCommand(sessionId, command, inputMode);
+		return this.callbacks.executeCommand(sessionId, command, inputMode, tabId);
 	}
 
 	async interruptSession(sessionId: string): Promise<boolean> {
@@ -306,8 +307,11 @@ export class CallbackRegistry {
 		return this.callbacks.openTerminalTab(sessionId, config);
 	}
 
-	async newAITabWithPrompt(sessionId: string, prompt: string): Promise<boolean> {
-		if (!this.callbacks.newAITabWithPrompt) return false;
+	async newAITabWithPrompt(
+		sessionId: string,
+		prompt: string
+	): Promise<{ success: boolean; tabId?: string }> {
+		if (!this.callbacks.newAITabWithPrompt) return { success: false };
 		return this.callbacks.newAITabWithPrompt(sessionId, prompt);
 	}
 

--- a/src/main/web-server/managers/CallbackRegistry.ts
+++ b/src/main/web-server/managers/CallbackRegistry.ts
@@ -232,10 +232,11 @@ export class CallbackRegistry {
 		sessionId: string,
 		command: string,
 		inputMode?: 'ai' | 'terminal',
-		tabId?: string
+		tabId?: string,
+		force?: boolean
 	): Promise<boolean> {
 		if (!this.callbacks.executeCommand) return false;
-		return this.callbacks.executeCommand(sessionId, command, inputMode, tabId);
+		return this.callbacks.executeCommand(sessionId, command, inputMode, tabId, force);
 	}
 
 	async interruptSession(sessionId: string): Promise<boolean> {

--- a/src/main/web-server/types.ts
+++ b/src/main/web-server/types.ts
@@ -242,12 +242,16 @@ export type WriteToSessionCallback = (sessionId: string, data: string) => boolea
  * Returns true if command was accepted (session not busy).
  * inputMode is optional - if provided, the renderer will use it instead of querying session state.
  * tabId is optional - if provided, the renderer targets that specific tab instead of the active tab.
+ * force is optional - if true, bypasses the renderer's own busy-state guard so
+ *   `dispatch --force` lands on a busy tab. The server-side guard is a separate
+ *   check that is gated by the `allowConcurrentSend` setting.
  */
 export type ExecuteCommandCallback = (
 	sessionId: string,
 	command: string,
 	inputMode?: 'ai' | 'terminal',
-	tabId?: string
+	tabId?: string,
+	force?: boolean
 ) => Promise<boolean>;
 
 /**

--- a/src/main/web-server/types.ts
+++ b/src/main/web-server/types.ts
@@ -241,11 +241,13 @@ export type WriteToSessionCallback = (sessionId: string, data: string) => boolea
  * This forwards the command to the renderer which handles spawn, state, and broadcasts.
  * Returns true if command was accepted (session not busy).
  * inputMode is optional - if provided, the renderer will use it instead of querying session state.
+ * tabId is optional - if provided, the renderer targets that specific tab instead of the active tab.
  */
 export type ExecuteCommandCallback = (
 	sessionId: string,
 	command: string,
-	inputMode?: 'ai' | 'terminal'
+	inputMode?: 'ai' | 'terminal',
+	tabId?: string
 ) => Promise<boolean>;
 
 /**
@@ -295,7 +297,17 @@ export type ReorderTabCallback = (
 export type ToggleBookmarkCallback = (sessionId: string) => Promise<boolean>;
 export type OpenFileTabCallback = (sessionId: string, filePath: string) => Promise<boolean>;
 export type RefreshFileTreeCallback = (sessionId: string) => Promise<boolean>;
-export type NewAITabWithPromptCallback = (sessionId: string, prompt: string) => Promise<boolean>;
+/**
+ * Callback type for atomically creating a new AI tab and dispatching a prompt into it.
+ * Returns the new tab id alongside success so callers (e.g. `maestro-cli dispatch
+ * --new-tab`) can address the same tab on later calls without owning a persistent
+ * channel.
+ */
+export type NewAITabWithPromptResult = { success: boolean; tabId?: string };
+export type NewAITabWithPromptCallback = (
+	sessionId: string,
+	prompt: string
+) => Promise<NewAITabWithPromptResult>;
 export type OpenBrowserTabCallback = (sessionId: string, url: string) => Promise<boolean>;
 export interface OpenTerminalTabConfig {
 	cwd?: string;

--- a/src/main/web-server/web-server-factory.ts
+++ b/src/main/web-server/web-server-factory.ts
@@ -364,7 +364,7 @@ export function createWebServerFactory(deps: WebServerFactoryDependencies) {
 		// This forwards AI commands to the renderer, ensuring single source of truth
 		// The renderer handles all spawn logic, state management, and broadcasts
 		server.setExecuteCommandCallback(
-			async (sessionId: string, command: string, inputMode?: 'ai' | 'terminal') => {
+			async (sessionId: string, command: string, inputMode?: 'ai' | 'terminal', tabId?: string) => {
 				const mainWindow = getMainWindow();
 				if (!mainWindow) {
 					logger.warn('mainWindow is null for executeCommand', 'WebServer');
@@ -380,14 +380,14 @@ export function createWebServerFactory(deps: WebServerFactoryDependencies) {
 				// This ensures web commands go through exact same code path as desktop commands
 				// Pass inputMode so renderer uses the web's intended mode (avoids sync issues)
 				logger.info(
-					`[Web → Renderer] Forwarding command | Maestro: ${sessionId} | Claude: ${agentSessionId} | Mode: ${inputMode || 'auto'} | Command: ${command.substring(0, 100)}`,
+					`[Web → Renderer] Forwarding command | Maestro: ${sessionId} | Claude: ${agentSessionId} | Mode: ${inputMode || 'auto'} | Tab: ${tabId || 'active'} | Command: ${command.substring(0, 100)}`,
 					'WebServer'
 				);
 				if (!isWebContentsAvailable(mainWindow)) {
 					logger.warn('webContents is not available for executeCommand', 'WebServer');
 					return false;
 				}
-				mainWindow.webContents.send('remote:executeCommand', sessionId, command, inputMode);
+				mainWindow.webContents.send('remote:executeCommand', sessionId, command, inputMode, tabId);
 				return true;
 			}
 		);
@@ -721,10 +721,10 @@ export function createWebServerFactory(deps: WebServerFactoryDependencies) {
 			const mainWindow = getMainWindow();
 			if (!mainWindow) {
 				logger.warn('mainWindow is null for newAITabWithPrompt', 'WebServer');
-				return false;
+				return { success: false };
 			}
 
-			return new Promise<boolean>((resolve) => {
+			return new Promise<{ success: boolean; tabId?: string }>((resolve) => {
 				const responseChannel = `remote:newAITabWithPrompt:response:${randomUUID()}`;
 				let resolved = false;
 
@@ -732,14 +732,25 @@ export function createWebServerFactory(deps: WebServerFactoryDependencies) {
 					if (resolved) return;
 					resolved = true;
 					clearTimeout(timeoutId);
-					resolve(result === true);
+					// Renderer was updated to ack with `{ success, tabId? }`. Older
+					// renderers that still send a bare boolean stay supported via
+					// the `result === true` fallback.
+					if (typeof result === 'object' && result !== null) {
+						const r = result as { success?: unknown; tabId?: unknown };
+						resolve({
+							success: r.success === true,
+							tabId: typeof r.tabId === 'string' ? r.tabId : undefined,
+						});
+					} else {
+						resolve({ success: result === true });
+					}
 				};
 
 				ipcMain.once(responseChannel, handleResponse);
 				if (!isWebContentsAvailable(mainWindow)) {
 					logger.warn('webContents is not available for newAITabWithPrompt', 'WebServer');
 					ipcMain.removeListener(responseChannel, handleResponse);
-					resolve(false);
+					resolve({ success: false });
 					return;
 				}
 				mainWindow.webContents.send(
@@ -757,7 +768,7 @@ export function createWebServerFactory(deps: WebServerFactoryDependencies) {
 						`newAITabWithPrompt callback timed out for session ${sessionId}`,
 						'WebServer'
 					);
-					resolve(false);
+					resolve({ success: false });
 				}, 5000);
 			});
 		});

--- a/src/main/web-server/web-server-factory.ts
+++ b/src/main/web-server/web-server-factory.ts
@@ -364,7 +364,13 @@ export function createWebServerFactory(deps: WebServerFactoryDependencies) {
 		// This forwards AI commands to the renderer, ensuring single source of truth
 		// The renderer handles all spawn logic, state management, and broadcasts
 		server.setExecuteCommandCallback(
-			async (sessionId: string, command: string, inputMode?: 'ai' | 'terminal', tabId?: string) => {
+			async (
+				sessionId: string,
+				command: string,
+				inputMode?: 'ai' | 'terminal',
+				tabId?: string,
+				force?: boolean
+			) => {
 				const mainWindow = getMainWindow();
 				if (!mainWindow) {
 					logger.warn('mainWindow is null for executeCommand', 'WebServer');
@@ -376,18 +382,30 @@ export function createWebServerFactory(deps: WebServerFactoryDependencies) {
 				const session = sessions.find((s) => s.id === sessionId);
 				const agentSessionId = session?.agentSessionId || 'none';
 
-				// Forward to renderer - it will handle spawn, state, and everything else
-				// This ensures web commands go through exact same code path as desktop commands
-				// Pass inputMode so renderer uses the web's intended mode (avoids sync issues)
+				// Forward to renderer - it will handle spawn, state, and everything else.
+				// Log metadata only at info level — remote commands can carry secrets,
+				// proprietary code, or PII; the full prompt goes to debug, which is
+				// only enabled by users who have explicitly opted in.
 				logger.info(
-					`[Web → Renderer] Forwarding command | Maestro: ${sessionId} | Claude: ${agentSessionId} | Mode: ${inputMode || 'auto'} | Tab: ${tabId || 'active'} | Command: ${command.substring(0, 100)}`,
+					`[Web → Renderer] Forwarding command | Maestro: ${sessionId} | Claude: ${agentSessionId} | Mode: ${inputMode || 'auto'} | Tab: ${tabId || 'active'} | Force: ${force ? 'yes' : 'no'} | CommandLength: ${command.length}`,
+					'WebServer'
+				);
+				logger.debug(
+					`[Web → Renderer] Command preview (truncated): ${command.substring(0, 100)}`,
 					'WebServer'
 				);
 				if (!isWebContentsAvailable(mainWindow)) {
 					logger.warn('webContents is not available for executeCommand', 'WebServer');
 					return false;
 				}
-				mainWindow.webContents.send('remote:executeCommand', sessionId, command, inputMode, tabId);
+				mainWindow.webContents.send(
+					'remote:executeCommand',
+					sessionId,
+					command,
+					inputMode,
+					tabId,
+					force
+				);
 				return true;
 			}
 		);

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -274,7 +274,12 @@ interface MaestroAPI {
 			) => void
 		) => () => void;
 		onRemoteCommand: (
-			callback: (sessionId: string, command: string, inputMode?: 'ai' | 'terminal') => void
+			callback: (
+				sessionId: string,
+				command: string,
+				inputMode?: 'ai' | 'terminal',
+				tabId?: string
+			) => void
 		) => () => void;
 		onRemoteSwitchMode: (
 			callback: (sessionId: string, mode: 'ai' | 'terminal') => void
@@ -312,7 +317,11 @@ interface MaestroAPI {
 		onRemoteNewAITabWithPrompt: (
 			callback: (sessionId: string, prompt: string, responseChannel: string) => void
 		) => () => void;
-		sendRemoteNewAITabWithPromptResponse: (responseChannel: string, success: boolean) => void;
+		sendRemoteNewAITabWithPromptResponse: (
+			responseChannel: string,
+			success: boolean,
+			tabId?: string
+		) => void;
 		onRemoteRefreshAutoRunDocs: (callback: (sessionId: string) => void) => () => void;
 		onRemoteConfigureAutoRun: (
 			callback: (

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -278,7 +278,8 @@ interface MaestroAPI {
 				sessionId: string,
 				command: string,
 				inputMode?: 'ai' | 'terminal',
-				tabId?: string
+				tabId?: string,
+				force?: boolean
 			) => void
 		) => () => void;
 		onRemoteSwitchMode: (

--- a/src/renderer/hooks/remote/useRemoteHandlers.ts
+++ b/src/renderer/hooks/remote/useRemoteHandlers.ts
@@ -119,13 +119,22 @@ export function useRemoteHandlers(deps: UseRemoteHandlersDeps): UseRemoteHandler
 				sessionId: string;
 				command: string;
 				inputMode?: 'ai' | 'terminal';
+				/** Optional explicit tab target (from `maestro-cli dispatch --session
+				 *  <tabId>`). When unset or unknown, falls back to the active tab. */
+				tabId?: string;
 			}>;
-			const { sessionId, command, inputMode: webInputMode } = customEvent.detail;
+			const {
+				sessionId,
+				command,
+				inputMode: webInputMode,
+				tabId: requestedTabId,
+			} = customEvent.detail;
 
 			logger.info('[Remote] Processing remote command via event:', undefined, {
 				sessionId,
 				command: command.substring(0, 50),
 				webInputMode,
+				requestedTabId,
 			});
 
 			// Find the session directly from sessionsRef (not from React state which may be stale)
@@ -328,6 +337,14 @@ export function useRemoteHandlers(deps: UseRemoteHandlersDeps): UseRemoteHandler
 				}
 			}
 
+			// Resolve the target tab outside the try/catch so the error path can
+			// write its log entry to the same tab we tried to write into.
+			const requestedTab = requestedTabId
+				? session.aiTabs?.find((t) => t.id === requestedTabId)
+				: undefined;
+			const targetTab = requestedTab ?? getActiveTab(session);
+			const writeTabId = targetTab?.id;
+
 			try {
 				// Get agent configuration for this session's tool type
 				const agent = await window.maestro.agents.get(session.toolType);
@@ -336,22 +353,20 @@ export function useRemoteHandlers(deps: UseRemoteHandlersDeps): UseRemoteHandler
 					return;
 				}
 
-				// Get the ACTIVE TAB's agentSessionId for session continuity
-				const activeTab = getActiveTab(session);
-				const tabAgentSessionId = activeTab?.agentSessionId;
-				const isReadOnly = activeTab?.readOnlyMode;
+				const tabAgentSessionId = targetTab?.agentSessionId;
+				const isReadOnly = targetTab?.readOnlyMode;
 
 				// Filter out YOLO/skip-permissions flags when read-only mode is active
 				const agentArgs = agent.args ?? [];
 				const spawnArgs = isReadOnly ? filterYoloArgs(agentArgs, agent) : [...agentArgs];
 
 				// Include tab ID in targetSessionId for proper output routing
-				const targetSessionId = `${sessionId}-ai-${activeTab?.id || 'default'}`;
+				const targetSessionId = `${sessionId}-ai-${targetTab?.id || 'default'}`;
 				const commandToUse = agent.path ?? agent.command ?? '';
 
 				const appendSystemPrompt = await prepareMaestroSystemPrompt({
 					session,
-					activeTabId: activeTab?.id,
+					activeTabId: targetTab?.id,
 				});
 
 				// Determine whether to send the prompt via stdin on Windows to avoid
@@ -367,7 +382,7 @@ export function useRemoteHandlers(deps: UseRemoteHandlersDeps): UseRemoteHandler
 				logger.info('[Remote] Spawning agent:', undefined, {
 					maestroSessionId: sessionId,
 					targetSessionId,
-					activeTabId: activeTab?.id,
+					targetTabId: targetTab?.id,
 					tabAgentSessionId: tabAgentSessionId || 'NEW SESSION',
 					isResume: !!tabAgentSessionId,
 					hasAppendSystemPrompt: !!appendSystemPrompt,
@@ -376,7 +391,7 @@ export function useRemoteHandlers(deps: UseRemoteHandlersDeps): UseRemoteHandler
 					prompt: promptToSend.substring(0, 100),
 				});
 
-				// Add user message to active tab's logs and set state to busy
+				// Add user message to target tab's logs and set state to busy
 				const userLogEntry: LogEntry = {
 					id: generateId(),
 					timestamp: Date.now(),
@@ -389,11 +404,14 @@ export function useRemoteHandlers(deps: UseRemoteHandlersDeps): UseRemoteHandler
 					prev.map((s) => {
 						if (s.id !== sessionId) return s;
 
-						const activeTab = getActiveTab(s);
+						// Pin the target tab id so we don't accidentally write into a
+						// different active tab if the user switched while we awaited
+						// the agent config above.
+						const resolvedWriteTabId = writeTabId ?? s.activeTabId;
 						const updatedAiTabs =
 							s.aiTabs?.length > 0
 								? s.aiTabs.map((tab) =>
-										tab.id === s.activeTabId
+										tab.id === resolvedWriteTabId
 											? {
 													...tab,
 													state: 'busy' as const,
@@ -403,10 +421,8 @@ export function useRemoteHandlers(deps: UseRemoteHandlersDeps): UseRemoteHandler
 									)
 								: s.aiTabs;
 
-						if (!activeTab) {
-							logger.error(
-								'[runAICommand] No active tab found - session has no aiTabs, this should not happen'
-							);
+						if (!s.aiTabs?.some((t) => t.id === resolvedWriteTabId)) {
+							logger.error('[runAICommand] Target tab not found in session — dropping user log');
 							return s;
 						}
 
@@ -465,11 +481,13 @@ export function useRemoteHandlers(deps: UseRemoteHandlersDeps): UseRemoteHandler
 				setSessions((prev) =>
 					prev.map((s) => {
 						if (s.id !== sessionId) return s;
-						const activeTab = getActiveTab(s);
+						// Mirror the success path: route the error log to the same tab
+						// we tried to write into, falling back to active when unset.
+						const resolvedWriteTabId = writeTabId ?? s.activeTabId;
 						const updatedAiTabs =
 							s.aiTabs?.length > 0
 								? s.aiTabs.map((tab) =>
-										tab.id === s.activeTabId
+										tab.id === resolvedWriteTabId
 											? {
 													...tab,
 													state: 'idle' as const,
@@ -480,9 +498,9 @@ export function useRemoteHandlers(deps: UseRemoteHandlersDeps): UseRemoteHandler
 									)
 								: s.aiTabs;
 
-						if (!activeTab) {
+						if (!s.aiTabs?.some((t) => t.id === resolvedWriteTabId)) {
 							logger.error(
-								'[runAICommand error] No active tab found - session has no aiTabs, this should not happen'
+								'[runAICommand error] Target tab not found in session — dropping error log'
 							);
 							return s;
 						}

--- a/src/renderer/hooks/remote/useRemoteHandlers.ts
+++ b/src/renderer/hooks/remote/useRemoteHandlers.ts
@@ -84,7 +84,7 @@ export function useRemoteHandlers(deps: UseRemoteHandlersDeps): UseRemoteHandler
 	// --- Store subscriptions ---
 	const sessions = useSessionStore(selectSessions);
 	const setSessions = useMemo(() => useSessionStore.getState().setSessions, []);
-	const addLogToActiveTab = useMemo(() => useSessionStore.getState().addLogToTab, []);
+	const addLogToTab = useMemo(() => useSessionStore.getState().addLogToTab, []);
 	const setSuccessFlashNotification = useMemo(
 		() => useUIStore.getState().setSuccessFlashNotification,
 		[]
@@ -120,14 +120,22 @@ export function useRemoteHandlers(deps: UseRemoteHandlersDeps): UseRemoteHandler
 				command: string;
 				inputMode?: 'ai' | 'terminal';
 				/** Optional explicit tab target (from `maestro-cli dispatch --session
-				 *  <tabId>`). When unset or unknown, falls back to the active tab. */
+				 *  <tabId>`). When unset, falls back to the active tab. When set
+				 *  but unknown, the command is dropped (we never silently re-route
+				 *  to the active tab — callers chaining `--session <tabId>` would
+				 *  otherwise believe the command landed in the requested tab). */
 				tabId?: string;
+				/** When true, bypass the renderer's busy-state guard. Mirrors the
+				 *  server-side `force` bit so `dispatch --force` can land on a
+				 *  busy session without being dropped at this boundary. */
+				force?: boolean;
 			}>;
 			const {
 				sessionId,
 				command,
 				inputMode: webInputMode,
 				tabId: requestedTabId,
+				force,
 			} = customEvent.detail;
 
 			logger.info('[Remote] Processing remote command via event:', undefined, {
@@ -241,11 +249,32 @@ export function useRemoteHandlers(deps: UseRemoteHandlersDeps): UseRemoteHandler
 				return;
 			}
 
-			// Check if session is busy
-			if (session.state === 'busy') {
+			// Check if session is busy. `force: true` (from `dispatch --force`)
+			// bypasses this guard — without that escape hatch, the renderer would
+			// silently drop forced dispatches and the server-side allow-list
+			// would be moot.
+			if (session.state === 'busy' && !force) {
 				logger.info('[Remote] Session is busy, cannot process command');
 				return;
 			}
+
+			// Resolve the target tab BEFORE the slash-command branch so unknown-
+			// command error logs land on the targeted tab instead of whichever
+			// tab happens to be active. This also lets us short-circuit early
+			// when `--session <tabId>` names a tab that no longer exists, rather
+			// than silently re-routing to the active tab (which would mislead
+			// callers chaining `command_result.tabId` back as `--session`).
+			const requestedTab = requestedTabId
+				? session.aiTabs?.find((t) => t.id === requestedTabId)
+				: undefined;
+			if (requestedTabId && !requestedTab) {
+				logger.warn(
+					`[Remote] Requested tabId "${requestedTabId}" not found in session ${sessionId} — dropping command (avoiding silent re-route to active tab)`
+				);
+				return;
+			}
+			const targetTab = requestedTab ?? getActiveTab(session);
+			const writeTabId = targetTab?.id;
 
 			// Check for slash commands (built-in and custom)
 			let promptToSend = command;
@@ -308,12 +337,14 @@ export function useRemoteHandlers(deps: UseRemoteHandlersDeps): UseRemoteHandler
 					// Read conductorProfile from settings store at call time
 					const conductorProfile = useSettingsStore.getState().conductorProfile;
 
-					// Substitute template variables
+					// Substitute template variables. Use the resolved target tab
+					// id for `activeTabId` so substitutions reflect the dispatch
+					// target rather than whatever tab is actually active in the UI.
 					promptToSend = substituteTemplateVariables(matchingCommand.prompt, {
 						session,
 						gitBranch,
 						groupId: session.groupId,
-						activeTabId: session.activeTabId,
+						activeTabId: writeTabId ?? session.activeTabId,
 						conductorProfile,
 					});
 					commandMetadata = {
@@ -327,23 +358,21 @@ export function useRemoteHandlers(deps: UseRemoteHandlersDeps): UseRemoteHandler
 						promptToSend.substring(0, 100)
 					);
 				} else {
-					// Unknown slash command
+					// Unknown slash command — route the error log to the targeted
+					// tab (not whichever tab happens to be active) so the caller
+					// sees the error in the conversation they dispatched into.
 					logger.info('[Remote] Unknown slash command:', undefined, commandText);
-					addLogToActiveTab(sessionId, {
-						source: 'system',
-						text: `Unknown command: ${commandText}`,
-					});
+					addLogToTab(
+						sessionId,
+						{
+							source: 'system',
+							text: `Unknown command: ${commandText}`,
+						},
+						writeTabId
+					);
 					return;
 				}
 			}
-
-			// Resolve the target tab outside the try/catch so the error path can
-			// write its log entry to the same tab we tried to write into.
-			const requestedTab = requestedTabId
-				? session.aiTabs?.find((t) => t.id === requestedTabId)
-				: undefined;
-			const targetTab = requestedTab ?? getActiveTab(session);
-			const writeTabId = targetTab?.id;
 
 			try {
 				// Get agent configuration for this session's tool type
@@ -351,6 +380,21 @@ export function useRemoteHandlers(deps: UseRemoteHandlersDeps): UseRemoteHandler
 				if (!agent) {
 					logger.info(`[Remote] ERROR: Agent not found for toolType: ${session.toolType}`);
 					return;
+				}
+
+				// The agent-config await above is a real microtask gap. Re-check
+				// that the tab we resolved still exists; if it was closed in the
+				// interim, abort before spawning so the agent doesn't start with
+				// a `${sessionId}-ai-${tabId}` route that nothing reads from.
+				if (writeTabId) {
+					const liveSession = sessionsRef.current.find((s) => s.id === sessionId);
+					const tabStillExists = liveSession?.aiTabs?.some((t) => t.id === writeTabId);
+					if (!tabStillExists) {
+						logger.warn(
+							`[Remote] Target tab "${writeTabId}" was closed before spawn — dropping command`
+						);
+						return;
+					}
 				}
 
 				const tabAgentSessionId = targetTab?.agentSessionId;

--- a/src/renderer/hooks/remote/useRemoteIntegration.ts
+++ b/src/renderer/hooks/remote/useRemoteIntegration.ts
@@ -85,12 +85,20 @@ export function useRemoteIntegration(deps: UseRemoteIntegrationDeps): UseRemoteI
 				tabId?: string,
 				force?: boolean
 			) => {
+				// Log metadata only at info level — remote commands can carry
+				// secrets, proprietary code, or PII. Mirror the redaction the
+				// main process applies in web-server-factory; the truncated
+				// preview moves to debug, which only opted-in users enable.
 				logger.info('[useRemoteIntegration] onRemoteCommand callback invoked:', undefined, {
 					sessionId,
-					command: command?.substring(0, 50),
+					commandLength: command?.length ?? 0,
 					inputMode,
 					tabId,
 					force,
+				});
+				logger.debug('[useRemoteIntegration] onRemoteCommand preview:', undefined, {
+					sessionId,
+					commandPreview: command?.substring(0, 50),
 				});
 
 				// Verify the session exists
@@ -148,11 +156,16 @@ export function useRemoteIntegration(deps: UseRemoteIntegrationDeps): UseRemoteI
 				// Pass the inputMode from web so handleRemoteCommand uses it
 				logger.info('[useRemoteIntegration] Dispatching maestro:remoteCommand event:', undefined, {
 					sessionId,
-					command: command?.substring(0, 50),
+					commandLength: command?.length ?? 0,
 					inputMode,
 					tabId,
 					force,
 				});
+				logger.debug(
+					'[useRemoteIntegration] Dispatching maestro:remoteCommand preview:',
+					undefined,
+					{ sessionId, commandPreview: command?.substring(0, 50) }
+				);
 				window.dispatchEvent(
 					new CustomEvent('maestro:remoteCommand', {
 						detail: { sessionId, command, inputMode, tabId, force },

--- a/src/renderer/hooks/remote/useRemoteIntegration.ts
+++ b/src/renderer/hooks/remote/useRemoteIntegration.ts
@@ -78,11 +78,12 @@ export function useRemoteIntegration(deps: UseRemoteIntegrationDeps): UseRemoteI
 	useEffect(() => {
 		logger.info('[useRemoteIntegration] Setting up onRemoteCommand listener');
 		const unsubscribeRemote = window.maestro.process.onRemoteCommand(
-			(sessionId: string, command: string, inputMode?: 'ai' | 'terminal') => {
+			(sessionId: string, command: string, inputMode?: 'ai' | 'terminal', tabId?: string) => {
 				logger.info('[useRemoteIntegration] onRemoteCommand callback invoked:', undefined, {
 					sessionId,
 					command: command?.substring(0, 50),
 					inputMode,
+					tabId,
 				});
 
 				// Verify the session exists
@@ -140,10 +141,11 @@ export function useRemoteIntegration(deps: UseRemoteIntegrationDeps): UseRemoteI
 					sessionId,
 					command: command?.substring(0, 50),
 					inputMode,
+					tabId,
 				});
 				window.dispatchEvent(
 					new CustomEvent('maestro:remoteCommand', {
-						detail: { sessionId, command, inputMode },
+						detail: { sessionId, command, inputMode, tabId },
 					})
 				);
 				logger.info('[useRemoteIntegration] Event dispatched successfully');
@@ -359,7 +361,7 @@ export function useRemoteIntegration(deps: UseRemoteIntegrationDeps): UseRemoteI
 					window.maestro.process.sendRemoteNewAITabWithPromptResponse(responseChannel, false);
 					return;
 				}
-				let tabCreated = false;
+				let createdTabId: string | undefined;
 				flushSync(() => {
 					setSessions((prev) =>
 						prev.map((s) => {
@@ -369,27 +371,35 @@ export function useRemoteIntegration(deps: UseRemoteIntegrationDeps): UseRemoteI
 								showThinking: defaultShowThinking,
 							});
 							if (!result) return s;
-							tabCreated = true;
+							createdTabId = result.tab.id;
 							return result.session;
 						})
 					);
-					if (tabCreated) {
+					if (createdTabId) {
 						setActiveSessionId(sessionId);
 					}
 				});
-				if (!tabCreated) {
+				if (!createdTabId) {
 					logger.warn(
 						'[useRemoteIntegration] onRemoteNewAITabWithPrompt: createTab failed, dropping prompt'
 					);
 					window.maestro.process.sendRemoteNewAITabWithPromptResponse(responseChannel, false);
 					return;
 				}
+				// Pass the new tab id explicitly so the renderer writes into the tab
+				// we just created — without it, useRemoteHandlers would fall back to
+				// activeTabId, which is correct here but would race in any future
+				// caller that doesn't atomically setActiveSessionId.
 				window.dispatchEvent(
 					new CustomEvent('maestro:remoteCommand', {
-						detail: { sessionId, command: prompt, inputMode: 'ai' },
+						detail: { sessionId, command: prompt, inputMode: 'ai', tabId: createdTabId },
 					})
 				);
-				window.maestro.process.sendRemoteNewAITabWithPromptResponse(responseChannel, true);
+				window.maestro.process.sendRemoteNewAITabWithPromptResponse(
+					responseChannel,
+					true,
+					createdTabId
+				);
 			}
 		);
 

--- a/src/renderer/hooks/remote/useRemoteIntegration.ts
+++ b/src/renderer/hooks/remote/useRemoteIntegration.ts
@@ -78,12 +78,19 @@ export function useRemoteIntegration(deps: UseRemoteIntegrationDeps): UseRemoteI
 	useEffect(() => {
 		logger.info('[useRemoteIntegration] Setting up onRemoteCommand listener');
 		const unsubscribeRemote = window.maestro.process.onRemoteCommand(
-			(sessionId: string, command: string, inputMode?: 'ai' | 'terminal', tabId?: string) => {
+			(
+				sessionId: string,
+				command: string,
+				inputMode?: 'ai' | 'terminal',
+				tabId?: string,
+				force?: boolean
+			) => {
 				logger.info('[useRemoteIntegration] onRemoteCommand callback invoked:', undefined, {
 					sessionId,
 					command: command?.substring(0, 50),
 					inputMode,
 					tabId,
+					force,
 				});
 
 				// Verify the session exists
@@ -99,8 +106,10 @@ export function useRemoteIntegration(deps: UseRemoteIntegrationDeps): UseRemoteI
 					return;
 				}
 
-				// Check if session is busy (should have been checked by web server, but double-check)
-				if (targetSession.state === 'busy') {
+				// Check if session is busy (should have been checked by web server,
+				// but double-check). `force: true` (from `dispatch --force`) opts
+				// out of the guard so a queued follow-up can land on a busy tab.
+				if (targetSession.state === 'busy' && !force) {
 					logger.warn(
 						'[useRemoteIntegration] Session is busy, dropping command. State:',
 						undefined,
@@ -142,10 +151,11 @@ export function useRemoteIntegration(deps: UseRemoteIntegrationDeps): UseRemoteI
 					command: command?.substring(0, 50),
 					inputMode,
 					tabId,
+					force,
 				});
 				window.dispatchEvent(
 					new CustomEvent('maestro:remoteCommand', {
-						detail: { sessionId, command, inputMode, tabId },
+						detail: { sessionId, command, inputMode, tabId, force },
 					})
 				);
 				logger.info('[useRemoteIntegration] Event dispatched successfully');


### PR DESCRIPTION
## Summary

PR1 of the [Maestro CLI surface refactor](https://gist.github.com/chr1syy/9e501e0ef439feb51664ec77cc1ae528). Splits the desktop-handoff half of `send --live` into a dedicated `maestro-cli dispatch` verb and surfaces tab/session IDs in the `send_command` and `new_ai_tab_with_prompt` WebSocket responses, so external consumers (Maestro-Discord, Cue) can chain dispatches without owning a persistent channel.

> Today's `send --live` is two unrelated things — local execution and desktop handoff — wedged into one command. We're splitting them: `send` stays local-and-synchronous, `dispatch` becomes the dedicated desktop handoff and returns a session ID so callers can address the same tab again.

No new architecture, no back-channel — pure rename + ID surfacing.

## What changed

- **New command:** `maestro-cli dispatch <agent> <prompt>` with `--new-tab`, `--session <tabId>`, `--force`. Output:
  ```json
  { "success": true, "agentId": "...", "sessionId": "tab-xyz", "tabId": "tab-xyz" }
  ```
- **`send_command`** now accepts an optional `tabId` and echoes the resolved tab id (caller-supplied tabId, or the session's `activeTabId` from `getSessionDetail`) in `command_result`.
- **`new_ai_tab_with_prompt`** returns the freshly-created `tabId` via the renderer ack — `NewAITabWithPromptCallback` now returns `{ success, tabId? }`, threaded through preload (`sendRemoteNewAITabWithPromptResponse`) + the IPC bridge in `web-server-factory`.
- **Renderer (`useRemoteHandlers`)** honors an explicit `tabId` from `maestro:remoteCommand` so a dispatch writes into the requested tab even if the user switches active tabs mid-flight (falls back to active when unset/unknown).
- **`send --live`** stays as a hidden alias that delegates to `runDispatch` and prints a one-line stderr deprecation notice. Stdout shape (`agentName: "live"`, null sessionId/response/usage) is preserved so existing scripts keep parsing.
- **Cue's CLI executor** (`cue-cli-executor.ts`) now spawns `maestro-cli dispatch <target> <message>` instead of `send <target> <message> --live`. The underlying WebSocket message is unchanged, so behavior is identical.

## Files touched

- New: `src/cli/commands/dispatch.ts`, `src/__tests__/cli/commands/dispatch.test.ts`
- CLI: `src/cli/commands/send.ts`, `src/cli/index.ts`
- Web server: `handlers/messageHandlers.ts`, `managers/CallbackRegistry.ts`, `WebServer.ts`, `web-server-factory.ts`, `types.ts`
- Preload + renderer: `main/preload/process.ts`, `renderer/global.d.ts`, `renderer/hooks/remote/useRemoteIntegration.ts`, `renderer/hooks/remote/useRemoteHandlers.ts`
- Cue: `src/main/cue/cue-cli-executor.ts`
- Updated tests across `messageHandlers`, `CallbackRegistry`, `web-server-factory`, `preload/process`, `useRemoteIntegration`, `cue-cli-executor`, and `send` test suites

## Test plan

- [x] `npm run lint` (tsc) clean
- [x] `npm run lint:eslint` clean
- [x] Prettier clean on all touched files
- [x] 372 in-scope tests pass: `dispatch.test.ts` (13 new cases), `send.test.ts`, `messageHandlers.test.ts`, `CallbackRegistry.test.ts`, `web-server-factory.test.ts`, `preload/process.test.ts`, `useRemoteIntegration.test.ts`, `useRemoteHandlers.test.ts`, `cue-cli-executor.test.ts`
- [x] Manual: `maestro-cli dispatch <agent> "hello" --new-tab` → returns tabId
- [x] Manual: chain `dispatch ... --session <tabId>` → writes to the correct tab even after a tab switch
- [x] Manual: `maestro-cli send <agent> "hello" --live` → still works, prints deprecation notice to stderr
- [x] Manual: Cue subscription with `command.mode: cli` → fires through `dispatch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a new maestro-cli "dispatch" command that returns structured sessionId/tabId and supports explicit tab targeting, creating a new tab, and a force option (force gated by settings).

* **Deprecations**
  * `send --live` is deprecated, emits a deprecation notice and preserves legacy response shape for compatibility.

* **Behavior**
  * IPC/remote flows now propagate tabId and force; tabId is only included when explicitly provided or created; force can bypass busy guards when allowed.

* **Tests**
  * Expanded test coverage for dispatch, send, and remote/IPC behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->