### PR TITLE
chore(ci): remove no-op build:prompts step (#804)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ jobs:
           node-version: '22'
           cache: 'npm'
       - run: npm ci
-      - run: npm run build:prompts
       - run: npx prettier --check .
       - run: npx eslint src/
       - run: npm run lint # TypeScript type checking
@@ -30,5 +29,4 @@ jobs:
           node-version: '22'
           cache: 'npm'
       - run: npm ci
-      - run: npm run build:prompts
       - run: npm run test

--- a/BUILDING_WINDOWS.md
+++ b/BUILDING_WINDOWS.md
@@ -62,7 +62,7 @@ If you encounter issues with the `dev:win` script or prefer to run the steps man
 3.  **Start the Electron main process:**
     Open a **new** PowerShell terminal and run the following command:
     ```powershell
-    npm run build:prompts; npx tsc -p tsconfig.main.json; $env:NODE_ENV='development'; npx electron .
+    npx tsc -p tsconfig.main.json; $env:NODE_ENV='development'; npx electron .
     ```
 
 This will launch the application in development mode with hot-reloading for the renderer.

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
 		"dev:web": "vite --config vite.config.web.mts",
 		"dev:win": "powershell -NoProfile -ExecutionPolicy Bypass -File ./scripts/start-dev.ps1",
 		"build": "npm run build:main && npm run build:preload && npm run build:renderer && npm run build:web && npm run build:cli",
-		"build:prompts": "echo 'No-op: prompts are now loaded from disk at runtime (see prompt-manager.ts)'",
 		"build:main": "tsc -p tsconfig.main.json",
 		"build:preload": "node scripts/build-preload.mjs",
 		"build:cli": "node scripts/build-cli.mjs",

--- a/scripts/start-dev.ps1
+++ b/scripts/start-dev.ps1
@@ -18,7 +18,7 @@ Start-Process powershell -ArgumentList '-NoExit', '-Command', $cmdRenderer
 Write-Host "Waiting for renderer dev server on port $vitePort..." -ForegroundColor Yellow
 Start-Sleep -Seconds 5
 
-$cmdBuild = "Set-Location -LiteralPath '$repoRootEscaped'; npm run build:prompts; npx tsc -p tsconfig.main.json; npm run build:preload; `$env:NODE_ENV='development'; `$env:VITE_PORT='$vitePort'; npx electron ."
+$cmdBuild = "Set-Location -LiteralPath '$repoRootEscaped'; npx tsc -p tsconfig.main.json; npm run build:preload; `$env:NODE_ENV='development'; `$env:VITE_PORT='$vitePort'; npx electron ."
 Start-Process powershell -ArgumentList '-NoExit', '-Command', $cmdBuild
 
 Write-Host "Launched renderer and main developer windows on port $vitePort." -ForegroundColor Green


### PR DESCRIPTION
## Summary

Fixes #804. Prompts are loaded from disk at runtime (`src/main/prompt-manager.ts`); the `build:prompts` npm script was a no-op shim added in `7189b06c` so existing CI pipelines wouldn't break. Drops the script and its remaining call sites:

- **`.github/workflows/ci.yml`** — remove `npm run build:prompts` from both the `lint-and-format` and `test` jobs.
- **`package.json`** — remove the no-op `build:prompts` script.
- **`BUILDING_WINDOWS.md`** + **`scripts/start-dev.ps1`** — drop `npm run build:prompts;` from the documented Windows dev command and the PowerShell dev launcher (otherwise these would invoke a non-existent script).

## Out of scope (for a follow-up)

The issue's Context section claims `scripts/generate-prompts.mjs` and `src/generated/prompts.ts` no longer exist — they do still exist on `rc`. Removing them (and the references in `docs/agent-guides/PROMPTS-SPECS.md`) is a separate cleanup; this PR keeps the scope to what the issue's \"What to do\" section explicitly requests.

## Test plan

- [x] `npx prettier --check` on touched files — clean
- [x] `node -e \"JSON.parse(...)\"` on `package.json` — valid
- [x] `npm run build:prompts` after the change — fails with \"missing script\" (expected; no callers remain in `package.json`, the CI workflow, or the dev scripts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Windows development build instructions to reflect streamlined process.

* **Chores**
  * Removed unnecessary build step from CI workflow configuration, development startup scripts, and npm package configuration.
  * Simplified development startup sequence.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RunMaestro/Maestro/pull/985)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->