### PR TITLE
fix(autorun): surface document stalls in a toast (#235)

### DIFF
--- a/src/renderer/hooks/batch/internal/useBatchRunner.ts
+++ b/src/renderer/hooks/batch/internal/useBatchRunner.ts
@@ -920,6 +920,12 @@ export function useBatchRunner({
 									}
 								);
 
+								// Whether another playbook document follows this one. `documents.length > 1`
+								// was wrong for the last doc in a multi-doc run — it would tell the
+								// user we were skipping to the next document when the batch was
+								// actually about to end.
+								const hasNextDocument = docIndex < documents.length - 1;
+
 								// Add a history entry specifically for this stalled document
 								const stallExplanation = [
 									`**Document Stalled: ${docEntry.filename}**`,
@@ -937,7 +943,7 @@ export function useBatchRunner({
 									'',
 									`**Remaining unchecked tasks:** ${newRemainingTasks}`,
 									'',
-									documents.length > 1
+									hasNextDocument
 										? `Skipping to the next document in the playbook...`
 										: `No more documents to process.`,
 								].join('\n');
@@ -960,10 +966,9 @@ export function useBatchRunner({
 								notifyToast({
 									type: 'warning',
 									title: isWatchdogFailure ? 'Auto Run agent stalled' : 'Auto Run document stalled',
-									message:
-										documents.length > 1
-											? `${docEntry.filename}: ${newRemainingTasks} task${newRemainingTasks === 1 ? '' : 's'} remaining. Skipping to next document.`
-											: `${docEntry.filename}: ${newRemainingTasks} task${newRemainingTasks === 1 ? '' : 's'} remaining. No more documents to process.`,
+									message: hasNextDocument
+										? `${docEntry.filename}: ${newRemainingTasks} task${newRemainingTasks === 1 ? '' : 's'} remaining. Skipping to next document.`
+										: `${docEntry.filename}: ${newRemainingTasks} task${newRemainingTasks === 1 ? '' : 's'} remaining. No more documents to process.`,
 									project: session.name,
 									sessionId,
 								});

--- a/src/renderer/hooks/batch/internal/useBatchRunner.ts
+++ b/src/renderer/hooks/batch/internal/useBatchRunner.ts
@@ -952,6 +952,22 @@ export function useBatchRunner({
 									success: false, // Mark as unsuccessful since we couldn't complete
 								});
 
+								// Surface the stall in a toast so the user sees it without having to
+								// open the history panel — pre-toast, silent stalls (token exhaustion,
+								// watchdog timeouts, agents that loop writing "I did nothing" notes)
+								// could go unnoticed for hours. Yellow/warning conveys "we noticed
+								// something is wrong and stopped this doc," click jumps to the session.
+								notifyToast({
+									type: 'warning',
+									title: isWatchdogFailure ? 'Auto Run agent stalled' : 'Auto Run document stalled',
+									message:
+										documents.length > 1
+											? `${docEntry.filename}: ${newRemainingTasks} task${newRemainingTasks === 1 ? '' : 's'} remaining. Skipping to next document.`
+											: `${docEntry.filename}: ${newRemainingTasks} task${newRemainingTasks === 1 ? '' : 's'} remaining. No more documents to process.`,
+									project: session.name,
+									sessionId,
+								});
+
 								// Skip to the next document instead of breaking the entire batch
 								break; // Break out of the inner while loop for this document
 							}


### PR DESCRIPTION
## Summary

Auto Run already detected per-document stalls (3 consecutive runs with no task-level progress, plus immediate-skip on watchdog stall/timeout) and wrote a history entry explaining what happened. But the only user-visible signal was that history entry — easy to miss during a long parallel run, which was exactly the failure mode reported in #235 (a 24-hour session with a ~4-hour silent gap).

This PR adds a yellow/warning toast next to the existing history entry write in `useBatchRunner.ts`. The toast:

- Distinguishes agent-level stalls (watchdog stalled / watchdog timeout — the path most likely to surface token exhaustion or process hangs) from the no-progress heuristic (\"agent wrote prose instead of doing work\").
- Tells the user whether we're moving to the next document or done.
- Sets `sessionId` + `project` so clicking it jumps to the session, where the existing history entry has the full diagnostic.

## Issues addressed

- **#235** — Token Exhaustion UX in Auto-Run Mode. Closes the visibility gap so silent stalls (token exhaustion is one cause, watchdog timeouts are another) get a UI notification instead of only a log + history entry.
- **#231** — Playbook Exit Condition Detection. Already shipped: the \`<!-- maestro:halt -->\` marker in \`src/cli/services/batch-processor.ts:41\` is the documented exit mechanism (pre-execution scan + mid-loop detection + halt event + full test coverage in \`batch-processor.test.ts\`). Will close that issue with a pointer rather than adding a redundant sentinel-file convention.

## Test plan

- [x] `npm run lint` clean
- [x] Prettier clean
- [x] ESLint clean
- [x] `npx vitest run src/__tests__/renderer/hooks/batch/` → 148 passed
- [x] `npx vitest run src/__tests__/renderer/components/AutoRun.test.tsx src/__tests__/cli/services/batch-processor.test.ts` → 236 passed
- [ ] Manual: run a playbook with a doc whose tasks the agent can't act on (e.g. \"figure out the meaning of life\") and confirm the toast fires after 3 no-progress iterations and clicking it jumps to the session.
- [ ] Manual: kill the agent process mid-run to trigger \`watchdog-stalled\` and confirm the \"agent stalled\" toast variant fires immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added warning notifications for stalled documents during batch processing that distinguish watchdog timeouts from generic stalls and tailor messages when the final document reports "No more documents to process" instead of suggesting skipping to the next document.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RunMaestro/Maestro/pull/1012?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->