### PR TITLE
fix(cue): pipeline view agent fallback prefers owner over sessions[0] (#912)

### DIFF
--- a/src/__tests__/main/cue/cue-config-normalizer-fanout.test.ts
+++ b/src/__tests__/main/cue/cue-config-normalizer-fanout.test.ts
@@ -164,3 +164,43 @@ describe('normalizer — fan_out_prompt_files resolution', () => {
 		expect(sub.prompt).toBe('shared across all');
 	});
 });
+
+describe('normalizer — settings.owner_agent_id passthrough', () => {
+	// Regression for #912: the validator and the CueSettings contract both
+	// accept `owner_agent_id`, but `normalizeSettings` was silently dropping
+	// it — so `computeOwnershipWarning` always saw `undefined` and fell
+	// through to the "first agent wins" branch.
+	it('propagates owner_agent_id from raw yaml into normalized settings', () => {
+		const raw = yaml.dump({
+			subscriptions: [{ name: 'Sub', event: 'app.startup', prompt: 'go' }],
+			settings: {
+				owner_agent_id: 'fe7c6b37-d7b1-4c2f-9049-f2288dd10c16',
+			},
+		});
+
+		const doc = parseCueConfigDocument(raw, projectRoot);
+		expect(doc).not.toBeNull();
+		const { config } = materializeCueConfig(doc!);
+
+		expect(config.settings.owner_agent_id).toBe('fe7c6b37-d7b1-4c2f-9049-f2288dd10c16');
+	});
+
+	it('trims whitespace and normalizes empty/non-string owner_agent_id to undefined', () => {
+		const cases: Array<{ input: unknown; expected: string | undefined }> = [
+			{ input: '  Obsidian  ', expected: 'Obsidian' },
+			{ input: '   ', expected: undefined },
+			{ input: '', expected: undefined },
+			{ input: 42, expected: undefined },
+		];
+
+		for (const { input, expected } of cases) {
+			const raw = yaml.dump({
+				subscriptions: [{ name: 'Sub', event: 'app.startup', prompt: 'go' }],
+				settings: { owner_agent_id: input },
+			});
+			const doc = parseCueConfigDocument(raw, projectRoot);
+			const { config } = materializeCueConfig(doc!);
+			expect(config.settings.owner_agent_id).toBe(expected);
+		}
+	});
+});

--- a/src/__tests__/main/cue/cue-session-state.test.ts
+++ b/src/__tests__/main/cue/cue-session-state.test.ts
@@ -185,6 +185,24 @@ describe('computeOwnershipWarning', () => {
 		expect(result).toContain('owner_agent_id targets "Opus"');
 	});
 
+	it('shows the resolved display name in the tooltip when owner_agent_id is a uuid', () => {
+		const session1 = makeCandidate({
+			id: 'fe7c6b37-d7b1-4c2f-9049-f2288dd10c16',
+			name: 'Obsidian',
+		});
+		const session2 = makeCandidate({ id: 'session-2', name: 'Server' });
+		const result = computeOwnershipWarning({
+			session: session2,
+			candidates: [session1, session2],
+			config: makeConfig({ owner_agent_id: 'fe7c6b37-d7b1-4c2f-9049-f2288dd10c16' }),
+			configFromAncestor: false,
+		});
+		// The tooltip should reference the human-readable name, not the
+		// uuid the user wrote in cue.yaml.
+		expect(result).toContain('targets "Obsidian"');
+		expect(result).not.toContain('fe7c6b37');
+	});
+
 	it('flags every session in the root when owner_agent_id matches nobody', () => {
 		const session1 = makeCandidate({ id: 'session-1', name: 'Opus' });
 		const session2 = makeCandidate({ id: 'session-2', name: 'Sonnet' });
@@ -321,6 +339,8 @@ describe('computeOwnershipWarning', () => {
 			config: makeConfig({ owner_agent_id: 'uuid-alpha' }),
 			configFromAncestor: false,
 		});
-		expect(fromB).toContain('targets "uuid-alpha"');
+		// The tooltip should reference the resolved display name ("Alpha"),
+		// not the raw uuid the user wrote in cue.yaml.
+		expect(fromB).toContain('targets "Alpha"');
 	});
 });

--- a/src/__tests__/renderer/components/CuePipelineEditor/utils/yamlToPipeline.test.ts
+++ b/src/__tests__/renderer/components/CuePipelineEditor/utils/yamlToPipeline.test.ts
@@ -1117,6 +1117,55 @@ describe('graphSessionsToPipelines', () => {
 		expect((agents[0].data as { sessionId: string }).sessionId).toBe('real-uuid-123');
 	});
 
+	it('uses owning graph session for the agent node when other sessions appear earlier in sessions.json (issue #912)', () => {
+		// Repro for issue #912: a cue.yaml in an Obsidian project defines an
+		// initial trigger with no agent_id and no chain successor. The Obsidian
+		// session is the only owner, but other unrelated sessions (e.g., a
+		// "Server" opencode session) appear earlier in the global sessions list.
+		// Without owner-aware fallback, findTargetSession would return
+		// sessions[0] — "Server" — instead of the Obsidian session that
+		// actually owns the YAML.
+		const graphSessions: CueGraphSession[] = [
+			{
+				sessionId: 'obsidian-id',
+				sessionName: 'Pedsidian',
+				toolType: 'claude-code',
+				subscriptions: [
+					{
+						name: 'note-watcher',
+						event: 'file.changed',
+						enabled: true,
+						prompt: 'Process note',
+						watch: '**/*.md',
+					},
+				],
+			},
+		];
+		const sessions: SessionInfo[] = [
+			{
+				id: 'server-id',
+				name: 'Server',
+				toolType: 'opencode',
+				cwd: '/tmp',
+				projectRoot: '/tmp/server',
+			},
+			{
+				id: 'obsidian-id',
+				name: 'Pedsidian',
+				toolType: 'claude-code',
+				cwd: '/tmp/pedsidian',
+				projectRoot: '/tmp/pedsidian',
+			},
+		];
+
+		const pipelines = graphSessionsToPipelines(graphSessions, sessions);
+		expect(pipelines).toHaveLength(1);
+
+		const agents = pipelines[0].nodes.filter((n) => n.type === 'agent');
+		expect(agents).toHaveLength(1);
+		expect((agents[0].data as AgentNodeData).sessionName).toBe('Pedsidian');
+	});
+
 	it('correctly maps agents when multiple sessions share subscriptions', () => {
 		// Two sessions share the same project root / cue.yaml with a chain pipeline.
 		// Both report all subscriptions. The builder should be target of the initial

--- a/src/main/cue/config/cue-config-normalizer.ts
+++ b/src/main/cue/config/cue-config-normalizer.ts
@@ -354,6 +354,15 @@ function normalizeSettings(rawSettings: Record<string, unknown> | undefined): Cu
 			typeof rawSettings?.queue_size === 'number'
 				? rawSettings.queue_size
 				: DEFAULT_CUE_SETTINGS.queue_size,
+		// Pin which agent owns this cue.yaml when multiple agents share the
+		// same projectRoot. Without this passthrough, the validator and
+		// contract both accept `owner_agent_id` but `computeOwnershipWarning`
+		// always sees `undefined` and silently falls through to the "first
+		// agent wins" branch — the exact symptom reported in #912.
+		owner_agent_id:
+			typeof rawSettings?.owner_agent_id === 'string' && rawSettings.owner_agent_id.trim() !== ''
+				? rawSettings.owner_agent_id.trim()
+				: undefined,
 	};
 }
 

--- a/src/main/cue/cue-session-state.ts
+++ b/src/main/cue/cue-session-state.ts
@@ -168,7 +168,10 @@ export function computeOwnershipWarning(params: {
 			return `settings.owner_agent_id "${explicitOwner}" does not match any agent in this projectRoot — unowned subscriptions are disabled until this is fixed.`;
 		}
 		if (owner.id === session.id) return undefined;
-		return `settings.owner_agent_id targets "${explicitOwner}" — unowned subscriptions run on that agent instead.`;
+		// Show the resolved display name rather than the raw `explicitOwner`
+		// value, which is often a UUID — the dashboard tooltip is meant to be
+		// human-readable, and a bare uuid is unhelpful at a glance.
+		return `settings.owner_agent_id targets "${owner.name}" — unowned subscriptions run on that agent instead.`;
 	}
 
 	const firstForRoot = sameRoot[0];

--- a/src/renderer/components/CuePipelineEditor/utils/yamlToPipeline.ts
+++ b/src/renderer/components/CuePipelineEditor/utils/yamlToPipeline.ts
@@ -1245,6 +1245,18 @@ function findTargetSession(
 		const nameMatch = sessions.find((s) => s.name === pipelineKey);
 		if (nameMatch) return nameMatch.name;
 
+		// Prefer an owning session before scanning the global sessions list. The
+		// YAML literally lives in that session's project root, so it's a far
+		// stronger signal than "first session that isn't already a source" or
+		// the unconditional sessions[0] fallback below — the latter would
+		// otherwise display the pipeline as connected to whichever session
+		// happens to be first in sessions.json (issue #912).
+		if (owners && owners.length > 0) {
+			const ownerNotUsed = owners.find((o) => !usedSessions.has(o));
+			if (ownerNotUsed) return ownerNotUsed;
+			return owners[0];
+		}
+
 		// For the initial subscription, try to find a session not already used as a source
 		// This is a heuristic: the target session is typically the one the YAML belongs to
 		for (const session of sessions) {


### PR DESCRIPTION
## Summary

- `findTargetSession` in `yamlToPipeline.ts` resolves which agent a pipeline trigger connects to. When no strong signal applied (no `agent_id` match, no chain successor, no name match), it fell through to `sessions[0]` — the first session in `sessions.json` — instead of preferring the session that owns the cue.yaml.
- Result, per #912: a pipeline defined in an Obsidian project's cue.yaml renders as connected to a totally unrelated session (e.g., "Server (opencode)") just because that session sits earlier in `sessions.json`.
- Fix prefers `_ownerSessions` (already threaded through by `graphSessionsToPipelines`) over the global sessions list at the heuristic-fallback step. The YAML literally lives in the owner's project root, so it's the strongest available signal.

closes #912

## Test plan

- [x] New unit test reproduces the issue and verifies the agent node uses the owning session even when an unrelated session appears first in `sessions.json`.
- [x] All 46 `yamlToPipeline.test.ts` tests pass.
- [x] All 2034 Cue tests (`src/__tests__/{main,renderer/{components/CuePipelineEditor,hooks/cue}}/`) pass.
- [x] `tsc --noEmit` clean.
- [x] eslint clean.
- [ ] Manually verify in app: open Cue modal → Pipeline view on a project whose cue.yaml has no `agent_id` and confirm the agent node shows the owning session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Session selection in pipelines now correctly prefers owning sessions for agent nodes and no longer falls back to unrelated sessions.
  * Ownership settings are preserved and sanitized so configured agent IDs survive normalization.
  * Ownership warning tooltips now show the resolved session display name instead of raw IDs.

* **Tests**
  * Added regression and coverage tests validating session resolution, owner ID normalization, and tooltip display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->