### PR TITLE
docs(cue): multi-root pipelines guide; fix validator misfire on missing source_session

### DIFF
--- a/docs/maestro-cue-configuration.md
+++ b/docs/maestro-cue-configuration.md
@@ -19,6 +19,10 @@ your-project/
 
 Maestro discovers this file automatically when the Cue Encore Feature is enabled. Each agent that has a `.maestro/cue.yaml` in its project root gets its own independent Cue engine instance.
 
+<Note>
+**One cue.yaml per agent project root.** The engine reads ONLY `<projectRoot>/.maestro/cue.yaml` for each agent — it does not walk parent directories and does not fall back to any ancestor or workspace-wide config. If your fleet has agents at multiple project roots, you maintain one cue.yaml per root. See [Multi-root pipelines](#multi-root-pipelines-agents-in-different-project-roots) below.
+</Note>
+
 ## Full Schema
 
 ```yaml
@@ -68,6 +72,30 @@ When two or more agents are registered against the same project directory (for e
 Accepted values for `owner_agent_id`: the agent's internal id (UUID) **or** its display name (e.g. `Obsidian`).
 
 Subscriptions with an explicit `agent_id` continue to fan out independently of ownership — useful when a single shared config intentionally targets multiple agents in the same workspace.
+
+## Multi-root pipelines (agents in different project roots)
+
+When a pipeline spans agents that live in **different** project roots, it is physically multiple cue.yaml files — one per participating agent's project root. The engine never aggregates yaml across roots, so a "single root cue.yaml" is not a reliable pattern for a multi-root agent fleet.
+
+**The rule:** Each subscription lives in the `.maestro/cue.yaml` of the agent that owns it. "Owning agent" = the agent whose `agent_id` matches the subscription's `agent_id` field. Cross-agent chains between subscriptions in different files are stitched at runtime via stable IDs in `source_session_ids` and `fan_out_ids` — they do not require a shared file.
+
+Where each role lives:
+
+| Subscription role                                                      | Lives in cue.yaml under...                                   |
+| ---------------------------------------------------------------------- | ------------------------------------------------------------ |
+| Trigger consumed by agent A (e.g. `file.changed` that prompts agent A) | Agent A's project root                                       |
+| Fan-out from A to [B, C, D]                                            | Agent A's project root (set `fan_out_ids` to B, C, D)        |
+| `agent.completed` chain step where upstream is X, downstream is Y      | Agent Y's project root (set `source_session_ids` to X)       |
+| Fan-in synthesis where upstreams are A, B, C and downstream is Z       | Agent Z's project root (set `source_session_ids` to A, B, C) |
+| Command node (`action: command`) attached to agent W's session         | Agent W's project root (it shares W's session and cwd)       |
+
+**Orchestration "at the root."** If you have an orchestrator agent whose project root sits above the worker agents in the filesystem, the orchestrator's own `.maestro/cue.yaml` is naturally where fan-in / synthesis subscriptions land — because it owns those subscriptions, not because it is "the root." Workers' triggers still live in each worker's own cue.yaml.
+
+**Use stable IDs across roots.** For chains and fan-out between agents at different roots, prefer the UUID-keyed fields (`source_session_ids: [<agent-uuid>]`, `fan_out_ids: [<uuid>, ...]`) over the legacy name-based fields (`source_session`, `fan_out`). Names are valid as a fallback but silently break when an agent is renamed; the UUID form survives renames.
+
+**Pipeline grouping across files.** A pipeline that spans roots still appears as one card in the Cue dashboard / Pipeline Editor as long as every participating subscription carries the same `pipeline_name` (and same `# Pipeline: Name (color: #hex)` comment header in each file). The visual editor handles this automatically; if you hand-author, keep the values consistent across every file.
+
+**The visual editor is the easy path.** When you save a multi-root pipeline from the Pipeline Editor, Maestro automatically partitions the subscriptions by owning agent's project root and writes one yaml per participating cwd. If you find yourself authoring a multi-root pipeline by hand and it gets fiddly, building it in the Pipeline Editor and letting it emit the per-cwd files is the supported path.
 
 ## Subscriptions
 

--- a/docs/maestro-cue-configuration.md
+++ b/docs/maestro-cue-configuration.md
@@ -46,8 +46,11 @@ subscriptions:
     schedule_times: list # Required for time.scheduled (HH:MM strings)
     schedule_days: list # Optional for time.scheduled (mon, tue, wed, thu, fri, sat, sun)
     watch: string # Required for file.changed, task.pending (glob pattern)
-    source_session: string | list # Required for agent.completed
-    fan_out: list # Optional. Target session names for fan-out
+    source_session: string | list # Required for agent.completed (display name or list of names)
+    source_session_ids: string | list # Optional companion to source_session — agent UUID(s). Preferred at runtime; survives renames
+    source_sub: string | list # Optional. Upstream subscription name(s) — required when action is "command". Aligns positionally with source_session arrays
+    fan_out: list # Optional. Target agent display names for fan-out
+    fan_out_ids: list # Optional companion to fan_out — agent UUIDs (parallel array). Preferred at runtime; survives renames
     filter: object # Optional. Payload field conditions
     repo: string # Optional for github.* (auto-detected if omitted)
     poll_minutes: number # Optional for github.*, task.pending
@@ -77,21 +80,21 @@ Subscriptions with an explicit `agent_id` continue to fan out independently of o
 
 When a pipeline spans agents that live in **different** project roots, it is physically multiple cue.yaml files — one per participating agent's project root. The engine never aggregates yaml across roots, so a "single root cue.yaml" is not a reliable pattern for a multi-root agent fleet.
 
-**The rule:** Each subscription lives in the `.maestro/cue.yaml` of the agent that owns it. "Owning agent" = the agent whose `agent_id` matches the subscription's `agent_id` field. Cross-agent chains between subscriptions in different files are stitched at runtime via stable IDs in `source_session_ids` and `fan_out_ids` — they do not require a shared file.
+**The rule:** Each subscription lives in the `.maestro/cue.yaml` of the agent that owns it. "Owning agent" = the agent whose `agent_id` matches the subscription's `agent_id` field. Cross-agent chains between subscriptions in different files are stitched at runtime via the standard `source_session` / `fan_out` fields plus their UUID-keyed companions (`source_session_ids` / `fan_out_ids`) — no shared file required.
 
 Where each role lives:
 
-| Subscription role                                                      | Lives in cue.yaml under...                                   |
-| ---------------------------------------------------------------------- | ------------------------------------------------------------ |
-| Trigger consumed by agent A (e.g. `file.changed` that prompts agent A) | Agent A's project root                                       |
-| Fan-out from A to [B, C, D]                                            | Agent A's project root (set `fan_out_ids` to B, C, D)        |
-| `agent.completed` chain step where upstream is X, downstream is Y      | Agent Y's project root (set `source_session_ids` to X)       |
-| Fan-in synthesis where upstreams are A, B, C and downstream is Z       | Agent Z's project root (set `source_session_ids` to A, B, C) |
-| Command node (`action: command`) attached to agent W's session         | Agent W's project root (it shares W's session and cwd)       |
+| Subscription role                                                      | Lives in cue.yaml under...                                                        |
+| ---------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| Trigger consumed by agent A (e.g. `file.changed` that prompts agent A) | Agent A's project root                                                            |
+| Fan-out from A to [B, C, D]                                            | Agent A's project root (set `fan_out` + `fan_out_ids`)                            |
+| `agent.completed` chain step where upstream is X, downstream is Y      | Agent Y's project root (set `source_session` + `source_session_ids` to X)         |
+| Fan-in synthesis where upstreams are A, B, C and downstream is Z       | Agent Z's project root (set `source_session` + `source_session_ids` to [A, B, C]) |
+| Command node (`action: command`) attached to agent W's session         | Agent W's project root (it shares W's session and cwd)                            |
 
 **Orchestration "at the root."** If you have an orchestrator agent whose project root sits above the worker agents in the filesystem, the orchestrator's own `.maestro/cue.yaml` is naturally where fan-in / synthesis subscriptions land — because it owns those subscriptions, not because it is "the root." Workers' triggers still live in each worker's own cue.yaml.
 
-**Use stable IDs across roots.** For chains and fan-out between agents at different roots, prefer the UUID-keyed fields (`source_session_ids: [<agent-uuid>]`, `fan_out_ids: [<uuid>, ...]`) over the legacy name-based fields (`source_session`, `fan_out`). Names are valid as a fallback but silently break when an agent is renamed; the UUID form survives renames.
+**Always set `source_session` / `fan_out`; add the `_ids` companions for rename stability.** The validator requires `source_session` on every `agent.completed` subscription, and `fan_out` is the canonical field for fan-out targets. **Additionally** populate the parallel UUID arrays — `source_session_ids: [<agent-uuid>]` next to `source_session: <agent-name>`, `fan_out_ids: [<uuid>, ...]` next to `fan_out: [<name>, ...]`. The dispatcher prefers ids at lookup time and falls back to names, so cross-root edges survive an upstream agent rename. Omitting the ids works but silently breaks on rename.
 
 **Pipeline grouping across files.** A pipeline that spans roots still appears as one card in the Cue dashboard / Pipeline Editor as long as every participating subscription carries the same `pipeline_name` (and same `# Pipeline: Name (color: #hex)` comment header in each file). The visual editor handles this automatically; if you hand-author, keep the values consistent across every file.
 
@@ -115,23 +118,26 @@ Either `prompt` or `prompt_file` must be provided. If both are present, `prompt_
 
 ### Optional Fields
 
-| Field                | Type            | Default | Description                                                                 |
-| -------------------- | --------------- | ------- | --------------------------------------------------------------------------- |
-| `enabled`            | boolean         | `true`  | Set to `false` to pause a subscription without removing it                  |
-| `agent_id`           | string (UUID)   | —       | UUID of the target agent. Auto-assigned by the Pipeline Editor              |
-| `prompt_file`        | string          | —       | Path to a `.md` file containing the prompt (alternative to inline `prompt`) |
-| `interval_minutes`   | number          | —       | Timer interval. Required for `time.heartbeat`                               |
-| `schedule_times`     | list of strings | —       | Times in `HH:MM` format. Required for `time.scheduled`                      |
-| `schedule_days`      | list of strings | —       | Days of week (`mon`–`sun`). Optional for `time.scheduled`                   |
-| `watch`              | string (glob)   | —       | File glob pattern. Required for `file.changed`, `task.pending`              |
-| `source_session`     | string or list  | —       | Source agent name(s). Required for `agent.completed`                        |
-| `fan_out`            | list of strings | —       | Target agent names to fan out to                                            |
-| `filter`             | object          | —       | Payload conditions (see [Filtering](./maestro-cue-advanced#filtering))      |
-| `repo`               | string          | —       | GitHub repo (`owner/repo`). Auto-detected from git remote                   |
-| `poll_minutes`       | number          | varies  | Poll interval for `github.*` (default 5) and `task.pending` (default 1)     |
-| `output_prompt`      | string          | —       | Follow-up prompt sent after the main run completes successfully             |
-| `output_prompt_file` | string          | —       | Path to a `.md` file for the output prompt (alternative to inline)          |
-| `label`              | string          | —       | Human-readable label displayed in the Cue dashboard and pipeline editor     |
+| Field                | Type            | Default | Description                                                                                                                                                                                                                               |
+| -------------------- | --------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `enabled`            | boolean         | `true`  | Set to `false` to pause a subscription without removing it                                                                                                                                                                                |
+| `agent_id`           | string (UUID)   | —       | UUID of the target agent. Auto-assigned by the Pipeline Editor                                                                                                                                                                            |
+| `prompt_file`        | string          | —       | Path to a `.md` file containing the prompt (alternative to inline `prompt`)                                                                                                                                                               |
+| `interval_minutes`   | number          | —       | Timer interval. Required for `time.heartbeat`                                                                                                                                                                                             |
+| `schedule_times`     | list of strings | —       | Times in `HH:MM` format. Required for `time.scheduled`                                                                                                                                                                                    |
+| `schedule_days`      | list of strings | —       | Days of week (`mon`–`sun`). Optional for `time.scheduled`                                                                                                                                                                                 |
+| `watch`              | string (glob)   | —       | File glob pattern. Required for `file.changed`, `task.pending`                                                                                                                                                                            |
+| `source_session`     | string or list  | —       | Source agent display name(s). Required for `agent.completed`                                                                                                                                                                              |
+| `source_session_ids` | string or list  | —       | Companion UUID(s) for `source_session`. Same shape (string ↔ string, list ↔ list). Preferred by the dispatcher at lookup time; falls back to `source_session` names when absent. Set this alongside `source_session` for rename stability |
+| `source_sub`         | string or list  | —       | Upstream subscription name(s) that narrow chain matching. **Required** when `action: command` on `agent.completed`. When `source_session` is an array, `source_sub` must be a same-length array (positional pairing)                      |
+| `fan_out`            | list of strings | —       | Target agent display names to fan out to                                                                                                                                                                                                  |
+| `fan_out_ids`        | list of strings | —       | Companion UUID array for `fan_out` (one entry per fan-out target). Preferred by the dispatcher at lookup time; falls back to `fan_out` names when absent. Set this alongside `fan_out` for rename stability                               |
+| `filter`             | object          | —       | Payload conditions (see [Filtering](./maestro-cue-advanced#filtering))                                                                                                                                                                    |
+| `repo`               | string          | —       | GitHub repo (`owner/repo`). Auto-detected from git remote                                                                                                                                                                                 |
+| `poll_minutes`       | number          | varies  | Poll interval for `github.*` (default 5) and `task.pending` (default 1)                                                                                                                                                                   |
+| `output_prompt`      | string          | —       | Follow-up prompt sent after the main run completes successfully                                                                                                                                                                           |
+| `output_prompt_file` | string          | —       | Path to a `.md` file for the output prompt (alternative to inline)                                                                                                                                                                        |
+| `label`              | string          | —       | Human-readable label displayed in the Cue dashboard and pipeline editor                                                                                                                                                                   |
 
 ### Prompt Field
 

--- a/docs/maestro-cue-examples.md
+++ b/docs/maestro-cue-examples.md
@@ -90,6 +90,10 @@ Lint, test, and deploy in sequence. Each step only runs if the previous one succ
 
 **Agents needed:** `linter`, `tester`, `deployer`
 
+<Note>
+This example assumes each agent has its own project root and therefore its own `.maestro/cue.yaml`. The three files below live under three different project roots — that's the supported pattern for multi-root pipelines (the engine reads each agent's own cue.yaml and never aggregates across roots). See [Multi-root pipelines](./maestro-cue-configuration#multi-root-pipelines-agents-in-different-project-roots) for the full rule. If all three agents share one project root, put all three subscriptions in a single `.maestro/cue.yaml` and use `agent_id` (or `settings.owner_agent_id` plus an explicit `agent_id` per sub) to route each one.
+</Note>
+
 The `linter` agent's `.maestro/cue.yaml`:
 
 ```yaml

--- a/docs/maestro-cue.md
+++ b/docs/maestro-cue.md
@@ -146,7 +146,7 @@ The header **?** button opens a built-in quick-reference guide covering Cue's pu
 
 ## Configuration File
 
-Cue is configured via a `.maestro/cue.yaml` file placed inside the `.maestro/` directory at your project root. See the [Configuration Reference](./maestro-cue-configuration) for the complete YAML schema.
+Cue is configured via a `.maestro/cue.yaml` file placed inside the `.maestro/` directory at your project root. Each agent has its **own** cue.yaml under its **own** project root — the engine reads only that file (no parent-directory walk, no shared workspace file). For pipelines that span agents at different roots, see [Multi-root pipelines](./maestro-cue-configuration#multi-root-pipelines-agents-in-different-project-roots) in the Configuration Reference. See the [Configuration Reference](./maestro-cue-configuration) for the complete YAML schema.
 
 ## Event Types
 

--- a/src/__tests__/main/cue/cue-yaml-loader.test.ts
+++ b/src/__tests__/main/cue/cue-yaml-loader.test.ts
@@ -112,6 +112,7 @@ subscriptions:
   - name: relay
     event: agent.completed
     source_session: researcher
+    source_sub: researcher-step
     action: command
     command:
       mode: cli
@@ -125,6 +126,7 @@ subscriptions:
 			expect(result).not.toBeNull();
 			const sub = result!.subscriptions[0];
 			expect(sub.action).toBe('command');
+			expect(sub.source_sub).toBe('researcher-step');
 			expect(sub.command).toEqual({
 				mode: 'cli',
 				cli: {
@@ -809,6 +811,35 @@ subscriptions:
 			});
 			expect(result.valid).toBe(false);
 			expect(result.errors).toEqual(
+				expect.arrayContaining([
+					expect.stringContaining(
+						'"source_sub" must be a string when "source_session" is a string'
+					),
+				])
+			);
+		});
+
+		it('does not emit a misleading source_sub/source_session shape error when source_session is missing', () => {
+			// Regression: the type-shape consistency check used to fire
+			// "source_sub must be a string when source_session is a string" even
+			// though source_session was undefined (the required-field check above
+			// already errored). Verify that only the required-field error is
+			// surfaced for the missing source_session, not the shape error.
+			const result = validateCueConfig({
+				subscriptions: [
+					{
+						name: 'missing-source-session',
+						event: 'agent.completed',
+						source_sub: ['chain-a'],
+						prompt: '{{CUE_SOURCE_OUTPUT}}',
+					},
+				],
+			});
+			expect(result.valid).toBe(false);
+			expect(result.errors).toEqual(
+				expect.arrayContaining([expect.stringContaining('"source_session" is required')])
+			);
+			expect(result.errors).not.toEqual(
 				expect.arrayContaining([
 					expect.stringContaining(
 						'"source_sub" must be a string when "source_session" is a string'

--- a/src/__tests__/main/cue/cue-yaml-loader.test.ts
+++ b/src/__tests__/main/cue/cue-yaml-loader.test.ts
@@ -848,6 +848,34 @@ subscriptions:
 			);
 		});
 
+		it('does not emit a misleading source_sub/source_session shape error when source_session is explicitly null', () => {
+			// YAML `source_session: ~` parses to null. The shape-check guard
+			// must treat null the same as undefined so a `~` value doesn't
+			// produce both a required-field error AND a misleading shape error.
+			const result = validateCueConfig({
+				subscriptions: [
+					{
+						name: 'null-source-session',
+						event: 'agent.completed',
+						source_session: null,
+						source_sub: ['chain-a'],
+						prompt: '{{CUE_SOURCE_OUTPUT}}',
+					},
+				],
+			});
+			expect(result.valid).toBe(false);
+			expect(result.errors).toEqual(
+				expect.arrayContaining([expect.stringContaining('"source_session" is required')])
+			);
+			expect(result.errors).not.toEqual(
+				expect.arrayContaining([
+					expect.stringContaining(
+						'"source_sub" must be a string when "source_session" is a string'
+					),
+				])
+			);
+		});
+
 		it('accepts prompt_file as alternative to prompt', () => {
 			const result = validateCueConfig({
 				subscriptions: [

--- a/src/main/cue/config/cue-config-validator.ts
+++ b/src/main/cue/config/cue-config-validator.ts
@@ -368,12 +368,15 @@ function validateEventSpecificFields(
 		}
 		// For fan-in chains, source_sub should align positionally with
 		// source_session so each upstream source maps to its exact upstream sub.
-		// Skip when source_session is undefined — the required-field check above
-		// already errored, and re-emitting a misleading "must be a string when
-		// source_session is a string" here just adds noise.
+		// Skip when either side is null/undefined — the required-field check
+		// above already errored on absent source_session, and re-emitting a
+		// misleading "must be a string when source_session is a string" here
+		// just adds noise. `!= null` intentionally treats `null` and `undefined`
+		// the same: a YAML `source_session: ~` or `source_session: null` parses
+		// to null but is semantically the same "absent" case.
 		const sourceSession = sub.source_session;
 		const sourceSub = sub.source_sub;
-		if (sourceSession !== undefined && sourceSub !== undefined) {
+		if (sourceSession != null && sourceSub != null) {
 			const sourceSessionIsArray = Array.isArray(sourceSession);
 			const sourceSubIsArray = Array.isArray(sourceSub);
 			if (sourceSessionIsArray && sourceSubIsArray) {

--- a/src/main/cue/config/cue-config-validator.ts
+++ b/src/main/cue/config/cue-config-validator.ts
@@ -368,20 +368,25 @@ function validateEventSpecificFields(
 		}
 		// For fan-in chains, source_sub should align positionally with
 		// source_session so each upstream source maps to its exact upstream sub.
+		// Skip when source_session is undefined — the required-field check above
+		// already errored, and re-emitting a misleading "must be a string when
+		// source_session is a string" here just adds noise.
 		const sourceSession = sub.source_session;
 		const sourceSub = sub.source_sub;
-		const sourceSessionIsArray = Array.isArray(sourceSession);
-		const sourceSubIsArray = Array.isArray(sourceSub);
-		if (Array.isArray(sourceSession) && Array.isArray(sourceSub)) {
-			if (sourceSession.length !== sourceSub.length) {
-				errors.push(
-					`${prefix}: "source_sub" length (${sourceSub.length}) must match "source_session" length (${sourceSession.length})`
-				);
+		if (sourceSession !== undefined && sourceSub !== undefined) {
+			const sourceSessionIsArray = Array.isArray(sourceSession);
+			const sourceSubIsArray = Array.isArray(sourceSub);
+			if (sourceSessionIsArray && sourceSubIsArray) {
+				if (sourceSession.length !== sourceSub.length) {
+					errors.push(
+						`${prefix}: "source_sub" length (${sourceSub.length}) must match "source_session" length (${sourceSession.length})`
+					);
+				}
+			} else if (sourceSessionIsArray && typeof sourceSub === 'string') {
+				errors.push(`${prefix}: "source_sub" must be an array when "source_session" is an array`);
+			} else if (!sourceSessionIsArray && sourceSubIsArray) {
+				errors.push(`${prefix}: "source_sub" must be a string when "source_session" is a string`);
 			}
-		} else if (sourceSessionIsArray && typeof sourceSub === 'string') {
-			errors.push(`${prefix}: "source_sub" must be an array when "source_session" is an array`);
-		} else if (!sourceSessionIsArray && sourceSubIsArray) {
-			errors.push(`${prefix}: "source_sub" must be a string when "source_session" is a string`);
 		}
 	} else if (event === 'task.pending') {
 		if (!sub.watch || typeof sub.watch !== 'string') {

--- a/src/prompts/_maestro-cue.md
+++ b/src/prompts/_maestro-cue.md
@@ -12,7 +12,7 @@ When you need to find an existing config, check `.maestro/cue.yaml` first, then 
 
 Each subscription has a unique `name`, an `event` type, an `enabled` flag, a `prompt` (with template variables), and event-specific fields.
 
-**One cue.yaml per agent project root.** The engine reads ONLY `<projectRoot>/.maestro/cue.yaml` for each agent — there is no parent-directory walk, no ancestor fallback, and no shared "global" cue.yaml. If your fleet has agents at three different project roots, you maintain three cue.yaml files. See **Multi-Root Pipelines** below before authoring a pipeline that spans more than one project root.
+**One cue.yaml per agent project root.** Each agent's engine looks for the canonical `<projectRoot>/.maestro/cue.yaml` (falling back to the legacy `<projectRoot>/maestro-cue.yaml` as described in the canonical-first + legacy-fallback rule above), **scoped strictly to that agent's own project root** — there is no parent-directory walk, no ancestor fallback into a workspace-wide config, and no implicit aggregation across roots. If your fleet has agents at three different project roots, you maintain three cue.yaml files (one per root, canonical or legacy per the rule above). See **Multi-Root Pipelines** below before authoring a pipeline that spans more than one project root.
 
 ### Event Types
 

--- a/src/prompts/_maestro-cue.md
+++ b/src/prompts/_maestro-cue.md
@@ -12,6 +12,8 @@ When you need to find an existing config, check `.maestro/cue.yaml` first, then 
 
 Each subscription has a unique `name`, an `event` type, an `enabled` flag, a `prompt` (with template variables), and event-specific fields.
 
+**One cue.yaml per agent project root.** The engine reads ONLY `<projectRoot>/.maestro/cue.yaml` for each agent — there is no parent-directory walk, no ancestor fallback, and no shared "global" cue.yaml. If your fleet has agents at three different project roots, you maintain three cue.yaml files. See **Multi-Root Pipelines** below before authoring a pipeline that spans more than one project root.
+
 ### Event Types
 
 | Event                 | Fires when…                                     | Key config fields                                     |
@@ -248,13 +250,44 @@ Pass `--source-agent-id {{AGENT_ID}}` so a subscription with `cli_output` can ro
 
 When a user asks you to add, modify, or debug a Cue subscription:
 
-1. Read the existing config first to understand current subscriptions, pipelines, and naming conventions. Check `.maestro/cue.yaml` (canonical) first, then `maestro-cue.yaml` at the project root (legacy fallback).
+1. Read the existing config first to understand current subscriptions, pipelines, and naming conventions. Check `.maestro/cue.yaml` (canonical) first, then `maestro-cue.yaml` at the project root (legacy fallback). **If the pipeline involves agents at more than one project root, you must read every participating agent's cue.yaml — there is no single aggregated file.** See **Multi-Root Pipelines** above.
 2. Keep subscription `name` values unique within the file — the engine keys on them.
 3. **Group related chains under one pipeline.** Before adding a new subscription, check whether it belongs in an existing pipeline (matching theme, agent set, or domain) — if so, reuse that `pipeline_name` instead of creating a new pipeline. If the user describes several related automations in one request, emit them as multiple subscriptions sharing a single `pipeline_name`, not as separate pipelines.
 4. **Within a pipeline, give each subscription its own `target_node_key`** (any UUID) so the Pipeline Editor renders the chains as separate visual lines instead of collapsing them onto one fan-in agent node. This applies whether the chains share an `agent_id` or not. Only reuse a `target_node_key` across subscriptions when you actually want a real fan-in node (multiple triggers/upstreams converging onto one shared agent node). If two chains genuinely need isolated context/models/project-roots, also give them distinct `agent_id`s (create with `{{MAESTRO_CLI_PATH}} create-agent <name> --cwd <project>` if needed); otherwise reusing one `agent_id` is fine and often preferred.
 5. **For Command nodes (shell scripts or `maestro-cli` calls inside a pipeline)** — see the **Command Nodes** section above for the full schema. The keyword is `action: command` plus a `command:` block; there is no separate top-level YAML key, no `event: command` type, and no separate node graph.
 6. For full schema, field reference, and worked examples, fetch the official Cue docs: https://docs.runmaestro.ai/maestro-cue-configuration, https://docs.runmaestro.ai/maestro-cue-events, https://docs.runmaestro.ai/maestro-cue-advanced, https://docs.runmaestro.ai/maestro-cue-examples. Don't guess field names.
 7. After writing, validate with `{{MAESTRO_CLI_PATH}} cue list` — the engine reloads automatically when the file changes.
+
+### Multi-Root Pipelines (agents in different project roots)
+
+A pipeline that spans agents living in **different** project roots is NOT a single-file authoring task. The engine never aggregates yaml files across roots — each agent's runtime only sees `<its-own-projectRoot>/.maestro/cue.yaml`. A pipeline split across N agents at N different roots is physically N separate yaml files; the visual Pipeline Editor manages this for you by writing one file per participating agent's cwd on every save.
+
+**When authoring multi-root pipelines by hand, the rule is:**
+
+- **Each subscription lives in its owning agent's local `.maestro/cue.yaml`.** "Owning agent" = the agent whose `agent_id` matches the subscription's `agent_id` field. Put the subscription in that agent's project root, not anywhere else.
+- **Cross-agent chains stitch at runtime via stable IDs, not via shared files.** Use `source_session_ids: [<upstream-agent-uuid>]` (and/or `source_session: <upstream-agent-name>` as a fallback) for `agent.completed` chains; use `fan_out_ids: [<target-agent-uuid>, ...]` for fan-out. The downstream subscription itself lives in the _downstream_ (consuming) agent's cue.yaml — the agent whose `agent_id` it carries.
+- **Fan-in / synthesis / orchestration subscriptions live with their target agent.** If "agent X waits for A, B, C to complete and summarizes," that fan-in subscription is in agent X's cue.yaml (not in A's, B's, or C's). When agent X is an orchestrator sitting at the workspace root and the workers are in subdirectories, that fan-in naturally lands in the root workspace's `.maestro/cue.yaml` — but the rule is "owning agent's cwd," not "root cwd."
+- **A single root cue.yaml is NOT a reliable pattern for a multi-root fleet.** Subscriptions placed at the root that name workers in subdirectories will never reach those workers — the workers' engines never read the root file. If the visual editor previously emitted a single root yaml that "worked," that pipeline only had subs whose `agent_id` resolved to the root agent.
+
+**Where to author what:**
+
+| Subscription role                                                       | Lives in cue.yaml under...                                   |
+| ----------------------------------------------------------------------- | ------------------------------------------------------------ |
+| Trigger consumed by agent A (e.g. `file.changed` that prompts agent A)  | Agent A's project root                                       |
+| Fan-out from A to [B, C, D]                                             | Agent A's project root (set `fan_out_ids` to B, C, D)        |
+| `agent.completed` chain step where downstream is agent Y, upstream is X | Agent Y's project root (set `source_session_ids` to X)       |
+| Fan-in synthesis where downstream is Z, upstreams are A, B, C           | Agent Z's project root (set `source_session_ids` to A, B, C) |
+| Command node (`action: command`) attached to agent W's session          | Agent W's project root (it shares W's session/cwd)           |
+
+**Discovery / writing checklist for hand-edited multi-root pipelines:**
+
+1. List the participating agents and their project roots: `{{MAESTRO_CLI_PATH}} list agents` (note each agent's `id` and `cwd`).
+2. For each agent that owns one or more subscriptions in the pipeline, open / create `<that-agent-cwd>/.maestro/cue.yaml`.
+3. Write each subscription under the cue.yaml of its `agent_id` owner. Use the same `pipeline_name` value across all files so the dashboard groups them under one pipeline card.
+4. For cross-agent references, prefer stable UUIDs in `source_session_ids` and `fan_out_ids` over the legacy name-based `source_session` / `fan_out` (names are valid as a fallback but break on rename).
+5. Validate from any agent's workspace with `{{MAESTRO_CLI_PATH}} cue list` — the command reports every agent's parsed config, so a missing or misplaced sub is immediately visible.
+
+**Single-root pipelines** (all subs target one agent, or all participating agents share one project root) live in exactly one cue.yaml under that one root — the multi-root rules above don't apply. The "Shared Workspaces" section below covers the related case where >1 agent is registered against the _same_ project root.
 
 ### Shared Workspaces: `settings.owner_agent_id`
 

--- a/src/prompts/_maestro-cue.md
+++ b/src/prompts/_maestro-cue.md
@@ -265,26 +265,26 @@ A pipeline that spans agents living in **different** project roots is NOT a sing
 **When authoring multi-root pipelines by hand, the rule is:**
 
 - **Each subscription lives in its owning agent's local `.maestro/cue.yaml`.** "Owning agent" = the agent whose `agent_id` matches the subscription's `agent_id` field. Put the subscription in that agent's project root, not anywhere else.
-- **Cross-agent chains stitch at runtime via stable IDs, not via shared files.** Use `source_session_ids: [<upstream-agent-uuid>]` (and/or `source_session: <upstream-agent-name>` as a fallback) for `agent.completed` chains; use `fan_out_ids: [<target-agent-uuid>, ...]` for fan-out. The downstream subscription itself lives in the _downstream_ (consuming) agent's cue.yaml — the agent whose `agent_id` it carries.
+- **Cross-agent chains stitch at runtime via the standard `source_session` / `fan_out` fields, with `_ids` companions for rename stability.** For `agent.completed` chains, `source_session` (the upstream agent's display name, or an array of names for fan-in) is **required** by the validator — supply `source_session_ids: [<upstream-agent-uuid>]` **alongside** it so the dispatcher can resolve the chain even if the upstream is renamed (ids are preferred at lookup time, names are the fallback). Same shape for fan-out: `fan_out: [<target-name>, ...]` is the canonical field, plus `fan_out_ids: [<uuid>, ...]` for rename safety. The downstream subscription itself lives in the _downstream_ (consuming) agent's cue.yaml — the agent whose `agent_id` it carries.
 - **Fan-in / synthesis / orchestration subscriptions live with their target agent.** If "agent X waits for A, B, C to complete and summarizes," that fan-in subscription is in agent X's cue.yaml (not in A's, B's, or C's). When agent X is an orchestrator sitting at the workspace root and the workers are in subdirectories, that fan-in naturally lands in the root workspace's `.maestro/cue.yaml` — but the rule is "owning agent's cwd," not "root cwd."
 - **A single root cue.yaml is NOT a reliable pattern for a multi-root fleet.** Subscriptions placed at the root that name workers in subdirectories will never reach those workers — the workers' engines never read the root file. If the visual editor previously emitted a single root yaml that "worked," that pipeline only had subs whose `agent_id` resolved to the root agent.
 
 **Where to author what:**
 
-| Subscription role                                                       | Lives in cue.yaml under...                                   |
-| ----------------------------------------------------------------------- | ------------------------------------------------------------ |
-| Trigger consumed by agent A (e.g. `file.changed` that prompts agent A)  | Agent A's project root                                       |
-| Fan-out from A to [B, C, D]                                             | Agent A's project root (set `fan_out_ids` to B, C, D)        |
-| `agent.completed` chain step where downstream is agent Y, upstream is X | Agent Y's project root (set `source_session_ids` to X)       |
-| Fan-in synthesis where downstream is Z, upstreams are A, B, C           | Agent Z's project root (set `source_session_ids` to A, B, C) |
-| Command node (`action: command`) attached to agent W's session          | Agent W's project root (it shares W's session/cwd)           |
+| Subscription role                                                       | Lives in cue.yaml under...                                                        |
+| ----------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| Trigger consumed by agent A (e.g. `file.changed` that prompts agent A)  | Agent A's project root                                                            |
+| Fan-out from A to [B, C, D]                                             | Agent A's project root (set `fan_out` + `fan_out_ids`)                            |
+| `agent.completed` chain step where downstream is agent Y, upstream is X | Agent Y's project root (set `source_session` + `source_session_ids` to X)         |
+| Fan-in synthesis where downstream is Z, upstreams are A, B, C           | Agent Z's project root (set `source_session` + `source_session_ids` to [A, B, C]) |
+| Command node (`action: command`) attached to agent W's session          | Agent W's project root (it shares W's session/cwd)                                |
 
 **Discovery / writing checklist for hand-edited multi-root pipelines:**
 
 1. List the participating agents and their project roots: `{{MAESTRO_CLI_PATH}} list agents` (note each agent's `id` and `cwd`).
 2. For each agent that owns one or more subscriptions in the pipeline, open / create `<that-agent-cwd>/.maestro/cue.yaml`.
 3. Write each subscription under the cue.yaml of its `agent_id` owner. Use the same `pipeline_name` value across all files so the dashboard groups them under one pipeline card.
-4. For cross-agent references, prefer stable UUIDs in `source_session_ids` and `fan_out_ids` over the legacy name-based `source_session` / `fan_out` (names are valid as a fallback but break on rename).
+4. For cross-agent references, always set `source_session` / `fan_out` (the validator requires `source_session` on every `agent.completed` sub) and **additionally** set the parallel `source_session_ids` / `fan_out_ids` UUID arrays so the dispatcher survives an upstream rename. The dispatcher prefers ids at lookup time; names are the fallback. Omitting the ids works but breaks silently when an agent gets renamed.
 5. Validate from any agent's workspace with `{{MAESTRO_CLI_PATH}} cue list` — the command reports every agent's parsed config, so a missing or misplaced sub is immediately visible.
 
 **Single-root pipelines** (all subs target one agent, or all participating agents share one project root) live in exactly one cue.yaml under that one root — the multi-root rules above don't apply. The "Shared Workspaces" section below covers the related case where >1 agent is registered against the _same_ project root.


### PR DESCRIPTION
## Summary

Documents the per-agent-cwd model for multi-root Cue pipelines and fixes a small validator misfire flagged by review bots on a related PR.

**Two commits, 6 files, +139 / -32. Docs + one validator guard tightening + one regression test.**

### Multi-root pipelines docs (commit 1)

The Cue engine reads only `<projectRoot>/.maestro/cue.yaml` for each agent — no parent-directory walk, no ancestor fallback, no shared workspace file. A pipeline spanning agents at different project roots is physically multiple yaml files (one per participating agent's cwd), stitched at runtime via `agent_id` references in `source_session_ids` / `fan_out_ids`. The visual Pipeline Editor handles this automatically; agents authoring YAML by hand need explicit guidance.

Added:
- A "Multi-Root Pipelines" section in the agent-facing prompt (`src/prompts/_maestro-cue.md`) and a mirrored "Multi-root pipelines" section in the user-facing configuration reference (`docs/maestro-cue-configuration.md`), both with a per-role placement table (trigger / fan-out / chain / fan-in / command) and a hand-authoring checklist.
- A `<Note>` callout under File Location in `maestro-cue-configuration.md` linking to the new section.
- An updated "Configuration File" paragraph in `maestro-cue.md` clarifying the per-agent-cwd model.
- A `<Note>` on the CI-Style Pipeline example in `maestro-cue-examples.md` annotating it as the canonical multi-root pattern (three separate yamls) vs. the same-root case with `agent_id` routing in one file.

### Validator misfire fix + schema-reference catch-up (commit 2)

Greptile and CodeRabbit flagged two issues downstream of PR #976's `source_sub` validator rule (already on `rc`):

1. **Doc/validator mismatch.** The Multi-root docs originally said "prefer `source_session_ids` over `source_session`" — but the validator (correctly) requires `source_session` on every `agent.completed` sub. An agent reading the guidance literally would write invalid YAML. Reframed the prose to make the `_ids` fields **companions** (for rename stability) rather than replacements.
2. **Schema-reference gap.** `source_session_ids` / `source_sub` / `fan_out_ids` were documented in prose but missing from the Full Schema block and the Optional Fields table. Added them.
3. **Misfiring type-shape guard in `cue-config-validator.ts`.** When `source_session` was undefined (which the required-field check above already errors on), the type-shape check still emitted `"source_sub" must be a string when "source_session" is a string` — a misleading second error against an undefined value. Wrapped the shape check in `if (sourceSession !== undefined && sourceSub !== undefined)`. Added a regression test that asserts only the required-field error fires in that case.
4. **Loader fixture refresh.** The CLI-send fixture at `cue-yaml-loader.test.ts:108-136` was an `agent.completed + action: command` config that became semantically invalid under #976's `source_sub` requirement. Added `source_sub: researcher-step` to keep the fixture valid; asserts it round-trips (CodeRabbit's outside-diff Quick Win).

## Files changed (6)

| File | Change |
| --- | --- |
| `docs/maestro-cue-configuration.md` | Multi-root section + schema reference catch-up |
| `docs/maestro-cue.md` | Configuration File copy linking to multi-root section |
| `docs/maestro-cue-examples.md` | Note on the CI-Style Pipeline example |
| `src/prompts/_maestro-cue.md` | Multi-Root Pipelines section + `_ids` companion-field framing |
| `src/main/cue/config/cue-config-validator.ts` | Skip type-shape check when `source_session` undefined |
| `src/__tests__/main/cue/cue-yaml-loader.test.ts` | Fixture update + regression case for the misfire fix |

## Notes

- Replaces #986, which was force-pushed multiple times and accumulated review noise from when the branch still carried two commits (`b9f5b401`, `a8cb55f5`) duplicating work already on `rc` via #976. Same final tree, clean history.
- No new behavior — just docs + one error-message cleanup. The `source_sub` requirement and the new validator/renderer rules pedram and bots discussed all live on `rc` already via #976.

## Test plan

- [x] `npx vitest run src/__tests__/main/cue/cue-yaml-loader.test.ts` — 143 pass, 0 fail (includes the new validator regression case).
- [x] `npx vitest run src/__tests__/renderer/components/CuePipelineEditor/utils/` — 346 pass, 0 fail.
- [x] Prettier clean across all touched files.
- [ ] CI `lint-and-format` + `test` green on the latest push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented misleading duplicate validation errors for certain multi-root subscription fields.

* **Documentation**
  * Clarified that each agent project root has its own .maestro/cue.yaml (no parent/workspace fallback).
  * Expanded subscription schema with UUID-aware companion fields and fan-out/chain narrowing guidance.
  * Added a “Multi-root pipelines” section explaining runtime stitching across roots.

* **Tests**
  * Added regression tests to cover the validation behavior above.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RunMaestro/Maestro/pull/987)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->