### PR TITLE
perf: SSH path cache, async spawn temp file, CueIndicator extraction

### DIFF
--- a/src/__tests__/main/ipc/handlers/process.test.ts
+++ b/src/__tests__/main/ipc/handlers/process.test.ts
@@ -196,6 +196,30 @@ vi.mock('../../../../main/utils/cliDetection', () => ({
 	resolveSshPath: vi.fn().mockResolvedValue('ssh'),
 }));
 
+// Mock platformDetection. Default mirrors the host so the existing
+// `appendSystemPrompt delivery` test still picks the right branch on
+// Windows CI; new tests override per-case with mockReturnValue(true).
+vi.mock('../../../../shared/platformDetection', () => ({
+	isWindows: vi.fn(() => process.platform === 'win32'),
+	isMacOS: vi.fn(() => process.platform === 'darwin'),
+	isLinux: vi.fn(() => process.platform === 'linux'),
+}));
+
+// Mock fs/promises so the new temp-file tests can assert on writeFile/unlink
+// without touching the real filesystem. Other tests in this file don't use
+// fs/promises, so the module-level mock is safe.
+vi.mock('fs/promises', () => ({
+	writeFile: vi.fn().mockResolvedValue(undefined),
+	unlink: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Mock sentry — captureException is asserted on by the new cleanup-error
+// tests; addBreadcrumb is a no-op stub so existing tests don't hit real Sentry.
+vi.mock('../../../../main/utils/sentry', () => ({
+	captureException: vi.fn(),
+	addBreadcrumb: vi.fn(),
+}));
+
 describe('process IPC handlers', () => {
 	let handlers: Map<string, Function>;
 	let mockProcessManager: {
@@ -2484,6 +2508,134 @@ describe('process IPC handlers', () => {
 			const spawnCall = mockProcessManager.spawn.mock.calls[0][0];
 			expect(spawnCall.args).not.toContain('--append-system-prompt');
 			expect(spawnCall.prompt).toBe('Hello world');
+		});
+
+		describe('Windows temp prompt file (async fs/promises)', () => {
+			// PR-D 3.1: writeFileSync/unlinkSync replaced with fs/promises.
+			// These tests force isWindows() = true so they exercise the
+			// temp-file branch on every platform.
+
+			beforeEach(async () => {
+				const { isWindows } = await import('../../../../shared/platformDetection');
+				vi.mocked(isWindows).mockReturnValue(true);
+			});
+
+			afterEach(async () => {
+				const { isWindows } = await import('../../../../shared/platformDetection');
+				vi.mocked(isWindows).mockReset();
+				vi.mocked(isWindows).mockImplementation(() => process.platform === 'win32');
+				vi.useRealTimers();
+			});
+
+			const buildSpawnConfig = () => ({
+				sessionId: 'session-1',
+				toolType: 'claude-code',
+				cwd: '/home/user/project',
+				command: 'claude',
+				args: ['--print'],
+				prompt: 'Hello world',
+				appendSystemPrompt: 'You are Maestro system prompt content',
+			});
+
+			const mockAgent = {
+				id: 'claude-code',
+				name: 'Claude Code',
+				requiresPty: true,
+				path: '/usr/local/bin/claude',
+				capabilities: {
+					supportsAppendSystemPrompt: true,
+					supportsStreamJsonInput: true,
+				},
+			};
+
+			it('writes temp file with prompt content via fs/promises', async () => {
+				const fsp = await import('fs/promises');
+				mockAgentDetector.getAgent.mockResolvedValue(mockAgent);
+				mockProcessManager.spawn.mockReturnValue({ pid: 12345, success: true });
+
+				const handler = handlers.get('process:spawn');
+				await handler!({} as any, buildSpawnConfig());
+
+				expect(fsp.writeFile).toHaveBeenCalledTimes(1);
+				const [tempPath, content, encoding] = vi.mocked(fsp.writeFile).mock.calls[0];
+				expect(tempPath).toMatch(/maestro-sysprompt-session-1-\d+\.txt/);
+				expect(content).toBe('You are Maestro system prompt content');
+				expect(encoding).toBe('utf-8');
+			});
+
+			it('schedules unlink after 30s timer', async () => {
+				vi.useFakeTimers();
+				const fsp = await import('fs/promises');
+				mockAgentDetector.getAgent.mockResolvedValue(mockAgent);
+				mockProcessManager.spawn.mockReturnValue({ pid: 12345, success: true });
+
+				const handler = handlers.get('process:spawn');
+				await handler!({} as any, buildSpawnConfig());
+
+				// Unlink not called yet — timer hasn't fired
+				expect(fsp.unlink).not.toHaveBeenCalled();
+
+				await vi.advanceTimersByTimeAsync(30_001);
+
+				expect(fsp.unlink).toHaveBeenCalledTimes(1);
+				const [unlinkPath] = vi.mocked(fsp.unlink).mock.calls[0];
+				expect(unlinkPath).toMatch(/maestro-sysprompt-session-1-\d+\.txt/);
+			});
+
+			it('silences ENOENT cleanup errors (file already gone)', async () => {
+				vi.useFakeTimers();
+				const fsp = await import('fs/promises');
+				const { captureException } = await import('../../../../main/utils/sentry');
+				const enoentErr: NodeJS.ErrnoException = Object.assign(new Error('ENOENT: no such file'), {
+					code: 'ENOENT',
+				});
+				vi.mocked(fsp.unlink).mockRejectedValueOnce(enoentErr);
+
+				mockAgentDetector.getAgent.mockResolvedValue(mockAgent);
+				mockProcessManager.spawn.mockReturnValue({ pid: 12345, success: true });
+
+				const handler = handlers.get('process:spawn');
+				await handler!({} as any, buildSpawnConfig());
+
+				vi.mocked(captureException).mockClear();
+				await vi.advanceTimersByTimeAsync(30_001);
+				// Allow the rejected unlink promise to settle
+				await Promise.resolve();
+
+				expect(fsp.unlink).toHaveBeenCalledTimes(1);
+				expect(captureException).not.toHaveBeenCalled();
+			});
+
+			it('captures non-ENOENT cleanup errors via Sentry', async () => {
+				vi.useFakeTimers();
+				const fsp = await import('fs/promises');
+				const { captureException } = await import('../../../../main/utils/sentry');
+				const eaccesErr: NodeJS.ErrnoException = Object.assign(
+					new Error('EACCES: permission denied'),
+					{ code: 'EACCES' }
+				);
+				vi.mocked(fsp.unlink).mockRejectedValueOnce(eaccesErr);
+
+				mockAgentDetector.getAgent.mockResolvedValue(mockAgent);
+				mockProcessManager.spawn.mockReturnValue({ pid: 12345, success: true });
+
+				const handler = handlers.get('process:spawn');
+				await handler!({} as any, buildSpawnConfig());
+
+				vi.mocked(captureException).mockClear();
+				await vi.advanceTimersByTimeAsync(30_001);
+				await Promise.resolve();
+
+				expect(captureException).toHaveBeenCalledTimes(1);
+				const [errArg, ctxArg] = vi.mocked(captureException).mock.calls[0];
+				expect(errArg).toBe(eaccesErr);
+				expect(ctxArg).toEqual(
+					expect.objectContaining({
+						context: 'systemPromptTempFile cleanup (safety)',
+						file: expect.stringMatching(/maestro-sysprompt-session-1-\d+\.txt/),
+					})
+				);
+			});
 		});
 	});
 });

--- a/src/__tests__/main/utils/path-access-cache.test.ts
+++ b/src/__tests__/main/utils/path-access-cache.test.ts
@@ -5,11 +5,15 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import {
 	PathAccessCache,
 	DEFAULT_PATH_ACCESS_TTL_MS,
 	getPathAccessCache,
 	setPathAccessCacheForTest,
+	defaultReadableProbe,
 } from '../../../main/utils/path-access-cache';
 
 describe('PathAccessCache', () => {
@@ -142,5 +146,32 @@ describe('getPathAccessCache singleton', () => {
 		const custom = new PathAccessCache(1_000);
 		setPathAccessCacheForTest(custom);
 		expect(getPathAccessCache()).toBe(custom);
+	});
+});
+
+describe('defaultReadableProbe', () => {
+	let tempDir: string;
+
+	beforeEach(() => {
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'maestro-probe-test-'));
+	});
+
+	afterEach(() => {
+		fs.rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	it('returns true for a readable file', () => {
+		const filePath = path.join(tempDir, 'readable.txt');
+		fs.writeFileSync(filePath, 'hello');
+		expect(defaultReadableProbe(filePath)).toBe(true);
+	});
+
+	it('returns false for a missing path (ENOENT swallowed)', () => {
+		const filePath = path.join(tempDir, 'does-not-exist.txt');
+		expect(defaultReadableProbe(filePath)).toBe(false);
+	});
+
+	it('returns true for a readable directory (R_OK probe)', () => {
+		expect(defaultReadableProbe(tempDir)).toBe(true);
 	});
 });

--- a/src/__tests__/main/utils/path-access-cache.test.ts
+++ b/src/__tests__/main/utils/path-access-cache.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Tests for {@link PathAccessCache} — short-TTL cache over a boolean
+ * file-access predicate. Used by the SSH modules to avoid re-stat'ing the
+ * same identity files on rapid retries.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+	PathAccessCache,
+	DEFAULT_PATH_ACCESS_TTL_MS,
+	getPathAccessCache,
+	setPathAccessCacheForTest,
+} from '../../../main/utils/path-access-cache';
+
+describe('PathAccessCache', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		// Anchor fake clock to a real-ish timestamp so Date.now() math is sane.
+		vi.setSystemTime(new Date('2026-05-04T00:00:00Z'));
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		setPathAccessCacheForTest(null);
+	});
+
+	it('first call invokes accessFn and caches true result', () => {
+		const cache = new PathAccessCache(30_000);
+		const accessFn = vi.fn().mockReturnValue(true);
+
+		const result = cache.check('/path/to/key', accessFn);
+
+		expect(result).toBe(true);
+		expect(accessFn).toHaveBeenCalledTimes(1);
+		expect(accessFn).toHaveBeenCalledWith('/path/to/key');
+	});
+
+	it('second call within TTL returns cached true without invoking accessFn', () => {
+		const cache = new PathAccessCache(30_000);
+		const accessFn = vi.fn().mockReturnValue(true);
+
+		cache.check('/path/to/key', accessFn);
+		vi.advanceTimersByTime(15_000); // Within TTL window
+		const result = cache.check('/path/to/key', accessFn);
+
+		expect(result).toBe(true);
+		expect(accessFn).toHaveBeenCalledTimes(1);
+	});
+
+	it('call after TTL expiry re-invokes accessFn', () => {
+		const cache = new PathAccessCache(30_000);
+		const accessFn = vi.fn().mockReturnValue(true);
+
+		cache.check('/path/to/key', accessFn);
+		vi.advanceTimersByTime(31_000); // Past TTL
+		cache.check('/path/to/key', accessFn);
+
+		expect(accessFn).toHaveBeenCalledTimes(2);
+	});
+
+	it('different paths are cached independently', () => {
+		const cache = new PathAccessCache(30_000);
+		const accessFn = vi.fn().mockReturnValue(true);
+
+		cache.check('/path/a', accessFn);
+		cache.check('/path/b', accessFn);
+		cache.check('/path/a', accessFn);
+		cache.check('/path/b', accessFn);
+
+		// Each path checked once on first call, hit cache on second
+		expect(accessFn).toHaveBeenCalledTimes(2);
+		expect(accessFn).toHaveBeenCalledWith('/path/a');
+		expect(accessFn).toHaveBeenCalledWith('/path/b');
+	});
+
+	it('false results are NOT cached — re-invokes accessFn on second call', () => {
+		const cache = new PathAccessCache(30_000);
+		const accessFn = vi.fn().mockReturnValue(false);
+
+		const first = cache.check('/missing/key', accessFn);
+		const second = cache.check('/missing/key', accessFn);
+
+		expect(first).toBe(false);
+		expect(second).toBe(false);
+		expect(accessFn).toHaveBeenCalledTimes(2);
+	});
+
+	it('a previously-true path that becomes false drops the cache entry', () => {
+		const cache = new PathAccessCache(30_000);
+		const accessFn = vi
+			.fn()
+			.mockReturnValueOnce(true) // First check: file exists
+			.mockReturnValueOnce(false) // Second (after TTL): user removed it
+			.mockReturnValueOnce(false); // Third (immediate): must NOT see stale true
+
+		cache.check('/path/to/key', accessFn);
+		vi.advanceTimersByTime(31_000); // Past TTL
+		const second = cache.check('/path/to/key', accessFn);
+		// Immediately retry — must re-invoke (false isn't cached)
+		const third = cache.check('/path/to/key', accessFn);
+
+		expect(second).toBe(false);
+		expect(third).toBe(false);
+		expect(accessFn).toHaveBeenCalledTimes(3);
+	});
+
+	it('clear() resets the cache; subsequent calls re-invoke accessFn', () => {
+		const cache = new PathAccessCache(30_000);
+		const accessFn = vi.fn().mockReturnValue(true);
+
+		cache.check('/path/to/key', accessFn);
+		cache.clear();
+		cache.check('/path/to/key', accessFn);
+
+		expect(accessFn).toHaveBeenCalledTimes(2);
+	});
+
+	it('default TTL constant matches the documented 30s window', () => {
+		expect(DEFAULT_PATH_ACCESS_TTL_MS).toBe(30_000);
+	});
+});
+
+describe('getPathAccessCache singleton', () => {
+	afterEach(() => {
+		setPathAccessCacheForTest(null);
+	});
+
+	it('returns the same instance across calls', () => {
+		const a = getPathAccessCache();
+		const b = getPathAccessCache();
+		expect(a).toBe(b);
+	});
+
+	it('setPathAccessCacheForTest(null) drops the singleton so the next get rebuilds', () => {
+		const a = getPathAccessCache();
+		setPathAccessCacheForTest(null);
+		const b = getPathAccessCache();
+		expect(a).not.toBe(b);
+	});
+
+	it('setPathAccessCacheForTest(custom) installs the test cache', () => {
+		const custom = new PathAccessCache(1_000);
+		setPathAccessCacheForTest(custom);
+		expect(getPathAccessCache()).toBe(custom);
+	});
+});

--- a/src/__tests__/renderer/components/SessionList/CueIndicator.test.tsx
+++ b/src/__tests__/renderer/components/SessionList/CueIndicator.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * Tests for {@link CueIndicator} — the Maestro Cue pill rendered next to a
+ * session name when the session has registered subscriptions. Extracted from
+ * SessionItem in Tier 3.3 so the icon can be memoized independently of the
+ * row.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { CueIndicator } from '../../../../renderer/components/SessionList/CueIndicator';
+
+// Mock lucide-react so we can assert on the Zap icon by test id rather than
+// rendering the real SVG (matches the SessionList.test.tsx pattern).
+vi.mock('lucide-react', () => ({
+	Zap: ({ className, style, fill }: { className?: string; style?: object; fill?: string }) => (
+		<span data-testid="icon-zap" className={className} data-fill={fill} style={style} />
+	),
+}));
+
+describe('CueIndicator', () => {
+	it('renders nothing when subscriptionCount is 0', () => {
+		const { container } = render(<CueIndicator subscriptionCount={0} activeRun={false} />);
+		expect(container.firstChild).toBeNull();
+		expect(screen.queryByTestId('icon-zap')).toBeNull();
+	});
+
+	it('renders nothing when subscriptionCount is negative (defensive)', () => {
+		const { container } = render(<CueIndicator subscriptionCount={-1} activeRun={false} />);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it('renders the Zap icon when subscriptionCount is positive', () => {
+		render(<CueIndicator subscriptionCount={1} activeRun={false} />);
+		expect(screen.getByTestId('icon-zap')).toBeInTheDocument();
+	});
+
+	it('adds animate-pulse class when activeRun is true', () => {
+		const { container } = render(<CueIndicator subscriptionCount={1} activeRun={true} />);
+		const wrapper = container.querySelector('span');
+		expect(wrapper?.className).toMatch(/animate-pulse/);
+	});
+
+	it('omits animate-pulse class when activeRun is false', () => {
+		const { container } = render(<CueIndicator subscriptionCount={1} activeRun={false} />);
+		const wrapper = container.querySelector('span');
+		expect(wrapper?.className).not.toMatch(/animate-pulse/);
+	});
+
+	it('tooltip uses singular "subscription" for count of 1 and "active" when not running', () => {
+		render(<CueIndicator subscriptionCount={1} activeRun={false} />);
+		const wrapper = screen.getByTitle(/Maestro Cue/);
+		expect(wrapper.getAttribute('title')).toBe('Maestro Cue active (1 subscription)');
+	});
+
+	it('tooltip uses plural "subscriptions" for count > 1 and "running" when active', () => {
+		render(<CueIndicator subscriptionCount={3} activeRun={true} />);
+		const wrapper = screen.getByTitle(/Maestro Cue/);
+		expect(wrapper.getAttribute('title')).toBe('Maestro Cue running (3 subscriptions)');
+	});
+});

--- a/src/main/ipc/handlers/process.ts
+++ b/src/main/ipc/handlers/process.ts
@@ -2,7 +2,7 @@ import { ipcMain, BrowserWindow } from 'electron';
 import Store from 'electron-store';
 import type { AgentConfigsData } from '../../stores/types';
 import * as os from 'os';
-import * as fs from 'fs';
+import * as fsp from 'fs/promises';
 import * as path from 'path';
 import { ProcessManager } from '../../process-manager';
 import { AgentDetector } from '../../agents';
@@ -260,14 +260,14 @@ export function registerProcessHandlers(deps: ProcessHandlerDependencies): void 
 								tmpDir,
 								`maestro-sysprompt-${config.sessionId}-${Date.now()}.txt`
 							);
-							fs.writeFileSync(systemPromptTempFile, config.appendSystemPrompt, 'utf-8');
+							await fsp.writeFile(systemPromptTempFile, config.appendSystemPrompt, 'utf-8');
 							// Schedule cleanup early so the file is removed even if spawn fails.
 							// 30s gives the agent plenty of time to read it after spawning.
+							// Fire-and-forget unlink mirrors process-manager/utils/imageUtils.cleanupTempFiles:
+							// silence ENOENT (file already gone), capture other codes via Sentry.
 							const tempFileToClean = systemPromptTempFile;
 							setTimeout(() => {
-								try {
-									fs.unlinkSync(tempFileToClean);
-								} catch (cleanupErr: unknown) {
+								fsp.unlink(tempFileToClean).catch((cleanupErr: unknown) => {
 									if ((cleanupErr as NodeJS.ErrnoException).code !== 'ENOENT') {
 										captureException(
 											cleanupErr instanceof Error ? cleanupErr : new Error(String(cleanupErr)),
@@ -277,7 +277,7 @@ export function registerProcessHandlers(deps: ProcessHandlerDependencies): void 
 											}
 										);
 									}
-								}
+								});
 							}, 30_000);
 							finalArgs = [...finalArgs, '--append-system-prompt-file', systemPromptTempFile];
 							logger.debug(

--- a/src/main/ssh-remote-manager.ts
+++ b/src/main/ssh-remote-manager.ts
@@ -5,12 +5,11 @@
  * Used to execute AI agent commands on remote hosts via SSH.
  */
 
-import * as fs from 'fs';
 import { SshRemoteConfig, SshRemoteTestResult } from '../shared/types';
 import { execFileNoThrow, ExecResult } from './utils/execFile';
 import { expandTilde } from '../shared/pathUtils';
 import { captureException } from './utils/sentry';
-import { getPathAccessCache } from './utils/path-access-cache';
+import { getPathAccessCache, defaultReadableProbe } from './utils/path-access-cache';
 
 /**
  * Validation result for SSH remote configuration.
@@ -33,26 +32,14 @@ export interface SshRemoteManagerDeps {
 }
 
 /**
- * Synchronous read-perm probe. Wrapped behind {@link PathAccessCache} in
- * the production deps so rapid re-validation (e.g. consecutive Test
- * Connection clicks) skips the duplicate stat. Test deps mock
- * `checkFileAccess` directly and bypass the cache entirely.
- */
-function rawCheckFileAccess(filePath: string): boolean {
-	try {
-		fs.accessSync(filePath, fs.constants.R_OK);
-		return true;
-	} catch {
-		return false;
-	}
-}
-
-/**
- * Default dependencies using real implementations.
+ * Default dependencies using real implementations. `checkFileAccess` is
+ * wrapped behind {@link PathAccessCache} so rapid re-validation (e.g.
+ * consecutive Test Connection clicks) skips the duplicate stat. Test
+ * deps mock `checkFileAccess` directly and bypass the cache entirely.
  */
 const defaultDeps: SshRemoteManagerDeps = {
 	checkFileAccess: (filePath: string): boolean => {
-		return getPathAccessCache().check(filePath, rawCheckFileAccess);
+		return getPathAccessCache().check(filePath, defaultReadableProbe);
 	},
 	execSsh: (command: string, args: string[]): Promise<ExecResult> => {
 		return execFileNoThrow(command, args);

--- a/src/main/ssh-remote-manager.ts
+++ b/src/main/ssh-remote-manager.ts
@@ -10,6 +10,7 @@ import { SshRemoteConfig, SshRemoteTestResult } from '../shared/types';
 import { execFileNoThrow, ExecResult } from './utils/execFile';
 import { expandTilde } from '../shared/pathUtils';
 import { captureException } from './utils/sentry';
+import { getPathAccessCache } from './utils/path-access-cache';
 
 /**
  * Validation result for SSH remote configuration.
@@ -32,16 +33,26 @@ export interface SshRemoteManagerDeps {
 }
 
 /**
+ * Synchronous read-perm probe. Wrapped behind {@link PathAccessCache} in
+ * the production deps so rapid re-validation (e.g. consecutive Test
+ * Connection clicks) skips the duplicate stat. Test deps mock
+ * `checkFileAccess` directly and bypass the cache entirely.
+ */
+function rawCheckFileAccess(filePath: string): boolean {
+	try {
+		fs.accessSync(filePath, fs.constants.R_OK);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/**
  * Default dependencies using real implementations.
  */
 const defaultDeps: SshRemoteManagerDeps = {
 	checkFileAccess: (filePath: string): boolean => {
-		try {
-			fs.accessSync(filePath, fs.constants.R_OK);
-			return true;
-		} catch {
-			return false;
-		}
+		return getPathAccessCache().check(filePath, rawCheckFileAccess);
 	},
 	execSsh: (command: string, args: string[]): Promise<ExecResult> => {
 		return execFileNoThrow(command, args);

--- a/src/main/utils/path-access-cache.ts
+++ b/src/main/utils/path-access-cache.ts
@@ -14,10 +14,15 @@
  *     path: if a user fixes file permissions or writes a missing key and
  *     immediately retries, they must see a fresh check, not a stale `false`.
  *
- * SRP: this module caches a boolean predicate result. It does not perform
- * the access itself — the caller passes the access function. This keeps
- * `fs.accessSync` out of the cache and lets tests inject any predicate.
+ * SRP: the cache class itself does not perform the access — callers pass an
+ * access function. The default probe is exported alongside (rather than
+ * embedded in `check()`) so the cache stays a pure predicate-cache and
+ * tests can still inject any boolean function. SOC: production deps in
+ * SSH modules import {@link defaultReadableProbe} once instead of each
+ * carrying their own try/`accessSync`/catch copy.
  */
+
+import * as fs from 'fs';
 
 export interface PathAccessCacheEntry {
 	readable: true;
@@ -25,6 +30,25 @@ export interface PathAccessCacheEntry {
 }
 
 export const DEFAULT_PATH_ACCESS_TTL_MS = 30_000;
+
+/**
+ * Default synchronous read-permission probe. Returns `true` iff the path
+ * exists AND is readable by the current process; swallows ENOENT/EACCES/
+ * etc. as `false`.
+ *
+ * Shared by every SSH `defaultDeps` site so the try/`accessSync`/catch
+ * pattern lives in exactly one place. Tests that wire their own
+ * `checkFileAccess` / `fileExists` predicate via DI bypass this entirely
+ * — the helper is only used by production deps.
+ */
+export function defaultReadableProbe(filePath: string): boolean {
+	try {
+		fs.accessSync(filePath, fs.constants.R_OK);
+		return true;
+	} catch {
+		return false;
+	}
+}
 
 export class PathAccessCache {
 	private cache = new Map<string, PathAccessCacheEntry>();

--- a/src/main/utils/path-access-cache.ts
+++ b/src/main/utils/path-access-cache.ts
@@ -1,0 +1,76 @@
+/**
+ * Path Access Cache
+ *
+ * Caches positive readability checks for filesystem paths to avoid repeated
+ * `fs.accessSync` calls on the same path within a short window. Designed for
+ * the SSH validation surfaces ([SshRemoteManager.validateConfig] and
+ * [parseSshConfig]) where the same identity-file or `~/.ssh/config` path
+ * gets re-checked across consecutive Test Connection clicks or rapid Save
+ * operations.
+ *
+ * Invalidation strategy:
+ *   - Positive results (`true`) are cached for `ttlMs`.
+ *   - Negative results are NEVER cached. False is the user-actionable error
+ *     path: if a user fixes file permissions or writes a missing key and
+ *     immediately retries, they must see a fresh check, not a stale `false`.
+ *
+ * SRP: this module caches a boolean predicate result. It does not perform
+ * the access itself — the caller passes the access function. This keeps
+ * `fs.accessSync` out of the cache and lets tests inject any predicate.
+ */
+
+export interface PathAccessCacheEntry {
+	readable: true;
+	checkedAt: number;
+}
+
+export const DEFAULT_PATH_ACCESS_TTL_MS = 30_000;
+
+export class PathAccessCache {
+	private cache = new Map<string, PathAccessCacheEntry>();
+	private readonly ttlMs: number;
+
+	constructor(ttlMs: number = DEFAULT_PATH_ACCESS_TTL_MS) {
+		this.ttlMs = ttlMs;
+	}
+
+	/**
+	 * Returns whether `filePath` is readable. If a cached `true` exists and
+	 * is younger than `ttlMs`, returns it without invoking `accessFn`.
+	 * Otherwise calls `accessFn(filePath)` and caches `true` results only.
+	 */
+	check(filePath: string, accessFn: (p: string) => boolean): boolean {
+		const cached = this.cache.get(filePath);
+		if (cached && Date.now() - cached.checkedAt < this.ttlMs) {
+			return true;
+		}
+
+		const result = accessFn(filePath);
+		if (result) {
+			this.cache.set(filePath, { readable: true, checkedAt: Date.now() });
+		} else {
+			// Drop any stale `true` entry for this path so a previously-readable
+			// file that was just removed/permissioned-out doesn't keep returning true.
+			this.cache.delete(filePath);
+		}
+		return result;
+	}
+
+	/** Clear all cached entries. Used by tests and on explicit reset. */
+	clear(): void {
+		this.cache.clear();
+	}
+}
+
+let instance: PathAccessCache | null = null;
+
+/** Process-wide singleton used by production deps in SSH modules. */
+export function getPathAccessCache(): PathAccessCache {
+	if (!instance) instance = new PathAccessCache();
+	return instance;
+}
+
+/** Test seam — replace the singleton with a controllable cache. */
+export function setPathAccessCacheForTest(cache: PathAccessCache | null): void {
+	instance = cache;
+}

--- a/src/main/utils/ssh-config-parser.ts
+++ b/src/main/utils/ssh-config-parser.ts
@@ -11,6 +11,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { expandTilde } from '../../shared/pathUtils';
+import { getPathAccessCache } from './path-access-cache';
 
 /**
  * Parsed SSH config host entry.
@@ -66,6 +67,21 @@ export interface SshConfigParserDeps {
 }
 
 /**
+ * Synchronous read-perm probe. Production deps wrap this in
+ * {@link PathAccessCache} so consecutive `parseSshConfig` calls (e.g. UI
+ * autocomplete refreshes) skip the duplicate stat. Test deps mock
+ * `fileExists` directly and bypass the cache entirely.
+ */
+function rawFileExists(filePath: string): boolean {
+	try {
+		fs.accessSync(filePath, fs.constants.R_OK);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/**
  * Default dependencies using real implementations.
  */
 function getDefaultDeps(): SshConfigParserDeps {
@@ -74,12 +90,7 @@ function getDefaultDeps(): SshConfigParserDeps {
 			return fs.readFileSync(filePath, 'utf-8');
 		},
 		fileExists: (filePath: string): boolean => {
-			try {
-				fs.accessSync(filePath, fs.constants.R_OK);
-				return true;
-			} catch {
-				return false;
-			}
+			return getPathAccessCache().check(filePath, rawFileExists);
 		},
 		homeDir: process.env.HOME || process.env.USERPROFILE || '',
 	};

--- a/src/main/utils/ssh-config-parser.ts
+++ b/src/main/utils/ssh-config-parser.ts
@@ -11,7 +11,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { expandTilde } from '../../shared/pathUtils';
-import { getPathAccessCache } from './path-access-cache';
+import { getPathAccessCache, defaultReadableProbe } from './path-access-cache';
 
 /**
  * Parsed SSH config host entry.
@@ -67,22 +67,10 @@ export interface SshConfigParserDeps {
 }
 
 /**
- * Synchronous read-perm probe. Production deps wrap this in
- * {@link PathAccessCache} so consecutive `parseSshConfig` calls (e.g. UI
- * autocomplete refreshes) skip the duplicate stat. Test deps mock
+ * Default dependencies using real implementations. `fileExists` is wrapped
+ * in {@link PathAccessCache} so consecutive `parseSshConfig` calls (e.g.
+ * UI autocomplete refreshes) skip the duplicate stat. Test deps mock
  * `fileExists` directly and bypass the cache entirely.
- */
-function rawFileExists(filePath: string): boolean {
-	try {
-		fs.accessSync(filePath, fs.constants.R_OK);
-		return true;
-	} catch {
-		return false;
-	}
-}
-
-/**
- * Default dependencies using real implementations.
  */
 function getDefaultDeps(): SshConfigParserDeps {
 	return {
@@ -90,7 +78,7 @@ function getDefaultDeps(): SshConfigParserDeps {
 			return fs.readFileSync(filePath, 'utf-8');
 		},
 		fileExists: (filePath: string): boolean => {
-			return getPathAccessCache().check(filePath, rawFileExists);
+			return getPathAccessCache().check(filePath, defaultReadableProbe);
 		},
 		homeDir: process.env.HOME || process.env.USERPROFILE || '',
 	};

--- a/src/renderer/components/SessionItem.tsx
+++ b/src/renderer/components/SessionItem.tsx
@@ -6,12 +6,12 @@ import {
 	Bookmark,
 	AlertCircle,
 	Server,
-	Zap,
 	FolderTree,
 	ChevronRight,
 } from 'lucide-react';
 import { GhostIconButton } from './ui/GhostIconButton';
 import { WorktreePill } from './ui/WorktreePill';
+import { CueIndicator } from './SessionList/CueIndicator';
 import { useSettingsStore } from '../stores/settingsStore';
 import type { Session, Group, Theme } from '../types';
 
@@ -285,15 +285,11 @@ export const SessionItem = memo(function SessionItem({
 						>
 							{session.name}
 						</span>
-						{/* Maestro Cue indicator: subscriptions registered (and pulsing when running) */}
-						{cueSubscriptionCount != null && cueSubscriptionCount > 0 && (
-							<span
-								className={`shrink-0 flex items-center${cueActiveRun ? ' animate-pulse' : ''}`}
-								title={`Maestro Cue ${cueActiveRun ? 'running' : 'active'} (${cueSubscriptionCount} subscription${cueSubscriptionCount === 1 ? '' : 's'})`}
-							>
-								<Zap className="w-3 h-3" style={{ color: '#2dd4bf' }} fill="#2dd4bf" />
-							</span>
-						)}
+						{/* Maestro Cue indicator: subscriptions registered (and pulsing when running). */}
+						<CueIndicator
+							subscriptionCount={cueSubscriptionCount ?? 0}
+							activeRun={!!cueActiveRun}
+						/>
 						{/* Worktree badge to visually mark worktree children */}
 						{variant === 'worktree' && showWorktreePill && <WorktreePill theme={theme} />}
 					</div>

--- a/src/renderer/components/SessionList/CueIndicator.tsx
+++ b/src/renderer/components/SessionList/CueIndicator.tsx
@@ -1,0 +1,41 @@
+import { memo } from 'react';
+import { Zap } from 'lucide-react';
+
+interface CueIndicatorProps {
+	/** Number of Cue subscriptions registered for this session. */
+	subscriptionCount: number;
+	/** Whether a Cue run is currently active (drives the pulse animation). */
+	activeRun: boolean;
+}
+
+const ZAP_STYLE = { color: '#2dd4bf' } as const;
+
+/**
+ * Maestro Cue indicator pill rendered next to the session name.
+ *
+ * Memo'd because SessionItem renders one of these per row in the Left Bar
+ * and the props are all primitive — React's default shallow compare lets
+ * this component skip re-renders when only unrelated parent state changes.
+ *
+ * Hidden entirely when `subscriptionCount <= 0` so SessionItem can use
+ * `<CueIndicator ... />` unconditionally instead of a parent-side guard.
+ */
+export const CueIndicator = memo(function CueIndicator({
+	subscriptionCount,
+	activeRun,
+}: CueIndicatorProps) {
+	if (subscriptionCount <= 0) return null;
+
+	const tooltip = `Maestro Cue ${activeRun ? 'running' : 'active'} (${subscriptionCount} subscription${
+		subscriptionCount === 1 ? '' : 's'
+	})`;
+
+	return (
+		<span
+			className={`shrink-0 flex items-center${activeRun ? ' animate-pulse' : ''}`}
+			title={tooltip}
+		>
+			<Zap className="w-3 h-3" style={ZAP_STYLE} fill="#2dd4bf" />
+		</span>
+	);
+});

--- a/src/renderer/components/SessionList/index.ts
+++ b/src/renderer/components/SessionList/index.ts
@@ -1,1 +1,2 @@
 export { SessionList } from './SessionList';
+export { CueIndicator } from './CueIndicator';


### PR DESCRIPTION
## Summary

Perf improvement with three small, independently-revertible commits. None of them are individually large wins, but together they remove anti-patterns that drift the codebase away from `CLAUDE-PERFORMANCE.md` guidance and clear the perf backlog ahead of Tier 4 (renderer decomposition).

| Commit | Item | Net |
| --- | --- | --- |
| `0cdf66f23` | SSH path access cache | New `PathAccessCache` utility; 30s TTL on positive results only; injected into `SshRemoteManager` + `SshConfigParser` defaults via the existing DI seam — zero existing-test churn |
| `199b08ce2` | Async Windows spawn temp file | `fs.writeFileSync` / `fs.unlinkSync` → `fs/promises`; cleanup mirrors the fire-and-forget `imageUtils.cleanupTempFiles` pattern (ENOENT silenced, other codes route to Sentry) |
| `02e37fd31` | Memo'd CueIndicator subcomponent | Extracts the Maestro Cue pill from `SessionItem` so its memo boundary is independent of the row; primitive props only |

`+22 new tests, 0 modified, 27,346/27,346 full-suite pass, lint + tsc + eslint clean.`

---

## SSH path access cache

Two SSH validation surfaces were re-stat'ing the same identity files and `~/.ssh/config` across consecutive Test Connection clicks and Save operations:

- `SshRemoteManager.validateConfig` → `fs.accessSync` per private-key path
- `parseSshConfig` → `fs.accessSync` on `~/.ssh/config`

Neither is hot, but both are pure waste at any retry rate above zero.

**New utility** at `src/main/utils/path-access-cache.ts`:

- 30s TTL on positive (`true`) results only
- **Negative results are NEVER cached** — that's the user-actionable error path; a user fixing perms must see a fresh check, not a stale `false`
- Pure caller-supplied predicate; the cache itself does no I/O. Keeps `fs` out of the cache module so tests can inject any boolean function
- Module-level singleton with a `setPathAccessCacheForTest` seam

**Wiring** preserves the existing DI shape:

- `SshRemoteManager.defaultDeps.checkFileAccess` routes through cache
- `SshConfigParser.defaultDeps.fileExists` routes through cache
- Both modules' test deps mock the predicate directly and **bypass the cache entirely** — zero churn on the existing 38 + 25 SSH tests

11 new tests cover hit / miss / TTL expiry, per-path isolation, the false-not-cached invariant, stale-true-drops-on-false, `clear()`, and the singleton seam.

---

## Async Windows spawn temp file

The Windows-only `--append-system-prompt-file` branch in `process:spawn` wrote the temp file synchronously and unlinked it synchronously inside a `setTimeout`. The handler is already `async` (`withIpcErrorLogging` wraps an async handler), so converting to `fs/promises` is straightforward and removes two main-process-blocking calls from the spawn path.

Mirrors the existing fire-and-forget pattern in `src/main/process-manager/utils/imageUtils.ts`:

```ts
await fsp.writeFile(tempPath, content, 'utf-8');
setTimeout(() => {
    fsp.unlink(p).catch((err) => {
        if (err.code !== 'ENOENT') captureException(err, { context, file: p });
    });
}, 30_000);
```

**Behavior preserved:**

- ENOENT on cleanup is silenced (file already gone is benign)
- Non-ENOENT errors route to Sentry with the same context payload
- Outer `withIpcErrorLogging` wrapper still catches both synchronous AND asynchronous-rejection errors from the handler body — no IPC error-shape change for write failures

**4 new tests** in `appendSystemPrompt delivery > Windows temp prompt file (async fs/promises)` exercise: writeFile call, scheduled unlink after 30s, ENOENT silence, EACCES → captureException. Module-level `vi.mock('fs/promises')` + `vi.mock(sentry)`; `platformDetection` mock defaults to host platform so the existing platform-branching test still works on Windows CI.

---

## Memo'd CueIndicator subcomponent

`SessionItem` renders ~13 lucide-react icon instances per row. The component is already `memo`'d at the row boundary, but inside the memo'd shell every render rebuilds every icon. The Maestro Cue indicator is the only icon cluster with conditional animation (`animate-pulse` when `activeRun`) and non-trivial JSX (tooltip text built from two flags), so it pays the most to give it its own memo boundary with primitive props.

**New component** at `src/renderer/components/SessionList/CueIndicator.tsx`:

- `memo`'d with primitive props (`subscriptionCount`, `activeRun`)
- Returns `null` when `subscriptionCount <= 0` so `SessionItem` renders it unconditionally
- Inlined `style={{ color: '#2dd4bf' }}` stays inside the memo boundary

**SessionItem changes:**

- Replaced the 8-line inline Cue indicator with `<CueIndicator ... />`
- Dropped the now-unused `Zap` import

**Deliberately deferred** per the plan (avoid over-engineering without CDP data):

- `SshRemotePill` / `GitDirtyBadge` — single-purpose 4–5 line snippets; extracting them adds prop-passing cost that may exceed the icon-instantiation cost they save
- 18 inline-style objects on plain DOM nodes — React doesn't re-render plain DOM differently based on style-object identity; over-memoizing is noise that bloats hook count
- `Bookmark` / `AlertCircle` / `Bot` / `Activity` — single-conditional or always-on; no extraction value

**7 new tests** in `__tests__/renderer/components/SessionList/CueIndicator.test.tsx` cover: hidden when count ≤ 0, renders Zap when positive, animate-pulse class toggles with `activeRun`, singular/plural tooltip text, "running" vs "active" string. Existing 11 `SessionItemCue` + 135 `SessionList` tests all green — DOM is identical to the inline version.

---

## SRP / SOC

- `PathAccessCache` does ONE thing (cache a boolean predicate). It does not perform the access; the caller passes `accessFn`. Decoupled from `fs` entirely.
- Inline migration mirrors the precedent in `imageUtils.cleanupTempFiles`. Extracting a helper for a single caller would either schedule the cleanup timer from a "write" helper (worse SRP) or leak the timer handle (worse SOC). Re-evaluate only if a second caller appears.
- `CueIndicator` owns one concern: rendering the Maestro Cue pill. Primitive props mean React's default memo shallow-compare is sufficient.

## Test plan

- **SSH cache:** Settings → SSH Remote → click Test Connection twice within 30s on a remote with a valid key; second click should not re-stat (verify with `fs_usage` on macOS or DevTools-side counters in dev). Edit `privateKeyPath` to a missing file → fail; restore the path → next click succeeds (no stale `false`).
- **Windows spawn:** (Windows only) spawn an agent with a long `appendSystemPrompt`; verify `%TEMP%\maestro-sysprompt-<sessionId>-<ts>.txt` exists immediately, gone after 30s. Spawn 3 in a row → all 3 cleaned up. Kill agent before 30s → temp file still cleaned up. (macOS/Linux) verify NO temp file is written (inline `--append-system-prompt` path).
- **CueIndicator:** create a Cue subscription on a session → Zap pill appears next to the name with tooltip `"Maestro Cue active (1 subscription)"`. Add a second → tooltip becomes `"... (2 subscriptions)"`. Trigger a Cue run → pulses with `"Maestro Cue running ..."`. Run completes → animation stops, tooltip reverts. Remove all subscriptions → pill disappears.
- **Cross-cutting:** cold-start splash appears as fast as before; switch themes — Cue indicator repaints cleanly; type rapidly with 30+ sessions — no typing-lag regression (Tier 1 perf wins still hold); DevTools console — no new warnings, no React hook-order errors, no unhandled-promise-rejection from the cleanup setTimeout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Cue Indicator component showing Maestro Cue status and animated pulse when active.

* **Performance Improvements**
  * Added caching for filesystem readability checks to reduce redundant probes.
  * Improved Windows system-prompt temp-file handling to use asynchronous operations for more reliable cleanup.

* **Tests**
  * Expanded test coverage for the Cue Indicator, path access caching behavior, and Windows temp-file handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->