### PR TITLE
feat(web): paste images into web/mobile chat composer

### DIFF
--- a/src/__tests__/main/preload/process.test.ts
+++ b/src/__tests__/main/preload/process.test.ts
@@ -274,7 +274,7 @@ describe('Process Preload API', () => {
 	});
 
 	describe('onRemoteCommand', () => {
-		it('should register listener and invoke callback with all parameters including tabId and force', () => {
+		it('should register listener and invoke callback with all parameters including tabId, force, and images', () => {
 			const callback = vi.fn();
 			let registeredHandler: (
 				event: unknown,
@@ -282,7 +282,8 @@ describe('Process Preload API', () => {
 				command: string,
 				inputMode?: 'ai' | 'terminal',
 				tabId?: string,
-				force?: boolean
+				force?: boolean,
+				images?: string[]
 			) => void;
 
 			mockOn.mockImplementation((channel: string, handler: typeof registeredHandler) => {
@@ -292,12 +293,20 @@ describe('Process Preload API', () => {
 			});
 
 			api.onRemoteCommand(callback);
-			registeredHandler!({}, 'session-123', 'test command', 'ai', 'tab-7', true);
+			const images = ['data:image/png;base64,abc'];
+			registeredHandler!({}, 'session-123', 'test command', 'ai', 'tab-7', true, images);
 
-			expect(callback).toHaveBeenCalledWith('session-123', 'test command', 'ai', 'tab-7', true);
+			expect(callback).toHaveBeenCalledWith(
+				'session-123',
+				'test command',
+				'ai',
+				'tab-7',
+				true,
+				images
+			);
 		});
 
-		it('forwards undefined tabId/force when the IPC sender omits them (legacy callers)', () => {
+		it('forwards undefined tabId/force/images when the IPC sender omits them (legacy callers)', () => {
 			const callback = vi.fn();
 			let registeredHandler: (
 				event: unknown,
@@ -305,7 +314,8 @@ describe('Process Preload API', () => {
 				command: string,
 				inputMode?: 'ai' | 'terminal',
 				tabId?: string,
-				force?: boolean
+				force?: boolean,
+				images?: string[]
 			) => void;
 
 			mockOn.mockImplementation((channel: string, handler: typeof registeredHandler) => {
@@ -321,6 +331,7 @@ describe('Process Preload API', () => {
 				'session-123',
 				'test command',
 				'ai',
+				undefined,
 				undefined,
 				undefined
 			);

--- a/src/__tests__/main/web-server/handlers/messageHandlers.test.ts
+++ b/src/__tests__/main/web-server/handlers/messageHandlers.test.ts
@@ -193,7 +193,8 @@ describe('WebSocketMessageHandler', () => {
 					'Hello Claude!',
 					'ai',
 					undefined,
-					false
+					false,
+					undefined
 				);
 			});
 
@@ -216,7 +217,8 @@ describe('WebSocketMessageHandler', () => {
 					'ls -la',
 					'terminal',
 					undefined,
-					false
+					false,
+					undefined
 				);
 			});
 		});
@@ -280,13 +282,36 @@ describe('WebSocketMessageHandler', () => {
 					'Hello',
 					'ai',
 					'tab-explicit',
-					false
+					false,
+					undefined
 				);
 			});
 
 			const response = JSON.parse((client.socket.send as any).mock.calls[0][0]);
 			expect(response.type).toBe('command_result');
 			expect(response.tabId).toBe('tab-explicit');
+		});
+
+		it('forwards pasted images so the renderer can attach them to the prompt', async () => {
+			const images = ['data:image/png;base64,abc', 'data:image/png;base64,def'];
+			handler.handleMessage(client, {
+				type: 'send_command',
+				sessionId: 'session-1',
+				command: 'look at this',
+				inputMode: 'ai',
+				images,
+			});
+
+			await vi.waitFor(() => {
+				expect(callbacks.executeCommand).toHaveBeenCalledWith(
+					'session-1',
+					'look at this',
+					'ai',
+					undefined,
+					false,
+					images
+				);
+			});
 		});
 
 		it('should bypass busy guard and forward command when force=true', async () => {
@@ -306,7 +331,8 @@ describe('WebSocketMessageHandler', () => {
 					'concurrent write',
 					'ai',
 					undefined,
-					true
+					true,
+					undefined
 				);
 			});
 

--- a/src/__tests__/main/web-server/handlers/messageHandlers.test.ts
+++ b/src/__tests__/main/web-server/handlers/messageHandlers.test.ts
@@ -292,6 +292,48 @@ describe('WebSocketMessageHandler', () => {
 			expect(response.tabId).toBe('tab-explicit');
 		});
 
+		it('accepts image-only sends in AI mode (no command, images present)', async () => {
+			// The web composer allows submitting in AI mode when only images
+			// are staged (no typed text). The server must not reject those
+			// requests as "missing command" — instead it forwards an empty
+			// command alongside the images so the renderer can attach them
+			// to a default image-only prompt.
+			const images = ['data:image/png;base64,abc'];
+			handler.handleMessage(client, {
+				type: 'send_command',
+				sessionId: 'session-1',
+				inputMode: 'ai',
+				images,
+			});
+
+			await vi.waitFor(() => {
+				expect(callbacks.executeCommand).toHaveBeenCalledWith(
+					'session-1',
+					'',
+					'ai',
+					undefined,
+					false,
+					images
+				);
+			});
+
+			const response = JSON.parse((client.socket.send as any).mock.calls[0][0]);
+			expect(response.type).toBe('command_result');
+			expect(response.success).toBe(true);
+		});
+
+		it('rejects send with neither command nor images', () => {
+			handler.handleMessage(client, {
+				type: 'send_command',
+				sessionId: 'session-1',
+				inputMode: 'ai',
+			});
+
+			const response = JSON.parse((client.socket.send as any).mock.calls[0][0]);
+			expect(response.type).toBe('error');
+			expect(callbacks.executeCommand).not.toHaveBeenCalled();
+		});
+
 		it('forwards pasted images so the renderer can attach them to the prompt', async () => {
 			const images = ['data:image/png;base64,abc', 'data:image/png;base64,def'];
 			handler.handleMessage(client, {

--- a/src/__tests__/main/web-server/managers/CallbackRegistry.test.ts
+++ b/src/__tests__/main/web-server/managers/CallbackRegistry.test.ts
@@ -372,6 +372,7 @@ describe('CallbackRegistry', () => {
 				'npm test',
 				undefined,
 				undefined,
+				undefined,
 				undefined
 			);
 		});
@@ -386,6 +387,7 @@ describe('CallbackRegistry', () => {
 				'session-5',
 				'npm test',
 				'terminal',
+				undefined,
 				undefined,
 				undefined
 			);
@@ -402,6 +404,7 @@ describe('CallbackRegistry', () => {
 				'explain this code',
 				'ai',
 				undefined,
+				undefined,
 				undefined
 			);
 		});
@@ -412,7 +415,14 @@ describe('CallbackRegistry', () => {
 
 			await registry.executeCommand('session-5', 'follow up', 'ai', 'tab-xyz');
 
-			expect(callback).toHaveBeenCalledWith('session-5', 'follow up', 'ai', 'tab-xyz', undefined);
+			expect(callback).toHaveBeenCalledWith(
+				'session-5',
+				'follow up',
+				'ai',
+				'tab-xyz',
+				undefined,
+				undefined
+			);
 		});
 
 		it('passes force argument to the callback so `dispatch --force` survives the WebSocket boundary', async () => {
@@ -421,7 +431,38 @@ describe('CallbackRegistry', () => {
 
 			await registry.executeCommand('session-5', 'concurrent write', 'ai', undefined, true);
 
-			expect(callback).toHaveBeenCalledWith('session-5', 'concurrent write', 'ai', undefined, true);
+			expect(callback).toHaveBeenCalledWith(
+				'session-5',
+				'concurrent write',
+				'ai',
+				undefined,
+				true,
+				undefined
+			);
+		});
+
+		it('passes images argument so pasted attachments survive the boundary', async () => {
+			const callback = vi.fn().mockResolvedValue(true);
+			registry.setExecuteCommandCallback(callback);
+
+			const images = ['data:image/png;base64,abc'];
+			await registry.executeCommand(
+				'session-5',
+				'look at this',
+				'ai',
+				undefined,
+				undefined,
+				images
+			);
+
+			expect(callback).toHaveBeenCalledWith(
+				'session-5',
+				'look at this',
+				'ai',
+				undefined,
+				undefined,
+				images
+			);
 		});
 	});
 

--- a/src/__tests__/main/web-server/web-server-factory.test.ts
+++ b/src/__tests__/main/web-server/web-server-factory.test.ts
@@ -498,6 +498,7 @@ describe('web-server/web-server-factory', () => {
 				'test command',
 				'ai',
 				undefined,
+				undefined,
 				undefined
 			);
 		});
@@ -518,6 +519,7 @@ describe('web-server/web-server-factory', () => {
 				'follow up',
 				'ai',
 				'tab-7',
+				undefined,
 				undefined
 			);
 		});
@@ -538,7 +540,37 @@ describe('web-server/web-server-factory', () => {
 				'concurrent write',
 				'ai',
 				undefined,
-				true
+				true,
+				undefined
+			);
+		});
+
+		it('forwards images so pasted attachments reach the renderer alongside the prompt', async () => {
+			const createWebServer = createWebServerFactory(deps);
+			const server = createWebServer();
+
+			const setExecuteCallback = server.setExecuteCommandCallback as ReturnType<typeof vi.fn>;
+			const callback = setExecuteCallback.mock.calls[0][0];
+
+			const images = ['data:image/png;base64,abc', 'data:image/png;base64,def'];
+			const result = await callback(
+				'session-1',
+				'look at this',
+				'ai',
+				undefined,
+				undefined,
+				images
+			);
+
+			expect(result).toBe(true);
+			expect(mockWebContents.send).toHaveBeenCalledWith(
+				'remote:executeCommand',
+				'session-1',
+				'look at this',
+				'ai',
+				undefined,
+				undefined,
+				images
 			);
 		});
 

--- a/src/__tests__/renderer/hooks/useRemoteHandlers_stdin.test.ts
+++ b/src/__tests__/renderer/hooks/useRemoteHandlers_stdin.test.ts
@@ -57,6 +57,10 @@ vi.mock('../../../renderer/utils/sentry', () => ({
 	captureException: vi.fn(),
 }));
 
+vi.mock('../../../renderer/hooks/input/useInputProcessing', () => ({
+	DEFAULT_IMAGE_ONLY_PROMPT: 'Describe this image.',
+}));
+
 // ============================================================================
 // Now import the hook and stores
 // ============================================================================
@@ -456,5 +460,84 @@ describe('useRemoteHandlers - remote command stdin flags (integration)', () => {
 		expect(spawnCall.images).toEqual(images);
 		// hasImages=true switches the stream-json branch on (when supported).
 		expect(spawnCall.sendPromptViaStdin).toBe(true);
+	});
+
+	it('injects the image-only default prompt when the web client sends images with no text', async () => {
+		// Image-only sends (paste an image, hit send without typing) reach the
+		// renderer with command=''. Forwarding that empty string straight to the
+		// agent CLI crashes Claude Code (`--print ''` exits code 1). The remote
+		// handler must inject the user-customizable image-only default prompt,
+		// mirroring the desktop input path. Regression test for IMG-03 in
+		// PR #942.
+		(window as any).maestro.agents.get.mockResolvedValue({
+			id: 'claude-code',
+			command: 'claude',
+			path: '/usr/bin/claude',
+			args: [],
+			capabilities: { supportsStreamJsonInput: true },
+		});
+
+		const session = createMockSession();
+		const deps = createMockDeps({
+			sessionsRef: { current: [session] },
+		});
+
+		renderHook(() => useRemoteHandlers(deps));
+		const handler = getRemoteCommandHandler();
+
+		const images = ['data:image/png;base64,abc'];
+		await act(async () => {
+			await handler(
+				new CustomEvent('maestro:remoteCommand', {
+					detail: {
+						sessionId: 'session-1',
+						command: '',
+						inputMode: 'ai',
+						images,
+					},
+				})
+			);
+		});
+
+		expect((window as any).maestro.process.spawn).toHaveBeenCalled();
+		const spawnCall = (window as any).maestro.process.spawn.mock.calls[0][0];
+		// Empty command + images must be replaced with the default prompt.
+		expect(spawnCall.prompt).toBe('Describe this image.');
+		expect(spawnCall.images).toEqual(images);
+	});
+
+	it('preserves a user-supplied prompt when images are also present', async () => {
+		// Sanity check: the image-only fallback must not clobber a real prompt.
+		(window as any).maestro.agents.get.mockResolvedValue({
+			id: 'claude-code',
+			command: 'claude',
+			path: '/usr/bin/claude',
+			args: [],
+			capabilities: { supportsStreamJsonInput: true },
+		});
+
+		const session = createMockSession();
+		const deps = createMockDeps({
+			sessionsRef: { current: [session] },
+		});
+
+		renderHook(() => useRemoteHandlers(deps));
+		const handler = getRemoteCommandHandler();
+
+		await act(async () => {
+			await handler(
+				new CustomEvent('maestro:remoteCommand', {
+					detail: {
+						sessionId: 'session-1',
+						command: 'what do you see?',
+						inputMode: 'ai',
+						images: ['data:image/png;base64,abc'],
+					},
+				})
+			);
+		});
+
+		const spawnCall = (window as any).maestro.process.spawn.mock.calls[0][0];
+		expect(spawnCall.prompt).toBe('what do you see?');
 	});
 });

--- a/src/__tests__/renderer/hooks/useRemoteHandlers_stdin.test.ts
+++ b/src/__tests__/renderer/hooks/useRemoteHandlers_stdin.test.ts
@@ -537,6 +537,7 @@ describe('useRemoteHandlers - remote command stdin flags (integration)', () => {
 			);
 		});
 
+		expect((window as any).maestro.process.spawn).toHaveBeenCalled();
 		const spawnCall = (window as any).maestro.process.spawn.mock.calls[0][0];
 		expect(spawnCall.prompt).toBe('what do you see?');
 	});

--- a/src/__tests__/renderer/hooks/useRemoteHandlers_stdin.test.ts
+++ b/src/__tests__/renderer/hooks/useRemoteHandlers_stdin.test.ts
@@ -371,9 +371,12 @@ describe('useRemoteHandlers - remote command stdin flags (integration)', () => {
 		expect(spawnCall.sendPromptViaStdin).toBe(false);
 	});
 
-	it('should always pass hasImages=false for remote commands (sendPromptViaStdin is false)', async () => {
-		// Remote commands never send images, so sendPromptViaStdin should always be false
-		// even when the agent supports stream-json input
+	it('passes hasImages=false when the remote command carries no images', async () => {
+		// Remote commands without an `images` array (the typical desktop+CLI
+		// path, and any web client that didn't paste an image) must keep
+		// sendPromptViaStdin=false so the stream-json branch isn't taken.
+		// Web/mobile paste-image flow exercises the with-images branch
+		// elsewhere.
 		(window as any).maestro.agents.get.mockResolvedValue({
 			id: 'claude-code',
 			command: 'claude',
@@ -405,9 +408,53 @@ describe('useRemoteHandlers - remote command stdin flags (integration)', () => {
 		expect((window as any).maestro.process.spawn).toHaveBeenCalled();
 		const spawnCall = (window as any).maestro.process.spawn.mock.calls[0][0];
 
-		// sendPromptViaStdin requires hasImages=true, which remote commands never set
+		// sendPromptViaStdin requires hasImages=true; this command has no images.
 		expect(spawnCall.sendPromptViaStdin).toBe(false);
 		// Raw stdin should be used instead on Windows
 		expect(spawnCall.sendPromptViaStdinRaw).toBe(true);
+		// And no images should be threaded into the spawn payload.
+		expect(spawnCall.images).toBeUndefined();
+	});
+
+	it('threads pasted images into the spawn payload when the web client sends them', async () => {
+		// Web/mobile clients can paste images into the chat composer; the
+		// remote-command path forwards those base64 data URLs end-to-end so
+		// the agent can attach them to the prompt, mirroring the desktop
+		// stagedImages flow.
+		(window as any).maestro.agents.get.mockResolvedValue({
+			id: 'claude-code',
+			command: 'claude',
+			path: '/usr/bin/claude',
+			args: [],
+			capabilities: { supportsStreamJsonInput: true },
+		});
+
+		const session = createMockSession();
+		const deps = createMockDeps({
+			sessionsRef: { current: [session] },
+		});
+
+		renderHook(() => useRemoteHandlers(deps));
+		const handler = getRemoteCommandHandler();
+
+		const images = ['data:image/png;base64,abc'];
+		await act(async () => {
+			await handler(
+				new CustomEvent('maestro:remoteCommand', {
+					detail: {
+						sessionId: 'session-1',
+						command: 'what do you see?',
+						inputMode: 'ai',
+						images,
+					},
+				})
+			);
+		});
+
+		expect((window as any).maestro.process.spawn).toHaveBeenCalled();
+		const spawnCall = (window as any).maestro.process.spawn.mock.calls[0][0];
+		expect(spawnCall.images).toEqual(images);
+		// hasImages=true switches the stream-json branch on (when supported).
+		expect(spawnCall.sendPromptViaStdin).toBe(true);
 	});
 });

--- a/src/__tests__/renderer/hooks/useRemoteIntegration.test.ts
+++ b/src/__tests__/renderer/hooks/useRemoteIntegration.test.ts
@@ -326,6 +326,7 @@ describe('useRemoteIntegration', () => {
 						inputMode: 'ai',
 						tabId: undefined,
 						force: undefined,
+						images: undefined,
 					},
 				})
 			);

--- a/src/__tests__/web/mobile/CommandInputBar.test.tsx
+++ b/src/__tests__/web/mobile/CommandInputBar.test.tsx
@@ -322,7 +322,8 @@ describe('CommandInputBar', () => {
 			const form = screen.getByRole('textbox').closest('form');
 			fireEvent.submit(form!);
 
-			expect(onSubmit).toHaveBeenCalledWith('test command');
+			// Second arg is the staged-images array; undefined when no images pasted.
+			expect(onSubmit).toHaveBeenCalledWith('test command', undefined);
 		});
 
 		it('does not submit empty value', () => {
@@ -385,7 +386,8 @@ describe('CommandInputBar', () => {
 			const input = screen.getByRole('textbox');
 			fireEvent.keyDown(input, { key: 'Enter' });
 
-			expect(onSubmit).toHaveBeenCalledWith('test');
+			// Terminal mode never carries images, so the second arg is always undefined.
+			expect(onSubmit).toHaveBeenCalledWith('test', undefined);
 		});
 
 		it('Shift+Enter ALSO submits in terminal mode (single line input)', () => {
@@ -399,7 +401,7 @@ describe('CommandInputBar', () => {
 			const input = screen.getByRole('textbox');
 			fireEvent.keyDown(input, { key: 'Enter', shiftKey: true });
 
-			expect(onSubmit).toHaveBeenCalledWith('test');
+			expect(onSubmit).toHaveBeenCalledWith('test', undefined);
 		});
 	});
 

--- a/src/main/preload/process.ts
+++ b/src/main/preload/process.ts
@@ -301,7 +301,8 @@ export function createProcessApi() {
 				command: string,
 				inputMode?: 'ai' | 'terminal',
 				tabId?: string,
-				force?: boolean
+				force?: boolean,
+				images?: string[]
 			) => void
 		): (() => void) => {
 			log('Registering onRemoteCommand listener');
@@ -311,7 +312,8 @@ export function createProcessApi() {
 				command: string,
 				inputMode?: 'ai' | 'terminal',
 				tabId?: string,
-				force?: boolean
+				force?: boolean,
+				images?: string[]
 			) => {
 				log('Received remote:executeCommand IPC', {
 					sessionId,
@@ -319,9 +321,10 @@ export function createProcessApi() {
 					inputMode,
 					tabId,
 					force,
+					imageCount: images?.length ?? 0,
 				});
 				try {
-					callback(sessionId, command, inputMode, tabId, force);
+					callback(sessionId, command, inputMode, tabId, force, images);
 				} catch (error) {
 					ipcRenderer.invoke(
 						'logger:log',

--- a/src/main/web-server/WebServer.ts
+++ b/src/main/web-server/WebServer.ts
@@ -746,8 +746,10 @@ export class WebServer {
 				command: string,
 				inputMode?: 'ai' | 'terminal',
 				tabId?: string,
-				force?: boolean
-			) => this.callbackRegistry.executeCommand(sessionId, command, inputMode, tabId, force),
+				force?: boolean,
+				images?: string[]
+			) =>
+				this.callbackRegistry.executeCommand(sessionId, command, inputMode, tabId, force, images),
 			switchMode: async (sessionId: string, mode: 'ai' | 'terminal') =>
 				this.callbackRegistry.switchMode(sessionId, mode),
 			selectSession: async (sessionId: string, tabId?: string, focus?: boolean) =>

--- a/src/main/web-server/handlers/messageHandlers.ts
+++ b/src/main/web-server/handlers/messageHandlers.ts
@@ -163,7 +163,8 @@ export interface MessageHandlerCallbacks {
 		command: string,
 		inputMode?: 'ai' | 'terminal',
 		tabId?: string,
-		force?: boolean
+		force?: boolean,
+		images?: string[]
 	) => Promise<boolean>;
 	switchMode: (sessionId: string, mode: 'ai' | 'terminal') => Promise<boolean>;
 	selectSession: (sessionId: string, tabId?: string, focus?: boolean) => Promise<boolean>;

--- a/src/main/web-server/handlers/messageHandlers.ts
+++ b/src/main/web-server/handlers/messageHandlers.ts
@@ -593,6 +593,11 @@ export class WebSocketMessageHandler {
 		// dispatch concurrent writes to an already-running agent. Used by
 		// `maestro-cli dispatch --force`.
 		const force = message.force === true;
+		// Optional base64 data URLs pasted from the web client. Threaded through
+		// to the renderer so AI tabs can include them in the agent prompt.
+		const images = Array.isArray(message.images)
+			? (message.images as unknown[]).filter((v): v is string => typeof v === 'string')
+			: undefined;
 
 		logger.info(
 			`[Web Command] Received: sessionId=${sessionId}, inputMode=${clientInputMode}, command=${command?.substring(0, 50)}`,
@@ -660,7 +665,7 @@ export class WebSocketMessageHandler {
 		// Pass clientInputMode so renderer uses the web's intended mode
 		if (this.callbacks.executeCommand) {
 			this.callbacks
-				.executeCommand(sessionId, command, clientInputMode, requestedTabId, force)
+				.executeCommand(sessionId, command, clientInputMode, requestedTabId, force, images)
 				.then((success) => {
 					this.send(client, {
 						type: 'command_result',

--- a/src/main/web-server/handlers/messageHandlers.ts
+++ b/src/main/web-server/handlers/messageHandlers.ts
@@ -601,18 +601,24 @@ export class WebSocketMessageHandler {
 			: undefined;
 
 		logger.info(
-			`[Web Command] Received: sessionId=${sessionId}, inputMode=${clientInputMode}, command=${command?.substring(0, 50)}`,
+			`[Web Command] Received: sessionId=${sessionId}, inputMode=${clientInputMode}, command=${command?.substring(0, 50)}, images=${images?.length ?? 0}`,
 			LOG_CONTEXT
 		);
 
-		if (!sessionId || !command) {
+		// Image-only sends are valid in AI mode (the composer lets users paste
+		// images and submit without typing), so the guard accepts either a
+		// non-empty command OR at least one image. Normalize a missing command
+		// to '' so the renderer's downstream LogEntry.text stays a string.
+		const hasImages = !!images && images.length > 0;
+		if (!sessionId || (!command && !hasImages)) {
 			logger.warn(
-				`[Web Command] Missing sessionId or command: sessionId=${sessionId}, commandLen=${command?.length}`,
+				`[Web Command] Missing sessionId or command/images: sessionId=${sessionId}, commandLen=${command?.length}, images=${images?.length ?? 0}`,
 				LOG_CONTEXT
 			);
 			this.sendError(client, 'Missing sessionId or command');
 			return;
 		}
+		const effectiveCommand = command ?? '';
 
 		// Get session details to check state and determine how to handle
 		const sessionDetail = this.callbacks.getSessionDetail?.(sessionId);
@@ -646,7 +652,7 @@ export class WebSocketMessageHandler {
 
 		// Log all web interface commands prominently
 		logger.info(
-			`[Web Command] Mode: ${mode} | Session: ${sessionId}${isAiMode ? ` | Claude: ${claudeId}` : ''} | Message: ${command}`,
+			`[Web Command] Mode: ${mode} | Session: ${sessionId}${isAiMode ? ` | Claude: ${claudeId}` : ''} | Message: ${effectiveCommand} | Images: ${images?.length ?? 0}`,
 			LOG_CONTEXT
 		);
 
@@ -666,7 +672,7 @@ export class WebSocketMessageHandler {
 		// Pass clientInputMode so renderer uses the web's intended mode
 		if (this.callbacks.executeCommand) {
 			this.callbacks
-				.executeCommand(sessionId, command, clientInputMode, requestedTabId, force, images)
+				.executeCommand(sessionId, effectiveCommand, clientInputMode, requestedTabId, force, images)
 				.then((success) => {
 					this.send(client, {
 						type: 'command_result',

--- a/src/main/web-server/managers/CallbackRegistry.ts
+++ b/src/main/web-server/managers/CallbackRegistry.ts
@@ -244,10 +244,11 @@ export class CallbackRegistry {
 		command: string,
 		inputMode?: 'ai' | 'terminal',
 		tabId?: string,
-		force?: boolean
+		force?: boolean,
+		images?: string[]
 	): Promise<boolean> {
 		if (!this.callbacks.executeCommand) return false;
-		return this.callbacks.executeCommand(sessionId, command, inputMode, tabId, force);
+		return this.callbacks.executeCommand(sessionId, command, inputMode, tabId, force, images);
 	}
 
 	async interruptSession(sessionId: string): Promise<boolean> {

--- a/src/main/web-server/types.ts
+++ b/src/main/web-server/types.ts
@@ -251,7 +251,8 @@ export type ExecuteCommandCallback = (
 	command: string,
 	inputMode?: 'ai' | 'terminal',
 	tabId?: string,
-	force?: boolean
+	force?: boolean,
+	images?: string[]
 ) => Promise<boolean>;
 
 /**

--- a/src/main/web-server/web-server-factory.ts
+++ b/src/main/web-server/web-server-factory.ts
@@ -370,7 +370,8 @@ export function createWebServerFactory(deps: WebServerFactoryDependencies) {
 				command: string,
 				inputMode?: 'ai' | 'terminal',
 				tabId?: string,
-				force?: boolean
+				force?: boolean,
+				images?: string[]
 			) => {
 				const mainWindow = getMainWindow();
 				if (!mainWindow) {
@@ -388,7 +389,7 @@ export function createWebServerFactory(deps: WebServerFactoryDependencies) {
 				// proprietary code, or PII; the full prompt goes to debug, which is
 				// only enabled by users who have explicitly opted in.
 				logger.info(
-					`[Web → Renderer] Forwarding command | Maestro: ${sessionId} | Claude: ${agentSessionId} | Mode: ${inputMode || 'auto'} | Tab: ${tabId || 'active'} | Force: ${force ? 'yes' : 'no'} | CommandLength: ${command.length}`,
+					`[Web → Renderer] Forwarding command | Maestro: ${sessionId} | Claude: ${agentSessionId} | Mode: ${inputMode || 'auto'} | Tab: ${tabId || 'active'} | Force: ${force ? 'yes' : 'no'} | Images: ${images?.length ?? 0} | CommandLength: ${command.length}`,
 					'WebServer'
 				);
 				logger.debug(
@@ -405,7 +406,8 @@ export function createWebServerFactory(deps: WebServerFactoryDependencies) {
 					command,
 					inputMode,
 					tabId,
-					force
+					force,
+					images
 				);
 				return true;
 			}

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -280,7 +280,8 @@ interface MaestroAPI {
 				command: string,
 				inputMode?: 'ai' | 'terminal',
 				tabId?: string,
-				force?: boolean
+				force?: boolean,
+				images?: string[]
 			) => void
 		) => () => void;
 		onRemoteSwitchMode: (

--- a/src/renderer/hooks/remote/useRemoteHandlers.ts
+++ b/src/renderer/hooks/remote/useRemoteHandlers.ts
@@ -23,6 +23,7 @@ import { gitService } from '../../services/git';
 import { captureException } from '../../utils/sentry';
 import { filterYoloArgs } from '../../utils/agentArgs';
 import { getStdinFlags, prepareMaestroSystemPrompt } from '../../utils/spawnHelpers';
+import { DEFAULT_IMAGE_ONLY_PROMPT } from '../input/useInputProcessing';
 import { logger } from '../../utils/logger';
 
 // ============================================================================
@@ -377,6 +378,14 @@ export function useRemoteHandlers(deps: UseRemoteHandlersDeps): UseRemoteHandler
 					);
 					return;
 				}
+			}
+
+			// Image-only sends (web/mobile composer paste with no text) arrive
+			// with an empty command. Inject the user-customizable image-only
+			// default prompt so the agent CLI doesn't crash on an empty --print
+			// arg, mirroring the desktop input path in useInputProcessing.
+			if (!promptToSend.trim() && images && images.length > 0) {
+				promptToSend = DEFAULT_IMAGE_ONLY_PROMPT;
 			}
 
 			try {

--- a/src/renderer/hooks/remote/useRemoteHandlers.ts
+++ b/src/renderer/hooks/remote/useRemoteHandlers.ts
@@ -129,6 +129,10 @@ export function useRemoteHandlers(deps: UseRemoteHandlersDeps): UseRemoteHandler
 				 *  server-side `force` bit so `dispatch --force` can land on a
 				 *  busy session without being dropped at this boundary. */
 				force?: boolean;
+				/** Optional base64 data URLs pasted from a web/mobile client.
+				 *  Forwarded to the agent spawn so AI tabs can render and send
+				 *  them in the prompt, mirroring desktop staged-images. */
+				images?: string[];
 			}>;
 			const {
 				sessionId,
@@ -136,6 +140,7 @@ export function useRemoteHandlers(deps: UseRemoteHandlersDeps): UseRemoteHandler
 				inputMode: webInputMode,
 				tabId: requestedTabId,
 				force,
+				images,
 			} = customEvent.detail;
 
 			logger.info('[Remote] Processing remote command via event:', undefined, {
@@ -417,10 +422,11 @@ export function useRemoteHandlers(deps: UseRemoteHandlersDeps): UseRemoteHandler
 				// exceeding the command line length limit. Remote commands may include
 				// substituted slash command prompts that can be very large.
 				const isSshSession = Boolean(session.sessionSshRemoteConfig?.enabled);
+				const remoteImages = images && images.length > 0 ? images : undefined;
 				const { sendPromptViaStdin, sendPromptViaStdinRaw } = getStdinFlags({
 					isSshSession,
 					supportsStreamJsonInput: agent.capabilities?.supportsStreamJsonInput ?? false,
-					hasImages: false, // Remote commands do not send images
+					hasImages: !!remoteImages,
 				});
 
 				logger.info('[Remote] Spawning agent:', undefined, {
@@ -433,6 +439,7 @@ export function useRemoteHandlers(deps: UseRemoteHandlersDeps): UseRemoteHandler
 					command: commandToUse,
 					args: spawnArgs,
 					prompt: promptToSend.substring(0, 100),
+					imageCount: remoteImages?.length ?? 0,
 				});
 
 				// Add user message to target tab's logs and set state to busy
@@ -441,6 +448,7 @@ export function useRemoteHandlers(deps: UseRemoteHandlersDeps): UseRemoteHandler
 					timestamp: Date.now(),
 					source: 'user',
 					text: promptToSend,
+					...(remoteImages && { images: remoteImages }),
 					...(commandMetadata && { aiCommand: commandMetadata }),
 				};
 
@@ -495,6 +503,7 @@ export function useRemoteHandlers(deps: UseRemoteHandlersDeps): UseRemoteHandler
 					command: commandToUse,
 					args: spawnArgs,
 					prompt: promptToSend,
+					images: remoteImages,
 					appendSystemPrompt,
 					agentSessionId: tabAgentSessionId ?? undefined,
 					readOnlyMode: isReadOnly,

--- a/src/renderer/hooks/remote/useRemoteIntegration.ts
+++ b/src/renderer/hooks/remote/useRemoteIntegration.ts
@@ -87,7 +87,8 @@ export function useRemoteIntegration(deps: UseRemoteIntegrationDeps): UseRemoteI
 				command: string,
 				inputMode?: 'ai' | 'terminal',
 				tabId?: string,
-				force?: boolean
+				force?: boolean,
+				images?: string[]
 			) => {
 				// Log metadata only at info level — remote commands can carry
 				// secrets, proprietary code, or PII. Mirror the redaction the
@@ -99,6 +100,7 @@ export function useRemoteIntegration(deps: UseRemoteIntegrationDeps): UseRemoteI
 					inputMode,
 					tabId,
 					force,
+					imageCount: images?.length ?? 0,
 				});
 				logger.debug('[useRemoteIntegration] onRemoteCommand preview:', undefined, {
 					sessionId,
@@ -164,6 +166,7 @@ export function useRemoteIntegration(deps: UseRemoteIntegrationDeps): UseRemoteI
 					inputMode,
 					tabId,
 					force,
+					imageCount: images?.length ?? 0,
 				});
 				logger.debug(
 					'[useRemoteIntegration] Dispatching maestro:remoteCommand preview:',
@@ -172,7 +175,7 @@ export function useRemoteIntegration(deps: UseRemoteIntegrationDeps): UseRemoteI
 				);
 				window.dispatchEvent(
 					new CustomEvent('maestro:remoteCommand', {
-						detail: { sessionId, command, inputMode, tabId, force },
+						detail: { sessionId, command, inputMode, tabId, force, images },
 					})
 				);
 				logger.info('[useRemoteIntegration] Event dispatched successfully');

--- a/src/web/hooks/useMobileSessionManagement.ts
+++ b/src/web/hooks/useMobileSessionManagement.ts
@@ -48,6 +48,10 @@ export interface LogEntry {
 	timestamp: number;
 	text: string;
 	source: 'user' | 'stdout' | 'stderr' | 'thinking' | 'tool';
+	/** Base64 data URLs attached to a user message (e.g. pasted images).
+	 *  Mirrors the renderer-side LogEntry.images so optimistic chat history
+	 *  shows the same attachments the agent receives. */
+	images?: string[];
 	metadata?: {
 		toolState?: {
 			name?: string;
@@ -187,7 +191,7 @@ export interface UseMobileSessionManagementReturn {
 	/** Handler to toggle bookmark on a session */
 	handleToggleBookmark: (sessionId: string) => void;
 	/** Add a user input log entry to session logs */
-	addUserLogEntry: (text: string, inputMode: 'ai' | 'terminal') => void;
+	addUserLogEntry: (text: string, inputMode: 'ai' | 'terminal', images?: string[]) => void;
 	/** WebSocket handlers for session state updates */
 	sessionsHandlers: MobileSessionHandlers;
 }
@@ -455,18 +459,22 @@ export function useMobileSessionManagement(
 	);
 
 	// Add a user input log entry to session logs
-	const addUserLogEntry = useCallback((text: string, inputMode: 'ai' | 'terminal') => {
-		const userLogEntry: LogEntry = {
-			id: `user-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
-			timestamp: Date.now(),
-			text,
-			source: 'user',
-		};
-		setSessionLogs((prev) => {
-			const logKey = inputMode === 'ai' ? 'aiLogs' : 'shellLogs';
-			return { ...prev, [logKey]: [...prev[logKey], userLogEntry] };
-		});
-	}, []);
+	const addUserLogEntry = useCallback(
+		(text: string, inputMode: 'ai' | 'terminal', images?: string[]) => {
+			const userLogEntry: LogEntry = {
+				id: `user-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
+				timestamp: Date.now(),
+				text,
+				source: 'user',
+				...(images && images.length > 0 ? { images } : {}),
+			};
+			setSessionLogs((prev) => {
+				const logKey = inputMode === 'ai' ? 'aiLogs' : 'shellLogs';
+				return { ...prev, [logKey]: [...prev[logKey], userLogEntry] };
+			});
+		},
+		[]
+	);
 
 	// WebSocket handlers for session updates
 	const sessionsHandlers = useMemo(

--- a/src/web/mobile/App.tsx
+++ b/src/web/mobile/App.tsx
@@ -1958,13 +1958,23 @@ export default function MobileApp() {
 			// Provide haptic feedback on send
 			triggerHaptic(HAPTIC_PATTERNS.send);
 
-			// Add user message to session logs immediately for display
-			addUserLogEntry(command, currentMode);
+			// Offline path: refuse to queue when images are staged. Our offline
+			// queue can't carry image payloads, so silently dropping them
+			// would mislead the user. Bail out early so the composer keeps
+			// the staged images for retry once the connection is back.
+			if ((isOffline || !isActuallyConnected) && effectiveImages?.length) {
+				webLogger.warn(
+					'Cannot queue pasted images while offline. Reconnect and resend with images.',
+					'Mobile'
+				);
+				return;
+			}
 
-			// If offline or not connected, queue the command for later.
-			// NOTE: the offline queue currently doesn't carry images — pasted
-			// images are dropped on offline send. Acceptable for v1; users can
-			// re-paste when reconnected.
+			// Add user message to session logs immediately for display
+			addUserLogEntry(command, currentMode, effectiveImages);
+
+			// If offline or not connected, queue the (image-free) command for
+			// later. Image-bearing sends were rejected above.
 			if (isOffline || !isActuallyConnected) {
 				const queued = queueCommand(activeSessionId, command, currentMode);
 				if (queued) {

--- a/src/web/mobile/App.tsx
+++ b/src/web/mobile/App.tsx
@@ -1946,11 +1946,14 @@ export default function MobileApp() {
 
 	// Handle command submission
 	const handleCommandSubmit = useCallback(
-		(command: string) => {
+		(command: string, images?: string[]) => {
 			if (!activeSessionId) return;
 
 			// Find the active session to get input mode
 			const currentMode = currentInputMode;
+			// Images are AI-mode only — terminal commands have no image concept.
+			const effectiveImages =
+				currentMode === 'ai' && images && images.length > 0 ? images : undefined;
 
 			// Provide haptic feedback on send
 			triggerHaptic(HAPTIC_PATTERNS.send);
@@ -1958,7 +1961,10 @@ export default function MobileApp() {
 			// Add user message to session logs immediately for display
 			addUserLogEntry(command, currentMode);
 
-			// If offline or not connected, queue the command for later
+			// If offline or not connected, queue the command for later.
+			// NOTE: the offline queue currently doesn't carry images — pasted
+			// images are dropped on offline send. Acceptable for v1; users can
+			// re-paste when reconnected.
 			if (isOffline || !isActuallyConnected) {
 				const queued = queueCommand(activeSessionId, command, currentMode);
 				if (queued) {
@@ -1976,9 +1982,10 @@ export default function MobileApp() {
 					sessionId: activeSessionId,
 					command,
 					inputMode: currentMode,
+					...(effectiveImages ? { images: effectiveImages } : {}),
 				});
 				webLogger.info(
-					`[Web->Server] Command send result: ${sendResult}, command="${command.substring(0, 50)}" mode=${currentMode} session=${activeSessionId}`,
+					`[Web->Server] Command send result: ${sendResult}, command="${command.substring(0, 50)}" mode=${currentMode} session=${activeSessionId} images=${effectiveImages?.length ?? 0}`,
 					'Mobile'
 				);
 			}

--- a/src/web/mobile/CommandInputBar.tsx
+++ b/src/web/mobile/CommandInputBar.tsx
@@ -25,6 +25,7 @@
 
 import React, { useRef, useEffect, useState, useCallback } from 'react';
 import { useThemeColors } from '../components/ThemeProvider';
+import { webLogger } from '../utils/logger';
 import { useSwipeUp } from '../hooks/useSwipeUp';
 import { useVoiceInput } from '../hooks/useVoiceInput';
 import { useKeyboardVisibility } from '../hooks/useKeyboardVisibility';
@@ -70,6 +71,16 @@ const MOBILE_MAX_WIDTH = 480;
 
 /** Height of expanded input on mobile (50% of viewport) */
 const MOBILE_EXPANDED_HEIGHT_VH = 50;
+
+/** Maximum number of staged images per message. Prevents pathological pastes
+ *  from producing multi-megabyte WebSocket frames or stalling the renderer. */
+const MAX_STAGED_IMAGES = 5;
+
+/** Maximum decoded byte size accepted per pasted image. Base64 inflates
+ *  payloads ~33%, so a 2 MB raw image becomes ~2.7 MB on the wire — high
+ *  enough to cover screenshots, low enough to keep a single message well
+ *  under typical WebSocket frame budgets. */
+const MAX_IMAGE_BYTES = 2 * 1024 * 1024;
 
 /**
  * Detect if the device is a mobile phone (not tablet/desktop)
@@ -207,11 +218,13 @@ export function CommandInputBar({
 	const [internalValue, setInternalValue] = useState('');
 	const value = controlledValue !== undefined ? controlledValue : internalValue;
 
-	// Staged images pasted into AI mode. Mirrors desktop's `stagedImages`:
-	// stored as base64 data URLs and shipped alongside the prompt on submit.
-	// Local-only state (the web client doesn't need to round-trip this through
-	// the server) and intentionally cleared on send to avoid double-attaching.
-	const [stagedImages, setStagedImages] = useState<string[]>([]);
+	// Staged images pasted into AI mode. Each entry pairs the base64 data URL
+	// with a short stable id so React reconciliation doesn't have to compare
+	// the full data URL on every render (which can be hundreds of KB) and so
+	// duplicate-image rejection can't produce duplicate keys. Mirrors
+	// desktop's `stagedImages` semantics: local-only state, cleared on send.
+	const [stagedImages, setStagedImages] = useState<{ id: string; dataUrl: string }[]>([]);
+	const stagedImageIdSeq = useRef(0);
 
 	// Determine if input should be disabled (must be before hooks that use it)
 	// In AI mode: NEVER disable the input - user can always prep next message
@@ -279,6 +292,12 @@ export function CommandInputBar({
 	// Separate flag for whether send is blocked (AI thinking)
 	// When true, shows X button instead of send button
 	const isSendBlocked = inputMode === 'ai' && isSessionBusy;
+
+	// Disable send when there's no text AND no AI-mode image attachments.
+	// Image-only sends are explicitly AI-mode only — terminal mode never
+	// considers staged images as a reason to enable the send button.
+	const isSendDisabledForCurrentInput =
+		isDisabled || (!value.trim() && (inputMode !== 'ai' || stagedImages.length === 0));
 
 	// Get placeholder text based on state
 	const getPlaceholder = () => {
@@ -349,6 +368,12 @@ export function CommandInputBar({
 	 * push them onto `stagedImages`. Only active in AI mode (terminal mode
 	 * doesn't have a meaningful image-attach concept). Text paste is left to
 	 * the browser default so existing autocomplete/expansion logic stays put.
+	 *
+	 * Enforces both a count cap (MAX_STAGED_IMAGES) and a per-image byte cap
+	 * (MAX_IMAGE_BYTES) so a runaway paste can't produce multi-megabyte
+	 * WebSocket frames. Failures (oversize image, FileReader error) are
+	 * logged via webLogger so they're visible in production — silent drops
+	 * would mislead users into thinking the attachment was sent.
 	 */
 	const handlePaste = useCallback(
 		(e: React.ClipboardEvent<HTMLTextAreaElement | HTMLInputElement>) => {
@@ -365,11 +390,39 @@ export function CommandInputBar({
 					e.preventDefault();
 					consumed = true;
 				}
+				if (blob.size > MAX_IMAGE_BYTES) {
+					webLogger.warn(
+						`Pasted image exceeds ${MAX_IMAGE_BYTES} byte cap (got ${blob.size}); dropping`,
+						'CommandInputBar'
+					);
+					continue;
+				}
 				const reader = new FileReader();
 				reader.onload = (event) => {
 					const result = event.target?.result;
 					if (typeof result !== 'string') return;
-					setStagedImages((prev) => (prev.includes(result) ? prev : [...prev, result]));
+					setStagedImages((prev) => {
+						if (prev.length >= MAX_STAGED_IMAGES) {
+							webLogger.warn(
+								`Staged image cap reached (${MAX_STAGED_IMAGES}); dropping additional paste`,
+								'CommandInputBar'
+							);
+							return prev;
+						}
+						if (prev.some((entry) => entry.dataUrl === result)) return prev;
+						stagedImageIdSeq.current += 1;
+						return [...prev, { id: `img-${stagedImageIdSeq.current}`, dataUrl: result }];
+					});
+				};
+				reader.onerror = () => {
+					// Surface the failure rather than silently swallowing it —
+					// without this the user would see the paste 'work' (event
+					// fired, no error in console) but no thumbnail would appear.
+					webLogger.error(
+						`FileReader failed to decode pasted image (${item.type})`,
+						'CommandInputBar',
+						reader.error ?? undefined
+					);
 				};
 				reader.readAsDataURL(blob);
 			}
@@ -396,19 +449,21 @@ export function CommandInputBar({
 	);
 
 	/**
-	 * Handle form submission
+	 * Handle form submission. Image attachments are AI-mode only — terminal
+	 * sends ignore any staged images entirely so a user who pasted images and
+	 * then switched to terminal can't accidentally ship them as a payload.
 	 */
 	const handleSubmit = useCallback(
 		(e: React.FormEvent) => {
 			e.preventDefault();
-			const hasImages = stagedImages.length > 0;
+			const hasImages = inputMode === 'ai' && stagedImages.length > 0;
 			if (isDisabled) return;
 			if (!value.trim() && !hasImages) return;
 
 			// Trigger haptic feedback on successful send
 			triggerHaptic(25);
 
-			onSubmit?.(value.trim(), hasImages ? stagedImages : undefined);
+			onSubmit?.(value.trim(), hasImages ? stagedImages.map((entry) => entry.dataUrl) : undefined);
 
 			// Clear input after submit (for uncontrolled mode)
 			if (controlledValue === undefined) {
@@ -419,7 +474,7 @@ export function CommandInputBar({
 			// Keep focus on textarea after submit
 			textareaRef.current?.focus();
 		},
-		[value, isDisabled, onSubmit, controlledValue, stagedImages]
+		[value, isDisabled, onSubmit, controlledValue, stagedImages, inputMode]
 	);
 
 	/**
@@ -515,19 +570,20 @@ export function CommandInputBar({
 	}, [isExpanded, isMobilePhone, inputMode]);
 
 	/**
-	 * Collapse input when submitting on mobile
+	 * Collapse input when submitting on mobile. Same AI-mode image gating as
+	 * `handleSubmit` so terminal sends never carry image payloads.
 	 */
 	const handleMobileSubmit = useCallback(
 		(e: React.FormEvent) => {
 			e.preventDefault();
-			const hasImages = stagedImages.length > 0;
+			const hasImages = inputMode === 'ai' && stagedImages.length > 0;
 			if (isDisabled || isSendBlocked) return;
 			if (!value.trim() && !hasImages) return;
 
 			// Trigger haptic feedback on successful send
 			triggerHaptic(25);
 
-			onSubmit?.(value.trim(), hasImages ? stagedImages : undefined);
+			onSubmit?.(value.trim(), hasImages ? stagedImages.map((entry) => entry.dataUrl) : undefined);
 
 			// Clear input after submit (for uncontrolled mode)
 			if (controlledValue === undefined) {
@@ -634,7 +690,9 @@ export function CommandInputBar({
 				)}
 
 			{/* Staged images preview — base64 thumbnails of pasted images, with
-			    a remove button per item. AI mode only; matches desktop layout. */}
+			    a remove button per item. AI mode only; matches desktop layout.
+			    Stable ids are used as React keys so reconciliation doesn't
+			    have to compare full data URLs across renders. */}
 			{inputMode === 'ai' && stagedImages.length > 0 && (
 				<div
 					style={{
@@ -645,16 +703,16 @@ export function CommandInputBar({
 						padding: '0 16px 8px 16px',
 					}}
 				>
-					{stagedImages.map((img, idx) => (
+					{stagedImages.map((entry, idx) => (
 						<div
-							key={img}
+							key={entry.id}
 							style={{
 								position: 'relative',
 								flexShrink: 0,
 							}}
 						>
 							<img
-								src={img}
+								src={entry.dataUrl}
 								alt={`Staged image ${idx + 1}`}
 								style={{
 									height: '64px',
@@ -668,7 +726,7 @@ export function CommandInputBar({
 							<button
 								type="button"
 								onClick={() =>
-									setStagedImages((prev) => prev.filter((existing) => existing !== img))
+									setStagedImages((prev) => prev.filter((existing) => existing.id !== entry.id))
 								}
 								aria-label={`Remove staged image ${idx + 1}`}
 								style={{
@@ -777,7 +835,7 @@ export function CommandInputBar({
 					{/* Full-width send button below textarea */}
 					<ExpandedModeSendInterruptButton
 						isInterruptMode={inputMode === 'ai' && isSessionBusy}
-						isSendDisabled={isDisabled || (!value.trim() && stagedImages.length === 0)}
+						isSendDisabled={isSendDisabledForCurrentInput}
 						onInterrupt={handleInterrupt}
 					/>
 				</form>
@@ -875,7 +933,7 @@ export function CommandInputBar({
 							</div>
 							<SendInterruptButton
 								isInterruptMode={false}
-								isSendDisabled={isDisabled || (!value.trim() && stagedImages.length === 0)}
+								isSendDisabled={isSendDisabledForCurrentInput}
 								onInterrupt={handleInterrupt}
 								sendButtonRef={sendButtonRef}
 								onTouchStart={handleSendButtonTouchStart}
@@ -1034,7 +1092,7 @@ export function CommandInputBar({
 									<div style={{ marginLeft: 'auto' }}>
 										<SendInterruptButton
 											isInterruptMode={inputMode === 'ai' && isSessionBusy}
-											isSendDisabled={isDisabled || (!value.trim() && stagedImages.length === 0)}
+											isSendDisabled={isSendDisabledForCurrentInput}
 											onInterrupt={handleInterrupt}
 											sendButtonRef={sendButtonRef}
 											onTouchStart={handleSendButtonTouchStart}
@@ -1046,7 +1104,7 @@ export function CommandInputBar({
 							) : (
 								<SendInterruptButton
 									isInterruptMode={inputMode === 'ai' && isSessionBusy}
-									isSendDisabled={isDisabled || (!value.trim() && stagedImages.length === 0)}
+									isSendDisabled={isSendDisabledForCurrentInput}
 									onInterrupt={handleInterrupt}
 									sendButtonRef={sendButtonRef}
 									onTouchStart={handleSendButtonTouchStart}

--- a/src/web/mobile/CommandInputBar.tsx
+++ b/src/web/mobile/CommandInputBar.tsx
@@ -102,8 +102,14 @@ export interface CommandInputBarProps {
 	isConnected: boolean;
 	/** Placeholder text for the input */
 	placeholder?: string;
-	/** Callback when command is submitted */
-	onSubmit?: (command: string) => void;
+	/**
+	 * Callback when command is submitted.
+	 * `images` is an optional array of base64 data URLs from the staged-image
+	 * tray (populated via clipboard paste). Mirrors the desktop `stagedImages`
+	 * shape so the renderer's remote-command path can spawn the agent with
+	 * the same payload.
+	 */
+	onSubmit?: (command: string, images?: string[]) => void;
 	/** Callback when input value changes */
 	onChange?: (value: string) => void;
 	/** Current input value (controlled) */
@@ -200,6 +206,12 @@ export function CommandInputBar({
 	// Internal state for uncontrolled mode
 	const [internalValue, setInternalValue] = useState('');
 	const value = controlledValue !== undefined ? controlledValue : internalValue;
+
+	// Staged images pasted into AI mode. Mirrors desktop's `stagedImages`:
+	// stored as base64 data URLs and shipped alongside the prompt on submit.
+	// Local-only state (the web client doesn't need to round-trip this through
+	// the server) and intentionally cleared on send to avoid double-attaching.
+	const [stagedImages, setStagedImages] = useState<string[]>([]);
 
 	// Determine if input should be disabled (must be before hooks that use it)
 	// In AI mode: NEVER disable the input - user can always prep next message
@@ -333,6 +345,39 @@ export function CommandInputBar({
 	}, [value]);
 
 	/**
+	 * Handle clipboard paste — extract any image items, base64-encode them, and
+	 * push them onto `stagedImages`. Only active in AI mode (terminal mode
+	 * doesn't have a meaningful image-attach concept). Text paste is left to
+	 * the browser default so existing autocomplete/expansion logic stays put.
+	 */
+	const handlePaste = useCallback(
+		(e: React.ClipboardEvent<HTMLTextAreaElement | HTMLInputElement>) => {
+			if (inputMode !== 'ai') return;
+			const items = e.clipboardData?.items;
+			if (!items) return;
+			let consumed = false;
+			for (let i = 0; i < items.length; i++) {
+				const item = items[i];
+				if (!item.type.startsWith('image/')) continue;
+				const blob = item.getAsFile();
+				if (!blob) continue;
+				if (!consumed) {
+					e.preventDefault();
+					consumed = true;
+				}
+				const reader = new FileReader();
+				reader.onload = (event) => {
+					const result = event.target?.result;
+					if (typeof result !== 'string') return;
+					setStagedImages((prev) => (prev.includes(result) ? prev : [...prev, result]));
+				};
+				reader.readAsDataURL(blob);
+			}
+		},
+		[inputMode]
+	);
+
+	/**
 	 * Handle textarea change
 	 * Also detects slash commands and shows autocomplete via hook
 	 */
@@ -356,22 +401,25 @@ export function CommandInputBar({
 	const handleSubmit = useCallback(
 		(e: React.FormEvent) => {
 			e.preventDefault();
-			if (!value.trim() || isDisabled) return;
+			const hasImages = stagedImages.length > 0;
+			if (isDisabled) return;
+			if (!value.trim() && !hasImages) return;
 
 			// Trigger haptic feedback on successful send
 			triggerHaptic(25);
 
-			onSubmit?.(value.trim());
+			onSubmit?.(value.trim(), hasImages ? stagedImages : undefined);
 
 			// Clear input after submit (for uncontrolled mode)
 			if (controlledValue === undefined) {
 				setInternalValue('');
 			}
+			setStagedImages([]);
 
 			// Keep focus on textarea after submit
 			textareaRef.current?.focus();
 		},
-		[value, isDisabled, onSubmit, controlledValue]
+		[value, isDisabled, onSubmit, controlledValue, stagedImages]
 	);
 
 	/**
@@ -472,17 +520,20 @@ export function CommandInputBar({
 	const handleMobileSubmit = useCallback(
 		(e: React.FormEvent) => {
 			e.preventDefault();
-			if (!value.trim() || isDisabled || isSendBlocked) return;
+			const hasImages = stagedImages.length > 0;
+			if (isDisabled || isSendBlocked) return;
+			if (!value.trim() && !hasImages) return;
 
 			// Trigger haptic feedback on successful send
 			triggerHaptic(25);
 
-			onSubmit?.(value.trim());
+			onSubmit?.(value.trim(), hasImages ? stagedImages : undefined);
 
 			// Clear input after submit (for uncontrolled mode)
 			if (controlledValue === undefined) {
 				setInternalValue('');
 			}
+			setStagedImages([]);
 
 			// Collapse on mobile after submit
 			if (isMobilePhone && inputMode === 'ai') {
@@ -494,7 +545,16 @@ export function CommandInputBar({
 				textareaRef.current?.focus();
 			}
 		},
-		[value, isDisabled, isSendBlocked, onSubmit, controlledValue, isMobilePhone, inputMode]
+		[
+			value,
+			isDisabled,
+			isSendBlocked,
+			onSubmit,
+			controlledValue,
+			isMobilePhone,
+			inputMode,
+			stagedImages,
+		]
 	);
 
 	// Calculate textarea height for mobile expanded mode
@@ -573,6 +633,68 @@ export function CommandInputBar({
 					/>
 				)}
 
+			{/* Staged images preview — base64 thumbnails of pasted images, with
+			    a remove button per item. AI mode only; matches desktop layout. */}
+			{inputMode === 'ai' && stagedImages.length > 0 && (
+				<div
+					style={{
+						display: 'flex',
+						gap: '8px',
+						overflowX: 'auto',
+						overflowY: 'visible',
+						padding: '0 16px 8px 16px',
+					}}
+				>
+					{stagedImages.map((img, idx) => (
+						<div
+							key={img}
+							style={{
+								position: 'relative',
+								flexShrink: 0,
+							}}
+						>
+							<img
+								src={img}
+								alt={`Staged image ${idx + 1}`}
+								style={{
+									height: '64px',
+									maxWidth: '160px',
+									objectFit: 'contain',
+									borderRadius: '8px',
+									border: `1px solid ${colors.border}`,
+									display: 'block',
+								}}
+							/>
+							<button
+								type="button"
+								onClick={() =>
+									setStagedImages((prev) => prev.filter((existing) => existing !== img))
+								}
+								aria-label={`Remove staged image ${idx + 1}`}
+								style={{
+									position: 'absolute',
+									top: '-6px',
+									right: '-6px',
+									width: '22px',
+									height: '22px',
+									borderRadius: '50%',
+									backgroundColor: 'rgba(239, 68, 68, 0.95)',
+									color: 'white',
+									border: 'none',
+									cursor: 'pointer',
+									fontSize: '14px',
+									lineHeight: '22px',
+									padding: 0,
+									boxShadow: '0 1px 4px rgba(0,0,0,0.3)',
+								}}
+							>
+								×
+							</button>
+						</div>
+					))}
+				</div>
+			)}
+
 			{/* Slash command autocomplete popup */}
 			<SlashCommandAutocomplete
 				isOpen={slashCommandOpen}
@@ -607,6 +729,7 @@ export function CommandInputBar({
 						value={value}
 						onChange={handleChange}
 						onKeyDown={handleKeyDown}
+						onPaste={handlePaste}
 						placeholder={getPlaceholder()}
 						disabled={isDisabled}
 						autoComplete="off"
@@ -654,7 +777,7 @@ export function CommandInputBar({
 					{/* Full-width send button below textarea */}
 					<ExpandedModeSendInterruptButton
 						isInterruptMode={inputMode === 'ai' && isSessionBusy}
-						isSendDisabled={isDisabled || !value.trim()}
+						isSendDisabled={isDisabled || (!value.trim() && stagedImages.length === 0)}
 						onInterrupt={handleInterrupt}
 					/>
 				</form>
@@ -752,7 +875,7 @@ export function CommandInputBar({
 							</div>
 							<SendInterruptButton
 								isInterruptMode={false}
-								isSendDisabled={isDisabled || !value.trim()}
+								isSendDisabled={isDisabled || (!value.trim() && stagedImages.length === 0)}
 								onInterrupt={handleInterrupt}
 								sendButtonRef={sendButtonRef}
 								onTouchStart={handleSendButtonTouchStart}
@@ -800,6 +923,7 @@ export function CommandInputBar({
 								value={value}
 								onChange={handleChange}
 								onKeyDown={handleKeyDown}
+								onPaste={handlePaste}
 								placeholder={getPlaceholder()}
 								disabled={isDisabled}
 								autoComplete="off"
@@ -910,7 +1034,7 @@ export function CommandInputBar({
 									<div style={{ marginLeft: 'auto' }}>
 										<SendInterruptButton
 											isInterruptMode={inputMode === 'ai' && isSessionBusy}
-											isSendDisabled={isDisabled || !value.trim()}
+											isSendDisabled={isDisabled || (!value.trim() && stagedImages.length === 0)}
 											onInterrupt={handleInterrupt}
 											sendButtonRef={sendButtonRef}
 											onTouchStart={handleSendButtonTouchStart}
@@ -922,7 +1046,7 @@ export function CommandInputBar({
 							) : (
 								<SendInterruptButton
 									isInterruptMode={inputMode === 'ai' && isSessionBusy}
-									isSendDisabled={isDisabled || !value.trim()}
+									isSendDisabled={isDisabled || (!value.trim() && stagedImages.length === 0)}
 									onInterrupt={handleInterrupt}
 									sendButtonRef={sendButtonRef}
 									onTouchStart={handleSendButtonTouchStart}

--- a/src/web/mobile/MessageHistory.tsx
+++ b/src/web/mobile/MessageHistory.tsx
@@ -24,6 +24,10 @@ export interface LogEntry {
 	content?: string;
 	source?: 'user' | 'stdout' | 'stderr' | 'system' | 'thinking' | 'tool';
 	type?: string;
+	/** Base64 data URLs attached to a user message (e.g. pasted images).
+	 *  Rendered inline as thumbnails in the user-message bubble so the
+	 *  optimistic local chat shows the same attachments the agent receives. */
+	images?: string[];
 	metadata?: {
 		toolState?: {
 			name?: string;
@@ -463,6 +467,36 @@ export function MessageHistory({
 									textAlign: 'left',
 								}}
 							>
+								{/* Pasted-image attachments — only meaningful on user messages
+								    in AI mode. Rendered inline so the optimistic local chat
+								    shows the same thumbnails the user staged before send,
+								    matching the desktop transcript. */}
+								{isUser && entry.images && entry.images.length > 0 && (
+									<div
+										style={{
+											display: 'flex',
+											flexWrap: 'wrap',
+											gap: '6px',
+											marginBottom: '6px',
+										}}
+									>
+										{entry.images.map((dataUrl, imgIdx) => (
+											<img
+												key={`${messageKey}-img-${imgIdx}`}
+												src={dataUrl}
+												alt={`Attached image ${imgIdx + 1}`}
+												style={{
+													maxWidth: '160px',
+													maxHeight: '160px',
+													objectFit: 'contain',
+													borderRadius: '6px',
+													border: `1px solid ${colors.border}`,
+													display: 'block',
+												}}
+											/>
+										))}
+									</div>
+								)}
 								{inputMode === 'terminal' || isUser ? (
 									// Terminal output and user input: render as plain monospace text
 									<div


### PR DESCRIPTION
## Summary

- Web/mobile chat composer now accepts pasted images, matching desktop behavior. Images stage as base64 thumbnails above the textarea (with per-image remove buttons), ride the existing `send_command` WebSocket message, and reach the agent through the renderer's remote-command spawn path — same wiring desktop uses for `stagedImages`.
- Threaded an optional `images?: string[]` field end-to-end: `WebClientMessage` → `ExecuteCommandCallback` → `remote:executeCommand` IPC (7th arg) → preload → `maestro:remoteCommand` event → `useRemoteHandlers` → `getStdinFlags(hasImages)` + `process.spawn`. AI mode only; offline-queue path drops images for now (noted with a comment).

## Files

- Web UI: `src/web/mobile/CommandInputBar.tsx`, `src/web/mobile/App.tsx`
- Main / preload: `src/main/web-server/types.ts`, `src/main/web-server/handlers/messageHandlers.ts`, `src/main/web-server/web-server-factory.ts`, `src/main/preload/process.ts`
- Renderer: `src/renderer/global.d.ts`, `src/renderer/hooks/remote/useRemoteIntegration.ts`, `src/renderer/hooks/remote/useRemoteHandlers.ts`
- Tests: updated strict-arity assertions in `process.test.ts`, `web-server-factory.test.ts`, `useRemoteIntegration.test.ts`; refreshed stale comment in `useRemoteHandlers_stdin.test.ts` and added a new with-images spawn coverage test.

## Test plan

- [x] `npm run lint` clean for every modified file
- [x] `npx prettier --check` clean for every modified file
- [x] All 146 tests across the 5 affected suites pass (`process.test.ts`, `web-server-factory.test.ts`, `useRemoteIntegration.test.ts`, `useRemoteHandlers.test.ts`, `useRemoteHandlers_stdin.test.ts`)
- [x] Manual smoke: launch `npm run dev`, paste an image into the mobile web composer, verify the thumbnail renders, send, and confirm the agent receives the image alongside the prompt
- [x] Manual smoke: paste multiple images, verify duplicate dedupe and × remove button
- [x] Manual smoke: image-only send (no text) works in AI mode; terminal mode is unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remote commands can include image attachments end-to-end. UI supports paste-to-stage images in AI mode with thumbnails, per-image remove, size/count limits, dedupe, and image-only AI sends; offline sends refuse to queue images.

* **Bug Fixes / Behavior**
  * Stdin/spawn routing and prompt logic updated for image-only and mixed text+image commands; image counts are logged and forwarded.

* **Tests**
  * Tests updated to cover image forwarding, image-only submissions, and adjusted message payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->