### PR TITLE
fix(files-pane): wire up git change indicators (#611)

### DIFF
--- a/src/__tests__/renderer/components/FileExplorerPanel.test.tsx
+++ b/src/__tests__/renderer/components/FileExplorerPanel.test.tsx
@@ -1261,8 +1261,10 @@ describe('FileExplorerPanel', () => {
 		const findIndicator = (row: HTMLElement | undefined) =>
 			row?.querySelector('[data-testid="git-change-indicator"]') as HTMLElement | undefined;
 
-		it('renders a change indicator for modified files (porcelain " M")', () => {
-			mockFileChanges = [{ path: 'package.json', status: ' M' }];
+		it('renders a change indicator for modified files (trimmed porcelain "M")', () => {
+			// `useGitStatusPolling` stores trimmed status codes, so production
+			// values look like `"M"` rather than `" M"`. We match that here.
+			mockFileChanges = [{ path: 'package.json', status: 'M' }];
 			const { container } = render(<FileExplorerPanel {...defaultProps} />);
 
 			const indicator = findIndicator(findRowFor(container, 'package.json'));
@@ -1280,8 +1282,8 @@ describe('FileExplorerPanel', () => {
 			expect(indicator).toHaveStyle({ backgroundColor: mockTheme.colors.success });
 		});
 
-		it('renders a change indicator for deleted files (porcelain " D")', () => {
-			mockFileChanges = [{ path: 'package.json', status: ' D' }];
+		it('renders a change indicator for deleted files (trimmed porcelain "D")', () => {
+			mockFileChanges = [{ path: 'package.json', status: 'D' }];
 			const { container } = render(<FileExplorerPanel {...defaultProps} />);
 
 			const indicator = findIndicator(findRowFor(container, 'package.json'));
@@ -1292,7 +1294,7 @@ describe('FileExplorerPanel', () => {
 		it('matches the full relative path, not a substring of the file name (#611)', () => {
 			// File "package.json" should NOT light up when a different file under
 			// src/ happens to contain "package" in its full path.
-			mockFileChanges = [{ path: 'src/package-loader.ts', status: ' M' }];
+			mockFileChanges = [{ path: 'src/package-loader.ts', status: 'M' }];
 			const { container } = render(<FileExplorerPanel {...defaultProps} />);
 
 			expect(findIndicator(findRowFor(container, 'package.json'))).toBeNull();
@@ -1304,7 +1306,7 @@ describe('FileExplorerPanel', () => {
 			const expandedSession = createMockSession({
 				fileExplorerExpanded: ['src', 'src/utils'],
 			});
-			mockFileChanges = [{ path: 'src/utils/helpers.ts', status: ' M' }];
+			mockFileChanges = [{ path: 'src/utils/helpers.ts', status: 'M' }];
 			const { container } = render(
 				<FileExplorerPanel {...defaultProps} session={expandedSession} />
 			);
@@ -1321,7 +1323,7 @@ describe('FileExplorerPanel', () => {
 
 		it('does not tint the file icon (icons stay consistent regardless of state)', () => {
 			// Per #611 follow-up, the icon should not change for added/modified/deleted.
-			mockFileChanges = [{ path: 'package.json', status: ' M' }];
+			mockFileChanges = [{ path: 'package.json', status: 'M' }];
 			const { container } = render(<FileExplorerPanel {...defaultProps} />);
 
 			// The mocked icon distinguishes types via test ids ('added-icon',
@@ -1333,7 +1335,7 @@ describe('FileExplorerPanel', () => {
 		});
 
 		it('applies bold font to changed file names', () => {
-			mockFileChanges = [{ path: 'package.json', status: ' M' }];
+			mockFileChanges = [{ path: 'package.json', status: 'M' }];
 			const { container } = render(<FileExplorerPanel {...defaultProps} />);
 
 			const boldItems = container.querySelectorAll('.font-medium');
@@ -1341,11 +1343,33 @@ describe('FileExplorerPanel', () => {
 		});
 
 		it('applies textMain color to changed file rows', () => {
-			mockFileChanges = [{ path: 'package.json', status: ' M' }];
+			mockFileChanges = [{ path: 'package.json', status: 'M' }];
 			const { container } = render(<FileExplorerPanel {...defaultProps} />);
 
 			const row = findRowFor(container, 'package.json');
 			expect(row).toHaveStyle({ color: mockTheme.colors.textMain });
+		});
+
+		it('uses the colorblind-safe palette when colorBlindMode is enabled', async () => {
+			const { useSettingsStore } = await import('../../../renderer/stores/settingsStore');
+			useSettingsStore.setState({ rightPanelWidth: 500, colorBlindMode: true });
+
+			mockFileChanges = [
+				{ path: 'package.json', status: 'M' },
+				{ path: 'README.md', status: '??' },
+			];
+			const { container } = render(<FileExplorerPanel {...defaultProps} />);
+
+			// Modified → orange (#EE7733), Added → teal (#009988)
+			expect(findIndicator(findRowFor(container, 'package.json'))).toHaveStyle({
+				backgroundColor: '#EE7733',
+			});
+			expect(findIndicator(findRowFor(container, 'README.md'))).toHaveStyle({
+				backgroundColor: '#009988',
+			});
+
+			// Restore default for subsequent tests.
+			useSettingsStore.setState({ colorBlindMode: false });
 		});
 	});
 

--- a/src/__tests__/renderer/components/FileExplorerPanel.test.tsx
+++ b/src/__tests__/renderer/components/FileExplorerPanel.test.tsx
@@ -224,6 +224,27 @@ vi.mock('../../../renderer/hooks/ui/useClickOutside', () => ({
 	},
 }));
 
+// Mock GitStatusContext so we can inject fileChanges for the active session
+// (FileExplorerPanel reads from useGitDetail for #611 git change indicators).
+let mockFileChanges: { path: string; status: string }[] = [];
+vi.mock('../../../renderer/contexts/GitStatusContext', () => ({
+	useGitDetail: () => ({
+		getFileDetails: () => ({
+			fileChanges: mockFileChanges.map((c) => ({
+				path: c.path,
+				status: c.status,
+				additions: 0,
+				deletions: 0,
+				modified: c.status.includes('M'),
+			})),
+			totalAdditions: 0,
+			totalDeletions: 0,
+			modifiedCount: 0,
+		}),
+		refreshGitStatus: vi.fn().mockResolvedValue(undefined),
+	}),
+}));
+
 // Create mock theme
 
 const createMockSession = (overrides: Partial<Session> = {}): Session =>
@@ -276,6 +297,7 @@ describe('FileExplorerPanel', () => {
 	beforeEach(async () => {
 		vi.clearAllMocks();
 		vi.useFakeTimers();
+		mockFileChanges = [];
 
 		// Force non-compact toolbar so RefreshCw icon renders. Default
 		// rightPanelWidth (384) is below RIGHT_PANEL_COMPACT_THRESHOLD (420),
@@ -1232,84 +1254,98 @@ describe('FileExplorerPanel', () => {
 	});
 
 	describe('Changed Files Display', () => {
-		it('displays change badge for modified files', () => {
-			const session = createMockSession({
-				changedFiles: [{ path: '/Users/test/project/package.json', type: 'modified' }],
-			});
-			render(<FileExplorerPanel {...defaultProps} session={session} />);
+		const findRowFor = (container: HTMLElement, label: string) =>
+			Array.from(container.querySelectorAll('[data-file-index]')).find((el) =>
+				el.textContent?.includes(label)
+			) as HTMLElement | undefined;
+		const findIndicator = (row: HTMLElement | undefined) =>
+			row?.querySelector('[data-testid="git-change-indicator"]') as HTMLElement | undefined;
 
-			expect(screen.getByText('modified')).toBeInTheDocument();
+		it('renders a change indicator for modified files (porcelain " M")', () => {
+			mockFileChanges = [{ path: 'package.json', status: ' M' }];
+			const { container } = render(<FileExplorerPanel {...defaultProps} />);
+
+			const indicator = findIndicator(findRowFor(container, 'package.json'));
+			expect(indicator).toBeDefined();
+			expect(indicator).toHaveAttribute('data-change-type', 'modified');
+			expect(indicator).toHaveStyle({ backgroundColor: mockTheme.colors.warning });
 		});
 
-		it('displays change badge for added files', () => {
-			const session = createMockSession({
-				changedFiles: [{ path: '/Users/test/project/package.json', type: 'added' }],
-			});
-			render(<FileExplorerPanel {...defaultProps} session={session} />);
+		it('renders a change indicator for added files (untracked "??")', () => {
+			mockFileChanges = [{ path: 'package.json', status: '??' }];
+			const { container } = render(<FileExplorerPanel {...defaultProps} />);
 
-			expect(screen.getByText('added')).toBeInTheDocument();
+			const indicator = findIndicator(findRowFor(container, 'package.json'));
+			expect(indicator).toHaveAttribute('data-change-type', 'added');
+			expect(indicator).toHaveStyle({ backgroundColor: mockTheme.colors.success });
 		});
 
-		it('displays change badge for deleted files', () => {
-			const session = createMockSession({
-				changedFiles: [{ path: '/Users/test/project/package.json', type: 'deleted' }],
-			});
-			render(<FileExplorerPanel {...defaultProps} session={session} />);
+		it('renders a change indicator for deleted files (porcelain " D")', () => {
+			mockFileChanges = [{ path: 'package.json', status: ' D' }];
+			const { container } = render(<FileExplorerPanel {...defaultProps} />);
 
-			expect(screen.getByText('deleted')).toBeInTheDocument();
+			const indicator = findIndicator(findRowFor(container, 'package.json'));
+			expect(indicator).toHaveAttribute('data-change-type', 'deleted');
+			expect(indicator).toHaveStyle({ backgroundColor: mockTheme.colors.error });
 		});
 
-		it('applies success color to added badge', () => {
-			const session = createMockSession({
-				changedFiles: [{ path: '/Users/test/project/package.json', type: 'added' }],
-			});
-			render(<FileExplorerPanel {...defaultProps} session={session} />);
+		it('matches the full relative path, not a substring of the file name (#611)', () => {
+			// File "package.json" should NOT light up when a different file under
+			// src/ happens to contain "package" in its full path.
+			mockFileChanges = [{ path: 'src/package-loader.ts', status: ' M' }];
+			const { container } = render(<FileExplorerPanel {...defaultProps} />);
 
-			const badge = screen.getByText('added');
-			expect(badge).toHaveStyle({ color: mockTheme.colors.success });
+			expect(findIndicator(findRowFor(container, 'package.json'))).toBeNull();
 		});
 
-		it('applies warning color to modified badge', () => {
-			const session = createMockSession({
-				changedFiles: [{ path: '/Users/test/project/package.json', type: 'modified' }],
+		it('highlights ancestor folders containing changed descendants', () => {
+			// Need to expand src/ so its descendants render; otherwise only the
+			// folder row appears.
+			const expandedSession = createMockSession({
+				fileExplorerExpanded: ['src', 'src/utils'],
 			});
-			render(<FileExplorerPanel {...defaultProps} session={session} />);
+			mockFileChanges = [{ path: 'src/utils/helpers.ts', status: ' M' }];
+			const { container } = render(
+				<FileExplorerPanel {...defaultProps} session={expandedSession} />
+			);
 
-			const badge = screen.getByText('modified');
-			expect(badge).toHaveStyle({ color: mockTheme.colors.warning });
+			// The src/ folder row shows the descendant-style indicator
+			const srcIndicator = findIndicator(findRowFor(container, 'src'));
+			expect(srcIndicator).toBeDefined();
+			expect(srcIndicator).toHaveAttribute('data-change-type', 'descendant');
+
+			// The leaf file itself shows the modified-type indicator
+			const helpersIndicator = findIndicator(findRowFor(container, 'helpers.ts'));
+			expect(helpersIndicator).toHaveAttribute('data-change-type', 'modified');
 		});
 
-		it('applies error color to deleted badge', () => {
-			const session = createMockSession({
-				changedFiles: [{ path: '/Users/test/project/package.json', type: 'deleted' }],
-			});
-			render(<FileExplorerPanel {...defaultProps} session={session} />);
+		it('does not tint the file icon (icons stay consistent regardless of state)', () => {
+			// Per #611 follow-up, the icon should not change for added/modified/deleted.
+			mockFileChanges = [{ path: 'package.json', status: ' M' }];
+			const { container } = render(<FileExplorerPanel {...defaultProps} />);
 
-			const badge = screen.getByText('deleted');
-			expect(badge).toHaveStyle({ color: mockTheme.colors.error });
+			// The mocked icon distinguishes types via test ids ('added-icon',
+			// 'modified-icon', 'deleted-icon'); the plain 'file-icon' is the
+			// untinted form. Asserting on it pins down that we no longer pass
+			// the change type into getExplorerFileIcon.
+			expect(container.querySelector('[data-testid="modified-icon"]')).toBeNull();
+			expect(container.querySelector('[data-testid="file-icon"]')).not.toBeNull();
 		});
 
 		it('applies bold font to changed file names', () => {
-			const session = createMockSession({
-				changedFiles: [{ path: '/Users/test/project/package.json', type: 'modified' }],
-			});
-			const { container } = render(<FileExplorerPanel {...defaultProps} session={session} />);
+			mockFileChanges = [{ path: 'package.json', status: ' M' }];
+			const { container } = render(<FileExplorerPanel {...defaultProps} />);
 
 			const boldItems = container.querySelectorAll('.font-medium');
 			expect(boldItems.length).toBeGreaterThan(0);
 		});
 
-		it('applies textMain color to changed file names', () => {
-			const session = createMockSession({
-				changedFiles: [{ path: '/Users/test/project/package.json', type: 'modified' }],
-			});
-			const { container } = render(<FileExplorerPanel {...defaultProps} session={session} />);
+		it('applies textMain color to changed file rows', () => {
+			mockFileChanges = [{ path: 'package.json', status: ' M' }];
+			const { container } = render(<FileExplorerPanel {...defaultProps} />);
 
-			// Find item with package.json
-			const fileItem = Array.from(container.querySelectorAll('[data-file-index]')).find((el) =>
-				el.textContent?.includes('package.json')
-			);
-			expect(fileItem).toHaveStyle({ color: mockTheme.colors.textMain });
+			const row = findRowFor(container, 'package.json');
+			expect(row).toHaveStyle({ color: mockTheme.colors.textMain });
 		});
 	});
 
@@ -1717,11 +1753,13 @@ describe('FileExplorerPanel', () => {
 			expect(screen.getByText('src')).toBeInTheDocument();
 		});
 
-		it('handles undefined changedFiles', () => {
-			const session = createMockSession({ changedFiles: undefined as any });
+		it('handles missing fileChanges from git context', () => {
+			mockFileChanges = [];
+			const session = createMockSession();
 			const { container } = render(<FileExplorerPanel {...defaultProps} session={session} />);
 
-			// Should render without crashing (fixed with optional chaining at line 201)
+			// No indicators should render when there are no changes.
+			expect(container.querySelector('[data-testid="git-change-indicator"]')).toBeNull();
 			expect(container).toBeTruthy();
 		});
 

--- a/src/__tests__/renderer/utils/gitChangeMap.test.ts
+++ b/src/__tests__/renderer/utils/gitChangeMap.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+import {
+	classifyGitStatus,
+	buildFileChangeMap,
+	buildChangedAncestors,
+} from '../../../renderer/utils/gitChangeMap';
+import type { GitFileChange } from '../../../renderer/hooks';
+
+describe('classifyGitStatus', () => {
+	it('maps untracked files to added', () => {
+		expect(classifyGitStatus('??')).toBe('added');
+	});
+
+	it('maps modified-in-worktree to modified', () => {
+		expect(classifyGitStatus(' M')).toBe('modified');
+	});
+
+	it('maps modified-in-index to modified', () => {
+		expect(classifyGitStatus('M ')).toBe('modified');
+	});
+
+	it('maps added-in-index to added', () => {
+		expect(classifyGitStatus('A ')).toBe('added');
+	});
+
+	it('maps deleted-in-worktree to deleted', () => {
+		expect(classifyGitStatus(' D')).toBe('deleted');
+	});
+
+	it('maps deleted-in-index to deleted', () => {
+		expect(classifyGitStatus('D ')).toBe('deleted');
+	});
+
+	it('treats added-then-deleted as deleted (file is gone on disk)', () => {
+		expect(classifyGitStatus('AD')).toBe('deleted');
+	});
+
+	it('treats renamed as modified', () => {
+		expect(classifyGitStatus('R ')).toBe('modified');
+	});
+
+	it('treats merge conflicts (UU) as modified', () => {
+		expect(classifyGitStatus('UU')).toBe('modified');
+	});
+
+	it('falls back to modified for unknown codes', () => {
+		expect(classifyGitStatus('XY')).toBe('modified');
+	});
+});
+
+describe('buildFileChangeMap', () => {
+	const mkChange = (path: string, status: string): GitFileChange => ({
+		path,
+		status,
+		additions: 0,
+		deletions: 0,
+		modified: false,
+	});
+
+	it('returns an empty map for undefined input', () => {
+		expect(buildFileChangeMap(undefined).size).toBe(0);
+	});
+
+	it('returns an empty map for empty input', () => {
+		expect(buildFileChangeMap([]).size).toBe(0);
+	});
+
+	it('keys by full relative path and classifies each entry', () => {
+		const map = buildFileChangeMap([
+			mkChange('src/index.ts', ' M'),
+			mkChange('README.md', '??'),
+			mkChange('old.txt', ' D'),
+		]);
+		expect(map.get('src/index.ts')).toBe('modified');
+		expect(map.get('README.md')).toBe('added');
+		expect(map.get('old.txt')).toBe('deleted');
+		expect(map.size).toBe(3);
+	});
+
+	it('skips entries with empty paths', () => {
+		expect(buildFileChangeMap([mkChange('', ' M')]).size).toBe(0);
+	});
+});
+
+describe('buildChangedAncestors', () => {
+	it('returns an empty set for empty input', () => {
+		expect(buildChangedAncestors([]).size).toBe(0);
+	});
+
+	it('collects every directory ancestor for each changed path', () => {
+		const ancestors = buildChangedAncestors(['src/foo/bar.ts', 'docs/index.md']);
+		expect(ancestors.has('src')).toBe(true);
+		expect(ancestors.has('src/foo')).toBe(true);
+		expect(ancestors.has('docs')).toBe(true);
+		// Leaf files themselves are NOT ancestors.
+		expect(ancestors.has('src/foo/bar.ts')).toBe(false);
+		expect(ancestors.has('docs/index.md')).toBe(false);
+	});
+
+	it('handles top-level files (no ancestors)', () => {
+		const ancestors = buildChangedAncestors(['package.json']);
+		expect(ancestors.size).toBe(0);
+	});
+
+	it('deduplicates shared ancestors', () => {
+		const ancestors = buildChangedAncestors(['src/a.ts', 'src/b.ts', 'src/nested/c.ts']);
+		expect(ancestors.has('src')).toBe(true);
+		expect(ancestors.has('src/nested')).toBe(true);
+		expect(ancestors.size).toBe(2);
+	});
+
+	it('ignores empty paths', () => {
+		expect(buildChangedAncestors(['']).size).toBe(0);
+	});
+});

--- a/src/__tests__/renderer/utils/gitChangeMap.test.ts
+++ b/src/__tests__/renderer/utils/gitChangeMap.test.ts
@@ -7,36 +7,35 @@ import {
 import type { GitFileChange } from '../../../renderer/hooks';
 
 describe('classifyGitStatus', () => {
+	// `useGitStatusPolling` stores `file.status.trim()` on GitFileChange, so the
+	// trimmed forms below are what callers see in production. The function also
+	// accepts the raw 2-char porcelain codes (covered separately below).
 	it('maps untracked files to added', () => {
 		expect(classifyGitStatus('??')).toBe('added');
 	});
 
-	it('maps modified-in-worktree to modified', () => {
-		expect(classifyGitStatus(' M')).toBe('modified');
+	it('maps modified-in-worktree (trimmed " M" → "M") to modified', () => {
+		expect(classifyGitStatus('M')).toBe('modified');
 	});
 
-	it('maps modified-in-index to modified', () => {
-		expect(classifyGitStatus('M ')).toBe('modified');
+	it('maps modified-in-index ("M") to modified', () => {
+		expect(classifyGitStatus('M')).toBe('modified');
 	});
 
-	it('maps added-in-index to added', () => {
-		expect(classifyGitStatus('A ')).toBe('added');
+	it('maps added-in-index (trimmed "A " → "A") to added', () => {
+		expect(classifyGitStatus('A')).toBe('added');
 	});
 
-	it('maps deleted-in-worktree to deleted', () => {
-		expect(classifyGitStatus(' D')).toBe('deleted');
+	it('maps deleted-in-worktree (trimmed " D" → "D") to deleted', () => {
+		expect(classifyGitStatus('D')).toBe('deleted');
 	});
 
-	it('maps deleted-in-index to deleted', () => {
-		expect(classifyGitStatus('D ')).toBe('deleted');
-	});
-
-	it('treats added-then-deleted as deleted (file is gone on disk)', () => {
+	it('treats added-then-deleted ("AD") as deleted (file is gone on disk)', () => {
 		expect(classifyGitStatus('AD')).toBe('deleted');
 	});
 
-	it('treats renamed as modified', () => {
-		expect(classifyGitStatus('R ')).toBe('modified');
+	it('treats renamed (trimmed "R " → "R") as modified', () => {
+		expect(classifyGitStatus('R')).toBe('modified');
 	});
 
 	it('treats merge conflicts (UU) as modified', () => {
@@ -45,6 +44,16 @@ describe('classifyGitStatus', () => {
 
 	it('falls back to modified for unknown codes', () => {
 		expect(classifyGitStatus('XY')).toBe('modified');
+	});
+
+	it('accepts raw untrimmed porcelain codes the same as trimmed ones', () => {
+		// Defensive: callers shouldn't need to remember whether their producer
+		// trimmed the status; both forms classify identically.
+		expect(classifyGitStatus(' M')).toBe('modified');
+		expect(classifyGitStatus('M ')).toBe('modified');
+		expect(classifyGitStatus(' D')).toBe('deleted');
+		expect(classifyGitStatus('A ')).toBe('added');
+		expect(classifyGitStatus(' ??')).toBe('added');
 	});
 });
 
@@ -65,11 +74,11 @@ describe('buildFileChangeMap', () => {
 		expect(buildFileChangeMap([]).size).toBe(0);
 	});
 
-	it('keys by full relative path and classifies each entry', () => {
+	it('keys by full relative path and classifies each entry (trimmed codes as produced by useGitStatusPolling)', () => {
 		const map = buildFileChangeMap([
-			mkChange('src/index.ts', ' M'),
+			mkChange('src/index.ts', 'M'),
 			mkChange('README.md', '??'),
-			mkChange('old.txt', ' D'),
+			mkChange('old.txt', 'D'),
 		]);
 		expect(map.get('src/index.ts')).toBe('modified');
 		expect(map.get('README.md')).toBe('added');
@@ -78,7 +87,7 @@ describe('buildFileChangeMap', () => {
 	});
 
 	it('skips entries with empty paths', () => {
-		expect(buildFileChangeMap([mkChange('', ' M')]).size).toBe(0);
+		expect(buildFileChangeMap([mkChange('', 'M')]).size).toBe(0);
 	});
 });
 

--- a/src/renderer/components/FileExplorerPanel.tsx
+++ b/src/renderer/components/FileExplorerPanel.tsx
@@ -25,7 +25,7 @@ import {
 	Search,
 } from 'lucide-react';
 import { Spinner } from './ui/Spinner';
-import type { Session, Theme, FocusArea } from '../types';
+import type { Session, Theme, FocusArea, FileChangeType } from '../types';
 import type { FileNode } from '../types/fileTree';
 import type { FileTreeChanges } from '../utils/fileExplorer';
 import {
@@ -35,6 +35,8 @@ import {
 	countNodesInTree,
 } from '../utils/fileExplorer';
 import { getExplorerFileIcon, getExplorerFolderIcon } from '../utils/theme';
+import { buildChangedAncestors, buildFileChangeMap } from '../utils/gitChangeMap';
+import { useGitDetail } from '../contexts/GitStatusContext';
 import { useLayerStack } from '../contexts/LayerStackContext';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
 import { useClickOutside } from '../hooks/ui/useClickOutside';
@@ -520,6 +522,14 @@ function FileExplorerPanelInner(props: FileExplorerPanelProps) {
 	const dotfilesToggleHidden = useSettingsStore((s) => s.dotfilesToggleHidden);
 	const colorBlindMode = useSettingsStore((s) => s.colorBlindMode);
 	const compact = rightPanelWidth < RIGHT_PANEL_COMPACT_THRESHOLD;
+
+	// Live git status comes from GitStatusProvider, which polls per session via
+	// useGitStatusPolling. The legacy session.changedFiles field is never
+	// populated, so consume the context directly here (#611).
+	const { getFileDetails } = useGitDetail();
+	const fileChanges = getFileDetails(session.id)?.fileChanges;
+	const changeMap = useMemo(() => buildFileChangeMap(fileChanges), [fileChanges]);
+	const changedAncestors = useMemo(() => buildChangedAncestors(changeMap.keys()), [changeMap]);
 
 	const { registerLayer, unregisterLayer, updateLayerHandler } = useLayerStack();
 	const layerIdRef = useRef<string>();
@@ -1087,8 +1097,21 @@ function FileExplorerPanelInner(props: FileExplorerPanelProps) {
 		}) => {
 			const { node, path: fullPath, depth, globalIndex } = item;
 			const absolutePath = `${session.fullPath}/${fullPath}`;
-			const change = session.changedFiles?.find((f) => f.path.includes(node.name));
 			const isFolder = node.type === 'folder';
+			// Match against the full relative path — `path.includes(node.name)` used
+			// to false-match files with identical leaf names. (#611)
+			const changeType: FileChangeType | undefined = isFolder ? undefined : changeMap.get(fullPath);
+			// Folders highlight when any descendant is changed (VSCode-style walk).
+			const folderHasChange = isFolder && changedAncestors.has(fullPath);
+			const hasChange = !!changeType || folderHasChange;
+			const changeColor =
+				changeType === 'added'
+					? theme.colors.success
+					: changeType === 'deleted'
+						? theme.colors.error
+						: changeType === 'modified'
+							? theme.colors.warning
+							: undefined;
 			const expandedSet = new Set(session.fileExplorerExpanded || []);
 			const isExpanded = expandedSet.has(fullPath);
 			// Check active file tab for selection highlighting
@@ -1124,7 +1147,7 @@ function FileExplorerPanelInner(props: FileExplorerPanelProps) {
 						height: `${virtualRow.size}px`,
 						transform: `translateY(${virtualRow.start}px)`,
 						paddingLeft: `${8 + depth * 20}px`,
-						color: change ? theme.colors.textMain : theme.colors.textDim,
+						color: hasChange ? theme.colors.textMain : theme.colors.textDim,
 						borderLeftColor: isKeyboardSelected ? theme.colors.accent : 'transparent',
 						backgroundColor: isKeyboardSelected
 							? theme.colors.bgActivity
@@ -1172,44 +1195,41 @@ function FileExplorerPanelInner(props: FileExplorerPanelProps) {
 							: getExplorerFileIcon(
 									node.name,
 									theme,
-									change?.type,
+									// Per #611 follow-up: don't tint the icon based on change
+									// state — let the dot + filename color carry that signal so
+									// the icon set stays visually consistent across themes.
+									undefined,
 									fileExplorerIconTheme,
 									colorBlindMode
 								)}
 					</span>
 					<span
-						className={`truncate min-w-0 flex-1 ${change ? 'font-medium' : ''}`}
+						className={`truncate min-w-0 flex-1 ${changeType ? 'font-medium' : ''}`}
 						title={node.name}
+						style={changeColor ? { color: changeColor } : undefined}
 					>
 						{node.name}
 					</span>
-					{change && (
+					{hasChange && (
 						<span
-							className="flex-shrink-0 text-[9px] px-1 rounded uppercase"
+							data-testid="git-change-indicator"
+							data-change-type={changeType ?? 'descendant'}
+							aria-label={changeType ? `${changeType} file` : 'contains changed files'}
+							title={changeType ?? 'contains changed files'}
+							className="flex-shrink-0 inline-block w-2 h-2 rounded-full"
 							style={{
-								backgroundColor:
-									change.type === 'added'
-										? theme.colors.success + '20'
-										: change.type === 'deleted'
-											? theme.colors.error + '20'
-											: theme.colors.warning + '20',
-								color:
-									change.type === 'added'
-										? theme.colors.success
-										: change.type === 'deleted'
-											? theme.colors.error
-											: theme.colors.warning,
+								backgroundColor: changeColor ?? theme.colors.textDim,
+								opacity: changeType ? 1 : 0.55,
 							}}
-						>
-							{change.type}
-						</span>
+						/>
 					)}
 				</div>
 			);
 		},
 		[
 			session.fullPath,
-			session.changedFiles,
+			changeMap,
+			changedAncestors,
 			session.fileExplorerExpanded,
 			session.id,
 			session.activeFileTabId,
@@ -1226,6 +1246,7 @@ function FileExplorerPanelInner(props: FileExplorerPanelProps) {
 			handleFileClick,
 			fileTreeFilter,
 			fileExplorerIconTheme,
+			colorBlindMode,
 			handleContextMenu,
 		]
 	);

--- a/src/renderer/components/FileExplorerPanel.tsx
+++ b/src/renderer/components/FileExplorerPanel.tsx
@@ -36,6 +36,7 @@ import {
 } from '../utils/fileExplorer';
 import { getExplorerFileIcon, getExplorerFolderIcon } from '../utils/theme';
 import { buildChangedAncestors, buildFileChangeMap } from '../utils/gitChangeMap';
+import { COLORBLIND_STATUS_COLORS } from '../constants/colorblindPalettes';
 import { useGitDetail } from '../contexts/GitStatusContext';
 import { useLayerStack } from '../contexts/LayerStackContext';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
@@ -1104,13 +1105,20 @@ function FileExplorerPanelInner(props: FileExplorerPanelProps) {
 			// Folders highlight when any descendant is changed (VSCode-style walk).
 			const folderHasChange = isFolder && changedAncestors.has(fullPath);
 			const hasChange = !!changeType || folderHasChange;
+			// Use the colorblind-safe status palette (teal/orange/vermillion) when
+			// the user has enabled colorBlindMode, mirroring how the default file
+			// icon already swaps its tint via the same palette. Keeps the dot
+			// distinguishable for protanopia/deuteranopia/tritanopia.
+			const successColor = colorBlindMode ? COLORBLIND_STATUS_COLORS.success : theme.colors.success;
+			const warningColor = colorBlindMode ? COLORBLIND_STATUS_COLORS.warning : theme.colors.warning;
+			const errorColor = colorBlindMode ? COLORBLIND_STATUS_COLORS.error : theme.colors.error;
 			const changeColor =
 				changeType === 'added'
-					? theme.colors.success
+					? successColor
 					: changeType === 'deleted'
-						? theme.colors.error
+						? errorColor
 						: changeType === 'modified'
-							? theme.colors.warning
+							? warningColor
 							: undefined;
 			const expandedSet = new Set(session.fileExplorerExpanded || []);
 			const isExpanded = expandedSet.has(fullPath);

--- a/src/renderer/utils/gitChangeMap.ts
+++ b/src/renderer/utils/gitChangeMap.ts
@@ -10,13 +10,16 @@ import type { GitFileChange } from '../hooks';
  * - any `A` in either position → `added`
  * - everything else (M, R, C, T, U…) → `modified`
  *
- * Designed to be permissive: unknown codes fall through as `modified` so a
- * dirty file is still surfaced rather than silently dropped.
+ * Accepts both raw porcelain (` M`, ` D`) and the trimmed form (`M`, `D`)
+ * that `useGitStatusPolling` stores on {@link GitFileChange}. Unknown codes
+ * fall through as `modified` so a dirty file is still surfaced rather than
+ * silently dropped.
  */
 export function classifyGitStatus(status: string): FileChangeType {
-	if (status === '??') return 'added';
-	if (status.includes('D')) return 'deleted';
-	if (status.includes('A')) return 'added';
+	const normalized = status.trim();
+	if (normalized === '??') return 'added';
+	if (normalized.includes('D')) return 'deleted';
+	if (normalized.includes('A')) return 'added';
 	return 'modified';
 }
 

--- a/src/renderer/utils/gitChangeMap.ts
+++ b/src/renderer/utils/gitChangeMap.ts
@@ -1,0 +1,60 @@
+import type { FileChangeType } from '../types';
+import type { GitFileChange } from '../hooks';
+
+/**
+ * Map a 2-char git porcelain status code (XY) to a {@link FileChangeType}.
+ *
+ * - `??` (untracked) → `added`
+ * - any `D` in either position (deleted, AD, MD, RD…) → `deleted`
+ *   (covers cases where the file is no longer on disk regardless of staging)
+ * - any `A` in either position → `added`
+ * - everything else (M, R, C, T, U…) → `modified`
+ *
+ * Designed to be permissive: unknown codes fall through as `modified` so a
+ * dirty file is still surfaced rather than silently dropped.
+ */
+export function classifyGitStatus(status: string): FileChangeType {
+	if (status === '??') return 'added';
+	if (status.includes('D')) return 'deleted';
+	if (status.includes('A')) return 'added';
+	return 'modified';
+}
+
+/**
+ * Build a `path → FileChangeType` lookup from {@link GitFileChange} entries.
+ *
+ * Paths are kept verbatim (relative to the repo root, matching the porcelain
+ * output), so callers should match against the same relative path produced by
+ * their file-tree walker.
+ */
+export function buildFileChangeMap(
+	fileChanges: readonly GitFileChange[] | undefined
+): Map<string, FileChangeType> {
+	const map = new Map<string, FileChangeType>();
+	if (!fileChanges) return map;
+	for (const change of fileChanges) {
+		if (!change.path) continue;
+		map.set(change.path, classifyGitStatus(change.status));
+	}
+	return map;
+}
+
+/**
+ * From a set of changed file paths, derive every ancestor directory path that
+ * contains a change. Used to highlight folders whose descendants are dirty.
+ *
+ * Example: input `['src/foo/bar.ts', 'README.md']`
+ *          output `Set { 'src', 'src/foo' }`
+ */
+export function buildChangedAncestors(paths: Iterable<string>): Set<string> {
+	const ancestors = new Set<string>();
+	for (const path of paths) {
+		if (!path) continue;
+		let idx = path.indexOf('/');
+		while (idx !== -1) {
+			ancestors.add(path.substring(0, idx));
+			idx = path.indexOf('/', idx + 1);
+		}
+	}
+	return ancestors;
+}


### PR DESCRIPTION
## Summary

- The Files pane has been silently broken because `session.changedFiles` is never populated; the file-tree never showed added/modified/deleted indicators. Switch the row renderer to read from `useGitDetail()` (already polled per session by `GitStatusProvider`).
- Drop the fragile `f.path.includes(node.name)` lookup in favour of a full-relative-path match. The old version false-matched siblings sharing a leaf name (e.g. `package.json` lighting up because `src/package-loader.ts` was modified).
- Walk the tree to highlight ancestor folders that contain changed descendants (VS Code style, per the #611 follow-up comment).
- Replace the tinted icon + uppercase `MOD`/`ADD`/`DEL` badge with a small colored dot indicator next to the filename. Icons stay consistent regardless of change state, exactly as the follow-up requested ("we DO NOT want to override/modify the icons themselves").

The new `buildFileChangeMap` / `buildChangedAncestors` / `classifyGitStatus` helpers translate git porcelain `XY` status codes into the existing `FileChangeType` union and are covered by their own unit-test file.

Closes #611.

## Test plan

- [x] `npx vitest run src/__tests__/renderer/utils/gitChangeMap.test.ts` (19 new unit tests pass)
- [x] `npx vitest run src/__tests__/renderer/components/FileExplorerPanel.test.tsx` (166 component tests pass, including new full-path / ancestor-walk / icon-consistency cases)
- [x] `npx tsc --noEmit -p tsconfig.app.json`
- [x] `npx tsc --noEmit -p tsconfig.test.json`
- [x] `npx prettier --check` on touched files
- [x] `npx eslint` on touched files (0 issues)
- [ ] Manually verify in dev build that modified / added / deleted indicators appear on the right files and that ancestor folders highlight

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File explorer shows per-row git change dots (added/modified/deleted), folders marked when descendants changed, and colorblind-safe palette support.
  * Icons no longer get tinted by change state; row highlighting (bold + row color) applied for changed items.
* **Bug Fixes**
  * Change indicators require full relative path matches and gracefully handle missing/empty git data.
* **Tests**
  * Expanded tests covering change classification, mapping, ancestor detection, and UI indicators.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RunMaestro/Maestro/pull/1007?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->