### PR TITLE
fix(cue): answer get_cue_subscriptions from main, not via dead renderer IPC

### DIFF
--- a/src/__tests__/main/web-server/web-server-factory.test.ts
+++ b/src/__tests__/main/web-server/web-server-factory.test.ts
@@ -1019,4 +1019,133 @@ describe('web-server/web-server-factory', () => {
 			);
 		});
 	});
+
+	describe('Cue subscription callbacks', () => {
+		// Regression: previously this callback forwarded the request to the
+		// renderer via `remote:getCueSubscriptions` and waited 30 s for a
+		// response, but no renderer handler existed. Every `maestro-cli cue
+		// list` call timed out. Now it must call the injected graph-data
+		// dependency directly and flatten the result.
+		it('flattens engine graph data into CueSubscriptionInfo[] without any IPC bounce', async () => {
+			const getCueGraphData = vi.fn().mockReturnValue([
+				{
+					sessionId: 'agent-1',
+					sessionName: 'Obsidian Digest',
+					toolType: 'claude-code',
+					subscriptions: [
+						{
+							name: 'Digest Script',
+							event: 'time.scheduled',
+							enabled: true,
+							prompt: '',
+							schedule_times: ['07:00'],
+							action: 'command',
+						},
+						{
+							name: 'Obsidian Daily Pipe-chain-1',
+							event: 'agent.completed',
+							enabled: true,
+							prompt: 'follow up',
+							source_session: 'Obsidian Digest',
+							source_sub: 'Digest Script',
+						},
+					],
+				},
+				{
+					sessionId: 'agent-2',
+					sessionName: 'Obsidian Git',
+					toolType: 'claude-code',
+					subscriptions: [
+						{
+							name: 'Git Script',
+							event: 'time.scheduled',
+							enabled: false,
+							prompt: '',
+							schedule_times: ['07:00'],
+							action: 'command',
+						},
+					],
+				},
+			]);
+
+			const createWebServer = createWebServerFactory({ ...deps, getCueGraphData });
+			const server = createWebServer() as any;
+
+			expect(server.setGetCueSubscriptionsCallback).toHaveBeenCalledTimes(1);
+			const callback = server.setGetCueSubscriptionsCallback.mock.calls[0][0];
+
+			const all = await callback();
+			expect(getCueGraphData).toHaveBeenCalledTimes(1);
+			expect(all).toHaveLength(3);
+			expect(all[0]).toMatchObject({
+				id: 'agent-1::Digest Script',
+				name: 'Digest Script',
+				eventType: 'time.scheduled',
+				sessionId: 'agent-1',
+				sessionName: 'Obsidian Digest',
+				enabled: true,
+				schedule: '07:00',
+				triggerCount: 0,
+			});
+			expect(all[2]).toMatchObject({
+				name: 'Git Script',
+				sessionId: 'agent-2',
+				enabled: false,
+			});
+		});
+
+		it('filters by sessionId when one is supplied', async () => {
+			const getCueGraphData = vi.fn().mockReturnValue([
+				{
+					sessionId: 'agent-1',
+					sessionName: 'Obsidian Digest',
+					toolType: 'claude-code',
+					subscriptions: [
+						{
+							name: 'Digest Script',
+							event: 'time.scheduled',
+							enabled: true,
+							prompt: '',
+							schedule_times: ['07:00'],
+						},
+					],
+				},
+				{
+					sessionId: 'agent-2',
+					sessionName: 'Obsidian Git',
+					toolType: 'claude-code',
+					subscriptions: [
+						{
+							name: 'Git Script',
+							event: 'time.scheduled',
+							enabled: true,
+							prompt: '',
+							schedule_times: ['07:00'],
+						},
+					],
+				},
+			]);
+
+			const createWebServer = createWebServerFactory({ ...deps, getCueGraphData });
+			const server = createWebServer() as any;
+			const callback = server.setGetCueSubscriptionsCallback.mock.calls[0][0];
+
+			const filtered = await callback('agent-2');
+			expect(filtered).toHaveLength(1);
+			expect(filtered[0].sessionId).toBe('agent-2');
+		});
+
+		it('returns [] and warns when the engine dependency is missing', async () => {
+			const createWebServer = createWebServerFactory({ ...deps, getCueGraphData: undefined });
+			const server = createWebServer() as any;
+			const callback = server.setGetCueSubscriptionsCallback.mock.calls[0][0];
+
+			const result = await callback();
+			expect(result).toEqual([]);
+			expect(logger.warn).toHaveBeenCalledWith(
+				expect.stringContaining('getCueGraphData dependency not available'),
+				'WebServer'
+			);
+		});
+	});
 });

--- a/src/__tests__/main/web-server/web-server-factory.test.ts
+++ b/src/__tests__/main/web-server/web-server-factory.test.ts
@@ -1040,6 +1040,7 @@ describe('web-server/web-server-factory', () => {
 							prompt: '',
 							schedule_times: ['07:00'],
 							action: 'command',
+							pipeline_name: 'Obsidian Daily Pipe',
 						},
 						{
 							name: 'Obsidian Daily Pipe-chain-1',
@@ -1048,6 +1049,7 @@ describe('web-server/web-server-factory', () => {
 							prompt: 'follow up',
 							source_session: 'Obsidian Digest',
 							source_sub: 'Digest Script',
+							pipeline_name: 'Obsidian Daily Pipe',
 						},
 					],
 				},
@@ -1063,6 +1065,7 @@ describe('web-server/web-server-factory', () => {
 							prompt: '',
 							schedule_times: ['07:00'],
 							action: 'command',
+							pipeline_name: 'Obsidian Daily Pipe',
 						},
 					],
 				},
@@ -1078,7 +1081,10 @@ describe('web-server/web-server-factory', () => {
 			expect(getCueGraphData).toHaveBeenCalledTimes(1);
 			expect(all).toHaveLength(3);
 			expect(all[0]).toMatchObject({
-				id: 'agent-1::Digest Script',
+				// `sessionId::pipeline::name` — the pipeline discriminator
+				// prevents collisions when two pipelines in the same session
+				// each define a sub with the same name.
+				id: 'agent-1::Obsidian Daily Pipe::Digest Script',
 				name: 'Digest Script',
 				eventType: 'time.scheduled',
 				sessionId: 'agent-1',
@@ -1088,10 +1094,112 @@ describe('web-server/web-server-factory', () => {
 				triggerCount: 0,
 			});
 			expect(all[2]).toMatchObject({
+				id: 'agent-2::Obsidian Daily Pipe::Git Script',
 				name: 'Git Script',
 				sessionId: 'agent-2',
 				enabled: false,
 			});
+		});
+
+		it('disambiguates ids when two pipelines in the same session share a sub name', async () => {
+			// CodeRabbit #983 (major): without the pipeline discriminator,
+			// both rows would emit id `agent-1::Foo` and a downstream toggle
+			// would mutate the wrong subscription. Lock in distinct ids.
+			const getCueGraphData = vi.fn().mockReturnValue([
+				{
+					sessionId: 'agent-1',
+					sessionName: 'Worker',
+					toolType: 'claude-code',
+					subscriptions: [
+						{
+							name: 'Foo',
+							event: 'time.heartbeat',
+							enabled: true,
+							prompt: '',
+							interval_minutes: 5,
+							pipeline_name: 'Pipeline A',
+						},
+						{
+							name: 'Foo',
+							event: 'time.heartbeat',
+							enabled: true,
+							prompt: '',
+							interval_minutes: 5,
+							pipeline_name: 'Pipeline B',
+						},
+					],
+				},
+			]);
+			const createWebServer = createWebServerFactory({ ...deps, getCueGraphData });
+			const server = createWebServer() as any;
+			const callback = server.setGetCueSubscriptionsCallback.mock.calls[0][0];
+			const all = await callback();
+			expect(all).toHaveLength(2);
+			expect(all[0].id).toBe('agent-1::Pipeline A::Foo');
+			expect(all[1].id).toBe('agent-1::Pipeline B::Foo');
+			expect(new Set(all.map((s: { id: string }) => s.id)).size).toBe(2);
+		});
+
+		it('falls back to the -chain-N stripped base name when pipeline_name is absent (legacy YAML)', async () => {
+			const getCueGraphData = vi.fn().mockReturnValue([
+				{
+					sessionId: 'agent-1',
+					sessionName: 'Worker',
+					toolType: 'claude-code',
+					subscriptions: [
+						{
+							name: 'LegacyPipe-chain-2',
+							event: 'agent.completed',
+							enabled: true,
+							prompt: '',
+							source_session: 'Worker',
+						},
+					],
+				},
+			]);
+			const createWebServer = createWebServerFactory({ ...deps, getCueGraphData });
+			const server = createWebServer() as any;
+			const callback = server.setGetCueSubscriptionsCallback.mock.calls[0][0];
+			const [entry] = await callback();
+			expect(entry.id).toBe('agent-1::LegacyPipe::LegacyPipe-chain-2');
+		});
+
+		it('renders schedule_days alongside schedule_times in the CLI schedule string', async () => {
+			// Greptile #982 + Pedram: previously `schedule_days` was silently
+			// dropped from the flattened output, so day-pinned schedules
+			// looked indistinguishable from every-day schedules in `cue list`.
+			const getCueGraphData = vi.fn().mockReturnValue([
+				{
+					sessionId: 'agent-1',
+					sessionName: 'Worker',
+					toolType: 'claude-code',
+					subscriptions: [
+						{
+							name: 'WeekdayMorning',
+							event: 'time.scheduled',
+							enabled: true,
+							prompt: '',
+							schedule_times: ['07:00'],
+							schedule_days: ['mon', 'wed', 'fri'],
+							pipeline_name: 'Sched',
+						},
+						{
+							name: 'DaysOnly',
+							event: 'time.scheduled',
+							enabled: true,
+							prompt: '',
+							schedule_days: ['sat', 'sun'],
+							pipeline_name: 'Sched',
+						},
+					],
+				},
+			]);
+			const createWebServer = createWebServerFactory({ ...deps, getCueGraphData });
+			const server = createWebServer() as any;
+			const callback = server.setGetCueSubscriptionsCallback.mock.calls[0][0];
+			const all = await callback();
+			expect(all[0].schedule).toBe('07:00 (Mon, Wed, Fri)');
+			expect(all[1].schedule).toBe('days: Sat, Sun');
 		});
 
 		it('filters by sessionId when one is supplied', async () => {

--- a/src/__tests__/shared/cue/subscription-id.test.ts
+++ b/src/__tests__/shared/cue/subscription-id.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import {
+	composeCueSubscriptionId,
+	parseCueSubscriptionId,
+	pipelineKeyForSubscription,
+} from '../../../shared/cue/subscription-id';
+
+describe('cue/subscription-id', () => {
+	describe('pipelineKeyForSubscription', () => {
+		it('prefers explicit pipeline_name', () => {
+			expect(
+				pipelineKeyForSubscription({ name: 'Pipe-chain-1', pipeline_name: 'My Pipeline' })
+			).toBe('My Pipeline');
+		});
+
+		it('strips -chain-N suffix when pipeline_name is absent', () => {
+			expect(pipelineKeyForSubscription({ name: 'Build-chain-3' })).toBe('Build');
+		});
+
+		it('strips -fanin suffix when pipeline_name is absent', () => {
+			expect(pipelineKeyForSubscription({ name: 'Aggregate-fanin' })).toBe('Aggregate');
+		});
+
+		it('strips -cmd-<id> suffix when pipeline_name is absent', () => {
+			expect(pipelineKeyForSubscription({ name: 'Run-cmd-abc123' })).toBe('Run');
+		});
+
+		it('strips -cli-out suffix when pipeline_name is absent', () => {
+			expect(pipelineKeyForSubscription({ name: 'Deploy-cli-out' })).toBe('Deploy');
+		});
+
+		it('returns the original name when no suffix matches', () => {
+			expect(pipelineKeyForSubscription({ name: 'Standalone' })).toBe('Standalone');
+		});
+
+		it('ignores an empty pipeline_name', () => {
+			expect(pipelineKeyForSubscription({ name: 'Build-chain-1', pipeline_name: '' })).toBe(
+				'Build'
+			);
+		});
+	});
+
+	describe('composeCueSubscriptionId', () => {
+		it('emits sessionId::pipeline::name', () => {
+			expect(
+				composeCueSubscriptionId('sess-1', {
+					name: 'Digest Script',
+					pipeline_name: 'Obsidian Daily Pipe',
+				})
+			).toBe('sess-1::Obsidian Daily Pipe::Digest Script');
+		});
+
+		it('disambiguates two same-named subs in different pipelines under one session', () => {
+			const a = composeCueSubscriptionId('sess-1', { name: 'Foo', pipeline_name: 'A' });
+			const b = composeCueSubscriptionId('sess-1', { name: 'Foo', pipeline_name: 'B' });
+			expect(a).not.toBe(b);
+		});
+
+		it('falls back to base-name stripping when pipeline_name is absent', () => {
+			expect(composeCueSubscriptionId('sess-1', { name: 'Build-chain-1' })).toBe(
+				'sess-1::Build::Build-chain-1'
+			);
+		});
+
+		it('throws when any component contains the "::" separator', () => {
+			// Hand-edited YAML could in principle smuggle "::" into a name;
+			// surface that loudly rather than silently emitting an
+			// unparseable id that the toggle path would reject as "no such
+			// subscription".
+			expect(() =>
+				composeCueSubscriptionId('sess::1', { name: 'Foo', pipeline_name: 'A' })
+			).toThrow(/must not contain/);
+			expect(() =>
+				composeCueSubscriptionId('sess-1', { name: 'Foo', pipeline_name: 'A::B' })
+			).toThrow(/must not contain/);
+			expect(() =>
+				composeCueSubscriptionId('sess-1', { name: 'Foo::Bar', pipeline_name: 'A' })
+			).toThrow(/must not contain/);
+		});
+	});
+
+	describe('parseCueSubscriptionId', () => {
+		it('round-trips a composed id', () => {
+			const id = composeCueSubscriptionId('sess-1', {
+				name: 'Digest Script',
+				pipeline_name: 'Obsidian Daily Pipe',
+			});
+			expect(parseCueSubscriptionId(id)).toEqual({
+				sessionId: 'sess-1',
+				pipeline: 'Obsidian Daily Pipe',
+				name: 'Digest Script',
+			});
+		});
+
+		it('returns null when the id does not have exactly three components', () => {
+			expect(parseCueSubscriptionId('only-one-part')).toBeNull();
+			expect(parseCueSubscriptionId('two::parts')).toBeNull();
+			expect(parseCueSubscriptionId('four::part::id::here')).toBeNull();
+		});
+
+		it('returns null when any component is empty', () => {
+			expect(parseCueSubscriptionId('::pipeline::name')).toBeNull();
+			expect(parseCueSubscriptionId('sess::::name')).toBeNull();
+			expect(parseCueSubscriptionId('sess::pipeline::')).toBeNull();
+		});
+	});
+});

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -364,6 +364,10 @@ const createWebServer = createWebServerFactory({
 		if (!cueEngine) return false;
 		return cueEngine.triggerSubscription(subscriptionName, prompt, sourceAgentId);
 	},
+	getCueGraphData: () => {
+		if (!cueEngine) return [];
+		return cueEngine.getGraphData();
+	},
 });
 
 // createWindow is now handled by windowManager (Phase 4 refactoring)

--- a/src/main/web-server/web-server-factory.ts
+++ b/src/main/web-server/web-server-factory.ts
@@ -20,6 +20,7 @@ import { parseGitBranches } from '../../shared/gitUtils';
 import type { Shortcut } from '../../shared/shortcut-types';
 import type { WebPlaybook, CueSubscriptionInfo } from './types';
 import type { CueGraphSession } from '../../shared/cue/contracts';
+import { composeCueSubscriptionId } from '../../shared/cue/subscription-id';
 import { getDefaultShell } from '../stores/defaults';
 import { buildWebSettingsSnapshot } from './web-settings-snapshot';
 import {
@@ -33,6 +34,39 @@ import {
 /** UUID v4 format regex for validating stored security tokens.
  *  Enforces version nibble (4) and variant bits ([89ab]). */
 const UUID_V4_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+/** Display-formats a Cue subscription's schedule for `cue list`. Surfaces
+ *  `schedule_times`, `interval_minutes`, and `schedule_days` in a single
+ *  human-readable string so day-pinned schedules don't show up as
+ *  `undefined` in the CLI:
+ *
+ *  - `schedule_times: ['07:00']`                              → `"07:00"`
+ *  - `schedule_times: ['07:00']`, `schedule_days: ['mon','wed']` → `"07:00 (Mon, Wed)"`
+ *  - `interval_minutes: 5`                                    → `"every 5m"`
+ *  - `schedule_days: ['mon','wed']` (no times, no interval)   → `"days: Mon, Wed"`
+ *  - none of the above                                        → `undefined`
+ */
+function formatCueSchedule(sub: {
+	schedule_times?: string[];
+	schedule_days?: string[];
+	interval_minutes?: number;
+}): string | undefined {
+	const days =
+		Array.isArray(sub.schedule_days) && sub.schedule_days.length > 0
+			? sub.schedule_days.map((d) => d.charAt(0).toUpperCase() + d.slice(1)).join(', ')
+			: null;
+	if (Array.isArray(sub.schedule_times) && sub.schedule_times.length > 0) {
+		const base = sub.schedule_times.join(', ');
+		return days ? `${base} (${days})` : base;
+	}
+	if (typeof sub.interval_minutes === 'number') {
+		return `every ${sub.interval_minutes}m`;
+	}
+	if (days) {
+		return `days: ${days}`;
+	}
+	return undefined;
+}
 
 /** Store interface for sessions */
 interface SessionsStore {
@@ -2293,18 +2327,19 @@ export function createWebServerFactory(deps: WebServerFactoryDependencies) {
 				for (const sub of session.subscriptions) {
 					subs.push({
 						// No stable per-subscription id in YAML; compose one from
-						// the owning session and the name (unique-within-pipeline
-						// by validator contract).
-						id: `${session.sessionId}::${sub.name}`,
+						// session + pipeline + name. Names are unique within a
+						// pipeline (validator contract), so the pipeline
+						// discriminator is what guarantees the id stays unique
+						// when two pipelines under the same session each define
+						// a sub with the same name. Without it, downstream
+						// resolvers (e.g. `setSubscriptionEnabled` in the
+						// follow-up PR) would match by name only and silently
+						// toggle the wrong row.
+						id: composeCueSubscriptionId(session.sessionId, sub),
 						name: sub.name,
 						eventType: sub.event,
 						pattern: typeof sub.watch === 'string' ? sub.watch : undefined,
-						schedule:
-							Array.isArray(sub.schedule_times) && sub.schedule_times.length > 0
-								? sub.schedule_times.join(', ')
-								: typeof sub.interval_minutes === 'number'
-									? `every ${sub.interval_minutes}m`
-									: undefined,
+						schedule: formatCueSchedule(sub),
 						sessionId: session.sessionId,
 						sessionName: session.sessionName,
 						enabled: sub.enabled !== false,

--- a/src/main/web-server/web-server-factory.ts
+++ b/src/main/web-server/web-server-factory.ts
@@ -18,7 +18,8 @@ import { execGit } from '../utils/remote-git';
 import { getSshRemoteById } from '../stores';
 import { parseGitBranches } from '../../shared/gitUtils';
 import type { Shortcut } from '../../shared/shortcut-types';
-import type { WebPlaybook } from './types';
+import type { WebPlaybook, CueSubscriptionInfo } from './types';
+import type { CueGraphSession } from '../../shared/cue/contracts';
 import { getDefaultShell } from '../stores/defaults';
 import { buildWebSettingsSnapshot } from './web-settings-snapshot';
 import {
@@ -61,6 +62,12 @@ export interface WebServerFactoryDependencies {
 		prompt?: string,
 		sourceAgentId?: string
 	) => boolean;
+	/** Direct CUE graph-data snapshot — bypasses renderer IPC round-trip.
+	 *  Required by `setGetCueSubscriptionsCallback` to answer the CLI's
+	 *  `get_cue_subscriptions` message in-process instead of forwarding it
+	 *  to the renderer (which never registered a listener, so every CLI
+	 *  `cue list` call timed out). */
+	getCueGraphData?: () => CueGraphSession[];
 }
 
 /**
@@ -2263,42 +2270,53 @@ export function createWebServerFactory(deps: WebServerFactoryDependencies) {
 
 		// ============ Cue Automation Callbacks ============
 
-		// Get Cue subscriptions — uses IPC request-response pattern
+		// Get Cue subscriptions — calls engine directly in the main process.
+		// Previous implementation forwarded `remote:getCueSubscriptions` to
+		// the renderer and waited 30 s for a response, but no renderer code
+		// ever registered a handler for that channel. The CLI's 10 s timeout
+		// fired every time, surfacing as `cue list` hanging with
+		// `Command timed out waiting for cue_subscriptions`. Mirrors the same
+		// pattern as `triggerCueSubscription` below — the engine lives in
+		// main process anyway, so the IPC bounce was never needed.
 		server.setGetCueSubscriptionsCallback(async (sessionId?: string) => {
-			const mainWindow = getMainWindow();
-			if (!mainWindow) {
-				logger.warn('mainWindow is null for getCueSubscriptions', 'WebServer');
+			if (!deps.getCueGraphData) {
+				logger.warn('getCueGraphData dependency not available', 'WebServer');
 				return [];
 			}
-
-			return new Promise((resolve) => {
-				const responseChannel = `remote:getCueSubscriptions:response:${randomUUID()}`;
-				let resolved = false;
-
-				const handleResponse = (_event: Electron.IpcMainEvent, result: any) => {
-					if (resolved) return;
-					resolved = true;
-					clearTimeout(timeoutId);
-					resolve(result ?? []);
-				};
-
-				ipcMain.once(responseChannel, handleResponse);
-				if (!isWebContentsAvailable(mainWindow)) {
-					logger.warn('webContents is not available for getCueSubscriptions', 'WebServer');
-					ipcMain.removeListener(responseChannel, handleResponse);
-					resolve([]);
-					return;
+			const graph = deps.getCueGraphData();
+			const filtered =
+				typeof sessionId === 'string' && sessionId.length > 0
+					? graph.filter((gs) => gs.sessionId === sessionId)
+					: graph;
+			const subs: CueSubscriptionInfo[] = [];
+			for (const session of filtered) {
+				for (const sub of session.subscriptions) {
+					subs.push({
+						// No stable per-subscription id in YAML; compose one from
+						// the owning session and the name (unique-within-pipeline
+						// by validator contract).
+						id: `${session.sessionId}::${sub.name}`,
+						name: sub.name,
+						eventType: sub.event,
+						pattern: typeof sub.watch === 'string' ? sub.watch : undefined,
+						schedule:
+							Array.isArray(sub.schedule_times) && sub.schedule_times.length > 0
+								? sub.schedule_times.join(', ')
+								: typeof sub.interval_minutes === 'number'
+									? `every ${sub.interval_minutes}m`
+									: undefined,
+						sessionId: session.sessionId,
+						sessionName: session.sessionName,
+						enabled: sub.enabled !== false,
+						// Per-subscription last-triggered / count are not yet
+						// tracked by the engine (only per-session). Leave the
+						// numeric fields zero so the CLI renders "never triggered"
+						// rather than fabricating a value.
+						triggerCount: 0,
+					});
 				}
-				mainWindow.webContents.send('remote:getCueSubscriptions', sessionId, responseChannel);
-
-				const timeoutId = setTimeout(() => {
-					if (resolved) return;
-					resolved = true;
-					ipcMain.removeListener(responseChannel, handleResponse);
-					logger.warn('getCueSubscriptions callback timed out', 'WebServer');
-					resolve([]);
-				}, 30000);
-			});
+			}
+			return subs;
 		});
 
 		// Toggle Cue subscription — uses IPC request-response pattern

--- a/src/shared/cue/subscription-id.ts
+++ b/src/shared/cue/subscription-id.ts
@@ -1,0 +1,86 @@
+/**
+ * Stable composite identity for a Cue subscription as exposed to remote
+ * callers (the CLI, the web/mobile UI). The Cue YAML itself doesn't carry a
+ * per-subscription primary key — subscription `name` is unique only *within*
+ * a pipeline, and a single session can host multiple pipelines that each
+ * legitimately define a sub with the same name. Composing
+ * `${sessionId}::${pipeline}::${name}` gives a stable, parseable id that
+ * survives that collision without needing to introduce a persisted uuid
+ * onto every YAML row.
+ *
+ * Used by the web-server factory's `setGetCueSubscriptionsCallback` and the
+ * follow-up `setSubscriptionEnabled` engine method so both sides agree on
+ * the same identity contract.
+ */
+
+/** Minimal shape needed to derive the pipeline discriminator. Kept narrow so
+ *  this module never has to import the full CueSubscription type (and so
+ *  tests don't need to construct a full subscription either). */
+export interface CueSubscriptionIdInput {
+	name: string;
+	pipeline_name?: string;
+}
+
+/** Field separator inside a composite id. Chosen to be visually distinctive
+ *  while still URL-safe and unambiguous against typical pipeline / sub names
+ *  (which never legitimately contain `::`). */
+export const CUE_SUBSCRIPTION_ID_SEP = '::';
+
+/**
+ * Derive the pipeline discriminator for a subscription. Prefers the
+ * authoritative `pipeline_name` field when present and non-empty; otherwise
+ * falls back to the legacy convention of stripping `-chain-N`, `-fanin`,
+ * `-cmd-<id>`, and `-cli-out` suffixes off the subscription name. Mirrors
+ * `getBasePipelineName` in `yamlToPipeline.ts` so both sides classify the
+ * same YAML into the same group.
+ */
+export function pipelineKeyForSubscription(sub: CueSubscriptionIdInput): string {
+	if (typeof sub.pipeline_name === 'string' && sub.pipeline_name.length > 0) {
+		return sub.pipeline_name;
+	}
+	return sub.name
+		.replace(/-chain-\d+$/, '')
+		.replace(/-fanin$/, '')
+		.replace(/-cmd-[a-z0-9]+$/i, '')
+		.replace(/-cli-out$/, '');
+}
+
+/**
+ * Compose the remote-exposed subscription id. Always
+ * `${sessionId}::${pipeline}::${name}`. Names containing `::` would break
+ * round-trip parsing — Cue validator rejects names with these characters, so
+ * this should never fire in practice, but we throw in dev to surface a hand-
+ * edited YAML mistake instead of silently producing a degenerate id.
+ */
+export function composeCueSubscriptionId(sessionId: string, sub: CueSubscriptionIdInput): string {
+	const pipeline = pipelineKeyForSubscription(sub);
+	if (
+		sessionId.includes(CUE_SUBSCRIPTION_ID_SEP) ||
+		pipeline.includes(CUE_SUBSCRIPTION_ID_SEP) ||
+		sub.name.includes(CUE_SUBSCRIPTION_ID_SEP)
+	) {
+		// Falling through silently would let a malformed component produce
+		// an unparseable id that the toggle path would then reject as
+		// "no such subscription" — worse than the YAML error this catches.
+		throw new Error(
+			`Cue subscription id components must not contain "${CUE_SUBSCRIPTION_ID_SEP}" (session=${sessionId}, pipeline=${pipeline}, name=${sub.name})`
+		);
+	}
+	return `${sessionId}${CUE_SUBSCRIPTION_ID_SEP}${pipeline}${CUE_SUBSCRIPTION_ID_SEP}${sub.name}`;
+}
+
+/**
+ * Inverse of {@link composeCueSubscriptionId}. Returns `null` when the input
+ * doesn't carry exactly three non-empty `::`-separated components — callers
+ * must treat `null` as "no matching subscription" rather than falling back
+ * to a partial match.
+ */
+export function parseCueSubscriptionId(
+	id: string
+): { sessionId: string; pipeline: string; name: string } | null {
+	const parts = id.split(CUE_SUBSCRIPTION_ID_SEP);
+	if (parts.length !== 3) return null;
+	const [sessionId, pipeline, name] = parts;
+	if (!sessionId || !pipeline || !name) return null;
+	return { sessionId, pipeline, name };
+}


### PR DESCRIPTION
## Summary

- Fixes \`maestro-cli cue list\` hanging with \`Command timed out waiting for cue_subscriptions\`.
- Root cause: the web-server factory forwarded \`remote:getCueSubscriptions\` to the renderer and waited 30 s for a response, but no renderer code ever registered a handler for that channel. The CLI's 10 s timeout fired every time.
- Mirrors the existing \`triggerCueSubscription\` pattern: a new \`getCueGraphData\` dependency on \`WebServerFactoryDependencies\` calls \`cueEngine.getGraphData()\` directly in main. The callback flattens \`CueGraphSession[]\` into \`CueSubscriptionInfo[]\` and optionally filters by \`sessionId\`. No more renderer round-trip.
- \`triggerSubscription(...)\` and the engine-side getter were already in main process, so the renderer bounce was never needed in the first place.

### Follow-up tracked here, not fixed in this PR

The same dead-bridge shape exists for \`remote:toggleCueSubscription\` and \`remote:getCueActivity\` — neither is reachable from any current CLI command, so they're not user-blocking right now. Recommend moving both to main-process direct calls in a follow-up (and removing the unused \`onRemoteGetCueSubscriptions\` / \`sendRemoteGetCueSubscriptionsResponse\` / \`onRemoteToggleCueSubscription\` / \`sendRemoteToggleCueSubscriptionResponse\` / \`onRemoteGetCueActivity\` / \`sendRemoteGetCueActivityResponse\` preload bridges, which now have zero callers).

## Test plan

- [x] \`vitest run src/__tests__/main/web-server/web-server-factory.test.ts\` — 51/51 pass, including three new tests:
  - flattens engine graph data into \`CueSubscriptionInfo[]\` without any IPC bounce
  - filters by \`sessionId\` when supplied
  - returns \`[]\` and warns when the dep is missing
- [x] \`vitest run src/__tests__/main/cue/cue-yaml-loader.test.ts src/__tests__/renderer/components/CuePipelineEditor/utils/yamlToPipeline.test.ts\` — 188/188 pass (no regressions in adjacent cue paths).
- [x] Type-check + prettier + ESLint clean on touched files.
- [ ] Smoke test against a workspace with a loaded \`.maestro/cue.yaml\`:
  - \`node /opt/Maestro/resources/maestro-cli.js cue list --json\` returns subscriptions instead of timing out.
  - \`cue trigger <existing-sub-name>\` still works (unchanged path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Web API exposes cue subscription lookup with stable subscription IDs, clearer schedule formatting, legacy YAML handling, and sessionId filtering.
  * CLI-facing schedule strings now render day+time combinations more readably.

* **Tests**
  * Added comprehensive tests covering subscription ID composition, disambiguation, schedule rendering, filtering, and missing-data warnings.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RunMaestro/Maestro/pull/982)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->