### PR TITLE
fix(feedback): skip provider-selection step, open chat directly (#766)

### DIFF
--- a/src/__tests__/renderer/components/FeedbackChatView.test.tsx
+++ b/src/__tests__/renderer/components/FeedbackChatView.test.tsx
@@ -57,42 +57,7 @@ describe('FeedbackChatView', () => {
 		});
 	});
 
-	it('shows provider selection when gh is authenticated', async () => {
-		window.maestro.feedback.checkGhAuth.mockResolvedValue({ authenticated: true });
-		window.maestro.agents.detect.mockResolvedValue([
-			{ id: 'claude-code', name: 'Claude Code', available: true },
-		]);
-
-		render(
-			<FeedbackChatView
-				theme={theme}
-				sessions={sessions}
-				onCancel={vi.fn()}
-				onSubmitSuccess={vi.fn()}
-			/>
-		);
-
-		await waitFor(() => {
-			expect(screen.getByText('Start')).toBeTruthy();
-		});
-	});
-
-	it('shows loading spinner during GH auth check', () => {
-		window.maestro.feedback.checkGhAuth.mockReturnValue(new Promise(() => {})); // Never resolves
-
-		render(
-			<FeedbackChatView
-				theme={theme}
-				sessions={sessions}
-				onCancel={vi.fn()}
-				onSubmitSuccess={vi.fn()}
-			/>
-		);
-
-		expect(screen.getByText('Checking GitHub CLI...')).toBeTruthy();
-	});
-
-	it('starts chat without a loading spinner when provider is selected', async () => {
+	it('auto-starts chat when gh is authenticated and a supported agent is detected', async () => {
 		window.maestro.feedback.checkGhAuth.mockResolvedValue({ authenticated: true });
 		window.maestro.agents.detect.mockResolvedValue([
 			{ id: 'claude-code', name: 'Claude Code', available: true },
@@ -111,21 +76,53 @@ describe('FeedbackChatView', () => {
 			/>
 		);
 
-		// Wait for provider selection screen
-		await waitFor(() => {
-			expect(screen.getByText('Start')).toBeTruthy();
-		});
-
-		// Click Start
-		screen.getByText('Start').click();
-
-		// Chat should appear with input but no spinner
+		// Skips the old provider-select screen and lands directly in chat.
 		await waitFor(() => {
 			expect(screen.getByPlaceholderText('Describe your issue or idea...')).toBeTruthy();
 		});
 
-		// No loading spinner should be visible
-		expect(screen.queryByText('Checking GitHub CLI...')).toBeNull();
+		// The provider-select dropdown / Start button should be gone for good.
+		expect(screen.queryByText('Start')).toBeNull();
+		expect(screen.queryByText('AI Provider')).toBeNull();
+
+		// The conversation prompt was fetched (chat actually started).
+		expect(window.maestro.feedback.getConversationPrompt).toHaveBeenCalled();
+	});
+
+	it('shows loading spinner during GH auth check', () => {
+		window.maestro.feedback.checkGhAuth.mockReturnValue(new Promise(() => {})); // Never resolves
+
+		render(
+			<FeedbackChatView
+				theme={theme}
+				sessions={sessions}
+				onCancel={vi.fn()}
+				onSubmitSuccess={vi.fn()}
+			/>
+		);
+
+		expect(screen.getByText('Checking GitHub CLI...')).toBeTruthy();
+	});
+
+	it('shows the no-providers screen when gh is authenticated but no supported agents are detected', async () => {
+		window.maestro.feedback.checkGhAuth.mockResolvedValue({ authenticated: true });
+		window.maestro.agents.detect.mockResolvedValue([]);
+
+		render(
+			<FeedbackChatView
+				theme={theme}
+				sessions={sessions}
+				onCancel={vi.fn()}
+				onSubmitSuccess={vi.fn()}
+			/>
+		);
+
+		await waitFor(() => {
+			expect(screen.getByText('No supported AI providers detected')).toBeTruthy();
+		});
+
+		// The chat should not have been started.
+		expect(window.maestro.feedback.getConversationPrompt).not.toHaveBeenCalled();
 	});
 
 	it('calls onCancel when Close button is clicked on GH error', async () => {

--- a/src/__tests__/renderer/components/FeedbackChatView.test.tsx
+++ b/src/__tests__/renderer/components/FeedbackChatView.test.tsx
@@ -147,4 +147,59 @@ describe('FeedbackChatView', () => {
 
 		expect(onCancel).toHaveBeenCalledOnce();
 	});
+
+	it('shows a distinct error screen when agent detection itself throws', async () => {
+		window.maestro.feedback.checkGhAuth.mockResolvedValue({ authenticated: true });
+		window.maestro.agents.detect.mockRejectedValue(new Error('IPC channel closed'));
+
+		render(
+			<FeedbackChatView
+				theme={theme}
+				sessions={sessions}
+				onCancel={vi.fn()}
+				onSubmitSuccess={vi.fn()}
+			/>
+		);
+
+		// Detection failure should NOT be misclassified as "no providers".
+		await waitFor(() => {
+			expect(screen.getByText('Could not detect AI providers')).toBeTruthy();
+		});
+		expect(screen.queryByText('No supported AI providers detected')).toBeNull();
+
+		// The error message bubbles up to the screen so the user can see what broke.
+		expect(screen.getByText('IPC channel closed')).toBeTruthy();
+
+		// Chat must not have been started.
+		expect(window.maestro.feedback.getConversationPrompt).not.toHaveBeenCalled();
+	});
+
+	it('lets the user dismiss the boot screen if conversation start fails', async () => {
+		const onCancel = vi.fn();
+		window.maestro.feedback.checkGhAuth.mockResolvedValue({ authenticated: true });
+		window.maestro.agents.detect.mockResolvedValue([
+			{ id: 'claude-code', name: 'Claude Code', available: true },
+		]);
+		window.maestro.feedback.getConversationPrompt.mockRejectedValue(
+			new Error('Prompt fetch failed')
+		);
+
+		render(
+			<FeedbackChatView
+				theme={theme}
+				sessions={sessions}
+				onCancel={onCancel}
+				onSubmitSuccess={vi.fn()}
+			/>
+		);
+
+		// Error message + Close button should appear so the user isn't stuck.
+		await waitFor(() => {
+			expect(screen.getByText('Prompt fetch failed')).toBeTruthy();
+		});
+		const closeButton = screen.getByText('Close');
+		expect(closeButton).toBeTruthy();
+		closeButton.click();
+		expect(onCancel).toHaveBeenCalledOnce();
+	});
 });

--- a/src/renderer/components/FeedbackChatView.tsx
+++ b/src/renderer/components/FeedbackChatView.tsx
@@ -38,6 +38,7 @@ import {
 	type FeedbackParsedResponse,
 } from '../services/feedbackConversation';
 import { openUrl } from '../utils/openUrl';
+import { captureException } from '../utils/sentry';
 import { useFeedbackDraftStore } from '../stores/feedbackDraftStore';
 
 // ============================================================================
@@ -129,6 +130,7 @@ export function FeedbackChatView({ theme, onCancel, onWidthChange }: FeedbackCha
 	const [selectedAgent, setSelectedAgent] = useState<ToolType>('claude-code');
 	const [detectedAgents, setDetectedAgents] = useState<Set<string>>(new Set());
 	const [agentsLoaded, setAgentsLoaded] = useState(false);
+	const [agentsDetectError, setAgentsDetectError] = useState<string | null>(null);
 	const [messages, setMessages] = useState<FeedbackMessage[]>([]);
 	const [inputValue, setInputValue] = useState('');
 	const [isLoading, setIsLoading] = useState(false);
@@ -193,8 +195,16 @@ export function FeedbackChatView({ theme, onCancel, onWidthChange }: FeedbackCha
 					if (firstAvailable) setSelectedAgent(firstAvailable.id);
 					setAgentsLoaded(true);
 				}
-			} catch {
-				if (mounted) setAgentsLoaded(true);
+			} catch (error) {
+				// Report so we hear about IPC/runtime failures in production rather
+				// than misclassifying them as "no providers installed".
+				captureException(error, { extra: { source: 'FeedbackChatView.agentDetect' } });
+				if (mounted) {
+					setAgentsDetectError(
+						error instanceof Error ? error.message : 'Failed to detect AI providers.'
+					);
+					setAgentsLoaded(true);
+				}
 			}
 		})();
 		return () => {
@@ -290,6 +300,9 @@ export function FeedbackChatView({ theme, onCancel, onWidthChange }: FeedbackCha
 			// Focus input immediately — no auto-greeting, user speaks first
 			requestAnimationFrame(() => inputRef.current?.focus());
 		} catch (error) {
+			// Release the auto-start latch so a future state change can retry,
+			// and surface the error in the boot screen with a Close action.
+			startedRef.current = false;
 			setSubmitError(error instanceof Error ? error.message : 'Failed to start conversation');
 		}
 	}, [selectedAgent]);
@@ -300,11 +313,11 @@ export function FeedbackChatView({ theme, onCancel, onWidthChange }: FeedbackCha
 	useEffect(() => {
 		if (startedRef.current) return;
 		if (ghAuth.checking || !ghAuth.ok) return;
-		if (!agentsLoaded) return;
+		if (!agentsLoaded || agentsDetectError) return;
 		if (availableTiles.length === 0) return;
 		startedRef.current = true;
 		void startConversation();
-	}, [ghAuth, agentsLoaded, availableTiles, startConversation]);
+	}, [ghAuth, agentsLoaded, agentsDetectError, availableTiles, startConversation]);
 
 	// --- Send message ---
 	const sendMessage = useCallback(async () => {
@@ -547,6 +560,31 @@ export function FeedbackChatView({ theme, onCancel, onWidthChange }: FeedbackCha
 		);
 	}
 
+	// --- Agent detection failed (IPC/runtime error, not "zero providers") ---
+	if (agentsDetectError) {
+		return (
+			<div className="flex flex-col items-center gap-4 py-8 px-6 text-center">
+				<AlertCircle className="w-10 h-10" style={{ color: theme.colors.error }} />
+				<div>
+					<p className="text-sm font-semibold mb-1" style={{ color: theme.colors.textMain }}>
+						Could not detect AI providers
+					</p>
+					<p className="text-xs leading-relaxed max-w-sm" style={{ color: theme.colors.textDim }}>
+						{agentsDetectError}
+					</p>
+				</div>
+				<button
+					type="button"
+					onClick={onCancel}
+					className="px-4 py-2 rounded text-xs font-bold transition-colors hover:opacity-90"
+					style={{ backgroundColor: theme.colors.accent, color: theme.colors.accentForeground }}
+				>
+					Close
+				</button>
+			</div>
+		);
+	}
+
 	// --- No supported AI provider detected ---
 	if (agentsLoaded && availableTiles.length === 0) {
 		return (
@@ -582,9 +620,19 @@ export function FeedbackChatView({ theme, onCancel, onWidthChange }: FeedbackCha
 					Starting feedback session...
 				</p>
 				{submitError && (
-					<p className="text-xs" style={{ color: theme.colors.warning }}>
-						{submitError}
-					</p>
+					<>
+						<p className="text-xs" style={{ color: theme.colors.warning }}>
+							{submitError}
+						</p>
+						<button
+							type="button"
+							onClick={onCancel}
+							className="px-4 py-2 rounded text-xs font-bold transition-colors hover:opacity-90"
+							style={{ backgroundColor: theme.colors.accent, color: theme.colors.accentForeground }}
+						>
+							Close
+						</button>
+					</>
 				)}
 			</div>
 		);

--- a/src/renderer/components/FeedbackChatView.tsx
+++ b/src/renderer/components/FeedbackChatView.tsx
@@ -300,6 +300,10 @@ export function FeedbackChatView({ theme, onCancel, onWidthChange }: FeedbackCha
 			// Focus input immediately — no auto-greeting, user speaks first
 			requestAnimationFrame(() => inputRef.current?.focus());
 		} catch (error) {
+			// Surface IPC/runtime failures from getConversationPrompt() and
+			// managerRef.current.start() to Sentry so production breakage is
+			// visible — these are unexpected errors, not recoverable conditions.
+			captureException(error, { extra: { source: 'FeedbackChatView.startConversation' } });
 			// Release the auto-start latch so a future state change can retry,
 			// and surface the error in the boot screen with a Close action.
 			startedRef.current = false;

--- a/src/renderer/components/FeedbackChatView.tsx
+++ b/src/renderer/components/FeedbackChatView.tsx
@@ -6,7 +6,7 @@
  * and when understanding reaches 80%, submits a well-structured GitHub issue.
  *
  * Features:
- * - Provider selection (reuses agent configuration pattern)
+ * - Auto-picks the first available supported provider — no selection step
  * - Chat interface with progress bar
  * - Screenshot drag-and-drop
  * - Support package opt-in
@@ -16,7 +16,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
 	ImagePlus,
-	MessageSquareHeart,
 	Send,
 	X,
 	Package,
@@ -38,8 +37,6 @@ import {
 	type FeedbackMessage,
 	type FeedbackParsedResponse,
 } from '../services/feedbackConversation';
-import { isBetaAgent } from '../../shared/agentMetadata';
-import { ThemedSelect } from './shared/ThemedSelect';
 import { openUrl } from '../utils/openUrl';
 import { useFeedbackDraftStore } from '../stores/feedbackDraftStore';
 
@@ -122,15 +119,16 @@ interface ExistingIssue {
 
 export function FeedbackChatView({ theme, onCancel, onWidthChange }: FeedbackChatViewProps) {
 	// --- State ---
-	const [step, setStep] = useState<
-		'gh-check' | 'provider-select' | 'chat' | 'matching' | 'submitting' | 'done'
-	>('gh-check');
+	const [step, setStep] = useState<'gh-check' | 'chat' | 'matching' | 'submitting' | 'done'>(
+		'gh-check'
+	);
 	const [ghAuth, setGhAuth] = useState<{ checking: boolean; ok: boolean; message?: string }>({
 		checking: true,
 		ok: false,
 	});
 	const [selectedAgent, setSelectedAgent] = useState<ToolType>('claude-code');
 	const [detectedAgents, setDetectedAgents] = useState<Set<string>>(new Set());
+	const [agentsLoaded, setAgentsLoaded] = useState(false);
 	const [messages, setMessages] = useState<FeedbackMessage[]>([]);
 	const [inputValue, setInputValue] = useState('');
 	const [isLoading, setIsLoading] = useState(false);
@@ -154,11 +152,11 @@ export function FeedbackChatView({ theme, onCancel, onWidthChange }: FeedbackCha
 	const messagesEndRef = useRef<HTMLDivElement>(null);
 	const inputRef = useRef<HTMLTextAreaElement>(null);
 	const fileInputRef = useRef<HTMLInputElement>(null);
+	const startedRef = useRef(false);
 
 	// --- Report desired width based on current step ---
 	useEffect(() => {
-		const isNarrow = step === 'gh-check' || step === 'provider-select';
-		onWidthChange?.(isNarrow ? 462 : 858);
+		onWidthChange?.(step === 'gh-check' ? 462 : 858);
 	}, [step, onWidthChange]);
 
 	// --- GH Auth Check ---
@@ -169,7 +167,6 @@ export function FeedbackChatView({ theme, onCancel, onWidthChange }: FeedbackCha
 				const result = await window.maestro.feedback.checkGhAuth();
 				if (mounted) {
 					setGhAuth({ checking: false, ok: result.authenticated, message: result.message });
-					if (result.authenticated) setStep('provider-select');
 				}
 			} catch {
 				if (mounted) {
@@ -194,9 +191,10 @@ export function FeedbackChatView({ theme, onCancel, onWidthChange }: FeedbackCha
 					// Auto-select first available
 					const firstAvailable = AGENT_TILES.find((t) => t.supported && available.has(t.id));
 					if (firstAvailable) setSelectedAgent(firstAvailable.id);
+					setAgentsLoaded(true);
 				}
 			} catch {
-				// Ignore
+				if (mounted) setAgentsLoaded(true);
 			}
 		})();
 		return () => {
@@ -295,6 +293,18 @@ export function FeedbackChatView({ theme, onCancel, onWidthChange }: FeedbackCha
 			setSubmitError(error instanceof Error ? error.message : 'Failed to start conversation');
 		}
 	}, [selectedAgent]);
+
+	// --- Auto-start conversation once GH auth + agent detection are ready.
+	//     The previous "pick a provider" screen is gone (#766) — Maestro infers
+	//     the provider from the first detected supported agent.
+	useEffect(() => {
+		if (startedRef.current) return;
+		if (ghAuth.checking || !ghAuth.ok) return;
+		if (!agentsLoaded) return;
+		if (availableTiles.length === 0) return;
+		startedRef.current = true;
+		void startConversation();
+	}, [ghAuth, agentsLoaded, availableTiles, startConversation]);
 
 	// --- Send message ---
 	const sendMessage = useCallback(async () => {
@@ -537,73 +547,45 @@ export function FeedbackChatView({ theme, onCancel, onWidthChange }: FeedbackCha
 		);
 	}
 
-	// --- Provider Selection ---
-	if (step === 'provider-select') {
+	// --- No supported AI provider detected ---
+	if (agentsLoaded && availableTiles.length === 0) {
 		return (
-			<div className="flex flex-col gap-5 p-6">
-				<div className="flex items-center gap-4">
-					<div
-						className="w-20 h-20 rounded-xl flex items-center justify-center shrink-0"
-						style={{ backgroundColor: `${theme.colors.accent}20` }}
-					>
-						<MessageSquareHeart className="w-10 h-10" style={{ color: theme.colors.accent }} />
-					</div>
-					<p className="text-sm" style={{ color: theme.colors.textDim }}>
-						Thank you for taking the time to give us feedback! Whether you're reporting an issue or
-						recommending a feature, an AI will help shape it into a well-structured GitHub issue for
-						us to act on. Pick which AI provider powers that conversation below.
+			<div className="flex flex-col items-center gap-4 py-8 px-6 text-center">
+				<AlertCircle className="w-10 h-10" style={{ color: theme.colors.warning }} />
+				<div>
+					<p className="text-sm font-semibold mb-1" style={{ color: theme.colors.textMain }}>
+						No supported AI providers detected
+					</p>
+					<p className="text-xs leading-relaxed max-w-sm" style={{ color: theme.colors.textDim }}>
+						Inline feedback uses an AI to shape your report into a well-structured GitHub issue.
+						Install Claude Code, Codex, or OpenCode and try again.
 					</p>
 				</div>
+				<button
+					type="button"
+					onClick={onCancel}
+					className="px-4 py-2 rounded text-xs font-bold transition-colors hover:opacity-90"
+					style={{ backgroundColor: theme.colors.accent, color: theme.colors.accentForeground }}
+				>
+					Close
+				</button>
+			</div>
+		);
+	}
 
-				<div className="flex flex-col gap-2">
-					<label className="text-xs font-bold" style={{ color: theme.colors.textMain }}>
-						AI Provider
-					</label>
-					<ThemedSelect
-						value={selectedAgent}
-						options={availableTiles.map((tile) => ({
-							value: tile.id,
-							label: `${tile.name}${isBetaAgent(tile.id) ? ' (Beta)' : ''}`,
-						}))}
-						onChange={(v) => setSelectedAgent(v as ToolType)}
-						theme={theme}
-					/>
-					<p className="text-[11px]" style={{ color: theme.colors.textDim }}>
-						This selects the provider that drives the feedback conversation — it doesn't create a
-						new agent in your sidebar.
-					</p>
-					{availableTiles.length === 0 && (
-						<p className="text-xs" style={{ color: theme.colors.warning }}>
-							No supported AI providers detected. Install Claude Code, Codex, or OpenCode.
-						</p>
-					)}
-				</div>
-
+	// --- Booting: GH ok, agent detection or conversation start in flight ---
+	if (step === 'gh-check') {
+		return (
+			<div className="flex flex-col items-center gap-3 py-8 px-6">
+				<Spinner size={24} color={theme.colors.accent} />
+				<p className="text-xs" style={{ color: theme.colors.textDim }}>
+					Starting feedback session...
+				</p>
 				{submitError && (
 					<p className="text-xs" style={{ color: theme.colors.warning }}>
 						{submitError}
 					</p>
 				)}
-
-				<div className="flex justify-end gap-2">
-					<button
-						type="button"
-						onClick={onCancel}
-						className="px-4 py-2 rounded text-xs transition-colors hover:bg-white/5"
-						style={{ color: theme.colors.textDim }}
-					>
-						Cancel
-					</button>
-					<button
-						type="button"
-						onClick={startConversation}
-						disabled={availableTiles.length === 0}
-						className="px-4 py-2 rounded text-xs font-bold transition-colors hover:opacity-90 disabled:opacity-40"
-						style={{ backgroundColor: theme.colors.accent, color: theme.colors.accentForeground }}
-					>
-						Start
-					</button>
-				</div>
 			</div>
 		);
 	}


### PR DESCRIPTION
## Summary

- Removes the redundant "Pick AI Provider" screen from the Send Feedback flow — Maestro already auto-detects the active agent, so the manual selection step was friction.
- After GH auth + agent detection complete, the conversation now starts automatically with the first available supported provider (claude-code → codex → opencode preference order).
- Adds a dedicated "No supported AI providers detected" alert screen for the zero-agents edge case.

Closes https://github.com/RunMaestro/Maestro/issues/766.

## What changed

`src/renderer/components/FeedbackChatView.tsx` (-21 net lines)
- Drop `'provider-select'` from the step state machine.
- Remove the entire ~70-line provider-selection render block (header copy, `ThemedSelect`, Cancel/Start buttons).
- Remove now-unused imports: `MessageSquareHeart`, `ThemedSelect`, `isBetaAgent`.
- Add `agentsLoaded` state + `startedRef` guard, and an effect that auto-invokes `startConversation()` once GH auth verifies and agent detection completes.
- Add an inline "No supported AI providers detected" screen.
- Add a brief "Starting feedback session..." spinner for the bootstrap window.

`src/__tests__/renderer/components/FeedbackChatView.test.tsx`
- Replace the "shows provider selection" test with "auto-starts chat when gh is authenticated and a supported agent is detected" — asserts the chat input appears with no user click, that `Start`/`AI Provider` are absent, and that `getConversationPrompt` was called.
- Add a new "no providers" test covering the alert screen.
- Other GH-auth coverage unchanged.

## Test plan

- [x] `vitest run src/__tests__/renderer/components/FeedbackChatView.test.tsx` — 5/5 pass
- [x] `prettier --check` clean on changed files
- [x] `eslint` clean on changed files
- [ ] Manual: open Send Feedback in dev with `gh` authenticated and Claude Code installed → verify the chat input appears immediately (no provider-select screen)
- [ ] Manual: with `gh` authenticated but no supported agents installed → verify the new "No supported AI providers detected" screen appears
- [ ] Manual: minimize/restore behavior still works (FeedbackModal animation untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Chat now auto-starts once GitHub auth and agent detection complete; provider-selection screen removed.
  * New early screens for "No supported AI providers detected" and for agent-detection failures (displays error message).

* **Tests**
  * Coverage updated for auto-start flow, no-provider scenario, agent-detection failure, conversation prompt fetch failure, and close/cancel behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->