### PR TITLE
fix(renderer): prevent renderer-unloading nav from inline-code in <a>

### DIFF
--- a/src/__tests__/main/app-lifecycle/window-manager.test.ts
+++ b/src/__tests__/main/app-lifecycle/window-manager.test.ts
@@ -624,7 +624,7 @@ describe('app-lifecycle/window-manager', () => {
 			expect(mockEvent.preventDefault).toHaveBeenCalled();
 		});
 
-		it('should allow file:// navigation within renderer directory in production', async () => {
+		it('should allow file:// navigation to the renderer entry HTML in production', async () => {
 			const { createWindowManager } = await import('../../../main/app-lifecycle/window-manager');
 
 			const windowManager = createWindowManager({
@@ -646,7 +646,7 @@ describe('app-lifecycle/window-manager', () => {
 			);
 			const navigateHandler = willNavigateCall![1];
 
-			// Should allow file:// navigation within the renderer's directory (/path/to/)
+			// Should allow file:// navigation to the renderer entry HTML itself.
 			const mockEvent = { preventDefault: vi.fn() };
 			navigateHandler(mockEvent, 'file:///path/to/index.html');
 			expect(mockEvent.preventDefault).not.toHaveBeenCalled();
@@ -677,6 +677,37 @@ describe('app-lifecycle/window-manager', () => {
 			// Should block file:// navigation to paths outside the renderer directory
 			const mockEvent = { preventDefault: vi.fn() };
 			navigateHandler(mockEvent, 'file:///etc/passwd');
+			expect(mockEvent.preventDefault).toHaveBeenCalled();
+		});
+
+		it('regression: should block file:// navigation to other files inside the renderer directory in production', async () => {
+			// A relative <a href="foo.md"> in chat output resolves against the
+			// current page URL (the renderer's index.html), producing a file://
+			// URL inside the renderer dir. The previous "directory prefix" check
+			// allowed that through, unloading the app to a non-existent file.
+			const { createWindowManager } = await import('../../../main/app-lifecycle/window-manager');
+
+			const windowManager = createWindowManager({
+				windowStateStore: mockWindowStateStore as unknown as Parameters<
+					typeof createWindowManager
+				>[0]['windowStateStore'],
+				isDevelopment: false,
+				preloadPath: '/path/to/preload.js',
+				rendererPath: '/path/to/index.html',
+				devServerUrl: 'http://localhost:5173',
+				useNativeTitleBar: false,
+				autoHideMenuBar: false,
+			});
+
+			windowManager.createWindow();
+
+			const willNavigateCall = mockWebContents.on.mock.calls.find(
+				(call: unknown[]) => call[0] === 'will-navigate'
+			);
+			const navigateHandler = willNavigateCall![1];
+
+			const mockEvent = { preventDefault: vi.fn() };
+			navigateHandler(mockEvent, 'file:///path/to/TEST-PLAN-0.16.15-RC.md');
 			expect(mockEvent.preventDefault).toHaveBeenCalled();
 		});
 

--- a/src/__tests__/main/app-lifecycle/window-manager.test.ts
+++ b/src/__tests__/main/app-lifecycle/window-manager.test.ts
@@ -711,6 +711,69 @@ describe('app-lifecycle/window-manager', () => {
 			expect(mockEvent.preventDefault).toHaveBeenCalled();
 		});
 
+		it('should block file:// navigation with a query string or fragment appended to the entry HTML', async () => {
+			// Exact-match check: even if the path matches the renderer entry,
+			// any added query/fragment is treated as different navigation.
+			const { createWindowManager } = await import('../../../main/app-lifecycle/window-manager');
+
+			const windowManager = createWindowManager({
+				windowStateStore: mockWindowStateStore as unknown as Parameters<
+					typeof createWindowManager
+				>[0]['windowStateStore'],
+				isDevelopment: false,
+				preloadPath: '/path/to/preload.js',
+				rendererPath: '/path/to/index.html',
+				devServerUrl: 'http://localhost:5173',
+				useNativeTitleBar: false,
+				autoHideMenuBar: false,
+			});
+
+			windowManager.createWindow();
+
+			const willNavigateCall = mockWebContents.on.mock.calls.find(
+				(call: unknown[]) => call[0] === 'will-navigate'
+			);
+			const navigateHandler = willNavigateCall![1];
+
+			for (const url of [
+				'file:///path/to/index.html?foo=bar',
+				'file:///path/to/index.html#hash',
+				'file:///path/to/index.htmlx', // suffix that "starts with" the entry
+			]) {
+				const mockEvent = { preventDefault: vi.fn() };
+				navigateHandler(mockEvent, url);
+				expect(mockEvent.preventDefault).toHaveBeenCalled();
+			}
+		});
+
+		it('should block dev server navigation in production mode', async () => {
+			// In production the dev-server origin is not on the allowlist.
+			const { createWindowManager } = await import('../../../main/app-lifecycle/window-manager');
+
+			const windowManager = createWindowManager({
+				windowStateStore: mockWindowStateStore as unknown as Parameters<
+					typeof createWindowManager
+				>[0]['windowStateStore'],
+				isDevelopment: false,
+				preloadPath: '/path/to/preload.js',
+				rendererPath: '/path/to/index.html',
+				devServerUrl: 'http://localhost:5173',
+				useNativeTitleBar: false,
+				autoHideMenuBar: false,
+			});
+
+			windowManager.createWindow();
+
+			const willNavigateCall = mockWebContents.on.mock.calls.find(
+				(call: unknown[]) => call[0] === 'will-navigate'
+			);
+			const navigateHandler = willNavigateCall![1];
+
+			const mockEvent = { preventDefault: vi.fn() };
+			navigateHandler(mockEvent, 'http://localhost:5173/');
+			expect(mockEvent.preventDefault).toHaveBeenCalled();
+		});
+
 		it('should allow dev server navigation in development mode', async () => {
 			const { createWindowManager } = await import('../../../main/app-lifecycle/window-manager');
 
@@ -737,6 +800,74 @@ describe('app-lifecycle/window-manager', () => {
 			const mockEvent = { preventDefault: vi.fn() };
 			navigateHandler(mockEvent, 'http://localhost:5173/some/path');
 			expect(mockEvent.preventDefault).not.toHaveBeenCalled();
+		});
+
+		it('should block file:// navigation in development mode', async () => {
+			// Dev mode only allows the dev-server origin, not local file:// URLs
+			// (the renderer is served from Vite, not from disk).
+			const { createWindowManager } = await import('../../../main/app-lifecycle/window-manager');
+
+			const windowManager = createWindowManager({
+				windowStateStore: mockWindowStateStore as unknown as Parameters<
+					typeof createWindowManager
+				>[0]['windowStateStore'],
+				isDevelopment: true,
+				preloadPath: '/path/to/preload.js',
+				rendererPath: '/path/to/index.html',
+				devServerUrl: 'http://localhost:5173',
+				useNativeTitleBar: false,
+				autoHideMenuBar: false,
+			});
+
+			windowManager.createWindow();
+
+			const willNavigateCall = mockWebContents.on.mock.calls.find(
+				(call: unknown[]) => call[0] === 'will-navigate'
+			);
+			const navigateHandler = willNavigateCall![1];
+
+			const mockEvent = { preventDefault: vi.fn() };
+			navigateHandler(mockEvent, 'file:///path/to/index.html');
+			expect(mockEvent.preventDefault).toHaveBeenCalled();
+		});
+
+		it('should register a single will-navigate handler regardless of how many navigation events fire', async () => {
+			// Regression for review feedback: rendererFileUrl/devUrl should be
+			// computed once at setup, not per-event. Easiest observable proof is
+			// that the handler is registered exactly once on the webContents.
+			const { createWindowManager } = await import('../../../main/app-lifecycle/window-manager');
+
+			const windowManager = createWindowManager({
+				windowStateStore: mockWindowStateStore as unknown as Parameters<
+					typeof createWindowManager
+				>[0]['windowStateStore'],
+				isDevelopment: false,
+				preloadPath: '/path/to/preload.js',
+				rendererPath: '/path/to/index.html',
+				devServerUrl: 'http://localhost:5173',
+				useNativeTitleBar: false,
+				autoHideMenuBar: false,
+			});
+
+			windowManager.createWindow();
+
+			const willNavigateCalls = mockWebContents.on.mock.calls.filter(
+				(call: unknown[]) => call[0] === 'will-navigate'
+			);
+			expect(willNavigateCalls).toHaveLength(1);
+
+			// Drive the handler many times — behavior should be stable and the
+			// allowed URL should still match exactly on every invocation.
+			const navigateHandler = willNavigateCalls[0][1];
+			for (let i = 0; i < 5; i++) {
+				const allowed = { preventDefault: vi.fn() };
+				navigateHandler(allowed, 'file:///path/to/index.html');
+				expect(allowed.preventDefault).not.toHaveBeenCalled();
+
+				const blocked = { preventDefault: vi.fn() };
+				navigateHandler(blocked, 'file:///path/to/other.md');
+				expect(blocked.preventDefault).toHaveBeenCalled();
+			}
 		});
 
 		it('should omit titleBarStyle when useNativeTitleBar is true', async () => {

--- a/src/__tests__/renderer/utils/inlineCodeCopy.test.tsx
+++ b/src/__tests__/renderer/utils/inlineCodeCopy.test.tsx
@@ -1,0 +1,171 @@
+/**
+ * Tests for inlineCodeCopy click/keydown handlers.
+ *
+ * Regression: when an inline <code> is nested inside an <a> (e.g. AI emits
+ * `[\`file.md\`](file.md)`), clicking the <code> would copy + flash but the
+ * browser's default link navigation would still run because the handler only
+ * called stopPropagation, not preventDefault. That navigation could unload
+ * the renderer to a non-existent in-bundle file (Linux: looks like a restart).
+ */
+
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock clipboard utility — the handler awaits this; default to success.
+const mockSafeClipboardWrite = vi.fn().mockResolvedValue(true);
+vi.mock('../../../renderer/utils/clipboard', () => ({
+	safeClipboardWrite: (...args: unknown[]) => mockSafeClipboardWrite(...args),
+}));
+
+// Mock the center-flash store so we don't render the overlay during tests.
+const mockNotifyCenterFlash = vi.fn();
+vi.mock('../../../renderer/stores/centerFlashStore', () => ({
+	notifyCenterFlash: (...args: unknown[]) => mockNotifyCenterFlash(...args),
+}));
+
+import {
+	buildInlineCodeHandlers,
+	extractInlineCodeText,
+} from '../../../renderer/utils/inlineCodeCopy';
+
+describe('inlineCodeCopy', () => {
+	beforeEach(() => {
+		mockSafeClipboardWrite.mockClear();
+		mockNotifyCenterFlash.mockClear();
+	});
+
+	describe('extractInlineCodeText', () => {
+		it('returns empty string for nullish/false children', () => {
+			expect(extractInlineCodeText(null)).toBe('');
+			expect(extractInlineCodeText(undefined)).toBe('');
+			expect(extractInlineCodeText(false)).toBe('');
+		});
+
+		it('returns string for plain text children', () => {
+			expect(extractInlineCodeText('hello')).toBe('hello');
+			expect(extractInlineCodeText(42)).toBe('42');
+		});
+
+		it('joins arrays of children', () => {
+			expect(extractInlineCodeText(['foo', 'bar', 'baz'])).toBe('foobarbaz');
+		});
+
+		it('recurses into React elements', () => {
+			const tree = React.createElement('span', null, 'inner');
+			expect(extractInlineCodeText(tree)).toBe('inner');
+		});
+	});
+
+	describe('buildInlineCodeHandlers — onClick', () => {
+		it('stops propagation and prevents default', () => {
+			const handlers = buildInlineCodeHandlers('npm install');
+			const e = {
+				preventDefault: vi.fn(),
+				stopPropagation: vi.fn(),
+			} as unknown as React.MouseEvent;
+
+			handlers.onClick(e);
+
+			expect(e.preventDefault).toHaveBeenCalledTimes(1);
+			expect(e.stopPropagation).toHaveBeenCalledTimes(1);
+		});
+
+		it('regression: prevents default link navigation when <code> is nested inside <a>', () => {
+			// Reproduces the AI-emitted `[\`file.md\`](file.md)` shape.
+			// Without preventDefault, the browser would resolve the relative href
+			// against the current page and navigate, unloading the renderer.
+			const handlers = buildInlineCodeHandlers('TEST-PLAN-0.16.15-RC.md');
+
+			// Capture-phase listener on the document fires BEFORE the inline-code
+			// handler — so by the time we inspect defaultPrevented after the click,
+			// it should reflect the handler's preventDefault().
+			let capturedEvent: Event | null = null;
+			const captureListener = (e: Event) => {
+				capturedEvent = e;
+			};
+
+			const linkClick = vi.fn();
+
+			const { getByText } = render(
+				React.createElement(
+					'a',
+					{
+						href: 'TEST-PLAN-0.16.15-RC.md',
+						onClick: linkClick,
+					},
+					React.createElement(
+						'code',
+						{
+							onClick: handlers.onClick,
+							role: 'button',
+							tabIndex: 0,
+						},
+						'TEST-PLAN-0.16.15-RC.md'
+					)
+				)
+			);
+
+			document.addEventListener('click', captureListener, true);
+			try {
+				fireEvent.click(getByText('TEST-PLAN-0.16.15-RC.md'));
+			} finally {
+				document.removeEventListener('click', captureListener, true);
+			}
+
+			// The <code> handler should have prevented the click's default action
+			// — that is what would otherwise let the browser perform <a> navigation.
+			expect(capturedEvent).not.toBeNull();
+			expect(capturedEvent!.defaultPrevented).toBe(true);
+
+			// stopPropagation also fires, so the parent <a>'s React onClick (which
+			// runs in the bubble phase) must NOT have been invoked.
+			expect(linkClick).not.toHaveBeenCalled();
+		});
+
+		it('copies the extracted text to the clipboard', async () => {
+			const handlers = buildInlineCodeHandlers('  some-command  ');
+			const e = {
+				preventDefault: vi.fn(),
+				stopPropagation: vi.fn(),
+			} as unknown as React.MouseEvent;
+
+			handlers.onClick(e);
+			// Allow the void copyInlineCode microtask to settle.
+			await Promise.resolve();
+			await Promise.resolve();
+
+			expect(mockSafeClipboardWrite).toHaveBeenCalledWith('some-command');
+		});
+	});
+
+	describe('buildInlineCodeHandlers — onKeyDown', () => {
+		it('handles Enter and Space, prevents default + stops propagation', () => {
+			const handlers = buildInlineCodeHandlers('value');
+			for (const key of ['Enter', ' ']) {
+				const e = {
+					key,
+					preventDefault: vi.fn(),
+					stopPropagation: vi.fn(),
+				} as unknown as React.KeyboardEvent;
+				handlers.onKeyDown(e);
+				expect(e.preventDefault).toHaveBeenCalledTimes(1);
+				expect(e.stopPropagation).toHaveBeenCalledTimes(1);
+			}
+		});
+
+		it('ignores other keys', () => {
+			const handlers = buildInlineCodeHandlers('value');
+			const e = {
+				key: 'a',
+				preventDefault: vi.fn(),
+				stopPropagation: vi.fn(),
+			} as unknown as React.KeyboardEvent;
+
+			handlers.onKeyDown(e);
+
+			expect(e.preventDefault).not.toHaveBeenCalled();
+			expect(e.stopPropagation).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/src/main/app-lifecycle/window-manager.ts
+++ b/src/main/app-lifecycle/window-manager.ts
@@ -369,20 +369,21 @@ export function createWindowManager(deps: WindowManagerDependencies): WindowMana
 				return { action: 'deny' };
 			});
 
-			// Restrict navigation to the app itself — prevent renderer from navigating away
+			// Restrict navigation to the app itself — prevent renderer from navigating away.
+			// Both the dev-server URL and the renderer entry's file:// URL are constants
+			// for the lifetime of this window, so compute them once at setup time rather
+			// than on every navigation event. The production guard only allows the
+			// renderer entry HTML itself: a previous "directory prefix" check let any
+			// file inside the renderer dir through, which meant a stray <a href="foo.md">
+			// in chat output could resolve relative to index.html and unload the app to
+			// a non-existent bundle file.
+			const allowedDevOrigin = isDevelopment ? new URL(devServerUrl).origin : null;
+			const rendererFileUrl = isDevelopment ? null : pathToFileURL(rendererPath).href;
 			mainWindow.webContents.on('will-navigate', (event, url) => {
 				const parsedUrl = new URL(url);
 				if (isDevelopment) {
-					// In dev mode, allow Vite dev server navigation
-					const devUrl = new URL(devServerUrl);
-					if (parsedUrl.origin === devUrl.origin) return;
+					if (parsedUrl.origin === allowedDevOrigin) return;
 				} else {
-					// In production, only allow navigation to the renderer entry HTML
-					// itself. A previous "directory prefix" check let any file inside
-					// the renderer dir through, which meant a stray <a href="foo.md">
-					// in chat output could resolve relative to index.html and unload
-					// the app to a non-existent bundle file.
-					const rendererFileUrl = pathToFileURL(rendererPath).href;
 					if (parsedUrl.protocol === 'file:' && url === rendererFileUrl) return;
 				}
 				event.preventDefault();

--- a/src/main/app-lifecycle/window-manager.ts
+++ b/src/main/app-lifecycle/window-manager.ts
@@ -3,7 +3,7 @@
  * Handles window state persistence, DevTools, crash detection, and auto-updater initialization.
  */
 
-import * as path from 'path';
+import { pathToFileURL } from 'url';
 import { BrowserWindow, Menu, ipcMain } from 'electron';
 import type Store from 'electron-store';
 import type { WindowState } from '../stores/types';
@@ -377,12 +377,13 @@ export function createWindowManager(deps: WindowManagerDependencies): WindowMana
 					const devUrl = new URL(devServerUrl);
 					if (parsedUrl.origin === devUrl.origin) return;
 				} else {
-					// In production, only allow file:// URLs within the app's renderer directory
-					if (
-						parsedUrl.protocol === 'file:' &&
-						url.includes(path.dirname(rendererPath).replace(/\\/g, '/'))
-					)
-						return;
+					// In production, only allow navigation to the renderer entry HTML
+					// itself. A previous "directory prefix" check let any file inside
+					// the renderer dir through, which meant a stray <a href="foo.md">
+					// in chat output could resolve relative to index.html and unload
+					// the app to a non-existent bundle file.
+					const rendererFileUrl = pathToFileURL(rendererPath).href;
+					if (parsedUrl.protocol === 'file:' && url === rendererFileUrl) return;
 				}
 				event.preventDefault();
 				logger.warn(`Blocked navigation to: ${url}`, 'Window');

--- a/src/renderer/utils/inlineCodeCopy.ts
+++ b/src/renderer/utils/inlineCodeCopy.ts
@@ -47,6 +47,13 @@ export const INLINE_CODE_CLICK_STYLE: React.CSSProperties = {
 export function buildInlineCodeHandlers(children: React.ReactNode) {
 	return {
 		onClick: (e: React.MouseEvent) => {
+			// preventDefault: when <code> is nested inside an <a> (e.g. AI emits
+			// `[\`file.md\`](file.md)`), stopPropagation alone keeps the parent
+			// link's onClick from firing — but the browser's default link
+			// navigation still runs because no preventDefault was called. That
+			// can navigate the renderer to a non-existent in-bundle file and
+			// unload the app. preventDefault is a no-op for standalone <code>.
+			e.preventDefault();
 			e.stopPropagation();
 			void copyInlineCode(children);
 		},


### PR DESCRIPTION
## Summary

When the AI emits a markdown link of the form `` [`file.md`](file.md) ``, the rendered `<a>` contains a clickable `<code>`. The inline-code click handler at `src/renderer/utils/inlineCodeCopy.ts` called `e.stopPropagation()` but not `e.preventDefault()`, so:

1. The `<code>` handler ran (copy + "Copied to Clipboard" flash, propagation stopped).
2. The outer `<a>`'s React `onClick` (which would have called `preventDefault()`) never fired.
3. The browser's default link navigation **still** ran, resolving the relative href against the current page (`file:///opt/Maestro/resources/app.asar/dist/renderer/index.html`).
4. Electron's `will-navigate` allowed any `file://` URL inside the renderer directory through, so the renderer navigated to a non-existent in-bundle file and unloaded the app — appearing as an "Electron restart" on Linux right after the "Copied" flash.

## Changes

- **`src/renderer/utils/inlineCodeCopy.ts`** — `buildInlineCodeHandlers` now calls `e.preventDefault()` alongside `e.stopPropagation()`. No-op for standalone `<code>`, decisive for `<code>` nested inside `<a>`.
- **`src/main/app-lifecycle/window-manager.ts`** — defense-in-depth: tightened `will-navigate` so production only allows navigation to the renderer entry HTML itself (`pathToFileURL(rendererPath)`), not any file inside the renderer directory. A future stray relative `<a>` can no longer unload the app.
- **Tests** — new `src/__tests__/renderer/utils/inlineCodeCopy.test.tsx` with the regression case (clicking nested `<code>` inside `<a>` must mark the click `defaultPrevented`); updated `src/__tests__/main/app-lifecycle/window-manager.test.ts` with a regression case asserting `file:///path/to/TEST-PLAN-0.16.15-RC.md` is now blocked.

## Test plan

- [x] `npx vitest run src/__tests__/renderer/utils/inlineCodeCopy.test.tsx` — 9 pass
- [x] `npx vitest run src/__tests__/main/app-lifecycle/window-manager.test.ts` — 30 pass (new regression case included)
- [x] `npx vitest run src/__tests__/renderer/components/MarkdownRenderer.test.tsx src/__tests__/renderer/utils/markdownConfig.test.ts` — 219 pass (consumers unaffected)
- [x] `npx prettier --check` on all changed files — clean
- [x] `npx eslint` on all changed source files — 0 errors / 0 warnings
- [ ] Manual repro on Linux: click an AI-emitted `` [`file.md`](file.md) `` link where the file isn't in the project tree — should no longer reload the app

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inline code copy when code is nested inside links—clicking now copies without triggering navigation.
  * Hardened renderer navigation: only the exact renderer entry URL is allowed; non-entry file:// navigation and mismatched/modified entry URLs are blocked, including stricter dev-server-origin checks.

* **Tests**
  * Added comprehensive tests for inline code copy behavior (click and keyboard) and navigation regressions, including handler registration and repeated-call behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->