### PR TITLE
fix: preserve duplicated agent name and inherit source group (#827)

### DIFF
--- a/src/__tests__/renderer/components/NewInstanceModal.test.tsx
+++ b/src/__tests__/renderer/components/NewInstanceModal.test.tsx
@@ -731,6 +731,7 @@ describe('NewInstanceModal', () => {
 				undefined,
 				undefined,
 				{ enabled: false, remoteId: null },
+				undefined,
 				undefined
 			);
 		});
@@ -779,6 +780,7 @@ describe('NewInstanceModal', () => {
 				undefined,
 				undefined,
 				{ enabled: false, remoteId: null },
+				undefined,
 				undefined
 			);
 		});
@@ -827,6 +829,7 @@ describe('NewInstanceModal', () => {
 				undefined,
 				undefined,
 				{ enabled: false, remoteId: null },
+				undefined,
 				undefined
 			);
 		});
@@ -876,6 +879,7 @@ describe('NewInstanceModal', () => {
 				undefined,
 				undefined,
 				{ enabled: false, remoteId: null },
+				undefined,
 				undefined
 			);
 			expect(onClose).toHaveBeenCalled();
@@ -1388,6 +1392,7 @@ describe('NewInstanceModal', () => {
 				undefined,
 				undefined,
 				{ enabled: false, remoteId: null },
+				undefined,
 				undefined
 			);
 		});
@@ -1536,6 +1541,7 @@ describe('NewInstanceModal', () => {
 				undefined,
 				undefined,
 				{ enabled: false, remoteId: null },
+				undefined,
 				undefined
 			);
 		});
@@ -2389,6 +2395,145 @@ describe('NewInstanceModal', () => {
 			expect(args[12]).toBe('xhigh');
 		});
 
+		it('forwards source.groupId through to onCreate so duplicates inherit the group (issue #827)', async () => {
+			const sourceSession: Session = {
+				id: 'session-grouped',
+				name: 'Grouped Agent',
+				toolType: 'claude-code',
+				cwd: '/test/project',
+				projectRoot: '/test/project',
+				fullPath: '/test/project',
+				state: 'idle',
+				inputMode: 'ai',
+				aiPid: 0,
+				terminalPid: 0,
+				port: 3000,
+				aiTabs: [],
+				activeTabId: 'tab-1',
+				closedTabHistory: [],
+				shellLogs: [],
+				executionQueue: [],
+				contextUsage: 0,
+				workLog: [],
+				isGitRepo: false,
+				changedFiles: [],
+				fileTree: [],
+				fileExplorerExpanded: [],
+				fileExplorerScrollPos: 0,
+				isLive: false,
+				groupId: 'group-abc',
+			} as Session;
+
+			vi.mocked(window.maestro.agents.detect).mockResolvedValue([
+				createAgentConfig({ id: 'claude-code', name: 'Claude Code', available: true }),
+			]);
+
+			render(
+				<NewInstanceModal
+					isOpen={true}
+					onClose={onClose}
+					onCreate={onCreate}
+					theme={theme}
+					existingSessions={[]}
+					sourceSession={sourceSession}
+				/>
+			);
+
+			await waitFor(() => {
+				const nameInput = screen.getByLabelText('Agent Name') as HTMLInputElement;
+				expect(nameInput.value).toBe('Grouped Agent (Copy)');
+			});
+
+			await act(async () => {
+				fireEvent.click(screen.getByText('Create Agent'));
+			});
+
+			// 14th positional arg (index 13) is groupId; must equal source.groupId so
+			// the duplicate lands in the same group as the original.
+			expect(onCreate).toHaveBeenCalled();
+			const args = onCreate.mock.calls[0];
+			expect(args[13]).toBe('group-abc');
+		});
+
+		it('does not clobber the user-typed name when sourceSession reference changes (issue #827)', async () => {
+			// Regression: AppModals derives sourceSession from a useMemo over the
+			// sessions array. Any unrelated sessions update produces a new object
+			// reference. The pre-fill effect must depend on sourceSession?.id, not
+			// the full object, otherwise it re-runs and overwrites whatever the
+			// user has typed in the name field.
+			const baseSession: Session = {
+				id: 'session-1',
+				name: 'Original Agent',
+				toolType: 'claude-code',
+				cwd: '/test/project',
+				projectRoot: '/test/project',
+				fullPath: '/test/project',
+				state: 'idle',
+				inputMode: 'ai',
+				aiPid: 0,
+				terminalPid: 0,
+				port: 3000,
+				aiTabs: [],
+				activeTabId: 'tab-1',
+				closedTabHistory: [],
+				shellLogs: [],
+				executionQueue: [],
+				contextUsage: 0,
+				workLog: [],
+				isGitRepo: false,
+				changedFiles: [],
+				fileTree: [],
+				fileExplorerExpanded: [],
+				fileExplorerScrollPos: 0,
+				isLive: false,
+			} as Session;
+
+			vi.mocked(window.maestro.agents.detect).mockResolvedValue([
+				createAgentConfig({ id: 'claude-code', name: 'Claude Code', available: true }),
+			]);
+
+			const { rerender } = render(
+				<NewInstanceModal
+					isOpen={true}
+					onClose={onClose}
+					onCreate={onCreate}
+					theme={theme}
+					existingSessions={[]}
+					sourceSession={baseSession}
+				/>
+			);
+
+			await waitFor(() => {
+				const nameInput = screen.getByLabelText('Agent Name') as HTMLInputElement;
+				expect(nameInput.value).toBe('Original Agent (Copy)');
+			});
+
+			// User edits the pre-filled name.
+			const nameInput = screen.getByLabelText('Agent Name') as HTMLInputElement;
+			await act(async () => {
+				fireEvent.change(nameInput, { target: { value: 'My New Agent' } });
+			});
+			expect(nameInput.value).toBe('My New Agent');
+
+			// Parent re-renders with a NEW object reference for the same source
+			// session (simulating the upstream useMemo recomputing when the
+			// sessions array updates). The user-typed value must be preserved.
+			await act(async () => {
+				rerender(
+					<NewInstanceModal
+						isOpen={true}
+						onClose={onClose}
+						onCreate={onCreate}
+						theme={theme}
+						existingSessions={[]}
+						sourceSession={{ ...baseSession }}
+					/>
+				);
+			});
+
+			expect((screen.getByLabelText('Agent Name') as HTMLInputElement).value).toBe('My New Agent');
+		});
+
 		it('should display SSH selector even when no agent is selected', async () => {
 			// This tests the bug where SSH section was hidden when no agents were available
 			vi.mocked(window.maestro.agents.detect).mockResolvedValue([
@@ -2552,6 +2697,7 @@ describe('NewInstanceModal', () => {
 					syncHistory: false,
 					workingDirOverride: '/test/path',
 				},
+				undefined,
 				undefined
 			);
 		});
@@ -2777,6 +2923,7 @@ describe('NewInstanceModal', () => {
 					remoteId: 'remote-1',
 					workingDirOverride: '/home/devuser/my-project',
 				}),
+				undefined,
 				undefined
 			);
 		});
@@ -2888,6 +3035,7 @@ describe('NewInstanceModal', () => {
 					remoteId: 'remote-1',
 					workingDirOverride: '/explicit/override/path',
 				}),
+				undefined,
 				undefined
 			);
 		});

--- a/src/__tests__/renderer/hooks/useSessionCrud.test.ts
+++ b/src/__tests__/renderer/hooks/useSessionCrud.test.ts
@@ -407,6 +407,33 @@ describe('useSessionCrud', () => {
 			expect(session.customEffort).toBe('high');
 		});
 
+		it('inherits groupId on the new session when provided (issue #827)', async () => {
+			const deps = createDeps();
+			const { result } = renderHook(() => useSessionCrud(deps));
+
+			await act(async () => {
+				await result.current.createNewSession(
+					'claude-code',
+					'/test/project',
+					'Duplicated Agent',
+					undefined,
+					undefined,
+					undefined,
+					undefined,
+					undefined,
+					undefined,
+					undefined,
+					undefined,
+					undefined,
+					undefined,
+					'group-abc'
+				);
+			});
+
+			const session = useSessionStore.getState().sessions[0];
+			expect(session.groupId).toBe('group-abc');
+		});
+
 		it('sets input mode to terminal for terminal agent', async () => {
 			const deps = createDeps();
 			const { result } = renderHook(() => useSessionCrud(deps));

--- a/src/renderer/components/AppModals/AppModals.tsx
+++ b/src/renderer/components/AppModals/AppModals.tsx
@@ -105,7 +105,9 @@ export interface AppModalsProps {
 			enabled: boolean;
 			remoteId: string | null;
 			workingDirOverride?: string;
-		}
+		},
+		customEffort?: string,
+		groupId?: string
 	) => void;
 	existingSessions: Session[];
 	duplicatingSessionId?: string | null; // Session ID to duplicate from

--- a/src/renderer/components/AppModals/AppSessionModals.tsx
+++ b/src/renderer/components/AppModals/AppSessionModals.tsx
@@ -41,7 +41,8 @@ export interface AppSessionModalsProps {
 			remoteId: string | null;
 			workingDirOverride?: string;
 		},
-		customEffort?: string
+		customEffort?: string,
+		groupId?: string
 	) => void;
 	existingSessions: Session[];
 	sourceSession?: Session; // For agent duplication

--- a/src/renderer/components/NewInstanceModal/NewInstanceModal.tsx
+++ b/src/renderer/components/NewInstanceModal/NewInstanceModal.tsx
@@ -414,6 +414,10 @@ export function NewInstanceModal({
 						shareHistoryToProjectDir: sshRemoteConfig?.shareHistoryToProjectDir,
 					};
 
+		// Inherit the source session's group when duplicating so the copy lands
+		// alongside the original (issue #827).
+		const inheritedGroupId = sourceSession?.groupId;
+
 		onCreate(
 			selectedAgent,
 			expandedWorkingDir,
@@ -427,7 +431,8 @@ export function NewInstanceModal({
 			agentCustomContextWindow,
 			agentCustomProviderPath,
 			sessionSshRemoteConfig,
-			agentCustomEffort
+			agentCustomEffort,
+			inheritedGroupId
 		);
 		onClose();
 
@@ -461,6 +466,7 @@ export function NewInstanceModal({
 		expandTilde,
 		handleWorkingDirChange,
 		existingSessions,
+		sourceSession?.groupId,
 	]);
 
 	// Check if form is valid for submission
@@ -526,6 +532,9 @@ export function NewInstanceModal({
 	}, [agents]);
 
 	// Effects - load agents and optionally pre-fill from source session
+	// Dependency uses sourceSession?.id (not the full object) so unrelated
+	// `sessions` store updates don't re-fire pre-fill and clobber what the
+	// user has typed (issue #827).
 	useEffect(() => {
 		if (isOpen) {
 			// Pass sourceSession to loadAgents to handle pre-fill AFTER agents are loaded
@@ -540,7 +549,7 @@ export function NewInstanceModal({
 			// Reset warning acknowledgment when modal opens
 			setDirectoryWarningAcknowledged(false);
 		}
-	}, [isOpen, sourceSession]);
+	}, [isOpen, sourceSession?.id]);
 
 	// Load SSH remote configurations independently of agent detection
 	// This ensures SSH remotes are available even if agent detection fails

--- a/src/renderer/components/NewInstanceModal/types.ts
+++ b/src/renderer/components/NewInstanceModal/types.ts
@@ -50,7 +50,8 @@ export interface NewInstanceModalProps {
 		customContextWindow?: number,
 		customProviderPath?: string,
 		sessionSshRemoteConfig?: SessionSshRemoteConfig,
-		customEffort?: string
+		customEffort?: string,
+		groupId?: string
 	) => void;
 	theme: Theme;
 	existingSessions: Session[];

--- a/src/renderer/hooks/session/useSessionCrud.ts
+++ b/src/renderer/hooks/session/useSessionCrud.ts
@@ -70,7 +70,8 @@ export interface UseSessionCrudReturn {
 			remoteId: string | null;
 			workingDirOverride?: string;
 		},
-		customEffort?: string
+		customEffort?: string,
+		groupId?: string
 	) => Promise<void>;
 	/** Opens the delete agent confirmation modal */
 	deleteSession: (id: string) => void;
@@ -145,7 +146,8 @@ export function useSessionCrud(deps: UseSessionCrudDeps): UseSessionCrudReturn {
 				remoteId: string | null;
 				workingDirOverride?: string;
 			},
-			customEffort?: string
+			customEffort?: string,
+			groupId?: string
 		) => {
 			try {
 				// Get agent definition to get correct command
@@ -269,6 +271,7 @@ export function useSessionCrud(deps: UseSessionCrudDeps): UseSessionCrudReturn {
 					customProviderPath,
 					customEffort: customEffort?.trim() || undefined,
 					sessionSshRemoteConfig,
+					groupId,
 					autoRunFolderPath: `${workingDir}/${PLAYBOOKS_DIR}`,
 				};
 


### PR DESCRIPTION
Fixes #827 — two related bugs in the **Duplicate agent** flow.

## Summary

### Bug 1 — Renamed name reverts to "(Copy)" on save

`NewInstanceModal`'s pre-fill effect depended on the full `sourceSession` object. `sourceSession` is computed in `AppModals.tsx` via `useMemo(() => sessions.find(...), [duplicatingSessionId, sessions])`. Whenever the `sessions` store updates (which happens for many unrelated reasons during modal interaction), the memo returns a *new object reference* even though the underlying data is unchanged. That re-fires the pre-fill effect and `setInstanceName(\`${source.name} (Copy)\`)` clobbers whatever the user has typed.

**Fix:** Change the effect dependency from `sourceSession` to `sourceSession?.id`. The effect now only re-fires when the source's *identity* changes, not on every parent re-render.

### Bug 2 — Group not inherited

`sourceSession.groupId` was never propagated through the duplication flow. The new agent always landed at the top level even when the original belonged to a group.

**Fix:** Threaded an optional `groupId` argument through:
- `NewInstanceModal.handleCreate` defaults it to `sourceSession?.groupId`
- `onCreate` / `onCreateSession` callback signatures (`NewInstanceModal/types.ts`, `AppSessionModals.tsx`, `AppModals.tsx`)
- `useSessionCrud.createNewSession` accepts and applies it on the new `Session`

This matches the existing pattern used by `useMergeSession` and `useSendToAgent`.

## Test plan

Automated:

- [x] Added regression test: name field is preserved when `sourceSession` reference changes (`NewInstanceModal.test.tsx`)
- [x] Added test: `groupId` from `sourceSession` is forwarded to `onCreate` as the 14th positional arg
- [x] Added test: `useSessionCrud.createNewSession` writes `groupId` onto the new `Session`
- [x] Updated all existing `expect(onCreate).toHaveBeenCalledWith(...)` assertions to account for the new trailing `groupId` arg
- [x] All 76 `NewInstanceModal` tests + all 53 `useSessionCrud` tests pass
- [x] Prettier and ESLint clean

Manual:

- [ ] Move an agent into a group → right-click → **Duplicate...** → confirm the duplicate lands in the same group
- [ ] Open **Duplicate...** → edit the pre-filled name → wait for any unrelated session update (e.g. another agent changes state) → confirm the typed name is not reset
- [ ] Click **Create Agent** → confirm the saved name matches what was typed (not `… (Copy)`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sessions can now be assigned to groups for improved organization and management
  * Group assignments are automatically preserved when duplicating sessions

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RunMaestro/Maestro/pull/979)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->