### PR TITLE
Fix RC field crashes from Sentry

### DIFF
--- a/docs/agent-guides/SHARED-UTILS.md
+++ b/docs/agent-guides/SHARED-UTILS.md
@@ -86,6 +86,13 @@ All utilities in Maestro organized by category. Each entry lists the file path, 
 | ---------------------- | -------------------- | ----------------------------------------------------------------------------------------------------------- |
 | `stripAnsiCodes(text)` | `(string) => string` | Remove ANSI escape codes, OSC sequences, iTerm2/VSCode shell integration sequences. Handles SSH edge cases. |
 
+## JSON Utilities (`src/shared/jsonUtils.ts` - Both)
+
+| Function           | Signature                         | Purpose                                                                   |
+| ------------------ | --------------------------------- | ------------------------------------------------------------------------- |
+| `stripJsonBom`     | `(value: string) => string`       | Remove a leading UTF-8 BOM from JSON text before parsing.                 |
+| `parseJsonWithBom` | `<T = unknown>(value: string): T` | `JSON.parse` wrapper that tolerates a leading BOM in persisted JSON text. |
+
 ### Main Process (`src/main/utils/stripAnsi.ts`)
 
 | Function         | Signature            | Purpose                                                                            |

--- a/src/__tests__/main/agents/detector.test.ts
+++ b/src/__tests__/main/agents/detector.test.ts
@@ -1621,6 +1621,34 @@ describe('agent-detector', () => {
 			// Hidden model's levels should not be excluded (they share the same platform levels)
 		});
 
+		it('falls back to static Codex reasoning levels when models_cache.json is missing', async () => {
+			mockExecFileNoThrow.mockImplementation(async (_cmd, args) => {
+				const binaryName = args[0];
+				if (binaryName === 'codex') {
+					return { stdout: '/usr/bin/codex\n', stderr: '', exitCode: 0 };
+				}
+				if (binaryName === 'bash') {
+					return { stdout: '/bin/bash\n', stderr: '', exitCode: 0 };
+				}
+				return { stdout: '', stderr: 'not found', exitCode: 1 };
+			});
+			_readFileSync.mockImplementation(() => {
+				const error = new Error('ENOENT: no such file or directory') as NodeJS.ErrnoException;
+				error.code = 'ENOENT';
+				throw error;
+			});
+
+			detector.clearCache();
+			await detector.detectAgents();
+
+			const options = await detector.discoverConfigOptions('codex', 'reasoningEffort');
+			expect(options).toEqual(['', 'minimal', 'low', 'medium', 'high', 'xhigh']);
+			expect(logger.debug).toHaveBeenCalledWith(
+				'Could not read Codex models_cache.json for config option discovery',
+				'AgentDetector'
+			);
+		});
+
 		it('should fall back to static options for select config options without dynamic discovery', async () => {
 			// Copilot-CLI's reasoningEffort is declared with a static `options` array
 			// and no dynamic discovery branch. Without the static fallback the

--- a/src/__tests__/main/cue/cue-db.test.ts
+++ b/src/__tests__/main/cue/cue-db.test.ts
@@ -454,6 +454,23 @@ describe('cue-db github seen tracking', () => {
 		expect(cutoff).toBeGreaterThan(before - olderThanMs - 1000);
 	});
 
+	it('github seen reads should be conservative when the database is closed', () => {
+		closeCueDb();
+
+		expect(isGitHubItemSeen('sub-1', 'pr:owner/repo:123')).toBe(true);
+		expect(hasAnyGitHubSeen('sub-1')).toBe(true);
+		expect(mockDb.prepare).not.toHaveBeenCalled();
+	});
+
+	it('github seen writes should no-op when the database is closed', () => {
+		closeCueDb();
+
+		markGitHubItemSeen('sub-1', 'pr:owner/repo:123');
+		pruneGitHubSeen(30 * 24 * 60 * 60 * 1000);
+
+		expect(mockDb.prepare).not.toHaveBeenCalled();
+	});
+
 	it('clearGitHubSeenForSubscription should delete all records for a subscription', () => {
 		clearGitHubSeenForSubscription('sub-1');
 

--- a/src/__tests__/main/cue/cue-github-poller.test.ts
+++ b/src/__tests__/main/cue/cue-github-poller.test.ts
@@ -20,6 +20,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 // Hoisted mock references (vi.hoisted runs before vi.mock hoisting)
 const {
 	mockExecFile,
+	mockIsCueDbReady,
 	mockIsGitHubItemSeen,
 	mockMarkGitHubItemSeen,
 	mockHasAnyGitHubSeen,
@@ -27,6 +28,7 @@ const {
 	mockCaptureException,
 } = vi.hoisted(() => ({
 	mockExecFile: vi.fn(),
+	mockIsCueDbReady: vi.fn<() => boolean>().mockReturnValue(true),
 	mockIsGitHubItemSeen: vi.fn<(subId: string, key: string) => boolean>().mockReturnValue(false),
 	mockMarkGitHubItemSeen: vi.fn<(subId: string, key: string) => void>(),
 	mockHasAnyGitHubSeen: vi.fn<(subId: string) => boolean>().mockReturnValue(true),
@@ -61,6 +63,7 @@ vi.mock('../../../main/utils/cliDetection', () => ({
 
 // Mock cue-db functions
 vi.mock('../../../main/cue/cue-db', () => ({
+	isCueDbReady: () => mockIsCueDbReady(),
 	isGitHubItemSeen: (subId: string, key: string) => mockIsGitHubItemSeen(subId, key),
 	markGitHubItemSeen: (subId: string, key: string) => mockMarkGitHubItemSeen(subId, key),
 	hasAnyGitHubSeen: (subId: string) => mockHasAnyGitHubSeen(subId),
@@ -204,8 +207,30 @@ describe('cue-github-poller', () => {
 		vi.clearAllMocks();
 		vi.useFakeTimers();
 		uuidCounter = 0;
+		mockIsCueDbReady.mockReturnValue(true);
 		mockIsGitHubItemSeen.mockReturnValue(false);
 		mockHasAnyGitHubSeen.mockReturnValue(true); // not first run by default
+	});
+
+	it('skips polling while Cue DB is not ready', async () => {
+		mockIsCueDbReady.mockReturnValue(false);
+		const config = makeConfig();
+		setupExecFile({
+			'--version': '2.0.0',
+			'pr list': JSON.stringify(samplePRs),
+		});
+
+		const cleanup = createCueGitHubPoller(config);
+		await vi.advanceTimersByTimeAsync(2000);
+
+		expect(config.onLog).toHaveBeenCalledWith(
+			'warn',
+			expect.stringContaining('Cue database not ready')
+		);
+		expect(mockExecFile).not.toHaveBeenCalled();
+		expect(config.onEvent).not.toHaveBeenCalled();
+
+		cleanup();
 	});
 
 	afterEach(() => {

--- a/src/__tests__/main/history-manager.test.ts
+++ b/src/__tests__/main/history-manager.test.ts
@@ -476,6 +476,50 @@ describe('HistoryManager', () => {
 			expect(result[0].id).toBe('e1');
 		});
 
+		it('should parse session files with a leading UTF-8 BOM', async () => {
+			const entries = [createMockEntry({ id: 'bom-entry' })];
+			const filePath = path.join(
+				'/mock/userData',
+				'history',
+				`${sanitizeSessionId('session-1')}.json`
+			);
+
+			mockExistsSync.mockImplementation((p: fs.PathLike) => p.toString() === filePath);
+			mockReadFileSync.mockReturnValue(`\uFEFF${createHistoryFileData('session-1', entries)}`);
+
+			const result = await manager.getEntries('session-1');
+			expect(result).toHaveLength(1);
+			expect(result[0].id).toBe('bom-entry');
+		});
+
+		it('should recover and rewrite the first valid object from concatenated JSON', async () => {
+			const entries = [createMockEntry({ id: 'recovered-entry' })];
+			const firstDocument = createHistoryFileData('session-1', entries);
+			const secondDocument = createHistoryFileData('session-1', [createMockEntry({ id: 'stale' })]);
+			const filePath = path.join(
+				'/mock/userData',
+				'history',
+				`${sanitizeSessionId('session-1')}.json`
+			);
+
+			mockExistsSync.mockImplementation((p: fs.PathLike) => p.toString() === filePath);
+			mockReadFileSync.mockReturnValue(`${firstDocument}${secondDocument}`);
+
+			const result = await manager.getEntries('session-1');
+
+			expect(result).toHaveLength(1);
+			expect(result[0].id).toBe('recovered-entry');
+			expect(mockWriteFileSync).toHaveBeenCalledWith(
+				filePath,
+				JSON.stringify(JSON.parse(firstDocument), null, 2),
+				'utf-8'
+			);
+			expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
+				expect.stringContaining('Recovered concatenated history JSON'),
+				expect.any(String)
+			);
+		});
+
 		it('should return empty array if session file does not exist', async () => {
 			mockExistsSync.mockReturnValue(false);
 			const result = await manager.getEntries('nonexistent');

--- a/src/__tests__/main/stores/instances.test.ts
+++ b/src/__tests__/main/stores/instances.test.ts
@@ -85,7 +85,19 @@ describe('stores/instances', () => {
 				name: 'maestro-bootstrap',
 				cwd: '/mock/user/data',
 				defaults: {},
+				deserialize: expect.any(Function),
 			});
+		});
+
+		it('configures stores with BOM-safe JSON deserialization', () => {
+			initializeStores({ productionDataPath: '/mock/production/path' });
+
+			for (const call of mockStoreConstructorCalls) {
+				expect(call.deserialize).toEqual(expect.any(Function));
+				expect((call.deserialize as (value: string) => unknown)('\uFEFF{"ok":true}')).toEqual({
+					ok: true,
+				});
+			}
 		});
 
 		it('should create settings store with sync path', () => {

--- a/src/__tests__/renderer/hooks/useFileExplorerEffects.test.ts
+++ b/src/__tests__/renderer/hooks/useFileExplorerEffects.test.ts
@@ -216,6 +216,61 @@ describe('useFileExplorerEffects', () => {
 			);
 		});
 
+		it('does not prepend the project root to absolute file links', async () => {
+			const useFileExplorerEffects = await loadHook();
+			const session = createMockSession();
+			const handleOpenFileTab = vi.fn();
+			const deps = createDeps({
+				sessionsRef: { current: [session] },
+				activeSessionIdRef: { current: 'session-1' },
+				handleOpenFileTab,
+			});
+
+			const { result } = renderHook(() => useFileExplorerEffects(deps));
+
+			await act(async () => {
+				await result.current.handleMainPanelFileClick('/test/project/src/index.ts:20');
+			});
+
+			expect(window.maestro.fs.readFile).toHaveBeenCalledWith(
+				'/test/project/src/index.ts',
+				undefined
+			);
+			expect(handleOpenFileTab).toHaveBeenCalledWith(
+				expect.objectContaining({
+					path: '/test/project/src/index.ts',
+					name: 'index.ts',
+				}),
+				{ openInNewTab: false }
+			);
+		});
+
+		it('strips line and column suffixes from relative file links', async () => {
+			const useFileExplorerEffects = await loadHook();
+			const session = createMockSession();
+			const handleOpenFileTab = vi.fn();
+			const deps = createDeps({
+				sessionsRef: { current: [session] },
+				activeSessionIdRef: { current: 'session-1' },
+				handleOpenFileTab,
+			});
+
+			const { result } = renderHook(() => useFileExplorerEffects(deps));
+
+			await act(async () => {
+				await result.current.handleMainPanelFileClick('src/index.ts:20:5');
+			});
+
+			expect(window.maestro.fs.stat).toHaveBeenCalledWith('/test/project/src/index.ts', undefined);
+			expect(handleOpenFileTab).toHaveBeenCalledWith(
+				expect.objectContaining({
+					path: '/test/project/src/index.ts',
+					name: 'index.ts',
+				}),
+				{ openInNewTab: false }
+			);
+		});
+
 		it('does nothing when session is not found', async () => {
 			const useFileExplorerEffects = await loadHook();
 			useSessionStore.setState({

--- a/src/__tests__/shared/jsonUtils.test.ts
+++ b/src/__tests__/shared/jsonUtils.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { parseJsonWithBom, stripJsonBom } from '../../shared/jsonUtils';
+
+describe('jsonUtils', () => {
+	it('strips a leading UTF-8 BOM', () => {
+		expect(stripJsonBom('\uFEFF{"ok":true}')).toBe('{"ok":true}');
+	});
+
+	it('does not strip non-leading BOM characters', () => {
+		expect(stripJsonBom('{"value":"\uFEFF"}')).toBe('{"value":"\uFEFF"}');
+	});
+
+	it('parses BOM-prefixed JSON', () => {
+		expect(parseJsonWithBom<{ ok: boolean }>('\uFEFF{"ok":true}')).toEqual({ ok: true });
+	});
+});

--- a/src/main/agents/detector.ts
+++ b/src/main/agents/detector.ts
@@ -24,6 +24,7 @@ import { checkBinaryExists, checkCustomPath, getExpandedEnv } from './path-probe
 import { AGENT_DEFINITIONS, type AgentConfig } from './definitions';
 import { discoverModelsFromLocalConfigs } from './opencode-config';
 import { isWindows } from '../../shared/platformDetection';
+import { parseJsonWithBom } from '../../shared/jsonUtils';
 
 const LOG_CONTEXT = 'AgentDetector';
 
@@ -348,13 +349,19 @@ export class AgentDetector {
 						const codexHome = process.env.CODEX_HOME || path.join(os.homedir(), '.codex');
 						const cachePath = path.join(codexHome, 'models_cache.json');
 						const cacheContent = fs.readFileSync(cachePath, 'utf8');
-						const cache = JSON.parse(cacheContent);
+						const cache = parseJsonWithBom<{
+							models?: Array<{ slug?: string; visibility?: string }>;
+						}>(cacheContent);
 						if (Array.isArray(cache.models)) {
 							const models = cache.models
 								.filter(
-									(m: { slug?: string; visibility?: string }) => m.slug && m.visibility !== 'hide'
+									(m: {
+										slug?: string;
+										visibility?: string;
+									}): m is { slug: string; visibility?: string } =>
+										typeof m.slug === 'string' && m.visibility !== 'hide'
 								)
-								.map((m: { slug: string }) => m.slug);
+								.map((m) => m.slug);
 							logger.info(
 								`Discovered ${models.length} models for ${agentId} from models_cache.json`,
 								LOG_CONTEXT,
@@ -520,33 +527,46 @@ export class AgentDetector {
 				case 'codex': {
 					if (optionKey === 'reasoningEffort') {
 						// Codex: read reasoning levels from ~/.codex/models_cache.json
-						const codexHome = process.env.CODEX_HOME || path.join(os.homedir(), '.codex');
-						const cachePath = path.join(codexHome, 'models_cache.json');
-						const cacheContent = fs.readFileSync(cachePath, 'utf8');
-						const cache = JSON.parse(cacheContent);
-						if (Array.isArray(cache.models)) {
-							// Collect union of all reasoning levels across visible models
-							const levelSet = new Set<string>();
-							for (const model of cache.models) {
-								if (model.visibility === 'hide') continue;
-								for (const rl of model.supported_reasoning_levels || []) {
-									if (rl.effort) levelSet.add(rl.effort);
+						try {
+							const codexHome = process.env.CODEX_HOME || path.join(os.homedir(), '.codex');
+							const cachePath = path.join(codexHome, 'models_cache.json');
+							const cacheContent = fs.readFileSync(cachePath, 'utf8');
+							const cache = parseJsonWithBom<{
+								models?: Array<{
+									visibility?: string;
+									supported_reasoning_levels?: Array<{ effort?: string }>;
+								}>;
+							}>(cacheContent);
+							if (Array.isArray(cache.models)) {
+								// Collect union of all reasoning levels across visible models
+								const levelSet = new Set<string>();
+								for (const model of cache.models) {
+									if (model.visibility === 'hide') continue;
+									for (const rl of model.supported_reasoning_levels || []) {
+										if (rl.effort) levelSet.add(rl.effort);
+									}
 								}
+								const levels = Array.from(levelSet);
+								// Sort by severity: minimal < low < medium < high < xhigh
+								const order = ['minimal', 'low', 'medium', 'high', 'xhigh'];
+								levels.sort(
+									(a, b) =>
+										(order.indexOf(a) === -1 ? 99 : order.indexOf(a)) -
+										(order.indexOf(b) === -1 ? 99 : order.indexOf(b))
+								);
+								logger.info(
+									`Discovered ${levels.length} reasoning levels for ${agentId} from models_cache.json`,
+									LOG_CONTEXT,
+									{ levels }
+								);
+								return ['', ...levels]; // Empty string = use default
 							}
-							const levels = Array.from(levelSet);
-							// Sort by severity: minimal < low < medium < high < xhigh
-							const order = ['minimal', 'low', 'medium', 'high', 'xhigh'];
-							levels.sort(
-								(a, b) =>
-									(order.indexOf(a) === -1 ? 99 : order.indexOf(a)) -
-									(order.indexOf(b) === -1 ? 99 : order.indexOf(b))
+						} catch {
+							// Fresh Codex installs may not have populated the cache yet.
+							logger.debug(
+								'Could not read Codex models_cache.json for config option discovery',
+								LOG_CONTEXT
 							);
-							logger.info(
-								`Discovered ${levels.length} reasoning levels for ${agentId} from models_cache.json`,
-								LOG_CONTEXT,
-								{ levels }
-							);
-							return ['', ...levels]; // Empty string = use default
 						}
 					}
 					break;

--- a/src/main/cue/cue-db.ts
+++ b/src/main/cue/cue-db.ts
@@ -484,6 +484,7 @@ export function pruneCueEvents(olderThanMs: number): void {
  * Check if a GitHub item has been seen for a given subscription.
  */
 export function isGitHubItemSeen(subscriptionId: string, itemKey: string): boolean {
+	if (!db) return true;
 	const row = getDb()
 		.prepare(`SELECT 1 FROM cue_github_seen WHERE subscription_id = ? AND item_key = ?`)
 		.get(subscriptionId, itemKey);
@@ -494,6 +495,13 @@ export function isGitHubItemSeen(subscriptionId: string, itemKey: string): boole
  * Mark a GitHub item as seen for a given subscription.
  */
 export function markGitHubItemSeen(subscriptionId: string, itemKey: string): void {
+	if (!db) {
+		log(
+			'warn',
+			`Dropping markGitHubItemSeen (subscriptionId=${subscriptionId}, itemKey=${itemKey}): Cue DB not initialized`
+		);
+		return;
+	}
 	getDb()
 		.prepare(
 			`INSERT OR IGNORE INTO cue_github_seen (subscription_id, item_key, seen_at) VALUES (?, ?, ?)`
@@ -506,6 +514,7 @@ export function markGitHubItemSeen(subscriptionId: string, itemKey: string): voi
  * Used for first-run seeding detection.
  */
 export function hasAnyGitHubSeen(subscriptionId: string): boolean {
+	if (!db) return true;
 	const row = getDb()
 		.prepare(`SELECT 1 FROM cue_github_seen WHERE subscription_id = ? LIMIT 1`)
 		.get(subscriptionId);
@@ -516,6 +525,7 @@ export function hasAnyGitHubSeen(subscriptionId: string): boolean {
  * Delete GitHub seen records older than the specified age in milliseconds.
  */
 export function pruneGitHubSeen(olderThanMs: number): void {
+	if (!db) return;
 	const cutoff = Date.now() - olderThanMs;
 	const result = getDb().prepare(`DELETE FROM cue_github_seen WHERE seen_at < ?`).run(cutoff);
 	if (result.changes > 0) {

--- a/src/main/cue/cue-github-poller.ts
+++ b/src/main/cue/cue-github-poller.ts
@@ -7,7 +7,13 @@
 
 import { execFile as cpExecFile } from 'child_process';
 import { createCueEvent, type CueEvent } from './cue-types';
-import { isGitHubItemSeen, markGitHubItemSeen, hasAnyGitHubSeen, pruneGitHubSeen } from './cue-db';
+import {
+	isCueDbReady,
+	isGitHubItemSeen,
+	markGitHubItemSeen,
+	hasAnyGitHubSeen,
+	pruneGitHubSeen,
+} from './cue-db';
 import { resolveGhPath, getExpandedEnv } from '../utils/cliDetection';
 import { captureException } from '../utils/sentry';
 import type { CueLogPayload } from '../../shared/cue-log-types';
@@ -310,6 +316,10 @@ export function createCueGitHubPoller(config: CueGitHubPollerConfig): () => void
 		// scheduleNextPoll loop keeps running so we resume cleanly when the
 		// app becomes visible again.
 		if (!isActive()) return;
+		if (!isCueDbReady()) {
+			onLog('warn', `[CUE] Cue database not ready — skipping GitHub poll for "${triggerName}"`);
+			return;
+		}
 
 		try {
 			if (!(await resolveGh())) return;
@@ -422,6 +432,7 @@ export function createCueGitHubPoller(config: CueGitHubPollerConfig): () => void
 	// Periodic prune every 24 hours (30-day retention)
 	pruneInterval = setInterval(
 		() => {
+			if (!isCueDbReady()) return;
 			pruneGitHubSeen(30 * 24 * 60 * 60 * 1000);
 		},
 		24 * 60 * 60 * 1000

--- a/src/main/history-manager.ts
+++ b/src/main/history-manager.ts
@@ -22,6 +22,7 @@ import * as path from 'path';
 import { app } from 'electron';
 import { logger } from './utils/logger';
 import { captureException } from './utils/sentry';
+import { parseJsonWithBom, stripJsonBom } from '../shared/jsonUtils';
 import { HistoryEntry } from '../shared/types';
 import {
 	HISTORY_VERSION,
@@ -50,6 +51,64 @@ async function pathExists(p: string): Promise<boolean> {
 		const code = (err as NodeJS.ErrnoException).code;
 		if (code === 'ENOENT') return false;
 		throw err;
+	}
+}
+
+function findFirstJsonObjectEnd(raw: string): number | null {
+	const start = raw.search(/\S/);
+	if (start === -1 || raw[start] !== '{') return null;
+
+	let depth = 0;
+	let inString = false;
+	let escaped = false;
+
+	for (let i = start; i < raw.length; i++) {
+		const char = raw[i];
+
+		if (inString) {
+			if (escaped) {
+				escaped = false;
+			} else if (char === '\\') {
+				escaped = true;
+			} else if (char === '"') {
+				inString = false;
+			}
+			continue;
+		}
+
+		if (char === '"') {
+			inString = true;
+			continue;
+		}
+
+		if (char === '{') {
+			depth++;
+		} else if (char === '}') {
+			depth--;
+			if (depth === 0) {
+				return i + 1;
+			}
+		}
+	}
+
+	return null;
+}
+
+function parseHistoryFileData(raw: string): { data: HistoryFileData; recovered: boolean } {
+	const normalized = stripJsonBom(raw);
+	try {
+		return { data: JSON.parse(normalized) as HistoryFileData, recovered: false };
+	} catch (error) {
+		if (!(error instanceof SyntaxError)) throw error;
+
+		const firstObjectEnd = findFirstJsonObjectEnd(normalized);
+		if (firstObjectEnd === null) throw error;
+
+		const trailing = normalized.slice(firstObjectEnd).trim();
+		if (trailing.length === 0) throw error;
+
+		const data = JSON.parse(normalized.slice(0, firstObjectEnd)) as HistoryFileData;
+		return { data, recovered: true };
 	}
 }
 
@@ -98,8 +157,8 @@ export class HistoryManager {
 		if (await pathExists(this.legacyFilePath)) {
 			try {
 				const raw = await fsp.readFile(this.legacyFilePath, 'utf-8');
-				const data = JSON.parse(raw);
-				return data.entries && data.entries.length > 0;
+				const data = parseJsonWithBom<{ entries?: HistoryEntry[] }>(raw);
+				return (data.entries?.length ?? 0) > 0;
 			} catch {
 				return false;
 			}
@@ -123,7 +182,7 @@ export class HistoryManager {
 
 		try {
 			const raw = await fsp.readFile(this.legacyFilePath, 'utf-8');
-			const legacyData = JSON.parse(raw);
+			const legacyData = parseJsonWithBom<{ entries?: HistoryEntry[] }>(raw);
 			const entries: HistoryEntry[] = legacyData.entries || [];
 
 			// Group entries by sessionId (skip entries without sessionId)
@@ -206,7 +265,14 @@ export class HistoryManager {
 		const filePath = this.getSessionFilePath(sessionId);
 		try {
 			const raw = await fsp.readFile(filePath, 'utf-8');
-			const data: HistoryFileData = JSON.parse(raw);
+			const { data, recovered } = parseHistoryFileData(raw);
+			if (recovered) {
+				logger.warn(
+					`Recovered concatenated history JSON for session ${sessionId}; rewriting clean file`,
+					LOG_CONTEXT
+				);
+				await fsp.writeFile(filePath, JSON.stringify(data, null, 2), 'utf-8');
+			}
 			return data.entries || [];
 		} catch (error) {
 			const code = (error as NodeJS.ErrnoException).code;
@@ -234,7 +300,7 @@ export class HistoryManager {
 
 		try {
 			const raw = await fsp.readFile(filePath, 'utf-8');
-			data = JSON.parse(raw);
+			data = parseHistoryFileData(raw).data;
 		} catch (error) {
 			const code = (error as NodeJS.ErrnoException).code;
 			if (code === 'ENOENT') {
@@ -287,7 +353,7 @@ export class HistoryManager {
 		}
 
 		try {
-			const data: HistoryFileData = JSON.parse(raw);
+			const data = parseHistoryFileData(raw).data;
 			const originalLength = data.entries.length;
 			data.entries = data.entries.filter((e) => e.id !== entryId);
 
@@ -331,7 +397,7 @@ export class HistoryManager {
 		}
 
 		try {
-			const data: HistoryFileData = JSON.parse(raw);
+			const data = parseHistoryFileData(raw).data;
 			const index = data.entries.findIndex((e) => e.id === entryId);
 
 			if (index === -1) {

--- a/src/main/history-manager.ts
+++ b/src/main/history-manager.ts
@@ -552,9 +552,16 @@ export class HistoryManager {
 			}
 
 			try {
-				const data: HistoryFileData = JSON.parse(raw);
-				let modified = false;
+				const { data, recovered } = parseHistoryFileData(raw);
+				let modified = recovered;
 				let perSessionUpdates = 0;
+
+				if (recovered) {
+					logger.warn(
+						`Recovered concatenated history JSON for session ${sessionId}; rewriting clean file`,
+						LOG_CONTEXT
+					);
+				}
 
 				for (const entry of data.entries) {
 					if (entry.agentSessionId === agentSessionId && entry.sessionName !== sessionName) {
@@ -567,10 +574,12 @@ export class HistoryManager {
 				if (modified) {
 					await fsp.writeFile(filePath, JSON.stringify(data, null, 2), 'utf-8');
 					updatedCount += perSessionUpdates;
-					logger.debug(
-						`Updated ${perSessionUpdates} entries for agentSessionId ${agentSessionId} in session ${sessionId}`,
-						LOG_CONTEXT
-					);
+					if (perSessionUpdates > 0) {
+						logger.debug(
+							`Updated ${perSessionUpdates} entries for agentSessionId ${agentSessionId} in session ${sessionId}`,
+							LOG_CONTEXT
+						);
+					}
 				}
 			} catch (error) {
 				logger.warn(`Failed to update sessionName in session ${sessionId}: ${error}`, LOG_CONTEXT);

--- a/src/main/stores/instances.ts
+++ b/src/main/stores/instances.ts
@@ -12,6 +12,7 @@
 
 import { app } from 'electron';
 import Store from 'electron-store';
+import { parseJsonWithBom } from '../../shared/jsonUtils';
 
 import type {
 	BootstrapSettings,
@@ -35,6 +36,10 @@ import {
 } from './defaults';
 
 import { getCustomSyncPath } from './utils';
+
+function deserializeStoreJson<T = Record<string, unknown>>(value: string): T {
+	return parseJsonWithBom<T>(value);
+}
 
 // ============================================================================
 // Store Instance Variables
@@ -80,6 +85,7 @@ export function initializeStores(options: StoreInitOptions): {
 		name: 'maestro-bootstrap',
 		cwd: app.getPath('userData'),
 		defaults: {},
+		deserialize: deserializeStoreJson,
 	});
 
 	// 2. Determine sync path
@@ -95,18 +101,21 @@ export function initializeStores(options: StoreInitOptions): {
 		name: 'maestro-settings',
 		cwd: _syncPath,
 		defaults: SETTINGS_DEFAULTS,
+		deserialize: deserializeStoreJson,
 	});
 
 	_sessionsStore = new Store<SessionsData>({
 		name: 'maestro-sessions',
 		cwd: _syncPath,
 		defaults: SESSIONS_DEFAULTS,
+		deserialize: deserializeStoreJson,
 	});
 
 	_groupsStore = new Store<GroupsData>({
 		name: 'maestro-groups',
 		cwd: _syncPath,
 		defaults: GROUPS_DEFAULTS,
+		deserialize: deserializeStoreJson,
 	});
 
 	// Agent configs are ALWAYS stored in the production path, even in dev mode
@@ -115,12 +124,14 @@ export function initializeStores(options: StoreInitOptions): {
 		name: 'maestro-agent-configs',
 		cwd: _productionDataPath,
 		defaults: AGENT_CONFIGS_DEFAULTS,
+		deserialize: deserializeStoreJson,
 	});
 
 	// Window state is intentionally NOT synced - it's per-device
 	_windowStateStore = new Store<WindowState>({
 		name: 'maestro-window-state',
 		defaults: WINDOW_STATE_DEFAULTS,
+		deserialize: deserializeStoreJson,
 	});
 
 	// Claude session origins - tracks which sessions were created by Maestro
@@ -128,6 +139,7 @@ export function initializeStores(options: StoreInitOptions): {
 		name: 'maestro-claude-session-origins',
 		cwd: _syncPath,
 		defaults: CLAUDE_SESSION_ORIGINS_DEFAULTS,
+		deserialize: deserializeStoreJson,
 	});
 
 	// Generic agent session origins - supports all agents (Codex, OpenCode, etc.)
@@ -135,6 +147,7 @@ export function initializeStores(options: StoreInitOptions): {
 		name: 'maestro-agent-session-origins',
 		cwd: _syncPath,
 		defaults: AGENT_SESSION_ORIGINS_DEFAULTS,
+		deserialize: deserializeStoreJson,
 	});
 
 	return {

--- a/src/main/stores/utils.ts
+++ b/src/main/stores/utils.ts
@@ -13,6 +13,7 @@ import { isWindows, isLinux } from '../../shared/platformDetection';
 import Store from 'electron-store';
 import fsSync from 'fs';
 
+import { parseJsonWithBom } from '../../shared/jsonUtils';
 import type { BootstrapSettings } from './types';
 
 // Re-export getDefaultShell from defaults for backward compatibility
@@ -207,6 +208,7 @@ export function getEarlySettings(syncPath: string): {
 	}>({
 		name: 'maestro-settings',
 		cwd: syncPath,
+		deserialize: parseJsonWithBom,
 	});
 
 	// Check if user has explicitly set GPU acceleration preference

--- a/src/renderer/hooks/git/useFileExplorerEffects.ts
+++ b/src/renderer/hooks/git/useFileExplorerEffects.ts
@@ -72,6 +72,34 @@ export interface UseFileExplorerEffectsReturn {
 	) => Promise<void>;
 }
 
+function stripLineColumnSuffix(filePath: string): string {
+	return filePath.replace(/:(\d+)(?::\d+)?$/, '');
+}
+
+function isAbsoluteFilePath(filePath: string): boolean {
+	return (
+		filePath.startsWith('/') || /^[A-Za-z]:[\\/]/.test(filePath) || filePath.startsWith('\\\\')
+	);
+}
+
+function joinFilePath(rootPath: string, relativePath: string): string {
+	const root = rootPath.replace(/[\\/]+$/, '');
+	const child = relativePath.replace(/^[\\/]+/, '');
+	return `${root}/${child}`;
+}
+
+function resolveClickedFilePath(projectRoot: string, fileReference: string): string {
+	const normalizedReference = stripLineColumnSuffix(fileReference.trim());
+	if (isAbsoluteFilePath(normalizedReference)) {
+		return normalizedReference;
+	}
+	return joinFilePath(projectRoot, normalizedReference);
+}
+
+function getFilename(filePath: string): string {
+	return filePath.split(/[\\/]/).pop() || filePath;
+}
+
 // ============================================================================
 // Hook
 // ============================================================================
@@ -129,7 +157,8 @@ export function useFileExplorerEffects(
 		async (relativePath: string, options?: { openInNewTab?: boolean }) => {
 			const currentSession = sessionsRef.current.find((s) => s.id === activeSessionIdRef.current);
 			if (!currentSession) return;
-			const filename = relativePath.split('/').pop() || relativePath;
+			const fullPath = resolveClickedFilePath(currentSession.fullPath, relativePath);
+			const filename = getFilename(fullPath);
 
 			// Get SSH remote ID
 			const sshRemoteId =
@@ -137,13 +166,11 @@ export function useFileExplorerEffects(
 
 			// Check if file should be opened externally (PDF, etc.)
 			if (!sshRemoteId && shouldOpenExternally(filename)) {
-				const fullPath = `${currentSession.fullPath}/${relativePath}`;
 				window.maestro.shell.openPath(fullPath);
 				return;
 			}
 
 			try {
-				const fullPath = `${currentSession.fullPath}/${relativePath}`;
 				// Fetch content and stat in parallel for efficiency
 				const [content, stat] = await Promise.all([
 					window.maestro.fs.readFile(fullPath, sshRemoteId),
@@ -172,7 +199,7 @@ export function useFileExplorerEffects(
 			} catch (error) {
 				captureException(error, {
 					extra: {
-						fullPath: `${currentSession.fullPath}/${relativePath}`,
+						fullPath,
 						filename,
 						sshRemoteId,
 						operation: 'file-open',

--- a/src/shared/jsonUtils.ts
+++ b/src/shared/jsonUtils.ts
@@ -1,0 +1,15 @@
+/**
+ * JSON parsing helpers shared by main and renderer code.
+ */
+
+/**
+ * JSON.parse rejects a leading UTF-8 BOM even though some editors and sync
+ * tools can write one into otherwise-valid JSON files.
+ */
+export function stripJsonBom(value: string): string {
+	return value.charCodeAt(0) === 0xfeff ? value.slice(1) : value;
+}
+
+export function parseJsonWithBom<T = unknown>(value: string): T {
+	return JSON.parse(stripJsonBom(value)) as T;
+}


### PR DESCRIPTION
## Summary
- Add BOM-safe JSON parsing and apply it to Electron stores, early settings, and Codex model cache reads.
- Recover concatenated history JSON by parsing the first valid object and rewriting a clean file.
- Fall back to static Codex config options when `models_cache.json` is missing or malformed.
- Normalize clicked file references before stat/read so `:line[:column]` suffixes and absolute paths do not produce bad paths.
- Guard Cue GitHub polling and seen-record helpers when the Cue DB has not initialized yet.

## Sentry
Addresses obvious RC field crashes seen in Sentry: MAESTRO-N6, MAESTRO-N4, MAESTRO-N5, MAESTRO-MB, MAESTRO-M6, MAESTRO-JF, MAESTRO-KX, MAESTRO-KW, MAESTRO-KV, MAESTRO-KD, MAESTRO-JZ, MAESTRO-JY, and MAESTRO-JX.

## Validation
- `npm run format:check:all`
- `npm run lint`
- `npm run lint:eslint`
- `npm run test`
- `npm run build`

The push hook also reran format, lint, ESLint, and the full test suite successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fallback when model configuration cache is unavailable for model-related options.

* **Bug Fixes**
  * Robust file-opening behavior for absolute and relative paths with line/column refs.
  * Better recovery and cleanup of corrupted or concatenated history files; BOM-tolerant JSON parsing improves session and settings loading.
  * Prevent background GitHub polling and related actions until the database is ready.

* **Tests**
  * Added tests covering parsing edge cases, DB readiness, and file-link handling.

* **Documentation**
  * Added JSON Utilities reference.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RunMaestro/Maestro/pull/977)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->