### PR TITLE
fix(cli): persist CLI-created agent to disk before responding

### DIFF
--- a/src/renderer/hooks/remote/useAppRemoteEventListeners.ts
+++ b/src/renderer/hooks/remote/useAppRemoteEventListeners.ts
@@ -1015,6 +1015,20 @@ export function useAppRemoteEventListeners(deps: UseAppRemoteEventListenersDeps)
 				isRemote: false,
 			});
 
+			// Persist the new agent to disk synchronously before responding. The
+			// renderer's debounced persistence path (useDebouncedPersistence) is
+			// driven by React render cycles and a 2s timer, so a CLI consumer that
+			// runs `create-agent` and then immediately `list agents` / `send` would
+			// otherwise hit the disk-backed CLI storage layer before the in-memory
+			// session has been flushed — surfacing as `AGENT_NOT_FOUND` (issue #1013).
+			// `setMany` is incremental and idempotent: the debounced flush that
+			// follows simply rewrites the same row.
+			try {
+				await window.maestro.sessions.setMany([newSession], []);
+			} catch (persistErr) {
+				logger.error('[Remote] Failed to persist new CLI-created session:', undefined, persistErr);
+			}
+
 			window.maestro.process.sendRemoteCreateSessionResponse(responseChannel, {
 				sessionId: newId,
 			});


### PR DESCRIPTION
## Summary

- The `maestro:remoteCreateSession` handler relied on the renderer's 2-second debounced persistence to flush the new agent. A CLI consumer that ran `maestro-cli create-agent` and immediately followed up with `list agents` / `send` / `show agent` hit the disk-backed CLI storage before the flush fired, surfacing as `AGENT_NOT_FOUND`.
- Force an immediate `sessions:setMany` write before sending the `create_session_result`, so the CLI contract "create returned success → the agent is on disk" holds. The subsequent debounced flush is idempotent — it just rewrites the same row.

Closes #1013

## Test plan

- [ ] Start Maestro desktop
- [ ] `maestro-cli create-agent "Test Agent" --cwd <path> --json` → agent shows in Left Bar
- [ ] `maestro-cli list agents --json` → returns the new agent (previously returned `[]`)
- [ ] `maestro-cli send <id> "test"` → succeeds (previously returned `AGENT_NOT_FOUND`)
- [ ] Inspect `%APPDATA%/Maestro/maestro-sessions.json` (or `~/Library/Application Support/Maestro/maestro-sessions.json`) → contains the agent immediately after `create-agent` returns
- [ ] `npm run lint` passes
- [ ] `npx vitest run src/__tests__/renderer/hooks/utils/useDebouncedPersistence.test.ts src/__tests__/cli/commands/create-agent.test.ts src/__tests__/main/web-server/handlers/messageHandlers.test.ts` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Session creation has been enhanced to ensure newly created sessions are reliably persisted. Improved error handling provides a smoother user experience by gracefully managing any temporary persistence issues without disrupting the workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RunMaestro/Maestro/pull/1014?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->