### PR TITLE
feat(export): opt-in reasoning logs in clipboard/Gist exports (#560)

### DIFF
--- a/src/__tests__/renderer/hooks/useTabExportHandlers.test.ts
+++ b/src/__tests__/renderer/hooks/useTabExportHandlers.test.ts
@@ -40,8 +40,10 @@ vi.mock('../../../renderer/stores/modalStore', () => ({
 
 // Mock contextExtractor
 const mockFormatLogsForClipboard = vi.fn();
+const mockHasThinkingEntries = vi.fn();
 vi.mock('../../../renderer/utils/contextExtractor', () => ({
 	formatLogsForClipboard: (...args: unknown[]) => mockFormatLogsForClipboard(...args),
+	hasThinkingEntries: (...args: unknown[]) => mockHasThinkingEntries(...args),
 }));
 
 // Mock notificationStore
@@ -143,6 +145,9 @@ beforeEach(() => {
 	// Default: formatLogsForClipboard returns a predictable string
 	mockFormatLogsForClipboard.mockReturnValue('formatted conversation text');
 
+	// Default: tabs have no thinking entries. Individual tests override.
+	mockHasThinkingEntries.mockReturnValue(false);
+
 	// Default: downloadTabExport resolves
 	mockDownloadTabExport.mockResolvedValue(undefined);
 
@@ -198,7 +203,9 @@ describe('useTabExportHandlers', () => {
 				await Promise.resolve();
 			});
 
-			expect(mockFormatLogsForClipboard).toHaveBeenCalledWith(tab.logs);
+			expect(mockFormatLogsForClipboard).toHaveBeenCalledWith(tab.logs, {
+				includeThinking: false,
+			});
 			expect(mockClipboardWriteText).toHaveBeenCalledWith('formatted conversation text');
 		});
 
@@ -211,6 +218,71 @@ describe('useTabExportHandlers', () => {
 
 			await act(async () => {
 				result.current.handleCopyContext('tab-1');
+				await Promise.resolve();
+			});
+
+			expect(mockFlashCopiedToClipboard).toHaveBeenCalledWith(undefined, 'Conversation Copied');
+		});
+
+		it('passes includeThinking through to formatLogsForClipboard', async () => {
+			const tab = createMockTab({ id: 'tab-1' });
+			const session = createMockSession({ aiTabs: [tab] });
+			const deps = createDeps({ sessionsRef: { current: [session] } });
+
+			const { result } = renderHook(() => useTabExportHandlers(deps));
+
+			await act(async () => {
+				result.current.handleCopyContext('tab-1', { includeThinking: true });
+				await Promise.resolve();
+			});
+
+			expect(mockFormatLogsForClipboard).toHaveBeenCalledWith(tab.logs, {
+				includeThinking: true,
+			});
+		});
+
+		it('uses the "with reasoning" flash label when the tab actually has thinking entries', async () => {
+			mockHasThinkingEntries.mockReturnValue(true);
+			const tab = createMockTab({
+				id: 'tab-1',
+				logs: [
+					createLogEntry({ source: 'user', text: 'Hi' }),
+					createLogEntry({ source: 'thinking', text: 'thinking step' }),
+					createLogEntry({ source: 'ai', text: 'Reply' }),
+				],
+			});
+			const session = createMockSession({ aiTabs: [tab] });
+			const deps = createDeps({ sessionsRef: { current: [session] } });
+
+			const { result } = renderHook(() => useTabExportHandlers(deps));
+
+			await act(async () => {
+				result.current.handleCopyContext('tab-1', { includeThinking: true });
+				await Promise.resolve();
+			});
+
+			expect(mockHasThinkingEntries).toHaveBeenCalledWith(tab.logs);
+			expect(mockFlashCopiedToClipboard).toHaveBeenCalledWith(
+				undefined,
+				'Conversation Copied (with reasoning)'
+			);
+		});
+
+		it('does not claim "with reasoning" when the flag is set but the tab has no thinking entries', async () => {
+			const tab = createMockTab({
+				id: 'tab-1',
+				logs: [
+					createLogEntry({ source: 'user', text: 'Hi' }),
+					createLogEntry({ source: 'ai', text: 'Reply' }),
+				],
+			});
+			const session = createMockSession({ aiTabs: [tab] });
+			const deps = createDeps({ sessionsRef: { current: [session] } });
+
+			const { result } = renderHook(() => useTabExportHandlers(deps));
+
+			await act(async () => {
+				result.current.handleCopyContext('tab-1', { includeThinking: true });
 				await Promise.resolve();
 			});
 
@@ -526,7 +598,29 @@ describe('useTabExportHandlers', () => {
 			expect(mockSetTabGistContent).toHaveBeenCalledWith({
 				filename: 'My_Tab_context.md',
 				content: 'gist body content',
+				sourceLogs: tab.logs,
 			});
+		});
+
+		it('forwards raw logs as sourceLogs so the modal can re-format on toggle', () => {
+			const logs = [
+				createLogEntry({ source: 'user', text: 'Hi' }),
+				createLogEntry({ source: 'thinking', text: 'I should explain X' }),
+				createLogEntry({ source: 'ai', text: 'Hello' }),
+			];
+			const tab = createMockTab({ id: 'tab-1', logs });
+			const session = createMockSession({ aiTabs: [tab] });
+			const deps = createDeps({ sessionsRef: { current: [session] } });
+
+			const { result } = renderHook(() => useTabExportHandlers(deps));
+
+			act(() => {
+				result.current.handlePublishTabGist('tab-1');
+			});
+
+			expect(mockSetTabGistContent).toHaveBeenCalledWith(
+				expect.objectContaining({ sourceLogs: logs })
+			);
 		});
 
 		it('opens the gist publish modal', () => {
@@ -929,8 +1023,10 @@ describe('useTabExportHandlers', () => {
 				await Promise.resolve();
 			});
 
-			expect(mockFormatLogsForClipboard).toHaveBeenCalledWith(activeTab.logs);
-			expect(mockFormatLogsForClipboard).not.toHaveBeenCalledWith(otherTab.logs);
+			expect(mockFormatLogsForClipboard).toHaveBeenCalledWith(activeTab.logs, {
+				includeThinking: false,
+			});
+			expect(mockFormatLogsForClipboard).not.toHaveBeenCalledWith(otherTab.logs, expect.anything());
 		});
 
 		it('does not find a tab from a non-active session', async () => {

--- a/src/__tests__/renderer/utils/contextExtractor.test.ts
+++ b/src/__tests__/renderer/utils/contextExtractor.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
 	extractTabContext,
 	formatLogsForGrooming,
+	formatLogsForClipboard,
+	hasThinkingEntries,
 	parseGroomedOutput,
 	estimateTokenCount,
 	estimateTextTokenCount,
@@ -117,6 +119,118 @@ describe('extractTabContext', () => {
 		context.logs.push(createMockLog({ text: 'Added' }));
 		expect(originalLogs).toHaveLength(1);
 		expect(context.logs).toHaveLength(2);
+	});
+});
+
+describe('formatLogsForClipboard', () => {
+	it('includes user and assistant entries only by default', () => {
+		const logs: LogEntry[] = [
+			createMockLog({ source: 'user', text: 'How do I implement X?' }),
+			createMockLog({ source: 'thinking', text: 'The user wants...' }),
+			createMockLog({ source: 'ai', text: 'Use the foo helper.' }),
+			createMockLog({ source: 'tool', text: 'Reading file...' }),
+			createMockLog({ source: 'system', text: 'system prompt' }),
+		];
+
+		const result = formatLogsForClipboard(logs);
+
+		expect(result).toBe('USER:\nHow do I implement X?\n\nASSISTANT:\nUse the foo helper.');
+		expect(result).not.toContain('THINKING');
+		expect(result).not.toContain('The user wants');
+	});
+
+	it('treats ai and stdout sources as ASSISTANT entries', () => {
+		const logs: LogEntry[] = [
+			createMockLog({ source: 'ai', text: 'first response' }),
+			createMockLog({ source: 'stdout', text: 'second response' }),
+		];
+
+		const result = formatLogsForClipboard(logs);
+
+		expect(result).toBe('ASSISTANT:\nfirst response\n\nASSISTANT:\nsecond response');
+	});
+
+	it('includes THINKING entries when includeThinking is true', () => {
+		const logs: LogEntry[] = [
+			createMockLog({ source: 'user', text: 'Why?' }),
+			createMockLog({ source: 'thinking', text: 'Considering the options...' }),
+			createMockLog({ source: 'ai', text: 'Because Y.' }),
+		];
+
+		const result = formatLogsForClipboard(logs, { includeThinking: true });
+
+		expect(result).toBe(
+			'USER:\nWhy?\n\nTHINKING:\nConsidering the options...\n\nASSISTANT:\nBecause Y.'
+		);
+	});
+
+	it('still excludes tool/system/stderr entries when includeThinking is true', () => {
+		const logs: LogEntry[] = [
+			createMockLog({ source: 'user', text: 'hi' }),
+			createMockLog({ source: 'thinking', text: 'reasoning' }),
+			createMockLog({ source: 'tool', text: 'tool call' }),
+			createMockLog({ source: 'stderr', text: 'stderr noise' }),
+			createMockLog({ source: 'system', text: 'system note' }),
+			createMockLog({ source: 'error', text: 'failure' }),
+			createMockLog({ source: 'ai', text: 'response' }),
+		];
+
+		const result = formatLogsForClipboard(logs, { includeThinking: true });
+
+		expect(result).toBe('USER:\nhi\n\nTHINKING:\nreasoning\n\nASSISTANT:\nresponse');
+	});
+
+	it('skips empty entries even when their source is included', () => {
+		const logs: LogEntry[] = [
+			createMockLog({ source: 'user', text: 'real message' }),
+			createMockLog({ source: 'thinking', text: '   ' }),
+			createMockLog({ source: 'thinking', text: '' }),
+			createMockLog({ source: 'ai', text: 'reply' }),
+		];
+
+		const result = formatLogsForClipboard(logs, { includeThinking: true });
+
+		expect(result).toBe('USER:\nreal message\n\nASSISTANT:\nreply');
+	});
+
+	it('returns an empty string when no entries qualify', () => {
+		const logs: LogEntry[] = [
+			createMockLog({ source: 'system', text: 'noise' }),
+			createMockLog({ source: 'tool', text: 'tool call' }),
+		];
+
+		expect(formatLogsForClipboard(logs)).toBe('');
+	});
+});
+
+describe('hasThinkingEntries', () => {
+	it('returns true when any entry has source "thinking" and non-empty text', () => {
+		const logs: LogEntry[] = [
+			createMockLog({ source: 'user', text: 'hi' }),
+			createMockLog({ source: 'thinking', text: 'reasoning' }),
+		];
+		expect(hasThinkingEntries(logs)).toBe(true);
+	});
+
+	it('returns false when no thinking entries exist', () => {
+		const logs: LogEntry[] = [
+			createMockLog({ source: 'user', text: 'hi' }),
+			createMockLog({ source: 'ai', text: 'hi back' }),
+		];
+		expect(hasThinkingEntries(logs)).toBe(false);
+	});
+
+	it('returns false when thinking entries are blank', () => {
+		const logs: LogEntry[] = [
+			createMockLog({ source: 'thinking', text: '' }),
+			createMockLog({ source: 'thinking', text: '   ' }),
+		];
+		expect(hasThinkingEntries(logs)).toBe(false);
+	});
+
+	it('returns false for undefined and null inputs', () => {
+		expect(hasThinkingEntries(undefined)).toBe(false);
+		expect(hasThinkingEntries(null)).toBe(false);
 	});
 });
 

--- a/src/renderer/components/AppStandaloneModals.tsx
+++ b/src/renderer/components/AppStandaloneModals.tsx
@@ -413,6 +413,7 @@ function AppStandaloneModalsInner({
 						(activeFileTab ? activeFileTab.name + activeFileTab.extension : 'conversation.md')
 					}
 					content={tabGistContent?.content ?? activeFileTab?.content ?? ''}
+					sourceLogs={tabGistContent?.sourceLogs}
 					onClose={() => {
 						setGistPublishModalOpen(false);
 						useTabStore.getState().setTabGistContent(null);

--- a/src/renderer/components/GistPublishModal.tsx
+++ b/src/renderer/components/GistPublishModal.tsx
@@ -1,11 +1,12 @@
-import { useRef, useState, useCallback } from 'react';
+import { useRef, useState, useCallback, useMemo } from 'react';
 import { Share2, Copy, Check, ExternalLink } from 'lucide-react';
 import { GhostIconButton } from './ui/GhostIconButton';
-import type { Theme } from '../types';
+import type { LogEntry, Theme } from '../types';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
 import { Modal } from './ui/Modal';
 import { safeClipboardWrite } from '../utils/clipboard';
 import { openUrl } from '../utils/openUrl';
+import { formatLogsForClipboard, hasThinkingEntries } from '../utils/contextExtractor';
 
 export interface GistInfo {
 	gistUrl: string;
@@ -21,6 +22,12 @@ interface GistPublishModalProps {
 	onSuccess: (gistUrl: string, isPublic: boolean) => void;
 	/** Existing gist info if the file was previously published */
 	existingGist?: GistInfo;
+	/**
+	 * Raw log entries that produced `content`. When provided and the logs
+	 * contain reasoning/thinking blocks, the modal shows an "Include
+	 * reasoning" toggle that re-formats the body before publishing.
+	 */
+	sourceLogs?: LogEntry[];
 }
 
 /**
@@ -35,6 +42,7 @@ export function GistPublishModal({
 	onClose,
 	onSuccess,
 	existingGist,
+	sourceLogs,
 }: GistPublishModalProps) {
 	const secretButtonRef = useRef<HTMLButtonElement>(null);
 	const copyButtonRef = useRef<HTMLButtonElement>(null);
@@ -42,6 +50,16 @@ export function GistPublishModal({
 	const [error, setError] = useState<string | null>(null);
 	const [copied, setCopied] = useState(false);
 	const [showRepublishOptions, setShowRepublishOptions] = useState(false);
+	const [includeThinking, setIncludeThinking] = useState(false);
+
+	const canToggleThinking = useMemo(() => hasThinkingEntries(sourceLogs), [sourceLogs]);
+
+	const effectiveContent = useMemo(() => {
+		if (canToggleThinking && includeThinking && sourceLogs) {
+			return formatLogsForClipboard(sourceLogs, { includeThinking: true });
+		}
+		return content;
+	}, [canToggleThinking, includeThinking, sourceLogs, content]);
 
 	const handlePublish = useCallback(
 		async (isPublic: boolean) => {
@@ -51,7 +69,7 @@ export function GistPublishModal({
 			try {
 				const result = await window.maestro.git.createGist(
 					filename,
-					content,
+					effectiveContent,
 					'', // No description - file name serves as context
 					isPublic
 				);
@@ -68,7 +86,7 @@ export function GistPublishModal({
 				setIsPublishing(false);
 			}
 		},
-		[filename, content, onSuccess, onClose]
+		[filename, effectiveContent, onSuccess, onClose]
 	);
 
 	const handlePublishSecret = useCallback(() => {
@@ -278,6 +296,27 @@ export function GistPublishModal({
 					<p className="text-xs" style={{ color: theme.colors.warning }}>
 						This will create a new gist. The existing gist URL will be replaced.
 					</p>
+				)}
+
+				{canToggleThinking && (
+					<label
+						className="flex items-start gap-2 text-xs cursor-pointer select-none"
+						style={{ color: theme.colors.textMain }}
+					>
+						<input
+							type="checkbox"
+							checked={includeThinking}
+							onChange={(e) => setIncludeThinking(e.target.checked)}
+							disabled={isPublishing}
+							className="mt-0.5"
+						/>
+						<span>
+							Include reasoning/thinking logs
+							<span className="block text-xs" style={{ color: theme.colors.textDim }}>
+								Adds the agent's reasoning blocks alongside the user/assistant turns.
+							</span>
+						</span>
+					</label>
 				)}
 
 				<div className="text-xs space-y-2" style={{ color: theme.colors.textDim }}>

--- a/src/renderer/components/MainPanel/types.ts
+++ b/src/renderer/components/MainPanel/types.ts
@@ -10,6 +10,7 @@ import type {
 	AgentError,
 	QueuedItem,
 } from '../../types';
+import type { CopyContextOptions } from '../../hooks/tabs/useTabExportHandlers';
 
 export interface SlashCommand {
 	command: string;
@@ -258,7 +259,7 @@ export interface MainPanelProps {
 	onSummarizeAndContinue?: (tabId: string) => void;
 	onMergeWith?: (tabId: string) => void;
 	onSendToAgent?: (tabId: string) => void;
-	onCopyContext?: (tabId: string) => void;
+	onCopyContext?: (tabId: string, options?: CopyContextOptions) => void;
 	onExportHtml?: (tabId: string) => void;
 	onPublishTabGist?: (tabId: string) => void;
 	/** Copy arbitrary text to the clipboard (wired by MainPanel for terminal buffer actions). */

--- a/src/renderer/components/TabBar/AITab.tsx
+++ b/src/renderer/components/TabBar/AITab.tsx
@@ -2,6 +2,7 @@ import React, { useState, useCallback, useEffect, useRef, memo, useMemo } from '
 import { createPortal } from 'react-dom';
 import { X, Star, Pencil, Loader2, AlertCircle } from 'lucide-react';
 import type { AITab as AITabType, Theme } from '../../types';
+import type { CopyContextOptions } from '../../hooks/tabs/useTabExportHandlers';
 import { safeClipboardWrite } from '../../utils/clipboard';
 import { buildSessionDeepLink } from '../../../shared/deep-link-urls';
 import { useTabHoverOverlay } from '../../hooks/tabs/useTabHoverOverlay';
@@ -42,8 +43,8 @@ export interface AITabProps {
 	onSendToAgent?: (tabId: string) => void;
 	/** Stable callback - receives tabId */
 	onSummarizeAndContinue?: (tabId: string) => void;
-	/** Stable callback - receives tabId */
-	onCopyContext?: (tabId: string) => void;
+	/** Stable callback - receives tabId (and optional CopyContextOptions for variants like "with reasoning") */
+	onCopyContext?: (tabId: string, options?: CopyContextOptions) => void;
 	/** Stable callback - receives tabId */
 	onExportHtml?: (tabId: string) => void;
 	/** Stable callback - receives tabId */
@@ -279,6 +280,15 @@ export const AITab = memo(function AITab({
 		(e: React.MouseEvent) => {
 			e.stopPropagation();
 			onCopyContext?.(tabId);
+			setOverlayOpen(false);
+		},
+		[onCopyContext, tabId, setOverlayOpen]
+	);
+
+	const handleCopyContextWithReasoningClick = useCallback(
+		(e: React.MouseEvent) => {
+			e.stopPropagation();
+			onCopyContext?.(tabId, { includeThinking: true });
 			setOverlayOpen(false);
 		},
 		[onCopyContext, tabId, setOverlayOpen]
@@ -558,6 +568,7 @@ export const AITab = memo(function AITab({
 							onMarkUnreadClick={handleMarkUnreadClick}
 							onExportHtmlClick={handleExportHtmlClick}
 							onCopyContextClick={handleCopyContextClick}
+							onCopyContextWithReasoningClick={handleCopyContextWithReasoningClick}
 							onSummarizeAndContinueClick={handleSummarizeAndContinueClick}
 							onMergeWithClick={handleMergeWithClick}
 							onSendToAgentClick={handleSendToAgentClick}

--- a/src/renderer/components/TabBar/AITabOverlayMenu.tsx
+++ b/src/renderer/components/TabBar/AITabOverlayMenu.tsx
@@ -19,6 +19,8 @@ import type { AITab, Theme } from '../../types';
 import { buildSessionDeepLink } from '../../../shared/deep-link-urls';
 import { useSettingsStore } from '../../stores/settingsStore';
 import { formatShortcutKeys } from '../../utils/shortcutFormatter';
+import { hasThinkingEntries } from '../../utils/contextExtractor';
+import type { CopyContextOptions } from '../../hooks/tabs/useTabExportHandlers';
 
 export interface AITabOverlayMenuProps {
 	tab: AITab;
@@ -36,6 +38,7 @@ export interface AITabOverlayMenuProps {
 	onMarkUnreadClick: (e: React.MouseEvent) => void;
 	onExportHtmlClick: (e: React.MouseEvent) => void;
 	onCopyContextClick: (e: React.MouseEvent) => void;
+	onCopyContextWithReasoningClick: (e: React.MouseEvent) => void;
 	onSummarizeAndContinueClick: (e: React.MouseEvent) => void;
 	onMergeWithClick: (e: React.MouseEvent) => void;
 	onSendToAgentClick: (e: React.MouseEvent) => void;
@@ -50,7 +53,7 @@ export interface AITabOverlayMenuProps {
 	onMergeWith?: (tabId: string) => void;
 	onSendToAgent?: (tabId: string) => void;
 	onSummarizeAndContinue?: (tabId: string) => void;
-	onCopyContext?: (tabId: string) => void;
+	onCopyContext?: (tabId: string, options?: CopyContextOptions) => void;
 	onExportHtml?: (tabId: string) => void;
 	onPublishGist?: (tabId: string) => void;
 	onMoveToFirst?: (tabId: string) => void;
@@ -79,6 +82,7 @@ export const AITabOverlayMenu = memo(function AITabOverlayMenu({
 	onMarkUnreadClick,
 	onExportHtmlClick,
 	onCopyContextClick,
+	onCopyContextWithReasoningClick,
 	onSummarizeAndContinueClick,
 	onMergeWithClick,
 	onSendToAgentClick,
@@ -244,6 +248,18 @@ export const AITabOverlayMenu = memo(function AITabOverlayMenu({
 					>
 						<Clipboard className="w-3.5 h-3.5" style={{ color: theme.colors.textDim }} />
 						Context: Copy to Clipboard
+					</button>
+				)}
+
+				{/* Context: Copy with Reasoning — only when the tab has reasoning blocks */}
+				{onCopyContext && hasThinkingEntries(tab.logs) && (
+					<button
+						onClick={onCopyContextWithReasoningClick}
+						className="w-full flex items-center gap-2 px-2 py-1.5 rounded text-xs hover:bg-white/10 transition-colors"
+						style={{ color: theme.colors.textMain }}
+					>
+						<Clipboard className="w-3.5 h-3.5" style={{ color: theme.colors.textDim }} />
+						Context: Copy with Reasoning
 					</button>
 				)}
 

--- a/src/renderer/components/TabBar/types.ts
+++ b/src/renderer/components/TabBar/types.ts
@@ -1,4 +1,5 @@
 import type { AITab, Theme, UnifiedTab } from '../../types';
+import type { CopyContextOptions } from '../../hooks/tabs/useTabExportHandlers';
 
 export interface TabBarProps {
 	tabs: AITab[];
@@ -28,7 +29,7 @@ export interface TabBarProps {
 	/** Handler to summarize and continue in a new tab */
 	onSummarizeAndContinue?: (tabId: string) => void;
 	/** Handler to copy conversation context to clipboard */
-	onCopyContext?: (tabId: string) => void;
+	onCopyContext?: (tabId: string, options?: CopyContextOptions) => void;
 	/** Handler to export tab as HTML */
 	onExportHtml?: (tabId: string) => void;
 	/** Handler to publish tab context as GitHub Gist */

--- a/src/renderer/hooks/tabs/useTabExportHandlers.ts
+++ b/src/renderer/hooks/tabs/useTabExportHandlers.ts
@@ -12,7 +12,7 @@
 import { useCallback } from 'react';
 import type { Session, Theme, AITab } from '../../types';
 import { useTabStore } from '../../stores/tabStore';
-import { formatLogsForClipboard } from '../../utils/contextExtractor';
+import { formatLogsForClipboard, hasThinkingEntries } from '../../utils/contextExtractor';
 import { notifyToast } from '../../stores/notificationStore';
 import { flashCopiedToClipboard } from '../../utils/flashCopiedToClipboard';
 import { logger } from '../../utils/logger';
@@ -37,9 +37,17 @@ export interface UseTabExportHandlersDeps {
 // Return type
 // ============================================================================
 
+export interface CopyContextOptions {
+	/** Include reasoning/thinking blocks in the copied text. Defaults to false. */
+	includeThinking?: boolean;
+}
+
 export interface UseTabExportHandlersReturn {
-	/** Copy tab conversation to clipboard */
-	handleCopyContext: (tabId: string) => void;
+	/**
+	 * Copy tab conversation to clipboard.
+	 * Pass `{ includeThinking: true }` to include reasoning/thinking blocks.
+	 */
+	handleCopyContext: (tabId: string, options?: CopyContextOptions) => void;
 	/** Export tab as HTML file download */
 	handleExportHtml: (tabId: string) => Promise<void>;
 	/** Open Gist publish modal with tab content */
@@ -71,11 +79,16 @@ export function useTabExportHandlers(deps: UseTabExportHandlersDeps): UseTabExpo
 		return { session: currentSession, tab };
 	};
 
-	const handleCopyContext = useCallback((tabId: string) => {
+	const handleCopyContext = useCallback((tabId: string, options?: CopyContextOptions) => {
 		const resolved = resolveSessionAndTab(tabId);
 		if (!resolved) return;
 
-		const text = formatLogsForClipboard(resolved.tab.logs);
+		const includeThinking = options?.includeThinking ?? false;
+		// Only claim "with reasoning" when the tab actually has reasoning entries —
+		// the flag alone isn't enough, since a caller could opt in to thinking on
+		// a tab whose reasoning blocks have all been cleared.
+		const hadThinking = includeThinking && hasThinkingEntries(resolved.tab.logs);
+		const text = formatLogsForClipboard(resolved.tab.logs, { includeThinking });
 		if (!text.trim()) {
 			notifyToast({
 				type: 'warning',
@@ -88,7 +101,10 @@ export function useTabExportHandlers(deps: UseTabExportHandlersDeps): UseTabExpo
 		navigator.clipboard
 			.writeText(text)
 			.then(() => {
-				flashCopiedToClipboard(undefined, 'Conversation Copied');
+				flashCopiedToClipboard(
+					undefined,
+					hadThinking ? 'Conversation Copied (with reasoning)' : 'Conversation Copied'
+				);
 			})
 			.catch((err) => {
 				logger.error('Failed to copy context:', undefined, err);
@@ -152,8 +168,8 @@ export function useTabExportHandlers(deps: UseTabExportHandlersDeps): UseTabExpo
 			resolved.tab.name || (resolved.tab.agentSessionId?.slice(0, 8) ?? 'conversation');
 		const filename = `${tabName.replace(/[^a-zA-Z0-9-_]/g, '_')}_context.md`;
 
-		// Set content and open the modal
-		useTabStore.getState().setTabGistContent({ filename, content });
+		// Set content (with raw logs so the modal can re-format on toggle) and open the modal
+		useTabStore.getState().setTabGistContent({ filename, content, sourceLogs: resolved.tab.logs });
 		setGistPublishModalOpen(true);
 	}, []);
 

--- a/src/renderer/stores/tabStore.ts
+++ b/src/renderer/stores/tabStore.ts
@@ -25,7 +25,7 @@
  */
 
 import { create } from 'zustand';
-import type { AITab, FilePreviewTab, Session } from '../types';
+import type { AITab, FilePreviewTab, Session, LogEntry } from '../types';
 import type { GistInfo } from '../components/GistPublishModal';
 import {
 	createTab as createTabHelper,
@@ -63,7 +63,17 @@ import { useSessionStore, selectActiveSession } from './sessionStore';
 
 export interface TabStoreState {
 	// Gist publishing state (moved from App.tsx local state)
-	tabGistContent: { filename: string; content: string; messageId?: string } | null;
+	tabGistContent: {
+		filename: string;
+		content: string;
+		messageId?: string;
+		/**
+		 * Raw log entries that produced `content`. When present, the publish modal
+		 * can re-format the body (e.g. to opt in to reasoning/thinking blocks)
+		 * without going back through the caller.
+		 */
+		sourceLogs?: LogEntry[];
+	} | null;
 	fileGistUrls: Record<string, GistInfo>;
 	/**
 	 * Pending terminal buffer content queued for "Send to Agent".
@@ -77,9 +87,7 @@ export interface TabStoreState {
 export interface TabStoreActions {
 	// === Gist UI state ===
 
-	setTabGistContent: (
-		content: { filename: string; content: string; messageId?: string } | null
-	) => void;
+	setTabGistContent: (content: TabStoreState['tabGistContent']) => void;
 	setPendingTerminalBufferSend: (pending: { content: string; sourceName: string } | null) => void;
 	setFileGistUrls: (urls: Record<string, GistInfo>) => void;
 	setFileGistUrl: (path: string, info: GistInfo) => void;

--- a/src/renderer/utils/contextExtractor.ts
+++ b/src/renderer/utils/contextExtractor.ts
@@ -648,13 +648,25 @@ export function calculateTotalTokens(contexts: ContextSource[]): number {
 	return contexts.reduce((total, context) => total + estimateTokenCount(context), 0);
 }
 
+export interface FormatLogsOptions {
+	/**
+	 * Include `source: 'thinking'` entries in the output, labeled as `THINKING:`.
+	 * Defaults to false — thinking blocks can be verbose and most exports want
+	 * just the user/assistant dialogue.
+	 */
+	includeThinking?: boolean;
+}
+
 /**
  * Convert log entries to a simple text format for clipboard copying.
- * Only includes user messages and AI responses - excludes thinking, system prompts,
- * tool calls, and other internal entries.
+ *
+ * By default only user messages and AI responses are included. Pass
+ * `{ includeThinking: true }` to also include reasoning blocks — the HTML
+ * export already includes them, so this option lets clipboard/gist match.
  *
  * @param logs - Array of log entries to convert
- * @returns Plain text with USER/ASSISTANT labels
+ * @param options - Optional inclusion flags
+ * @returns Plain text with USER/ASSISTANT/THINKING labels
  *
  * @example
  * const text = formatLogsForClipboard(tab.logs);
@@ -665,7 +677,8 @@ export function calculateTotalTokens(contexts: ContextSource[]): number {
  * // ASSISTANT:
  * // To implement feature X, you should...
  */
-export function formatLogsForClipboard(logs: LogEntry[]): string {
+export function formatLogsForClipboard(logs: LogEntry[], options: FormatLogsOptions = {}): string {
+	const { includeThinking = false } = options;
 	const sections: string[] = [];
 
 	for (const log of logs) {
@@ -680,11 +693,27 @@ export function formatLogsForClipboard(logs: LogEntry[]): string {
 			sections.push(`USER:\n${log.text}`);
 		} else if (log.source === 'ai' || log.source === 'stdout') {
 			sections.push(`ASSISTANT:\n${log.text}`);
+		} else if (log.source === 'thinking' && includeThinking) {
+			sections.push(`THINKING:\n${log.text}`);
 		}
-		// Skip: thinking, tool, system, stderr, error
+		// Skip: tool, system, stderr, error (and thinking when not opted in)
 	}
 
 	return sections.join('\n\n');
+}
+
+/**
+ * Whether a log array contains any reasoning/thinking entries with non-empty text.
+ * Used to decide whether to surface the "Include reasoning" toggle in export UIs.
+ */
+export function hasThinkingEntries(logs: LogEntry[] | undefined | null): boolean {
+	if (!logs) return false;
+	for (const log of logs) {
+		if (log.source === 'thinking' && log.text && log.text.trim() !== '') {
+			return true;
+		}
+	}
+	return false;
 }
 
 /**


### PR DESCRIPTION
Closes #560.

## Summary

- HTML export already includes reasoning/thinking blocks; clipboard copy and Gist publish were silently stripping them. This adds opt-in inclusion to both, with the same `THINKING:` label HTML uses, so the three export surfaces stay consistent.
- Toggle is per-export, not a global setting (per the issue's UX guidance).
- Both UI affordances are conditional — they only appear when the tab actually contains reasoning entries, so they don't clutter the menu/modal for agents without thinking output.

## What changed

| Surface | Before | After |
| --- | --- | --- |
| Copy Context (clipboard) | Thinking excluded | New tab overlay entry "Context: Copy with Reasoning" (only shown when tab has thinking entries) |
| Publish as Gist | Thinking excluded | "Include reasoning/thinking logs" checkbox in `GistPublishModal` (only shown when the source logs have thinking entries); default off |
| Export as HTML | Already included | No change |

## Implementation notes

- ` formatLogsForClipboard()` gains an optional `{ includeThinking?: boolean }` argument. When true, `source: 'thinking'` entries are emitted with a `THINKING:` header alongside `USER:` / `ASSISTANT:`. Tool, system, stderr, and error entries remain excluded.
- New `hasThinkingEntries()` helper drives the conditional visibility for the menu item and modal toggle.
- `tabGistContent` in `tabStore` carries an optional `sourceLogs?: LogEntry[]` so the modal can re-format on toggle without round-tripping through the caller.
- `onCopyContext` prop signature widened to `(tabId: string, options?: CopyContextOptions) => void` at all five declaration sites; existing callers don't need to change.

## Test plan

- [x] `tsc --noEmit -p tsconfig.renderer.json` clean
- [x] `tsc --noEmit -p tsconfig.tests.json` clean
- [x] ESLint clean on all changed files
- [x] Prettier clean
- [x] `vitest run` on scoped tests: 139/0 in changed test files, 302/0 in TabBar/MainPanel — no regressions
- [x] 10 new unit cases for `formatLogsForClipboard` (default vs `{ includeThinking: true }`, empty entries, tool/system/stderr still excluded, etc.) and `hasThinkingEntries`
- [x] New hook tests for `includeThinking` pass-through, "with reasoning" toast variant, and `sourceLogs` forwarding to the publish modal
- [ ] Manual smoke: open a Claude Code tab with reasoning, verify the new overlay menu entry appears, verify the Gist modal checkbox appears and toggles content correctly
- [ ] Manual smoke: open a tab without reasoning entries (e.g. plain shell-style output), verify neither affordance appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Copy with Reasoning" option to include thinking logs when copying context to clipboard
  * Added toggle in gist publishing modal to optionally include reasoning logs in published content

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RunMaestro/Maestro/pull/1008?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->