### PR TITLE
fix(web): honor 'All' for Max Output Lines per Response on mobile/web

### DIFF
--- a/src/__tests__/web/mobile/MessageHistory.test.tsx
+++ b/src/__tests__/web/mobile/MessageHistory.test.tsx
@@ -240,47 +240,77 @@ describe('MessageHistory', () => {
 	});
 
 	describe('Message Truncation', () => {
-		const longText = 'A'.repeat(600); // > CHAR_TRUNCATE_THRESHOLD (500)
-		const manyLines = 'Line\n'.repeat(15); // > LINE_TRUNCATE_THRESHOLD (8)
+		// 15 newline-separated lines; > any finite cap we exercise below.
+		const manyLines = Array.from({ length: 15 }, (_, i) => `Line ${i + 1}`).join('\n');
+		// 600 characters on a single line — used to assert that char length alone
+		// does NOT trigger truncation (matches desktop TerminalOutput behavior).
+		const longSingleLine = 'A'.repeat(600);
 
-		it('truncates text longer than 500 characters', () => {
-			const logs: LogEntry[] = [createLogEntry({ text: longText })];
-			render(<MessageHistory logs={logs} inputMode="ai" />);
-			expect(screen.getByText('▶ expand')).toBeInTheDocument();
-		});
-
-		it('truncates text with more than 8 lines when a finite line cap is configured', () => {
+		it('truncates by lines when line count exceeds the configured cap', () => {
 			const logs: LogEntry[] = [createLogEntry({ text: manyLines })];
-			// With the default "All" cap (Infinity) line-based truncation is off —
-			// mirror the desktop Max Output Lines setting by passing an explicit cap.
 			render(<MessageHistory logs={logs} inputMode="ai" maxOutputLines={8} />);
 			expect(screen.getByText('▶ expand')).toBeInTheDocument();
+			// Should only show first 8 lines.
+			expect(screen.getByText(/Line 1\b/)).toBeInTheDocument();
+			expect(screen.getByText(/Line 8\b/)).toBeInTheDocument();
+			expect(screen.queryByText(/Line 9\b/)).not.toBeInTheDocument();
 		});
 
+		it('does not truncate when line count is at or under the configured cap', () => {
+			const logs: LogEntry[] = [createLogEntry({ text: manyLines })];
+			render(<MessageHistory logs={logs} inputMode="ai" maxOutputLines={50} />);
+			expect(screen.queryByText('▶ expand')).not.toBeInTheDocument();
+		});
+
+		// Regression: prior to fix/web-chat-expand the component had a 500-char
+		// truncation that fired regardless of the user's "Max Output Lines" choice,
+		// so picking "All" still collapsed long single-line responses.
+		it('does not truncate by character length when maxOutputLines is "All" (Infinity)', () => {
+			const logs: LogEntry[] = [createLogEntry({ text: longSingleLine })];
+			render(<MessageHistory logs={logs} inputMode="ai" maxOutputLines={Infinity} />);
+			expect(screen.queryByText('▶ expand')).not.toBeInTheDocument();
+		});
+
+		// Regression: even on the multi-line path, "All" must mean no truncation.
 		it('does not truncate by lines when maxOutputLines is "All" (Infinity)', () => {
 			const logs: LogEntry[] = [createLogEntry({ text: manyLines })];
 			render(<MessageHistory logs={logs} inputMode="ai" maxOutputLines={Infinity} />);
-			// 15 lines but only ~75 chars, so char-based truncation does not kick in.
+			expect(screen.queryByText('▶ expand')).not.toBeInTheDocument();
+		});
+
+		// Regression: a long single-line response must not collapse just because of
+		// its character count when a finite line cap is configured — only line
+		// counts gate truncation, matching desktop TerminalOutput.
+		it('does not truncate by character length when only a finite line cap is configured', () => {
+			const logs: LogEntry[] = [createLogEntry({ text: longSingleLine })];
+			render(<MessageHistory logs={logs} inputMode="ai" maxOutputLines={15} />);
+			expect(screen.queryByText('▶ expand')).not.toBeInTheDocument();
+		});
+
+		it('defaults to "All" (no truncation) when maxOutputLines is omitted', () => {
+			const logs: LogEntry[] = [createLogEntry({ text: manyLines })];
+			render(<MessageHistory logs={logs} inputMode="ai" />);
 			expect(screen.queryByText('▶ expand')).not.toBeInTheDocument();
 		});
 
 		it('does not truncate short text', () => {
 			const logs: LogEntry[] = [createLogEntry({ text: 'Short text' })];
-			render(<MessageHistory logs={logs} inputMode="ai" />);
+			render(<MessageHistory logs={logs} inputMode="ai" maxOutputLines={8} />);
 			expect(screen.queryByText('▶ expand')).not.toBeInTheDocument();
 		});
 
 		it('shows "(tap to expand)" hint for truncated messages', () => {
-			const logs: LogEntry[] = [createLogEntry({ text: longText })];
-			render(<MessageHistory logs={logs} inputMode="ai" />);
+			const logs: LogEntry[] = [createLogEntry({ text: manyLines })];
+			render(<MessageHistory logs={logs} inputMode="ai" maxOutputLines={8} />);
 			expect(screen.getByText(/tap to expand/)).toBeInTheDocument();
 		});
 
 		it('expands truncated message on click', () => {
-			const logs: LogEntry[] = [createLogEntry({ id: 'expand-test', text: longText })];
-			const { container } = render(<MessageHistory logs={logs} inputMode="ai" />);
+			const logs: LogEntry[] = [createLogEntry({ id: 'expand-test', text: manyLines })];
+			const { container } = render(
+				<MessageHistory logs={logs} inputMode="ai" maxOutputLines={8} />
+			);
 
-			// Find the message container and click it
 			const messageDiv = container.querySelector('[style*="cursor: pointer"]');
 			expect(messageDiv).toBeInTheDocument();
 
@@ -290,8 +320,10 @@ describe('MessageHistory', () => {
 		});
 
 		it('collapses expanded message on second click', () => {
-			const logs: LogEntry[] = [createLogEntry({ id: 'collapse-test', text: longText })];
-			const { container } = render(<MessageHistory logs={logs} inputMode="ai" />);
+			const logs: LogEntry[] = [createLogEntry({ id: 'collapse-test', text: manyLines })];
+			const { container } = render(
+				<MessageHistory logs={logs} inputMode="ai" maxOutputLines={8} />
+			);
 
 			const messageDiv = container.querySelector('[style*="cursor: pointer"]');
 
@@ -304,43 +336,24 @@ describe('MessageHistory', () => {
 			expect(screen.getByText('▶ expand')).toBeInTheDocument();
 		});
 
-		it('truncates by lines when line count exceeds the configured cap', () => {
-			const tenLines =
-				'Line 1\nLine 2\nLine 3\nLine 4\nLine 5\nLine 6\nLine 7\nLine 8\nLine 9\nLine 10';
-			const logs: LogEntry[] = [createLogEntry({ text: tenLines })];
-			render(<MessageHistory logs={logs} inputMode="ai" maxOutputLines={8} />);
-
-			// Should show truncation indicator
-			expect(screen.getByText('▶ expand')).toBeInTheDocument();
-			// Should only show first 8 lines
-			expect(screen.getByText(/Line 1/)).toBeInTheDocument();
-			expect(screen.getByText(/Line 8/)).toBeInTheDocument();
-			expect(screen.queryByText(/Line 9/)).not.toBeInTheDocument();
-		});
-
-		it('truncates by character count when under line threshold', () => {
-			// 501 chars but only 1 line
-			const longSingleLine = 'X'.repeat(501);
-			const logs: LogEntry[] = [createLogEntry({ text: longSingleLine })];
-			render(<MessageHistory logs={logs} inputMode="ai" />);
-
-			expect(screen.getByText('▶ expand')).toBeInTheDocument();
-		});
-
 		it('shows full text when expanded', () => {
-			const logs: LogEntry[] = [createLogEntry({ id: 'full-text-test', text: longText })];
-			const { container } = render(<MessageHistory logs={logs} inputMode="ai" />);
+			const logs: LogEntry[] = [createLogEntry({ id: 'full-text-test', text: manyLines })];
+			const { container } = render(
+				<MessageHistory logs={logs} inputMode="ai" maxOutputLines={8} />
+			);
 
 			const messageDiv = container.querySelector('[style*="cursor: pointer"]');
 			fireEvent.click(messageDiv!);
 
-			// Should show full text (600 As)
-			expect(screen.getByText(longText)).toBeInTheDocument();
+			// All 15 lines should now be visible.
+			expect(screen.getByText(/Line 15\b/)).toBeInTheDocument();
 		});
 
 		it('has pointer cursor for truncatable messages', () => {
-			const logs: LogEntry[] = [createLogEntry({ text: longText })];
-			const { container } = render(<MessageHistory logs={logs} inputMode="ai" />);
+			const logs: LogEntry[] = [createLogEntry({ text: manyLines })];
+			const { container } = render(
+				<MessageHistory logs={logs} inputMode="ai" maxOutputLines={8} />
+			);
 
 			const messageDiv = container.querySelector('[style*="cursor"]');
 			expect(messageDiv).toHaveStyle({ cursor: 'pointer' });
@@ -373,12 +386,12 @@ describe('MessageHistory', () => {
 
 		it('calls onMessageTap even for truncatable messages', () => {
 			const onMessageTap = vi.fn();
-			const longText = 'A'.repeat(600);
-			const entry = createLogEntry({ text: longText });
+			const manyLines = Array.from({ length: 15 }, (_, i) => `Line ${i + 1}`).join('\n');
+			const entry = createLogEntry({ text: manyLines });
 			const logs: LogEntry[] = [entry];
 
 			const { container } = render(
-				<MessageHistory logs={logs} inputMode="ai" onMessageTap={onMessageTap} />
+				<MessageHistory logs={logs} inputMode="ai" onMessageTap={onMessageTap} maxOutputLines={8} />
 			);
 
 			const messageDiv = container.querySelector('[style*="cursor: pointer"]');
@@ -759,12 +772,13 @@ describe('MessageHistory', () => {
 			expect(screen.getByText('Hello 你好 مرحبا 🎉')).toBeInTheDocument();
 		});
 
-		it('handles very long single-word text', () => {
+		it('handles very long single-word text without truncating when "All"', () => {
+			// Long char count alone must NOT trigger truncation under the
+			// desktop-parity rules — only the line cap drives the collapse.
 			const longWord = 'supercalifragilisticexpialidocious'.repeat(50);
 			const logs: LogEntry[] = [createLogEntry({ text: longWord })];
 			render(<MessageHistory logs={logs} inputMode="ai" />);
-			// Should show truncation due to length
-			expect(screen.getByText('▶ expand')).toBeInTheDocument();
+			expect(screen.queryByText('▶ expand')).not.toBeInTheDocument();
 		});
 
 		it('handles special HTML characters', () => {
@@ -889,14 +903,16 @@ describe('MessageHistory', () => {
 		});
 
 		it('handles expand/collapse during scroll', () => {
-			const longText = 'A'.repeat(600);
+			const manyLines = Array.from({ length: 15 }, (_, i) => `Line ${i + 1}`).join('\n');
 			const logs: LogEntry[] = [
-				createLogEntry({ id: 'msg-1', text: longText }),
+				createLogEntry({ id: 'msg-1', text: manyLines }),
 				createLogEntry({ id: 'msg-2', text: 'Short message' }),
-				createLogEntry({ id: 'msg-3', text: longText }),
+				createLogEntry({ id: 'msg-3', text: manyLines }),
 			];
 
-			const { container } = render(<MessageHistory logs={logs} inputMode="ai" />);
+			const { container } = render(
+				<MessageHistory logs={logs} inputMode="ai" maxOutputLines={8} />
+			);
 
 			// Find first truncatable message and expand it
 			const firstExpandable = container.querySelector('[style*="cursor: pointer"]');
@@ -908,10 +924,12 @@ describe('MessageHistory', () => {
 		});
 
 		it('maintains expanded state across re-renders', () => {
-			const longText = 'A'.repeat(600);
-			const logs: LogEntry[] = [createLogEntry({ id: 'persistent', text: longText })];
+			const manyLines = Array.from({ length: 15 }, (_, i) => `Line ${i + 1}`).join('\n');
+			const logs: LogEntry[] = [createLogEntry({ id: 'persistent', text: manyLines })];
 
-			const { container, rerender } = render(<MessageHistory logs={logs} inputMode="ai" />);
+			const { container, rerender } = render(
+				<MessageHistory logs={logs} inputMode="ai" maxOutputLines={8} />
+			);
 
 			// Expand the message
 			const messageDiv = container.querySelector('[style*="cursor: pointer"]');
@@ -919,7 +937,7 @@ describe('MessageHistory', () => {
 			expect(screen.getByText('▼ collapse')).toBeInTheDocument();
 
 			// Rerender with same logs
-			rerender(<MessageHistory logs={logs} inputMode="ai" />);
+			rerender(<MessageHistory logs={logs} inputMode="ai" maxOutputLines={8} />);
 
 			// Should still be expanded
 			expect(screen.getByText('▼ collapse')).toBeInTheDocument();

--- a/src/web/mobile/MessageHistory.tsx
+++ b/src/web/mobile/MessageHistory.tsx
@@ -12,11 +12,6 @@ import { stripAnsiCodes } from '../../shared/stringUtils';
 import { formatTimestamp } from '../../shared/formatters';
 import { WebReadingContent } from './WebReadingContent';
 
-/** Threshold for character-based truncation */
-const CHAR_TRUNCATE_THRESHOLD = 500;
-/** Threshold for line-based truncation */
-const LINE_TRUNCATE_THRESHOLD = 8;
-
 export interface LogEntry {
 	id?: string;
 	timestamp: number;
@@ -52,8 +47,8 @@ export interface MessageHistoryProps {
 	enableBionifyReadingMode?: boolean;
 	/**
 	 * Max output lines per message before collapsing — mirrors the desktop
-	 * "Max Output Lines per Response" setting. Pass `Infinity` (or omit) to
-	 * fall back to the local line/char defaults and never force-truncate.
+	 * "Max Output Lines per Response" setting. Pass `Infinity` (or omit) for
+	 * "All": no truncation regardless of length.
 	 */
 	maxOutputLines?: number;
 }
@@ -117,40 +112,25 @@ export function MessageHistory({
 	const [hasNewMessages, setHasNewMessages] = useState(false);
 	const [newMessageCount, setNewMessageCount] = useState(0);
 
-	// When the user-configured line cap is finite ("15" / "25" / …) it takes
-	// precedence over the local mobile default; "All" (Infinity) disables
-	// line-based collapse entirely, matching desktop behavior.
+	// "All" (Infinity / unset) disables truncation entirely; a finite cap
+	// drives line-based collapse, matching desktop TerminalOutput.tsx behavior.
 	const hasLineCap = Number.isFinite(maxOutputLines);
-	const effectiveLineCap = hasLineCap ? maxOutputLines : LINE_TRUNCATE_THRESHOLD;
 
-	/**
-	 * Check if a message should be truncated
-	 */
 	const shouldTruncate = useCallback(
 		(text: string): boolean => {
-			if (text.length > CHAR_TRUNCATE_THRESHOLD) return true;
 			if (!hasLineCap) return false;
-			const lineCount = text.split('\n').length;
-			return lineCount > effectiveLineCap;
+			return text.split('\n').length > maxOutputLines;
 		},
-		[effectiveLineCap, hasLineCap]
+		[hasLineCap, maxOutputLines]
 	);
 
-	/**
-	 * Get truncated text for display
-	 */
 	const getTruncatedText = useCallback(
 		(text: string): string => {
+			if (!hasLineCap) return text;
 			const lines = text.split('\n');
-			if (hasLineCap && lines.length > effectiveLineCap) {
-				return lines.slice(0, effectiveLineCap).join('\n');
-			}
-			if (text.length > CHAR_TRUNCATE_THRESHOLD) {
-				return text.slice(0, CHAR_TRUNCATE_THRESHOLD);
-			}
-			return text;
+			return lines.length > maxOutputLines ? lines.slice(0, maxOutputLines).join('\n') : text;
 		},
-		[effectiveLineCap, hasLineCap]
+		[hasLineCap, maxOutputLines]
 	);
 
 	/**


### PR DESCRIPTION
## Summary

- The web/mobile `MessageHistory` had an unconditional 500-char truncation that fired regardless of the user's "Max Output Lines per Response" choice. Selecting **All** still collapsed any AI response longer than ~500 chars with a "tap to expand" hint.
- The dead `LINE_TRUNCATE_THRESHOLD = 8` fallback was also unreachable behind a `!hasLineCap` early-return.
- Drop the char-based threshold and the dead fallback so the web UI matches desktop `TerminalOutput.tsx:350` exactly: **All (Infinity / unset) disables truncation entirely**; a finite cap drives line-based collapse only.

## Why now

Originally introduced in `725491d` ("port Max Output Lines setting"). Commit message stated the intent — "MessageHistory now applies line-based truncation only when a finite cap is configured" — but the legacy 500-char path was left behind, so "All" never actually meant All.

Verified this is **not** caused by the soaked PRs (#895, #921, #923) — none of them touch the truncation logic. PR #921 only appends a `ToolCard` helper to `MessageHistory.tsx`.

## Code change

`src/web/mobile/MessageHistory.tsx` — `shouldTruncate` / `getTruncatedText` short-circuit on `!hasLineCap` and otherwise gate on line count alone. `CHAR_TRUNCATE_THRESHOLD` and the unreachable `LINE_TRUNCATE_THRESHOLD` fallback are removed.

## Test plan

- [x] Replace char-based truncation assertions with line-based equivalents.
- [x] Add regression: long single-line content + `maxOutputLines={Infinity}` → no expand hint.
- [x] Add regression: 15-line content + `maxOutputLines={Infinity}` → no expand hint.
- [x] Add regression: 600-char single-line + finite cap → no expand hint (only line counts gate truncation).
- [x] Add regression: omitted `maxOutputLines` defaults to "All" — no truncation.
- [x] `npx vitest run src/__tests__/web/mobile/MessageHistory.test.tsx` — 81/81 pass.
- [x] `npx tsc --noEmit -p tsconfig.json` and `-p tsconfig.lint.json` — clean.
- [x] `npx prettier --check` and `npx eslint` on the touched files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed message truncation to use line-count instead of character-based truncation
  * Fixed "All" option to properly disable truncation regardless of message length

* **Tests**
  * Refactored test suite to validate line-count truncation behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->