### PR TITLE
fix(codex): place -C working-dir flag before exec subcommand (#959)

### DIFF
--- a/src/__tests__/cli/services/agent-spawner.test.ts
+++ b/src/__tests__/cli/services/agent-spawner.test.ts
@@ -2133,6 +2133,10 @@ Some text with [x] in it that's not a checkbox
 			const c = args.indexOf('-C');
 			expect(c).toBeGreaterThanOrEqual(0);
 			expect(args[c + 1]).toBe('/working');
+			// Regression: issue #959 — `-C` is a root-level global flag on Codex
+			// and is silently ignored when it appears after the `exec` subcommand.
+			// Ensure -C precedes exec.
+			expect(c).toBeLessThan(args.indexOf('exec'));
 			// resume args are ['resume', '<id>']
 			expect(args).toContain('resume');
 			expect(args).toContain('codex-thread-123');

--- a/src/__tests__/main/agents/definitions.test.ts
+++ b/src/__tests__/main/agents/definitions.test.ts
@@ -225,6 +225,19 @@ describe('agent-definitions', () => {
 			expect(args).toEqual(['-C', '/path/to/project']);
 		});
 
+		// Regression: issue #959 — Codex's `-C` is a root-level global flag
+		// and must precede the `exec` subcommand.
+		it('marks codex workingDirArgs as belonging before batchModePrefix', () => {
+			const codex = getAgentDefinition('codex');
+			expect(codex?.workingDirArgsBeforeBatchPrefix).toBe(true);
+		});
+
+		it('does not mark factory-droid workingDirArgs as belonging before batchModePrefix', () => {
+			const droid = getAgentDefinition('factory-droid');
+			// Droid's `--cwd` is a subcommand-scoped flag — keep current ordering
+			expect(droid?.workingDirArgsBeforeBatchPrefix).toBeFalsy();
+		});
+
 		it('should use = syntax for Copilot resume args', () => {
 			const copilot = getAgentDefinition('copilot-cli');
 			expect(copilot?.resumeArgs).toBeDefined();

--- a/src/__tests__/main/utils/agent-args.test.ts
+++ b/src/__tests__/main/utils/agent-args.test.ts
@@ -203,6 +203,68 @@ describe('buildAgentArgs', () => {
 		expect(result).toEqual(['--print']);
 	});
 
+	// Regression: issue #959 — Codex's `-C` is a root-level global flag and
+	// must appear BEFORE the `exec` subcommand. Agents that opt into
+	// `workingDirArgsBeforeBatchPrefix` place workingDirArgs at the very start.
+	it('places workingDirArgs before batchModePrefix when workingDirArgsBeforeBatchPrefix is true', () => {
+		const agent = makeAgent({
+			id: 'codex',
+			batchModePrefix: ['exec'],
+			batchModeArgs: ['--dangerously-bypass-approvals-and-sandbox', '--skip-git-repo-check'],
+			jsonOutputArgs: ['--json'],
+			workingDirArgs: (dir: string) => ['-C', dir],
+			workingDirArgsBeforeBatchPrefix: true,
+		});
+		const result = buildAgentArgs(agent, {
+			baseArgs: [],
+			prompt: 'do stuff',
+			cwd: 'D:\\Projects\\MyProject',
+		});
+		expect(result).toEqual([
+			'-C',
+			'D:\\Projects\\MyProject',
+			'exec',
+			'--dangerously-bypass-approvals-and-sandbox',
+			'--skip-git-repo-check',
+			'--json',
+		]);
+		// Sanity: `-C` must come before `exec`, not after
+		expect(result.indexOf('-C')).toBeLessThan(result.indexOf('exec'));
+	});
+
+	it('keeps subcommand-scoped workingDirArgs after batchModePrefix when flag is omitted (Droid)', () => {
+		const agent = makeAgent({
+			id: 'factory-droid',
+			batchModePrefix: ['exec'],
+			batchModeArgs: ['--skip-permissions-unsafe'],
+			workingDirArgs: (dir: string) => ['--cwd', dir],
+			// workingDirArgsBeforeBatchPrefix intentionally not set
+		});
+		const result = buildAgentArgs(agent, {
+			baseArgs: [],
+			prompt: 'do stuff',
+			cwd: '/project',
+		});
+		// `--cwd` stays after `exec` to preserve Droid's subcommand-scoped flag
+		expect(result.indexOf('exec')).toBeLessThan(result.indexOf('--cwd'));
+		expect(result).toEqual(['exec', '--skip-permissions-unsafe', '--cwd', '/project']);
+	});
+
+	it('does not duplicate workingDirArgs when workingDirArgsBeforeBatchPrefix is true', () => {
+		const agent = makeAgent({
+			batchModePrefix: ['exec'],
+			workingDirArgs: (dir: string) => ['-C', dir],
+			workingDirArgsBeforeBatchPrefix: true,
+		});
+		const result = buildAgentArgs(agent, {
+			baseArgs: [],
+			prompt: 'hello',
+			cwd: '/project',
+		});
+		const dashCCount = result.filter((a) => a === '-C').length;
+		expect(dashCCount).toBe(1);
+	});
+
 	// -- readOnlyArgs --
 	it('adds readOnlyArgs when readOnlyMode is true', () => {
 		const agent = makeAgent({ readOnlyArgs: ['--agent', 'plan'] });

--- a/src/cli/services/agent-spawner.ts
+++ b/src/cli/services/agent-spawner.ts
@@ -574,6 +574,16 @@ async function spawnJsonLineAgent(
 	// Build args from agent definition (without the prompt or model/customArgs —
 	// those come from applyAgentConfigOverrides via configOptions).
 	const preOverrideArgs: string[] = [];
+
+	// Codex's `-C` / `--cd` is a root-level global flag and is silently ignored
+	// when it appears after the `exec` subcommand (issue #959 /
+	// https://github.com/openai/codex/issues/9671). Prepend the working-dir
+	// args BEFORE batchModePrefix so the final ordering is
+	// `codex -C <dir> exec ...` instead of `codex exec ... -C <dir>`.
+	if (toolType === 'codex' && def?.workingDirArgs) {
+		preOverrideArgs.push(...def.workingDirArgs(cwd));
+	}
+
 	if (def?.batchModePrefix) preOverrideArgs.push(...def.batchModePrefix);
 
 	// In read-only mode, filter out YOLO/bypass args from batchModeArgs
@@ -594,11 +604,6 @@ async function spawnJsonLineAgent(
 
 	if (agentSessionId && def?.resumeArgs) {
 		preOverrideArgs.push(...def.resumeArgs(agentSessionId));
-	}
-
-	// Codex requires explicit working directory arg (other agents use process cwd)
-	if (toolType === 'codex' && def?.workingDirArgs) {
-		preOverrideArgs.push(...def.workingDirArgs(cwd));
 	}
 
 	// Layer agent-level + session-level overrides (model, effort, customArgs)

--- a/src/main/agents/definitions.ts
+++ b/src/main/agents/definitions.ts
@@ -96,6 +96,7 @@ export interface AgentConfig extends BaseAgentConfig {
 	readOnlyArgs?: string[]; // Args for read-only/plan mode (e.g., ['--agent', 'plan'])
 	modelArgs?: (modelId: string) => string[]; // Function to build model selection args (e.g., ['--model', modelId])
 	workingDirArgs?: (dir: string) => string[]; // Function to build working directory args (e.g., ['-C', dir])
+	workingDirArgsBeforeBatchPrefix?: boolean; // If true, workingDirArgs are placed BEFORE batchModePrefix (e.g. Codex `-C` is a root-level global flag and must precede the `exec` subcommand)
 	imageArgs?: (imagePath: string) => string[]; // Function to build image attachment args (e.g., ['-i', imagePath] for Codex)
 	imagePromptBuilder?: (imagePaths: string[]) => string; // Function to embed image references into the prompt (e.g., Copilot @mentions)
 	promptArgs?: (prompt: string) => string[]; // Function to build prompt args (e.g., ['-p', prompt] for OpenCode)
@@ -203,6 +204,10 @@ export const AGENT_DEFINITIONS: AgentDefinition[] = [
 		readOnlyCliEnforced: true, // CLI enforces read-only via --sandbox read-only
 		yoloModeArgs: ['--dangerously-bypass-approvals-and-sandbox'], // Full access mode
 		workingDirArgs: (dir: string) => ['-C', dir], // Set working directory
+		// `-C` / `--cd` is a root-level global flag on the Codex CLI and is silently
+		// ignored when it appears after the `exec` subcommand (see issue #959 and
+		// https://github.com/openai/codex/issues/9671).
+		workingDirArgsBeforeBatchPrefix: true,
 		imageArgs: (imagePath: string) => ['-i', imagePath], // Image attachment: codex exec -i /path/to/image.png
 		modelArgs: (modelId: string) => ['-m', modelId], // Model selection: codex exec -m gpt-5.3-codex
 		// Agent-specific configuration options shown in UI

--- a/src/main/utils/agent-args.ts
+++ b/src/main/utils/agent-args.ts
@@ -110,6 +110,16 @@ export function buildAgentArgs(
 		finalArgs = [...agent.batchModePrefix, ...finalArgs];
 	}
 
+	// Some agents (Codex) require workingDirArgs to appear BEFORE the batch-mode
+	// subcommand because the flag is parsed as a root-level global, not a
+	// subcommand flag. Prepend here so the result is `<cmd> -C <dir> exec ...`
+	// instead of `<cmd> exec -C <dir> ...`. Agents whose workingDirArgs are
+	// subcommand-scoped (Droid `--cwd`, Gemini `--include-directories`) fall
+	// through to the post-batchMode append below.
+	if (agent.workingDirArgs && options.cwd && agent.workingDirArgsBeforeBatchPrefix) {
+		finalArgs = [...agent.workingDirArgs(options.cwd), ...finalArgs];
+	}
+
 	if (agent.batchModeArgs && inBatchMode) {
 		// Skip batch mode args (e.g. -y, --dangerously-bypass-approvals-and-sandbox)
 		// when readOnlyMode is active. Batch mode args grant write/approval permissions
@@ -128,7 +138,7 @@ export function buildAgentArgs(
 		finalArgs = [...finalArgs, ...agent.jsonOutputArgs];
 	}
 
-	if (agent.workingDirArgs && options.cwd) {
+	if (agent.workingDirArgs && options.cwd && !agent.workingDirArgsBeforeBatchPrefix) {
 		finalArgs = [...finalArgs, ...agent.workingDirArgs(options.cwd)];
 	}
 


### PR DESCRIPTION
## Summary

Fixes #959. The Codex CLI parses `-C` / `--cd` as a **root-level global flag** and silently ignores it when it appears after the `exec` subcommand. Both `buildAgentArgs` (desktop / Auto Run / Cue) and the CLI's `spawnJsonLineAgent` (maestro-cli send / playbooks) were appending `workingDirArgs` after `batchModePrefix`, producing:

```
codex exec --dangerously-bypass-... --skip-git-repo-check --json -C D:\Projects\MyProject -- "prompt"
```

Codex silently ignored the `-C` and fell back to its own cwd resolution — most visible on Windows where Codex also has process-cwd resolution bugs (openai/codex#9671).

After:

```
codex -C D:\Projects\MyProject exec --dangerously-bypass-... --skip-git-repo-check --json -- "prompt"
```

## Implementation

- Added an opt-in `workingDirArgsBeforeBatchPrefix?: boolean` on the agent definition. Codex sets it to `true`.
- `buildAgentArgs` now prepends `workingDirArgs` before `batchModePrefix` when this flag is set; otherwise it preserves the current append-after-prefix behavior.
- CLI `spawnJsonLineAgent` does the same for Codex — preserves the existing Codex-only scoping so Droid's CLI path is unchanged (Droid's `--cwd` is a subcommand-scoped flag and was never applied by the CLI path).
- Droid (`--cwd`) and Gemini (`--include-directories`) remain unaffected.

## Tests

- `agent-args.test.ts`: new tests verifying (1) Codex ordering with `-C` before `exec`, (2) Droid ordering preserves `--cwd` after `exec`, (3) no duplication when flag is set.
- `definitions.test.ts`: asserts Codex has `workingDirArgsBeforeBatchPrefix: true` and Droid does not.
- `agent-spawner.test.ts`: extended the existing Codex spawn test to assert `-C` precedes `exec`.

## Test plan

- [x] `npx vitest run src/__tests__/main/utils/agent-args.test.ts src/__tests__/main/agents/definitions.test.ts` — 101 passing
- [x] `npx vitest run src/__tests__/cli/services/agent-spawner.test.ts` — 113 passing
- [x] `npx vitest run src/__tests__/main/ipc/handlers/agents.test.ts src/__tests__/integration/provider-integration.test.ts src/__tests__/integration/group-chat-integration.test.ts` — 73 passing
- [x] Prettier and ESLint clean on touched files
- [ ] Manual verification on Windows with a Codex agent in a non-default project root (recommended)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Codex's working directory flag handling to ensure correct command-line argument ordering, resolving cases where the flag would be ignored.

* **Tests**
  * Added comprehensive regression test coverage for working directory argument placement across different agent configurations to prevent future regressions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RunMaestro/Maestro/pull/984)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->