### PR TITLE
fix(worktrees): filter discovered worktrees by parent repo identity

### DIFF
--- a/src/__tests__/renderer/hooks/useWorktreeHandlers.test.ts
+++ b/src/__tests__/renderer/hooks/useWorktreeHandlers.test.ts
@@ -470,6 +470,60 @@ describe('handleSaveWorktreeConfig', () => {
 
 		expect(mockGit.scanWorktreeDirectory).not.toHaveBeenCalled();
 	});
+
+	it('filters out scanned subdirs whose repoRoot does not match the parent repo', async () => {
+		// Same repo-identity guard as scanWorktreeConfigs, applied at the moment
+		// the user saves the worktree config. Without this, pointing the agent
+		// at a basePath that contains worktrees from another repo would attach
+		// them on the spot, before any later rescan could clean up.
+		useSessionStore.setState({
+			sessions: [
+				{
+					...mockParentSession,
+					cwd: '/repos/repo-a',
+					worktreeConfig: undefined,
+				},
+			],
+			activeSessionId: 'parent-1',
+		} as any);
+
+		mockGit.worktreeInfo.mockResolvedValueOnce({
+			success: true,
+			exists: true,
+			isWorktree: false,
+			repoRoot: '/repos/repo-a',
+		});
+
+		mockGit.scanWorktreeDirectory.mockResolvedValue({
+			gitSubdirs: [
+				{
+					path: '/shared/worktrees/feat-mine',
+					branch: 'feat-mine',
+					name: 'feat-mine',
+					repoRoot: '/repos/repo-a',
+				},
+				{
+					path: '/shared/worktrees/feat-other',
+					branch: 'feat-other',
+					name: 'feat-other',
+					repoRoot: '/repos/repo-b',
+				},
+			],
+		});
+
+		const { result } = renderHook(() => useWorktreeHandlers());
+
+		await act(async () => {
+			await result.current.handleSaveWorktreeConfig({
+				basePath: '/shared/worktrees',
+				watchEnabled: false,
+			});
+		});
+
+		const sessions = useSessionStore.getState().sessions;
+		const children = sessions.filter((s) => s.parentSessionId === 'parent-1');
+		expect(children.map((s) => s.worktreeBranch)).toEqual(['feat-mine']);
+	});
 });
 
 // ============================================================================
@@ -1976,6 +2030,7 @@ describe('Effects', () => {
 				sessionsLoaded: true,
 			} as any);
 
+			(notifyToast as any).mockClear();
 			renderHook(() => useWorktreeHandlers());
 
 			await act(async () => {
@@ -1985,6 +2040,90 @@ describe('Effects', () => {
 			const sessions = useSessionStore.getState().sessions;
 			expect(sessions.some((s) => s.id === 'wrong-agent-child')).toBe(false);
 			expect(sessions.some((s) => s.id === 'correct-child')).toBe(true);
+			// Wrong-agent detachments must NOT fire the misleading "Worktree Removed"
+			// toast — the worktree still exists on disk. Use "Worktree Re-assigned"
+			// (or no toast) so the user isn't told the worktree was deleted.
+			expect(notifyToast).not.toHaveBeenCalledWith(
+				expect.objectContaining({ title: 'Worktree Removed' })
+			);
+			expect(notifyToast).toHaveBeenCalledWith(
+				expect.objectContaining({ title: 'Worktree Re-assigned', message: 'feat-other' })
+			);
+		});
+
+		it('attaches wrong-agent child to the correct parent in the same scan pass', async () => {
+			// Regression for the "queued stale children block same-pass reattachment"
+			// edge case: parent-a flags a misattached child for detachment, then
+			// parent-b's iteration must NOT skip that path because of the
+			// (about-to-be-removed) wrong-agent session still in the store.
+			vi.useFakeTimers();
+
+			const parentA = {
+				...mockParentSession,
+				id: 'parent-a',
+				cwd: '/repos/repo-a',
+				worktreeConfig: { basePath: '/shared/worktrees', watchEnabled: false },
+			};
+			const parentB = {
+				...mockParentSession,
+				id: 'parent-b',
+				cwd: '/repos/repo-b',
+				worktreeConfig: { basePath: '/shared/worktrees', watchEnabled: false },
+			};
+
+			// Wrong-agent child: cwd is a worktree of repo-b but it's attached to parent-a
+			const wrongAgentChild = createChildSession({
+				id: 'wrong-agent-child',
+				cwd: '/shared/worktrees/feat-b',
+				worktreeBranch: 'feat-b',
+				parentSessionId: 'parent-a',
+			});
+
+			// First call (parent-a) → repo-a; second call (parent-b) → repo-b
+			mockGit.worktreeInfo
+				.mockResolvedValueOnce({
+					success: true,
+					exists: true,
+					isWorktree: false,
+					repoRoot: '/repos/repo-a',
+				})
+				.mockResolvedValueOnce({
+					success: true,
+					exists: true,
+					isWorktree: false,
+					repoRoot: '/repos/repo-b',
+				});
+
+			mockGit.scanWorktreeDirectory.mockResolvedValue({
+				gitSubdirs: [
+					{
+						path: '/shared/worktrees/feat-b',
+						branch: 'feat-b',
+						name: 'feat-b',
+						repoRoot: '/repos/repo-b',
+					},
+				],
+			});
+
+			useSessionStore.setState({
+				sessions: [parentA, parentB, wrongAgentChild],
+				activeSessionId: 'parent-a',
+				sessionsLoaded: true,
+			} as any);
+
+			renderHook(() => useWorktreeHandlers());
+
+			await act(async () => {
+				await vi.runAllTimersAsync();
+			});
+
+			const sessions = useSessionStore.getState().sessions;
+			// Old child gone, new child created under the correct parent in the same pass
+			expect(sessions.some((s) => s.id === 'wrong-agent-child')).toBe(false);
+			const childrenB = sessions.filter((s) => s.parentSessionId === 'parent-b');
+			expect(childrenB).toHaveLength(1);
+			expect(childrenB[0].worktreeBranch).toBe('feat-b');
+			expect(childrenB[0].cwd).toBe('/shared/worktrees/feat-b');
 		});
 
 		it('two parents sharing a basePath each receive only their own repo worktrees', async () => {

--- a/src/__tests__/renderer/hooks/useWorktreeHandlers.test.ts
+++ b/src/__tests__/renderer/hooks/useWorktreeHandlers.test.ts
@@ -50,6 +50,9 @@ const mockGit = {
 	onWorktreeRemoved: vi.fn().mockReturnValue(() => {}),
 	worktreeSetup: vi.fn().mockResolvedValue({ success: true }),
 	removeWorktree: vi.fn().mockResolvedValue({ success: true }),
+	// Default: not a git repo. Tests that exercise the repoRoot filter override
+	// this per-test to return matching/mismatching repoRoots.
+	worktreeInfo: vi.fn().mockResolvedValue({ success: true, exists: false, isWorktree: false }),
 };
 
 const mockParentSession = {
@@ -1857,6 +1860,411 @@ describe('Effects', () => {
 			unmount();
 
 			expect(cleanupFn).toHaveBeenCalled();
+		});
+	});
+
+	describe('Repo-identity filter (parent ↔ subdir.repoRoot match)', () => {
+		// Regression for the "worktrees re-added under a wrong agent" bug. After
+		// the worktree-wipe bug (PR #931 missing), the renderer would happily
+		// attach every worktree found under basePath to whichever parent agent's
+		// scan iterated first — even when those worktrees belonged to a different
+		// repo entirely.
+
+		it('filters out scanned subdirs whose repoRoot does not match the parent repo', async () => {
+			vi.useFakeTimers();
+
+			const parentWithConfig = {
+				...mockParentSession,
+				cwd: '/repos/repo-a',
+				worktreeConfig: { basePath: '/shared/worktrees', watchEnabled: false },
+			};
+
+			// Parent's main repo
+			mockGit.worktreeInfo.mockResolvedValueOnce({
+				success: true,
+				exists: true,
+				isWorktree: false,
+				repoRoot: '/repos/repo-a',
+			});
+
+			// Two subdirs in the basePath: one belongs to repo-a, the other to repo-b
+			mockGit.scanWorktreeDirectory.mockResolvedValue({
+				gitSubdirs: [
+					{
+						path: '/shared/worktrees/feat-mine',
+						branch: 'feat-mine',
+						name: 'feat-mine',
+						repoRoot: '/repos/repo-a',
+					},
+					{
+						path: '/shared/worktrees/feat-other',
+						branch: 'feat-other',
+						name: 'feat-other',
+						repoRoot: '/repos/repo-b',
+					},
+				],
+			});
+
+			useSessionStore.setState({
+				sessions: [parentWithConfig],
+				activeSessionId: 'parent-1',
+				sessionsLoaded: true,
+			} as any);
+
+			renderHook(() => useWorktreeHandlers());
+
+			await act(async () => {
+				await vi.runAllTimersAsync();
+			});
+
+			const sessions = useSessionStore.getState().sessions;
+			const children = sessions.filter((s) => s.parentSessionId === 'parent-1');
+			expect(children.map((s) => s.worktreeBranch).sort()).toEqual(['feat-mine']);
+		});
+
+		it('detaches a child whose cwd is a worktree of a different repo (self-heals wrong-agent attachment)', async () => {
+			vi.useFakeTimers();
+
+			const parentWithConfig = {
+				...mockParentSession,
+				cwd: '/repos/repo-a',
+				worktreeConfig: { basePath: '/shared/worktrees', watchEnabled: false },
+			};
+
+			// Wrong-agent child: was attached to repo-a's parent, but its cwd is
+			// actually a worktree of repo-b.
+			const wrongAgentChild = createChildSession({
+				id: 'wrong-agent-child',
+				cwd: '/shared/worktrees/feat-other',
+				worktreeBranch: 'feat-other',
+				parentSessionId: 'parent-1',
+			});
+			const correctChild = createChildSession({
+				id: 'correct-child',
+				cwd: '/shared/worktrees/feat-mine',
+				worktreeBranch: 'feat-mine',
+				parentSessionId: 'parent-1',
+			});
+
+			mockGit.worktreeInfo.mockResolvedValueOnce({
+				success: true,
+				exists: true,
+				isWorktree: false,
+				repoRoot: '/repos/repo-a',
+			});
+
+			mockGit.scanWorktreeDirectory.mockResolvedValue({
+				gitSubdirs: [
+					{
+						path: '/shared/worktrees/feat-mine',
+						branch: 'feat-mine',
+						name: 'feat-mine',
+						repoRoot: '/repos/repo-a',
+					},
+					{
+						path: '/shared/worktrees/feat-other',
+						branch: 'feat-other',
+						name: 'feat-other',
+						repoRoot: '/repos/repo-b',
+					},
+				],
+			});
+
+			useSessionStore.setState({
+				sessions: [parentWithConfig, wrongAgentChild, correctChild],
+				activeSessionId: 'parent-1',
+				sessionsLoaded: true,
+			} as any);
+
+			renderHook(() => useWorktreeHandlers());
+
+			await act(async () => {
+				await vi.runAllTimersAsync();
+			});
+
+			const sessions = useSessionStore.getState().sessions;
+			expect(sessions.some((s) => s.id === 'wrong-agent-child')).toBe(false);
+			expect(sessions.some((s) => s.id === 'correct-child')).toBe(true);
+		});
+
+		it('two parents sharing a basePath each receive only their own repo worktrees', async () => {
+			vi.useFakeTimers();
+
+			const parentA = {
+				...mockParentSession,
+				id: 'parent-a',
+				cwd: '/repos/repo-a',
+				worktreeConfig: { basePath: '/shared/worktrees', watchEnabled: false },
+			};
+			const parentB = {
+				...mockParentSession,
+				id: 'parent-b',
+				cwd: '/repos/repo-b',
+				worktreeConfig: { basePath: '/shared/worktrees', watchEnabled: false },
+			};
+
+			// First call (parent-a's scan) → resolve parent-a's repoRoot
+			// Second call (parent-b's scan) → resolve parent-b's repoRoot
+			mockGit.worktreeInfo
+				.mockResolvedValueOnce({
+					success: true,
+					exists: true,
+					isWorktree: false,
+					repoRoot: '/repos/repo-a',
+				})
+				.mockResolvedValueOnce({
+					success: true,
+					exists: true,
+					isWorktree: false,
+					repoRoot: '/repos/repo-b',
+				});
+
+			// Both parents see the same scan result (same basePath)
+			mockGit.scanWorktreeDirectory.mockResolvedValue({
+				gitSubdirs: [
+					{
+						path: '/shared/worktrees/feat-a',
+						branch: 'feat-a',
+						name: 'feat-a',
+						repoRoot: '/repos/repo-a',
+					},
+					{
+						path: '/shared/worktrees/feat-b',
+						branch: 'feat-b',
+						name: 'feat-b',
+						repoRoot: '/repos/repo-b',
+					},
+				],
+			});
+
+			useSessionStore.setState({
+				sessions: [parentA, parentB],
+				activeSessionId: 'parent-a',
+				sessionsLoaded: true,
+			} as any);
+
+			renderHook(() => useWorktreeHandlers());
+
+			await act(async () => {
+				await vi.runAllTimersAsync();
+			});
+
+			const sessions = useSessionStore.getState().sessions;
+			const childrenA = sessions.filter((s) => s.parentSessionId === 'parent-a');
+			const childrenB = sessions.filter((s) => s.parentSessionId === 'parent-b');
+			expect(childrenA.map((s) => s.worktreeBranch)).toEqual(['feat-a']);
+			expect(childrenB.map((s) => s.worktreeBranch)).toEqual(['feat-b']);
+		});
+
+		it('falls back to legacy behavior when the parent repoRoot cannot be resolved', async () => {
+			vi.useFakeTimers();
+
+			const parentWithConfig = {
+				...mockParentSession,
+				cwd: '/repos/not-a-git-repo',
+				worktreeConfig: { basePath: '/shared/worktrees', watchEnabled: false },
+			};
+
+			// worktreeInfo says the parent path isn't a git repo
+			mockGit.worktreeInfo.mockResolvedValueOnce({
+				success: true,
+				exists: false,
+				isWorktree: false,
+			});
+
+			mockGit.scanWorktreeDirectory.mockResolvedValue({
+				gitSubdirs: [
+					{
+						path: '/shared/worktrees/feat',
+						branch: 'feat',
+						name: 'feat',
+						repoRoot: '/repos/repo-a',
+					},
+				],
+			});
+
+			useSessionStore.setState({
+				sessions: [parentWithConfig],
+				activeSessionId: 'parent-1',
+				sessionsLoaded: true,
+			} as any);
+
+			renderHook(() => useWorktreeHandlers());
+
+			await act(async () => {
+				await vi.runAllTimersAsync();
+			});
+
+			// Fall-back path: when we can't determine the parent's repo, don't filter.
+			const children = useSessionStore
+				.getState()
+				.sessions.filter((s) => s.parentSessionId === 'parent-1');
+			expect(children).toHaveLength(1);
+			expect(children[0].worktreeBranch).toBe('feat');
+		});
+
+		it('falls back to legacy behavior when subdir.repoRoot is null', async () => {
+			vi.useFakeTimers();
+
+			const parentWithConfig = {
+				...mockParentSession,
+				cwd: '/repos/repo-a',
+				worktreeConfig: { basePath: '/shared/worktrees', watchEnabled: false },
+			};
+
+			mockGit.worktreeInfo.mockResolvedValueOnce({
+				success: true,
+				exists: true,
+				isWorktree: false,
+				repoRoot: '/repos/repo-a',
+			});
+
+			mockGit.scanWorktreeDirectory.mockResolvedValue({
+				gitSubdirs: [
+					{
+						path: '/shared/worktrees/feat',
+						branch: 'feat',
+						name: 'feat',
+						repoRoot: null,
+					},
+				],
+			});
+
+			useSessionStore.setState({
+				sessions: [parentWithConfig],
+				activeSessionId: 'parent-1',
+				sessionsLoaded: true,
+			} as any);
+
+			renderHook(() => useWorktreeHandlers());
+
+			await act(async () => {
+				await vi.runAllTimersAsync();
+			});
+
+			const children = useSessionStore
+				.getState()
+				.sessions.filter((s) => s.parentSessionId === 'parent-1');
+			expect(children).toHaveLength(1);
+		});
+
+		it('chokidar onWorktreeDiscovered rejects a worktree from a different repo', async () => {
+			let discoveryCallback: ((data: any) => Promise<void>) | undefined;
+			mockGit.onWorktreeDiscovered.mockImplementation((cb: any) => {
+				discoveryCallback = cb;
+				return () => {};
+			});
+
+			const parentWithWatch = {
+				...mockParentSession,
+				cwd: '/repos/repo-a',
+				worktreeConfig: { basePath: '/shared/worktrees', watchEnabled: true },
+			};
+
+			useSessionStore.setState({
+				sessions: [parentWithWatch],
+				activeSessionId: 'parent-1',
+				sessionsLoaded: false,
+			} as any);
+
+			renderHook(() => useWorktreeHandlers());
+
+			// First worktreeInfo call: the discovered worktree path → repo-b
+			// Second worktreeInfo call: the parent's cwd → repo-a
+			// (Renderer fires both in parallel via Promise.all, so order doesn't
+			// matter — we just need both to resolve to non-matching repos.)
+			mockGit.worktreeInfo.mockImplementation(async (path: string) => {
+				if (path === '/shared/worktrees/feat-other') {
+					return {
+						success: true,
+						exists: true,
+						isWorktree: true,
+						repoRoot: '/repos/repo-b',
+					};
+				}
+				if (path === '/repos/repo-a') {
+					return {
+						success: true,
+						exists: true,
+						isWorktree: false,
+						repoRoot: '/repos/repo-a',
+					};
+				}
+				return { success: true, exists: false, isWorktree: false };
+			});
+
+			await act(async () => {
+				await discoveryCallback!({
+					sessionId: 'parent-1',
+					worktree: {
+						path: '/shared/worktrees/feat-other',
+						name: 'feat-other',
+						branch: 'feat-other',
+					},
+				});
+			});
+
+			const sessions = useSessionStore.getState().sessions;
+			const children = sessions.filter((s) => s.parentSessionId === 'parent-1');
+			expect(children).toHaveLength(0);
+		});
+
+		it('chokidar onWorktreeDiscovered accepts a worktree from the matching repo', async () => {
+			let discoveryCallback: ((data: any) => Promise<void>) | undefined;
+			mockGit.onWorktreeDiscovered.mockImplementation((cb: any) => {
+				discoveryCallback = cb;
+				return () => {};
+			});
+
+			const parentWithWatch = {
+				...mockParentSession,
+				cwd: '/repos/repo-a',
+				worktreeConfig: { basePath: '/shared/worktrees', watchEnabled: true },
+			};
+
+			useSessionStore.setState({
+				sessions: [parentWithWatch],
+				activeSessionId: 'parent-1',
+				sessionsLoaded: false,
+			} as any);
+
+			renderHook(() => useWorktreeHandlers());
+
+			mockGit.worktreeInfo.mockImplementation(async (path: string) => {
+				if (path === '/shared/worktrees/feat-mine') {
+					return {
+						success: true,
+						exists: true,
+						isWorktree: true,
+						repoRoot: '/repos/repo-a',
+					};
+				}
+				if (path === '/repos/repo-a') {
+					return {
+						success: true,
+						exists: true,
+						isWorktree: false,
+						repoRoot: '/repos/repo-a',
+					};
+				}
+				return { success: true, exists: false, isWorktree: false };
+			});
+
+			await act(async () => {
+				await discoveryCallback!({
+					sessionId: 'parent-1',
+					worktree: {
+						path: '/shared/worktrees/feat-mine',
+						name: 'feat-mine',
+						branch: 'feat-mine',
+					},
+				});
+			});
+
+			const sessions = useSessionStore.getState().sessions;
+			const children = sessions.filter((s) => s.parentSessionId === 'parent-1');
+			expect(children).toHaveLength(1);
+			expect(children[0].worktreeBranch).toBe('feat-mine');
 		});
 	});
 });

--- a/src/__tests__/renderer/hooks/useWorktreeHandlers.test.ts
+++ b/src/__tests__/renderer/hooks/useWorktreeHandlers.test.ts
@@ -30,12 +30,21 @@ vi.mock('../../../renderer/utils/ids', () => ({
 	generateId: vi.fn(() => `mock-id-${++idCounter}`),
 }));
 
+// Mock sentry so the repo-root resolver tests can assert unexpected errors are
+// reported (silent swallowing would re-introduce the wrong-parent bug with no
+// production signal).
+vi.mock('../../../renderer/utils/sentry', () => ({
+	captureException: vi.fn(),
+	captureMessage: vi.fn(),
+}));
+
 import { useWorktreeHandlers } from '../../../renderer/hooks/worktree/useWorktreeHandlers';
 import { useModalStore, getModalActions } from '../../../renderer/stores/modalStore';
 import { useSessionStore } from '../../../renderer/stores/sessionStore';
 import { useSettingsStore } from '../../../renderer/stores/settingsStore';
 import { gitService } from '../../../renderer/services/git';
 import { notifyToast } from '../../../renderer/stores/notificationStore';
+import { captureException } from '../../../renderer/utils/sentry';
 import type { Session } from '../../../renderer/types';
 
 // ============================================================================
@@ -2404,6 +2413,126 @@ describe('Effects', () => {
 			const children = sessions.filter((s) => s.parentSessionId === 'parent-1');
 			expect(children).toHaveLength(1);
 			expect(children[0].worktreeBranch).toBe('feat-mine');
+		});
+
+		it('reports unexpected worktreeInfo errors to Sentry from resolveRepoRoot (does not silently swallow)', async () => {
+			vi.useFakeTimers();
+			const consoleSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+
+			const parentWithConfig = {
+				...mockParentSession,
+				cwd: '/repos/repo-a',
+				worktreeConfig: { basePath: '/shared/worktrees', watchEnabled: false },
+			};
+
+			// Simulate an unexpected IPC failure (e.g. main-process handler regressed
+			// or threw). Without the error-reporting fix, this would silently disable
+			// the repo-root guard with no production signal.
+			const unexpectedErr = new Error('IPC handler crashed');
+			mockGit.worktreeInfo.mockRejectedValueOnce(unexpectedErr);
+
+			mockGit.scanWorktreeDirectory.mockResolvedValue({
+				gitSubdirs: [
+					{
+						path: '/shared/worktrees/feat',
+						branch: 'feat',
+						name: 'feat',
+						repoRoot: '/repos/repo-a',
+					},
+				],
+			});
+
+			useSessionStore.setState({
+				sessions: [parentWithConfig],
+				activeSessionId: 'parent-1',
+				sessionsLoaded: true,
+			} as any);
+
+			(captureException as any).mockClear();
+			renderHook(() => useWorktreeHandlers());
+
+			await act(async () => {
+				await vi.runAllTimersAsync();
+			});
+
+			expect(captureException).toHaveBeenCalledWith(
+				unexpectedErr,
+				expect.objectContaining({
+					extra: expect.objectContaining({ source: 'resolveRepoRoot' }),
+				})
+			);
+			expect(consoleSpy).toHaveBeenCalledWith(
+				expect.stringContaining('resolveRepoRoot failed'),
+				undefined,
+				expect.stringContaining('IPC handler crashed')
+			);
+
+			consoleSpy.mockRestore();
+		});
+
+		it('reports unexpected worktreeInfo errors from the chokidar discovery handler', async () => {
+			let discoveryCallback: ((data: any) => Promise<void>) | undefined;
+			mockGit.onWorktreeDiscovered.mockImplementation((cb: any) => {
+				discoveryCallback = cb;
+				return () => {};
+			});
+
+			const consoleSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+
+			const parentWithWatch = {
+				...mockParentSession,
+				cwd: '/repos/repo-a',
+				worktreeConfig: { basePath: '/shared/worktrees', watchEnabled: true },
+			};
+
+			useSessionStore.setState({
+				sessions: [parentWithWatch],
+				activeSessionId: 'parent-1',
+				sessionsLoaded: false,
+			} as any);
+
+			renderHook(() => useWorktreeHandlers());
+
+			// Parent lookup succeeds; discovered-path lookup throws.
+			const unexpectedErr = new Error('renderer IPC bridge dropped');
+			mockGit.worktreeInfo.mockImplementation(async (path: string) => {
+				if (path === '/repos/repo-a') {
+					return {
+						success: true,
+						exists: true,
+						isWorktree: false,
+						repoRoot: '/repos/repo-a',
+					};
+				}
+				throw unexpectedErr;
+			});
+
+			(captureException as any).mockClear();
+
+			await act(async () => {
+				await discoveryCallback!({
+					sessionId: 'parent-1',
+					worktree: {
+						path: '/shared/worktrees/feat',
+						name: 'feat',
+						branch: 'feat',
+					},
+				});
+			});
+
+			expect(captureException).toHaveBeenCalledWith(
+				unexpectedErr,
+				expect.objectContaining({
+					extra: expect.objectContaining({ source: 'onWorktreeDiscovered' }),
+				})
+			);
+			expect(consoleSpy).toHaveBeenCalledWith(
+				expect.stringContaining('worktreeInfo failed'),
+				undefined,
+				expect.stringContaining('renderer IPC bridge dropped')
+			);
+
+			consoleSpy.mockRestore();
 		});
 	});
 });

--- a/src/renderer/hooks/worktree/useWorktreeHandlers.ts
+++ b/src/renderer/hooks/worktree/useWorktreeHandlers.ts
@@ -211,9 +211,24 @@ export function useWorktreeHandlers(): WorktreeHandlersReturn {
 				if (gitSubdirs.length > 0) {
 					const newWorktreeSessions: Session[] = [];
 
+					// Same repo-identity guard as scanWorktreeConfigs: if the user just
+					// pointed this agent at a basePath that contains worktrees from a
+					// different repo, skip those subdirs instead of attaching them.
+					const parentRepoRoot = await resolveRepoRoot(activeSession.cwd, parentSshRemoteId);
+
 					for (const subdir of gitSubdirs) {
 						// Skip main/master/HEAD branches — they're typically the main repo
 						if (isSkippableBranch(subdir.branch)) continue;
+
+						// Repo-identity check (mirrors scanWorktreeConfigs). Falls back to
+						// legacy behavior when either side can't be resolved.
+						if (
+							parentRepoRoot &&
+							subdir.repoRoot &&
+							normalizePath(subdir.repoRoot) !== parentRepoRoot
+						) {
+							continue;
+						}
 
 						// Check if session already exists (read latest state each iteration)
 						const latestSessions = useSessionStore.getState().sessions;
@@ -575,7 +590,13 @@ export function useWorktreeHandlers(): WorktreeHandlersReturn {
 		if (sessionsWithWorktreeConfig.length === 0) return;
 
 		const newWorktreeSessions: Session[] = [];
+		// Children that no longer exist on disk — surfaced as "Worktree Removed".
 		const staleSessionIds: string[] = [];
+		// Children whose cwd still exists but belongs to a different repo. Surfaced
+		// as "Worktree Re-assigned" instead of "Worktree Removed" so the user isn't
+		// told their worktree was deleted (it wasn't — it just attaches to the
+		// correct parent on the next scan / chokidar event).
+		const reassignedSessionIds: string[] = [];
 
 		for (const parentSession of sessionsWithWorktreeConfig) {
 			try {
@@ -613,7 +634,16 @@ export function useWorktreeHandlers(): WorktreeHandlersReturn {
 
 					const normalizedSubdirPath = normalizePath(subdir.path);
 					const latestSessions = useSessionStore.getState().sessions;
+					// Sessions queued for stale-removal or re-assignment are about to be
+					// detached at the end of this scan, so they must NOT block other
+					// parents in the same pass from creating the correct child. Without
+					// this, in the overlapping-basePath recovery case parent A would
+					// queue a wrong-agent child for detachment and parent B would skip
+					// the same path because the (about-to-be-removed) session still
+					// matches by cwd in the store.
+					const stalePending = new Set([...staleSessionIds, ...reassignedSessionIds]);
 					const existingSession = latestSessions.find((s) => {
+						if (stalePending.has(s.id)) return false;
 						const normalizedCwd = normalizePath(s.cwd);
 						return (
 							normalizedCwd === normalizedSubdirPath ||
@@ -692,7 +722,7 @@ export function useWorktreeHandlers(): WorktreeHandlersReturn {
 								logger.warn(
 									`[WorktreeScan] Detaching ${child.id} from ${parentSession.id}: child cwd ${child.cwd} belongs to repo ${subdirRepoRoot}, not parent's repo ${parentRepoRoot}`
 								);
-								staleSessionIds.push(child.id);
+								reassignedSessionIds.push(child.id);
 							}
 						}
 					}
@@ -704,6 +734,36 @@ export function useWorktreeHandlers(): WorktreeHandlersReturn {
 					err
 				);
 			}
+		}
+
+		// Apply removals BEFORE additions so the additions' cwd-dedup doesn't see
+		// soon-to-be-detached wrong-agent children and filter out the correct
+		// re-attached child. Without this ordering the same-pass recovery
+		// (parent A flags wrong-agent child stale, parent B creates the correct
+		// child for the same cwd) would silently drop the new child.
+		if (staleSessionIds.length > 0 || reassignedSessionIds.length > 0) {
+			const staleSet = new Set(staleSessionIds);
+			const reassignedSet = new Set(reassignedSessionIds);
+			const removalSet = new Set([...staleSessionIds, ...reassignedSessionIds]);
+			useSessionStore.getState().setSessions((prev) => {
+				const removed = prev.filter((s) => removalSet.has(s.id));
+				for (const s of removed) {
+					if (reassignedSet.has(s.id)) {
+						notifyToast({
+							type: 'info',
+							title: 'Worktree Re-assigned',
+							message: s.worktreeBranch || s.name,
+						});
+					} else if (staleSet.has(s.id)) {
+						notifyToast({
+							type: 'info',
+							title: 'Worktree Removed',
+							message: s.worktreeBranch || s.name,
+						});
+					}
+				}
+				return prev.filter((s) => !removalSet.has(s.id));
+			});
 		}
 
 		if (newWorktreeSessions.length > 0) {
@@ -720,21 +780,6 @@ export function useWorktreeHandlers(): WorktreeHandlersReturn {
 				.setSessions((prev) =>
 					prev.map((s) => (parentIds.has(s.id) ? { ...s, worktreesExpanded: true } : s))
 				);
-		}
-
-		if (staleSessionIds.length > 0) {
-			const staleSet = new Set(staleSessionIds);
-			useSessionStore.getState().setSessions((prev) => {
-				const removed = prev.filter((s) => staleSet.has(s.id));
-				for (const s of removed) {
-					notifyToast({
-						type: 'info',
-						title: 'Worktree Removed',
-						message: s.worktreeBranch || s.name,
-					});
-				}
-				return prev.filter((s) => !staleSet.has(s.id));
-			});
 		}
 	}, []);
 

--- a/src/renderer/hooks/worktree/useWorktreeHandlers.ts
+++ b/src/renderer/hooks/worktree/useWorktreeHandlers.ts
@@ -87,6 +87,27 @@ function isSkippableBranch(branch: string | null | undefined): boolean {
 	return branch === 'main' || branch === 'master' || branch === 'HEAD';
 }
 
+/**
+ * Resolve the canonical main-repo root for a path, normalized for comparison.
+ *
+ * Uses `worktreeInfo` (not `getRepoRoot`) so that when the path is itself a
+ * worktree, we get the *main* repo root (parent of `--git-common-dir`) rather
+ * than the worktree's own toplevel. This is what we need to verify that a
+ * scanned subdir actually belongs to the parent agent's repository.
+ *
+ * Returns null if the path isn't a git repo or the lookup fails — callers
+ * should treat null as "can't filter" and fall back to the legacy behavior.
+ */
+async function resolveRepoRoot(path: string, sshRemoteId?: string): Promise<string | null> {
+	try {
+		const info = await window.maestro.git.worktreeInfo(path, sshRemoteId);
+		if (!info.success || !info.exists || !info.repoRoot) return null;
+		return normalizePath(info.repoRoot);
+	} catch {
+		return null;
+	}
+}
+
 // buildWorktreeSession and BuildWorktreeSessionParams are imported from ../../utils/worktreeSession
 // normalizePath and sessionMatchesWorktreeRoot are imported from ../../utils/worktreeDedup
 
@@ -565,9 +586,30 @@ export function useWorktreeHandlers(): WorktreeHandlersReturn {
 				);
 				const { gitSubdirs, scanFailed } = scanResult;
 
+				// Resolve the parent's main repo root once so we can verify each scanned
+				// subdir actually belongs to *this* parent's repository. Without this,
+				// two parents whose basePaths overlap (or a basePath that contains
+				// worktrees from a different repo) would race — whichever parent's loop
+				// iterates first would grab every worktree, producing the "worktrees
+				// re-added under a wrong agent" bug after a wipe + restart.
+				const parentRepoRoot = await resolveRepoRoot(parentSession.cwd, sshRemoteId);
+
 				// Detect additions
 				for (const subdir of gitSubdirs) {
 					if (isSkippableBranch(subdir.branch)) continue;
+
+					// Repo-identity check: if we know both the parent's repo root and the
+					// subdir's repo root, skip subdirs that don't match. If either is
+					// missing (parent isn't a git repo, or git couldn't resolve the
+					// subdir's common-dir), fall back to the legacy "trust the basePath"
+					// behavior so we don't break setups that worked before.
+					if (
+						parentRepoRoot &&
+						subdir.repoRoot &&
+						normalizePath(subdir.repoRoot) !== parentRepoRoot
+					) {
+						continue;
+					}
 
 					const normalizedSubdirPath = normalizePath(subdir.path);
 					const latestSessions = useSessionStore.getState().sessions;
@@ -614,7 +656,14 @@ export function useWorktreeHandlers(): WorktreeHandlersReturn {
 						`[WorktreeScan] Skipping removal phase for ${parentSession.worktreeConfig!.basePath} — scan failed`
 					);
 				} else {
-					const diskPaths = new Set(gitSubdirs.map((d) => normalizePath(d.path)));
+					// Build a quick lookup from normalized subdir path → its repoRoot,
+					// so we can detect children that exist on disk but were attached to
+					// the wrong parent (the worktrees-under-wrong-agent recovery case).
+					const subdirByPath = new Map<string, { repoRoot: string | null }>();
+					for (const d of gitSubdirs) {
+						subdirByPath.set(normalizePath(d.path), { repoRoot: d.repoRoot });
+					}
+					const diskPaths = new Set(subdirByPath.keys());
 					const latestSessions = useSessionStore.getState().sessions;
 					const childSessions = latestSessions.filter(
 						(s) => s.parentSessionId === parentSession.id
@@ -625,7 +674,24 @@ export function useWorktreeHandlers(): WorktreeHandlersReturn {
 						);
 					} else {
 						for (const child of childSessions) {
-							if (!diskPaths.has(normalizePath(child.cwd))) {
+							const childPath = normalizePath(child.cwd);
+							if (!diskPaths.has(childPath)) {
+								staleSessionIds.push(child.id);
+								continue;
+							}
+							// Detach children whose cwd points at a worktree of a different
+							// repo than this parent. Without this, after the worktree-wipe
+							// bug the wrong-agent children would never get re-attached to
+							// the correct parent (the existing-session dedup would block it).
+							const subdirRepoRoot = subdirByPath.get(childPath)?.repoRoot ?? null;
+							if (
+								parentRepoRoot &&
+								subdirRepoRoot &&
+								normalizePath(subdirRepoRoot) !== parentRepoRoot
+							) {
+								logger.warn(
+									`[WorktreeScan] Detaching ${child.id} from ${parentSession.id}: child cwd ${child.cwd} belongs to repo ${subdirRepoRoot}, not parent's repo ${parentRepoRoot}`
+								);
 								staleSessionIds.push(child.id);
 							}
 						}
@@ -750,9 +816,29 @@ export function useWorktreeHandlers(): WorktreeHandlersReturn {
 			});
 			if (existingSession) return;
 
+			const sshRemoteId = getSshRemoteId(parentSession);
+
+			// Repo-identity check: chokidar fires for every new directory under the
+			// watched basePath, including ones that turn out to be worktrees of a
+			// *different* repo. Without this guard, those would be attached to the
+			// wrong parent agent (matching the periodic-scan logic above).
+			const [parentRepoRoot, discoveredInfo] = await Promise.all([
+				resolveRepoRoot(parentSession.cwd, sshRemoteId),
+				window.maestro.git.worktreeInfo(worktree.path, sshRemoteId).catch(() => null),
+			]);
+			const discoveredRepoRoot =
+				discoveredInfo && discoveredInfo.success && discoveredInfo.repoRoot
+					? normalizePath(discoveredInfo.repoRoot)
+					: null;
+			if (parentRepoRoot && discoveredRepoRoot && discoveredRepoRoot !== parentRepoRoot) {
+				logger.warn(
+					`[WT-DEBUG] SKIPPED: discovered worktree ${worktree.path} belongs to repo ${discoveredRepoRoot}, not parent's repo ${parentRepoRoot}`
+				);
+				return;
+			}
+
 			const { defaultSaveToHistory: savToHist, defaultShowThinking: showThink } =
 				useSettingsStore.getState();
-			const sshRemoteId = getSshRemoteId(parentSession);
 			const gitInfo = await fetchGitInfo(worktree.path, sshRemoteId);
 
 			const worktreeSession = buildWorktreeSession({

--- a/src/renderer/hooks/worktree/useWorktreeHandlers.ts
+++ b/src/renderer/hooks/worktree/useWorktreeHandlers.ts
@@ -30,6 +30,7 @@ import {
 	sessionMatchesWorktreeRoot,
 } from '../../utils/worktreeDedup';
 import { logger } from '../../utils/logger';
+import { captureException } from '../../utils/sentry';
 
 // ============================================================================
 // Return type
@@ -95,15 +96,26 @@ function isSkippableBranch(branch: string | null | undefined): boolean {
  * than the worktree's own toplevel. This is what we need to verify that a
  * scanned subdir actually belongs to the parent agent's repository.
  *
- * Returns null if the path isn't a git repo or the lookup fails — callers
- * should treat null as "can't filter" and fall back to the legacy behavior.
+ * Returns null in two cases:
+ *  - "Not a git repo / no repoRoot" — explicit signal from `worktreeInfo`.
+ *    Callers fall back to the legacy "trust the basePath" behavior.
+ *  - Unexpected exception (IPC failure, etc.) — we return null *and* report
+ *    the error to Sentry + the logger. Without that signal, a regressed IPC
+ *    would silently disable the repo-root guard and re-introduce the
+ *    wrong-parent attachment bug with no production trace.
  */
 async function resolveRepoRoot(path: string, sshRemoteId?: string): Promise<string | null> {
 	try {
 		const info = await window.maestro.git.worktreeInfo(path, sshRemoteId);
 		if (!info.success || !info.exists || !info.repoRoot) return null;
 		return normalizePath(info.repoRoot);
-	} catch {
+	} catch (err) {
+		logger.error(
+			`[WorktreeScan] resolveRepoRoot failed for ${path}:`,
+			undefined,
+			err instanceof Error ? err.message : String(err)
+		);
+		captureException(err, { extra: { path, sshRemoteId, source: 'resolveRepoRoot' } });
 		return null;
 	}
 }
@@ -869,7 +881,26 @@ export function useWorktreeHandlers(): WorktreeHandlersReturn {
 			// wrong parent agent (matching the periodic-scan logic above).
 			const [parentRepoRoot, discoveredInfo] = await Promise.all([
 				resolveRepoRoot(parentSession.cwd, sshRemoteId),
-				window.maestro.git.worktreeInfo(worktree.path, sshRemoteId).catch(() => null),
+				// Unexpected IPC errors here are reported to Sentry rather than
+				// silently nulled out — otherwise a regressed worktreeInfo would
+				// disable the repo-root guard for chokidar discoveries with no
+				// production signal. An explicit "not a repo" still resolves to
+				// `info.success=false` and falls through to the legacy fallback.
+				window.maestro.git.worktreeInfo(worktree.path, sshRemoteId).catch((err) => {
+					logger.error(
+						`[WorktreeWatcher] worktreeInfo failed for ${worktree.path}:`,
+						undefined,
+						err instanceof Error ? err.message : String(err)
+					);
+					captureException(err, {
+						extra: {
+							path: worktree.path,
+							sshRemoteId,
+							source: 'onWorktreeDiscovered',
+						},
+					});
+					return null;
+				}),
 			]);
 			const discoveredRepoRoot =
 				discoveredInfo && discoveredInfo.success && discoveredInfo.repoRoot


### PR DESCRIPTION
## Summary

`scanWorktreeConfigs` and the chokidar `onWorktreeDiscovered` listener attached every worktree found under `worktreeConfig.basePath` to the parent agent that "owned" that basePath, **without verifying the worktree actually belonged to the parent's git repository**. With two parents whose basePaths overlap — or one basePath containing worktrees from multiple repos — whichever parent's loop iterated first grabbed everything.

This is the bug behind "all my worktrees got re-attached under the wrong agent" after the worktree-wipe fixed by #931 corrupted the persisted state in older builds.

## What changed

- **`useWorktreeHandlers.ts`** — resolve the parent's main-repo root once per scan via `worktreeInfo` (parent of `--git-common-dir`, so worktree parents resolve to the same canonical root as the main repo) and skip subdirs whose `repoRoot` doesn't match. When either side can't be resolved, fall back to the legacy "trust the basePath" behavior so existing setups keep working.
- Also detach already-attached children whose `cwd` is a worktree of a different repo. Without this, the wrong-agent children would never be re-attached to the correct parent — the existing-session dedup in `scanWorktreeConfigs` would block it.
- Symmetric guard in the chokidar `onWorktreeDiscovered` listener: fetch the parent and discovered-worktree `repoRoot`s in parallel and skip mismatches.

No IPC contract changes — the renderer uses the existing `git.worktreeInfo` IPC for both directions.

## Repro

1. Configure a parent agent at `repos/repo-a` with `worktreeConfig.basePath = /shared/worktrees`.
2. Drop a worktree of an unrelated repo into `/shared/worktrees/feat-other` (e.g. an existing leftover from an older project).
3. Restart the app or trigger a visibility-change rescan.

**Before:** `feat-other` is attached to repo-a's parent agent.
**After:** `feat-other` is filtered out; only worktrees that share repo-a's main repo root are attached.

## Test plan

- [x] `vitest run src/__tests__/renderer/hooks/useWorktreeHandlers.test.ts` — 67 pass (60 existing + 7 new):
  - filters scanned subdirs whose `repoRoot` doesn't match the parent
  - detaches a child whose `cwd` is a worktree of a different repo (self-heals the wrong-agent attachment)
  - two parents sharing a basePath each receive only their own repo's worktrees
  - falls back to legacy behavior when the parent's `repoRoot` can't be resolved
  - falls back to legacy behavior when subdir's `repoRoot` is null
  - chokidar `onWorktreeDiscovered` rejects a worktree from a different repo
  - chokidar `onWorktreeDiscovered` accepts a worktree from the matching repo
- [x] `vitest run src/__tests__/main/ipc/handlers/git.test.ts` — 153 pass (no regressions, no main-side changes)
- [x] `tsc --noEmit -p tsconfig.lint.json` clean
- [x] `tsc --noEmit -p tsconfig.main.json` clean
- [x] `prettier --check` clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented misattachment of worktrees by enforcing repository identity during scans and watcher events
  * Ensured stale or reassigned child sessions are detached before reattachment
  * Fixed ordering/deduplication so attachments aren’t blocked by pending removals

* **User-facing**
  * Notifications now distinguish "Worktree Re-assigned" from "Worktree Removed"

* **Tests**
  * Expanded tests for repo-identity filtering, discovery/attachment, and error reporting to monitoring
<!-- end of auto-generated comment: release notes by coderabbit.ai -->