### PR TITLE
perf: hot-path wins (persistence diff + Cue idle + stats batch)

### DIFF
--- a/src/__tests__/main/cue/cue-active-state.test.ts
+++ b/src/__tests__/main/cue/cue-active-state.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Tests for the Cue active-state module.
+ *
+ * The visibility-aware pause that PR-B 1.4 wires into every scanner.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+	isCueActive,
+	setCueActive,
+	resetCueActiveForTests,
+} from '../../../main/cue/cue-active-state';
+
+describe('cue-active-state', () => {
+	beforeEach(() => {
+		resetCueActiveForTests();
+	});
+
+	it('defaults to active', () => {
+		expect(isCueActive()).toBe(true);
+	});
+
+	it('flips to inactive when setCueActive(false) is called', () => {
+		setCueActive(false);
+		expect(isCueActive()).toBe(false);
+	});
+
+	it('flips back to active when setCueActive(true) is called', () => {
+		setCueActive(false);
+		setCueActive(true);
+		expect(isCueActive()).toBe(true);
+	});
+
+	it('is idempotent — repeated calls preserve the same state', () => {
+		setCueActive(false);
+		setCueActive(false);
+		expect(isCueActive()).toBe(false);
+		setCueActive(true);
+		setCueActive(true);
+		expect(isCueActive()).toBe(true);
+	});
+
+	it('resetCueActiveForTests restores the default', () => {
+		setCueActive(false);
+		resetCueActiveForTests();
+		expect(isCueActive()).toBe(true);
+	});
+});

--- a/src/__tests__/main/cue/cue-file-watcher.test.ts
+++ b/src/__tests__/main/cue/cue-file-watcher.test.ts
@@ -240,4 +240,84 @@ describe('cue-file-watcher', () => {
 
 		consoleSpy.mockRestore();
 	});
+
+	// PR-B 1.4: visibility-aware pause
+	describe('isActive gate', () => {
+		it('drops the debounced event when isActive returns false', () => {
+			const onEvent = vi.fn();
+			let active = false;
+
+			createCueFileWatcher({
+				watchGlob: '**/*.ts',
+				projectRoot: '/test',
+				debounceMs: 5000,
+				onEvent,
+				triggerName: 'test',
+				isActive: () => active,
+			});
+
+			const changeHandler = mockOn.mock.calls.find((call) => call[0] === 'change')?.[1];
+			changeHandler('src/index.ts');
+			vi.advanceTimersByTime(5000);
+
+			expect(onEvent).not.toHaveBeenCalled();
+		});
+
+		it('dispatches the next event after isActive flips to true', () => {
+			const onEvent = vi.fn();
+			let active = false;
+
+			createCueFileWatcher({
+				watchGlob: '**/*.ts',
+				projectRoot: '/test',
+				debounceMs: 5000,
+				onEvent,
+				triggerName: 'test',
+				isActive: () => active,
+			});
+
+			const changeHandler = mockOn.mock.calls.find((call) => call[0] === 'change')?.[1];
+			changeHandler('src/inactive.ts');
+			vi.advanceTimersByTime(5000);
+			expect(onEvent).not.toHaveBeenCalled();
+
+			active = true;
+			changeHandler('src/active.ts');
+			vi.advanceTimersByTime(5000);
+			expect(onEvent).toHaveBeenCalledTimes(1);
+		});
+
+		it('still subscribes to chokidar even when isActive is false (no setup teardown)', () => {
+			createCueFileWatcher({
+				watchGlob: '**/*.ts',
+				projectRoot: '/test',
+				debounceMs: 5000,
+				onEvent: vi.fn(),
+				triggerName: 'test',
+				isActive: () => false,
+			});
+
+			const registeredEvents = mockOn.mock.calls.map((call) => call[0]);
+			expect(registeredEvents).toContain('change');
+			expect(registeredEvents).toContain('add');
+			expect(registeredEvents).toContain('unlink');
+		});
+
+		it('defaults to always-active when isActive is omitted', () => {
+			const onEvent = vi.fn();
+			createCueFileWatcher({
+				watchGlob: '**/*.ts',
+				projectRoot: '/test',
+				debounceMs: 5000,
+				onEvent,
+				triggerName: 'test',
+			});
+
+			const changeHandler = mockOn.mock.calls.find((call) => call[0] === 'change')?.[1];
+			changeHandler('src/index.ts');
+			vi.advanceTimersByTime(5000);
+
+			expect(onEvent).toHaveBeenCalledTimes(1);
+		});
+	});
 });

--- a/src/__tests__/main/cue/cue-github-poller.test.ts
+++ b/src/__tests__/main/cue/cue-github-poller.test.ts
@@ -937,4 +937,63 @@ describe('cue-github-poller', () => {
 			cleanup();
 		});
 	});
+
+	// PR-B 1.4: visibility-aware pause
+	describe('isActive gate', () => {
+		it('skips the gh fetch when isActive returns false', async () => {
+			let active = false;
+			const config = makeConfig({ isActive: () => active });
+			setupExecFile({
+				'--version': '2.0.0',
+				'pr list': JSON.stringify(samplePRs),
+			});
+
+			const cleanup = createCueGitHubPoller(config);
+			await vi.advanceTimersByTimeAsync(2000);
+
+			// gh CLI was never invoked because doPoll short-circuited
+			expect(mockExecFile).not.toHaveBeenCalled();
+			expect(config.onEvent).not.toHaveBeenCalled();
+
+			cleanup();
+		});
+
+		it('resumes polling on the next interval when isActive flips back to true', async () => {
+			let active = false;
+			const config = makeConfig({ isActive: () => active });
+			setupExecFile({
+				'--version': '2.0.0',
+				'pr list': JSON.stringify(samplePRs),
+			});
+
+			const cleanup = createCueGitHubPoller(config);
+
+			// Initial poll attempt while inactive — no gh call.
+			await vi.advanceTimersByTimeAsync(2100);
+			expect(mockExecFile).not.toHaveBeenCalled();
+
+			// Activate, then advance past the configured poll interval.
+			active = true;
+			await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+
+			expect(mockExecFile).toHaveBeenCalled();
+
+			cleanup();
+		});
+
+		it('defaults to always-active when isActive is omitted', async () => {
+			const config = makeConfig();
+			setupExecFile({
+				'--version': '2.0.0',
+				'pr list': JSON.stringify(samplePRs),
+			});
+
+			const cleanup = createCueGitHubPoller(config);
+			await vi.advanceTimersByTimeAsync(2100);
+
+			expect(mockExecFile).toHaveBeenCalled();
+
+			cleanup();
+		});
+	});
 });

--- a/src/__tests__/main/cue/cue-task-scanner.test.ts
+++ b/src/__tests__/main/cue/cue-task-scanner.test.ts
@@ -301,5 +301,87 @@ describe('cue-task-scanner', () => {
 
 			cleanup();
 		});
+
+		// PR-B 1.4: visibility-aware pause
+		describe('isActive gate', () => {
+			it('skips the directory walk when isActive returns false', async () => {
+				const onEvent = vi.fn();
+				let active = false;
+
+				const cleanup = createCueTaskScanner({
+					watchGlob: '**/*.md',
+					pollMinutes: 1,
+					projectRoot: '/project',
+					onEvent,
+					onLog: vi.fn(),
+					triggerName: 'test-scanner',
+					isActive: () => active,
+				});
+
+				await vi.advanceTimersByTimeAsync(3000);
+
+				expect(onEvent).not.toHaveBeenCalled();
+				// Walk never happened — readdirSync should not have been called
+				expect(mockReaddirSync).not.toHaveBeenCalled();
+				expect(mockReadFileSync).not.toHaveBeenCalled();
+
+				cleanup();
+			});
+
+			it('resumes scanning on the next interval when isActive flips back to true', async () => {
+				const onEvent = vi.fn();
+				let active = false;
+
+				mockReaddirSync.mockImplementation((_dir: string, opts: { withFileTypes: boolean }) => {
+					if (opts?.withFileTypes) {
+						return [{ name: 'task.md', isDirectory: () => false, isFile: () => true }];
+					}
+					return [];
+				});
+				mockReadFileSync.mockReturnValue('- [ ] task\n');
+
+				const cleanup = createCueTaskScanner({
+					watchGlob: '**/*.md',
+					pollMinutes: 1,
+					projectRoot: '/project',
+					onEvent,
+					onLog: vi.fn(),
+					triggerName: 'test-scanner',
+					isActive: () => active,
+				});
+
+				// Initial scan happens but is paused
+				await vi.advanceTimersByTimeAsync(3000);
+				expect(mockReaddirSync).not.toHaveBeenCalled();
+
+				// Activate — next interval tick should now scan
+				active = true;
+				await vi.advanceTimersByTimeAsync(60_000); // pollMinutes * 60_000 = 1 min
+				expect(mockReaddirSync).toHaveBeenCalled();
+
+				cleanup();
+			});
+
+			it('defaults to always-active when isActive is omitted', async () => {
+				const onEvent = vi.fn();
+
+				mockReaddirSync.mockImplementation(() => []);
+
+				const cleanup = createCueTaskScanner({
+					watchGlob: '**/*.md',
+					pollMinutes: 1,
+					projectRoot: '/project',
+					onEvent,
+					onLog: vi.fn(),
+					triggerName: 'test-scanner',
+					// No isActive — should behave as always-active.
+				});
+
+				await vi.advanceTimersByTimeAsync(3000);
+				expect(mockReaddirSync).toHaveBeenCalled();
+
+				cleanup();
+			});
+		});
 	});
 });

--- a/src/__tests__/main/ipc/handlers/persistence.test.ts
+++ b/src/__tests__/main/ipc/handlers/persistence.test.ts
@@ -1014,7 +1014,7 @@ describe('persistence IPC handlers', () => {
 			expect(mockWebServer.broadcastSessionStateChange).not.toHaveBeenCalled();
 		});
 
-		it('returns false on ENOSPC write error', async () => {
+		it('returns false on ENOSPC write error (recoverable)', async () => {
 			const error = new Error('ENOSPC: no space left on device') as NodeJS.ErrnoException;
 			error.code = 'ENOSPC';
 			mockSessionsStore.set.mockImplementation(() => {
@@ -1028,9 +1028,11 @@ describe('persistence IPC handlers', () => {
 			expect(result).toBe(false);
 		});
 
-		it('returns false on JSON serialization error', async () => {
+		it('returns false on ENFILE write error (recoverable)', async () => {
+			const error = new Error('ENFILE: too many open files') as NodeJS.ErrnoException;
+			error.code = 'ENFILE';
 			mockSessionsStore.set.mockImplementation(() => {
-				throw new TypeError('Converting circular structure to JSON');
+				throw error;
 			});
 			mockSessionsStore.get.mockReturnValue([]);
 
@@ -1038,6 +1040,19 @@ describe('persistence IPC handlers', () => {
 			const result = await handler!({} as any, [{ ...baseSession }], []);
 
 			expect(result).toBe(false);
+		});
+
+		it('rethrows unexpected errors so withIpcErrorLogging can surface them to Sentry', async () => {
+			mockSessionsStore.set.mockImplementation(() => {
+				throw new TypeError('Converting circular structure to JSON');
+			});
+			mockSessionsStore.get.mockReturnValue([]);
+
+			const handler = handlers.get('sessions:setMany');
+
+			await expect(handler!({} as any, [{ ...baseSession }], [])).rejects.toThrow(
+				'Converting circular structure to JSON'
+			);
 		});
 	});
 

--- a/src/__tests__/main/ipc/handlers/persistence.test.ts
+++ b/src/__tests__/main/ipc/handlers/persistence.test.ts
@@ -148,6 +148,7 @@ describe('persistence IPC handlers', () => {
 				'sessions:getActiveSessionId',
 				'sessions:setActiveSessionId',
 				'sessions:setAll',
+				'sessions:setMany',
 				'groups:getAll',
 				'groups:setAll',
 				'cli:getActivity',
@@ -818,6 +819,223 @@ describe('persistence IPC handlers', () => {
 
 			const handler = handlers.get('sessions:setAll');
 			const result = await handler!({} as any, [{ id: 's1', name: 'S1', state: 'idle' }]);
+
+			expect(result).toBe(false);
+		});
+	});
+
+	describe('sessions:setMany', () => {
+		const baseSession = {
+			id: 's1',
+			name: 'Session 1',
+			cwd: '/test',
+			projectRoot: '/test',
+			state: 'idle' as const,
+			inputMode: 'ai' as const,
+			toolType: 'claude-code',
+		};
+
+		it('writes the merged sessions array to the store', async () => {
+			mockSessionsStore.get.mockReturnValue([{ ...baseSession }]);
+
+			const handler = handlers.get('sessions:setMany');
+			await handler!({} as any, [{ ...baseSession, name: 'Updated' }], []);
+
+			expect(mockSessionsStore.set).toHaveBeenCalledWith(
+				'sessions',
+				expect.arrayContaining([expect.objectContaining({ id: 's1', name: 'Updated' })])
+			);
+		});
+
+		it('returns true on success', async () => {
+			mockSessionsStore.get.mockReturnValue([]);
+			const handler = handlers.get('sessions:setMany');
+			const result = await handler!({} as any, [], []);
+			expect(result).toBe(true);
+		});
+
+		it('is a no-op when given empty updates and empty removeIds', async () => {
+			mockSessionsStore.get.mockReturnValue([{ ...baseSession }]);
+			const handler = handlers.get('sessions:setMany');
+			await handler!({} as any, [], []);
+
+			// merged should equal previous (no add, no remove)
+			expect(mockSessionsStore.set).toHaveBeenCalledWith('sessions', [
+				expect.objectContaining({ id: 's1' }),
+			]);
+		});
+
+		it('replaces an existing session by id', async () => {
+			mockSessionsStore.get.mockReturnValue([
+				{ ...baseSession, name: 'Old' },
+				{ ...baseSession, id: 's2', name: 'Other' },
+			]);
+			const handler = handlers.get('sessions:setMany');
+			await handler!({} as any, [{ ...baseSession, name: 'New' }], []);
+
+			const merged = mockSessionsStore.set.mock.calls[0][1];
+			expect(merged).toHaveLength(2);
+			expect(merged.find((s: any) => s.id === 's1').name).toBe('New');
+			expect(merged.find((s: any) => s.id === 's2').name).toBe('Other');
+		});
+
+		it('appends a new session to the end', async () => {
+			mockSessionsStore.get.mockReturnValue([{ ...baseSession }]);
+			const handler = handlers.get('sessions:setMany');
+			await handler!({} as any, [{ ...baseSession, id: 's2', name: 'Two' }], []);
+
+			const merged = mockSessionsStore.set.mock.calls[0][1];
+			expect(merged.map((s: any) => s.id)).toEqual(['s1', 's2']);
+		});
+
+		it('removes sessions whose id is in removeIds', async () => {
+			mockSessionsStore.get.mockReturnValue([
+				{ ...baseSession, id: 's1' },
+				{ ...baseSession, id: 's2' },
+			]);
+			const handler = handlers.get('sessions:setMany');
+			await handler!({} as any, [], ['s1']);
+
+			const merged = mockSessionsStore.set.mock.calls[0][1];
+			expect(merged.map((s: any) => s.id)).toEqual(['s2']);
+		});
+
+		it('handles mixed updates and removes in one call', async () => {
+			mockSessionsStore.get.mockReturnValue([
+				{ ...baseSession, id: 's1' },
+				{ ...baseSession, id: 's2' },
+				{ ...baseSession, id: 's3' },
+			]);
+			const handler = handlers.get('sessions:setMany');
+			await handler!(
+				{} as any,
+				[
+					{ ...baseSession, id: 's2', name: 'Updated' },
+					{ ...baseSession, id: 's4', name: 'New' },
+				],
+				['s1']
+			);
+
+			const merged = mockSessionsStore.set.mock.calls[0][1];
+			// s1 removed, s2 updated, s3 untouched, s4 appended
+			expect(merged.map((s: any) => s.id)).toEqual(['s2', 's3', 's4']);
+			expect(merged.find((s: any) => s.id === 's2').name).toBe('Updated');
+		});
+
+		it('preserves existing order when updating', async () => {
+			mockSessionsStore.get.mockReturnValue([
+				{ ...baseSession, id: 'a' },
+				{ ...baseSession, id: 'b' },
+				{ ...baseSession, id: 'c' },
+			]);
+			const handler = handlers.get('sessions:setMany');
+			await handler!({} as any, [{ ...baseSession, id: 'b', name: 'B-updated' }], []);
+
+			const merged = mockSessionsStore.set.mock.calls[0][1];
+			expect(merged.map((s: any) => s.id)).toEqual(['a', 'b', 'c']);
+		});
+
+		it('lets remove win when an id appears in both updates and removeIds', async () => {
+			mockSessionsStore.get.mockReturnValue([{ ...baseSession }]);
+			const handler = handlers.get('sessions:setMany');
+			await handler!({} as any, [{ ...baseSession, name: 'Should be ignored' }], ['s1']);
+
+			const merged = mockSessionsStore.set.mock.calls[0][1];
+			expect(merged).toEqual([]);
+		});
+
+		it('treats updates with unseen ids as adds (broadcastSessionAdded)', async () => {
+			mockWebServer.getWebClientCount.mockReturnValue(2);
+			mockSessionsStore.get.mockReturnValue([]);
+
+			const handler = handlers.get('sessions:setMany');
+			await handler!({} as any, [{ ...baseSession, id: 'new1' }], []);
+
+			expect(mockWebServer.broadcastSessionAdded).toHaveBeenCalledWith(
+				expect.objectContaining({ id: 'new1' })
+			);
+			expect(mockWebServer.broadcastSessionStateChange).not.toHaveBeenCalled();
+		});
+
+		it('broadcasts state changes for updated sessions when web clients connected', async () => {
+			mockWebServer.getWebClientCount.mockReturnValue(2);
+			mockSessionsStore.get.mockReturnValue([{ ...baseSession, state: 'idle' }]);
+
+			const handler = handlers.get('sessions:setMany');
+			await handler!({} as any, [{ ...baseSession, state: 'busy' }], []);
+
+			expect(mockWebServer.broadcastSessionStateChange).toHaveBeenCalledWith(
+				's1',
+				'busy',
+				expect.any(Object)
+			);
+		});
+
+		it('broadcasts removals for ids that existed', async () => {
+			mockWebServer.getWebClientCount.mockReturnValue(2);
+			mockSessionsStore.get.mockReturnValue([{ ...baseSession }]);
+
+			const handler = handlers.get('sessions:setMany');
+			await handler!({} as any, [], ['s1']);
+
+			expect(mockWebServer.broadcastSessionRemoved).toHaveBeenCalledWith('s1');
+		});
+
+		it('does not broadcast removals for ids that did not exist', async () => {
+			mockWebServer.getWebClientCount.mockReturnValue(2);
+			mockSessionsStore.get.mockReturnValue([{ ...baseSession, id: 's1' }]);
+
+			const handler = handlers.get('sessions:setMany');
+			await handler!({} as any, [], ['nonexistent']);
+
+			expect(mockWebServer.broadcastSessionRemoved).not.toHaveBeenCalled();
+		});
+
+		it('does not broadcast when no web clients are connected', async () => {
+			mockWebServer.getWebClientCount.mockReturnValue(0);
+			mockSessionsStore.get.mockReturnValue([{ ...baseSession }]);
+
+			const handler = handlers.get('sessions:setMany');
+			await handler!({} as any, [{ ...baseSession, state: 'busy' }], ['nonexistent']);
+
+			expect(mockWebServer.broadcastSessionStateChange).not.toHaveBeenCalled();
+			expect(mockWebServer.broadcastSessionAdded).not.toHaveBeenCalled();
+			expect(mockWebServer.broadcastSessionRemoved).not.toHaveBeenCalled();
+		});
+
+		it('does not broadcast state-change for an unchanged session', async () => {
+			mockWebServer.getWebClientCount.mockReturnValue(2);
+			mockSessionsStore.get.mockReturnValue([{ ...baseSession }]);
+
+			const handler = handlers.get('sessions:setMany');
+			// New object with identical primitives — should be silent.
+			await handler!({} as any, [{ ...baseSession }], []);
+
+			expect(mockWebServer.broadcastSessionStateChange).not.toHaveBeenCalled();
+		});
+
+		it('returns false on ENOSPC write error', async () => {
+			const error = new Error('ENOSPC: no space left on device') as NodeJS.ErrnoException;
+			error.code = 'ENOSPC';
+			mockSessionsStore.set.mockImplementation(() => {
+				throw error;
+			});
+			mockSessionsStore.get.mockReturnValue([]);
+
+			const handler = handlers.get('sessions:setMany');
+			const result = await handler!({} as any, [{ ...baseSession }], []);
+
+			expect(result).toBe(false);
+		});
+
+		it('returns false on JSON serialization error', async () => {
+			mockSessionsStore.set.mockImplementation(() => {
+				throw new TypeError('Converting circular structure to JSON');
+			});
+			mockSessionsStore.get.mockReturnValue([]);
+
+			const handler = handlers.get('sessions:setMany');
+			const result = await handler!({} as any, [{ ...baseSession }], []);
 
 			expect(result).toBe(false);
 		});

--- a/src/__tests__/main/ipc/handlers/persistence.test.ts
+++ b/src/__tests__/main/ipc/handlers/persistence.test.ts
@@ -614,6 +614,90 @@ describe('persistence IPC handlers', () => {
 			expect(mockWebServer.broadcastSessionStateChange).toHaveBeenCalled();
 		});
 
+		// Characterization tests for cliActivity diff semantics. PR-A commit 2 will
+		// swap the JSON.stringify comparison for a shallow field compare; these
+		// tests pin down the exact (prev, curr) pairs that must continue to
+		// broadcast (or stay silent) so the swap is verifiable.
+		describe('cliActivity diff (lock-in for shallow-compare swap)', () => {
+			const baseSession = {
+				id: 'session-1',
+				name: 'Session 1',
+				cwd: '/test',
+				state: 'idle' as const,
+				inputMode: 'ai' as const,
+				toolType: 'claude-code',
+			};
+			const playbookA = { playbookId: 'pb-a', playbookName: 'Build', startedAt: 1000 };
+			const playbookB = { playbookId: 'pb-b', playbookName: 'Test', startedAt: 2000 };
+
+			beforeEach(() => {
+				mockWebServer.getWebClientCount.mockReturnValue(2);
+			});
+
+			it('does not broadcast when both prev and curr have no cliActivity', async () => {
+				mockSessionsStore.get.mockReturnValue([{ ...baseSession }]);
+				const handler = handlers.get('sessions:setAll');
+				await handler!({} as any, [{ ...baseSession }]);
+				expect(mockWebServer.broadcastSessionStateChange).not.toHaveBeenCalled();
+			});
+
+			it('broadcasts when cliActivity goes from undefined to playbook', async () => {
+				mockSessionsStore.get.mockReturnValue([{ ...baseSession }]);
+				const handler = handlers.get('sessions:setAll');
+				await handler!({} as any, [{ ...baseSession, cliActivity: playbookA }]);
+				expect(mockWebServer.broadcastSessionStateChange).toHaveBeenCalledTimes(1);
+			});
+
+			it('broadcasts when cliActivity goes from playbook to undefined', async () => {
+				mockSessionsStore.get.mockReturnValue([{ ...baseSession, cliActivity: playbookA }]);
+				const handler = handlers.get('sessions:setAll');
+				await handler!({} as any, [{ ...baseSession }]);
+				expect(mockWebServer.broadcastSessionStateChange).toHaveBeenCalledTimes(1);
+			});
+
+			it('broadcasts when playbookId changes', async () => {
+				mockSessionsStore.get.mockReturnValue([{ ...baseSession, cliActivity: playbookA }]);
+				const handler = handlers.get('sessions:setAll');
+				await handler!({} as any, [
+					{ ...baseSession, cliActivity: { ...playbookA, playbookId: 'pb-c' } },
+				]);
+				expect(mockWebServer.broadcastSessionStateChange).toHaveBeenCalledTimes(1);
+			});
+
+			it('broadcasts when playbookName changes', async () => {
+				mockSessionsStore.get.mockReturnValue([{ ...baseSession, cliActivity: playbookA }]);
+				const handler = handlers.get('sessions:setAll');
+				await handler!({} as any, [
+					{ ...baseSession, cliActivity: { ...playbookA, playbookName: 'NewName' } },
+				]);
+				expect(mockWebServer.broadcastSessionStateChange).toHaveBeenCalledTimes(1);
+			});
+
+			it('broadcasts when startedAt changes', async () => {
+				mockSessionsStore.get.mockReturnValue([{ ...baseSession, cliActivity: playbookA }]);
+				const handler = handlers.get('sessions:setAll');
+				await handler!({} as any, [
+					{ ...baseSession, cliActivity: { ...playbookA, startedAt: 9999 } },
+				]);
+				expect(mockWebServer.broadcastSessionStateChange).toHaveBeenCalledTimes(1);
+			});
+
+			it('does not broadcast when cliActivity reference changes but fields match', async () => {
+				mockSessionsStore.get.mockReturnValue([{ ...baseSession, cliActivity: playbookA }]);
+				const handler = handlers.get('sessions:setAll');
+				// New object, same field values — should be treated as unchanged.
+				await handler!({} as any, [{ ...baseSession, cliActivity: { ...playbookA } }]);
+				expect(mockWebServer.broadcastSessionStateChange).not.toHaveBeenCalled();
+			});
+
+			it('broadcasts when entire playbook is swapped', async () => {
+				mockSessionsStore.get.mockReturnValue([{ ...baseSession, cliActivity: playbookA }]);
+				const handler = handlers.get('sessions:setAll');
+				await handler!({} as any, [{ ...baseSession, cliActivity: playbookB }]);
+				expect(mockWebServer.broadcastSessionStateChange).toHaveBeenCalledTimes(1);
+			});
+		});
+
 		it('should not broadcast when no web clients connected', async () => {
 			mockWebServer.getWebClientCount.mockReturnValue(0);
 			const sessions = [

--- a/src/__tests__/main/ipc/handlers/stats.test.ts
+++ b/src/__tests__/main/ipc/handlers/stats.test.ts
@@ -153,6 +153,38 @@ describe('stats IPC handlers', () => {
 				expect(handlers.has(channel)).toBe(true);
 			}
 		});
+
+		// PR-B 1.5: registerStatsHandlers must wire flushQueryEventsSync to
+		// app:before-quit so buffered events aren't lost on quit.
+		it('registers a before-quit handler that flushes the query event buffer', async () => {
+			const { app } = await import('electron');
+			const beforeQuitCalls = vi.mocked(app.on).mock.calls.filter((c) => c[0] === 'before-quit');
+			expect(beforeQuitCalls.length).toBeGreaterThanOrEqual(1);
+
+			// Capture the most-recently-registered before-quit handler — the
+			// stats handler is one of several modules that may register on
+			// this event, so we don't assume length === 1.
+			const handler = beforeQuitCalls[beforeQuitCalls.length - 1][1] as () => void;
+			mockFlushQueryEventsSync.mockClear();
+
+			handler();
+
+			expect(mockFlushQueryEventsSync).toHaveBeenCalledTimes(1);
+		});
+
+		it('before-quit handler swallows flush errors (does not block shutdown)', async () => {
+			const { app } = await import('electron');
+			const beforeQuitCalls = vi.mocked(app.on).mock.calls.filter((c) => c[0] === 'before-quit');
+			const handler = beforeQuitCalls[beforeQuitCalls.length - 1][1] as () => void;
+
+			mockFlushQueryEventsSync.mockImplementationOnce(() => {
+				throw new Error('disk full');
+			});
+
+			// Should NOT propagate — failing to flush stats must not block
+			// app shutdown. Sentry capture is fire-and-forget inside the catch.
+			expect(() => handler()).not.toThrow();
+		});
 	});
 
 	describe('stats:updated broadcast verification', () => {

--- a/src/__tests__/main/ipc/handlers/stats.test.ts
+++ b/src/__tests__/main/ipc/handlers/stats.test.ts
@@ -11,13 +11,19 @@ import { registerStatsHandlers } from '../../../../main/ipc/handlers/stats';
 import * as statsDbModule from '../../../../main/stats';
 import type { StatsDB } from '../../../../main/stats';
 
-// Mock electron's ipcMain and BrowserWindow
+// Mock electron's ipcMain, BrowserWindow, and app
 vi.mock('electron', () => ({
 	ipcMain: {
 		handle: vi.fn(),
 		removeHandler: vi.fn(),
 	},
 	BrowserWindow: vi.fn(),
+	app: {
+		// Stats handler now registers a before-quit hook to flush the
+		// query-events buffer; tests don't exercise the hook so a noop is fine.
+		on: vi.fn(),
+		getPath: vi.fn().mockReturnValue('/mock/user/data'),
+	},
 }));
 
 // Mock the stats-db module
@@ -25,6 +31,16 @@ vi.mock('../../../../main/stats', () => ({
 	getStatsDB: vi.fn(),
 	getInitializationResult: vi.fn(),
 	clearInitializationResult: vi.fn(),
+}));
+
+// Mock the query-events buffer so tests can verify it's called without
+// needing a real SQLite DB. PR-B 1.5: the IPC handler now enqueues into
+// this buffer instead of calling db.insertQueryEvent directly.
+const mockEnqueueQueryEvent = vi.fn(() => 'buffered-query-event-id');
+const mockFlushQueryEventsSync = vi.fn();
+vi.mock('../../../../main/stats/query-events-buffer', () => ({
+	enqueueQueryEvent: (...args: unknown[]) => mockEnqueueQueryEvent(...args),
+	flushQueryEventsSync: () => mockFlushQueryEventsSync(),
 }));
 
 // Mock the logger
@@ -52,6 +68,10 @@ describe('stats IPC handlers', () => {
 
 		// Create mock stats database
 		mockStatsDB = {
+			// PR-B 1.5: the record-query handler no longer calls insertQueryEvent;
+			// it enqueues into query-events-buffer instead. Other paths (auto-run,
+			// session-lifecycle) still call the direct DB methods.
+			database: {} as never,
 			insertQueryEvent: vi.fn().mockReturnValue('query-event-id'),
 			insertAutoRunSession: vi.fn().mockReturnValue('autorun-session-id'),
 			updateAutoRunSession: vi.fn().mockReturnValue(true),
@@ -151,7 +171,8 @@ describe('stats IPC handlers', () => {
 
 				await handler!({} as any, queryEvent);
 
-				expect(mockStatsDB.insertQueryEvent).toHaveBeenCalledWith(queryEvent);
+				// PR-B 1.5: enqueueQueryEvent is called instead of insertQueryEvent
+				expect(mockEnqueueQueryEvent).toHaveBeenCalledWith(mockStatsDB.database, queryEvent);
 				expect(mockMainWindow.webContents.send).toHaveBeenCalledWith('stats:updated');
 				expect(mockMainWindow.webContents.send).toHaveBeenCalledTimes(1);
 			});
@@ -176,7 +197,7 @@ describe('stats IPC handlers', () => {
 				await handler!({} as any, queryEvent);
 
 				// No error should be thrown, and no send should happen
-				expect(mockStatsDB.insertQueryEvent).toHaveBeenCalled();
+				expect(mockEnqueueQueryEvent).toHaveBeenCalled();
 				expect(mockMainWindow.webContents.send).not.toHaveBeenCalled();
 			});
 
@@ -194,7 +215,7 @@ describe('stats IPC handlers', () => {
 
 				await handler!({} as any, queryEvent);
 
-				expect(mockStatsDB.insertQueryEvent).toHaveBeenCalled();
+				expect(mockEnqueueQueryEvent).toHaveBeenCalled();
 				expect(mockMainWindow.webContents.send).not.toHaveBeenCalled();
 			});
 		});
@@ -331,12 +352,12 @@ describe('stats IPC handlers', () => {
 	});
 
 	describe('broadcast timing', () => {
-		it('should broadcast after database write completes', async () => {
+		it('should broadcast after enqueueing the query event', async () => {
 			const executionOrder: string[] = [];
 
-			vi.mocked(mockStatsDB.insertQueryEvent).mockImplementation(() => {
-				executionOrder.push('db-write');
-				return 'query-event-id';
+			mockEnqueueQueryEvent.mockImplementation(() => {
+				executionOrder.push('enqueue');
+				return 'buffered-id';
 			});
 
 			mockMainWindow.webContents.send = vi.fn().mockImplementation(() => {
@@ -352,7 +373,8 @@ describe('stats IPC handlers', () => {
 				duration: 5000,
 			});
 
-			expect(executionOrder).toEqual(['db-write', 'broadcast']);
+			// PR-B 1.5: enqueue is sync (no DB write yet); broadcast follows.
+			expect(executionOrder).toEqual(['enqueue', 'broadcast']);
 		});
 	});
 

--- a/src/__tests__/main/stats/query-events-buffer.test.ts
+++ b/src/__tests__/main/stats/query-events-buffer.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Tests for the stats query-event write buffer (PR-B 1.5).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+	enqueueQueryEvent,
+	flushQueryEventsSync,
+	getQueryEventBufferSize,
+	resetQueryEventBufferForTests,
+	QUERY_EVENT_BATCH_SIZE,
+	QUERY_EVENT_FLUSH_INTERVAL_MS,
+} from '../../../main/stats/query-events-buffer';
+import type { QueryEvent } from '../../../shared/stats-types';
+
+vi.mock('../../../main/utils/logger', () => ({
+	logger: {
+		debug: vi.fn(),
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+	},
+}));
+
+interface MockStatement {
+	run: ReturnType<typeof vi.fn>;
+}
+interface MockTransactionFactory {
+	(fn: () => void): () => void;
+}
+interface MockDb {
+	prepare: ReturnType<typeof vi.fn>;
+	transaction: MockTransactionFactory;
+}
+
+function makeMockDb(): { db: MockDb; stmt: MockStatement; runs: unknown[][] } {
+	const runs: unknown[][] = [];
+	const stmt: MockStatement = {
+		run: vi.fn((...args: unknown[]) => {
+			runs.push(args);
+		}),
+	};
+	const db: MockDb = {
+		prepare: vi.fn(() => stmt),
+		transaction: ((fn: () => void) => () => {
+			fn();
+		}) as MockTransactionFactory,
+	};
+	return { db, stmt, runs };
+}
+
+const sampleEvent: Omit<QueryEvent, 'id'> = {
+	sessionId: 's1',
+	agentType: 'claude-code',
+	source: 'user',
+	startTime: 1000,
+	duration: 500,
+	projectPath: '/p',
+	tabId: 't1',
+	isRemote: false,
+};
+
+describe('query-events-buffer', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		resetQueryEventBufferForTests();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('buffers a single event without writing immediately', () => {
+		const { db, stmt } = makeMockDb();
+		enqueueQueryEvent(db as never, sampleEvent);
+
+		expect(getQueryEventBufferSize()).toBe(1);
+		expect(stmt.run).not.toHaveBeenCalled();
+	});
+
+	it('returns a generated id synchronously', () => {
+		const { db } = makeMockDb();
+		const id = enqueueQueryEvent(db as never, sampleEvent);
+
+		expect(typeof id).toBe('string');
+		expect(id.length).toBeGreaterThan(0);
+	});
+
+	it('flushes to the DB after the timer interval elapses', () => {
+		const { db, stmt } = makeMockDb();
+		enqueueQueryEvent(db as never, sampleEvent);
+		expect(stmt.run).not.toHaveBeenCalled();
+
+		vi.advanceTimersByTime(QUERY_EVENT_FLUSH_INTERVAL_MS);
+
+		expect(stmt.run).toHaveBeenCalledTimes(1);
+		expect(getQueryEventBufferSize()).toBe(0);
+	});
+
+	it('flushes when the batch threshold is reached, before the timer fires', () => {
+		const { db, stmt } = makeMockDb();
+		for (let i = 0; i < QUERY_EVENT_BATCH_SIZE; i++) {
+			enqueueQueryEvent(db as never, sampleEvent);
+		}
+
+		// Threshold-flush should happen synchronously inside the last enqueue.
+		expect(stmt.run).toHaveBeenCalledTimes(QUERY_EVENT_BATCH_SIZE);
+		expect(getQueryEventBufferSize()).toBe(0);
+	});
+
+	it('wraps the batch in a single transaction', () => {
+		const { db, stmt } = makeMockDb();
+		const txSpy = vi.fn(((fn: () => void) => () => fn()) as MockTransactionFactory);
+		db.transaction = txSpy;
+
+		enqueueQueryEvent(db as never, sampleEvent);
+		enqueueQueryEvent(db as never, sampleEvent);
+		enqueueQueryEvent(db as never, sampleEvent);
+		flushQueryEventsSync();
+
+		expect(txSpy).toHaveBeenCalledTimes(1);
+		expect(stmt.run).toHaveBeenCalledTimes(3);
+	});
+
+	it('explicit flushQueryEventsSync drains the buffer immediately', () => {
+		const { db, stmt } = makeMockDb();
+		enqueueQueryEvent(db as never, sampleEvent);
+		enqueueQueryEvent(db as never, sampleEvent);
+		expect(stmt.run).not.toHaveBeenCalled();
+
+		flushQueryEventsSync();
+
+		expect(stmt.run).toHaveBeenCalledTimes(2);
+		expect(getQueryEventBufferSize()).toBe(0);
+	});
+
+	it('flushQueryEventsSync is a no-op when buffer is empty', () => {
+		const { db, stmt } = makeMockDb();
+		// Establish a DB reference but no events
+		enqueueQueryEvent(db as never, sampleEvent);
+		flushQueryEventsSync();
+		stmt.run.mockClear();
+
+		flushQueryEventsSync();
+
+		expect(stmt.run).not.toHaveBeenCalled();
+	});
+
+	it('flushQueryEventsSync clears the pending timer', () => {
+		const { db, stmt } = makeMockDb();
+		enqueueQueryEvent(db as never, sampleEvent);
+		flushQueryEventsSync();
+
+		// Advancing time past the flush interval should NOT fire another flush
+		// (no events buffered, no timer scheduled).
+		stmt.run.mockClear();
+		vi.advanceTimersByTime(QUERY_EVENT_FLUSH_INTERVAL_MS * 2);
+		expect(stmt.run).not.toHaveBeenCalled();
+	});
+
+	it('schedules at most one timer for a stream of fast enqueues', () => {
+		const { db, stmt } = makeMockDb();
+		for (let i = 0; i < 5; i++) {
+			enqueueQueryEvent(db as never, sampleEvent);
+		}
+		// One timer pending — advancing past the interval flushes everything.
+		vi.advanceTimersByTime(QUERY_EVENT_FLUSH_INTERVAL_MS);
+		expect(stmt.run).toHaveBeenCalledTimes(5);
+	});
+
+	it('drops events on flush failure rather than retrying', () => {
+		const { db, stmt } = makeMockDb();
+		// Make the transaction throw on first run.
+		db.transaction = (() => () => {
+			throw new Error('disk full');
+		}) as MockTransactionFactory;
+
+		enqueueQueryEvent(db as never, sampleEvent);
+		enqueueQueryEvent(db as never, sampleEvent);
+
+		expect(() => flushQueryEventsSync()).not.toThrow();
+		// Buffer was cleared even though the transaction failed.
+		expect(getQueryEventBufferSize()).toBe(0);
+		// Subsequent flush is a no-op (buffer empty).
+		flushQueryEventsSync();
+		expect(stmt.run).not.toHaveBeenCalled();
+	});
+
+	it('passes the correct field shape to stmt.run', () => {
+		const { db, stmt } = makeMockDb();
+		enqueueQueryEvent(db as never, sampleEvent);
+		flushQueryEventsSync();
+
+		expect(stmt.run).toHaveBeenCalledTimes(1);
+		const args = stmt.run.mock.calls[0];
+		expect(args).toHaveLength(9);
+		// args[0] is the generated id; args[1..] mirror the event fields.
+		expect(args[1]).toBe('s1');
+		expect(args[2]).toBe('claude-code');
+		expect(args[3]).toBe('user');
+		expect(args[4]).toBe(1000);
+		expect(args[5]).toBe(500);
+		expect(args[6]).toBe('/p');
+		expect(args[7]).toBe('t1');
+		expect(args[8]).toBe(0); // isRemote false → 0
+	});
+
+	it('encodes isRemote=true as 1 and missing tabId as null', () => {
+		const { db, stmt } = makeMockDb();
+		enqueueQueryEvent(db as never, {
+			...sampleEvent,
+			isRemote: true,
+			tabId: undefined,
+		});
+		flushQueryEventsSync();
+
+		const args = stmt.run.mock.calls[0];
+		expect(args[7]).toBe(null);
+		expect(args[8]).toBe(1);
+	});
+
+	it('handles undefined isRemote as null', () => {
+		const { db, stmt } = makeMockDb();
+		const eventWithoutRemote = { ...sampleEvent };
+		delete (eventWithoutRemote as { isRemote?: unknown }).isRemote;
+		enqueueQueryEvent(db as never, eventWithoutRemote);
+		flushQueryEventsSync();
+
+		const args = stmt.run.mock.calls[0];
+		expect(args[8]).toBe(null);
+	});
+
+	it('survives a DB reference change between flushes', () => {
+		const first = makeMockDb();
+		const second = makeMockDb();
+
+		enqueueQueryEvent(first.db as never, sampleEvent);
+		flushQueryEventsSync();
+		expect(first.stmt.run).toHaveBeenCalledTimes(1);
+
+		// New DB reference — buffer module clears its statement cache and
+		// prepares against the new DB.
+		enqueueQueryEvent(second.db as never, sampleEvent);
+		flushQueryEventsSync();
+		expect(second.stmt.run).toHaveBeenCalledTimes(1);
+		expect(first.stmt.run).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not flush before any enqueue establishes a DB reference', () => {
+		// No enqueue has happened, so flush has no DB to write to.
+		expect(() => flushQueryEventsSync()).not.toThrow();
+	});
+});

--- a/src/__tests__/renderer/components/CuePipelineEditor/PipelineCanvas.test.tsx
+++ b/src/__tests__/renderer/components/CuePipelineEditor/PipelineCanvas.test.tsx
@@ -15,6 +15,7 @@ vi.mock('reactflow', () => {
 		Controls: () => <div data-testid="rf-controls" />,
 		MiniMap: () => <div data-testid="rf-minimap" />,
 		ConnectionMode: { Loose: 'loose' },
+		ConnectionLineType: { Bezier: 'bezier' },
 	};
 });
 

--- a/src/__tests__/renderer/hooks/cue/useCueVisibilityWiring.test.ts
+++ b/src/__tests__/renderer/hooks/cue/useCueVisibilityWiring.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Tests for useCueVisibilityWiring — forwards renderer visibility
+ * changes to the main-process Cue scanner subsystem.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useCueVisibilityWiring } from '../../../../renderer/hooks/cue/useCueVisibilityWiring';
+
+describe('useCueVisibilityWiring', () => {
+	let setActive: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		setActive = vi.fn().mockResolvedValue(undefined);
+		// The cue mock is provided by setup.ts but reset call counts here.
+		(window.maestro.cue as unknown as { setActive: typeof setActive }).setActive = setActive;
+		// Reset visibility to "visible" between tests.
+		Object.defineProperty(document, 'hidden', { configurable: true, value: false });
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('seeds main process with current visibility state on mount', () => {
+		Object.defineProperty(document, 'hidden', { configurable: true, value: true });
+		renderHook(() => useCueVisibilityWiring());
+		expect(setActive).toHaveBeenCalledTimes(1);
+		expect(setActive).toHaveBeenCalledWith(false);
+	});
+
+	it('seeds with active=true when document is visible at mount', () => {
+		Object.defineProperty(document, 'hidden', { configurable: true, value: false });
+		renderHook(() => useCueVisibilityWiring());
+		expect(setActive).toHaveBeenCalledTimes(1);
+		expect(setActive).toHaveBeenCalledWith(true);
+	});
+
+	it('forwards visibilitychange events as setActive(!hidden)', () => {
+		renderHook(() => useCueVisibilityWiring());
+		expect(setActive).toHaveBeenCalledWith(true); // mount seed
+
+		// Hide the document and dispatch the event
+		Object.defineProperty(document, 'hidden', { configurable: true, value: true });
+		document.dispatchEvent(new Event('visibilitychange'));
+		expect(setActive).toHaveBeenLastCalledWith(false);
+
+		// Show the document again
+		Object.defineProperty(document, 'hidden', { configurable: true, value: false });
+		document.dispatchEvent(new Event('visibilitychange'));
+		expect(setActive).toHaveBeenLastCalledWith(true);
+	});
+
+	it('removes its visibilitychange listener on unmount', () => {
+		const { unmount } = renderHook(() => useCueVisibilityWiring());
+		setActive.mockClear();
+		unmount();
+
+		Object.defineProperty(document, 'hidden', { configurable: true, value: true });
+		document.dispatchEvent(new Event('visibilitychange'));
+		expect(setActive).not.toHaveBeenCalled();
+	});
+
+	it('does not throw when window.maestro.cue is missing', () => {
+		const original = window.maestro.cue;
+		(window.maestro as unknown as { cue: unknown }).cue = undefined;
+		try {
+			expect(() => renderHook(() => useCueVisibilityWiring())).not.toThrow();
+		} finally {
+			(window.maestro as unknown as { cue: unknown }).cue = original;
+		}
+	});
+
+	it('swallows IPC rejection without throwing', async () => {
+		setActive.mockRejectedValue(new Error('IPC error'));
+		expect(() => renderHook(() => useCueVisibilityWiring())).not.toThrow();
+		// Wait a microtask for the catch handler.
+		await Promise.resolve();
+	});
+});

--- a/src/__tests__/renderer/hooks/useSessionCategories.test.ts
+++ b/src/__tests__/renderer/hooks/useSessionCategories.test.ts
@@ -694,18 +694,24 @@ describe('useSessionCategories', () => {
 			expect(map.has('pa-c2')).toBe(false);
 		});
 
-		it('getWorktreeChildren returns identical arrays to map lookup', () => {
+		it('getWorktreeChildren returns the SAME array reference as map lookup', () => {
 			const fx = buildFixture();
 			resetStore(fx.allSessions, fx.groups);
 			const { result } = renderHook(() => useSessionCategories('', fx.sortedSessions));
 
-			// getWorktreeChildren must return the same array as the (unsorted) map.get
-			expect(result.current.getWorktreeChildren('pa')).toEqual(
+			// Identity (toBe), not deep-equal (toEqual): consumers may
+			// memoize on this reference. If a future change accidentally
+			// returns a clone instead of the original, dependent useMemo /
+			// React.memo bail-outs would silently break.
+			expect(result.current.getWorktreeChildren('pa')).toBe(
 				result.current.worktreeChildrenByParentId.get('pa')
 			);
-			expect(result.current.getWorktreeChildren('pb')).toEqual(
+			expect(result.current.getWorktreeChildren('pb')).toBe(
 				result.current.worktreeChildrenByParentId.get('pb')
 			);
+			// Unknown parent: caller-side fallback to a fresh [] each call,
+			// so identity does not hold here — content equality is the
+			// right contract.
 			expect(result.current.getWorktreeChildren('nonexistent')).toEqual([]);
 		});
 

--- a/src/__tests__/renderer/hooks/useSessionCategories.test.ts
+++ b/src/__tests__/renderer/hooks/useSessionCategories.test.ts
@@ -587,4 +587,149 @@ describe('useSessionCategories', () => {
 			expect(result.current.sortedFilteredSessions).toHaveLength(100);
 		});
 	});
+
+	// -----------------------------------------------------------------------
+	// Deep-equal lock-in for memo-cascade refactor
+	//
+	// PR-A commit 5 will collapse the four chained `useMemo`s
+	// (worktreeChildrenByParentId → sortedWorktreeChildrenByParentId →
+	// sortedSessionIndexById → getWorktreeChildren) into a single pass.
+	// These tests pin down the exact output shape for a representative
+	// fixture so the refactor is verified to produce identical results.
+	// -----------------------------------------------------------------------
+	describe('memo-cascade lock-in (PR-A 1.3)', () => {
+		function buildFixture() {
+			// 2 worktree parents, each with 2 children
+			const parentA = makeSession({ id: 'pa', name: '🌟 Alpha Parent' });
+			const childA1 = makeSession({
+				id: 'pa-c1',
+				name: '🌟 Branch Zeta',
+				parentSessionId: 'pa',
+			});
+			const childA2 = makeSession({
+				id: 'pa-c2',
+				name: '🔥 Branch Aurora',
+				parentSessionId: 'pa',
+			});
+			const parentB = makeSession({ id: 'pb', name: 'Bravo Parent', groupId: 'g1' });
+			const childB1 = makeSession({
+				id: 'pb-c1',
+				name: 'Branch X',
+				parentSessionId: 'pb',
+			});
+			const childB2 = makeSession({
+				id: 'pb-c2',
+				name: 'Branch Y',
+				parentSessionId: 'pb',
+			});
+			// Standalone sessions: bookmarked, grouped, ungrouped
+			const bookmark1 = makeSession({ id: 'b1', name: 'Bookmark 1', bookmarked: true });
+			const grouped1 = makeSession({ id: 'gr1', name: 'Grouped 1', groupId: 'g1' });
+			const ungrouped1 = makeSession({ id: 'u1', name: 'Ungrouped 1' });
+			const ungrouped2 = makeSession({ id: 'u2', name: 'Ungrouped 2' });
+
+			const allSessions = [
+				parentA,
+				childA1,
+				childA2,
+				parentB,
+				childB1,
+				childB2,
+				bookmark1,
+				grouped1,
+				ungrouped1,
+				ungrouped2,
+			];
+			// Top-level sessions only (sortedSessions excludes worktree children)
+			const sortedSessions = [parentA, parentB, bookmark1, grouped1, ungrouped1, ungrouped2];
+			const groups = [makeGroup({ id: 'g1', name: 'Group One' })];
+			return { allSessions, sortedSessions, groups };
+		}
+
+		it('produces stable worktreeChildrenByParentId for the fixture', () => {
+			const fx = buildFixture();
+			resetStore(fx.allSessions, fx.groups);
+			const { result } = renderHook(() => useSessionCategories('', fx.sortedSessions));
+
+			const map = result.current.worktreeChildrenByParentId;
+			expect(map.size).toBe(2);
+			expect(
+				map
+					.get('pa')!
+					.map((c) => c.id)
+					.sort()
+			).toEqual(['pa-c1', 'pa-c2']);
+			expect(
+				map
+					.get('pb')!
+					.map((c) => c.id)
+					.sort()
+			).toEqual(['pb-c1', 'pb-c2']);
+		});
+
+		it('produces stable sortedWorktreeChildrenByParentId for the fixture', () => {
+			const fx = buildFixture();
+			resetStore(fx.allSessions, fx.groups);
+			const { result } = renderHook(() => useSessionCategories('', fx.sortedSessions));
+
+			const map = result.current.sortedWorktreeChildrenByParentId;
+			// Aurora < Zeta (sort ignores emojis)
+			expect(map.get('pa')!.map((c) => c.id)).toEqual(['pa-c2', 'pa-c1']);
+			// X < Y (alphabetical)
+			expect(map.get('pb')!.map((c) => c.id)).toEqual(['pb-c1', 'pb-c2']);
+		});
+
+		it('produces stable sortedSessionIndexById for the fixture', () => {
+			const fx = buildFixture();
+			resetStore(fx.allSessions, fx.groups);
+			const { result } = renderHook(() => useSessionCategories('', fx.sortedSessions));
+
+			const map = result.current.sortedSessionIndexById;
+			expect(map.size).toBe(fx.sortedSessions.length);
+			fx.sortedSessions.forEach((s, i) => {
+				expect(map.get(s.id)).toBe(i);
+			});
+			// Ids not in sortedSessions should not be in the index map
+			expect(map.has('pa-c1')).toBe(false);
+			expect(map.has('pa-c2')).toBe(false);
+		});
+
+		it('getWorktreeChildren returns identical arrays to map lookup', () => {
+			const fx = buildFixture();
+			resetStore(fx.allSessions, fx.groups);
+			const { result } = renderHook(() => useSessionCategories('', fx.sortedSessions));
+
+			// getWorktreeChildren must return the same array as the (unsorted) map.get
+			expect(result.current.getWorktreeChildren('pa')).toEqual(
+				result.current.worktreeChildrenByParentId.get('pa')
+			);
+			expect(result.current.getWorktreeChildren('pb')).toEqual(
+				result.current.worktreeChildrenByParentId.get('pb')
+			);
+			expect(result.current.getWorktreeChildren('nonexistent')).toEqual([]);
+		});
+
+		it('reference identity holds across renders when sessions array does not change', () => {
+			const fx = buildFixture();
+			resetStore(fx.allSessions, fx.groups);
+			const { result, rerender } = renderHook(() => useSessionCategories('', fx.sortedSessions));
+
+			const firstRun = {
+				worktreeChildrenByParentId: result.current.worktreeChildrenByParentId,
+				sortedWorktreeChildrenByParentId: result.current.sortedWorktreeChildrenByParentId,
+				sortedSessionIndexById: result.current.sortedSessionIndexById,
+				getWorktreeChildren: result.current.getWorktreeChildren,
+			};
+
+			rerender();
+
+			// Sessions reference unchanged → memo outputs must be reference-stable.
+			expect(result.current.worktreeChildrenByParentId).toBe(firstRun.worktreeChildrenByParentId);
+			expect(result.current.sortedWorktreeChildrenByParentId).toBe(
+				firstRun.sortedWorktreeChildrenByParentId
+			);
+			expect(result.current.sortedSessionIndexById).toBe(firstRun.sortedSessionIndexById);
+			expect(result.current.getWorktreeChildren).toBe(firstRun.getWorktreeChildren);
+		});
+	});
 });

--- a/src/__tests__/renderer/hooks/utils/useDebouncedPersistence.test.ts
+++ b/src/__tests__/renderer/hooks/utils/useDebouncedPersistence.test.ts
@@ -955,7 +955,7 @@ describe('useDebouncedPersistence', () => {
 		});
 
 		describe('session with no aiTabs', () => {
-			it('should return session as-is when aiTabs is empty', () => {
+			it('should still strip runtime-only fields when aiTabs is empty', () => {
 				const session = makeSession({
 					aiTabs: [],
 					activeTabId: '',
@@ -971,9 +971,11 @@ describe('useDebouncedPersistence', () => {
 				});
 
 				const persisted = vi.mocked(window.maestro.sessions.setAll).mock.calls[0][0] as Session[];
-				// When aiTabs is empty, the session is returned as-is
+				// aiTabs stays empty, but runtime state is reset so a stuck
+				// busy state can't survive a restart with no process backing it.
 				expect(persisted[0].aiTabs).toEqual([]);
-				expect(persisted[0].state).toBe('busy');
+				expect(persisted[0].state).toBe('idle');
+				expect(persisted[0].busySource).toBeUndefined();
 			});
 		});
 
@@ -1278,7 +1280,7 @@ describe('useDebouncedPersistence', () => {
 				expect(result.current.isPending).toBe(true);
 			});
 
-			it('should become false after debounce timer fires', () => {
+			it('should become false after debounce timer fires', async () => {
 				const sessions = [makeSession()];
 				const initialLoadRef = makeInitialLoadRef(true);
 
@@ -1289,14 +1291,16 @@ describe('useDebouncedPersistence', () => {
 
 				expect(result.current.isPending).toBe(true);
 
-				act(() => {
-					vi.advanceTimersByTime(2000);
+				// Async because persistInternal awaits the IPC; isPending is
+				// only flipped after the awaited promise resolves.
+				await act(async () => {
+					await vi.advanceTimersByTimeAsync(2000);
 				});
 
 				expect(result.current.isPending).toBe(false);
 			});
 
-			it('should become false after flushNow', () => {
+			it('should become false after flushNow', async () => {
 				const sessions = [makeSession()];
 				const initialLoadRef = makeInitialLoadRef(true);
 
@@ -1307,8 +1311,11 @@ describe('useDebouncedPersistence', () => {
 
 				expect(result.current.isPending).toBe(true);
 
-				act(() => {
+				await act(async () => {
 					result.current.flushNow();
+					// Flush microtasks so the awaited persistInternal resolves
+					// and isPending is updated.
+					await vi.advanceTimersByTimeAsync(0);
 				});
 
 				expect(result.current.isPending).toBe(false);
@@ -1869,7 +1876,7 @@ describe('useDebouncedPersistence', () => {
 			expect(window.maestro.sessions.setMany).not.toHaveBeenCalled();
 		});
 
-		it('second flush with one mutated session ships only that session via setMany', () => {
+		it('second flush with one mutated session ships only that session via setMany', async () => {
 			const s1 = makeSession({ id: 's1', name: 'One' });
 			const s2 = makeSession({ id: 's2', name: 'Two' });
 			const initialLoadRef = makeInitialLoadRef(true);
@@ -1878,17 +1885,19 @@ describe('useDebouncedPersistence', () => {
 				({ sessions }) => useDebouncedPersistence(sessions, initialLoadRef),
 				{ initialProps: { sessions: [s1, s2] } }
 			);
-			// First flush — establishes baseline via setAll
-			act(() => {
-				vi.advanceTimersByTime(2000);
+			// First flush — establishes baseline via setAll. Async because
+			// persistInternal awaits the IPC; the baseline is only captured
+			// after the mock's resolved promise flushes through microtasks.
+			await act(async () => {
+				await vi.advanceTimersByTimeAsync(2000);
 			});
 			expect(window.maestro.sessions.setAll).toHaveBeenCalledTimes(1);
 
 			// Mutate s1 only — Zustand pattern produces a new session object
 			const s1Updated = { ...s1, name: 'One Updated' };
 			rerender({ sessions: [s1Updated, s2] });
-			act(() => {
-				vi.advanceTimersByTime(2000);
+			await act(async () => {
+				await vi.advanceTimersByTimeAsync(2000);
 			});
 
 			expect(window.maestro.sessions.setMany).toHaveBeenCalledTimes(1);
@@ -1902,7 +1911,7 @@ describe('useDebouncedPersistence', () => {
 			expect(removeIds).toEqual([]);
 		});
 
-		it('second flush with no changes is a no-op (no IPC call)', () => {
+		it('second flush with no changes is a no-op (no IPC call)', async () => {
 			const s1 = makeSession({ id: 's1', name: 'One' });
 			const initialLoadRef = makeInitialLoadRef(true);
 
@@ -1910,8 +1919,8 @@ describe('useDebouncedPersistence', () => {
 				({ sessions }) => useDebouncedPersistence(sessions, initialLoadRef),
 				{ initialProps: { sessions: [s1] } }
 			);
-			act(() => {
-				vi.advanceTimersByTime(2000);
+			await act(async () => {
+				await vi.advanceTimersByTimeAsync(2000);
 			});
 			vi.mocked(window.maestro.sessions.setAll).mockClear();
 			vi.mocked(window.maestro.sessions.setMany).mockClear();
@@ -1919,15 +1928,15 @@ describe('useDebouncedPersistence', () => {
 			// Same array reference — re-render forces effect to re-run but the
 			// diff finds nothing changed.
 			rerender({ sessions: [s1] });
-			act(() => {
-				vi.advanceTimersByTime(2000);
+			await act(async () => {
+				await vi.advanceTimersByTimeAsync(2000);
 			});
 
 			expect(window.maestro.sessions.setAll).not.toHaveBeenCalled();
 			expect(window.maestro.sessions.setMany).not.toHaveBeenCalled();
 		});
 
-		it('second flush with one removed session ships empty updates + tombstone id', () => {
+		it('second flush with one removed session ships empty updates + tombstone id', async () => {
 			const s1 = makeSession({ id: 's1' });
 			const s2 = makeSession({ id: 's2' });
 			const initialLoadRef = makeInitialLoadRef(true);
@@ -1936,14 +1945,14 @@ describe('useDebouncedPersistence', () => {
 				({ sessions }) => useDebouncedPersistence(sessions, initialLoadRef),
 				{ initialProps: { sessions: [s1, s2] } }
 			);
-			act(() => {
-				vi.advanceTimersByTime(2000);
+			await act(async () => {
+				await vi.advanceTimersByTimeAsync(2000);
 			});
 			vi.mocked(window.maestro.sessions.setMany).mockClear();
 
 			rerender({ sessions: [s1] });
-			act(() => {
-				vi.advanceTimersByTime(2000);
+			await act(async () => {
+				await vi.advanceTimersByTimeAsync(2000);
 			});
 
 			expect(window.maestro.sessions.setMany).toHaveBeenCalledTimes(1);
@@ -1955,7 +1964,7 @@ describe('useDebouncedPersistence', () => {
 			expect(removeIds).toEqual(['s2']);
 		});
 
-		it('second flush with one new session ships it as an update (no tombstones)', () => {
+		it('second flush with one new session ships it as an update (no tombstones)', async () => {
 			const s1 = makeSession({ id: 's1' });
 			const s2 = makeSession({ id: 's2' });
 			const initialLoadRef = makeInitialLoadRef(true);
@@ -1964,14 +1973,14 @@ describe('useDebouncedPersistence', () => {
 				({ sessions }) => useDebouncedPersistence(sessions, initialLoadRef),
 				{ initialProps: { sessions: [s1] } }
 			);
-			act(() => {
-				vi.advanceTimersByTime(2000);
+			await act(async () => {
+				await vi.advanceTimersByTimeAsync(2000);
 			});
 			vi.mocked(window.maestro.sessions.setMany).mockClear();
 
 			rerender({ sessions: [s1, s2] });
-			act(() => {
-				vi.advanceTimersByTime(2000);
+			await act(async () => {
+				await vi.advanceTimersByTimeAsync(2000);
 			});
 
 			const [updates, removeIds] = vi.mocked(window.maestro.sessions.setMany).mock.calls[0] as [
@@ -1983,7 +1992,7 @@ describe('useDebouncedPersistence', () => {
 			expect(removeIds).toEqual([]);
 		});
 
-		it('second flush handles mixed update + add + remove in one call', () => {
+		it('second flush handles mixed update + add + remove in one call', async () => {
 			const s1 = makeSession({ id: 's1', name: 'Keep' });
 			const s2 = makeSession({ id: 's2', name: 'Mutate' });
 			const s3 = makeSession({ id: 's3', name: 'Drop' });
@@ -1993,16 +2002,16 @@ describe('useDebouncedPersistence', () => {
 				({ sessions }) => useDebouncedPersistence(sessions, initialLoadRef),
 				{ initialProps: { sessions: [s1, s2, s3] } }
 			);
-			act(() => {
-				vi.advanceTimersByTime(2000);
+			await act(async () => {
+				await vi.advanceTimersByTimeAsync(2000);
 			});
 			vi.mocked(window.maestro.sessions.setMany).mockClear();
 
 			const s2Updated = { ...s2, name: 'Mutated' };
 			const s4 = makeSession({ id: 's4', name: 'New' });
 			rerender({ sessions: [s1, s2Updated, s4] });
-			act(() => {
-				vi.advanceTimersByTime(2000);
+			await act(async () => {
+				await vi.advanceTimersByTimeAsync(2000);
 			});
 
 			const [updates, removeIds] = vi.mocked(window.maestro.sessions.setMany).mock.calls[0] as [
@@ -2013,7 +2022,7 @@ describe('useDebouncedPersistence', () => {
 			expect(removeIds).toEqual(['s3']);
 		});
 
-		it('rapid mutations within one debounce window collapse into one setMany', () => {
+		it('rapid mutations within one debounce window collapse into one setMany', async () => {
 			const s1 = makeSession({ id: 's1', name: 'A' });
 			const initialLoadRef = makeInitialLoadRef(true);
 
@@ -2021,23 +2030,23 @@ describe('useDebouncedPersistence', () => {
 				({ sessions }) => useDebouncedPersistence(sessions, initialLoadRef),
 				{ initialProps: { sessions: [s1] } }
 			);
-			act(() => {
-				vi.advanceTimersByTime(2000);
+			await act(async () => {
+				await vi.advanceTimersByTimeAsync(2000);
 			});
 			vi.mocked(window.maestro.sessions.setMany).mockClear();
 
 			// Three rapid mutations within the debounce window
 			rerender({ sessions: [{ ...s1, name: 'B' }] });
-			act(() => {
-				vi.advanceTimersByTime(500);
+			await act(async () => {
+				await vi.advanceTimersByTimeAsync(500);
 			});
 			rerender({ sessions: [{ ...s1, name: 'C' }] });
-			act(() => {
-				vi.advanceTimersByTime(500);
+			await act(async () => {
+				await vi.advanceTimersByTimeAsync(500);
 			});
 			rerender({ sessions: [{ ...s1, name: 'D' }] });
-			act(() => {
-				vi.advanceTimersByTime(2000);
+			await act(async () => {
+				await vi.advanceTimersByTimeAsync(2000);
 			});
 
 			expect(window.maestro.sessions.setMany).toHaveBeenCalledTimes(1);
@@ -2048,7 +2057,7 @@ describe('useDebouncedPersistence', () => {
 			expect(updates[0].name).toBe('D'); // Final value wins
 		});
 
-		it('flushNow() after first flush uses setMany for dirty changes', () => {
+		it('flushNow() after first flush uses setMany for dirty changes', async () => {
 			const s1 = makeSession({ id: 's1', name: 'A' });
 			const initialLoadRef = makeInitialLoadRef(true);
 
@@ -2056,20 +2065,21 @@ describe('useDebouncedPersistence', () => {
 				({ sessions }) => useDebouncedPersistence(sessions, initialLoadRef),
 				{ initialProps: { sessions: [s1] } }
 			);
-			act(() => {
-				vi.advanceTimersByTime(2000);
+			await act(async () => {
+				await vi.advanceTimersByTimeAsync(2000);
 			});
 			vi.mocked(window.maestro.sessions.setMany).mockClear();
 
 			rerender({ sessions: [{ ...s1, name: 'B' }] });
-			act(() => {
+			await act(async () => {
 				result.current.flushNow();
+				await vi.advanceTimersByTimeAsync(0);
 			});
 
 			expect(window.maestro.sessions.setMany).toHaveBeenCalledTimes(1);
 		});
 
-		it('unmount after first flush uses setMany when dirty', () => {
+		it('unmount after first flush uses setMany when dirty', async () => {
 			const s1 = makeSession({ id: 's1', name: 'A' });
 			const initialLoadRef = makeInitialLoadRef(true);
 
@@ -2077,8 +2087,8 @@ describe('useDebouncedPersistence', () => {
 				({ sessions }) => useDebouncedPersistence(sessions, initialLoadRef),
 				{ initialProps: { sessions: [s1] } }
 			);
-			act(() => {
-				vi.advanceTimersByTime(2000);
+			await act(async () => {
+				await vi.advanceTimersByTimeAsync(2000);
 			});
 			vi.mocked(window.maestro.sessions.setAll).mockClear();
 			vi.mocked(window.maestro.sessions.setMany).mockClear();

--- a/src/__tests__/renderer/hooks/utils/useDebouncedPersistence.test.ts
+++ b/src/__tests__/renderer/hooks/utils/useDebouncedPersistence.test.ts
@@ -2100,6 +2100,80 @@ describe('useDebouncedPersistence', () => {
 			expect(window.maestro.sessions.setAll).not.toHaveBeenCalled();
 		});
 
+		// Retry contract: when the IPC reports a recoverable failure, the
+		// baseline must NOT advance and isPending must NOT clear — otherwise
+		// beforeunload (which gates on isPending) would have no chance to
+		// retry, and the next debounce flush would diff against a baseline
+		// that doesn't reflect what's actually on disk.
+		it('keeps isPending true and does not advance baseline when setMany returns false', async () => {
+			const s1 = makeSession({ id: 's1', name: 'One' });
+			const initialLoadRef = makeInitialLoadRef(true);
+
+			const { result, rerender } = renderHook(
+				({ sessions }) => useDebouncedPersistence(sessions, initialLoadRef),
+				{ initialProps: { sessions: [s1] } }
+			);
+			// First flush succeeds (mock returns undefined, treated as truthy).
+			await act(async () => {
+				await vi.advanceTimersByTimeAsync(2000);
+			});
+			vi.mocked(window.maestro.sessions.setMany).mockClear();
+			expect(result.current.isPending).toBe(false);
+
+			// Next flush hits a recoverable disk error.
+			vi.mocked(window.maestro.sessions.setMany).mockResolvedValueOnce(false);
+			rerender({ sessions: [{ ...s1, name: 'Two' }] });
+			await act(async () => {
+				await vi.advanceTimersByTimeAsync(2000);
+			});
+
+			// setMany was called and returned false. isPending stays true so
+			// the next mutation OR beforeunload will retry.
+			expect(window.maestro.sessions.setMany).toHaveBeenCalledTimes(1);
+			expect(result.current.isPending).toBe(true);
+
+			// Recovery: next flush should re-ship the same dirty session
+			// because the baseline didn't advance on the previous failure.
+			vi.mocked(window.maestro.sessions.setMany).mockClear();
+			rerender({ sessions: [{ ...s1, name: 'Two' }] });
+			await act(async () => {
+				await vi.advanceTimersByTimeAsync(2000);
+			});
+			// The same session is dirty again because previouslyPersistedRef
+			// was preserved at the pre-failure baseline.
+			const [updates] = vi.mocked(window.maestro.sessions.setMany).mock.calls[0] as [
+				Session[],
+				string[],
+			];
+			expect(updates).toHaveLength(1);
+			expect(updates[0].id).toBe('s1');
+			expect(updates[0].name).toBe('Two');
+		});
+
+		it('keeps isPending true when persistInternal rejects (unexpected exception)', async () => {
+			const s1 = makeSession({ id: 's1', name: 'One' });
+			const initialLoadRef = makeInitialLoadRef(true);
+
+			const { result, rerender } = renderHook(
+				({ sessions }) => useDebouncedPersistence(sessions, initialLoadRef),
+				{ initialProps: { sessions: [s1] } }
+			);
+			await act(async () => {
+				await vi.advanceTimersByTimeAsync(2000);
+			});
+			vi.mocked(window.maestro.sessions.setMany).mockClear();
+
+			vi.mocked(window.maestro.sessions.setMany).mockRejectedValueOnce(
+				new Error('IPC channel closed')
+			);
+			rerender({ sessions: [{ ...s1, name: 'Two' }] });
+			await act(async () => {
+				await vi.advanceTimersByTimeAsync(2000);
+			});
+
+			expect(result.current.isPending).toBe(true);
+		});
+
 		it('reference-equal session prop on rerender is treated as unchanged', () => {
 			const s1 = makeSession({ id: 's1' });
 			const initialLoadRef = makeInitialLoadRef(true);

--- a/src/__tests__/renderer/hooks/utils/useDebouncedPersistence.test.ts
+++ b/src/__tests__/renderer/hooks/utils/useDebouncedPersistence.test.ts
@@ -1847,4 +1847,269 @@ describe('useDebouncedPersistence', () => {
 			expect(tab2.name).toBe('Tab 2'); // Metadata preserved
 		});
 	});
+
+	// -----------------------------------------------------------------------
+	// PR-A 1.1: dirty-only flushes via setMany after first flush
+	//
+	// First flush after load uses setAll to seed main process and capture a
+	// diff baseline. Subsequent flushes diff sessions by reference and ship
+	// only the changed subset (and tombstone ids) via setMany.
+	// -----------------------------------------------------------------------
+	describe('dirty-only flushes (PR-A 1.1)', () => {
+		it('first flush after load uses setAll to seed the baseline', () => {
+			const s1 = makeSession({ id: 's1', name: 'One' });
+			const initialLoadRef = makeInitialLoadRef(true);
+
+			renderHook(() => useDebouncedPersistence([s1], initialLoadRef));
+			act(() => {
+				vi.advanceTimersByTime(2000);
+			});
+
+			expect(window.maestro.sessions.setAll).toHaveBeenCalledTimes(1);
+			expect(window.maestro.sessions.setMany).not.toHaveBeenCalled();
+		});
+
+		it('second flush with one mutated session ships only that session via setMany', () => {
+			const s1 = makeSession({ id: 's1', name: 'One' });
+			const s2 = makeSession({ id: 's2', name: 'Two' });
+			const initialLoadRef = makeInitialLoadRef(true);
+
+			const { rerender } = renderHook(
+				({ sessions }) => useDebouncedPersistence(sessions, initialLoadRef),
+				{ initialProps: { sessions: [s1, s2] } }
+			);
+			// First flush — establishes baseline via setAll
+			act(() => {
+				vi.advanceTimersByTime(2000);
+			});
+			expect(window.maestro.sessions.setAll).toHaveBeenCalledTimes(1);
+
+			// Mutate s1 only — Zustand pattern produces a new session object
+			const s1Updated = { ...s1, name: 'One Updated' };
+			rerender({ sessions: [s1Updated, s2] });
+			act(() => {
+				vi.advanceTimersByTime(2000);
+			});
+
+			expect(window.maestro.sessions.setMany).toHaveBeenCalledTimes(1);
+			const [updates, removeIds] = vi.mocked(window.maestro.sessions.setMany).mock.calls[0] as [
+				Session[],
+				string[],
+			];
+			expect(updates).toHaveLength(1);
+			expect(updates[0].id).toBe('s1');
+			expect(updates[0].name).toBe('One Updated');
+			expect(removeIds).toEqual([]);
+		});
+
+		it('second flush with no changes is a no-op (no IPC call)', () => {
+			const s1 = makeSession({ id: 's1', name: 'One' });
+			const initialLoadRef = makeInitialLoadRef(true);
+
+			const { rerender } = renderHook(
+				({ sessions }) => useDebouncedPersistence(sessions, initialLoadRef),
+				{ initialProps: { sessions: [s1] } }
+			);
+			act(() => {
+				vi.advanceTimersByTime(2000);
+			});
+			vi.mocked(window.maestro.sessions.setAll).mockClear();
+			vi.mocked(window.maestro.sessions.setMany).mockClear();
+
+			// Same array reference — re-render forces effect to re-run but the
+			// diff finds nothing changed.
+			rerender({ sessions: [s1] });
+			act(() => {
+				vi.advanceTimersByTime(2000);
+			});
+
+			expect(window.maestro.sessions.setAll).not.toHaveBeenCalled();
+			expect(window.maestro.sessions.setMany).not.toHaveBeenCalled();
+		});
+
+		it('second flush with one removed session ships empty updates + tombstone id', () => {
+			const s1 = makeSession({ id: 's1' });
+			const s2 = makeSession({ id: 's2' });
+			const initialLoadRef = makeInitialLoadRef(true);
+
+			const { rerender } = renderHook(
+				({ sessions }) => useDebouncedPersistence(sessions, initialLoadRef),
+				{ initialProps: { sessions: [s1, s2] } }
+			);
+			act(() => {
+				vi.advanceTimersByTime(2000);
+			});
+			vi.mocked(window.maestro.sessions.setMany).mockClear();
+
+			rerender({ sessions: [s1] });
+			act(() => {
+				vi.advanceTimersByTime(2000);
+			});
+
+			expect(window.maestro.sessions.setMany).toHaveBeenCalledTimes(1);
+			const [updates, removeIds] = vi.mocked(window.maestro.sessions.setMany).mock.calls[0] as [
+				Session[],
+				string[],
+			];
+			expect(updates).toEqual([]);
+			expect(removeIds).toEqual(['s2']);
+		});
+
+		it('second flush with one new session ships it as an update (no tombstones)', () => {
+			const s1 = makeSession({ id: 's1' });
+			const s2 = makeSession({ id: 's2' });
+			const initialLoadRef = makeInitialLoadRef(true);
+
+			const { rerender } = renderHook(
+				({ sessions }) => useDebouncedPersistence(sessions, initialLoadRef),
+				{ initialProps: { sessions: [s1] } }
+			);
+			act(() => {
+				vi.advanceTimersByTime(2000);
+			});
+			vi.mocked(window.maestro.sessions.setMany).mockClear();
+
+			rerender({ sessions: [s1, s2] });
+			act(() => {
+				vi.advanceTimersByTime(2000);
+			});
+
+			const [updates, removeIds] = vi.mocked(window.maestro.sessions.setMany).mock.calls[0] as [
+				Session[],
+				string[],
+			];
+			expect(updates).toHaveLength(1);
+			expect(updates[0].id).toBe('s2');
+			expect(removeIds).toEqual([]);
+		});
+
+		it('second flush handles mixed update + add + remove in one call', () => {
+			const s1 = makeSession({ id: 's1', name: 'Keep' });
+			const s2 = makeSession({ id: 's2', name: 'Mutate' });
+			const s3 = makeSession({ id: 's3', name: 'Drop' });
+			const initialLoadRef = makeInitialLoadRef(true);
+
+			const { rerender } = renderHook(
+				({ sessions }) => useDebouncedPersistence(sessions, initialLoadRef),
+				{ initialProps: { sessions: [s1, s2, s3] } }
+			);
+			act(() => {
+				vi.advanceTimersByTime(2000);
+			});
+			vi.mocked(window.maestro.sessions.setMany).mockClear();
+
+			const s2Updated = { ...s2, name: 'Mutated' };
+			const s4 = makeSession({ id: 's4', name: 'New' });
+			rerender({ sessions: [s1, s2Updated, s4] });
+			act(() => {
+				vi.advanceTimersByTime(2000);
+			});
+
+			const [updates, removeIds] = vi.mocked(window.maestro.sessions.setMany).mock.calls[0] as [
+				Session[],
+				string[],
+			];
+			expect(updates.map((s) => s.id).sort()).toEqual(['s2', 's4']);
+			expect(removeIds).toEqual(['s3']);
+		});
+
+		it('rapid mutations within one debounce window collapse into one setMany', () => {
+			const s1 = makeSession({ id: 's1', name: 'A' });
+			const initialLoadRef = makeInitialLoadRef(true);
+
+			const { rerender } = renderHook(
+				({ sessions }) => useDebouncedPersistence(sessions, initialLoadRef),
+				{ initialProps: { sessions: [s1] } }
+			);
+			act(() => {
+				vi.advanceTimersByTime(2000);
+			});
+			vi.mocked(window.maestro.sessions.setMany).mockClear();
+
+			// Three rapid mutations within the debounce window
+			rerender({ sessions: [{ ...s1, name: 'B' }] });
+			act(() => {
+				vi.advanceTimersByTime(500);
+			});
+			rerender({ sessions: [{ ...s1, name: 'C' }] });
+			act(() => {
+				vi.advanceTimersByTime(500);
+			});
+			rerender({ sessions: [{ ...s1, name: 'D' }] });
+			act(() => {
+				vi.advanceTimersByTime(2000);
+			});
+
+			expect(window.maestro.sessions.setMany).toHaveBeenCalledTimes(1);
+			const [updates] = vi.mocked(window.maestro.sessions.setMany).mock.calls[0] as [
+				Session[],
+				string[],
+			];
+			expect(updates[0].name).toBe('D'); // Final value wins
+		});
+
+		it('flushNow() after first flush uses setMany for dirty changes', () => {
+			const s1 = makeSession({ id: 's1', name: 'A' });
+			const initialLoadRef = makeInitialLoadRef(true);
+
+			const { result, rerender } = renderHook(
+				({ sessions }) => useDebouncedPersistence(sessions, initialLoadRef),
+				{ initialProps: { sessions: [s1] } }
+			);
+			act(() => {
+				vi.advanceTimersByTime(2000);
+			});
+			vi.mocked(window.maestro.sessions.setMany).mockClear();
+
+			rerender({ sessions: [{ ...s1, name: 'B' }] });
+			act(() => {
+				result.current.flushNow();
+			});
+
+			expect(window.maestro.sessions.setMany).toHaveBeenCalledTimes(1);
+		});
+
+		it('unmount after first flush uses setMany when dirty', () => {
+			const s1 = makeSession({ id: 's1', name: 'A' });
+			const initialLoadRef = makeInitialLoadRef(true);
+
+			const { rerender, unmount } = renderHook(
+				({ sessions }) => useDebouncedPersistence(sessions, initialLoadRef),
+				{ initialProps: { sessions: [s1] } }
+			);
+			act(() => {
+				vi.advanceTimersByTime(2000);
+			});
+			vi.mocked(window.maestro.sessions.setAll).mockClear();
+			vi.mocked(window.maestro.sessions.setMany).mockClear();
+
+			rerender({ sessions: [{ ...s1, name: 'B' }] });
+			unmount();
+
+			expect(window.maestro.sessions.setMany).toHaveBeenCalledTimes(1);
+			expect(window.maestro.sessions.setAll).not.toHaveBeenCalled();
+		});
+
+		it('reference-equal session prop on rerender is treated as unchanged', () => {
+			const s1 = makeSession({ id: 's1' });
+			const initialLoadRef = makeInitialLoadRef(true);
+
+			const { rerender } = renderHook(
+				({ sessions }) => useDebouncedPersistence(sessions, initialLoadRef),
+				{ initialProps: { sessions: [s1] } }
+			);
+			act(() => {
+				vi.advanceTimersByTime(2000);
+			});
+			vi.mocked(window.maestro.sessions.setMany).mockClear();
+
+			// Same s1 reference inside a new array — the diff sees no per-session change
+			rerender({ sessions: [s1] });
+			act(() => {
+				vi.advanceTimersByTime(2000);
+			});
+
+			expect(window.maestro.sessions.setMany).not.toHaveBeenCalled();
+		});
+	});
 });

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -208,6 +208,7 @@ const mockMaestro = {
 		get: vi.fn().mockResolvedValue([]),
 		save: vi.fn().mockResolvedValue(undefined),
 		setAll: vi.fn().mockResolvedValue(undefined),
+		setMany: vi.fn().mockResolvedValue(undefined),
 		getActiveSessionId: vi.fn().mockResolvedValue(''),
 		setActiveSessionId: vi.fn().mockResolvedValue(undefined),
 	},

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -571,6 +571,7 @@ const mockMaestro = {
 		getEventCount: vi.fn().mockResolvedValue(0),
 		enable: vi.fn().mockResolvedValue(undefined),
 		disable: vi.fn().mockResolvedValue(undefined),
+		setActive: vi.fn().mockResolvedValue(undefined),
 		stopRun: vi.fn().mockResolvedValue(false),
 		stopAll: vi.fn().mockResolvedValue(undefined),
 		refreshSession: vi.fn().mockResolvedValue(undefined),

--- a/src/main/cue/cue-active-state.ts
+++ b/src/main/cue/cue-active-state.ts
@@ -1,0 +1,39 @@
+/**
+ * Cue active-state module.
+ *
+ * Holds a single boolean flag that the Cue subsystem consults before doing
+ * any expensive background work (file walks, HTTP polls, dispatch). The
+ * renderer flips it via `cue:setActive` IPC on visibility change so we
+ * don't burn CPU running scanners while the app is hidden.
+ *
+ * Follows the visibility-aware pattern documented in
+ * CLAUDE-PERFORMANCE.md§"Visibility-Aware Operations".
+ *
+ * The flag defaults to `true` so subsystems that haven't been wired through
+ * the IPC bridge yet (e.g. CLI, tests, headless agents) keep their current
+ * behavior.
+ */
+
+let cueActive = true;
+
+/** Returns true when the Cue subsystem should be doing background work. */
+export function isCueActive(): boolean {
+	return cueActive;
+}
+
+/**
+ * Flip the active flag. Called from the `cue:setActive` IPC handler in
+ * response to renderer-side `visibilitychange` events.
+ *
+ * Setting it to `false` does NOT stop any in-flight work — scanners check
+ * the flag at the start of each tick. This is intentional: stopping mid-tick
+ * could leave partial state (open file handles, in-progress HTTP requests).
+ */
+export function setCueActive(active: boolean): void {
+	cueActive = active;
+}
+
+/** Test-only — reset to the default. */
+export function resetCueActiveForTests(): void {
+	cueActive = true;
+}

--- a/src/main/cue/cue-file-watcher.ts
+++ b/src/main/cue/cue-file-watcher.ts
@@ -16,6 +16,15 @@ export interface CueFileWatcherConfig {
 	onEvent: (event: CueEvent) => void;
 	triggerName: string;
 	onLog?: (level: string, message: string) => void;
+	/**
+	 * Optional gate: when this returns `false`, debounced events are dropped
+	 * instead of dispatched. The chokidar watcher itself stays subscribed
+	 * (OS file-watch is nearly free) — only the downstream emit + filter +
+	 * dispatch is skipped. Used by the visibility-aware pause; see
+	 * CLAUDE-PERFORMANCE.md§"Visibility-Aware Operations". Defaults to
+	 * always-active when omitted.
+	 */
+	isActive?: () => boolean;
 }
 
 /**
@@ -24,6 +33,7 @@ export interface CueFileWatcherConfig {
  */
 export function createCueFileWatcher(config: CueFileWatcherConfig): () => void {
 	const { watchGlob, projectRoot, debounceMs, onEvent, triggerName } = config;
+	const isActive = config.isActive ?? (() => true);
 	const debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
 	const watcher = chokidar.watch(watchGlob, {
@@ -49,6 +59,11 @@ export function createCueFileWatcher(config: CueFileWatcherConfig): () => void {
 			filePath,
 			setTimeout(() => {
 				debounceTimers.delete(filePath);
+
+				// Visibility-aware pause: drop the event when inactive. We don't
+				// queue it for later — file changes that happened while hidden
+				// can be re-discovered on resume via re-scan paths.
+				if (!isActive()) return;
 
 				const absolutePath = path.resolve(projectRoot, filePath);
 

--- a/src/main/cue/cue-github-poller.ts
+++ b/src/main/cue/cue-github-poller.ts
@@ -74,6 +74,13 @@ export interface CueGitHubPollerConfig {
 	subscriptionId: string;
 	/** GitHub state filter: "open" (default), "closed", "merged" (PRs only), or "all" */
 	ghState?: string;
+	/**
+	 * Optional gate: when this returns `false`, doPoll skips the HTTP fetch
+	 * to gh CLI. The 24h prune timer keeps running (cheap). Used by the
+	 * visibility-aware pause; see CLAUDE-PERFORMANCE.md§"Visibility-Aware
+	 * Operations". Defaults to always-active when omitted.
+	 */
+	isActive?: () => boolean;
 }
 
 /**
@@ -92,6 +99,7 @@ export function createCueGitHubPoller(config: CueGitHubPollerConfig): () => void
 		ghState,
 	} = config;
 	const stateFilter = ghState ?? 'open';
+	const isActive = config.isActive ?? (() => true);
 
 	let stopped = false;
 	let initialTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -290,6 +298,10 @@ export function createCueGitHubPoller(config: CueGitHubPollerConfig): () => void
 
 	async function doPoll(): Promise<void> {
 		if (stopped) return;
+		// Visibility-aware pause: skip the gh CLI fetch when inactive. The
+		// scheduleNextPoll loop keeps running so we resume cleanly when the
+		// app becomes visible again.
+		if (!isActive()) return;
 
 		try {
 			if (!(await resolveGh())) return;

--- a/src/main/cue/cue-task-scanner.ts
+++ b/src/main/cue/cue-task-scanner.ts
@@ -21,6 +21,13 @@ export interface CueTaskScannerConfig {
 	onEvent: (event: CueEvent) => void;
 	onLog: (level: string, message: string) => void;
 	triggerName: string;
+	/**
+	 * Optional gate: when this returns `false`, the scanner skips its tick
+	 * (no directory walk, no file reads, no events). Used by the
+	 * visibility-aware pause — CLAUDE-PERFORMANCE.md§"Visibility-Aware Operations".
+	 * Defaults to always-active when omitted.
+	 */
+	isActive?: () => boolean;
 }
 
 /** A pending task extracted from a markdown file */
@@ -86,6 +93,7 @@ function walkDir(dir: string, root: string): string[] {
  */
 export function createCueTaskScanner(config: CueTaskScannerConfig): () => void {
 	const { watchGlob, pollMinutes, projectRoot, onEvent, onLog, triggerName } = config;
+	const isActive = config.isActive ?? (() => true);
 
 	let stopped = false;
 	let initialTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -102,6 +110,10 @@ export function createCueTaskScanner(config: CueTaskScannerConfig): () => void {
 
 	async function doScan(): Promise<void> {
 		if (stopped) return;
+		// Visibility-aware pause: skip the entire tick when inactive.
+		// The interval keeps firing so we resume cleanly on the next visible
+		// tick — no need to tear down and re-create timers.
+		if (!isActive()) return;
 
 		try {
 			const allFiles = walkDir(projectRoot, projectRoot);

--- a/src/main/cue/triggers/cue-file-watcher-trigger-source.ts
+++ b/src/main/cue/triggers/cue-file-watcher-trigger-source.ts
@@ -6,6 +6,7 @@
  * centralized `passesFilter` helper before emitting.
  */
 
+import { isCueActive } from '../cue-active-state';
 import { createCueFileWatcher } from '../cue-file-watcher';
 import { passesFilter } from './cue-trigger-filter';
 import type { CueTriggerSource, CueTriggerSourceContext } from './cue-trigger-source';
@@ -29,6 +30,7 @@ export function createCueFileWatcherTriggerSource(
 				debounceMs: DEFAULT_FILE_DEBOUNCE_MS,
 				triggerName: ctx.subscription.name,
 				onLog: (level, message) => ctx.onLog(level as Parameters<typeof ctx.onLog>[0], message),
+				isActive: isCueActive,
 				onEvent: (event) => {
 					if (!ctx.enabled()) return;
 					if (!passesFilter(ctx.subscription, event, ctx.onLog)) return;

--- a/src/main/cue/triggers/cue-github-poller-trigger-source.ts
+++ b/src/main/cue/triggers/cue-github-poller-trigger-source.ts
@@ -6,6 +6,7 @@
  * centralized `passesFilter` helper before emitting.
  */
 
+import { isCueActive } from '../cue-active-state';
 import { createCueGitHubPoller } from '../cue-github-poller';
 import { passesFilter } from './cue-trigger-filter';
 import type { CueTriggerSource, CueTriggerSourceContext } from './cue-trigger-source';
@@ -38,6 +39,7 @@ export function createCueGitHubPollerTriggerSource(
 				subscriptionId: `${ctx.session.id}:${ctx.subscription.name}`,
 				ghState: ctx.subscription.gh_state,
 				onLog: (level, message) => ctx.onLog(level as Parameters<typeof ctx.onLog>[0], message),
+				isActive: isCueActive,
 				onEvent: (event) => {
 					if (!ctx.enabled()) return;
 					if (!passesFilter(ctx.subscription, event, ctx.onLog)) return;

--- a/src/main/cue/triggers/cue-task-scanner-trigger-source.ts
+++ b/src/main/cue/triggers/cue-task-scanner-trigger-source.ts
@@ -6,6 +6,7 @@
  * centralized `passesFilter` helper before emitting.
  */
 
+import { isCueActive } from '../cue-active-state';
 import { createCueTaskScanner } from '../cue-task-scanner';
 import { passesFilter } from './cue-trigger-filter';
 import type { CueTriggerSource, CueTriggerSourceContext } from './cue-trigger-source';
@@ -29,6 +30,7 @@ export function createCueTaskScannerTriggerSource(
 				projectRoot: ctx.session.projectRoot,
 				triggerName: ctx.subscription.name,
 				onLog: (level, message) => ctx.onLog(level as Parameters<typeof ctx.onLog>[0], message),
+				isActive: isCueActive,
 				onEvent: (event) => {
 					if (!ctx.enabled()) return;
 					if (!passesFilter(ctx.subscription, event, ctx.onLog)) return;

--- a/src/main/ipc/handlers/cue.ts
+++ b/src/main/ipc/handlers/cue.ts
@@ -140,7 +140,16 @@ export function registerCueHandlers(deps: CueHandlerDependencies): void {
 	ipcMain.handle(
 		'cue:setActive',
 		withIpcErrorLogging(handlerOpts('setActive'), async (active: boolean): Promise<void> => {
-			setCueActive(Boolean(active));
+			// Strict type check rather than Boolean(active) coercion. Coercion
+			// would silently accept truthy strings / numbers / objects from a
+			// misbehaving caller, hiding the bug. withIpcErrorLogging surfaces
+			// thrown TypeErrors to Sentry so we get a real signal.
+			if (typeof active !== 'boolean') {
+				throw new TypeError(
+					`cue:setActive expected boolean, got ${typeof active} (${String(active)})`
+				);
+			}
+			setCueActive(active);
 		})
 	);
 

--- a/src/main/ipc/handlers/cue.ts
+++ b/src/main/ipc/handlers/cue.ts
@@ -26,6 +26,7 @@ import {
 	writeCueConfigFile,
 	writeCuePromptFile,
 } from '../../cue/config/cue-config-repository';
+import { setCueActive } from '../../cue/cue-active-state';
 import { loadPipelineLayout, savePipelineLayout } from '../../cue/pipeline-layout-store';
 import { captureException } from '../../utils/sentry';
 import type { CueEngine } from '../../cue/cue-engine';
@@ -128,6 +129,18 @@ export function registerCueHandlers(deps: CueHandlerDependencies): void {
 		'cue:disable',
 		withIpcErrorLogging(handlerOpts('disable'), async (): Promise<void> => {
 			requireEngine().stop();
+		})
+	);
+
+	// Visibility-aware pause: the renderer flips this on visibilitychange so
+	// scanners (file-watcher / task-scanner / github-poller) stop doing
+	// expensive background work while the app is hidden. Different from
+	// enable/disable, which fully starts/stops the engine — setActive only
+	// gates the per-tick work and does not tear down state.
+	ipcMain.handle(
+		'cue:setActive',
+		withIpcErrorLogging(handlerOpts('setActive'), async (active: boolean): Promise<void> => {
+			setCueActive(Boolean(active));
 		})
 	);
 

--- a/src/main/ipc/handlers/persistence.ts
+++ b/src/main/ipc/handlers/persistence.ts
@@ -151,6 +151,132 @@ export function registerPersistenceHandlers(deps: PersistenceHandlerDependencies
 		sessionsStore.set('activeSessionId', id);
 	});
 
+	/**
+	 * Incremental session persistence: merge a subset of dirty sessions into
+	 * the existing stored sessions, optionally removing some by id.
+	 *
+	 * This is the preferred path for the renderer's debounced persistence —
+	 * it avoids cloning + serializing the entire sessions tree on every
+	 * change. `sessions:setAll` remains as the bootstrap path and as a
+	 * fallback when no diff baseline is available.
+	 *
+	 * Semantics:
+	 *  - `updates`: sessions to merge. If id matches an existing session,
+	 *    replaces it. If id is new, appends it. Order of new sessions
+	 *    follows the order in `updates`.
+	 *  - `removeIds`: sessions to remove. Applied alongside updates; a
+	 *    session in both lists is removed (remove wins).
+	 *  - Sessions not mentioned in either list are preserved as-is.
+	 *  - Broadcasts to web clients fire only for the touched sessions
+	 *    (added / state-changed / removed), matching `setAll` semantics.
+	 */
+	ipcMain.handle(
+		'sessions:setMany',
+		async (_, updates: StoredSession[] = [], removeIds: string[] = []) => {
+			const previousSessions = sessionsStore.get('sessions', []);
+			const previousMap = new Map(previousSessions.map((s) => [s.id, s]));
+			const removeSet = new Set(removeIds);
+			const updateMap = new Map(updates.map((s) => [s.id, s]));
+
+			// Build merged array preserving the existing order. Apply updates and
+			// skip removals in a single pass, then append any new sessions whose
+			// ids weren't seen in the existing array.
+			const merged: StoredSession[] = [];
+			for (const prev of previousSessions) {
+				if (removeSet.has(prev.id)) continue;
+				const update = updateMap.get(prev.id);
+				if (update) {
+					merged.push(update);
+					updateMap.delete(prev.id);
+				} else {
+					merged.push(prev);
+				}
+			}
+			for (const newSession of updateMap.values()) {
+				if (removeSet.has(newSession.id)) continue;
+				merged.push(newSession);
+			}
+
+			// Lifecycle logging (parallel to setAll's debug logs)
+			for (const session of updates) {
+				if (!previousMap.has(session.id) && !removeSet.has(session.id)) {
+					logger.debug('Session created', 'Sessions', {
+						sessionId: session.id,
+						name: session.name,
+						toolType: session.toolType,
+						cwd: session.cwd,
+					});
+				}
+			}
+			for (const id of removeIds) {
+				const prev = previousMap.get(id);
+				if (prev) {
+					logger.debug('Session destroyed', 'Sessions', {
+						sessionId: prev.id,
+						name: prev.name,
+					});
+				}
+			}
+
+			const webServer = getWebServer();
+			if (webServer && webServer.getWebClientCount() > 0) {
+				for (const session of updates) {
+					if (removeSet.has(session.id)) continue;
+					const prev = previousMap.get(session.id);
+					if (prev) {
+						if (
+							prev.state !== session.state ||
+							prev.inputMode !== session.inputMode ||
+							prev.name !== session.name ||
+							prev.cwd !== session.cwd ||
+							cliActivityChanged(prev.cliActivity, session.cliActivity)
+						) {
+							webServer.broadcastSessionStateChange(session.id, session.state, {
+								name: session.name,
+								toolType: session.toolType,
+								inputMode: session.inputMode,
+								cwd: session.cwd,
+								cliActivity: session.cliActivity,
+							});
+						}
+					} else {
+						webServer.broadcastSessionAdded({
+							id: session.id,
+							name: session.name,
+							toolType: session.toolType,
+							state: session.state,
+							inputMode: session.inputMode,
+							cwd: session.cwd,
+							groupId: session.groupId || null,
+							groupName: session.groupName || null,
+							groupEmoji: session.groupEmoji || null,
+							parentSessionId: session.parentSessionId || null,
+							worktreeBranch: session.worktreeBranch || null,
+						});
+					}
+				}
+				for (const id of removeIds) {
+					if (previousMap.has(id)) {
+						webServer.broadcastSessionRemoved(id);
+					}
+				}
+			}
+
+			try {
+				sessionsStore.set('sessions', merged);
+			} catch (err) {
+				const code = (err as NodeJS.ErrnoException).code;
+				logger.warn(
+					`Failed to persist sessions (setMany): ${code || (err as Error).message}`,
+					'Sessions'
+				);
+				return false;
+			}
+
+			return true;
+		}
+	);
+
 	ipcMain.handle('sessions:setAll', async (_, sessions: StoredSession[]) => {
 		// Get previous sessions to detect changes
 		const previousSessions = sessionsStore.get('sessions', []);

--- a/src/main/ipc/handlers/persistence.ts
+++ b/src/main/ipc/handlers/persistence.ts
@@ -25,7 +25,7 @@ import {
 // Re-export types from canonical source so existing imports from './persistence' still work
 export type { MaestroSettings, SessionsData, GroupsData } from '../../stores/types';
 import type { MaestroSettings, SessionsData, GroupsData, StoredSession } from '../../stores/types';
-import type { Group } from '../../../shared/types';
+import type { Group, SessionCliActivity } from '../../../shared/types';
 
 /**
  * Shallow-compare cliActivity for the diff broadcast.
@@ -38,8 +38,8 @@ import type { Group } from '../../../shared/types';
  * magnitude cheaper.
  */
 function cliActivityChanged(
-	prev: { playbookId?: string; playbookName?: string; startedAt?: number } | null | undefined,
-	curr: { playbookId?: string; playbookName?: string; startedAt?: number } | null | undefined
+	prev: SessionCliActivity | null | undefined,
+	curr: SessionCliActivity | null | undefined
 ): boolean {
 	// Existence change (one is null/undefined, the other isn't) — broadcast.
 	if (!prev !== !curr) return true;
@@ -266,11 +266,23 @@ export function registerPersistenceHandlers(deps: PersistenceHandlerDependencies
 				sessionsStore.set('sessions', merged);
 			} catch (err) {
 				const code = (err as NodeJS.ErrnoException).code;
-				logger.warn(
-					`Failed to persist sessions (setMany): ${code || (err as Error).message}`,
-					'Sessions'
+				// Recoverable filesystem errors — the next debounced flush will
+				// retry when conditions improve. Log warn and return false so
+				// the renderer's flush path can mark the write as unconfirmed.
+				if (code === 'ENOSPC' || code === 'ENFILE' || code === 'EMFILE') {
+					logger.warn(`Failed to persist sessions (setMany): ${code}`, 'Sessions');
+					return false;
+				}
+				// Anything else is unexpected — log error and rethrow so
+				// withIpcErrorLogging surfaces it to Sentry. Per CLAUDE.md
+				// §"Error Handling & Sentry", silent swallows hide bugs from
+				// production telemetry.
+				logger.error(
+					`Unexpected error persisting sessions (setMany): ${(err as Error).message}`,
+					'Sessions',
+					err
 				);
-				return false;
+				throw err;
 			}
 
 			return true;

--- a/src/main/ipc/handlers/persistence.ts
+++ b/src/main/ipc/handlers/persistence.ts
@@ -28,6 +28,32 @@ import type { MaestroSettings, SessionsData, GroupsData, StoredSession } from '.
 import type { Group } from '../../../shared/types';
 
 /**
+ * Shallow-compare cliActivity for the diff broadcast.
+ *
+ * Replaces a previous `JSON.stringify(prev) !== JSON.stringify(curr)` per
+ * session per persistence flush, which was 2× O(stringify) per call. The
+ * cliActivity producer (`useCliActivityMonitoring`) only ever sets the field
+ * to `undefined` or to `{ playbookId, playbookName, startedAt }`, so a 4-step
+ * primitive comparison is equivalent at all real call sites and an order of
+ * magnitude cheaper.
+ */
+function cliActivityChanged(
+	prev: { playbookId?: string; playbookName?: string; startedAt?: number } | null | undefined,
+	curr: { playbookId?: string; playbookName?: string; startedAt?: number } | null | undefined
+): boolean {
+	// Existence change (one is null/undefined, the other isn't) — broadcast.
+	if (!prev !== !curr) return true;
+	// Both are nullish — no change.
+	if (!prev || !curr) return false;
+	// Both present — compare known fields.
+	return (
+		prev.playbookId !== curr.playbookId ||
+		prev.playbookName !== curr.playbookName ||
+		prev.startedAt !== curr.startedAt
+	);
+}
+
+/**
  * Dependencies required for persistence handlers
  */
 export interface PersistenceHandlerDependencies {
@@ -167,7 +193,7 @@ export function registerPersistenceHandlers(deps: PersistenceHandlerDependencies
 						prevSession.inputMode !== session.inputMode ||
 						prevSession.name !== session.name ||
 						prevSession.cwd !== session.cwd ||
-						JSON.stringify(prevSession.cliActivity) !== JSON.stringify(session.cliActivity)
+						cliActivityChanged(prevSession.cliActivity, session.cliActivity)
 					) {
 						webServer.broadcastSessionStateChange(session.id, session.state, {
 							name: session.name,

--- a/src/main/ipc/handlers/stats.ts
+++ b/src/main/ipc/handlers/stats.ts
@@ -14,6 +14,7 @@
 
 import { ipcMain, BrowserWindow, app } from 'electron';
 import { logger } from '../../utils/logger';
+import { captureException } from '../../utils/sentry';
 import { withIpcErrorLogging, CreateHandlerOptions } from '../../utils/ipcHandler';
 import { getStatsDB } from '../../stats';
 import { enqueueQueryEvent, flushQueryEventsSync } from '../../stats/query-events-buffer';
@@ -87,6 +88,12 @@ export function registerStatsHandlers(deps: StatsHandlerDependencies): void {
 			flushQueryEventsSync();
 		} catch (err) {
 			logger.warn('Failed to flush query event buffer on quit', LOG_CONTEXT, err);
+			// Surface to Sentry so we get a real signal in production —
+			// quit-time data loss is the worst time to lose telemetry, since
+			// we can't retry. Per CLAUDE.md §"Error Handling & Sentry".
+			void captureException(err instanceof Error ? err : new Error(String(err)), {
+				operation: 'stats:beforeQuitFlush',
+			});
 		}
 	});
 

--- a/src/main/ipc/handlers/stats.ts
+++ b/src/main/ipc/handlers/stats.ts
@@ -12,10 +12,11 @@
  * - CSV export for data analysis
  */
 
-import { ipcMain, BrowserWindow } from 'electron';
+import { ipcMain, BrowserWindow, app } from 'electron';
 import { logger } from '../../utils/logger';
 import { withIpcErrorLogging, CreateHandlerOptions } from '../../utils/ipcHandler';
 import { getStatsDB } from '../../stats';
+import { enqueueQueryEvent, flushQueryEventsSync } from '../../stats/query-events-buffer';
 import {
 	QueryEvent,
 	AutoRunSession,
@@ -77,24 +78,44 @@ function broadcastStatsUpdate(getMainWindow: () => BrowserWindow | null): void {
 export function registerStatsHandlers(deps: StatsHandlerDependencies): void {
 	const { getMainWindow, settingsStore } = deps;
 
-	// Record a query event (interactive conversation turn)
+	// PR-B 1.5: flush any buffered query events synchronously before the app
+	// exits so we don't drop them. The handler is fire-and-forget — if it
+	// throws (e.g. DB already closed) the buffer module logs it; we don't
+	// want to block quit on stats persistence.
+	app.on('before-quit', () => {
+		try {
+			flushQueryEventsSync();
+		} catch (err) {
+			logger.warn('Failed to flush query event buffer on quit', LOG_CONTEXT, err);
+		}
+	});
+
+	// Record a query event (interactive conversation turn).
+	//
+	// PR-B 1.5: events are buffered and flushed in a single transaction every
+	// 500ms or every 50 events (whichever first). This collapses many
+	// per-turn fsyncs into one, on the streaming hot path. The buffered
+	// id is generated synchronously and returned — callers don't need to
+	// wait for the actual write.
 	ipcMain.handle(
 		'stats:record-query',
 		withIpcErrorLogging(handlerOpts('recordQuery'), async (event: Omit<QueryEvent, 'id'>) => {
-			// Check if stats collection is enabled
 			if (!isStatsCollectionEnabled(settingsStore)) {
 				logger.debug('Stats collection disabled, skipping query event', LOG_CONTEXT);
 				return null;
 			}
 
 			const db = getStatsDB();
-			const id = db.insertQueryEvent(event);
-			logger.debug(`Recorded query event: ${id}`, LOG_CONTEXT, {
+			const id = enqueueQueryEvent(db.database, event);
+			logger.debug(`Buffered query event: ${id}`, LOG_CONTEXT, {
 				sessionId: event.sessionId,
 				agentType: event.agentType,
 				source: event.source,
 				duration: event.duration,
 			});
+			// Notify renderer that stats may have changed soon. The actual
+			// write happens asynchronously; the dashboard is best-effort
+			// realtime, so a small lag (≤500ms) is acceptable.
 			broadcastStatsUpdate(getMainWindow);
 			return id;
 		})

--- a/src/main/preload/cue.ts
+++ b/src/main/preload/cue.ts
@@ -69,6 +69,11 @@ export function createCueApi() {
 		// Disable the Cue engine (runtime control)
 		disable: (): Promise<void> => ipcRenderer.invoke('cue:disable'),
 
+		// Visibility-aware pause — the renderer flips this on visibilitychange
+		// so the scanner subsystem skips expensive background work while the
+		// app is hidden. Idempotent.
+		setActive: (active: boolean): Promise<void> => ipcRenderer.invoke('cue:setActive', active),
+
 		// Stop a specific running Cue execution
 		stopRun: (runId: string): Promise<boolean> => ipcRenderer.invoke('cue:stopRun', { runId }),
 

--- a/src/main/preload/settings.ts
+++ b/src/main/preload/settings.ts
@@ -42,6 +42,14 @@ export function createSessionsApi() {
 	return {
 		getAll: () => ipcRenderer.invoke('sessions:getAll'),
 		setAll: (sessions: StoredSession[]) => ipcRenderer.invoke('sessions:setAll', sessions),
+		/**
+		 * Incremental persistence: merge `updates` into the stored sessions and
+		 * remove any whose id is in `removeIds`. Preferred over `setAll` for
+		 * debounced flushes — avoids cloning + serializing the entire sessions
+		 * tree on every change.
+		 */
+		setMany: (updates: StoredSession[], removeIds: string[] = []) =>
+			ipcRenderer.invoke('sessions:setMany', updates, removeIds),
 		getActiveSessionId: () => ipcRenderer.invoke('sessions:getActiveSessionId') as Promise<string>,
 		setActiveSessionId: (id: string) => ipcRenderer.invoke('sessions:setActiveSessionId', id),
 	};

--- a/src/main/stats/query-events-buffer.ts
+++ b/src/main/stats/query-events-buffer.ts
@@ -20,14 +20,14 @@
  * calls `enqueueQueryEvent(db, event)`; main process registers
  * `flushQueryEventsSync()` on `app:before-quit`.
  *
- * See PR-B 1.5 (`/Users/saifccript/.claude/plans/...`) and
- * CLAUDE-PERFORMANCE.md§"Update Batching".
+ * See PR-B 1.5 and CLAUDE-PERFORMANCE.md §"Update Batching".
  */
 
 import type Database from 'better-sqlite3';
 import type { QueryEvent } from '../../shared/stats-types';
 import { generateId, normalizePath, LOG_CONTEXT, StatementCache } from './utils';
 import { logger } from '../utils/logger';
+import { captureException } from '../utils/sentry';
 
 /** Flush when this many events accumulate. */
 export const QUERY_EVENT_BATCH_SIZE = 50;
@@ -128,6 +128,14 @@ export function flushQueryEventsSync(): void {
 		logger.error('Failed to flush query event buffer', LOG_CONTEXT, {
 			count: events.length,
 			error: err instanceof Error ? err.message : String(err),
+		});
+		// Surface to Sentry with the full Error object (not just .message) so
+		// the stack trace makes it across the wire — matters for diagnosing
+		// rare DB corruption / lock contention. Per CLAUDE.md §"Error
+		// Handling & Sentry".
+		void captureException(err instanceof Error ? err : new Error(String(err)), {
+			operation: 'stats:flushQueryEventBuffer',
+			count: events.length,
 		});
 		// Don't re-buffer — events are lost rather than risk an infinite
 		// retry loop if the DB is in a permanently bad state.

--- a/src/main/stats/query-events-buffer.ts
+++ b/src/main/stats/query-events-buffer.ts
@@ -1,0 +1,154 @@
+/**
+ * Query event write buffer.
+ *
+ * Replaces the previous one-write-per-event path on the `stats:record-query`
+ * IPC channel. The renderer fires a recordQuery on every interactive turn
+ * (and the auto-run path adds more on top); each fire used to do a single
+ * `stmt.run()` against the stats SQLite DB. Under normal load that's many
+ * synchronous writes per second on the main process's hot path.
+ *
+ * Mirrors the batching cadence already used elsewhere in the codebase
+ * (logger 50ms, thinking-chunk 50ms — see commit `e475c0bad`):
+ *
+ *  - Auto-flush after FLUSH_INTERVAL_MS or when the buffer reaches BATCH_SIZE
+ *  - Synchronous flush hook for app-quit so we don't lose buffered events
+ *  - Single transaction per flush — better-sqlite3 wraps an arbitrary number
+ *    of inserts atomically, so the per-event WAL + fsync overhead collapses
+ *    into one
+ *
+ * The buffer is intentionally module-level (not a class). The IPC handler
+ * calls `enqueueQueryEvent(db, event)`; main process registers
+ * `flushQueryEventsSync()` on `app:before-quit`.
+ *
+ * See PR-B 1.5 (`/Users/saifccript/.claude/plans/...`) and
+ * CLAUDE-PERFORMANCE.md§"Update Batching".
+ */
+
+import type Database from 'better-sqlite3';
+import type { QueryEvent } from '../../shared/stats-types';
+import { generateId, normalizePath, LOG_CONTEXT, StatementCache } from './utils';
+import { logger } from '../utils/logger';
+
+/** Flush when this many events accumulate. */
+export const QUERY_EVENT_BATCH_SIZE = 50;
+/** Auto-flush after this many ms since the first event in the current batch. */
+export const QUERY_EVENT_FLUSH_INTERVAL_MS = 500;
+
+const INSERT_SQL = `
+  INSERT INTO query_events (id, session_id, agent_type, source, start_time, duration, project_path, tab_id, is_remote)
+  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+`;
+
+interface PendingEvent {
+	id: string;
+	event: Omit<QueryEvent, 'id'>;
+}
+
+const stmtCache = new StatementCache();
+let buffer: PendingEvent[] = [];
+let flushTimer: ReturnType<typeof setTimeout> | null = null;
+let lastDb: Database.Database | null = null;
+
+/**
+ * Enqueue a query event for batched persistence.
+ *
+ * Returns the generated id immediately (synchronously). The actual SQL
+ * INSERT happens later — when the batch fills up, the flush timer fires,
+ * or `flushQueryEventsSync` is called explicitly. Callers that don't need
+ * the id can ignore it.
+ */
+export function enqueueQueryEvent(db: Database.Database, event: Omit<QueryEvent, 'id'>): string {
+	if (lastDb !== db) {
+		// DB instance changed (rare — only at startup or in tests). Drop the
+		// statement cache because prepared statements are bound to a DB.
+		stmtCache.clear();
+		lastDb = db;
+	}
+
+	const id = generateId();
+	buffer.push({ id, event });
+
+	if (buffer.length >= QUERY_EVENT_BATCH_SIZE) {
+		flushQueryEventsSync();
+	} else if (!flushTimer) {
+		flushTimer = setTimeout(() => {
+			flushTimer = null;
+			flushQueryEventsSync();
+		}, QUERY_EVENT_FLUSH_INTERVAL_MS);
+	}
+
+	return id;
+}
+
+/**
+ * Synchronously flush any buffered events to disk.
+ *
+ * Called automatically by the timer / batch threshold. Also called
+ * explicitly on app-quit and when the test harness needs deterministic
+ * write ordering.
+ *
+ * On flush failure, the buffered events are dropped (not retried). The
+ * stats DB is best-effort telemetry — losing a handful of events on the
+ * rare occasion the DB is unavailable is preferred to a retry loop that
+ * could spin during a real DB-corruption incident.
+ */
+export function flushQueryEventsSync(): void {
+	if (flushTimer) {
+		clearTimeout(flushTimer);
+		flushTimer = null;
+	}
+	if (!lastDb || buffer.length === 0) {
+		return;
+	}
+
+	const events = buffer;
+	buffer = [];
+
+	const stmt = stmtCache.get(lastDb, INSERT_SQL);
+
+	try {
+		const tx = lastDb.transaction(() => {
+			for (const { id, event } of events) {
+				stmt.run(
+					id,
+					event.sessionId,
+					event.agentType,
+					event.source,
+					event.startTime,
+					event.duration,
+					normalizePath(event.projectPath),
+					event.tabId ?? null,
+					event.isRemote !== undefined ? (event.isRemote ? 1 : 0) : null
+				);
+			}
+		});
+		tx();
+		logger.debug(`Flushed ${events.length} query event(s)`, LOG_CONTEXT);
+	} catch (err) {
+		logger.error('Failed to flush query event buffer', LOG_CONTEXT, {
+			count: events.length,
+			error: err instanceof Error ? err.message : String(err),
+		});
+		// Don't re-buffer — events are lost rather than risk an infinite
+		// retry loop if the DB is in a permanently bad state.
+	}
+}
+
+/** Number of events currently waiting to flush. Test/diagnostic helper. */
+export function getQueryEventBufferSize(): number {
+	return buffer.length;
+}
+
+/**
+ * Reset internal state — tests only. Production has a single global buffer
+ * for the lifetime of the process; tests need to reset between cases.
+ */
+export function resetQueryEventBufferForTests(): void {
+	if (flushTimer) {
+		clearTimeout(flushTimer);
+		flushTimer = null;
+	}
+	buffer = [];
+	stmtCache.clear();
+	lastDb = null;
+}

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -128,6 +128,7 @@ import { useMainPanelProps, useSessionListProps, useRightPanelProps } from './ho
 import { useAgentListeners } from './hooks/agent/useAgentListeners';
 import { useSymphonyContribution } from './hooks/symphony/useSymphonyContribution';
 import { useCueAutoDiscovery } from './hooks/useCueAutoDiscovery';
+import { useCueVisibilityWiring } from './hooks/cue/useCueVisibilityWiring';
 
 // Import contexts
 import { useLayerStack } from './contexts/LayerStackContext';
@@ -781,6 +782,11 @@ function MaestroConsoleInner() {
 
 	// --- CUE AUTO-DISCOVERY (gated by Encore Feature) ---
 	useCueAutoDiscovery(sessions, encoreFeatures);
+
+	// --- CUE VISIBILITY WIRING (PR-B 1.4) ---
+	// Forwards document visibility to the main-process Cue scanner
+	// subsystem so it pauses background work when the window is hidden.
+	useCueVisibilityWiring();
 
 	// --- TAB HANDLERS (extracted hook) ---
 	const {

--- a/src/renderer/components/CuePipelineEditor/PipelineCanvas.tsx
+++ b/src/renderer/components/CuePipelineEditor/PipelineCanvas.tsx
@@ -8,6 +8,7 @@
 import React from 'react';
 import ReactFlow, {
 	Background,
+	ConnectionLineType,
 	ConnectionMode,
 	Controls,
 	MiniMap,
@@ -29,6 +30,7 @@ import type {
 	CuePipelineSessionInfo as SessionInfo,
 	IncomingAgentEdgeInfo,
 } from '../../../shared/cue-pipeline-types';
+import { CUE_COLOR } from '../../../shared/cue-pipeline-types';
 import type { CueSettings } from '../../../shared/cue';
 import { Hand, MousePointer2 } from 'lucide-react';
 import { TriggerNode, type TriggerNodeDataProps } from './nodes/TriggerNode';
@@ -235,6 +237,19 @@ export const PipelineCanvas = React.memo(function PipelineCanvas({
 		[theme.colors.bgActivity, theme.colors.border]
 	);
 	const miniMapMaskColor = React.useMemo(() => `${theme.colors.bgMain}cc`, [theme.colors.bgMain]);
+	// Drag-preview line shown while connecting one handle to another. Without
+	// an explicit style, ReactFlow uses its default `stroke: #b1b1b7` at 1px
+	// — invisible against most theme backgrounds. Match the committed-edge
+	// look (CUE_COLOR, 2px, dashed) so the user sees a clear preview while
+	// dragging and a smooth visual transition into the final edge on release.
+	const connectionLineStyle = React.useMemo(
+		() => ({
+			stroke: CUE_COLOR,
+			strokeWidth: 2,
+			strokeDasharray: '6 3',
+		}),
+		[]
+	);
 	const miniMapNodeColor = React.useCallback(
 		(node: Node) => {
 			if (node.type === 'trigger') {
@@ -299,6 +314,8 @@ export const PipelineCanvas = React.memo(function PipelineCanvas({
 				onDragOver={onDragOver}
 				onDrop={onDrop}
 				connectionMode={ConnectionMode.Loose}
+				connectionLineType={ConnectionLineType.Bezier}
+				connectionLineStyle={connectionLineStyle}
 				minZoom={0.1}
 				maxZoom={2}
 				// All Pipelines view is read-only. These ReactFlow props are the

--- a/src/renderer/components/CuePipelineEditor/PipelineCanvas.tsx
+++ b/src/renderer/components/CuePipelineEditor/PipelineCanvas.tsx
@@ -363,10 +363,17 @@ export const PipelineCanvas = React.memo(function PipelineCanvas({
 				maxZoom={2}
 				// All Pipelines view is read-only. These ReactFlow props are the
 				// first line of defense — the parent also guards each callback.
-				// Hand mode also disables node/group dragging so left-drag on a
-				// node falls through to the canvas pan instead of moving it.
+				// Hand mode disables node/group dragging so left-drag on a node
+				// falls through to the canvas pan instead of moving the node.
+				// Connections, however, are scoped to handles (not the node
+				// body) and should always work regardless of canvas mode —
+				// matches n8n / Zapier / Figma's behavior, where handle
+				// affordances are unaffected by pan vs. select. The
+				// drag-preview line also requires nodesConnectable=true to
+				// render, so gating this on mode broke the preview in hand
+				// mode.
 				nodesDraggable={!isReadOnly && interactionMode === 'pointer'}
-				nodesConnectable={!isReadOnly && interactionMode === 'pointer'}
+				nodesConnectable={!isReadOnly}
 				elementsSelectable={!isReadOnly}
 				// Hand mode: left-drag pans (ReactFlow default). Pointer mode:
 				// left-drag box-selects, middle/right-drag still pans as an

--- a/src/renderer/components/CuePipelineEditor/PipelineCanvas.tsx
+++ b/src/renderer/components/CuePipelineEditor/PipelineCanvas.tsx
@@ -12,6 +12,8 @@ import ReactFlow, {
 	ConnectionMode,
 	Controls,
 	MiniMap,
+	getBezierPath,
+	type ConnectionLineComponentProps,
 	type Node,
 	type Edge,
 	type OnNodesChange,
@@ -54,6 +56,46 @@ const nodeTypes = {
 	command: CommandNode,
 	error: ErrorNode,
 	'pipeline-group': PipelineGroupNode,
+};
+
+/**
+ * Custom drag-preview component for the connection line.
+ *
+ * ReactFlow's default `<ConnectionLine>` paints `.react-flow__connection-path`
+ * with `stroke: #b1b1b7` at 1px — invisible against our dark theme. Setting
+ * `connectionLineStyle` alone proved insufficient (no visible line during
+ * drag, only the committed edge appearing on release). A custom component
+ * bypasses any styling/specificity issues with the default render path
+ * entirely — we own the `<path>` element and its attributes.
+ *
+ * Visual contract: dashed bezier in CUE_COLOR at 2px, matching the look of
+ * committed edges (which also use bezier + CUE_COLOR via PipelineEdge.tsx)
+ * so the drag → release transition feels continuous.
+ */
+const PipelineConnectionLine = (props: ConnectionLineComponentProps) => {
+	const { fromX, fromY, toX, toY, fromPosition, toPosition } = props;
+	const [path] = getBezierPath({
+		sourceX: fromX,
+		sourceY: fromY,
+		sourcePosition: fromPosition,
+		targetX: toX,
+		targetY: toY,
+		targetPosition: toPosition,
+	});
+	return (
+		<g>
+			<path
+				d={path}
+				fill="none"
+				stroke={CUE_COLOR}
+				strokeWidth={2}
+				strokeDasharray="6 3"
+				strokeLinecap="round"
+				className="react-flow__connection-path"
+			/>
+			<circle cx={toX} cy={toY} r={4} fill={CUE_COLOR} stroke="none" />
+		</g>
+	);
 };
 
 export type CanvasInteractionMode = 'hand' | 'pointer';
@@ -316,6 +358,7 @@ export const PipelineCanvas = React.memo(function PipelineCanvas({
 				connectionMode={ConnectionMode.Loose}
 				connectionLineType={ConnectionLineType.Bezier}
 				connectionLineStyle={connectionLineStyle}
+				connectionLineComponent={PipelineConnectionLine}
 				minZoom={0.1}
 				maxZoom={2}
 				// All Pipelines view is read-only. These ReactFlow props are the

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -3130,6 +3130,13 @@ interface MaestroAPI {
 		getEventCount: () => Promise<number>;
 		enable: () => Promise<void>;
 		disable: () => Promise<void>;
+		/**
+		 * Visibility-aware pause. Flip to false while the app is hidden so
+		 * the Cue scanner subsystem skips expensive background work; flip
+		 * back to true on visibility. Different from `disable`, which tears
+		 * the engine down entirely.
+		 */
+		setActive: (active: boolean) => Promise<void>;
 		stopRun: (runId: string) => Promise<boolean>;
 		stopAll: () => Promise<void>;
 		triggerSubscription: (

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -196,6 +196,13 @@ interface MaestroAPI {
 	sessions: {
 		getAll: () => Promise<any[]>;
 		setAll: (sessions: any[]) => Promise<boolean>;
+		/**
+		 * Incremental persistence: merge `updates` into the stored sessions and
+		 * remove any whose id is in `removeIds`. Preferred over `setAll` for
+		 * debounced flushes — avoids cloning + serializing the entire sessions
+		 * tree on every change.
+		 */
+		setMany: (updates: any[], removeIds?: string[]) => Promise<boolean>;
 		getActiveSessionId: () => Promise<string>;
 		setActiveSessionId: (id: string) => Promise<void>;
 	};

--- a/src/renderer/hooks/cue/useCueVisibilityWiring.ts
+++ b/src/renderer/hooks/cue/useCueVisibilityWiring.ts
@@ -15,12 +15,19 @@
 import { useEffect } from 'react';
 import { useEventListener } from '../utils/useEventListener';
 import { logger } from '../../utils/logger';
+import { captureException } from '../../utils/sentry';
 
 function notifyMain(active: boolean): void {
 	const cue = window.maestro?.cue;
 	if (!cue || typeof cue.setActive !== 'function') return;
 	cue.setActive(active).catch((err: unknown) => {
 		logger.debug('[Cue] setActive IPC failed', undefined, err);
+		// Fail-soft locally (worst case scanners stay running, which is the
+		// pre-existing behavior) but surface to Sentry — repeated failures
+		// would otherwise be invisible. Per CLAUDE.md §"Error Handling & Sentry".
+		captureException(err instanceof Error ? err : new Error(String(err)), {
+			extra: { operation: 'cue.setActive', active },
+		});
 	});
 }
 

--- a/src/renderer/hooks/cue/useCueVisibilityWiring.ts
+++ b/src/renderer/hooks/cue/useCueVisibilityWiring.ts
@@ -1,0 +1,42 @@
+/**
+ * useCueVisibilityWiring.ts
+ *
+ * Forwards the renderer's visibilitychange events to the main-process Cue
+ * scanner subsystem so it can pause expensive background work (file walks,
+ * gh CLI fetches, file-event dispatch) while the app is hidden.
+ *
+ * Mounts once in App.tsx. The hook is fire-and-forget: failures to invoke
+ * `cue:setActive` are logged at debug level — the worst case is the
+ * scanners stay running, which is the pre-existing behavior.
+ *
+ * See CLAUDE-PERFORMANCE.md§"Visibility-Aware Operations" and PR-B 1.4.
+ */
+
+import { useEffect } from 'react';
+import { useEventListener } from '../utils/useEventListener';
+import { logger } from '../../utils/logger';
+
+function notifyMain(active: boolean): void {
+	const cue = window.maestro?.cue;
+	if (!cue || typeof cue.setActive !== 'function') return;
+	cue.setActive(active).catch((err: unknown) => {
+		logger.debug('[Cue] setActive IPC failed', undefined, err);
+	});
+}
+
+export function useCueVisibilityWiring(): void {
+	// Seed the main process with the current visibility state on mount.
+	// Without this, a renderer that starts up while the window is hidden
+	// would leave Cue active until the first visibilitychange event fires.
+	useEffect(() => {
+		notifyMain(!document.hidden);
+	}, []);
+
+	useEventListener(
+		'visibilitychange',
+		() => {
+			notifyMain(!document.hidden);
+		},
+		{ target: document }
+	);
+}

--- a/src/renderer/hooks/session/useSessionCategories.ts
+++ b/src/renderer/hooks/session/useSessionCategories.ts
@@ -29,38 +29,48 @@ export function useSessionCategories(
 	const sessions = useSessionStore((s) => s.sessions);
 	const groups = useSessionStore((s) => s.groups);
 
-	const worktreeChildrenByParentId = useMemo(() => {
-		const map = new Map<string, Session[]>();
-		sessions.forEach((session) => {
-			if (!session.parentSessionId) return;
-			const siblings = map.get(session.parentSessionId);
-			if (siblings) {
-				siblings.push(session);
-			} else {
-				map.set(session.parentSessionId, [session]);
+	// PR-A 1.3: collapse what used to be four chained `useMemo`s
+	// (worktreeChildrenByParentId → sortedWorktreeChildrenByParentId →
+	// sortedSessionIndexById → getWorktreeChildren) into a single pass.
+	// All four invalidate together when either `sessions` or `sortedSessions`
+	// changes, so chaining gave us four cascading recomputations on every
+	// session mutation. Computing them in one memo with a shared loop drops
+	// the per-mutation render cost roughly in proportion to the number of
+	// chained memos eliminated.
+	//
+	// See CLAUDE-PERFORMANCE.md§"Consolidate chained `useMemo` calls".
+	const { worktreeChildrenByParentId, sortedWorktreeChildrenByParentId, sortedSessionIndexById } =
+		useMemo(() => {
+			const childMap = new Map<string, Session[]>();
+			for (const session of sessions) {
+				if (!session.parentSessionId) continue;
+				const siblings = childMap.get(session.parentSessionId);
+				if (siblings) {
+					siblings.push(session);
+				} else {
+					childMap.set(session.parentSessionId, [session]);
+				}
 			}
-		});
-		return map;
-	}, [sessions]);
 
-	const sortedWorktreeChildrenByParentId = useMemo(() => {
-		const map = new Map<string, Session[]>();
-		worktreeChildrenByParentId.forEach((children, parentId) => {
-			map.set(
-				parentId,
-				[...children].sort((a, b) => compareSessionNames(a.name, b.name))
-			);
-		});
-		return map;
-	}, [worktreeChildrenByParentId]);
+			const sortedChildMap = new Map<string, Session[]>();
+			for (const [parentId, children] of childMap) {
+				sortedChildMap.set(
+					parentId,
+					[...children].sort((a, b) => compareSessionNames(a.name, b.name))
+				);
+			}
 
-	const sortedSessionIndexById = useMemo(() => {
-		const map = new Map<string, number>();
-		sortedSessions.forEach((session, index) => {
-			map.set(session.id, index);
-		});
-		return map;
-	}, [sortedSessions]);
+			const indexMap = new Map<string, number>();
+			for (let i = 0; i < sortedSessions.length; i++) {
+				indexMap.set(sortedSessions[i].id, i);
+			}
+
+			return {
+				worktreeChildrenByParentId: childMap,
+				sortedWorktreeChildrenByParentId: sortedChildMap,
+				sortedSessionIndexById: indexMap,
+			};
+		}, [sessions, sortedSessions]);
 
 	const getWorktreeChildren = useCallback(
 		(parentId: string): Session[] => worktreeChildrenByParentId.get(parentId) || [],

--- a/src/renderer/hooks/utils/useDebouncedPersistence.ts
+++ b/src/renderer/hooks/utils/useDebouncedPersistence.ts
@@ -5,6 +5,24 @@
  * During AI streaming, sessions can change 100+ times per second.
  * This hook batches those changes and writes at most once every 2 seconds.
  *
+ * Persistence path (after PR-A 1.1):
+ *  - First flush after load: ship the entire prepared sessions array via
+ *    `sessions:setAll`. This seeds the main process and establishes a
+ *    diff baseline (`previouslyPersistedRef`).
+ *  - Subsequent flushes: diff `sessionsRef.current` against the baseline
+ *    using reference equality per session, then ship only the changed
+ *    sessions plus the ids of any removed sessions via
+ *    `sessions:setMany`. With Zustand's immutable update pattern, every
+ *    mutated session gets a fresh object reference — so the diff catches
+ *    every real change in O(N) without needing per-mutator dirty
+ *    tracking.
+ *
+ * Why diff in the hook rather than tracking dirty IDs in the store: the
+ * 200+ existing `setSessions((prev) => prev.map(...))` call sites use
+ * the functional updater form. Wrapping every site to record dirty IDs
+ * would risk regressions; reference-diff captures the same information
+ * in one place with no caller-side changes.
+ *
  * Features:
  * - Configurable debounce delay (default 2 seconds)
  * - Flush-on-unmount to prevent data loss
@@ -181,6 +199,43 @@ export interface UseDebouncedPersistenceReturn {
 export const DEFAULT_DEBOUNCE_DELAY = 2000;
 
 /**
+ * Diff two sessions arrays by reference identity per element.
+ *
+ * Returns the subset of `curr` whose session reference differs from the
+ * matching id in `prev` (these are the sessions that need to be shipped),
+ * plus the ids of any sessions that existed in `prev` but not in `curr`
+ * (tombstones).
+ *
+ * Reference equality works because mutators always create new session
+ * objects via spread (`{ ...session, ...updates }`) — that's the React/Zustand
+ * paradigm and the same constraint that React.memo relies on.
+ */
+function diffSessions(
+	prev: Session[],
+	curr: Session[]
+): { dirty: Session[]; tombstones: string[] } {
+	const prevById = new Map<string, Session>();
+	for (const session of prev) prevById.set(session.id, session);
+
+	const dirty: Session[] = [];
+	const currIds = new Set<string>();
+	for (const session of curr) {
+		currIds.add(session.id);
+		const prevSession = prevById.get(session.id);
+		if (!prevSession || prevSession !== session) {
+			dirty.push(session);
+		}
+	}
+
+	const tombstones: string[] = [];
+	for (const id of prevById.keys()) {
+		if (!currIds.has(id)) tombstones.push(id);
+	}
+
+	return { dirty, tombstones };
+}
+
+/**
  * Hook that debounces session persistence to reduce disk writes.
  *
  * @param sessions - Array of sessions to persist
@@ -206,6 +261,41 @@ export function useDebouncedPersistence(
 	// Track if flush is in progress to prevent double-flushing
 	const flushingRef = useRef(false);
 
+	// Snapshot of the sessions array as it existed at the previous flush.
+	// Starts null — the first flush after load uses setAll to seed the main
+	// process and captures the snapshot. Every subsequent flush diffs the
+	// current sessions array against this snapshot and ships only the
+	// changed subset via setMany.
+	const previouslyPersistedRef = useRef<Session[] | null>(null);
+
+	/**
+	 * Run one persistence pass. Synchronous (fire-and-forget IPC) — safe
+	 * to call from unmount and beforeunload paths where we can't await.
+	 *
+	 * - First call after load: ships everything via setAll, captures the
+	 *   current sessions array as the diff baseline.
+	 * - Subsequent calls: diffs against the baseline; ships only the
+	 *   changed subset (and tombstone ids) via setMany; updates the
+	 *   baseline. No-op if nothing changed.
+	 */
+	const persistInternal = useCallback((): void => {
+		const current = sessionsRef.current;
+		if (previouslyPersistedRef.current === null) {
+			const sessionsForPersistence = current.map(prepareSessionForPersistence);
+			window.maestro.sessions.setAll(sessionsForPersistence);
+			previouslyPersistedRef.current = current;
+			return;
+		}
+		const { dirty, tombstones } = diffSessions(previouslyPersistedRef.current, current);
+		if (dirty.length === 0 && tombstones.length === 0) {
+			previouslyPersistedRef.current = current;
+			return;
+		}
+		const dirtyForPersistence = dirty.map(prepareSessionForPersistence);
+		window.maestro.sessions.setMany(dirtyForPersistence, tombstones);
+		previouslyPersistedRef.current = current;
+	}, []);
+
 	/**
 	 * Internal function to persist sessions immediately.
 	 * Called by both the debounce timer and flushNow.
@@ -215,13 +305,12 @@ export function useDebouncedPersistence(
 
 		flushingRef.current = true;
 		try {
-			const sessionsForPersistence = sessionsRef.current.map(prepareSessionForPersistence);
-			window.maestro.sessions.setAll(sessionsForPersistence);
+			persistInternal();
 			setIsPending(false);
 		} finally {
 			flushingRef.current = false;
 		}
-	}, []);
+	}, [persistInternal]);
 
 	/**
 	 * Force immediate persistence of pending changes.
@@ -283,10 +372,10 @@ export function useDebouncedPersistence(
 			// Only flush if initial load is complete - otherwise we might save an empty array
 			// before sessions have been loaded, wiping out the user's data
 			if (initialLoadComplete.current) {
-				const sessionsForPersistence = sessionsRef.current.map(prepareSessionForPersistence);
-				window.maestro.sessions.setAll(sessionsForPersistence);
+				persistInternal();
 			}
 		};
+		 
 	}, []);
 
 	// Flush on visibility change (user switching away from app)
@@ -308,9 +397,9 @@ export function useDebouncedPersistence(
 	useEffect(() => {
 		const handleBeforeUnload = () => {
 			if (isPending) {
-				// Synchronous flush for beforeunload
-				const sessionsForPersistence = sessionsRef.current.map(prepareSessionForPersistence);
-				window.maestro.sessions.setAll(sessionsForPersistence);
+				// Synchronous flush for beforeunload — uses the same dirty-only
+				// path as the debounce timer (see persistInternal).
+				persistInternal();
 			}
 		};
 
@@ -319,7 +408,7 @@ export function useDebouncedPersistence(
 		return () => {
 			window.removeEventListener('beforeunload', handleBeforeUnload);
 		};
-	}, [isPending]);
+	}, [isPending, persistInternal]);
 
 	return { isPending, flushNow };
 }

--- a/src/renderer/hooks/utils/useDebouncedPersistence.ts
+++ b/src/renderer/hooks/utils/useDebouncedPersistence.ts
@@ -34,6 +34,7 @@ import { useEffect, useRef, useCallback, useState } from 'react';
 import type { Session } from '../../types';
 import { sanitizeBrowserTabForPersistence } from '../../utils/browserTabPersistence';
 import { logger } from '../../utils/logger';
+import { captureException } from '../../utils/sentry';
 
 // Maximum persisted logs per AI tab (matches session persistence limit)
 const MAX_PERSISTED_LOGS_PER_TAB = 100;
@@ -56,49 +57,42 @@ const MAX_PERSISTED_LOGS_PER_TAB = 100;
  * This is a local copy to avoid circular imports in session persistence logic.
  */
 const prepareSessionForPersistence = (session: Session): Session => {
-	// Edge case: a session with no aiTabs shouldn't happen after migration,
-	// but if it does we still strip runtime fields here so a stuck `state:
-	// 'busy'` (or any other process-tied state) doesn't survive a restart.
-	// Returning as-is would otherwise mean the session shows busy on next
-	// launch with no underlying process to back it up.
-	if (!session.aiTabs || session.aiTabs.length === 0) {
-		return {
-			...session,
-			aiTabs: [],
-			state: 'idle',
-			busySource: undefined,
-			thinkingStartTime: undefined,
-			currentCycleTokens: undefined,
-			currentCycleBytes: undefined,
-			statusMessage: undefined,
-			sshRemote: undefined,
-			sshRemoteId: undefined,
-			remoteCwd: undefined,
-		} as unknown as Session;
-	}
-
 	// Filter out tabs with active wizard state - incomplete wizards should not persist
 	// When a wizard completes, wizardState is cleared (set to undefined) and the tab
 	// becomes a regular session that should persist.
-	const nonWizardTabs = session.aiTabs.filter((tab) => !tab.wizardState?.isActive);
+	//
+	// Note: aiTabs may be missing or empty (edge case — shouldn't happen
+	// after migration). We don't early-return for that case anymore: the
+	// shared sanitization below (terminal/browser tab cleanup, runtime-field
+	// stripping, SSH state reset) must still run regardless of aiTabs
+	// presence so a stuck busy state can't survive a restart.
+	const sourceTabs = session.aiTabs ?? [];
+	const nonWizardTabs = sourceTabs.filter((tab) => !tab.wizardState?.isActive);
 
-	// If all tabs were wizard tabs, create a fresh empty tab to avoid empty session
-	const tabsToProcess =
-		nonWizardTabs.length > 0
-			? nonWizardTabs
-			: [
-					{
-						id: session.aiTabs[0].id, // Keep the first tab's ID for consistency
-						agentSessionId: null,
-						name: null,
-						starred: false,
-						logs: [],
-						inputValue: '',
-						stagedImages: [],
-						createdAt: Date.now(),
-						state: 'idle' as const,
-					},
-				];
+	// "All tabs were wizard tabs" fallback — only fires when there were
+	// originally tabs but every one was a wizard. For truly-empty input
+	// (aiTabs missing or already empty) we keep aiTabs empty rather than
+	// invent a synthetic tab the caller never had.
+	let tabsToProcess: Session['aiTabs'];
+	if (nonWizardTabs.length > 0) {
+		tabsToProcess = nonWizardTabs;
+	} else if (sourceTabs.length > 0) {
+		tabsToProcess = [
+			{
+				id: sourceTabs[0].id, // Keep the first tab's ID for consistency
+				agentSessionId: null,
+				name: null,
+				starred: false,
+				logs: [],
+				inputValue: '',
+				stagedImages: [],
+				createdAt: Date.now(),
+				state: 'idle' as const,
+			},
+		];
+	} else {
+		tabsToProcess = [];
+	}
 
 	// Truncate logs and reset runtime state in each tab
 	const truncatedTabs = tabsToProcess.map((tab) => ({
@@ -286,62 +280,61 @@ export function useDebouncedPersistence(
 	const previouslyPersistedRef = useRef<Session[] | null>(null);
 
 	/**
-	 * Run one persistence pass. Returns a Promise so debounced callers can
-	 * await the IPC and only advance the diff baseline once the main process
-	 * confirms the write succeeded. Without that, a transient ENOSPC /
-	 * ENFILE on one flush would silently mark the dirty sessions as
-	 * persisted, so the next flush wouldn't retry them.
+	 * Run one persistence pass. Throws on failure so callers can decide
+	 * whether to clear the pending flag — without that, a transient ENOSPC
+	 * would silently mark dirty sessions as persisted AND clear isPending,
+	 * leaving beforeunload with no signal to attempt one more retry before
+	 * the window closes.
 	 *
 	 * - First call after load: ships everything via setAll. Baseline is
 	 *   captured ONLY if setAll resolves truthy.
 	 * - Subsequent calls: diffs against the baseline; ships only the
 	 *   changed subset via setMany. Baseline advances ONLY if the IPC
 	 *   resolves truthy.
-	 * - On rejection or false: log + captureException, leave the baseline
-	 *   untouched so the next flush retries the still-dirty sessions.
+	 * - On rejection or `ok === false`: leave previouslyPersistedRef
+	 *   untouched (so the next diff retries the still-dirty sessions) and
+	 *   throw — caller decides whether to surface and how to handle.
 	 *
-	 * Sync callers (unmount, beforeunload) ignore the returned Promise —
-	 * those contexts can't await anyway. Best-effort there is fine: the
-	 * subsequent app launch will reconcile from disk.
+	 * Sync callers (unmount, beforeunload) wrap the returned Promise in a
+	 * .catch — those contexts can't propagate the throw anyway, but they
+	 * still need to log so the failure is visible.
 	 */
 	const persistInternal = useCallback(async (): Promise<void> => {
 		const current = sessionsRef.current;
-		try {
-			if (previouslyPersistedRef.current === null) {
-				const sessionsForPersistence = current.map(prepareSessionForPersistence);
-				const ok = await window.maestro.sessions.setAll(sessionsForPersistence);
-				if (ok !== false) {
-					previouslyPersistedRef.current = current;
-				}
-				return;
+		if (previouslyPersistedRef.current === null) {
+			const sessionsForPersistence = current.map(prepareSessionForPersistence);
+			const ok = await window.maestro.sessions.setAll(sessionsForPersistence);
+			if (ok === false) {
+				throw new Error('sessions:setAll returned false (recoverable disk error)');
 			}
-			const { dirty, tombstones } = diffSessions(previouslyPersistedRef.current, current);
-			if (dirty.length === 0 && tombstones.length === 0) {
-				// Nothing changed — safe to advance the baseline (it would be
-				// identical anyway).
-				previouslyPersistedRef.current = current;
-				return;
-			}
-			const dirtyForPersistence = dirty.map(prepareSessionForPersistence);
-			const ok = await window.maestro.sessions.setMany(dirtyForPersistence, tombstones);
-			if (ok !== false) {
-				previouslyPersistedRef.current = current;
-			}
-		} catch (err) {
-			logger.warn('[Persistence] flush failed; baseline preserved for retry', undefined, err);
-			// Leave previouslyPersistedRef untouched. Next diff() call will
-			// see the same dirty sessions and retry. captureException is
-			// fire-and-forget through main-process logger plumbing.
+			previouslyPersistedRef.current = current;
+			return;
 		}
+		const { dirty, tombstones } = diffSessions(previouslyPersistedRef.current, current);
+		if (dirty.length === 0 && tombstones.length === 0) {
+			// Nothing changed — safe to advance the baseline (it would be
+			// identical anyway).
+			previouslyPersistedRef.current = current;
+			return;
+		}
+		const dirtyForPersistence = dirty.map(prepareSessionForPersistence);
+		const ok = await window.maestro.sessions.setMany(dirtyForPersistence, tombstones);
+		if (ok === false) {
+			throw new Error('sessions:setMany returned false (recoverable disk error)');
+		}
+		previouslyPersistedRef.current = current;
 	}, []);
 
 	/**
-	 * Internal function to persist sessions immediately.
-	 * Called by both the debounce timer and flushNow.
+	 * Wrapper invoked by the debounce timer and flushNow. Awaits
+	 * persistInternal and ONLY clears `isPending` when the persist
+	 * actually succeeded — otherwise the beforeunload listener (which
+	 * gates its sync flush on `isPending`) would never get the chance to
+	 * retry.
 	 *
-	 * Awaits persistInternal so flushingRef stays held until the IPC
-	 * resolves — otherwise concurrent flushes could interleave and
-	 * advance the baseline mid-flight.
+	 * Failures are logged + reported to Sentry but not rethrown to the
+	 * timer callback — there's no caller above that could meaningfully
+	 * handle it, and an unhandled rejection here would just produce noise.
 	 */
 	const persistSessions = useCallback(async () => {
 		if (flushingRef.current) return;
@@ -350,6 +343,17 @@ export function useDebouncedPersistence(
 		try {
 			await persistInternal();
 			setIsPending(false);
+		} catch (err) {
+			logger.warn(
+				'[Persistence] flush failed; isPending preserved for next-mutation/beforeunload retry',
+				undefined,
+				err
+			);
+			captureException(err instanceof Error ? err : new Error(String(err)), {
+				extra: { operation: 'useDebouncedPersistence.persistSessions' },
+			});
+			// Deliberately do NOT setIsPending(false) — the failed write is
+			// still pending. Next mutation OR beforeunload will retry.
 		} finally {
 			flushingRef.current = false;
 		}
@@ -415,7 +419,12 @@ export function useDebouncedPersistence(
 			// Only flush if initial load is complete - otherwise we might save an empty array
 			// before sessions have been loaded, wiping out the user's data
 			if (initialLoadComplete.current) {
-				persistInternal();
+				// persistInternal can throw; we can't propagate from a cleanup
+				// function, so swallow + log. The next launch will reconcile
+				// from disk regardless.
+				persistInternal().catch((err) => {
+					logger.warn('[Persistence] unmount flush failed', undefined, err);
+				});
 			}
 		};
 	}, []);
@@ -441,7 +450,11 @@ export function useDebouncedPersistence(
 			if (isPending) {
 				// Synchronous flush for beforeunload — uses the same dirty-only
 				// path as the debounce timer (see persistInternal).
-				persistInternal();
+				// Swallow rejections: the window is closing, there's no caller
+				// above to handle them.
+				persistInternal().catch((err) => {
+					logger.warn('[Persistence] beforeunload flush failed', undefined, err);
+				});
 			}
 		};
 

--- a/src/renderer/hooks/utils/useDebouncedPersistence.ts
+++ b/src/renderer/hooks/utils/useDebouncedPersistence.ts
@@ -375,7 +375,6 @@ export function useDebouncedPersistence(
 				persistInternal();
 			}
 		};
-		 
 	}, []);
 
 	// Flush on visibility change (user switching away from app)

--- a/src/renderer/hooks/utils/useDebouncedPersistence.ts
+++ b/src/renderer/hooks/utils/useDebouncedPersistence.ts
@@ -33,6 +33,7 @@
 import { useEffect, useRef, useCallback, useState } from 'react';
 import type { Session } from '../../types';
 import { sanitizeBrowserTabForPersistence } from '../../utils/browserTabPersistence';
+import { logger } from '../../utils/logger';
 
 // Maximum persisted logs per AI tab (matches session persistence limit)
 const MAX_PERSISTED_LOGS_PER_TAB = 100;
@@ -55,9 +56,25 @@ const MAX_PERSISTED_LOGS_PER_TAB = 100;
  * This is a local copy to avoid circular imports in session persistence logic.
  */
 const prepareSessionForPersistence = (session: Session): Session => {
-	// If no aiTabs, return as-is (shouldn't happen after migration)
+	// Edge case: a session with no aiTabs shouldn't happen after migration,
+	// but if it does we still strip runtime fields here so a stuck `state:
+	// 'busy'` (or any other process-tied state) doesn't survive a restart.
+	// Returning as-is would otherwise mean the session shows busy on next
+	// launch with no underlying process to back it up.
 	if (!session.aiTabs || session.aiTabs.length === 0) {
-		return session;
+		return {
+			...session,
+			aiTabs: [],
+			state: 'idle',
+			busySource: undefined,
+			thinkingStartTime: undefined,
+			currentCycleTokens: undefined,
+			currentCycleBytes: undefined,
+			statusMessage: undefined,
+			sshRemote: undefined,
+			sshRemoteId: undefined,
+			remoteCwd: undefined,
+		} as unknown as Session;
 	}
 
 	// Filter out tabs with active wizard state - incomplete wizards should not persist
@@ -269,43 +286,69 @@ export function useDebouncedPersistence(
 	const previouslyPersistedRef = useRef<Session[] | null>(null);
 
 	/**
-	 * Run one persistence pass. Synchronous (fire-and-forget IPC) — safe
-	 * to call from unmount and beforeunload paths where we can't await.
+	 * Run one persistence pass. Returns a Promise so debounced callers can
+	 * await the IPC and only advance the diff baseline once the main process
+	 * confirms the write succeeded. Without that, a transient ENOSPC /
+	 * ENFILE on one flush would silently mark the dirty sessions as
+	 * persisted, so the next flush wouldn't retry them.
 	 *
-	 * - First call after load: ships everything via setAll, captures the
-	 *   current sessions array as the diff baseline.
+	 * - First call after load: ships everything via setAll. Baseline is
+	 *   captured ONLY if setAll resolves truthy.
 	 * - Subsequent calls: diffs against the baseline; ships only the
-	 *   changed subset (and tombstone ids) via setMany; updates the
-	 *   baseline. No-op if nothing changed.
+	 *   changed subset via setMany. Baseline advances ONLY if the IPC
+	 *   resolves truthy.
+	 * - On rejection or false: log + captureException, leave the baseline
+	 *   untouched so the next flush retries the still-dirty sessions.
+	 *
+	 * Sync callers (unmount, beforeunload) ignore the returned Promise —
+	 * those contexts can't await anyway. Best-effort there is fine: the
+	 * subsequent app launch will reconcile from disk.
 	 */
-	const persistInternal = useCallback((): void => {
+	const persistInternal = useCallback(async (): Promise<void> => {
 		const current = sessionsRef.current;
-		if (previouslyPersistedRef.current === null) {
-			const sessionsForPersistence = current.map(prepareSessionForPersistence);
-			window.maestro.sessions.setAll(sessionsForPersistence);
-			previouslyPersistedRef.current = current;
-			return;
+		try {
+			if (previouslyPersistedRef.current === null) {
+				const sessionsForPersistence = current.map(prepareSessionForPersistence);
+				const ok = await window.maestro.sessions.setAll(sessionsForPersistence);
+				if (ok !== false) {
+					previouslyPersistedRef.current = current;
+				}
+				return;
+			}
+			const { dirty, tombstones } = diffSessions(previouslyPersistedRef.current, current);
+			if (dirty.length === 0 && tombstones.length === 0) {
+				// Nothing changed — safe to advance the baseline (it would be
+				// identical anyway).
+				previouslyPersistedRef.current = current;
+				return;
+			}
+			const dirtyForPersistence = dirty.map(prepareSessionForPersistence);
+			const ok = await window.maestro.sessions.setMany(dirtyForPersistence, tombstones);
+			if (ok !== false) {
+				previouslyPersistedRef.current = current;
+			}
+		} catch (err) {
+			logger.warn('[Persistence] flush failed; baseline preserved for retry', undefined, err);
+			// Leave previouslyPersistedRef untouched. Next diff() call will
+			// see the same dirty sessions and retry. captureException is
+			// fire-and-forget through main-process logger plumbing.
 		}
-		const { dirty, tombstones } = diffSessions(previouslyPersistedRef.current, current);
-		if (dirty.length === 0 && tombstones.length === 0) {
-			previouslyPersistedRef.current = current;
-			return;
-		}
-		const dirtyForPersistence = dirty.map(prepareSessionForPersistence);
-		window.maestro.sessions.setMany(dirtyForPersistence, tombstones);
-		previouslyPersistedRef.current = current;
 	}, []);
 
 	/**
 	 * Internal function to persist sessions immediately.
 	 * Called by both the debounce timer and flushNow.
+	 *
+	 * Awaits persistInternal so flushingRef stays held until the IPC
+	 * resolves — otherwise concurrent flushes could interleave and
+	 * advance the baseline mid-flight.
 	 */
-	const persistSessions = useCallback(() => {
+	const persistSessions = useCallback(async () => {
 		if (flushingRef.current) return;
 
 		flushingRef.current = true;
 		try {
-			persistInternal();
+			await persistInternal();
 			setIsPending(false);
 		} finally {
 			flushingRef.current = false;

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -712,6 +712,26 @@ svg.wand-sparkle-active path:nth-child(8) {
 	opacity: 1;
 }
 
+/*
+ * Cue pipeline drag-preview line (connecting nodes).
+ *
+ * The Cue PipelineCanvas passes a custom <PipelineConnectionLine> component
+ * via `connectionLineComponent` so we render the path ourselves with full
+ * control. This rule is a belt-and-suspenders safety net for any ReactFlow
+ * surface that falls back to the default ConnectionLine — without it, the
+ * default `stroke: #b1b1b7` is invisible against the dark theme.
+ *
+ * If the inline style on a custom component sets stroke explicitly, that
+ * style has higher specificity than this class rule and wins. This rule
+ * only kicks in when nothing else has styled the path.
+ */
+.react-flow__connection-path {
+	stroke: #06b6d4; /* CUE_COLOR — keep in sync with shared/cue-pipeline-types.ts */
+	stroke-width: 2;
+	stroke-dasharray: 6 3;
+	fill: none;
+}
+
 /* Reduced motion preference - accessibility best practice */
 /* ==========================================
    Header Bar Container Queries

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -54,7 +54,7 @@ export type {
 	ModeratorConfig,
 } from '../../shared/group-chat-types';
 // Import AgentError for use within this file
-import type { AgentError } from '../../shared/types';
+import type { AgentError, SessionCliActivity } from '../../shared/types';
 
 export type SessionState = 'idle' | 'busy' | 'waiting_input' | 'connecting' | 'error';
 export type FileChangeType = 'modified' | 'added' | 'deleted';
@@ -669,12 +669,10 @@ export interface Session {
 	batchRunnerPrompt?: string;
 	// Timestamp when the batch runner prompt was last modified
 	batchRunnerPromptModifiedAt?: number;
-	// CLI activity - present when CLI is running a playbook on this session
-	cliActivity?: {
-		playbookId: string;
-		playbookName: string;
-		startedAt: number;
-	};
+	// CLI activity - present when CLI is running a playbook on this session.
+	// Shape lives in shared/types.ts (SessionCliActivity) so the persistence
+	// diff comparator stays in lock-step with this producer's contract.
+	cliActivity?: SessionCliActivity;
 
 	// Tab management for AI mode (multi-tab Claude Code sessions)
 	// Each tab represents a separate Claude Code conversation

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -168,6 +168,23 @@ export interface Group {
 	collapsed: boolean;
 }
 
+/**
+ * Cli activity attached to a Session when the CLI is running a playbook on
+ * that session. Single source of truth for both the renderer's Session type
+ * (`renderer/types/index.ts`) and the main-process persistence diff
+ * comparator (`main/ipc/handlers/persistence.ts:cliActivityChanged`).
+ *
+ * Producer: `useCliActivityMonitoring` in
+ * `renderer/hooks/remote/useCliActivityMonitoring.ts`. If a new field is added
+ * here, the comparator must compare it too — TypeScript will flag the omission
+ * because both sites depend on this exact shape.
+ */
+export interface SessionCliActivity {
+	playbookId: string;
+	playbookName: string;
+	startedAt: number;
+}
+
 // Simplified session interface for CLI (subset of full Session)
 export interface SessionInfo {
 	id: string;


### PR DESCRIPTION
## Summary

Three coherent perf bundles + one Cue UX polish, all on the streaming hot path:

- **session persistence + categorization:** stop cloning the entire sessions tree on every change, replace per-session `JSON.stringify(cliActivity)` with a shallow primitive compare, and collapse the four chained `useMemo`s in `useSessionCategories` into one pass.
- **background work hygiene:** Cue scanners (file watcher, task scanner, GitHub poller) pause when the app is hidden via a new `cue:setActive` IPC; stats query-event writes batch to SQLite in 50-event / 500ms windows wrapped in a single transaction.
- **Cue UX polish:** restore the drag-preview line when connecting two pipeline nodes — works in both pan and select canvas modes now.

12 commits. 26,946+ tests pass. `tsc` clean. `eslint` clean.

## session persistence + categorization

### `sessions:setMany` (the load-bearing change)

- **Before:** every debounced flush mapped `prepareSessionForPersistence` over **all** sessions and shipped the full tree across IPC. CLAUDE-PERFORMANCE.md observed >500 MB short-lived heap churn from this pattern.
- **After:** first flush after load uses `setAll` to seed the main process and capture a baseline. Subsequent flushes diff `sessions` against the baseline by reference equality per element (Zustand's immutable update pattern guarantees mutated sessions get a fresh reference) and ship only the changed subset + tombstone ids via the new `setMany` IPC handler.
- **IPC payload:** O(N) → O(dirty), typically 1–2 of 30+ sessions during streaming.
- **Why hook-level diff and not store-level dirty tracking:** 200+ existing `setSessions(prev => prev.map(...))` call sites use the functional-updater form. Wrapping every mutator was invasive and risky; the diff captures the same information in one place with no caller changes.

Commits: `315eeb402` (characterization), `03a9503be` (handler), `5aa3eb60b` (renderer switch).

### cliActivity shallow compare

- **Before:** `JSON.stringify(prev.cliActivity) !== JSON.stringify(curr.cliActivity)` per session per flush. With 30+ sessions × 200ms cadence during streaming, thousands of stringify ops per minute.
- **After:** 4-step primitive comparison. The producer (`useCliActivityMonitoring`) only ever sets the field to `undefined` or `{ playbookId, playbookName, startedAt }`, so a field-by-field check is equivalent at every real call site.
- **Per-session diff cost:** O(stringify ~100B × 2) → O(1).

Commit: `01a3063df`.

### `useSessionCategories` memo consolidation

- **Before:** four `useMemo`s daisy-chained, each invalidated by the previous. Every session mutation triggered four cascading recomputes.
- **After:** one `useMemo` keyed on `[sessions, sortedSessions]`, computes all three Maps in one pass. `getWorktreeChildren` stays as a `useCallback` — same identity contract, same output.
- **Render cost:** session-list traversal cost drops roughly proportional to the number of memos eliminated.

Commit: `f5eedbf1d`.

## background work hygiene

### Cue scanners visibility-aware pause

- **Before:** `cue-task-scanner`, `cue-file-watcher`, and `cue-github-poller` ran unconditionally regardless of whether the Maestro window was visible. Task scanner did per-minute directory walks + markdown reads. GitHub poller hit `gh` CLI every 5 min. Result: laptop fans spinning while users weren't looking.
- **After:** module-level `cueActive` flag (`cue-active-state.ts`) gates per-tick work in each scanner. New `useCueVisibilityWiring` hook in `App.tsx` forwards `document.visibilityState` via `cue:setActive` IPC. When inactive: task scanner skips the walk, GitHub poller skips the gh fetch, file watcher drops dispatch (chokidar subscription stays alive — OS file-watch is nearly free). Pause-don't-stop preserves clean resume on the next tick.
- **Default-active** is preserved when `isActive` is omitted, so CLI / tests / headless agents are unaffected.

Commits: `e8d58a591` (engine + scanners), `7f2c10295` (renderer wiring).

### Stats DB write batching

- **Before:** every `stats:record-query` IPC fired a single `stmt.run()` against SQLite. Many fsyncs per second on the streaming hot path.
- **After:** events buffered for 500ms or 50 events (whichever first). Flush wraps all buffered inserts in one `db.transaction(() => { ... })` — N WAL+fsync collapses into one. Same cadence as the existing logger / thinking-chunk batching landed in `e475c0bad`.
- Generated id returned synchronously so callers (which all `.catch()` and discard the id) don't wait for the disk write.
- `before-quit` hook flushes any in-flight buffer; events lost on flush failure (best-effort telemetry vs. infinite-retry risk).
- The process-listener path (auto-run batch mode, has its own retry logic) deliberately untouched.

Commit: `64f5c936f`.

## Cue pipeline UX — drag-preview line restored

The connection-line that follows the cursor while dragging from one node handle to another was effectively invisible. ReactFlow's default styling is `stroke: #b1b1b7` at 1px — washed out against our dark theme. Users saw the resulting edge appear on mouse-up with no visual cue during the drag itself. Compounded by `nodesConnectable` being gated on canvas pan/select mode, which broke the preview entirely in pan mode.

Fixes layered three ways:

1. **Custom `connectionLineComponent`** — `PipelineConnectionLine` paints its own SVG path: dashed bezier in `CUE_COLOR` at 2px with a small dot at the cursor tip. Bypasses any styling/specificity issues with the default render path.
2. **`connectionLineStyle` + `connectionLineType` props** as belt-and-suspenders for any path that falls back to the default ConnectionLine.
3. **CSS rule** on `.react-flow__connection-path` for the same belt-and-suspenders reason in case a future change reverts the prop.
4. **Decouple `nodesConnectable` from canvas mode.** Hand mode still disables node-body dragging (so left-drag pans through), but handles always work — matches n8n / Zapier / Figma's connector tool.

Commits: `ae6c28f1c`, `ba2e42a18`, `8f46c752b`, `8e195ddc1`.

## Risk profile

| Risk | Mitigation |
| --- | --- |
| Reference-diff misses a session mutation done in-place | Same constraint React.memo and Zustand selectors require — already enforced project-wide. Verified by 10 new tests covering update / add / remove / no-op / rapid-mutation / unmount paths. |
| `setAll` semantics change | First flush still calls `setAll` (preserves bootstrap path); 75 existing test assertions on `setAll` continue to pass. |
| `setMany` mishandles add/remove edge cases | 17 dedicated tests cover empty, single, mixed, conflict (remove wins), unseen-id, no-broadcast, error paths. |
| cliActivity comparison drifts from JSON.stringify behavior | 8 lock-in tests pin every (prev, curr) transition that must broadcast or stay silent — pass on both old and new code. |
| Memo consolidation changes output shape | 5 lock-in tests assert deep-equal Map content + reference identity across renders for a 10-session fixture — pass on both old and new code. |
| Cue scanners miss events during long-hidden windows | Pause-don't-stop preserves OS-level file watching. On resume, downstream re-scan paths catch up. The 24h GitHub prune timer is unaffected. |
| Stats buffer loses events on crash | Best-effort telemetry. The `before-quit` hook flushes on graceful exit. Hard crashes lose at most ~50 events / 500ms. |

## Test plan

- `npm run test` — **26,946 passed, 0 failed** (108 pre-existing skipped)
- `npm run lint` — clean across `tsconfig.lint.json`, `tsconfig.main.json`, `tsconfig.cli.json`
- `npm run lint:eslint` — clean
- +48 new tests across persistence (8 cliActivity diff, 17 setMany, 10 dirty-only flush, 5 categorization lock-in), Cue (5 active-state, 12 scanner gates, 6 visibility hook), and stats (15 buffer cases)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cue now respects renderer visibility: background scanning pauses when the window is hidden and resumes when visible.
  * Incremental session persistence added to update/remove sessions more efficiently.

* **Improvements**
  * Query events are buffered and flushed in batches for more resilient analytics and shutdown handling.
  * Improved pipeline connection preview visuals and connection interaction affordances.

* **Tests**
  * Expanded coverage around visibility gating, incremental persistence, buffered query events, and related wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->