### PR TITLE
fix(cue): empty-graph CTA + tighten regression coverage

### DIFF
--- a/src/__tests__/main/cue/cue-engine.test.ts
+++ b/src/__tests__/main/cue/cue-engine.test.ts
@@ -1832,6 +1832,39 @@ describe('CueEngine', () => {
 			expect(date.getDay()).toBe(1); // Monday
 			expect(date.getDate()).toBe(16);
 		});
+
+		// Regression for d85290c51: when a single-day schedule's slot has
+		// already passed today, the next occurrence is exactly 7 days out.
+		// The original loop bound (`dayOffset < 7`) excluded offset 7 and
+		// the function returned null, leaving the schedule silently dead
+		// until the user toggled Cue or restarted. The fix bumped the
+		// bound to `<= 7` so weekly schedules always resolve.
+		it("resolves to same day next week when today's slot has passed", () => {
+			// Monday 2026-03-09 at 09:01 — schedule for Monday 09:00 has
+			// already passed by one minute. Without the fix, this returned null.
+			vi.setSystemTime(new Date('2026-03-09T09:01:00'));
+			const result = calculateNextScheduledTime(['09:00'], ['mon']);
+			expect(result).not.toBeNull();
+			const date = new Date(result!);
+			expect(date.getDay()).toBe(1); // Monday
+			// Next Monday is 2026-03-16 — exactly 7 days later
+			expect(date.getDate()).toBe(16);
+			expect(date.getHours()).toBe(9);
+			expect(date.getMinutes()).toBe(0);
+		});
+
+		it('resolves to same day next week with multi-day filter when today is the only matching day past its slot', () => {
+			// Wednesday 2026-03-11 at 23:59 — schedule fires Wed/Fri at 09:00.
+			// Wednesday's slot is past, Friday is offset 2 → that's the next
+			// fire, NOT next Wednesday. Verifies the picks-earliest semantic
+			// still holds with the extended bound.
+			vi.setSystemTime(new Date('2026-03-11T23:59:00'));
+			const result = calculateNextScheduledTime(['09:00'], ['wed', 'fri']);
+			expect(result).not.toBeNull();
+			const date = new Date(result!);
+			expect(date.getDay()).toBe(5); // Friday
+			expect(date.getDate()).toBe(13);
+		});
 	});
 
 	describe('time.scheduled subscriptions', () => {

--- a/src/__tests__/main/cue/cue-fan-in-tracker.test.ts
+++ b/src/__tests__/main/cue/cue-fan-in-tracker.test.ts
@@ -393,4 +393,127 @@ describe('CueFanInTracker — new inspection methods', () => {
 			expect(result[0].expectedCount).toBe(2);
 		});
 	});
+
+	// ─── Regression: chainDepth propagation through fan-in ────────────────────
+	// Bug 30ab9a5c4: fan-in dispatch did not forward the max chainDepth across
+	// completed sources, so circular pipelines routed through fan-in nodes
+	// bypassed the depth guard in CueCompletionService.notifyAgentCompleted —
+	// the next dispatch saw chainDepth=0 and ran indefinitely. The fix stores
+	// chainDepth in FanInSourceCompletion and the all-complete + timeout-continue
+	// paths both pass `Math.max(...completions.map(c => c.chainDepth))` to
+	// dispatchSubscription. These tests guard both paths.
+	describe('chainDepth propagation', () => {
+		it('forwards max chainDepth to dispatchSubscription when all sources complete', () => {
+			const tracker = makeTracker();
+			const sub = makeSub();
+			const settings = makeSettings();
+			const sources = ['session-a', 'session-b'];
+
+			tracker.handleCompletion(
+				'owner',
+				settings,
+				sub,
+				sources,
+				'session-a',
+				'Agent A',
+				makeCompletion({ chainDepth: 3 })
+			);
+			tracker.handleCompletion(
+				'owner',
+				settings,
+				sub,
+				sources,
+				'session-b',
+				'Agent B',
+				makeCompletion({ chainDepth: 7 })
+			);
+
+			expect(dispatch).toHaveBeenCalledTimes(1);
+			// dispatchSubscription signature: (ownerSessionId, sub, event, completedNames, chainDepth?)
+			const call = dispatch.mock.calls[0];
+			expect(call[0]).toBe('owner');
+			expect(call[1]).toBe(sub);
+			// Last positional argument is chainDepth — must equal max(3, 7) = 7,
+			// NOT the last completion's depth (would mask cycles where the
+			// deepest source isn't the most recent), and NOT 0 (the original
+			// bug, which let cycles run forever).
+			expect(call[4]).toBe(7);
+		});
+
+		it('forwards max chainDepth in timeout-continue mode', () => {
+			vi.setSystemTime(new Date('2026-04-21T10:00:00Z'));
+			const tracker = makeTracker();
+			const sub = makeSub({ fan_in_timeout_minutes: 10 });
+			const settings = makeSettings({ timeout_on_fail: 'continue' });
+			const sources = ['session-a', 'session-b'];
+
+			// Only session-a completes; session-b is left dangling and the
+			// timer fires the timeout-continue branch.
+			tracker.handleCompletion(
+				'owner',
+				settings,
+				sub,
+				sources,
+				'session-a',
+				'Agent A',
+				makeCompletion({ chainDepth: 5 })
+			);
+
+			// Advance past the per-sub fan_in_timeout_minutes (10m).
+			vi.advanceTimersByTime(11 * 60 * 1000);
+
+			expect(dispatch).toHaveBeenCalledTimes(1);
+			const call = dispatch.mock.calls[0];
+			// Only one completion arrived, so max == that source's chainDepth (5).
+			// The bug would have passed 0 here, masking cycles when partial
+			// fan-ins continue through to dispatch.
+			expect(call[4]).toBe(5);
+		});
+
+		it('falls back to chainDepth=0 when completions carry no chainDepth field', () => {
+			// Defensive: events from older code paths or external callers may
+			// omit chainDepth. The tracker must default to 0 (matching the
+			// `?? 0` fallback in cue-fan-in-tracker.ts:219) rather than NaN
+			// (which Math.max returns when fed undefined).
+			const tracker = makeTracker();
+			const sub = makeSub();
+			const settings = makeSettings();
+			const sources = ['session-a', 'session-b'];
+
+			// Spread overrides into makeCompletion but force chainDepth=undefined
+			// to simulate an external completion that didn't set it.
+			const completionMissingDepth = {
+				sessionName: 'agent-a',
+				status: 'completed' as const,
+				exitCode: 0,
+				durationMs: 1000,
+				stdout: 'output',
+				triggeredBy: 'fan-in-sub',
+			};
+
+			tracker.handleCompletion(
+				'owner',
+				settings,
+				sub,
+				sources,
+				'session-a',
+				'Agent A',
+				completionMissingDepth as never
+			);
+			tracker.handleCompletion(
+				'owner',
+				settings,
+				sub,
+				sources,
+				'session-b',
+				'Agent B',
+				completionMissingDepth as never
+			);
+
+			expect(dispatch).toHaveBeenCalledTimes(1);
+			const call = dispatch.mock.calls[0];
+			expect(call[4]).toBe(0);
+			expect(Number.isNaN(call[4])).toBe(false);
+		});
+	});
 });

--- a/src/__tests__/renderer/components/CueModal.test.tsx
+++ b/src/__tests__/renderer/components/CueModal.test.tsx
@@ -43,8 +43,17 @@ vi.mock('../../../renderer/components/CueYamlEditor', () => ({
 		isOpen ? <div data-testid="cue-yaml-editor">YAML Editor Mock</div> : null,
 }));
 
+// `vi.hoisted` so the captured ref exists before vi.mock evaluates the factory.
+// Tests assert against `capturedEditorProps.initialPipelineId` to verify that
+// the parent (CueModal) propagates / clears the "View in Pipeline" token.
+const capturedEditorProps = vi.hoisted(() => ({
+	initialPipelineId: undefined as { id: string | null; nonce: string } | undefined,
+	renderCount: 0,
+}));
 vi.mock('../../../renderer/components/CuePipelineEditor', () => ({
-	CuePipelineEditor: () => {
+	CuePipelineEditor: (props: { initialPipelineId?: { id: string | null; nonce: string } }) => {
+		capturedEditorProps.initialPipelineId = props.initialPipelineId;
+		capturedEditorProps.renderCount += 1;
 		return <div data-testid="cue-pipeline-editor">Pipeline Editor Mock</div>;
 	},
 }));
@@ -178,6 +187,8 @@ describe('CueModal', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		mockUseCueReturn = { ...defaultUseCueReturn };
+		capturedEditorProps.initialPipelineId = undefined;
+		capturedEditorProps.renderCount = 0;
 	});
 
 	describe('rendering', () => {
@@ -415,6 +426,72 @@ describe('CueModal', () => {
 			fireEvent.click(screen.getByText('Pipeline Editor'));
 			expect(screen.getByTestId('cue-pipeline-editor')).toBeInTheDocument();
 			expect(screen.queryByText('Sessions with Cue')).not.toBeInTheDocument();
+		});
+	});
+
+	// Regression for 42ac8333e: handleSetActiveTab MUST clear pendingPipelineId
+	// when navigating away from the pipeline tab. Without this, a stale nonce
+	// would survive the unmount/remount cycle, and a fresh CuePipelineEditor's
+	// initial-pre-select effect (appliedNonce.current === null on the new
+	// instance) would re-snap the user back to the "View in Pipeline" target
+	// they just navigated away from.
+	describe('pending pipeline token (regression: tab switch must clear it)', () => {
+		it('clears initialPipelineId when navigating away from the pipeline tab', () => {
+			mockUseCueReturn = {
+				...defaultUseCueReturn,
+				sessions: [mockSession],
+			};
+
+			render(<CueModal theme={mockTheme} onClose={mockOnClose} />);
+
+			// Default tab is 'pipeline' — editor renders with no pending token.
+			expect(capturedEditorProps.initialPipelineId).toBeUndefined();
+
+			// Navigate to Dashboard and click "View in Pipeline" — handler sets
+			// pendingPipelineId AND switches activeTab to 'pipeline', so the
+			// editor remounts and now sees the token in its initialPipelineId prop.
+			fireEvent.click(screen.getByText('Dashboard'));
+			fireEvent.click(screen.getByText('View in Pipeline'));
+
+			expect(capturedEditorProps.initialPipelineId).toBeDefined();
+			const tokenAfterView = capturedEditorProps.initialPipelineId!;
+			expect(typeof tokenAfterView.nonce).toBe('string');
+			expect(tokenAfterView.nonce.length).toBeGreaterThan(0);
+
+			// Navigate back to Dashboard. handleSetActiveTab(non-pipeline) MUST
+			// reset pendingPipelineId to null. The editor unmounts here, so we
+			// can't read its props — that's the whole point of the regression
+			// (the next remount is where the bug manifested).
+			fireEvent.click(screen.getByText('Dashboard'));
+
+			// Return to the pipeline tab. The freshly-mounted editor's
+			// initialPipelineId must be undefined (no stale token survives).
+			// Before the fix, the same `tokenAfterView` would still be present
+			// here and snap the user back to the prior pipeline.
+			fireEvent.click(screen.getByText('Pipeline Editor'));
+			expect(capturedEditorProps.initialPipelineId).toBeUndefined();
+		});
+
+		it('preserves the token when navigating within the pipeline tab', () => {
+			// Defensive: handleSetActiveTab is idempotent for `tab === 'pipeline'`.
+			// Calling it with the already-active value must NOT clear the token —
+			// otherwise rapid re-clicks of the Pipeline Editor tab would race
+			// against a still-pending "View in Pipeline" navigation.
+			mockUseCueReturn = {
+				...defaultUseCueReturn,
+				sessions: [mockSession],
+			};
+
+			render(<CueModal theme={mockTheme} onClose={mockOnClose} />);
+
+			fireEvent.click(screen.getByText('Dashboard'));
+			fireEvent.click(screen.getByText('View in Pipeline'));
+			expect(capturedEditorProps.initialPipelineId).toBeDefined();
+			const tokenAfterView = capturedEditorProps.initialPipelineId!;
+
+			// Clicking the already-active Pipeline Editor tab must not clear it.
+			fireEvent.click(screen.getByText('Pipeline Editor'));
+			expect(capturedEditorProps.initialPipelineId?.nonce).toBe(tokenAfterView.nonce);
 		});
 	});
 

--- a/src/__tests__/renderer/components/CuePipelineEditor/CuePipelineEditor.loadingGate.test.tsx
+++ b/src/__tests__/renderer/components/CuePipelineEditor/CuePipelineEditor.loadingGate.test.tsx
@@ -1,0 +1,276 @@
+/**
+ * Regression: empty Cue graph showed a spinner forever instead of the
+ * "Create your first pipeline" CTA.
+ *
+ * Failure trace:
+ *   1. `useCueGraphData` finishes its initial fetch with `graphSessions=[]`
+ *      and flips `graphInitialLoading` → false.
+ *   2. `usePipelineLayout`'s restore effect early-returns when
+ *      `graphSessions.length === 0`, so `pipelinesLoaded` stays at its
+ *      initial `false`.
+ *   3. The editor's `isLoading={graphLoading || !pipelinesLoaded}` evaluates
+ *      to `false || true === true`. Spinner renders, CTA never shows.
+ *
+ * Fix: the editor now gates `!pipelinesLoaded` behind `graphSessions.length > 0`
+ * — empty graphSessions after the parent fetch completes correctly falls
+ * through to the CTA.
+ *
+ * These tests assert the four-way truth table on the `isLoading` prop that
+ * `CuePipelineEditor` passes to `PipelineCanvas`. Testing at this boundary
+ * (rather than via the rendered spinner) keeps the regression coverage
+ * decoupled from `PipelineEmptyState` so that component is free to evolve
+ * without breaking these guards.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import React from 'react';
+import type { CueGraphSession } from '../../../../shared/cue-pipeline-types';
+
+// ─── Captured props ──────────────────────────────────────────────────────────
+let capturedIsLoading: boolean | undefined;
+let capturedPipelineCount: number | undefined;
+
+vi.mock('reactflow', () => ({
+	default: (props: any) => <div data-testid="react-flow">{props.children}</div>,
+	ReactFlowProvider: ({ children }: any) => <>{children}</>,
+	useReactFlow: () => ({
+		fitView: vi.fn(),
+		screenToFlowPosition: vi.fn((pos: any) => pos),
+		setViewport: vi.fn(),
+	}),
+	useNodesInitialized: () => false,
+	applyNodeChanges: (_changes: any[], nodes: any[]) => nodes,
+	Background: () => null,
+	Controls: () => null,
+	MiniMap: () => null,
+	ConnectionMode: { Loose: 'loose' },
+	Position: { Left: 'left', Right: 'right' },
+	Handle: () => null,
+	MarkerType: { ArrowClosed: 'arrowclosed' },
+}));
+
+vi.mock('../../../../renderer/components/CuePipelineEditor/PipelineCanvas', () => ({
+	PipelineCanvas: React.memo((props: any) => {
+		capturedIsLoading = props.isLoading;
+		capturedPipelineCount = props.pipelineCount;
+		return <div data-testid="pipeline-canvas" />;
+	}),
+}));
+vi.mock('../../../../renderer/components/CuePipelineEditor/PipelineToolbar', () => ({
+	PipelineToolbar: () => <div />,
+}));
+vi.mock('../../../../renderer/components/CuePipelineEditor/PipelineContextMenu', () => ({
+	PipelineContextMenu: () => null,
+}));
+
+// ─── Stable hook mocks ───────────────────────────────────────────────────────
+// Test toggles `mockPipelinesLoaded` and `mockPipelineCount` before each render.
+let mockPipelinesLoaded = false;
+let mockPipelineCount = 0;
+
+const stableCueSettings = {
+	timeout_minutes: 30,
+	timeout_on_fail: 'break' as const,
+	max_concurrent: 1,
+	queue_size: 10,
+};
+
+function makeStateHook() {
+	const pipelines = Array.from({ length: mockPipelineCount }, (_, i) => ({
+		id: `p${i + 1}`,
+		name: `Pipeline ${i + 1}`,
+		color: '#06b6d4',
+		nodes: [],
+		edges: [],
+	}));
+	return {
+		pipelineState: { pipelines, selectedPipelineId: null as string | null },
+		setPipelineState: vi.fn(),
+		isAllPipelinesView: true,
+		isDirty: false,
+		setIsDirty: vi.fn(),
+		saveStatus: 'idle' as const,
+		validationErrors: [],
+		cueSettings: stableCueSettings,
+		setCueSettings: vi.fn(),
+		showSettings: false,
+		setShowSettings: vi.fn(),
+		runningPipelineIds: new Set<string>(),
+		runningAgentsByPipeline: new Map<string, Set<string>>(),
+		runningSubscriptionsByPipeline: new Map<string, Set<string>>(),
+		persistLayout: vi.fn(),
+		pendingSavedViewportRef: { current: null as null | { x: number; y: number; zoom: number } },
+		pipelinesLoaded: mockPipelinesLoaded,
+		handleSave: vi.fn(),
+		handleDiscard: vi.fn(),
+		createPipeline: vi.fn(),
+		deletePipeline: vi.fn(),
+		renamePipeline: vi.fn(),
+		selectPipeline: vi.fn(),
+		changePipelineColor: vi.fn(),
+		onUpdateNode: vi.fn(),
+		onUpdateEdgePrompt: vi.fn(),
+		onDeleteNode: vi.fn(),
+		onUpdateEdge: vi.fn(),
+		onDeleteEdge: vi.fn(),
+	};
+}
+let stateHookCache = makeStateHook();
+
+vi.mock('../../../../renderer/hooks/cue/usePipelineState', () => ({
+	usePipelineState: () => stateHookCache,
+	DEFAULT_TRIGGER_LABELS: {},
+	validatePipelines: vi.fn(),
+}));
+
+const stableSelectionHook = {
+	selectedNodeId: null,
+	setSelectedNodeId: vi.fn(),
+	selectedEdgeId: null,
+	setSelectedEdgeId: vi.fn(),
+	selectedNode: null,
+	selectedNodePipelineId: null,
+	selectedNodeHasOutgoingEdge: false,
+	hasIncomingAgentEdges: false,
+	incomingAgentEdgeCount: 0,
+	incomingAgentEdges: [],
+	incomingTriggerEdges: [],
+	selectedEdge: null,
+	selectedEdgePipelineId: null,
+	selectedEdgePipelineColor: '#06b6d4',
+	edgeSourceNode: null,
+	edgeTargetNode: null,
+	onCanvasSessionIds: new Set<string>(),
+	onNodeClick: vi.fn(),
+	onEdgeClick: vi.fn(),
+	onPaneClick: vi.fn(),
+	handleConfigureNode: vi.fn(),
+};
+vi.mock('../../../../renderer/hooks/cue/usePipelineSelection', () => ({
+	usePipelineSelection: () => stableSelectionHook,
+}));
+
+vi.mock('../../../../renderer/components/CuePipelineEditor/utils/pipelineGraph', () => ({
+	convertToReactFlowNodes: vi.fn(() => []),
+	convertToReactFlowEdges: vi.fn(() => []),
+	computePipelineYOffsets: vi.fn(() => new Map()),
+}));
+
+import { CuePipelineEditor } from '../../../../renderer/components/CuePipelineEditor/CuePipelineEditor';
+
+const mockTheme = {
+	name: 'test',
+	colors: {
+		bgMain: '#1a1a2e',
+		bgActivity: '#16213e',
+		border: '#333',
+		textMain: '#e4e4e7',
+		textDim: '#a1a1aa',
+		accent: '#06b6d4',
+		accentForeground: '#fff',
+		success: '#22c55e',
+	},
+} as any;
+
+// Synthetic non-empty graph session — content doesn't matter, only `length > 0`.
+const SOME_GRAPH_SESSION: CueGraphSession = {
+	sessionId: 's1',
+	sessionName: 'Agent 1',
+	projectRoot: '/tmp',
+	subscriptions: [],
+} as unknown as CueGraphSession;
+
+function renderEditor({
+	graphLoading,
+	graphSessions,
+}: {
+	graphLoading: boolean;
+	graphSessions: CueGraphSession[];
+}) {
+	stateHookCache = makeStateHook();
+	render(
+		<CuePipelineEditor
+			sessions={[]}
+			graphSessions={graphSessions}
+			onSwitchToSession={vi.fn()}
+			onClose={vi.fn()}
+			theme={mockTheme}
+			graphLoading={graphLoading}
+		/>
+	);
+}
+
+describe('CuePipelineEditor — isLoading gate (regression: empty graph spinner stayed forever)', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		capturedIsLoading = undefined;
+		capturedPipelineCount = undefined;
+		mockPipelinesLoaded = false;
+		mockPipelineCount = 0;
+	});
+
+	it('shows spinner while parent is fetching graph data (graphLoading=true, empty)', () => {
+		mockPipelinesLoaded = false;
+		mockPipelineCount = 0;
+		renderEditor({ graphLoading: true, graphSessions: [] });
+		expect(capturedIsLoading).toBe(true);
+		expect(capturedPipelineCount).toBe(0);
+	});
+
+	it('shows spinner while parent is fetching graph data (graphLoading=true, non-empty)', () => {
+		mockPipelinesLoaded = false;
+		mockPipelineCount = 1;
+		renderEditor({ graphLoading: true, graphSessions: [SOME_GRAPH_SESSION] });
+		expect(capturedIsLoading).toBe(true);
+	});
+
+	it('falls through to CTA when graph fetch completes with no sessions', () => {
+		// THE REGRESSION. Before the fix, isLoading was true here because
+		// pipelinesLoaded never flipped (the layout hook early-returns on
+		// empty graphSessions). PipelineCanvas would render the spinner
+		// forever and the user would never see "Create your first pipeline".
+		mockPipelinesLoaded = false;
+		mockPipelineCount = 0;
+		renderEditor({ graphLoading: false, graphSessions: [] });
+		expect(capturedIsLoading).toBe(false);
+		expect(capturedPipelineCount).toBe(0);
+	});
+
+	it('keeps spinner up while non-empty graph data is still being restored', () => {
+		// graphSessions has data, but the layout hook hasn't finished merging
+		// it with the saved layout yet. The editor MUST keep the spinner up
+		// or the CTA flashes briefly before the pipelines render.
+		mockPipelinesLoaded = false;
+		mockPipelineCount = 0;
+		renderEditor({ graphLoading: false, graphSessions: [SOME_GRAPH_SESSION] });
+		expect(capturedIsLoading).toBe(true);
+	});
+
+	it('hides spinner once the layout has been restored', () => {
+		mockPipelinesLoaded = true;
+		mockPipelineCount = 1;
+		renderEditor({ graphLoading: false, graphSessions: [SOME_GRAPH_SESSION] });
+		expect(capturedIsLoading).toBe(false);
+		expect(capturedPipelineCount).toBe(1);
+	});
+
+	it('hides spinner when the prop default kicks in (graphLoading omitted)', () => {
+		// Some call sites omit `graphLoading` (the prop is optional, defaults
+		// to false). With sessions present and pipelines loaded, the editor
+		// must not require the prop to be threaded through.
+		mockPipelinesLoaded = true;
+		mockPipelineCount = 1;
+		stateHookCache = makeStateHook();
+		render(
+			<CuePipelineEditor
+				sessions={[]}
+				graphSessions={[SOME_GRAPH_SESSION]}
+				onSwitchToSession={vi.fn()}
+				onClose={vi.fn()}
+				theme={mockTheme}
+			/>
+		);
+		expect(capturedIsLoading).toBe(false);
+	});
+});

--- a/src/__tests__/renderer/components/CuePipelineEditor/panels/NodeConfigPanel.test.tsx
+++ b/src/__tests__/renderer/components/CuePipelineEditor/panels/NodeConfigPanel.test.tsx
@@ -176,4 +176,157 @@ describe('NodeConfigPanel', () => {
 		expect(secondPanel.textContent).toBe('agent-2');
 		expect(secondPanel).not.toBe(firstPanel);
 	});
+
+	// Regression for 96a87a19c: when multiple agent visual nodes share a
+	// `sessionId` within a pipeline, the canvas labels them "Agent (1)",
+	// "Agent (2)" via pipelineGraph's per-pipeline session-index logic. The
+	// config panel header used to show just "Agent", leaving the user unsure
+	// which instance their edits applied to. The fix mirrors the canvas's
+	// suffix in the panel header.
+	describe('agent instance suffix (regression: ambiguous header for shared sessionId)', () => {
+		function makeAgent(id: string, sessionId: string, sessionName: string): PipelineNode {
+			return {
+				id,
+				type: 'agent',
+				position: { x: 0, y: 0 },
+				data: {
+					sessionId,
+					sessionName,
+					toolType: 'claude-code',
+				} as AgentNodeData,
+			};
+		}
+
+		// Helper: the header span concatenates the sessionName text node and
+		// the IIFE-returned suffix text node into one element. testing-library's
+		// `getByText` normalizes whitespace and compares the *full* text content
+		// of an element, so we match against the combined string.
+		function getAgentHeaderSpan(): HTMLElement {
+			return screen.getByText((_content, element) => {
+				if (!element || element.tagName !== 'SPAN') return false;
+				const txt = element.textContent ?? '';
+				// Bold-weight header span — discriminate from sibling pill spans
+				// (which carry toolType / status). 600-weight is set inline above.
+				return /^(Test Agent|Pedsidian|Floating Agent)( \(\d+\))?$/.test(txt);
+			}) as HTMLElement;
+		}
+
+		it('omits the suffix when only one node uses this sessionId in the pipeline', () => {
+			const pipeline: CuePipeline = {
+				id: 'p1',
+				name: 'P1',
+				color: '#06b6d4',
+				nodes: [makeAgent('agent-1', 'sess-1', 'Test Agent')],
+				edges: [],
+			};
+
+			render(
+				<NodeConfigPanel
+					selectedNode={pipeline.nodes[0]}
+					pipelines={[pipeline]}
+					theme={darkTheme}
+					onUpdateNode={vi.fn()}
+					onDeleteNode={vi.fn()}
+				/>
+			);
+
+			// Header text is just the name — no parenthetical suffix.
+			expect(getAgentHeaderSpan().textContent).toBe('Test Agent');
+		});
+
+		it('appends "(1)" / "(2)" when multiple visual nodes share the same sessionId', () => {
+			// Two agent nodes pointing at the same backing session — exactly the
+			// shape pipelineGraph indexes with the (N) suffix on the canvas.
+			const a = makeAgent('agent-1', 'sess-1', 'Pedsidian');
+			const b = makeAgent('agent-2', 'sess-1', 'Pedsidian');
+			const pipeline: CuePipeline = {
+				id: 'p1',
+				name: 'P1',
+				color: '#06b6d4',
+				nodes: [a, b],
+				edges: [],
+			};
+
+			const { rerender } = render(
+				<NodeConfigPanel
+					selectedNode={a}
+					pipelines={[pipeline]}
+					theme={darkTheme}
+					onUpdateNode={vi.fn()}
+					onDeleteNode={vi.fn()}
+				/>
+			);
+
+			// First instance — header reads exactly "Pedsidian (1)".
+			expect(getAgentHeaderSpan().textContent).toBe('Pedsidian (1)');
+
+			rerender(
+				<NodeConfigPanel
+					selectedNode={b}
+					pipelines={[pipeline]}
+					theme={darkTheme}
+					onUpdateNode={vi.fn()}
+					onDeleteNode={vi.fn()}
+				/>
+			);
+
+			expect(getAgentHeaderSpan().textContent).toBe('Pedsidian (2)');
+		});
+
+		it('isolates the suffix per pipeline (does not leak across siblings)', () => {
+			// Two pipelines each with one node sharing the same sessionId.
+			// Within either pipeline, only one node uses that sessionId, so
+			// neither header gets a suffix. This guards the "find the OWNING
+			// pipeline first" rule — without it, the implementation could
+			// scan all pipelines and double-count.
+			const aP1 = makeAgent('agent-1', 'sess-1', 'Pedsidian');
+			const aP2 = makeAgent('agent-2', 'sess-1', 'Pedsidian');
+			const p1: CuePipeline = {
+				id: 'p1',
+				name: 'P1',
+				color: '#06b6d4',
+				nodes: [aP1],
+				edges: [],
+			};
+			const p2: CuePipeline = {
+				id: 'p2',
+				name: 'P2',
+				color: '#a855f7',
+				nodes: [aP2],
+				edges: [],
+			};
+
+			render(
+				<NodeConfigPanel
+					selectedNode={aP1}
+					pipelines={[p1, p2]}
+					theme={darkTheme}
+					onUpdateNode={vi.fn()}
+					onDeleteNode={vi.fn()}
+				/>
+			);
+
+			expect(getAgentHeaderSpan().textContent).toBe('Pedsidian');
+		});
+
+		it('omits the suffix when the selected node is not present in any pipeline', () => {
+			// Defensive: the IIFE returns '' when `owningPipeline` is undefined.
+			// This shape can happen if the panel renders during a transient
+			// state where the node was deleted but the selectedNode prop has
+			// not yet flushed.
+			const orphan = makeAgent('agent-orphan', 'sess-1', 'Floating Agent');
+
+			render(
+				<NodeConfigPanel
+					selectedNode={orphan}
+					pipelines={[]}
+					theme={darkTheme}
+					onUpdateNode={vi.fn()}
+					onDeleteNode={vi.fn()}
+				/>
+			);
+
+			expect(getAgentHeaderSpan().textContent).toBe('Floating Agent');
+		});
+	});
 });

--- a/src/__tests__/renderer/components/CuePipelineEditor/utils/pipelineRoundTrip.shapes.test.ts
+++ b/src/__tests__/renderer/components/CuePipelineEditor/utils/pipelineRoundTrip.shapes.test.ts
@@ -1,0 +1,450 @@
+/**
+ * Round-trip integration tests for pipeline shapes that have *historically*
+ * lost data when serialized to YAML and reloaded. Complements
+ * `pipelineRoundTrip.integration.test.ts` (which covers prompt isolation,
+ * pipeline color, agent identity, and iteration order) by guarding the
+ * shape-specific failure modes that produced repeated bugfix commits over
+ * the last quarter:
+ *
+ *   - Trigger fan-out (1 trigger → N parallel agents) must preserve every
+ *     downstream agent and the per-target prompt distribution.
+ *     [977034e42] preserve target_node_key + fan_out_node_keys
+ *
+ *   - Multi-agent linear chains must preserve depth and the per-agent
+ *     prompts (which round-trip as agent.inputPrompt rather than edge.prompt
+ *     because chain prompts are emitted as the chain sub's `prompt` field).
+ *     [705f3763a] preserve node positions and prevent pipeline-vanishes-after-save
+ *     [dc853069e] resolve chain upstreams via source_sub on load
+ *
+ *   - Trigger event configs (time.scheduled days+times, file.changed
+ *     watch+filter, github.pull_request repo+poll_minutes,
+ *     time.heartbeat interval_minutes) must round-trip exactly.
+ *
+ *   - Double round-trip is structurally idempotent — guards drift bugs
+ *     where save→reload→save mutates fields.
+ *
+ * Test invariants:
+ *   - Visual-only fields (positions, ids, edge ids) are intentionally NOT
+ *     compared. Auto-layout regenerates positions; ids regenerate on load.
+ *   - Per-edge `mode` (autorun/debate) is INTENTIONALLY NOT TESTED here:
+ *     edge modes are persisted as YAML comments by `pipelineToYaml`, and
+ *     `yaml.load()` strips comments — so they are recovered separately
+ *     from the editor-side `pipelineLayout.json` sidecar, not from the
+ *     YAML body. A round-trip test through `yaml.load()` would correctly
+ *     show "lost" and create a misleading assertion. See pipelineToYaml.ts
+ *     `getEdgeModeComment()` for the source-of-truth on this design.
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as yaml from 'js-yaml';
+
+import { pipelinesToYaml } from '../../../../../renderer/components/CuePipelineEditor/utils/pipelineToYaml';
+import { subscriptionsToPipelines } from '../../../../../renderer/components/CuePipelineEditor/utils/yamlToPipeline';
+import type {
+	AgentNodeData,
+	CuePipeline,
+	PipelineEdge,
+	PipelineNode,
+	TriggerNodeData,
+} from '../../../../../shared/cue-pipeline-types';
+import type { CueEventType, CueSubscription } from '../../../../../shared/cue/contracts';
+
+// ─── Fixture helpers ─────────────────────────────────────────────────────────
+
+interface PipelineSession {
+	id: string;
+	name: string;
+	toolType: 'claude-code';
+}
+
+function trigger(
+	id: string,
+	eventType: CueEventType,
+	config: TriggerNodeData['config'] = {}
+): PipelineNode {
+	return {
+		id,
+		type: 'trigger',
+		position: { x: 0, y: 0 },
+		data: { eventType, label: 'Trigger', config } as TriggerNodeData,
+	};
+}
+
+function agent(id: string, sessionId: string, sessionName: string): PipelineNode {
+	return {
+		id,
+		type: 'agent',
+		position: { x: 200, y: 0 },
+		data: { sessionId, sessionName, toolType: 'claude-code' } as AgentNodeData,
+	};
+}
+
+function edge(
+	id: string,
+	source: string,
+	target: string,
+	overrides: Partial<PipelineEdge> = {}
+): PipelineEdge {
+	return { id, source, target, mode: 'pass', ...overrides };
+}
+
+function pipeline(
+	name: string,
+	color: string,
+	nodes: PipelineNode[],
+	edges: PipelineEdge[]
+): CuePipeline {
+	return { id: name.toLowerCase(), name, color, nodes, edges };
+}
+
+/**
+ * Drives the same pipelinesToYaml → YAML parse → subscriptionsToPipelines
+ * cycle that the runtime uses. Mirrors the normalizer's prompt-file inlining
+ * so tests don't need to know about external prompt files. Handles BOTH
+ * `prompt_file` (single) and `fan_out_prompt_files` (array) — both shapes
+ * are emitted by `pipelineToYaml` depending on whether the trigger feeds
+ * one target or fans out to many.
+ */
+function roundTrip(pipelines: CuePipeline[], sessions: PipelineSession[]): CuePipeline[] {
+	const { yaml: yamlStr, promptFiles } = pipelinesToYaml(pipelines);
+	const parsed = yaml.load(yamlStr) as {
+		subscriptions: Array<Record<string, unknown>>;
+	};
+	const subs: CueSubscription[] = parsed.subscriptions.map((raw) => {
+		// Single prompt_file: resolve to inline prompt (mirrors normalizer).
+		const promptFile = typeof raw.prompt_file === 'string' ? raw.prompt_file : undefined;
+		const prompt = promptFile ? (promptFiles.get(promptFile) ?? '') : '';
+
+		// Fan-out prompts: each slot's prompt_file becomes the inline string.
+		const fanOutPromptFilesRaw = Array.isArray(raw.fan_out_prompt_files)
+			? (raw.fan_out_prompt_files as string[])
+			: undefined;
+		const fanOutPrompts = fanOutPromptFilesRaw?.map((p) => promptFiles.get(p) ?? '');
+
+		const { prompt_file: _pf, output_prompt_file: _opf, ...rest } = raw;
+		return {
+			...(rest as Partial<CueSubscription>),
+			enabled: rest.enabled !== false,
+			prompt,
+			...(fanOutPrompts ? { fan_out_prompts: fanOutPrompts } : {}),
+		} as CueSubscription;
+	});
+	return subscriptionsToPipelines(subs, sessions);
+}
+
+// ─── Shape: trigger fan-out (1 trigger → N agents) ───────────────────────────
+
+describe('round-trip: trigger fan-out preserves all downstream agents', () => {
+	it('one trigger fanning out to three distinct agents reconstructs all three', () => {
+		const t1 = trigger('t1', 'time.heartbeat', { interval_minutes: 5 });
+		const a1 = agent('a1', 'sess-a', 'Alpha');
+		const a2 = agent('a2', 'sess-b', 'Bravo');
+		const a3 = agent('a3', 'sess-c', 'Charlie');
+
+		const pipelines = [
+			pipeline(
+				'FanOut',
+				'#06b6d4',
+				[t1, a1, a2, a3],
+				[
+					edge('e1', 't1', 'a1', { prompt: 'task alpha' }),
+					edge('e2', 't1', 'a2', { prompt: 'task bravo' }),
+					edge('e3', 't1', 'a3', { prompt: 'task charlie' }),
+				]
+			),
+		];
+		const sessions: PipelineSession[] = [
+			{ id: 'sess-a', name: 'Alpha', toolType: 'claude-code' },
+			{ id: 'sess-b', name: 'Bravo', toolType: 'claude-code' },
+			{ id: 'sess-c', name: 'Charlie', toolType: 'claude-code' },
+		];
+
+		const [reconstructed] = roundTrip(pipelines, sessions);
+
+		// All three agents survived (the fan-out target list was the bug surface).
+		const agentSessionIds = reconstructed.nodes
+			.filter((n) => n.type === 'agent')
+			.map((n) => (n.data as AgentNodeData).sessionId)
+			.sort();
+		expect(agentSessionIds).toEqual(['sess-a', 'sess-b', 'sess-c']);
+
+		// Three trigger→agent edges remain (the topology survived).
+		const triggerNode = reconstructed.nodes.find((n) => n.type === 'trigger')!;
+		const outgoing = reconstructed.edges.filter((e) => e.source === triggerNode.id);
+		expect(outgoing).toHaveLength(3);
+	});
+
+	it('fan-out distributes per-target prompts via fan_out_prompts', () => {
+		// `pipelineToYaml` emits per-target prompts as `fan_out_prompt_files`,
+		// the normalizer inlines them as `fan_out_prompts[i]`, and the
+		// renderer threads them onto the trigger→agent edge. Without this
+		// distribution intact, all three agents would receive the same
+		// fallback `prompt` (currently '') instead of their own task strings.
+		const t1 = trigger('t1', 'time.heartbeat', { interval_minutes: 5 });
+		const a1 = agent('a1', 'sess-a', 'Alpha');
+		const a2 = agent('a2', 'sess-b', 'Bravo');
+
+		const pipelines = [
+			pipeline(
+				'FanOut',
+				'#06b6d4',
+				[t1, a1, a2],
+				[
+					edge('e1', 't1', 'a1', { prompt: 'work for alpha' }),
+					edge('e2', 't1', 'a2', { prompt: 'work for bravo' }),
+				]
+			),
+		];
+		const sessions: PipelineSession[] = [
+			{ id: 'sess-a', name: 'Alpha', toolType: 'claude-code' },
+			{ id: 'sess-b', name: 'Bravo', toolType: 'claude-code' },
+		];
+
+		const [reconstructed] = roundTrip(pipelines, sessions);
+		const promptsByAgentName: Record<string, string | undefined> = {};
+		for (const e of reconstructed.edges) {
+			const target = reconstructed.nodes.find((n) => n.id === e.target);
+			if (target?.type !== 'agent') continue;
+			promptsByAgentName[(target.data as AgentNodeData).sessionName] = e.prompt;
+		}
+		expect(promptsByAgentName).toEqual({
+			Alpha: 'work for alpha',
+			Bravo: 'work for bravo',
+		});
+	});
+
+	it('fan-out to two visual nodes pointing at the SAME sessionId stays as two nodes', () => {
+		// Regression for 977034e42: two visual instances of the same agent
+		// in a fan-out used to merge into a single node on reload because
+		// the loader keyed by sessionId. The fix added stable nodeKeys
+		// persisted as `target_node_key` / `fan_out_node_keys`.
+		const t1 = trigger('t1', 'time.heartbeat', { interval_minutes: 5 });
+		const a1: PipelineNode = {
+			...agent('a1', 'sess-a', 'Alpha'),
+			data: { ...(agent('a1', 'sess-a', 'Alpha').data as AgentNodeData), nodeKey: 'key-1' },
+		};
+		const a2: PipelineNode = {
+			...agent('a2', 'sess-a', 'Alpha'),
+			data: { ...(agent('a2', 'sess-a', 'Alpha').data as AgentNodeData), nodeKey: 'key-2' },
+		};
+
+		const pipelines = [
+			pipeline(
+				'DupFanOut',
+				'#06b6d4',
+				[t1, a1, a2],
+				[
+					edge('e1', 't1', 'a1', { prompt: 'instance 1 work' }),
+					edge('e2', 't1', 'a2', { prompt: 'instance 2 work' }),
+				]
+			),
+		];
+		const sessions: PipelineSession[] = [{ id: 'sess-a', name: 'Alpha', toolType: 'claude-code' }];
+
+		const [reconstructed] = roundTrip(pipelines, sessions);
+
+		// Two distinct agent nodes, both pointing at sess-a — NOT merged.
+		const agents = reconstructed.nodes.filter((n) => n.type === 'agent');
+		expect(agents).toHaveLength(2);
+		expect(agents.every((n) => (n.data as AgentNodeData).sessionId === 'sess-a')).toBe(true);
+	});
+});
+
+// ─── Shape: multi-agent linear chain ─────────────────────────────────────────
+
+describe('round-trip: multi-agent linear chain', () => {
+	it('a four-deep chain preserves every node and the chain topology', () => {
+		const t1 = trigger('t1', 'time.heartbeat', { interval_minutes: 5 });
+		const a1 = agent('a1', 'sess-1', 'A1');
+		const a2 = agent('a2', 'sess-2', 'A2');
+		const a3 = agent('a3', 'sess-3', 'A3');
+		const a4 = agent('a4', 'sess-4', 'A4');
+
+		const pipelines = [
+			pipeline(
+				'Chain',
+				'#06b6d4',
+				[t1, a1, a2, a3, a4],
+				[
+					edge('e1', 't1', 'a1', { prompt: 'first' }),
+					edge('e2', 'a1', 'a2', { prompt: 'second' }),
+					edge('e3', 'a2', 'a3', { prompt: 'third' }),
+					edge('e4', 'a3', 'a4', { prompt: 'fourth' }),
+				]
+			),
+		];
+		const sessions: PipelineSession[] = [
+			{ id: 'sess-1', name: 'A1', toolType: 'claude-code' },
+			{ id: 'sess-2', name: 'A2', toolType: 'claude-code' },
+			{ id: 'sess-3', name: 'A3', toolType: 'claude-code' },
+			{ id: 'sess-4', name: 'A4', toolType: 'claude-code' },
+		];
+
+		const [reconstructed] = roundTrip(pipelines, sessions);
+
+		expect(reconstructed.nodes.filter((n) => n.type === 'agent')).toHaveLength(4);
+		expect(reconstructed.nodes.filter((n) => n.type === 'trigger')).toHaveLength(1);
+
+		// Walk the topology by following edges from the trigger and assert the
+		// agent visitation order. Edge prompts on chain edges intentionally
+		// land on the target agent's `inputPrompt` (chain subs emit the prompt
+		// at the SUB level, not the edge level — see yamlToPipeline.ts:1030),
+		// so we assert the per-agent sequence rather than per-edge.
+		const triggerNode = reconstructed.nodes.find((n) => n.type === 'trigger')!;
+		const visitedAgents: string[] = [];
+		let current: PipelineNode | undefined = triggerNode;
+		const seen = new Set<string>();
+		while (current && !seen.has(current.id)) {
+			seen.add(current.id);
+			const next = reconstructed.edges.find((e) => e.source === current!.id);
+			if (!next) break;
+			const target = reconstructed.nodes.find((n) => n.id === next.target);
+			if (!target) break;
+			if (target.type === 'agent') {
+				visitedAgents.push((target.data as AgentNodeData).sessionId);
+			}
+			current = target;
+		}
+		expect(visitedAgents).toEqual(['sess-1', 'sess-2', 'sess-3', 'sess-4']);
+	});
+
+	it('chain prompts on agent.inputPrompt round-trip onto the same field', () => {
+		// IMPORTANT: chain prompts in this model live on the TARGET agent's
+		// `inputPrompt` field, NOT on the edge between agents. `pipelineToYaml`
+		// only reads `edge.prompt` for trigger→agent edges (fan-out path);
+		// for chain (agent→agent) edges, it reads the target's `inputPrompt`.
+		// Setting `edge.prompt` on a chain edge silently drops the value.
+		// This test guards the supported path: input prompts on agent nodes.
+		const t1 = trigger('t1', 'time.heartbeat', { interval_minutes: 5 });
+		const a1 = agent('a1', 'sess-1', 'A1');
+		const a2: PipelineNode = {
+			...agent('a2', 'sess-2', 'A2'),
+			data: {
+				...(agent('a2', 'sess-2', 'A2').data as AgentNodeData),
+				inputPrompt: 'follow up with a2',
+			},
+		};
+
+		const pipelines = [
+			pipeline(
+				'Prompted',
+				'#06b6d4',
+				[t1, a1, a2],
+				[edge('e1', 't1', 'a1', { prompt: 'kick off' }), edge('e2', 'a1', 'a2')]
+			),
+		];
+		const sessions: PipelineSession[] = [
+			{ id: 'sess-1', name: 'A1', toolType: 'claude-code' },
+			{ id: 'sess-2', name: 'A2', toolType: 'claude-code' },
+		];
+
+		const [reconstructed] = roundTrip(pipelines, sessions);
+		const a2Node = reconstructed.nodes.find(
+			(n) => n.type === 'agent' && (n.data as AgentNodeData).sessionId === 'sess-2'
+		);
+		expect(a2Node).toBeDefined();
+		// The downstream agent's input prompt survives the round-trip. The
+		// reconstructor strips an auto-injected `{{CUE_SOURCE_OUTPUT}}\n\n`
+		// prefix; the user-typed body must remain.
+		expect((a2Node!.data as AgentNodeData).inputPrompt).toContain('follow up with a2');
+	});
+});
+
+// ─── Shape: trigger event configs round-trip exactly ─────────────────────────
+
+describe('round-trip: trigger event configs survive serialization', () => {
+	function getReconstructedTriggerConfig(
+		eventType: CueEventType,
+		config: TriggerNodeData['config']
+	): TriggerNodeData {
+		const t1 = trigger('t1', eventType, config);
+		const a1 = agent('a1', 'sess-a', 'Alpha');
+		const pipelines = [
+			pipeline('Trig', '#06b6d4', [t1, a1], [edge('e1', 't1', 'a1', { prompt: 'work' })]),
+		];
+		const sessions: PipelineSession[] = [{ id: 'sess-a', name: 'Alpha', toolType: 'claude-code' }];
+
+		const [reconstructed] = roundTrip(pipelines, sessions);
+		const triggerNode = reconstructed.nodes.find((n) => n.type === 'trigger')!;
+		return triggerNode.data as TriggerNodeData;
+	}
+
+	it('time.heartbeat preserves interval_minutes', () => {
+		const data = getReconstructedTriggerConfig('time.heartbeat', { interval_minutes: 17 });
+		expect(data.eventType).toBe('time.heartbeat');
+		expect(data.config.interval_minutes).toBe(17);
+	});
+
+	it('time.scheduled preserves schedule_times AND schedule_days', () => {
+		const data = getReconstructedTriggerConfig('time.scheduled', {
+			schedule_times: ['09:00', '17:30'],
+			schedule_days: ['mon', 'wed', 'fri'],
+		});
+		expect(data.eventType).toBe('time.scheduled');
+		expect(data.config.schedule_times).toEqual(['09:00', '17:30']);
+		expect(data.config.schedule_days).toEqual(['mon', 'wed', 'fri']);
+	});
+
+	it('file.changed preserves watch and filter', () => {
+		const data = getReconstructedTriggerConfig('file.changed', {
+			watch: 'src/**/*.ts',
+			filter: { extension: 'ts' },
+		});
+		expect(data.eventType).toBe('file.changed');
+		expect(data.config.watch).toBe('src/**/*.ts');
+		expect(data.config.filter).toEqual({ extension: 'ts' });
+	});
+
+	it('github.pull_request preserves repo and poll_minutes', () => {
+		const data = getReconstructedTriggerConfig('github.pull_request', {
+			repo: 'org/repo',
+			poll_minutes: 15,
+		});
+		expect(data.eventType).toBe('github.pull_request');
+		expect(data.config.repo).toBe('org/repo');
+		expect(data.config.poll_minutes).toBe(15);
+	});
+});
+
+// ─── Shape: double round-trip is a no-op (idempotence) ──────────────────────
+
+describe('round-trip: double round-trip is structurally idempotent', () => {
+	it('save → reload → save → reload produces the same structure as one round-trip', () => {
+		// Catches drift bugs where one round-trip succeeds but a second
+		// pass mutates fields (the kind of bug that only surfaces in the
+		// field as "save N times and pipeline starts diverging").
+		const t1 = trigger('t1', 'time.heartbeat', { interval_minutes: 5 });
+		const a1 = agent('a1', 'sess-a', 'Alpha');
+		const a2 = agent('a2', 'sess-b', 'Bravo');
+
+		const pipelines = [
+			pipeline(
+				'Idem',
+				'#06b6d4',
+				[t1, a1, a2],
+				[edge('e1', 't1', 'a1', { prompt: 'first' }), edge('e2', 'a1', 'a2', { prompt: 'second' })]
+			),
+		];
+		const sessions: PipelineSession[] = [
+			{ id: 'sess-a', name: 'Alpha', toolType: 'claude-code' },
+			{ id: 'sess-b', name: 'Bravo', toolType: 'claude-code' },
+		];
+
+		const r1 = roundTrip(pipelines, sessions);
+		const r2 = roundTrip(r1, sessions);
+
+		// Structural equality on (nodeCount, edgeCount, agent membership).
+		expect(r2).toHaveLength(r1.length);
+		const summarize = (ps: CuePipeline[]) =>
+			ps.map((p) => ({
+				name: p.name,
+				color: p.color,
+				agentSessionIds: p.nodes
+					.filter((n) => n.type === 'agent')
+					.map((n) => (n.data as AgentNodeData).sessionId)
+					.sort(),
+				edgeCount: p.edges.length,
+			}));
+		expect(summarize(r2)).toEqual(summarize(r1));
+	});
+});

--- a/src/__tests__/renderer/hooks/cue/usePipelineLayout.test.ts
+++ b/src/__tests__/renderer/hooks/cue/usePipelineLayout.test.ts
@@ -675,4 +675,183 @@ describe('usePipelineLayout', () => {
 			expect(result.current.pipelinesLoaded).toBe(true);
 		});
 	});
+
+	// Regression for f94108e7b: replaced an `restoreInFlightRef` boolean with a
+	// `latestRestoreIdRef` counter so a stale in-flight load whose await
+	// resolves AFTER a newer load has started cannot apply its result on top
+	// of the newer one. The boolean variant only checked "is one in flight?"
+	// — it could not distinguish "the same load that started" from "a newer
+	// one that fired during my await". When graphSessions changed mid-fetch,
+	// both callbacks would race to setPipelineState with different snapshots.
+	describe('request-id guard (regression: stale in-flight load must not overwrite newer one)', () => {
+		// Helper: returns a deferred-promise pair so the test controls when
+		// each loadPipelineLayout call resolves.
+		function makeDeferred<T>(): { promise: Promise<T>; resolve: (v: T) => void } {
+			let resolve!: (v: T) => void;
+			const promise = new Promise<T>((res) => {
+				resolve = res;
+			});
+			return { promise, resolve };
+		}
+
+		// loadPipelineLayout is called by THREE effects in this scenario:
+		//   1) the standalone writtenRoots-reseed effect (fires once on mount
+		//      with deps=[lastWrittenRootsRef])
+		//   2) the pipeline-restore effect (fires on mount with the initial
+		//      graphSessions)
+		//   3) the pipeline-restore effect AGAIN (fires on rerender when
+		//      graphSessions changes, before the previous load resolves).
+		// The race the fix guards against is between calls #2 and #3 — call
+		// #1 is irrelevant. This helper resolves call #1 immediately to null
+		// (writtenRoots ignores null) and gives back deferreds for calls #2/#3.
+		function setupLoadPipelineLayoutQueue() {
+			const stale = makeDeferred<unknown>();
+			const fresh = makeDeferred<unknown>();
+			let callCount = 0;
+			(window as any).maestro.cue.loadPipelineLayout = vi.fn().mockImplementation(() => {
+				callCount += 1;
+				if (callCount === 1) return Promise.resolve(null); // writtenRoots reseed
+				if (callCount === 2) return stale.promise; // first pipeline-restore (stale)
+				if (callCount === 3) return fresh.promise; // re-rendered pipeline-restore (fresh)
+				return Promise.resolve(null);
+			});
+			return { stale, fresh, getCallCount: () => callCount };
+		}
+
+		it('drops the stale load when graphSessions change and the first await resolves last', async () => {
+			// Two distinct live-pipeline snapshots — one per "before"/"after"
+			// graphSessions. graphSessionsToPipelines is the synchronous
+			// derive-from-graph function called at the top of loadLayout, so
+			// stubbing it to return distinct arrays per call lets us assert
+			// which snapshot won the race.
+			const stalePipelines = [makePipeline('stale')];
+			const freshPipelines = [makePipeline('fresh')];
+			mockGraphSessionsToPipelines.mockImplementation((graphSessions: any) => {
+				const ids = graphSessions.map((g: any) => g.sessionId).join(',');
+				return ids === 's1' ? (stalePipelines as any) : (freshPipelines as any);
+			});
+
+			const { stale, fresh } = setupLoadPipelineLayoutQueue();
+			const setPipelineState = vi.fn();
+
+			// Hoist refs that must be stable across renders. createDefaultParams
+			// allocates a fresh `lastWrittenRootsRef`/`savedStateRef` each call,
+			// which would trip the writtenRoots-reseed effect's dep array and
+			// fire an extra loadPipelineLayout on every rerender — defeating
+			// the whole point of the queue.
+			const lastWrittenRootsRef = { current: new Set<string>() };
+			const savedStateRef = { current: '' };
+			const setIsDirty = vi.fn();
+			const reactFlowInstance = createDefaultParams().reactFlowInstance;
+
+			// First render: graphSessions = [s1]. Pipeline-restore fires reqId=1
+			// and awaits the `stale` deferred.
+			let currentGraphSessions: ReturnType<typeof makeGraphSession>[] = [makeGraphSession('s1')];
+			const { rerender } = renderHook(() =>
+				usePipelineLayout({
+					reactFlowInstance,
+					graphSessions: currentGraphSessions,
+					sessions: [makeSessionInfo('s1')],
+					pipelineState: { pipelines: [], selectedPipelineId: null },
+					setPipelineState,
+					savedStateRef,
+					lastWrittenRootsRef,
+					setIsDirty,
+				})
+			);
+
+			// Re-render with new graphSessions BEFORE the first load resolves.
+			// Pipeline-restore effect re-runs reqId=2 and awaits the `fresh`
+			// deferred. latestRestoreIdRef is now 2; the stale callback at
+			// reqId=1 must bail when its await eventually resolves.
+			currentGraphSessions = [makeGraphSession('s2')];
+			rerender();
+
+			// Resolve the FRESH load first. Its reqId (2) still matches
+			// latestRestoreIdRef (2), so it applies state.
+			await act(async () => {
+				fresh.resolve(null);
+				await vi.advanceTimersByTimeAsync(0);
+			});
+			expect(setPipelineState).toHaveBeenCalledTimes(1);
+			expect(setPipelineState.mock.calls[0][0].pipelines).toEqual(freshPipelines);
+
+			// Now resolve the STALE load. Its reqId (1) !== latestRestoreIdRef
+			// (2), so the guard must bail. Without the fix, this call would
+			// land second and stomp the fresh state with the stale snapshot.
+			setPipelineState.mockClear();
+			await act(async () => {
+				stale.resolve(null);
+				await vi.advanceTimersByTimeAsync(0);
+			});
+			expect(setPipelineState).not.toHaveBeenCalled();
+		});
+
+		it('drops the stale load even when its await resolves first', async () => {
+			// Symmetric case: stale load resolves BEFORE the fresh one. Without
+			// the fix, the boolean `restoreInFlightRef` would let the stale
+			// callback set `hasRestoredLayoutRef = true`, and the fresh
+			// callback would then bail via that flag — leaving the user
+			// looking at stale data. The reqId guard correctly prefers the
+			// fresh result regardless of resolution order.
+			const stalePipelines = [makePipeline('stale')];
+			const freshPipelines = [makePipeline('fresh')];
+			mockGraphSessionsToPipelines.mockImplementation((graphSessions: any) => {
+				const ids = graphSessions.map((g: any) => g.sessionId).join(',');
+				return ids === 's1' ? (stalePipelines as any) : (freshPipelines as any);
+			});
+
+			const { stale, fresh, getCallCount } = setupLoadPipelineLayoutQueue();
+			const setPipelineState = vi.fn();
+
+			// Stable refs (see comment in the previous test).
+			const lastWrittenRootsRef = { current: new Set<string>() };
+			const savedStateRef = { current: '' };
+			const setIsDirty = vi.fn();
+			const reactFlowInstance = createDefaultParams().reactFlowInstance;
+
+			let currentGraphSessions: ReturnType<typeof makeGraphSession>[] = [makeGraphSession('s1')];
+			const { rerender } = renderHook(() =>
+				usePipelineLayout({
+					reactFlowInstance,
+					graphSessions: currentGraphSessions,
+					sessions: [makeSessionInfo('s1')],
+					pipelineState: { pipelines: [], selectedPipelineId: null },
+					setPipelineState,
+					savedStateRef,
+					lastWrittenRootsRef,
+					setIsDirty,
+				})
+			);
+
+			// Sanity: after the first render, exactly the writtenRoots reseed
+			// and the first pipeline-restore call have been issued.
+			expect(getCallCount()).toBe(2);
+			expect(setPipelineState).not.toHaveBeenCalled();
+
+			currentGraphSessions = [makeGraphSession('s2')];
+			rerender();
+
+			// After rerender the pipeline-restore effect re-fires; the third
+			// call is the fresh load awaiting `fresh.promise`.
+			expect(getCallCount()).toBe(3);
+			expect(setPipelineState).not.toHaveBeenCalled();
+
+			// Stale resolves first — its reqId (1) !== current (2), so it
+			// must bail and leave hasRestoredLayoutRef untouched.
+			await act(async () => {
+				stale.resolve(null);
+				await vi.advanceTimersByTimeAsync(0);
+			});
+			expect(setPipelineState).not.toHaveBeenCalled();
+
+			// Fresh resolves last — its reqId (2) matches and it applies state.
+			await act(async () => {
+				fresh.resolve(null);
+				await vi.advanceTimersByTimeAsync(0);
+			});
+			expect(setPipelineState).toHaveBeenCalledTimes(1);
+			expect(setPipelineState.mock.calls[0][0].pipelines).toEqual(freshPipelines);
+		});
+	});
 });

--- a/src/__tests__/renderer/hooks/useCue.test.ts
+++ b/src/__tests__/renderer/hooks/useCue.test.ts
@@ -299,6 +299,50 @@ describe('useCue', () => {
 			notifySpy.mockRestore();
 		});
 
+		// Regression for 42ac8333e: an earlier version of the toast title
+		// appended the raw `payload.queuedAt` ISO-8601 string in square
+		// brackets so that back-to-back drops produced distinct titles
+		// (instead of collapsing into a single visible toast). That leaked
+		// a wire-format timestamp into user-facing UI. The fix uses a
+		// localized clock + milliseconds suffix instead. Guard both the
+		// removal of the raw ISO and the presence of the new ms tag.
+		it('toast title uses localized time + ms (no raw ISO leak)', async () => {
+			let activityCallback: ((p: unknown) => void) | null = null;
+			mockOnActivityUpdate.mockImplementation((cb: (p: unknown) => void) => {
+				activityCallback = cb;
+				return mockUnsubscribe;
+			});
+			const notificationStore = await import('../../../renderer/stores/notificationStore');
+			const notifySpy = vi.spyOn(notificationStore, 'notifyToast').mockReturnValue(undefined);
+
+			await renderAndSettle();
+
+			// Pick an instant whose ISO form contains a recognizable substring
+			// we can grep for in the title — `2026-04-21T10:11:12.345Z`.
+			const queuedAt = Date.UTC(2026, 3, 21, 10, 11, 12, 345);
+			act(() => {
+				activityCallback?.({
+					type: 'queueOverflow',
+					sessionId: 's-1',
+					sessionName: 'Sess A',
+					subscriptionName: 'sub-x',
+					queuedAt,
+				});
+			});
+
+			expect(notifySpy).toHaveBeenCalledTimes(1);
+			const call = notifySpy.mock.calls[0][0] as { title: string };
+			// No raw ISO substrings — both the date prefix and the trailing
+			// "Z" leaked through square brackets in the original bug.
+			expect(call.title).not.toMatch(/2026-04-21T/);
+			expect(call.title).not.toMatch(/\[.*Z\]/);
+			// Milliseconds tag must be present so back-to-back drops within
+			// the same wall-clock second still produce distinct titles.
+			expect(call.title).toMatch(/\d+ms/);
+			expect(call.title).toContain('Sess A');
+			notifySpy.mockRestore();
+		});
+
 		it('does not fire a toast for runFinished payloads', async () => {
 			let activityCallback: ((p: unknown) => void) | null = null;
 			mockOnActivityUpdate.mockImplementation((cb: (p: unknown) => void) => {

--- a/src/renderer/components/CuePipelineEditor/CuePipelineEditor.tsx
+++ b/src/renderer/components/CuePipelineEditor/CuePipelineEditor.tsx
@@ -455,7 +455,7 @@ function CuePipelineEditorInner({
 				onTriggerPipeline={onTriggerPipeline}
 				isDirty={isDirty}
 				runningPipelineIds={runningPipelineIds}
-				isLoading={graphLoading || !pipelinesLoaded}
+				isLoading={graphLoading || (graphSessions.length > 0 && !pipelinesLoaded)}
 				interactionMode={interactionMode}
 				setInteractionMode={setInteractionMode}
 			/>


### PR DESCRIPTION
## Summary

Fixes the bug where the Cue pipeline editor showed a spinner forever instead of the "Create your first pipeline" CTA when no Cue subscriptions were registered. Bundles regression coverage for five recent fixes that shipped without tests, plus a round-trip harness for the pipeline ↔ YAML serialization path.

## The bug fix

`useCueGraphData` returns `[]` when no agent has Cue subscriptions and flips `graphInitialLoading` to `false`. But `usePipelineLayout`'s restore effect early-returns on empty `graphSessions` and never marks `pipelinesLoaded=true`. The editor's `graphLoading || !pipelinesLoaded` gate then evaluated to `false || true === true`, so the spinner never went away.

One-line fix at the parent boundary: gate `!pipelinesLoaded` behind `graphSessions.length > 0` so an empty fetch result correctly drops to the CTA.

```diff
- isLoading={graphLoading || !pipelinesLoaded}
+ isLoading={graphLoading || (graphSessions.length > 0 && !pipelinesLoaded)}
```

The `usePipelineLayout` hook's semantics and existing tests stay untouched — the integration logic lives where both signals are available.

## Why the broader test additions

Recent Cue branch history is ~53% bugfix commits. The pattern: most bugs sit at integration boundaries (data round-trips, multi-pipeline state, race conditions) — places unit tests don't cover. This PR closes the highest-value gaps:

**Regression tests for five recent fixes that shipped without coverage:**

| Fix | Bug shape | New tests |
| --- | --- | --- |
| `42ac8333e` | Tab-switch must clear `pendingPipelineId`; toast title leaked raw ISO | 3 |
| `96a87a19c` | Agent panel header missing instance suffix when sessionId shared | 4 |
| `f94108e7b` | `usePipelineLayout` race when `graphSessions` change mid-fetch | 2 |
| `30ab9a5c4` | Fan-in tracker dropped chainDepth, breaking depth guard on cycles | 3 |
| `d85290c51` | `calculateNextScheduledTime` returned `null` for same-day-next-week | 2 |

**Round-trip harness (`pipelineRoundTrip.shapes.test.ts`):**

Mirrors the runtime's `pipelinesToYaml → yaml.load → subscriptionsToPipelines` cycle, including the normalizer's prompt-file inlining (handles both `prompt_file` and `fan_out_prompt_files`). 10 tests covering trigger fan-out, multi-agent chains, every trigger event config (heartbeat / scheduled / file.changed / github.pull_request), and double-round-trip idempotence.

While building it I uncovered two design facts now documented inline so future readers don't waste time on the same dead-ends:

- Edge `mode` (autorun / debate) is YAML-comment-only by design (`getEdgeModeComment`) and recovered from the layout sidecar, not the YAML body
- Chain prompts canonically live on `agent.inputPrompt`, not on the chain edge — `pipelineToYaml` only reads `edge.prompt` for trigger→agent edges

## Honest scope note

These are bounded regression guards anchored to specific fixes — they catch reverts of the corresponding code, not novel bug paths. The round-trip harness is the most generalizable: any future field-loss in the YAML serialization path will fail it.

The 5-pick list deliberately skipped `89833d325` (scheduledFiredKeys session scoping) because the registry refactor makes the bug structurally impossible — re-introducing it would require an API change that existing tests already block.

## Stats

- **2 commits:** the fix (with its 6-test regression file) is committable on its own; the broader test additions are a separate commit so they can be reverted independently
- **30 new tests** across 8 files
- **Cue suite:** 2,164 tests / 116 files passing, typecheck clean

## Test plan

- Open Cue modal on a project with no Cue subscriptions → "Create your first pipeline" CTA renders (no spinner)
- Open Cue modal on a project with existing pipelines → editor renders normally, no flash of CTA
- During the initial graph fetch the spinner still shows (confirm `graphLoading=true` path unchanged)
- `npm run test -- --run src/__tests__/main/cue src/__tests__/renderer/components/CuePipelineEditor src/__tests__/renderer/hooks/cue src/__tests__/renderer/components/CueModal.test.tsx src/__tests__/renderer/hooks/useCue.test.ts src/__tests__/shared/cue` passes
- `npx tsc --noEmit` clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the pipeline editor's loading indicator to clear properly when viewing empty graphs, preventing an indefinite loading state when a pipeline contains no sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->