### PR TITLE
Add Paseo schedule commands to Maestro CLI

### DIFF
--- a/src/__tests__/cli/commands/paseo.test.ts
+++ b/src/__tests__/cli/commands/paseo.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach, afterEach, type MockInstance } from 'vitest';
+
+vi.mock('../../../cli/services/paseo', () => ({
+	createPaseoSchedule: vi.fn(),
+	listPaseoSchedules: vi.fn(),
+	getPaseoScheduleLogs: vi.fn(),
+}));
+
+vi.mock('../../../cli/output/formatter', () => ({
+	formatError: vi.fn((message: string) => `Error: ${message}`),
+}));
+
+import {
+	paseoScheduleCreate,
+	paseoScheduleList,
+	paseoScheduleLogs,
+} from '../../../cli/commands/paseo';
+import {
+	createPaseoSchedule,
+	getPaseoScheduleLogs,
+	listPaseoSchedules,
+} from '../../../cli/services/paseo';
+
+describe('paseo command', () => {
+	let consoleSpy: MockInstance;
+	let consoleErrorSpy: MockInstance;
+	let processExitSpy: MockInstance;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+		consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+		processExitSpy = vi
+			.spyOn(process, 'exit')
+			.mockImplementation((code?: string | number | null | undefined) => {
+				throw new Error(`process.exit(${code})`);
+			});
+	});
+
+	afterEach(() => {
+		consoleSpy.mockRestore();
+		consoleErrorSpy.mockRestore();
+		processExitSpy.mockRestore();
+	});
+
+	it('creates a Paseo schedule and prints stdout', async () => {
+		vi.mocked(createPaseoSchedule).mockResolvedValue({
+			stdout: 'ID NAME\nabc demo\n',
+			stderr: '',
+		});
+
+		await paseoScheduleCreate('do work', {
+			every: '2m',
+			name: 'demo',
+			provider: 'codex',
+			cwd: '/repo',
+			maxRuns: '2',
+			expiresIn: '10m',
+		});
+
+		expect(createPaseoSchedule).toHaveBeenCalledWith('do work', {
+			every: '2m',
+			name: 'demo',
+			provider: 'codex',
+			cwd: '/repo',
+			maxRuns: '2',
+			expiresIn: '10m',
+		});
+		expect(consoleSpy).toHaveBeenCalledWith('ID NAME\nabc demo');
+		expect(processExitSpy).not.toHaveBeenCalled();
+	});
+
+	it('lists schedules', async () => {
+		vi.mocked(listPaseoSchedules).mockResolvedValue({ stdout: 'schedules\n', stderr: '' });
+
+		await paseoScheduleList({ json: true, host: '127.0.0.1:6767' });
+
+		expect(listPaseoSchedules).toHaveBeenCalledWith({
+			json: true,
+			host: '127.0.0.1:6767',
+		});
+		expect(consoleSpy).toHaveBeenCalledWith('schedules');
+	});
+
+	it('shows schedule logs', async () => {
+		vi.mocked(getPaseoScheduleLogs).mockResolvedValue({ stdout: 'logs\n', stderr: '' });
+
+		await paseoScheduleLogs('abc123', { cliPath: '/bin/paseo' });
+
+		expect(getPaseoScheduleLogs).toHaveBeenCalledWith('abc123', { cliPath: '/bin/paseo' });
+		expect(consoleSpy).toHaveBeenCalledWith('logs');
+	});
+
+	it('prints JSON errors when json mode is enabled', async () => {
+		vi.mocked(listPaseoSchedules).mockRejectedValue(new Error('daemon unavailable'));
+
+		await expect(paseoScheduleList({ json: true })).rejects.toThrow('process.exit(1)');
+
+		const output = JSON.parse(consoleErrorSpy.mock.calls[0][0]);
+		expect(output).toEqual({ success: false, error: 'daemon unavailable' });
+	});
+
+	it('prints human-readable errors otherwise', async () => {
+		vi.mocked(listPaseoSchedules).mockRejectedValue(new Error('daemon unavailable'));
+
+		await expect(paseoScheduleList({})).rejects.toThrow('process.exit(1)');
+
+		expect(consoleErrorSpy).toHaveBeenCalledWith('Error: daemon unavailable');
+	});
+});

--- a/src/__tests__/cli/commands/paseo.test.ts
+++ b/src/__tests__/cli/commands/paseo.test.ts
@@ -4,6 +4,7 @@ vi.mock('../../../cli/services/paseo', () => ({
 	createPaseoSchedule: vi.fn(),
 	listPaseoSchedules: vi.fn(),
 	getPaseoScheduleLogs: vi.fn(),
+	runPaseoAgent: vi.fn(),
 }));
 
 vi.mock('../../../cli/output/formatter', () => ({
@@ -11,6 +12,7 @@ vi.mock('../../../cli/output/formatter', () => ({
 }));
 
 import {
+	paseoRun,
 	paseoScheduleCreate,
 	paseoScheduleList,
 	paseoScheduleLogs,
@@ -19,6 +21,7 @@ import {
 	createPaseoSchedule,
 	getPaseoScheduleLogs,
 	listPaseoSchedules,
+	runPaseoAgent,
 } from '../../../cli/services/paseo';
 
 describe('paseo command', () => {
@@ -67,6 +70,29 @@ describe('paseo command', () => {
 			expiresIn: '10m',
 		});
 		expect(consoleSpy).toHaveBeenCalledWith('ID NAME\nabc demo');
+		expect(processExitSpy).not.toHaveBeenCalled();
+	});
+
+	it('runs a titled Paseo agent and prints stdout', async () => {
+		vi.mocked(runPaseoAgent).mockResolvedValue({
+			stdout: 'agent-123\n',
+			stderr: '',
+		});
+
+		await paseoRun('do visible work', {
+			title: 'Visible Work',
+			provider: 'codex',
+			cwd: '/repo',
+			detach: true,
+		});
+
+		expect(runPaseoAgent).toHaveBeenCalledWith('do visible work', {
+			title: 'Visible Work',
+			provider: 'codex',
+			cwd: '/repo',
+			detach: true,
+		});
+		expect(consoleSpy).toHaveBeenCalledWith('agent-123');
 		expect(processExitSpy).not.toHaveBeenCalled();
 	});
 

--- a/src/__tests__/cli/services/paseo.test.ts
+++ b/src/__tests__/cli/services/paseo.test.ts
@@ -27,7 +27,10 @@ import {
 	runPaseoCommand,
 } from '../../../cli/services/paseo';
 
-function mockSpawnResult(code: number, stdout = '', stderr = ''): void {
+function mockSpawnChild(): EventEmitter & {
+	stdout: Readable;
+	stderr: Readable;
+} {
 	const child = new EventEmitter() as EventEmitter & {
 		stdout: Readable;
 		stderr: Readable;
@@ -36,6 +39,12 @@ function mockSpawnResult(code: number, stdout = '', stderr = ''): void {
 	child.stderr = new Readable({ read() {} });
 
 	vi.mocked(spawn).mockReturnValue(child as any);
+
+	return child;
+}
+
+function mockSpawnResult(code: number | null, stdout = '', stderr = ''): void {
+	const child = mockSpawnChild();
 
 	setImmediate(() => {
 		if (stdout) child.stdout.emit('data', Buffer.from(stdout));
@@ -101,6 +110,26 @@ describe('paseo service', () => {
 		await expect(runPaseoCommand(['bad'], { cliPath: '/bin/paseo' })).rejects.toThrow('bad option');
 	});
 
+	it('rejects failed Paseo commands that close without an exit code', async () => {
+		mockSpawnResult(null);
+
+		await expect(runPaseoCommand(['bad'], { cliPath: '/bin/paseo' })).rejects.toThrow(
+			'Paseo exited without an exit code'
+		);
+	});
+
+	it('rejects when the Paseo process fails to spawn', async () => {
+		const child = mockSpawnChild();
+
+		setImmediate(() => {
+			child.emit('error', new Error('ENOENT'));
+		});
+
+		await expect(
+			runPaseoCommand(['schedule', 'ls'], { cliPath: '/missing/paseo' })
+		).rejects.toThrow('Failed to run Paseo CLI (/missing/paseo): ENOENT');
+	});
+
 	it('builds schedule create arguments', async () => {
 		mockSpawnResult(0, 'created\n');
 
@@ -135,6 +164,36 @@ describe('paseo service', () => {
 				'--json',
 				'do work',
 			],
+			expect.any(Object)
+		);
+	});
+
+	it('builds schedule create arguments with explicit immediate run control', async () => {
+		mockSpawnResult(0, 'created\n');
+
+		await createPaseoSchedule('do work now', {
+			cliPath: '/bin/paseo',
+			every: '2m',
+			runNow: true,
+		});
+
+		expect(spawn).toHaveBeenLastCalledWith(
+			'/bin/paseo',
+			['schedule', 'create', '--every', '2m', '--run-now', 'do work now'],
+			expect.any(Object)
+		);
+
+		mockSpawnResult(0, 'created\n');
+
+		await createPaseoSchedule('do work later', {
+			cliPath: '/bin/paseo',
+			every: '2m',
+			runNow: false,
+		});
+
+		expect(spawn).toHaveBeenLastCalledWith(
+			'/bin/paseo',
+			['schedule', 'create', '--every', '2m', '--no-run-now', 'do work later'],
 			expect.any(Object)
 		);
 	});

--- a/src/__tests__/cli/services/paseo.test.ts
+++ b/src/__tests__/cli/services/paseo.test.ts
@@ -25,6 +25,7 @@ import {
 	listPaseoSchedules,
 	resolvePaseoCliPath,
 	runPaseoCommand,
+	runPaseoAgent,
 } from '../../../cli/services/paseo';
 
 function mockSpawnChild(): EventEmitter & {
@@ -194,6 +195,71 @@ describe('paseo service', () => {
 		expect(spawn).toHaveBeenLastCalledWith(
 			'/bin/paseo',
 			['schedule', 'create', '--every', '2m', '--no-run-now', 'do work later'],
+			expect.any(Object)
+		);
+	});
+
+	it('builds run arguments with title and detached execution by default', async () => {
+		mockSpawnResult(0, 'agent-123\n');
+
+		await runPaseoAgent('do visible work', {
+			cliPath: '/bin/paseo',
+			title: 'Visible Work',
+			provider: 'codex',
+			mode: 'bypass',
+			cwd: '/repo',
+			host: '127.0.0.1:6767',
+			json: true,
+		});
+
+		expect(spawn).toHaveBeenLastCalledWith(
+			'/bin/paseo',
+			[
+				'run',
+				'--title',
+				'Visible Work',
+				'--provider',
+				'codex',
+				'--mode',
+				'bypass',
+				'--cwd',
+				'/repo',
+				'--detach',
+				'--host',
+				'127.0.0.1:6767',
+				'--json',
+				'do visible work',
+			],
+			expect.any(Object)
+		);
+	});
+
+	it('builds run arguments without detach when explicitly disabled', async () => {
+		mockSpawnResult(0, 'done\n');
+
+		await runPaseoAgent('do foreground work', {
+			cliPath: '/bin/paseo',
+			title: 'Foreground Work',
+			model: 'gpt-5.4',
+			thinking: 'high',
+			detach: false,
+			waitTimeout: '5m',
+		});
+
+		expect(spawn).toHaveBeenLastCalledWith(
+			'/bin/paseo',
+			[
+				'run',
+				'--title',
+				'Foreground Work',
+				'--model',
+				'gpt-5.4',
+				'--thinking',
+				'high',
+				'--wait-timeout',
+				'5m',
+				'do foreground work',
+			],
 			expect.any(Object)
 		);
 	});

--- a/src/__tests__/cli/services/paseo.test.ts
+++ b/src/__tests__/cli/services/paseo.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('fs', () => ({
+	statSync: vi.fn(),
+	accessSync: vi.fn(),
+	constants: { X_OK: 1 },
+}));
+
+vi.mock('os', () => ({
+	platform: vi.fn(() => 'darwin'),
+}));
+
+vi.mock('child_process', () => ({
+	spawn: vi.fn(),
+}));
+
+import { EventEmitter } from 'events';
+import { Readable } from 'stream';
+import * as fs from 'fs';
+import * as os from 'os';
+import { spawn } from 'child_process';
+import {
+	createPaseoSchedule,
+	getPaseoScheduleLogs,
+	listPaseoSchedules,
+	resolvePaseoCliPath,
+	runPaseoCommand,
+} from '../../../cli/services/paseo';
+
+function mockSpawnResult(code: number, stdout = '', stderr = ''): void {
+	const child = new EventEmitter() as EventEmitter & {
+		stdout: Readable;
+		stderr: Readable;
+	};
+	child.stdout = new Readable({ read() {} });
+	child.stderr = new Readable({ read() {} });
+
+	vi.mocked(spawn).mockReturnValue(child as any);
+
+	setImmediate(() => {
+		if (stdout) child.stdout.emit('data', Buffer.from(stdout));
+		if (stderr) child.stderr.emit('data', Buffer.from(stderr));
+		child.emit('close', code);
+	});
+}
+
+describe('paseo service', () => {
+	const originalEnv = process.env.PASEO_CLI_PATH;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		delete process.env.PASEO_CLI_PATH;
+		vi.mocked(os.platform).mockReturnValue('darwin');
+		vi.mocked(fs.statSync).mockReturnValue({ isFile: () => true } as any);
+		vi.mocked(fs.accessSync).mockReturnValue(undefined);
+	});
+
+	afterEach(() => {
+		if (originalEnv === undefined) {
+			delete process.env.PASEO_CLI_PATH;
+		} else {
+			process.env.PASEO_CLI_PATH = originalEnv;
+		}
+	});
+
+	it('prefers an explicit CLI path', () => {
+		expect(resolvePaseoCliPath('/tmp/paseo')).toBe('/tmp/paseo');
+	});
+
+	it('uses PASEO_CLI_PATH before bundled defaults', () => {
+		process.env.PASEO_CLI_PATH = '/env/paseo';
+		expect(resolvePaseoCliPath()).toBe('/env/paseo');
+	});
+
+	it('uses the macOS bundled Paseo CLI when executable', () => {
+		expect(resolvePaseoCliPath()).toBe('/Applications/Paseo.app/Contents/Resources/bin/paseo');
+	});
+
+	it('falls back to PATH command when bundled CLI is unavailable', () => {
+		vi.mocked(fs.statSync).mockImplementation(() => {
+			throw new Error('missing');
+		});
+		expect(resolvePaseoCliPath()).toBe('paseo');
+	});
+
+	it('runs Paseo commands and returns output', async () => {
+		mockSpawnResult(0, 'ok\n', 'warn\n');
+
+		const result = await runPaseoCommand(['schedule', 'ls'], { cliPath: '/bin/paseo' });
+
+		expect(spawn).toHaveBeenCalledWith('/bin/paseo', ['schedule', 'ls'], {
+			env: process.env,
+			stdio: ['ignore', 'pipe', 'pipe'],
+		});
+		expect(result).toEqual({ stdout: 'ok\n', stderr: 'warn\n' });
+	});
+
+	it('rejects failed Paseo commands with stderr and exit code', async () => {
+		mockSpawnResult(2, '', 'bad option\n');
+
+		await expect(runPaseoCommand(['bad'], { cliPath: '/bin/paseo' })).rejects.toThrow('bad option');
+	});
+
+	it('builds schedule create arguments', async () => {
+		mockSpawnResult(0, 'created\n');
+
+		await createPaseoSchedule('do work', {
+			cliPath: '/bin/paseo',
+			every: '2m',
+			name: 'demo',
+			provider: 'codex',
+			cwd: '/repo',
+			maxRuns: '2',
+			expiresIn: '10m',
+			json: true,
+		});
+
+		expect(spawn).toHaveBeenCalledWith(
+			'/bin/paseo',
+			[
+				'schedule',
+				'create',
+				'--every',
+				'2m',
+				'--name',
+				'demo',
+				'--provider',
+				'codex',
+				'--cwd',
+				'/repo',
+				'--max-runs',
+				'2',
+				'--expires-in',
+				'10m',
+				'--json',
+				'do work',
+			],
+			expect.any(Object)
+		);
+	});
+
+	it('builds schedule list and logs arguments', async () => {
+		mockSpawnResult(0, '');
+		await listPaseoSchedules({ cliPath: '/bin/paseo', host: '127.0.0.1:6767' });
+
+		expect(spawn).toHaveBeenLastCalledWith(
+			'/bin/paseo',
+			['schedule', 'ls', '--host', '127.0.0.1:6767'],
+			expect.any(Object)
+		);
+
+		mockSpawnResult(0, '');
+		await getPaseoScheduleLogs('abc123', { cliPath: '/bin/paseo', json: true });
+
+		expect(spawn).toHaveBeenLastCalledWith(
+			'/bin/paseo',
+			['schedule', 'logs', '--json', 'abc123'],
+			expect.any(Object)
+		);
+	});
+});

--- a/src/cli/commands/paseo.ts
+++ b/src/cli/commands/paseo.ts
@@ -4,6 +4,7 @@ import {
 	createPaseoSchedule,
 	getPaseoScheduleLogs,
 	listPaseoSchedules,
+	runPaseoAgent,
 	type PaseoCommandResult,
 } from '../services/paseo';
 import { formatError } from '../output/formatter';
@@ -27,6 +28,17 @@ interface PaseoScheduleCreateCommandOptions extends PaseoBaseOptions {
 	runNow?: boolean;
 }
 
+interface PaseoRunCommandOptions extends PaseoBaseOptions {
+	title?: string;
+	provider?: string;
+	model?: string;
+	thinking?: string;
+	mode?: string;
+	cwd?: string;
+	detach?: boolean;
+	waitTimeout?: string;
+}
+
 function printResult(result: PaseoCommandResult): void {
 	if (result.stdout.trim()) {
 		console.log(result.stdout.trimEnd());
@@ -44,6 +56,15 @@ function printError(error: unknown, json?: boolean): void {
 		console.error(formatError(message));
 	}
 	process.exit(1);
+}
+
+export async function paseoRun(prompt: string, options: PaseoRunCommandOptions): Promise<void> {
+	try {
+		const result = await runPaseoAgent(prompt, options);
+		printResult(result);
+	} catch (error) {
+		printError(error, options.json);
+	}
 }
 
 export async function paseoScheduleCreate(

--- a/src/cli/commands/paseo.ts
+++ b/src/cli/commands/paseo.ts
@@ -1,0 +1,81 @@
+// Paseo command group for Maestro CLI
+
+import {
+	createPaseoSchedule,
+	getPaseoScheduleLogs,
+	listPaseoSchedules,
+	type PaseoCommandResult,
+} from '../services/paseo';
+import { formatError } from '../output/formatter';
+
+interface PaseoBaseOptions {
+	cliPath?: string;
+	host?: string;
+	json?: boolean;
+}
+
+interface PaseoScheduleCreateCommandOptions extends PaseoBaseOptions {
+	every?: string;
+	cron?: string;
+	name?: string;
+	target?: string;
+	provider?: string;
+	mode?: string;
+	cwd?: string;
+	maxRuns?: string;
+	expiresIn?: string;
+	runNow?: boolean;
+	noRunNow?: boolean;
+}
+
+function printResult(result: PaseoCommandResult): void {
+	if (result.stdout.trim()) {
+		console.log(result.stdout.trimEnd());
+	}
+	if (result.stderr.trim()) {
+		console.error(result.stderr.trimEnd());
+	}
+}
+
+function printError(error: unknown, json?: boolean): void {
+	const message = error instanceof Error ? error.message : 'Unknown error';
+	if (json) {
+		console.error(JSON.stringify({ success: false, error: message }, null, 2));
+	} else {
+		console.error(formatError(message));
+	}
+	process.exit(1);
+}
+
+export async function paseoScheduleCreate(
+	prompt: string,
+	options: PaseoScheduleCreateCommandOptions
+): Promise<void> {
+	try {
+		const result = await createPaseoSchedule(prompt, options);
+		printResult(result);
+	} catch (error) {
+		printError(error, options.json);
+	}
+}
+
+export async function paseoScheduleList(options: PaseoBaseOptions): Promise<void> {
+	try {
+		const result = await listPaseoSchedules(options);
+		printResult(result);
+	} catch (error) {
+		printError(error, options.json);
+	}
+}
+
+export async function paseoScheduleLogs(
+	scheduleId: string,
+	options: PaseoBaseOptions
+): Promise<void> {
+	try {
+		const result = await getPaseoScheduleLogs(scheduleId, options);
+		printResult(result);
+	} catch (error) {
+		printError(error, options.json);
+	}
+}

--- a/src/cli/commands/paseo.ts
+++ b/src/cli/commands/paseo.ts
@@ -25,7 +25,6 @@ interface PaseoScheduleCreateCommandOptions extends PaseoBaseOptions {
 	maxRuns?: string;
 	expiresIn?: string;
 	runNow?: boolean;
-	noRunNow?: boolean;
 }
 
 function printResult(result: PaseoCommandResult): void {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -23,7 +23,12 @@ import {
 	settingsAgentSet,
 	settingsAgentReset,
 } from './commands/settings-agent';
-import { paseoScheduleCreate, paseoScheduleList, paseoScheduleLogs } from './commands/paseo';
+import {
+	paseoRun,
+	paseoScheduleCreate,
+	paseoScheduleList,
+	paseoScheduleLogs,
+} from './commands/paseo';
 
 // Read version from package.json at runtime
 function getVersion(): string {
@@ -123,6 +128,24 @@ program
 
 // Paseo commands - create and inspect Paseo-managed schedules from Maestro
 const paseo = program.command('paseo').description('Manage Paseo tasks from Maestro');
+
+paseo
+	.command('run <prompt>')
+	.description('Create and start a titled Paseo agent')
+	.option('--title <title>', 'Paseo agent title')
+	.option('--provider <provider>', 'Paseo provider, or provider/model')
+	.option('--model <model>', 'Model to use')
+	.option('--thinking <id>', 'Thinking option ID to use for this run')
+	.option('--mode <mode>', 'Provider-specific mode')
+	.option('--cwd <path>', 'Working directory for the agent')
+	.option('--detach', 'Run in background', true)
+	.option('--no-detach', 'Wait for the run instead of detaching')
+	.option('--wait-timeout <duration>', 'Maximum time to wait when not detached')
+	.option('--host <host>', 'Paseo daemon host target')
+	.option('--cli-path <path>', 'Path to the Paseo CLI binary')
+	.option('--json', 'Ask Paseo for JSON output')
+	.action(paseoRun);
+
 const paseoSchedule = paseo.command('schedule').description('Manage Paseo recurring schedules');
 
 paseoSchedule

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -23,6 +23,7 @@ import {
 	settingsAgentSet,
 	settingsAgentReset,
 } from './commands/settings-agent';
+import { paseoScheduleCreate, paseoScheduleList, paseoScheduleLogs } from './commands/paseo';
 
 // Read version from package.json at runtime
 function getVersion(): string {
@@ -119,6 +120,45 @@ program
 	.description('Send a message to an agent and get a JSON response')
 	.option('-s, --session <id>', 'Resume an existing agent session (for multi-turn conversations)')
 	.action(send);
+
+// Paseo commands - create and inspect Paseo-managed schedules from Maestro
+const paseo = program.command('paseo').description('Manage Paseo tasks from Maestro');
+const paseoSchedule = paseo.command('schedule').description('Manage Paseo recurring schedules');
+
+paseoSchedule
+	.command('create <prompt>')
+	.description('Create a Paseo schedule')
+	.option('--every <duration>', 'Fixed interval cadence (for example: 5m, 1h)')
+	.option('--cron <expr>', 'Cron cadence expression')
+	.option('--name <name>', 'Schedule name')
+	.option('--target <target>', 'Run target: self, new-agent, or agent id')
+	.option('--provider <provider>', 'Paseo provider, or provider/model')
+	.option('--mode <mode>', 'Provider-specific mode')
+	.option('--cwd <path>', 'Working directory for scheduled runs')
+	.option('--max-runs <n>', 'Maximum number of runs')
+	.option('--expires-in <duration>', 'Time to live for the schedule')
+	.option('--run-now', 'Fire one immediate run on creation')
+	.option('--no-run-now', 'Wait for the first cadence interval')
+	.option('--host <host>', 'Paseo daemon host target')
+	.option('--cli-path <path>', 'Path to the Paseo CLI binary')
+	.option('--json', 'Ask Paseo for JSON output')
+	.action(paseoScheduleCreate);
+
+paseoSchedule
+	.command('ls')
+	.description('List Paseo schedules')
+	.option('--host <host>', 'Paseo daemon host target')
+	.option('--cli-path <path>', 'Path to the Paseo CLI binary')
+	.option('--json', 'Ask Paseo for JSON output')
+	.action(paseoScheduleList);
+
+paseoSchedule
+	.command('logs <schedule-id>')
+	.description('Show Paseo schedule run logs')
+	.option('--host <host>', 'Paseo daemon host target')
+	.option('--cli-path <path>', 'Path to the Paseo CLI binary')
+	.option('--json', 'Ask Paseo for JSON output')
+	.action(paseoScheduleLogs);
 
 // Settings commands
 const settings = program.command('settings').description('View and manage Maestro configuration');

--- a/src/cli/services/paseo.ts
+++ b/src/cli/services/paseo.ts
@@ -27,7 +27,6 @@ export interface PaseoScheduleCreateOptions extends PaseoExecOptions {
 	maxRuns?: string;
 	expiresIn?: string;
 	runNow?: boolean;
-	noRunNow?: boolean;
 	host?: string;
 	json?: boolean;
 }
@@ -96,9 +95,9 @@ export function runPaseoCommand(
 				return;
 			}
 
-			const details = [stderr.trim(), stdout.trim(), `Paseo exited with code ${code}`]
-				.filter(Boolean)
-				.join('\n');
+			const exitDetail =
+				code === null ? 'Paseo exited without an exit code' : `Paseo exited with code ${code}`;
+			const details = [stderr.trim(), stdout.trim(), exitDetail].filter(Boolean).join('\n');
 			reject(new Error(details));
 		});
 	});
@@ -133,10 +132,9 @@ export function createPaseoSchedule(
 	addOption(args, '--max-runs', options.maxRuns);
 	addOption(args, '--expires-in', options.expiresIn);
 
-	if (options.runNow) {
+	if (options.runNow === true) {
 		args.push('--run-now');
-	}
-	if (options.noRunNow) {
+	} else if (options.runNow === false) {
 		args.push('--no-run-now');
 	}
 

--- a/src/cli/services/paseo.ts
+++ b/src/cli/services/paseo.ts
@@ -31,6 +31,19 @@ export interface PaseoScheduleCreateOptions extends PaseoExecOptions {
 	json?: boolean;
 }
 
+export interface PaseoRunOptions extends PaseoExecOptions {
+	title?: string;
+	provider?: string;
+	model?: string;
+	thinking?: string;
+	mode?: string;
+	cwd?: string;
+	detach?: boolean;
+	waitTimeout?: string;
+	host?: string;
+	json?: boolean;
+}
+
 export interface PaseoScheduleListOptions extends PaseoExecOptions {
 	host?: string;
 	json?: boolean;
@@ -138,6 +151,28 @@ export function createPaseoSchedule(
 		args.push('--no-run-now');
 	}
 
+	addCommonOptions(args, options);
+	args.push(prompt);
+
+	return runPaseoCommand(args, options);
+}
+
+export function runPaseoAgent(
+	prompt: string,
+	options: PaseoRunOptions
+): Promise<PaseoCommandResult> {
+	const args = ['run'];
+
+	addOption(args, '--title', options.title);
+	addOption(args, '--provider', options.provider);
+	addOption(args, '--model', options.model);
+	addOption(args, '--thinking', options.thinking);
+	addOption(args, '--mode', options.mode);
+	addOption(args, '--cwd', options.cwd);
+	if (options.detach !== false) {
+		args.push('--detach');
+	}
+	addOption(args, '--wait-timeout', options.waitTimeout);
 	addCommonOptions(args, options);
 	args.push(prompt);
 

--- a/src/cli/services/paseo.ts
+++ b/src/cli/services/paseo.ts
@@ -1,0 +1,163 @@
+// Paseo CLI adapter for Maestro CLI
+// Wraps the local Paseo CLI so Maestro can create and inspect Paseo-managed work.
+
+import * as childProcess from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+
+const MACOS_BUNDLED_PASEO_CLI = '/Applications/Paseo.app/Contents/Resources/bin/paseo';
+
+export interface PaseoExecOptions {
+	cliPath?: string;
+}
+
+export interface PaseoCommandResult {
+	stdout: string;
+	stderr: string;
+}
+
+export interface PaseoScheduleCreateOptions extends PaseoExecOptions {
+	every?: string;
+	cron?: string;
+	name?: string;
+	target?: string;
+	provider?: string;
+	mode?: string;
+	cwd?: string;
+	maxRuns?: string;
+	expiresIn?: string;
+	runNow?: boolean;
+	noRunNow?: boolean;
+	host?: string;
+	json?: boolean;
+}
+
+export interface PaseoScheduleListOptions extends PaseoExecOptions {
+	host?: string;
+	json?: boolean;
+}
+
+export interface PaseoScheduleLogsOptions extends PaseoExecOptions {
+	host?: string;
+	json?: boolean;
+}
+
+function isExecutable(filePath: string): boolean {
+	try {
+		const stats = fs.statSync(filePath);
+		if (!stats.isFile()) return false;
+		if (os.platform() !== 'win32') {
+			fs.accessSync(filePath, fs.constants.X_OK);
+		}
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+export function resolvePaseoCliPath(explicitPath?: string): string {
+	if (explicitPath) return explicitPath;
+	if (process.env.PASEO_CLI_PATH) return process.env.PASEO_CLI_PATH;
+	if (os.platform() === 'darwin' && isExecutable(MACOS_BUNDLED_PASEO_CLI)) {
+		return MACOS_BUNDLED_PASEO_CLI;
+	}
+	return 'paseo';
+}
+
+export function runPaseoCommand(
+	args: string[],
+	options: PaseoExecOptions = {}
+): Promise<PaseoCommandResult> {
+	return new Promise((resolve, reject) => {
+		const cliPath = resolvePaseoCliPath(options.cliPath);
+		const child = childProcess.spawn(cliPath, args, {
+			env: process.env,
+			stdio: ['ignore', 'pipe', 'pipe'],
+		});
+
+		let stdout = '';
+		let stderr = '';
+
+		child.stdout?.on('data', (data: Buffer) => {
+			stdout += data.toString();
+		});
+
+		child.stderr?.on('data', (data: Buffer) => {
+			stderr += data.toString();
+		});
+
+		child.on('error', (error) => {
+			reject(new Error(`Failed to run Paseo CLI (${cliPath}): ${error.message}`));
+		});
+
+		child.on('close', (code) => {
+			if (code === 0) {
+				resolve({ stdout, stderr });
+				return;
+			}
+
+			const details = [stderr.trim(), stdout.trim(), `Paseo exited with code ${code}`]
+				.filter(Boolean)
+				.join('\n');
+			reject(new Error(details));
+		});
+	});
+}
+
+function addOption(args: string[], flag: string, value?: string): void {
+	if (value !== undefined && value !== '') {
+		args.push(flag, value);
+	}
+}
+
+function addCommonOptions(args: string[], options: { host?: string; json?: boolean }): void {
+	addOption(args, '--host', options.host);
+	if (options.json) {
+		args.push('--json');
+	}
+}
+
+export function createPaseoSchedule(
+	prompt: string,
+	options: PaseoScheduleCreateOptions
+): Promise<PaseoCommandResult> {
+	const args = ['schedule', 'create'];
+
+	addOption(args, '--every', options.every);
+	addOption(args, '--cron', options.cron);
+	addOption(args, '--name', options.name);
+	addOption(args, '--target', options.target);
+	addOption(args, '--provider', options.provider);
+	addOption(args, '--mode', options.mode);
+	addOption(args, '--cwd', options.cwd);
+	addOption(args, '--max-runs', options.maxRuns);
+	addOption(args, '--expires-in', options.expiresIn);
+
+	if (options.runNow) {
+		args.push('--run-now');
+	}
+	if (options.noRunNow) {
+		args.push('--no-run-now');
+	}
+
+	addCommonOptions(args, options);
+	args.push(prompt);
+
+	return runPaseoCommand(args, options);
+}
+
+export function listPaseoSchedules(options: PaseoScheduleListOptions): Promise<PaseoCommandResult> {
+	const args = ['schedule', 'ls'];
+	addCommonOptions(args, options);
+	return runPaseoCommand(args, options);
+}
+
+export function getPaseoScheduleLogs(
+	scheduleId: string,
+	options: PaseoScheduleLogsOptions
+): Promise<PaseoCommandResult> {
+	const args = ['schedule', 'logs'];
+	addCommonOptions(args, options);
+	args.push(scheduleId);
+	return runPaseoCommand(args, options);
+}


### PR DESCRIPTION
## Summary

This PR adds a small, CLI-first integration point between Maestro and Paseo by introducing a `maestro-cli paseo schedule ...` command group.

The goal is to let Maestro act as the user-facing orchestration entrypoint while delegating agent lifecycle, recurring execution, timelines, and visibility to a running Paseo daemon.

## Background

Maestro already provides a useful agent-oriented CLI surface (`send`, playbooks, settings, session inspection) and is well positioned to act as an orchestration layer for higher-level workflows. Paseo, meanwhile, provides a daemon-backed execution model with a native UI for inspecting agent timelines, schedule runs, logs, and multi-agent progress.

In local testing, the most reliable integration path was not to ask an intermediate agent to run shell commands, but to let Maestro call the Paseo CLI directly and return the structured result to the user or automation layer.

That gives a clean division of responsibilities:

- Maestro owns task intake, orchestration, templates, and future planning/delegation flows.
- Paseo owns spawned agent execution, recurring schedules, timeline/log visibility, and daemon state.

## Research / Findings

A short local spike validated the following:

- A running Paseo desktop app exposes a reachable local daemon.
- The bundled Paseo CLI can manage that daemon from the terminal.
- `paseo schedule create` can create bounded scheduled agent runs with `--max-runs` and `--expires-in`, which is important for safe automation.
- Schedule runs show up in Paseo's UI/daemon timeline and can be inspected with `paseo schedule ls` and `paseo schedule logs <id>`.
- Providers such as `codex` and `claude` are discovered by Paseo and can be selected per scheduled task.
- For now, this PR intentionally focuses on schedule management. One-off `paseo run --title` support would be a natural follow-up because it provides better UI titles for ad hoc delegated tasks.

## Changes

This PR adds:

- A Paseo CLI adapter in `src/cli/services/paseo.ts`
  - Resolves the Paseo CLI path from, in order:
    - an explicit `--cli-path`
    - `PASEO_CLI_PATH`
    - the macOS bundled app path (`/Applications/Paseo.app/Contents/Resources/bin/paseo`)
    - `paseo` from `PATH`
  - Executes Paseo commands via `child_process.spawn`
  - Returns stdout/stderr and surfaces non-zero exits as errors

- A new command module in `src/cli/commands/paseo.ts`
  - `paseo schedule create <prompt>`
  - `paseo schedule ls`
  - `paseo schedule logs <schedule-id>`
  - Supports `--json`, `--host`, and `--cli-path`

- CLI registration in `src/cli/index.ts`

- Unit coverage for both service and command layers

## Example Usage

```bash
maestro-cli paseo schedule ls

maestro-cli paseo schedule create \
  --every 30m \
  --name repo-health-check \
  --provider codex \
  --cwd /path/to/repo \
  --max-runs 8 \
  --expires-in 4h \
  "Check the repo health, run focused checks, and summarize the result."

maestro-cli paseo schedule logs <schedule-id>
```

## Safety Notes

The schedule creation path exposes Paseo's built-in bounding controls:

- `--max-runs`
- `--expires-in`
- `--no-run-now`
- explicit `--cwd`
- explicit provider selection

These are useful defaults for higher-level orchestration because Maestro can create visible, bounded Paseo work without creating unbounded recurring agents.

## Validation

Targeted checks:

```bash
npx tsc -p tsconfig.cli.json --noEmit
npx vitest run src/__tests__/cli/services/paseo.test.ts src/__tests__/cli/commands/paseo.test.ts src/__tests__/cli/commands/send.test.ts src/__tests__/cli/services/agent-spawner.test.ts
```

Full push validation also passed:

```text
Test Files  546 passed | 1 skipped (547)
Tests       22548 passed | 107 skipped (22655)
```

The push hook also ran:

- `npm run build:prompts`
- `npm run format:check:all`
- `npm run lint`
- `npm run lint:eslint`
- `npm run test`

`lint:eslint` reported one existing warning in `src/main/web-server/web-server-factory.ts`, but no errors.

## Follow-up Plan

This is deliberately a small integration slice. Follow-up improvements that would build on it:

1. Add `maestro-cli paseo run` support
   - Wrap `paseo run --title --detach --provider --cwd`
   - Use this for one-off delegated tasks where UI titles matter

2. Add a higher-level `delegate` command
   - Generate a structured task plan
   - Use Claude or another reasoning-heavy provider for planning/review
   - Use Codex or another execution-heavy provider for implementation/checking
   - Dispatch approved tasks through the Paseo adapter

3. Persist Paseo IDs in Maestro-side task records
   - schedule id
   - agent id
   - provider
   - cwd
   - created time
   - status/log lookup metadata

4. Add richer output parsing for `--json`
   - Return typed schedule objects from the adapter instead of raw stdout when JSON is requested

5. Expose this from playbooks or future workflow templates
   - Recurring maintenance jobs
   - repo health checks
   - multi-agent research/implementation/review loops


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a top-level Paseo CLI group with run plus schedule commands (create, list, logs), supporting host/CLI-path selection and --json output.
* **Tests**
  * Added unit tests covering Paseo commands and the CLI adapter, including success/failure paths, output handling, and argument/exec wiring.
* **Chores**
  * Added a CLI adapter to invoke and capture output from the local Paseo executable and registered the new commands.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RunMaestro/Maestro/pull/1030?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->