### PR TITLE
fix(codex): plumb customEffort and stop displaying capacity as usage

### DIFF
--- a/src/__tests__/renderer/components/HistoryDetailModal.test.tsx
+++ b/src/__tests__/renderer/components/HistoryDetailModal.test.tsx
@@ -755,6 +755,12 @@ describe('HistoryDetailModal', () => {
 				<HistoryDetailModal
 					theme={mockTheme}
 					entry={createMockEntry({
+						// Accumulated multi-tool entry: raw tokens overflow the window,
+						// but the preserved per-entry contextUsage is the last known good
+						// percentage. The display must clamp at 100% rather than render
+						// 0% (issue #762: previously the overflow path silently surfaced
+						// the capacity as the used-token count).
+						contextUsage: 100,
 						usageStats: {
 							inputTokens: 150000,
 							outputTokens: 1000,
@@ -768,7 +774,6 @@ describe('HistoryDetailModal', () => {
 				/>
 			);
 
-			// Should cap at 100%
 			expect(screen.getByText('100%')).toBeInTheDocument();
 		});
 

--- a/src/__tests__/renderer/components/NewInstanceModal.test.tsx
+++ b/src/__tests__/renderer/components/NewInstanceModal.test.tsx
@@ -730,7 +730,8 @@ describe('NewInstanceModal', () => {
 				undefined,
 				undefined,
 				undefined,
-				{ enabled: false, remoteId: null }
+				{ enabled: false, remoteId: null },
+				undefined
 			);
 		});
 
@@ -777,7 +778,8 @@ describe('NewInstanceModal', () => {
 				undefined,
 				undefined,
 				undefined,
-				{ enabled: false, remoteId: null }
+				{ enabled: false, remoteId: null },
+				undefined
 			);
 		});
 
@@ -824,7 +826,8 @@ describe('NewInstanceModal', () => {
 				undefined,
 				undefined,
 				undefined,
-				{ enabled: false, remoteId: null }
+				{ enabled: false, remoteId: null },
+				undefined
 			);
 		});
 	});
@@ -872,7 +875,8 @@ describe('NewInstanceModal', () => {
 				undefined,
 				undefined,
 				undefined,
-				{ enabled: false, remoteId: null }
+				{ enabled: false, remoteId: null },
+				undefined
 			);
 			expect(onClose).toHaveBeenCalled();
 		});
@@ -1383,7 +1387,8 @@ describe('NewInstanceModal', () => {
 				undefined,
 				undefined,
 				undefined,
-				{ enabled: false, remoteId: null }
+				{ enabled: false, remoteId: null },
+				undefined
 			);
 		});
 
@@ -1530,7 +1535,8 @@ describe('NewInstanceModal', () => {
 				undefined,
 				undefined,
 				undefined,
-				{ enabled: false, remoteId: null }
+				{ enabled: false, remoteId: null },
+				undefined
 			);
 		});
 	});
@@ -2470,7 +2476,8 @@ describe('NewInstanceModal', () => {
 					remoteId: 'remote-1',
 					syncHistory: false,
 					workingDirOverride: '/test/path',
-				}
+				},
+				undefined
 			);
 		});
 
@@ -2694,7 +2701,8 @@ describe('NewInstanceModal', () => {
 					enabled: true,
 					remoteId: 'remote-1',
 					workingDirOverride: '/home/devuser/my-project',
-				})
+				}),
+				undefined
 			);
 		});
 
@@ -2804,7 +2812,8 @@ describe('NewInstanceModal', () => {
 					enabled: true,
 					remoteId: 'remote-1',
 					workingDirOverride: '/explicit/override/path',
-				})
+				}),
+				undefined
 			);
 		});
 

--- a/src/__tests__/renderer/components/NewInstanceModal.test.tsx
+++ b/src/__tests__/renderer/components/NewInstanceModal.test.tsx
@@ -2314,6 +2314,81 @@ describe('NewInstanceModal', () => {
 			expect(sourceSession.customArgs).toBe('--model=opus --verbose');
 		});
 
+		it('forwards source.customEffort through to onCreate when duplicating a Codex agent', async () => {
+			// Positive coverage for the customEffort plumbing (#755) and the
+			// duplicate-flow merge fix (CodeRabbit review): the picked effort must
+			// flow through as the trailing customEffort arg, not just `undefined`.
+			const sourceSession: Session = {
+				id: 'session-codex',
+				name: 'Codex Agent',
+				toolType: 'codex',
+				cwd: '/home/testuser/proj',
+				projectRoot: '/home/testuser/proj',
+				fullPath: '/home/testuser/proj',
+				state: 'idle',
+				inputMode: 'ai',
+				aiPid: 0,
+				terminalPid: 0,
+				port: 3000,
+				aiTabs: [],
+				activeTabId: 'tab-1',
+				closedTabHistory: [],
+				shellLogs: [],
+				executionQueue: [],
+				contextUsage: 0,
+				workLog: [],
+				isGitRepo: false,
+				changedFiles: [],
+				fileTree: [],
+				fileExplorerExpanded: [],
+				fileExplorerScrollPos: 0,
+				isLive: false,
+				customEffort: 'xhigh',
+			} as Session;
+
+			vi.mocked(window.maestro.agents.detect).mockResolvedValue([
+				createAgentConfig({
+					id: 'codex',
+					name: 'OpenAI Codex',
+					available: true,
+					configOptions: [
+						{
+							key: 'reasoningEffort',
+							type: 'select',
+							label: 'Reasoning Effort',
+							default: '',
+							options: ['', 'minimal', 'low', 'medium', 'high', 'xhigh'],
+						},
+					],
+				}),
+			]);
+
+			render(
+				<NewInstanceModal
+					isOpen={true}
+					onClose={onClose}
+					onCreate={onCreate}
+					theme={theme}
+					existingSessions={[]}
+					sourceSession={sourceSession}
+				/>
+			);
+
+			await waitFor(() => {
+				const nameInput = screen.getByLabelText('Agent Name') as HTMLInputElement;
+				expect(nameInput.value).toBe('Codex Agent (Copy)');
+			});
+
+			await act(async () => {
+				fireEvent.click(screen.getByText('Create Agent'));
+			});
+
+			// 13th positional arg is customEffort. assert it's 'xhigh', not undefined.
+			expect(onCreate).toHaveBeenCalled();
+			const args = onCreate.mock.calls[0];
+			expect(args[12]).toBe('xhigh');
+		});
+
 		it('should display SSH selector even when no agent is selected', async () => {
 			// This tests the bug where SSH section was hidden when no agents were available
 			vi.mocked(window.maestro.agents.detect).mockResolvedValue([

--- a/src/__tests__/renderer/components/TabSwitcherModal.test.tsx
+++ b/src/__tests__/renderer/components/TabSwitcherModal.test.tsx
@@ -572,13 +572,16 @@ describe('TabSwitcherModal', () => {
 				expect(screen.getByText('20%')).toBeInTheDocument();
 			});
 
-			it('caps at 100%', () => {
+			it('caps at 100% when tokens fill the window exactly', () => {
+				// Use values that fill the window without overflowing so we exercise
+				// the Math.min(100, …) cap rather than the overflow branch (which now
+				// returns untrustworthy zeros — see issue #762).
 				const tab = createTestTab({
 					usageStats: {
-						inputTokens: 150000,
+						inputTokens: 199500,
 						outputTokens: 0,
-						cacheReadInputTokens: 100000, // Excluded from calculation (cumulative)
-						cacheCreationInputTokens: 100000,
+						cacheReadInputTokens: 0,
+						cacheCreationInputTokens: 500,
 						totalCostUsd: 5.0,
 						contextWindow: 200000,
 					},
@@ -596,7 +599,7 @@ describe('TabSwitcherModal', () => {
 					/>
 				);
 
-				// (150000 + 100000) / 200000 = 125% -> capped at 100% (cacheRead excluded)
+				// 200000 / 200000 = 100%
 				expect(screen.getByText('100%')).toBeInTheDocument();
 			});
 		});

--- a/src/__tests__/renderer/components/TabSwitcherModal.test.tsx
+++ b/src/__tests__/renderer/components/TabSwitcherModal.test.tsx
@@ -602,6 +602,38 @@ describe('TabSwitcherModal', () => {
 				// 200000 / 200000 = 100%
 				expect(screen.getByText('100%')).toBeInTheDocument();
 			});
+
+			it('hides the gauge when accumulated tokens overflow without a fallback', () => {
+				// Issue #762: an accumulated multi-tool turn can blow past the configured
+				// window before any session-level percentage has been preserved. We must
+				// not surface that as "0%" — hide the gauge instead so users don't read
+				// untrustworthy data.
+				const tab = createTestTab({
+					usageStats: {
+						inputTokens: 150000,
+						outputTokens: 0,
+						cacheReadInputTokens: 100000,
+						cacheCreationInputTokens: 100000,
+						totalCostUsd: 5.0,
+						contextWindow: 200000,
+					},
+				});
+
+				renderWithLayerStack(
+					<TabSwitcherModal
+						theme={theme}
+						tabs={[tab]}
+						activeTabId={tab.id}
+						projectRoot="/test"
+						onTabSelect={vi.fn()}
+						onNamedSessionSelect={vi.fn()}
+						onClose={vi.fn()}
+					/>
+				);
+
+				// No percentage badge should render (raw=350000 > window=200000, no fallback).
+				expect(screen.queryByText(/^\d+%$/)).not.toBeInTheDocument();
+			});
 		});
 	});
 

--- a/src/__tests__/renderer/hooks/useSessionCrud.test.ts
+++ b/src/__tests__/renderer/hooks/useSessionCrud.test.ts
@@ -389,7 +389,9 @@ describe('useSessionCrud', () => {
 					{ API_KEY: 'secret' },
 					'gpt-4',
 					8192,
-					'/custom/provider'
+					'/custom/provider',
+					undefined,
+					'high'
 				);
 			});
 
@@ -402,6 +404,7 @@ describe('useSessionCrud', () => {
 			expect(session.customModel).toBe('gpt-4');
 			expect(session.customContextWindow).toBe(8192);
 			expect(session.customProviderPath).toBe('/custom/provider');
+			expect(session.customEffort).toBe('high');
 		});
 
 		it('sets input mode to terminal for terminal agent', async () => {

--- a/src/__tests__/renderer/utils/contextUsage.test.ts
+++ b/src/__tests__/renderer/utils/contextUsage.test.ts
@@ -361,6 +361,7 @@ describe('calculateContextDisplay', () => {
 		expect(result.tokens).toBe(100000);
 		expect(result.percentage).toBe(50);
 		expect(result.contextWindow).toBe(200000);
+		expect(result.trustworthy).toBe(true);
 	});
 
 	it('should fall back to fallbackPercentage when tokens exceed context window', () => {
@@ -377,16 +378,21 @@ describe('calculateContextDisplay', () => {
 		// Raw = 1008000 > 200000, so falls back: tokens = round(75/100 * 200000) = 150000
 		expect(result.tokens).toBe(150000);
 		expect(result.percentage).toBe(75);
+		expect(result.trustworthy).toBe(true);
 	});
 
-	it('should cap percentage at 100 when tokens are close to window', () => {
+	it('should cap percentage at 100 when fallback tokens fill the entire window', () => {
+		// Raw overflow with a fallback percentage at the window cap derives tokens
+		// equal to the full window — percentage must clamp to 100 (not 100.x).
 		const result = calculateContextDisplay(
 			{ inputTokens: 190000, cacheReadInputTokens: 15000, cacheCreationInputTokens: 0 },
 			200000,
-			'claude-code'
+			'claude-code',
+			100
 		);
-		// (190000 + 15000) / 200000 = 102.5% -> capped at 100%
+		expect(result.tokens).toBe(200000);
 		expect(result.percentage).toBe(100);
+		expect(result.trustworthy).toBe(true);
 	});
 
 	it('should return zeros when context window is 0', () => {
@@ -394,9 +400,13 @@ describe('calculateContextDisplay', () => {
 		expect(result.tokens).toBe(0);
 		expect(result.percentage).toBe(0);
 		expect(result.contextWindow).toBe(0);
+		expect(result.trustworthy).toBe(false);
 	});
 
-	it('should clamp tokens to the window when accumulated values exceed it without a fallback', () => {
+	it('should return untrustworthy zeros when accumulated values overflow without a fallback', () => {
+		// Issue #762: previously this branch returned tokens=contextWindow, surfacing
+		// the capacity (e.g. 700,000) as if it were the used token count. Now it
+		// returns zeros + trustworthy:false so the caller can preserve last-known-good.
 		const result = calculateContextDisplay(
 			{
 				inputTokens: 50000,
@@ -407,9 +417,10 @@ describe('calculateContextDisplay', () => {
 			'claude-code'
 			// no fallback
 		);
-		// Raw = 1008000 > 200000, but no fallback, so clamp to the configured window
-		expect(result.tokens).toBe(200000);
-		expect(result.percentage).toBe(100);
+		expect(result.tokens).toBe(0);
+		expect(result.percentage).toBe(0);
+		expect(result.contextWindow).toBe(200000);
+		expect(result.trustworthy).toBe(false);
 	});
 
 	it('should clamp fallback percentages above 100 before deriving tokens', () => {
@@ -425,6 +436,7 @@ describe('calculateContextDisplay', () => {
 		);
 		expect(result.tokens).toBe(200000);
 		expect(result.percentage).toBe(100);
+		expect(result.trustworthy).toBe(true);
 	});
 
 	it('should use Codex semantics (includes output tokens)', () => {

--- a/src/main/agents/definitions.ts
+++ b/src/main/agents/definitions.ts
@@ -227,6 +227,9 @@ export const AGENT_DEFINITIONS: AgentDefinition[] = [
 				label: 'Reasoning Effort',
 				description: 'How much the model should reason before responding.',
 				dynamic: true,
+				// Static fallback used when ~/.codex/models_cache.json hasn't been
+				// written yet (e.g. fresh install) so the dropdown still renders.
+				options: ['', 'minimal', 'low', 'medium', 'high', 'xhigh'],
 				default: '',
 				argBuilder: (value: string) =>
 					value && value.trim() ? ['-c', `reasoning.effort="${value.trim()}"`] : [],

--- a/src/renderer/components/AppModals/AppSessionModals.tsx
+++ b/src/renderer/components/AppModals/AppSessionModals.tsx
@@ -38,7 +38,8 @@ export interface AppSessionModalsProps {
 			enabled: boolean;
 			remoteId: string | null;
 			workingDirOverride?: string;
-		}
+		},
+		customEffort?: string
 	) => void;
 	existingSessions: Session[];
 	sourceSession?: Session; // For agent duplication

--- a/src/renderer/components/NewInstanceModal/NewInstanceModal.tsx
+++ b/src/renderer/components/NewInstanceModal/NewInstanceModal.tsx
@@ -373,6 +373,12 @@ export function NewInstanceModal({
 		// Get contextWindow and providerPath from agent config
 		const agentCustomContextWindow = agentConfigs[selectedAgent]?.contextWindow || undefined;
 		const agentCustomProviderPath = agentConfigs[selectedAgent]?.providerPath?.trim() || undefined;
+		// Effort/reasoningEffort: agents use one or the other key (e.g. Codex stores
+		// it under `reasoningEffort`, Claude Code uses `effort`).
+		const agentCustomEffort =
+			agentConfigs[selectedAgent]?.reasoningEffort?.trim() ||
+			agentConfigs[selectedAgent]?.effort?.trim() ||
+			undefined;
 
 		// Get SSH remote configuration for this session (stored per-session, not per-agent)
 		const sshRemoteConfig = agentSshRemoteConfigs[selectedAgent];
@@ -410,7 +416,8 @@ export function NewInstanceModal({
 			agentCustomModel,
 			agentCustomContextWindow,
 			agentCustomProviderPath,
-			sessionSshRemoteConfig
+			sessionSshRemoteConfig,
+			agentCustomEffort
 		);
 		onClose();
 

--- a/src/renderer/components/NewInstanceModal/NewInstanceModal.tsx
+++ b/src/renderer/components/NewInstanceModal/NewInstanceModal.tsx
@@ -202,6 +202,16 @@ export function NewInstanceModal({
 				if (source.customProviderPath) {
 					sourceConfig.providerPath = source.customProviderPath;
 				}
+				if (source.customEffort) {
+					// Agents use either `effort` (Claude Code) or `reasoningEffort` (Codex,
+					// Copilot-CLI, Factory Droid). Pick whichever key the source agent
+					// actually defines so the value round-trips through the modal.
+					const sourceAgent = detectedAgents.find((a: AgentConfig) => a.id === source.toolType);
+					const hasReasoning = sourceAgent?.configOptions?.some(
+						(opt) => opt.key === 'reasoningEffort'
+					);
+					sourceConfig[hasReasoning ? 'reasoningEffort' : 'effort'] = source.customEffort;
+				}
 				configs[source.toolType] = sourceConfig;
 			}
 

--- a/src/renderer/components/NewInstanceModal/types.ts
+++ b/src/renderer/components/NewInstanceModal/types.ts
@@ -49,7 +49,8 @@ export interface NewInstanceModalProps {
 		customModel?: string,
 		customContextWindow?: number,
 		customProviderPath?: string,
-		sessionSshRemoteConfig?: SessionSshRemoteConfig
+		sessionSshRemoteConfig?: SessionSshRemoteConfig,
+		customEffort?: string
 	) => void;
 	theme: Theme;
 	existingSessions: Session[];

--- a/src/renderer/components/TabSwitcherModal.tsx
+++ b/src/renderer/components/TabSwitcherModal.tsx
@@ -95,12 +95,17 @@ function getTabLastActivity(tab: AITab): number | undefined {
 /**
  * Get context usage percentage from usage stats.
  * Uses calculateContextDisplay() which handles accumulated multi-tool token overflow.
+ *
+ * Returns `null` when no trustworthy reading is available (no usage yet, or
+ * accumulated tokens overflow the window without a preserved fallback). Callers
+ * should treat `null` as "no gauge to show" rather than rendering a misleading
+ * 0% — see issue #762.
  */
-function getContextPercentage(tab: AITab, agentId?: ToolType): number {
-	if (!tab.usageStats) return 0;
+function getContextPercentage(tab: AITab, agentId?: ToolType): number | null {
+	if (!tab.usageStats) return null;
 	const { contextWindow } = tab.usageStats;
-	if (!contextWindow || contextWindow === 0) return 0;
-	return calculateContextDisplay(
+	if (!contextWindow || contextWindow === 0) return null;
+	const result = calculateContextDisplay(
 		{
 			inputTokens: tab.usageStats.inputTokens,
 			outputTokens: tab.usageStats.outputTokens,
@@ -109,7 +114,8 @@ function getContextPercentage(tab: AITab, agentId?: ToolType): number {
 		},
 		contextWindow,
 		agentId
-	).percentage;
+	);
+	return result.trustworthy ? result.percentage : null;
 }
 
 /**
@@ -792,8 +798,10 @@ export function TabSwitcherModal({
 										</div>
 									</div>
 
-									{/* Context Gauge - only show when context window is configured */}
-									{(tab.usageStats?.contextWindow ?? 0) > 0 && (
+									{/* Context Gauge — hidden when no trustworthy reading is available
+									    (overflow without a preserved fallback) so we don't surface a
+									    misleading 0%. */}
+									{contextPct !== null && (
 										<div className="flex-shrink-0">
 											<ContextGauge percentage={contextPct} theme={theme} />
 										</div>

--- a/src/renderer/hooks/mainPanel/useContextWindow.ts
+++ b/src/renderer/hooks/mainPanel/useContextWindow.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useRef } from 'react';
 import { calculateContextDisplay } from '../../utils/contextUsage';
 import { captureException } from '../../utils/sentry';
 import type { Session, AITab } from '../../types';
@@ -57,11 +57,30 @@ export function useContextWindow(activeSession: Session | null, activeTab: AITab
 		return configured > 0 ? configured : reported;
 	}, [configuredContextWindow, activeTab?.usageStats?.contextWindow]);
 
+	// Hold the last trustworthy result per tab so an untrustworthy frame
+	// (overflow without fallback, missing window) preserves the prior good
+	// values instead of displaying the capacity as if it were usage (#762).
+	const lastGoodRef = useRef<{ tabId: string | null; tokens: number; percentage: number }>({
+		tabId: null,
+		tokens: 0,
+		percentage: 0,
+	});
+
 	// Compute context tokens and percentage using the shared helper.
 	// Handles accumulated multi-tool turns by falling back to session.contextUsage.
 	const { tokens: activeTabContextTokens, percentage: activeTabContextUsage } = useMemo(() => {
-		if (!activeTab?.usageStats) return { tokens: 0, percentage: 0 };
-		return calculateContextDisplay(
+		const currentTabId = activeTab?.id ?? null;
+		// Reset last-good when switching tabs so a previous tab's reading doesn't
+		// bleed into a fresh tab that hasn't reported usage yet.
+		if (lastGoodRef.current.tabId !== currentTabId) {
+			lastGoodRef.current = { tabId: currentTabId, tokens: 0, percentage: 0 };
+		}
+
+		if (!activeTab?.usageStats) {
+			return { tokens: lastGoodRef.current.tokens, percentage: lastGoodRef.current.percentage };
+		}
+
+		const result = calculateContextDisplay(
 			{
 				inputTokens: activeTab.usageStats.inputTokens,
 				outputTokens: activeTab.usageStats.outputTokens,
@@ -72,7 +91,20 @@ export function useContextWindow(activeSession: Session | null, activeTab: AITab
 			activeSession?.toolType,
 			activeSession?.contextUsage
 		);
+
+		if (result.trustworthy) {
+			lastGoodRef.current = {
+				tabId: currentTabId,
+				tokens: result.tokens,
+				percentage: result.percentage,
+			};
+			return { tokens: result.tokens, percentage: result.percentage };
+		}
+
+		// Untrustworthy frame: keep last known good values.
+		return { tokens: lastGoodRef.current.tokens, percentage: lastGoodRef.current.percentage };
 	}, [
+		activeTab?.id,
 		activeTab?.usageStats,
 		activeSession?.toolType,
 		activeTabContextWindow,

--- a/src/renderer/hooks/session/useSessionCrud.ts
+++ b/src/renderer/hooks/session/useSessionCrud.ts
@@ -69,7 +69,8 @@ export interface UseSessionCrudReturn {
 			enabled: boolean;
 			remoteId: string | null;
 			workingDirOverride?: string;
-		}
+		},
+		customEffort?: string
 	) => Promise<void>;
 	/** Opens the delete agent confirmation modal */
 	deleteSession: (id: string) => void;
@@ -143,7 +144,8 @@ export function useSessionCrud(deps: UseSessionCrudDeps): UseSessionCrudReturn {
 				enabled: boolean;
 				remoteId: string | null;
 				workingDirOverride?: string;
-			}
+			},
+			customEffort?: string
 		) => {
 			try {
 				// Get agent definition to get correct command
@@ -265,6 +267,7 @@ export function useSessionCrud(deps: UseSessionCrudDeps): UseSessionCrudReturn {
 					customModel,
 					customContextWindow,
 					customProviderPath,
+					customEffort,
 					sessionSshRemoteConfig,
 					autoRunFolderPath: `${workingDir}/${PLAYBOOKS_DIR}`,
 				};

--- a/src/renderer/hooks/session/useSessionCrud.ts
+++ b/src/renderer/hooks/session/useSessionCrud.ts
@@ -267,7 +267,7 @@ export function useSessionCrud(deps: UseSessionCrudDeps): UseSessionCrudReturn {
 					customModel,
 					customContextWindow,
 					customProviderPath,
-					customEffort,
+					customEffort: customEffort?.trim() || undefined,
 					sessionSshRemoteConfig,
 					autoRunFolderPath: `${workingDir}/${PLAYBOOKS_DIR}`,
 				};

--- a/src/renderer/utils/contextUsage.ts
+++ b/src/renderer/utils/contextUsage.ts
@@ -180,6 +180,14 @@ export interface ContextDisplayResult {
 	percentage: number;
 	/** Effective context window size used for the calculation */
 	contextWindow: number;
+	/**
+	 * True when the result is computed from real usage data; false when the
+	 * function had to fall back (overflow with no trustworthy fallback %, or
+	 * missing window size). Callers should hold their previous good values
+	 * when this is false instead of displaying the fallback as if it were a
+	 * real measurement (see issue #762).
+	 */
+	trustworthy: boolean;
 }
 
 /**
@@ -193,7 +201,7 @@ export interface ContextDisplayResult {
  * @param contextWindow - Effective context window size (0 = unknown)
  * @param agentId - Agent type for agent-specific calculation
  * @param fallbackPercentage - Preserved contextUsage % to use when tokens overflow
- * @returns Display-ready tokens, percentage, and window size
+ * @returns Display-ready tokens, percentage, and window size, plus a `trustworthy` flag
  */
 export function calculateContextDisplay(
 	usageStats: {
@@ -207,31 +215,34 @@ export function calculateContextDisplay(
 	fallbackPercentage?: number | null
 ): ContextDisplayResult {
 	if (!contextWindow || contextWindow <= 0) {
-		return { tokens: 0, percentage: 0, contextWindow: 0 };
+		return { tokens: 0, percentage: 0, contextWindow: 0, trustworthy: false };
 	}
 
 	const raw = calculateContextTokens(usageStats, agentId);
 
 	let tokens = raw;
+	let trustworthy = true;
 	if (raw > contextWindow) {
 		if (
 			fallbackPercentage != null &&
 			Number.isFinite(fallbackPercentage) &&
 			fallbackPercentage >= 0
 		) {
-			// Accumulated multi-tool turn: derive tokens from preserved percentage
+			// Accumulated multi-tool turn: derive tokens from preserved percentage.
 			const boundedFallback = Math.min(100, fallbackPercentage);
 			tokens = Math.round((boundedFallback / 100) * contextWindow);
 		} else {
-			// We don't have a trustworthy fallback percentage yet, so clamp to the
-			// configured window instead of displaying an impossible token total.
-			tokens = contextWindow;
+			// No trustworthy fallback. Return zeros and flag the result as untrustworthy
+			// so the caller can hold its previous values (issue #762: previously this
+			// branch displayed `contextWindow` itself, surfacing the capacity as if it
+			// were the used-token count).
+			return { tokens: 0, percentage: 0, contextWindow, trustworthy: false };
 		}
 	}
 
 	const percentage = tokens <= 0 ? 0 : Math.min(100, Math.round((tokens / contextWindow) * 100));
 
-	return { tokens, percentage, contextWindow };
+	return { tokens, percentage, contextWindow, trustworthy };
 }
 
 /**


### PR DESCRIPTION
## Summary

Three Codex-cluster UX bugs, fixed together:

- **#863** — Codex reasoning-effort selector was hidden on fresh installs where `~/.codex/models_cache.json` hasn't been written yet. `AgentConfigPanel` returns `null` for a `dynamic` select with no options. Added a static `options: ['', 'minimal', 'low', 'medium', 'high', 'xhigh']` fallback to the codex `reasoningEffort` definition. Dynamic discovery still wins once the cache exists.
- **#755** — `customEffort` was declared on `Session` and consumed downstream (MainPanel, agentStore, CLI), but the new-agent creation flow never read or passed it, so picking `xhigh` in the modal had no effect and the chat header always showed `default`. Threaded `customEffort` through `NewInstanceModal.handleCreate` → `AppSessionModals.onCreateSession` → `useSessionCrud.createNewSession`.
- **#762** — `calculateContextDisplay`'s overflow-without-fallback branch silently substituted `tokens = contextWindow`, surfacing the configured capacity (e.g. 700,000) as the "used tokens" value in the context modal. `ContextDisplayResult` now carries a `trustworthy` flag; that branch returns `{tokens:0, percentage:0, trustworthy:false}`. `useContextWindow` holds the last trustworthy `{tokens, percentage}` per tab via `useRef` and falls back to it on untrustworthy frames (resets on tab switch).

## Test plan

- [x] `npx vitest run` for `contextUsage`, `useContextWindow`, `useSessionCrud`, `NewInstanceModal`, `HistoryDetailModal`, `TabSwitcherModal`, agent `definitions`, agent `detector` — 485 pass / 0 fail
- [x] `npm run lint` — no new errors in changed files
- [x] `npx prettier --check` on all 12 changed files — clean
- [ ] Manual: create a fresh Codex agent, pick `xhigh`, confirm header shows `xhigh` in the new session
- [ ] Manual: open context modal during a long multi-tool turn, confirm it never flashes the configured capacity as the used-token count

Closes #863, #755, #762.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persist and forward custom reasoning effort when duplicating or creating sessions.
  * Reasoning-effort dropdown includes a fallback option so it shows earlier.

* **Bug Fixes**
  * Added trustworthiness checks for context usage to avoid showing misleading capacity.
  * Context usage display is cached per tab and hidden when computation is untrustworthy.

* **Tests**
  * Updated tests to cover trustworthy flag and custom effort forwarding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->