### PR TITLE
fix(sidebar): show working indicator on fresh Claude agents

### DIFF
--- a/src/__tests__/renderer/components/SessionList.test.tsx
+++ b/src/__tests__/renderer/components/SessionList.test.tsx
@@ -2569,6 +2569,75 @@ describe('SessionList', () => {
 			const indicator = container.querySelector('[title="No active Claude session"]');
 			expect(indicator).toBeInTheDocument();
 		});
+
+		it('shows working color (not hollow) for busy claude without agentSessionId', () => {
+			// Regression: fresh worktrees that are actively working but haven't bound a
+			// provider session yet should still surface the busy indicator.
+			const sessions = [
+				createMockSession({
+					id: 's1',
+					name: 'Fresh Worktree',
+					toolType: 'claude-code',
+					agentSessionId: undefined,
+					state: 'busy',
+				}),
+			];
+			useSessionStore.setState({ sessions: sessions });
+			useUIStore.setState({ leftSidebarOpen: true });
+			const props = createDefaultProps({
+				sortedSessions: sessions,
+			});
+			const { container } = render(<SessionList {...props} />);
+
+			// Hollow "no session" indicator must not be shown while the agent is busy.
+			expect(container.querySelector('[title="No active Claude session"]')).not.toBeInTheDocument();
+			// The colored "thinking" indicator must be present.
+			expect(container.querySelector('[title="Agent is thinking"]')).toBeInTheDocument();
+		});
+
+		it('shows connecting color (not hollow) for connecting claude without agentSessionId', () => {
+			const sessions = [
+				createMockSession({
+					id: 's1',
+					name: 'Connecting Worktree',
+					toolType: 'claude-code',
+					agentSessionId: undefined,
+					state: 'connecting',
+				}),
+			];
+			useSessionStore.setState({ sessions: sessions });
+			useUIStore.setState({ leftSidebarOpen: true });
+			const props = createDefaultProps({
+				sortedSessions: sessions,
+			});
+			const { container } = render(<SessionList {...props} />);
+
+			expect(container.querySelector('[title="No active Claude session"]')).not.toBeInTheDocument();
+			expect(
+				container.querySelector('[title="Attempting to establish connection"]')
+			).toBeInTheDocument();
+		});
+
+		it('shows working color in skinny mode for busy claude without agentSessionId', () => {
+			const sessions = [
+				createMockSession({
+					id: 's1',
+					name: 'Fresh Worktree Skinny',
+					toolType: 'claude-code',
+					agentSessionId: undefined,
+					state: 'busy',
+				}),
+			];
+			useSessionStore.setState({ sessions: sessions });
+			useUIStore.setState({ leftSidebarOpen: false });
+			const props = createDefaultProps({
+				sortedSessions: sessions,
+			});
+			const { container } = render(<SessionList {...props} />);
+
+			// In skinny mode the unbound idle dot also must not appear when busy.
+			expect(container.querySelector('[title="No active Claude session"]')).not.toBeInTheDocument();
+		});
 	});
 
 	// ============================================================================

--- a/src/renderer/components/SessionItem.tsx
+++ b/src/renderer/components/SessionItem.tsx
@@ -93,6 +93,15 @@ export const SessionItem = memo(function SessionItem({
 	const showGitLocalBadge =
 		variant !== 'bookmark' && variant !== 'worktree' && session.toolType !== 'terminal';
 
+	// Hollow "no Claude session bound" dot only applies when truly idle —
+	// active states (busy/connecting/etc.) must surface their color so
+	// fresh agents that are working still light up.
+	const isUnboundIdle =
+		session.toolType === 'claude-code' &&
+		!session.agentSessionId &&
+		!isInBatch &&
+		session.state === 'idle';
+
 	// Determine container styling based on variant
 	const getContainerClassName = () => {
 		const isWorktree = variant === 'worktree';
@@ -337,58 +346,46 @@ export const SessionItem = memo(function SessionItem({
 						))}
 
 					{/* AI Status Indicator with Unread Badge */}
-					{(() => {
-						// Hollow "no Claude session bound" dot only applies when truly idle —
-						// active states (busy/connecting/etc.) must surface their color so
-						// fresh agents that are working still light up.
-						const isUnboundIdle =
-							session.toolType === 'claude-code' &&
-							!session.agentSessionId &&
-							!isInBatch &&
-							session.state === 'idle';
-						return (
-							<div className="relative">
-								<div
-									className={`w-2 h-2 rounded-full ${session.state === 'connecting' ? 'animate-pulse' : session.state === 'busy' || isInBatch ? 'animate-pulse' : ''}`}
-									style={
-										isUnboundIdle
-											? {
-													border: `1.5px solid ${theme.colors.textDim}`,
-													backgroundColor: 'transparent',
-												}
-											: {
-													backgroundColor: isInBatch
-														? theme.colors.warning
-														: getStatusColor(session.state, theme),
-												}
-									}
-									title={
-										isUnboundIdle
-											? 'No active Claude session'
-											: session.state === 'idle'
-												? 'Ready and waiting'
-												: session.state === 'busy'
-													? session.cliActivity
-														? `CLI: Running playbook "${session.cliActivity.playbookName}"`
-														: 'Agent is thinking'
-													: session.state === 'connecting'
-														? 'Attempting to establish connection'
-														: session.state === 'error'
-															? 'No connection with agent'
-															: 'Waiting for input'
-									}
-								/>
-								{/* Unread Notification Badge */}
-								{!isActive && session.aiTabs?.some((tab) => tab.hasUnread) && (
-									<div
-										className="absolute -top-0.5 -right-0.5 w-1.5 h-1.5 rounded-full"
-										style={{ backgroundColor: theme.colors.error }}
-										title="Unread messages"
-									/>
-								)}
-							</div>
-						);
-					})()}
+					<div className="relative">
+						<div
+							className={`w-2 h-2 rounded-full ${session.state === 'connecting' ? 'animate-pulse' : session.state === 'busy' || isInBatch ? 'animate-pulse' : ''}`}
+							style={
+								isUnboundIdle
+									? {
+											border: `1.5px solid ${theme.colors.textDim}`,
+											backgroundColor: 'transparent',
+										}
+									: {
+											backgroundColor: isInBatch
+												? theme.colors.warning
+												: getStatusColor(session.state, theme),
+										}
+							}
+							title={
+								isUnboundIdle
+									? 'No active Claude session'
+									: session.state === 'idle'
+										? 'Ready and waiting'
+										: session.state === 'busy'
+											? session.cliActivity
+												? `CLI: Running playbook "${session.cliActivity.playbookName}"`
+												: 'Agent is thinking'
+											: session.state === 'connecting'
+												? 'Attempting to establish connection'
+												: session.state === 'error'
+													? 'No connection with agent'
+													: 'Waiting for input'
+							}
+						/>
+						{/* Unread Notification Badge */}
+						{!isActive && session.aiTabs?.some((tab) => tab.hasUnread) && (
+							<div
+								className="absolute -top-0.5 -right-0.5 w-1.5 h-1.5 rounded-full"
+								style={{ backgroundColor: theme.colors.error }}
+								title="Unread messages"
+							/>
+						)}
+					</div>
 				</div>
 			</div>
 		</div>

--- a/src/renderer/components/SessionItem.tsx
+++ b/src/renderer/components/SessionItem.tsx
@@ -337,46 +337,58 @@ export const SessionItem = memo(function SessionItem({
 						))}
 
 					{/* AI Status Indicator with Unread Badge */}
-					<div className="relative">
-						<div
-							className={`w-2 h-2 rounded-full ${session.state === 'connecting' ? 'animate-pulse' : session.state === 'busy' || isInBatch ? 'animate-pulse' : ''}`}
-							style={
-								session.toolType === 'claude-code' && !session.agentSessionId && !isInBatch
-									? {
-											border: `1.5px solid ${theme.colors.textDim}`,
-											backgroundColor: 'transparent',
-										}
-									: {
-											backgroundColor: isInBatch
-												? theme.colors.warning
-												: getStatusColor(session.state, theme),
-										}
-							}
-							title={
-								session.toolType === 'claude-code' && !session.agentSessionId
-									? 'No active Claude session'
-									: session.state === 'idle'
-										? 'Ready and waiting'
-										: session.state === 'busy'
-											? session.cliActivity
-												? `CLI: Running playbook "${session.cliActivity.playbookName}"`
-												: 'Agent is thinking'
-											: session.state === 'connecting'
-												? 'Attempting to establish connection'
-												: session.state === 'error'
-													? 'No connection with agent'
-													: 'Waiting for input'
-							}
-						/>
-						{/* Unread Notification Badge */}
-						{!isActive && session.aiTabs?.some((tab) => tab.hasUnread) && (
-							<div
-								className="absolute -top-0.5 -right-0.5 w-1.5 h-1.5 rounded-full"
-								style={{ backgroundColor: theme.colors.error }}
-								title="Unread messages"
-							/>
-						)}
-					</div>
+					{(() => {
+						// Hollow "no Claude session bound" dot only applies when truly idle —
+						// active states (busy/connecting/etc.) must surface their color so
+						// fresh agents that are working still light up.
+						const isUnboundIdle =
+							session.toolType === 'claude-code' &&
+							!session.agentSessionId &&
+							!isInBatch &&
+							session.state === 'idle';
+						return (
+							<div className="relative">
+								<div
+									className={`w-2 h-2 rounded-full ${session.state === 'connecting' ? 'animate-pulse' : session.state === 'busy' || isInBatch ? 'animate-pulse' : ''}`}
+									style={
+										isUnboundIdle
+											? {
+													border: `1.5px solid ${theme.colors.textDim}`,
+													backgroundColor: 'transparent',
+												}
+											: {
+													backgroundColor: isInBatch
+														? theme.colors.warning
+														: getStatusColor(session.state, theme),
+												}
+									}
+									title={
+										isUnboundIdle
+											? 'No active Claude session'
+											: session.state === 'idle'
+												? 'Ready and waiting'
+												: session.state === 'busy'
+													? session.cliActivity
+														? `CLI: Running playbook "${session.cliActivity.playbookName}"`
+														: 'Agent is thinking'
+													: session.state === 'connecting'
+														? 'Attempting to establish connection'
+														: session.state === 'error'
+															? 'No connection with agent'
+															: 'Waiting for input'
+									}
+								/>
+								{/* Unread Notification Badge */}
+								{!isActive && session.aiTabs?.some((tab) => tab.hasUnread) && (
+									<div
+										className="absolute -top-0.5 -right-0.5 w-1.5 h-1.5 rounded-full"
+										style={{ backgroundColor: theme.colors.error }}
+										title="Unread messages"
+									/>
+								)}
+							</div>
+						);
+					})()}
 				</div>
 			</div>
 		</div>

--- a/src/renderer/components/SessionList/CollapsedSessionPill.tsx
+++ b/src/renderer/components/SessionList/CollapsedSessionPill.tsx
@@ -45,6 +45,10 @@ export const CollapsedSessionPill = memo(function CollapsedSessionPill({
 				const isFirst = idx === 0;
 				const isLast = idx === allSessions.length - 1;
 				const isInBatch = activeBatchSessionIds.includes(s.id);
+				// Hollow "no Claude session bound" only applies when truly idle —
+				// active states surface their color so fresh agents still light up.
+				const isUnboundIdle =
+					s.toolType === 'claude-code' && !s.agentSessionId && !isInBatch && s.state === 'idle';
 
 				return (
 					<div
@@ -54,7 +58,7 @@ export const CollapsedSessionPill = memo(function CollapsedSessionPill({
 						aria-label={`Switch to ${s.name}`}
 						className={`group/segment relative flex-1 h-full ${isInBatch ? 'animate-pulse' : ''}`}
 						style={{
-							...(s.toolType === 'claude-code' && !s.agentSessionId && !isInBatch
+							...(isUnboundIdle
 								? { border: `1px solid ${theme.colors.textDim}`, backgroundColor: 'transparent' }
 								: {
 										backgroundColor: isInBatch

--- a/src/renderer/components/SessionList/SkinnySidebar.tsx
+++ b/src/renderer/components/SessionList/SkinnySidebar.tsx
@@ -42,12 +42,16 @@ export const SkinnySidebar = memo(function SkinnySidebar({
 			{visibleSessions.map((session) => {
 				const isInBatch = activeBatchSessionIds.includes(session.id);
 				const hasUnreadTabs = session.aiTabs?.some((tab) => tab.hasUnread);
+				// Hollow "no Claude session bound" dot only applies when truly idle —
+				// active states surface the normal color so fresh agents still light up.
+				const isUnboundIdle =
+					session.toolType === 'claude-code' && !session.agentSessionId && session.state === 'idle';
 				const effectiveStatusColor = isInBatch
 					? theme.colors.warning
-					: session.toolType === 'claude-code' && !session.agentSessionId
+					: isUnboundIdle
 						? undefined
 						: getStatusColor(session.state, theme);
-				const shouldPulse = session.state === 'busy' || isInBatch;
+				const shouldPulse = session.state === 'busy' || session.state === 'connecting' || isInBatch;
 
 				return (
 					<div
@@ -70,7 +74,7 @@ export const SkinnySidebar = memo(function SkinnySidebar({
 								className={`w-3 h-3 rounded-full ${shouldPulse ? 'animate-pulse' : ''}`}
 								style={{
 									opacity: activeSessionId === session.id ? 1 : 0.25,
-									...(session.toolType === 'claude-code' && !session.agentSessionId && !isInBatch
+									...(isUnboundIdle && !isInBatch
 										? {
 												border: `1.5px solid ${theme.colors.textDim}`,
 												backgroundColor: 'transparent',
@@ -79,11 +83,7 @@ export const SkinnySidebar = memo(function SkinnySidebar({
 												backgroundColor: effectiveStatusColor,
 											}),
 								}}
-								title={
-									session.toolType === 'claude-code' && !session.agentSessionId
-										? 'No active Claude session'
-										: undefined
-								}
+								title={isUnboundIdle ? 'No active Claude session' : undefined}
 							/>
 							{activeSessionId !== session.id && hasUnreadTabs && (
 								<div

--- a/src/renderer/components/SessionList/SkinnySidebar.tsx
+++ b/src/renderer/components/SessionList/SkinnySidebar.tsx
@@ -45,7 +45,10 @@ export const SkinnySidebar = memo(function SkinnySidebar({
 				// Hollow "no Claude session bound" dot only applies when truly idle —
 				// active states surface the normal color so fresh agents still light up.
 				const isUnboundIdle =
-					session.toolType === 'claude-code' && !session.agentSessionId && session.state === 'idle';
+					session.toolType === 'claude-code' &&
+					!session.agentSessionId &&
+					!isInBatch &&
+					session.state === 'idle';
 				const effectiveStatusColor = isInBatch
 					? theme.colors.warning
 					: isUnboundIdle
@@ -74,7 +77,7 @@ export const SkinnySidebar = memo(function SkinnySidebar({
 								className={`w-3 h-3 rounded-full ${shouldPulse ? 'animate-pulse' : ''}`}
 								style={{
 									opacity: activeSessionId === session.id ? 1 : 0.25,
-									...(isUnboundIdle && !isInBatch
+									...(isUnboundIdle
 										? {
 												border: `1.5px solid ${theme.colors.textDim}`,
 												backgroundColor: 'transparent',


### PR DESCRIPTION
## Summary

- Fresh worktrees (and any newly-spawned `claude-code` agent that hadn't emitted its first `session_id`) showed a hollow/transparent status dot even while actively working. The hollow ring was meant to signal "no provider session bound yet," but it overrode the busy/connecting/error colors and hid the working indicator until the first response came back.
- Scoped the hollow rendering to `state === 'idle'` only. Active states (`busy`, `connecting`, `waiting_input`, `error`) now surface their normal color via `getStatusColor()` regardless of `agentSessionId` in `SessionItem`, `SkinnySidebar`, and `CollapsedSessionPill`. Also widened the skinny-sidebar pulse trigger to include `connecting`.

## Test plan

- [x] `tsc -p tsconfig.lint.json --noEmit` exits 0
- [x] vitest on `SessionList.test.tsx`, `SessionList/`, and `SessionItemCue.test.tsx`: 224 passed (3 new regression tests added)
  - busy + no `agentSessionId` shows "Agent is thinking" (not hollow)
  - connecting + no `agentSessionId` shows "Attempting to establish connection" (not hollow)
  - busy + no `agentSessionId` in skinny mode does not render hollow dot
- [x] eslint + prettier clean on changed files
- [ ] Manual: spawn a fresh worktree and confirm pulsing yellow/orange dot appears immediately while the agent boots

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined Claude session status indicators: hollow (transparent) markers now only show for truly idle, unbound sessions; active states show filled, color-coded dots and pulse during connecting/busy operations. Display is consistent across layouts and batch membership.
* **Tests**
  * Added regression coverage to ensure status indicators and tooltips render correctly across idle, connecting, and busy scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->