### PR TITLE
fix(chat): preserve single newlines on chat surfaces (#622)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -141,9 +141,9 @@
 			}
 		},
 		"node_modules/@acemir/cssom": {
-			"version": "0.9.28",
-			"resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.28.tgz",
-			"integrity": "sha512-LuS6IVEivI75vKN8S04qRD+YySP0RmU/cV8UNukhQZvprxF+76Z43TNo/a08eCodaGhT1Us8etqS1ZRY9/Or0A==",
+			"version": "0.9.31",
+			"resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
+			"integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -180,33 +180,24 @@
 				"url": "https://github.com/sponsors/antfu"
 			}
 		},
-		"node_modules/@antfu/utils": {
-			"version": "9.3.0",
-			"resolved": "https://registry.npmjs.org/@antfu/utils/-/utils-9.3.0.tgz",
-			"integrity": "sha512-9hFT4RauhcUzqOE4f1+frMKLZrgNog5b06I7VmZQV1BkvwvqrbC8EBZf3L1eEL2AKb6rNKjER0sEvJiSP1FXEA==",
-			"license": "MIT",
-			"funding": {
-				"url": "https://github.com/sponsors/antfu"
-			}
-		},
 		"node_modules/@asamuzakjp/css-color": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.0.tgz",
-			"integrity": "sha512-9xiBAtLn4aNsa4mDnpovJvBn72tNEIACyvlqaNJ+ADemR+yeMJWnBudOi2qGDviJa7SwcDOU/TRh5dnET7qk0w==",
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
+			"integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@csstools/css-calc": "^2.1.4",
-				"@csstools/css-color-parser": "^3.1.0",
-				"@csstools/css-parser-algorithms": "^3.0.5",
-				"@csstools/css-tokenizer": "^3.0.4",
-				"lru-cache": "^11.2.2"
+				"@csstools/css-calc": "^3.0.0",
+				"@csstools/css-color-parser": "^4.0.1",
+				"@csstools/css-parser-algorithms": "^4.0.0",
+				"@csstools/css-tokenizer": "^4.0.0",
+				"lru-cache": "^11.2.5"
 			}
 		},
 		"node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
-			"version": "11.2.4",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
-			"integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
+			"version": "11.3.6",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+			"integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
 			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"engines": {
@@ -214,9 +205,9 @@
 			}
 		},
 		"node_modules/@asamuzakjp/dom-selector": {
-			"version": "6.7.6",
-			"resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.7.6.tgz",
-			"integrity": "sha512-hBaJER6A9MpdG3WgdlOolHmbOYvSk46y7IQN/1+iqiCuUu6iWdQrs9DGKF8ocqsEqWujWf/V7b7vaDgiUmIvUg==",
+			"version": "6.8.1",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
+			"integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -224,13 +215,13 @@
 				"bidi-js": "^1.0.3",
 				"css-tree": "^3.1.0",
 				"is-potential-custom-element-name": "^1.0.1",
-				"lru-cache": "^11.2.4"
+				"lru-cache": "^11.2.6"
 			}
 		},
 		"node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
-			"version": "11.2.4",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
-			"integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
+			"version": "11.3.6",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+			"integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
 			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"engines": {
@@ -245,13 +236,13 @@
 			"license": "MIT"
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-			"integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+			"integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.27.1",
+				"@babel/helper-validator-identifier": "^7.28.5",
 				"js-tokens": "^4.0.0",
 				"picocolors": "^1.1.1"
 			},
@@ -260,9 +251,9 @@
 			}
 		},
 		"node_modules/@babel/compat-data": {
-			"version": "7.28.5",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.5.tgz",
-			"integrity": "sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==",
+			"version": "7.29.3",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
+			"integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -270,21 +261,21 @@
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.28.5",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
-			"integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+			"integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/code-frame": "^7.27.1",
-				"@babel/generator": "^7.28.5",
-				"@babel/helper-compilation-targets": "^7.27.2",
-				"@babel/helper-module-transforms": "^7.28.3",
-				"@babel/helpers": "^7.28.4",
-				"@babel/parser": "^7.28.5",
-				"@babel/template": "^7.27.2",
-				"@babel/traverse": "^7.28.5",
-				"@babel/types": "^7.28.5",
+				"@babel/code-frame": "^7.29.0",
+				"@babel/generator": "^7.29.0",
+				"@babel/helper-compilation-targets": "^7.28.6",
+				"@babel/helper-module-transforms": "^7.28.6",
+				"@babel/helpers": "^7.28.6",
+				"@babel/parser": "^7.29.0",
+				"@babel/template": "^7.28.6",
+				"@babel/traverse": "^7.29.0",
+				"@babel/types": "^7.29.0",
 				"@jridgewell/remapping": "^2.3.5",
 				"convert-source-map": "^2.0.0",
 				"debug": "^4.1.0",
@@ -311,14 +302,14 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.28.5",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.5.tgz",
-			"integrity": "sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==",
+			"version": "7.29.1",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+			"integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/parser": "^7.28.5",
-				"@babel/types": "^7.28.5",
+				"@babel/parser": "^7.29.0",
+				"@babel/types": "^7.29.0",
 				"@jridgewell/gen-mapping": "^0.3.12",
 				"@jridgewell/trace-mapping": "^0.3.28",
 				"jsesc": "^3.0.2"
@@ -328,13 +319,13 @@
 			}
 		},
 		"node_modules/@babel/helper-compilation-targets": {
-			"version": "7.27.2",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
-			"integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+			"integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/compat-data": "^7.27.2",
+				"@babel/compat-data": "^7.28.6",
 				"@babel/helper-validator-option": "^7.27.1",
 				"browserslist": "^4.24.0",
 				"lru-cache": "^5.1.1",
@@ -365,29 +356,29 @@
 			}
 		},
 		"node_modules/@babel/helper-module-imports": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
-			"integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+			"integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/traverse": "^7.27.1",
-				"@babel/types": "^7.27.1"
+				"@babel/traverse": "^7.28.6",
+				"@babel/types": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-module-transforms": {
-			"version": "7.28.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
-			"integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+			"integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-module-imports": "^7.27.1",
-				"@babel/helper-validator-identifier": "^7.27.1",
-				"@babel/traverse": "^7.28.3"
+				"@babel/helper-module-imports": "^7.28.6",
+				"@babel/helper-validator-identifier": "^7.28.5",
+				"@babel/traverse": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -427,14 +418,14 @@
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.28.4",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
-			"integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
+			"version": "7.29.2",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+			"integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/template": "^7.27.2",
-				"@babel/types": "^7.28.4"
+				"@babel/template": "^7.28.6",
+				"@babel/types": "^7.29.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -457,42 +448,42 @@
 			}
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.28.4",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
-			"integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+			"version": "7.29.2",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+			"integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/template": {
-			"version": "7.27.2",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
-			"integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+			"integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/code-frame": "^7.27.1",
-				"@babel/parser": "^7.27.2",
-				"@babel/types": "^7.27.1"
+				"@babel/code-frame": "^7.28.6",
+				"@babel/parser": "^7.28.6",
+				"@babel/types": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.28.5",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.5.tgz",
-			"integrity": "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+			"integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/code-frame": "^7.27.1",
-				"@babel/generator": "^7.28.5",
+				"@babel/code-frame": "^7.29.0",
+				"@babel/generator": "^7.29.0",
 				"@babel/helper-globals": "^7.28.0",
-				"@babel/parser": "^7.28.5",
-				"@babel/template": "^7.27.2",
-				"@babel/types": "^7.28.5",
+				"@babel/parser": "^7.29.0",
+				"@babel/template": "^7.28.6",
+				"@babel/types": "^7.29.0",
 				"debug": "^4.3.1"
 			},
 			"engines": {
@@ -524,48 +515,46 @@
 			}
 		},
 		"node_modules/@braintree/sanitize-url": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.1.tgz",
-			"integrity": "sha512-i1L7noDNxtFyL5DmZafWy1wRVhGehQmzZaz1HiN5e7iylJMSZR7ekOV7NsIqa5qBldlLrsKv4HbgFUVlQrz8Mw==",
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
+			"integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
 			"license": "MIT"
 		},
 		"node_modules/@chevrotain/cst-dts-gen": {
-			"version": "11.0.3",
-			"resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-11.0.3.tgz",
-			"integrity": "sha512-BvIKpRLeS/8UbfxXxgC33xOumsacaeCKAjAeLyOn7Pcp95HiRbrpl14S+9vaZLolnbssPIUuiUd8IvgkRyt6NQ==",
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-12.0.0.tgz",
+			"integrity": "sha512-fSL4KXjTl7cDgf0B5Rip9Q05BOrYvkJV/RrBTE/bKDN096E4hN/ySpcBK5B24T76dlQ2i32Zc3PAE27jFnFrKg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@chevrotain/gast": "11.0.3",
-				"@chevrotain/types": "11.0.3",
-				"lodash-es": "4.17.21"
+				"@chevrotain/gast": "12.0.0",
+				"@chevrotain/types": "12.0.0"
 			}
 		},
 		"node_modules/@chevrotain/gast": {
-			"version": "11.0.3",
-			"resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-11.0.3.tgz",
-			"integrity": "sha512-+qNfcoNk70PyS/uxmj3li5NiECO+2YKZZQMbmjTqRI3Qchu8Hig/Q9vgkHpI3alNjr7M+a2St5pw5w5F6NL5/Q==",
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-12.0.0.tgz",
+			"integrity": "sha512-1ne/m3XsIT8aEdrvT33so0GUC+wkctpUPK6zU9IlOyJLUbR0rg4G7ZiApiJbggpgPir9ERy3FRjT6T7lpgetnQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@chevrotain/types": "11.0.3",
-				"lodash-es": "4.17.21"
+				"@chevrotain/types": "12.0.0"
 			}
 		},
 		"node_modules/@chevrotain/regexp-to-ast": {
-			"version": "11.0.3",
-			"resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-11.0.3.tgz",
-			"integrity": "sha512-1fMHaBZxLFvWI067AVbGJav1eRY7N8DDvYCTwGBiE/ytKBgP8azTdgyrKyWZ9Mfh09eHWb5PgTSO8wi7U824RA==",
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-12.0.0.tgz",
+			"integrity": "sha512-p+EW9MaJwgaHguhoqwOtx/FwuGr+DnNn857sXWOi/mClXIkPGl3rn7hGNWvo31HA3vyeQxjqe+H36yZJwYU8cA==",
 			"license": "Apache-2.0"
 		},
 		"node_modules/@chevrotain/types": {
-			"version": "11.0.3",
-			"resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.0.3.tgz",
-			"integrity": "sha512-gsiM3G8b58kZC2HaWR50gu6Y1440cHiJ+i3JUvcp/35JchYejb2+5MVeJK0iKThYpAa/P2PYFV4hoi44HD+aHQ==",
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-12.0.0.tgz",
+			"integrity": "sha512-S+04vjFQKeuYw0/eW3U52LkAHQsB1ASxsPGsLPUyQgrZ2iNNibQrsidruDzjEX2JYfespXMG0eZmXlhA6z7nWA==",
 			"license": "Apache-2.0"
 		},
 		"node_modules/@chevrotain/utils": {
-			"version": "11.0.3",
-			"resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.0.3.tgz",
-			"integrity": "sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ==",
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-12.0.0.tgz",
+			"integrity": "sha512-lB59uJoaGIfOOL9knQqQRfhl9g7x8/wqFkp13zTdkRu1huG9kg6IJs1O8hqj9rs6h7orGxHJUKb+mX3rPbWGhA==",
 			"license": "Apache-2.0"
 		},
 		"node_modules/@codemirror/autocomplete": {
@@ -736,9 +725,9 @@
 			}
 		},
 		"node_modules/@codemirror/view": {
-			"version": "6.43.0",
-			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.0.tgz",
-			"integrity": "sha512-V7ZCLQO3Jus9hzh2jVCCPW3mO4IBMr43O37PqSUYautJSnnJF41YlgLw21x0fLJTYvJ+Vkm6Gp+qKGH9pltgXA==",
+			"version": "6.42.1",
+			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.42.1.tgz",
+			"integrity": "sha512-ToN3oFc0nsxNUYVF5P0ztLgbC4UPPjPtA9aKYhkOKQaZASpOUo6ISXyQLP66ctVwlDc+j6Jv0uK5IFALkiXztg==",
 			"license": "MIT",
 			"dependencies": {
 				"@codemirror/state": "^6.6.0",
@@ -748,9 +737,9 @@
 			}
 		},
 		"node_modules/@csstools/color-helpers": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
-			"integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+			"integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -764,13 +753,13 @@
 			],
 			"license": "MIT-0",
 			"engines": {
-				"node": ">=18"
+				"node": ">=20.19.0"
 			}
 		},
 		"node_modules/@csstools/css-calc": {
-			"version": "2.1.4",
-			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
-			"integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+			"integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
 			"dev": true,
 			"funding": [
 				{
@@ -784,17 +773,17 @@
 			],
 			"license": "MIT",
 			"engines": {
-				"node": ">=18"
+				"node": ">=20.19.0"
 			},
 			"peerDependencies": {
-				"@csstools/css-parser-algorithms": "^3.0.5",
-				"@csstools/css-tokenizer": "^3.0.4"
+				"@csstools/css-parser-algorithms": "^4.0.0",
+				"@csstools/css-tokenizer": "^4.0.0"
 			}
 		},
 		"node_modules/@csstools/css-color-parser": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
-			"integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+			"integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -808,21 +797,21 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"@csstools/color-helpers": "^5.1.0",
-				"@csstools/css-calc": "^2.1.4"
+				"@csstools/color-helpers": "^6.0.2",
+				"@csstools/css-calc": "^3.2.0"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=20.19.0"
 			},
 			"peerDependencies": {
-				"@csstools/css-parser-algorithms": "^3.0.5",
-				"@csstools/css-tokenizer": "^3.0.4"
+				"@csstools/css-parser-algorithms": "^4.0.0",
+				"@csstools/css-tokenizer": "^4.0.0"
 			}
 		},
 		"node_modules/@csstools/css-parser-algorithms": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
-			"integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+			"integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
 			"dev": true,
 			"funding": [
 				{
@@ -836,16 +825,16 @@
 			],
 			"license": "MIT",
 			"engines": {
-				"node": ">=18"
+				"node": ">=20.19.0"
 			},
 			"peerDependencies": {
-				"@csstools/css-tokenizer": "^3.0.4"
+				"@csstools/css-tokenizer": "^4.0.0"
 			}
 		},
 		"node_modules/@csstools/css-syntax-patches-for-csstree": {
-			"version": "1.0.20",
-			"resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.20.tgz",
-			"integrity": "sha512-8BHsjXfSciZxjmHQOuVdW2b8WLUPts9a+mfL13/PzEviufUEW2xnvQuOlKs9dRBHgRqJ53SF/DUoK9+MZk72oQ==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+			"integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
 			"dev": true,
 			"funding": [
 				{
@@ -858,14 +847,19 @@
 				}
 			],
 			"license": "MIT-0",
-			"engines": {
-				"node": ">=18"
+			"peerDependencies": {
+				"css-tree": "^3.2.1"
+			},
+			"peerDependenciesMeta": {
+				"css-tree": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@csstools/css-tokenizer": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
-			"integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+			"integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
 			"dev": true,
 			"funding": [
 				{
@@ -879,7 +873,7 @@
 			],
 			"license": "MIT",
 			"engines": {
-				"node": ">=18"
+				"node": ">=20.19.0"
 			}
 		},
 		"node_modules/@dagrejs/dagre": {
@@ -936,10 +930,17 @@
 				"node": ">=10.12.0"
 			}
 		},
+		"node_modules/@electron/asar/node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@electron/asar/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -957,10 +958,32 @@
 				"node": ">= 6"
 			}
 		},
+		"node_modules/@electron/asar/node_modules/glob": {
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.1.1",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			},
+			"engines": {
+				"node": "*"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
 		"node_modules/@electron/asar/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -1070,6 +1093,79 @@
 				"node": ">= 22.12.0"
 			}
 		},
+		"node_modules/@electron/osx-sign": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/@electron/osx-sign/-/osx-sign-1.3.3.tgz",
+			"integrity": "sha512-KZ8mhXvWv2rIEgMbWZ4y33bDHyUKMXnx4M0sTyPNK/vcB81ImdeY9Ggdqy0SWbMDgmbqyQ+phgejh6V3R2QuSg==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"compare-version": "^0.1.2",
+				"debug": "^4.3.4",
+				"fs-extra": "^10.0.0",
+				"isbinaryfile": "^4.0.8",
+				"minimist": "^1.2.6",
+				"plist": "^3.0.5"
+			},
+			"bin": {
+				"electron-osx-flat": "bin/electron-osx-flat.js",
+				"electron-osx-sign": "bin/electron-osx-sign.js"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/@electron/osx-sign/node_modules/fs-extra": {
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+			"integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@electron/osx-sign/node_modules/isbinaryfile": {
+			"version": "4.0.10",
+			"resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.10.tgz",
+			"integrity": "sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 8.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/gjtorikian/"
+			}
+		},
+		"node_modules/@electron/osx-sign/node_modules/jsonfile": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"universalify": "^2.0.0"
+			},
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.6"
+			}
+		},
+		"node_modules/@electron/osx-sign/node_modules/universalify": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
 		"node_modules/@electron/rebuild": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-4.0.4.tgz",
@@ -1089,29 +1185,6 @@
 			},
 			"engines": {
 				"node": ">=22.12.0"
-			}
-		},
-		"node_modules/@electron/rebuild/node_modules/@malept/cross-spawn-promise": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-2.0.0.tgz",
-			"integrity": "sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://github.com/sponsors/malept"
-				},
-				{
-					"type": "tidelift",
-					"url": "https://tidelift.com/subscription/pkg/npm-.malept-cross-spawn-promise?utm_medium=referral&utm_source=npm_fund"
-				}
-			],
-			"license": "Apache-2.0",
-			"dependencies": {
-				"cross-spawn": "^7.0.1"
-			},
-			"engines": {
-				"node": ">= 12.13.0"
 			}
 		},
 		"node_modules/@electron/rebuild/node_modules/abbrev": {
@@ -1142,16 +1215,6 @@
 			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": ">=20"
-			}
-		},
-		"node_modules/@electron/rebuild/node_modules/minipass": {
-			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
 			}
 		},
 		"node_modules/@electron/rebuild/node_modules/minizlib": {
@@ -1272,6 +1335,162 @@
 			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": ">=18"
+			}
+		},
+		"node_modules/@electron/universal": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@electron/universal/-/universal-2.0.3.tgz",
+			"integrity": "sha512-Wn9sPYIVFRFl5HmwMJkARCCf7rqK/EurkfQ/rJZ14mHP3iYTjZSIOSVonEAnhWeAXwtw7zOekGRlc6yTtZ0t+g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@electron/asar": "^3.3.1",
+				"@malept/cross-spawn-promise": "^2.0.0",
+				"debug": "^4.3.1",
+				"dir-compare": "^4.2.0",
+				"fs-extra": "^11.1.1",
+				"minimatch": "^9.0.3",
+				"plist": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=16.4"
+			}
+		},
+		"node_modules/@electron/universal/node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@electron/universal/node_modules/brace-expansion": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+			"integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/@electron/universal/node_modules/fs-extra": {
+			"version": "11.3.5",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
+			"integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=14.14"
+			}
+		},
+		"node_modules/@electron/universal/node_modules/jsonfile": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"universalify": "^2.0.0"
+			},
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.6"
+			}
+		},
+		"node_modules/@electron/universal/node_modules/minimatch": {
+			"version": "9.0.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+			"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.2"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@electron/universal/node_modules/universalify": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/@electron/windows-sign": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@electron/windows-sign/-/windows-sign-1.2.2.tgz",
+			"integrity": "sha512-dfZeox66AvdPtb2lD8OsIIQh12Tp0GNCRUDfBHIKGpbmopZto2/A8nSpYYLoedPIHpqkeblZ/k8OV0Gy7PYuyQ==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"cross-dirname": "^0.1.0",
+				"debug": "^4.3.4",
+				"fs-extra": "^11.1.1",
+				"minimist": "^1.2.8",
+				"postject": "^1.0.0-alpha.6"
+			},
+			"bin": {
+				"electron-windows-sign": "bin/electron-windows-sign.js"
+			},
+			"engines": {
+				"node": ">=14.14"
+			}
+		},
+		"node_modules/@electron/windows-sign/node_modules/fs-extra": {
+			"version": "11.3.5",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
+			"integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=14.14"
+			}
+		},
+		"node_modules/@electron/windows-sign/node_modules/jsonfile": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"universalify": "^2.0.0"
+			},
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.6"
+			}
+		},
+		"node_modules/@electron/windows-sign/node_modules/universalify": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">= 10.0.0"
 			}
 		},
 		"node_modules/@emnapi/core": {
@@ -1796,24 +2015,31 @@
 			}
 		},
 		"node_modules/@eslint/config-array": {
-			"version": "0.21.1",
-			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
-			"integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
+			"version": "0.21.2",
+			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+			"integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@eslint/object-schema": "^2.1.7",
 				"debug": "^4.3.1",
-				"minimatch": "^3.1.2"
+				"minimatch": "^3.1.5"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			}
 		},
+		"node_modules/@eslint/config-array/node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@eslint/config-array/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1822,9 +2048,9 @@
 			}
 		},
 		"node_modules/@eslint/config-array/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -1861,20 +2087,20 @@
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.3.tgz",
-			"integrity": "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==",
+			"version": "3.3.5",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+			"integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"ajv": "^6.12.4",
+				"ajv": "^6.14.0",
 				"debug": "^4.3.2",
 				"espree": "^10.0.1",
 				"globals": "^14.0.0",
 				"ignore": "^5.2.0",
 				"import-fresh": "^3.2.1",
 				"js-yaml": "^4.1.1",
-				"minimatch": "^3.1.2",
+				"minimatch": "^3.1.5",
 				"strip-json-comments": "^3.1.1"
 			},
 			"engines": {
@@ -1884,10 +2110,17 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
+		"node_modules/@eslint/eslintrc/node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1919,9 +2152,9 @@
 			}
 		},
 		"node_modules/@eslint/eslintrc/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -1931,23 +2164,10 @@
 				"node": "*"
 			}
 		},
-		"node_modules/@eslint/eslintrc/node_modules/strip-json-comments": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/@eslint/js": {
-			"version": "9.39.2",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.2.tgz",
-			"integrity": "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==",
+			"version": "9.39.4",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+			"integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -1981,6 +2201,24 @@
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			}
 		},
+		"node_modules/@exodus/bytes": {
+			"version": "1.15.0",
+			"resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+			"integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"@noble/hashes": "^1.8.0 || ^2.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@noble/hashes": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@fastify/accept-negotiator": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@fastify/accept-negotiator/-/accept-negotiator-1.1.0.tgz",
@@ -2002,9 +2240,9 @@
 			}
 		},
 		"node_modules/@fastify/ajv-compiler/node_modules/ajv": {
-			"version": "8.17.1",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+			"integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
 			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
@@ -2018,9 +2256,9 @@
 			}
 		},
 		"node_modules/@fastify/ajv-compiler/node_modules/ajv/node_modules/fast-uri": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-			"integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+			"integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
 			"funding": [
 				{
 					"type": "github",
@@ -2127,27 +2365,6 @@
 				"@opentelemetry/api": "^1.3.0"
 			}
 		},
-		"node_modules/@fastify/otel/node_modules/balanced-match": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-			"license": "MIT",
-			"engines": {
-				"node": "18 || 20 || >=22"
-			}
-		},
-		"node_modules/@fastify/otel/node_modules/brace-expansion": {
-			"version": "5.0.6",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^4.0.2"
-			},
-			"engines": {
-				"node": "18 || 20 || >=22"
-			}
-		},
 		"node_modules/@fastify/otel/node_modules/import-in-the-middle": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-2.0.6.tgz",
@@ -2158,21 +2375,6 @@
 				"acorn-import-attributes": "^1.9.5",
 				"cjs-module-lexer": "^2.2.0",
 				"module-details-from-path": "^1.0.4"
-			}
-		},
-		"node_modules/@fastify/otel/node_modules/minimatch": {
-			"version": "10.2.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-			"license": "BlueOak-1.0.0",
-			"dependencies": {
-				"brace-expansion": "^5.0.5"
-			},
-			"engines": {
-				"node": "18 || 20 || >=22"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/@fastify/rate-limit": {
@@ -2199,18 +2401,6 @@
 				"mime": "^3.0.0"
 			}
 		},
-		"node_modules/@fastify/send/node_modules/mime": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
-			"integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
-			"license": "MIT",
-			"bin": {
-				"mime": "cli.js"
-			},
-			"engines": {
-				"node": ">=10.0.0"
-			}
-		},
 		"node_modules/@fastify/static": {
 			"version": "7.0.4",
 			"resolved": "https://registry.npmjs.org/@fastify/static/-/static-7.0.4.tgz",
@@ -2223,50 +2413,6 @@
 				"fastify-plugin": "^4.0.0",
 				"fastq": "^1.17.0",
 				"glob": "^10.3.4"
-			}
-		},
-		"node_modules/@fastify/static/node_modules/glob": {
-			"version": "10.5.0",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-			"integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-			"license": "ISC",
-			"dependencies": {
-				"foreground-child": "^3.1.0",
-				"jackspeak": "^3.1.2",
-				"minimatch": "^9.0.4",
-				"minipass": "^7.1.2",
-				"package-json-from-dist": "^1.0.0",
-				"path-scurry": "^1.11.1"
-			},
-			"bin": {
-				"glob": "dist/esm/bin.mjs"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/@fastify/static/node_modules/minimatch": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/@fastify/static/node_modules/minipass": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-			"license": "ISC",
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
 			}
 		},
 		"node_modules/@fastify/websocket": {
@@ -2288,25 +2434,39 @@
 			"license": "MIT"
 		},
 		"node_modules/@humanfs/core": {
-			"version": "0.19.1",
-			"resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-			"integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+			"version": "0.19.2",
+			"resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+			"integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"dependencies": {
+				"@humanfs/types": "^0.15.0"
+			},
 			"engines": {
 				"node": ">=18.18.0"
 			}
 		},
 		"node_modules/@humanfs/node": {
-			"version": "0.16.7",
-			"resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-			"integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+			"version": "0.16.8",
+			"resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+			"integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@humanfs/core": "^0.19.1",
+				"@humanfs/core": "^0.19.2",
+				"@humanfs/types": "^0.15.0",
 				"@humanwhocodes/retry": "^0.4.0"
 			},
+			"engines": {
+				"node": ">=18.18.0"
+			}
+		},
+		"node_modules/@humanfs/types": {
+			"version": "0.15.0",
+			"resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+			"integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+			"dev": true,
+			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=18.18.0"
 			}
@@ -2346,31 +2506,14 @@
 			"license": "MIT"
 		},
 		"node_modules/@iconify/utils": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.0.2.tgz",
-			"integrity": "sha512-EfJS0rLfVuRuJRn4psJHtK2A9TqVnkxPpHY6lYHiB9+8eSuudsxbwMiavocG45ujOo6FJ+CIRlRnlOGinzkaGQ==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.2.tgz",
+			"integrity": "sha512-jVf75icVVgSVGf9+QWBeCHdFL35yZ06HMHl9sCa059pITTP781lOacvRazfwAmXDKiBiUdQQMWVnuiw/RaQNhQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@antfu/install-pkg": "^1.1.0",
-				"@antfu/utils": "^9.2.0",
 				"@iconify/types": "^2.0.0",
-				"debug": "^4.4.1",
-				"globals": "^15.15.0",
-				"kolorist": "^1.8.0",
-				"local-pkg": "^1.1.1",
-				"mlly": "^1.7.4"
-			}
-		},
-		"node_modules/@iconify/utils/node_modules/globals": {
-			"version": "15.15.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
-			"integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
+				"import-meta-resolve": "^4.2.0"
 			}
 		},
 		"node_modules/@isaacs/cliui": {
@@ -2388,30 +2531,6 @@
 			},
 			"engines": {
 				"node": ">=12"
-			}
-		},
-		"node_modules/@isaacs/cliui/node_modules/ansi-regex": {
-			"version": "6.2.2",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
-			}
-		},
-		"node_modules/@isaacs/cliui/node_modules/ansi-styles": {
-			"version": "6.2.3",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-			"integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
 		"node_modules/@isaacs/cliui/node_modules/emoji-regex": {
@@ -2437,38 +2556,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/@isaacs/cliui/node_modules/strip-ansi": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-			"integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
-			}
-		},
-		"node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-			"integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^6.1.0",
-				"string-width": "^5.0.1",
-				"strip-ansi": "^7.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-			}
-		},
 		"node_modules/@isaacs/fs-minipass": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
@@ -2480,16 +2567,6 @@
 			},
 			"engines": {
 				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@isaacs/fs-minipass/node_modules/minipass": {
-			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
 			}
 		},
 		"node_modules/@jridgewell/gen-mapping": {
@@ -2651,6 +2728,29 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/@malept/cross-spawn-promise": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-2.0.0.tgz",
+			"integrity": "sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://github.com/sponsors/malept"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/subscription/pkg/npm-.malept-cross-spawn-promise?utm_medium=referral&utm_source=npm_fund"
+				}
+			],
+			"license": "Apache-2.0",
+			"dependencies": {
+				"cross-spawn": "^7.0.1"
+			},
+			"engines": {
+				"node": ">= 12.13.0"
+			}
+		},
 		"node_modules/@malept/flatpak-bundler": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/@malept/flatpak-bundler/-/flatpak-bundler-0.4.0.tgz",
@@ -2684,9 +2784,9 @@
 			}
 		},
 		"node_modules/@malept/flatpak-bundler/node_modules/jsonfile": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-			"integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2713,12 +2813,12 @@
 			"license": "MIT"
 		},
 		"node_modules/@mermaid-js/parser": {
-			"version": "0.6.3",
-			"resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-0.6.3.tgz",
-			"integrity": "sha512-lnjOhe7zyHjc+If7yT4zoedx2vo4sHaTmtkl1+or8BRTnCtDmcTpAjpzDSfCZrshM5bCoz0GyidzadJAH1xobA==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.1.0.tgz",
+			"integrity": "sha512-gxK9ZX2+Fex5zu8LhRQoMeMPEHbc73UKZ0FQ54YrQtUxE1VVhMwzeNtKRPAu5aXks4FasbMe4xB4bWrmq6Jlxw==",
 			"license": "MIT",
 			"dependencies": {
-				"langium": "3.3.1"
+				"langium": "^4.0.0"
 			}
 		},
 		"node_modules/@napi-rs/wasm-runtime": {
@@ -3251,9 +3351,9 @@
 			}
 		},
 		"node_modules/@opentelemetry/semantic-conventions": {
-			"version": "1.41.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
-			"integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
+			"version": "1.40.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
+			"integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=14"
@@ -3275,9 +3375,9 @@
 			}
 		},
 		"node_modules/@oxc-project/types": {
-			"version": "0.130.0",
-			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.130.0.tgz",
-			"integrity": "sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==",
+			"version": "0.128.0",
+			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.128.0.tgz",
+			"integrity": "sha512-huv1Y/LzBJkBVHt3OlC7u0zHBW9qXf1FdD7sGmc1rXc2P1mTwHssYv7jyGx5KAACSCH+9B3Bhn6Z9luHRvf7pQ==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
@@ -3301,13 +3401,13 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.60.0",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
-			"integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+			"version": "1.59.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+			"integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright": "1.60.0"
+				"playwright": "1.59.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -3666,9 +3766,9 @@
 			}
 		},
 		"node_modules/@reduxjs/toolkit/node_modules/immer": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/immer/-/immer-11.1.0.tgz",
-			"integrity": "sha512-dlzb07f5LDY+tzs+iLCSXV2yuhaYfezqyZQc+n6baLECWkOMEWxkECAOnXL0ba7lsA25fM9b2jtzpu/uxo1a7g==",
+			"version": "11.1.7",
+			"resolved": "https://registry.npmjs.org/immer/-/immer-11.1.7.tgz",
+			"integrity": "sha512-LFVFtAROHcDy1er5UI6nodRFnZ2SgdCXhfNSI+DpObO8N7Pur/muBGsjzH5wpnFHCYhYVQxZskCkV4koQ//3/Q==",
 			"license": "MIT",
 			"funding": {
 				"type": "opencollective",
@@ -3676,9 +3776,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-android-arm64": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.1.tgz",
-			"integrity": "sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg==",
+			"version": "1.0.0-rc.18",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.18.tgz",
+			"integrity": "sha512-lIDyUAfD7U3+BWKzdxMbJcsYHuqXqmGz40aeRqvuAm3y5TkJSYTBW2RDrn65DJFPQqVjUAUqq5uz8urzQ8aBdQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -3693,9 +3793,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-darwin-arm64": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.1.tgz",
-			"integrity": "sha512-cKnAhWEsV7TPcA/5EAteDp6KcJZBQ2G+BqE7zayMMi7kMvwRsbv7WT9aOnn0WNl4SKEIf43vjS31iUPu80nzXg==",
+			"version": "1.0.0-rc.18",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.18.tgz",
+			"integrity": "sha512-apJq2ktnGp27nSInMR5Vcj8kY6xJzDAvfdIFlpDcAK/w4cDO58qVoi1YQsES/SKiFNge/6e4CUzgjfHduYqWpQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -3710,9 +3810,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-darwin-x64": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.1.tgz",
-			"integrity": "sha512-YKrVwQjIRBPo+5G/u03wGjbdy4q7pyzCe93DK9VJ7zkVmeg8LJ7GbgsiHWdR4xSoe4CAXRD7Bcjgbtr64bkXNg==",
+			"version": "1.0.0-rc.18",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.18.tgz",
+			"integrity": "sha512-5Ofot8xbs+pxRHJqm9/9N/4sTQOvdrwEsmPE9pdLEEoAbdZtG6F2LMDfO1sp6ZAtXJuJV/21ew2srq3W8NXB5g==",
 			"cpu": [
 				"x64"
 			],
@@ -3727,9 +3827,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-freebsd-x64": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.1.tgz",
-			"integrity": "sha512-z/oBsREo46SsFqBwYtFe0kpJeBijAT48O/WXLI4suiCLBkr03RTtTJMCzSdDd2znlh8VJizL09XVkQgk8IZonw==",
+			"version": "1.0.0-rc.18",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.18.tgz",
+			"integrity": "sha512-7h8eeOTT1eyqJyx64BFCnWZpNm486hGWt2sqeLLgDxA0xI1oGZ9H7gK1S85uNGmBhkdPwa/6reTxfFFKvIsebw==",
 			"cpu": [
 				"x64"
 			],
@@ -3744,9 +3844,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.1.tgz",
-			"integrity": "sha512-ik8q7GM11zxvYxFc2PeDcT6TBvhCQMaUxfph/M5l9sKuTs/Sjg3L+Byw0F7w0ZVLBZmx30P+gG0ECzzN+MFcmQ==",
+			"version": "1.0.0-rc.18",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.18.tgz",
+			"integrity": "sha512-eRcm/HVt9U/JFu5RKAEKwGQYtDCKWLiaH6wOnsSEp6NMBb/3Os8LgHZlNyzMpFVNmiiMFlfb2zEnebfzJrHFmg==",
 			"cpu": [
 				"arm"
 			],
@@ -3761,9 +3861,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm64-gnu": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.1.tgz",
-			"integrity": "sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A==",
+			"version": "1.0.0-rc.18",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.18.tgz",
+			"integrity": "sha512-SOrT/cT4ukTmgnrEz/Hg3m7LBnuCLW9psDeMKrimRWY4I8DmnO7Lco8W2vtqPmMkbVu8iJ+g4GFLVLLOVjJ9DQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -3778,9 +3878,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm64-musl": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.1.tgz",
-			"integrity": "sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg==",
+			"version": "1.0.0-rc.18",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.18.tgz",
+			"integrity": "sha512-QWjdxN1HJCpBTAcZ5N5F7wju3gVPzRzSpmGzx7na0c/1qpN9CFil+xt+l9lV/1M6/gqHSNXCiqPfwhVJPeLnug==",
 			"cpu": [
 				"arm64"
 			],
@@ -3795,9 +3895,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-ppc64-gnu": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.1.tgz",
-			"integrity": "sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg==",
+			"version": "1.0.0-rc.18",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.18.tgz",
+			"integrity": "sha512-ugCOyj7a4d9h3q9B+wXmf6g3a68UsjGh6dob5DHevHGMwDUbhsYNbSPxJsENcIttJZ9jv7qGM2UesLw5jqIhdg==",
 			"cpu": [
 				"ppc64"
 			],
@@ -3812,9 +3912,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-s390x-gnu": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.1.tgz",
-			"integrity": "sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ==",
+			"version": "1.0.0-rc.18",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.18.tgz",
+			"integrity": "sha512-kKWRhbsotpXkGbcd5dllUWg5gEXcDAa8u5YnP9AV5DYNbvJHGzzuwv7dpmhc8NqKMJldl0a+x76IHbspEpEmdA==",
 			"cpu": [
 				"s390x"
 			],
@@ -3829,9 +3929,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-x64-gnu": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.1.tgz",
-			"integrity": "sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw==",
+			"version": "1.0.0-rc.18",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.18.tgz",
+			"integrity": "sha512-uCo8ElcCIAMyYAZyuIZ81oFkhTSIllNvUCHCAlbhlN4ji3uC28h7IIdlXyIvGO7HsuqnV9p3rD/bpH7XhIyhRw==",
 			"cpu": [
 				"x64"
 			],
@@ -3846,9 +3946,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-x64-musl": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.1.tgz",
-			"integrity": "sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ==",
+			"version": "1.0.0-rc.18",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.18.tgz",
+			"integrity": "sha512-XNOQZtuE6yUIvx4rwGemwh8kpL1xvU41FXy/s9K7T/3JVcqGzo3NfKM2HrbrGgfPYGFW42f07Wk++aOC6B9NWA==",
 			"cpu": [
 				"x64"
 			],
@@ -3863,9 +3963,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-openharmony-arm64": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.1.tgz",
-			"integrity": "sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ==",
+			"version": "1.0.0-rc.18",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.18.tgz",
+			"integrity": "sha512-tSn/kzrfa7tNOXr7sEacDBN4YsIqTyLqh45IO0nHDwtpKIDNDJr+VFojt+4klSpChxB29JLyduSsE0MKEwa65A==",
 			"cpu": [
 				"arm64"
 			],
@@ -3880,9 +3980,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-wasm32-wasi": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.1.tgz",
-			"integrity": "sha512-+1xc9X45l8ufsBAm6Gjvx2qDRIY9lTVt0cgWNcJ+1gdhXvkbxePA60yRTwSTuXL09CMhyJmjpV7E3NoyxbqFQQ==",
+			"version": "1.0.0-rc.18",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.18.tgz",
+			"integrity": "sha512-+J9YGmc+czgqlhYmwun3S3O0FIZhsH8ep2456xwjAdIOmuJxM7xz4P4PtrxU+Bz17a/5bqPA8o3HAAoX0teUdg==",
 			"cpu": [
 				"wasm32"
 			],
@@ -3899,9 +3999,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-win32-arm64-msvc": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.1.tgz",
-			"integrity": "sha512-1D+UqZdfnuR+Jy1GgMJwi85bD40H21uNmOPRWQhw4oRSuolZ/B5rixZ45DK2KXOTCvmVCecauWgEhbw8bI7tOw==",
+			"version": "1.0.0-rc.18",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.18.tgz",
+			"integrity": "sha512-zsu47DgU0FQzSwi6sU9dZoEdUv7pc1AptSEz/Z8HBg54sV0Pbs3N0+CrIbTsgiu6EyoaNN9CHboqbLaz9lhOyQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -3916,9 +4016,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-win32-x64-msvc": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.1.tgz",
-			"integrity": "sha512-INAycaWuhlOK3wk4mRHGsdgwYWmd9cChdPdE9bwWmy6rn9VqVNYNFGhOdXrofXUxwHIncSiPNb8tNm8knDVIeQ==",
+			"version": "1.0.0-rc.18",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.18.tgz",
+			"integrity": "sha512-7H+3yqGgmnlDTRRhw/xpYY9J1kf4GC681nVc4GqKhExZTDrVVrV2tsOR9kso0fvgBdcTCcQShx4SLLoHgaLwhg==",
 			"cpu": [
 				"x64"
 			],
@@ -3933,9 +4033,9 @@
 			}
 		},
 		"node_modules/@rolldown/pluginutils": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
-			"integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+			"version": "1.0.0-rc.7",
+			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.7.tgz",
+			"integrity": "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -4274,12 +4374,12 @@
 			}
 		},
 		"node_modules/@tanstack/react-virtual": {
-			"version": "3.13.13",
-			"resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.13.tgz",
-			"integrity": "sha512-4o6oPMDvQv+9gMi8rE6gWmsOjtUZUYIJHv7EB+GblyYdi8U6OqLl8rhHWIUZSL1dUU2dPwTdTgybCKf9EjIrQg==",
+			"version": "3.13.24",
+			"resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.24.tgz",
+			"integrity": "sha512-aIJvz5OSkhNIhZIpYivrxrPTKYsjW9Uzy+sP/mx0S3sev2HyvPb7xmjbYvokzEpfgYHy/HjzJ2zFAETuUfgCpg==",
 			"license": "MIT",
 			"dependencies": {
-				"@tanstack/virtual-core": "3.13.13"
+				"@tanstack/virtual-core": "3.14.0"
 			},
 			"funding": {
 				"type": "github",
@@ -4291,13 +4391,34 @@
 			}
 		},
 		"node_modules/@tanstack/virtual-core": {
-			"version": "3.13.13",
-			"resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.13.tgz",
-			"integrity": "sha512-uQFoSdKKf5S8k51W5t7b2qpfkyIbdHMzAn+AMQvHPxKUPeo1SsGaA4JRISQT87jm28b7z8OEqPcg1IOZagQHcA==",
+			"version": "3.14.0",
+			"resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.14.0.tgz",
+			"integrity": "sha512-JLANqGy/D6k4Ujmh8Tr25lGimuOXNiaVyXaCAZS0W+1390sADdGnyUdSWNIfd49gebtIxGMij4IktRVzrdr12Q==",
 			"license": "MIT",
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/tannerlinsley"
+			}
+		},
+		"node_modules/@testing-library/dom": {
+			"version": "10.4.1",
+			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+			"integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/code-frame": "^7.10.4",
+				"@babel/runtime": "^7.12.5",
+				"@types/aria-query": "^5.0.1",
+				"aria-query": "5.3.0",
+				"dom-accessibility-api": "^0.5.9",
+				"lz-string": "^1.5.0",
+				"picocolors": "1.1.1",
+				"pretty-format": "^27.0.2"
+			},
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/@testing-library/jest-dom": {
@@ -4328,9 +4449,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@testing-library/react": {
-			"version": "16.3.0",
-			"resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.0.tgz",
-			"integrity": "sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==",
+			"version": "16.3.2",
+			"resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+			"integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4356,9 +4477,9 @@
 			}
 		},
 		"node_modules/@tootallnate/once": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-			"integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
+			"integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -4377,9 +4498,9 @@
 			}
 		},
 		"node_modules/@types/adm-zip": {
-			"version": "0.5.7",
-			"resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.7.tgz",
-			"integrity": "sha512-DNEs/QvmyRLurdQPChqq0Md4zGvPwHerAJYWk9l2jCbD1VPpnzRJorOdiq4zsw09NFbYnhfsoEhWtxIzXpn2yw==",
+			"version": "0.5.8",
+			"resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.8.tgz",
+			"integrity": "sha512-RVVH7QvZYbN+ihqZ4kX/dMiowf6o+Jk1fNwiSdx0NahBJLU787zkULhGhJM8mf/obmLGmgdMM0bXsQTmyfbR7Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4395,6 +4516,14 @@
 			"dependencies": {
 				"@types/readdir-glob": "*"
 			}
+		},
+		"node_modules/@types/aria-query": {
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+			"integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/@types/better-sqlite3": {
 			"version": "7.6.13",
@@ -4654,9 +4783,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/d3-shape": {
-			"version": "3.1.7",
-			"resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
-			"integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+			"version": "3.1.8",
+			"resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+			"integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/d3-path": "*"
@@ -4700,9 +4829,9 @@
 			}
 		},
 		"node_modules/@types/debug": {
-			"version": "4.1.12",
-			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
-			"integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+			"version": "4.1.13",
+			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+			"integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/ms": "*"
@@ -4732,9 +4861,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/estree": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+			"integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
 			"license": "MIT"
 		},
 		"node_modules/@types/estree-jsx": {
@@ -4772,9 +4901,9 @@
 			}
 		},
 		"node_modules/@types/http-cache-semantics": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
-			"integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+			"integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -4900,16 +5029,15 @@
 			}
 		},
 		"node_modules/@types/prismjs": {
-			"version": "1.26.5",
-			"resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.5.tgz",
-			"integrity": "sha512-AUZTa7hQ2KY5L7AmtSiqxlhWxb4ina0yd8hNbl4TWuqnv/pFP0nDMb3YrfSBf4hJVGLh2YEIBfKaBW/9UEl6IQ==",
+			"version": "1.26.6",
+			"resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.6.tgz",
+			"integrity": "sha512-vqlvI7qlMvcCBbVe0AKAb4f97//Hy0EBTaiW8AalRnG/xAN5zOiWWyrNqNXeq8+KAuvRewjCVY1+IPxk4RdNYw==",
 			"license": "MIT"
 		},
 		"node_modules/@types/prop-types": {
 			"version": "15.7.15",
 			"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
 			"integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@types/qrcode": {
@@ -4923,10 +5051,9 @@
 			}
 		},
 		"node_modules/@types/react": {
-			"version": "18.3.27",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
-			"integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
-			"dev": true,
+			"version": "18.3.28",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+			"integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/prop-types": "*",
@@ -5037,17 +5164,17 @@
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "8.59.3",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.3.tgz",
-			"integrity": "sha512-PwFvSKsXGShKGW6n5bZOhGHEcCZXM8HofLK9fNsEwZXzFRjoY+XT1Vsf1zgyXdwTr0ZYz1/2tkZ0DBTT9jZjhw==",
+			"version": "8.59.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.2.tgz",
+			"integrity": "sha512-j/bwmkBvHUtPNxzuWe5z6BEk3q54YRyGlBXkSsmfoih7zNrBvl5A9A98anlp/7JbyZcWIJ8KXo/3Tq/DjFLtuQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.12.2",
-				"@typescript-eslint/scope-manager": "8.59.3",
-				"@typescript-eslint/type-utils": "8.59.3",
-				"@typescript-eslint/utils": "8.59.3",
-				"@typescript-eslint/visitor-keys": "8.59.3",
+				"@typescript-eslint/scope-manager": "8.59.2",
+				"@typescript-eslint/type-utils": "8.59.2",
+				"@typescript-eslint/utils": "8.59.2",
+				"@typescript-eslint/visitor-keys": "8.59.2",
 				"ignore": "^7.0.5",
 				"natural-compare": "^1.4.0",
 				"ts-api-utils": "^2.5.0"
@@ -5060,22 +5187,22 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/parser": "^8.59.3",
+				"@typescript-eslint/parser": "^8.59.2",
 				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
 				"typescript": ">=4.8.4 <6.1.0"
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "8.59.3",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.3.tgz",
-			"integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
+			"version": "8.59.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.2.tgz",
+			"integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "8.59.3",
-				"@typescript-eslint/types": "8.59.3",
-				"@typescript-eslint/typescript-estree": "8.59.3",
-				"@typescript-eslint/visitor-keys": "8.59.3",
+				"@typescript-eslint/scope-manager": "8.59.2",
+				"@typescript-eslint/types": "8.59.2",
+				"@typescript-eslint/typescript-estree": "8.59.2",
+				"@typescript-eslint/visitor-keys": "8.59.2",
 				"debug": "^4.4.3"
 			},
 			"engines": {
@@ -5091,14 +5218,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/project-service": {
-			"version": "8.59.3",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.3.tgz",
-			"integrity": "sha512-ECiUWa/KYRGDFUqTNehaRgzDshnJfkTABJxVemHk4ko22gcr0ukloKjWvyQ64g8YCV/UI47kN1dbmjf/GaQYng==",
+			"version": "8.59.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.2.tgz",
+			"integrity": "sha512-+2hqvEkeyf/0FBor67duF0Ll7Ot8jyKzDQOSrxazF/danillRq2DwR9dLptsXpoZQqxE1UisSmoZewrlPas9Vw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/tsconfig-utils": "^8.59.3",
-				"@typescript-eslint/types": "^8.59.3",
+				"@typescript-eslint/tsconfig-utils": "^8.59.2",
+				"@typescript-eslint/types": "^8.59.2",
 				"debug": "^4.4.3"
 			},
 			"engines": {
@@ -5113,14 +5240,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "8.59.3",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.3.tgz",
-			"integrity": "sha512-t2LvZnoEfzKtnPjgeEu41xw5gxq9mQVfYy4OoZ4Vlt0sk3JwxmhCca/AR7DwOiHrjWgjAj6as4AhRLKSDfvZIA==",
+			"version": "8.59.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.2.tgz",
+			"integrity": "sha512-JzfyEpEtOU89CcFSwyNS3mu4MLvLSXqnmX05+aKBDM+TdR5jzcGOEBwxwGNxrEQ7p/z6kK2WyioCGBf2zZBnvg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.59.3",
-				"@typescript-eslint/visitor-keys": "8.59.3"
+				"@typescript-eslint/types": "8.59.2",
+				"@typescript-eslint/visitor-keys": "8.59.2"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5131,9 +5258,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/tsconfig-utils": {
-			"version": "8.59.3",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.3.tgz",
-			"integrity": "sha512-PcIJHjmaREXLgIAIzLnSY9VucEzz8FKXsRgFa1DmdGCK/5tJpW03TKJF01Q6VZd1lLdz2sIKPWaDUZN9dp//dw==",
+			"version": "8.59.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.2.tgz",
+			"integrity": "sha512-BKK4alN7oi4C/zv4VqHQ+uRU+lTa6JGIZ7s1juw7b3RHo9OfKB+bKX3u0iVZetdsUCBBkSbdWbarJbmN0fTeSw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -5148,15 +5275,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "8.59.3",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.3.tgz",
-			"integrity": "sha512-g71d8QD8UaiHGvrJwyIS1hCX5r63w6Jll+4VEYhEAHXTDIqX1JgxhTAbEHtKntL9kuc4jRo7/GWw5xfCepSccQ==",
+			"version": "8.59.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.2.tgz",
+			"integrity": "sha512-nhqaj1nmTdVVl/BP5omXNRGO38jn5iosis2vbdmupF2txCf8ylWT8lx+JlvMYYVqzGVKtjojUFoQ3JRWK+mfzQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.59.3",
-				"@typescript-eslint/typescript-estree": "8.59.3",
-				"@typescript-eslint/utils": "8.59.3",
+				"@typescript-eslint/types": "8.59.2",
+				"@typescript-eslint/typescript-estree": "8.59.2",
+				"@typescript-eslint/utils": "8.59.2",
 				"debug": "^4.4.3",
 				"ts-api-utils": "^2.5.0"
 			},
@@ -5173,9 +5300,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "8.59.3",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.3.tgz",
-			"integrity": "sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg==",
+			"version": "8.59.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.2.tgz",
+			"integrity": "sha512-e82GVOE8Ps3E++Egvb6Y3Dw0S10u8NkQ9KXmtRhCWJJ8kDhOJTvtMAWnFL16kB1583goCWXsr0NieKCZMs2/0Q==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -5187,16 +5314,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "8.59.3",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.3.tgz",
-			"integrity": "sha512-CbRjVRAf7Lr9Kr8RopKcbY45p2VfmmHrm0ygOCYFi7oU8q19m0Fs/6iHS7kNOmwpp+ob07ZVcAqlxUod9lYdmg==",
+			"version": "8.59.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.2.tgz",
+			"integrity": "sha512-o0XPGNwcWw+FIwStOWn+BwBuEmL6QXP0rsvAFg7ET1dey1Nr6Wb1ac8p5HEsK0ygO/6mUxlk+YWQD9xcb/nnXg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/project-service": "8.59.3",
-				"@typescript-eslint/tsconfig-utils": "8.59.3",
-				"@typescript-eslint/types": "8.59.3",
-				"@typescript-eslint/visitor-keys": "8.59.3",
+				"@typescript-eslint/project-service": "8.59.2",
+				"@typescript-eslint/tsconfig-utils": "8.59.2",
+				"@typescript-eslint/types": "8.59.2",
+				"@typescript-eslint/visitor-keys": "8.59.2",
 				"debug": "^4.4.3",
 				"minimatch": "^10.2.2",
 				"semver": "^7.7.3",
@@ -5214,56 +5341,17 @@
 				"typescript": ">=4.8.4 <6.1.0"
 			}
 		},
-		"node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "18 || 20 || >=22"
-			}
-		},
-		"node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-			"version": "5.0.6",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^4.0.2"
-			},
-			"engines": {
-				"node": "18 || 20 || >=22"
-			}
-		},
-		"node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-			"version": "10.2.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"dependencies": {
-				"brace-expansion": "^5.0.5"
-			},
-			"engines": {
-				"node": "18 || 20 || >=22"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "8.59.3",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.3.tgz",
-			"integrity": "sha512-JAvT14goBzRzzzZyqq3P9BLArIxTtQURUtFgQ/V7FO+eU+Gg6ES+5ymOPP1wRxXcxAYeivCk4uS3jCKWI1K8Zg==",
+			"version": "8.59.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.2.tgz",
+			"integrity": "sha512-Juw3EinkXqjaffxz6roowvV7GZT/kET5vSKKZT6upl5TXdWkLkYmNPXwDDL2Vkt2DPn0nODIS4egC/0AGxKo/Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.9.1",
-				"@typescript-eslint/scope-manager": "8.59.3",
-				"@typescript-eslint/types": "8.59.3",
-				"@typescript-eslint/typescript-estree": "8.59.3"
+				"@typescript-eslint/scope-manager": "8.59.2",
+				"@typescript-eslint/types": "8.59.2",
+				"@typescript-eslint/typescript-estree": "8.59.2"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5278,13 +5366,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.59.3",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.3.tgz",
-			"integrity": "sha512-f1UQF7ggd42YiwI5wGrRaPsa+P0CINBlrkLPmGfpq/u/I/oVtecoEIfFR9ag/oa1sLOsRNZ6xehf6qMZhQGBDg==",
+			"version": "8.59.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.2.tgz",
+			"integrity": "sha512-NwjLUnGy8/Zfx23fl50tRC8rYaYnM52xNRYFAXvmiil9yh1+K6aRVQMnzW6gQB/1DLgWt977lYQn7C+wtgXZiA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.59.3",
+				"@typescript-eslint/types": "8.59.2",
 				"eslint-visitor-keys": "^5.0.0"
 			},
 			"engines": {
@@ -5309,19 +5397,29 @@
 			}
 		},
 		"node_modules/@ungap/structured-clone": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
-			"integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
+			"integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
 			"license": "ISC"
 		},
+		"node_modules/@upsetjs/venn.js": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@upsetjs/venn.js/-/venn.js-2.0.0.tgz",
+			"integrity": "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==",
+			"license": "MIT",
+			"optionalDependencies": {
+				"d3-selection": "^3.0.0",
+				"d3-transition": "^3.0.1"
+			}
+		},
 		"node_modules/@vitejs/plugin-react": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.2.tgz",
-			"integrity": "sha512-DlSMqo4WhThw4vB8Mpn0Woe9J+Jfq1geJ61AKW0QEgLzGMNwtIMdxbDUzLxcun8W7NbJO0e2Jg/Nxm3cCSVzzg==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.1.tgz",
+			"integrity": "sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@rolldown/pluginutils": "^1.0.0"
+				"@rolldown/pluginutils": "1.0.0-rc.7"
 			},
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
@@ -5341,14 +5439,14 @@
 			}
 		},
 		"node_modules/@vitest/coverage-v8": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.6.tgz",
-			"integrity": "sha512-36l628fQ/9a/8ihy97eOtEnvWQEdqULQOJtcaxtoNq0G1w3Mxd4szSahOaMM9/NGyZ+hyKcMtIW/WIxq0XQViQ==",
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.5.tgz",
+			"integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@bcoe/v8-coverage": "^1.0.2",
-				"@vitest/utils": "4.1.6",
+				"@vitest/utils": "4.1.5",
 				"ast-v8-to-istanbul": "^1.0.0",
 				"istanbul-lib-coverage": "^3.2.2",
 				"istanbul-lib-report": "^3.0.1",
@@ -5362,8 +5460,8 @@
 				"url": "https://opencollective.com/vitest"
 			},
 			"peerDependencies": {
-				"@vitest/browser": "4.1.6",
-				"vitest": "4.1.6"
+				"@vitest/browser": "4.1.5",
+				"vitest": "4.1.5"
 			},
 			"peerDependenciesMeta": {
 				"@vitest/browser": {
@@ -5372,16 +5470,16 @@
 			}
 		},
 		"node_modules/@vitest/expect": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
-			"integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+			"integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@standard-schema/spec": "^1.1.0",
 				"@types/chai": "^5.2.2",
-				"@vitest/spy": "4.1.6",
-				"@vitest/utils": "4.1.6",
+				"@vitest/spy": "4.1.5",
+				"@vitest/utils": "4.1.5",
 				"chai": "^6.2.2",
 				"tinyrainbow": "^3.1.0"
 			},
@@ -5390,13 +5488,13 @@
 			}
 		},
 		"node_modules/@vitest/mocker": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
-			"integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+			"integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/spy": "4.1.6",
+				"@vitest/spy": "4.1.5",
 				"estree-walker": "^3.0.3",
 				"magic-string": "^0.30.21"
 			},
@@ -5417,9 +5515,9 @@
 			}
 		},
 		"node_modules/@vitest/pretty-format": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
-			"integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+			"integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5430,13 +5528,13 @@
 			}
 		},
 		"node_modules/@vitest/runner": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
-			"integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+			"integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/utils": "4.1.6",
+				"@vitest/utils": "4.1.5",
 				"pathe": "^2.0.3"
 			},
 			"funding": {
@@ -5444,14 +5542,14 @@
 			}
 		},
 		"node_modules/@vitest/snapshot": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
-			"integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+			"integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "4.1.6",
-				"@vitest/utils": "4.1.6",
+				"@vitest/pretty-format": "4.1.5",
+				"@vitest/utils": "4.1.5",
 				"magic-string": "^0.30.21",
 				"pathe": "^2.0.3"
 			},
@@ -5460,9 +5558,9 @@
 			}
 		},
 		"node_modules/@vitest/spy": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
-			"integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+			"integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
@@ -5470,13 +5568,13 @@
 			}
 		},
 		"node_modules/@vitest/utils": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
-			"integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+			"integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "4.1.6",
+				"@vitest/pretty-format": "4.1.5",
 				"convert-source-map": "^2.0.0",
 				"tinyrainbow": "^3.1.0"
 			},
@@ -5498,9 +5596,9 @@
 			}
 		},
 		"node_modules/@xmldom/xmldom": {
-			"version": "0.8.11",
-			"resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
-			"integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
+			"version": "0.8.13",
+			"resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+			"integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -5586,9 +5684,9 @@
 			"license": "MIT"
 		},
 		"node_modules/acorn": {
-			"version": "8.15.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+			"version": "8.16.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+			"integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
 			"license": "MIT",
 			"bin": {
 				"acorn": "bin/acorn"
@@ -5617,9 +5715,9 @@
 			}
 		},
 		"node_modules/adm-zip": {
-			"version": "0.5.16",
-			"resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
-			"integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
+			"version": "0.5.17",
+			"resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
+			"integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=12.0"
@@ -5666,9 +5764,9 @@
 			}
 		},
 		"node_modules/ajv": {
-			"version": "6.12.6",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+			"integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5700,9 +5798,9 @@
 			}
 		},
 		"node_modules/ajv-formats/node_modules/ajv": {
-			"version": "8.17.1",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+			"integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
 			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
@@ -5716,9 +5814,9 @@
 			}
 		},
 		"node_modules/ajv-formats/node_modules/fast-uri": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-			"integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+			"integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
 			"funding": [
 				{
 					"type": "github",
@@ -5818,6 +5916,306 @@
 				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
+		"node_modules/app-builder-bin": {
+			"version": "5.0.0-alpha.12",
+			"resolved": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-5.0.0-alpha.12.tgz",
+			"integrity": "sha512-j87o0j6LqPL3QRr8yid6c+Tt5gC7xNfYo6uQIQkorAC6MpeayVMZrEDzKmJJ/Hlv7EnOQpaRm53k6ktDYZyB6w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/app-builder-lib": {
+			"version": "26.8.1",
+			"resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-26.8.1.tgz",
+			"integrity": "sha512-p0Im/Dx5C4tmz8QEE1Yn4MkuPC8PrnlRneMhWJj7BBXQfNTJUshM/bp3lusdEsDbvvfJZpXWnYesgSLvwtM2Zw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@develar/schema-utils": "~2.6.5",
+				"@electron/asar": "3.4.1",
+				"@electron/fuses": "^1.8.0",
+				"@electron/get": "^3.0.0",
+				"@electron/notarize": "2.5.0",
+				"@electron/osx-sign": "1.3.3",
+				"@electron/rebuild": "^4.0.3",
+				"@electron/universal": "2.0.3",
+				"@malept/flatpak-bundler": "^0.4.0",
+				"@types/fs-extra": "9.0.13",
+				"async-exit-hook": "^2.0.1",
+				"builder-util": "26.8.1",
+				"builder-util-runtime": "9.5.1",
+				"chromium-pickle-js": "^0.2.0",
+				"ci-info": "4.3.1",
+				"debug": "^4.3.4",
+				"dotenv": "^16.4.5",
+				"dotenv-expand": "^11.0.6",
+				"ejs": "^3.1.8",
+				"electron-publish": "26.8.1",
+				"fs-extra": "^10.1.0",
+				"hosted-git-info": "^4.1.0",
+				"isbinaryfile": "^5.0.0",
+				"jiti": "^2.4.2",
+				"js-yaml": "^4.1.0",
+				"json5": "^2.2.3",
+				"lazy-val": "^1.0.5",
+				"minimatch": "^10.0.3",
+				"plist": "3.1.0",
+				"proper-lockfile": "^4.1.2",
+				"resedit": "^1.7.0",
+				"semver": "~7.7.3",
+				"tar": "^7.5.7",
+				"temp-file": "^3.4.0",
+				"tiny-async-pool": "1.3.0",
+				"which": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"peerDependencies": {
+				"dmg-builder": "26.8.1",
+				"electron-builder-squirrel-windows": "26.8.1"
+			}
+		},
+		"node_modules/app-builder-lib/node_modules/@electron/get": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@electron/get/-/get-3.1.0.tgz",
+			"integrity": "sha512-F+nKc0xW+kVbBRhFzaMgPy3KwmuNTYX1fx6+FxxoSnNgwYX6LD7AKBTWkU0MQ6IBoe7dz069CNkR673sPAgkCQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.1.1",
+				"env-paths": "^2.2.0",
+				"fs-extra": "^8.1.0",
+				"got": "^11.8.5",
+				"progress": "^2.0.3",
+				"semver": "^6.2.0",
+				"sumchecker": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"optionalDependencies": {
+				"global-agent": "^3.0.0"
+			}
+		},
+		"node_modules/app-builder-lib/node_modules/@electron/get/node_modules/fs-extra": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+			"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^4.0.0",
+				"universalify": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=6 <7 || >=8"
+			}
+		},
+		"node_modules/app-builder-lib/node_modules/@electron/get/node_modules/semver": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			}
+		},
+		"node_modules/app-builder-lib/node_modules/@electron/notarize": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@electron/notarize/-/notarize-2.5.0.tgz",
+			"integrity": "sha512-jNT8nwH1f9X5GEITXaQ8IF/KdskvIkOFfB2CvwumsveVidzpSc+mvhhTMdAGSYF3O+Nq49lJ7y+ssODRXu06+A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.1.1",
+				"fs-extra": "^9.0.1",
+				"promise-retry": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/app-builder-lib/node_modules/@electron/notarize/node_modules/fs-extra": {
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+			"integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"at-least-node": "^1.0.0",
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/app-builder-lib/node_modules/@electron/notarize/node_modules/jsonfile": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"universalify": "^2.0.0"
+			},
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.6"
+			}
+		},
+		"node_modules/app-builder-lib/node_modules/@electron/notarize/node_modules/universalify": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/app-builder-lib/node_modules/chownr": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+			"integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/app-builder-lib/node_modules/ci-info": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz",
+			"integrity": "sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/sibiraj-s"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/app-builder-lib/node_modules/fs-extra": {
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+			"integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/app-builder-lib/node_modules/fs-extra/node_modules/jsonfile": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"universalify": "^2.0.0"
+			},
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.6"
+			}
+		},
+		"node_modules/app-builder-lib/node_modules/fs-extra/node_modules/universalify": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/app-builder-lib/node_modules/isexe": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
+			"integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/app-builder-lib/node_modules/jiti": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+			"integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"jiti": "lib/jiti-cli.mjs"
+			}
+		},
+		"node_modules/app-builder-lib/node_modules/minizlib": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+			"integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"minipass": "^7.1.2"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/app-builder-lib/node_modules/tar": {
+			"version": "7.5.15",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
+			"integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"@isaacs/fs-minipass": "^4.0.0",
+				"chownr": "^3.0.0",
+				"minipass": "^7.1.2",
+				"minizlib": "^3.1.0",
+				"yallist": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/app-builder-lib/node_modules/which": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
+			"integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"isexe": "^3.1.1"
+			},
+			"bin": {
+				"node-which": "bin/which.js"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/app-builder-lib/node_modules/yallist": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+			"integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/aproba": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz",
@@ -5861,164 +6259,6 @@
 				"node": ">= 14"
 			}
 		},
-		"node_modules/archiver-utils/node_modules/buffer": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.2.1"
-			}
-		},
-		"node_modules/archiver-utils/node_modules/glob": {
-			"version": "10.5.0",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-			"integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-			"license": "ISC",
-			"dependencies": {
-				"foreground-child": "^3.1.0",
-				"jackspeak": "^3.1.2",
-				"minimatch": "^9.0.4",
-				"minipass": "^7.1.2",
-				"package-json-from-dist": "^1.0.0",
-				"path-scurry": "^1.11.1"
-			},
-			"bin": {
-				"glob": "dist/esm/bin.mjs"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/archiver-utils/node_modules/minimatch": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/archiver-utils/node_modules/minipass": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-			"license": "ISC",
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			}
-		},
-		"node_modules/archiver-utils/node_modules/readable-stream": {
-			"version": "4.7.0",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
-			"integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
-			"license": "MIT",
-			"dependencies": {
-				"abort-controller": "^3.0.0",
-				"buffer": "^6.0.3",
-				"events": "^3.3.0",
-				"process": "^0.11.10",
-				"string_decoder": "^1.3.0"
-			},
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			}
-		},
-		"node_modules/archiver/node_modules/b4a": {
-			"version": "1.7.3",
-			"resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.3.tgz",
-			"integrity": "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==",
-			"license": "Apache-2.0",
-			"peerDependencies": {
-				"react-native-b4a": "*"
-			},
-			"peerDependenciesMeta": {
-				"react-native-b4a": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/archiver/node_modules/buffer": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.2.1"
-			}
-		},
-		"node_modules/archiver/node_modules/buffer-crc32": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
-			"integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=8.0.0"
-			}
-		},
-		"node_modules/archiver/node_modules/readable-stream": {
-			"version": "4.7.0",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
-			"integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
-			"license": "MIT",
-			"dependencies": {
-				"abort-controller": "^3.0.0",
-				"buffer": "^6.0.3",
-				"events": "^3.3.0",
-				"process": "^0.11.10",
-				"string_decoder": "^1.3.0"
-			},
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			}
-		},
-		"node_modules/archiver/node_modules/tar-stream": {
-			"version": "3.1.7",
-			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
-			"integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
-			"license": "MIT",
-			"dependencies": {
-				"b4a": "^1.6.4",
-				"fast-fifo": "^1.2.0",
-				"streamx": "^2.15.0"
-			}
-		},
 		"node_modules/are-we-there-yet": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
@@ -6032,6 +6272,21 @@
 			},
 			"engines": {
 				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+			}
+		},
+		"node_modules/are-we-there-yet/node_modules/readable-stream": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
 			}
 		},
 		"node_modules/arg": {
@@ -6308,9 +6563,9 @@
 			}
 		},
 		"node_modules/autoprefixer": {
-			"version": "10.4.22",
-			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.22.tgz",
-			"integrity": "sha512-ARe0v/t9gO28Bznv6GgqARmVqcWOV3mfgUPn9becPHMiD3o9BwlRgaeccZnwTpZ7Zwqrm+c1sUSsMxIzQzc8Xg==",
+			"version": "10.5.0",
+			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.0.tgz",
+			"integrity": "sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==",
 			"dev": true,
 			"funding": [
 				{
@@ -6328,10 +6583,9 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"browserslist": "^4.27.0",
-				"caniuse-lite": "^1.0.30001754",
+				"browserslist": "^4.28.2",
+				"caniuse-lite": "^1.0.30001787",
 				"fraction.js": "^5.3.4",
-				"normalize-range": "^0.1.2",
 				"picocolors": "^1.1.1",
 				"postcss-value-parser": "^4.2.0"
 			},
@@ -6382,10 +6636,13 @@
 			}
 		},
 		"node_modules/balanced-match": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"license": "MIT"
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
 		},
 		"node_modules/bare-events": {
 			"version": "2.8.2",
@@ -6399,6 +6656,83 @@
 				"bare-abort-controller": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/bare-fs": {
+			"version": "4.7.1",
+			"resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.1.tgz",
+			"integrity": "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"bare-events": "^2.5.4",
+				"bare-path": "^3.0.0",
+				"bare-stream": "^2.6.4",
+				"bare-url": "^2.2.2",
+				"fast-fifo": "^1.3.2"
+			},
+			"engines": {
+				"bare": ">=1.16.0"
+			},
+			"peerDependencies": {
+				"bare-buffer": "*"
+			},
+			"peerDependenciesMeta": {
+				"bare-buffer": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/bare-os": {
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
+			"integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
+			"license": "Apache-2.0",
+			"engines": {
+				"bare": ">=1.14.0"
+			}
+		},
+		"node_modules/bare-path": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+			"integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"bare-os": "^3.0.1"
+			}
+		},
+		"node_modules/bare-stream": {
+			"version": "2.13.1",
+			"resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.1.tgz",
+			"integrity": "sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"streamx": "^2.25.0",
+				"teex": "^1.0.1"
+			},
+			"peerDependencies": {
+				"bare-abort-controller": "*",
+				"bare-buffer": "*",
+				"bare-events": "*"
+			},
+			"peerDependenciesMeta": {
+				"bare-abort-controller": {
+					"optional": true
+				},
+				"bare-buffer": {
+					"optional": true
+				},
+				"bare-events": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/bare-url": {
+			"version": "2.4.3",
+			"resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.3.tgz",
+			"integrity": "sha512-Kccpc7ACfXaxfeInfqKcZtW4pT5YBn1mesc4sCsun6sRwtbJ4h+sNOaksUpYEJUKfN65YWC6Bw2OJEFiKxq8nQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"bare-path": "^3.0.0"
 			}
 		},
 		"node_modules/base64-js": {
@@ -6422,19 +6756,22 @@
 			"license": "MIT"
 		},
 		"node_modules/baseline-browser-mapping": {
-			"version": "2.9.17",
-			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.17.tgz",
-			"integrity": "sha512-agD0MgJFUP/4nvjqzIB29zRPUuCF7Ge6mEv9s8dHrtYD7QWXRcx75rOADE/d5ah1NI+0vkDl0yorDd5U852IQQ==",
+			"version": "2.10.27",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.27.tgz",
+			"integrity": "sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
-				"baseline-browser-mapping": "dist/cli.js"
+				"baseline-browser-mapping": "dist/cli.cjs"
+			},
+			"engines": {
+				"node": ">=6.0.0"
 			}
 		},
 		"node_modules/better-sqlite3": {
-			"version": "12.10.0",
-			"resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.10.0.tgz",
-			"integrity": "sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==",
+			"version": "12.9.0",
+			"resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.9.0.tgz",
+			"integrity": "sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6442,7 +6779,7 @@
 				"prebuild-install": "^7.1.1"
 			},
 			"engines": {
-				"node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
+				"node": "20.x || 22.x || 23.x || 24.x || 25.x"
 			}
 		},
 		"node_modules/bidi-js": {
@@ -6487,6 +6824,20 @@
 				"readable-stream": "^3.4.0"
 			}
 		},
+		"node_modules/bl/node_modules/readable-stream": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"license": "MIT",
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
 		"node_modules/boolean": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
@@ -6497,12 +6848,15 @@
 			"optional": true
 		},
 		"node_modules/brace-expansion": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
 			"license": "MIT",
 			"dependencies": {
-				"balanced-match": "^1.0.0"
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
 			}
 		},
 		"node_modules/braces": {
@@ -6518,9 +6872,9 @@
 			}
 		},
 		"node_modules/browserslist": {
-			"version": "4.28.0",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.0.tgz",
-			"integrity": "sha512-tbydkR/CxfMwelN0vwdP/pLkDwyAASZ+VfWm4EOwlB6SWhx1sYnWLqo8N5j0rAzPfzfRaxt0mM/4wPU/Su84RQ==",
+			"version": "4.28.2",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+			"integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
 			"dev": true,
 			"funding": [
 				{
@@ -6538,11 +6892,11 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"baseline-browser-mapping": "^2.8.25",
-				"caniuse-lite": "^1.0.30001754",
-				"electron-to-chromium": "^1.5.249",
-				"node-releases": "^2.0.27",
-				"update-browserslist-db": "^1.1.4"
+				"baseline-browser-mapping": "^2.10.12",
+				"caniuse-lite": "^1.0.30001782",
+				"electron-to-chromium": "^1.5.328",
+				"node-releases": "^2.0.36",
+				"update-browserslist-db": "^1.2.3"
 			},
 			"bin": {
 				"browserslist": "cli.js"
@@ -6576,13 +6930,12 @@
 			}
 		},
 		"node_modules/buffer-crc32": {
-			"version": "0.2.13",
-			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-			"integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-			"dev": true,
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+			"integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
 			"license": "MIT",
 			"engines": {
-				"node": "*"
+				"node": ">=8.0.0"
 			}
 		},
 		"node_modules/buffer-from": {
@@ -6591,6 +6944,120 @@
 			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/builder-util": {
+			"version": "26.8.1",
+			"resolved": "https://registry.npmjs.org/builder-util/-/builder-util-26.8.1.tgz",
+			"integrity": "sha512-pm1lTYbGyc90DHgCDO7eo8Rl4EqKLciayNbZqGziqnH9jrlKe8ZANGdityLZU+pJh16dfzjAx2xQq9McuIPEtw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/debug": "^4.1.6",
+				"7zip-bin": "~5.2.0",
+				"app-builder-bin": "5.0.0-alpha.12",
+				"builder-util-runtime": "9.5.1",
+				"chalk": "^4.1.2",
+				"cross-spawn": "^7.0.6",
+				"debug": "^4.3.4",
+				"fs-extra": "^10.1.0",
+				"http-proxy-agent": "^7.0.0",
+				"https-proxy-agent": "^7.0.0",
+				"js-yaml": "^4.1.0",
+				"sanitize-filename": "^1.6.3",
+				"source-map-support": "^0.5.19",
+				"stat-mode": "^1.0.0",
+				"temp-file": "^3.4.0",
+				"tiny-async-pool": "1.3.0"
+			}
+		},
+		"node_modules/builder-util-runtime": {
+			"version": "9.5.1",
+			"resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.5.1.tgz",
+			"integrity": "sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ==",
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.3.4",
+				"sax": "^1.2.4"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/builder-util/node_modules/agent-base": {
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/builder-util/node_modules/fs-extra": {
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+			"integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/builder-util/node_modules/http-proxy-agent": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/builder-util/node_modules/https-proxy-agent": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/builder-util/node_modules/jsonfile": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"universalify": "^2.0.0"
+			},
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.6"
+			}
+		},
+		"node_modules/builder-util/node_modules/universalify": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 10.0.0"
+			}
 		},
 		"node_modules/cacache": {
 			"version": "16.1.3",
@@ -6622,11 +7089,28 @@
 				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
+		"node_modules/cacache/node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/cacache/node_modules/brace-expansion": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+			"integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
 		"node_modules/cacache/node_modules/glob": {
 			"version": "8.1.0",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
 			"integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
-			"deprecated": "Glob versions prior to v9 are no longer supported",
+			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -6651,6 +7135,19 @@
 			"license": "ISC",
 			"engines": {
 				"node": ">=12"
+			}
+		},
+		"node_modules/cacache/node_modules/minimatch": {
+			"version": "5.1.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+			"integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/cacache/node_modules/minipass": {
@@ -6703,15 +7200,15 @@
 			}
 		},
 		"node_modules/call-bind": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-			"integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+			"integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"call-bind-apply-helpers": "^1.0.0",
-				"es-define-property": "^1.0.0",
-				"get-intrinsic": "^1.2.4",
+				"call-bind-apply-helpers": "^1.0.2",
+				"es-define-property": "^1.0.1",
+				"get-intrinsic": "^1.3.0",
 				"set-function-length": "^1.2.2"
 			},
 			"engines": {
@@ -6782,9 +7279,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001756",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001756.tgz",
-			"integrity": "sha512-4HnCNKbMLkLdhJz3TToeVWHSnfJvPaq6vu/eRP0Ahub/07n484XHhBF5AJoSGHdVrS8tKFauUQz8Bp9P7LVx7A==",
+			"version": "1.0.30001792",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
+			"integrity": "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==",
 			"dev": true,
 			"funding": [
 				{
@@ -6803,9 +7300,9 @@
 			"license": "CC-BY-4.0"
 		},
 		"node_modules/canvas": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/canvas/-/canvas-3.2.0.tgz",
-			"integrity": "sha512-jk0GxrLtUEmW/TmFsk2WghvgHe8B0pxGilqCL21y8lHkPUGa6FTsnCNtHPOzT8O3y+N+m3espawV80bbBlgfTA==",
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/canvas/-/canvas-3.2.3.tgz",
+			"integrity": "sha512-PzE5nJZPz72YUAfo8oTp0u3fqqY7IzlTubneAihqDYAUcBk7ryeCmBbdJBEdaH0bptSOe2VT2Zwcb3UaFyaSWw==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -6826,13 +7323,6 @@
 				"type": "donate",
 				"url": "https://www.paypal.me/kirilvatev"
 			}
-		},
-		"node_modules/canvas/node_modules/node-addon-api": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
-			"integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/ccount": {
 			"version": "2.0.1",
@@ -6925,29 +7415,31 @@
 			}
 		},
 		"node_modules/chevrotain": {
-			"version": "11.0.3",
-			"resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.0.3.tgz",
-			"integrity": "sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw==",
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-12.0.0.tgz",
+			"integrity": "sha512-csJvb+6kEiQaqo1woTdSAuOWdN0WTLIydkKrBnS+V5gZz0oqBrp4kQ35519QgK6TpBThiG3V1vNSHlIkv4AglQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@chevrotain/cst-dts-gen": "11.0.3",
-				"@chevrotain/gast": "11.0.3",
-				"@chevrotain/regexp-to-ast": "11.0.3",
-				"@chevrotain/types": "11.0.3",
-				"@chevrotain/utils": "11.0.3",
-				"lodash-es": "4.17.21"
+				"@chevrotain/cst-dts-gen": "12.0.0",
+				"@chevrotain/gast": "12.0.0",
+				"@chevrotain/regexp-to-ast": "12.0.0",
+				"@chevrotain/types": "12.0.0",
+				"@chevrotain/utils": "12.0.0"
+			},
+			"engines": {
+				"node": ">=22.0.0"
 			}
 		},
 		"node_modules/chevrotain-allstar": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.3.1.tgz",
-			"integrity": "sha512-b7g+y9A0v4mxCW1qUhf3BSVPg+/NvGErk/dOkrDaHA0nQIQGAtrOjlX//9OQtRlSCy+x9rfB5N8yC71lH1nvMw==",
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.4.3.tgz",
+			"integrity": "sha512-2X4mkroolSMKqW+H22pyPMUVDqYZzPhephTmg/NODKb1IGYPHfxfhcW0EjS7wcPJNbze2i4vBWT7zT5FKF2lrQ==",
 			"license": "MIT",
 			"dependencies": {
-				"lodash-es": "^4.17.21"
+				"lodash-es": "^4.18.1"
 			},
 			"peerDependencies": {
-				"chevrotain": "^11.0.0"
+				"chevrotain": "^12.0.0"
 			}
 		},
 		"node_modules/chokidar": {
@@ -6972,18 +7464,6 @@
 			},
 			"optionalDependencies": {
 				"fsevents": "~2.3.2"
-			}
-		},
-		"node_modules/chokidar/node_modules/glob-parent": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-			"license": "ISC",
-			"dependencies": {
-				"is-glob": "^4.0.1"
-			},
-			"engines": {
-				"node": ">= 6"
 			}
 		},
 		"node_modules/chownr": {
@@ -7106,6 +7586,37 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/cliui/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/cliui/node_modules/wrap-ansi": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
 		"node_modules/clone": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
@@ -7190,9 +7701,9 @@
 			}
 		},
 		"node_modules/commander": {
-			"version": "14.0.2",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-14.0.2.tgz",
-			"integrity": "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==",
+			"version": "14.0.3",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+			"integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=20"
@@ -7222,46 +7733,6 @@
 			},
 			"engines": {
 				"node": ">= 14"
-			}
-		},
-		"node_modules/compress-commons/node_modules/buffer": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.2.1"
-			}
-		},
-		"node_modules/compress-commons/node_modules/readable-stream": {
-			"version": "4.7.0",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
-			"integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
-			"license": "MIT",
-			"dependencies": {
-				"abort-controller": "^3.0.0",
-				"buffer": "^6.0.3",
-				"events": "^3.3.0",
-				"process": "^0.11.10",
-				"string_decoder": "^1.3.0"
-			},
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
 		},
 		"node_modules/concat-map": {
@@ -7341,9 +7812,9 @@
 			}
 		},
 		"node_modules/conf/node_modules/ajv": {
-			"version": "8.17.1",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+			"integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
 			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
@@ -7357,9 +7828,9 @@
 			}
 		},
 		"node_modules/conf/node_modules/fast-uri": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-			"integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+			"integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
 			"funding": [
 				{
 					"type": "github",
@@ -7376,12 +7847,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
 			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"license": "MIT"
-		},
-		"node_modules/confbox": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.2.tgz",
-			"integrity": "sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==",
 			"license": "MIT"
 		},
 		"node_modules/console-control-strings": {
@@ -7470,51 +7935,20 @@
 				"node": ">= 14"
 			}
 		},
-		"node_modules/crc32-stream/node_modules/buffer": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.2.1"
-			}
-		},
-		"node_modules/crc32-stream/node_modules/readable-stream": {
-			"version": "4.7.0",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
-			"integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
-			"license": "MIT",
-			"dependencies": {
-				"abort-controller": "^3.0.0",
-				"buffer": "^6.0.3",
-				"events": "^3.3.0",
-				"process": "^0.11.10",
-				"string_decoder": "^1.3.0"
-			},
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			}
-		},
 		"node_modules/crelt": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
 			"integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
 			"license": "MIT"
+		},
+		"node_modules/cross-dirname": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/cross-dirname/-/cross-dirname-0.1.0.tgz",
+			"integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.6",
@@ -7531,14 +7965,14 @@
 			}
 		},
 		"node_modules/css-tree": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
-			"integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+			"integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"mdn-data": "2.12.2",
-				"source-map-js": "^1.0.1"
+				"mdn-data": "2.27.1",
+				"source-map-js": "^1.2.1"
 			},
 			"engines": {
 				"node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
@@ -7565,31 +7999,41 @@
 			}
 		},
 		"node_modules/cssstyle": {
-			"version": "5.3.3",
-			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.3.tgz",
-			"integrity": "sha512-OytmFH+13/QXONJcC75QNdMtKpceNk3u8ThBjyyYjkEcy/ekBwR1mMAuNvi3gdBPW3N5TlCzQ0WZw8H0lN/bDw==",
+			"version": "5.3.7",
+			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
+			"integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@asamuzakjp/css-color": "^4.0.3",
-				"@csstools/css-syntax-patches-for-csstree": "^1.0.14",
-				"css-tree": "^3.1.0"
+				"@asamuzakjp/css-color": "^4.1.1",
+				"@csstools/css-syntax-patches-for-csstree": "^1.0.21",
+				"css-tree": "^3.1.0",
+				"lru-cache": "^11.2.4"
 			},
 			"engines": {
 				"node": ">=20"
+			}
+		},
+		"node_modules/cssstyle/node_modules/lru-cache": {
+			"version": "11.3.6",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+			"integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
 			}
 		},
 		"node_modules/csstype": {
 			"version": "3.2.3",
 			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
 			"integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/cytoscape": {
-			"version": "3.33.1",
-			"resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
-			"integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
+			"version": "3.33.3",
+			"resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.3.tgz",
+			"integrity": "sha512-Gej7U+OKR+LZ8kvX7rb2HhCYJ0IhvEFsnkud4SB1PR+BUY/TsSO0dmOW59WEVLu51b1Rm+gQRKoz4bLYxGSZ2g==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10"
@@ -7849,9 +8293,9 @@
 			}
 		},
 		"node_modules/d3-format": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
-			"integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+			"integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
 			"license": "ISC",
 			"engines": {
 				"node": ">=12"
@@ -8085,9 +8529,9 @@
 			}
 		},
 		"node_modules/dagre-d3-es": {
-			"version": "7.0.13",
-			"resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.13.tgz",
-			"integrity": "sha512-efEhnxpSuwpYOKRm/L5KbqoZmNNukHa/Flty4Wp62JRvgH2ojwVgPgdYyr4twpieZnyRDdIH7PY2mopX26+j2Q==",
+			"version": "7.0.14",
+			"resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz",
+			"integrity": "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==",
 			"license": "MIT",
 			"dependencies": {
 				"d3": "^7.9.0",
@@ -8095,15 +8539,25 @@
 			}
 		},
 		"node_modules/data-urls": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.0.tgz",
-			"integrity": "sha512-BnBS08aLUM+DKamupXs3w2tJJoqU+AkaE/+6vQxi/G/DPmIZFJJp9Dkb1kM03AZx8ADehDUZgsNxju3mPXZYIA==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.1.tgz",
+			"integrity": "sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"whatwg-mimetype": "^4.0.0",
-				"whatwg-url": "^15.0.0"
+				"whatwg-mimetype": "^5.0.0",
+				"whatwg-url": "^15.1.0"
 			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/data-urls/node_modules/whatwg-mimetype": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+			"integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=20"
 			}
@@ -8173,9 +8627,9 @@
 			}
 		},
 		"node_modules/dayjs": {
-			"version": "1.11.19",
-			"resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.19.tgz",
-			"integrity": "sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==",
+			"version": "1.11.20",
+			"resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
+			"integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
 			"license": "MIT"
 		},
 		"node_modules/debounce-fn": {
@@ -8233,9 +8687,9 @@
 			"license": "MIT"
 		},
 		"node_modules/decode-named-character-reference": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.2.0.tgz",
-			"integrity": "sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+			"integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
 			"license": "MIT",
 			"dependencies": {
 				"character-entities": "^2.0.0"
@@ -8348,9 +8802,9 @@
 			}
 		},
 		"node_modules/delaunator": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.1.tgz",
-			"integrity": "sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+			"integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
 			"license": "ISC",
 			"dependencies": {
 				"robust-predicates": "^3.0.2"
@@ -8429,9 +8883,9 @@
 			"license": "Apache-2.0"
 		},
 		"node_modules/diff": {
-			"version": "8.0.3",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
-			"integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+			"integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.3.1"
@@ -8448,6 +8902,48 @@
 			"resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
 			"integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
 			"license": "MIT"
+		},
+		"node_modules/dir-compare": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/dir-compare/-/dir-compare-4.2.0.tgz",
+			"integrity": "sha512-2xMCmOoMrdQIPHdsTawECdNPwlVFB9zGcz3kuhmBO6U3oU+UQjsue0i8ayLKpgBcm+hcXPMVSGUN9d+pvJ6+VQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"minimatch": "^3.0.5",
+				"p-limit": "^3.1.0 "
+			}
+		},
+		"node_modules/dir-compare/node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/dir-compare/node_modules/brace-expansion": {
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/dir-compare/node_modules/minimatch": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
 		},
 		"node_modules/dlv": {
 			"version": "1.1.3",
@@ -8473,453 +8969,6 @@
 				"dmg-license": "^1.0.11"
 			}
 		},
-		"node_modules/dmg-builder/node_modules/@electron/get": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@electron/get/-/get-3.1.0.tgz",
-			"integrity": "sha512-F+nKc0xW+kVbBRhFzaMgPy3KwmuNTYX1fx6+FxxoSnNgwYX6LD7AKBTWkU0MQ6IBoe7dz069CNkR673sPAgkCQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"debug": "^4.1.1",
-				"env-paths": "^2.2.0",
-				"fs-extra": "^8.1.0",
-				"got": "^11.8.5",
-				"progress": "^2.0.3",
-				"semver": "^6.2.0",
-				"sumchecker": "^3.0.1"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"optionalDependencies": {
-				"global-agent": "^3.0.0"
-			}
-		},
-		"node_modules/dmg-builder/node_modules/@electron/get/node_modules/fs-extra": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-			"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"graceful-fs": "^4.2.0",
-				"jsonfile": "^4.0.0",
-				"universalify": "^0.1.0"
-			},
-			"engines": {
-				"node": ">=6 <7 || >=8"
-			}
-		},
-		"node_modules/dmg-builder/node_modules/@electron/get/node_modules/semver": {
-			"version": "6.3.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
-			}
-		},
-		"node_modules/dmg-builder/node_modules/@electron/notarize": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/@electron/notarize/-/notarize-2.5.0.tgz",
-			"integrity": "sha512-jNT8nwH1f9X5GEITXaQ8IF/KdskvIkOFfB2CvwumsveVidzpSc+mvhhTMdAGSYF3O+Nq49lJ7y+ssODRXu06+A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"debug": "^4.1.1",
-				"fs-extra": "^9.0.1",
-				"promise-retry": "^2.0.1"
-			},
-			"engines": {
-				"node": ">= 10.0.0"
-			}
-		},
-		"node_modules/dmg-builder/node_modules/@electron/notarize/node_modules/fs-extra": {
-			"version": "9.1.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-			"integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"at-least-node": "^1.0.0",
-				"graceful-fs": "^4.2.0",
-				"jsonfile": "^6.0.1",
-				"universalify": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/dmg-builder/node_modules/@electron/notarize/node_modules/jsonfile": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"universalify": "^2.0.0"
-			},
-			"optionalDependencies": {
-				"graceful-fs": "^4.1.6"
-			}
-		},
-		"node_modules/dmg-builder/node_modules/@electron/notarize/node_modules/universalify": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 10.0.0"
-			}
-		},
-		"node_modules/dmg-builder/node_modules/@electron/osx-sign": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/@electron/osx-sign/-/osx-sign-1.3.3.tgz",
-			"integrity": "sha512-KZ8mhXvWv2rIEgMbWZ4y33bDHyUKMXnx4M0sTyPNK/vcB81ImdeY9Ggdqy0SWbMDgmbqyQ+phgejh6V3R2QuSg==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"compare-version": "^0.1.2",
-				"debug": "^4.3.4",
-				"fs-extra": "^10.0.0",
-				"isbinaryfile": "^4.0.8",
-				"minimist": "^1.2.6",
-				"plist": "^3.0.5"
-			},
-			"bin": {
-				"electron-osx-flat": "bin/electron-osx-flat.js",
-				"electron-osx-sign": "bin/electron-osx-sign.js"
-			},
-			"engines": {
-				"node": ">=12.0.0"
-			}
-		},
-		"node_modules/dmg-builder/node_modules/@electron/osx-sign/node_modules/isbinaryfile": {
-			"version": "4.0.10",
-			"resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.10.tgz",
-			"integrity": "sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 8.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/gjtorikian/"
-			}
-		},
-		"node_modules/dmg-builder/node_modules/@electron/universal": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@electron/universal/-/universal-2.0.3.tgz",
-			"integrity": "sha512-Wn9sPYIVFRFl5HmwMJkARCCf7rqK/EurkfQ/rJZ14mHP3iYTjZSIOSVonEAnhWeAXwtw7zOekGRlc6yTtZ0t+g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@electron/asar": "^3.3.1",
-				"@malept/cross-spawn-promise": "^2.0.0",
-				"debug": "^4.3.1",
-				"dir-compare": "^4.2.0",
-				"fs-extra": "^11.1.1",
-				"minimatch": "^9.0.3",
-				"plist": "^3.1.0"
-			},
-			"engines": {
-				"node": ">=16.4"
-			}
-		},
-		"node_modules/dmg-builder/node_modules/@electron/universal/node_modules/fs-extra": {
-			"version": "11.3.5",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
-			"integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"graceful-fs": "^4.2.0",
-				"jsonfile": "^6.0.1",
-				"universalify": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=14.14"
-			}
-		},
-		"node_modules/dmg-builder/node_modules/@electron/universal/node_modules/jsonfile": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"universalify": "^2.0.0"
-			},
-			"optionalDependencies": {
-				"graceful-fs": "^4.1.6"
-			}
-		},
-		"node_modules/dmg-builder/node_modules/@electron/universal/node_modules/minimatch": {
-			"version": "9.0.9",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-			"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^2.0.2"
-			},
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/dmg-builder/node_modules/@electron/universal/node_modules/universalify": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 10.0.0"
-			}
-		},
-		"node_modules/dmg-builder/node_modules/@malept/cross-spawn-promise": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-2.0.0.tgz",
-			"integrity": "sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://github.com/sponsors/malept"
-				},
-				{
-					"type": "tidelift",
-					"url": "https://tidelift.com/subscription/pkg/npm-.malept-cross-spawn-promise?utm_medium=referral&utm_source=npm_fund"
-				}
-			],
-			"license": "Apache-2.0",
-			"dependencies": {
-				"cross-spawn": "^7.0.1"
-			},
-			"engines": {
-				"node": ">= 12.13.0"
-			}
-		},
-		"node_modules/dmg-builder/node_modules/agent-base": {
-			"version": "7.1.4",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/dmg-builder/node_modules/app-builder-bin": {
-			"version": "5.0.0-alpha.12",
-			"resolved": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-5.0.0-alpha.12.tgz",
-			"integrity": "sha512-j87o0j6LqPL3QRr8yid6c+Tt5gC7xNfYo6uQIQkorAC6MpeayVMZrEDzKmJJ/Hlv7EnOQpaRm53k6ktDYZyB6w==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/dmg-builder/node_modules/app-builder-lib": {
-			"version": "26.8.1",
-			"resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-26.8.1.tgz",
-			"integrity": "sha512-p0Im/Dx5C4tmz8QEE1Yn4MkuPC8PrnlRneMhWJj7BBXQfNTJUshM/bp3lusdEsDbvvfJZpXWnYesgSLvwtM2Zw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@develar/schema-utils": "~2.6.5",
-				"@electron/asar": "3.4.1",
-				"@electron/fuses": "^1.8.0",
-				"@electron/get": "^3.0.0",
-				"@electron/notarize": "2.5.0",
-				"@electron/osx-sign": "1.3.3",
-				"@electron/rebuild": "^4.0.3",
-				"@electron/universal": "2.0.3",
-				"@malept/flatpak-bundler": "^0.4.0",
-				"@types/fs-extra": "9.0.13",
-				"async-exit-hook": "^2.0.1",
-				"builder-util": "26.8.1",
-				"builder-util-runtime": "9.5.1",
-				"chromium-pickle-js": "^0.2.0",
-				"ci-info": "4.3.1",
-				"debug": "^4.3.4",
-				"dotenv": "^16.4.5",
-				"dotenv-expand": "^11.0.6",
-				"ejs": "^3.1.8",
-				"electron-publish": "26.8.1",
-				"fs-extra": "^10.1.0",
-				"hosted-git-info": "^4.1.0",
-				"isbinaryfile": "^5.0.0",
-				"jiti": "^2.4.2",
-				"js-yaml": "^4.1.0",
-				"json5": "^2.2.3",
-				"lazy-val": "^1.0.5",
-				"minimatch": "^10.0.3",
-				"plist": "3.1.0",
-				"proper-lockfile": "^4.1.2",
-				"resedit": "^1.7.0",
-				"semver": "~7.7.3",
-				"tar": "^7.5.7",
-				"temp-file": "^3.4.0",
-				"tiny-async-pool": "1.3.0",
-				"which": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			},
-			"peerDependencies": {
-				"dmg-builder": "26.8.1",
-				"electron-builder-squirrel-windows": "26.8.1"
-			}
-		},
-		"node_modules/dmg-builder/node_modules/builder-util": {
-			"version": "26.8.1",
-			"resolved": "https://registry.npmjs.org/builder-util/-/builder-util-26.8.1.tgz",
-			"integrity": "sha512-pm1lTYbGyc90DHgCDO7eo8Rl4EqKLciayNbZqGziqnH9jrlKe8ZANGdityLZU+pJh16dfzjAx2xQq9McuIPEtw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/debug": "^4.1.6",
-				"7zip-bin": "~5.2.0",
-				"app-builder-bin": "5.0.0-alpha.12",
-				"builder-util-runtime": "9.5.1",
-				"chalk": "^4.1.2",
-				"cross-spawn": "^7.0.6",
-				"debug": "^4.3.4",
-				"fs-extra": "^10.1.0",
-				"http-proxy-agent": "^7.0.0",
-				"https-proxy-agent": "^7.0.0",
-				"js-yaml": "^4.1.0",
-				"sanitize-filename": "^1.6.3",
-				"source-map-support": "^0.5.19",
-				"stat-mode": "^1.0.0",
-				"temp-file": "^3.4.0",
-				"tiny-async-pool": "1.3.0"
-			}
-		},
-		"node_modules/dmg-builder/node_modules/builder-util-runtime": {
-			"version": "9.5.1",
-			"resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.5.1.tgz",
-			"integrity": "sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"debug": "^4.3.4",
-				"sax": "^1.2.4"
-			},
-			"engines": {
-				"node": ">=12.0.0"
-			}
-		},
-		"node_modules/dmg-builder/node_modules/chownr": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-			"integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/dmg-builder/node_modules/ci-info": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz",
-			"integrity": "sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/sibiraj-s"
-				}
-			],
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/dmg-builder/node_modules/dir-compare": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/dir-compare/-/dir-compare-4.2.0.tgz",
-			"integrity": "sha512-2xMCmOoMrdQIPHdsTawECdNPwlVFB9zGcz3kuhmBO6U3oU+UQjsue0i8ayLKpgBcm+hcXPMVSGUN9d+pvJ6+VQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"minimatch": "^3.0.5",
-				"p-limit": "^3.1.0 "
-			}
-		},
-		"node_modules/dmg-builder/node_modules/dir-compare/node_modules/brace-expansion": {
-			"version": "1.1.14",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"node_modules/dmg-builder/node_modules/dir-compare/node_modules/minimatch": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/dmg-builder/node_modules/dotenv": {
-			"version": "16.6.1",
-			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-			"integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://dotenvx.com"
-			}
-		},
-		"node_modules/dmg-builder/node_modules/dotenv-expand": {
-			"version": "11.0.7",
-			"resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-11.0.7.tgz",
-			"integrity": "sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"dotenv": "^16.4.5"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://dotenvx.com"
-			}
-		},
-		"node_modules/dmg-builder/node_modules/electron-publish": {
-			"version": "26.8.1",
-			"resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-26.8.1.tgz",
-			"integrity": "sha512-q+jrSTIh/Cv4eGZa7oVR+grEJo/FoLMYBAnSL5GCtqwUpr1T+VgKB/dn1pnzxIxqD8S/jP1yilT9VrwCqINR4w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/fs-extra": "^9.0.11",
-				"builder-util": "26.8.1",
-				"builder-util-runtime": "9.5.1",
-				"chalk": "^4.1.2",
-				"form-data": "^4.0.5",
-				"fs-extra": "^10.1.0",
-				"lazy-val": "^1.0.5",
-				"mime": "^2.5.2"
-			}
-		},
 		"node_modules/dmg-builder/node_modules/fs-extra": {
 			"version": "10.1.0",
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
@@ -8935,7 +8984,7 @@
 				"node": ">=12"
 			}
 		},
-		"node_modules/dmg-builder/node_modules/fs-extra/node_modules/jsonfile": {
+		"node_modules/dmg-builder/node_modules/jsonfile": {
 			"version": "6.2.1",
 			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
 			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
@@ -8948,7 +8997,7 @@
 				"graceful-fs": "^4.1.6"
 			}
 		},
-		"node_modules/dmg-builder/node_modules/fs-extra/node_modules/universalify": {
+		"node_modules/dmg-builder/node_modules/universalify": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
 			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
@@ -8956,188 +9005,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 10.0.0"
-			}
-		},
-		"node_modules/dmg-builder/node_modules/http-proxy-agent": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"agent-base": "^7.1.0",
-				"debug": "^4.3.4"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/dmg-builder/node_modules/https-proxy-agent": {
-			"version": "7.0.6",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"agent-base": "^7.1.2",
-				"debug": "4"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/dmg-builder/node_modules/isexe": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
-			"integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/dmg-builder/node_modules/jiti": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
-			"integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
-			"dev": true,
-			"license": "MIT",
-			"bin": {
-				"jiti": "lib/jiti-cli.mjs"
-			}
-		},
-		"node_modules/dmg-builder/node_modules/minimatch": {
-			"version": "10.2.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"dependencies": {
-				"brace-expansion": "^5.0.5"
-			},
-			"engines": {
-				"node": "18 || 20 || >=22"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/dmg-builder/node_modules/minimatch/node_modules/balanced-match": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "18 || 20 || >=22"
-			}
-		},
-		"node_modules/dmg-builder/node_modules/minimatch/node_modules/brace-expansion": {
-			"version": "5.0.6",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^4.0.2"
-			},
-			"engines": {
-				"node": "18 || 20 || >=22"
-			}
-		},
-		"node_modules/dmg-builder/node_modules/minipass": {
-			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			}
-		},
-		"node_modules/dmg-builder/node_modules/minizlib": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
-			"integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"minipass": "^7.1.2"
-			},
-			"engines": {
-				"node": ">= 18"
-			}
-		},
-		"node_modules/dmg-builder/node_modules/p-limit": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"yocto-queue": "^0.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/dmg-builder/node_modules/semver": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/dmg-builder/node_modules/tar": {
-			"version": "7.5.15",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
-			"integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"dependencies": {
-				"@isaacs/fs-minipass": "^4.0.0",
-				"chownr": "^3.0.0",
-				"minipass": "^7.1.2",
-				"minizlib": "^3.1.0",
-				"yallist": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/dmg-builder/node_modules/which": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
-			"integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"isexe": "^3.1.1"
-			},
-			"bin": {
-				"node-which": "bin/which.js"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/dmg-builder/node_modules/yallist": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-			"integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": ">=18"
 			}
 		},
 		"node_modules/dmg-license": {
@@ -9180,10 +9047,18 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/dom-accessibility-api": {
+			"version": "0.5.16",
+			"resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+			"integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
 		"node_modules/dompurify": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.0.tgz",
-			"integrity": "sha512-r+f6MYR1gGN1eJv0TVQbhA7if/U7P87cdPl3HN5rikqaBSBxLiCb/b9O+2eG0cxz0ghyU+mU1QkbsOwERMYlWQ==",
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.2.tgz",
+			"integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
 			"license": "(MPL-2.0 OR Apache-2.0)",
 			"optionalDependencies": {
 				"@types/trusted-types": "^2.0.7"
@@ -9202,6 +9077,35 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/dotenv": {
+			"version": "16.6.1",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+			"integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://dotenvx.com"
+			}
+		},
+		"node_modules/dotenv-expand": {
+			"version": "11.0.7",
+			"resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-11.0.7.tgz",
+			"integrity": "sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"dotenv": "^16.4.5"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://dotenvx.com"
 			}
 		},
 		"node_modules/dunder-proto": {
@@ -9231,6 +9135,20 @@
 				"stream-shift": "^1.0.2"
 			}
 		},
+		"node_modules/duplexify/node_modules/readable-stream": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"license": "MIT",
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
 		"node_modules/eastasianwidth": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -9254,9 +9172,9 @@
 			}
 		},
 		"node_modules/electron": {
-			"version": "41.6.1",
-			"resolved": "https://registry.npmjs.org/electron/-/electron-41.6.1.tgz",
-			"integrity": "sha512-3y1Q0AkPnqwaJJZV146KlZ63VIVlQVlWdLiArkwnGUOxZAZD5cvag4TMUsu/gN+FZhkkpelgvdTXPZvTb34I8A==",
+			"version": "41.6.0",
+			"resolved": "https://registry.npmjs.org/electron/-/electron-41.6.0.tgz",
+			"integrity": "sha512-5UWV5FXkYMzCDV6FvLCa5mzlCBtlX/H1Af27TD5di+4CUCPi0/ZmWPBdSBlYrunsBlUvlcpW8X0NurW4zesQ6g==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -9298,344 +9216,17 @@
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/electron-builder/node_modules/@electron/get": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@electron/get/-/get-3.1.0.tgz",
-			"integrity": "sha512-F+nKc0xW+kVbBRhFzaMgPy3KwmuNTYX1fx6+FxxoSnNgwYX6LD7AKBTWkU0MQ6IBoe7dz069CNkR673sPAgkCQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"debug": "^4.1.1",
-				"env-paths": "^2.2.0",
-				"fs-extra": "^8.1.0",
-				"got": "^11.8.5",
-				"progress": "^2.0.3",
-				"semver": "^6.2.0",
-				"sumchecker": "^3.0.1"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"optionalDependencies": {
-				"global-agent": "^3.0.0"
-			}
-		},
-		"node_modules/electron-builder/node_modules/@electron/get/node_modules/fs-extra": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-			"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"graceful-fs": "^4.2.0",
-				"jsonfile": "^4.0.0",
-				"universalify": "^0.1.0"
-			},
-			"engines": {
-				"node": ">=6 <7 || >=8"
-			}
-		},
-		"node_modules/electron-builder/node_modules/@electron/get/node_modules/jsonfile": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-			"integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-			"dev": true,
-			"license": "MIT",
-			"optionalDependencies": {
-				"graceful-fs": "^4.1.6"
-			}
-		},
-		"node_modules/electron-builder/node_modules/@electron/get/node_modules/semver": {
-			"version": "6.3.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
-			}
-		},
-		"node_modules/electron-builder/node_modules/@electron/get/node_modules/universalify": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 4.0.0"
-			}
-		},
-		"node_modules/electron-builder/node_modules/@electron/notarize": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/@electron/notarize/-/notarize-2.5.0.tgz",
-			"integrity": "sha512-jNT8nwH1f9X5GEITXaQ8IF/KdskvIkOFfB2CvwumsveVidzpSc+mvhhTMdAGSYF3O+Nq49lJ7y+ssODRXu06+A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"debug": "^4.1.1",
-				"fs-extra": "^9.0.1",
-				"promise-retry": "^2.0.1"
-			},
-			"engines": {
-				"node": ">= 10.0.0"
-			}
-		},
-		"node_modules/electron-builder/node_modules/@electron/notarize/node_modules/fs-extra": {
-			"version": "9.1.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-			"integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"at-least-node": "^1.0.0",
-				"graceful-fs": "^4.2.0",
-				"jsonfile": "^6.0.1",
-				"universalify": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/electron-builder/node_modules/@electron/osx-sign": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/@electron/osx-sign/-/osx-sign-1.3.3.tgz",
-			"integrity": "sha512-KZ8mhXvWv2rIEgMbWZ4y33bDHyUKMXnx4M0sTyPNK/vcB81ImdeY9Ggdqy0SWbMDgmbqyQ+phgejh6V3R2QuSg==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"compare-version": "^0.1.2",
-				"debug": "^4.3.4",
-				"fs-extra": "^10.0.0",
-				"isbinaryfile": "^4.0.8",
-				"minimist": "^1.2.6",
-				"plist": "^3.0.5"
-			},
-			"bin": {
-				"electron-osx-flat": "bin/electron-osx-flat.js",
-				"electron-osx-sign": "bin/electron-osx-sign.js"
-			},
-			"engines": {
-				"node": ">=12.0.0"
-			}
-		},
-		"node_modules/electron-builder/node_modules/@electron/osx-sign/node_modules/isbinaryfile": {
-			"version": "4.0.10",
-			"resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.10.tgz",
-			"integrity": "sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 8.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/gjtorikian/"
-			}
-		},
-		"node_modules/electron-builder/node_modules/@electron/universal": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@electron/universal/-/universal-2.0.3.tgz",
-			"integrity": "sha512-Wn9sPYIVFRFl5HmwMJkARCCf7rqK/EurkfQ/rJZ14mHP3iYTjZSIOSVonEAnhWeAXwtw7zOekGRlc6yTtZ0t+g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@electron/asar": "^3.3.1",
-				"@malept/cross-spawn-promise": "^2.0.0",
-				"debug": "^4.3.1",
-				"dir-compare": "^4.2.0",
-				"fs-extra": "^11.1.1",
-				"minimatch": "^9.0.3",
-				"plist": "^3.1.0"
-			},
-			"engines": {
-				"node": ">=16.4"
-			}
-		},
-		"node_modules/electron-builder/node_modules/@electron/universal/node_modules/fs-extra": {
-			"version": "11.3.5",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
-			"integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"graceful-fs": "^4.2.0",
-				"jsonfile": "^6.0.1",
-				"universalify": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=14.14"
-			}
-		},
-		"node_modules/electron-builder/node_modules/@electron/universal/node_modules/minimatch": {
-			"version": "9.0.9",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-			"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^2.0.2"
-			},
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/electron-builder/node_modules/@malept/cross-spawn-promise": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-2.0.0.tgz",
-			"integrity": "sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://github.com/sponsors/malept"
-				},
-				{
-					"type": "tidelift",
-					"url": "https://tidelift.com/subscription/pkg/npm-.malept-cross-spawn-promise?utm_medium=referral&utm_source=npm_fund"
-				}
-			],
-			"license": "Apache-2.0",
-			"dependencies": {
-				"cross-spawn": "^7.0.1"
-			},
-			"engines": {
-				"node": ">= 12.13.0"
-			}
-		},
-		"node_modules/electron-builder/node_modules/agent-base": {
-			"version": "7.1.4",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/electron-builder/node_modules/app-builder-bin": {
-			"version": "5.0.0-alpha.12",
-			"resolved": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-5.0.0-alpha.12.tgz",
-			"integrity": "sha512-j87o0j6LqPL3QRr8yid6c+Tt5gC7xNfYo6uQIQkorAC6MpeayVMZrEDzKmJJ/Hlv7EnOQpaRm53k6ktDYZyB6w==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/electron-builder/node_modules/app-builder-lib": {
+		"node_modules/electron-builder-squirrel-windows": {
 			"version": "26.8.1",
-			"resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-26.8.1.tgz",
-			"integrity": "sha512-p0Im/Dx5C4tmz8QEE1Yn4MkuPC8PrnlRneMhWJj7BBXQfNTJUshM/bp3lusdEsDbvvfJZpXWnYesgSLvwtM2Zw==",
+			"resolved": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-26.8.1.tgz",
+			"integrity": "sha512-o288fIdgPLHA76eDrFADHPoo7VyGkDCYbLV1GzndaMSAVBoZrGvM9m2IehdcVMzdAZJ2eV9bgyissQXHv5tGzA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
-				"@develar/schema-utils": "~2.6.5",
-				"@electron/asar": "3.4.1",
-				"@electron/fuses": "^1.8.0",
-				"@electron/get": "^3.0.0",
-				"@electron/notarize": "2.5.0",
-				"@electron/osx-sign": "1.3.3",
-				"@electron/rebuild": "^4.0.3",
-				"@electron/universal": "2.0.3",
-				"@malept/flatpak-bundler": "^0.4.0",
-				"@types/fs-extra": "9.0.13",
-				"async-exit-hook": "^2.0.1",
+				"app-builder-lib": "26.8.1",
 				"builder-util": "26.8.1",
-				"builder-util-runtime": "9.5.1",
-				"chromium-pickle-js": "^0.2.0",
-				"ci-info": "4.3.1",
-				"debug": "^4.3.4",
-				"dotenv": "^16.4.5",
-				"dotenv-expand": "^11.0.6",
-				"ejs": "^3.1.8",
-				"electron-publish": "26.8.1",
-				"fs-extra": "^10.1.0",
-				"hosted-git-info": "^4.1.0",
-				"isbinaryfile": "^5.0.0",
-				"jiti": "^2.4.2",
-				"js-yaml": "^4.1.0",
-				"json5": "^2.2.3",
-				"lazy-val": "^1.0.5",
-				"minimatch": "^10.0.3",
-				"plist": "3.1.0",
-				"proper-lockfile": "^4.1.2",
-				"resedit": "^1.7.0",
-				"semver": "~7.7.3",
-				"tar": "^7.5.7",
-				"temp-file": "^3.4.0",
-				"tiny-async-pool": "1.3.0",
-				"which": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			},
-			"peerDependencies": {
-				"dmg-builder": "26.8.1",
-				"electron-builder-squirrel-windows": "26.8.1"
-			}
-		},
-		"node_modules/electron-builder/node_modules/app-builder-lib/node_modules/ci-info": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz",
-			"integrity": "sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/sibiraj-s"
-				}
-			],
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/electron-builder/node_modules/builder-util": {
-			"version": "26.8.1",
-			"resolved": "https://registry.npmjs.org/builder-util/-/builder-util-26.8.1.tgz",
-			"integrity": "sha512-pm1lTYbGyc90DHgCDO7eo8Rl4EqKLciayNbZqGziqnH9jrlKe8ZANGdityLZU+pJh16dfzjAx2xQq9McuIPEtw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/debug": "^4.1.6",
-				"7zip-bin": "~5.2.0",
-				"app-builder-bin": "5.0.0-alpha.12",
-				"builder-util-runtime": "9.5.1",
-				"chalk": "^4.1.2",
-				"cross-spawn": "^7.0.6",
-				"debug": "^4.3.4",
-				"fs-extra": "^10.1.0",
-				"http-proxy-agent": "^7.0.0",
-				"https-proxy-agent": "^7.0.0",
-				"js-yaml": "^4.1.0",
-				"sanitize-filename": "^1.6.3",
-				"source-map-support": "^0.5.19",
-				"stat-mode": "^1.0.0",
-				"temp-file": "^3.4.0",
-				"tiny-async-pool": "1.3.0"
-			}
-		},
-		"node_modules/electron-builder/node_modules/builder-util-runtime": {
-			"version": "9.5.1",
-			"resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.5.1.tgz",
-			"integrity": "sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"debug": "^4.3.4",
-				"sax": "^1.2.4"
-			},
-			"engines": {
-				"node": ">=12.0.0"
-			}
-		},
-		"node_modules/electron-builder/node_modules/chownr": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-			"integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": ">=18"
+				"electron-winstaller": "5.4.0"
 			}
 		},
 		"node_modules/electron-builder/node_modules/ci-info": {
@@ -9654,71 +9245,55 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/electron-builder/node_modules/dir-compare": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/dir-compare/-/dir-compare-4.2.0.tgz",
-			"integrity": "sha512-2xMCmOoMrdQIPHdsTawECdNPwlVFB9zGcz3kuhmBO6U3oU+UQjsue0i8ayLKpgBcm+hcXPMVSGUN9d+pvJ6+VQ==",
+		"node_modules/electron-builder/node_modules/fs-extra": {
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+			"integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"minimatch": "^3.0.5",
-				"p-limit": "^3.1.0 "
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=12"
 			}
 		},
-		"node_modules/electron-builder/node_modules/dir-compare/node_modules/brace-expansion": {
-			"version": "1.1.14",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+		"node_modules/electron-builder/node_modules/jsonfile": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
+				"universalify": "^2.0.0"
+			},
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.6"
 			}
 		},
-		"node_modules/electron-builder/node_modules/dir-compare/node_modules/minimatch": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+		"node_modules/electron-builder/node_modules/universalify": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
 			"dev": true,
-			"license": "ISC",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/electron-devtools-installer": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/electron-devtools-installer/-/electron-devtools-installer-4.0.0.tgz",
+			"integrity": "sha512-9Tntu/jtfSn0n6N/ZI6IdvRqXpDyLQiDuuIbsBI+dL+1Ef7C8J2JwByw58P3TJiNeuqyV3ZkphpNWuZK5iSY2w==",
+			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
+				"unzip-crx-3": "^0.2.0"
 			}
 		},
-		"node_modules/electron-builder/node_modules/dotenv": {
-			"version": "16.6.1",
-			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-			"integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://dotenvx.com"
-			}
-		},
-		"node_modules/electron-builder/node_modules/dotenv-expand": {
-			"version": "11.0.7",
-			"resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-11.0.7.tgz",
-			"integrity": "sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"dotenv": "^16.4.5"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://dotenvx.com"
-			}
-		},
-		"node_modules/electron-builder/node_modules/electron-publish": {
+		"node_modules/electron-publish": {
 			"version": "26.8.1",
 			"resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-26.8.1.tgz",
 			"integrity": "sha512-q+jrSTIh/Cv4eGZa7oVR+grEJo/FoLMYBAnSL5GCtqwUpr1T+VgKB/dn1pnzxIxqD8S/jP1yilT9VrwCqINR4w==",
@@ -9735,7 +9310,7 @@
 				"mime": "^2.5.2"
 			}
 		},
-		"node_modules/electron-builder/node_modules/fs-extra": {
+		"node_modules/electron-publish/node_modules/fs-extra": {
 			"version": "10.1.0",
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
 			"integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
@@ -9750,58 +9325,10 @@
 				"node": ">=12"
 			}
 		},
-		"node_modules/electron-builder/node_modules/http-proxy-agent": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"agent-base": "^7.1.0",
-				"debug": "^4.3.4"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/electron-builder/node_modules/https-proxy-agent": {
-			"version": "7.0.6",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"agent-base": "^7.1.2",
-				"debug": "4"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/electron-builder/node_modules/isexe": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
-			"integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/electron-builder/node_modules/jiti": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
-			"integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
-			"dev": true,
-			"license": "MIT",
-			"bin": {
-				"jiti": "lib/jiti-cli.mjs"
-			}
-		},
-		"node_modules/electron-builder/node_modules/jsonfile": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-			"integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+		"node_modules/electron-publish/node_modules/jsonfile": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -9811,115 +9338,20 @@
 				"graceful-fs": "^4.1.6"
 			}
 		},
-		"node_modules/electron-builder/node_modules/minimatch": {
-			"version": "10.2.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"dependencies": {
-				"brace-expansion": "^5.0.5"
-			},
-			"engines": {
-				"node": "18 || 20 || >=22"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/electron-builder/node_modules/minimatch/node_modules/balanced-match": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+		"node_modules/electron-publish/node_modules/mime": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+			"integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
 			"dev": true,
 			"license": "MIT",
-			"engines": {
-				"node": "18 || 20 || >=22"
-			}
-		},
-		"node_modules/electron-builder/node_modules/minimatch/node_modules/brace-expansion": {
-			"version": "5.0.6",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^4.0.2"
-			},
-			"engines": {
-				"node": "18 || 20 || >=22"
-			}
-		},
-		"node_modules/electron-builder/node_modules/minipass": {
-			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			}
-		},
-		"node_modules/electron-builder/node_modules/minizlib": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
-			"integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"minipass": "^7.1.2"
-			},
-			"engines": {
-				"node": ">= 18"
-			}
-		},
-		"node_modules/electron-builder/node_modules/p-limit": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"yocto-queue": "^0.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/electron-builder/node_modules/semver": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-			"dev": true,
-			"license": "ISC",
 			"bin": {
-				"semver": "bin/semver.js"
+				"mime": "cli.js"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=4.0.0"
 			}
 		},
-		"node_modules/electron-builder/node_modules/tar": {
-			"version": "7.5.15",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
-			"integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"dependencies": {
-				"@isaacs/fs-minipass": "^4.0.0",
-				"chownr": "^3.0.0",
-				"minipass": "^7.1.2",
-				"minizlib": "^3.1.0",
-				"yallist": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/electron-builder/node_modules/universalify": {
+		"node_modules/electron-publish/node_modules/universalify": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
 			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
@@ -9927,42 +9359,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 10.0.0"
-			}
-		},
-		"node_modules/electron-builder/node_modules/which": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
-			"integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"isexe": "^3.1.1"
-			},
-			"bin": {
-				"node-which": "bin/which.js"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/electron-builder/node_modules/yallist": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-			"integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/electron-devtools-installer": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/electron-devtools-installer/-/electron-devtools-installer-4.0.0.tgz",
-			"integrity": "sha512-9Tntu/jtfSn0n6N/ZI6IdvRqXpDyLQiDuuIbsBI+dL+1Ef7C8J2JwByw58P3TJiNeuqyV3ZkphpNWuZK5iSY2w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"unzip-crx-3": "^0.2.0"
 			}
 		},
 		"node_modules/electron-rebuild": {
@@ -9995,29 +9391,6 @@
 				"node": ">=12.13.0"
 			}
 		},
-		"node_modules/electron-rebuild/node_modules/@malept/cross-spawn-promise": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-2.0.0.tgz",
-			"integrity": "sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://github.com/sponsors/malept"
-				},
-				{
-					"type": "tidelift",
-					"url": "https://tidelift.com/subscription/pkg/npm-.malept-cross-spawn-promise?utm_medium=referral&utm_source=npm_fund"
-				}
-			],
-			"license": "Apache-2.0",
-			"dependencies": {
-				"cross-spawn": "^7.0.1"
-			},
-			"engines": {
-				"node": ">= 12.13.0"
-			}
-		},
 		"node_modules/electron-rebuild/node_modules/fs-extra": {
 			"version": "10.1.0",
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
@@ -10034,9 +9407,9 @@
 			}
 		},
 		"node_modules/electron-rebuild/node_modules/jsonfile": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-			"integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -10070,9 +9443,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.259",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.259.tgz",
-			"integrity": "sha512-I+oLXgpEJzD6Cwuwt1gYjxsDmu/S/Kd41mmLA3O+/uH2pFRO/DvOjUyGozL8j3KeLV6WyZ7ssPwELMsXCcsJAQ==",
+			"version": "1.5.352",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.352.tgz",
+			"integrity": "sha512-9wHk8x6dyuimoe18EdiDPWKExNdxYqo4fn4FwOVVper6RxT3cmpBwBkWWfSOCYJjQdIco/nPhJhNLmn4Ufg1Yg==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -10092,19 +9465,6 @@
 				"tiny-typed-emitter": "^2.1.0"
 			}
 		},
-		"node_modules/electron-updater/node_modules/builder-util-runtime": {
-			"version": "9.5.1",
-			"resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.5.1.tgz",
-			"integrity": "sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ==",
-			"license": "MIT",
-			"dependencies": {
-				"debug": "^4.3.4",
-				"sax": "^1.2.4"
-			},
-			"engines": {
-				"node": ">=12.0.0"
-			}
-		},
 		"node_modules/electron-updater/node_modules/fs-extra": {
 			"version": "10.1.0",
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
@@ -10120,27 +9480,15 @@
 			}
 		},
 		"node_modules/electron-updater/node_modules/jsonfile": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-			"integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
 			"license": "MIT",
 			"dependencies": {
 				"universalify": "^2.0.0"
 			},
 			"optionalDependencies": {
 				"graceful-fs": "^4.1.6"
-			}
-		},
-		"node_modules/electron-updater/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/electron-updater/node_modules/universalify": {
@@ -10150,6 +9498,44 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/electron-winstaller": {
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/electron-winstaller/-/electron-winstaller-5.4.0.tgz",
+			"integrity": "sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@electron/asar": "^3.2.1",
+				"debug": "^4.1.1",
+				"fs-extra": "^7.0.1",
+				"lodash": "^4.17.21",
+				"temp": "^0.9.0"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			},
+			"optionalDependencies": {
+				"@electron/windows-sign": "^1.1.2"
+			}
+		},
+		"node_modules/electron-winstaller/node_modules/fs-extra": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+			"integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"graceful-fs": "^4.1.2",
+				"jsonfile": "^4.0.0",
+				"universalify": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=6 <7 || >=8"
 			}
 		},
 		"node_modules/electron/node_modules/@types/node": {
@@ -10168,6 +9554,13 @@
 			"integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/emoji-mart": {
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/emoji-mart/-/emoji-mart-5.6.0.tgz",
+			"integrity": "sha512-eJp3QRe79pjwa+duv+n7+5YsNhRcMl812EcFVwrnRvYKoNPoQb5qxU8DG6Bgwji0akHdp6D4Ln6tYLG58MFSow==",
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/emoji-regex": {
 			"version": "8.0.0",
@@ -10221,9 +9614,9 @@
 			"license": "MIT"
 		},
 		"node_modules/es-abstract": {
-			"version": "1.24.1",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.1.tgz",
-			"integrity": "sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==",
+			"version": "1.24.2",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
+			"integrity": "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -10310,16 +9703,16 @@
 			}
 		},
 		"node_modules/es-iterator-helpers": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.2.2.tgz",
-			"integrity": "sha512-BrUQ0cPTB/IwXj23HtwHjS9n7O4h9FX94b4xc5zlTHxeLgTAdzYUDyy6KdExAl9lbN5rtfe44xpjpmj9grxs5w==",
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.3.2.tgz",
+			"integrity": "sha512-HVLACW1TppGYjJ8H6/jqH/pqOtKRw6wMlrB23xfExmFWxFquAIWCmwoLsOyN96K4a5KbmOf5At9ZUO3GZbetAw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"call-bind": "^1.0.8",
+				"call-bind": "^1.0.9",
 				"call-bound": "^1.0.4",
 				"define-properties": "^1.2.1",
-				"es-abstract": "^1.24.1",
+				"es-abstract": "^1.24.2",
 				"es-errors": "^1.3.0",
 				"es-set-tostringtag": "^2.1.0",
 				"function-bind": "^1.1.2",
@@ -10331,7 +9724,7 @@
 				"has-symbols": "^1.1.0",
 				"internal-slot": "^1.1.0",
 				"iterator.prototype": "^1.1.5",
-				"safe-array-concat": "^1.1.3"
+				"math-intrinsics": "^1.1.0"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -10405,9 +9798,9 @@
 			}
 		},
 		"node_modules/es-toolkit": {
-			"version": "1.43.0",
-			"resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.43.0.tgz",
-			"integrity": "sha512-SKCT8AsWvYzBBuUqMk4NPwFlSdqLpJwmy6AP322ERn8W2YLIB6JBXnwMI2Qsh2gfphT3q7EKAxKb23cvFHFwKA==",
+			"version": "1.46.1",
+			"resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.1.tgz",
+			"integrity": "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==",
 			"license": "MIT",
 			"workspaces": [
 				"docs",
@@ -10494,25 +9887,25 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "9.39.2",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz",
-			"integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
+			"version": "9.39.4",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+			"integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.1",
-				"@eslint/config-array": "^0.21.1",
+				"@eslint/config-array": "^0.21.2",
 				"@eslint/config-helpers": "^0.4.2",
 				"@eslint/core": "^0.17.0",
-				"@eslint/eslintrc": "^3.3.1",
-				"@eslint/js": "9.39.2",
+				"@eslint/eslintrc": "^3.3.5",
+				"@eslint/js": "9.39.4",
 				"@eslint/plugin-kit": "^0.4.1",
 				"@humanfs/node": "^0.16.6",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@humanwhocodes/retry": "^0.4.2",
 				"@types/estree": "^1.0.6",
-				"ajv": "^6.12.4",
+				"ajv": "^6.14.0",
 				"chalk": "^4.0.0",
 				"cross-spawn": "^7.0.6",
 				"debug": "^4.3.2",
@@ -10531,7 +9924,7 @@
 				"is-glob": "^4.0.0",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
 				"lodash.merge": "^4.6.2",
-				"minimatch": "^3.1.2",
+				"minimatch": "^3.1.5",
 				"natural-compare": "^1.4.0",
 				"optionator": "^0.9.3"
 			},
@@ -10603,9 +9996,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-react-hooks": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.0.1.tgz",
-			"integrity": "sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+			"integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -10619,13 +10012,20 @@
 				"node": ">=18"
 			},
 			"peerDependencies": {
-				"eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+				"eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
 			}
 		},
+		"node_modules/eslint-plugin-react/node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/eslint-plugin-react/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -10634,9 +10034,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-react/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -10644,24 +10044,6 @@
 			},
 			"engines": {
 				"node": "*"
-			}
-		},
-		"node_modules/eslint-plugin-react/node_modules/resolve": {
-			"version": "2.0.0-next.5",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
-			"integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"is-core-module": "^2.13.0",
-				"path-parse": "^1.0.7",
-				"supports-preserve-symlinks-flag": "^1.0.0"
-			},
-			"bin": {
-				"resolve": "bin/resolve"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/eslint-plugin-react/node_modules/semver": {
@@ -10704,10 +10086,17 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
+		"node_modules/eslint/node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/eslint/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -10728,21 +10117,17 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
-		"node_modules/eslint/node_modules/find-up": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+		"node_modules/eslint/node_modules/glob-parent": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+			"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
 			"dev": true,
-			"license": "MIT",
+			"license": "ISC",
 			"dependencies": {
-				"locate-path": "^6.0.0",
-				"path-exists": "^4.0.0"
+				"is-glob": "^4.0.3"
 			},
 			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
+				"node": ">=10.13.0"
 			}
 		},
 		"node_modules/eslint/node_modules/ignore": {
@@ -10755,26 +10140,10 @@
 				"node": ">= 4"
 			}
 		},
-		"node_modules/eslint/node_modules/locate-path": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"p-locate": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/eslint/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -10782,48 +10151,6 @@
 			},
 			"engines": {
 				"node": "*"
-			}
-		},
-		"node_modules/eslint/node_modules/p-limit": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"yocto-queue": "^0.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/eslint/node_modules/p-locate": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"p-limit": "^3.0.2"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/eslint/node_modules/path-exists": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/espree": {
@@ -10858,9 +10185,9 @@
 			}
 		},
 		"node_modules/esquery": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
-			"integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+			"integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
@@ -10933,9 +10260,9 @@
 			}
 		},
 		"node_modules/eventemitter3": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-			"integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+			"integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
 			"license": "MIT"
 		},
 		"node_modules/events": {
@@ -10981,12 +10308,6 @@
 			"integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
 			"dev": true,
 			"license": "Apache-2.0"
-		},
-		"node_modules/exsolve": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
-			"integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
-			"license": "MIT"
 		},
 		"node_modules/extend": {
 			"version": "3.0.2",
@@ -11067,19 +10388,6 @@
 				"node": ">=8.6.0"
 			}
 		},
-		"node_modules/fast-glob/node_modules/glob-parent": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"is-glob": "^4.0.1"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
 		"node_modules/fast-json-stable-stringify": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -11103,9 +10411,9 @@
 			}
 		},
 		"node_modules/fast-json-stringify/node_modules/ajv": {
-			"version": "8.17.1",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+			"integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
 			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
@@ -11136,9 +10444,9 @@
 			}
 		},
 		"node_modules/fast-json-stringify/node_modules/ajv/node_modules/fast-uri": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-			"integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+			"integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
 			"funding": [
 				{
 					"type": "github",
@@ -11220,9 +10528,9 @@
 			"license": "MIT"
 		},
 		"node_modules/fastq": {
-			"version": "1.19.1",
-			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
-			"integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+			"version": "1.20.1",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+			"integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
 			"license": "ISC",
 			"dependencies": {
 				"reusify": "^1.0.4"
@@ -11251,6 +10559,24 @@
 				"pend": "~1.2.0"
 			}
 		},
+		"node_modules/fdir": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"peerDependencies": {
+				"picomatch": "^3 || ^4"
+			},
+			"peerDependenciesMeta": {
+				"picomatch": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/file-entry-cache": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -11271,13 +10597,43 @@
 			"license": "MIT"
 		},
 		"node_modules/filelist": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
-			"integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.6.tgz",
+			"integrity": "sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"minimatch": "^5.0.1"
+			}
+		},
+		"node_modules/filelist/node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/filelist/node_modules/brace-expansion": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+			"integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/filelist/node_modules/minimatch": {
+			"version": "5.1.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+			"integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/fill-range": {
@@ -11307,15 +10663,20 @@
 			}
 		},
 		"node_modules/find-up": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-			"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"locate-path": "^3.0.0"
+				"locate-path": "^6.0.0",
+				"path-exists": "^4.0.0"
 			},
 			"engines": {
-				"node": ">=6"
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/find-yarn-workspace-root": {
@@ -11343,9 +10704,9 @@
 			}
 		},
 		"node_modules/flatted": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-			"integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+			"integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -11579,6 +10940,19 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/gauge/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/generator-function": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
@@ -11700,62 +11074,66 @@
 			"license": "ISC"
 		},
 		"node_modules/glob": {
-			"version": "7.2.3",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-			"deprecated": "Glob versions prior to v9 are no longer supported",
-			"dev": true,
+			"version": "10.5.0",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+			"integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
 			"license": "ISC",
 			"dependencies": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.1.1",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
+				"foreground-child": "^3.1.0",
+				"jackspeak": "^3.1.2",
+				"minimatch": "^9.0.4",
+				"minipass": "^7.1.2",
+				"package-json-from-dist": "^1.0.0",
+				"path-scurry": "^1.11.1"
 			},
-			"engines": {
-				"node": "*"
+			"bin": {
+				"glob": "dist/esm/bin.mjs"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/glob-parent": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-			"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-			"dev": true,
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
 			"license": "ISC",
 			"dependencies": {
-				"is-glob": "^4.0.3"
+				"is-glob": "^4.0.1"
 			},
 			"engines": {
-				"node": ">=10.13.0"
+				"node": ">= 6"
 			}
 		},
+		"node_modules/glob/node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"license": "MIT"
+		},
 		"node_modules/glob/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-			"dev": true,
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+			"integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
 			"license": "MIT",
 			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
+				"balanced-match": "^1.0.0"
 			}
 		},
 		"node_modules/glob/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-			"dev": true,
+			"version": "9.0.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+			"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
 			"license": "ISC",
 			"dependencies": {
-				"brace-expansion": "^1.1.7"
+				"brace-expansion": "^2.0.2"
 			},
 			"engines": {
-				"node": "*"
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/global-agent": {
@@ -11947,9 +11325,9 @@
 			"license": "ISC"
 		},
 		"node_modules/hasown": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+			"integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -12232,16 +11610,16 @@
 			"license": "ISC"
 		},
 		"node_modules/html-encoding-sniffer": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
-			"integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+			"integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"whatwg-encoding": "^3.1.1"
+				"@exodus/bytes": "^1.6.0"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
 			}
 		},
 		"node_modules/html-escaper": {
@@ -12381,6 +11759,14 @@
 				"node": "^8.11.2 || >=10"
 			}
 		},
+		"node_modules/iconv-corefoundation/node_modules/node-addon-api": {
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
+			"integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
 		"node_modules/iconv-lite": {
 			"version": "0.6.3",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -12472,6 +11858,16 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/import-meta-resolve": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+			"integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/imurmurhash": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -12554,9 +11950,9 @@
 			}
 		},
 		"node_modules/ip-address": {
-			"version": "10.1.0",
-			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-			"integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+			"integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -12693,13 +12089,13 @@
 			}
 		},
 		"node_modules/is-core-module": {
-			"version": "2.16.1",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-			"integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+			"version": "2.16.2",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+			"integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"hasown": "^2.0.2"
+				"hasown": "^2.0.3"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -13126,9 +12522,10 @@
 			}
 		},
 		"node_modules/isarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+			"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/isbinaryfile": {
@@ -13291,18 +12688,19 @@
 			}
 		},
 		"node_modules/jsdom": {
-			"version": "27.2.0",
-			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.2.0.tgz",
-			"integrity": "sha512-454TI39PeRDW1LgpyLPyURtB4Zx1tklSr6+OFOipsxGUH1WMTvk6C65JQdrj455+DP2uJ1+veBEHTGFKWVLFoA==",
+			"version": "27.4.0",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.4.0.tgz",
+			"integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@acemir/cssom": "^0.9.23",
-				"@asamuzakjp/dom-selector": "^6.7.4",
-				"cssstyle": "^5.3.3",
+				"@acemir/cssom": "^0.9.28",
+				"@asamuzakjp/dom-selector": "^6.7.6",
+				"@exodus/bytes": "^1.6.0",
+				"cssstyle": "^5.3.4",
 				"data-urls": "^6.0.0",
 				"decimal.js": "^10.6.0",
-				"html-encoding-sniffer": "^4.0.0",
+				"html-encoding-sniffer": "^6.0.0",
 				"http-proxy-agent": "^7.0.2",
 				"https-proxy-agent": "^7.0.6",
 				"is-potential-custom-element-name": "^1.0.1",
@@ -13312,7 +12710,6 @@
 				"tough-cookie": "^6.0.0",
 				"w3c-xmlserializer": "^5.0.0",
 				"webidl-conversions": "^8.0.0",
-				"whatwg-encoding": "^3.1.1",
 				"whatwg-mimetype": "^4.0.0",
 				"whatwg-url": "^15.1.0",
 				"ws": "^8.18.3",
@@ -13437,13 +12834,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/json-stable-stringify/node_modules/isarray": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-			"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -13514,6 +12904,13 @@
 				"setimmediate": "^1.0.5"
 			}
 		},
+		"node_modules/jszip/node_modules/isarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/jszip/node_modules/readable-stream": {
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
@@ -13548,9 +12945,9 @@
 			}
 		},
 		"node_modules/katex": {
-			"version": "0.16.25",
-			"resolved": "https://registry.npmjs.org/katex/-/katex-0.16.25.tgz",
-			"integrity": "sha512-woHRUZ/iF23GBP1dkDQMh1QBad9dmr8/PAwNA54VrSOVYgI12MAcE14TqnDdQOdzyEonGzMepYnqBMYdsoAr8Q==",
+			"version": "0.16.45",
+			"resolved": "https://registry.npmjs.org/katex/-/katex-0.16.45.tgz",
+			"integrity": "sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA==",
 			"funding": [
 				"https://opencollective.com/katex",
 				"https://github.com/sponsors/katex"
@@ -13597,26 +12994,22 @@
 				"graceful-fs": "^4.1.11"
 			}
 		},
-		"node_modules/kolorist": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/kolorist/-/kolorist-1.8.0.tgz",
-			"integrity": "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==",
-			"license": "MIT"
-		},
 		"node_modules/langium": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/langium/-/langium-3.3.1.tgz",
-			"integrity": "sha512-QJv/h939gDpvT+9SiLVlY7tZC3xB2qK57v0J04Sh9wpMb6MP1q8gB21L3WIo8T5P1MSMg3Ep14L7KkDCFG3y4w==",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/langium/-/langium-4.2.3.tgz",
+			"integrity": "sha512-sOPIi4hISFnY7twwV97ca1TsxpBtXq0URu/LL1AvxwccPG/RIBBlKS7a/f/EL6w8lTNaS0EFs/F+IdSOaqYpng==",
 			"license": "MIT",
 			"dependencies": {
-				"chevrotain": "~11.0.3",
-				"chevrotain-allstar": "~0.3.0",
+				"@chevrotain/regexp-to-ast": "~12.0.0",
+				"chevrotain": "~12.0.0",
+				"chevrotain-allstar": "~0.4.3",
 				"vscode-languageserver": "~9.0.1",
 				"vscode-languageserver-textdocument": "~1.0.11",
-				"vscode-uri": "~3.0.8"
+				"vscode-uri": "~3.1.0"
 			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
 			}
 		},
 		"node_modules/layout-base": {
@@ -13642,6 +13035,12 @@
 			"engines": {
 				"node": ">= 0.6.3"
 			}
+		},
+		"node_modules/lazystream/node_modules/isarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+			"license": "MIT"
 		},
 		"node_modules/lazystream/node_modules/readable-stream": {
 			"version": "2.3.8",
@@ -13998,46 +13397,32 @@
 				"uc.micro": "^2.0.0"
 			}
 		},
-		"node_modules/local-pkg": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-1.1.2.tgz",
-			"integrity": "sha512-arhlxbFRmoQHl33a0Zkle/YWlmNwoyt6QNZEIJcqNbdrsix5Lvc4HyyI3EnwxTYlZYc32EbYrQ8SzEZ7dqgg9A==",
+		"node_modules/locate-path": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"mlly": "^1.7.4",
-				"pkg-types": "^2.3.0",
-				"quansync": "^0.2.11"
+				"p-locate": "^5.0.0"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": ">=10"
 			},
 			"funding": {
-				"url": "https://github.com/sponsors/antfu"
-			}
-		},
-		"node_modules/locate-path": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-			"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-			"license": "MIT",
-			"dependencies": {
-				"p-locate": "^3.0.0",
-				"path-exists": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=6"
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/lodash": {
-			"version": "4.17.21",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+			"version": "4.18.1",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+			"integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
 			"license": "MIT"
 		},
 		"node_modules/lodash-es": {
-			"version": "4.17.21",
-			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-			"integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+			"version": "4.18.1",
+			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+			"integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
 			"license": "MIT"
 		},
 		"node_modules/lodash.escaperegexp": {
@@ -14143,6 +13528,17 @@
 				"react": "^16.5.1 || ^17.0.0 || ^18.0.0"
 			}
 		},
+		"node_modules/lz-string": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+			"integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"bin": {
+				"lz-string": "bin/bin.js"
+			}
+		},
 		"node_modules/lzma-native": {
 			"version": "8.0.6",
 			"resolved": "https://registry.npmjs.org/lzma-native/-/lzma-native-8.0.6.tgz",
@@ -14169,6 +13565,21 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/lzma-native/node_modules/readable-stream": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
 		"node_modules/magic-string": {
 			"version": "0.30.21",
 			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -14180,13 +13591,13 @@
 			}
 		},
 		"node_modules/magicast": {
-			"version": "0.5.3",
-			"resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
-			"integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+			"integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/parser": "^7.29.3",
+				"@babel/parser": "^7.29.0",
 				"@babel/types": "^7.29.0",
 				"source-map-js": "^1.2.1"
 			}
@@ -14305,9 +13716,9 @@
 			}
 		},
 		"node_modules/marked": {
-			"version": "17.0.1",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-17.0.1.tgz",
-			"integrity": "sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg==",
+			"version": "17.0.6",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-17.0.6.tgz",
+			"integrity": "sha512-gB0gkNafnonOw0obSTEGZTT86IuhILt2Wfx0mWH/1Au83kybTayroZ/V6nS25mN7u8ASy+5fMhgB3XPNrOZdmA==",
 			"license": "MIT",
 			"bin": {
 				"marked": "bin/marked.js"
@@ -14369,9 +13780,9 @@
 			}
 		},
 		"node_modules/mdast-util-from-markdown": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz",
-			"integrity": "sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+			"integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mdast": "^4.0.0",
@@ -14667,9 +14078,9 @@
 			}
 		},
 		"node_modules/mdn-data": {
-			"version": "2.12.2",
-			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
-			"integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+			"version": "2.27.1",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+			"integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
 			"dev": true,
 			"license": "CC0-1.0"
 		},
@@ -14690,27 +14101,28 @@
 			}
 		},
 		"node_modules/mermaid": {
-			"version": "11.12.1",
-			"resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.12.1.tgz",
-			"integrity": "sha512-UlIZrRariB11TY1RtTgUWp65tphtBv4CSq7vyS2ZZ2TgoMjs2nloq+wFqxiwcxlhHUvs7DPGgMjs2aeQxz5h9g==",
+			"version": "11.14.0",
+			"resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.14.0.tgz",
+			"integrity": "sha512-GSGloRsBs+JINmmhl0JDwjpuezCsHB4WGI4NASHxL3fHo3o/BRXTxhDLKnln8/Q0lRFRyDdEjmk1/d5Sn1Xz8g==",
 			"license": "MIT",
 			"dependencies": {
 				"@braintree/sanitize-url": "^7.1.1",
-				"@iconify/utils": "^3.0.1",
-				"@mermaid-js/parser": "^0.6.3",
+				"@iconify/utils": "^3.0.2",
+				"@mermaid-js/parser": "^1.1.0",
 				"@types/d3": "^7.4.3",
-				"cytoscape": "^3.29.3",
+				"@upsetjs/venn.js": "^2.0.0",
+				"cytoscape": "^3.33.1",
 				"cytoscape-cose-bilkent": "^4.1.0",
 				"cytoscape-fcose": "^2.2.0",
 				"d3": "^7.9.0",
 				"d3-sankey": "^0.12.3",
-				"dagre-d3-es": "7.0.13",
-				"dayjs": "^1.11.18",
-				"dompurify": "^3.2.5",
-				"katex": "^0.16.22",
+				"dagre-d3-es": "7.0.14",
+				"dayjs": "^1.11.19",
+				"dompurify": "^3.3.1",
+				"katex": "^0.16.25",
 				"khroma": "^2.1.0",
-				"lodash-es": "^4.17.21",
-				"marked": "^16.2.1",
+				"lodash-es": "^4.17.23",
+				"marked": "^16.3.0",
 				"roughjs": "^4.6.6",
 				"stylis": "^4.3.6",
 				"ts-dedent": "^2.2.0",
@@ -15349,16 +14761,15 @@
 			}
 		},
 		"node_modules/mime": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
-			"integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
-			"dev": true,
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+			"integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
 			"license": "MIT",
 			"bin": {
 				"mime": "cli.js"
 			},
 			"engines": {
-				"node": ">=4.0.0"
+				"node": ">=10.0.0"
 			}
 		},
 		"node_modules/mime-db": {
@@ -15414,15 +14825,18 @@
 			}
 		},
 		"node_modules/minimatch": {
-			"version": "5.1.6",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-			"integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-			"license": "ISC",
+			"version": "10.2.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"brace-expansion": "^2.0.1"
+				"brace-expansion": "^5.0.5"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/minimist": {
@@ -15435,12 +14849,12 @@
 			}
 		},
 		"node_modules/minipass": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-			"integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-			"license": "ISC",
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+			"license": "BlueOak-1.0.0",
 			"engines": {
-				"node": ">=8"
+				"node": ">=16 || 14 >=14.17"
 			}
 		},
 		"node_modules/minipass-collect": {
@@ -15515,11 +14929,11 @@
 			"license": "ISC"
 		},
 		"node_modules/minipass-flush": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
-			"integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.7.tgz",
+			"integrity": "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==",
 			"dev": true,
-			"license": "ISC",
+			"license": "BlueOak-1.0.0",
 			"dependencies": {
 				"minipass": "^3.0.0"
 			},
@@ -15666,35 +15080,6 @@
 			"integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
 			"license": "MIT"
 		},
-		"node_modules/mlly": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz",
-			"integrity": "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==",
-			"license": "MIT",
-			"dependencies": {
-				"acorn": "^8.15.0",
-				"pathe": "^2.0.3",
-				"pkg-types": "^1.3.1",
-				"ufo": "^1.6.1"
-			}
-		},
-		"node_modules/mlly/node_modules/confbox": {
-			"version": "0.1.8",
-			"resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
-			"integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
-			"license": "MIT"
-		},
-		"node_modules/mlly/node_modules/pkg-types": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
-			"integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
-			"license": "MIT",
-			"dependencies": {
-				"confbox": "^0.1.8",
-				"mlly": "^1.7.4",
-				"pathe": "^2.0.1"
-			}
-		},
 		"node_modules/mnemonist": {
 			"version": "0.39.6",
 			"resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.39.6.tgz",
@@ -15729,9 +15114,9 @@
 			}
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.11",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-			"integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+			"version": "3.3.12",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+			"integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -15771,9 +15156,9 @@
 			}
 		},
 		"node_modules/node-abi": {
-			"version": "3.85.0",
-			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.85.0.tgz",
-			"integrity": "sha512-zsFhmbkAzwhTft6nd3VxcG0cvJsT70rL+BIGHWVq5fi6MwGrHwzqKaxXE+Hl2GmnGItnDKPPkO5/LQqjVkIdFg==",
+			"version": "3.92.0",
+			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
+			"integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
 			"license": "MIT",
 			"dependencies": {
 				"semver": "^7.3.5"
@@ -15783,12 +15168,10 @@
 			}
 		},
 		"node_modules/node-addon-api": {
-			"version": "1.7.2",
-			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
-			"integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+			"integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+			"license": "MIT"
 		},
 		"node_modules/node-api-version": {
 			"version": "0.1.4",
@@ -15798,6 +15181,35 @@
 			"license": "MIT",
 			"dependencies": {
 				"semver": "^7.3.5"
+			}
+		},
+		"node_modules/node-exports-info": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
+			"integrity": "sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"array.prototype.flatmap": "^1.3.3",
+				"es-errors": "^1.3.0",
+				"object.entries": "^1.1.9",
+				"semver": "^6.3.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/node-exports-info/node_modules/semver": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
 			}
 		},
 		"node_modules/node-gyp": {
@@ -15838,6 +15250,59 @@
 				"node-gyp-build-test": "build-test.js"
 			}
 		},
+		"node_modules/node-gyp/node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/node-gyp/node_modules/brace-expansion": {
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/node-gyp/node_modules/glob": {
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.1.1",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			},
+			"engines": {
+				"node": "*"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/node-gyp/node_modules/minimatch": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
 		"node_modules/node-pty": {
 			"version": "1.2.0-beta.12",
 			"resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.2.0-beta.12.tgz",
@@ -15848,16 +15313,10 @@
 				"node-addon-api": "^7.1.0"
 			}
 		},
-		"node_modules/node-pty/node_modules/node-addon-api": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
-			"integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-			"license": "MIT"
-		},
 		"node_modules/node-releases": {
-			"version": "2.0.27",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
-			"integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+			"version": "2.0.38",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
+			"integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -15881,16 +15340,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
 			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/normalize-range": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
-			"integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -16179,6 +15628,19 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/ora/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/own-keys": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
@@ -16208,30 +15670,35 @@
 			}
 		},
 		"node_modules/p-limit": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"p-try": "^2.0.0"
+				"yocto-queue": "^0.1.0"
 			},
 			"engines": {
-				"node": ">=6"
+				"node": ">=10"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/p-locate": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-			"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"p-limit": "^2.0.0"
+				"p-limit": "^3.0.2"
 			},
 			"engines": {
-				"node": ">=6"
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/p-map": {
@@ -16266,9 +15733,9 @@
 			"license": "BlueOak-1.0.0"
 		},
 		"node_modules/package-manager-detector": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.5.0.tgz",
-			"integrity": "sha512-uBj69dVlYe/+wxj8JOpr97XfsxH/eumMt6HqjNTmJDf/6NO9s+0uxeOneIz3AsPt2m6y9PqzDzd3ATcU17MNfw==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
+			"integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
 			"license": "MIT"
 		},
 		"node_modules/pako": {
@@ -16317,26 +15784,26 @@
 			"license": "MIT"
 		},
 		"node_modules/parse5": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
-			"integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+			"integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"entities": "^6.0.0"
+				"entities": "^8.0.0"
 			},
 			"funding": {
 				"url": "https://github.com/inikulin/parse5?sponsor=1"
 			}
 		},
 		"node_modules/parse5/node_modules/entities": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-			"integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+			"integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"engines": {
-				"node": ">=0.12"
+				"node": ">=20.19.0"
 			},
 			"funding": {
 				"url": "https://github.com/fb55/entities?sponsor=1"
@@ -16417,12 +15884,12 @@
 			"license": "MIT"
 		},
 		"node_modules/path-exists": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-			"integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
 			"license": "MIT",
 			"engines": {
-				"node": ">=4"
+				"node": ">=8"
 			}
 		},
 		"node_modules/path-is-absolute": {
@@ -16477,6 +15944,7 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
 			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/pe-library": {
@@ -16599,9 +16067,9 @@
 			}
 		},
 		"node_modules/pino-std-serializers": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
-			"integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+			"integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
 			"license": "MIT"
 		},
 		"node_modules/pino/node_modules/process-warning": {
@@ -16630,17 +16098,6 @@
 				"node": ">= 6"
 			}
 		},
-		"node_modules/pkg-types": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
-			"integrity": "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==",
-			"license": "MIT",
-			"dependencies": {
-				"confbox": "^0.2.2",
-				"exsolve": "^1.0.7",
-				"pathe": "^2.0.3"
-			}
-		},
 		"node_modules/pkg-up": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
@@ -16653,14 +16110,75 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/pkg-up/node_modules/find-up": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+			"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+			"license": "MIT",
+			"dependencies": {
+				"locate-path": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/pkg-up/node_modules/locate-path": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+			"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+			"license": "MIT",
+			"dependencies": {
+				"p-locate": "^3.0.0",
+				"path-exists": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/pkg-up/node_modules/p-limit": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+			"license": "MIT",
+			"dependencies": {
+				"p-try": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/pkg-up/node_modules/p-locate": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+			"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+			"license": "MIT",
+			"dependencies": {
+				"p-limit": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/pkg-up/node_modules/path-exists": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+			"integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/playwright": {
-			"version": "1.60.0",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
-			"integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+			"version": "1.59.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+			"integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright-core": "1.60.0"
+				"playwright-core": "1.59.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -16673,9 +16191,9 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.60.0",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
-			"integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+			"version": "1.59.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+			"integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -16795,6 +16313,28 @@
 			},
 			"peerDependencies": {
 				"postcss": "^8.0.0"
+			}
+		},
+		"node_modules/postcss-import/node_modules/resolve": {
+			"version": "1.22.12",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+			"integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"is-core-module": "^2.16.1",
+				"path-parse": "^1.0.7",
+				"supports-preserve-symlinks-flag": "^1.0.0"
+			},
+			"bin": {
+				"resolve": "bin/resolve"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/postcss-js": {
@@ -16952,10 +16492,41 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/postject": {
+			"version": "1.0.0-alpha.6",
+			"resolved": "https://registry.npmjs.org/postject/-/postject-1.0.0-alpha.6.tgz",
+			"integrity": "sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"commander": "^9.4.0"
+			},
+			"bin": {
+				"postject": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/postject/node_modules/commander": {
+			"version": "9.5.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+			"integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": "^12.20.0 || >=14"
+			}
+		},
 		"node_modules/prebuild-install": {
 			"version": "7.1.3",
 			"resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
 			"integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+			"deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
 			"license": "MIT",
 			"dependencies": {
 				"detect-libc": "^2.0.0",
@@ -16989,9 +16560,9 @@
 			}
 		},
 		"node_modules/prettier": {
-			"version": "3.8.0",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.0.tgz",
-			"integrity": "sha512-yEPsovQfpxYfgWNhCfECjG5AQaO+K3dp6XERmOepyPDVqcJm+bjyCVO3pmU+nAPe0N5dDvekfGezt/EIiRe1TA==",
+			"version": "3.8.3",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+			"integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -17003,6 +16574,44 @@
 			"funding": {
 				"url": "https://github.com/prettier/prettier?sponsor=1"
 			}
+		},
+		"node_modules/pretty-format": {
+			"version": "27.5.1",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ansi-regex": "^5.0.1",
+				"ansi-styles": "^5.0.0",
+				"react-is": "^17.0.1"
+			},
+			"engines": {
+				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+			}
+		},
+		"node_modules/pretty-format/node_modules/ansi-styles": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/pretty-format/node_modules/react-is": {
+			"version": "17.0.2",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/prismjs": {
 			"version": "1.30.0",
@@ -17137,9 +16746,9 @@
 			}
 		},
 		"node_modules/pump": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
-			"integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+			"integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
 			"license": "MIT",
 			"dependencies": {
 				"end-of-stream": "^1.1.0",
@@ -17227,6 +16836,21 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/qrcode/node_modules/p-limit": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+			"license": "MIT",
+			"dependencies": {
+				"p-try": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/qrcode/node_modules/p-locate": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
@@ -17239,11 +16863,14 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/qrcode/node_modules/path-exists": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+		"node_modules/qrcode/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
 			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
 			"engines": {
 				"node": ">=8"
 			}
@@ -17303,22 +16930,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/quansync": {
-			"version": "0.2.11",
-			"resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz",
-			"integrity": "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://github.com/sponsors/antfu"
-				},
-				{
-					"type": "individual",
-					"url": "https://github.com/sponsors/sxzz"
-				}
-			],
-			"license": "MIT"
-		},
 		"node_modules/queue-microtask": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -17374,11 +16985,19 @@
 				"rc": "cli.js"
 			}
 		},
+		"node_modules/rc/node_modules/strip-json-comments": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+			"integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/react": {
 			"version": "18.3.1",
 			"resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
 			"integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"loose-envify": "^1.1.0"
@@ -17388,9 +17007,9 @@
 			}
 		},
 		"node_modules/react-diff-view": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/react-diff-view/-/react-diff-view-3.3.2.tgz",
-			"integrity": "sha512-wPVq4ktTcGOHbhnWKU/gHLtd3N2Xd+OZ/XQWcKA06dsxlSsESePAumQILwHtiak2nMCMiWcIfBpqZ5OiharUPA==",
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/react-diff-view/-/react-diff-view-3.3.3.tgz",
+			"integrity": "sha512-CPveApk6n7ZbkW7T6PoptR7LWAvD9hohTHZ7WnKnu3GZkTfUB5rvg486apPo94iYVi4fZd3Nt+rtBZ5877exoQ==",
 			"license": "MIT",
 			"dependencies": {
 				"classnames": "^2.3.2",
@@ -17408,7 +17027,6 @@
 			"version": "18.3.1",
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
 			"integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"loose-envify": "^1.1.0",
@@ -17417,6 +17035,13 @@
 			"peerDependencies": {
 				"react": "^18.3.1"
 			}
+		},
+		"node_modules/react-is": {
+			"version": "19.2.6",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.6.tgz",
+			"integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/react-markdown": {
 			"version": "10.1.0",
@@ -17469,9 +17094,9 @@
 			}
 		},
 		"node_modules/react-syntax-highlighter": {
-			"version": "16.1.0",
-			"resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-16.1.0.tgz",
-			"integrity": "sha512-E40/hBiP5rCNwkeBN1vRP+xow1X0pndinO+z3h7HLsHyjztbyjfzNWNKuAsJj+7DLam9iT4AaaOZnueCU+Nplg==",
+			"version": "16.1.1",
+			"resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-16.1.1.tgz",
+			"integrity": "sha512-PjVawBGy80C6YbC5DDZJeUjBmC7skaoEUdvfFQediQHgCL7aKyVHe57SaJGfQsloGDac+gCpTfRdtxzWWKmCXA==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/runtime": "^7.28.4",
@@ -17540,17 +17165,43 @@
 			}
 		},
 		"node_modules/readable-stream": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+			"integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
 			"license": "MIT",
 			"dependencies": {
-				"inherits": "^2.0.3",
-				"string_decoder": "^1.1.1",
-				"util-deprecate": "^1.0.1"
+				"abort-controller": "^3.0.0",
+				"buffer": "^6.0.3",
+				"events": "^3.3.0",
+				"process": "^0.11.10",
+				"string_decoder": "^1.3.0"
 			},
 			"engines": {
-				"node": ">= 6"
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			}
+		},
+		"node_modules/readable-stream/node_modules/buffer": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.2.1"
 			}
 		},
 		"node_modules/readdir-glob": {
@@ -17560,6 +17211,33 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"minimatch": "^5.1.0"
+			}
+		},
+		"node_modules/readdir-glob/node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"license": "MIT"
+		},
+		"node_modules/readdir-glob/node_modules/brace-expansion": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+			"integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/readdir-glob/node_modules/minimatch": {
+			"version": "5.1.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+			"integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/readdirp": {
@@ -17596,15 +17274,15 @@
 			}
 		},
 		"node_modules/recharts": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/recharts/-/recharts-3.6.0.tgz",
-			"integrity": "sha512-L5bjxvQRAe26RlToBAziKUB7whaGKEwD3znoM6fz3DrTowCIC/FnJYnuq1GEzB8Zv2kdTfaxQfi5GoH0tBinyg==",
+			"version": "3.8.1",
+			"resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+			"integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
 			"license": "MIT",
 			"workspaces": [
 				"www"
 			],
 			"dependencies": {
-				"@reduxjs/toolkit": "1.x.x || 2.x.x",
+				"@reduxjs/toolkit": "^1.9.0 || 2.x.x",
 				"clsx": "^2.1.1",
 				"decimal.js-light": "^2.5.1",
 				"es-toolkit": "^1.39.3",
@@ -17929,13 +17607,16 @@
 			"license": "MIT"
 		},
 		"node_modules/resolve": {
-			"version": "1.22.11",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
-			"integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+			"version": "2.0.0-next.6",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.6.tgz",
+			"integrity": "sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
+				"es-errors": "^1.3.0",
 				"is-core-module": "^2.16.1",
+				"node-exports-info": "^1.6.0",
+				"object-keys": "^1.1.1",
 				"path-parse": "^1.0.7",
 				"supports-preserve-symlinks-flag": "^1.0.0"
 			},
@@ -18052,6 +17733,59 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"node_modules/rimraf/node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/rimraf/node_modules/brace-expansion": {
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/rimraf/node_modules/glob": {
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.1.1",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			},
+			"engines": {
+				"node": "*"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/rimraf/node_modules/minimatch": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
 		"node_modules/roarr": {
 			"version": "2.15.4",
 			"resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
@@ -18072,20 +17806,20 @@
 			}
 		},
 		"node_modules/robust-predicates": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
-			"integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+			"integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
 			"license": "Unlicense"
 		},
 		"node_modules/rolldown": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.1.tgz",
-			"integrity": "sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ==",
+			"version": "1.0.0-rc.18",
+			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.18.tgz",
+			"integrity": "sha512-phmyKBpuBdRYDf4hgyynGAYn/rDDe+iZXKVJ7WX5b1zQzpLkP5oJRPGsfJuHdzPMlyyEO/4sPW6yfSx2gf7lVg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@oxc-project/types": "=0.130.0",
-				"@rolldown/pluginutils": "^1.0.0"
+				"@oxc-project/types": "=0.128.0",
+				"@rolldown/pluginutils": "1.0.0-rc.18"
 			},
 			"bin": {
 				"rolldown": "bin/cli.mjs"
@@ -18094,22 +17828,29 @@
 				"node": "^20.19.0 || >=22.12.0"
 			},
 			"optionalDependencies": {
-				"@rolldown/binding-android-arm64": "1.0.1",
-				"@rolldown/binding-darwin-arm64": "1.0.1",
-				"@rolldown/binding-darwin-x64": "1.0.1",
-				"@rolldown/binding-freebsd-x64": "1.0.1",
-				"@rolldown/binding-linux-arm-gnueabihf": "1.0.1",
-				"@rolldown/binding-linux-arm64-gnu": "1.0.1",
-				"@rolldown/binding-linux-arm64-musl": "1.0.1",
-				"@rolldown/binding-linux-ppc64-gnu": "1.0.1",
-				"@rolldown/binding-linux-s390x-gnu": "1.0.1",
-				"@rolldown/binding-linux-x64-gnu": "1.0.1",
-				"@rolldown/binding-linux-x64-musl": "1.0.1",
-				"@rolldown/binding-openharmony-arm64": "1.0.1",
-				"@rolldown/binding-wasm32-wasi": "1.0.1",
-				"@rolldown/binding-win32-arm64-msvc": "1.0.1",
-				"@rolldown/binding-win32-x64-msvc": "1.0.1"
+				"@rolldown/binding-android-arm64": "1.0.0-rc.18",
+				"@rolldown/binding-darwin-arm64": "1.0.0-rc.18",
+				"@rolldown/binding-darwin-x64": "1.0.0-rc.18",
+				"@rolldown/binding-freebsd-x64": "1.0.0-rc.18",
+				"@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.18",
+				"@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.18",
+				"@rolldown/binding-linux-arm64-musl": "1.0.0-rc.18",
+				"@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.18",
+				"@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.18",
+				"@rolldown/binding-linux-x64-gnu": "1.0.0-rc.18",
+				"@rolldown/binding-linux-x64-musl": "1.0.0-rc.18",
+				"@rolldown/binding-openharmony-arm64": "1.0.0-rc.18",
+				"@rolldown/binding-wasm32-wasi": "1.0.0-rc.18",
+				"@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.18",
+				"@rolldown/binding-win32-x64-msvc": "1.0.0-rc.18"
 			}
+		},
+		"node_modules/rolldown/node_modules/@rolldown/pluginutils": {
+			"version": "1.0.0-rc.18",
+			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.18.tgz",
+			"integrity": "sha512-CUY5Mnhe64xQBGZEEXQ5WyZwsc1JU3vAZLIxtrsBt3LO6UOb+C8GunVKqe9sT8NeWb4lqSaoJtp2xo6GxT1MNw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/roughjs": {
 			"version": "4.6.6",
@@ -18164,15 +17905,15 @@
 			}
 		},
 		"node_modules/safe-array-concat": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
-			"integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.4.tgz",
+			"integrity": "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"call-bind": "^1.0.8",
-				"call-bound": "^1.0.2",
-				"get-intrinsic": "^1.2.6",
+				"call-bind": "^1.0.9",
+				"call-bound": "^1.0.4",
+				"get-intrinsic": "^1.3.0",
 				"has-symbols": "^1.1.0",
 				"isarray": "^2.0.5"
 			},
@@ -18182,13 +17923,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
-		},
-		"node_modules/safe-array-concat/node_modules/isarray": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-			"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/safe-buffer": {
 			"version": "5.2.1",
@@ -18226,13 +17960,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
-		},
-		"node_modules/safe-push-apply/node_modules/isarray": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-			"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/safe-regex-test": {
 			"version": "1.1.0",
@@ -18277,9 +18004,9 @@
 			"license": "MIT"
 		},
 		"node_modules/sanitize-filename": {
-			"version": "1.6.3",
-			"resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
-			"integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
+			"version": "1.6.4",
+			"resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.4.tgz",
+			"integrity": "sha512-9ZyI08PsvdQl2r/bBIGubpVdR3RR9sY6RDiWFPreA21C/EFlQhmgo20UZlNjZMMZNubusLhAQozkA0Od5J21Eg==",
 			"dev": true,
 			"license": "WTFPL OR ISC",
 			"dependencies": {
@@ -18287,10 +18014,13 @@
 			}
 		},
 		"node_modules/sax": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/sax/-/sax-1.4.3.tgz",
-			"integrity": "sha512-yqYn1JhPczigF94DMS+shiDMjDowYO6y9+wB/4WgO0Y19jWYk0lQ4tuG5KI7kj4FTp1wxPj5IFfcrz/s1c3jjQ==",
-			"license": "BlueOak-1.0.0"
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+			"integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=11.0.0"
+			}
 		},
 		"node_modules/saxes": {
 			"version": "6.0.0",
@@ -18309,7 +18039,6 @@
 			"version": "0.23.2",
 			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
 			"integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"loose-envify": "^1.1.0"
@@ -18322,9 +18051,9 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/semver": {
-			"version": "7.8.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-			"integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
@@ -18526,14 +18255,14 @@
 			}
 		},
 		"node_modules/side-channel-list": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-			"integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+			"integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-errors": "^1.3.0",
-				"object-inspect": "^1.13.3"
+				"object-inspect": "^1.13.4"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -18696,13 +18425,13 @@
 			}
 		},
 		"node_modules/socks": {
-			"version": "2.8.7",
-			"resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
-			"integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+			"version": "2.8.8",
+			"resolved": "https://registry.npmjs.org/socks/-/socks-2.8.8.tgz",
+			"integrity": "sha512-NlGELfPrgX2f1TAAcz0WawlLn+0r3FyhhCRpFFK2CemXenPYvzMWWZINv3eDNo9ucdwme7oCHRY0Jnbs4aIkog==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"ip-address": "^10.0.1",
+				"ip-address": "^10.1.1",
 				"smart-buffer": "^4.2.0"
 			},
 			"engines": {
@@ -18726,9 +18455,9 @@
 			}
 		},
 		"node_modules/sonic-boom": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.0.tgz",
-			"integrity": "sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+			"integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
 			"license": "MIT",
 			"dependencies": {
 				"atomic-sleep": "^1.0.0"
@@ -18885,9 +18614,9 @@
 			"license": "MIT"
 		},
 		"node_modules/streamx": {
-			"version": "2.23.0",
-			"resolved": "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz",
-			"integrity": "sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==",
+			"version": "2.25.0",
+			"resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
+			"integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
 			"license": "MIT",
 			"dependencies": {
 				"events-universal": "^1.0.0",
@@ -18928,6 +18657,30 @@
 				"emoji-regex": "^8.0.0",
 				"is-fullwidth-code-point": "^3.0.0",
 				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/string-width-cjs/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/string-width/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
 			},
 			"engines": {
 				"node": ">=8"
@@ -19046,15 +18799,18 @@
 			}
 		},
 		"node_modules/strip-ansi": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
 			"license": "MIT",
 			"dependencies": {
-				"ansi-regex": "^5.0.1"
+				"ansi-regex": "^6.2.2"
 			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
 			}
 		},
 		"node_modules/strip-ansi-cjs": {
@@ -19068,6 +18824,18 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/strip-ansi/node_modules/ansi-regex": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
 			}
 		},
 		"node_modules/strip-indent": {
@@ -19084,12 +18852,16 @@
 			}
 		},
 		"node_modules/strip-json-comments": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-			"integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=0.10.0"
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/style-mod": {
@@ -19117,9 +18889,9 @@
 			}
 		},
 		"node_modules/stylis": {
-			"version": "4.3.6",
-			"resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
-			"integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
+			"integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
 			"license": "MIT"
 		},
 		"node_modules/sucrase": {
@@ -19205,9 +18977,9 @@
 			"license": "MIT"
 		},
 		"node_modules/tailwindcss": {
-			"version": "3.4.18",
-			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.18.tgz",
-			"integrity": "sha512-6A2rnmW5xZMdw11LYjhcI5846rt9pbLSabY5XPxo+XWdxwZaFEn47Go4NzFiHu9sNNmr/kXivP1vStfvMaK1GQ==",
+			"version": "3.4.19",
+			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
+			"integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -19242,10 +19014,46 @@
 				"node": ">=14.0.0"
 			}
 		},
+		"node_modules/tailwindcss/node_modules/glob-parent": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+			"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"is-glob": "^4.0.3"
+			},
+			"engines": {
+				"node": ">=10.13.0"
+			}
+		},
+		"node_modules/tailwindcss/node_modules/resolve": {
+			"version": "1.22.12",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+			"integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"is-core-module": "^2.16.1",
+				"path-parse": "^1.0.7",
+				"supports-preserve-symlinks-flag": "^1.0.0"
+			},
+			"bin": {
+				"resolve": "bin/resolve"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/tar": {
 			"version": "6.2.1",
 			"resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
 			"integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+			"deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -19278,7 +19086,21 @@
 			"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
 			"license": "ISC"
 		},
-		"node_modules/tar-stream": {
+		"node_modules/tar-fs/node_modules/readable-stream": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"license": "MIT",
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/tar-fs/node_modules/tar-stream": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
 			"integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
@@ -19294,12 +19116,72 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/tar-stream": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+			"integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+			"license": "MIT",
+			"dependencies": {
+				"b4a": "^1.6.4",
+				"bare-fs": "^4.5.5",
+				"fast-fifo": "^1.2.0",
+				"streamx": "^2.15.0"
+			}
+		},
+		"node_modules/tar-stream/node_modules/b4a": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+			"integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+			"license": "Apache-2.0",
+			"peerDependencies": {
+				"react-native-b4a": "*"
+			},
+			"peerDependenciesMeta": {
+				"react-native-b4a": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/tar/node_modules/minipass": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+			"integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/tar/node_modules/yallist": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/teex": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+			"integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+			"license": "MIT",
+			"dependencies": {
+				"streamx": "^2.12.5"
+			}
+		},
+		"node_modules/temp": {
+			"version": "0.9.4",
+			"resolved": "https://registry.npmjs.org/temp/-/temp-0.9.4.tgz",
+			"integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"mkdirp": "^0.5.1",
+				"rimraf": "~2.6.2"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
 		},
 		"node_modules/temp-file": {
 			"version": "3.4.0",
@@ -19328,9 +19210,9 @@
 			}
 		},
 		"node_modules/temp-file/node_modules/jsonfile": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-			"integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -19350,19 +19232,105 @@
 				"node": ">= 10.0.0"
 			}
 		},
+		"node_modules/temp/node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/temp/node_modules/brace-expansion": {
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/temp/node_modules/glob": {
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+			"dev": true,
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.1.1",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			},
+			"engines": {
+				"node": "*"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/temp/node_modules/minimatch": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+			"dev": true,
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/temp/node_modules/mkdirp": {
+			"version": "0.5.6",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+			"integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"minimist": "^1.2.6"
+			},
+			"bin": {
+				"mkdirp": "bin/cmd.js"
+			}
+		},
+		"node_modules/temp/node_modules/rimraf": {
+			"version": "2.6.3",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+			"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+			"deprecated": "Rimraf versions prior to v4 are no longer supported",
+			"dev": true,
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"glob": "^7.1.3"
+			},
+			"bin": {
+				"rimraf": "bin.js"
+			}
+		},
 		"node_modules/text-decoder": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
-			"integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+			"integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"b4a": "^1.6.4"
 			}
 		},
 		"node_modules/text-decoder/node_modules/b4a": {
-			"version": "1.7.3",
-			"resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.3.tgz",
-			"integrity": "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==",
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+			"integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
 			"license": "Apache-2.0",
 			"peerDependencies": {
 				"react-native-b4a": "*"
@@ -19445,9 +19413,9 @@
 			"license": "MIT"
 		},
 		"node_modules/tinyexec": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
-			"integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+			"integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
@@ -19470,24 +19438,6 @@
 				"url": "https://github.com/sponsors/SuperchupuDev"
 			}
 		},
-		"node_modules/tinyglobby/node_modules/fdir": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12.0.0"
-			},
-			"peerDependencies": {
-				"picomatch": "^3 || ^4"
-			},
-			"peerDependenciesMeta": {
-				"picomatch": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/tinyrainbow": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
@@ -19499,22 +19449,22 @@
 			}
 		},
 		"node_modules/tldts": {
-			"version": "7.0.19",
-			"resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.19.tgz",
-			"integrity": "sha512-8PWx8tvC4jDB39BQw1m4x8y5MH1BcQ5xHeL2n7UVFulMPH/3Q0uiamahFJ3lXA0zO2SUyRXuVVbWSDmstlt9YA==",
+			"version": "7.0.30",
+			"resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.30.tgz",
+			"integrity": "sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"tldts-core": "^7.0.19"
+				"tldts-core": "^7.0.30"
 			},
 			"bin": {
 				"tldts": "bin/cli.js"
 			}
 		},
 		"node_modules/tldts-core": {
-			"version": "7.0.19",
-			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.19.tgz",
-			"integrity": "sha512-lJX2dEWx0SGH4O6p+7FPwYmJ/bu1JbcGJ8RLaG9b7liIgZ85itUVEPbMtWRVrde/0fnDPEPHW10ZsKW3kVsE9A==",
+			"version": "7.0.30",
+			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.30.tgz",
+			"integrity": "sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -19569,9 +19519,9 @@
 			}
 		},
 		"node_modules/tough-cookie": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
-			"integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+			"integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
@@ -19800,16 +19750,16 @@
 			}
 		},
 		"node_modules/typescript-eslint": {
-			"version": "8.59.3",
-			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.3.tgz",
-			"integrity": "sha512-KgusgyDgG4LI8Ih/sWaCtZ06tckLAS5CvT5A4D1Q7bYVoAAyzwiZvE4BmwDHkhRVkvhRBepKeASoFzQetha7Fg==",
+			"version": "8.59.2",
+			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.2.tgz",
+			"integrity": "sha512-pJw051uomb3ZeCzGTpRb8RbEqB5Y4WWet8gl/GcTlU35BSx0PVdZ86/bqkQCyKKuraVQEK7r6kBHQXF+fBhkoQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/eslint-plugin": "8.59.3",
-				"@typescript-eslint/parser": "8.59.3",
-				"@typescript-eslint/typescript-estree": "8.59.3",
-				"@typescript-eslint/utils": "8.59.3"
+				"@typescript-eslint/eslint-plugin": "8.59.2",
+				"@typescript-eslint/parser": "8.59.2",
+				"@typescript-eslint/typescript-estree": "8.59.2",
+				"@typescript-eslint/utils": "8.59.2"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -19827,12 +19777,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
 			"integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
-			"license": "MIT"
-		},
-		"node_modules/ufo": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
-			"integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
 			"license": "MIT"
 		},
 		"node_modules/unbox-primitive": {
@@ -19955,9 +19899,9 @@
 			}
 		},
 		"node_modules/unist-util-visit": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
-			"integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+			"integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/unist": "^3.0.0",
@@ -20019,9 +19963,9 @@
 			}
 		},
 		"node_modules/update-browserslist-db": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.4.tgz",
-			"integrity": "sha512-q0SPT4xyU84saUX+tomz1WLkxUbuaJnR1xWt17M7fJtEJigJeWUNGUqrauFXsHnqev9y9JTRGwk13tFBuKby4A==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+			"integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
 			"dev": true,
 			"funding": [
 				{
@@ -20082,9 +20026,9 @@
 			"license": "MIT"
 		},
 		"node_modules/uuid": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-			"integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+			"version": "11.1.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+			"integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
 			"funding": [
 				"https://github.com/sponsors/broofa",
 				"https://github.com/sponsors/ctavan"
@@ -20175,16 +20119,16 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "8.0.13",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-8.0.13.tgz",
-			"integrity": "sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==",
+			"version": "8.0.11",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-8.0.11.tgz",
+			"integrity": "sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"lightningcss": "^1.32.0",
 				"picomatch": "^4.0.4",
 				"postcss": "^8.5.14",
-				"rolldown": "1.0.1",
+				"rolldown": "1.0.0-rc.18",
 				"tinyglobby": "^0.2.16"
 			},
 			"bin": {
@@ -20253,19 +20197,19 @@
 			}
 		},
 		"node_modules/vitest": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
-			"integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+			"integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/expect": "4.1.6",
-				"@vitest/mocker": "4.1.6",
-				"@vitest/pretty-format": "4.1.6",
-				"@vitest/runner": "4.1.6",
-				"@vitest/snapshot": "4.1.6",
-				"@vitest/spy": "4.1.6",
-				"@vitest/utils": "4.1.6",
+				"@vitest/expect": "4.1.5",
+				"@vitest/mocker": "4.1.5",
+				"@vitest/pretty-format": "4.1.5",
+				"@vitest/runner": "4.1.5",
+				"@vitest/snapshot": "4.1.5",
+				"@vitest/spy": "4.1.5",
+				"@vitest/utils": "4.1.5",
 				"es-module-lexer": "^2.0.0",
 				"expect-type": "^1.3.0",
 				"magic-string": "^0.30.21",
@@ -20293,12 +20237,12 @@
 				"@edge-runtime/vm": "*",
 				"@opentelemetry/api": "^1.9.0",
 				"@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-				"@vitest/browser-playwright": "4.1.6",
-				"@vitest/browser-preview": "4.1.6",
-				"@vitest/browser-webdriverio": "4.1.6",
-				"@vitest/coverage-istanbul": "4.1.6",
-				"@vitest/coverage-v8": "4.1.6",
-				"@vitest/ui": "4.1.6",
+				"@vitest/browser-playwright": "4.1.5",
+				"@vitest/browser-preview": "4.1.5",
+				"@vitest/browser-webdriverio": "4.1.5",
+				"@vitest/coverage-istanbul": "4.1.5",
+				"@vitest/coverage-v8": "4.1.5",
+				"@vitest/ui": "4.1.5",
 				"happy-dom": "*",
 				"jsdom": "*",
 				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -20386,9 +20330,9 @@
 			"license": "MIT"
 		},
 		"node_modules/vscode-uri": {
-			"version": "3.0.8",
-			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.8.tgz",
-			"integrity": "sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+			"integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
 			"license": "MIT"
 		},
 		"node_modules/w3c-keyname": {
@@ -20440,26 +20384,13 @@
 			}
 		},
 		"node_modules/webidl-conversions": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.0.tgz",
-			"integrity": "sha512-n4W4YFyz5JzOfQeA8oN7dUYpR+MBP3PIUsn2jLjWXwK5ASUzt0Jc/A5sAUZoCYFJRGF0FBKJ+1JjN43rNdsQzA==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+			"integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=20"
-			}
-		},
-		"node_modules/whatwg-encoding": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
-			"integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"iconv-lite": "0.6.3"
-			},
-			"engines": {
-				"node": ">=18"
 			}
 		},
 		"node_modules/whatwg-mimetype": {
@@ -20549,13 +20480,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/which-builtin-type/node_modules/isarray": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-			"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/which-collection": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
@@ -20582,9 +20506,9 @@
 			"license": "ISC"
 		},
 		"node_modules/which-typed-array": {
-			"version": "1.1.19",
-			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
-			"integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
+			"version": "1.1.20",
+			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+			"integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -20641,18 +20565,17 @@
 			}
 		},
 		"node_modules/wrap-ansi": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-			"dev": true,
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+			"integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
 			"license": "MIT",
 			"dependencies": {
-				"ansi-styles": "^4.0.0",
-				"string-width": "^4.1.0",
-				"strip-ansi": "^6.0.0"
+				"ansi-styles": "^6.1.0",
+				"string-width": "^5.0.1",
+				"strip-ansi": "^7.0.1"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=12"
 			},
 			"funding": {
 				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
@@ -20676,6 +20599,53 @@
 				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
 			}
 		},
+		"node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/ansi-styles": {
+			"version": "6.2.3",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+			"integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/emoji-regex": {
+			"version": "9.2.2",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+			"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+			"license": "MIT"
+		},
+		"node_modules/wrap-ansi/node_modules/string-width": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+			"integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+			"license": "MIT",
+			"dependencies": {
+				"eastasianwidth": "^0.2.0",
+				"emoji-regex": "^9.2.2",
+				"strip-ansi": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -20683,9 +20653,9 @@
 			"license": "ISC"
 		},
 		"node_modules/ws": {
-			"version": "8.18.3",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-			"integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+			"integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=10.0.0"
@@ -20764,9 +20734,9 @@
 			"license": "ISC"
 		},
 		"node_modules/yaml": {
-			"version": "2.9.0",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-			"integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+			"version": "2.8.4",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
+			"integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -20819,6 +20789,16 @@
 				"fd-slicer": "~1.1.0"
 			}
 		},
+		"node_modules/yauzl/node_modules/buffer-crc32": {
+			"version": "0.2.13",
+			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+			"integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "*"
+			}
+		},
 		"node_modules/yocto-queue": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -20846,50 +20826,10 @@
 				"node": ">= 14"
 			}
 		},
-		"node_modules/zip-stream/node_modules/buffer": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.2.1"
-			}
-		},
-		"node_modules/zip-stream/node_modules/readable-stream": {
-			"version": "4.7.0",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
-			"integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
-			"license": "MIT",
-			"dependencies": {
-				"abort-controller": "^3.0.0",
-				"buffer": "^6.0.3",
-				"events": "^3.3.0",
-				"process": "^0.11.10",
-				"string_decoder": "^1.3.0"
-			},
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			}
-		},
 		"node_modules/zod": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-4.2.1.tgz",
-			"integrity": "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw==",
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+			"integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
@@ -20910,9 +20850,9 @@
 			}
 		},
 		"node_modules/zustand": {
-			"version": "5.0.11",
-			"resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.11.tgz",
-			"integrity": "sha512-fdZY+dk7zn/vbWNCYmzZULHRrss0jx5pPFiOuMZ/5HJN6Yv3u+1Wswy/4MpZEkEGhtNH+pwxZB8OKgUBPzYAGg==",
+			"version": "5.0.13",
+			"resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.13.tgz",
+			"integrity": "sha512-efI2tVaVQPqtOh114loML/Z80Y4NP3yc+Ff0fYiZJPauNeWZeIp/bRFD7I9bfmCOYBh/PHxlglQ9+wvlwnPikQ==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=12.20.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,6 +70,7 @@
 				"recharts": "^3.6.0",
 				"rehype-raw": "^7.0.0",
 				"rehype-slug": "^6.0.0",
+				"remark-breaks": "^4.0.0",
 				"remark-frontmatter": "^5.0.0",
 				"remark-gfm": "^4.0.1",
 				"semver": "^7.7.4",
@@ -140,9 +141,9 @@
 			}
 		},
 		"node_modules/@acemir/cssom": {
-			"version": "0.9.31",
-			"resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
-			"integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+			"version": "0.9.28",
+			"resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.28.tgz",
+			"integrity": "sha512-LuS6IVEivI75vKN8S04qRD+YySP0RmU/cV8UNukhQZvprxF+76Z43TNo/a08eCodaGhT1Us8etqS1ZRY9/Or0A==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -179,24 +180,33 @@
 				"url": "https://github.com/sponsors/antfu"
 			}
 		},
+		"node_modules/@antfu/utils": {
+			"version": "9.3.0",
+			"resolved": "https://registry.npmjs.org/@antfu/utils/-/utils-9.3.0.tgz",
+			"integrity": "sha512-9hFT4RauhcUzqOE4f1+frMKLZrgNog5b06I7VmZQV1BkvwvqrbC8EBZf3L1eEL2AKb6rNKjER0sEvJiSP1FXEA==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/antfu"
+			}
+		},
 		"node_modules/@asamuzakjp/css-color": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
-			"integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.0.tgz",
+			"integrity": "sha512-9xiBAtLn4aNsa4mDnpovJvBn72tNEIACyvlqaNJ+ADemR+yeMJWnBudOi2qGDviJa7SwcDOU/TRh5dnET7qk0w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@csstools/css-calc": "^3.0.0",
-				"@csstools/css-color-parser": "^4.0.1",
-				"@csstools/css-parser-algorithms": "^4.0.0",
-				"@csstools/css-tokenizer": "^4.0.0",
-				"lru-cache": "^11.2.5"
+				"@csstools/css-calc": "^2.1.4",
+				"@csstools/css-color-parser": "^3.1.0",
+				"@csstools/css-parser-algorithms": "^3.0.5",
+				"@csstools/css-tokenizer": "^3.0.4",
+				"lru-cache": "^11.2.2"
 			}
 		},
 		"node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
-			"version": "11.3.6",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
-			"integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
+			"version": "11.2.4",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
+			"integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
 			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"engines": {
@@ -204,9 +214,9 @@
 			}
 		},
 		"node_modules/@asamuzakjp/dom-selector": {
-			"version": "6.8.1",
-			"resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
-			"integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
+			"version": "6.7.6",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.7.6.tgz",
+			"integrity": "sha512-hBaJER6A9MpdG3WgdlOolHmbOYvSk46y7IQN/1+iqiCuUu6iWdQrs9DGKF8ocqsEqWujWf/V7b7vaDgiUmIvUg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -214,13 +224,13 @@
 				"bidi-js": "^1.0.3",
 				"css-tree": "^3.1.0",
 				"is-potential-custom-element-name": "^1.0.1",
-				"lru-cache": "^11.2.6"
+				"lru-cache": "^11.2.4"
 			}
 		},
 		"node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
-			"version": "11.3.6",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
-			"integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
+			"version": "11.2.4",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
+			"integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
 			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"engines": {
@@ -235,13 +245,13 @@
 			"license": "MIT"
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-			"integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+			"integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.28.5",
+				"@babel/helper-validator-identifier": "^7.27.1",
 				"js-tokens": "^4.0.0",
 				"picocolors": "^1.1.1"
 			},
@@ -250,9 +260,9 @@
 			}
 		},
 		"node_modules/@babel/compat-data": {
-			"version": "7.29.3",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
-			"integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
+			"version": "7.28.5",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.5.tgz",
+			"integrity": "sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -260,21 +270,21 @@
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-			"integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+			"version": "7.28.5",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
+			"integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/code-frame": "^7.29.0",
-				"@babel/generator": "^7.29.0",
-				"@babel/helper-compilation-targets": "^7.28.6",
-				"@babel/helper-module-transforms": "^7.28.6",
-				"@babel/helpers": "^7.28.6",
-				"@babel/parser": "^7.29.0",
-				"@babel/template": "^7.28.6",
-				"@babel/traverse": "^7.29.0",
-				"@babel/types": "^7.29.0",
+				"@babel/code-frame": "^7.27.1",
+				"@babel/generator": "^7.28.5",
+				"@babel/helper-compilation-targets": "^7.27.2",
+				"@babel/helper-module-transforms": "^7.28.3",
+				"@babel/helpers": "^7.28.4",
+				"@babel/parser": "^7.28.5",
+				"@babel/template": "^7.27.2",
+				"@babel/traverse": "^7.28.5",
+				"@babel/types": "^7.28.5",
 				"@jridgewell/remapping": "^2.3.5",
 				"convert-source-map": "^2.0.0",
 				"debug": "^4.1.0",
@@ -301,14 +311,14 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.29.1",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-			"integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+			"version": "7.28.5",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.5.tgz",
+			"integrity": "sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/parser": "^7.29.0",
-				"@babel/types": "^7.29.0",
+				"@babel/parser": "^7.28.5",
+				"@babel/types": "^7.28.5",
 				"@jridgewell/gen-mapping": "^0.3.12",
 				"@jridgewell/trace-mapping": "^0.3.28",
 				"jsesc": "^3.0.2"
@@ -318,13 +328,13 @@
 			}
 		},
 		"node_modules/@babel/helper-compilation-targets": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-			"integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+			"version": "7.27.2",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
+			"integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/compat-data": "^7.28.6",
+				"@babel/compat-data": "^7.27.2",
 				"@babel/helper-validator-option": "^7.27.1",
 				"browserslist": "^4.24.0",
 				"lru-cache": "^5.1.1",
@@ -355,29 +365,29 @@
 			}
 		},
 		"node_modules/@babel/helper-module-imports": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-			"integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
+			"integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/traverse": "^7.28.6",
-				"@babel/types": "^7.28.6"
+				"@babel/traverse": "^7.27.1",
+				"@babel/types": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-module-transforms": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-			"integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+			"version": "7.28.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
+			"integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-module-imports": "^7.28.6",
-				"@babel/helper-validator-identifier": "^7.28.5",
-				"@babel/traverse": "^7.28.6"
+				"@babel/helper-module-imports": "^7.27.1",
+				"@babel/helper-validator-identifier": "^7.27.1",
+				"@babel/traverse": "^7.28.3"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -417,14 +427,14 @@
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.29.2",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-			"integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+			"version": "7.28.4",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
+			"integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/template": "^7.28.6",
-				"@babel/types": "^7.29.0"
+				"@babel/template": "^7.27.2",
+				"@babel/types": "^7.28.4"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -447,42 +457,42 @@
 			}
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.29.2",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
-			"integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+			"version": "7.28.4",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+			"integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/template": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-			"integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+			"version": "7.27.2",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
+			"integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/code-frame": "^7.28.6",
-				"@babel/parser": "^7.28.6",
-				"@babel/types": "^7.28.6"
+				"@babel/code-frame": "^7.27.1",
+				"@babel/parser": "^7.27.2",
+				"@babel/types": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-			"integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+			"version": "7.28.5",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.5.tgz",
+			"integrity": "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/code-frame": "^7.29.0",
-				"@babel/generator": "^7.29.0",
+				"@babel/code-frame": "^7.27.1",
+				"@babel/generator": "^7.28.5",
 				"@babel/helper-globals": "^7.28.0",
-				"@babel/parser": "^7.29.0",
-				"@babel/template": "^7.28.6",
-				"@babel/types": "^7.29.0",
+				"@babel/parser": "^7.28.5",
+				"@babel/template": "^7.27.2",
+				"@babel/types": "^7.28.5",
 				"debug": "^4.3.1"
 			},
 			"engines": {
@@ -514,46 +524,48 @@
 			}
 		},
 		"node_modules/@braintree/sanitize-url": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
-			"integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.1.tgz",
+			"integrity": "sha512-i1L7noDNxtFyL5DmZafWy1wRVhGehQmzZaz1HiN5e7iylJMSZR7ekOV7NsIqa5qBldlLrsKv4HbgFUVlQrz8Mw==",
 			"license": "MIT"
 		},
 		"node_modules/@chevrotain/cst-dts-gen": {
-			"version": "12.0.0",
-			"resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-12.0.0.tgz",
-			"integrity": "sha512-fSL4KXjTl7cDgf0B5Rip9Q05BOrYvkJV/RrBTE/bKDN096E4hN/ySpcBK5B24T76dlQ2i32Zc3PAE27jFnFrKg==",
+			"version": "11.0.3",
+			"resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-11.0.3.tgz",
+			"integrity": "sha512-BvIKpRLeS/8UbfxXxgC33xOumsacaeCKAjAeLyOn7Pcp95HiRbrpl14S+9vaZLolnbssPIUuiUd8IvgkRyt6NQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@chevrotain/gast": "12.0.0",
-				"@chevrotain/types": "12.0.0"
+				"@chevrotain/gast": "11.0.3",
+				"@chevrotain/types": "11.0.3",
+				"lodash-es": "4.17.21"
 			}
 		},
 		"node_modules/@chevrotain/gast": {
-			"version": "12.0.0",
-			"resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-12.0.0.tgz",
-			"integrity": "sha512-1ne/m3XsIT8aEdrvT33so0GUC+wkctpUPK6zU9IlOyJLUbR0rg4G7ZiApiJbggpgPir9ERy3FRjT6T7lpgetnQ==",
+			"version": "11.0.3",
+			"resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-11.0.3.tgz",
+			"integrity": "sha512-+qNfcoNk70PyS/uxmj3li5NiECO+2YKZZQMbmjTqRI3Qchu8Hig/Q9vgkHpI3alNjr7M+a2St5pw5w5F6NL5/Q==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@chevrotain/types": "12.0.0"
+				"@chevrotain/types": "11.0.3",
+				"lodash-es": "4.17.21"
 			}
 		},
 		"node_modules/@chevrotain/regexp-to-ast": {
-			"version": "12.0.0",
-			"resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-12.0.0.tgz",
-			"integrity": "sha512-p+EW9MaJwgaHguhoqwOtx/FwuGr+DnNn857sXWOi/mClXIkPGl3rn7hGNWvo31HA3vyeQxjqe+H36yZJwYU8cA==",
+			"version": "11.0.3",
+			"resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-11.0.3.tgz",
+			"integrity": "sha512-1fMHaBZxLFvWI067AVbGJav1eRY7N8DDvYCTwGBiE/ytKBgP8azTdgyrKyWZ9Mfh09eHWb5PgTSO8wi7U824RA==",
 			"license": "Apache-2.0"
 		},
 		"node_modules/@chevrotain/types": {
-			"version": "12.0.0",
-			"resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-12.0.0.tgz",
-			"integrity": "sha512-S+04vjFQKeuYw0/eW3U52LkAHQsB1ASxsPGsLPUyQgrZ2iNNibQrsidruDzjEX2JYfespXMG0eZmXlhA6z7nWA==",
+			"version": "11.0.3",
+			"resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.0.3.tgz",
+			"integrity": "sha512-gsiM3G8b58kZC2HaWR50gu6Y1440cHiJ+i3JUvcp/35JchYejb2+5MVeJK0iKThYpAa/P2PYFV4hoi44HD+aHQ==",
 			"license": "Apache-2.0"
 		},
 		"node_modules/@chevrotain/utils": {
-			"version": "12.0.0",
-			"resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-12.0.0.tgz",
-			"integrity": "sha512-lB59uJoaGIfOOL9knQqQRfhl9g7x8/wqFkp13zTdkRu1huG9kg6IJs1O8hqj9rs6h7orGxHJUKb+mX3rPbWGhA==",
+			"version": "11.0.3",
+			"resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.0.3.tgz",
+			"integrity": "sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ==",
 			"license": "Apache-2.0"
 		},
 		"node_modules/@codemirror/autocomplete": {
@@ -724,9 +736,9 @@
 			}
 		},
 		"node_modules/@codemirror/view": {
-			"version": "6.42.1",
-			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.42.1.tgz",
-			"integrity": "sha512-ToN3oFc0nsxNUYVF5P0ztLgbC4UPPjPtA9aKYhkOKQaZASpOUo6ISXyQLP66ctVwlDc+j6Jv0uK5IFALkiXztg==",
+			"version": "6.43.0",
+			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.0.tgz",
+			"integrity": "sha512-V7ZCLQO3Jus9hzh2jVCCPW3mO4IBMr43O37PqSUYautJSnnJF41YlgLw21x0fLJTYvJ+Vkm6Gp+qKGH9pltgXA==",
 			"license": "MIT",
 			"dependencies": {
 				"@codemirror/state": "^6.6.0",
@@ -736,9 +748,9 @@
 			}
 		},
 		"node_modules/@csstools/color-helpers": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
-			"integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+			"integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
 			"dev": true,
 			"funding": [
 				{
@@ -752,13 +764,13 @@
 			],
 			"license": "MIT-0",
 			"engines": {
-				"node": ">=20.19.0"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@csstools/css-calc": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
-			"integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+			"integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -772,17 +784,17 @@
 			],
 			"license": "MIT",
 			"engines": {
-				"node": ">=20.19.0"
+				"node": ">=18"
 			},
 			"peerDependencies": {
-				"@csstools/css-parser-algorithms": "^4.0.0",
-				"@csstools/css-tokenizer": "^4.0.0"
+				"@csstools/css-parser-algorithms": "^3.0.5",
+				"@csstools/css-tokenizer": "^3.0.4"
 			}
 		},
 		"node_modules/@csstools/css-color-parser": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
-			"integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+			"integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
 			"dev": true,
 			"funding": [
 				{
@@ -796,21 +808,21 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"@csstools/color-helpers": "^6.0.2",
-				"@csstools/css-calc": "^3.2.0"
+				"@csstools/color-helpers": "^5.1.0",
+				"@csstools/css-calc": "^2.1.4"
 			},
 			"engines": {
-				"node": ">=20.19.0"
+				"node": ">=18"
 			},
 			"peerDependencies": {
-				"@csstools/css-parser-algorithms": "^4.0.0",
-				"@csstools/css-tokenizer": "^4.0.0"
+				"@csstools/css-parser-algorithms": "^3.0.5",
+				"@csstools/css-tokenizer": "^3.0.4"
 			}
 		},
 		"node_modules/@csstools/css-parser-algorithms": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
-			"integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+			"integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -824,16 +836,16 @@
 			],
 			"license": "MIT",
 			"engines": {
-				"node": ">=20.19.0"
+				"node": ">=18"
 			},
 			"peerDependencies": {
-				"@csstools/css-tokenizer": "^4.0.0"
+				"@csstools/css-tokenizer": "^3.0.4"
 			}
 		},
 		"node_modules/@csstools/css-syntax-patches-for-csstree": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
-			"integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+			"version": "1.0.20",
+			"resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.20.tgz",
+			"integrity": "sha512-8BHsjXfSciZxjmHQOuVdW2b8WLUPts9a+mfL13/PzEviufUEW2xnvQuOlKs9dRBHgRqJ53SF/DUoK9+MZk72oQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -846,19 +858,14 @@
 				}
 			],
 			"license": "MIT-0",
-			"peerDependencies": {
-				"css-tree": "^3.2.1"
-			},
-			"peerDependenciesMeta": {
-				"css-tree": {
-					"optional": true
-				}
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/@csstools/css-tokenizer": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
-			"integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+			"integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
 			"dev": true,
 			"funding": [
 				{
@@ -872,7 +879,7 @@
 			],
 			"license": "MIT",
 			"engines": {
-				"node": ">=20.19.0"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@dagrejs/dagre": {
@@ -929,17 +936,10 @@
 				"node": ">=10.12.0"
 			}
 		},
-		"node_modules/@electron/asar/node_modules/balanced-match": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/@electron/asar/node_modules/brace-expansion": {
-			"version": "1.1.14",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -957,32 +957,10 @@
 				"node": ">= 6"
 			}
 		},
-		"node_modules/@electron/asar/node_modules/glob": {
-			"version": "7.2.3",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.1.1",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
-			},
-			"engines": {
-				"node": "*"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
 		"node_modules/@electron/asar/node_modules/minimatch": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -1092,79 +1070,6 @@
 				"node": ">= 22.12.0"
 			}
 		},
-		"node_modules/@electron/osx-sign": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/@electron/osx-sign/-/osx-sign-1.3.3.tgz",
-			"integrity": "sha512-KZ8mhXvWv2rIEgMbWZ4y33bDHyUKMXnx4M0sTyPNK/vcB81ImdeY9Ggdqy0SWbMDgmbqyQ+phgejh6V3R2QuSg==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"compare-version": "^0.1.2",
-				"debug": "^4.3.4",
-				"fs-extra": "^10.0.0",
-				"isbinaryfile": "^4.0.8",
-				"minimist": "^1.2.6",
-				"plist": "^3.0.5"
-			},
-			"bin": {
-				"electron-osx-flat": "bin/electron-osx-flat.js",
-				"electron-osx-sign": "bin/electron-osx-sign.js"
-			},
-			"engines": {
-				"node": ">=12.0.0"
-			}
-		},
-		"node_modules/@electron/osx-sign/node_modules/fs-extra": {
-			"version": "10.1.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-			"integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"graceful-fs": "^4.2.0",
-				"jsonfile": "^6.0.1",
-				"universalify": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@electron/osx-sign/node_modules/isbinaryfile": {
-			"version": "4.0.10",
-			"resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.10.tgz",
-			"integrity": "sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 8.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/gjtorikian/"
-			}
-		},
-		"node_modules/@electron/osx-sign/node_modules/jsonfile": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"universalify": "^2.0.0"
-			},
-			"optionalDependencies": {
-				"graceful-fs": "^4.1.6"
-			}
-		},
-		"node_modules/@electron/osx-sign/node_modules/universalify": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 10.0.0"
-			}
-		},
 		"node_modules/@electron/rebuild": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-4.0.4.tgz",
@@ -1184,6 +1089,29 @@
 			},
 			"engines": {
 				"node": ">=22.12.0"
+			}
+		},
+		"node_modules/@electron/rebuild/node_modules/@malept/cross-spawn-promise": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-2.0.0.tgz",
+			"integrity": "sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://github.com/sponsors/malept"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/subscription/pkg/npm-.malept-cross-spawn-promise?utm_medium=referral&utm_source=npm_fund"
+				}
+			],
+			"license": "Apache-2.0",
+			"dependencies": {
+				"cross-spawn": "^7.0.1"
+			},
+			"engines": {
+				"node": ">= 12.13.0"
 			}
 		},
 		"node_modules/@electron/rebuild/node_modules/abbrev": {
@@ -1214,6 +1142,16 @@
 			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": ">=20"
+			}
+		},
+		"node_modules/@electron/rebuild/node_modules/minipass": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
 			}
 		},
 		"node_modules/@electron/rebuild/node_modules/minizlib": {
@@ -1334,162 +1272,6 @@
 			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": ">=18"
-			}
-		},
-		"node_modules/@electron/universal": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@electron/universal/-/universal-2.0.3.tgz",
-			"integrity": "sha512-Wn9sPYIVFRFl5HmwMJkARCCf7rqK/EurkfQ/rJZ14mHP3iYTjZSIOSVonEAnhWeAXwtw7zOekGRlc6yTtZ0t+g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@electron/asar": "^3.3.1",
-				"@malept/cross-spawn-promise": "^2.0.0",
-				"debug": "^4.3.1",
-				"dir-compare": "^4.2.0",
-				"fs-extra": "^11.1.1",
-				"minimatch": "^9.0.3",
-				"plist": "^3.1.0"
-			},
-			"engines": {
-				"node": ">=16.4"
-			}
-		},
-		"node_modules/@electron/universal/node_modules/balanced-match": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@electron/universal/node_modules/brace-expansion": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-			"integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0"
-			}
-		},
-		"node_modules/@electron/universal/node_modules/fs-extra": {
-			"version": "11.3.5",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
-			"integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"graceful-fs": "^4.2.0",
-				"jsonfile": "^6.0.1",
-				"universalify": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=14.14"
-			}
-		},
-		"node_modules/@electron/universal/node_modules/jsonfile": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"universalify": "^2.0.0"
-			},
-			"optionalDependencies": {
-				"graceful-fs": "^4.1.6"
-			}
-		},
-		"node_modules/@electron/universal/node_modules/minimatch": {
-			"version": "9.0.9",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-			"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^2.0.2"
-			},
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/@electron/universal/node_modules/universalify": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 10.0.0"
-			}
-		},
-		"node_modules/@electron/windows-sign": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@electron/windows-sign/-/windows-sign-1.2.2.tgz",
-			"integrity": "sha512-dfZeox66AvdPtb2lD8OsIIQh12Tp0GNCRUDfBHIKGpbmopZto2/A8nSpYYLoedPIHpqkeblZ/k8OV0Gy7PYuyQ==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"cross-dirname": "^0.1.0",
-				"debug": "^4.3.4",
-				"fs-extra": "^11.1.1",
-				"minimist": "^1.2.8",
-				"postject": "^1.0.0-alpha.6"
-			},
-			"bin": {
-				"electron-windows-sign": "bin/electron-windows-sign.js"
-			},
-			"engines": {
-				"node": ">=14.14"
-			}
-		},
-		"node_modules/@electron/windows-sign/node_modules/fs-extra": {
-			"version": "11.3.5",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
-			"integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"graceful-fs": "^4.2.0",
-				"jsonfile": "^6.0.1",
-				"universalify": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=14.14"
-			}
-		},
-		"node_modules/@electron/windows-sign/node_modules/jsonfile": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"universalify": "^2.0.0"
-			},
-			"optionalDependencies": {
-				"graceful-fs": "^4.1.6"
-			}
-		},
-		"node_modules/@electron/windows-sign/node_modules/universalify": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">= 10.0.0"
 			}
 		},
 		"node_modules/@emnapi/core": {
@@ -2014,31 +1796,24 @@
 			}
 		},
 		"node_modules/@eslint/config-array": {
-			"version": "0.21.2",
-			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
-			"integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+			"version": "0.21.1",
+			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
+			"integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@eslint/object-schema": "^2.1.7",
 				"debug": "^4.3.1",
-				"minimatch": "^3.1.5"
+				"minimatch": "^3.1.2"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			}
 		},
-		"node_modules/@eslint/config-array/node_modules/balanced-match": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/@eslint/config-array/node_modules/brace-expansion": {
-			"version": "1.1.14",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2047,9 +1822,9 @@
 			}
 		},
 		"node_modules/@eslint/config-array/node_modules/minimatch": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -2086,20 +1861,20 @@
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
-			"version": "3.3.5",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
-			"integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.3.tgz",
+			"integrity": "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"ajv": "^6.14.0",
+				"ajv": "^6.12.4",
 				"debug": "^4.3.2",
 				"espree": "^10.0.1",
 				"globals": "^14.0.0",
 				"ignore": "^5.2.0",
 				"import-fresh": "^3.2.1",
 				"js-yaml": "^4.1.1",
-				"minimatch": "^3.1.5",
+				"minimatch": "^3.1.2",
 				"strip-json-comments": "^3.1.1"
 			},
 			"engines": {
@@ -2109,17 +1884,10 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
-		"node_modules/@eslint/eslintrc/node_modules/balanced-match": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-			"version": "1.1.14",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2151,9 +1919,9 @@
 			}
 		},
 		"node_modules/@eslint/eslintrc/node_modules/minimatch": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -2163,10 +1931,23 @@
 				"node": "*"
 			}
 		},
+		"node_modules/@eslint/eslintrc/node_modules/strip-json-comments": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/@eslint/js": {
-			"version": "9.39.4",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
-			"integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+			"version": "9.39.2",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.2.tgz",
+			"integrity": "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -2200,24 +1981,6 @@
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			}
 		},
-		"node_modules/@exodus/bytes": {
-			"version": "1.15.0",
-			"resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
-			"integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-			},
-			"peerDependencies": {
-				"@noble/hashes": "^1.8.0 || ^2.0.0"
-			},
-			"peerDependenciesMeta": {
-				"@noble/hashes": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/@fastify/accept-negotiator": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@fastify/accept-negotiator/-/accept-negotiator-1.1.0.tgz",
@@ -2239,9 +2002,9 @@
 			}
 		},
 		"node_modules/@fastify/ajv-compiler/node_modules/ajv": {
-			"version": "8.20.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-			"integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+			"version": "8.17.1",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
 			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
@@ -2255,9 +2018,9 @@
 			}
 		},
 		"node_modules/@fastify/ajv-compiler/node_modules/ajv/node_modules/fast-uri": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-			"integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+			"integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
 			"funding": [
 				{
 					"type": "github",
@@ -2364,6 +2127,27 @@
 				"@opentelemetry/api": "^1.3.0"
 			}
 		},
+		"node_modules/@fastify/otel/node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/@fastify/otel/node_modules/brace-expansion": {
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
 		"node_modules/@fastify/otel/node_modules/import-in-the-middle": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-2.0.6.tgz",
@@ -2374,6 +2158,21 @@
 				"acorn-import-attributes": "^1.9.5",
 				"cjs-module-lexer": "^2.2.0",
 				"module-details-from-path": "^1.0.4"
+			}
+		},
+		"node_modules/@fastify/otel/node_modules/minimatch": {
+			"version": "10.2.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"brace-expansion": "^5.0.5"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/@fastify/rate-limit": {
@@ -2400,6 +2199,18 @@
 				"mime": "^3.0.0"
 			}
 		},
+		"node_modules/@fastify/send/node_modules/mime": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+			"integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+			"license": "MIT",
+			"bin": {
+				"mime": "cli.js"
+			},
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
 		"node_modules/@fastify/static": {
 			"version": "7.0.4",
 			"resolved": "https://registry.npmjs.org/@fastify/static/-/static-7.0.4.tgz",
@@ -2412,6 +2223,50 @@
 				"fastify-plugin": "^4.0.0",
 				"fastq": "^1.17.0",
 				"glob": "^10.3.4"
+			}
+		},
+		"node_modules/@fastify/static/node_modules/glob": {
+			"version": "10.5.0",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+			"integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+			"license": "ISC",
+			"dependencies": {
+				"foreground-child": "^3.1.0",
+				"jackspeak": "^3.1.2",
+				"minimatch": "^9.0.4",
+				"minipass": "^7.1.2",
+				"package-json-from-dist": "^1.0.0",
+				"path-scurry": "^1.11.1"
+			},
+			"bin": {
+				"glob": "dist/esm/bin.mjs"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@fastify/static/node_modules/minimatch": {
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@fastify/static/node_modules/minipass": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
 			}
 		},
 		"node_modules/@fastify/websocket": {
@@ -2433,39 +2288,25 @@
 			"license": "MIT"
 		},
 		"node_modules/@humanfs/core": {
-			"version": "0.19.2",
-			"resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
-			"integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+			"version": "0.19.1",
+			"resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+			"integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"dependencies": {
-				"@humanfs/types": "^0.15.0"
-			},
 			"engines": {
 				"node": ">=18.18.0"
 			}
 		},
 		"node_modules/@humanfs/node": {
-			"version": "0.16.8",
-			"resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
-			"integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+			"version": "0.16.7",
+			"resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+			"integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@humanfs/core": "^0.19.2",
-				"@humanfs/types": "^0.15.0",
+				"@humanfs/core": "^0.19.1",
 				"@humanwhocodes/retry": "^0.4.0"
 			},
-			"engines": {
-				"node": ">=18.18.0"
-			}
-		},
-		"node_modules/@humanfs/types": {
-			"version": "0.15.0",
-			"resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
-			"integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
-			"dev": true,
-			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=18.18.0"
 			}
@@ -2505,14 +2346,31 @@
 			"license": "MIT"
 		},
 		"node_modules/@iconify/utils": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.2.tgz",
-			"integrity": "sha512-jVf75icVVgSVGf9+QWBeCHdFL35yZ06HMHl9sCa059pITTP781lOacvRazfwAmXDKiBiUdQQMWVnuiw/RaQNhQ==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.0.2.tgz",
+			"integrity": "sha512-EfJS0rLfVuRuJRn4psJHtK2A9TqVnkxPpHY6lYHiB9+8eSuudsxbwMiavocG45ujOo6FJ+CIRlRnlOGinzkaGQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@antfu/install-pkg": "^1.1.0",
+				"@antfu/utils": "^9.2.0",
 				"@iconify/types": "^2.0.0",
-				"import-meta-resolve": "^4.2.0"
+				"debug": "^4.4.1",
+				"globals": "^15.15.0",
+				"kolorist": "^1.8.0",
+				"local-pkg": "^1.1.1",
+				"mlly": "^1.7.4"
+			}
+		},
+		"node_modules/@iconify/utils/node_modules/globals": {
+			"version": "15.15.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
+			"integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/@isaacs/cliui": {
@@ -2530,6 +2388,30 @@
 			},
 			"engines": {
 				"node": ">=12"
+			}
+		},
+		"node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+			"version": "6.2.3",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+			"integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
 		"node_modules/@isaacs/cliui/node_modules/emoji-regex": {
@@ -2555,6 +2437,38 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+			"integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
+		"node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+			"integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^6.1.0",
+				"string-width": "^5.0.1",
+				"strip-ansi": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
 		"node_modules/@isaacs/fs-minipass": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
@@ -2566,6 +2480,16 @@
 			},
 			"engines": {
 				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@isaacs/fs-minipass/node_modules/minipass": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
 			}
 		},
 		"node_modules/@jridgewell/gen-mapping": {
@@ -2727,29 +2651,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/@malept/cross-spawn-promise": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-2.0.0.tgz",
-			"integrity": "sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://github.com/sponsors/malept"
-				},
-				{
-					"type": "tidelift",
-					"url": "https://tidelift.com/subscription/pkg/npm-.malept-cross-spawn-promise?utm_medium=referral&utm_source=npm_fund"
-				}
-			],
-			"license": "Apache-2.0",
-			"dependencies": {
-				"cross-spawn": "^7.0.1"
-			},
-			"engines": {
-				"node": ">= 12.13.0"
-			}
-		},
 		"node_modules/@malept/flatpak-bundler": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/@malept/flatpak-bundler/-/flatpak-bundler-0.4.0.tgz",
@@ -2783,9 +2684,9 @@
 			}
 		},
 		"node_modules/@malept/flatpak-bundler/node_modules/jsonfile": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+			"integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2812,12 +2713,12 @@
 			"license": "MIT"
 		},
 		"node_modules/@mermaid-js/parser": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.1.0.tgz",
-			"integrity": "sha512-gxK9ZX2+Fex5zu8LhRQoMeMPEHbc73UKZ0FQ54YrQtUxE1VVhMwzeNtKRPAu5aXks4FasbMe4xB4bWrmq6Jlxw==",
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-0.6.3.tgz",
+			"integrity": "sha512-lnjOhe7zyHjc+If7yT4zoedx2vo4sHaTmtkl1+or8BRTnCtDmcTpAjpzDSfCZrshM5bCoz0GyidzadJAH1xobA==",
 			"license": "MIT",
 			"dependencies": {
-				"langium": "^4.0.0"
+				"langium": "3.3.1"
 			}
 		},
 		"node_modules/@napi-rs/wasm-runtime": {
@@ -3350,9 +3251,9 @@
 			}
 		},
 		"node_modules/@opentelemetry/semantic-conventions": {
-			"version": "1.40.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
-			"integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
+			"version": "1.41.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
+			"integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=14"
@@ -3374,9 +3275,9 @@
 			}
 		},
 		"node_modules/@oxc-project/types": {
-			"version": "0.128.0",
-			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.128.0.tgz",
-			"integrity": "sha512-huv1Y/LzBJkBVHt3OlC7u0zHBW9qXf1FdD7sGmc1rXc2P1mTwHssYv7jyGx5KAACSCH+9B3Bhn6Z9luHRvf7pQ==",
+			"version": "0.130.0",
+			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.130.0.tgz",
+			"integrity": "sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
@@ -3400,13 +3301,13 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.59.1",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
-			"integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+			"version": "1.60.0",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+			"integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright": "1.59.1"
+				"playwright": "1.60.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -3765,9 +3666,9 @@
 			}
 		},
 		"node_modules/@reduxjs/toolkit/node_modules/immer": {
-			"version": "11.1.7",
-			"resolved": "https://registry.npmjs.org/immer/-/immer-11.1.7.tgz",
-			"integrity": "sha512-LFVFtAROHcDy1er5UI6nodRFnZ2SgdCXhfNSI+DpObO8N7Pur/muBGsjzH5wpnFHCYhYVQxZskCkV4koQ//3/Q==",
+			"version": "11.1.0",
+			"resolved": "https://registry.npmjs.org/immer/-/immer-11.1.0.tgz",
+			"integrity": "sha512-dlzb07f5LDY+tzs+iLCSXV2yuhaYfezqyZQc+n6baLECWkOMEWxkECAOnXL0ba7lsA25fM9b2jtzpu/uxo1a7g==",
 			"license": "MIT",
 			"funding": {
 				"type": "opencollective",
@@ -3775,9 +3676,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-android-arm64": {
-			"version": "1.0.0-rc.18",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.18.tgz",
-			"integrity": "sha512-lIDyUAfD7U3+BWKzdxMbJcsYHuqXqmGz40aeRqvuAm3y5TkJSYTBW2RDrn65DJFPQqVjUAUqq5uz8urzQ8aBdQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.1.tgz",
+			"integrity": "sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg==",
 			"cpu": [
 				"arm64"
 			],
@@ -3792,9 +3693,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-darwin-arm64": {
-			"version": "1.0.0-rc.18",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.18.tgz",
-			"integrity": "sha512-apJq2ktnGp27nSInMR5Vcj8kY6xJzDAvfdIFlpDcAK/w4cDO58qVoi1YQsES/SKiFNge/6e4CUzgjfHduYqWpQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.1.tgz",
+			"integrity": "sha512-cKnAhWEsV7TPcA/5EAteDp6KcJZBQ2G+BqE7zayMMi7kMvwRsbv7WT9aOnn0WNl4SKEIf43vjS31iUPu80nzXg==",
 			"cpu": [
 				"arm64"
 			],
@@ -3809,9 +3710,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-darwin-x64": {
-			"version": "1.0.0-rc.18",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.18.tgz",
-			"integrity": "sha512-5Ofot8xbs+pxRHJqm9/9N/4sTQOvdrwEsmPE9pdLEEoAbdZtG6F2LMDfO1sp6ZAtXJuJV/21ew2srq3W8NXB5g==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.1.tgz",
+			"integrity": "sha512-YKrVwQjIRBPo+5G/u03wGjbdy4q7pyzCe93DK9VJ7zkVmeg8LJ7GbgsiHWdR4xSoe4CAXRD7Bcjgbtr64bkXNg==",
 			"cpu": [
 				"x64"
 			],
@@ -3826,9 +3727,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-freebsd-x64": {
-			"version": "1.0.0-rc.18",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.18.tgz",
-			"integrity": "sha512-7h8eeOTT1eyqJyx64BFCnWZpNm486hGWt2sqeLLgDxA0xI1oGZ9H7gK1S85uNGmBhkdPwa/6reTxfFFKvIsebw==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.1.tgz",
+			"integrity": "sha512-z/oBsREo46SsFqBwYtFe0kpJeBijAT48O/WXLI4suiCLBkr03RTtTJMCzSdDd2znlh8VJizL09XVkQgk8IZonw==",
 			"cpu": [
 				"x64"
 			],
@@ -3843,9 +3744,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-			"version": "1.0.0-rc.18",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.18.tgz",
-			"integrity": "sha512-eRcm/HVt9U/JFu5RKAEKwGQYtDCKWLiaH6wOnsSEp6NMBb/3Os8LgHZlNyzMpFVNmiiMFlfb2zEnebfzJrHFmg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.1.tgz",
+			"integrity": "sha512-ik8q7GM11zxvYxFc2PeDcT6TBvhCQMaUxfph/M5l9sKuTs/Sjg3L+Byw0F7w0ZVLBZmx30P+gG0ECzzN+MFcmQ==",
 			"cpu": [
 				"arm"
 			],
@@ -3860,9 +3761,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm64-gnu": {
-			"version": "1.0.0-rc.18",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.18.tgz",
-			"integrity": "sha512-SOrT/cT4ukTmgnrEz/Hg3m7LBnuCLW9psDeMKrimRWY4I8DmnO7Lco8W2vtqPmMkbVu8iJ+g4GFLVLLOVjJ9DQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.1.tgz",
+			"integrity": "sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A==",
 			"cpu": [
 				"arm64"
 			],
@@ -3877,9 +3778,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm64-musl": {
-			"version": "1.0.0-rc.18",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.18.tgz",
-			"integrity": "sha512-QWjdxN1HJCpBTAcZ5N5F7wju3gVPzRzSpmGzx7na0c/1qpN9CFil+xt+l9lV/1M6/gqHSNXCiqPfwhVJPeLnug==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.1.tgz",
+			"integrity": "sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg==",
 			"cpu": [
 				"arm64"
 			],
@@ -3894,9 +3795,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-ppc64-gnu": {
-			"version": "1.0.0-rc.18",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.18.tgz",
-			"integrity": "sha512-ugCOyj7a4d9h3q9B+wXmf6g3a68UsjGh6dob5DHevHGMwDUbhsYNbSPxJsENcIttJZ9jv7qGM2UesLw5jqIhdg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.1.tgz",
+			"integrity": "sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg==",
 			"cpu": [
 				"ppc64"
 			],
@@ -3911,9 +3812,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-s390x-gnu": {
-			"version": "1.0.0-rc.18",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.18.tgz",
-			"integrity": "sha512-kKWRhbsotpXkGbcd5dllUWg5gEXcDAa8u5YnP9AV5DYNbvJHGzzuwv7dpmhc8NqKMJldl0a+x76IHbspEpEmdA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.1.tgz",
+			"integrity": "sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ==",
 			"cpu": [
 				"s390x"
 			],
@@ -3928,9 +3829,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-x64-gnu": {
-			"version": "1.0.0-rc.18",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.18.tgz",
-			"integrity": "sha512-uCo8ElcCIAMyYAZyuIZ81oFkhTSIllNvUCHCAlbhlN4ji3uC28h7IIdlXyIvGO7HsuqnV9p3rD/bpH7XhIyhRw==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.1.tgz",
+			"integrity": "sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw==",
 			"cpu": [
 				"x64"
 			],
@@ -3945,9 +3846,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-x64-musl": {
-			"version": "1.0.0-rc.18",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.18.tgz",
-			"integrity": "sha512-XNOQZtuE6yUIvx4rwGemwh8kpL1xvU41FXy/s9K7T/3JVcqGzo3NfKM2HrbrGgfPYGFW42f07Wk++aOC6B9NWA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.1.tgz",
+			"integrity": "sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ==",
 			"cpu": [
 				"x64"
 			],
@@ -3962,9 +3863,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-openharmony-arm64": {
-			"version": "1.0.0-rc.18",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.18.tgz",
-			"integrity": "sha512-tSn/kzrfa7tNOXr7sEacDBN4YsIqTyLqh45IO0nHDwtpKIDNDJr+VFojt+4klSpChxB29JLyduSsE0MKEwa65A==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.1.tgz",
+			"integrity": "sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -3979,9 +3880,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-wasm32-wasi": {
-			"version": "1.0.0-rc.18",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.18.tgz",
-			"integrity": "sha512-+J9YGmc+czgqlhYmwun3S3O0FIZhsH8ep2456xwjAdIOmuJxM7xz4P4PtrxU+Bz17a/5bqPA8o3HAAoX0teUdg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.1.tgz",
+			"integrity": "sha512-+1xc9X45l8ufsBAm6Gjvx2qDRIY9lTVt0cgWNcJ+1gdhXvkbxePA60yRTwSTuXL09CMhyJmjpV7E3NoyxbqFQQ==",
 			"cpu": [
 				"wasm32"
 			],
@@ -3998,9 +3899,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-win32-arm64-msvc": {
-			"version": "1.0.0-rc.18",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.18.tgz",
-			"integrity": "sha512-zsu47DgU0FQzSwi6sU9dZoEdUv7pc1AptSEz/Z8HBg54sV0Pbs3N0+CrIbTsgiu6EyoaNN9CHboqbLaz9lhOyQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.1.tgz",
+			"integrity": "sha512-1D+UqZdfnuR+Jy1GgMJwi85bD40H21uNmOPRWQhw4oRSuolZ/B5rixZ45DK2KXOTCvmVCecauWgEhbw8bI7tOw==",
 			"cpu": [
 				"arm64"
 			],
@@ -4015,9 +3916,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-win32-x64-msvc": {
-			"version": "1.0.0-rc.18",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.18.tgz",
-			"integrity": "sha512-7H+3yqGgmnlDTRRhw/xpYY9J1kf4GC681nVc4GqKhExZTDrVVrV2tsOR9kso0fvgBdcTCcQShx4SLLoHgaLwhg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.1.tgz",
+			"integrity": "sha512-INAycaWuhlOK3wk4mRHGsdgwYWmd9cChdPdE9bwWmy6rn9VqVNYNFGhOdXrofXUxwHIncSiPNb8tNm8knDVIeQ==",
 			"cpu": [
 				"x64"
 			],
@@ -4032,9 +3933,9 @@
 			}
 		},
 		"node_modules/@rolldown/pluginutils": {
-			"version": "1.0.0-rc.7",
-			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.7.tgz",
-			"integrity": "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+			"integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -4373,12 +4274,12 @@
 			}
 		},
 		"node_modules/@tanstack/react-virtual": {
-			"version": "3.13.24",
-			"resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.24.tgz",
-			"integrity": "sha512-aIJvz5OSkhNIhZIpYivrxrPTKYsjW9Uzy+sP/mx0S3sev2HyvPb7xmjbYvokzEpfgYHy/HjzJ2zFAETuUfgCpg==",
+			"version": "3.13.13",
+			"resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.13.tgz",
+			"integrity": "sha512-4o6oPMDvQv+9gMi8rE6gWmsOjtUZUYIJHv7EB+GblyYdi8U6OqLl8rhHWIUZSL1dUU2dPwTdTgybCKf9EjIrQg==",
 			"license": "MIT",
 			"dependencies": {
-				"@tanstack/virtual-core": "3.14.0"
+				"@tanstack/virtual-core": "3.13.13"
 			},
 			"funding": {
 				"type": "github",
@@ -4390,34 +4291,13 @@
 			}
 		},
 		"node_modules/@tanstack/virtual-core": {
-			"version": "3.14.0",
-			"resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.14.0.tgz",
-			"integrity": "sha512-JLANqGy/D6k4Ujmh8Tr25lGimuOXNiaVyXaCAZS0W+1390sADdGnyUdSWNIfd49gebtIxGMij4IktRVzrdr12Q==",
+			"version": "3.13.13",
+			"resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.13.tgz",
+			"integrity": "sha512-uQFoSdKKf5S8k51W5t7b2qpfkyIbdHMzAn+AMQvHPxKUPeo1SsGaA4JRISQT87jm28b7z8OEqPcg1IOZagQHcA==",
 			"license": "MIT",
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/tannerlinsley"
-			}
-		},
-		"node_modules/@testing-library/dom": {
-			"version": "10.4.1",
-			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-			"integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/runtime": "^7.12.5",
-				"@types/aria-query": "^5.0.1",
-				"aria-query": "5.3.0",
-				"dom-accessibility-api": "^0.5.9",
-				"lz-string": "^1.5.0",
-				"picocolors": "1.1.1",
-				"pretty-format": "^27.0.2"
-			},
-			"engines": {
-				"node": ">=18"
 			}
 		},
 		"node_modules/@testing-library/jest-dom": {
@@ -4448,9 +4328,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@testing-library/react": {
-			"version": "16.3.2",
-			"resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
-			"integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+			"version": "16.3.0",
+			"resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.0.tgz",
+			"integrity": "sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4476,9 +4356,9 @@
 			}
 		},
 		"node_modules/@tootallnate/once": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
-			"integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+			"integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -4497,9 +4377,9 @@
 			}
 		},
 		"node_modules/@types/adm-zip": {
-			"version": "0.5.8",
-			"resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.8.tgz",
-			"integrity": "sha512-RVVH7QvZYbN+ihqZ4kX/dMiowf6o+Jk1fNwiSdx0NahBJLU787zkULhGhJM8mf/obmLGmgdMM0bXsQTmyfbR7Q==",
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.7.tgz",
+			"integrity": "sha512-DNEs/QvmyRLurdQPChqq0Md4zGvPwHerAJYWk9l2jCbD1VPpnzRJorOdiq4zsw09NFbYnhfsoEhWtxIzXpn2yw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4515,14 +4395,6 @@
 			"dependencies": {
 				"@types/readdir-glob": "*"
 			}
-		},
-		"node_modules/@types/aria-query": {
-			"version": "5.0.4",
-			"resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
-			"integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true
 		},
 		"node_modules/@types/better-sqlite3": {
 			"version": "7.6.13",
@@ -4782,9 +4654,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/d3-shape": {
-			"version": "3.1.8",
-			"resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
-			"integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+			"version": "3.1.7",
+			"resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
+			"integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/d3-path": "*"
@@ -4828,9 +4700,9 @@
 			}
 		},
 		"node_modules/@types/debug": {
-			"version": "4.1.13",
-			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
-			"integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+			"version": "4.1.12",
+			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+			"integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/ms": "*"
@@ -4860,9 +4732,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/estree": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
-			"integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
 			"license": "MIT"
 		},
 		"node_modules/@types/estree-jsx": {
@@ -4900,9 +4772,9 @@
 			}
 		},
 		"node_modules/@types/http-cache-semantics": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
-			"integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
+			"integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -5028,15 +4900,16 @@
 			}
 		},
 		"node_modules/@types/prismjs": {
-			"version": "1.26.6",
-			"resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.6.tgz",
-			"integrity": "sha512-vqlvI7qlMvcCBbVe0AKAb4f97//Hy0EBTaiW8AalRnG/xAN5zOiWWyrNqNXeq8+KAuvRewjCVY1+IPxk4RdNYw==",
+			"version": "1.26.5",
+			"resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.5.tgz",
+			"integrity": "sha512-AUZTa7hQ2KY5L7AmtSiqxlhWxb4ina0yd8hNbl4TWuqnv/pFP0nDMb3YrfSBf4hJVGLh2YEIBfKaBW/9UEl6IQ==",
 			"license": "MIT"
 		},
 		"node_modules/@types/prop-types": {
 			"version": "15.7.15",
 			"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
 			"integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@types/qrcode": {
@@ -5050,9 +4923,10 @@
 			}
 		},
 		"node_modules/@types/react": {
-			"version": "18.3.28",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
-			"integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+			"version": "18.3.27",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
+			"integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/prop-types": "*",
@@ -5163,17 +5037,17 @@
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "8.59.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.2.tgz",
-			"integrity": "sha512-j/bwmkBvHUtPNxzuWe5z6BEk3q54YRyGlBXkSsmfoih7zNrBvl5A9A98anlp/7JbyZcWIJ8KXo/3Tq/DjFLtuQ==",
+			"version": "8.59.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.3.tgz",
+			"integrity": "sha512-PwFvSKsXGShKGW6n5bZOhGHEcCZXM8HofLK9fNsEwZXzFRjoY+XT1Vsf1zgyXdwTr0ZYz1/2tkZ0DBTT9jZjhw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.12.2",
-				"@typescript-eslint/scope-manager": "8.59.2",
-				"@typescript-eslint/type-utils": "8.59.2",
-				"@typescript-eslint/utils": "8.59.2",
-				"@typescript-eslint/visitor-keys": "8.59.2",
+				"@typescript-eslint/scope-manager": "8.59.3",
+				"@typescript-eslint/type-utils": "8.59.3",
+				"@typescript-eslint/utils": "8.59.3",
+				"@typescript-eslint/visitor-keys": "8.59.3",
 				"ignore": "^7.0.5",
 				"natural-compare": "^1.4.0",
 				"ts-api-utils": "^2.5.0"
@@ -5186,22 +5060,22 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/parser": "^8.59.2",
+				"@typescript-eslint/parser": "^8.59.3",
 				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
 				"typescript": ">=4.8.4 <6.1.0"
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "8.59.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.2.tgz",
-			"integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
+			"version": "8.59.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.3.tgz",
+			"integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "8.59.2",
-				"@typescript-eslint/types": "8.59.2",
-				"@typescript-eslint/typescript-estree": "8.59.2",
-				"@typescript-eslint/visitor-keys": "8.59.2",
+				"@typescript-eslint/scope-manager": "8.59.3",
+				"@typescript-eslint/types": "8.59.3",
+				"@typescript-eslint/typescript-estree": "8.59.3",
+				"@typescript-eslint/visitor-keys": "8.59.3",
 				"debug": "^4.4.3"
 			},
 			"engines": {
@@ -5217,14 +5091,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/project-service": {
-			"version": "8.59.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.2.tgz",
-			"integrity": "sha512-+2hqvEkeyf/0FBor67duF0Ll7Ot8jyKzDQOSrxazF/danillRq2DwR9dLptsXpoZQqxE1UisSmoZewrlPas9Vw==",
+			"version": "8.59.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.3.tgz",
+			"integrity": "sha512-ECiUWa/KYRGDFUqTNehaRgzDshnJfkTABJxVemHk4ko22gcr0ukloKjWvyQ64g8YCV/UI47kN1dbmjf/GaQYng==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/tsconfig-utils": "^8.59.2",
-				"@typescript-eslint/types": "^8.59.2",
+				"@typescript-eslint/tsconfig-utils": "^8.59.3",
+				"@typescript-eslint/types": "^8.59.3",
 				"debug": "^4.4.3"
 			},
 			"engines": {
@@ -5239,14 +5113,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "8.59.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.2.tgz",
-			"integrity": "sha512-JzfyEpEtOU89CcFSwyNS3mu4MLvLSXqnmX05+aKBDM+TdR5jzcGOEBwxwGNxrEQ7p/z6kK2WyioCGBf2zZBnvg==",
+			"version": "8.59.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.3.tgz",
+			"integrity": "sha512-t2LvZnoEfzKtnPjgeEu41xw5gxq9mQVfYy4OoZ4Vlt0sk3JwxmhCca/AR7DwOiHrjWgjAj6as4AhRLKSDfvZIA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.59.2",
-				"@typescript-eslint/visitor-keys": "8.59.2"
+				"@typescript-eslint/types": "8.59.3",
+				"@typescript-eslint/visitor-keys": "8.59.3"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5257,9 +5131,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/tsconfig-utils": {
-			"version": "8.59.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.2.tgz",
-			"integrity": "sha512-BKK4alN7oi4C/zv4VqHQ+uRU+lTa6JGIZ7s1juw7b3RHo9OfKB+bKX3u0iVZetdsUCBBkSbdWbarJbmN0fTeSw==",
+			"version": "8.59.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.3.tgz",
+			"integrity": "sha512-PcIJHjmaREXLgIAIzLnSY9VucEzz8FKXsRgFa1DmdGCK/5tJpW03TKJF01Q6VZd1lLdz2sIKPWaDUZN9dp//dw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -5274,15 +5148,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "8.59.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.2.tgz",
-			"integrity": "sha512-nhqaj1nmTdVVl/BP5omXNRGO38jn5iosis2vbdmupF2txCf8ylWT8lx+JlvMYYVqzGVKtjojUFoQ3JRWK+mfzQ==",
+			"version": "8.59.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.3.tgz",
+			"integrity": "sha512-g71d8QD8UaiHGvrJwyIS1hCX5r63w6Jll+4VEYhEAHXTDIqX1JgxhTAbEHtKntL9kuc4jRo7/GWw5xfCepSccQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.59.2",
-				"@typescript-eslint/typescript-estree": "8.59.2",
-				"@typescript-eslint/utils": "8.59.2",
+				"@typescript-eslint/types": "8.59.3",
+				"@typescript-eslint/typescript-estree": "8.59.3",
+				"@typescript-eslint/utils": "8.59.3",
 				"debug": "^4.4.3",
 				"ts-api-utils": "^2.5.0"
 			},
@@ -5299,9 +5173,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "8.59.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.2.tgz",
-			"integrity": "sha512-e82GVOE8Ps3E++Egvb6Y3Dw0S10u8NkQ9KXmtRhCWJJ8kDhOJTvtMAWnFL16kB1583goCWXsr0NieKCZMs2/0Q==",
+			"version": "8.59.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.3.tgz",
+			"integrity": "sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -5313,16 +5187,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "8.59.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.2.tgz",
-			"integrity": "sha512-o0XPGNwcWw+FIwStOWn+BwBuEmL6QXP0rsvAFg7ET1dey1Nr6Wb1ac8p5HEsK0ygO/6mUxlk+YWQD9xcb/nnXg==",
+			"version": "8.59.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.3.tgz",
+			"integrity": "sha512-CbRjVRAf7Lr9Kr8RopKcbY45p2VfmmHrm0ygOCYFi7oU8q19m0Fs/6iHS7kNOmwpp+ob07ZVcAqlxUod9lYdmg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/project-service": "8.59.2",
-				"@typescript-eslint/tsconfig-utils": "8.59.2",
-				"@typescript-eslint/types": "8.59.2",
-				"@typescript-eslint/visitor-keys": "8.59.2",
+				"@typescript-eslint/project-service": "8.59.3",
+				"@typescript-eslint/tsconfig-utils": "8.59.3",
+				"@typescript-eslint/types": "8.59.3",
+				"@typescript-eslint/visitor-keys": "8.59.3",
 				"debug": "^4.4.3",
 				"minimatch": "^10.2.2",
 				"semver": "^7.7.3",
@@ -5340,17 +5214,56 @@
 				"typescript": ">=4.8.4 <6.1.0"
 			}
 		},
+		"node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+			"version": "10.2.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"brace-expansion": "^5.0.5"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "8.59.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.2.tgz",
-			"integrity": "sha512-Juw3EinkXqjaffxz6roowvV7GZT/kET5vSKKZT6upl5TXdWkLkYmNPXwDDL2Vkt2DPn0nODIS4egC/0AGxKo/Q==",
+			"version": "8.59.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.3.tgz",
+			"integrity": "sha512-JAvT14goBzRzzzZyqq3P9BLArIxTtQURUtFgQ/V7FO+eU+Gg6ES+5ymOPP1wRxXcxAYeivCk4uS3jCKWI1K8Zg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.9.1",
-				"@typescript-eslint/scope-manager": "8.59.2",
-				"@typescript-eslint/types": "8.59.2",
-				"@typescript-eslint/typescript-estree": "8.59.2"
+				"@typescript-eslint/scope-manager": "8.59.3",
+				"@typescript-eslint/types": "8.59.3",
+				"@typescript-eslint/typescript-estree": "8.59.3"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5365,13 +5278,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.59.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.2.tgz",
-			"integrity": "sha512-NwjLUnGy8/Zfx23fl50tRC8rYaYnM52xNRYFAXvmiil9yh1+K6aRVQMnzW6gQB/1DLgWt977lYQn7C+wtgXZiA==",
+			"version": "8.59.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.3.tgz",
+			"integrity": "sha512-f1UQF7ggd42YiwI5wGrRaPsa+P0CINBlrkLPmGfpq/u/I/oVtecoEIfFR9ag/oa1sLOsRNZ6xehf6qMZhQGBDg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.59.2",
+				"@typescript-eslint/types": "8.59.3",
 				"eslint-visitor-keys": "^5.0.0"
 			},
 			"engines": {
@@ -5396,29 +5309,19 @@
 			}
 		},
 		"node_modules/@ungap/structured-clone": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
-			"integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+			"integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
 			"license": "ISC"
 		},
-		"node_modules/@upsetjs/venn.js": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@upsetjs/venn.js/-/venn.js-2.0.0.tgz",
-			"integrity": "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==",
-			"license": "MIT",
-			"optionalDependencies": {
-				"d3-selection": "^3.0.0",
-				"d3-transition": "^3.0.1"
-			}
-		},
 		"node_modules/@vitejs/plugin-react": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.1.tgz",
-			"integrity": "sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.2.tgz",
+			"integrity": "sha512-DlSMqo4WhThw4vB8Mpn0Woe9J+Jfq1geJ61AKW0QEgLzGMNwtIMdxbDUzLxcun8W7NbJO0e2Jg/Nxm3cCSVzzg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@rolldown/pluginutils": "1.0.0-rc.7"
+				"@rolldown/pluginutils": "^1.0.0"
 			},
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
@@ -5438,14 +5341,14 @@
 			}
 		},
 		"node_modules/@vitest/coverage-v8": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.5.tgz",
-			"integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
+			"version": "4.1.6",
+			"resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.6.tgz",
+			"integrity": "sha512-36l628fQ/9a/8ihy97eOtEnvWQEdqULQOJtcaxtoNq0G1w3Mxd4szSahOaMM9/NGyZ+hyKcMtIW/WIxq0XQViQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@bcoe/v8-coverage": "^1.0.2",
-				"@vitest/utils": "4.1.5",
+				"@vitest/utils": "4.1.6",
 				"ast-v8-to-istanbul": "^1.0.0",
 				"istanbul-lib-coverage": "^3.2.2",
 				"istanbul-lib-report": "^3.0.1",
@@ -5459,8 +5362,8 @@
 				"url": "https://opencollective.com/vitest"
 			},
 			"peerDependencies": {
-				"@vitest/browser": "4.1.5",
-				"vitest": "4.1.5"
+				"@vitest/browser": "4.1.6",
+				"vitest": "4.1.6"
 			},
 			"peerDependenciesMeta": {
 				"@vitest/browser": {
@@ -5469,16 +5372,16 @@
 			}
 		},
 		"node_modules/@vitest/expect": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
-			"integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+			"version": "4.1.6",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
+			"integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@standard-schema/spec": "^1.1.0",
 				"@types/chai": "^5.2.2",
-				"@vitest/spy": "4.1.5",
-				"@vitest/utils": "4.1.5",
+				"@vitest/spy": "4.1.6",
+				"@vitest/utils": "4.1.6",
 				"chai": "^6.2.2",
 				"tinyrainbow": "^3.1.0"
 			},
@@ -5487,13 +5390,13 @@
 			}
 		},
 		"node_modules/@vitest/mocker": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
-			"integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+			"version": "4.1.6",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
+			"integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/spy": "4.1.5",
+				"@vitest/spy": "4.1.6",
 				"estree-walker": "^3.0.3",
 				"magic-string": "^0.30.21"
 			},
@@ -5514,9 +5417,9 @@
 			}
 		},
 		"node_modules/@vitest/pretty-format": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
-			"integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+			"version": "4.1.6",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
+			"integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5527,13 +5430,13 @@
 			}
 		},
 		"node_modules/@vitest/runner": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
-			"integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+			"version": "4.1.6",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
+			"integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/utils": "4.1.5",
+				"@vitest/utils": "4.1.6",
 				"pathe": "^2.0.3"
 			},
 			"funding": {
@@ -5541,14 +5444,14 @@
 			}
 		},
 		"node_modules/@vitest/snapshot": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
-			"integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+			"version": "4.1.6",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
+			"integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "4.1.5",
-				"@vitest/utils": "4.1.5",
+				"@vitest/pretty-format": "4.1.6",
+				"@vitest/utils": "4.1.6",
 				"magic-string": "^0.30.21",
 				"pathe": "^2.0.3"
 			},
@@ -5557,9 +5460,9 @@
 			}
 		},
 		"node_modules/@vitest/spy": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
-			"integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+			"version": "4.1.6",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
+			"integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
@@ -5567,13 +5470,13 @@
 			}
 		},
 		"node_modules/@vitest/utils": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
-			"integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+			"version": "4.1.6",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
+			"integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "4.1.5",
+				"@vitest/pretty-format": "4.1.6",
 				"convert-source-map": "^2.0.0",
 				"tinyrainbow": "^3.1.0"
 			},
@@ -5595,9 +5498,9 @@
 			}
 		},
 		"node_modules/@xmldom/xmldom": {
-			"version": "0.8.13",
-			"resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
-			"integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+			"version": "0.8.11",
+			"resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
+			"integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -5683,9 +5586,9 @@
 			"license": "MIT"
 		},
 		"node_modules/acorn": {
-			"version": "8.16.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-			"integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+			"version": "8.15.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"license": "MIT",
 			"bin": {
 				"acorn": "bin/acorn"
@@ -5714,9 +5617,9 @@
 			}
 		},
 		"node_modules/adm-zip": {
-			"version": "0.5.17",
-			"resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
-			"integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+			"version": "0.5.16",
+			"resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
+			"integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=12.0"
@@ -5763,9 +5666,9 @@
 			}
 		},
 		"node_modules/ajv": {
-			"version": "6.15.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
-			"integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+			"version": "6.12.6",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5797,9 +5700,9 @@
 			}
 		},
 		"node_modules/ajv-formats/node_modules/ajv": {
-			"version": "8.20.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-			"integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+			"version": "8.17.1",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
 			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
@@ -5813,9 +5716,9 @@
 			}
 		},
 		"node_modules/ajv-formats/node_modules/fast-uri": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-			"integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+			"integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
 			"funding": [
 				{
 					"type": "github",
@@ -5915,306 +5818,6 @@
 				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
-		"node_modules/app-builder-bin": {
-			"version": "5.0.0-alpha.12",
-			"resolved": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-5.0.0-alpha.12.tgz",
-			"integrity": "sha512-j87o0j6LqPL3QRr8yid6c+Tt5gC7xNfYo6uQIQkorAC6MpeayVMZrEDzKmJJ/Hlv7EnOQpaRm53k6ktDYZyB6w==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/app-builder-lib": {
-			"version": "26.8.1",
-			"resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-26.8.1.tgz",
-			"integrity": "sha512-p0Im/Dx5C4tmz8QEE1Yn4MkuPC8PrnlRneMhWJj7BBXQfNTJUshM/bp3lusdEsDbvvfJZpXWnYesgSLvwtM2Zw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@develar/schema-utils": "~2.6.5",
-				"@electron/asar": "3.4.1",
-				"@electron/fuses": "^1.8.0",
-				"@electron/get": "^3.0.0",
-				"@electron/notarize": "2.5.0",
-				"@electron/osx-sign": "1.3.3",
-				"@electron/rebuild": "^4.0.3",
-				"@electron/universal": "2.0.3",
-				"@malept/flatpak-bundler": "^0.4.0",
-				"@types/fs-extra": "9.0.13",
-				"async-exit-hook": "^2.0.1",
-				"builder-util": "26.8.1",
-				"builder-util-runtime": "9.5.1",
-				"chromium-pickle-js": "^0.2.0",
-				"ci-info": "4.3.1",
-				"debug": "^4.3.4",
-				"dotenv": "^16.4.5",
-				"dotenv-expand": "^11.0.6",
-				"ejs": "^3.1.8",
-				"electron-publish": "26.8.1",
-				"fs-extra": "^10.1.0",
-				"hosted-git-info": "^4.1.0",
-				"isbinaryfile": "^5.0.0",
-				"jiti": "^2.4.2",
-				"js-yaml": "^4.1.0",
-				"json5": "^2.2.3",
-				"lazy-val": "^1.0.5",
-				"minimatch": "^10.0.3",
-				"plist": "3.1.0",
-				"proper-lockfile": "^4.1.2",
-				"resedit": "^1.7.0",
-				"semver": "~7.7.3",
-				"tar": "^7.5.7",
-				"temp-file": "^3.4.0",
-				"tiny-async-pool": "1.3.0",
-				"which": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			},
-			"peerDependencies": {
-				"dmg-builder": "26.8.1",
-				"electron-builder-squirrel-windows": "26.8.1"
-			}
-		},
-		"node_modules/app-builder-lib/node_modules/@electron/get": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@electron/get/-/get-3.1.0.tgz",
-			"integrity": "sha512-F+nKc0xW+kVbBRhFzaMgPy3KwmuNTYX1fx6+FxxoSnNgwYX6LD7AKBTWkU0MQ6IBoe7dz069CNkR673sPAgkCQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"debug": "^4.1.1",
-				"env-paths": "^2.2.0",
-				"fs-extra": "^8.1.0",
-				"got": "^11.8.5",
-				"progress": "^2.0.3",
-				"semver": "^6.2.0",
-				"sumchecker": "^3.0.1"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"optionalDependencies": {
-				"global-agent": "^3.0.0"
-			}
-		},
-		"node_modules/app-builder-lib/node_modules/@electron/get/node_modules/fs-extra": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-			"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"graceful-fs": "^4.2.0",
-				"jsonfile": "^4.0.0",
-				"universalify": "^0.1.0"
-			},
-			"engines": {
-				"node": ">=6 <7 || >=8"
-			}
-		},
-		"node_modules/app-builder-lib/node_modules/@electron/get/node_modules/semver": {
-			"version": "6.3.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
-			}
-		},
-		"node_modules/app-builder-lib/node_modules/@electron/notarize": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/@electron/notarize/-/notarize-2.5.0.tgz",
-			"integrity": "sha512-jNT8nwH1f9X5GEITXaQ8IF/KdskvIkOFfB2CvwumsveVidzpSc+mvhhTMdAGSYF3O+Nq49lJ7y+ssODRXu06+A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"debug": "^4.1.1",
-				"fs-extra": "^9.0.1",
-				"promise-retry": "^2.0.1"
-			},
-			"engines": {
-				"node": ">= 10.0.0"
-			}
-		},
-		"node_modules/app-builder-lib/node_modules/@electron/notarize/node_modules/fs-extra": {
-			"version": "9.1.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-			"integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"at-least-node": "^1.0.0",
-				"graceful-fs": "^4.2.0",
-				"jsonfile": "^6.0.1",
-				"universalify": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/app-builder-lib/node_modules/@electron/notarize/node_modules/jsonfile": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"universalify": "^2.0.0"
-			},
-			"optionalDependencies": {
-				"graceful-fs": "^4.1.6"
-			}
-		},
-		"node_modules/app-builder-lib/node_modules/@electron/notarize/node_modules/universalify": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 10.0.0"
-			}
-		},
-		"node_modules/app-builder-lib/node_modules/chownr": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-			"integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/app-builder-lib/node_modules/ci-info": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz",
-			"integrity": "sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/sibiraj-s"
-				}
-			],
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/app-builder-lib/node_modules/fs-extra": {
-			"version": "10.1.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-			"integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"graceful-fs": "^4.2.0",
-				"jsonfile": "^6.0.1",
-				"universalify": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/app-builder-lib/node_modules/fs-extra/node_modules/jsonfile": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"universalify": "^2.0.0"
-			},
-			"optionalDependencies": {
-				"graceful-fs": "^4.1.6"
-			}
-		},
-		"node_modules/app-builder-lib/node_modules/fs-extra/node_modules/universalify": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 10.0.0"
-			}
-		},
-		"node_modules/app-builder-lib/node_modules/isexe": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
-			"integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/app-builder-lib/node_modules/jiti": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
-			"integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
-			"dev": true,
-			"license": "MIT",
-			"bin": {
-				"jiti": "lib/jiti-cli.mjs"
-			}
-		},
-		"node_modules/app-builder-lib/node_modules/minizlib": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
-			"integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"minipass": "^7.1.2"
-			},
-			"engines": {
-				"node": ">= 18"
-			}
-		},
-		"node_modules/app-builder-lib/node_modules/tar": {
-			"version": "7.5.15",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
-			"integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"dependencies": {
-				"@isaacs/fs-minipass": "^4.0.0",
-				"chownr": "^3.0.0",
-				"minipass": "^7.1.2",
-				"minizlib": "^3.1.0",
-				"yallist": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/app-builder-lib/node_modules/which": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
-			"integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"isexe": "^3.1.1"
-			},
-			"bin": {
-				"node-which": "bin/which.js"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/app-builder-lib/node_modules/yallist": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-			"integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": ">=18"
-			}
-		},
 		"node_modules/aproba": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz",
@@ -6258,6 +5861,164 @@
 				"node": ">= 14"
 			}
 		},
+		"node_modules/archiver-utils/node_modules/buffer": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.2.1"
+			}
+		},
+		"node_modules/archiver-utils/node_modules/glob": {
+			"version": "10.5.0",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+			"integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+			"license": "ISC",
+			"dependencies": {
+				"foreground-child": "^3.1.0",
+				"jackspeak": "^3.1.2",
+				"minimatch": "^9.0.4",
+				"minipass": "^7.1.2",
+				"package-json-from-dist": "^1.0.0",
+				"path-scurry": "^1.11.1"
+			},
+			"bin": {
+				"glob": "dist/esm/bin.mjs"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/archiver-utils/node_modules/minimatch": {
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/archiver-utils/node_modules/minipass": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			}
+		},
+		"node_modules/archiver-utils/node_modules/readable-stream": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+			"integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+			"license": "MIT",
+			"dependencies": {
+				"abort-controller": "^3.0.0",
+				"buffer": "^6.0.3",
+				"events": "^3.3.0",
+				"process": "^0.11.10",
+				"string_decoder": "^1.3.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			}
+		},
+		"node_modules/archiver/node_modules/b4a": {
+			"version": "1.7.3",
+			"resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.3.tgz",
+			"integrity": "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==",
+			"license": "Apache-2.0",
+			"peerDependencies": {
+				"react-native-b4a": "*"
+			},
+			"peerDependenciesMeta": {
+				"react-native-b4a": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/archiver/node_modules/buffer": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.2.1"
+			}
+		},
+		"node_modules/archiver/node_modules/buffer-crc32": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+			"integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/archiver/node_modules/readable-stream": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+			"integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+			"license": "MIT",
+			"dependencies": {
+				"abort-controller": "^3.0.0",
+				"buffer": "^6.0.3",
+				"events": "^3.3.0",
+				"process": "^0.11.10",
+				"string_decoder": "^1.3.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			}
+		},
+		"node_modules/archiver/node_modules/tar-stream": {
+			"version": "3.1.7",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+			"integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+			"license": "MIT",
+			"dependencies": {
+				"b4a": "^1.6.4",
+				"fast-fifo": "^1.2.0",
+				"streamx": "^2.15.0"
+			}
+		},
 		"node_modules/are-we-there-yet": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
@@ -6271,21 +6032,6 @@
 			},
 			"engines": {
 				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-			}
-		},
-		"node_modules/are-we-there-yet/node_modules/readable-stream": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"inherits": "^2.0.3",
-				"string_decoder": "^1.1.1",
-				"util-deprecate": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 6"
 			}
 		},
 		"node_modules/arg": {
@@ -6562,9 +6308,9 @@
 			}
 		},
 		"node_modules/autoprefixer": {
-			"version": "10.5.0",
-			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.0.tgz",
-			"integrity": "sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==",
+			"version": "10.4.22",
+			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.22.tgz",
+			"integrity": "sha512-ARe0v/t9gO28Bznv6GgqARmVqcWOV3mfgUPn9becPHMiD3o9BwlRgaeccZnwTpZ7Zwqrm+c1sUSsMxIzQzc8Xg==",
 			"dev": true,
 			"funding": [
 				{
@@ -6582,9 +6328,10 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"browserslist": "^4.28.2",
-				"caniuse-lite": "^1.0.30001787",
+				"browserslist": "^4.27.0",
+				"caniuse-lite": "^1.0.30001754",
 				"fraction.js": "^5.3.4",
+				"normalize-range": "^0.1.2",
 				"picocolors": "^1.1.1",
 				"postcss-value-parser": "^4.2.0"
 			},
@@ -6635,13 +6382,10 @@
 			}
 		},
 		"node_modules/balanced-match": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-			"license": "MIT",
-			"engines": {
-				"node": "18 || 20 || >=22"
-			}
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"license": "MIT"
 		},
 		"node_modules/bare-events": {
 			"version": "2.8.2",
@@ -6655,83 +6399,6 @@
 				"bare-abort-controller": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/bare-fs": {
-			"version": "4.7.1",
-			"resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.1.tgz",
-			"integrity": "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"bare-events": "^2.5.4",
-				"bare-path": "^3.0.0",
-				"bare-stream": "^2.6.4",
-				"bare-url": "^2.2.2",
-				"fast-fifo": "^1.3.2"
-			},
-			"engines": {
-				"bare": ">=1.16.0"
-			},
-			"peerDependencies": {
-				"bare-buffer": "*"
-			},
-			"peerDependenciesMeta": {
-				"bare-buffer": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/bare-os": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
-			"integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
-			"license": "Apache-2.0",
-			"engines": {
-				"bare": ">=1.14.0"
-			}
-		},
-		"node_modules/bare-path": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
-			"integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"bare-os": "^3.0.1"
-			}
-		},
-		"node_modules/bare-stream": {
-			"version": "2.13.1",
-			"resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.1.tgz",
-			"integrity": "sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"streamx": "^2.25.0",
-				"teex": "^1.0.1"
-			},
-			"peerDependencies": {
-				"bare-abort-controller": "*",
-				"bare-buffer": "*",
-				"bare-events": "*"
-			},
-			"peerDependenciesMeta": {
-				"bare-abort-controller": {
-					"optional": true
-				},
-				"bare-buffer": {
-					"optional": true
-				},
-				"bare-events": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/bare-url": {
-			"version": "2.4.3",
-			"resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.3.tgz",
-			"integrity": "sha512-Kccpc7ACfXaxfeInfqKcZtW4pT5YBn1mesc4sCsun6sRwtbJ4h+sNOaksUpYEJUKfN65YWC6Bw2OJEFiKxq8nQ==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"bare-path": "^3.0.0"
 			}
 		},
 		"node_modules/base64-js": {
@@ -6755,22 +6422,19 @@
 			"license": "MIT"
 		},
 		"node_modules/baseline-browser-mapping": {
-			"version": "2.10.27",
-			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.27.tgz",
-			"integrity": "sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA==",
+			"version": "2.9.17",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.17.tgz",
+			"integrity": "sha512-agD0MgJFUP/4nvjqzIB29zRPUuCF7Ge6mEv9s8dHrtYD7QWXRcx75rOADE/d5ah1NI+0vkDl0yorDd5U852IQQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
-				"baseline-browser-mapping": "dist/cli.cjs"
-			},
-			"engines": {
-				"node": ">=6.0.0"
+				"baseline-browser-mapping": "dist/cli.js"
 			}
 		},
 		"node_modules/better-sqlite3": {
-			"version": "12.9.0",
-			"resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.9.0.tgz",
-			"integrity": "sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==",
+			"version": "12.10.0",
+			"resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.10.0.tgz",
+			"integrity": "sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6778,7 +6442,7 @@
 				"prebuild-install": "^7.1.1"
 			},
 			"engines": {
-				"node": "20.x || 22.x || 23.x || 24.x || 25.x"
+				"node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
 			}
 		},
 		"node_modules/bidi-js": {
@@ -6823,20 +6487,6 @@
 				"readable-stream": "^3.4.0"
 			}
 		},
-		"node_modules/bl/node_modules/readable-stream": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-			"license": "MIT",
-			"dependencies": {
-				"inherits": "^2.0.3",
-				"string_decoder": "^1.1.1",
-				"util-deprecate": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
 		"node_modules/boolean": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
@@ -6847,15 +6497,12 @@
 			"optional": true
 		},
 		"node_modules/brace-expansion": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
 			"license": "MIT",
 			"dependencies": {
-				"balanced-match": "^4.0.2"
-			},
-			"engines": {
-				"node": "18 || 20 || >=22"
+				"balanced-match": "^1.0.0"
 			}
 		},
 		"node_modules/braces": {
@@ -6871,9 +6518,9 @@
 			}
 		},
 		"node_modules/browserslist": {
-			"version": "4.28.2",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-			"integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+			"version": "4.28.0",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.0.tgz",
+			"integrity": "sha512-tbydkR/CxfMwelN0vwdP/pLkDwyAASZ+VfWm4EOwlB6SWhx1sYnWLqo8N5j0rAzPfzfRaxt0mM/4wPU/Su84RQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -6891,11 +6538,11 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"baseline-browser-mapping": "^2.10.12",
-				"caniuse-lite": "^1.0.30001782",
-				"electron-to-chromium": "^1.5.328",
-				"node-releases": "^2.0.36",
-				"update-browserslist-db": "^1.2.3"
+				"baseline-browser-mapping": "^2.8.25",
+				"caniuse-lite": "^1.0.30001754",
+				"electron-to-chromium": "^1.5.249",
+				"node-releases": "^2.0.27",
+				"update-browserslist-db": "^1.1.4"
 			},
 			"bin": {
 				"browserslist": "cli.js"
@@ -6929,12 +6576,13 @@
 			}
 		},
 		"node_modules/buffer-crc32": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
-			"integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
+			"version": "0.2.13",
+			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+			"integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=8.0.0"
+				"node": "*"
 			}
 		},
 		"node_modules/buffer-from": {
@@ -6943,120 +6591,6 @@
 			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/builder-util": {
-			"version": "26.8.1",
-			"resolved": "https://registry.npmjs.org/builder-util/-/builder-util-26.8.1.tgz",
-			"integrity": "sha512-pm1lTYbGyc90DHgCDO7eo8Rl4EqKLciayNbZqGziqnH9jrlKe8ZANGdityLZU+pJh16dfzjAx2xQq9McuIPEtw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/debug": "^4.1.6",
-				"7zip-bin": "~5.2.0",
-				"app-builder-bin": "5.0.0-alpha.12",
-				"builder-util-runtime": "9.5.1",
-				"chalk": "^4.1.2",
-				"cross-spawn": "^7.0.6",
-				"debug": "^4.3.4",
-				"fs-extra": "^10.1.0",
-				"http-proxy-agent": "^7.0.0",
-				"https-proxy-agent": "^7.0.0",
-				"js-yaml": "^4.1.0",
-				"sanitize-filename": "^1.6.3",
-				"source-map-support": "^0.5.19",
-				"stat-mode": "^1.0.0",
-				"temp-file": "^3.4.0",
-				"tiny-async-pool": "1.3.0"
-			}
-		},
-		"node_modules/builder-util-runtime": {
-			"version": "9.5.1",
-			"resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.5.1.tgz",
-			"integrity": "sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ==",
-			"license": "MIT",
-			"dependencies": {
-				"debug": "^4.3.4",
-				"sax": "^1.2.4"
-			},
-			"engines": {
-				"node": ">=12.0.0"
-			}
-		},
-		"node_modules/builder-util/node_modules/agent-base": {
-			"version": "7.1.4",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/builder-util/node_modules/fs-extra": {
-			"version": "10.1.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-			"integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"graceful-fs": "^4.2.0",
-				"jsonfile": "^6.0.1",
-				"universalify": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/builder-util/node_modules/http-proxy-agent": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"agent-base": "^7.1.0",
-				"debug": "^4.3.4"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/builder-util/node_modules/https-proxy-agent": {
-			"version": "7.0.6",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"agent-base": "^7.1.2",
-				"debug": "4"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/builder-util/node_modules/jsonfile": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"universalify": "^2.0.0"
-			},
-			"optionalDependencies": {
-				"graceful-fs": "^4.1.6"
-			}
-		},
-		"node_modules/builder-util/node_modules/universalify": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 10.0.0"
-			}
 		},
 		"node_modules/cacache": {
 			"version": "16.1.3",
@@ -7088,28 +6622,11 @@
 				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
-		"node_modules/cacache/node_modules/balanced-match": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/cacache/node_modules/brace-expansion": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-			"integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0"
-			}
-		},
 		"node_modules/cacache/node_modules/glob": {
 			"version": "8.1.0",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
 			"integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
-			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+			"deprecated": "Glob versions prior to v9 are no longer supported",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -7134,19 +6651,6 @@
 			"license": "ISC",
 			"engines": {
 				"node": ">=12"
-			}
-		},
-		"node_modules/cacache/node_modules/minimatch": {
-			"version": "5.1.9",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-			"integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/cacache/node_modules/minipass": {
@@ -7199,15 +6703,15 @@
 			}
 		},
 		"node_modules/call-bind": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
-			"integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+			"integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"call-bind-apply-helpers": "^1.0.2",
-				"es-define-property": "^1.0.1",
-				"get-intrinsic": "^1.3.0",
+				"call-bind-apply-helpers": "^1.0.0",
+				"es-define-property": "^1.0.0",
+				"get-intrinsic": "^1.2.4",
 				"set-function-length": "^1.2.2"
 			},
 			"engines": {
@@ -7278,9 +6782,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001792",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
-			"integrity": "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==",
+			"version": "1.0.30001756",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001756.tgz",
+			"integrity": "sha512-4HnCNKbMLkLdhJz3TToeVWHSnfJvPaq6vu/eRP0Ahub/07n484XHhBF5AJoSGHdVrS8tKFauUQz8Bp9P7LVx7A==",
 			"dev": true,
 			"funding": [
 				{
@@ -7299,9 +6803,9 @@
 			"license": "CC-BY-4.0"
 		},
 		"node_modules/canvas": {
-			"version": "3.2.3",
-			"resolved": "https://registry.npmjs.org/canvas/-/canvas-3.2.3.tgz",
-			"integrity": "sha512-PzE5nJZPz72YUAfo8oTp0u3fqqY7IzlTubneAihqDYAUcBk7ryeCmBbdJBEdaH0bptSOe2VT2Zwcb3UaFyaSWw==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/canvas/-/canvas-3.2.0.tgz",
+			"integrity": "sha512-jk0GxrLtUEmW/TmFsk2WghvgHe8B0pxGilqCL21y8lHkPUGa6FTsnCNtHPOzT8O3y+N+m3espawV80bbBlgfTA==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -7322,6 +6826,13 @@
 				"type": "donate",
 				"url": "https://www.paypal.me/kirilvatev"
 			}
+		},
+		"node_modules/canvas/node_modules/node-addon-api": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+			"integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/ccount": {
 			"version": "2.0.1",
@@ -7414,31 +6925,29 @@
 			}
 		},
 		"node_modules/chevrotain": {
-			"version": "12.0.0",
-			"resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-12.0.0.tgz",
-			"integrity": "sha512-csJvb+6kEiQaqo1woTdSAuOWdN0WTLIydkKrBnS+V5gZz0oqBrp4kQ35519QgK6TpBThiG3V1vNSHlIkv4AglQ==",
+			"version": "11.0.3",
+			"resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.0.3.tgz",
+			"integrity": "sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@chevrotain/cst-dts-gen": "12.0.0",
-				"@chevrotain/gast": "12.0.0",
-				"@chevrotain/regexp-to-ast": "12.0.0",
-				"@chevrotain/types": "12.0.0",
-				"@chevrotain/utils": "12.0.0"
-			},
-			"engines": {
-				"node": ">=22.0.0"
+				"@chevrotain/cst-dts-gen": "11.0.3",
+				"@chevrotain/gast": "11.0.3",
+				"@chevrotain/regexp-to-ast": "11.0.3",
+				"@chevrotain/types": "11.0.3",
+				"@chevrotain/utils": "11.0.3",
+				"lodash-es": "4.17.21"
 			}
 		},
 		"node_modules/chevrotain-allstar": {
-			"version": "0.4.3",
-			"resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.4.3.tgz",
-			"integrity": "sha512-2X4mkroolSMKqW+H22pyPMUVDqYZzPhephTmg/NODKb1IGYPHfxfhcW0EjS7wcPJNbze2i4vBWT7zT5FKF2lrQ==",
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.3.1.tgz",
+			"integrity": "sha512-b7g+y9A0v4mxCW1qUhf3BSVPg+/NvGErk/dOkrDaHA0nQIQGAtrOjlX//9OQtRlSCy+x9rfB5N8yC71lH1nvMw==",
 			"license": "MIT",
 			"dependencies": {
-				"lodash-es": "^4.18.1"
+				"lodash-es": "^4.17.21"
 			},
 			"peerDependencies": {
-				"chevrotain": "^12.0.0"
+				"chevrotain": "^11.0.0"
 			}
 		},
 		"node_modules/chokidar": {
@@ -7463,6 +6972,18 @@
 			},
 			"optionalDependencies": {
 				"fsevents": "~2.3.2"
+			}
+		},
+		"node_modules/chokidar/node_modules/glob-parent": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+			"license": "ISC",
+			"dependencies": {
+				"is-glob": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
 			}
 		},
 		"node_modules/chownr": {
@@ -7585,37 +7106,6 @@
 				"node": ">=12"
 			}
 		},
-		"node_modules/cliui/node_modules/strip-ansi": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/cliui/node_modules/wrap-ansi": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^4.0.0",
-				"string-width": "^4.1.0",
-				"strip-ansi": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-			}
-		},
 		"node_modules/clone": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
@@ -7700,9 +7190,9 @@
 			}
 		},
 		"node_modules/commander": {
-			"version": "14.0.3",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-			"integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+			"version": "14.0.2",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-14.0.2.tgz",
+			"integrity": "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=20"
@@ -7732,6 +7222,46 @@
 			},
 			"engines": {
 				"node": ">= 14"
+			}
+		},
+		"node_modules/compress-commons/node_modules/buffer": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.2.1"
+			}
+		},
+		"node_modules/compress-commons/node_modules/readable-stream": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+			"integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+			"license": "MIT",
+			"dependencies": {
+				"abort-controller": "^3.0.0",
+				"buffer": "^6.0.3",
+				"events": "^3.3.0",
+				"process": "^0.11.10",
+				"string_decoder": "^1.3.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
 		},
 		"node_modules/concat-map": {
@@ -7811,9 +7341,9 @@
 			}
 		},
 		"node_modules/conf/node_modules/ajv": {
-			"version": "8.20.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-			"integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+			"version": "8.17.1",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
 			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
@@ -7827,9 +7357,9 @@
 			}
 		},
 		"node_modules/conf/node_modules/fast-uri": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-			"integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+			"integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
 			"funding": [
 				{
 					"type": "github",
@@ -7846,6 +7376,12 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
 			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"license": "MIT"
+		},
+		"node_modules/confbox": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.2.tgz",
+			"integrity": "sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==",
 			"license": "MIT"
 		},
 		"node_modules/console-control-strings": {
@@ -7934,20 +7470,51 @@
 				"node": ">= 14"
 			}
 		},
+		"node_modules/crc32-stream/node_modules/buffer": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.2.1"
+			}
+		},
+		"node_modules/crc32-stream/node_modules/readable-stream": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+			"integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+			"license": "MIT",
+			"dependencies": {
+				"abort-controller": "^3.0.0",
+				"buffer": "^6.0.3",
+				"events": "^3.3.0",
+				"process": "^0.11.10",
+				"string_decoder": "^1.3.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			}
+		},
 		"node_modules/crelt": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
 			"integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
 			"license": "MIT"
-		},
-		"node_modules/cross-dirname": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/cross-dirname/-/cross-dirname-0.1.0.tgz",
-			"integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true
 		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.6",
@@ -7964,14 +7531,14 @@
 			}
 		},
 		"node_modules/css-tree": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
-			"integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+			"integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"mdn-data": "2.27.1",
-				"source-map-js": "^1.2.1"
+				"mdn-data": "2.12.2",
+				"source-map-js": "^1.0.1"
 			},
 			"engines": {
 				"node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
@@ -7998,41 +7565,31 @@
 			}
 		},
 		"node_modules/cssstyle": {
-			"version": "5.3.7",
-			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
-			"integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
+			"version": "5.3.3",
+			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.3.tgz",
+			"integrity": "sha512-OytmFH+13/QXONJcC75QNdMtKpceNk3u8ThBjyyYjkEcy/ekBwR1mMAuNvi3gdBPW3N5TlCzQ0WZw8H0lN/bDw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@asamuzakjp/css-color": "^4.1.1",
-				"@csstools/css-syntax-patches-for-csstree": "^1.0.21",
-				"css-tree": "^3.1.0",
-				"lru-cache": "^11.2.4"
+				"@asamuzakjp/css-color": "^4.0.3",
+				"@csstools/css-syntax-patches-for-csstree": "^1.0.14",
+				"css-tree": "^3.1.0"
 			},
 			"engines": {
 				"node": ">=20"
-			}
-		},
-		"node_modules/cssstyle/node_modules/lru-cache": {
-			"version": "11.3.6",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
-			"integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": "20 || >=22"
 			}
 		},
 		"node_modules/csstype": {
 			"version": "3.2.3",
 			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
 			"integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/cytoscape": {
-			"version": "3.33.3",
-			"resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.3.tgz",
-			"integrity": "sha512-Gej7U+OKR+LZ8kvX7rb2HhCYJ0IhvEFsnkud4SB1PR+BUY/TsSO0dmOW59WEVLu51b1Rm+gQRKoz4bLYxGSZ2g==",
+			"version": "3.33.1",
+			"resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
+			"integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10"
@@ -8292,9 +7849,9 @@
 			}
 		},
 		"node_modules/d3-format": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
-			"integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+			"integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
 			"license": "ISC",
 			"engines": {
 				"node": ">=12"
@@ -8528,9 +8085,9 @@
 			}
 		},
 		"node_modules/dagre-d3-es": {
-			"version": "7.0.14",
-			"resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz",
-			"integrity": "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==",
+			"version": "7.0.13",
+			"resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.13.tgz",
+			"integrity": "sha512-efEhnxpSuwpYOKRm/L5KbqoZmNNukHa/Flty4Wp62JRvgH2ojwVgPgdYyr4twpieZnyRDdIH7PY2mopX26+j2Q==",
 			"license": "MIT",
 			"dependencies": {
 				"d3": "^7.9.0",
@@ -8538,25 +8095,15 @@
 			}
 		},
 		"node_modules/data-urls": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.1.tgz",
-			"integrity": "sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.0.tgz",
+			"integrity": "sha512-BnBS08aLUM+DKamupXs3w2tJJoqU+AkaE/+6vQxi/G/DPmIZFJJp9Dkb1kM03AZx8ADehDUZgsNxju3mPXZYIA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"whatwg-mimetype": "^5.0.0",
-				"whatwg-url": "^15.1.0"
+				"whatwg-mimetype": "^4.0.0",
+				"whatwg-url": "^15.0.0"
 			},
-			"engines": {
-				"node": ">=20"
-			}
-		},
-		"node_modules/data-urls/node_modules/whatwg-mimetype": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
-			"integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
-			"dev": true,
-			"license": "MIT",
 			"engines": {
 				"node": ">=20"
 			}
@@ -8626,9 +8173,9 @@
 			}
 		},
 		"node_modules/dayjs": {
-			"version": "1.11.20",
-			"resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
-			"integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+			"version": "1.11.19",
+			"resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.19.tgz",
+			"integrity": "sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==",
 			"license": "MIT"
 		},
 		"node_modules/debounce-fn": {
@@ -8686,9 +8233,9 @@
 			"license": "MIT"
 		},
 		"node_modules/decode-named-character-reference": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
-			"integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.2.0.tgz",
+			"integrity": "sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==",
 			"license": "MIT",
 			"dependencies": {
 				"character-entities": "^2.0.0"
@@ -8801,9 +8348,9 @@
 			}
 		},
 		"node_modules/delaunator": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
-			"integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.1.tgz",
+			"integrity": "sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==",
 			"license": "ISC",
 			"dependencies": {
 				"robust-predicates": "^3.0.2"
@@ -8882,9 +8429,9 @@
 			"license": "Apache-2.0"
 		},
 		"node_modules/diff": {
-			"version": "8.0.4",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
-			"integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+			"version": "8.0.3",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
+			"integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.3.1"
@@ -8901,48 +8448,6 @@
 			"resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
 			"integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
 			"license": "MIT"
-		},
-		"node_modules/dir-compare": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/dir-compare/-/dir-compare-4.2.0.tgz",
-			"integrity": "sha512-2xMCmOoMrdQIPHdsTawECdNPwlVFB9zGcz3kuhmBO6U3oU+UQjsue0i8ayLKpgBcm+hcXPMVSGUN9d+pvJ6+VQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"minimatch": "^3.0.5",
-				"p-limit": "^3.1.0 "
-			}
-		},
-		"node_modules/dir-compare/node_modules/balanced-match": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/dir-compare/node_modules/brace-expansion": {
-			"version": "1.1.14",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"node_modules/dir-compare/node_modules/minimatch": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
-			}
 		},
 		"node_modules/dlv": {
 			"version": "1.1.3",
@@ -8968,6 +8473,453 @@
 				"dmg-license": "^1.0.11"
 			}
 		},
+		"node_modules/dmg-builder/node_modules/@electron/get": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@electron/get/-/get-3.1.0.tgz",
+			"integrity": "sha512-F+nKc0xW+kVbBRhFzaMgPy3KwmuNTYX1fx6+FxxoSnNgwYX6LD7AKBTWkU0MQ6IBoe7dz069CNkR673sPAgkCQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.1.1",
+				"env-paths": "^2.2.0",
+				"fs-extra": "^8.1.0",
+				"got": "^11.8.5",
+				"progress": "^2.0.3",
+				"semver": "^6.2.0",
+				"sumchecker": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"optionalDependencies": {
+				"global-agent": "^3.0.0"
+			}
+		},
+		"node_modules/dmg-builder/node_modules/@electron/get/node_modules/fs-extra": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+			"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^4.0.0",
+				"universalify": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=6 <7 || >=8"
+			}
+		},
+		"node_modules/dmg-builder/node_modules/@electron/get/node_modules/semver": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			}
+		},
+		"node_modules/dmg-builder/node_modules/@electron/notarize": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@electron/notarize/-/notarize-2.5.0.tgz",
+			"integrity": "sha512-jNT8nwH1f9X5GEITXaQ8IF/KdskvIkOFfB2CvwumsveVidzpSc+mvhhTMdAGSYF3O+Nq49lJ7y+ssODRXu06+A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.1.1",
+				"fs-extra": "^9.0.1",
+				"promise-retry": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/dmg-builder/node_modules/@electron/notarize/node_modules/fs-extra": {
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+			"integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"at-least-node": "^1.0.0",
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/dmg-builder/node_modules/@electron/notarize/node_modules/jsonfile": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"universalify": "^2.0.0"
+			},
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.6"
+			}
+		},
+		"node_modules/dmg-builder/node_modules/@electron/notarize/node_modules/universalify": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/dmg-builder/node_modules/@electron/osx-sign": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/@electron/osx-sign/-/osx-sign-1.3.3.tgz",
+			"integrity": "sha512-KZ8mhXvWv2rIEgMbWZ4y33bDHyUKMXnx4M0sTyPNK/vcB81ImdeY9Ggdqy0SWbMDgmbqyQ+phgejh6V3R2QuSg==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"compare-version": "^0.1.2",
+				"debug": "^4.3.4",
+				"fs-extra": "^10.0.0",
+				"isbinaryfile": "^4.0.8",
+				"minimist": "^1.2.6",
+				"plist": "^3.0.5"
+			},
+			"bin": {
+				"electron-osx-flat": "bin/electron-osx-flat.js",
+				"electron-osx-sign": "bin/electron-osx-sign.js"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/dmg-builder/node_modules/@electron/osx-sign/node_modules/isbinaryfile": {
+			"version": "4.0.10",
+			"resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.10.tgz",
+			"integrity": "sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 8.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/gjtorikian/"
+			}
+		},
+		"node_modules/dmg-builder/node_modules/@electron/universal": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@electron/universal/-/universal-2.0.3.tgz",
+			"integrity": "sha512-Wn9sPYIVFRFl5HmwMJkARCCf7rqK/EurkfQ/rJZ14mHP3iYTjZSIOSVonEAnhWeAXwtw7zOekGRlc6yTtZ0t+g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@electron/asar": "^3.3.1",
+				"@malept/cross-spawn-promise": "^2.0.0",
+				"debug": "^4.3.1",
+				"dir-compare": "^4.2.0",
+				"fs-extra": "^11.1.1",
+				"minimatch": "^9.0.3",
+				"plist": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=16.4"
+			}
+		},
+		"node_modules/dmg-builder/node_modules/@electron/universal/node_modules/fs-extra": {
+			"version": "11.3.5",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
+			"integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=14.14"
+			}
+		},
+		"node_modules/dmg-builder/node_modules/@electron/universal/node_modules/jsonfile": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"universalify": "^2.0.0"
+			},
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.6"
+			}
+		},
+		"node_modules/dmg-builder/node_modules/@electron/universal/node_modules/minimatch": {
+			"version": "9.0.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+			"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.2"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/dmg-builder/node_modules/@electron/universal/node_modules/universalify": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/dmg-builder/node_modules/@malept/cross-spawn-promise": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-2.0.0.tgz",
+			"integrity": "sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://github.com/sponsors/malept"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/subscription/pkg/npm-.malept-cross-spawn-promise?utm_medium=referral&utm_source=npm_fund"
+				}
+			],
+			"license": "Apache-2.0",
+			"dependencies": {
+				"cross-spawn": "^7.0.1"
+			},
+			"engines": {
+				"node": ">= 12.13.0"
+			}
+		},
+		"node_modules/dmg-builder/node_modules/agent-base": {
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/dmg-builder/node_modules/app-builder-bin": {
+			"version": "5.0.0-alpha.12",
+			"resolved": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-5.0.0-alpha.12.tgz",
+			"integrity": "sha512-j87o0j6LqPL3QRr8yid6c+Tt5gC7xNfYo6uQIQkorAC6MpeayVMZrEDzKmJJ/Hlv7EnOQpaRm53k6ktDYZyB6w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/dmg-builder/node_modules/app-builder-lib": {
+			"version": "26.8.1",
+			"resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-26.8.1.tgz",
+			"integrity": "sha512-p0Im/Dx5C4tmz8QEE1Yn4MkuPC8PrnlRneMhWJj7BBXQfNTJUshM/bp3lusdEsDbvvfJZpXWnYesgSLvwtM2Zw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@develar/schema-utils": "~2.6.5",
+				"@electron/asar": "3.4.1",
+				"@electron/fuses": "^1.8.0",
+				"@electron/get": "^3.0.0",
+				"@electron/notarize": "2.5.0",
+				"@electron/osx-sign": "1.3.3",
+				"@electron/rebuild": "^4.0.3",
+				"@electron/universal": "2.0.3",
+				"@malept/flatpak-bundler": "^0.4.0",
+				"@types/fs-extra": "9.0.13",
+				"async-exit-hook": "^2.0.1",
+				"builder-util": "26.8.1",
+				"builder-util-runtime": "9.5.1",
+				"chromium-pickle-js": "^0.2.0",
+				"ci-info": "4.3.1",
+				"debug": "^4.3.4",
+				"dotenv": "^16.4.5",
+				"dotenv-expand": "^11.0.6",
+				"ejs": "^3.1.8",
+				"electron-publish": "26.8.1",
+				"fs-extra": "^10.1.0",
+				"hosted-git-info": "^4.1.0",
+				"isbinaryfile": "^5.0.0",
+				"jiti": "^2.4.2",
+				"js-yaml": "^4.1.0",
+				"json5": "^2.2.3",
+				"lazy-val": "^1.0.5",
+				"minimatch": "^10.0.3",
+				"plist": "3.1.0",
+				"proper-lockfile": "^4.1.2",
+				"resedit": "^1.7.0",
+				"semver": "~7.7.3",
+				"tar": "^7.5.7",
+				"temp-file": "^3.4.0",
+				"tiny-async-pool": "1.3.0",
+				"which": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"peerDependencies": {
+				"dmg-builder": "26.8.1",
+				"electron-builder-squirrel-windows": "26.8.1"
+			}
+		},
+		"node_modules/dmg-builder/node_modules/builder-util": {
+			"version": "26.8.1",
+			"resolved": "https://registry.npmjs.org/builder-util/-/builder-util-26.8.1.tgz",
+			"integrity": "sha512-pm1lTYbGyc90DHgCDO7eo8Rl4EqKLciayNbZqGziqnH9jrlKe8ZANGdityLZU+pJh16dfzjAx2xQq9McuIPEtw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/debug": "^4.1.6",
+				"7zip-bin": "~5.2.0",
+				"app-builder-bin": "5.0.0-alpha.12",
+				"builder-util-runtime": "9.5.1",
+				"chalk": "^4.1.2",
+				"cross-spawn": "^7.0.6",
+				"debug": "^4.3.4",
+				"fs-extra": "^10.1.0",
+				"http-proxy-agent": "^7.0.0",
+				"https-proxy-agent": "^7.0.0",
+				"js-yaml": "^4.1.0",
+				"sanitize-filename": "^1.6.3",
+				"source-map-support": "^0.5.19",
+				"stat-mode": "^1.0.0",
+				"temp-file": "^3.4.0",
+				"tiny-async-pool": "1.3.0"
+			}
+		},
+		"node_modules/dmg-builder/node_modules/builder-util-runtime": {
+			"version": "9.5.1",
+			"resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.5.1.tgz",
+			"integrity": "sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.3.4",
+				"sax": "^1.2.4"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/dmg-builder/node_modules/chownr": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+			"integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/dmg-builder/node_modules/ci-info": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz",
+			"integrity": "sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/sibiraj-s"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/dmg-builder/node_modules/dir-compare": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/dir-compare/-/dir-compare-4.2.0.tgz",
+			"integrity": "sha512-2xMCmOoMrdQIPHdsTawECdNPwlVFB9zGcz3kuhmBO6U3oU+UQjsue0i8ayLKpgBcm+hcXPMVSGUN9d+pvJ6+VQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"minimatch": "^3.0.5",
+				"p-limit": "^3.1.0 "
+			}
+		},
+		"node_modules/dmg-builder/node_modules/dir-compare/node_modules/brace-expansion": {
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/dmg-builder/node_modules/dir-compare/node_modules/minimatch": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/dmg-builder/node_modules/dotenv": {
+			"version": "16.6.1",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+			"integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://dotenvx.com"
+			}
+		},
+		"node_modules/dmg-builder/node_modules/dotenv-expand": {
+			"version": "11.0.7",
+			"resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-11.0.7.tgz",
+			"integrity": "sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"dotenv": "^16.4.5"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://dotenvx.com"
+			}
+		},
+		"node_modules/dmg-builder/node_modules/electron-publish": {
+			"version": "26.8.1",
+			"resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-26.8.1.tgz",
+			"integrity": "sha512-q+jrSTIh/Cv4eGZa7oVR+grEJo/FoLMYBAnSL5GCtqwUpr1T+VgKB/dn1pnzxIxqD8S/jP1yilT9VrwCqINR4w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/fs-extra": "^9.0.11",
+				"builder-util": "26.8.1",
+				"builder-util-runtime": "9.5.1",
+				"chalk": "^4.1.2",
+				"form-data": "^4.0.5",
+				"fs-extra": "^10.1.0",
+				"lazy-val": "^1.0.5",
+				"mime": "^2.5.2"
+			}
+		},
 		"node_modules/dmg-builder/node_modules/fs-extra": {
 			"version": "10.1.0",
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
@@ -8983,7 +8935,7 @@
 				"node": ">=12"
 			}
 		},
-		"node_modules/dmg-builder/node_modules/jsonfile": {
+		"node_modules/dmg-builder/node_modules/fs-extra/node_modules/jsonfile": {
 			"version": "6.2.1",
 			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
 			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
@@ -8996,7 +8948,7 @@
 				"graceful-fs": "^4.1.6"
 			}
 		},
-		"node_modules/dmg-builder/node_modules/universalify": {
+		"node_modules/dmg-builder/node_modules/fs-extra/node_modules/universalify": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
 			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
@@ -9004,6 +8956,188 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/dmg-builder/node_modules/http-proxy-agent": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/dmg-builder/node_modules/https-proxy-agent": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/dmg-builder/node_modules/isexe": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
+			"integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/dmg-builder/node_modules/jiti": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+			"integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"jiti": "lib/jiti-cli.mjs"
+			}
+		},
+		"node_modules/dmg-builder/node_modules/minimatch": {
+			"version": "10.2.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"brace-expansion": "^5.0.5"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/dmg-builder/node_modules/minimatch/node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/dmg-builder/node_modules/minimatch/node_modules/brace-expansion": {
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/dmg-builder/node_modules/minipass": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			}
+		},
+		"node_modules/dmg-builder/node_modules/minizlib": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+			"integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"minipass": "^7.1.2"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/dmg-builder/node_modules/p-limit": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"yocto-queue": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/dmg-builder/node_modules/semver": {
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/dmg-builder/node_modules/tar": {
+			"version": "7.5.15",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
+			"integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"@isaacs/fs-minipass": "^4.0.0",
+				"chownr": "^3.0.0",
+				"minipass": "^7.1.2",
+				"minizlib": "^3.1.0",
+				"yallist": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/dmg-builder/node_modules/which": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
+			"integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"isexe": "^3.1.1"
+			},
+			"bin": {
+				"node-which": "bin/which.js"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/dmg-builder/node_modules/yallist": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+			"integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/dmg-license": {
@@ -9046,18 +9180,10 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/dom-accessibility-api": {
-			"version": "0.5.16",
-			"resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
-			"integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true
-		},
 		"node_modules/dompurify": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.2.tgz",
-			"integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.0.tgz",
+			"integrity": "sha512-r+f6MYR1gGN1eJv0TVQbhA7if/U7P87cdPl3HN5rikqaBSBxLiCb/b9O+2eG0cxz0ghyU+mU1QkbsOwERMYlWQ==",
 			"license": "(MPL-2.0 OR Apache-2.0)",
 			"optionalDependencies": {
 				"@types/trusted-types": "^2.0.7"
@@ -9076,35 +9202,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/dotenv": {
-			"version": "16.6.1",
-			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-			"integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://dotenvx.com"
-			}
-		},
-		"node_modules/dotenv-expand": {
-			"version": "11.0.7",
-			"resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-11.0.7.tgz",
-			"integrity": "sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"dotenv": "^16.4.5"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://dotenvx.com"
 			}
 		},
 		"node_modules/dunder-proto": {
@@ -9134,20 +9231,6 @@
 				"stream-shift": "^1.0.2"
 			}
 		},
-		"node_modules/duplexify/node_modules/readable-stream": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-			"license": "MIT",
-			"dependencies": {
-				"inherits": "^2.0.3",
-				"string_decoder": "^1.1.1",
-				"util-deprecate": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
 		"node_modules/eastasianwidth": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -9171,9 +9254,9 @@
 			}
 		},
 		"node_modules/electron": {
-			"version": "41.6.0",
-			"resolved": "https://registry.npmjs.org/electron/-/electron-41.6.0.tgz",
-			"integrity": "sha512-5UWV5FXkYMzCDV6FvLCa5mzlCBtlX/H1Af27TD5di+4CUCPi0/ZmWPBdSBlYrunsBlUvlcpW8X0NurW4zesQ6g==",
+			"version": "41.6.1",
+			"resolved": "https://registry.npmjs.org/electron/-/electron-41.6.1.tgz",
+			"integrity": "sha512-3y1Q0AkPnqwaJJZV146KlZ63VIVlQVlWdLiArkwnGUOxZAZD5cvag4TMUsu/gN+FZhkkpelgvdTXPZvTb34I8A==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -9215,17 +9298,344 @@
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/electron-builder-squirrel-windows": {
-			"version": "26.8.1",
-			"resolved": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-26.8.1.tgz",
-			"integrity": "sha512-o288fIdgPLHA76eDrFADHPoo7VyGkDCYbLV1GzndaMSAVBoZrGvM9m2IehdcVMzdAZJ2eV9bgyissQXHv5tGzA==",
+		"node_modules/electron-builder/node_modules/@electron/get": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@electron/get/-/get-3.1.0.tgz",
+			"integrity": "sha512-F+nKc0xW+kVbBRhFzaMgPy3KwmuNTYX1fx6+FxxoSnNgwYX6LD7AKBTWkU0MQ6IBoe7dz069CNkR673sPAgkCQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
-				"app-builder-lib": "26.8.1",
+				"debug": "^4.1.1",
+				"env-paths": "^2.2.0",
+				"fs-extra": "^8.1.0",
+				"got": "^11.8.5",
+				"progress": "^2.0.3",
+				"semver": "^6.2.0",
+				"sumchecker": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"optionalDependencies": {
+				"global-agent": "^3.0.0"
+			}
+		},
+		"node_modules/electron-builder/node_modules/@electron/get/node_modules/fs-extra": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+			"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^4.0.0",
+				"universalify": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=6 <7 || >=8"
+			}
+		},
+		"node_modules/electron-builder/node_modules/@electron/get/node_modules/jsonfile": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+			"integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+			"dev": true,
+			"license": "MIT",
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.6"
+			}
+		},
+		"node_modules/electron-builder/node_modules/@electron/get/node_modules/semver": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			}
+		},
+		"node_modules/electron-builder/node_modules/@electron/get/node_modules/universalify": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4.0.0"
+			}
+		},
+		"node_modules/electron-builder/node_modules/@electron/notarize": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@electron/notarize/-/notarize-2.5.0.tgz",
+			"integrity": "sha512-jNT8nwH1f9X5GEITXaQ8IF/KdskvIkOFfB2CvwumsveVidzpSc+mvhhTMdAGSYF3O+Nq49lJ7y+ssODRXu06+A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.1.1",
+				"fs-extra": "^9.0.1",
+				"promise-retry": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/electron-builder/node_modules/@electron/notarize/node_modules/fs-extra": {
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+			"integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"at-least-node": "^1.0.0",
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/electron-builder/node_modules/@electron/osx-sign": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/@electron/osx-sign/-/osx-sign-1.3.3.tgz",
+			"integrity": "sha512-KZ8mhXvWv2rIEgMbWZ4y33bDHyUKMXnx4M0sTyPNK/vcB81ImdeY9Ggdqy0SWbMDgmbqyQ+phgejh6V3R2QuSg==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"compare-version": "^0.1.2",
+				"debug": "^4.3.4",
+				"fs-extra": "^10.0.0",
+				"isbinaryfile": "^4.0.8",
+				"minimist": "^1.2.6",
+				"plist": "^3.0.5"
+			},
+			"bin": {
+				"electron-osx-flat": "bin/electron-osx-flat.js",
+				"electron-osx-sign": "bin/electron-osx-sign.js"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/electron-builder/node_modules/@electron/osx-sign/node_modules/isbinaryfile": {
+			"version": "4.0.10",
+			"resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.10.tgz",
+			"integrity": "sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 8.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/gjtorikian/"
+			}
+		},
+		"node_modules/electron-builder/node_modules/@electron/universal": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@electron/universal/-/universal-2.0.3.tgz",
+			"integrity": "sha512-Wn9sPYIVFRFl5HmwMJkARCCf7rqK/EurkfQ/rJZ14mHP3iYTjZSIOSVonEAnhWeAXwtw7zOekGRlc6yTtZ0t+g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@electron/asar": "^3.3.1",
+				"@malept/cross-spawn-promise": "^2.0.0",
+				"debug": "^4.3.1",
+				"dir-compare": "^4.2.0",
+				"fs-extra": "^11.1.1",
+				"minimatch": "^9.0.3",
+				"plist": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=16.4"
+			}
+		},
+		"node_modules/electron-builder/node_modules/@electron/universal/node_modules/fs-extra": {
+			"version": "11.3.5",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
+			"integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=14.14"
+			}
+		},
+		"node_modules/electron-builder/node_modules/@electron/universal/node_modules/minimatch": {
+			"version": "9.0.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+			"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.2"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/electron-builder/node_modules/@malept/cross-spawn-promise": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-2.0.0.tgz",
+			"integrity": "sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://github.com/sponsors/malept"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/subscription/pkg/npm-.malept-cross-spawn-promise?utm_medium=referral&utm_source=npm_fund"
+				}
+			],
+			"license": "Apache-2.0",
+			"dependencies": {
+				"cross-spawn": "^7.0.1"
+			},
+			"engines": {
+				"node": ">= 12.13.0"
+			}
+		},
+		"node_modules/electron-builder/node_modules/agent-base": {
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/electron-builder/node_modules/app-builder-bin": {
+			"version": "5.0.0-alpha.12",
+			"resolved": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-5.0.0-alpha.12.tgz",
+			"integrity": "sha512-j87o0j6LqPL3QRr8yid6c+Tt5gC7xNfYo6uQIQkorAC6MpeayVMZrEDzKmJJ/Hlv7EnOQpaRm53k6ktDYZyB6w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/electron-builder/node_modules/app-builder-lib": {
+			"version": "26.8.1",
+			"resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-26.8.1.tgz",
+			"integrity": "sha512-p0Im/Dx5C4tmz8QEE1Yn4MkuPC8PrnlRneMhWJj7BBXQfNTJUshM/bp3lusdEsDbvvfJZpXWnYesgSLvwtM2Zw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@develar/schema-utils": "~2.6.5",
+				"@electron/asar": "3.4.1",
+				"@electron/fuses": "^1.8.0",
+				"@electron/get": "^3.0.0",
+				"@electron/notarize": "2.5.0",
+				"@electron/osx-sign": "1.3.3",
+				"@electron/rebuild": "^4.0.3",
+				"@electron/universal": "2.0.3",
+				"@malept/flatpak-bundler": "^0.4.0",
+				"@types/fs-extra": "9.0.13",
+				"async-exit-hook": "^2.0.1",
 				"builder-util": "26.8.1",
-				"electron-winstaller": "5.4.0"
+				"builder-util-runtime": "9.5.1",
+				"chromium-pickle-js": "^0.2.0",
+				"ci-info": "4.3.1",
+				"debug": "^4.3.4",
+				"dotenv": "^16.4.5",
+				"dotenv-expand": "^11.0.6",
+				"ejs": "^3.1.8",
+				"electron-publish": "26.8.1",
+				"fs-extra": "^10.1.0",
+				"hosted-git-info": "^4.1.0",
+				"isbinaryfile": "^5.0.0",
+				"jiti": "^2.4.2",
+				"js-yaml": "^4.1.0",
+				"json5": "^2.2.3",
+				"lazy-val": "^1.0.5",
+				"minimatch": "^10.0.3",
+				"plist": "3.1.0",
+				"proper-lockfile": "^4.1.2",
+				"resedit": "^1.7.0",
+				"semver": "~7.7.3",
+				"tar": "^7.5.7",
+				"temp-file": "^3.4.0",
+				"tiny-async-pool": "1.3.0",
+				"which": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"peerDependencies": {
+				"dmg-builder": "26.8.1",
+				"electron-builder-squirrel-windows": "26.8.1"
+			}
+		},
+		"node_modules/electron-builder/node_modules/app-builder-lib/node_modules/ci-info": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz",
+			"integrity": "sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/sibiraj-s"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/electron-builder/node_modules/builder-util": {
+			"version": "26.8.1",
+			"resolved": "https://registry.npmjs.org/builder-util/-/builder-util-26.8.1.tgz",
+			"integrity": "sha512-pm1lTYbGyc90DHgCDO7eo8Rl4EqKLciayNbZqGziqnH9jrlKe8ZANGdityLZU+pJh16dfzjAx2xQq9McuIPEtw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/debug": "^4.1.6",
+				"7zip-bin": "~5.2.0",
+				"app-builder-bin": "5.0.0-alpha.12",
+				"builder-util-runtime": "9.5.1",
+				"chalk": "^4.1.2",
+				"cross-spawn": "^7.0.6",
+				"debug": "^4.3.4",
+				"fs-extra": "^10.1.0",
+				"http-proxy-agent": "^7.0.0",
+				"https-proxy-agent": "^7.0.0",
+				"js-yaml": "^4.1.0",
+				"sanitize-filename": "^1.6.3",
+				"source-map-support": "^0.5.19",
+				"stat-mode": "^1.0.0",
+				"temp-file": "^3.4.0",
+				"tiny-async-pool": "1.3.0"
+			}
+		},
+		"node_modules/electron-builder/node_modules/builder-util-runtime": {
+			"version": "9.5.1",
+			"resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.5.1.tgz",
+			"integrity": "sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.3.4",
+				"sax": "^1.2.4"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/electron-builder/node_modules/chownr": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+			"integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/electron-builder/node_modules/ci-info": {
@@ -9244,55 +9654,71 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/electron-builder/node_modules/fs-extra": {
-			"version": "10.1.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-			"integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+		"node_modules/electron-builder/node_modules/dir-compare": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/dir-compare/-/dir-compare-4.2.0.tgz",
+			"integrity": "sha512-2xMCmOoMrdQIPHdsTawECdNPwlVFB9zGcz3kuhmBO6U3oU+UQjsue0i8ayLKpgBcm+hcXPMVSGUN9d+pvJ6+VQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"graceful-fs": "^4.2.0",
-				"jsonfile": "^6.0.1",
-				"universalify": "^2.0.0"
+				"minimatch": "^3.0.5",
+				"p-limit": "^3.1.0 "
+			}
+		},
+		"node_modules/electron-builder/node_modules/dir-compare/node_modules/brace-expansion": {
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/electron-builder/node_modules/dir-compare/node_modules/minimatch": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/electron-builder/node_modules/dotenv": {
+			"version": "16.6.1",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+			"integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://dotenvx.com"
+			}
+		},
+		"node_modules/electron-builder/node_modules/dotenv-expand": {
+			"version": "11.0.7",
+			"resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-11.0.7.tgz",
+			"integrity": "sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"dotenv": "^16.4.5"
 			},
 			"engines": {
 				"node": ">=12"
-			}
-		},
-		"node_modules/electron-builder/node_modules/jsonfile": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"universalify": "^2.0.0"
 			},
-			"optionalDependencies": {
-				"graceful-fs": "^4.1.6"
+			"funding": {
+				"url": "https://dotenvx.com"
 			}
 		},
-		"node_modules/electron-builder/node_modules/universalify": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 10.0.0"
-			}
-		},
-		"node_modules/electron-devtools-installer": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/electron-devtools-installer/-/electron-devtools-installer-4.0.0.tgz",
-			"integrity": "sha512-9Tntu/jtfSn0n6N/ZI6IdvRqXpDyLQiDuuIbsBI+dL+1Ef7C8J2JwByw58P3TJiNeuqyV3ZkphpNWuZK5iSY2w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"unzip-crx-3": "^0.2.0"
-			}
-		},
-		"node_modules/electron-publish": {
+		"node_modules/electron-builder/node_modules/electron-publish": {
 			"version": "26.8.1",
 			"resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-26.8.1.tgz",
 			"integrity": "sha512-q+jrSTIh/Cv4eGZa7oVR+grEJo/FoLMYBAnSL5GCtqwUpr1T+VgKB/dn1pnzxIxqD8S/jP1yilT9VrwCqINR4w==",
@@ -9309,7 +9735,7 @@
 				"mime": "^2.5.2"
 			}
 		},
-		"node_modules/electron-publish/node_modules/fs-extra": {
+		"node_modules/electron-builder/node_modules/fs-extra": {
 			"version": "10.1.0",
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
 			"integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
@@ -9324,10 +9750,58 @@
 				"node": ">=12"
 			}
 		},
-		"node_modules/electron-publish/node_modules/jsonfile": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+		"node_modules/electron-builder/node_modules/http-proxy-agent": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/electron-builder/node_modules/https-proxy-agent": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/electron-builder/node_modules/isexe": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
+			"integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/electron-builder/node_modules/jiti": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+			"integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"jiti": "lib/jiti-cli.mjs"
+			}
+		},
+		"node_modules/electron-builder/node_modules/jsonfile": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+			"integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -9337,20 +9811,115 @@
 				"graceful-fs": "^4.1.6"
 			}
 		},
-		"node_modules/electron-publish/node_modules/mime": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
-			"integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+		"node_modules/electron-builder/node_modules/minimatch": {
+			"version": "10.2.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
 			"dev": true,
-			"license": "MIT",
-			"bin": {
-				"mime": "cli.js"
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"brace-expansion": "^5.0.5"
 			},
 			"engines": {
-				"node": ">=4.0.0"
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/electron-publish/node_modules/universalify": {
+		"node_modules/electron-builder/node_modules/minimatch/node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/electron-builder/node_modules/minimatch/node_modules/brace-expansion": {
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/electron-builder/node_modules/minipass": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			}
+		},
+		"node_modules/electron-builder/node_modules/minizlib": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+			"integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"minipass": "^7.1.2"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/electron-builder/node_modules/p-limit": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"yocto-queue": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/electron-builder/node_modules/semver": {
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/electron-builder/node_modules/tar": {
+			"version": "7.5.15",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
+			"integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"@isaacs/fs-minipass": "^4.0.0",
+				"chownr": "^3.0.0",
+				"minipass": "^7.1.2",
+				"minizlib": "^3.1.0",
+				"yallist": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/electron-builder/node_modules/universalify": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
 			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
@@ -9358,6 +9927,42 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/electron-builder/node_modules/which": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
+			"integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"isexe": "^3.1.1"
+			},
+			"bin": {
+				"node-which": "bin/which.js"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/electron-builder/node_modules/yallist": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+			"integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/electron-devtools-installer": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/electron-devtools-installer/-/electron-devtools-installer-4.0.0.tgz",
+			"integrity": "sha512-9Tntu/jtfSn0n6N/ZI6IdvRqXpDyLQiDuuIbsBI+dL+1Ef7C8J2JwByw58P3TJiNeuqyV3ZkphpNWuZK5iSY2w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"unzip-crx-3": "^0.2.0"
 			}
 		},
 		"node_modules/electron-rebuild": {
@@ -9390,6 +9995,29 @@
 				"node": ">=12.13.0"
 			}
 		},
+		"node_modules/electron-rebuild/node_modules/@malept/cross-spawn-promise": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-2.0.0.tgz",
+			"integrity": "sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://github.com/sponsors/malept"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/subscription/pkg/npm-.malept-cross-spawn-promise?utm_medium=referral&utm_source=npm_fund"
+				}
+			],
+			"license": "Apache-2.0",
+			"dependencies": {
+				"cross-spawn": "^7.0.1"
+			},
+			"engines": {
+				"node": ">= 12.13.0"
+			}
+		},
 		"node_modules/electron-rebuild/node_modules/fs-extra": {
 			"version": "10.1.0",
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
@@ -9406,9 +10034,9 @@
 			}
 		},
 		"node_modules/electron-rebuild/node_modules/jsonfile": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+			"integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -9442,9 +10070,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.352",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.352.tgz",
-			"integrity": "sha512-9wHk8x6dyuimoe18EdiDPWKExNdxYqo4fn4FwOVVper6RxT3cmpBwBkWWfSOCYJjQdIco/nPhJhNLmn4Ufg1Yg==",
+			"version": "1.5.259",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.259.tgz",
+			"integrity": "sha512-I+oLXgpEJzD6Cwuwt1gYjxsDmu/S/Kd41mmLA3O+/uH2pFRO/DvOjUyGozL8j3KeLV6WyZ7ssPwELMsXCcsJAQ==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -9464,6 +10092,19 @@
 				"tiny-typed-emitter": "^2.1.0"
 			}
 		},
+		"node_modules/electron-updater/node_modules/builder-util-runtime": {
+			"version": "9.5.1",
+			"resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.5.1.tgz",
+			"integrity": "sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ==",
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.3.4",
+				"sax": "^1.2.4"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
 		"node_modules/electron-updater/node_modules/fs-extra": {
 			"version": "10.1.0",
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
@@ -9479,15 +10120,27 @@
 			}
 		},
 		"node_modules/electron-updater/node_modules/jsonfile": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+			"integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
 			"license": "MIT",
 			"dependencies": {
 				"universalify": "^2.0.0"
 			},
 			"optionalDependencies": {
 				"graceful-fs": "^4.1.6"
+			}
+		},
+		"node_modules/electron-updater/node_modules/semver": {
+			"version": "7.7.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/electron-updater/node_modules/universalify": {
@@ -9497,44 +10150,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 10.0.0"
-			}
-		},
-		"node_modules/electron-winstaller": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/electron-winstaller/-/electron-winstaller-5.4.0.tgz",
-			"integrity": "sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==",
-			"dev": true,
-			"hasInstallScript": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@electron/asar": "^3.2.1",
-				"debug": "^4.1.1",
-				"fs-extra": "^7.0.1",
-				"lodash": "^4.17.21",
-				"temp": "^0.9.0"
-			},
-			"engines": {
-				"node": ">=8.0.0"
-			},
-			"optionalDependencies": {
-				"@electron/windows-sign": "^1.1.2"
-			}
-		},
-		"node_modules/electron-winstaller/node_modules/fs-extra": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-			"integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"graceful-fs": "^4.1.2",
-				"jsonfile": "^4.0.0",
-				"universalify": "^0.1.0"
-			},
-			"engines": {
-				"node": ">=6 <7 || >=8"
 			}
 		},
 		"node_modules/electron/node_modules/@types/node": {
@@ -9553,13 +10168,6 @@
 			"integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/emoji-mart": {
-			"version": "5.6.0",
-			"resolved": "https://registry.npmjs.org/emoji-mart/-/emoji-mart-5.6.0.tgz",
-			"integrity": "sha512-eJp3QRe79pjwa+duv+n7+5YsNhRcMl812EcFVwrnRvYKoNPoQb5qxU8DG6Bgwji0akHdp6D4Ln6tYLG58MFSow==",
-			"license": "MIT",
-			"peer": true
 		},
 		"node_modules/emoji-regex": {
 			"version": "8.0.0",
@@ -9613,9 +10221,9 @@
 			"license": "MIT"
 		},
 		"node_modules/es-abstract": {
-			"version": "1.24.2",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
-			"integrity": "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==",
+			"version": "1.24.1",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.1.tgz",
+			"integrity": "sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -9702,16 +10310,16 @@
 			}
 		},
 		"node_modules/es-iterator-helpers": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.3.2.tgz",
-			"integrity": "sha512-HVLACW1TppGYjJ8H6/jqH/pqOtKRw6wMlrB23xfExmFWxFquAIWCmwoLsOyN96K4a5KbmOf5At9ZUO3GZbetAw==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.2.2.tgz",
+			"integrity": "sha512-BrUQ0cPTB/IwXj23HtwHjS9n7O4h9FX94b4xc5zlTHxeLgTAdzYUDyy6KdExAl9lbN5rtfe44xpjpmj9grxs5w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"call-bind": "^1.0.9",
+				"call-bind": "^1.0.8",
 				"call-bound": "^1.0.4",
 				"define-properties": "^1.2.1",
-				"es-abstract": "^1.24.2",
+				"es-abstract": "^1.24.1",
 				"es-errors": "^1.3.0",
 				"es-set-tostringtag": "^2.1.0",
 				"function-bind": "^1.1.2",
@@ -9723,7 +10331,7 @@
 				"has-symbols": "^1.1.0",
 				"internal-slot": "^1.1.0",
 				"iterator.prototype": "^1.1.5",
-				"math-intrinsics": "^1.1.0"
+				"safe-array-concat": "^1.1.3"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -9797,9 +10405,9 @@
 			}
 		},
 		"node_modules/es-toolkit": {
-			"version": "1.46.1",
-			"resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.1.tgz",
-			"integrity": "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==",
+			"version": "1.43.0",
+			"resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.43.0.tgz",
+			"integrity": "sha512-SKCT8AsWvYzBBuUqMk4NPwFlSdqLpJwmy6AP322ERn8W2YLIB6JBXnwMI2Qsh2gfphT3q7EKAxKb23cvFHFwKA==",
 			"license": "MIT",
 			"workspaces": [
 				"docs",
@@ -9886,25 +10494,25 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "9.39.4",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
-			"integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+			"version": "9.39.2",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz",
+			"integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.1",
-				"@eslint/config-array": "^0.21.2",
+				"@eslint/config-array": "^0.21.1",
 				"@eslint/config-helpers": "^0.4.2",
 				"@eslint/core": "^0.17.0",
-				"@eslint/eslintrc": "^3.3.5",
-				"@eslint/js": "9.39.4",
+				"@eslint/eslintrc": "^3.3.1",
+				"@eslint/js": "9.39.2",
 				"@eslint/plugin-kit": "^0.4.1",
 				"@humanfs/node": "^0.16.6",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@humanwhocodes/retry": "^0.4.2",
 				"@types/estree": "^1.0.6",
-				"ajv": "^6.14.0",
+				"ajv": "^6.12.4",
 				"chalk": "^4.0.0",
 				"cross-spawn": "^7.0.6",
 				"debug": "^4.3.2",
@@ -9923,7 +10531,7 @@
 				"is-glob": "^4.0.0",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
 				"lodash.merge": "^4.6.2",
-				"minimatch": "^3.1.5",
+				"minimatch": "^3.1.2",
 				"natural-compare": "^1.4.0",
 				"optionator": "^0.9.3"
 			},
@@ -9995,9 +10603,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-react-hooks": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
-			"integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.0.1.tgz",
+			"integrity": "sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -10011,20 +10619,13 @@
 				"node": ">=18"
 			},
 			"peerDependencies": {
-				"eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
+				"eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
 			}
 		},
-		"node_modules/eslint-plugin-react/node_modules/balanced-match": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/eslint-plugin-react/node_modules/brace-expansion": {
-			"version": "1.1.14",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -10033,9 +10634,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-react/node_modules/minimatch": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -10043,6 +10644,24 @@
 			},
 			"engines": {
 				"node": "*"
+			}
+		},
+		"node_modules/eslint-plugin-react/node_modules/resolve": {
+			"version": "2.0.0-next.5",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
+			"integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-core-module": "^2.13.0",
+				"path-parse": "^1.0.7",
+				"supports-preserve-symlinks-flag": "^1.0.0"
+			},
+			"bin": {
+				"resolve": "bin/resolve"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/eslint-plugin-react/node_modules/semver": {
@@ -10085,17 +10704,10 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
-		"node_modules/eslint/node_modules/balanced-match": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/eslint/node_modules/brace-expansion": {
-			"version": "1.1.14",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -10116,17 +10728,21 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
-		"node_modules/eslint/node_modules/glob-parent": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-			"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+		"node_modules/eslint/node_modules/find-up": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
 			"dev": true,
-			"license": "ISC",
+			"license": "MIT",
 			"dependencies": {
-				"is-glob": "^4.0.3"
+				"locate-path": "^6.0.0",
+				"path-exists": "^4.0.0"
 			},
 			"engines": {
-				"node": ">=10.13.0"
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/eslint/node_modules/ignore": {
@@ -10139,10 +10755,26 @@
 				"node": ">= 4"
 			}
 		},
+		"node_modules/eslint/node_modules/locate-path": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"p-locate": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/eslint/node_modules/minimatch": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -10150,6 +10782,48 @@
 			},
 			"engines": {
 				"node": "*"
+			}
+		},
+		"node_modules/eslint/node_modules/p-limit": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"yocto-queue": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/eslint/node_modules/p-locate": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"p-limit": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/eslint/node_modules/path-exists": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/espree": {
@@ -10184,9 +10858,9 @@
 			}
 		},
 		"node_modules/esquery": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
-			"integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+			"integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
@@ -10259,9 +10933,9 @@
 			}
 		},
 		"node_modules/eventemitter3": {
-			"version": "5.0.4",
-			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
-			"integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+			"integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
 			"license": "MIT"
 		},
 		"node_modules/events": {
@@ -10307,6 +10981,12 @@
 			"integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
 			"dev": true,
 			"license": "Apache-2.0"
+		},
+		"node_modules/exsolve": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
+			"integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
+			"license": "MIT"
 		},
 		"node_modules/extend": {
 			"version": "3.0.2",
@@ -10387,6 +11067,19 @@
 				"node": ">=8.6.0"
 			}
 		},
+		"node_modules/fast-glob/node_modules/glob-parent": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"is-glob": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
 		"node_modules/fast-json-stable-stringify": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -10410,9 +11103,9 @@
 			}
 		},
 		"node_modules/fast-json-stringify/node_modules/ajv": {
-			"version": "8.20.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-			"integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+			"version": "8.17.1",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
 			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
@@ -10443,9 +11136,9 @@
 			}
 		},
 		"node_modules/fast-json-stringify/node_modules/ajv/node_modules/fast-uri": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-			"integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+			"integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
 			"funding": [
 				{
 					"type": "github",
@@ -10527,9 +11220,9 @@
 			"license": "MIT"
 		},
 		"node_modules/fastq": {
-			"version": "1.20.1",
-			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
-			"integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+			"version": "1.19.1",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
+			"integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
 			"license": "ISC",
 			"dependencies": {
 				"reusify": "^1.0.4"
@@ -10558,24 +11251,6 @@
 				"pend": "~1.2.0"
 			}
 		},
-		"node_modules/fdir": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12.0.0"
-			},
-			"peerDependencies": {
-				"picomatch": "^3 || ^4"
-			},
-			"peerDependenciesMeta": {
-				"picomatch": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/file-entry-cache": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -10596,43 +11271,13 @@
 			"license": "MIT"
 		},
 		"node_modules/filelist": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.6.tgz",
-			"integrity": "sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
+			"integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"minimatch": "^5.0.1"
-			}
-		},
-		"node_modules/filelist/node_modules/balanced-match": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/filelist/node_modules/brace-expansion": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-			"integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0"
-			}
-		},
-		"node_modules/filelist/node_modules/minimatch": {
-			"version": "5.1.9",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-			"integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/fill-range": {
@@ -10662,20 +11307,15 @@
 			}
 		},
 		"node_modules/find-up": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-			"dev": true,
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+			"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
 			"license": "MIT",
 			"dependencies": {
-				"locate-path": "^6.0.0",
-				"path-exists": "^4.0.0"
+				"locate-path": "^3.0.0"
 			},
 			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
+				"node": ">=6"
 			}
 		},
 		"node_modules/find-yarn-workspace-root": {
@@ -10703,9 +11343,9 @@
 			}
 		},
 		"node_modules/flatted": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
-			"integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+			"integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -10939,19 +11579,6 @@
 			"dev": true,
 			"license": "ISC"
 		},
-		"node_modules/gauge/node_modules/strip-ansi": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/generator-function": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
@@ -11073,66 +11700,62 @@
 			"license": "ISC"
 		},
 		"node_modules/glob": {
-			"version": "10.5.0",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-			"integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+			"deprecated": "Glob versions prior to v9 are no longer supported",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"foreground-child": "^3.1.0",
-				"jackspeak": "^3.1.2",
-				"minimatch": "^9.0.4",
-				"minipass": "^7.1.2",
-				"package-json-from-dist": "^1.0.0",
-				"path-scurry": "^1.11.1"
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.1.1",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
 			},
-			"bin": {
-				"glob": "dist/esm/bin.mjs"
+			"engines": {
+				"node": "*"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/glob-parent": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+			"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"is-glob": "^4.0.1"
+				"is-glob": "^4.0.3"
 			},
 			"engines": {
-				"node": ">= 6"
+				"node": ">=10.13.0"
 			}
 		},
-		"node_modules/glob/node_modules/balanced-match": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"license": "MIT"
-		},
 		"node_modules/glob/node_modules/brace-expansion": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-			"integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"balanced-match": "^1.0.0"
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
 			}
 		},
 		"node_modules/glob/node_modules/minimatch": {
-			"version": "9.0.9",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-			"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"brace-expansion": "^2.0.2"
+				"brace-expansion": "^1.1.7"
 			},
 			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
+				"node": "*"
 			}
 		},
 		"node_modules/global-agent": {
@@ -11324,9 +11947,9 @@
 			"license": "ISC"
 		},
 		"node_modules/hasown": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-			"integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -11609,16 +12232,16 @@
 			"license": "ISC"
 		},
 		"node_modules/html-encoding-sniffer": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
-			"integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+			"integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@exodus/bytes": "^1.6.0"
+				"whatwg-encoding": "^3.1.1"
 			},
 			"engines": {
-				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+				"node": ">=18"
 			}
 		},
 		"node_modules/html-escaper": {
@@ -11758,14 +12381,6 @@
 				"node": "^8.11.2 || >=10"
 			}
 		},
-		"node_modules/iconv-corefoundation/node_modules/node-addon-api": {
-			"version": "1.7.2",
-			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
-			"integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true
-		},
 		"node_modules/iconv-lite": {
 			"version": "0.6.3",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -11857,16 +12472,6 @@
 				"node": ">=18"
 			}
 		},
-		"node_modules/import-meta-resolve": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
-			"integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
 		"node_modules/imurmurhash": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -11949,9 +12554,9 @@
 			}
 		},
 		"node_modules/ip-address": {
-			"version": "10.2.0",
-			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-			"integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+			"integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -12088,13 +12693,13 @@
 			}
 		},
 		"node_modules/is-core-module": {
-			"version": "2.16.2",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
-			"integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+			"version": "2.16.1",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+			"integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"hasown": "^2.0.3"
+				"hasown": "^2.0.2"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -12521,10 +13126,9 @@
 			}
 		},
 		"node_modules/isarray": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-			"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-			"dev": true,
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
 			"license": "MIT"
 		},
 		"node_modules/isbinaryfile": {
@@ -12687,19 +13291,18 @@
 			}
 		},
 		"node_modules/jsdom": {
-			"version": "27.4.0",
-			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.4.0.tgz",
-			"integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
+			"version": "27.2.0",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.2.0.tgz",
+			"integrity": "sha512-454TI39PeRDW1LgpyLPyURtB4Zx1tklSr6+OFOipsxGUH1WMTvk6C65JQdrj455+DP2uJ1+veBEHTGFKWVLFoA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@acemir/cssom": "^0.9.28",
-				"@asamuzakjp/dom-selector": "^6.7.6",
-				"@exodus/bytes": "^1.6.0",
-				"cssstyle": "^5.3.4",
+				"@acemir/cssom": "^0.9.23",
+				"@asamuzakjp/dom-selector": "^6.7.4",
+				"cssstyle": "^5.3.3",
 				"data-urls": "^6.0.0",
 				"decimal.js": "^10.6.0",
-				"html-encoding-sniffer": "^6.0.0",
+				"html-encoding-sniffer": "^4.0.0",
 				"http-proxy-agent": "^7.0.2",
 				"https-proxy-agent": "^7.0.6",
 				"is-potential-custom-element-name": "^1.0.1",
@@ -12709,6 +13312,7 @@
 				"tough-cookie": "^6.0.0",
 				"w3c-xmlserializer": "^5.0.0",
 				"webidl-conversions": "^8.0.0",
+				"whatwg-encoding": "^3.1.1",
 				"whatwg-mimetype": "^4.0.0",
 				"whatwg-url": "^15.1.0",
 				"ws": "^8.18.3",
@@ -12833,6 +13437,13 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/json-stable-stringify/node_modules/isarray": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+			"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -12903,13 +13514,6 @@
 				"setimmediate": "^1.0.5"
 			}
 		},
-		"node_modules/jszip/node_modules/isarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/jszip/node_modules/readable-stream": {
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
@@ -12944,9 +13548,9 @@
 			}
 		},
 		"node_modules/katex": {
-			"version": "0.16.45",
-			"resolved": "https://registry.npmjs.org/katex/-/katex-0.16.45.tgz",
-			"integrity": "sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA==",
+			"version": "0.16.25",
+			"resolved": "https://registry.npmjs.org/katex/-/katex-0.16.25.tgz",
+			"integrity": "sha512-woHRUZ/iF23GBP1dkDQMh1QBad9dmr8/PAwNA54VrSOVYgI12MAcE14TqnDdQOdzyEonGzMepYnqBMYdsoAr8Q==",
 			"funding": [
 				"https://opencollective.com/katex",
 				"https://github.com/sponsors/katex"
@@ -12993,22 +13597,26 @@
 				"graceful-fs": "^4.1.11"
 			}
 		},
+		"node_modules/kolorist": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/kolorist/-/kolorist-1.8.0.tgz",
+			"integrity": "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==",
+			"license": "MIT"
+		},
 		"node_modules/langium": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/langium/-/langium-4.2.3.tgz",
-			"integrity": "sha512-sOPIi4hISFnY7twwV97ca1TsxpBtXq0URu/LL1AvxwccPG/RIBBlKS7a/f/EL6w8lTNaS0EFs/F+IdSOaqYpng==",
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/langium/-/langium-3.3.1.tgz",
+			"integrity": "sha512-QJv/h939gDpvT+9SiLVlY7tZC3xB2qK57v0J04Sh9wpMb6MP1q8gB21L3WIo8T5P1MSMg3Ep14L7KkDCFG3y4w==",
 			"license": "MIT",
 			"dependencies": {
-				"@chevrotain/regexp-to-ast": "~12.0.0",
-				"chevrotain": "~12.0.0",
-				"chevrotain-allstar": "~0.4.3",
+				"chevrotain": "~11.0.3",
+				"chevrotain-allstar": "~0.3.0",
 				"vscode-languageserver": "~9.0.1",
 				"vscode-languageserver-textdocument": "~1.0.11",
-				"vscode-uri": "~3.1.0"
+				"vscode-uri": "~3.0.8"
 			},
 			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
+				"node": ">=16.0.0"
 			}
 		},
 		"node_modules/layout-base": {
@@ -13034,12 +13642,6 @@
 			"engines": {
 				"node": ">= 0.6.3"
 			}
-		},
-		"node_modules/lazystream/node_modules/isarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-			"license": "MIT"
 		},
 		"node_modules/lazystream/node_modules/readable-stream": {
 			"version": "2.3.8",
@@ -13396,32 +13998,46 @@
 				"uc.micro": "^2.0.0"
 			}
 		},
-		"node_modules/locate-path": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-			"dev": true,
+		"node_modules/local-pkg": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-1.1.2.tgz",
+			"integrity": "sha512-arhlxbFRmoQHl33a0Zkle/YWlmNwoyt6QNZEIJcqNbdrsix5Lvc4HyyI3EnwxTYlZYc32EbYrQ8SzEZ7dqgg9A==",
 			"license": "MIT",
 			"dependencies": {
-				"p-locate": "^5.0.0"
+				"mlly": "^1.7.4",
+				"pkg-types": "^2.3.0",
+				"quansync": "^0.2.11"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=14"
 			},
 			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
+				"url": "https://github.com/sponsors/antfu"
+			}
+		},
+		"node_modules/locate-path": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+			"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+			"license": "MIT",
+			"dependencies": {
+				"p-locate": "^3.0.0",
+				"path-exists": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/lodash": {
-			"version": "4.18.1",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-			"integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+			"version": "4.17.21",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
 			"license": "MIT"
 		},
 		"node_modules/lodash-es": {
-			"version": "4.18.1",
-			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
-			"integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+			"version": "4.17.21",
+			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+			"integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
 			"license": "MIT"
 		},
 		"node_modules/lodash.escaperegexp": {
@@ -13527,17 +14143,6 @@
 				"react": "^16.5.1 || ^17.0.0 || ^18.0.0"
 			}
 		},
-		"node_modules/lz-string": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
-			"integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"bin": {
-				"lz-string": "bin/bin.js"
-			}
-		},
 		"node_modules/lzma-native": {
 			"version": "8.0.6",
 			"resolved": "https://registry.npmjs.org/lzma-native/-/lzma-native-8.0.6.tgz",
@@ -13564,21 +14169,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/lzma-native/node_modules/readable-stream": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"inherits": "^2.0.3",
-				"string_decoder": "^1.1.1",
-				"util-deprecate": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
 		"node_modules/magic-string": {
 			"version": "0.30.21",
 			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -13590,13 +14180,13 @@
 			}
 		},
 		"node_modules/magicast": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
-			"integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+			"integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/parser": "^7.29.0",
+				"@babel/parser": "^7.29.3",
 				"@babel/types": "^7.29.0",
 				"source-map-js": "^1.2.1"
 			}
@@ -13715,9 +14305,9 @@
 			}
 		},
 		"node_modules/marked": {
-			"version": "17.0.6",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-17.0.6.tgz",
-			"integrity": "sha512-gB0gkNafnonOw0obSTEGZTT86IuhILt2Wfx0mWH/1Au83kybTayroZ/V6nS25mN7u8ASy+5fMhgB3XPNrOZdmA==",
+			"version": "17.0.1",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-17.0.1.tgz",
+			"integrity": "sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg==",
 			"license": "MIT",
 			"bin": {
 				"marked": "bin/marked.js"
@@ -13779,9 +14369,9 @@
 			}
 		},
 		"node_modules/mdast-util-from-markdown": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
-			"integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz",
+			"integrity": "sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mdast": "^4.0.0",
@@ -13993,6 +14583,20 @@
 				"url": "https://opencollective.com/unified"
 			}
 		},
+		"node_modules/mdast-util-newline-to-break": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-newline-to-break/-/mdast-util-newline-to-break-2.0.0.tgz",
+			"integrity": "sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"mdast-util-find-and-replace": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
 		"node_modules/mdast-util-phrasing": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
@@ -14063,9 +14667,9 @@
 			}
 		},
 		"node_modules/mdn-data": {
-			"version": "2.27.1",
-			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
-			"integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+			"version": "2.12.2",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+			"integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
 			"dev": true,
 			"license": "CC0-1.0"
 		},
@@ -14086,28 +14690,27 @@
 			}
 		},
 		"node_modules/mermaid": {
-			"version": "11.14.0",
-			"resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.14.0.tgz",
-			"integrity": "sha512-GSGloRsBs+JINmmhl0JDwjpuezCsHB4WGI4NASHxL3fHo3o/BRXTxhDLKnln8/Q0lRFRyDdEjmk1/d5Sn1Xz8g==",
+			"version": "11.12.1",
+			"resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.12.1.tgz",
+			"integrity": "sha512-UlIZrRariB11TY1RtTgUWp65tphtBv4CSq7vyS2ZZ2TgoMjs2nloq+wFqxiwcxlhHUvs7DPGgMjs2aeQxz5h9g==",
 			"license": "MIT",
 			"dependencies": {
 				"@braintree/sanitize-url": "^7.1.1",
-				"@iconify/utils": "^3.0.2",
-				"@mermaid-js/parser": "^1.1.0",
+				"@iconify/utils": "^3.0.1",
+				"@mermaid-js/parser": "^0.6.3",
 				"@types/d3": "^7.4.3",
-				"@upsetjs/venn.js": "^2.0.0",
-				"cytoscape": "^3.33.1",
+				"cytoscape": "^3.29.3",
 				"cytoscape-cose-bilkent": "^4.1.0",
 				"cytoscape-fcose": "^2.2.0",
 				"d3": "^7.9.0",
 				"d3-sankey": "^0.12.3",
-				"dagre-d3-es": "7.0.14",
-				"dayjs": "^1.11.19",
-				"dompurify": "^3.3.1",
-				"katex": "^0.16.25",
+				"dagre-d3-es": "7.0.13",
+				"dayjs": "^1.11.18",
+				"dompurify": "^3.2.5",
+				"katex": "^0.16.22",
 				"khroma": "^2.1.0",
-				"lodash-es": "^4.17.23",
-				"marked": "^16.3.0",
+				"lodash-es": "^4.17.21",
+				"marked": "^16.2.1",
 				"roughjs": "^4.6.6",
 				"stylis": "^4.3.6",
 				"ts-dedent": "^2.2.0",
@@ -14746,15 +15349,16 @@
 			}
 		},
 		"node_modules/mime": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
-			"integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+			"integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+			"dev": true,
 			"license": "MIT",
 			"bin": {
 				"mime": "cli.js"
 			},
 			"engines": {
-				"node": ">=10.0.0"
+				"node": ">=4.0.0"
 			}
 		},
 		"node_modules/mime-db": {
@@ -14810,18 +15414,15 @@
 			}
 		},
 		"node_modules/minimatch": {
-			"version": "10.2.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-			"license": "BlueOak-1.0.0",
+			"version": "5.1.6",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+			"integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+			"license": "ISC",
 			"dependencies": {
-				"brace-expansion": "^5.0.5"
+				"brace-expansion": "^2.0.1"
 			},
 			"engines": {
-				"node": "18 || 20 || >=22"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
+				"node": ">=10"
 			}
 		},
 		"node_modules/minimist": {
@@ -14834,12 +15435,12 @@
 			}
 		},
 		"node_modules/minipass": {
-			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-			"license": "BlueOak-1.0.0",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+			"integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+			"license": "ISC",
 			"engines": {
-				"node": ">=16 || 14 >=14.17"
+				"node": ">=8"
 			}
 		},
 		"node_modules/minipass-collect": {
@@ -14914,11 +15515,11 @@
 			"license": "ISC"
 		},
 		"node_modules/minipass-flush": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.7.tgz",
-			"integrity": "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
+			"integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
 			"dev": true,
-			"license": "BlueOak-1.0.0",
+			"license": "ISC",
 			"dependencies": {
 				"minipass": "^3.0.0"
 			},
@@ -15065,6 +15666,35 @@
 			"integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
 			"license": "MIT"
 		},
+		"node_modules/mlly": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz",
+			"integrity": "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==",
+			"license": "MIT",
+			"dependencies": {
+				"acorn": "^8.15.0",
+				"pathe": "^2.0.3",
+				"pkg-types": "^1.3.1",
+				"ufo": "^1.6.1"
+			}
+		},
+		"node_modules/mlly/node_modules/confbox": {
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+			"integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+			"license": "MIT"
+		},
+		"node_modules/mlly/node_modules/pkg-types": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+			"integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+			"license": "MIT",
+			"dependencies": {
+				"confbox": "^0.1.8",
+				"mlly": "^1.7.4",
+				"pathe": "^2.0.1"
+			}
+		},
 		"node_modules/mnemonist": {
 			"version": "0.39.6",
 			"resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.39.6.tgz",
@@ -15099,9 +15729,9 @@
 			}
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.12",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-			"integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+			"version": "3.3.11",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+			"integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
 			"dev": true,
 			"funding": [
 				{
@@ -15141,9 +15771,9 @@
 			}
 		},
 		"node_modules/node-abi": {
-			"version": "3.92.0",
-			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
-			"integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
+			"version": "3.85.0",
+			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.85.0.tgz",
+			"integrity": "sha512-zsFhmbkAzwhTft6nd3VxcG0cvJsT70rL+BIGHWVq5fi6MwGrHwzqKaxXE+Hl2GmnGItnDKPPkO5/LQqjVkIdFg==",
 			"license": "MIT",
 			"dependencies": {
 				"semver": "^7.3.5"
@@ -15153,10 +15783,12 @@
 			}
 		},
 		"node_modules/node-addon-api": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
-			"integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-			"license": "MIT"
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
+			"integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
 		},
 		"node_modules/node-api-version": {
 			"version": "0.1.4",
@@ -15166,35 +15798,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"semver": "^7.3.5"
-			}
-		},
-		"node_modules/node-exports-info": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
-			"integrity": "sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"array.prototype.flatmap": "^1.3.3",
-				"es-errors": "^1.3.0",
-				"object.entries": "^1.1.9",
-				"semver": "^6.3.1"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/node-exports-info/node_modules/semver": {
-			"version": "6.3.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
 			}
 		},
 		"node_modules/node-gyp": {
@@ -15235,59 +15838,6 @@
 				"node-gyp-build-test": "build-test.js"
 			}
 		},
-		"node_modules/node-gyp/node_modules/balanced-match": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/node-gyp/node_modules/brace-expansion": {
-			"version": "1.1.14",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"node_modules/node-gyp/node_modules/glob": {
-			"version": "7.2.3",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.1.1",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
-			},
-			"engines": {
-				"node": "*"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/node-gyp/node_modules/minimatch": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/node-pty": {
 			"version": "1.2.0-beta.12",
 			"resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.2.0-beta.12.tgz",
@@ -15298,10 +15848,16 @@
 				"node-addon-api": "^7.1.0"
 			}
 		},
+		"node_modules/node-pty/node_modules/node-addon-api": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+			"integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+			"license": "MIT"
+		},
 		"node_modules/node-releases": {
-			"version": "2.0.38",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
-			"integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+			"version": "2.0.27",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
+			"integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -15325,6 +15881,16 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
 			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/normalize-range": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+			"integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -15613,19 +16179,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/ora/node_modules/strip-ansi": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/own-keys": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
@@ -15655,35 +16208,30 @@
 			}
 		},
 		"node_modules/p-limit": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-			"dev": true,
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
 			"license": "MIT",
 			"dependencies": {
-				"yocto-queue": "^0.1.0"
+				"p-try": "^2.0.0"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=6"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/p-locate": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-			"dev": true,
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+			"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
 			"license": "MIT",
 			"dependencies": {
-				"p-limit": "^3.0.2"
+				"p-limit": "^2.0.0"
 			},
 			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
+				"node": ">=6"
 			}
 		},
 		"node_modules/p-map": {
@@ -15718,9 +16266,9 @@
 			"license": "BlueOak-1.0.0"
 		},
 		"node_modules/package-manager-detector": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
-			"integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.5.0.tgz",
+			"integrity": "sha512-uBj69dVlYe/+wxj8JOpr97XfsxH/eumMt6HqjNTmJDf/6NO9s+0uxeOneIz3AsPt2m6y9PqzDzd3ATcU17MNfw==",
 			"license": "MIT"
 		},
 		"node_modules/pako": {
@@ -15769,26 +16317,26 @@
 			"license": "MIT"
 		},
 		"node_modules/parse5": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
-			"integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+			"integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"entities": "^8.0.0"
+				"entities": "^6.0.0"
 			},
 			"funding": {
 				"url": "https://github.com/inikulin/parse5?sponsor=1"
 			}
 		},
 		"node_modules/parse5/node_modules/entities": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
-			"integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+			"integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"engines": {
-				"node": ">=20.19.0"
+				"node": ">=0.12"
 			},
 			"funding": {
 				"url": "https://github.com/fb55/entities?sponsor=1"
@@ -15869,12 +16417,12 @@
 			"license": "MIT"
 		},
 		"node_modules/path-exists": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+			"integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
 			"license": "MIT",
 			"engines": {
-				"node": ">=8"
+				"node": ">=4"
 			}
 		},
 		"node_modules/path-is-absolute": {
@@ -15929,7 +16477,6 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
 			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/pe-library": {
@@ -16052,9 +16599,9 @@
 			}
 		},
 		"node_modules/pino-std-serializers": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
-			"integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
+			"integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==",
 			"license": "MIT"
 		},
 		"node_modules/pino/node_modules/process-warning": {
@@ -16083,6 +16630,17 @@
 				"node": ">= 6"
 			}
 		},
+		"node_modules/pkg-types": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
+			"integrity": "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==",
+			"license": "MIT",
+			"dependencies": {
+				"confbox": "^0.2.2",
+				"exsolve": "^1.0.7",
+				"pathe": "^2.0.3"
+			}
+		},
 		"node_modules/pkg-up": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
@@ -16095,75 +16653,14 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/pkg-up/node_modules/find-up": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-			"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-			"license": "MIT",
-			"dependencies": {
-				"locate-path": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/pkg-up/node_modules/locate-path": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-			"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-			"license": "MIT",
-			"dependencies": {
-				"p-locate": "^3.0.0",
-				"path-exists": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/pkg-up/node_modules/p-limit": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-			"license": "MIT",
-			"dependencies": {
-				"p-try": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/pkg-up/node_modules/p-locate": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-			"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-			"license": "MIT",
-			"dependencies": {
-				"p-limit": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/pkg-up/node_modules/path-exists": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-			"integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/playwright": {
-			"version": "1.59.1",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
-			"integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+			"version": "1.60.0",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+			"integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright-core": "1.59.1"
+				"playwright-core": "1.60.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -16176,9 +16673,9 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.59.1",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
-			"integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+			"version": "1.60.0",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+			"integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -16298,28 +16795,6 @@
 			},
 			"peerDependencies": {
 				"postcss": "^8.0.0"
-			}
-		},
-		"node_modules/postcss-import/node_modules/resolve": {
-			"version": "1.22.12",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
-			"integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"es-errors": "^1.3.0",
-				"is-core-module": "^2.16.1",
-				"path-parse": "^1.0.7",
-				"supports-preserve-symlinks-flag": "^1.0.0"
-			},
-			"bin": {
-				"resolve": "bin/resolve"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/postcss-js": {
@@ -16477,41 +16952,10 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/postject": {
-			"version": "1.0.0-alpha.6",
-			"resolved": "https://registry.npmjs.org/postject/-/postject-1.0.0-alpha.6.tgz",
-			"integrity": "sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"commander": "^9.4.0"
-			},
-			"bin": {
-				"postject": "dist/cli.js"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/postject/node_modules/commander": {
-			"version": "9.5.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
-			"integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": "^12.20.0 || >=14"
-			}
-		},
 		"node_modules/prebuild-install": {
 			"version": "7.1.3",
 			"resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
 			"integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
-			"deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
 			"license": "MIT",
 			"dependencies": {
 				"detect-libc": "^2.0.0",
@@ -16545,9 +16989,9 @@
 			}
 		},
 		"node_modules/prettier": {
-			"version": "3.8.3",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
-			"integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+			"version": "3.8.0",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.0.tgz",
+			"integrity": "sha512-yEPsovQfpxYfgWNhCfECjG5AQaO+K3dp6XERmOepyPDVqcJm+bjyCVO3pmU+nAPe0N5dDvekfGezt/EIiRe1TA==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -16559,44 +17003,6 @@
 			"funding": {
 				"url": "https://github.com/prettier/prettier?sponsor=1"
 			}
-		},
-		"node_modules/pretty-format": {
-			"version": "27.5.1",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"ansi-regex": "^5.0.1",
-				"ansi-styles": "^5.0.0",
-				"react-is": "^17.0.1"
-			},
-			"engines": {
-				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-			}
-		},
-		"node_modules/pretty-format/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/pretty-format/node_modules/react-is": {
-			"version": "17.0.2",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true
 		},
 		"node_modules/prismjs": {
 			"version": "1.30.0",
@@ -16731,9 +17137,9 @@
 			}
 		},
 		"node_modules/pump": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
-			"integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+			"integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
 			"license": "MIT",
 			"dependencies": {
 				"end-of-stream": "^1.1.0",
@@ -16821,21 +17227,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/qrcode/node_modules/p-limit": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-			"license": "MIT",
-			"dependencies": {
-				"p-try": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/qrcode/node_modules/p-locate": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
@@ -16848,14 +17239,11 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/qrcode/node_modules/strip-ansi": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+		"node_modules/qrcode/node_modules/path-exists": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
 			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
 			"engines": {
 				"node": ">=8"
 			}
@@ -16915,6 +17303,22 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/quansync": {
+			"version": "0.2.11",
+			"resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz",
+			"integrity": "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://github.com/sponsors/antfu"
+				},
+				{
+					"type": "individual",
+					"url": "https://github.com/sponsors/sxzz"
+				}
+			],
+			"license": "MIT"
+		},
 		"node_modules/queue-microtask": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -16970,19 +17374,11 @@
 				"rc": "cli.js"
 			}
 		},
-		"node_modules/rc/node_modules/strip-json-comments": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-			"integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/react": {
 			"version": "18.3.1",
 			"resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
 			"integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"loose-envify": "^1.1.0"
@@ -16992,9 +17388,9 @@
 			}
 		},
 		"node_modules/react-diff-view": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/react-diff-view/-/react-diff-view-3.3.3.tgz",
-			"integrity": "sha512-CPveApk6n7ZbkW7T6PoptR7LWAvD9hohTHZ7WnKnu3GZkTfUB5rvg486apPo94iYVi4fZd3Nt+rtBZ5877exoQ==",
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/react-diff-view/-/react-diff-view-3.3.2.tgz",
+			"integrity": "sha512-wPVq4ktTcGOHbhnWKU/gHLtd3N2Xd+OZ/XQWcKA06dsxlSsESePAumQILwHtiak2nMCMiWcIfBpqZ5OiharUPA==",
 			"license": "MIT",
 			"dependencies": {
 				"classnames": "^2.3.2",
@@ -17012,6 +17408,7 @@
 			"version": "18.3.1",
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
 			"integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"loose-envify": "^1.1.0",
@@ -17020,13 +17417,6 @@
 			"peerDependencies": {
 				"react": "^18.3.1"
 			}
-		},
-		"node_modules/react-is": {
-			"version": "19.2.6",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.6.tgz",
-			"integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
-			"license": "MIT",
-			"peer": true
 		},
 		"node_modules/react-markdown": {
 			"version": "10.1.0",
@@ -17079,9 +17469,9 @@
 			}
 		},
 		"node_modules/react-syntax-highlighter": {
-			"version": "16.1.1",
-			"resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-16.1.1.tgz",
-			"integrity": "sha512-PjVawBGy80C6YbC5DDZJeUjBmC7skaoEUdvfFQediQHgCL7aKyVHe57SaJGfQsloGDac+gCpTfRdtxzWWKmCXA==",
+			"version": "16.1.0",
+			"resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-16.1.0.tgz",
+			"integrity": "sha512-E40/hBiP5rCNwkeBN1vRP+xow1X0pndinO+z3h7HLsHyjztbyjfzNWNKuAsJj+7DLam9iT4AaaOZnueCU+Nplg==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/runtime": "^7.28.4",
@@ -17150,43 +17540,17 @@
 			}
 		},
 		"node_modules/readable-stream": {
-			"version": "4.7.0",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
-			"integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
 			"license": "MIT",
 			"dependencies": {
-				"abort-controller": "^3.0.0",
-				"buffer": "^6.0.3",
-				"events": "^3.3.0",
-				"process": "^0.11.10",
-				"string_decoder": "^1.3.0"
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			}
-		},
-		"node_modules/readable-stream/node_modules/buffer": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.2.1"
+				"node": ">= 6"
 			}
 		},
 		"node_modules/readdir-glob": {
@@ -17196,33 +17560,6 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"minimatch": "^5.1.0"
-			}
-		},
-		"node_modules/readdir-glob/node_modules/balanced-match": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"license": "MIT"
-		},
-		"node_modules/readdir-glob/node_modules/brace-expansion": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-			"integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0"
-			}
-		},
-		"node_modules/readdir-glob/node_modules/minimatch": {
-			"version": "5.1.9",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-			"integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/readdirp": {
@@ -17259,15 +17596,15 @@
 			}
 		},
 		"node_modules/recharts": {
-			"version": "3.8.1",
-			"resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
-			"integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/recharts/-/recharts-3.6.0.tgz",
+			"integrity": "sha512-L5bjxvQRAe26RlToBAziKUB7whaGKEwD3znoM6fz3DrTowCIC/FnJYnuq1GEzB8Zv2kdTfaxQfi5GoH0tBinyg==",
 			"license": "MIT",
 			"workspaces": [
 				"www"
 			],
 			"dependencies": {
-				"@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+				"@reduxjs/toolkit": "1.x.x || 2.x.x",
 				"clsx": "^2.1.1",
 				"decimal.js-light": "^2.5.1",
 				"es-toolkit": "^1.39.3",
@@ -17433,6 +17770,21 @@
 				"url": "https://opencollective.com/unified"
 			}
 		},
+		"node_modules/remark-breaks": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/remark-breaks/-/remark-breaks-4.0.0.tgz",
+			"integrity": "sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"mdast-util-newline-to-break": "^2.0.0",
+				"unified": "^11.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
 		"node_modules/remark-frontmatter": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/remark-frontmatter/-/remark-frontmatter-5.0.0.tgz",
@@ -17577,16 +17929,13 @@
 			"license": "MIT"
 		},
 		"node_modules/resolve": {
-			"version": "2.0.0-next.6",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.6.tgz",
-			"integrity": "sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==",
+			"version": "1.22.11",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+			"integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"es-errors": "^1.3.0",
 				"is-core-module": "^2.16.1",
-				"node-exports-info": "^1.6.0",
-				"object-keys": "^1.1.1",
 				"path-parse": "^1.0.7",
 				"supports-preserve-symlinks-flag": "^1.0.0"
 			},
@@ -17703,59 +18052,6 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/rimraf/node_modules/balanced-match": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/rimraf/node_modules/brace-expansion": {
-			"version": "1.1.14",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"node_modules/rimraf/node_modules/glob": {
-			"version": "7.2.3",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.1.1",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
-			},
-			"engines": {
-				"node": "*"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/rimraf/node_modules/minimatch": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/roarr": {
 			"version": "2.15.4",
 			"resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
@@ -17776,20 +18072,20 @@
 			}
 		},
 		"node_modules/robust-predicates": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
-			"integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
+			"integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==",
 			"license": "Unlicense"
 		},
 		"node_modules/rolldown": {
-			"version": "1.0.0-rc.18",
-			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.18.tgz",
-			"integrity": "sha512-phmyKBpuBdRYDf4hgyynGAYn/rDDe+iZXKVJ7WX5b1zQzpLkP5oJRPGsfJuHdzPMlyyEO/4sPW6yfSx2gf7lVg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.1.tgz",
+			"integrity": "sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@oxc-project/types": "=0.128.0",
-				"@rolldown/pluginutils": "1.0.0-rc.18"
+				"@oxc-project/types": "=0.130.0",
+				"@rolldown/pluginutils": "^1.0.0"
 			},
 			"bin": {
 				"rolldown": "bin/cli.mjs"
@@ -17798,29 +18094,22 @@
 				"node": "^20.19.0 || >=22.12.0"
 			},
 			"optionalDependencies": {
-				"@rolldown/binding-android-arm64": "1.0.0-rc.18",
-				"@rolldown/binding-darwin-arm64": "1.0.0-rc.18",
-				"@rolldown/binding-darwin-x64": "1.0.0-rc.18",
-				"@rolldown/binding-freebsd-x64": "1.0.0-rc.18",
-				"@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.18",
-				"@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.18",
-				"@rolldown/binding-linux-arm64-musl": "1.0.0-rc.18",
-				"@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.18",
-				"@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.18",
-				"@rolldown/binding-linux-x64-gnu": "1.0.0-rc.18",
-				"@rolldown/binding-linux-x64-musl": "1.0.0-rc.18",
-				"@rolldown/binding-openharmony-arm64": "1.0.0-rc.18",
-				"@rolldown/binding-wasm32-wasi": "1.0.0-rc.18",
-				"@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.18",
-				"@rolldown/binding-win32-x64-msvc": "1.0.0-rc.18"
+				"@rolldown/binding-android-arm64": "1.0.1",
+				"@rolldown/binding-darwin-arm64": "1.0.1",
+				"@rolldown/binding-darwin-x64": "1.0.1",
+				"@rolldown/binding-freebsd-x64": "1.0.1",
+				"@rolldown/binding-linux-arm-gnueabihf": "1.0.1",
+				"@rolldown/binding-linux-arm64-gnu": "1.0.1",
+				"@rolldown/binding-linux-arm64-musl": "1.0.1",
+				"@rolldown/binding-linux-ppc64-gnu": "1.0.1",
+				"@rolldown/binding-linux-s390x-gnu": "1.0.1",
+				"@rolldown/binding-linux-x64-gnu": "1.0.1",
+				"@rolldown/binding-linux-x64-musl": "1.0.1",
+				"@rolldown/binding-openharmony-arm64": "1.0.1",
+				"@rolldown/binding-wasm32-wasi": "1.0.1",
+				"@rolldown/binding-win32-arm64-msvc": "1.0.1",
+				"@rolldown/binding-win32-x64-msvc": "1.0.1"
 			}
-		},
-		"node_modules/rolldown/node_modules/@rolldown/pluginutils": {
-			"version": "1.0.0-rc.18",
-			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.18.tgz",
-			"integrity": "sha512-CUY5Mnhe64xQBGZEEXQ5WyZwsc1JU3vAZLIxtrsBt3LO6UOb+C8GunVKqe9sT8NeWb4lqSaoJtp2xo6GxT1MNw==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/roughjs": {
 			"version": "4.6.6",
@@ -17875,15 +18164,15 @@
 			}
 		},
 		"node_modules/safe-array-concat": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.4.tgz",
-			"integrity": "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
+			"integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"call-bind": "^1.0.9",
-				"call-bound": "^1.0.4",
-				"get-intrinsic": "^1.3.0",
+				"call-bind": "^1.0.8",
+				"call-bound": "^1.0.2",
+				"get-intrinsic": "^1.2.6",
 				"has-symbols": "^1.1.0",
 				"isarray": "^2.0.5"
 			},
@@ -17893,6 +18182,13 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/safe-array-concat/node_modules/isarray": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+			"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/safe-buffer": {
 			"version": "5.2.1",
@@ -17930,6 +18226,13 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/safe-push-apply/node_modules/isarray": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+			"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/safe-regex-test": {
 			"version": "1.1.0",
@@ -17974,9 +18277,9 @@
 			"license": "MIT"
 		},
 		"node_modules/sanitize-filename": {
-			"version": "1.6.4",
-			"resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.4.tgz",
-			"integrity": "sha512-9ZyI08PsvdQl2r/bBIGubpVdR3RR9sY6RDiWFPreA21C/EFlQhmgo20UZlNjZMMZNubusLhAQozkA0Od5J21Eg==",
+			"version": "1.6.3",
+			"resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
+			"integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
 			"dev": true,
 			"license": "WTFPL OR ISC",
 			"dependencies": {
@@ -17984,13 +18287,10 @@
 			}
 		},
 		"node_modules/sax": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
-			"integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": ">=11.0.0"
-			}
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.4.3.tgz",
+			"integrity": "sha512-yqYn1JhPczigF94DMS+shiDMjDowYO6y9+wB/4WgO0Y19jWYk0lQ4tuG5KI7kj4FTp1wxPj5IFfcrz/s1c3jjQ==",
+			"license": "BlueOak-1.0.0"
 		},
 		"node_modules/saxes": {
 			"version": "6.0.0",
@@ -18009,6 +18309,7 @@
 			"version": "0.23.2",
 			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
 			"integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"loose-envify": "^1.1.0"
@@ -18021,9 +18322,9 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/semver": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+			"integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
 			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
@@ -18225,14 +18526,14 @@
 			}
 		},
 		"node_modules/side-channel-list": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
-			"integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+			"integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-errors": "^1.3.0",
-				"object-inspect": "^1.13.4"
+				"object-inspect": "^1.13.3"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -18395,13 +18696,13 @@
 			}
 		},
 		"node_modules/socks": {
-			"version": "2.8.8",
-			"resolved": "https://registry.npmjs.org/socks/-/socks-2.8.8.tgz",
-			"integrity": "sha512-NlGELfPrgX2f1TAAcz0WawlLn+0r3FyhhCRpFFK2CemXenPYvzMWWZINv3eDNo9ucdwme7oCHRY0Jnbs4aIkog==",
+			"version": "2.8.7",
+			"resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+			"integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"ip-address": "^10.1.1",
+				"ip-address": "^10.0.1",
 				"smart-buffer": "^4.2.0"
 			},
 			"engines": {
@@ -18425,9 +18726,9 @@
 			}
 		},
 		"node_modules/sonic-boom": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
-			"integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.0.tgz",
+			"integrity": "sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==",
 			"license": "MIT",
 			"dependencies": {
 				"atomic-sleep": "^1.0.0"
@@ -18584,9 +18885,9 @@
 			"license": "MIT"
 		},
 		"node_modules/streamx": {
-			"version": "2.25.0",
-			"resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
-			"integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
+			"version": "2.23.0",
+			"resolved": "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz",
+			"integrity": "sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==",
 			"license": "MIT",
 			"dependencies": {
 				"events-universal": "^1.0.0",
@@ -18627,30 +18928,6 @@
 				"emoji-regex": "^8.0.0",
 				"is-fullwidth-code-point": "^3.0.0",
 				"strip-ansi": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/string-width-cjs/node_modules/strip-ansi": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/string-width/node_modules/strip-ansi": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
 			},
 			"engines": {
 				"node": ">=8"
@@ -18769,18 +19046,15 @@
 			}
 		},
 		"node_modules/strip-ansi": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
 			"license": "MIT",
 			"dependencies": {
-				"ansi-regex": "^6.2.2"
+				"ansi-regex": "^5.0.1"
 			},
 			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+				"node": ">=8"
 			}
 		},
 		"node_modules/strip-ansi-cjs": {
@@ -18794,18 +19068,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/strip-ansi/node_modules/ansi-regex": {
-			"version": "6.2.2",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
 			}
 		},
 		"node_modules/strip-indent": {
@@ -18822,16 +19084,12 @@
 			}
 		},
 		"node_modules/strip-json-comments": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-			"dev": true,
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+			"integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
 			"license": "MIT",
 			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/style-mod": {
@@ -18859,9 +19117,9 @@
 			}
 		},
 		"node_modules/stylis": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
-			"integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
+			"integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
 			"license": "MIT"
 		},
 		"node_modules/sucrase": {
@@ -18947,9 +19205,9 @@
 			"license": "MIT"
 		},
 		"node_modules/tailwindcss": {
-			"version": "3.4.19",
-			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
-			"integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
+			"version": "3.4.18",
+			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.18.tgz",
+			"integrity": "sha512-6A2rnmW5xZMdw11LYjhcI5846rt9pbLSabY5XPxo+XWdxwZaFEn47Go4NzFiHu9sNNmr/kXivP1vStfvMaK1GQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -18984,46 +19242,10 @@
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/tailwindcss/node_modules/glob-parent": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-			"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"is-glob": "^4.0.3"
-			},
-			"engines": {
-				"node": ">=10.13.0"
-			}
-		},
-		"node_modules/tailwindcss/node_modules/resolve": {
-			"version": "1.22.12",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
-			"integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"es-errors": "^1.3.0",
-				"is-core-module": "^2.16.1",
-				"path-parse": "^1.0.7",
-				"supports-preserve-symlinks-flag": "^1.0.0"
-			},
-			"bin": {
-				"resolve": "bin/resolve"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/tar": {
 			"version": "6.2.1",
 			"resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
 			"integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
-			"deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -19056,21 +19278,7 @@
 			"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
 			"license": "ISC"
 		},
-		"node_modules/tar-fs/node_modules/readable-stream": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-			"license": "MIT",
-			"dependencies": {
-				"inherits": "^2.0.3",
-				"string_decoder": "^1.1.1",
-				"util-deprecate": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
-		"node_modules/tar-fs/node_modules/tar-stream": {
+		"node_modules/tar-stream": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
 			"integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
@@ -19086,72 +19294,12 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/tar-stream": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
-			"integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
-			"license": "MIT",
-			"dependencies": {
-				"b4a": "^1.6.4",
-				"bare-fs": "^4.5.5",
-				"fast-fifo": "^1.2.0",
-				"streamx": "^2.15.0"
-			}
-		},
-		"node_modules/tar-stream/node_modules/b4a": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
-			"integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
-			"license": "Apache-2.0",
-			"peerDependencies": {
-				"react-native-b4a": "*"
-			},
-			"peerDependenciesMeta": {
-				"react-native-b4a": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/tar/node_modules/minipass": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-			"integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/tar/node_modules/yallist": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"dev": true,
 			"license": "ISC"
-		},
-		"node_modules/teex": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
-			"integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
-			"license": "MIT",
-			"dependencies": {
-				"streamx": "^2.12.5"
-			}
-		},
-		"node_modules/temp": {
-			"version": "0.9.4",
-			"resolved": "https://registry.npmjs.org/temp/-/temp-0.9.4.tgz",
-			"integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"mkdirp": "^0.5.1",
-				"rimraf": "~2.6.2"
-			},
-			"engines": {
-				"node": ">=6.0.0"
-			}
 		},
 		"node_modules/temp-file": {
 			"version": "3.4.0",
@@ -19180,9 +19328,9 @@
 			}
 		},
 		"node_modules/temp-file/node_modules/jsonfile": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+			"integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -19202,105 +19350,19 @@
 				"node": ">= 10.0.0"
 			}
 		},
-		"node_modules/temp/node_modules/balanced-match": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true
-		},
-		"node_modules/temp/node_modules/brace-expansion": {
-			"version": "1.1.14",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"node_modules/temp/node_modules/glob": {
-			"version": "7.2.3",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-			"dev": true,
-			"license": "ISC",
-			"peer": true,
-			"dependencies": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.1.1",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
-			},
-			"engines": {
-				"node": "*"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/temp/node_modules/minimatch": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-			"dev": true,
-			"license": "ISC",
-			"peer": true,
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/temp/node_modules/mkdirp": {
-			"version": "0.5.6",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-			"integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"minimist": "^1.2.6"
-			},
-			"bin": {
-				"mkdirp": "bin/cmd.js"
-			}
-		},
-		"node_modules/temp/node_modules/rimraf": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-			"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-			"deprecated": "Rimraf versions prior to v4 are no longer supported",
-			"dev": true,
-			"license": "ISC",
-			"peer": true,
-			"dependencies": {
-				"glob": "^7.1.3"
-			},
-			"bin": {
-				"rimraf": "bin.js"
-			}
-		},
 		"node_modules/text-decoder": {
-			"version": "1.2.7",
-			"resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
-			"integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
+			"integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"b4a": "^1.6.4"
 			}
 		},
 		"node_modules/text-decoder/node_modules/b4a": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
-			"integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+			"version": "1.7.3",
+			"resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.3.tgz",
+			"integrity": "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==",
 			"license": "Apache-2.0",
 			"peerDependencies": {
 				"react-native-b4a": "*"
@@ -19383,9 +19445,9 @@
 			"license": "MIT"
 		},
 		"node_modules/tinyexec": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
-			"integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+			"integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
@@ -19408,6 +19470,24 @@
 				"url": "https://github.com/sponsors/SuperchupuDev"
 			}
 		},
+		"node_modules/tinyglobby/node_modules/fdir": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"peerDependencies": {
+				"picomatch": "^3 || ^4"
+			},
+			"peerDependenciesMeta": {
+				"picomatch": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/tinyrainbow": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
@@ -19419,22 +19499,22 @@
 			}
 		},
 		"node_modules/tldts": {
-			"version": "7.0.30",
-			"resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.30.tgz",
-			"integrity": "sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==",
+			"version": "7.0.19",
+			"resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.19.tgz",
+			"integrity": "sha512-8PWx8tvC4jDB39BQw1m4x8y5MH1BcQ5xHeL2n7UVFulMPH/3Q0uiamahFJ3lXA0zO2SUyRXuVVbWSDmstlt9YA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"tldts-core": "^7.0.30"
+				"tldts-core": "^7.0.19"
 			},
 			"bin": {
 				"tldts": "bin/cli.js"
 			}
 		},
 		"node_modules/tldts-core": {
-			"version": "7.0.30",
-			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.30.tgz",
-			"integrity": "sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==",
+			"version": "7.0.19",
+			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.19.tgz",
+			"integrity": "sha512-lJX2dEWx0SGH4O6p+7FPwYmJ/bu1JbcGJ8RLaG9b7liIgZ85itUVEPbMtWRVrde/0fnDPEPHW10ZsKW3kVsE9A==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -19489,9 +19569,9 @@
 			}
 		},
 		"node_modules/tough-cookie": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
-			"integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
+			"integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
@@ -19720,16 +19800,16 @@
 			}
 		},
 		"node_modules/typescript-eslint": {
-			"version": "8.59.2",
-			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.2.tgz",
-			"integrity": "sha512-pJw051uomb3ZeCzGTpRb8RbEqB5Y4WWet8gl/GcTlU35BSx0PVdZ86/bqkQCyKKuraVQEK7r6kBHQXF+fBhkoQ==",
+			"version": "8.59.3",
+			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.3.tgz",
+			"integrity": "sha512-KgusgyDgG4LI8Ih/sWaCtZ06tckLAS5CvT5A4D1Q7bYVoAAyzwiZvE4BmwDHkhRVkvhRBepKeASoFzQetha7Fg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/eslint-plugin": "8.59.2",
-				"@typescript-eslint/parser": "8.59.2",
-				"@typescript-eslint/typescript-estree": "8.59.2",
-				"@typescript-eslint/utils": "8.59.2"
+				"@typescript-eslint/eslint-plugin": "8.59.3",
+				"@typescript-eslint/parser": "8.59.3",
+				"@typescript-eslint/typescript-estree": "8.59.3",
+				"@typescript-eslint/utils": "8.59.3"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -19747,6 +19827,12 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
 			"integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+			"license": "MIT"
+		},
+		"node_modules/ufo": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
+			"integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
 			"license": "MIT"
 		},
 		"node_modules/unbox-primitive": {
@@ -19869,9 +19955,9 @@
 			}
 		},
 		"node_modules/unist-util-visit": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
-			"integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
+			"integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/unist": "^3.0.0",
@@ -19933,9 +20019,9 @@
 			}
 		},
 		"node_modules/update-browserslist-db": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-			"integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.4.tgz",
+			"integrity": "sha512-q0SPT4xyU84saUX+tomz1WLkxUbuaJnR1xWt17M7fJtEJigJeWUNGUqrauFXsHnqev9y9JTRGwk13tFBuKby4A==",
 			"dev": true,
 			"funding": [
 				{
@@ -19996,9 +20082,9 @@
 			"license": "MIT"
 		},
 		"node_modules/uuid": {
-			"version": "11.1.1",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-			"integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+			"version": "11.1.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+			"integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
 			"funding": [
 				"https://github.com/sponsors/broofa",
 				"https://github.com/sponsors/ctavan"
@@ -20089,16 +20175,16 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "8.0.11",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-8.0.11.tgz",
-			"integrity": "sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow==",
+			"version": "8.0.13",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-8.0.13.tgz",
+			"integrity": "sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"lightningcss": "^1.32.0",
 				"picomatch": "^4.0.4",
 				"postcss": "^8.5.14",
-				"rolldown": "1.0.0-rc.18",
+				"rolldown": "1.0.1",
 				"tinyglobby": "^0.2.16"
 			},
 			"bin": {
@@ -20167,19 +20253,19 @@
 			}
 		},
 		"node_modules/vitest": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
-			"integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+			"version": "4.1.6",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
+			"integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/expect": "4.1.5",
-				"@vitest/mocker": "4.1.5",
-				"@vitest/pretty-format": "4.1.5",
-				"@vitest/runner": "4.1.5",
-				"@vitest/snapshot": "4.1.5",
-				"@vitest/spy": "4.1.5",
-				"@vitest/utils": "4.1.5",
+				"@vitest/expect": "4.1.6",
+				"@vitest/mocker": "4.1.6",
+				"@vitest/pretty-format": "4.1.6",
+				"@vitest/runner": "4.1.6",
+				"@vitest/snapshot": "4.1.6",
+				"@vitest/spy": "4.1.6",
+				"@vitest/utils": "4.1.6",
 				"es-module-lexer": "^2.0.0",
 				"expect-type": "^1.3.0",
 				"magic-string": "^0.30.21",
@@ -20207,12 +20293,12 @@
 				"@edge-runtime/vm": "*",
 				"@opentelemetry/api": "^1.9.0",
 				"@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-				"@vitest/browser-playwright": "4.1.5",
-				"@vitest/browser-preview": "4.1.5",
-				"@vitest/browser-webdriverio": "4.1.5",
-				"@vitest/coverage-istanbul": "4.1.5",
-				"@vitest/coverage-v8": "4.1.5",
-				"@vitest/ui": "4.1.5",
+				"@vitest/browser-playwright": "4.1.6",
+				"@vitest/browser-preview": "4.1.6",
+				"@vitest/browser-webdriverio": "4.1.6",
+				"@vitest/coverage-istanbul": "4.1.6",
+				"@vitest/coverage-v8": "4.1.6",
+				"@vitest/ui": "4.1.6",
 				"happy-dom": "*",
 				"jsdom": "*",
 				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -20300,9 +20386,9 @@
 			"license": "MIT"
 		},
 		"node_modules/vscode-uri": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
-			"integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.8.tgz",
+			"integrity": "sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==",
 			"license": "MIT"
 		},
 		"node_modules/w3c-keyname": {
@@ -20354,13 +20440,26 @@
 			}
 		},
 		"node_modules/webidl-conversions": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
-			"integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.0.tgz",
+			"integrity": "sha512-n4W4YFyz5JzOfQeA8oN7dUYpR+MBP3PIUsn2jLjWXwK5ASUzt0Jc/A5sAUZoCYFJRGF0FBKJ+1JjN43rNdsQzA==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=20"
+			}
+		},
+		"node_modules/whatwg-encoding": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+			"integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"iconv-lite": "0.6.3"
+			},
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/whatwg-mimetype": {
@@ -20450,6 +20549,13 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/which-builtin-type/node_modules/isarray": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+			"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/which-collection": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
@@ -20476,9 +20582,9 @@
 			"license": "ISC"
 		},
 		"node_modules/which-typed-array": {
-			"version": "1.1.20",
-			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
-			"integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+			"version": "1.1.19",
+			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
+			"integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -20535,17 +20641,18 @@
 			}
 		},
 		"node_modules/wrap-ansi": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-			"integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"ansi-styles": "^6.1.0",
-				"string-width": "^5.0.1",
-				"strip-ansi": "^7.0.1"
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=10"
 			},
 			"funding": {
 				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
@@ -20569,53 +20676,6 @@
 				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
 			}
 		},
-		"node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/wrap-ansi/node_modules/ansi-styles": {
-			"version": "6.2.3",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-			"integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/wrap-ansi/node_modules/emoji-regex": {
-			"version": "9.2.2",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-			"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-			"license": "MIT"
-		},
-		"node_modules/wrap-ansi/node_modules/string-width": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-			"integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-			"license": "MIT",
-			"dependencies": {
-				"eastasianwidth": "^0.2.0",
-				"emoji-regex": "^9.2.2",
-				"strip-ansi": "^7.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -20623,9 +20683,9 @@
 			"license": "ISC"
 		},
 		"node_modules/ws": {
-			"version": "8.20.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-			"integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+			"version": "8.18.3",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+			"integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=10.0.0"
@@ -20704,9 +20764,9 @@
 			"license": "ISC"
 		},
 		"node_modules/yaml": {
-			"version": "2.8.4",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
-			"integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+			"integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -20759,16 +20819,6 @@
 				"fd-slicer": "~1.1.0"
 			}
 		},
-		"node_modules/yauzl/node_modules/buffer-crc32": {
-			"version": "0.2.13",
-			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-			"integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/yocto-queue": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -20796,10 +20846,50 @@
 				"node": ">= 14"
 			}
 		},
+		"node_modules/zip-stream/node_modules/buffer": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.2.1"
+			}
+		},
+		"node_modules/zip-stream/node_modules/readable-stream": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+			"integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+			"license": "MIT",
+			"dependencies": {
+				"abort-controller": "^3.0.0",
+				"buffer": "^6.0.3",
+				"events": "^3.3.0",
+				"process": "^0.11.10",
+				"string_decoder": "^1.3.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			}
+		},
 		"node_modules/zod": {
-			"version": "4.4.3",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-			"integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.2.1.tgz",
+			"integrity": "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
@@ -20820,9 +20910,9 @@
 			}
 		},
 		"node_modules/zustand": {
-			"version": "5.0.13",
-			"resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.13.tgz",
-			"integrity": "sha512-efI2tVaVQPqtOh114loML/Z80Y4NP3yc+Ff0fYiZJPauNeWZeIp/bRFD7I9bfmCOYBh/PHxlglQ9+wvlwnPikQ==",
+			"version": "5.0.11",
+			"resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.11.tgz",
+			"integrity": "sha512-fdZY+dk7zn/vbWNCYmzZULHRrss0jx5pPFiOuMZ/5HJN6Yv3u+1Wswy/4MpZEkEGhtNH+pwxZB8OKgUBPzYAGg==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=12.20.0"

--- a/package.json
+++ b/package.json
@@ -305,6 +305,7 @@
 		"recharts": "^3.6.0",
 		"rehype-raw": "^7.0.0",
 		"rehype-slug": "^6.0.0",
+		"remark-breaks": "^4.0.0",
 		"remark-frontmatter": "^5.0.0",
 		"remark-gfm": "^4.0.1",
 		"semver": "^7.7.4",

--- a/src/__tests__/renderer/components/MarkdownRenderer.test.tsx
+++ b/src/__tests__/renderer/components/MarkdownRenderer.test.tsx
@@ -1276,10 +1276,15 @@ describe('MarkdownRenderer', () => {
 
 		it('keeps paragraph breaks (blank line) regardless of chatLineBreaks', () => {
 			const content = 'paragraph one\n\nparagraph two';
-			const { container } = render(
+
+			const defaultRender = render(<MarkdownRenderer {...defaultProps} content={content} />);
+			expect(defaultRender.container.querySelectorAll('p').length).toBe(2);
+			defaultRender.unmount();
+
+			const chatRender = render(
 				<MarkdownRenderer {...defaultProps} content={content} chatLineBreaks />
 			);
-			expect(container.querySelectorAll('p').length).toBe(2);
+			expect(chatRender.container.querySelectorAll('p').length).toBe(2);
 		});
 	});
 });

--- a/src/__tests__/renderer/components/MarkdownRenderer.test.tsx
+++ b/src/__tests__/renderer/components/MarkdownRenderer.test.tsx
@@ -1251,4 +1251,35 @@ describe('MarkdownRenderer', () => {
 			expect(link!.getAttribute('href')).toBe('https://example.com');
 		});
 	});
+
+	describe('chatLineBreaks (#622)', () => {
+		// Two lines joined by a single newline. CommonMark treats this as a soft
+		// break (rendered as a space) which flattens multi-line chat messages.
+		// chatLineBreaks must turn the soft break into a hard <br>.
+		const multilineContent = 'first line\nsecond line';
+
+		it('collapses single newlines by default (document semantics)', () => {
+			const { container } = render(
+				<MarkdownRenderer {...defaultProps} content={multilineContent} />
+			);
+			expect(container.querySelector('br')).toBeNull();
+		});
+
+		it('preserves single newlines as <br> when chatLineBreaks is enabled', () => {
+			const { container } = render(
+				<MarkdownRenderer {...defaultProps} content={multilineContent} chatLineBreaks />
+			);
+			expect(container.querySelector('br')).not.toBeNull();
+			expect(screen.getByText(/first line/)).toBeInTheDocument();
+			expect(screen.getByText(/second line/)).toBeInTheDocument();
+		});
+
+		it('keeps paragraph breaks (blank line) regardless of chatLineBreaks', () => {
+			const content = 'paragraph one\n\nparagraph two';
+			const { container } = render(
+				<MarkdownRenderer {...defaultProps} content={content} chatLineBreaks />
+			);
+			expect(container.querySelectorAll('p').length).toBe(2);
+		});
+	});
 });

--- a/src/renderer/components/GroupChatMessages.tsx
+++ b/src/renderer/components/GroupChatMessages.tsx
@@ -359,6 +359,7 @@ export const GroupChatMessages = forwardRef<GroupChatMessagesHandle, GroupChatMe
 														content={displayContent}
 														theme={theme}
 														onCopy={copyToClipboard}
+														chatLineBreaks
 													/>
 												) : (
 													<div className="whitespace-pre-wrap">
@@ -400,6 +401,7 @@ export const GroupChatMessages = forwardRef<GroupChatMessagesHandle, GroupChatMe
 														content={msg.content}
 														theme={theme}
 														onCopy={copyToClipboard}
+														chatLineBreaks
 													/>
 												) : (
 													<div className="whitespace-pre-wrap">
@@ -427,6 +429,7 @@ export const GroupChatMessages = forwardRef<GroupChatMessagesHandle, GroupChatMe
 												content={msg.content}
 												theme={theme}
 												onCopy={copyToClipboard}
+												chatLineBreaks
 											/>
 										</div>
 									) : (

--- a/src/renderer/components/HistoryDetailModal.tsx
+++ b/src/renderer/components/HistoryDetailModal.tsx
@@ -539,6 +539,7 @@ export function HistoryDetailModal({
 						projectRoot={projectRoot}
 						onFileClick={onFileClick}
 						enableBionifyReadingMode={bionifyReadingMode}
+						chatLineBreaks
 					/>
 				</div>
 

--- a/src/renderer/components/MarkdownRenderer.tsx
+++ b/src/renderer/components/MarkdownRenderer.tsx
@@ -1,6 +1,7 @@
 import React, { memo, useMemo, useState, useCallback, useEffect } from 'react';
 import ReactMarkdown from 'react-markdown';
 import rehypeRaw from 'rehype-raw';
+import remarkBreaks from 'remark-breaks';
 import DOMPurify from 'dompurify';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { getSyntaxStyle } from '../utils/syntaxTheme';
@@ -313,6 +314,16 @@ interface MarkdownRendererProps {
 	bionifyIntensity?: number;
 	/** Algorithm string controlling Bionify highlight lengths */
 	bionifyAlgorithm?: string;
+	/**
+	 * Treat single newlines as hard line breaks (chat-style rendering).
+	 *
+	 * Default CommonMark collapses single `\n` between non-blank lines into a
+	 * space. That's correct for document/file preview, but wrong for chat
+	 * surfaces where users expect line structure to be preserved (#622). When
+	 * enabled, this routes content through `remark-breaks` so single newlines
+	 * render as `<br>`.
+	 */
+	chatLineBreaks?: boolean;
 }
 
 /**
@@ -342,6 +353,7 @@ export const MarkdownRenderer = memo(
 		enableBionifyReadingMode = false,
 		bionifyIntensity,
 		bionifyAlgorithm,
+		chatLineBreaks = false,
 	}: MarkdownRendererProps) => {
 		// Resolve homeDir for tilde path expansion (module-level cache, fetched once)
 		const [homeDir, setHomeDir] = useState<string | undefined>(getHomeDir);
@@ -367,6 +379,11 @@ export const MarkdownRenderer = memo(
 				remarkFrontmatter,
 				remarkFrontmatterTable,
 			];
+			// Chat surfaces need single-newline-as-<br> semantics (#622); file/doc
+			// preview keeps default CommonMark behavior so paragraph reflow works.
+			if (chatLineBreaks) {
+				plugins.push(remarkBreaks);
+			}
 			// Add remarkFileLinks if we have file tree for relative paths,
 			// OR if we have projectRoot for absolute paths (even with empty file tree)
 			// OR if we have homeDir for tilde paths (even without file tree or projectRoot)
@@ -377,7 +394,7 @@ export const MarkdownRenderer = memo(
 				]);
 			}
 			return plugins;
-		}, [fileTree, fileTreeIndices, cwd, projectRoot, homeDir]);
+		}, [fileTree, fileTreeIndices, cwd, projectRoot, homeDir, chatLineBreaks]);
 
 		// Defense-in-depth: sanitize raw HTML with DOMPurify before markdown parsing
 		// to strip script tags, event handlers, and other XSS vectors

--- a/src/renderer/components/TerminalOutput.tsx
+++ b/src/renderer/components/TerminalOutput.tsx
@@ -491,6 +491,7 @@ const LogItemComponent = memo(
 									cwd={cwd}
 									projectRoot={projectRoot}
 									onFileClick={onFileClick}
+									chatLineBreaks
 								/>
 							</div>
 							{!!log.agentError?.parsedJson && onShowErrorDetails && (
@@ -542,6 +543,7 @@ const LogItemComponent = memo(
 										cwd={cwd}
 										projectRoot={projectRoot}
 										onFileClick={onFileClick}
+										chatLineBreaks
 									/>
 								) : (
 									log.text
@@ -707,6 +709,7 @@ const LogItemComponent = memo(
 											cwd={cwd}
 											projectRoot={projectRoot}
 											onFileClick={onFileClick}
+											chatLineBreaks
 										/>
 									) : (
 										displayText
@@ -793,6 +796,7 @@ const LogItemComponent = memo(
 											cwd={cwd}
 											projectRoot={projectRoot}
 											onFileClick={onFileClick}
+											chatLineBreaks
 										/>
 									) : (
 										<div>{filteredText}</div>
@@ -871,6 +875,7 @@ const LogItemComponent = memo(
 										cwd={cwd}
 										projectRoot={projectRoot}
 										onFileClick={onFileClick}
+										chatLineBreaks
 									/>
 								) : (
 									// Raw markdown source mode (show original text with markdown syntax visible)

--- a/src/web/mobile/MobileMarkdownRenderer.tsx
+++ b/src/web/mobile/MobileMarkdownRenderer.tsx
@@ -16,6 +16,7 @@
 
 import React, { memo, useCallback, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
+import remarkBreaks from 'remark-breaks';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { vscDarkPlus, vs } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import { useThemeColors, useTheme } from '../components/ThemeProvider';
@@ -23,6 +24,10 @@ import { triggerHaptic, HAPTIC_PATTERNS } from './constants';
 import { REMARK_GFM_PLUGINS } from '../../shared/markdownPlugins';
 import { extractHexColor } from '../../shared/hexColor';
 import { BionifyText, getBionifyReadingModeStyles } from '../../renderer/utils/bionifyReadingMode';
+
+// Mobile chat surfaces (#622): single `\n` should render as a hard break,
+// not be collapsed into a space the way CommonMark does for document prose.
+const MOBILE_CHAT_REMARK_PLUGINS = [...REMARK_GFM_PLUGINS, remarkBreaks];
 
 /**
  * Props for MobileMarkdownRenderer
@@ -319,7 +324,7 @@ export const MobileMarkdownRenderer = memo(
           }
         `}</style>
 				<ReactMarkdown
-					remarkPlugins={REMARK_GFM_PLUGINS}
+					remarkPlugins={MOBILE_CHAT_REMARK_PLUGINS}
 					components={{
 						// Links open in new tab
 						a: ({ href, children }) => (


### PR DESCRIPTION
## Summary

Continues the work shipped in PR #996 (for #775) by addressing the related sub-problem in issue #622: **ReactMarkdown collapses single `\n` into a space, which visually flattens multi-line assistant messages on chat surfaces.**

Issue #622 lists three sub-problems on chat surfaces (AI Terminal, group chat, mobile message history). This PR fixes sub-problem 1 (newline flattening). Sub-problems 2 (display math `\$\$...\$\$`) and 3 (raw/plain toggle for user messages) are out of scope — math needs a new dependency stack (KaTeX) and the toggle change needs UX decisions.

## Changes

- Add an opt-in `chatLineBreaks` prop on `MarkdownRenderer` that wires `remark-breaks` into the plugin stack
- Enable it on chat surfaces only:
  - `TerminalOutput` — AI assistant messages (all three render paths: collapsed, expanded, default), thinking/streaming, error log entries
  - `GroupChatMessages` — assistant messages (collapsed, expanded, default)
  - `HistoryDetailModal` — historical AI responses
  - `MobileMarkdownRenderer` — applied unconditionally (it is only used by mobile chat surfaces via `WebReadingContent` → `MessageHistory` + `ResponseViewer`)
- **Intentionally left untouched** (document/file-preview surfaces, where CommonMark paragraph reflow is correct): `DocumentGraphView`, `DirectorNotes/AIOverviewTab`, and the `FilePreview` render path
- Add `remark-breaks` as a dependency
- 3 new tests on `MarkdownRenderer`: default collapses single newlines, `chatLineBreaks` emits `<br>`, blank-line paragraph breaks still produce two `<p>` elements either way

## Test plan

- [ ] Multi-line AI assistant message in AI Terminal renders with line breaks preserved (not flattened to one paragraph)
- [ ] Multi-line message in group chat renders with line breaks preserved
- [ ] Multi-line response in History detail modal renders with line breaks preserved
- [ ] Mobile message history / mobile response viewer preserves line breaks
- [ ] Markdown file preview (`.md` files in workspace) still reflows paragraphs the standard CommonMark way — single `\n` collapses to a space
- [ ] Code blocks, lists, tables, links, file links all still work on chat surfaces
- [x] `MarkdownRenderer` tests pass (13/13 including 3 new)
- [x] `TerminalOutput` + mobile chat tests pass (201/201)
- [x] Prettier clean, ESLint clean, TypeScript clean (all three tsconfigs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat-style line breaks for markdown rendering: single newlines can be shown as visible breaks across desktop and mobile chat surfaces.

* **Tests**
  * Added tests verifying newline-to-HTML behavior with chat-style breaks enabled and with default CommonMark handling.

* **Chores**
  * Added markdown line-breaks dependency to the toolchain.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RunMaestro/Maestro/pull/1000?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->