### PR TITLE
chore(tests): dedup repeated import type Session lines in 4 files

### DIFF
--- a/src/__tests__/renderer/components/GroupChatInput.test.tsx
+++ b/src/__tests__/renderer/components/GroupChatInput.test.tsx
@@ -14,7 +14,6 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { GroupChatInput } from '../../../renderer/components/GroupChatInput';
 import type { Session, Group, GroupChatParticipant } from '../../../renderer/types';
-import type { Session, Group, GroupChatParticipant } from '../../../renderer/types';
 import { createMockSession as baseCreateMockSession } from '../../helpers/mockSession';
 
 import { createMockTheme } from '../../helpers/mockTheme';

--- a/src/__tests__/renderer/components/InlineWizard/WizardInputPanel.test.tsx
+++ b/src/__tests__/renderer/components/InlineWizard/WizardInputPanel.test.tsx
@@ -18,7 +18,6 @@ import {
 	formatEnterToSend,
 } from '../../../../renderer/utils/shortcutFormatter';
 import type { Session } from '../../../../renderer/types';
-import type { Session } from '../../../../renderer/types';
 import { createMockSession as baseCreateMockSession } from '../../../helpers/mockSession';
 
 import { mockTheme } from '../../../helpers/mockTheme';

--- a/src/__tests__/renderer/components/InputArea.test.tsx
+++ b/src/__tests__/renderer/components/InputArea.test.tsx
@@ -4,7 +4,6 @@ import userEvent from '@testing-library/user-event';
 import { InputArea } from '../../../renderer/components/InputArea';
 import { formatEnterToSend } from '../../../renderer/utils/shortcutFormatter';
 import type { Session } from '../../../renderer/types';
-import type { Session } from '../../../renderer/types';
 import { createMockSession as baseCreateMockSession } from '../../helpers/mockSession';
 
 import { mockTheme } from '../../helpers/mockTheme';

--- a/src/__tests__/renderer/components/WorktreeRunSection.test.tsx
+++ b/src/__tests__/renderer/components/WorktreeRunSection.test.tsx
@@ -3,7 +3,6 @@ import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
 import React from 'react';
 import { WorktreeRunSection } from '../../../renderer/components/WorktreeRunSection';
 import type { Session } from '../../../renderer/types';
-import type { Session } from '../../../renderer/types';
 import { createMockSession as baseCreateMockSession } from '../../helpers/mockSession';
 import { gitService } from '../../../renderer/services/git';
 


### PR DESCRIPTION
## Summary

Removes a duplicated `import type { Session } from '../../../renderer/types';` line from each of four test files. The duplicates are pre-existing on `rc` and have been silently de-duped by the older `esbuild` bundled with `vitest@4.0.15`. Newer `vitest` patches (e.g. `4.1.5`, which any fresh `npm install` resolves to within the current `^4.0.15` range) ship a `vite`/`oxc` parser that correctly rejects the duplicate as a parse error, leaving four files reporting `(0 test)` and 232 tests silently unrun.

## Files

- `src/__tests__/renderer/components/InputArea.test.tsx`
- `src/__tests__/renderer/components/WorktreeRunSection.test.tsx`
- `src/__tests__/renderer/components/InlineWizard/WizardInputPanel.test.tsx`
- `src/__tests__/renderer/components/GroupChatInput.test.tsx`

## Why merge first

Prerequisite for any branch whose `npm install` resolves a fresh lockfile (which pulls newer vitest with the strict parser). The companion package-upgrade PRs (`stage-4-typescript-6`, `stage-6-vite-8`, `stage-7-electron-41`) all regenerate the lockfile and need this PR landed first to avoid silent test skipping.

## Verification

Validation: full vitest suite on a fresh `npm install` (lockfile regenerated to force vitest 4.1.5): **775 files pass, 0 fail, 27,356 tests pass** on a `/tmp` ext4 worktree.

## Test plan

- [ ] CI runs the full vitest suite and the four previously-skipped files report their full test counts (~232 added)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for worktree-related functionality with expanded test scenarios.
  * Cleaned up test file imports for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->