### PR TITLE
fix(cli): register copilot-cli parser + honor promptArgs in send

### DIFF
--- a/src/__tests__/cli/services/agent-spawner.test.ts
+++ b/src/__tests__/cli/services/agent-spawner.test.ts
@@ -1441,6 +1441,47 @@ Some text with [x] in it that's not a checkbox
 			await resultPromise;
 		});
 
+		it('should spawn copilot-cli with -p prompt arg and parse its result event', async () => {
+			const resultPromise = spawnAgent('copilot-cli', '/project', 'Hello copilot');
+			await new Promise((resolve) => setTimeout(resolve, 0));
+
+			const [cmd, args] = mockSpawn.mock.calls[0];
+			expect(cmd).toBeTruthy();
+
+			// Copilot-CLI batch mode: copilot --allow-all --output-format json -p "prompt"
+			expect(args).toContain('--allow-all');
+			expect(args).toContain('--output-format');
+			expect(args).toContain('json');
+			expect(args).toContain('-p');
+			expect(args).toContain('Hello copilot');
+			// promptArgs path replaces the '--' separator
+			expect(args).not.toContain('--');
+
+			// Emit a session.start init event
+			mockStdout.emit(
+				'data',
+				Buffer.from(JSON.stringify({ type: 'session.start', data: { sessionId: 'cop-1' } }) + '\n')
+			);
+			// Emit a final assistant.message (no toolRequests + non-empty content → result)
+			mockStdout.emit(
+				'data',
+				Buffer.from(
+					JSON.stringify({
+						type: 'assistant.message',
+						sessionId: 'cop-1',
+						data: { content: 'Final answer from copilot', toolRequests: [] },
+					}) + '\n'
+				)
+			);
+			await new Promise((resolve) => setTimeout(resolve, 0));
+			mockChild.emit('close', 0);
+
+			const result = await resultPromise;
+			expect(result.success).toBe(true);
+			expect(result.response).toBe('Final answer from copilot');
+			expect(result.agentSessionId).toBe('cop-1');
+		});
+
 		it('should let a pre-set CLAUDE_CODE_DISABLE_BACKGROUND_TASKS from shell env win', async () => {
 			const originalValue = process.env.CLAUDE_CODE_DISABLE_BACKGROUND_TASKS;
 			process.env.CLAUDE_CODE_DISABLE_BACKGROUND_TASKS = '0';

--- a/src/cli/services/agent-spawner.ts
+++ b/src/cli/services/agent-spawner.ts
@@ -4,10 +4,7 @@
 import { spawn, SpawnOptions, ChildProcess } from 'child_process';
 import * as fs from 'fs';
 import type { AgentSshRemoteConfig, ToolType, UsageStats } from '../../shared/types';
-import type { AgentOutputParser } from '../../main/parsers/agent-output-parser';
-import { CodexOutputParser } from '../../main/parsers/codex-output-parser';
-import { OpenCodeOutputParser } from '../../main/parsers/opencode-output-parser';
-import { FactoryDroidOutputParser } from '../../main/parsers/factory-droid-output-parser';
+import { createOutputParser } from '../../main/parsers/parser-factory';
 import { aggregateModelUsage } from '../../main/parsers/usage-aggregator';
 import { getAgentDefinition } from '../../main/agents/definitions';
 import { hasCapability } from '../../main/agents/capabilities';
@@ -549,20 +546,6 @@ function mergeUsageStats(
 	return merged;
 }
 
-/** Create the appropriate output parser for a given agent type */
-function createParser(toolType: ToolType): AgentOutputParser {
-	switch (toolType) {
-		case 'codex':
-			return new CodexOutputParser();
-		case 'opencode':
-			return new OpenCodeOutputParser();
-		case 'factory-droid':
-			return new FactoryDroidOutputParser();
-		default:
-			throw new Error(`No parser available for agent type: ${toolType}`);
-	}
-}
-
 /**
  * Generic spawner for agents that use JSON line output parsed via AgentOutputParser.
  * Handles Codex, OpenCode, Factory Droid, and any future agents with the same pattern.
@@ -632,8 +615,16 @@ async function spawnJsonLineAgent(
 
 	const noPromptSeparator = !!def?.noPromptSeparator;
 
-	// Local prompt embedding mirrors wrapSpawnWithSsh's default behavior
-	const localArgs = noPromptSeparator ? [...baseArgs, prompt] : [...baseArgs, '--', prompt];
+	// Local prompt embedding mirrors wrapSpawnWithSsh's default behavior.
+	// Mirror ChildProcessSpawner's precedence so agents like Copilot/Gemini
+	// that ship a `promptArgs` builder (e.g. ['-p', prompt]) get the prompt
+	// via their flag instead of the bare '--' separator (which Copilot CLI
+	// doesn't accept as a positional prompt).
+	const localArgs = def?.promptArgs
+		? [...baseArgs, ...def.promptArgs(prompt)]
+		: noPromptSeparator
+			? [...baseArgs, prompt]
+			: [...baseArgs, '--', prompt];
 
 	const agentCommand = getAgentCommand(toolType);
 
@@ -653,6 +644,7 @@ async function spawnJsonLineAgent(
 				customEnvVars: buildSshEnvForRemote(def, readOnlyMode, userCustomEnvVars),
 				agentBinaryName: def?.binaryName,
 				noPromptSeparator,
+				promptArgs: def?.promptArgs,
 			},
 			sshRemoteConfig
 		);
@@ -660,6 +652,14 @@ async function spawnJsonLineAgent(
 			return sshUnresolvedFailure(sshRemoteConfig);
 		}
 		({ spawnCommand, spawnArgs, spawnCwd, spawnEnv, sshStdinScript } = applySshWrapResult(wrapped));
+	}
+
+	// Resolve the output parser before spawning so a misconfigured agent type
+	// fails fast instead of leaving an orphaned child process. Reviewer flagged
+	// the previous post-spawn null-check as a process leak (greptile P1).
+	const parser = createOutputParser(toolType);
+	if (!parser) {
+		return { success: false, error: `No parser available for agent type: ${toolType}` };
 	}
 
 	return new Promise((resolve) => {
@@ -671,7 +671,6 @@ async function spawnJsonLineAgent(
 
 		const child = spawn(spawnCommand, spawnArgs, options);
 
-		const parser = createParser(toolType);
 		let jsonBuffer = '';
 		let result: string | undefined;
 		let sessionId: string | undefined;


### PR DESCRIPTION
## Summary

- `maestro-cli send` against any `copilot-cli` agent threw `Error: No parser available for agent type: copilot-cli` because `src/cli/services/agent-spawner.ts` had its own duplicated parser switch that was missing the entry. Replaced it with `createOutputParser()` from `parser-factory.ts` so the registry is single-source (copilot-cli is already wired there).
- Same spawner ignored each agent definition's `promptArgs` builder, so even after registration Copilot would have spawned with the prompt as a positional arg after `--` instead of via `-p`. Mirrored `ChildProcessSpawner`'s precedence (`promptArgs` → `noPromptSeparator` → `--`); Copilot now spawns as `copilot --allow-all --output-format json -p "<prompt>"`.
- Added a regression test that asserts the argv shape and round-trips a `session.start` + final `assistant.message` event into a successful result with the captured session id.

## Repro

```
$ maestro-cli send <copilot-agent> "hi"
Error: No parser available for agent type: copilot-cli
    at createParser (.../dist/cli/maestro-cli.js:56686:13)
    at spawnJsonLineAgent (...)
    at spawnAgent (...)
    at _Command.send (...)
```

## Test plan

- [x] `npm run lint` — all three tsc projects clean
- [x] `prettier --check` clean on changed files
- [x] `eslint` clean on `src/cli/services/agent-spawner.ts`
- [x] `vitest run src/__tests__/cli/services/agent-spawner.test.ts` — 85/85 passing (84 pre-existing + 1 new copilot regression)
- [x] Manual: `maestro-cli send <copilot-agent> "hi"` returns a response instead of throwing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test coverage validating agent spawn behavior for the copilot-cli flow, including flag handling and JSON-line output parsing to ensure successful session responses.

* **Refactor**
  * Improved agent spawner to centralize output parser creation and streamline prompt-argument handling for more reliable local and wrapped executions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->