### PR TITLE
refactor(events): unify listener hygiene + add leak regression net

### DIFF
--- a/src/__tests__/helpers/listenerLeakAssertions.ts
+++ b/src/__tests__/helpers/listenerLeakAssertions.ts
@@ -1,0 +1,89 @@
+/**
+ * Test helpers for verifying that DOM event listeners attached to a target
+ * are removed by the time the component is unmounted.
+ *
+ * Usage:
+ *   const target = document; // or window, or an element
+ *   const { addSpy, removeSpy } = spyOnListeners(target);
+ *   const { unmount } = render(<MyComponent />);
+ *   unmount();
+ *   expectAllListenersRemoved(addSpy, removeSpy);
+ *
+ * The assertion verifies that every (eventType, listener) pair passed to
+ * addEventListener was later passed to removeEventListener with the same
+ * listener reference. Anonymous-handler leaks are caught because we compare
+ * by identity, not name.
+ */
+
+import { vi, type MockInstance } from 'vitest';
+
+export type AddListenerSpy = MockInstance<typeof EventTarget.prototype.addEventListener>;
+export type RemoveListenerSpy = MockInstance<typeof EventTarget.prototype.removeEventListener>;
+
+export interface ListenerSpyHandles {
+	addSpy: AddListenerSpy;
+	removeSpy: RemoveListenerSpy;
+	/** Restore the original methods. Idempotent. */
+	restore: () => void;
+}
+
+/**
+ * Spy on `addEventListener` and `removeEventListener` of the given target.
+ * The originals are still invoked via vi.spyOn's default behaviour, so
+ * listeners attached during the test still fire.
+ */
+export function spyOnListeners(target: EventTarget = document): ListenerSpyHandles {
+	const addSpy = vi.spyOn(target, 'addEventListener') as AddListenerSpy;
+	const removeSpy = vi.spyOn(target, 'removeEventListener') as RemoveListenerSpy;
+	return {
+		addSpy,
+		removeSpy,
+		restore: () => {
+			addSpy.mockRestore();
+			removeSpy.mockRestore();
+		},
+	};
+}
+
+/**
+ * Throw if any (eventType, listener) pair added via addEventListener was not
+ * later passed to removeEventListener with the same listener reference.
+ *
+ * If the same pair was added more than once (rare but legal), each add
+ * needs a matching remove — this is a count-aware multiset comparison.
+ */
+export function expectAllListenersRemoved(
+	addSpy: AddListenerSpy,
+	removeSpy: RemoveListenerSpy
+): void {
+	const added = addSpy.mock.calls.map(([eventType, listener]) => ({
+		eventType: String(eventType),
+		listener,
+	}));
+	const removed = removeSpy.mock.calls.map(([eventType, listener]) => ({
+		eventType: String(eventType),
+		listener,
+	}));
+
+	const remaining = [...removed];
+	const leaked: Array<{ eventType: string }> = [];
+
+	for (const add of added) {
+		const idx = remaining.findIndex(
+			(r) => r.eventType === add.eventType && r.listener === add.listener
+		);
+		if (idx === -1) {
+			leaked.push({ eventType: add.eventType });
+		} else {
+			remaining.splice(idx, 1);
+		}
+	}
+
+	if (leaked.length > 0) {
+		const summary = leaked.map((l) => l.eventType).join(', ');
+		throw new Error(
+			`Listener leak: ${leaked.length} listener(s) added but never removed [${summary}]. ` +
+				`Total adds: ${added.length}, total removes: ${removed.length}.`
+		);
+	}
+}

--- a/src/__tests__/helpers/listenerLeakAssertions.ts
+++ b/src/__tests__/helpers/listenerLeakAssertions.ts
@@ -9,10 +9,12 @@
  *   unmount();
  *   expectAllListenersRemoved(addSpy, removeSpy);
  *
- * The assertion verifies that every (eventType, listener) pair passed to
- * addEventListener was later passed to removeEventListener with the same
- * listener reference. Anonymous-handler leaks are caught because we compare
- * by identity, not name.
+ * The assertion verifies that every (eventType, listener, capture) triple
+ * passed to addEventListener was later passed to removeEventListener with
+ * matching identity. Per DOM spec, only the `capture` flag from the options
+ * bag (or the legacy boolean `useCapture`) participates in listener identity
+ * — `passive`, `once`, `signal` do not. Anonymous-handler leaks are caught
+ * because we compare listener references by identity, not by name.
  */
 
 import { vi, type MockInstance } from 'vitest';
@@ -46,41 +48,61 @@ export function spyOnListeners(target: EventTarget = document): ListenerSpyHandl
 }
 
 /**
- * Throw if any (eventType, listener) pair added via addEventListener was not
- * later passed to removeEventListener with the same listener reference.
+ * Normalize the third argument to addEventListener / removeEventListener
+ * (which can be `undefined`, a boolean useCapture flag, or an
+ * AddEventListenerOptions object) into the single `capture` boolean that
+ * actually participates in listener identity per the DOM spec.
+ */
+function getCaptureFlag(options: unknown): boolean {
+	if (typeof options === 'boolean') return options;
+	if (options !== null && typeof options === 'object' && 'capture' in options) {
+		return Boolean((options as { capture?: unknown }).capture);
+	}
+	return false;
+}
+
+/**
+ * Throw if any (eventType, listener, capture) triple added via
+ * addEventListener was not later passed to removeEventListener with matching
+ * identity. A listener registered with `{ capture: true }` and removed
+ * without options is correctly reported as a leak — the spec treats those
+ * as two different listener registrations.
  *
- * If the same pair was added more than once (rare but legal), each add
+ * If the same triple was added more than once (rare but legal), each add
  * needs a matching remove — this is a count-aware multiset comparison.
  */
 export function expectAllListenersRemoved(
 	addSpy: AddListenerSpy,
 	removeSpy: RemoveListenerSpy
 ): void {
-	const added = addSpy.mock.calls.map(([eventType, listener]) => ({
+	const added = addSpy.mock.calls.map(([eventType, listener, options]) => ({
 		eventType: String(eventType),
 		listener,
+		capture: getCaptureFlag(options),
 	}));
-	const removed = removeSpy.mock.calls.map(([eventType, listener]) => ({
+	const removed = removeSpy.mock.calls.map(([eventType, listener, options]) => ({
 		eventType: String(eventType),
 		listener,
+		capture: getCaptureFlag(options),
 	}));
 
 	const remaining = [...removed];
-	const leaked: Array<{ eventType: string }> = [];
+	const leaked: Array<{ eventType: string; capture: boolean }> = [];
 
 	for (const add of added) {
 		const idx = remaining.findIndex(
-			(r) => r.eventType === add.eventType && r.listener === add.listener
+			(r) =>
+				r.eventType === add.eventType && r.listener === add.listener && r.capture === add.capture
 		);
 		if (idx === -1) {
-			leaked.push({ eventType: add.eventType });
+			leaked.push({ eventType: add.eventType, capture: add.capture });
 		} else {
 			remaining.splice(idx, 1);
 		}
 	}
 
 	if (leaked.length > 0) {
-		const summary = leaked.map((l) => l.eventType).join(', ');
+		const summary = leaked.map((l) => `${l.eventType}${l.capture ? ' (capture)' : ''}`).join(', ');
 		throw new Error(
 			`Listener leak: ${leaked.length} listener(s) added but never removed [${summary}]. ` +
 				`Total adds: ${added.length}, total removes: ${removed.length}.`

--- a/src/__tests__/renderer/components/ExecutionQueueBrowser.test.tsx
+++ b/src/__tests__/renderer/components/ExecutionQueueBrowser.test.tsx
@@ -10,6 +10,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, within } from '@testing-library/react';
 import { ExecutionQueueBrowser } from '../../../renderer/components/ExecutionQueueBrowser';
 import type { Session, Theme, QueuedItem } from '../../../renderer/types';
+import { spyOnListeners, expectAllListenersRemoved } from '../../helpers/listenerLeakAssertions';
 
 // Mock the LayerStackContext
 const mockRegisterLayer = vi.fn().mockReturnValue('layer-1');
@@ -1883,6 +1884,54 @@ describe('ExecutionQueueBrowser', () => {
 			// The outer wrapper divs (with onMouseMove for drop targeting) should exist
 			const wrappers = container.querySelectorAll('.relative.my-1');
 			expect(wrappers.length).toBe(2);
+		});
+
+		it('does not attach window keydown/mouseup listeners while idle', () => {
+			const spies = spyOnListeners(window);
+			const session = createSession({
+				id: 'active-session',
+				executionQueue: [createQueuedItem({ id: 'item-1' }), createQueuedItem({ id: 'item-2' })],
+			});
+			render(
+				<ExecutionQueueBrowser
+					isOpen={true}
+					onClose={mockOnClose}
+					sessions={[session]}
+					activeSessionId="active-session"
+					theme={theme}
+					onRemoveItem={mockOnRemoveItem}
+					onSwitchSession={mockOnSwitchSession}
+					onReorderItems={mockOnReorderItems}
+				/>
+			);
+			const keydownAdds = spies.addSpy.mock.calls.filter(([t]) => t === 'keydown');
+			const mouseupAdds = spies.addSpy.mock.calls.filter(([t]) => t === 'mouseup');
+			expect(keydownAdds).toHaveLength(0);
+			expect(mouseupAdds).toHaveLength(0);
+			spies.restore();
+		});
+
+		it('does not leak listeners when unmounted while idle', () => {
+			const spies = spyOnListeners(window);
+			const session = createSession({
+				id: 'active-session',
+				executionQueue: [createQueuedItem({ id: 'item-1' }), createQueuedItem({ id: 'item-2' })],
+			});
+			const { unmount } = render(
+				<ExecutionQueueBrowser
+					isOpen={true}
+					onClose={mockOnClose}
+					sessions={[session]}
+					activeSessionId="active-session"
+					theme={theme}
+					onRemoveItem={mockOnRemoveItem}
+					onSwitchSession={mockOnSwitchSession}
+					onReorderItems={mockOnReorderItems}
+				/>
+			);
+			unmount();
+			expectAllListenersRemoved(spies.addSpy, spies.removeSpy);
+			spies.restore();
 		});
 	});
 });

--- a/src/__tests__/renderer/components/FileExplorerPanel.test.tsx
+++ b/src/__tests__/renderer/components/FileExplorerPanel.test.tsx
@@ -7,6 +7,7 @@ import type { Session, Theme } from '../../../renderer/types';
 import { createMockSession as baseCreateMockSession } from '../../helpers/mockSession';
 
 import { mockTheme } from '../../helpers/mockTheme';
+import { spyOnListeners, expectAllListenersRemoved } from '../../helpers/listenerLeakAssertions';
 // Mock lucide-react
 vi.mock('lucide-react', () => ({
 	ChevronRight: ({ className, style }: { className?: string; style?: React.CSSProperties }) => (
@@ -2208,6 +2209,50 @@ describe('FileExplorerPanel', () => {
 			// Focus behavior with requestAnimationFrame is tested elsewhere
 			const cancelButton = screen.getByText('Cancel');
 			expect(cancelButton).toBeInTheDocument();
+		});
+
+		it('does not attach a window keydown listener until the menu is opened', () => {
+			const spies = spyOnListeners(window);
+			render(<FileExplorerPanel {...defaultProps} />);
+			const keydownAdds = spies.addSpy.mock.calls.filter(([t]) => t === 'keydown');
+			expect(keydownAdds).toHaveLength(0);
+			spies.restore();
+		});
+
+		it('closes the context menu on Escape', () => {
+			const { container } = render(<FileExplorerPanel {...defaultProps} />);
+			const fileItem = Array.from(container.querySelectorAll('[data-file-index]')).find((el) =>
+				el.textContent?.includes('package.json')
+			);
+			fireEvent.contextMenu(fileItem!, { clientX: 100, clientY: 200 });
+			expect(screen.getByText('Copy Path')).toBeInTheDocument();
+
+			fireEvent.keyDown(window, { key: 'Escape' });
+			expect(screen.queryByText('Copy Path')).not.toBeInTheDocument();
+		});
+
+		it('removes its keydown listener after the menu closes (no leak)', () => {
+			const spies = spyOnListeners(window);
+			const { container } = render(<FileExplorerPanel {...defaultProps} />);
+			const fileItem = Array.from(container.querySelectorAll('[data-file-index]')).find((el) =>
+				el.textContent?.includes('package.json')
+			);
+			fireEvent.contextMenu(fileItem!, { clientX: 100, clientY: 200 });
+			fireEvent.keyDown(window, { key: 'Escape' });
+			expectAllListenersRemoved(spies.addSpy, spies.removeSpy);
+			spies.restore();
+		});
+
+		it('removes its keydown listener on unmount with menu open (no leak)', () => {
+			const spies = spyOnListeners(window);
+			const { container, unmount } = render(<FileExplorerPanel {...defaultProps} />);
+			const fileItem = Array.from(container.querySelectorAll('[data-file-index]')).find((el) =>
+				el.textContent?.includes('package.json')
+			);
+			fireEvent.contextMenu(fileItem!, { clientX: 100, clientY: 200 });
+			unmount();
+			expectAllListenersRemoved(spies.addSpy, spies.removeSpy);
+			spies.restore();
 		});
 	});
 });

--- a/src/__tests__/renderer/components/GroupChatList.test.tsx
+++ b/src/__tests__/renderer/components/GroupChatList.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * Tests for GroupChatList — left-sidebar list of Group Chats.
+ *
+ * Characterization tests for Tier 2 listener-hygiene refactor: pin down the
+ * GroupChatContextMenu Escape-key behaviour and listener cleanup before
+ * swapping to useEventListener.
+ */
+
+import { render, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { GroupChatList } from '../../../renderer/components/GroupChatList';
+import { mockTheme } from '../../helpers/mockTheme';
+import { spyOnListeners, expectAllListenersRemoved } from '../../helpers/listenerLeakAssertions';
+import type { GroupChat } from '../../../shared/group-chat-types';
+
+// Stub the click-outside hook so we only measure the context menu's own keydown
+// listener in the leak assertion.
+vi.mock('../../../renderer/hooks', async (orig) => {
+	const actual = await (orig as () => Promise<Record<string, unknown>>)();
+	return {
+		...actual,
+		useClickOutside: vi.fn(),
+		useContextMenuPosition: () => ({ left: 0, top: 0, ready: true }),
+	};
+});
+
+const baseChat: GroupChat = {
+	id: 'gc-1',
+	name: 'Test Chat',
+	createdAt: 1,
+	moderatorAgentId: 'claude-code',
+	moderatorSessionId: 'group-chat-gc-1-moderator',
+	participants: [],
+	logPath: '/tmp/log',
+	imagesDir: '/tmp/imgs',
+};
+
+function renderList(overrides: Partial<Parameters<typeof GroupChatList>[0]> = {}) {
+	const defaults = {
+		theme: mockTheme,
+		groupChats: [baseChat],
+		activeGroupChatId: null,
+		onOpenGroupChat: vi.fn(),
+		onNewGroupChat: vi.fn(),
+		onEditGroupChat: vi.fn(),
+		onRenameGroupChat: vi.fn(),
+		onDeleteGroupChat: vi.fn(),
+	} as const;
+	return render(<GroupChatList {...defaults} {...overrides} />);
+}
+
+function openContextMenu(container: HTMLElement) {
+	// Walk up from the chat name to the row element that owns the onContextMenu
+	// handler (the row has py-1.5; the section header has py-2 — distinguish by
+	// closeting on the cursor-pointer class plus walking up from the name).
+	const nameSpan = container.querySelector('span.text-sm.truncate');
+	expect(nameSpan).not.toBeNull();
+	const row = (nameSpan as HTMLElement).closest('[class*="cursor-pointer"]');
+	expect(row).not.toBeNull();
+	fireEvent.contextMenu(row as HTMLElement, { clientX: 50, clientY: 50 });
+}
+
+describe('GroupChatList', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('renders the list with a single chat', () => {
+		const { getByText } = renderList();
+		expect(getByText('Test Chat')).toBeInTheDocument();
+	});
+
+	it('does not mount the context-menu keydown listener until right-clicked', () => {
+		const spies = spyOnListeners(document);
+		renderList();
+		const keydownAdds = spies.addSpy.mock.calls.filter(([t]) => t === 'keydown');
+		expect(keydownAdds).toHaveLength(0);
+		spies.restore();
+	});
+
+	it('closes the context menu on Escape after right-click', () => {
+		const { container, queryByText } = renderList();
+		openContextMenu(container);
+		expect(queryByText('Edit')).toBeInTheDocument();
+
+		fireEvent.keyDown(document, { key: 'Escape' });
+		expect(queryByText('Edit')).not.toBeInTheDocument();
+	});
+
+	it('removes the context-menu keydown listener after Escape closes the menu', () => {
+		const spies = spyOnListeners(document);
+		const { container } = renderList();
+		openContextMenu(container);
+		fireEvent.keyDown(document, { key: 'Escape' });
+		expectAllListenersRemoved(spies.addSpy, spies.removeSpy);
+		spies.restore();
+	});
+
+	it('removes the context-menu keydown listener on unmount', () => {
+		const spies = spyOnListeners(document);
+		const { container, unmount } = renderList();
+		openContextMenu(container);
+		unmount();
+		expectAllListenersRemoved(spies.addSpy, spies.removeSpy);
+		spies.restore();
+	});
+});

--- a/src/__tests__/renderer/components/HistoryDetailModal.test.tsx
+++ b/src/__tests__/renderer/components/HistoryDetailModal.test.tsx
@@ -5,6 +5,7 @@ import type { Theme, HistoryEntry } from '../../../renderer/types';
 import { useSettingsStore } from '../../../renderer/stores/settingsStore';
 
 import { mockTheme } from '../../helpers/mockTheme';
+import { spyOnListeners, expectAllListenersRemoved } from '../../helpers/listenerLeakAssertions';
 // Mock LayerStackContext
 const mockRegisterLayer = vi.fn(() => 'layer-id-1');
 const mockUnregisterLayer = vi.fn();
@@ -1177,6 +1178,40 @@ describe('HistoryDetailModal', () => {
 			fireEvent.keyDown(window, { key: 'ArrowRight' });
 
 			expect(mockOnNavigate).not.toHaveBeenCalled();
+		});
+
+		it('should not call onNavigate after unmount', () => {
+			const { unmount } = render(
+				<HistoryDetailModal
+					theme={mockTheme}
+					entry={mockEntries[1]}
+					onClose={mockOnClose}
+					filteredEntries={mockEntries}
+					currentIndex={1}
+					onNavigate={mockOnNavigate}
+				/>
+			);
+			unmount();
+			fireEvent.keyDown(window, { key: 'ArrowLeft' });
+			fireEvent.keyDown(window, { key: 'ArrowRight' });
+			expect(mockOnNavigate).not.toHaveBeenCalled();
+		});
+
+		it('should remove its keydown listener on unmount (no leak)', () => {
+			const spies = spyOnListeners(window);
+			const { unmount } = render(
+				<HistoryDetailModal
+					theme={mockTheme}
+					entry={mockEntries[1]}
+					onClose={mockOnClose}
+					filteredEntries={mockEntries}
+					currentIndex={1}
+					onNavigate={mockOnNavigate}
+				/>
+			);
+			unmount();
+			expectAllListenersRemoved(spies.addSpy, spies.removeSpy);
+			spies.restore();
 		});
 	});
 

--- a/src/__tests__/renderer/components/KeyboardMasteryCelebration.test.tsx
+++ b/src/__tests__/renderer/components/KeyboardMasteryCelebration.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * Tests for KeyboardMasteryCelebration — the confetti modal that appears when
+ * the user reaches a new keyboard mastery level.
+ *
+ * Characterization tests for Tier 2 listener-hygiene refactor: pin down the
+ * keydown handling and listener cleanup before swapping to useEventListener.
+ */
+
+import { render, fireEvent, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { KeyboardMasteryCelebration } from '../../../renderer/components/KeyboardMasteryCelebration';
+import { mockTheme } from '../../helpers/mockTheme';
+import { spyOnListeners, expectAllListenersRemoved } from '../../helpers/listenerLeakAssertions';
+
+// Confetti is a side-effect-only canvas library; render it as a no-op in tests.
+vi.mock('canvas-confetti', () => ({
+	default: vi.fn(),
+}));
+
+// useModalLayer registers with the layer stack — we don't care about that here.
+vi.mock('../../../renderer/hooks/ui/useModalLayer', () => ({
+	useModalLayer: vi.fn(),
+}));
+
+describe('KeyboardMasteryCelebration', () => {
+	let onClose: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		onClose = vi.fn();
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('renders the level title', () => {
+		const { getByText } = render(
+			<KeyboardMasteryCelebration theme={mockTheme} level={1} onClose={onClose} disableConfetti />
+		);
+		expect(getByText('Level Up!')).toBeInTheDocument();
+	});
+
+	it('shows Maestro title at level 4', () => {
+		const { getByText } = render(
+			<KeyboardMasteryCelebration theme={mockTheme} level={4} onClose={onClose} disableConfetti />
+		);
+		expect(getByText('Keyboard Maestro!')).toBeInTheDocument();
+	});
+
+	it('closes on Enter keydown', () => {
+		vi.useFakeTimers();
+		render(
+			<KeyboardMasteryCelebration theme={mockTheme} level={1} onClose={onClose} disableConfetti />
+		);
+		fireEvent.keyDown(window, { key: 'Enter' });
+		// handleClose schedules an 800ms close via setTimeout; advance timers.
+		act(() => {
+			vi.advanceTimersByTime(800);
+		});
+		expect(onClose).toHaveBeenCalledTimes(1);
+		vi.useRealTimers();
+	});
+
+	it('closes on Escape keydown', () => {
+		vi.useFakeTimers();
+		render(
+			<KeyboardMasteryCelebration theme={mockTheme} level={1} onClose={onClose} disableConfetti />
+		);
+		fireEvent.keyDown(window, { key: 'Escape' });
+		act(() => {
+			vi.advanceTimersByTime(800);
+		});
+		expect(onClose).toHaveBeenCalledTimes(1);
+		vi.useRealTimers();
+	});
+
+	it('ignores other keydowns', () => {
+		vi.useFakeTimers();
+		render(
+			<KeyboardMasteryCelebration theme={mockTheme} level={1} onClose={onClose} disableConfetti />
+		);
+		fireEvent.keyDown(window, { key: 'a' });
+		fireEvent.keyDown(window, { key: 'ArrowDown' });
+		act(() => {
+			vi.advanceTimersByTime(2000);
+		});
+		expect(onClose).not.toHaveBeenCalled();
+		vi.useRealTimers();
+	});
+
+	it('does not call onClose after unmount', () => {
+		vi.useFakeTimers();
+		const { unmount } = render(
+			<KeyboardMasteryCelebration theme={mockTheme} level={1} onClose={onClose} disableConfetti />
+		);
+		unmount();
+		fireEvent.keyDown(window, { key: 'Enter' });
+		fireEvent.keyDown(window, { key: 'Escape' });
+		act(() => {
+			vi.advanceTimersByTime(2000);
+		});
+		expect(onClose).not.toHaveBeenCalled();
+		vi.useRealTimers();
+	});
+
+	it('removes its keydown listener on unmount (no leak)', () => {
+		const spies = spyOnListeners(window);
+		const { unmount } = render(
+			<KeyboardMasteryCelebration theme={mockTheme} level={1} onClose={onClose} disableConfetti />
+		);
+		unmount();
+		expectAllListenersRemoved(spies.addSpy, spies.removeSpy);
+		spies.restore();
+	});
+});

--- a/src/__tests__/renderer/components/NotificationPopover.test.tsx
+++ b/src/__tests__/renderer/components/NotificationPopover.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * Tests for NotificationPopover — popover for toggling notification types.
+ *
+ * Characterization tests for Tier 2 listener-hygiene refactor: pin down the
+ * Escape-key dismissal and listener cleanup before swapping to useEventListener.
+ */
+
+import { useRef, type RefObject } from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { NotificationPopover } from '../../../renderer/components/NotificationPopover';
+import { mockTheme } from '../../helpers/mockTheme';
+import { spyOnListeners, expectAllListenersRemoved } from '../../helpers/listenerLeakAssertions';
+
+// useClickOutside also attaches listeners; stub it so we only measure the
+// popover's own keydown listener in the leak assertion.
+vi.mock('../../../renderer/hooks/ui/useClickOutside', () => ({
+	useClickOutside: vi.fn(),
+}));
+
+// Test harness: provide an anchor ref backed by a real element so the popover
+// can measure its bounding rect and render.
+function Harness({ onClose }: { onClose: () => void }) {
+	const anchorRef = useRef<HTMLButtonElement>(null);
+	return (
+		<>
+			<button ref={anchorRef} data-testid="anchor">
+				anchor
+			</button>
+			<NotificationPopover
+				theme={mockTheme}
+				anchorRef={anchorRef as RefObject<HTMLElement | null>}
+				onClose={onClose}
+			/>
+		</>
+	);
+}
+
+describe('NotificationPopover', () => {
+	let onClose: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		onClose = vi.fn();
+		// Provide a non-zero rect so the popover renders (it bails out if rect is null).
+		HTMLElement.prototype.getBoundingClientRect = vi.fn(() => ({
+			top: 100,
+			left: 100,
+			right: 200,
+			bottom: 150,
+			width: 100,
+			height: 50,
+			x: 100,
+			y: 100,
+			toJSON: () => ({}),
+		})) as never;
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('calls onClose on Escape key', () => {
+		render(<Harness onClose={onClose} />);
+		fireEvent.keyDown(document, { key: 'Escape' });
+		expect(onClose).toHaveBeenCalledTimes(1);
+	});
+
+	it('ignores non-Escape keys', () => {
+		render(<Harness onClose={onClose} />);
+		fireEvent.keyDown(document, { key: 'Enter' });
+		fireEvent.keyDown(document, { key: 'a' });
+		fireEvent.keyDown(document, { key: 'ArrowDown' });
+		expect(onClose).not.toHaveBeenCalled();
+	});
+
+	it('does not call onClose after unmount', () => {
+		const { unmount } = render(<Harness onClose={onClose} />);
+		unmount();
+		fireEvent.keyDown(document, { key: 'Escape' });
+		expect(onClose).not.toHaveBeenCalled();
+	});
+
+	it('removes its keydown listener on unmount (no leak)', () => {
+		const spies = spyOnListeners(document);
+		const { unmount } = render(<Harness onClose={onClose} />);
+		unmount();
+		expectAllListenersRemoved(spies.addSpy, spies.removeSpy);
+		spies.restore();
+	});
+});

--- a/src/__tests__/renderer/components/NotificationPopover.test.tsx
+++ b/src/__tests__/renderer/components/NotificationPopover.test.tsx
@@ -88,9 +88,15 @@ describe('NotificationPopover', () => {
 
 	it('removes its keydown listener on unmount (no leak)', () => {
 		const spies = spyOnListeners(document);
-		const { unmount } = render(<Harness onClose={onClose} />);
-		unmount();
-		expectAllListenersRemoved(spies.addSpy, spies.removeSpy);
-		spies.restore();
+		try {
+			const { unmount } = render(<Harness onClose={onClose} />);
+			unmount();
+			expectAllListenersRemoved(spies.addSpy, spies.removeSpy);
+		} finally {
+			// Restore in finally so the document spy is undone even if the
+			// assertion throws — otherwise the prototype patch leaks into the
+			// next test in this worker.
+			spies.restore();
+		}
 	});
 });

--- a/src/__tests__/renderer/components/NotificationPopover.test.tsx
+++ b/src/__tests__/renderer/components/NotificationPopover.test.tsx
@@ -38,10 +38,15 @@ function Harness({ onClose }: { onClose: () => void }) {
 
 describe('NotificationPopover', () => {
 	let onClose: ReturnType<typeof vi.fn>;
+	let originalGetBoundingClientRect: typeof HTMLElement.prototype.getBoundingClientRect;
 
 	beforeEach(() => {
 		onClose = vi.fn();
 		// Provide a non-zero rect so the popover renders (it bails out if rect is null).
+		// Save the original so we can restore it in afterEach — vi.clearAllMocks()
+		// does NOT undo prototype-method assignments, and leaving the mock in place
+		// pollutes other tests in the same vitest worker.
+		originalGetBoundingClientRect = HTMLElement.prototype.getBoundingClientRect;
 		HTMLElement.prototype.getBoundingClientRect = vi.fn(() => ({
 			top: 100,
 			left: 100,
@@ -56,6 +61,7 @@ describe('NotificationPopover', () => {
 	});
 
 	afterEach(() => {
+		HTMLElement.prototype.getBoundingClientRect = originalGetBoundingClientRect;
 		vi.clearAllMocks();
 	});
 

--- a/src/__tests__/renderer/components/TerminalSelectionContextMenu.test.tsx
+++ b/src/__tests__/renderer/components/TerminalSelectionContextMenu.test.tsx
@@ -7,6 +7,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { TerminalSelectionContextMenu } from '../../../renderer/components/TerminalSelectionContextMenu';
 import type { Theme } from '../../../renderer/types';
+import { spyOnListeners, expectAllListenersRemoved } from '../../helpers/listenerLeakAssertions';
 
 const baseTheme: Theme = {
 	id: 'dark',
@@ -105,5 +106,69 @@ describe('TerminalSelectionContextMenu', () => {
 		);
 		fireEvent.keyDown(document, { key: 'Escape' });
 		expect(onDismiss).toHaveBeenCalledTimes(1);
+	});
+
+	it('dismisses on document mousedown outside the menu', () => {
+		const onDismiss = vi.fn();
+		render(
+			<TerminalSelectionContextMenu
+				menu={menu}
+				theme={baseTheme}
+				onDismiss={onDismiss}
+				onCopy={vi.fn()}
+				onSendToAgent={vi.fn()}
+			/>
+		);
+		fireEvent.mouseDown(document.body);
+		expect(onDismiss).toHaveBeenCalledTimes(1);
+	});
+
+	it('ignores non-Escape keys', () => {
+		const onDismiss = vi.fn();
+		render(
+			<TerminalSelectionContextMenu
+				menu={menu}
+				theme={baseTheme}
+				onDismiss={onDismiss}
+				onCopy={vi.fn()}
+				onSendToAgent={vi.fn()}
+			/>
+		);
+		fireEvent.keyDown(document, { key: 'a' });
+		fireEvent.keyDown(document, { key: 'Enter' });
+		expect(onDismiss).not.toHaveBeenCalled();
+	});
+
+	it('does not call onDismiss after unmount', () => {
+		const onDismiss = vi.fn();
+		const { unmount } = render(
+			<TerminalSelectionContextMenu
+				menu={menu}
+				theme={baseTheme}
+				onDismiss={onDismiss}
+				onCopy={vi.fn()}
+				onSendToAgent={vi.fn()}
+			/>
+		);
+		unmount();
+		fireEvent.keyDown(document, { key: 'Escape' });
+		fireEvent.mouseDown(document.body);
+		expect(onDismiss).not.toHaveBeenCalled();
+	});
+
+	it('removes its document listeners on unmount (no leak)', () => {
+		const spies = spyOnListeners(document);
+		const { unmount } = render(
+			<TerminalSelectionContextMenu
+				menu={menu}
+				theme={baseTheme}
+				onDismiss={vi.fn()}
+				onCopy={vi.fn()}
+				onSendToAgent={vi.fn()}
+			/>
+		);
+		unmount();
+		expectAllListenersRemoved(spies.addSpy, spies.removeSpy);
+		spies.restore();
 	});
 });

--- a/src/__tests__/renderer/hooks/utils/useEventListener.test.ts
+++ b/src/__tests__/renderer/hooks/utils/useEventListener.test.ts
@@ -68,17 +68,22 @@ describe('useEventListener', () => {
 		it('attaches to a DOM element target and removes the listener on unmount', () => {
 			const el = document.createElement('div');
 			document.body.appendChild(el);
-			const handler = vi.fn();
-			const { unmount } = renderHook(() => useEventListener('click', handler, { target: el }));
+			try {
+				const handler = vi.fn();
+				const { unmount } = renderHook(() => useEventListener('click', handler, { target: el }));
 
-			fireEvent.click(el);
-			expect(handler).toHaveBeenCalledTimes(1);
+				fireEvent.click(el);
+				expect(handler).toHaveBeenCalledTimes(1);
 
-			unmount();
-			fireEvent.click(el);
-			expect(handler).toHaveBeenCalledTimes(1);
-
-			document.body.removeChild(el);
+				unmount();
+				fireEvent.click(el);
+				expect(handler).toHaveBeenCalledTimes(1);
+			} finally {
+				// Always remove the appended element, even if an assertion threw —
+				// otherwise an orphan <div> persists in document.body for the next
+				// test in this worker.
+				document.body.removeChild(el);
+			}
 		});
 
 		it('does not attach a listener when target is null', () => {

--- a/src/__tests__/renderer/hooks/utils/useEventListener.test.ts
+++ b/src/__tests__/renderer/hooks/utils/useEventListener.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Tests for useEventListener — generic event-listener hook used across the
+ * renderer. Covers the original window-only behaviour plus the new
+ * `target` and `enabled` options.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { fireEvent } from '@testing-library/react';
+import { useEventListener } from '../../../../renderer/hooks/utils/useEventListener';
+import { spyOnListeners, expectAllListenersRemoved } from '../../../helpers/listenerLeakAssertions';
+
+describe('useEventListener', () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	describe('default target (window)', () => {
+		it('invokes the handler when an event fires on window', () => {
+			const handler = vi.fn();
+			renderHook(() => useEventListener('keydown', handler));
+			fireEvent.keyDown(window, { key: 'a' });
+			expect(handler).toHaveBeenCalledTimes(1);
+		});
+
+		it('removes the listener on unmount', () => {
+			const handler = vi.fn();
+			const spies = spyOnListeners(window);
+			const { unmount } = renderHook(() => useEventListener('keydown', handler));
+			unmount();
+			fireEvent.keyDown(window, { key: 'a' });
+			expect(handler).not.toHaveBeenCalled();
+			expectAllListenersRemoved(spies.addSpy, spies.removeSpy);
+			spies.restore();
+		});
+
+		it('reads the latest handler closure (ref pattern)', () => {
+			let calls = 0;
+			const { rerender } = renderHook(
+				({ value }: { value: number }) =>
+					useEventListener('keydown', () => {
+						calls = value;
+					}),
+				{ initialProps: { value: 1 } }
+			);
+			rerender({ value: 42 });
+			fireEvent.keyDown(window, { key: 'a' });
+			expect(calls).toBe(42);
+		});
+	});
+
+	describe('target option', () => {
+		it('attaches to document when target=document', () => {
+			const handler = vi.fn();
+			renderHook(() => useEventListener('keydown', handler, { target: document }));
+			fireEvent.keyDown(document, { key: 'a' });
+			expect(handler).toHaveBeenCalledTimes(1);
+		});
+
+		it('does NOT receive window events when target=document', () => {
+			const handler = vi.fn();
+			renderHook(() => useEventListener('keydown', handler, { target: document }));
+			// Dispatch directly on window (skipping body) so it doesn't bubble to document.
+			window.dispatchEvent(new KeyboardEvent('keydown', { key: 'a' }));
+			expect(handler).not.toHaveBeenCalled();
+		});
+
+		it('attaches to a DOM element target', () => {
+			const el = document.createElement('div');
+			document.body.appendChild(el);
+			const handler = vi.fn();
+			renderHook(() => useEventListener('click', handler, { target: el }));
+			fireEvent.click(el);
+			expect(handler).toHaveBeenCalledTimes(1);
+			document.body.removeChild(el);
+		});
+
+		it('does not attach a listener when target is null', () => {
+			const handler = vi.fn();
+			const spies = spyOnListeners(window);
+			renderHook(() => useEventListener('keydown', handler, { target: null }));
+			expect(spies.addSpy).not.toHaveBeenCalled();
+			fireEvent.keyDown(window, { key: 'a' });
+			expect(handler).not.toHaveBeenCalled();
+			spies.restore();
+		});
+
+		it('removes its document listener on unmount', () => {
+			const handler = vi.fn();
+			const spies = spyOnListeners(document);
+			const { unmount } = renderHook(() =>
+				useEventListener('keydown', handler, { target: document })
+			);
+			unmount();
+			expectAllListenersRemoved(spies.addSpy, spies.removeSpy);
+			spies.restore();
+		});
+	});
+
+	describe('enabled option', () => {
+		it('does not attach when enabled is false', () => {
+			const handler = vi.fn();
+			const spies = spyOnListeners(window);
+			renderHook(() => useEventListener('keydown', handler, { enabled: false }));
+			expect(spies.addSpy).not.toHaveBeenCalled();
+			fireEvent.keyDown(window, { key: 'a' });
+			expect(handler).not.toHaveBeenCalled();
+			spies.restore();
+		});
+
+		it('attaches/detaches as enabled toggles', () => {
+			const handler = vi.fn();
+			const { rerender } = renderHook(
+				({ on }: { on: boolean }) => useEventListener('keydown', handler, { enabled: on }),
+				{ initialProps: { on: false } }
+			);
+
+			fireEvent.keyDown(window, { key: 'a' });
+			expect(handler).not.toHaveBeenCalled();
+
+			act(() => {
+				rerender({ on: true });
+			});
+			fireEvent.keyDown(window, { key: 'b' });
+			expect(handler).toHaveBeenCalledTimes(1);
+
+			act(() => {
+				rerender({ on: false });
+			});
+			fireEvent.keyDown(window, { key: 'c' });
+			expect(handler).toHaveBeenCalledTimes(1);
+		});
+
+		it('cleans up the listener on unmount when enabled was true', () => {
+			const handler = vi.fn();
+			const spies = spyOnListeners(window);
+			const { unmount } = renderHook(() => useEventListener('keydown', handler, { enabled: true }));
+			unmount();
+			expectAllListenersRemoved(spies.addSpy, spies.removeSpy);
+			spies.restore();
+		});
+	});
+});

--- a/src/__tests__/renderer/hooks/utils/useEventListener.test.ts
+++ b/src/__tests__/renderer/hooks/utils/useEventListener.test.ts
@@ -65,13 +65,19 @@ describe('useEventListener', () => {
 			expect(handler).not.toHaveBeenCalled();
 		});
 
-		it('attaches to a DOM element target', () => {
+		it('attaches to a DOM element target and removes the listener on unmount', () => {
 			const el = document.createElement('div');
 			document.body.appendChild(el);
 			const handler = vi.fn();
-			renderHook(() => useEventListener('click', handler, { target: el }));
+			const { unmount } = renderHook(() => useEventListener('click', handler, { target: el }));
+
 			fireEvent.click(el);
 			expect(handler).toHaveBeenCalledTimes(1);
+
+			unmount();
+			fireEvent.click(el);
+			expect(handler).toHaveBeenCalledTimes(1);
+
 			document.body.removeChild(el);
 		});
 

--- a/src/renderer/components/ExecutionQueueBrowser.tsx
+++ b/src/renderer/components/ExecutionQueueBrowser.tsx
@@ -11,6 +11,7 @@ import {
 	Check,
 } from 'lucide-react';
 import { useModalLayer } from '../hooks/ui/useModalLayer';
+import { useEventListener } from '../hooks/utils/useEventListener';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
 import type { Session, Theme, QueuedItem } from '../types';
 import { safeClipboardWrite } from '../utils/clipboard';
@@ -424,25 +425,20 @@ function QueueItemRow({
 		};
 	}, []);
 
-	// Handle escape key to cancel drag
-	useEffect(() => {
-		const handleKeyDown = (e: KeyboardEvent) => {
-			if (e.key === 'Escape' && isDragging) {
+	// Handle escape key + global mouseup to cancel/complete drag (only attached
+	// while a drag is in progress).
+	useEventListener(
+		'keydown',
+		(e) => {
+			if ((e as KeyboardEvent).key === 'Escape') {
 				onDragCancel?.();
 				isDraggingRef.current = false;
 				setIsPressed(false);
 			}
-		};
-
-		if (isDragging) {
-			window.addEventListener('keydown', handleKeyDown);
-			window.addEventListener('mouseup', handleMouseUp);
-			return () => {
-				window.removeEventListener('keydown', handleKeyDown);
-				window.removeEventListener('mouseup', handleMouseUp);
-			};
-		}
-	}, [isDragging, onDragCancel]);
+		},
+		{ enabled: !!isDragging }
+	);
+	useEventListener('mouseup', () => handleMouseUp(), { enabled: !!isDragging });
 
 	// Visual states
 	const showDragReady = canDrag && isHovered && !isDragging && !isAnyDragging;

--- a/src/renderer/components/FileExplorerPanel.tsx
+++ b/src/renderer/components/FileExplorerPanel.tsx
@@ -38,6 +38,7 @@ import { useLayerStack } from '../contexts/LayerStackContext';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
 import { useClickOutside } from '../hooks/ui/useClickOutside';
 import { useContextMenuPosition } from '../hooks/ui/useContextMenuPosition';
+import { useEventListener } from '../hooks/utils/useEventListener';
 import { getRevealLabel, getOpenInLabel } from '../utils/platformUtils';
 import { safeClipboardWrite } from '../utils/clipboard';
 import { flashCopiedToClipboard } from '../utils/flashCopiedToClipboard';
@@ -919,18 +920,16 @@ function FileExplorerPanelInner(props: FileExplorerPanelProps) {
 		}
 	}, [deleteModal, session.id, session.fileTree, onShowFlash, sshRemoteId, setSessions]);
 
-	// Close context menu on Escape key
-	useEffect(() => {
-		const handleKeyDown = (e: KeyboardEvent) => {
-			if (e.key === 'Escape' && contextMenu) {
+	// Close context menu on Escape key (only attached while the menu is open).
+	useEventListener(
+		'keydown',
+		(e) => {
+			if ((e as KeyboardEvent).key === 'Escape') {
 				setContextMenu(null);
 			}
-		};
-		if (contextMenu) {
-			window.addEventListener('keydown', handleKeyDown);
-			return () => window.removeEventListener('keydown', handleKeyDown);
-		}
-	}, [contextMenu]);
+		},
+		{ enabled: contextMenu !== null }
+	);
 
 	// Register layer when filter is open
 	useEffect(() => {

--- a/src/renderer/components/GroupChatList.tsx
+++ b/src/renderer/components/GroupChatList.tsx
@@ -5,6 +5,7 @@
  */
 
 import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
+import { useEventListener } from '../hooks/utils/useEventListener';
 import {
 	MessageSquare,
 	ChevronDown,
@@ -52,15 +53,13 @@ function GroupChatContextMenu({
 	useClickOutside(menuRef, onClose);
 
 	// Close on Escape
-	useEffect(() => {
-		const handleKeyDown = (e: KeyboardEvent) => {
-			if (e.key === 'Escape') {
-				onClose();
-			}
-		};
-		document.addEventListener('keydown', handleKeyDown);
-		return () => document.removeEventListener('keydown', handleKeyDown);
-	}, [onClose]);
+	useEventListener(
+		'keydown',
+		(e) => {
+			if ((e as KeyboardEvent).key === 'Escape') onClose();
+		},
+		{ target: document }
+	);
 
 	// Measure menu and adjust position to stay within viewport
 	const { left, top, ready } = useContextMenuPosition(menuRef, x, y);

--- a/src/renderer/components/HistoryDetailModal.tsx
+++ b/src/renderer/components/HistoryDetailModal.tsx
@@ -19,6 +19,7 @@ import {
 } from 'lucide-react';
 import type { Theme, HistoryEntry, ToolType } from '../types';
 import type { FileNode } from '../types/fileTree';
+import { useEventListener } from '../hooks/utils/useEventListener';
 import { useModalLayer } from '../hooks/ui/useModalLayer';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
 import { formatElapsedTime } from '../utils/formatters';
@@ -122,24 +123,20 @@ export function HistoryDetailModal({
 		}
 	}, [showDeleteConfirm]);
 
-	// Keyboard navigation for prev/next with arrow keys
-	useEffect(() => {
-		const handleKeyDown = (e: KeyboardEvent) => {
-			// Don't handle if delete confirmation is showing
-			if (showDeleteConfirm) return;
+	// Keyboard navigation for prev/next with arrow keys.
+	useEventListener('keydown', (e) => {
+		// Don't handle if delete confirmation is showing
+		if (showDeleteConfirm) return;
 
-			if (e.key === 'ArrowLeft') {
-				e.preventDefault();
-				goToPrev();
-			} else if (e.key === 'ArrowRight') {
-				e.preventDefault();
-				goToNext();
-			}
-		};
-
-		window.addEventListener('keydown', handleKeyDown);
-		return () => window.removeEventListener('keydown', handleKeyDown);
-	}, [goToPrev, goToNext, showDeleteConfirm]);
+		const ke = e as KeyboardEvent;
+		if (ke.key === 'ArrowLeft') {
+			ke.preventDefault();
+			goToPrev();
+		} else if (ke.key === 'ArrowRight') {
+			ke.preventDefault();
+			goToNext();
+		}
+	});
 
 	const formatTime = (timestamp: number) => formatTimestamp(timestamp, 'datetime');
 

--- a/src/renderer/components/KeyboardMasteryCelebration.tsx
+++ b/src/renderer/components/KeyboardMasteryCelebration.tsx
@@ -10,6 +10,7 @@ import { useEffect, useRef, useCallback, useState, useMemo } from 'react';
 import { Keyboard, Trophy, Sparkles } from 'lucide-react';
 import confetti from 'canvas-confetti';
 import type { Theme, Shortcut } from '../types';
+import { useEventListener } from '../hooks/utils/useEventListener';
 import { useModalLayer } from '../hooks/ui/useModalLayer';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
 import { KEYBOARD_MASTERY_LEVELS } from '../constants/keyboardMastery';
@@ -164,18 +165,15 @@ export function KeyboardMasteryCelebration({
 	const handleCloseRef = useRef(handleClose);
 	handleCloseRef.current = handleClose;
 
-	// Handle keyboard events - use ref to avoid stale closure
-	useEffect(() => {
-		const handleKeyDown = (e: KeyboardEvent) => {
-			if (e.key === 'Enter' || e.key === 'Escape') {
-				e.preventDefault();
-				handleCloseRef.current();
-			}
-		};
-
-		window.addEventListener('keydown', handleKeyDown);
-		return () => window.removeEventListener('keydown', handleKeyDown);
-	}, []); // Empty deps - handler reads from ref
+	// Handle keyboard events. The hook's internal ref keeps the handler stable
+	// without re-subscribing.
+	useEventListener('keydown', (e) => {
+		const ke = e as KeyboardEvent;
+		if (ke.key === 'Enter' || ke.key === 'Escape') {
+			ke.preventDefault();
+			handleCloseRef.current();
+		}
+	});
 
 	// Register with layer stack
 	useModalLayer(MODAL_PRIORITIES.KEYBOARD_MASTERY, 'Keyboard Mastery Level Up Celebration', () =>

--- a/src/renderer/components/NotificationPopover.tsx
+++ b/src/renderer/components/NotificationPopover.tsx
@@ -1,9 +1,10 @@
-import { useRef, useEffect, memo } from 'react';
+import { useRef, memo } from 'react';
 import { createPortal } from 'react-dom';
 import { Bell, Volume2, Coffee, type LucideIcon } from 'lucide-react';
 import type { Theme } from '../types';
 import { ToggleSwitch } from './ui/ToggleSwitch';
 import { useClickOutside } from '../hooks/ui/useClickOutside';
+import { useEventListener } from '../hooks/utils/useEventListener';
 import { useSettingsStore } from '../stores/settingsStore';
 
 interface NotificationPopoverProps {
@@ -37,16 +38,17 @@ export const NotificationPopover = memo(function NotificationPopover({
 	});
 
 	// Escape key dismissal
-	useEffect(() => {
-		const handleKeyDown = (e: KeyboardEvent) => {
-			if (e.key === 'Escape') {
-				e.stopPropagation();
+	useEventListener(
+		'keydown',
+		(e) => {
+			const ke = e as KeyboardEvent;
+			if (ke.key === 'Escape') {
+				ke.stopPropagation();
 				onClose();
 			}
-		};
-		document.addEventListener('keydown', handleKeyDown);
-		return () => document.removeEventListener('keydown', handleKeyDown);
-	}, [onClose]);
+		},
+		{ target: document }
+	);
 
 	// Position relative to anchor
 	const anchorRect = anchorRef.current?.getBoundingClientRect();

--- a/src/renderer/components/TerminalSelectionContextMenu.tsx
+++ b/src/renderer/components/TerminalSelectionContextMenu.tsx
@@ -5,10 +5,11 @@
  * (and no URL link is being hovered — that case is handled by LinkContextMenu).
  */
 
-import { useEffect, useRef, useCallback } from 'react';
+import { useRef, useCallback } from 'react';
 import { Copy, Send } from 'lucide-react';
 import type { Theme } from '../types';
 import { useContextMenuPosition } from '../hooks/ui/useContextMenuPosition';
+import { useEventListener } from '../hooks/utils/useEventListener';
 
 export interface TerminalSelectionContextMenuState {
 	x: number;
@@ -40,18 +41,14 @@ export function TerminalSelectionContextMenu({
 
 	const { left, top, ready } = useContextMenuPosition(menuRef, menu.x, menu.y);
 
-	useEffect(() => {
-		const handleMouseDown = () => onDismissRef.current();
-		const handleKey = (e: KeyboardEvent) => {
-			if (e.key === 'Escape') onDismissRef.current();
-		};
-		document.addEventListener('mousedown', handleMouseDown);
-		document.addEventListener('keydown', handleKey);
-		return () => {
-			document.removeEventListener('mousedown', handleMouseDown);
-			document.removeEventListener('keydown', handleKey);
-		};
-	}, []);
+	useEventListener('mousedown', () => onDismissRef.current(), { target: document });
+	useEventListener(
+		'keydown',
+		(e) => {
+			if ((e as KeyboardEvent).key === 'Escape') onDismissRef.current();
+		},
+		{ target: document }
+	);
 
 	const handleCopy = useCallback(() => {
 		onCopy?.(menu.selection);

--- a/src/renderer/hooks/utils/useEventListener.ts
+++ b/src/renderer/hooks/utils/useEventListener.ts
@@ -1,36 +1,69 @@
 /**
  * useEventListener.ts
  *
- * Generic hook for adding and removing window event listeners with proper
- * cleanup on unmount or when the event type / handler changes.
+ * Generic hook for adding and removing DOM event listeners with proper
+ * cleanup on unmount or when the event type / target / enabled state changes.
+ *
+ * The handler is held in a ref so callers can pass an inline function
+ * without re-subscribing on every render — only `eventType`, `target`, and
+ * `enabled` cause re-subscription.
  */
 
 import { useEffect, useRef } from 'react';
 
+export interface UseEventListenerOptions {
+	/**
+	 * The EventTarget to attach the listener to. Defaults to `window`.
+	 * Pass `document` for click-outside / global keyboard handlers, or an
+	 * `HTMLElement` (typically from a ref) for element-scoped listeners.
+	 * Pass `null` to skip subscription (useful for ref-based targets that
+	 * may be initially null).
+	 */
+	target?: Window | Document | HTMLElement | null;
+	/**
+	 * When `false`, the listener is not attached. Toggling between `true` and
+	 * `false` re-attaches / detaches the listener cleanly. Defaults to `true`.
+	 */
+	enabled?: boolean;
+}
+
 /**
- * Attaches an event listener to `window` for the given event type and
- * automatically removes it when the component unmounts or dependencies change.
- *
- * @param eventType - The name of the DOM event (e.g. 'maestro:openFileTab')
- * @param handler   - The event handler callback
+ * Attaches an event listener to the given target (default `window`) for the
+ * given event type and automatically removes it when the component unmounts
+ * or when `eventType`, `target`, or `enabled` changes.
  *
  * @example
- * useEventListener('maestro:openFileTab', (e: Event) => {
+ * useEventListener('maestro:openFileTab', (e) => {
  *   const { sessionId, filePath } = (e as CustomEvent).detail;
  *   // ...
  * });
+ *
+ * @example  document-scoped Escape handler, only when modal is open
+ * useEventListener(
+ *   'keydown',
+ *   (e) => { if (e.key === 'Escape') onClose(); },
+ *   { target: document, enabled: isOpen }
+ * );
  */
-export function useEventListener(eventType: string, handler: (event: Event) => void): void {
+export function useEventListener(
+	eventType: string,
+	handler: (event: Event) => void,
+	options?: UseEventListenerOptions
+): void {
+	const { target = typeof window !== 'undefined' ? window : null, enabled = true } = options ?? {};
+
 	// Keep a stable ref to the handler so the effect only re-runs when
-	// eventType changes, not on every render where handler is re-created.
+	// eventType / target / enabled change, not on every render where the
+	// handler closure is re-created.
 	const handlerRef = useRef(handler);
 	handlerRef.current = handler;
 
 	useEffect(() => {
+		if (!enabled || !target) return;
 		const listener = (event: Event) => handlerRef.current(event);
-		window.addEventListener(eventType, listener);
+		target.addEventListener(eventType, listener);
 		return () => {
-			window.removeEventListener(eventType, listener);
+			target.removeEventListener(eventType, listener);
 		};
-	}, [eventType]);
+	}, [eventType, target, enabled]);
 }


### PR DESCRIPTION
## Summary

- Extend `useEventListener` with backward-compatible `target` (Window/Document/HTMLElement/null) and `enabled` (boolean) options so document-scoped and conditionally-attached listeners can use the canonical hook.
- Swap 7 hand-rolled `add/removeEventListener` pairs to `useEventListener` across 5 always-on and 2 conditional sites — behavior preserved exactly.
- Add an `expectAllListenersRemoved` test helper plus characterization tests on every touched site to lock in current observable behavior and catch future listener leaks.

## What changed

4 commits, each independently revert-safe:

1. `test(events)` — characterization tests + leak helper (7 sites covered, ~360 tests in scope)
2. `feat(useEventListener)` — add `target` + `enabled` options + 11 hook tests
3. `refactor(events)` — 5 always-on swaps: KeyboardMasteryCelebration, HistoryDetailModal, NotificationPopover, GroupChatContextMenu, TerminalSelectionContextMenu
4. `refactor(events)` — 2 conditional swaps using new `enabled` flag: FileExplorerPanel context menu (`enabled: contextMenu !== null`), ExecutionQueueBrowser drag (`enabled: !!isDragging`)

## What this PR deliberately does NOT do

The original audit listed several additional items. After merging the rc, four were already fixed or invalid and one was deliberately preserved:

- `useResizablePanel` mid-drag cleanup — already fixed (cleanup-on-unmount effect at lines 52-58 calls `cleanupRef.current?.()`).
- `process-manager` escalation timer leak — already cleared on early exit (`child.once('exit', () => clearTimeout(...))` and `ptyProc.onExit(() => clearTimeout(...))`).
- `cue-file-watcher` debounce-timer accumulation — already deletes the map entry inside the timer callback at line 51.
- `useModalHandlers` `passive` flag mismatch — false positive. `removeEventListener` only consults `capture` from the options bag; `passive` is silently ignored on removal, so the listener IS being removed correctly.
- `AchievementCard` click-outside — deliberate `setTimeout(() => addEventListener, 0)` to skip the opener click. A naïve swap to `useEventListener` would attach synchronously and the popover would close itself instantly. Left untouched; can revisit with a dedicated `useClickOutsideOnDelay` hook if the pattern recurs.

## Reusable artifact

`src/__tests__/helpers/listenerLeakAssertions.ts` exports `spyOnListeners(target)` and `expectAllListenersRemoved(addSpy, removeSpy)`. Identity-based comparison — anonymous-handler leaks still caught. Drop into any test that touches the DOM event surface.

## Performance impact

This is hygiene, not a performance fix. The new test helper prevents a class of listener-leak regression going forward, but no user-perceived metric will move from this PR alone. The actual app-slowness story remains in Tier 1 (`sessions:setMany` IPC, persistence diff, `useSessionCategories` cascade, Cue scanner visibility-aware pause, stats batching, history I/O).

## Test plan

- Full suite: `npm run test` — **26,862 passed, 0 failed** (108 pre-existing skipped)
- TypeScript: `npm run lint` — clean across `tsconfig.lint.json`, `tsconfig.main.json`, `tsconfig.cli.json`
- ESLint: `npm run lint:eslint` — clean
- Per-touched-site spy-symmetry assertion (`expectAllListenersRemoved`) wired into all 7 component test files plus the hook tests
- Conditional-attachment tests assert no listener is attached while the gate is false (FileExplorer `contextMenu === null`, ExecutionQueue `!isDragging`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a test helper to detect event-listener leaks and comprehensive tests ensuring components attach/remove global listeners correctly across lifecycles.

* **Refactor**
  * Centralized event-listener handling across multiple UI components for more reliable cleanup.
  * Enhanced event-listening utility to support explicit targets and enable/disable control for finer lifecycle management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->