### PR TITLE
fix: render YAML front matter in Auto Run preview, truncate browser tab titles

### DIFF
--- a/src/__tests__/renderer/components/TabBar.test.tsx
+++ b/src/__tests__/renderer/components/TabBar.test.tsx
@@ -2224,6 +2224,63 @@ describe('TabBar', () => {
 			expect(activeTabName).not.toHaveClass('truncate');
 		});
 
+		it('truncates browser tab titles for both active and inactive tabs', () => {
+			const longTitle = 'A very very very long browser tab title that should be truncated';
+			const otherLongTitle =
+				'Another extremely long browser tab title that should also be truncated';
+			render(
+				<TabBar
+					tabs={[createTab({ id: 'tab-1', name: 'Chat' })]}
+					activeTabId="tab-1"
+					theme={mockTheme}
+					onTabSelect={mockOnTabSelect}
+					onTabClose={mockOnTabClose}
+					onNewTab={mockOnNewTab}
+					unifiedTabs={[
+						{
+							type: 'browser',
+							id: 'browser-1',
+							data: {
+								id: 'browser-1',
+								url: 'https://example.com',
+								title: longTitle,
+								createdAt: 1,
+								canGoBack: false,
+								canGoForward: false,
+								isLoading: false,
+							} as any,
+						},
+						{
+							type: 'browser',
+							id: 'browser-2',
+							data: {
+								id: 'browser-2',
+								url: 'https://example.org',
+								title: otherLongTitle,
+								createdAt: 2,
+								canGoBack: false,
+								canGoForward: false,
+								isLoading: false,
+							} as any,
+						},
+					]}
+					activeBrowserTabId="browser-1"
+					onBrowserTabSelect={mockOnBrowserTabSelect}
+					onBrowserTabClose={mockOnBrowserTabClose}
+				/>
+			);
+
+			// Active browser tab: still truncated, with a slightly larger max width
+			const activeTitle = screen.getByText(longTitle);
+			expect(activeTitle).toHaveClass('truncate');
+			expect(activeTitle).toHaveClass('max-w-[180px]');
+
+			// Inactive browser tab: truncated with the standard max width
+			const inactiveTitle = screen.getByText(otherLongTitle);
+			expect(inactiveTitle).toHaveClass('truncate');
+			expect(inactiveTitle).toHaveClass('max-w-[140px]');
+		});
+
 		it('handles many tabs', () => {
 			const tabs = Array.from({ length: 50 }, (_, i) =>
 				createTab({ id: `tab-${i}`, name: `Tab ${i + 1}` })

--- a/src/renderer/components/TabBar/BrowserTabItem.tsx
+++ b/src/renderer/components/TabBar/BrowserTabItem.tsx
@@ -326,7 +326,7 @@ export const BrowserTabItem = memo(function BrowserTabItem({
 			)}
 
 			<span
-				className={`text-xs font-medium ${isActive ? 'whitespace-nowrap' : 'truncate max-w-[140px]'}`}
+				className={`text-xs font-medium truncate ${isActive ? 'max-w-[180px]' : 'max-w-[140px]'}`}
 				style={{ color: isActive ? theme.colors.textMain : theme.colors.textDim }}
 			>
 				{label}

--- a/src/renderer/hooks/batch/useAutoRunMarkdown.ts
+++ b/src/renderer/hooks/batch/useAutoRunMarkdown.ts
@@ -8,6 +8,8 @@ import {
 	generateAutoRunProseStyles,
 	createMarkdownComponents,
 } from '../../utils/markdownConfig';
+import remarkFrontmatter from 'remark-frontmatter';
+import { remarkFrontmatterTable } from '../../utils/remarkFrontmatterTable';
 import { remarkFileLinks, buildFileTreeIndices } from '../../utils/remarkFileLinks';
 import { getHomeDir, getHomeDirAsync } from '../../utils/homeDir';
 import { MermaidRenderer } from '../../components/MermaidRenderer';
@@ -152,7 +154,7 @@ export function useAutoRunMarkdown({
 
 	// 8. Memoize remarkPlugins - include remarkFileLinks when we have file tree
 	const remarkPlugins = useMemo(() => {
-		const plugins: any[] = [...REMARK_GFM_PLUGINS];
+		const plugins: any[] = [...REMARK_GFM_PLUGINS, remarkFrontmatter, remarkFrontmatterTable];
 		if (fileTree.length > 0 || homeDir) {
 			// cwd is empty since we're at the root of the Auto Run folder
 			plugins.push([remarkFileLinks, { indices: fileTreeIndices || undefined, cwd: '', homeDir }]);


### PR DESCRIPTION
## Summary

Two small UI papercut bugs from in-app feedback. Both are scoped, mechanical fixes with no overlap in surface area.

### Fix #889 — Auto Run preview flattens YAML front matter

`useAutoRunMarkdown` was missing the `remark-frontmatter` + `remarkFrontmatterTable` plugins that `MarkdownRenderer` and `FilePreview` already use. Without them, ReactMarkdown treats:

\`\`\`
---
title: My Doc
share_note_link: https://example.com
share_note_updated: 2026-04-23T16:06:03-05:00
---
\`\`\`

…as a thematic break followed by a setext H2 underline, which collapses every front-matter line into a single visual heading — exactly the "flattened into one line" behavior reported.

Adding both plugins makes the Auto Run preview render front matter as the same "Document metadata" table you already get in the file preview pane.

### Fix #853 — Internal browser tab titles overflow when active

`BrowserTabItem` switched the active tab from \`truncate max-w-[140px]\` to \`whitespace-nowrap\` (no max width), so long page titles ran past the tab and into adjacent tabs. Chrome/Safari truncate active tabs the same way as inactive ones, just with a bit more room.

The fix: always truncate, give the active tab \`max-w-[180px]\` and inactive tabs keep \`max-w-[140px]\`.

## Files changed

- \`src/renderer/hooks/batch/useAutoRunMarkdown.ts\` — add \`remark-frontmatter\` + \`remarkFrontmatterTable\` to the plugin list
- \`src/renderer/components/TabBar/BrowserTabItem.tsx\` — always truncate the title span; widen the active max-width
- \`src/__tests__/renderer/components/TabBar.test.tsx\` — new test asserting that both the active and inactive browser tab titles get \`truncate\` plus the expected max-width

## Test plan

- [x] \`npx vitest run src/__tests__/renderer/components/TabBar.test.tsx\` — 171 pass
- [x] \`npx vitest run src/__tests__/renderer/components/AutoRun.test.tsx src/__tests__/renderer/components/AutoRunBlurSaveTiming.test.tsx\` — 210 pass
- [x] Prettier + ESLint clean on the three changed files
- [x] \`npx tsc --noEmit\` reports no new errors in the changed files
- [ ] Manual: paste a markdown doc with YAML front matter into an Auto Run document and confirm the preview shows the metadata table
- [ ] Manual: open enough internal browser tabs with long titles to overflow and confirm the active one truncates with an ellipsis

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added tests for browser tab title truncation in unified mode for active and inactive tabs.

* **Bug Fixes**
  * Improved tab label truncation behavior based on active/inactive tab state.

* **New Features**
  * Added support for parsing Markdown frontmatter content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->