### PR TITLE
docs(cli): cover dispatch, gist create, open-browser, open-terminal, director-notes

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -91,6 +91,18 @@ Error codes: `AGENT_NOT_FOUND`, `AGENT_UNSUPPORTED`, `CLAUDE_NOT_FOUND`, `CODEX_
 
 Supported agent types: `claude-code`, `codex`.
 
+#### Messages that start with a dash
+
+Messages whose first character is a dash (em-dash `—`, en-dash `–`, double-dash `--`, minus `-`) collide with option parsing and will be rejected as unknown flags. Use the standard `--` end-of-options separator so the message is passed verbatim:
+
+```bash
+maestro-cli send <agent-id> -- "———revise the spec"
+maestro-cli send <agent-id> -s <session-id> -- "--re-run"
+maestro-cli dispatch <agent-id> -- "--force the rewrite"
+```
+
+Everything after `--` is treated as positional, so any flags you need (`-s`, `-r`, `-t`, `--new-tab`, `-f`) must come before the separator.
+
 ### Dispatching to a Desktop Tab
 
 `dispatch` hands a prompt to an agent in the running Maestro desktop app and returns the tab/session id, so callers can address the same tab on follow-up calls without holding a persistent channel. It replaces `send --live` for orchestration use cases (Cue pipelines, external bots, multi-step automations).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -83,13 +83,50 @@ On failure, `success` is `false` and an `error` field is included:
 | `-s, --session <id>` | Resume an existing session instead of creating a new one                                                                                                                                            |
 | `-r, --read-only`    | Run in read-only/plan mode (agent cannot modify files)                                                                                                                                              |
 | `-t, --tab`          | Open/focus the agent's session tab in the Maestro desktop app                                                                                                                                       |
-| `-l, --live`         | Route the message through the Maestro desktop so it appears in the agent's tab                                                                                                                      |
+| `-l, --live`         | **Deprecated — use `dispatch` instead.** Route the message through the Maestro desktop so it appears in the agent's tab                                                                             |
 | `--new-tab`          | With `--live`, create a new AI tab and send the prompt into it                                                                                                                                      |
 | `-f, --force`        | With `--live`, bypass the busy-state guard so you can dispatch concurrent writes to a single agent's active tab. Requires `allowConcurrentSend=true`; otherwise exits with code `FORCE_NOT_ALLOWED` |
 
 Error codes: `AGENT_NOT_FOUND`, `AGENT_UNSUPPORTED`, `CLAUDE_NOT_FOUND`, `CODEX_NOT_FOUND`, `INVALID_OPTIONS`, `FORCE_NOT_ALLOWED`, `MAESTRO_NOT_RUNNING`, `SESSION_NOT_FOUND`, `COMMAND_FAILED`.
 
 Supported agent types: `claude-code`, `codex`.
+
+### Dispatching to a Desktop Tab
+
+`dispatch` hands a prompt to an agent in the running Maestro desktop app and returns the tab/session id, so callers can address the same tab on follow-up calls without holding a persistent channel. It replaces `send --live` for orchestration use cases (Cue pipelines, external bots, multi-step automations).
+
+```bash
+# Dispatch to the active tab of an agent
+maestro-cli dispatch <agent-id> "review the PR description"
+
+# Open a fresh tab and dispatch the prompt into it
+maestro-cli dispatch <agent-id> "start a new review pass" --new-tab
+
+# Continue a previous dispatch by targeting its tab
+maestro-cli dispatch <agent-id> "and now run the tests" -s <tab-id>
+
+# Force a write to a busy tab (requires allowConcurrentSend=true)
+maestro-cli dispatch <agent-id> "interrupt with this" -f
+```
+
+Output is always JSON. `sessionId` and `tabId` are the same value, duplicated so polling consumers can use either name:
+
+```json
+{
+	"success": true,
+	"agentId": "a1b2c3d4-...",
+	"sessionId": "tab-xyz",
+	"tabId": "tab-xyz"
+}
+```
+
+| Flag                 | Description                                                                                       |
+| -------------------- | ------------------------------------------------------------------------------------------------- |
+| `--new-tab`          | Create a fresh AI tab in the target agent. Mutually exclusive with `-s`                           |
+| `-s, --session <id>` | Target an existing tab by id (from a previous `dispatch`). Mutually exclusive with `--new-tab`    |
+| `-f, --force`        | Bypass the busy-state guard. Gated by `allowConcurrentSend`; errors with code `FORCE_NOT_ALLOWED` |
+
+Error codes: `INVALID_OPTIONS`, `AGENT_NOT_FOUND`, `FORCE_NOT_ALLOWED`, `MAESTRO_NOT_RUNNING`, `SESSION_NOT_FOUND`, `COMMAND_FAILED`. Requires the Maestro desktop app to be running.
 
 ### Listing Sessions
 
@@ -517,6 +554,47 @@ Open a file as a preview tab in the Maestro desktop app:
 maestro-cli open-file <file-path> [--session <id>]
 ```
 
+#### Open a Browser Tab
+
+Open a URL as a browser tab in the Maestro desktop app. Only `http(s)` URLs are accepted; scheme-less inputs like `localhost:3000` or `example.com:8080` are auto-prefixed with `https://`.
+
+```bash
+# Open in the active agent
+maestro-cli open-browser https://docs.runmaestro.ai
+
+# Scheme-less — gets https:// prepended
+maestro-cli open-browser localhost:3000
+
+# Target a specific agent
+maestro-cli open-browser https://github.com/RunMaestro/Maestro -a <agent-id>
+```
+
+| Flag               | Description                                       |
+| ------------------ | ------------------------------------------------- |
+| `-a, --agent <id>` | Target agent by ID (defaults to the active agent) |
+
+#### Open a Terminal Tab
+
+Open a fresh terminal tab in the Maestro desktop app. The working directory must resolve inside the target agent's `cwd`; paths outside it are rejected.
+
+```bash
+# Open a terminal in the active agent's cwd with the default shell
+maestro-cli open-terminal
+
+# Custom cwd, shell, and tab label
+maestro-cli open-terminal --cwd ./packages/api --shell bash --name "API tests"
+
+# Target a specific agent
+maestro-cli open-terminal -a <agent-id> --name "Build watch"
+```
+
+| Flag               | Description                                                         | Default     |
+| ------------------ | ------------------------------------------------------------------- | ----------- |
+| `-a, --agent <id>` | Target agent by ID (defaults to the active agent)                   | —           |
+| `--cwd <path>`     | Working directory for the terminal (must be inside the agent's cwd) | agent's cwd |
+| `--shell <bin>`    | Shell binary to use                                                 | `zsh`       |
+| `--name <label>`   | Display name for the tab                                            | —           |
+
 #### Refresh the File Tree
 
 Refresh the file tree sidebar after creating multiple files or making significant filesystem changes:
@@ -738,6 +816,63 @@ maestro-cli cue trigger "deploy" --prompt "Deploy commit abc123 to production" -
 # Re-run a failed automation
 maestro-cli cue trigger "lint-on-save"
 ```
+
+## Director's Notes
+
+Director's Notes is an Encore feature (`encoreFeatures.directorNotes`) that builds a unified history view across every agent in your fleet, plus an AI-generated synopsis of recent activity.
+
+```bash
+# Show recent unified history (last N days, default 7)
+maestro-cli director-notes history -d 3
+
+# Limit to user-initiated entries only
+maestro-cli director-notes history --filter user -l 50
+
+# Markdown output for piping into a doc
+maestro-cli director-notes history -f markdown -d 1
+
+# AI synopsis of the past day (requires the desktop app running)
+maestro-cli director-notes synopsis -d 1
+maestro-cli director-notes synopsis --json
+```
+
+| Subcommand | Flag                  | Description                                                              |
+| ---------- | --------------------- | ------------------------------------------------------------------------ |
+| both       | `-d, --days <n>`      | Lookback period in days (defaults to the app's Director's Notes setting) |
+| both       | `-f, --format <type>` | Output format: `json`, `markdown`, `text` (default `text`)               |
+| both       | `--json`              | Shorthand for `--format json`                                            |
+| `history`  | `--filter <type>`     | Filter by entry type: `auto`, `user`, `cue`                              |
+| `history`  | `-l, --limit <n>`     | Maximum entries to show (default 100)                                    |
+
+`synopsis` requires the desktop app to be running; `history` reads from disk and works offline. If `encoreFeatures.directorNotes` is disabled, enable it first with `maestro-cli settings set encoreFeatures.directorNotes true`.
+
+## Publishing Session Transcripts to Gists
+
+Publish an agent's session transcript to a GitHub gist so you can share it with collaborators or attach it to a bug report. Routes through the running Maestro desktop app (which holds the live transcript) and uses the user's authenticated `gh` CLI under the hood.
+
+```bash
+# Create a private gist (default)
+maestro-cli gist create <agent-id>
+
+# Add a description
+maestro-cli gist create <agent-id> -d "Auth refactor pairing session"
+
+# Make it public
+maestro-cli gist create <agent-id> --public -d "Repro for issue #1234"
+```
+
+| Flag                       | Description                            | Default |
+| -------------------------- | -------------------------------------- | ------- |
+| `-d, --description <text>` | Gist description                       | —       |
+| `-p, --public`             | Create a public gist (default private) | private |
+
+Output is JSON with the gist URL on success:
+
+```json
+{ "success": true, "agentId": "a1b2c3d4-...", "gistUrl": "https://gist.github.com/..." }
+```
+
+Requires the Maestro desktop app to be running and `gh` to be authenticated (`gh auth login`). Error codes: `AGENT_NOT_FOUND`, `MAESTRO_NOT_RUNNING`, `GIST_CREATE_FAILED`.
 
 ## Scheduling with Cron
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -120,13 +120,13 @@ Output is always JSON. `sessionId` and `tabId` are the same value, duplicated so
 }
 ```
 
-| Flag                 | Description                                                                                       |
-| -------------------- | ------------------------------------------------------------------------------------------------- |
-| `--new-tab`          | Create a fresh AI tab in the target agent. Mutually exclusive with `-s`                           |
-| `-s, --session <id>` | Target an existing tab by id (from a previous `dispatch`). Mutually exclusive with `--new-tab`    |
-| `-f, --force`        | Bypass the busy-state guard. Gated by `allowConcurrentSend`; errors with code `FORCE_NOT_ALLOWED` |
+| Flag                 | Description                                                                                                                                    |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--new-tab`          | Create a fresh AI tab in the target agent. Mutually exclusive with `-s` and `-f` (a new tab is never busy, so `--force` has nothing to bypass) |
+| `-s, --session <id>` | Target an existing tab by id (from a previous `dispatch`). Mutually exclusive with `--new-tab`                                                 |
+| `-f, --force`        | Bypass the busy-state guard. Gated by `allowConcurrentSend`; errors with code `FORCE_NOT_ALLOWED`. Cannot be combined with `--new-tab`         |
 
-Error codes: `INVALID_OPTIONS`, `AGENT_NOT_FOUND`, `FORCE_NOT_ALLOWED`, `MAESTRO_NOT_RUNNING`, `SESSION_NOT_FOUND`, `COMMAND_FAILED`. Requires the Maestro desktop app to be running.
+Error codes: `INVALID_OPTIONS`, `AGENT_NOT_FOUND`, `FORCE_NOT_ALLOWED`, `MAESTRO_NOT_RUNNING`, `SESSION_NOT_FOUND`, `NEW_TAB_NO_ID`, `COMMAND_FAILED`. `NEW_TAB_NO_ID` fires when the desktop app acknowledges `--new-tab` without returning a tab id, leaving callers nothing to chain follow-up dispatches against. Requires the Maestro desktop app to be running.
 
 ### Listing Sessions
 

--- a/src/prompts/_maestro-cli.md
+++ b/src/prompts/_maestro-cli.md
@@ -129,6 +129,18 @@ Output (always JSON; `sessionId` and `tabId` are duplicates of the same value, k
 
 Error codes: `INVALID_OPTIONS`, `AGENT_NOT_FOUND`, `FORCE_NOT_ALLOWED`, `MAESTRO_NOT_RUNNING`, `SESSION_NOT_FOUND`, `NEW_TAB_NO_ID`, `COMMAND_FAILED`. `NEW_TAB_NO_ID` fires when the desktop acks `--new-tab` without returning a tab id, leaving nothing to chain follow-up dispatches against. Requires the desktop app to be running.
 
+#### Messages that start with a dash
+
+Messages whose first character is a dash (em-dash `—`, en-dash `–`, double-dash `--`, minus `-`) collide with option parsing and will be rejected as unknown flags. Use the standard `--` end-of-options separator so the message is passed verbatim:
+
+```bash
+{{MAESTRO_CLI_PATH}} send <agent-id> -- "———revise the spec"
+{{MAESTRO_CLI_PATH}} send <agent-id> -s <session-id> -- "--re-run"
+{{MAESTRO_CLI_PATH}} dispatch <agent-id> -- "--force the rewrite"
+```
+
+Everything after `--` is treated as positional, so any flags (`-s`, `-r`, `-t`, `--new-tab`, `-f`) must come before the separator.
+
 ### Resource Listing and Inspection
 
 ```bash

--- a/src/prompts/_maestro-cli.md
+++ b/src/prompts/_maestro-cli.md
@@ -103,9 +103,31 @@ Send a message to another agent and receive a JSON response. Useful for inter-ag
 | `-s, --session <id>` | Resume an existing session instead of creating a new one                                                                                                                                                                              |
 | `-r, --read-only`    | Run in read-only mode (agent cannot modify files)                                                                                                                                                                                     |
 | `-t, --tab`          | Open/focus the agent's session tab in Maestro                                                                                                                                                                                         |
-| `-l, --live`         | Route the message through the Maestro desktop so it appears in the agent's tab                                                                                                                                                        |
+| `-l, --live`         | **Deprecated — use `dispatch` instead.** Route the message through the Maestro desktop so it appears in the agent's tab                                                                                                               |
 | `--new-tab`          | With `--live`, create a new AI tab and send the prompt into it                                                                                                                                                                        |
 | `-f, --force`        | With `--live`, bypass the busy-state guard so you can dispatch concurrent writes to a single agent's active tab. Gated by the `allowConcurrentSend` setting (off by default); errors out with code `FORCE_NOT_ALLOWED` if not enabled |
+
+### Dispatch a Prompt to a Desktop Tab
+
+Hand a prompt to an agent in the running Maestro desktop and get back the tab/session id so you can address the same tab on follow-up calls. This is the replacement for `send --live`: same desktop-handoff behavior, but no synchronous response and no need to own a persistent channel — pollers and pipelines (Cue, Maestro-Discord, etc.) re-target by tab id.
+
+```bash
+{{MAESTRO_CLI_PATH}} dispatch <agent-id> "Your message here" [--new-tab] [-s <tab-id>] [-f]
+```
+
+| Flag                 | Description                                                                                                                                       |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--new-tab`          | Create a fresh AI tab in the target agent and dispatch the prompt into it. Mutually exclusive with `-s`                                           |
+| `-s, --session <id>` | Target an existing tab by its tab id (returned from a previous `dispatch`). Mutually exclusive with `--new-tab`                                   |
+| `-f, --force`        | Bypass the busy-state guard when writing to a busy tab. Gated by `allowConcurrentSend` (off by default); errors out with code `FORCE_NOT_ALLOWED` |
+
+Output (always JSON; `sessionId` and `tabId` are duplicates of the same value, kept for caller convenience):
+
+```json
+{ "success": true, "agentId": "a1b2c3d4-...", "sessionId": "tab-xyz", "tabId": "tab-xyz" }
+```
+
+Error codes: `INVALID_OPTIONS`, `AGENT_NOT_FOUND`, `FORCE_NOT_ALLOWED`, `MAESTRO_NOT_RUNNING`, `SESSION_NOT_FOUND`, `COMMAND_FAILED`. Requires the desktop app to be running.
 
 ### Resource Listing and Inspection
 
@@ -162,12 +184,20 @@ Use these after filesystem changes so the user sees updates immediately:
 # Open a file in Maestro
 {{MAESTRO_CLI_PATH}} open-file <file-path> [--session <id>]
 
+# Open a URL as a browser tab (scheme-less inputs like `localhost:3000` are auto-prefixed with https://)
+{{MAESTRO_CLI_PATH}} open-browser <url> [-a, --agent <id>]
+
+# Open a fresh terminal tab (cwd must be inside the target agent's working directory)
+{{MAESTRO_CLI_PATH}} open-terminal [-a, --agent <id>] [--cwd <path>] [--shell <bin>] [--name <label>]
+
 # Refresh the file tree after multiple file changes
 {{MAESTRO_CLI_PATH}} refresh-files [--session <id>]
 
 # Refresh Auto Run documents after creating or modifying them
 {{MAESTRO_CLI_PATH}} refresh-auto-run [--session <id>]
 ```
+
+`open-browser` only accepts `http(s)` URLs. `open-terminal` defaults to `zsh`; pass `--shell` to override and `--name` to set the tab label.
 
 ### Notifications
 
@@ -245,6 +275,16 @@ Unified history and AI-generated synopses across all agents.
 {{MAESTRO_CLI_PATH}} director-notes history [-d, --days <n>] [-f, --format json|markdown|text] [--filter auto|user|cue] [-l, --limit <n>]
 {{MAESTRO_CLI_PATH}} director-notes synopsis [-d, --days <n>] [--json]
 ```
+
+### Gists
+
+Publish an agent's session transcript to a GitHub gist. Routes through the running desktop app (which holds the live transcript) and uses the user's authenticated `gh` CLI under the hood.
+
+```bash
+{{MAESTRO_CLI_PATH}} gist create <agent-id> [-d, --description <text>] [-p, --public]
+```
+
+Defaults to a private gist; pass `-p` for public. Output is JSON with `gistUrl` on success. Requires the desktop app to be running and `gh` to be authenticated. Error codes: `AGENT_NOT_FOUND`, `MAESTRO_NOT_RUNNING`, `GIST_CREATE_FAILED`.
 
 ### Prompts (Self-Reference)
 

--- a/src/prompts/_maestro-cli.md
+++ b/src/prompts/_maestro-cli.md
@@ -115,11 +115,11 @@ Hand a prompt to an agent in the running Maestro desktop and get back the tab/se
 {{MAESTRO_CLI_PATH}} dispatch <agent-id> "Your message here" [--new-tab] [-s <tab-id>] [-f]
 ```
 
-| Flag                 | Description                                                                                                                                       |
-| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--new-tab`          | Create a fresh AI tab in the target agent and dispatch the prompt into it. Mutually exclusive with `-s`                                           |
-| `-s, --session <id>` | Target an existing tab by its tab id (returned from a previous `dispatch`). Mutually exclusive with `--new-tab`                                   |
-| `-f, --force`        | Bypass the busy-state guard when writing to a busy tab. Gated by `allowConcurrentSend` (off by default); errors out with code `FORCE_NOT_ALLOWED` |
+| Flag                 | Description                                                                                                                                                                            |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--new-tab`          | Create a fresh AI tab in the target agent and dispatch the prompt into it. Mutually exclusive with `-s` and `-f` (a new tab is never busy)                                             |
+| `-s, --session <id>` | Target an existing tab by its tab id (returned from a previous `dispatch`). Mutually exclusive with `--new-tab`                                                                        |
+| `-f, --force`        | Bypass the busy-state guard when writing to a busy tab. Gated by `allowConcurrentSend` (off by default); errors out with code `FORCE_NOT_ALLOWED`. Cannot be combined with `--new-tab` |
 
 Output (always JSON; `sessionId` and `tabId` are duplicates of the same value, kept for caller convenience):
 
@@ -127,7 +127,7 @@ Output (always JSON; `sessionId` and `tabId` are duplicates of the same value, k
 { "success": true, "agentId": "a1b2c3d4-...", "sessionId": "tab-xyz", "tabId": "tab-xyz" }
 ```
 
-Error codes: `INVALID_OPTIONS`, `AGENT_NOT_FOUND`, `FORCE_NOT_ALLOWED`, `MAESTRO_NOT_RUNNING`, `SESSION_NOT_FOUND`, `COMMAND_FAILED`. Requires the desktop app to be running.
+Error codes: `INVALID_OPTIONS`, `AGENT_NOT_FOUND`, `FORCE_NOT_ALLOWED`, `MAESTRO_NOT_RUNNING`, `SESSION_NOT_FOUND`, `NEW_TAB_NO_ID`, `COMMAND_FAILED`. `NEW_TAB_NO_ID` fires when the desktop acks `--new-tab` without returning a tab id, leaving nothing to chain follow-up dispatches against. Requires the desktop app to be running.
 
 ### Resource Listing and Inspection
 


### PR DESCRIPTION
## Summary

Closes documentation gaps for five maestro-cli commands across both the bundled agent-facing CLI reference (`src/prompts/_maestro-cli.md`) and the public user guide (`docs/cli.md`).

- **`dispatch`** (PR #907): full section with flag table (`--new-tab`, `-s`, `-f`), JSON response shape (`sessionId`/`tabId` duplicated), and error codes. The `send --live` row is now marked deprecated and points to `dispatch`.
- **`gist create`** (PR #898): section with flag table, `gh` auth prerequisite, error codes (`AGENT_NOT_FOUND`, `MAESTRO_NOT_RUNNING`, `GIST_CREATE_FAILED`).
- **`open-browser`**: `http(s)`-only constraint and scheme-less auto-prefix behavior documented.
- **`open-terminal`**: cwd-confinement rule and `zsh` default documented.
- **`director-notes`**: was previously only in the bundled prompt; now in the public guide too, with the `encoreFeatures.directorNotes` Encore-flag prerequisite called out.

Pure documentation — no source changes. Diffstat: `docs/cli.md +137/-2`, `src/prompts/_maestro-cli.md +42/-2`.

Source for each command was read directly from `src/cli/commands/{dispatch,gist,open-browser,open-terminal}.ts` and `src/cli/index.ts` to ensure flag names, defaults, and error codes match implementation.

## Test plan

- [ ] Render `docs/cli.md` in Mintlify preview and confirm the new sections (Dispatching to a Desktop Tab, Open a Browser Tab, Open a Terminal Tab, Director's Notes, Publishing Session Transcripts to Gists) render cleanly with no broken tables or anchors.
- [ ] Spot-check the bundled prompt is still valid for `maestro-cli prompts get _maestro-cli` (no broken `{{MAESTRO_CLI_PATH}}` interpolation, no orphaned headings).
- [ ] Confirm flag tables match each command's actual options (`maestro-cli dispatch --help`, `maestro-cli gist create --help`, `maestro-cli open-browser --help`, `maestro-cli open-terminal --help`, `maestro-cli director-notes history --help`, `maestro-cli director-notes synopsis --help`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `dispatch` to route prompts to running desktop tabs; always returns JSON with session/tab IDs.
  * New CLI commands: `open-browser` (http(s) only, auto-prefixes https) and `open-terminal` (cwd-aware, configurable shell/name).
  * Director’s Notes (history, synopsis formats) and `gist create` to publish session transcripts via the desktop app.

* **Documentation / CLI guidance**
  * Messages starting with `-` must use `--` to prevent option parsing.
  * `--new-tab` and `-s/--session` are mutually exclusive; `-f/--force` can bypass busy-guard but may be disallowed. 

* **Deprecations**
  * Deprecated `send -l/--live`; use `dispatch`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->