### PR TITLE
feat(cli): add session list/show for external history polling (PR2)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -150,6 +150,113 @@ JSON output includes full session metadata:
 
 Currently supported for `claude-code` agents.
 
+### Session Inspection
+
+Inspect open AI tabs across the running Maestro desktop app and read their conversation history. Pair `dispatch --new-tab` (writes, returns a `tabId`) with `session show <tabId>` (reads, supports `--since` and `--tail`) to build a stateless poll loop without owning a persistent connection — used by Maestro-Discord and Cue follow-ups.
+
+Both verbs talk to the running desktop over the same WebSocket as `dispatch`. There is no on-disk fallback: if the app is not running, the CLI exits with code `MAESTRO_NOT_RUNNING`.
+
+#### List Open Tabs
+
+Flatten every open AI tab across every Maestro agent into addressable entries:
+
+```bash
+# Default: compact text (one tab per line)
+maestro-cli session list
+
+# JSON for scripting
+maestro-cli session list --json
+```
+
+Default text columns: `state` (`busy` / `idle`), star (`★` if starred), `tabId`, agent name + id, tab name, `createdAt` (relative). One tab per line so the output pipes cleanly into `grep`, `awk`, etc.
+
+JSON envelope:
+
+```json
+{
+	"success": true,
+	"sessions": [
+		{
+			"tabId": "tab-1",
+			"sessionId": "tab-1",
+			"agentId": "a1b2c3d4-...",
+			"agentName": "Backend",
+			"toolType": "claude-code",
+			"name": "Refactor parser",
+			"agentSessionId": "claude-uuid-1",
+			"state": "idle",
+			"createdAt": 1714268000000,
+			"starred": false
+		}
+	]
+}
+```
+
+To extract just `tabId`s with `jq`: `maestro-cli session list --json | jq '.sessions[].tabId'`.
+
+#### Show Conversation History
+
+Print a tab's conversation log, with optional cursor (`--since`) and cap (`--tail`) filters applied desktop-side so the wire payload stays small even on long conversations.
+
+```bash
+# Default: formatted transcript (header + per-message blocks)
+maestro-cli session show <tab-id>
+
+# JSON for scripting
+maestro-cli session show <tab-id> --json
+
+# Only messages newer than an ISO-8601 timestamp
+maestro-cli session show <tab-id> --since "2026-04-28T10:00:00Z"
+
+# `--since` also accepts a bare epoch number (auto-detects ms vs sec by magnitude,
+# so both `Date.now()` and `Date.now() / 1000` cursors work without a unit flag)
+maestro-cli session show <tab-id> --since 1714268000
+
+# Cap at the last N messages (applied after `--since`)
+maestro-cli session show <tab-id> --tail 20
+
+# Combine cursor + cap for poll loops
+maestro-cli session show <tab-id> --since "$LAST_TS" --tail 50
+```
+
+| Flag                  | Description                                                                                |
+| --------------------- | ------------------------------------------------------------------------------------------ |
+| `--since <timestamp>` | Only return messages strictly after this timestamp (ISO-8601, or epoch ms/sec auto-scaled) |
+| `--tail <n>`          | Cap output to the last N messages (non-negative integer; applied after `--since`)          |
+| `--json`              | Output as JSON (default is a formatted transcript)                                         |
+
+JSON shape:
+
+```json
+{
+	"success": true,
+	"tabId": "tab-1",
+	"sessionId": "tab-1",
+	"agentId": "a1b2c3d4-...",
+	"agentSessionId": "claude-uuid-1",
+	"messages": [
+		{
+			"id": "log-1",
+			"role": "user",
+			"source": "user",
+			"content": "Hello",
+			"timestamp": "2026-04-28T10:00:00.000Z"
+		},
+		{
+			"id": "log-2",
+			"role": "assistant",
+			"source": "ai",
+			"content": "Hi there",
+			"timestamp": "2026-04-28T10:00:01.000Z"
+		}
+	]
+}
+```
+
+`role` is a coarse classification (`user` | `assistant` | `system` | `tool` | `thinking` | `error` | `unknown`) so conversational consumers can branch on intent; the raw `source` is preserved alongside for callers that need to discriminate further. ISO timestamps are emitted verbatim so a `messages[-1].timestamp` from one call can be fed directly back into `--since` on the next.
+
+Error codes: `MISSING_TAB_ID`, `TAB_NOT_FOUND`, `INVALID_OPTION`, `MAESTRO_NOT_RUNNING`, `COMMAND_FAILED`. All errors are emitted as `{ "success": false, "error": "...", "code": "..." }` with exit code `1`.
+
 ### Creating and Removing Agents
 
 Create agents directly from the command line. Requires the Maestro desktop app to be running.

--- a/src/__tests__/cli/commands/session.test.ts
+++ b/src/__tests__/cli/commands/session.test.ts
@@ -1,0 +1,361 @@
+/**
+ * @file session.test.ts
+ * @description Tests for `maestro-cli session list` and `session show`
+ *
+ * These two commands are PR2 of the CLI surface refactor: read-only
+ * conversation-state inspection used by external pollers (Maestro-Discord,
+ * Cue follow-ups) that paired with `dispatch` form the "write then poll"
+ * loop the design plan calls out.
+ *
+ * The tests cover the CLI's contract — JSON output shape, --since/--tail
+ * forwarding, error mapping — independent of the desktop. The desktop-side
+ * read logic is exercised via the integration tests when the WebSocket
+ * handler runs against a real session store.
+ */
+
+import { describe, it, expect, vi, beforeEach, type MockInstance } from 'vitest';
+
+vi.mock('../../../cli/services/maestro-client', () => ({
+	withMaestroClient: vi.fn(),
+}));
+
+import { sessionList, sessionShow } from '../../../cli/commands/session';
+import { withMaestroClient } from '../../../cli/services/maestro-client';
+
+describe('session list command', () => {
+	let consoleSpy: MockInstance;
+	let processExitSpy: MockInstance;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+		processExitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+	});
+
+	it('sends list_desktop_sessions and emits JSON with the desktop-supplied entries', async () => {
+		const mockSendCommand = vi.fn().mockResolvedValue({
+			type: 'desktop_sessions_list',
+			success: true,
+			sessions: [
+				{
+					tabId: 'tab-1',
+					sessionId: 'tab-1',
+					agentId: 'agent-a',
+					agentName: 'Backend',
+					toolType: 'claude-code',
+					name: 'Refactor parser',
+					agentSessionId: 'claude-uuid-1',
+					state: 'idle',
+					createdAt: 1714268000000,
+					starred: false,
+				},
+			],
+		});
+		vi.mocked(withMaestroClient).mockImplementation(async (action) => {
+			const mockClient = { sendCommand: mockSendCommand };
+			return action(mockClient as never);
+		});
+
+		await sessionList({ json: true });
+
+		expect(mockSendCommand).toHaveBeenCalledWith(
+			{ type: 'list_desktop_sessions' },
+			'desktop_sessions_list'
+		);
+
+		const output = JSON.parse(consoleSpy.mock.calls[0][0]);
+		expect(output.success).toBe(true);
+		expect(output.sessions).toHaveLength(1);
+		expect(output.sessions[0].tabId).toBe('tab-1');
+		expect(output.sessions[0].agentId).toBe('agent-a');
+		expect(processExitSpy).not.toHaveBeenCalled();
+	});
+
+	it('returns an empty array when the desktop reports no open tabs', async () => {
+		const mockSendCommand = vi.fn().mockResolvedValue({
+			type: 'desktop_sessions_list',
+			success: true,
+			sessions: [],
+		});
+		vi.mocked(withMaestroClient).mockImplementation(async (action) => {
+			const mockClient = { sendCommand: mockSendCommand };
+			return action(mockClient as never);
+		});
+
+		await sessionList({ json: true });
+
+		const output = JSON.parse(consoleSpy.mock.calls[0][0]);
+		expect(output.sessions).toEqual([]);
+	});
+
+	it('renders a human-readable table when --json is omitted', async () => {
+		const mockSendCommand = vi.fn().mockResolvedValue({
+			type: 'desktop_sessions_list',
+			success: true,
+			sessions: [
+				{
+					tabId: 'tab-1',
+					sessionId: 'tab-1',
+					agentId: 'agent-a',
+					agentName: 'Backend',
+					toolType: 'claude-code',
+					name: null,
+					agentSessionId: null,
+					state: 'busy',
+					createdAt: 1714268000000,
+					starred: true,
+				},
+			],
+		});
+		vi.mocked(withMaestroClient).mockImplementation(async (action) => {
+			const mockClient = { sendCommand: mockSendCommand };
+			return action(mockClient as never);
+		});
+
+		await sessionList({});
+
+		// First (and only) line should reference the tab id and agent name.
+		// Asserting on the substring keeps the test stable against future
+		// formatting tweaks (column spacing, additional flags) while still
+		// catching regressions where the entry is dropped entirely.
+		expect(consoleSpy.mock.calls[0][0]).toContain('tab-1');
+		expect(consoleSpy.mock.calls[0][0]).toContain('Backend');
+	});
+
+	it('maps connection errors to MAESTRO_NOT_RUNNING (consistent with dispatch)', async () => {
+		vi.mocked(withMaestroClient).mockRejectedValue(new Error('ECONNREFUSED'));
+
+		await sessionList({ json: true });
+
+		const output = JSON.parse(consoleSpy.mock.calls[0][0]);
+		expect(output.success).toBe(false);
+		expect(output.code).toBe('MAESTRO_NOT_RUNNING');
+		expect(processExitSpy).toHaveBeenCalledWith(1);
+	});
+
+	it.each([
+		['Maestro desktop app is not running'],
+		['Maestro discovery file is stale (app may have crashed)'],
+		['Not connected to Maestro'],
+	])('maps MaestroClient error "%s" to MAESTRO_NOT_RUNNING', async (errorMessage) => {
+		// Same three pre-WebSocket throws covered by dispatch.test — keeping the
+		// mapping in sync means external scripts can branch on a single error
+		// code regardless of which CLI verb they used.
+		vi.mocked(withMaestroClient).mockRejectedValue(new Error(errorMessage));
+
+		await sessionList({ json: true });
+
+		const output = JSON.parse(consoleSpy.mock.calls[0][0]);
+		expect(output.code).toBe('MAESTRO_NOT_RUNNING');
+		expect(processExitSpy).toHaveBeenCalledWith(1);
+	});
+});
+
+describe('session show command', () => {
+	let consoleSpy: MockInstance;
+	let processExitSpy: MockInstance;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+		processExitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+	});
+
+	it('sends get_session_history with the tab id and prints the conversation', async () => {
+		const mockSendCommand = vi.fn().mockResolvedValue({
+			type: 'session_history_result',
+			success: true,
+			tabId: 'tab-1',
+			sessionId: 'tab-1',
+			agentId: 'agent-a',
+			agentSessionId: 'claude-uuid-1',
+			messages: [
+				{
+					id: 'log-1',
+					role: 'user',
+					source: 'user',
+					content: 'Hello',
+					timestamp: '2026-04-28T10:00:00.000Z',
+				},
+				{
+					id: 'log-2',
+					role: 'assistant',
+					source: 'ai',
+					content: 'Hi there',
+					timestamp: '2026-04-28T10:00:01.000Z',
+				},
+			],
+		});
+		vi.mocked(withMaestroClient).mockImplementation(async (action) => {
+			const mockClient = { sendCommand: mockSendCommand };
+			return action(mockClient as never);
+		});
+
+		await sessionShow('tab-1', {});
+
+		expect(mockSendCommand).toHaveBeenCalledWith(
+			{ type: 'get_session_history', tabId: 'tab-1' },
+			'session_history_result'
+		);
+
+		const output = JSON.parse(consoleSpy.mock.calls[0][0]);
+		expect(output.success).toBe(true);
+		expect(output.tabId).toBe('tab-1');
+		expect(output.messages).toHaveLength(2);
+		expect(output.messages[0].role).toBe('user');
+		expect(output.messages[1].role).toBe('assistant');
+		expect(processExitSpy).not.toHaveBeenCalled();
+	});
+
+	it('forwards --since as ms epoch when given an ISO timestamp', async () => {
+		const mockSendCommand = vi.fn().mockResolvedValue({
+			type: 'session_history_result',
+			success: true,
+			tabId: 'tab-1',
+			sessionId: 'tab-1',
+			agentId: 'agent-a',
+			agentSessionId: null,
+			messages: [],
+		});
+		vi.mocked(withMaestroClient).mockImplementation(async (action) => {
+			const mockClient = { sendCommand: mockSendCommand };
+			return action(mockClient as never);
+		});
+
+		await sessionShow('tab-1', { since: '2026-04-28T10:00:00.000Z' });
+
+		expect(mockSendCommand).toHaveBeenCalledWith(
+			expect.objectContaining({
+				type: 'get_session_history',
+				tabId: 'tab-1',
+				sinceMs: Date.parse('2026-04-28T10:00:00.000Z'),
+			}),
+			'session_history_result'
+		);
+	});
+
+	it('treats a numeric --since below 1e12 as seconds (matches Date.now()/1000 cursors)', async () => {
+		// Heuristic protection: a Discord bot pickling a `Math.floor(Date.now() /
+		// 1000)` cursor would otherwise filter the entire transcript out (every
+		// log timestamp is ms, so the seconds value would be ~1000x too small
+		// and pass the > comparison trivially). Auto-scaling matches both
+		// cursor styles without requiring explicit unit flags.
+		const mockSendCommand = vi.fn().mockResolvedValue({
+			type: 'session_history_result',
+			success: true,
+			tabId: 'tab-1',
+			sessionId: 'tab-1',
+			agentId: 'agent-a',
+			agentSessionId: null,
+			messages: [],
+		});
+		vi.mocked(withMaestroClient).mockImplementation(async (action) => {
+			const mockClient = { sendCommand: mockSendCommand };
+			return action(mockClient as never);
+		});
+
+		await sessionShow('tab-1', { since: '1714268000' });
+
+		expect(mockSendCommand).toHaveBeenCalledWith(
+			expect.objectContaining({ sinceMs: 1714268000 * 1000 }),
+			'session_history_result'
+		);
+	});
+
+	it('treats a numeric --since at or above 1e12 as ms', async () => {
+		const mockSendCommand = vi.fn().mockResolvedValue({
+			type: 'session_history_result',
+			success: true,
+			tabId: 'tab-1',
+			sessionId: 'tab-1',
+			agentId: 'agent-a',
+			agentSessionId: null,
+			messages: [],
+		});
+		vi.mocked(withMaestroClient).mockImplementation(async (action) => {
+			const mockClient = { sendCommand: mockSendCommand };
+			return action(mockClient as never);
+		});
+
+		await sessionShow('tab-1', { since: '1714268000000' });
+
+		expect(mockSendCommand).toHaveBeenCalledWith(
+			expect.objectContaining({ sinceMs: 1714268000000 }),
+			'session_history_result'
+		);
+	});
+
+	it('rejects an unparseable --since with INVALID_OPTION', async () => {
+		await sessionShow('tab-1', { since: 'not-a-date' });
+
+		const output = JSON.parse(consoleSpy.mock.calls[0][0]);
+		expect(output.success).toBe(false);
+		expect(output.code).toBe('INVALID_OPTION');
+		expect(processExitSpy).toHaveBeenCalledWith(1);
+		expect(withMaestroClient).not.toHaveBeenCalled();
+	});
+
+	it('forwards --tail as an integer to the desktop', async () => {
+		const mockSendCommand = vi.fn().mockResolvedValue({
+			type: 'session_history_result',
+			success: true,
+			tabId: 'tab-1',
+			sessionId: 'tab-1',
+			agentId: 'agent-a',
+			agentSessionId: null,
+			messages: [],
+		});
+		vi.mocked(withMaestroClient).mockImplementation(async (action) => {
+			const mockClient = { sendCommand: mockSendCommand };
+			return action(mockClient as never);
+		});
+
+		await sessionShow('tab-1', { tail: '5' });
+
+		expect(mockSendCommand).toHaveBeenCalledWith(
+			expect.objectContaining({ type: 'get_session_history', tabId: 'tab-1', tail: 5 }),
+			'session_history_result'
+		);
+	});
+
+	it('rejects a negative --tail with INVALID_OPTION', async () => {
+		await sessionShow('tab-1', { tail: '-1' });
+
+		const output = JSON.parse(consoleSpy.mock.calls[0][0]);
+		expect(output.success).toBe(false);
+		expect(output.code).toBe('INVALID_OPTION');
+		expect(processExitSpy).toHaveBeenCalledWith(1);
+		expect(withMaestroClient).not.toHaveBeenCalled();
+	});
+
+	it('surfaces TAB_NOT_FOUND from the desktop response', async () => {
+		const mockSendCommand = vi.fn().mockResolvedValue({
+			type: 'session_history_result',
+			success: false,
+			error: 'Tab not found: tab-bogus',
+			code: 'TAB_NOT_FOUND',
+		});
+		vi.mocked(withMaestroClient).mockImplementation(async (action) => {
+			const mockClient = { sendCommand: mockSendCommand };
+			return action(mockClient as never);
+		});
+
+		await sessionShow('tab-bogus', {});
+
+		const output = JSON.parse(consoleSpy.mock.calls[0][0]);
+		expect(output.success).toBe(false);
+		expect(output.code).toBe('TAB_NOT_FOUND');
+		expect(processExitSpy).toHaveBeenCalledWith(1);
+	});
+
+	it('maps connection errors to MAESTRO_NOT_RUNNING', async () => {
+		vi.mocked(withMaestroClient).mockRejectedValue(new Error('ECONNREFUSED'));
+
+		await sessionShow('tab-1', {});
+
+		const output = JSON.parse(consoleSpy.mock.calls[0][0]);
+		expect(output.success).toBe(false);
+		expect(output.code).toBe('MAESTRO_NOT_RUNNING');
+		expect(processExitSpy).toHaveBeenCalledWith(1);
+	});
+});

--- a/src/__tests__/cli/commands/session.test.ts
+++ b/src/__tests__/cli/commands/session.test.ts
@@ -114,12 +114,17 @@ describe('session list command', () => {
 
 		await sessionList({});
 
-		// First (and only) line should reference the tab id and agent name.
-		// Asserting on the substring keeps the test stable against future
-		// formatting tweaks (column spacing, additional flags) while still
-		// catching regressions where the entry is dropped entirely.
-		expect(consoleSpy.mock.calls[0][0]).toContain('tab-1');
-		expect(consoleSpy.mock.calls[0][0]).toContain('Backend');
+		// Default text mode includes state, star, tabId, agent name+id, and a
+		// relative createdAt column. Asserting each surface independently catches
+		// regressions where any column is dropped without freezing exact spacing.
+		const line = consoleSpy.mock.calls[0][0] as string;
+		expect(line).toContain('tab-1');
+		expect(line).toContain('Backend');
+		expect(line).toContain('busy');
+		expect(line).toContain('★');
+		// createdAt rendered via formatRelativeTime — the exact phrase depends on
+		// `now`, but the column is non-empty for any finite epoch.
+		expect(line.split('  ').filter(Boolean).length).toBeGreaterThanOrEqual(4);
 	});
 
 	it('maps connection errors to MAESTRO_NOT_RUNNING (consistent with dispatch)', async () => {
@@ -161,7 +166,56 @@ describe('session show command', () => {
 		processExitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
 	});
 
-	it('sends get_session_history with the tab id and prints the conversation', async () => {
+	it('sends get_session_history with the tab id and prints JSON when --json is set', async () => {
+		const mockSendCommand = vi.fn().mockResolvedValue({
+			type: 'session_history_result',
+			success: true,
+			tabId: 'tab-1',
+			sessionId: 'tab-1',
+			agentId: 'agent-a',
+			agentSessionId: 'claude-uuid-1',
+			messages: [
+				{
+					id: 'log-1',
+					role: 'user',
+					source: 'user',
+					content: 'Hello',
+					timestamp: '2026-04-28T10:00:00.000Z',
+				},
+				{
+					id: 'log-2',
+					role: 'assistant',
+					source: 'ai',
+					content: 'Hi there',
+					timestamp: '2026-04-28T10:00:01.000Z',
+				},
+			],
+		});
+		vi.mocked(withMaestroClient).mockImplementation(async (action) => {
+			const mockClient = { sendCommand: mockSendCommand };
+			return action(mockClient as never);
+		});
+
+		await sessionShow('tab-1', { json: true });
+
+		expect(mockSendCommand).toHaveBeenCalledWith(
+			{ type: 'get_session_history', tabId: 'tab-1' },
+			'session_history_result'
+		);
+
+		const output = JSON.parse(consoleSpy.mock.calls[0][0]);
+		expect(output.success).toBe(true);
+		expect(output.tabId).toBe('tab-1');
+		expect(output.messages).toHaveLength(2);
+		expect(output.messages[0].role).toBe('user');
+		expect(output.messages[1].role).toBe('assistant');
+		expect(processExitSpy).not.toHaveBeenCalled();
+	});
+
+	it('renders a formatted transcript by default (no --json flag)', async () => {
+		// Default text mode prints a header line followed by one block per
+		// message. ISO timestamps are emitted verbatim so callers can feed them
+		// back into `--since` without re-parsing.
 		const mockSendCommand = vi.fn().mockResolvedValue({
 			type: 'session_history_result',
 			success: true,
@@ -193,18 +247,43 @@ describe('session show command', () => {
 
 		await sessionShow('tab-1', {});
 
-		expect(mockSendCommand).toHaveBeenCalledWith(
-			{ type: 'get_session_history', tabId: 'tab-1' },
-			'session_history_result'
-		);
-
-		const output = JSON.parse(consoleSpy.mock.calls[0][0]);
-		expect(output.success).toBe(true);
-		expect(output.tabId).toBe('tab-1');
-		expect(output.messages).toHaveLength(2);
-		expect(output.messages[0].role).toBe('user');
-		expect(output.messages[1].role).toBe('assistant');
+		const lines = consoleSpy.mock.calls.map((c) => c[0] as string);
+		const joined = lines.join('\n');
+		// Header
+		expect(joined).toContain('Tab: tab-1');
+		expect(joined).toContain('Agent: agent-a');
+		expect(joined).toContain('Session: claude-uuid-1');
+		expect(joined).toContain('Messages: 2');
+		// Per-message blocks with verbatim ISO timestamps + roles + content
+		expect(joined).toContain('[2026-04-28T10:00:00.000Z] user');
+		expect(joined).toContain('Hello');
+		expect(joined).toContain('[2026-04-28T10:00:01.000Z] assistant');
+		expect(joined).toContain('Hi there');
+		// Should not be a single JSON blob
+		expect(() => JSON.parse(lines[0])).toThrow();
 		expect(processExitSpy).not.toHaveBeenCalled();
+	});
+
+	it('prints a friendly placeholder when the conversation is empty (text mode)', async () => {
+		const mockSendCommand = vi.fn().mockResolvedValue({
+			type: 'session_history_result',
+			success: true,
+			tabId: 'tab-1',
+			sessionId: 'tab-1',
+			agentId: 'agent-a',
+			agentSessionId: null,
+			messages: [],
+		});
+		vi.mocked(withMaestroClient).mockImplementation(async (action) => {
+			const mockClient = { sendCommand: mockSendCommand };
+			return action(mockClient as never);
+		});
+
+		await sessionShow('tab-1', {});
+
+		const joined = consoleSpy.mock.calls.map((c) => c[0] as string).join('\n');
+		expect(joined).toContain('Messages: 0');
+		expect(joined).toContain('(no messages)');
 	});
 
 	it('forwards --since as ms epoch when given an ISO timestamp', async () => {

--- a/src/__tests__/cli/commands/session.test.ts
+++ b/src/__tests__/cli/commands/session.test.ts
@@ -328,6 +328,51 @@ describe('session show command', () => {
 		expect(withMaestroClient).not.toHaveBeenCalled();
 	});
 
+	it.each([['5abc'], ['1.9'], ['5e2'], ['  '], ['']])(
+		'rejects partially-numeric --tail %p with INVALID_OPTION (no silent truncation)',
+		async (raw) => {
+			// `Number.parseInt('5abc', 10) === 5` and `parseInt('1.9', 10) === 1`
+			// silently accept these as valid tails — the strict regex precheck
+			// is the only thing keeping a typo from quietly capping history at
+			// the wrong number.
+			await sessionShow('tab-1', { tail: raw });
+
+			const output = JSON.parse(consoleSpy.mock.calls[0][0]);
+			expect(output.success).toBe(false);
+			expect(output.code).toBe('INVALID_OPTION');
+			expect(processExitSpy).toHaveBeenCalledWith(1);
+			expect(withMaestroClient).not.toHaveBeenCalled();
+		}
+	);
+
+	it('forwards --tail 0 as numeric 0 (handler enforces empty-history semantics)', async () => {
+		// `--tail 0` is a legitimate ask ("give me nothing yet, just confirm
+		// the tab exists"). The CLI must propagate the literal zero — the
+		// desktop side has its own slice-bug guard for the historical
+		// `slice(-0)` foot-gun. Asserting the wire value here keeps the two
+		// halves of the contract pinned down independently.
+		const mockSendCommand = vi.fn().mockResolvedValue({
+			type: 'session_history_result',
+			success: true,
+			tabId: 'tab-1',
+			sessionId: 'tab-1',
+			agentId: 'agent-a',
+			agentSessionId: null,
+			messages: [],
+		});
+		vi.mocked(withMaestroClient).mockImplementation(async (action) => {
+			const mockClient = { sendCommand: mockSendCommand };
+			return action(mockClient as never);
+		});
+
+		await sessionShow('tab-1', { tail: '0' });
+
+		expect(mockSendCommand).toHaveBeenCalledWith(
+			expect.objectContaining({ type: 'get_session_history', tabId: 'tab-1', tail: 0 }),
+			'session_history_result'
+		);
+	});
+
 	it('surfaces TAB_NOT_FOUND from the desktop response', async () => {
 		const mockSendCommand = vi.fn().mockResolvedValue({
 			type: 'session_history_result',

--- a/src/__tests__/main/web-server/handlers/messageHandlers.test.ts
+++ b/src/__tests__/main/web-server/handlers/messageHandlers.test.ts
@@ -132,6 +132,8 @@ function createMockCallbacks(): MessageHandlerCallbacks {
 		killTerminalForWeb: vi.fn().mockReturnValue(true),
 		notifyToast: vi.fn().mockResolvedValue(true),
 		notifyCenterFlash: vi.fn().mockResolvedValue(true),
+		listDesktopSessions: vi.fn().mockReturnValue([]),
+		getSessionHistory: vi.fn().mockReturnValue(null),
 	};
 }
 
@@ -1831,6 +1833,143 @@ describe('WebSocketMessageHandler', () => {
 			expect(response.type).toBe('create_gist_result');
 			expect(response.success).toBe(false);
 			expect(response.error).toContain('not configured');
+		});
+	});
+
+	// PR2 of the CLI surface refactor: read-only session inspection used by
+	// `maestro-cli session list` and `session show <tabId>`. The handlers here
+	// are deliberately stateless so external pollers (Maestro-Discord, Cue
+	// follow-ups) can call them at arbitrary cadence.
+	describe('List Desktop Sessions (CLI → Desktop)', () => {
+		it('returns the desktop_sessions_list payload from the callback', () => {
+			(callbacks.listDesktopSessions as any).mockReturnValue([
+				{
+					tabId: 'tab-1',
+					sessionId: 'tab-1',
+					agentId: 'agent-a',
+					agentName: 'Backend',
+					toolType: 'claude-code',
+					name: 'Refactor parser',
+					agentSessionId: 'claude-uuid-1',
+					state: 'idle',
+					createdAt: 1714268000000,
+					starred: false,
+				},
+			]);
+
+			handler.handleMessage(client, { type: 'list_desktop_sessions', requestId: 'req-1' });
+
+			const response = JSON.parse((client.socket.send as any).mock.calls[0][0]);
+			expect(response.type).toBe('desktop_sessions_list');
+			expect(response.success).toBe(true);
+			expect(response.sessions).toHaveLength(1);
+			expect(response.sessions[0].tabId).toBe('tab-1');
+			expect(response.requestId).toBe('req-1');
+		});
+
+		it('returns an empty list when the callback is unconfigured rather than echoing', () => {
+			// Unknown-type echo would confuse the CLI's request/response pairing
+			// (`MaestroClient` matches by responseType). Returning the empty
+			// success shape keeps the wire contract intact even when the desktop
+			// hasn't wired up the callback yet — older builds on a newer CLI.
+			callbacks.listDesktopSessions = undefined;
+			handler.setCallbacks(callbacks);
+
+			handler.handleMessage(client, { type: 'list_desktop_sessions', requestId: 'req-1' });
+
+			const response = JSON.parse((client.socket.send as any).mock.calls[0][0]);
+			expect(response.type).toBe('desktop_sessions_list');
+			expect(response.success).toBe(true);
+			expect(response.sessions).toEqual([]);
+		});
+	});
+
+	describe('Get Session History (CLI → Desktop)', () => {
+		const mockHistory = {
+			tabId: 'tab-1',
+			sessionId: 'tab-1',
+			agentId: 'agent-a',
+			agentSessionId: 'claude-uuid-1',
+			messages: [
+				{
+					id: 'log-1',
+					role: 'user' as const,
+					source: 'user',
+					content: 'Hello',
+					timestamp: '2026-04-28T10:00:00.000Z',
+				},
+			],
+		};
+
+		it('forwards tabId / sinceMs / tail to the callback and returns the result', () => {
+			(callbacks.getSessionHistory as any).mockReturnValue(mockHistory);
+
+			handler.handleMessage(client, {
+				type: 'get_session_history',
+				tabId: 'tab-1',
+				sinceMs: 1714268000000,
+				tail: 5,
+				requestId: 'req-2',
+			});
+
+			expect(callbacks.getSessionHistory).toHaveBeenCalledWith('tab-1', {
+				sinceMs: 1714268000000,
+				tail: 5,
+			});
+
+			const response = JSON.parse((client.socket.send as any).mock.calls[0][0]);
+			expect(response.type).toBe('session_history_result');
+			expect(response.success).toBe(true);
+			expect(response.tabId).toBe('tab-1');
+			expect(response.messages).toHaveLength(1);
+			expect(response.requestId).toBe('req-2');
+		});
+
+		it('emits MISSING_TAB_ID when tabId is omitted', () => {
+			handler.handleMessage(client, {
+				type: 'get_session_history',
+				requestId: 'req-2',
+			});
+
+			const response = JSON.parse((client.socket.send as any).mock.calls[0][0]);
+			expect(response.type).toBe('session_history_result');
+			expect(response.success).toBe(false);
+			expect(response.code).toBe('MISSING_TAB_ID');
+			expect(callbacks.getSessionHistory).not.toHaveBeenCalled();
+		});
+
+		it('emits TAB_NOT_FOUND when the desktop has no matching tab', () => {
+			(callbacks.getSessionHistory as any).mockReturnValue(null);
+
+			handler.handleMessage(client, {
+				type: 'get_session_history',
+				tabId: 'tab-bogus',
+				requestId: 'req-3',
+			});
+
+			const response = JSON.parse((client.socket.send as any).mock.calls[0][0]);
+			expect(response.type).toBe('session_history_result');
+			expect(response.success).toBe(false);
+			expect(response.code).toBe('TAB_NOT_FOUND');
+		});
+
+		it('coerces a negative tail to undefined rather than passing it through', () => {
+			// Negative tail would silently invert `slice(-N)` semantics on the
+			// desktop side ("everything except the last N" instead of "last N").
+			// Drop it at the boundary so a buggy caller can never poison the
+			// desktop's read.
+			(callbacks.getSessionHistory as any).mockReturnValue(mockHistory);
+
+			handler.handleMessage(client, {
+				type: 'get_session_history',
+				tabId: 'tab-1',
+				tail: -3,
+			});
+
+			expect(callbacks.getSessionHistory).toHaveBeenCalledWith('tab-1', {
+				sinceMs: undefined,
+				tail: undefined,
+			});
 		});
 	});
 });

--- a/src/__tests__/main/web-server/web-server-factory.test.ts
+++ b/src/__tests__/main/web-server/web-server-factory.test.ts
@@ -83,6 +83,8 @@ vi.mock('../../../main/web-server/WebServer', () => {
 			setKillTerminalForWebCallback = vi.fn();
 			setNotifyToastCallback = vi.fn();
 			setNotifyCenterFlashCallback = vi.fn();
+			setListDesktopSessionsCallback = vi.fn();
+			setGetSessionHistoryCallback = vi.fn();
 
 			constructor(port: number, securityToken?: string) {
 				this.port = port;

--- a/src/__tests__/main/web-server/web-server-factory.test.ts
+++ b/src/__tests__/main/web-server/web-server-factory.test.ts
@@ -428,6 +428,145 @@ describe('web-server/web-server-factory', () => {
 		});
 	});
 
+	// PR2 of the CLI surface refactor: read-only conversation-state inspection
+	// surfaced via `maestro-cli session show <tabId>`. The callback wired here
+	// is the desktop-side half of the contract; the CLI half is tested in
+	// `src/__tests__/cli/commands/session.test.ts`.
+	describe('getSessionHistoryCallback behavior', () => {
+		// Session shape with three logs at known timestamps so --since / --tail
+		// boundaries are unambiguous. Stored on `mockSessionsStore` per-test so
+		// we can vary the ordering / source mix without churning the outer
+		// fixture.
+		const stockSession = (logs: Array<Record<string, unknown>>) => [
+			{
+				id: 'agent-a',
+				name: 'Backend',
+				toolType: 'claude-code',
+				state: 'idle',
+				inputMode: 'ai',
+				cwd: '/test/path',
+				aiTabs: [
+					{
+						id: 'tab-1',
+						agentSessionId: 'claude-uuid-1',
+						logs,
+					},
+				],
+				activeTabId: 'tab-1',
+			},
+		];
+
+		const getCallback = () => {
+			const createWebServer = createWebServerFactory(deps);
+			const server = createWebServer();
+			const setGetSessionHistoryCallback = server.setGetSessionHistoryCallback as ReturnType<
+				typeof vi.fn
+			>;
+			return setGetSessionHistoryCallback.mock.calls[0][0];
+		};
+
+		it('returns null when the tab id does not match any open tab', () => {
+			vi.mocked(mockSessionsStore.get).mockReturnValue(
+				stockSession([{ id: 'log-1', source: 'user', text: 'hi', timestamp: 100 }])
+			);
+
+			const callback = getCallback();
+			expect(callback('tab-bogus')).toBeNull();
+		});
+
+		it('returns the full transcript with derived roles when no filters are passed', () => {
+			vi.mocked(mockSessionsStore.get).mockReturnValue(
+				stockSession([
+					{ id: 'log-1', source: 'user', text: 'hi', timestamp: 100 },
+					{ id: 'log-2', source: 'ai', text: 'hello', timestamp: 200 },
+					{ id: 'log-3', source: 'stdout', text: 'legacy reply', timestamp: 300 },
+				])
+			);
+
+			const callback = getCallback();
+			const result = callback('tab-1');
+
+			expect(result).not.toBeNull();
+			expect(result.tabId).toBe('tab-1');
+			expect(result.agentId).toBe('agent-a');
+			expect(result.agentSessionId).toBe('claude-uuid-1');
+			expect(result.messages).toHaveLength(3);
+			expect(result.messages.map((m: { role: string }) => m.role)).toEqual([
+				'user',
+				'assistant',
+				// `stdout` collapses to `assistant` because legacy / non-AI agent
+				// flows store assistant replies under that source.
+				'assistant',
+			]);
+		});
+
+		it('drops messages at or before --sinceMs (cursor is exclusive)', () => {
+			vi.mocked(mockSessionsStore.get).mockReturnValue(
+				stockSession([
+					{ id: 'log-1', source: 'user', text: 'a', timestamp: 100 },
+					{ id: 'log-2', source: 'ai', text: 'b', timestamp: 200 },
+					{ id: 'log-3', source: 'user', text: 'c', timestamp: 300 },
+				])
+			);
+
+			const callback = getCallback();
+			const result = callback('tab-1', { sinceMs: 200 });
+
+			// `> sinceMs` (not `>=`) keeps the cursor exclusive so a Discord
+			// bot can reuse the last received timestamp without seeing the
+			// same message twice on the next poll.
+			expect(result.messages).toHaveLength(1);
+			expect(result.messages[0].id).toBe('log-3');
+		});
+
+		it('returns an empty array for --tail 0 (the slice(-0) foot-gun)', () => {
+			// Regression guard for the original `slice(-options.tail)` bug:
+			// `-0 === 0`, so `slice(-0)` returned the full array and `--tail 0`
+			// silently shipped the entire transcript instead of nothing.
+			vi.mocked(mockSessionsStore.get).mockReturnValue(
+				stockSession([
+					{ id: 'log-1', source: 'user', text: 'a', timestamp: 100 },
+					{ id: 'log-2', source: 'ai', text: 'b', timestamp: 200 },
+				])
+			);
+
+			const callback = getCallback();
+			const result = callback('tab-1', { tail: 0 });
+
+			expect(result.messages).toEqual([]);
+		});
+
+		it('returns the last N messages when --tail is positive', () => {
+			vi.mocked(mockSessionsStore.get).mockReturnValue(
+				stockSession([
+					{ id: 'log-1', source: 'user', text: 'a', timestamp: 100 },
+					{ id: 'log-2', source: 'ai', text: 'b', timestamp: 200 },
+					{ id: 'log-3', source: 'user', text: 'c', timestamp: 300 },
+				])
+			);
+
+			const callback = getCallback();
+			const result = callback('tab-1', { tail: 2 });
+
+			expect(result.messages).toHaveLength(2);
+			expect(result.messages.map((m: { id: string }) => m.id)).toEqual(['log-2', 'log-3']);
+		});
+
+		it('clamps --tail above the transcript length to the full transcript', () => {
+			vi.mocked(mockSessionsStore.get).mockReturnValue(
+				stockSession([
+					{ id: 'log-1', source: 'user', text: 'a', timestamp: 100 },
+					{ id: 'log-2', source: 'ai', text: 'b', timestamp: 200 },
+				])
+			);
+
+			const callback = getCallback();
+			const result = callback('tab-1', { tail: 99 });
+
+			expect(result.messages).toHaveLength(2);
+		});
+	});
+
 	describe('writeToSessionCallback behavior', () => {
 		it('should return false when processManager is null', () => {
 			deps.getProcessManager = vi.fn().mockReturnValue(null);

--- a/src/cli/commands/session.ts
+++ b/src/cli/commands/session.ts
@@ -1,0 +1,235 @@
+// Session inspection commands — read-only access to desktop conversation state
+// for external pollers (Maestro-Discord, Cue follow-ups, etc.).
+//
+// `session list` enumerates every open AI tab across every Maestro agent.
+// `session show <tabId>` returns that tab's conversation history, with optional
+// `--since` (poll cursor) and `--tail` (cap) filters applied desktop-side so the
+// wire payload stays small even on long conversations.
+//
+// Both verbs talk to the running desktop via the same WebSocket the `dispatch`
+// command uses; there is no on-disk fallback. If the desktop is not running the
+// CLI fails loudly with `MAESTRO_NOT_RUNNING` so callers can react rather than
+// silently get back stale data.
+
+import { withMaestroClient } from '../services/maestro-client';
+
+export interface SessionListOptions {
+	json?: boolean;
+}
+
+export interface SessionShowOptions {
+	since?: string;
+	tail?: string;
+	json?: boolean;
+}
+
+interface DesktopSessionEntry {
+	tabId: string;
+	sessionId: string;
+	agentId: string;
+	agentName: string;
+	toolType: string;
+	name: string | null;
+	agentSessionId: string | null;
+	state: 'idle' | 'busy';
+	createdAt: number;
+	starred: boolean;
+}
+
+interface SessionMessage {
+	id: string;
+	role: string;
+	source: string;
+	content: string;
+	timestamp: string;
+}
+
+interface SessionShowResult {
+	success: true;
+	tabId: string;
+	sessionId: string;
+	agentId: string;
+	agentSessionId: string | null;
+	messages: SessionMessage[];
+}
+
+function emitErrorJson(error: string, code: string): void {
+	console.log(JSON.stringify({ success: false, error, code }, null, 2));
+}
+
+/**
+ * Translate transport-layer errors into CLI error codes consistent with
+ * `dispatch`. MaestroClient throws three distinct strings before any WebSocket
+ * activity ("Maestro desktop app is not running", "Maestro discovery file is
+ * stale (app may have crashed)", "Not connected to Maestro"); without these
+ * mappings, those errors fall through to a generic CLI error and break the
+ * error-code contract downstream consumers (Maestro-Discord) rely on to
+ * distinguish "app down" from "command rejected".
+ */
+function mapTransportError(error: unknown): { error: string; code: string } | null {
+	const msg = error instanceof Error ? error.message : String(error);
+	const lowerMsg = msg.toLowerCase();
+	if (
+		lowerMsg.includes('econnrefused') ||
+		lowerMsg.includes('connection refused') ||
+		lowerMsg.includes('websocket') ||
+		lowerMsg.includes('enotfound') ||
+		lowerMsg.includes('etimedout') ||
+		lowerMsg.includes('maestro desktop app is not running') ||
+		lowerMsg.includes('discovery file is stale') ||
+		lowerMsg.includes('not connected to maestro')
+	) {
+		return {
+			error: 'Maestro desktop is not running or not reachable',
+			code: 'MAESTRO_NOT_RUNNING',
+		};
+	}
+	return null;
+}
+
+/**
+ * Parse `--since` accepting:
+ *   - ISO-8601 timestamps ("2026-04-28T10:00:00Z") — output of a previous
+ *     `session show`'s `messages[].timestamp`, the natural cursor source.
+ *   - Numeric epoch values (ms or seconds — auto-detected by magnitude).
+ * Returns ms epoch for the wire, or null if the input is unparseable so the
+ * caller can fail loudly with INVALID_OPTION rather than silently filtering.
+ */
+function parseSinceToMs(since: string): number | null {
+	const trimmed = since.trim();
+	if (!trimmed) return null;
+
+	if (/^-?\d+$/.test(trimmed)) {
+		const num = Number(trimmed);
+		if (!Number.isFinite(num)) return null;
+		// Heuristic: timestamps after ~2001 in seconds (1e9) vs ms (1e12). A bare
+		// integer below 1e12 is interpreted as seconds; above as ms. Picks the
+		// right interpretation for both `Date.now()` and `Date.now() / 1000`.
+		return num >= 1e12 ? num : num * 1000;
+	}
+
+	const parsed = Date.parse(trimmed);
+	if (Number.isNaN(parsed)) return null;
+	return parsed;
+}
+
+export async function sessionList(options: SessionListOptions): Promise<void> {
+	try {
+		const sessions = await withMaestroClient(async (client) => {
+			const result = await client.sendCommand<{ sessions?: DesktopSessionEntry[] }>(
+				{ type: 'list_desktop_sessions' },
+				'desktop_sessions_list'
+			);
+			return result.sessions ?? [];
+		});
+
+		if (options.json) {
+			console.log(JSON.stringify({ success: true, sessions }, null, 2));
+			return;
+		}
+
+		if (sessions.length === 0) {
+			console.log('No open AI tabs.');
+			return;
+		}
+
+		// Compact human-readable view: one tab per line so the output is grep-able
+		// and pipes cleanly into other tools while still being readable for a
+		// quick glance.
+		for (const s of sessions) {
+			const stateMarker = s.state === 'busy' ? '*' : ' ';
+			const starMarker = s.starred ? '★' : ' ';
+			const name = s.name ?? '(unnamed)';
+			console.log(
+				`${stateMarker} ${starMarker} ${s.tabId}  agent=${s.agentName} (${s.agentId})  ${name}`
+			);
+		}
+	} catch (error) {
+		const mapped = mapTransportError(error);
+		if (mapped) {
+			emitErrorJson(mapped.error, mapped.code);
+		} else {
+			const msg = error instanceof Error ? error.message : String(error);
+			emitErrorJson(`Failed to list sessions: ${msg}`, 'COMMAND_FAILED');
+		}
+		process.exit(1);
+	}
+}
+
+export async function sessionShow(tabId: string, options: SessionShowOptions): Promise<void> {
+	let sinceMs: number | undefined;
+	if (options.since !== undefined) {
+		const parsed = parseSinceToMs(options.since);
+		if (parsed === null) {
+			emitErrorJson(
+				`Invalid --since value: ${options.since} (expected ISO-8601 or epoch number)`,
+				'INVALID_OPTION'
+			);
+			process.exit(1);
+			return;
+		}
+		sinceMs = parsed;
+	}
+
+	let tail: number | undefined;
+	if (options.tail !== undefined) {
+		const parsed = Number.parseInt(options.tail, 10);
+		if (!Number.isFinite(parsed) || parsed < 0) {
+			emitErrorJson(
+				`Invalid --tail value: ${options.tail} (expected non-negative integer)`,
+				'INVALID_OPTION'
+			);
+			process.exit(1);
+			return;
+		}
+		tail = parsed;
+	}
+
+	try {
+		const result = await withMaestroClient(async (client) => {
+			return client.sendCommand<{
+				success?: boolean;
+				error?: string;
+				code?: string;
+				tabId?: string;
+				sessionId?: string;
+				agentId?: string;
+				agentSessionId?: string | null;
+				messages?: SessionMessage[];
+			}>(
+				{
+					type: 'get_session_history',
+					tabId,
+					...(sinceMs !== undefined ? { sinceMs } : {}),
+					...(tail !== undefined ? { tail } : {}),
+				},
+				'session_history_result'
+			);
+		});
+
+		if (!result.success) {
+			emitErrorJson(result.error ?? 'Unknown error', result.code ?? 'UNKNOWN');
+			process.exit(1);
+			return;
+		}
+
+		const payload: SessionShowResult = {
+			success: true,
+			tabId: result.tabId ?? tabId,
+			sessionId: result.sessionId ?? tabId,
+			agentId: result.agentId ?? '',
+			agentSessionId: result.agentSessionId ?? null,
+			messages: result.messages ?? [],
+		};
+		console.log(JSON.stringify(payload, null, 2));
+	} catch (error) {
+		const mapped = mapTransportError(error);
+		if (mapped) {
+			emitErrorJson(mapped.error, mapped.code);
+		} else {
+			const msg = error instanceof Error ? error.message : String(error);
+			emitErrorJson(`Failed to show session: ${msg}`, 'COMMAND_FAILED');
+		}
+		process.exit(1);
+	}
+}

--- a/src/cli/commands/session.ts
+++ b/src/cli/commands/session.ts
@@ -12,6 +12,7 @@
 // silently get back stale data.
 
 import { withMaestroClient } from '../services/maestro-client';
+import { formatRelativeTime } from '../../shared/formatters';
 
 export interface SessionListOptions {
 	json?: boolean;
@@ -20,6 +21,7 @@ export interface SessionListOptions {
 export interface SessionShowOptions {
 	since?: string;
 	tail?: string;
+	json?: boolean;
 }
 
 interface DesktopSessionEntry {
@@ -134,13 +136,16 @@ export async function sessionList(options: SessionListOptions): Promise<void> {
 
 		// Compact human-readable view: one tab per line so the output is grep-able
 		// and pipes cleanly into other tools while still being readable for a
-		// quick glance.
+		// quick glance. Columns: state | star | tabId | agent | name | createdAt.
+		// `state` is spelled out (busy/idle) rather than relying on the `*` marker
+		// alone so `grep busy` works without column-counting.
 		for (const s of sessions) {
-			const stateMarker = s.state === 'busy' ? '*' : ' ';
-			const starMarker = s.starred ? '★' : ' ';
+			const state = s.state === 'busy' ? 'busy' : 'idle';
+			const star = s.starred ? '★' : ' ';
 			const name = s.name ?? '(unnamed)';
+			const created = Number.isFinite(s.createdAt) ? formatRelativeTime(s.createdAt) : '—';
 			console.log(
-				`${stateMarker} ${starMarker} ${s.tabId}  agent=${s.agentName} (${s.agentId})  ${name}`
+				`${state} ${star} ${s.tabId}  ${s.agentName} (${s.agentId})  ${name}  ${created}`
 			);
 		}
 	} catch (error) {
@@ -224,7 +229,32 @@ export async function sessionShow(tabId: string, options: SessionShowOptions): P
 			agentSessionId: result.agentSessionId ?? null,
 			messages: result.messages ?? [],
 		};
-		console.log(JSON.stringify(payload, null, 2));
+
+		if (options.json) {
+			console.log(JSON.stringify(payload, null, 2));
+			return;
+		}
+
+		// Default text mode: header + per-message transcript. ISO timestamps are
+		// preserved verbatim so consumers can round-trip them straight into a
+		// follow-up `session show --since "<timestamp>"` call without having to
+		// re-parse a localized datetime.
+		const headerParts = [`Tab: ${payload.tabId}`, `Agent: ${payload.agentId || '(unknown)'}`];
+		if (payload.agentSessionId) headerParts.push(`Session: ${payload.agentSessionId}`);
+		headerParts.push(`Messages: ${payload.messages.length}`);
+		console.log(headerParts.join('  '));
+
+		if (payload.messages.length === 0) {
+			console.log('(no messages)');
+			return;
+		}
+
+		console.log('');
+		for (const msg of payload.messages) {
+			console.log(`[${msg.timestamp}] ${msg.role}`);
+			console.log(msg.content);
+			console.log('');
+		}
 	} catch (error) {
 		const mapped = mapTransportError(error);
 		if (mapped) {

--- a/src/cli/commands/session.ts
+++ b/src/cli/commands/session.ts
@@ -20,7 +20,6 @@ export interface SessionListOptions {
 export interface SessionShowOptions {
 	since?: string;
 	tail?: string;
-	json?: boolean;
 }
 
 interface DesktopSessionEntry {
@@ -173,8 +172,12 @@ export async function sessionShow(tabId: string, options: SessionShowOptions): P
 
 	let tail: number | undefined;
 	if (options.tail !== undefined) {
-		const parsed = Number.parseInt(options.tail, 10);
-		if (!Number.isFinite(parsed) || parsed < 0) {
+		// Strict regex up front: `Number.parseInt('5abc', 10)` is `5` and
+		// `parseInt('1.9', 10)` is `1`, so a permissive parse silently accepts
+		// malformed flags and quietly truncates. Reject anything that isn't a
+		// run of digits so the caller learns about the typo immediately.
+		const trimmedTail = options.tail.trim();
+		if (!/^\d+$/.test(trimmedTail)) {
 			emitErrorJson(
 				`Invalid --tail value: ${options.tail} (expected non-negative integer)`,
 				'INVALID_OPTION'
@@ -182,7 +185,7 @@ export async function sessionShow(tabId: string, options: SessionShowOptions): P
 			process.exit(1);
 			return;
 		}
-		tail = parsed;
+		tail = Number(trimmedTail);
 	}
 
 	try {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -11,6 +11,7 @@ import { showAgent } from './commands/show-agent';
 import { cleanPlaybooks } from './commands/clean-playbooks';
 import { send } from './commands/send';
 import { dispatch } from './commands/dispatch';
+import { sessionList, sessionShow } from './commands/session';
 import { listSessions } from './commands/list-sessions';
 import { openFile } from './commands/open-file';
 import { openBrowser } from './commands/open-browser';
@@ -182,6 +183,30 @@ program
 		'Bypass the busy-state guard when writing to a busy tab; requires allowConcurrentSend (cannot be combined with --new-tab — a fresh tab is never busy)'
 	)
 	.action(dispatch);
+
+// Session inspection commands - read-only access to desktop conversation state.
+// Lets external pollers (Maestro-Discord, Cue follow-ups) pick up where Maestro
+// left off without owning a persistent channel — pair with `dispatch` to write
+// and `session show` to follow up.
+const session = program
+	.command('session')
+	.description('Inspect open desktop tabs and their conversation history');
+
+session
+	.command('list')
+	.description('List open desktop AI tabs and their tab/session IDs')
+	.option('--json', 'Output as JSON (for scripting)')
+	.action(sessionList);
+
+session
+	.command('show <tab-id>')
+	.description('Print conversation history for a desktop tab')
+	.option(
+		'--since <timestamp>',
+		'Only return messages after this timestamp (ISO-8601 or epoch ms/sec)'
+	)
+	.option('--tail <n>', 'Only return the last N messages (applied after --since)')
+	.action(sessionShow);
 
 // Open file command - open a file in the Maestro desktop app
 program

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -206,6 +206,7 @@ session
 		'Only return messages after this timestamp (ISO-8601 or epoch ms/sec)'
 	)
 	.option('--tail <n>', 'Only return the last N messages (applied after --since)')
+	.option('--json', 'Output as JSON (for scripting); default is a formatted transcript')
 	.action(sessionShow);
 
 // Open file command - open a file in the Maestro desktop app

--- a/src/main/web-server/WebServer.ts
+++ b/src/main/web-server/WebServer.ts
@@ -117,6 +117,8 @@ import type {
 	GenerateDirectorNotesSynopsisCallback,
 	NotifyToastCallback,
 	NotifyCenterFlashCallback,
+	ListDesktopSessionsCallback,
+	GetSessionHistoryCallback,
 } from './types';
 
 // Logger context for all web server logs
@@ -597,6 +599,14 @@ export class WebServer {
 		this.callbackRegistry.setNotifyCenterFlashCallback(callback);
 	}
 
+	setListDesktopSessionsCallback(callback: ListDesktopSessionsCallback): void {
+		this.callbackRegistry.setListDesktopSessionsCallback(callback);
+	}
+
+	setGetSessionHistoryCallback(callback: GetSessionHistoryCallback): void {
+		this.callbackRegistry.setGetSessionHistoryCallback(callback);
+	}
+
 	broadcastGroupsChanged(groups: GroupData[]): void {
 		this.broadcastService.broadcastGroupsChanged(groups);
 	}
@@ -858,6 +868,9 @@ export class WebServer {
 				this.killTerminalForWebCallback?.(sessionId) ?? false,
 			notifyToast: async (params) => this.callbackRegistry.notifyToast(params),
 			notifyCenterFlash: async (params) => this.callbackRegistry.notifyCenterFlash(params),
+			listDesktopSessions: () => this.callbackRegistry.listDesktopSessions(),
+			getSessionHistory: (tabId, options) =>
+				this.callbackRegistry.getSessionHistory(tabId, options),
 		});
 	}
 

--- a/src/main/web-server/handlers/messageHandlers.ts
+++ b/src/main/web-server/handlers/messageHandlers.ts
@@ -28,6 +28,8 @@
  * - stop_auto_run: Stop an active auto-run for a session
  * - get_settings: Fetch current web settings
  * - set_setting: Modify a single setting (allowlisted keys only)
+ * - list_desktop_sessions: Enumerate open AI tabs across all agents (CLI: `session list`)
+ * - get_session_history: Return tab conversation history with --since/--tail filters (CLI: `session show`)
  */
 
 import path from 'path';
@@ -55,6 +57,9 @@ import type {
 	NotifyToastColor,
 	NotifyCenterFlashColor,
 	NotifyCenterFlashVariant,
+	DesktopSessionEntry,
+	SessionHistoryResult,
+	GetSessionHistoryOptions,
 } from '../types';
 
 /** Canonical Toast / Center Flash color set (shared design language). */
@@ -272,6 +277,17 @@ export interface MessageHandlerCallbacks {
 	killTerminalForWeb: (sessionId: string) => boolean;
 	notifyToast: (params: NotifyToastParams) => Promise<boolean>;
 	notifyCenterFlash: (params: NotifyCenterFlashParams) => Promise<boolean>;
+	/** External-pickup primitive used by `maestro-cli session list`. Surfaces every
+	 *  open AI tab across all desktop agents so consumers (Maestro-Discord, Cue)
+	 *  can address tabs by id without owning a persistent channel. */
+	listDesktopSessions: () => DesktopSessionEntry[];
+	/** Read-only conversation history fetch used by `maestro-cli session show
+	 *  <tabId>`. Filters (`sinceMs`, `tail`) live alongside the read so we don't
+	 *  ship the full transcript over the wire on every poll. */
+	getSessionHistory: (
+		tabId: string,
+		options?: GetSessionHistoryOptions
+	) => SessionHistoryResult | null;
 }
 
 /**
@@ -548,6 +564,14 @@ export class WebSocketMessageHandler {
 
 			case 'notify_center_flash':
 				this.handleNotifyCenterFlash(client, message);
+				break;
+
+			case 'list_desktop_sessions':
+				this.handleListDesktopSessions(client, message);
+				break;
+
+			case 'get_session_history':
+				this.handleGetSessionHistory(client, message);
 				break;
 
 			default:
@@ -3180,6 +3204,85 @@ export class WebSocketMessageHandler {
 			.notifyCenterFlash({ message: body, detail, color, duration })
 			.then((success) => sendResult(success, success ? undefined : 'Failed to show flash'))
 			.catch((error) => sendResult(false, `Failed to show flash: ${error.message}`));
+	}
+
+	/**
+	 * Handle list_desktop_sessions message — enumerate every open AI tab across
+	 * desktop agents. Stateless read backed by the persisted session store; no
+	 * subscription side-effects so external pollers (Maestro-Discord, Cue) can
+	 * call this every few seconds without leaking state into the desktop.
+	 */
+	private handleListDesktopSessions(client: WebClient, message: WebClientMessage): void {
+		const sessions = this.callbacks.listDesktopSessions ? this.callbacks.listDesktopSessions() : [];
+		this.send(client, {
+			type: 'desktop_sessions_list',
+			success: true,
+			sessions,
+			requestId: message.requestId,
+		});
+	}
+
+	/**
+	 * Handle get_session_history message — return the conversation log for a
+	 * tab, optionally filtered by `sinceMs` (poll cursor) and/or `tail` (cap).
+	 * Errors are returned in the same response type rather than as a generic
+	 * `error` so the CLI's request/response pairing stays deterministic.
+	 */
+	private handleGetSessionHistory(client: WebClient, message: WebClientMessage): void {
+		const tabId = typeof message.tabId === 'string' ? message.tabId : undefined;
+		if (!tabId) {
+			this.send(client, {
+				type: 'session_history_result',
+				success: false,
+				error: 'Missing tabId',
+				code: 'MISSING_TAB_ID',
+				requestId: message.requestId,
+			});
+			return;
+		}
+
+		if (!this.callbacks.getSessionHistory) {
+			this.send(client, {
+				type: 'session_history_result',
+				success: false,
+				error: 'Session history not configured',
+				code: 'NOT_CONFIGURED',
+				requestId: message.requestId,
+			});
+			return;
+		}
+
+		const sinceMs =
+			typeof message.sinceMs === 'number' && Number.isFinite(message.sinceMs)
+				? message.sinceMs
+				: undefined;
+		const tail =
+			typeof message.tail === 'number' && Number.isFinite(message.tail) && message.tail >= 0
+				? Math.floor(message.tail)
+				: undefined;
+
+		const result = this.callbacks.getSessionHistory(tabId, { sinceMs, tail });
+		if (!result) {
+			this.send(client, {
+				type: 'session_history_result',
+				success: false,
+				error: `Tab not found: ${tabId}`,
+				code: 'TAB_NOT_FOUND',
+				requestId: message.requestId,
+			});
+			return;
+		}
+
+		this.send(client, {
+			type: 'session_history_result',
+			success: true,
+			tabId: result.tabId,
+			sessionId: result.sessionId,
+			agentId: result.agentId,
+			agentSessionId: result.agentSessionId,
+			messages: result.messages,
+			requestId: message.requestId,
+		});
 	}
 
 	/**

--- a/src/main/web-server/managers/CallbackRegistry.ts
+++ b/src/main/web-server/managers/CallbackRegistry.ts
@@ -81,6 +81,11 @@ import type {
 	NotifyCenterFlashCallback,
 	NotifyToastParams,
 	NotifyCenterFlashParams,
+	ListDesktopSessionsCallback,
+	GetSessionHistoryCallback,
+	GetSessionHistoryOptions,
+	DesktopSessionEntry,
+	SessionHistoryResult,
 } from '../types';
 
 const LOG_CONTEXT = 'CallbackRegistry';
@@ -148,6 +153,8 @@ export interface WebServerCallbacks {
 	generateDirectorNotesSynopsis: GenerateDirectorNotesSynopsisCallback | null;
 	notifyToast: NotifyToastCallback | null;
 	notifyCenterFlash: NotifyCenterFlashCallback | null;
+	listDesktopSessions: ListDesktopSessionsCallback | null;
+	getSessionHistory: GetSessionHistoryCallback | null;
 }
 
 export class CallbackRegistry {
@@ -211,6 +218,8 @@ export class CallbackRegistry {
 		generateDirectorNotesSynopsis: null,
 		notifyToast: null,
 		notifyCenterFlash: null,
+		listDesktopSessions: null,
+		getSessionHistory: null,
 	};
 
 	// ============ Getter Methods ============
@@ -576,6 +585,17 @@ export class CallbackRegistry {
 		return this.callbacks.notifyCenterFlash(params);
 	}
 
+	listDesktopSessions(): DesktopSessionEntry[] {
+		return this.callbacks.listDesktopSessions?.() ?? [];
+	}
+
+	getSessionHistory(
+		tabId: string,
+		options?: GetSessionHistoryOptions
+	): SessionHistoryResult | null {
+		return this.callbacks.getSessionHistory?.(tabId, options) ?? null;
+	}
+
 	// ============ Setter Methods ============
 
 	setGetSessionsCallback(callback: GetSessionsCallback): void {
@@ -818,6 +838,14 @@ export class CallbackRegistry {
 
 	setNotifyCenterFlashCallback(callback: NotifyCenterFlashCallback): void {
 		this.callbacks.notifyCenterFlash = callback;
+	}
+
+	setListDesktopSessionsCallback(callback: ListDesktopSessionsCallback): void {
+		this.callbacks.listDesktopSessions = callback;
+	}
+
+	setGetSessionHistoryCallback(callback: GetSessionHistoryCallback): void {
+		this.callbacks.getSessionHistory = callback;
 	}
 
 	// ============ Check Methods ============

--- a/src/main/web-server/types.ts
+++ b/src/main/web-server/types.ts
@@ -416,6 +416,75 @@ export type GetBionifyReadingModeCallback = () => boolean;
  */
 export type GetCustomCommandsCallback = () => CustomAICommand[];
 
+// =============================================================================
+// External Session Inspection (maestro-cli session list / session show)
+// =============================================================================
+
+/**
+ * Single open AI tab surfaced by `maestro-cli session list`.
+ *
+ * `tabId` is the addressable identifier consumers (Maestro-Discord, Cue) pass
+ * back to `dispatch --session <id>` and `session show <id>`. `sessionId` is
+ * an alias kept for symmetry with `dispatch`'s response shape — the duplicate
+ * field lets polling consumers use whichever name they prefer.
+ */
+export interface DesktopSessionEntry {
+	tabId: string;
+	sessionId: string;
+	/** Maestro agent (LeftBar entity) ID this tab belongs to. */
+	agentId: string;
+	agentName: string;
+	toolType: string;
+	/** User-defined tab name; null when the user hasn't named the tab. */
+	name: string | null;
+	/** Provider session id (e.g. Claude `session_id`) bound to this tab. */
+	agentSessionId: string | null;
+	state: 'idle' | 'busy';
+	createdAt: number;
+	starred: boolean;
+}
+
+/**
+ * One message in a session-history response.
+ *
+ * `role` is a coarse derived label intended for conversational consumers
+ * (Discord bots etc.). `source` preserves the raw `LogEntry.source` so callers
+ * that need finer detail (e.g. distinguishing tool output from assistant text)
+ * can still discriminate.
+ */
+export interface SessionHistoryMessage {
+	id: string;
+	role: 'user' | 'assistant' | 'system' | 'tool' | 'thinking' | 'error' | 'unknown';
+	source: string;
+	content: string;
+	/** ISO-8601 timestamp. */
+	timestamp: string;
+}
+
+export interface SessionHistoryResult {
+	tabId: string;
+	sessionId: string;
+	agentId: string;
+	agentSessionId: string | null;
+	messages: SessionHistoryMessage[];
+}
+
+export interface GetSessionHistoryOptions {
+	/** Drop messages with timestamp ≤ this epoch ms. Use for poll-friendly cursoring. */
+	sinceMs?: number;
+	/** After other filters, keep only the last N messages. */
+	tail?: number;
+}
+
+/** Callback to enumerate all open AI tabs across all desktop agents. */
+export type ListDesktopSessionsCallback = () => DesktopSessionEntry[];
+
+/** Callback to fetch a tab's full conversation history by tabId. */
+export type GetSessionHistoryCallback = (
+	tabId: string,
+	options?: GetSessionHistoryOptions
+) => SessionHistoryResult | null;
+
 /**
  * Callback type for fetching history entries.
  * Uses HistoryEntry from shared/types.ts as the canonical type.

--- a/src/main/web-server/web-server-factory.ts
+++ b/src/main/web-server/web-server-factory.ts
@@ -175,6 +175,105 @@ export function createWebServerFactory(deps: WebServerFactoryDependencies) {
 			});
 		});
 
+		// `maestro-cli session list` — flatten all open AI tabs into addressable
+		// entries. The CLI does not need group/cwd metadata; the structurally
+		// smaller payload keeps polling cheap. Reads straight from the persisted
+		// session store (same source the renderer pushes to via `sessions:save`),
+		// so the data is as fresh as the desktop's own state.
+		server.setListDesktopSessionsCallback(() => {
+			const sessions = sessionsStore.get<StoredSession[]>('sessions', []);
+			const entries = [];
+			for (const s of sessions) {
+				const aiTabs = (s.aiTabs as Array<Record<string, any>> | undefined) ?? [];
+				for (const tab of aiTabs) {
+					if (!tab || typeof tab.id !== 'string') continue;
+					entries.push({
+						tabId: tab.id,
+						sessionId: tab.id,
+						agentId: s.id,
+						agentName: s.name,
+						toolType: s.toolType,
+						name: typeof tab.name === 'string' ? tab.name : null,
+						agentSessionId: typeof tab.agentSessionId === 'string' ? tab.agentSessionId : null,
+						state: tab.state === 'busy' ? ('busy' as const) : ('idle' as const),
+						createdAt: typeof tab.createdAt === 'number' ? tab.createdAt : 0,
+						starred: tab.starred === true,
+					});
+				}
+			}
+			return entries;
+		});
+
+		// `maestro-cli session show <tabId>` — return the tab's conversation
+		// history with optional `--since` (poll cursor) and `--tail` (cap)
+		// filters applied here so the CLI never receives more than it asked for.
+		// `LogEntry.source` values map to a coarse `role` for conversational
+		// consumers (Discord bots); the raw `source` is preserved alongside so
+		// callers that want finer detail (tool vs assistant text) can still
+		// discriminate. `stdout` is treated as `assistant` because legacy /
+		// non-AI agent flows store assistant replies under that source.
+		server.setGetSessionHistoryCallback((tabId, options) => {
+			const sessions = sessionsStore.get<StoredSession[]>('sessions', []);
+			for (const s of sessions) {
+				const aiTabs = (s.aiTabs as Array<Record<string, any>> | undefined) ?? [];
+				const tab = aiTabs.find((t) => t && t.id === tabId);
+				if (!tab) continue;
+				const rawLogs = (tab.logs as Array<Record<string, any>> | undefined) ?? [];
+				let logs = rawLogs;
+				if (options?.sinceMs !== undefined) {
+					const cutoff = options.sinceMs;
+					logs = logs.filter((l) => typeof l.timestamp === 'number' && l.timestamp > cutoff);
+				}
+				if (options?.tail !== undefined && options.tail >= 0) {
+					logs = logs.slice(-options.tail);
+				}
+				const messages = logs.map((l) => {
+					const source = typeof l.source === 'string' ? l.source : 'unknown';
+					const tsMs = typeof l.timestamp === 'number' ? l.timestamp : 0;
+					let role: 'user' | 'assistant' | 'system' | 'tool' | 'thinking' | 'error' | 'unknown';
+					switch (source) {
+						case 'user':
+							role = 'user';
+							break;
+						case 'ai':
+						case 'stdout':
+							role = 'assistant';
+							break;
+						case 'thinking':
+							role = 'thinking';
+							break;
+						case 'tool':
+							role = 'tool';
+							break;
+						case 'system':
+							role = 'system';
+							break;
+						case 'error':
+						case 'stderr':
+							role = 'error';
+							break;
+						default:
+							role = 'unknown';
+					}
+					return {
+						id: typeof l.id === 'string' ? l.id : `${tab.id}-${tsMs}`,
+						role,
+						source,
+						content: typeof l.text === 'string' ? l.text : '',
+						timestamp: new Date(tsMs).toISOString(),
+					};
+				});
+				return {
+					tabId,
+					sessionId: tabId,
+					agentId: s.id,
+					agentSessionId: typeof tab.agentSessionId === 'string' ? tab.agentSessionId : null,
+					messages,
+				};
+			}
+			return null;
+		});
+
 		// Set up callback for web server to fetch single session details
 		// Optional tabId param allows fetching logs for a specific tab (avoids race conditions)
 		server.setGetSessionDetailCallback((sessionId: string, tabId?: string) => {

--- a/src/main/web-server/web-server-factory.ts
+++ b/src/main/web-server/web-server-factory.ts
@@ -225,7 +225,11 @@ export function createWebServerFactory(deps: WebServerFactoryDependencies) {
 					logs = logs.filter((l) => typeof l.timestamp === 'number' && l.timestamp > cutoff);
 				}
 				if (options?.tail !== undefined && options.tail >= 0) {
-					logs = logs.slice(-options.tail);
+					// `slice(-0)` is identical to `slice(0)` (because `-0 === 0`),
+					// which would silently return the full transcript when the
+					// caller asked for zero messages. Compute the start index
+					// explicitly so `tail: 0` yields `[]`.
+					logs = logs.slice(Math.max(logs.length - options.tail, 0));
 				}
 				const messages = logs.map((l) => {
 					const source = typeof l.source === 'string' ? l.source : 'unknown';


### PR DESCRIPTION
## Summary

PR2 of the Maestro CLI plan — splits read-only conversation-state inspection out of `dispatch`'s write path so external pollers (Maestro-Discord, Cue follow-ups) can pick up where Maestro left off without owning a persistent channel. Pair `dispatch --new-tab` (writes, returns tabId) with `session show <tabId>` (reads, applies `--since`/`--tail` filters) for a stateless poll loop.

- `maestro-cli session list [--json]` — flattens every open AI tab across every Maestro agent into addressable entries `{tabId, agentId, agentName, toolType, name, agentSessionId, state, createdAt, starred}`.
- `maestro-cli session show <tabId> [--since <ts>] [--tail <n>]` — returns the tab's conversation history. `--since` accepts ISO-8601 or an epoch number (auto-detected as ms vs sec by magnitude, so a `Date.now()/1000` cursor and a `Date.now()` cursor both work without a unit flag).
- New `list_desktop_sessions` / `get_session_history` WebSocket message types backed by stateless callbacks that read straight from the persisted session store — no renderer round-trip and no broadcast side-effects, so polling cadence is bounded only by IPC.
- `LogEntry.source` mapped to a coarse `role` (`user` | `assistant` | `system` | `tool` | `thinking` | `error` | `unknown`) for conversational consumers; raw `source` preserved alongside for callers that need to discriminate beyond role.
- Errors land in the typed response (`MISSING_TAB_ID` / `TAB_NOT_FOUND` / `NOT_CONFIGURED` / `MAESTRO_NOT_RUNNING` / `INVALID_OPTION`) rather than as a generic `error` so the CLI's request/response pairing stays deterministic.

## Test plan

- [x] `npx vitest run src/__tests__/cli/commands/session.test.ts` — 16 new tests cover JSON output shape, `--since` ISO/epoch parsing, `--tail` validation, transport-error mapping, and `TAB_NOT_FOUND` surfacing
- [x] `npx vitest run src/__tests__/main/web-server/handlers/messageHandlers.test.ts` — 6 new handler tests cover `list_desktop_sessions` payload, `MISSING_TAB_ID` / `TAB_NOT_FOUND` paths, `--tail` negative-coercion guard
- [x] `npx vitest run src/__tests__/main/web-server/web-server-factory.test.ts` — mock `WebServer` updated with new setters; all 37 tests pass
- [x] All 270 PR2-relevant tests pass (CLI + web-server scope); prettier & ESLint clean on touched files
- [ ] Manual: `maestro-cli dispatch <agent> "test" --new-tab`, capture `tabId`, then `maestro-cli session show <tabId>` returns the prompt + assistant reply
- [ ] Manual: `maestro-cli session show <tabId> --since "$(date -u +%FT%TZ)"` + a follow-up dispatch returns only the new turn
- [ ] Manual: `maestro-cli session list` lists all open tabs across agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `session list` to enumerate open AI tabs (compact or JSON) and `session show <tab-id>` to view conversation history with `--since`, `--tail`, and `--json` options.

* **Behavior Improvements**
  * Improved `--since` parsing (ISO or epoch seconds/ms), strict `--tail` validation (accepts 0), clearer transcript/list formatting, and deterministic error codes for missing/unmatched tabs and connection failures.

* **Tests**
  * Expanded unit and integration tests for CLI commands, websocket handlers, callback wiring, input validation, and error mapping.

* **Documentation**
  * CLI docs updated with usage, JSON envelope, filters, and failure semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->