### PR TITLE
fix(worktrees): keep nested worktrees from disappearing on restart

### DIFF
--- a/src/__tests__/main/ipc/handlers/git.test.ts
+++ b/src/__tests__/main/ipc/handlers/git.test.ts
@@ -4178,6 +4178,181 @@ branch refs/heads/bugfix-123
 			expect(result.gitSubdirs[0].branch).toBe('feature-branch');
 			expect(result.scanFailed).toBeFalsy();
 		});
+
+		it('should discover nested worktrees from slash-named branches', async () => {
+			// Regression: branches like "fix/worktree-removal" produce a nested
+			// path <basePath>/fix/worktree-removal. Without one-level recursion,
+			// the scan misses these and the renderer wrongly removes the session.
+			vi.mocked(mockFs.readdir).mockImplementation(async (dir: any) => {
+				if (String(dir) === '/parent') {
+					return [
+						// Flat worktree (existing happy path)
+						{ name: 'flat-branch', isDirectory: () => true },
+						// Group directory containing nested worktrees
+						{ name: 'fix', isDirectory: () => true },
+					] as any;
+				}
+				if (String(dir) === path.join('/parent', 'fix')) {
+					return [
+						{ name: 'worktree-removal', isDirectory: () => true },
+						{ name: 'files-restart', isDirectory: () => true },
+					] as any;
+				}
+				return [] as any;
+			});
+
+			vi.mocked(execFile.execFileNoThrow).mockImplementation(async (cmd, args, cwd) => {
+				const cwdStr = String(cwd);
+
+				// Group directory itself is NOT a git repo
+				if (cwdStr === path.join('/parent', 'fix')) {
+					if (args?.includes('--is-inside-work-tree')) {
+						return { stdout: '', stderr: 'fatal: not a git repository', exitCode: 128 };
+					}
+				}
+
+				// Helper: act like a real worktree at the given path
+				const respondAsWorktreeAt = (workPath: string, branch: string) => {
+					if (cwdStr === workPath) {
+						if (args?.includes('--is-inside-work-tree')) {
+							return { stdout: 'true\n', stderr: '', exitCode: 0 };
+						}
+						if (args?.includes('--show-toplevel')) {
+							return { stdout: workPath, stderr: '', exitCode: 0 };
+						}
+						if (args?.includes('--git-dir')) {
+							return {
+								stdout: `/parent/main-repo/.git/worktrees/${branch}`,
+								stderr: '',
+								exitCode: 0,
+							};
+						}
+						if (args?.includes('--git-common-dir')) {
+							return { stdout: '/parent/main-repo/.git', stderr: '', exitCode: 0 };
+						}
+						if (args?.includes('--abbrev-ref')) {
+							return { stdout: `${branch}\n`, stderr: '', exitCode: 0 };
+						}
+					}
+					return null;
+				};
+
+				return (
+					respondAsWorktreeAt(path.join('/parent', 'flat-branch'), 'flat-branch') ??
+					respondAsWorktreeAt(
+						path.join('/parent', 'fix', 'worktree-removal'),
+						'fix/worktree-removal'
+					) ??
+					respondAsWorktreeAt(
+						path.join('/parent', 'fix', 'files-restart'),
+						'fix/files-restart'
+					) ?? { stdout: '', stderr: 'fatal: not a git repository', exitCode: 128 }
+				);
+			});
+
+			const handler = handlers.get('git:scanWorktreeDirectory');
+			const result = await handler!({} as any, '/parent');
+
+			const paths = (result.gitSubdirs as Array<{ path: string; branch: string }>)
+				.map((e) => e.path)
+				.sort();
+			expect(paths).toEqual(
+				[
+					path.join('/parent', 'flat-branch'),
+					path.join('/parent', 'fix', 'files-restart'),
+					path.join('/parent', 'fix', 'worktree-removal'),
+				].sort()
+			);
+			const nested = (result.gitSubdirs as Array<{ path: string; branch: string }>).find(
+				(e) => e.path === path.join('/parent', 'fix', 'worktree-removal')
+			);
+			expect(nested?.branch).toBe('fix/worktree-removal');
+			expect(result.scanFailed).toBeFalsy();
+		});
+
+		it('should not recurse beyond one level', async () => {
+			// MAX_DEPTH=1 means we cover <basePath>/<group>/<branch> but not deeper.
+			// Worktrees at <basePath>/a/b/c must NOT appear.
+			vi.mocked(mockFs.readdir).mockImplementation(async (dir: any) => {
+				const s = String(dir);
+				if (s === '/parent') return [{ name: 'a', isDirectory: () => true }] as any;
+				if (s === path.join('/parent', 'a')) return [{ name: 'b', isDirectory: () => true }] as any;
+				if (s === path.join('/parent', 'a', 'b'))
+					return [{ name: 'c', isDirectory: () => true }] as any;
+				return [] as any;
+			});
+
+			// Make every level look like "not a git repo" except the deepest one.
+			vi.mocked(execFile.execFileNoThrow).mockImplementation(async (cmd, args, cwd) => {
+				const cwdStr = String(cwd);
+				if (cwdStr === path.join('/parent', 'a', 'b', 'c')) {
+					if (args?.includes('--is-inside-work-tree')) {
+						return { stdout: 'true\n', stderr: '', exitCode: 0 };
+					}
+					if (args?.includes('--show-toplevel')) {
+						return { stdout: cwdStr, stderr: '', exitCode: 0 };
+					}
+					if (args?.includes('--abbrev-ref')) {
+						return { stdout: 'too-deep\n', stderr: '', exitCode: 0 };
+					}
+					return { stdout: '.git', stderr: '', exitCode: 0 };
+				}
+				return { stdout: '', stderr: 'fatal: not a git repository', exitCode: 128 };
+			});
+
+			const handler = handlers.get('git:scanWorktreeDirectory');
+			const result = await handler!({} as any, '/parent');
+
+			expect(result.gitSubdirs).toHaveLength(0);
+			expect(result.scanFailed).toBeFalsy();
+		});
+
+		it('should swallow read errors on nested group directories', async () => {
+			// If recursing into a group dir fails (perms, race with deletion), the
+			// rest of the scan must still succeed. Without this, a transient
+			// failure on one nested branch wipes every sibling worktree session.
+			vi.mocked(mockFs.readdir).mockImplementation(async (dir: any) => {
+				const s = String(dir);
+				if (s === '/parent') {
+					return [
+						{ name: 'good-flat', isDirectory: () => true },
+						{ name: 'broken-group', isDirectory: () => true },
+					] as any;
+				}
+				if (s === path.join('/parent', 'broken-group')) {
+					const err = new Error('EACCES: permission denied') as NodeJS.ErrnoException;
+					err.code = 'EACCES';
+					throw err;
+				}
+				return [] as any;
+			});
+
+			vi.mocked(execFile.execFileNoThrow).mockImplementation(async (cmd, args, cwd) => {
+				const cwdStr = String(cwd);
+				if (cwdStr === path.join('/parent', 'good-flat')) {
+					if (args?.includes('--is-inside-work-tree')) {
+						return { stdout: 'true\n', stderr: '', exitCode: 0 };
+					}
+					if (args?.includes('--show-toplevel')) {
+						return { stdout: cwdStr, stderr: '', exitCode: 0 };
+					}
+					if (args?.includes('--abbrev-ref')) {
+						return { stdout: 'good-flat\n', stderr: '', exitCode: 0 };
+					}
+					return { stdout: '.git', stderr: '', exitCode: 0 };
+				}
+				return { stdout: '', stderr: 'fatal: not a git repository', exitCode: 128 };
+			});
+
+			const handler = handlers.get('git:scanWorktreeDirectory');
+			const result = await handler!({} as any, '/parent');
+
+			expect(result.gitSubdirs).toHaveLength(1);
+			expect((result.gitSubdirs as Array<{ name: string }>)[0].name).toBe('good-flat');
+			// Whole-scan failure must NOT be flagged — that would trigger the renderer's
+			// removal-skip fallback; we only flag scanFailed for the top-level read.
+			expect(result.scanFailed).toBeFalsy();
+		});
 	});
 
 	describe('git:watchWorktreeDirectory', () => {
@@ -4208,7 +4383,7 @@ branch refs/heads/bugfix-123
 				ignored: /(^|[/\\])\../,
 				persistent: true,
 				ignoreInitial: true,
-				depth: 0,
+				depth: 1,
 			});
 			expect(mockWatcher.on).toHaveBeenCalledWith('addDir', expect.any(Function));
 			expect(mockWatcher.on).toHaveBeenCalledWith('error', expect.any(Function));

--- a/src/__tests__/main/ipc/handlers/git.test.ts
+++ b/src/__tests__/main/ipc/handlers/git.test.ts
@@ -86,6 +86,11 @@ vi.mock('../../../../main/utils/remote-git', () => ({
 	execGit: vi.fn(),
 }));
 
+// Mock remote-fs (used by scanWorktreeDirectory's SSH branch)
+vi.mock('../../../../main/utils/remote-fs', () => ({
+	readDirRemote: vi.fn(),
+}));
+
 // Mock the stores module — git.ts now imports getSshRemoteById from here
 // instead of receiving it via dependency injection. We delegate to the
 // mockSettingsStore so existing tests can still drive SSH remote lookups
@@ -4305,6 +4310,29 @@ branch refs/heads/bugfix-123
 
 			expect(result.gitSubdirs).toHaveLength(0);
 			expect(result.scanFailed).toBeFalsy();
+		});
+
+		it('should set scanFailed when SSH readDirRemote fails at the top level', async () => {
+			// Regression: previously the SSH branch in readSubdirs returned null on
+			// failure, scanLevel returned [], the outer try/catch never fired, and
+			// the renderer received { gitSubdirs: [] } with no scanFailed flag.
+			// That triggered bulk-removal of every SSH worktree session whenever
+			// the remote read failed (network blip, expired auth, missing path).
+			mockSettingsStore.get.mockReturnValue([
+				{ id: 'ssh-1', host: 'remote.example.com', user: 'me' },
+			]);
+
+			const remoteFs = await import('../../../../main/utils/remote-fs');
+			vi.mocked(remoteFs.readDirRemote).mockResolvedValue({
+				success: false,
+				error: 'connection timed out',
+			} as any);
+
+			const handler = handlers.get('git:scanWorktreeDirectory');
+			const result = await handler!({} as any, '/remote/worktrees', 'ssh-1');
+
+			expect(result.gitSubdirs).toEqual([]);
+			expect(result.scanFailed).toBe(true);
 		});
 
 		it('should swallow read errors on nested group directories', async () => {

--- a/src/__tests__/renderer/hooks/useWorktreeHandlers.test.ts
+++ b/src/__tests__/renderer/hooks/useWorktreeHandlers.test.ts
@@ -1312,6 +1312,68 @@ describe('Effects', () => {
 			);
 		});
 
+		it('preserves child sessions whose cwd is a nested path under basePath', async () => {
+			// Regression for #931: worktrees from slash-named branches live at
+			// <basePath>/<group>/<branch> (e.g. /projects/worktrees/fix/foo). The
+			// main process now recurses one level so gitSubdirs includes those
+			// paths; this test pins that the renderer's stale-detection treats
+			// nested entries the same as flat ones (no spurious removal).
+			vi.useFakeTimers();
+
+			const flatChild = createChildSession({
+				id: 'flat-child',
+				cwd: '/projects/worktrees/feature-flat',
+				worktreeBranch: 'feature-flat',
+				parentSessionId: 'parent-1',
+			});
+			const nestedChild = createChildSession({
+				id: 'nested-child',
+				cwd: '/projects/worktrees/fix/worktree-removal',
+				worktreeBranch: 'fix/worktree-removal',
+				parentSessionId: 'parent-1',
+			});
+
+			const parentWithConfig = {
+				...mockParentSession,
+				worktreeConfig: { basePath: '/projects/worktrees', watchEnabled: false },
+			};
+
+			mockGit.scanWorktreeDirectory.mockResolvedValue({
+				gitSubdirs: [
+					{
+						path: '/projects/worktrees/feature-flat',
+						branch: 'feature-flat',
+						name: 'feature-flat',
+					},
+					{
+						path: '/projects/worktrees/fix/worktree-removal',
+						branch: 'fix/worktree-removal',
+						name: 'worktree-removal',
+					},
+				],
+			});
+
+			useSessionStore.setState({
+				sessions: [parentWithConfig, flatChild, nestedChild],
+				activeSessionId: 'parent-1',
+				sessionsLoaded: true,
+			} as any);
+
+			(notifyToast as any).mockClear();
+			renderHook(() => useWorktreeHandlers());
+
+			await act(async () => {
+				await vi.runAllTimersAsync();
+			});
+
+			const sessions = useSessionStore.getState().sessions;
+			expect(sessions.some((s) => s.id === 'flat-child')).toBe(true);
+			expect(sessions.some((s) => s.id === 'nested-child')).toBe(true);
+			expect(notifyToast).not.toHaveBeenCalledWith(
+				expect.objectContaining({ title: 'Worktree Removed' })
+			);
+		});
+
 		it('does NOT remove child sessions when scan reports scanFailed', async () => {
 			vi.useFakeTimers();
 

--- a/src/main/ipc/handlers/git.ts
+++ b/src/main/ipc/handlers/git.ts
@@ -1108,12 +1108,23 @@ export function registerGitHandlers(_deps: GitHandlerDependencies): void {
 							: `${parent}/${child}`
 						: path.join(parent, child);
 
-				const readSubdirs = async (dir: string): Promise<SubdirEntry[] | null> => {
+				// Throws on read failure (matching local `fs.readdir` behavior) so the
+				// outer try/catch can surface scanFailed: true at the top level. Nested
+				// recursion wraps this in its own try/catch and swallows the throw.
+				// Without this, an SSH `readDirRemote` failure would silently return []
+				// and the renderer would bulk-remove every child session.
+				const readSubdirs = async (dir: string): Promise<SubdirEntry[]> => {
 					if (sshRemote) {
 						const result = await readDirRemote(dir, sshRemote);
 						if (!result.success || !result.data) {
-							logger.error(`Failed to read remote directory ${dir}: ${result.error}`, LOG_CONTEXT);
-							return null;
+							const err = new Error(
+								`Failed to read remote directory ${dir}: ${result.error || 'unknown error'}`
+							) as NodeJS.ErrnoException;
+							// Tag as ENOENT so the outer catch's Sentry-quieting branch applies —
+							// remote read failures are typically "path no longer exists / not reachable",
+							// not bugs worth paging on.
+							err.code = 'ENOENT';
+							throw err;
 						}
 						return result.data.filter((e) => e.isDirectory && !e.name.startsWith('.'));
 					}
@@ -1196,14 +1207,10 @@ export function registerGitHandlers(_deps: GitHandlerDependencies): void {
 							repoRoot = path.dirname(commonDirAbs);
 						}
 					} else {
-						const repoRootResult = await execGit(
-							['rev-parse', '--show-toplevel'],
-							subdirPath,
-							sshRemote
-						);
-						if (repoRootResult.exitCode === 0) {
-							repoRoot = repoRootResult.stdout.trim();
-						}
+						// For non-worktree git repos, the toplevel IS the repo root —
+						// reuse the value we already fetched above instead of re-running
+						// `git rev-parse --show-toplevel`.
+						repoRoot = toplevel;
 					}
 
 					return {
@@ -1217,13 +1224,12 @@ export function registerGitHandlers(_deps: GitHandlerDependencies): void {
 
 				// Walk a directory level: inspect each subdir, then recurse into any
 				// non-git subdirs (up to MAX_DEPTH below the original parentPath).
-				// Failures while reading a nested directory are swallowed: a missing
-				// or unreadable group dir shouldn't fail the entire scan.
+				// Failures while reading a nested directory are swallowed by the
+				// inner try/catch — a missing or unreadable group dir shouldn't fail
+				// the entire scan. Top-level failure propagates up to the outer
+				// try/catch so scanFailed is surfaced and the renderer skips removal.
 				const scanLevel = async (dir: string, depthRemaining: number): Promise<ScanEntry[]> => {
 					const subdirs = await readSubdirs(dir);
-					if (subdirs === null) {
-						return [];
-					}
 
 					const results = await Promise.all(
 						subdirs.map(async (subdir) => {
@@ -1426,7 +1432,15 @@ export function registerGitHandlers(_deps: GitHandlerDependencies): void {
 						worktreeWatchDebounceTimers.set(debounceKey, timer);
 					});
 
-					// Handler for directory removals (e.g., git worktree remove from CLI)
+					// Handler for directory removals (e.g., `git worktree remove` from CLI).
+					//
+					// With depth: 1 this can fire spuriously for an intermediate group
+					// directory (e.g. <basePath>/fix) when its last nested worktree is
+					// removed and the empty parent is cleaned up. We forward the event
+					// regardless because (a) the dir is gone so we can't run git checks
+					// to validate, and (b) the renderer's onWorktreeRemoved handler
+					// already filters by registered child cwds — an unknown path is a
+					// no-op, not a session removal. See useWorktreeHandlers.ts.
 					watcher.on('unlinkDir', (dirPath: string) => {
 						if (dirPath === worktreePath) return;
 

--- a/src/main/ipc/handlers/git.ts
+++ b/src/main/ipc/handlers/git.ts
@@ -1074,6 +1074,11 @@ export function registerGitHandlers(_deps: GitHandlerDependencies): void {
 	// This is used for auto-discovering worktrees in a parent directory
 	// PERFORMANCE: Parallelized git operations to avoid blocking UI (was sequential before)
 	// Supports SSH remote execution via optional sshRemoteId parameter
+	//
+	// Recurses one level into non-git subdirectories so worktrees created from
+	// branch names with slashes (e.g. "fix/worktree-removal" → /worktrees/fix/worktree-removal)
+	// are still discovered. Without recursion, those nested worktrees are absent
+	// from the result and the renderer's stale-detection wrongly removes them.
 	ipcMain.handle(
 		'git:scanWorktreeDirectory',
 		createIpcHandler(
@@ -1081,135 +1086,172 @@ export function registerGitHandlers(_deps: GitHandlerDependencies): void {
 			async (parentPath: string, sshRemoteId?: string) => {
 				const sshRemote = sshRemoteId ? getSshRemoteById(sshRemoteId) : undefined;
 
-				try {
-					// Read directory contents (SSH-aware)
-					let subdirs: Array<{ name: string; isDirectory: boolean }>;
+				// Maximum recursion depth below the configured basePath. 1 covers the
+				// common case `<basePath>/<group>/<branch>` from slash-named branches.
+				// Going deeper would multiply git invocations without a real-world need
+				// (git itself rejects nested worktrees inside the main repo).
+				const MAX_DEPTH = 1;
 
+				type SubdirEntry = { name: string; isDirectory: boolean };
+				type ScanEntry = {
+					path: string;
+					name: string;
+					isWorktree: boolean;
+					branch: string | null;
+					repoRoot: string | null;
+				};
+
+				const joinPath = (parent: string, child: string): string =>
+					sshRemote
+						? parent.endsWith('/')
+							? `${parent}${child}`
+							: `${parent}/${child}`
+						: path.join(parent, child);
+
+				const readSubdirs = async (dir: string): Promise<SubdirEntry[] | null> => {
 					if (sshRemote) {
-						// SSH remote: use readDirRemote
-						const result = await readDirRemote(parentPath, sshRemote);
+						const result = await readDirRemote(dir, sshRemote);
 						if (!result.success || !result.data) {
-							logger.error(
-								`Failed to read remote directory ${parentPath}: ${result.error}`,
-								LOG_CONTEXT
-							);
-							return { gitSubdirs: [], scanFailed: true };
+							logger.error(`Failed to read remote directory ${dir}: ${result.error}`, LOG_CONTEXT);
+							return null;
 						}
-						// Filter to only directories (excluding hidden directories)
-						subdirs = result.data.filter((e) => e.isDirectory && !e.name.startsWith('.'));
-					} else {
-						// Local: use standard fs operations
-						const entries = await fs.readdir(parentPath, { withFileTypes: true });
-						// Filter to only directories (excluding hidden directories)
-						subdirs = entries
-							.filter((e) => e.isDirectory() && !e.name.startsWith('.'))
-							.map((e) => ({
-								name: e.name,
-								isDirectory: true,
-							}));
+						return result.data.filter((e) => e.isDirectory && !e.name.startsWith('.'));
+					}
+					const entries = await fs.readdir(dir, { withFileTypes: true });
+					return entries
+						.filter((e) => e.isDirectory() && !e.name.startsWith('.'))
+						.map((e) => ({ name: e.name, isDirectory: true }));
+				};
+
+				// Inspect a single directory: returns the worktree entry if it IS a
+				// git repo/worktree root, or null otherwise. Caller decides whether
+				// to recurse into a null result.
+				const inspectSubdir = async (
+					subdirPath: string,
+					name: string
+				): Promise<ScanEntry | null> => {
+					const isInsideWorkTree = await execGit(
+						['rev-parse', '--is-inside-work-tree'],
+						subdirPath,
+						sshRemote
+					);
+					if (isInsideWorkTree.exitCode !== 0) {
+						return null; // Not a git repo
 					}
 
-					// Process all subdirectories in parallel instead of sequentially
-					// This dramatically reduces the time for directories with many worktrees
+					// Verify this directory IS a worktree/repo root, not just a subdirectory inside one.
+					// Without this check, subdirectories like "build/" or "src/" inside a worktree
+					// would pass --is-inside-work-tree and be incorrectly treated as separate worktrees.
+					const toplevelResult = await execGit(
+						['rev-parse', '--show-toplevel'],
+						subdirPath,
+						sshRemote
+					);
+					if (toplevelResult.exitCode !== 0) {
+						return null; // Git command failed — treat as invalid
+					}
+					const toplevel = toplevelResult.stdout.trim();
+					// For local paths, canonicalize via realpath so that symlinked base
+					// paths (common on Linux: /home → /data/home; Windows junctions) match
+					// what git rev-parse --show-toplevel returns. path.resolve alone does
+					// NOT follow symlinks, which previously caused every subdir to be
+					// rejected and the entire worktree set to be marked stale.
+					const normalizedSubdir = sshRemote
+						? subdirPath
+						: await fs.realpath(subdirPath).catch(() => path.resolve(subdirPath));
+					const normalizedToplevel = sshRemote
+						? toplevel
+						: await fs.realpath(toplevel).catch(() => path.resolve(toplevel));
+					if (normalizedSubdir !== normalizedToplevel) {
+						return null; // Subdirectory inside a repo, not a repo/worktree root
+					}
+
+					// Run remaining git commands in parallel for each subdirectory (SSH-aware via execGit)
+					const [gitDirResult, gitCommonDirResult, branchResult] = await Promise.all([
+						execGit(['rev-parse', '--git-dir'], subdirPath, sshRemote),
+						execGit(['rev-parse', '--git-common-dir'], subdirPath, sshRemote),
+						execGit(['rev-parse', '--abbrev-ref', 'HEAD'], subdirPath, sshRemote),
+					]);
+
+					const gitDir = gitDirResult.exitCode === 0 ? gitDirResult.stdout.trim() : '';
+					const gitCommonDir =
+						gitCommonDirResult.exitCode === 0 ? gitCommonDirResult.stdout.trim() : gitDir;
+					const isWorktree = gitDir !== gitCommonDir;
+					const branch = branchResult.exitCode === 0 ? branchResult.stdout.trim() : null;
+
+					// Get repo root
+					let repoRoot: string | null = null;
+					if (isWorktree && gitCommonDir) {
+						// For SSH, use POSIX path operations
+						if (sshRemote) {
+							const commonDirAbs = gitCommonDir.startsWith('/')
+								? gitCommonDir
+								: `${subdirPath}/${gitCommonDir}`.replace(/\/+/g, '/');
+							// Get parent directory (remove last path component)
+							repoRoot = commonDirAbs.split('/').slice(0, -1).join('/') || '/';
+						} else {
+							const commonDirAbs = path.isAbsolute(gitCommonDir)
+								? gitCommonDir
+								: path.resolve(subdirPath, gitCommonDir);
+							repoRoot = path.dirname(commonDirAbs);
+						}
+					} else {
+						const repoRootResult = await execGit(
+							['rev-parse', '--show-toplevel'],
+							subdirPath,
+							sshRemote
+						);
+						if (repoRootResult.exitCode === 0) {
+							repoRoot = repoRootResult.stdout.trim();
+						}
+					}
+
+					return {
+						path: subdirPath,
+						name,
+						isWorktree,
+						branch,
+						repoRoot,
+					};
+				};
+
+				// Walk a directory level: inspect each subdir, then recurse into any
+				// non-git subdirs (up to MAX_DEPTH below the original parentPath).
+				// Failures while reading a nested directory are swallowed: a missing
+				// or unreadable group dir shouldn't fail the entire scan.
+				const scanLevel = async (dir: string, depthRemaining: number): Promise<ScanEntry[]> => {
+					const subdirs = await readSubdirs(dir);
+					if (subdirs === null) {
+						return [];
+					}
+
 					const results = await Promise.all(
 						subdirs.map(async (subdir) => {
-							// Use POSIX path joining for remote paths
-							const subdirPath = sshRemote
-								? parentPath.endsWith('/')
-									? `${parentPath}${subdir.name}`
-									: `${parentPath}/${subdir.name}`
-								: path.join(parentPath, subdir.name);
-
-							// Check if it's inside a git work tree (SSH-aware via execGit)
-							const isInsideWorkTree = await execGit(
-								['rev-parse', '--is-inside-work-tree'],
-								subdirPath,
-								sshRemote
-							);
-							if (isInsideWorkTree.exitCode !== 0) {
-								return null; // Not a git repo
+							const subdirPath = joinPath(dir, subdir.name);
+							const entry = await inspectSubdir(subdirPath, subdir.name);
+							if (entry) {
+								return [entry];
 							}
-
-							// Verify this directory IS a worktree/repo root, not just a subdirectory inside one.
-							// Without this check, subdirectories like "build/" or "src/" inside a worktree
-							// would pass --is-inside-work-tree and be incorrectly treated as separate worktrees.
-							const toplevelResult = await execGit(
-								['rev-parse', '--show-toplevel'],
-								subdirPath,
-								sshRemote
-							);
-							if (toplevelResult.exitCode !== 0) {
-								return null; // Git command failed — treat as invalid
-							}
-							const toplevel = toplevelResult.stdout.trim();
-							// For local paths, canonicalize via realpath so that symlinked base
-							// paths (common on Linux: /home → /data/home; Windows junctions) match
-							// what git rev-parse --show-toplevel returns. path.resolve alone does
-							// NOT follow symlinks, which previously caused every subdir to be
-							// rejected and the entire worktree set to be marked stale.
-							const normalizedSubdir = sshRemote
-								? subdirPath
-								: await fs.realpath(subdirPath).catch(() => path.resolve(subdirPath));
-							const normalizedToplevel = sshRemote
-								? toplevel
-								: await fs.realpath(toplevel).catch(() => path.resolve(toplevel));
-							if (normalizedSubdir !== normalizedToplevel) {
-								return null; // Subdirectory inside a repo, not a repo/worktree root
-							}
-
-							// Run remaining git commands in parallel for each subdirectory (SSH-aware via execGit)
-							const [gitDirResult, gitCommonDirResult, branchResult] = await Promise.all([
-								execGit(['rev-parse', '--git-dir'], subdirPath, sshRemote),
-								execGit(['rev-parse', '--git-common-dir'], subdirPath, sshRemote),
-								execGit(['rev-parse', '--abbrev-ref', 'HEAD'], subdirPath, sshRemote),
-							]);
-
-							const gitDir = gitDirResult.exitCode === 0 ? gitDirResult.stdout.trim() : '';
-							const gitCommonDir =
-								gitCommonDirResult.exitCode === 0 ? gitCommonDirResult.stdout.trim() : gitDir;
-							const isWorktree = gitDir !== gitCommonDir;
-							const branch = branchResult.exitCode === 0 ? branchResult.stdout.trim() : null;
-
-							// Get repo root
-							let repoRoot: string | null = null;
-							if (isWorktree && gitCommonDir) {
-								// For SSH, use POSIX path operations
-								if (sshRemote) {
-									const commonDirAbs = gitCommonDir.startsWith('/')
-										? gitCommonDir
-										: `${subdirPath}/${gitCommonDir}`.replace(/\/+/g, '/');
-									// Get parent directory (remove last path component)
-									repoRoot = commonDirAbs.split('/').slice(0, -1).join('/') || '/';
-								} else {
-									const commonDirAbs = path.isAbsolute(gitCommonDir)
-										? gitCommonDir
-										: path.resolve(subdirPath, gitCommonDir);
-									repoRoot = path.dirname(commonDirAbs);
-								}
-							} else {
-								const repoRootResult = await execGit(
-									['rev-parse', '--show-toplevel'],
-									subdirPath,
-									sshRemote
-								);
-								if (repoRootResult.exitCode === 0) {
-									repoRoot = repoRootResult.stdout.trim();
+							if (depthRemaining > 0) {
+								try {
+									return await scanLevel(subdirPath, depthRemaining - 1);
+								} catch (err) {
+									const code = (err as NodeJS.ErrnoException | undefined)?.code;
+									if (code !== 'ENOENT' && code !== 'EACCES' && code !== 'ENOTDIR') {
+										logger.warn(`${LOG_CONTEXT} Failed to recurse into ${subdirPath}: ${err}`);
+									}
+									return [];
 								}
 							}
-
-							return {
-								path: subdirPath,
-								name: subdir.name,
-								isWorktree,
-								branch,
-								repoRoot,
-							};
+							return [];
 						})
 					);
 
-					// Filter out null results (non-git directories)
-					const gitSubdirs = results.filter((r): r is NonNullable<typeof r> => r !== null);
+					return results.flat();
+				};
 
+				try {
+					const gitSubdirs = await scanLevel(parentPath, MAX_DEPTH);
 					return { gitSubdirs };
 				} catch (err) {
 					// ENOENT is expected when the configured parent path has been moved
@@ -1275,12 +1317,17 @@ export function registerGitHandlers(_deps: GitHandlerDependencies): void {
 					// Verify directory exists
 					await fs.access(worktreePath);
 
-					// Start watching the directory (only top level, not recursive)
+					// Watch one level deep so worktrees from slash-named branches
+					// (e.g. "fix/worktree-removal" → <basePath>/fix/worktree-removal)
+					// also fire addDir/unlinkDir events. The addDir handler validates
+					// every candidate via `is-inside-work-tree` + `show-toplevel`, so
+					// the intermediate group directory (e.g. "fix") is rejected and
+					// only the actual worktree is reported as discovered.
 					const watcher = chokidar.watch(worktreePath, {
 						ignored: /(^|[/\\])\../, // Ignore dotfiles
 						persistent: true,
 						ignoreInitial: true,
-						depth: 0, // Only watch top-level directory changes
+						depth: 1,
 					});
 
 					// Handler for directory additions


### PR DESCRIPTION
## Summary

- `scanWorktreeDirectory` only read immediate children of the configured `basePath`, so worktrees from slash-named branches (e.g. `fix/worktree-removal` → `<basePath>/fix/worktree-removal`) never appeared in `gitSubdirs`. On every app restart, `scanWorktreeConfigs` then bulk-removed those nested children because their `cwd` was absent from the scan.
- Recurse one level into non-git subdirs (configurable `MAX_DEPTH = 1`) so the common `<basePath>/<group>/<branch>` layout is covered. Errors while reading a nested group dir are swallowed locally and do **not** flag `scanFailed` — that flag is reserved for the top-level read so the renderer's removal-skip fallback continues to work.
- Bump the chokidar watcher from `depth: 0` to `depth: 1` so live `addDir` / `unlinkDir` events fire for nested worktrees too. The existing `is-inside-work-tree` + `show-toplevel` checks in the addDir handler correctly reject the intermediate group dir (e.g. `fix/`).

## Repro

1. Create a worktree from a slash-named branch: `git worktree add <basePath>/fix/foo fix/foo`.
2. Open the agent in Maestro so the child session is registered.
3. Restart the app. The session for `fix/foo` disappears even though the worktree is still on disk.

After this PR, the session survives the restart (and external `git worktree add`/`remove` for nested branches now triggers the live listener).

## Test plan

- [x] `vitest run src/__tests__/main/ipc/handlers/git.test.ts` (156 tests, all green) — includes the existing scan/watcher coverage plus three new cases:
  - nested worktrees from slash-named branches are discovered alongside flat ones
  - recursion stops at one level (`<basePath>/a/b/c` is **not** scanned)
  - read errors on a nested group dir don't fail the whole scan or set `scanFailed`
- [x] `vitest run src/__tests__/renderer/hooks/useWorktreeHandlers.test.ts` (60 tests)
- [x] `vitest run src/__tests__/main/preload/git.test.ts src/__tests__/renderer/components/WorktreeRunSection.test.tsx src/__tests__/renderer/components/AppWorktreeModals.test.tsx`
- [x] Updated the existing watcher test to expect `depth: 1` (was the only spec asserting on the old value).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Discover nested worktrees in subdirectories, including branch names that contain slashes.

* **Bug Fixes**
  * Scan tolerates partial directory read errors and still returns available worktrees; top-level remote read failures mark scans as failed.
  * Enforced one-level recursion to avoid deeper nested discovery.
  * File-watcher now monitors one directory level deeper to detect nested worktree changes.

* **Tests**
  * Expanded coverage for nested discovery, recursion limits, SSH/read failures, and watcher behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->