### PR TITLE
fix(updater): bypass busy-agent quit gate so Windows installer isn't orphaned

### DIFF
--- a/src/__tests__/main/app-lifecycle/window-manager.test.ts
+++ b/src/__tests__/main/app-lifecycle/window-manager.test.ts
@@ -442,6 +442,66 @@ describe('app-lifecycle/window-manager', () => {
 			expect(mockInitAutoUpdater).toHaveBeenCalled();
 		});
 
+		it('passes onBeforeQuitAndInstall to auto-updater that invokes confirmQuit', async () => {
+			const { createWindowManager } = await import('../../../main/app-lifecycle/window-manager');
+			const confirmQuit = vi.fn();
+			const getConfirmQuit = vi.fn(() => confirmQuit);
+
+			const windowManager = createWindowManager({
+				windowStateStore: mockWindowStateStore as unknown as Parameters<
+					typeof createWindowManager
+				>[0]['windowStateStore'],
+				isDevelopment: false,
+				preloadPath: '/path/to/preload.js',
+				rendererPath: '/path/to/index.html',
+				devServerUrl: 'http://localhost:5173',
+				useNativeTitleBar: false,
+				autoHideMenuBar: false,
+				getConfirmQuit,
+			});
+
+			windowManager.createWindow();
+
+			// initAutoUpdater(window, options)
+			expect(mockInitAutoUpdater).toHaveBeenCalledWith(
+				expect.anything(),
+				expect.objectContaining({ onBeforeQuitAndInstall: expect.any(Function) })
+			);
+
+			// Pull the option and confirm it routes to confirmQuit
+			const options = mockInitAutoUpdater.mock.calls[0][1] as {
+				onBeforeQuitAndInstall: () => void;
+			};
+			options.onBeforeQuitAndInstall();
+
+			expect(getConfirmQuit).toHaveBeenCalled();
+			expect(confirmQuit).toHaveBeenCalledTimes(1);
+		});
+
+		it('onBeforeQuitAndInstall is a no-op when quit handler is not yet wired', async () => {
+			const { createWindowManager } = await import('../../../main/app-lifecycle/window-manager');
+
+			const windowManager = createWindowManager({
+				windowStateStore: mockWindowStateStore as unknown as Parameters<
+					typeof createWindowManager
+				>[0]['windowStateStore'],
+				isDevelopment: false,
+				preloadPath: '/path/to/preload.js',
+				rendererPath: '/path/to/index.html',
+				devServerUrl: 'http://localhost:5173',
+				useNativeTitleBar: false,
+				autoHideMenuBar: false,
+				getConfirmQuit: () => null,
+			});
+
+			windowManager.createWindow();
+
+			const options = mockInitAutoUpdater.mock.calls[0][1] as {
+				onBeforeQuitAndInstall: () => void;
+			};
+			expect(() => options.onBeforeQuitAndInstall()).not.toThrow();
+		});
+
 		it('should register stub handlers in development mode', async () => {
 			const { createWindowManager } = await import('../../../main/app-lifecycle/window-manager');
 

--- a/src/__tests__/main/auto-updater.test.ts
+++ b/src/__tests__/main/auto-updater.test.ts
@@ -37,6 +37,11 @@ vi.mock('../../main/utils/safe-send', () => ({
 	isWebContentsAvailable: vi.fn(() => false),
 }));
 
+const mockCaptureException = vi.fn().mockResolvedValue(undefined);
+vi.mock('../../main/utils/sentry', () => ({
+	captureException: (...args: unknown[]) => mockCaptureException(...args),
+}));
+
 // electron-updater is loaded via dynamic `require` inside auto-updater.ts to
 // defer electron.app access — that bypasses vitest's module mocker. We use the
 // __setAutoUpdaterForTesting escape hatch instead.
@@ -108,14 +113,15 @@ describe('main/auto-updater', () => {
 			expect(mockAutoUpdater.quitAndInstall).toHaveBeenCalledWith(false, true);
 		});
 
-		it('still calls quitAndInstall if onBeforeQuitAndInstall throws', async () => {
+		it('still calls quitAndInstall if onBeforeQuitAndInstall throws and reports to Sentry', async () => {
 			const { initAutoUpdater, __setAutoUpdaterForTesting } =
 				await import('../../main/auto-updater');
 			__setAutoUpdaterForTesting(
 				mockAutoUpdater as unknown as Parameters<typeof __setAutoUpdaterForTesting>[0]
 			);
+			const hookError = new Error('hook blew up');
 			const onBeforeQuitAndInstall = vi.fn(() => {
-				throw new Error('hook blew up');
+				throw hookError;
 			});
 
 			initAutoUpdater({} as Parameters<typeof initAutoUpdater>[0], {
@@ -128,6 +134,39 @@ describe('main/auto-updater', () => {
 			expect(() => installHandler!()).not.toThrow();
 
 			expect(onBeforeQuitAndInstall).toHaveBeenCalledTimes(1);
+			expect(mockAutoUpdater.quitAndInstall).toHaveBeenCalledWith(false, true);
+			expect(mockCaptureException).toHaveBeenCalledWith(
+				hookError,
+				expect.objectContaining({
+					module: 'AutoUpdater',
+					hook: 'onBeforeQuitAndInstall',
+					operation: 'updates:install',
+				})
+			);
+		});
+
+		it('wraps non-Error throws from onBeforeQuitAndInstall before reporting to Sentry', async () => {
+			const { initAutoUpdater, __setAutoUpdaterForTesting } =
+				await import('../../main/auto-updater');
+			__setAutoUpdaterForTesting(
+				mockAutoUpdater as unknown as Parameters<typeof __setAutoUpdaterForTesting>[0]
+			);
+			const onBeforeQuitAndInstall = vi.fn(() => {
+				// eslint-disable-next-line @typescript-eslint/no-throw-literal
+				throw 'string-thrown';
+			});
+
+			initAutoUpdater({} as Parameters<typeof initAutoUpdater>[0], {
+				onBeforeQuitAndInstall,
+			});
+
+			const installHandler = ipcHandlers.get('updates:install');
+			installHandler!();
+
+			expect(mockCaptureException).toHaveBeenCalledWith(
+				expect.objectContaining({ message: 'string-thrown' }),
+				expect.any(Object)
+			);
 			expect(mockAutoUpdater.quitAndInstall).toHaveBeenCalledWith(false, true);
 		});
 	});

--- a/src/__tests__/main/auto-updater.test.ts
+++ b/src/__tests__/main/auto-updater.test.ts
@@ -1,0 +1,134 @@
+/**
+ * @file auto-updater.test.ts
+ * @description Tests for the electron-updater integration in src/main/auto-updater.ts.
+ *
+ * Focused on the `updates:install` IPC handler — specifically that it invokes
+ * the optional `onBeforeQuitAndInstall` hook before calling
+ * `autoUpdater.quitAndInstall()`. This hook is what lets the host bypass the
+ * busy-agent quit confirmation gate so the Windows installer (which spawns
+ * waiting on our PID) isn't orphaned by `before-quit` preventDefault.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Capture IPC handler registrations so we can invoke them from tests.
+const ipcHandlers = new Map<string, (...args: unknown[]) => unknown>();
+const mockHandle = vi.fn((channel: string, fn: (...args: unknown[]) => unknown) => {
+	ipcHandlers.set(channel, fn);
+});
+
+vi.mock('electron', () => ({
+	BrowserWindow: class {},
+	ipcMain: {
+		handle: (channel: string, fn: (...args: unknown[]) => unknown) => mockHandle(channel, fn),
+	},
+}));
+
+vi.mock('../../main/utils/logger', () => ({
+	logger: {
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+		debug: vi.fn(),
+	},
+}));
+
+vi.mock('../../main/utils/safe-send', () => ({
+	isWebContentsAvailable: vi.fn(() => false),
+}));
+
+// electron-updater is loaded via dynamic `require` inside auto-updater.ts to
+// defer electron.app access — that bypasses vitest's module mocker. We use the
+// __setAutoUpdaterForTesting escape hatch instead.
+const mockAutoUpdater = {
+	autoDownload: false,
+	autoInstallOnAppQuit: false,
+	allowPrerelease: false,
+	on: vi.fn(),
+	checkForUpdates: vi.fn(),
+	downloadUpdate: vi.fn(),
+	quitAndInstall: vi.fn(),
+};
+
+describe('main/auto-updater', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.resetModules();
+		ipcHandlers.clear();
+		mockAutoUpdater.quitAndInstall.mockReset();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	describe('updates:install handler', () => {
+		it('invokes onBeforeQuitAndInstall before quitAndInstall', async () => {
+			const { initAutoUpdater, __setAutoUpdaterForTesting } =
+				await import('../../main/auto-updater');
+			__setAutoUpdaterForTesting(
+				mockAutoUpdater as unknown as Parameters<typeof __setAutoUpdaterForTesting>[0]
+			);
+			const callOrder: string[] = [];
+			const onBeforeQuitAndInstall = vi.fn(() => {
+				callOrder.push('onBeforeQuitAndInstall');
+			});
+			mockAutoUpdater.quitAndInstall.mockImplementation(() => {
+				callOrder.push('quitAndInstall');
+			});
+
+			initAutoUpdater({} as Parameters<typeof initAutoUpdater>[0], {
+				onBeforeQuitAndInstall,
+			});
+
+			const installHandler = ipcHandlers.get('updates:install');
+			expect(installHandler).toBeTruthy();
+
+			await installHandler!();
+
+			expect(onBeforeQuitAndInstall).toHaveBeenCalledTimes(1);
+			expect(mockAutoUpdater.quitAndInstall).toHaveBeenCalledWith(false, true);
+			expect(callOrder).toEqual(['onBeforeQuitAndInstall', 'quitAndInstall']);
+		});
+
+		it('still calls quitAndInstall when no onBeforeQuitAndInstall is provided', async () => {
+			const { initAutoUpdater, __setAutoUpdaterForTesting } =
+				await import('../../main/auto-updater');
+			__setAutoUpdaterForTesting(
+				mockAutoUpdater as unknown as Parameters<typeof __setAutoUpdaterForTesting>[0]
+			);
+
+			initAutoUpdater({} as Parameters<typeof initAutoUpdater>[0]);
+
+			const installHandler = ipcHandlers.get('updates:install');
+			expect(installHandler).toBeTruthy();
+
+			await installHandler!();
+
+			expect(mockAutoUpdater.quitAndInstall).toHaveBeenCalledWith(false, true);
+		});
+
+		it('still calls quitAndInstall if onBeforeQuitAndInstall throws', async () => {
+			const { initAutoUpdater, __setAutoUpdaterForTesting } =
+				await import('../../main/auto-updater');
+			__setAutoUpdaterForTesting(
+				mockAutoUpdater as unknown as Parameters<typeof __setAutoUpdaterForTesting>[0]
+			);
+			const onBeforeQuitAndInstall = vi.fn(() => {
+				throw new Error('hook blew up');
+			});
+
+			initAutoUpdater({} as Parameters<typeof initAutoUpdater>[0], {
+				onBeforeQuitAndInstall,
+			});
+
+			const installHandler = ipcHandlers.get('updates:install');
+			expect(installHandler).toBeTruthy();
+
+			expect(() => installHandler!()).not.toThrow();
+
+			expect(onBeforeQuitAndInstall).toHaveBeenCalledTimes(1);
+			expect(mockAutoUpdater.quitAndInstall).toHaveBeenCalledWith(false, true);
+		});
+	});
+});

--- a/src/main/app-lifecycle/window-manager.ts
+++ b/src/main/app-lifecycle/window-manager.ts
@@ -148,6 +148,12 @@ export interface WindowManagerDependencies {
 	useNativeTitleBar: boolean;
 	/** Whether to auto-hide the menu bar (Linux/Windows) */
 	autoHideMenuBar: boolean;
+	/**
+	 * Lazy getter for the quit handler's confirmQuit function. Used by the
+	 * auto-updater install path to bypass the busy-agent quit confirmation
+	 * gate. Lazy because the quit handler is constructed after the window.
+	 */
+	getConfirmQuit?: () => (() => void) | null | undefined;
 }
 
 /** Window manager instance */
@@ -171,6 +177,7 @@ export function createWindowManager(deps: WindowManagerDependencies): WindowMana
 		devServerUrl,
 		useNativeTitleBar,
 		autoHideMenuBar,
+		getConfirmQuit,
 	} = deps;
 
 	return {
@@ -526,7 +533,12 @@ export function createWindowManager(deps: WindowManagerDependencies): WindowMana
 
 			// Initialize auto-updater (only in production)
 			if (!isDevelopment) {
-				initAutoUpdater(mainWindow);
+				initAutoUpdater(mainWindow, {
+					onBeforeQuitAndInstall: () => {
+						const confirmQuit = getConfirmQuit?.();
+						confirmQuit?.();
+					},
+				});
 				logger.info('Auto-updater initialized', 'Window');
 			} else {
 				// Register stub handlers in development mode so users get a helpful error

--- a/src/main/auto-updater.ts
+++ b/src/main/auto-updater.ts
@@ -10,6 +10,7 @@
 import type { UpdateInfo, ProgressInfo, AppUpdater } from 'electron-updater';
 import { BrowserWindow, ipcMain } from 'electron';
 import { logger } from './utils/logger';
+import { captureException } from './utils/sentry';
 import { isWebContentsAvailable } from './utils/safe-send';
 
 export interface UpdateStatus {
@@ -60,8 +61,13 @@ function getAutoUpdater(): AppUpdater {
  * @internal Test-only: inject a mock autoUpdater. The real implementation is
  * loaded via dynamic `require` to defer electron.app access, which sidesteps
  * vitest's module mocker — this hook lets tests provide a stand-in.
+ *
+ * Hard-gated to non-production builds: the symbol still exists in production
+ * bundles (TS can't conditionally export) but the body is a no-op there, so
+ * a stray call can't subvert the real updater singleton.
  */
 export function __setAutoUpdaterForTesting(updater: AppUpdater | null): void {
+	if (process.env.NODE_ENV === 'production') return;
 	_autoUpdater = updater;
 }
 
@@ -242,6 +248,11 @@ function setupIpcHandlers(): void {
 				`onBeforeQuitAndInstall hook threw: ${err instanceof Error ? err.message : String(err)}`,
 				'AutoUpdater'
 			);
+			void captureException(err instanceof Error ? err : new Error(String(err)), {
+				module: 'AutoUpdater',
+				hook: 'onBeforeQuitAndInstall',
+				operation: 'updates:install',
+			});
 		}
 		autoUpdater.quitAndInstall(false, true);
 	});

--- a/src/main/auto-updater.ts
+++ b/src/main/auto-updater.ts
@@ -29,6 +29,7 @@ export interface UpdateStatus {
 let mainWindow: BrowserWindow | null = null;
 let currentStatus: UpdateStatus = { status: 'idle' };
 let ipcHandlersRegistered = false;
+let onBeforeQuitAndInstall: (() => void) | null = null;
 
 // Lazy-loaded autoUpdater instance
 let _autoUpdater: AppUpdater | null = null;
@@ -56,10 +57,33 @@ function getAutoUpdater(): AppUpdater {
 }
 
 /**
+ * @internal Test-only: inject a mock autoUpdater. The real implementation is
+ * loaded via dynamic `require` to defer electron.app access, which sidesteps
+ * vitest's module mocker — this hook lets tests provide a stand-in.
+ */
+export function __setAutoUpdaterForTesting(updater: AppUpdater | null): void {
+	_autoUpdater = updater;
+}
+
+/**
+ * Options for initializing the auto-updater.
+ */
+export interface InitAutoUpdaterOptions {
+	/**
+	 * Called immediately before `autoUpdater.quitAndInstall()` runs (i.e. when the
+	 * user clicks "Install Update"). Lets the host bypass the busy-agent quit
+	 * confirmation gate so the Windows installer — which spawns waiting on our PID
+	 * — isn't orphaned by `before-quit` preventDefault.
+	 */
+	onBeforeQuitAndInstall?: () => void;
+}
+
+/**
  * Initialize the auto-updater and set up event handlers
  */
-export function initAutoUpdater(window: BrowserWindow): void {
+export function initAutoUpdater(window: BrowserWindow, options?: InitAutoUpdaterOptions): void {
 	mainWindow = window;
+	onBeforeQuitAndInstall = options?.onBeforeQuitAndInstall ?? null;
 
 	const autoUpdater = getAutoUpdater();
 
@@ -207,6 +231,18 @@ function setupIpcHandlers(): void {
 	// Install update (quit and install)
 	ipcMain.handle('updates:install', () => {
 		logger.info('Installing update — quitting and restarting app', 'AutoUpdater');
+		// Bypass the busy-agent quit confirmation gate. The user already opted in
+		// via the update modal, and on Windows quitAndInstall spawns the NSIS
+		// installer bound to our PID — if before-quit preventDefaults the quit, the
+		// installer is orphaned waiting for a parent exit that may never come.
+		try {
+			onBeforeQuitAndInstall?.();
+		} catch (err) {
+			logger.warn(
+				`onBeforeQuitAndInstall hook threw: ${err instanceof Error ? err.message : String(err)}`,
+				'AutoUpdater'
+			);
+		}
 		autoUpdater.quitAndInstall(false, true);
 	});
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -133,6 +133,7 @@ import {
 	createSettingsWatcher,
 	createWindowManager,
 	createQuitHandler,
+	type QuitHandler,
 } from './app-lifecycle';
 // Phase 3 refactoring - process listeners
 import { setupProcessListeners as setupProcessListenersModule } from './process-listeners';
@@ -308,6 +309,12 @@ const settingsWatcher = createSettingsWatcher({
 const devServerPort = process.env.VITE_PORT ? parseInt(process.env.VITE_PORT, 10) : 5173;
 const devServerUrl = `http://localhost:${devServerPort}`;
 
+// Forward declaration: quitHandler is constructed after the window, but the
+// window manager needs a lazy reference so the auto-updater install path can
+// bypass the busy-agent quit confirmation gate (otherwise on Windows the
+// installer is orphaned by before-quit preventDefault).
+let quitHandler: QuitHandler | null = null;
+
 // Create window manager with dependency injection (Phase 4 refactoring)
 const windowManager = createWindowManager({
 	windowStateStore,
@@ -317,6 +324,7 @@ const windowManager = createWindowManager({
 	devServerUrl: devServerUrl,
 	useNativeTitleBar,
 	autoHideMenuBar,
+	getConfirmQuit: () => quitHandler?.confirmQuit,
 });
 
 // Create web server factory with dependency injection (Phase 2 refactoring)
@@ -805,7 +813,7 @@ app.on('window-all-closed', () => {
 });
 
 // Create and setup quit handler with dependency injection (Phase 4 refactoring)
-const quitHandler = createQuitHandler({
+quitHandler = createQuitHandler({
 	getMainWindow: () => mainWindow,
 	getProcessManager: () => processManager,
 	getWebServer: () => webServer,


### PR DESCRIPTION
## Summary

- On Windows, `autoUpdater.quitAndInstall(false, true)` spawns the NSIS installer bound to our PID **before** `app.quit()` fires. The existing `before-quit` handler intercepts the quit to ask the renderer about busy agents (`event.preventDefault()`), which leaves the spawned installer waiting for a parent exit — only the 5s safety timeout rescues it, and unreliably.
- The user already opted in via `UpdateCheckModal`, so the busy-agent confirmation is redundant on the install path. We now mark the quit pre-confirmed before calling `quitAndInstall`, using the existing `QuitHandler.confirmQuit()` escape hatch.

## Implementation

- `src/main/auto-updater.ts` — `initAutoUpdater` accepts `{ onBeforeQuitAndInstall? }`. The hook fires inside the `updates:install` handler before `quitAndInstall(false, true)`. Failures in the hook are logged and don't block the install. Added `__setAutoUpdaterForTesting` (test-only) so vitest can inject a mock past the dynamic `require('electron-updater')` that bypasses the module mocker.
- `src/main/app-lifecycle/window-manager.ts` — new optional `getConfirmQuit` dep on `WindowManagerDependencies`; passed into `initAutoUpdater` as `onBeforeQuitAndInstall`. Lazy because the quit handler is constructed after the window.
- `src/main/index.ts` — hoist a `let quitHandler: QuitHandler | null = null` forward declaration above `createWindowManager`, wire `getConfirmQuit: () => quitHandler?.confirmQuit`. The closure resolves at install-click time, by which point the handler exists.

## Test plan

- [x] `npx vitest run src/__tests__/main/auto-updater.test.ts src/__tests__/main/app-lifecycle/window-manager.test.ts src/__tests__/main/app-lifecycle/quit-handler.test.ts` — 55/55 pass
- [x] Type check (`npm run lint`) clean for changed files (pre-existing failures elsewhere are unrelated)
- [x] Prettier and ESLint clean
- [ ] Manual Windows verification: trigger an update install, confirm the app exits without the 5s safety-timeout fallback firing and the installer takes over cleanly
- [ ] Manual macOS / Linux smoke: confirm install path still works (no functional change expected on those platforms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-updater now invokes the app's quit-confirmation hook (if present) before installing updates.

* **Bug Fixes**
  * Installation proceeds safely even if the quit-confirmation hook throws or is absent; errors are reported without blocking install.

* **Tests**
  * Added tests covering auto-updater installation behavior, quit-confirmation integration, and error-reporting edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->