### PR TITLE
fix(terminal): number tabs by creation order, not visual position

### DIFF
--- a/src/__tests__/renderer/components/TabBar.test.tsx
+++ b/src/__tests__/renderer/components/TabBar.test.tsx
@@ -4631,6 +4631,66 @@ describe('Unified tabs drag and drop', () => {
 		// Should call onUnifiedTabReorder with index 1 -> 2 (last index)
 		expect(mockOnUnifiedTabReorder).toHaveBeenCalledWith(1, 2);
 	});
+
+	// Regression: when the user clicks back to an AI tab and then opens a 2nd
+	// terminal, addTerminalTab inserts the new terminal directly after the AI
+	// tab — which places it visually to the LEFT of the existing terminal.
+	// "Terminal N" labels must follow creation order so the older terminal
+	// stays "Terminal 1" and the new one becomes "Terminal 2".
+	it('numbers terminal tabs by creation order, not visual position', () => {
+		const olderTerminal = {
+			id: 'term-older',
+			name: null,
+			shellType: 'zsh',
+			pid: 100,
+			cwd: '/test',
+			createdAt: 1000,
+			state: 'idle' as const,
+		};
+		const newerTerminal = {
+			id: 'term-newer',
+			name: null,
+			shellType: 'zsh',
+			pid: 200,
+			cwd: '/test',
+			createdAt: 2000,
+			state: 'idle' as const,
+		};
+
+		// Newer terminal sits BEFORE the older terminal in visual order
+		// (mirrors what addTerminalTab produces when an AI tab is active).
+		const unifiedTabsReversed = [
+			{ type: 'ai' as const, id: 'ai-tab-1', data: aiTab1 },
+			{ type: 'terminal' as const, id: 'term-newer', data: newerTerminal },
+			{ type: 'terminal' as const, id: 'term-older', data: olderTerminal },
+		];
+
+		render(
+			<TabBar
+				tabs={aiTabs}
+				activeTabId="ai-tab-1"
+				theme={mockTheme}
+				onTabSelect={vi.fn()}
+				onTabClose={vi.fn()}
+				onNewTab={vi.fn()}
+				unifiedTabs={unifiedTabsReversed}
+				activeFileTabId={null}
+				onFileTabSelect={mockOnFileTabSelect}
+				onFileTabClose={mockOnFileTabClose}
+				onTerminalTabSelect={vi.fn()}
+				onTerminalTabClose={vi.fn()}
+			/>
+		);
+
+		expect(screen.getByText('Terminal 1').closest('[data-tab-id]')).toHaveAttribute(
+			'data-tab-id',
+			'term-older'
+		);
+		expect(screen.getByText('Terminal 2').closest('[data-tab-id]')).toHaveAttribute(
+			'data-tab-id',
+			'term-newer'
+		);
+	});
 });
 
 describe('Unified active tab styling consistency', () => {

--- a/src/renderer/components/TabBar/TabBar.tsx
+++ b/src/renderer/components/TabBar/TabBar.tsx
@@ -308,6 +308,22 @@ function TabBarInner({
 	// Shared props computed once for the rendering loop
 	const allTabs = unifiedTabs ?? [];
 
+	// Map of terminal-tab id → display index, ordered by creation time so the
+	// "Terminal N" label reflects the order the user opened them — not the
+	// position in the visual tab strip. Without this, opening a 2nd terminal
+	// while an AI tab is active inserts the new terminal to the LEFT of the
+	// existing one (insertAfterActiveInUnifiedTabOrder), which would otherwise
+	// make the new tab "Terminal 1" and rename the original to "Terminal 2".
+	const terminalIndexById = useMemo(() => {
+		const terminals = allTabs.flatMap((ut) =>
+			ut.type === 'terminal' ? [{ id: ut.id, createdAt: ut.data.createdAt }] : []
+		);
+		terminals.sort((a, b) => a.createdAt - b.createdAt);
+		const map = new Map<string, number>();
+		terminals.forEach((t, idx) => map.set(t.id, idx));
+		return map;
+	}, [allTabs]);
+
 	/** Render a separator bar between inactive tabs */
 	const separator = (
 		<div
@@ -519,9 +535,7 @@ function TabBarInner({
 							);
 						} else if (unifiedTab.type === 'terminal') {
 							const terminalTab = unifiedTab.data;
-							const terminalIndex = allTabs
-								.filter((ut) => ut.type === 'terminal')
-								.findIndex((ut) => ut.id === unifiedTab.id);
+							const terminalIndex = terminalIndexById.get(unifiedTab.id) ?? 0;
 							return (
 								<React.Fragment key={unifiedTab.id}>
 									{showSeparator && separator}


### PR DESCRIPTION
## Summary

- Opening a 2nd terminal while an AI tab is active caused the new terminal to display as "Terminal 1" and the original to be re-labeled "Terminal 2"
- Root cause: `TabBar.tsx` computed the `Terminal N` index from the visual `unifiedTabs` order, but `addTerminalTab` inserts the new terminal directly after the currently-active tab — placing it visually to the LEFT of the existing terminal when an AI tab is active
- Replaced the visual-order `findIndex` with a `useMemo`-cached `terminalIndexById` map sorted by `data.createdAt`, aligning TabBar with the storage-order indexing already used in `MainPanel.tsx` and `AppSessionModals.tsx`

## Test plan

- [x] New regression test in `TabBar.test.tsx` renders a unified tab list where the newer terminal sits before the older one in visual order, asserts older stays "Terminal 1" / newer becomes "Terminal 2"
- [x] TabBar test suite: 171 pass / 0 fail
- [x] terminalTabHelpers + AppSessionModals tests: 57 pass / 0 fail
- [x] TypeScript clean on changed files
- [x] Prettier + ESLint clean
- [ ] Manual: open agent → open Terminal → click AI tab → open another Terminal → verify they read "Terminal 1" / "Terminal 2" in creation order

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed terminal tab numbering to correctly reflect creation order, ensuring "Terminal 1" and "Terminal 2" labels remain consistent with their actual terminal tabs even when displayed in different visual order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->