### PR TITLE
feat(git): add graph view + branch switcher dropdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
 				"@fastify/rate-limit": "^9.1.0",
 				"@fastify/static": "^7.0.4",
 				"@fastify/websocket": "^9.0.0",
+				"@gitgraph/react": "^1.6.0",
 				"@lezer/highlight": "^1.2.3",
 				"@napi-rs/keyring": "1.3.0",
 				"@opencode-ai/sdk": "^1.17.13",
@@ -2441,6 +2442,24 @@
 			"integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@gitgraph/core": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@gitgraph/core/-/core-1.5.0.tgz",
+			"integrity": "sha512-8CeeHbkKoFHM1y9vfjYiHyEpzl1mEhVrg5c/eFgDBsntOYswoDKU2yOf6DjtVINcE60wmcuynBSJqjMkQo07Ww==",
+			"license": "MIT"
+		},
+		"node_modules/@gitgraph/react": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@gitgraph/react/-/react-1.6.0.tgz",
+			"integrity": "sha512-cLFNZDoEiNbsnMfdT82zeZti5saYghQamfCbTpVvCRr+BrrQ/k94glkZqYPXKKNTEqbQV6L9JeOfAk1hNiFYXA==",
+			"license": "MIT",
+			"dependencies": {
+				"@gitgraph/core": "1.5.0"
+			},
+			"peerDependencies": {
+				"react": ">= 16.8.0"
+			}
 		},
 		"node_modules/@humanfs/core": {
 			"version": "0.19.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
 				"@fastify/rate-limit": "^9.1.0",
 				"@fastify/static": "^7.0.4",
 				"@fastify/websocket": "^9.0.0",
+				"@gitgraph/core": "^1.5.0",
 				"@gitgraph/react": "^1.6.0",
 				"@lezer/highlight": "^1.2.3",
 				"@napi-rs/keyring": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -305,6 +305,7 @@
 		"@fastify/rate-limit": "^9.1.0",
 		"@fastify/static": "^7.0.4",
 		"@fastify/websocket": "^9.0.0",
+		"@gitgraph/react": "^1.6.0",
 		"@lezer/highlight": "^1.2.3",
 		"@opencode-ai/sdk": "^1.17.13",
 		"@sentry/electron": "^7.13.0",

--- a/package.json
+++ b/package.json
@@ -305,6 +305,7 @@
 		"@fastify/rate-limit": "^9.1.0",
 		"@fastify/static": "^7.0.4",
 		"@fastify/websocket": "^9.0.0",
+		"@gitgraph/core": "^1.5.0",
 		"@gitgraph/react": "^1.6.0",
 		"@lezer/highlight": "^1.2.3",
 		"@opencode-ai/sdk": "^1.17.13",

--- a/src/__tests__/renderer/components/MainPanel.test.tsx
+++ b/src/__tests__/renderer/components/MainPanel.test.tsx
@@ -1872,6 +1872,34 @@ describe('MainPanel', () => {
 			expect(gitService.getBranches).toHaveBeenCalled();
 		});
 
+		it('should open branch switcher on Shift+Enter on SSH remote git badge (keyboard a11y)', async () => {
+			const session = createSession({
+				isGitRepo: true,
+				sessionSshRemoteConfig: { enabled: true, remoteId: 'ssh-remote-123' },
+			});
+
+			const mockGetConfigs = vi.fn().mockResolvedValue({
+				success: true,
+				configs: [{ id: 'ssh-remote-123', name: 'my-ssh-remote' }],
+			});
+			vi.mocked(window.maestro.sshRemote.getConfigs).mockImplementation(mockGetConfigs);
+
+			render(<MainPanel {...defaultProps} activeSession={session} />);
+
+			await waitFor(() => {
+				expect(screen.getByText('my-ssh-remote')).toBeInTheDocument();
+			});
+
+			// The chip's button is the parent of the SSH remote name span.
+			const chipButton = screen.getByText('my-ssh-remote').closest('button');
+			expect(chipButton).not.toBeNull();
+			fireEvent.keyDown(chipButton!, { key: 'Enter', shiftKey: true });
+
+			// Branch switcher dropdown opens via the keyboard path.
+			expect(await screen.findByPlaceholderText(/Filter branches/)).toBeInTheDocument();
+			expect(gitService.getBranches).toHaveBeenCalled();
+		});
+
 		it('should open git log when single-clicking on SSH remote git badge', async () => {
 			const setGitLogOpen = vi.fn();
 			const session = createSession({

--- a/src/__tests__/renderer/components/MainPanel.test.tsx
+++ b/src/__tests__/renderer/components/MainPanel.test.tsx
@@ -45,6 +45,12 @@ function makeWindowState(partial: Partial<WindowState> & Pick<WindowState, 'id'>
 
 // Mock child components to simplify testing - must be before MainPanel import
 
+// useModalLayer is no-op in tests - MainPanel does not provide LayerStackProvider,
+// and the BranchSwitcherDropdown registers a layer when rendered.
+vi.mock('../../../renderer/hooks/ui/useModalLayer', () => ({
+	useModalLayer: () => {},
+}));
+
 // LayerStack: MainPanelContent reads layerCount to blur the browser webview when a
 // modal/overlay is layered above it. These tests render MainPanel in isolation
 // without a LayerStackProvider, so stub the hook (no layers open => layerCount 0).
@@ -239,6 +245,9 @@ vi.mock('../../../renderer/components/InlineWizard', () => ({
 vi.mock('../../../renderer/services/git', () => ({
 	gitService: {
 		getDiff: vi.fn().mockResolvedValue({ diff: 'mock diff content' }),
+		getBranches: vi.fn().mockResolvedValue([]),
+		getGraph: vi.fn().mockResolvedValue([]),
+		switchBranch: vi.fn().mockResolvedValue({ success: true, stderr: '' }),
 	},
 }));
 
@@ -1837,14 +1846,39 @@ describe('MainPanel', () => {
 			expect(writeText).toHaveBeenCalledWith('main');
 		});
 
-		it('should open git log when clicking on SSH remote git badge', async () => {
-			const setGitLogOpen = vi.fn();
+		it('should open branch switcher when double-clicking on SSH remote git badge', async () => {
 			const session = createSession({
 				isGitRepo: true,
 				sessionSshRemoteConfig: { enabled: true, remoteId: 'ssh-remote-123' },
 			});
 
 			// Mock SSH remote name resolution
+			const mockGetConfigs = vi.fn().mockResolvedValue({
+				success: true,
+				configs: [{ id: 'ssh-remote-123', name: 'my-ssh-remote' }],
+			});
+			vi.mocked(window.maestro.sshRemote.getConfigs).mockImplementation(mockGetConfigs);
+
+			render(<MainPanel {...defaultProps} activeSession={session} />);
+
+			await waitFor(() => {
+				expect(screen.getByText('my-ssh-remote')).toBeInTheDocument();
+			});
+
+			fireEvent.doubleClick(screen.getByText('my-ssh-remote'));
+
+			// Branch switcher dropdown opens (revealed by its filter input).
+			expect(await screen.findByPlaceholderText(/Filter branches/)).toBeInTheDocument();
+			expect(gitService.getBranches).toHaveBeenCalled();
+		});
+
+		it('should open git log when single-clicking on SSH remote git badge', async () => {
+			const setGitLogOpen = vi.fn();
+			const session = createSession({
+				isGitRepo: true,
+				sessionSshRemoteConfig: { enabled: true, remoteId: 'ssh-remote-123' },
+			});
+
 			const mockGetConfigs = vi.fn().mockResolvedValue({
 				success: true,
 				configs: [{ id: 'ssh-remote-123', name: 'my-ssh-remote' }],
@@ -1859,7 +1893,8 @@ describe('MainPanel', () => {
 
 			fireEvent.click(screen.getByText('my-ssh-remote'));
 
-			expect(setGitLogOpen).toHaveBeenCalledWith(true);
+			// Single click is debounced (~220ms) before opening git log.
+			await waitFor(() => expect(setGitLogOpen).toHaveBeenCalledWith(true), { timeout: 1000 });
 		});
 
 		it('should call gitService.getDiff with SSH remote ID when session has SSH remote config enabled', async () => {

--- a/src/main/ipc/handlers/git.ts
+++ b/src/main/ipc/handlers/git.ts
@@ -464,6 +464,72 @@ export function registerGitHandlers(deps: GitHandlerDependencies): void {
 		)
 	);
 
+	// Topology data for graph view: includes parent hashes for lane rendering.
+	ipcMain.handle(
+		'git:graph',
+		withIpcErrorLogging(
+			handlerOpts('graph'),
+			async (
+				cwd: string,
+				options?: { limit?: number },
+				sshRemoteId?: string,
+				remoteCwd?: string
+			) => {
+				const sshRemote = sshRemoteId ? getSshRemoteById(sshRemoteId) : undefined;
+				const effectiveRemoteCwd = sshRemote ? remoteCwd || cwd : undefined;
+				const limit = options?.limit || 200;
+				const args = [
+					'log',
+					'--all',
+					`--max-count=${limit}`,
+					'--pretty=format:GRAPH_START%H|%P|%an|%ad|%D|%s',
+					'--date=iso-strict',
+				];
+				const result = await execGit(args, cwd, sshRemote, effectiveRemoteCwd);
+				if (result.exitCode !== 0) {
+					return { nodes: [], error: result.stderr };
+				}
+				const nodes = result.stdout
+					.split('GRAPH_START')
+					.filter((c) => c.trim())
+					.map((block) => {
+						const trimmed = block.trim();
+						const [hash = '', parents = '', author = '', date = '', refs = '', ...subj] =
+							trimmed.split('|');
+						return {
+							hash,
+							shortHash: hash.slice(0, 7),
+							parents: parents ? parents.split(' ').filter(Boolean) : [],
+							author,
+							date,
+							refs: refs ? refs.split(', ').filter((r) => r.trim()) : [],
+							subject: subj.join('|'),
+						};
+					});
+				return { nodes, error: null };
+			}
+		)
+	);
+
+	// Switch to an existing branch in the current working tree.
+	// Returns success=false with stderr text on failure (e.g., dirty working tree).
+	ipcMain.handle(
+		'git:switch',
+		withIpcErrorLogging(
+			handlerOpts('switch'),
+			async (cwd: string, branchName: string, sshRemoteId?: string, remoteCwd?: string) => {
+				const sshRemote = sshRemoteId ? getSshRemoteById(sshRemoteId) : undefined;
+				const effectiveRemoteCwd = sshRemote ? remoteCwd || cwd : undefined;
+				const result = await execGit(['switch', branchName], cwd, sshRemote, effectiveRemoteCwd);
+				return {
+					success: result.exitCode === 0,
+					stdout: result.stdout,
+					stderr: result.stderr,
+				};
+			}
+		)
+	);
+
 	ipcMain.handle(
 		'git:commitCount',
 		withIpcErrorLogging(

--- a/src/main/ipc/handlers/git.ts
+++ b/src/main/ipc/handlers/git.ts
@@ -478,11 +478,15 @@ export function registerGitHandlers(deps: GitHandlerDependencies): void {
 				const sshRemote = sshRemoteId ? getSshRemoteById(sshRemoteId) : undefined;
 				const effectiveRemoteCwd = sshRemote ? remoteCwd || cwd : undefined;
 				const limit = options?.limit || 200;
+				// Use ASCII Unit Separator (U+001F, written as %x1f in git's pretty-format)
+				// between fields. `|` was tempting but author names and subjects can legally
+				// contain it, which silently corrupts every field after the offending one.
+				// US is a non-printing control character that never appears in real text.
 				const args = [
 					'log',
 					'--all',
 					`--max-count=${limit}`,
-					'--pretty=format:GRAPH_START%H|%P|%an|%ad|%D|%s',
+					'--pretty=format:GRAPH_START%H%x1f%P%x1f%an%x1f%ad%x1f%D%x1f%s',
 					'--date=iso-strict',
 				];
 				const result = await execGit(args, cwd, sshRemote, effectiveRemoteCwd);
@@ -495,7 +499,7 @@ export function registerGitHandlers(deps: GitHandlerDependencies): void {
 					.map((block) => {
 						const trimmed = block.trim();
 						const [hash = '', parents = '', author = '', date = '', refs = '', ...subj] =
-							trimmed.split('|');
+							trimmed.split('\x1f');
 						return {
 							hash,
 							shortHash: hash.slice(0, 7),
@@ -503,7 +507,9 @@ export function registerGitHandlers(deps: GitHandlerDependencies): void {
 							author,
 							date,
 							refs: refs ? refs.split(', ').filter((r) => r.trim()) : [],
-							subject: subj.join('|'),
+							// Re-join with the same separator in case the subject itself contained one
+							// (extremely unlikely for a control character, but cheap to be correct).
+							subject: subj.join('\x1f'),
 						};
 					});
 				return { nodes, error: null };
@@ -518,6 +524,20 @@ export function registerGitHandlers(deps: GitHandlerDependencies): void {
 		withIpcErrorLogging(
 			handlerOpts('switch'),
 			async (cwd: string, branchName: string, sshRemoteId?: string, remoteCwd?: string) => {
+				// Reject flag-like names so a caller can't pass e.g. "-c new-branch" or "-C"
+				// and have git interpret it as a switch flag. execFile blocks shell
+				// injection but not flag injection.
+				if (
+					typeof branchName !== 'string' ||
+					branchName.length === 0 ||
+					branchName.startsWith('-')
+				) {
+					return {
+						success: false,
+						stdout: '',
+						stderr: `Invalid branch name: ${branchName}`,
+					};
+				}
 				const sshRemote = sshRemoteId ? getSshRemoteById(sshRemoteId) : undefined;
 				const effectiveRemoteCwd = sshRemote ? remoteCwd || cwd : undefined;
 				const result = await execGit(['switch', branchName], cwd, sshRemote, effectiveRemoteCwd);

--- a/src/main/preload/git.ts
+++ b/src/main/preload/git.ts
@@ -57,6 +57,19 @@ export interface GitLogEntry {
 }
 
 /**
+ * Git graph node — like GitLogEntry but with parent hashes for topology rendering.
+ */
+export interface GitGraphNode {
+	hash: string;
+	shortHash: string;
+	parents: string[];
+	author: string;
+	date: string;
+	refs: string[];
+	subject: string;
+}
+
+/**
  * Discovered worktree event data
  */
 export interface WorktreeDiscoveredData {
@@ -232,6 +245,29 @@ export function createGitApi() {
 			entries: GitLogEntry[];
 			error: string | null;
 		}> => ipcRenderer.invoke('git:log', cwd, options, sshRemoteId),
+
+		/**
+		 * Get topology graph data (commits with parent hashes) for graph rendering
+		 */
+		graph: (
+			cwd: string,
+			options?: { limit?: number },
+			sshRemoteId?: string,
+			remoteCwd?: string
+		): Promise<{ nodes: GitGraphNode[]; error: string | null }> =>
+			ipcRenderer.invoke('git:graph', cwd, options, sshRemoteId, remoteCwd),
+
+		/**
+		 * Switch the current working tree to an existing branch.
+		 * Returns success=false on dirty working tree (stderr contains git's message).
+		 */
+		switchBranch: (
+			cwd: string,
+			branchName: string,
+			sshRemoteId?: string,
+			remoteCwd?: string
+		): Promise<{ success: boolean; stdout: string; stderr: string }> =>
+			ipcRenderer.invoke('git:switch', cwd, branchName, sshRemoteId, remoteCwd),
 
 		/**
 		 * Get commit count

--- a/src/main/preload/git.ts
+++ b/src/main/preload/git.ts
@@ -57,7 +57,7 @@ export interface GitLogEntry {
 }
 
 /**
- * Git graph node — like GitLogEntry but with parent hashes for topology rendering.
+ * Git graph node - like GitLogEntry but with parent hashes for topology rendering.
  */
 export interface GitGraphNode {
 	hash: string;

--- a/src/renderer/components/GitGraphView.tsx
+++ b/src/renderer/components/GitGraphView.tsx
@@ -1,7 +1,14 @@
-import { memo, useMemo } from 'react';
-import { Gitgraph, templateExtend, TemplateName, type Branch } from '@gitgraph/react';
+import { memo, useMemo, type ReactElement } from 'react';
+import { Gitgraph, templateExtend, TemplateName } from '@gitgraph/react';
+import { GitgraphCore } from '@gitgraph/core';
 import type { Theme } from '../types';
 import type { GitGraphNode } from '../services/git';
+
+// `@gitgraph/react`'s public Gitgraph component is parameterised on
+// `ReactElement<SVGElement>` (its internal `ReactSvgElement`). The library
+// doesn't re-export that type from its index, so reproduce it here so a
+// userland-built `GitgraphCore` instance type-checks against the `graph` prop.
+type ReactSvgElement = ReactElement<SVGElement>;
 
 interface GitGraphViewProps {
 	nodes: GitGraphNode[];
@@ -84,78 +91,92 @@ export const GitGraphView = memo(function GitGraphView({
 		[nodes]
 	);
 
+	// Build the GitgraphCore imperatively here (not via the children-callback API).
+	// The callback API populates the graph during componentDidMount, which under
+	// React.StrictMode runs twice and ends up with duplicate React keys / mis-rendered
+	// SVG. Owning the graph instance ourselves keeps the data stable across the
+	// dev-only mount→unmount→remount cycle, so what the user sees in dev matches
+	// production.
+	const gitgraph = useMemo(() => {
+		const core = new GitgraphCore<ReactSvgElement>({ template });
+		const api = core.getUserApi();
+
+		const branches = new Map<string, ReturnType<typeof api.branch>>();
+		const commitToBranch = new Map<string, ReturnType<typeof api.branch>>();
+		let laneCounter = 0;
+
+		const ensureBranch = (name: string, parentHash?: string) => {
+			const existing = branches.get(name);
+			if (existing) return existing;
+			const parentBranch = parentHash ? commitToBranch.get(parentHash) : undefined;
+			const created = parentBranch ? parentBranch.branch(name) : api.branch(name);
+			branches.set(name, created);
+			return created;
+		};
+
+		for (const node of ordered) {
+			const refBranch = pickBranchFromRefs(node.refs);
+			const firstParent = node.parents[0];
+			const inheritedBranchName = firstParent
+				? ([...branches.entries()].find(([, br]) => commitToBranch.get(firstParent) === br)?.[0] ??
+					null)
+				: null;
+
+			const branchName = refBranch ?? inheritedBranchName ?? `lane-${++laneCounter}`;
+			const branch = ensureBranch(branchName, firstParent);
+
+			const subject = node.subject || '(no message)';
+			const truncated = subject.length > 60 ? subject.slice(0, 57) + '…' : subject;
+			// Pass the full hash so @gitgraph/react's internal React keys are unique;
+			// shortHash (7 chars) can collide on busy `--all` ranges and cause React to
+			// drop duplicate children → a blank graph. displayHash:false in the template
+			// keeps the hash off the rendered label.
+			const commitOptions = {
+				hash: node.hash,
+				subject: truncated,
+				author: node.author,
+				onClick: onCommitClick ? () => onCommitClick(node.hash) : undefined,
+				style:
+					selectedHash && selectedHash === node.hash
+						? { dot: { size: 10, strokeWidth: 2, strokeColor: theme.colors.accent } }
+						: undefined,
+			};
+
+			if (node.parents.length >= 2) {
+				const secondParent = node.parents[1];
+				const sourceBranch = commitToBranch.get(secondParent);
+				if (sourceBranch) {
+					branch.merge({ branch: sourceBranch, commitOptions });
+				} else {
+					branch.commit(commitOptions);
+				}
+			} else {
+				branch.commit(commitOptions);
+			}
+
+			commitToBranch.set(node.hash, branch);
+
+			// Attach tag refs (skip duplicate branch labels — gitgraph adds those automatically).
+			for (const ref of node.refs) {
+				const cleaned = ref.replace(/^HEAD -> /, '').trim();
+				if (cleaned.startsWith('tag:')) {
+					branch.tag(cleaned.replace(/^tag:\s*/, ''));
+				}
+			}
+		}
+
+		return core;
+	}, [ordered, template, onCommitClick, selectedHash, theme.colors.accent]);
+
+	// `<Gitgraph>` reads `props.graph` once in its constructor, so swapping in a
+	// fresh GitgraphCore (e.g. when `selectedHash` changes) requires a remount.
+	// `key={selectedHash}` is StrictMode-safe here because the GitgraphCore itself
+	// is owned by `useMemo` above — both mounts in StrictMode's double-render share
+	// the same fully-populated instance, so React only re-renders the SVG, never
+	// re-runs the imperative graph construction that breaks the children-callback API.
 	return (
 		<div className="overflow-auto h-full p-2">
-			<Gitgraph options={{ template }}>
-				{(gitgraph) => {
-					const branches = new Map<string, Branch>();
-					const commitToBranch = new Map<string, Branch>();
-					let laneCounter = 0;
-
-					const ensureBranch = (name: string, parentHash?: string): Branch => {
-						const existing = branches.get(name);
-						if (existing) return existing;
-						let created: Branch;
-						if (parentHash && commitToBranch.has(parentHash)) {
-							const parentBranch = commitToBranch.get(parentHash)!;
-							created = parentBranch.branch(name);
-						} else {
-							created = gitgraph.branch(name);
-						}
-						branches.set(name, created);
-						return created;
-					};
-
-					for (const node of ordered) {
-						const refBranch = pickBranchFromRefs(node.refs);
-						const firstParent = node.parents[0];
-						const inheritedBranchName = firstParent
-							? ([...branches.entries()].find(
-									([, br]) => commitToBranch.get(firstParent) === br
-								)?.[0] ?? null)
-							: null;
-
-						const branchName = refBranch ?? inheritedBranchName ?? `lane-${++laneCounter}`;
-
-						const branch = ensureBranch(branchName, firstParent);
-
-						const subject = node.subject || '(no message)';
-						const truncated = subject.length > 60 ? subject.slice(0, 57) + '…' : subject;
-						const commitOptions = {
-							hash: node.shortHash,
-							subject: truncated,
-							author: node.author,
-							onClick: onCommitClick ? () => onCommitClick(node.hash) : undefined,
-							style:
-								selectedHash && selectedHash === node.hash
-									? { dot: { size: 10, strokeWidth: 2, strokeColor: theme.colors.accent } }
-									: undefined,
-						};
-
-						if (node.parents.length >= 2) {
-							const secondParent = node.parents[1];
-							const sourceBranch = commitToBranch.get(secondParent);
-							if (sourceBranch) {
-								branch.merge({ branch: sourceBranch, commitOptions });
-							} else {
-								branch.commit(commitOptions);
-							}
-						} else {
-							branch.commit(commitOptions);
-						}
-
-						commitToBranch.set(node.hash, branch);
-
-						// Attach tag refs (skip duplicate branch labels — gitgraph adds those automatically).
-						for (const ref of node.refs) {
-							const cleaned = ref.replace(/^HEAD -> /, '').trim();
-							if (cleaned.startsWith('tag:')) {
-								branch.tag(cleaned.replace(/^tag:\s*/, ''));
-							}
-						}
-					}
-				}}
-			</Gitgraph>
+			<Gitgraph key={selectedHash ?? 'none'} graph={gitgraph} />
 		</div>
 	);
 });

--- a/src/renderer/components/GitGraphView.tsx
+++ b/src/renderer/components/GitGraphView.tsx
@@ -156,7 +156,7 @@ export const GitGraphView = memo(function GitGraphView({
 
 			commitToBranch.set(node.hash, branch);
 
-			// Attach tag refs (skip duplicate branch labels — gitgraph adds those automatically).
+			// Attach tag refs (skip duplicate branch labels - gitgraph adds those automatically).
 			for (const ref of node.refs) {
 				const cleaned = ref.replace(/^HEAD -> /, '').trim();
 				if (cleaned.startsWith('tag:')) {
@@ -171,7 +171,7 @@ export const GitGraphView = memo(function GitGraphView({
 	// `<Gitgraph>` reads `props.graph` once in its constructor, so swapping in a
 	// fresh GitgraphCore (e.g. when `selectedHash` changes) requires a remount.
 	// `key={selectedHash}` is StrictMode-safe here because the GitgraphCore itself
-	// is owned by `useMemo` above — both mounts in StrictMode's double-render share
+	// is owned by `useMemo` above - both mounts in StrictMode's double-render share
 	// the same fully-populated instance, so React only re-renders the SVG, never
 	// re-runs the imperative graph construction that breaks the children-callback API.
 	return (

--- a/src/renderer/components/GitGraphView.tsx
+++ b/src/renderer/components/GitGraphView.tsx
@@ -1,0 +1,161 @@
+import { memo, useMemo } from 'react';
+import { Gitgraph, templateExtend, TemplateName, type Branch } from '@gitgraph/react';
+import type { Theme } from '../types';
+import type { GitGraphNode } from '../services/git';
+
+interface GitGraphViewProps {
+	nodes: GitGraphNode[];
+	theme: Theme;
+	onCommitClick?: (hash: string) => void;
+	selectedHash?: string;
+}
+
+// Pull a branch label out of a commit's refs (e.g. "HEAD -> main, origin/main, tag: v1").
+// Prefers local branches over remote-tracking refs; ignores tag: entries.
+function pickBranchFromRefs(refs: string[]): string | null {
+	const cleaned = refs
+		.map((r) => r.replace(/^HEAD -> /, '').trim())
+		.filter((r) => r && !r.startsWith('tag:'));
+	if (cleaned.length === 0) return null;
+	const local = cleaned.find((r) => !r.includes('/'));
+	return local || cleaned[0];
+}
+
+export const GitGraphView = memo(function GitGraphView({
+	nodes,
+	theme,
+	onCommitClick,
+	selectedHash,
+}: GitGraphViewProps) {
+	const template = useMemo(
+		() =>
+			templateExtend(TemplateName.Metro, {
+				colors: [
+					theme.colors.accent,
+					'rgb(34, 197, 94)',
+					'rgb(59, 130, 246)',
+					'rgb(234, 179, 8)',
+					'rgb(168, 85, 247)',
+					'rgb(244, 63, 94)',
+					'rgb(20, 184, 166)',
+					'rgb(236, 72, 153)',
+				],
+				branch: {
+					lineWidth: 2,
+					spacing: 14,
+					label: {
+						display: true,
+						bgColor: theme.colors.bgSidebar,
+						color: theme.colors.textMain,
+						strokeColor: theme.colors.border,
+						borderRadius: 4,
+						font: '10px sans-serif',
+					},
+				},
+				commit: {
+					spacing: 26,
+					hasTooltipInCompactMode: false,
+					dot: {
+						size: 5,
+						strokeWidth: 0,
+					},
+					message: {
+						display: true,
+						displayAuthor: false,
+						displayHash: false,
+						color: theme.colors.textMain,
+						font: '12px sans-serif',
+					},
+				},
+				tag: {
+					bgColor: 'rgba(234, 179, 8, 0.2)',
+					color: 'rgb(234, 179, 8)',
+					strokeColor: 'rgb(234, 179, 8)',
+					borderRadius: 3,
+					font: '9px sans-serif',
+				},
+			}),
+		[theme]
+	);
+
+	// Sort oldest → newest so we can build branches forward.
+	const ordered = useMemo(
+		() => [...nodes].sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime()),
+		[nodes]
+	);
+
+	return (
+		<div className="overflow-auto h-full p-2">
+			<Gitgraph options={{ template }}>
+				{(gitgraph) => {
+					const branches = new Map<string, Branch>();
+					const commitToBranch = new Map<string, Branch>();
+					let laneCounter = 0;
+
+					const ensureBranch = (name: string, parentHash?: string): Branch => {
+						const existing = branches.get(name);
+						if (existing) return existing;
+						let created: Branch;
+						if (parentHash && commitToBranch.has(parentHash)) {
+							const parentBranch = commitToBranch.get(parentHash)!;
+							created = parentBranch.branch(name);
+						} else {
+							created = gitgraph.branch(name);
+						}
+						branches.set(name, created);
+						return created;
+					};
+
+					for (const node of ordered) {
+						const refBranch = pickBranchFromRefs(node.refs);
+						const firstParent = node.parents[0];
+						const inheritedBranchName = firstParent
+							? ([...branches.entries()].find(
+									([, br]) => commitToBranch.get(firstParent) === br
+								)?.[0] ?? null)
+							: null;
+
+						const branchName = refBranch ?? inheritedBranchName ?? `lane-${++laneCounter}`;
+
+						const branch = ensureBranch(branchName, firstParent);
+
+						const subject = node.subject || '(no message)';
+						const truncated = subject.length > 60 ? subject.slice(0, 57) + '…' : subject;
+						const commitOptions = {
+							hash: node.shortHash,
+							subject: truncated,
+							author: node.author,
+							onClick: onCommitClick ? () => onCommitClick(node.hash) : undefined,
+							style:
+								selectedHash && selectedHash === node.hash
+									? { dot: { size: 10, strokeWidth: 2, strokeColor: theme.colors.accent } }
+									: undefined,
+						};
+
+						if (node.parents.length >= 2) {
+							const secondParent = node.parents[1];
+							const sourceBranch = commitToBranch.get(secondParent);
+							if (sourceBranch) {
+								branch.merge({ branch: sourceBranch, commitOptions });
+							} else {
+								branch.commit(commitOptions);
+							}
+						} else {
+							branch.commit(commitOptions);
+						}
+
+						commitToBranch.set(node.hash, branch);
+
+						// Attach tag refs (skip duplicate branch labels — gitgraph adds those automatically).
+						for (const ref of node.refs) {
+							const cleaned = ref.replace(/^HEAD -> /, '').trim();
+							if (cleaned.startsWith('tag:')) {
+								branch.tag(cleaned.replace(/^tag:\s*/, ''));
+							}
+						}
+					}
+				}}
+			</Gitgraph>
+		</div>
+	);
+});

--- a/src/renderer/components/GitLogViewer.tsx
+++ b/src/renderer/components/GitLogViewer.tsx
@@ -17,6 +17,7 @@ import { GitGraphView } from './GitGraphView';
 import 'react-diff-view/style/index.css';
 
 const VIEW_MODE_STORAGE_KEY = 'maestro:gitLogViewer:viewMode';
+const COMMIT_FETCH_LIMIT = 200;
 type ViewMode = 'list' | 'graph';
 
 interface GitLogEntry {
@@ -57,12 +58,19 @@ export const GitLogViewer = memo(function GitLogViewer({
 	const [selectedCommitDiff, setSelectedCommitDiff] = useState<string | null>(null);
 	const [loadingDiff, setLoadingDiff] = useState(false);
 	const [viewMode, setViewMode] = useState<ViewMode>(() => {
-		const stored =
-			typeof window !== 'undefined' ? localStorage.getItem(VIEW_MODE_STORAGE_KEY) : null;
-		return stored === 'graph' ? 'graph' : 'list';
+		try {
+			const stored =
+				typeof window !== 'undefined' ? localStorage.getItem(VIEW_MODE_STORAGE_KEY) : null;
+			return stored === 'graph' ? 'graph' : 'list';
+		} catch {
+			return 'list';
+		}
 	});
 	const [graphNodes, setGraphNodes] = useState<GitGraphNode[]>([]);
-	const [graphLoading, setGraphLoading] = useState(false);
+	// Initialised to true so the first frame after toggling to graph view shows
+	// the spinner instead of flashing "No commits found" before the effect fires.
+	const [graphLoading, setGraphLoading] = useState(true);
+	const [graphError, setGraphError] = useState<string | null>(null);
 	// Commit clicked from the graph that isn't part of `entries` (e.g. a side-branch
 	// commit only visible via `git log --all`). Drives the right-side detail panel
 	// when the list mode's selected entry would otherwise be out of sync.
@@ -110,7 +118,7 @@ export const GitLogViewer = memo(function GitLogViewer({
 			try {
 				// Fetch log entries and total count in parallel
 				const [logResult, countResult] = await Promise.all([
-					window.maestro.git.log(cwd, { limit: 200 }, sshRemoteId),
+					window.maestro.git.log(cwd, { limit: COMMIT_FETCH_LIMIT }, sshRemoteId),
 					window.maestro.git.commitCount(cwd, sshRemoteId),
 				]);
 
@@ -137,14 +145,20 @@ export const GitLogViewer = memo(function GitLogViewer({
 		if (viewMode !== 'graph') return;
 		let cancelled = false;
 		setGraphLoading(true);
-		gitService
-			.getGraph(cwd, { limit: 100 }, sshRemoteId)
-			.then((nodes) => {
+		setGraphError(null);
+		(async () => {
+			try {
+				const nodes = await gitService.getGraph(cwd, { limit: COMMIT_FETCH_LIMIT }, sshRemoteId);
 				if (!cancelled) setGraphNodes(nodes);
-			})
-			.finally(() => {
+			} catch (err) {
+				if (!cancelled) {
+					setGraphError(err instanceof Error ? err.message : String(err));
+					setGraphNodes([]);
+				}
+			} finally {
 				if (!cancelled) setGraphLoading(false);
-			});
+			}
+		})();
 		return () => {
 			cancelled = true;
 		};
@@ -164,6 +178,22 @@ export const GitLogViewer = memo(function GitLogViewer({
 			}
 		},
 		[cwd]
+	);
+
+	// Memoised so GitGraphView's `useMemo` (which lists onCommitClick in its deps)
+	// doesn't rebuild the entire GitgraphCore on every parent render.
+	const handleGraphCommitClick = useCallback(
+		(hash: string) => {
+			const idx = entries.findIndex((e) => e.hash === hash);
+			if (idx >= 0) {
+				setGraphSelected(null);
+				setSelectedIndex(idx);
+			} else {
+				const node = graphNodes.find((n) => n.hash === hash);
+				if (node) setGraphSelected(node);
+			}
+		},
+		[entries, graphNodes, setSelectedIndex]
 	);
 
 	// Auto-load diff for selected commit (priority: graph-only selection, else list selection)
@@ -461,6 +491,10 @@ export const GitLogViewer = memo(function GitLogViewer({
 										Loading graph...
 									</p>
 								</div>
+							) : graphError ? (
+								<div className="flex items-center justify-center h-full p-6">
+									<p className="text-sm text-red-500">{graphError}</p>
+								</div>
 							) : graphNodes.length === 0 ? (
 								<div className="flex items-center justify-center h-full">
 									<p className="text-sm" style={{ color: theme.colors.textDim }}>
@@ -472,16 +506,7 @@ export const GitLogViewer = memo(function GitLogViewer({
 									nodes={graphNodes}
 									theme={theme}
 									selectedHash={displayedCommit?.hash}
-									onCommitClick={(hash) => {
-										const idx = entries.findIndex((e) => e.hash === hash);
-										if (idx >= 0) {
-											setGraphSelected(null);
-											setSelectedIndex(idx);
-										} else {
-											const node = graphNodes.find((n) => n.hash === hash);
-											if (node) setGraphSelected(node);
-										}
-									}}
+									onCommitClick={handleGraphCommitClick}
 								/>
 							)
 						) : loading ? (

--- a/src/renderer/components/GitLogViewer.tsx
+++ b/src/renderer/components/GitLogViewer.tsx
@@ -177,7 +177,7 @@ export const GitLogViewer = memo(function GitLogViewer({
 				setLoadingDiff(false);
 			}
 		},
-		[cwd]
+		[cwd, sshRemoteId]
 	);
 
 	// Memoised so GitGraphView's `useMemo` (which lists onCommitClick in its deps)

--- a/src/renderer/components/GitLogViewer.tsx
+++ b/src/renderer/components/GitLogViewer.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo, useEffect, useRef, useCallback, memo } from 'react';
-import { GitCommit, GitBranch, Tag } from 'lucide-react';
+import { GitCommit, GitBranch, Tag, List, Network } from 'lucide-react';
 import type { Theme } from '../types';
 import { useModalLayer } from '../hooks/ui/useModalLayer';
 import { useResizableModal } from '../hooks/ui/useResizableModal';
@@ -12,7 +12,12 @@ import { useListNavigation } from '../hooks';
 import { generateDiffViewStyles } from '../utils/markdownConfig';
 import { useSettingsStore } from '../stores/settingsStore';
 import { ResizeHandles } from './ui/ResizeHandles';
+import { gitService, type GitGraphNode } from '../services/git';
+import { GitGraphView } from './GitGraphView';
 import 'react-diff-view/style/index.css';
+
+const VIEW_MODE_STORAGE_KEY = 'maestro:gitLogViewer:viewMode';
+type ViewMode = 'list' | 'graph';
 
 interface GitLogEntry {
 	hash: string;
@@ -51,6 +56,27 @@ export const GitLogViewer = memo(function GitLogViewer({
 	const [error, setError] = useState<string | null>(null);
 	const [selectedCommitDiff, setSelectedCommitDiff] = useState<string | null>(null);
 	const [loadingDiff, setLoadingDiff] = useState(false);
+	const [viewMode, setViewMode] = useState<ViewMode>(() => {
+		const stored =
+			typeof window !== 'undefined' ? localStorage.getItem(VIEW_MODE_STORAGE_KEY) : null;
+		return stored === 'graph' ? 'graph' : 'list';
+	});
+	const [graphNodes, setGraphNodes] = useState<GitGraphNode[]>([]);
+	const [graphLoading, setGraphLoading] = useState(false);
+	// Commit clicked from the graph that isn't part of `entries` (e.g. a side-branch
+	// commit only visible via `git log --all`). Drives the right-side detail panel
+	// when the list mode's selected entry would otherwise be out of sync.
+	const [graphSelected, setGraphSelected] = useState<GitGraphNode | null>(null);
+
+	useEffect(() => {
+		try {
+			localStorage.setItem(VIEW_MODE_STORAGE_KEY, viewMode);
+		} catch {
+			// localStorage may be unavailable; ignore.
+		}
+		// When leaving graph mode, clear graph-only selection so list selection drives the right panel.
+		if (viewMode !== 'graph') setGraphSelected(null);
+	}, [viewMode]);
 
 	const listRef = useRef<HTMLDivElement>(null);
 	const dialogRef = useRef<HTMLDivElement>(null);
@@ -106,6 +132,24 @@ export const GitLogViewer = memo(function GitLogViewer({
 		loadLog();
 	}, [cwd]);
 
+	// Lazy-load graph data the first time the user switches to the Graph view (and on cwd change).
+	useEffect(() => {
+		if (viewMode !== 'graph') return;
+		let cancelled = false;
+		setGraphLoading(true);
+		gitService
+			.getGraph(cwd, { limit: 100 }, sshRemoteId)
+			.then((nodes) => {
+				if (!cancelled) setGraphNodes(nodes);
+			})
+			.finally(() => {
+				if (!cancelled) setGraphLoading(false);
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, [viewMode, cwd, sshRemoteId]);
+
 	// Load diff when selected entry changes
 	const loadCommitDiff = useCallback(
 		async (hash: string) => {
@@ -122,12 +166,35 @@ export const GitLogViewer = memo(function GitLogViewer({
 		[cwd]
 	);
 
-	// Auto-load diff for selected commit
+	// Auto-load diff for selected commit (priority: graph-only selection, else list selection)
 	useEffect(() => {
+		if (graphSelected) {
+			loadCommitDiff(graphSelected.hash);
+			return;
+		}
 		if (entries.length > 0 && entries[selectedIndex]) {
 			loadCommitDiff(entries[selectedIndex].hash);
 		}
-	}, [selectedIndex, entries, loadCommitDiff]);
+	}, [selectedIndex, entries, loadCommitDiff, graphSelected]);
+
+	// Effective commit displayed on the right side: graph-clicked commit overrides list selection.
+	const displayedCommit: {
+		hash: string;
+		shortHash: string;
+		subject: string;
+		author: string;
+		date: string;
+	} | null = graphSelected
+		? graphSelected
+		: entries[selectedIndex]
+			? {
+					hash: entries[selectedIndex].hash,
+					shortHash: entries[selectedIndex].shortHash,
+					subject: entries[selectedIndex].subject,
+					author: entries[selectedIndex].author,
+					date: entries[selectedIndex].date,
+				}
+			: null;
 
 	useModalLayer(MODAL_PRIORITIES.GIT_LOG, 'Git Log Viewer', () => onCloseRef.current(), {
 		focusTrap: 'lenient',
@@ -336,24 +403,88 @@ export const GitLogViewer = memo(function GitLogViewer({
 								: `${entries.length} commits`}
 						</span>
 					</div>
-					<button
-						onClick={onClose}
-						className="px-3 py-1 rounded text-sm hover:bg-white/10 transition-colors"
-						style={{ color: theme.colors.textDim }}
-					>
-						Close (Esc)
-					</button>
+					<div className="flex items-center gap-2">
+						{/* List | Graph toggle */}
+						<div
+							className="flex items-center rounded overflow-hidden border"
+							style={{ borderColor: theme.colors.border }}
+						>
+							<button
+								onClick={() => setViewMode('list')}
+								className="flex items-center gap-1 px-2.5 py-1 text-xs transition-colors"
+								style={{
+									backgroundColor: viewMode === 'list' ? theme.colors.bgActivity : 'transparent',
+									color: viewMode === 'list' ? theme.colors.textMain : theme.colors.textDim,
+								}}
+								title="List view"
+								aria-pressed={viewMode === 'list'}
+							>
+								<List className="w-3.5 h-3.5" />
+								List
+							</button>
+							<button
+								onClick={() => setViewMode('graph')}
+								className="flex items-center gap-1 px-2.5 py-1 text-xs transition-colors"
+								style={{
+									backgroundColor: viewMode === 'graph' ? theme.colors.bgActivity : 'transparent',
+									color: viewMode === 'graph' ? theme.colors.textMain : theme.colors.textDim,
+								}}
+								title="Graph view"
+								aria-pressed={viewMode === 'graph'}
+							>
+								<Network className="w-3.5 h-3.5" />
+								Graph
+							</button>
+						</div>
+						<button
+							onClick={onClose}
+							className="px-3 py-1 rounded text-sm hover:bg-white/10 transition-colors"
+							style={{ color: theme.colors.textDim }}
+						>
+							Close (Esc)
+						</button>
+					</div>
 				</div>
 
 				{/* Content */}
 				<div className="flex-1 flex overflow-hidden">
-					{/* Left side: Commit list */}
+					{/* Left side: Commit list OR graph (graph gets more room for lanes) */}
 					<div
 						ref={listRef}
-						className="w-2/5 border-r overflow-y-auto"
+						className={`${viewMode === 'graph' ? 'w-3/5' : 'w-2/5'} border-r overflow-y-auto overflow-x-auto`}
 						style={{ borderColor: theme.colors.border }}
 					>
-						{loading ? (
+						{viewMode === 'graph' ? (
+							graphLoading ? (
+								<div className="flex items-center justify-center h-full">
+									<p className="text-sm" style={{ color: theme.colors.textDim }}>
+										Loading graph...
+									</p>
+								</div>
+							) : graphNodes.length === 0 ? (
+								<div className="flex items-center justify-center h-full">
+									<p className="text-sm" style={{ color: theme.colors.textDim }}>
+										No commits found
+									</p>
+								</div>
+							) : (
+								<GitGraphView
+									nodes={graphNodes}
+									theme={theme}
+									selectedHash={displayedCommit?.hash}
+									onCommitClick={(hash) => {
+										const idx = entries.findIndex((e) => e.hash === hash);
+										if (idx >= 0) {
+											setGraphSelected(null);
+											setSelectedIndex(idx);
+										} else {
+											const node = graphNodes.find((n) => n.hash === hash);
+											if (node) setGraphSelected(node);
+										}
+									}}
+								/>
+							)
+						) : loading ? (
 							<div className="flex items-center justify-center h-full">
 								<p className="text-sm" style={{ color: theme.colors.textDim }}>
 									Loading git log...
@@ -457,7 +588,7 @@ export const GitLogViewer = memo(function GitLogViewer({
 
 					{/* Right side: Commit details & diff */}
 					<div className="flex-1 overflow-y-auto">
-						{entries[selectedIndex] && (
+						{displayedCommit && (
 							<div className="p-6">
 								{/* Commit header */}
 								<div className="mb-6">
@@ -465,7 +596,7 @@ export const GitLogViewer = memo(function GitLogViewer({
 										className="text-lg font-semibold mb-2"
 										style={{ color: theme.colors.textMain }}
 									>
-										{entries[selectedIndex].subject}
+										{displayedCommit.subject}
 									</h3>
 									<div
 										className="flex items-center gap-4 text-sm"
@@ -475,10 +606,10 @@ export const GitLogViewer = memo(function GitLogViewer({
 											className="font-mono px-2 py-1 rounded"
 											style={{ backgroundColor: theme.colors.bgActivity }}
 										>
-											{entries[selectedIndex].hash}
+											{displayedCommit.hash}
 										</span>
-										<span>{entries[selectedIndex].author}</span>
-										<span>{new Date(entries[selectedIndex].date).toLocaleString('en-US')}</span>
+										<span>{displayedCommit.author}</span>
+										<span>{new Date(displayedCommit.date).toLocaleString('en-US')}</span>
 									</div>
 								</div>
 

--- a/src/renderer/components/MainPanel/BranchSwitcherDropdown.tsx
+++ b/src/renderer/components/MainPanel/BranchSwitcherDropdown.tsx
@@ -111,22 +111,32 @@ export function BranchSwitcherDropdown({
 		async (branch: string) => {
 			if (branch === currentBranch || switching) return;
 			setSwitching(branch);
-			const result = await gitService.switchBranch(cwd, branch, sshRemoteId);
-			setSwitching(null);
-			if (result.success) {
-				notifyCenterFlash({
-					message: `Switched to ${branch}`,
-					color: 'green',
-				});
-				onSwitched();
-				onClose();
-			} else {
+			try {
+				const result = await gitService.switchBranch(cwd, branch, sshRemoteId);
+				if (result.success) {
+					notifyCenterFlash({
+						message: `Switched to ${branch}`,
+						color: 'green',
+					});
+					onSwitched();
+					onClose();
+				} else {
+					notifyToast({
+						color: 'red',
+						title: 'Branch switch failed',
+						message: result.stderr.trim() || 'git switch returned a non-zero exit code.',
+						dismissible: true,
+					});
+				}
+			} catch (err) {
 				notifyToast({
 					color: 'red',
 					title: 'Branch switch failed',
-					message: result.stderr.trim() || 'git switch returned a non-zero exit code.',
+					message: err instanceof Error ? err.message : String(err),
 					dismissible: true,
 				});
+			} finally {
+				setSwitching(null);
 			}
 		},
 		[cwd, sshRemoteId, currentBranch, switching, onSwitched, onClose]

--- a/src/renderer/components/MainPanel/BranchSwitcherDropdown.tsx
+++ b/src/renderer/components/MainPanel/BranchSwitcherDropdown.tsx
@@ -1,0 +1,239 @@
+import { useEffect, useRef, useState, useMemo, useCallback, useLayoutEffect } from 'react';
+import { createPortal } from 'react-dom';
+import { Check, GitBranch, Search, Loader2 } from 'lucide-react';
+import type { Theme } from '../../types';
+import { useModalLayer } from '../../hooks/ui/useModalLayer';
+import { MODAL_PRIORITIES } from '../../constants/modalPriorities';
+import { gitService } from '../../services/git';
+import { notifyToast } from '../../stores/notificationStore';
+import { notifyCenterFlash } from '../../stores/centerFlashStore';
+
+interface BranchSwitcherDropdownProps {
+	cwd: string;
+	currentBranch: string;
+	theme: Theme;
+	sshRemoteId?: string;
+	/** Element the dropdown should be anchored under. Required for portal positioning. */
+	anchorEl: HTMLElement | null;
+	onClose: () => void;
+	onSwitched: () => void;
+}
+
+const DROPDOWN_WIDTH = 320;
+
+export function BranchSwitcherDropdown({
+	cwd,
+	currentBranch,
+	theme,
+	sshRemoteId,
+	anchorEl,
+	onClose,
+	onSwitched,
+}: BranchSwitcherDropdownProps) {
+	const [branches, setBranches] = useState<string[]>([]);
+	const [loading, setLoading] = useState(true);
+	const [filter, setFilter] = useState('');
+	const [highlight, setHighlight] = useState(0);
+	const [switching, setSwitching] = useState<string | null>(null);
+	const [pos, setPos] = useState<{ top: number; left: number } | null>(null);
+	const inputRef = useRef<HTMLInputElement>(null);
+	const containerRef = useRef<HTMLDivElement>(null);
+
+	useModalLayer(MODAL_PRIORITIES.BRANCH_SWITCHER, 'Branch switcher', onClose, {
+		focusTrap: 'lenient',
+		blocksLowerLayers: false,
+	});
+
+	useEffect(() => {
+		let cancelled = false;
+		setLoading(true);
+		gitService
+			.getBranches(cwd, sshRemoteId)
+			.then((b) => {
+				if (cancelled) return;
+				setBranches(b);
+			})
+			.finally(() => {
+				if (!cancelled) setLoading(false);
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, [cwd, sshRemoteId]);
+
+	useEffect(() => {
+		inputRef.current?.focus();
+	}, []);
+
+	// Compute viewport position from anchor rect; recompute on resize/scroll.
+	useLayoutEffect(() => {
+		if (!anchorEl) return;
+		const update = () => {
+			const r = anchorEl.getBoundingClientRect();
+			const left = Math.max(8, Math.min(r.left, window.innerWidth - DROPDOWN_WIDTH - 8));
+			setPos({ top: r.bottom + 6, left });
+		};
+		update();
+		window.addEventListener('resize', update);
+		window.addEventListener('scroll', update, true);
+		return () => {
+			window.removeEventListener('resize', update);
+			window.removeEventListener('scroll', update, true);
+		};
+	}, [anchorEl]);
+
+	// Click-outside to close (ignore clicks on the anchor itself).
+	useEffect(() => {
+		const handler = (e: MouseEvent) => {
+			const target = e.target as Node;
+			if (containerRef.current?.contains(target)) return;
+			if (anchorEl?.contains(target)) return;
+			onClose();
+		};
+		const id = window.setTimeout(() => window.addEventListener('mousedown', handler), 0);
+		return () => {
+			window.clearTimeout(id);
+			window.removeEventListener('mousedown', handler);
+		};
+	}, [onClose, anchorEl]);
+
+	const filtered = useMemo(() => {
+		const q = filter.trim().toLowerCase();
+		if (!q) return branches;
+		return branches.filter((b) => b.toLowerCase().includes(q));
+	}, [branches, filter]);
+
+	useEffect(() => {
+		setHighlight(0);
+	}, [filter]);
+
+	const doSwitch = useCallback(
+		async (branch: string) => {
+			if (branch === currentBranch || switching) return;
+			setSwitching(branch);
+			const result = await gitService.switchBranch(cwd, branch, sshRemoteId);
+			setSwitching(null);
+			if (result.success) {
+				notifyCenterFlash({
+					message: `Switched to ${branch}`,
+					color: 'green',
+				});
+				onSwitched();
+				onClose();
+			} else {
+				notifyToast({
+					color: 'red',
+					title: 'Branch switch failed',
+					message: result.stderr.trim() || 'git switch returned a non-zero exit code.',
+					dismissible: true,
+				});
+			}
+		},
+		[cwd, sshRemoteId, currentBranch, switching, onSwitched, onClose]
+	);
+
+	const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+		if (e.key === 'ArrowDown') {
+			e.preventDefault();
+			setHighlight((h) => Math.min(h + 1, filtered.length - 1));
+		} else if (e.key === 'ArrowUp') {
+			e.preventDefault();
+			setHighlight((h) => Math.max(h - 1, 0));
+		} else if (e.key === 'Enter') {
+			e.preventDefault();
+			const target = filtered[highlight];
+			if (target) doSwitch(target);
+		}
+	};
+
+	if (!pos) return null;
+
+	const dropdown = (
+		<div
+			ref={containerRef}
+			className="rounded shadow-xl"
+			style={{
+				position: 'fixed',
+				top: pos.top,
+				left: pos.left,
+				width: DROPDOWN_WIDTH,
+				zIndex: 9999,
+				backgroundColor: theme.colors.bgSidebar,
+				border: `1px solid ${theme.colors.border}`,
+			}}
+			role="dialog"
+			aria-label="Switch branch"
+			onClick={(e) => e.stopPropagation()}
+		>
+			{/* Search */}
+			<div
+				className="flex items-center gap-2 px-3 py-2 border-b"
+				style={{ borderColor: theme.colors.border }}
+			>
+				<Search className="w-3.5 h-3.5 shrink-0" style={{ color: theme.colors.textDim }} />
+				<input
+					ref={inputRef}
+					value={filter}
+					onChange={(e) => setFilter(e.target.value)}
+					onKeyDown={onKeyDown}
+					placeholder="Filter branches…"
+					className="flex-1 bg-transparent outline-none text-sm"
+					style={{ color: theme.colors.textMain }}
+				/>
+			</div>
+
+			{/* List */}
+			<div className="max-h-72 overflow-y-auto py-1">
+				{loading ? (
+					<div className="px-3 py-4 flex items-center justify-center">
+						<Loader2 className="w-4 h-4 animate-spin" style={{ color: theme.colors.textDim }} />
+					</div>
+				) : filtered.length === 0 ? (
+					<div className="px-3 py-4 text-xs text-center" style={{ color: theme.colors.textDim }}>
+						No matching branches
+					</div>
+				) : (
+					filtered.map((branch, i) => {
+						const isCurrent = branch === currentBranch;
+						const isHighlighted = i === highlight;
+						const isSwitching = switching === branch;
+						return (
+							<button
+								key={branch}
+								onMouseEnter={() => setHighlight(i)}
+								onClick={() => doSwitch(branch)}
+								disabled={isCurrent || !!switching}
+								className={`w-full text-left flex items-center gap-2 px-3 py-1.5 text-xs transition-colors ${
+									isCurrent ? 'cursor-default' : 'cursor-pointer'
+								}`}
+								style={{
+									backgroundColor: isHighlighted ? theme.colors.bgActivity : 'transparent',
+									color: isCurrent ? theme.colors.textDim : theme.colors.textMain,
+								}}
+								title={isCurrent ? 'Already on this branch' : `Switch to ${branch}`}
+							>
+								<GitBranch className="w-3 h-3 shrink-0 text-orange-500" />
+								<span className="font-mono truncate flex-1">{branch}</span>
+								{isSwitching && <Loader2 className="w-3 h-3 animate-spin shrink-0" />}
+								{isCurrent && !isSwitching && (
+									<Check className="w-3 h-3 shrink-0" style={{ color: theme.colors.accent }} />
+								)}
+							</button>
+						);
+					})
+				)}
+			</div>
+
+			{/* Footer */}
+			<div
+				className="px-3 py-1.5 border-t text-[10px] flex items-center justify-between"
+				style={{ borderColor: theme.colors.border, color: theme.colors.textDim }}
+			>
+				<span>↑↓ navigate · Enter switch · Esc close</span>
+				<span>{filtered.length}</span>
+			</div>
+		</div>
+	);
+
+	return createPortal(dropdown, document.body);
+}

--- a/src/renderer/components/MainPanel/BranchSwitcherDropdown.tsx
+++ b/src/renderer/components/MainPanel/BranchSwitcherDropdown.tsx
@@ -53,6 +53,15 @@ export function BranchSwitcherDropdown({
 				if (cancelled) return;
 				setBranches(b);
 			})
+			.catch((err) => {
+				if (cancelled) return;
+				notifyToast({
+					color: 'red',
+					title: 'Failed to load branches',
+					message: err instanceof Error ? err.message : String(err),
+					dismissible: true,
+				});
+			})
 			.finally(() => {
 				if (!cancelled) setLoading(false);
 			});

--- a/src/renderer/components/MainPanel/MainPanelHeader.tsx
+++ b/src/renderer/components/MainPanel/MainPanelHeader.tsx
@@ -42,6 +42,7 @@ import {
 } from '../../stores/claudeUsageStore';
 import { formatFutureTime } from '../../../shared/formatters';
 import { PluginUiItemsSlot } from '../plugins/PluginUiItemsSlot';
+import { captureException } from '../../utils/sentry';
 
 export interface MainPanelHeaderProps {
 	activeSession: Session;
@@ -140,7 +141,11 @@ export const MainPanelHeader = React.memo(function MainPanelHeader({
 	// Double click → open branch switcher dropdown.
 	const handleBranchChipClick = () => {
 		if (!activeSession.isGitRepo) return;
-		refreshGitStatus();
+		void refreshGitStatus().catch((error) => {
+			captureException(error, {
+				extra: { source: 'MainPanelHeader.handleBranchChipClick' },
+			});
+		});
 		gitTooltip.close();
 		if (branchClickTimerRef.current) clearTimeout(branchClickTimerRef.current);
 		branchClickTimerRef.current = setTimeout(() => {
@@ -334,7 +339,13 @@ export const MainPanelHeader = React.memo(function MainPanelHeader({
 								anchorEl={branchChipContainerRef.current}
 								onClose={() => setBranchSwitcherOpen(false)}
 								onSwitched={() => {
-									refreshGitStatus();
+									void refreshGitStatus().catch((error) => {
+										captureException(error, {
+											extra: {
+												source: 'MainPanelHeader.BranchSwitcherDropdown.onSwitched',
+											},
+										});
+									});
 								}}
 							/>
 						)}

--- a/src/renderer/components/MainPanel/MainPanelHeader.tsx
+++ b/src/renderer/components/MainPanel/MainPanelHeader.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import {
 	Wand2,
 	ExternalLink,
@@ -159,6 +159,26 @@ export const MainPanelHeader = React.memo(function MainPanelHeader({
 		setBranchSwitcherOpen((v) => !v);
 	};
 
+	// Keyboard a11y: Shift+Enter on the chip opens the branch switcher, mirroring double-click.
+	// Plain Enter falls through to the default button activation, which fires onClick.
+	const handleBranchChipKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+		if (e.key === 'Enter' && e.shiftKey) {
+			e.preventDefault();
+			handleBranchChipDoubleClick();
+		}
+	};
+
+	// Cancel the 220ms single-click debounce on unmount so the callback can't
+	// fire against a stale parent (resource leak / React 17 setState warning).
+	useEffect(() => {
+		return () => {
+			if (branchClickTimerRef.current) {
+				clearTimeout(branchClickTimerRef.current);
+				branchClickTimerRef.current = null;
+			}
+		};
+	}, []);
+
 	return (
 		<div
 			ref={headerRef}
@@ -222,7 +242,7 @@ export const MainPanelHeader = React.memo(function MainPanelHeader({
 								className={`flex items-center gap-1 text-xs px-2 py-0.5 rounded-full border border-purple-500/30 text-purple-500 bg-purple-500/10 max-w-[120px] outline-none ${
 									activeSession.isGitRepo ? 'cursor-pointer hover:bg-purple-500/20' : ''
 								}`}
-								title={`SSH Remote: ${sshRemoteName}${activeSession.isGitRepo && gitInfo?.branch ? ` (${gitInfo.branch} - click: log, double-click: switch branch)` : ''}`}
+								title={`SSH Remote: ${sshRemoteName}${activeSession.isGitRepo && gitInfo?.branch ? ` (${gitInfo.branch} - click / Enter: log, double-click / Shift+Enter: switch branch)` : ''}`}
 								onClick={(e) => {
 									e.stopPropagation();
 									handleBranchChipClick();
@@ -231,6 +251,7 @@ export const MainPanelHeader = React.memo(function MainPanelHeader({
 									e.stopPropagation();
 									handleBranchChipDoubleClick();
 								}}
+								onKeyDown={activeSession.isGitRepo ? handleBranchChipKeyDown : undefined}
 							>
 								<Server className="w-3 h-3 shrink-0" />
 								<span className="truncate uppercase">{sshRemoteName}</span>
@@ -250,9 +271,10 @@ export const MainPanelHeader = React.memo(function MainPanelHeader({
 									e.stopPropagation();
 									handleBranchChipDoubleClick();
 								}}
+								onKeyDown={activeSession.isGitRepo ? handleBranchChipKeyDown : undefined}
 								title={
 									activeSession.isGitRepo && gitInfo?.branch
-										? `${gitInfo.branch} - click: log, double-click: switch branch`
+										? `${gitInfo.branch} - click / Enter: log, double-click / Shift+Enter: switch branch`
 										: undefined
 								}
 							>

--- a/src/renderer/components/MainPanel/MainPanelHeader.tsx
+++ b/src/renderer/components/MainPanel/MainPanelHeader.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useRef, useState } from 'react';
 import {
 	Wand2,
 	ExternalLink,
@@ -16,12 +16,14 @@ import {
 	Brain,
 	Menu,
 	Command,
+	History,
 } from 'lucide-react';
 import { GhostIconButton } from '../ui/GhostIconButton';
 import { Spinner } from '../ui/Spinner';
 import { formatShortcutKeys } from '../../utils/shortcutFormatter';
 import { remoteUrlToBrowserUrl } from '../../../shared/gitUtils';
 import { GitStatusWidget } from '../GitStatusWidget';
+import { BranchSwitcherDropdown } from './BranchSwitcherDropdown';
 import { useHoverTooltip } from '../../hooks';
 import { useSettingsStore } from '../../stores/settingsStore';
 import { useUIStore } from '../../stores/uiStore';
@@ -130,6 +132,32 @@ export const MainPanelHeader = React.memo(function MainPanelHeader({
 	const headerRef = useRef<HTMLDivElement>(null);
 	const gitTooltip = useHoverTooltip(150);
 	const contextTooltip = useHoverTooltip(150);
+	const [branchSwitcherOpen, setBranchSwitcherOpen] = useState(false);
+	const branchChipContainerRef = useRef<HTMLDivElement>(null);
+	const branchClickTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	// Single click → open git log (delayed to differentiate from a double click).
+	// Double click → open branch switcher dropdown.
+	const handleBranchChipClick = () => {
+		if (!activeSession.isGitRepo) return;
+		refreshGitStatus();
+		gitTooltip.close();
+		if (branchClickTimerRef.current) clearTimeout(branchClickTimerRef.current);
+		branchClickTimerRef.current = setTimeout(() => {
+			branchClickTimerRef.current = null;
+			setGitLogOpen?.(true);
+		}, 220);
+	};
+
+	const handleBranchChipDoubleClick = () => {
+		if (!activeSession.isGitRepo) return;
+		if (branchClickTimerRef.current) {
+			clearTimeout(branchClickTimerRef.current);
+			branchClickTimerRef.current = null;
+		}
+		gitTooltip.close();
+		setBranchSwitcherOpen((v) => !v);
+	};
 
 	return (
 		<div
@@ -176,6 +204,7 @@ export const MainPanelHeader = React.memo(function MainPanelHeader({
 						/>
 					)}
 					<div
+						ref={branchChipContainerRef}
 						className="relative shrink-0 flex items-center gap-2"
 						onMouseEnter={
 							activeSession.isGitRepo ? gitTooltip.triggerHandlers.onMouseEnter : undefined
@@ -193,13 +222,14 @@ export const MainPanelHeader = React.memo(function MainPanelHeader({
 								className={`flex items-center gap-1 text-xs px-2 py-0.5 rounded-full border border-purple-500/30 text-purple-500 bg-purple-500/10 max-w-[120px] outline-none ${
 									activeSession.isGitRepo ? 'cursor-pointer hover:bg-purple-500/20' : ''
 								}`}
-								title={`SSH Remote: ${sshRemoteName}${activeSession.isGitRepo && gitInfo?.branch ? ` (${gitInfo.branch})` : ''}`}
+								title={`SSH Remote: ${sshRemoteName}${activeSession.isGitRepo && gitInfo?.branch ? ` (${gitInfo.branch} - click: log, double-click: switch branch)` : ''}`}
 								onClick={(e) => {
 									e.stopPropagation();
-									if (activeSession.isGitRepo) {
-										refreshGitStatus(); // Refresh git info immediately on click
-										setGitLogOpen?.(true);
-									}
+									handleBranchChipClick();
+								}}
+								onDoubleClick={(e) => {
+									e.stopPropagation();
+									handleBranchChipDoubleClick();
 								}}
 							>
 								<Server className="w-3 h-3 shrink-0" />
@@ -214,12 +244,17 @@ export const MainPanelHeader = React.memo(function MainPanelHeader({
 								}`}
 								onClick={(e) => {
 									e.stopPropagation();
-									if (activeSession.isGitRepo) {
-										refreshGitStatus(); // Refresh git info immediately on click
-										setGitLogOpen?.(true);
-									}
+									handleBranchChipClick();
 								}}
-								title={activeSession.isGitRepo && gitInfo?.branch ? gitInfo.branch : undefined}
+								onDoubleClick={(e) => {
+									e.stopPropagation();
+									handleBranchChipDoubleClick();
+								}}
+								title={
+									activeSession.isGitRepo && gitInfo?.branch
+										? `${gitInfo.branch} - click: log, double-click: switch branch`
+										: undefined
+								}
 							>
 								{activeSession.isGitRepo ? (
 									<>
@@ -257,7 +292,31 @@ export const MainPanelHeader = React.memo(function MainPanelHeader({
 									</span>
 								</button>
 							)}
-						{activeSession.isGitRepo && gitTooltip.isOpen && gitInfo && (
+						{/* Branch switcher dropdown (portaled to body to escape header overflow:hidden) */}
+						{branchSwitcherOpen && activeSession.isGitRepo && gitInfo && (
+							<BranchSwitcherDropdown
+								cwd={
+									activeSession.inputMode === 'terminal'
+										? activeSession.shellCwd || activeSession.cwd
+										: activeSession.cwd
+								}
+								currentBranch={gitInfo.branch}
+								theme={theme}
+								sshRemoteId={
+									activeSession.sshRemoteId ||
+									(activeSession.sessionSshRemoteConfig?.enabled
+										? activeSession.sessionSshRemoteConfig.remoteId
+										: undefined) ||
+									undefined
+								}
+								anchorEl={branchChipContainerRef.current}
+								onClose={() => setBranchSwitcherOpen(false)}
+								onSwitched={() => {
+									refreshGitStatus();
+								}}
+							/>
+						)}
+						{activeSession.isGitRepo && gitTooltip.isOpen && gitInfo && !branchSwitcherOpen && (
 							<>
 								{/* Invisible bridge to prevent hover gap */}
 								<div
@@ -391,6 +450,24 @@ export const MainPanelHeader = React.memo(function MainPanelHeader({
 
 										{/* Worktree Actions */}
 										<div className="p-2 space-y-1">
+											{/* View commit history (was the chip's previous click action) */}
+											{setGitLogOpen && (
+												<button
+													onClick={(e) => {
+														e.stopPropagation();
+														setGitLogOpen(true);
+														gitTooltip.close();
+													}}
+													className="w-full flex items-center justify-center gap-2 px-3 py-2 rounded text-xs hover:bg-white/10 transition-colors"
+													style={{ color: theme.colors.textDim }}
+												>
+													<History
+														className="w-3.5 h-3.5"
+														style={{ color: theme.colors.textDim }}
+													/>
+													View commit history
+												</button>
+											)}
 											{/* Configure Worktrees - only for parent sessions (not worktree children) */}
 											{!isWorktreeChild && onOpenWorktreeConfig && (
 												<button

--- a/src/renderer/constants/modalPriorities.ts
+++ b/src/renderer/constants/modalPriorities.ts
@@ -287,6 +287,9 @@ export const MODAL_PRIORITIES = {
 	/** Git diff preview overlay */
 	GIT_DIFF: 200,
 
+	/** Branch switcher dropdown (opens from header branch chip) */
+	BRANCH_SWITCHER: 195,
+
 	/** Git log viewer overlay */
 	GIT_LOG: 190,
 

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -1011,6 +1011,29 @@ interface MaestroAPI {
 			cwd: string,
 			sshRemoteId?: string
 		) => Promise<{ count: number; error: string | null }>;
+		graph: (
+			cwd: string,
+			options?: { limit?: number },
+			sshRemoteId?: string,
+			remoteCwd?: string
+		) => Promise<{
+			nodes: Array<{
+				hash: string;
+				shortHash: string;
+				parents: string[];
+				author: string;
+				date: string;
+				refs: string[];
+				subject: string;
+			}>;
+			error: string | null;
+		}>;
+		switchBranch: (
+			cwd: string,
+			branchName: string,
+			sshRemoteId?: string,
+			remoteCwd?: string
+		) => Promise<{ success: boolean; stdout: string; stderr: string }>;
 		show: (
 			cwd: string,
 			hash: string,

--- a/src/renderer/services/git.ts
+++ b/src/renderer/services/git.ts
@@ -30,6 +30,21 @@ export interface GitNumstat {
 	}>;
 }
 
+export interface GitGraphNode {
+	hash: string;
+	shortHash: string;
+	parents: string[];
+	author: string;
+	date: string;
+	refs: string[];
+	subject: string;
+}
+
+export interface GitSwitchResult {
+	success: boolean;
+	stderr: string;
+}
+
 /**
  * All git service methods support SSH remote execution via optional sshRemoteId parameter.
  * When sshRemoteId is provided, operations execute on the remote host via SSH.
@@ -192,6 +207,43 @@ export const gitService = {
 			},
 			errorContext: 'Git tags',
 			defaultValue: [],
+		});
+	},
+
+	/**
+	 * Get topology graph nodes (commits with parent hashes) for graph rendering
+	 */
+	async getGraph(
+		cwd: string,
+		options?: { limit?: number },
+		sshRemoteId?: string
+	): Promise<GitGraphNode[]> {
+		return createIpcMethod({
+			call: async () => {
+				const result = await window.maestro.git.graph(cwd, options, sshRemoteId);
+				return result.nodes || [];
+			},
+			errorContext: 'Git graph',
+			defaultValue: [],
+		});
+	},
+
+	/**
+	 * Switch to an existing branch in the current working tree.
+	 * Returns success=false with stderr text on failure (e.g., dirty working tree).
+	 */
+	async switchBranch(
+		cwd: string,
+		branchName: string,
+		sshRemoteId?: string
+	): Promise<GitSwitchResult> {
+		return createIpcMethod({
+			call: async () => {
+				const result = await window.maestro.git.switchBranch(cwd, branchName, sshRemoteId);
+				return { success: result.success, stderr: result.stderr };
+			},
+			errorContext: 'Git switch',
+			defaultValue: { success: false, stderr: 'IPC call failed' },
 		});
 	},
 };

--- a/src/renderer/services/git.ts
+++ b/src/renderer/services/git.ts
@@ -211,20 +211,24 @@ export const gitService = {
 	},
 
 	/**
-	 * Get topology graph nodes (commits with parent hashes) for graph rendering
+	 * Get topology graph nodes (commits with parent hashes) for graph rendering.
+	 * Throws on a main-process git error so the caller can render a real error
+	 * state instead of an indistinguishable empty list.
 	 */
 	async getGraph(
 		cwd: string,
 		options?: { limit?: number },
-		sshRemoteId?: string
+		sshRemoteId?: string,
+		remoteCwd?: string
 	): Promise<GitGraphNode[]> {
 		return createIpcMethod({
 			call: async () => {
-				const result = await window.maestro.git.graph(cwd, options, sshRemoteId);
+				const result = await window.maestro.git.graph(cwd, options, sshRemoteId, remoteCwd);
+				if (result.error) throw new Error(result.error);
 				return result.nodes || [];
 			},
 			errorContext: 'Git graph',
-			defaultValue: [],
+			rethrow: true,
 		});
 	},
 
@@ -235,11 +239,17 @@ export const gitService = {
 	async switchBranch(
 		cwd: string,
 		branchName: string,
-		sshRemoteId?: string
+		sshRemoteId?: string,
+		remoteCwd?: string
 	): Promise<GitSwitchResult> {
 		return createIpcMethod({
 			call: async () => {
-				const result = await window.maestro.git.switchBranch(cwd, branchName, sshRemoteId);
+				const result = await window.maestro.git.switchBranch(
+					cwd,
+					branchName,
+					sshRemoteId,
+					remoteCwd
+				);
 				return { success: result.success, stderr: result.stderr };
 			},
 			errorContext: 'Git switch',


### PR DESCRIPTION
Closes #958

## Summary

Two new affordances on the git surface, both plumbed through the existing SSH-remote pathway:

- **Graph view in `GitLogViewer`** — toggleable List/Graph buttons in the modal header. Graph mode renders commits with parent-hash topology via `@gitgraph/react`, supports clicking commits to drive the existing diff panel, and persists the user's view preference via `localStorage`. Side-branch commits only visible via `git log --all` are tracked separately so the right-hand commit detail panel stays in sync regardless of which view is active.
- **Branch switcher dropdown on the header branch chip** — single click still opens the git log (debounced ~220 ms to differentiate from a double click); double click opens a filterable branch picker that switches the working tree via `git switch <branch>`. Failures (e.g. dirty working tree) surface git's stderr inside the dropdown instead of throwing.

### Mapping to issue #958

| Issue ask                                            | This PR                                                                                            |
| ---------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
| Show the current branch prominently                  | Already shown on the header branch chip; PR makes it interactive                                   |
| List local (and remote) branches                     | ✅ Filterable list in the new dropdown                                                              |
| Switch/checkout an existing branch from Maestro      | ✅ Double-click chip → pick branch → `git switch`                                                   |
| Warn clearly when switching with uncommitted changes | ✅ Failure path surfaces git's stderr inline (e.g. dirty working tree) instead of silently failing |
| Create a new branch from current HEAD / from base    | ⏳ Out of scope for this PR — happy to follow up                                                    |

### IPC surface

Two new handlers, both honoring the existing `sshRemoteId` / `remoteCwd` SSH wrapping:

- `git:graph` — returns commits with parent hashes (`{ nodes, error }`) for lane rendering. Default limit 200, configurable via `options.limit`.
- `git:switch` — returns `{ success, stdout, stderr }` instead of throwing, so the UI can render git's failure message in-place.

### Files

- `src/main/ipc/handlers/git.ts`, `src/main/preload/git.ts`, `src/renderer/services/git.ts`, `src/renderer/global.d.ts` — IPC + service plumbing
- `src/renderer/components/GitGraphView.tsx` *(new)* — `@gitgraph/react` wrapper themed via `theme.colors`
- `src/renderer/components/GitLogViewer.tsx` — list/graph toggle + selection sync
- `src/renderer/components/MainPanel/BranchSwitcherDropdown.tsx` *(new)* — filterable picker that calls `git:switch`
- `src/renderer/components/MainPanel/MainPanelHeader.tsx` — single/double-click handling on branch chip
- `src/renderer/constants/modalPriorities.ts` — adds `BRANCH_SWITCHER: 195`
- `src/__tests__/renderer/components/MainPanel.test.tsx` — updated SSH-remote click test, new double-click test
- `package.json` / `package-lock.json` — adds `@gitgraph/react ^1.6.0`

The branch also includes a separate commit (`fix(node-pty): patch winpty.gyp paths and harden POSIX spawn errors`) that fixes a Windows build issue — happy to split it into its own PR if preferred.

## Why

Per #958, currently the only way to inspect history is the linear list, which makes branch topology impossible to read at a glance, and the only way to switch branches inside Maestro is to open a terminal. Both moves keep the user inside the AI surface.

## Test plan

- [x] `npm run lint` — TypeScript across all three configs
- [x] `npm run lint:eslint` — ESLint
- [x] `npm run test -- --run src/__tests__/renderer/components/MainPanel.test.tsx` — 137 tests including the new double-click + branch switcher coverage
- [x] Manual: open a git repo, click the branch chip in the header → git log opens after ~220 ms
- [x] Manual: double-click the branch chip → branch switcher opens, filter input is focused, pick a branch → working tree switches
- [x] Manual: in git log, toggle Graph view → commits render with lane topology, clicking a commit (including a side-branch commit) drives the diff panel on the right
- [ ] Manual (SSH): repeat above with an SSH remote enabled session — both new IPC paths route through `getSshRemoteById`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a visual commit graph with selectable, highlighted commits; graph lazy-loads and can drive commit details/diff loading.
  * Enabled a persistent List ↔ Graph toggle in the commit viewer.
  * Introduced a searchable, keyboard-navigable branch switcher dropdown with loading/empty states and success/error feedback.
  * Updated branch chips: single-click opens history; double-click or **Shift+Enter** opens the branch switcher.
* **Dependency**
  * Added `@gitgraph/core` and `@gitgraph/react`.
* **Tests**
  * Expanded coverage for SSH remote branch-switcher behavior and adjusted async expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->