### PR TITLE
Dashboard enhancements: worktree analytics, agent overview, drill-down filter, polish

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -113,7 +113,7 @@ The major contributions to 0.14.x remain:
 - Leaderboard tracking now works across multiple systems and syncs level from cloud 🏆
 - Agent duplication. Pro tip: Consider a group of unused "Template" agents ✌️
 - New setting to prevent system from going to sleep while agents are active 🛏️
-- The tab menu has a new "Publish as GitHub Gist" option  📝
+- The tab menu has a new "Publish as GitHub Gist" option 📝
 - The tab menu has options to move the tab to the first or last position 🔀
 - [Maestro-Playbooks](https://github.com/pedramamini/Maestro-Playbooks) can now contain non-markdown assets 📙
 - Improved default shell detection 🐚
@@ -142,10 +142,12 @@ Thanks for the contributions: @t1mmen @aejfager @Crumbgrabber @whglaser @b3nw @d
 - TAKE TWO! Fixed Linux ARM64 build architecture contamination issues 🏗️
 
 ### v0.13.1 Changes
+
 - Fixed Linux ARM64 build architecture contamination issues 🏗️
 - Enhanced error handling for Auto Run batch processing 🚨
 
 ### v0.13.0 Changes
+
 - Added a global usage dashboard, data collection begins with this install 🎛️
 - Added a Playbook Exchange for downloading pre-defined Auto Run playbooks from [Maestro-Playbooks](https://github.com/pedramamini/Maestro-Playbooks) 📕
 - Bundled OpenSpec commands for structured change proposals 📝
@@ -169,15 +171,19 @@ Thanks for the contributions: @t1mmen @aejfager @Crumbgrabber @whglaser @b3nw @d
 The big changes in the v0.12.x line are the following three:
 
 ## Show Thinking
-🤔 There is now a toggle to show thinking for the agent, the default for new tabs is off, though this can be changed under Settings > General. The toggle shows next to History and Read-Only. Very similar pattern. This has been the #1 most requested feature, though personally, I don't think I'll use it as I prefer to not see the details of the work, but the results of the work. Just as we work with our colleagues. 
+
+🤔 There is now a toggle to show thinking for the agent, the default for new tabs is off, though this can be changed under Settings > General. The toggle shows next to History and Read-Only. Very similar pattern. This has been the #1 most requested feature, though personally, I don't think I'll use it as I prefer to not see the details of the work, but the results of the work. Just as we work with our colleagues.
 
 ## GitHub Spec-Kit Integration
+
 🎯 Added [GitHub Spec-Kit](https://github.com/github/spec-kit) commands into Maestro with a built in updater to grab the latest prompts from the repository. We do override `/speckit-implement` (the final step) to create Auto Run docs and guide the user through their execution, which thanks to Wortrees from v0.11.x allows us to run in parallel!
 
 ## Context Management Tools
+
 📖 Added context management options from tab right-click menu. You can now compress, merge, and transfer contexts between agents. You will received (configurable) warnings at 60% and 80% context consumption with a hint to compact.
 
 ## Changes Specific to v0.12.3:
+
 - We now have hosted documentation through Mintlify 📚
 - Export any tab conversation as self-contained themed HTML file 📄
 - Publish files as private/public Gists 🌐
@@ -290,6 +296,7 @@ The big changes in the v0.12.x line are the following three:
 Minor bugfixes on top of v0.7.3:
 
 # Onboarding, Wizard, and Tours
+
 - Implemented comprehensive onboarding wizard with integrated tour system 🚀
 - Added project-understanding confidence display to wizard UI 🎨
 - Enhanced keyboard navigation across all wizard screens ⌨️
@@ -297,6 +304,7 @@ Minor bugfixes on top of v0.7.3:
 - Added First Run Celebration modal with confetti animation 🎉
 
 # UI / UX Enhancements
+
 - Added expand-to-fullscreen button for Auto Run interface 🖥️
 - Created dedicated modal component and improved modal priority constants for expanded Auto Run view 📐
 - Enhanced user experience with fullscreen editing capabilities ✨
@@ -306,15 +314,18 @@ Minor bugfixes on top of v0.7.3:
 - Enhanced toast context with agent name for OS notifications 📢
 
 # Auto Run Workflow Improvements
+
 - Created phase document generation for Auto Run workflow 📄
 - Added real-time log streaming to the LogViewer component 📊
 
 # Application Behavior / Core Fixes
+
 - Added validation to prevent nested worktrees inside the main repository 🚫
 - Fixed process manager to properly emit exit events on errors 🔧
 - Fixed process exit handling to ensure proper cleanup 🧹
 
 # Update System
+
 - Implemented automatic update checking on application startup 🚀
 - Added settings toggle for enabling/disabling startup update checks ⚙️
 
@@ -332,6 +343,7 @@ Minor bugfixes on top of v0.7.3:
 **Latest: v0.6.1** | Released December 4, 2025
 
 In this release...
+
 - Added recursive subfolder support for Auto Run markdown files 🗂️
 - Enhanced document tree display with expandable folder navigation 🌳
 - Enabled creating documents in subfolders with path selection 📁
@@ -344,6 +356,7 @@ In this release...
 - Added support for nested folder structures in document management 🏗️
 
 Plus the pre-release ALPHA...
+
 - Template vars now set context in default autorun prompt 🚀
 - Added Enter key support for queued message confirmation dialog ⌨️
 - Kill process capability added to System Process Monitor 💀
@@ -503,6 +516,7 @@ Plus the pre-release ALPHA...
 All releases are available on the [GitHub Releases page](https://github.com/RunMaestro/Maestro/releases).
 
 Maestro is available for:
+
 - **macOS** - Apple Silicon (arm64) and Intel (x64)
 - **Windows** - x64
 - **Linux** - x64 and arm64, AppImage, deb, and rpm packages

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -13,6 +13,36 @@ Maestro can update itself automatically! This feature was introduced in **v0.8.7
 
 ---
 
+## v0.16.x - Maestro Cue
+
+**Latest: v0.16.16** | Released April 28, 2026
+
+# Major 0.16.x Additions
+
+🪄 **Maestro Cue** is a new trigger-based cross-agent orchestration capability. Heartbeats, GitHub issues/PRs, file system monitors, and other data sources can bring your agents to life and pass work between one another.
+
+💻 **Major Shell Upgrade** — Full-featured xterm.js terminal tabs alongside your existing AI and file preview tabs. Open multiple terminals and rename them freely.
+
+🧑‍✈️ GitHub Copilot-CLI — Copilot-CLI joins Maestro as a first-class agent with end-to-end integration for both local and remote (over SSH).
+
+🌐 **Web UX Parity** — The web/mobile interface now supports real PTY terminals, swipeable panels, notification dropdowns, and dozens of desktop-equivalent features. Full touch-friendly experience on tablets and phones.
+
+🔗 **SSH Shared History** — History synchronization across multiple Maestro instances working on the same project via SSH. Each host writes per-hostname JSONL files to `.maestro/history/` on the remote, so all participants see each other's work.
+
+🌍 **Browser Tabs** — Open web pages directly inside Maestro as first-class tabs alongside AI, terminal, and file preview tabs. Full address bar, navigation controls, session persistence across restarts, and bulk close support. Great for referencing docs, dashboards, or web UIs without leaving the workspace.
+
+## Changes in v0.16.16-RC
+
+MAJOR: Bugfix in Tab Renaming
+
+- XTerminal now auto-copies settled text selections to your clipboard so highlight-to-copy "just works" 📋
+- Create Worktree modal lets you type partial branch suffixes — trailing `/`, `.`, and `-` are preserved while editing ✍️
+- Branch name sanitization only trims truly invalid ref endings, so valid trailing hyphens stick around 🏷️
+- Rename Tab "Auto" tooltip now formats meta keys correctly across platforms via renderer-safe shortcut formatting ⌨️
+- Added test coverage for the XTerminal auto-copy flow, branch sanitizer rules, and tooltip key formatting 🧪
+
+---
+
 ## v0.15.x - Maestro Symphony
 
 **Latest: v0.15.3** | Released April 5, 2026

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "maestro",
-	"version": "0.15.3",
+	"version": "0.16.16-RC",
 	"description": "Maestro hones fractured attention into focused intent.",
 	"main": "dist/main/index.js",
 	"author": {

--- a/src/__tests__/main/history-manager.test.ts
+++ b/src/__tests__/main/history-manager.test.ts
@@ -1170,7 +1170,7 @@ describe('HistoryManager', () => {
 	// ----------------------------------------------------------------
 	describe('startWatching() / stopWatching()', () => {
 		it('should start watching history directory for changes', () => {
-			const mockWatcher = { close: vi.fn() } as unknown as fs.FSWatcher;
+			const mockWatcher = { close: vi.fn(), on: vi.fn() } as unknown as fs.FSWatcher;
 			mockWatch.mockReturnValue(mockWatcher);
 			mockExistsSync.mockReturnValue(true);
 
@@ -1184,7 +1184,7 @@ describe('HistoryManager', () => {
 		});
 
 		it('should create directory if it does not exist before watching', () => {
-			const mockWatcher = { close: vi.fn() } as unknown as fs.FSWatcher;
+			const mockWatcher = { close: vi.fn(), on: vi.fn() } as unknown as fs.FSWatcher;
 			mockWatch.mockReturnValue(mockWatcher);
 			mockExistsSync.mockReturnValue(false);
 
@@ -1196,7 +1196,7 @@ describe('HistoryManager', () => {
 		});
 
 		it('should invoke callback when a .json file changes', () => {
-			const mockWatcher = { close: vi.fn() } as unknown as fs.FSWatcher;
+			const mockWatcher = { close: vi.fn(), on: vi.fn() } as unknown as fs.FSWatcher;
 			let watchCallback: (event: string, filename: string | null) => void = () => {};
 			mockWatch.mockImplementation((_dir: string, cb: unknown) => {
 				watchCallback = cb as (event: string, filename: string | null) => void;
@@ -1214,7 +1214,7 @@ describe('HistoryManager', () => {
 		});
 
 		it('should not invoke callback for non-json files', () => {
-			const mockWatcher = { close: vi.fn() } as unknown as fs.FSWatcher;
+			const mockWatcher = { close: vi.fn(), on: vi.fn() } as unknown as fs.FSWatcher;
 			let watchCallback: (event: string, filename: string | null) => void = () => {};
 			mockWatch.mockImplementation((_dir: string, cb: unknown) => {
 				watchCallback = cb as (event: string, filename: string | null) => void;
@@ -1230,7 +1230,7 @@ describe('HistoryManager', () => {
 		});
 
 		it('should not invoke callback when filename is null', () => {
-			const mockWatcher = { close: vi.fn() } as unknown as fs.FSWatcher;
+			const mockWatcher = { close: vi.fn(), on: vi.fn() } as unknown as fs.FSWatcher;
 			let watchCallback: (event: string, filename: string | null) => void = () => {};
 			mockWatch.mockImplementation((_dir: string, cb: unknown) => {
 				watchCallback = cb as (event: string, filename: string | null) => void;
@@ -1246,7 +1246,7 @@ describe('HistoryManager', () => {
 		});
 
 		it('should not start watching again if already watching', () => {
-			const mockWatcher = { close: vi.fn() } as unknown as fs.FSWatcher;
+			const mockWatcher = { close: vi.fn(), on: vi.fn() } as unknown as fs.FSWatcher;
 			mockWatch.mockReturnValue(mockWatcher);
 			mockExistsSync.mockReturnValue(true);
 
@@ -1257,7 +1257,7 @@ describe('HistoryManager', () => {
 		});
 
 		it('should stop watching and close watcher', () => {
-			const mockWatcher = { close: vi.fn() } as unknown as fs.FSWatcher;
+			const mockWatcher = { close: vi.fn(), on: vi.fn() } as unknown as fs.FSWatcher;
 			mockWatch.mockReturnValue(mockWatcher);
 			mockExistsSync.mockReturnValue(true);
 
@@ -1268,8 +1268,8 @@ describe('HistoryManager', () => {
 		});
 
 		it('should allow re-watching after stop', () => {
-			const mockWatcher1 = { close: vi.fn() } as unknown as fs.FSWatcher;
-			const mockWatcher2 = { close: vi.fn() } as unknown as fs.FSWatcher;
+			const mockWatcher1 = { close: vi.fn(), on: vi.fn() } as unknown as fs.FSWatcher;
+			const mockWatcher2 = { close: vi.fn(), on: vi.fn() } as unknown as fs.FSWatcher;
 			mockWatch.mockReturnValueOnce(mockWatcher1).mockReturnValueOnce(mockWatcher2);
 			mockExistsSync.mockReturnValue(true);
 
@@ -1283,6 +1283,30 @@ describe('HistoryManager', () => {
 		it('should be safe to call stopWatching when not watching', () => {
 			// Should not throw
 			expect(() => manager.stopWatching()).not.toThrow();
+		});
+
+		it('should register an error handler on the watcher to prevent unhandled rejections', () => {
+			const onSpy = vi.fn();
+			const mockWatcher = { close: vi.fn(), on: onSpy } as unknown as fs.FSWatcher;
+			mockWatch.mockReturnValue(mockWatcher);
+			mockExistsSync.mockReturnValue(true);
+
+			manager.startWatching(vi.fn());
+
+			expect(onSpy).toHaveBeenCalledWith('error', expect.any(Function));
+		});
+
+		it('should log and not throw if fs.watch itself throws', () => {
+			mockWatch.mockImplementation(() => {
+				throw new Error('EBUSY: resource busy');
+			});
+			mockExistsSync.mockReturnValue(true);
+
+			expect(() => manager.startWatching(vi.fn())).not.toThrow();
+			expect(logger.warn).toHaveBeenCalledWith(
+				expect.stringContaining('Failed to start history watcher'),
+				expect.any(String)
+			);
 		});
 	});
 

--- a/src/__tests__/main/ipc/handlers/git.test.ts
+++ b/src/__tests__/main/ipc/handlers/git.test.ts
@@ -3978,7 +3978,7 @@ branch refs/heads/bugfix-123
 
 			expect(mockFs.access).toHaveBeenCalledWith('/parent/worktrees');
 			expect(mockChokidar.watch).toHaveBeenCalledWith('/parent/worktrees', {
-				ignored: /(^|[/\\])\../,
+				ignored: [/(^|[/\\])\../, expect.any(RegExp)],
 				persistent: true,
 				ignoreInitial: true,
 				depth: 0,

--- a/src/__tests__/main/stats/aggregations.test.ts
+++ b/src/__tests__/main/stats/aggregations.test.ts
@@ -1368,6 +1368,109 @@ describe('Aggregation queries return correct calculations', () => {
 			expect(stats.byDay[1].date).toBe('2024-01-01');
 		});
 	});
+
+	describe('byWorktreeStatus breakdown calculations', () => {
+		it('should return correct worktree vs parent counts and durations', async () => {
+			mockStatement.get.mockReturnValue({ count: 100, total_duration: 500000 });
+			// queryByWorktreeStatus is the 10th .all call in getAggregatedStats; populate
+			// the prior 9 with empty arrays so we can isolate the worktree assertion.
+			mockStatement.all
+				.mockReturnValueOnce([]) // 1: byAgent
+				.mockReturnValueOnce([]) // 2: bySource
+				.mockReturnValueOnce([]) // 3: byLocation
+				.mockReturnValueOnce([]) // 4: byDay
+				.mockReturnValueOnce([]) // 5: byAgentByDay
+				.mockReturnValueOnce([]) // 6: byHour
+				.mockReturnValueOnce([]) // 7: sessionsByAgent (from querySessionStats)
+				.mockReturnValueOnce([]) // 8: sessionsByDay (from querySessionStats)
+				.mockReturnValueOnce([]) // 9: bySessionByDay
+				.mockReturnValueOnce([
+					{ is_worktree: 0, count: 70, duration: 350000 },
+					{ is_worktree: 1, count: 30, duration: 150000 },
+				]); // 10: byWorktreeStatus
+
+			const { StatsDB } = await import('../../../main/stats');
+			const db = new StatsDB();
+			db.initialize();
+
+			const stats = db.getAggregatedStats('week');
+
+			expect(stats.worktreeQueries).toBe(30);
+			expect(stats.parentQueries).toBe(70);
+			expect(stats.byWorktreeStatus).toEqual({
+				worktree: { count: 30, duration: 150000 },
+				parent: { count: 70, duration: 350000 },
+			});
+		});
+
+		it('should default to zeros when no rows exist', async () => {
+			mockStatement.get.mockReturnValue({ count: 0, total_duration: 0 });
+			mockStatement.all.mockReturnValue([]);
+
+			const { StatsDB } = await import('../../../main/stats');
+			const db = new StatsDB();
+			db.initialize();
+
+			const stats = db.getAggregatedStats('day');
+
+			expect(stats.worktreeQueries).toBe(0);
+			expect(stats.parentQueries).toBe(0);
+			expect(stats.byWorktreeStatus).toEqual({
+				worktree: { count: 0, duration: 0 },
+				parent: { count: 0, duration: 0 },
+			});
+		});
+
+		it('should treat NULL is_worktree (legacy rows) as parent via COALESCE', async () => {
+			// SQL's COALESCE(is_worktree, 0) collapses NULL to 0 before grouping, so the
+			// driver only sees a single 0-bucket row even when legacy NULL rows are present.
+			mockStatement.get.mockReturnValue({ count: 50, total_duration: 250000 });
+			mockStatement.all
+				.mockReturnValueOnce([]) // 1: byAgent
+				.mockReturnValueOnce([]) // 2: bySource
+				.mockReturnValueOnce([]) // 3: byLocation
+				.mockReturnValueOnce([]) // 4: byDay
+				.mockReturnValueOnce([]) // 5: byAgentByDay
+				.mockReturnValueOnce([]) // 6: byHour
+				.mockReturnValueOnce([]) // 7: sessionsByAgent
+				.mockReturnValueOnce([]) // 8: sessionsByDay
+				.mockReturnValueOnce([]) // 9: bySessionByDay
+				.mockReturnValueOnce([{ is_worktree: 0, count: 50, duration: 250000 }]); // 10
+
+			const { StatsDB } = await import('../../../main/stats');
+			const db = new StatsDB();
+			db.initialize();
+
+			const stats = db.getAggregatedStats('all');
+
+			expect(stats.parentQueries).toBe(50);
+			expect(stats.worktreeQueries).toBe(0);
+			expect(stats.byWorktreeStatus.parent).toEqual({ count: 50, duration: 250000 });
+			expect(stats.byWorktreeStatus.worktree).toEqual({ count: 0, duration: 0 });
+		});
+
+		it('should use COALESCE(is_worktree, 0) in the SQL query', async () => {
+			mockStatement.get.mockReturnValue({ count: 0, total_duration: 0 });
+			mockStatement.all.mockReturnValue([]);
+
+			const { StatsDB } = await import('../../../main/stats');
+			const db = new StatsDB();
+			db.initialize();
+
+			db.getAggregatedStats('week');
+
+			const prepareCalls = mockDb.prepare.mock.calls;
+			const worktreeCall = prepareCalls.find((call) =>
+				(call[0] as string).includes('COALESCE(is_worktree, 0)')
+			);
+
+			expect(worktreeCall).toBeDefined();
+			expect(worktreeCall![0]).toContain('GROUP BY COALESCE(is_worktree, 0)');
+			expect(worktreeCall![0]).toContain('FROM query_events');
+			// Ensures duration is summed alongside the count for the activity-split bar
+			expect(worktreeCall![0]).toContain('SUM(duration)');
+		});
+	});
 });
 
 /**

--- a/src/__tests__/main/stats/paths.test.ts
+++ b/src/__tests__/main/stats/paths.test.ts
@@ -720,7 +720,7 @@ describe('File path normalization in database (forward slashes consistently)', (
 			});
 
 			// Verify that the statement was called with normalized path
-			// insertQueryEvent now has 9 parameters: id, sessionId, agentType, source, startTime, duration, projectPath, tabId, isRemote
+			// insertQueryEvent now has 10 parameters: id, sessionId, agentType, source, startTime, duration, projectPath, tabId, isRemote, isWorktree
 			expect(mockStatement.run).toHaveBeenCalledWith(
 				expect.any(String), // id
 				'session-1',
@@ -730,7 +730,8 @@ describe('File path normalization in database (forward slashes consistently)', (
 				5000,
 				'C:/Users/TestUser/Projects/MyApp', // normalized path
 				'tab-1',
-				null // isRemote (undefined → null)
+				null, // isRemote (undefined → null)
+				null // isWorktree (undefined → null)
 			);
 		});
 
@@ -749,7 +750,7 @@ describe('File path normalization in database (forward slashes consistently)', (
 				tabId: 'tab-1',
 			});
 
-			// insertQueryEvent now has 9 parameters including isRemote
+			// insertQueryEvent now has 10 parameters including isRemote and isWorktree
 			expect(mockStatement.run).toHaveBeenCalledWith(
 				expect.any(String),
 				'session-1',
@@ -759,7 +760,8 @@ describe('File path normalization in database (forward slashes consistently)', (
 				5000,
 				'/Users/testuser/Projects/MyApp', // unchanged
 				'tab-1',
-				null // isRemote (undefined → null)
+				null, // isRemote (undefined → null)
+				null // isWorktree (undefined → null)
 			);
 		});
 
@@ -777,7 +779,7 @@ describe('File path normalization in database (forward slashes consistently)', (
 				// projectPath is undefined
 			});
 
-			// insertQueryEvent now has 9 parameters including isRemote
+			// insertQueryEvent now has 10 parameters including isRemote and isWorktree
 			expect(mockStatement.run).toHaveBeenCalledWith(
 				expect.any(String),
 				'session-1',
@@ -787,7 +789,8 @@ describe('File path normalization in database (forward slashes consistently)', (
 				5000,
 				null, // undefined becomes null
 				null, // tabId undefined → null
-				null // isRemote undefined → null
+				null, // isRemote undefined → null
+				null // isWorktree undefined → null
 			);
 		});
 	});

--- a/src/__tests__/main/stats/query-events.test.ts
+++ b/src/__tests__/main/stats/query-events.test.ts
@@ -279,7 +279,7 @@ describe('Stats aggregation and filtering', () => {
 
 			// Should only contain headers
 			expect(csv).toBe(
-				'id,sessionId,agentType,source,startTime,duration,projectPath,tabId,isRemote'
+				'id,sessionId,agentType,source,startTime,duration,projectPath,tabId,isRemote,isWorktree'
 			);
 		});
 	});

--- a/src/__tests__/main/stats/stats-db.test.ts
+++ b/src/__tests__/main/stats/stats-db.test.ts
@@ -284,13 +284,13 @@ describe('StatsDB class (mocked)', () => {
 			const db = new StatsDB();
 			db.initialize();
 
-			// Currently we have version 4 migration (v1: initial schema, v2: is_remote column, v3: session_lifecycle table, v4: compound indexes)
-			expect(db.getTargetVersion()).toBe(4);
+			// Currently we have version 5 migrations (v1: initial schema, v2: is_remote column, v3: session_lifecycle table, v4: compound indexes, v5: is_worktree column)
+			expect(db.getTargetVersion()).toBe(5);
 		});
 
 		it('should return false from hasPendingMigrations() when up to date', async () => {
 			mockDb.pragma.mockImplementation((sql: string) => {
-				if (sql === 'user_version') return [{ user_version: 4 }];
+				if (sql === 'user_version') return [{ user_version: 5 }];
 				return undefined;
 			});
 
@@ -305,8 +305,8 @@ describe('StatsDB class (mocked)', () => {
 			// This test verifies the hasPendingMigrations() logic
 			// by checking current version < target version
 
-			// Simulate a database that's already at version 4 (target version)
-			let currentVersion = 4;
+			// Simulate a database that's already at version 5 (target version)
+			let currentVersion = 5;
 			mockDb.pragma.mockImplementation((sql: string) => {
 				if (sql === 'user_version') return [{ user_version: currentVersion }];
 				// Handle version updates from migration
@@ -320,9 +320,9 @@ describe('StatsDB class (mocked)', () => {
 			const db = new StatsDB();
 			db.initialize();
 
-			// At version 4, target is 4, so no pending migrations
-			expect(db.getCurrentVersion()).toBe(4);
-			expect(db.getTargetVersion()).toBe(4);
+			// At version 5, target is 5, so no pending migrations
+			expect(db.getCurrentVersion()).toBe(5);
+			expect(db.getTargetVersion()).toBe(5);
 			expect(db.hasPendingMigrations()).toBe(false);
 		});
 

--- a/src/__tests__/renderer/components/SessionList.test.tsx
+++ b/src/__tests__/renderer/components/SessionList.test.tsx
@@ -1221,7 +1221,16 @@ describe('SessionList', () => {
 		});
 
 		it('shows busy status with pulse animation', () => {
-			const sessions = [createMockSession({ id: 's1', name: 'Busy Session', state: 'busy' })];
+			// Claude sessions without an agentSessionId render a static "no active Claude session"
+			// indicator regardless of state — provide one so the busy animation is exercised.
+			const sessions = [
+				createMockSession({
+					id: 's1',
+					name: 'Busy Session',
+					state: 'busy',
+					agentSessionId: 'agent-session-1',
+				}),
+			];
 			useSessionStore.setState({ sessions: sessions });
 			useUIStore.setState({ leftSidebarOpen: true });
 			const props = createDefaultProps({
@@ -1229,8 +1238,8 @@ describe('SessionList', () => {
 			});
 			const { container } = render(<SessionList {...props} />);
 
-			// Look for animate-pulse class on status indicator
-			const pulsingElements = container.querySelectorAll('.animate-pulse');
+			// Busy state renders an animate-ping ring behind the status dot
+			const pulsingElements = container.querySelectorAll('.animate-ping');
 			expect(pulsingElements.length).toBeGreaterThan(0);
 		});
 

--- a/src/__tests__/renderer/components/UsageDashboard/AgentComparisonChart.test.tsx
+++ b/src/__tests__/renderer/components/UsageDashboard/AgentComparisonChart.test.tsx
@@ -13,7 +13,7 @@
  * - Applies theme colors correctly
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import React from 'react';
 import { AgentComparisonChart } from '../../../../renderer/components/UsageDashboard/AgentComparisonChart';
@@ -532,6 +532,171 @@ describe('AgentComparisonChart', () => {
 			render(<AgentComparisonChart data={mockData} theme={theme} />);
 
 			expect(screen.queryByText(/\(Worktree\)/)).not.toBeInTheDocument();
+		});
+	});
+
+	describe('Drill-Down Filtering', () => {
+		// `[role="listitem"]` targets the outer bar row only — the inner count/
+		// duration labels share `.flex.items-center.gap-3` but have no role.
+		const BAR_ROW_SELECTOR = '[role="listitem"][aria-label]';
+
+		it('does not set cursor pointer or tabIndex when onAgentClick is not provided', () => {
+			const { container } = render(<AgentComparisonChart data={mockData} theme={theme} />);
+
+			const barRows = container.querySelectorAll(BAR_ROW_SELECTOR);
+			expect(barRows.length).toBeGreaterThan(0);
+			const firstRow = barRows[0] as HTMLElement;
+			expect(firstRow.style.cursor).toBe('');
+			expect(firstRow.getAttribute('tabIndex')).toBeNull();
+		});
+
+		it('sets cursor pointer and tabIndex when onAgentClick is provided', () => {
+			const onAgentClick = vi.fn();
+			const { container } = render(
+				<AgentComparisonChart data={mockData} theme={theme} onAgentClick={onAgentClick} />
+			);
+
+			const barRows = container.querySelectorAll(BAR_ROW_SELECTOR);
+			const firstRow = barRows[0] as HTMLElement;
+			expect(firstRow.style.cursor).toBe('pointer');
+			expect(firstRow.getAttribute('tabIndex')).toBe('0');
+		});
+
+		it('fires onAgentClick with the bar key and resolved label on click', () => {
+			const onAgentClick = vi.fn();
+			const { container } = render(
+				<AgentComparisonChart data={mockData} theme={theme} onAgentClick={onAgentClick} />
+			);
+
+			// Bars are sorted by duration desc → claude-code is first.
+			const barRows = container.querySelectorAll(BAR_ROW_SELECTOR);
+			fireEvent.click(barRows[0]);
+
+			expect(onAgentClick).toHaveBeenCalledTimes(1);
+			expect(onAgentClick).toHaveBeenCalledWith('claude-code', 'Claude Code');
+		});
+
+		it('fires onAgentClick on Enter and Space key activation', () => {
+			const onAgentClick = vi.fn();
+			const { container } = render(
+				<AgentComparisonChart data={mockData} theme={theme} onAgentClick={onAgentClick} />
+			);
+
+			const barRows = container.querySelectorAll(BAR_ROW_SELECTOR);
+			fireEvent.keyDown(barRows[0], { key: 'Enter' });
+			fireEvent.keyDown(barRows[0], { key: ' ' });
+
+			expect(onAgentClick).toHaveBeenCalledTimes(2);
+		});
+
+		it('dims non-matching bars to 30% opacity when activeFilterKey is set', () => {
+			const { container } = render(
+				<AgentComparisonChart
+					data={mockData}
+					theme={theme}
+					onAgentClick={vi.fn()}
+					activeFilterKey="claude-code"
+				/>
+			);
+
+			const barRows = container.querySelectorAll(BAR_ROW_SELECTOR);
+			// Sorted: claude-code (selected, opacity 1), factory-droid + terminal (dimmed)
+			expect((barRows[0] as HTMLElement).style.opacity).toBe('1');
+			expect((barRows[1] as HTMLElement).style.opacity).toBe('0.3');
+			expect((barRows[2] as HTMLElement).style.opacity).toBe('0.3');
+		});
+
+		it('renders bars at full opacity when no filter is active', () => {
+			const { container } = render(
+				<AgentComparisonChart
+					data={mockData}
+					theme={theme}
+					onAgentClick={vi.fn()}
+					activeFilterKey={null}
+				/>
+			);
+
+			const barRows = container.querySelectorAll(BAR_ROW_SELECTOR);
+			barRows.forEach((row) => {
+				expect((row as HTMLElement).style.opacity).toBe('1');
+			});
+		});
+
+		it('applies an accent-colored outline to the selected bar container', () => {
+			const { container } = render(
+				<AgentComparisonChart
+					data={mockData}
+					theme={theme}
+					onAgentClick={vi.fn()}
+					activeFilterKey="claude-code"
+				/>
+			);
+
+			const barContainers = container.querySelectorAll(
+				'.flex-1.h-full.rounded.overflow-hidden.relative'
+			);
+			expect(barContainers.length).toBe(3);
+			// Selected bar (claude-code, sorted first) gets an inset accent outline.
+			const selected = barContainers[0] as HTMLElement;
+			expect(selected.style.boxShadow).toContain('inset');
+			expect(selected.style.boxShadow).toContain('2px');
+			// Non-selected bars do not have the outline.
+			expect((barContainers[1] as HTMLElement).style.boxShadow).toBe('');
+		});
+
+		it('reflects selection state via aria-pressed', () => {
+			const { container } = render(
+				<AgentComparisonChart
+					data={mockData}
+					theme={theme}
+					onAgentClick={vi.fn()}
+					activeFilterKey="factory-droid"
+				/>
+			);
+
+			const barRows = container.querySelectorAll(BAR_ROW_SELECTOR);
+			// Sorted by duration: claude-code (false), factory-droid (true), terminal (false).
+			expect(barRows[0].getAttribute('aria-pressed')).toBe('false');
+			expect(barRows[1].getAttribute('aria-pressed')).toBe('true');
+			expect(barRows[2].getAttribute('aria-pressed')).toBe('false');
+		});
+
+		it('passes the worktree key suffix when a worktree bar is clicked', () => {
+			const parent = makeSession({ id: 'parent', toolType: 'claude-code' });
+			const worktree = makeSession({
+				id: 'wt-1',
+				toolType: 'claude-code',
+				parentSessionId: 'parent',
+			});
+			const onAgentClick = vi.fn();
+
+			const dataWithSessions: StatsAggregation = {
+				...mockData,
+				bySessionByDay: {
+					parent: [{ date: '2024-12-20', count: 20, duration: 1500000 }],
+					'wt-1': [{ date: '2024-12-20', count: 10, duration: 500000 }],
+				},
+			};
+
+			const { container } = render(
+				<AgentComparisonChart
+					data={dataWithSessions}
+					theme={theme}
+					sessions={[parent, worktree]}
+					onAgentClick={onAgentClick}
+				/>
+			);
+
+			// Find the worktree bar by aria-label suffix and click it.
+			const barRows = Array.from(container.querySelectorAll(BAR_ROW_SELECTOR)) as HTMLElement[];
+			const worktreeRow = barRows.find((row) =>
+				row.getAttribute('aria-label')?.startsWith('Claude Code (Worktree)')
+			);
+			expect(worktreeRow).toBeDefined();
+
+			fireEvent.click(worktreeRow!);
+
+			expect(onAgentClick).toHaveBeenCalledWith('claude-code__worktree', 'Claude Code (Worktree)');
 		});
 	});
 

--- a/src/__tests__/renderer/components/UsageDashboard/AgentComparisonChart.test.tsx
+++ b/src/__tests__/renderer/components/UsageDashboard/AgentComparisonChart.test.tsx
@@ -18,7 +18,38 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import React from 'react';
 import { AgentComparisonChart } from '../../../../renderer/components/UsageDashboard/AgentComparisonChart';
 import type { StatsAggregation } from '../../../../renderer/hooks/stats/useStats';
+import type { Session } from '../../../../renderer/types';
 import { THEMES } from '../../../../shared/themes';
+
+let _sessionIdCounter = 0;
+function makeSession(overrides: Partial<Session> = {}): Session {
+	_sessionIdCounter++;
+	return {
+		id: `s${_sessionIdCounter}`,
+		name: `Session ${_sessionIdCounter}`,
+		toolType: 'claude-code',
+		state: 'idle',
+		cwd: '/tmp',
+		fullPath: '/tmp',
+		projectRoot: '/tmp',
+		aiLogs: [],
+		shellLogs: [],
+		workLog: [],
+		contextUsage: 0,
+		inputMode: 'ai',
+		aiPid: 0,
+		terminalPid: 0,
+		port: 0,
+		isLive: false,
+		changedFiles: [],
+		isGitRepo: false,
+		fileTree: [],
+		fileExplorerExpanded: [],
+		fileExplorerScrollPos: 0,
+		createdAt: 0,
+		...overrides,
+	} as Session;
+}
 
 // Test theme
 const theme = THEMES['dracula'];
@@ -418,6 +449,85 @@ describe('AgentComparisonChart', () => {
 
 			const firstBar = bars[0] as HTMLElement;
 			expect(firstBar.style.transition).toContain('opacity');
+		});
+	});
+
+	describe('Worktree Differentiation', () => {
+		it('splits worktree agents into separate bars and tags them with "(Worktree)"', () => {
+			const parent = makeSession({ id: 'parent', toolType: 'claude-code' });
+			const worktree = makeSession({
+				id: 'wt-1',
+				toolType: 'claude-code',
+				parentSessionId: 'parent',
+			});
+
+			const dataWithSessions: StatsAggregation = {
+				...mockData,
+				bySessionByDay: {
+					parent: [{ date: '2024-12-20', count: 20, duration: 1500000 }],
+					'wt-1': [{ date: '2024-12-20', count: 10, duration: 500000 }],
+				},
+			};
+
+			render(
+				<AgentComparisonChart data={dataWithSessions} theme={theme} sessions={[parent, worktree]} />
+			);
+
+			// "claude-code" appears in both the bar label and the legend
+			expect(screen.getAllByText('claude-code').length).toBeGreaterThanOrEqual(1);
+			// "claude-code (Worktree)" appears in both the bar label and the legend
+			expect(screen.getAllByText('claude-code (Worktree)').length).toBeGreaterThanOrEqual(1);
+		});
+
+		it('renders the Agent vs Worktree Agent legend when worktrees are present', () => {
+			const parent = makeSession({ id: 'parent', toolType: 'claude-code' });
+			const worktree = makeSession({
+				id: 'wt-1',
+				toolType: 'claude-code',
+				parentSessionId: 'parent',
+			});
+
+			const dataWithSessions: StatsAggregation = {
+				...mockData,
+				bySessionByDay: {
+					parent: [{ date: '2024-12-20', count: 20, duration: 1500000 }],
+					'wt-1': [{ date: '2024-12-20', count: 10, duration: 500000 }],
+				},
+			};
+
+			const { container } = render(
+				<AgentComparisonChart data={dataWithSessions} theme={theme} sessions={[parent, worktree]} />
+			);
+
+			const legendBlock = container.querySelector('[aria-label="Worktree differentiation legend"]');
+			expect(legendBlock).not.toBeNull();
+			expect(legendBlock?.textContent).toContain('Agent');
+			expect(legendBlock?.textContent).toContain('Worktree Agent');
+		});
+
+		it('does not render the worktree legend when no worktree sessions exist', () => {
+			const regular = makeSession({ id: 'reg', toolType: 'claude-code' });
+
+			const dataWithSessions: StatsAggregation = {
+				...mockData,
+				bySessionByDay: {
+					reg: [{ date: '2024-12-20', count: 20, duration: 1500000 }],
+				},
+			};
+
+			const { container } = render(
+				<AgentComparisonChart data={dataWithSessions} theme={theme} sessions={[regular]} />
+			);
+
+			expect(container.querySelector('[aria-label="Worktree differentiation legend"]')).toBeNull();
+		});
+
+		it('falls back to byAgent aggregation when sessions prop is not provided', () => {
+			// Without sessions, no worktree info — should render exactly the
+			// providers in byAgent without "(Worktree)" suffixes.
+			render(<AgentComparisonChart data={mockData} theme={theme} />);
+
+			expect(screen.queryByText(/\(Worktree\)/)).not.toBeInTheDocument();
 		});
 	});
 });

--- a/src/__tests__/renderer/components/UsageDashboard/AgentComparisonChart.test.tsx
+++ b/src/__tests__/renderer/components/UsageDashboard/AgentComparisonChart.test.tsx
@@ -132,10 +132,12 @@ describe('AgentComparisonChart', () => {
 		it('renders agent names', () => {
 			render(<AgentComparisonChart data={mockData} theme={theme} />);
 
-			// Use getAllByText since agent names appear in both bar labels and legend
-			expect(screen.getAllByText('claude-code').length).toBeGreaterThanOrEqual(1);
-			expect(screen.getAllByText('factory-droid').length).toBeGreaterThanOrEqual(1);
-			expect(screen.getAllByText('terminal').length).toBeGreaterThanOrEqual(1);
+			// Without sessions, raw agent type keys are prettified via
+			// AGENT_DISPLAY_NAMES (e.g. "claude-code" → "Claude Code").
+			// Use getAllByText since names appear in both bar labels and legend.
+			expect(screen.getAllByText('Claude Code').length).toBeGreaterThanOrEqual(1);
+			expect(screen.getAllByText('Factory Droid').length).toBeGreaterThanOrEqual(1);
+			expect(screen.getAllByText('Terminal').length).toBeGreaterThanOrEqual(1);
 		});
 
 		it('renders with empty data showing message', () => {
@@ -148,7 +150,7 @@ describe('AgentComparisonChart', () => {
 			render(<AgentComparisonChart data={singleAgentData} theme={theme} />);
 
 			// Use getAllByText since agent name appears in both bar label and legend
-			expect(screen.getAllByText('claude-code').length).toBeGreaterThanOrEqual(1);
+			expect(screen.getAllByText('Claude Code').length).toBeGreaterThanOrEqual(1);
 			// Single agent should show 100%
 			expect(screen.getByText('100.0%')).toBeInTheDocument();
 		});
@@ -196,10 +198,11 @@ describe('AgentComparisonChart', () => {
 			const agentLabels = container.querySelectorAll('.w-28.truncate');
 			const agentNames = Array.from(agentLabels).map((el) => el.textContent);
 
-			// In duration mode, claude-code has highest duration (2000000), then codex (1600000), then terminal (500000)
-			expect(agentNames[0]).toBe('claude-code');
-			expect(agentNames[1]).toBe('factory-droid');
-			expect(agentNames[2]).toBe('terminal');
+			// Bars are sorted by duration: claude-code (2000000) > factory-droid
+			// (1600000) > terminal (500000). Labels are prettified by buildNameMap.
+			expect(agentNames[0]).toBe('Claude Code');
+			expect(agentNames[1]).toBe('Factory Droid');
+			expect(agentNames[2]).toBe('Terminal');
 		});
 	});
 
@@ -473,10 +476,11 @@ describe('AgentComparisonChart', () => {
 				<AgentComparisonChart data={dataWithSessions} theme={theme} sessions={[parent, worktree]} />
 			);
 
-			// "claude-code" appears in both the bar label and the legend
-			expect(screen.getAllByText('claude-code').length).toBeGreaterThanOrEqual(1);
-			// "claude-code (Worktree)" appears in both the bar label and the legend
-			expect(screen.getAllByText('claude-code (Worktree)').length).toBeGreaterThanOrEqual(1);
+			// Two sessions share toolType "claude-code" so resolveAgentDisplayName
+			// falls back to the prettified type name. Labels appear in both the
+			// bar row and the legend.
+			expect(screen.getAllByText('Claude Code').length).toBeGreaterThanOrEqual(1);
+			expect(screen.getAllByText('Claude Code (Worktree)').length).toBeGreaterThanOrEqual(1);
 		});
 
 		it('renders the Agent vs Worktree Agent legend when worktrees are present', () => {
@@ -528,6 +532,109 @@ describe('AgentComparisonChart', () => {
 			render(<AgentComparisonChart data={mockData} theme={theme} />);
 
 			expect(screen.queryByText(/\(Worktree\)/)).not.toBeInTheDocument();
+		});
+	});
+
+	describe('Session Name Resolution', () => {
+		it('uses the user-assigned session name when a single session matches the provider', () => {
+			// One session of toolType "claude-code" — buildNameMap should pick
+			// the session's name ("Backend API") for the bar label.
+			const session = makeSession({
+				id: 'backend-api',
+				name: 'Backend API',
+				toolType: 'claude-code',
+			});
+			const data: StatsAggregation = {
+				...singleAgentData,
+				byAgent: {
+					'claude-code': { count: 20, duration: 1000000 },
+				},
+			};
+
+			render(<AgentComparisonChart data={data} theme={theme} sessions={[session]} />);
+
+			expect(screen.getAllByText('Backend API').length).toBeGreaterThanOrEqual(1);
+			expect(screen.queryByText('Claude Code')).not.toBeInTheDocument();
+		});
+
+		it('falls back to prettified type when multiple sessions share the same provider', () => {
+			// Two distinct claude-code sessions — buildNameMap can't pick one,
+			// so it should use the prettified type name.
+			const a = makeSession({ id: 'a', name: 'Frontend', toolType: 'claude-code' });
+			const b = makeSession({ id: 'b', name: 'Backend', toolType: 'claude-code' });
+			const data: StatsAggregation = {
+				...singleAgentData,
+				byAgent: {
+					'claude-code': { count: 20, duration: 1000000 },
+				},
+			};
+
+			render(<AgentComparisonChart data={data} theme={theme} sessions={[a, b]} />);
+
+			expect(screen.getAllByText('Claude Code').length).toBeGreaterThanOrEqual(1);
+		});
+
+		it('disambiguates colliding display names with " (2)" suffixes', () => {
+			// Two providers, single matching session each, both named "Worker".
+			// buildNameMap should append " (2)" to the second to avoid collision.
+			const a = makeSession({ id: 'a', name: 'Worker', toolType: 'claude-code' });
+			const b = makeSession({ id: 'b', name: 'Worker', toolType: 'opencode' });
+			const data: StatsAggregation = {
+				...mockData,
+				byAgent: {
+					'claude-code': { count: 30, duration: 2000000 },
+					opencode: { count: 20, duration: 1000000 },
+				},
+			};
+
+			render(<AgentComparisonChart data={data} theme={theme} sessions={[a, b]} />);
+
+			expect(screen.getAllByText('Worker').length).toBeGreaterThanOrEqual(1);
+			expect(screen.getAllByText('Worker (2)').length).toBeGreaterThanOrEqual(1);
+		});
+
+		it('uses prettified type for providers with no matching session', () => {
+			// Sessions present but none with matching toolType — falls through
+			// to prettifyAgentType.
+			const session = makeSession({
+				id: 'unrelated',
+				name: 'Unrelated',
+				toolType: 'opencode',
+			});
+			const data: StatsAggregation = {
+				...singleAgentData,
+				byAgent: {
+					'factory-droid': { count: 10, duration: 500000 },
+				},
+			};
+
+			render(<AgentComparisonChart data={data} theme={theme} sessions={[session]} />);
+
+			expect(screen.getAllByText('Factory Droid').length).toBeGreaterThanOrEqual(1);
+		});
+
+		it('uses resolved name in tooltip', () => {
+			const session = makeSession({
+				id: 'backend-api',
+				name: 'Backend API',
+				toolType: 'claude-code',
+			});
+			const data: StatsAggregation = {
+				...singleAgentData,
+				byAgent: {
+					'claude-code': { count: 20, duration: 1000000 },
+				},
+			};
+
+			const { container } = render(
+				<AgentComparisonChart data={data} theme={theme} sessions={[session]} />
+			);
+
+			const barRows = container.querySelectorAll('.flex.items-center.gap-3');
+			fireEvent.mouseEnter(barRows[0]);
+
+			const tooltip = container.querySelector('.fixed.z-50');
+			expect(tooltip?.textContent).toContain('Backend API');
 		});
 	});
 });

--- a/src/__tests__/renderer/components/UsageDashboard/AgentEfficiencyChart.test.tsx
+++ b/src/__tests__/renderer/components/UsageDashboard/AgentEfficiencyChart.test.tsx
@@ -1,0 +1,191 @@
+/**
+ * Tests for AgentEfficiencyChart component
+ *
+ * Focuses on the name resolution behavior shared with the other dashboard
+ * charts: provider keys are resolved via `buildNameMap` so chart labels and
+ * row titles show the user-assigned session names (or the prettified type
+ * fallback) instead of raw "claude-code"-style identifiers.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { AgentEfficiencyChart } from '../../../../renderer/components/UsageDashboard/AgentEfficiencyChart';
+import type { StatsAggregation } from '../../../../renderer/hooks/stats/useStats';
+import type { Session } from '../../../../renderer/types';
+import { THEMES } from '../../../../shared/themes';
+
+let _sessionIdCounter = 0;
+function makeSession(overrides: Partial<Session> = {}): Session {
+	_sessionIdCounter++;
+	return {
+		id: `s${_sessionIdCounter}`,
+		name: `Session ${_sessionIdCounter}`,
+		toolType: 'claude-code',
+		state: 'idle',
+		cwd: '/tmp',
+		fullPath: '/tmp',
+		projectRoot: '/tmp',
+		aiLogs: [],
+		shellLogs: [],
+		workLog: [],
+		contextUsage: 0,
+		inputMode: 'ai',
+		aiPid: 0,
+		terminalPid: 0,
+		port: 0,
+		isLive: false,
+		changedFiles: [],
+		isGitRepo: false,
+		fileTree: [],
+		fileExplorerExpanded: [],
+		fileExplorerScrollPos: 0,
+		createdAt: 0,
+		...overrides,
+	} as Session;
+}
+
+const theme = THEMES['dracula'];
+
+const baseData: StatsAggregation = {
+	totalQueries: 50,
+	totalDuration: 3600000,
+	avgDuration: 72000,
+	byAgent: {
+		'claude-code': { count: 30, duration: 2000000 },
+		'factory-droid': { count: 20, duration: 1600000 },
+	},
+	bySource: { user: 35, auto: 15 },
+	byDay: [],
+};
+
+describe('AgentEfficiencyChart', () => {
+	describe('Rendering', () => {
+		it('renders the title', () => {
+			render(<AgentEfficiencyChart data={baseData} theme={theme} />);
+			expect(screen.getByText('Agent Efficiency')).toBeInTheDocument();
+		});
+
+		it('renders the empty-state message when no agent data is present', () => {
+			const emptyData: StatsAggregation = {
+				totalQueries: 0,
+				totalDuration: 0,
+				avgDuration: 0,
+				byAgent: {},
+				bySource: { user: 0, auto: 0 },
+				byDay: [],
+			};
+			render(<AgentEfficiencyChart data={emptyData} theme={theme} />);
+			expect(screen.getByText('No agent query data available')).toBeInTheDocument();
+		});
+	});
+
+	describe('Session Name Resolution', () => {
+		it('uses the user-assigned session name when a single session matches the provider', () => {
+			const session = makeSession({
+				id: 'backend-api',
+				name: 'Backend API',
+				toolType: 'claude-code',
+			});
+			const data: StatsAggregation = {
+				...baseData,
+				byAgent: {
+					'claude-code': { count: 20, duration: 1000000 },
+				},
+			};
+
+			render(<AgentEfficiencyChart data={data} theme={theme} sessions={[session]} />);
+
+			expect(screen.getAllByText('Backend API').length).toBeGreaterThanOrEqual(1);
+			expect(screen.queryByText('Claude Code')).not.toBeInTheDocument();
+		});
+
+		it('falls back to prettified type when multiple sessions share the same provider', () => {
+			const a = makeSession({ id: 'a', name: 'Frontend', toolType: 'claude-code' });
+			const b = makeSession({ id: 'b', name: 'Backend', toolType: 'claude-code' });
+			const data: StatsAggregation = {
+				...baseData,
+				byAgent: {
+					'claude-code': { count: 20, duration: 1000000 },
+				},
+			};
+
+			render(<AgentEfficiencyChart data={data} theme={theme} sessions={[a, b]} />);
+
+			expect(screen.getAllByText('Claude Code').length).toBeGreaterThanOrEqual(1);
+		});
+
+		it('disambiguates colliding display names with " (2)" suffixes', () => {
+			const a = makeSession({ id: 'a', name: 'Worker', toolType: 'claude-code' });
+			const b = makeSession({ id: 'b', name: 'Worker', toolType: 'opencode' });
+			const data: StatsAggregation = {
+				...baseData,
+				byAgent: {
+					'claude-code': { count: 30, duration: 2000000 },
+					opencode: { count: 20, duration: 1000000 },
+				},
+			};
+
+			render(<AgentEfficiencyChart data={data} theme={theme} sessions={[a, b]} />);
+
+			expect(screen.getAllByText('Worker').length).toBeGreaterThanOrEqual(1);
+			expect(screen.getAllByText('Worker (2)').length).toBeGreaterThanOrEqual(1);
+		});
+
+		it('prettifies raw agent type keys when no sessions are provided', () => {
+			render(<AgentEfficiencyChart data={baseData} theme={theme} />);
+			// "claude-code" → "Claude Code", "factory-droid" → "Factory Droid"
+			expect(screen.getAllByText('Claude Code').length).toBeGreaterThanOrEqual(1);
+			expect(screen.getAllByText('Factory Droid').length).toBeGreaterThanOrEqual(1);
+		});
+
+		it('shows resolved name in row title attribute (used as tooltip on truncation)', () => {
+			const session = makeSession({
+				id: 'backend-api',
+				name: 'Backend API',
+				toolType: 'claude-code',
+			});
+			const data: StatsAggregation = {
+				...baseData,
+				byAgent: {
+					'claude-code': { count: 20, duration: 1000000 },
+				},
+			};
+
+			const { container } = render(
+				<AgentEfficiencyChart data={data} theme={theme} sessions={[session]} />
+			);
+
+			const labelEl = container.querySelector('.w-28[title]') as HTMLElement | null;
+			expect(labelEl).not.toBeNull();
+			expect(labelEl?.title).toBe('Backend API');
+		});
+	});
+
+	describe('Worktree Differentiation', () => {
+		it('splits worktree agents into separate rows tagged with "(Worktree)"', () => {
+			const parent = makeSession({ id: 'parent', toolType: 'claude-code' });
+			const worktree = makeSession({
+				id: 'wt-1',
+				toolType: 'claude-code',
+				parentSessionId: 'parent',
+			});
+
+			const dataWithSessions: StatsAggregation = {
+				...baseData,
+				bySessionByDay: {
+					parent: [{ date: '2024-12-20', count: 20, duration: 1500000 }],
+					'wt-1': [{ date: '2024-12-20', count: 10, duration: 500000 }],
+				},
+			};
+
+			render(
+				<AgentEfficiencyChart data={dataWithSessions} theme={theme} sessions={[parent, worktree]} />
+			);
+
+			// Two sessions share toolType "claude-code" so the name resolves to
+			// the prettified type for the regular row plus a "(Worktree)" suffix.
+			expect(screen.getAllByText('Claude Code').length).toBeGreaterThanOrEqual(1);
+			expect(screen.getAllByText('Claude Code (Worktree)').length).toBeGreaterThanOrEqual(1);
+		});
+	});
+});

--- a/src/__tests__/renderer/components/UsageDashboard/AgentEfficiencyChart.test.tsx
+++ b/src/__tests__/renderer/components/UsageDashboard/AgentEfficiencyChart.test.tsx
@@ -161,6 +161,56 @@ describe('AgentEfficiencyChart', () => {
 		});
 	});
 
+	describe('Drill-down filter', () => {
+		it('renders all entries at full opacity when no activeFilterKey is provided', () => {
+			const { container } = render(<AgentEfficiencyChart data={baseData} theme={theme} />);
+			// Row containers live at the top of the .space-y-3 wrapper as
+			// `.flex.items-center.gap-3` divs. With no filter, neither row should
+			// have the dim opacity applied.
+			const rows = container.querySelectorAll('.space-y-3 > div.flex.items-center.gap-3');
+			expect(rows.length).toBe(2);
+			rows.forEach((row) => {
+				expect((row as HTMLElement).style.opacity).not.toBe('0.3');
+			});
+		});
+
+		it('dims rows that do not match activeFilterKey to 0.3 opacity', () => {
+			const { container } = render(
+				<AgentEfficiencyChart data={baseData} theme={theme} activeFilterKey="claude-code" />
+			);
+			const rows = container.querySelectorAll(
+				'.space-y-3 > div.flex.items-center.gap-3'
+			) as NodeListOf<HTMLElement>;
+			expect(rows.length).toBe(2);
+
+			// Two providers: claude-code (matches) and factory-droid (dimmed).
+			// Sort by efficiency: data has claude-code at 2000000/30 ≈ 66667ms,
+			// factory-droid at 1600000/20 = 80000ms — claude-code is faster, so
+			// it renders first. We don't depend on order; instead, find the row
+			// whose label is "Claude Code" vs "Factory Droid".
+			const claudeRow = Array.from(rows).find((r) => r.textContent?.includes('Claude Code'));
+			const factoryRow = Array.from(rows).find((r) => r.textContent?.includes('Factory Droid'));
+
+			expect(claudeRow).toBeDefined();
+			expect(factoryRow).toBeDefined();
+			expect(claudeRow?.style.opacity).not.toBe('0.3');
+			expect(factoryRow?.style.opacity).toBe('0.3');
+		});
+
+		it('dims all rows when activeFilterKey matches no entry', () => {
+			const { container } = render(
+				<AgentEfficiencyChart data={baseData} theme={theme} activeFilterKey="nonexistent" />
+			);
+			const rows = container.querySelectorAll(
+				'.space-y-3 > div.flex.items-center.gap-3'
+			) as NodeListOf<HTMLElement>;
+			expect(rows.length).toBe(2);
+			rows.forEach((row) => {
+				expect(row.style.opacity).toBe('0.3');
+			});
+		});
+	});
+
 	describe('Worktree Differentiation', () => {
 		it('splits worktree agents into separate rows tagged with "(Worktree)"', () => {
 			const parent = makeSession({ id: 'parent', toolType: 'claude-code' });

--- a/src/__tests__/renderer/components/UsageDashboard/AgentOverviewCards.test.tsx
+++ b/src/__tests__/renderer/components/UsageDashboard/AgentOverviewCards.test.tsx
@@ -20,6 +20,15 @@ import { THEMES } from '../../../../shared/themes';
 
 const theme = THEMES['dracula'];
 
+// JSDOM normalises hex colors to rgb() when they're read back off `element.style`
+const hexToRgb = (hex: string): string => {
+	const v = hex.replace('#', '');
+	const r = parseInt(v.slice(0, 2), 16);
+	const g = parseInt(v.slice(2, 4), 16);
+	const b = parseInt(v.slice(4, 6), 16);
+	return `rgb(${r}, ${g}, ${b})`;
+};
+
 const buildSession = (overrides: Partial<Session>): Session =>
 	({
 		id: 'sess-1',
@@ -209,6 +218,130 @@ describe('AgentOverviewCards', () => {
 
 		const card = screen.getByTestId('agent-card');
 		expect(card.querySelector('[data-testid="sparkline-empty"]')).not.toBeNull();
+	});
+
+	describe('Drill-down filter highlight', () => {
+		it('does not highlight any card when activeFilterKey is null', () => {
+			const sessions: Session[] = [
+				buildSession({ id: 's1', name: 'Alpha', toolType: 'claude-code' }),
+				buildSession({ id: 's2', name: 'Beta', toolType: 'codex' }),
+			];
+
+			render(
+				<AgentOverviewCards
+					sessions={sessions}
+					data={buildData()}
+					theme={theme}
+					activeFilterKey={null}
+				/>
+			);
+
+			const cards = screen.getAllByTestId('agent-card');
+			cards.forEach((card) => {
+				expect(card.dataset.selected).toBeUndefined();
+				expect(card.style.border).not.toContain('2px');
+			});
+		});
+
+		it('highlights only the parent card whose toolType matches a provider key', () => {
+			const sessions: Session[] = [
+				buildSession({ id: 's1', name: 'Claude', toolType: 'claude-code' }),
+				buildSession({ id: 's2', name: 'Codex', toolType: 'codex' }),
+				buildSession({
+					id: 's3',
+					name: 'Claude WT',
+					toolType: 'claude-code',
+					parentSessionId: 's1',
+					worktreeBranch: 'feature/x',
+				}),
+			];
+
+			render(
+				<AgentOverviewCards
+					sessions={sessions}
+					data={buildData()}
+					theme={theme}
+					activeFilterKey="claude-code"
+				/>
+			);
+
+			const cards = screen.getAllByTestId('agent-card');
+			// Parent claude-code card should be selected
+			expect(cards[0].dataset.selected).toBe('true');
+			expect(cards[0].style.border).toBe(`2px solid ${hexToRgb(theme.colors.accent)}`);
+			// codex card should not be selected
+			expect(cards[1].dataset.selected).toBeUndefined();
+			// Worktree of claude-code should NOT match the bare provider key
+			expect(cards[2].dataset.selected).toBeUndefined();
+			expect(cards[2].style.border).toContain('dashed');
+		});
+
+		it('highlights only worktree cards when filter key has __worktree suffix', () => {
+			const sessions: Session[] = [
+				buildSession({ id: 'p1', name: 'Claude Parent', toolType: 'claude-code' }),
+				buildSession({
+					id: 'wt1',
+					name: 'Claude WT',
+					toolType: 'claude-code',
+					parentSessionId: 'p1',
+					worktreeBranch: 'feature/x',
+				}),
+			];
+
+			render(
+				<AgentOverviewCards
+					sessions={sessions}
+					data={buildData()}
+					theme={theme}
+					activeFilterKey="claude-code__worktree"
+				/>
+			);
+
+			const cards = screen.getAllByTestId('agent-card');
+			// Parent should NOT be highlighted by the worktree key
+			expect(cards[0].dataset.selected).toBeUndefined();
+			// Worktree card should be highlighted
+			expect(cards[1].dataset.selected).toBe('true');
+			expect(cards[1].style.border).toBe(`2px solid ${hexToRgb(theme.colors.accent)}`);
+		});
+
+		it('highlights a single card when filter key matches the session id', () => {
+			const sessions: Session[] = [
+				buildSession({ id: 's1', name: 'Alpha', toolType: 'claude-code' }),
+				buildSession({ id: 's2', name: 'Beta', toolType: 'claude-code' }),
+			];
+
+			render(
+				<AgentOverviewCards
+					sessions={sessions}
+					data={buildData()}
+					theme={theme}
+					activeFilterKey="s2"
+				/>
+			);
+
+			const cards = screen.getAllByTestId('agent-card');
+			expect(cards[0].dataset.selected).toBeUndefined();
+			expect(cards[1].dataset.selected).toBe('true');
+		});
+
+		it('highlights nothing when the filter key does not match any session', () => {
+			const sessions: Session[] = [
+				buildSession({ id: 's1', name: 'Alpha', toolType: 'claude-code' }),
+			];
+
+			render(
+				<AgentOverviewCards
+					sessions={sessions}
+					data={buildData()}
+					theme={theme}
+					activeFilterKey="opencode"
+				/>
+			);
+
+			const cards = screen.getAllByTestId('agent-card');
+			expect(cards[0].dataset.selected).toBeUndefined();
+		});
 	});
 
 	it('staggers card-enter animation delays at 60ms per card', () => {

--- a/src/__tests__/renderer/components/UsageDashboard/AgentOverviewCards.test.tsx
+++ b/src/__tests__/renderer/components/UsageDashboard/AgentOverviewCards.test.tsx
@@ -1,0 +1,229 @@
+/**
+ * Tests for AgentOverviewCards component
+ *
+ * Verifies:
+ * - Renders one card per non-terminal session
+ * - Status dot color reflects session state (idle/busy/error/other)
+ * - Worktree children show the WT badge, dashed border, and branch row
+ * - Query count comes from bySessionByDay when present, falls back to byAgent
+ * - Sparklines render with per-session counts (accent color for worktrees)
+ * - Empty / terminal-only session arrays render nothing
+ * - Staggered card-enter animation delays are applied
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { AgentOverviewCards } from '../../../../renderer/components/UsageDashboard/AgentOverviewCards';
+import type { StatsAggregation } from '../../../../renderer/hooks/stats/useStats';
+import type { Session } from '../../../../renderer/types';
+import { THEMES } from '../../../../shared/themes';
+
+const theme = THEMES['dracula'];
+
+const buildSession = (overrides: Partial<Session>): Session =>
+	({
+		id: 'sess-1',
+		name: 'Agent One',
+		toolType: 'claude-code',
+		state: 'idle',
+		contextUsage: 0,
+		...overrides,
+	}) as Session;
+
+const buildData = (overrides: Partial<StatsAggregation> = {}): StatsAggregation => ({
+	totalQueries: 0,
+	totalDuration: 0,
+	avgDuration: 0,
+	byAgent: {},
+	bySource: { user: 0, auto: 0 },
+	byLocation: { local: 0, remote: 0 },
+	byDay: [],
+	byHour: [],
+	totalSessions: 0,
+	sessionsByAgent: {},
+	sessionsByDay: [],
+	avgSessionDuration: 0,
+	byAgentByDay: {},
+	bySessionByDay: {},
+	...overrides,
+});
+
+describe('AgentOverviewCards', () => {
+	it('renders the grid container with one card per non-terminal session', () => {
+		const sessions: Session[] = [
+			buildSession({ id: 's1', name: 'Alpha' }),
+			buildSession({ id: 's2', name: 'Beta', toolType: 'codex' }),
+			buildSession({ id: 's3', name: 'Term', toolType: 'terminal' }),
+		];
+
+		render(<AgentOverviewCards sessions={sessions} data={buildData()} theme={theme} />);
+
+		expect(screen.getByTestId('agent-overview-cards')).toBeInTheDocument();
+		const cards = screen.getAllByTestId('agent-card');
+		expect(cards).toHaveLength(2);
+		expect(screen.getByText('Alpha')).toBeInTheDocument();
+		expect(screen.getByText('Beta')).toBeInTheDocument();
+		expect(screen.queryByText('Term')).not.toBeInTheDocument();
+	});
+
+	it('renders nothing when there are no non-terminal sessions', () => {
+		const { container: emptyContainer } = render(
+			<AgentOverviewCards sessions={[]} data={buildData()} theme={theme} />
+		);
+		expect(emptyContainer.firstChild).toBeNull();
+
+		const { container: terminalOnly } = render(
+			<AgentOverviewCards
+				sessions={[buildSession({ id: 't1', toolType: 'terminal' })]}
+				data={buildData()}
+				theme={theme}
+			/>
+		);
+		expect(terminalOnly.firstChild).toBeNull();
+	});
+
+	it('colors the status dot based on session state', () => {
+		const sessions: Session[] = [
+			buildSession({ id: 'idle', name: 'Idle', state: 'idle' }),
+			buildSession({ id: 'busy', name: 'Busy', state: 'busy' }),
+			buildSession({ id: 'err', name: 'Err', state: 'error' }),
+			buildSession({ id: 'wait', name: 'Wait', state: 'waiting_input' }),
+		];
+
+		render(<AgentOverviewCards sessions={sessions} data={buildData()} theme={theme} />);
+
+		const cards = screen.getAllByTestId('agent-card');
+		const dots = cards.map((c) => c.querySelector('[data-testid="agent-card-status-dot"]'));
+
+		// Hex → JSDOM-normalised rgb()
+		const hexToRgb = (hex: string) => {
+			const v = hex.replace('#', '');
+			const r = parseInt(v.slice(0, 2), 16);
+			const g = parseInt(v.slice(2, 4), 16);
+			const b = parseInt(v.slice(4, 6), 16);
+			return `rgb(${r}, ${g}, ${b})`;
+		};
+
+		expect((dots[0] as HTMLElement).style.backgroundColor).toBe(hexToRgb(theme.colors.success));
+		expect((dots[1] as HTMLElement).style.backgroundColor).toBe(hexToRgb(theme.colors.warning));
+		expect((dots[2] as HTMLElement).style.backgroundColor).toBe(hexToRgb(theme.colors.error));
+		// `waiting_input` → textDim fallback
+		expect((dots[3] as HTMLElement).style.backgroundColor).toBe(hexToRgb(theme.colors.textDim));
+	});
+
+	it('animates the status dot only when the session is busy', () => {
+		const sessions: Session[] = [
+			buildSession({ id: 'idle', name: 'Idle', state: 'idle' }),
+			buildSession({ id: 'busy', name: 'Busy', state: 'busy' }),
+		];
+
+		render(<AgentOverviewCards sessions={sessions} data={buildData()} theme={theme} />);
+
+		const cards = screen.getAllByTestId('agent-card');
+		const idleDot = cards[0].querySelector('[data-testid="agent-card-status-dot"]') as HTMLElement;
+		const busyDot = cards[1].querySelector('[data-testid="agent-card-status-dot"]') as HTMLElement;
+
+		expect(idleDot.style.animation).toBe('');
+		expect(busyDot.style.animation).toContain('status-pulse');
+	});
+
+	it('renders the WT badge, branch row, and dashed border for worktree children', () => {
+		const sessions: Session[] = [
+			buildSession({
+				id: 'wt-1',
+				name: 'Worktree One',
+				parentSessionId: 'parent-1',
+				worktreeBranch: 'feature/awesome',
+			}),
+			buildSession({ id: 'p-1', name: 'Parent One' }),
+		];
+
+		render(<AgentOverviewCards sessions={sessions} data={buildData()} theme={theme} />);
+
+		const cards = screen.getAllByTestId('agent-card');
+
+		// Worktree card
+		expect(cards[0].querySelector('[data-testid="agent-card-wt-badge"]')).not.toBeNull();
+		expect(cards[0].querySelector('[data-testid="agent-card-branch"]')?.textContent).toBe(
+			'feature/awesome'
+		);
+		expect(cards[0].style.border).toContain('dashed');
+
+		// Parent (non-worktree) card
+		expect(cards[1].querySelector('[data-testid="agent-card-wt-badge"]')).toBeNull();
+		expect(cards[1].querySelector('[data-testid="agent-card-branch"]')).toBeNull();
+		expect(cards[1].style.border).toContain('solid');
+	});
+
+	it('uses bySessionByDay totals for the query count when present', () => {
+		const sessions: Session[] = [buildSession({ id: 's1', name: 'Alpha' })];
+		const data = buildData({
+			bySessionByDay: {
+				s1: [
+					{ date: '2024-12-20', count: 7, duration: 1000 },
+					{ date: '2024-12-21', count: 13, duration: 2000 },
+				],
+			},
+			byAgent: {
+				// Provider total should be ignored when per-session data exists.
+				'claude-code': { count: 999, duration: 0 },
+			},
+		});
+
+		render(<AgentOverviewCards sessions={sessions} data={data} theme={theme} />);
+
+		expect(screen.getByTestId('agent-card-query-count').textContent).toBe('20');
+	});
+
+	it('falls back to byAgent[toolType] when bySessionByDay has no entry', () => {
+		const sessions: Session[] = [buildSession({ id: 's1', name: 'Alpha' })];
+		const data = buildData({
+			byAgent: { 'claude-code': { count: 42, duration: 0 } },
+		});
+
+		render(<AgentOverviewCards sessions={sessions} data={data} theme={theme} />);
+
+		expect(screen.getByTestId('agent-card-query-count').textContent).toBe('42');
+	});
+
+	it('renders a per-session sparkline when bySessionByDay has data', () => {
+		const sessions: Session[] = [buildSession({ id: 's1', name: 'Alpha' })];
+		const data = buildData({
+			bySessionByDay: {
+				s1: [{ date: '2024-12-21', count: 5, duration: 1000 }],
+			},
+		});
+
+		render(<AgentOverviewCards sessions={sessions} data={data} theme={theme} />);
+
+		// Single non-zero day → renders the active sparkline (the empty
+		// dashed-baseline state would emit `sparkline-empty` instead).
+		const card = screen.getByTestId('agent-card');
+		expect(card.querySelector('[data-testid="sparkline"]')).not.toBeNull();
+	});
+
+	it('renders the empty/dashed sparkline when no per-session day data exists', () => {
+		const sessions: Session[] = [buildSession({ id: 's1', name: 'Alpha' })];
+
+		render(<AgentOverviewCards sessions={sessions} data={buildData()} theme={theme} />);
+
+		const card = screen.getByTestId('agent-card');
+		expect(card.querySelector('[data-testid="sparkline-empty"]')).not.toBeNull();
+	});
+
+	it('staggers card-enter animation delays at 60ms per card', () => {
+		const sessions: Session[] = [
+			buildSession({ id: 'a', name: 'A' }),
+			buildSession({ id: 'b', name: 'B' }),
+			buildSession({ id: 'c', name: 'C' }),
+		];
+
+		render(<AgentOverviewCards sessions={sessions} data={buildData()} theme={theme} />);
+
+		const cards = screen.getAllByTestId('agent-card');
+		expect(cards[0].style.animationDelay).toBe('0ms');
+		expect(cards[1].style.animationDelay).toBe('60ms');
+		expect(cards[2].style.animationDelay).toBe('120ms');
+		cards.forEach((c) => expect(c.className).toContain('card-enter'));
+	});
+});

--- a/src/__tests__/renderer/components/UsageDashboard/AgentUsageChart.test.tsx
+++ b/src/__tests__/renderer/components/UsageDashboard/AgentUsageChart.test.tsx
@@ -7,8 +7,8 @@
  * names (or the prettified type fallback) instead of raw UUID prefixes.
  */
 
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { AgentUsageChart } from '../../../../renderer/components/UsageDashboard/AgentUsageChart';
 import type { StatsAggregation } from '../../../../renderer/hooks/stats/useStats';
 import type { Session } from '../../../../renderer/types';
@@ -150,6 +150,172 @@ describe('AgentUsageChart', () => {
 			render(<AgentUsageChart data={data} timeRange="week" theme={theme} sessions={[]} />);
 
 			expect(screen.getByText('Claude Code')).toBeInTheDocument();
+		});
+	});
+
+	describe('Drill-down filter', () => {
+		// Two-session fixture used across the drill-down tests below.
+		function buildTwoSessionFixture() {
+			const sessionA = makeSession({ id: 'sess-aaa', name: 'Backend' });
+			const sessionB = makeSession({ id: 'sess-bbb', name: 'Frontend' });
+			const data = dataForSessions({
+				'sess-aaa': [{ date: '2024-12-20', count: 5, duration: 60_000 }],
+				'sess-bbb': [{ date: '2024-12-20', count: 3, duration: 30_000 }],
+			});
+			return { sessions: [sessionA, sessionB], data };
+		}
+
+		it('renders legend items as non-interactive when onAgentClick is not provided', () => {
+			const { sessions, data } = buildTwoSessionFixture();
+			const { container } = render(
+				<AgentUsageChart data={data} timeRange="week" theme={theme} sessions={sessions} />
+			);
+
+			const legendButtons = container.querySelectorAll('[role="button"]');
+			expect(legendButtons.length).toBe(0);
+		});
+
+		it('renders legend items as buttons with tabIndex when onAgentClick is provided', () => {
+			const { sessions, data } = buildTwoSessionFixture();
+			const { container } = render(
+				<AgentUsageChart
+					data={data}
+					timeRange="week"
+					theme={theme}
+					sessions={sessions}
+					onAgentClick={vi.fn()}
+				/>
+			);
+
+			const legendButtons = container.querySelectorAll('[role="button"]');
+			// Sorted by total queries desc → Backend (5), Frontend (3).
+			expect(legendButtons.length).toBe(2);
+			legendButtons.forEach((btn) => {
+				expect(btn.getAttribute('tabIndex')).toBe('0');
+				expect((btn as HTMLElement).style.cursor).toBe('pointer');
+			});
+		});
+
+		it('fires onAgentClick with the session key and resolved display name', () => {
+			const { sessions, data } = buildTwoSessionFixture();
+			const onAgentClick = vi.fn();
+			const { container } = render(
+				<AgentUsageChart
+					data={data}
+					timeRange="week"
+					theme={theme}
+					sessions={sessions}
+					onAgentClick={onAgentClick}
+				/>
+			);
+
+			const legendButtons = container.querySelectorAll('[role="button"]');
+			fireEvent.click(legendButtons[0]); // Backend (sorted first by total)
+
+			expect(onAgentClick).toHaveBeenCalledTimes(1);
+			expect(onAgentClick).toHaveBeenCalledWith('sess-aaa', 'Backend');
+		});
+
+		it('fires onAgentClick on Enter and Space key activation', () => {
+			const { sessions, data } = buildTwoSessionFixture();
+			const onAgentClick = vi.fn();
+			const { container } = render(
+				<AgentUsageChart
+					data={data}
+					timeRange="week"
+					theme={theme}
+					sessions={sessions}
+					onAgentClick={onAgentClick}
+				/>
+			);
+
+			const legendButtons = container.querySelectorAll('[role="button"]');
+			fireEvent.keyDown(legendButtons[0], { key: 'Enter' });
+			fireEvent.keyDown(legendButtons[0], { key: ' ' });
+
+			expect(onAgentClick).toHaveBeenCalledTimes(2);
+		});
+
+		it('highlights the matching legend item with an accent background', () => {
+			const { sessions, data } = buildTwoSessionFixture();
+			const { container } = render(
+				<AgentUsageChart
+					data={data}
+					timeRange="week"
+					theme={theme}
+					sessions={sessions}
+					onAgentClick={vi.fn()}
+					activeFilterKey="sess-aaa"
+				/>
+			);
+
+			const legendButtons = container.querySelectorAll(
+				'[role="button"]'
+			) as NodeListOf<HTMLElement>;
+			// Backend (sorted first) is selected; Frontend is not.
+			expect(legendButtons[0].style.backgroundColor).not.toBe('');
+			expect(legendButtons[1].style.backgroundColor).toBe('');
+		});
+
+		it('reflects selection state via aria-pressed', () => {
+			const { sessions, data } = buildTwoSessionFixture();
+			const { container } = render(
+				<AgentUsageChart
+					data={data}
+					timeRange="week"
+					theme={theme}
+					sessions={sessions}
+					onAgentClick={vi.fn()}
+					activeFilterKey="sess-bbb"
+				/>
+			);
+
+			const legendButtons = container.querySelectorAll('[role="button"]');
+			// Sorted: Backend (false), Frontend (true).
+			expect(legendButtons[0].getAttribute('aria-pressed')).toBe('false');
+			expect(legendButtons[1].getAttribute('aria-pressed')).toBe('true');
+		});
+
+		it('dims non-selected lines to 0.15 stroke-opacity and thickens the selected line', () => {
+			const { sessions, data } = buildTwoSessionFixture();
+			const { container } = render(
+				<AgentUsageChart
+					data={data}
+					timeRange="week"
+					theme={theme}
+					sessions={sessions}
+					onAgentClick={vi.fn()}
+					activeFilterKey="sess-aaa"
+				/>
+			);
+
+			// Two lines, sorted: sess-aaa (selected), sess-bbb (dimmed).
+			const lines = container.querySelectorAll('path');
+			expect(lines.length).toBe(2);
+			expect(lines[0].getAttribute('stroke-opacity')).toBe('1');
+			expect(lines[0].getAttribute('stroke-width')).toBe('2.5');
+			expect(lines[1].getAttribute('stroke-opacity')).toBe('0.15');
+			expect(lines[1].getAttribute('stroke-width')).toBe('2');
+		});
+
+		it('renders all lines at full opacity and default width when no filter is active', () => {
+			const { sessions, data } = buildTwoSessionFixture();
+			const { container } = render(
+				<AgentUsageChart
+					data={data}
+					timeRange="week"
+					theme={theme}
+					sessions={sessions}
+					onAgentClick={vi.fn()}
+					activeFilterKey={null}
+				/>
+			);
+
+			const lines = container.querySelectorAll('path');
+			lines.forEach((line) => {
+				expect(line.getAttribute('stroke-opacity')).toBe('1');
+				expect(line.getAttribute('stroke-width')).toBe('2');
+			});
 		});
 	});
 });

--- a/src/__tests__/renderer/components/UsageDashboard/AgentUsageChart.test.tsx
+++ b/src/__tests__/renderer/components/UsageDashboard/AgentUsageChart.test.tsx
@@ -1,0 +1,155 @@
+/**
+ * Tests for AgentUsageChart component
+ *
+ * Focuses on session-name resolution behavior shared with the other dashboard
+ * charts: session keys from `bySessionByDay` are resolved via `buildNameMap`
+ * so the line legend, tooltips, and aria labels show user-assigned session
+ * names (or the prettified type fallback) instead of raw UUID prefixes.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { AgentUsageChart } from '../../../../renderer/components/UsageDashboard/AgentUsageChart';
+import type { StatsAggregation } from '../../../../renderer/hooks/stats/useStats';
+import type { Session } from '../../../../renderer/types';
+import { THEMES } from '../../../../shared/themes';
+
+let _sessionIdCounter = 0;
+function makeSession(overrides: Partial<Session> = {}): Session {
+	_sessionIdCounter++;
+	return {
+		id: `s${_sessionIdCounter}`,
+		name: `Session ${_sessionIdCounter}`,
+		toolType: 'claude-code',
+		state: 'idle',
+		cwd: '/tmp',
+		fullPath: '/tmp',
+		projectRoot: '/tmp',
+		aiLogs: [],
+		shellLogs: [],
+		workLog: [],
+		contextUsage: 0,
+		inputMode: 'ai',
+		aiPid: 0,
+		terminalPid: 0,
+		port: 0,
+		isLive: false,
+		changedFiles: [],
+		isGitRepo: false,
+		fileTree: [],
+		fileExplorerExpanded: [],
+		fileExplorerScrollPos: 0,
+		createdAt: 0,
+		...overrides,
+	} as Session;
+}
+
+const theme = THEMES['dracula'];
+
+const baseEmptyData: StatsAggregation = {
+	totalQueries: 0,
+	totalDuration: 0,
+	avgDuration: 0,
+	byAgent: {},
+	bySource: { user: 0, auto: 0 },
+	byLocation: { local: 0, remote: 0 },
+	byDay: [],
+	byHour: [],
+	totalSessions: 0,
+	sessionsByAgent: {},
+	sessionsByDay: [],
+	avgSessionDuration: 0,
+	byAgentByDay: {},
+	bySessionByDay: {},
+};
+
+function dataForSessions(
+	sessionDays: Record<string, Array<{ date: string; count: number; duration: number }>>
+): StatsAggregation {
+	return { ...baseEmptyData, bySessionByDay: sessionDays };
+}
+
+describe('AgentUsageChart', () => {
+	describe('Rendering', () => {
+		it('renders the title', () => {
+			render(<AgentUsageChart data={baseEmptyData} timeRange="week" theme={theme} />);
+			expect(screen.getByText('Agent Usage Over Time')).toBeInTheDocument();
+		});
+
+		it('renders the empty-state message when no session data is present', () => {
+			render(<AgentUsageChart data={baseEmptyData} timeRange="week" theme={theme} />);
+			expect(screen.getByText('No usage data available')).toBeInTheDocument();
+		});
+	});
+
+	describe('Session Name Resolution', () => {
+		it('uses the user-assigned session name when the stat key matches a session', () => {
+			const session = makeSession({ id: 'sess-aaa', name: 'Backend API' });
+			const data = dataForSessions({
+				'sess-aaa': [{ date: '2024-12-20', count: 5, duration: 60_000 }],
+			});
+
+			render(<AgentUsageChart data={data} timeRange="week" theme={theme} sessions={[session]} />);
+
+			expect(screen.getByText('Backend API')).toBeInTheDocument();
+		});
+
+		it('matches stat keys with tab-id suffixes back to the underlying session', () => {
+			const session = makeSession({ id: 'sess-bbb', name: 'Frontend' });
+			const data = dataForSessions({
+				'sess-bbb-ai-tab1': [{ date: '2024-12-20', count: 3, duration: 30_000 }],
+			});
+
+			render(<AgentUsageChart data={data} timeRange="week" theme={theme} sessions={[session]} />);
+
+			expect(screen.getByText('Frontend')).toBeInTheDocument();
+		});
+
+		it('disambiguates colliding session names with " (2)" suffixes', () => {
+			const a = makeSession({ id: 'sess-aaa', name: 'Worker' });
+			const b = makeSession({ id: 'sess-bbb', name: 'Worker' });
+			const data = dataForSessions({
+				'sess-aaa': [{ date: '2024-12-20', count: 5, duration: 60_000 }],
+				'sess-bbb': [{ date: '2024-12-20', count: 3, duration: 30_000 }],
+			});
+
+			render(<AgentUsageChart data={data} timeRange="week" theme={theme} sessions={[a, b]} />);
+
+			expect(screen.getByText('Worker')).toBeInTheDocument();
+			expect(screen.getByText('Worker (2)')).toBeInTheDocument();
+		});
+
+		it('appends " (WT)" suffix to worktree-child session names', () => {
+			const parent = makeSession({ id: 'parent', name: 'Main App' });
+			const worktree = makeSession({
+				id: 'wt-1',
+				name: 'Feature Branch',
+				parentSessionId: 'parent',
+			});
+			const data = dataForSessions({
+				parent: [{ date: '2024-12-20', count: 5, duration: 60_000 }],
+				'wt-1': [{ date: '2024-12-20', count: 3, duration: 30_000 }],
+			});
+
+			render(
+				<AgentUsageChart data={data} timeRange="week" theme={theme} sessions={[parent, worktree]} />
+			);
+
+			expect(screen.getByText('Main App')).toBeInTheDocument();
+			expect(screen.getByText('Feature Branch (WT)')).toBeInTheDocument();
+		});
+
+		it('falls back to a prettified key when no matching session exists', () => {
+			// "claude-code" is the canonical agent id, so prettifyAgentType returns
+			// "Claude Code" — used as the legend label when no session is registered
+			// for this stat key.
+			const data = dataForSessions({
+				'claude-code': [{ date: '2024-12-20', count: 5, duration: 60_000 }],
+			});
+
+			render(<AgentUsageChart data={data} timeRange="week" theme={theme} sessions={[]} />);
+
+			expect(screen.getByText('Claude Code')).toBeInTheDocument();
+		});
+	});
+});

--- a/src/__tests__/renderer/components/UsageDashboard/SessionStats.test.tsx
+++ b/src/__tests__/renderer/components/UsageDashboard/SessionStats.test.tsx
@@ -102,3 +102,41 @@ describe('SessionStats — worktree breakdown', () => {
 		expect(screen.queryByTestId('worktree-breakdown')).not.toBeInTheDocument();
 	});
 });
+
+describe('SessionStats — agent type display names', () => {
+	it('shows the user-assigned name when only one session of that type exists', () => {
+		const sessions = [makeSession({ name: 'Backend API', toolType: 'claude-code' })];
+
+		render(<SessionStats sessions={sessions} theme={theme} />);
+
+		expect(screen.getByText('Backend API')).toBeInTheDocument();
+		expect(screen.queryByText('Claude Code')).not.toBeInTheDocument();
+	});
+
+	it('shows the prettified type when multiple sessions share the type', () => {
+		const sessions = [
+			makeSession({ name: 'Frontend', toolType: 'claude-code' }),
+			makeSession({ name: 'Backend', toolType: 'claude-code' }),
+		];
+
+		render(<SessionStats sessions={sessions} theme={theme} />);
+
+		expect(screen.getByText('Claude Code')).toBeInTheDocument();
+		expect(screen.queryByText('Frontend')).not.toBeInTheDocument();
+		expect(screen.queryByText('Backend')).not.toBeInTheDocument();
+	});
+
+	it('uses canonical display names for known agent types via shared resolver', () => {
+		const sessions = [
+			makeSession({ name: 'A', toolType: 'opencode' }),
+			makeSession({ name: 'B', toolType: 'opencode' }),
+			makeSession({ name: 'C', toolType: 'factory-droid' }),
+			makeSession({ name: 'D', toolType: 'factory-droid' }),
+		];
+
+		render(<SessionStats sessions={sessions} theme={theme} />);
+
+		expect(screen.getByText('OpenCode')).toBeInTheDocument();
+		expect(screen.getByText('Factory Droid')).toBeInTheDocument();
+	});
+});

--- a/src/__tests__/renderer/components/UsageDashboard/SessionStats.test.tsx
+++ b/src/__tests__/renderer/components/UsageDashboard/SessionStats.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * Tests for SessionStats component
+ *
+ * Verifies the worktree vs regular session breakdown introduced in
+ * Doc 1 of the Dashboard Enhancements playbook (worktree differentiation).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { SessionStats } from '../../../../renderer/components/UsageDashboard/SessionStats';
+import type { Session } from '../../../../renderer/types';
+import { THEMES } from '../../../../shared/themes';
+
+const theme = THEMES['dracula'];
+
+let idCounter = 0;
+function makeSession(overrides: Partial<Session> = {}): Session {
+	idCounter++;
+	return {
+		id: `s${idCounter}`,
+		name: `Session ${idCounter}`,
+		toolType: 'claude-code',
+		state: 'idle',
+		cwd: '/tmp',
+		fullPath: '/tmp',
+		projectRoot: '/tmp',
+		aiLogs: [],
+		shellLogs: [],
+		workLog: [],
+		contextUsage: 0,
+		inputMode: 'ai',
+		aiPid: 0,
+		terminalPid: 0,
+		port: 0,
+		isLive: false,
+		changedFiles: [],
+		isGitRepo: false,
+		fileTree: [],
+		fileExplorerExpanded: [],
+		fileExplorerScrollPos: 0,
+		createdAt: 0,
+		...overrides,
+	} as Session;
+}
+
+describe('SessionStats — worktree breakdown', () => {
+	it('renders the Regular | Worktree stat pair when sessions exist', () => {
+		const sessions = [
+			makeSession(),
+			makeSession({ parentSessionId: 'parent-1' }),
+			makeSession({ parentSessionId: 'parent-1' }),
+		];
+
+		render(<SessionStats sessions={sessions} theme={theme} />);
+
+		const breakdown = screen.getByTestId('worktree-breakdown');
+		expect(breakdown).toBeInTheDocument();
+		expect(breakdown.textContent).toContain('Regular:');
+		expect(breakdown.textContent).toContain('1');
+		expect(breakdown.textContent).toContain('Worktree:');
+		expect(breakdown.textContent).toContain('2');
+	});
+
+	it('counts parent agents (worktreeConfig set) as Regular, not Worktree', () => {
+		const sessions = [
+			makeSession({ worktreeConfig: { basePath: '/tmp/wt', watchEnabled: true } }),
+			makeSession({ parentSessionId: 'parent-1' }),
+		];
+
+		render(<SessionStats sessions={sessions} theme={theme} />);
+
+		const breakdown = screen.getByTestId('worktree-breakdown');
+		expect(breakdown).toHaveAttribute('aria-label', 'Regular: 1 | Worktree: 1');
+	});
+
+	it('shows zero counts when there are no worktree children', () => {
+		const sessions = [makeSession(), makeSession()];
+
+		render(<SessionStats sessions={sessions} theme={theme} />);
+
+		const breakdown = screen.getByTestId('worktree-breakdown');
+		expect(breakdown).toHaveAttribute('aria-label', 'Regular: 2 | Worktree: 0');
+	});
+
+	it('excludes terminal sessions from the worktree breakdown', () => {
+		const sessions = [
+			makeSession({ toolType: 'terminal' }),
+			makeSession({ toolType: 'terminal', parentSessionId: 'p1' }),
+			makeSession(),
+			makeSession({ parentSessionId: 'p2' }),
+		];
+
+		render(<SessionStats sessions={sessions} theme={theme} />);
+
+		const breakdown = screen.getByTestId('worktree-breakdown');
+		expect(breakdown).toHaveAttribute('aria-label', 'Regular: 1 | Worktree: 1');
+	});
+
+	it('does not render the breakdown row when no agent sessions exist', () => {
+		render(<SessionStats sessions={[]} theme={theme} />);
+
+		expect(screen.queryByTestId('worktree-breakdown')).not.toBeInTheDocument();
+	});
+});

--- a/src/__tests__/renderer/components/UsageDashboard/SummaryCards.test.tsx
+++ b/src/__tests__/renderer/components/UsageDashboard/SummaryCards.test.tsx
@@ -16,7 +16,10 @@ import React from 'react';
 import {
 	AnimatedNumber,
 	BouncingDots,
+	ContextUsageBar,
+	RealtimeMetricsCard,
 	SummaryCards,
+	TokenCostBadge,
 } from '../../../../renderer/components/UsageDashboard/SummaryCards';
 import type { StatsAggregation } from '../../../../renderer/hooks/stats/useStats';
 import type { Session } from '../../../../renderer/types';
@@ -380,12 +383,11 @@ describe('SummaryCards', () => {
 
 	describe('Icons', () => {
 		it('renders SVG icons for each metric', () => {
-			const { container } = render(
-				<SummaryCards data={mockData} theme={theme} sessions={mockSessions} />
-			);
+			render(<SummaryCards data={mockData} theme={theme} sessions={mockSessions} />);
 
-			// Each card should have an SVG icon (10 cards = 10 icons)
-			const svgElements = container.querySelectorAll('svg');
+			// Scope to the metrics grid so the realtime card's icons don't inflate the count
+			const grid = screen.getByTestId('summary-cards');
+			const svgElements = grid.querySelectorAll('svg');
 			expect(svgElements.length).toBe(10);
 		});
 	});
@@ -564,5 +566,158 @@ describe('BouncingDots', () => {
 		const root = screen.getByTestId('bouncing-dots');
 		// Without a color prop, the element falls through to currentColor from CSS.
 		expect(root.getAttribute('style')).toBeFalsy();
+	});
+});
+
+// JSDOM normalises CSS hex colors into `rgb(...)` form when they round-trip
+// through inline `style`, so we compare the normalised form for theme colors.
+function hexToRgb(hex: string): string {
+	const value = hex.replace('#', '');
+	const r = parseInt(value.slice(0, 2), 16);
+	const g = parseInt(value.slice(2, 4), 16);
+	const b = parseInt(value.slice(4, 6), 16);
+	return `rgb(${r}, ${g}, ${b})`;
+}
+
+describe('ContextUsageBar', () => {
+	it('renders the percentage rounded to a whole number', () => {
+		render(<ContextUsageBar percentage={42.7} theme={theme} />);
+
+		expect(screen.getByText('43%')).toBeInTheDocument();
+	});
+
+	it('caps values above 100 at 100% so the bar never overflows', () => {
+		render(<ContextUsageBar percentage={150} theme={theme} />);
+
+		expect(screen.getByText('100%')).toBeInTheDocument();
+		const bar = screen.getByRole('progressbar');
+		expect(bar.getAttribute('aria-valuenow')).toBe('100');
+	});
+
+	it('uses the success color for usage below the warning threshold', () => {
+		render(<ContextUsageBar percentage={40} theme={theme} />);
+
+		const bar = screen.getByRole('progressbar');
+		const fill = bar.firstElementChild as HTMLElement;
+		expect(fill.style.backgroundColor).toBe(hexToRgb(theme.colors.success));
+		// No critical glow under the warning threshold.
+		expect(fill.style.boxShadow).toBe('');
+	});
+
+	it('uses the warning color in the 70-89% band', () => {
+		render(<ContextUsageBar percentage={75} theme={theme} />);
+
+		const bar = screen.getByRole('progressbar');
+		const fill = bar.firstElementChild as HTMLElement;
+		expect(fill.style.backgroundColor).toBe(hexToRgb(theme.colors.warning));
+	});
+
+	it('uses the error color and adds a glow at or above 90%', () => {
+		render(<ContextUsageBar percentage={92} theme={theme} />);
+
+		const bar = screen.getByRole('progressbar');
+		const fill = bar.firstElementChild as HTMLElement;
+		expect(fill.style.backgroundColor).toBe(hexToRgb(theme.colors.error));
+		expect(fill.style.boxShadow).not.toBe('');
+	});
+});
+
+const buildSession = (overrides: Partial<Session>): Session =>
+	({
+		id: 'sess-1',
+		name: 'Agent One',
+		toolType: 'claude-code',
+		state: 'idle',
+		contextUsage: 0,
+		...overrides,
+	}) as Session;
+
+describe('TokenCostBadge', () => {
+	it('aggregates currentCycleTokens across busy sessions only', () => {
+		const sessions = [
+			buildSession({ id: 'a', state: 'busy', currentCycleTokens: 1500, name: 'Alpha' }),
+			buildSession({ id: 'b', state: 'busy', currentCycleTokens: 2500, name: 'Beta' }),
+			// Idle session is ignored even if it reports a token count.
+			buildSession({ id: 'c', state: 'idle', currentCycleTokens: 9999, name: 'Gamma' }),
+		];
+
+		render(<TokenCostBadge sessions={sessions} theme={theme} />);
+
+		// 4000 total → "4.0K"
+		expect(screen.getByText('4.0K')).toBeInTheDocument();
+		expect(screen.getByText(/Alpha/)).toBeInTheDocument();
+		expect(screen.getByText(/Beta/)).toBeInTheDocument();
+		expect(screen.queryByText(/Gamma/)).not.toBeInTheDocument();
+	});
+
+	it('shows $0.00 when there are no busy sessions', () => {
+		render(<TokenCostBadge sessions={[]} theme={theme} />);
+
+		expect(screen.getByTestId('token-cost-estimate').textContent).toBe('$0.00');
+	});
+
+	it('omits the breakdown when no busy session reports tokens', () => {
+		const sessions = [buildSession({ state: 'busy', currentCycleTokens: 0 })];
+		render(<TokenCostBadge sessions={sessions} theme={theme} />);
+
+		expect(screen.queryByTestId('token-cost-breakdown')).not.toBeInTheDocument();
+	});
+});
+
+describe('RealtimeMetricsCard', () => {
+	it('uses the highest contextUsage across active sessions for the bar', () => {
+		const sessions = [
+			buildSession({ id: '1', state: 'idle', contextUsage: 45 }),
+			buildSession({ id: '2', state: 'busy', contextUsage: 88 }),
+			// Error sessions are excluded from "active" so this 99 must NOT win.
+			buildSession({ id: '3', state: 'error', contextUsage: 99 }),
+		];
+
+		render(<RealtimeMetricsCard sessions={sessions} theme={theme} />);
+
+		expect(screen.getByText('88%')).toBeInTheDocument();
+	});
+
+	it('shows the active agent count with correct singular/plural label', () => {
+		const single = [buildSession({ state: 'idle', contextUsage: 10 })];
+		const { unmount } = render(<RealtimeMetricsCard sessions={single} theme={theme} />);
+		expect(screen.getByText('1 active agent')).toBeInTheDocument();
+		unmount();
+
+		const many = [
+			buildSession({ id: 'a', state: 'idle' }),
+			buildSession({ id: 'b', state: 'busy' }),
+		];
+		render(<RealtimeMetricsCard sessions={many} theme={theme} />);
+		expect(screen.getByText('2 active agents')).toBeInTheDocument();
+	});
+
+	it('renders the thinking indicator only when a busy session has thinkingStartTime', () => {
+		const now = Date.now();
+		const sessions = [
+			buildSession({ state: 'busy', thinkingStartTime: now - 5500, contextUsage: 30 }),
+		];
+
+		render(<RealtimeMetricsCard sessions={sessions} theme={theme} />);
+
+		const indicator = screen.getByTestId('realtime-thinking-elapsed');
+		// 5500ms → 5s elapsed
+		expect(indicator.textContent).toContain('5s');
+	});
+
+	it('hides the thinking indicator when no session is actively thinking', () => {
+		const sessions = [buildSession({ state: 'idle', contextUsage: 20 })];
+
+		render(<RealtimeMetricsCard sessions={sessions} theme={theme} />);
+
+		expect(screen.queryByTestId('realtime-thinking-elapsed')).not.toBeInTheDocument();
+	});
+
+	it('applies the animation delay as inline style for staggered entrance', () => {
+		render(<RealtimeMetricsCard sessions={[]} theme={theme} animationDelay={320} />);
+
+		const card = screen.getByTestId('realtime-metrics-card');
+		expect(card.style.animationDelay).toBe('320ms');
+		expect(card.className).toContain('card-enter');
 	});
 });

--- a/src/__tests__/renderer/components/UsageDashboard/SummaryCards.test.tsx
+++ b/src/__tests__/renderer/components/UsageDashboard/SummaryCards.test.tsx
@@ -13,7 +13,11 @@
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { SummaryCards } from '../../../../renderer/components/UsageDashboard/SummaryCards';
+import {
+	AnimatedNumber,
+	BouncingDots,
+	SummaryCards,
+} from '../../../../renderer/components/UsageDashboard/SummaryCards';
 import type { StatsAggregation } from '../../../../renderer/hooks/stats/useStats';
 import type { Session } from '../../../../renderer/types';
 import { THEMES } from '../../../../shared/themes';
@@ -161,11 +165,11 @@ describe('SummaryCards', () => {
 			expect(cards).toHaveLength(10);
 		});
 
-		it('renders Total Queries metric', () => {
+		it('renders Total Queries metric', async () => {
 			render(<SummaryCards data={mockData} theme={theme} />);
 
 			expect(screen.getByText('Total Queries')).toBeInTheDocument();
-			expect(screen.getByText('150')).toBeInTheDocument();
+			expect(await screen.findByText('150')).toBeInTheDocument();
 		});
 
 		it('renders Total Time metric', () => {
@@ -218,30 +222,30 @@ describe('SummaryCards', () => {
 	});
 
 	describe('Number Formatting', () => {
-		it('formats thousands with K suffix', () => {
+		it('formats thousands with K suffix', async () => {
 			const dataWithThousands: StatsAggregation = {
 				...mockData,
 				totalQueries: 1500,
 			};
 			render(<SummaryCards data={dataWithThousands} theme={theme} />);
 
-			expect(screen.getByText('1.5K')).toBeInTheDocument();
+			expect(await screen.findByText('1.5K')).toBeInTheDocument();
 		});
 
-		it('formats millions with M suffix', () => {
+		it('formats millions with M suffix', async () => {
 			render(<SummaryCards data={largeNumbersData} theme={theme} />);
 
-			expect(screen.getByText('1.5M')).toBeInTheDocument();
+			expect(await screen.findByText('1.5M')).toBeInTheDocument();
 		});
 
-		it('displays small numbers without suffix', () => {
+		it('displays small numbers without suffix', async () => {
 			const dataWithSmallNumbers: StatsAggregation = {
 				...mockData,
 				totalQueries: 42,
 			};
 			render(<SummaryCards data={dataWithSmallNumbers} theme={theme} />);
 
-			expect(screen.getByText('42')).toBeInTheDocument();
+			expect(await screen.findByText('42')).toBeInTheDocument();
 		});
 	});
 
@@ -426,10 +430,10 @@ describe('SummaryCards', () => {
 			expect(screen.getAllByText('0').length).toBeGreaterThanOrEqual(1);
 		});
 
-		it('handles very large numbers', () => {
+		it('handles very large numbers', async () => {
 			render(<SummaryCards data={largeNumbersData} theme={theme} />);
 
-			expect(screen.getByText('1.5M')).toBeInTheDocument();
+			expect(await screen.findByText('1.5M')).toBeInTheDocument();
 			expect(screen.getByText('100h 0m')).toBeInTheDocument();
 		});
 
@@ -456,5 +460,109 @@ describe('SummaryCards', () => {
 			const valueElements = container.querySelectorAll('[title]');
 			expect(valueElements.length).toBeGreaterThan(0);
 		});
+	});
+});
+
+describe('AnimatedNumber', () => {
+	it('renders the final numeric value after the count-up animation completes', async () => {
+		render(<AnimatedNumber value="150" />);
+
+		expect(await screen.findByText('150')).toBeInTheDocument();
+	});
+
+	it('starts numeric values from 0 before the animation runs', () => {
+		const { container } = render(<AnimatedNumber value="150" />);
+
+		// Initial state renders the count-up start, not the final value.
+		expect(container.textContent).toBe('0');
+	});
+
+	it('preserves the K suffix and decimal precision while animating', async () => {
+		render(<AnimatedNumber value="1.5K" />);
+
+		expect(await screen.findByText('1.5K')).toBeInTheDocument();
+	});
+
+	it('preserves the M suffix and decimal precision while animating', async () => {
+		render(<AnimatedNumber value="2.0M" />);
+
+		expect(await screen.findByText('2.0M')).toBeInTheDocument();
+	});
+
+	it('preserves the % suffix while animating', async () => {
+		render(<AnimatedNumber value="80%" />);
+
+		expect(await screen.findByText('80%')).toBeInTheDocument();
+	});
+
+	it('renders duration strings immediately without animation', () => {
+		render(<AnimatedNumber value="12h 34m" />);
+
+		// Strings that aren't pure numerics display the final value on the first render.
+		expect(screen.getByText('12h 34m')).toBeInTheDocument();
+	});
+
+	it('renders peak hour strings immediately without animation', () => {
+		render(<AnimatedNumber value="9 AM" />);
+
+		expect(screen.getByText('9 AM')).toBeInTheDocument();
+	});
+
+	it('renders agent name strings immediately without animation', () => {
+		render(<AnimatedNumber value="claude-code" />);
+
+		expect(screen.getByText('claude-code')).toBeInTheDocument();
+	});
+
+	it('renders the N/A placeholder immediately without animation', () => {
+		render(<AnimatedNumber value="N/A" />);
+
+		expect(screen.getByText('N/A')).toBeInTheDocument();
+	});
+
+	it('renders zero values without breaking', () => {
+		const { container } = render(<AnimatedNumber value="0" />);
+
+		// 0 → 0 animation displays 0 throughout, including initial state.
+		expect(container.textContent).toBe('0');
+	});
+});
+
+describe('BouncingDots', () => {
+	it('renders three dot spans inside the bounce-dots container', () => {
+		const { container } = render(<BouncingDots />);
+
+		const root = container.querySelector('.bounce-dots');
+		expect(root).not.toBeNull();
+		expect(root?.querySelectorAll('span').length).toBe(3);
+	});
+
+	it('has a status role with a default loading label for screen readers', () => {
+		render(<BouncingDots />);
+
+		const root = screen.getByTestId('bouncing-dots');
+		expect(root).toHaveAttribute('role', 'status');
+		expect(root).toHaveAttribute('aria-label', 'Loading');
+	});
+
+	it('accepts a custom aria-label', () => {
+		render(<BouncingDots label="Agent thinking" />);
+
+		expect(screen.getByTestId('bouncing-dots')).toHaveAttribute('aria-label', 'Agent thinking');
+	});
+
+	it('applies the color prop as inline color so dots inherit currentColor', () => {
+		render(<BouncingDots color="#ff79c6" />);
+
+		const root = screen.getByTestId('bouncing-dots');
+		expect(root).toHaveStyle({ color: '#ff79c6' });
+	});
+
+	it('omits inline color when no color prop is provided', () => {
+		render(<BouncingDots />);
+
+		const root = screen.getByTestId('bouncing-dots');
+		// Without a color prop, the element falls through to currentColor from CSS.
+		expect(root.getAttribute('style')).toBeFalsy();
 	});
 });

--- a/src/__tests__/renderer/components/UsageDashboard/SummaryCards.test.tsx
+++ b/src/__tests__/renderer/components/UsageDashboard/SummaryCards.test.tsx
@@ -385,10 +385,59 @@ describe('SummaryCards', () => {
 		it('renders SVG icons for each metric', () => {
 			render(<SummaryCards data={mockData} theme={theme} sessions={mockSessions} />);
 
-			// Scope to the metrics grid so the realtime card's icons don't inflate the count
+			// Scope to the metrics grid so the realtime card's icons don't inflate the count.
+			// Subtract sparkline SVGs (rendered for the Total Queries + Total Time cards) so
+			// this assertion stays focused on the per-metric lucide icon.
 			const grid = screen.getByTestId('summary-cards');
 			const svgElements = grid.querySelectorAll('svg');
-			expect(svgElements.length).toBe(10);
+			const sparklines = grid.querySelectorAll(
+				'[data-testid="sparkline"], [data-testid="sparkline-empty"]'
+			);
+			expect(svgElements.length - sparklines.length).toBe(10);
+		});
+	});
+
+	describe('Sparklines', () => {
+		const dataWithByDay: StatsAggregation = {
+			...mockData,
+			byDay: [
+				{ date: '2024-12-15', count: 10, duration: 600000 },
+				{ date: '2024-12-16', count: 20, duration: 1200000 },
+				{ date: '2024-12-17', count: 15, duration: 800000 },
+				{ date: '2024-12-18', count: 30, duration: 1500000 },
+				{ date: '2024-12-19', count: 25, duration: 1300000 },
+				{ date: '2024-12-20', count: 50, duration: 2400000 },
+				{ date: '2024-12-21', count: 100, duration: 4800000 },
+			],
+		};
+
+		it('renders sparklines on Total Queries and Total Time cards when byDay has data', () => {
+			render(<SummaryCards data={dataWithByDay} theme={theme} />);
+
+			const queriesCard = screen.getByRole('group', { name: /Total Queries: 150/i });
+			const totalTimeCard = screen.getByRole('group', { name: /Total Time: 2h 0m/i });
+
+			expect(queriesCard.querySelector('[data-testid="sparkline"]')).not.toBeNull();
+			expect(totalTimeCard.querySelector('[data-testid="sparkline"]')).not.toBeNull();
+		});
+
+		it('does not render sparklines on cards without trend data', () => {
+			render(<SummaryCards data={dataWithByDay} theme={theme} sessions={mockSessions} />);
+
+			const agentsCard = screen.getByRole('group', { name: /^Agents:/i });
+			const openTabsCard = screen.getByRole('group', { name: /Open Tabs:/i });
+
+			expect(agentsCard.querySelector('[data-testid="sparkline"]')).toBeNull();
+			expect(openTabsCard.querySelector('[data-testid="sparkline"]')).toBeNull();
+		});
+
+		it('renders an empty (dashed-baseline) sparkline when byDay is empty', () => {
+			// emptyData has byDay: [] — left-padded to seven zeros, the Sparkline
+			// collapses to its empty/dashed baseline state.
+			render(<SummaryCards data={emptyData} theme={theme} />);
+
+			const queriesCard = screen.getByRole('group', { name: /Total Queries: 0/i });
+			expect(queriesCard.querySelector('[data-testid="sparkline-empty"]')).not.toBeNull();
 		});
 	});
 

--- a/src/__tests__/renderer/components/UsageDashboard/SummaryCards.test.tsx
+++ b/src/__tests__/renderer/components/UsageDashboard/SummaryCards.test.tsx
@@ -347,7 +347,7 @@ describe('SummaryCards', () => {
 			const cards = screen.getAllByTestId('metric-card');
 			cards.forEach((card) => {
 				expect(card).toHaveStyle({
-					backgroundColor: theme.colors.bgMain,
+					backgroundColor: theme.colors.bgActivity,
 				});
 			});
 		});
@@ -368,7 +368,7 @@ describe('SummaryCards', () => {
 			const cards = screen.getAllByTestId('metric-card');
 			cards.forEach((card) => {
 				expect(card).toHaveStyle({
-					backgroundColor: nordTheme.colors.bgMain,
+					backgroundColor: nordTheme.colors.bgActivity,
 				});
 			});
 		});

--- a/src/__tests__/renderer/components/UsageDashboard/WorktreeAnalytics.test.tsx
+++ b/src/__tests__/renderer/components/UsageDashboard/WorktreeAnalytics.test.tsx
@@ -1,0 +1,305 @@
+/**
+ * Tests for WorktreeAnalytics component
+ *
+ * Verifies:
+ * - Renders Parent / Worktree summary cards with correct counts
+ * - Ratio badge formats correctly across edge cases (no parents, both zero)
+ * - Activity split bar reflects parent / worktree query proportions and
+ *   surfaces the dashed pattern on the worktree segment
+ * - Empty-data state of the activity bar shows the placeholder row
+ * - Per-branch breakdown sorts by query count descending and shows the
+ *   branch name + sparkline; absent worktrees render the empty hint
+ * - Terminal sessions are excluded from agent counts
+ * - Card-enter staggered animations are applied
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import { WorktreeAnalytics } from '../../../../renderer/components/UsageDashboard/WorktreeAnalytics';
+import type { StatsAggregation } from '../../../../renderer/hooks/stats/useStats';
+import type { Session } from '../../../../renderer/types';
+import { THEMES } from '../../../../shared/themes';
+
+const theme = THEMES['dracula'];
+
+const buildSession = (overrides: Partial<Session>): Session =>
+	({
+		id: 'sess-1',
+		name: 'Agent One',
+		toolType: 'claude-code',
+		state: 'idle',
+		contextUsage: 0,
+		...overrides,
+	}) as Session;
+
+const buildData = (overrides: Partial<StatsAggregation> = {}): StatsAggregation => ({
+	totalQueries: 0,
+	totalDuration: 0,
+	avgDuration: 0,
+	byAgent: {},
+	bySource: { user: 0, auto: 0 },
+	byLocation: { local: 0, remote: 0 },
+	byDay: [],
+	byHour: [],
+	totalSessions: 0,
+	sessionsByAgent: {},
+	sessionsByDay: [],
+	avgSessionDuration: 0,
+	byAgentByDay: {},
+	bySessionByDay: {},
+	...overrides,
+});
+
+describe('WorktreeAnalytics', () => {
+	it('renders the section with role + aria label', () => {
+		render(
+			<WorktreeAnalytics
+				sessions={[buildSession({ id: 'p', name: 'Parent' })]}
+				data={buildData()}
+				theme={theme}
+			/>
+		);
+		expect(screen.getByTestId('worktree-analytics')).toBeInTheDocument();
+		expect(screen.getByRole('region', { name: 'Worktree Analytics' })).toBeInTheDocument();
+	});
+
+	it('renders Parent and Worktree summary cards with correct counts', () => {
+		const sessions: Session[] = [
+			buildSession({ id: 'p1', name: 'Parent A' }),
+			buildSession({ id: 'p2', name: 'Parent B' }),
+			buildSession({ id: 'w1', name: 'WT One', parentSessionId: 'p1' }),
+			buildSession({ id: 'w2', name: 'WT Two', parentSessionId: 'p1' }),
+			buildSession({ id: 'w3', name: 'WT Three', parentSessionId: 'p2' }),
+		];
+
+		render(<WorktreeAnalytics sessions={sessions} data={buildData()} theme={theme} />);
+
+		const cards = screen.getAllByTestId('worktree-stat-card');
+		expect(cards).toHaveLength(2);
+		expect(cards[0]).toHaveAttribute('aria-label', 'Parent Agents: 2');
+		expect(cards[1]).toHaveAttribute('aria-label', 'Worktree Agents: 3');
+	});
+
+	it('excludes terminal sessions from the parent / worktree counts', () => {
+		const sessions: Session[] = [
+			buildSession({ id: 't1', toolType: 'terminal' }),
+			buildSession({ id: 't2', toolType: 'terminal', parentSessionId: 'x' }),
+			buildSession({ id: 'p1', name: 'Parent' }),
+			buildSession({ id: 'w1', name: 'Worktree', parentSessionId: 'p1' }),
+		];
+
+		render(<WorktreeAnalytics sessions={sessions} data={buildData()} theme={theme} />);
+
+		const cards = screen.getAllByTestId('worktree-stat-card');
+		expect(cards[0]).toHaveAttribute('aria-label', 'Parent Agents: 1');
+		expect(cards[1]).toHaveAttribute('aria-label', 'Worktree Agents: 1');
+	});
+
+	describe('ratio badge', () => {
+		it('shows an em dash when no agents exist', () => {
+			render(<WorktreeAnalytics sessions={[]} data={buildData()} theme={theme} />);
+			expect(screen.getByTestId('worktree-ratio-badge').textContent).toBe('—');
+		});
+
+		it('shows the worktree-to-parent ratio with two decimals', () => {
+			const sessions: Session[] = [
+				buildSession({ id: 'p1' }),
+				buildSession({ id: 'p2' }),
+				buildSession({ id: 'w1', parentSessionId: 'p1' }),
+				buildSession({ id: 'w2', parentSessionId: 'p1' }),
+				buildSession({ id: 'w3', parentSessionId: 'p2' }),
+			];
+			render(<WorktreeAnalytics sessions={sessions} data={buildData()} theme={theme} />);
+			expect(screen.getByTestId('worktree-ratio-badge').textContent).toBe('1.50×');
+		});
+
+		it('shows infinity when there are worktrees but no parents (orphaned children)', () => {
+			const sessions: Session[] = [buildSession({ id: 'w1', parentSessionId: 'missing' })];
+			render(<WorktreeAnalytics sessions={sessions} data={buildData()} theme={theme} />);
+			expect(screen.getByTestId('worktree-ratio-badge').textContent).toBe('∞×');
+		});
+	});
+
+	describe('activity split bar', () => {
+		it('renders the empty placeholder when there is no query activity', () => {
+			render(
+				<WorktreeAnalytics
+					sessions={[buildSession({ id: 'p1' })]}
+					data={buildData({ worktreeQueries: 0, parentQueries: 0 })}
+					theme={theme}
+				/>
+			);
+			expect(screen.getByTestId('worktree-split-bar-empty')).toBeInTheDocument();
+			expect(screen.queryByTestId('worktree-split-bar')).not.toBeInTheDocument();
+		});
+
+		it('sizes parent and worktree segments by query proportion', () => {
+			render(
+				<WorktreeAnalytics
+					sessions={[buildSession({ id: 'p1' })]}
+					data={buildData({ parentQueries: 75, worktreeQueries: 25 })}
+					theme={theme}
+				/>
+			);
+			const parent = screen.getByTestId('worktree-split-parent') as HTMLElement;
+			const worktree = screen.getByTestId('worktree-split-worktree') as HTMLElement;
+			expect(parent.style.width).toBe('75%');
+			expect(worktree.style.width).toBe('25%');
+		});
+
+		it('applies the dashed pattern to the worktree segment only', () => {
+			render(
+				<WorktreeAnalytics
+					sessions={[buildSession({ id: 'p1' })]}
+					data={buildData({ parentQueries: 50, worktreeQueries: 50 })}
+					theme={theme}
+				/>
+			);
+			const parent = screen.getByTestId('worktree-split-parent') as HTMLElement;
+			const worktree = screen.getByTestId('worktree-split-worktree') as HTMLElement;
+			expect(parent.style.backgroundImage).toBe('');
+			expect(worktree.style.backgroundImage).toContain('repeating-linear-gradient');
+		});
+
+		it('exposes overall percentages via aria-label for screen readers', () => {
+			render(
+				<WorktreeAnalytics
+					sessions={[buildSession({ id: 'p1' })]}
+					data={buildData({ parentQueries: 30, worktreeQueries: 70 })}
+					theme={theme}
+				/>
+			);
+			expect(screen.getByTestId('worktree-split-bar')).toHaveAttribute(
+				'aria-label',
+				'Parent 30%, Worktree 70%'
+			);
+		});
+
+		it('treats missing worktreeQueries / parentQueries as zero', () => {
+			render(
+				<WorktreeAnalytics
+					sessions={[buildSession({ id: 'p1' })]}
+					data={buildData()}
+					theme={theme}
+				/>
+			);
+			expect(screen.getByTestId('worktree-split-bar-empty')).toBeInTheDocument();
+		});
+	});
+
+	describe('per-branch breakdown', () => {
+		it('renders the empty hint when there are no worktree sessions', () => {
+			render(
+				<WorktreeAnalytics
+					sessions={[buildSession({ id: 'p1' })]}
+					data={buildData()}
+					theme={theme}
+				/>
+			);
+			expect(screen.getByTestId('worktree-branch-empty')).toBeInTheDocument();
+			expect(screen.queryByTestId('worktree-branch-list')).not.toBeInTheDocument();
+		});
+
+		it('sorts worktree rows by query count descending', () => {
+			const sessions: Session[] = [
+				buildSession({
+					id: 'low',
+					name: 'Low Activity',
+					parentSessionId: 'p1',
+					worktreeBranch: 'feat/low',
+				}),
+				buildSession({
+					id: 'high',
+					name: 'High Activity',
+					parentSessionId: 'p1',
+					worktreeBranch: 'feat/high',
+				}),
+				buildSession({
+					id: 'mid',
+					name: 'Mid Activity',
+					parentSessionId: 'p1',
+					worktreeBranch: 'feat/mid',
+				}),
+			];
+
+			const data = buildData({
+				bySessionByDay: {
+					low: [{ date: '2024-12-21', count: 1, duration: 0 }],
+					high: [
+						{ date: '2024-12-20', count: 10, duration: 0 },
+						{ date: '2024-12-21', count: 15, duration: 0 },
+					],
+					mid: [{ date: '2024-12-21', count: 5, duration: 0 }],
+				},
+			});
+
+			render(<WorktreeAnalytics sessions={sessions} data={data} theme={theme} />);
+
+			const rows = screen.getAllByTestId('worktree-branch-row');
+			expect(rows).toHaveLength(3);
+
+			const branchNames = rows.map(
+				(row) => within(row).getByTestId('worktree-branch-name').textContent
+			);
+			expect(branchNames).toEqual(['feat/high', 'feat/mid', 'feat/low']);
+
+			const counts = rows.map(
+				(row) => within(row).getByTestId('worktree-branch-count').textContent
+			);
+			expect(counts).toEqual(['25', '5', '1']);
+		});
+
+		it('falls back to the session name when worktreeBranch is missing', () => {
+			const sessions: Session[] = [
+				buildSession({
+					id: 'wt1',
+					name: 'Unnamed Branch Agent',
+					parentSessionId: 'p1',
+				}),
+			];
+			render(<WorktreeAnalytics sessions={sessions} data={buildData()} theme={theme} />);
+			expect(screen.getByTestId('worktree-branch-name').textContent).toBe('Unnamed Branch Agent');
+		});
+
+		it('renders an active sparkline when bySessionByDay has data', () => {
+			const sessions: Session[] = [
+				buildSession({ id: 'wt1', parentSessionId: 'p1', worktreeBranch: 'feat/x' }),
+			];
+			const data = buildData({
+				bySessionByDay: { wt1: [{ date: '2024-12-21', count: 7, duration: 0 }] },
+			});
+			render(<WorktreeAnalytics sessions={sessions} data={data} theme={theme} />);
+			const row = screen.getByTestId('worktree-branch-row');
+			expect(row.querySelector('[data-testid="sparkline"]')).not.toBeNull();
+		});
+
+		it('renders the dashed empty sparkline when no per-session data exists', () => {
+			const sessions: Session[] = [
+				buildSession({ id: 'wt1', parentSessionId: 'p1', worktreeBranch: 'feat/x' }),
+			];
+			render(<WorktreeAnalytics sessions={sessions} data={buildData()} theme={theme} />);
+			const row = screen.getByTestId('worktree-branch-row');
+			expect(row.querySelector('[data-testid="sparkline-empty"]')).not.toBeNull();
+		});
+	});
+
+	it('staggers card-enter animation delays on stat cards (80ms) and branch rows (60ms)', () => {
+		const sessions: Session[] = [
+			buildSession({ id: 'p1', name: 'Parent' }),
+			buildSession({ id: 'wt1', parentSessionId: 'p1', worktreeBranch: 'feat/a' }),
+			buildSession({ id: 'wt2', parentSessionId: 'p1', worktreeBranch: 'feat/b' }),
+		];
+		render(<WorktreeAnalytics sessions={sessions} data={buildData()} theme={theme} />);
+
+		const statCards = screen.getAllByTestId('worktree-stat-card');
+		expect(statCards[0].style.animationDelay).toBe('0ms');
+		expect(statCards[1].style.animationDelay).toBe('80ms');
+		statCards.forEach((c) => expect(c.className).toContain('card-enter'));
+
+		const branchRows = screen.getAllByTestId('worktree-branch-row');
+		// Stagger starts at index+2 to chain visually behind the two stat cards.
+		expect(branchRows[0].style.animationDelay).toBe('120ms');
+		expect(branchRows[1].style.animationDelay).toBe('180ms');
+		branchRows.forEach((r) => expect(r.className).toContain('card-enter'));
+	});
+});

--- a/src/__tests__/renderer/components/UsageDashboard/chart-accessibility.test.tsx
+++ b/src/__tests__/renderer/components/UsageDashboard/chart-accessibility.test.tsx
@@ -315,13 +315,16 @@ describe('Chart Accessibility - SummaryCards', () => {
 
 	it('each metric card has role="group"', () => {
 		render(<SummaryCards data={mockStatsData} theme={mockTheme} />);
-		const groups = screen.getAllByRole('group');
-		expect(groups).toHaveLength(10); // 10 metric cards
+		const metricCards = screen.getAllByTestId('metric-card');
+		expect(metricCards).toHaveLength(10); // 10 metric cards
+		metricCards.forEach((card) => {
+			expect(card).toHaveAttribute('role', 'group');
+		});
 	});
 
 	it('metric cards have descriptive aria-labels', () => {
 		render(<SummaryCards data={mockStatsData} theme={mockTheme} />);
-		const groups = screen.getAllByRole('group');
+		const metricCards = screen.getAllByTestId('metric-card');
 
 		const expectedLabels = [
 			/Agents/i,
@@ -336,19 +339,19 @@ describe('Chart Accessibility - SummaryCards', () => {
 			/Local %/i,
 		];
 
-		groups.forEach((group, index) => {
-			expect(group).toHaveAttribute('aria-label');
-			const label = group.getAttribute('aria-label') || '';
+		metricCards.forEach((card, index) => {
+			expect(card).toHaveAttribute('aria-label');
+			const label = card.getAttribute('aria-label') || '';
 			expect(label).toMatch(expectedLabels[index]);
 		});
 	});
 
 	it('metric cards include values in aria-labels', () => {
 		render(<SummaryCards data={mockStatsData} theme={mockTheme} />);
-		const groups = screen.getAllByRole('group');
+		const metricCards = screen.getAllByTestId('metric-card');
 
-		groups.forEach((group) => {
-			const label = group.getAttribute('aria-label') || '';
+		metricCards.forEach((card) => {
+			const label = card.getAttribute('aria-label') || '';
 			// Should contain a value (number, time, or percentage)
 			expect(label).toMatch(/: .+/); // Has colon followed by value
 		});

--- a/src/__tests__/renderer/components/UsageDashboard/chartUtils.test.ts
+++ b/src/__tests__/renderer/components/UsageDashboard/chartUtils.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Tests for chartUtils helpers (UsageDashboard).
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+	isWorktreeAgent,
+	isParentAgent,
+	findSessionByStatId,
+} from '../../../../renderer/components/UsageDashboard/chartUtils';
+import type { Session } from '../../../../renderer/types';
+
+let idCounter = 0;
+function makeSession(overrides: Partial<Session> = {}): Session {
+	idCounter++;
+	return {
+		id: `s${idCounter}`,
+		name: `Session ${idCounter}`,
+		toolType: 'claude-code',
+		state: 'idle',
+		cwd: '/tmp',
+		fullPath: '/tmp',
+		projectRoot: '/tmp',
+		aiLogs: [],
+		shellLogs: [],
+		workLog: [],
+		contextUsage: 0,
+		inputMode: 'ai',
+		aiPid: 0,
+		terminalPid: 0,
+		port: 0,
+		isLive: false,
+		changedFiles: [],
+		isGitRepo: false,
+		fileTree: [],
+		fileExplorerExpanded: [],
+		fileExplorerScrollPos: 0,
+		createdAt: 0,
+		...overrides,
+	} as Session;
+}
+
+describe('chartUtils', () => {
+	describe('isWorktreeAgent', () => {
+		it('returns true when parentSessionId is set', () => {
+			const session = makeSession({ parentSessionId: 'parent-id' });
+			expect(isWorktreeAgent(session)).toBe(true);
+		});
+
+		it('returns false when parentSessionId is undefined', () => {
+			const session = makeSession();
+			expect(isWorktreeAgent(session)).toBe(false);
+		});
+
+		it('returns false when parentSessionId is an empty string', () => {
+			const session = makeSession({ parentSessionId: '' });
+			expect(isWorktreeAgent(session)).toBe(false);
+		});
+	});
+
+	describe('isParentAgent', () => {
+		it('returns true when worktreeConfig is set', () => {
+			const session = makeSession({
+				worktreeConfig: { basePath: '/tmp/wt', watchEnabled: true },
+			});
+			expect(isParentAgent(session)).toBe(true);
+		});
+
+		it('returns false when worktreeConfig is undefined', () => {
+			const session = makeSession();
+			expect(isParentAgent(session)).toBe(false);
+		});
+
+		it('does not flag worktree children as parents', () => {
+			const session = makeSession({ parentSessionId: 'p1' });
+			expect(isParentAgent(session)).toBe(false);
+		});
+	});
+
+	describe('findSessionByStatId', () => {
+		it('returns the session whose id is a prefix of the stat id', () => {
+			const a = makeSession({ id: 'sess-aaa' });
+			const b = makeSession({ id: 'sess-bbb' });
+			expect(findSessionByStatId('sess-bbb-ai-tab1', [a, b])).toBe(b);
+		});
+
+		it('matches when stat id equals session id exactly', () => {
+			const a = makeSession({ id: 'exact-match' });
+			expect(findSessionByStatId('exact-match', [a])).toBe(a);
+		});
+
+		it('returns undefined when no session matches', () => {
+			const a = makeSession({ id: 'sess-aaa' });
+			expect(findSessionByStatId('unrelated-id', [a])).toBeUndefined();
+		});
+
+		it('returns undefined for an empty or missing sessions list', () => {
+			expect(findSessionByStatId('any-id', undefined)).toBeUndefined();
+			expect(findSessionByStatId('any-id', [])).toBeUndefined();
+		});
+	});
+});

--- a/src/__tests__/renderer/components/UsageDashboard/chartUtils.test.ts
+++ b/src/__tests__/renderer/components/UsageDashboard/chartUtils.test.ts
@@ -7,6 +7,9 @@ import {
 	isWorktreeAgent,
 	isParentAgent,
 	findSessionByStatId,
+	prettifyAgentType,
+	resolveAgentDisplayName,
+	buildNameMap,
 } from '../../../../renderer/components/UsageDashboard/chartUtils';
 import type { Session } from '../../../../renderer/types';
 
@@ -97,6 +100,120 @@ describe('chartUtils', () => {
 		it('returns undefined for an empty or missing sessions list', () => {
 			expect(findSessionByStatId('any-id', undefined)).toBeUndefined();
 			expect(findSessionByStatId('any-id', [])).toBeUndefined();
+		});
+	});
+
+	describe('prettifyAgentType', () => {
+		it('returns the canonical display name for known agent ids', () => {
+			expect(prettifyAgentType('claude-code')).toBe('Claude Code');
+			expect(prettifyAgentType('factory-droid')).toBe('Factory Droid');
+			expect(prettifyAgentType('opencode')).toBe('OpenCode');
+		});
+
+		it('falls back to splitting on hyphens and capitalizing each word', () => {
+			expect(prettifyAgentType('my-custom-agent')).toBe('My Custom Agent');
+			expect(prettifyAgentType('single')).toBe('Single');
+		});
+
+		it('handles empty strings without crashing', () => {
+			expect(prettifyAgentType('')).toBe('');
+		});
+	});
+
+	describe('resolveAgentDisplayName', () => {
+		it('matches by session id (with stat suffix) and returns the user name', () => {
+			const session = makeSession({ id: 'sess-aaa', name: 'Backend API' });
+			expect(resolveAgentDisplayName('sess-aaa-ai-tab1', [session])).toEqual({
+				name: 'Backend API',
+				isWorktree: false,
+			});
+		});
+
+		it('flags worktree children via isWorktree', () => {
+			const session = makeSession({
+				id: 'sess-aaa',
+				name: 'Frontend WT',
+				parentSessionId: 'parent-id',
+			});
+			expect(resolveAgentDisplayName('sess-aaa', [session])).toEqual({
+				name: 'Frontend WT',
+				isWorktree: true,
+			});
+		});
+
+		it('returns the single matching session name when key is a toolType', () => {
+			const session = makeSession({ id: 'sess-bbb', name: 'My Project', toolType: 'codex' });
+			expect(resolveAgentDisplayName('codex', [session])).toEqual({
+				name: 'My Project',
+				isWorktree: false,
+			});
+		});
+
+		it('returns the prettified type when multiple sessions share the toolType', () => {
+			const a = makeSession({ id: 'sess-aaa', name: 'A', toolType: 'claude-code' });
+			const b = makeSession({ id: 'sess-bbb', name: 'B', toolType: 'claude-code' });
+			expect(resolveAgentDisplayName('claude-code', [a, b])).toEqual({
+				name: 'Claude Code',
+				isWorktree: false,
+			});
+		});
+
+		it('falls back to prettifying the key when no session matches', () => {
+			expect(resolveAgentDisplayName('claude-code', [])).toEqual({
+				name: 'Claude Code',
+				isWorktree: false,
+			});
+			expect(resolveAgentDisplayName('my-custom-thing', undefined)).toEqual({
+				name: 'My Custom Thing',
+				isWorktree: false,
+			});
+		});
+
+		it('uses the prettified toolType when a matched session has no name', () => {
+			const session = makeSession({ id: 'sess-aaa', name: '', toolType: 'claude-code' });
+			expect(resolveAgentDisplayName('sess-aaa', [session])).toEqual({
+				name: 'Claude Code',
+				isWorktree: false,
+			});
+		});
+	});
+
+	describe('buildNameMap', () => {
+		it('resolves each key to its display name and worktree flag', () => {
+			const a = makeSession({ id: 'sess-aaa', name: 'Backend' });
+			const b = makeSession({ id: 'sess-bbb', name: 'Frontend', parentSessionId: 'p1' });
+			const map = buildNameMap(['sess-aaa', 'sess-bbb', 'claude-code'], [a, b]);
+			expect(map.get('sess-aaa')).toEqual({ name: 'Backend', isWorktree: false });
+			expect(map.get('sess-bbb')).toEqual({ name: 'Frontend', isWorktree: true });
+			expect(map.get('claude-code')).toEqual({ name: 'Claude Code', isWorktree: false });
+		});
+
+		it('disambiguates collisions with " (2)", " (3)" suffixes in input order', () => {
+			const a = makeSession({ id: 'sess-aaa', name: 'API' });
+			const b = makeSession({ id: 'sess-bbb', name: 'API' });
+			const c = makeSession({ id: 'sess-ccc', name: 'API' });
+			const map = buildNameMap(['sess-aaa', 'sess-bbb', 'sess-ccc'], [a, b, c]);
+			expect(map.get('sess-aaa')?.name).toBe('API');
+			expect(map.get('sess-bbb')?.name).toBe('API (2)');
+			expect(map.get('sess-ccc')?.name).toBe('API (3)');
+		});
+
+		it('disambiguates collisions across resolution sources (session vs prettified type)', () => {
+			const a = makeSession({ id: 'sess-aaa', name: 'Claude Code' });
+			const map = buildNameMap(['sess-aaa', 'claude-code'], [a]);
+			expect(map.get('sess-aaa')?.name).toBe('Claude Code');
+			expect(map.get('claude-code')?.name).toBe('Claude Code (2)');
+		});
+
+		it('handles empty input lists', () => {
+			expect(buildNameMap([], [])).toEqual(new Map());
+		});
+
+		it('returns one entry per key even if keys repeat', () => {
+			const a = makeSession({ id: 'sess-aaa', name: 'Backend' });
+			const map = buildNameMap(['sess-aaa', 'sess-aaa'], [a]);
+			expect(map.size).toBe(1);
+			expect(map.get('sess-aaa')?.name).toBe('Backend');
 		});
 	});
 });

--- a/src/__tests__/renderer/components/UsageDashboard/responsive-layout.test.tsx
+++ b/src/__tests__/renderer/components/UsageDashboard/responsive-layout.test.tsx
@@ -54,6 +54,9 @@ vi.mock('lucide-react', () => {
 		PanelTop: createIcon('panel-top', '🔲'),
 		Trophy: createIcon('trophy', '🏆'),
 		Filter: createIcon('filter', '🔍'),
+		Cpu: createIcon('cpu', '🖥️'),
+		DollarSign: createIcon('dollar', '💲'),
+		Activity: createIcon('activity', '📈'),
 	};
 });
 

--- a/src/__tests__/renderer/components/UsageDashboard/responsive-layout.test.tsx
+++ b/src/__tests__/renderer/components/UsageDashboard/responsive-layout.test.tsx
@@ -53,6 +53,7 @@ vi.mock('lucide-react', () => {
 		Zap: createIcon('zap', '⚡'),
 		PanelTop: createIcon('panel-top', '🔲'),
 		Trophy: createIcon('trophy', '🏆'),
+		Filter: createIcon('filter', '🔍'),
 	};
 });
 

--- a/src/__tests__/renderer/components/UsageDashboard/state-transition-animations.test.tsx
+++ b/src/__tests__/renderer/components/UsageDashboard/state-transition-animations.test.tsx
@@ -54,6 +54,9 @@ vi.mock('lucide-react', () => {
 		PanelTop: createIcon('panel-top', '🔲'),
 		Trophy: createIcon('trophy', '🏆'),
 		Filter: createIcon('filter', '🔍'),
+		Cpu: createIcon('cpu', '🖥️'),
+		DollarSign: createIcon('dollar', '💲'),
+		Activity: createIcon('activity', '📈'),
 	};
 });
 

--- a/src/__tests__/renderer/components/UsageDashboard/state-transition-animations.test.tsx
+++ b/src/__tests__/renderer/components/UsageDashboard/state-transition-animations.test.tsx
@@ -53,6 +53,7 @@ vi.mock('lucide-react', () => {
 		Zap: createIcon('zap', '⚡'),
 		PanelTop: createIcon('panel-top', '🔲'),
 		Trophy: createIcon('trophy', '🏆'),
+		Filter: createIcon('filter', '🔍'),
 	};
 });
 

--- a/src/__tests__/renderer/components/UsageDashboard/state-transition-animations.test.tsx
+++ b/src/__tests__/renderer/components/UsageDashboard/state-transition-animations.test.tsx
@@ -6,7 +6,7 @@
  *
  * Animation types tested:
  * - View mode transition animations (dashboard-content-enter)
- * - Staggered card entrance animations (dashboard-card-enter)
+ * - Staggered card entrance animations (card-enter)
  * - Chart section enter animations (dashboard-section-enter)
  * - Reduced motion accessibility handling
  */
@@ -208,12 +208,12 @@ describe('Usage Dashboard State Transition Animations', () => {
 			expect(expectedKeyframe.to.opacity).toBe(1);
 		});
 
-		it('defines dashboard-card-enter keyframe animation', () => {
+		it('defines card-enter keyframe animation', () => {
 			const expectedKeyframe = {
-				from: { opacity: 0, transform: 'translateY(12px) scale(0.98)' },
+				from: { opacity: 0, transform: 'translateY(12px) scale(0.96)' },
 				to: { opacity: 1, transform: 'translateY(0) scale(1)' },
 			};
-			expect(expectedKeyframe.from.transform).toContain('scale(0.98)');
+			expect(expectedKeyframe.from.transform).toContain('scale(0.96)');
 			expect(expectedKeyframe.to.transform).toContain('scale(1)');
 		});
 
@@ -290,12 +290,12 @@ describe('Usage Dashboard State Transition Animations', () => {
 			bySessionByDay: {},
 		};
 
-		it('applies dashboard-card-enter class to metric cards', () => {
+		it('applies card-enter class to metric cards', () => {
 			render(<SummaryCards data={mockData} theme={mockTheme} />);
 
 			const cards = screen.getAllByTestId('metric-card');
 			cards.forEach((card) => {
-				expect(card).toHaveClass('dashboard-card-enter');
+				expect(card).toHaveClass('card-enter');
 			});
 		});
 
@@ -307,7 +307,7 @@ describe('Usage Dashboard State Transition Animations', () => {
 
 			// Verify each card has incrementing animation delay
 			cards.forEach((card, index) => {
-				const expectedDelay = `${index * 50}ms`;
+				const expectedDelay = `${index * 80}ms`;
 				expect(card).toHaveStyle({ animationDelay: expectedDelay });
 			});
 		});
@@ -319,11 +319,11 @@ describe('Usage Dashboard State Transition Animations', () => {
 			expect(cards[0]).toHaveStyle({ animationDelay: '0ms' });
 		});
 
-		it('last card has 450ms delay (9 * 50ms)', () => {
+		it('last card has 720ms delay (9 * 80ms)', () => {
 			render(<SummaryCards data={mockData} theme={mockTheme} />);
 
 			const cards = screen.getAllByTestId('metric-card');
-			expect(cards[9]).toHaveStyle({ animationDelay: '450ms' });
+			expect(cards[9]).toHaveStyle({ animationDelay: '720ms' });
 		});
 	});
 
@@ -442,9 +442,9 @@ describe('Usage Dashboard State Transition Animations', () => {
 			expect(expectedDuration).toBe('0.35s');
 		});
 
-		it('card stagger interval is 50ms', () => {
-			const expectedInterval = 50;
-			expect(expectedInterval).toBe(50);
+		it('card stagger interval is 80ms', () => {
+			const expectedInterval = 80;
+			expect(expectedInterval).toBe(80);
 		});
 
 		it('section stagger interval is 100ms', () => {
@@ -458,7 +458,7 @@ describe('Usage Dashboard State Transition Animations', () => {
 			// CSS media query in index.css disables animations:
 			// @media (prefers-reduced-motion: reduce) {
 			//   .dashboard-content-enter,
-			//   .dashboard-card-enter,
+			//   .card-enter,
 			//   .dashboard-section-enter {
 			//     animation: none !important;
 			//     opacity: 1 !important;
@@ -495,7 +495,7 @@ describe('Usage Dashboard State Transition Animations', () => {
 
 		it('card and section animations start with opacity 0', () => {
 			// Initial state before animation plays
-			const cssDefinition = '.dashboard-card-enter { opacity: 0; }';
+			const cssDefinition = '.card-enter { opacity: 0; }';
 			expect(cssDefinition).toContain('opacity: 0');
 		});
 	});

--- a/src/__tests__/renderer/components/UsageDashboardModal.test.tsx
+++ b/src/__tests__/renderer/components/UsageDashboardModal.test.tsx
@@ -1159,7 +1159,10 @@ describe('UsageDashboardModal', () => {
 			});
 
 			// Initial state shows 67% interactive (100/150)
-			expect(screen.getByText('67%')).toBeInTheDocument();
+			// Wrapped in waitFor because the value count-up animation runs over 600ms.
+			await waitFor(() => {
+				expect(screen.getByText('67%')).toBeInTheDocument();
+			});
 
 			mockGetAggregation.mockResolvedValueOnce(afterAutoRunData);
 

--- a/src/__tests__/renderer/components/UsageDashboardModal.test.tsx
+++ b/src/__tests__/renderer/components/UsageDashboardModal.test.tsx
@@ -28,6 +28,7 @@ vi.mock('lucide-react', () => {
 		RefreshCw: createIcon('refresh', '🔄'),
 		Database: createIcon('database', '💾'),
 		// SummaryCards icons
+		Filter: createIcon('filter', '🔍'),
 		MessageSquare: createIcon('message-square', '💬'),
 		Clock: createIcon('clock', '🕐'),
 		Timer: createIcon('timer', '⏱️'),
@@ -381,6 +382,64 @@ describe('UsageDashboardModal', () => {
 				expect(options[3]).toHaveValue('quarter');
 				expect(options[4]).toHaveValue('year');
 				expect(options[5]).toHaveValue('all');
+			});
+		});
+	});
+
+	describe('Drill-down Filter Reset', () => {
+		// Helper: click the first agent row in the rendered AgentComparisonChart
+		// to set the dashboard filter. The chart renders rows as
+		// role="listitem" with an aria-label that includes "Click to filter
+		// dashboard." when the row is interactive.
+		async function activateFilterByClickingBar() {
+			const clickableBars = await screen.findAllByLabelText(/Click to filter dashboard\./);
+			expect(clickableBars.length).toBeGreaterThan(0);
+			fireEvent.click(clickableBars[0]);
+		}
+
+		it('clears the active filter when the time range changes', async () => {
+			render(<UsageDashboardModal isOpen={true} onClose={onClose} theme={theme} />);
+
+			// Wait for data to load and the chart to render
+			await waitFor(() => {
+				expect(mockGetAggregation).toHaveBeenCalledWith('week');
+			});
+
+			await activateFilterByClickingBar();
+
+			// Filter bar should be visible
+			await waitFor(() => {
+				expect(screen.getByTestId('dashboard-filter-bar')).toBeInTheDocument();
+			});
+
+			// Change the time range — this should reset the filter
+			const select = screen.getByRole('combobox');
+			fireEvent.change(select, { target: { value: 'month' } });
+
+			await waitFor(() => {
+				expect(screen.queryByTestId('dashboard-filter-bar')).not.toBeInTheDocument();
+			});
+		});
+
+		it('clears the active filter when switching dashboard tabs', async () => {
+			render(<UsageDashboardModal isOpen={true} onClose={onClose} theme={theme} />);
+
+			await waitFor(() => {
+				expect(mockGetAggregation).toHaveBeenCalledWith('week');
+			});
+
+			await activateFilterByClickingBar();
+
+			await waitFor(() => {
+				expect(screen.getByTestId('dashboard-filter-bar')).toBeInTheDocument();
+			});
+
+			// Switch to the Agents tab — the useEffect should clear the filter
+			const tabs = screen.getAllByRole('tab');
+			fireEvent.click(tabs[1]); // 'agents' tab
+
+			await waitFor(() => {
+				expect(screen.queryByTestId('dashboard-filter-bar')).not.toBeInTheDocument();
 			});
 		});
 	});

--- a/src/__tests__/renderer/components/UsageDashboardModal.test.tsx
+++ b/src/__tests__/renderer/components/UsageDashboardModal.test.tsx
@@ -54,6 +54,10 @@ vi.mock('lucide-react', () => {
 		// WeekdayComparisonChart icons
 		Briefcase: createIcon('briefcase', '💼'),
 		Coffee: createIcon('coffee', '☕'),
+		// RealtimeMetricsCard icons
+		Cpu: createIcon('cpu', '🖥️'),
+		DollarSign: createIcon('dollar', '💲'),
+		Activity: createIcon('activity', '📈'),
 	};
 });
 

--- a/src/__tests__/renderer/hooks/useAgentListeners.test.ts
+++ b/src/__tests__/renderer/hooks/useAgentListeners.test.ts
@@ -640,9 +640,7 @@ describe('useAgentListeners', () => {
 			// Should clear usage stats
 			expect(updatedTab?.usageStats).toBeUndefined();
 			// Should add a system log entry about resume failure
-			const resumeLog = updatedTab?.logs.find((l) =>
-				l.text.includes('Session resume failed')
-			);
+			const resumeLog = updatedTab?.logs.find((l) => l.text.includes('Session resume failed'));
 			expect(resumeLog).toBeDefined();
 			// Should reset context usage
 			expect(deps.batchedUpdater.updateContextUsage).toHaveBeenCalledWith('sess-1', 0);

--- a/src/__tests__/shared/platformDetection.test.ts
+++ b/src/__tests__/shared/platformDetection.test.ts
@@ -78,4 +78,38 @@ describe('platformDetection', () => {
 			expect(getWhichCommand()).toBe('which');
 		});
 	});
+
+	describe('renderer (browser) fallback', () => {
+		// In a renderer, `process` is undefined and `globalThis.maestro.platform`
+		// is provided by the preload bridge. Simulate the no-process case by
+		// blanking process.platform; the fallback should pick up maestro.platform.
+		const g = globalThis as unknown as { maestro?: { platform?: string } };
+
+		it('reads platform from globalThis.maestro.platform when process.platform is empty', () => {
+			Object.defineProperty(process, 'platform', { value: '', configurable: true });
+			const savedMaestro = g.maestro;
+			try {
+				g.maestro = { platform: 'darwin' };
+				expect(isMacOS()).toBe(true);
+				expect(isWindows()).toBe(false);
+				expect(isLinux()).toBe(false);
+			} finally {
+				g.maestro = savedMaestro;
+			}
+		});
+
+		it('falls back to linux when neither process.platform nor maestro is defined', () => {
+			Object.defineProperty(process, 'platform', { value: '', configurable: true });
+			const savedMaestro = g.maestro;
+			try {
+				g.maestro = undefined;
+				expect(() => isMacOS()).not.toThrow();
+				expect(isLinux()).toBe(true);
+				expect(isMacOS()).toBe(false);
+				expect(isWindows()).toBe(false);
+			} finally {
+				g.maestro = savedMaestro;
+			}
+		});
+	});
 });

--- a/src/main/history-manager.ts
+++ b/src/main/history-manager.ts
@@ -493,15 +493,27 @@ export class HistoryManager {
 			fs.mkdirSync(this.historyDir, { recursive: true });
 		}
 
-		this.watcher = fs.watch(this.historyDir, (_eventType, filename) => {
-			if (filename?.endsWith('.json')) {
-				const sessionId = filename.replace('.json', '');
-				logger.debug(`History file changed: ${filename}`, LOG_CONTEXT);
-				onExternalChange(sessionId);
-			}
-		});
+		try {
+			this.watcher = fs.watch(this.historyDir, (_eventType, filename) => {
+				if (filename?.endsWith('.json')) {
+					const sessionId = filename.replace('.json', '');
+					logger.debug(`History file changed: ${filename}`, LOG_CONTEXT);
+					onExternalChange(sessionId);
+				}
+			});
 
-		logger.info('Started watching history directory', LOG_CONTEXT);
+			// Prevent runtime errors (e.g. Windows UNKNOWN, disk unmount) from
+			// becoming unhandled rejections. Swallow to logger; caller stays alive.
+			this.watcher.on('error', (error) => {
+				logger.warn(`History watcher error: ${error.message}`, LOG_CONTEXT);
+			});
+
+			logger.info('Started watching history directory', LOG_CONTEXT);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			logger.warn(`Failed to start history watcher: ${message}`, LOG_CONTEXT);
+			this.watcher = null;
+		}
 	}
 
 	/**

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -208,6 +208,20 @@ if (crashReportingEnabled && !isDevelopment) {
 				tracesSampleRate: 0,
 				// Filter out sensitive data
 				beforeSend(event) {
+					// Drop unfixable Windows drive-root noise: EBUSY/EPERM on always-locked
+					// system files (pagefile.sys, hiberfil.sys, DumpStack.log.tmp, ...) that
+					// show up when users point watchers at C:\ or similar. See MAESTRO-G5/G6.
+					const firstException = event.exception?.values?.[0];
+					const exceptionValue = firstException?.value ?? '';
+					if (
+						/^(EBUSY|EPERM): [^,]+, lstat /i.test(exceptionValue) &&
+						/(pagefile\.sys|hiberfil\.sys|swapfile\.sys|DumpStack\.log|System Volume Information)/i.test(
+							exceptionValue
+						)
+					) {
+						return null;
+					}
+
 					// Remove any potential sensitive data from the event
 					if (event.user) {
 						delete event.user.ip_address;

--- a/src/main/ipc/handlers/autorun.ts
+++ b/src/main/ipc/handlers/autorun.ts
@@ -6,6 +6,7 @@ import Store from 'electron-store';
 import { logger } from '../../utils/logger';
 import { createIpcHandler, CreateHandlerOptions } from '../../utils/ipcHandler';
 import { resolveDirentType } from '../../utils/dirent-utils';
+import { WINDOWS_LOCKED_SYSTEM_FILES } from '../../utils/watcher-ignore';
 import { SshRemoteConfig } from '../../../shared/types';
 import { MaestroSettings } from './persistence';
 import { isWebContentsAvailable } from '../../utils/safe-send';
@@ -845,7 +846,10 @@ export function registerAutorunHandlers(
 
 				// Start watching the folder recursively using chokidar (cross-platform)
 				const watcher = chokidar.watch(folderPath, {
-					ignored: /(^|[/\\])\../, // Ignore dotfiles
+					ignored: [
+						/(^|[/\\])\../, // Ignore dotfiles
+						WINDOWS_LOCKED_SYSTEM_FILES,
+					],
 					persistent: true,
 					ignoreInitial: true, // Don't emit events for existing files on startup
 					depth: 99, // Recursive watching

--- a/src/main/ipc/handlers/documentGraph.ts
+++ b/src/main/ipc/handlers/documentGraph.ts
@@ -3,6 +3,7 @@ import chokidar, { FSWatcher } from 'chokidar';
 import { logger } from '../../utils/logger';
 import { createIpcHandler, CreateHandlerOptions } from '../../utils/ipcHandler';
 import { isWebContentsAvailable } from '../../utils/safe-send';
+import { WINDOWS_LOCKED_SYSTEM_FILES } from '../../utils/watcher-ignore';
 
 const LOG_CONTEXT = '[DocumentGraph]';
 
@@ -153,6 +154,7 @@ export function registerDocumentGraphHandlers(deps: DocumentGraphHandlerDependen
 					/dist/,
 					/build/,
 					/\.git/,
+					WINDOWS_LOCKED_SYSTEM_FILES,
 				],
 				persistent: true,
 				ignoreInitial: true, // Don't emit events for existing files on startup

--- a/src/main/ipc/handlers/git.ts
+++ b/src/main/ipc/handlers/git.ts
@@ -14,6 +14,7 @@ import {
 import { resolveGhPath, getCachedGhStatus, setCachedGhStatus } from '../../utils/cliDetection';
 import { getShellPath } from '../../runtime/getShellPath';
 import { captureMessage } from '../../utils/sentry';
+import { WINDOWS_LOCKED_SYSTEM_FILES } from '../../utils/watcher-ignore';
 import {
 	parseGitBranches,
 	parseGitTags,
@@ -1223,7 +1224,10 @@ export function registerGitHandlers(deps: GitHandlerDependencies): void {
 
 					// Start watching the directory (only top level, not recursive)
 					const watcher = chokidar.watch(worktreePath, {
-						ignored: /(^|[/\\])\../, // Ignore dotfiles
+						ignored: [
+							/(^|[/\\])\../, // Ignore dotfiles
+							WINDOWS_LOCKED_SYSTEM_FILES,
+						],
 						persistent: true,
 						ignoreInitial: true,
 						depth: 0, // Only watch top-level directory changes

--- a/src/main/ipc/handlers/marketplace.ts
+++ b/src/main/ipc/handlers/marketplace.ts
@@ -563,6 +563,12 @@ function setupLocalManifestWatcher(app: App): void {
 			}, WATCHER_DEBOUNCE_MS);
 		});
 
+		// Prevent runtime errors (e.g. Windows UNKNOWN, file removed) from
+		// becoming unhandled rejections.
+		localManifestWatcher.on('error', (error) => {
+			logger.warn(`Local manifest watcher error: ${error.message}`, LOG_CONTEXT);
+		});
+
 		logger.debug('Local manifest file watcher initialized', LOG_CONTEXT);
 	} catch (error) {
 		// File might not exist yet - this is normal

--- a/src/main/preload/stats.ts
+++ b/src/main/preload/stats.ts
@@ -21,6 +21,7 @@ export interface QueryEvent {
 	projectPath?: string;
 	tabId?: string;
 	isRemote?: boolean;
+	isWorktree?: boolean;
 }
 
 /**
@@ -58,6 +59,7 @@ export interface SessionCreatedEvent {
 	projectPath?: string;
 	createdAt: number;
 	isRemote?: boolean;
+	isWorktree?: boolean;
 }
 
 /**

--- a/src/main/stats/aggregations.ts
+++ b/src/main/stats/aggregations.ts
@@ -81,29 +81,48 @@ function queryBySource(db: Database.Database, startTime: number): { user: number
 function queryByWorktreeStatus(
 	db: Database.Database,
 	startTime: number
-): { worktreeQueries: number; parentQueries: number } {
+): {
+	worktreeQueries: number;
+	parentQueries: number;
+	byWorktreeStatus: {
+		worktree: { count: number; duration: number };
+		parent: { count: number; duration: number };
+	};
+} {
 	const perfStart = perfMetrics.start();
 	const rows = db
 		.prepare(
 			`
-      SELECT COALESCE(is_worktree, 0) as is_worktree, COUNT(*) as count
+      SELECT COALESCE(is_worktree, 0) as is_worktree,
+             COUNT(*) as count,
+             COALESCE(SUM(duration), 0) as duration
       FROM query_events
       WHERE start_time >= ?
       GROUP BY COALESCE(is_worktree, 0)
     `
 		)
-		.all(startTime) as Array<{ is_worktree: number; count: number }>;
+		.all(startTime) as Array<{ is_worktree: number; count: number; duration: number }>;
 
-	const result = { worktreeQueries: 0, parentQueries: 0 };
+	const byWorktreeStatus = {
+		worktree: { count: 0, duration: 0 },
+		parent: { count: 0, duration: 0 },
+	};
 	for (const row of rows) {
 		if (row.is_worktree === 1) {
-			result.worktreeQueries = row.count;
+			byWorktreeStatus.worktree.count += row.count;
+			byWorktreeStatus.worktree.duration += row.duration;
 		} else {
-			result.parentQueries += row.count;
+			// Treat NULL (legacy data) and 0 as parent
+			byWorktreeStatus.parent.count += row.count;
+			byWorktreeStatus.parent.duration += row.duration;
 		}
 	}
 	perfMetrics.end(perfStart, 'getAggregatedStats:byWorktreeStatus');
-	return result;
+	return {
+		worktreeQueries: byWorktreeStatus.worktree.count,
+		parentQueries: byWorktreeStatus.parent.count,
+		byWorktreeStatus,
+	};
 }
 
 function queryByLocation(
@@ -380,5 +399,6 @@ export function getAggregatedStats(db: Database.Database, range: StatsTimeRange)
 		bySessionByDay,
 		worktreeQueries: worktreeStatus.worktreeQueries,
 		parentQueries: worktreeStatus.parentQueries,
+		byWorktreeStatus: worktreeStatus.byWorktreeStatus,
 	};
 }

--- a/src/main/stats/aggregations.ts
+++ b/src/main/stats/aggregations.ts
@@ -78,6 +78,34 @@ function queryBySource(db: Database.Database, startTime: number): { user: number
 	return result;
 }
 
+function queryByWorktreeStatus(
+	db: Database.Database,
+	startTime: number
+): { worktreeQueries: number; parentQueries: number } {
+	const perfStart = perfMetrics.start();
+	const rows = db
+		.prepare(
+			`
+      SELECT COALESCE(is_worktree, 0) as is_worktree, COUNT(*) as count
+      FROM query_events
+      WHERE start_time >= ?
+      GROUP BY COALESCE(is_worktree, 0)
+    `
+		)
+		.all(startTime) as Array<{ is_worktree: number; count: number }>;
+
+	const result = { worktreeQueries: 0, parentQueries: 0 };
+	for (const row of rows) {
+		if (row.is_worktree === 1) {
+			result.worktreeQueries = row.count;
+		} else {
+			result.parentQueries += row.count;
+		}
+	}
+	perfMetrics.end(perfStart, 'getAggregatedStats:byWorktreeStatus');
+	return result;
+}
+
 function queryByLocation(
 	db: Database.Database,
 	startTime: number
@@ -322,6 +350,7 @@ export function getAggregatedStats(db: Database.Database, range: StatsTimeRange)
 	const byHour = queryByHour(db, startTime);
 	const sessionStats = querySessionStats(db, startTime);
 	const bySessionByDay = queryBySessionByDay(db, startTime);
+	const worktreeStatus = queryByWorktreeStatus(db, startTime);
 
 	const totalDuration = perfMetrics.end(perfStart, 'getAggregatedStats:total', {
 		range,
@@ -349,5 +378,7 @@ export function getAggregatedStats(db: Database.Database, range: StatsTimeRange)
 		...sessionStats,
 		byAgentByDay,
 		bySessionByDay,
+		worktreeQueries: worktreeStatus.worktreeQueries,
+		parentQueries: worktreeStatus.parentQueries,
 	};
 }

--- a/src/main/stats/data-management.ts
+++ b/src/main/stats/data-management.ts
@@ -136,8 +136,9 @@ function csvEscape(value: string): string {
 /**
  * Export query events to CSV format.
  *
- * Includes all fields (including isRemote added in migration v2)
- * with proper CSV escaping for values containing quotes, commas, or newlines.
+ * Includes all fields (including isRemote added in migration v2 and isWorktree
+ * added in migration v5) with proper CSV escaping for values containing
+ * quotes, commas, or newlines.
  */
 export function exportToCsv(db: Database.Database, range: StatsTimeRange): string {
 	const events = getQueryEvents(db, range);
@@ -152,6 +153,7 @@ export function exportToCsv(db: Database.Database, range: StatsTimeRange): strin
 		'projectPath',
 		'tabId',
 		'isRemote',
+		'isWorktree',
 	];
 
 	const rows = events.map((e) => [
@@ -164,6 +166,7 @@ export function exportToCsv(db: Database.Database, range: StatsTimeRange): strin
 		csvEscape(e.projectPath ?? ''),
 		csvEscape(e.tabId ?? ''),
 		csvEscape(e.isRemote !== undefined ? String(e.isRemote) : ''),
+		csvEscape(e.isWorktree !== undefined ? String(e.isWorktree) : ''),
 	]);
 
 	return [headers.join(','), ...rows.map((row) => row.join(','))].join('\n');

--- a/src/main/stats/migrations.ts
+++ b/src/main/stats/migrations.ts
@@ -60,6 +60,12 @@ export function getMigrations(): Migration[] {
 			description: 'Add compound indexes on query_events for dashboard query performance',
 			up: (db) => migrateV4(db),
 		},
+		{
+			version: 5,
+			description:
+				'Add is_worktree column to query_events and session_lifecycle for worktree analytics',
+			up: (db) => migrateV5(db),
+		},
 	];
 }
 
@@ -246,4 +252,35 @@ function migrateV4(db: Database.Database): void {
 	runStatements(db, CREATE_COMPOUND_INDEXES_SQL);
 
 	logger.debug('Added compound indexes on query_events', LOG_CONTEXT);
+}
+
+/**
+ * Migration v5: Add is_worktree column to query_events and session_lifecycle.
+ *
+ * Uses PRAGMA table_info to check whether the column already exists before
+ * issuing ALTER TABLE — this lets the migration be safely re-applied if a
+ * previous run partially completed before being recorded.
+ */
+function migrateV5(db: Database.Database): void {
+	if (!hasColumn(db, 'query_events', 'is_worktree')) {
+		db.prepare('ALTER TABLE query_events ADD COLUMN is_worktree INTEGER DEFAULT 0').run();
+	}
+	db.prepare('CREATE INDEX IF NOT EXISTS idx_query_is_worktree ON query_events(is_worktree)').run();
+
+	if (!hasColumn(db, 'session_lifecycle', 'is_worktree')) {
+		db.prepare('ALTER TABLE session_lifecycle ADD COLUMN is_worktree INTEGER DEFAULT 0').run();
+	}
+
+	logger.debug(
+		'Added is_worktree column to query_events and session_lifecycle tables',
+		LOG_CONTEXT
+	);
+}
+
+/**
+ * Check whether a column exists on a table using SQLite's PRAGMA table_info.
+ */
+function hasColumn(db: Database.Database, table: string, column: string): boolean {
+	const rows = db.pragma(`table_info(${table})`) as Array<{ name: string }> | undefined;
+	return Array.isArray(rows) && rows.some((row) => row.name === column);
 }

--- a/src/main/stats/query-events.ts
+++ b/src/main/stats/query-events.ts
@@ -14,8 +14,8 @@ import { logger } from '../utils/logger';
 const stmtCache = new StatementCache();
 
 const INSERT_SQL = `
-  INSERT INTO query_events (id, session_id, agent_type, source, start_time, duration, project_path, tab_id, is_remote)
-  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+  INSERT INTO query_events (id, session_id, agent_type, source, start_time, duration, project_path, tab_id, is_remote, is_worktree)
+  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 `;
 
 /**
@@ -34,7 +34,8 @@ export function insertQueryEvent(db: Database.Database, event: Omit<QueryEvent, 
 		event.duration,
 		normalizePath(event.projectPath),
 		event.tabId ?? null,
-		event.isRemote !== undefined ? (event.isRemote ? 1 : 0) : null
+		event.isRemote !== undefined ? (event.isRemote ? 1 : 0) : null,
+		event.isWorktree !== undefined ? (event.isWorktree ? 1 : 0) : null
 	);
 
 	logger.debug(`Inserted query event ${id}`, LOG_CONTEXT);

--- a/src/main/stats/row-mappers.ts
+++ b/src/main/stats/row-mappers.ts
@@ -27,6 +27,7 @@ export interface QueryEventRow {
 	project_path: string | null;
 	tab_id: string | null;
 	is_remote: number | null;
+	is_worktree: number | null;
 }
 
 export interface AutoRunSessionRow {
@@ -62,6 +63,7 @@ export interface SessionLifecycleRow {
 	closed_at: number | null;
 	duration: number | null;
 	is_remote: number | null;
+	is_worktree: number | null;
 }
 
 export interface MigrationRecordRow {
@@ -87,6 +89,7 @@ export function mapQueryEventRow(row: QueryEventRow): QueryEvent {
 		projectPath: row.project_path ?? undefined,
 		tabId: row.tab_id ?? undefined,
 		isRemote: row.is_remote !== null ? row.is_remote === 1 : undefined,
+		isWorktree: row.is_worktree !== null ? row.is_worktree === 1 : undefined,
 	};
 }
 
@@ -128,6 +131,7 @@ export function mapSessionLifecycleRow(row: SessionLifecycleRow): SessionLifecyc
 		closedAt: row.closed_at ?? undefined,
 		duration: row.duration ?? undefined,
 		isRemote: row.is_remote !== null ? row.is_remote === 1 : undefined,
+		isWorktree: row.is_worktree !== null ? row.is_worktree === 1 : undefined,
 	};
 }
 

--- a/src/main/stats/session-lifecycle.ts
+++ b/src/main/stats/session-lifecycle.ts
@@ -15,8 +15,8 @@ import { logger } from '../utils/logger';
 const stmtCache = new StatementCache();
 
 const INSERT_SQL = `
-  INSERT INTO session_lifecycle (id, session_id, agent_type, project_path, created_at, is_remote)
-  VALUES (?, ?, ?, ?, ?, ?)
+  INSERT INTO session_lifecycle (id, session_id, agent_type, project_path, created_at, is_remote, is_worktree)
+  VALUES (?, ?, ?, ?, ?, ?, ?)
 `;
 
 /**
@@ -35,7 +35,8 @@ export function recordSessionCreated(
 		event.agentType,
 		normalizePath(event.projectPath),
 		event.createdAt,
-		event.isRemote !== undefined ? (event.isRemote ? 1 : 0) : null
+		event.isRemote !== undefined ? (event.isRemote ? 1 : 0) : null,
+		event.isWorktree !== undefined ? (event.isWorktree ? 1 : 0) : null
 	);
 
 	logger.debug(`Recorded session created: ${event.sessionId}`, LOG_CONTEXT);

--- a/src/main/utils/watcher-ignore.ts
+++ b/src/main/utils/watcher-ignore.ts
@@ -1,0 +1,18 @@
+/**
+ * Shared ignore patterns for recursive file watchers (chokidar).
+ *
+ * Windows places a handful of always-locked system files at drive roots
+ * (pagefile.sys, hiberfil.sys, swapfile.sys, DumpStack.log.tmp, System
+ * Volume Information). When a user points Maestro at a drive root — or
+ * a path that transitively symlinks to one — chokidar's initial walk
+ * hits `EBUSY: resource busy or locked` on each lstat. See MAESTRO-G5/G6.
+ *
+ * These files can never be meaningfully watched, so skip them everywhere
+ * that builds a recursive watch tree.
+ */
+
+/** Windows drive-root system files that always fail lstat with EBUSY. */
+export const WINDOWS_LOCKED_SYSTEM_FILES: RegExp = new RegExp(
+	'(^|[/\\\\])(pagefile\\.sys|hiberfil\\.sys|swapfile\\.sys|DumpStack\\.log(\\.tmp)?|System Volume Information)$',
+	'i'
+);

--- a/src/main/web-server/web-server-factory.ts
+++ b/src/main/web-server/web-server-factory.ts
@@ -77,7 +77,7 @@ export function createWebServerFactory(deps: WebServerFactoryDependencies) {
 				securityToken = randomUUID();
 				try {
 					settingsStore.set('webAuthToken', securityToken);
-				} catch (e) {
+				} catch {
 					// Persist failure is non-fatal — server starts with an ephemeral token
 					logger.warn(
 						'Failed to persist new webAuthToken, URL will not survive restart',

--- a/src/renderer/components/SessionItem.tsx
+++ b/src/renderer/components/SessionItem.tsx
@@ -8,6 +8,43 @@ import { getStatusColor } from '../utils/theme';
 // ============================================================================
 
 /**
+ * Maps session state (plus batch / disconnected overrides) to a status color,
+ * an animation flag, and a human-readable label used for the status dot tooltip.
+ *
+ * Special cases:
+ * - `isInBatch`: always warning + pulse (Auto Run takes precedence over agent state)
+ * - Claude Code without an `agentSessionId`: hollow dot signal (textDim, no animation)
+ */
+export function getEnhancedStatusColor(
+	session: Session,
+	theme: Theme,
+	isInBatch: boolean
+): { color: string; animate: boolean; label: string } {
+	if (isInBatch) {
+		return { color: theme.colors.warning, animate: true, label: 'Auto Run active' };
+	}
+
+	if (session.toolType === 'claude-code' && !session.agentSessionId) {
+		return { color: theme.colors.textDim, animate: false, label: 'No active Claude session' };
+	}
+
+	switch (session.state) {
+		case 'idle':
+			return { color: theme.colors.success, animate: false, label: 'Ready' };
+		case 'busy':
+			return { color: theme.colors.warning, animate: true, label: 'Thinking' };
+		case 'error':
+			return { color: theme.colors.error, animate: false, label: 'Error' };
+		case 'connecting':
+			return { color: '#ff8800', animate: true, label: 'Connecting' };
+		case 'waiting_input':
+			return { color: theme.colors.accent, animate: true, label: 'Waiting for input' };
+		default:
+			return { color: theme.colors.textDim, animate: false, label: 'Unknown' };
+	}
+}
+
+/**
  * Variant determines the context in which the session item is rendered:
  * - 'bookmark': Session in the Bookmarks folder (shows group badge if session belongs to a group)
  * - 'group': Session inside a group folder

--- a/src/renderer/components/SessionItem.tsx
+++ b/src/renderer/components/SessionItem.tsx
@@ -1,5 +1,14 @@
 import React, { memo } from 'react';
-import { Activity, GitBranch, Bot, Bookmark, AlertCircle, Server, FolderTree } from 'lucide-react';
+import {
+	Activity,
+	GitBranch,
+	Bot,
+	Bookmark,
+	AlertCircle,
+	Server,
+	FolderTree,
+	ChevronRight,
+} from 'lucide-react';
 import type { Session, Group, Theme } from '../types';
 
 // ============================================================================
@@ -71,6 +80,7 @@ export interface SessionItemProps {
 	gitFileCount?: number;
 	isInBatch?: boolean;
 	jumpNumber?: string | null; // Session jump shortcut number (1-9, 0)
+	worktreeChildCount?: number; // Number of worktree children (used for collapsed count badge)
 
 	// Handlers
 	onSelect: () => void;
@@ -81,6 +91,7 @@ export interface SessionItemProps {
 	onFinishRename: (newName: string) => void;
 	onStartRename: () => void;
 	onToggleBookmark: () => void;
+	onToggleWorktrees?: (sessionId: string) => void;
 }
 
 /**
@@ -111,6 +122,7 @@ export const SessionItem = memo(function SessionItem({
 	gitFileCount,
 	isInBatch = false,
 	jumpNumber,
+	worktreeChildCount,
 	onSelect,
 	onDragStart,
 	onDragOver,
@@ -119,7 +131,14 @@ export const SessionItem = memo(function SessionItem({
 	onFinishRename,
 	onStartRename,
 	onToggleBookmark,
+	onToggleWorktrees,
 }: SessionItemProps) {
+	// Parent agents (sessions with worktreeConfig) get an inline chevron toggle.
+	// Default to expanded when worktreesExpanded is undefined to match useSortedSessions.
+	const isWorktreeParent = variant !== 'worktree' && Boolean(session.worktreeConfig);
+	const worktreesExpanded = session.worktreesExpanded ?? true;
+	const showCollapsedCountBadge =
+		isWorktreeParent && !worktreesExpanded && (worktreeChildCount ?? 0) > 0;
 	// Determine if we show the GIT/LOCAL badge (not shown in bookmark variant, terminal sessions, or worktree variant)
 	const showGitLocalBadge =
 		variant !== 'bookmark' && variant !== 'worktree' && session.toolType !== 'terminal';
@@ -184,6 +203,38 @@ export const SessionItem = memo(function SessionItem({
 					/>
 				) : (
 					<div className="flex items-center gap-1.5" onDoubleClick={onStartRename}>
+						{/* Worktree expand/collapse chevron for parent agents (rotates 90deg when expanded) */}
+						{isWorktreeParent && onToggleWorktrees && (
+							<button
+								type="button"
+								onClick={(e) => {
+									e.stopPropagation();
+									onToggleWorktrees(session.id);
+								}}
+								className="w-4 h-4 rounded hover:bg-white/10 shrink-0 flex items-center justify-center transition-colors"
+								title={worktreesExpanded ? 'Collapse worktrees' : 'Expand worktrees'}
+								aria-label={worktreesExpanded ? 'Collapse worktrees' : 'Expand worktrees'}
+								aria-expanded={worktreesExpanded}
+							>
+								<ChevronRight
+									className={`w-3 h-3 transition-transform duration-200 ${worktreesExpanded ? 'rotate-90' : ''}`}
+									style={{ color: theme.colors.textDim }}
+								/>
+							</button>
+						)}
+						{/* Collapsed worktree child count badge */}
+						{showCollapsedCountBadge && (
+							<span
+								className="text-[9px] px-1.5 py-0.5 rounded-full shrink-0 font-medium"
+								style={{
+									backgroundColor: theme.colors.accent + '33',
+									color: theme.colors.accent,
+								}}
+								title={`${worktreeChildCount} hidden worktree${worktreeChildCount === 1 ? '' : 's'}`}
+							>
+								{worktreeChildCount}
+							</span>
+						)}
 						{/* Bookmark icon (only in bookmark variant, always filled) */}
 						{variant === 'bookmark' && session.bookmarked && (
 							<Bookmark

--- a/src/renderer/components/SessionItem.tsx
+++ b/src/renderer/components/SessionItem.tsx
@@ -90,7 +90,9 @@ export const SessionItem = memo(function SessionItem({
 
 	// Determine container styling based on variant
 	const getContainerClassName = () => {
-		const base = `cursor-move flex items-center justify-between group border-l-2 transition-all hover:bg-opacity-50 ${isDragging ? 'opacity-50' : ''}`;
+		// Worktree items get a dashed left border to visually distinguish from regular agents
+		const borderClass = variant === 'worktree' ? 'border-l-2 border-dashed' : 'border-l-2';
+		const base = `cursor-move flex items-center justify-between group ${borderClass} transition-all hover:bg-opacity-50 ${isDragging ? 'opacity-50' : ''}`;
 
 		if (variant === 'flat') {
 			return `mx-3 px-3 py-2 rounded mb-1 ${base}`;
@@ -115,7 +117,9 @@ export const SessionItem = memo(function SessionItem({
 			style={{
 				borderColor: isActive || isKeyboardSelected ? theme.colors.accent : 'transparent',
 				backgroundColor: isActive
-					? theme.colors.bgActivity
+					? variant === 'worktree'
+						? theme.colors.accent + '15'
+						: theme.colors.bgActivity
 					: isKeyboardSelected
 						? theme.colors.bgActivity + '40'
 						: 'transparent',
@@ -156,6 +160,30 @@ export const SessionItem = memo(function SessionItem({
 						>
 							{session.name}
 						</span>
+						{/* Worktree badge to visually mark worktree children */}
+						{variant === 'worktree' && (
+							<span
+								className="text-[9px] font-medium uppercase tracking-wider px-1 py-0.5 rounded shrink-0"
+								style={{
+									backgroundColor: theme.colors.accent + '33',
+									border: `1px solid ${theme.colors.accent}66`,
+									color: theme.colors.accent,
+								}}
+							>
+								Worktree
+							</span>
+						)}
+					</div>
+				)}
+
+				{/* Branch name for worktree children (below session name) */}
+				{variant === 'worktree' && session.worktreeBranch && !isEditing && (
+					<div
+						className="text-[10px] mt-0.5 truncate"
+						style={{ color: theme.colors.textDim }}
+						title={session.worktreeBranch}
+					>
+						{session.worktreeBranch}
 					</div>
 				)}
 

--- a/src/renderer/components/SessionItem.tsx
+++ b/src/renderer/components/SessionItem.tsx
@@ -335,7 +335,7 @@ export const SessionItem = memo(function SessionItem({
 				{/* AUTO Mode Indicator */}
 				{isInBatch && (
 					<div
-						className="flex items-center gap-1 px-1.5 py-0.5 rounded text-[9px] font-bold uppercase animate-pulse"
+						className="flex items-center gap-1 px-1.5 py-0.5 rounded text-[9px] font-bold uppercase animate-status-pulse"
 						style={{
 							backgroundColor: theme.colors.warning + '30',
 							color: theme.colors.warning,

--- a/src/renderer/components/SessionItem.tsx
+++ b/src/renderer/components/SessionItem.tsx
@@ -1,7 +1,6 @@
 import React, { memo } from 'react';
 import { Activity, GitBranch, Bot, Bookmark, AlertCircle, Server, FolderTree } from 'lucide-react';
 import type { Session, Group, Theme } from '../types';
-import { getStatusColor } from '../utils/theme';
 
 // ============================================================================
 // SessionItem - Unified session item component for all list contexts
@@ -124,6 +123,12 @@ export const SessionItem = memo(function SessionItem({
 	// Determine if we show the GIT/LOCAL badge (not shown in bookmark variant, terminal sessions, or worktree variant)
 	const showGitLocalBadge =
 		variant !== 'bookmark' && variant !== 'worktree' && session.toolType !== 'terminal';
+
+	// Status indicator: enhanced color/animation/label, plus hollow signal for
+	// Claude Code agents that haven't bound to a provider session yet.
+	const statusInfo = getEnhancedStatusColor(session, theme, isInBatch);
+	const isDisconnected =
+		session.toolType === 'claude-code' && !session.agentSessionId && !isInBatch;
 
 	// Determine container styling based on variant
 	const getContainerClassName = () => {
@@ -389,32 +394,34 @@ export const SessionItem = memo(function SessionItem({
 					))}
 
 				{/* AI Status Indicator with Unread Badge - ml-auto ensures it aligns to right edge */}
-				<div className="relative ml-auto">
+				<div className="relative ml-auto w-2 h-2">
+					{/* Pulse ring: only renders for animated states, sits behind the dot */}
+					{statusInfo.animate && (
+						<span
+							className="absolute inset-0 rounded-full animate-ping"
+							style={{ backgroundColor: statusInfo.color, opacity: 0.3 }}
+							aria-hidden="true"
+						/>
+					)}
+					{/* Core status dot: filled by default, hollow when Claude has no provider session.
+					    Busy CLI activity overrides the generic "Thinking" tooltip with the playbook name. */}
 					<div
-						className={`w-2 h-2 rounded-full ${session.state === 'connecting' ? 'animate-pulse' : session.state === 'busy' || isInBatch ? 'animate-pulse' : ''}`}
+						className="relative w-2 h-2 rounded-full"
 						style={
-							session.toolType === 'claude-code' && !session.agentSessionId && !isInBatch
-								? { border: `1.5px solid ${theme.colors.textDim}`, backgroundColor: 'transparent' }
+							isDisconnected
+								? {
+										border: `1.5px solid ${theme.colors.textDim}`,
+										backgroundColor: 'transparent',
+									}
 								: {
-										backgroundColor: isInBatch
-											? theme.colors.warning
-											: getStatusColor(session.state, theme),
+										backgroundColor: statusInfo.color,
+										boxShadow: statusInfo.animate ? `0 0 6px ${statusInfo.color}60` : undefined,
 									}
 						}
 						title={
-							session.toolType === 'claude-code' && !session.agentSessionId
-								? 'No active Claude session'
-								: session.state === 'idle'
-									? 'Ready and waiting'
-									: session.state === 'busy'
-										? session.cliActivity
-											? `CLI: Running playbook "${session.cliActivity.playbookName}"`
-											: 'Agent is thinking'
-										: session.state === 'connecting'
-											? 'Attempting to establish connection'
-											: session.state === 'error'
-												? 'No connection with agent'
-												: 'Waiting for input'
+							session.state === 'busy' && session.cliActivity && !isInBatch
+								? `CLI: Running playbook "${session.cliActivity.playbookName}"`
+								: statusInfo.label
 						}
 					/>
 					{/* Unread Notification Badge */}

--- a/src/renderer/components/SessionItem.tsx
+++ b/src/renderer/components/SessionItem.tsx
@@ -1,5 +1,5 @@
 import React, { memo } from 'react';
-import { Activity, GitBranch, Bot, Bookmark, AlertCircle, Server } from 'lucide-react';
+import { Activity, GitBranch, Bot, Bookmark, AlertCircle, Server, FolderTree } from 'lucide-react';
 import type { Session, Group, Theme } from '../types';
 import { getStatusColor } from '../utils/theme';
 
@@ -153,6 +153,16 @@ export const SessionItem = memo(function SessionItem({
 						{/* Branch icon for worktree children */}
 						{variant === 'worktree' && (
 							<GitBranch className="w-3 h-3 shrink-0" style={{ color: theme.colors.accent }} />
+						)}
+						{/* Parent agent indicator: shown for sessions that have spawned worktree children */}
+						{variant !== 'worktree' && session.worktreeConfig && (
+							<span
+								className="shrink-0 inline-flex"
+								title="Parent agent with worktrees"
+								aria-label="Parent agent with worktrees"
+							>
+								<FolderTree size={10} style={{ color: theme.colors.textDim }} />
+							</span>
 						)}
 						<span
 							className={`font-medium truncate ${variant === 'worktree' ? 'text-xs' : 'text-sm'}`}

--- a/src/renderer/components/SessionList/SessionList.tsx
+++ b/src/renderer/components/SessionList/SessionList.tsx
@@ -4,11 +4,9 @@ import {
 	Plus,
 	ChevronRight,
 	ChevronDown,
-	ChevronUp,
 	X,
 	Radio,
 	Folder,
-	GitBranch,
 	Menu,
 	Bookmark,
 	Trophy,
@@ -450,7 +448,7 @@ function SessionListInner(props: SessionListProps) {
 
 		const content = (
 			<>
-				{/* Parent session - no chevron, maintains alignment */}
+				{/* Parent session — chevron in SessionItem toggles worktree expansion. */}
 				<SessionItem
 					session={session}
 					variant={effectiveVariant}
@@ -465,6 +463,7 @@ function SessionListInner(props: SessionListProps) {
 					gitFileCount={getFileCount(session.id)}
 					isInBatch={activeBatchSessionIds.includes(session.id)}
 					jumpNumber={getSessionJumpNumber(session.id)}
+					worktreeChildCount={worktreeChildren.length}
 					onSelect={selectHandlers.get(session.id)!}
 					onDragStart={dragStartHandlers.get(session.id)!}
 					onDragOver={handleDragOver}
@@ -473,49 +472,30 @@ function SessionListInner(props: SessionListProps) {
 					onFinishRename={finishRenameHandlers.get(session.id)!}
 					onStartRename={() => startRenamingSession(`${options.keyPrefix}-${session.id}`)}
 					onToggleBookmark={toggleBookmarkHandlers.get(session.id)!}
+					onToggleWorktrees={onToggleWorktreeExpanded}
 				/>
 
-				{/* Thin band below parent when worktrees exist but collapsed - click to expand */}
-				{hasWorktrees && !worktreesExpanded && onToggleWorktreeExpanded && (
-					<button
-						onClick={(e) => {
-							e.stopPropagation();
-							onToggleWorktreeExpanded(session.id);
-						}}
-						className="w-full flex items-center justify-center gap-1.5 py-0.5 text-[9px] font-medium hover:opacity-80 transition-opacity cursor-pointer"
-						style={{
-							backgroundColor: theme.colors.accent + '15',
-							color: theme.colors.accent,
-						}}
-						title={`${worktreeChildren.length} worktree${worktreeChildren.length > 1 ? 's' : ''} (click to expand)`}
-					>
-						<GitBranch className="w-2.5 h-2.5" />
-						<span>
-							{worktreeChildren.length} worktree{worktreeChildren.length > 1 ? 's' : ''}
-						</span>
-						<ChevronDown className="w-2.5 h-2.5" />
-					</button>
-				)}
-
-				{/* Worktree children drawer (when expanded) */}
-				{hasWorktrees && worktreesExpanded && onToggleWorktreeExpanded && (
+				{/* Worktree children with tree-connector visualization. Always rendered
+				    so maxHeight + opacity drive the expand/collapse animation. */}
+				{hasWorktrees && onToggleWorktreeExpanded && (
 					<div
-						className={`rounded-bl overflow-hidden ${needsWorktreeWrapper ? '' : 'ml-1'}`}
-						style={{
-							backgroundColor: theme.colors.accent + '10',
-							borderLeft: needsWorktreeWrapper ? 'none' : `1px solid ${theme.colors.accent}30`,
-							borderBottom: `1px solid ${theme.colors.accent}30`,
-						}}
+						className="tree-children transition-all duration-200 ease-in-out overflow-hidden"
+						style={
+							{
+								'--tree-line-color': `${theme.colors.accent}30`,
+								'--tree-bg-color': theme.colors.bgSidebar,
+								maxHeight: worktreesExpanded ? `${worktreeChildren.length * 48}px` : '0px',
+								opacity: worktreesExpanded ? 1 : 0,
+							} as React.CSSProperties
+						}
 					>
-						{/* Worktree children list */}
-						<div>
-							{(sortedWorktreeChildrenByParentId.get(session.id) || []).map((child) => {
-								const childGlobalIdx = sortedSessionIndexById.get(child.id) ?? -1;
-								const isChildKeyboardSelected =
-									activeFocus === 'sidebar' && childGlobalIdx === selectedSidebarIndex;
-								return (
+						{(sortedWorktreeChildrenByParentId.get(session.id) || []).map((child) => {
+							const childGlobalIdx = sortedSessionIndexById.get(child.id) ?? -1;
+							const isChildKeyboardSelected =
+								activeFocus === 'sidebar' && childGlobalIdx === selectedSidebarIndex;
+							return (
+								<div key={`worktree-${session.id}-${child.id}`} className="tree-child">
 									<SessionItem
-										key={`worktree-${session.id}-${child.id}`}
 										session={child}
 										variant="worktree"
 										theme={theme}
@@ -534,28 +514,9 @@ function SessionListInner(props: SessionListProps) {
 										onStartRename={() => startRenamingSession(`worktree-${session.id}-${child.id}`)}
 										onToggleBookmark={toggleBookmarkHandlers.get(child.id)!}
 									/>
-								);
-							})}
-						</div>
-						{/* Drawer handle at bottom - click to collapse */}
-						<button
-							onClick={(e) => {
-								e.stopPropagation();
-								onToggleWorktreeExpanded(session.id);
-							}}
-							className="w-full flex items-center justify-center gap-1.5 py-0.5 text-[9px] font-medium hover:opacity-80 transition-opacity cursor-pointer"
-							style={{
-								backgroundColor: theme.colors.accent + '20',
-								color: theme.colors.accent,
-							}}
-							title="Click to collapse worktrees"
-						>
-							<GitBranch className="w-2.5 h-2.5" />
-							<span>
-								{worktreeChildren.length} worktree{worktreeChildren.length > 1 ? 's' : ''}
-							</span>
-							<ChevronUp className="w-2.5 h-2.5" />
-						</button>
+								</div>
+							);
+						})}
 					</div>
 				)}
 			</>

--- a/src/renderer/components/UsageDashboard/ActivityHeatmap.tsx
+++ b/src/renderer/components/UsageDashboard/ActivityHeatmap.tsx
@@ -596,7 +596,10 @@ export const ActivityHeatmap = memo(function ActivityHeatmap({
 		>
 			{/* Header with title and metric toggle */}
 			<div className="flex items-center justify-between mb-4">
-				<h3 className="text-sm font-medium" style={{ color: theme.colors.textMain }}>
+				<h3
+					className="text-sm font-medium"
+					style={{ color: theme.colors.textMain, animation: 'card-enter 0.4s ease both' }}
+				>
 					Activity Heatmap
 				</h3>
 				<div className="flex items-center gap-2">

--- a/src/renderer/components/UsageDashboard/AgentComparisonChart.tsx
+++ b/src/renderer/components/UsageDashboard/AgentComparisonChart.tsx
@@ -41,9 +41,13 @@ interface AgentComparisonChartProps {
 	colorBlindMode?: boolean;
 	/** Current sessions list — when provided, worktree agents are split into separate bars. */
 	sessions?: Session[];
-	/** Drill-down click handler — wired by the dashboard, consumed in a follow-up task. */
+	/** Drill-down click handler — fires with the bar's `key`/`label` on click. */
 	onAgentClick?: (key: string, displayName: string) => void;
-	/** Active drill-down filter key — consumed in a follow-up task to dim non-selected bars. */
+	/**
+	 * Active drill-down filter key. When set, the matching bar gets an accent
+	 * outline; non-matching bars dim to 30% opacity. `null` (or undefined) means
+	 * no filter is active and bars render normally.
+	 */
 	activeFilterKey?: string | null;
 }
 
@@ -118,6 +122,8 @@ export const AgentComparisonChart = memo(function AgentComparisonChart({
 	theme,
 	colorBlindMode = false,
 	sessions,
+	onAgentClick,
+	activeFilterKey = null,
 }: AgentComparisonChartProps) {
 	const [hoveredAgent, setHoveredAgent] = useState<string | null>(null);
 	const [tooltipPos, setTooltipPos] = useState<{ x: number; y: number } | null>(null);
@@ -277,6 +283,17 @@ export const AgentComparisonChart = memo(function AgentComparisonChart({
 		setTooltipPos(null);
 	}, []);
 
+	// Forward bar clicks to the dashboard's drill-down handler. The dashboard
+	// owns toggle behavior (clicking the active bar clears the filter); this
+	// component just reports which row was clicked.
+	const handleAgentClick = useCallback(
+		(key: string, label: string) => {
+			if (!onAgentClick) return;
+			onAgentClick(key, label);
+		},
+		[onAgentClick]
+	);
+
 	// Get hovered agent data for tooltip (matched by row key, since the same
 	// provider can appear twice — once as regular and once as worktree).
 	const hoveredAgentData = useMemo(() => {
@@ -296,7 +313,10 @@ export const AgentComparisonChart = memo(function AgentComparisonChart({
 		>
 			{/* Header */}
 			<div className="flex items-center justify-between mb-4">
-				<h3 className="text-sm font-medium" style={{ color: theme.colors.textMain }}>
+				<h3
+					className="text-sm font-medium"
+					style={{ color: theme.colors.textMain, animation: 'card-enter 0.4s ease both' }}
+				>
 					Provider Comparison
 				</h3>
 			</div>
@@ -315,16 +335,38 @@ export const AgentComparisonChart = memo(function AgentComparisonChart({
 						{agentData.map((agent) => {
 							const barWidth = maxDuration > 0 ? (agent.duration / maxDuration) * 100 : 0;
 							const isHovered = hoveredAgent === agent.key;
+							const isClickable = !!onAgentClick;
+							const isFiltered = activeFilterKey != null;
+							const isSelected = isFiltered && activeFilterKey === agent.key;
+							const isDimmed = isFiltered && !isSelected;
 
 							return (
 								<div
 									key={agent.key}
 									className="flex items-center gap-3"
-									style={{ height: barHeight }}
+									style={{
+										height: barHeight,
+										cursor: isClickable ? 'pointer' : undefined,
+										opacity: isDimmed ? 0.3 : 1,
+										transition: 'opacity 0.2s ease',
+									}}
 									onMouseEnter={(e) => handleMouseEnter(agent.key, e)}
 									onMouseLeave={handleMouseLeave}
+									onClick={isClickable ? () => handleAgentClick(agent.key, agent.label) : undefined}
+									onKeyDown={
+										isClickable
+											? (e) => {
+													if (e.key === 'Enter' || e.key === ' ') {
+														e.preventDefault();
+														handleAgentClick(agent.key, agent.label);
+													}
+												}
+											: undefined
+									}
 									role="listitem"
-									aria-label={`${agent.label}: ${agent.count} queries, ${formatDuration(agent.duration)}`}
+									tabIndex={isClickable ? 0 : undefined}
+									aria-pressed={isClickable ? isSelected : undefined}
+									aria-label={`${agent.label}: ${agent.count} queries, ${formatDuration(agent.duration)}${isClickable ? '. Click to filter dashboard.' : ''}`}
 								>
 									{/* Agent name label */}
 									<div
@@ -342,6 +384,11 @@ export const AgentComparisonChart = memo(function AgentComparisonChart({
 										className="flex-1 h-full rounded overflow-hidden relative"
 										style={{
 											backgroundColor: `${theme.colors.border}30`,
+											// Selected bar gets an accent outline (analogue of recharts
+											// `<Cell>` stroke + strokeWidth). `boxShadow` is used over
+											// `border` so the bar geometry doesn't shift on selection.
+											boxShadow: isSelected ? `inset 0 0 0 2px ${theme.colors.accent}` : undefined,
+											transition: 'box-shadow 0.2s ease',
 										}}
 										role="meter"
 										aria-valuenow={agent.durationPercentage}

--- a/src/renderer/components/UsageDashboard/AgentComparisonChart.tsx
+++ b/src/renderer/components/UsageDashboard/AgentComparisonChart.tsx
@@ -16,7 +16,7 @@ import React, { memo, useMemo, useCallback, useState } from 'react';
 import type { Theme, Session } from '../../types';
 import type { StatsAggregation } from '../../hooks/stats/useStats';
 import { COLORBLIND_AGENT_PALETTE } from '../../constants/colorblindPalettes';
-import { findSessionByStatId, isWorktreeAgent } from './chartUtils';
+import { findSessionByStatId, isWorktreeAgent, buildNameMap } from './chartUtils';
 
 interface AgentData {
 	/** Stable React key — `${agent}` for regular, `${agent}__worktree` for worktree variant. */
@@ -177,6 +177,19 @@ export const AgentComparisonChart = memo(function AgentComparisonChart({
 
 		const items: AgentData[] = [];
 
+		// Resolve raw provider keys (e.g. "claude-code") to user-facing names
+		// (e.g. the user's "Backend API" session name, or the prettified
+		// "Claude Code" fallback). Built from the union of byAgent and the split
+		// aggregation so both rendering paths get coherent labels.
+		const providerKeys = Array.from(
+			new Set([
+				...Object.keys(data.byAgent),
+				...(splitAggregation ? Object.keys(splitAggregation) : []),
+			])
+		);
+		const nameMap = buildNameMap(providerKeys, sessions);
+		const resolveLabel = (provider: string) => nameMap.get(provider)?.name ?? provider;
+
 		// Track unique providers in deterministic order to assign colors stably.
 		const providerColorIdx: Record<string, number> = {};
 		const assignColor = (provider: string): string => {
@@ -189,10 +202,11 @@ export const AgentComparisonChart = memo(function AgentComparisonChart({
 		if (splitAggregation) {
 			for (const [provider, buckets] of Object.entries(splitAggregation)) {
 				const color = assignColor(provider);
+				const baseLabel = resolveLabel(provider);
 				if (buckets.regular.count > 0 || buckets.regular.duration > 0) {
 					items.push({
 						key: provider,
-						label: provider,
+						label: baseLabel,
 						agent: provider,
 						count: buckets.regular.count,
 						duration: buckets.regular.duration,
@@ -205,7 +219,7 @@ export const AgentComparisonChart = memo(function AgentComparisonChart({
 				if (buckets.worktree.count > 0 || buckets.worktree.duration > 0) {
 					items.push({
 						key: `${provider}__worktree`,
-						label: `${provider} (Worktree)`,
+						label: `${baseLabel} (Worktree)`,
 						agent: provider,
 						count: buckets.worktree.count,
 						duration: buckets.worktree.duration,
@@ -219,21 +233,22 @@ export const AgentComparisonChart = memo(function AgentComparisonChart({
 		} else {
 			for (const [provider, stats] of Object.entries(data.byAgent)) {
 				const color = assignColor(provider);
+				const resolved = nameMap.get(provider);
 				items.push({
 					key: provider,
-					label: provider,
+					label: resolved?.name ?? provider,
 					agent: provider,
 					count: stats.count,
 					duration: stats.duration,
 					durationPercentage: totalDuration > 0 ? (stats.duration / totalDuration) * 100 : 0,
 					color,
-					isWorktree: false,
+					isWorktree: resolved?.isWorktree ?? false,
 				});
 			}
 		}
 
 		return items.sort((a, b) => b.duration - a.duration);
-	}, [data.byAgent, splitAggregation, theme, colorBlindMode]);
+	}, [data.byAgent, splitAggregation, theme, colorBlindMode, sessions]);
 
 	const hasWorktreeBars = useMemo(() => agentData.some((d) => d.isWorktree), [agentData]);
 

--- a/src/renderer/components/UsageDashboard/AgentComparisonChart.tsx
+++ b/src/renderer/components/UsageDashboard/AgentComparisonChart.tsx
@@ -41,6 +41,10 @@ interface AgentComparisonChartProps {
 	colorBlindMode?: boolean;
 	/** Current sessions list — when provided, worktree agents are split into separate bars. */
 	sessions?: Session[];
+	/** Drill-down click handler — wired by the dashboard, consumed in a follow-up task. */
+	onAgentClick?: (key: string, displayName: string) => void;
+	/** Active drill-down filter key — consumed in a follow-up task to dim non-selected bars. */
+	activeFilterKey?: string | null;
 }
 
 /**

--- a/src/renderer/components/UsageDashboard/AgentComparisonChart.tsx
+++ b/src/renderer/components/UsageDashboard/AgentComparisonChart.tsx
@@ -13,16 +13,23 @@
  */
 
 import React, { memo, useMemo, useCallback, useState } from 'react';
-import type { Theme } from '../../types';
+import type { Theme, Session } from '../../types';
 import type { StatsAggregation } from '../../hooks/stats/useStats';
 import { COLORBLIND_AGENT_PALETTE } from '../../constants/colorblindPalettes';
+import { findSessionByStatId, isWorktreeAgent } from './chartUtils';
 
 interface AgentData {
+	/** Stable React key — `${agent}` for regular, `${agent}__worktree` for worktree variant. */
+	key: string;
+	/** Provider name shown in the bar label, optionally suffixed with "(Worktree)". */
+	label: string;
+	/** Underlying provider/agent type used for color assignment. */
 	agent: string;
 	count: number;
 	duration: number;
 	durationPercentage: number;
 	color: string;
+	isWorktree: boolean;
 }
 
 interface AgentComparisonChartProps {
@@ -32,6 +39,8 @@ interface AgentComparisonChartProps {
 	theme: Theme;
 	/** Enable colorblind-friendly colors */
 	colorBlindMode?: boolean;
+	/** Current sessions list — when provided, worktree agents are split into separate bars. */
+	sessions?: Session[];
 }
 
 /**
@@ -104,29 +113,129 @@ export const AgentComparisonChart = memo(function AgentComparisonChart({
 	data,
 	theme,
 	colorBlindMode = false,
+	sessions,
 }: AgentComparisonChartProps) {
 	const [hoveredAgent, setHoveredAgent] = useState<string | null>(null);
 	const [tooltipPos, setTooltipPos] = useState<{ x: number; y: number } | null>(null);
 
+	// Compute per-(provider, worktree-status) aggregation when sessions are
+	// available and the underlying per-session breakdown identifies any
+	// worktree agents. Returns null if differentiation isn't possible — the
+	// caller falls back to the legacy by-provider aggregation.
+	const splitAggregation = useMemo((): Record<
+		string,
+		{ regular: { count: number; duration: number }; worktree: { count: number; duration: number } }
+	> | null => {
+		const bySessionByDay = data.bySessionByDay;
+		if (!sessions || sessions.length === 0) return null;
+		if (!bySessionByDay || Object.keys(bySessionByDay).length === 0) return null;
+
+		const result: Record<
+			string,
+			{
+				regular: { count: number; duration: number };
+				worktree: { count: number; duration: number };
+			}
+		> = {};
+		let foundWorktree = false;
+
+		for (const [statSessionId, days] of Object.entries(bySessionByDay)) {
+			const session = findSessionByStatId(statSessionId, sessions);
+			if (!session) continue; // Historical session no longer present — skip.
+			const provider = session.toolType;
+			const isWt = isWorktreeAgent(session);
+			if (isWt) foundWorktree = true;
+
+			if (!result[provider]) {
+				result[provider] = {
+					regular: { count: 0, duration: 0 },
+					worktree: { count: 0, duration: 0 },
+				};
+			}
+			const bucket = isWt ? result[provider].worktree : result[provider].regular;
+			for (const day of days) {
+				bucket.count += day.count;
+				bucket.duration += day.duration;
+			}
+		}
+
+		// If no worktree agents were found, splitting adds no signal — let the
+		// chart render the simpler byAgent view to avoid losing historical data
+		// from sessions that aren't currently in the sessions list.
+		return foundWorktree ? result : null;
+	}, [data.bySessionByDay, sessions]);
+
 	// Process and sort agent data
 	const agentData = useMemo((): AgentData[] => {
-		const entries = Object.entries(data.byAgent);
-		if (entries.length === 0) return [];
+		const totalDuration =
+			(splitAggregation
+				? Object.values(splitAggregation).reduce(
+						(sum, p) => sum + p.regular.duration + p.worktree.duration,
+						0
+					)
+				: Object.values(data.byAgent).reduce((sum, stats) => sum + stats.duration, 0)) || 0;
 
-		// Calculate total duration for percentage
-		const totalDuration = entries.reduce((sum, [, stats]) => sum + stats.duration, 0);
+		const items: AgentData[] = [];
 
-		// Map and sort by duration descending
-		return entries
-			.map(([agent, stats], index) => ({
-				agent,
-				count: stats.count,
-				duration: stats.duration,
-				durationPercentage: totalDuration > 0 ? (stats.duration / totalDuration) * 100 : 0,
-				color: getAgentColor(agent, index, theme, colorBlindMode),
-			}))
-			.sort((a, b) => b.duration - a.duration);
-	}, [data.byAgent, theme, colorBlindMode]);
+		// Track unique providers in deterministic order to assign colors stably.
+		const providerColorIdx: Record<string, number> = {};
+		const assignColor = (provider: string): string => {
+			if (!(provider in providerColorIdx)) {
+				providerColorIdx[provider] = Object.keys(providerColorIdx).length;
+			}
+			return getAgentColor(provider, providerColorIdx[provider], theme, colorBlindMode);
+		};
+
+		if (splitAggregation) {
+			for (const [provider, buckets] of Object.entries(splitAggregation)) {
+				const color = assignColor(provider);
+				if (buckets.regular.count > 0 || buckets.regular.duration > 0) {
+					items.push({
+						key: provider,
+						label: provider,
+						agent: provider,
+						count: buckets.regular.count,
+						duration: buckets.regular.duration,
+						durationPercentage:
+							totalDuration > 0 ? (buckets.regular.duration / totalDuration) * 100 : 0,
+						color,
+						isWorktree: false,
+					});
+				}
+				if (buckets.worktree.count > 0 || buckets.worktree.duration > 0) {
+					items.push({
+						key: `${provider}__worktree`,
+						label: `${provider} (Worktree)`,
+						agent: provider,
+						count: buckets.worktree.count,
+						duration: buckets.worktree.duration,
+						durationPercentage:
+							totalDuration > 0 ? (buckets.worktree.duration / totalDuration) * 100 : 0,
+						color,
+						isWorktree: true,
+					});
+				}
+			}
+		} else {
+			for (const [provider, stats] of Object.entries(data.byAgent)) {
+				const color = assignColor(provider);
+				items.push({
+					key: provider,
+					label: provider,
+					agent: provider,
+					count: stats.count,
+					duration: stats.duration,
+					durationPercentage: totalDuration > 0 ? (stats.duration / totalDuration) * 100 : 0,
+					color,
+					isWorktree: false,
+				});
+			}
+		}
+
+		return items.sort((a, b) => b.duration - a.duration);
+	}, [data.byAgent, splitAggregation, theme, colorBlindMode]);
+
+	const hasWorktreeBars = useMemo(() => agentData.some((d) => d.isWorktree), [agentData]);
 
 	// Get max duration for bar width calculation
 	const maxDuration = useMemo(() => {
@@ -149,10 +258,11 @@ export const AgentComparisonChart = memo(function AgentComparisonChart({
 		setTooltipPos(null);
 	}, []);
 
-	// Get hovered agent data for tooltip
+	// Get hovered agent data for tooltip (matched by row key, since the same
+	// provider can appear twice — once as regular and once as worktree).
 	const hoveredAgentData = useMemo(() => {
 		if (!hoveredAgent) return null;
-		return agentData.find((d) => d.agent === hoveredAgent) || null;
+		return agentData.find((d) => d.key === hoveredAgent) || null;
 	}, [hoveredAgent, agentData]);
 
 	// Bar height
@@ -185,17 +295,17 @@ export const AgentComparisonChart = memo(function AgentComparisonChart({
 					<div className="space-y-2" role="list" aria-label="Agent usage data">
 						{agentData.map((agent) => {
 							const barWidth = maxDuration > 0 ? (agent.duration / maxDuration) * 100 : 0;
-							const isHovered = hoveredAgent === agent.agent;
+							const isHovered = hoveredAgent === agent.key;
 
 							return (
 								<div
-									key={agent.agent}
+									key={agent.key}
 									className="flex items-center gap-3"
 									style={{ height: barHeight }}
-									onMouseEnter={(e) => handleMouseEnter(agent.agent, e)}
+									onMouseEnter={(e) => handleMouseEnter(agent.key, e)}
 									onMouseLeave={handleMouseLeave}
 									role="listitem"
-									aria-label={`${agent.agent}: ${agent.count} queries, ${formatDuration(agent.duration)}`}
+									aria-label={`${agent.label}: ${agent.count} queries, ${formatDuration(agent.duration)}`}
 								>
 									{/* Agent name label */}
 									<div
@@ -203,9 +313,9 @@ export const AgentComparisonChart = memo(function AgentComparisonChart({
 										style={{
 											color: isHovered ? theme.colors.textMain : theme.colors.textDim,
 										}}
-										title={agent.agent}
+										title={agent.label}
 									>
-										{agent.agent}
+										{agent.label}
 									</div>
 
 									{/* Bar container */}
@@ -218,7 +328,7 @@ export const AgentComparisonChart = memo(function AgentComparisonChart({
 										aria-valuenow={agent.durationPercentage}
 										aria-valuemin={0}
 										aria-valuemax={100}
-										aria-label={`${agent.agent} usage percentage`}
+										aria-label={`${agent.label} usage percentage`}
 									>
 										{/* Bar fill */}
 										<div
@@ -226,7 +336,18 @@ export const AgentComparisonChart = memo(function AgentComparisonChart({
 											style={{
 												width: `${Math.max(barWidth, 2)}%`,
 												backgroundColor: agent.color,
-												opacity: isHovered ? 1 : 0.85,
+												// Worktree bars render at reduced opacity with a diagonal stripe
+												// overlay so they're visually distinct from regular agent bars.
+												opacity: isHovered
+													? agent.isWorktree
+														? 0.75
+														: 1
+													: agent.isWorktree
+														? 0.55
+														: 0.85,
+												backgroundImage: agent.isWorktree
+													? 'repeating-linear-gradient(45deg, rgba(255,255,255,0.18) 0 4px, transparent 4px 8px)'
+													: undefined,
 												transition: 'width 0.5s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.2s ease',
 											}}
 											aria-hidden="true"
@@ -300,7 +421,7 @@ export const AgentComparisonChart = memo(function AgentComparisonChart({
 								className="w-2 h-2 rounded-full"
 								style={{ backgroundColor: hoveredAgentData.color }}
 							/>
-							{hoveredAgentData.agent}
+							{hoveredAgentData.label}
 						</div>
 						<div style={{ color: theme.colors.textDim }}>
 							<div>
@@ -321,10 +442,19 @@ export const AgentComparisonChart = memo(function AgentComparisonChart({
 					aria-label="Chart legend"
 				>
 					{agentData.slice(0, 6).map((agent) => (
-						<div key={agent.agent} className="flex items-center gap-1.5" role="listitem">
-							<div className="w-2.5 h-2.5 rounded-sm" style={{ backgroundColor: agent.color }} />
+						<div key={agent.key} className="flex items-center gap-1.5" role="listitem">
+							<div
+								className="w-2.5 h-2.5 rounded-sm"
+								style={{
+									backgroundColor: agent.color,
+									opacity: agent.isWorktree ? 0.55 : 1,
+									backgroundImage: agent.isWorktree
+										? 'repeating-linear-gradient(45deg, rgba(255,255,255,0.18) 0 2px, transparent 2px 4px)'
+										: undefined,
+								}}
+							/>
 							<span className="text-xs" style={{ color: theme.colors.textDim }}>
-								{agent.agent}
+								{agent.label}
 							</span>
 						</div>
 					))}
@@ -332,6 +462,38 @@ export const AgentComparisonChart = memo(function AgentComparisonChart({
 						<span className="text-xs" style={{ color: theme.colors.textDim }}>
 							+{agentData.length - 6} more
 						</span>
+					)}
+					{hasWorktreeBars && (
+						<div
+							className="flex items-center gap-3 w-full mt-1 pt-2 border-t"
+							style={{ borderColor: `${theme.colors.border}60` }}
+							role="listitem"
+							aria-label="Worktree differentiation legend"
+						>
+							<div className="flex items-center gap-1.5">
+								<div
+									className="w-2.5 h-2.5 rounded-sm"
+									style={{ backgroundColor: theme.colors.textDim, opacity: 0.85 }}
+								/>
+								<span className="text-xs" style={{ color: theme.colors.textDim }}>
+									Agent
+								</span>
+							</div>
+							<div className="flex items-center gap-1.5">
+								<div
+									className="w-2.5 h-2.5 rounded-sm"
+									style={{
+										backgroundColor: theme.colors.textDim,
+										opacity: 0.55,
+										backgroundImage:
+											'repeating-linear-gradient(45deg, rgba(255,255,255,0.18) 0 2px, transparent 2px 4px)',
+									}}
+								/>
+								<span className="text-xs" style={{ color: theme.colors.textDim }}>
+									Worktree Agent
+								</span>
+							</div>
+						</div>
 					)}
 				</div>
 			)}

--- a/src/renderer/components/UsageDashboard/AgentEfficiencyChart.tsx
+++ b/src/renderer/components/UsageDashboard/AgentEfficiencyChart.tsx
@@ -16,7 +16,7 @@ import { memo, useMemo } from 'react';
 import type { Theme, Session } from '../../types';
 import type { StatsAggregation } from '../../hooks/stats/useStats';
 import { COLORBLIND_AGENT_PALETTE } from '../../constants/colorblindPalettes';
-import { findSessionByStatId, isWorktreeAgent } from './chartUtils';
+import { findSessionByStatId, isWorktreeAgent, buildNameMap } from './chartUtils';
 
 interface AgentEfficiencyChartProps {
 	/** Aggregated stats data from the API */
@@ -25,7 +25,8 @@ interface AgentEfficiencyChartProps {
 	theme: Theme;
 	/** Enable colorblind-friendly colors */
 	colorBlindMode?: boolean;
-	/** Current sessions list — when provided, worktree agents render with a dashed/striped pattern. */
+	/** Current sessions list — when provided, agents are labeled with their
+	 * user-assigned session names and worktree agents render with a striped pattern. */
 	sessions?: Session[];
 }
 
@@ -47,23 +48,6 @@ function formatDuration(ms: number): string {
 		return `${minutes}m ${seconds}s`;
 	}
 	return `${seconds}s`;
-}
-
-/**
- * Format agent type display name
- */
-function formatAgentName(agent: string): string {
-	const names: Record<string, string> = {
-		'claude-code': 'Claude Code',
-		opencode: 'OpenCode',
-		'openai-codex': 'OpenAI Codex',
-		codex: 'Codex',
-		'gemini-cli': 'Gemini CLI',
-		'qwen3-coder': 'Qwen3 Coder',
-		'factory-droid': 'Factory Droid',
-		terminal: 'Terminal',
-	};
-	return names[agent] || agent;
 }
 
 /**
@@ -152,12 +136,25 @@ export const AgentEfficiencyChart = memo(function AgentEfficiencyChart({
 
 		const entries: Entry[] = [];
 
+		// Resolve raw provider keys (e.g. "claude-code") to user-facing names
+		// (e.g. the user's "Backend API" session name, or the prettified
+		// "Claude Code" fallback). Built from the union of byAgent and the split
+		// aggregation so both rendering paths get coherent labels.
+		const providerKeys = Array.from(
+			new Set([
+				...Object.keys(data.byAgent),
+				...(splitAggregation ? Object.keys(splitAggregation) : []),
+			])
+		);
+		const nameMap = buildNameMap(providerKeys, sessions);
+
 		if (splitAggregation) {
 			for (const [provider, buckets] of Object.entries(splitAggregation)) {
+				const baseLabel = nameMap.get(provider)?.name ?? provider;
 				if (buckets.regular.count > 0) {
 					entries.push({
 						key: provider,
-						label: formatAgentName(provider),
+						label: baseLabel,
 						agent: provider,
 						avgDuration: buckets.regular.duration / buckets.regular.count,
 						totalQueries: buckets.regular.count,
@@ -168,7 +165,7 @@ export const AgentEfficiencyChart = memo(function AgentEfficiencyChart({
 				if (buckets.worktree.count > 0) {
 					entries.push({
 						key: `${provider}__worktree`,
-						label: `${formatAgentName(provider)} (Worktree)`,
+						label: `${baseLabel} (Worktree)`,
 						agent: provider,
 						avgDuration: buckets.worktree.duration / buckets.worktree.count,
 						totalQueries: buckets.worktree.count,
@@ -180,20 +177,21 @@ export const AgentEfficiencyChart = memo(function AgentEfficiencyChart({
 		} else {
 			for (const [agent, stats] of Object.entries(data.byAgent)) {
 				if (stats.count <= 0) continue;
+				const resolved = nameMap.get(agent);
 				entries.push({
 					key: agent,
-					label: formatAgentName(agent),
+					label: resolved?.name ?? agent,
 					agent,
 					avgDuration: stats.duration / stats.count,
 					totalQueries: stats.count,
 					totalDuration: stats.duration,
-					isWorktree: false,
+					isWorktree: resolved?.isWorktree ?? false,
 				});
 			}
 		}
 
 		return entries.sort((a, b) => a.avgDuration - b.avgDuration); // Fastest first
-	}, [data.byAgent, splitAggregation]);
+	}, [data.byAgent, splitAggregation, sessions]);
 
 	const hasWorktreeBars = useMemo(() => efficiencyData.some((e) => e.isWorktree), [efficiencyData]);
 

--- a/src/renderer/components/UsageDashboard/AgentEfficiencyChart.tsx
+++ b/src/renderer/components/UsageDashboard/AgentEfficiencyChart.tsx
@@ -28,7 +28,7 @@ interface AgentEfficiencyChartProps {
 	/** Current sessions list — when provided, agents are labeled with their
 	 * user-assigned session names and worktree agents render with a striped pattern. */
 	sessions?: Session[];
-	/** Active drill-down filter key — consumed in a follow-up task to dim non-selected entries. */
+	/** Active drill-down filter key — when set, non-matching entries dim to 0.3 opacity. */
 	activeFilterKey?: string | null;
 }
 
@@ -80,6 +80,7 @@ export const AgentEfficiencyChart = memo(function AgentEfficiencyChart({
 	theme,
 	colorBlindMode = false,
 	sessions,
+	activeFilterKey = null,
 }: AgentEfficiencyChartProps) {
 	// Compute per-(provider, worktree-status) aggregation when sessions are
 	// available and at least one worktree session is found. Returns null
@@ -206,7 +207,10 @@ export const AgentEfficiencyChart = memo(function AgentEfficiencyChart({
 	if (efficiencyData.length === 0) {
 		return (
 			<div className="p-4 rounded-lg" style={{ backgroundColor: theme.colors.bgMain }}>
-				<h3 className="text-sm font-medium mb-4" style={{ color: theme.colors.textMain }}>
+				<h3
+					className="text-sm font-medium mb-4"
+					style={{ color: theme.colors.textMain, animation: 'card-enter 0.4s ease both' }}
+				>
 					Agent Efficiency
 				</h3>
 				<div
@@ -225,7 +229,10 @@ export const AgentEfficiencyChart = memo(function AgentEfficiencyChart({
 			style={{ backgroundColor: theme.colors.bgMain }}
 			data-testid="agent-efficiency-chart"
 		>
-			<h3 className="text-sm font-medium mb-4" style={{ color: theme.colors.textMain }}>
+			<h3
+				className="text-sm font-medium mb-4"
+				style={{ color: theme.colors.textMain, animation: 'card-enter 0.4s ease both' }}
+			>
 				Agent Efficiency
 				<span className="text-xs font-normal ml-2" style={{ color: theme.colors.textDim }}>
 					(avg response time per query)
@@ -245,9 +252,17 @@ export const AgentEfficiencyChart = memo(function AgentEfficiencyChart({
 					return efficiencyData.map((agent) => {
 						const percentage = maxDuration > 0 ? (agent.avgDuration / maxDuration) * 100 : 0;
 						const color = getAgentColor(providerColorIdx[agent.agent], theme, colorBlindMode);
+						const isDimmed = activeFilterKey !== null && activeFilterKey !== agent.key;
 
 						return (
-							<div key={agent.key} className="flex items-center gap-3">
+							<div
+								key={agent.key}
+								className="flex items-center gap-3"
+								style={{
+									opacity: isDimmed ? 0.3 : 1,
+									transition: 'opacity 0.15s ease',
+								}}
+							>
 								{/* Agent name */}
 								<div
 									className="w-28 text-sm truncate flex-shrink-0 flex items-center gap-2"

--- a/src/renderer/components/UsageDashboard/AgentEfficiencyChart.tsx
+++ b/src/renderer/components/UsageDashboard/AgentEfficiencyChart.tsx
@@ -28,6 +28,8 @@ interface AgentEfficiencyChartProps {
 	/** Current sessions list — when provided, agents are labeled with their
 	 * user-assigned session names and worktree agents render with a striped pattern. */
 	sessions?: Session[];
+	/** Active drill-down filter key — consumed in a follow-up task to dim non-selected entries. */
+	activeFilterKey?: string | null;
 }
 
 /**

--- a/src/renderer/components/UsageDashboard/AgentEfficiencyChart.tsx
+++ b/src/renderer/components/UsageDashboard/AgentEfficiencyChart.tsx
@@ -13,9 +13,10 @@
  */
 
 import { memo, useMemo } from 'react';
-import type { Theme } from '../../types';
+import type { Theme, Session } from '../../types';
 import type { StatsAggregation } from '../../hooks/stats/useStats';
 import { COLORBLIND_AGENT_PALETTE } from '../../constants/colorblindPalettes';
+import { findSessionByStatId, isWorktreeAgent } from './chartUtils';
 
 interface AgentEfficiencyChartProps {
 	/** Aggregated stats data from the API */
@@ -24,6 +25,8 @@ interface AgentEfficiencyChartProps {
 	theme: Theme;
 	/** Enable colorblind-friendly colors */
 	colorBlindMode?: boolean;
+	/** Current sessions list — when provided, worktree agents render with a dashed/striped pattern. */
+	sessions?: Session[];
 }
 
 /**
@@ -90,21 +93,109 @@ export const AgentEfficiencyChart = memo(function AgentEfficiencyChart({
 	data,
 	theme,
 	colorBlindMode = false,
+	sessions,
 }: AgentEfficiencyChartProps) {
+	// Compute per-(provider, worktree-status) aggregation when sessions are
+	// available and at least one worktree session is found. Returns null
+	// otherwise so the chart falls back to the legacy by-provider view.
+	const splitAggregation = useMemo((): Record<
+		string,
+		{ regular: { count: number; duration: number }; worktree: { count: number; duration: number } }
+	> | null => {
+		const bySessionByDay = data.bySessionByDay;
+		if (!sessions || sessions.length === 0) return null;
+		if (!bySessionByDay || Object.keys(bySessionByDay).length === 0) return null;
+
+		const result: Record<
+			string,
+			{
+				regular: { count: number; duration: number };
+				worktree: { count: number; duration: number };
+			}
+		> = {};
+		let foundWorktree = false;
+
+		for (const [statSessionId, days] of Object.entries(bySessionByDay)) {
+			const session = findSessionByStatId(statSessionId, sessions);
+			if (!session) continue;
+			const provider = session.toolType;
+			const isWt = isWorktreeAgent(session);
+			if (isWt) foundWorktree = true;
+
+			if (!result[provider]) {
+				result[provider] = {
+					regular: { count: 0, duration: 0 },
+					worktree: { count: 0, duration: 0 },
+				};
+			}
+			const bucket = isWt ? result[provider].worktree : result[provider].regular;
+			for (const day of days) {
+				bucket.count += day.count;
+				bucket.duration += day.duration;
+			}
+		}
+
+		return foundWorktree ? result : null;
+	}, [data.bySessionByDay, sessions]);
+
 	// Calculate efficiency data (avg duration per query) for each agent
 	const efficiencyData = useMemo(() => {
-		const agents = Object.entries(data.byAgent)
-			.map(([agent, stats]) => ({
-				agent,
-				avgDuration: stats.count > 0 ? stats.duration / stats.count : 0,
-				totalQueries: stats.count,
-				totalDuration: stats.duration,
-			}))
-			.filter((a) => a.totalQueries > 0) // Only show agents with data
-			.sort((a, b) => a.avgDuration - b.avgDuration); // Fastest first
+		type Entry = {
+			key: string;
+			label: string;
+			agent: string;
+			avgDuration: number;
+			totalQueries: number;
+			totalDuration: number;
+			isWorktree: boolean;
+		};
 
-		return agents;
-	}, [data.byAgent]);
+		const entries: Entry[] = [];
+
+		if (splitAggregation) {
+			for (const [provider, buckets] of Object.entries(splitAggregation)) {
+				if (buckets.regular.count > 0) {
+					entries.push({
+						key: provider,
+						label: formatAgentName(provider),
+						agent: provider,
+						avgDuration: buckets.regular.duration / buckets.regular.count,
+						totalQueries: buckets.regular.count,
+						totalDuration: buckets.regular.duration,
+						isWorktree: false,
+					});
+				}
+				if (buckets.worktree.count > 0) {
+					entries.push({
+						key: `${provider}__worktree`,
+						label: `${formatAgentName(provider)} (Worktree)`,
+						agent: provider,
+						avgDuration: buckets.worktree.duration / buckets.worktree.count,
+						totalQueries: buckets.worktree.count,
+						totalDuration: buckets.worktree.duration,
+						isWorktree: true,
+					});
+				}
+			}
+		} else {
+			for (const [agent, stats] of Object.entries(data.byAgent)) {
+				if (stats.count <= 0) continue;
+				entries.push({
+					key: agent,
+					label: formatAgentName(agent),
+					agent,
+					avgDuration: stats.duration / stats.count,
+					totalQueries: stats.count,
+					totalDuration: stats.duration,
+					isWorktree: false,
+				});
+			}
+		}
+
+		return entries.sort((a, b) => a.avgDuration - b.avgDuration); // Fastest first
+	}, [data.byAgent, splitAggregation]);
+
+	const hasWorktreeBars = useMemo(() => efficiencyData.some((e) => e.isWorktree), [efficiencyData]);
 
 	// Get max duration for bar scaling
 	const maxDuration = useMemo(() => {
@@ -142,71 +233,113 @@ export const AgentEfficiencyChart = memo(function AgentEfficiencyChart({
 			</h3>
 
 			<div className="space-y-3">
-				{efficiencyData.map((agent, index) => {
-					const percentage = maxDuration > 0 ? (agent.avgDuration / maxDuration) * 100 : 0;
-					const color = getAgentColor(index, theme, colorBlindMode);
+				{(() => {
+					// Assign colors per unique provider so the regular and worktree
+					// variants of the same provider share a color.
+					const providerColorIdx: Record<string, number> = {};
+					for (const entry of efficiencyData) {
+						if (!(entry.agent in providerColorIdx)) {
+							providerColorIdx[entry.agent] = Object.keys(providerColorIdx).length;
+						}
+					}
+					return efficiencyData.map((agent) => {
+						const percentage = maxDuration > 0 ? (agent.avgDuration / maxDuration) * 100 : 0;
+						const color = getAgentColor(providerColorIdx[agent.agent], theme, colorBlindMode);
 
-					return (
-						<div key={agent.agent} className="flex items-center gap-3">
-							{/* Agent name */}
-							<div
-								className="w-28 text-sm truncate flex-shrink-0 flex items-center gap-2"
-								style={{ color: theme.colors.textDim }}
-								title={formatAgentName(agent.agent)}
-							>
+						return (
+							<div key={agent.key} className="flex items-center gap-3">
+								{/* Agent name */}
 								<div
-									className="w-2.5 h-2.5 rounded-sm flex-shrink-0"
-									style={{ backgroundColor: color }}
-								/>
-								{formatAgentName(agent.agent)}
-							</div>
-
-							{/* Bar */}
-							<div
-								className="flex-1 h-6 rounded overflow-hidden"
-								style={{ backgroundColor: `${theme.colors.border}30` }}
-							>
-								<div
-									className="h-full rounded flex items-center justify-end"
-									style={{
-										width: `${Math.max(percentage, 8)}%`,
-										backgroundColor: color,
-										opacity: 0.85,
-										transition: 'width 0.5s cubic-bezier(0.4, 0, 0.2, 1)',
-									}}
+									className="w-28 text-sm truncate flex-shrink-0 flex items-center gap-2"
+									style={{ color: theme.colors.textDim }}
+									title={agent.label}
 								>
-									{percentage > 25 && (
-										<span
-											className="text-xs font-medium px-2 text-white whitespace-nowrap"
-											style={{ textShadow: '0 1px 2px rgba(0,0,0,0.3)' }}
-										>
-											{formatDuration(agent.avgDuration)}
-										</span>
-									)}
+									<div
+										className="w-2.5 h-2.5 rounded-sm flex-shrink-0"
+										style={{
+											backgroundColor: color,
+											opacity: agent.isWorktree ? 0.55 : 1,
+											backgroundImage: agent.isWorktree
+												? 'repeating-linear-gradient(45deg, rgba(255,255,255,0.18) 0 2px, transparent 2px 4px)'
+												: undefined,
+										}}
+									/>
+									{agent.label}
+								</div>
+
+								{/* Bar */}
+								<div
+									className="flex-1 h-6 rounded overflow-hidden"
+									style={{ backgroundColor: `${theme.colors.border}30` }}
+								>
+									<div
+										className="h-full rounded flex items-center justify-end"
+										style={{
+											width: `${Math.max(percentage, 8)}%`,
+											backgroundColor: color,
+											opacity: agent.isWorktree ? 0.55 : 0.85,
+											backgroundImage: agent.isWorktree
+												? 'repeating-linear-gradient(45deg, rgba(255,255,255,0.18) 0 4px, transparent 4px 8px)'
+												: undefined,
+											transition: 'width 0.5s cubic-bezier(0.4, 0, 0.2, 1)',
+										}}
+									>
+										{percentage > 25 && (
+											<span
+												className="text-xs font-medium px-2 text-white whitespace-nowrap"
+												style={{ textShadow: '0 1px 2px rgba(0,0,0,0.3)' }}
+											>
+												{formatDuration(agent.avgDuration)}
+											</span>
+										)}
+									</div>
+								</div>
+
+								{/* Duration label */}
+								<div
+									className="w-20 text-xs text-right flex-shrink-0 flex flex-col"
+									style={{ color: theme.colors.textDim }}
+								>
+									<span className="font-medium" style={{ color: theme.colors.textMain }}>
+										{formatDuration(agent.avgDuration)}
+									</span>
+									<span className="text-[10px] opacity-70">{agent.totalQueries} queries</span>
 								</div>
 							</div>
-
-							{/* Duration label */}
-							<div
-								className="w-20 text-xs text-right flex-shrink-0 flex flex-col"
-								style={{ color: theme.colors.textDim }}
-							>
-								<span className="font-medium" style={{ color: theme.colors.textMain }}>
-									{formatDuration(agent.avgDuration)}
-								</span>
-								<span className="text-[10px] opacity-70">{agent.totalQueries} queries</span>
-							</div>
-						</div>
-					);
-				})}
+						);
+					});
+				})()}
 			</div>
 
 			{/* Legend */}
 			<div
-				className="mt-4 pt-3 border-t text-xs flex items-center gap-4"
+				className="mt-4 pt-3 border-t text-xs flex items-center gap-4 flex-wrap"
 				style={{ borderColor: theme.colors.border, color: theme.colors.textDim }}
 			>
 				<span>Sorted by efficiency (fastest first)</span>
+				{hasWorktreeBars && (
+					<>
+						<div className="flex items-center gap-1.5">
+							<div
+								className="w-2.5 h-2.5 rounded-sm"
+								style={{ backgroundColor: theme.colors.textDim, opacity: 0.85 }}
+							/>
+							<span>Agent</span>
+						</div>
+						<div className="flex items-center gap-1.5">
+							<div
+								className="w-2.5 h-2.5 rounded-sm"
+								style={{
+									backgroundColor: theme.colors.textDim,
+									opacity: 0.55,
+									backgroundImage:
+										'repeating-linear-gradient(45deg, rgba(255,255,255,0.18) 0 2px, transparent 2px 4px)',
+								}}
+							/>
+							<span>Worktree Agent</span>
+						</div>
+					</>
+				)}
 			</div>
 		</div>
 	);

--- a/src/renderer/components/UsageDashboard/AgentOverviewCards.tsx
+++ b/src/renderer/components/UsageDashboard/AgentOverviewCards.tsx
@@ -51,12 +51,41 @@ function buildSessionSparkline(sessionByDay: ByDayEntry[] | undefined): number[]
 	return [...new Array(SPARKLINE_DAYS - counts.length).fill(0), ...counts];
 }
 
+/**
+ * Resolve whether a session card should be highlighted by the current
+ * drill-down filter. The filter key originates from a few different surfaces:
+ *
+ *   - `AgentComparisonChart` emits provider keys like `claude-code` (parent)
+ *     or `claude-code__worktree` (worktree variant).
+ *   - `AgentUsageChart` emits per-session keys (e.g. `${provider}:${id}` or
+ *     bare session ids).
+ *
+ * We highlight cards by matching against either the session id directly, or
+ * — for provider-shaped keys — the session's `toolType`, separating worktree
+ * and non-worktree variants so a "Worktrees" filter doesn't paint the parent
+ * card and vice versa.
+ */
+function isSessionHighlighted(session: Session, activeFilterKey: string | null): boolean {
+	if (!activeFilterKey) return false;
+	if (activeFilterKey === session.id) return true;
+
+	const WORKTREE_SUFFIX = '__worktree';
+	if (activeFilterKey.endsWith(WORKTREE_SUFFIX)) {
+		const provider = activeFilterKey.slice(0, -WORKTREE_SUFFIX.length);
+		return Boolean(session.parentSessionId) && session.toolType === provider;
+	}
+
+	return !session.parentSessionId && session.toolType === activeFilterKey;
+}
+
 interface AgentCardProps {
 	session: Session;
 	data: StatsAggregation;
 	theme: Theme;
 	/** 0-based index for the staggered card-enter animation */
 	animationIndex: number;
+	/** When true, render the card with a thicker accent border to flag the active filter */
+	isSelected: boolean;
 }
 
 const AgentCard = memo(function AgentCard({
@@ -64,6 +93,7 @@ const AgentCard = memo(function AgentCard({
 	data,
 	theme,
 	animationIndex,
+	isSelected,
 }: AgentCardProps) {
 	const isWorktree = Boolean(session.parentSessionId);
 	const isBusy = session.state === 'busy';
@@ -86,17 +116,27 @@ const AgentCard = memo(function AgentCard({
 
 	const sparklineColor = isWorktree ? theme.colors.accent : statusColor;
 
+	// When the dashboard filter selects this card's agent, the 1px default
+	// border is replaced with a 2px solid accent border. Worktree dashing is
+	// suppressed for the duration — the highlight outranks the worktree
+	// affordance, and the existing "WT" badge keeps the worktree distinction
+	// visible.
+	const border = isSelected
+		? `2px solid ${theme.colors.accent}`
+		: isWorktree
+			? `1px dashed ${theme.colors.accent}99`
+			: `1px solid ${theme.colors.border}`;
+
 	return (
 		<div
 			className="card-enter relative p-3 rounded-lg flex flex-col gap-1.5"
 			style={{
 				backgroundColor: theme.colors.bgActivity,
-				border: isWorktree
-					? `1px dashed ${theme.colors.accent}99`
-					: `1px solid ${theme.colors.border}`,
+				border,
 				animationDelay: `${animationIndex * 60}ms`,
 			}}
 			data-testid="agent-card"
+			data-selected={isSelected ? 'true' : undefined}
 			role="group"
 			aria-label={`${session.name}, ${session.state}, ${queryCount} ${
 				queryCount === 1 ? 'query' : 'queries'
@@ -173,12 +213,19 @@ interface AgentOverviewCardsProps {
 	data: StatsAggregation;
 	/** Current theme for color-aware styling */
 	theme: Theme;
+	/**
+	 * Active dashboard drill-down filter key. When set, the matching session
+	 * card(s) render with a 2px accent border so the selection is visible at
+	 * the top of the dashboard. `null` means no filter is active.
+	 */
+	activeFilterKey?: string | null;
 }
 
 export const AgentOverviewCards = memo(function AgentOverviewCards({
 	sessions,
 	data,
 	theme,
+	activeFilterKey = null,
 }: AgentOverviewCardsProps) {
 	// Terminal sessions aren't "agents" — exclude them so the card row
 	// matches the agent count shown elsewhere in the dashboard.
@@ -206,6 +253,7 @@ export const AgentOverviewCards = memo(function AgentOverviewCards({
 					data={data}
 					theme={theme}
 					animationIndex={index}
+					isSelected={isSessionHighlighted(session, activeFilterKey)}
 				/>
 			))}
 		</div>

--- a/src/renderer/components/UsageDashboard/AgentOverviewCards.tsx
+++ b/src/renderer/components/UsageDashboard/AgentOverviewCards.tsx
@@ -1,0 +1,215 @@
+/**
+ * AgentOverviewCards
+ *
+ * Top-of-dashboard grid showing one compact card per active agent
+ * (excluding internal terminal sessions). Each card surfaces the agent
+ * name, live status dot, query count, and a 7-day activity sparkline.
+ *
+ * Worktree children render with a dashed accent border, a "WT" badge,
+ * and their checked-out branch — so a parent and its worktrees are
+ * visually distinguishable at a glance.
+ */
+
+import { memo, useMemo } from 'react';
+import type { Session, SessionState, Theme } from '../../types';
+import type { StatsAggregation } from '../../hooks/stats/useStats';
+import { Sparkline } from './Sparkline';
+
+const SPARKLINE_DAYS = 7;
+
+type ByDayEntry = StatsAggregation['byDay'][number];
+
+/**
+ * Map a session state to its theme status color. Falls back to
+ * `textDim` for transient states (waiting_input, connecting, etc.)
+ * so they don't false-positive as healthy / errored.
+ */
+function getStatusColor(state: SessionState, theme: Theme): string {
+	switch (state) {
+		case 'idle':
+			return theme.colors.success;
+		case 'busy':
+			return theme.colors.warning;
+		case 'error':
+			return theme.colors.error;
+		default:
+			return theme.colors.textDim;
+	}
+}
+
+/**
+ * Pull the last `SPARKLINE_DAYS` entries' counts (oldest → newest),
+ * left-padding with zeros so the sparkline geometry stays stable for
+ * sessions with fewer than seven recorded days.
+ */
+function buildSessionSparkline(sessionByDay: ByDayEntry[] | undefined): number[] {
+	if (!sessionByDay || sessionByDay.length === 0) {
+		return new Array(SPARKLINE_DAYS).fill(0);
+	}
+	const counts = sessionByDay.slice(-SPARKLINE_DAYS).map((d) => d.count);
+	if (counts.length >= SPARKLINE_DAYS) return counts;
+	return [...new Array(SPARKLINE_DAYS - counts.length).fill(0), ...counts];
+}
+
+interface AgentCardProps {
+	session: Session;
+	data: StatsAggregation;
+	theme: Theme;
+	/** 0-based index for the staggered card-enter animation */
+	animationIndex: number;
+}
+
+const AgentCard = memo(function AgentCard({
+	session,
+	data,
+	theme,
+	animationIndex,
+}: AgentCardProps) {
+	const isWorktree = Boolean(session.parentSessionId);
+	const isBusy = session.state === 'busy';
+	const statusColor = getStatusColor(session.state, theme);
+
+	const { queryCount, sparklineData } = useMemo(() => {
+		const sessionByDay = data.bySessionByDay?.[session.id];
+		if (sessionByDay && sessionByDay.length > 0) {
+			const total = sessionByDay.reduce((sum, d) => sum + d.count, 0);
+			return { queryCount: total, sparklineData: buildSessionSparkline(sessionByDay) };
+		}
+		// Per-session breakdown isn't available — fall back to the
+		// provider-level total so we still surface a count.
+		const agentData = data.byAgent?.[session.toolType];
+		return {
+			queryCount: agentData?.count ?? 0,
+			sparklineData: buildSessionSparkline(undefined),
+		};
+	}, [data.bySessionByDay, data.byAgent, session.id, session.toolType]);
+
+	const sparklineColor = isWorktree ? theme.colors.accent : statusColor;
+
+	return (
+		<div
+			className="card-enter relative p-3 rounded-lg flex flex-col gap-1.5"
+			style={{
+				backgroundColor: theme.colors.bgActivity,
+				border: isWorktree
+					? `1px dashed ${theme.colors.accent}99`
+					: `1px solid ${theme.colors.border}`,
+				animationDelay: `${animationIndex * 60}ms`,
+			}}
+			data-testid="agent-card"
+			role="group"
+			aria-label={`${session.name}, ${session.state}, ${queryCount} ${
+				queryCount === 1 ? 'query' : 'queries'
+			}`}
+		>
+			<div className="flex items-center gap-2 min-w-0">
+				<span
+					className="flex-shrink-0 w-2 h-2 rounded-full"
+					style={{
+						backgroundColor: statusColor,
+						animation: isBusy ? 'status-pulse 1.4s ease-in-out infinite' : undefined,
+					}}
+					aria-hidden="true"
+					data-testid="agent-card-status-dot"
+				/>
+				<span
+					className="text-sm font-medium truncate flex-1 min-w-0"
+					style={{ color: theme.colors.textMain }}
+					title={session.name}
+				>
+					{session.name}
+				</span>
+				{isWorktree && (
+					<span
+						className="flex-shrink-0 px-1 py-0.5 rounded text-[9px] font-bold uppercase tracking-wide"
+						style={{
+							backgroundColor: `${theme.colors.accent}20`,
+							color: theme.colors.accent,
+						}}
+						data-testid="agent-card-wt-badge"
+					>
+						WT
+					</span>
+				)}
+			</div>
+			{isWorktree && session.worktreeBranch && (
+				<div
+					className="text-[11px] truncate"
+					style={{ color: theme.colors.textDim }}
+					title={session.worktreeBranch}
+					data-testid="agent-card-branch"
+				>
+					{session.worktreeBranch}
+				</div>
+			)}
+			<div className="flex items-end justify-between gap-2 mt-auto">
+				<div className="flex flex-col min-w-0">
+					<span
+						className="text-[9px] uppercase tracking-wide"
+						style={{ color: theme.colors.textDim }}
+					>
+						Queries
+					</span>
+					<span
+						className="text-base font-semibold"
+						style={{ color: theme.colors.textMain }}
+						data-testid="agent-card-query-count"
+					>
+						{queryCount}
+					</span>
+				</div>
+				<div className="flex-shrink-0 opacity-80 pointer-events-none">
+					<Sparkline data={sparklineData} color={sparklineColor} width={70} height={22} />
+				</div>
+			</div>
+		</div>
+	);
+});
+
+interface AgentOverviewCardsProps {
+	/** All known sessions (terminal-only sessions are filtered out) */
+	sessions: Session[];
+	/** Aggregated stats — used for per-session query counts and sparklines */
+	data: StatsAggregation;
+	/** Current theme for color-aware styling */
+	theme: Theme;
+}
+
+export const AgentOverviewCards = memo(function AgentOverviewCards({
+	sessions,
+	data,
+	theme,
+}: AgentOverviewCardsProps) {
+	// Terminal sessions aren't "agents" — exclude them so the card row
+	// matches the agent count shown elsewhere in the dashboard.
+	const activeSessions = useMemo(
+		() => sessions.filter((s) => s.toolType !== 'terminal'),
+		[sessions]
+	);
+
+	if (activeSessions.length === 0) return null;
+
+	return (
+		<div
+			className="grid gap-3"
+			style={{
+				gridTemplateColumns: 'repeat(auto-fill, minmax(220px, 1fr))',
+			}}
+			data-testid="agent-overview-cards"
+			role="region"
+			aria-label="Active agents overview"
+		>
+			{activeSessions.map((session, index) => (
+				<AgentCard
+					key={session.id}
+					session={session}
+					data={data}
+					theme={theme}
+					animationIndex={index}
+				/>
+			))}
+		</div>
+	);
+});
+
+export default AgentOverviewCards;

--- a/src/renderer/components/UsageDashboard/AgentUsageChart.tsx
+++ b/src/renderer/components/UsageDashboard/AgentUsageChart.tsx
@@ -61,9 +61,13 @@ interface AgentUsageChartProps {
 	colorBlindMode?: boolean;
 	/** Current sessions for mapping IDs to names */
 	sessions?: Session[];
-	/** Drill-down click handler — wired by the dashboard, consumed in a follow-up task. */
+	/** Drill-down click handler — fires with the legend item's session key + display name. */
 	onAgentClick?: (key: string, displayName: string) => void;
-	/** Active drill-down filter key — consumed in a follow-up task to dim non-selected lines. */
+	/**
+	 * Active drill-down filter key. When set, the matching line is rendered with
+	 * a thicker stroke and the legend item is highlighted; non-matching lines
+	 * dim to 15% stroke opacity. `null`/undefined means no filter is active.
+	 */
 	activeFilterKey?: string | null;
 }
 
@@ -146,6 +150,8 @@ export const AgentUsageChart = memo(function AgentUsageChart({
 	theme,
 	colorBlindMode = false,
 	sessions,
+	onAgentClick,
+	activeFilterKey = null,
 }: AgentUsageChartProps) {
 	const [hoveredDay, setHoveredDay] = useState<{ dayIndex: number; agent?: string } | null>(null);
 	const [tooltipPos, setTooltipPos] = useState<{ x: number; y: number } | null>(null);
@@ -316,6 +322,17 @@ export const AgentUsageChart = memo(function AgentUsageChart({
 		setTooltipPos(null);
 	}, []);
 
+	// Forward legend clicks to the dashboard's drill-down handler. Toggle
+	// behavior (clicking the active legend item clears the filter) is owned by
+	// the dashboard; this component just reports which agent was clicked.
+	const handleAgentClick = useCallback(
+		(agentKey: string, displayName: string) => {
+			if (!onAgentClick) return;
+			onAgentClick(agentKey, displayName);
+		},
+		[onAgentClick]
+	);
+
 	return (
 		<div
 			className="p-4 rounded-lg"
@@ -325,7 +342,10 @@ export const AgentUsageChart = memo(function AgentUsageChart({
 		>
 			{/* Header with title and metric toggle */}
 			<div className="flex items-center justify-between mb-4">
-				<h3 className="text-sm font-medium" style={{ color: theme.colors.textMain }}>
+				<h3
+					className="text-sm font-medium"
+					style={{ color: theme.colors.textMain, animation: 'card-enter 0.4s ease both' }}
+				>
 					Agent Usage Over Time
 				</h3>
 				<div className="flex items-center gap-2">
@@ -433,17 +453,24 @@ export const AgentUsageChart = memo(function AgentUsageChart({
 						{agents.map((agent, agentIdx) => {
 							const color = getAgentColor(agentIdx, colorBlindMode);
 							const isWorktree = worktreeAgents.has(agent);
+							const isFiltered = activeFilterKey != null;
+							const isSelected = isFiltered && activeFilterKey === agent;
+							const isDimmed = isFiltered && !isSelected;
 							return (
 								<path
 									key={`line-${agent}`}
 									d={linePaths[agent]}
 									fill="none"
 									stroke={color}
-									strokeWidth={2}
+									strokeWidth={isSelected ? 2.5 : 2}
+									strokeOpacity={isDimmed ? 0.15 : 1}
 									strokeLinecap="round"
 									strokeLinejoin="round"
 									strokeDasharray={isWorktree ? '5 3' : undefined}
-									style={{ transition: 'd 0.5s cubic-bezier(0.4, 0, 0.2, 1)' }}
+									style={{
+										transition:
+											'd 0.5s cubic-bezier(0.4, 0, 0.2, 1), stroke-opacity 0.2s ease, stroke-width 0.2s ease',
+									}}
 								/>
 							);
 						})}
@@ -451,6 +478,9 @@ export const AgentUsageChart = memo(function AgentUsageChart({
 						{/* Data points for each agent */}
 						{agents.map((agent, agentIdx) => {
 							const color = getAgentColor(agentIdx, colorBlindMode);
+							const isFiltered = activeFilterKey != null;
+							const isSelected = isFiltered && activeFilterKey === agent;
+							const isDimmed = isFiltered && !isSelected;
 							return chartData[agent].map((day, dayIdx) => {
 								const x = xScale(dayIdx);
 								const y = yScale(metricMode === 'count' ? day.count : day.duration);
@@ -465,9 +495,10 @@ export const AgentUsageChart = memo(function AgentUsageChart({
 										fill={isHovered ? color : theme.colors.bgMain}
 										stroke={color}
 										strokeWidth={2}
+										opacity={isDimmed ? 0.15 : 1}
 										style={{
 											cursor: 'pointer',
-											transition: 'r 0.15s ease',
+											transition: 'r 0.15s ease, opacity 0.2s ease',
 										}}
 										onMouseEnter={(e) => handleMouseEnter(dayIdx, agent, e)}
 										onMouseLeave={handleMouseLeave}
@@ -527,7 +558,7 @@ export const AgentUsageChart = memo(function AgentUsageChart({
 				)}
 			</div>
 
-			{/* Legend */}
+			{/* Legend — clickable when `onAgentClick` is wired (drill-down filter). */}
 			<div
 				className="flex items-center justify-center gap-4 mt-3 pt-3 border-t flex-wrap"
 				style={{ borderColor: theme.colors.border }}
@@ -535,8 +566,39 @@ export const AgentUsageChart = memo(function AgentUsageChart({
 				{agents.map((agent, idx) => {
 					const color = getAgentColor(idx, colorBlindMode);
 					const isWorktree = worktreeAgents.has(agent);
+					const displayName = agentDisplayNames[agent];
+					const isClickable = !!onAgentClick;
+					const isFiltered = activeFilterKey != null;
+					const isSelected = isFiltered && activeFilterKey === agent;
+					const isDimmed = isFiltered && !isSelected;
 					return (
-						<div key={agent} className="flex items-center gap-1.5">
+						<div
+							key={agent}
+							className="flex items-center gap-1.5 rounded"
+							style={{
+								padding: isClickable ? '2px 6px' : undefined,
+								margin: isClickable ? '-2px -6px' : undefined,
+								cursor: isClickable ? 'pointer' : undefined,
+								backgroundColor: isSelected ? `${theme.colors.accent}26` : undefined,
+								opacity: isDimmed ? 0.5 : 1,
+								transition: 'background-color 0.2s ease, opacity 0.2s ease',
+							}}
+							onClick={isClickable ? () => handleAgentClick(agent, displayName) : undefined}
+							onKeyDown={
+								isClickable
+									? (e) => {
+											if (e.key === 'Enter' || e.key === ' ') {
+												e.preventDefault();
+												handleAgentClick(agent, displayName);
+											}
+										}
+									: undefined
+							}
+							role={isClickable ? 'button' : undefined}
+							tabIndex={isClickable ? 0 : undefined}
+							aria-pressed={isClickable ? isSelected : undefined}
+							aria-label={isClickable ? `${displayName}. Click to filter dashboard.` : undefined}
+						>
 							{isWorktree ? (
 								<svg width={12} height={2} aria-hidden="true">
 									<line
@@ -553,7 +615,7 @@ export const AgentUsageChart = memo(function AgentUsageChart({
 								<div className="w-3 h-0.5 rounded" style={{ backgroundColor: color }} />
 							)}
 							<span className="text-xs" style={{ color: theme.colors.textDim }}>
-								{agentDisplayNames[agent]}
+								{displayName}
 							</span>
 						</div>
 					);

--- a/src/renderer/components/UsageDashboard/AgentUsageChart.tsx
+++ b/src/renderer/components/UsageDashboard/AgentUsageChart.tsx
@@ -19,7 +19,7 @@ import { format, parseISO } from 'date-fns';
 import type { Theme, Session } from '../../types';
 import type { StatsTimeRange, StatsAggregation } from '../../hooks/stats/useStats';
 import { COLORBLIND_AGENT_PALETTE } from '../../constants/colorblindPalettes';
-import { findSessionByStatId, isWorktreeAgent } from './chartUtils';
+import { buildNameMap } from './chartUtils';
 
 // 10 distinct colors for agents
 const AGENT_COLORS = [
@@ -136,32 +136,6 @@ function getAgentColor(index: number, colorBlindMode: boolean): string {
 	return AGENT_COLORS[index % AGENT_COLORS.length];
 }
 
-/**
- * Extract a display name from a session ID
- * Session IDs are in format: "sessionId-ai-tabId" or similar
- * Returns the first 8 chars of the session UUID or the name if found.
- * Worktree agents are suffixed with " (WT)" so they're distinguishable in
- * legends and tooltips.
- */
-function getSessionDisplayName(sessionId: string, sessions?: Session[]): string {
-	const session = findSessionByStatId(sessionId, sessions);
-	const suffix = session && isWorktreeAgent(session) ? ' (WT)' : '';
-
-	if (session?.name) {
-		return `${session.name}${suffix}`;
-	}
-
-	// Fallback: extract the UUID part and show first 8 chars
-	// Format is typically "uuid-ai-tabId" or just "uuid"
-	const parts = sessionId.split('-');
-	if (parts.length >= 5) {
-		// UUID format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-		// Take first segment
-		return `${parts[0].substring(0, 8).toUpperCase()}${suffix}`;
-	}
-	return `${sessionId.substring(0, 8).toUpperCase()}${suffix}`;
-}
-
 export const AgentUsageChart = memo(function AgentUsageChart({
 	data,
 	timeRange,
@@ -196,13 +170,19 @@ export const AgentUsageChart = memo(function AgentUsageChart({
 		const topSessions = sessionTotals.slice(0, 10);
 		const agentList = topSessions.map((s) => s.sessionId);
 
-		// Build display name map and worktree flag set
+		// Resolve session IDs to user-facing display names via the shared
+		// `buildNameMap` utility — keeps name resolution consistent with the
+		// other dashboard charts. Worktree sessions still get a " (WT)" text
+		// suffix on top of the visual dashed-line indicator so they're
+		// distinguishable in tooltips where the line marker isn't visible.
+		const nameMap = buildNameMap(agentList, sessions);
 		const displayNames: Record<string, string> = {};
 		const worktreeSet = new Set<string>();
 		for (const sessionId of agentList) {
-			displayNames[sessionId] = getSessionDisplayName(sessionId, sessions);
-			const session = findSessionByStatId(sessionId, sessions);
-			if (session && isWorktreeAgent(session)) {
+			const resolved = nameMap.get(sessionId);
+			if (!resolved) continue;
+			displayNames[sessionId] = resolved.isWorktree ? `${resolved.name} (WT)` : resolved.name;
+			if (resolved.isWorktree) {
 				worktreeSet.add(sessionId);
 			}
 		}

--- a/src/renderer/components/UsageDashboard/AgentUsageChart.tsx
+++ b/src/renderer/components/UsageDashboard/AgentUsageChart.tsx
@@ -19,6 +19,7 @@ import { format, parseISO } from 'date-fns';
 import type { Theme, Session } from '../../types';
 import type { StatsTimeRange, StatsAggregation } from '../../hooks/stats/useStats';
 import { COLORBLIND_AGENT_PALETTE } from '../../constants/colorblindPalettes';
+import { findSessionByStatId, isWorktreeAgent } from './chartUtils';
 
 // 10 distinct colors for agents
 const AGENT_COLORS = [
@@ -138,17 +139,16 @@ function getAgentColor(index: number, colorBlindMode: boolean): string {
 /**
  * Extract a display name from a session ID
  * Session IDs are in format: "sessionId-ai-tabId" or similar
- * Returns the first 8 chars of the session UUID or the name if found
+ * Returns the first 8 chars of the session UUID or the name if found.
+ * Worktree agents are suffixed with " (WT)" so they're distinguishable in
+ * legends and tooltips.
  */
 function getSessionDisplayName(sessionId: string, sessions?: Session[]): string {
-	// Try to find the session by ID to get its name
-	if (sessions) {
-		// Session IDs in stats may include tab suffixes like "-ai-tabId"
-		// Try to match the base session ID
-		const session = sessions.find((s) => sessionId.startsWith(s.id));
-		if (session?.name) {
-			return session.name;
-		}
+	const session = findSessionByStatId(sessionId, sessions);
+	const suffix = session && isWorktreeAgent(session) ? ' (WT)' : '';
+
+	if (session?.name) {
+		return `${session.name}${suffix}`;
 	}
 
 	// Fallback: extract the UUID part and show first 8 chars
@@ -157,9 +157,9 @@ function getSessionDisplayName(sessionId: string, sessions?: Session[]): string 
 	if (parts.length >= 5) {
 		// UUID format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 		// Take first segment
-		return parts[0].substring(0, 8).toUpperCase();
+		return `${parts[0].substring(0, 8).toUpperCase()}${suffix}`;
 	}
-	return sessionId.substring(0, 8).toUpperCase();
+	return `${sessionId.substring(0, 8).toUpperCase()}${suffix}`;
 }
 
 export const AgentUsageChart = memo(function AgentUsageChart({
@@ -181,7 +181,7 @@ export const AgentUsageChart = memo(function AgentUsageChart({
 	const innerHeight = chartHeight - padding.top - padding.bottom;
 
 	// Get list of agents and their data (limited to top 10 by total queries)
-	const { agents, chartData, allDates, agentDisplayNames } = useMemo(() => {
+	const { agents, chartData, allDates, agentDisplayNames, worktreeAgents } = useMemo(() => {
 		const bySessionByDay = data.bySessionByDay || {};
 
 		// Calculate total queries per session to rank them
@@ -196,10 +196,15 @@ export const AgentUsageChart = memo(function AgentUsageChart({
 		const topSessions = sessionTotals.slice(0, 10);
 		const agentList = topSessions.map((s) => s.sessionId);
 
-		// Build display name map
+		// Build display name map and worktree flag set
 		const displayNames: Record<string, string> = {};
+		const worktreeSet = new Set<string>();
 		for (const sessionId of agentList) {
 			displayNames[sessionId] = getSessionDisplayName(sessionId, sessions);
+			const session = findSessionByStatId(sessionId, sessions);
+			if (session && isWorktreeAgent(session)) {
+				worktreeSet.add(sessionId);
+			}
 		}
 
 		// Collect all unique dates from selected agents
@@ -248,6 +253,7 @@ export const AgentUsageChart = memo(function AgentUsageChart({
 			chartData: agentData,
 			allDates: combinedData,
 			agentDisplayNames: displayNames,
+			worktreeAgents: worktreeSet,
 		};
 	}, [data.bySessionByDay, sessions]);
 
@@ -442,6 +448,7 @@ export const AgentUsageChart = memo(function AgentUsageChart({
 						{/* Lines for each agent */}
 						{agents.map((agent, agentIdx) => {
 							const color = getAgentColor(agentIdx, colorBlindMode);
+							const isWorktree = worktreeAgents.has(agent);
 							return (
 								<path
 									key={`line-${agent}`}
@@ -451,6 +458,7 @@ export const AgentUsageChart = memo(function AgentUsageChart({
 									strokeWidth={2}
 									strokeLinecap="round"
 									strokeLinejoin="round"
+									strokeDasharray={isWorktree ? '5 3' : undefined}
 									style={{ transition: 'd 0.5s cubic-bezier(0.4, 0, 0.2, 1)' }}
 								/>
 							);
@@ -542,9 +550,24 @@ export const AgentUsageChart = memo(function AgentUsageChart({
 			>
 				{agents.map((agent, idx) => {
 					const color = getAgentColor(idx, colorBlindMode);
+					const isWorktree = worktreeAgents.has(agent);
 					return (
 						<div key={agent} className="flex items-center gap-1.5">
-							<div className="w-3 h-0.5 rounded" style={{ backgroundColor: color }} />
+							{isWorktree ? (
+								<svg width={12} height={2} aria-hidden="true">
+									<line
+										x1={0}
+										y1={1}
+										x2={12}
+										y2={1}
+										stroke={color}
+										strokeWidth={2}
+										strokeDasharray="3 2"
+									/>
+								</svg>
+							) : (
+								<div className="w-3 h-0.5 rounded" style={{ backgroundColor: color }} />
+							)}
 							<span className="text-xs" style={{ color: theme.colors.textDim }}>
 								{agentDisplayNames[agent]}
 							</span>

--- a/src/renderer/components/UsageDashboard/AgentUsageChart.tsx
+++ b/src/renderer/components/UsageDashboard/AgentUsageChart.tsx
@@ -61,6 +61,10 @@ interface AgentUsageChartProps {
 	colorBlindMode?: boolean;
 	/** Current sessions for mapping IDs to names */
 	sessions?: Session[];
+	/** Drill-down click handler — wired by the dashboard, consumed in a follow-up task. */
+	onAgentClick?: (key: string, displayName: string) => void;
+	/** Active drill-down filter key — consumed in a follow-up task to dim non-selected lines. */
+	activeFilterKey?: string | null;
 }
 
 /**

--- a/src/renderer/components/UsageDashboard/AutoRunStats.tsx
+++ b/src/renderer/components/UsageDashboard/AutoRunStats.tsx
@@ -399,7 +399,10 @@ export const AutoRunStats = memo(function AutoRunStats({
 				role="figure"
 				aria-label={`Tasks completed over time chart. ${tasksByDate.length} days of data.`}
 			>
-				<h3 className="text-sm font-medium mb-4" style={{ color: theme.colors.textMain }}>
+				<h3
+					className="text-sm font-medium mb-4"
+					style={{ color: theme.colors.textMain, animation: 'card-enter 0.4s ease both' }}
+				>
 					Tasks Completed Over Time
 				</h3>
 

--- a/src/renderer/components/UsageDashboard/DurationTrendsChart.tsx
+++ b/src/renderer/components/UsageDashboard/DurationTrendsChart.tsx
@@ -306,7 +306,10 @@ export const DurationTrendsChart = memo(function DurationTrendsChart({
 		>
 			{/* Header with title and smoothing toggle */}
 			<div className="flex items-center justify-between mb-4">
-				<h3 className="text-sm font-medium" style={{ color: theme.colors.textMain }}>
+				<h3
+					className="text-sm font-medium"
+					style={{ color: theme.colors.textMain, animation: 'card-enter 0.4s ease both' }}
+				>
 					Duration Trends
 				</h3>
 				<div className="flex items-center gap-2">

--- a/src/renderer/components/UsageDashboard/LocationDistributionChart.tsx
+++ b/src/renderer/components/UsageDashboard/LocationDistributionChart.tsx
@@ -215,7 +215,10 @@ export const LocationDistributionChart = memo(function LocationDistributionChart
 		>
 			{/* Header with title */}
 			<div className="flex items-center justify-between mb-4">
-				<h3 className="text-sm font-medium" style={{ color: theme.colors.textMain }}>
+				<h3
+					className="text-sm font-medium"
+					style={{ color: theme.colors.textMain, animation: 'card-enter 0.4s ease both' }}
+				>
 					Session Location
 				</h3>
 			</div>

--- a/src/renderer/components/UsageDashboard/LongestAutoRunsTable.tsx
+++ b/src/renderer/components/UsageDashboard/LongestAutoRunsTable.tsx
@@ -184,7 +184,10 @@ export const LongestAutoRunsTable = memo(function LongestAutoRunsTable({
 		>
 			<div className="flex items-center gap-2 mb-4">
 				<Trophy className="w-4 h-4" style={{ color: theme.colors.accent }} />
-				<h3 className="text-sm font-medium" style={{ color: theme.colors.textMain }}>
+				<h3
+					className="text-sm font-medium"
+					style={{ color: theme.colors.textMain, animation: 'card-enter 0.4s ease both' }}
+				>
 					Top {Math.min(topSessions.length, MAX_ROWS)} Longest Auto Runs
 				</h3>
 				<span className="text-xs" style={{ color: theme.colors.textDim }}>

--- a/src/renderer/components/UsageDashboard/PeakHoursChart.tsx
+++ b/src/renderer/components/UsageDashboard/PeakHoursChart.tsx
@@ -118,7 +118,10 @@ export const PeakHoursChart = memo(function PeakHoursChart({
 		>
 			{/* Header */}
 			<div className="flex items-center justify-between mb-3">
-				<h3 className="text-sm font-medium" style={{ color: theme.colors.textMain }}>
+				<h3
+					className="text-sm font-medium"
+					style={{ color: theme.colors.textMain, animation: 'card-enter 0.4s ease both' }}
+				>
 					Peak Hours
 				</h3>
 				<div className="flex items-center gap-2">

--- a/src/renderer/components/UsageDashboard/SessionStats.tsx
+++ b/src/renderer/components/UsageDashboard/SessionStats.tsx
@@ -183,7 +183,10 @@ export const SessionStats = memo(function SessionStats({
 	if (agentSessions.length === 0) {
 		return (
 			<div className="p-4 rounded-lg" style={{ backgroundColor: theme.colors.bgMain }}>
-				<h3 className="text-sm font-medium mb-4" style={{ color: theme.colors.textMain }}>
+				<h3
+					className="text-sm font-medium mb-4"
+					style={{ color: theme.colors.textMain, animation: 'card-enter 0.4s ease both' }}
+				>
 					Agent Statistics
 				</h3>
 				<div
@@ -198,7 +201,10 @@ export const SessionStats = memo(function SessionStats({
 
 	return (
 		<div className="p-4 rounded-lg" style={{ backgroundColor: theme.colors.bgMain }}>
-			<h3 className="text-sm font-medium mb-4" style={{ color: theme.colors.textMain }}>
+			<h3
+				className="text-sm font-medium mb-4"
+				style={{ color: theme.colors.textMain, animation: 'card-enter 0.4s ease both' }}
+			>
 				Agent Statistics
 			</h3>
 

--- a/src/renderer/components/UsageDashboard/SessionStats.tsx
+++ b/src/renderer/components/UsageDashboard/SessionStats.tsx
@@ -15,6 +15,7 @@ import React, { memo, useMemo } from 'react';
 import { Monitor, GitBranch, Folder, Laptop } from 'lucide-react';
 import type { Theme, Session, ToolType } from '../../types';
 import { COLORBLIND_AGENT_PALETTE } from '../../constants/colorblindPalettes';
+import { isWorktreeAgent } from './chartUtils';
 
 interface SessionStatsProps {
 	/** Array of all sessions */
@@ -119,6 +120,8 @@ export const SessionStats = memo(function SessionStats({
 		let localSessions = 0;
 		let bookmarked = 0;
 		let withWorktrees = 0;
+		let worktreeChildren = 0;
+		let regularSessions = 0;
 
 		for (const session of agentSessions) {
 			// Count by agent type
@@ -152,6 +155,15 @@ export const SessionStats = memo(function SessionStats({
 			if (session.worktreeConfig || session.parentSessionId) {
 				withWorktrees++;
 			}
+
+			// Worktree children (sessions spawned from a parent) vs regular agents.
+			// A "regular" session here is anything that is NOT a worktree child —
+			// parent agents are counted as regular alongside standalone agents.
+			if (isWorktreeAgent(session)) {
+				worktreeChildren++;
+			} else {
+				regularSessions++;
+			}
 		}
 
 		return {
@@ -163,6 +175,8 @@ export const SessionStats = memo(function SessionStats({
 			localSessions,
 			bookmarked,
 			withWorktrees,
+			worktreeChildren,
+			regularSessions,
 		};
 	}, [agentSessions]);
 
@@ -230,6 +244,22 @@ export const SessionStats = memo(function SessionStats({
 					theme={theme}
 					subValue={stats.remoteSessions > 0 ? `${stats.remoteSessions} remote` : undefined}
 				/>
+			</div>
+
+			{/* Worktree vs Regular Breakdown */}
+			<div
+				className="flex items-center gap-2 mb-4 text-xs"
+				style={{ color: theme.colors.textDim }}
+				data-testid="worktree-breakdown"
+				aria-label={`Regular: ${stats.regularSessions} | Worktree: ${stats.worktreeChildren}`}
+			>
+				<span>
+					Regular: <span style={{ color: theme.colors.textMain }}>{stats.regularSessions}</span>
+				</span>
+				<span style={{ opacity: 0.5 }}>|</span>
+				<span>
+					Worktree: <span style={{ color: theme.colors.textMain }}>{stats.worktreeChildren}</span>
+				</span>
 			</div>
 
 			{/* Agent Type Breakdown */}

--- a/src/renderer/components/UsageDashboard/SessionStats.tsx
+++ b/src/renderer/components/UsageDashboard/SessionStats.tsx
@@ -15,7 +15,7 @@ import React, { memo, useMemo } from 'react';
 import { Monitor, GitBranch, Folder, Laptop } from 'lucide-react';
 import type { Theme, Session, ToolType } from '../../types';
 import { COLORBLIND_AGENT_PALETTE } from '../../constants/colorblindPalettes';
-import { isWorktreeAgent } from './chartUtils';
+import { isWorktreeAgent, resolveAgentDisplayName } from './chartUtils';
 
 interface SessionStatsProps {
 	/** Array of all sessions */
@@ -81,23 +81,6 @@ function getAgentColor(index: number, theme: Theme, colorBlindMode?: boolean): s
 		'#6366f1',
 	];
 	return additionalColors[(index - 1) % additionalColors.length];
-}
-
-/**
- * Format agent type display name
- */
-function formatAgentName(toolType: ToolType): string {
-	const names: Record<string, string> = {
-		'claude-code': 'Claude Code',
-		opencode: 'OpenCode',
-		'openai-codex': 'OpenAI Codex',
-		codex: 'Codex',
-		'gemini-cli': 'Gemini CLI',
-		'qwen3-coder': 'Qwen3 Coder',
-		'factory-droid': 'Factory Droid',
-		terminal: 'Terminal',
-	};
-	return names[toolType] || toolType;
 }
 
 export const SessionStats = memo(function SessionStats({
@@ -180,7 +163,10 @@ export const SessionStats = memo(function SessionStats({
 		};
 	}, [agentSessions]);
 
-	// Sort agents by count (descending)
+	// Sort agents by count (descending) and resolve display names from sessions
+	// so the breakdown surfaces user-assigned names (e.g. "Backend API") when a
+	// provider has a single registered session, falling back to the prettified
+	// agent type when multiple sessions share the type.
 	const sortedAgents = useMemo(
 		() =>
 			Object.entries(stats.byAgent)
@@ -189,8 +175,9 @@ export const SessionStats = memo(function SessionStats({
 					agent: agent as ToolType,
 					count,
 					color: getAgentColor(index, theme, colorBlindMode),
+					displayName: resolveAgentDisplayName(agent, agentSessions).name,
 				})),
-		[stats.byAgent, theme, colorBlindMode]
+		[stats.byAgent, theme, colorBlindMode, agentSessions]
 	);
 
 	if (agentSessions.length === 0) {
@@ -284,7 +271,7 @@ export const SessionStats = memo(function SessionStats({
 										className="w-2.5 h-2.5 rounded-sm flex-shrink-0"
 										style={{ backgroundColor: agent.color }}
 									/>
-									{formatAgentName(agent.agent)}
+									{agent.displayName}
 								</div>
 
 								{/* Bar */}

--- a/src/renderer/components/UsageDashboard/SourceDistributionChart.tsx
+++ b/src/renderer/components/UsageDashboard/SourceDistributionChart.tsx
@@ -254,7 +254,10 @@ export const SourceDistributionChart = memo(function SourceDistributionChart({
 		>
 			{/* Header with title and metric toggle */}
 			<div className="flex items-center justify-between mb-4">
-				<h3 className="text-sm font-medium" style={{ color: theme.colors.textMain }}>
+				<h3
+					className="text-sm font-medium"
+					style={{ color: theme.colors.textMain, animation: 'card-enter 0.4s ease both' }}
+				>
 					Session Type
 				</h3>
 				<div className="flex items-center gap-2">

--- a/src/renderer/components/UsageDashboard/Sparkline.tsx
+++ b/src/renderer/components/UsageDashboard/Sparkline.tsx
@@ -1,0 +1,165 @@
+/**
+ * Sparkline
+ *
+ * Lightweight inline SVG trend chart used inside summary cards, agent
+ * overview cards, and worktree analytics. Renders a smooth (quadratic
+ * bezier) line plus a tinted area fill, with an optional glowing end
+ * dot at the most recent data point.
+ *
+ * Empty data (or all zeros) collapses to a dashed horizontal baseline
+ * so the layout stays stable when there's nothing to plot yet.
+ */
+
+import { memo, useMemo } from 'react';
+
+interface SparklineProps {
+	/** Sequential numeric values to plot (oldest → newest) */
+	data: number[];
+	/** SVG width in px (default 80) */
+	width?: number;
+	/** SVG height in px (default 24) */
+	height?: number;
+	/** Stroke + fill base color */
+	color: string;
+	/** Opacity for the area fill below the line (default 0.15) */
+	fillOpacity?: number;
+	/** Render a glowing dot at the last data point (default true) */
+	showEndDot?: boolean;
+	/** Line stroke width (default 1.5) */
+	strokeWidth?: number;
+}
+
+const PADDING = 2;
+
+interface Point {
+	x: number;
+	y: number;
+}
+
+/**
+ * Build a smooth path string through `points` using quadratic beziers.
+ * Each segment's control is the data point itself; each segment ends at
+ * the midpoint between consecutive points, with a final `T` smoothing
+ * into the last data point.
+ */
+function buildSmoothPath(points: Point[]): string {
+	if (points.length === 0) return '';
+	if (points.length === 1) {
+		const { x, y } = points[0];
+		return `M ${x} ${y}`;
+	}
+	if (points.length === 2) {
+		return `M ${points[0].x} ${points[0].y} L ${points[1].x} ${points[1].y}`;
+	}
+
+	let d = `M ${points[0].x} ${points[0].y}`;
+	for (let i = 1; i < points.length - 1; i++) {
+		const xc = (points[i].x + points[i + 1].x) / 2;
+		const yc = (points[i].y + points[i + 1].y) / 2;
+		d += ` Q ${points[i].x} ${points[i].y} ${xc} ${yc}`;
+	}
+	const last = points[points.length - 1];
+	d += ` T ${last.x} ${last.y}`;
+	return d;
+}
+
+export const Sparkline = memo(function Sparkline({
+	data,
+	width = 80,
+	height = 24,
+	color,
+	fillOpacity = 0.15,
+	showEndDot = true,
+	strokeWidth = 1.5,
+}: SparklineProps) {
+	const isEmpty = useMemo(() => data.length === 0 || data.every((v) => v === 0), [data]);
+
+	const { linePath, areaPath, endPoint } = useMemo(() => {
+		if (isEmpty || data.length === 0) {
+			return { linePath: '', areaPath: '', endPoint: null as Point | null };
+		}
+
+		const innerWidth = Math.max(0, width - PADDING * 2);
+		const innerHeight = Math.max(0, height - PADDING * 2);
+
+		const min = Math.min(...data);
+		const max = Math.max(...data);
+		const range = max - min;
+
+		const points: Point[] = data.map((value, i) => {
+			const x = data.length === 1 ? width / 2 : PADDING + (i / (data.length - 1)) * innerWidth;
+			// Flat data → center vertically; otherwise normalize so max sits at top.
+			const normalized = range === 0 ? 0.5 : (value - min) / range;
+			const y = PADDING + (1 - normalized) * innerHeight;
+			return { x, y };
+		});
+
+		const line = buildSmoothPath(points);
+		const baseY = height - PADDING;
+		const firstX = points[0].x;
+		const lastX = points[points.length - 1].x;
+		const area = `${line} L ${lastX} ${baseY} L ${firstX} ${baseY} Z`;
+
+		return {
+			linePath: line,
+			areaPath: area,
+			endPoint: points[points.length - 1],
+		};
+	}, [data, isEmpty, width, height]);
+
+	if (isEmpty) {
+		const midY = height / 2;
+		return (
+			<svg
+				width={width}
+				height={height}
+				viewBox={`0 0 ${width} ${height}`}
+				aria-hidden="true"
+				data-testid="sparkline-empty"
+			>
+				<line
+					x1={PADDING}
+					y1={midY}
+					x2={width - PADDING}
+					y2={midY}
+					stroke={color}
+					strokeWidth={strokeWidth}
+					strokeDasharray="4 3"
+					strokeLinecap="round"
+					opacity={0.5}
+				/>
+			</svg>
+		);
+	}
+
+	return (
+		<svg
+			width={width}
+			height={height}
+			viewBox={`0 0 ${width} ${height}`}
+			aria-hidden="true"
+			data-testid="sparkline"
+		>
+			<path d={areaPath} fill={color} fillOpacity={fillOpacity} stroke="none" />
+			<path
+				d={linePath}
+				fill="none"
+				stroke={color}
+				strokeWidth={strokeWidth}
+				strokeLinecap="round"
+				strokeLinejoin="round"
+			/>
+			{showEndDot && endPoint && (
+				<circle
+					cx={endPoint.x}
+					cy={endPoint.y}
+					r={2}
+					fill={color}
+					style={{ filter: `drop-shadow(0 0 2px ${color})` }}
+				/>
+			)}
+		</svg>
+	);
+});
+
+export default Sparkline;

--- a/src/renderer/components/UsageDashboard/SummaryCards.tsx
+++ b/src/renderer/components/UsageDashboard/SummaryCards.tsx
@@ -17,7 +17,7 @@
  * - Formatted values for readability
  */
 
-import React, { memo, useMemo, useState } from 'react';
+import React, { memo, useEffect, useMemo, useState } from 'react';
 import {
 	MessageSquare,
 	Clock,
@@ -135,6 +135,122 @@ export function getCardStyles(
 }
 
 /**
+ * Parses a metric value to determine if it can be animated as a count-up.
+ * Matches pure numeric values with an optional `K` / `M` / `%` suffix
+ * (the formats produced by `formatNumber` and percentage formatters).
+ *
+ * Returns `null` for strings like durations (`"12h 34m"`), peak hour
+ * (`"9 AM"`), agent names, or `"N/A"` — these display immediately.
+ */
+function parseAnimatedValue(
+	value: string
+): { target: number; suffix: string; decimals: number } | null {
+	const match = value.match(/^(\d+(?:\.\d+)?)([KM%])?$/);
+	if (!match) return null;
+	const numStr = match[1];
+	const suffix = match[2] ?? '';
+	const dotIdx = numStr.indexOf('.');
+	const decimals = dotIdx >= 0 ? numStr.length - dotIdx - 1 : 0;
+	return { target: parseFloat(numStr), suffix, decimals };
+}
+
+function formatProgress(current: number, decimals: number, suffix: string): string {
+	return `${current.toFixed(decimals)}${suffix}`;
+}
+
+interface AnimatedNumberProps {
+	/** Final value to display. Numeric strings count up; non-numeric display immediately. */
+	value: string;
+	/** Animation duration in ms (default: 600) */
+	duration?: number;
+}
+
+/**
+ * Animates a numeric `value` from 0 to its target using an ease-out cubic
+ * curve. String values that don't parse as pure numbers (durations, agent
+ * names, etc.) are rendered immediately without animation. Respects the
+ * user's `prefers-reduced-motion` setting.
+ */
+export const AnimatedNumber = memo(function AnimatedNumber({
+	value,
+	duration = 600,
+}: AnimatedNumberProps) {
+	const parsed = useMemo(() => parseAnimatedValue(value), [value]);
+	const [display, setDisplay] = useState(() =>
+		parsed ? formatProgress(0, parsed.decimals, parsed.suffix) : value
+	);
+
+	useEffect(() => {
+		if (!parsed) {
+			setDisplay(value);
+			return;
+		}
+
+		const prefersReducedMotion =
+			typeof window !== 'undefined' &&
+			window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
+		if (prefersReducedMotion) {
+			setDisplay(value);
+			return;
+		}
+
+		const { target, suffix, decimals } = parsed;
+		setDisplay(formatProgress(0, decimals, suffix));
+
+		let raf = 0;
+		let start = 0;
+
+		const tick = (now: number) => {
+			if (start === 0) start = now;
+			const progress = Math.min(1, (now - start) / duration);
+			const eased = 1 - Math.pow(1 - progress, 3);
+			setDisplay(formatProgress(target * eased, decimals, suffix));
+			if (progress < 1) {
+				raf = requestAnimationFrame(tick);
+			}
+		};
+
+		raf = requestAnimationFrame(tick);
+		return () => cancelAnimationFrame(raf);
+	}, [value, parsed, duration]);
+
+	return <>{display}</>;
+});
+
+interface BouncingDotsProps {
+	/** Color for the dots — defaults to `currentColor` so callers can tint via CSS */
+	color?: string;
+	/** Optional ARIA label; defaults to `"Loading"` for screen readers */
+	label?: string;
+}
+
+/**
+ * Three dots that bounce in sequence for loading / thinking states.
+ *
+ * Animation, sizing, and stagger delays live in `index.css` under the
+ * `.bounce-dots` selector and respect `prefers-reduced-motion`.
+ */
+export const BouncingDots = memo(function BouncingDots({
+	color,
+	label = 'Loading',
+}: BouncingDotsProps) {
+	const style: React.CSSProperties | undefined = color ? { color } : undefined;
+	return (
+		<span
+			className="bounce-dots"
+			style={style}
+			role="status"
+			aria-label={label}
+			data-testid="bouncing-dots"
+		>
+			<span aria-hidden="true" />
+			<span aria-hidden="true" />
+			<span aria-hidden="true" />
+		</span>
+	);
+});
+
+/**
  * Single metric card component
  */
 interface MetricCardProps {
@@ -203,7 +319,7 @@ const MetricCard = memo(function MetricCard({
 					}}
 					title={value}
 				>
-					{value}
+					<AnimatedNumber value={value} />
 				</div>
 				{extra}
 			</div>

--- a/src/renderer/components/UsageDashboard/SummaryCards.tsx
+++ b/src/renderer/components/UsageDashboard/SummaryCards.tsx
@@ -29,9 +29,13 @@ import {
 	Globe,
 	Zap,
 	PanelTop,
+	Cpu,
+	DollarSign,
+	Activity,
 } from 'lucide-react';
 import type { Theme, Session } from '../../types';
 import type { StatsAggregation } from '../../hooks/stats/useStats';
+import { formatCost } from '../../../shared/formatters';
 
 interface SummaryCardsProps {
 	/** Aggregated stats data from the API */
@@ -337,6 +341,283 @@ function formatHour(hour: number): string {
 	return `${displayHour} ${suffix}`;
 }
 
+interface ContextUsageBarProps {
+	/** Context usage as a percentage (0-100). Values above 100 are capped. */
+	percentage: number;
+	theme: Theme;
+}
+
+/**
+ * Threshold-colored progress bar for an agent's context window usage.
+ * Green <70%, yellow 70-89%, red ≥90% (with a subtle red glow).
+ */
+export const ContextUsageBar = memo(function ContextUsageBar({
+	percentage,
+	theme,
+}: ContextUsageBarProps) {
+	const capped = Math.max(0, Math.min(100, percentage));
+	const isCritical = capped >= 90;
+	const fillColor = isCritical
+		? theme.colors.error
+		: capped >= 70
+			? theme.colors.warning
+			: theme.colors.success;
+
+	return (
+		<div className="w-full" data-testid="context-usage-bar">
+			<div
+				className="flex items-center justify-between text-[10px] mb-1"
+				style={{ color: theme.colors.textDim }}
+			>
+				<span className="uppercase tracking-wide">Context</span>
+				<span style={{ color: fillColor, fontWeight: 600 }}>{Math.round(capped)}%</span>
+			</div>
+			<div
+				className="w-full h-1.5 rounded-full overflow-hidden"
+				style={{ backgroundColor: theme.colors.bgMain }}
+				role="progressbar"
+				aria-valuenow={Math.round(capped)}
+				aria-valuemin={0}
+				aria-valuemax={100}
+				aria-label="Context window usage"
+			>
+				<div
+					className="h-full rounded-full transition-all duration-500 ease-out"
+					style={{
+						width: `${capped}%`,
+						backgroundColor: fillColor,
+						boxShadow: isCritical ? `0 0 6px ${theme.colors.error}60` : undefined,
+					}}
+				/>
+			</div>
+		</div>
+	);
+});
+
+// Placeholder per-1K-token rates for current-cycle cost estimation.
+// `currentCycleTokens` does not split input vs output, so we apply a blended
+// rate that approximates Claude pricing ($3/M input, $15/M output).
+// TODO: replace with provider-specific rates and split when the parser exposes
+// input/output token counts for the in-flight cycle.
+const CURRENT_CYCLE_INPUT_RATE_PER_1K = 0.003;
+const CURRENT_CYCLE_OUTPUT_RATE_PER_1K = 0.015;
+const CURRENT_CYCLE_BLENDED_RATE_PER_1K =
+	(CURRENT_CYCLE_INPUT_RATE_PER_1K + CURRENT_CYCLE_OUTPUT_RATE_PER_1K) / 2;
+
+interface TokenCostBadgeProps {
+	sessions: Session[];
+	theme: Theme;
+}
+
+/**
+ * Aggregates `currentCycleTokens` across busy sessions and renders the total
+ * with a blended-rate cost estimate plus a per-session breakdown.
+ */
+export const TokenCostBadge = memo(function TokenCostBadge({
+	sessions,
+	theme,
+}: TokenCostBadgeProps) {
+	const { totalTokens, estimatedCost, breakdown } = useMemo(() => {
+		const busy = sessions.filter((s) => s.state === 'busy');
+		let total = 0;
+		const items: Array<{ id: string; name: string; tokens: number }> = [];
+		for (const s of busy) {
+			const tokens = s.currentCycleTokens ?? 0;
+			if (tokens > 0) {
+				total += tokens;
+				items.push({ id: s.id, name: s.name, tokens });
+			}
+		}
+		items.sort((a, b) => b.tokens - a.tokens);
+		const cost = (total / 1000) * CURRENT_CYCLE_BLENDED_RATE_PER_1K;
+		return { totalTokens: total, estimatedCost: cost, breakdown: items };
+	}, [sessions]);
+
+	return (
+		<div className="flex flex-col" data-testid="token-cost-badge">
+			<div className="text-[10px] uppercase tracking-wide" style={{ color: theme.colors.textDim }}>
+				Cycle Tokens
+			</div>
+			<div className="flex items-baseline gap-2 mt-0.5">
+				<span
+					className="font-bold"
+					style={{ color: theme.colors.textMain, fontSize: '20px' }}
+					title={`${totalTokens.toLocaleString()} tokens`}
+				>
+					{formatNumber(totalTokens)}
+				</span>
+				<span
+					className="text-xs font-medium"
+					style={{ color: theme.colors.warning }}
+					title="Estimated cost for the current thinking cycle"
+					data-testid="token-cost-estimate"
+				>
+					{formatCost(estimatedCost)}
+				</span>
+			</div>
+			{breakdown.length > 0 && (
+				<div
+					className="mt-1 flex flex-wrap gap-x-2 gap-y-0.5 text-[9px]"
+					style={{ color: theme.colors.textDim }}
+					data-testid="token-cost-breakdown"
+				>
+					{breakdown.slice(0, 4).map((item) => (
+						<span key={item.id} title={`${item.tokens.toLocaleString()} tokens`}>
+							{item.name}: {formatNumber(item.tokens)}
+						</span>
+					))}
+					{breakdown.length > 4 && <span>+{breakdown.length - 4} more</span>}
+				</div>
+			)}
+		</div>
+	);
+});
+
+interface RealtimeMetricsCardProps {
+	sessions: Session[];
+	theme: Theme;
+	/** Stagger delay (in ms) for the card-enter animation */
+	animationDelay?: number;
+}
+
+/**
+ * Compact, information-dense card combining live context-usage,
+ * current-cycle token/cost, and elapsed thinking time across active agents.
+ */
+export const RealtimeMetricsCard = memo(function RealtimeMetricsCard({
+	sessions,
+	theme,
+	animationDelay = 0,
+}: RealtimeMetricsCardProps) {
+	const activeSessions = useMemo(
+		() => sessions.filter((s) => s.state === 'busy' || s.state === 'idle'),
+		[sessions]
+	);
+
+	const peakContextUsage = useMemo(() => {
+		let peak = 0;
+		for (const s of activeSessions) {
+			if (typeof s.contextUsage === 'number' && s.contextUsage > peak) {
+				peak = s.contextUsage;
+			}
+		}
+		return peak;
+	}, [activeSessions]);
+
+	const earliestThinkingStart = useMemo(() => {
+		let earliest: number | null = null;
+		for (const s of sessions) {
+			if (s.state === 'busy' && typeof s.thinkingStartTime === 'number') {
+				if (earliest === null || s.thinkingStartTime < earliest) {
+					earliest = s.thinkingStartTime;
+				}
+			}
+		}
+		return earliest;
+	}, [sessions]);
+
+	// Tick once a second while any session is thinking so elapsed time updates
+	// smoothly; the dashboard's stats subscription is too coarse for this.
+	const [elapsedMs, setElapsedMs] = useState(() =>
+		earliestThinkingStart !== null ? Date.now() - earliestThinkingStart : 0
+	);
+	useEffect(() => {
+		if (earliestThinkingStart === null) {
+			setElapsedMs(0);
+			return;
+		}
+		setElapsedMs(Date.now() - earliestThinkingStart);
+		const interval = window.setInterval(() => {
+			setElapsedMs(Date.now() - earliestThinkingStart);
+		}, 1000);
+		return () => window.clearInterval(interval);
+	}, [earliestThinkingStart]);
+
+	const elapsedSeconds = Math.max(0, Math.floor(elapsedMs / 1000));
+	const isThinking = earliestThinkingStart !== null;
+	const activeCount = activeSessions.length;
+
+	return (
+		<div
+			className="p-4 card-enter"
+			style={{
+				...getCardStyles('elevated', theme),
+				animationDelay: `${animationDelay}ms`,
+			}}
+			data-testid="realtime-metrics-card"
+			role="group"
+			aria-label="Real-time agent metrics"
+		>
+			<div className="flex items-start gap-3">
+				<div
+					className="flex-shrink-0 p-2 rounded-md"
+					style={{
+						backgroundColor: `${theme.colors.accent}15`,
+						color: theme.colors.accent,
+					}}
+				>
+					<Activity className="w-4 h-4" />
+				</div>
+				<div className="min-w-0 flex-1">
+					<div
+						className="text-xs uppercase tracking-wide mb-2"
+						style={{ color: theme.colors.textDim }}
+					>
+						Real-time
+					</div>
+					<div className="flex items-center gap-1.5 mb-2">
+						<Cpu
+							className="w-3 h-3 flex-shrink-0"
+							style={{ color: theme.colors.textDim }}
+							aria-hidden="true"
+						/>
+						<div className="flex-1">
+							<ContextUsageBar percentage={peakContextUsage} theme={theme} />
+						</div>
+					</div>
+					<div className="flex items-center gap-1.5 mt-3">
+						<DollarSign
+							className="w-3 h-3 flex-shrink-0"
+							style={{ color: theme.colors.textDim }}
+							aria-hidden="true"
+						/>
+						<div className="flex-1">
+							<TokenCostBadge sessions={sessions} theme={theme} />
+						</div>
+					</div>
+					{isThinking && (
+						<div
+							className="mt-3 inline-flex items-center gap-1.5 text-[11px] animate-pulse"
+							style={{ color: theme.colors.warning }}
+							data-testid="realtime-thinking-elapsed"
+							aria-label={`Thinking for ${elapsedSeconds} seconds`}
+						>
+							<Clock className="w-3 h-3" aria-hidden="true" />
+							Thinking: {elapsedSeconds}s
+						</div>
+					)}
+				</div>
+			</div>
+			<div
+				className="mt-3 pt-3 border-t flex items-center gap-1.5 text-[10px]"
+				style={{ borderColor: theme.colors.border, color: theme.colors.textDim }}
+				data-testid="realtime-active-count"
+			>
+				<span
+					className="w-1.5 h-1.5 rounded-full"
+					style={{ backgroundColor: theme.colors.success }}
+					aria-hidden="true"
+				/>
+				<span>
+					{activeCount} active {activeCount === 1 ? 'agent' : 'agents'}
+				</span>
+			</div>
+		</div>
+	);
+});
+
+const EMPTY_SESSIONS: Session[] = [];
+
 export const SummaryCards = memo(function SummaryCards({
 	data,
 	theme,
@@ -510,27 +791,39 @@ export const SummaryCards = memo(function SummaryCards({
 	];
 
 	return (
-		<div
-			className="grid gap-4"
-			style={{
-				gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))`,
-			}}
-			data-testid="summary-cards"
-			role="region"
-			aria-label="Usage summary metrics"
-		>
-			{metrics.map((metric, index) => (
-				<MetricCard
-					key={metric.label}
-					icon={metric.icon}
-					label={metric.label}
-					value={metric.value}
+		<>
+			<div
+				className="grid gap-4"
+				style={{
+					gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))`,
+				}}
+				data-testid="summary-cards"
+				role="region"
+				aria-label="Usage summary metrics"
+			>
+				{metrics.map((metric, index) => (
+					<MetricCard
+						key={metric.label}
+						icon={metric.icon}
+						label={metric.label}
+						value={metric.value}
+						theme={theme}
+						animationIndex={index}
+						extra={metric.extra}
+					/>
+				))}
+			</div>
+			<div
+				className="grid grid-cols-1 md:grid-cols-2 gap-3 mt-3"
+				data-testid="summary-realtime-row"
+			>
+				<RealtimeMetricsCard
+					sessions={sessions ?? EMPTY_SESSIONS}
 					theme={theme}
-					animationIndex={index}
-					extra={metric.extra}
+					animationDelay={320}
 				/>
-			))}
-		</div>
+			</div>
+		</>
 	);
 });
 

--- a/src/renderer/components/UsageDashboard/SummaryCards.tsx
+++ b/src/renderer/components/UsageDashboard/SummaryCards.tsx
@@ -89,6 +89,8 @@ interface MetricCardProps {
 	theme: Theme;
 	/** Animation delay index for staggered entrance (0-based) */
 	animationIndex?: number;
+	/** Optional content rendered below the value (e.g. status breakdown) */
+	extra?: React.ReactNode;
 }
 
 const MetricCard = memo(function MetricCard({
@@ -97,6 +99,7 @@ const MetricCard = memo(function MetricCard({
 	value,
 	theme,
 	animationIndex = 0,
+	extra,
 }: MetricCardProps) {
 	return (
 		<div
@@ -128,6 +131,7 @@ const MetricCard = memo(function MetricCard({
 				<div className="text-2xl font-bold" style={{ color: theme.colors.textMain }} title={value}>
 					{value}
 				</div>
+				{extra}
 			</div>
 		</div>
 	);
@@ -168,6 +172,56 @@ export const SummaryCards = memo(function SummaryCards({
 		}, 0);
 	}, [sessions]);
 
+	// Per-state agent counts for the mini status breakdown shown under the Agents card.
+	// Excludes terminal sessions to match `agentCount`.
+	const statusCounts = useMemo(() => {
+		if (!sessions) return null;
+		let busy = 0;
+		let idle = 0;
+		let error = 0;
+		for (const s of sessions) {
+			if (s.toolType === 'terminal') continue;
+			if (s.state === 'busy') busy++;
+			else if (s.state === 'error') error++;
+			else if (s.state === 'idle') idle++;
+		}
+		return { busy, idle, error };
+	}, [sessions]);
+
+	const statusBreakdown = statusCounts ? (
+		<div
+			className="flex items-center gap-2 mt-1.5 text-[10px]"
+			style={{ color: theme.colors.textDim }}
+			data-testid="agent-status-breakdown"
+			aria-label={`${statusCounts.busy} busy, ${statusCounts.idle} idle, ${statusCounts.error} errors`}
+		>
+			<span className="flex items-center gap-1" title={`${statusCounts.busy} busy`}>
+				<span
+					className="w-1.5 h-1.5 rounded-full"
+					style={{ backgroundColor: theme.colors.warning }}
+					aria-hidden="true"
+				/>
+				{statusCounts.busy}
+			</span>
+			<span className="flex items-center gap-1" title={`${statusCounts.idle} idle`}>
+				<span
+					className="w-1.5 h-1.5 rounded-full"
+					style={{ backgroundColor: theme.colors.success }}
+					aria-hidden="true"
+				/>
+				{statusCounts.idle}
+			</span>
+			<span className="flex items-center gap-1" title={`${statusCounts.error} errors`}>
+				<span
+					className="w-1.5 h-1.5 rounded-full"
+					style={{ backgroundColor: theme.colors.error }}
+					aria-hidden="true"
+				/>
+				{statusCounts.error}
+			</span>
+		</div>
+	) : null;
+
 	// Calculate derived metrics
 	const { mostActiveAgent, interactiveRatio, peakHour, localVsRemote, queriesPerSession } =
 		useMemo(() => {
@@ -206,11 +260,17 @@ export const SummaryCards = memo(function SummaryCards({
 			};
 		}, [data.byAgent, data.bySource, data.byHour, data.byLocation, agentCount, data.totalQueries]);
 
-	const metrics = [
+	const metrics: Array<{
+		icon: React.ReactNode;
+		label: string;
+		value: string;
+		extra?: React.ReactNode;
+	}> = [
 		{
 			icon: <Layers className="w-4 h-4" />,
 			label: 'Agents',
 			value: formatNumber(agentCount),
+			extra: statusBreakdown,
 		},
 		{
 			icon: <PanelTop className="w-4 h-4" />,
@@ -277,6 +337,7 @@ export const SummaryCards = memo(function SummaryCards({
 					value={metric.value}
 					theme={theme}
 					animationIndex={index}
+					extra={metric.extra}
 				/>
 			))}
 		</div>

--- a/src/renderer/components/UsageDashboard/SummaryCards.tsx
+++ b/src/renderer/components/UsageDashboard/SummaryCards.tsx
@@ -80,6 +80,60 @@ function formatNumber(num: number): string {
 }
 
 /**
+ * Visual variants for metric cards.
+ *
+ * - `elevated`: solid background, subtle border + shadow (default)
+ * - `outlined`: transparent background, accent-colored border
+ * - `filled`: tinted accent background with accent border
+ * - `ghost`: transparent background, no border
+ */
+export type CardVariant = 'elevated' | 'outlined' | 'filled' | 'ghost';
+
+/**
+ * Compute variant-specific card styles. The accent color falls back to the
+ * theme's accent when not provided so callers can tint cards independently.
+ */
+export function getCardStyles(
+	variant: CardVariant,
+	theme: Theme,
+	accentColor?: string
+): React.CSSProperties {
+	const accent = accentColor ?? theme.colors.accent;
+	const base: React.CSSProperties = {
+		borderRadius: '10px',
+		transition: 'all 200ms cubic-bezier(0.4, 0, 0.2, 1)',
+	};
+
+	switch (variant) {
+		case 'elevated':
+			return {
+				...base,
+				backgroundColor: theme.colors.bgActivity,
+				border: `1px solid ${theme.colors.border}`,
+				boxShadow: '0 2px 8px rgba(0,0,0,0.15)',
+			};
+		case 'outlined':
+			return {
+				...base,
+				backgroundColor: 'transparent',
+				border: `1px solid ${accent}66`,
+			};
+		case 'filled':
+			return {
+				...base,
+				backgroundColor: `${accent}26`,
+				border: `1px solid ${accent}4D`,
+			};
+		case 'ghost':
+			return {
+				...base,
+				backgroundColor: 'transparent',
+				border: 'none',
+			};
+	}
+}
+
+/**
  * Single metric card component
  */
 interface MetricCardProps {
@@ -91,6 +145,10 @@ interface MetricCardProps {
 	animationIndex?: number;
 	/** Optional content rendered below the value (e.g. status breakdown) */
 	extra?: React.ReactNode;
+	/** Visual variant — defaults to `'elevated'` */
+	variant?: CardVariant;
+	/** Optional accent color override for `outlined` / `filled` variants */
+	accentColor?: string;
 }
 
 const MetricCard = memo(function MetricCard({
@@ -100,12 +158,14 @@ const MetricCard = memo(function MetricCard({
 	theme,
 	animationIndex = 0,
 	extra,
+	variant = 'elevated',
+	accentColor,
 }: MetricCardProps) {
 	return (
 		<div
-			className="p-4 rounded-lg flex items-start gap-3 dashboard-card-enter"
+			className="p-4 flex items-start gap-3 dashboard-card-enter"
 			style={{
-				backgroundColor: theme.colors.bgMain,
+				...getCardStyles(variant, theme, accentColor),
 				animationDelay: `${animationIndex * 50}ms`,
 			}}
 			data-testid="metric-card"

--- a/src/renderer/components/UsageDashboard/SummaryCards.tsx
+++ b/src/renderer/components/UsageDashboard/SummaryCards.tsx
@@ -17,7 +17,7 @@
  * - Formatted values for readability
  */
 
-import React, { memo, useMemo } from 'react';
+import React, { memo, useMemo, useState } from 'react';
 import {
 	MessageSquare,
 	Clock,
@@ -110,6 +110,7 @@ export function getCardStyles(
 				...base,
 				backgroundColor: theme.colors.bgActivity,
 				border: `1px solid ${theme.colors.border}`,
+				borderTop: `2px solid ${accent}`,
 				boxShadow: '0 2px 8px rgba(0,0,0,0.15)',
 			};
 		case 'outlined':
@@ -161,16 +162,22 @@ const MetricCard = memo(function MetricCard({
 	variant = 'elevated',
 	accentColor,
 }: MetricCardProps) {
+	const [hovered, setHovered] = useState(false);
+
 	return (
 		<div
-			className="p-4 flex items-start gap-3 dashboard-card-enter"
+			className="p-4 flex items-start gap-3 card-enter"
 			style={{
 				...getCardStyles(variant, theme, accentColor),
-				animationDelay: `${animationIndex * 50}ms`,
+				animationDelay: `${animationIndex * 80}ms`,
+				transform: hovered ? 'scale(0.98)' : undefined,
+				filter: hovered ? 'brightness(1.1)' : undefined,
 			}}
 			data-testid="metric-card"
 			role="group"
 			aria-label={`${label}: ${value}`}
+			onMouseEnter={() => setHovered(true)}
+			onMouseLeave={() => setHovered(false)}
 		>
 			<div
 				className="flex-shrink-0 p-2 rounded-md"
@@ -188,7 +195,14 @@ const MetricCard = memo(function MetricCard({
 				>
 					{label}
 				</div>
-				<div className="text-2xl font-bold" style={{ color: theme.colors.textMain }} title={value}>
+				<div
+					className="font-bold"
+					style={{
+						color: theme.colors.textMain,
+						fontSize: 'clamp(18px, 3vw, 28px)',
+					}}
+					title={value}
+				>
 					{value}
 				</div>
 				{extra}

--- a/src/renderer/components/UsageDashboard/SummaryCards.tsx
+++ b/src/renderer/components/UsageDashboard/SummaryCards.tsx
@@ -36,6 +36,33 @@ import {
 import type { Theme, Session } from '../../types';
 import type { StatsAggregation } from '../../hooks/stats/useStats';
 import { formatCost } from '../../../shared/formatters';
+import { Sparkline } from './Sparkline';
+
+type ByDayEntry = StatsAggregation['byDay'][number];
+
+const SPARKLINE_DAYS = 7;
+
+/**
+ * Extracts the most recent `SPARKLINE_DAYS` daily query counts (oldest →
+ * newest), left-padding with zeros so the returned array always has
+ * `SPARKLINE_DAYS` entries. This keeps sparkline geometry stable when
+ * the user has fewer than a week of activity.
+ */
+export function getLast7Days(byDay: ByDayEntry[]): number[] {
+	const counts = byDay.slice(-SPARKLINE_DAYS).map((d) => d.count);
+	if (counts.length >= SPARKLINE_DAYS) return counts;
+	return [...new Array(SPARKLINE_DAYS - counts.length).fill(0), ...counts];
+}
+
+/**
+ * Same as {@link getLast7Days} but pulls each day's total `duration`
+ * (in ms) instead of the query count.
+ */
+export function getLast7DaysDuration(byDay: ByDayEntry[]): number[] {
+	const durations = byDay.slice(-SPARKLINE_DAYS).map((d) => d.duration);
+	if (durations.length >= SPARKLINE_DAYS) return durations;
+	return [...new Array(SPARKLINE_DAYS - durations.length).fill(0), ...durations];
+}
 
 interface SummaryCardsProps {
 	/** Aggregated stats data from the API */
@@ -270,6 +297,10 @@ interface MetricCardProps {
 	variant?: CardVariant;
 	/** Optional accent color override for `outlined` / `filled` variants */
 	accentColor?: string;
+	/** Optional 7-day trend data rendered as a mini sparkline in the corner */
+	sparklineData?: number[];
+	/** Sparkline stroke + fill color; defaults to the theme accent */
+	sparklineColor?: string;
 }
 
 const MetricCard = memo(function MetricCard({
@@ -281,12 +312,14 @@ const MetricCard = memo(function MetricCard({
 	extra,
 	variant = 'elevated',
 	accentColor,
+	sparklineData,
+	sparklineColor,
 }: MetricCardProps) {
 	const [hovered, setHovered] = useState(false);
 
 	return (
 		<div
-			className="p-4 flex items-start gap-3 card-enter"
+			className="relative p-4 flex items-start gap-3 card-enter"
 			style={{
 				...getCardStyles(variant, theme, accentColor),
 				animationDelay: `${animationIndex * 80}ms`,
@@ -327,6 +360,16 @@ const MetricCard = memo(function MetricCard({
 				</div>
 				{extra}
 			</div>
+			{sparklineData && (
+				<div className="absolute bottom-2 right-2 opacity-60 pointer-events-none">
+					<Sparkline
+						data={sparklineData}
+						color={sparklineColor ?? theme.colors.accent}
+						width={60}
+						height={20}
+					/>
+				</div>
+			)}
 		</div>
 	);
 });
@@ -731,11 +774,16 @@ export const SummaryCards = memo(function SummaryCards({
 			};
 		}, [data.byAgent, data.bySource, data.byHour, data.byLocation, agentCount, data.totalQueries]);
 
+	const queriesSparkline = useMemo(() => getLast7Days(data.byDay), [data.byDay]);
+	const durationSparkline = useMemo(() => getLast7DaysDuration(data.byDay), [data.byDay]);
+
 	const metrics: Array<{
 		icon: React.ReactNode;
 		label: string;
 		value: string;
 		extra?: React.ReactNode;
+		sparklineData?: number[];
+		sparklineColor?: string;
 	}> = [
 		{
 			icon: <Layers className="w-4 h-4" />,
@@ -752,6 +800,7 @@ export const SummaryCards = memo(function SummaryCards({
 			icon: <MessageSquare className="w-4 h-4" />,
 			label: 'Total Queries',
 			value: formatNumber(data.totalQueries),
+			sparklineData: queriesSparkline,
 		},
 		{
 			icon: <Zap className="w-4 h-4" />,
@@ -762,6 +811,7 @@ export const SummaryCards = memo(function SummaryCards({
 			icon: <Clock className="w-4 h-4" />,
 			label: 'Total Time',
 			value: formatDuration(data.totalDuration),
+			sparklineData: durationSparkline,
 		},
 		{
 			icon: <Timer className="w-4 h-4" />,
@@ -810,6 +860,8 @@ export const SummaryCards = memo(function SummaryCards({
 						theme={theme}
 						animationIndex={index}
 						extra={metric.extra}
+						sparklineData={metric.sparklineData}
+						sparklineColor={metric.sparklineColor}
 					/>
 				))}
 			</div>

--- a/src/renderer/components/UsageDashboard/TasksByHourChart.tsx
+++ b/src/renderer/components/UsageDashboard/TasksByHourChart.tsx
@@ -140,7 +140,10 @@ export const TasksByHourChart = memo(function TasksByHourChart({
 	if (loading) {
 		return (
 			<div className="p-4 rounded-lg" style={{ backgroundColor: theme.colors.bgMain }}>
-				<h3 className="text-sm font-medium mb-4" style={{ color: theme.colors.textMain }}>
+				<h3
+					className="text-sm font-medium mb-4"
+					style={{ color: theme.colors.textMain, animation: 'card-enter 0.4s ease both' }}
+				>
 					Tasks by Time of Day
 				</h3>
 				<div
@@ -156,7 +159,10 @@ export const TasksByHourChart = memo(function TasksByHourChart({
 	if (error) {
 		return (
 			<div className="p-4 rounded-lg" style={{ backgroundColor: theme.colors.bgMain }}>
-				<h3 className="text-sm font-medium mb-4" style={{ color: theme.colors.textMain }}>
+				<h3
+					className="text-sm font-medium mb-4"
+					style={{ color: theme.colors.textMain, animation: 'card-enter 0.4s ease both' }}
+				>
 					Tasks by Time of Day
 				</h3>
 				<div
@@ -182,7 +188,10 @@ export const TasksByHourChart = memo(function TasksByHourChart({
 	if (totalTasks === 0) {
 		return (
 			<div className="p-4 rounded-lg" style={{ backgroundColor: theme.colors.bgMain }}>
-				<h3 className="text-sm font-medium mb-4" style={{ color: theme.colors.textMain }}>
+				<h3
+					className="text-sm font-medium mb-4"
+					style={{ color: theme.colors.textMain, animation: 'card-enter 0.4s ease both' }}
+				>
 					Tasks by Time of Day
 				</h3>
 				<div

--- a/src/renderer/components/UsageDashboard/UsageDashboardModal.tsx
+++ b/src/renderer/components/UsageDashboard/UsageDashboardModal.tsx
@@ -419,6 +419,16 @@ export function UsageDashboardModal({
 		setFilter(null);
 	}, []);
 
+	// Reset the drill-down filter when the time range or active dashboard tab
+	// changes. The filter key only makes sense in the context of the data
+	// currently on screen — switching to a different time range or view can
+	// surface a totally different set of agents, so leaving a stale filter
+	// active would silently hide all charts. setState with `null` is a no-op
+	// when no filter is active, so this is cheap on the common path.
+	useEffect(() => {
+		setFilter(null);
+	}, [timeRange, viewMode]);
+
 	// Apply the active filter to the aggregation. When no filter is set, pass
 	// the raw stats through unchanged so referential equality is preserved
 	// (downstream charts can rely on memoization).
@@ -937,6 +947,7 @@ export function UsageDashboardModal({
 												sessions={sessions}
 												data={filteredStats ?? data}
 												theme={theme}
+												activeFilterKey={filter?.key ?? null}
 											/>
 										</ChartErrorBoundary>
 									)}

--- a/src/renderer/components/UsageDashboard/UsageDashboardModal.tsx
+++ b/src/renderer/components/UsageDashboard/UsageDashboardModal.tsx
@@ -103,6 +103,65 @@ interface StatsAggregation {
 // View mode options for the dashboard
 type ViewMode = 'overview' | 'agents' | 'activity' | 'autorun';
 
+// Drill-down filter applied across all charts. `key` is the per-agent map key
+// used in `byAgent` / `byAgentByDay` (or session id for `bySessionByDay`).
+interface DashboardFilter {
+	type: 'agent' | 'session';
+	key: string;
+	displayName: string;
+}
+
+/**
+ * Filter a StatsAggregation down to a single agent's data.
+ *
+ * Filters the per-agent maps (`byAgent`, `byAgentByDay`, `bySessionByDay`) to
+ * include only entries for the selected key, then recalculates the totals
+ * (`totalQueries`, `totalDuration`, `avgDuration`) from what remains. Other
+ * fields (per-source, per-location, per-day, per-hour) are passed through
+ * unchanged — the per-agent data does not exist on those breakdowns, so the
+ * filtered view falls back to global numbers for charts that consume them.
+ */
+function filterStatsForAgent(stats: StatsAggregation, agentKey: string): StatsAggregation {
+	const agentEntry = stats.byAgent[agentKey];
+	const filteredByAgent: Record<string, { count: number; duration: number }> = agentEntry
+		? { [agentKey]: agentEntry }
+		: {};
+
+	const agentDayEntry = stats.byAgentByDay[agentKey];
+	const filteredByAgentByDay: Record<
+		string,
+		Array<{ date: string; count: number; duration: number }>
+	> = agentDayEntry ? { [agentKey]: agentDayEntry } : {};
+
+	// `bySessionByDay` is keyed by session id, but the drill-down filter key is
+	// an agent identifier. Match sessions whose key starts with the agent key
+	// (the agent provider is the prefix in session ids); when nothing matches,
+	// fall back to an empty map so dependent charts render zero state.
+	const filteredBySessionByDay: Record<
+		string,
+		Array<{ date: string; count: number; duration: number }>
+	> = {};
+	for (const [sessionKey, days] of Object.entries(stats.bySessionByDay)) {
+		if (sessionKey === agentKey || sessionKey.startsWith(`${agentKey}:`)) {
+			filteredBySessionByDay[sessionKey] = days;
+		}
+	}
+
+	const totalQueries = agentEntry?.count ?? 0;
+	const totalDuration = agentEntry?.duration ?? 0;
+	const avgDuration = totalQueries > 0 ? totalDuration / totalQueries : 0;
+
+	return {
+		...stats,
+		byAgent: filteredByAgent,
+		byAgentByDay: filteredByAgentByDay,
+		bySessionByDay: filteredBySessionByDay,
+		totalQueries,
+		totalDuration,
+		avgDuration,
+	};
+}
+
 interface UsageDashboardModalProps {
 	isOpen: boolean;
 	onClose: () => void;
@@ -170,6 +229,7 @@ export function UsageDashboardModal({
 	const [showNewDataIndicator, setShowNewDataIndicator] = useState(false);
 	const [databaseSize, setDatabaseSize] = useState<number | null>(null);
 	const [focusedSection, setFocusedSection] = useState<SectionId | null>(null);
+	const [filter, setFilter] = useState<DashboardFilter | null>(null);
 
 	const containerRef = useRef<HTMLDivElement>(null);
 	const contentRef = useRef<HTMLDivElement>(null);
@@ -285,6 +345,38 @@ export function UsageDashboardModal({
 		setViewMode(mode);
 		setFocusedSection(null);
 	}, []);
+
+	// Drill-down filter handlers. Clicking the same agent again clears the
+	// filter (toggle); clicking a different agent replaces it.
+	const handleFilterByAgent = useCallback((key: string, displayName: string) => {
+		setFilter((current) =>
+			current && current.type === 'agent' && current.key === key
+				? null
+				: { type: 'agent', key, displayName }
+		);
+	}, []);
+
+	const clearFilter = useCallback(() => {
+		setFilter(null);
+	}, []);
+
+	// Apply the active filter to the aggregation. When no filter is set, pass
+	// the raw stats through unchanged so referential equality is preserved
+	// (downstream charts can rely on memoization).
+	const filteredStats = useMemo(() => {
+		if (!data || !filter) return data;
+		if (filter.type === 'agent') {
+			return filterStatsForAgent(data, filter.key);
+		}
+		return data;
+	}, [data, filter]);
+
+	// These bindings are scaffolding for the drill-down UI (filter bar,
+	// per-chart click handlers) added in the follow-up task. `void` keeps
+	// TS6133 / no-unused-vars quiet without leaving the wiring half-built.
+	void handleFilterByAgent;
+	void clearFilter;
+	void filteredStats;
 
 	// Handle Cmd+Shift+[ and Cmd+Shift+] for tab navigation
 	useEffect(() => {

--- a/src/renderer/components/UsageDashboard/UsageDashboardModal.tsx
+++ b/src/renderer/components/UsageDashboard/UsageDashboardModal.tsx
@@ -1004,6 +1004,7 @@ export function UsageDashboardModal({
 												data={data}
 												theme={theme}
 												colorBlindMode={colorBlindMode}
+												sessions={sessions}
 											/>
 										</ChartErrorBoundary>
 									</div>

--- a/src/renderer/components/UsageDashboard/UsageDashboardModal.tsx
+++ b/src/renderer/components/UsageDashboard/UsageDashboardModal.tsx
@@ -16,6 +16,7 @@
 import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { X, BarChart3, Calendar, Download, Database } from 'lucide-react';
 import { SummaryCards } from './SummaryCards';
+import { AgentOverviewCards } from './AgentOverviewCards';
 import { ActivityHeatmap } from './ActivityHeatmap';
 import { AgentComparisonChart } from './AgentComparisonChart';
 import { SourceDistributionChart } from './SourceDistributionChart';
@@ -728,6 +729,15 @@ export function UsageDashboardModal({
 							{/* View-specific content based on viewMode */}
 							{viewMode === 'overview' && (
 								<>
+									{/* Active Agents Overview - per-agent status, branch, sparkline.
+									    Sits above keyboard-navigable sections; AgentOverviewCards
+									    provides its own role="region" + aria-label. */}
+									{sessions.length > 0 && (
+										<ChartErrorBoundary theme={theme} chartName="Agent Overview">
+											<AgentOverviewCards sessions={sessions} data={data} theme={theme} />
+										</ChartErrorBoundary>
+									)}
+
 									{/* Summary Stats Cards - Horizontal row at top, responsive */}
 									<div
 										ref={setSectionRef('summary-cards')}

--- a/src/renderer/components/UsageDashboard/UsageDashboardModal.tsx
+++ b/src/renderer/components/UsageDashboard/UsageDashboardModal.tsx
@@ -26,6 +26,7 @@ import { DurationTrendsChart } from './DurationTrendsChart';
 import { AgentUsageChart } from './AgentUsageChart';
 import { AutoRunStats } from './AutoRunStats';
 import { SessionStats } from './SessionStats';
+import { WorktreeAnalytics } from './WorktreeAnalytics';
 import { AgentEfficiencyChart } from './AgentEfficiencyChart';
 import { WeekdayComparisonChart } from './WeekdayComparisonChart';
 import { TasksByHourChart } from './TasksByHourChart';
@@ -970,6 +971,16 @@ export function UsageDashboardModal({
 											/>
 										</ChartErrorBoundary>
 									</div>
+
+									{/* Worktree Analytics — only shown when at least one worktree
+									    session exists. WorktreeAnalytics provides its own role="region"
+									    + aria-label, so it sits outside the keyboard-navigable sections
+									    (same pattern as AgentOverviewCards in the Overview tab). */}
+									{sessions.some((s) => !!s.parentSessionId) && (
+										<ChartErrorBoundary theme={theme} chartName="Worktree Analytics">
+											<WorktreeAnalytics sessions={sessions} data={data} theme={theme} />
+										</ChartErrorBoundary>
+									)}
 
 									{/* Agent Efficiency */}
 									<div

--- a/src/renderer/components/UsageDashboard/UsageDashboardModal.tsx
+++ b/src/renderer/components/UsageDashboard/UsageDashboardModal.tsx
@@ -89,6 +89,14 @@ interface StatsAggregation {
 	byAgentByDay: Record<string, Array<{ date: string; count: number; duration: number }>>;
 	// Per-session per-day breakdown for agent usage chart
 	bySessionByDay: Record<string, Array<{ date: string; count: number; duration: number }>>;
+	// Worktree breakdown (added in stats DB v5; optional for backwards
+	// compatibility — populated at runtime by the stats aggregation handler).
+	worktreeQueries?: number;
+	parentQueries?: number;
+	byWorktreeStatus?: {
+		worktree: { count: number; duration: number };
+		parent: { count: number; duration: number };
+	};
 }
 
 // View mode options for the dashboard

--- a/src/renderer/components/UsageDashboard/UsageDashboardModal.tsx
+++ b/src/renderer/components/UsageDashboard/UsageDashboardModal.tsx
@@ -162,6 +162,56 @@ function filterStatsForAgent(stats: StatsAggregation, agentKey: string): StatsAg
 	};
 }
 
+/**
+ * Placeholder shown in place of charts that don't have a per-agent breakdown
+ * (ActivityHeatmap, PeakHoursChart, WeekdayComparisonChart) while a drill-down
+ * filter is active. Surfaces the filtered agent's name and a clickable "Clear
+ * filter" link so the user can recover the full view in one click.
+ */
+function FilteredChartPlaceholder({
+	chartName,
+	theme,
+	onClear,
+}: {
+	chartName: string;
+	theme: Theme;
+	onClear: () => void;
+}) {
+	return (
+		<div
+			className="p-4 rounded-lg flex items-center justify-center"
+			style={{
+				backgroundColor: theme.colors.bgMain,
+				color: theme.colors.textDim,
+				minHeight: 120,
+			}}
+			data-testid={`filtered-placeholder-${chartName.toLowerCase().replace(/\s+/g, '-')}`}
+			role="status"
+			aria-live="polite"
+		>
+			<span className="text-sm">
+				Hourly breakdown not available for individual agents.{' '}
+				<button
+					type="button"
+					onClick={onClear}
+					className="chart-clickable underline"
+					style={{
+						color: theme.colors.accent,
+						background: 'none',
+						border: 'none',
+						padding: 0,
+						font: 'inherit',
+					}}
+					data-testid={`filtered-placeholder-clear-${chartName.toLowerCase().replace(/\s+/g, '-')}`}
+				>
+					Clear filter
+				</button>{' '}
+				to see all data.
+			</span>
+		</div>
+	);
+}
+
 interface UsageDashboardModalProps {
 	isOpen: boolean;
 	onClose: () => void;
@@ -1028,11 +1078,19 @@ export function UsageDashboardModal({
 										data-testid="section-peak-hours"
 									>
 										<ChartErrorBoundary theme={theme} chartName="Peak Hours">
-											<PeakHoursChart
-												data={filteredStats ?? data}
-												theme={theme}
-												colorBlindMode={colorBlindMode}
-											/>
+											{filter ? (
+												<FilteredChartPlaceholder
+													chartName="Peak Hours"
+													theme={theme}
+													onClear={clearFilter}
+												/>
+											) : (
+												<PeakHoursChart
+													data={filteredStats ?? data}
+													theme={theme}
+													colorBlindMode={colorBlindMode}
+												/>
+											)}
 										</ChartErrorBoundary>
 									</div>
 
@@ -1055,12 +1113,20 @@ export function UsageDashboardModal({
 										data-testid="section-activity-heatmap"
 									>
 										<ChartErrorBoundary theme={theme} chartName="Activity Heatmap">
-											<ActivityHeatmap
-												data={filteredStats ?? data}
-												timeRange={timeRange}
-												theme={theme}
-												colorBlindMode={colorBlindMode}
-											/>
+											{filter ? (
+												<FilteredChartPlaceholder
+													chartName="Activity Heatmap"
+													theme={theme}
+													onClear={clearFilter}
+												/>
+											) : (
+												<ActivityHeatmap
+													data={filteredStats ?? data}
+													timeRange={timeRange}
+													theme={theme}
+													colorBlindMode={colorBlindMode}
+												/>
+											)}
 										</ChartErrorBoundary>
 									</div>
 
@@ -1249,12 +1315,20 @@ export function UsageDashboardModal({
 										data-testid="section-activity-heatmap"
 									>
 										<ChartErrorBoundary theme={theme} chartName="Activity Heatmap">
-											<ActivityHeatmap
-												data={filteredStats ?? data}
-												timeRange={timeRange}
-												theme={theme}
-												colorBlindMode={colorBlindMode}
-											/>
+											{filter ? (
+												<FilteredChartPlaceholder
+													chartName="Activity Heatmap"
+													theme={theme}
+													onClear={clearFilter}
+												/>
+											) : (
+												<ActivityHeatmap
+													data={filteredStats ?? data}
+													timeRange={timeRange}
+													theme={theme}
+													colorBlindMode={colorBlindMode}
+												/>
+											)}
 										</ChartErrorBoundary>
 									</div>
 
@@ -1276,11 +1350,19 @@ export function UsageDashboardModal({
 										data-testid="section-weekday-comparison"
 									>
 										<ChartErrorBoundary theme={theme} chartName="Weekday Comparison">
-											<WeekdayComparisonChart
-												data={filteredStats ?? data}
-												theme={theme}
-												colorBlindMode={colorBlindMode}
-											/>
+											{filter ? (
+												<FilteredChartPlaceholder
+													chartName="Weekday Comparison"
+													theme={theme}
+													onClear={clearFilter}
+												/>
+											) : (
+												<WeekdayComparisonChart
+													data={filteredStats ?? data}
+													theme={theme}
+													colorBlindMode={colorBlindMode}
+												/>
+											)}
 										</ChartErrorBoundary>
 									</div>
 

--- a/src/renderer/components/UsageDashboard/UsageDashboardModal.tsx
+++ b/src/renderer/components/UsageDashboard/UsageDashboardModal.tsx
@@ -778,6 +778,7 @@ export function UsageDashboardModal({
 												data={data}
 												theme={theme}
 												colorBlindMode={colorBlindMode}
+												sessions={sessions}
 											/>
 										</ChartErrorBoundary>
 									</div>
@@ -975,6 +976,7 @@ export function UsageDashboardModal({
 												data={data}
 												theme={theme}
 												colorBlindMode={colorBlindMode}
+												sessions={sessions}
 											/>
 										</ChartErrorBoundary>
 									</div>

--- a/src/renderer/components/UsageDashboard/UsageDashboardModal.tsx
+++ b/src/renderer/components/UsageDashboard/UsageDashboardModal.tsx
@@ -14,7 +14,7 @@
  */
 
 import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
-import { X, BarChart3, Calendar, Download, Database } from 'lucide-react';
+import { X, BarChart3, Calendar, Download, Database, Filter } from 'lucide-react';
 import { SummaryCards } from './SummaryCards';
 import { AgentOverviewCards } from './AgentOverviewCards';
 import { ActivityHeatmap } from './ActivityHeatmap';
@@ -248,7 +248,10 @@ export function UsageDashboardModal({
 		}
 	}, [isOpen, defaultTimeRange]);
 
-	// Register with layer stack for proper Escape handling
+	// Register with layer stack for proper Escape handling.
+	// When a drill-down filter is active, Escape clears the filter first
+	// instead of closing the modal — coordinated through the layer stack so
+	// the modal still owns the only Escape-keydown listener.
 	useEffect(() => {
 		if (isOpen) {
 			const id = registerLayer({
@@ -257,7 +260,13 @@ export function UsageDashboardModal({
 				blocksLowerLayers: true,
 				capturesFocus: true,
 				focusTrap: 'lenient',
-				onEscape: () => onCloseRef.current(),
+				onEscape: () => {
+					if (filterRef.current) {
+						setFilter(null);
+					} else {
+						onCloseRef.current();
+					}
+				},
 			});
 			return () => unregisterLayer(id);
 		}
@@ -371,12 +380,11 @@ export function UsageDashboardModal({
 		return data;
 	}, [data, filter]);
 
-	// These bindings are scaffolding for the drill-down UI (filter bar,
-	// per-chart click handlers) added in the follow-up task. `void` keeps
-	// TS6133 / no-unused-vars quiet without leaving the wiring half-built.
-	void handleFilterByAgent;
-	void clearFilter;
-	void filteredStats;
+	// Mirror the active filter into a ref so the layer-stack `onEscape`
+	// callback (registered once when the modal opens) can read the latest
+	// value without forcing the layer to re-register on every filter change.
+	const filterRef = useRef(filter);
+	filterRef.current = filter;
 
 	// Handle Cmd+Shift+[ and Cmd+Shift+] for tab navigation
 	useEffect(() => {
@@ -789,6 +797,46 @@ export function UsageDashboardModal({
 					className="flex-1 overflow-y-auto scrollbar-thin p-6"
 					style={{ backgroundColor: theme.colors.bgMain }}
 				>
+					{/* Drill-down Filter Indicator — visible whenever a chart filter is active */}
+					{filter && (
+						<div
+							className="card-enter mb-4"
+							style={{
+								display: 'flex',
+								alignItems: 'center',
+								gap: '8px',
+								backgroundColor: `${theme.colors.accent}26`, // 15% over base alpha
+								borderLeft: `3px solid ${theme.colors.accent}`,
+								borderRadius: '8px',
+								padding: '8px 12px',
+								color: theme.colors.textMain,
+							}}
+							data-testid="dashboard-filter-bar"
+							role="status"
+							aria-live="polite"
+						>
+							<Filter size={14} style={{ color: theme.colors.accent }} aria-hidden="true" />
+							<span className="text-sm">
+								Filtered to: <strong>{filter.displayName}</strong>
+							</span>
+							<button
+								type="button"
+								onClick={clearFilter}
+								className="ml-auto flex items-center gap-1 px-2 py-0.5 rounded text-xs transition-colors"
+								style={{ color: theme.colors.textDim }}
+								onMouseEnter={(e) =>
+									(e.currentTarget.style.backgroundColor = `${theme.colors.accent}25`)
+								}
+								onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = 'transparent')}
+								aria-label="Clear filter"
+								title="Clear filter (Esc)"
+								data-testid="dashboard-filter-clear"
+							>
+								<X size={14} />
+								Clear
+							</button>
+						</div>
+					)}
 					{loading && !data ? (
 						<DashboardSkeleton
 							theme={theme}
@@ -835,7 +883,11 @@ export function UsageDashboardModal({
 									    provides its own role="region" + aria-label. */}
 									{sessions.length > 0 && (
 										<ChartErrorBoundary theme={theme} chartName="Agent Overview">
-											<AgentOverviewCards sessions={sessions} data={data} theme={theme} />
+											<AgentOverviewCards
+												sessions={sessions}
+												data={filteredStats ?? data}
+												theme={theme}
+											/>
 										</ChartErrorBoundary>
 									)}
 
@@ -858,7 +910,7 @@ export function UsageDashboardModal({
 									>
 										<ChartErrorBoundary theme={theme} chartName="Summary Cards">
 											<SummaryCards
-												data={data}
+												data={filteredStats ?? data}
 												theme={theme}
 												columns={layout.summaryCardsCols}
 												sessions={sessions}
@@ -886,10 +938,12 @@ export function UsageDashboardModal({
 									>
 										<ChartErrorBoundary theme={theme} chartName="Agent Comparison">
 											<AgentComparisonChart
-												data={data}
+												data={filteredStats ?? data}
 												theme={theme}
 												colorBlindMode={colorBlindMode}
 												sessions={sessions}
+												onAgentClick={handleFilterByAgent}
+												activeFilterKey={filter?.key ?? null}
 											/>
 										</ChartErrorBoundary>
 									</div>
@@ -921,7 +975,7 @@ export function UsageDashboardModal({
 										>
 											<ChartErrorBoundary theme={theme} chartName="Source Distribution">
 												<SourceDistributionChart
-													data={data}
+													data={filteredStats ?? data}
 													theme={theme}
 													colorBlindMode={colorBlindMode}
 												/>
@@ -947,7 +1001,7 @@ export function UsageDashboardModal({
 										>
 											<ChartErrorBoundary theme={theme} chartName="Location Distribution">
 												<LocationDistributionChart
-													data={data}
+													data={filteredStats ?? data}
 													theme={theme}
 													colorBlindMode={colorBlindMode}
 												/>
@@ -974,7 +1028,11 @@ export function UsageDashboardModal({
 										data-testid="section-peak-hours"
 									>
 										<ChartErrorBoundary theme={theme} chartName="Peak Hours">
-											<PeakHoursChart data={data} theme={theme} colorBlindMode={colorBlindMode} />
+											<PeakHoursChart
+												data={filteredStats ?? data}
+												theme={theme}
+												colorBlindMode={colorBlindMode}
+											/>
 										</ChartErrorBoundary>
 									</div>
 
@@ -998,7 +1056,7 @@ export function UsageDashboardModal({
 									>
 										<ChartErrorBoundary theme={theme} chartName="Activity Heatmap">
 											<ActivityHeatmap
-												data={data}
+												data={filteredStats ?? data}
 												timeRange={timeRange}
 												theme={theme}
 												colorBlindMode={colorBlindMode}
@@ -1026,7 +1084,7 @@ export function UsageDashboardModal({
 									>
 										<ChartErrorBoundary theme={theme} chartName="Duration Trends">
 											<DurationTrendsChart
-												data={data}
+												data={filteredStats ?? data}
 												timeRange={timeRange}
 												theme={theme}
 												colorBlindMode={colorBlindMode}
@@ -1070,7 +1128,11 @@ export function UsageDashboardModal({
 									    (same pattern as AgentOverviewCards in the Overview tab). */}
 									{sessions.some((s) => !!s.parentSessionId) && (
 										<ChartErrorBoundary theme={theme} chartName="Worktree Analytics">
-											<WorktreeAnalytics sessions={sessions} data={data} theme={theme} />
+											<WorktreeAnalytics
+												sessions={sessions}
+												data={filteredStats ?? data}
+												theme={theme}
+											/>
 										</ChartErrorBoundary>
 									)}
 
@@ -1094,10 +1156,11 @@ export function UsageDashboardModal({
 									>
 										<ChartErrorBoundary theme={theme} chartName="Agent Efficiency">
 											<AgentEfficiencyChart
-												data={data}
+												data={filteredStats ?? data}
 												theme={theme}
 												colorBlindMode={colorBlindMode}
 												sessions={sessions}
+												activeFilterKey={filter?.key ?? null}
 											/>
 										</ChartErrorBoundary>
 									</div>
@@ -1122,10 +1185,12 @@ export function UsageDashboardModal({
 									>
 										<ChartErrorBoundary theme={theme} chartName="Provider Comparison">
 											<AgentComparisonChart
-												data={data}
+												data={filteredStats ?? data}
 												theme={theme}
 												colorBlindMode={colorBlindMode}
 												sessions={sessions}
+												onAgentClick={handleFilterByAgent}
+												activeFilterKey={filter?.key ?? null}
 											/>
 										</ChartErrorBoundary>
 									</div>
@@ -1150,11 +1215,13 @@ export function UsageDashboardModal({
 									>
 										<ChartErrorBoundary theme={theme} chartName="Agent Usage">
 											<AgentUsageChart
-												data={data}
+												data={filteredStats ?? data}
 												timeRange={timeRange}
 												theme={theme}
 												colorBlindMode={colorBlindMode}
 												sessions={sessions}
+												onAgentClick={handleFilterByAgent}
+												activeFilterKey={filter?.key ?? null}
 											/>
 										</ChartErrorBoundary>
 									</div>
@@ -1183,7 +1250,7 @@ export function UsageDashboardModal({
 									>
 										<ChartErrorBoundary theme={theme} chartName="Activity Heatmap">
 											<ActivityHeatmap
-												data={data}
+												data={filteredStats ?? data}
 												timeRange={timeRange}
 												theme={theme}
 												colorBlindMode={colorBlindMode}
@@ -1210,7 +1277,7 @@ export function UsageDashboardModal({
 									>
 										<ChartErrorBoundary theme={theme} chartName="Weekday Comparison">
 											<WeekdayComparisonChart
-												data={data}
+												data={filteredStats ?? data}
 												theme={theme}
 												colorBlindMode={colorBlindMode}
 											/>
@@ -1236,7 +1303,7 @@ export function UsageDashboardModal({
 									>
 										<ChartErrorBoundary theme={theme} chartName="Duration Trends">
 											<DurationTrendsChart
-												data={data}
+												data={filteredStats ?? data}
 												timeRange={timeRange}
 												theme={theme}
 												colorBlindMode={colorBlindMode}

--- a/src/renderer/components/UsageDashboard/WeekdayComparisonChart.tsx
+++ b/src/renderer/components/UsageDashboard/WeekdayComparisonChart.tsx
@@ -117,7 +117,10 @@ export const WeekdayComparisonChart = memo(function WeekdayComparisonChart({
 	if (!hasData) {
 		return (
 			<div className="p-4 rounded-lg" style={{ backgroundColor: theme.colors.bgMain }}>
-				<h3 className="text-sm font-medium mb-4" style={{ color: theme.colors.textMain }}>
+				<h3
+					className="text-sm font-medium mb-4"
+					style={{ color: theme.colors.textMain, animation: 'card-enter 0.4s ease both' }}
+				>
 					Weekday vs Weekend
 				</h3>
 				<div

--- a/src/renderer/components/UsageDashboard/WorktreeAnalytics.tsx
+++ b/src/renderer/components/UsageDashboard/WorktreeAnalytics.tsx
@@ -1,0 +1,378 @@
+/**
+ * WorktreeAnalytics
+ *
+ * Worktree-focused analytics section in the Agents tab. Surfaces the
+ * relationship between parent agents and their worktree children:
+ *
+ *   1. Summary row — Parent vs Worktree agent counts plus a ratio badge.
+ *   2. Activity split bar — horizontal stacked bar of parent vs worktree
+ *      query proportion (worktree segment uses the dashed/striped pattern
+ *      established in Doc 1's visual language for worktree differentiation).
+ *   3. Per-branch breakdown — one row per worktree session showing the
+ *      branch name, query count, and a 7-day Sparkline, sorted by activity.
+ *
+ * The component is gated upstream so it only renders when at least one
+ * worktree session exists; it still degrades gracefully for empty data.
+ */
+
+import React, { memo, useMemo } from 'react';
+import { Layers, GitBranch } from 'lucide-react';
+import type { Theme, Session } from '../../types';
+import type { StatsAggregation } from '../../hooks/stats/useStats';
+import { getCardStyles } from './SummaryCards';
+import { Sparkline } from './Sparkline';
+import { isWorktreeAgent } from './chartUtils';
+
+const SPARKLINE_DAYS = 7;
+
+interface WorktreeAnalyticsProps {
+	/** All known sessions (terminal-only sessions are filtered out). */
+	sessions: Session[];
+	/** Aggregated stats — worktree counts come from `worktreeQueries` / `parentQueries`. */
+	data: StatsAggregation;
+	/** Current theme for color-aware styling. */
+	theme: Theme;
+}
+
+interface StatCardProps {
+	icon: React.ReactNode;
+	label: string;
+	value: number | string;
+	theme: Theme;
+	/** 0-based index for the staggered card-enter animation. */
+	animationIndex: number;
+	/** Accent override for the icon background and elevated border-top. */
+	accentColor?: string;
+}
+
+const StatCard = memo(function StatCard({
+	icon,
+	label,
+	value,
+	theme,
+	animationIndex,
+	accentColor,
+}: StatCardProps) {
+	const accent = accentColor ?? theme.colors.accent;
+	return (
+		<div
+			className="card-enter relative p-4 flex items-start gap-3"
+			style={{
+				...getCardStyles('elevated', theme, accent),
+				animationDelay: `${animationIndex * 80}ms`,
+			}}
+			data-testid="worktree-stat-card"
+			role="group"
+			aria-label={`${label}: ${value}`}
+		>
+			<div
+				className="flex-shrink-0 p-2 rounded-md"
+				style={{
+					backgroundColor: `${accent}15`,
+					color: accent,
+				}}
+			>
+				{icon}
+			</div>
+			<div className="min-w-0 flex-1">
+				<div
+					className="text-xs uppercase tracking-wide mb-1"
+					style={{ color: theme.colors.textDim }}
+				>
+					{label}
+				</div>
+				<div
+					className="font-bold"
+					style={{
+						color: theme.colors.textMain,
+						fontSize: 'clamp(18px, 3vw, 28px)',
+					}}
+				>
+					{value}
+				</div>
+			</div>
+		</div>
+	);
+});
+
+/**
+ * Pull the last `SPARKLINE_DAYS` entries' counts (oldest → newest), left-padding
+ * with zeros so sparkline geometry stays stable for sessions with fewer than
+ * seven recorded days. Mirrors the helper used by AgentOverviewCards.
+ */
+function buildSessionSparkline(sessionByDay: Array<{ count: number }> | undefined): number[] {
+	if (!sessionByDay || sessionByDay.length === 0) {
+		return new Array(SPARKLINE_DAYS).fill(0);
+	}
+	const counts = sessionByDay.slice(-SPARKLINE_DAYS).map((d) => d.count);
+	if (counts.length >= SPARKLINE_DAYS) return counts;
+	return [...new Array(SPARKLINE_DAYS - counts.length).fill(0), ...counts];
+}
+
+/**
+ * Format the worktree-to-parent ratio for the badge.
+ *
+ * Both zero → em dash; parents only → "0×"; worktrees with no parents → "∞×";
+ * otherwise `(worktrees / parents).toFixed(2)×`.
+ */
+function formatRatio(parents: number, worktrees: number): string {
+	if (parents === 0 && worktrees === 0) return '—';
+	if (parents === 0) return '∞×';
+	return `${(worktrees / parents).toFixed(2)}×`;
+}
+
+export const WorktreeAnalytics = memo(function WorktreeAnalytics({
+	sessions,
+	data,
+	theme,
+}: WorktreeAnalyticsProps) {
+	// Terminal-only sessions are not "agents" — exclude them so counts match
+	// the rest of the dashboard (SessionStats / AgentOverviewCards).
+	const agentSessions = useMemo(
+		() => sessions.filter((s) => s.toolType !== 'terminal'),
+		[sessions]
+	);
+
+	const { parentCount, worktreeCount, ratioLabel } = useMemo(() => {
+		let parents = 0;
+		let worktrees = 0;
+		for (const s of agentSessions) {
+			if (isWorktreeAgent(s)) worktrees++;
+			else parents++;
+		}
+		return {
+			parentCount: parents,
+			worktreeCount: worktrees,
+			ratioLabel: formatRatio(parents, worktrees),
+		};
+	}, [agentSessions]);
+
+	const { parentQueries, worktreeQueries, totalQueries, parentPct, worktreePct } = useMemo(() => {
+		const wq = data.worktreeQueries ?? 0;
+		const pq = data.parentQueries ?? 0;
+		const total = wq + pq;
+		return {
+			parentQueries: pq,
+			worktreeQueries: wq,
+			totalQueries: total,
+			parentPct: total > 0 ? (pq / total) * 100 : 0,
+			worktreePct: total > 0 ? (wq / total) * 100 : 0,
+		};
+	}, [data.worktreeQueries, data.parentQueries]);
+
+	const perBranch = useMemo(() => {
+		const items: Array<{ session: Session; count: number; sparkline: number[] }> = [];
+		for (const s of agentSessions) {
+			if (!isWorktreeAgent(s)) continue;
+			const sessionByDay = data.bySessionByDay?.[s.id];
+			const count = sessionByDay ? sessionByDay.reduce((sum, d) => sum + d.count, 0) : 0;
+			items.push({
+				session: s,
+				count,
+				sparkline: buildSessionSparkline(sessionByDay),
+			});
+		}
+		items.sort((a, b) => b.count - a.count);
+		return items;
+	}, [agentSessions, data.bySessionByDay]);
+
+	return (
+		<div
+			className="p-4 rounded-lg"
+			style={{ backgroundColor: theme.colors.bgMain }}
+			data-testid="worktree-analytics"
+			role="region"
+			aria-label="Worktree Analytics"
+		>
+			<div className="flex items-center justify-between mb-4">
+				<h3
+					className="text-sm font-medium"
+					style={{ color: theme.colors.textMain, animation: 'card-enter 0.4s ease both' }}
+				>
+					Worktrees
+				</h3>
+				<span
+					className="px-2 py-0.5 rounded text-[10px] font-bold uppercase tracking-wider"
+					style={{
+						backgroundColor: `${theme.colors.accent}20`,
+						color: theme.colors.accent,
+					}}
+					data-testid="worktree-ratio-badge"
+					title="Worktree-to-parent ratio"
+				>
+					{ratioLabel}
+				</span>
+			</div>
+
+			<div className="grid grid-cols-2 gap-3 mb-6">
+				<StatCard
+					icon={<Layers className="w-4 h-4" />}
+					label="Parent Agents"
+					value={parentCount}
+					theme={theme}
+					animationIndex={0}
+					accentColor={theme.colors.accent}
+				/>
+				<StatCard
+					icon={<GitBranch className="w-4 h-4" />}
+					label="Worktree Agents"
+					value={worktreeCount}
+					theme={theme}
+					animationIndex={1}
+					accentColor={theme.colors.success}
+				/>
+			</div>
+
+			<div className="mb-6" data-testid="worktree-activity-split">
+				<div
+					className="flex items-center justify-between text-[10px] uppercase tracking-wider mb-2"
+					style={{ color: theme.colors.textDim }}
+				>
+					<span>Query Activity</span>
+					<span>{totalQueries} total</span>
+				</div>
+				{totalQueries === 0 ? (
+					<div
+						className="h-7 rounded flex items-center justify-center text-xs"
+						style={{
+							backgroundColor: `${theme.colors.border}30`,
+							color: theme.colors.textDim,
+						}}
+						data-testid="worktree-split-bar-empty"
+					>
+						No query activity yet
+					</div>
+				) : (
+					<div
+						className="flex h-7 rounded overflow-hidden"
+						style={{ backgroundColor: `${theme.colors.border}30` }}
+						data-testid="worktree-split-bar"
+						role="img"
+						aria-label={`Parent ${Math.round(parentPct)}%, Worktree ${Math.round(worktreePct)}%`}
+					>
+						<div
+							className="flex items-center justify-center px-2"
+							style={{
+								width: `${parentPct}%`,
+								backgroundColor: theme.colors.accent,
+								opacity: 0.85,
+								transition: 'width 0.5s cubic-bezier(0.4, 0, 0.2, 1)',
+							}}
+							data-testid="worktree-split-parent"
+						>
+							{parentPct >= 12 && (
+								<span
+									className="text-[10px] font-medium text-white whitespace-nowrap"
+									style={{ textShadow: '0 1px 2px rgba(0,0,0,0.3)' }}
+								>
+									Parent · {parentQueries}
+								</span>
+							)}
+						</div>
+						<div
+							className="flex items-center justify-center px-2"
+							style={{
+								width: `${worktreePct}%`,
+								backgroundColor: theme.colors.success,
+								backgroundImage:
+									'repeating-linear-gradient(45deg, rgba(255,255,255,0.22) 0 4px, transparent 4px 8px)',
+								opacity: 0.85,
+								transition: 'width 0.5s cubic-bezier(0.4, 0, 0.2, 1)',
+							}}
+							data-testid="worktree-split-worktree"
+						>
+							{worktreePct >= 12 && (
+								<span
+									className="text-[10px] font-medium text-white whitespace-nowrap"
+									style={{ textShadow: '0 1px 2px rgba(0,0,0,0.3)' }}
+								>
+									Worktree · {worktreeQueries}
+								</span>
+							)}
+						</div>
+					</div>
+				)}
+			</div>
+
+			<div>
+				<h4
+					className="text-xs font-medium uppercase tracking-wider mb-3"
+					style={{ color: theme.colors.textDim }}
+				>
+					By Branch
+				</h4>
+				{perBranch.length === 0 ? (
+					<div
+						className="text-xs"
+						style={{ color: theme.colors.textDim }}
+						data-testid="worktree-branch-empty"
+					>
+						No worktree agents to display.
+					</div>
+				) : (
+					<div className="space-y-2" data-testid="worktree-branch-list">
+						{perBranch.map((entry, index) => {
+							const branch = entry.session.worktreeBranch || entry.session.name;
+							return (
+								<div
+									key={entry.session.id}
+									className="card-enter flex items-center gap-3 p-2 rounded"
+									style={{
+										backgroundColor: theme.colors.bgActivity,
+										border: `1px dashed ${theme.colors.success}66`,
+										animationDelay: `${(index + 2) * 60}ms`,
+									}}
+									data-testid="worktree-branch-row"
+									role="group"
+									aria-label={`${branch}: ${entry.count} ${
+										entry.count === 1 ? 'query' : 'queries'
+									}`}
+								>
+									<GitBranch
+										className="w-3.5 h-3.5 flex-shrink-0"
+										style={{ color: theme.colors.success }}
+										aria-hidden="true"
+									/>
+									<div className="flex-1 min-w-0">
+										<div
+											className="text-sm truncate"
+											style={{ color: theme.colors.textMain }}
+											title={branch}
+											data-testid="worktree-branch-name"
+										>
+											{branch}
+										</div>
+										<div
+											className="text-[10px] truncate"
+											style={{ color: theme.colors.textDim }}
+											title={entry.session.name}
+										>
+											{entry.session.name}
+										</div>
+									</div>
+									<div className="flex-shrink-0 opacity-80 pointer-events-none">
+										<Sparkline
+											data={entry.sparkline}
+											color={theme.colors.success}
+											width={70}
+											height={20}
+										/>
+									</div>
+									<div
+										className="w-10 text-right text-xs flex-shrink-0"
+										style={{ color: theme.colors.textDim }}
+										data-testid="worktree-branch-count"
+									>
+										{entry.count}
+									</div>
+								</div>
+							);
+						})}
+					</div>
+				)}
+			</div>
+		</div>
+	);
+});
+
+export default WorktreeAnalytics;

--- a/src/renderer/components/UsageDashboard/chartUtils.ts
+++ b/src/renderer/components/UsageDashboard/chartUtils.ts
@@ -1,0 +1,34 @@
+/**
+ * Shared utilities for UsageDashboard chart components.
+ *
+ * Worktree differentiation helpers let charts visually distinguish
+ * worktree child agents from regular agents and parent agents.
+ */
+
+import type { Session } from '../../types';
+
+/**
+ * Returns true if the session is a worktree child (was spawned from a parent agent).
+ */
+export function isWorktreeAgent(session: Session): boolean {
+	return !!session.parentSessionId;
+}
+
+/**
+ * Returns true if the session is a parent agent that manages worktree children.
+ */
+export function isParentAgent(session: Session): boolean {
+	return !!session.worktreeConfig;
+}
+
+/**
+ * Resolve a stats `sessionId` (which may include suffixes like tab IDs) to the
+ * matching Session by prefix. Returns undefined if no match is found.
+ */
+export function findSessionByStatId(
+	statSessionId: string,
+	sessions: Session[] | undefined
+): Session | undefined {
+	if (!sessions || sessions.length === 0) return undefined;
+	return sessions.find((s) => statSessionId.startsWith(s.id));
+}

--- a/src/renderer/components/UsageDashboard/chartUtils.ts
+++ b/src/renderer/components/UsageDashboard/chartUtils.ts
@@ -3,9 +3,15 @@
  *
  * Worktree differentiation helpers let charts visually distinguish
  * worktree child agents from regular agents and parent agents.
+ *
+ * Name resolution helpers translate raw stats keys (which can be either
+ * session IDs or agent type strings like "claude-code") into the user-facing
+ * names users assigned to agents in the Left Bar, so charts surface "Backend
+ * API" instead of "claude-code".
  */
 
 import type { Session } from '../../types';
+import { AGENT_DISPLAY_NAMES } from '../../../shared/agentMetadata';
 
 /**
  * Returns true if the session is a worktree child (was spawned from a parent agent).
@@ -31,4 +37,89 @@ export function findSessionByStatId(
 ): Session | undefined {
 	if (!sessions || sessions.length === 0) return undefined;
 	return sessions.find((s) => statSessionId.startsWith(s.id));
+}
+
+/**
+ * Convert an agent type string into a human-readable name.
+ *
+ * For known agent IDs ("claude-code", "factory-droid", etc.) this returns the
+ * canonical display name from `AGENT_DISPLAY_NAMES`. For anything else, the
+ * key is split on `-` and each segment capitalized so "my-custom-agent"
+ * becomes "My Custom Agent".
+ */
+export function prettifyAgentType(type: string): string {
+	if (Object.prototype.hasOwnProperty.call(AGENT_DISPLAY_NAMES, type)) {
+		return AGENT_DISPLAY_NAMES[type as keyof typeof AGENT_DISPLAY_NAMES];
+	}
+	if (!type) return type;
+	return type
+		.split('-')
+		.filter((part) => part.length > 0)
+		.map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+		.join(' ');
+}
+
+/**
+ * Resolve a single chart-data key (either a session ID or an agent type
+ * string) to a display name plus a worktree flag for visual differentiation.
+ *
+ * Resolution order:
+ *   1. Match the key against `Session.id` (with optional suffixes like tab IDs).
+ *   2. Match the key against any session's `toolType` — if a session of that
+ *      type exists, prefer that session's user-assigned name (single-instance
+ *      case) and otherwise fall through to the prettified type.
+ *   3. Fall back to `prettifyAgentType(key)`.
+ */
+export function resolveAgentDisplayName(
+	key: string,
+	sessions: Session[] | undefined
+): { name: string; isWorktree: boolean } {
+	const byId = findSessionByStatId(key, sessions);
+	if (byId) {
+		return {
+			name: byId.name || prettifyAgentType(byId.toolType),
+			isWorktree: isWorktreeAgent(byId),
+		};
+	}
+
+	if (sessions && sessions.length > 0) {
+		const matchingByType = sessions.filter((s) => s.toolType === key);
+		if (matchingByType.length === 1 && matchingByType[0].name) {
+			return {
+				name: matchingByType[0].name,
+				isWorktree: isWorktreeAgent(matchingByType[0]),
+			};
+		}
+		if (matchingByType.length > 0) {
+			return { name: prettifyAgentType(key), isWorktree: false };
+		}
+	}
+
+	return { name: prettifyAgentType(key), isWorktree: false };
+}
+
+/**
+ * Batch-resolve multiple chart keys to display names, disambiguating any
+ * duplicate names by appending ` (2)`, ` (3)`, etc. in input order.
+ *
+ * The returned map preserves the original keys so callers can look up the
+ * resolved name and worktree flag without re-running resolution.
+ */
+export function buildNameMap(
+	keys: string[],
+	sessions: Session[] | undefined
+): Map<string, { name: string; isWorktree: boolean }> {
+	const result = new Map<string, { name: string; isWorktree: boolean }>();
+	const nameCounts = new Map<string, number>();
+
+	for (const key of keys) {
+		if (result.has(key)) continue;
+		const resolved = resolveAgentDisplayName(key, sessions);
+		const seen = nameCounts.get(resolved.name) ?? 0;
+		const finalName = seen === 0 ? resolved.name : `${resolved.name} (${seen + 1})`;
+		nameCounts.set(resolved.name, seen + 1);
+		result.set(key, { name: finalName, isWorktree: resolved.isWorktree });
+	}
+
+	return result;
 }

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -2239,6 +2239,10 @@ interface MaestroAPI {
 			bySessionByDay: Record<string, Array<{ date: string; count: number; duration: number }>>;
 			worktreeQueries: number;
 			parentQueries: number;
+			byWorktreeStatus: {
+				worktree: { count: number; duration: number };
+				parent: { count: number; duration: number };
+			};
 		}>;
 		// Export query events to CSV
 		exportCsv: (range: 'day' | 'week' | 'month' | 'quarter' | 'year' | 'all') => Promise<string>;

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -2148,6 +2148,7 @@ interface MaestroAPI {
 			projectPath?: string;
 			tabId?: string;
 			isRemote?: boolean;
+			isWorktree?: boolean;
 		}) => Promise<string>;
 		// Start an Auto Run session (returns session ID)
 		startAutoRun: (session: {
@@ -2236,6 +2237,8 @@ interface MaestroAPI {
 			avgSessionDuration: number;
 			byAgentByDay: Record<string, Array<{ date: string; count: number; duration: number }>>;
 			bySessionByDay: Record<string, Array<{ date: string; count: number; duration: number }>>;
+			worktreeQueries: number;
+			parentQueries: number;
 		}>;
 		// Export query events to CSV
 		exportCsv: (range: 'day' | 'week' | 'month' | 'quarter' | 'year' | 'all') => Promise<string>;
@@ -2261,6 +2264,7 @@ interface MaestroAPI {
 			projectPath?: string;
 			createdAt: number;
 			isRemote?: boolean;
+			isWorktree?: boolean;
 		}) => Promise<string | null>;
 		// Record session closure
 		recordSessionClosed: (sessionId: string, closedAt: number) => Promise<boolean>;

--- a/src/renderer/hooks/agent/useAgentExecution.ts
+++ b/src/renderer/hooks/agent/useAgentExecution.ts
@@ -252,6 +252,7 @@ export function useAgentExecution(deps: UseAgentExecutionDeps): UseAgentExecutio
 										projectPath: effectiveCwd,
 										tabId: activeTab?.id,
 										isRemote: session.sessionSshRemoteConfig?.enabled ?? false,
+										isWorktree: !!session.parentSessionId,
 									})
 									.catch((err) => {
 										// Don't fail the batch flow if stats recording fails

--- a/src/renderer/hooks/agent/useAgentListeners.ts
+++ b/src/renderer/hooks/agent/useAgentListeners.ts
@@ -729,6 +729,7 @@ export function useAgentListeners(deps: UseAgentListenersDeps): void {
 					const isAutoRunQuery = deps.getBatchStateRef.current
 						? deps.getBatchStateRef.current(sessionIdForStats).isRunning
 						: false;
+					const sessionForStats = getSessions().find((s) => s.id === sessionIdForStats);
 
 					window.maestro.stats
 						.recordQuery({
@@ -740,6 +741,7 @@ export function useAgentListeners(deps: UseAgentListenersDeps): void {
 							projectPath: toastData.projectPath,
 							tabId: toastData.tabId,
 							isRemote: toastData.isRemote,
+							isWorktree: !!sessionForStats?.parentSessionId,
 						})
 						.catch((err) => {
 							console.warn('[onProcessExit] Failed to record query stats:', err);

--- a/src/renderer/hooks/session/useSessionCrud.ts
+++ b/src/renderer/hooks/session/useSessionCrud.ts
@@ -268,6 +268,7 @@ export function useSessionCrud(deps: UseSessionCrudDeps): UseSessionCrudReturn {
 					projectPath: workingDir,
 					createdAt: Date.now(),
 					isRemote: !!isRemoteSession,
+					isWorktree: false,
 				});
 
 				setActiveFocus('main');

--- a/src/renderer/hooks/stats/useStats.ts
+++ b/src/renderer/hooks/stats/useStats.ts
@@ -39,6 +39,15 @@ export interface StatsAggregation {
 	byAgentByDay: Record<string, Array<{ date: string; count: number; duration: number }>>;
 	// Per-session per-day breakdown for agent usage chart
 	bySessionByDay: Record<string, Array<{ date: string; count: number; duration: number }>>;
+	// Worktree breakdown (added in stats DB v5; optional so tests / older
+	// callers don't have to populate them — runtime data from the stats
+	// aggregation handler always includes these fields).
+	worktreeQueries?: number;
+	parentQueries?: number;
+	byWorktreeStatus?: {
+		worktree: { count: number; duration: number };
+		parent: { count: number; duration: number };
+	};
 }
 
 // Return type for the useStats hook

--- a/src/renderer/hooks/symphony/useSymphonyContribution.ts
+++ b/src/renderer/hooks/symphony/useSymphonyContribution.ts
@@ -225,6 +225,7 @@ export function useSymphonyContribution(
 				projectPath: data.localPath,
 				createdAt: Date.now(),
 				isRemote: false,
+				isWorktree: false,
 			});
 
 			// Focus input

--- a/src/renderer/hooks/wizard/useWizardHandlers.ts
+++ b/src/renderer/hooks/wizard/useWizardHandlers.ts
@@ -1186,6 +1186,7 @@ export function useWizardHandlers(deps: UseWizardHandlersDeps): UseWizardHandler
 				projectPath: directoryPath,
 				createdAt: Date.now(),
 				isRemote: !!sessionSshRemoteConfig?.enabled,
+				isWorktree: false,
 			});
 
 			clearResumeState();

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -229,14 +229,38 @@ textarea::placeholder {
 }
 
 /* Usage Dashboard - Staggered card entrance animation */
-@keyframes dashboard-card-enter {
+@keyframes card-enter {
 	0% {
 		opacity: 0;
-		transform: translateY(12px) scale(0.98);
+		transform: translateY(12px) scale(0.96);
 	}
 	100% {
 		opacity: 1;
 		transform: translateY(0) scale(1);
+	}
+}
+
+/* Usage Dashboard - Accent glow on hover for elevated cards */
+@keyframes card-glow {
+	0% {
+		box-shadow: 0 0 0px transparent;
+	}
+	100% {
+		box-shadow: 0 0 12px var(--glow-color, rgba(189, 147, 249, 0.15));
+	}
+}
+
+/* Bouncing dots loading indicator (for thinking / loading states) */
+@keyframes bounce-dot {
+	0%,
+	80%,
+	100% {
+		transform: scale(0.6);
+		opacity: 0.4;
+	}
+	40% {
+		transform: scale(1);
+		opacity: 1;
 	}
 }
 
@@ -257,9 +281,37 @@ textarea::placeholder {
 	animation: dashboard-content-enter 0.25s cubic-bezier(0.4, 0, 0.2, 1) forwards;
 }
 
-.dashboard-card-enter {
-	animation: dashboard-card-enter 0.3s cubic-bezier(0.4, 0, 0.2, 1) forwards;
+.card-enter {
+	animation: card-enter 0.3s cubic-bezier(0.4, 0, 0.2, 1) forwards;
 	opacity: 0;
+}
+
+/* Bouncing dots — three dots that bounce in sequence for loading / thinking */
+.bounce-dots {
+	display: inline-flex;
+	align-items: center;
+}
+
+.bounce-dots span {
+	display: inline-block;
+	width: 6px;
+	height: 6px;
+	border-radius: 9999px;
+	margin: 0 2px;
+	background-color: currentColor;
+	animation: bounce-dot 1.4s ease-in-out infinite;
+}
+
+.bounce-dots span:nth-child(1) {
+	animation-delay: 0ms;
+}
+
+.bounce-dots span:nth-child(2) {
+	animation-delay: 160ms;
+}
+
+.bounce-dots span:nth-child(3) {
+	animation-delay: 320ms;
 }
 
 .dashboard-section-enter {
@@ -734,11 +786,16 @@ svg.wand-sparkle-active path:nth-child(8) {
 
 	/* Disable Usage Dashboard state transition animations */
 	.dashboard-content-enter,
-	.dashboard-card-enter,
+	.card-enter,
 	.dashboard-section-enter {
 		animation: none !important;
 		opacity: 1 !important;
 		transform: none !important;
+	}
+
+	/* Disable bouncing dots animation for reduced motion users */
+	.bounce-dots span {
+		animation: none !important;
 	}
 
 	/* Disable Document Graph search highlight animations */

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -753,6 +753,64 @@ svg.wand-sparkle-active path:nth-child(8) {
    End Header Bar Container Queries
    ========================================== */
 
+/* ==========================================
+   Sidebar Parent-Child Tree Connectors
+   ==========================================
+   Visually links a parent agent in the sidebar to its expanded worktree
+   children with a vertical line and per-child horizontal branch.
+
+   --tree-line-color: stroke color for the connecting lines (set inline
+                      from the active theme accent)
+   --tree-bg-color:   sidebar background, used to mask the vertical line
+                      below the last child so it terminates cleanly
+*/
+
+.tree-children {
+	position: relative;
+}
+
+.tree-children::before {
+	content: '';
+	position: absolute;
+	left: 20px;
+	top: 0;
+	bottom: 12px;
+	width: 1px;
+	background-color: var(--tree-line-color, rgba(255, 255, 255, 0.15));
+	pointer-events: none;
+}
+
+.tree-child {
+	position: relative;
+}
+
+.tree-child::before {
+	content: '';
+	position: absolute;
+	left: 20px;
+	top: 50%;
+	width: 12px;
+	height: 1px;
+	background-color: var(--tree-line-color, rgba(255, 255, 255, 0.15));
+	pointer-events: none;
+}
+
+/* Cap the vertical line below the last child so it doesn't overshoot */
+.tree-child:last-child::after {
+	content: '';
+	position: absolute;
+	left: 20px;
+	top: 50%;
+	bottom: 0;
+	width: 1px;
+	background-color: var(--tree-bg-color, transparent);
+	pointer-events: none;
+}
+
+/* ==========================================
+   End Sidebar Parent-Child Tree Connectors
+   ========================================== */
+
 @media (prefers-reduced-motion: reduce) {
 	.animate-pulse,
 	.animate-spin,

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -319,6 +319,15 @@ textarea::placeholder {
 	opacity: 0;
 }
 
+.chart-clickable {
+	cursor: pointer;
+	transition: opacity 0.15s ease;
+}
+
+.chart-clickable:hover {
+	opacity: 0.8;
+}
+
 .animate-in {
 	animation: fade-in 0.2s ease-in;
 }
@@ -849,6 +858,11 @@ svg.wand-sparkle-active path:nth-child(8) {
 		animation: none !important;
 		opacity: 1 !important;
 		transform: none !important;
+	}
+
+	/* Disable chart-clickable hover transition for reduced motion */
+	.chart-clickable {
+		transition: none !important;
 	}
 
 	/* Disable bouncing dots animation for reduced motion users */

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -321,6 +321,40 @@ textarea::placeholder {
 	}
 }
 
+/* Status indicator pulse - gentler alternative to Tailwind's animate-ping.
+   Used by the AUTO badge and any status dot that wants a softer breathing effect. */
+@keyframes status-pulse {
+	0%,
+	100% {
+		opacity: 1;
+		transform: scale(1);
+	}
+	50% {
+		opacity: 0.7;
+		transform: scale(1.3);
+	}
+}
+
+/* Status indicator glow - subtle box-shadow expansion paired with a colored dot.
+   Set --status-glow-color on the element to control the hue. */
+@keyframes status-glow {
+	0%,
+	100% {
+		box-shadow: 0 0 4px var(--status-glow-color, currentColor);
+	}
+	50% {
+		box-shadow: 0 0 8px var(--status-glow-color, currentColor);
+	}
+}
+
+.animate-status-pulse {
+	animation: status-pulse 2s ease-in-out infinite;
+}
+
+.animate-status-glow {
+	animation: status-glow 2s ease-in-out infinite;
+}
+
 /* Restore list styling for markdown preview prose containers */
 .prose ul {
 	list-style-type: disc !important;
@@ -709,6 +743,12 @@ svg.wand-sparkle-active path:nth-child(8) {
 
 	/* Disable Document Graph search highlight animations */
 	.search-highlight {
+		animation: none !important;
+	}
+
+	/* Disable status indicator animations */
+	.animate-status-pulse,
+	.animate-status-glow {
 		animation: none !important;
 	}
 }

--- a/src/shared/platformDetection.ts
+++ b/src/shared/platformDetection.ts
@@ -1,26 +1,43 @@
 /**
  * Centralized platform detection utilities.
  *
- * All functions read process.platform at call time so that tests can
+ * All functions read the platform string at call time so that tests can
  * override it via Object.defineProperty(process, 'platform', { value: '...', configurable: true })
  * without module-level caching defeating the mock.
  *
  * Do NOT convert these to module-level constants.
+ *
+ * In renderer (browser) contexts there is no `process` global; the platform
+ * string is exposed via the preload bridge at `window.maestro.platform`.
+ * Touching the bare `process` identifier in renderer code throws a
+ * ReferenceError, so the lookup goes through `globalThis` instead.
  */
+
+type GlobalWithPlatform = {
+	process?: { platform?: string };
+	maestro?: { platform?: string };
+};
+
+function getPlatform(): string {
+	const g = globalThis as GlobalWithPlatform;
+	if (g.process?.platform) return g.process.platform;
+	if (g.maestro?.platform) return g.maestro.platform;
+	return 'linux';
+}
 
 /** Returns true when running on Windows (win32). */
 export function isWindows(): boolean {
-	return process.platform === 'win32';
+	return getPlatform() === 'win32';
 }
 
 /** Returns true when running on macOS (darwin). */
 export function isMacOS(): boolean {
-	return process.platform === 'darwin';
+	return getPlatform() === 'darwin';
 }
 
 /** Returns true when running on Linux. */
 export function isLinux(): boolean {
-	return process.platform === 'linux';
+	return getPlatform() === 'linux';
 }
 
 /**

--- a/src/shared/stats-types.ts
+++ b/src/shared/stats-types.ts
@@ -105,6 +105,11 @@ export interface StatsAggregation {
 	worktreeQueries: number;
 	/** Count of queries originating from parent (non-worktree) agents */
 	parentQueries: number;
+	/** Detailed worktree breakdown including duration totals (for activity split bar) */
+	byWorktreeStatus: {
+		worktree: { count: number; duration: number };
+		parent: { count: number; duration: number };
+	};
 }
 
 /**

--- a/src/shared/stats-types.ts
+++ b/src/shared/stats-types.ts
@@ -101,6 +101,10 @@ export interface StatsAggregation {
 	byAgentByDay: Record<string, Array<{ date: string; count: number; duration: number }>>;
 	/** Queries and duration by Maestro session per day (for agent usage chart) */
 	bySessionByDay: Record<string, Array<{ date: string; count: number; duration: number }>>;
+	/** Count of queries originating from worktree (child) agents */
+	worktreeQueries: number;
+	/** Count of queries originating from parent (non-worktree) agents */
+	parentQueries: number;
 }
 
 /**

--- a/src/shared/stats-types.ts
+++ b/src/shared/stats-types.ts
@@ -18,6 +18,8 @@ export interface QueryEvent {
 	tabId?: string;
 	/** Whether this query was executed on a remote SSH session */
 	isRemote?: boolean;
+	/** Whether this query came from a worktree session (child of a parent agent) */
+	isWorktree?: boolean;
 }
 
 /**
@@ -64,6 +66,8 @@ export interface SessionLifecycleEvent {
 	duration?: number;
 	/** Whether this was a remote SSH session */
 	isRemote?: boolean;
+	/** Whether this session is a worktree (child of a parent agent) */
+	isWorktree?: boolean;
 }
 
 /**
@@ -112,4 +116,4 @@ export interface StatsFilters {
 /**
  * Database schema version for migrations
  */
-export const STATS_DB_VERSION = 4;
+export const STATS_DB_VERSION = 5;


### PR DESCRIPTION
## Summary

Major Usage Dashboard expansion across 42 commits, organized into themed slices:

- **Worktree analytics** — `is_worktree` column + migration v5; per-worktree-status duration breakdown in stats aggregation; `WorktreeAnalytics` section in the Agents tab (parent vs. worktree summary cards, activity split bar) gated on the presence of worktree sessions; charts visually differentiate worktrees; sidebar adds tree connector lines + chevron/count badge for collapsing worktree children.
- **Status indicators** — `getEnhancedStatusColor` helper consolidates state→color/animation mapping; busy state migrates from in-place `animate-pulse` dot to a separate `animate-ping` ring behind a static dot, with `0 0 6px ${color}60` glow; AUTO badge gets `animate-status-pulse`; SummaryCards gain a per-agent status breakdown.
- **MetricCard system** — refactored to a variant-based design (`elevated` etc.) with hover state + accent line; new `BouncingDots` and `AnimatedNumber` primitives; `card-enter` and `bounce-dot` keyframes; 7-day sparklines on Total Queries / Total Time; new `ContextUsageBar`, `TokenCostBadge`, and `RealtimeMetricsCard` summarising live context %, current-cycle token cost, and elapsed thinking time across active agents.
- **Agent name resolution** — shared `buildNameMap` helpers in `chartUtils` route display-name resolution through `AgentComparisonChart`, `AgentEfficiencyChart`, `AgentUsageChart`, and `SessionStats` so renamed/custom agents render consistently.
- **AgentOverviewCards** — new top-of-overview row with per-agent status, branch, sparkline, and a 2px accent border highlight that mirrors `AgentComparisonChart`'s drill-down selection.
- **Interactive drill-down filter** — `DashboardFilter` state + `filterStatsForAgent` utility (filters `byAgent` / `byAgentByDay` / `bySessionByDay` and recalculates totals) + filtered-stats `useMemo`; click any agent bar/line/legend item to filter every chart in the modal; non-selected entries dim to 0.15–0.5 opacity, selected entry gets stroke-thickening + accent legend background; ActivityHeatmap, PeakHoursChart, WeekdayComparisonChart get a `FilteredChartPlaceholder` (with Clear button) instead of stale data; Escape clears the filter via the layer stack before falling through to modal close; filter resets on time-range/tab change so a stale filter never hides every chart.
- **Polish + cleanup (this session's last two commits)** — `card-enter 0.4s ease both` on chart `<h3>` titles across 10 chart components; merge conflict resolution in `FileExplorerPanel.tsx`; ESLint warning fix (unused `e` in catch); test mock additions for newly imported `lucide-react` icons; chart-accessibility test re-scoping to `getAllByTestId('metric-card')` to accommodate the 11th `role="group"` (RealtimeMetricsCard); SessionList test asserts `.animate-ping` instead of `.animate-pulse` and supplies `agentSessionId` to exercise the busy path; prettier-drift tidy on `docs/releases.md` and `useAgentListeners.test.ts`.

## Verification

- ``npm run lint`` clean (3 tsconfigs).
- ``npm run lint:eslint`` clean (0 errors, 0 warnings).
- ``npm run format:check:all`` clean.
- ``npx vitest run`` clean: **22678 / 22678 passed**, 107 skipped, 0 failed.
- ``validate:push`` pre-push hook passes end-to-end (build:prompts → format:check → lint → lint:eslint → full vitest run).

## Test plan

- [ ] Open Usage Dashboard → Overview: verify `AgentOverviewCards` renders above the summary, sparklines populate, status colors match agent state.
- [ ] Click an agent in `AgentComparisonChart`: verify drill-down filter activates, every chart updates, non-selected entries dim to 0.15–0.5 opacity, ActivityHeatmap / PeakHoursChart / WeekdayComparisonChart show `FilteredChartPlaceholder` with a working Clear button.
- [ ] With filter active, change the time range or switch tabs: verify filter clears automatically.
- [ ] With filter active, press Escape: verify filter clears (modal stays open). Press Escape again: modal closes.
- [ ] Open a worktree session: verify `WorktreeAnalytics` appears in Agents tab; verify chevron/count badge in sidebar toggles children visibility; verify worktree row visual differentiation.
- [ ] Drive an active AI session: verify `RealtimeMetricsCard` updates `ContextUsageBar`, `TokenCostBadge`, and elapsed-thinking-time live (1s tick); verify `AnimatedNumber` count-ups on summary cards.
- [ ] Light vs dark theme: confirm new accent borders, glows, and animated states render correctly in both.
- [ ] SSH remote agent: confirm worktree analytics + status indicators behave the same as local.
- [ ] Reduced motion preference: confirm `.chart-clickable` and other animations respect the reduced-motion override.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added worktree analytics visualization with parent vs. child agent breakdown and activity heatmaps.
  * Introduced agent overview cards with live status indicators and 7-day query sparklines.
  * Added real-time metrics card showing context usage, token cost estimates, and active agent count.
  * Enabled drill-down filtering on dashboard charts to isolate specific agent analytics.
  * Enhanced session status display with improved busy animations and disconnected state indicators.

* **Bug Fixes**
  * Improved filesystem watcher stability by filtering Windows locked system files and handling watch errors gracefully.
  * Enhanced platform detection fallback for renderer context.

* **Tests**
  * Expanded test coverage across dashboard components and stats aggregation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->