### PR TITLE
fix(node-pty): patch winpty.gyp paths and harden POSIX spawn errors

### DIFF
--- a/patches/node-pty+1.1.0.patch
+++ b/patches/node-pty+1.1.0.patch
@@ -1,3 +1,25 @@
+diff --git a/node_modules/node-pty/deps/winpty/src/winpty.gyp b/node_modules/node-pty/deps/winpty/src/winpty.gyp
+index 1111111..2222222 100644
+--- a/node_modules/node-pty/deps/winpty/src/winpty.gyp
++++ b/node_modules/node-pty/deps/winpty/src/winpty.gyp
+@@ -10,7 +10,7 @@
+     #    make -j4 CXX=i686-w64-mingw32-g++ LDFLAGS="-static -static-libgcc -static-libstdc++"
+
+     'variables': {
+-        'WINPTY_COMMIT_HASH%': '<!(cmd /c "cd shared && GetCommitHash.bat")',
++        'WINPTY_COMMIT_HASH%': '<!(cmd /c "cd shared && .\\GetCommitHash.bat")',
+     },
+     'target_defaults' : {
+         'defines' : [
+@@ -22,7 +22,7 @@
+         'include_dirs': [
+             # Add the 'src/gen' directory to the include path and force gyp to
+             # run the script (re)generating the version header.
+-            '<!(cmd /c "cd shared && UpdateGenVersion.bat <(WINPTY_COMMIT_HASH)")',
++            '<!(cmd /c "cd shared && .\\UpdateGenVersion.bat <(WINPTY_COMMIT_HASH)")',
+         ]
+     },
+     'targets' : [
 diff --git a/node_modules/node-pty/src/unix/pty.cc b/node_modules/node-pty/src/unix/pty.cc
 index 7b4b9e1..2e5293d 100644
 --- a/node_modules/node-pty/src/unix/pty.cc
@@ -9,11 +31,11 @@ index 7b4b9e1..2e5293d 100644
 -                int* err);
 +                std::string* err);
  #endif
- 
+
  struct DelBuf {
 @@ -352,7 +352,7 @@ Napi::Value PtyFork(const Napi::CallbackInfo& info) {
    std::string helper_path = info[9].As<Napi::String>();
- 
+
    pid_t pid;
 -  int master;
 +  int master = -1;
@@ -23,7 +45,7 @@ index 7b4b9e1..2e5293d 100644
 @@ -367,10 +367,13 @@ Napi::Value PtyFork(const Napi::CallbackInfo& info) {
      argv[i + 3] = strdup(arg.c_str());
    }
- 
+
 -  int err = -1;
 +  std::string err;
    pty_posix_spawn(argv, env, term, &winp, &master, &pid, &err);
@@ -39,7 +61,7 @@ index 7b4b9e1..2e5293d 100644
      throw Napi::Error::New(napiEnv, "Could not set master fd to nonblocking.");
 @@ -684,15 +687,26 @@ pty_getproc(int fd, char *tty) {
  #endif
- 
+
  #if defined(__APPLE__)
 +static std::string format_error(const char* func, int err_code) {
 +  char buf[256];
@@ -55,17 +77,18 @@ index 7b4b9e1..2e5293d 100644
                  pid_t* pid,
 -                int* err) {
 +                std::string* err) {
-   int low_fds[3];
+-  int low_fds[3];
++  int low_fds[3] = { -1, -1, -1 };
    size_t count = 0;
 +  int res = 0;
 +  int slave = -1;
 +  char slave_pty_name[128];
 +  int spawn_err;
 +  sigset_t signal_set;
- 
+
    for (; count < 3; count++) {
      low_fds[count] = posix_openpt(O_RDWR);
-@@ -704,82 +718,103 @@ pty_posix_spawn(char** argv, char** env,
+@@ -704,82 +718,105 @@ pty_posix_spawn(char** argv, char** env,
                POSIX_SPAWN_SETSIGDEF |
                POSIX_SPAWN_SETSIGMASK |
                POSIX_SPAWN_SETSID;
@@ -82,7 +105,7 @@ index 7b4b9e1..2e5293d 100644
 +    *err = format_error("posix_openpt failed", errno);
 +    goto done;
    }
- 
+
 -  int res = grantpt(*master) || unlockpt(*master);
 +  res = grantpt(*master);
    if (res == -1) {
@@ -96,7 +119,7 @@ index 7b4b9e1..2e5293d 100644
 +    *err = format_error("unlockpt failed", errno);
 +    goto done;
    }
- 
+
    // Use TIOCPTYGNAME instead of ptsname() to avoid threading problems.
 -  int slave;
 -  char slave_pty_name[128];
@@ -106,14 +129,14 @@ index 7b4b9e1..2e5293d 100644
 +    *err = format_error("ioctl(TIOCPTYGNAME) failed", errno);
 +    goto done;
    }
- 
+
    slave = open(slave_pty_name, O_RDWR | O_NOCTTY);
    if (slave == -1) {
 -    return;
 +    *err = format_error("open slave pty failed", errno);
 +    goto done;
    }
- 
+
    if (termp) {
      res = tcsetattr(slave, TCSANOW, termp);
      if (res == -1) {
@@ -122,7 +145,7 @@ index 7b4b9e1..2e5293d 100644
 +      goto done;
      };
    }
- 
+
    if (winp) {
      res = ioctl(slave, TIOCSWINSZ, winp);
      if (res == -1) {
@@ -131,7 +154,7 @@ index 7b4b9e1..2e5293d 100644
 +      goto done;
      }
    }
- 
+
 -  posix_spawn_file_actions_t acts;
 -  posix_spawn_file_actions_init(&acts);
    posix_spawn_file_actions_adddup2(&acts, slave, STDIN_FILENO);
@@ -139,7 +162,7 @@ index 7b4b9e1..2e5293d 100644
    posix_spawn_file_actions_adddup2(&acts, slave, STDERR_FILENO);
    posix_spawn_file_actions_addclose(&acts, slave);
    posix_spawn_file_actions_addclose(&acts, *master);
- 
+
 -  posix_spawnattr_t attrs;
 -  posix_spawnattr_init(&attrs);
 -  *err = posix_spawnattr_setflags(&attrs, flags);
@@ -149,7 +172,7 @@ index 7b4b9e1..2e5293d 100644
 +    *err = format_error("posix_spawnattr_setflags failed", spawn_err);
      goto done;
    }
- 
+
 -  sigset_t signal_set;
    /* Reset all signal the child to their default behavior */
    sigfillset(&signal_set);
@@ -160,7 +183,7 @@ index 7b4b9e1..2e5293d 100644
 +    *err = format_error("posix_spawnattr_setsigdefault failed", spawn_err);
      goto done;
    }
- 
+
    /* Reset the signal mask for all signals */
    sigemptyset(&signal_set);
 -  *err = posix_spawnattr_setsigmask(&attrs, &signal_set);
@@ -170,7 +193,7 @@ index 7b4b9e1..2e5293d 100644
 +    *err = format_error("posix_spawnattr_setsigmask failed", spawn_err);
      goto done;
    }
- 
+
    do
 -    *err = posix_spawn(pid, argv[0], &acts, &attrs, argv, env);
 -  while (*err == EINTR);
@@ -185,11 +208,13 @@ index 7b4b9e1..2e5293d 100644
 +  if (slave != -1) {
 +    close(slave);
 +  }
- 
+
 -  for (; count > 0; count--) {
 -    close(low_fds[count]);
-+  for (size_t i = 0; i <= count; i++) {
-+    close(low_fds[i]);
++  for (size_t i = 0; i < 3; i++) {
++    if (low_fds[i] != -1) {
++      close(low_fds[i]);
++    }
    }
  }
  #endif


### PR DESCRIPTION
Split out from #962 per @pedramamini's review — this commit is unrelated to the git graph / branch switcher feature and is easier to review and revert independently here.

## Summary

Two fixes against the patched `node-pty@1.1.0`:

- **`winpty.gyp` (Windows build):** prefix the `GetCommitHash.bat` / `UpdateGenVersion.bat` invocations with `.\\` so `cmd /c` finds them when the working directory isn't on the lookup path. Without this the native build fails on Windows.
- **`pty_posix_spawn` (macOS error reporting):** surface the actual `posix_spawnp` errno via a `format_error` helper and a `std::string err` out-param, instead of collapsing every failure into the generic `"posix_spawnp failed."` string.

### CodeRabbit fix folded in

The original PR #962 version of this patch had an OOB / uninitialised-FD bug in the cleanup loop (CodeRabbit flagged it). This branch addresses it:

- Initialise `int low_fds[3] = { -1, -1, -1 };`
- Replace `for (size_t i = 0; i <= count; i++) close(low_fds[i]);` with a bounded, `-1`-aware variant that iterates `0..3` and skips uninitialised entries — no array OOB, no `close()` on stack garbage.

## Why

`node-pty` ships an upstream patch via `patch-package`. The Windows build silently breaks for new contributors without the gyp prefix fix, and a bare `"posix_spawnp failed."` made macOS spawn issues effectively unreproducible.

## Test plan

- [ ] `npm install` on Windows applies the patch cleanly via `patch-package`.
- [ ] `npm install` on macOS applies cleanly.
- [ ] On macOS, force a spawn failure (e.g. invalid command) and confirm the thrown `Napi::Error` carries the formatted `"posix_spawn failed: <strerror>"` instead of the legacy generic string.