### PR TITLE
fix(cli): order Codex -C before resume so maestro-cli send resumes work

### DIFF
--- a/src/__tests__/cli/services/agent-spawner.test.ts
+++ b/src/__tests__/cli/services/agent-spawner.test.ts
@@ -2134,8 +2134,13 @@ Some text with [x] in it that's not a checkbox
 			expect(c).toBeGreaterThanOrEqual(0);
 			expect(args[c + 1]).toBe('/working');
 			// resume args are ['resume', '<id>']
-			expect(args).toContain('resume');
-			expect(args).toContain('codex-thread-123');
+			const r = args.indexOf('resume');
+			expect(r).toBeGreaterThanOrEqual(0);
+			expect(args[r + 1]).toBe('codex-thread-123');
+			// `-C` must precede the `resume` subcommand — once Codex consumes
+			// `resume`, trailing flags get parsed by `codex exec resume`, which
+			// rejects `-C`.
+			expect(c).toBeLessThan(r);
 		});
 
 		it('unsupported agent type returns a failure result', async () => {

--- a/src/cli/services/agent-spawner.ts
+++ b/src/cli/services/agent-spawner.ts
@@ -592,13 +592,16 @@ async function spawnJsonLineAgent(
 	if (def?.jsonOutputArgs) preOverrideArgs.push(...def.jsonOutputArgs);
 	if (readOnlyMode && def?.readOnlyArgs) preOverrideArgs.push(...def.readOnlyArgs);
 
-	if (agentSessionId && def?.resumeArgs) {
-		preOverrideArgs.push(...def.resumeArgs(agentSessionId));
-	}
-
-	// Codex requires explicit working directory arg (other agents use process cwd)
+	// Codex requires explicit working directory arg (other agents use process cwd).
+	// Must be emitted before resumeArgs because `resume` is a subcommand of
+	// `codex exec` — once it's consumed, trailing flags like `-C` are parsed
+	// against `codex exec resume`, which doesn't accept them.
 	if (toolType === 'codex' && def?.workingDirArgs) {
 		preOverrideArgs.push(...def.workingDirArgs(cwd));
+	}
+
+	if (agentSessionId && def?.resumeArgs) {
+		preOverrideArgs.push(...def.resumeArgs(agentSessionId));
 	}
 
 	// Layer agent-level + session-level overrides (model, effort, customArgs)


### PR DESCRIPTION
## Summary

- `maestro-cli send` failed on follow-up messages to a Codex agent with `error: unexpected argument '-C' found ... Usage: codex exec resume [OPTIONS] [SESSION_ID] [PROMPT]`. The first message worked because `sessionId` was null and the resume branch was skipped; once a session id was saved, every subsequent send hit the resume path and broke.
- Root cause: `src/cli/services/agent-spawner.ts` appended `resumeArgs` before `workingDirArgs`, producing `codex exec ... resume <id> -C <cwd> -- <prompt>`. `resume` is a subcommand of `codex exec`, so once it's consumed, trailing flags are parsed against `codex exec resume`, which doesn't accept `-C`.
- Fix: emit `workingDirArgs` before `resumeArgs` for Codex. Matches the canonical comment in `src/main/agents/definitions.ts` (`[-C dir] [resume <id>]`) and the desktop builder `src/main/utils/agent-args.ts`, which already had the right order.
- Strengthened the existing Codex spawn test to assert `-C` precedes `resume` so this can't silently regress.

This was originally surfaced as a "Failed to get response from agent" error in the Maestro Discord bot — the bot was just relaying the upstream maestro-cli failure.

## Test plan

- [x] `vitest run src/__tests__/cli/services/agent-spawner.test.ts -t "Codex spawn preserves working-dir flag and resume args"` — passes with the new ordering assertion
- [x] `eslint` clean on the two touched files
- [x] `prettier --check` clean on the two touched files
- [ ] Manual: send two messages back-to-back to a Codex agent via `maestro-cli send` (or via Maestro Discord) — both should succeed; previously the second send failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed argument ordering for agent spawn commands to ensure proper parsing of working directory configuration before session resumption.

* **Tests**
  * Enhanced regression test to validate correct argument sequencing in agent spawn operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->