### PR TITLE
fix(cue): harden cue.yaml chain validation + topo-sort chain subs in pipeline editor

### DIFF
--- a/docs/maestro-cue-configuration.md
+++ b/docs/maestro-cue-configuration.md
@@ -238,8 +238,9 @@ If an AI agent writes `cue.yaml` directly (without using the visual editor), inc
 
 1. Initial trigger subscription uses `action: command` with a valid `command` object.
 2. The downstream `agent.completed` subscription includes `source_sub` pointing to that command subscription name.
-3. Keep `pipeline_name` consistent across all subs in the pipeline.
-4. Keep per-node identity fields (`target_node_key`, `fan_out_node_keys`) stable once created.
+3. For fan-in chains, when `source_sub` / `source_session` / `source_session_ids` are arrays, all three must be the **same length and positionally aligned**: index `i` in each array refers to the same upstream source. The validator rejects mismatched lengths.
+4. Keep `pipeline_name` consistent across all subs in the pipeline.
+5. Keep per-node identity fields (`target_node_key`, `fan_out_node_keys`) stable once created.
 
 Example:
 

--- a/src/__tests__/main/cue/cue-yaml-loader.test.ts
+++ b/src/__tests__/main/cue/cue-yaml-loader.test.ts
@@ -819,6 +819,31 @@ subscriptions:
 			);
 		});
 
+		it('rejects source_sub string when source_session is an array', () => {
+			// Symmetric to the previous test — guards the opposite shape-mismatch
+			// branch (`source_session` is an array but `source_sub` is a plain
+			// string) so the error message stays specific.
+			const result = validateCueConfig({
+				subscriptions: [
+					{
+						name: 'fan-in-invalid-shape-2',
+						event: 'agent.completed',
+						source_session: ['A', 'B'],
+						source_sub: 'chain-a',
+						prompt: '{{CUE_SOURCE_OUTPUT}}',
+					},
+				],
+			});
+			expect(result.valid).toBe(false);
+			expect(result.errors).toEqual(
+				expect.arrayContaining([
+					expect.stringContaining(
+						'"source_sub" must be an array when "source_session" is an array'
+					),
+				])
+			);
+		});
+
 		it('does not emit a misleading source_sub/source_session shape error when source_session is missing', () => {
 			// Regression: the type-shape consistency check used to fire
 			// "source_sub must be a string when source_session is a string" even

--- a/src/__tests__/renderer/components/CuePipelineEditor/utils/yamlToPipeline.errorNodes.test.ts
+++ b/src/__tests__/renderer/components/CuePipelineEditor/utils/yamlToPipeline.errorNodes.test.ts
@@ -251,4 +251,92 @@ describe('yamlToPipeline — error nodes for unresolved agents', () => {
 		expect(summarize(p1.nodes)).toEqual(summarize(p2.nodes));
 		expect(summarizeEdges(p1.nodes, p1.edges)).toEqual(summarizeEdges(p2.nodes, p2.edges));
 	});
+
+	it('emits a missing-source error node when source_sub names an unknown subscription (agent target)', () => {
+		// Greptile #981: locks in the visible-error path when `source_sub`
+		// references a subscription that is NOT in the current pipeline's
+		// `knownSubNames` set. Without this test a future refactor could
+		// silently revert to the session-name fallback and the canvas would
+		// quietly wire to whatever agent happens to share the source name.
+		const subs: CueSubscription[] = [
+			{
+				name: 'pipe',
+				event: 'time.heartbeat',
+				enabled: true,
+				prompt: '',
+				interval_minutes: 5,
+				agent_id: 'sess-up',
+			},
+			{
+				name: 'pipe-chain-1',
+				event: 'agent.completed',
+				enabled: true,
+				prompt: 'follow up',
+				source_session: ['Up'],
+				source_session_ids: ['sess-up'],
+				// References a subscription that does NOT exist in this
+				// pipeline — must produce an error node, NOT a phantom agent.
+				source_sub: ['Stale Ghost Sub'],
+				agent_id: 'sess-down',
+			},
+		];
+		const sessions = makeSessions([
+			['sess-up', 'Up'],
+			['sess-down', 'Down'],
+		]);
+
+		const [pipeline] = subscriptionsToPipelines(subs, sessions);
+		const errs = errorNodes(pipeline.nodes);
+		expect(errs).toHaveLength(1);
+		const data = errs[0].data as ErrorNodeData;
+		expect(data.reason).toBe('missing-source');
+		expect(data.subscriptionName).toBe('pipe-chain-1');
+		expect(data.message).toContain('Stale Ghost Sub');
+		// The downstream target ("Down") must wire to the error node, not to
+		// the "Up" agent that shares the source name. Surfacing the gap on the
+		// canvas is the whole point of this branch.
+		const downstream = pipeline.nodes.find(
+			(n) => n.type === 'agent' && (n.data as { sessionName?: string }).sessionName === 'Down'
+		);
+		expect(downstream).toBeDefined();
+		const incomingToDownstream = pipeline.edges.filter((e) => e.target === downstream!.id);
+		expect(incomingToDownstream).toHaveLength(1);
+		expect(incomingToDownstream[0].source).toBe(errs[0].id);
+	});
+
+	it('emits a missing-source error node for a command-target chain when source_sub is unknown', () => {
+		// Same regression as above for the command-action branch — the new
+		// `!knownSubNames.has(subRef)` guard exists in two places in
+		// `yamlToPipeline.ts` and both should be locked in.
+		const subs: CueSubscription[] = [
+			{
+				name: 'pipe',
+				event: 'time.heartbeat',
+				enabled: true,
+				prompt: '',
+				interval_minutes: 5,
+				agent_id: 'sess-up',
+			},
+			{
+				name: 'pipe-cmd-chain',
+				event: 'agent.completed',
+				enabled: true,
+				prompt: '',
+				source_session: ['Up'],
+				source_session_ids: ['sess-up'],
+				source_sub: ['Stale Ghost Sub'],
+				agent_id: 'sess-up',
+				action: 'command',
+				command: { mode: 'shell', shell: 'echo hi' },
+			},
+		];
+		const sessions = makeSessions([['sess-up', 'Up']]);
+
+		const [pipeline] = subscriptionsToPipelines(subs, sessions);
+		const errs = errorNodes(pipeline.nodes);
+		expect(errs).toHaveLength(1);
+		const data = errs[0].data as ErrorNodeData;
+		expect(data.reason).toBe('missing-source');
+		expect(data.message).toContain('Stale Ghost Sub');
+	});
 });

--- a/src/__tests__/renderer/components/CuePipelineEditor/utils/yamlToPipeline.test.ts
+++ b/src/__tests__/renderer/components/CuePipelineEditor/utils/yamlToPipeline.test.ts
@@ -1783,4 +1783,114 @@ describe('subscriptionsToPipelines — chain subs resolve upstream via source_su
 		expect(edgeExists(trigger, cmd1)).toBe(true);
 		expect(edgeExists(trigger, cmd2)).toBe(true);
 	});
+
+	// Regression: when chain subs carry `target_node_key` (the keyed dedup
+	// path in `getOrCreateAgentNode`), the legacy sessionName fallback is
+	// skipped. If chain-2 (fan-in) is processed before chain-4 because of
+	// the chain-index sort, chain-2's source_sub → chain-4 lookup fails to
+	// find the not-yet-created chain-4 target node and falls back to a
+	// session-name resolver that invents a phantom agent. Then chain-4's
+	// keyed target creates a SECOND agent for the same session — and the
+	// real chain-4 target ends up disconnected from chain-2 on the canvas.
+	// Reproduces the Obsidian Daily Pipe shape from the user bug report.
+	it('keeps fan-in wiring intact when chains carry target_node_key and chain-index ordering misranks dependencies', () => {
+		const subs: CueSubscription[] = [
+			{
+				name: 'Pipeline 1-cmd-a',
+				event: 'time.scheduled',
+				enabled: true,
+				prompt: './script1.sh',
+				action: 'command',
+				command: { mode: 'shell', shell: './script1.sh' },
+				schedule_times: ['07:00'],
+				agent_id: 'session-0',
+				pipeline_name: 'Pipeline 1',
+				target_node_key: 'cmd-a-key',
+			},
+			{
+				name: 'Pipeline 1-cmd-b',
+				event: 'time.scheduled',
+				enabled: true,
+				prompt: './script2.sh',
+				action: 'command',
+				command: { mode: 'shell', shell: './script2.sh' },
+				schedule_times: ['07:00'],
+				agent_id: 'session-1',
+				pipeline_name: 'Pipeline 1',
+				target_node_key: 'cmd-b-key',
+			},
+			{
+				name: 'Pipeline 1-chain-1',
+				event: 'agent.completed',
+				enabled: true,
+				prompt: 'report output',
+				source_session: 'Cue Test 1',
+				source_session_ids: 'session-0',
+				source_sub: 'Pipeline 1-cmd-a',
+				agent_id: 'session-0',
+				pipeline_name: 'Pipeline 1',
+				target_node_key: 'chain-1-key',
+			},
+			{
+				// Fan-in (chain-2) is misranked under chain-index sort:
+				// it sources chain-4 (idx 4) but its own idx is 2.
+				name: 'Pipeline 1-chain-2',
+				event: 'agent.completed',
+				enabled: true,
+				prompt: 'aggregate',
+				source_session: ['Cue Test 1', 'Cue Test 2'],
+				source_session_ids: ['session-0', 'session-1'],
+				source_sub: ['Pipeline 1-chain-1', 'Pipeline 1-chain-4'],
+				agent_id: 'session-2',
+				pipeline_name: 'Pipeline 1',
+				target_node_key: 'chain-2-key',
+			},
+			{
+				name: 'Pipeline 1-chain-4',
+				event: 'agent.completed',
+				enabled: true,
+				prompt: 'report output',
+				source_session: 'Cue Test 2',
+				source_session_ids: 'session-1',
+				source_sub: 'Pipeline 1-cmd-b',
+				agent_id: 'session-1',
+				pipeline_name: 'Pipeline 1',
+				target_node_key: 'chain-4-key',
+			},
+		];
+		const sessions = makeSessions('Cue Test 1', 'Cue Test 2', 'Cue Test Main');
+
+		const pipelines = subscriptionsToPipelines(subs, sessions);
+		expect(pipelines).toHaveLength(1);
+		const p = pipelines[0];
+
+		const triggers = p.nodes.filter((n) => n.type === 'trigger');
+		const commands = p.nodes.filter((n) => n.type === 'command');
+		const agents = p.nodes.filter((n) => n.type === 'agent');
+		const errors = p.nodes.filter((n) => n.type === 'error');
+
+		expect(errors).toHaveLength(0);
+		expect(triggers).toHaveLength(1);
+		expect(commands).toHaveLength(2);
+		// Exactly three agents: Cue Test 1, Cue Test 2, Cue Test Main —
+		// no phantom duplicates from premature creation.
+		expect(agents).toHaveLength(3);
+		const agentNames = agents.map((a) => (a.data as AgentNodeData).sessionName).sort();
+		expect(agentNames).toEqual(['Cue Test 1', 'Cue Test 2', 'Cue Test Main']);
+
+		const cmdA = commands.find((n) => (n.data as CommandNodeData).name === 'Pipeline 1-cmd-a')!;
+		const cmdB = commands.find((n) => (n.data as CommandNodeData).name === 'Pipeline 1-cmd-b')!;
+		const a1 = agents.find((n) => (n.data as AgentNodeData).sessionName === 'Cue Test 1')!;
+		const a2 = agents.find((n) => (n.data as AgentNodeData).sessionName === 'Cue Test 2')!;
+		const main = agents.find((n) => (n.data as AgentNodeData).sessionName === 'Cue Test Main')!;
+
+		const edgeExists = (from: PipelineNode, to: PipelineNode) =>
+			p.edges.some((e) => e.source === from.id && e.target === to.id);
+
+		// Full chain must be connected end-to-end.
+		expect(edgeExists(cmdA, a1)).toBe(true);
+		expect(edgeExists(cmdB, a2)).toBe(true);
+		expect(edgeExists(a1, main)).toBe(true);
+		expect(edgeExists(a2, main)).toBe(true);
+	});
 });

--- a/src/renderer/components/CuePipelineEditor/utils/yamlToPipeline.ts
+++ b/src/renderer/components/CuePipelineEditor/utils/yamlToPipeline.ts
@@ -506,8 +506,18 @@ export function subscriptionsToPipelines(
 		// YAML write order:
 		//   1. Initial triggers first (so agents exist before their chain
 		//      consumers try to reference them).
-		//   2. Within chain subs, sort by chain index (matches the pipeline's
-		//      natural left-to-right flow).
+		//   2. Within chain subs, topologically sort by `source_sub` so a
+		//      chain that references another chain comes AFTER its source.
+		//      Chain index is only a TIE-BREAKER for ready subs and for the
+		//      cycle-fallback path — it does NOT reliably encode dependency
+		//      order. Example: chain-2 fan-in with source_sub=[chain-1,
+		//      chain-4] must come after chain-4 (index 4 > 2) so that
+		//      chain-2's source lookup finds chain-4's already-registered
+		//      target node in subNameToNode. Without that ordering, the
+		//      source lookup falls back to session-name resolution and
+		//      invents a premature agent node — and when chain-4 later
+		//      creates its own keyed target, the canvas ends up with a
+		//      disconnected phantom agent next to the real one.
 		//   3. Break ties on subscription name for total determinism.
 		// Without this, re-saving YAML in a different order used to visually
 		// swap agents that shared a session name — the "two agents swapped"
@@ -523,15 +533,85 @@ export function subscriptionsToPipelines(
 		// `-fanin` suffix as a very high chain index so fan-in always sorts
 		// last among non-initial subs.
 		const isLegacyFanIn = (name: string) => /-fanin$/.test(name);
-		const sorted = [...subs].sort((a, b) => {
-			const aInit = isInitialTrigger(a) ? 0 : 1;
-			const bInit = isInitialTrigger(b) ? 0 : 1;
-			if (aInit !== bInit) return aInit - bInit;
-			const aIdx = isLegacyFanIn(a.name) ? Number.MAX_SAFE_INTEGER : getChainIndex(a.name);
-			const bIdx = isLegacyFanIn(b.name) ? Number.MAX_SAFE_INTEGER : getChainIndex(b.name);
+		const chainPriority = (name: string): number =>
+			isLegacyFanIn(name) ? Number.MAX_SAFE_INTEGER : getChainIndex(name);
+		const tieBreak = (a: CueSubscription, b: CueSubscription): number => {
+			const aIdx = chainPriority(a.name);
+			const bIdx = chainPriority(b.name);
 			if (aIdx !== bIdx) return aIdx - bIdx;
 			return a.name.localeCompare(b.name);
-		});
+		};
+
+		const initialTriggerSubs: CueSubscription[] = [];
+		const chainSubsForSort: CueSubscription[] = [];
+		for (const sub of subs) {
+			if (isInitialTrigger(sub)) initialTriggerSubs.push(sub);
+			else chainSubsForSort.push(sub);
+		}
+		initialTriggerSubs.sort(tieBreak);
+
+		// Kahn's algorithm over chain subs, prioritising lowest chain index
+		// among ready candidates so the chain-index intuition still wins
+		// when it doesn't violate a real source_sub dependency. Only chain
+		// subs participate in the topology — initial-trigger subs (including
+		// command-action triggers) have already been added in the previous
+		// step and their `subNameToNode` entries are created by the trigger
+		// branch below before any chain sub runs.
+		const chainSubNames = new Set(chainSubsForSort.map((s) => s.name));
+		const chainByName = new Map(chainSubsForSort.map((s) => [s.name, s]));
+		const refsOf = (sub: CueSubscription): string[] => {
+			const raw = Array.isArray(sub.source_sub)
+				? sub.source_sub
+				: sub.source_sub
+					? [sub.source_sub]
+					: [];
+			return raw.filter((r): r is string => typeof r === 'string' && chainSubNames.has(r));
+		};
+		const indegree = new Map<string, number>();
+		const dependents = new Map<string, string[]>();
+		for (const sub of chainSubsForSort) {
+			indegree.set(sub.name, refsOf(sub).length);
+		}
+		for (const sub of chainSubsForSort) {
+			for (const ref of refsOf(sub)) {
+				const list = dependents.get(ref) ?? [];
+				list.push(sub.name);
+				dependents.set(ref, list);
+			}
+		}
+		const ready: string[] = chainSubsForSort
+			.filter((s) => (indegree.get(s.name) ?? 0) === 0)
+			.map((s) => s.name);
+		const orderedChainSubs: CueSubscription[] = [];
+		const consumed = new Set<string>();
+		while (ready.length > 0) {
+			// Pick the ready candidate with the lowest tie-break ranking.
+			let bestIdx = 0;
+			for (let i = 1; i < ready.length; i++) {
+				if (tieBreak(chainByName.get(ready[i])!, chainByName.get(ready[bestIdx])!) < 0) {
+					bestIdx = i;
+				}
+			}
+			const [name] = ready.splice(bestIdx, 1);
+			consumed.add(name);
+			orderedChainSubs.push(chainByName.get(name)!);
+			for (const dep of dependents.get(name) ?? []) {
+				const next = (indegree.get(dep) ?? 0) - 1;
+				indegree.set(dep, next);
+				if (next === 0) ready.push(dep);
+			}
+		}
+		// Cycle fallback: if any chain sub never reached indegree=0 (the
+		// YAML contains a self-referential source_sub loop), append the
+		// remaining subs in tie-break order so they still render — the
+		// loader stays lossy-but-visible instead of silently dropping them.
+		if (consumed.size < chainSubsForSort.length) {
+			const leftovers = chainSubsForSort.filter((s) => !consumed.has(s.name));
+			leftovers.sort(tieBreak);
+			orderedChainSubs.push(...leftovers);
+		}
+
+		const sorted: CueSubscription[] = [...initialTriggerSubs, ...orderedChainSubs];
 		const knownSubNames = new Set(sorted.map((s) => s.name));
 
 		let triggerCount = 0;


### PR DESCRIPTION
## Summary

- Hardens `cue.yaml` validation around command chains (`source_sub` required when an `agent.completed` sub has `action: command`; fan-in `source_sub`/`source_session` array shapes must match positionally).
- Adds visible error nodes in the Pipeline Editor when `source_sub` points at an unknown subscription, instead of silently falling back to session-name resolution.
- **Topologically sorts chain subs by `source_sub` dependencies in `yamlToPipeline.ts`.** The previous chain-index sort placed a fan-in chain before the chains it depended on; under `target_node_key`-keyed pipelines this produced a duplicate phantom agent node and left the real fan-in target disconnected on canvas. Chain index is retained as a tie-breaker for deterministic layout and as the cycle-fallback order.
- Documents the agent-authored Trigger → Cmd → Agent YAML checklist in `docs/maestro-cue-configuration.md`.

Reproduces the user-reported `Obsidian Daily Pipe` failure mode (Schedule → \`Digest/Git/Health Script\` (cmd) → per-agent chain → fan-in to Copilot) where the editor showed unresolved upstream links instead of the configured graph.

## Test plan

- [x] `vitest run src/__tests__/renderer/components/CuePipelineEditor/utils/yamlToPipeline.test.ts` — 47/47 pass, including new regression test `keeps fan-in wiring intact when chains carry target_node_key and chain-index ordering misranks dependencies` (failed before fix with 4 agent nodes; passes after with the expected 3).
- [x] `vitest run src/__tests__/renderer/components/CuePipelineEditor/utils/ src/__tests__/main/cue/cue-yaml-loader.test.ts` — 489/489 pass.
- [x] Type-check + prettier clean on changed files.
- [ ] Manually open a pipeline with a Trigger → Cmd → Agent → fan-in shape (each chain carrying a `target_node_key`) and confirm no phantom unresolved agent nodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error detection for fan-in chain configurations with missing source references, now explicitly flagging invalid source relationships.
  * Enhanced validation for array-based configuration fields to ensure consistent length alignment.

* **Documentation**
  * Updated configuration guide with validation rules for fan-in chains requiring positionally-aligned source mappings.

* **Tests**
  * Added comprehensive test coverage for chain subscription resolution and error scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RunMaestro/Maestro/pull/981)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->