### PR TITLE
Symphony: CLI-IPC: WebSocket bridge for provider agents to trigger Maestro UI actions (#511)

### DIFF
--- a/src/__tests__/cli/commands/auto-run.test.ts
+++ b/src/__tests__/cli/commands/auto-run.test.ts
@@ -16,6 +16,7 @@ import { describe, it, expect, vi, beforeEach, type MockInstance } from 'vitest'
 // Mock fs
 vi.mock('fs', () => ({
 	existsSync: vi.fn(),
+	statSync: vi.fn(),
 }));
 
 // Mock maestro-client
@@ -24,9 +25,14 @@ vi.mock('../../../cli/services/maestro-client', () => ({
 	resolveTargetSessionId: vi.fn(),
 }));
 
+vi.mock('../../../cli/services/storage', () => ({
+	getSessionById: vi.fn(),
+}));
+
 import { autoRun } from '../../../cli/commands/auto-run';
 import { withMaestroClient, resolveTargetSessionId } from '../../../cli/services/maestro-client';
-import { existsSync } from 'fs';
+import { getSessionById } from '../../../cli/services/storage';
+import { existsSync, statSync } from 'fs';
 import path from 'path';
 
 describe('auto-run command', () => {
@@ -39,6 +45,14 @@ describe('auto-run command', () => {
 		consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 		consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 		processExitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+		vi.mocked(statSync).mockReturnValue({ isFile: () => true } as never);
+		vi.mocked(getSessionById).mockReturnValue({
+			id: 'agent-123',
+			name: 'Agent',
+			toolType: 'claude-code',
+			cwd: '/repo',
+			autoRunFolderPath: '/path/to',
+		} as never);
 	});
 
 	it('should configure auto-run with valid document paths', async () => {
@@ -61,6 +75,30 @@ describe('auto-run command', () => {
 			expect.stringContaining('Auto-run configured with 2 documents')
 		);
 		expect(processExitSpy).not.toHaveBeenCalled();
+	});
+
+	it('should send relative document paths from the agent Auto Run folder', async () => {
+		vi.mocked(existsSync).mockReturnValue(true);
+		vi.mocked(resolveTargetSessionId).mockReturnValue('agent-123');
+
+		let sentMessage: Record<string, unknown> | undefined;
+		vi.mocked(withMaestroClient).mockImplementation(async (action) => {
+			const mockClient = {
+				sendCommand: vi.fn().mockImplementation((msg) => {
+					sentMessage = msg;
+					return Promise.resolve({
+						type: 'configure_auto_run_result',
+						success: true,
+					});
+				}),
+			};
+			return action(mockClient as never);
+		});
+
+		await autoRun(['/path/to/nested/doc.md'], { agent: 'agent-123' });
+
+		const docs = sentMessage!.documents as Array<{ filename: string }>;
+		expect(docs[0].filename).toBe('nested/doc.md');
 	});
 
 	it('should error with no documents', async () => {

--- a/src/__tests__/cli/commands/auto-run.test.ts
+++ b/src/__tests__/cli/commands/auto-run.test.ts
@@ -101,6 +101,37 @@ describe('auto-run command', () => {
 		expect(docs[0].filename).toBe('nested/doc.md');
 	});
 
+	it.each([
+		{ label: 'the default', options: {}, expected: false },
+		{ label: '--background', options: { background: true }, expected: true },
+		{
+			label: '--focus overriding --background',
+			options: { background: true, focus: true },
+			expected: false,
+		},
+	])('should send background=$expected for $label placement', async ({ options, expected }) => {
+		vi.mocked(existsSync).mockReturnValue(true);
+		vi.mocked(resolveTargetSessionId).mockReturnValue('agent-123');
+
+		let sentMessage: Record<string, unknown> | undefined;
+		vi.mocked(withMaestroClient).mockImplementation(async (action) => {
+			const mockClient = {
+				sendCommand: vi.fn().mockImplementation((msg) => {
+					sentMessage = msg;
+					return Promise.resolve({
+						type: 'configure_auto_run_result',
+						success: true,
+					});
+				}),
+			};
+			return action(mockClient as never);
+		});
+
+		await autoRun(['/path/to/doc.md'], options);
+
+		expect(sentMessage?.background).toBe(expected);
+	});
+
 	it('should error with no documents', async () => {
 		await autoRun([], {});
 

--- a/src/__tests__/cli/commands/refresh-auto-run.test.ts
+++ b/src/__tests__/cli/commands/refresh-auto-run.test.ts
@@ -6,7 +6,7 @@
 import { describe, it, expect, vi, beforeEach, type MockInstance } from 'vitest';
 
 vi.mock('../../../cli/services/maestro-client', () => ({
-	resolveSessionId: vi.fn(),
+	resolveTargetSessionId: vi.fn(),
 	withMaestroClient: vi.fn(),
 }));
 
@@ -15,7 +15,7 @@ vi.mock('../../../cli/output/formatter', () => ({
 }));
 
 import { refreshAutoRun } from '../../../cli/commands/refresh-auto-run';
-import { resolveSessionId, withMaestroClient } from '../../../cli/services/maestro-client';
+import { resolveTargetSessionId, withMaestroClient } from '../../../cli/services/maestro-client';
 
 describe('refresh-auto-run command', () => {
 	let consoleSpy: MockInstance;
@@ -27,7 +27,7 @@ describe('refresh-auto-run command', () => {
 		consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 		consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 		processExitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
-		vi.mocked(resolveSessionId).mockReturnValue('target-session');
+		vi.mocked(resolveTargetSessionId).mockReturnValue('target-session');
 		vi.mocked(withMaestroClient).mockImplementation(async (action) => {
 			const client = {
 				sendCommand: vi.fn().mockResolvedValue({
@@ -40,9 +40,9 @@ describe('refresh-auto-run command', () => {
 	});
 
 	it('refreshes Auto Run documents with an explicit session', async () => {
-		await refreshAutoRun({ session: 'target-session' });
+		await refreshAutoRun({ agent: 'target-session' });
 
-		expect(resolveSessionId).toHaveBeenCalledWith({ session: 'target-session' });
+		expect(resolveTargetSessionId).toHaveBeenCalledWith('target-session');
 		expect(withMaestroClient).toHaveBeenCalledTimes(1);
 		const action = vi.mocked(withMaestroClient).mock.calls[0][0];
 		const sendCommand = vi.fn().mockResolvedValue({
@@ -59,7 +59,7 @@ describe('refresh-auto-run command', () => {
 	});
 
 	it('refreshes Auto Run documents with the resolved default session', async () => {
-		vi.mocked(resolveSessionId).mockReturnValue('resolved-session');
+		vi.mocked(resolveTargetSessionId).mockReturnValue('resolved-session');
 
 		await refreshAutoRun({});
 
@@ -78,11 +78,9 @@ describe('refresh-auto-run command', () => {
 	it('exits with an error when Maestro is not reachable', async () => {
 		vi.mocked(withMaestroClient).mockRejectedValue(new Error('Maestro desktop app is not running'));
 
-		await refreshAutoRun({ session: 'target-session' });
+		await refreshAutoRun({ agent: 'target-session' });
 
-		expect(consoleErrorSpy).toHaveBeenCalledWith(
-			'Error: Failed to refresh Auto Run documents: Maestro desktop app is not running'
-		);
+		expect(consoleErrorSpy).toHaveBeenCalledWith('Error: Maestro desktop app is not running');
 		expect(processExitSpy).toHaveBeenCalledWith(1);
 	});
 
@@ -98,11 +96,9 @@ describe('refresh-auto-run command', () => {
 			return action(client as never);
 		});
 
-		await refreshAutoRun({ session: 'target-session' });
+		await refreshAutoRun({ agent: 'target-session' });
 
-		expect(consoleErrorSpy).toHaveBeenCalledWith(
-			'Error: Failed to refresh Auto Run documents: Session not found'
-		);
+		expect(consoleErrorSpy).toHaveBeenCalledWith('Error: Session not found');
 		expect(processExitSpy).toHaveBeenCalledWith(1);
 	});
 });

--- a/src/__tests__/cli/commands/refresh-auto-run.test.ts
+++ b/src/__tests__/cli/commands/refresh-auto-run.test.ts
@@ -1,0 +1,108 @@
+/**
+ * @file refresh-auto-run.test.ts
+ * @description Tests for the refresh-auto-run CLI command
+ */
+
+import { describe, it, expect, vi, beforeEach, type MockInstance } from 'vitest';
+
+vi.mock('../../../cli/services/maestro-client', () => ({
+	resolveSessionId: vi.fn(),
+	withMaestroClient: vi.fn(),
+}));
+
+vi.mock('../../../cli/output/formatter', () => ({
+	formatError: vi.fn((message: string) => `Error: ${message}`),
+}));
+
+import { refreshAutoRun } from '../../../cli/commands/refresh-auto-run';
+import { resolveSessionId, withMaestroClient } from '../../../cli/services/maestro-client';
+
+describe('refresh-auto-run command', () => {
+	let consoleSpy: MockInstance;
+	let consoleErrorSpy: MockInstance;
+	let processExitSpy: MockInstance;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+		consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+		processExitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+		vi.mocked(resolveSessionId).mockReturnValue('target-session');
+		vi.mocked(withMaestroClient).mockImplementation(async (action) => {
+			const client = {
+				sendCommand: vi.fn().mockResolvedValue({
+					type: 'refresh_auto_run_docs_result',
+					success: true,
+				}),
+			};
+			return action(client as never);
+		});
+	});
+
+	it('refreshes Auto Run documents with an explicit session', async () => {
+		await refreshAutoRun({ session: 'target-session' });
+
+		expect(resolveSessionId).toHaveBeenCalledWith({ session: 'target-session' });
+		expect(withMaestroClient).toHaveBeenCalledTimes(1);
+		const action = vi.mocked(withMaestroClient).mock.calls[0][0];
+		const sendCommand = vi.fn().mockResolvedValue({
+			type: 'refresh_auto_run_docs_result',
+			success: true,
+		});
+		await action({ sendCommand } as never);
+		expect(sendCommand).toHaveBeenCalledWith(
+			{ type: 'refresh_auto_run_docs', sessionId: 'target-session' },
+			'refresh_auto_run_docs_result'
+		);
+		expect(consoleSpy).toHaveBeenCalledWith('Auto Run documents refreshed');
+		expect(processExitSpy).not.toHaveBeenCalled();
+	});
+
+	it('refreshes Auto Run documents with the resolved default session', async () => {
+		vi.mocked(resolveSessionId).mockReturnValue('resolved-session');
+
+		await refreshAutoRun({});
+
+		const action = vi.mocked(withMaestroClient).mock.calls[0][0];
+		const sendCommand = vi.fn().mockResolvedValue({
+			type: 'refresh_auto_run_docs_result',
+			success: true,
+		});
+		await action({ sendCommand } as never);
+		expect(sendCommand).toHaveBeenCalledWith(
+			{ type: 'refresh_auto_run_docs', sessionId: 'resolved-session' },
+			'refresh_auto_run_docs_result'
+		);
+	});
+
+	it('exits with an error when Maestro is not reachable', async () => {
+		vi.mocked(withMaestroClient).mockRejectedValue(new Error('Maestro desktop app is not running'));
+
+		await refreshAutoRun({ session: 'target-session' });
+
+		expect(consoleErrorSpy).toHaveBeenCalledWith(
+			'Error: Failed to refresh Auto Run documents: Maestro desktop app is not running'
+		);
+		expect(processExitSpy).toHaveBeenCalledWith(1);
+	});
+
+	it('exits with an error when Maestro rejects the refresh', async () => {
+		vi.mocked(withMaestroClient).mockImplementation(async (action) => {
+			const client = {
+				sendCommand: vi.fn().mockResolvedValue({
+					type: 'refresh_auto_run_docs_result',
+					success: false,
+					error: 'Session not found',
+				}),
+			};
+			return action(client as never);
+		});
+
+		await refreshAutoRun({ session: 'target-session' });
+
+		expect(consoleErrorSpy).toHaveBeenCalledWith(
+			'Error: Failed to refresh Auto Run documents: Session not found'
+		);
+		expect(processExitSpy).toHaveBeenCalledWith(1);
+	});
+});

--- a/src/__tests__/cli/commands/refresh-auto-run.test.ts
+++ b/src/__tests__/cli/commands/refresh-auto-run.test.ts
@@ -51,7 +51,7 @@ describe('refresh-auto-run command', () => {
 		});
 		await action({ sendCommand } as never);
 		expect(sendCommand).toHaveBeenCalledWith(
-			{ type: 'refresh_auto_run_docs', sessionId: 'target-session' },
+			{ type: 'refresh_auto_run_docs', sessionId: 'target-session', background: false },
 			'refresh_auto_run_docs_result'
 		);
 		expect(consoleSpy).toHaveBeenCalledWith('Auto Run documents refreshed');
@@ -70,7 +70,7 @@ describe('refresh-auto-run command', () => {
 		});
 		await action({ sendCommand } as never);
 		expect(sendCommand).toHaveBeenCalledWith(
-			{ type: 'refresh_auto_run_docs', sessionId: 'resolved-session' },
+			{ type: 'refresh_auto_run_docs', sessionId: 'resolved-session', background: false },
 			'refresh_auto_run_docs_result'
 		);
 	});

--- a/src/__tests__/cli/commands/refresh-files.test.ts
+++ b/src/__tests__/cli/commands/refresh-files.test.ts
@@ -6,7 +6,7 @@
 import { describe, it, expect, vi, beforeEach, type MockInstance } from 'vitest';
 
 vi.mock('../../../cli/services/maestro-client', () => ({
-	resolveSessionId: vi.fn(),
+	resolveTargetSessionId: vi.fn(),
 	withMaestroClient: vi.fn(),
 }));
 
@@ -15,7 +15,7 @@ vi.mock('../../../cli/output/formatter', () => ({
 }));
 
 import { refreshFiles } from '../../../cli/commands/refresh-files';
-import { resolveSessionId, withMaestroClient } from '../../../cli/services/maestro-client';
+import { resolveTargetSessionId, withMaestroClient } from '../../../cli/services/maestro-client';
 
 describe('refresh-files command', () => {
 	let consoleSpy: MockInstance;
@@ -27,7 +27,7 @@ describe('refresh-files command', () => {
 		consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 		consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 		processExitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
-		vi.mocked(resolveSessionId).mockReturnValue('target-session');
+		vi.mocked(resolveTargetSessionId).mockReturnValue('target-session');
 		vi.mocked(withMaestroClient).mockImplementation(async (action) => {
 			const client = {
 				sendCommand: vi.fn().mockResolvedValue({
@@ -40,9 +40,9 @@ describe('refresh-files command', () => {
 	});
 
 	it('refreshes the file tree with an explicit session', async () => {
-		await refreshFiles({ session: 'target-session' });
+		await refreshFiles({ agent: 'target-session' });
 
-		expect(resolveSessionId).toHaveBeenCalledWith({ session: 'target-session' });
+		expect(resolveTargetSessionId).toHaveBeenCalledWith('target-session');
 		expect(withMaestroClient).toHaveBeenCalledTimes(1);
 		const action = vi.mocked(withMaestroClient).mock.calls[0][0];
 		const sendCommand = vi.fn().mockResolvedValue({
@@ -59,7 +59,7 @@ describe('refresh-files command', () => {
 	});
 
 	it('refreshes the file tree with the resolved default session', async () => {
-		vi.mocked(resolveSessionId).mockReturnValue('resolved-session');
+		vi.mocked(resolveTargetSessionId).mockReturnValue('resolved-session');
 
 		await refreshFiles({});
 
@@ -78,11 +78,9 @@ describe('refresh-files command', () => {
 	it('exits with an error when Maestro is not reachable', async () => {
 		vi.mocked(withMaestroClient).mockRejectedValue(new Error('Maestro desktop app is not running'));
 
-		await refreshFiles({ session: 'target-session' });
+		await refreshFiles({ agent: 'target-session' });
 
-		expect(consoleErrorSpy).toHaveBeenCalledWith(
-			'Error: Failed to refresh file tree: Maestro desktop app is not running'
-		);
+		expect(consoleErrorSpy).toHaveBeenCalledWith('Error: Maestro desktop app is not running');
 		expect(processExitSpy).toHaveBeenCalledWith(1);
 	});
 
@@ -98,11 +96,9 @@ describe('refresh-files command', () => {
 			return action(client as never);
 		});
 
-		await refreshFiles({ session: 'target-session' });
+		await refreshFiles({ agent: 'target-session' });
 
-		expect(consoleErrorSpy).toHaveBeenCalledWith(
-			'Error: Failed to refresh file tree: Session not found'
-		);
+		expect(consoleErrorSpy).toHaveBeenCalledWith('Error: Session not found');
 		expect(processExitSpy).toHaveBeenCalledWith(1);
 	});
 });

--- a/src/__tests__/cli/commands/refresh-files.test.ts
+++ b/src/__tests__/cli/commands/refresh-files.test.ts
@@ -1,0 +1,108 @@
+/**
+ * @file refresh-files.test.ts
+ * @description Tests for the refresh-files CLI command
+ */
+
+import { describe, it, expect, vi, beforeEach, type MockInstance } from 'vitest';
+
+vi.mock('../../../cli/services/maestro-client', () => ({
+	resolveSessionId: vi.fn(),
+	withMaestroClient: vi.fn(),
+}));
+
+vi.mock('../../../cli/output/formatter', () => ({
+	formatError: vi.fn((message: string) => `Error: ${message}`),
+}));
+
+import { refreshFiles } from '../../../cli/commands/refresh-files';
+import { resolveSessionId, withMaestroClient } from '../../../cli/services/maestro-client';
+
+describe('refresh-files command', () => {
+	let consoleSpy: MockInstance;
+	let consoleErrorSpy: MockInstance;
+	let processExitSpy: MockInstance;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+		consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+		processExitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+		vi.mocked(resolveSessionId).mockReturnValue('target-session');
+		vi.mocked(withMaestroClient).mockImplementation(async (action) => {
+			const client = {
+				sendCommand: vi.fn().mockResolvedValue({
+					type: 'refresh_file_tree_result',
+					success: true,
+				}),
+			};
+			return action(client as never);
+		});
+	});
+
+	it('refreshes the file tree with an explicit session', async () => {
+		await refreshFiles({ session: 'target-session' });
+
+		expect(resolveSessionId).toHaveBeenCalledWith({ session: 'target-session' });
+		expect(withMaestroClient).toHaveBeenCalledTimes(1);
+		const action = vi.mocked(withMaestroClient).mock.calls[0][0];
+		const sendCommand = vi.fn().mockResolvedValue({
+			type: 'refresh_file_tree_result',
+			success: true,
+		});
+		await action({ sendCommand } as never);
+		expect(sendCommand).toHaveBeenCalledWith(
+			{ type: 'refresh_file_tree', sessionId: 'target-session' },
+			'refresh_file_tree_result'
+		);
+		expect(consoleSpy).toHaveBeenCalledWith('File tree refreshed');
+		expect(processExitSpy).not.toHaveBeenCalled();
+	});
+
+	it('refreshes the file tree with the resolved default session', async () => {
+		vi.mocked(resolveSessionId).mockReturnValue('resolved-session');
+
+		await refreshFiles({});
+
+		const action = vi.mocked(withMaestroClient).mock.calls[0][0];
+		const sendCommand = vi.fn().mockResolvedValue({
+			type: 'refresh_file_tree_result',
+			success: true,
+		});
+		await action({ sendCommand } as never);
+		expect(sendCommand).toHaveBeenCalledWith(
+			{ type: 'refresh_file_tree', sessionId: 'resolved-session' },
+			'refresh_file_tree_result'
+		);
+	});
+
+	it('exits with an error when Maestro is not reachable', async () => {
+		vi.mocked(withMaestroClient).mockRejectedValue(new Error('Maestro desktop app is not running'));
+
+		await refreshFiles({ session: 'target-session' });
+
+		expect(consoleErrorSpy).toHaveBeenCalledWith(
+			'Error: Failed to refresh file tree: Maestro desktop app is not running'
+		);
+		expect(processExitSpy).toHaveBeenCalledWith(1);
+	});
+
+	it('exits with an error when Maestro rejects the refresh', async () => {
+		vi.mocked(withMaestroClient).mockImplementation(async (action) => {
+			const client = {
+				sendCommand: vi.fn().mockResolvedValue({
+					type: 'refresh_file_tree_result',
+					success: false,
+					error: 'Session not found',
+				}),
+			};
+			return action(client as never);
+		});
+
+		await refreshFiles({ session: 'target-session' });
+
+		expect(consoleErrorSpy).toHaveBeenCalledWith(
+			'Error: Failed to refresh file tree: Session not found'
+		);
+		expect(processExitSpy).toHaveBeenCalledWith(1);
+	});
+});

--- a/src/__tests__/cli/commands/send.test.ts
+++ b/src/__tests__/cli/commands/send.test.ts
@@ -33,6 +33,7 @@ vi.mock('../../../cli/services/system-prompt', () => ({
 vi.mock('../../../cli/services/storage', () => ({
 	resolveAgentId: vi.fn(),
 	getSessionById: vi.fn(),
+	getConfigDirectory: vi.fn(() => '/tmp/maestro-test'),
 }));
 
 // Mock usage-aggregator
@@ -465,7 +466,7 @@ describe('send command', () => {
 		const output = JSON.parse(consoleSpy.mock.calls[0][0]);
 		expect(output.success).toBe(true);
 		expect(consoleErrorSpy).toHaveBeenCalledWith(
-			'Warning: Sent message, but could not focus Maestro tab: Maestro desktop app is not running'
+			'Warning: Could not focus session tab in Maestro desktop (app may not be running)'
 		);
 		expect(processExitSpy).not.toHaveBeenCalled();
 	});

--- a/src/__tests__/cli/commands/send.test.ts
+++ b/src/__tests__/cli/commands/send.test.ts
@@ -62,6 +62,7 @@ import { prepareMaestroSystemPromptCli } from '../../../cli/services/system-prom
 
 describe('send command', () => {
 	let consoleSpy: MockInstance;
+	let consoleErrorSpy: MockInstance;
 	let processExitSpy: MockInstance;
 
 	const mockAgent = (overrides: Partial<SessionInfo> = {}): SessionInfo => ({
@@ -76,6 +77,7 @@ describe('send command', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+		consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 		processExitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
 		// Default: system-prompt builder returns undefined so existing assertions
 		// that don't include `appendSystemPrompt` keep passing (vitest treats
@@ -408,5 +410,63 @@ describe('send command', () => {
 		const output = JSON.parse(consoleSpy.mock.calls[0][0]);
 		expect(output.success).toBe(true);
 		expect(output.usage).toBeNull();
+	});
+
+	it('should focus the Maestro session tab when --tab is provided', async () => {
+		vi.mocked(resolveAgentId).mockReturnValue('agent-abc-123');
+		vi.mocked(getSessionById).mockReturnValue(mockAgent());
+		vi.mocked(detectAgent).mockResolvedValue({ available: true, path: '/usr/bin/claude' });
+		vi.mocked(spawnAgent).mockResolvedValue({
+			success: true,
+			response: 'OK',
+			agentSessionId: 'session-no-stats',
+		});
+		vi.mocked(withMaestroClient).mockImplementation(async (action) => {
+			await action({
+				sendCommand: vi.fn().mockResolvedValue({
+					type: 'select_session_result',
+					success: true,
+					sessionId: 'agent-abc-123',
+				}),
+			} as never);
+		});
+
+		await send('agent-abc', 'Simple message', { tab: true });
+
+		expect(withMaestroClient).toHaveBeenCalledTimes(1);
+		const action = vi.mocked(withMaestroClient).mock.calls[0][0];
+		const sendCommand = vi.fn().mockResolvedValue({
+			type: 'select_session_result',
+			success: true,
+			sessionId: 'agent-abc-123',
+		});
+		await action({ sendCommand } as never);
+		expect(sendCommand).toHaveBeenCalledWith(
+			{ type: 'select_session', sessionId: 'agent-abc-123', focus: true },
+			'select_session_result'
+		);
+		expect(consoleErrorSpy).not.toHaveBeenCalled();
+		expect(processExitSpy).not.toHaveBeenCalled();
+	});
+
+	it('should warn but not fail when --tab cannot reach Maestro desktop', async () => {
+		vi.mocked(resolveAgentId).mockReturnValue('agent-abc-123');
+		vi.mocked(getSessionById).mockReturnValue(mockAgent());
+		vi.mocked(detectAgent).mockResolvedValue({ available: true, path: '/usr/bin/claude' });
+		vi.mocked(spawnAgent).mockResolvedValue({
+			success: true,
+			response: 'OK',
+			agentSessionId: 'session-no-stats',
+		});
+		vi.mocked(withMaestroClient).mockRejectedValue(new Error('Maestro desktop app is not running'));
+
+		await send('agent-abc', 'Simple message', { tab: true });
+
+		const output = JSON.parse(consoleSpy.mock.calls[0][0]);
+		expect(output.success).toBe(true);
+		expect(consoleErrorSpy).toHaveBeenCalledWith(
+			'Warning: Sent message, but could not focus Maestro tab: Maestro desktop app is not running'
+		);
+		expect(processExitSpy).not.toHaveBeenCalled();
 	});
 });

--- a/src/__tests__/cli/commands/status.test.ts
+++ b/src/__tests__/cli/commands/status.test.ts
@@ -61,7 +61,7 @@ describe('status command', () => {
 		expect(consoleSpy).toHaveBeenCalledWith('Maestro desktop app is not running');
 		expect(isCliServerRunning).not.toHaveBeenCalled();
 		expect(withMaestroClient).not.toHaveBeenCalled();
-		expect(processExitSpy).not.toHaveBeenCalled();
+		expect(processExitSpy).toHaveBeenCalledWith(3);
 	});
 
 	it('prints stale discovery when the PID is not running', async () => {
@@ -73,7 +73,7 @@ describe('status command', () => {
 			'Maestro discovery file is stale (app may have crashed)'
 		);
 		expect(withMaestroClient).not.toHaveBeenCalled();
-		expect(processExitSpy).not.toHaveBeenCalled();
+		expect(processExitSpy).toHaveBeenCalledWith(3);
 	});
 
 	it('pings Maestro and prints the port with session count', async () => {
@@ -91,7 +91,7 @@ describe('status command', () => {
 		await action({ sendCommand } as never);
 		expect(sendCommand).toHaveBeenNthCalledWith(1, { type: 'ping' }, 'pong');
 		expect(sendCommand).toHaveBeenNthCalledWith(2, { type: 'get_sessions' }, 'sessions_list');
-		expect(consoleSpy).toHaveBeenCalledWith('Maestro is running on port 47321 with 2 sessions');
+		expect(consoleSpy).toHaveBeenCalledWith('Maestro is running on port 47321 with 2 agents');
 		expect(processExitSpy).not.toHaveBeenCalled();
 	});
 
@@ -108,7 +108,7 @@ describe('status command', () => {
 
 		await status();
 
-		expect(consoleSpy).toHaveBeenCalledWith('Maestro is running on port 47321 with 0 sessions');
+		expect(consoleSpy).toHaveBeenCalledWith('Maestro is running on port 47321 with 0 agents');
 	});
 
 	it('exits with an error when Maestro cannot be reached', async () => {
@@ -116,9 +116,7 @@ describe('status command', () => {
 
 		await status();
 
-		expect(consoleErrorSpy).toHaveBeenCalledWith(
-			'Error: Failed to reach Maestro desktop app: Connection refused'
-		);
-		expect(processExitSpy).toHaveBeenCalledWith(1);
+		expect(consoleErrorSpy).toHaveBeenCalledWith('Error: Connection refused');
+		expect(processExitSpy).toHaveBeenCalledWith(3);
 	});
 });

--- a/src/__tests__/cli/commands/status.test.ts
+++ b/src/__tests__/cli/commands/status.test.ts
@@ -1,0 +1,124 @@
+/**
+ * @file status.test.ts
+ * @description Tests for the status CLI command
+ */
+
+import { describe, it, expect, vi, beforeEach, type MockInstance } from 'vitest';
+
+vi.mock('../../../shared/cli-server-discovery', () => ({
+	readCliServerInfo: vi.fn(),
+	isCliServerRunning: vi.fn(),
+}));
+
+vi.mock('../../../cli/services/maestro-client', () => ({
+	withMaestroClient: vi.fn(),
+}));
+
+vi.mock('../../../cli/output/formatter', () => ({
+	formatError: vi.fn((message: string) => `Error: ${message}`),
+}));
+
+import { status } from '../../../cli/commands/status';
+import { readCliServerInfo, isCliServerRunning } from '../../../shared/cli-server-discovery';
+import { withMaestroClient } from '../../../cli/services/maestro-client';
+
+describe('status command', () => {
+	let consoleSpy: MockInstance;
+	let consoleErrorSpy: MockInstance;
+	let processExitSpy: MockInstance;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+		consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+		processExitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+		vi.mocked(readCliServerInfo).mockReturnValue({
+			port: 47321,
+			token: 'test-token',
+			pid: 1234,
+			startedAt: 1710000000000,
+		});
+		vi.mocked(isCliServerRunning).mockReturnValue(true);
+		vi.mocked(withMaestroClient).mockImplementation(async (action) => {
+			const client = {
+				sendCommand: vi
+					.fn()
+					.mockResolvedValueOnce({ type: 'pong' })
+					.mockResolvedValueOnce({
+						type: 'sessions_list',
+						sessions: [{ id: 'session-1' }, { id: 'session-2' }],
+					}),
+			};
+			return action(client as never);
+		});
+	});
+
+	it('prints not running when the discovery file is missing', async () => {
+		vi.mocked(readCliServerInfo).mockReturnValue(null);
+
+		await status();
+
+		expect(consoleSpy).toHaveBeenCalledWith('Maestro desktop app is not running');
+		expect(isCliServerRunning).not.toHaveBeenCalled();
+		expect(withMaestroClient).not.toHaveBeenCalled();
+		expect(processExitSpy).not.toHaveBeenCalled();
+	});
+
+	it('prints stale discovery when the PID is not running', async () => {
+		vi.mocked(isCliServerRunning).mockReturnValue(false);
+
+		await status();
+
+		expect(consoleSpy).toHaveBeenCalledWith(
+			'Maestro discovery file is stale (app may have crashed)'
+		);
+		expect(withMaestroClient).not.toHaveBeenCalled();
+		expect(processExitSpy).not.toHaveBeenCalled();
+	});
+
+	it('pings Maestro and prints the port with session count', async () => {
+		await status();
+
+		expect(withMaestroClient).toHaveBeenCalledTimes(1);
+		const action = vi.mocked(withMaestroClient).mock.calls[0][0];
+		const sendCommand = vi
+			.fn()
+			.mockResolvedValueOnce({ type: 'pong' })
+			.mockResolvedValueOnce({
+				type: 'sessions_list',
+				sessions: [{ id: 'session-1' }, { id: 'session-2' }, { id: 'session-3' }],
+			});
+		await action({ sendCommand } as never);
+		expect(sendCommand).toHaveBeenNthCalledWith(1, { type: 'ping' }, 'pong');
+		expect(sendCommand).toHaveBeenNthCalledWith(2, { type: 'get_sessions' }, 'sessions_list');
+		expect(consoleSpy).toHaveBeenCalledWith('Maestro is running on port 47321 with 2 sessions');
+		expect(processExitSpy).not.toHaveBeenCalled();
+	});
+
+	it('treats a missing sessions array as zero sessions', async () => {
+		vi.mocked(withMaestroClient).mockImplementation(async (action) => {
+			const client = {
+				sendCommand: vi
+					.fn()
+					.mockResolvedValueOnce({ type: 'pong' })
+					.mockResolvedValueOnce({ type: 'sessions_list' }),
+			};
+			return action(client as never);
+		});
+
+		await status();
+
+		expect(consoleSpy).toHaveBeenCalledWith('Maestro is running on port 47321 with 0 sessions');
+	});
+
+	it('exits with an error when Maestro cannot be reached', async () => {
+		vi.mocked(withMaestroClient).mockRejectedValue(new Error('Connection refused'));
+
+		await status();
+
+		expect(consoleErrorSpy).toHaveBeenCalledWith(
+			'Error: Failed to reach Maestro desktop app: Connection refused'
+		);
+		expect(processExitSpy).toHaveBeenCalledWith(1);
+	});
+});

--- a/src/__tests__/cli/services/maestro-client-session.test.ts
+++ b/src/__tests__/cli/services/maestro-client-session.test.ts
@@ -7,13 +7,11 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { SessionInfo } from '../../../shared/types';
 
 vi.mock('../../../cli/services/storage', () => ({
-	getSessionById: vi.fn(),
 	readSessions: vi.fn(),
-	readSettings: vi.fn(),
 }));
 
 import { resolveSessionId } from '../../../cli/services/maestro-client';
-import { getSessionById, readSessions, readSettings } from '../../../cli/services/storage';
+import { readSessions } from '../../../cli/services/storage';
 
 describe('resolveSessionId', () => {
 	const mockSession = (overrides: Partial<SessionInfo> = {}): SessionInfo => ({
@@ -27,32 +25,27 @@ describe('resolveSessionId', () => {
 
 	beforeEach(() => {
 		vi.clearAllMocks();
-		vi.mocked(readSettings).mockReturnValue({});
 		vi.mocked(readSessions).mockReturnValue([]);
-		vi.mocked(getSessionById).mockReturnValue(undefined);
 	});
 
 	it('uses an explicit session when provided', () => {
 		expect(resolveSessionId({ session: 'target-session' })).toBe('target-session');
-		expect(readSettings).not.toHaveBeenCalled();
 	});
 
-	it('uses the active session from settings when it exists', () => {
-		vi.mocked(readSettings).mockReturnValue({ activeSessionId: 'active-session' });
-		vi.mocked(getSessionById).mockReturnValue(mockSession({ id: 'active-session' }));
-
-		expect(resolveSessionId()).toBe('active-session');
-	});
-
-	it('falls back to the first stored session when there is no active session', () => {
+	it('falls back to the first stored session when no session is provided', () => {
 		vi.mocked(readSessions).mockReturnValue([mockSession({ id: 'first-session' })]);
 
 		expect(resolveSessionId()).toBe('first-session');
 	});
 
-	it('throws when no session can be resolved', () => {
-		expect(() => resolveSessionId()).toThrow(
-			'No Maestro sessions found. Pass --session <id> to target a specific session.'
+	it('exits when no session can be resolved', () => {
+		const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+		const processExitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+		expect(resolveSessionId()).toBe('');
+		expect(consoleErrorSpy).toHaveBeenCalledWith(
+			'Error: No agents found. Create an agent in Maestro first.'
 		);
+		expect(processExitSpy).toHaveBeenCalledWith(1);
 	});
 });

--- a/src/__tests__/cli/services/maestro-client-session.test.ts
+++ b/src/__tests__/cli/services/maestro-client-session.test.ts
@@ -1,0 +1,58 @@
+/**
+ * @file maestro-client-session.test.ts
+ * @description Tests for CLI Maestro session resolution helpers
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { SessionInfo } from '../../../shared/types';
+
+vi.mock('../../../cli/services/storage', () => ({
+	getSessionById: vi.fn(),
+	readSessions: vi.fn(),
+	readSettings: vi.fn(),
+}));
+
+import { resolveSessionId } from '../../../cli/services/maestro-client';
+import { getSessionById, readSessions, readSettings } from '../../../cli/services/storage';
+
+describe('resolveSessionId', () => {
+	const mockSession = (overrides: Partial<SessionInfo> = {}): SessionInfo => ({
+		id: 'session-123',
+		name: 'Test Agent',
+		toolType: 'claude-code',
+		cwd: '/path/to/project',
+		projectRoot: '/path/to/project',
+		...overrides,
+	});
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.mocked(readSettings).mockReturnValue({});
+		vi.mocked(readSessions).mockReturnValue([]);
+		vi.mocked(getSessionById).mockReturnValue(undefined);
+	});
+
+	it('uses an explicit session when provided', () => {
+		expect(resolveSessionId({ session: 'target-session' })).toBe('target-session');
+		expect(readSettings).not.toHaveBeenCalled();
+	});
+
+	it('uses the active session from settings when it exists', () => {
+		vi.mocked(readSettings).mockReturnValue({ activeSessionId: 'active-session' });
+		vi.mocked(getSessionById).mockReturnValue(mockSession({ id: 'active-session' }));
+
+		expect(resolveSessionId()).toBe('active-session');
+	});
+
+	it('falls back to the first stored session when there is no active session', () => {
+		vi.mocked(readSessions).mockReturnValue([mockSession({ id: 'first-session' })]);
+
+		expect(resolveSessionId()).toBe('first-session');
+	});
+
+	it('throws when no session can be resolved', () => {
+		expect(() => resolveSessionId()).toThrow(
+			'No Maestro sessions found. Pass --session <id> to target a specific session.'
+		);
+	});
+});

--- a/src/__tests__/cli/services/maestro-client.test.ts
+++ b/src/__tests__/cli/services/maestro-client.test.ts
@@ -275,19 +275,29 @@ describe('MaestroClient', () => {
 			expect(result.type).toBe('pong');
 		});
 
-		it('should ignore non-JSON messages', async () => {
+		it('should not match by response type when requestId is present but unknown', async () => {
 			const client = await createConnectedClient();
 
 			const commandPromise = client.sendCommand<{ type: string }>({ type: 'ping' }, 'pong');
 
-			// Send invalid JSON
-			mockWsInstance.emit('message', 'not json');
+			mockWsInstance.emit(
+				'message',
+				JSON.stringify({ type: 'pong', requestId: 'different-request' })
+			);
 
-			// Then send valid matching message
 			mockWsInstance.emit('message', JSON.stringify({ type: 'pong' }));
 
 			const result = await commandPromise;
 			expect(result.type).toBe('pong');
+		});
+
+		it('should reject pending requests on non-JSON messages', async () => {
+			const client = await createConnectedClient();
+
+			const commandPromise = client.sendCommand<{ type: string }>({ type: 'ping' }, 'pong');
+
+			expect(() => mockWsInstance.emit('message', 'not json')).toThrow();
+			await expect(commandPromise).rejects.toThrow('Invalid message from Maestro desktop app');
 		});
 	});
 

--- a/src/__tests__/cli/services/maestro-client.test.ts
+++ b/src/__tests__/cli/services/maestro-client.test.ts
@@ -296,7 +296,7 @@ describe('MaestroClient', () => {
 
 			const commandPromise = client.sendCommand<{ type: string }>({ type: 'ping' }, 'pong');
 
-			expect(() => mockWsInstance.emit('message', 'not json')).toThrow();
+			expect(() => mockWsInstance.emit('message', 'not json')).not.toThrow();
 			await expect(commandPromise).rejects.toThrow('Invalid message from Maestro desktop app');
 		});
 	});

--- a/src/__tests__/main/web-server/handlers/messageHandlers.test.ts
+++ b/src/__tests__/main/web-server/handlers/messageHandlers.test.ts
@@ -2524,6 +2524,9 @@ describe('WebSocketMessageHandler', () => {
 					maxLoops: 3,
 					saveAsPlaybook: undefined,
 					launch: true,
+					background: false,
+					model: undefined,
+					effort: undefined,
 					worktree: undefined,
 				});
 			});
@@ -2532,6 +2535,22 @@ describe('WebSocketMessageHandler', () => {
 			expect(response.type).toBe('configure_auto_run_result');
 			expect(response.success).toBe(true);
 			expect(response.sessionId).toBe('session-1');
+		});
+
+		it('should forward background placement as a strict opt-in', async () => {
+			handler.handleMessage(client, {
+				type: 'configure_auto_run',
+				sessionId: 'session-1',
+				documents: [{ filename: 'doc1.md' }],
+				background: true,
+			});
+
+			await vi.waitFor(() => {
+				expect(callbacks.configureAutoRun).toHaveBeenCalledWith(
+					'session-1',
+					expect.objectContaining({ background: true })
+				);
+			});
 		});
 
 		it('should reject configure auto run with missing sessionId', () => {
@@ -2592,6 +2611,9 @@ describe('WebSocketMessageHandler', () => {
 					maxLoops: undefined,
 					saveAsPlaybook: 'My Playbook',
 					launch: undefined,
+					background: false,
+					model: undefined,
+					effort: undefined,
 					worktree: undefined,
 				});
 			});
@@ -2646,6 +2668,9 @@ describe('WebSocketMessageHandler', () => {
 					maxLoops: undefined,
 					saveAsPlaybook: undefined,
 					launch: true,
+					background: false,
+					model: undefined,
+					effort: undefined,
 					worktree: {
 						enabled: true,
 						path: '/tmp/worktree',

--- a/src/__tests__/renderer/hooks/batch/useSpecDrivenConfig.test.ts
+++ b/src/__tests__/renderer/hooks/batch/useSpecDrivenConfig.test.ts
@@ -1,0 +1,41 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useSpecDrivenConfig } from '../../../../renderer/hooks/batch/useSpecDrivenConfig';
+import { useBatchStore } from '../../../../renderer/stores/batchStore';
+
+describe('useSpecDrivenConfig', () => {
+	beforeEach(() => {
+		useBatchStore.setState({
+			documentTaskCounts: new Map(),
+			isLoadingDocuments: false,
+		});
+	});
+
+	it('seeds documents and loop settings from an initial config', () => {
+		const document = {
+			id: 'remote-document',
+			filename: 'nested/spec',
+			resetOnCompletion: true,
+			isDuplicate: false,
+		};
+		const { result } = renderHook(() =>
+			useSpecDrivenConfig({
+				presetDocuments: ['preset'],
+				initialConfig: {
+					documents: [document],
+					loopEnabled: true,
+					maxLoops: 3,
+				},
+				allDocuments: [],
+				getDocumentTaskCount: vi.fn(),
+			})
+		);
+
+		expect(result.current.documents).toEqual([document]);
+		expect(result.current.initialDocumentsRef.current).toEqual(['nested/spec']);
+		expect(result.current.loopEnabled).toBe(true);
+		expect(result.current.maxLoops).toBe(3);
+		expect(result.current.initialLoopEnabledRef.current).toBe(true);
+		expect(result.current.initialMaxLoopsRef.current).toBe(3);
+	});
+});

--- a/src/__tests__/renderer/hooks/useAppRemoteEventListeners.test.ts
+++ b/src/__tests__/renderer/hooks/useAppRemoteEventListeners.test.ts
@@ -110,4 +110,57 @@ describe('useAppRemoteEventListeners', () => {
 			},
 		});
 	});
+
+	it('preserves a nested relative document path when launching', async () => {
+		const folderPath = path.join(os.tmpdir(), 'maestro-auto-run');
+		const session = createMockSession({ autoRunFolderPath: folderPath });
+		const startBatchRun = vi.fn().mockResolvedValue(undefined);
+
+		const deps: UseAppRemoteEventListenersDeps = {
+			sessionsRef: { current: [session] },
+			setActiveSessionId: vi.fn(),
+			setSessions: vi.fn(),
+			setGroups: vi.fn(),
+			handleOpenFileTab: vi.fn(),
+			refreshFileTree: vi.fn(),
+			handleAutoRunRefresh: vi.fn(),
+			startBatchRun,
+			stopBatchRun: vi.fn(),
+			resumeAfterError: vi.fn(),
+			skipCurrentDocument: vi.fn(),
+			abortBatchOnError: vi.fn(),
+		};
+
+		renderHook(() => useAppRemoteEventListeners(deps));
+
+		act(() => {
+			window.dispatchEvent(
+				new CustomEvent('maestro:configureAutoRun', {
+					detail: {
+						sessionId: session.id,
+						config: {
+							documents: [{ filename: 'nested/spec.md', resetOnCompletion: true }],
+							launch: true,
+						},
+						responseChannel: 'launch-response',
+					},
+				})
+			);
+		});
+
+		await waitFor(() => {
+			expect(startBatchRun).toHaveBeenCalledWith(
+				session.id,
+				expect.objectContaining({
+					documents: [
+						expect.objectContaining({
+							filename: 'nested/spec',
+							resetOnCompletion: true,
+						}),
+					],
+				}),
+				folderPath
+			);
+		});
+	});
 });

--- a/src/__tests__/renderer/hooks/useAppRemoteEventListeners.test.ts
+++ b/src/__tests__/renderer/hooks/useAppRemoteEventListeners.test.ts
@@ -1,0 +1,113 @@
+import path from 'path';
+import os from 'os';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+	useAppRemoteEventListeners,
+	type UseAppRemoteEventListenersDeps,
+} from '../../../renderer/hooks/remote/useAppRemoteEventListeners';
+import { useBatchStore } from '../../../renderer/stores/batchStore';
+import { useModalStore } from '../../../renderer/stores/modalStore';
+import { useUIStore } from '../../../renderer/stores/uiStore';
+import type { Session } from '../../../renderer/types';
+import { createMockSession } from '../../helpers/mockSession';
+
+describe('useAppRemoteEventListeners', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		window.maestro.process.sendRemoteConfigureAutoRunResponse = vi.fn();
+		useBatchStore.getState().clearDocumentList();
+		useModalStore.setState({ modals: new Map() });
+		useUIStore.setState({ rightPanelOpen: false, activeRightTab: 'files' });
+	});
+
+	it('opens a preconfigured Batch Runner without launching', async () => {
+		const folderPath = path.join(os.tmpdir(), 'maestro-auto-run');
+		const documentPath = path.join('nested', 'spec.md');
+		const selectedFile = path.join('nested', 'spec');
+		const session = createMockSession({ autoRunFolderPath: folderPath });
+		const sessionsRef = { current: [session] };
+		const setSessions = vi.fn((next: Session[] | ((previous: Session[]) => Session[])) => {
+			sessionsRef.current = typeof next === 'function' ? next(sessionsRef.current) : next;
+		});
+		const setActiveSessionId = vi.fn();
+		const startBatchRun = vi.fn().mockResolvedValue(undefined);
+
+		vi.mocked(window.maestro.autorun.readDoc).mockResolvedValue({
+			success: true,
+			content: '# Spec',
+		});
+
+		const deps: UseAppRemoteEventListenersDeps = {
+			sessionsRef,
+			setActiveSessionId,
+			setSessions,
+			setGroups: vi.fn(),
+			handleOpenFileTab: vi.fn(),
+			refreshFileTree: vi.fn(),
+			handleAutoRunRefresh: vi.fn(),
+			startBatchRun,
+			stopBatchRun: vi.fn(),
+			resumeAfterError: vi.fn(),
+			skipCurrentDocument: vi.fn(),
+			abortBatchOnError: vi.fn(),
+		};
+
+		renderHook(() => useAppRemoteEventListeners(deps));
+
+		act(() => {
+			window.dispatchEvent(
+				new CustomEvent('maestro:configureAutoRun', {
+					detail: {
+						sessionId: session.id,
+						config: {
+							documents: [{ filename: documentPath, resetOnCompletion: true }],
+							prompt: 'Review each task',
+							loopEnabled: true,
+							maxLoops: 3,
+						},
+						responseChannel: 'configure-response',
+					},
+				})
+			);
+		});
+
+		await waitFor(() => {
+			expect(window.maestro.process.sendRemoteConfigureAutoRunResponse).toHaveBeenCalledWith(
+				'configure-response',
+				{ success: true }
+			);
+		});
+
+		expect(startBatchRun).not.toHaveBeenCalled();
+		expect(window.maestro.autorun.readDoc).toHaveBeenCalledWith(
+			folderPath,
+			documentPath,
+			undefined
+		);
+		expect(setActiveSessionId).toHaveBeenCalledWith(session.id);
+		expect(sessionsRef.current[0]).toMatchObject({
+			autoRunSelectedFile: selectedFile,
+			autoRunContent: '# Spec',
+			batchRunnerPrompt: 'Review each task',
+		});
+		expect(useBatchStore.getState().documentList).toEqual([selectedFile]);
+		expect(useUIStore.getState()).toMatchObject({
+			rightPanelOpen: true,
+			activeRightTab: 'autorun',
+		});
+		expect(useModalStore.getState().getData('batchRunner')).toMatchObject({
+			initialConfig: {
+				documents: [
+					{
+						filename: selectedFile,
+						resetOnCompletion: true,
+					},
+				],
+				prompt: 'Review each task',
+				loopEnabled: true,
+				maxLoops: 3,
+			},
+		});
+	});
+});

--- a/src/__tests__/renderer/hooks/useAppRemoteEventListeners.test.ts
+++ b/src/__tests__/renderer/hooks/useAppRemoteEventListeners.test.ts
@@ -111,6 +111,75 @@ describe('useAppRemoteEventListeners', () => {
 		});
 	});
 
+	it('configures the Batch Runner in the background without moving the view', async () => {
+		const folderPath = path.join(os.tmpdir(), 'maestro-auto-run');
+		const session = createMockSession({ autoRunFolderPath: folderPath });
+		const sessionsRef = { current: [session] };
+		const setSessions = vi.fn((next: Session[] | ((previous: Session[]) => Session[])) => {
+			sessionsRef.current = typeof next === 'function' ? next(sessionsRef.current) : next;
+		});
+		const setActiveSessionId = vi.fn();
+
+		vi.mocked(window.maestro.autorun.readDoc).mockResolvedValue({
+			success: true,
+			content: '# Background Spec',
+		});
+
+		const deps: UseAppRemoteEventListenersDeps = {
+			sessionsRef,
+			setActiveSessionId,
+			setSessions,
+			setGroups: vi.fn(),
+			handleOpenFileTab: vi.fn(),
+			refreshFileTree: vi.fn(),
+			handleAutoRunRefresh: vi.fn(),
+			startBatchRun: vi.fn().mockResolvedValue(undefined),
+			stopBatchRun: vi.fn(),
+			resumeAfterError: vi.fn(),
+			skipCurrentDocument: vi.fn(),
+			abortBatchOnError: vi.fn(),
+		};
+
+		renderHook(() => useAppRemoteEventListeners(deps));
+
+		act(() => {
+			window.dispatchEvent(
+				new CustomEvent('maestro:configureAutoRun', {
+					detail: {
+						sessionId: session.id,
+						config: {
+							documents: [{ filename: 'background.md' }],
+							background: true,
+						},
+						responseChannel: 'background-configure-response',
+					},
+				})
+			);
+		});
+
+		await waitFor(() => {
+			expect(window.maestro.process.sendRemoteConfigureAutoRunResponse).toHaveBeenCalledWith(
+				'background-configure-response',
+				{ success: true }
+			);
+		});
+
+		expect(setActiveSessionId).not.toHaveBeenCalled();
+		expect(sessionsRef.current[0]).toMatchObject({
+			autoRunSelectedFile: 'background',
+			autoRunContent: '# Background Spec',
+		});
+		expect(useUIStore.getState()).toMatchObject({
+			rightPanelOpen: false,
+			activeRightTab: 'files',
+		});
+		expect(useModalStore.getState().getData('batchRunner')).toMatchObject({
+			initialConfig: {
+				documents: [expect.objectContaining({ filename: 'background' })],
+			},
+		});
+	});
+
 	it('preserves a nested relative document path when launching', async () => {
 		const folderPath = path.join(os.tmpdir(), 'maestro-auto-run');
 		const session = createMockSession({ autoRunFolderPath: folderPath });

--- a/src/__tests__/shared/cli-server-discovery.test.ts
+++ b/src/__tests__/shared/cli-server-discovery.test.ts
@@ -16,6 +16,8 @@ vi.mock('fs', () => ({
 	mkdirSync: vi.fn(),
 	renameSync: vi.fn(),
 	unlinkSync: vi.fn(),
+	chmodSync: vi.fn(),
+	statSync: vi.fn(),
 }));
 
 vi.mock('os', () => ({
@@ -47,6 +49,8 @@ const mockFs = {
 	mkdirSync: fs.mkdirSync as ReturnType<typeof vi.fn>,
 	renameSync: fs.renameSync as ReturnType<typeof vi.fn>,
 	unlinkSync: fs.unlinkSync as ReturnType<typeof vi.fn>,
+	chmodSync: fs.chmodSync as ReturnType<typeof vi.fn>,
+	statSync: fs.statSync as ReturnType<typeof vi.fn>,
 };
 
 const mockOs = {
@@ -81,6 +85,8 @@ describe('cli-server-discovery', () => {
 		mockFs.mkdirSync.mockReturnValue(undefined);
 		mockFs.renameSync.mockReturnValue(undefined);
 		mockFs.unlinkSync.mockReturnValue(undefined);
+		mockFs.chmodSync.mockReturnValue(undefined);
+		mockFs.statSync.mockReturnValue({ mode: 0o700 });
 	});
 
 	afterEach(() => {
@@ -261,9 +267,11 @@ describe('cli-server-discovery', () => {
 			expect(mockFs.writeFileSync).toHaveBeenCalledWith(
 				expectedTmp,
 				JSON.stringify(sampleInfo, null, 2),
-				'utf-8'
+				{ encoding: 'utf-8', mode: 0o600 }
 			);
+			expect(mockFs.chmodSync).toHaveBeenCalledWith(expectedTmp, 0o600);
 			expect(mockFs.renameSync).toHaveBeenCalledWith(expectedTmp, expectedFile);
+			expect(mockFs.chmodSync).toHaveBeenCalledWith(expectedFile, 0o600);
 		});
 
 		it('should create directory if it does not exist', () => {
@@ -273,7 +281,7 @@ describe('cli-server-discovery', () => {
 
 			expect(mockFs.mkdirSync).toHaveBeenCalledWith(
 				path.join('/Users/testuser', 'Library', 'Application Support', 'maestro'),
-				{ recursive: true }
+				{ recursive: true, mode: 0o700 }
 			);
 		});
 

--- a/src/__tests__/shared/focusPlacement.test.ts
+++ b/src/__tests__/shared/focusPlacement.test.ts
@@ -33,6 +33,7 @@ const FOCUSING_TODAY: BackgroundCapableVerb[] = [
 	'create-worktree',
 	'switch-mode',
 	'refresh-auto-run',
+	'auto-run',
 ];
 
 describe('no verb changes its default', () => {

--- a/src/cli/commands/auto-run.ts
+++ b/src/cli/commands/auto-run.ts
@@ -3,6 +3,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { withMaestroClient, resolveTargetSessionId } from '../services/maestro-client';
+import { getSessionById } from '../services/storage';
 
 interface AutoRunOptions {
 	agent?: string;
@@ -24,10 +25,35 @@ interface AutoRunOptions {
 	effort?: string;
 }
 
+interface ConfigureAutoRunResult {
+	type: 'configure_auto_run_result';
+	success: boolean;
+	playbookId?: string;
+	error?: string;
+}
+
+function getAutoRunDocumentFilename(documentPath: string, autoRunFolderPath: string): string {
+	const resolvedDocumentPath = path.resolve(documentPath);
+	const relativePath = path.relative(autoRunFolderPath, resolvedDocumentPath);
+	if (
+		relativePath === '' ||
+		relativePath.startsWith('..' + path.sep) ||
+		relativePath === '..' ||
+		path.isAbsolute(relativePath)
+	) {
+		throw new Error(
+			`Document must be in the session Auto Run folder: ${autoRunFolderPath}. Received: ${resolvedDocumentPath}`
+		);
+	}
+
+	return relativePath.split(path.sep).join(path.posix.sep);
+}
+
 export async function autoRun(docs: string[], options: AutoRunOptions): Promise<void> {
 	if (!docs || docs.length === 0) {
 		console.error('Error: At least one document path is required');
 		process.exit(1);
+		return;
 	}
 
 	// Resolve and validate each document path
@@ -38,22 +64,50 @@ export async function autoRun(docs: string[], options: AutoRunOptions): Promise<
 		if (!fs.existsSync(absolutePath)) {
 			console.error(`Error: File not found: ${absolutePath}`);
 			process.exit(1);
+			return;
+		}
+
+		const stats = fs.statSync(absolutePath);
+		if (!stats.isFile()) {
+			console.error(`Error: Document is not a file: ${absolutePath}`);
+			process.exit(1);
+			return;
 		}
 
 		if (path.extname(absolutePath).toLowerCase() !== '.md') {
 			console.error(`Error: File must be a .md file: ${absolutePath}`);
 			process.exit(1);
+			return;
 		}
 
 		resolvedPaths.push(absolutePath);
 	}
 
 	const sessionId = resolveTargetSessionId(options.agent);
+	const session = getSessionById(sessionId);
+	if (!session) {
+		console.error(`Error: Session not found: ${sessionId}`);
+		process.exit(1);
+		return;
+	}
+	if (!session.autoRunFolderPath) {
+		console.error(`Error: Session has no Auto Run folder configured: ${sessionId}`);
+		process.exit(1);
+		return;
+	}
+	const autoRunFolderPath = path.resolve(session.autoRunFolderPath);
 
-	const documents = resolvedPaths.map((d) => ({
-		filename: d,
-		resetOnCompletion: options.resetOnCompletion || false,
-	}));
+	let documents: Array<{ filename: string; resetOnCompletion: boolean }>;
+	try {
+		documents = resolvedPaths.map((d) => ({
+			filename: getAutoRunDocumentFilename(d, autoRunFolderPath),
+			resetOnCompletion: options.resetOnCompletion || false,
+		}));
+	} catch (error) {
+		console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+		process.exit(1);
+		return;
+	}
 
 	const loopEnabled = options.loop || options.maxLoops !== undefined;
 	const maxLoops =
@@ -66,6 +120,7 @@ export async function autoRun(docs: string[], options: AutoRunOptions): Promise<
 	if (maxLoops !== undefined && (isNaN(maxLoops) || maxLoops < 1)) {
 		console.error('Error: --max-loops must be a positive integer');
 		process.exit(1);
+		return;
 	}
 
 	// Worktree configuration: requires --launch and --branch.
@@ -85,12 +140,15 @@ export async function autoRun(docs: string[], options: AutoRunOptions): Promise<
 		if (!options.launch) {
 			console.error('Error: --worktree requires --launch');
 			process.exit(1);
+			return;
 		} else if (!options.branch || options.branch.trim() === '') {
 			console.error('Error: --worktree requires --branch <name>');
 			process.exit(1);
+			return;
 		} else if (!options.worktreePath || options.worktreePath.trim() === '') {
 			console.error('Error: --worktree requires --worktree-path <path>');
 			process.exit(1);
+			return;
 		} else {
 			worktree = {
 				enabled: true,
@@ -112,6 +170,7 @@ export async function autoRun(docs: string[], options: AutoRunOptions): Promise<
 			'Error: --branch, --base-branch, --worktree-path, --create-pr, and --pr-target-branch require --worktree'
 		);
 		process.exit(1);
+		return;
 	}
 
 	// Run-scoped model/effort overrides. Sent only when set so an omitted flag
@@ -121,12 +180,7 @@ export async function autoRun(docs: string[], options: AutoRunOptions): Promise<
 
 	try {
 		const result = await withMaestroClient(async (client) => {
-			return client.sendCommand<{
-				type: string;
-				success: boolean;
-				playbookId?: string;
-				error?: string;
-			}>(
+			return client.sendCommand<ConfigureAutoRunResult>(
 				{
 					type: 'configure_auto_run',
 					sessionId,
@@ -144,6 +198,12 @@ export async function autoRun(docs: string[], options: AutoRunOptions): Promise<
 			);
 		});
 
+		if (!result.success) {
+			console.error(`Error: ${result.error || 'Failed to configure auto-run'}`);
+			process.exit(1);
+			return;
+		}
+
 		if (result.success) {
 			if (options.saveAs) {
 				console.log(
@@ -158,12 +218,10 @@ export async function autoRun(docs: string[], options: AutoRunOptions): Promise<
 					`Auto-run configured with ${documents.length} document${documents.length !== 1 ? 's' : ''}`
 				);
 			}
-		} else {
-			console.error(`Error: ${result.error || 'Failed to configure auto-run'}`);
-			process.exit(1);
 		}
 	} catch (error) {
 		console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
 		process.exit(1);
+		return;
 	}
 }

--- a/src/cli/commands/auto-run.ts
+++ b/src/cli/commands/auto-run.ts
@@ -204,20 +204,18 @@ export async function autoRun(docs: string[], options: AutoRunOptions): Promise<
 			return;
 		}
 
-		if (result.success) {
-			if (options.saveAs) {
-				console.log(
-					`Playbook '${options.saveAs}' saved${result.playbookId ? ` (ID: ${result.playbookId})` : ''}`
-				);
-			} else if (options.launch) {
-				console.log(
-					`Auto-run launched with ${documents.length} document${documents.length !== 1 ? 's' : ''}`
-				);
-			} else {
-				console.log(
-					`Auto-run configured with ${documents.length} document${documents.length !== 1 ? 's' : ''}`
-				);
-			}
+		if (options.saveAs) {
+			console.log(
+				`Playbook '${options.saveAs}' saved${result.playbookId ? ` (ID: ${result.playbookId})` : ''}`
+			);
+		} else if (options.launch) {
+			console.log(
+				`Auto-run launched with ${documents.length} document${documents.length !== 1 ? 's' : ''}`
+			);
+		} else {
+			console.log(
+				`Auto-run configured with ${documents.length} document${documents.length !== 1 ? 's' : ''}`
+			);
 		}
 	} catch (error) {
 		console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);

--- a/src/cli/commands/auto-run.ts
+++ b/src/cli/commands/auto-run.ts
@@ -4,6 +4,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { withMaestroClient, resolveTargetSessionId } from '../services/maestro-client';
 import { getSessionById } from '../services/storage';
+import { resolveBackgroundFlag } from '../../shared/focusPlacement';
 
 interface AutoRunOptions {
 	agent?: string;
@@ -19,6 +20,8 @@ interface AutoRunOptions {
 	worktreePath?: string;
 	createPr?: boolean;
 	prTargetBranch?: string;
+	background?: boolean;
+	focus?: boolean;
 	// Run-scoped overrides: they win over the agent's configured model/effort for
 	// this run only and are never written back to the session.
 	model?: string;
@@ -177,6 +180,7 @@ export async function autoRun(docs: string[], options: AutoRunOptions): Promise<
 	// leaves the agent's configured default untouched.
 	const runModel = options.model?.trim() || undefined;
 	const runEffort = options.effort?.trim() || undefined;
+	const background = resolveBackgroundFlag(options, 'auto-run');
 
 	try {
 		const result = await withMaestroClient(async (client) => {
@@ -190,6 +194,7 @@ export async function autoRun(docs: string[], options: AutoRunOptions): Promise<
 					maxLoops,
 					saveAsPlaybook: options.saveAs,
 					launch: options.launch,
+					background,
 					worktree,
 					...(runModel && { model: runModel }),
 					...(runEffort && { effort: runEffort }),

--- a/src/cli/commands/status.ts
+++ b/src/cli/commands/status.ts
@@ -9,11 +9,13 @@ export async function status(): Promise<void> {
 	if (!info) {
 		console.log('Maestro desktop app is not running');
 		process.exit(ExitCode.NotRunning);
+		return;
 	}
 
 	if (!isCliServerRunning()) {
 		console.log('Maestro discovery file is stale (app may have crashed)');
 		process.exit(ExitCode.NotRunning);
+		return;
 	}
 
 	try {
@@ -35,5 +37,6 @@ export async function status(): Promise<void> {
 	} catch (error) {
 		console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
 		process.exit(ExitCode.NotRunning);
+		return;
 	}
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -696,6 +696,8 @@ program
 	.option('--max-loops <n>', 'Maximum loop count (implies --loop)')
 	.option('--save-as <name>', "Save as a playbook with this name (don't launch)")
 	.option('--launch', 'Start the auto-run immediately (default: just configure)')
+	.option('--background', 'Configure without switching to the target agent or Auto Run view')
+	.option('--focus', 'Switch to the target agent and Auto Run view while configuring (default)')
 	.option('--reset-on-completion', 'Enable reset-on-completion for all documents')
 	.option(
 		'--worktree',

--- a/src/cli/services/maestro-client.ts
+++ b/src/cli/services/maestro-client.ts
@@ -156,6 +156,14 @@ export class MaestroClient {
 		}
 	}
 
+	private rejectAllPending(error: Error): void {
+		for (const [, pending] of this.pendingRequests) {
+			clearTimeout(pending.timeout);
+			pending.reject(error);
+		}
+		this.pendingRequests.clear();
+	}
+
 	private setupMessageHandler(): void {
 		if (!this.ws) return;
 
@@ -221,6 +229,9 @@ export class MaestroClient {
 					pending.resolve(msg);
 					return;
 				}
+				if (msgRequestId) {
+					return;
+				}
 
 				// Fall back to matching by response type
 				for (const [requestId, pending] of this.pendingRequests) {
@@ -231,8 +242,9 @@ export class MaestroClient {
 						return;
 					}
 				}
-			} catch {
-				// Ignore non-JSON messages
+			} catch (error) {
+				this.rejectAllPending(new Error('Invalid message from Maestro desktop app'));
+				throw error;
 			}
 		});
 	}
@@ -242,7 +254,7 @@ export class MaestroClient {
  * Resolve session ID from CLI options.
  * Uses the provided --session value, or falls back to the first available session.
  */
-export function resolveSessionId(options: { session?: string }): string {
+export function resolveSessionId(options: { session?: string } = {}): string {
 	if (options.session) {
 		return options.session;
 	}
@@ -251,6 +263,7 @@ export function resolveSessionId(options: { session?: string }): string {
 	if (sessions.length === 0) {
 		console.error('Error: No agents found. Create an agent in Maestro first.');
 		process.exit(1);
+		return '';
 	}
 
 	return sessions[0].id;

--- a/src/cli/services/maestro-client.ts
+++ b/src/cli/services/maestro-client.ts
@@ -242,9 +242,10 @@ export class MaestroClient {
 						return;
 					}
 				}
-			} catch (error) {
+			} catch {
+				// A malformed frame invalidates this short-lived connection, so reject
+				// every in-flight command through the promises their callers await.
 				this.rejectAllPending(new Error('Invalid message from Maestro desktop app'));
-				throw error;
 			}
 		});
 	}

--- a/src/main/preload/process/autoRunConfigRemote.ts
+++ b/src/main/preload/process/autoRunConfigRemote.ts
@@ -1,4 +1,5 @@
 import { ipcRenderer } from 'electron';
+import type { ConfigureAutoRunConfig } from '../../web-server/types';
 
 export function createAutoRunConfigRemoteApi() {
 	return {
@@ -18,9 +19,14 @@ export function createAutoRunConfigRemoteApi() {
 		 * Subscribe to remote configure auto-run from CLI/web interface
 		 */
 		onRemoteConfigureAutoRun: (
-			callback: (sessionId: string, config: any, responseChannel: string) => void
+			callback: (sessionId: string, config: ConfigureAutoRunConfig, responseChannel: string) => void
 		): (() => void) => {
-			const handler = (_: unknown, sessionId: string, config: any, responseChannel: string) => {
+			const handler = (
+				_: unknown,
+				sessionId: string,
+				config: ConfigureAutoRunConfig,
+				responseChannel: string
+			) => {
 				try {
 					// callback may return a promise even though typed as void
 					Promise.resolve(callback(sessionId, config, responseChannel)).catch((error) => {

--- a/src/main/web-server/callbacks/autoRunConfigCallbacks.ts
+++ b/src/main/web-server/callbacks/autoRunConfigCallbacks.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'crypto';
 import { ipcMain } from 'electron';
 import type { WebServer } from '../WebServer';
+import type { ConfigureAutoRunConfig } from '../types';
 import type { WebServerFactoryDependencies } from '../web-server-factory';
 import { logger } from '../../utils/logger';
 import { isWebContentsAvailable } from '../../utils/safe-send';
@@ -27,7 +28,7 @@ export function registerAutoRunConfigCallbacks(
 		return true;
 	});
 
-	server.setConfigureAutoRunCallback(async (sessionId: string, config: any) => {
+	server.setConfigureAutoRunCallback(async (sessionId: string, config: ConfigureAutoRunConfig) => {
 		const mainWindow = getMainWindow();
 		if (!mainWindow) {
 			logger.warn('mainWindow is null for configureAutoRun', 'WebServer');

--- a/src/main/web-server/handlers/messageHandlers/autoRun.ts
+++ b/src/main/web-server/handlers/messageHandlers/autoRun.ts
@@ -221,6 +221,7 @@ export function handleConfigureAutoRun(
 		maxLoops: message.maxLoops !== undefined ? Number(message.maxLoops) : undefined,
 		saveAsPlaybook: message.saveAsPlaybook as string | undefined,
 		launch: message.launch as boolean | undefined,
+		background: readBackgroundField(message),
 		model: message.model as string | undefined,
 		effort: message.effort as string | undefined,
 		worktree,

--- a/src/main/web-server/handlers/messageHandlers/types.ts
+++ b/src/main/web-server/handlers/messageHandlers/types.ts
@@ -37,6 +37,7 @@ import type {
 	ConsultAgentParams,
 	ConsultAgentResult,
 	RenameTabResult,
+	ConfigureAutoRunCallback,
 } from '../../types';
 import type { CadenzaPayload } from '../../../../shared/cadenza-types';
 import type { MovementPayload, MovementStateSnapshot } from '../../../../shared/movement-types';
@@ -188,32 +189,7 @@ export interface MessageHandlerCallbacks {
 		itemId: string
 	) => Promise<{ success: boolean; removed: boolean; error?: string }>;
 	refreshAutoRunDocs: (sessionId: string, background?: boolean) => Promise<boolean>;
-	configureAutoRun: (
-		sessionId: string,
-		config: {
-			documents: Array<{ filename: string; resetOnCompletion?: boolean }>;
-			prompt?: string;
-			loopEnabled?: boolean;
-			maxLoops?: number;
-			saveAsPlaybook?: string;
-			launch?: boolean;
-			/**
-			 * Per-run model/effort override (CLI `--model` / `--effort`). Wins over the
-			 * session's configured model for this run's spawns only; never written back
-			 * to the session. Absent means "use the agent default".
-			 */
-			model?: string;
-			effort?: string;
-			worktree?: {
-				enabled: boolean;
-				path: string;
-				branchName: string;
-				baseBranch: string;
-				createPROnCompletion: boolean;
-				prTargetBranch: string;
-			};
-		}
-	) => Promise<{ success: boolean; playbookId?: string; error?: string }>;
+	configureAutoRun: ConfigureAutoRunCallback;
 	/**
 	 * Launch a desktop-owned Goal-Driven Auto Run (`goal-run --visible`). Goal
 	 * mode is document-less, so this carries a free-text goal rather than a

--- a/src/main/web-server/types.ts
+++ b/src/main/web-server/types.ts
@@ -251,7 +251,7 @@ export interface ConfigureAutoRunConfig {
 		enabled: boolean;
 		path: string;
 		branchName: string;
-		baseBranch: string;
+		baseBranch?: string;
 		createPROnCompletion: boolean;
 		prTargetBranch: string;
 	};

--- a/src/main/web-server/types.ts
+++ b/src/main/web-server/types.ts
@@ -227,6 +227,35 @@ export interface CliActivity {
 	startedAt: number;
 }
 
+/**
+ * Auto Run document configuration received from CLI/web IPC.
+ */
+export interface ConfigureAutoRunDocument {
+	filename: string;
+	resetOnCompletion?: boolean;
+}
+
+/**
+ * Auto Run configuration payload received from CLI/web IPC.
+ */
+export interface ConfigureAutoRunConfig {
+	documents: ConfigureAutoRunDocument[];
+	prompt?: string;
+	loopEnabled?: boolean;
+	maxLoops?: number;
+	saveAsPlaybook?: string;
+	launch?: boolean;
+}
+
+/**
+ * Response returned after forwarding an Auto Run configuration request.
+ */
+export interface ConfigureAutoRunResult {
+	success: boolean;
+	playbookId?: string;
+	error?: string;
+}
+
 // =============================================================================
 // WebSocket Client Types
 // =============================================================================
@@ -447,6 +476,10 @@ export type OpenTerminalTabCallback = (
 	config: OpenTerminalTabConfig
 ) => Promise<boolean>;
 export type RefreshAutoRunDocsCallback = (sessionId: string) => Promise<boolean>;
+export type ConfigureAutoRunCallback = (
+	sessionId: string,
+	config: ConfigureAutoRunConfig
+) => Promise<ConfigureAutoRunResult>;
 
 /**
  * Updates the Auto Run folder for an existing session. Mirrors what the desktop

--- a/src/main/web-server/types.ts
+++ b/src/main/web-server/types.ts
@@ -245,6 +245,16 @@ export interface ConfigureAutoRunConfig {
 	maxLoops?: number;
 	saveAsPlaybook?: string;
 	launch?: boolean;
+	model?: string;
+	effort?: string;
+	worktree?: {
+		enabled: boolean;
+		path: string;
+		branchName: string;
+		baseBranch: string;
+		createPROnCompletion: boolean;
+		prTargetBranch: string;
+	};
 }
 
 /**
@@ -275,6 +285,7 @@ export interface WebClient {
  */
 export interface WebClientMessage {
 	type: string;
+	requestId?: string;
 	sessionId?: string;
 	tabId?: string;
 	command?: string;
@@ -596,31 +607,6 @@ export type InteractMovementDesignerCallback = (
 	action: ConcertoDesignerAction
 ) => Promise<ConcertoDesignerActionResult>;
 export type NotifyCenterFlashCallback = (params: NotifyCenterFlashParams) => Promise<boolean>;
-export type ConfigureAutoRunCallback = (
-	sessionId: string,
-	config: {
-		documents: Array<{ filename: string; resetOnCompletion?: boolean }>;
-		prompt?: string;
-		loopEnabled?: boolean;
-		maxLoops?: number;
-		saveAsPlaybook?: string;
-		launch?: boolean;
-		/**
-		 * Per-run model/effort override (CLI `--model` / `--effort`). Wins over the
-		 * session's configured model for this run's spawns only; never written back
-		 * to the session. Absent means "use the agent default".
-		 */
-		model?: string;
-		effort?: string;
-		worktree?: {
-			enabled: boolean;
-			path: string;
-			branchName: string;
-			createPROnCompletion: boolean;
-			prTargetBranch: string;
-		};
-	}
-) => Promise<{ success: boolean; playbookId?: string; error?: string }>;
 
 /**
  * Callback type for fetching current theme.

--- a/src/main/web-server/types.ts
+++ b/src/main/web-server/types.ts
@@ -201,6 +201,35 @@ export interface CliActivity {
 	startedAt: number;
 }
 
+/**
+ * Auto Run document configuration received from CLI/web IPC.
+ */
+export interface ConfigureAutoRunDocument {
+	filename: string;
+	resetOnCompletion?: boolean;
+}
+
+/**
+ * Auto Run configuration payload received from CLI/web IPC.
+ */
+export interface ConfigureAutoRunConfig {
+	documents: ConfigureAutoRunDocument[];
+	prompt?: string;
+	loopEnabled?: boolean;
+	maxLoops?: number;
+	saveAsPlaybook?: string;
+	launch?: boolean;
+}
+
+/**
+ * Response returned after forwarding an Auto Run configuration request.
+ */
+export interface ConfigureAutoRunResult {
+	success: boolean;
+	playbookId?: string;
+	error?: string;
+}
+
 // =============================================================================
 // WebSocket Client Types
 // =============================================================================
@@ -638,6 +667,10 @@ export type RefreshAutoRunDocsCallback = (
 	sessionId: string,
 	background?: boolean
 ) => Promise<boolean>;
+export type ConfigureAutoRunCallback = (
+	sessionId: string,
+	config: ConfigureAutoRunConfig
+) => Promise<ConfigureAutoRunResult>;
 
 /**
  * Updates the Auto Run folder for an existing session. Mirrors what the desktop

--- a/src/main/web-server/types.ts
+++ b/src/main/web-server/types.ts
@@ -219,6 +219,8 @@ export interface ConfigureAutoRunConfig {
 	maxLoops?: number;
 	saveAsPlaybook?: string;
 	launch?: boolean;
+	/** Configure state without moving the active agent or Auto Run view. */
+	background?: boolean;
 	model?: string;
 	effort?: string;
 	worktree?: {

--- a/src/main/web-server/types.ts
+++ b/src/main/web-server/types.ts
@@ -219,6 +219,16 @@ export interface ConfigureAutoRunConfig {
 	maxLoops?: number;
 	saveAsPlaybook?: string;
 	launch?: boolean;
+	model?: string;
+	effort?: string;
+	worktree?: {
+		enabled: boolean;
+		path: string;
+		branchName: string;
+		baseBranch: string;
+		createPROnCompletion: boolean;
+		prTargetBranch: string;
+	};
 }
 
 /**
@@ -249,6 +259,7 @@ export interface WebClient {
  */
 export interface WebClientMessage {
 	type: string;
+	requestId?: string;
 	sessionId?: string;
 	tabId?: string;
 	command?: string;
@@ -784,31 +795,6 @@ export type InteractMovementDesignerCallback = (
 	action: ConcertoDesignerAction
 ) => Promise<ConcertoDesignerActionResult>;
 export type NotifyCenterFlashCallback = (params: NotifyCenterFlashParams) => Promise<boolean>;
-export type ConfigureAutoRunCallback = (
-	sessionId: string,
-	config: {
-		documents: Array<{ filename: string; resetOnCompletion?: boolean }>;
-		prompt?: string;
-		loopEnabled?: boolean;
-		maxLoops?: number;
-		saveAsPlaybook?: string;
-		launch?: boolean;
-		/**
-		 * Per-run model/effort override (CLI `--model` / `--effort`). Wins over the
-		 * session's configured model for this run's spawns only; never written back
-		 * to the session. Absent means "use the agent default".
-		 */
-		model?: string;
-		effort?: string;
-		worktree?: {
-			enabled: boolean;
-			path: string;
-			branchName: string;
-			createPROnCompletion: boolean;
-			prTargetBranch: string;
-		};
-	}
-) => Promise<{ success: boolean; playbookId?: string; error?: string }>;
 
 /**
  * Launch a Goal-Driven Auto Run that the DESKTOP owns, from the CLI

--- a/src/main/web-server/types.ts
+++ b/src/main/web-server/types.ts
@@ -225,7 +225,7 @@ export interface ConfigureAutoRunConfig {
 		enabled: boolean;
 		path: string;
 		branchName: string;
-		baseBranch: string;
+		baseBranch?: string;
 		createPROnCompletion: boolean;
 		prTargetBranch: string;
 	};

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -2256,6 +2256,78 @@ function MaestroConsoleInner() {
 			sshReduceEntryCapFraction: settings.sshReduceEntryCapFraction,
 		});
 
+	// CLI IPC remote events dispatched by useRemoteIntegration.
+	useEffect(() => {
+		const handleRemoteOpenFileTab = async (event: Event) => {
+			const { sessionId, filePath } = (
+				event as CustomEvent<{ sessionId: string; filePath: string }>
+			).detail;
+			const session = sessionsRef.current.find((s) => s.id === sessionId);
+			if (!session || !filePath) return;
+
+			const sshRemoteId =
+				session.sshRemoteId || session.sessionSshRemoteConfig?.remoteId || undefined;
+			const fileName = filePath.replace(/\\/g, '/').split('/').pop() || filePath;
+
+			try {
+				const [content, stat] = await Promise.all([
+					window.maestro.fs.readFile(filePath, sshRemoteId),
+					window.maestro.fs.stat(filePath, sshRemoteId),
+				]);
+				if (content === null) return;
+
+				setActiveSessionId(sessionId);
+				handleOpenFileTab({
+					path: filePath,
+					name: fileName,
+					content,
+					sshRemoteId,
+					lastModified: stat?.modifiedAt ? new Date(stat.modifiedAt).getTime() : Date.now(),
+				});
+				setActiveFocus('main');
+			} catch (error) {
+				console.error('[Remote] Failed to open file tab:', error);
+			}
+		};
+
+		const handleRemoteRefreshFileTree = (event: Event) => {
+			const { sessionId } = (event as CustomEvent<{ sessionId: string }>).detail;
+			const session = sessionsRef.current.find((s) => s.id === sessionId);
+			if (!session) return;
+			refreshFileTree(sessionId);
+		};
+
+		const handleRemoteRefreshAutoRunDocs = (event: Event) => {
+			const { sessionId } = (event as CustomEvent<{ sessionId: string }>).detail;
+			const session = sessionsRef.current.find((s) => s.id === sessionId);
+			if (!session) return;
+
+			if (activeSessionIdRef.current !== sessionId) {
+				setActiveSessionId(sessionId);
+				return;
+			}
+			handleAutoRunRefresh();
+		};
+
+		window.addEventListener('maestro:openFileTab', handleRemoteOpenFileTab);
+		window.addEventListener('maestro:refreshFileTree', handleRemoteRefreshFileTree);
+		window.addEventListener('maestro:refreshAutoRunDocs', handleRemoteRefreshAutoRunDocs);
+
+		return () => {
+			window.removeEventListener('maestro:openFileTab', handleRemoteOpenFileTab);
+			window.removeEventListener('maestro:refreshFileTree', handleRemoteRefreshFileTree);
+			window.removeEventListener('maestro:refreshAutoRunDocs', handleRemoteRefreshAutoRunDocs);
+		};
+	}, [
+		activeSessionIdRef,
+		handleAutoRunRefresh,
+		handleOpenFileTab,
+		refreshFileTree,
+		setActiveFocus,
+		setActiveSessionId,
+		sessionsRef,
+	]);
+
 	// --- FILE EXPLORER EFFECTS ---
 	// Extracted hook for file explorer side effects and keyboard navigation (Phase 2.6)
 	const { stableFileTree, handleMainPanelFileClick } = useFileExplorerEffects({

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -181,8 +181,20 @@ import { PluginModalPanelMount } from './components/plugins/PluginModalPanelMoun
 
 // Import types and constants
 // Note: GroupChat, GroupChatState are imported from types (re-exported from shared)
-import type { RightPanelTab, Session, QueuedItem, CustomAICommand } from './types';
+import type {
+	RightPanelTab,
+	Session,
+	QueuedItem,
+	CustomAICommand,
+	ThinkingItem,
+	BatchRunConfig,
+	BatchDocumentEntry,
+} from './types';
 import { useResolvedTheme } from './hooks/ui/useResolvedTheme';
+import { THEMES } from './constants/themes';
+import { usePluginContributions } from './hooks/usePluginContributions';
+import { resolvePluginTheme } from './utils/pluginThemes';
+import { generateId } from './utils/ids';
 import { getActiveOutputSearchKey } from './utils/outputSearch';
 import { reorderQueueItem } from './utils/executionQueue';
 import { getContextColor } from './utils/theme';
@@ -215,6 +227,21 @@ import { useUIStore } from './stores/uiStore';
 import { useSettingsStore } from './stores/settingsStore';
 import { useTabStore } from './stores/tabStore';
 import { useFileExplorerStore } from './stores/fileExplorerStore';
+
+type RemoteConfigureAutoRunConfig = {
+	documents: Array<{ filename: string; resetOnCompletion?: boolean }>;
+	prompt?: string;
+	loopEnabled?: boolean;
+	maxLoops?: number;
+	saveAsPlaybook?: string;
+	launch?: boolean;
+};
+
+type RemoteConfigureAutoRunResult = {
+	success: boolean;
+	playbookId?: string;
+	error?: string;
+};
 
 function MaestroConsoleInner() {
 	// --- LAYER STACK (for blocking shortcuts when modals are open) ---
@@ -317,6 +344,7 @@ function MaestroConsoleInner() {
 		setMemoryViewerOpen,
 		// Batch Runner Modal
 		setBatchRunnerModalOpen,
+		openBatchRunnerWithConfig,
 		// Auto Run Setup Modal
 		setAutoRunSetupModalOpen,
 		// Marketplace Modal - marketplaceModalOpen now self-sourced in AppStandaloneModals
@@ -2309,14 +2337,138 @@ function MaestroConsoleInner() {
 			handleAutoRunRefresh();
 		};
 
+		const handleRemoteConfigureAutoRun = async (event: Event) => {
+			const { sessionId, config, responseChannel } = (
+				event as CustomEvent<{
+					sessionId: string;
+					config: RemoteConfigureAutoRunConfig;
+					responseChannel: string;
+				}>
+			).detail;
+			const sendResponse = (result: RemoteConfigureAutoRunResult) => {
+				window.maestro.process.sendRemoteConfigureAutoRunResponse(responseChannel, result);
+			};
+			try {
+				const session = sessionsRef.current.find((s) => s.id === sessionId);
+				if (!session) {
+					sendResponse({ success: false, error: 'Session not found' });
+					return;
+				}
+
+				const documents: BatchDocumentEntry[] = config.documents.map((doc, index, allDocs) => {
+					const filename = doc.filename.replace(/\.md$/i, '');
+					return {
+						id: generateId(),
+						filename,
+						resetOnCompletion: doc.resetOnCompletion || false,
+						isDuplicate:
+							allDocs.findIndex((other) => other.filename.replace(/\.md$/i, '') === filename) !==
+							index,
+					};
+				});
+				const batchConfig: BatchRunConfig = {
+					documents,
+					prompt: config.prompt || '',
+					loopEnabled: config.loopEnabled || false,
+					maxLoops:
+						config.loopEnabled || config.maxLoops !== undefined ? (config.maxLoops ?? null) : null,
+				};
+
+				if (config.saveAsPlaybook) {
+					try {
+						const result = await window.maestro.playbooks.create(sessionId, {
+							name: config.saveAsPlaybook,
+							documents: documents.map((doc) => ({
+								filename: doc.filename,
+								resetOnCompletion: doc.resetOnCompletion,
+							})),
+							prompt: batchConfig.prompt,
+							loopEnabled: batchConfig.loopEnabled,
+							maxLoops: batchConfig.maxLoops,
+						});
+						if (!result.success || !result.playbook) {
+							sendResponse({
+								success: false,
+								error: result.error || 'Failed to save playbook',
+							});
+							return;
+						}
+						sendResponse({ success: true, playbookId: result.playbook.id });
+					} catch (error) {
+						sendResponse({
+							success: false,
+							error: error instanceof Error ? error.message : String(error),
+						});
+					}
+					return;
+				}
+
+				if (!session.autoRunFolderPath) {
+					sendResponse({ success: false, error: 'Session has no Auto Run folder configured' });
+					return;
+				}
+
+				if (config.launch) {
+					try {
+						await startBatchRunRef.current(sessionId, batchConfig, session.autoRunFolderPath);
+						sendResponse({ success: true });
+					} catch (error) {
+						sendResponse({
+							success: false,
+							error: error instanceof Error ? error.message : String(error),
+						});
+					}
+					return;
+				}
+
+				const selectedFile = documents[0]?.filename;
+				let selectedContent = '';
+				if (selectedFile) {
+					const sshRemoteId =
+						session.sshRemoteId || session.sessionSshRemoteConfig?.remoteId || undefined;
+					const result = await window.maestro.autorun.readDoc(
+						session.autoRunFolderPath,
+						selectedFile + '.md',
+						sshRemoteId
+					);
+					selectedContent = result.success ? result.content || '' : '';
+				}
+
+				updateSessionWith(sessionId, (s) => ({
+					...s,
+					autoRunSelectedFile: selectedFile,
+					autoRunContent: selectedContent,
+					autoRunContentVersion: (s.autoRunContentVersion || 0) + 1,
+					batchRunnerPrompt: batchConfig.prompt,
+					batchRunnerPromptModifiedAt: Date.now(),
+				}));
+				setAutoRunDocumentList(documents.map((doc) => doc.filename));
+				setActiveSessionId(sessionId);
+				setRightPanelOpen(true);
+				setActiveRightTab('autorun');
+				openBatchRunnerWithConfig(batchConfig);
+				sendResponse({ success: true });
+			} catch (error) {
+				captureException(error, {
+					extra: { context: 'handleRemoteConfigureAutoRun', sessionId },
+				});
+				sendResponse({
+					success: false,
+					error: error instanceof Error ? error.message : String(error),
+				});
+			}
+		};
+
 		window.addEventListener('maestro:openFileTab', handleRemoteOpenFileTab);
 		window.addEventListener('maestro:refreshFileTree', handleRemoteRefreshFileTree);
 		window.addEventListener('maestro:refreshAutoRunDocs', handleRemoteRefreshAutoRunDocs);
+		window.addEventListener('maestro:configureAutoRun', handleRemoteConfigureAutoRun);
 
 		return () => {
 			window.removeEventListener('maestro:openFileTab', handleRemoteOpenFileTab);
 			window.removeEventListener('maestro:refreshFileTree', handleRemoteRefreshFileTree);
 			window.removeEventListener('maestro:refreshAutoRunDocs', handleRemoteRefreshAutoRunDocs);
+			window.removeEventListener('maestro:configureAutoRun', handleRemoteConfigureAutoRun);
 		};
 	}, [
 		activeSessionIdRef,
@@ -2324,8 +2476,12 @@ function MaestroConsoleInner() {
 		handleOpenFileTab,
 		refreshFileTree,
 		setActiveFocus,
+		setActiveRightTab,
+		setRightPanelOpen,
 		setActiveSessionId,
 		sessionsRef,
+		setAutoRunDocumentList,
+		openBatchRunnerWithConfig,
 	]);
 
 	// --- FILE EXPLORER EFFECTS ---

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -181,15 +181,7 @@ import { PluginModalPanelMount } from './components/plugins/PluginModalPanelMoun
 
 // Import types and constants
 // Note: GroupChat, GroupChatState are imported from types (re-exported from shared)
-import type {
-	RightPanelTab,
-	Session,
-	QueuedItem,
-	CustomAICommand,
-	ThinkingItem,
-	BatchRunConfig,
-	BatchDocumentEntry,
-} from './types';
+import type { RightPanelTab, Session, QueuedItem, CustomAICommand } from './types';
 import { useResolvedTheme } from './hooks/ui/useResolvedTheme';
 import { getActiveOutputSearchKey } from './utils/outputSearch';
 import { reorderQueueItem } from './utils/executionQueue';
@@ -223,21 +215,6 @@ import { useUIStore } from './stores/uiStore';
 import { useSettingsStore } from './stores/settingsStore';
 import { useTabStore } from './stores/tabStore';
 import { useFileExplorerStore } from './stores/fileExplorerStore';
-
-type RemoteConfigureAutoRunConfig = {
-	documents: Array<{ filename: string; resetOnCompletion?: boolean }>;
-	prompt?: string;
-	loopEnabled?: boolean;
-	maxLoops?: number;
-	saveAsPlaybook?: string;
-	launch?: boolean;
-};
-
-type RemoteConfigureAutoRunResult = {
-	success: boolean;
-	playbookId?: string;
-	error?: string;
-};
 
 function MaestroConsoleInner() {
 	// --- LAYER STACK (for blocking shortcuts when modals are open) ---
@@ -340,7 +317,6 @@ function MaestroConsoleInner() {
 		setMemoryViewerOpen,
 		// Batch Runner Modal
 		setBatchRunnerModalOpen,
-		openBatchRunnerWithConfig,
 		// Auto Run Setup Modal
 		setAutoRunSetupModalOpen,
 		// Marketplace Modal - marketplaceModalOpen now self-sourced in AppStandaloneModals
@@ -2279,207 +2255,6 @@ function MaestroConsoleInner() {
 			sshReduceEntryCapEnabled: settings.sshReduceEntryCapEnabled,
 			sshReduceEntryCapFraction: settings.sshReduceEntryCapFraction,
 		});
-
-	// CLI IPC remote events dispatched by useRemoteIntegration.
-	useEffect(() => {
-		const handleRemoteOpenFileTab = async (event: Event) => {
-			const { sessionId, filePath } = (
-				event as CustomEvent<{ sessionId: string; filePath: string }>
-			).detail;
-			const session = sessionsRef.current.find((s) => s.id === sessionId);
-			if (!session || !filePath) return;
-
-			const sshRemoteId =
-				session.sshRemoteId || session.sessionSshRemoteConfig?.remoteId || undefined;
-			const fileName = filePath.replace(/\\/g, '/').split('/').pop() || filePath;
-
-			try {
-				const [content, stat] = await Promise.all([
-					window.maestro.fs.readFile(filePath, sshRemoteId),
-					window.maestro.fs.stat(filePath, sshRemoteId),
-				]);
-				if (content === null) return;
-
-				setActiveSessionId(sessionId);
-				handleOpenFileTab({
-					path: filePath,
-					name: fileName,
-					content,
-					sshRemoteId,
-					lastModified: stat?.modifiedAt ? new Date(stat.modifiedAt).getTime() : Date.now(),
-				});
-				setActiveFocus('main');
-			} catch (error) {
-				console.error('[Remote] Failed to open file tab:', error);
-			}
-		};
-
-		const handleRemoteRefreshFileTree = (event: Event) => {
-			const { sessionId } = (event as CustomEvent<{ sessionId: string }>).detail;
-			const session = sessionsRef.current.find((s) => s.id === sessionId);
-			if (!session) return;
-			refreshFileTree(sessionId);
-		};
-
-		const handleRemoteRefreshAutoRunDocs = (event: Event) => {
-			const { sessionId } = (event as CustomEvent<{ sessionId: string }>).detail;
-			const session = sessionsRef.current.find((s) => s.id === sessionId);
-			if (!session) return;
-
-			if (activeSessionIdRef.current !== sessionId) {
-				setActiveSessionId(sessionId);
-				return;
-			}
-			handleAutoRunRefresh();
-		};
-
-		const handleRemoteConfigureAutoRun = async (event: Event) => {
-			const { sessionId, config, responseChannel } = (
-				event as CustomEvent<{
-					sessionId: string;
-					config: RemoteConfigureAutoRunConfig;
-					responseChannel: string;
-				}>
-			).detail;
-			const sendResponse = (result: RemoteConfigureAutoRunResult) => {
-				window.maestro.process.sendRemoteConfigureAutoRunResponse(responseChannel, result);
-			};
-			try {
-				const session = sessionsRef.current.find((s) => s.id === sessionId);
-				if (!session) {
-					sendResponse({ success: false, error: 'Session not found' });
-					return;
-				}
-
-				const documents: BatchDocumentEntry[] = config.documents.map((doc, index, allDocs) => {
-					const filename = doc.filename.replace(/\.md$/i, '');
-					return {
-						id: generateId(),
-						filename,
-						resetOnCompletion: doc.resetOnCompletion || false,
-						isDuplicate:
-							allDocs.findIndex((other) => other.filename.replace(/\.md$/i, '') === filename) !==
-							index,
-					};
-				});
-				const batchConfig: BatchRunConfig = {
-					documents,
-					prompt: config.prompt || '',
-					loopEnabled: config.loopEnabled || false,
-					maxLoops:
-						config.loopEnabled || config.maxLoops !== undefined ? (config.maxLoops ?? null) : null,
-				};
-
-				if (config.saveAsPlaybook) {
-					try {
-						const result = await window.maestro.playbooks.create(sessionId, {
-							name: config.saveAsPlaybook,
-							documents: documents.map((doc) => ({
-								filename: doc.filename,
-								resetOnCompletion: doc.resetOnCompletion,
-							})),
-							prompt: batchConfig.prompt,
-							loopEnabled: batchConfig.loopEnabled,
-							maxLoops: batchConfig.maxLoops,
-						});
-						if (!result.success || !result.playbook) {
-							sendResponse({
-								success: false,
-								error: result.error || 'Failed to save playbook',
-							});
-							return;
-						}
-						sendResponse({ success: true, playbookId: result.playbook.id });
-					} catch (error) {
-						sendResponse({
-							success: false,
-							error: error instanceof Error ? error.message : String(error),
-						});
-					}
-					return;
-				}
-
-				if (!session.autoRunFolderPath) {
-					sendResponse({ success: false, error: 'Session has no Auto Run folder configured' });
-					return;
-				}
-
-				if (config.launch) {
-					try {
-						await startBatchRun(sessionId, batchConfig, session.autoRunFolderPath);
-						sendResponse({ success: true });
-					} catch (error) {
-						sendResponse({
-							success: false,
-							error: error instanceof Error ? error.message : String(error),
-						});
-					}
-					return;
-				}
-
-				const selectedFile = documents[0]?.filename;
-				let selectedContent = '';
-				if (selectedFile) {
-					const sshRemoteId =
-						session.sshRemoteId || session.sessionSshRemoteConfig?.remoteId || undefined;
-					const result = await window.maestro.autorun.readDoc(
-						session.autoRunFolderPath,
-						selectedFile + '.md',
-						sshRemoteId
-					);
-					selectedContent = result.success ? result.content || '' : '';
-				}
-
-				updateSessionWith(sessionId, (s) => ({
-					...s,
-					autoRunSelectedFile: selectedFile,
-					autoRunContent: selectedContent,
-					autoRunContentVersion: (s.autoRunContentVersion || 0) + 1,
-					batchRunnerPrompt: batchConfig.prompt,
-					batchRunnerPromptModifiedAt: Date.now(),
-				}));
-				setAutoRunDocumentList(documents.map((doc) => doc.filename));
-				setActiveSessionId(sessionId);
-				setRightPanelOpen(true);
-				setActiveRightTab('autorun');
-				openBatchRunnerWithConfig(batchConfig);
-				sendResponse({ success: true });
-			} catch (error) {
-				captureException(error, {
-					extra: { context: 'handleRemoteConfigureAutoRun', sessionId },
-				});
-				sendResponse({
-					success: false,
-					error: error instanceof Error ? error.message : String(error),
-				});
-			}
-		};
-
-		window.addEventListener('maestro:openFileTab', handleRemoteOpenFileTab);
-		window.addEventListener('maestro:refreshFileTree', handleRemoteRefreshFileTree);
-		window.addEventListener('maestro:refreshAutoRunDocs', handleRemoteRefreshAutoRunDocs);
-		window.addEventListener('maestro:configureAutoRun', handleRemoteConfigureAutoRun);
-
-		return () => {
-			window.removeEventListener('maestro:openFileTab', handleRemoteOpenFileTab);
-			window.removeEventListener('maestro:refreshFileTree', handleRemoteRefreshFileTree);
-			window.removeEventListener('maestro:refreshAutoRunDocs', handleRemoteRefreshAutoRunDocs);
-			window.removeEventListener('maestro:configureAutoRun', handleRemoteConfigureAutoRun);
-		};
-	}, [
-		activeSessionIdRef,
-		handleAutoRunRefresh,
-		handleOpenFileTab,
-		refreshFileTree,
-		setActiveFocus,
-		setActiveRightTab,
-		setRightPanelOpen,
-		setActiveSessionId,
-		sessionsRef,
-		setAutoRunDocumentList,
-		openBatchRunnerWithConfig,
-		startBatchRun,
-	]);
 
 	// --- FILE EXPLORER EFFECTS ---
 	// Extracted hook for file explorer side effects and keyboard navigation (Phase 2.6)

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -191,10 +191,6 @@ import type {
 	BatchDocumentEntry,
 } from './types';
 import { useResolvedTheme } from './hooks/ui/useResolvedTheme';
-import { THEMES } from './constants/themes';
-import { usePluginContributions } from './hooks/usePluginContributions';
-import { resolvePluginTheme } from './utils/pluginThemes';
-import { generateId } from './utils/ids';
 import { getActiveOutputSearchKey } from './utils/outputSearch';
 import { reorderQueueItem } from './utils/executionQueue';
 import { getContextColor } from './utils/theme';
@@ -2410,7 +2406,7 @@ function MaestroConsoleInner() {
 
 				if (config.launch) {
 					try {
-						await startBatchRunRef.current(sessionId, batchConfig, session.autoRunFolderPath);
+						await startBatchRun(sessionId, batchConfig, session.autoRunFolderPath);
 						sendResponse({ success: true });
 					} catch (error) {
 						sendResponse({
@@ -2482,6 +2478,7 @@ function MaestroConsoleInner() {
 		sessionsRef,
 		setAutoRunDocumentList,
 		openBatchRunnerWithConfig,
+		startBatchRun,
 	]);
 
 	// --- FILE EXPLORER EFFECTS ---

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -2336,6 +2336,78 @@ function MaestroConsoleInner() {
 			sshReduceEntryCapFraction: settings.sshReduceEntryCapFraction,
 		});
 
+	// CLI IPC remote events dispatched by useRemoteIntegration.
+	useEffect(() => {
+		const handleRemoteOpenFileTab = async (event: Event) => {
+			const { sessionId, filePath } = (
+				event as CustomEvent<{ sessionId: string; filePath: string }>
+			).detail;
+			const session = sessionsRef.current.find((s) => s.id === sessionId);
+			if (!session || !filePath) return;
+
+			const sshRemoteId =
+				session.sshRemoteId || session.sessionSshRemoteConfig?.remoteId || undefined;
+			const fileName = filePath.replace(/\\/g, '/').split('/').pop() || filePath;
+
+			try {
+				const [content, stat] = await Promise.all([
+					window.maestro.fs.readFile(filePath, sshRemoteId),
+					window.maestro.fs.stat(filePath, sshRemoteId),
+				]);
+				if (content === null) return;
+
+				setActiveSessionId(sessionId);
+				handleOpenFileTab({
+					path: filePath,
+					name: fileName,
+					content,
+					sshRemoteId,
+					lastModified: stat?.modifiedAt ? new Date(stat.modifiedAt).getTime() : Date.now(),
+				});
+				setActiveFocus('main');
+			} catch (error) {
+				console.error('[Remote] Failed to open file tab:', error);
+			}
+		};
+
+		const handleRemoteRefreshFileTree = (event: Event) => {
+			const { sessionId } = (event as CustomEvent<{ sessionId: string }>).detail;
+			const session = sessionsRef.current.find((s) => s.id === sessionId);
+			if (!session) return;
+			refreshFileTree(sessionId);
+		};
+
+		const handleRemoteRefreshAutoRunDocs = (event: Event) => {
+			const { sessionId } = (event as CustomEvent<{ sessionId: string }>).detail;
+			const session = sessionsRef.current.find((s) => s.id === sessionId);
+			if (!session) return;
+
+			if (activeSessionIdRef.current !== sessionId) {
+				setActiveSessionId(sessionId);
+				return;
+			}
+			handleAutoRunRefresh();
+		};
+
+		window.addEventListener('maestro:openFileTab', handleRemoteOpenFileTab);
+		window.addEventListener('maestro:refreshFileTree', handleRemoteRefreshFileTree);
+		window.addEventListener('maestro:refreshAutoRunDocs', handleRemoteRefreshAutoRunDocs);
+
+		return () => {
+			window.removeEventListener('maestro:openFileTab', handleRemoteOpenFileTab);
+			window.removeEventListener('maestro:refreshFileTree', handleRemoteRefreshFileTree);
+			window.removeEventListener('maestro:refreshAutoRunDocs', handleRemoteRefreshAutoRunDocs);
+		};
+	}, [
+		activeSessionIdRef,
+		handleAutoRunRefresh,
+		handleOpenFileTab,
+		refreshFileTree,
+		setActiveFocus,
+		setActiveSessionId,
+		sessionsRef,
+	]);
+
 	// --- FILE EXPLORER EFFECTS ---
 	// Extracted hook for file explorer side effects and keyboard navigation (Phase 2.6)
 	const { stableFileTree, handleMainPanelFileClick } = useFileExplorerEffects({

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -195,10 +195,6 @@ import type {
 	BatchDocumentEntry,
 } from './types';
 import { useResolvedTheme } from './hooks/ui/useResolvedTheme';
-import { THEMES } from './constants/themes';
-import { usePluginContributions } from './hooks/usePluginContributions';
-import { resolvePluginTheme } from './utils/pluginThemes';
-import { generateId } from './utils/ids';
 import { getActiveOutputSearchKey } from './utils/outputSearch';
 import { reorderQueueItem, applyQueuedItemEdit } from './utils/executionQueue';
 import { getContextColor } from './utils/theme';
@@ -2485,7 +2481,7 @@ function MaestroConsoleInner() {
 
 				if (config.launch) {
 					try {
-						await startBatchRunRef.current(sessionId, batchConfig, session.autoRunFolderPath);
+						await startBatchRun(sessionId, batchConfig, session.autoRunFolderPath);
 						sendResponse({ success: true });
 					} catch (error) {
 						sendResponse({
@@ -2557,6 +2553,7 @@ function MaestroConsoleInner() {
 		sessionsRef,
 		setAutoRunDocumentList,
 		openBatchRunnerWithConfig,
+		startBatchRun,
 	]);
 
 	// --- FILE EXPLORER EFFECTS ---

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -190,8 +190,15 @@ import type {
 	QueuedItem,
 	CustomAICommand,
 	QueuedItemEditPatch,
+	ThinkingItem,
+	BatchRunConfig,
+	BatchDocumentEntry,
 } from './types';
 import { useResolvedTheme } from './hooks/ui/useResolvedTheme';
+import { THEMES } from './constants/themes';
+import { usePluginContributions } from './hooks/usePluginContributions';
+import { resolvePluginTheme } from './utils/pluginThemes';
+import { generateId } from './utils/ids';
 import { getActiveOutputSearchKey } from './utils/outputSearch';
 import { reorderQueueItem, applyQueuedItemEdit } from './utils/executionQueue';
 import { getContextColor } from './utils/theme';
@@ -225,6 +232,21 @@ import { useUIStore } from './stores/uiStore';
 import { useSettingsStore } from './stores/settingsStore';
 import { useTabStore } from './stores/tabStore';
 import { useFileExplorerStore } from './stores/fileExplorerStore';
+
+type RemoteConfigureAutoRunConfig = {
+	documents: Array<{ filename: string; resetOnCompletion?: boolean }>;
+	prompt?: string;
+	loopEnabled?: boolean;
+	maxLoops?: number;
+	saveAsPlaybook?: string;
+	launch?: boolean;
+};
+
+type RemoteConfigureAutoRunResult = {
+	success: boolean;
+	playbookId?: string;
+	error?: string;
+};
 
 function MaestroConsoleInner() {
 	// --- LAYER STACK (for blocking shortcuts when modals are open) ---
@@ -328,6 +350,7 @@ function MaestroConsoleInner() {
 		setMemoryViewerOpen,
 		// Batch Runner Modal
 		setBatchRunnerModalOpen,
+		openBatchRunnerWithConfig,
 		// Auto Run Setup Modal
 		setAutoRunSetupModalOpen,
 		// Marketplace Modal - marketplaceModalOpen now self-sourced in AppStandaloneModals
@@ -2389,14 +2412,138 @@ function MaestroConsoleInner() {
 			handleAutoRunRefresh();
 		};
 
+		const handleRemoteConfigureAutoRun = async (event: Event) => {
+			const { sessionId, config, responseChannel } = (
+				event as CustomEvent<{
+					sessionId: string;
+					config: RemoteConfigureAutoRunConfig;
+					responseChannel: string;
+				}>
+			).detail;
+			const sendResponse = (result: RemoteConfigureAutoRunResult) => {
+				window.maestro.process.sendRemoteConfigureAutoRunResponse(responseChannel, result);
+			};
+			try {
+				const session = sessionsRef.current.find((s) => s.id === sessionId);
+				if (!session) {
+					sendResponse({ success: false, error: 'Session not found' });
+					return;
+				}
+
+				const documents: BatchDocumentEntry[] = config.documents.map((doc, index, allDocs) => {
+					const filename = doc.filename.replace(/\.md$/i, '');
+					return {
+						id: generateId(),
+						filename,
+						resetOnCompletion: doc.resetOnCompletion || false,
+						isDuplicate:
+							allDocs.findIndex((other) => other.filename.replace(/\.md$/i, '') === filename) !==
+							index,
+					};
+				});
+				const batchConfig: BatchRunConfig = {
+					documents,
+					prompt: config.prompt || '',
+					loopEnabled: config.loopEnabled || false,
+					maxLoops:
+						config.loopEnabled || config.maxLoops !== undefined ? (config.maxLoops ?? null) : null,
+				};
+
+				if (config.saveAsPlaybook) {
+					try {
+						const result = await window.maestro.playbooks.create(sessionId, {
+							name: config.saveAsPlaybook,
+							documents: documents.map((doc) => ({
+								filename: doc.filename,
+								resetOnCompletion: doc.resetOnCompletion,
+							})),
+							prompt: batchConfig.prompt,
+							loopEnabled: batchConfig.loopEnabled,
+							maxLoops: batchConfig.maxLoops,
+						});
+						if (!result.success || !result.playbook) {
+							sendResponse({
+								success: false,
+								error: result.error || 'Failed to save playbook',
+							});
+							return;
+						}
+						sendResponse({ success: true, playbookId: result.playbook.id });
+					} catch (error) {
+						sendResponse({
+							success: false,
+							error: error instanceof Error ? error.message : String(error),
+						});
+					}
+					return;
+				}
+
+				if (!session.autoRunFolderPath) {
+					sendResponse({ success: false, error: 'Session has no Auto Run folder configured' });
+					return;
+				}
+
+				if (config.launch) {
+					try {
+						await startBatchRunRef.current(sessionId, batchConfig, session.autoRunFolderPath);
+						sendResponse({ success: true });
+					} catch (error) {
+						sendResponse({
+							success: false,
+							error: error instanceof Error ? error.message : String(error),
+						});
+					}
+					return;
+				}
+
+				const selectedFile = documents[0]?.filename;
+				let selectedContent = '';
+				if (selectedFile) {
+					const sshRemoteId =
+						session.sshRemoteId || session.sessionSshRemoteConfig?.remoteId || undefined;
+					const result = await window.maestro.autorun.readDoc(
+						session.autoRunFolderPath,
+						selectedFile + '.md',
+						sshRemoteId
+					);
+					selectedContent = result.success ? result.content || '' : '';
+				}
+
+				updateSessionWith(sessionId, (s) => ({
+					...s,
+					autoRunSelectedFile: selectedFile,
+					autoRunContent: selectedContent,
+					autoRunContentVersion: (s.autoRunContentVersion || 0) + 1,
+					batchRunnerPrompt: batchConfig.prompt,
+					batchRunnerPromptModifiedAt: Date.now(),
+				}));
+				setAutoRunDocumentList(documents.map((doc) => doc.filename));
+				setActiveSessionId(sessionId);
+				setRightPanelOpen(true);
+				setActiveRightTab('autorun');
+				openBatchRunnerWithConfig(batchConfig);
+				sendResponse({ success: true });
+			} catch (error) {
+				captureException(error, {
+					extra: { context: 'handleRemoteConfigureAutoRun', sessionId },
+				});
+				sendResponse({
+					success: false,
+					error: error instanceof Error ? error.message : String(error),
+				});
+			}
+		};
+
 		window.addEventListener('maestro:openFileTab', handleRemoteOpenFileTab);
 		window.addEventListener('maestro:refreshFileTree', handleRemoteRefreshFileTree);
 		window.addEventListener('maestro:refreshAutoRunDocs', handleRemoteRefreshAutoRunDocs);
+		window.addEventListener('maestro:configureAutoRun', handleRemoteConfigureAutoRun);
 
 		return () => {
 			window.removeEventListener('maestro:openFileTab', handleRemoteOpenFileTab);
 			window.removeEventListener('maestro:refreshFileTree', handleRemoteRefreshFileTree);
 			window.removeEventListener('maestro:refreshAutoRunDocs', handleRemoteRefreshAutoRunDocs);
+			window.removeEventListener('maestro:configureAutoRun', handleRemoteConfigureAutoRun);
 		};
 	}, [
 		activeSessionIdRef,
@@ -2404,8 +2551,12 @@ function MaestroConsoleInner() {
 		handleOpenFileTab,
 		refreshFileTree,
 		setActiveFocus,
+		setActiveRightTab,
+		setRightPanelOpen,
 		setActiveSessionId,
 		sessionsRef,
+		setAutoRunDocumentList,
+		openBatchRunnerWithConfig,
 	]);
 
 	// --- FILE EXPLORER EFFECTS ---

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -190,9 +190,6 @@ import type {
 	QueuedItem,
 	CustomAICommand,
 	QueuedItemEditPatch,
-	ThinkingItem,
-	BatchRunConfig,
-	BatchDocumentEntry,
 } from './types';
 import { useResolvedTheme } from './hooks/ui/useResolvedTheme';
 import { getActiveOutputSearchKey } from './utils/outputSearch';
@@ -228,21 +225,6 @@ import { useUIStore } from './stores/uiStore';
 import { useSettingsStore } from './stores/settingsStore';
 import { useTabStore } from './stores/tabStore';
 import { useFileExplorerStore } from './stores/fileExplorerStore';
-
-type RemoteConfigureAutoRunConfig = {
-	documents: Array<{ filename: string; resetOnCompletion?: boolean }>;
-	prompt?: string;
-	loopEnabled?: boolean;
-	maxLoops?: number;
-	saveAsPlaybook?: string;
-	launch?: boolean;
-};
-
-type RemoteConfigureAutoRunResult = {
-	success: boolean;
-	playbookId?: string;
-	error?: string;
-};
 
 function MaestroConsoleInner() {
 	// --- LAYER STACK (for blocking shortcuts when modals are open) ---
@@ -346,7 +328,6 @@ function MaestroConsoleInner() {
 		setMemoryViewerOpen,
 		// Batch Runner Modal
 		setBatchRunnerModalOpen,
-		openBatchRunnerWithConfig,
 		// Auto Run Setup Modal
 		setAutoRunSetupModalOpen,
 		// Marketplace Modal - marketplaceModalOpen now self-sourced in AppStandaloneModals
@@ -2354,207 +2335,6 @@ function MaestroConsoleInner() {
 			sshReduceEntryCapEnabled: settings.sshReduceEntryCapEnabled,
 			sshReduceEntryCapFraction: settings.sshReduceEntryCapFraction,
 		});
-
-	// CLI IPC remote events dispatched by useRemoteIntegration.
-	useEffect(() => {
-		const handleRemoteOpenFileTab = async (event: Event) => {
-			const { sessionId, filePath } = (
-				event as CustomEvent<{ sessionId: string; filePath: string }>
-			).detail;
-			const session = sessionsRef.current.find((s) => s.id === sessionId);
-			if (!session || !filePath) return;
-
-			const sshRemoteId =
-				session.sshRemoteId || session.sessionSshRemoteConfig?.remoteId || undefined;
-			const fileName = filePath.replace(/\\/g, '/').split('/').pop() || filePath;
-
-			try {
-				const [content, stat] = await Promise.all([
-					window.maestro.fs.readFile(filePath, sshRemoteId),
-					window.maestro.fs.stat(filePath, sshRemoteId),
-				]);
-				if (content === null) return;
-
-				setActiveSessionId(sessionId);
-				handleOpenFileTab({
-					path: filePath,
-					name: fileName,
-					content,
-					sshRemoteId,
-					lastModified: stat?.modifiedAt ? new Date(stat.modifiedAt).getTime() : Date.now(),
-				});
-				setActiveFocus('main');
-			} catch (error) {
-				console.error('[Remote] Failed to open file tab:', error);
-			}
-		};
-
-		const handleRemoteRefreshFileTree = (event: Event) => {
-			const { sessionId } = (event as CustomEvent<{ sessionId: string }>).detail;
-			const session = sessionsRef.current.find((s) => s.id === sessionId);
-			if (!session) return;
-			refreshFileTree(sessionId);
-		};
-
-		const handleRemoteRefreshAutoRunDocs = (event: Event) => {
-			const { sessionId } = (event as CustomEvent<{ sessionId: string }>).detail;
-			const session = sessionsRef.current.find((s) => s.id === sessionId);
-			if (!session) return;
-
-			if (activeSessionIdRef.current !== sessionId) {
-				setActiveSessionId(sessionId);
-				return;
-			}
-			handleAutoRunRefresh();
-		};
-
-		const handleRemoteConfigureAutoRun = async (event: Event) => {
-			const { sessionId, config, responseChannel } = (
-				event as CustomEvent<{
-					sessionId: string;
-					config: RemoteConfigureAutoRunConfig;
-					responseChannel: string;
-				}>
-			).detail;
-			const sendResponse = (result: RemoteConfigureAutoRunResult) => {
-				window.maestro.process.sendRemoteConfigureAutoRunResponse(responseChannel, result);
-			};
-			try {
-				const session = sessionsRef.current.find((s) => s.id === sessionId);
-				if (!session) {
-					sendResponse({ success: false, error: 'Session not found' });
-					return;
-				}
-
-				const documents: BatchDocumentEntry[] = config.documents.map((doc, index, allDocs) => {
-					const filename = doc.filename.replace(/\.md$/i, '');
-					return {
-						id: generateId(),
-						filename,
-						resetOnCompletion: doc.resetOnCompletion || false,
-						isDuplicate:
-							allDocs.findIndex((other) => other.filename.replace(/\.md$/i, '') === filename) !==
-							index,
-					};
-				});
-				const batchConfig: BatchRunConfig = {
-					documents,
-					prompt: config.prompt || '',
-					loopEnabled: config.loopEnabled || false,
-					maxLoops:
-						config.loopEnabled || config.maxLoops !== undefined ? (config.maxLoops ?? null) : null,
-				};
-
-				if (config.saveAsPlaybook) {
-					try {
-						const result = await window.maestro.playbooks.create(sessionId, {
-							name: config.saveAsPlaybook,
-							documents: documents.map((doc) => ({
-								filename: doc.filename,
-								resetOnCompletion: doc.resetOnCompletion,
-							})),
-							prompt: batchConfig.prompt,
-							loopEnabled: batchConfig.loopEnabled,
-							maxLoops: batchConfig.maxLoops,
-						});
-						if (!result.success || !result.playbook) {
-							sendResponse({
-								success: false,
-								error: result.error || 'Failed to save playbook',
-							});
-							return;
-						}
-						sendResponse({ success: true, playbookId: result.playbook.id });
-					} catch (error) {
-						sendResponse({
-							success: false,
-							error: error instanceof Error ? error.message : String(error),
-						});
-					}
-					return;
-				}
-
-				if (!session.autoRunFolderPath) {
-					sendResponse({ success: false, error: 'Session has no Auto Run folder configured' });
-					return;
-				}
-
-				if (config.launch) {
-					try {
-						await startBatchRun(sessionId, batchConfig, session.autoRunFolderPath);
-						sendResponse({ success: true });
-					} catch (error) {
-						sendResponse({
-							success: false,
-							error: error instanceof Error ? error.message : String(error),
-						});
-					}
-					return;
-				}
-
-				const selectedFile = documents[0]?.filename;
-				let selectedContent = '';
-				if (selectedFile) {
-					const sshRemoteId =
-						session.sshRemoteId || session.sessionSshRemoteConfig?.remoteId || undefined;
-					const result = await window.maestro.autorun.readDoc(
-						session.autoRunFolderPath,
-						selectedFile + '.md',
-						sshRemoteId
-					);
-					selectedContent = result.success ? result.content || '' : '';
-				}
-
-				updateSessionWith(sessionId, (s) => ({
-					...s,
-					autoRunSelectedFile: selectedFile,
-					autoRunContent: selectedContent,
-					autoRunContentVersion: (s.autoRunContentVersion || 0) + 1,
-					batchRunnerPrompt: batchConfig.prompt,
-					batchRunnerPromptModifiedAt: Date.now(),
-				}));
-				setAutoRunDocumentList(documents.map((doc) => doc.filename));
-				setActiveSessionId(sessionId);
-				setRightPanelOpen(true);
-				setActiveRightTab('autorun');
-				openBatchRunnerWithConfig(batchConfig);
-				sendResponse({ success: true });
-			} catch (error) {
-				captureException(error, {
-					extra: { context: 'handleRemoteConfigureAutoRun', sessionId },
-				});
-				sendResponse({
-					success: false,
-					error: error instanceof Error ? error.message : String(error),
-				});
-			}
-		};
-
-		window.addEventListener('maestro:openFileTab', handleRemoteOpenFileTab);
-		window.addEventListener('maestro:refreshFileTree', handleRemoteRefreshFileTree);
-		window.addEventListener('maestro:refreshAutoRunDocs', handleRemoteRefreshAutoRunDocs);
-		window.addEventListener('maestro:configureAutoRun', handleRemoteConfigureAutoRun);
-
-		return () => {
-			window.removeEventListener('maestro:openFileTab', handleRemoteOpenFileTab);
-			window.removeEventListener('maestro:refreshFileTree', handleRemoteRefreshFileTree);
-			window.removeEventListener('maestro:refreshAutoRunDocs', handleRemoteRefreshAutoRunDocs);
-			window.removeEventListener('maestro:configureAutoRun', handleRemoteConfigureAutoRun);
-		};
-	}, [
-		activeSessionIdRef,
-		handleAutoRunRefresh,
-		handleOpenFileTab,
-		refreshFileTree,
-		setActiveFocus,
-		setActiveRightTab,
-		setRightPanelOpen,
-		setActiveSessionId,
-		sessionsRef,
-		setAutoRunDocumentList,
-		openBatchRunnerWithConfig,
-		startBatchRun,
-	]);
 
 	// --- FILE EXPLORER EFFECTS ---
 	// Extracted hook for file explorer side effects and keyboard navigation (Phase 2.6)

--- a/src/renderer/components/AppModals/AppUtilityModals.tsx
+++ b/src/renderer/components/AppModals/AppUtilityModals.tsx
@@ -533,6 +533,7 @@ export const AppUtilityModals = memo(function AppUtilityModals({
 	// the BatchRunnerModal opens with all freshly generated docs pre-selected.
 	const batchRunnerData = useModalStore(selectModalData('batchRunner'));
 	const batchRunnerPresetDocuments = batchRunnerData?.presetDocuments;
+	const initialBatchRunConfig = batchRunnerData?.initialConfig;
 
 	// Snooze modals subscribe to the modal store directly rather than taking
 	// open/close props - they need no state from App.tsx beyond the theme.
@@ -763,6 +764,7 @@ export const AppUtilityModals = memo(function AppUtilityModals({
 					lastModifiedAt={activeSession.batchRunnerPromptModifiedAt}
 					showConfirmation={showConfirmation}
 					folderPath={activeSession.autoRunFolderPath}
+					initialConfig={initialBatchRunConfig}
 					presetDocuments={batchRunnerPresetDocuments}
 					allDocuments={autoRunDocumentList}
 					documentTree={autoRunDocumentTree}

--- a/src/renderer/components/AppModals/AppUtilityModals.tsx
+++ b/src/renderer/components/AppModals/AppUtilityModals.tsx
@@ -539,6 +539,7 @@ export const AppUtilityModals = memo(function AppUtilityModals({
 	// the BatchRunnerModal opens with all freshly generated docs pre-selected.
 	const batchRunnerData = useModalStore(selectModalData('batchRunner'));
 	const batchRunnerPresetDocuments = batchRunnerData?.presetDocuments;
+	const initialBatchRunConfig = batchRunnerData?.initialConfig;
 
 	// Snooze modals subscribe to the modal store directly rather than taking
 	// open/close props - they need no state from App.tsx beyond the theme.
@@ -788,6 +789,7 @@ export const AppUtilityModals = memo(function AppUtilityModals({
 					lastModifiedAt={activeSession.batchRunnerPromptModifiedAt}
 					showConfirmation={showConfirmation}
 					folderPath={activeSession.autoRunFolderPath}
+					initialConfig={initialBatchRunConfig}
 					presetDocuments={batchRunnerPresetDocuments}
 					allDocuments={autoRunDocumentList}
 					documentTree={autoRunDocumentTree}

--- a/src/renderer/components/BatchRunnerModal.tsx
+++ b/src/renderer/components/BatchRunnerModal.tsx
@@ -58,6 +58,7 @@ interface BatchRunnerModalProps {
 	onGo: (config: BatchRunConfig) => void | Promise<void>;
 	onSave: (prompt: string) => void;
 	initialPrompt?: string;
+	initialConfig?: Partial<BatchRunConfig>;
 	lastModifiedAt?: number;
 	showConfirmation: (message: string, onConfirm: () => void) => void;
 	// Multi-document support
@@ -113,6 +114,7 @@ export function BatchRunnerModal(props: BatchRunnerModalProps) {
 		onGo,
 		onSave,
 		initialPrompt,
+		initialConfig,
 		lastModifiedAt,
 		showConfirmation,
 		folderPath,
@@ -219,7 +221,12 @@ export function BatchRunnerModal(props: BatchRunnerModalProps) {
 		totalTaskCount,
 		hasNoTasks,
 		missingDocCount,
-	} = useSpecDrivenConfig({ presetDocuments, allDocuments, getDocumentTaskCount });
+	} = useSpecDrivenConfig({
+		presetDocuments,
+		initialConfig,
+		allDocuments,
+		getDocumentTaskCount,
+	});
 
 	// Fresh-context-per mode. Default 'task' preserves legacy behavior (one
 	// agent invocation per unchecked task). 'document' makes the agent walk
@@ -265,7 +272,11 @@ export function BatchRunnerModal(props: BatchRunnerModalProps) {
 		handleSave,
 		isModified,
 		hasUnsavedChanges,
-	} = usePromptComposerState({ initialPrompt, showConfirmation, onSave });
+	} = usePromptComposerState({
+		initialPrompt: initialConfig?.prompt ?? initialPrompt,
+		showConfirmation,
+		onSave,
+	});
 
 	// Compute if there are unsaved configuration changes
 	// This checks if documents, loop settings, or prompt have changed from initial values

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -761,14 +761,7 @@ interface MaestroAPI {
 		onRemoteConfigureAutoRun: (
 			callback: (
 				sessionId: string,
-				config: {
-					documents: Array<{ filename: string; resetOnCompletion?: boolean }>;
-					prompt?: string;
-					loopEnabled?: boolean;
-					maxLoops?: number;
-					saveAsPlaybook?: string;
-					launch?: boolean;
-				},
+				config: import('../main/web-server/types').ConfigureAutoRunConfig,
 				responseChannel: string
 			) => void
 		) => () => void;

--- a/src/renderer/hooks/batch/useSpecDrivenConfig.ts
+++ b/src/renderer/hooks/batch/useSpecDrivenConfig.ts
@@ -8,12 +8,13 @@
  */
 
 import { useState, useRef, useMemo, useEffect } from 'react';
-import type { BatchDocumentEntry } from '../../types';
+import type { BatchDocumentEntry, BatchRunConfig } from '../../types';
 import { useBatchStore } from '../../stores/batchStore';
 import { generateId } from '../../utils/ids';
 
 export interface UseSpecDrivenConfigDeps {
 	presetDocuments?: string[];
+	initialConfig?: Partial<Pick<BatchRunConfig, 'documents' | 'loopEnabled' | 'maxLoops'>>;
 	allDocuments: string[];
 	getDocumentTaskCount: (filename: string) => Promise<number>;
 }
@@ -40,12 +41,16 @@ export interface UseSpecDrivenConfigReturn {
 
 export function useSpecDrivenConfig({
 	presetDocuments,
+	initialConfig,
 	allDocuments,
 	getDocumentTaskCount,
 }: UseSpecDrivenConfigDeps): UseSpecDrivenConfigReturn {
 	// Document list state. Opens empty unless the inline wizard's "Start Auto
 	// Run" pre-seeded it with freshly generated docs via `presetDocuments`.
 	const [documents, setDocuments] = useState<BatchDocumentEntry[]>(() => {
+		if (initialConfig?.documents?.length) {
+			return initialConfig.documents;
+		}
 		if (presetDocuments && presetDocuments.length > 0) {
 			return presetDocuments.map((filename) => ({
 				id: generateId(),
@@ -60,7 +65,8 @@ export function useSpecDrivenConfig({
 	// Track initial document state for dirty checking. Mirrors the run-list
 	// initialization above so dirty detection is correct for preset opens too.
 	const initialDocumentsRef = useRef<string[]>(
-		presetDocuments && presetDocuments.length > 0 ? [...presetDocuments] : []
+		initialConfig?.documents?.map((doc) => doc.filename) ??
+			(presetDocuments && presetDocuments.length > 0 ? [...presetDocuments] : [])
 	);
 
 	// Task counts per document (keyed by filename, value = unchecked task count).
@@ -85,12 +91,12 @@ export function useSpecDrivenConfig({
 	);
 
 	// Loop mode state
-	const [loopEnabled, setLoopEnabled] = useState(false);
-	const [maxLoops, setMaxLoops] = useState<number | null>(null); // null = infinite
+	const [loopEnabled, setLoopEnabled] = useState(initialConfig?.loopEnabled ?? false);
+	const [maxLoops, setMaxLoops] = useState<number | null>(initialConfig?.maxLoops ?? null); // null = infinite
 
 	// Track initial loop settings for dirty checking
-	const initialLoopEnabledRef = useRef(false);
-	const initialMaxLoopsRef = useRef<number | null>(null);
+	const initialLoopEnabledRef = useRef(initialConfig?.loopEnabled ?? false);
+	const initialMaxLoopsRef = useRef<number | null>(initialConfig?.maxLoops ?? null);
 
 	// Use ref for getDocumentTaskCount to avoid dependency issues
 	const getDocumentTaskCountRef = useRef(getDocumentTaskCount);

--- a/src/renderer/hooks/remote/useAppRemoteEventListeners.ts
+++ b/src/renderer/hooks/remote/useAppRemoteEventListeners.ts
@@ -16,6 +16,7 @@ import { useBatchStore } from '../../stores/batchStore';
 import { useModalStore } from '../../stores/modalStore';
 import { useUIStore } from '../../stores/uiStore';
 import { PLAYBOOKS_DIR } from '../../../shared/maestro-paths';
+import { getBasename, isAbsolutePath } from '../../../shared/formatters';
 import { getBrowserTabPartition } from '../../utils/browserTabPersistence';
 import { insertAfterActiveInUnifiedTabOrder } from '../../utils/unifiedTabOrderUtils';
 import {
@@ -41,6 +42,28 @@ import {
 	canCreateGroupInside,
 	removeGroupAndPromoteChildren,
 } from '../../../shared/groupHierarchy';
+
+function resolveRemoteAutoRunFilename(filename: string, folderPath: string): string {
+	const normalized = filename.replace(/\\/g, '/').replace(/\.md$/i, '');
+	const normalizedFolder = folderPath.replace(/\\/g, '/').replace(/\/$/, '');
+	let relative = normalized;
+
+	if (isAbsolutePath(filename)) {
+		if (!normalized.toLowerCase().startsWith(`${normalizedFolder.toLowerCase()}/`)) {
+			throw new Error(
+				`Auto Run document is outside the configured folder: ${getBasename(filename)}`
+			);
+		}
+		relative = normalized.slice(normalizedFolder.length + 1);
+	}
+
+	relative = relative.replace(/^\.\/+/, '');
+	if (!relative || relative.split('/').includes('..')) {
+		throw new Error(`Invalid Auto Run document path: ${filename}`);
+	}
+
+	return relative;
+}
 
 // ============================================================================
 // Dependencies interface
@@ -409,32 +432,12 @@ export function useAppRemoteEventListeners(deps: UseAppRemoteEventListenersDeps)
 				}
 
 				const documents = (config.documents || []).map(
-					(doc: { filename: string; resetOnCompletion?: boolean }) => {
-						// Compute path relative to the session's autoRunFolderPath.
-						// CLI sends full absolute paths (e.g., "/path/to/Auto Run Docs/subdir/temp.md")
-						// but the batch processor expects the path relative to folderPath without .md
-						// (e.g., "subdir/temp").
-						let name = doc.filename.replace(/\.md$/i, '');
-						// Normalize separators to forward slash for comparison
-						const normalized = name.replace(/\\/g, '/');
-						const normalizedFolder = (folderPath || '').replace(/\\/g, '/');
-						// Case-insensitive prefix check for cross-platform compatibility (Windows drive letters)
-						const normalizedLower = normalized.toLowerCase();
-						const folderLower = normalizedFolder.toLowerCase();
-						if (normalizedFolder && normalizedLower.startsWith(folderLower + '/')) {
-							name = normalized.substring(normalizedFolder.length + 1);
-						} else {
-							// Fallback for paths not under folderPath: use basename only
-							const lastSlash = Math.max(name.lastIndexOf('/'), name.lastIndexOf('\\'));
-							if (lastSlash >= 0) name = name.substring(lastSlash + 1);
-						}
-						return {
-							id: generateId(),
-							filename: name,
-							resetOnCompletion: doc.resetOnCompletion || false,
-							isDuplicate: false,
-						};
-					}
+					(doc: { filename: string; resetOnCompletion?: boolean }) => ({
+						id: generateId(),
+						filename: resolveRemoteAutoRunFilename(doc.filename, folderPath),
+						resetOnCompletion: doc.resetOnCompletion || false,
+						isDuplicate: false,
+					})
 				);
 
 				if (documents.length === 0) {
@@ -590,7 +593,7 @@ export function useAppRemoteEventListeners(deps: UseAppRemoteEventListenersDeps)
 			const documents: BatchDocumentEntry[] = (config.documents || []).map(
 				(doc: { filename: string; resetOnCompletion?: boolean }) => ({
 					id: generateId(),
-					filename: doc.filename.replace(/\.md$/i, ''),
+					filename: resolveRemoteAutoRunFilename(doc.filename, folderPath),
 					resetOnCompletion: doc.resetOnCompletion || false,
 					isDuplicate: false,
 				})

--- a/src/renderer/hooks/remote/useAppRemoteEventListeners.ts
+++ b/src/renderer/hooks/remote/useAppRemoteEventListeners.ts
@@ -12,6 +12,9 @@ import { useEventListener } from '../utils/useEventListener';
 import { generateId } from '../../utils/ids';
 import { useSessionStore, selectSessionById } from '../../stores/sessionStore';
 import { useSettingsStore } from '../../stores/settingsStore';
+import { useBatchStore } from '../../stores/batchStore';
+import { useModalStore } from '../../stores/modalStore';
+import { useUIStore } from '../../stores/uiStore';
 import { PLAYBOOKS_DIR } from '../../../shared/maestro-paths';
 import { getBrowserTabPartition } from '../../utils/browserTabPersistence';
 import { insertAfterActiveInUnifiedTabOrder } from '../../utils/unifiedTabOrderUtils';
@@ -19,7 +22,15 @@ import {
 	createTerminalTab as createTerminalTabHelper,
 	addTerminalTab as addTerminalTabHelper,
 } from '../../utils/terminalTabHelpers';
-import type { Session, AITab, ToolType, Group, BatchRunConfig, BrowserTab } from '../../types';
+import type {
+	Session,
+	AITab,
+	ToolType,
+	Group,
+	BatchRunConfig,
+	BatchDocumentEntry,
+	BrowserTab,
+} from '../../types';
 import { logger } from '../../utils/logger';
 import { captureException, captureMessage } from '../../utils/sentry';
 import { DEFAULT_BATCH_PROMPT } from '../batch/batchUtils';
@@ -566,12 +577,69 @@ export function useAppRemoteEventListeners(deps: UseAppRemoteEventListenersDeps)
 				return;
 			}
 
-			// Case 3: Just configure (no launch, no save)
-			// Without --launch or --save-as, there is no persistent state to update.
-			// Return an error guiding the user to use one of those flags.
+			// Case 3: Configure the Batch Runner modal without launching.
+			const folderPath = session.autoRunFolderPath;
+			if (!folderPath) {
+				window.maestro.process.sendRemoteConfigureAutoRunResponse(responseChannel, {
+					success: false,
+					error: 'No Auto Run folder configured for this session',
+				});
+				return;
+			}
+
+			const documents: BatchDocumentEntry[] = (config.documents || []).map(
+				(doc: { filename: string; resetOnCompletion?: boolean }) => ({
+					id: generateId(),
+					filename: doc.filename.replace(/\.md$/i, ''),
+					resetOnCompletion: doc.resetOnCompletion || false,
+					isDuplicate: false,
+				})
+			);
+			if (documents.length === 0) {
+				window.maestro.process.sendRemoteConfigureAutoRunResponse(responseChannel, {
+					success: false,
+					error: 'No documents provided for auto-run',
+				});
+				return;
+			}
+
+			const selectedFile = documents[0].filename;
+			const sshRemoteId =
+				session.sshRemoteId || session.sessionSshRemoteConfig?.remoteId || undefined;
+			const contentResult = await window.maestro.autorun.readDoc(
+				folderPath,
+				`${selectedFile}.md`,
+				sshRemoteId
+			);
+			const batchConfig: BatchRunConfig = {
+				documents,
+				prompt: config.prompt || '',
+				loopEnabled: config.loopEnabled || false,
+				maxLoops: config.maxLoops ?? null,
+			};
+
+			setSessions((prev) =>
+				prev.map((candidate) =>
+					candidate.id === sessionId
+						? {
+								...candidate,
+								autoRunSelectedFile: selectedFile,
+								autoRunContent: contentResult.success ? contentResult.content || '' : '',
+								autoRunContentVersion: (candidate.autoRunContentVersion || 0) + 1,
+								batchRunnerPrompt: batchConfig.prompt,
+								batchRunnerPromptModifiedAt: Date.now(),
+							}
+						: candidate
+				)
+			);
+			useBatchStore.getState().setDocumentList(documents.map((document) => document.filename));
+			setActiveSessionId(sessionId);
+			const uiActions = useUIStore.getState();
+			uiActions.setRightPanelOpen(true);
+			uiActions.setActiveRightTab('autorun');
+			useModalStore.getState().openBatchRunnerWithConfig(batchConfig);
 			window.maestro.process.sendRemoteConfigureAutoRunResponse(responseChannel, {
-				success: false,
-				error: 'Use --launch to start auto-run immediately, or --save-as to save as a playbook',
+				success: true,
 			});
 		} catch (error) {
 			logger.error('[Remote] Failed to configure auto-run:', undefined, error);

--- a/src/renderer/hooks/remote/useAppRemoteEventListeners.ts
+++ b/src/renderer/hooks/remote/useAppRemoteEventListeners.ts
@@ -17,6 +17,7 @@ import { useModalStore } from '../../stores/modalStore';
 import { useUIStore } from '../../stores/uiStore';
 import { PLAYBOOKS_DIR } from '../../../shared/maestro-paths';
 import { asThinkingMode } from '../../../shared/types';
+import { getBasename, isAbsolutePath } from '../../../shared/formatters';
 import { getBrowserTabPartition } from '../../utils/browserTabPersistence';
 import { insertAfterActiveInUnifiedTabOrder } from '../../utils/unifiedTabOrderUtils';
 import {
@@ -53,6 +54,28 @@ import {
 	canCreateGroupInside,
 	removeGroupAndPromoteChildren,
 } from '../../../shared/groupHierarchy';
+
+function resolveRemoteAutoRunFilename(filename: string, folderPath: string): string {
+	const normalized = filename.replace(/\\/g, '/').replace(/\.md$/i, '');
+	const normalizedFolder = folderPath.replace(/\\/g, '/').replace(/\/$/, '');
+	let relative = normalized;
+
+	if (isAbsolutePath(filename)) {
+		if (!normalized.toLowerCase().startsWith(`${normalizedFolder.toLowerCase()}/`)) {
+			throw new Error(
+				`Auto Run document is outside the configured folder: ${getBasename(filename)}`
+			);
+		}
+		relative = normalized.slice(normalizedFolder.length + 1);
+	}
+
+	relative = relative.replace(/^\.\/+/, '');
+	if (!relative || relative.split('/').includes('..')) {
+		throw new Error(`Invalid Auto Run document path: ${filename}`);
+	}
+
+	return relative;
+}
 
 // ============================================================================
 // Dependencies interface
@@ -668,32 +691,12 @@ export function useAppRemoteEventListeners(deps: UseAppRemoteEventListenersDeps)
 				}
 
 				const documents = (config.documents || []).map(
-					(doc: { filename: string; resetOnCompletion?: boolean }) => {
-						// Compute path relative to the session's autoRunFolderPath.
-						// CLI sends full absolute paths (e.g., "/path/to/Auto Run Docs/subdir/temp.md")
-						// but the batch processor expects the path relative to folderPath without .md
-						// (e.g., "subdir/temp").
-						let name = doc.filename.replace(/\.md$/i, '');
-						// Normalize separators to forward slash for comparison
-						const normalized = name.replace(/\\/g, '/');
-						const normalizedFolder = (folderPath || '').replace(/\\/g, '/');
-						// Case-insensitive prefix check for cross-platform compatibility (Windows drive letters)
-						const normalizedLower = normalized.toLowerCase();
-						const folderLower = normalizedFolder.toLowerCase();
-						if (normalizedFolder && normalizedLower.startsWith(folderLower + '/')) {
-							name = normalized.substring(normalizedFolder.length + 1);
-						} else {
-							// Fallback for paths not under folderPath: use basename only
-							const lastSlash = Math.max(name.lastIndexOf('/'), name.lastIndexOf('\\'));
-							if (lastSlash >= 0) name = name.substring(lastSlash + 1);
-						}
-						return {
-							id: generateId(),
-							filename: name,
-							resetOnCompletion: doc.resetOnCompletion || false,
-							isDuplicate: false,
-						};
-					}
+					(doc: { filename: string; resetOnCompletion?: boolean }) => ({
+						id: generateId(),
+						filename: resolveRemoteAutoRunFilename(doc.filename, folderPath),
+						resetOnCompletion: doc.resetOnCompletion || false,
+						isDuplicate: false,
+					})
 				);
 
 				if (documents.length === 0) {
@@ -849,7 +852,7 @@ export function useAppRemoteEventListeners(deps: UseAppRemoteEventListenersDeps)
 			const documents: BatchDocumentEntry[] = (config.documents || []).map(
 				(doc: { filename: string; resetOnCompletion?: boolean }) => ({
 					id: generateId(),
-					filename: doc.filename.replace(/\.md$/i, ''),
+					filename: resolveRemoteAutoRunFilename(doc.filename, folderPath),
 					resetOnCompletion: doc.resetOnCompletion || false,
 					isDuplicate: false,
 				})

--- a/src/renderer/hooks/remote/useAppRemoteEventListeners.ts
+++ b/src/renderer/hooks/remote/useAppRemoteEventListeners.ts
@@ -12,6 +12,9 @@ import { useEventListener } from '../utils/useEventListener';
 import { generateId } from '../../utils/ids';
 import { useSessionStore, selectSessionById } from '../../stores/sessionStore';
 import { useSettingsStore } from '../../stores/settingsStore';
+import { useBatchStore } from '../../stores/batchStore';
+import { useModalStore } from '../../stores/modalStore';
+import { useUIStore } from '../../stores/uiStore';
 import { PLAYBOOKS_DIR } from '../../../shared/maestro-paths';
 import { asThinkingMode } from '../../../shared/types';
 import { getBrowserTabPartition } from '../../utils/browserTabPersistence';
@@ -23,7 +26,15 @@ import {
 	getTerminalTabDisplayName,
 	getTerminalSessionId,
 } from '../../utils/terminalTabHelpers';
-import type { Session, AITab, ToolType, Group, BatchRunConfig, BrowserTab } from '../../types';
+import type {
+	Session,
+	AITab,
+	ToolType,
+	Group,
+	BatchRunConfig,
+	BatchDocumentEntry,
+	BrowserTab,
+} from '../../types';
 import { logger } from '../../utils/logger';
 import { FILE_TREE_REFRESH_EVENT } from '../../utils/fileTreeRefresh';
 import { spawnPtyForTab } from '../../services/terminalSpawn';
@@ -825,12 +836,69 @@ export function useAppRemoteEventListeners(deps: UseAppRemoteEventListenersDeps)
 				return;
 			}
 
-			// Case 3: Just configure (no launch, no save)
-			// Without --launch or --save-as, there is no persistent state to update.
-			// Return an error guiding the user to use one of those flags.
+			// Case 3: Configure the Batch Runner modal without launching.
+			const folderPath = session.autoRunFolderPath;
+			if (!folderPath) {
+				window.maestro.process.sendRemoteConfigureAutoRunResponse(responseChannel, {
+					success: false,
+					error: 'No Auto Run folder configured for this session',
+				});
+				return;
+			}
+
+			const documents: BatchDocumentEntry[] = (config.documents || []).map(
+				(doc: { filename: string; resetOnCompletion?: boolean }) => ({
+					id: generateId(),
+					filename: doc.filename.replace(/\.md$/i, ''),
+					resetOnCompletion: doc.resetOnCompletion || false,
+					isDuplicate: false,
+				})
+			);
+			if (documents.length === 0) {
+				window.maestro.process.sendRemoteConfigureAutoRunResponse(responseChannel, {
+					success: false,
+					error: 'No documents provided for auto-run',
+				});
+				return;
+			}
+
+			const selectedFile = documents[0].filename;
+			const sshRemoteId =
+				session.sshRemoteId || session.sessionSshRemoteConfig?.remoteId || undefined;
+			const contentResult = await window.maestro.autorun.readDoc(
+				folderPath,
+				`${selectedFile}.md`,
+				sshRemoteId
+			);
+			const batchConfig: BatchRunConfig = {
+				documents,
+				prompt: config.prompt || '',
+				loopEnabled: config.loopEnabled || false,
+				maxLoops: config.maxLoops ?? null,
+			};
+
+			setSessions((prev) =>
+				prev.map((candidate) =>
+					candidate.id === sessionId
+						? {
+								...candidate,
+								autoRunSelectedFile: selectedFile,
+								autoRunContent: contentResult.success ? contentResult.content || '' : '',
+								autoRunContentVersion: (candidate.autoRunContentVersion || 0) + 1,
+								batchRunnerPrompt: batchConfig.prompt,
+								batchRunnerPromptModifiedAt: Date.now(),
+							}
+						: candidate
+				)
+			);
+			useBatchStore.getState().setDocumentList(documents.map((document) => document.filename));
+			setActiveSessionId(sessionId);
+			const uiActions = useUIStore.getState();
+			uiActions.setRightPanelOpen(true);
+			uiActions.setActiveRightTab('autorun');
+			useModalStore.getState().openBatchRunnerWithConfig(batchConfig);
 			window.maestro.process.sendRemoteConfigureAutoRunResponse(responseChannel, {
-				success: false,
-				error: 'Use --launch to start auto-run immediately, or --save-as to save as a playbook',
+				success: true,
 			});
 		} catch (error) {
 			logger.error('[Remote] Failed to configure auto-run:', undefined, error);

--- a/src/renderer/hooks/remote/useAppRemoteEventListeners.ts
+++ b/src/renderer/hooks/remote/useAppRemoteEventListeners.ts
@@ -649,7 +649,13 @@ export function useAppRemoteEventListeners(deps: UseAppRemoteEventListenersDeps)
 
 	// Handle remote configure auto-run events from CLI/web interface
 	useEventListener('maestro:configureAutoRun', async (e: Event) => {
-		const { sessionId, config, responseChannel } = (e as CustomEvent).detail;
+		const { sessionId, config, responseChannel } = (
+			e as CustomEvent<{
+				sessionId: string;
+				config: import('../../../main/web-server/types').ConfigureAutoRunConfig;
+				responseChannel: string;
+			}>
+		).detail;
 
 		try {
 			// Find the target session
@@ -666,7 +672,10 @@ export function useAppRemoteEventListeners(deps: UseAppRemoteEventListenersDeps)
 			if (config.saveAsPlaybook) {
 				const result = await window.maestro.playbooks.create(sessionId, {
 					name: config.saveAsPlaybook,
-					documents: config.documents || [],
+					documents: (config.documents || []).map((document) => ({
+						...document,
+						resetOnCompletion: document.resetOnCompletion || false,
+					})),
 					loopEnabled: config.loopEnabled || false,
 					maxLoops: config.maxLoops,
 					prompt: config.prompt || '',
@@ -895,10 +904,12 @@ export function useAppRemoteEventListeners(deps: UseAppRemoteEventListenersDeps)
 				)
 			);
 			useBatchStore.getState().setDocumentList(documents.map((document) => document.filename));
-			setActiveSessionId(sessionId);
-			const uiActions = useUIStore.getState();
-			uiActions.setRightPanelOpen(true);
-			uiActions.setActiveRightTab('autorun');
+			if (!config.background) {
+				setActiveSessionId(sessionId);
+				const uiActions = useUIStore.getState();
+				uiActions.setRightPanelOpen(true);
+				uiActions.setActiveRightTab('autorun');
+			}
 			useModalStore.getState().openBatchRunnerWithConfig(batchConfig);
 			window.maestro.process.sendRemoteConfigureAutoRunResponse(responseChannel, {
 				success: true,

--- a/src/renderer/hooks/remote/useRemoteIntegration.ts
+++ b/src/renderer/hooks/remote/useRemoteIntegration.ts
@@ -317,6 +317,57 @@ export function useRemoteIntegration(deps: UseRemoteIntegrationDeps): UseRemoteI
 		};
 	}, [setSessions]);
 
+	// Handle remote file tab open requests from CLI IPC
+	useEffect(() => {
+		const unsubscribeOpenFileTab = window.maestro.process.onRemoteOpenFileTab(
+			(sessionId: string, filePath: string) => {
+				window.dispatchEvent(
+					new CustomEvent('maestro:openFileTab', {
+						detail: { sessionId, filePath },
+					})
+				);
+			}
+		);
+
+		return () => {
+			unsubscribeOpenFileTab();
+		};
+	}, []);
+
+	// Handle remote file tree refresh requests from CLI IPC
+	useEffect(() => {
+		const unsubscribeRefreshFileTree = window.maestro.process.onRemoteRefreshFileTree(
+			(sessionId: string) => {
+				window.dispatchEvent(
+					new CustomEvent('maestro:refreshFileTree', {
+						detail: { sessionId },
+					})
+				);
+			}
+		);
+
+		return () => {
+			unsubscribeRefreshFileTree();
+		};
+	}, []);
+
+	// Handle remote Auto Run document refresh requests from CLI IPC
+	useEffect(() => {
+		const unsubscribeRefreshAutoRunDocs = window.maestro.process.onRemoteRefreshAutoRunDocs(
+			(sessionId: string) => {
+				window.dispatchEvent(
+					new CustomEvent('maestro:refreshAutoRunDocs', {
+						detail: { sessionId },
+					})
+				);
+			}
+		);
+
+		return () => {
+			unsubscribeRefreshAutoRunDocs();
+		};
+	}, []);
+
 	// Handle remote interrupts from web interface
 	// This allows web interrupts to go through the same code path as desktop (handleInterrupt)
 	useEffect(() => {

--- a/src/renderer/hooks/remote/useRemoteIntegration.ts
+++ b/src/renderer/hooks/remote/useRemoteIntegration.ts
@@ -25,15 +25,6 @@ import {
 	interactWithConcertoDesignerFrame,
 } from '../../components/Concerto/concertoDesignerBridge';
 
-type RemoteConfigureAutoRunConfig = {
-	documents: Array<{ filename: string; resetOnCompletion?: boolean }>;
-	prompt?: string;
-	loopEnabled?: boolean;
-	maxLoops?: number;
-	saveAsPlaybook?: string;
-	launch?: boolean;
-};
-
 /**
  * Dependencies for the useRemoteIntegration hook.
  * Uses refs for values that change frequently to avoid re-attaching listeners.
@@ -325,74 +316,6 @@ export function useRemoteIntegration(deps: UseRemoteIntegrationDeps): UseRemoteI
 			unsubscribeSwitchMode();
 		};
 	}, [setSessions]);
-
-	// Handle remote file tab open requests from CLI IPC
-	useEffect(() => {
-		const unsubscribeOpenFileTab = window.maestro.process.onRemoteOpenFileTab(
-			(sessionId: string, filePath: string) => {
-				window.dispatchEvent(
-					new CustomEvent('maestro:openFileTab', {
-						detail: { sessionId, filePath },
-					})
-				);
-			}
-		);
-
-		return () => {
-			unsubscribeOpenFileTab();
-		};
-	}, []);
-
-	// Handle remote file tree refresh requests from CLI IPC
-	useEffect(() => {
-		const unsubscribeRefreshFileTree = window.maestro.process.onRemoteRefreshFileTree(
-			(sessionId: string) => {
-				window.dispatchEvent(
-					new CustomEvent('maestro:refreshFileTree', {
-						detail: { sessionId },
-					})
-				);
-			}
-		);
-
-		return () => {
-			unsubscribeRefreshFileTree();
-		};
-	}, []);
-
-	// Handle remote Auto Run document refresh requests from CLI IPC
-	useEffect(() => {
-		const unsubscribeRefreshAutoRunDocs = window.maestro.process.onRemoteRefreshAutoRunDocs(
-			(sessionId: string) => {
-				window.dispatchEvent(
-					new CustomEvent('maestro:refreshAutoRunDocs', {
-						detail: { sessionId },
-					})
-				);
-			}
-		);
-
-		return () => {
-			unsubscribeRefreshAutoRunDocs();
-		};
-	}, []);
-
-	// Handle remote Auto Run configuration requests from CLI IPC
-	useEffect(() => {
-		const unsubscribeConfigureAutoRun = window.maestro.process.onRemoteConfigureAutoRun(
-			(sessionId: string, config: RemoteConfigureAutoRunConfig, responseChannel: string) => {
-				window.dispatchEvent(
-					new CustomEvent('maestro:configureAutoRun', {
-						detail: { sessionId, config, responseChannel },
-					})
-				);
-			}
-		);
-
-		return () => {
-			unsubscribeConfigureAutoRun();
-		};
-	}, []);
 
 	// Handle remote interrupts from web interface
 	// This allows web interrupts to go through the same code path as desktop (handleInterrupt)

--- a/src/renderer/hooks/remote/useRemoteIntegration.ts
+++ b/src/renderer/hooks/remote/useRemoteIntegration.ts
@@ -25,6 +25,15 @@ import {
 	interactWithConcertoDesignerFrame,
 } from '../../components/Concerto/concertoDesignerBridge';
 
+type RemoteConfigureAutoRunConfig = {
+	documents: Array<{ filename: string; resetOnCompletion?: boolean }>;
+	prompt?: string;
+	loopEnabled?: boolean;
+	maxLoops?: number;
+	saveAsPlaybook?: string;
+	launch?: boolean;
+};
+
 /**
  * Dependencies for the useRemoteIntegration hook.
  * Uses refs for values that change frequently to avoid re-attaching listeners.
@@ -365,6 +374,23 @@ export function useRemoteIntegration(deps: UseRemoteIntegrationDeps): UseRemoteI
 
 		return () => {
 			unsubscribeRefreshAutoRunDocs();
+		};
+	}, []);
+
+	// Handle remote Auto Run configuration requests from CLI IPC
+	useEffect(() => {
+		const unsubscribeConfigureAutoRun = window.maestro.process.onRemoteConfigureAutoRun(
+			(sessionId: string, config: RemoteConfigureAutoRunConfig, responseChannel: string) => {
+				window.dispatchEvent(
+					new CustomEvent('maestro:configureAutoRun', {
+						detail: { sessionId, config, responseChannel },
+					})
+				);
+			}
+		);
+
+		return () => {
+			unsubscribeConfigureAutoRun();
 		};
 	}, []);
 

--- a/src/renderer/hooks/remote/useRemoteIntegration.ts
+++ b/src/renderer/hooks/remote/useRemoteIntegration.ts
@@ -44,15 +44,6 @@ import {
 	consumeDesktopAiTabSelection,
 } from '../../utils/desktopTabSelectionSync';
 
-type RemoteConfigureAutoRunConfig = {
-	documents: Array<{ filename: string; resetOnCompletion?: boolean }>;
-	prompt?: string;
-	loopEnabled?: boolean;
-	maxLoops?: number;
-	saveAsPlaybook?: string;
-	launch?: boolean;
-};
-
 /**
  * Dependencies for the useRemoteIntegration hook.
  * Uses refs for values that change frequently to avoid re-attaching listeners.
@@ -475,74 +466,6 @@ export function useRemoteIntegration(deps: UseRemoteIntegrationDeps): UseRemoteI
 			unsubscribeSwitchMode();
 		};
 	}, [sessionsRef]);
-
-	// Handle remote file tab open requests from CLI IPC
-	useEffect(() => {
-		const unsubscribeOpenFileTab = window.maestro.process.onRemoteOpenFileTab(
-			(sessionId: string, filePath: string) => {
-				window.dispatchEvent(
-					new CustomEvent('maestro:openFileTab', {
-						detail: { sessionId, filePath },
-					})
-				);
-			}
-		);
-
-		return () => {
-			unsubscribeOpenFileTab();
-		};
-	}, []);
-
-	// Handle remote file tree refresh requests from CLI IPC
-	useEffect(() => {
-		const unsubscribeRefreshFileTree = window.maestro.process.onRemoteRefreshFileTree(
-			(sessionId: string) => {
-				window.dispatchEvent(
-					new CustomEvent('maestro:refreshFileTree', {
-						detail: { sessionId },
-					})
-				);
-			}
-		);
-
-		return () => {
-			unsubscribeRefreshFileTree();
-		};
-	}, []);
-
-	// Handle remote Auto Run document refresh requests from CLI IPC
-	useEffect(() => {
-		const unsubscribeRefreshAutoRunDocs = window.maestro.process.onRemoteRefreshAutoRunDocs(
-			(sessionId: string) => {
-				window.dispatchEvent(
-					new CustomEvent('maestro:refreshAutoRunDocs', {
-						detail: { sessionId },
-					})
-				);
-			}
-		);
-
-		return () => {
-			unsubscribeRefreshAutoRunDocs();
-		};
-	}, []);
-
-	// Handle remote Auto Run configuration requests from CLI IPC
-	useEffect(() => {
-		const unsubscribeConfigureAutoRun = window.maestro.process.onRemoteConfigureAutoRun(
-			(sessionId: string, config: RemoteConfigureAutoRunConfig, responseChannel: string) => {
-				window.dispatchEvent(
-					new CustomEvent('maestro:configureAutoRun', {
-						detail: { sessionId, config, responseChannel },
-					})
-				);
-			}
-		);
-
-		return () => {
-			unsubscribeConfigureAutoRun();
-		};
-	}, []);
 
 	// Handle remote interrupts from web interface
 	// This allows web interrupts to go through the same code path as desktop (handleInterrupt)

--- a/src/renderer/hooks/remote/useRemoteIntegration.ts
+++ b/src/renderer/hooks/remote/useRemoteIntegration.ts
@@ -44,6 +44,15 @@ import {
 	consumeDesktopAiTabSelection,
 } from '../../utils/desktopTabSelectionSync';
 
+type RemoteConfigureAutoRunConfig = {
+	documents: Array<{ filename: string; resetOnCompletion?: boolean }>;
+	prompt?: string;
+	loopEnabled?: boolean;
+	maxLoops?: number;
+	saveAsPlaybook?: string;
+	launch?: boolean;
+};
+
 /**
  * Dependencies for the useRemoteIntegration hook.
  * Uses refs for values that change frequently to avoid re-attaching listeners.
@@ -515,6 +524,23 @@ export function useRemoteIntegration(deps: UseRemoteIntegrationDeps): UseRemoteI
 
 		return () => {
 			unsubscribeRefreshAutoRunDocs();
+		};
+	}, []);
+
+	// Handle remote Auto Run configuration requests from CLI IPC
+	useEffect(() => {
+		const unsubscribeConfigureAutoRun = window.maestro.process.onRemoteConfigureAutoRun(
+			(sessionId: string, config: RemoteConfigureAutoRunConfig, responseChannel: string) => {
+				window.dispatchEvent(
+					new CustomEvent('maestro:configureAutoRun', {
+						detail: { sessionId, config, responseChannel },
+					})
+				);
+			}
+		);
+
+		return () => {
+			unsubscribeConfigureAutoRun();
 		};
 	}, []);
 

--- a/src/renderer/hooks/remote/useRemoteIntegration.ts
+++ b/src/renderer/hooks/remote/useRemoteIntegration.ts
@@ -467,6 +467,57 @@ export function useRemoteIntegration(deps: UseRemoteIntegrationDeps): UseRemoteI
 		};
 	}, [sessionsRef]);
 
+	// Handle remote file tab open requests from CLI IPC
+	useEffect(() => {
+		const unsubscribeOpenFileTab = window.maestro.process.onRemoteOpenFileTab(
+			(sessionId: string, filePath: string) => {
+				window.dispatchEvent(
+					new CustomEvent('maestro:openFileTab', {
+						detail: { sessionId, filePath },
+					})
+				);
+			}
+		);
+
+		return () => {
+			unsubscribeOpenFileTab();
+		};
+	}, []);
+
+	// Handle remote file tree refresh requests from CLI IPC
+	useEffect(() => {
+		const unsubscribeRefreshFileTree = window.maestro.process.onRemoteRefreshFileTree(
+			(sessionId: string) => {
+				window.dispatchEvent(
+					new CustomEvent('maestro:refreshFileTree', {
+						detail: { sessionId },
+					})
+				);
+			}
+		);
+
+		return () => {
+			unsubscribeRefreshFileTree();
+		};
+	}, []);
+
+	// Handle remote Auto Run document refresh requests from CLI IPC
+	useEffect(() => {
+		const unsubscribeRefreshAutoRunDocs = window.maestro.process.onRemoteRefreshAutoRunDocs(
+			(sessionId: string) => {
+				window.dispatchEvent(
+					new CustomEvent('maestro:refreshAutoRunDocs', {
+						detail: { sessionId },
+					})
+				);
+			}
+		);
+
+		return () => {
+			unsubscribeRefreshAutoRunDocs();
+		};
+	}, []);
+
 	// Handle remote interrupts from web interface
 	// This allows web interrupts to go through the same code path as desktop (handleInterrupt)
 	useEffect(() => {

--- a/src/renderer/hooks/remote/useRemoteIntegration.ts
+++ b/src/renderer/hooks/remote/useRemoteIntegration.ts
@@ -1566,7 +1566,11 @@ export function useRemoteIntegration(deps: UseRemoteIntegrationDeps): UseRemoteI
 	// Handle remote configure auto-run from CLI/web interface
 	useEffect(() => {
 		const unsubscribe = window.maestro.process.onRemoteConfigureAutoRun(
-			(sessionId: string, config: any, responseChannel: string) => {
+			(
+				sessionId: string,
+				config: import('../../../main/web-server/types').ConfigureAutoRunConfig,
+				responseChannel: string
+			) => {
 				window.dispatchEvent(
 					new CustomEvent('maestro:configureAutoRun', {
 						detail: { sessionId, config, responseChannel },

--- a/src/renderer/stores/modalStore.ts
+++ b/src/renderer/stores/modalStore.ts
@@ -591,6 +591,13 @@ export const useModalStore = create<ModalStore>()((set, get) => ({
 			state.openModal('promptComposer');
 		}
 	},
+
+	openBatchRunnerWithConfig: (initialConfig) => {
+		get().openModal('batchRunner', {
+			initialConfig,
+			presetDocuments: initialConfig.documents?.map((doc) => doc.filename),
+		});
+	},
 }));
 
 // ============================================================================

--- a/src/renderer/stores/modalStore.ts
+++ b/src/renderer/stores/modalStore.ts
@@ -15,7 +15,7 @@
  */
 
 import { create } from 'zustand';
-import type { Session, SettingsTab, AgentError } from '../types';
+import type { Session, SettingsTab, AgentError, BatchRunConfig } from '../types';
 import type { GitStreamingOperation } from '../../shared/gitUtils';
 import type { SerializableWizardState } from '../components/Wizard';
 import type { ConductorBadge } from '../constants/conductorBadges';
@@ -261,6 +261,8 @@ export interface KeyboardMasteryData {
 export interface BatchRunnerModalData {
 	/** Document filenames (without `.md`) to pre-populate the run list with. When omitted, the run list opens empty. */
 	presetDocuments?: string[];
+	/** Optional full config to seed prompt, loop settings, and documents. */
+	initialConfig?: Partial<BatchRunConfig>;
 }
 
 // ============================================================================
@@ -472,6 +474,7 @@ interface ModalStoreActions {
 	 * full-screen - so repeated presses switch sizes instead of doing nothing.
 	 */
 	cyclePromptComposer: () => void;
+	openBatchRunnerWithConfig: (initialConfig: Partial<BatchRunConfig>) => void;
 }
 
 export type ModalStore = ModalStoreState & ModalStoreActions;
@@ -900,6 +903,11 @@ export function getModalActions() {
 			open ? openModal('batchRunner', {}) : closeModal('batchRunner'),
 		openBatchRunnerWithPresets: (presetDocuments: string[]) =>
 			openModal('batchRunner', { presetDocuments }),
+		openBatchRunnerWithConfig: (initialConfig: Partial<BatchRunConfig>) =>
+			openModal('batchRunner', {
+				initialConfig,
+				presetDocuments: initialConfig.documents?.map((doc) => doc.filename),
+			}),
 
 		// Auto Run Setup Modal
 		setAutoRunSetupModalOpen: (open: boolean) =>

--- a/src/renderer/stores/modalStore.ts
+++ b/src/renderer/stores/modalStore.ts
@@ -15,7 +15,7 @@
  */
 
 import { create } from 'zustand';
-import type { Session, SettingsTab, AgentError } from '../types';
+import type { Session, SettingsTab, AgentError, BatchRunConfig } from '../types';
 import type { GitStreamingOperation } from '../../shared/gitUtils';
 import type { SerializableWizardState } from '../components/Wizard';
 import type { ConductorBadge } from '../constants/conductorBadges';
@@ -326,6 +326,8 @@ export interface KeyboardMasteryData {
 export interface BatchRunnerModalData {
 	/** Document filenames (without `.md`) to pre-populate the run list with. When omitted, the run list opens empty. */
 	presetDocuments?: string[];
+	/** Optional full config to seed prompt, loop settings, and documents. */
+	initialConfig?: Partial<BatchRunConfig>;
 }
 
 // ============================================================================
@@ -653,6 +655,7 @@ interface ModalStoreActions {
 	 * full-screen - so repeated presses switch sizes instead of doing nothing.
 	 */
 	cyclePromptComposer: () => void;
+	openBatchRunnerWithConfig: (initialConfig: Partial<BatchRunConfig>) => void;
 }
 
 export type ModalStore = ModalStoreState & ModalStoreActions;
@@ -1089,6 +1092,11 @@ export function getModalActions() {
 			open ? openModal('batchRunner', {}) : closeModal('batchRunner'),
 		openBatchRunnerWithPresets: (presetDocuments: string[]) =>
 			openModal('batchRunner', { presetDocuments }),
+		openBatchRunnerWithConfig: (initialConfig: Partial<BatchRunConfig>) =>
+			openModal('batchRunner', {
+				initialConfig,
+				presetDocuments: initialConfig.documents?.map((doc) => doc.filename),
+			}),
 
 		// Auto Run Setup Modal
 		setAutoRunSetupModalOpen: (open: boolean) =>

--- a/src/renderer/stores/modalStore.ts
+++ b/src/renderer/stores/modalStore.ts
@@ -780,6 +780,13 @@ export const useModalStore = create<ModalStore>()((set, get) => ({
 			state.openModal('promptComposer');
 		}
 	},
+
+	openBatchRunnerWithConfig: (initialConfig) => {
+		get().openModal('batchRunner', {
+			initialConfig,
+			presetDocuments: initialConfig.documents?.map((doc) => doc.filename),
+		});
+	},
 }));
 
 // ============================================================================

--- a/src/shared/cli-server-discovery.ts
+++ b/src/shared/cli-server-discovery.ts
@@ -50,9 +50,33 @@ function getConfigDir(): string {
 }
 
 const DISCOVERY_FILE = 'cli-server.json';
+const OWNER_READ_WRITE = 0o600;
+const OWNER_DIRECTORY = 0o700;
 
 function getDiscoveryFilePath(): string {
 	return path.join(getConfigDir(), DISCOVERY_FILE);
+}
+
+function ensurePrivateConfigDir(dir: string): void {
+	const stats = fs.statSync(dir);
+	if ((stats.mode & 0o077) !== 0) {
+		fs.chmodSync(dir, OWNER_DIRECTORY);
+	}
+}
+
+function isValidCliServerInfo(data: CliServerInfo): boolean {
+	return (
+		Number.isInteger(data.port) &&
+		data.port > 0 &&
+		data.port <= 65535 &&
+		typeof data.token === 'string' &&
+		data.token.length > 0 &&
+		Number.isInteger(data.pid) &&
+		data.pid > 0 &&
+		Number.isInteger(data.startedAt) &&
+		data.startedAt >= 0 &&
+		(data.version === undefined || typeof data.version === 'string')
+	);
 }
 
 /**
@@ -62,11 +86,17 @@ export function writeCliServerInfo(info: CliServerInfo): void {
 	const filePath = getDiscoveryFilePath();
 	const dir = path.dirname(filePath);
 	if (!fs.existsSync(dir)) {
-		fs.mkdirSync(dir, { recursive: true });
+		fs.mkdirSync(dir, { recursive: true, mode: OWNER_DIRECTORY });
 	}
+	ensurePrivateConfigDir(dir);
 	const tmpPath = filePath + '.tmp';
-	fs.writeFileSync(tmpPath, JSON.stringify(info, null, 2), 'utf-8');
+	fs.writeFileSync(tmpPath, JSON.stringify(info, null, 2), {
+		encoding: 'utf-8',
+		mode: OWNER_READ_WRITE,
+	});
+	fs.chmodSync(tmpPath, OWNER_READ_WRITE);
 	fs.renameSync(tmpPath, filePath);
+	fs.chmodSync(filePath, OWNER_READ_WRITE);
 }
 
 /**
@@ -78,15 +108,7 @@ export function readCliServerInfo(): CliServerInfo | null {
 		const filePath = getDiscoveryFilePath();
 		const content = fs.readFileSync(filePath, 'utf-8');
 		const data = JSON.parse(content) as CliServerInfo;
-		if (
-			typeof data.port === 'number' &&
-			typeof data.token === 'string' &&
-			typeof data.pid === 'number' &&
-			typeof data.startedAt === 'number'
-		) {
-			return data;
-		}
-		return null;
+		return isValidCliServerInfo(data) ? data : null;
 	} catch {
 		return null;
 	}

--- a/src/shared/focusPlacement.ts
+++ b/src/shared/focusPlacement.ts
@@ -104,6 +104,8 @@ export const CLI_BACKGROUND_DEFAULTS = {
 	 * still happens either way.
 	 */
 	'refresh-auto-run': false,
+	/** maestro-cli auto-run - opens the configured Auto Run view today. */
+	'auto-run': false,
 	/**
 	 * maestro-cli switch-mode - proceeds today.
 	 *


### PR DESCRIPTION
## Maestro Symphony Contribution

Closes #511

Contributed via [Maestro Symphony](https://runmaestro.ai).

**Status:** Ready for Review
**Started:** 2026-05-22T00:40:48.300Z

---

This PR will be updated automatically when the Auto Run completes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CLI integration for opening files, refreshing file trees and Auto Run documents, configuring Auto Run, and checking Maestro status.
  * Auto Run now validates Markdown files and uses folder-relative document paths.
  * Remote Auto Run configurations can prefill prompts, documents, looping options, launch runs, or save playbooks.
  * Batch Runner opens with preconfigured documents, prompts, and loop settings.

* **Bug Fixes**
  * Improved handling of connection failures, invalid responses, unavailable sessions, and unsuccessful Auto Run operations.
  * Added clearer status reporting when Maestro is unavailable or stale.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->