### PR TITLE
fix(mobile): add Claude cache partitions to displayed input tokens (#844)

### DIFF
--- a/src/__tests__/web/mobile/MobileHistoryPanel.test.tsx
+++ b/src/__tests__/web/mobile/MobileHistoryPanel.test.tsx
@@ -916,6 +916,70 @@ describe('MobileHistoryPanel', () => {
 			expect(screen.getByText('Out: 750')).toBeInTheDocument();
 		});
 
+		// Issue #844: on resumed Claude sessions, inputTokens carries only the
+		// uncached delta — the cache partitions must be added back so the
+		// detail view does not display single-digit values for a long session.
+		it('adds Claude cache partitions to the detail view input total', async () => {
+			const entries = [
+				createAutoEntry({
+					usageStats: {
+						inputTokens: 6,
+						outputTokens: 500,
+						cacheReadInputTokens: 45_000,
+						cacheCreationInputTokens: 3_000,
+						totalCostUsd: 0.5,
+						contextWindow: 200_000,
+					},
+				}),
+			];
+			global.fetch = vi.fn().mockResolvedValue({
+				ok: true,
+				json: () => Promise.resolve({ entries }),
+			});
+
+			render(<MobileHistoryPanel onClose={vi.fn()} toolType="claude-code" />);
+
+			await act(async () => {
+				await vi.runAllTimersAsync();
+			});
+
+			fireEvent.click(screen.getByRole('button', { name: /AUTO entry from/i }));
+
+			// 6 + 45,000 + 3,000 = 48,006
+			expect(screen.getByText('In: 48,006')).toBeInTheDocument();
+			expect(screen.getByText('Out: 500')).toBeInTheDocument();
+		});
+
+		it('does not double-count cache fields for Codex in detail view', async () => {
+			const entries = [
+				createAutoEntry({
+					usageStats: {
+						inputTokens: 10_000,
+						outputTokens: 1_000,
+						cacheReadInputTokens: 8_000,
+						cacheCreationInputTokens: 0,
+						totalCostUsd: 0.25,
+						contextWindow: 128_000,
+					},
+				}),
+			];
+			global.fetch = vi.fn().mockResolvedValue({
+				ok: true,
+				json: () => Promise.resolve({ entries }),
+			});
+
+			render(<MobileHistoryPanel onClose={vi.fn()} toolType="codex" />);
+
+			await act(async () => {
+				await vi.runAllTimersAsync();
+			});
+
+			fireEvent.click(screen.getByRole('button', { name: /AUTO entry from/i }));
+
+			// Codex: inputTokens already includes cached input; expect raw value.
+			expect(screen.getByText('In: 10,000')).toBeInTheDocument();
+		});
+
 		it('shows cost in detail view', async () => {
 			const entries = [
 				createAutoEntry({

--- a/src/__tests__/web/mobile/SessionStatusBanner.test.tsx
+++ b/src/__tests__/web/mobile/SessionStatusBanner.test.tsx
@@ -746,6 +746,41 @@ describe('SessionStatusBanner', () => {
 
 			expect(screen.getByText('500')).toBeInTheDocument();
 		});
+
+		// Issue #844: on resumed Claude sessions, inputTokens is only the uncached
+		// delta. The cache partitions must be added back so the displayed total
+		// reflects the real input size rather than single-digit values.
+		it('adds Claude cache partitions to displayed input for the total', () => {
+			const usageStats = createUsageStats({
+				inputTokens: 6,
+				outputTokens: 500,
+				cacheReadInputTokens: 45_000,
+				cacheCreationInputTokens: 3_000,
+			});
+			const session = createSession({ usageStats, toolType: 'claude-code' as any });
+
+			render(<SessionStatusBanner session={session} />);
+
+			// 6 + 45000 + 3000 + 500 (output) = 48,506 → '48.5K'
+			expect(screen.getByText('48.5K')).toBeInTheDocument();
+			expect(
+				screen.getByTitle(/Input: 48,006 \| Output: 500 \| Total: 48,506 tokens/)
+			).toBeInTheDocument();
+		});
+
+		it('does not add cache fields for Codex (already included in inputTokens)', () => {
+			const usageStats = createUsageStats({
+				inputTokens: 10_000,
+				outputTokens: 1_000,
+				cacheReadInputTokens: 8_000,
+			});
+			const session = createSession({ usageStats, toolType: 'codex' as any });
+
+			render(<SessionStatusBanner session={session} />);
+
+			// 10000 + 1000 = 11,000 → '11.0K' (cacheRead not double-counted)
+			expect(screen.getByText('11.0K')).toBeInTheDocument();
+		});
 	});
 
 	describe('ThinkingIndicator component', () => {

--- a/src/web/mobile/MobileHistoryPanel.tsx
+++ b/src/web/mobile/MobileHistoryPanel.tsx
@@ -21,6 +21,7 @@ import { HistoryEntry } from '../../shared/types';
 import { stripAnsiCodes } from '../../shared/stringUtils';
 import { formatElapsedTime, formatTimestamp } from '../../shared/formatters';
 import { useSwipeGestures } from '../hooks/useSwipeGestures';
+import { calculateDisplayInputTokens } from '../../renderer/utils/contextUsage';
 
 const formatTime = (timestamp: number) => formatTimestamp(timestamp, 'smart');
 
@@ -275,6 +276,11 @@ interface HistoryDetailViewProps {
 	totalCount: number;
 	/** Navigate to a specific index */
 	onNavigate: (index: number) => void;
+	/**
+	 * Active session's agent type. Used to compute display input tokens
+	 * correctly per agent (see issue #844).
+	 */
+	toolType?: string;
 }
 
 function HistoryDetailView({
@@ -283,6 +289,7 @@ function HistoryDetailView({
 	currentIndex,
 	totalCount,
 	onNavigate,
+	toolType,
 }: HistoryDetailViewProps) {
 	const colors = useThemeColors();
 
@@ -604,7 +611,8 @@ function HistoryDetailView({
 							}}
 						>
 							<span style={{ color: colors.accent }}>
-								In: {(entry.usageStats.inputTokens ?? 0).toLocaleString('en-US')}
+								In:{' '}
+								{calculateDisplayInputTokens(entry.usageStats, toolType).toLocaleString('en-US')}
 							</span>
 							<span style={{ color: colors.success }}>
 								Out: {(entry.usageStats.outputTokens ?? 0).toLocaleString('en-US')}
@@ -815,6 +823,11 @@ export interface MobileHistoryPanelProps {
 	projectPath?: string;
 	/** Current active session ID (for filtering) */
 	sessionId?: string;
+	/**
+	 * Active session's agent type (e.g. `claude-code`, `codex`).
+	 * Used to compute display input tokens correctly per agent (see issue #844).
+	 */
+	toolType?: string;
 	/** Initial filter state */
 	initialFilter?: 'all' | 'AUTO' | 'USER';
 	/** Initial search query */
@@ -841,6 +854,7 @@ export function MobileHistoryPanel({
 	onClose,
 	projectPath,
 	sessionId,
+	toolType,
 	initialFilter = 'all',
 	initialSearchQuery = '',
 	initialSearchOpen = false,
@@ -1385,6 +1399,7 @@ export function MobileHistoryPanel({
 					currentIndex={selectedIndex}
 					totalCount={filteredEntries.length}
 					onNavigate={handleNavigate}
+					toolType={toolType}
 				/>
 			)}
 		</>

--- a/src/web/mobile/SessionStatusBanner.tsx
+++ b/src/web/mobile/SessionStatusBanner.tsx
@@ -33,7 +33,10 @@ import {
 import { stripAnsiCodes } from '../../shared/stringUtils';
 // SYNC: Uses estimateContextUsage() from shared/contextUsage.ts
 // See that file for the canonical formula and all locations that must stay in sync.
-import { estimateContextUsage } from '../../renderer/utils/contextUsage';
+import {
+	calculateDisplayInputTokens,
+	estimateContextUsage,
+} from '../../renderer/utils/contextUsage';
 
 /**
  * Props for SessionStatusBanner component
@@ -270,8 +273,18 @@ const ElapsedTimeDisplay = memo(function ElapsedTimeDisplay({
 /**
  * TokenCount component - displays total token count in a compact format
  * Shows total tokens (input + output) for mobile-friendly display.
+ *
+ * The input total is computed via `calculateDisplayInputTokens`, which adds the
+ * Claude cache partitions back so resumed sessions don't show single-digit
+ * uncached deltas as if they were the full input (see issue #844).
  */
-function TokenCount({ usageStats }: { usageStats?: UsageStats | null }) {
+function TokenCount({
+	usageStats,
+	toolType,
+}: {
+	usageStats?: UsageStats | null;
+	toolType?: string;
+}) {
 	const colors = useThemeColors();
 
 	// Don't render if no usage stats or no token data
@@ -279,7 +292,7 @@ function TokenCount({ usageStats }: { usageStats?: UsageStats | null }) {
 		return null;
 	}
 
-	const inputTokens = usageStats.inputTokens ?? 0;
+	const inputTokens = calculateDisplayInputTokens(usageStats, toolType);
 	const outputTokens = usageStats.outputTokens ?? 0;
 	const totalTokens = inputTokens + outputTokens;
 
@@ -718,7 +731,7 @@ export function SessionStatusBanner({
 						<CostTracker usageStats={session.usageStats} />
 
 						{/* Token count (compact, total only for mobile) */}
-						<TokenCount usageStats={session.usageStats} />
+						<TokenCount usageStats={session.usageStats} toolType={session.toolType} />
 
 						{/* Elapsed time when thinking */}
 						{isThinking && thinkingStartTime && (


### PR DESCRIPTION
## Summary

Finishes the fix for issue #844 on the mobile/web side. The desktop UI already routes input-token displays through `calculateDisplayInputTokens` (`HistoryDetailModal`, `MainPanelHeader`), but two mobile surfaces still rendered the raw `usageStats.inputTokens` field — so resumed Claude sessions kept showing the single-digit uncached delta as if it were the full input size.

Two surfaces fixed:

- `src/web/mobile/SessionStatusBanner.tsx` — `TokenCount` now accepts `toolType` and routes the input total through `calculateDisplayInputTokens`. The parent already had `session.toolType`, so threading it down was a one-line change.
- `src/web/mobile/MobileHistoryPanel.tsx` — `HistoryDetailView` accepts `toolType` and uses the helper at the In/Out display site. `MobileHistoryPanelProps` gains a `toolType?` prop so callers can pass the active session's agent type.

For Claude (the formula default), the helper adds `cacheReadInputTokens + cacheCreationInputTokens` back so the displayed input reflects the real input size. For Codex (`COMBINED_CONTEXT_AGENTS`) it returns `inputTokens` unchanged because Codex already includes cached input there — no double counting.

## Test plan

- `src/__tests__/web/mobile/SessionStatusBanner.test.tsx` — added two cases:
  - Claude: `inputTokens: 6, cacheReadInputTokens: 45_000, cacheCreationInputTokens: 3_000, outputTokens: 500` → displayed total `48.5K`, title shows `Input: 48,006 | Output: 500 | Total: 48,506 tokens`.
  - Codex: `inputTokens: 10_000, cacheReadInputTokens: 8_000, outputTokens: 1_000` → displayed total `11.0K` (cache not double-counted).
- `src/__tests__/web/mobile/MobileHistoryPanel.test.tsx` — added two cases mirroring the same scenarios in the detail view (`In: 48,006` for Claude, `In: 10,000` for Codex).
- All 183 tests across both files pass; no existing assertions changed (existing tests had no cache fields, so the Claude formula yields the same value).

### Manual verification

- [ ] Open the mobile UI on a long-running resumed Claude session; confirm the status banner token count is no longer a single-digit/tiny value.
- [ ] Open the mobile history detail view on a resumed Claude entry; confirm the `In:` value reflects the full input (uncached + cache hits + cache writes).
- [ ] Same flows on a Codex session: input total should match the API's `input_tokens` (cached input not double-counted).

Closes #844 (mobile/web side; desktop side was previously addressed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test cases validating token count calculations in detail views and status banners, ensuring proper handling of cached partitions for resumed Claude sessions versus other agent types.

* **Bug Fixes**
  * Fixed token display in session history panels and status banners to correctly include cached tokens for resumed sessions while preventing double-counting for other agent types.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RunMaestro/Maestro/pull/980)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->