### PR TITLE
feat: detect local git metadata during remote session creation

### DIFF
--- a/src/renderer/hooks/remote/useAppRemoteEventListeners.ts
+++ b/src/renderer/hooks/remote/useAppRemoteEventListeners.ts
@@ -497,6 +497,8 @@ export function useAppRemoteEventListeners(deps: UseAppRemoteEventListenersDeps)
 			// Probe git repo state for the cwd so the header badge shows the branch
 			// instead of "LOCAL". Mirrors the GUI's useSessionCrud flow. For SSH
 			// sessions, defer the check until onSshRemote fires (see useAgentListeners).
+			// gitService methods route through createIpcMethod with a defaultValue,
+			// so they swallow IPC errors (and report to Sentry) rather than throwing.
 			const sshConfig = config?.sessionSshRemoteConfig as
 				| { enabled?: boolean; remoteId?: string | null }
 				| undefined;
@@ -506,17 +508,13 @@ export function useAppRemoteEventListeners(deps: UseAppRemoteEventListenersDeps)
 			let gitTags: string[] | undefined;
 			let gitRefsCacheTime: number | undefined;
 			if (!isRemoteSession) {
-				try {
-					isGitRepo = await gitService.isRepo(cwd);
-					if (isGitRepo) {
-						[gitBranches, gitTags] = await Promise.all([
-							gitService.getBranches(cwd),
-							gitService.getTags(cwd),
-						]);
-						gitRefsCacheTime = Date.now();
-					}
-				} catch (err) {
-					logger.error('[Remote] git probe failed during session create', undefined, err);
+				isGitRepo = await gitService.isRepo(cwd);
+				if (isGitRepo) {
+					[gitBranches, gitTags] = await Promise.all([
+						gitService.getBranches(cwd),
+						gitService.getTags(cwd),
+					]);
+					gitRefsCacheTime = Date.now();
 				}
 			}
 

--- a/src/renderer/hooks/remote/useAppRemoteEventListeners.ts
+++ b/src/renderer/hooks/remote/useAppRemoteEventListeners.ts
@@ -22,6 +22,7 @@ import {
 import type { Session, AITab, ToolType, Group, BatchRunConfig, BrowserTab } from '../../types';
 import { logger } from '../../utils/logger';
 import { DEFAULT_BATCH_PROMPT } from '../batch/batchUtils';
+import { gitService } from '../../services/git';
 
 // ============================================================================
 // Dependencies interface
@@ -493,6 +494,32 @@ export function useAppRemoteEventListeners(deps: UseAppRemoteEventListenersDeps)
 				showThinking: currentDefaults.defaultShowThinking,
 			};
 
+			// Probe git repo state for the cwd so the header badge shows the branch
+			// instead of "LOCAL". Mirrors the GUI's useSessionCrud flow. For SSH
+			// sessions, defer the check until onSshRemote fires (see useAgentListeners).
+			const sshConfig = config?.sessionSshRemoteConfig as
+				| { enabled?: boolean; remoteId?: string | null }
+				| undefined;
+			const isRemoteSession = !!(sshConfig?.enabled && sshConfig.remoteId);
+			let isGitRepo = false;
+			let gitBranches: string[] | undefined;
+			let gitTags: string[] | undefined;
+			let gitRefsCacheTime: number | undefined;
+			if (!isRemoteSession) {
+				try {
+					isGitRepo = await gitService.isRepo(cwd);
+					if (isGitRepo) {
+						[gitBranches, gitTags] = await Promise.all([
+							gitService.getBranches(cwd),
+							gitService.getTags(cwd),
+						]);
+						gitRefsCacheTime = Date.now();
+					}
+				} catch (err) {
+					logger.error('[Remote] git probe failed during session create', undefined, err);
+				}
+			}
+
 			const newSession: Session = {
 				id: newId,
 				name,
@@ -502,7 +529,10 @@ export function useAppRemoteEventListeners(deps: UseAppRemoteEventListenersDeps)
 				cwd,
 				fullPath: cwd,
 				projectRoot: cwd,
-				isGitRepo: false,
+				isGitRepo,
+				...(gitBranches !== undefined && { gitBranches }),
+				...(gitTags !== undefined && { gitTags }),
+				...(gitRefsCacheTime !== undefined && { gitRefsCacheTime }),
 				aiLogs: [],
 				shellLogs: [
 					{


### PR DESCRIPTION
- Probe local cwd git state before session creation
- Populate session branch and tag metadata when available
- Preserve SSH git detection for remote listener flow
- Log git probe failures without blocking session creation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sessions now auto-detect whether the workspace is a Git repository during creation.
  * For detected repos, branches and tags are fetched concurrently and cached with a timestamp.
  * Git checks are skipped for SSH-designated remote sessions.
  * Git probing is non-blocking—session creation proceeds even if repository metadata can't be obtained.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->