### PR TITLE
feat(web): mobile parity additions for tokens, cache, and worktree branches

### DIFF
--- a/src/__tests__/main/web-server/handlers/messageHandlers.test.ts
+++ b/src/__tests__/main/web-server/handlers/messageHandlers.test.ts
@@ -233,7 +233,13 @@ describe('WebSocketMessageHandler', () => {
 			});
 
 			await vi.waitFor(() => {
-				expect(callbacks.executeCommand).toHaveBeenCalledWith('session-1', 'test', undefined);
+				expect(callbacks.executeCommand).toHaveBeenCalledWith(
+					'session-1',
+					'test',
+					undefined,
+					undefined,
+					false
+				);
 			});
 
 			const response = JSON.parse((client.socket.send as any).mock.calls[0][0]);

--- a/src/__tests__/main/web-server/handlers/messageHandlers.test.ts
+++ b/src/__tests__/main/web-server/handlers/messageHandlers.test.ts
@@ -83,6 +83,8 @@ function createMockCallbacks(): MessageHandlerCallbacks {
 		newAITabWithPrompt: vi.fn().mockResolvedValue({ success: true, tabId: 'tab-mock-123' }),
 		refreshAutoRunDocs: vi.fn().mockResolvedValue(true),
 		configureAutoRun: vi.fn().mockResolvedValue({ success: true }),
+		removeQueueItem: vi.fn().mockResolvedValue(true),
+		reorderQueue: vi.fn().mockResolvedValue(true),
 		getSessions: vi.fn().mockReturnValue([
 			{
 				id: 'session-1',
@@ -221,7 +223,7 @@ describe('WebSocketMessageHandler', () => {
 			});
 		});
 
-		it('should reject command when session is busy', () => {
+		it('should forward command when session is busy so desktop can queue it', async () => {
 			(callbacks.getSessionDetail as any).mockReturnValue({ state: 'busy', inputMode: 'ai' });
 
 			handler.handleMessage(client, {
@@ -230,10 +232,13 @@ describe('WebSocketMessageHandler', () => {
 				command: 'test',
 			});
 
+			await vi.waitFor(() => {
+				expect(callbacks.executeCommand).toHaveBeenCalledWith('session-1', 'test', undefined);
+			});
+
 			const response = JSON.parse((client.socket.send as any).mock.calls[0][0]);
-			expect(response.type).toBe('error');
-			expect(response.message).toContain('busy');
-			expect(callbacks.executeCommand).not.toHaveBeenCalled();
+			expect(response.type).toBe('command_result');
+			expect(response.success).toBe(true);
 		});
 
 		it('omits tabId from command_result on the no-tabId path so callers do not chain to a stale snapshot', async () => {

--- a/src/__tests__/main/web-server/web-server-factory.test.ts
+++ b/src/__tests__/main/web-server/web-server-factory.test.ts
@@ -83,6 +83,8 @@ vi.mock('../../../main/web-server/WebServer', () => {
 			setKillTerminalForWebCallback = vi.fn();
 			setNotifyToastCallback = vi.fn();
 			setNotifyCenterFlashCallback = vi.fn();
+			setRemoveQueueItemCallback = vi.fn();
+			setReorderQueueCallback = vi.fn();
 
 			constructor(port: number, securityToken?: string) {
 				this.port = port;

--- a/src/__tests__/renderer/hooks/useAgentListeners.test.ts
+++ b/src/__tests__/renderer/hooks/useAgentListeners.test.ts
@@ -201,6 +201,9 @@ beforeEach(() => {
 		stats: {
 			recordQuery: vi.fn().mockResolvedValue(undefined),
 		},
+		web: {
+			broadcastToolExecution: vi.fn().mockResolvedValue(true),
+		},
 		logger: {
 			log: vi.fn(),
 		},

--- a/src/__tests__/renderer/hooks/useRemoteIntegration.test.ts
+++ b/src/__tests__/renderer/hooks/useRemoteIntegration.test.ts
@@ -49,6 +49,10 @@ describe('useRemoteIntegration', () => {
 	let onRemoteNewAITabWithPromptHandler:
 		| ((sessionId: string, prompt: string, responseChannel: string) => void)
 		| undefined;
+	let onRemoteRemoveQueueItemHandler: ((sessionId: string, itemId: string) => void) | undefined;
+	let onRemoteReorderQueueHandler:
+		| ((sessionId: string, fromIndex: number, toIndex: number) => void)
+		| undefined;
 
 	const mockProcess = {
 		...window.maestro.process,
@@ -120,6 +124,14 @@ describe('useRemoteIntegration', () => {
 			return () => {};
 		}),
 		onRemoteConfigureAutoRun: vi.fn().mockImplementation(() => {
+			return () => {};
+		}),
+		onRemoteRemoveQueueItem: vi.fn().mockImplementation((handler) => {
+			onRemoteRemoveQueueItemHandler = handler;
+			return () => {};
+		}),
+		onRemoteReorderQueue: vi.fn().mockImplementation((handler) => {
+			onRemoteReorderQueueHandler = handler;
 			return () => {};
 		}),
 		sendRemoteNewTabResponse: vi.fn(),
@@ -202,6 +214,7 @@ describe('useRemoteIntegration', () => {
 		...window.maestro.web,
 		broadcastTabsChange: vi.fn(),
 		broadcastSessionState: vi.fn(),
+		broadcastExecutionQueue: vi.fn(),
 	};
 
 	const mockClaude = {
@@ -239,6 +252,8 @@ describe('useRemoteIntegration', () => {
 		onRemoteReorderTabHandler = undefined;
 		onRemoteToggleBookmarkHandler = undefined;
 		onRemoteNewAITabWithPromptHandler = undefined;
+		onRemoteRemoveQueueItemHandler = undefined;
+		onRemoteReorderQueueHandler = undefined;
 
 		window.maestro = {
 			...originalMaestro,
@@ -371,7 +386,7 @@ describe('useRemoteIntegration', () => {
 			dispatchEventSpy.mockRestore();
 		});
 
-		it('ignores command when session is busy', () => {
+		it('forwards command when session is busy so it can be queued', () => {
 			const session = createMockSession({ id: 'session-1', state: 'busy' });
 			const deps = createDeps({ sessions: [session] });
 			const dispatchEventSpy = vi.spyOn(window, 'dispatchEvent');
@@ -382,8 +397,17 @@ describe('useRemoteIntegration', () => {
 				onRemoteCommandHandler?.('session-1', 'test command', 'ai');
 			});
 
-			expect(deps.setActiveSessionId).not.toHaveBeenCalled();
-			expect(dispatchEventSpy).not.toHaveBeenCalled();
+			expect(deps.setActiveSessionId).toHaveBeenCalledWith('session-1');
+			expect(dispatchEventSpy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					type: 'maestro:remoteCommand',
+					detail: expect.objectContaining({
+						sessionId: 'session-1',
+						command: 'test command',
+						inputMode: 'ai',
+					}),
+				})
+			);
 
 			dispatchEventSpy.mockRestore();
 		});

--- a/src/main/ipc/handlers/web.ts
+++ b/src/main/ipc/handlers/web.ts
@@ -25,7 +25,12 @@
 import { ipcMain } from 'electron';
 import { logger } from '../../utils/logger';
 import { WebServer } from '../../web-server';
-import type { AITabData } from '../../web-server/services/broadcastService';
+import type {
+	AITabData,
+	GitStatusData,
+	ToolExecutionData,
+	QueuedItemData,
+} from '../../web-server/types';
 import type { SettingsStoreInterface } from '../../stores/types';
 import { writeCliServerInfo, deleteCliServerInfo } from '../../../shared/cli-server-discovery';
 
@@ -167,6 +172,42 @@ export function registerWebHandlers(deps: WebHandlerDependencies): void {
 		}
 	);
 
+	ipcMain.handle(
+		'web:broadcastGitStatus',
+		async (_, sessionId: string, gitStatus: GitStatusData | null) => {
+			const webServer = getWebServer();
+			if (webServer && webServer.getWebClientCount() > 0) {
+				webServer.broadcastGitStatus(sessionId, gitStatus);
+				return true;
+			}
+			return false;
+		}
+	);
+
+	ipcMain.handle(
+		'web:broadcastExecutionQueue',
+		async (_, sessionId: string, executionQueue: QueuedItemData[]) => {
+			const webServer = getWebServer();
+			if (webServer && webServer.getWebClientCount() > 0) {
+				webServer.broadcastExecutionQueue(sessionId, executionQueue);
+				return true;
+			}
+			return false;
+		}
+	);
+
+	ipcMain.handle(
+		'web:broadcastToolExecution',
+		async (_, sessionId: string, tabId: string | undefined, tool: ToolExecutionData) => {
+			const webServer = getWebServer();
+			if (webServer && webServer.getWebClientCount() > 0) {
+				webServer.broadcastToolExecution(sessionId, tabId, tool);
+				return true;
+			}
+			return false;
+		}
+	);
+
 	// Broadcast session state change to web clients (for real-time busy/idle updates)
 	// This is called directly from the renderer to bypass debounced persistence
 	// which resets state to 'idle' before saving
@@ -181,6 +222,8 @@ export function registerWebHandlers(deps: WebHandlerDependencies): void {
 				toolType?: string;
 				inputMode?: string;
 				cwd?: string;
+				currentCycleTokens?: number;
+				thinkingStartTime?: number;
 			}
 		) => {
 			const webServer = getWebServer();

--- a/src/main/preload/process.ts
+++ b/src/main/preload/process.ts
@@ -1316,6 +1316,30 @@ export function createProcessApi() {
 		},
 
 		/**
+		 * Subscribe to remote execution queue item removal from web interface
+		 */
+		onRemoteRemoveQueueItem: (
+			callback: (sessionId: string, itemId: string) => void
+		): (() => void) => {
+			const handler = (_: unknown, sessionId: string, itemId: string) =>
+				callback(sessionId, itemId);
+			ipcRenderer.on('remote:removeQueueItem', handler);
+			return () => ipcRenderer.removeListener('remote:removeQueueItem', handler);
+		},
+
+		/**
+		 * Subscribe to remote execution queue reorder from web interface
+		 */
+		onRemoteReorderQueue: (
+			callback: (sessionId: string, fromIndex: number, toIndex: number) => void
+		): (() => void) => {
+			const handler = (_: unknown, sessionId: string, fromIndex: number, toIndex: number) =>
+				callback(sessionId, fromIndex, toIndex);
+			ipcRenderer.on('remote:reorderQueue', handler);
+			return () => ipcRenderer.removeListener('remote:reorderQueue', handler);
+		},
+
+		/**
 		 * Subscribe to stderr from runCommand (separate stream)
 		 */
 		onStderr: (callback: (sessionId: string, data: string) => void): (() => void) => {

--- a/src/main/preload/web.ts
+++ b/src/main/preload/web.ts
@@ -8,6 +8,7 @@
  */
 
 import { ipcRenderer } from 'electron';
+import type { GitStatusData, QueuedItemData, ToolExecutionData } from '../web-server/types';
 
 /**
  * Auto Run state for broadcasting
@@ -39,19 +40,7 @@ export interface AiTabState {
 	thinkingStartTime?: number | null;
 }
 
-export interface QueuedItemState {
-	id: string;
-	timestamp: number;
-	tabId: string;
-	type: 'message' | 'command';
-	text?: string;
-	images?: string[];
-	command?: string;
-	commandArgs?: string;
-	commandDescription?: string;
-	tabName?: string;
-	readOnlyMode?: boolean;
-}
+export type QueuedItemState = QueuedItemData;
 
 /**
  * Creates the web interface API object for preload exposure
@@ -70,14 +59,17 @@ export function createWebApi() {
 		broadcastTabsChange: (sessionId: string, aiTabs: AiTabState[], activeTabId: string) =>
 			ipcRenderer.invoke('web:broadcastTabsChange', sessionId, aiTabs, activeTabId),
 
-		broadcastGitStatus: (sessionId: string, gitStatus: unknown | null) =>
+		broadcastGitStatus: (sessionId: string, gitStatus: GitStatusData | null) =>
 			ipcRenderer.invoke('web:broadcastGitStatus', sessionId, gitStatus),
 
 		broadcastExecutionQueue: (sessionId: string, executionQueue: QueuedItemState[]) =>
 			ipcRenderer.invoke('web:broadcastExecutionQueue', sessionId, executionQueue),
 
-		broadcastToolExecution: (sessionId: string, tabId: string | undefined, tool: unknown) =>
-			ipcRenderer.invoke('web:broadcastToolExecution', sessionId, tabId, tool),
+		broadcastToolExecution: (
+			sessionId: string,
+			tabId: string | undefined,
+			tool: ToolExecutionData
+		) => ipcRenderer.invoke('web:broadcastToolExecution', sessionId, tabId, tool),
 
 		// Broadcast session state change to web clients (for real-time busy/idle updates)
 		broadcastSessionState: (

--- a/src/main/preload/web.ts
+++ b/src/main/preload/web.ts
@@ -39,6 +39,20 @@ export interface AiTabState {
 	thinkingStartTime?: number | null;
 }
 
+export interface QueuedItemState {
+	id: string;
+	timestamp: number;
+	tabId: string;
+	type: 'message' | 'command';
+	text?: string;
+	images?: string[];
+	command?: string;
+	commandArgs?: string;
+	commandDescription?: string;
+	tabName?: string;
+	readOnlyMode?: boolean;
+}
+
 /**
  * Creates the web interface API object for preload exposure
  */
@@ -56,6 +70,15 @@ export function createWebApi() {
 		broadcastTabsChange: (sessionId: string, aiTabs: AiTabState[], activeTabId: string) =>
 			ipcRenderer.invoke('web:broadcastTabsChange', sessionId, aiTabs, activeTabId),
 
+		broadcastGitStatus: (sessionId: string, gitStatus: unknown | null) =>
+			ipcRenderer.invoke('web:broadcastGitStatus', sessionId, gitStatus),
+
+		broadcastExecutionQueue: (sessionId: string, executionQueue: QueuedItemState[]) =>
+			ipcRenderer.invoke('web:broadcastExecutionQueue', sessionId, executionQueue),
+
+		broadcastToolExecution: (sessionId: string, tabId: string | undefined, tool: unknown) =>
+			ipcRenderer.invoke('web:broadcastToolExecution', sessionId, tabId, tool),
+
 		// Broadcast session state change to web clients (for real-time busy/idle updates)
 		broadcastSessionState: (
 			sessionId: string,
@@ -65,6 +88,8 @@ export function createWebApi() {
 				toolType?: string;
 				inputMode?: string;
 				cwd?: string;
+				currentCycleTokens?: number;
+				thinkingStartTime?: number;
 			}
 		) => ipcRenderer.invoke('web:broadcastSessionState', sessionId, state, additionalData),
 	};

--- a/src/main/web-server/WebServer.ts
+++ b/src/main/web-server/WebServer.ts
@@ -49,6 +49,9 @@ import type {
 	CliActivity,
 	NotificationEvent,
 	SessionBroadcastData,
+	GitStatusData,
+	ToolExecutionData,
+	QueuedItemData,
 	WebClient,
 	WebClientMessage,
 	WebSettings,
@@ -73,6 +76,8 @@ import type {
 	NewAITabWithPromptCallback,
 	RefreshAutoRunDocsCallback,
 	ConfigureAutoRunCallback,
+	RemoveQueueItemCallback,
+	ReorderQueueCallback,
 	GetThemeCallback,
 	GetBionifyReadingModeCallback,
 	GetCustomCommandsCallback,
@@ -457,6 +462,14 @@ export class WebServer {
 		this.callbackRegistry.setConfigureAutoRunCallback(callback);
 	}
 
+	setRemoveQueueItemCallback(callback: RemoveQueueItemCallback): void {
+		this.callbackRegistry.setRemoveQueueItemCallback(callback);
+	}
+
+	setReorderQueueCallback(callback: ReorderQueueCallback): void {
+		this.callbackRegistry.setReorderQueueCallback(callback);
+	}
+
 	setGetHistoryCallback(callback: GetHistoryCallback): void {
 		this.callbackRegistry.setGetHistoryCallback(callback);
 	}
@@ -782,6 +795,10 @@ export class WebServer {
 				sessionId: string,
 				config: Parameters<CallbackRegistry['configureAutoRun']>[1]
 			) => this.callbackRegistry.configureAutoRun(sessionId, config),
+			removeQueueItem: async (sessionId: string, itemId: string) =>
+				this.callbackRegistry.removeQueueItem(sessionId, itemId),
+			reorderQueue: async (sessionId: string, fromIndex: number, toIndex: number) =>
+				this.callbackRegistry.reorderQueue(sessionId, fromIndex, toIndex),
 			getSessions: () => this.callbackRegistry.getSessions(),
 			getLiveSessionInfo: (sessionId: string) =>
 				this.liveSessionManager.getLiveSessionInfo(sessionId),
@@ -884,6 +901,8 @@ export class WebServer {
 			inputMode?: string;
 			cwd?: string;
 			cliActivity?: CliActivity;
+			currentCycleTokens?: number;
+			thinkingStartTime?: number;
 		}
 	): void {
 		this.broadcastService.broadcastSessionStateChange(sessionId, state, additionalData);
@@ -907,6 +926,22 @@ export class WebServer {
 
 	broadcastTabsChange(sessionId: string, aiTabs: AITabData[], activeTabId: string): void {
 		this.broadcastService.broadcastTabsChange(sessionId, aiTabs, activeTabId);
+	}
+
+	broadcastGitStatus(sessionId: string, gitStatus: GitStatusData | null): void {
+		this.broadcastService.broadcastGitStatus(sessionId, gitStatus);
+	}
+
+	broadcastExecutionQueue(sessionId: string, executionQueue: QueuedItemData[]): void {
+		this.broadcastService.broadcastExecutionQueue(sessionId, executionQueue);
+	}
+
+	broadcastToolExecution(
+		sessionId: string,
+		tabId: string | undefined,
+		tool: ToolExecutionData
+	): void {
+		this.broadcastService.broadcastToolExecution(sessionId, tabId, tool);
 	}
 
 	broadcastThemeChange(theme: Theme): void {

--- a/src/main/web-server/handlers/messageHandlers.ts
+++ b/src/main/web-server/handlers/messageHandlers.ts
@@ -28,6 +28,8 @@
  * - stop_auto_run: Stop an active auto-run for a session
  * - get_settings: Fetch current web settings
  * - set_setting: Modify a single setting (allowlisted keys only)
+ * - remove_queue_item: Remove a queued session item
+ * - reorder_queue: Reorder queued session items
  */
 
 import path from 'path';
@@ -203,6 +205,8 @@ export interface MessageHandlerCallbacks {
 			};
 		}
 	) => Promise<{ success: boolean; playbookId?: string; error?: string }>;
+	removeQueueItem: (sessionId: string, itemId: string) => Promise<boolean>;
+	reorderQueue: (sessionId: string, fromIndex: number, toIndex: number) => Promise<boolean>;
 	getSessions: () => Array<{
 		id: string;
 		name: string;
@@ -550,6 +554,14 @@ export class WebSocketMessageHandler {
 				this.handleNotifyCenterFlash(client, message);
 				break;
 
+			case 'remove_queue_item':
+				this.handleRemoveQueueItem(client, message);
+				break;
+
+			case 'reorder_queue':
+				this.handleReorderQueue(client, message);
+				break;
+
 			default:
 				this.handleUnknown(client, message);
 		}
@@ -614,23 +626,9 @@ export class WebSocketMessageHandler {
 			return;
 		}
 
-		// Check if session is busy - prevent race conditions between desktop and web.
-		// `force: true` opts out of this guard (see `maestro-cli send --live --force`).
-		if (sessionDetail.state === 'busy' && !force) {
-			this.sendError(
-				client,
-				'Session is busy - please wait for the current operation to complete',
-				{
-					sessionId,
-				}
-			);
-			logger.debug(`Command rejected - session ${sessionId} is busy`, LOG_CONTEXT);
-			return;
-		}
 		if (sessionDetail.state === 'busy' && force) {
 			logger.info(`[Web Command] Force-dispatching to busy session ${sessionId}`, LOG_CONTEXT);
 		}
-
 		// Use client's inputMode if provided, otherwise fall back to server state
 		const effectiveMode = clientInputMode || sessionDetail.inputMode;
 		const isAiMode = effectiveMode === 'ai';
@@ -857,6 +855,55 @@ export class WebSocketMessageHandler {
 			});
 			this.send(client, { type: 'sessions_list', sessions: sessionsWithLiveInfo });
 		}
+	}
+
+	private handleRemoveQueueItem(client: WebClient, message: WebClientMessage): void {
+		const sessionId = message.sessionId as string;
+		const itemId = message.itemId as string;
+
+		if (!sessionId || !itemId) {
+			this.sendError(client, 'Missing sessionId or itemId');
+			return;
+		}
+
+		if (!this.callbacks.removeQueueItem) {
+			this.sendError(client, 'Queue removal not configured');
+			return;
+		}
+
+		this.callbacks
+			.removeQueueItem(sessionId, itemId)
+			.then((success) => {
+				this.send(client, { type: 'remove_queue_item_result', success, sessionId, itemId });
+			})
+			.catch((error) => {
+				this.sendError(client, `Failed to remove queue item: ${error.message}`);
+			});
+	}
+
+	private handleReorderQueue(client: WebClient, message: WebClientMessage): void {
+		const sessionId = message.sessionId as string;
+		const fromIndex = Number(message.fromIndex);
+		const toIndex = Number(message.toIndex);
+
+		if (!sessionId || !Number.isInteger(fromIndex) || !Number.isInteger(toIndex)) {
+			this.sendError(client, 'Missing sessionId, fromIndex, or toIndex');
+			return;
+		}
+
+		if (!this.callbacks.reorderQueue) {
+			this.sendError(client, 'Queue reorder not configured');
+			return;
+		}
+
+		this.callbacks
+			.reorderQueue(sessionId, fromIndex, toIndex)
+			.then((success) => {
+				this.send(client, { type: 'reorder_queue_result', success, sessionId, fromIndex, toIndex });
+			})
+			.catch((error) => {
+				this.sendError(client, `Failed to reorder queue: ${error.message}`);
+			});
 	}
 
 	/**

--- a/src/main/web-server/managers/CallbackRegistry.ts
+++ b/src/main/web-server/managers/CallbackRegistry.ts
@@ -29,6 +29,8 @@ import type {
 	NewAITabWithPromptCallback,
 	RefreshAutoRunDocsCallback,
 	ConfigureAutoRunCallback,
+	RemoveQueueItemCallback,
+	ReorderQueueCallback,
 	GetThemeCallback,
 	GetBionifyReadingModeCallback,
 	GetCustomCommandsCallback,
@@ -113,6 +115,8 @@ export interface WebServerCallbacks {
 	newAITabWithPrompt: NewAITabWithPromptCallback | null;
 	refreshAutoRunDocs: RefreshAutoRunDocsCallback | null;
 	configureAutoRun: ConfigureAutoRunCallback | null;
+	removeQueueItem: RemoveQueueItemCallback | null;
+	reorderQueue: ReorderQueueCallback | null;
 	getHistory: GetHistoryCallback | null;
 	getAutoRunDocs: GetAutoRunDocsCallback | null;
 	getAutoRunDocContent: GetAutoRunDocContentCallback | null;
@@ -176,6 +180,8 @@ export class CallbackRegistry {
 		newAITabWithPrompt: null,
 		refreshAutoRunDocs: null,
 		configureAutoRun: null,
+		removeQueueItem: null,
+		reorderQueue: null,
 		getHistory: null,
 		getAutoRunDocs: null,
 		getAutoRunDocContent: null,
@@ -352,6 +358,16 @@ export class CallbackRegistry {
 	): Promise<{ success: boolean; playbookId?: string; error?: string }> {
 		if (!this.callbacks.configureAutoRun) return { success: false, error: 'Not configured' };
 		return this.callbacks.configureAutoRun(sessionId, config);
+	}
+
+	async removeQueueItem(sessionId: string, itemId: string): Promise<boolean> {
+		if (!this.callbacks.removeQueueItem) return false;
+		return this.callbacks.removeQueueItem(sessionId, itemId);
+	}
+
+	async reorderQueue(sessionId: string, fromIndex: number, toIndex: number): Promise<boolean> {
+		if (!this.callbacks.reorderQueue) return false;
+		return this.callbacks.reorderQueue(sessionId, fromIndex, toIndex);
 	}
 
 	getHistory(projectPath?: string, sessionId?: string): ReturnType<GetHistoryCallback> | [] {
@@ -678,6 +694,14 @@ export class CallbackRegistry {
 
 	setConfigureAutoRunCallback(callback: ConfigureAutoRunCallback): void {
 		this.callbacks.configureAutoRun = callback;
+	}
+
+	setRemoveQueueItemCallback(callback: RemoveQueueItemCallback): void {
+		this.callbacks.removeQueueItem = callback;
+	}
+
+	setReorderQueueCallback(callback: ReorderQueueCallback): void {
+		this.callbacks.reorderQueue = callback;
 	}
 
 	setGetHistoryCallback(callback: GetHistoryCallback): void {

--- a/src/main/web-server/services/broadcastService.ts
+++ b/src/main/web-server/services/broadcastService.ts
@@ -38,6 +38,9 @@ import type {
 	GroupChatState,
 	CueActivityEntry,
 	CueSubscriptionInfo,
+	GitStatusData,
+	ToolExecutionData,
+	QueuedItemData,
 } from '../types';
 
 // Re-export types for backwards compatibility
@@ -135,6 +138,8 @@ export class BroadcastService {
 			inputMode?: string;
 			cwd?: string;
 			cliActivity?: CliActivity;
+			currentCycleTokens?: number;
+			thinkingStartTime?: number;
 		}
 	): void {
 		this.broadcastToAll({
@@ -221,6 +226,47 @@ export class BroadcastService {
 			sessionId,
 			aiTabs,
 			activeTabId,
+			timestamp: Date.now(),
+		});
+	}
+
+	/**
+	 * Broadcast git status changes to all connected web clients.
+	 */
+	broadcastGitStatus(sessionId: string, gitStatus: GitStatusData | null): void {
+		this.broadcastToAll({
+			type: 'git_status_changed',
+			sessionId,
+			gitStatus,
+			timestamp: Date.now(),
+		});
+	}
+
+	/**
+	 * Broadcast execution queue changes to all connected web clients.
+	 */
+	broadcastExecutionQueue(sessionId: string, executionQueue: QueuedItemData[]): void {
+		this.broadcastToAll({
+			type: 'execution_queue_changed',
+			sessionId,
+			executionQueue,
+			timestamp: Date.now(),
+		});
+	}
+
+	/**
+	 * Broadcast structured tool execution events to clients subscribed to the session.
+	 */
+	broadcastToolExecution(
+		sessionId: string,
+		tabId: string | undefined,
+		tool: ToolExecutionData
+	): void {
+		this.broadcastToSession(sessionId, {
+			type: 'tool_execution',
+			sessionId,
+			tabId,
+			tool,
 			timestamp: Date.now(),
 		});
 	}

--- a/src/main/web-server/types.ts
+++ b/src/main/web-server/types.ts
@@ -24,6 +24,50 @@ export interface SessionUsageStats {
 	cacheCreationInputTokens?: number;
 	totalCostUsd?: number;
 	contextWindow?: number;
+	reasoningTokens?: number;
+}
+
+export type QueuedItemType = 'message' | 'command';
+
+export interface QueuedItemData {
+	id: string;
+	timestamp: number;
+	tabId: string;
+	type: QueuedItemType;
+	text?: string;
+	images?: string[];
+	command?: string;
+	commandArgs?: string;
+	commandDescription?: string;
+	tabName?: string;
+	readOnlyMode?: boolean;
+}
+
+export interface GitFileChangeData {
+	path: string;
+	status: string;
+	additions: number;
+	deletions: number;
+	modified: boolean;
+}
+
+export interface GitStatusData {
+	fileCount: number;
+	branch?: string;
+	remote?: string;
+	behind: number;
+	ahead: number;
+	fileChanges?: GitFileChangeData[];
+	totalAdditions: number;
+	totalDeletions: number;
+	modifiedCount: number;
+	lastUpdated: number;
+}
+
+export interface ToolExecutionData {
+	toolName: string;
+	state?: unknown;
+	timestamp: number;
 }
 
 /**
@@ -109,6 +153,10 @@ export interface SessionData {
 	agentSessionId?: string | null;
 	/** Timestamp when AI started thinking (for elapsed time display) */
 	thinkingStartTime?: number | null;
+	currentCycleTokens?: number;
+	executionQueue?: QueuedItemData[];
+	isGitRepo?: boolean;
+	gitStatus?: GitStatusData | null;
 	aiTabs?: AITabData[];
 	activeTabId?: string;
 	/** Whether session is bookmarked (shows in Bookmarks group) */
@@ -153,6 +201,10 @@ export interface SessionBroadcastData {
 	/** Worktree subagent support */
 	parentSessionId?: string | null;
 	worktreeBranch?: string | null;
+	currentCycleTokens?: number;
+	executionQueue?: QueuedItemData[];
+	isGitRepo?: boolean;
+	gitStatus?: GitStatusData | null;
 }
 
 // =============================================================================
@@ -400,6 +452,12 @@ export type ConfigureAutoRunCallback = (
 		};
 	}
 ) => Promise<{ success: boolean; playbookId?: string; error?: string }>;
+export type RemoveQueueItemCallback = (sessionId: string, itemId: string) => Promise<boolean>;
+export type ReorderQueueCallback = (
+	sessionId: string,
+	fromIndex: number,
+	toIndex: number
+) => Promise<boolean>;
 
 /**
  * Callback type for fetching current theme.

--- a/src/main/web-server/web-server-factory.ts
+++ b/src/main/web-server/web-server-factory.ts
@@ -212,6 +212,8 @@ export function createWebServerFactory(deps: WebServerFactoryDependencies) {
 				usageStats: session.usageStats,
 				agentSessionId: session.agentSessionId,
 				isGitRepo: session.isGitRepo,
+				currentCycleTokens: session.currentCycleTokens || 0,
+				executionQueue: session.executionQueue || [],
 				activeTabId: targetTabId,
 			};
 		});
@@ -627,6 +629,38 @@ export function createWebServerFactory(deps: WebServerFactoryDependencies) {
 			mainWindow.webContents.send('remote:toggleBookmark', sessionId);
 			return true;
 		});
+
+		server.setRemoveQueueItemCallback(async (sessionId: string, itemId: string) => {
+			const mainWindow = getMainWindow();
+			if (!mainWindow) {
+				logger.warn('mainWindow is null for removeQueueItem', 'WebServer');
+				return false;
+			}
+
+			if (!isWebContentsAvailable(mainWindow)) {
+				logger.warn('webContents is not available for removeQueueItem', 'WebServer');
+				return false;
+			}
+			mainWindow.webContents.send('remote:removeQueueItem', sessionId, itemId);
+			return true;
+		});
+
+		server.setReorderQueueCallback(
+			async (sessionId: string, fromIndex: number, toIndex: number) => {
+				const mainWindow = getMainWindow();
+				if (!mainWindow) {
+					logger.warn('mainWindow is null for reorderQueue', 'WebServer');
+					return false;
+				}
+
+				if (!isWebContentsAvailable(mainWindow)) {
+					logger.warn('webContents is not available for reorderQueue', 'WebServer');
+					return false;
+				}
+				mainWindow.webContents.send('remote:reorderQueue', sessionId, fromIndex, toIndex);
+				return true;
+			}
+		);
 
 		server.setOpenFileTabCallback(async (sessionId: string, filePath: string) => {
 			const mainWindow = getMainWindow();

--- a/src/renderer/contexts/GitStatusContext.tsx
+++ b/src/renderer/contexts/GitStatusContext.tsx
@@ -117,18 +117,33 @@ export function GitStatusProvider({
 	const prevBroadcastHashRef = useRef<Map<string, string>>(new Map());
 
 	useEffect(() => {
-		for (const [sessionId, status] of gitStatusMap) {
-			const statusHash = JSON.stringify(status);
-			if (prevBroadcastHashRef.current.get(sessionId) === statusHash) continue;
-			window.maestro.web.broadcastGitStatus(sessionId, status);
-			prevBroadcastHashRef.current.set(sessionId, statusHash);
-		}
+		void (async () => {
+			for (const [sessionId, status] of gitStatusMap) {
+				const statusHash = JSON.stringify(status);
+				if (prevBroadcastHashRef.current.get(sessionId) === statusHash) continue;
 
-		for (const sessionId of prevBroadcastHashRef.current.keys()) {
-			if (gitStatusMap.has(sessionId)) continue;
-			window.maestro.web.broadcastGitStatus(sessionId, null);
-			prevBroadcastHashRef.current.delete(sessionId);
-		}
+				try {
+					await window.maestro.web.broadcastGitStatus(sessionId, status);
+					prevBroadcastHashRef.current.set(sessionId, statusHash);
+				} catch (error) {
+					console.error(
+						`[GitStatusProvider] Failed to broadcast git status for ${sessionId}:`,
+						error
+					);
+				}
+			}
+
+			for (const sessionId of Array.from(prevBroadcastHashRef.current.keys())) {
+				if (gitStatusMap.has(sessionId)) continue;
+
+				try {
+					await window.maestro.web.broadcastGitStatus(sessionId, null);
+					prevBroadcastHashRef.current.delete(sessionId);
+				} catch (error) {
+					console.error(`[GitStatusProvider] Failed to clear git status for ${sessionId}:`, error);
+				}
+			}
+		})();
 	}, [gitStatusMap]);
 
 	// ============================================================================

--- a/src/renderer/contexts/GitStatusContext.tsx
+++ b/src/renderer/contexts/GitStatusContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useMemo, ReactNode } from 'react';
+import { createContext, useContext, useEffect, useRef, useMemo, ReactNode } from 'react';
 import {
 	useGitStatusPolling,
 	type GitStatusData,
@@ -114,6 +114,22 @@ export function GitStatusProvider({
 		...options,
 		activeSessionId,
 	});
+	const prevBroadcastHashRef = useRef<Map<string, string>>(new Map());
+
+	useEffect(() => {
+		for (const [sessionId, status] of gitStatusMap) {
+			const statusHash = JSON.stringify(status);
+			if (prevBroadcastHashRef.current.get(sessionId) === statusHash) continue;
+			window.maestro.web.broadcastGitStatus(sessionId, status);
+			prevBroadcastHashRef.current.set(sessionId, statusHash);
+		}
+
+		for (const sessionId of prevBroadcastHashRef.current.keys()) {
+			if (gitStatusMap.has(sessionId)) continue;
+			window.maestro.web.broadcastGitStatus(sessionId, null);
+			prevBroadcastHashRef.current.delete(sessionId);
+		}
+	}, [gitStatusMap]);
 
 	// ============================================================================
 	// BRANCH CONTEXT VALUE (rarely changes)

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -444,6 +444,10 @@ interface MaestroAPI {
 			) => void
 		) => () => void;
 		sendRemoteTriggerCueSubscriptionResponse: (responseChannel: string, result: unknown) => void;
+		onRemoteRemoveQueueItem: (callback: (sessionId: string, itemId: string) => void) => () => void;
+		onRemoteReorderQueue: (
+			callback: (sessionId: string, fromIndex: number, toIndex: number) => void
+		) => () => void;
 		onStderr: (callback: (sessionId: string, data: string) => void) => () => void;
 		onCommandExit: (callback: (sessionId: string, code: number) => void) => () => void;
 		onUsage: (callback: (sessionId: string, usageStats: UsageStats) => void) => () => void;
@@ -563,6 +567,28 @@ interface MaestroAPI {
 			}>,
 			activeTabId: string
 		) => Promise<void>;
+		broadcastGitStatus: (sessionId: string, gitStatus: unknown | null) => Promise<boolean>;
+		broadcastExecutionQueue: (
+			sessionId: string,
+			executionQueue: Array<{
+				id: string;
+				timestamp: number;
+				tabId: string;
+				type: 'message' | 'command';
+				text?: string;
+				images?: string[];
+				command?: string;
+				commandArgs?: string;
+				commandDescription?: string;
+				tabName?: string;
+				readOnlyMode?: boolean;
+			}>
+		) => Promise<boolean>;
+		broadcastToolExecution: (
+			sessionId: string,
+			tabId: string | undefined,
+			tool: unknown
+		) => Promise<boolean>;
 		broadcastSessionState: (
 			sessionId: string,
 			state: string,
@@ -571,6 +597,8 @@ interface MaestroAPI {
 				toolType?: string;
 				inputMode?: string;
 				cwd?: string;
+				currentCycleTokens?: number;
+				thinkingStartTime?: number;
 			}
 		) => Promise<boolean>;
 	};

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -4,6 +4,8 @@
  * This file makes the window.maestro API available throughout the renderer.
  */
 
+import type { GitStatusData, QueuedItemData, ToolExecutionData } from '../main/web-server/types';
+
 // Vite raw imports for .md files
 declare module '*.md?raw' {
 	const content: string;
@@ -567,27 +569,15 @@ interface MaestroAPI {
 			}>,
 			activeTabId: string
 		) => Promise<void>;
-		broadcastGitStatus: (sessionId: string, gitStatus: unknown | null) => Promise<boolean>;
+		broadcastGitStatus: (sessionId: string, gitStatus: GitStatusData | null) => Promise<boolean>;
 		broadcastExecutionQueue: (
 			sessionId: string,
-			executionQueue: Array<{
-				id: string;
-				timestamp: number;
-				tabId: string;
-				type: 'message' | 'command';
-				text?: string;
-				images?: string[];
-				command?: string;
-				commandArgs?: string;
-				commandDescription?: string;
-				tabName?: string;
-				readOnlyMode?: boolean;
-			}>
+			executionQueue: QueuedItemData[]
 		) => Promise<boolean>;
 		broadcastToolExecution: (
 			sessionId: string,
 			tabId: string | undefined,
-			tool: unknown
+			tool: ToolExecutionData
 		) => Promise<boolean>;
 		broadcastSessionState: (
 			sessionId: string,

--- a/src/renderer/hooks/agent/useAgentListeners.ts
+++ b/src/renderer/hooks/agent/useAgentListeners.ts
@@ -1864,6 +1864,15 @@ export function useAgentListeners(deps: UseAgentListenersDeps): void {
 					? `tool-${toolEvent.toolCallId}`
 					: `tool-${Date.now()}-${toolEvent.toolName}`;
 
+				window.maestro.web.broadcastToolExecution(actualSessionId, tabId, toolEvent).catch((error) => {
+					console.error('[useAgentListeners] Failed to broadcast tool execution', {
+						error,
+						sessionId: actualSessionId,
+						tabId,
+						toolEvent,
+					});
+				});
+
 				setSessions((prev) =>
 					prev.map((s) => {
 						if (s.id !== actualSessionId) return s;

--- a/src/renderer/hooks/agent/useAgentListeners.ts
+++ b/src/renderer/hooks/agent/useAgentListeners.ts
@@ -1864,14 +1864,16 @@ export function useAgentListeners(deps: UseAgentListenersDeps): void {
 					? `tool-${toolEvent.toolCallId}`
 					: `tool-${Date.now()}-${toolEvent.toolName}`;
 
-				window.maestro.web.broadcastToolExecution(actualSessionId, tabId, toolEvent).catch((error) => {
-					console.error('[useAgentListeners] Failed to broadcast tool execution', {
-						error,
-						sessionId: actualSessionId,
-						tabId,
-						toolEvent,
+				window.maestro.web
+					.broadcastToolExecution(actualSessionId, tabId, toolEvent)
+					.catch((error) => {
+						console.error('[useAgentListeners] Failed to broadcast tool execution', {
+							error,
+							sessionId: actualSessionId,
+							tabId,
+							toolEvent,
+						});
 					});
-				});
 
 				setSessions((prev) =>
 					prev.map((s) => {

--- a/src/renderer/hooks/remote/useRemoteHandlers.ts
+++ b/src/renderer/hooks/remote/useRemoteHandlers.ts
@@ -11,7 +11,7 @@
  */
 
 import { useEffect, useMemo, useCallback } from 'react';
-import type { Session, SessionState, LogEntry, CustomAICommand } from '../../types';
+import type { Session, SessionState, LogEntry, CustomAICommand, QueuedItem } from '../../types';
 import { hasCapabilityCached } from '../agent/useAgentCapabilities';
 import { useSessionStore } from '../../stores/sessionStore';
 import { useSettingsStore } from '../../stores/settingsStore';
@@ -249,12 +249,33 @@ export function useRemoteHandlers(deps: UseRemoteHandlersDeps): UseRemoteHandler
 				return;
 			}
 
-			// Check if session is busy. `force: true` (from `dispatch --force`)
-			// bypasses this guard — without that escape hatch, the renderer would
-			// silently drop forced dispatches and the server-side allow-list
-			// would be moot.
+			// Check if session is busy. `force: true` bypasses queueing so
+			// `dispatch --force` can land immediately on a busy tab.
 			if (session.state === 'busy' && !force) {
-				logger.info('[Remote] Session is busy, cannot process command');
+				const targetTab = getActiveTab(session);
+				if (!targetTab) {
+					logger.info('[Remote] Session is busy and has no active tab, cannot queue command');
+					return;
+				}
+
+				const queuedItem: QueuedItem = {
+					id: generateId(),
+					timestamp: Date.now(),
+					tabId: targetTab.id,
+					type: command.trim().startsWith('/') ? 'command' : 'message',
+					...(command.trim().startsWith('/') ? { command: command.trim() } : { text: command }),
+					tabName: targetTab.name || undefined,
+					readOnlyMode: targetTab.readOnlyMode,
+				};
+
+				setSessions((prev) =>
+					prev.map((s) =>
+						s.id === sessionId
+							? { ...s, executionQueue: [...(s.executionQueue ?? []), queuedItem] }
+							: s
+					)
+				);
+				logger.info('[Remote] Session is busy, queued command instead');
 				return;
 			}
 

--- a/src/renderer/hooks/remote/useRemoteIntegration.ts
+++ b/src/renderer/hooks/remote/useRemoteIntegration.ts
@@ -118,17 +118,6 @@ export function useRemoteIntegration(deps: UseRemoteIntegrationDeps): UseRemoteI
 					return;
 				}
 
-				// Check if session is busy (should have been checked by web server,
-				// but double-check). `force: true` (from `dispatch --force`) opts
-				// out of the guard so a queued follow-up can land on a busy tab.
-				if (targetSession.state === 'busy' && !force) {
-					logger.warn(
-						'[useRemoteIntegration] Session is busy, dropping command. State:',
-						undefined,
-						targetSession.state
-					);
-					return;
-				}
 				logger.info(
 					'[useRemoteIntegration] Session state check passed:',
 					undefined,
@@ -546,6 +535,46 @@ export function useRemoteIntegration(deps: UseRemoteIntegrationDeps): UseRemoteI
 			}
 		);
 
+		const unsubscribeRemoveQueueItem = window.maestro.process.onRemoteRemoveQueueItem(
+			(sessionId: string, itemId: string) => {
+				setSessions((prev) =>
+					prev.map((s) =>
+						s.id === sessionId
+							? {
+									...s,
+									executionQueue: (s.executionQueue ?? []).filter((item) => item.id !== itemId),
+								}
+							: s
+					)
+				);
+			}
+		);
+
+		const unsubscribeReorderQueue = window.maestro.process.onRemoteReorderQueue(
+			(sessionId: string, fromIndex: number, toIndex: number) => {
+				setSessions((prev) =>
+					prev.map((s) => {
+						if (s.id !== sessionId) return s;
+						const currentQueue = s.executionQueue ?? [];
+						const len = currentQueue.length;
+						if (
+							fromIndex === toIndex ||
+							fromIndex < 0 ||
+							fromIndex >= len ||
+							toIndex < 0 ||
+							toIndex >= len
+						) {
+							return s;
+						}
+						const executionQueue = [...currentQueue];
+						const [movedItem] = executionQueue.splice(fromIndex, 1);
+						executionQueue.splice(toIndex, 0, movedItem);
+						return { ...s, executionQueue };
+					})
+				);
+			}
+		);
+
 		return () => {
 			unsubscribeSelectSession();
 			unsubscribeSelectTab();
@@ -556,6 +585,8 @@ export function useRemoteIntegration(deps: UseRemoteIntegrationDeps): UseRemoteI
 			unsubscribeStarTab();
 			unsubscribeReorderTab();
 			unsubscribeToggleBookmark();
+			unsubscribeRemoveQueueItem();
+			unsubscribeReorderQueue();
 		};
 	}, [
 		sessionsRef,
@@ -1018,7 +1049,8 @@ export function useRemoteIntegration(deps: UseRemoteIntegrationDeps): UseRemoteI
 	// Track previous session states for broadcasting state changes to web clients
 	// This is separate from tab changes because session state (busy/idle) changes need
 	// to be broadcast immediately for proper UI feedback on the web interface
-	const prevSessionStatesRef = useRef<Map<string, string>>(new Map());
+	const prevSessionStateHashesRef = useRef<Map<string, string>>(new Map());
+	const prevQueueHashesRef = useRef<Map<string, string>>(new Map());
 
 	// Only set up the interval when live mode is active
 	useEffect(() => {
@@ -1033,15 +1065,26 @@ export function useRemoteIntegration(deps: UseRemoteIntegrationDeps): UseRemoteI
 			sessions.forEach((session) => {
 				// Broadcast session state changes (busy/idle) to web clients
 				// This bypasses the debounced persistence which resets state to 'idle' before saving
-				const prevState = prevSessionStatesRef.current.get(session.id);
-				if (prevState !== session.state) {
+				const stateHash = `${session.state}:${session.currentCycleTokens || 0}:${session.thinkingStartTime || ''}`;
+				if (prevSessionStateHashesRef.current.get(session.id) !== stateHash) {
 					window.maestro.web.broadcastSessionState(session.id, session.state, {
 						name: session.name,
 						toolType: session.toolType,
 						inputMode: session.inputMode,
 						cwd: session.cwd,
+						currentCycleTokens: session.currentCycleTokens || 0,
+						thinkingStartTime: session.thinkingStartTime,
 					});
-					prevSessionStatesRef.current.set(session.id, session.state);
+					prevSessionStateHashesRef.current.set(session.id, stateHash);
+				}
+
+				const executionQueue = session.executionQueue ?? [];
+				const queueHash = executionQueue
+					.map((item) => `${item.id}:${item.tabId}:${item.type}:${item.text || item.command || ''}`)
+					.join('|');
+				if (prevQueueHashesRef.current.get(session.id) !== queueHash) {
+					window.maestro.web.broadcastExecutionQueue(session.id, executionQueue);
+					prevQueueHashesRef.current.set(session.id, queueHash);
 				}
 
 				if (!session.aiTabs || session.aiTabs.length === 0) return;

--- a/src/web/hooks/useMobileSessionManagement.ts
+++ b/src/web/hooks/useMobileSessionManagement.ts
@@ -35,7 +35,15 @@
 
 import { useState, useCallback, useRef, useEffect, useMemo } from 'react';
 import type { Session } from './useSessions';
-import type { WebSocketState, AITabData, AutoRunState, CustomCommand } from './useWebSocket';
+import type {
+	WebSocketState,
+	AITabData,
+	AutoRunState,
+	CustomCommand,
+	GitStatusData,
+	QueuedItemData,
+	ToolExecutionData,
+} from './useWebSocket';
 import { buildApiUrl, getMaestroConfig, updateUrlForSessionTab } from '../utils/config';
 import { webLogger } from '../utils/logger';
 import type { Theme } from '../../shared/theme-types';
@@ -49,11 +57,7 @@ export interface LogEntry {
 	text: string;
 	source: 'user' | 'stdout' | 'stderr' | 'thinking' | 'tool';
 	metadata?: {
-		toolState?: {
-			name?: string;
-			status?: 'running' | 'completed' | 'error';
-			input?: Record<string, unknown>;
-		};
+		toolState?: ToolExecutionData['state'];
 	};
 }
 
@@ -144,6 +148,9 @@ export interface MobileSessionHandlers {
 	onCustomCommands: (commands: CustomCommand[]) => void;
 	onAutoRunStateChange: (sessionId: string, state: AutoRunState | null) => void;
 	onTabsChanged: (sessionId: string, aiTabs: AITabData[], newActiveTabId: string) => void;
+	onGitStatusChanged: (sessionId: string, gitStatus: GitStatusData | null) => void;
+	onExecutionQueueChanged: (sessionId: string, executionQueue: QueuedItemData[]) => void;
+	onToolExecution: (sessionId: string, tabId: string | undefined, tool: ToolExecutionData) => void;
 }
 
 /**
@@ -788,6 +795,30 @@ export function useMobileSessionManagement(
 					activeTabIdRef.current = newActiveTabId;
 					setActiveTabId(newActiveTabId);
 				}
+			},
+			onGitStatusChanged: (sessionId: string, gitStatus: GitStatusData | null) => {
+				setSessions((prev) => prev.map((s) => (s.id === sessionId ? { ...s, gitStatus } : s)));
+			},
+			onExecutionQueueChanged: (sessionId: string, executionQueue: QueuedItemData[]) => {
+				setSessions((prev) => prev.map((s) => (s.id === sessionId ? { ...s, executionQueue } : s)));
+			},
+			onToolExecution: (sessionId: string, tabId: string | undefined, tool: ToolExecutionData) => {
+				if (activeSessionIdRef.current !== sessionId) return;
+				if (tabId && activeTabIdRef.current && tabId !== activeTabIdRef.current) return;
+
+				const toolLogEntry: LogEntry = {
+					id: `tool-${Date.now()}-${tool.toolName}`,
+					timestamp: tool.timestamp || Date.now(),
+					text: tool.toolName,
+					source: 'tool',
+					metadata: {
+						toolState: tool.state,
+					},
+				};
+				setSessionLogs((prev) => ({
+					...prev,
+					aiLogs: [...prev.aiLogs, toolLogEntry],
+				}));
 			},
 		}),
 		[

--- a/src/web/hooks/useMobileSessionManagement.ts
+++ b/src/web/hooks/useMobileSessionManagement.ts
@@ -250,6 +250,7 @@ export function useMobileSessionManagement(
 
 	// Track previous session states for detecting busy -> idle transitions
 	const previousSessionStatesRef = useRef<Map<string, string>>(new Map());
+	const toolLogIdCounterRef = useRef(0);
 
 	// Ref to track activeSessionId for use in callbacks (avoids stale closure issues)
 	// Initialize with same value as state to avoid race condition where WebSocket
@@ -806,8 +807,9 @@ export function useMobileSessionManagement(
 				if (activeSessionIdRef.current !== sessionId) return;
 				if (tabId && activeTabIdRef.current && tabId !== activeTabIdRef.current) return;
 
+				toolLogIdCounterRef.current += 1;
 				const toolLogEntry: LogEntry = {
-					id: `tool-${Date.now()}-${tool.toolName}`,
+					id: `tool-${tool.timestamp || Date.now()}-${tool.toolName}-${toolLogIdCounterRef.current}`,
 					timestamp: tool.timestamp || Date.now(),
 					text: tool.toolName,
 					source: 'tool',

--- a/src/web/hooks/useWebSocket.ts
+++ b/src/web/hooks/useWebSocket.ts
@@ -17,7 +17,7 @@ import { webLogger } from '../utils/logger';
 /**
  * Cap on the dedup cache for session_output messages. The previous
  * implementation grew to 1000 entries then rebuilt a smaller Set; switching
- * to a bounded LRU keeps memory flat and eviction O(1).
+ * to a bounded Map keeps memory flat and eviction O(1).
  */
 const MAX_SEEN_MSG_IDS = 500;
 
@@ -861,6 +861,9 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
 						// Dedupe using message ID if available
 						if (outputMsg.msgId) {
 							if (seenMsgIdsRef.current.has(outputMsg.msgId)) {
+								// Refresh recency before skipping so eviction is LRU-on-access.
+								seenMsgIdsRef.current.delete(outputMsg.msgId);
+								seenMsgIdsRef.current.set(outputMsg.msgId, true);
 								webLogger.debug(
 									`DEDUPE: Skipping duplicate session_output msgId=${outputMsg.msgId}`,
 									'WebSocket'
@@ -868,7 +871,7 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
 								break;
 							}
 							seenMsgIdsRef.current.set(outputMsg.msgId, true);
-							// Bounded LRU: if we hit the cap, drop the oldest insertion.
+							// Bounded LRU: if we hit the cap, drop the least recently seen ID.
 							// Map iteration is insertion-order so .keys().next() is the oldest.
 							if (seenMsgIdsRef.current.size > MAX_SEEN_MSG_IDS) {
 								const oldest = seenMsgIdsRef.current.keys().next().value;

--- a/src/web/hooks/useWebSocket.ts
+++ b/src/web/hooks/useWebSocket.ts
@@ -36,6 +36,51 @@ export type WebSocketState =
  */
 export type UsageStats = Partial<BaseUsageStats>;
 
+export interface QueuedItemData {
+	id: string;
+	timestamp: number;
+	tabId: string;
+	type: 'message' | 'command';
+	text?: string;
+	images?: string[];
+	command?: string;
+	commandArgs?: string;
+	commandDescription?: string;
+	tabName?: string;
+	readOnlyMode?: boolean;
+}
+
+export interface GitFileChangeData {
+	path: string;
+	status: string;
+	additions: number;
+	deletions: number;
+	modified: boolean;
+}
+
+export interface GitStatusData {
+	fileCount: number;
+	branch?: string;
+	remote?: string;
+	behind: number;
+	ahead: number;
+	fileChanges?: GitFileChangeData[];
+	totalAdditions: number;
+	totalDeletions: number;
+	modifiedCount: number;
+	lastUpdated: number;
+}
+
+export interface ToolExecutionData {
+	toolName: string;
+	state?: {
+		status?: 'running' | 'completed' | 'error';
+		input?: unknown;
+		output?: unknown;
+	};
+	timestamp: number;
+}
+
 /**
  * AI Tab data for multi-tab support within a Maestro session
  */
@@ -83,6 +128,10 @@ export interface SessionData {
 	aiTabs?: AITabData[];
 	activeTabId?: string;
 	bookmarked?: boolean; // Whether session is bookmarked (shows in Bookmarks group)
+	currentCycleTokens?: number;
+	executionQueue?: QueuedItemData[];
+	isGitRepo?: boolean;
+	gitStatus?: GitStatusData | null;
 	// Worktree subagent support
 	parentSessionId?: string | null; // If this is a worktree child, links to parent session
 	worktreeBranch?: string | null; // Git branch for this worktree child
@@ -140,6 +189,9 @@ export type ServerMessageType =
 	| 'tool_event'
 	| 'terminal_data'
 	| 'terminal_ready'
+	| 'git_status_changed'
+	| 'execution_queue_changed'
+	| 'tool_execution'
 	| 'pong'
 	| 'subscribed'
 	| 'echo'
@@ -209,6 +261,8 @@ export interface SessionStateChangeMessage extends ServerMessage {
 	toolType?: string;
 	inputMode?: string;
 	cwd?: string;
+	currentCycleTokens?: number;
+	thinkingStartTime?: number;
 }
 
 /**
@@ -398,6 +452,25 @@ export interface TabsChangedMessage extends ServerMessage {
 	activeTabId: string;
 }
 
+export interface GitStatusChangedMessage extends ServerMessage {
+	type: 'git_status_changed';
+	sessionId: string;
+	gitStatus: GitStatusData | null;
+}
+
+export interface ExecutionQueueChangedMessage extends ServerMessage {
+	type: 'execution_queue_changed';
+	sessionId: string;
+	executionQueue: QueuedItemData[];
+}
+
+export interface ToolExecutionMessage extends ServerMessage {
+	type: 'tool_execution';
+	sessionId: string;
+	tabId?: string;
+	tool: ToolExecutionData;
+}
+
 /**
  * Group chat message data
  */
@@ -498,6 +571,9 @@ export type TypedServerMessage =
 	| GroupChatMessageBroadcast
 	| GroupChatStateChangeBroadcast
 	| ToolEventMessage
+	| GitStatusChangedMessage
+	| ExecutionQueueChangedMessage
+	| ToolExecutionMessage
 	| ErrorMessage
 	| ServerMessage;
 
@@ -561,6 +637,9 @@ export interface WebSocketEventHandlers {
 	onGroupChatMessage?: (chatId: string, message: GroupChatMessage) => void;
 	/** Called when group chat state changes */
 	onGroupChatStateChange?: (chatId: string, state: Partial<GroupChatState>) => void;
+	onGitStatusChanged?: (sessionId: string, gitStatus: GitStatusData | null) => void;
+	onExecutionQueueChanged?: (sessionId: string, executionQueue: QueuedItemData[]) => void;
+	onToolExecution?: (sessionId: string, tabId: string | undefined, tool: ToolExecutionData) => void;
 	/** Called when connection state changes */
 	onConnectionChange?: (state: WebSocketState) => void;
 	/** Called when an error occurs */
@@ -833,6 +912,8 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
 								toolType: stateChangeMsg.toolType,
 								inputMode: stateChangeMsg.inputMode,
 								cwd: stateChangeMsg.cwd,
+								currentCycleTokens: stateChangeMsg.currentCycleTokens,
+								thinkingStartTime: stateChangeMsg.thinkingStartTime,
 							}
 						);
 						break;
@@ -1007,6 +1088,27 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
 							gcChatId,
 							gcState as Partial<GroupChatState>
 						);
+						break;
+					}
+
+					case 'git_status_changed': {
+						const gitMsg = message as GitStatusChangedMessage;
+						handlersRef.current?.onGitStatusChanged?.(gitMsg.sessionId, gitMsg.gitStatus);
+						break;
+					}
+
+					case 'execution_queue_changed': {
+						const queueMsg = message as ExecutionQueueChangedMessage;
+						handlersRef.current?.onExecutionQueueChanged?.(
+							queueMsg.sessionId,
+							queueMsg.executionQueue
+						);
+						break;
+					}
+
+					case 'tool_execution': {
+						const toolMsg = message as ToolExecutionMessage;
+						handlersRef.current?.onToolExecution?.(toolMsg.sessionId, toolMsg.tabId, toolMsg.tool);
 						break;
 					}
 

--- a/src/web/hooks/useWebSocket.ts
+++ b/src/web/hooks/useWebSocket.ts
@@ -15,6 +15,13 @@ import { buildWebSocketUrl as buildWsUrl, getCurrentSessionId } from '../utils/c
 import { webLogger } from '../utils/logger';
 
 /**
+ * Cap on the dedup cache for session_output messages. The previous
+ * implementation grew to 1000 entries then rebuilt a smaller Set; switching
+ * to a bounded LRU keeps memory flat and eviction O(1).
+ */
+const MAX_SEEN_MSG_IDS = 500;
+
+/**
  * WebSocket connection states
  */
 export type WebSocketState =
@@ -692,8 +699,10 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
 	// Connection ID to handle StrictMode double-mounting - each mount gets unique ID
 	const connectionIdRef = useRef<number>(0);
 	const mountIdRef = useRef<number>(0);
-	// Track seen message IDs to dedupe duplicate broadcasts
-	const seenMsgIdsRef = useRef<Set<string>>(new Set());
+	// Track seen message IDs to dedupe duplicate broadcasts.
+	// A Map gives us insertion-ordered iteration, so capping the size and
+	// dropping the oldest entry is O(1) — no Set rebuilds on every batch.
+	const seenMsgIdsRef = useRef<Map<string, true>>(new Map());
 	// Ref for handleMessage to avoid stale closure issues
 	const handleMessageRef = useRef<((event: MessageEvent) => void) | null>(null);
 	// Pending request-response map for sendRequest correlation
@@ -858,11 +867,14 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRet
 								);
 								break;
 							}
-							seenMsgIdsRef.current.add(outputMsg.msgId);
-							// Limit set size to prevent memory leaks (keep last 1000 IDs)
-							if (seenMsgIdsRef.current.size > 1000) {
-								const idsArray = Array.from(seenMsgIdsRef.current);
-								seenMsgIdsRef.current = new Set(idsArray.slice(-500));
+							seenMsgIdsRef.current.set(outputMsg.msgId, true);
+							// Bounded LRU: if we hit the cap, drop the oldest insertion.
+							// Map iteration is insertion-order so .keys().next() is the oldest.
+							if (seenMsgIdsRef.current.size > MAX_SEEN_MSG_IDS) {
+								const oldest = seenMsgIdsRef.current.keys().next().value;
+								if (oldest !== undefined) {
+									seenMsgIdsRef.current.delete(oldest);
+								}
 							}
 						}
 						webLogger.debug(

--- a/src/web/mobile/App.tsx
+++ b/src/web/mobile/App.tsx
@@ -1070,6 +1070,48 @@ function GroupChatListSheet({ chats, onSelectChat, onNewChat, onClose }: GroupCh
 }
 
 /**
+ * Build the tooltip for the in-cycle "Thinking N tokens" indicator.
+ * Adds the lifetime input/output/cache/reasoning breakdown when available so
+ * the mobile surface reaches parity with the desktop usage display. Reasoning
+ * tokens are reported separately by some agents but are already rolled into
+ * outputTokens upstream — they show as a labeled breakdown line, never added
+ * to the total again.
+ */
+function buildTokenTooltip(
+	currentCycleTokens: number,
+	usageStats?: Partial<import('../../shared/types').UsageStats> | null
+): string {
+	const cycleLine = `${currentCycleTokens.toLocaleString('en-US')} tokens this cycle`;
+	if (!usageStats) return cycleLine;
+
+	const inputTokens = usageStats.inputTokens ?? 0;
+	const outputTokens = usageStats.outputTokens ?? 0;
+	const reasoningTokens = usageStats.reasoningTokens ?? 0;
+	const cacheReadTokens = usageStats.cacheReadInputTokens ?? 0;
+	const cacheCreationTokens = usageStats.cacheCreationInputTokens ?? 0;
+	const totalTokens = inputTokens + outputTokens;
+
+	if (totalTokens === 0) return cycleLine;
+
+	const parts: string[] = [
+		cycleLine,
+		`Input: ${inputTokens.toLocaleString('en-US')}`,
+		`Output: ${outputTokens.toLocaleString('en-US')}`,
+	];
+	if (cacheReadTokens > 0) {
+		parts.push(`Cache read: ${cacheReadTokens.toLocaleString('en-US')}`);
+	}
+	if (cacheCreationTokens > 0) {
+		parts.push(`Cache create: ${cacheCreationTokens.toLocaleString('en-US')}`);
+	}
+	if (reasoningTokens > 0) {
+		parts.push(`Reasoning (in output): ${reasoningTokens.toLocaleString('en-US')}`);
+	}
+	parts.push(`Total: ${totalTokens.toLocaleString('en-US')} tokens`);
+	return parts.join(' | ');
+}
+
+/**
  * Main mobile app component with WebSocket connection management
  */
 export default function MobileApp() {
@@ -2956,7 +2998,6 @@ export default function MobileApp() {
 		const currentLogs =
 			activeSession.inputMode === 'ai' ? sessionLogs.aiLogs : sessionLogs.shellLogs;
 		const queue = activeSession.executionQueue || [];
-		const gitStatus = activeSession.gitStatus;
 		const currentCycleTokens = activeSession.currentCycleTokens || 0;
 
 		// Show message history
@@ -2974,7 +3015,7 @@ export default function MobileApp() {
 					overflow: 'hidden', // Contain MessageHistory's scroll
 				}}
 			>
-				{(queue.length > 0 || gitStatus || currentCycleTokens > 0) && (
+				{(queue.length > 0 || currentCycleTokens > 0) && (
 					<div
 						style={{
 							display: 'flex',
@@ -2997,16 +3038,8 @@ export default function MobileApp() {
 							}}
 						>
 							{currentCycleTokens > 0 && (
-								<span title={`${currentCycleTokens.toLocaleString('en-US')} tokens this cycle`}>
+								<span title={buildTokenTooltip(currentCycleTokens, activeSession.usageStats)}>
 									Thinking {currentCycleTokens.toLocaleString('en-US')} tokens
-								</span>
-							)}
-							{gitStatus && (
-								<span title="Git status">
-									Git {gitStatus.fileCount} files
-									{gitStatus.branch ? ` on ${gitStatus.branch}` : ''}
-									{gitStatus.ahead > 0 ? ` ↑${gitStatus.ahead}` : ''}
-									{gitStatus.behind > 0 ? ` ↓${gitStatus.behind}` : ''}
 								</span>
 							)}
 							{queue.length > 0 && <span>{queue.length} queued</span>}

--- a/src/web/mobile/App.tsx
+++ b/src/web/mobile/App.tsx
@@ -2130,6 +2130,51 @@ export default function MobileApp() {
 		[settingsHook.settings?.shortcuts]
 	);
 
+	const handleRemoveQueueItem = useCallback(
+		(itemId: string) => {
+			if (!activeSessionId) return;
+			send({ type: 'remove_queue_item', sessionId: activeSessionId, itemId });
+			setSessions((prev) =>
+				prev.map((s) =>
+					s.id === activeSessionId
+						? {
+								...s,
+								executionQueue: (s.executionQueue || []).filter((item) => item.id !== itemId),
+							}
+						: s
+				)
+			);
+		},
+		[activeSessionId, send, setSessions]
+	);
+
+	const handleReorderQueueItem = useCallback(
+		(fromIndex: number, toIndex: number) => {
+			if (!activeSessionId) return;
+			const queueLength = activeSession?.executionQueue?.length ?? 0;
+			if (
+				fromIndex === toIndex ||
+				fromIndex < 0 ||
+				fromIndex >= queueLength ||
+				toIndex < 0 ||
+				toIndex >= queueLength
+			) {
+				return;
+			}
+			send({ type: 'reorder_queue', sessionId: activeSessionId, fromIndex, toIndex });
+			setSessions((prev) =>
+				prev.map((s) => {
+					if (s.id !== activeSessionId) return s;
+					const executionQueue = [...(s.executionQueue || [])];
+					const [movedItem] = executionQueue.splice(fromIndex, 1);
+					executionQueue.splice(toIndex, 0, movedItem);
+					return { ...s, executionQueue };
+				})
+			);
+		},
+		[activeSession?.executionQueue?.length, activeSessionId, send, setSessions]
+	);
+
 	useMobileKeyboardHandler({
 		shortcuts: resolvedShortcuts,
 		activeSession,
@@ -2910,6 +2955,9 @@ export default function MobileApp() {
 		// Get logs based on current input mode
 		const currentLogs =
 			activeSession.inputMode === 'ai' ? sessionLogs.aiLogs : sessionLogs.shellLogs;
+		const queue = activeSession.executionQueue || [];
+		const gitStatus = activeSession.gitStatus;
+		const currentCycleTokens = activeSession.currentCycleTokens || 0;
 
 		// Show message history
 		return (
@@ -2926,6 +2974,122 @@ export default function MobileApp() {
 					overflow: 'hidden', // Contain MessageHistory's scroll
 				}}
 			>
+				{(queue.length > 0 || gitStatus || currentCycleTokens > 0) && (
+					<div
+						style={{
+							display: 'flex',
+							flexDirection: 'column',
+							gap: '6px',
+							padding: '8px 10px',
+							backgroundColor: colors.bgSidebar,
+							border: `1px solid ${colors.border}`,
+							borderRadius: '6px',
+							fontSize: '12px',
+						}}
+					>
+						<div
+							style={{
+								display: 'flex',
+								alignItems: 'center',
+								gap: '8px',
+								flexWrap: 'wrap',
+								color: colors.textDim,
+							}}
+						>
+							{currentCycleTokens > 0 && (
+								<span title={`${currentCycleTokens.toLocaleString('en-US')} tokens this cycle`}>
+									Thinking {currentCycleTokens.toLocaleString('en-US')} tokens
+								</span>
+							)}
+							{gitStatus && (
+								<span title="Git status">
+									Git {gitStatus.fileCount} files
+									{gitStatus.branch ? ` on ${gitStatus.branch}` : ''}
+									{gitStatus.ahead > 0 ? ` ↑${gitStatus.ahead}` : ''}
+									{gitStatus.behind > 0 ? ` ↓${gitStatus.behind}` : ''}
+								</span>
+							)}
+							{queue.length > 0 && <span>{queue.length} queued</span>}
+						</div>
+						{queue.length > 0 && (
+							<div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+								{queue.map((item, index) => (
+									<div
+										key={item.id}
+										style={{
+											display: 'grid',
+											gridTemplateColumns: '1fr auto auto auto',
+											alignItems: 'center',
+											gap: '6px',
+											minHeight: '28px',
+										}}
+									>
+										<span
+											style={{
+												overflow: 'hidden',
+												textOverflow: 'ellipsis',
+												whiteSpace: 'nowrap',
+												color: colors.textMain,
+											}}
+											title={item.text || item.command || item.commandDescription || item.type}
+										>
+											{item.command || item.text || item.commandDescription || item.type}
+										</span>
+										<button
+											type="button"
+											onClick={() => handleReorderQueueItem(index, index - 1)}
+											disabled={index === 0}
+											aria-disabled={index === 0}
+											style={{
+												width: '28px',
+												height: '28px',
+												borderRadius: '4px',
+												border: `1px solid ${colors.border}`,
+												backgroundColor: colors.bgMain,
+												color: index === 0 ? colors.textDim : colors.textMain,
+											}}
+											title="Move queued item up"
+										>
+											↑
+										</button>
+										<button
+											type="button"
+											onClick={() => handleReorderQueueItem(index, index + 1)}
+											disabled={index === queue.length - 1}
+											aria-disabled={index === queue.length - 1}
+											style={{
+												width: '28px',
+												height: '28px',
+												borderRadius: '4px',
+												border: `1px solid ${colors.border}`,
+												backgroundColor: colors.bgMain,
+												color: index === queue.length - 1 ? colors.textDim : colors.textMain,
+											}}
+											title="Move queued item down"
+										>
+											↓
+										</button>
+										<button
+											type="button"
+											onClick={() => handleRemoveQueueItem(item.id)}
+											style={{
+												width: '28px',
+												height: '28px',
+												borderRadius: '4px',
+												border: `1px solid ${colors.border}`,
+												backgroundColor: colors.bgMain,
+												color: colors.error,
+											}}
+											title="Remove queued item"
+										>
+											×
+										</button>
+									</div>
+								))}
+							</div>
+						)}
+					</div>
+				)}
 				{currentInputMode === 'terminal' ? (
 					<WebTerminal
 						key={`terminal-${activeSessionId}`}

--- a/src/web/mobile/MessageHistory.tsx
+++ b/src/web/mobile/MessageHistory.tsx
@@ -28,7 +28,8 @@ export interface LogEntry {
 		toolState?: {
 			name?: string;
 			status?: 'running' | 'completed' | 'error';
-			input?: Record<string, unknown>;
+			input?: unknown;
+			output?: unknown;
 		};
 	};
 }
@@ -364,6 +365,8 @@ export function MessageHistory({
 					const isError = source === 'stderr';
 					const isSystem = source === 'system';
 					const isThinking = source === 'thinking';
+					const isTool = source === 'tool';
+					const messageKey = entry.id || `${entry.timestamp}-${index}`;
 					const isExpanded = expandedMessages.has(messageKey);
 					const isTruncatable = shouldTruncate(text);
 					const displayText = isExpanded || !isTruncatable ? text : getTruncatedText(text);
@@ -388,7 +391,7 @@ export function MessageHistory({
 									? `${colors.accent}15`
 									: isError
 										? `${colors.error}10`
-										: isSystem
+										: isSystem || isTool
 											? `${colors.textDim}10`
 											: isThinking
 												? `${colors.accent}08`
@@ -397,7 +400,13 @@ export function MessageHistory({
 								border: isThinking
 									? undefined
 									: `1px solid ${
-											isUser ? `${colors.accent}30` : isError ? `${colors.error}30` : colors.border
+											isUser
+												? `${colors.accent}30`
+												: isError
+													? `${colors.error}30`
+													: isTool
+														? `${colors.accent}30`
+														: colors.border
 										}`,
 								cursor: isTruncatable ? 'pointer' : 'default',
 								// Align user messages to the right
@@ -437,6 +446,8 @@ export function MessageHistory({
 												? 'Thinking'
 												: isSystem
 													? 'System'
+													: isTool
+														? 'Tool'
 													: inputMode === 'ai'
 														? 'AI'
 														: 'Output'}
@@ -463,7 +474,9 @@ export function MessageHistory({
 									textAlign: 'left',
 								}}
 							>
-								{inputMode === 'terminal' || isUser ? (
+								{isTool ? (
+									<ToolCard entry={entry} />
+								) : inputMode === 'terminal' || isUser ? (
 									// Terminal output and user input: render as plain monospace text
 									<div
 										style={{
@@ -532,6 +545,79 @@ export function MessageHistory({
 						</span>
 					)}
 				</button>
+			)}
+		</div>
+	);
+}
+
+function getToolDetail(input: unknown): string | null {
+	if (!input || typeof input !== 'object') return null;
+	const value = input as Record<string, unknown>;
+	const candidates = [
+		value.command,
+		value.pattern,
+		value.file_path,
+		value.filePath,
+		value.query,
+		value.description,
+		value.prompt,
+		value.task_id,
+		value.path,
+		value.cmd,
+		value.code,
+	];
+	for (const candidate of candidates) {
+		if (typeof candidate === 'string' && candidate.trim()) {
+			return candidate.length > 160 ? `${candidate.slice(0, 157)}...` : candidate;
+		}
+	}
+	return null;
+}
+
+function ToolCard({ entry }: { entry: LogEntry }) {
+	const colors = useThemeColors();
+	const state = entry.metadata?.toolState;
+	const detail = getToolDetail(state?.input);
+	const status = state?.status;
+	const statusColor =
+		status === 'completed' ? colors.success : status === 'error' ? colors.error : colors.warning;
+
+	return (
+		<div
+			style={{
+				display: 'flex',
+				flexDirection: 'column',
+				gap: '6px',
+				fontFamily: 'ui-monospace, monospace',
+				fontSize: '12px',
+				lineHeight: 1.4,
+			}}
+		>
+			<div style={{ display: 'flex', alignItems: 'center', gap: '8px', minWidth: 0 }}>
+				<span style={{ color: statusColor, flexShrink: 0 }}>
+					{status === 'completed' ? '✓' : status === 'error' ? '!' : '●'}
+				</span>
+				<span
+					style={{
+						color: colors.textMain,
+						overflow: 'hidden',
+						textOverflow: 'ellipsis',
+						whiteSpace: 'nowrap',
+					}}
+				>
+					{entry.text || entry.content || 'Tool'}
+				</span>
+			</div>
+			{detail && (
+				<div
+					style={{
+						color: colors.textDim,
+						whiteSpace: 'pre-wrap',
+						wordBreak: 'break-word',
+					}}
+				>
+					{detail}
+				</div>
 			)}
 		</div>
 	);

--- a/src/web/mobile/MessageHistory.tsx
+++ b/src/web/mobile/MessageHistory.tsx
@@ -365,8 +365,6 @@ export function MessageHistory({
 					const isError = source === 'stderr';
 					const isSystem = source === 'system';
 					const isThinking = source === 'thinking';
-					const isTool = source === 'tool';
-					const messageKey = entry.id || `${entry.timestamp}-${index}`;
 					const isExpanded = expandedMessages.has(messageKey);
 					const isTruncatable = shouldTruncate(text);
 					const displayText = isExpanded || !isTruncatable ? text : getTruncatedText(text);
@@ -391,7 +389,7 @@ export function MessageHistory({
 									? `${colors.accent}15`
 									: isError
 										? `${colors.error}10`
-										: isSystem || isTool
+										: isSystem
 											? `${colors.textDim}10`
 											: isThinking
 												? `${colors.accent}08`
@@ -400,13 +398,7 @@ export function MessageHistory({
 								border: isThinking
 									? undefined
 									: `1px solid ${
-											isUser
-												? `${colors.accent}30`
-												: isError
-													? `${colors.error}30`
-													: isTool
-														? `${colors.accent}30`
-														: colors.border
+											isUser ? `${colors.accent}30` : isError ? `${colors.error}30` : colors.border
 										}`,
 								cursor: isTruncatable ? 'pointer' : 'default',
 								// Align user messages to the right
@@ -446,8 +438,6 @@ export function MessageHistory({
 												? 'Thinking'
 												: isSystem
 													? 'System'
-													: isTool
-														? 'Tool'
 													: inputMode === 'ai'
 														? 'AI'
 														: 'Output'}
@@ -474,9 +464,7 @@ export function MessageHistory({
 									textAlign: 'left',
 								}}
 							>
-								{isTool ? (
-									<ToolCard entry={entry} />
-								) : inputMode === 'terminal' || isUser ? (
+								{inputMode === 'terminal' || isUser ? (
 									// Terminal output and user input: render as plain monospace text
 									<div
 										style={{

--- a/src/web/mobile/SessionPillBar.tsx
+++ b/src/web/mobile/SessionPillBar.tsx
@@ -228,6 +228,43 @@ function SessionPill({ session, isActive, onSelect, onLongPress }: SessionPillPr
 				{session.name}
 			</span>
 
+			{/* Worktree branch badge — only for sessions that are worktree
+			 * children (parentSessionId is set), so we don't double-decorate
+			 * the parent session itself. Mirrors the desktop sidebar's branch
+			 * affordance for worktree subagents. */}
+			{session.parentSessionId && session.worktreeBranch && (
+				<span
+					title={`Worktree branch: ${session.worktreeBranch}`}
+					aria-label={`Worktree branch ${session.worktreeBranch}`}
+					style={{
+						display: 'inline-flex',
+						alignItems: 'center',
+						gap: '2px',
+						fontSize: '10px',
+						fontWeight: 500,
+						color: colors.textDim,
+						backgroundColor: `${colors.textDim}15`,
+						padding: '2px 5px',
+						borderRadius: '3px',
+						lineHeight: 1,
+						maxWidth: '90px',
+						overflow: 'hidden',
+						textOverflow: 'ellipsis',
+						whiteSpace: 'nowrap',
+					}}
+				>
+					<span aria-hidden="true">⎇</span>
+					<span
+						style={{
+							overflow: 'hidden',
+							textOverflow: 'ellipsis',
+						}}
+					>
+						{session.worktreeBranch}
+					</span>
+				</span>
+			)}
+
 			{/* Mode icon */}
 			{renderModeIcon()}
 		</button>

--- a/src/web/mobile/SessionPillBar.tsx
+++ b/src/web/mobile/SessionPillBar.tsx
@@ -258,6 +258,7 @@ function SessionPill({ session, isActive, onSelect, onLongPress }: SessionPillPr
 						style={{
 							overflow: 'hidden',
 							textOverflow: 'ellipsis',
+							minWidth: 0,
 						}}
 					>
 						{session.worktreeBranch}

--- a/src/web/mobile/SessionStatusBanner.tsx
+++ b/src/web/mobile/SessionStatusBanner.tsx
@@ -318,7 +318,7 @@ function TokenCount({ usageStats }: { usageStats?: UsageStats | null }) {
 		tooltipParts.push(`Cache create: ${cacheCreationTokens.toLocaleString('en-US')}`);
 	}
 	if (reasoningTokens > 0) {
-		tooltipParts.push(`Reasoning: ${reasoningTokens.toLocaleString('en-US')}`);
+		tooltipParts.push(`Reasoning (in output): ${reasoningTokens.toLocaleString('en-US')}`);
 	}
 	tooltipParts.push(`Total: ${totalTokens.toLocaleString('en-US')} tokens`);
 

--- a/src/web/mobile/SessionStatusBanner.tsx
+++ b/src/web/mobile/SessionStatusBanner.tsx
@@ -281,7 +281,11 @@ function TokenCount({ usageStats }: { usageStats?: UsageStats | null }) {
 
 	const inputTokens = usageStats.inputTokens ?? 0;
 	const outputTokens = usageStats.outputTokens ?? 0;
-	const totalTokens = inputTokens + outputTokens;
+	// Reasoning tokens are reported separately by certain agents (Codex o3 /
+	// o4-mini). Desktop folds them into the displayed total; mirror that here
+	// so mobile parity matches.
+	const reasoningTokens = usageStats.reasoningTokens ?? 0;
+	const totalTokens = inputTokens + outputTokens + reasoningTokens;
 
 	// Don't show if no tokens yet
 	if (totalTokens === 0) {
@@ -299,6 +303,15 @@ function TokenCount({ usageStats }: { usageStats?: UsageStats | null }) {
 		return count.toString();
 	};
 
+	const tooltipParts = [
+		`Input: ${inputTokens.toLocaleString('en-US')}`,
+		`Output: ${outputTokens.toLocaleString('en-US')}`,
+	];
+	if (reasoningTokens > 0) {
+		tooltipParts.push(`Reasoning: ${reasoningTokens.toLocaleString('en-US')}`);
+	}
+	tooltipParts.push(`Total: ${totalTokens.toLocaleString('en-US')} tokens`);
+
 	return (
 		<span
 			style={{
@@ -314,7 +327,7 @@ function TokenCount({ usageStats }: { usageStats?: UsageStats | null }) {
 				lineHeight: 1,
 				flexShrink: 0,
 			}}
-			title={`Input: ${inputTokens.toLocaleString('en-US')} | Output: ${outputTokens.toLocaleString('en-US')} | Total: ${totalTokens.toLocaleString('en-US')} tokens`}
+			title={tooltipParts.join(' | ')}
 			aria-label={`${totalTokens.toLocaleString('en-US')} tokens used`}
 		>
 			<span style={{ fontSize: '10px' }}>📊</span>

--- a/src/web/mobile/SessionStatusBanner.tsx
+++ b/src/web/mobile/SessionStatusBanner.tsx
@@ -303,10 +303,21 @@ function TokenCount({ usageStats }: { usageStats?: UsageStats | null }) {
 		return count.toString();
 	};
 
+	// Cache token counts come through for Claude/Codex; desktop's usage
+	// breakdown surfaces them, mobile previously did not.
+	const cacheReadTokens = usageStats.cacheReadInputTokens ?? 0;
+	const cacheCreationTokens = usageStats.cacheCreationInputTokens ?? 0;
+
 	const tooltipParts = [
 		`Input: ${inputTokens.toLocaleString('en-US')}`,
 		`Output: ${outputTokens.toLocaleString('en-US')}`,
 	];
+	if (cacheReadTokens > 0) {
+		tooltipParts.push(`Cache read: ${cacheReadTokens.toLocaleString('en-US')}`);
+	}
+	if (cacheCreationTokens > 0) {
+		tooltipParts.push(`Cache create: ${cacheCreationTokens.toLocaleString('en-US')}`);
+	}
 	if (reasoningTokens > 0) {
 		tooltipParts.push(`Reasoning: ${reasoningTokens.toLocaleString('en-US')}`);
 	}

--- a/src/web/mobile/SessionStatusBanner.tsx
+++ b/src/web/mobile/SessionStatusBanner.tsx
@@ -281,11 +281,10 @@ function TokenCount({ usageStats }: { usageStats?: UsageStats | null }) {
 
 	const inputTokens = usageStats.inputTokens ?? 0;
 	const outputTokens = usageStats.outputTokens ?? 0;
-	// Reasoning tokens are reported separately by certain agents (Codex o3 /
-	// o4-mini). Desktop folds them into the displayed total; mirror that here
-	// so mobile parity matches.
+	// Reasoning tokens are reported separately by certain agents, but they are
+	// already included in outputTokens. Keep them as a tooltip breakdown only.
 	const reasoningTokens = usageStats.reasoningTokens ?? 0;
-	const totalTokens = inputTokens + outputTokens + reasoningTokens;
+	const totalTokens = inputTokens + outputTokens;
 
 	// Don't show if no tokens yet
 	if (totalTokens === 0) {


### PR DESCRIPTION
## Summary

- include reasoning token counts in the mobile session token display
- show cache read/write token counts in the mobile token tooltip
- add worktree branch badges to mobile session pills
- bound the web WebSocket deduplication cache with LRU-style eviction
- include a Prettier-only cleanup commit for existing release-note format drift

## Validation

Reported from pre-push validation on the final branch:

- `npm run lint`
- `npm run lint:eslint`
- `npm run format:check:all`
- `npm run test` — 22,528 passed / 22,635 total, 107 skipped

## Notes

Playwright web coverage and web e2e scripts are intentionally not included in this upstream branch; this PR contains only the production web/mobile changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mobile: execution-queue panel with move/remove controls, worktree branch badges on session pills, and expanded token/cycle display
  * Message history: tool execution entries with dedicated styling and status indicators

* **Real-time & Sync**
  * Web/preload/websocket broadcasts for git status, execution-queue, and tool execution; remote commands now enqueue rather than drop; session state includes token/timing fields

* **Performance**
  * Bounded, recency-aware message deduplication

* **Documentation**
  * Standardized release notes formatting

* **Tests**
  * Updated tests and mocks to cover queue/remote behaviors and command flow
<!-- end of auto-generated comment: release notes by coderabbit.ai -->