### PR TITLE
fix(renderer): #913 platform detection crash on missing process global

### DIFF
--- a/src/__tests__/shared/platformDetection.test.ts
+++ b/src/__tests__/shared/platformDetection.test.ts
@@ -78,4 +78,38 @@ describe('platformDetection', () => {
 			expect(getWhichCommand()).toBe('which');
 		});
 	});
+
+	describe('renderer (browser) fallback', () => {
+		// In a renderer, `process` is undefined and `globalThis.maestro.platform`
+		// is provided by the preload bridge. Simulate the no-process case by
+		// blanking process.platform; the fallback should pick up maestro.platform.
+		const g = globalThis as unknown as { maestro?: { platform?: string } };
+
+		it('reads platform from globalThis.maestro.platform when process.platform is empty', () => {
+			Object.defineProperty(process, 'platform', { value: '', configurable: true });
+			const savedMaestro = g.maestro;
+			try {
+				g.maestro = { platform: 'darwin' };
+				expect(isMacOS()).toBe(true);
+				expect(isWindows()).toBe(false);
+				expect(isLinux()).toBe(false);
+			} finally {
+				g.maestro = savedMaestro;
+			}
+		});
+
+		it('falls back to linux when neither process.platform nor maestro is defined', () => {
+			Object.defineProperty(process, 'platform', { value: '', configurable: true });
+			const savedMaestro = g.maestro;
+			try {
+				g.maestro = undefined;
+				expect(() => isMacOS()).not.toThrow();
+				expect(isLinux()).toBe(true);
+				expect(isMacOS()).toBe(false);
+				expect(isWindows()).toBe(false);
+			} finally {
+				g.maestro = savedMaestro;
+			}
+		});
+	});
 });

--- a/src/shared/platformDetection.ts
+++ b/src/shared/platformDetection.ts
@@ -1,26 +1,43 @@
 /**
  * Centralized platform detection utilities.
  *
- * All functions read process.platform at call time so that tests can
+ * All functions read the platform string at call time so that tests can
  * override it via Object.defineProperty(process, 'platform', { value: '...', configurable: true })
  * without module-level caching defeating the mock.
  *
  * Do NOT convert these to module-level constants.
+ *
+ * In renderer (browser) contexts there is no `process` global; the platform
+ * string is exposed via the preload bridge at `window.maestro.platform`.
+ * Touching the bare `process` identifier in renderer code throws a
+ * ReferenceError, so the lookup goes through `globalThis` instead.
  */
+
+type GlobalWithPlatform = {
+	process?: { platform?: string };
+	maestro?: { platform?: string };
+};
+
+function getPlatform(): string {
+	const g = globalThis as GlobalWithPlatform;
+	if (g.process?.platform) return g.process.platform;
+	if (g.maestro?.platform) return g.maestro.platform;
+	return 'linux';
+}
 
 /** Returns true when running on Windows (win32). */
 export function isWindows(): boolean {
-	return process.platform === 'win32';
+	return getPlatform() === 'win32';
 }
 
 /** Returns true when running on macOS (darwin). */
 export function isMacOS(): boolean {
-	return process.platform === 'darwin';
+	return getPlatform() === 'darwin';
 }
 
 /** Returns true when running on Linux. */
 export function isLinux(): boolean {
-	return process.platform === 'linux';
+	return getPlatform() === 'linux';
 }
 
 /**


### PR DESCRIPTION
## Summary
- `RenameTabModal` imports `isMacOS()` from `src/shared/platformDetection.ts` so it can label the new Cmd/Ctrl+Shift+Enter Auto-name shortcut.
- Those helpers read `process.platform` directly. The renderer has no `process` global, so opening the rename modal threw `ReferenceError: process is not defined`, which the React Error Boundary caught and crashed the page (issue #913).
- Read the platform string off `globalThis` instead, falling back to `globalThis.maestro.platform` (exposed by the preload bridge) when there is no Node `process`.

## Test plan
- [x] `npx vitest run src/__tests__/shared/platformDetection.test.ts` — all 14 tests pass, including two new cases covering the renderer fallback path.
- [x] `npx tsc -p tsconfig.lint.json` / `tsconfig.main.json` / `tsconfig.cli.json` — no new errors (only the pre-existing `generated/prompts` issue from a fresh checkout).
- [ ] Manual smoke: package the app, open the rename-tab modal on a session that has been removed, and confirm no crash.

closes #913

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved platform detection to reliably work in both Node.js and browser/renderer environments.
  * Enhanced platform detection to gracefully handle scenarios where standard platform APIs are unavailable, with appropriate fallback behavior.

* **Tests**
  * Added comprehensive test coverage for platform detection across different environments and fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->