### PR TITLE
feat(cli): inject Maestro system prompt into CLI agent spawns

### DIFF
--- a/src/__tests__/cli/commands/send.test.ts
+++ b/src/__tests__/cli/commands/send.test.ts
@@ -24,6 +24,11 @@ vi.mock('../../../cli/services/agent-spawner', () => ({
 	detectAgent: vi.fn(),
 }));
 
+// Mock system-prompt so we can assert it gets called (or skipped on --no-system-prompt)
+vi.mock('../../../cli/services/system-prompt', () => ({
+	prepareMaestroSystemPromptCli: vi.fn(),
+}));
+
 // Mock storage
 vi.mock('../../../cli/services/storage', () => ({
 	resolveAgentId: vi.fn(),
@@ -53,6 +58,7 @@ import { withMaestroClient } from '../../../cli/services/maestro-client';
 import { spawnAgent, detectAgent } from '../../../cli/services/agent-spawner';
 import { resolveAgentId, getSessionById } from '../../../cli/services/storage';
 import { estimateContextUsage } from '../../../main/parsers/usage-aggregator';
+import { prepareMaestroSystemPromptCli } from '../../../cli/services/system-prompt';
 
 describe('send command', () => {
 	let consoleSpy: MockInstance;
@@ -71,6 +77,10 @@ describe('send command', () => {
 		vi.clearAllMocks();
 		consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 		processExitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+		// Default: system-prompt builder returns undefined so existing assertions
+		// that don't include `appendSystemPrompt` keep passing (vitest treats
+		// undefined-valued object keys as absent in `toHaveBeenCalledWith`).
+		vi.mocked(prepareMaestroSystemPromptCli).mockResolvedValue(undefined);
 	});
 
 	it('should query an agent and return JSON response for new session', async () => {
@@ -289,6 +299,98 @@ describe('send command', () => {
 		expect(output.response).toBeNull();
 		expect(output.usage).not.toBeNull();
 		expect(processExitSpy).toHaveBeenCalledWith(1);
+	});
+
+	it('builds and passes the Maestro system prompt by default', async () => {
+		vi.mocked(resolveAgentId).mockReturnValue('agent-abc-123');
+		const agent = mockAgent();
+		vi.mocked(getSessionById).mockReturnValue(agent);
+		vi.mocked(detectAgent).mockResolvedValue({ available: true, path: '/usr/bin/claude' });
+		vi.mocked(prepareMaestroSystemPromptCli).mockResolvedValue('the maestro context');
+		vi.mocked(spawnAgent).mockResolvedValue({
+			success: true,
+			response: 'ok',
+			agentSessionId: 'session-1',
+		});
+
+		await send('agent-abc', 'hello', {});
+
+		expect(prepareMaestroSystemPromptCli).toHaveBeenCalledWith(agent);
+		expect(spawnAgent).toHaveBeenCalledWith(
+			'claude-code',
+			'/path/to/project',
+			'hello',
+			undefined,
+			expect.objectContaining({ appendSystemPrompt: 'the maestro context' })
+		);
+	});
+
+	it('skips building the Maestro system prompt when --no-system-prompt is set', async () => {
+		vi.mocked(resolveAgentId).mockReturnValue('agent-abc-123');
+		vi.mocked(getSessionById).mockReturnValue(mockAgent());
+		vi.mocked(detectAgent).mockResolvedValue({ available: true, path: '/usr/bin/claude' });
+		vi.mocked(spawnAgent).mockResolvedValue({
+			success: true,
+			response: 'ok',
+			agentSessionId: 'session-1',
+		});
+
+		// Commander negates `--no-system-prompt` to `systemPrompt: false`
+		await send('agent-abc', 'hello', { systemPrompt: false });
+
+		expect(prepareMaestroSystemPromptCli).not.toHaveBeenCalled();
+		expect(spawnAgent).toHaveBeenCalledWith(
+			'claude-code',
+			'/path/to/project',
+			'hello',
+			undefined,
+			expect.objectContaining({ appendSystemPrompt: undefined })
+		);
+	});
+
+	it('still injects the system prompt on resume (parity with desktop)', async () => {
+		vi.mocked(resolveAgentId).mockReturnValue('agent-abc-123');
+		vi.mocked(getSessionById).mockReturnValue(mockAgent());
+		vi.mocked(detectAgent).mockResolvedValue({ available: true, path: '/usr/bin/claude' });
+		vi.mocked(prepareMaestroSystemPromptCli).mockResolvedValue('still here on resume');
+		vi.mocked(spawnAgent).mockResolvedValue({
+			success: true,
+			response: 'ok',
+			agentSessionId: 'session-xyz',
+		});
+
+		await send('agent-abc', 'follow-up', { session: 'session-xyz' });
+
+		expect(prepareMaestroSystemPromptCli).toHaveBeenCalled();
+		expect(spawnAgent).toHaveBeenCalledWith(
+			'claude-code',
+			'/path/to/project',
+			'follow-up',
+			'session-xyz',
+			expect.objectContaining({ appendSystemPrompt: 'still here on resume' })
+		);
+	});
+
+	it('continues without the system prompt when prepareMaestroSystemPromptCli returns undefined (non-fatal)', async () => {
+		vi.mocked(resolveAgentId).mockReturnValue('agent-abc-123');
+		vi.mocked(getSessionById).mockReturnValue(mockAgent());
+		vi.mocked(detectAgent).mockResolvedValue({ available: true, path: '/usr/bin/claude' });
+		vi.mocked(prepareMaestroSystemPromptCli).mockResolvedValue(undefined);
+		vi.mocked(spawnAgent).mockResolvedValue({
+			success: true,
+			response: 'ok',
+			agentSessionId: 'session-1',
+		});
+
+		await send('agent-abc', 'hello', {});
+
+		expect(prepareMaestroSystemPromptCli).toHaveBeenCalled();
+		expect(spawnAgent).toHaveBeenCalled();
+		const callArgs = vi.mocked(spawnAgent).mock.calls[0];
+		expect(callArgs[4]?.appendSystemPrompt).toBeUndefined();
+		// And the send must still succeed end-to-end
+		const output = JSON.parse(consoleSpy.mock.calls[0][0]);
+		expect(output.success).toBe(true);
 	});
 
 	it('should handle null usage stats gracefully', async () => {

--- a/src/__tests__/cli/services/agent-spawner.test.ts
+++ b/src/__tests__/cli/services/agent-spawner.test.ts
@@ -2144,4 +2144,168 @@ Some text with [x] in it that's not a checkbox
 			expect(result.error).toMatch(/Unsupported agent type/);
 		});
 	});
+
+	describe('spawnAgent: appendSystemPrompt', () => {
+		beforeEach(() => {
+			mockSpawn.mockReturnValue(mockChild);
+		});
+
+		it('passes the Maestro system prompt to Claude via --append-system-prompt (non-Windows)', async () => {
+			const originalPlatform = process.platform;
+			Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
+			try {
+				const p = spawnAgent('claude-code', '/p', 'user msg', undefined, {
+					appendSystemPrompt: 'maestro context here',
+				});
+				await driveSpawnToCompletion(p, 0, CLAUDE_OK());
+
+				const { args } = spawnCall();
+				const flagIdx = args.indexOf('--append-system-prompt');
+				expect(flagIdx).toBeGreaterThanOrEqual(0);
+				expect(args[flagIdx + 1]).toBe('maestro context here');
+				// The flag must precede the '--' separator so it doesn't get
+				// swallowed as part of the positional prompt.
+				const sepIdx = args.indexOf('--');
+				expect(flagIdx).toBeLessThan(sepIdx);
+				expect(args[sepIdx + 1]).toBe('user msg');
+			} finally {
+				Object.defineProperty(process, 'platform', {
+					value: originalPlatform,
+					configurable: true,
+				});
+			}
+		});
+
+		it('uses --append-system-prompt-file with a temp file on Windows local execution', async () => {
+			const originalPlatform = process.platform;
+			Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+			const writeSpy = vi.spyOn(fs, 'writeFileSync').mockImplementation(() => undefined);
+			try {
+				const p = spawnAgent('claude-code', 'C:\\proj', 'hi', undefined, {
+					appendSystemPrompt: 'sysprompt',
+				});
+				await driveSpawnToCompletion(p, 0, CLAUDE_OK());
+
+				const { args } = spawnCall();
+				const fileFlagIdx = args.indexOf('--append-system-prompt-file');
+				expect(fileFlagIdx).toBeGreaterThanOrEqual(0);
+				// The arg after the flag should be a tmp-path with the maestro prefix
+				expect(args[fileFlagIdx + 1]).toMatch(/maestro-sysprompt-/);
+				// Inline flag must NOT also be emitted on the Windows local path
+				expect(args.indexOf('--append-system-prompt')).toBe(-1);
+				// And we must have written the temp file
+				expect(writeSpy).toHaveBeenCalledWith(
+					expect.stringMatching(/maestro-sysprompt-/),
+					'sysprompt',
+					'utf-8'
+				);
+			} finally {
+				writeSpy.mockRestore();
+				Object.defineProperty(process, 'platform', {
+					value: originalPlatform,
+					configurable: true,
+				});
+			}
+		});
+
+		it('uses inline --append-system-prompt on Windows when SSH is enabled (cmd is in a shell script)', async () => {
+			const originalPlatform = process.platform;
+			Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+			mockWrapSpawnWithSsh.mockResolvedValue({
+				command: 'ssh',
+				args: ['remotehost', 'claude --append-system-prompt sysprompt -- hi'],
+				cwd: '/home/user',
+				customEnvVars: undefined,
+				prompt: undefined,
+				sshStdinScript: undefined,
+				sshRemoteUsed: { id: 'r1', name: 'r1', host: 'remotehost' },
+			});
+			try {
+				const p = spawnAgent('claude-code', '/p', 'hi', undefined, {
+					appendSystemPrompt: 'sysprompt',
+					sshRemoteConfig: { enabled: true, remoteId: 'r1' },
+				});
+				await driveSpawnToCompletion(p, 0, CLAUDE_OK());
+
+				expect(mockWrapSpawnWithSsh).toHaveBeenCalled();
+				const [wrapConfig] = mockWrapSpawnWithSsh.mock.calls[0] as [{ args: string[] }];
+				const flagIdx = wrapConfig.args.indexOf('--append-system-prompt');
+				expect(flagIdx).toBeGreaterThanOrEqual(0);
+				expect(wrapConfig.args[flagIdx + 1]).toBe('sysprompt');
+				expect(wrapConfig.args.indexOf('--append-system-prompt-file')).toBe(-1);
+			} finally {
+				Object.defineProperty(process, 'platform', {
+					value: originalPlatform,
+					configurable: true,
+				});
+			}
+		});
+
+		it('still injects the Maestro system prompt on resume (Claude reads it every turn)', async () => {
+			const p = spawnAgent('claude-code', '/p', 'follow-up', 'session-abc', {
+				appendSystemPrompt: 'maestro context',
+			});
+			await driveSpawnToCompletion(p, 0, CLAUDE_OK());
+
+			const { args } = spawnCall();
+			expect(args).toContain('--resume');
+			expect(args).toContain('session-abc');
+			const flagIdx = args.indexOf('--append-system-prompt');
+			expect(flagIdx).toBeGreaterThanOrEqual(0);
+			expect(args[flagIdx + 1]).toBe('maestro context');
+		});
+
+		it('Codex (no native --append-system-prompt support) embeds the system prompt in the first user turn', async () => {
+			const p = spawnAgent('codex', '/p', 'do thing', undefined, {
+				appendSystemPrompt: 'maestro ctx',
+			});
+			await driveSpawnToCompletion(p, 0, CODEX_INIT());
+
+			const { args } = spawnCall();
+			// codex uses `-- <prompt>` positional form
+			const sepIdx = args.indexOf('--');
+			expect(sepIdx).toBeGreaterThan(0);
+			const positional = args[sepIdx + 1];
+			expect(positional).toContain('maestro ctx');
+			expect(positional).toContain('# User Request');
+			expect(positional).toContain('do thing');
+			// must NOT emit the native flag for agents that don't support it
+			expect(args.indexOf('--append-system-prompt')).toBe(-1);
+			expect(args.indexOf('--append-system-prompt-file')).toBe(-1);
+		});
+
+		it('Codex resume skips system-prompt embedding (already captured in transcript)', async () => {
+			const p = spawnAgent('codex', '/p', 'do thing', 'codex-thread-xyz', {
+				appendSystemPrompt: 'maestro ctx',
+			});
+			await driveSpawnToCompletion(p, 0, CODEX_INIT());
+
+			const { args } = spawnCall();
+			const sepIdx = args.indexOf('--');
+			expect(sepIdx).toBeGreaterThan(0);
+			const positional = args[sepIdx + 1];
+			expect(positional).toBe('do thing');
+			expect(positional).not.toContain('maestro ctx');
+			expect(positional).not.toContain('# User Request');
+		});
+
+		it('Claude spawn without appendSystemPrompt does NOT add the flag (regression)', async () => {
+			const p = spawnAgent('claude-code', '/p', 'hi');
+			await driveSpawnToCompletion(p, 0, CLAUDE_OK());
+
+			const { args } = spawnCall();
+			expect(args.indexOf('--append-system-prompt')).toBe(-1);
+			expect(args.indexOf('--append-system-prompt-file')).toBe(-1);
+		});
+
+		it('Codex spawn without appendSystemPrompt passes the raw user prompt unchanged (regression)', async () => {
+			const p = spawnAgent('codex', '/p', 'just the user message');
+			await driveSpawnToCompletion(p, 0, CODEX_INIT());
+
+			const { args } = spawnCall();
+			const sepIdx = args.indexOf('--');
+			expect(sepIdx).toBeGreaterThan(0);
+			expect(args[sepIdx + 1]).toBe('just the user message');
+		});
+	});
 });

--- a/src/__tests__/cli/services/agent-spawner.test.ts
+++ b/src/__tests__/cli/services/agent-spawner.test.ts
@@ -2208,6 +2208,38 @@ Some text with [x] in it that's not a checkbox
 			}
 		});
 
+		it('sanitizes the session tag in the Windows temp-file path to block traversal', async () => {
+			const originalPlatform = process.platform;
+			Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+			const writeSpy = vi.spyOn(fs, 'writeFileSync').mockImplementation(() => undefined);
+			try {
+				// A session id containing path separators / `..` would normally
+				// let `path.join(os.tmpdir(), …)` walk upward and escape tmpdir.
+				// We pass it through as the agentSessionId (which becomes the
+				// sessionTag inside buildAppendSystemPromptArgs).
+				const p = spawnAgent('claude-code', 'C:\\proj', 'hi', '../../../etc/passwd', {
+					appendSystemPrompt: 'sysprompt',
+				});
+				await driveSpawnToCompletion(p, 0, CLAUDE_OK());
+
+				const { args } = spawnCall();
+				const fileFlagIdx = args.indexOf('--append-system-prompt-file');
+				expect(fileFlagIdx).toBeGreaterThanOrEqual(0);
+				const tempPath = args[fileFlagIdx + 1];
+				// Sanitized path must not contain unescaped traversal tokens
+				expect(tempPath).not.toMatch(/\.\.\//);
+				expect(tempPath).not.toMatch(/\.\.\\/);
+				// And the dangerous chars should have collapsed to safe ones
+				expect(tempPath).toMatch(/maestro-sysprompt-[A-Za-z0-9_-]+-\d+\.txt$/);
+			} finally {
+				writeSpy.mockRestore();
+				Object.defineProperty(process, 'platform', {
+					value: originalPlatform,
+					configurable: true,
+				});
+			}
+		});
+
 		it('uses inline --append-system-prompt on Windows when SSH is enabled (cmd is in a shell script)', async () => {
 			const originalPlatform = process.platform;
 			Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });

--- a/src/__tests__/cli/services/batch-processor.test.ts
+++ b/src/__tests__/cli/services/batch-processor.test.ts
@@ -41,6 +41,20 @@ vi.mock('../../../cli/services/agent-spawner', () => ({
 	writeDoc: vi.fn(),
 }));
 
+// Mock the CLI system-prompt builder. Real-impl would read the bundled
+// `maestro-system-prompt` template from disk + call git — neither is
+// available or interesting under unit tests. We can still observe whether
+// runPlaybook calls it and what it produces by tweaking the mock per test.
+vi.mock('../../../cli/services/system-prompt', () => ({
+	prepareMaestroSystemPromptCli: vi.fn(),
+}));
+
+// Mock CLI prompt-loader so batch-processor can read the default Auto Run
+// + synopsis prompts without hitting disk. Per-test overrides allowed.
+vi.mock('../../../cli/services/prompt-loader', () => ({
+	getCliPrompt: vi.fn().mockResolvedValue('Default Auto Run prompt'),
+}));
+
 // Mock storage
 vi.mock('../../../cli/services/storage', () => ({
 	addHistoryEntry: vi.fn(),
@@ -77,6 +91,7 @@ import {
 } from '../../../cli/services/agent-spawner';
 import { addHistoryEntry, readGroups } from '../../../cli/services/storage';
 import { registerCliActivity, unregisterCliActivity } from '../../../shared/cli-activity';
+import { prepareMaestroSystemPromptCli } from '../../../cli/services/system-prompt';
 
 describe('batch-processor', () => {
 	// Helper to create mock session
@@ -126,6 +141,10 @@ describe('batch-processor', () => {
 			agentSessionId: 'claude-session-123',
 		});
 		vi.mocked(uncheckAllTasks).mockImplementation((content) => content.replace(/\[x\]/gi, '[ ]'));
+		// Default: system prompt builder returns undefined (matches the
+		// non-fatal fallback when the template can't be loaded). Tests that
+		// care about positive-case wiring override this in-test.
+		vi.mocked(prepareMaestroSystemPromptCli).mockResolvedValue(undefined);
 	});
 
 	afterEach(() => {
@@ -328,6 +347,74 @@ describe('batch-processor', () => {
 			expect(taskStartEvents.length).toBe(1);
 			expect(taskCompleteEvents.length).toBe(1);
 			expect(taskCompleteEvents[0]?.success).toBe(true);
+		});
+
+		it('injects the Maestro system prompt into the task spawn (parity with desktop Auto Run)', async () => {
+			vi.mocked(prepareMaestroSystemPromptCli).mockResolvedValue('the maestro context');
+			let callCount = 0;
+			vi.mocked(readDocAndCountTasks).mockImplementation(() => {
+				callCount++;
+				if (callCount <= 3) return { content: '- [ ] Task', taskCount: 1 };
+				return { content: '', taskCount: 0 };
+			});
+
+			const session = mockSession();
+			const playbook = mockPlaybook();
+
+			await collectEvents(runPlaybook(session, playbook, '/playbooks'));
+
+			expect(prepareMaestroSystemPromptCli).toHaveBeenCalledWith(session);
+			// Spawn call #0 is the task spawn — must carry appendSystemPrompt
+			const taskSpawnOpts = vi.mocked(spawnAgent).mock.calls[0][4];
+			expect(taskSpawnOpts?.appendSystemPrompt).toBe('the maestro context');
+		});
+
+		it('omits the Maestro system prompt from the synopsis spawn (resume reuses the existing transcript)', async () => {
+			vi.mocked(prepareMaestroSystemPromptCli).mockResolvedValue('the maestro context');
+			let callCount = 0;
+			vi.mocked(readDocAndCountTasks).mockImplementation(() => {
+				callCount++;
+				if (callCount <= 3) return { content: '- [ ] Task', taskCount: 1 };
+				return { content: '', taskCount: 0 };
+			});
+			vi.mocked(spawnAgent).mockResolvedValue({
+				success: true,
+				response: '**Summary:** ok\n**Details:** ok',
+				agentSessionId: 'claude-session-123',
+			});
+
+			const session = mockSession();
+			const playbook = mockPlaybook();
+
+			await collectEvents(runPlaybook(session, playbook, '/playbooks'));
+
+			// Two spawns: index 0 = task spawn, index 1 = synopsis (resume).
+			// Synopsis spawn must NOT carry appendSystemPrompt — matches the
+			// desktop `spawnBackgroundSynopsis` path which omits it on resume.
+			expect(vi.mocked(spawnAgent).mock.calls.length).toBeGreaterThanOrEqual(2);
+			const synopsisSpawnOpts = vi.mocked(spawnAgent).mock.calls[1][4];
+			expect(synopsisSpawnOpts?.appendSystemPrompt).toBeUndefined();
+		});
+
+		it('builds the system prompt once per playbook run, not once per task', async () => {
+			vi.mocked(prepareMaestroSystemPromptCli).mockResolvedValue('the maestro context');
+			// Three tasks then completion: scan + processing call + after-task call
+			let callCount = 0;
+			vi.mocked(readDocAndCountTasks).mockImplementation(() => {
+				callCount++;
+				if (callCount <= 6) return { content: '- [ ] A\n- [ ] B', taskCount: 2 };
+				return { content: '', taskCount: 0 };
+			});
+
+			const session = mockSession();
+			const playbook = mockPlaybook();
+
+			await collectEvents(runPlaybook(session, playbook, '/playbooks'));
+
+			// Called exactly once for the playbook, not per-task — important for
+			// avoiding repeated git execFile + prompt-read overhead inside the
+			// task loop.
+			expect(prepareMaestroSystemPromptCli).toHaveBeenCalledTimes(1);
 		});
 
 		it('should call spawnAgent with combined prompt and document', async () => {

--- a/src/__tests__/cli/services/prompt-loader.test.ts
+++ b/src/__tests__/cli/services/prompt-loader.test.ts
@@ -1,0 +1,143 @@
+/**
+ * @file prompt-loader.test.ts
+ * @description Tests for the CLI prompt loader: customization precedence,
+ * candidate-path fallback, in-memory caching, and `{{REF:name}}` resolution.
+ *
+ * The renderer/main pair (src/main/prompt-manager.ts) is the canonical impl
+ * — the CLI loader mirrors its behavior so an agent driven by `maestro-cli`
+ * sees the same content as a desktop-spawned agent, including the absolute
+ * on-disk paths that `{{REF:_interface-primitives}}` etc. expand to.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Single shared mock fn so the named-export and default-export view of
+// `fs/promises.readFile` are the same instance — otherwise the prompt-loader
+// reads via the default while tests configure the named (or vice versa) and
+// the configuration goes nowhere. See `agent-spawner.test.ts` for the same
+// "mocked first, then re-export as default" pattern.
+const mockReadFile = vi.fn();
+vi.mock('fs/promises', () => ({
+	default: { readFile: mockReadFile },
+	readFile: mockReadFile,
+}));
+
+vi.mock('fs', async () => {
+	const actual = await vi.importActual<typeof import('fs')>('fs');
+	const mocked = {
+		...actual,
+		accessSync: vi.fn(),
+		constants: actual.constants,
+	};
+	return { ...mocked, default: mocked };
+});
+
+vi.mock('../../../cli/services/storage', () => ({
+	getConfigDirectory: vi.fn(() => '/mock/config'),
+}));
+
+import fsSync from 'fs';
+import { getCliPrompt, _resetCliPromptCacheForTests } from '../../../cli/services/prompt-loader';
+
+describe('CLI prompt-loader', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		_resetCliPromptCacheForTests();
+	});
+
+	it('returns the user-customized content when one exists and skips bundled', async () => {
+		// First call: read customizations file → returns user-edited content.
+		// fs.promises.readFile reads the customizations json then never reads
+		// any bundled fallback (asserted by call count).
+		mockReadFile.mockResolvedValueOnce(
+			JSON.stringify({
+				prompts: {
+					'autorun-default': {
+						content: 'user edited content',
+						isModified: true,
+					},
+				},
+			})
+		);
+		// accessSync probes for the bundled REF resolver dir — return success
+		// so subsequent REF expansion has a stable root if it ever runs.
+		vi.mocked(fsSync.accessSync).mockReturnValue(undefined);
+
+		const content = await getCliPrompt('autorun-default');
+
+		expect(content).toBe('user edited content');
+		// Only the customizations file should have been read — no bundled fallback
+		expect(mockReadFile).toHaveBeenCalledTimes(1);
+	});
+
+	it('falls back to bundled content when no customization is present', async () => {
+		// 1st readFile: customizations file → ENOENT
+		// 2nd readFile: first bundled candidate succeeds
+		const customizationErr = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+		mockReadFile.mockRejectedValueOnce(customizationErr).mockResolvedValueOnce('bundled content');
+		vi.mocked(fsSync.accessSync).mockReturnValue(undefined);
+
+		const content = await getCliPrompt('autorun-default');
+
+		expect(content).toBe('bundled content');
+		// Customizations + first bundled candidate were tried
+		expect(mockReadFile).toHaveBeenCalled();
+	});
+
+	it('caches a loaded prompt so subsequent calls do not re-read the filesystem', async () => {
+		mockReadFile.mockResolvedValueOnce(
+			JSON.stringify({
+				prompts: { 'autorun-default': { content: 'cached', isModified: true } },
+			})
+		);
+		vi.mocked(fsSync.accessSync).mockReturnValue(undefined);
+
+		const first = await getCliPrompt('autorun-default');
+		const second = await getCliPrompt('autorun-default');
+
+		expect(first).toBe('cached');
+		expect(second).toBe('cached');
+		expect(mockReadFile).toHaveBeenCalledTimes(1);
+	});
+
+	it('expands {{REF:name}} to the absolute on-disk path of the bundled file', async () => {
+		// Customizations file ENOENT, then bundled file contains a REF.
+		// accessSync says the probe file exists so getBundledPromptsDir resolves.
+		const customizationErr = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+		mockReadFile
+			.mockRejectedValueOnce(customizationErr)
+			.mockResolvedValueOnce('See `{{REF:_interface-primitives}}` for the routing table.\n');
+		vi.mocked(fsSync.accessSync).mockReturnValue(undefined);
+
+		const content = await getCliPrompt('maestro-system-prompt');
+
+		// The REF must have been replaced with a string that looks like an
+		// absolute path ending in the include's filename. Both Unix and Windows
+		// emit native separators, so just assert the filename component.
+		expect(content).toMatch(/_interface-primitives\.md/);
+		expect(content).not.toContain('{{REF:_interface-primitives}}');
+	});
+
+	it('leaves an unknown {{REF:...}} placeholder unchanged (no panic)', async () => {
+		const customizationErr = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+		mockReadFile
+			.mockRejectedValueOnce(customizationErr)
+			.mockResolvedValueOnce('hello {{REF:not-a-real-prompt-id}} world');
+		vi.mocked(fsSync.accessSync).mockReturnValue(undefined);
+
+		const content = await getCliPrompt('autorun-default');
+
+		expect(content).toBe('hello {{REF:not-a-real-prompt-id}} world');
+	});
+
+	it('throws when no candidate file can be loaded', async () => {
+		const enoent = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+		// Every readFile call (customizations + every bundled candidate) fails
+		mockReadFile.mockRejectedValue(enoent);
+		vi.mocked(fsSync.accessSync).mockImplementation(() => {
+			throw enoent;
+		});
+
+		await expect(getCliPrompt('autorun-default')).rejects.toThrow(/Failed to load prompt/);
+	});
+});

--- a/src/__tests__/cli/services/prompt-loader.test.ts
+++ b/src/__tests__/cli/services/prompt-loader.test.ts
@@ -14,9 +14,11 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // Single shared mock fn so the named-export and default-export view of
 // `fs/promises.readFile` are the same instance — otherwise the prompt-loader
 // reads via the default while tests configure the named (or vice versa) and
-// the configuration goes nowhere. See `agent-spawner.test.ts` for the same
-// "mocked first, then re-export as default" pattern.
-const mockReadFile = vi.fn();
+// the configuration goes nowhere. `vi.hoisted` is required because `vi.mock`
+// calls are hoisted to the top of the file; referencing a plain `const`
+// declared between imports breaks on hoist-ordering in newer vitest
+// (CI hits "Cannot access 'mockReadFile' before initialization").
+const { mockReadFile } = vi.hoisted(() => ({ mockReadFile: vi.fn() }));
 vi.mock('fs/promises', () => ({
 	default: { readFile: mockReadFile },
 	readFile: mockReadFile,
@@ -24,10 +26,14 @@ vi.mock('fs/promises', () => ({
 
 vi.mock('fs', async () => {
 	const actual = await vi.importActual<typeof import('fs')>('fs');
+	// `actual.constants` is a getter on the fs module — spreading `actual`
+	// drops it (only own enumerable data properties carry through), and
+	// `getBundledPromptsDir` reads `fs.constants.R_OK`. Inline the literal
+	// so the mock surface still exposes a usable constants object.
 	const mocked = {
 		...actual,
 		accessSync: vi.fn(),
-		constants: actual.constants,
+		constants: { ...actual.constants, R_OK: 4 },
 	};
 	return { ...mocked, default: mocked };
 });

--- a/src/__tests__/cli/services/system-prompt.test.ts
+++ b/src/__tests__/cli/services/system-prompt.test.ts
@@ -82,11 +82,24 @@ describe('prepareMaestroSystemPromptCli', () => {
 	});
 
 	it('returns undefined when the prompt template fails to load (non-fatal)', async () => {
-		vi.mocked(getCliPrompt).mockRejectedValue(new Error('template missing'));
+		vi.mocked(getCliPrompt).mockRejectedValue(
+			new Error('Failed to load prompt "maestro-system-prompt" (maestro-system-prompt.md)')
+		);
 
 		const result = await prepareMaestroSystemPromptCli(mockSession());
 
 		expect(result).toBeUndefined();
+	});
+
+	it('re-throws unexpected errors so genuine bugs surface (not just "failed to load")', async () => {
+		// A non-"Failed to load…" error indicates a bug in the loader or a
+		// caller misuse — those must propagate so the user sees them rather
+		// than silently spawning without a system prompt.
+		vi.mocked(getCliPrompt).mockRejectedValue(new TypeError('something is undefined'));
+
+		await expect(prepareMaestroSystemPromptCli(mockSession())).rejects.toThrow(
+			/something is undefined/
+		);
 	});
 
 	it('skips git branch lookup when the cwd is not a git repo', async () => {

--- a/src/__tests__/cli/services/system-prompt.test.ts
+++ b/src/__tests__/cli/services/system-prompt.test.ts
@@ -1,0 +1,144 @@
+/**
+ * @file system-prompt.test.ts
+ * @description Tests for `prepareMaestroSystemPromptCli` — the CLI-side
+ * builder that loads `maestro-system-prompt`, threads in branch / history /
+ * conductor context, and returns the substituted template for use as
+ * `appendSystemPrompt`. Mirrors the renderer's `prepareMaestroSystemPrompt`
+ * in `src/renderer/utils/spawnHelpers.ts`.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { SessionInfo } from '../../../shared/types';
+
+vi.mock('../../../cli/services/prompt-loader', () => ({
+	getCliPrompt: vi.fn(),
+}));
+
+vi.mock('../../../cli/services/storage', () => ({
+	getConfigDirectory: vi.fn(() => '/mock/config'),
+	readSettingValue: vi.fn(),
+}));
+
+vi.mock('../../../cli/services/git-utils', () => ({
+	getGitBranch: vi.fn(),
+	isGitRepo: vi.fn(),
+}));
+
+vi.mock('fs', async () => {
+	const actual = await vi.importActual<typeof import('fs')>('fs');
+	// `actual.constants` is a getter on the fs module — spreading `actual`
+	// drops it (only own enumerable data properties carry through), and
+	// production code reads `fs.constants.R_OK`. Inline the literal so the
+	// mock surface still exposes a usable constants object.
+	const mocked = {
+		...actual,
+		accessSync: vi.fn(),
+		constants: { ...actual.constants, R_OK: 4 },
+	};
+	return { ...mocked, default: mocked };
+});
+
+import fs from 'fs';
+import { prepareMaestroSystemPromptCli } from '../../../cli/services/system-prompt';
+import { getCliPrompt } from '../../../cli/services/prompt-loader';
+import { readSettingValue } from '../../../cli/services/storage';
+import { getGitBranch, isGitRepo } from '../../../cli/services/git-utils';
+
+const mockSession = (overrides: Partial<SessionInfo> = {}): SessionInfo => ({
+	id: 'agent-abc-123',
+	name: 'Test Agent',
+	toolType: 'claude-code',
+	cwd: '/path/to/project',
+	projectRoot: '/path/to/project',
+	...overrides,
+});
+
+describe('prepareMaestroSystemPromptCli', () => {
+	beforeEach(() => {
+		// Clear call history but keep implementations — explicit per-test
+		// defaults below so behavior is unambiguous.
+		vi.clearAllMocks();
+		// Re-establish the mocked storage default since resetAllMocks would
+		// nuke it, and we want a stable getConfigDirectory return value.
+		vi.mocked(isGitRepo).mockReturnValue(true);
+		vi.mocked(getGitBranch).mockReturnValue('main');
+		vi.mocked(readSettingValue).mockReturnValue('');
+		vi.mocked(fs.accessSync).mockImplementation(() => {
+			// Default: history file does NOT exist (fresh session)
+			throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+		});
+	});
+
+	it('substitutes agent identity, branch, and conductor profile into the template', async () => {
+		vi.mocked(getCliPrompt).mockResolvedValue(
+			'You are {{AGENT_NAME}} on branch {{GIT_BRANCH}}.\nConductor: {{CONDUCTOR_PROFILE}}'
+		);
+		vi.mocked(readSettingValue).mockReturnValue('senior engineer, prefers concise');
+
+		const result = await prepareMaestroSystemPromptCli(mockSession({ name: 'Codex Bot' }));
+
+		expect(result).toContain('You are Codex Bot on branch main.');
+		expect(result).toContain('Conductor: senior engineer, prefers concise');
+	});
+
+	it('returns undefined when the prompt template fails to load (non-fatal)', async () => {
+		vi.mocked(getCliPrompt).mockRejectedValue(new Error('template missing'));
+
+		const result = await prepareMaestroSystemPromptCli(mockSession());
+
+		expect(result).toBeUndefined();
+	});
+
+	it('skips git branch lookup when the cwd is not a git repo', async () => {
+		vi.mocked(getCliPrompt).mockResolvedValue('branch=[{{GIT_BRANCH}}]');
+		vi.mocked(isGitRepo).mockReturnValue(false);
+
+		const result = await prepareMaestroSystemPromptCli(mockSession());
+
+		expect(getGitBranch).not.toHaveBeenCalled();
+		expect(result).toBe('branch=[]');
+	});
+
+	it('omits the history file path when one is not yet written (fresh session)', async () => {
+		vi.mocked(getCliPrompt).mockResolvedValue('history=[{{AGENT_HISTORY_PATH}}]');
+		// fs.accessSync is already mocked to throw ENOENT in beforeEach
+
+		const result = await prepareMaestroSystemPromptCli(mockSession());
+
+		expect(result).toBe('history=[]');
+	});
+
+	it('includes the history file path when the file exists locally', async () => {
+		vi.mocked(getCliPrompt).mockResolvedValue('history=[{{AGENT_HISTORY_PATH}}]');
+		// Override the throw-by-default beforeEach with a no-op success.
+		vi.mocked(fs.accessSync).mockImplementation(() => undefined);
+
+		const result = await prepareMaestroSystemPromptCli(mockSession({ id: 'sess-1' }));
+
+		// Sanitized session id forms the filename
+		expect(result).toMatch(/history=\[.*sess-1\.json\]/);
+	});
+
+	it('skips the history file pointer for SSH sessions (path is local-only)', async () => {
+		vi.mocked(getCliPrompt).mockResolvedValue('history=[{{AGENT_HISTORY_PATH}}]');
+		vi.mocked(fs.accessSync).mockImplementation(() => undefined);
+
+		const result = await prepareMaestroSystemPromptCli(
+			mockSession({
+				sessionSshRemoteConfig: { enabled: true, remoteId: 'remote1' },
+			})
+		);
+
+		expect(result).toBe('history=[]');
+	});
+
+	it('tolerates a non-string conductor profile setting', async () => {
+		vi.mocked(getCliPrompt).mockResolvedValue('cond=[{{CONDUCTOR_PROFILE}}]');
+		// e.g. a malformed settings file with a non-string value
+		vi.mocked(readSettingValue).mockReturnValue({ accidentallyAnObject: true });
+
+		const result = await prepareMaestroSystemPromptCli(mockSession());
+
+		expect(result).toBe('cond=[]');
+	});
+});

--- a/src/cli/commands/send.ts
+++ b/src/cli/commands/send.ts
@@ -3,6 +3,7 @@
 
 import { spawnAgent, detectAgent, type AgentResult } from '../services/agent-spawner';
 import { resolveAgentId, getSessionById } from '../services/storage';
+import { prepareMaestroSystemPromptCli } from '../services/system-prompt';
 import { estimateContextUsage } from '../../main/parsers/usage-aggregator';
 import { getAgentDefinition } from '../../main/agents/definitions';
 import { withMaestroClient } from '../services/maestro-client';
@@ -12,6 +13,11 @@ interface SendOptions {
 	session?: string;
 	readOnly?: boolean;
 	tab?: boolean;
+	// Commander auto-negates `--no-system-prompt` into `systemPrompt: false`,
+	// defaulting to true when the flag is omitted. Bots calling
+	// `maestro-cli send` get the Maestro system context by default — parity
+	// with desktop spawn sites that all pass `appendSystemPrompt`.
+	systemPrompt?: boolean;
 }
 
 interface SendResponse {
@@ -114,6 +120,16 @@ export async function send(
 	// when multiple callers (e.g. Discord threads) send concurrently.
 	const agentSessionId = options.session;
 
+	// Build the Maestro system prompt unless the caller opted out with
+	// `--no-system-prompt`. Failure to build (template missing, fs error) is
+	// non-fatal: spawn proceeds without the prompt rather than failing the
+	// whole send, matching the renderer's `prepareMaestroSystemPrompt` which
+	// returns undefined on failure (`src/renderer/utils/spawnHelpers.ts:35`).
+	const includeSystemPrompt = options.systemPrompt !== false;
+	const appendSystemPrompt = includeSystemPrompt
+		? await prepareMaestroSystemPromptCli(agent)
+		: undefined;
+
 	// Spawn agent — spawnAgent handles --resume vs fresh session internally
 	const result = await spawnAgent(agent.toolType, agent.cwd, message, agentSessionId, {
 		readOnlyMode: options.readOnly,
@@ -122,6 +138,7 @@ export async function send(
 		customArgs: agent.customArgs,
 		customEnvVars: agent.customEnvVars,
 		sshRemoteConfig: agent.sessionSshRemoteConfig,
+		appendSystemPrompt,
 	});
 	const response = buildResponse(agentId, agent.name, result, agent.toolType);
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -150,6 +150,10 @@ program
 	.option('-s, --session <id>', 'Resume an existing agent session (for multi-turn conversations)')
 	.option('-r, --read-only', 'Run in read-only/plan mode (agent cannot modify files)')
 	.option('-t, --tab', 'Open/focus the session tab in Maestro desktop')
+	.option(
+		'--no-system-prompt',
+		'Skip the Maestro system prompt (agent identity, git branch, history path, conductor profile). Default is to include it for parity with the desktop app.'
+	)
 	.action(send);
 
 // Dispatch command - hand a prompt to the desktop and return tab/session ID.

--- a/src/cli/services/agent-spawner.ts
+++ b/src/cli/services/agent-spawner.ts
@@ -3,6 +3,8 @@
 
 import { spawn, SpawnOptions, ChildProcess } from 'child_process';
 import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import type { AgentSshRemoteConfig, ToolType, UsageStats } from '../../shared/types';
 import { createOutputParser } from '../../main/parsers/parser-factory';
 import { aggregateModelUsage } from '../../main/parsers/usage-aggregator';
@@ -42,8 +44,18 @@ function finalizeAgentStdin(child: ChildProcess, sshStdinScript?: string): void 
 
 type SpawnOverrides = Pick<
 	SpawnAgentOptions,
-	'customModel' | 'customEffort' | 'customArgs' | 'customEnvVars'
+	'customModel' | 'customEffort' | 'customArgs' | 'customEnvVars' | 'appendSystemPrompt'
 >;
+
+/**
+ * Maximum command-line length we'll accept before falling back to
+ * `--append-system-prompt-file <tmp>` on Windows. Matches the threshold logic
+ * in `src/main/ipc/handlers/process.ts` — Windows CreateProcess caps the
+ * cmdline at ~32K, so a large inline system prompt would silently truncate.
+ * SSH sessions are exempt: the command runs inside a shell script, not the OS
+ * cmdline. The 30s cleanup mirrors the desktop handler's safety window.
+ */
+const SYSTEM_PROMPT_TMPFILE_CLEANUP_MS = 30_000;
 
 /**
  * Resolve agent-level + session-level overrides and produce final args plus
@@ -105,6 +117,42 @@ function applyEnvLayers(
 	}
 	if (userEnvVars) Object.assign(env, userEnvVars);
 	if (readOnlyOverrides) Object.assign(env, readOnlyOverrides);
+}
+
+/**
+ * Build the args needed to deliver an append-system-prompt to a Claude-style
+ * agent. On Windows local execution the prompt is written to a temp file and
+ * passed via `--append-system-prompt-file` to dodge CreateProcess's ~32K
+ * cmdline limit; everywhere else (and on SSH, where the command runs inside a
+ * shell script) we pass the content inline via `--append-system-prompt`.
+ * Mirrors the equivalent branch in `src/main/ipc/handlers/process.ts`. The
+ * temp-file cleanup is fire-and-forget: scheduled 30s out so the agent has
+ * plenty of time to read it before deletion, regardless of whether the spawn
+ * succeeded.
+ */
+function buildAppendSystemPromptArgs(
+	content: string,
+	sessionTag: string,
+	isSshSession: boolean
+): string[] {
+	if (isWindows() && !isSshSession) {
+		const tempFile = path.join(os.tmpdir(), `maestro-sysprompt-${sessionTag}-${Date.now()}.txt`);
+		try {
+			fs.writeFileSync(tempFile, content, 'utf-8');
+		} catch {
+			// If we can't write the temp file, fall back to inline. The agent
+			// may truncate, but that's better than silently dropping the prompt.
+			return ['--append-system-prompt', content];
+		}
+		setTimeout(() => {
+			fs.promises.unlink(tempFile).catch(() => {
+				// Best-effort cleanup. ENOENT is fine; other errors are not
+				// actionable from CLI without a Sentry pipeline.
+			});
+		}, SYSTEM_PROMPT_TMPFILE_CLEANUP_MS);
+		return ['--append-system-prompt-file', tempFile];
+	}
+	return ['--append-system-prompt', content];
 }
 
 // Claude Code arguments for batch mode (stream-json format)
@@ -289,12 +337,29 @@ async function spawnClaudeAgent(
 
 	// Layer agent-level + session-level overrides (model, effort, customArgs)
 	// and extract the user-configured env vars (agent + session customEnvVars).
-	const { args: baseArgs, userCustomEnvVars } = resolveAgentOverrides(
+	const { args: resolvedArgs, userCustomEnvVars } = resolveAgentOverrides(
 		'claude-code',
 		def,
 		preOverrideArgs,
 		overrides
 	);
+
+	// Inject the Maestro system prompt via `--append-system-prompt(-file)`. The
+	// flag rides through both the local args and the SSH-wrapped args because
+	// `wrapSpawnWithSsh` rebuilds the remote command from `baseArgs` below.
+	// Claude Code re-reads this flag every turn (not persisted in the session
+	// transcript), so include it on resume too — matches desktop behavior at
+	// `src/main/ipc/handlers/process.ts:254`.
+	const baseArgs = overrides.appendSystemPrompt
+		? [
+				...resolvedArgs,
+				...buildAppendSystemPromptArgs(
+					overrides.appendSystemPrompt,
+					agentSessionId || 'fresh',
+					!!sshRemoteConfig?.enabled
+				),
+			]
+		: resolvedArgs;
 
 	// Build local env: defaults (shell wins) + batch-mode defaults (shell wins)
 	// + user env vars (override shell) + read-only overrides (always).
@@ -603,7 +668,7 @@ async function spawnJsonLineAgent(
 
 	// Layer agent-level + session-level overrides (model, effort, customArgs)
 	// and extract the user-configured env vars (agent + session customEnvVars).
-	const { args: baseArgs, userCustomEnvVars } = resolveAgentOverrides(
+	const { args: resolvedArgs, userCustomEnvVars } = resolveAgentOverrides(
 		toolType,
 		def,
 		preOverrideArgs,
@@ -620,6 +685,31 @@ async function spawnJsonLineAgent(
 		readOnlyMode ? def?.readOnlyEnvOverrides : undefined
 	);
 
+	// System prompt delivery for JSON-line agents:
+	//  - Agents declaring `supportsAppendSystemPrompt: true` get the dedicated
+	//    flag (no agent in this branch does today, but the gate future-proofs).
+	//  - Everyone else gets the prompt embedded in the user message on first
+	//    turn; on resume we skip — desktop relies on the prompt being already
+	//    captured in the agent's session transcript (see
+	//    `src/main/ipc/handlers/process.ts:300-312`).
+	const supportsNativeSystemPrompt = hasCapability(toolType, 'supportsAppendSystemPrompt');
+	const isResume = !!agentSessionId;
+	const baseArgs =
+		overrides.appendSystemPrompt && supportsNativeSystemPrompt
+			? [
+					...resolvedArgs,
+					...buildAppendSystemPromptArgs(
+						overrides.appendSystemPrompt,
+						agentSessionId || 'fresh',
+						!!sshRemoteConfig?.enabled
+					),
+				]
+			: resolvedArgs;
+	const effectivePrompt =
+		overrides.appendSystemPrompt && !supportsNativeSystemPrompt && !isResume
+			? `${overrides.appendSystemPrompt}\n\n---\n\n# User Request\n\n${prompt}`
+			: prompt;
+
 	const noPromptSeparator = !!def?.noPromptSeparator;
 
 	// Local prompt embedding mirrors wrapSpawnWithSsh's default behavior.
@@ -628,10 +718,10 @@ async function spawnJsonLineAgent(
 	// via their flag instead of the bare '--' separator (which Copilot CLI
 	// doesn't accept as a positional prompt).
 	const localArgs = def?.promptArgs
-		? [...baseArgs, ...def.promptArgs(prompt)]
+		? [...baseArgs, ...def.promptArgs(effectivePrompt)]
 		: noPromptSeparator
-			? [...baseArgs, prompt]
-			: [...baseArgs, '--', prompt];
+			? [...baseArgs, effectivePrompt]
+			: [...baseArgs, '--', effectivePrompt];
 
 	const agentCommand = getAgentCommand(toolType);
 
@@ -642,12 +732,16 @@ async function spawnJsonLineAgent(
 	let sshStdinScript: string | undefined;
 
 	if (sshRemoteConfig?.enabled) {
+		// Pass `effectivePrompt` (not the raw `prompt`) so the embed-in-turn-1
+		// fallback for agents without native --append-system-prompt support
+		// also reaches the SSH remote. baseArgs already carries the native
+		// flag for agents that support it.
 		const wrapped = await maybeWrapSpawnWithSsh(
 			{
 				command: agentCommand,
 				args: baseArgs,
 				cwd,
-				prompt,
+				prompt: effectivePrompt,
 				customEnvVars: buildSshEnvForRemote(def, readOnlyMode, userCustomEnvVars),
 				agentBinaryName: def?.binaryName,
 				noPromptSeparator,
@@ -783,6 +877,15 @@ export interface SpawnAgentOptions {
 	 * desktop app when sessions are configured for SSH remote execution.
 	 */
 	sshRemoteConfig?: AgentSshRemoteConfig;
+	/**
+	 * Maestro system prompt to deliver alongside the user message. Mirrors the
+	 * desktop `process:spawn` handler's `appendSystemPrompt` field. For agents
+	 * with `supportsAppendSystemPrompt: true` (Claude Code today) this is
+	 * passed via `--append-system-prompt`; otherwise it's embedded into the
+	 * first user turn (skipped on resume so it's not repeated). Callers should
+	 * build this via `prepareMaestroSystemPromptCli()` in `./system-prompt.ts`.
+	 */
+	appendSystemPrompt?: string;
 }
 
 /**
@@ -802,6 +905,7 @@ export async function spawnAgent(
 		customEffort: options?.customEffort,
 		customArgs: options?.customArgs,
 		customEnvVars: options?.customEnvVars,
+		appendSystemPrompt: options?.appendSystemPrompt,
 	};
 
 	if (toolType === 'claude-code') {

--- a/src/cli/services/agent-spawner.ts
+++ b/src/cli/services/agent-spawner.ts
@@ -12,6 +12,7 @@ import { getAgentDefinition } from '../../main/agents/definitions';
 import { hasCapability } from '../../main/agents/capabilities';
 import { getAgentCustomPath, readAgentConfig, readSshRemotes } from './storage';
 import { generateUUID } from '../../shared/uuid';
+import { sanitizeSessionId } from '../../shared/history';
 import { buildExpandedPath, buildExpandedEnv } from '../../shared/pathUtils';
 import { isWindows, getWhichCommand } from '../../shared/platformDetection';
 import { applyAgentConfigOverrides } from '../../main/utils/agent-args';
@@ -136,20 +137,44 @@ function buildAppendSystemPromptArgs(
 	isSshSession: boolean
 ): string[] {
 	if (isWindows() && !isSshSession) {
-		const tempFile = path.join(os.tmpdir(), `maestro-sysprompt-${sessionTag}-${Date.now()}.txt`);
+		// Sanitize the session tag before interpolating into a tmp path.
+		// `path.join('/tmp', '../etc/passwd')` normalizes upward, escaping
+		// `os.tmpdir()`, so a hostile session id could redirect the write.
+		// `sanitizeSessionId` (shared with history file naming) collapses
+		// anything outside [A-Za-z0-9_-] to `_`.
+		const safeTag = sanitizeSessionId(sessionTag) || 'session';
+		const tempFile = path.join(os.tmpdir(), `maestro-sysprompt-${safeTag}-${Date.now()}.txt`);
 		try {
 			fs.writeFileSync(tempFile, content, 'utf-8');
-		} catch {
+		} catch (writeErr) {
 			// If we can't write the temp file, fall back to inline. The agent
-			// may truncate, but that's better than silently dropping the prompt.
+			// may truncate on Windows cmdline limits, but that's better than
+			// silently dropping the prompt. Log so the user can spot the
+			// downgrade — CLI has no Sentry pipeline, so stderr is the visibility
+			// surface available here.
+			const reason = writeErr instanceof Error ? writeErr.message : String(writeErr);
+			console.error(
+				`[maestro-cli] system prompt tempfile write failed (${reason}); falling back to inline --append-system-prompt`
+			);
 			return ['--append-system-prompt', content];
 		}
-		setTimeout(() => {
-			fs.promises.unlink(tempFile).catch(() => {
-				// Best-effort cleanup. ENOENT is fine; other errors are not
-				// actionable from CLI without a Sentry pipeline.
+		// `.unref()` so the 30s cleanup timer doesn't keep the CLI alive after
+		// the agent already exited — without it, `maestro-cli send` would
+		// appear to hang on Windows until the timer fires.
+		const cleanupTimer = setTimeout(() => {
+			fs.promises.unlink(tempFile).catch((unlinkErr: NodeJS.ErrnoException) => {
+				// ENOENT means the file is already gone — expected if the OS
+				// cleaned tmpdir or a parallel run won the race. Other errors
+				// indicate a real problem (permissions, FS issue): surface them
+				// on stderr so the user has a breadcrumb.
+				if (unlinkErr.code !== 'ENOENT') {
+					console.error(
+						`[maestro-cli] system prompt tempfile cleanup failed (${unlinkErr.message}) at ${tempFile}`
+					);
+				}
 			});
 		}, SYSTEM_PROMPT_TMPFILE_CLEANUP_MS);
+		cleanupTimer.unref?.();
 		return ['--append-system-prompt-file', tempFile];
 	}
 	return ['--append-system-prompt', content];

--- a/src/cli/services/batch-processor.ts
+++ b/src/cli/services/batch-processor.ts
@@ -1,7 +1,6 @@
 // Batch processor service for CLI
 // Executes playbooks and yields JSONL events
 
-import { execFileSync } from 'child_process';
 import type { Playbook, SessionInfo, UsageStats, HistoryEntry } from '../../shared/types';
 import type { JsonlEvent } from '../output/jsonl';
 import {
@@ -20,22 +19,8 @@ import { generateUUID } from '../../shared/uuid';
 import { formatElapsedTime } from '../../shared/formatters';
 import { PROMPT_IDS } from '../../shared/promptDefinitions';
 import { getCliPrompt } from './prompt-loader';
-
-/**
- * Get the current git branch for a directory
- */
-function getGitBranch(cwd: string): string | undefined {
-	try {
-		const branch = execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
-			cwd,
-			encoding: 'utf-8',
-			stdio: ['pipe', 'pipe', 'pipe'],
-		}).trim();
-		return branch || undefined;
-	} catch {
-		return undefined;
-	}
-}
+import { getGitBranch, isGitRepo } from './git-utils';
+import { prepareMaestroSystemPromptCli } from './system-prompt';
 
 /**
  * Detect the `<!-- maestro:halt -->` early-exit marker in a document.
@@ -58,22 +43,6 @@ export function detectHaltMarker(content: string): { halted: boolean; reason?: s
 	if (!match) return { halted: false };
 	const reason = match[1]?.trim();
 	return { halted: true, reason: reason || undefined };
-}
-
-/**
- * Check if a directory is a git repository
- */
-function isGitRepo(cwd: string): boolean {
-	try {
-		execFileSync('git', ['rev-parse', '--is-inside-work-tree'], {
-			cwd,
-			encoding: 'utf-8',
-			stdio: ['pipe', 'pipe', 'pipe'],
-		});
-		return true;
-	} catch {
-		return false;
-	}
 }
 
 /**
@@ -266,6 +235,15 @@ export async function* runPlaybook(
 			};
 			return;
 		}
+
+		// Build the Maestro system prompt once per playbook run. It's identical
+		// for every task in the loop (session/branch/conductor don't change
+		// between tasks), so caching avoids repeating the prompt-load + git
+		// branch probe per task. Mirrors the desktop Auto Run path which calls
+		// `prepareMaestroSystemPrompt` per spawn but reads from a hot in-memory
+		// cache (`useAgentExecution.ts:226`). Failure is non-fatal: tasks run
+		// without the system prompt rather than aborting the playbook.
+		const playbookSystemPrompt = await prepareMaestroSystemPromptCli(session);
 
 		// Track totals
 		let totalCompletedTasks = 0;
@@ -492,13 +470,20 @@ export async function* runPlaybook(
 						};
 					}
 
-					// Spawn agent with combined prompt + document
+					// Spawn agent with combined prompt + document. The Maestro
+					// system prompt is delivered as an out-of-band flag (or
+					// embedded in turn 1 for agents lacking native support) so
+					// the agent sees the same Maestro context as a desktop Auto
+					// Run task. Synopsis spawn below intentionally omits this
+					// — it's a resume into the same agent that already has the
+					// prompt and re-sending would waste tokens.
 					const result = await spawnAgent(session.toolType, session.cwd, finalPrompt, undefined, {
 						customModel: session.customModel,
 						customEffort: session.customEffort,
 						customArgs: session.customArgs,
 						customEnvVars: session.customEnvVars,
 						sshRemoteConfig: session.sessionSshRemoteConfig,
+						appendSystemPrompt: playbookSystemPrompt,
 					});
 
 					const elapsedMs = Date.now() - taskStartTime;

--- a/src/cli/services/git-utils.ts
+++ b/src/cli/services/git-utils.ts
@@ -1,0 +1,31 @@
+// Small git helpers shared by the CLI. Mirrors the read-only subset of
+// `src/main/ipc/handlers/git.ts` and `src/renderer/services/git.ts` that the
+// CLI needs without pulling in Electron/IPC machinery.
+
+import { execFileSync } from 'child_process';
+
+export function getGitBranch(cwd: string): string | undefined {
+	try {
+		const branch = execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
+			cwd,
+			encoding: 'utf-8',
+			stdio: ['pipe', 'pipe', 'pipe'],
+		}).trim();
+		return branch || undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+export function isGitRepo(cwd: string): boolean {
+	try {
+		execFileSync('git', ['rev-parse', '--is-inside-work-tree'], {
+			cwd,
+			encoding: 'utf-8',
+			stdio: ['pipe', 'pipe', 'pipe'],
+		});
+		return true;
+	} catch {
+		return false;
+	}
+}

--- a/src/cli/services/prompt-loader.ts
+++ b/src/cli/services/prompt-loader.ts
@@ -4,11 +4,83 @@
 // honor identical precedence (matches the Electron prompt-manager).
 
 import fs from 'fs/promises';
+import fsSync from 'fs';
 import path from 'path';
-import { getPromptFilename } from '../../shared/promptDefinitions';
+import { CORE_PROMPTS, getPromptFilename } from '../../shared/promptDefinitions';
 import { getConfigDirectory } from './storage';
 
 const cliPromptCache = new Map<string, string>();
+let bundledPromptsDir: string | null = null;
+
+const REF_PATTERN = /\{\{REF:([a-zA-Z0-9_-]+)\}\}/g;
+
+function getBundledPromptCandidates(filename: string): string[] {
+	// The CLI runs in three contexts: dev (ts-node from src), packaged Electron
+	// (process.resourcesPath), and standalone bundled CLI (Resources/maestro-cli.js).
+	const projectRoot = path.resolve(__dirname, '..', '..', '..');
+	const candidates = [path.join(projectRoot, 'src', 'prompts', filename)];
+
+	if (typeof process !== 'undefined' && (process as { resourcesPath?: string }).resourcesPath) {
+		candidates.push(
+			path.join((process as { resourcesPath?: string }).resourcesPath!, 'prompts', 'core', filename)
+		);
+	}
+
+	candidates.push(
+		path.join(path.dirname(process.argv[1] || __dirname), 'prompts', 'core', filename)
+	);
+	candidates.push(path.join(__dirname, '..', 'prompts', 'core', filename));
+
+	return candidates;
+}
+
+/**
+ * Resolve the on-disk directory that holds bundled prompt files. Probes the
+ * same candidate chain as getCliPrompt() using a known file (the first entry
+ * in CORE_PROMPTS) and remembers whichever location exists. Used by
+ * resolveRefs() so `{{REF:name}}` expands to an absolute path the agent can
+ * read with its file tools, mirroring the Electron prompt-manager.
+ */
+function getBundledPromptsDir(): string | null {
+	if (bundledPromptsDir) return bundledPromptsDir;
+
+	const probeFilename = CORE_PROMPTS[0]?.filename;
+	if (!probeFilename) return null;
+
+	for (const candidate of getBundledPromptCandidates(probeFilename)) {
+		try {
+			fsSync.accessSync(candidate, fsSync.constants.R_OK);
+			bundledPromptsDir = path.dirname(candidate);
+			return bundledPromptsDir;
+		} catch {
+			// Try next candidate
+		}
+	}
+	return null;
+}
+
+/**
+ * Expand `{{REF:name}}` directives to the absolute on-disk path of the bundled
+ * `.md` for that prompt id. Matches the renderer-facing behavior in
+ * `src/main/prompt-manager.ts:resolveRefs` so agents launched via the CLI see
+ * the same paths Settings → Maestro Prompts hands to desktop-spawned agents.
+ * Unresolvable refs (unknown id or no bundled dir found) are left as-is so the
+ * agent at least has a chance to surface the problem rather than seeing an
+ * empty path.
+ */
+function resolveRefs(content: string): string {
+	if (!REF_PATTERN.test(content)) return content;
+	REF_PATTERN.lastIndex = 0;
+
+	const promptsDir = getBundledPromptsDir();
+	if (!promptsDir) return content;
+
+	return content.replace(REF_PATTERN, (match, name: string) => {
+		const def = CORE_PROMPTS.find((p) => p.id === name);
+		if (!def) return match;
+		return path.resolve(promptsDir, def.filename);
+	});
+}
 
 async function getCustomizedPrompt(id: string): Promise<string | null> {
 	try {
@@ -32,33 +104,20 @@ export async function getCliPrompt(id: string): Promise<string> {
 
 	const customized = await getCustomizedPrompt(id);
 	if (customized !== null) {
-		cliPromptCache.set(id, customized);
-		return customized;
+		const resolved = resolveRefs(customized);
+		cliPromptCache.set(id, resolved);
+		return resolved;
 	}
 
 	const filename = getPromptFilename(id);
-
-	// The CLI runs in three contexts: dev (ts-node from src), packaged Electron
-	// (process.resourcesPath), and standalone bundled CLI (Resources/maestro-cli.js).
-	const projectRoot = path.resolve(__dirname, '..', '..', '..');
-	const candidates = [path.join(projectRoot, 'src', 'prompts', filename)];
-
-	if (typeof process !== 'undefined' && (process as { resourcesPath?: string }).resourcesPath) {
-		candidates.push(
-			path.join((process as { resourcesPath?: string }).resourcesPath!, 'prompts', 'core', filename)
-		);
-	}
-
-	candidates.push(
-		path.join(path.dirname(process.argv[1] || __dirname), 'prompts', 'core', filename)
-	);
-	candidates.push(path.join(__dirname, '..', 'prompts', 'core', filename));
+	const candidates = getBundledPromptCandidates(filename);
 
 	for (const candidate of candidates) {
 		try {
 			const content = await fs.readFile(candidate, 'utf-8');
-			cliPromptCache.set(id, content);
-			return content;
+			const resolved = resolveRefs(content);
+			cliPromptCache.set(id, resolved);
+			return resolved;
 		} catch {
 			// Try next candidate
 		}
@@ -67,4 +126,12 @@ export async function getCliPrompt(id: string): Promise<string> {
 	throw new Error(
 		`Failed to load prompt "${id}" (${filename}). Searched: ${candidates.join(', ')}`
 	);
+}
+
+/**
+ * Test-only: reset cached state between tests.
+ */
+export function _resetCliPromptCacheForTests(): void {
+	cliPromptCache.clear();
+	bundledPromptsDir = null;
 }

--- a/src/cli/services/prompt-loader.ts
+++ b/src/cli/services/prompt-loader.ts
@@ -12,8 +12,6 @@ import { getConfigDirectory } from './storage';
 const cliPromptCache = new Map<string, string>();
 let bundledPromptsDir: string | null = null;
 
-const REF_PATTERN = /\{\{REF:([a-zA-Z0-9_-]+)\}\}/g;
-
 function getBundledPromptCandidates(filename: string): string[] {
 	// The CLI runs in three contexts: dev (ts-node from src), packaged Electron
 	// (process.resourcesPath), and standalone bundled CLI (Resources/maestro-cli.js).
@@ -69,13 +67,17 @@ function getBundledPromptsDir(): string | null {
  * empty path.
  */
 function resolveRefs(content: string): string {
-	if (!REF_PATTERN.test(content)) return content;
-	REF_PATTERN.lastIndex = 0;
+	// Local /g regex — using a module-level singleton would force manual
+	// `lastIndex = 0` resets between the `.test()` probe and `.replace()` and
+	// silently skip later matches if any helper in between also called
+	// `.test()`. A fresh regex per call has zero shared state.
+	const refPattern = /\{\{REF:([a-zA-Z0-9_-]+)\}\}/g;
+	if (!content.includes('{{REF:')) return content;
 
 	const promptsDir = getBundledPromptsDir();
 	if (!promptsDir) return content;
 
-	return content.replace(REF_PATTERN, (match, name: string) => {
+	return content.replace(refPattern, (match, name: string) => {
 		const def = CORE_PROMPTS.find((p) => p.id === name);
 		if (!def) return match;
 		return path.resolve(promptsDir, def.filename);

--- a/src/cli/services/system-prompt.ts
+++ b/src/cli/services/system-prompt.ts
@@ -54,8 +54,18 @@ export async function prepareMaestroSystemPromptCli(
 	let template: string;
 	try {
 		template = await getCliPrompt(PROMPT_IDS.MAESTRO_SYSTEM_PROMPT);
-	} catch {
-		return undefined;
+	} catch (err) {
+		// `getCliPrompt` throws a known "Failed to load prompt …" Error when no
+		// candidate file is readable. That's the only failure mode we want to
+		// treat as non-fatal — anything else (TypeError, parse bug, etc.) is a
+		// real defect and should bubble up to the caller's error handler rather
+		// than masquerade as "prompt missing". Log the swallow so the user has
+		// a breadcrumb when their relay bot suddenly loses Maestro context.
+		if (err instanceof Error && err.message.startsWith('Failed to load prompt')) {
+			console.error(`[maestro-cli] ${err.message}; spawning without Maestro system prompt`);
+			return undefined;
+		}
+		throw err;
 	}
 
 	const sessionIsGitRepo = isGitRepo(session.cwd);

--- a/src/cli/services/system-prompt.ts
+++ b/src/cli/services/system-prompt.ts
@@ -1,0 +1,88 @@
+// Build the Maestro system prompt for CLI-spawned agents.
+//
+// Mirrors `src/renderer/utils/spawnHelpers.ts:prepareMaestroSystemPrompt` so a
+// bot driving Maestro through `maestro-cli send` or Auto Run sees the same
+// Maestro context — agent identity, git branch, history-file pointer,
+// conductor profile, prompt customizations — that a desktop-spawned agent
+// receives. Without this, CLI-spawned agents are missing the entire "what is
+// Maestro and what can I do with it" preamble.
+
+import path from 'path';
+import fs from 'fs';
+import type { SessionInfo } from '../../shared/types';
+import { substituteTemplateVariables } from '../../shared/templateVariables';
+import { PROMPT_IDS } from '../../shared/promptDefinitions';
+import { sanitizeSessionId } from '../../shared/history';
+import { getCliPrompt } from './prompt-loader';
+import { getConfigDirectory, readSettingValue } from './storage';
+import { getGitBranch, isGitRepo } from './git-utils';
+
+/**
+ * Resolve the absolute path of an existing per-session history file, mirroring
+ * `HistoryManager.getHistoryFilePath` in `src/main/history-manager.ts`. Returns
+ * undefined when the file does not yet exist (e.g. a brand-new session) so the
+ * `{{AGENT_HISTORY_PATH}}` placeholder renders as an empty string — matching
+ * the renderer-side helper, which also returns undefined in that case.
+ */
+function getHistoryFilePath(sessionId: string): string | undefined {
+	const filePath = path.join(
+		getConfigDirectory(),
+		'history',
+		`${sanitizeSessionId(sessionId)}.json`
+	);
+	try {
+		fs.accessSync(filePath, fs.constants.R_OK);
+		return filePath;
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * Build the Maestro system prompt to pass via `appendSystemPrompt` when
+ * spawning a CLI agent. Returns undefined if the prompt template fails to
+ * load (caller should treat that as "spawn without the system prompt" rather
+ * than aborting the whole send).
+ *
+ * Loads via `getCliPrompt()` so user customizations from Settings → Maestro
+ * Prompts win over the bundled default, and `{{REF:name}}` directives are
+ * expanded to absolute on-disk paths the agent can read with its file tools.
+ */
+export async function prepareMaestroSystemPromptCli(
+	session: SessionInfo
+): Promise<string | undefined> {
+	let template: string;
+	try {
+		template = await getCliPrompt(PROMPT_IDS.MAESTRO_SYSTEM_PROMPT);
+	} catch {
+		return undefined;
+	}
+
+	const sessionIsGitRepo = isGitRepo(session.cwd);
+	const gitBranch = sessionIsGitRepo ? getGitBranch(session.cwd) : undefined;
+
+	// Skip the history-file pointer for SSH sessions — the path is local to the
+	// Maestro app's machine, not the remote where the agent will actually run.
+	const isSsh = !!session.sessionSshRemoteConfig?.enabled;
+	const historyFilePath = isSsh ? undefined : getHistoryFilePath(session.id);
+
+	const conductorProfileSetting = readSettingValue('conductorProfile');
+	const conductorProfile =
+		typeof conductorProfileSetting === 'string' ? conductorProfileSetting : undefined;
+
+	return substituteTemplateVariables(template, {
+		session: {
+			id: session.id,
+			name: session.name,
+			toolType: session.toolType,
+			cwd: session.cwd,
+			projectRoot: session.projectRoot,
+			autoRunFolderPath: session.autoRunFolderPath,
+			isGitRepo: sessionIsGitRepo,
+		},
+		gitBranch,
+		groupId: session.groupId,
+		historyFilePath,
+		conductorProfile,
+	});
+}


### PR DESCRIPTION
## Summary

- `maestro-cli send` and Auto Run task spawns now pass the Maestro system prompt (`maestro-system-prompt`) via `--append-system-prompt`, matching the desktop spawn sites in `src/renderer/utils/spawnHelpers.ts`. Relay bots driving Maestro through the CLI finally see agent identity, git branch, history-file pointer, conductor profile, and the `{{REF:_interface-primitives}}`/`_maestro-cli`/etc. pointers resolved to absolute on-disk paths.
- Customizations made in Settings → Maestro Prompts already flowed through the CLI loader; this PR just makes them reach the actual agent at spawn time. Auto Run synopsis spawns stay lean (no system prompt) to match the desktop's `spawnBackgroundSynopsis`.
- Opt-out via `maestro-cli send --no-system-prompt` for callers that want a lean prompt without Maestro context.

## What changed

- **`src/cli/services/prompt-loader.ts`** — new `resolveRefs()` mirrors `src/main/prompt-manager.ts:resolveRefs`, expanding `{{REF:name}}` to absolute paths so the agent's file tools can read the bundled includes.
- **`src/cli/services/system-prompt.ts`** (new) — `prepareMaestroSystemPromptCli(session)` mirrors the renderer's `prepareMaestroSystemPrompt`: loads the customization-aware template, resolves git branch / history-file path (skipped on SSH) / conductor profile, substitutes template variables. Returns `undefined` non-fatally when prep fails so spawns proceed without the prompt rather than aborting.
- **`src/cli/services/git-utils.ts`** (new) — extracted `getGitBranch` / `isGitRepo` from `batch-processor.ts` so both `system-prompt.ts` and `batch-processor.ts` share the same helpers without a circular import.
- **`src/cli/services/agent-spawner.ts`** — added `appendSystemPrompt` to `SpawnAgentOptions`; wired into `spawnClaudeAgent` (always re-sent on resume, since Claude reads the flag every turn) and `spawnJsonLineAgent` (capability-gated on `supportsAppendSystemPrompt`; agents that lack native support embed the prompt in turn 1 and skip on resume, matching `src/main/ipc/handlers/process.ts:300-312`). Windows-local execution falls back to `--append-system-prompt-file` with a 30s temp-file cleanup to dodge the CreateProcess cmdline limit; SSH stays inline because the command runs inside a shell script.
- **`src/cli/commands/send.ts`** + **`src/cli/index.ts`** — builds the system prompt by default; new `--no-system-prompt` Commander flag (`systemPrompt: false`) opts out.
- **`src/cli/services/batch-processor.ts`** — system prompt built once per playbook run (not per task — git + prompt-load overhead) and injected into the task spawn. Synopsis resume intentionally omits it.

## Test plan

- [x] `npx tsc -p tsconfig.cli.json --noEmit` clean
- [x] `npx tsc -p tsconfig.main.json --noEmit` clean
- [x] `npx tsc -p tsconfig.lint.json` clean
- [x] `npx prettier --check` clean on touched files
- [x] `npx eslint` clean on touched source files
- [x] Full CLI test suite (`src/__tests__/cli`) passes: 783/783
- [x] New tests in `src/__tests__/cli/services/prompt-loader.test.ts` (6) cover customization precedence, bundled fallback, caching, REF resolution success/unknown-id passthrough, no-candidates failure
- [x] New tests in `src/__tests__/cli/services/system-prompt.test.ts` (7) cover template substitution, non-fatal failure, non-git skip, history-file existence/SSH skip, malformed `conductorProfile`
- [x] New tests in `agent-spawner.test.ts` (8) cover Claude inline flag (non-Windows), Windows-local temp-file path, Windows+SSH inline override, resume re-injection, Codex embed-in-turn-1, Codex resume skip, regression tests confirming flag absence when not requested
- [x] New tests in `send.test.ts` (4) cover default injection, `--no-system-prompt` skip, resume parity, non-fatal `undefined` handling
- [x] New tests in `batch-processor.test.ts` (3) cover task-spawn injection, synopsis omission, single-build-per-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI send now defaults to including a Maestro system prompt and offers a flag to skip it (--no-system-prompt). System prompts are prepared once per playbook run and injected into agent execution; playbook execution stops on a detected halt marker.
  * Prompt loading now supports reference expansion and in-memory caching; prompts may include repo/branch and history info when available.

* **Tests**
  * Added extensive tests covering system-prompt building/injection, prompt loading, and playbook behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RunMaestro/Maestro/pull/1003)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->