### PR TITLE
Fix obvious RC Sentry field crashes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -292,6 +292,35 @@ jobs:
         env:
           DEBUG: electron-builder
 
+      # Verify native modules are correctly included in unpacked resources (Windows x64)
+      - name: Verify native modules in package (Windows)
+        if: matrix.platform == 'win'
+        shell: pwsh
+        run: |
+          $unpackedDir = "release/win-unpacked/resources/app.asar.unpacked"
+          $nativeModules = @(
+            "node_modules/node-pty/build/Release/pty.node",
+            "node_modules/better-sqlite3/build/Release/better_sqlite3.node"
+          )
+
+          foreach ($relativePath in $nativeModules) {
+            $nativePath = Join-Path $unpackedDir $relativePath
+            Write-Host "Checking for $relativePath in unpacked resources..."
+            if (Test-Path $nativePath) {
+              Get-Item $nativePath | Format-List FullName,Length
+            } else {
+              Write-Error "ERROR: $relativePath not found in unpacked resources"
+              Write-Host "Available native modules:"
+              if (Test-Path $unpackedDir) {
+                Get-ChildItem -Path $unpackedDir -Filter *.node -Recurse -ErrorAction SilentlyContinue |
+                  Select-Object -ExpandProperty FullName
+              } else {
+                Write-Host "Directory not found: $unpackedDir"
+              }
+              exit 1
+            }
+          }
+
       # Linux/macOS: Rebuild native modules for the target arch, verify, then package.
       # npmRebuild: false in package.json prevents electron-builder from re-running npm rebuild,
       # so we ensure correct binaries are in place first via the shared script.

--- a/src/__tests__/main/cue/cue-github-poller.test.ts
+++ b/src/__tests__/main/cue/cue-github-poller.test.ts
@@ -82,6 +82,7 @@ vi.mock('../../../main/cue/cue-db', () => ({
 
 import {
 	createCueGitHubPoller,
+	isGitHubConnectivityError,
 	isGitHubRateLimitError,
 	GITHUB_RATE_LIMIT_MAX_BACKOFF_MS,
 	type CueGitHubPollerConfig,
@@ -909,6 +910,26 @@ describe('cue-github-poller', () => {
 		});
 	});
 
+	describe('connectivity detection (isGitHubConnectivityError)', () => {
+		it('matches GitHub CLI connection failures', () => {
+			expect(
+				isGitHubConnectivityError(
+					new Error(
+						'error connecting to api.github.com\ncheck your internet connection or https://githubstatus.com'
+					)
+				)
+			).toBe(true);
+		});
+
+		it('matches DNS failures', () => {
+			expect(isGitHubConnectivityError(new Error('ENOTFOUND api.github.com'))).toBe(true);
+		});
+
+		it('does not match auth/configuration failures', () => {
+			expect(isGitHubConnectivityError(new Error('gh auth login required'))).toBe(false);
+		});
+	});
+
 	// ─── Phase 12C + 13A: backoff + Sentry behavior ────────────────────────
 	describe('rate-limit backoff and Sentry reporting', () => {
 		it('emits rateLimitBackoff payload on rate-limit error without Sentry', async () => {
@@ -932,9 +953,25 @@ describe('cue-github-poller', () => {
 			cleanup();
 		});
 
-		it('reports non-rate-limit errors to Sentry with cue:github:doPoll tag', async () => {
+		it('does not report GitHub connectivity errors to Sentry', async () => {
 			const config = makeConfig();
 			setupExecFileReject('pr list', 'ENOTFOUND api.github.com');
+			mockExecFile.mockImplementationOnce((_c, _a, _o, cb) => cb(null, '2.0.0', ''));
+
+			const cleanup = createCueGitHubPoller(config);
+			await vi.advanceTimersByTimeAsync(2100);
+
+			const sentryCalls = mockCaptureException.mock.calls.filter(
+				(c) => (c[1] as { operation: string }).operation === 'cue:github:doPoll'
+			);
+			expect(sentryCalls).toHaveLength(0);
+
+			cleanup();
+		});
+
+		it('reports non-rate-limit/non-connectivity errors to Sentry with cue:github:doPoll tag', async () => {
+			const config = makeConfig();
+			setupExecFileReject('pr list', 'gh auth login required');
 			mockExecFile.mockImplementationOnce((_c, _a, _o, cb) => cb(null, '2.0.0', ''));
 
 			const cleanup = createCueGitHubPoller(config);

--- a/src/__tests__/main/group-chat/group-chat-router.test.ts
+++ b/src/__tests__/main/group-chat/group-chat-router.test.ts
@@ -46,6 +46,11 @@ vi.mock('../../../main/utils/ssh-spawn-wrapper', () => ({
 	wrapSpawnWithSsh: (...args: unknown[]) => mockWrapSpawnWithSsh(...args),
 }));
 
+const mockCaptureException = vi.fn();
+vi.mock('../../../main/utils/sentry', () => ({
+	captureException: (...args: unknown[]) => mockCaptureException(...args),
+}));
+
 vi.mock('../../../main/prompt-manager', () => ({
 	getPrompt: vi.fn((id: string) => {
 		const fs = require('fs');
@@ -860,6 +865,30 @@ describe('group-chat-router', () => {
 				call[0].sessionId?.includes(`group-chat-${chat.id}-participant-Client-`)
 			);
 			expect(participantSpawns).toHaveLength(1);
+		});
+
+		it('does not report auto-add races after the moderator has stopped', async () => {
+			const chat = await createTestChatWithModerator('Auto Add Stopped Moderator Test');
+			clearAllModeratorSessions();
+			mockCaptureException.mockClear();
+			setGetSessionsCallback(() => [
+				{
+					id: 'session-client',
+					name: 'Client',
+					toolType: 'claude-code',
+					cwd: '/tmp/project',
+				},
+			]);
+
+			await routeModeratorResponse(
+				chat.id,
+				'@Client: Please create the requested file',
+				mockProcessManager,
+				mockAgentDetector
+			);
+
+			expect(mockCaptureException).not.toHaveBeenCalled();
+			expect((await loadGroupChat(chat.id))?.participants).toEqual([]);
 		});
 	});
 

--- a/src/__tests__/shared/sentryFilters.test.ts
+++ b/src/__tests__/shared/sentryFilters.test.ts
@@ -160,6 +160,17 @@ describe('shouldDropSentryEvent', () => {
 			).toBe(true);
 		});
 
+		it('drops GitHub CLI network failures when the user is offline', () => {
+			expect(
+				shouldDropSentryEvent(
+					exceptionEvent(
+						'Error',
+						'Command failed: gh pr list\nerror connecting to api.github.com\ncheck your internet connection'
+					)
+				)
+			).toBe(true);
+		});
+
 		it('drops shell PATH probe timeouts', () => {
 			expect(shouldDropSentryEvent(exceptionEvent('Error', 'Timed out reading shell PATH'))).toBe(
 				true

--- a/src/main/cue/cue-github-poller.ts
+++ b/src/main/cue/cue-github-poller.ts
@@ -94,6 +94,35 @@ export function isGitHubRateLimitError(err: unknown): boolean {
 	);
 }
 
+/**
+ * Detect connectivity failures from the GitHub CLI. These are operational
+ * conditions (offline/VPN/DNS/GitHub unreachable), not app crashes.
+ */
+export function isGitHubConnectivityError(err: unknown): boolean {
+	const msg = (
+		err && typeof err === 'object' && 'message' in err && typeof err.message === 'string'
+			? err.message
+			: String(err ?? '')
+	).toLowerCase();
+	const stderr =
+		err &&
+		typeof err === 'object' &&
+		'stderr' in err &&
+		typeof (err as { stderr: unknown }).stderr === 'string'
+			? (err as { stderr: string }).stderr.toLowerCase()
+			: '';
+	const haystack = `${msg}\n${stderr}`;
+	return (
+		haystack.includes('error connecting to api.github.com') ||
+		haystack.includes('check your internet connection') ||
+		haystack.includes('enotfound api.github.com') ||
+		haystack.includes('econnreset') ||
+		haystack.includes('etimedout') ||
+		haystack.includes('network is unreachable') ||
+		haystack.includes('could not resolve host: api.github.com')
+	);
+}
+
 /** Expanded env so packaged Electron can find gh in /opt/homebrew/bin, /usr/local/bin, etc. */
 const ghEnv = getExpandedEnv();
 
@@ -542,6 +571,11 @@ export function createCueGitHubPoller(config: CueGitHubPollerConfig): () => void
 					'warn',
 					`[CUE] "${triggerName}" rate-limited by GitHub — backing off to ${backoffMin}m`,
 					payload
+				);
+			} else if (isGitHubConnectivityError(err)) {
+				onLog(
+					'warn',
+					`[CUE] GitHub poll skipped for "${triggerName}" because GitHub is unreachable: ${message}`
 				);
 			} else {
 				// Emit typed payload so the metric interceptor bumps the

--- a/src/main/group-chat/group-chat-router.ts
+++ b/src/main/group-chat/group-chat-router.ts
@@ -54,6 +54,14 @@ const LOG_CONTEXT = '[GroupChatRouter]';
 // Re-export setGetCustomShellPathCallback for index.ts to use
 export { setGetCustomShellPathCallback };
 
+function isModeratorInactiveAutoAddRace(error: unknown, groupChatId: string): boolean {
+	if (!(error instanceof Error)) return false;
+	return (
+		error.message ===
+		`Moderator must be active before adding participants to group chat: ${groupChatId}`
+	);
+}
+
 /**
  * Session info for matching @mentions to available Maestro sessions.
  */
@@ -620,6 +628,14 @@ export async function routeUserMessage(
 						);
 					}
 				} catch (error) {
+					if (isModeratorInactiveAutoAddRace(error, groupChatId)) {
+						logger.warn(
+							`Skipped auto-adding participant ${mentionedName}: moderator is no longer active`,
+							LOG_CONTEXT,
+							{ groupChatId }
+						);
+						continue;
+					}
 					logger.error(
 						`Failed to auto-add participant ${mentionedName} from user mention`,
 						LOG_CONTEXT,
@@ -1033,6 +1049,14 @@ export async function routeModeratorResponse(
 						);
 					}
 				} catch (error) {
+					if (isModeratorInactiveAutoAddRace(error, groupChatId)) {
+						logger.warn(
+							`Skipped auto-adding participant ${mentionedName}: moderator is no longer active`,
+							LOG_CONTEXT,
+							{ groupChatId }
+						);
+						continue;
+					}
 					logger.error(`Failed to auto-add participant ${mentionedName}`, LOG_CONTEXT, {
 						error,
 						groupChatId,

--- a/src/shared/sentryFilters.ts
+++ b/src/shared/sentryFilters.ts
@@ -130,6 +130,13 @@ export function shouldDropSentryEvent(event: MinimalSentryEvent): boolean {
 	// ---- 5. Network failures (user offline) ----
 
 	if (/MarketplaceFetchError: Network error fetching .*: fetch failed/i.test(haystack)) return true;
+	if (
+		/error connecting to api\.github\.com/i.test(haystack) ||
+		/check your internet connection/i.test(haystack) ||
+		/ENOTFOUND api\.github\.com/i.test(haystack)
+	) {
+		return true;
+	}
 
 	// ---- 6. Shell detection failures ----
 


### PR DESCRIPTION
## Summary
- Treat GitHub CLI connectivity failures from Cue polling as operational offline/unreachable states instead of Sentry crashes, with shared filter coverage for already-captured network noise.
- Suppress the group-chat auto-add race that happens when the moderator is no longer active before a mentioned participant is added.
- Add a Windows release packaging guard for required native modules, including better-sqlite3, so RC artifacts fail CI if unpacked native bindings are missing.

## Sentry
- Addresses MAESTRO-Q0, MAESTRO-KE, MAESTRO-K5: gh pr list connectivity failures in rc Cue polling.
- Addresses MAESTRO-NK: groupChat:autoAddParticipant moderator inactive race.
- Guards against recurrence of MAESTRO-Q3 / MAESTRO-JV Windows native binding package failures.

## Validation
- npx vitest run src/__tests__/main/cue/cue-github-poller.test.ts src/__tests__/main/group-chat/group-chat-router.test.ts src/__tests__/shared/sentryFilters.test.ts
- npm run lint
- npm run lint:eslint
- npm run test
- npm run build
- git push pre-push gate: format:check:all, lint, lint:eslint, test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of GitHub connectivity failures to prevent false error reporting when offline or experiencing network issues.
  * Enhanced group chat participant auto-add logic to gracefully handle race conditions when a moderator becomes inactive.

* **Tests**
  * Added test coverage for GitHub connectivity error detection and group chat routing scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RunMaestro/Maestro/pull/1011?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->