### PR TITLE
Show Thinking From Remote Controllers

### DIFF
--- a/AGENT_SUPPORT.md
+++ b/AGENT_SUPPORT.md
@@ -671,14 +671,15 @@ describe('YourAgentOutputParser', () => {
 
 ### Claude Code ✅ Fully Implemented
 
-| Aspect           | Value                                |
-| ---------------- | ------------------------------------ |
-| Binary           | `claude`                             |
-| JSON Output      | `--output-format stream-json`        |
-| Resume           | `--resume <session-id>`              |
-| Read-only        | `--permission-mode plan`             |
-| Session ID Field | `session_id` (snake_case)            |
-| Session Storage  | `~/.claude/projects/<encoded-path>/` |
+| Aspect                     | Value                                                                                       |
+| -------------------------- | ------------------------------------------------------------------------------------------- |
+| Binary                     | `claude`                                                                                    |
+| JSON Output                | `--output-format stream-json`                                                               |
+| Resume                     | `--resume <session-id>`                                                                     |
+| Read-only                  | `--permission-mode plan`                                                                    |
+| Session ID Field           | `session_id` (snake_case)                                                                   |
+| Session Storage            | `~/.claude/projects/<encoded-path>/`                                                        |
+| External Activity Tracking | ✅ Supported — JSONL append watcher (see [[CLAUDE-AGENTS.md]] § External Activity Tracking) |
 
 **Implementation Status:**
 
@@ -697,17 +698,18 @@ describe('YourAgentOutputParser', () => {
 
 ### OpenCode 🔄 Stub Ready
 
-| Aspect           | Value                                                         |
-| ---------------- | ------------------------------------------------------------- |
-| Binary           | `opencode`                                                    |
-| JSON Output      | `--format json`                                               |
-| Resume           | `--session <session-id>`                                      |
-| Read-only        | `--agent plan`                                                |
-| Session ID Field | `sessionID` (camelCase)                                       |
-| Session Storage  | ✅ File-based (see below)                                     |
-| YOLO Mode        | ✅ Auto-enabled in batch mode                                 |
-| Model Selection  | `--model provider/model`                                      |
-| Config File      | `~/.config/opencode/opencode.json` or project `opencode.json` |
+| Aspect                     | Value                                                                                                  |
+| -------------------------- | ------------------------------------------------------------------------------------------------------ |
+| Binary                     | `opencode`                                                                                             |
+| JSON Output                | `--format json`                                                                                        |
+| Resume                     | `--session <session-id>`                                                                               |
+| Read-only                  | `--agent plan`                                                                                         |
+| Session ID Field           | `sessionID` (camelCase)                                                                                |
+| Session Storage            | ✅ File-based (see below)                                                                              |
+| YOLO Mode                  | ✅ Auto-enabled in batch mode                                                                          |
+| Model Selection            | `--model provider/model`                                                                               |
+| Config File                | `~/.config/opencode/opencode.json` or project `opencode.json`                                          |
+| External Activity Tracking | ✅ Supported — per-message-file create watcher (see [[CLAUDE-AGENTS.md]] § External Activity Tracking) |
 
 **YOLO Mode (Auto-Approval) Details:**
 
@@ -881,18 +883,19 @@ Since OpenCode supports multiple providers/models, Maestro should consider:
 
 ### Codex ✅ Fully Implemented
 
-| Aspect           | Value                                                             |
-| ---------------- | ----------------------------------------------------------------- |
-| Binary           | `codex`                                                           |
-| JSON Output      | `--json`                                                          |
-| Batch Mode       | `exec` subcommand                                                 |
-| Resume           | `resume <thread_id>` (v0.30.0+)                                   |
-| Read-only        | `--sandbox read-only`                                             |
-| YOLO Mode        | `--dangerously-bypass-approvals-and-sandbox` (enabled by default) |
-| Session ID Field | `thread_id` (from `thread.started` event)                         |
-| Session Storage  | `~/.codex/sessions/YYYY/MM/DD/*.jsonl`                            |
-| Context Window   | 128K tokens                                                       |
-| Pricing          | o4-mini: $1.10/$4.40 per million tokens (input/output)            |
+| Aspect                     | Value                                                                                       |
+| -------------------------- | ------------------------------------------------------------------------------------------- |
+| Binary                     | `codex`                                                                                     |
+| JSON Output                | `--json`                                                                                    |
+| Batch Mode                 | `exec` subcommand                                                                           |
+| Resume                     | `resume <thread_id>` (v0.30.0+)                                                             |
+| Read-only                  | `--sandbox read-only`                                                                       |
+| YOLO Mode                  | `--dangerously-bypass-approvals-and-sandbox` (enabled by default)                           |
+| Session ID Field           | `thread_id` (from `thread.started` event)                                                   |
+| Session Storage            | `~/.codex/sessions/YYYY/MM/DD/*.jsonl`                                                      |
+| Context Window             | 128K tokens                                                                                 |
+| Pricing                    | o4-mini: $1.10/$4.40 per million tokens (input/output)                                      |
+| External Activity Tracking | ✅ Supported — JSONL append watcher (see [[CLAUDE-AGENTS.md]] § External Activity Tracking) |
 
 **Implementation Status:**
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -251,6 +251,10 @@ processManager.on('stderr', (sessionId, data) => { ... });
 processManager.on('command-exit', (sessionId, code) => { ... });
 ```
 
+### Owned vs Observed Sessions
+
+Maestro tracks two distinct kinds of agent sessions. **Owned sessions** are spawned by `ProcessManager` and carry full PTY or child-process control — Maestro can write to stdin, send signals, capture stdout/stderr, parse usage events inline, and tear the process down. These are the sessions users create via the Left Bar. **Observed sessions** are externally-spawned agents (e.g., a `claude` invocation launched over SSH on the same host, or a `codex` run started from another terminal) that Maestro discovers by watching each agent's session-storage directory via `external-session-coordinator.ts` and `session-file-watcher.ts`. Observed sessions are **read-only**: Maestro surfaces them in the thinking pill and ingests their usage into the Usage Dashboard, but cannot send input, interrupt, or otherwise drive an externally-spawned agent — there is no PTY handle to write to. See the External Agent Visibility section in [CLAUDE.md](CLAUDE.md) for the extension contract.
+
 ---
 
 ## Layer Stack System

--- a/CLAUDE-AGENTS.md
+++ b/CLAUDE-AGENTS.md
@@ -90,6 +90,22 @@ Centralized in `src/shared/agentMetadata.ts` (importable from any process):
 - **YOLO Mode:** Auto-enabled in batch mode (no flag needed)
 - **Multi-Provider:** Supports 75+ LLMs including Ollama, LM Studio, llama.cpp
 
+## External Activity Tracking
+
+Maestro observes externally-spawned agent sessions by watching each agent's session-storage directory on disk. Sessions launched outside Maestro (e.g., the agent's own CLI in another terminal, or an SSH session on the same host) are surfaced in the thinking pill and ingested into the Usage Dashboard alongside Maestro-owned sessions. See the **External Agent Visibility** section in [[CLAUDE.md]] for the watcher pipeline.
+
+| Agent         | Storage Path                                     | File Model         | Participates? |
+| ------------- | ------------------------------------------------ | ------------------ | ------------- |
+| Claude Code   | `~/.claude/projects/<encoded>/<id>.jsonl`        | JSONL append       | Yes           |
+| Codex         | `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`   | JSONL append       | Yes           |
+| Factory Droid | `~/.factory/sessions/<encoded>/<uuid>.jsonl`     | JSONL append       | Yes           |
+| OpenCode      | `~/.local/share/opencode/storage/.../<msg>.json` | Per-message create | Yes           |
+| Terminal      | (no session storage)                             | —                  | No            |
+
+**Same-user only:** the watchers read session files directly via the local filesystem, so visibility is bounded by OS permissions. Maestro will only observe sessions owned by the same OS user running the app; cross-user observation is out of scope.
+
+**v1 visual treatment:** externally-observed sessions render identically to Maestro-spawned sessions in the thinking pill — there is no separate badge or styling. Users see the unified set of active agents on the host regardless of who spawned them.
+
 ## Adding New Agents
 
 To add support for a new agent:

--- a/CLAUDE-IPC.md
+++ b/CLAUDE-IPC.md
@@ -52,6 +52,22 @@ The `window.maestro` API exposes the following namespaces:
 - `documentGraph` - File watching: watchFolder, unwatchFolder
 - `documentGraph` - Real-time updates via `documentGraph:filesChanged` event
 
+## External Session Activity
+
+Surfaces externally-spawned agent sessions (e.g., Claude Code launched over SSH by the same OS user) observed via per-agent storage-directory watchers. Backed by `ExternalSessionCoordinator`; event shape and the `isActive(event)` helper live in `src/shared/sessionActivity.ts`. See the **External Agent Visibility** section in [[CLAUDE.md]] for the watcher pipeline.
+
+- `storage.listExternalSessions()` - Hydrates the current snapshot of watched session files. Returns `Promise<SessionActivityEvent[]>`.
+- `storage.onExternalActivity(callback)` - Subscribes to coalesced coordinator state changes. The callback receives `SessionActivityEvent[]` batches as files grow or appear. Returns an unsubscribe function.
+
+```typescript
+window.maestro.storage = {
+  listExternalSessions: () => Promise<SessionActivityEvent[]>,
+  onExternalActivity: (callback: (events: SessionActivityEvent[]) => void) => () => void,
+};
+```
+
+Each `SessionActivityEvent` carries `{ agentId, sessionId, projectPath, lastActivityAt, source, sizeBytes }`, where `source` is `'local'` for Maestro-spawned sessions and `'external'` for watch-only observations.
+
 ## History API
 
 Per-agent history storage with 5,000 entries per agent (up from 1,000 global). Each agent's history is stored as a JSON file in `~/Library/Application Support/Maestro/history/{sessionId}.json`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,46 +167,48 @@ src/
 
 ## Key Files for Common Tasks
 
-| Task                         | Primary Files                                                                                                                                                           |
-| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Add IPC handler              | `src/main/index.ts`, `src/main/preload.ts`                                                                                                                              |
-| Add UI component             | `src/renderer/components/`                                                                                                                                              |
-| Add web/mobile component     | `src/web/components/`, `src/web/mobile/`                                                                                                                                |
-| Add keyboard shortcut        | `src/renderer/constants/shortcuts.ts`, `App.tsx`                                                                                                                        |
-| Add theme                    | `src/renderer/constants/themes.ts`                                                                                                                                      |
-| Add modal                    | Component + `src/renderer/constants/modalPriorities.ts`                                                                                                                 |
-| Add tab overlay menu         | See Tab Hover Overlay Menu pattern in [[CLAUDE-PATTERNS.md]]                                                                                                            |
-| Add setting                  | `src/shared/settingsMetadata.ts` (metadata), `src/renderer/stores/settingsStore.ts`, `src/main/stores/defaults.ts`                                                      |
-| Add template variable        | `src/shared/templateVariables.ts`, `src/renderer/utils/templateVariables.ts`                                                                                            |
-| Modify system prompts        | `src/prompts/*.md` (wizard, Auto Run, etc.)                                                                                                                             |
-| Add Spec-Kit command         | `src/prompts/speckit/`, `src/main/speckit-manager.ts`                                                                                                                   |
-| Add OpenSpec command         | `src/prompts/openspec/`, `src/main/openspec-manager.ts`                                                                                                                 |
-| Add CLI command              | `src/cli/commands/`, `src/cli/index.ts`                                                                                                                                 |
-| Add new agent                | `src/shared/agentIds.ts`, `src/main/agents/definitions.ts`, `src/main/agents/capabilities.ts`, `src/shared/agentMetadata.ts` — see [AGENT_SUPPORT.md](AGENT_SUPPORT.md) |
-| Add agent output parser      | `src/main/parsers/`, `src/main/parsers/index.ts`                                                                                                                        |
-| Add agent session storage    | `src/main/storage/` (extend `BaseSessionStorage`), `src/main/storage/index.ts`                                                                                          |
-| Add agent error patterns     | `src/main/parsers/error-patterns.ts`                                                                                                                                    |
-| Add agent context window     | `src/shared/agentConstants.ts` (`DEFAULT_CONTEXT_WINDOWS`, `FALLBACK_CONTEXT_WINDOW`)                                                                                   |
-| Add playbook feature         | `src/cli/services/playbooks.ts`                                                                                                                                         |
-| Add marketplace playbook     | `src/main/ipc/handlers/marketplace.ts` (import from GitHub)                                                                                                             |
-| Playbook import/export       | `src/main/ipc/handlers/playbooks.ts` (ZIP handling with assets)                                                                                                         |
-| Modify wizard flow           | `src/renderer/components/Wizard/` (see [[CLAUDE-WIZARD.md]])                                                                                                            |
-| Add tour step                | `src/renderer/components/Wizard/tour/tourSteps.ts`                                                                                                                      |
-| Modify file linking          | `src/renderer/utils/remarkFileLinks.ts` (remark plugin for `[[wiki]]` and path links)                                                                                   |
-| Add documentation page       | `docs/*.md`, `docs/docs.json` (navigation)                                                                                                                              |
-| Add documentation screenshot | `docs/screenshots/` (PNG, kebab-case naming)                                                                                                                            |
-| MCP server integration       | See [MCP Server docs](https://docs.runmaestro.ai/mcp-server)                                                                                                            |
-| Add stats/analytics feature  | `src/main/stats-db.ts`, `src/main/ipc/handlers/stats.ts`                                                                                                                |
-| Add Usage Dashboard chart    | `src/renderer/components/UsageDashboard/`                                                                                                                               |
-| Add Document Graph feature   | `src/renderer/components/DocumentGraph/`, `src/main/ipc/handlers/documentGraph.ts`                                                                                      |
-| Add colorblind palette       | `src/renderer/constants/colorblindPalettes.ts`                                                                                                                          |
-| Add performance metrics      | `src/shared/performance-metrics.ts`                                                                                                                                     |
-| Add power management         | `src/main/power-manager.ts`, `src/main/ipc/handlers/system.ts`                                                                                                          |
-| Spawn agent with SSH support | `src/main/utils/ssh-spawn-wrapper.ts` (required for SSH remote execution)                                                                                               |
-| Modify file preview tabs     | `TabBar.tsx`, `FilePreview.tsx`, `MainPanel.tsx` (see ARCHITECTURE.md → File Preview Tab System)                                                                        |
-| Add Director's Notes feature | `src/renderer/components/DirectorNotes/`, `src/main/ipc/handlers/director-notes.ts`                                                                                     |
-| Add Encore Feature           | `src/renderer/types/index.ts` (flag), `useSettings.ts` (state), `SettingsModal.tsx` (toggle UI), gate in `App.tsx` + keyboard handler                                   |
-| Modify history components    | `src/renderer/components/History/`                                                                                                                                      |
+| Task                                 | Primary Files                                                                                                                                                           |
+| ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Add IPC handler                      | `src/main/index.ts`, `src/main/preload.ts`                                                                                                                              |
+| Add UI component                     | `src/renderer/components/`                                                                                                                                              |
+| Add web/mobile component             | `src/web/components/`, `src/web/mobile/`                                                                                                                                |
+| Add keyboard shortcut                | `src/renderer/constants/shortcuts.ts`, `App.tsx`                                                                                                                        |
+| Add theme                            | `src/renderer/constants/themes.ts`                                                                                                                                      |
+| Add modal                            | Component + `src/renderer/constants/modalPriorities.ts`                                                                                                                 |
+| Add tab overlay menu                 | See Tab Hover Overlay Menu pattern in [[CLAUDE-PATTERNS.md]]                                                                                                            |
+| Add setting                          | `src/shared/settingsMetadata.ts` (metadata), `src/renderer/stores/settingsStore.ts`, `src/main/stores/defaults.ts`                                                      |
+| Add template variable                | `src/shared/templateVariables.ts`, `src/renderer/utils/templateVariables.ts`                                                                                            |
+| Modify system prompts                | `src/prompts/*.md` (wizard, Auto Run, etc.)                                                                                                                             |
+| Add Spec-Kit command                 | `src/prompts/speckit/`, `src/main/speckit-manager.ts`                                                                                                                   |
+| Add OpenSpec command                 | `src/prompts/openspec/`, `src/main/openspec-manager.ts`                                                                                                                 |
+| Add CLI command                      | `src/cli/commands/`, `src/cli/index.ts`                                                                                                                                 |
+| Add new agent                        | `src/shared/agentIds.ts`, `src/main/agents/definitions.ts`, `src/main/agents/capabilities.ts`, `src/shared/agentMetadata.ts` — see [AGENT_SUPPORT.md](AGENT_SUPPORT.md) |
+| Add agent output parser              | `src/main/parsers/`, `src/main/parsers/index.ts`                                                                                                                        |
+| Add agent session storage            | `src/main/storage/` (extend `BaseSessionStorage`), `src/main/storage/index.ts`                                                                                          |
+| Add storage watch spec for new agent | extend `BaseSessionStorage.getStorageWatchSpec()` in `src/main/storage/<agent>-session-storage.ts`                                                                      |
+| Watch external agent activity        | `src/main/storage/external-session-coordinator.ts`, `src/main/storage/session-file-watcher.ts`, `src/main/process-listeners/external-stats-ingester.ts`                 |
+| Add agent error patterns             | `src/main/parsers/error-patterns.ts`                                                                                                                                    |
+| Add agent context window             | `src/shared/agentConstants.ts` (`DEFAULT_CONTEXT_WINDOWS`, `FALLBACK_CONTEXT_WINDOW`)                                                                                   |
+| Add playbook feature                 | `src/cli/services/playbooks.ts`                                                                                                                                         |
+| Add marketplace playbook             | `src/main/ipc/handlers/marketplace.ts` (import from GitHub)                                                                                                             |
+| Playbook import/export               | `src/main/ipc/handlers/playbooks.ts` (ZIP handling with assets)                                                                                                         |
+| Modify wizard flow                   | `src/renderer/components/Wizard/` (see [[CLAUDE-WIZARD.md]])                                                                                                            |
+| Add tour step                        | `src/renderer/components/Wizard/tour/tourSteps.ts`                                                                                                                      |
+| Modify file linking                  | `src/renderer/utils/remarkFileLinks.ts` (remark plugin for `[[wiki]]` and path links)                                                                                   |
+| Add documentation page               | `docs/*.md`, `docs/docs.json` (navigation)                                                                                                                              |
+| Add documentation screenshot         | `docs/screenshots/` (PNG, kebab-case naming)                                                                                                                            |
+| MCP server integration               | See [MCP Server docs](https://docs.runmaestro.ai/mcp-server)                                                                                                            |
+| Add stats/analytics feature          | `src/main/stats-db.ts`, `src/main/ipc/handlers/stats.ts`                                                                                                                |
+| Add Usage Dashboard chart            | `src/renderer/components/UsageDashboard/`                                                                                                                               |
+| Add Document Graph feature           | `src/renderer/components/DocumentGraph/`, `src/main/ipc/handlers/documentGraph.ts`                                                                                      |
+| Add colorblind palette               | `src/renderer/constants/colorblindPalettes.ts`                                                                                                                          |
+| Add performance metrics              | `src/shared/performance-metrics.ts`                                                                                                                                     |
+| Add power management                 | `src/main/power-manager.ts`, `src/main/ipc/handlers/system.ts`                                                                                                          |
+| Spawn agent with SSH support         | `src/main/utils/ssh-spawn-wrapper.ts` (required for SSH remote execution)                                                                                               |
+| Modify file preview tabs             | `TabBar.tsx`, `FilePreview.tsx`, `MainPanel.tsx` (see ARCHITECTURE.md → File Preview Tab System)                                                                        |
+| Add Director's Notes feature         | `src/renderer/components/DirectorNotes/`, `src/main/ipc/handlers/director-notes.ts`                                                                                     |
+| Add Encore Feature                   | `src/renderer/types/index.ts` (flag), `useSettings.ts` (state), `SettingsModal.tsx` (toggle UI), gate in `App.tsx` + keyboard handler                                   |
+| Modify history components            | `src/renderer/components/History/`                                                                                                                                      |
 
 ---
 
@@ -291,6 +293,16 @@ if (sshStore && session.sshRemoteConfig?.enabled) {
 - Agent's `binaryName` is used for remote execution (not local paths)
 
 See [[CLAUDE-PATTERNS.md]] for detailed SSH patterns.
+
+---
+
+### External Agent Visibility
+
+Maestro watches each agent's session-storage directory and surfaces externally-spawned sessions (e.g., agents launched over SSH on the same host, or via the agent's own CLI in another terminal) in the thinking pill and Usage Dashboard. The watcher pipeline lives in `src/main/storage/external-session-coordinator.ts` and `src/main/storage/session-file-watcher.ts`; ingestion into the stats DB is handled by `src/main/process-listeners/external-stats-ingester.ts`.
+
+This feature is **same-user only**: it relies on local filesystem permissions to read the session files. Cross-user observation is out of scope — Maestro will only see sessions owned by the same OS user running the app.
+
+When **adding a new agent**, implement `getStorageWatchSpec()` on the agent's storage class (extending `BaseSessionStorage`). JSONL-append agents (Claude Code, Codex, Copilot CLI, Factory Droid) use `activityEvent: 'append'`; per-message-file agents (like OpenCode) use `activityEvent: 'create'`. Wire-up is automatic via the coordinator's registry iteration — no further plumbing is required.
 
 ---
 

--- a/docs/agent-guides/AGENT-INFRA.md
+++ b/docs/agent-guides/AGENT-INFRA.md
@@ -1,0 +1,208 @@
+---
+type: reference
+title: Agent Infrastructure
+created: 2026-05-14
+tags:
+  - agents
+  - storage
+  - ipc
+related:
+  - '[[CLAUDE-AGENTS]]'
+  - '[[CLAUDE-IPC]]'
+  - '[[IPC-PATTERNS]]'
+---
+
+# Agent Infrastructure
+
+Cross-cutting infrastructure that all agents plug into: per-agent session
+storage, the external-session watcher pipeline, and the renderer-facing IPC
+bridge that surfaces externally-spawned agent activity. Read this when you are
+adding a new agent or extending the visibility surface for an existing one.
+
+For the agent capability matrix see [[CLAUDE-AGENTS]]. For the full IPC namespace
+listing see [[CLAUDE-IPC]]. For the cross-cutting IPC subscription pattern (event
+channels, cleanup contracts, renderer bookkeeping) see
+[IPC-PATTERNS](./IPC-PATTERNS.md).
+
+---
+
+## `getStorageWatchSpec()` — the storage extension point
+
+Each agent's session-storage class extends `BaseSessionStorage`
+(`src/main/storage/base-session-storage.ts`). To opt the agent into external
+session visibility, override `getStorageWatchSpec()` and return a
+`StorageWatchSpec`.
+
+```typescript
+interface StorageWatchSpec {
+	rootDir: string;
+	fileMatcher: (relPath: string) => { sessionId: string; projectPath: string } | null;
+	activityEvent?: 'append' | 'create';
+}
+```
+
+- **`rootDir`** — absolute path to the directory the watcher should observe
+  recursively. Missing or unreadable directories are tolerated; same-user scope
+  means it is normal for some agents to be uninstalled on a given host.
+- **`fileMatcher`** — pure, synchronous function from a path **relative to
+  `rootDir`** to a `{ sessionId, projectPath }` match, or `null` for paths that
+  don't correspond to a tracked session (sidecar metadata, wrong depth,
+  unrelated junk). It runs on every chokidar event, so it must not perform I/O.
+- **`activityEvent`** — which file event represents live activity for this
+  agent. Default `'append'` (existing per-session JSONL grows in place — Claude
+  Code, Codex, Copilot CLI, Factory Droid). Use `'create'` when each new message
+  arrives as a brand-new file in a per-session directory (OpenCode pre-v1.2 JSON
+  layout).
+
+The default `BaseSessionStorage.getStorageWatchSpec()` returns `null`, meaning
+"this agent doesn't expose externally observable session files." Storage classes
+without per-session files on a stable path should leave the default in place.
+
+### Example: append-style (Claude Code)
+
+```typescript
+// src/main/storage/claude-session-storage.ts
+getStorageWatchSpec(): StorageWatchSpec | null {
+	return {
+		rootDir: this.getProjectsDir(),
+		fileMatcher: (relPath) => {
+			const segments = relPath.split(path.sep);
+			if (segments.length !== 2) return null;
+			const [encodedProjectSegment, fileName] = segments;
+			if (!fileName.endsWith('.jsonl')) return null;
+			return {
+				sessionId: fileName.slice(0, -'.jsonl'.length),
+				projectPath: encodedProjectSegment,
+			};
+		},
+		activityEvent: 'append',
+	};
+}
+```
+
+### Example: create-style (OpenCode)
+
+```typescript
+// src/main/storage/opencode-session-storage.ts
+getStorageWatchSpec(): StorageWatchSpec | null {
+	return {
+		rootDir: OPENCODE_STORAGE_DIR,
+		fileMatcher: (relPath) => {
+			const segments = relPath.split(path.sep);
+			if (segments.length !== 3) return null;
+			const [, sessionSegment, fileName] = segments;
+			if (!fileName.endsWith('.json')) return null;
+			return { sessionId: sessionSegment, projectPath: '' };
+		},
+		activityEvent: 'create',
+	};
+}
+```
+
+Wire-up is automatic — the coordinator iterates the storage registry on boot,
+calls `getStorageWatchSpec()` on every entry, and starts a `SessionFileWatcher`
+for any spec it gets back. No further plumbing is required.
+
+---
+
+## `ExternalSessionCoordinator` — boot contract
+
+**Where it lives:** `src/main/storage/external-session-coordinator.ts`.
+
+**When it starts:** during main-process boot in `src/main/index.ts`, after the
+process manager and the storage registry are constructed. The coordinator is
+held as a module-level singleton and constructed with:
+
+```typescript
+externalSessionCoordinator = new ExternalSessionCoordinator({
+	processManager,
+	storageRegistry,
+});
+externalSessionCoordinator.start().catch((err) => {
+	logger.error(`Failed to start ExternalSessionCoordinator: ${err}`, 'Startup');
+});
+```
+
+`start()` walks the storage registry, reads each agent's `StorageWatchSpec`,
+and launches one `SessionFileWatcher` per agent that exposes one. Per-watcher
+failures are logged but never fatal — a single misbehaving agent must not bring
+the whole coordinator down.
+
+**Two responsibilities the per-agent watcher doesn't handle on its own:**
+
+1. **Source annotation / dedup.** Maestro itself may already be driving a
+   session whose JSONL the watcher would otherwise classify as "external."
+   The coordinator stamps `source: 'local' | 'external'` by asking
+   `ProcessManager.findByAgentSessionId(event.sessionId)`. Sessions Maestro
+   owns are still folded into the coalesced state map (so the renderer sees
+   one consistent view), but per-file `'append'` / `'create'` events are
+   suppressed for them — the stats DB would otherwise get a second insert via
+   the process-driven path.
+2. **Burst coalescing.** Bulk imports or chatty agents can fire many
+   append/create events in quick succession. The coordinator debounces the
+   outward `'state-changed'` emission to 100ms (`STATE_CHANGE_DEBOUNCE_MS`) so
+   renderer state churn stays sane.
+
+**Shutdown:** `stop()` is wired into the quit handler (`src/main/app-lifecycle/
+quit-handler.ts` → `stopExternalSessionCoordinator`). It cancels the pending
+debounce timer, stops every watcher in parallel, and clears the state map. Safe
+to call multiple times.
+
+**Same-user, local-FS scope only.** Cross-user observation is out of scope —
+Maestro will only see sessions owned by the OS user running the app. SSH remote
+watching is also out of scope; see `SessionFileWatcher` for the underlying
+constraints.
+
+---
+
+## IPC bridge — surfacing activity to the renderer
+
+The coordinator's two outbound channels feed two distinct consumers:
+
+| Coordinator event       | Consumer                                                                                       |
+| ----------------------- | ---------------------------------------------------------------------------------------------- |
+| `'state-changed'`       | Renderer (via `EXTERNAL_ACTIVITY_CHANNEL = 'storage:externalActivity'`)                        |
+| `'append'` / `'create'` | In-process `external-stats-ingester.ts` — tails the JSONL deltas to mirror usage into stats DB |
+
+The renderer subscribes through the preload bridge:
+
+```typescript
+// hydrate
+const initial = await window.maestro.storage.listExternalSessions();
+
+// subscribe
+const unsubscribe = window.maestro.storage.onExternalActivity((events) => {
+	// events: SessionActivityEvent[]
+});
+```
+
+Handlers are registered by `registerExternalSessionsHandlers()` in
+`src/main/ipc/handlers/external-sessions.ts`, which:
+
+1. exposes `'storage:list-external-sessions'` → returns
+   `Array.from(coordinator.getState().values())` for renderer hydration, and
+2. forwards every coordinator `'state-changed'` payload onto the
+   `'storage:externalActivity'` channel via `safeSend`.
+
+The preload-side wrapper (`src/main/preload/storage.ts`) is the canonical place
+to learn the on-the-wire shape; the renderer hook
+`src/renderer/hooks/session/useExternalSessionActivity.ts` shows the expected
+hydrate-then-subscribe pattern. For the broader IPC subscription / cleanup
+contract, see [IPC-PATTERNS](./IPC-PATTERNS.md).
+
+---
+
+## Adding a new agent — checklist
+
+1. Create the storage class extending `BaseSessionStorage`
+   (`src/main/storage/<agent>-session-storage.ts`).
+2. Override `getStorageWatchSpec()` if the agent persists per-session files on
+   a stable path. Pick `activityEvent: 'append'` for JSONL-grow agents,
+   `'create'` for per-message-file agents.
+3. Register the storage in `src/main/storage/index.ts` (`initializeSessionStorages`).
+4. Done — the coordinator picks the new agent up automatically on next boot.
+   No coordinator, IPC handler, preload, or renderer changes are required for
+   visibility.
+
+If the agent does not write per-session files (e.g., terminal), leave the
+default `getStorageWatchSpec(): null` in place. It will be quietly skipped.

--- a/docs/agent-guides/STATS-ANALYTICS.md
+++ b/docs/agent-guides/STATS-ANALYTICS.md
@@ -1,0 +1,181 @@
+---
+type: reference
+title: Stats & Analytics
+created: 2026-05-14
+tags:
+  - stats
+  - analytics
+  - storage
+  - usage-dashboard
+related:
+  - '[[AGENT-INFRA]]'
+  - '[[CLAUDE-IPC]]'
+  - '[[CLAUDE-FEATURES]]'
+---
+
+# Stats & Analytics
+
+How Maestro records AI query activity to its local SQLite stats database and
+how that data feeds the Usage Dashboard. Read this when you are adding a new
+chart, adjusting the ingestion path, or debugging why a session shows up (or
+doesn't) in the dashboard.
+
+For the storage-watcher pipeline that powers file-driven ingestion see
+[[AGENT-INFRA]]. For the renderer-facing chart catalog see [[CLAUDE-FEATURES]].
+
+---
+
+## The stats DB
+
+**Where it lives:** `src/main/stats/stats-db.ts` (class `StatsDB`). The
+underlying SQLite file is `stats.db` under Electron's `userData` directory.
+Access is mediated by a process-wide singleton (`getStatsDB()` /
+`initializeStatsDB()` / `closeStatsDB()` from `src/main/stats/singleton.ts`),
+and CRUD is split across focused modules under `src/main/stats/`:
+
+| Module                 | Responsibility                                                               |
+| ---------------------- | ---------------------------------------------------------------------------- |
+| `query-events.ts`      | Insert / query individual AI query/response rows                             |
+| `auto-run.ts`          | Auto Run session + task lifecycle rows                                       |
+| `session-lifecycle.ts` | Created-at / closed-at events for sessions (local vs SSH remote)             |
+| `aggregations.ts`      | Dashboard rollups (by agent, by day, by hour, by source, by location)        |
+| `migrations.ts`        | Versioned schema migrations (current `STATS_DB_VERSION` is in `stats-types`) |
+| `data-management.ts`   | Retention pruning and CSV export                                             |
+| `schema.ts`            | Raw `CREATE TABLE` / `CREATE INDEX` SQL                                      |
+
+### Query-event schema
+
+The dashboard's hottest table is `query_events` — one row per AI
+query/response cycle. Shape lives in `src/shared/stats-types.ts`:
+
+```typescript
+interface QueryEvent {
+	id: string;
+	sessionId: string;
+	agentType: string;
+	source: 'user' | 'auto' | 'external-fs';
+	startTime: number; // epoch ms
+	duration: number; // ms, 0 for external-fs rows
+	projectPath?: string;
+	tabId?: string;
+	isRemote?: boolean; // SSH remote sessions, added in migration v2
+}
+```
+
+The on-disk schema mirrors the TypeScript shape; see
+`CREATE_QUERY_EVENTS_SQL` and `CREATE_QUERY_EVENTS_V5_SQL` in
+`src/main/stats/schema.ts`. The `source` CHECK constraint was widened to
+include `'external-fs'` in migration v5.
+
+---
+
+## Two ingestion paths
+
+Rows can arrive in `query_events` through two completely separate code paths.
+Both ultimately call `insertQueryEventWithRetry` (`src/main/process-listeners/
+insertQueryEventWithRetry.ts`) so retry semantics are shared, but the
+trigger and the data source differ.
+
+### 1. Process-driven — `stats-listener.ts`
+
+**File:** `src/main/process-listeners/stats-listener.ts`.
+
+For sessions Maestro itself spawned. `ProcessManager` parses the agent's
+streamed output, builds a `QueryCompleteData` payload, and emits
+`'query-complete'`. The stats listener subscribes, persists the row, and
+broadcasts `stats:updated` to the renderer so the dashboard can refresh.
+
+`source` here is either `'user'` (the human pressed Enter) or `'auto'`
+(Auto Run / batch). Duration is real because the listener has both the
+process start time and the result-message timestamp.
+
+### 2. File-driven — `external-stats-ingester.ts`
+
+**File:** `src/main/process-listeners/external-stats-ingester.ts`.
+
+For sessions Maestro did **not** spawn (a Claude Code run started over SSH
+on the same host, the user opening Codex in another terminal, etc.).
+`ExternalSessionCoordinator` watches each agent's session-storage
+directory (see [[AGENT-INFRA]]) and emits `'append'` / `'create'` events.
+The ingester:
+
+1. `fs.stat`s the file, computes the byte delta against an in-memory
+   offset table (no whole-file re-reads, no on-disk offset persistence).
+2. Reads just the delta with positional `fs.read`.
+3. Splits on newlines and feeds each line through the agent's registered
+   `AgentOutputParser`. Result messages produce `query_events` rows
+   tagged `source: 'external-fs'`.
+
+Duration is `0` for these rows — the parser cannot reconstruct timing
+from JSONL alone. `startTime` is the file's most recent activity
+timestamp so dashboard time-range filters bucket the row correctly.
+
+Dedup with the process-driven path is handled by the coordinator: it
+only forwards file events for sessions whose annotated `source` is
+`'external'`, so a session Maestro is already driving locally never
+reaches the ingester.
+
+---
+
+## The `source` field on `QueryCompleteData`
+
+Defined in `src/main/process-manager/types.ts`:
+
+```typescript
+interface QueryCompleteData {
+	sessionId: string;
+	agentType: string;
+	source: 'user' | 'auto' | 'external-fs';
+	startTime: number;
+	duration: number;
+	projectPath?: string;
+	tabId?: string;
+}
+```
+
+- `'user'` / `'auto'` are emitted on `ProcessManager`'s `'query-complete'`
+  event for Maestro-spawned processes.
+- `'external-fs'` is synthesized by `ExternalStatsIngester` for
+  file-watched sessions. It is **not** emitted on
+  `ProcessManager`'s `'query-complete'` event; it only flows directly to
+  `db.insertQueryEvent`.
+
+### Filtering by `source` in the Usage Dashboard
+
+`StatsFilters` (`src/shared/stats-types.ts`) exposes a `source` field
+accepted by `getQueryEvents()`:
+
+```typescript
+interface StatsFilters {
+	agentType?: string;
+	source?: 'user' | 'auto' | 'external-fs';
+	projectPath?: string;
+	sessionId?: string;
+}
+```
+
+Pass it through to scope a dashboard query to a single origin (e.g.,
+`source: 'external-fs'` to show only externally-observed activity).
+
+**Aggregation quirk to know about:** `queryBySource()` in
+`src/main/stats/aggregations.ts` restricts its grouping to `'user'` and
+`'auto'` so the typed result stays a `{ user: number; auto: number }`
+pair — the dashboard's source-distribution chart only renders those two
+buckets today. `external-fs` rows still contribute to overall totals
+(`queryTotals`, by-agent, by-day, etc.); they just don't appear in the
+user/auto split. If you add a new chart that needs to call out external
+activity, query `query_events` directly with the filter rather than
+extending `queryBySource()` past its two-bucket contract.
+
+---
+
+## Adding a new chart that cares about `source`
+
+1. Decide whether the chart wants per-row data (call `getQueryEvents` with
+   a `source` filter) or an aggregate (extend `aggregations.ts` with a
+   purpose-built query — don't overload `queryBySource`).
+2. Surface it via an existing IPC handler under `src/main/ipc/handlers/
+stats.ts` if one fits; otherwise add a new one.
+3. Render in `src/renderer/components/UsageDashboard/`. Use
+   `ChartErrorBoundary` and the existing skeleton patterns — see
+   [[CLAUDE-FEATURES]] for the catalog.

--- a/src/__tests__/main/process-listeners/external-stats-ingester.test.ts
+++ b/src/__tests__/main/process-listeners/external-stats-ingester.test.ts
@@ -1,0 +1,394 @@
+/**
+ * Tests for ExternalStatsIngester — the file-driven companion to the
+ * process-driven stats listener. Subscribes to the coordinator's per-file
+ * 'append' / 'create' events, tails JSONL deltas, parses each line through
+ * the per-agent output parser, and on result messages inserts a row tagged
+ * `source: 'external-fs'` via the shared retry helper.
+ *
+ * The coordinator is faked as a bare `EventEmitter` so the test can drive
+ * synthetic events directly. The agent parser is faked as a single-line
+ * lookup table so we can express "this exact line should be classified as
+ * a result message" deterministically. The filesystem is faked through the
+ * `fsImpl` injection point — no real I/O happens here.
+ */
+
+import { EventEmitter } from 'events';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { ExternalStatsIngester } from '../../../main/process-listeners/external-stats-ingester';
+import type { AgentOutputParser, ParsedEvent } from '../../../main/parsers';
+import type { ToolType } from '../../../shared/types';
+import type { SessionActivityEvent } from '../../../shared/sessionActivity';
+import type { StatsDB } from '../../../main/stats';
+import type { ProcessListenerDependencies } from '../../../main/process-listeners/types';
+import { APPEND_EVENT, CREATE_EVENT } from '../../../main/storage/external-session-coordinator';
+
+// --- helpers ----------------------------------------------------------------
+
+const RESULT_LINE = '{"type":"result","session_id":"sess-1"}';
+const FILE_PATH = '/tmp/maestro-test-session.jsonl';
+
+function makeActivityEvent(overrides: Partial<SessionActivityEvent> = {}): SessionActivityEvent {
+	return {
+		agentId: 'claude-code',
+		sessionId: 'sess-1',
+		projectPath: '/proj',
+		lastActivityAt: 1_700_000_000_000,
+		source: 'external',
+		sizeBytes: 0,
+		...overrides,
+	};
+}
+
+/**
+ * Minimal AgentOutputParser stub that classifies one specific line as a result
+ * message and returns null for everything else. Each method is a `vi.fn` so
+ * the test can override behavior for the throw case.
+ */
+function makeParser(agentId: ToolType, resultLine: string = RESULT_LINE): AgentOutputParser {
+	const resultEvent: ParsedEvent = {
+		type: 'result',
+		sessionId: 'sess-1',
+		text: 'done',
+	};
+	return {
+		agentId,
+		parseJsonLine: vi.fn((line: string) => (line === resultLine ? resultEvent : null)),
+		isResultMessage: vi.fn((event: ParsedEvent) => event.type === 'result'),
+		extractSessionId: vi.fn((event: ParsedEvent) => event.sessionId ?? null),
+		extractUsage: vi.fn(() => null),
+		extractSlashCommands: vi.fn(() => null),
+		parseJsonObject: vi.fn(() => null),
+		detectErrorFromLine: vi.fn(() => null),
+		detectErrorFromParsed: vi.fn(() => null),
+		detectErrorFromExit: vi.fn(() => null),
+	};
+}
+
+interface FakeFileHandle {
+	read: ReturnType<typeof vi.fn>;
+	close: ReturnType<typeof vi.fn>;
+}
+
+/**
+ * Build a minimal `fs.promises`-shaped fake whose `stat` returns the
+ * configured size and whose `open(...).read()` fills the buffer with the
+ * configured content slice. Tracks every call so tests can assert that the
+ * ingester read from the right offset.
+ */
+function makeFsImpl(content: string) {
+	const stat = vi.fn(async (_path: string) => ({ size: Buffer.byteLength(content, 'utf-8') }));
+	const open = vi.fn(async (_path: string, _flags: string): Promise<FakeFileHandle> => {
+		return {
+			read: vi.fn(async (buf: Buffer, _off: number, length: number, position: number) => {
+				const slice = Buffer.from(content, 'utf-8').subarray(position, position + length);
+				slice.copy(buf, 0, 0, slice.length);
+				return { bytesRead: slice.length, buffer: buf };
+			}),
+			close: vi.fn(async () => {}),
+		};
+	});
+	return { stat, open };
+}
+
+// --- tests ------------------------------------------------------------------
+
+describe('ExternalStatsIngester', () => {
+	let coordinator: EventEmitter;
+	let statsDB: StatsDB;
+	let logger: ProcessListenerDependencies['logger'];
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		coordinator = new EventEmitter();
+		statsDB = {
+			isReady: vi.fn(() => true),
+			insertQueryEvent: vi.fn(() => 'event-id-1'),
+		} as unknown as StatsDB;
+		logger = {
+			info: vi.fn(),
+			error: vi.fn(),
+			warn: vi.fn(),
+			debug: vi.fn(),
+		};
+	});
+
+	it("inserts a stats row with source: 'external-fs' when the parser flags a result line on 'append'", async () => {
+		const parser = makeParser('claude-code');
+		const fsImpl = makeFsImpl(RESULT_LINE + '\n');
+
+		new ExternalStatsIngester({
+			coordinator,
+			statsDB,
+			parsersByAgent: new Map([['claude-code', parser]]),
+			logger,
+			fsImpl: fsImpl as unknown as ConstructorParameters<typeof ExternalStatsIngester>[0]['fsImpl'],
+		});
+
+		coordinator.emit(
+			APPEND_EVENT,
+			makeActivityEvent({
+				agentId: 'claude-code',
+				sessionId: 'sess-1',
+				projectPath: '/proj',
+				lastActivityAt: 1_700_000_001_000,
+			}),
+			FILE_PATH
+		);
+
+		// Allow the queued microtasks for fs.stat / fs.open / retry helper to settle.
+		await vi.waitFor(() => expect(statsDB.insertQueryEvent).toHaveBeenCalledTimes(1));
+
+		expect(statsDB.insertQueryEvent).toHaveBeenCalledWith({
+			sessionId: 'sess-1',
+			agentType: 'claude-code',
+			source: 'external-fs',
+			startTime: 1_700_000_001_000,
+			duration: 0,
+			projectPath: '/proj',
+			tabId: undefined,
+		});
+		expect(parser.parseJsonLine).toHaveBeenCalledWith(RESULT_LINE);
+		expect(fsImpl.stat).toHaveBeenCalledWith(FILE_PATH);
+	});
+
+	it("also reacts to 'create' events (used by OpenCode's per-message file layout)", async () => {
+		const parser = makeParser('opencode');
+		const fsImpl = makeFsImpl(RESULT_LINE + '\n');
+
+		new ExternalStatsIngester({
+			coordinator,
+			statsDB,
+			parsersByAgent: new Map([['opencode', parser]]),
+			logger,
+			fsImpl: fsImpl as unknown as ConstructorParameters<typeof ExternalStatsIngester>[0]['fsImpl'],
+		});
+
+		coordinator.emit(
+			CREATE_EVENT,
+			makeActivityEvent({ agentId: 'opencode', sessionId: 'oc-sess-1' }),
+			'/tmp/opencode-msg.json'
+		);
+
+		await vi.waitFor(() => expect(statsDB.insertQueryEvent).toHaveBeenCalledTimes(1));
+		expect(statsDB.insertQueryEvent).toHaveBeenCalledWith(
+			expect.objectContaining({
+				sessionId: 'oc-sess-1',
+				agentType: 'opencode',
+				source: 'external-fs',
+			})
+		);
+	});
+
+	it('retries on transient DB failure and eventually inserts (first 2 attempts throw, 3rd succeeds)', async () => {
+		const parser = makeParser('claude-code');
+		const fsImpl = makeFsImpl(RESULT_LINE + '\n');
+
+		vi.mocked(statsDB.insertQueryEvent)
+			.mockImplementationOnce(() => {
+				throw new Error('SQLITE_BUSY-1');
+			})
+			.mockImplementationOnce(() => {
+				throw new Error('SQLITE_BUSY-2');
+			})
+			.mockImplementationOnce(() => 'event-id-after-retries');
+
+		new ExternalStatsIngester({
+			coordinator,
+			statsDB,
+			parsersByAgent: new Map([['claude-code', parser]]),
+			logger,
+			fsImpl: fsImpl as unknown as ConstructorParameters<typeof ExternalStatsIngester>[0]['fsImpl'],
+		});
+
+		coordinator.emit(APPEND_EVENT, makeActivityEvent(), FILE_PATH);
+
+		// 3 attempts with 100ms + 200ms backoff means the final call lands around
+		// ~300ms after the first attempt. Loose `waitFor` is fine; we're not
+		// validating exact timing, just eventual success.
+		await vi.waitFor(
+			() => {
+				expect(statsDB.insertQueryEvent).toHaveBeenCalledTimes(3);
+			},
+			{ timeout: 2000 }
+		);
+
+		expect(logger.warn).toHaveBeenCalledWith(
+			expect.stringContaining('Stats DB insert failed'),
+			expect.any(String),
+			expect.objectContaining({ sessionId: 'sess-1' })
+		);
+		expect(logger.error).not.toHaveBeenCalled();
+	});
+
+	it('does NOT insert and DOES warn-log when the parser throws on a line', async () => {
+		const parser = makeParser('claude-code');
+		vi.mocked(parser.parseJsonLine).mockImplementation(() => {
+			throw new Error('parser exploded');
+		});
+		const fsImpl = makeFsImpl(RESULT_LINE + '\n');
+
+		new ExternalStatsIngester({
+			coordinator,
+			statsDB,
+			parsersByAgent: new Map([['claude-code', parser]]),
+			logger,
+			fsImpl: fsImpl as unknown as ConstructorParameters<typeof ExternalStatsIngester>[0]['fsImpl'],
+		});
+
+		coordinator.emit(APPEND_EVENT, makeActivityEvent(), FILE_PATH);
+
+		// Wait one tick for the async handler to settle.
+		await vi.waitFor(() =>
+			expect(logger.warn).toHaveBeenCalledWith(
+				expect.stringContaining('Parser threw on line'),
+				expect.any(String),
+				expect.objectContaining({
+					agentId: 'claude-code',
+					sessionId: 'sess-1',
+				})
+			)
+		);
+
+		expect(statsDB.insertQueryEvent).not.toHaveBeenCalled();
+	});
+
+	it('skips lines the parser classifies as non-result events without inserting', async () => {
+		const parser = makeParser('claude-code');
+		// parseJsonLine returns a non-result event for any line we feed it.
+		vi.mocked(parser.parseJsonLine).mockImplementation(
+			(): ParsedEvent => ({ type: 'text', text: 'partial chunk', sessionId: 'sess-1' })
+		);
+		const fsImpl = makeFsImpl('{"type":"assistant","text":"chunk"}\n');
+
+		new ExternalStatsIngester({
+			coordinator,
+			statsDB,
+			parsersByAgent: new Map([['claude-code', parser]]),
+			logger,
+			fsImpl: fsImpl as unknown as ConstructorParameters<typeof ExternalStatsIngester>[0]['fsImpl'],
+		});
+
+		coordinator.emit(APPEND_EVENT, makeActivityEvent(), FILE_PATH);
+
+		// Give microtasks a chance to settle then assert nothing happened.
+		await new Promise((r) => setTimeout(r, 10));
+		expect(statsDB.insertQueryEvent).not.toHaveBeenCalled();
+		expect(parser.isResultMessage).toHaveBeenCalled();
+	});
+
+	it('tails by delta: a second append reads only the new bytes, not the whole file', async () => {
+		const parser = makeParser('claude-code');
+		// First chunk: a non-result chunk. Second chunk: the result line.
+		const firstChunk = '{"type":"assistant","text":"think"}\n';
+		const secondChunk = RESULT_LINE + '\n';
+
+		let totalContent = firstChunk;
+		const stat = vi.fn(async () => ({ size: Buffer.byteLength(totalContent, 'utf-8') }));
+		const readCalls: Array<{ position: number; length: number }> = [];
+		const open = vi.fn(async () => ({
+			read: vi.fn(async (buf: Buffer, _off: number, length: number, position: number) => {
+				readCalls.push({ position, length });
+				const slice = Buffer.from(totalContent, 'utf-8').subarray(position, position + length);
+				slice.copy(buf, 0, 0, slice.length);
+				return { bytesRead: slice.length, buffer: buf };
+			}),
+			close: vi.fn(async () => {}),
+		}));
+
+		new ExternalStatsIngester({
+			coordinator,
+			statsDB,
+			parsersByAgent: new Map([['claude-code', parser]]),
+			logger,
+			fsImpl: { stat, open } as unknown as ConstructorParameters<
+				typeof ExternalStatsIngester
+			>[0]['fsImpl'],
+		});
+
+		coordinator.emit(APPEND_EVENT, makeActivityEvent(), FILE_PATH);
+		await vi.waitFor(() => expect(readCalls).toHaveLength(1));
+		expect(readCalls[0]).toEqual({
+			position: 0,
+			length: Buffer.byteLength(firstChunk, 'utf-8'),
+		});
+		expect(statsDB.insertQueryEvent).not.toHaveBeenCalled();
+
+		// Simulate the agent appending more bytes; size grows by `secondChunk`.
+		totalContent = firstChunk + secondChunk;
+		coordinator.emit(APPEND_EVENT, makeActivityEvent(), FILE_PATH);
+
+		await vi.waitFor(() => expect(statsDB.insertQueryEvent).toHaveBeenCalledTimes(1));
+		expect(readCalls).toHaveLength(2);
+		expect(readCalls[1]).toEqual({
+			position: Buffer.byteLength(firstChunk, 'utf-8'),
+			length: Buffer.byteLength(secondChunk, 'utf-8'),
+		});
+	});
+
+	it('does nothing when no parser is registered for the agent', async () => {
+		const fsImpl = makeFsImpl(RESULT_LINE + '\n');
+
+		new ExternalStatsIngester({
+			coordinator,
+			statsDB,
+			parsersByAgent: new Map(), // empty registry
+			logger,
+			fsImpl: fsImpl as unknown as ConstructorParameters<typeof ExternalStatsIngester>[0]['fsImpl'],
+		});
+
+		coordinator.emit(APPEND_EVENT, makeActivityEvent(), FILE_PATH);
+		await new Promise((r) => setTimeout(r, 10));
+
+		expect(statsDB.insertQueryEvent).not.toHaveBeenCalled();
+	});
+
+	it('skips processing entirely when the stats DB is not ready', async () => {
+		vi.mocked(statsDB.isReady).mockReturnValue(false);
+		const parser = makeParser('claude-code');
+		const fsImpl = makeFsImpl(RESULT_LINE + '\n');
+
+		new ExternalStatsIngester({
+			coordinator,
+			statsDB,
+			parsersByAgent: new Map([['claude-code', parser]]),
+			logger,
+			fsImpl: fsImpl as unknown as ConstructorParameters<typeof ExternalStatsIngester>[0]['fsImpl'],
+		});
+
+		coordinator.emit(APPEND_EVENT, makeActivityEvent(), FILE_PATH);
+		await new Promise((r) => setTimeout(r, 10));
+
+		expect(statsDB.insertQueryEvent).not.toHaveBeenCalled();
+	});
+
+	it('warn-logs and recovers when fs.stat rejects (file went away mid-event)', async () => {
+		const parser = makeParser('claude-code');
+		const stat = vi.fn(async () => {
+			throw new Error('ENOENT: file gone');
+		});
+		const open = vi.fn();
+
+		new ExternalStatsIngester({
+			coordinator,
+			statsDB,
+			parsersByAgent: new Map([['claude-code', parser]]),
+			logger,
+			fsImpl: { stat, open } as unknown as ConstructorParameters<
+				typeof ExternalStatsIngester
+			>[0]['fsImpl'],
+		});
+
+		coordinator.emit(APPEND_EVENT, makeActivityEvent(), FILE_PATH);
+		await vi.waitFor(() =>
+			expect(logger.warn).toHaveBeenCalledWith(
+				expect.stringContaining('Failed to stat'),
+				expect.any(String),
+				expect.any(Object)
+			)
+		);
+
+		expect(open).not.toHaveBeenCalled();
+		expect(statsDB.insertQueryEvent).not.toHaveBeenCalled();
+	});
+});

--- a/src/__tests__/main/process-listeners/insertQueryEventWithRetry.test.ts
+++ b/src/__tests__/main/process-listeners/insertQueryEventWithRetry.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Tests for the shared insertQueryEventWithRetry helper.
+ *
+ * Both the process-driven `setupStatsListener` and the file-driven
+ * `ExternalStatsIngester` use this helper to insert into the stats DB with
+ * exponential-backoff retry on transient SQLite errors. These tests exercise
+ * the retry/logging behavior directly — listener-level tests don't need to
+ * re-cover them.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+	insertQueryEventWithRetry,
+	MAX_RETRY_ATTEMPTS,
+} from '../../../main/process-listeners/insertQueryEventWithRetry';
+import type { QueryCompleteData } from '../../../main/process-manager/types';
+import type { StatsDB } from '../../../main/stats';
+import type { ProcessListenerDependencies } from '../../../main/process-listeners/types';
+
+function makeQueryData(overrides: Partial<QueryCompleteData> = {}): QueryCompleteData {
+	return {
+		sessionId: 'session-test',
+		agentType: 'claude-code',
+		source: 'user',
+		startTime: Date.now() - 1000,
+		duration: 1000,
+		projectPath: '/test/project',
+		tabId: 'tab-test',
+		...overrides,
+	};
+}
+
+describe('insertQueryEventWithRetry', () => {
+	let mockDB: StatsDB;
+	let mockLogger: ProcessListenerDependencies['logger'];
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockLogger = {
+			info: vi.fn(),
+			error: vi.fn(),
+			warn: vi.fn(),
+			debug: vi.fn(),
+		};
+		mockDB = {
+			isReady: vi.fn(() => true),
+			insertQueryEvent: vi.fn(() => 'event-id-success'),
+		} as unknown as StatsDB;
+	});
+
+	it('returns the inserted id on the first successful attempt', async () => {
+		const id = await insertQueryEventWithRetry(mockDB, makeQueryData(), mockLogger);
+
+		expect(id).toBe('event-id-success');
+		expect(mockDB.insertQueryEvent).toHaveBeenCalledTimes(1);
+		expect(mockLogger.warn).not.toHaveBeenCalled();
+		expect(mockLogger.error).not.toHaveBeenCalled();
+	});
+
+	it('passes through all QueryCompleteData fields to db.insertQueryEvent', async () => {
+		const data = makeQueryData({
+			sessionId: 'sess-1',
+			agentType: 'codex',
+			source: 'auto',
+			startTime: 12345,
+			duration: 6789,
+			projectPath: '/proj',
+			tabId: 'tab-1',
+		});
+		await insertQueryEventWithRetry(mockDB, data, mockLogger);
+
+		expect(mockDB.insertQueryEvent).toHaveBeenCalledWith({
+			sessionId: 'sess-1',
+			agentType: 'codex',
+			source: 'auto',
+			startTime: 12345,
+			duration: 6789,
+			projectPath: '/proj',
+			tabId: 'tab-1',
+		});
+	});
+
+	it("forwards the new 'external-fs' source value without alteration", async () => {
+		await insertQueryEventWithRetry(mockDB, makeQueryData({ source: 'external-fs' }), mockLogger);
+
+		expect(mockDB.insertQueryEvent).toHaveBeenCalledWith(
+			expect.objectContaining({ source: 'external-fs' })
+		);
+	});
+
+	it('retries on transient failure and returns the id once an attempt succeeds', async () => {
+		vi.mocked(mockDB.insertQueryEvent)
+			.mockImplementationOnce(() => {
+				throw new Error('SQLITE_BUSY');
+			})
+			.mockImplementationOnce(() => 'event-id-after-retry');
+
+		const id = await insertQueryEventWithRetry(
+			mockDB,
+			makeQueryData({ sessionId: 'session-retry' }),
+			mockLogger
+		);
+
+		expect(id).toBe('event-id-after-retry');
+		expect(mockDB.insertQueryEvent).toHaveBeenCalledTimes(2);
+		expect(mockLogger.warn).toHaveBeenCalledWith(
+			expect.stringContaining('Stats DB insert failed'),
+			'[Stats]',
+			expect.objectContaining({ sessionId: 'session-retry' })
+		);
+	});
+
+	it(`returns null and logs error after ${MAX_RETRY_ATTEMPTS} consecutive failures`, async () => {
+		vi.mocked(mockDB.insertQueryEvent).mockImplementation(() => {
+			throw new Error('persistent failure');
+		});
+
+		const id = await insertQueryEventWithRetry(
+			mockDB,
+			makeQueryData({ sessionId: 'session-fail' }),
+			mockLogger
+		);
+
+		expect(id).toBeNull();
+		expect(mockDB.insertQueryEvent).toHaveBeenCalledTimes(MAX_RETRY_ATTEMPTS);
+		expect(mockLogger.error).toHaveBeenCalledWith(
+			expect.stringContaining(`Failed to record query event after ${MAX_RETRY_ATTEMPTS} attempts`),
+			'[Stats]',
+			expect.objectContaining({ sessionId: 'session-fail' })
+		);
+		// Intermediate warns: MAX_RETRY_ATTEMPTS - 1 (last failure is the final error log).
+		expect(mockLogger.warn).toHaveBeenCalledTimes(MAX_RETRY_ATTEMPTS - 1);
+	});
+
+	it('never throws — even when every attempt fails, the promise resolves with null', async () => {
+		vi.mocked(mockDB.insertQueryEvent).mockImplementation(() => {
+			throw new Error('always fail');
+		});
+
+		await expect(
+			insertQueryEventWithRetry(mockDB, makeQueryData(), mockLogger)
+		).resolves.toBeNull();
+	});
+});

--- a/src/__tests__/main/process-listeners/stats-listener.test.ts
+++ b/src/__tests__/main/process-listeners/stats-listener.test.ts
@@ -116,48 +116,10 @@ describe('Stats Listener', () => {
 		expect(mockSafeSend).not.toHaveBeenCalled();
 	});
 
-	it('should log error when recording fails after retries', async () => {
-		vi.mocked(mockStatsDB.insertQueryEvent).mockImplementation(() => {
-			throw new Error('Database error');
-		});
-
-		setupStatsListener(mockProcessManager, {
-			safeSend: mockSafeSend,
-			getStatsDB: () => mockStatsDB,
-			logger: mockLogger,
-		});
-
-		const handler = eventHandlers.get('query-complete');
-		const testQueryData: QueryCompleteData = {
-			sessionId: 'session-789',
-			agentType: 'opencode',
-			source: 'user',
-			startTime: Date.now(),
-			duration: 2000,
-			projectPath: '/test/project',
-			tabId: 'tab-789',
-		};
-
-		handler?.('session-789', testQueryData);
-
-		// Wait for all retries to complete (100ms + 200ms + final attempt)
-		await vi.waitFor(
-			() => {
-				expect(mockLogger.error).toHaveBeenCalledWith(
-					expect.stringContaining('Failed to record query event after 3 attempts'),
-					'[Stats]',
-					expect.objectContaining({
-						sessionId: 'session-789',
-					})
-				);
-			},
-			{ timeout: 1000 }
-		);
-		// Should have tried 3 times
-		expect(mockStatsDB.insertQueryEvent).toHaveBeenCalledTimes(3);
-		// Should not have broadcasted update on failure
-		expect(mockSafeSend).not.toHaveBeenCalled();
-	});
+	// Retry / backoff behavior (3 attempts, exponential backoff, error logging on
+	// final failure) is exercised against the extracted helper in
+	// `insertQueryEventWithRetry.test.ts`. The listener-level test only needs to
+	// confirm the helper is wired in — success and not-ready paths above suffice.
 
 	it('should log debug info when recording succeeds', async () => {
 		setupStatsListener(mockProcessManager, {
@@ -192,48 +154,5 @@ describe('Stats Listener', () => {
 				})
 			);
 		});
-	});
-
-	it('should retry on transient failure and succeed', async () => {
-		// First call fails, second succeeds
-		vi.mocked(mockStatsDB.insertQueryEvent)
-			.mockImplementationOnce(() => {
-				throw new Error('Transient error');
-			})
-			.mockImplementationOnce(() => 'event-id-456');
-
-		setupStatsListener(mockProcessManager, {
-			safeSend: mockSafeSend,
-			getStatsDB: () => mockStatsDB,
-			logger: mockLogger,
-		});
-
-		const handler = eventHandlers.get('query-complete');
-		const testQueryData: QueryCompleteData = {
-			sessionId: 'session-retry',
-			agentType: 'claude-code',
-			source: 'user',
-			startTime: Date.now(),
-			duration: 1000,
-			projectPath: '/test/project',
-			tabId: 'tab-retry',
-		};
-
-		handler?.('session-retry', testQueryData);
-
-		// Wait for retry to complete
-		await vi.waitFor(
-			() => {
-				expect(mockStatsDB.insertQueryEvent).toHaveBeenCalledTimes(2);
-				expect(mockSafeSend).toHaveBeenCalledWith('stats:updated');
-			},
-			{ timeout: 500 }
-		);
-		// Should have logged warning for first failure
-		expect(mockLogger.warn).toHaveBeenCalledWith(
-			expect.stringContaining('Stats DB insert failed'),
-			'[Stats]',
-			expect.any(Object)
-		);
 	});
 });

--- a/src/__tests__/main/stats/integration.test.ts
+++ b/src/__tests__/main/stats/integration.test.ts
@@ -501,10 +501,19 @@ describe('Concurrent writes and database locking', () => {
 		it('should handle 100 concurrent writes across all three tables', async () => {
 			const writesByTable = { query: 0, session: 0, task: 0 };
 
-			// Track which table each insert goes to based on SQL
+			// Track which table each insert goes to based on SQL. We assign
+			// `tracker.run` on every prepare (not just the matching ones) so a
+			// non-matching SQL doesn't reuse the counter set by an earlier
+			// matching one — migration v5 in particular runs an
+			// `INSERT INTO query_events_v5 ... FROM query_events` during
+			// initialize, which previously left the shared `tracker.run` pointing
+			// at the query counter and over-counted every subsequent run() call
+			// in the migration (DROP, RENAME, index creates, _migrations insert).
+			// Match `INSERT INTO query_events ` (trailing space) so the v5
+			// migration's `query_events_v5` insert is not counted as a real one.
 			mockDb.prepare.mockImplementation((sql: string) => {
 				const tracker = mockStatement;
-				if (sql.includes('INSERT INTO query_events')) {
+				if (sql.includes('INSERT INTO query_events ')) {
 					tracker.run = vi.fn(() => {
 						writesByTable.query++;
 						return { changes: 1 };
@@ -519,6 +528,8 @@ describe('Concurrent writes and database locking', () => {
 						writesByTable.task++;
 						return { changes: 1 };
 					});
+				} else {
+					tracker.run = vi.fn(() => ({ changes: 1 }));
 				}
 				return tracker;
 			});

--- a/src/__tests__/main/stats/stats-db.test.ts
+++ b/src/__tests__/main/stats/stats-db.test.ts
@@ -284,13 +284,14 @@ describe('StatsDB class (mocked)', () => {
 			const db = new StatsDB();
 			db.initialize();
 
-			// Currently we have version 4 migration (v1: initial schema, v2: is_remote column, v3: session_lifecycle table, v4: compound indexes)
-			expect(db.getTargetVersion()).toBe(4);
+			// v1: initial schema, v2: is_remote column, v3: session_lifecycle table,
+			// v4: compound indexes, v5: widen query_events.source CHECK to allow 'external-fs'.
+			expect(db.getTargetVersion()).toBe(5);
 		});
 
 		it('should return false from hasPendingMigrations() when up to date', async () => {
 			mockDb.pragma.mockImplementation((sql: string) => {
-				if (sql === 'user_version') return [{ user_version: 4 }];
+				if (sql === 'user_version') return [{ user_version: 5 }];
 				return undefined;
 			});
 
@@ -305,8 +306,8 @@ describe('StatsDB class (mocked)', () => {
 			// This test verifies the hasPendingMigrations() logic
 			// by checking current version < target version
 
-			// Simulate a database that's already at version 4 (target version)
-			let currentVersion = 4;
+			// Simulate a database that's already at version 5 (current target version)
+			let currentVersion = 5;
 			mockDb.pragma.mockImplementation((sql: string) => {
 				if (sql === 'user_version') return [{ user_version: currentVersion }];
 				// Handle version updates from migration
@@ -320,9 +321,9 @@ describe('StatsDB class (mocked)', () => {
 			const db = new StatsDB();
 			db.initialize();
 
-			// At version 4, target is 4, so no pending migrations
-			expect(db.getCurrentVersion()).toBe(4);
-			expect(db.getTargetVersion()).toBe(4);
+			// At version 5, target is 5, so no pending migrations
+			expect(db.getCurrentVersion()).toBe(5);
+			expect(db.getTargetVersion()).toBe(5);
 			expect(db.hasPendingMigrations()).toBe(false);
 		});
 

--- a/src/__tests__/main/storage/external-session-coordinator.test.ts
+++ b/src/__tests__/main/storage/external-session-coordinator.test.ts
@@ -1,0 +1,657 @@
+/**
+ * Tests for ExternalSessionCoordinator — the single owner of on-disk session
+ * watchers that folds per-agent activity into one coalesced state stream and
+ * stamps each event with `source: 'local' | 'external'` based on whether
+ * ProcessManager is already driving the same agent-native sessionId.
+ *
+ * SessionFileWatcher is mocked so we can drive synthetic 'create' / 'append' /
+ * 'idle' events directly. Tests focus on:
+ *  - boot-time watcher construction (one per non-null spec, tolerant of
+ *    missing storages / null specs / start() failures)
+ *  - event routing into the internal state map
+ *  - source annotation via ProcessManager.findByAgentSessionId
+ *  - 100ms debounce coalescing of bursts into a single 'state-changed' emit
+ *  - idle removal + stop() cleanup semantics
+ */
+
+import { EventEmitter } from 'events';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import type { ToolType } from '../../../shared/types';
+import type { AgentSessionStorage } from '../../../main/agents';
+import type { SessionActivityEvent } from '../../../shared/sessionActivity';
+import type { StorageWatchSpec } from '../../../main/storage/base-session-storage';
+import type { ProcessManager } from '../../../main/process-manager';
+import type { ManagedProcess } from '../../../main/process-manager/types';
+
+// --- mock SessionFileWatcher -------------------------------------------------
+
+interface FakeWatcherOptions {
+	agentId: ToolType;
+	storageDir: string;
+	fileMatcher: StorageWatchSpec['fileMatcher'];
+}
+
+interface FakeWatcher extends EventEmitter {
+	agentId: ToolType;
+	storageDir: string;
+	fileMatcher: StorageWatchSpec['fileMatcher'];
+	start: ReturnType<typeof vi.fn>;
+	stop: ReturnType<typeof vi.fn>;
+}
+
+// `vi.hoisted` runs before `vi.mock` factories, which themselves are hoisted
+// to the top of the file. This is the only way to share mutable state between
+// the mocked module and the test body without tripping the no-top-level-vars
+// guard inside `vi.mock`.
+const mockState = vi.hoisted(() => {
+	return {
+		createdWatchers: [] as FakeWatcher[],
+	};
+});
+
+vi.mock('../../../main/storage/session-file-watcher', async () => {
+	const { EventEmitter: EE } = await import('events');
+	const { vi: viInner } = await import('vitest');
+	class FakeSessionFileWatcher extends EE {
+		agentId: ToolType;
+		storageDir: string;
+		fileMatcher: StorageWatchSpec['fileMatcher'];
+		start = viInner.fn(async () => {});
+		stop = viInner.fn(async () => {});
+
+		constructor(options: FakeWatcherOptions) {
+			super();
+			this.agentId = options.agentId;
+			this.storageDir = options.storageDir;
+			this.fileMatcher = options.fileMatcher;
+			mockState.createdWatchers.push(this as unknown as FakeWatcher);
+		}
+	}
+	return { SessionFileWatcher: FakeSessionFileWatcher };
+});
+
+const createdWatchers = mockState.createdWatchers;
+
+vi.mock('../../../main/utils/logger', () => ({
+	logger: {
+		info: vi.fn(),
+		debug: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+	},
+}));
+
+// Imported after vi.mock so the coordinator picks up the mocked watcher.
+import {
+	ExternalSessionCoordinator,
+	STATE_CHANGED_EVENT,
+	STATE_CHANGE_DEBOUNCE_MS,
+	type ExternalSessionStateChange,
+} from '../../../main/storage/external-session-coordinator';
+
+// --- test helpers ------------------------------------------------------------
+
+function makeSpec(rootDir: string): StorageWatchSpec {
+	return {
+		rootDir,
+		fileMatcher: (rel: string) => ({ sessionId: rel, projectPath: '' }),
+	};
+}
+
+interface StubStorageOptions {
+	agentId: ToolType;
+	spec: StorageWatchSpec | null;
+	throwsFromSpec?: boolean;
+	omitSpecFn?: boolean;
+}
+
+/**
+ * Build a minimal AgentSessionStorage stub that exposes only what the
+ * coordinator reads from it (`getStorageWatchSpec`). All other methods are
+ * cast through `unknown` because the coordinator never touches them.
+ */
+function makeStorageStub(options: StubStorageOptions): AgentSessionStorage {
+	const stub: Partial<AgentSessionStorage> & {
+		getStorageWatchSpec?: () => StorageWatchSpec | null;
+	} = { agentId: options.agentId };
+
+	if (!options.omitSpecFn) {
+		stub.getStorageWatchSpec = () => {
+			if (options.throwsFromSpec) throw new Error('boom');
+			return options.spec;
+		};
+	}
+
+	return stub as AgentSessionStorage;
+}
+
+function makeProcessManager(
+	overrides: Partial<Pick<ProcessManager, 'findByAgentSessionId'>> = {}
+): ProcessManager {
+	const fake = {
+		findByAgentSessionId: vi.fn(() => undefined),
+		...overrides,
+	};
+	return fake as unknown as ProcessManager;
+}
+
+function activityEvent(
+	overrides: Partial<SessionActivityEvent> & { sessionId: string }
+): SessionActivityEvent {
+	return {
+		agentId: 'claude-code',
+		projectPath: 'proj',
+		lastActivityAt: Date.now(),
+		source: 'external',
+		sizeBytes: 0,
+		...overrides,
+	};
+}
+
+async function flushMicrotasks(): Promise<void> {
+	// Two passes drain promise.then callbacks queued from within the
+	// coordinator's await watcher.start() loop without depending on real time.
+	await Promise.resolve();
+	await Promise.resolve();
+}
+
+// --- tests -------------------------------------------------------------------
+
+describe('ExternalSessionCoordinator', () => {
+	beforeEach(() => {
+		createdWatchers.length = 0;
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.clearAllMocks();
+	});
+
+	describe('start()', () => {
+		it('instantiates one watcher per storage with a non-null spec', async () => {
+			const claudeStorage = makeStorageStub({
+				agentId: 'claude-code',
+				spec: makeSpec('/tmp/claude'),
+			});
+			const codexStorage = makeStorageStub({
+				agentId: 'codex',
+				spec: makeSpec('/tmp/codex'),
+			});
+
+			const coordinator = new ExternalSessionCoordinator({
+				processManager: makeProcessManager(),
+				storageRegistry: { 'claude-code': claudeStorage, codex: codexStorage },
+			});
+
+			await coordinator.start();
+
+			expect(createdWatchers).toHaveLength(2);
+			expect(new Set(createdWatchers.map((w) => w.agentId))).toEqual(
+				new Set(['claude-code', 'codex'])
+			);
+			expect(createdWatchers.every((w) => w.start.mock.calls.length === 1)).toBe(true);
+
+			await coordinator.stop();
+		});
+
+		it('skips undefined storages and storages without a getStorageWatchSpec method', async () => {
+			const claudeStorage = makeStorageStub({
+				agentId: 'claude-code',
+				spec: makeSpec('/tmp/claude'),
+			});
+			const legacyStorage = makeStorageStub({
+				agentId: 'opencode',
+				spec: null,
+				omitSpecFn: true,
+			});
+
+			const coordinator = new ExternalSessionCoordinator({
+				processManager: makeProcessManager(),
+				storageRegistry: {
+					'claude-code': claudeStorage,
+					opencode: legacyStorage,
+					codex: undefined,
+				},
+			});
+
+			await coordinator.start();
+
+			expect(createdWatchers).toHaveLength(1);
+			expect(createdWatchers[0].agentId).toBe('claude-code');
+
+			await coordinator.stop();
+		});
+
+		it('skips storages whose getStorageWatchSpec() returns null', async () => {
+			const claudeStorage = makeStorageStub({
+				agentId: 'claude-code',
+				spec: makeSpec('/tmp/claude'),
+			});
+			const codexStorage = makeStorageStub({ agentId: 'codex', spec: null });
+
+			const coordinator = new ExternalSessionCoordinator({
+				processManager: makeProcessManager(),
+				storageRegistry: { 'claude-code': claudeStorage, codex: codexStorage },
+			});
+
+			await coordinator.start();
+
+			expect(createdWatchers).toHaveLength(1);
+			expect(createdWatchers[0].agentId).toBe('claude-code');
+
+			await coordinator.stop();
+		});
+
+		it('does not throw when getStorageWatchSpec() throws — just skips that storage', async () => {
+			const claudeStorage = makeStorageStub({
+				agentId: 'claude-code',
+				spec: makeSpec('/tmp/claude'),
+			});
+			const badStorage = makeStorageStub({
+				agentId: 'codex',
+				spec: null,
+				throwsFromSpec: true,
+			});
+
+			const coordinator = new ExternalSessionCoordinator({
+				processManager: makeProcessManager(),
+				storageRegistry: { 'claude-code': claudeStorage, codex: badStorage },
+			});
+
+			await expect(coordinator.start()).resolves.toBeUndefined();
+			expect(createdWatchers).toHaveLength(1);
+			expect(createdWatchers[0].agentId).toBe('claude-code');
+
+			await coordinator.stop();
+		});
+
+		it('tolerates per-watcher start() failures (logs and skips, does not throw)', async () => {
+			// Make the first watcher's start() reject; the coordinator's per-storage
+			// loop awaits start() right after construction, so we wait for the first
+			// FakeWatcher to appear and rewrite its start() before the await yields.
+			// Simpler approach: a getter on the registry returns a stub that, when
+			// the coordinator constructs its watcher, the next push gets its start
+			// swapped out. We do this by polling synchronously after start() is invoked.
+			const claudeStorage = makeStorageStub({
+				agentId: 'claude-code',
+				spec: makeSpec('/tmp/claude'),
+			});
+			const codexStorage = makeStorageStub({
+				agentId: 'codex',
+				spec: makeSpec('/tmp/codex'),
+			});
+
+			const coordinator = new ExternalSessionCoordinator({
+				processManager: makeProcessManager(),
+				storageRegistry: { 'claude-code': claudeStorage, codex: codexStorage },
+			});
+
+			// Patch the prototype so the FIRST watcher's start() rejects. Cast to
+			// `any` because prototype-level overrides require erasing the readonly
+			// instance-field type that vitest infers.
+			const ctor = (await import('../../../main/storage/session-file-watcher'))
+				.SessionFileWatcher as unknown as new (options: FakeWatcherOptions) => FakeWatcher;
+			const proto = ctor.prototype as unknown as Record<string, unknown>;
+			const originalStart = proto.start;
+			let callCount = 0;
+			proto.start = vi.fn(async () => {
+				callCount += 1;
+				if (callCount === 1) throw new Error('chokidar exploded');
+			});
+
+			try {
+				await expect(coordinator.start()).resolves.toBeUndefined();
+				expect(createdWatchers).toHaveLength(2);
+				await expect(coordinator.stop()).resolves.toBeUndefined();
+			} finally {
+				proto.start = originalStart;
+			}
+		});
+
+		it('is idempotent — a second start() does not re-instantiate watchers', async () => {
+			const claudeStorage = makeStorageStub({
+				agentId: 'claude-code',
+				spec: makeSpec('/tmp/claude'),
+			});
+
+			const coordinator = new ExternalSessionCoordinator({
+				processManager: makeProcessManager(),
+				storageRegistry: { 'claude-code': claudeStorage },
+			});
+
+			await coordinator.start();
+			await coordinator.start();
+
+			expect(createdWatchers).toHaveLength(1);
+
+			await coordinator.stop();
+		});
+	});
+
+	describe('event handling', () => {
+		it('emits state-changed after the debounce window on append', async () => {
+			vi.useFakeTimers();
+			const coordinator = new ExternalSessionCoordinator({
+				processManager: makeProcessManager(),
+				storageRegistry: {
+					'claude-code': makeStorageStub({
+						agentId: 'claude-code',
+						spec: makeSpec('/tmp/claude'),
+					}),
+				},
+			});
+			await coordinator.start();
+			await flushMicrotasks();
+
+			const listener = vi.fn();
+			coordinator.on(STATE_CHANGED_EVENT, listener);
+
+			createdWatchers[0].emit('append', activityEvent({ sessionId: 'sess-1' }));
+
+			// Listener not invoked synchronously — coalesced through the timer.
+			expect(listener).not.toHaveBeenCalled();
+
+			await vi.advanceTimersByTimeAsync(STATE_CHANGE_DEBOUNCE_MS + 1);
+
+			expect(listener).toHaveBeenCalledTimes(1);
+			const payload = listener.mock.calls[0][0] as ExternalSessionStateChange;
+			expect(payload.events).toHaveLength(1);
+			expect(payload.events[0].sessionId).toBe('sess-1');
+
+			await coordinator.stop();
+		});
+
+		it('emits state-changed on create the same way as append', async () => {
+			vi.useFakeTimers();
+			const coordinator = new ExternalSessionCoordinator({
+				processManager: makeProcessManager(),
+				storageRegistry: {
+					'claude-code': makeStorageStub({
+						agentId: 'claude-code',
+						spec: makeSpec('/tmp/claude'),
+					}),
+				},
+			});
+			await coordinator.start();
+			await flushMicrotasks();
+
+			const listener = vi.fn();
+			coordinator.on(STATE_CHANGED_EVENT, listener);
+
+			createdWatchers[0].emit('create', activityEvent({ sessionId: 'sess-new' }));
+			await vi.advanceTimersByTimeAsync(STATE_CHANGE_DEBOUNCE_MS + 1);
+
+			expect(listener).toHaveBeenCalledTimes(1);
+			const payload = listener.mock.calls[0][0] as ExternalSessionStateChange;
+			expect(payload.events.map((e) => e.sessionId)).toEqual(['sess-new']);
+
+			await coordinator.stop();
+		});
+
+		it("annotates source as 'local' when ProcessManager has a matching agentSessionId", async () => {
+			vi.useFakeTimers();
+			const local = {
+				sessionId: 'local-internal-id',
+				agentSessionId: 'sess-local',
+			} as ManagedProcess;
+			const processManager = makeProcessManager({
+				findByAgentSessionId: vi.fn((id: string) => (id === 'sess-local' ? local : undefined)),
+			});
+			const coordinator = new ExternalSessionCoordinator({
+				processManager,
+				storageRegistry: {
+					'claude-code': makeStorageStub({
+						agentId: 'claude-code',
+						spec: makeSpec('/tmp/claude'),
+					}),
+				},
+			});
+			await coordinator.start();
+			await flushMicrotasks();
+
+			const listener = vi.fn();
+			coordinator.on(STATE_CHANGED_EVENT, listener);
+
+			createdWatchers[0].emit(
+				'append',
+				activityEvent({ sessionId: 'sess-local', source: 'external' })
+			);
+			await vi.advanceTimersByTimeAsync(STATE_CHANGE_DEBOUNCE_MS + 1);
+
+			const payload = listener.mock.calls[0][0] as ExternalSessionStateChange;
+			expect(payload.events).toHaveLength(1);
+			expect(payload.events[0].source).toBe('local');
+			expect(processManager.findByAgentSessionId).toHaveBeenCalledWith('sess-local');
+
+			await coordinator.stop();
+		});
+
+		it("annotates source as 'external' when ProcessManager has no matching session", async () => {
+			vi.useFakeTimers();
+			const processManager = makeProcessManager({
+				findByAgentSessionId: vi.fn(() => undefined),
+			});
+			const coordinator = new ExternalSessionCoordinator({
+				processManager,
+				storageRegistry: {
+					'claude-code': makeStorageStub({
+						agentId: 'claude-code',
+						spec: makeSpec('/tmp/claude'),
+					}),
+				},
+			});
+			await coordinator.start();
+			await flushMicrotasks();
+
+			const listener = vi.fn();
+			coordinator.on(STATE_CHANGED_EVENT, listener);
+
+			// Send in a payload with source already set to 'local' to prove the
+			// coordinator rewrites it based on the live processManager lookup,
+			// not on whatever the watcher claimed.
+			createdWatchers[0].emit(
+				'append',
+				activityEvent({ sessionId: 'sess-remote', source: 'local' })
+			);
+			await vi.advanceTimersByTimeAsync(STATE_CHANGE_DEBOUNCE_MS + 1);
+
+			const payload = listener.mock.calls[0][0] as ExternalSessionStateChange;
+			expect(payload.events[0].source).toBe('external');
+
+			await coordinator.stop();
+		});
+
+		it('coalesces a burst of events within the debounce window into one emission', async () => {
+			vi.useFakeTimers();
+			const coordinator = new ExternalSessionCoordinator({
+				processManager: makeProcessManager(),
+				storageRegistry: {
+					'claude-code': makeStorageStub({
+						agentId: 'claude-code',
+						spec: makeSpec('/tmp/claude'),
+					}),
+				},
+			});
+			await coordinator.start();
+			await flushMicrotasks();
+
+			const listener = vi.fn();
+			coordinator.on(STATE_CHANGED_EVENT, listener);
+
+			const watcher = createdWatchers[0];
+			watcher.emit('create', activityEvent({ sessionId: 'a', sizeBytes: 1 }));
+			watcher.emit('append', activityEvent({ sessionId: 'a', sizeBytes: 2 }));
+			watcher.emit('append', activityEvent({ sessionId: 'b', sizeBytes: 1 }));
+			watcher.emit('append', activityEvent({ sessionId: 'a', sizeBytes: 3 }));
+
+			// Inside the debounce window — still no fire.
+			await vi.advanceTimersByTimeAsync(STATE_CHANGE_DEBOUNCE_MS - 1);
+			expect(listener).not.toHaveBeenCalled();
+
+			await vi.advanceTimersByTimeAsync(2);
+			expect(listener).toHaveBeenCalledTimes(1);
+
+			const payload = listener.mock.calls[0][0] as ExternalSessionStateChange;
+			const byId = new Map(payload.events.map((e) => [e.sessionId, e]));
+			expect(byId.size).toBe(2);
+			// Latest write for 'a' (sizeBytes 3) should have won — the map keeps the
+			// most recent annotated event per key.
+			expect(byId.get('a')?.sizeBytes).toBe(3);
+			expect(byId.get('b')?.sizeBytes).toBe(1);
+
+			await coordinator.stop();
+		});
+
+		it('removes the entry on idle and emits state-changed reflecting the deletion', async () => {
+			vi.useFakeTimers();
+			const coordinator = new ExternalSessionCoordinator({
+				processManager: makeProcessManager(),
+				storageRegistry: {
+					'claude-code': makeStorageStub({
+						agentId: 'claude-code',
+						spec: makeSpec('/tmp/claude'),
+					}),
+				},
+			});
+			await coordinator.start();
+			await flushMicrotasks();
+
+			const watcher = createdWatchers[0];
+			watcher.emit('append', activityEvent({ sessionId: 'sess-1' }));
+			await vi.advanceTimersByTimeAsync(STATE_CHANGE_DEBOUNCE_MS + 1);
+			expect(coordinator.getState().size).toBe(1);
+
+			const listener = vi.fn();
+			coordinator.on(STATE_CHANGED_EVENT, listener);
+
+			watcher.emit('idle', activityEvent({ sessionId: 'sess-1' }));
+			await vi.advanceTimersByTimeAsync(STATE_CHANGE_DEBOUNCE_MS + 1);
+
+			expect(listener).toHaveBeenCalledTimes(1);
+			const payload = listener.mock.calls[0][0] as ExternalSessionStateChange;
+			expect(payload.events).toHaveLength(0);
+			expect(coordinator.getState().size).toBe(0);
+
+			await coordinator.stop();
+		});
+
+		it('idle for an unknown session is a silent no-op (no state-changed emitted)', async () => {
+			vi.useFakeTimers();
+			const coordinator = new ExternalSessionCoordinator({
+				processManager: makeProcessManager(),
+				storageRegistry: {
+					'claude-code': makeStorageStub({
+						agentId: 'claude-code',
+						spec: makeSpec('/tmp/claude'),
+					}),
+				},
+			});
+			await coordinator.start();
+			await flushMicrotasks();
+
+			const listener = vi.fn();
+			coordinator.on(STATE_CHANGED_EVENT, listener);
+
+			createdWatchers[0].emit('idle', activityEvent({ sessionId: 'ghost' }));
+			await vi.advanceTimersByTimeAsync(STATE_CHANGE_DEBOUNCE_MS + 1);
+
+			expect(listener).not.toHaveBeenCalled();
+			expect(coordinator.getState().size).toBe(0);
+
+			await coordinator.stop();
+		});
+	});
+
+	describe('getState()', () => {
+		it('returns a defensive snapshot — mutating the result does not affect internal state', async () => {
+			vi.useFakeTimers();
+			const coordinator = new ExternalSessionCoordinator({
+				processManager: makeProcessManager(),
+				storageRegistry: {
+					'claude-code': makeStorageStub({
+						agentId: 'claude-code',
+						spec: makeSpec('/tmp/claude'),
+					}),
+				},
+			});
+			await coordinator.start();
+			await flushMicrotasks();
+
+			createdWatchers[0].emit('append', activityEvent({ sessionId: 'sess-1' }));
+			await vi.advanceTimersByTimeAsync(STATE_CHANGE_DEBOUNCE_MS + 1);
+
+			const snapshot = coordinator.getState();
+			expect(snapshot.size).toBe(1);
+			snapshot.clear();
+			expect(coordinator.getState().size).toBe(1);
+
+			await coordinator.stop();
+		});
+	});
+
+	describe('stop()', () => {
+		it('calls stop() on every started watcher', async () => {
+			const claudeStorage = makeStorageStub({
+				agentId: 'claude-code',
+				spec: makeSpec('/tmp/claude'),
+			});
+			const codexStorage = makeStorageStub({
+				agentId: 'codex',
+				spec: makeSpec('/tmp/codex'),
+			});
+
+			const coordinator = new ExternalSessionCoordinator({
+				processManager: makeProcessManager(),
+				storageRegistry: { 'claude-code': claudeStorage, codex: codexStorage },
+			});
+
+			await coordinator.start();
+			await coordinator.stop();
+
+			expect(createdWatchers).toHaveLength(2);
+			expect(createdWatchers.every((w) => w.stop.mock.calls.length === 1)).toBe(true);
+		});
+
+		it('clears the state map and any pending debounce timer', async () => {
+			vi.useFakeTimers();
+			const coordinator = new ExternalSessionCoordinator({
+				processManager: makeProcessManager(),
+				storageRegistry: {
+					'claude-code': makeStorageStub({
+						agentId: 'claude-code',
+						spec: makeSpec('/tmp/claude'),
+					}),
+				},
+			});
+			await coordinator.start();
+			await flushMicrotasks();
+
+			const listener = vi.fn();
+			coordinator.on(STATE_CHANGED_EVENT, listener);
+
+			createdWatchers[0].emit('append', activityEvent({ sessionId: 'sess-1' }));
+			// Stop BEFORE the debounce timer fires — listener should never see it.
+			await coordinator.stop();
+			await vi.advanceTimersByTimeAsync(STATE_CHANGE_DEBOUNCE_MS + 10);
+
+			expect(listener).not.toHaveBeenCalled();
+			expect(coordinator.getState().size).toBe(0);
+		});
+
+		it('is safe to call multiple times', async () => {
+			const coordinator = new ExternalSessionCoordinator({
+				processManager: makeProcessManager(),
+				storageRegistry: {
+					'claude-code': makeStorageStub({
+						agentId: 'claude-code',
+						spec: makeSpec('/tmp/claude'),
+					}),
+				},
+			});
+			await coordinator.start();
+			await expect(coordinator.stop()).resolves.toBeUndefined();
+			await expect(coordinator.stop()).resolves.toBeUndefined();
+		});
+	});
+});

--- a/src/__tests__/main/storage/opencode-watch-spec.test.ts
+++ b/src/__tests__/main/storage/opencode-watch-spec.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Tests for OpenCodeSessionStorage.getStorageWatchSpec().
+ *
+ * OpenCode's session activity shape is unique among the supported agents:
+ * each new message is written as its own `.json` file inside a per-session
+ * directory, so the matcher identifies the session by the parent directory
+ * segment (not the filename), and the spec advertises `activityEvent: 'create'`
+ * rather than the `'append'` default used by the JSONL-per-session agents.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import os from 'os';
+import path from 'path';
+
+vi.mock('electron', () => ({
+	app: {
+		getPath: vi.fn(() => '/tmp/maestro-test-userData'),
+	},
+}));
+
+vi.mock('electron-store', () => ({
+	default: vi.fn().mockImplementation(() => ({
+		get: vi.fn((_key: string, defaultValue?: unknown) => defaultValue),
+		set: vi.fn(),
+		store: {},
+	})),
+}));
+
+vi.mock('../../../main/utils/logger', () => ({
+	logger: {
+		info: vi.fn(),
+		debug: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+	},
+}));
+
+import { OpenCodeSessionStorage } from '../../../main/storage/opencode-session-storage';
+import { isWindows } from '../../../shared/platformDetection';
+
+describe('OpenCodeSessionStorage.getStorageWatchSpec', () => {
+	const storage = new OpenCodeSessionStorage();
+	const spec = storage.getStorageWatchSpec();
+
+	it('returns a non-null spec', () => {
+		expect(spec).not.toBeNull();
+	});
+
+	it('advertises activityEvent: "create" (not the default append)', () => {
+		expect(spec?.activityEvent).toBe('create');
+	});
+
+	it('rootDir is the XDG OpenCode storage directory for the current platform', () => {
+		const expected = isWindows()
+			? path.join(
+					process.env.APPDATA || path.join(os.homedir(), 'AppData', 'Roaming'),
+					'opencode',
+					'storage'
+				)
+			: path.join(os.homedir(), '.local', 'share', 'opencode', 'storage');
+		expect(spec?.rootDir).toBe(expected);
+	});
+
+	it('matches a `<projectId>/<sessionId>/<msg-id>.json` path and returns the parent directory as sessionId', () => {
+		const rel = path.join(
+			'message',
+			'ses_4d585107dffeO9bO3HvMdvLYyC',
+			'msg_aaaaaaaaaaaaaaaaaaaaaaaaaa.json'
+		);
+		expect(spec?.fileMatcher(rel)).toEqual({
+			sessionId: 'ses_4d585107dffeO9bO3HvMdvLYyC',
+			projectPath: '',
+		});
+	});
+
+	it('returns null for `global.json` at the root', () => {
+		expect(spec?.fileMatcher('global.json')).toBeNull();
+	});
+
+	it('returns null for a `.txt` file inside a session dir', () => {
+		const rel = path.join('message', 'ses_4d585107dffeO9bO3HvMdvLYyC', 'msg_aaaa.txt');
+		expect(spec?.fileMatcher(rel)).toBeNull();
+	});
+
+	it('returns null for an empty path', () => {
+		expect(spec?.fileMatcher('')).toBeNull();
+	});
+});

--- a/src/__tests__/main/storage/session-file-watcher.test.ts
+++ b/src/__tests__/main/storage/session-file-watcher.test.ts
@@ -1,0 +1,274 @@
+/**
+ * Tests for SessionFileWatcher — generic on-disk watcher used to surface
+ * activity from agent sessions Maestro did NOT spawn.
+ *
+ * These tests use real files under `os.tmpdir()` and a real chokidar watcher.
+ * `fs` is intentionally NOT mocked. Time-sensitive assertions (idle window,
+ * debounce) lean on `vi.useFakeTimers({ toFake: [...] })` with only the timer
+ * APIs the watcher itself uses faked out, leaving `setImmediate`,
+ * `process.nextTick`, etc. on real time so chokidar / libuv keep delivering
+ * filesystem events.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { EventEmitter } from 'events';
+import { promises as fs } from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { SessionFileWatcher } from '../../../main/storage/session-file-watcher';
+import {
+	EXTERNAL_ACTIVITY_IDLE_MS,
+	type SessionActivityEvent,
+} from '../../../shared/sessionActivity';
+
+// Capture the real setTimeout / clearTimeout once at module load — these stay
+// usable even after `vi.useFakeTimers()` swaps the globals.
+const realSetTimeout = globalThis.setTimeout.bind(globalThis);
+const realClearTimeout = globalThis.clearTimeout.bind(globalThis);
+
+vi.mock('../../../main/utils/logger', () => ({
+	logger: {
+		info: vi.fn(),
+		debug: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+	},
+}));
+
+// On macOS chokidar uses fsevents which can take a tick or two before it
+// starts reporting events. This delay is short but real-time.
+const CHOKIDAR_READY_MS = 250;
+const CHOKIDAR_EVENT_MS = 250;
+
+function realDelay(ms: number): Promise<void> {
+	return new Promise((resolve) => realSetTimeout(resolve, ms));
+}
+
+function waitForEvent<T = SessionActivityEvent>(
+	emitter: EventEmitter,
+	event: string,
+	timeoutMs = 3000
+): Promise<T> {
+	return new Promise((resolve, reject) => {
+		const timer = realSetTimeout(() => {
+			emitter.off(event, handler);
+			reject(new Error(`Timed out waiting for '${event}' after ${timeoutMs}ms`));
+		}, timeoutMs);
+		function handler(payload: T) {
+			realClearTimeout(timer);
+			resolve(payload);
+		}
+		emitter.once(event, handler);
+	});
+}
+
+/**
+ * Default matcher: relative paths shaped as `<project>/sess-<id>.jsonl`.
+ * Anything else returns null, so the watcher must ignore it.
+ */
+function makeMatcher() {
+	return (rel: string) => {
+		const normalized = rel.split(path.sep).join('/');
+		const match = normalized.match(/^(.+)\/sess-(.+)\.jsonl$/);
+		if (!match) return null;
+		return { projectPath: match[1], sessionId: match[2] };
+	};
+}
+
+describe('SessionFileWatcher', () => {
+	let tmpRoot: string;
+	let watcher: SessionFileWatcher | null = null;
+
+	beforeEach(async () => {
+		tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'maestro-sfw-'));
+	});
+
+	afterEach(async () => {
+		if (watcher) {
+			await watcher.stop();
+			watcher = null;
+		}
+		vi.useRealTimers();
+		await fs.rm(tmpRoot, { recursive: true, force: true }).catch(() => {});
+	});
+
+	it('emits "create" when a new matching session file appears', async () => {
+		watcher = new SessionFileWatcher({
+			agentId: 'claude-code',
+			storageDir: tmpRoot,
+			fileMatcher: makeMatcher(),
+			debounceMs: 25,
+		});
+		await watcher.start();
+		await realDelay(CHOKIDAR_READY_MS);
+
+		const projectDir = path.join(tmpRoot, 'proj-1');
+		await fs.mkdir(projectDir);
+
+		const eventPromise = waitForEvent(watcher, 'create');
+		const filePath = path.join(projectDir, 'sess-abc.jsonl');
+		const initialContent = 'first line\n';
+		await fs.writeFile(filePath, initialContent);
+
+		const event = await eventPromise;
+		expect(event.agentId).toBe('claude-code');
+		expect(event.sessionId).toBe('abc');
+		expect(event.projectPath).toBe('proj-1');
+		expect(event.source).toBe('external');
+		expect(event.sizeBytes).toBe(initialContent.length);
+		expect(event.lastActivityAt).toBeGreaterThan(0);
+		expect(Date.now() - event.lastActivityAt).toBeLessThan(5000);
+	});
+
+	it('emits "append" when an existing session file grows', async () => {
+		const projectDir = path.join(tmpRoot, 'proj-2');
+		await fs.mkdir(projectDir);
+		const filePath = path.join(projectDir, 'sess-xyz.jsonl');
+		const initialContent = 'existing\n';
+		await fs.writeFile(filePath, initialContent);
+
+		watcher = new SessionFileWatcher({
+			agentId: 'claude-code',
+			storageDir: tmpRoot,
+			fileMatcher: makeMatcher(),
+			debounceMs: 25,
+		});
+		await watcher.start();
+		await realDelay(CHOKIDAR_READY_MS);
+
+		const eventPromise = waitForEvent(watcher, 'append');
+		const before = Date.now();
+		await fs.appendFile(filePath, 'more bytes here\n');
+		const event = await eventPromise;
+
+		expect(event.sessionId).toBe('xyz');
+		expect(event.projectPath).toBe('proj-2');
+		expect(event.source).toBe('external');
+		expect(event.sizeBytes).toBeGreaterThan(initialContent.length);
+		expect(event.lastActivityAt).toBeGreaterThanOrEqual(before);
+	});
+
+	it('emits no events for files where fileMatcher returns null', async () => {
+		watcher = new SessionFileWatcher({
+			agentId: 'claude-code',
+			storageDir: tmpRoot,
+			fileMatcher: makeMatcher(),
+			debounceMs: 25,
+		});
+		await watcher.start();
+		await realDelay(CHOKIDAR_READY_MS);
+
+		let createCount = 0;
+		let appendCount = 0;
+		watcher.on('create', () => {
+			createCount += 1;
+		});
+		watcher.on('append', () => {
+			appendCount += 1;
+		});
+
+		// Two unrelated paths: a top-level non-jsonl file, and a jsonl file
+		// that doesn't match the `sess-*` shape the matcher requires.
+		await fs.writeFile(path.join(tmpRoot, 'random.txt'), 'hello');
+		const otherDir = path.join(tmpRoot, 'proj-3');
+		await fs.mkdir(otherDir);
+		await fs.writeFile(path.join(otherDir, 'not-a-session.jsonl'), 'noise\n');
+
+		// Give chokidar more than enough time to deliver + debounce both events.
+		await realDelay(CHOKIDAR_EVENT_MS + 100);
+
+		expect(createCount).toBe(0);
+		expect(appendCount).toBe(0);
+	});
+
+	it('debounces rapid appends into a single event', async () => {
+		const projectDir = path.join(tmpRoot, 'proj-4');
+		await fs.mkdir(projectDir);
+		const filePath = path.join(projectDir, 'sess-rapid.jsonl');
+		await fs.writeFile(filePath, 'init\n');
+
+		watcher = new SessionFileWatcher({
+			agentId: 'claude-code',
+			storageDir: tmpRoot,
+			fileMatcher: makeMatcher(),
+			debounceMs: 200,
+		});
+		await watcher.start();
+		await realDelay(CHOKIDAR_READY_MS);
+
+		let appendCount = 0;
+		watcher.on('append', () => {
+			appendCount += 1;
+		});
+
+		// 10 rapid appends within the debounce window.
+		for (let i = 0; i < 10; i += 1) {
+			await fs.appendFile(filePath, `line ${i}\n`);
+		}
+
+		// Wait long enough that the debounce timer flushes exactly once.
+		await realDelay(500);
+		expect(appendCount).toBe(1);
+	});
+
+	it('resolves start() without throwing on a non-existent root dir', async () => {
+		const missingDir = path.join(tmpRoot, 'definitely-not-here');
+		watcher = new SessionFileWatcher({
+			agentId: 'claude-code',
+			storageDir: missingDir,
+			fileMatcher: makeMatcher(),
+		});
+
+		await expect(watcher.start()).resolves.toBeUndefined();
+
+		// And stop() should be a clean no-op too.
+		await expect(watcher.stop()).resolves.toBeUndefined();
+	});
+
+	it('emits "idle" after EXTERNAL_ACTIVITY_IDLE_MS of quiet', async () => {
+		// Fake only the timer APIs the watcher itself uses. Leave setImmediate,
+		// setInterval, Date, and process.nextTick on real time so chokidar /
+		// fsevents continue delivering FS events normally.
+		vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+
+		const projectDir = path.join(tmpRoot, 'proj-5');
+		await fs.mkdir(projectDir);
+
+		watcher = new SessionFileWatcher({
+			agentId: 'claude-code',
+			storageDir: tmpRoot,
+			fileMatcher: makeMatcher(),
+			debounceMs: 50,
+		});
+
+		const createEvents: SessionActivityEvent[] = [];
+		const idleEvents: SessionActivityEvent[] = [];
+		watcher.on('create', (e: SessionActivityEvent) => createEvents.push(e));
+		watcher.on('idle', (e: SessionActivityEvent) => idleEvents.push(e));
+
+		await watcher.start();
+		await realDelay(CHOKIDAR_READY_MS);
+
+		// Write a matching file. Chokidar will deliver 'add' on real time;
+		// the watcher will then schedule debounce + idle via FAKE setTimeout.
+		await fs.writeFile(path.join(projectDir, 'sess-idle.jsonl'), 'data\n');
+		await realDelay(CHOKIDAR_EVENT_MS);
+
+		// Flush the debounce timer → 'create' fires.
+		await vi.advanceTimersByTimeAsync(100);
+		expect(createEvents).toHaveLength(1);
+		expect(idleEvents).toHaveLength(0);
+
+		// Idle should NOT have fired yet — we're well inside the window.
+		await vi.advanceTimersByTimeAsync(EXTERNAL_ACTIVITY_IDLE_MS - 200);
+		expect(idleEvents).toHaveLength(0);
+
+		// Cross the idle boundary.
+		await vi.advanceTimersByTimeAsync(500);
+		expect(idleEvents).toHaveLength(1);
+		expect(idleEvents[0].sessionId).toBe('idle');
+		expect(idleEvents[0].source).toBe('external');
+		expect(idleEvents[0].agentId).toBe('claude-code');
+	});
+});

--- a/src/__tests__/main/storage/watch-specs.test.ts
+++ b/src/__tests__/main/storage/watch-specs.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Tests for getStorageWatchSpec() across agent storage implementations.
+ *
+ * These are pure matcher unit tests — they instantiate each storage class,
+ * pull the spec, and run the `fileMatcher` against representative relative
+ * paths. SessionFileWatcher integration is covered separately in
+ * `session-file-watcher.test.ts`.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import os from 'os';
+import path from 'path';
+
+vi.mock('electron', () => ({
+	app: {
+		getPath: vi.fn(() => '/tmp/maestro-test-userData'),
+	},
+}));
+
+vi.mock('electron-store', () => ({
+	default: vi.fn().mockImplementation(() => ({
+		get: vi.fn((_key: string, defaultValue?: unknown) => defaultValue),
+		set: vi.fn(),
+		store: {},
+	})),
+}));
+
+vi.mock('../../../main/utils/logger', () => ({
+	logger: {
+		info: vi.fn(),
+		debug: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+	},
+}));
+
+import { ClaudeSessionStorage } from '../../../main/storage/claude-session-storage';
+import type { ClaudeSessionOriginsData } from '../../../main/storage/claude-session-storage';
+import { CodexSessionStorage } from '../../../main/storage/codex-session-storage';
+import { FactoryDroidSessionStorage } from '../../../main/storage/factory-droid-session-storage';
+import type Store from 'electron-store';
+
+const stubStore = {
+	get: vi.fn((_key: string, defaultValue?: unknown) => defaultValue),
+	set: vi.fn(),
+	store: {},
+} as unknown as Store<ClaudeSessionOriginsData>;
+
+describe('getStorageWatchSpec', () => {
+	describe('ClaudeSessionStorage', () => {
+		const storage = new ClaudeSessionStorage(stubStore);
+		const spec = storage.getStorageWatchSpec();
+
+		it('returns a non-null spec', () => {
+			expect(spec).not.toBeNull();
+		});
+
+		it('rootDir is ~/.claude/projects', () => {
+			expect(spec?.rootDir).toBe(path.join(os.homedir(), '.claude', 'projects'));
+		});
+
+		it('matches `<encoded-cwd>/<session-id>.jsonl` and returns the sessionId', () => {
+			const rel = path.join('-Users-octavia-myproject', 'abc-123-def.jsonl');
+			expect(spec?.fileMatcher(rel)).toEqual({
+				sessionId: 'abc-123-def',
+				projectPath: '-Users-octavia-myproject',
+			});
+		});
+
+		it('returns null for a too-shallow path (no project segment)', () => {
+			expect(spec?.fileMatcher('abc-123.jsonl')).toBeNull();
+		});
+
+		it('returns null for a too-deep path (extra nested segment)', () => {
+			const rel = path.join('-Users-octavia-myproject', 'nested', 'abc-123.jsonl');
+			expect(spec?.fileMatcher(rel)).toBeNull();
+		});
+
+		it('returns null for a non-jsonl file (e.g., temp/swap file)', () => {
+			const rel = path.join('-Users-octavia-myproject', 'abc-123.tmp');
+			expect(spec?.fileMatcher(rel)).toBeNull();
+		});
+	});
+
+	describe('CodexSessionStorage', () => {
+		const storage = new CodexSessionStorage();
+		const spec = storage.getStorageWatchSpec();
+
+		it('returns a non-null spec', () => {
+			expect(spec).not.toBeNull();
+		});
+
+		it('rootDir is ~/.codex/sessions', () => {
+			expect(spec?.rootDir).toBe(path.join(os.homedir(), '.codex', 'sessions'));
+		});
+
+		it('matches `YYYY/MM/DD/rollout-<ts>-<uuid>.jsonl` and returns the UUID as sessionId', () => {
+			const rel = path.join(
+				'2026',
+				'05',
+				'14',
+				'rollout-20260514_123045_001-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.jsonl'
+			);
+			expect(spec?.fileMatcher(rel)).toEqual({
+				sessionId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+				projectPath: '',
+			});
+		});
+
+		it('returns null when the date segments are not numeric', () => {
+			const rel = path.join(
+				'YYYY',
+				'05',
+				'14',
+				'rollout-20260514_123045_001-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.jsonl'
+			);
+			expect(spec?.fileMatcher(rel)).toBeNull();
+		});
+
+		it('returns null for a too-shallow path (missing day segment)', () => {
+			const rel = path.join(
+				'2026',
+				'05',
+				'rollout-20260514_123045_001-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.jsonl'
+			);
+			expect(spec?.fileMatcher(rel)).toBeNull();
+		});
+
+		it('returns null for a file that does not match the rollout pattern', () => {
+			const rel = path.join('2026', '05', '14', 'not-a-rollout.jsonl');
+			expect(spec?.fileMatcher(rel)).toBeNull();
+		});
+	});
+
+	describe('FactoryDroidSessionStorage', () => {
+		const storage = new FactoryDroidSessionStorage();
+		const spec = storage.getStorageWatchSpec();
+
+		it('returns a non-null spec', () => {
+			expect(spec).not.toBeNull();
+		});
+
+		it('rootDir is ~/.factory/sessions', () => {
+			expect(spec?.rootDir).toBe(path.join(os.homedir(), '.factory', 'sessions'));
+		});
+
+		it('matches `<encoded-cwd>/<uuid>.jsonl` and returns the UUID as sessionId', () => {
+			const rel = path.join(
+				'-Users-octavia-myproject',
+				'11111111-2222-3333-4444-555555555555.jsonl'
+			);
+			expect(spec?.fileMatcher(rel)).toEqual({
+				sessionId: '11111111-2222-3333-4444-555555555555',
+				projectPath: '-Users-octavia-myproject',
+			});
+		});
+
+		it('returns null for the `.settings.json` sidecar (wrong suffix)', () => {
+			const rel = path.join(
+				'-Users-octavia-myproject',
+				'11111111-2222-3333-4444-555555555555.settings.json'
+			);
+			expect(spec?.fileMatcher(rel)).toBeNull();
+		});
+
+		it('returns null for a too-shallow path (no project segment)', () => {
+			expect(spec?.fileMatcher('11111111-2222-3333-4444-555555555555.jsonl')).toBeNull();
+		});
+
+		it('returns null for a too-deep path (extra nested segment)', () => {
+			const rel = path.join(
+				'-Users-octavia-myproject',
+				'nested',
+				'11111111-2222-3333-4444-555555555555.jsonl'
+			);
+			expect(spec?.fileMatcher(rel)).toBeNull();
+		});
+	});
+});

--- a/src/__tests__/renderer/hooks/useExternalSessionActivity.test.ts
+++ b/src/__tests__/renderer/hooks/useExternalSessionActivity.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { useExternalSessionActivity } from '../../../renderer/hooks/session/useExternalSessionActivity';
+import type { SessionActivityEvent } from '../../../shared/sessionActivity';
+
+function makeEvent(overrides: Partial<SessionActivityEvent> = {}): SessionActivityEvent {
+	return {
+		agentId: 'claude-code',
+		sessionId: 'sess-1',
+		projectPath: '/repo',
+		lastActivityAt: Date.now(),
+		source: 'external',
+		sizeBytes: 1024,
+		...overrides,
+	};
+}
+
+describe('useExternalSessionActivity', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.mocked(window.maestro.storage.listExternalSessions).mockResolvedValue([]);
+		vi.mocked(window.maestro.storage.onExternalActivity).mockReturnValue(() => {});
+	});
+
+	it('returns an empty array before hydration completes', () => {
+		const { result } = renderHook(() => useExternalSessionActivity());
+		expect(result.current).toEqual([]);
+	});
+
+	it('hydrates from listExternalSessions on mount', async () => {
+		const initial = [makeEvent({ sessionId: 'a' }), makeEvent({ sessionId: 'b' })];
+		vi.mocked(window.maestro.storage.listExternalSessions).mockResolvedValue(initial);
+
+		const { result } = renderHook(() => useExternalSessionActivity());
+
+		await waitFor(() => {
+			expect(result.current).toEqual(initial);
+		});
+		expect(window.maestro.storage.listExternalSessions).toHaveBeenCalledTimes(1);
+	});
+
+	it('updates state when onExternalActivity fires', async () => {
+		let pushUpdate: ((events: SessionActivityEvent[]) => void) | null = null;
+		vi.mocked(window.maestro.storage.onExternalActivity).mockImplementation((cb) => {
+			pushUpdate = cb;
+			return () => {};
+		});
+
+		const { result } = renderHook(() => useExternalSessionActivity());
+
+		await waitFor(() => {
+			expect(window.maestro.storage.onExternalActivity).toHaveBeenCalled();
+		});
+		expect(pushUpdate).not.toBeNull();
+
+		const next = [makeEvent({ sessionId: 'live-1' })];
+		act(() => {
+			pushUpdate!(next);
+		});
+
+		expect(result.current).toEqual(next);
+	});
+
+	it('unsubscribes from onExternalActivity on unmount', async () => {
+		const unsubscribe = vi.fn();
+		vi.mocked(window.maestro.storage.onExternalActivity).mockReturnValue(unsubscribe);
+
+		const { unmount } = renderHook(() => useExternalSessionActivity());
+
+		await waitFor(() => {
+			expect(window.maestro.storage.onExternalActivity).toHaveBeenCalled();
+		});
+
+		unmount();
+		expect(unsubscribe).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not setState after unmount when hydration resolves late', async () => {
+		let resolveHydrate: (value: SessionActivityEvent[]) => void = () => {};
+		vi.mocked(window.maestro.storage.listExternalSessions).mockReturnValue(
+			new Promise<SessionActivityEvent[]>((resolve) => {
+				resolveHydrate = resolve;
+			})
+		);
+
+		const { unmount } = renderHook(() => useExternalSessionActivity());
+		unmount();
+
+		// Should not throw / warn after unmount.
+		await act(async () => {
+			resolveHydrate([makeEvent()]);
+			await Promise.resolve();
+		});
+	});
+
+	it('logs and continues when hydration rejects', async () => {
+		const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+		vi.mocked(window.maestro.storage.listExternalSessions).mockRejectedValue(new Error('boom'));
+
+		const { result } = renderHook(() => useExternalSessionActivity());
+
+		await waitFor(() => {
+			expect(consoleErrorSpy).toHaveBeenCalled();
+		});
+		expect(result.current).toEqual([]);
+
+		consoleErrorSpy.mockRestore();
+	});
+
+	it('returns empty array and skips subscription when storage API is missing', () => {
+		const original = window.maestro.storage;
+		// Simulate older preload build / non-Electron renderer.
+		(window.maestro as unknown as Record<string, unknown>).storage = undefined;
+
+		try {
+			const { result } = renderHook(() => useExternalSessionActivity());
+			expect(result.current).toEqual([]);
+		} finally {
+			(window.maestro as unknown as Record<string, unknown>).storage = original;
+		}
+	});
+});

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -494,6 +494,10 @@ const mockMaestro = {
 		recordSessionClosed: vi.fn().mockResolvedValue(true),
 		getSessionLifecycle: vi.fn().mockResolvedValue([]),
 	},
+	storage: {
+		listExternalSessions: vi.fn().mockResolvedValue([]),
+		onExternalActivity: vi.fn().mockReturnValue(() => {}),
+	},
 	sshRemote: {
 		getConfigs: vi.fn().mockResolvedValue({ success: true, configs: [] }),
 		getDefaultId: vi.fn().mockResolvedValue({ success: true, id: null }),

--- a/src/__tests__/shared/sessionActivity.test.ts
+++ b/src/__tests__/shared/sessionActivity.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Tests for shared/sessionActivity.ts — the `isActive` threshold helper that
+ * decides whether an externally-observed session is still "thinking".
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+	EXTERNAL_ACTIVITY_ACTIVE_MS,
+	EXTERNAL_ACTIVITY_IDLE_MS,
+	isActive,
+	type SessionActivityEvent,
+} from '../../shared/sessionActivity';
+
+function makeEvent(lastActivityAt: number): SessionActivityEvent {
+	return {
+		agentId: 'claude-code',
+		sessionId: 'sess-1',
+		projectPath: '/tmp/project',
+		lastActivityAt,
+		source: 'external',
+		sizeBytes: 1234,
+	};
+}
+
+describe('sessionActivity', () => {
+	describe('constants', () => {
+		it('exposes the active and idle thresholds', () => {
+			expect(EXTERNAL_ACTIVITY_ACTIVE_MS).toBe(3000);
+			expect(EXTERNAL_ACTIVITY_IDLE_MS).toBe(30000);
+		});
+
+		it('idle threshold is strictly greater than active threshold', () => {
+			expect(EXTERNAL_ACTIVITY_IDLE_MS).toBeGreaterThan(EXTERNAL_ACTIVITY_ACTIVE_MS);
+		});
+	});
+
+	describe('isActive', () => {
+		const now = 1_700_000_000_000;
+
+		it('returns true when activity is in the same millisecond as now', () => {
+			expect(isActive(makeEvent(now), now)).toBe(true);
+		});
+
+		it('returns true 1ms before the active boundary', () => {
+			const event = makeEvent(now - (EXTERNAL_ACTIVITY_ACTIVE_MS - 1));
+			expect(isActive(event, now)).toBe(true);
+		});
+
+		it('returns true exactly at the active boundary (inclusive)', () => {
+			const event = makeEvent(now - EXTERNAL_ACTIVITY_ACTIVE_MS);
+			expect(isActive(event, now)).toBe(true);
+		});
+
+		it('returns false 1ms past the active boundary', () => {
+			const event = makeEvent(now - (EXTERNAL_ACTIVITY_ACTIVE_MS + 1));
+			expect(isActive(event, now)).toBe(false);
+		});
+
+		it('returns false for events well past the active window', () => {
+			const event = makeEvent(now - EXTERNAL_ACTIVITY_IDLE_MS);
+			expect(isActive(event, now)).toBe(false);
+		});
+
+		it('handles future timestamps as active (clock skew tolerance)', () => {
+			// If the file's mtime is slightly ahead of `now` (e.g., clock skew),
+			// `now - lastActivityAt` becomes negative and stays <= threshold.
+			const event = makeEvent(now + 500);
+			expect(isActive(event, now)).toBe(true);
+		});
+
+		it('uses Date.now() when `now` is omitted', () => {
+			const fresh = makeEvent(Date.now());
+			expect(isActive(fresh)).toBe(true);
+
+			const stale = makeEvent(Date.now() - (EXTERNAL_ACTIVITY_ACTIVE_MS + 100));
+			expect(isActive(stale)).toBe(false);
+		});
+	});
+});

--- a/src/main/app-lifecycle/quit-handler.ts
+++ b/src/main/app-lifecycle/quit-handler.ts
@@ -45,6 +45,8 @@ export interface QuitHandlerDependencies {
 	powerManager: typeof powerManagerInstance;
 	/** Function to stop group chat moderator cleanup interval */
 	stopSessionCleanup?: () => void;
+	/** Function to stop the external session coordinator (file watchers) */
+	stopExternalSessionCoordinator?: () => Promise<void> | void;
 }
 
 /** Quit handler state */
@@ -94,6 +96,7 @@ export function createQuitHandler(deps: QuitHandlerDependencies): QuitHandler {
 		stopSettingsWatcher,
 		powerManager,
 		stopSessionCleanup,
+		stopExternalSessionCoordinator,
 	} = deps;
 
 	const state: QuitHandlerState = {
@@ -213,6 +216,13 @@ export function createQuitHandler(deps: QuitHandlerDependencies): QuitHandler {
 		// Stop group chat moderator cleanup interval
 		if (stopSessionCleanup) {
 			stopSessionCleanup();
+		}
+
+		// Stop external session coordinator (file watchers for remote agent activity)
+		if (stopExternalSessionCoordinator) {
+			Promise.resolve(stopExternalSessionCoordinator()).catch((err) => {
+				logger.error(`Error stopping external session coordinator: ${err}`, 'Shutdown');
+			});
 		}
 
 		// Clean up active grooming sessions (context merge/transfer operations)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -85,7 +85,8 @@ import { ExternalSessionCoordinator } from './storage/external-session-coordinat
 import { getAllSessionStorages } from './agents';
 import type { AgentSessionStorage } from './agents';
 import type { ToolType } from '../shared/types';
-import { initializeOutputParsers } from './parsers';
+import { initializeOutputParsers, getAllOutputParsers, type AgentOutputParser } from './parsers';
+import { ExternalStatsIngester } from './process-listeners/external-stats-ingester';
 import { calculateContextTokens } from './parsers/usage-aggregator';
 import {
 	DEMO_MODE,
@@ -594,6 +595,25 @@ function setupIpcHandlers() {
 		externalSessionCoordinator.start().catch((err) => {
 			logger.error(`Failed to start ExternalSessionCoordinator: ${err}`, 'Startup');
 		});
+
+		// File-driven stats ingestion: parallel path to the process-driven
+		// `setupStatsListener`. Reacts to the coordinator's per-file 'append'
+		// and 'create' events, tails JSONL deltas, and writes
+		// `source: 'external-fs'` rows into the stats DB. Passive — no
+		// start/stop; listeners drop when the coordinator stops.
+		const statsDB = getStatsDB();
+		if (statsDB.isReady()) {
+			const parsersByAgent = new Map<ToolType, AgentOutputParser>();
+			for (const parser of getAllOutputParsers()) {
+				parsersByAgent.set(parser.agentId, parser);
+			}
+			new ExternalStatsIngester({
+				coordinator: externalSessionCoordinator,
+				statsDB,
+				parsersByAgent,
+				logger,
+			});
+		}
 	}
 	registerExternalSessionsHandlers({
 		getCoordinator: () => externalSessionCoordinator,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -597,6 +597,7 @@ function setupIpcHandlers() {
 	}
 	registerExternalSessionsHandlers({
 		getCoordinator: () => externalSessionCoordinator,
+		getMainWindow: () => mainWindow,
 	});
 
 	// Helper to get agent config values (custom args/env vars, model, etc.)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -53,6 +53,7 @@ import {
 	registerTabNamingHandlers,
 	registerAgentErrorHandlers,
 	registerDirectorNotesHandlers,
+	registerExternalSessionsHandlers,
 	registerWakatimeHandlers,
 	setupLoggerEventForwarding,
 	cleanupAllGroomingSessions,
@@ -80,6 +81,10 @@ import { updateParticipant, loadGroupChat, updateGroupChat } from './group-chat/
 import { stopSessionCleanup } from './group-chat/group-chat-moderator';
 import { needsSessionRecovery, initiateSessionRecovery } from './group-chat/session-recovery';
 import { initializeSessionStorages } from './storage';
+import { ExternalSessionCoordinator } from './storage/external-session-coordinator';
+import { getAllSessionStorages } from './agents';
+import type { AgentSessionStorage } from './agents';
+import type { ToolType } from '../shared/types';
 import { initializeOutputParsers } from './parsers';
 import { calculateContextTokens } from './parsers/usage-aggregator';
 import {
@@ -265,6 +270,7 @@ let mainWindow: BrowserWindow | null = null;
 let processManager: ProcessManager | null = null;
 let webServer: WebServer | null = null;
 let agentDetector: AgentDetector | null = null;
+let externalSessionCoordinator: ExternalSessionCoordinator | null = null;
 
 // Create safeSend with dependency injection (Phase 2 refactoring)
 const safeSend = createSafeSend(() => mainWindow);
@@ -472,6 +478,7 @@ const quitHandler = createQuitHandler({
 	stopSettingsWatcher: () => settingsWatcher.stop(),
 	powerManager,
 	stopSessionCleanup,
+	stopExternalSessionCoordinator: () => externalSessionCoordinator?.stop(),
 });
 quitHandler.setup();
 
@@ -571,6 +578,26 @@ function setupIpcHandlers() {
 	// Pass the shared claudeSessionOriginsStore so session names/stars are consistent
 	initializeSessionStorages({ claudeSessionOriginsStore });
 	registerAgentSessionsHandlers({ getMainWindow: () => mainWindow, agentSessionOriginsStore });
+
+	// Wire up the external session coordinator: watches on-disk session files
+	// for activity from agents driven outside Maestro (remote SSH, other shells)
+	// and surfaces them to the renderer via the storage:* IPC handlers.
+	if (processManager) {
+		const storageRegistry: Partial<Record<ToolType, AgentSessionStorage>> = {};
+		for (const storage of getAllSessionStorages()) {
+			storageRegistry[storage.agentId] = storage;
+		}
+		externalSessionCoordinator = new ExternalSessionCoordinator({
+			processManager,
+			storageRegistry,
+		});
+		externalSessionCoordinator.start().catch((err) => {
+			logger.error(`Failed to start ExternalSessionCoordinator: ${err}`, 'Startup');
+		});
+	}
+	registerExternalSessionsHandlers({
+		getCoordinator: () => externalSessionCoordinator,
+	});
 
 	// Helper to get agent config values (custom args/env vars, model, etc.)
 	const getAgentConfigForAgent = (agentId: string): Record<string, any> => {

--- a/src/main/ipc/handlers/external-sessions.ts
+++ b/src/main/ipc/handlers/external-sessions.ts
@@ -1,0 +1,50 @@
+/**
+ * External Sessions IPC Handlers
+ *
+ * Exposes the {@link ExternalSessionCoordinator}'s snapshot of on-disk
+ * session activity to the renderer. The renderer hydrates with
+ * `storage:list-external-sessions` and then subscribes to live updates
+ * via the `state-changed` event (forwarded over IPC by the preload bridge
+ * in Phase 4 task 3).
+ */
+
+import { ipcMain } from 'electron';
+import { logger } from '../../utils/logger';
+import { withIpcErrorLogging, CreateHandlerOptions } from '../../utils/ipcHandler';
+import type { ExternalSessionCoordinator } from '../../storage/external-session-coordinator';
+import type { SessionActivityEvent } from '../../../shared/sessionActivity';
+
+const LOG_CONTEXT = '[ExternalSessions]';
+
+const handlerOpts = (operation: string): Pick<CreateHandlerOptions, 'context' | 'operation'> => ({
+	context: LOG_CONTEXT,
+	operation,
+});
+
+/**
+ * Dependencies required for external-sessions handler registration.
+ */
+export interface ExternalSessionsHandlerDependencies {
+	getCoordinator: () => ExternalSessionCoordinator | null;
+}
+
+/**
+ * Register all external-sessions IPC handlers.
+ */
+export function registerExternalSessionsHandlers(deps: ExternalSessionsHandlerDependencies): void {
+	const { getCoordinator } = deps;
+
+	ipcMain.handle(
+		'storage:list-external-sessions',
+		withIpcErrorLogging(
+			handlerOpts('listExternalSessions'),
+			async (): Promise<SessionActivityEvent[]> => {
+				const coordinator = getCoordinator();
+				if (!coordinator) return [];
+				return Array.from(coordinator.getState().values());
+			}
+		)
+	);
+
+	logger.debug(`${LOG_CONTEXT} External sessions IPC handlers registered`);
+}

--- a/src/main/ipc/handlers/external-sessions.ts
+++ b/src/main/ipc/handlers/external-sessions.ts
@@ -4,17 +4,25 @@
  * Exposes the {@link ExternalSessionCoordinator}'s snapshot of on-disk
  * session activity to the renderer. The renderer hydrates with
  * `storage:list-external-sessions` and then subscribes to live updates
- * via the `state-changed` event (forwarded over IPC by the preload bridge
- * in Phase 4 task 3).
+ * via the `storage:externalActivity` channel, which mirrors the
+ * coordinator's `'state-changed'` event into the renderer over IPC.
  */
 
-import { ipcMain } from 'electron';
+import { ipcMain, BrowserWindow } from 'electron';
 import { logger } from '../../utils/logger';
 import { withIpcErrorLogging, CreateHandlerOptions } from '../../utils/ipcHandler';
-import type { ExternalSessionCoordinator } from '../../storage/external-session-coordinator';
+import { createSafeSend, type GetMainWindow } from '../../utils/safe-send';
+import {
+	type ExternalSessionCoordinator,
+	type ExternalSessionStateChange,
+	STATE_CHANGED_EVENT,
+} from '../../storage/external-session-coordinator';
 import type { SessionActivityEvent } from '../../../shared/sessionActivity';
 
 const LOG_CONTEXT = '[ExternalSessions]';
+
+/** Renderer-facing channel carrying coalesced coordinator state changes. */
+export const EXTERNAL_ACTIVITY_CHANNEL = 'storage:externalActivity';
 
 const handlerOpts = (operation: string): Pick<CreateHandlerOptions, 'context' | 'operation'> => ({
 	context: LOG_CONTEXT,
@@ -26,13 +34,17 @@ const handlerOpts = (operation: string): Pick<CreateHandlerOptions, 'context' | 
  */
 export interface ExternalSessionsHandlerDependencies {
 	getCoordinator: () => ExternalSessionCoordinator | null;
+	getMainWindow: GetMainWindow;
 }
 
 /**
- * Register all external-sessions IPC handlers.
+ * Register all external-sessions IPC handlers and wire the coordinator's
+ * `'state-changed'` event onto the {@link EXTERNAL_ACTIVITY_CHANNEL} so the
+ * renderer can subscribe via `window.maestro.storage.onExternalActivity`.
  */
 export function registerExternalSessionsHandlers(deps: ExternalSessionsHandlerDependencies): void {
-	const { getCoordinator } = deps;
+	const { getCoordinator, getMainWindow } = deps;
+	const safeSend = createSafeSend(getMainWindow as () => BrowserWindow | null);
 
 	ipcMain.handle(
 		'storage:list-external-sessions',
@@ -45,6 +57,13 @@ export function registerExternalSessionsHandlers(deps: ExternalSessionsHandlerDe
 			}
 		)
 	);
+
+	const coordinator = getCoordinator();
+	if (coordinator) {
+		coordinator.on(STATE_CHANGED_EVENT, (payload: ExternalSessionStateChange) => {
+			safeSend(EXTERNAL_ACTIVITY_CHANNEL, payload);
+		});
+	}
 
 	logger.debug(`${LOG_CONTEXT} External sessions IPC handlers registered`);
 }

--- a/src/main/ipc/handlers/index.ts
+++ b/src/main/ipc/handlers/index.ts
@@ -52,6 +52,10 @@ import { registerSymphonyHandlers, SymphonyHandlerDependencies } from './symphon
 import { registerAgentErrorHandlers } from './agent-error';
 import { registerTabNamingHandlers, TabNamingHandlerDependencies } from './tabNaming';
 import { registerDirectorNotesHandlers, DirectorNotesHandlerDependencies } from './director-notes';
+import {
+	registerExternalSessionsHandlers,
+	ExternalSessionsHandlerDependencies,
+} from './external-sessions';
 import { registerWakatimeHandlers } from './wakatime';
 import { AgentDetector } from '../../agents';
 import { ProcessManager } from '../../process-manager';
@@ -96,6 +100,8 @@ export { registerTabNamingHandlers };
 export type { TabNamingHandlerDependencies };
 export { registerDirectorNotesHandlers };
 export type { DirectorNotesHandlerDependencies };
+export { registerExternalSessionsHandlers };
+export type { ExternalSessionsHandlerDependencies };
 export { registerWakatimeHandlers };
 export type { AgentsHandlerDependencies };
 export type { ProcessHandlerDependencies };

--- a/src/main/preload/index.ts
+++ b/src/main/preload/index.ts
@@ -50,6 +50,7 @@ import { createSymphonyApi } from './symphony';
 import { createTabNamingApi } from './tabNaming';
 import { createDirectorNotesApi } from './directorNotes';
 import { createWakatimeApi } from './wakatime';
+import { createStorageApi } from './storage';
 
 // Expose protected methods that allow the renderer process to use
 // the ipcRenderer without exposing the entire object
@@ -191,6 +192,9 @@ contextBridge.exposeInMainWorld('maestro', {
 
 	// WakaTime API (CLI check, API key validation)
 	wakatime: createWakatimeApi(),
+
+	// Storage activity API (external session-file watcher events)
+	storage: createStorageApi(),
 });
 
 // Re-export factory functions for external consumers (e.g., tests)
@@ -264,6 +268,8 @@ export {
 	createDirectorNotesApi,
 	// WakaTime
 	createWakatimeApi,
+	// Storage activity
+	createStorageApi,
 };
 
 // Re-export types for TypeScript consumers
@@ -472,3 +478,8 @@ export type {
 	// From wakatime
 	WakatimeApi,
 } from './wakatime';
+export type {
+	// From storage
+	StorageApi,
+	SessionActivityEvent,
+} from './storage';

--- a/src/main/preload/storage.ts
+++ b/src/main/preload/storage.ts
@@ -1,0 +1,33 @@
+/**
+ * Preload API for on-disk session storage activity.
+ *
+ * Bridges the {@link ExternalSessionCoordinator}'s `'state-changed'` stream
+ * to the renderer. The renderer hydrates with `listExternalSessions()` and
+ * then subscribes via `onExternalActivity()` for live updates.
+ */
+
+import { ipcRenderer } from 'electron';
+import type { SessionActivityEvent } from '../../shared/sessionActivity';
+
+/** IPC channel used to forward coalesced coordinator state changes. */
+export const EXTERNAL_ACTIVITY_CHANNEL = 'storage:externalActivity';
+
+/**
+ * Creates the storage API object exposed as `window.maestro.storage`.
+ */
+export function createStorageApi() {
+	return {
+		listExternalSessions: (): Promise<SessionActivityEvent[]> =>
+			ipcRenderer.invoke('storage:list-external-sessions'),
+
+		onExternalActivity: (callback: (events: SessionActivityEvent[]) => void) => {
+			const handler = (_: unknown, payload: { events: SessionActivityEvent[] }) =>
+				callback(payload.events);
+			ipcRenderer.on(EXTERNAL_ACTIVITY_CHANNEL, handler);
+			return () => ipcRenderer.removeListener(EXTERNAL_ACTIVITY_CHANNEL, handler);
+		},
+	};
+}
+
+export type StorageApi = ReturnType<typeof createStorageApi>;
+export type { SessionActivityEvent } from '../../shared/sessionActivity';

--- a/src/main/process-listeners/__tests__/stats-listener.test.ts
+++ b/src/main/process-listeners/__tests__/stats-listener.test.ts
@@ -116,48 +116,10 @@ describe('Stats Listener', () => {
 		expect(mockSafeSend).not.toHaveBeenCalled();
 	});
 
-	it('should log error when recording fails after retries', async () => {
-		vi.mocked(mockStatsDB.insertQueryEvent).mockImplementation(() => {
-			throw new Error('Database error');
-		});
-
-		setupStatsListener(mockProcessManager, {
-			safeSend: mockSafeSend,
-			getStatsDB: () => mockStatsDB,
-			logger: mockLogger,
-		});
-
-		const handler = eventHandlers.get('query-complete');
-		const testQueryData: QueryCompleteData = {
-			sessionId: 'session-789',
-			agentType: 'opencode',
-			source: 'user',
-			startTime: Date.now(),
-			duration: 2000,
-			projectPath: '/test/project',
-			tabId: 'tab-789',
-		};
-
-		handler?.('session-789', testQueryData);
-
-		// Wait for all retries to complete (100ms + 200ms + final attempt)
-		await vi.waitFor(
-			() => {
-				expect(mockLogger.error).toHaveBeenCalledWith(
-					expect.stringContaining('Failed to record query event after 3 attempts'),
-					'[Stats]',
-					expect.objectContaining({
-						sessionId: 'session-789',
-					})
-				);
-			},
-			{ timeout: 1000 }
-		);
-		// Should have tried 3 times
-		expect(mockStatsDB.insertQueryEvent).toHaveBeenCalledTimes(3);
-		// Should not have broadcasted update on failure
-		expect(mockSafeSend).not.toHaveBeenCalled();
-	});
+	// Retry / backoff behavior (3 attempts, exponential backoff, error logging on
+	// final failure) is exercised against the extracted helper in
+	// `insertQueryEventWithRetry.test.ts`. The listener-level test only needs to
+	// confirm the helper is wired in — success and not-ready paths above suffice.
 
 	it('should log debug info when recording succeeds', async () => {
 		setupStatsListener(mockProcessManager, {
@@ -192,48 +154,5 @@ describe('Stats Listener', () => {
 				})
 			);
 		});
-	});
-
-	it('should retry on transient failure and succeed', async () => {
-		// First call fails, second succeeds
-		vi.mocked(mockStatsDB.insertQueryEvent)
-			.mockImplementationOnce(() => {
-				throw new Error('Transient error');
-			})
-			.mockImplementationOnce(() => 'event-id-456');
-
-		setupStatsListener(mockProcessManager, {
-			safeSend: mockSafeSend,
-			getStatsDB: () => mockStatsDB,
-			logger: mockLogger,
-		});
-
-		const handler = eventHandlers.get('query-complete');
-		const testQueryData: QueryCompleteData = {
-			sessionId: 'session-retry',
-			agentType: 'claude-code',
-			source: 'user',
-			startTime: Date.now(),
-			duration: 1000,
-			projectPath: '/test/project',
-			tabId: 'tab-retry',
-		};
-
-		handler?.('session-retry', testQueryData);
-
-		// Wait for retry to complete
-		await vi.waitFor(
-			() => {
-				expect(mockStatsDB.insertQueryEvent).toHaveBeenCalledTimes(2);
-				expect(mockSafeSend).toHaveBeenCalledWith('stats:updated');
-			},
-			{ timeout: 500 }
-		);
-		// Should have logged warning for first failure
-		expect(mockLogger.warn).toHaveBeenCalledWith(
-			expect.stringContaining('Stats DB insert failed'),
-			'[Stats]',
-			expect.any(Object)
-		);
 	});
 });

--- a/src/main/process-listeners/external-stats-ingester.ts
+++ b/src/main/process-listeners/external-stats-ingester.ts
@@ -1,0 +1,186 @@
+/**
+ * ExternalStatsIngester
+ *
+ * File-driven companion to {@link import('./stats-listener').setupStatsListener}.
+ * Listens for per-file `'append'` / `'create'` events from
+ * {@link ExternalSessionCoordinator}, tails the underlying JSONL (delta from
+ * the last known byte offset — never re-reads the whole file), parses each
+ * line through the agent's registered output parser, and on result messages
+ * inserts a `query_events` row with `source: 'external-fs'` via
+ * {@link insertQueryEventWithRetry}.
+ *
+ * Passive by design: no `start()` / `stop()` lifecycle of its own. Constructed
+ * after the coordinator is up; cleanup happens implicitly when the coordinator
+ * stops and stops firing events. Per-file byte offsets live in memory only —
+ * on the next process boot the watcher re-derives them from `fs.stat`.
+ *
+ * Dedup with the process-driven path is handled upstream: the coordinator only
+ * forwards file events for sessions whose annotated `source` is `'external'`,
+ * so a session Maestro is already driving locally never reaches the ingester.
+ */
+
+import { EventEmitter } from 'events';
+import { promises as fs } from 'fs';
+
+import type { AgentOutputParser, ParsedEvent } from '../parsers';
+import type { ToolType } from '../../shared/types';
+import type { SessionActivityEvent } from '../../shared/sessionActivity';
+import type { StatsDB } from '../stats';
+import type { QueryCompleteData } from '../process-manager/types';
+import type { ProcessListenerDependencies } from './types';
+import {
+	APPEND_EVENT,
+	CREATE_EVENT,
+	type ExternalSessionCoordinator,
+} from '../storage/external-session-coordinator';
+import { insertQueryEventWithRetry } from './insertQueryEventWithRetry';
+
+const LOG_CONTEXT = '[ExternalStatsIngester]';
+
+export interface ExternalStatsIngesterOptions {
+	coordinator: ExternalSessionCoordinator | EventEmitter;
+	statsDB: StatsDB;
+	parsersByAgent: Map<ToolType, AgentOutputParser>;
+	logger: ProcessListenerDependencies['logger'];
+	/**
+	 * Optional injection point for `fs.stat` / `fs.open` so unit tests can
+	 * drive the ingester without touching the real filesystem. Defaults to
+	 * Node's `fs.promises`.
+	 */
+	fsImpl?: Pick<typeof fs, 'stat' | 'open'>;
+}
+
+/**
+ * In-memory byte offset table keyed by absolute file path. We never persist
+ * these — on the next process boot we either (a) skip files that have not
+ * changed since startup, or (b) restart at the current `fs.stat().size` on the
+ * first append.
+ */
+type OffsetTable = Map<string, number>;
+
+export class ExternalStatsIngester {
+	private readonly coordinator: ExternalSessionCoordinator | EventEmitter;
+	private readonly statsDB: StatsDB;
+	private readonly parsersByAgent: Map<ToolType, AgentOutputParser>;
+	private readonly logger: ProcessListenerDependencies['logger'];
+	private readonly fsImpl: Pick<typeof fs, 'stat' | 'open'>;
+	private readonly offsets: OffsetTable = new Map();
+
+	constructor(options: ExternalStatsIngesterOptions) {
+		this.coordinator = options.coordinator;
+		this.statsDB = options.statsDB;
+		this.parsersByAgent = options.parsersByAgent;
+		this.logger = options.logger;
+		this.fsImpl = options.fsImpl ?? fs;
+
+		this.coordinator.on(APPEND_EVENT, (event: SessionActivityEvent, filePath: string) => {
+			void this.handle(event, filePath);
+		});
+		this.coordinator.on(CREATE_EVENT, (event: SessionActivityEvent, filePath: string) => {
+			void this.handle(event, filePath);
+		});
+	}
+
+	/**
+	 * Process a single file activity event:
+	 *   1. `fs.stat` the file, compute byte delta against the last known offset.
+	 *   2. Read just the delta (`fs.open` + positional `read`, no whole-file load).
+	 *   3. Run each line through the agent's parser and insert a stats row for
+	 *      every parsed result message.
+	 *
+	 * Filesystem failures (file went away mid-event, permission flip) are logged
+	 * at `warn` and swallowed — the watcher will retry on the next event.
+	 */
+	private async handle(event: SessionActivityEvent, filePath: string): Promise<void> {
+		if (!filePath) return;
+
+		let endOffset: number;
+		try {
+			const stats = await this.fsImpl.stat(filePath);
+			endOffset = stats.size;
+		} catch (err) {
+			this.logger.warn(`Failed to stat ${filePath}: ${(err as Error).message}`, LOG_CONTEXT, {
+				agentId: event.agentId,
+				sessionId: event.sessionId,
+			});
+			return;
+		}
+
+		const startOffset = this.offsets.get(filePath) ?? 0;
+		if (endOffset <= startOffset) {
+			// Spurious change (touch / metadata) — nothing new to read.
+			this.offsets.set(filePath, endOffset);
+			return;
+		}
+
+		let delta: string;
+		try {
+			const handle = await this.fsImpl.open(filePath, 'r');
+			try {
+				const length = endOffset - startOffset;
+				const buf = Buffer.alloc(length);
+				await handle.read(buf, 0, length, startOffset);
+				delta = buf.toString('utf-8');
+			} finally {
+				await handle.close();
+			}
+		} catch (err) {
+			this.logger.warn(
+				`Failed to read delta from ${filePath}: ${(err as Error).message}`,
+				LOG_CONTEXT,
+				{ agentId: event.agentId, sessionId: event.sessionId }
+			);
+			return;
+		}
+
+		this.offsets.set(filePath, endOffset);
+		await this.processBuffer(event, delta);
+	}
+
+	/**
+	 * Split the delta on newlines and feed each non-empty line through the
+	 * agent parser. Lines whose parsed event is a result message produce a
+	 * `query_events` row tagged `source: 'external-fs'`. Parser exceptions
+	 * are warn-logged and the offending line is skipped — never thrown out.
+	 */
+	private async processBuffer(event: SessionActivityEvent, content: string): Promise<void> {
+		const parser = this.parsersByAgent.get(event.agentId);
+		if (!parser) return;
+
+		if (!this.statsDB.isReady()) return;
+
+		for (const rawLine of content.split('\n')) {
+			const line = rawLine.trim();
+			if (!line) continue;
+
+			let parsed: ParsedEvent | null;
+			try {
+				parsed = parser.parseJsonLine(line);
+			} catch (err) {
+				this.logger.warn(`Parser threw on line: ${(err as Error).message}`, LOG_CONTEXT, {
+					agentId: event.agentId,
+					sessionId: event.sessionId,
+				});
+				continue;
+			}
+			if (!parsed) continue;
+			if (!parser.isResultMessage(parsed)) continue;
+
+			const queryData: QueryCompleteData = {
+				sessionId: event.sessionId,
+				agentType: event.agentId,
+				source: 'external-fs',
+				// We don't have process-manager-style start/duration info from
+				// JSONL alone. Use the file's most recent activity timestamp as
+				// the row's start_time so dashboard time-range filters bucket
+				// the event correctly; duration is left at 0 since the parser
+				// can't reconstruct it for sessions Maestro didn't spawn.
+				startTime: event.lastActivityAt,
+				duration: 0,
+				projectPath: event.projectPath || undefined,
+			};
+
+			await insertQueryEventWithRetry(this.statsDB, queryData, this.logger);
+		}
+	}
+}

--- a/src/main/process-listeners/insertQueryEventWithRetry.ts
+++ b/src/main/process-listeners/insertQueryEventWithRetry.ts
@@ -1,0 +1,81 @@
+/**
+ * Shared helper that inserts a stats `query_events` row with exponential-backoff
+ * retry for transient SQLite failures (busy/locked, briefly disconnected handles).
+ *
+ * Both ingestion paths use it:
+ *  - {@link import('./stats-listener').setupStatsListener} — process-driven
+ *    events from Maestro-spawned agents.
+ *  - {@link import('./external-stats-ingester').ExternalStatsIngester} —
+ *    file-driven events from agents Maestro did NOT spawn.
+ *
+ * Keeping the retry logic in one place satisfies the dedup mandate in
+ * `CLAUDE.md` (no copy-pasted helpers across listeners).
+ */
+
+import type { QueryCompleteData } from '../process-manager/types';
+import type { ProcessListenerDependencies } from './types';
+
+/**
+ * Maximum number of retry attempts for transient database failures.
+ */
+export const MAX_RETRY_ATTEMPTS = 3;
+
+/**
+ * Base delay in milliseconds for exponential backoff (doubles each retry):
+ * 100ms, 200ms, 400ms between attempts.
+ */
+export const RETRY_BASE_DELAY_MS = 100;
+
+/**
+ * Attempts to insert a query event with retry logic for transient failures.
+ *
+ * Returns the generated event id on success, or `null` after `MAX_RETRY_ATTEMPTS`
+ * consecutive failures (the final failure is logged at `error`; intermediate
+ * failures at `warn`). Never throws — callers can treat `null` as a hard fail.
+ */
+export async function insertQueryEventWithRetry(
+	db: ReturnType<ProcessListenerDependencies['getStatsDB']>,
+	queryData: QueryCompleteData,
+	logger: ProcessListenerDependencies['logger']
+): Promise<string | null> {
+	for (let attempt = 1; attempt <= MAX_RETRY_ATTEMPTS; attempt++) {
+		try {
+			const id = db.insertQueryEvent({
+				sessionId: queryData.sessionId,
+				agentType: queryData.agentType,
+				source: queryData.source,
+				startTime: queryData.startTime,
+				duration: queryData.duration,
+				projectPath: queryData.projectPath,
+				tabId: queryData.tabId,
+			});
+			return id;
+		} catch (error) {
+			const isLastAttempt = attempt === MAX_RETRY_ATTEMPTS;
+
+			if (isLastAttempt) {
+				logger.error(
+					`Failed to record query event after ${MAX_RETRY_ATTEMPTS} attempts`,
+					'[Stats]',
+					{
+						error: String(error),
+						sessionId: queryData.sessionId,
+					}
+				);
+			} else {
+				const delay = RETRY_BASE_DELAY_MS * Math.pow(2, attempt - 1);
+				logger.warn(
+					`Stats DB insert failed (attempt ${attempt}/${MAX_RETRY_ATTEMPTS}), retrying in ${delay}ms`,
+					'[Stats]',
+					{
+						error: String(error),
+						sessionId: queryData.sessionId,
+					}
+				);
+				await new Promise((resolve) => setTimeout(resolve, delay));
+			}
+		}
+	}
+
+	return null;
+}

--- a/src/main/process-listeners/stats-listener.ts
+++ b/src/main/process-listeners/stats-listener.ts
@@ -6,67 +6,7 @@
 import type { ProcessManager } from '../process-manager';
 import type { QueryCompleteData } from '../process-manager/types';
 import type { ProcessListenerDependencies } from './types';
-
-/**
- * Maximum number of retry attempts for transient database failures.
- */
-const MAX_RETRY_ATTEMPTS = 3;
-
-/**
- * Base delay in milliseconds for exponential backoff (doubles each retry).
- */
-const RETRY_BASE_DELAY_MS = 100;
-
-/**
- * Attempts to insert a query event with retry logic for transient failures.
- * Uses exponential backoff: 100ms, 200ms, 400ms delays between retries.
- */
-async function insertQueryEventWithRetry(
-	db: ReturnType<ProcessListenerDependencies['getStatsDB']>,
-	queryData: QueryCompleteData,
-	logger: ProcessListenerDependencies['logger']
-): Promise<string | null> {
-	for (let attempt = 1; attempt <= MAX_RETRY_ATTEMPTS; attempt++) {
-		try {
-			const id = db.insertQueryEvent({
-				sessionId: queryData.sessionId,
-				agentType: queryData.agentType,
-				source: queryData.source,
-				startTime: queryData.startTime,
-				duration: queryData.duration,
-				projectPath: queryData.projectPath,
-				tabId: queryData.tabId,
-			});
-			return id;
-		} catch (error) {
-			const isLastAttempt = attempt === MAX_RETRY_ATTEMPTS;
-
-			if (isLastAttempt) {
-				logger.error(
-					`Failed to record query event after ${MAX_RETRY_ATTEMPTS} attempts`,
-					'[Stats]',
-					{
-						error: String(error),
-						sessionId: queryData.sessionId,
-					}
-				);
-			} else {
-				const delay = RETRY_BASE_DELAY_MS * Math.pow(2, attempt - 1);
-				logger.warn(
-					`Stats DB insert failed (attempt ${attempt}/${MAX_RETRY_ATTEMPTS}), retrying in ${delay}ms`,
-					'[Stats]',
-					{
-						error: String(error),
-						sessionId: queryData.sessionId,
-					}
-				);
-				await new Promise((resolve) => setTimeout(resolve, delay));
-			}
-		}
-	}
-
-	return null;
-}
+import { insertQueryEventWithRetry } from './insertQueryEventWithRetry';
 
 /**
  * Sets up the query-complete listener for stats tracking.

--- a/src/main/process-listeners/wakatime-listener.ts
+++ b/src/main/process-listeners/wakatime-listener.ts
@@ -77,7 +77,7 @@ export function setupWakaTimeListener(
 		sessionId: string,
 		projectDir: string | undefined,
 		projectName: string,
-		source?: 'user' | 'auto'
+		source?: 'user' | 'auto' | 'external-fs'
 	): void {
 		const sessionFiles = pendingFiles.get(sessionId);
 		if (!sessionFiles || sessionFiles.size === 0) return;

--- a/src/main/process-manager/ProcessManager.ts
+++ b/src/main/process-manager/ProcessManager.ts
@@ -43,6 +43,14 @@ export class ProcessManager extends EventEmitter {
 		this.childProcessSpawner = new ChildProcessSpawner(this.processes, this, this.bufferManager);
 		this.localCommandRunner = new LocalCommandRunner(this);
 		this.sshCommandRunner = new SshCommandRunner(this);
+
+		// Mirror the agent-native session id onto the managed process so
+		// external-session de-dup can look it up without re-implementing the
+		// session-id extraction logic that lives inside the output parsers.
+		this.on('session-id', (sessionId: string, agentSessionId: string) => {
+			const proc = this.processes.get(sessionId);
+			if (proc) proc.agentSessionId = agentSessionId;
+		});
 	}
 
 	/**
@@ -283,6 +291,19 @@ export class ProcessManager extends EventEmitter {
 	 */
 	get(sessionId: string): ManagedProcess | undefined {
 		return this.processes.get(sessionId);
+	}
+
+	/**
+	 * Look up a managed process by the agent-native session id (e.g. Claude's
+	 * `session_id`). Used by ExternalSessionCoordinator to decide whether
+	 * filesystem-observed activity comes from a Maestro-spawned session
+	 * (`source: 'local'`) or from one we did not spawn (`source: 'external'`).
+	 */
+	findByAgentSessionId(agentSessionId: string): ManagedProcess | undefined {
+		for (const proc of this.processes.values()) {
+			if (proc.agentSessionId === agentSessionId) return proc;
+		}
+		return undefined;
 	}
 
 	/**

--- a/src/main/process-manager/types.ts
+++ b/src/main/process-manager/types.ts
@@ -44,6 +44,13 @@ export interface ProcessConfig {
 export interface ManagedProcess {
 	sessionId: string;
 	toolType: string;
+	/**
+	 * Agent-native session id reported by the underlying CLI (e.g. Claude's
+	 * `session_id` UUID). Populated when the `'session-id'` event fires and
+	 * used by ExternalSessionCoordinator to de-dup file-watcher activity
+	 * against Maestro-spawned sessions.
+	 */
+	agentSessionId?: string;
 	ptyProcess?: IPty;
 	childProcess?: ChildProcess;
 	cwd: string;

--- a/src/main/process-manager/types.ts
+++ b/src/main/process-manager/types.ts
@@ -136,7 +136,14 @@ export interface ToolExecution {
 export interface QueryCompleteData {
 	sessionId: string;
 	agentType: string;
-	source: 'user' | 'auto';
+	/**
+	 * - `user` / `auto` — emitted by ProcessManager for Maestro-spawned processes.
+	 * - `external-fs` — synthesized by the external-session file watcher when
+	 *   ingesting JSONL activity from agents Maestro did NOT spawn (see
+	 *   `ExternalStatsIngester`). Not emitted on `ProcessManager`'s
+	 *   `'query-complete'` event; only flows directly to `db.insertQueryEvent`.
+	 */
+	source: 'user' | 'auto' | 'external-fs';
 	startTime: number;
 	duration: number;
 	projectPath?: string;

--- a/src/main/stats/aggregations.ts
+++ b/src/main/stats/aggregations.ts
@@ -59,12 +59,16 @@ function queryByAgent(
 
 function queryBySource(db: Database.Database, startTime: number): { user: number; auto: number } {
 	const perfStart = perfMetrics.start();
+	// Restrict to 'user' / 'auto' rows so the typed cast stays accurate; the
+	// dashboard's source breakdown only renders those two buckets. Externally
+	// ingested rows (source = 'external-fs') still contribute to overall totals
+	// via `queryTotals`, just not to this user/auto split.
 	const rows = db
 		.prepare(
 			`
       SELECT source, COUNT(*) as count
       FROM query_events
-      WHERE start_time >= ?
+      WHERE start_time >= ? AND source IN ('user', 'auto')
       GROUP BY source
     `
 		)

--- a/src/main/stats/migrations.ts
+++ b/src/main/stats/migrations.ts
@@ -25,6 +25,7 @@ import {
 	CREATE_SESSION_LIFECYCLE_SQL,
 	CREATE_SESSION_LIFECYCLE_INDEXES_SQL,
 	CREATE_COMPOUND_INDEXES_SQL,
+	CREATE_QUERY_EVENTS_V5_SQL,
 	runStatements,
 } from './schema';
 import { LOG_CONTEXT } from './utils';
@@ -59,6 +60,12 @@ export function getMigrations(): Migration[] {
 			version: 4,
 			description: 'Add compound indexes on query_events for dashboard query performance',
 			up: (db) => migrateV4(db),
+		},
+		{
+			version: 5,
+			description:
+				"Extend query_events.source CHECK constraint to allow 'external-fs' for externally-ingested sessions",
+			up: (db) => migrateV5(db),
 		},
 	];
 }
@@ -246,4 +253,41 @@ function migrateV4(db: Database.Database): void {
 	runStatements(db, CREATE_COMPOUND_INDEXES_SQL);
 
 	logger.debug('Added compound indexes on query_events', LOG_CONTEXT);
+}
+
+/**
+ * Migration v5: Widen `query_events.source` CHECK constraint to include
+ * `'external-fs'` for events ingested from the on-disk session watcher.
+ *
+ * SQLite does not allow modifying a CHECK constraint in place, so the table is
+ * rebuilt: create a sibling with the new constraint, copy rows over, swap
+ * names, then recreate the indexes (DROP TABLE drops them).
+ *
+ * Runs inside the migration transaction in {@link applyMigration}, so partial
+ * failure rolls the whole thing back.
+ */
+function migrateV5(db: Database.Database): void {
+	db.prepare(CREATE_QUERY_EVENTS_V5_SQL).run();
+
+	db.prepare(
+		`
+      INSERT INTO query_events_v5
+        (id, session_id, agent_type, source, start_time, duration, project_path, tab_id, is_remote)
+      SELECT id, session_id, agent_type, source, start_time, duration, project_path, tab_id, is_remote
+      FROM query_events
+    `
+	).run();
+
+	db.prepare('DROP TABLE query_events').run();
+	db.prepare('ALTER TABLE query_events_v5 RENAME TO query_events').run();
+
+	// Indexes were dropped with the original table — recreate the full set.
+	runStatements(db, CREATE_QUERY_EVENTS_INDEXES_SQL);
+	runStatements(db, CREATE_COMPOUND_INDEXES_SQL);
+	db.prepare('CREATE INDEX IF NOT EXISTS idx_query_is_remote ON query_events(is_remote)').run();
+
+	logger.debug(
+		"Rebuilt query_events with widened source CHECK constraint (allows 'external-fs')",
+		LOG_CONTEXT
+	);
 }

--- a/src/main/stats/row-mappers.ts
+++ b/src/main/stats/row-mappers.ts
@@ -21,7 +21,7 @@ export interface QueryEventRow {
 	id: string;
 	session_id: string;
 	agent_type: string;
-	source: 'user' | 'auto';
+	source: 'user' | 'auto' | 'external-fs';
 	start_time: number;
 	duration: number;
 	project_path: string | null;

--- a/src/main/stats/schema.ts
+++ b/src/main/stats/schema.ts
@@ -41,7 +41,7 @@ export const CREATE_QUERY_EVENTS_SQL = `
     id TEXT PRIMARY KEY,
     session_id TEXT NOT NULL,
     agent_type TEXT NOT NULL,
-    source TEXT NOT NULL CHECK(source IN ('user', 'auto')),
+    source TEXT NOT NULL CHECK(source IN ('user', 'auto', 'external-fs')),
     start_time INTEGER NOT NULL,
     duration INTEGER NOT NULL,
     project_path TEXT,
@@ -125,6 +125,29 @@ export const CREATE_SESSION_LIFECYCLE_SQL = `
 export const CREATE_SESSION_LIFECYCLE_INDEXES_SQL = `
   CREATE INDEX IF NOT EXISTS idx_session_created_at ON session_lifecycle(created_at);
   CREATE INDEX IF NOT EXISTS idx_session_agent_type ON session_lifecycle(agent_type)
+`;
+
+// ============================================================================
+// Query Events V5 — Rebuilt table with widened source CHECK constraint
+// ============================================================================
+
+/**
+ * Sibling table used by migration v5 to widen the `source` CHECK constraint
+ * (SQLite cannot ALTER a CHECK constraint in place). Mirrors the production
+ * schema including the `is_remote` column added in migration v2.
+ */
+export const CREATE_QUERY_EVENTS_V5_SQL = `
+  CREATE TABLE query_events_v5 (
+    id TEXT PRIMARY KEY,
+    session_id TEXT NOT NULL,
+    agent_type TEXT NOT NULL,
+    source TEXT NOT NULL CHECK(source IN ('user', 'auto', 'external-fs')),
+    start_time INTEGER NOT NULL,
+    duration INTEGER NOT NULL,
+    project_path TEXT,
+    tab_id TEXT,
+    is_remote INTEGER
+  )
 `;
 
 // ============================================================================

--- a/src/main/storage/base-session-storage.ts
+++ b/src/main/storage/base-session-storage.ts
@@ -30,6 +30,7 @@ import type {
 	SessionReadOptions,
 	SessionMessage,
 } from '../agents/session-storage';
+import type { SessionFileMatcher } from './session-file-watcher';
 
 /**
  * A simplified message representation for search purposes.
@@ -38,6 +39,30 @@ import type {
 export interface SearchableMessage {
 	role: 'user' | 'assistant';
 	textContent: string;
+}
+
+/**
+ * Spec describing how to watch this agent's on-disk session storage for
+ * activity from sessions Maestro did NOT spawn (e.g., the same user running
+ * the agent's CLI directly, or over SSH).
+ *
+ * Consumed by {@link SessionFileWatcher} to construct a chokidar watcher and
+ * route filesystem events to per-session activity events.
+ */
+export interface StorageWatchSpec {
+	/**
+	 * Absolute path to the directory the watcher should recursively observe.
+	 * Missing or unreadable directories are tolerated by the watcher — same-user
+	 * scope means it's normal for some agents to be uninstalled.
+	 */
+	rootDir: string;
+	/**
+	 * Pure, synchronous mapping from a path relative to `rootDir` to a session
+	 * match. Return `null` for paths that don't correspond to a tracked session
+	 * (sidecar metadata, wrong depth, unrelated junk). The matcher is called on
+	 * every filesystem event, so it must not perform I/O.
+	 */
+	fileMatcher: SessionFileMatcher;
 }
 
 /**
@@ -87,6 +112,27 @@ export abstract class BaseSessionStorage implements AgentSessionStorage {
 		projectPath: string,
 		sshConfig?: SshRemoteConfig
 	): Promise<SearchableMessage[]>;
+
+	/**
+	 * Return the spec needed to watch this agent's on-disk session storage for
+	 * activity from sessions Maestro did NOT spawn. Same-user, local-FS only —
+	 * SSH remote watching is out of scope (see {@link SessionFileWatcher}).
+	 *
+	 * Default returns `null`, meaning "this agent doesn't support watching"
+	 * (e.g., it has no predictable per-session file on disk). Subclasses that
+	 * write per-session JSONL files to a stable path should override.
+	 *
+	 * The returned `fileMatcher` is called on every chokidar event under
+	 * `rootDir`, so it MUST be synchronous, pure, and tolerant of unrelated
+	 * paths (return `null`). See {@link StorageWatchSpec} for the contract.
+	 *
+	 * @returns Spec describing the storage root and a path-to-session matcher,
+	 *   or `null` if this agent does not expose externally observable session
+	 *   files.
+	 */
+	getStorageWatchSpec(): StorageWatchSpec | null {
+		return null;
+	}
 
 	/**
 	 * Cursor-based pagination over listSessions() results.

--- a/src/main/storage/base-session-storage.ts
+++ b/src/main/storage/base-session-storage.ts
@@ -63,6 +63,19 @@ export interface StorageWatchSpec {
 	 * every filesystem event, so it must not perform I/O.
 	 */
 	fileMatcher: SessionFileMatcher;
+	/**
+	 * Which `SessionFileWatcher` event the consumer should treat as the session
+	 * activity signal:
+	 * - `'append'` (default): existing per-session file grows in place
+	 *   (Claude / Codex / Factory Droid — single JSONL per session).
+	 * - `'create'`: each new message arrives as a brand-new file in a
+	 *   per-session directory (OpenCode pre-v1.2 JSON layout).
+	 *
+	 * Omitted is equivalent to `'append'`. The watcher itself still emits both
+	 * `create` and `append` events; this field tells phase 4's coordinator which
+	 * one to bind to as the live-activity signal for this agent.
+	 */
+	activityEvent?: 'append' | 'create';
 }
 
 /**

--- a/src/main/storage/claude-session-storage.ts
+++ b/src/main/storage/claude-session-storage.ts
@@ -320,6 +320,7 @@ export class ClaudeSessionStorage extends BaseSessionStorage {
 					projectPath: encodedProjectSegment,
 				};
 			},
+			activityEvent: 'append',
 		};
 	}
 

--- a/src/main/storage/claude-session-storage.ts
+++ b/src/main/storage/claude-session-storage.ts
@@ -33,7 +33,7 @@ import type {
 } from '../agents';
 import type { ToolType, SshRemoteConfig } from '../../shared/types';
 import { BaseSessionStorage } from './base-session-storage';
-import type { SearchableMessage } from './base-session-storage';
+import type { SearchableMessage, StorageWatchSpec } from './base-session-storage';
 
 const LOG_CONTEXT = '[ClaudeSessionStorage]';
 const MAX_SESSION_FILE_SIZE = 100 * 1024 * 1024; // 100 MB
@@ -291,6 +291,36 @@ export class ClaudeSessionStorage extends BaseSessionStorage {
 	 */
 	private getProjectsDir(): string {
 		return path.join(os.homedir(), '.claude', 'projects');
+	}
+
+	/**
+	 * Describes how to watch Claude Code's on-disk session storage for activity
+	 * from sessions Maestro did not spawn. Claude lays files out as
+	 * `~/.claude/projects/<encoded-cwd>/<session-id>.jsonl`, so the matcher
+	 * requires exactly two path segments and a `.jsonl` suffix.
+	 *
+	 * The first segment is Claude's encoded form of the cwd produced by
+	 * {@link encodeClaudeProjectPath} (`/[^a-zA-Z0-9]/g` → `-`). The encoding is
+	 * lossy and there is no decode helper in the codebase to reuse, so the
+	 * encoded segment is passed through as `projectPath`. Downstream consumers
+	 * that need the real cwd must read it from the JSONL contents (e.g., a
+	 * `cwd` field on later entries) since the matcher contract is synchronous.
+	 */
+	getStorageWatchSpec(): StorageWatchSpec | null {
+		return {
+			rootDir: this.getProjectsDir(),
+			fileMatcher: (relPath) => {
+				const segments = relPath.split(path.sep);
+				if (segments.length !== 2) return null;
+				const [encodedProjectSegment, fileName] = segments;
+				if (!fileName.endsWith('.jsonl')) return null;
+				if (!encodedProjectSegment) return null;
+				return {
+					sessionId: fileName.slice(0, -'.jsonl'.length),
+					projectPath: encodedProjectSegment,
+				};
+			},
+		};
 	}
 
 	/**

--- a/src/main/storage/codex-session-storage.ts
+++ b/src/main/storage/codex-session-storage.ts
@@ -35,7 +35,7 @@ import type {
 } from '../agents';
 import type { ToolType, SshRemoteConfig } from '../../shared/types';
 import { BaseSessionStorage } from './base-session-storage';
-import type { SearchableMessage } from './base-session-storage';
+import type { SearchableMessage, StorageWatchSpec } from './base-session-storage';
 
 const LOG_CONTEXT = '[CodexSessionStorage]';
 const MAX_SESSION_FILE_SIZE = 100 * 1024 * 1024; // 100 MB
@@ -106,12 +106,17 @@ interface CodexMessageContent {
 }
 
 /**
+ * Codex rollout filename pattern: `rollout-YYYYMMDD_HHMMSS_MMM-UUID.jsonl`.
+ * Capture group 1 is the session UUID.
+ */
+const CODEX_ROLLOUT_FILENAME_REGEX = /^rollout-[\d_]+-([a-f0-9-]+)\.jsonl$/i;
+
+/**
  * Extract the session ID (UUID) from a Codex session filename
  * Format: rollout-TIMESTAMP-UUID.jsonl
  */
 function extractSessionIdFromFilename(filename: string): string | null {
-	// Match pattern: rollout-YYYYMMDD_HHMMSS_MMM-UUID.jsonl or similar
-	const match = filename.match(/rollout-[\d_]+-([a-f0-9-]+)\.jsonl$/i);
+	const match = filename.match(CODEX_ROLLOUT_FILENAME_REGEX);
 	if (match) {
 		return match[1];
 	}
@@ -455,6 +460,38 @@ export class CodexSessionStorage extends BaseSessionStorage {
 	 */
 	private getSessionsDir(): string {
 		return CODEX_SESSIONS_DIR;
+	}
+
+	/**
+	 * Describes how to watch Codex's on-disk session storage for activity from
+	 * sessions Maestro did not spawn. Codex lays files out as
+	 * `~/.codex/sessions/YYYY/MM/DD/rollout-<ts>-<uuid>.jsonl`, so the matcher
+	 * requires exactly four path segments (year/month/day/file) with the
+	 * rollout pattern from {@link CODEX_ROLLOUT_FILENAME_REGEX}.
+	 *
+	 * TODO: Codex does not encode the cwd in the file path — it stores it
+	 * inside the JSONL contents (`session_meta.payload.cwd`). The matcher must
+	 * be synchronous and pure, so `projectPath` is returned as `''` here;
+	 * downstream consumers that need the real cwd must read it from the file.
+	 */
+	getStorageWatchSpec(): StorageWatchSpec | null {
+		return {
+			rootDir: this.getSessionsDir(),
+			fileMatcher: (relPath) => {
+				const segments = relPath.split(path.sep);
+				if (segments.length !== 4) return null;
+				const [year, month, day, fileName] = segments;
+				if (!/^\d{4}$/.test(year)) return null;
+				if (!/^\d{2}$/.test(month)) return null;
+				if (!/^\d{2}$/.test(day)) return null;
+				const match = fileName.match(CODEX_ROLLOUT_FILENAME_REGEX);
+				if (!match) return null;
+				return {
+					sessionId: match[1],
+					projectPath: '',
+				};
+			},
+		};
 	}
 
 	/**

--- a/src/main/storage/codex-session-storage.ts
+++ b/src/main/storage/codex-session-storage.ts
@@ -491,6 +491,7 @@ export class CodexSessionStorage extends BaseSessionStorage {
 					projectPath: '',
 				};
 			},
+			activityEvent: 'append',
 		};
 	}
 

--- a/src/main/storage/external-session-coordinator.ts
+++ b/src/main/storage/external-session-coordinator.ts
@@ -51,6 +51,19 @@ export interface ExternalSessionStateChange {
 export const STATE_CHANGED_EVENT = 'state-changed' as const;
 
 /**
+ * Per-file activity events forwarded from the underlying watchers. Listeners
+ * receive `(event: SessionActivityEvent, filePath: string)` and are intended
+ * for in-process consumers that need the absolute file path (e.g., the
+ * external stats ingester that tails JSONL deltas).
+ *
+ * Only fired for events whose annotated `source` resolved to `'external'` —
+ * sessions Maestro is already driving locally are filtered out so downstream
+ * consumers don't have to dedup themselves.
+ */
+export const APPEND_EVENT = 'append' as const;
+export const CREATE_EVENT = 'create' as const;
+
+/**
  * Reads `getStorageWatchSpec()` off a storage instance without forcing every
  * caller to know it's defined on {@link BaseSessionStorage}. Returns `null`
  * for the (legal) case where the storage doesn't ship a spec.
@@ -123,8 +136,17 @@ export class ExternalSessionCoordinator extends EventEmitter {
 			// which one each agent treats as its dominant signal. The
 			// renderer-visible "is this session thinking?" check uses
 			// `isActive(event)` on the timestamp, not the event name.
-			watcher.on('append', (event) => this.handleActivity(event));
-			watcher.on('create', (event) => this.handleActivity(event));
+			//
+			// We accept the second `filePath` arg from the watcher emit so we
+			// can re-broadcast it on the coordinator's own `'append'` /
+			// `'create'` channels for in-process consumers (the stats ingester)
+			// that need to read the underlying JSONL.
+			watcher.on('append', (event, filePath: string) =>
+				this.handleFileActivity(APPEND_EVENT, event, filePath)
+			);
+			watcher.on('create', (event, filePath: string) =>
+				this.handleFileActivity(CREATE_EVENT, event, filePath)
+			);
 			watcher.on('idle', (event) => this.handleIdle(event));
 
 			try {
@@ -167,11 +189,27 @@ export class ExternalSessionCoordinator extends EventEmitter {
 		this.started = false;
 	}
 
-	private handleActivity(event: SessionActivityEvent): void {
+	/**
+	 * Update the coalesced state map for the renderer-facing `state-changed`
+	 * stream AND re-emit the underlying watcher event on the coordinator's
+	 * `'append'` / `'create'` channel for in-process consumers that need the
+	 * file path. The per-file event is suppressed for sessions Maestro already
+	 * drives locally (the stats DB would otherwise get a second insert via the
+	 * process-driven path).
+	 */
+	private handleFileActivity(
+		channel: typeof APPEND_EVENT | typeof CREATE_EVENT,
+		event: SessionActivityEvent,
+		filePath: string
+	): void {
 		const annotated = this.annotateSource(event);
 		const key = `${annotated.agentId}:${annotated.sessionId}`;
 		this.stateMap.set(key, annotated);
 		this.scheduleStateChange();
+
+		if (annotated.source === 'external') {
+			this.emit(channel, annotated, filePath);
+		}
 	}
 
 	private handleIdle(event: SessionActivityEvent): void {

--- a/src/main/storage/external-session-coordinator.ts
+++ b/src/main/storage/external-session-coordinator.ts
@@ -1,0 +1,202 @@
+/**
+ * ExternalSessionCoordinator
+ *
+ * Single owner of the on-disk session watchers for all agents. Walks the
+ * storage registry, instantiates one {@link SessionFileWatcher} per agent
+ * that exposes a {@link StorageWatchSpec}, and folds the resulting per-file
+ * events into a single coalesced `'state-changed'` stream the renderer can
+ * subscribe to.
+ *
+ * Two responsibilities the per-agent watcher doesn't handle on its own:
+ *
+ *  1. De-dup against locally-spawned sessions — Maestro itself may already
+ *     be driving a session whose JSONL we'd otherwise classify as "external."
+ *     The coordinator stamps `source: 'local' | 'external'` by asking
+ *     `ProcessManager.findByAgentSessionId`.
+ *  2. Burst coalescing — bulk imports or chatty agents can fire many
+ *     append/create events in quick succession; we debounce the outward
+ *     `'state-changed'` emission to 100ms so renderer state churn stays sane.
+ *
+ * Same-user, local-FS scope only; see {@link SessionFileWatcher} for the
+ * underlying constraints.
+ */
+
+import { EventEmitter } from 'events';
+import type { ToolType } from '../../shared/types';
+import type { AgentSessionStorage } from '../agents';
+import type { ProcessManager } from '../process-manager';
+import type { SessionActivityEvent } from '../../shared/sessionActivity';
+import { SessionFileWatcher } from './session-file-watcher';
+import type { BaseSessionStorage, StorageWatchSpec } from './base-session-storage';
+import { logger } from '../utils/logger';
+
+const LOG_CONTEXT = '[ExternalSessionCoordinator]';
+
+/** Debounce window for coalescing bursts of activity events. */
+export const STATE_CHANGE_DEBOUNCE_MS = 100;
+
+export interface ExternalSessionCoordinatorOptions {
+	processManager: ProcessManager;
+	storageRegistry: Partial<Record<ToolType, AgentSessionStorage>>;
+}
+
+export interface ExternalSessionStateChange {
+	events: SessionActivityEvent[];
+}
+
+/**
+ * Name of the event emitted whenever the coalesced state changes. Listeners
+ * receive an {@link ExternalSessionStateChange} payload.
+ */
+export const STATE_CHANGED_EVENT = 'state-changed' as const;
+
+/**
+ * Reads `getStorageWatchSpec()` off a storage instance without forcing every
+ * caller to know it's defined on {@link BaseSessionStorage}. Returns `null`
+ * for the (legal) case where the storage doesn't ship a spec.
+ */
+function readWatchSpec(storage: AgentSessionStorage): StorageWatchSpec | null {
+	const candidate = storage as AgentSessionStorage & Partial<BaseSessionStorage>;
+	if (typeof candidate.getStorageWatchSpec !== 'function') return null;
+	return candidate.getStorageWatchSpec.call(candidate) ?? null;
+}
+
+export class ExternalSessionCoordinator extends EventEmitter {
+	private readonly processManager: ProcessManager;
+	private readonly storageRegistry: Partial<Record<ToolType, AgentSessionStorage>>;
+	private readonly watchers: SessionFileWatcher[] = [];
+	private readonly stateMap = new Map<string, SessionActivityEvent>();
+	private stateDebounceTimer: NodeJS.Timeout | null = null;
+	private started = false;
+
+	constructor(options: ExternalSessionCoordinatorOptions) {
+		super();
+		this.processManager = options.processManager;
+		this.storageRegistry = options.storageRegistry;
+	}
+
+	/**
+	 * Snapshot of the current external-session activity state. Returned as a
+	 * fresh `Map` so callers can't mutate the internal store.
+	 */
+	getState(): Map<string, SessionActivityEvent> {
+		return new Map(this.stateMap);
+	}
+
+	/**
+	 * Start one watcher per storage that exposes a {@link StorageWatchSpec}.
+	 * Storages without a spec are skipped silently. Per-watcher failures are
+	 * logged but never fatal — a single misbehaving agent must not take the
+	 * whole coordinator down.
+	 */
+	async start(): Promise<void> {
+		if (this.started) return;
+		this.started = true;
+
+		const entries = Object.entries(this.storageRegistry) as Array<
+			[ToolType, AgentSessionStorage | undefined]
+		>;
+
+		for (const [agentId, storage] of entries) {
+			if (!storage) continue;
+
+			let spec: StorageWatchSpec | null;
+			try {
+				spec = readWatchSpec(storage);
+			} catch (err) {
+				logger.warn(
+					`getStorageWatchSpec() threw for ${agentId}: ${(err as Error).message}`,
+					LOG_CONTEXT
+				);
+				continue;
+			}
+			if (!spec) continue;
+
+			const watcher = new SessionFileWatcher({
+				agentId,
+				storageDir: spec.rootDir,
+				fileMatcher: spec.fileMatcher,
+			});
+
+			// Both 'append' and 'create' represent live activity — the
+			// activityEvent field on the spec is purely informational about
+			// which one each agent treats as its dominant signal. The
+			// renderer-visible "is this session thinking?" check uses
+			// `isActive(event)` on the timestamp, not the event name.
+			watcher.on('append', (event) => this.handleActivity(event));
+			watcher.on('create', (event) => this.handleActivity(event));
+			watcher.on('idle', (event) => this.handleIdle(event));
+
+			try {
+				await watcher.start();
+				this.watchers.push(watcher);
+			} catch (err) {
+				logger.warn(
+					`Failed to start watcher for ${agentId}: ${(err as Error).message}`,
+					LOG_CONTEXT
+				);
+			}
+		}
+	}
+
+	/**
+	 * Stop every watcher, drop accumulated state, and cancel any pending
+	 * debounced emission. Safe to call multiple times.
+	 */
+	async stop(): Promise<void> {
+		if (this.stateDebounceTimer) {
+			clearTimeout(this.stateDebounceTimer);
+			this.stateDebounceTimer = null;
+		}
+
+		const watchers = this.watchers.splice(0, this.watchers.length);
+		await Promise.all(
+			watchers.map(async (watcher) => {
+				try {
+					await watcher.stop();
+				} catch (err) {
+					logger.warn(
+						`Error stopping watcher for ${watcher.agentId}: ${(err as Error).message}`,
+						LOG_CONTEXT
+					);
+				}
+			})
+		);
+
+		this.stateMap.clear();
+		this.started = false;
+	}
+
+	private handleActivity(event: SessionActivityEvent): void {
+		const annotated = this.annotateSource(event);
+		const key = `${annotated.agentId}:${annotated.sessionId}`;
+		this.stateMap.set(key, annotated);
+		this.scheduleStateChange();
+	}
+
+	private handleIdle(event: SessionActivityEvent): void {
+		const key = `${event.agentId}:${event.sessionId}`;
+		if (this.stateMap.delete(key)) {
+			this.scheduleStateChange();
+		}
+	}
+
+	private annotateSource(event: SessionActivityEvent): SessionActivityEvent {
+		const local = this.processManager.findByAgentSessionId(event.sessionId);
+		return {
+			...event,
+			source: local ? 'local' : 'external',
+		};
+	}
+
+	private scheduleStateChange(): void {
+		if (this.stateDebounceTimer) return;
+		this.stateDebounceTimer = setTimeout(() => {
+			this.stateDebounceTimer = null;
+			const payload: ExternalSessionStateChange = {
+				events: Array.from(this.stateMap.values()),
+			};
+			this.emit(STATE_CHANGED_EVENT, payload);
+		}, STATE_CHANGE_DEBOUNCE_MS);
+	}
+}

--- a/src/main/storage/factory-droid-session-storage.ts
+++ b/src/main/storage/factory-droid-session-storage.ts
@@ -31,7 +31,11 @@ import fs from 'fs/promises';
 import { logger } from '../utils/logger';
 import { captureException } from '../utils/sentry';
 import { readDirRemote, readFileRemote, statRemote } from '../utils/remote-fs';
-import { BaseSessionStorage, type SearchableMessage } from './base-session-storage';
+import {
+	BaseSessionStorage,
+	type SearchableMessage,
+	type StorageWatchSpec,
+} from './base-session-storage';
 import type {
 	AgentSessionInfo,
 	SessionMessagesResult,
@@ -158,6 +162,36 @@ function extractTextFromContent(content: FactoryContentItem[] | string): string 
  */
 export class FactoryDroidSessionStorage extends BaseSessionStorage {
 	readonly agentId: ToolType = 'factory-droid';
+
+	/**
+	 * Describes how to watch Factory Droid's on-disk session storage for activity
+	 * from sessions Maestro did not spawn. Factory lays files out as
+	 * `~/.factory/sessions/<encoded-cwd>/<uuid>.jsonl` alongside a
+	 * `<uuid>.settings.json` sidecar, so the matcher requires exactly two path
+	 * segments and a `.jsonl` suffix (rejecting the sidecar).
+	 *
+	 * Factory's encoding from {@link encodeProjectPath} (`[\\/]` → `-`) is lossy
+	 * when a real directory name contains `-`, and there is no decode helper in
+	 * the codebase to reuse. The encoded segment is passed through as
+	 * `projectPath`; downstream consumers that need the real cwd must read it
+	 * from the JSONL contents (the matcher contract is synchronous).
+	 */
+	getStorageWatchSpec(): StorageWatchSpec | null {
+		return {
+			rootDir: getFactorySessionsDir(),
+			fileMatcher: (relPath) => {
+				const segments = relPath.split(path.sep);
+				if (segments.length !== 2) return null;
+				const [encodedProjectSegment, fileName] = segments;
+				if (!encodedProjectSegment) return null;
+				if (!fileName.endsWith('.jsonl')) return null;
+				return {
+					sessionId: fileName.slice(0, -'.jsonl'.length),
+					projectPath: encodedProjectSegment,
+				};
+			},
+		};
+	}
 
 	/**
 	 * Get the session directory for a project

--- a/src/main/storage/factory-droid-session-storage.ts
+++ b/src/main/storage/factory-droid-session-storage.ts
@@ -190,6 +190,7 @@ export class FactoryDroidSessionStorage extends BaseSessionStorage {
 					projectPath: encodedProjectSegment,
 				};
 			},
+			activityEvent: 'append',
 		};
 	}
 

--- a/src/main/storage/opencode-session-storage.ts
+++ b/src/main/storage/opencode-session-storage.ts
@@ -32,7 +32,11 @@ import type {
 	SessionReadOptions,
 	SessionMessage,
 } from '../agents';
-import { BaseSessionStorage, type SearchableMessage } from './base-session-storage';
+import {
+	BaseSessionStorage,
+	type SearchableMessage,
+	type StorageWatchSpec,
+} from './base-session-storage';
 import type { ToolType, SshRemoteConfig } from '../../shared/types';
 import { isWindows } from '../../shared/platformDetection';
 
@@ -370,6 +374,35 @@ async function listJsonFilesRemote(dirPath: string, sshConfig: SshRemoteConfig):
  */
 export class OpenCodeSessionStorage extends BaseSessionStorage {
 	readonly agentId: ToolType = 'opencode';
+
+	/**
+	 * Describes how to watch OpenCode's on-disk session storage for activity
+	 * from sessions Maestro did not spawn. Unlike Claude / Codex / Factory Droid
+	 * — which each maintain ONE JSONL file per session that grows via append —
+	 * OpenCode writes every new message as a SEPARATE `.json` file inside a
+	 * per-session directory. Activity therefore manifests as `'create'` events,
+	 * not `'append'`; this spec sets `activityEvent: 'create'` so phase 4's
+	 * coordinator binds to the right SessionFileWatcher signal. The session is
+	 * identified by the parent directory name (segment[1]), not the filename.
+	 */
+	getStorageWatchSpec(): StorageWatchSpec | null {
+		return {
+			rootDir: OPENCODE_STORAGE_DIR,
+			fileMatcher: (relPath) => {
+				if (!relPath) return null;
+				const segments = relPath.split(path.sep);
+				if (segments.length !== 3) return null;
+				const [, sessionSegment, fileName] = segments;
+				if (!sessionSegment) return null;
+				if (!fileName.endsWith('.json')) return null;
+				return {
+					sessionId: sessionSegment,
+					projectPath: '',
+				};
+			},
+			activityEvent: 'create',
+		};
+	}
 
 	/**
 	 * Get the session directory for a project (local)

--- a/src/main/storage/session-file-watcher.ts
+++ b/src/main/storage/session-file-watcher.ts
@@ -1,0 +1,278 @@
+/**
+ * SessionFileWatcher
+ *
+ * Generic watcher for an agent's on-disk session storage directory. Surfaces
+ * activity from agent processes Maestro did NOT spawn — typically sessions
+ * started over SSH by the same local user — by reacting to JSONL appends and
+ * file creations under `storageDir`. Same-user only: relies on local filesystem
+ * permissions, no cross-user or remote-FS support. Local FS only — SSH paths
+ * are out of scope. We watch artifacts on disk; we do not track PIDs.
+ */
+
+import { EventEmitter } from 'events';
+import { promises as fs, type Stats } from 'fs';
+import * as path from 'path';
+import chokidar, { type FSWatcher } from 'chokidar';
+import type { ToolType } from '../../shared/types';
+import { EXTERNAL_ACTIVITY_IDLE_MS, type SessionActivityEvent } from '../../shared/sessionActivity';
+import { logger } from '../utils/logger';
+
+const LOG_CONTEXT = '[SessionFileWatcher]';
+const DEFAULT_DEBOUNCE_MS = 250;
+
+export interface SessionFileMatch {
+	sessionId: string;
+	projectPath: string;
+}
+
+export type SessionFileMatcher = (relPath: string) => SessionFileMatch | null;
+
+export interface SessionFileWatcherOptions {
+	agentId: ToolType;
+	storageDir: string;
+	fileMatcher: SessionFileMatcher;
+	/** Per-sessionId debounce window for collapsing rapid appends. Default 250ms. */
+	debounceMs?: number;
+}
+
+type PendingEventType = 'create' | 'append';
+
+interface WatchedSession {
+	sessionId: string;
+	projectPath: string;
+	filePath: string;
+	sizeBytes: number;
+	lastActivityAt: number;
+	pendingEvent: PendingEventType | null;
+	debounceTimer: NodeJS.Timeout | null;
+	idleTimer: NodeJS.Timeout | null;
+}
+
+/**
+ * Emits `'create'` when a new matching session file appears, `'append'` when an
+ * already-seen file grows, and `'idle'` after EXTERNAL_ACTIVITY_IDLE_MS of
+ * silence on a previously-active session. Every event payload is a fully
+ * populated {@link SessionActivityEvent} with `source: 'external'`.
+ */
+export class SessionFileWatcher extends EventEmitter {
+	readonly agentId: ToolType;
+	readonly storageDir: string;
+	private readonly fileMatcher: SessionFileMatcher;
+	private readonly debounceMs: number;
+
+	private watcher: FSWatcher | null = null;
+	private readonly sessions = new Map<string, WatchedSession>();
+
+	constructor(options: SessionFileWatcherOptions) {
+		super();
+		this.agentId = options.agentId;
+		this.storageDir = options.storageDir;
+		this.fileMatcher = options.fileMatcher;
+		this.debounceMs = options.debounceMs ?? DEFAULT_DEBOUNCE_MS;
+	}
+
+	/**
+	 * Begin watching `storageDir`. No-op (with an info log) if the directory is
+	 * missing or unreadable — same-user scope means missing dirs are normal
+	 * (e.g., user has Claude installed but not Codex).
+	 */
+	async start(): Promise<void> {
+		if (this.watcher) return;
+
+		try {
+			await fs.access(this.storageDir);
+		} catch (err) {
+			const code = (err as NodeJS.ErrnoException)?.code;
+			if (code === 'ENOENT' || code === 'EACCES' || code === 'EPERM') {
+				logger.warn(
+					`Storage dir not accessible (${code}); watcher will not start: ${this.storageDir}`,
+					LOG_CONTEXT
+				);
+				return;
+			}
+			logger.warn(
+				`Unexpected error accessing storage dir ${this.storageDir}: ${(err as Error).message}`,
+				LOG_CONTEXT
+			);
+			return;
+		}
+
+		try {
+			this.watcher = chokidar.watch(this.storageDir, {
+				persistent: true,
+				ignoreInitial: true,
+				alwaysStat: true,
+				depth: 99,
+			});
+
+			this.watcher.on('add', (filePath, stats) => this.handleAdd(filePath, stats));
+			this.watcher.on('change', (filePath, stats) => this.handleChange(filePath, stats));
+			this.watcher.on('error', (error) => {
+				const msg = error instanceof Error ? error.message : String(error);
+				logger.warn(`Watcher error for ${this.storageDir}: ${msg}`, LOG_CONTEXT);
+			});
+
+			logger.info(
+				`Started session file watcher for ${this.agentId}: ${this.storageDir}`,
+				LOG_CONTEXT
+			);
+		} catch (err) {
+			logger.warn(
+				`Failed to initialize chokidar for ${this.storageDir}: ${(err as Error).message}`,
+				LOG_CONTEXT
+			);
+			this.watcher = null;
+		}
+	}
+
+	/** Stop watching, clear all timers, and drop tracked-session state. */
+	async stop(): Promise<void> {
+		for (const session of this.sessions.values()) {
+			if (session.debounceTimer) clearTimeout(session.debounceTimer);
+			if (session.idleTimer) clearTimeout(session.idleTimer);
+		}
+		this.sessions.clear();
+
+		if (this.watcher) {
+			try {
+				await this.watcher.close();
+			} catch (err) {
+				logger.warn(
+					`Error closing watcher for ${this.storageDir}: ${(err as Error).message}`,
+					LOG_CONTEXT
+				);
+			}
+			this.watcher = null;
+		}
+	}
+
+	/**
+	 * Snapshot of sessions that are still inside the idle window
+	 * (last activity within EXTERNAL_ACTIVITY_IDLE_MS of `Date.now()`).
+	 */
+	listActive(): SessionActivityEvent[] {
+		const now = Date.now();
+		const events: SessionActivityEvent[] = [];
+		for (const session of this.sessions.values()) {
+			if (now - session.lastActivityAt <= EXTERNAL_ACTIVITY_IDLE_MS) {
+				events.push(this.toEvent(session));
+			}
+		}
+		return events;
+	}
+
+	private handleAdd(filePath: string, stats?: Stats): void {
+		const match = this.matchPath(filePath);
+		if (!match) return;
+
+		const size = stats?.size ?? 0;
+		const now = Date.now();
+		const existing = this.sessions.get(match.sessionId);
+		const session: WatchedSession = existing ?? {
+			sessionId: match.sessionId,
+			projectPath: match.projectPath,
+			filePath,
+			sizeBytes: size,
+			lastActivityAt: now,
+			pendingEvent: null,
+			debounceTimer: null,
+			idleTimer: null,
+		};
+
+		session.filePath = filePath;
+		session.projectPath = match.projectPath;
+		session.sizeBytes = size;
+		session.lastActivityAt = now;
+		// If a debounced event is already queued for this session (rare —
+		// would only happen if 'add' fires twice without an intervening flush),
+		// keep the earlier event type since 'create' must be emitted first.
+		session.pendingEvent = session.pendingEvent ?? 'create';
+		this.sessions.set(match.sessionId, session);
+
+		this.scheduleDebounce(session);
+		this.scheduleIdle(session);
+	}
+
+	private handleChange(filePath: string, stats?: Stats): void {
+		const match = this.matchPath(filePath);
+		if (!match) return;
+
+		const size = stats?.size ?? 0;
+		const now = Date.now();
+		let session = this.sessions.get(match.sessionId);
+
+		if (!session) {
+			// We missed the 'add' (e.g., file existed before start with ignoreInitial,
+			// then was written to). Treat this first observation as 'append' so the
+			// renderer reacts to live activity rather than spuriously announcing a
+			// "new" session that already existed.
+			session = {
+				sessionId: match.sessionId,
+				projectPath: match.projectPath,
+				filePath,
+				sizeBytes: size,
+				lastActivityAt: now,
+				pendingEvent: 'append',
+				debounceTimer: null,
+				idleTimer: null,
+			};
+			this.sessions.set(match.sessionId, session);
+		} else {
+			if (size <= session.sizeBytes) {
+				// Spurious change (touch, metadata) — no append, don't reset idle.
+				return;
+			}
+			session.sizeBytes = size;
+			session.lastActivityAt = now;
+			session.filePath = filePath;
+			session.projectPath = match.projectPath;
+			// Preserve a queued 'create' so it still fires first; otherwise this
+			// is an append.
+			if (session.pendingEvent !== 'create') {
+				session.pendingEvent = 'append';
+			}
+		}
+
+		this.scheduleDebounce(session);
+		this.scheduleIdle(session);
+	}
+
+	private matchPath(filePath: string): SessionFileMatch | null {
+		const rel = path.relative(this.storageDir, filePath);
+		if (!rel || rel.startsWith('..') || path.isAbsolute(rel)) return null;
+		return this.fileMatcher(rel);
+	}
+
+	private scheduleDebounce(session: WatchedSession): void {
+		if (session.debounceTimer) clearTimeout(session.debounceTimer);
+		session.debounceTimer = setTimeout(() => {
+			session.debounceTimer = null;
+			const eventType = session.pendingEvent;
+			session.pendingEvent = null;
+			if (eventType) {
+				this.emit(eventType, this.toEvent(session));
+			}
+		}, this.debounceMs);
+	}
+
+	private scheduleIdle(session: WatchedSession): void {
+		if (session.idleTimer) clearTimeout(session.idleTimer);
+		session.idleTimer = setTimeout(() => {
+			session.idleTimer = null;
+			const event = this.toEvent(session);
+			this.sessions.delete(session.sessionId);
+			this.emit('idle', event);
+		}, EXTERNAL_ACTIVITY_IDLE_MS);
+	}
+
+	private toEvent(session: WatchedSession): SessionActivityEvent {
+		return {
+			agentId: this.agentId,
+			sessionId: session.sessionId,
+			projectPath: session.projectPath,
+			lastActivityAt: session.lastActivityAt,
+			source: 'external',
+			sizeBytes: session.sizeBytes,
+		};
+	}
+}

--- a/src/main/storage/session-file-watcher.ts
+++ b/src/main/storage/session-file-watcher.ts
@@ -250,7 +250,12 @@ export class SessionFileWatcher extends EventEmitter {
 			const eventType = session.pendingEvent;
 			session.pendingEvent = null;
 			if (eventType) {
-				this.emit(eventType, this.toEvent(session));
+				// Emit with (event, filePath) so consumers that need the absolute
+				// path (e.g., the stats ingester tailing the JSONL) get it without
+				// exposing it on the IPC-visible SessionActivityEvent payload.
+				// Single-arg listeners on the existing 'append' / 'create' channels
+				// still work — the second arg is just ignored.
+				this.emit(eventType, this.toEvent(session), session.filePath);
 			}
 		}, this.debounceMs);
 	}

--- a/src/main/wakatime-manager.ts
+++ b/src/main/wakatime-manager.ts
@@ -543,7 +543,7 @@ export class WakaTimeManager {
 		sessionId: string,
 		projectName: string,
 		projectCwd?: string,
-		source?: 'user' | 'auto'
+		source?: 'user' | 'auto' | 'external-fs'
 	): Promise<void> {
 		// Check if enabled
 		const enabled = this.settingsStore.get('wakatimeEnabled', false);
@@ -616,7 +616,7 @@ export class WakaTimeManager {
 		files: Array<{ filePath: string; timestamp: number }>,
 		projectName: string,
 		projectCwd?: string,
-		source?: 'user' | 'auto'
+		source?: 'user' | 'auto' | 'external-fs'
 	): Promise<void> {
 		if (files.length === 0) return;
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -135,6 +135,8 @@ import {
 	useQuickActionsHandlers,
 	// Session cycling (Cmd+Shift+[/])
 	useCycleSession,
+	// External (filesystem-watched) session activity
+	useExternalSessionActivity,
 	// Input mode toggle (Tier 3A)
 	useInputMode,
 	// Live mode management (Tier 3B)
@@ -166,6 +168,7 @@ import { ToastContainer } from './components/Toast';
 // Import types and constants
 // Note: GroupChat, GroupChatState are imported from types (re-exported from shared)
 import type { RightPanelTab, Session, QueuedItem, CustomAICommand, ThinkingItem } from './types';
+import { isActive as isExternalSessionActive } from '../shared/sessionActivity';
 import { THEMES } from './constants/themes';
 import { generateId } from './utils/ids';
 import { getContextColor } from './utils/theme';
@@ -1177,6 +1180,11 @@ function MaestroConsoleInner() {
 		onNavigateToGroupChat: handleOpenGroupChat,
 	});
 
+	// External (filesystem-watched) session activity — sessions discovered by
+	// watching agent storage directories, not spawned by Maestro. Appended into
+	// thinkingItems below so externally-driven agents light the pill too.
+	const externalSessionActivity = useExternalSessionActivity();
+
 	// PERF: Memoize thinkingItems at App level to avoid passing full sessions array to children.
 	// This prevents InputArea from re-rendering on unrelated session updates (e.g., terminal output).
 	// Flat list of (session, tab) pairs — one entry per busy tab across all sessions.
@@ -1196,8 +1204,40 @@ function MaestroConsoleInner() {
 				items.push({ session, tab: null });
 			}
 		}
+
+		// v1: external sessions rendered identically to local. To distinguish, branch here on event.source.
+		// Collect agent-native session IDs already represented by a local thinking item; an external
+		// event with a matching sessionId is the *same* session, just observed via the file watcher.
+		const localAgentSessionIds = new Set<string>();
+		for (const item of items) {
+			const id = item.tab?.agentSessionId || item.session.agentSessionId;
+			if (id) localAgentSessionIds.add(id);
+		}
+		for (const event of externalSessionActivity) {
+			if (!isExternalSessionActive(event)) continue;
+			if (localAgentSessionIds.has(event.sessionId)) continue;
+
+			// Display name: last path segment of the project, fall back to the session UUID octet.
+			const pathSegments = event.projectPath
+				? event.projectPath.split(/[\\/]/).filter(Boolean)
+				: [];
+			const displayName =
+				pathSegments[pathSegments.length - 1] ?? event.sessionId.substring(0, 8).toUpperCase();
+			// Synthesize the minimal Session-shaped object the pill renderer consumes
+			// (id, name, agentSessionId, thinkingStartTime, currentCycleTokens). Other Session
+			// fields are unused on this code path, so we narrow-cast through `unknown`.
+			const syntheticSession = {
+				id: `external:${event.agentId}:${event.sessionId}`,
+				name: displayName,
+				agentSessionId: event.sessionId,
+				thinkingStartTime: event.lastActivityAt,
+				currentCycleTokens: 0,
+			} as unknown as Session;
+			items.push({ session: syntheticSession, tab: null, event });
+		}
+
 		return items;
-	}, [sessions]);
+	}, [sessions, externalSessionActivity]);
 
 	// addLogToTab/addLogToActiveTab now used directly via store in useWizardHandlers
 

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -2732,6 +2732,23 @@ interface MaestroAPI {
 		checkCli: () => Promise<{ available: boolean; version?: string }>;
 		validateApiKey: (key: string) => Promise<{ valid: boolean }>;
 	};
+
+	// Storage activity API (external session-file watcher events).
+	// Backed by ExternalSessionCoordinator — see src/shared/sessionActivity.ts
+	// for the event shape and the `isActive(event)` helper.
+	storage: {
+		listExternalSessions: () => Promise<SessionActivityEvent[]>;
+		onExternalActivity: (callback: (events: SessionActivityEvent[]) => void) => () => void;
+	};
+}
+
+interface SessionActivityEvent {
+	agentId: string;
+	sessionId: string;
+	projectPath: string;
+	lastActivityAt: number;
+	source: 'local' | 'external';
+	sizeBytes: number;
 }
 
 declare global {

--- a/src/renderer/hooks/session/index.ts
+++ b/src/renderer/hooks/session/index.ts
@@ -55,3 +55,6 @@ export type { UseSessionCrudDeps, UseSessionCrudReturn } from './useSessionCrud'
 // Session cycling (Cmd+Shift+[/])
 export { useCycleSession } from './useCycleSession';
 export type { UseCycleSessionDeps, UseCycleSessionReturn } from './useCycleSession';
+
+// External (filesystem-watched) session activity feed
+export { useExternalSessionActivity } from './useExternalSessionActivity';

--- a/src/renderer/hooks/session/useExternalSessionActivity.ts
+++ b/src/renderer/hooks/session/useExternalSessionActivity.ts
@@ -1,0 +1,53 @@
+import { useEffect, useState } from 'react';
+import type { SessionActivityEvent } from '../../../shared/sessionActivity';
+
+/**
+ * Subscribes to externally-driven agent session activity surfaced by
+ * {@link ExternalSessionCoordinator} (main process), via the
+ * `window.maestro.storage` preload bridge.
+ *
+ * On mount: hydrates with `listExternalSessions()` then subscribes to
+ * `onExternalActivity` for live coalesced state-changes. The returned array
+ * is the current snapshot — consumers should use the `isActive(event)` helper
+ * from `shared/sessionActivity` to decide whether to render a thinking pill.
+ */
+export function useExternalSessionActivity(): SessionActivityEvent[] {
+	const [events, setEvents] = useState<SessionActivityEvent[]>([]);
+
+	useEffect(() => {
+		// Guard: storage API may be absent in older preload builds or non-Electron
+		// environments (e.g., the web renderer). Treat as "no external activity".
+		if (!window.maestro?.storage) {
+			return;
+		}
+
+		let mounted = true;
+
+		// The preload bridge types `agentId` as `string` (see global.d.ts ambient
+		// declaration), but the coordinator only emits events for ToolType-backed
+		// storage classes — safe to widen at this boundary.
+		window.maestro.storage
+			.listExternalSessions()
+			.then((initial) => {
+				if (mounted) {
+					setEvents(initial as SessionActivityEvent[]);
+				}
+			})
+			.catch((error) => {
+				console.error('[useExternalSessionActivity] Failed to hydrate:', error);
+			});
+
+		const unsubscribe = window.maestro.storage.onExternalActivity((next) => {
+			if (mounted) {
+				setEvents(next as SessionActivityEvent[]);
+			}
+		});
+
+		return () => {
+			mounted = false;
+			unsubscribe();
+		};
+	}, []);
+
+	return events;
+}

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -27,6 +27,11 @@ export type { SymphonySessionMetadata } from '../../shared/symphony-types';
 // Import Symphony types for use in this file
 import type { SymphonySessionMetadata } from '../../shared/symphony-types';
 
+// Re-export session activity types for use in this file and consumers
+export type { SessionActivityEvent, SessionActivitySource } from '../../shared/sessionActivity';
+// Import for extension in this file
+import type { SessionActivityEvent } from '../../shared/sessionActivity';
+
 // Import for extension in this file
 import type {
 	WorktreeConfig as BaseWorktreeConfig,
@@ -432,6 +437,9 @@ export interface AITab {
 export interface ThinkingItem {
 	session: Session;
 	tab: AITab | null; // null for legacy sessions without tab-level tracking
+	// Present only for externally-watched sessions (not spawned by Maestro).
+	// v1 renders these identically to local items; future versions can branch on event.source.
+	event?: SessionActivityEvent;
 }
 
 // Closed tab entry for undo functionality (Cmd+Shift+T)

--- a/src/shared/sessionActivity.ts
+++ b/src/shared/sessionActivity.ts
@@ -1,0 +1,59 @@
+/**
+ * Session Activity Types
+ *
+ * Shared types describing activity in agent session files on disk, regardless
+ * of whether Maestro itself spawned the agent. Used to surface remote/external
+ * agent activity (e.g., a Claude Code session started over SSH by the same user)
+ * in the same UI + stats paths as locally-spawned agents.
+ *
+ * Same-user only: we rely on local filesystem permissions on the watched
+ * storage directories. No cross-user / cross-account support.
+ */
+
+import type { ToolType } from './types';
+
+/**
+ * Distinguishes Maestro-spawned sessions ('local') from sessions discovered
+ * via the on-disk session-file watcher ('external').
+ */
+export type SessionActivitySource = 'local' | 'external';
+
+/**
+ * Emitted whenever a watched session file grows or appears.
+ *
+ * - `agentId`     — the agent that owns the session file (e.g., 'claude-code').
+ * - `sessionId`   — agent-native session identifier parsed from the file path.
+ * - `projectPath` — project / workspace path associated with the session.
+ * - `lastActivityAt` — epoch ms timestamp of the most recent append/create.
+ * - `source`      — 'local' for Maestro-spawned, 'external' for watched-only.
+ * - `sizeBytes`   — current size of the underlying session file in bytes.
+ */
+export interface SessionActivityEvent {
+	agentId: ToolType;
+	sessionId: string;
+	projectPath: string;
+	lastActivityAt: number;
+	source: SessionActivitySource;
+	sizeBytes: number;
+}
+
+/**
+ * A session is treated as "thinking" if its file has been appended to within
+ * this many milliseconds of `now`.
+ */
+export const EXTERNAL_ACTIVITY_ACTIVE_MS = 3000;
+
+/**
+ * A session is cleared from the active set after this many milliseconds of
+ * filesystem quiet.
+ */
+export const EXTERNAL_ACTIVITY_IDLE_MS = 30000;
+
+/**
+ * Returns true if the event's `lastActivityAt` is within the active window
+ * relative to `now`. Used by both the watcher and the renderer to decide
+ * whether to show a thinking pill for an external session.
+ */
+export function isActive(event: SessionActivityEvent, now: number = Date.now()): boolean {
+	return now - event.lastActivityAt <= EXTERNAL_ACTIVITY_ACTIVE_MS;
+}

--- a/src/shared/stats-types.ts
+++ b/src/shared/stats-types.ts
@@ -11,7 +11,13 @@ export interface QueryEvent {
 	id: string;
 	sessionId: string;
 	agentType: string;
-	source: 'user' | 'auto';
+	/**
+	 * - `user` / `auto` — events emitted by Maestro-spawned processes.
+	 * - `external-fs` — events ingested by the external-session file watcher
+	 *   for agents Maestro did NOT spawn (e.g., same user driving the CLI
+	 *   directly or over SSH). See `ExternalStatsIngester`.
+	 */
+	source: 'user' | 'auto' | 'external-fs';
 	startTime: number;
 	duration: number;
 	projectPath?: string;
@@ -104,7 +110,7 @@ export interface StatsAggregation {
  */
 export interface StatsFilters {
 	agentType?: string;
-	source?: 'user' | 'auto';
+	source?: 'user' | 'auto' | 'external-fs';
 	projectPath?: string;
 	sessionId?: string;
 }
@@ -112,4 +118,4 @@ export interface StatsFilters {
 /**
  * Database schema version for migrations
  */
-export const STATS_DB_VERSION = 4;
+export const STATS_DB_VERSION = 5;


### PR DESCRIPTION
- **MAESTRO: add shared session activity types for remote agent visibility**
- **MAESTRO: add SessionFileWatcher for external session visibility**
- **MAESTRO: add unit tests for SessionFileWatcher + session activity helpers**
- **MAESTRO: add getStorageWatchSpec() hook on BaseSessionStorage**
- **MAESTRO: add getStorageWatchSpec() for Claude + Codex storage**
- **MAESTRO: add getStorageWatchSpec() for Factory Droid storage**
- **MAESTRO: add unit tests for getStorageWatchSpec() across storage classes**
- **MAESTRO: add getStorageWatchSpec() for OpenCode (create-shape activity)**
- **MAESTRO: add ExternalSessionCoordinator + ProcessManager de-dup hook**
- **MAESTRO: wire ExternalSessionCoordinator into main + IPC handler**
- **MAESTRO: expose external session activity to renderer via preload bridge**
- **MAESTRO: add useExternalSessionActivity renderer hook**
- **MAESTRO: integrate external session activity into thinking pill**
- **MAESTRO: add ExternalSessionCoordinator unit tests**
- **MAESTRO: widen query_events.source for external-fs ingestion**
- **MAESTRO: widen wakatime source param to match QueryCompleteData**
- **MAESTRO: add ExternalStatsIngester + extract insert-retry helper**
- **MAESTRO: wire ExternalStatsIngester into main process boot**
- **MAESTRO: add ExternalStatsIngester tests + coordinator file-path forwarding**
- **MAESTRO: port retry tests to insertQueryEventWithRetry.test.ts**
- **MAESTRO: document External Agent Visibility in CLAUDE.md**
- **MAESTRO: document External Activity Tracking in CLAUDE-AGENTS.md**
- **MAESTRO: add docs/agent-guides/AGENT-INFRA.md**
- **MAESTRO: add External Activity Tracking row to AGENT_SUPPORT.md**
- **MAESTRO: add docs/agent-guides/STATS-ANALYTICS.md**
- **MAESTRO: document storage.* external activity IPC in CLAUDE-IPC.md**
- **MAESTRO: document owned vs observed sessions in ARCHITECTURE.md**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * External agent session visibility: Detect and display sessions spawned outside the app (separate terminals, SSH).
  * Track external session activity in the Usage Dashboard with real-time updates.

* **Documentation**
  * Added comprehensive guides on agent infrastructure and session management.
  * Updated supported agents reference documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RunMaestro/Maestro/pull/999)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->