### PR TITLE
feat(session-list): add Copy Agent ID to context menu

### DIFF
--- a/src/__tests__/renderer/components/SessionList.test.tsx
+++ b/src/__tests__/renderer/components/SessionList.test.tsx
@@ -46,6 +46,7 @@ vi.mock('lucide-react', () => ({
 	Keyboard: () => <span data-testid="icon-keyboard" />,
 	Radio: () => <span data-testid="icon-radio" />,
 	Copy: () => <span data-testid="icon-copy" />,
+	Hash: () => <span data-testid="icon-hash" />,
 	ExternalLink: () => <span data-testid="icon-external-link" />,
 	PanelLeftClose: () => <span data-testid="icon-panel-left-close" />,
 	PanelLeftOpen: () => <span data-testid="icon-panel-left-open" />,

--- a/src/renderer/components/SessionList/SessionContextMenu.tsx
+++ b/src/renderer/components/SessionList/SessionContextMenu.tsx
@@ -3,6 +3,7 @@ import {
 	ChevronRight,
 	Settings,
 	Copy,
+	Hash,
 	Bookmark,
 	FolderInput,
 	FolderPlus,
@@ -15,6 +16,7 @@ import {
 } from 'lucide-react';
 import type { Group, Session, Theme } from '../../types';
 import { useClickOutside, useContextMenuPosition } from '../../hooks';
+import { flashCopiedToClipboard } from '../../utils/flashCopiedToClipboard';
 
 interface SessionContextMenuProps {
 	x: number;
@@ -186,6 +188,20 @@ export function SessionContextMenu({
 			>
 				<Copy className="w-3.5 h-3.5" />
 				Duplicate...
+			</button>
+
+			<button
+				type="button"
+				onClick={() => {
+					void navigator.clipboard.writeText(session.id);
+					flashCopiedToClipboard(session.id, 'Agent ID Copied');
+					onDismiss();
+				}}
+				className="w-full text-left px-3 py-1.5 text-xs hover:bg-white/5 transition-colors flex items-center gap-2"
+				style={{ color: theme.colors.textMain }}
+			>
+				<Hash className="w-3.5 h-3.5" />
+				Copy Agent ID
 			</button>
 
 			{!session.parentSessionId && (

--- a/src/renderer/components/SessionList/SessionContextMenu.tsx
+++ b/src/renderer/components/SessionList/SessionContextMenu.tsx
@@ -17,7 +17,7 @@ import {
 import type { Group, Session, Theme } from '../../types';
 import { useClickOutside, useContextMenuPosition } from '../../hooks';
 import { flashCopiedToClipboard } from '../../utils/flashCopiedToClipboard';
-import { captureException } from '../../utils/sentry';
+import { safeClipboardWrite } from '../../utils/clipboard';
 
 interface SessionContextMenuProps {
 	x: number;
@@ -194,13 +194,9 @@ export function SessionContextMenu({
 			<button
 				type="button"
 				onClick={async () => {
-					try {
-						await navigator.clipboard.writeText(session.id);
-					} catch (err) {
-						captureException(err, { extra: { sessionId: session.id, action: 'copy-agent-id' } });
-						throw err;
+					if (await safeClipboardWrite(session.id)) {
+						flashCopiedToClipboard(session.id, 'Agent ID Copied');
 					}
-					flashCopiedToClipboard(session.id, 'Agent ID Copied');
 					onDismiss();
 				}}
 				className="w-full text-left px-3 py-1.5 text-xs hover:bg-white/5 transition-colors flex items-center gap-2"

--- a/src/renderer/components/SessionList/SessionContextMenu.tsx
+++ b/src/renderer/components/SessionList/SessionContextMenu.tsx
@@ -17,6 +17,7 @@ import {
 import type { Group, Session, Theme } from '../../types';
 import { useClickOutside, useContextMenuPosition } from '../../hooks';
 import { flashCopiedToClipboard } from '../../utils/flashCopiedToClipboard';
+import { captureException } from '../../utils/sentry';
 
 interface SessionContextMenuProps {
 	x: number;
@@ -192,8 +193,13 @@ export function SessionContextMenu({
 
 			<button
 				type="button"
-				onClick={() => {
-					void navigator.clipboard.writeText(session.id);
+				onClick={async () => {
+					try {
+						await navigator.clipboard.writeText(session.id);
+					} catch (err) {
+						captureException(err, { extra: { sessionId: session.id, action: 'copy-agent-id' } });
+						throw err;
+					}
 					flashCopiedToClipboard(session.id, 'Agent ID Copied');
 					onDismiss();
 				}}


### PR DESCRIPTION
<img width="284" height="309" alt="Bildschirmfoto 2026-05-10 um 09 10 27" src="https://github.com/user-attachments/assets/61b0b8a5-5d9b-4355-9b14-52a4ee9b0a13" />

## Summary
- Adds a Copy Agent ID entry to the agent right-click context menu in the Left Bar
- Writes session.id to the clipboard and triggers the canonical themed center flash (Agent ID Copied)
- Adds Hash to the lucide-react mock in SessionList.test.tsx so the new icon resolves under vitest

<img width="352" height="96" alt="Bildschirmfoto 2026-05-10 um 09 10 17" src="https://github.com/user-attachments/assets/e9181536-a185-4035-8d88-138fb5ae6a83" />


## Test plan
- [ ] Right-click any agent in the Left Bar; Copy Agent ID appears between Duplicate and bookmark
- [ ] Click it; clipboard contains the agent UUID and a themed Agent ID Copied flash shows the ID
- [ ] npm run test passes (SessionList context-menu tests no longer fail on missing Hash export)

Generated with Claude Code (https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Copy Agent ID" action to the session context menu that copies the ID to the clipboard, shows a success flash message, and handles failures gracefully.

* **Tests**
  * Updated test mocks to support the new context-menu UI elements introduced.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RunMaestro/Maestro/pull/978)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->