### PR TITLE
fix(ipc): graceful no-op on stale paths for shell + fs handlers

### DIFF
--- a/src/__tests__/main/ipc/handlers/filesystem.test.ts
+++ b/src/__tests__/main/ipc/handlers/filesystem.test.ts
@@ -308,6 +308,20 @@ describe('filesystem handlers', () => {
 
 			expect(result).toMatch(/^data:image\/svg\+xml;base64,/);
 		});
+
+		it('should return null when path resolves to a directory (EISDIR)', async () => {
+			// Caller may pass a path that turned out to be a folder. Returning
+			// null instead of throwing keeps the IPC promise from rejecting and
+			// surfacing as an unhandled rejection. Fixes MAESTRO-JP.
+			vi.mocked(fs.readFile).mockRejectedValue(
+				Object.assign(new Error('EISDIR'), { code: 'EISDIR' })
+			);
+
+			const handler = registeredHandlers.get('fs:readFile');
+			const result = await handler!({}, '/test/some-folder');
+
+			expect(result).toBeNull();
+		});
 	});
 
 	describe('fs:stat', () => {

--- a/src/__tests__/main/ipc/handlers/system.test.ts
+++ b/src/__tests__/main/ipc/handlers/system.test.ts
@@ -635,14 +635,16 @@ describe('system IPC handlers', () => {
 			await expect(handler!({} as any, '')).rejects.toThrow('Invalid path');
 		});
 
-		it('should throw error for non-existent path', async () => {
+		it('should resolve gracefully (no throw) for non-existent path', async () => {
+			// Stale paths are user-caused (file deleted between display and click);
+			// handler should log + return rather than reject the IPC. Fixes
+			// MAESTRO-K1/HN/HS.
 			vi.mocked(fsSync.existsSync).mockReturnValue(false);
 
 			const handler = handlers.get('shell:showItemInFolder');
 
-			await expect(handler!({} as any, '/non/existent/path')).rejects.toThrow(
-				'Path does not exist'
-			);
+			await expect(handler!({} as any, '/non/existent/path')).resolves.toBeUndefined();
+			expect(shell.showItemInFolder).not.toHaveBeenCalled();
 		});
 	});
 
@@ -662,12 +664,13 @@ describe('system IPC handlers', () => {
 			await expect(handler!({} as any, '')).rejects.toThrow('Invalid path');
 		});
 
-		it('should throw error for non-existent path', async () => {
+		it('should resolve gracefully (no throw) for non-existent path', async () => {
+			// File already gone → user's intent is satisfied; treat as no-op
+			// instead of rejecting the IPC. Fixes MAESTRO-JD/JC.
 			vi.mocked(fsSync.existsSync).mockReturnValue(false);
 			const handler = handlers.get('shell:trashItem');
-			await expect(handler!({} as any, '/non/existent/path')).rejects.toThrow(
-				'Path does not exist'
-			);
+			await expect(handler!({} as any, '/non/existent/path')).resolves.toBeUndefined();
+			expect(shell.trashItem).not.toHaveBeenCalled();
 		});
 
 		it('should handle aborted operation gracefully', async () => {

--- a/src/main/ipc/handlers/filesystem.ts
+++ b/src/main/ipc/handlers/filesystem.ts
@@ -185,6 +185,13 @@ export function registerFilesystemHandlers(): void {
 			if (error?.code === 'ENOENT') {
 				return null;
 			}
+			// EISDIR happens when a caller passes a directory path (e.g., user
+			// clicks an entry that resolved to a folder). Treat like ENOENT —
+			// return null so the renderer can handle the absence cleanly instead
+			// of surfacing an unhandled IPC rejection. Fixes MAESTRO-JP.
+			if (error?.code === 'EISDIR') {
+				return null;
+			}
 			throw new Error(`Failed to read file: ${error}`);
 		}
 	});

--- a/src/main/ipc/handlers/system.ts
+++ b/src/main/ipc/handlers/system.ts
@@ -250,8 +250,12 @@ export function registerSystemHandlers(deps: SystemHandlerDependencies): void {
 		}
 		// Resolve to absolute path and verify it exists
 		const absolutePath = path.resolve(itemPath);
+		// Path missing → user's intent (delete) is already satisfied; no-op gracefully
+		// rather than rejecting the IPC promise, which surfaces as an unhandled
+		// rejection in the renderer. Fixes MAESTRO-JD/JC.
 		if (!fsSync.existsSync(absolutePath)) {
-			throw new Error(`Path does not exist: ${absolutePath}`);
+			logger.warn(`shell:trashItem - path does not exist: ${absolutePath}`, 'Shell');
+			return;
 		}
 		try {
 			await shell.trashItem(absolutePath);
@@ -278,8 +282,12 @@ export function registerSystemHandlers(deps: SystemHandlerDependencies): void {
 		}
 		// Resolve to absolute path and verify it exists
 		const absolutePath = path.resolve(itemPath);
+		// Stale path → log + return rather than rejecting the IPC, which produces
+		// noisy unhandled rejections from fire-and-forget callers in the renderer.
+		// Mirrors the shell:openPath fix (MAESTRO-B3). Fixes MAESTRO-K1/HN/HS.
 		if (!fsSync.existsSync(absolutePath)) {
-			throw new Error(`Path does not exist: ${absolutePath}`);
+			logger.warn(`shell:showItemInFolder - path does not exist: ${absolutePath}`, 'Shell');
+			return;
 		}
 		shell.showItemInFolder(absolutePath);
 	});


### PR DESCRIPTION
## Summary

Several IPC handlers reject the renderer's promise when the user supplies a path that was already removed (or that turned out to be a directory). Those callers are fire-and-forget, so the rejections surface as unhandled rejections in the renderer and Sentry captures them as bugs — even though the underlying state is routine user activity (file deleted between display and click, dropdown entry pointing at a folder, etc.).

This change mirrors the existing \`shell:openPath\` (MAESTRO-B3) and \`fs:readFile\`-ENOENT pattern so the same situations log a warning and return cleanly instead of throwing:

- \`shell:showItemInFolder\` → log + return when the path is gone
- \`shell:trashItem\` → log + return when the path is gone (user's intent already satisfied)
- \`fs:readFile\` → return \`null\` on \`EISDIR\` like it already does on \`ENOENT\`

Tests updated to cover the new behavior. No renderer changes needed; existing fire-and-forget call sites simply stop rejecting.

## Sentry issues addressed

- [MAESTRO-K1](https://smash-labs.sentry.io/issues/MAESTRO-K1) — \`shell:showItemInFolder\` "Path does not exist"
- [MAESTRO-HN](https://smash-labs.sentry.io/issues/MAESTRO-HN) — same
- [MAESTRO-HS](https://smash-labs.sentry.io/issues/MAESTRO-HS) — same
- [MAESTRO-JD](https://smash-labs.sentry.io/issues/MAESTRO-JD) — \`shell:trashItem\` "Path does not exist"
- [MAESTRO-JC](https://smash-labs.sentry.io/issues/MAESTRO-JC) — same
- [MAESTRO-JP](https://smash-labs.sentry.io/issues/MAESTRO-JP) — \`fs:readFile\` EISDIR (folder passed instead of file)

## Test plan

- [x] \`npx vitest run src/__tests__/main/ipc/handlers/system.test.ts src/__tests__/main/ipc/handlers/filesystem.test.ts\` — passes (146/146)
- [x] \`npm run lint:eslint\` — no new errors (only pre-existing warning in unrelated \`web-server-factory.ts\`)
- [ ] Manual: right-click a file in the file tree, delete it from the OS, then click "Reveal in Finder" / "Move to Trash" → no toast / no Sentry capture
- [ ] Manual: pass a directory path to a file-open code path → renderer treats result as missing rather than crashing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * File read operations now gracefully handle attempts to read directories, returning null instead of throwing errors
  * Shell operations no longer reject when target paths don't exist; they complete gracefully with a warning log

* **Tests**
  * Added test coverage for directory path handling in file read operations
  * Updated tests to verify graceful completion of shell operations with missing paths

<!-- end of auto-generated comment: release notes by coderabbit.ai -->