### PR TITLE
chore(deps): bump vite to 8.x + plugin-react 6 + vitest 4.1 + esbuild 0.28

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -103,8 +103,8 @@
 				"@types/ws": "^8.5.10",
 				"@typescript-eslint/eslint-plugin": "^8.59.2",
 				"@typescript-eslint/parser": "^8.59.2",
-				"@vitejs/plugin-react": "^4.2.1",
-				"@vitest/coverage-v8": "^4.0.15",
+				"@vitejs/plugin-react": "^6.0.1",
+				"@vitest/coverage-v8": "^4.1.5",
 				"@welldone-software/why-did-you-render": "^8.0.3",
 				"autoprefixer": "^10.4.16",
 				"baseline-browser-mapping": "^2.9.17",
@@ -115,7 +115,7 @@
 				"electron-devtools-installer": "^4.0.0",
 				"electron-playwright-helpers": "^2.0.1",
 				"electron-rebuild": "^3.2.9",
-				"esbuild": "^0.24.2",
+				"esbuild": "^0.28.0",
 				"eslint": "^9.39.2",
 				"eslint-config-prettier": "^10.1.8",
 				"eslint-plugin-react": "^7.37.5",
@@ -133,9 +133,8 @@
 				"tailwindcss": "^3.4.1",
 				"typescript": "^6.0.3",
 				"typescript-eslint": "^8.59.2",
-				"vite": "^5.0.11",
-				"vite-plugin-electron": "^0.28.2",
-				"vitest": "^4.0.15"
+				"vite": "^8.0.11",
+				"vitest": "^4.1.5"
 			},
 			"engines": {
 				"node": ">=22.0.0"
@@ -388,16 +387,6 @@
 				"@babel/core": "^7.0.0"
 			}
 		},
-		"node_modules/@babel/helper-plugin-utils": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
-			"integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
 		"node_modules/@babel/helper-string-parser": {
 			"version": "7.27.1",
 			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
@@ -456,38 +445,6 @@
 			},
 			"engines": {
 				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/@babel/plugin-transform-react-jsx-self": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
-			"integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.27.1"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-transform-react-jsx-source": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
-			"integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.27.1"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
 			}
 		},
 		"node_modules/@babel/runtime": {
@@ -563,10 +520,41 @@
 			"integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
 			"license": "MIT"
 		},
+		"node_modules/@chevrotain/cst-dts-gen": {
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-12.0.0.tgz",
+			"integrity": "sha512-fSL4KXjTl7cDgf0B5Rip9Q05BOrYvkJV/RrBTE/bKDN096E4hN/ySpcBK5B24T76dlQ2i32Zc3PAE27jFnFrKg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@chevrotain/gast": "12.0.0",
+				"@chevrotain/types": "12.0.0"
+			}
+		},
+		"node_modules/@chevrotain/gast": {
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-12.0.0.tgz",
+			"integrity": "sha512-1ne/m3XsIT8aEdrvT33so0GUC+wkctpUPK6zU9IlOyJLUbR0rg4G7ZiApiJbggpgPir9ERy3FRjT6T7lpgetnQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@chevrotain/types": "12.0.0"
+			}
+		},
+		"node_modules/@chevrotain/regexp-to-ast": {
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-12.0.0.tgz",
+			"integrity": "sha512-p+EW9MaJwgaHguhoqwOtx/FwuGr+DnNn857sXWOi/mClXIkPGl3rn7hGNWvo31HA3vyeQxjqe+H36yZJwYU8cA==",
+			"license": "Apache-2.0"
+		},
 		"node_modules/@chevrotain/types": {
-			"version": "11.1.2",
-			"resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
-			"integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-12.0.0.tgz",
+			"integrity": "sha512-S+04vjFQKeuYw0/eW3U52LkAHQsB1ASxsPGsLPUyQgrZ2iNNibQrsidruDzjEX2JYfespXMG0eZmXlhA6z7nWA==",
+			"license": "Apache-2.0"
+		},
+		"node_modules/@chevrotain/utils": {
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-12.0.0.tgz",
+			"integrity": "sha512-lB59uJoaGIfOOL9knQqQRfhl9g7x8/wqFkp13zTdkRu1huG9kg6IJs1O8hqj9rs6h7orGxHJUKb+mX3rPbWGhA==",
 			"license": "Apache-2.0"
 		},
 		"node_modules/@codemirror/autocomplete": {
@@ -769,9 +757,9 @@
 			}
 		},
 		"node_modules/@csstools/css-calc": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
-			"integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+			"integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
 			"dev": true,
 			"funding": [
 				{
@@ -793,9 +781,9 @@
 			}
 		},
 		"node_modules/@csstools/css-color-parser": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.1.tgz",
-			"integrity": "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+			"integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -810,7 +798,7 @@
 			"license": "MIT",
 			"dependencies": {
 				"@csstools/color-helpers": "^6.0.2",
-				"@csstools/css-calc": "^3.2.1"
+				"@csstools/css-calc": "^3.2.0"
 			},
 			"engines": {
 				"node": ">=20.19.0"
@@ -844,9 +832,9 @@
 			}
 		},
 		"node_modules/@csstools/css-syntax-patches-for-csstree": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.4.tgz",
-			"integrity": "sha512-wgsqt92b7C7tQhIdPNxj0n9zuUbQlvAuI1exyzeNrOKOi62SD7ren8zqszmpVREjAOqg8cD2FqYhQfAuKjk4sw==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+			"integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
 			"dev": true,
 			"funding": [
 				{
@@ -1264,9 +1252,9 @@
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.24.2.tgz",
-			"integrity": "sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==",
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+			"integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
 			"cpu": [
 				"ppc64"
 			],
@@ -1281,9 +1269,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.24.2.tgz",
-			"integrity": "sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==",
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+			"integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
 			"cpu": [
 				"arm"
 			],
@@ -1298,9 +1286,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm64": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.24.2.tgz",
-			"integrity": "sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==",
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+			"integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
 			"cpu": [
 				"arm64"
 			],
@@ -1315,9 +1303,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-x64": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.24.2.tgz",
-			"integrity": "sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==",
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+			"integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
 			"cpu": [
 				"x64"
 			],
@@ -1332,9 +1320,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-arm64": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.24.2.tgz",
-			"integrity": "sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==",
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+			"integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -1349,9 +1337,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-x64": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.24.2.tgz",
-			"integrity": "sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==",
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+			"integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1366,9 +1354,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.24.2.tgz",
-			"integrity": "sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==",
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+			"integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -1383,9 +1371,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-x64": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.24.2.tgz",
-			"integrity": "sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==",
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+			"integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
 			"cpu": [
 				"x64"
 			],
@@ -1400,9 +1388,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.24.2.tgz",
-			"integrity": "sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==",
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+			"integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
 			"cpu": [
 				"arm"
 			],
@@ -1417,9 +1405,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm64": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.24.2.tgz",
-			"integrity": "sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==",
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+			"integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
 			"cpu": [
 				"arm64"
 			],
@@ -1434,9 +1422,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ia32": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.24.2.tgz",
-			"integrity": "sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==",
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+			"integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
 			"cpu": [
 				"ia32"
 			],
@@ -1451,9 +1439,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-loong64": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.24.2.tgz",
-			"integrity": "sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==",
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+			"integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
 			"cpu": [
 				"loong64"
 			],
@@ -1468,9 +1456,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-mips64el": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.24.2.tgz",
-			"integrity": "sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==",
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+			"integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
 			"cpu": [
 				"mips64el"
 			],
@@ -1485,9 +1473,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ppc64": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.24.2.tgz",
-			"integrity": "sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==",
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+			"integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
 			"cpu": [
 				"ppc64"
 			],
@@ -1502,9 +1490,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-riscv64": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.24.2.tgz",
-			"integrity": "sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==",
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+			"integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
 			"cpu": [
 				"riscv64"
 			],
@@ -1519,9 +1507,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-s390x": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.24.2.tgz",
-			"integrity": "sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==",
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+			"integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
 			"cpu": [
 				"s390x"
 			],
@@ -1536,9 +1524,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-x64": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.24.2.tgz",
-			"integrity": "sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==",
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+			"integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1553,9 +1541,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-arm64": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.24.2.tgz",
-			"integrity": "sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==",
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+			"integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
 			"cpu": [
 				"arm64"
 			],
@@ -1570,9 +1558,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-x64": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.24.2.tgz",
-			"integrity": "sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==",
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+			"integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
 			"cpu": [
 				"x64"
 			],
@@ -1587,9 +1575,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-arm64": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.24.2.tgz",
-			"integrity": "sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==",
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+			"integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
 			"cpu": [
 				"arm64"
 			],
@@ -1604,9 +1592,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-x64": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.24.2.tgz",
-			"integrity": "sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==",
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+			"integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
 			"cpu": [
 				"x64"
 			],
@@ -1633,15 +1621,14 @@
 			"os": [
 				"openharmony"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/sunos-x64": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.24.2.tgz",
-			"integrity": "sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==",
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+			"integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
 			"cpu": [
 				"x64"
 			],
@@ -1656,9 +1643,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-arm64": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.24.2.tgz",
-			"integrity": "sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==",
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+			"integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
 			"cpu": [
 				"arm64"
 			],
@@ -1673,9 +1660,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-ia32": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.24.2.tgz",
-			"integrity": "sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==",
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+			"integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
 			"cpu": [
 				"ia32"
 			],
@@ -1690,9 +1677,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-x64": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.24.2.tgz",
-			"integrity": "sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==",
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+			"integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
 			"cpu": [
 				"x64"
 			],
@@ -2227,9 +2214,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@iconify/utils": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.3.tgz",
-			"integrity": "sha512-LPKOXPn/zV+zis1oOfGWogaXVpqUybF3ZS6SCZIsz8vg0ivVp9+fVqyYB7xq0aiST/VhUQYGO1qo6uoYSiEJqw==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.2.tgz",
+			"integrity": "sha512-jVf75icVVgSVGf9+QWBeCHdFL35yZ06HMHl9sCa059pITTP781lOacvRazfwAmXDKiBiUdQQMWVnuiw/RaQNhQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@antfu/install-pkg": "^1.1.0",
@@ -2521,12 +2508,12 @@
 			"license": "MIT"
 		},
 		"node_modules/@mermaid-js/parser": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.1.1.tgz",
-			"integrity": "sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.1.0.tgz",
+			"integrity": "sha512-gxK9ZX2+Fex5zu8LhRQoMeMPEHbc73UKZ0FQ54YrQtUxE1VVhMwzeNtKRPAu5aXks4FasbMe4xB4bWrmq6Jlxw==",
 			"license": "MIT",
 			"dependencies": {
-				"@chevrotain/types": "~11.1.1"
+				"langium": "^4.0.0"
 			}
 		},
 		"node_modules/@napi-rs/wasm-runtime": {
@@ -3059,9 +3046,9 @@
 			}
 		},
 		"node_modules/@opentelemetry/semantic-conventions": {
-			"version": "1.41.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
-			"integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
+			"version": "1.40.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
+			"integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=14"
@@ -3083,9 +3070,9 @@
 			}
 		},
 		"node_modules/@oxc-project/types": {
-			"version": "0.129.0",
-			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.129.0.tgz",
-			"integrity": "sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg==",
+			"version": "0.128.0",
+			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.128.0.tgz",
+			"integrity": "sha512-huv1Y/LzBJkBVHt3OlC7u0zHBW9qXf1FdD7sGmc1rXc2P1mTwHssYv7jyGx5KAACSCH+9B3Bhn6Z9luHRvf7pQ==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
@@ -3109,13 +3096,13 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.60.0",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
-			"integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+			"version": "1.59.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+			"integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright": "1.60.0"
+				"playwright": "1.59.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -3474,9 +3461,9 @@
 			}
 		},
 		"node_modules/@reduxjs/toolkit/node_modules/immer": {
-			"version": "11.1.8",
-			"resolved": "https://registry.npmjs.org/immer/-/immer-11.1.8.tgz",
-			"integrity": "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==",
+			"version": "11.1.7",
+			"resolved": "https://registry.npmjs.org/immer/-/immer-11.1.7.tgz",
+			"integrity": "sha512-LFVFtAROHcDy1er5UI6nodRFnZ2SgdCXhfNSI+DpObO8N7Pur/muBGsjzH5wpnFHCYhYVQxZskCkV4koQ//3/Q==",
 			"license": "MIT",
 			"funding": {
 				"type": "opencollective",
@@ -3484,9 +3471,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-android-arm64": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0.tgz",
-			"integrity": "sha512-TWMZnRLMe63C2Lhyicviu7ZHaU4kxa6PS3rofvc9GmcvptzNN11BcfQ4Sl7MwTOsisQoa2keB/EBdNCAnUo8vA==",
+			"version": "1.0.0-rc.18",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.18.tgz",
+			"integrity": "sha512-lIDyUAfD7U3+BWKzdxMbJcsYHuqXqmGz40aeRqvuAm3y5TkJSYTBW2RDrn65DJFPQqVjUAUqq5uz8urzQ8aBdQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -3501,9 +3488,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-darwin-arm64": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0.tgz",
-			"integrity": "sha512-6XcD+8k0gPVItNagEw78/qqcBDwKcwDYS8V2hRmVsfUSIrd8cWe/CBvRDI5toqFyPfj+FJr6t8U6Xj2P2prEew==",
+			"version": "1.0.0-rc.18",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.18.tgz",
+			"integrity": "sha512-apJq2ktnGp27nSInMR5Vcj8kY6xJzDAvfdIFlpDcAK/w4cDO58qVoi1YQsES/SKiFNge/6e4CUzgjfHduYqWpQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -3518,9 +3505,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-darwin-x64": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0.tgz",
-			"integrity": "sha512-iN/tWVXRQDWvmZlKdceP1Dwug9GDpEymhb9p4xnEe6zvCg5lFmzVljl+1qR1NVx3yfGpr2Na+CuLmv5IU8uzfQ==",
+			"version": "1.0.0-rc.18",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.18.tgz",
+			"integrity": "sha512-5Ofot8xbs+pxRHJqm9/9N/4sTQOvdrwEsmPE9pdLEEoAbdZtG6F2LMDfO1sp6ZAtXJuJV/21ew2srq3W8NXB5g==",
 			"cpu": [
 				"x64"
 			],
@@ -3535,9 +3522,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-freebsd-x64": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0.tgz",
-			"integrity": "sha512-jjQMDvvwSOuhOwMszD/klSOjyWMM3zI64hWTj9KT5x4MxRbZAf+7vLQ6qouRhtsLVFHr3f0ILaJAfgENPiQdAQ==",
+			"version": "1.0.0-rc.18",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.18.tgz",
+			"integrity": "sha512-7h8eeOTT1eyqJyx64BFCnWZpNm486hGWt2sqeLLgDxA0xI1oGZ9H7gK1S85uNGmBhkdPwa/6reTxfFFKvIsebw==",
 			"cpu": [
 				"x64"
 			],
@@ -3552,9 +3539,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0.tgz",
-			"integrity": "sha512-d//Dtg2x6/m3mbV64yUGNnDGNZaDGRpDLLNGerHQUVObuNaIQaaDp25yUiqGXtHEXX+NP2d0wAlmKgpYgIAJ2A==",
+			"version": "1.0.0-rc.18",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.18.tgz",
+			"integrity": "sha512-eRcm/HVt9U/JFu5RKAEKwGQYtDCKWLiaH6wOnsSEp6NMBb/3Os8LgHZlNyzMpFVNmiiMFlfb2zEnebfzJrHFmg==",
 			"cpu": [
 				"arm"
 			],
@@ -3569,9 +3556,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm64-gnu": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0.tgz",
-			"integrity": "sha512-n7Ofp0mx+aB2cC+Sdy5YtMnXtY9lchnHbY+3Yt0uq9JsWQExf4f5Whu0tK0R8Jdc9S6RchTHjIFY7uc92puOVQ==",
+			"version": "1.0.0-rc.18",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.18.tgz",
+			"integrity": "sha512-SOrT/cT4ukTmgnrEz/Hg3m7LBnuCLW9psDeMKrimRWY4I8DmnO7Lco8W2vtqPmMkbVu8iJ+g4GFLVLLOVjJ9DQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -3586,9 +3573,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm64-musl": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0.tgz",
-			"integrity": "sha512-EIVjy2cgd7uuMMo94FVkBp7F6DhcZAUwNURkSG3RwUmvAXR6s0ISxM81U+IydcZByPG0pZIHsf1b6kTxoFDgJA==",
+			"version": "1.0.0-rc.18",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.18.tgz",
+			"integrity": "sha512-QWjdxN1HJCpBTAcZ5N5F7wju3gVPzRzSpmGzx7na0c/1qpN9CFil+xt+l9lV/1M6/gqHSNXCiqPfwhVJPeLnug==",
 			"cpu": [
 				"arm64"
 			],
@@ -3603,9 +3590,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-ppc64-gnu": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0.tgz",
-			"integrity": "sha512-JEwwOPcwTLAcpDQlqSmjEmfs63xJnSiUNIGvLcDLUHCWK4XowpS/7c7tUsUH6uT/ct6bMUTdXKfI8967FYj6mg==",
+			"version": "1.0.0-rc.18",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.18.tgz",
+			"integrity": "sha512-ugCOyj7a4d9h3q9B+wXmf6g3a68UsjGh6dob5DHevHGMwDUbhsYNbSPxJsENcIttJZ9jv7qGM2UesLw5jqIhdg==",
 			"cpu": [
 				"ppc64"
 			],
@@ -3620,9 +3607,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-s390x-gnu": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0.tgz",
-			"integrity": "sha512-0wjCFhLrihtAubnT9iA0N++0pSV0z5Hg7tNGdNJ4RFaINceHadoF+kiFGyY1qSSNVIAZtLotG8Ju1bgDPkjnFA==",
+			"version": "1.0.0-rc.18",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.18.tgz",
+			"integrity": "sha512-kKWRhbsotpXkGbcd5dllUWg5gEXcDAa8u5YnP9AV5DYNbvJHGzzuwv7dpmhc8NqKMJldl0a+x76IHbspEpEmdA==",
 			"cpu": [
 				"s390x"
 			],
@@ -3637,9 +3624,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-x64-gnu": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0.tgz",
-			"integrity": "sha512-Dfn7iak9BcMMePxcoJfpSbWqnEyrp/dRF63/8qW/eHBdOZov6x5aShLLEYGYdIeSJ6vMLK/XCVB+lGIxm41bQA==",
+			"version": "1.0.0-rc.18",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.18.tgz",
+			"integrity": "sha512-uCo8ElcCIAMyYAZyuIZ81oFkhTSIllNvUCHCAlbhlN4ji3uC28h7IIdlXyIvGO7HsuqnV9p3rD/bpH7XhIyhRw==",
 			"cpu": [
 				"x64"
 			],
@@ -3654,9 +3641,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-x64-musl": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0.tgz",
-			"integrity": "sha512-5/utzzDmD/pD/bmuaUcbTf/sZYy0aztwIVlfpoW1fTjCZ0BaPOMVWGZL1zvgxyi7ZIVYWlxKONHmSbHuiOh8Jw==",
+			"version": "1.0.0-rc.18",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.18.tgz",
+			"integrity": "sha512-XNOQZtuE6yUIvx4rwGemwh8kpL1xvU41FXy/s9K7T/3JVcqGzo3NfKM2HrbrGgfPYGFW42f07Wk++aOC6B9NWA==",
 			"cpu": [
 				"x64"
 			],
@@ -3671,9 +3658,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-openharmony-arm64": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0.tgz",
-			"integrity": "sha512-ouJs8VcUomfLfpbUECqFMRqdV4x6aeAK3MA4m6vTrJJjKyWTV5KnxZx7Jd9G+GlDaQQxubcba00x16OyJ1meig==",
+			"version": "1.0.0-rc.18",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.18.tgz",
+			"integrity": "sha512-tSn/kzrfa7tNOXr7sEacDBN4YsIqTyLqh45IO0nHDwtpKIDNDJr+VFojt+4klSpChxB29JLyduSsE0MKEwa65A==",
 			"cpu": [
 				"arm64"
 			],
@@ -3688,9 +3675,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-wasm32-wasi": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0.tgz",
-			"integrity": "sha512-E+oHKGiDA+lsKMmFtffDDw91EryDT7uJocrIuCHqhm6bCTM6xFK+3gaCkYOHfPwQr0cCNarSM2xaELoQDz9jJg==",
+			"version": "1.0.0-rc.18",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.18.tgz",
+			"integrity": "sha512-+J9YGmc+czgqlhYmwun3S3O0FIZhsH8ep2456xwjAdIOmuJxM7xz4P4PtrxU+Bz17a/5bqPA8o3HAAoX0teUdg==",
 			"cpu": [
 				"wasm32"
 			],
@@ -3707,9 +3694,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-win32-arm64-msvc": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0.tgz",
-			"integrity": "sha512-yYK02n8Rngo+gbm1y6G0+7jk1sJ/2Wt7K0me0Y7k/ErBpyf+LJ2gFpqWVTcRV1rUepBlQRmpgWkTQCiiwrK0Ow==",
+			"version": "1.0.0-rc.18",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.18.tgz",
+			"integrity": "sha512-zsu47DgU0FQzSwi6sU9dZoEdUv7pc1AptSEz/Z8HBg54sV0Pbs3N0+CrIbTsgiu6EyoaNN9CHboqbLaz9lhOyQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -3724,9 +3711,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-win32-x64-msvc": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0.tgz",
-			"integrity": "sha512-14bpChMahXRRXiTwahSl+zzHPW6qQTXtkMuJBFlbo+pqSAews2d4BdCSHfrJ/MBsCZtpmTafsY+1QhBzitcmdg==",
+			"version": "1.0.0-rc.18",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.18.tgz",
+			"integrity": "sha512-7H+3yqGgmnlDTRRhw/xpYY9J1kf4GC681nVc4GqKhExZTDrVVrV2tsOR9kso0fvgBdcTCcQShx4SLLoHgaLwhg==",
 			"cpu": [
 				"x64"
 			],
@@ -3741,361 +3728,11 @@
 			}
 		},
 		"node_modules/@rolldown/pluginutils": {
-			"version": "1.0.0-beta.27",
-			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
-			"integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+			"version": "1.0.0-rc.7",
+			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.7.tgz",
+			"integrity": "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/@rollup/rollup-android-arm-eabi": {
-			"version": "4.60.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.3.tgz",
-			"integrity": "sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			]
-		},
-		"node_modules/@rollup/rollup-android-arm64": {
-			"version": "4.60.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.3.tgz",
-			"integrity": "sha512-xw3xtkDApIOGayehp2+Rz4zimfkaX65r4t47iy+ymQB2G4iJCBBfj0ogVg5jpvjpn8UWn/+q9tprxleYeNp3Hw==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			]
-		},
-		"node_modules/@rollup/rollup-darwin-arm64": {
-			"version": "4.60.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.3.tgz",
-			"integrity": "sha512-vo6Y5Qfpx7/5EaamIwi0WqW2+zfiusVihKatLvtN1VFVy3D13uERk/6gZLU1UiHRL6fDXqj/ELIeVRGnvcTE1g==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			]
-		},
-		"node_modules/@rollup/rollup-darwin-x64": {
-			"version": "4.60.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.3.tgz",
-			"integrity": "sha512-D+0QGcZhBzTN82weOnsSlY7V7+RMmPuF1CkbxyMAGE8+ZHeUjyb76ZiWmBlCu//AQQONvxcqRbwZTajZKqjuOw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			]
-		},
-		"node_modules/@rollup/rollup-freebsd-arm64": {
-			"version": "4.60.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.3.tgz",
-			"integrity": "sha512-6HnvHCT7fDyj6R0Ph7A6x8dQS/S38MClRWeDLqc0MdfWkxjiu1HSDYrdPhqSILzjTIC/pnXbbJbo+ft+gy/9hQ==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"freebsd"
-			]
-		},
-		"node_modules/@rollup/rollup-freebsd-x64": {
-			"version": "4.60.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.3.tgz",
-			"integrity": "sha512-KHLgC3WKlUYW3ShFKnnosZDOJ0xjg9zp7au3sIm2bs/tGBeC2ipmvRh/N7JKi0t9Ue20C0dpEshi8WUubg+cnA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"freebsd"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-			"version": "4.60.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.3.tgz",
-			"integrity": "sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-arm-musleabihf": {
-			"version": "4.60.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.3.tgz",
-			"integrity": "sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-arm64-gnu": {
-			"version": "4.60.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.3.tgz",
-			"integrity": "sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-arm64-musl": {
-			"version": "4.60.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.3.tgz",
-			"integrity": "sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-loong64-gnu": {
-			"version": "4.60.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.3.tgz",
-			"integrity": "sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==",
-			"cpu": [
-				"loong64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-loong64-musl": {
-			"version": "4.60.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.3.tgz",
-			"integrity": "sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==",
-			"cpu": [
-				"loong64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-ppc64-gnu": {
-			"version": "4.60.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.3.tgz",
-			"integrity": "sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==",
-			"cpu": [
-				"ppc64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-ppc64-musl": {
-			"version": "4.60.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.3.tgz",
-			"integrity": "sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==",
-			"cpu": [
-				"ppc64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
-			"version": "4.60.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.3.tgz",
-			"integrity": "sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==",
-			"cpu": [
-				"riscv64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-riscv64-musl": {
-			"version": "4.60.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.3.tgz",
-			"integrity": "sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==",
-			"cpu": [
-				"riscv64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-s390x-gnu": {
-			"version": "4.60.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.3.tgz",
-			"integrity": "sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==",
-			"cpu": [
-				"s390x"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-x64-gnu": {
-			"version": "4.60.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.3.tgz",
-			"integrity": "sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-x64-musl": {
-			"version": "4.60.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.3.tgz",
-			"integrity": "sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-openbsd-x64": {
-			"version": "4.60.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.3.tgz",
-			"integrity": "sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openbsd"
-			]
-		},
-		"node_modules/@rollup/rollup-openharmony-arm64": {
-			"version": "4.60.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.3.tgz",
-			"integrity": "sha512-AaXwSvUi3QIPtroAUw1t5yHGIyqKEXwH54WUocFolZhpGDruJcs8c+xPNDRn4XiQsS7MEwnYsHW2l0MBLDMkWg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openharmony"
-			]
-		},
-		"node_modules/@rollup/rollup-win32-arm64-msvc": {
-			"version": "4.60.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.3.tgz",
-			"integrity": "sha512-65LAKM/bAWDqKNEelHlcHvm2V+Vfb8C6INFxQXRHCvaVN1rJfwr4NvdP4FyzUaLqWfaCGaadf6UbTm8xJeYfEg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			]
-		},
-		"node_modules/@rollup/rollup-win32-ia32-msvc": {
-			"version": "4.60.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.3.tgz",
-			"integrity": "sha512-EEM2gyhBF5MFnI6vMKdX1LAosE627RGBzIoGMdLloPZkXrUN0Ckqgr2Qi8+J3zip/8NVVro3/FjB+tjhZUgUHA==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			]
-		},
-		"node_modules/@rollup/rollup-win32-x64-gnu": {
-			"version": "4.60.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.3.tgz",
-			"integrity": "sha512-E5Eb5H/DpxaoXH++Qkv28RcUJboMopmdDUALBczvHMf7hNIxaDZqwY5lK12UK1BHacSmvupoEWGu+n993Z0y1A==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			]
-		},
-		"node_modules/@rollup/rollup-win32-x64-msvc": {
-			"version": "4.60.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.3.tgz",
-			"integrity": "sha512-hPt/bgL5cE+Qp+/TPHBqptcAgPzgj46mPcg/16zNUmbQk0j+mOEQV/+Lqu8QRtDV3Ek95Q6FeFITpuhl6OTsAA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			]
 		},
 		"node_modules/@sentry-internal/browser-utils": {
 			"version": "10.50.0",
@@ -4583,51 +4220,6 @@
 			"license": "MIT",
 			"peer": true
 		},
-		"node_modules/@types/babel__core": {
-			"version": "7.20.5",
-			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
-			"integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/parser": "^7.20.7",
-				"@babel/types": "^7.20.7",
-				"@types/babel__generator": "*",
-				"@types/babel__template": "*",
-				"@types/babel__traverse": "*"
-			}
-		},
-		"node_modules/@types/babel__generator": {
-			"version": "7.27.0",
-			"resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
-			"integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/types": "^7.0.0"
-			}
-		},
-		"node_modules/@types/babel__template": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
-			"integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/parser": "^7.1.0",
-				"@babel/types": "^7.0.0"
-			}
-		},
-		"node_modules/@types/babel__traverse": {
-			"version": "7.28.0",
-			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
-			"integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/types": "^7.28.2"
-			}
-		},
 		"node_modules/@types/better-sqlite3": {
 			"version": "7.6.13",
 			"resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
@@ -5084,9 +4676,9 @@
 			}
 		},
 		"node_modules/@types/node": {
-			"version": "20.19.41",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
-			"integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
+			"version": "20.19.39",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+			"integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~6.21.0"
@@ -5267,17 +4859,17 @@
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "8.59.3",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.3.tgz",
-			"integrity": "sha512-PwFvSKsXGShKGW6n5bZOhGHEcCZXM8HofLK9fNsEwZXzFRjoY+XT1Vsf1zgyXdwTr0ZYz1/2tkZ0DBTT9jZjhw==",
+			"version": "8.59.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.2.tgz",
+			"integrity": "sha512-j/bwmkBvHUtPNxzuWe5z6BEk3q54YRyGlBXkSsmfoih7zNrBvl5A9A98anlp/7JbyZcWIJ8KXo/3Tq/DjFLtuQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.12.2",
-				"@typescript-eslint/scope-manager": "8.59.3",
-				"@typescript-eslint/type-utils": "8.59.3",
-				"@typescript-eslint/utils": "8.59.3",
-				"@typescript-eslint/visitor-keys": "8.59.3",
+				"@typescript-eslint/scope-manager": "8.59.2",
+				"@typescript-eslint/type-utils": "8.59.2",
+				"@typescript-eslint/utils": "8.59.2",
+				"@typescript-eslint/visitor-keys": "8.59.2",
 				"ignore": "^7.0.5",
 				"natural-compare": "^1.4.0",
 				"ts-api-utils": "^2.5.0"
@@ -5290,22 +4882,22 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/parser": "^8.59.3",
+				"@typescript-eslint/parser": "^8.59.2",
 				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
 				"typescript": ">=4.8.4 <6.1.0"
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "8.59.3",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.3.tgz",
-			"integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
+			"version": "8.59.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.2.tgz",
+			"integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "8.59.3",
-				"@typescript-eslint/types": "8.59.3",
-				"@typescript-eslint/typescript-estree": "8.59.3",
-				"@typescript-eslint/visitor-keys": "8.59.3",
+				"@typescript-eslint/scope-manager": "8.59.2",
+				"@typescript-eslint/types": "8.59.2",
+				"@typescript-eslint/typescript-estree": "8.59.2",
+				"@typescript-eslint/visitor-keys": "8.59.2",
 				"debug": "^4.4.3"
 			},
 			"engines": {
@@ -5321,14 +4913,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/project-service": {
-			"version": "8.59.3",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.3.tgz",
-			"integrity": "sha512-ECiUWa/KYRGDFUqTNehaRgzDshnJfkTABJxVemHk4ko22gcr0ukloKjWvyQ64g8YCV/UI47kN1dbmjf/GaQYng==",
+			"version": "8.59.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.2.tgz",
+			"integrity": "sha512-+2hqvEkeyf/0FBor67duF0Ll7Ot8jyKzDQOSrxazF/danillRq2DwR9dLptsXpoZQqxE1UisSmoZewrlPas9Vw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/tsconfig-utils": "^8.59.3",
-				"@typescript-eslint/types": "^8.59.3",
+				"@typescript-eslint/tsconfig-utils": "^8.59.2",
+				"@typescript-eslint/types": "^8.59.2",
 				"debug": "^4.4.3"
 			},
 			"engines": {
@@ -5343,14 +4935,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "8.59.3",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.3.tgz",
-			"integrity": "sha512-t2LvZnoEfzKtnPjgeEu41xw5gxq9mQVfYy4OoZ4Vlt0sk3JwxmhCca/AR7DwOiHrjWgjAj6as4AhRLKSDfvZIA==",
+			"version": "8.59.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.2.tgz",
+			"integrity": "sha512-JzfyEpEtOU89CcFSwyNS3mu4MLvLSXqnmX05+aKBDM+TdR5jzcGOEBwxwGNxrEQ7p/z6kK2WyioCGBf2zZBnvg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.59.3",
-				"@typescript-eslint/visitor-keys": "8.59.3"
+				"@typescript-eslint/types": "8.59.2",
+				"@typescript-eslint/visitor-keys": "8.59.2"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5361,9 +4953,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/tsconfig-utils": {
-			"version": "8.59.3",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.3.tgz",
-			"integrity": "sha512-PcIJHjmaREXLgIAIzLnSY9VucEzz8FKXsRgFa1DmdGCK/5tJpW03TKJF01Q6VZd1lLdz2sIKPWaDUZN9dp//dw==",
+			"version": "8.59.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.2.tgz",
+			"integrity": "sha512-BKK4alN7oi4C/zv4VqHQ+uRU+lTa6JGIZ7s1juw7b3RHo9OfKB+bKX3u0iVZetdsUCBBkSbdWbarJbmN0fTeSw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -5378,15 +4970,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "8.59.3",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.3.tgz",
-			"integrity": "sha512-g71d8QD8UaiHGvrJwyIS1hCX5r63w6Jll+4VEYhEAHXTDIqX1JgxhTAbEHtKntL9kuc4jRo7/GWw5xfCepSccQ==",
+			"version": "8.59.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.2.tgz",
+			"integrity": "sha512-nhqaj1nmTdVVl/BP5omXNRGO38jn5iosis2vbdmupF2txCf8ylWT8lx+JlvMYYVqzGVKtjojUFoQ3JRWK+mfzQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.59.3",
-				"@typescript-eslint/typescript-estree": "8.59.3",
-				"@typescript-eslint/utils": "8.59.3",
+				"@typescript-eslint/types": "8.59.2",
+				"@typescript-eslint/typescript-estree": "8.59.2",
+				"@typescript-eslint/utils": "8.59.2",
 				"debug": "^4.4.3",
 				"ts-api-utils": "^2.5.0"
 			},
@@ -5403,9 +4995,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "8.59.3",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.3.tgz",
-			"integrity": "sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg==",
+			"version": "8.59.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.2.tgz",
+			"integrity": "sha512-e82GVOE8Ps3E++Egvb6Y3Dw0S10u8NkQ9KXmtRhCWJJ8kDhOJTvtMAWnFL16kB1583goCWXsr0NieKCZMs2/0Q==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -5417,16 +5009,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "8.59.3",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.3.tgz",
-			"integrity": "sha512-CbRjVRAf7Lr9Kr8RopKcbY45p2VfmmHrm0ygOCYFi7oU8q19m0Fs/6iHS7kNOmwpp+ob07ZVcAqlxUod9lYdmg==",
+			"version": "8.59.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.2.tgz",
+			"integrity": "sha512-o0XPGNwcWw+FIwStOWn+BwBuEmL6QXP0rsvAFg7ET1dey1Nr6Wb1ac8p5HEsK0ygO/6mUxlk+YWQD9xcb/nnXg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/project-service": "8.59.3",
-				"@typescript-eslint/tsconfig-utils": "8.59.3",
-				"@typescript-eslint/types": "8.59.3",
-				"@typescript-eslint/visitor-keys": "8.59.3",
+				"@typescript-eslint/project-service": "8.59.2",
+				"@typescript-eslint/tsconfig-utils": "8.59.2",
+				"@typescript-eslint/types": "8.59.2",
+				"@typescript-eslint/visitor-keys": "8.59.2",
 				"debug": "^4.4.3",
 				"minimatch": "^10.2.2",
 				"semver": "^7.7.3",
@@ -5445,16 +5037,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "8.59.3",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.3.tgz",
-			"integrity": "sha512-JAvT14goBzRzzzZyqq3P9BLArIxTtQURUtFgQ/V7FO+eU+Gg6ES+5ymOPP1wRxXcxAYeivCk4uS3jCKWI1K8Zg==",
+			"version": "8.59.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.2.tgz",
+			"integrity": "sha512-Juw3EinkXqjaffxz6roowvV7GZT/kET5vSKKZT6upl5TXdWkLkYmNPXwDDL2Vkt2DPn0nODIS4egC/0AGxKo/Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.9.1",
-				"@typescript-eslint/scope-manager": "8.59.3",
-				"@typescript-eslint/types": "8.59.3",
-				"@typescript-eslint/typescript-estree": "8.59.3"
+				"@typescript-eslint/scope-manager": "8.59.2",
+				"@typescript-eslint/types": "8.59.2",
+				"@typescript-eslint/typescript-estree": "8.59.2"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5469,13 +5061,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.59.3",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.3.tgz",
-			"integrity": "sha512-f1UQF7ggd42YiwI5wGrRaPsa+P0CINBlrkLPmGfpq/u/I/oVtecoEIfFR9ag/oa1sLOsRNZ6xehf6qMZhQGBDg==",
+			"version": "8.59.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.2.tgz",
+			"integrity": "sha512-NwjLUnGy8/Zfx23fl50tRC8rYaYnM52xNRYFAXvmiil9yh1+K6aRVQMnzW6gQB/1DLgWt977lYQn7C+wtgXZiA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.59.3",
+				"@typescript-eslint/types": "8.59.2",
 				"eslint-visitor-keys": "^5.0.0"
 			},
 			"engines": {
@@ -5516,35 +5108,40 @@
 			}
 		},
 		"node_modules/@vitejs/plugin-react": {
-			"version": "4.7.0",
-			"resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
-			"integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.1.tgz",
+			"integrity": "sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/core": "^7.28.0",
-				"@babel/plugin-transform-react-jsx-self": "^7.27.1",
-				"@babel/plugin-transform-react-jsx-source": "^7.27.1",
-				"@rolldown/pluginutils": "1.0.0-beta.27",
-				"@types/babel__core": "^7.20.5",
-				"react-refresh": "^0.17.0"
+				"@rolldown/pluginutils": "1.0.0-rc.7"
 			},
 			"engines": {
-				"node": "^14.18.0 || >=16.0.0"
+				"node": "^20.19.0 || >=22.12.0"
 			},
 			"peerDependencies": {
-				"vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+				"@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
+				"babel-plugin-react-compiler": "^1.0.0",
+				"vite": "^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@rolldown/plugin-babel": {
+					"optional": true
+				},
+				"babel-plugin-react-compiler": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@vitest/coverage-v8": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.6.tgz",
-			"integrity": "sha512-36l628fQ/9a/8ihy97eOtEnvWQEdqULQOJtcaxtoNq0G1w3Mxd4szSahOaMM9/NGyZ+hyKcMtIW/WIxq0XQViQ==",
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.5.tgz",
+			"integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@bcoe/v8-coverage": "^1.0.2",
-				"@vitest/utils": "4.1.6",
+				"@vitest/utils": "4.1.5",
 				"ast-v8-to-istanbul": "^1.0.0",
 				"istanbul-lib-coverage": "^3.2.2",
 				"istanbul-lib-report": "^3.0.1",
@@ -5558,8 +5155,8 @@
 				"url": "https://opencollective.com/vitest"
 			},
 			"peerDependencies": {
-				"@vitest/browser": "4.1.6",
-				"vitest": "4.1.6"
+				"@vitest/browser": "4.1.5",
+				"vitest": "4.1.5"
 			},
 			"peerDependenciesMeta": {
 				"@vitest/browser": {
@@ -5568,16 +5165,16 @@
 			}
 		},
 		"node_modules/@vitest/expect": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
-			"integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+			"integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@standard-schema/spec": "^1.1.0",
 				"@types/chai": "^5.2.2",
-				"@vitest/spy": "4.1.6",
-				"@vitest/utils": "4.1.6",
+				"@vitest/spy": "4.1.5",
+				"@vitest/utils": "4.1.5",
 				"chai": "^6.2.2",
 				"tinyrainbow": "^3.1.0"
 			},
@@ -5585,10 +5182,37 @@
 				"url": "https://opencollective.com/vitest"
 			}
 		},
+		"node_modules/@vitest/mocker": {
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+			"integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/spy": "4.1.5",
+				"estree-walker": "^3.0.3",
+				"magic-string": "^0.30.21"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"msw": "^2.4.9",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"msw": {
+					"optional": true
+				},
+				"vite": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@vitest/pretty-format": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
-			"integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+			"integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5599,13 +5223,13 @@
 			}
 		},
 		"node_modules/@vitest/runner": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
-			"integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+			"integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/utils": "4.1.6",
+				"@vitest/utils": "4.1.5",
 				"pathe": "^2.0.3"
 			},
 			"funding": {
@@ -5613,14 +5237,14 @@
 			}
 		},
 		"node_modules/@vitest/snapshot": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
-			"integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+			"integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "4.1.6",
-				"@vitest/utils": "4.1.6",
+				"@vitest/pretty-format": "4.1.5",
+				"@vitest/utils": "4.1.5",
 				"magic-string": "^0.30.21",
 				"pathe": "^2.0.3"
 			},
@@ -5629,9 +5253,9 @@
 			}
 		},
 		"node_modules/@vitest/spy": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
-			"integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+			"integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
@@ -5639,13 +5263,13 @@
 			}
 		},
 		"node_modules/@vitest/utils": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
-			"integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+			"integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "4.1.6",
+				"@vitest/pretty-format": "4.1.5",
 				"convert-source-map": "^2.0.0",
 				"tinyrainbow": "^3.1.0"
 			},
@@ -6676,9 +6300,9 @@
 			"license": "MIT"
 		},
 		"node_modules/baseline-browser-mapping": {
-			"version": "2.10.29",
-			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.29.tgz",
-			"integrity": "sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ==",
+			"version": "2.10.27",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.27.tgz",
+			"integrity": "sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -6689,9 +6313,9 @@
 			}
 		},
 		"node_modules/better-sqlite3": {
-			"version": "12.10.0",
-			"resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.10.0.tgz",
-			"integrity": "sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==",
+			"version": "12.9.0",
+			"resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.9.0.tgz",
+			"integrity": "sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6699,7 +6323,7 @@
 				"prebuild-install": "^7.1.1"
 			},
 			"engines": {
-				"node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
+				"node": "20.x || 22.x || 23.x || 24.x || 25.x"
 			}
 		},
 		"node_modules/bidi-js": {
@@ -6785,9 +6409,9 @@
 			"optional": true
 		},
 		"node_modules/brace-expansion": {
-			"version": "5.0.6",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^4.0.2"
@@ -7325,6 +6949,34 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/chevrotain": {
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-12.0.0.tgz",
+			"integrity": "sha512-csJvb+6kEiQaqo1woTdSAuOWdN0WTLIydkKrBnS+V5gZz0oqBrp4kQ35519QgK6TpBThiG3V1vNSHlIkv4AglQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@chevrotain/cst-dts-gen": "12.0.0",
+				"@chevrotain/gast": "12.0.0",
+				"@chevrotain/regexp-to-ast": "12.0.0",
+				"@chevrotain/types": "12.0.0",
+				"@chevrotain/utils": "12.0.0"
+			},
+			"engines": {
+				"node": ">=22.0.0"
+			}
+		},
+		"node_modules/chevrotain-allstar": {
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.4.3.tgz",
+			"integrity": "sha512-2X4mkroolSMKqW+H22pyPMUVDqYZzPhephTmg/NODKb1IGYPHfxfhcW0EjS7wcPJNbze2i4vBWT7zT5FKF2lrQ==",
+			"license": "MIT",
+			"dependencies": {
+				"lodash-es": "^4.18.1"
+			},
+			"peerDependencies": {
+				"chevrotain": "^12.0.0"
 			}
 		},
 		"node_modules/chokidar": {
@@ -8958,9 +8610,9 @@
 			"peer": true
 		},
 		"node_modules/dompurify": {
-			"version": "3.4.3",
-			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.3.tgz",
-			"integrity": "sha512-VVwJidIJcp1hpg2OMXML3ZVRPYSZiq4aX7qBh83BSIpOaRDqI+qxhXjjIWnpzkOXhmp0L81lnoME1mnCc9H48A==",
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.2.tgz",
+			"integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
 			"license": "(MPL-2.0 OR Apache-2.0)",
 			"optionalDependencies": {
 				"@types/trusted-types": "^2.0.7"
@@ -9652,9 +9304,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.355",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.355.tgz",
-			"integrity": "sha512-LUPZhKzZPYSPme1jEYohpkA+ybYCJztr1quAdBd7E7h3+VOBVcKkwwtBJu41nrjawrRzfb8mtMfzWozoaK0ZIQ==",
+			"version": "1.5.352",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.352.tgz",
+			"integrity": "sha512-9wHk8x6dyuimoe18EdiDPWKExNdxYqo4fn4FwOVVper6RxT3cmpBwBkWWfSOCYJjQdIco/nPhJhNLmn4Ufg1Yg==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -9711,18 +9363,6 @@
 			},
 			"optionalDependencies": {
 				"graceful-fs": "^4.1.6"
-			}
-		},
-		"node_modules/electron-updater/node_modules/semver": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/electron-updater/node_modules/universalify": {
@@ -10012,9 +9652,9 @@
 			"optional": true
 		},
 		"node_modules/esbuild": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.2.tgz",
-			"integrity": "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==",
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+			"integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -10025,31 +9665,32 @@
 				"node": ">=18"
 			},
 			"optionalDependencies": {
-				"@esbuild/aix-ppc64": "0.24.2",
-				"@esbuild/android-arm": "0.24.2",
-				"@esbuild/android-arm64": "0.24.2",
-				"@esbuild/android-x64": "0.24.2",
-				"@esbuild/darwin-arm64": "0.24.2",
-				"@esbuild/darwin-x64": "0.24.2",
-				"@esbuild/freebsd-arm64": "0.24.2",
-				"@esbuild/freebsd-x64": "0.24.2",
-				"@esbuild/linux-arm": "0.24.2",
-				"@esbuild/linux-arm64": "0.24.2",
-				"@esbuild/linux-ia32": "0.24.2",
-				"@esbuild/linux-loong64": "0.24.2",
-				"@esbuild/linux-mips64el": "0.24.2",
-				"@esbuild/linux-ppc64": "0.24.2",
-				"@esbuild/linux-riscv64": "0.24.2",
-				"@esbuild/linux-s390x": "0.24.2",
-				"@esbuild/linux-x64": "0.24.2",
-				"@esbuild/netbsd-arm64": "0.24.2",
-				"@esbuild/netbsd-x64": "0.24.2",
-				"@esbuild/openbsd-arm64": "0.24.2",
-				"@esbuild/openbsd-x64": "0.24.2",
-				"@esbuild/sunos-x64": "0.24.2",
-				"@esbuild/win32-arm64": "0.24.2",
-				"@esbuild/win32-ia32": "0.24.2",
-				"@esbuild/win32-x64": "0.24.2"
+				"@esbuild/aix-ppc64": "0.28.0",
+				"@esbuild/android-arm": "0.28.0",
+				"@esbuild/android-arm64": "0.28.0",
+				"@esbuild/android-x64": "0.28.0",
+				"@esbuild/darwin-arm64": "0.28.0",
+				"@esbuild/darwin-x64": "0.28.0",
+				"@esbuild/freebsd-arm64": "0.28.0",
+				"@esbuild/freebsd-x64": "0.28.0",
+				"@esbuild/linux-arm": "0.28.0",
+				"@esbuild/linux-arm64": "0.28.0",
+				"@esbuild/linux-ia32": "0.28.0",
+				"@esbuild/linux-loong64": "0.28.0",
+				"@esbuild/linux-mips64el": "0.28.0",
+				"@esbuild/linux-ppc64": "0.28.0",
+				"@esbuild/linux-riscv64": "0.28.0",
+				"@esbuild/linux-s390x": "0.28.0",
+				"@esbuild/linux-x64": "0.28.0",
+				"@esbuild/netbsd-arm64": "0.28.0",
+				"@esbuild/netbsd-x64": "0.28.0",
+				"@esbuild/openbsd-arm64": "0.28.0",
+				"@esbuild/openbsd-x64": "0.28.0",
+				"@esbuild/openharmony-arm64": "0.28.0",
+				"@esbuild/sunos-x64": "0.28.0",
+				"@esbuild/win32-arm64": "0.28.0",
+				"@esbuild/win32-ia32": "0.28.0",
+				"@esbuild/win32-x64": "0.28.0"
 			}
 		},
 		"node_modules/escalade": {
@@ -13153,9 +12794,9 @@
 			}
 		},
 		"node_modules/katex": {
-			"version": "0.16.46",
-			"resolved": "https://registry.npmjs.org/katex/-/katex-0.16.46.tgz",
-			"integrity": "sha512-WHy4Coo+bGZyH7NwJKHkS04YFsFcarWbAEOAC3EMndzdN6VSZqklLLIgfxzyaW9jDoeGYJX9SWbJPKpecox0Uw==",
+			"version": "0.16.45",
+			"resolved": "https://registry.npmjs.org/katex/-/katex-0.16.45.tgz",
+			"integrity": "sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA==",
 			"funding": [
 				"https://opencollective.com/katex",
 				"https://github.com/sponsors/katex"
@@ -13200,6 +12841,24 @@
 			"license": "MIT",
 			"dependencies": {
 				"graceful-fs": "^4.1.11"
+			}
+		},
+		"node_modules/langium": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/langium/-/langium-4.2.3.tgz",
+			"integrity": "sha512-sOPIi4hISFnY7twwV97ca1TsxpBtXq0URu/LL1AvxwccPG/RIBBlKS7a/f/EL6w8lTNaS0EFs/F+IdSOaqYpng==",
+			"license": "MIT",
+			"dependencies": {
+				"@chevrotain/regexp-to-ast": "~12.0.0",
+				"chevrotain": "~12.0.0",
+				"chevrotain-allstar": "~0.4.3",
+				"vscode-languageserver": "~9.0.1",
+				"vscode-languageserver-textdocument": "~1.0.11",
+				"vscode-uri": "~3.1.0"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
 			}
 		},
 		"node_modules/layout-base": {
@@ -13821,13 +13480,13 @@
 			}
 		},
 		"node_modules/magicast": {
-			"version": "0.5.3",
-			"resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
-			"integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+			"integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/parser": "^7.29.3",
+				"@babel/parser": "^7.29.0",
 				"@babel/types": "^7.29.0",
 				"source-map-js": "^1.2.1"
 			}
@@ -14317,14 +13976,14 @@
 			}
 		},
 		"node_modules/mermaid": {
-			"version": "11.15.0",
-			"resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.15.0.tgz",
-			"integrity": "sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==",
+			"version": "11.14.0",
+			"resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.14.0.tgz",
+			"integrity": "sha512-GSGloRsBs+JINmmhl0JDwjpuezCsHB4WGI4NASHxL3fHo3o/BRXTxhDLKnln8/Q0lRFRyDdEjmk1/d5Sn1Xz8g==",
 			"license": "MIT",
 			"dependencies": {
 				"@braintree/sanitize-url": "^7.1.1",
 				"@iconify/utils": "^3.0.2",
-				"@mermaid-js/parser": "^1.1.1",
+				"@mermaid-js/parser": "^1.1.0",
 				"@types/d3": "^7.4.3",
 				"@upsetjs/venn.js": "^2.0.0",
 				"cytoscape": "^3.33.1",
@@ -14335,14 +13994,14 @@
 				"dagre-d3-es": "7.0.14",
 				"dayjs": "^1.11.19",
 				"dompurify": "^3.3.1",
-				"es-toolkit": "^1.45.1",
 				"katex": "^0.16.25",
 				"khroma": "^2.1.0",
+				"lodash-es": "^4.17.23",
 				"marked": "^16.3.0",
 				"roughjs": "^4.6.6",
 				"stylis": "^4.3.6",
 				"ts-dedent": "^2.2.0",
-				"uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0"
+				"uuid": "^11.1.0"
 			}
 		},
 		"node_modules/mermaid/node_modules/marked": {
@@ -15530,9 +15189,9 @@
 			}
 		},
 		"node_modules/node-releases": {
-			"version": "2.0.44",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.44.tgz",
-			"integrity": "sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==",
+			"version": "2.0.38",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
+			"integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -16373,13 +16032,13 @@
 			}
 		},
 		"node_modules/playwright": {
-			"version": "1.60.0",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
-			"integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+			"version": "1.59.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+			"integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright-core": "1.60.0"
+				"playwright-core": "1.59.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -16392,9 +16051,9 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.60.0",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
-			"integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+			"version": "1.59.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+			"integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -17235,16 +16894,6 @@
 				}
 			}
 		},
-		"node_modules/react-refresh": {
-			"version": "0.17.0",
-			"resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
-			"integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/react-syntax-highlighter": {
 			"version": "16.1.1",
 			"resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-16.1.1.tgz",
@@ -17936,14 +17585,14 @@
 			"license": "Unlicense"
 		},
 		"node_modules/rolldown": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0.tgz",
-			"integrity": "sha512-yD986aXDESFGS95spT1LAv0jssywP4npMEjmMHyN2/5+eE8qQJUype2AaKkRiLgBgyD0LFlubwAht7VmY8rGoA==",
+			"version": "1.0.0-rc.18",
+			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.18.tgz",
+			"integrity": "sha512-phmyKBpuBdRYDf4hgyynGAYn/rDDe+iZXKVJ7WX5b1zQzpLkP5oJRPGsfJuHdzPMlyyEO/4sPW6yfSx2gf7lVg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@oxc-project/types": "=0.129.0",
-				"@rolldown/pluginutils": "1.0.0"
+				"@oxc-project/types": "=0.128.0",
+				"@rolldown/pluginutils": "1.0.0-rc.18"
 			},
 			"bin": {
 				"rolldown": "bin/cli.mjs"
@@ -17952,79 +17601,27 @@
 				"node": "^20.19.0 || >=22.12.0"
 			},
 			"optionalDependencies": {
-				"@rolldown/binding-android-arm64": "1.0.0",
-				"@rolldown/binding-darwin-arm64": "1.0.0",
-				"@rolldown/binding-darwin-x64": "1.0.0",
-				"@rolldown/binding-freebsd-x64": "1.0.0",
-				"@rolldown/binding-linux-arm-gnueabihf": "1.0.0",
-				"@rolldown/binding-linux-arm64-gnu": "1.0.0",
-				"@rolldown/binding-linux-arm64-musl": "1.0.0",
-				"@rolldown/binding-linux-ppc64-gnu": "1.0.0",
-				"@rolldown/binding-linux-s390x-gnu": "1.0.0",
-				"@rolldown/binding-linux-x64-gnu": "1.0.0",
-				"@rolldown/binding-linux-x64-musl": "1.0.0",
-				"@rolldown/binding-openharmony-arm64": "1.0.0",
-				"@rolldown/binding-wasm32-wasi": "1.0.0",
-				"@rolldown/binding-win32-arm64-msvc": "1.0.0",
-				"@rolldown/binding-win32-x64-msvc": "1.0.0"
+				"@rolldown/binding-android-arm64": "1.0.0-rc.18",
+				"@rolldown/binding-darwin-arm64": "1.0.0-rc.18",
+				"@rolldown/binding-darwin-x64": "1.0.0-rc.18",
+				"@rolldown/binding-freebsd-x64": "1.0.0-rc.18",
+				"@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.18",
+				"@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.18",
+				"@rolldown/binding-linux-arm64-musl": "1.0.0-rc.18",
+				"@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.18",
+				"@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.18",
+				"@rolldown/binding-linux-x64-gnu": "1.0.0-rc.18",
+				"@rolldown/binding-linux-x64-musl": "1.0.0-rc.18",
+				"@rolldown/binding-openharmony-arm64": "1.0.0-rc.18",
+				"@rolldown/binding-wasm32-wasi": "1.0.0-rc.18",
+				"@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.18",
+				"@rolldown/binding-win32-x64-msvc": "1.0.0-rc.18"
 			}
 		},
 		"node_modules/rolldown/node_modules/@rolldown/pluginutils": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0.tgz",
-			"integrity": "sha512-aKs/3GSWyV0mrhNmt/96/Z3yczC3yvrzYATCiCXQebBsGyYzjNdUphRVLeJQ67ySKVXRfMxt2lm12pmXvbPFQQ==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/rollup": {
-			"version": "4.60.3",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.3.tgz",
-			"integrity": "sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/estree": "1.0.8"
-			},
-			"bin": {
-				"rollup": "dist/bin/rollup"
-			},
-			"engines": {
-				"node": ">=18.0.0",
-				"npm": ">=8.0.0"
-			},
-			"optionalDependencies": {
-				"@rollup/rollup-android-arm-eabi": "4.60.3",
-				"@rollup/rollup-android-arm64": "4.60.3",
-				"@rollup/rollup-darwin-arm64": "4.60.3",
-				"@rollup/rollup-darwin-x64": "4.60.3",
-				"@rollup/rollup-freebsd-arm64": "4.60.3",
-				"@rollup/rollup-freebsd-x64": "4.60.3",
-				"@rollup/rollup-linux-arm-gnueabihf": "4.60.3",
-				"@rollup/rollup-linux-arm-musleabihf": "4.60.3",
-				"@rollup/rollup-linux-arm64-gnu": "4.60.3",
-				"@rollup/rollup-linux-arm64-musl": "4.60.3",
-				"@rollup/rollup-linux-loong64-gnu": "4.60.3",
-				"@rollup/rollup-linux-loong64-musl": "4.60.3",
-				"@rollup/rollup-linux-ppc64-gnu": "4.60.3",
-				"@rollup/rollup-linux-ppc64-musl": "4.60.3",
-				"@rollup/rollup-linux-riscv64-gnu": "4.60.3",
-				"@rollup/rollup-linux-riscv64-musl": "4.60.3",
-				"@rollup/rollup-linux-s390x-gnu": "4.60.3",
-				"@rollup/rollup-linux-x64-gnu": "4.60.3",
-				"@rollup/rollup-linux-x64-musl": "4.60.3",
-				"@rollup/rollup-openbsd-x64": "4.60.3",
-				"@rollup/rollup-openharmony-arm64": "4.60.3",
-				"@rollup/rollup-win32-arm64-msvc": "4.60.3",
-				"@rollup/rollup-win32-ia32-msvc": "4.60.3",
-				"@rollup/rollup-win32-x64-gnu": "4.60.3",
-				"@rollup/rollup-win32-x64-msvc": "4.60.3",
-				"fsevents": "~2.3.2"
-			}
-		},
-		"node_modules/rollup/node_modules/@types/estree": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+			"version": "1.0.0-rc.18",
+			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.18.tgz",
+			"integrity": "sha512-CUY5Mnhe64xQBGZEEXQ5WyZwsc1JU3vAZLIxtrsBt3LO6UOb+C8GunVKqe9sT8NeWb4lqSaoJtp2xo6GxT1MNw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -18227,9 +17824,9 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/semver": {
-			"version": "7.8.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-			"integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
@@ -18601,9 +18198,9 @@
 			}
 		},
 		"node_modules/socks": {
-			"version": "2.8.9",
-			"resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
-			"integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+			"version": "2.8.8",
+			"resolved": "https://registry.npmjs.org/socks/-/socks-2.8.8.tgz",
+			"integrity": "sha512-NlGELfPrgX2f1TAAcz0WawlLn+0r3FyhhCRpFFK2CemXenPYvzMWWZINv3eDNo9ucdwme7oCHRY0Jnbs4aIkog==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -19805,16 +19402,16 @@
 			}
 		},
 		"node_modules/typescript-eslint": {
-			"version": "8.59.3",
-			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.3.tgz",
-			"integrity": "sha512-KgusgyDgG4LI8Ih/sWaCtZ06tckLAS5CvT5A4D1Q7bYVoAAyzwiZvE4BmwDHkhRVkvhRBepKeASoFzQetha7Fg==",
+			"version": "8.59.2",
+			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.2.tgz",
+			"integrity": "sha512-pJw051uomb3ZeCzGTpRb8RbEqB5Y4WWet8gl/GcTlU35BSx0PVdZ86/bqkQCyKKuraVQEK7r6kBHQXF+fBhkoQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/eslint-plugin": "8.59.3",
-				"@typescript-eslint/parser": "8.59.3",
-				"@typescript-eslint/typescript-estree": "8.59.3",
-				"@typescript-eslint/utils": "8.59.3"
+				"@typescript-eslint/eslint-plugin": "8.59.2",
+				"@typescript-eslint/parser": "8.59.2",
+				"@typescript-eslint/typescript-estree": "8.59.2",
+				"@typescript-eslint/utils": "8.59.2"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -20071,16 +19668,16 @@
 			"license": "MIT"
 		},
 		"node_modules/uuid": {
-			"version": "14.0.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-			"integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+			"version": "11.1.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+			"integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
 			"funding": [
 				"https://github.com/sponsors/broofa",
 				"https://github.com/sponsors/ctavan"
 			],
 			"license": "MIT",
 			"bin": {
-				"uuid": "dist-node/bin/uuid"
+				"uuid": "dist/esm/bin/uuid"
 			}
 		},
 		"node_modules/verror": {
@@ -20164,1132 +19761,16 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "5.4.21",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
-			"integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"esbuild": "^0.21.3",
-				"postcss": "^8.4.43",
-				"rollup": "^4.20.0"
-			},
-			"bin": {
-				"vite": "bin/vite.js"
-			},
-			"engines": {
-				"node": "^18.0.0 || >=20.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/vitejs/vite?sponsor=1"
-			},
-			"optionalDependencies": {
-				"fsevents": "~2.3.3"
-			},
-			"peerDependencies": {
-				"@types/node": "^18.0.0 || >=20.0.0",
-				"less": "*",
-				"lightningcss": "^1.21.0",
-				"sass": "*",
-				"sass-embedded": "*",
-				"stylus": "*",
-				"sugarss": "*",
-				"terser": "^5.4.0"
-			},
-			"peerDependenciesMeta": {
-				"@types/node": {
-					"optional": true
-				},
-				"less": {
-					"optional": true
-				},
-				"lightningcss": {
-					"optional": true
-				},
-				"sass": {
-					"optional": true
-				},
-				"sass-embedded": {
-					"optional": true
-				},
-				"stylus": {
-					"optional": true
-				},
-				"sugarss": {
-					"optional": true
-				},
-				"terser": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/vite-plugin-electron": {
-			"version": "0.28.8",
-			"resolved": "https://registry.npmjs.org/vite-plugin-electron/-/vite-plugin-electron-0.28.8.tgz",
-			"integrity": "sha512-ir+B21oSGK9j23OEvt4EXyco9xDCaF6OGFe0V/8Zc0yL2+HMyQ6mmNQEIhXsEsZCSfIowBpwQBeHH4wVsfraeg==",
-			"dev": true,
-			"license": "MIT",
-			"peerDependencies": {
-				"vite-plugin-electron-renderer": "*"
-			},
-			"peerDependenciesMeta": {
-				"vite-plugin-electron-renderer": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/aix-ppc64": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
-			"integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
-			"cpu": [
-				"ppc64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"aix"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/android-arm": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
-			"integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/android-arm64": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
-			"integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/android-x64": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
-			"integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/darwin-arm64": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
-			"integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/darwin-x64": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
-			"integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
-			"integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/freebsd-x64": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
-			"integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/linux-arm": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
-			"integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/linux-arm64": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
-			"integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/linux-ia32": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
-			"integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/linux-loong64": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
-			"integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
-			"cpu": [
-				"loong64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/linux-mips64el": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
-			"integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
-			"cpu": [
-				"mips64el"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/linux-ppc64": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
-			"integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
-			"cpu": [
-				"ppc64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/linux-riscv64": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
-			"integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
-			"cpu": [
-				"riscv64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/linux-s390x": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
-			"integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
-			"cpu": [
-				"s390x"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/linux-x64": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
-			"integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/netbsd-x64": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
-			"integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"netbsd"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/openbsd-x64": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
-			"integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openbsd"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/sunos-x64": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
-			"integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"sunos"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/win32-arm64": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
-			"integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/win32-ia32": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
-			"integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/win32-x64": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
-			"integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vite/node_modules/esbuild": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
-			"integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
-			"dev": true,
-			"hasInstallScript": true,
-			"license": "MIT",
-			"bin": {
-				"esbuild": "bin/esbuild"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"optionalDependencies": {
-				"@esbuild/aix-ppc64": "0.21.5",
-				"@esbuild/android-arm": "0.21.5",
-				"@esbuild/android-arm64": "0.21.5",
-				"@esbuild/android-x64": "0.21.5",
-				"@esbuild/darwin-arm64": "0.21.5",
-				"@esbuild/darwin-x64": "0.21.5",
-				"@esbuild/freebsd-arm64": "0.21.5",
-				"@esbuild/freebsd-x64": "0.21.5",
-				"@esbuild/linux-arm": "0.21.5",
-				"@esbuild/linux-arm64": "0.21.5",
-				"@esbuild/linux-ia32": "0.21.5",
-				"@esbuild/linux-loong64": "0.21.5",
-				"@esbuild/linux-mips64el": "0.21.5",
-				"@esbuild/linux-ppc64": "0.21.5",
-				"@esbuild/linux-riscv64": "0.21.5",
-				"@esbuild/linux-s390x": "0.21.5",
-				"@esbuild/linux-x64": "0.21.5",
-				"@esbuild/netbsd-x64": "0.21.5",
-				"@esbuild/openbsd-x64": "0.21.5",
-				"@esbuild/sunos-x64": "0.21.5",
-				"@esbuild/win32-arm64": "0.21.5",
-				"@esbuild/win32-ia32": "0.21.5",
-				"@esbuild/win32-x64": "0.21.5"
-			}
-		},
-		"node_modules/vitest": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
-			"integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@vitest/expect": "4.1.6",
-				"@vitest/mocker": "4.1.6",
-				"@vitest/pretty-format": "4.1.6",
-				"@vitest/runner": "4.1.6",
-				"@vitest/snapshot": "4.1.6",
-				"@vitest/spy": "4.1.6",
-				"@vitest/utils": "4.1.6",
-				"es-module-lexer": "^2.0.0",
-				"expect-type": "^1.3.0",
-				"magic-string": "^0.30.21",
-				"obug": "^2.1.1",
-				"pathe": "^2.0.3",
-				"picomatch": "^4.0.3",
-				"std-env": "^4.0.0-rc.1",
-				"tinybench": "^2.9.0",
-				"tinyexec": "^1.0.2",
-				"tinyglobby": "^0.2.15",
-				"tinyrainbow": "^3.1.0",
-				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
-				"why-is-node-running": "^2.3.0"
-			},
-			"bin": {
-				"vitest": "vitest.mjs"
-			},
-			"engines": {
-				"node": "^20.0.0 || ^22.0.0 || >=24.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/vitest"
-			},
-			"peerDependencies": {
-				"@edge-runtime/vm": "*",
-				"@opentelemetry/api": "^1.9.0",
-				"@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-				"@vitest/browser-playwright": "4.1.6",
-				"@vitest/browser-preview": "4.1.6",
-				"@vitest/browser-webdriverio": "4.1.6",
-				"@vitest/coverage-istanbul": "4.1.6",
-				"@vitest/coverage-v8": "4.1.6",
-				"@vitest/ui": "4.1.6",
-				"happy-dom": "*",
-				"jsdom": "*",
-				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
-			},
-			"peerDependenciesMeta": {
-				"@edge-runtime/vm": {
-					"optional": true
-				},
-				"@opentelemetry/api": {
-					"optional": true
-				},
-				"@types/node": {
-					"optional": true
-				},
-				"@vitest/browser-playwright": {
-					"optional": true
-				},
-				"@vitest/browser-preview": {
-					"optional": true
-				},
-				"@vitest/browser-webdriverio": {
-					"optional": true
-				},
-				"@vitest/coverage-istanbul": {
-					"optional": true
-				},
-				"@vitest/coverage-v8": {
-					"optional": true
-				},
-				"@vitest/ui": {
-					"optional": true
-				},
-				"happy-dom": {
-					"optional": true
-				},
-				"jsdom": {
-					"optional": true
-				},
-				"vite": {
-					"optional": false
-				}
-			}
-		},
-		"node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
-			"integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
-			"cpu": [
-				"ppc64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"aix"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vitest/node_modules/@esbuild/android-arm": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
-			"integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vitest/node_modules/@esbuild/android-arm64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
-			"integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vitest/node_modules/@esbuild/android-x64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
-			"integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
-			"integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vitest/node_modules/@esbuild/darwin-x64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
-			"integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
-			"integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
-			"integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vitest/node_modules/@esbuild/linux-arm": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
-			"integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vitest/node_modules/@esbuild/linux-arm64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
-			"integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vitest/node_modules/@esbuild/linux-ia32": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
-			"integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vitest/node_modules/@esbuild/linux-loong64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
-			"integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
-			"cpu": [
-				"loong64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
-			"integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
-			"cpu": [
-				"mips64el"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
-			"integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
-			"cpu": [
-				"ppc64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
-			"integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
-			"cpu": [
-				"riscv64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vitest/node_modules/@esbuild/linux-s390x": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
-			"integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
-			"cpu": [
-				"s390x"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vitest/node_modules/@esbuild/linux-x64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
-			"integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vitest/node_modules/@esbuild/netbsd-arm64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
-			"integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"netbsd"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
-			"integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"netbsd"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vitest/node_modules/@esbuild/openbsd-arm64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
-			"integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openbsd"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
-			"integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openbsd"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vitest/node_modules/@esbuild/sunos-x64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
-			"integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"sunos"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vitest/node_modules/@esbuild/win32-arm64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
-			"integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vitest/node_modules/@esbuild/win32-ia32": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
-			"integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vitest/node_modules/@esbuild/win32-x64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
-			"integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vitest/node_modules/@vitest/mocker": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
-			"integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@vitest/spy": "4.1.6",
-				"estree-walker": "^3.0.3",
-				"magic-string": "^0.30.21"
-			},
-			"funding": {
-				"url": "https://opencollective.com/vitest"
-			},
-			"peerDependencies": {
-				"msw": "^2.4.9",
-				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
-			},
-			"peerDependenciesMeta": {
-				"msw": {
-					"optional": true
-				},
-				"vite": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/vitest/node_modules/esbuild": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
-			"integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
-			"dev": true,
-			"hasInstallScript": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"bin": {
-				"esbuild": "bin/esbuild"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"optionalDependencies": {
-				"@esbuild/aix-ppc64": "0.28.0",
-				"@esbuild/android-arm": "0.28.0",
-				"@esbuild/android-arm64": "0.28.0",
-				"@esbuild/android-x64": "0.28.0",
-				"@esbuild/darwin-arm64": "0.28.0",
-				"@esbuild/darwin-x64": "0.28.0",
-				"@esbuild/freebsd-arm64": "0.28.0",
-				"@esbuild/freebsd-x64": "0.28.0",
-				"@esbuild/linux-arm": "0.28.0",
-				"@esbuild/linux-arm64": "0.28.0",
-				"@esbuild/linux-ia32": "0.28.0",
-				"@esbuild/linux-loong64": "0.28.0",
-				"@esbuild/linux-mips64el": "0.28.0",
-				"@esbuild/linux-ppc64": "0.28.0",
-				"@esbuild/linux-riscv64": "0.28.0",
-				"@esbuild/linux-s390x": "0.28.0",
-				"@esbuild/linux-x64": "0.28.0",
-				"@esbuild/netbsd-arm64": "0.28.0",
-				"@esbuild/netbsd-x64": "0.28.0",
-				"@esbuild/openbsd-arm64": "0.28.0",
-				"@esbuild/openbsd-x64": "0.28.0",
-				"@esbuild/openharmony-arm64": "0.28.0",
-				"@esbuild/sunos-x64": "0.28.0",
-				"@esbuild/win32-arm64": "0.28.0",
-				"@esbuild/win32-ia32": "0.28.0",
-				"@esbuild/win32-x64": "0.28.0"
-			}
-		},
-		"node_modules/vitest/node_modules/vite": {
-			"version": "8.0.12",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-8.0.12.tgz",
-			"integrity": "sha512-w2dDofOWv2QB09ZITZBsvKTVAlYvPR4IAmrY/v0ir9KvLs0xybR7i48wxhM1/oyBWO34wPns+bPGw5ZrZqDpZg==",
+			"version": "8.0.11",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-8.0.11.tgz",
+			"integrity": "sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"lightningcss": "^1.32.0",
 				"picomatch": "^4.0.4",
 				"postcss": "^8.5.14",
-				"rolldown": "1.0.0",
+				"rolldown": "1.0.0-rc.18",
 				"tinyglobby": "^0.2.16"
 			},
 			"bin": {
@@ -21356,6 +19837,145 @@
 					"optional": true
 				}
 			}
+		},
+		"node_modules/vitest": {
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+			"integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/expect": "4.1.5",
+				"@vitest/mocker": "4.1.5",
+				"@vitest/pretty-format": "4.1.5",
+				"@vitest/runner": "4.1.5",
+				"@vitest/snapshot": "4.1.5",
+				"@vitest/spy": "4.1.5",
+				"@vitest/utils": "4.1.5",
+				"es-module-lexer": "^2.0.0",
+				"expect-type": "^1.3.0",
+				"magic-string": "^0.30.21",
+				"obug": "^2.1.1",
+				"pathe": "^2.0.3",
+				"picomatch": "^4.0.3",
+				"std-env": "^4.0.0-rc.1",
+				"tinybench": "^2.9.0",
+				"tinyexec": "^1.0.2",
+				"tinyglobby": "^0.2.15",
+				"tinyrainbow": "^3.1.0",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+				"why-is-node-running": "^2.3.0"
+			},
+			"bin": {
+				"vitest": "vitest.mjs"
+			},
+			"engines": {
+				"node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"@edge-runtime/vm": "*",
+				"@opentelemetry/api": "^1.9.0",
+				"@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+				"@vitest/browser-playwright": "4.1.5",
+				"@vitest/browser-preview": "4.1.5",
+				"@vitest/browser-webdriverio": "4.1.5",
+				"@vitest/coverage-istanbul": "4.1.5",
+				"@vitest/coverage-v8": "4.1.5",
+				"@vitest/ui": "4.1.5",
+				"happy-dom": "*",
+				"jsdom": "*",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@edge-runtime/vm": {
+					"optional": true
+				},
+				"@opentelemetry/api": {
+					"optional": true
+				},
+				"@types/node": {
+					"optional": true
+				},
+				"@vitest/browser-playwright": {
+					"optional": true
+				},
+				"@vitest/browser-preview": {
+					"optional": true
+				},
+				"@vitest/browser-webdriverio": {
+					"optional": true
+				},
+				"@vitest/coverage-istanbul": {
+					"optional": true
+				},
+				"@vitest/coverage-v8": {
+					"optional": true
+				},
+				"@vitest/ui": {
+					"optional": true
+				},
+				"happy-dom": {
+					"optional": true
+				},
+				"jsdom": {
+					"optional": true
+				},
+				"vite": {
+					"optional": false
+				}
+			}
+		},
+		"node_modules/vscode-jsonrpc": {
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+			"integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/vscode-languageserver": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
+			"integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
+			"license": "MIT",
+			"dependencies": {
+				"vscode-languageserver-protocol": "3.17.5"
+			},
+			"bin": {
+				"installServerIntoExtension": "bin/installServerIntoExtension"
+			}
+		},
+		"node_modules/vscode-languageserver-protocol": {
+			"version": "3.17.5",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+			"integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+			"license": "MIT",
+			"dependencies": {
+				"vscode-jsonrpc": "8.2.0",
+				"vscode-languageserver-types": "3.17.5"
+			}
+		},
+		"node_modules/vscode-languageserver-textdocument": {
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+			"integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+			"license": "MIT"
+		},
+		"node_modules/vscode-languageserver-types": {
+			"version": "3.17.5",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+			"integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+			"license": "MIT"
+		},
+		"node_modules/vscode-uri": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+			"integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+			"license": "MIT"
 		},
 		"node_modules/w3c-keyname": {
 			"version": "2.2.8",
@@ -21675,9 +20295,9 @@
 			"license": "ISC"
 		},
 		"node_modules/ws": {
-			"version": "8.20.1",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-			"integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+			"integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=10.0.0"
@@ -21756,9 +20376,9 @@
 			"license": "ISC"
 		},
 		"node_modules/yaml": {
-			"version": "2.9.0",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-			"integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+			"version": "2.8.4",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
+			"integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {

--- a/package.json
+++ b/package.json
@@ -335,8 +335,8 @@
 		"@types/ws": "^8.5.10",
 		"@typescript-eslint/eslint-plugin": "^8.59.2",
 		"@typescript-eslint/parser": "^8.59.2",
-		"@vitejs/plugin-react": "^4.2.1",
-		"@vitest/coverage-v8": "^4.0.15",
+		"@vitejs/plugin-react": "^6.0.1",
+		"@vitest/coverage-v8": "^4.1.5",
 		"@welldone-software/why-did-you-render": "^8.0.3",
 		"autoprefixer": "^10.4.16",
 		"baseline-browser-mapping": "^2.9.17",
@@ -347,7 +347,7 @@
 		"electron-devtools-installer": "^4.0.0",
 		"electron-playwright-helpers": "^2.0.1",
 		"electron-rebuild": "^3.2.9",
-		"esbuild": "^0.24.2",
+		"esbuild": "^0.28.0",
 		"eslint": "^9.39.2",
 		"eslint-config-prettier": "^10.1.8",
 		"eslint-plugin-react": "^7.37.5",
@@ -365,9 +365,8 @@
 		"tailwindcss": "^3.4.1",
 		"typescript": "^6.0.3",
 		"typescript-eslint": "^8.59.2",
-		"vite": "^5.0.11",
-		"vite-plugin-electron": "^0.28.2",
-		"vitest": "^4.0.15"
+		"vite": "^8.0.11",
+		"vitest": "^4.1.5"
 	},
 	"engines": {
 		"node": ">=22.0.0"

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -54,13 +54,20 @@ export default defineConfig(({ mode }) => ({
 					: path.join(__dirname, 'src/renderer/wdyr.ts'),
 		},
 	},
-	esbuild: {
-		// Strip console.* and debugger in production builds
+	// Vite 8 with Rolldown uses oxc; the older esbuild config is silently
+	// ignored in this path. Express the same drop intent via oxc.
+	oxc: {
+		jsxRefresh: mode !== 'production',
 		drop: mode === 'production' ? ['console', 'debugger'] : [],
 	},
 	build: {
 		outDir: path.join(__dirname, 'dist/renderer'),
 		emptyOutDir: true,
+		// Vite 8 changed the default CSS minifier to lightningcss, which is
+		// strict about malformed CSS that earlier versions tolerated. Pin to
+		// esbuild to match prior behavior; xterm's CSS contains intentionally
+		// odd selectors that lightningcss rejects.
+		cssMinify: 'esbuild',
 		// Disable modulepreload polyfill — Electron loads from local filesystem
 		modulePreload: false,
 		rollupOptions: {

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -55,18 +55,23 @@ export default defineConfig(({ mode }) => ({
 		},
 	},
 	// Vite 8 with Rolldown uses oxc; the older esbuild config is silently
-	// ignored in this path. Express the same drop intent via oxc.
+	// ignored in this path. Express the same drop intent via oxc. JSX Fast
+	// Refresh is handled by @vitejs/plugin-react above (`fastRefresh` option),
+	// so an oxc-level toggle here would be redundant and could double-inject.
 	oxc: {
-		jsxRefresh: mode !== 'production',
 		drop: mode === 'production' ? ['console', 'debugger'] : [],
 	},
 	build: {
 		outDir: path.join(__dirname, 'dist/renderer'),
 		emptyOutDir: true,
-		// Vite 8 changed the default CSS minifier to lightningcss, which is
-		// strict about malformed CSS that earlier versions tolerated. Pin to
-		// esbuild to match prior behavior; xterm's CSS contains intentionally
-		// odd selectors that lightningcss rejects.
+		// TODO(vite-css): revisit this pin once one of these is true:
+		//   1) lightningcss tolerates xterm's malformed selectors (see
+		//      `[-:\s|]`-style class on or near style.css line ~2801)
+		//   2) xterm.js fixes its CSS upstream
+		//   3) we pre-process xterm's CSS through a tolerant pass before vite
+		// Vite 8 flipped the default CSS minifier to lightningcss, which is
+		// strict about malformed CSS that esbuild's minifier silently passed
+		// through. esbuild here matches prior (Vite 5-7) behavior.
 		cssMinify: 'esbuild',
 		// Disable modulepreload polyfill — Electron loads from local filesystem
 		modulePreload: false,

--- a/vite.config.web.mts
+++ b/vite.config.web.mts
@@ -48,8 +48,9 @@ export default defineConfig(({ mode }) => ({
 		__GIT_HASH__: JSON.stringify(gitHash),
 	},
 
-	esbuild: {
-		// Strip console.log and console.debug in production builds
+	// Vite 8 with Rolldown uses oxc; the older esbuild config is silently
+	// ignored in this path. Express the same drop intent via oxc.
+	oxc: {
 		drop: mode === 'production' ? ['console', 'debugger'] : [],
 	},
 
@@ -65,6 +66,11 @@ export default defineConfig(({ mode }) => ({
 	build: {
 		outDir: path.join(__dirname, 'dist/web'),
 		emptyOutDir: true,
+
+		// Vite 8 changed the default CSS minifier to lightningcss, which is
+		// strict about malformed CSS that earlier versions tolerated. Pin to
+		// esbuild to match prior behavior.
+		cssMinify: 'esbuild',
 
 		// Generate source maps for debugging
 		sourcemap: true,

--- a/vite.config.web.mts
+++ b/vite.config.web.mts
@@ -67,9 +67,14 @@ export default defineConfig(({ mode }) => ({
 		outDir: path.join(__dirname, 'dist/web'),
 		emptyOutDir: true,
 
-		// Vite 8 changed the default CSS minifier to lightningcss, which is
-		// strict about malformed CSS that earlier versions tolerated. Pin to
-		// esbuild to match prior behavior.
+		// TODO(vite-css): revisit this pin once one of these is true:
+		//   1) lightningcss tolerates xterm's malformed selectors (the web
+		//      config also pulls xterm CSS via @xterm/xterm)
+		//   2) xterm.js fixes its CSS upstream
+		//   3) we pre-process xterm's CSS through a tolerant pass before vite
+		// Vite 8 flipped the default CSS minifier to lightningcss, which is
+		// strict about malformed CSS that esbuild's minifier silently passed
+		// through. esbuild here matches prior (Vite 5-7) behavior.
 		cssMinify: 'esbuild',
 
 		// Generate source maps for debugging


### PR DESCRIPTION
## Summary

Vite major bump from a planned package-upgrade pass. Surfaces and addresses two real Vite 8 / Rolldown behavior shifts.

- `vite` `^5.0.11` → `^8.0.11` (3 majors)
- `@vitejs/plugin-react` `^4.2.1` → `^6.0.1` (sync, vite 8 peer)
- `vitest` `^4.0.15` → `^4.1.5` (sync, latest 4.x; no v5 yet)
- `@vitest/coverage-v8` `^4.0.15` → `^4.1.5` (sync)
- `esbuild` `^0.24.2` → `^0.28.0` (sync, vite 8 peer)
- removed `vite-plugin-electron` `^0.28.2` — verified zero imports in source

## Behavior shifts addressed in `vite.config.{mts,web.mts}`

1. **`cssMinify: 'esbuild'` pinned.** Vite 8 changed the default CSS minifier to lightningcss, which strictly rejects xterm's intentionally-malformed selectors that esbuild's minifier silently passed through. A `TODO(vite-css)` comment beside each pin names three exit criteria (lightningcss tolerance, xterm upstream fix, or local pre-processing).
2. **`esbuild.drop` → `oxc.drop`.** Vite 8 with Rolldown uses `oxc` as the transformer; the legacy `esbuild` config block is silently ignored. Without this migration, source `console.*` calls leak into production bundles. Verified by grepping production output before/after — known source `console.log` strings (e.g. `"AgentSessionsModal: No activeSession"`) are correctly stripped after the migration.

JSX Fast Refresh stays handled by `react({ fastRefresh: !disableHmr })` from `@vitejs/plugin-react`; no separate oxc-level toggle is needed (would double-inject).

## Verification

- `npm run lint` clean
- `npm run lint:eslint` clean
- `npm run format:check` (src/) clean
- `npm run build` clean under Vite 8 / Rolldown
- Full vitest suite on `/tmp` ext4 worktree: **775 files pass, 0 fail, 27,356 tests pass** when stacked on #965
- Production-build console.log stripping verified via grep

## Merge ordering

⚠ Land **after** #965 (`chore/dedup-test-imports`). This branch bumps `vitest` to 4.1.x which has a stricter parser; without the dedup branch, 4 test files silently report `(0 test)`.

## Test plan

- [ ] CI lint + build pass under Vite 8
- [ ] CI vitest pass count matches baseline (after #965 lands)
- [ ] Manual: smoke-test xterm rendering — open AI Terminal, run a TUI like `htop` or `vim`
- [ ] Manual: confirm console.log stripping in a packaged production build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies and build tooling to improve build performance and reliability.
* **Build / Configuration**
  * Adjusted production build stripping and minification approach for more consistent release outputs.
  * Injected compile-time app version and commit hash constants for use at runtime.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RunMaestro/Maestro/pull/969)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->