### PR TITLE
Add Claude and Codex token usage dashboard

### DIFF
--- a/src/__tests__/main/agents/codex-usage-sampler.test.ts
+++ b/src/__tests__/main/agents/codex-usage-sampler.test.ts
@@ -97,4 +97,41 @@ describe('codex-usage-sampler', () => {
 			],
 		});
 	});
+
+	it('drops non-finite usage percentages from quota windows', async () => {
+		await fs.writeFile(
+			path.join(TEST_ROOT, 'auth.json'),
+			JSON.stringify({
+				tokens: {
+					access_token: 'redacted-token',
+				},
+			})
+		);
+		vi.mocked(globalThis.fetch).mockResolvedValue({
+			ok: true,
+			status: 200,
+			json: vi.fn().mockResolvedValue({
+				email: 'codex@example.com',
+				rate_limit: {
+					primary_window: { used_percent: Number.NaN, reset_at: 1779550000 },
+					secondary_window: { used_percent: Number.POSITIVE_INFINITY, reset_at: 1779900000 },
+				},
+				additional_rate_limits: [
+					{
+						limit_name: 'bad-window',
+						rate_limit: {
+							primary_window: { used_percent: Number.NaN, reset_at: 1779560000 },
+						},
+					},
+				],
+			}),
+		} as unknown as Response);
+
+		const snapshot = await sampleCodexUsage({ codexHome: TEST_ROOT });
+
+		expect(snapshot.authState).toBe('authenticated');
+		expect(snapshot.session).toBeUndefined();
+		expect(snapshot.weekly).toBeUndefined();
+		expect(snapshot.additionalLimits).toEqual([]);
+	});
 });

--- a/src/__tests__/main/agents/codex-usage-sampler.test.ts
+++ b/src/__tests__/main/agents/codex-usage-sampler.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'fs/promises';
+import path from 'path';
+
+const { captureMessageMock } = vi.hoisted(() => ({
+	captureMessageMock: vi.fn(),
+}));
+
+vi.mock('../../../main/utils/sentry', () => ({
+	captureMessage: captureMessageMock,
+}));
+
+import { sampleCodexUsage } from '../../../main/agents/codex-usage-sampler';
+
+const TEST_ROOT = path.join(process.cwd(), '.tmp-codex-usage-sampler');
+
+describe('codex-usage-sampler', () => {
+	beforeEach(async () => {
+		await fs.rm(TEST_ROOT, { recursive: true, force: true });
+		await fs.mkdir(TEST_ROOT, { recursive: true });
+		captureMessageMock.mockReset().mockResolvedValue(undefined);
+		vi.stubGlobal('fetch', vi.fn());
+	});
+
+	afterEach(async () => {
+		vi.unstubAllGlobals();
+		await fs.rm(TEST_ROOT, { recursive: true, force: true });
+	});
+
+	it('returns a missing_auth snapshot when auth.json is absent', async () => {
+		const snapshot = await sampleCodexUsage({ codexHome: TEST_ROOT });
+
+		expect(snapshot).toMatchObject({
+			codexHomeKey: TEST_ROOT,
+			authState: 'missing_auth',
+		});
+		expect(snapshot.error).toContain('No auth.json');
+		expect(globalThis.fetch).not.toHaveBeenCalled();
+	});
+
+	it('maps wham usage windows into a sanitized Codex snapshot', async () => {
+		await fs.writeFile(
+			path.join(TEST_ROOT, 'auth.json'),
+			JSON.stringify({
+				tokens: {
+					access_token: 'redacted-token',
+					account_id: 'account-123',
+				},
+			})
+		);
+		vi.mocked(globalThis.fetch).mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					email: 'codex@example.com',
+					plan_type: 'pro',
+					rate_limit: {
+						primary_window: { used_percent: 12, reset_at: 1779550000 },
+						secondary_window: { used_percent: 34, reset_at: 1779900000 },
+					},
+					additional_rate_limits: [
+						{
+							limit_name: 'gpt-5.3-codex',
+							rate_limit: {
+								primary_window: { used_percent: 5, reset_at: 1779560000 },
+							},
+						},
+					],
+				}),
+				{ status: 200, headers: { 'Content-Type': 'application/json' } }
+			)
+		);
+
+		const snapshot = await sampleCodexUsage({ codexHome: TEST_ROOT });
+
+		expect(globalThis.fetch).toHaveBeenCalledWith(
+			'https://chatgpt.com/backend-api/wham/usage',
+			expect.objectContaining({
+				headers: expect.objectContaining({
+					Authorization: 'Bearer redacted-token',
+					'ChatGPT-Account-Id': 'account-123',
+				}),
+			})
+		);
+		expect(snapshot).toMatchObject({
+			codexHomeKey: TEST_ROOT,
+			authState: 'authenticated',
+			email: 'codex@example.com',
+			planType: 'pro',
+			session: { percent: 12, resetsAt: '2026-05-23T15:26:40.000Z' },
+			weekly: { percent: 34, resetsAt: '2026-05-27T16:40:00.000Z' },
+			additionalLimits: [
+				{
+					name: 'gpt-5.3-codex',
+					percent: 5,
+					resetsAt: '2026-05-23T18:13:20.000Z',
+				},
+			],
+		});
+	});
+});

--- a/src/__tests__/main/agents/codex-usage-startup.test.ts
+++ b/src/__tests__/main/agents/codex-usage-startup.test.ts
@@ -3,7 +3,8 @@
  *
  * Covers review-sensitive behavior:
  *   - corrupted CODEX_HOME values fall back to the default account home
- *   - one account failure does not cancel sampling for the rest of the batch
+ *   - recoverable account failures do not cancel sampling for the rest of the batch
+ *   - unexpected account failures are reported after the rest of the batch runs
  *   - discovery only swallows expected missing/unreadable auth.json errors
  */
 
@@ -216,10 +217,11 @@ describe('codex-usage-startup → runCodexUsageSampling', () => {
 		expect(getAllCodexUsageSnapshots()).toHaveProperty('/Users/test/.codex');
 	});
 
-	it('continues sampling other accounts when one account throws unexpectedly', async () => {
+	it('continues sampling other accounts when one account throws a recoverable error', async () => {
+		const recoverable = Object.assign(new Error('timed out'), { code: 'ETIMEDOUT' });
 		sampleCodexUsageMock.mockImplementation(async ({ codexHome }: { codexHome: string }) => {
 			if (codexHome === '/Users/test/.codex-broken') {
-				throw new Error('boom');
+				throw recoverable;
 			}
 			return makeSnapshot(codexHome);
 		});
@@ -249,8 +251,60 @@ describe('codex-usage-startup → runCodexUsageSampling', () => {
 		expect(sampleCodexUsageMock).toHaveBeenCalledTimes(2);
 		expect(snapshots).toHaveProperty('/Users/test/.codex-good');
 		expect(snapshots).not.toHaveProperty('/Users/test/.codex-broken');
+		expect(captureExceptionMock).not.toHaveBeenCalled();
 		expect(loggerWarnMock).toHaveBeenCalledWith(
 			expect.stringContaining('Failed to sample Codex usage snapshot'),
+			expect.any(String),
+			expect.objectContaining({
+				codexHomeKey: '/Users/test/.codex-broken',
+				error: 'timed out',
+			})
+		);
+	});
+
+	it('samples remaining accounts before surfacing unexpected account errors', async () => {
+		const unexpected = new Error('boom');
+		sampleCodexUsageMock.mockImplementation(async ({ codexHome }: { codexHome: string }) => {
+			if (codexHome === '/Users/test/.codex-broken') {
+				throw unexpected;
+			}
+			return makeSnapshot(codexHome);
+		});
+
+		await expect(
+			runCodexUsageSampling({
+				sessionsStore: makeStore({
+					sessions: [
+						{
+							id: 'codex-good',
+							toolType: 'codex',
+							cwd: '/tmp',
+							customEnvVars: { CODEX_HOME: '/Users/test/.codex-good' },
+						},
+						{
+							id: 'codex-broken',
+							toolType: 'codex',
+							cwd: '/tmp',
+							customEnvVars: { CODEX_HOME: '/Users/test/.codex-broken' },
+						},
+					],
+				}) as never,
+				agentConfigsStore: makeStore({ configs: {} }) as never,
+				agentDetector: makeDetector(FAKE_AGENT) as never,
+			})
+		).rejects.toThrow('boom');
+
+		const snapshots = getAllCodexUsageSnapshots();
+		expect(sampleCodexUsageMock).toHaveBeenCalledTimes(2);
+		expect(snapshots).toHaveProperty('/Users/test/.codex-good');
+		expect(snapshots).not.toHaveProperty('/Users/test/.codex-broken');
+		expect(captureExceptionMock).toHaveBeenCalledWith(unexpected, {
+			operation: 'codexUsage:runCodexUsageSampling.sample',
+			codexHome: '/Users/test/.codex-broken',
+			codexHomeKey: '/Users/test/.codex-broken',
+		});
+		expect(loggerWarnMock).toHaveBeenCalledWith(
+			expect.stringContaining('Unexpected failure while sampling Codex usage snapshot'),
 			expect.any(String),
 			expect.objectContaining({
 				codexHomeKey: '/Users/test/.codex-broken',

--- a/src/__tests__/main/agents/codex-usage-startup.test.ts
+++ b/src/__tests__/main/agents/codex-usage-startup.test.ts
@@ -4,15 +4,20 @@
  * Covers review-sensitive behavior:
  *   - corrupted CODEX_HOME values fall back to the default account home
  *   - one account failure does not cancel sampling for the rest of the batch
+ *   - discovery only swallows expected missing/unreadable auth.json errors
  */
 
+import * as fs from 'fs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { sampleCodexUsageMock, loggerWarnMock, loggerInfoMock } = vi.hoisted(() => ({
-	sampleCodexUsageMock: vi.fn(),
-	loggerWarnMock: vi.fn(),
-	loggerInfoMock: vi.fn(),
-}));
+const { sampleCodexUsageMock, loggerWarnMock, loggerInfoMock, captureExceptionMock } = vi.hoisted(
+	() => ({
+		sampleCodexUsageMock: vi.fn(),
+		loggerWarnMock: vi.fn(),
+		loggerInfoMock: vi.fn(),
+		captureExceptionMock: vi.fn(),
+	})
+);
 
 vi.mock('../../../main/agents/codex-usage-sampler', () => ({
 	sampleCodexUsage: sampleCodexUsageMock,
@@ -25,6 +30,10 @@ vi.mock('../../../main/utils/logger', () => ({
 		debug: vi.fn(),
 		error: vi.fn(),
 	},
+}));
+
+vi.mock('../../../main/utils/sentry', () => ({
+	captureException: captureExceptionMock,
 }));
 
 vi.mock('electron-store', () => {
@@ -57,7 +66,10 @@ vi.mock('os', async () => {
 	};
 });
 
-import { runCodexUsageSampling } from '../../../main/agents/codex-usage-startup';
+import {
+	discoverCodexHomes,
+	runCodexUsageSampling,
+} from '../../../main/agents/codex-usage-startup';
 import {
 	clearCodexUsageSnapshots,
 	getAllCodexUsageSnapshots,
@@ -103,6 +115,10 @@ function makeSnapshot(codexHomeKey: string): CodexUsageSnapshot {
 	};
 }
 
+function makeDirent(name: string, isDirectory = true): fs.Dirent {
+	return { name, isDirectory: () => isDirectory } as fs.Dirent;
+}
+
 const FAKE_AGENT = {
 	id: 'codex',
 	name: 'Codex',
@@ -113,11 +129,67 @@ const FAKE_AGENT = {
 	available: true,
 };
 
+describe('codex-usage-startup → discoverCodexHomes', () => {
+	beforeEach(() => {
+		captureExceptionMock.mockReset();
+	});
+
+	it('skips homes with missing or unreadable auth.json files', async () => {
+		const readdirSpy = vi
+			.spyOn(fs.promises, 'readdir')
+			.mockResolvedValue([
+				makeDirent('.codex-missing'),
+				makeDirent('.codex-denied'),
+				makeDirent('.codex-good'),
+			] as never);
+		const accessSpy = vi
+			.spyOn(fs.promises, 'access')
+			.mockImplementation(async (authPath: fs.PathLike) => {
+				const pathText = String(authPath);
+				if (pathText.includes('.codex-missing')) {
+					throw Object.assign(new Error('missing'), { code: 'ENOENT' });
+				}
+				if (pathText.includes('.codex-denied')) {
+					throw Object.assign(new Error('denied'), { code: 'EACCES' });
+				}
+			});
+
+		try {
+			await expect(discoverCodexHomes('/Users/test')).resolves.toEqual(['/Users/test/.codex-good']);
+			expect(captureExceptionMock).not.toHaveBeenCalled();
+		} finally {
+			readdirSpy.mockRestore();
+			accessSpy.mockRestore();
+		}
+	});
+
+	it('reports and rethrows unexpected auth.json access errors', async () => {
+		const unexpected = Object.assign(new Error('disk failure'), { code: 'EIO' });
+		const readdirSpy = vi
+			.spyOn(fs.promises, 'readdir')
+			.mockResolvedValue([makeDirent('.codex-broken')] as never);
+		const accessSpy = vi.spyOn(fs.promises, 'access').mockRejectedValue(unexpected);
+
+		try {
+			await expect(discoverCodexHomes('/Users/test')).rejects.toThrow('disk failure');
+			expect(captureExceptionMock).toHaveBeenCalledWith(unexpected, {
+				operation: 'codexUsage:discoverCodexHomes.access',
+				codexHome: '/Users/test/.codex-broken',
+				authPath: '/Users/test/.codex-broken/auth.json',
+			});
+		} finally {
+			readdirSpy.mockRestore();
+			accessSpy.mockRestore();
+		}
+	});
+});
+
 describe('codex-usage-startup → runCodexUsageSampling', () => {
 	beforeEach(() => {
 		sampleCodexUsageMock.mockReset();
 		loggerWarnMock.mockReset();
 		loggerInfoMock.mockReset();
+		captureExceptionMock.mockReset();
 		resetCodexUsageStore();
 		clearCodexUsageSnapshots();
 	});

--- a/src/__tests__/main/agents/codex-usage-startup.test.ts
+++ b/src/__tests__/main/agents/codex-usage-startup.test.ts
@@ -74,6 +74,7 @@ import {
 import {
 	clearCodexUsageSnapshots,
 	getAllCodexUsageSnapshots,
+	resolveCodexHomeKey,
 	__resetForTests as resetCodexUsageStore,
 	type CodexUsageSnapshot,
 } from '../../../main/stores/codexUsageStore';
@@ -135,6 +136,33 @@ describe('codex-usage-startup → discoverCodexHomes', () => {
 		captureExceptionMock.mockReset();
 	});
 
+	it('returns no homes for recoverable home directory read failures', async () => {
+		const denied = Object.assign(new Error('denied'), { code: 'EACCES' });
+		const readdirSpy = vi.spyOn(fs.promises, 'readdir').mockRejectedValue(denied);
+
+		try {
+			await expect(discoverCodexHomes('/Users/test')).resolves.toEqual([]);
+			expect(captureExceptionMock).not.toHaveBeenCalled();
+		} finally {
+			readdirSpy.mockRestore();
+		}
+	});
+
+	it('reports and rethrows unexpected home directory read failures', async () => {
+		const unexpected = Object.assign(new Error('disk failure'), { code: 'EIO' });
+		const readdirSpy = vi.spyOn(fs.promises, 'readdir').mockRejectedValue(unexpected);
+
+		try {
+			await expect(discoverCodexHomes('/Users/test')).rejects.toThrow('disk failure');
+			expect(captureExceptionMock).toHaveBeenCalledWith(unexpected, {
+				operation: 'codexUsage:discoverCodexHomes.readdir',
+				homeDir: '/Users/test',
+			});
+		} finally {
+			readdirSpy.mockRestore();
+		}
+	});
+
 	it('skips homes with missing or unreadable auth.json files', async () => {
 		const readdirSpy = vi
 			.spyOn(fs.promises, 'readdir')
@@ -182,6 +210,12 @@ describe('codex-usage-startup → discoverCodexHomes', () => {
 			readdirSpy.mockRestore();
 			accessSpy.mockRestore();
 		}
+	});
+});
+
+describe('codexUsageStore → resolveCodexHomeKey', () => {
+	it('falls back to the default CODEX_HOME for an empty env value', () => {
+		expect(resolveCodexHomeKey({ CODEX_HOME: '' })).toBe('/Users/test/.codex');
 	});
 });
 

--- a/src/__tests__/main/agents/codex-usage-startup.test.ts
+++ b/src/__tests__/main/agents/codex-usage-startup.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Tests for src/main/agents/codex-usage-startup.ts
+ *
+ * Covers review-sensitive behavior:
+ *   - corrupted CODEX_HOME values fall back to the default account home
+ *   - one account failure does not cancel sampling for the rest of the batch
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { sampleCodexUsageMock, loggerWarnMock, loggerInfoMock } = vi.hoisted(() => ({
+	sampleCodexUsageMock: vi.fn(),
+	loggerWarnMock: vi.fn(),
+	loggerInfoMock: vi.fn(),
+}));
+
+vi.mock('../../../main/agents/codex-usage-sampler', () => ({
+	sampleCodexUsage: sampleCodexUsageMock,
+}));
+
+vi.mock('../../../main/utils/logger', () => ({
+	logger: {
+		warn: loggerWarnMock,
+		info: loggerInfoMock,
+		debug: vi.fn(),
+		error: vi.fn(),
+	},
+}));
+
+vi.mock('electron-store', () => {
+	return {
+		default: class MockStore {
+			data: Record<string, unknown>;
+			constructor(options: Record<string, unknown>) {
+				this.data = { ...((options.defaults as Record<string, unknown>) ?? {}) };
+			}
+			get(key: string, defaultValue?: unknown): unknown {
+				if (Object.prototype.hasOwnProperty.call(this.data, key)) {
+					return this.data[key];
+				}
+				return defaultValue;
+			}
+			set(key: string, value: unknown): void {
+				this.data[key] = value;
+			}
+		},
+	};
+});
+
+vi.mock('os', async () => {
+	const actual = await vi.importActual<typeof import('os')>('os');
+	const homedir = () => '/Users/test';
+	return {
+		...actual,
+		homedir,
+		default: { ...actual, homedir },
+	};
+});
+
+import { runCodexUsageSampling } from '../../../main/agents/codex-usage-startup';
+import {
+	clearCodexUsageSnapshots,
+	getAllCodexUsageSnapshots,
+	__resetForTests as resetCodexUsageStore,
+	type CodexUsageSnapshot,
+} from '../../../main/stores/codexUsageStore';
+
+interface FakeStore<T> {
+	get(key: string, defaultValue?: unknown): unknown;
+	set(key: string, value: unknown): void;
+	_data: T;
+}
+
+function makeStore<T extends Record<string, unknown>>(data: T): FakeStore<T> {
+	const _data = { ...data };
+	return {
+		_data,
+		get(key: string, defaultValue?: unknown): unknown {
+			if (Object.prototype.hasOwnProperty.call(_data, key)) {
+				return (_data as Record<string, unknown>)[key];
+			}
+			return defaultValue;
+		},
+		set(key: string, value: unknown): void {
+			(_data as Record<string, unknown>)[key] = value;
+		},
+	};
+}
+
+function makeDetector(agentResult: unknown): {
+	getAgent: ReturnType<typeof vi.fn>;
+} {
+	return { getAgent: vi.fn().mockResolvedValue(agentResult) };
+}
+
+function makeSnapshot(codexHomeKey: string): CodexUsageSnapshot {
+	return {
+		sampledAt: new Date().toISOString(),
+		codexHomeKey,
+		authState: 'authenticated',
+		session: { percent: 25, resetsAt: '2026-05-15T05:00:00.000Z' },
+		weekly: { percent: 50, resetsAt: '2026-05-22T00:00:00.000Z' },
+	};
+}
+
+const FAKE_AGENT = {
+	id: 'codex',
+	name: 'Codex',
+	binaryName: 'codex',
+	command: 'codex',
+	path: '/usr/local/bin/codex',
+	args: [],
+	available: true,
+};
+
+describe('codex-usage-startup → runCodexUsageSampling', () => {
+	beforeEach(() => {
+		sampleCodexUsageMock.mockReset();
+		loggerWarnMock.mockReset();
+		loggerInfoMock.mockReset();
+		resetCodexUsageStore();
+		clearCodexUsageSnapshots();
+	});
+
+	it('falls back to the default CODEX_HOME when stored env is corrupted', async () => {
+		sampleCodexUsageMock.mockResolvedValue(makeSnapshot('/Users/test/.codex'));
+
+		await runCodexUsageSampling({
+			sessionsStore: makeStore({
+				sessions: [
+					{
+						id: 'codex-1',
+						toolType: 'codex',
+						cwd: '/tmp',
+						customEnvVars: { CODEX_HOME: { bad: true } },
+					},
+				],
+			}) as never,
+			agentConfigsStore: makeStore({ configs: {} }) as never,
+			agentDetector: makeDetector(FAKE_AGENT) as never,
+		});
+
+		expect(sampleCodexUsageMock).toHaveBeenCalledWith({ codexHome: '/Users/test/.codex' });
+		expect(getAllCodexUsageSnapshots()).toHaveProperty('/Users/test/.codex');
+	});
+
+	it('continues sampling other accounts when one account throws unexpectedly', async () => {
+		sampleCodexUsageMock.mockImplementation(async ({ codexHome }: { codexHome: string }) => {
+			if (codexHome === '/Users/test/.codex-broken') {
+				throw new Error('boom');
+			}
+			return makeSnapshot(codexHome);
+		});
+
+		await runCodexUsageSampling({
+			sessionsStore: makeStore({
+				sessions: [
+					{
+						id: 'codex-good',
+						toolType: 'codex',
+						cwd: '/tmp',
+						customEnvVars: { CODEX_HOME: '/Users/test/.codex-good' },
+					},
+					{
+						id: 'codex-broken',
+						toolType: 'codex',
+						cwd: '/tmp',
+						customEnvVars: { CODEX_HOME: '/Users/test/.codex-broken' },
+					},
+				],
+			}) as never,
+			agentConfigsStore: makeStore({ configs: {} }) as never,
+			agentDetector: makeDetector(FAKE_AGENT) as never,
+		});
+
+		const snapshots = getAllCodexUsageSnapshots();
+		expect(sampleCodexUsageMock).toHaveBeenCalledTimes(2);
+		expect(snapshots).toHaveProperty('/Users/test/.codex-good');
+		expect(snapshots).not.toHaveProperty('/Users/test/.codex-broken');
+		expect(loggerWarnMock).toHaveBeenCalledWith(
+			expect.stringContaining('Failed to sample Codex usage snapshot'),
+			expect.any(String),
+			expect.objectContaining({
+				codexHomeKey: '/Users/test/.codex-broken',
+				error: 'boom',
+			})
+		);
+	});
+});

--- a/src/__tests__/main/ipc/handlers/agents.test.ts
+++ b/src/__tests__/main/ipc/handlers/agents.test.ts
@@ -74,6 +74,9 @@ vi.mock('../../../../main/utils/execFile', () => ({
 // Mock fs
 vi.mock('fs', () => ({
 	existsSync: vi.fn(),
+	readdirSync: vi.fn(),
+	accessSync: vi.fn(),
+	constants: { R_OK: 4 },
 	promises: {
 		readdir: vi.fn(),
 		readFile: vi.fn(),
@@ -113,6 +116,8 @@ describe('agents IPC handlers', () => {
 	beforeEach(() => {
 		// Clear mocks
 		vi.clearAllMocks();
+		vi.mocked(fs.readdirSync).mockReturnValue([] as any);
+		vi.mocked(fs.accessSync).mockImplementation(() => undefined);
 
 		// Create mock agent detector
 		mockAgentDetector = {
@@ -178,7 +183,11 @@ describe('agents IPC handlers', () => {
 				'agents:reprobe',
 				'agents:getMaestroPDetectedPath',
 				'agents:getClaudeUsageSnapshots',
+				'agents:getClaudeUsageAccountKeys',
 				'claude:usage:refresh-all',
+				'agents:getCodexUsageSnapshots',
+				'agents:getCodexUsageAccountKeys',
+				'codex:usage:refresh-all',
 			];
 
 			for (const channel of expectedChannels) {

--- a/src/__tests__/main/preload/agents.test.ts
+++ b/src/__tests__/main/preload/agents.test.ts
@@ -400,4 +400,26 @@ describe('Agents Preload API', () => {
 			expect(result).toBeNull();
 		});
 	});
+
+	describe('usage quota APIs', () => {
+		it('should invoke agents:getClaudeUsageAccountKeys', async () => {
+			const keys = ['/Users/me/.claude-work'];
+			mockInvoke.mockResolvedValue(keys);
+
+			const result = await api.getClaudeUsageAccountKeys();
+
+			expect(mockInvoke).toHaveBeenCalledWith('agents:getClaudeUsageAccountKeys');
+			expect(result).toEqual(keys);
+		});
+
+		it('should invoke agents:getCodexUsageAccountKeys', async () => {
+			const keys = ['/Users/me/.codex-work'];
+			mockInvoke.mockResolvedValue(keys);
+
+			const result = await api.getCodexUsageAccountKeys();
+
+			expect(mockInvoke).toHaveBeenCalledWith('agents:getCodexUsageAccountKeys');
+			expect(result).toEqual(keys);
+		});
+	});
 });

--- a/src/__tests__/renderer/components/UsageDashboard/ClaudePlanUsage.test.tsx
+++ b/src/__tests__/renderer/components/UsageDashboard/ClaudePlanUsage.test.tsx
@@ -1,0 +1,324 @@
+/**
+ * Tests for ClaudePlanUsage
+ *
+ * Covers:
+ *   - empty state when no snapshots are cached
+ *   - multi-row rendering with the same account-short-name derivation as the badge
+ *     (incl. the `.claude` → `default` fallback)
+ *   - bars render with progressbar role + accessible percentage
+ *   - refresh button calls the IPC and triggers a store refresh
+ *   - in-flight `refreshing` flag disables the refresh button
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
+import { ClaudePlanUsage } from '../../../../renderer/components/UsageDashboard/ClaudePlanUsage';
+import { useClaudeUsageStore } from '../../../../renderer/stores/claudeUsageStore';
+import { useSessionStore } from '../../../../renderer/stores/sessionStore';
+import { THEMES } from '../../../../shared/themes';
+
+const theme = THEMES['dracula'];
+
+const refreshClaudeUsageSnapshotsMock = vi.fn();
+const getClaudeUsageSnapshotsMock = vi.fn();
+const getCustomEnvVarsMock = vi.fn();
+
+beforeEach(() => {
+	refreshClaudeUsageSnapshotsMock.mockReset().mockResolvedValue({ refreshed: 1 });
+	getClaudeUsageSnapshotsMock.mockReset().mockResolvedValue({});
+	getCustomEnvVarsMock.mockReset().mockResolvedValue({});
+
+	(global as any).window = (global as any).window ?? {};
+	(window as any).maestro = {
+		agents: {
+			getClaudeUsageSnapshots: getClaudeUsageSnapshotsMock,
+			refreshClaudeUsageSnapshots: refreshClaudeUsageSnapshotsMock,
+			getCustomEnvVars: getCustomEnvVarsMock,
+		},
+	};
+
+	useClaudeUsageStore.getState().__resetForTests();
+	useSessionStore.setState({ sessions: [] } as any);
+	cleanup();
+});
+
+function seedSnapshots(snapshots: Record<string, any>) {
+	useClaudeUsageStore.setState({ snapshots, loaded: true, refreshing: false } as any);
+}
+
+function seedSessions(configDirs: string[]) {
+	// Build minimal claude-code session records that carry the requested
+	// CLAUDE_CONFIG_DIR values via customEnvVars — that's all the dashboard
+	// needs to enumerate them as configured accounts.
+	const sessions = configDirs.map((dir, i) => ({
+		id: `sess-${i}`,
+		name: `sess-${i}`,
+		toolType: 'claude-code',
+		cwd: '/tmp',
+		customEnvVars: { CLAUDE_CONFIG_DIR: dir },
+	}));
+	useSessionStore.setState({ sessions } as any);
+}
+
+describe('ClaudePlanUsage — empty state', () => {
+	it('renders the empty message when no accounts are configured and no snapshots cached', () => {
+		render(<ClaudePlanUsage theme={theme} />);
+		expect(screen.getByTestId('claude-plan-empty')).toBeInTheDocument();
+		expect(screen.queryByTestId('claude-plan-row-default')).toBeNull();
+	});
+});
+
+describe('ClaudePlanUsage — configured account without snapshot', () => {
+	it('renders a "hit Refresh" CTA for a session-configured account that has no snapshot yet', () => {
+		// Session declares CLAUDE_CONFIG_DIR but the snapshot store is empty —
+		// the tab list should still surface the account, and the per-tab body
+		// should guide the user to hit Refresh instead of showing nothing.
+		seedSessions(['/Users/me/.claude-pending']);
+
+		render(<ClaudePlanUsage theme={theme} />);
+
+		expect(screen.getByTestId('claude-plan-row-pending-pending')).toBeInTheDocument();
+		expect(screen.queryAllByRole('progressbar')).toHaveLength(0);
+	});
+
+	it('mixes a configured-but-empty tab with an authenticated one', () => {
+		seedSnapshots({
+			'/Users/me/.claude': {
+				sampledAt: '2026-05-15T00:00:00.000Z',
+				configDirKey: '/Users/me/.claude',
+				authState: 'authenticated',
+				session: { percent: 50, resetsAt: '2026-05-15T05:00:00.000Z' },
+				weekAllModels: { percent: 30, resetsAt: '2026-05-22T00:00:00.000Z' },
+				weekSonnetOnly: { percent: 10, resetsAt: '2026-05-22T00:00:00.000Z' },
+			},
+		});
+		seedSessions(['/Users/me/.claude', '/Users/me/.claude-pending']);
+
+		render(<ClaudePlanUsage theme={theme} />);
+
+		// Both tabs render.
+		expect(screen.getByTestId('claude-plan-tab-default')).toBeInTheDocument();
+		expect(screen.getByTestId('claude-plan-tab-pending')).toBeInTheDocument();
+
+		// Switch to the pending tab — CTA visible, no bars.
+		fireEvent.click(screen.getByTestId('claude-plan-tab-pending'));
+		expect(screen.getByTestId('claude-plan-row-pending-pending')).toBeInTheDocument();
+		expect(screen.queryAllByRole('progressbar')).toHaveLength(0);
+	});
+});
+
+describe('ClaudePlanUsage — multi-account tabs', () => {
+	it('renders a tab per account but only one row at a time (selected tab)', () => {
+		seedSnapshots({
+			'/Users/me/.claude': {
+				sampledAt: '2026-05-15T00:00:00.000Z',
+				configDirKey: '/Users/me/.claude',
+				session: { percent: 50, resetsAt: '2026-05-15T05:00:00.000Z' },
+				weekAllModels: { percent: 30, resetsAt: '2026-05-22T00:00:00.000Z' },
+				weekSonnetOnly: { percent: 10, resetsAt: '2026-05-22T00:00:00.000Z' },
+			},
+			'/Users/me/.claude-gmail': {
+				sampledAt: '2026-05-15T00:00:00.000Z',
+				configDirKey: '/Users/me/.claude-gmail',
+				session: { percent: 97, resetsAt: '2026-05-15T05:00:00.000Z' },
+				weekAllModels: { percent: 80, resetsAt: '2026-05-22T00:00:00.000Z' },
+				weekSonnetOnly: { percent: 5, resetsAt: '2026-05-22T00:00:00.000Z' },
+			},
+		});
+
+		render(<ClaudePlanUsage theme={theme} />);
+
+		// Both account tabs render.
+		expect(screen.getByTestId('claude-plan-account-tabs')).toBeInTheDocument();
+		expect(screen.getByTestId('claude-plan-tab-default')).toBeInTheDocument();
+		expect(screen.getByTestId('claude-plan-tab-gmail')).toBeInTheDocument();
+
+		// Only the first tab's row is visible (entries sort by short name; "default" wins).
+		expect(screen.getByTestId('claude-plan-row-default')).toBeInTheDocument();
+		expect(screen.queryByTestId('claude-plan-row-gmail')).toBeNull();
+		expect(screen.getAllByRole('progressbar')).toHaveLength(3);
+	});
+
+	it('switches the visible row when a different tab is clicked', () => {
+		seedSnapshots({
+			'/Users/me/.claude': {
+				sampledAt: '2026-05-15T00:00:00.000Z',
+				configDirKey: '/Users/me/.claude',
+				session: { percent: 50, resetsAt: '2026-05-15T05:00:00.000Z' },
+				weekAllModels: { percent: 30, resetsAt: '2026-05-22T00:00:00.000Z' },
+				weekSonnetOnly: { percent: 10, resetsAt: '2026-05-22T00:00:00.000Z' },
+			},
+			'/Users/me/.claude-gmail': {
+				sampledAt: '2026-05-15T00:00:00.000Z',
+				configDirKey: '/Users/me/.claude-gmail',
+				session: { percent: 97, resetsAt: '2026-05-15T05:00:00.000Z' },
+				weekAllModels: { percent: 80, resetsAt: '2026-05-22T00:00:00.000Z' },
+				weekSonnetOnly: { percent: 5, resetsAt: '2026-05-22T00:00:00.000Z' },
+			},
+		});
+
+		render(<ClaudePlanUsage theme={theme} />);
+
+		fireEvent.click(screen.getByTestId('claude-plan-tab-gmail'));
+
+		expect(screen.queryByTestId('claude-plan-row-default')).toBeNull();
+		expect(screen.getByTestId('claude-plan-row-gmail')).toBeInTheDocument();
+	});
+
+	it('renders the tab bar even when only one account exists', () => {
+		// Tab bar stays visible for single-account configurations so the user
+		// always sees the account picker structure (they explicitly want to
+		// enumerate accounts even when there's just one today, in case they
+		// add more later).
+		seedSnapshots({
+			'/Users/me/.claude': {
+				sampledAt: '2026-05-15T00:00:00.000Z',
+				configDirKey: '/Users/me/.claude',
+				session: { percent: 50, resetsAt: '2026-05-15T05:00:00.000Z' },
+				weekAllModels: { percent: 30, resetsAt: '2026-05-22T00:00:00.000Z' },
+				weekSonnetOnly: { percent: 10, resetsAt: '2026-05-22T00:00:00.000Z' },
+			},
+		});
+
+		render(<ClaudePlanUsage theme={theme} />);
+
+		expect(screen.getByTestId('claude-plan-account-tabs')).toBeInTheDocument();
+		expect(screen.getByTestId('claude-plan-tab-default')).toBeInTheDocument();
+		expect(screen.getByTestId('claude-plan-row-default')).toBeInTheDocument();
+	});
+
+	it('exposes percent values via aria-valuenow on each bar', () => {
+		seedSnapshots({
+			'/Users/me/.claude-work': {
+				sampledAt: '2026-05-15T00:00:00.000Z',
+				configDirKey: '/Users/me/.claude-work',
+				session: { percent: 42, resetsAt: '2026-05-15T05:00:00.000Z' },
+				weekAllModels: { percent: 7, resetsAt: '2026-05-22T00:00:00.000Z' },
+				weekSonnetOnly: { percent: 99, resetsAt: '2026-05-22T00:00:00.000Z' },
+			},
+		});
+
+		render(<ClaudePlanUsage theme={theme} />);
+
+		const bars = screen.getAllByRole('progressbar');
+		const values = bars.map((b) => b.getAttribute('aria-valuenow'));
+		expect(values).toEqual(['42', '7', '99']);
+	});
+});
+
+describe('ClaudePlanUsage — unauthenticated row', () => {
+	it('renders the "run /login" CTA in place of bars when authState is unauthenticated', () => {
+		seedSnapshots({
+			'/Users/me/.claude-0din': {
+				sampledAt: '2026-05-15T00:00:00.000Z',
+				configDirKey: '/Users/me/.claude-0din',
+				authState: 'unauthenticated',
+				session: { percent: 0, resetsAt: '2026-05-15T00:00:00.000Z' },
+				weekAllModels: { percent: 0, resetsAt: '2026-05-15T00:00:00.000Z' },
+				weekSonnetOnly: { percent: 0, resetsAt: '2026-05-15T00:00:00.000Z' },
+			},
+		});
+
+		render(<ClaudePlanUsage theme={theme} />);
+
+		// CTA element rendered, bars suppressed.
+		expect(screen.getByTestId('claude-plan-row-0din-unauthenticated')).toBeInTheDocument();
+		expect(screen.queryAllByRole('progressbar')).toHaveLength(0);
+		expect(screen.getByText(/Not logged in/i)).toBeInTheDocument();
+		expect(screen.getByText(/\/login/i)).toBeInTheDocument();
+	});
+
+	it('renders the unauthenticated CTA when its tab is selected', () => {
+		seedSnapshots({
+			'/Users/me/.claude': {
+				sampledAt: '2026-05-15T00:00:00.000Z',
+				configDirKey: '/Users/me/.claude',
+				authState: 'authenticated',
+				session: { percent: 50, resetsAt: '2026-05-15T05:00:00.000Z' },
+				weekAllModels: { percent: 30, resetsAt: '2026-05-22T00:00:00.000Z' },
+				weekSonnetOnly: { percent: 10, resetsAt: '2026-05-22T00:00:00.000Z' },
+			},
+			'/Users/me/.claude-0din': {
+				sampledAt: '2026-05-15T00:00:00.000Z',
+				configDirKey: '/Users/me/.claude-0din',
+				authState: 'unauthenticated',
+				session: { percent: 0, resetsAt: '2026-05-15T00:00:00.000Z' },
+				weekAllModels: { percent: 0, resetsAt: '2026-05-15T00:00:00.000Z' },
+				weekSonnetOnly: { percent: 0, resetsAt: '2026-05-15T00:00:00.000Z' },
+			},
+		});
+
+		render(<ClaudePlanUsage theme={theme} />);
+
+		// Both tabs render. Entries sort by deriveAccountShortName; "0din" (digit '0',
+		// charcode 48) sorts before "default" (letter 'd'), so the unauthenticated
+		// tab is the initial selection.
+		expect(screen.getByTestId('claude-plan-tab-default')).toBeInTheDocument();
+		expect(screen.getByTestId('claude-plan-tab-0din')).toBeInTheDocument();
+		expect(screen.getByTestId('claude-plan-row-0din-unauthenticated')).toBeInTheDocument();
+		expect(screen.queryAllByRole('progressbar')).toHaveLength(0);
+
+		// Switch to the authenticated tab — CTA disappears, three bars appear.
+		fireEvent.click(screen.getByTestId('claude-plan-tab-default'));
+		expect(screen.queryByTestId('claude-plan-row-0din-unauthenticated')).toBeNull();
+		expect(screen.getAllByRole('progressbar')).toHaveLength(3);
+	});
+
+	it('treats missing authState as authenticated for back-compat', () => {
+		// Snapshots persisted before authState existed must continue to
+		// render as bars, not as the unauthenticated CTA.
+		seedSnapshots({
+			'/Users/me/.claude': {
+				sampledAt: '2026-05-15T00:00:00.000Z',
+				configDirKey: '/Users/me/.claude',
+				session: { percent: 22, resetsAt: '2026-05-15T05:00:00.000Z' },
+				weekAllModels: { percent: 8, resetsAt: '2026-05-22T00:00:00.000Z' },
+				weekSonnetOnly: { percent: 1, resetsAt: '2026-05-22T00:00:00.000Z' },
+			},
+		});
+
+		render(<ClaudePlanUsage theme={theme} />);
+
+		expect(screen.getAllByRole('progressbar')).toHaveLength(3);
+		expect(screen.queryByTestId('claude-plan-row-default-unauthenticated')).toBeNull();
+	});
+});
+
+describe('ClaudePlanUsage — refresh wiring', () => {
+	it('calls the refresh IPC and re-pulls the store on click', async () => {
+		getClaudeUsageSnapshotsMock.mockResolvedValue({
+			'/Users/me/.claude': {
+				sampledAt: '2026-05-15T01:00:00.000Z',
+				configDirKey: '/Users/me/.claude',
+				session: { percent: 11, resetsAt: '2026-05-15T05:00:00.000Z' },
+				weekAllModels: { percent: 2, resetsAt: '2026-05-22T00:00:00.000Z' },
+				weekSonnetOnly: { percent: 1, resetsAt: '2026-05-22T00:00:00.000Z' },
+			},
+		});
+
+		render(<ClaudePlanUsage theme={theme} />);
+		fireEvent.click(screen.getByTestId('claude-plan-refresh'));
+
+		await waitFor(() => {
+			expect(refreshClaudeUsageSnapshotsMock).toHaveBeenCalledTimes(1);
+			expect(getClaudeUsageSnapshotsMock).toHaveBeenCalledTimes(1);
+		});
+
+		await waitFor(() => {
+			expect(screen.getByTestId('claude-plan-row-default')).toBeInTheDocument();
+		});
+	});
+
+	it('disables the refresh button while a refresh is in flight', () => {
+		useClaudeUsageStore.setState({
+			snapshots: {},
+			loaded: true,
+			refreshing: true,
+		} as any);
+
+		render(<ClaudePlanUsage theme={theme} />);
+		const button = screen.getByTestId('claude-plan-refresh') as HTMLButtonElement;
+		expect(button.disabled).toBe(true);
+		expect(button.textContent).toContain('Sampling');
+	});
+});

--- a/src/__tests__/renderer/components/UsageDashboard/CodexPlanUsage.test.tsx
+++ b/src/__tests__/renderer/components/UsageDashboard/CodexPlanUsage.test.tsx
@@ -1,0 +1,253 @@
+/**
+ * Tests for CodexPlanUsage
+ *
+ * Mirrors the ClaudePlanUsage coverage for the Codex quota widget:
+ *   - empty state when no Codex accounts are configured
+ *   - configured CODEX_HOME accounts with no cached snapshot
+ *   - multi-account tab selection
+ *   - accessible quota progress bars
+ *   - non-authenticated/error rows
+ *   - refresh IPC wiring
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
+import { CodexPlanUsage } from '../../../../renderer/components/UsageDashboard/CodexPlanUsage';
+import { useCodexUsageStore } from '../../../../renderer/stores/codexUsageStore';
+import { useSessionStore } from '../../../../renderer/stores/sessionStore';
+import { THEMES } from '../../../../shared/themes';
+
+const theme = THEMES['dracula'];
+
+const refreshCodexUsageSnapshotsMock = vi.fn();
+const getCodexUsageSnapshotsMock = vi.fn();
+const getCustomEnvVarsMock = vi.fn();
+
+beforeEach(() => {
+	refreshCodexUsageSnapshotsMock.mockReset().mockResolvedValue({ refreshed: 1 });
+	getCodexUsageSnapshotsMock.mockReset().mockResolvedValue({});
+	getCustomEnvVarsMock.mockReset().mockResolvedValue({});
+
+	(global as any).window = (global as any).window ?? {};
+	(window as any).maestro = {
+		agents: {
+			getCodexUsageSnapshots: getCodexUsageSnapshotsMock,
+			refreshCodexUsageSnapshots: refreshCodexUsageSnapshotsMock,
+			getCustomEnvVars: getCustomEnvVarsMock,
+		},
+	};
+
+	useCodexUsageStore.getState().__resetForTests();
+	useSessionStore.setState({ sessions: [] } as any);
+	cleanup();
+});
+
+function seedSnapshots(snapshots: Record<string, any>) {
+	useCodexUsageStore.setState({ snapshots, loaded: true, refreshing: false } as any);
+}
+
+function seedSessions(codexHomes: string[]) {
+	const sessions = codexHomes.map((dir, i) => ({
+		id: `sess-${i}`,
+		name: `sess-${i}`,
+		toolType: 'codex',
+		cwd: '/tmp',
+		customEnvVars: { CODEX_HOME: dir },
+	}));
+	useSessionStore.setState({ sessions } as any);
+}
+
+describe('CodexPlanUsage — empty state', () => {
+	it('renders the empty message when no Codex accounts are configured and no snapshots are cached', () => {
+		render(<CodexPlanUsage theme={theme} />);
+
+		expect(screen.getByTestId('codex-plan-empty')).toBeInTheDocument();
+		expect(screen.queryByTestId('codex-plan-row-default')).toBeNull();
+	});
+});
+
+describe('CodexPlanUsage — configured account without snapshot', () => {
+	it('renders a "hit Refresh" CTA for a session-configured account with no snapshot yet', () => {
+		seedSessions(['/Users/me/.codex-pending']);
+
+		render(<CodexPlanUsage theme={theme} />);
+
+		expect(screen.getByTestId('codex-plan-row-pending-pending')).toBeInTheDocument();
+		expect(screen.queryAllByRole('progressbar')).toHaveLength(0);
+	});
+
+	it('mixes a configured-but-empty tab with an authenticated one', () => {
+		seedSnapshots({
+			'/Users/me/.codex': {
+				sampledAt: '2026-05-15T00:00:00.000Z',
+				codexHomeKey: '/Users/me/.codex',
+				authState: 'authenticated',
+				session: { percent: 50, resetsAt: '2026-05-15T05:00:00.000Z' },
+				weekly: { percent: 30, resetsAt: '2026-05-22T00:00:00.000Z' },
+			},
+		});
+		seedSessions(['/Users/me/.codex', '/Users/me/.codex-pending']);
+
+		render(<CodexPlanUsage theme={theme} />);
+
+		expect(screen.getByTestId('codex-plan-tab-default')).toBeInTheDocument();
+		expect(screen.getByTestId('codex-plan-tab-pending')).toBeInTheDocument();
+
+		fireEvent.click(screen.getByTestId('codex-plan-tab-pending'));
+		expect(screen.getByTestId('codex-plan-row-pending-pending')).toBeInTheDocument();
+		expect(screen.queryAllByRole('progressbar')).toHaveLength(0);
+	});
+});
+
+describe('CodexPlanUsage — multi-account tabs', () => {
+	it('renders a tab per account but only one selected row at a time', () => {
+		seedSnapshots({
+			'/Users/me/.codex': {
+				sampledAt: '2026-05-15T00:00:00.000Z',
+				codexHomeKey: '/Users/me/.codex',
+				authState: 'authenticated',
+				session: { percent: 50, resetsAt: '2026-05-15T05:00:00.000Z' },
+				weekly: { percent: 30, resetsAt: '2026-05-22T00:00:00.000Z' },
+			},
+			'/Users/me/.codex-work': {
+				sampledAt: '2026-05-15T00:00:00.000Z',
+				codexHomeKey: '/Users/me/.codex-work',
+				authState: 'authenticated',
+				session: { percent: 97, resetsAt: '2026-05-15T05:00:00.000Z' },
+				weekly: { percent: 80, resetsAt: '2026-05-22T00:00:00.000Z' },
+			},
+		});
+
+		render(<CodexPlanUsage theme={theme} />);
+
+		expect(screen.getByTestId('codex-plan-account-tabs')).toBeInTheDocument();
+		expect(screen.getByTestId('codex-plan-tab-default')).toBeInTheDocument();
+		expect(screen.getByTestId('codex-plan-tab-work')).toBeInTheDocument();
+
+		expect(screen.getByTestId('codex-plan-row-default')).toBeInTheDocument();
+		expect(screen.queryByTestId('codex-plan-row-work')).toBeNull();
+		expect(screen.getAllByRole('progressbar')).toHaveLength(2);
+	});
+
+	it('switches the visible row when another Codex account tab is clicked', () => {
+		seedSnapshots({
+			'/Users/me/.codex': {
+				sampledAt: '2026-05-15T00:00:00.000Z',
+				codexHomeKey: '/Users/me/.codex',
+				authState: 'authenticated',
+				session: { percent: 50, resetsAt: '2026-05-15T05:00:00.000Z' },
+				weekly: { percent: 30, resetsAt: '2026-05-22T00:00:00.000Z' },
+			},
+			'/Users/me/.codex-work': {
+				sampledAt: '2026-05-15T00:00:00.000Z',
+				codexHomeKey: '/Users/me/.codex-work',
+				authState: 'authenticated',
+				session: { percent: 97, resetsAt: '2026-05-15T05:00:00.000Z' },
+				weekly: { percent: 80, resetsAt: '2026-05-22T00:00:00.000Z' },
+			},
+		});
+
+		render(<CodexPlanUsage theme={theme} />);
+
+		fireEvent.click(screen.getByTestId('codex-plan-tab-work'));
+
+		expect(screen.queryByTestId('codex-plan-row-default')).toBeNull();
+		expect(screen.getByTestId('codex-plan-row-work')).toBeInTheDocument();
+	});
+
+	it('exposes percentage values via aria-valuenow on each quota bar', () => {
+		seedSnapshots({
+			'/Users/me/.codex-work': {
+				sampledAt: '2026-05-15T00:00:00.000Z',
+				codexHomeKey: '/Users/me/.codex-work',
+				authState: 'authenticated',
+				session: { percent: 42, resetsAt: '2026-05-15T05:00:00.000Z' },
+				weekly: { percent: 7, resetsAt: '2026-05-22T00:00:00.000Z' },
+				additionalLimits: [{ name: 'gpt-5.5', percent: 99, resetsAt: '2026-05-16T00:00:00.000Z' }],
+			},
+		});
+
+		render(<CodexPlanUsage theme={theme} />);
+
+		const values = screen
+			.getAllByRole('progressbar')
+			.map((bar) => bar.getAttribute('aria-valuenow'));
+		expect(values).toEqual(['42', '7', '99']);
+	});
+});
+
+describe('CodexPlanUsage — non-authenticated row', () => {
+	it('renders an auth warning in place of bars when authState is unauthenticated', () => {
+		seedSnapshots({
+			'/Users/me/.codex-0din': {
+				sampledAt: '2026-05-15T00:00:00.000Z',
+				codexHomeKey: '/Users/me/.codex-0din',
+				authState: 'unauthenticated',
+				error: 'Codex auth token was rejected. Run `codex login` for this CODEX_HOME.',
+			},
+		});
+
+		render(<CodexPlanUsage theme={theme} />);
+
+		expect(screen.getByTestId('codex-plan-row-0din-unauthenticated')).toBeInTheDocument();
+		expect(screen.queryAllByRole('progressbar')).toHaveLength(0);
+		expect(screen.getByText(/codex login/i)).toBeInTheDocument();
+	});
+
+	it('renders an error row in place of bars when sampling fails', () => {
+		seedSnapshots({
+			'/Users/me/.codex-work': {
+				sampledAt: '2026-05-15T00:00:00.000Z',
+				codexHomeKey: '/Users/me/.codex-work',
+				authState: 'error',
+				error: 'Codex quota endpoint returned HTTP 500.',
+			},
+		});
+
+		render(<CodexPlanUsage theme={theme} />);
+
+		expect(screen.getByTestId('codex-plan-row-work-error')).toBeInTheDocument();
+		expect(screen.queryAllByRole('progressbar')).toHaveLength(0);
+		expect(screen.getByText(/HTTP 500/i)).toBeInTheDocument();
+	});
+});
+
+describe('CodexPlanUsage — refresh wiring', () => {
+	it('calls the refresh IPC and re-pulls sanitized snapshots on click', async () => {
+		getCodexUsageSnapshotsMock.mockResolvedValue({
+			'/Users/me/.codex': {
+				sampledAt: '2026-05-15T01:00:00.000Z',
+				codexHomeKey: '/Users/me/.codex',
+				authState: 'authenticated',
+				session: { percent: 11, resetsAt: '2026-05-15T05:00:00.000Z' },
+				weekly: { percent: 2, resetsAt: '2026-05-22T00:00:00.000Z' },
+			},
+		});
+
+		render(<CodexPlanUsage theme={theme} />);
+		fireEvent.click(screen.getByTestId('codex-plan-refresh'));
+
+		await waitFor(() => {
+			expect(refreshCodexUsageSnapshotsMock).toHaveBeenCalledTimes(1);
+			expect(getCodexUsageSnapshotsMock).toHaveBeenCalledTimes(1);
+		});
+
+		await waitFor(() => {
+			expect(screen.getByTestId('codex-plan-row-default')).toBeInTheDocument();
+		});
+	});
+
+	it('disables the refresh button while a refresh is already in flight', () => {
+		useCodexUsageStore.setState({
+			snapshots: {},
+			loaded: true,
+			refreshing: true,
+		} as any);
+
+		render(<CodexPlanUsage theme={theme} />);
+		const button = screen.getByTestId('codex-plan-refresh') as HTMLButtonElement;
+
+		expect(button.disabled).toBe(true);
+		expect(button.textContent).toContain('Sampling');
+	});
+});

--- a/src/__tests__/renderer/components/UsageDashboard/UsageDashboardModal.test.tsx
+++ b/src/__tests__/renderer/components/UsageDashboard/UsageDashboardModal.test.tsx
@@ -15,6 +15,8 @@ import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
 import '@testing-library/jest-dom';
 import { UsageDashboardModal } from '../../../../renderer/components/UsageDashboard/UsageDashboardModal';
 import { useSettingsStore } from '../../../../renderer/stores/settingsStore';
+import { useClaudeUsageStore } from '../../../../renderer/stores/claudeUsageStore';
+import { useCodexUsageStore } from '../../../../renderer/stores/codexUsageStore';
 import { mockTheme } from '../../../helpers/mockTheme';
 import type { StatsAggregation } from '../../../../shared/stats-types';
 
@@ -40,6 +42,14 @@ vi.mock('../../../../renderer/components/UsageDashboard/CueStats', () => ({
 			CueStats stub
 		</div>
 	),
+}));
+
+vi.mock('../../../../renderer/components/UsageDashboard/ClaudePlanUsage', () => ({
+	ClaudePlanUsage: () => <div data-testid="anthropic-usage-mock">Anthropic Usage stub</div>,
+}));
+
+vi.mock('../../../../renderer/components/UsageDashboard/CodexPlanUsage', () => ({
+	CodexPlanUsage: () => <div data-testid="codex-usage-mock">Codex Usage stub</div>,
 }));
 
 // Populated aggregation so the dashboard renders the tab panel (the empty
@@ -106,6 +116,24 @@ const populatedAggregation: StatsAggregation = {
 	bySessionSource: {},
 };
 
+const emptyAggregation: StatsAggregation = {
+	totalQueries: 0,
+	totalDuration: 0,
+	avgDuration: 0,
+	byAgent: {},
+	bySource: { user: 0, auto: 0 },
+	byLocation: { local: 0, remote: 0 },
+	byDay: [],
+	byHour: [],
+	totalSessions: 0,
+	sessionsByAgent: {},
+	sessionsByDay: [],
+	avgSessionDuration: 0,
+	byAgentByDay: {},
+	bySessionByDay: {},
+	bySessionSource: {},
+};
+
 const mockStats = {
 	getAggregation: vi.fn(),
 	getDatabaseSize: vi.fn(),
@@ -115,6 +143,12 @@ const mockStats = {
 
 const mockDialog = { saveFile: vi.fn() };
 const mockFs = { writeFile: vi.fn() };
+const mockAgents = {
+	getClaudeUsageSnapshots: vi.fn(),
+	getCodexUsageSnapshots: vi.fn(),
+	refreshClaudeUsageSnapshots: vi.fn(),
+	refreshCodexUsageSnapshots: vi.fn(),
+};
 
 function setEncoreFlags({ maestroCue, usageStats }: { maestroCue: boolean; usageStats: boolean }) {
 	useSettingsStore.setState({
@@ -127,12 +161,52 @@ function setEncoreFlags({ maestroCue, usageStats }: { maestroCue: boolean; usage
 	});
 }
 
+function seedAnthropicUsageSnapshots() {
+	useClaudeUsageStore.setState({
+		loaded: true,
+		refreshing: false,
+		snapshots: {
+			'/Users/me/.claude-work': {
+				sampledAt: '2026-05-23T00:00:00.000Z',
+				configDirKey: '/Users/me/.claude-work',
+				authState: 'authenticated',
+				session: { percent: 20, resetsAt: '2026-05-23T05:00:00.000Z' },
+				weekAllModels: { percent: 40, resetsAt: '2026-05-30T00:00:00.000Z' },
+				weekSonnetOnly: { percent: 10, resetsAt: '2026-05-30T00:00:00.000Z' },
+			},
+		},
+	} as any);
+}
+
+function seedCodexUsageSnapshots() {
+	useCodexUsageStore.setState({
+		loaded: true,
+		refreshing: false,
+		snapshots: {
+			'/Users/me/.codex-work': {
+				sampledAt: '2026-05-23T00:00:00.000Z',
+				codexHomeKey: '/Users/me/.codex-work',
+				authState: 'authenticated',
+				session: { percent: 15, resetsAt: '2026-05-23T05:00:00.000Z' },
+				weekly: { percent: 33, resetsAt: '2026-05-30T00:00:00.000Z' },
+			},
+		},
+	} as any);
+}
+
 beforeEach(() => {
 	vi.clearAllMocks();
+	useClaudeUsageStore.getState().__resetForTests();
+	useCodexUsageStore.getState().__resetForTests();
+	mockAgents.getClaudeUsageSnapshots.mockResolvedValue({});
+	mockAgents.getCodexUsageSnapshots.mockResolvedValue({});
+	mockAgents.refreshClaudeUsageSnapshots.mockResolvedValue({ refreshed: 1 });
+	mockAgents.refreshCodexUsageSnapshots.mockResolvedValue({ refreshed: 1 });
 	(window as unknown as { maestro: Record<string, unknown> }).maestro = {
 		stats: mockStats,
 		dialog: mockDialog,
 		fs: mockFs,
+		agents: mockAgents,
 		// Minimum surface needed by `useGlobalAgentStats` (called from the
 		// dashboard's Achievement share image flow).
 		agentSessions: {
@@ -175,11 +249,14 @@ describe('UsageDashboardModal — Cue tab gating', () => {
 		});
 
 		expect(screen.queryByRole('tab', { name: 'Cue' })).not.toBeInTheDocument();
-		// Confirm the four base tabs are still wired up.
+		// Confirm the base tabs are still wired up.
 		expect(screen.getByRole('tab', { name: 'Overview' })).toBeInTheDocument();
+		expect(screen.getByRole('tab', { name: 'Agent Overview' })).toBeInTheDocument();
 		expect(screen.getByRole('tab', { name: 'Agents' })).toBeInTheDocument();
 		expect(screen.getByRole('tab', { name: 'Activity' })).toBeInTheDocument();
 		expect(screen.getByRole('tab', { name: 'Auto Run' })).toBeInTheDocument();
+		expect(screen.getByRole('tab', { name: 'Shortcuts' })).toBeInTheDocument();
+		expect(screen.queryByRole('tab', { name: 'Token Quota Cockpit' })).not.toBeInTheDocument();
 	});
 
 	it('renders <CueStats> when the Cue tab is selected', async () => {
@@ -212,5 +289,110 @@ describe('UsageDashboardModal — Cue tab gating', () => {
 		// Default time range is 'week' and we passed colorBlindMode=true through.
 		expect(stub).toHaveAttribute('data-time-range', 'week');
 		expect(stub).toHaveAttribute('data-colorblind', 'true');
+	});
+});
+
+describe('UsageDashboardModal — provider quota tabs', () => {
+	it('shows Anthropic Usage and Codex Usage only when useful provider snapshots exist', async () => {
+		setEncoreFlags({ maestroCue: true, usageStats: true });
+		seedAnthropicUsageSnapshots();
+		seedCodexUsageSnapshots();
+
+		render(<UsageDashboardModal isOpen={true} onClose={() => {}} theme={mockTheme} />);
+
+		await waitFor(() => {
+			expect(screen.getByTestId('usage-dashboard-content')).toBeInTheDocument();
+		});
+
+		expect(screen.queryByRole('tab', { name: 'Token Quota Cockpit' })).not.toBeInTheDocument();
+		expect(screen.getByRole('tab', { name: 'Anthropic Usage' })).toBeInTheDocument();
+		expect(screen.getByRole('tab', { name: 'Codex Usage' })).toBeInTheDocument();
+
+		await act(async () => {
+			fireEvent.click(screen.getByRole('tab', { name: 'Anthropic Usage' }));
+		});
+
+		await waitFor(() => {
+			expect(screen.getByTestId('anthropic-usage-mock')).toBeInTheDocument();
+		});
+
+		await act(async () => {
+			fireEvent.click(screen.getByRole('tab', { name: 'Codex Usage' }));
+		});
+
+		expect(screen.getByTestId('codex-usage-mock')).toBeInTheDocument();
+		expect(mockAgents.refreshClaudeUsageSnapshots).not.toHaveBeenCalled();
+		expect(mockAgents.refreshCodexUsageSnapshots).not.toHaveBeenCalled();
+	});
+
+	it('hides provider quota tabs when usageStats is disabled even if snapshots exist', async () => {
+		setEncoreFlags({ maestroCue: false, usageStats: false });
+		seedAnthropicUsageSnapshots();
+		seedCodexUsageSnapshots();
+
+		render(<UsageDashboardModal isOpen={true} onClose={() => {}} theme={mockTheme} />);
+
+		await waitFor(() => {
+			expect(screen.getByTestId('usage-dashboard-content')).toBeInTheDocument();
+		});
+
+		expect(screen.queryByRole('tab', { name: 'Anthropic Usage' })).not.toBeInTheDocument();
+		expect(screen.queryByRole('tab', { name: 'Codex Usage' })).not.toBeInTheDocument();
+	});
+
+	it('hides provider quota tabs when snapshots contain no useful quota details', async () => {
+		setEncoreFlags({ maestroCue: false, usageStats: true });
+		useClaudeUsageStore.setState({
+			loaded: true,
+			refreshing: false,
+			snapshots: {
+				'/Users/me/.claude-work': {
+					sampledAt: '2026-05-23T00:00:00.000Z',
+					configDirKey: '/Users/me/.claude-work',
+					authState: 'unauthenticated',
+					session: { percent: 0, resetsAt: '2026-05-23T05:00:00.000Z' },
+					weekAllModels: { percent: 0, resetsAt: '2026-05-30T00:00:00.000Z' },
+					weekSonnetOnly: { percent: 0, resetsAt: '2026-05-30T00:00:00.000Z' },
+				},
+			},
+		} as any);
+		useCodexUsageStore.setState({
+			loaded: true,
+			refreshing: false,
+			snapshots: {
+				'/Users/me/.codex-work': {
+					sampledAt: '2026-05-23T00:00:00.000Z',
+					codexHomeKey: '/Users/me/.codex-work',
+					authState: 'error',
+					error: 'Endpoint unavailable',
+				},
+			},
+		} as any);
+
+		render(<UsageDashboardModal isOpen={true} onClose={() => {}} theme={mockTheme} />);
+
+		await waitFor(() => {
+			expect(screen.getByTestId('usage-dashboard-content')).toBeInTheDocument();
+		});
+
+		expect(screen.queryByRole('tab', { name: 'Anthropic Usage' })).not.toBeInTheDocument();
+		expect(screen.queryByRole('tab', { name: 'Codex Usage' })).not.toBeInTheDocument();
+	});
+
+	it('bypasses the AI-query empty state because provider quota snapshots do not come from stats.db', async () => {
+		setEncoreFlags({ maestroCue: false, usageStats: true });
+		seedCodexUsageSnapshots();
+		mockStats.getAggregation.mockResolvedValueOnce(emptyAggregation);
+
+		render(<UsageDashboardModal isOpen={true} onClose={() => {}} theme={mockTheme} />);
+
+		await act(async () => {
+			fireEvent.click(screen.getByRole('tab', { name: 'Codex Usage' }));
+		});
+
+		await waitFor(() => {
+			expect(screen.getByTestId('codex-usage-mock')).toBeInTheDocument();
+		});
+		expect(screen.queryByText(/No usage data yet/i)).not.toBeInTheDocument();
 	});
 });

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -338,7 +338,11 @@ const mockMaestro = {
 		}),
 		getMaestroPDetectedPath: vi.fn().mockResolvedValue(null),
 		getClaudeUsageSnapshots: vi.fn().mockResolvedValue({}),
+		getClaudeUsageAccountKeys: vi.fn().mockResolvedValue([]),
+		getCodexUsageSnapshots: vi.fn().mockResolvedValue({}),
+		getCodexUsageAccountKeys: vi.fn().mockResolvedValue([]),
 		refreshClaudeUsageSnapshots: vi.fn().mockResolvedValue({ refreshed: 0 }),
+		refreshCodexUsageSnapshots: vi.fn().mockResolvedValue({ refreshed: 0 }),
 	},
 	fonts: {
 		detect: vi.fn().mockResolvedValue([]),

--- a/src/main/agents/claude-usage-startup.ts
+++ b/src/main/agents/claude-usage-startup.ts
@@ -10,7 +10,7 @@
  * lazily when an `auto`-mode tab actually needs the data.
  *
  * Why "per CLAUDE_CONFIG_DIR account":
- *   The Max-plan quota is bucketed per Anthropic account, and Maestro users
+ *   The Claude plan quota is bucketed per Anthropic account, and Maestro users
  *   commonly switch accounts via `CLAUDE_CONFIG_DIR=/Users/foo/.claude-gmail`
  *   vs `.claude-smash`. Each canonical path is its own snapshot key. We
  *   resolve the effective env per session (agent-level customEnvVars merged
@@ -35,7 +35,8 @@
  *     `extraResources` in `package.json` for mac/win/linux).
  */
 
-import fs from 'fs';
+import * as fs from 'fs';
+import os from 'os';
 import path from 'path';
 import Store from 'electron-store';
 
@@ -87,6 +88,49 @@ interface SamplingTarget {
 	configDirKey: string;
 	cwd: string;
 	customEnvVars: Record<string, string>;
+}
+
+const ACCOUNT_DIR_EXCLUDE_RE =
+	/(^|[-_.])(backup|bak|old|archive|archived|stage|local|server)([-_.]|$)/i;
+
+function isLikelyClaudeAccountDirName(name: string): boolean {
+	return name === '.claude' || name.startsWith('.claude-');
+}
+
+/**
+ * Discover local Claude Code account directories, mirroring the common
+ * `/token-cockpit` setup where each account lives in a separate
+ * `~/.claude-*` directory. Backups and local/server scratch dirs are skipped
+ * so the dashboard lists active accounts, not migration leftovers.
+ */
+export function discoverClaudeConfigDirs(homeDir = os.homedir()): string[] {
+	let entries: fs.Dirent[];
+	try {
+		entries = fs.readdirSync(homeDir, { withFileTypes: true });
+	} catch (err) {
+		logger.warn('Failed to discover Claude config dirs', LOG_CONTEXT, {
+			homeDir,
+			error: err instanceof Error ? err.message : String(err),
+		});
+		return [];
+	}
+
+	const dirs: string[] = [];
+	for (const entry of entries) {
+		if (!entry.isDirectory()) continue;
+		if (!isLikelyClaudeAccountDirName(entry.name)) continue;
+		if (ACCOUNT_DIR_EXCLUDE_RE.test(entry.name)) continue;
+
+		const dir = path.join(homeDir, entry.name);
+		try {
+			fs.accessSync(path.join(dir, '.claude.json'), fs.constants.R_OK);
+		} catch {
+			continue;
+		}
+		dirs.push(dir);
+	}
+
+	return dirs.sort((a, b) => a.localeCompare(b));
 }
 
 /**
@@ -298,6 +342,19 @@ export async function runStartupUsageSampling(deps: StartupUsageSamplingDeps): P
 		if (!target) continue;
 		if (!targetsByKey.has(target.configDirKey)) {
 			targetsByKey.set(target.configDirKey, target);
+		}
+	}
+
+	if (mode === 'manual') {
+		for (const configDir of discoverClaudeConfigDirs()) {
+			const configDirKey = resolveConfigDirKey({ CLAUDE_CONFIG_DIR: configDir });
+			if (targetsByKey.has(configDirKey)) continue;
+			targetsByKey.set(configDirKey, {
+				configDir,
+				configDirKey,
+				cwd: os.homedir(),
+				customEnvVars: { ...agentLevelEnvVars, CLAUDE_CONFIG_DIR: configDir },
+			});
 		}
 	}
 

--- a/src/main/agents/claude-usage-startup.ts
+++ b/src/main/agents/claude-usage-startup.ts
@@ -103,10 +103,10 @@ function isLikelyClaudeAccountDirName(name: string): boolean {
  * `~/.claude-*` directory. Backups and local/server scratch dirs are skipped
  * so the dashboard lists active accounts, not migration leftovers.
  */
-export function discoverClaudeConfigDirs(homeDir = os.homedir()): string[] {
+export async function discoverClaudeConfigDirs(homeDir = os.homedir()): Promise<string[]> {
 	let entries: fs.Dirent[];
 	try {
-		entries = fs.readdirSync(homeDir, { withFileTypes: true });
+		entries = await fs.promises.readdir(homeDir, { withFileTypes: true });
 	} catch (err) {
 		logger.warn('Failed to discover Claude config dirs', LOG_CONTEXT, {
 			homeDir,
@@ -123,7 +123,7 @@ export function discoverClaudeConfigDirs(homeDir = os.homedir()): string[] {
 
 		const dir = path.join(homeDir, entry.name);
 		try {
-			fs.accessSync(path.join(dir, '.claude.json'), fs.constants.R_OK);
+			await fs.promises.access(path.join(dir, '.claude.json'), fs.constants.R_OK);
 		} catch {
 			continue;
 		}
@@ -346,7 +346,7 @@ export async function runStartupUsageSampling(deps: StartupUsageSamplingDeps): P
 	}
 
 	if (mode === 'manual') {
-		for (const configDir of discoverClaudeConfigDirs()) {
+		for (const configDir of await discoverClaudeConfigDirs()) {
 			const configDirKey = resolveConfigDirKey({ CLAUDE_CONFIG_DIR: configDir });
 			if (targetsByKey.has(configDirKey)) continue;
 			targetsByKey.set(configDirKey, {

--- a/src/main/agents/codex-usage-sampler.ts
+++ b/src/main/agents/codex-usage-sampler.ts
@@ -160,7 +160,9 @@ export async function sampleCodexUsage(opts: SampleCodexUsageOptions): Promise<C
 
 function parseWindow(window: WhamUsageWindow | undefined): CodexUsageSnapshot['session'] | null {
 	if (!window) return null;
-	if (typeof window.used_percent !== 'number') return null;
+	if (typeof window.used_percent !== 'number' || !Number.isFinite(window.used_percent)) {
+		return null;
+	}
 	const resetsAt = parseResetAt(window.reset_at);
 	if (!resetsAt) return null;
 	return {

--- a/src/main/agents/codex-usage-sampler.ts
+++ b/src/main/agents/codex-usage-sampler.ts
@@ -1,0 +1,222 @@
+/**
+ * Codex Usage Sampler
+ *
+ * Reads Codex CLI OAuth metadata from CODEX_HOME/auth.json and asks the
+ * ChatGPT quota metadata endpoint for the account's active rate-limit windows.
+ * This is intentionally isolated from the renderer so auth tokens never leave
+ * the main process.
+ */
+
+import fs from 'fs/promises';
+import path from 'path';
+
+import type { CodexUsageSnapshot } from '../stores/codexUsageStore';
+import { resolveCodexHomeKey } from '../stores/codexUsageStore';
+import { captureMessage } from '../utils/sentry';
+
+const CODEX_USAGE_ENDPOINT = 'https://chatgpt.com/backend-api/wham/usage';
+const DEFAULT_TIMEOUT_MS = 15_000;
+
+export interface SampleCodexUsageOptions {
+	codexHome: string;
+	timeoutMs?: number;
+}
+
+interface CodexAuthFile {
+	tokens?: {
+		access_token?: string;
+		account_id?: string;
+		id_token?: string;
+	};
+}
+
+interface WhamUsageWindow {
+	used_percent?: unknown;
+	reset_at?: unknown;
+}
+
+interface WhamUsageResponse {
+	email?: unknown;
+	plan_type?: unknown;
+	rate_limit?: {
+		limit_reached?: unknown;
+		primary_window?: WhamUsageWindow;
+		secondary_window?: WhamUsageWindow;
+	};
+	additional_rate_limits?: Array<{
+		limit_name?: unknown;
+		metered_feature?: unknown;
+		rate_limit?: {
+			primary_window?: WhamUsageWindow;
+		};
+	}>;
+}
+
+export async function sampleCodexUsage(opts: SampleCodexUsageOptions): Promise<CodexUsageSnapshot> {
+	const codexHomeKey = resolveCodexHomeKey({ CODEX_HOME: opts.codexHome });
+	const sampledAt = new Date().toISOString();
+	const authPath = path.join(codexHomeKey, 'auth.json');
+
+	let auth: CodexAuthFile;
+	try {
+		auth = JSON.parse(await fs.readFile(authPath, 'utf8')) as CodexAuthFile;
+	} catch (err) {
+		return {
+			sampledAt,
+			codexHomeKey,
+			authState: 'missing_auth',
+			error:
+				err && typeof err === 'object' && 'code' in err && err.code === 'ENOENT'
+					? `No auth.json at ${authPath}`
+					: 'Failed to read Codex auth.json',
+		};
+	}
+
+	const accessToken = auth.tokens?.access_token;
+	const accountId = auth.tokens?.account_id;
+	if (!accessToken) {
+		return {
+			sampledAt,
+			codexHomeKey,
+			authState: 'unauthenticated',
+			email: extractEmailFromJwt(auth.tokens?.id_token),
+			error: 'No access_token in auth.json. Run `codex login` for this CODEX_HOME.',
+		};
+	}
+
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), opts.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+	let response: Response;
+	try {
+		response = await fetch(CODEX_USAGE_ENDPOINT, {
+			headers: {
+				Authorization: `Bearer ${accessToken}`,
+				Accept: 'application/json',
+				...(accountId ? { 'ChatGPT-Account-Id': accountId } : {}),
+			},
+			signal: controller.signal,
+		});
+	} catch (err) {
+		clearTimeout(timeout);
+		void reportCodexUsageFailure(codexHomeKey, `request: ${formatError(err)}`);
+		return {
+			sampledAt,
+			codexHomeKey,
+			authState: 'error',
+			email: extractEmailFromJwt(auth.tokens?.id_token),
+			error: 'Failed to request Codex quota metadata.',
+		};
+	} finally {
+		clearTimeout(timeout);
+	}
+
+	if (!response.ok) {
+		const status = response.status;
+		void reportCodexUsageFailure(codexHomeKey, `http ${status}`);
+		return {
+			sampledAt,
+			codexHomeKey,
+			authState: status === 401 || status === 403 ? 'unauthenticated' : 'error',
+			email: extractEmailFromJwt(auth.tokens?.id_token),
+			error:
+				status === 401 || status === 403
+					? 'Codex auth token was rejected. Run `codex login` for this CODEX_HOME.'
+					: `Codex quota endpoint returned HTTP ${status}.`,
+		};
+	}
+
+	let body: WhamUsageResponse;
+	try {
+		body = (await response.json()) as WhamUsageResponse;
+	} catch (err) {
+		void reportCodexUsageFailure(codexHomeKey, `json: ${formatError(err)}`);
+		return {
+			sampledAt,
+			codexHomeKey,
+			authState: 'error',
+			email: extractEmailFromJwt(auth.tokens?.id_token),
+			error: 'Codex quota endpoint returned malformed JSON.',
+		};
+	}
+
+	const rateLimit = body.rate_limit ?? {};
+	const session = parseWindow(rateLimit.primary_window);
+	const weekly = parseWindow(rateLimit.secondary_window);
+
+	return {
+		sampledAt,
+		codexHomeKey,
+		authState: 'authenticated',
+		email:
+			typeof body.email === 'string' && body.email.length > 0
+				? body.email
+				: extractEmailFromJwt(auth.tokens?.id_token),
+		planType: typeof body.plan_type === 'string' ? body.plan_type : undefined,
+		session: session ?? undefined,
+		weekly: weekly ?? undefined,
+		additionalLimits: parseAdditionalLimits(body.additional_rate_limits),
+	};
+}
+
+function parseWindow(window: WhamUsageWindow | undefined): CodexUsageSnapshot['session'] | null {
+	if (!window) return null;
+	if (typeof window.used_percent !== 'number') return null;
+	const resetsAt = parseResetAt(window.reset_at);
+	if (!resetsAt) return null;
+	return {
+		percent: window.used_percent,
+		resetsAt,
+	};
+}
+
+function parseAdditionalLimits(
+	limits: WhamUsageResponse['additional_rate_limits']
+): CodexUsageSnapshot['additionalLimits'] {
+	if (!Array.isArray(limits)) return [];
+	const parsed: NonNullable<CodexUsageSnapshot['additionalLimits']> = [];
+	for (const limit of limits) {
+		const name =
+			typeof limit.limit_name === 'string'
+				? limit.limit_name
+				: typeof limit.metered_feature === 'string'
+					? limit.metered_feature
+					: null;
+		const window = parseWindow(limit.rate_limit?.primary_window);
+		if (!name || !window) continue;
+		parsed.push({ name, percent: window.percent, resetsAt: window.resetsAt });
+	}
+	return parsed;
+}
+
+function parseResetAt(value: unknown): string | null {
+	if (typeof value !== 'number' || !Number.isFinite(value)) return null;
+	const milliseconds = value > 10_000_000_000 ? value : value * 1000;
+	const date = new Date(milliseconds);
+	return Number.isNaN(date.getTime()) ? null : date.toISOString();
+}
+
+function extractEmailFromJwt(idToken: string | undefined): string | undefined {
+	if (!idToken) return undefined;
+	try {
+		const payload = idToken.split('.')[1];
+		if (!payload) return undefined;
+		const padded = payload + '='.repeat((4 - (payload.length % 4)) % 4);
+		const decoded = JSON.parse(Buffer.from(padded, 'base64url').toString('utf8')) as {
+			email?: unknown;
+		};
+		return typeof decoded.email === 'string' ? decoded.email : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function formatError(err: unknown): string {
+	return err instanceof Error ? err.message : String(err);
+}
+
+async function reportCodexUsageFailure(codexHomeKey: string, reason: string): Promise<void> {
+	await captureMessage('codex usage sample failed', 'warning', {
+		codexHomeKey,
+		reason,
+	});
+}

--- a/src/main/agents/codex-usage-startup.ts
+++ b/src/main/agents/codex-usage-startup.ts
@@ -34,9 +34,31 @@ interface SamplingTarget {
 
 const ACCOUNT_DIR_EXCLUDE_RE =
 	/(^|[-_.])(backup|bak|old|archive|archived|stage|local|server)([-_.]|$)/i;
+const RECOVERABLE_SAMPLE_ERROR_CODES = new Set([
+	'ENOENT',
+	'EACCES',
+	'ENOTDIR',
+	'ECONNRESET',
+	'ECONNREFUSED',
+	'ENOTFOUND',
+	'ETIMEDOUT',
+	'EAI_AGAIN',
+]);
 
 function isLikelyCodexAccountDirName(name: string): boolean {
 	return name === '.codex' || name.startsWith('.codex-');
+}
+
+function getErrorCode(err: unknown): string | undefined {
+	if (!err || typeof err !== 'object' || !('code' in err)) return undefined;
+	const code = (err as { code?: unknown }).code;
+	return typeof code === 'string' ? code : undefined;
+}
+
+function isRecoverableSampleError(err: unknown): boolean {
+	const code = getErrorCode(err);
+	if (code && RECOVERABLE_SAMPLE_ERROR_CODES.has(code)) return true;
+	return err instanceof Error && (err.name === 'AbortError' || err.name === 'TimeoutError');
 }
 
 /**
@@ -146,7 +168,7 @@ export async function runCodexUsageSampling(deps: CodexUsageSamplingDeps): Promi
 		accounts: Array.from(targetsByKey.keys()),
 	});
 
-	await Promise.all(
+	const results = await Promise.allSettled(
 		Array.from(targetsByKey.values()).map(async (target) => {
 			try {
 				const snapshot = await sampleCodexUsage({ codexHome: target.codexHome });
@@ -158,11 +180,30 @@ export async function runCodexUsageSampling(deps: CodexUsageSamplingDeps): Promi
 					weeklyPercent: snapshot.weekly?.percent,
 				});
 			} catch (err) {
-				logger.warn('Failed to sample Codex usage snapshot', LOG_CONTEXT, {
+				const error = err instanceof Error ? err : new Error(String(err));
+				const context = {
 					codexHomeKey: target.codexHomeKey,
-					error: err instanceof Error ? err.message : String(err),
+					error: error.message,
+				};
+				if (isRecoverableSampleError(err)) {
+					logger.warn('Failed to sample Codex usage snapshot', LOG_CONTEXT, context);
+					return;
+				}
+				logger.warn('Unexpected failure while sampling Codex usage snapshot', LOG_CONTEXT, context);
+				void captureException(error, {
+					operation: 'codexUsage:runCodexUsageSampling.sample',
+					codexHome: target.codexHome,
+					codexHomeKey: target.codexHomeKey,
 				});
+				throw error;
 			}
 		})
 	);
+
+	const unexpectedFailure = results.find(
+		(result): result is PromiseRejectedResult => result.status === 'rejected'
+	);
+	if (unexpectedFailure) {
+		throw unexpectedFailure.reason;
+	}
 }

--- a/src/main/agents/codex-usage-startup.ts
+++ b/src/main/agents/codex-usage-startup.ts
@@ -34,6 +34,7 @@ interface SamplingTarget {
 
 const ACCOUNT_DIR_EXCLUDE_RE =
 	/(^|[-_.])(backup|bak|old|archive|archived|stage|local|server)([-_.]|$)/i;
+const RECOVERABLE_DISCOVERY_ERROR_CODES = new Set(['ENOENT', 'EACCES', 'ENOTDIR']);
 const RECOVERABLE_SAMPLE_ERROR_CODES = new Set([
 	'ENOENT',
 	'EACCES',
@@ -70,6 +71,14 @@ export async function discoverCodexHomes(homeDir = os.homedir()): Promise<string
 	try {
 		entries = await fs.promises.readdir(homeDir, { withFileTypes: true });
 	} catch (err) {
+		const code = getErrorCode(err);
+		if (!code || !RECOVERABLE_DISCOVERY_ERROR_CODES.has(code)) {
+			void captureException(err, {
+				operation: 'codexUsage:discoverCodexHomes.readdir',
+				homeDir,
+			});
+			throw err;
+		}
 		logger.warn('Failed to discover Codex homes', LOG_CONTEXT, {
 			homeDir,
 			error: err instanceof Error ? err.message : String(err),

--- a/src/main/agents/codex-usage-startup.ts
+++ b/src/main/agents/codex-usage-startup.ts
@@ -15,6 +15,7 @@ import Store from 'electron-store';
 import type { AgentDetector } from './detector';
 import type { AgentConfigsData } from '../stores/types';
 import { logger } from '../utils/logger';
+import { captureException } from '../utils/sentry';
 import { resolveCodexHomeKey, setCodexUsageSnapshot } from '../stores/codexUsageStore';
 import { sampleCodexUsage } from './codex-usage-sampler';
 
@@ -60,10 +61,20 @@ export async function discoverCodexHomes(homeDir = os.homedir()): Promise<string
 		if (!isLikelyCodexAccountDirName(entry.name)) continue;
 		if (ACCOUNT_DIR_EXCLUDE_RE.test(entry.name)) continue;
 		const codexHome = path.join(homeDir, entry.name);
+		const authPath = path.join(codexHome, 'auth.json');
 		try {
-			await fs.promises.access(path.join(codexHome, 'auth.json'), fs.constants.R_OK);
-		} catch {
-			continue;
+			await fs.promises.access(authPath, fs.constants.R_OK);
+		} catch (err) {
+			const code = (err as NodeJS.ErrnoException).code;
+			if (code === 'ENOENT' || code === 'EACCES') {
+				continue;
+			}
+			void captureException(err, {
+				operation: 'codexUsage:discoverCodexHomes.access',
+				codexHome,
+				authPath,
+			});
+			throw err;
 		}
 		homes.push(codexHome);
 	}

--- a/src/main/agents/codex-usage-startup.ts
+++ b/src/main/agents/codex-usage-startup.ts
@@ -1,0 +1,149 @@
+/**
+ * Codex Usage Manual Sampler
+ *
+ * Builds one quota sampling target per CODEX_HOME referenced by Codex sessions
+ * or agent-level custom env vars, then persists the snapshots for the Usage
+ * Dashboard. Unlike Claude, Codex sampling is an HTTP metadata request rather
+ * than a TUI screen scrape, so the dashboard can refresh it on demand.
+ */
+
+import os from 'os';
+import path from 'path';
+import * as fs from 'fs';
+import Store from 'electron-store';
+
+import type { AgentDetector } from './detector';
+import type { AgentConfigsData } from '../stores/types';
+import { logger } from '../utils/logger';
+import { resolveCodexHomeKey, setCodexUsageSnapshot } from '../stores/codexUsageStore';
+import { sampleCodexUsage } from './codex-usage-sampler';
+
+const LOG_CONTEXT = '[CodexUsageSampler]';
+
+export interface CodexUsageSamplingDeps {
+	sessionsStore: Store<{ sessions: any[] }>;
+	agentConfigsStore: Store<AgentConfigsData>;
+	agentDetector: AgentDetector;
+}
+
+interface SamplingTarget {
+	codexHome: string;
+	codexHomeKey: string;
+}
+
+const ACCOUNT_DIR_EXCLUDE_RE =
+	/(^|[-_.])(backup|bak|old|archive|archived|stage|local|server)([-_.]|$)/i;
+
+function isLikelyCodexAccountDirName(name: string): boolean {
+	return name === '.codex' || name.startsWith('.codex-');
+}
+
+/**
+ * Discover local Codex account homes, mirroring `/token-cockpit` setups where
+ * each OAuth account has its own `CODEX_HOME`.
+ */
+export function discoverCodexHomes(homeDir = os.homedir()): string[] {
+	let entries: fs.Dirent[];
+	try {
+		entries = fs.readdirSync(homeDir, { withFileTypes: true });
+	} catch (err) {
+		logger.warn('Failed to discover Codex homes', LOG_CONTEXT, {
+			homeDir,
+			error: err instanceof Error ? err.message : String(err),
+		});
+		return [];
+	}
+
+	const homes: string[] = [];
+	for (const entry of entries) {
+		if (!entry.isDirectory()) continue;
+		if (!isLikelyCodexAccountDirName(entry.name)) continue;
+		if (ACCOUNT_DIR_EXCLUDE_RE.test(entry.name)) continue;
+		const codexHome = path.join(homeDir, entry.name);
+		try {
+			fs.accessSync(path.join(codexHome, 'auth.json'), fs.constants.R_OK);
+		} catch {
+			continue;
+		}
+		homes.push(codexHome);
+	}
+
+	return homes.sort((a, b) => a.localeCompare(b));
+}
+
+function getAgentLevelEnvVars(agentConfigsStore: Store<AgentConfigsData>): Record<string, string> {
+	const configs = agentConfigsStore.get('configs', {});
+	const envVars = configs['codex']?.customEnvVars;
+	return envVars && typeof envVars === 'object' ? (envVars as Record<string, string>) : {};
+}
+
+function buildTarget(
+	session: Record<string, unknown>,
+	agentLevelEnvVars: Record<string, string>
+): SamplingTarget {
+	const sessionEnvVars =
+		session.customEnvVars && typeof session.customEnvVars === 'object'
+			? (session.customEnvVars as Record<string, string>)
+			: {};
+	const merged = { ...agentLevelEnvVars, ...sessionEnvVars };
+	const codexHome = merged.CODEX_HOME || path.join(os.homedir(), '.codex');
+	const codexHomeKey = resolveCodexHomeKey({ CODEX_HOME: codexHome });
+	return { codexHome, codexHomeKey };
+}
+
+export async function runCodexUsageSampling(deps: CodexUsageSamplingDeps): Promise<void> {
+	const codexAgent = await deps.agentDetector.getAgent('codex');
+	if (!codexAgent) {
+		logger.warn('Skipping Codex usage sampling: codex agent not detected', LOG_CONTEXT);
+		return;
+	}
+
+	const storedSessions = deps.sessionsStore.get('sessions', []) as Array<Record<string, unknown>>;
+	const codexSessions = storedSessions.filter((s) => s?.toolType === 'codex');
+	const agentLevelEnvVars = getAgentLevelEnvVars(deps.agentConfigsStore);
+
+	const targetsByKey = new Map<string, SamplingTarget>();
+	for (const session of codexSessions) {
+		const target = buildTarget(session, agentLevelEnvVars);
+		if (!targetsByKey.has(target.codexHomeKey)) {
+			targetsByKey.set(target.codexHomeKey, target);
+		}
+	}
+
+	for (const codexHome of discoverCodexHomes()) {
+		const codexHomeKey = resolveCodexHomeKey({ CODEX_HOME: codexHome });
+		if (!targetsByKey.has(codexHomeKey)) {
+			targetsByKey.set(codexHomeKey, { codexHome, codexHomeKey });
+		}
+	}
+
+	if (targetsByKey.size === 0) {
+		const fallbackHome = agentLevelEnvVars.CODEX_HOME || path.join(os.homedir(), '.codex');
+		const fallbackKey = resolveCodexHomeKey({ CODEX_HOME: fallbackHome });
+		targetsByKey.set(fallbackKey, { codexHome: fallbackHome, codexHomeKey: fallbackKey });
+	}
+
+	logger.info(`Sampling Codex usage for ${targetsByKey.size} account(s)`, LOG_CONTEXT, {
+		accounts: Array.from(targetsByKey.keys()),
+	});
+
+	await Promise.all(
+		Array.from(targetsByKey.values()).map(async (target) => {
+			const snapshot = await sampleCodexUsage({ codexHome: target.codexHome });
+			try {
+				setCodexUsageSnapshot(snapshot);
+				logger.info('Stored Codex usage snapshot', LOG_CONTEXT, {
+					codexHomeKey: snapshot.codexHomeKey,
+					authState: snapshot.authState,
+					sessionPercent: snapshot.session?.percent,
+					weeklyPercent: snapshot.weekly?.percent,
+				});
+			} catch (err) {
+				logger.warn('Failed to persist Codex usage snapshot', LOG_CONTEXT, {
+					codexHomeKey: target.codexHomeKey,
+					error: err instanceof Error ? err.message : String(err),
+				});
+			}
+		})
+	);
+}

--- a/src/main/agents/codex-usage-startup.ts
+++ b/src/main/agents/codex-usage-startup.ts
@@ -42,10 +42,10 @@ function isLikelyCodexAccountDirName(name: string): boolean {
  * Discover local Codex account homes, mirroring `/token-cockpit` setups where
  * each OAuth account has its own `CODEX_HOME`.
  */
-export function discoverCodexHomes(homeDir = os.homedir()): string[] {
+export async function discoverCodexHomes(homeDir = os.homedir()): Promise<string[]> {
 	let entries: fs.Dirent[];
 	try {
-		entries = fs.readdirSync(homeDir, { withFileTypes: true });
+		entries = await fs.promises.readdir(homeDir, { withFileTypes: true });
 	} catch (err) {
 		logger.warn('Failed to discover Codex homes', LOG_CONTEXT, {
 			homeDir,
@@ -61,7 +61,7 @@ export function discoverCodexHomes(homeDir = os.homedir()): string[] {
 		if (ACCOUNT_DIR_EXCLUDE_RE.test(entry.name)) continue;
 		const codexHome = path.join(homeDir, entry.name);
 		try {
-			fs.accessSync(path.join(codexHome, 'auth.json'), fs.constants.R_OK);
+			await fs.promises.access(path.join(codexHome, 'auth.json'), fs.constants.R_OK);
 		} catch {
 			continue;
 		}
@@ -86,7 +86,11 @@ function buildTarget(
 			? (session.customEnvVars as Record<string, string>)
 			: {};
 	const merged = { ...agentLevelEnvVars, ...sessionEnvVars };
-	const codexHome = merged.CODEX_HOME || path.join(os.homedir(), '.codex');
+	const configuredCodexHome =
+		typeof merged.CODEX_HOME === 'string' && merged.CODEX_HOME.length > 0
+			? merged.CODEX_HOME
+			: null;
+	const codexHome = configuredCodexHome ?? path.join(os.homedir(), '.codex');
 	const codexHomeKey = resolveCodexHomeKey({ CODEX_HOME: codexHome });
 	return { codexHome, codexHomeKey };
 }
@@ -110,7 +114,7 @@ export async function runCodexUsageSampling(deps: CodexUsageSamplingDeps): Promi
 		}
 	}
 
-	for (const codexHome of discoverCodexHomes()) {
+	for (const codexHome of await discoverCodexHomes()) {
 		const codexHomeKey = resolveCodexHomeKey({ CODEX_HOME: codexHome });
 		if (!targetsByKey.has(codexHomeKey)) {
 			targetsByKey.set(codexHomeKey, { codexHome, codexHomeKey });
@@ -118,7 +122,11 @@ export async function runCodexUsageSampling(deps: CodexUsageSamplingDeps): Promi
 	}
 
 	if (targetsByKey.size === 0) {
-		const fallbackHome = agentLevelEnvVars.CODEX_HOME || path.join(os.homedir(), '.codex');
+		const configuredFallbackHome =
+			typeof agentLevelEnvVars.CODEX_HOME === 'string' && agentLevelEnvVars.CODEX_HOME.length > 0
+				? agentLevelEnvVars.CODEX_HOME
+				: null;
+		const fallbackHome = configuredFallbackHome ?? path.join(os.homedir(), '.codex');
 		const fallbackKey = resolveCodexHomeKey({ CODEX_HOME: fallbackHome });
 		targetsByKey.set(fallbackKey, { codexHome: fallbackHome, codexHomeKey: fallbackKey });
 	}
@@ -129,8 +137,8 @@ export async function runCodexUsageSampling(deps: CodexUsageSamplingDeps): Promi
 
 	await Promise.all(
 		Array.from(targetsByKey.values()).map(async (target) => {
-			const snapshot = await sampleCodexUsage({ codexHome: target.codexHome });
 			try {
+				const snapshot = await sampleCodexUsage({ codexHome: target.codexHome });
 				setCodexUsageSnapshot(snapshot);
 				logger.info('Stored Codex usage snapshot', LOG_CONTEXT, {
 					codexHomeKey: snapshot.codexHomeKey,
@@ -139,7 +147,7 @@ export async function runCodexUsageSampling(deps: CodexUsageSamplingDeps): Promi
 					weeklyPercent: snapshot.weekly?.percent,
 				});
 			} catch (err) {
-				logger.warn('Failed to persist Codex usage snapshot', LOG_CONTEXT, {
+				logger.warn('Failed to sample Codex usage snapshot', LOG_CONTEXT, {
 					codexHomeKey: target.codexHomeKey,
 					error: err instanceof Error ? err.message : String(err),
 				});

--- a/src/main/ipc/handlers/agents.ts
+++ b/src/main/ipc/handlers/agents.ts
@@ -28,9 +28,19 @@ import { stripAnsi } from '../../utils/stripAnsi';
 import { SshRemoteConfig } from '../../../shared/types';
 import { MaestroSettings } from './persistence';
 import { captureException } from '../../utils/sentry';
-import { getAllSnapshots as getAllClaudeUsageSnapshots } from '../../stores/claudeUsageStore';
+import {
+	getAllSnapshots as getAllClaudeUsageSnapshots,
+	resolveConfigDirKey,
+} from '../../stores/claudeUsageStore';
+import { getAllCodexUsageSnapshots, resolveCodexHomeKey } from '../../stores/codexUsageStore';
 import type { UsageSnapshot } from '../../agents/claude-mode-selector';
-import { runStartupUsageSampling, getMaestroPBinPath } from '../../agents/claude-usage-startup';
+import type { CodexUsageSnapshot } from '../../stores/codexUsageStore';
+import {
+	runStartupUsageSampling,
+	getMaestroPBinPath,
+	discoverClaudeConfigDirs,
+} from '../../agents/claude-usage-startup';
+import { runCodexUsageSampling, discoverCodexHomes } from '../../agents/codex-usage-startup';
 
 const LOG_CONTEXT = '[AgentDetector]';
 const CONFIG_LOG_CONTEXT = '[AgentConfig]';
@@ -1597,7 +1607,7 @@ export function registerAgentsHandlers(deps: AgentsHandlerDependencies): void {
 		})
 	);
 
-	// Snapshot mirror for the renderer: returns every non-expired Claude Max-plan
+	// Snapshot mirror for the renderer: returns every non-expired Claude plan
 	// usage snapshot keyed by canonical CLAUDE_CONFIG_DIR. The renderer's
 	// claudeUsageStore lazily fetches via this handler on first read and re-fetches
 	// whenever `process:claude-mode-resolved` arrives (the only signal that
@@ -1610,6 +1620,14 @@ export function registerAgentsHandlers(deps: AgentsHandlerDependencies): void {
 				return getAllClaudeUsageSnapshots();
 			}
 		)
+	);
+
+	ipcMain.handle(
+		'agents:getClaudeUsageAccountKeys',
+		withIpcErrorLogging(handlerOpts('getClaudeUsageAccountKeys'), async (): Promise<string[]> => {
+			const configDirs = await discoverClaudeConfigDirs();
+			return configDirs.map((configDir) => resolveConfigDirKey({ CLAUDE_CONFIG_DIR: configDir }));
+		})
 	);
 
 	// On-demand re-sampler. Delegates to the same `runStartupUsageSampling()`
@@ -1651,6 +1669,58 @@ export function registerAgentsHandlers(deps: AgentsHandlerDependencies): void {
 
 				const refreshed = Object.keys(getAllClaudeUsageSnapshots()).length;
 				logger.info(`Refreshed Claude usage snapshots`, LOG_CONTEXT, { refreshed });
+				return { refreshed };
+			}
+		)
+	);
+
+	// Snapshot mirror for the renderer: returns every non-expired Codex quota
+	// usage snapshot keyed by canonical CODEX_HOME. The auth-sensitive auth.json
+	// read and ChatGPT metadata request stay in the main process.
+	ipcMain.handle(
+		'agents:getCodexUsageSnapshots',
+		withIpcErrorLogging(
+			handlerOpts('getCodexUsageSnapshots'),
+			async (): Promise<Record<string, CodexUsageSnapshot>> => {
+				return getAllCodexUsageSnapshots();
+			}
+		)
+	);
+
+	ipcMain.handle(
+		'agents:getCodexUsageAccountKeys',
+		withIpcErrorLogging(handlerOpts('getCodexUsageAccountKeys'), async (): Promise<string[]> => {
+			const codexHomes = await discoverCodexHomes();
+			return codexHomes.map((codexHome) => resolveCodexHomeKey({ CODEX_HOME: codexHome }));
+		})
+	);
+
+	ipcMain.handle(
+		'codex:usage:refresh-all',
+		withIpcErrorLogging(
+			handlerOpts('refreshCodexUsage'),
+			async (): Promise<{ refreshed: number }> => {
+				const agentDetector = getAgentDetector();
+				if (!agentDetector || !sessionsStore) {
+					logger.warn(
+						'Skipping codex:usage:refresh-all — agents handler missing required deps',
+						LOG_CONTEXT,
+						{
+							hasDetector: !!agentDetector,
+							hasSessionsStore: !!sessionsStore,
+						}
+					);
+					return { refreshed: 0 };
+				}
+
+				await runCodexUsageSampling({
+					sessionsStore: sessionsStore as unknown as Store<{ sessions: any[] }>,
+					agentConfigsStore,
+					agentDetector,
+				});
+
+				const refreshed = Object.keys(getAllCodexUsageSnapshots()).length;
+				logger.info(`Refreshed Codex usage snapshots`, LOG_CONTEXT, { refreshed });
 				return { refreshed };
 			}
 		)

--- a/src/main/preload/agents.ts
+++ b/src/main/preload/agents.ts
@@ -17,6 +17,7 @@ import {
 	type SnapshotUpdatedPayload,
 } from '../../shared/agentCapabilities';
 import type { UsageSnapshot } from '../agents/claude-mode-selector';
+import type { CodexUsageSnapshot } from '../stores/codexUsageStore';
 
 // Re-export for consumers that import from preload. `AgentStatus` is
 // re-exported only (no local usage in this file); TypeScript's
@@ -31,6 +32,7 @@ export type {
 	SnapshotUpdatedPayload,
 } from '../../shared/agentCapabilities';
 export type { UsageSnapshot } from '../agents/claude-mode-selector';
+export type { CodexUsageSnapshot } from '../stores/codexUsageStore';
 
 /**
  * Agent refresh result
@@ -224,12 +226,31 @@ export function createAgentsApi() {
 			ipcRenderer.invoke('agents:getMaestroPDetectedPath'),
 
 		/**
-		 * Fetch the live Claude Max-plan usage snapshot map keyed by canonical
+		 * Fetch the live Claude plan usage snapshot map keyed by canonical
 		 * `CLAUDE_CONFIG_DIR`. Used by the renderer-side claudeUsageStore to
 		 * mirror main-process state for the mode badge and Usage Dashboard.
 		 */
 		getClaudeUsageSnapshots: (): Promise<Record<string, UsageSnapshot>> =>
 			ipcRenderer.invoke('agents:getClaudeUsageSnapshots'),
+
+		/**
+		 * Discover local Claude account keys that can be sampled for quota status.
+		 */
+		getClaudeUsageAccountKeys: (): Promise<string[]> =>
+			ipcRenderer.invoke('agents:getClaudeUsageAccountKeys'),
+
+		/**
+		 * Fetch sanitized Codex quota snapshots keyed by canonical CODEX_HOME.
+		 * Main owns auth.json reads and quota endpoint calls.
+		 */
+		getCodexUsageSnapshots: (): Promise<Record<string, CodexUsageSnapshot>> =>
+			ipcRenderer.invoke('agents:getCodexUsageSnapshots'),
+
+		/**
+		 * Discover local CODEX_HOME account keys that can be sampled for quota status.
+		 */
+		getCodexUsageAccountKeys: (): Promise<string[]> =>
+			ipcRenderer.invoke('agents:getCodexUsageAccountKeys'),
 
 		/**
 		 * Trigger a fresh `runStartupUsageSampling()` pass on main so every known
@@ -240,6 +261,13 @@ export function createAgentsApi() {
 		 */
 		refreshClaudeUsageSnapshots: (): Promise<{ refreshed: number }> =>
 			ipcRenderer.invoke('claude:usage:refresh-all'),
+
+		/**
+		 * Trigger a fresh Codex quota sampling pass on main, then let renderer
+		 * stores pull the sanitized snapshot map.
+		 */
+		refreshCodexUsageSnapshots: (): Promise<{ refreshed: number }> =>
+			ipcRenderer.invoke('codex:usage:refresh-all'),
 	};
 }
 

--- a/src/main/stores/codexUsageStore.ts
+++ b/src/main/stores/codexUsageStore.ts
@@ -101,7 +101,10 @@ export function clearCodexUsageSnapshots(): void {
 }
 
 export function resolveCodexHomeKey(env: NodeJS.ProcessEnv): string {
-	const raw = env.CODEX_HOME ?? path.join(os.homedir(), '.codex');
+	const raw =
+		typeof env.CODEX_HOME === 'string' && env.CODEX_HOME.length > 0
+			? env.CODEX_HOME
+			: path.join(os.homedir(), '.codex');
 	return path.resolve(raw);
 }
 

--- a/src/main/stores/codexUsageStore.ts
+++ b/src/main/stores/codexUsageStore.ts
@@ -1,0 +1,110 @@
+/**
+ * Codex Usage Snapshot Store
+ *
+ * Caches ChatGPT/Codex quota snapshots per canonical CODEX_HOME account. This
+ * mirrors the Claude plan usage store shape without coupling Codex quota
+ * data to Claude's `CLAUDE_CONFIG_DIR` semantics.
+ */
+
+import os from 'os';
+import path from 'path';
+import Store from 'electron-store';
+
+export interface CodexUsageWindow {
+	percent: number;
+	resetsAt: string;
+}
+
+export interface CodexAdditionalLimit {
+	name: string;
+	percent: number;
+	resetsAt?: string;
+}
+
+export type CodexUsageAuthState = 'authenticated' | 'missing_auth' | 'unauthenticated' | 'error';
+
+export interface CodexUsageSnapshot {
+	sampledAt: string;
+	codexHomeKey: string;
+	authState: CodexUsageAuthState;
+	label?: string;
+	email?: string;
+	planType?: string;
+	session?: CodexUsageWindow;
+	weekly?: CodexUsageWindow;
+	additionalLimits?: CodexAdditionalLimit[];
+	error?: string;
+}
+
+export const CODEX_USAGE_SNAPSHOT_TTL_MS = 24 * 60 * 60 * 1000;
+
+interface CodexUsageStoreData {
+	snapshots: Record<string, CodexUsageSnapshot>;
+}
+
+const STORE_NAME = 'codex-usage-snapshots';
+const STORE_DEFAULTS: CodexUsageStoreData = { snapshots: {} };
+
+let _store: Store<CodexUsageStoreData> | null = null;
+
+function getStore(): Store<CodexUsageStoreData> {
+	if (_store === null) {
+		_store = new Store<CodexUsageStoreData>({
+			name: STORE_NAME,
+			defaults: STORE_DEFAULTS,
+		});
+	}
+	return _store;
+}
+
+function isExpired(snapshot: CodexUsageSnapshot, now: number): boolean {
+	const sampledAtMs = new Date(snapshot.sampledAt).getTime();
+	if (Number.isNaN(sampledAtMs)) return true;
+	return now - sampledAtMs > CODEX_USAGE_SNAPSHOT_TTL_MS;
+}
+
+export function setCodexUsageSnapshot(snapshot: CodexUsageSnapshot): void {
+	const store = getStore();
+	const now = Date.now();
+	const current = store.get('snapshots', {});
+	const next: Record<string, CodexUsageSnapshot> = {};
+	for (const [key, entry] of Object.entries(current)) {
+		if (!isExpired(entry, now)) {
+			next[key] = entry;
+		}
+	}
+	next[snapshot.codexHomeKey] = snapshot;
+	store.set('snapshots', next);
+}
+
+export function getAllCodexUsageSnapshots(): Record<string, CodexUsageSnapshot> {
+	const store = getStore();
+	const now = Date.now();
+	const current = store.get('snapshots', {});
+	const live: Record<string, CodexUsageSnapshot> = {};
+	let prunedAny = false;
+	for (const [key, entry] of Object.entries(current)) {
+		if (isExpired(entry, now)) {
+			prunedAny = true;
+		} else {
+			live[key] = entry;
+		}
+	}
+	if (prunedAny) {
+		store.set('snapshots', live);
+	}
+	return live;
+}
+
+export function clearCodexUsageSnapshots(): void {
+	getStore().set('snapshots', {});
+}
+
+export function resolveCodexHomeKey(env: NodeJS.ProcessEnv): string {
+	const raw = env.CODEX_HOME ?? path.join(os.homedir(), '.codex');
+	return path.resolve(raw);
+}
+
+export function __resetForTests(): void {
+	_store = null;
+}

--- a/src/renderer/components/UsageDashboard/ClaudePlanUsage.tsx
+++ b/src/renderer/components/UsageDashboard/ClaudePlanUsage.tsx
@@ -431,6 +431,10 @@ export const ClaudePlanUsage = memo(function ClaudePlanUsage({
 		}
 		setVisualBusy(false);
 	}, [refreshing, visualBusy]);
+	const handleRefreshRef = useRef(handleRefresh);
+	useEffect(() => {
+		handleRefreshRef.current = handleRefresh;
+	}, [handleRefresh]);
 
 	const isBusy = refreshing || visualBusy;
 
@@ -463,16 +467,10 @@ export const ClaudePlanUsage = memo(function ClaudePlanUsage({
 		if (configuredAccountKeys.length === 0) return;
 		if (snapshotCount === 0) return;
 		const timer = window.setInterval(() => {
-			void handleRefresh();
+			void handleRefreshRef.current();
 		}, refreshIntervalMs);
 		return () => window.clearInterval(timer);
-	}, [
-		showRefreshButton,
-		refreshIntervalMs,
-		configuredAccountKeys.length,
-		snapshotCount,
-		handleRefresh,
-	]);
+	}, [showRefreshButton, refreshIntervalMs, configuredAccountKeys.length, snapshotCount]);
 
 	const renderAccount = useCallback(
 		(configDirKey: string) => {

--- a/src/renderer/components/UsageDashboard/ClaudePlanUsage.tsx
+++ b/src/renderer/components/UsageDashboard/ClaudePlanUsage.tsx
@@ -1,0 +1,677 @@
+/**
+ * ClaudePlanUsage
+ *
+ * Per-account Claude plan quota burndown for the Usage Dashboard.
+ * One row per canonical `CLAUDE_CONFIG_DIR` account, three stacked horizontal
+ * bars per row (session window, week all-models, week Sonnet-only). Bar fill
+ * color tracks the same `LIMIT_THRESHOLD_PERCENT` the spawner consults, so
+ * what the dashboard shows in orange / yellow is exactly what would trip the
+ * auto-fallback on the next turn.
+ *
+ * Snapshot data is read live from `claudeUsageStore` (the renderer mirror of
+ * the on-disk map main writes). The "Refresh" button triggers a fresh
+ * `runStartupUsageSampling()` on main, then pulls the updated map back into
+ * the store in a single click.
+ */
+
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { ChevronDown, Clock, Loader2, RefreshCw } from 'lucide-react';
+import type { Theme } from '../../types';
+import { useClaudeUsageStore, type ClaudeUsageSnapshot } from '../../stores/claudeUsageStore';
+import { useSessionStore } from '../../stores/sessionStore';
+import { formatFutureTime } from '../../../shared/formatters';
+import { getHomeDir, getHomeDirAsync } from '../../utils/homeDir';
+
+function deriveAccountShortName(configDirKey: string | undefined): string {
+	if (!configDirKey) return 'default';
+	const trimmed = configDirKey.replace(/\/+$/, '');
+	const basename = trimmed.slice(trimmed.lastIndexOf('/') + 1);
+	if (!basename || basename === '.claude') return 'default';
+	if (basename.startsWith('.claude-')) return basename.slice('.claude-'.length);
+	if (basename.startsWith('.claude')) return basename.slice('.claude'.length) || 'default';
+	return basename;
+}
+
+function deriveAccountDisplayName(configDirKey: string | undefined): string {
+	const shortName = deriveAccountShortName(configDirKey);
+	return shortName === 'default' ? 'Default account' : shortName;
+}
+
+/**
+ * Lightweight renderer-side mirror of `resolveConfigDirKey` from the main
+ * store. Strips trailing slashes so two spellings of the same path collapse
+ * to one tab. Full `path.resolve()` semantics (`..` normalization, separator
+ * canonicalization) live on the main side; user-configured CLAUDE_CONFIG_DIR
+ * values are clean absolute paths in practice, so a string-level normalize
+ * is enough here. If a renderer-derived key ever drifts from a main-side
+ * snapshot key the tab simply shows the "Refresh to sample" CTA instead of
+ * bars — graceful degradation rather than a crash.
+ */
+function normalizeConfigDirKey(value: string): string {
+	return value.replace(/\/+$/, '');
+}
+
+interface ClaudePlanUsageProps {
+	theme: Theme;
+	accountKeys?: string[];
+	showAllAccounts?: boolean;
+	autoRefresh?: boolean;
+	showRefreshButton?: boolean;
+}
+
+interface BarRowProps {
+	label: string;
+	percent: number;
+	resetsAt: string;
+	theme: Theme;
+}
+
+// Mirrors `LIMIT_THRESHOLD_PERCENT` in `src/main/agents/claude-mode-selector.ts`.
+// Duplicated here to keep the renderer bundle free of main-process imports — same
+// rationale as the snapshot shape in `claudeUsageStore.ts`.
+const LIMIT_THRESHOLD = 99;
+const WARNING_THRESHOLD = 75;
+const REFRESH_OPTIONS = [
+	{ value: 0, label: 'Off' },
+	{ value: 60_000, label: '1 min' },
+	{ value: 5 * 60_000, label: '5 min' },
+	{ value: 15 * 60_000, label: '15 min' },
+	{ value: 30 * 60_000, label: '30 min' },
+];
+
+/**
+ * Resolve the fill color for a usage bar. The base fill is the theme's
+ * accent color so the widget reads as part of the surrounding chrome rather
+ * than landing as a bright traffic-light gradient; the threshold cliffs only
+ * kick in once usage is genuinely a concern (75% warning, 99% hard limit).
+ */
+function resolveFillColor(percent: number, theme: Theme): string {
+	if (percent >= LIMIT_THRESHOLD) return theme.colors.error ?? theme.colors.warning;
+	if (percent >= WARNING_THRESHOLD) return theme.colors.warning;
+	return theme.colors.accent;
+}
+
+const BarRow = memo(function BarRow({ label, percent, resetsAt, theme }: BarRowProps) {
+	const clampedPercent = Math.min(100, Math.max(0, percent));
+	const fillColor = resolveFillColor(clampedPercent, theme);
+	const showInsideLabel = clampedPercent >= 22;
+	const displayPercent = Math.round(clampedPercent);
+
+	return (
+		<div className="flex items-center gap-4">
+			<div
+				className="w-44 text-sm whitespace-nowrap flex-shrink-0"
+				style={{ color: theme.colors.textMain }}
+			>
+				{label}
+			</div>
+			<div
+				className="flex-1 h-7 rounded overflow-hidden relative"
+				style={{ backgroundColor: theme.colors.border }}
+				role="progressbar"
+				aria-label={`${label}: ${displayPercent}%`}
+				aria-valuenow={displayPercent}
+				aria-valuemin={0}
+				aria-valuemax={100}
+			>
+				<div
+					className="h-full rounded flex items-center"
+					style={{
+						width: `${Math.max(clampedPercent, 2)}%`,
+						backgroundColor: fillColor,
+						opacity: 0.9,
+						transition: 'width 0.5s cubic-bezier(0.4, 0, 0.2, 1)',
+					}}
+				>
+					{showInsideLabel && (
+						<span
+							className="text-sm font-semibold px-2"
+							style={{
+								color: theme.colors.bgMain,
+								textShadow: '0 1px 2px rgba(0,0,0,0.15)',
+							}}
+						>
+							{displayPercent}%
+						</span>
+					)}
+				</div>
+				{!showInsideLabel && (
+					// Low-percent fallback: print the number to the right of the
+					// fill at the same baseline so 0-21% rows aren't unreadable.
+					<span
+						className="absolute top-1/2 -translate-y-1/2 text-sm font-medium"
+						style={{
+							left: `calc(${Math.max(clampedPercent, 2)}% + 8px)`,
+							color: theme.colors.textMain,
+						}}
+					>
+						{displayPercent}%
+					</span>
+				)}
+			</div>
+			<div
+				className="text-xs text-left whitespace-nowrap flex-shrink-0 ml-auto"
+				style={{ color: theme.colors.textDim, minWidth: '12rem' }}
+				title={`Resets at ${new Date(resetsAt).toLocaleString()}`}
+			>
+				resets {formatFutureTime(resetsAt)}
+			</div>
+		</div>
+	);
+});
+
+const AccountPill = memo(function AccountPill({
+	configDirKey,
+	theme,
+}: {
+	configDirKey: string;
+	theme: Theme;
+}) {
+	return (
+		<span
+			className="inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium"
+			style={{
+				color: theme.colors.accent,
+				backgroundColor: `${theme.colors.accent}15`,
+				border: `1px solid ${theme.colors.accent}35`,
+			}}
+			title={configDirKey}
+		>
+			{deriveAccountDisplayName(configDirKey)}
+		</span>
+	);
+});
+
+interface AccountRowProps {
+	configDirKey: string;
+	snapshot: ClaudeUsageSnapshot;
+	theme: Theme;
+}
+
+const AccountRow = memo(function AccountRow({ configDirKey, snapshot, theme }: AccountRowProps) {
+	const shortName = deriveAccountShortName(configDirKey);
+	const isUnauthenticated = snapshot.authState === 'unauthenticated';
+
+	return (
+		<div className="space-y-2" data-testid={`claude-plan-row-${shortName}`}>
+			<div className="flex items-center gap-2">
+				<AccountPill configDirKey={configDirKey} theme={theme} />
+				<div className="text-xs" style={{ color: theme.colors.textDim, opacity: 0.7 }}>
+					{configDirKey}
+				</div>
+			</div>
+			{isUnauthenticated ? (
+				// Claude's /usage panel for this CLAUDE_CONFIG_DIR rendered
+				// "Not logged in · Run /login". Surface that as a CTA instead
+				// of bars — the percentages would all be 0 and meaningless.
+				<div
+					className="flex items-center gap-2 px-3 py-2 rounded text-xs"
+					style={{
+						backgroundColor: `${theme.colors.warning ?? theme.colors.accent}15`,
+						color: theme.colors.textMain,
+						border: `1px solid ${theme.colors.warning ?? theme.colors.accent}40`,
+					}}
+					data-testid={`claude-plan-row-${shortName}-unauthenticated`}
+				>
+					<span style={{ color: theme.colors.warning ?? theme.colors.accent }}>●</span>
+					<span>
+						Not logged in. Run <code style={{ color: theme.colors.accent }}>/login</code> in a
+						Claude session that uses this account.
+					</span>
+				</div>
+			) : (
+				<>
+					<BarRow
+						label="Session window"
+						percent={snapshot.session.percent}
+						resetsAt={snapshot.session.resetsAt}
+						theme={theme}
+					/>
+					<BarRow
+						label="Week (all models)"
+						percent={snapshot.weekAllModels.percent}
+						resetsAt={snapshot.weekAllModels.resetsAt}
+						theme={theme}
+					/>
+					<BarRow
+						label="Week (Sonnet only)"
+						percent={snapshot.weekSonnetOnly.percent}
+						resetsAt={snapshot.weekSonnetOnly.resetsAt}
+						theme={theme}
+					/>
+				</>
+			)}
+		</div>
+	);
+});
+
+const PendingRow = memo(function PendingRow({
+	configDirKey,
+	theme,
+}: {
+	configDirKey: string;
+	theme: Theme;
+}) {
+	const shortName = deriveAccountShortName(configDirKey);
+	return (
+		<div className="space-y-2" data-testid={`claude-plan-row-${shortName}-pending`}>
+			<div className="flex items-center gap-2">
+				<AccountPill configDirKey={configDirKey} theme={theme} />
+				<div className="text-xs" style={{ color: theme.colors.textDim, opacity: 0.7 }}>
+					{configDirKey}
+				</div>
+			</div>
+			<div
+				className="flex items-center gap-2 px-3 py-2 rounded text-xs"
+				style={{
+					backgroundColor: `${theme.colors.accent}10`,
+					color: theme.colors.textMain,
+					border: `1px solid ${theme.colors.accent}30`,
+				}}
+			>
+				<span style={{ color: theme.colors.accent }}>○</span>
+				<span>
+					No snapshot cached for this account yet. Hit{' '}
+					<strong style={{ color: theme.colors.accent }}>Refresh</strong>.
+				</span>
+			</div>
+		</div>
+	);
+});
+
+export const ClaudePlanUsage = memo(function ClaudePlanUsage({
+	theme,
+	accountKeys = [],
+	showAllAccounts = false,
+	autoRefresh = true,
+	showRefreshButton = true,
+}: ClaudePlanUsageProps) {
+	const snapshots = useClaudeUsageStore((s) => s.snapshots);
+	const refreshing = useClaudeUsageStore((s) => s.refreshing);
+	const sessions = useSessionStore((s) => s.sessions);
+	const [discoveredAccountKeys, setDiscoveredAccountKeys] = useState<string[]>([]);
+
+	// Agent-level customEnvVars for claude-code. Fetched once on mount via
+	// IPC; updates are rare (Settings → Agents) so we don't subscribe to a
+	// live channel — the user can hit Refresh to re-pull.
+	const [agentLevelEnvVars, setAgentLevelEnvVars] = useState<Record<string, string>>({});
+	useEffect(() => {
+		let cancelled = false;
+		window.maestro.agents
+			.getCustomEnvVars('claude-code')
+			.then((env) => {
+				if (!cancelled && env) setAgentLevelEnvVars(env);
+			})
+			.catch(() => {
+				// Best-effort; agent-level vars are optional context. The
+				// session-level fallback below still produces a usable tab list.
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, []);
+
+	useEffect(() => {
+		let cancelled = false;
+		const getKeys = window.maestro.agents.getClaudeUsageAccountKeys;
+		if (typeof getKeys !== 'function') return;
+		Promise.resolve(getKeys())
+			.then((keys) => {
+				if (!cancelled && Array.isArray(keys)) {
+					setDiscoveredAccountKeys(keys.map(normalizeConfigDirKey));
+				}
+			})
+			.catch(() => {});
+		return () => {
+			cancelled = true;
+		};
+	}, []);
+
+	// Home dir for resolving the implicit default `~/.claude` account. The
+	// renderer doesn't have direct fs access; cached IPC fetch via homeDir.ts
+	// returns synchronously on subsequent renders.
+	const [homeDir, setHomeDir] = useState<string | undefined>(getHomeDir);
+	useEffect(() => {
+		if (!homeDir) {
+			getHomeDirAsync()?.then(setHomeDir);
+		}
+	}, [homeDir]);
+	const defaultConfigDirKey = homeDir ? normalizeConfigDirKey(`${homeDir}/.claude`) : null;
+
+	// Account list derived from configured agents/sessions, NOT from snapshot
+	// keys. This way the dashboard shows every account the user has explicitly
+	// wired up — including ones that haven't been sampled yet — and the
+	// per-tab UI can guide them to hit Refresh.
+	//
+	// Sourcing rule mirrors the main-side sampler (claude-usage-startup.ts):
+	// merge agent-level + session-level customEnvVars (session wins). Sessions
+	// without an explicit CLAUDE_CONFIG_DIR fall back to the implicit default
+	// (`~/.claude`) so the user can still see that account is in use even when
+	// it hasn't been sampled (sampling the default is a deliberate skip on the
+	// main side — see `buildTarget` in claude-usage-startup.ts).
+	const configuredAccountKeys = useMemo(() => {
+		const keys = new Set<string>();
+		for (const key of accountKeys) {
+			keys.add(normalizeConfigDirKey(key));
+		}
+		for (const key of discoveredAccountKeys) {
+			keys.add(normalizeConfigDirKey(key));
+		}
+		for (const s of sessions) {
+			if (s.toolType !== 'claude-code') continue;
+			const sessionEnv = (s.customEnvVars ?? {}) as Record<string, string>;
+			const merged = { ...agentLevelEnvVars, ...sessionEnv };
+			const dir = merged.CLAUDE_CONFIG_DIR;
+			if (typeof dir === 'string' && dir.length > 0) {
+				keys.add(normalizeConfigDirKey(dir));
+			} else if (defaultConfigDirKey) {
+				keys.add(defaultConfigDirKey);
+			}
+		}
+		// Also include any snapshot key that didn't surface in session config —
+		// e.g. an account that was sampled in a previous app run but whose
+		// session has since been deleted. Keeping the tab lets the user still
+		// see the cached data instead of it vanishing.
+		for (const key of Object.keys(snapshots)) {
+			keys.add(normalizeConfigDirKey(key));
+		}
+		return Array.from(keys).sort((a, b) =>
+			deriveAccountShortName(a).localeCompare(deriveAccountShortName(b))
+		);
+	}, [
+		accountKeys,
+		discoveredAccountKeys,
+		sessions,
+		agentLevelEnvVars,
+		snapshots,
+		defaultConfigDirKey,
+	]);
+
+	// Sub-tab selection by configDirKey. Defaults to the first account on
+	// mount; clamps back to the first whenever the selected key disappears.
+	const [selectedKey, setSelectedKey] = useState<string | null>(null);
+	useEffect(() => {
+		if (configuredAccountKeys.length === 0) {
+			if (selectedKey !== null) setSelectedKey(null);
+			return;
+		}
+		if (selectedKey === null || !configuredAccountKeys.includes(selectedKey)) {
+			setSelectedKey(configuredAccountKeys[0]);
+		}
+	}, [configuredAccountKeys, selectedKey]);
+
+	const effectiveSelectedKey = selectedKey ?? configuredAccountKeys[0] ?? null;
+	const selectedSnapshot: ClaudeUsageSnapshot | null = effectiveSelectedKey
+		? (snapshots[effectiveSelectedKey] ?? null)
+		: null;
+	const snapshotCount = Object.keys(snapshots).length;
+
+	// Visual gate that keeps the spinning state on-screen long enough for the
+	// eye to register it, even when the IPC round-trip returns in <100ms.
+	// Independent of `refreshing` so a fast sample still animates the button
+	// for a full beat instead of flashing.
+	const [visualBusy, setVisualBusy] = useState(false);
+	const [refreshIntervalMs, setRefreshIntervalMs] = useState(0);
+
+	const handleRefresh = useCallback(async () => {
+		if (refreshing || visualBusy) return;
+		setVisualBusy(true);
+		const minVisibleMs = 900;
+		const start = Date.now();
+		try {
+			await window.maestro.agents.refreshClaudeUsageSnapshots();
+		} catch {
+			// Main-side errors surface in main logs; the store keeps the last good
+			// map rather than blowing up the dashboard.
+		}
+		await useClaudeUsageStore.getState().refresh();
+		const elapsed = Date.now() - start;
+		if (elapsed < minVisibleMs) {
+			await new Promise((r) => setTimeout(r, minVisibleMs - elapsed));
+		}
+		setVisualBusy(false);
+	}, [refreshing, visualBusy]);
+
+	const isBusy = refreshing || visualBusy;
+
+	// Auto-sample on first arrival when the dashboard opens with at least one
+	// configured account but no cached snapshots — saves the user a manual
+	// Refresh click. The empty-snapshot CTA still acts as a fallback if the
+	// auto-sample itself fails. Guarded by a ref so React Strict-Mode's
+	// double-mount in dev doesn't fire two samples back-to-back.
+	const autoRefreshFiredRef = useRef(false);
+	useEffect(() => {
+		if (!autoRefresh) return;
+		if (autoRefreshFiredRef.current) return;
+		if (configuredAccountKeys.length === 0) return;
+		if (snapshotCount > 0) return;
+		if (refreshing || visualBusy) return;
+		autoRefreshFiredRef.current = true;
+		void handleRefresh();
+	}, [
+		autoRefresh,
+		configuredAccountKeys.length,
+		snapshotCount,
+		refreshing,
+		visualBusy,
+		handleRefresh,
+	]);
+
+	useEffect(() => {
+		if (!showRefreshButton) return;
+		if (refreshIntervalMs <= 0) return;
+		if (configuredAccountKeys.length === 0) return;
+		if (snapshotCount === 0) return;
+		const timer = window.setInterval(() => {
+			void handleRefresh();
+		}, refreshIntervalMs);
+		return () => window.clearInterval(timer);
+	}, [
+		showRefreshButton,
+		refreshIntervalMs,
+		configuredAccountKeys.length,
+		snapshotCount,
+		handleRefresh,
+	]);
+
+	const renderAccount = useCallback(
+		(configDirKey: string) => {
+			const snapshot = snapshots[configDirKey];
+			return snapshot ? (
+				<AccountRow
+					key={configDirKey}
+					configDirKey={configDirKey}
+					snapshot={snapshot}
+					theme={theme}
+				/>
+			) : (
+				<PendingRow key={configDirKey} configDirKey={configDirKey} theme={theme} />
+			);
+		},
+		[snapshots, theme]
+	);
+
+	return (
+		<div
+			className="p-4 rounded-lg"
+			style={{ backgroundColor: theme.colors.bgMain }}
+			data-testid="claude-plan-usage"
+		>
+			<div className="flex flex-wrap items-center justify-between gap-3 mb-4">
+				<div className="flex items-center gap-2">
+					<h3 className="text-sm font-medium" style={{ color: theme.colors.textMain }}>
+						Claude Plan Usage
+					</h3>
+					<span
+						className="rounded-full px-2 py-0.5 text-xs"
+						style={{
+							color: theme.colors.textDim,
+							backgroundColor: `${theme.colors.border}55`,
+							border: `1px solid ${theme.colors.border}`,
+						}}
+					>
+						Claude Code
+					</span>
+				</div>
+				{showRefreshButton && (
+					<div className="flex flex-wrap items-center justify-end gap-2">
+						<label className="relative flex items-center">
+							<Clock
+								className="w-3.5 h-3.5 absolute left-2.5 pointer-events-none"
+								style={{ color: theme.colors.textDim }}
+							/>
+							<select
+								value={refreshIntervalMs}
+								onChange={(event) => setRefreshIntervalMs(Number(event.target.value))}
+								className="pl-8 pr-7 py-1.5 rounded text-xs border cursor-pointer outline-none appearance-none"
+								style={{
+									backgroundColor: theme.colors.bgActivity,
+									borderColor: theme.colors.border,
+									color: theme.colors.textMain,
+								}}
+								aria-label="Claude usage auto refresh interval"
+								data-testid="claude-plan-refresh-interval"
+							>
+								{REFRESH_OPTIONS.map((option) => (
+									<option key={option.value} value={option.value}>
+										Auto refresh: {option.label}
+									</option>
+								))}
+							</select>
+							<ChevronDown
+								className="absolute right-2 w-3 h-3 pointer-events-none"
+								style={{ color: theme.colors.textDim }}
+								aria-hidden="true"
+							/>
+						</label>
+						<button
+							type="button"
+							onClick={handleRefresh}
+							disabled={isBusy}
+							className="relative flex items-center gap-1.5 px-3 py-1.5 rounded text-xs font-medium transition-colors disabled:cursor-not-allowed overflow-hidden"
+							style={{
+								color: isBusy ? theme.colors.bgMain : theme.colors.accent,
+								backgroundColor: isBusy ? theme.colors.accent : `${theme.colors.accent}15`,
+								border: `1px solid ${theme.colors.accent}40`,
+								minWidth: '7.25rem',
+							}}
+							data-testid="claude-plan-refresh"
+							aria-label="Refresh Claude usage snapshots"
+							aria-busy={isBusy}
+						>
+							{isBusy ? (
+								<>
+									<span
+										className="absolute inset-0 pointer-events-none claude-plan-refresh-sweep"
+										style={{
+											backgroundImage: `linear-gradient(90deg, transparent 0%, ${theme.colors.bgMain}66 50%, transparent 100%)`,
+										}}
+										aria-hidden="true"
+									/>
+									<Loader2 className="w-3.5 h-3.5 animate-spin relative" aria-hidden="true" />
+									<span className="relative">Sampling...</span>
+								</>
+							) : (
+								<>
+									<RefreshCw className="w-3.5 h-3.5" aria-hidden="true" />
+									<span>Refresh</span>
+								</>
+							)}
+						</button>
+					</div>
+				)}
+			</div>
+
+			{showAllAccounts && configuredAccountKeys.length > 0 && (
+				<div className="space-y-4">{configuredAccountKeys.map(renderAccount)}</div>
+			)}
+
+			{/* Account tab bar — renders whenever at least one account is
+			    configured so the structure stays consistent when accounts are
+			    added/removed. A bare empty state still hides the bar. */}
+			{!showAllAccounts && configuredAccountKeys.length >= 1 && (
+				<div
+					className="flex items-center gap-1 mb-4 border-b"
+					style={{ borderColor: theme.colors.border }}
+					role="tablist"
+					aria-label="Claude account selector"
+					data-testid="claude-plan-account-tabs"
+				>
+					{configuredAccountKeys.map((configDirKey) => {
+						const shortName = deriveAccountShortName(configDirKey);
+						const isActive = effectiveSelectedKey === configDirKey;
+						const tabSnapshot = snapshots[configDirKey];
+						const isUnauth = tabSnapshot?.authState === 'unauthenticated';
+						const hasSnapshot = !!tabSnapshot;
+						return (
+							<button
+								key={configDirKey}
+								type="button"
+								role="tab"
+								aria-selected={isActive}
+								onClick={() => setSelectedKey(configDirKey)}
+								className="px-3 py-1.5 text-sm font-medium transition-colors relative -mb-px"
+								style={{
+									color: isActive ? theme.colors.accent : theme.colors.textDim,
+									borderBottom: `2px solid ${isActive ? theme.colors.accent : 'transparent'}`,
+								}}
+								title={configDirKey}
+								data-testid={`claude-plan-tab-${shortName}`}
+							>
+								<span className="flex items-center gap-1.5">
+									{deriveAccountDisplayName(configDirKey)}
+									{/* Status dot:
+									    - warning = "not logged in"
+									    - dim     = "no snapshot yet, hit Refresh"
+									    - none    = snapshot present + authenticated */}
+									{isUnauth ? (
+										<span
+											className="text-[10px]"
+											style={{ color: theme.colors.warning ?? theme.colors.accent }}
+											title="Not logged in"
+										>
+											●
+										</span>
+									) : !hasSnapshot ? (
+										<span
+											className="text-[10px]"
+											style={{ color: theme.colors.textDim, opacity: 0.6 }}
+											title="No snapshot yet - hit Refresh"
+										>
+											○
+										</span>
+									) : null}
+								</span>
+							</button>
+						);
+					})}
+				</div>
+			)}
+
+			{configuredAccountKeys.length === 0 ? (
+				<div
+					className="flex items-center justify-center h-24 text-sm text-center px-4"
+					style={{ color: theme.colors.textDim }}
+					data-testid="claude-plan-empty"
+				>
+					No Claude accounts configured. Set CLAUDE_CONFIG_DIR on a Claude Code session (or the
+					agent) — we sample only explicitly-configured accounts so we never trigger a browser OAuth
+					prompt.
+				</div>
+			) : showAllAccounts ? null : effectiveSelectedKey && selectedSnapshot ? (
+				<AccountRow
+					key={effectiveSelectedKey}
+					configDirKey={effectiveSelectedKey}
+					snapshot={selectedSnapshot}
+					theme={theme}
+				/>
+			) : effectiveSelectedKey ? (
+				// Account is configured but no snapshot in the store yet — guide
+				// the user to hit Refresh rather than silently rendering nothing.
+				<PendingRow configDirKey={effectiveSelectedKey} theme={theme} />
+			) : null}
+		</div>
+	);
+});
+
+export default ClaudePlanUsage;

--- a/src/renderer/components/UsageDashboard/CodexPlanUsage.tsx
+++ b/src/renderer/components/UsageDashboard/CodexPlanUsage.tsx
@@ -1,0 +1,614 @@
+/**
+ * CodexPlanUsage
+ *
+ * Per-account Codex quota burndown for the Usage Dashboard Overview tab.
+ * Mirrors ClaudePlanUsage's account-tab + horizontal-bar pattern, but reads
+ * sanitized ChatGPT/Codex quota snapshots from `codexUsageStore`.
+ */
+
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { ChevronDown, Clock, Loader2, RefreshCw } from 'lucide-react';
+import type { Theme } from '../../types';
+import { useCodexUsageStore, type CodexUsageSnapshot } from '../../stores/codexUsageStore';
+import { useSessionStore } from '../../stores/sessionStore';
+import { formatFutureTime } from '../../../shared/formatters';
+import { getHomeDir, getHomeDirAsync } from '../../utils/homeDir';
+
+function deriveAccountShortName(codexHomeKey: string | undefined): string {
+	if (!codexHomeKey) return 'default';
+	const trimmed = codexHomeKey.replace(/\/+$/, '');
+	const basename = trimmed.slice(trimmed.lastIndexOf('/') + 1);
+	if (!basename || basename === '.codex') return 'default';
+	if (basename.startsWith('.codex-')) return basename.slice('.codex-'.length);
+	if (basename.startsWith('.codex')) return basename.slice('.codex'.length) || 'default';
+	return basename;
+}
+
+function deriveAccountDisplayName(codexHomeKey: string | undefined): string {
+	const shortName = deriveAccountShortName(codexHomeKey);
+	return shortName === 'default' ? 'Default account' : shortName;
+}
+
+function normalizeCodexHomeKey(value: string): string {
+	return value.replace(/\/+$/, '');
+}
+
+interface CodexPlanUsageProps {
+	theme: Theme;
+	accountKeys?: string[];
+	showAllAccounts?: boolean;
+	autoRefresh?: boolean;
+	showRefreshButton?: boolean;
+}
+
+interface BarRowProps {
+	label: string;
+	percent: number;
+	resetsAt?: string;
+	theme: Theme;
+}
+
+const WARNING_THRESHOLD = 75;
+const LIMIT_THRESHOLD = 99;
+const REFRESH_OPTIONS = [
+	{ value: 0, label: 'Off' },
+	{ value: 60_000, label: '1 min' },
+	{ value: 5 * 60_000, label: '5 min' },
+	{ value: 15 * 60_000, label: '15 min' },
+	{ value: 30 * 60_000, label: '30 min' },
+];
+
+function resolveFillColor(percent: number, theme: Theme): string {
+	if (percent >= LIMIT_THRESHOLD) return theme.colors.error ?? theme.colors.warning;
+	if (percent >= WARNING_THRESHOLD) return theme.colors.warning;
+	return theme.colors.accent;
+}
+
+const BarRow = memo(function BarRow({ label, percent, resetsAt, theme }: BarRowProps) {
+	const clampedPercent = Math.min(100, Math.max(0, percent));
+	const fillColor = resolveFillColor(clampedPercent, theme);
+	const showInsideLabel = clampedPercent >= 22;
+	const displayPercent = Math.round(clampedPercent);
+
+	return (
+		<div className="flex items-center gap-4">
+			<div
+				className="w-44 text-sm whitespace-nowrap flex-shrink-0"
+				style={{ color: theme.colors.textMain }}
+			>
+				{label}
+			</div>
+			<div
+				className="flex-1 h-7 rounded overflow-hidden relative"
+				style={{ backgroundColor: theme.colors.border }}
+				role="progressbar"
+				aria-label={`${label}: ${displayPercent}%`}
+				aria-valuenow={displayPercent}
+				aria-valuemin={0}
+				aria-valuemax={100}
+			>
+				<div
+					className="h-full rounded flex items-center"
+					style={{
+						width: `${Math.max(clampedPercent, 2)}%`,
+						backgroundColor: fillColor,
+						opacity: 0.9,
+						transition: 'width 0.5s cubic-bezier(0.4, 0, 0.2, 1)',
+					}}
+				>
+					{showInsideLabel && (
+						<span
+							className="text-sm font-semibold px-2"
+							style={{
+								color: theme.colors.bgMain,
+								textShadow: '0 1px 2px rgba(0,0,0,0.15)',
+							}}
+						>
+							{displayPercent}%
+						</span>
+					)}
+				</div>
+				{!showInsideLabel && (
+					<span
+						className="absolute top-1/2 -translate-y-1/2 text-sm font-medium"
+						style={{
+							left: `calc(${Math.max(clampedPercent, 2)}% + 8px)`,
+							color: theme.colors.textMain,
+						}}
+					>
+						{displayPercent}%
+					</span>
+				)}
+			</div>
+			<div
+				className="text-xs text-left whitespace-nowrap flex-shrink-0 ml-auto"
+				style={{ color: theme.colors.textDim, minWidth: '12rem' }}
+				title={resetsAt ? `Resets at ${new Date(resetsAt).toLocaleString()}` : undefined}
+			>
+				{resetsAt ? `resets ${formatFutureTime(resetsAt)}` : 'reset unknown'}
+			</div>
+		</div>
+	);
+});
+
+const AccountPill = memo(function AccountPill({
+	codexHomeKey,
+	theme,
+}: {
+	codexHomeKey: string;
+	theme: Theme;
+}) {
+	return (
+		<span
+			className="inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium"
+			style={{
+				color: theme.colors.accent,
+				backgroundColor: `${theme.colors.accent}15`,
+				border: `1px solid ${theme.colors.accent}35`,
+			}}
+			title={codexHomeKey}
+		>
+			{deriveAccountDisplayName(codexHomeKey)}
+		</span>
+	);
+});
+
+interface AccountRowProps {
+	codexHomeKey: string;
+	snapshot: CodexUsageSnapshot;
+	theme: Theme;
+}
+
+const AccountRow = memo(function AccountRow({ codexHomeKey, snapshot, theme }: AccountRowProps) {
+	const shortName = deriveAccountShortName(codexHomeKey);
+	const hasBars =
+		snapshot.session || snapshot.weekly || (snapshot.additionalLimits?.length ?? 0) > 0;
+
+	return (
+		<div className="space-y-2" data-testid={`codex-plan-row-${shortName}`}>
+			<div className="flex items-center gap-2">
+				<AccountPill codexHomeKey={codexHomeKey} theme={theme} />
+				{snapshot.email && (
+					<div className="text-xs" style={{ color: theme.colors.textDim, opacity: 0.7 }}>
+						{snapshot.email}
+					</div>
+				)}
+				{snapshot.planType && (
+					<div
+						className="text-xs px-1.5 py-0.5 rounded"
+						style={{
+							color: theme.colors.accent,
+							backgroundColor: `${theme.colors.accent}15`,
+						}}
+					>
+						{snapshot.planType}
+					</div>
+				)}
+			</div>
+
+			{snapshot.authState !== 'authenticated' ? (
+				<div
+					className="flex items-center gap-2 px-3 py-2 rounded text-xs"
+					style={{
+						backgroundColor: `${theme.colors.warning ?? theme.colors.accent}15`,
+						color: theme.colors.textMain,
+						border: `1px solid ${theme.colors.warning ?? theme.colors.accent}40`,
+					}}
+					data-testid={`codex-plan-row-${shortName}-${snapshot.authState}`}
+				>
+					<span style={{ color: theme.colors.warning ?? theme.colors.accent }}>●</span>
+					<span>{snapshot.error ?? 'Codex quota is unavailable for this account.'}</span>
+				</div>
+			) : hasBars ? (
+				<>
+					{snapshot.session && (
+						<BarRow
+							label="Session (5h)"
+							percent={snapshot.session.percent}
+							resetsAt={snapshot.session.resetsAt}
+							theme={theme}
+						/>
+					)}
+					{snapshot.weekly && (
+						<BarRow
+							label="Weekly"
+							percent={snapshot.weekly.percent}
+							resetsAt={snapshot.weekly.resetsAt}
+							theme={theme}
+						/>
+					)}
+					{(snapshot.additionalLimits ?? []).map((limit) => (
+						<BarRow
+							key={limit.name}
+							label={limit.name}
+							percent={limit.percent}
+							resetsAt={limit.resetsAt}
+							theme={theme}
+						/>
+					))}
+				</>
+			) : (
+				<div
+					className="flex items-center gap-2 px-3 py-2 rounded text-xs"
+					style={{
+						backgroundColor: `${theme.colors.accent}10`,
+						color: theme.colors.textMain,
+						border: `1px solid ${theme.colors.accent}30`,
+					}}
+				>
+					<span style={{ color: theme.colors.accent }}>○</span>
+					<span>Quota endpoint returned no rate-limit windows for this account.</span>
+				</div>
+			)}
+		</div>
+	);
+});
+
+const PendingRow = memo(function PendingRow({
+	codexHomeKey,
+	theme,
+}: {
+	codexHomeKey: string;
+	theme: Theme;
+}) {
+	const shortName = deriveAccountShortName(codexHomeKey);
+	return (
+		<div className="space-y-2" data-testid={`codex-plan-row-${shortName}-pending`}>
+			<div className="flex items-center gap-2">
+				<AccountPill codexHomeKey={codexHomeKey} theme={theme} />
+				<div className="text-xs" style={{ color: theme.colors.textDim, opacity: 0.7 }}>
+					{codexHomeKey}
+				</div>
+			</div>
+			<div
+				className="flex items-center gap-2 px-3 py-2 rounded text-xs"
+				style={{
+					backgroundColor: `${theme.colors.accent}10`,
+					color: theme.colors.textMain,
+					border: `1px solid ${theme.colors.accent}30`,
+				}}
+			>
+				<span style={{ color: theme.colors.accent }}>○</span>
+				<span>
+					No snapshot cached for this account yet. Hit{' '}
+					<strong style={{ color: theme.colors.accent }}>Refresh</strong>.
+				</span>
+			</div>
+		</div>
+	);
+});
+
+export const CodexPlanUsage = memo(function CodexPlanUsage({
+	theme,
+	accountKeys = [],
+	showAllAccounts = false,
+	autoRefresh = true,
+	showRefreshButton = true,
+}: CodexPlanUsageProps) {
+	const snapshots = useCodexUsageStore((s) => s.snapshots);
+	const refreshing = useCodexUsageStore((s) => s.refreshing);
+	const sessions = useSessionStore((s) => s.sessions);
+	const [agentLevelEnvVars, setAgentLevelEnvVars] = useState<Record<string, string>>({});
+	const [discoveredAccountKeys, setDiscoveredAccountKeys] = useState<string[]>([]);
+	const [homeDir, setHomeDir] = useState<string | undefined>(getHomeDir);
+
+	useEffect(() => {
+		let cancelled = false;
+		window.maestro.agents
+			.getCustomEnvVars('codex')
+			.then((env) => {
+				if (!cancelled && env) setAgentLevelEnvVars(env);
+			})
+			.catch(() => {});
+		return () => {
+			cancelled = true;
+		};
+	}, []);
+
+	useEffect(() => {
+		let cancelled = false;
+		const getKeys = window.maestro.agents.getCodexUsageAccountKeys;
+		if (typeof getKeys !== 'function') return;
+		Promise.resolve(getKeys())
+			.then((keys) => {
+				if (!cancelled && Array.isArray(keys)) {
+					setDiscoveredAccountKeys(keys.map(normalizeCodexHomeKey));
+				}
+			})
+			.catch(() => {});
+		return () => {
+			cancelled = true;
+		};
+	}, []);
+
+	useEffect(() => {
+		if (!homeDir) {
+			getHomeDirAsync()?.then(setHomeDir);
+		}
+	}, [homeDir]);
+
+	const defaultCodexHomeKey = homeDir ? normalizeCodexHomeKey(`${homeDir}/.codex`) : null;
+
+	const configuredAccountKeys = useMemo(() => {
+		const keys = new Set<string>();
+		for (const key of accountKeys) {
+			keys.add(normalizeCodexHomeKey(key));
+		}
+		for (const key of discoveredAccountKeys) {
+			keys.add(normalizeCodexHomeKey(key));
+		}
+		for (const s of sessions) {
+			if (s.toolType !== 'codex') continue;
+			const sessionEnv = (s.customEnvVars ?? {}) as Record<string, string>;
+			const merged = { ...agentLevelEnvVars, ...sessionEnv };
+			const dir = merged.CODEX_HOME;
+			if (typeof dir === 'string' && dir.length > 0) {
+				keys.add(normalizeCodexHomeKey(dir));
+			} else if (defaultCodexHomeKey) {
+				keys.add(defaultCodexHomeKey);
+			}
+		}
+		for (const key of Object.keys(snapshots)) {
+			keys.add(normalizeCodexHomeKey(key));
+		}
+		return Array.from(keys).sort((a, b) =>
+			deriveAccountShortName(a).localeCompare(deriveAccountShortName(b))
+		);
+	}, [
+		accountKeys,
+		discoveredAccountKeys,
+		sessions,
+		agentLevelEnvVars,
+		snapshots,
+		defaultCodexHomeKey,
+	]);
+
+	const [selectedKey, setSelectedKey] = useState<string | null>(null);
+	useEffect(() => {
+		if (configuredAccountKeys.length === 0) {
+			if (selectedKey !== null) setSelectedKey(null);
+			return;
+		}
+		if (selectedKey === null || !configuredAccountKeys.includes(selectedKey)) {
+			setSelectedKey(configuredAccountKeys[0]);
+		}
+	}, [configuredAccountKeys, selectedKey]);
+
+	const effectiveSelectedKey = selectedKey ?? configuredAccountKeys[0] ?? null;
+	const selectedSnapshot = effectiveSelectedKey ? (snapshots[effectiveSelectedKey] ?? null) : null;
+	const snapshotCount = Object.keys(snapshots).length;
+
+	const [visualBusy, setVisualBusy] = useState(false);
+	const [refreshIntervalMs, setRefreshIntervalMs] = useState(0);
+	const handleRefresh = useCallback(async () => {
+		if (refreshing || visualBusy) return;
+		setVisualBusy(true);
+		const minVisibleMs = 900;
+		const start = Date.now();
+		try {
+			await window.maestro.agents.refreshCodexUsageSnapshots();
+		} catch {
+			// Main logs carry the detailed failure. Keep the last renderer snapshot.
+		}
+		await useCodexUsageStore.getState().refresh();
+		const elapsed = Date.now() - start;
+		if (elapsed < minVisibleMs) {
+			await new Promise((r) => setTimeout(r, minVisibleMs - elapsed));
+		}
+		setVisualBusy(false);
+	}, [refreshing, visualBusy]);
+
+	const autoRefreshFiredRef = useRef(false);
+	useEffect(() => {
+		if (!autoRefresh) return;
+		if (autoRefreshFiredRef.current) return;
+		if (configuredAccountKeys.length === 0) return;
+		if (snapshotCount > 0) return;
+		if (refreshing || visualBusy) return;
+		autoRefreshFiredRef.current = true;
+		void handleRefresh();
+	}, [
+		autoRefresh,
+		configuredAccountKeys.length,
+		snapshotCount,
+		refreshing,
+		visualBusy,
+		handleRefresh,
+	]);
+
+	useEffect(() => {
+		if (!showRefreshButton) return;
+		if (refreshIntervalMs <= 0) return;
+		if (configuredAccountKeys.length === 0) return;
+		if (snapshotCount === 0) return;
+		const timer = window.setInterval(() => {
+			void handleRefresh();
+		}, refreshIntervalMs);
+		return () => window.clearInterval(timer);
+	}, [
+		showRefreshButton,
+		refreshIntervalMs,
+		configuredAccountKeys.length,
+		snapshotCount,
+		handleRefresh,
+	]);
+
+	const isBusy = refreshing || visualBusy;
+	const renderAccount = useCallback(
+		(codexHomeKey: string) => {
+			const snapshot = snapshots[codexHomeKey];
+			return snapshot ? (
+				<AccountRow
+					key={codexHomeKey}
+					codexHomeKey={codexHomeKey}
+					snapshot={snapshot}
+					theme={theme}
+				/>
+			) : (
+				<PendingRow key={codexHomeKey} codexHomeKey={codexHomeKey} theme={theme} />
+			);
+		},
+		[snapshots, theme]
+	);
+
+	return (
+		<div
+			className="p-4 rounded-lg"
+			style={{ backgroundColor: theme.colors.bgMain }}
+			data-testid="codex-plan-usage"
+		>
+			<div className="flex flex-wrap items-center justify-between gap-3 mb-4">
+				<h3 className="text-sm font-medium" style={{ color: theme.colors.textMain }}>
+					Codex Plan Usage
+				</h3>
+				{showRefreshButton && (
+					<div className="flex flex-wrap items-center justify-end gap-2">
+						<label className="relative flex items-center">
+							<Clock
+								className="w-3.5 h-3.5 absolute left-2.5 pointer-events-none"
+								style={{ color: theme.colors.textDim }}
+							/>
+							<select
+								value={refreshIntervalMs}
+								onChange={(event) => setRefreshIntervalMs(Number(event.target.value))}
+								className="pl-8 pr-7 py-1.5 rounded text-xs border cursor-pointer outline-none appearance-none"
+								style={{
+									backgroundColor: theme.colors.bgActivity,
+									borderColor: theme.colors.border,
+									color: theme.colors.textMain,
+								}}
+								aria-label="Codex usage auto refresh interval"
+								data-testid="codex-plan-refresh-interval"
+							>
+								{REFRESH_OPTIONS.map((option) => (
+									<option key={option.value} value={option.value}>
+										Auto refresh: {option.label}
+									</option>
+								))}
+							</select>
+							<ChevronDown
+								className="absolute right-2 w-3 h-3 pointer-events-none"
+								style={{ color: theme.colors.textDim }}
+								aria-hidden="true"
+							/>
+						</label>
+						<button
+							type="button"
+							onClick={handleRefresh}
+							disabled={isBusy}
+							className="relative flex items-center gap-1.5 px-3 py-1.5 rounded text-xs font-medium transition-colors disabled:cursor-not-allowed overflow-hidden"
+							style={{
+								color: isBusy ? theme.colors.bgMain : theme.colors.accent,
+								backgroundColor: isBusy ? theme.colors.accent : `${theme.colors.accent}15`,
+								border: `1px solid ${theme.colors.accent}40`,
+								minWidth: '7.25rem',
+							}}
+							data-testid="codex-plan-refresh"
+							aria-label="Refresh Codex usage snapshots"
+							aria-busy={isBusy}
+						>
+							{isBusy ? (
+								<>
+									<span
+										className="absolute inset-0 pointer-events-none claude-plan-refresh-sweep"
+										style={{
+											backgroundImage: `linear-gradient(90deg, transparent 0%, ${theme.colors.bgMain}66 50%, transparent 100%)`,
+										}}
+										aria-hidden="true"
+									/>
+									<Loader2 className="w-3.5 h-3.5 animate-spin relative" aria-hidden="true" />
+									<span className="relative">Sampling...</span>
+								</>
+							) : (
+								<>
+									<RefreshCw className="w-3.5 h-3.5" aria-hidden="true" />
+									<span>Refresh</span>
+								</>
+							)}
+						</button>
+					</div>
+				)}
+			</div>
+
+			{showAllAccounts && configuredAccountKeys.length > 0 && (
+				<div className="space-y-4">{configuredAccountKeys.map(renderAccount)}</div>
+			)}
+
+			{!showAllAccounts && configuredAccountKeys.length >= 1 && (
+				<div
+					className="flex items-center gap-1 mb-4 border-b"
+					style={{ borderColor: theme.colors.border }}
+					role="tablist"
+					aria-label="Codex account selector"
+					data-testid="codex-plan-account-tabs"
+				>
+					{configuredAccountKeys.map((codexHomeKey) => {
+						const shortName = deriveAccountShortName(codexHomeKey);
+						const isActive = effectiveSelectedKey === codexHomeKey;
+						const tabSnapshot = snapshots[codexHomeKey];
+						const hasSnapshot = !!tabSnapshot;
+						const isWarning = tabSnapshot && tabSnapshot.authState !== 'authenticated';
+						return (
+							<button
+								key={codexHomeKey}
+								type="button"
+								role="tab"
+								aria-selected={isActive}
+								onClick={() => setSelectedKey(codexHomeKey)}
+								className="px-3 py-1.5 text-sm font-medium transition-colors relative -mb-px"
+								style={{
+									color: isActive ? theme.colors.accent : theme.colors.textDim,
+									borderBottom: `2px solid ${isActive ? theme.colors.accent : 'transparent'}`,
+								}}
+								title={codexHomeKey}
+								data-testid={`codex-plan-tab-${shortName}`}
+							>
+								<span className="flex items-center gap-1.5">
+									{deriveAccountDisplayName(codexHomeKey)}
+									{isWarning ? (
+										<span
+											className="text-[10px]"
+											style={{ color: theme.colors.warning ?? theme.colors.accent }}
+											title="Needs attention"
+										>
+											●
+										</span>
+									) : !hasSnapshot ? (
+										<span
+											className="text-[10px]"
+											style={{ color: theme.colors.textDim, opacity: 0.6 }}
+											title="No snapshot yet - hit Refresh"
+										>
+											○
+										</span>
+									) : null}
+								</span>
+							</button>
+						);
+					})}
+				</div>
+			)}
+
+			{configuredAccountKeys.length === 0 ? (
+				<div
+					className="flex items-center justify-center h-24 text-sm text-center px-4"
+					style={{ color: theme.colors.textDim }}
+					data-testid="codex-plan-empty"
+				>
+					No Codex sessions configured. Create or open a Codex session to sample CODEX_HOME quota.
+				</div>
+			) : showAllAccounts ? null : effectiveSelectedKey && selectedSnapshot ? (
+				<AccountRow
+					key={effectiveSelectedKey}
+					codexHomeKey={effectiveSelectedKey}
+					snapshot={selectedSnapshot}
+					theme={theme}
+				/>
+			) : effectiveSelectedKey ? (
+				<PendingRow codexHomeKey={effectiveSelectedKey} theme={theme} />
+			) : null}
+		</div>
+	);
+});
+
+export default CodexPlanUsage;

--- a/src/renderer/components/UsageDashboard/CodexPlanUsage.tsx
+++ b/src/renderer/components/UsageDashboard/CodexPlanUsage.tsx
@@ -397,6 +397,10 @@ export const CodexPlanUsage = memo(function CodexPlanUsage({
 		}
 		setVisualBusy(false);
 	}, [refreshing, visualBusy]);
+	const handleRefreshRef = useRef(handleRefresh);
+	useEffect(() => {
+		handleRefreshRef.current = handleRefresh;
+	}, [handleRefresh]);
 
 	const autoRefreshFiredRef = useRef(false);
 	useEffect(() => {
@@ -422,16 +426,10 @@ export const CodexPlanUsage = memo(function CodexPlanUsage({
 		if (configuredAccountKeys.length === 0) return;
 		if (snapshotCount === 0) return;
 		const timer = window.setInterval(() => {
-			void handleRefresh();
+			void handleRefreshRef.current();
 		}, refreshIntervalMs);
 		return () => window.clearInterval(timer);
-	}, [
-		showRefreshButton,
-		refreshIntervalMs,
-		configuredAccountKeys.length,
-		snapshotCount,
-		handleRefresh,
-	]);
+	}, [showRefreshButton, refreshIntervalMs, configuredAccountKeys.length, snapshotCount]);
 
 	const isBusy = refreshing || visualBusy;
 	const renderAccount = useCallback(
@@ -510,7 +508,7 @@ export const CodexPlanUsage = memo(function CodexPlanUsage({
 							{isBusy ? (
 								<>
 									<span
-										className="absolute inset-0 pointer-events-none claude-plan-refresh-sweep"
+										className="absolute inset-0 pointer-events-none codex-plan-refresh-sweep"
 										style={{
 											backgroundImage: `linear-gradient(90deg, transparent 0%, ${theme.colors.bgMain}66 50%, transparent 100%)`,
 										}}

--- a/src/renderer/components/UsageDashboard/UsageDashboardModal.tsx
+++ b/src/renderer/components/UsageDashboard/UsageDashboardModal.tsx
@@ -30,6 +30,8 @@ import { DurationTrendsChart } from './DurationTrendsChart';
 import { AgentUsageChart } from './AgentUsageChart';
 import { AutoRunStats } from './AutoRunStats';
 import { SessionStats } from './SessionStats';
+import { ClaudePlanUsage } from './ClaudePlanUsage';
+import { CodexPlanUsage } from './CodexPlanUsage';
 import { WorktreeAnalytics } from './WorktreeAnalytics';
 import { AgentEfficiencyChart } from './AgentEfficiencyChart';
 import { WeekdayComparisonChart } from './WeekdayComparisonChart';
@@ -56,6 +58,8 @@ import {
 import { useModalLayer } from '../../hooks/ui/useModalLayer';
 import { MODAL_PRIORITIES } from '../../constants/modalPriorities';
 import { useSettingsStore } from '../../stores/settingsStore';
+import { useClaudeUsageStore, type ClaudeUsageSnapshot } from '../../stores/claudeUsageStore';
+import { useCodexUsageStore, type CodexUsageSnapshot } from '../../stores/codexUsageStore';
 import { useGlobalAgentStats } from '../../hooks/stats/useGlobalAgentStats';
 import { getRendererPerfMetrics, logger } from '../../utils/logger';
 import { PERFORMANCE_THRESHOLDS } from '../../../shared/performance-metrics';
@@ -81,13 +85,17 @@ const AUTORUN_SECTIONS = [
 	'tasks-by-hour',
 	'longest-autoruns',
 ] as const;
+const ANTHROPIC_USAGE_SECTIONS = ['anthropic-usage'] as const;
+const CODEX_USAGE_SECTIONS = ['codex-usage'] as const;
 
 type SectionId =
 	| (typeof OVERVIEW_SECTIONS)[number]
 	| (typeof AGENTS_SECTIONS)[number]
 	| (typeof AGENT_OVERVIEW_SECTIONS)[number]
 	| (typeof ACTIVITY_SECTIONS)[number]
-	| (typeof AUTORUN_SECTIONS)[number];
+	| (typeof AUTORUN_SECTIONS)[number]
+	| (typeof ANTHROPIC_USAGE_SECTIONS)[number]
+	| (typeof CODEX_USAGE_SECTIONS)[number];
 
 // Performance metrics instance for dashboard
 const perfMetrics = getRendererPerfMetrics('UsageDashboard');
@@ -101,6 +109,8 @@ type ViewMode =
 	| 'agent-overview'
 	| 'activity'
 	| 'autorun'
+	| 'anthropic-usage'
+	| 'codex-usage'
 	| 'cue'
 	| 'shortcuts';
 
@@ -165,6 +175,31 @@ const BASE_VIEW_MODE_TABS: { value: ViewMode; label: string }[] = [
 
 const EMPTY_SESSIONS: Session[] = [];
 
+function hasValidQuotaWindow(window: { percent: number; resetsAt?: string } | undefined): boolean {
+	if (!window) return false;
+	if (!Number.isFinite(window.percent)) return false;
+	if (window.percent < 0) return false;
+	return typeof window.resetsAt === 'string' && window.resetsAt.length > 0;
+}
+
+function hasUsefulAnthropicQuotaDetails(snapshot: ClaudeUsageSnapshot): boolean {
+	if (snapshot.authState === 'unauthenticated') return false;
+	return (
+		hasValidQuotaWindow(snapshot.session) ||
+		hasValidQuotaWindow(snapshot.weekAllModels) ||
+		hasValidQuotaWindow(snapshot.weekSonnetOnly)
+	);
+}
+
+function hasUsefulCodexQuotaDetails(snapshot: CodexUsageSnapshot): boolean {
+	if (snapshot.authState !== 'authenticated') return false;
+	return (
+		hasValidQuotaWindow(snapshot.session) ||
+		hasValidQuotaWindow(snapshot.weekly) ||
+		(snapshot.additionalLimits ?? []).some(hasValidQuotaWindow)
+	);
+}
+
 export function UsageDashboardModal({
 	isOpen,
 	onClose,
@@ -188,14 +223,32 @@ export function UsageDashboardModal({
 	// Tab visibility must match the IPC handler's gating: both Encore flags
 	// have to be on, otherwise the renderer hits a generic error/retry state
 	// instead of the friendly disabled note.
+	const usageStatsTabEnabled = useSettingsStore((s) => s.encoreFeatures.usageStats);
 	const cueTabEnabled = useSettingsStore(
 		(s) => s.encoreFeatures.maestroCue && s.encoreFeatures.usageStats
 	);
+	const claudeUsageSnapshots = useClaudeUsageStore((s) => s.snapshots);
+	const claudeUsageSnapshotsLoaded = useClaudeUsageStore((s) => s.loaded);
+	const codexUsageSnapshots = useCodexUsageStore((s) => s.snapshots);
+	const codexUsageSnapshotsLoaded = useCodexUsageStore((s) => s.loaded);
+	const hasAnthropicUsageDetails =
+		usageStatsTabEnabled &&
+		Object.values(claudeUsageSnapshots).some(hasUsefulAnthropicQuotaDetails);
+	const hasCodexUsageDetails =
+		usageStatsTabEnabled && Object.values(codexUsageSnapshots).some(hasUsefulCodexQuotaDetails);
 	const VIEW_MODE_TABS = useMemo<{ value: ViewMode; label: string }[]>(() => {
-		return cueTabEnabled
-			? [...BASE_VIEW_MODE_TABS, { value: 'cue', label: 'Cue' }]
-			: BASE_VIEW_MODE_TABS;
-	}, [cueTabEnabled]);
+		const tabs = [...BASE_VIEW_MODE_TABS];
+		if (hasAnthropicUsageDetails) {
+			tabs.push({ value: 'anthropic-usage', label: 'Anthropic Usage' });
+		}
+		if (hasCodexUsageDetails) {
+			tabs.push({ value: 'codex-usage', label: 'Codex Usage' });
+		}
+		if (cueTabEnabled) {
+			tabs.push({ value: 'cue', label: 'Cue' });
+		}
+		return tabs;
+	}, [cueTabEnabled, hasAnthropicUsageDetails, hasCodexUsageDetails]);
 
 	const [timeRange, setTimeRange] = useState<StatsTimeRange>(defaultTimeRange);
 	const [viewMode, setViewMode] = useState<ViewMode>('overview');
@@ -288,6 +341,19 @@ export function UsageDashboardModal({
 		},
 		[timeRange]
 	);
+
+	// Quota provider tabs are based on cached/sanitized snapshots only.
+	// This refreshes the renderer mirror from main without triggering provider
+	// samplers such as Claude Code's TUI-backed /usage flow.
+	useEffect(() => {
+		if (!isOpen || !usageStatsTabEnabled) return;
+		if (!claudeUsageSnapshotsLoaded) {
+			void useClaudeUsageStore.getState().refresh();
+		}
+		if (!codexUsageSnapshotsLoaded) {
+			void useCodexUsageStore.getState().refresh();
+		}
+	}, [isOpen, usageStatsTabEnabled, claudeUsageSnapshotsLoaded, codexUsageSnapshotsLoaded]);
 
 	// Initial fetch and real-time updates subscription
 	useEffect(() => {
@@ -396,7 +462,7 @@ export function UsageDashboardModal({
 		};
 	}, [containerWidth]);
 
-	// Get sections for current view mode
+	// Get sections for current view mode.
 	const currentSections = useMemo((): readonly SectionId[] => {
 		switch (viewMode) {
 			case 'overview':
@@ -409,6 +475,10 @@ export function UsageDashboardModal({
 				return ACTIVITY_SECTIONS;
 			case 'autorun':
 				return AUTORUN_SECTIONS;
+			case 'anthropic-usage':
+				return ANTHROPIC_USAGE_SECTIONS;
+			case 'codex-usage':
+				return CODEX_USAGE_SECTIONS;
 			case 'cue':
 				return [];
 			case 'shortcuts':
@@ -418,12 +488,12 @@ export function UsageDashboardModal({
 		}
 	}, [viewMode]);
 
-	// Fall back to 'overview' if either Encore flag flips off while the Cue tab is active
+	// Fall back to 'overview' if a dynamic provider/Cue tab disappears.
 	useEffect(() => {
-		if (!cueTabEnabled && viewMode === 'cue') {
+		if (!VIEW_MODE_TABS.some((tab) => tab.value === viewMode)) {
 			switchViewMode('overview');
 		}
-	}, [cueTabEnabled, viewMode, switchViewMode]);
+	}, [VIEW_MODE_TABS, viewMode, switchViewMode]);
 
 	// Get section label for accessibility
 	const getSectionLabel = useCallback((sectionId: SectionId): string => {
@@ -434,6 +504,8 @@ export function UsageDashboardModal({
 			'autorun-task-percentiles': 'Auto Run Task Duration Percentiles',
 			'agent-overview-cards': 'Active Agents Overview',
 			'session-stats': 'Agent Statistics',
+			'anthropic-usage': 'Anthropic Usage',
+			'codex-usage': 'Codex Usage',
 			'agent-efficiency': 'Agent Efficiency Chart',
 			'agent-comparison': 'Provider Comparison Chart',
 			'provider-trends': 'Provider Trends Over Time',
@@ -772,7 +844,11 @@ export function UsageDashboardModal({
 						<DashboardSkeleton
 							theme={theme}
 							viewMode={
-								viewMode === 'cue' || viewMode === 'agent-overview' || viewMode === 'shortcuts'
+								viewMode === 'cue' ||
+								viewMode === 'agent-overview' ||
+								viewMode === 'shortcuts' ||
+								viewMode === 'anthropic-usage' ||
+								viewMode === 'codex-usage'
 									? 'overview'
 									: viewMode
 							}
@@ -810,6 +886,66 @@ export function UsageDashboardModal({
 							aria-labelledby={`tab-${viewMode}`}
 						>
 							<KeyboardStats timeRange={timeRange} theme={theme} />
+						</div>
+					) : viewMode === 'anthropic-usage' ? (
+						// Quota snapshots come from provider-specific samplers, not stats.db.
+						// Keep this tab visible even when the analytics database has no AI-query rows.
+						<div
+							key={viewMode}
+							className="space-y-6 dashboard-content-enter"
+							data-testid="usage-dashboard-content"
+							role="tabpanel"
+							id={`tabpanel-${viewMode}`}
+							aria-labelledby={`tab-${viewMode}`}
+						>
+							<div
+								ref={setSectionRef('anthropic-usage')}
+								tabIndex={0}
+								role="region"
+								aria-label={getSectionLabel('anthropic-usage')}
+								onKeyDown={(e) => handleSectionKeyDown(e, 'anthropic-usage')}
+								className="outline-none rounded-lg transition-shadow dashboard-section-enter"
+								style={{
+									boxShadow:
+										focusedSection === 'anthropic-usage'
+											? `0 0 0 2px ${theme.colors.accent}`
+											: 'none',
+								}}
+								data-testid="section-anthropic-usage"
+							>
+								<ChartErrorBoundary theme={theme} chartName="Anthropic Usage">
+									<ClaudePlanUsage theme={theme} showAllAccounts autoRefresh={false} />
+								</ChartErrorBoundary>
+							</div>
+						</div>
+					) : viewMode === 'codex-usage' ? (
+						// Quota snapshots come from provider-specific samplers, not stats.db.
+						// Keep this tab visible even when the analytics database has no AI-query rows.
+						<div
+							key={viewMode}
+							className="space-y-6 dashboard-content-enter"
+							data-testid="usage-dashboard-content"
+							role="tabpanel"
+							id={`tabpanel-${viewMode}`}
+							aria-labelledby={`tab-${viewMode}`}
+						>
+							<div
+								ref={setSectionRef('codex-usage')}
+								tabIndex={0}
+								role="region"
+								aria-label={getSectionLabel('codex-usage')}
+								onKeyDown={(e) => handleSectionKeyDown(e, 'codex-usage')}
+								className="outline-none rounded-lg transition-shadow dashboard-section-enter"
+								style={{
+									boxShadow:
+										focusedSection === 'codex-usage' ? `0 0 0 2px ${theme.colors.accent}` : 'none',
+								}}
+								data-testid="section-codex-usage"
+							>
+								<ChartErrorBoundary theme={theme} chartName="Codex Usage">
+									<CodexPlanUsage theme={theme} showAllAccounts autoRefresh={false} />
+								</ChartErrorBoundary>
+							</div>
 						</div>
 					) : !data ||
 					  (data.totalQueries === 0 && data.bySource.user === 0 && data.bySource.auto === 0) ? (

--- a/src/renderer/components/UsageDashboard/index.ts
+++ b/src/renderer/components/UsageDashboard/index.ts
@@ -7,3 +7,5 @@
 
 export { UsageDashboardModal } from './UsageDashboardModal';
 export { SessionStats } from './SessionStats';
+export { ClaudePlanUsage } from './ClaudePlanUsage';
+export { CodexPlanUsage } from './CodexPlanUsage';

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -1044,13 +1044,34 @@ interface MaestroAPI {
 				{
 					sampledAt: string;
 					configDirKey: string;
+					authState?: 'authenticated' | 'unauthenticated';
 					session: { percent: number; resetsAt: string };
 					weekAllModels: { percent: number; resetsAt: string };
 					weekSonnetOnly: { percent: number; resetsAt: string };
 				}
 			>
 		>;
+		getClaudeUsageAccountKeys: () => Promise<string[]>;
+		getCodexUsageSnapshots: () => Promise<
+			Record<
+				string,
+				{
+					sampledAt: string;
+					codexHomeKey: string;
+					authState: 'authenticated' | 'missing_auth' | 'unauthenticated' | 'error';
+					label?: string;
+					email?: string;
+					planType?: string;
+					session?: { percent: number; resetsAt: string };
+					weekly?: { percent: number; resetsAt: string };
+					additionalLimits?: Array<{ name: string; percent: number; resetsAt?: string }>;
+					error?: string;
+				}
+			>
+		>;
+		getCodexUsageAccountKeys: () => Promise<string[]>;
 		refreshClaudeUsageSnapshots: () => Promise<{ refreshed: number }>;
+		refreshCodexUsageSnapshots: () => Promise<{ refreshed: number }>;
 	};
 	// Agent Sessions API - all methods accept optional sshRemoteId for SSH remote session storage access
 	agentSessions: {

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -383,7 +383,8 @@ textarea::placeholder {
 	}
 }
 
-.claude-plan-refresh-sweep {
+.claude-plan-refresh-sweep,
+.codex-plan-refresh-sweep {
 	animation: claude-plan-refresh-sweep 1.2s ease-in-out infinite;
 }
 

--- a/src/renderer/stores/claudeUsageStore.ts
+++ b/src/renderer/stores/claudeUsageStore.ts
@@ -1,5 +1,5 @@
 /**
- * claudeUsageStore — renderer-side mirror of the main-process Claude Max-plan
+ * claudeUsageStore — renderer-side mirror of the main-process Claude plan
  * usage snapshot map.
  *
  * Snapshots live on disk (electron-store namespace `claude-usage-snapshots`,

--- a/src/renderer/stores/codexUsageStore.ts
+++ b/src/renderer/stores/codexUsageStore.ts
@@ -1,0 +1,71 @@
+/**
+ * codexUsageStore — renderer-side mirror of Codex quota snapshots.
+ *
+ * Main owns the auth-sensitive sampling path. Renderer components only fetch
+ * already-sanitized quota windows through IPC.
+ */
+
+import { create } from 'zustand';
+
+export interface CodexUsageWindow {
+	percent: number;
+	resetsAt: string;
+}
+
+export interface CodexAdditionalLimit {
+	name: string;
+	percent: number;
+	resetsAt?: string;
+}
+
+export type CodexUsageAuthState = 'authenticated' | 'missing_auth' | 'unauthenticated' | 'error';
+
+export interface CodexUsageSnapshot {
+	sampledAt: string;
+	codexHomeKey: string;
+	authState: CodexUsageAuthState;
+	label?: string;
+	email?: string;
+	planType?: string;
+	session?: CodexUsageWindow;
+	weekly?: CodexUsageWindow;
+	additionalLimits?: CodexAdditionalLimit[];
+	error?: string;
+}
+
+interface CodexUsageState {
+	snapshots: Record<string, CodexUsageSnapshot>;
+	loaded: boolean;
+	refreshing: boolean;
+	setSnapshots: (next: Record<string, CodexUsageSnapshot>) => void;
+	refresh: () => Promise<void>;
+	__resetForTests: () => void;
+}
+
+const initial = {
+	snapshots: {} as Record<string, CodexUsageSnapshot>,
+	loaded: false,
+	refreshing: false,
+};
+
+export const useCodexUsageStore = create<CodexUsageState>((set, get) => ({
+	...initial,
+	setSnapshots: (next) => set({ snapshots: next, loaded: true }),
+	refresh: async () => {
+		if (get().refreshing) return;
+		set({ refreshing: true });
+		try {
+			const next = await window.maestro.agents.getCodexUsageSnapshots();
+			set({ snapshots: next ?? {}, loaded: true });
+		} catch {
+			set({ loaded: true });
+		} finally {
+			set({ refreshing: false });
+		}
+	},
+	__resetForTests: () => set({ ...initial }),
+}));
+
+export function getAllCodexUsageSnapshots(): Record<string, CodexUsageSnapshot> {
+	return useCodexUsageStore.getState().snapshots;
+}


### PR DESCRIPTION
## Summary

This PR adds provider-specific quota usage surfaces to the existing Usage Dashboard for Claude/Anthropic and Codex, without bringing back the removed generic "Claude Max Plan Usage" panel in the Overview tab.

The dashboard now behaves like a cockpit for weekly quota limits: it shows quota bars only when the Usage and Stats Encore Feature is enabled and only when Maestro has useful cached quota data for that provider.

## Why

Maestro already tracks rich usage analytics, but quota limits were not visible in a reliable, provider-specific way. The previous dashboard direction mixed quota UI into the main Overview and used provider/account naming that could be misleading.

This change moves quota monitoring into dedicated provider tabs:

- `Anthropic Usage` for Claude/Anthropic quota snapshots.
- `Codex Usage` for Codex quota snapshots.

That keeps the main analytics dashboard focused while still making quota pressure visible when the user has real quota data available.

## User-facing behavior

### Dynamic tabs

The Usage Dashboard builds the provider tabs dynamically:

- `Anthropic Usage` appears only when `encoreFeatures.usageStats` is enabled and at least one Claude/Anthropic snapshot has useful quota window data.
- `Codex Usage` appears only when `encoreFeatures.usageStats` is enabled and at least one Codex snapshot has useful quota window data.
- Empty, unauthenticated, or error-only snapshots do not create visible quota tabs.
- If a provider tab disappears while selected, the dashboard falls back to `Overview`.

This avoids showing a blank or misleading tab just because a provider exists.

### Quota panels

Both provider panels show account-level quota rows using the same visual language:

- Account selector pills.
- Horizontal usage bars.
- Reset-time labels.
- Refresh button.
- Configurable auto-refresh interval.
- Optional "show all accounts" mode used by the dashboard tabs.

The dashboard mounts provider panels with `autoRefresh={false}`. Opening the Usage Dashboard refreshes only the renderer mirror from cached main-process state; it does not automatically launch provider samplers or run expensive provider commands.

### Feature gating

The quota tabs are gated behind the existing Usage and Stats Encore Feature. If `usageStats` is off, provider snapshots can exist in stores, but the Usage Dashboard will not expose the provider quota tabs.

## Data flow

```mermaid
flowchart LR
    A[Provider auth/config files] --> B[Main process sampler]
    B --> C[Sanitized quota snapshot store]
    C --> D[IPC/preload safe bridge]
    D --> E[Renderer usage store]
    E --> F[Usage Dashboard provider tab]
```

In plain terms: main process reads sensitive provider-side files, strips the data down to safe quota metadata, and the renderer only receives sanitized snapshots.

## Codex implementation

This PR adds a Codex quota path parallel to the existing Claude/Anthropic snapshot path:

- Main process discovers Codex auth/config context.
- Main process reads `CODEX_HOME/auth.json` when available.
- Main process requests quota metadata from the ChatGPT/Codex usage endpoint.
- Main process stores sanitized Codex snapshots.
- Renderer accesses snapshots through preload/IPC only.

The renderer never reads auth files or tokens directly.

## Claude/Anthropic implementation

This PR keeps the upstream `rc` decision to remove the old "Claude Max Plan Usage" Overview panel, then adds a new provider-specific Anthropic tab instead.

It also improves account discovery so multiple local Claude config directories can be represented when useful snapshots exist, while still avoiding backup/archive/stage/local scratch directories.

## Main files changed

### Main process

- `src/main/agents/codex-usage-sampler.ts`
- `src/main/agents/codex-usage-startup.ts`
- `src/main/stores/codexUsageStore.ts`
- `src/main/agents/claude-usage-startup.ts`
- `src/main/ipc/handlers/agents.ts`
- `src/main/preload/agents.ts`

### Renderer

- `src/renderer/components/UsageDashboard/UsageDashboardModal.tsx`
- `src/renderer/components/UsageDashboard/ClaudePlanUsage.tsx`
- `src/renderer/components/UsageDashboard/CodexPlanUsage.tsx`
- `src/renderer/stores/claudeUsageStore.ts`
- `src/renderer/stores/codexUsageStore.ts`
- `src/renderer/global.d.ts`

### Tests

- `src/__tests__/main/agents/codex-usage-sampler.test.ts`
- `src/__tests__/main/ipc/handlers/agents.test.ts`
- `src/__tests__/main/preload/agents.test.ts`
- `src/__tests__/renderer/components/UsageDashboard/ClaudePlanUsage.test.tsx`
- `src/__tests__/renderer/components/UsageDashboard/CodexPlanUsage.test.tsx`
- `src/__tests__/renderer/components/UsageDashboard/UsageDashboardModal.test.tsx`

## Validation

Executed successfully after rebasing on `origin/rc`:

- `git diff --check`
- `npm run lint -- --pretty false`
- `npx vitest run src/__tests__/renderer/components/UsageDashboard/UsageDashboardModal.test.tsx src/__tests__/renderer/components/UsageDashboard/ClaudePlanUsage.test.tsx src/__tests__/renderer/components/UsageDashboard/CodexPlanUsage.test.tsx src/__tests__/main/agents/codex-usage-sampler.test.ts src/__tests__/main/ipc/handlers/agents.test.ts src/__tests__/main/preload/agents.test.ts`
  - 6 files passed
  - 142 tests passed
- `npm run build`
  - passed
  - emitted existing Vite/CSS/chunk-size warnings
- `npm run test`
  - 935 files passed
  - 1 file skipped
  - 29,562 tests passed
  - 108 tests skipped

The repository push hook also ran successfully before publishing the branch to the fork:

- `npm run format:check:all`
- `npm run lint`
- `npm run lint:eslint`
- `npm run test`

## Notes and risk

- Codex quota metadata depends on the currently available ChatGPT/Codex usage endpoint. Failures are fail-closed: empty or error-only snapshots do not create a visible dashboard tab.
- Provider secrets remain in main-process scope. Renderer receives sanitized quota snapshots only.
- This PR intentionally excludes unrelated local `olive-nights` theme work from the branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-account Codex quota view with progress bars, auth CTAs, manual/auto/periodic refresh and visual busy state.
  * Claude account auto-discovery and integrated Anthropic/Codex usage tabs in the Usage Dashboard.
  * Background snapshot caching and on-demand snapshot refresh controls.

* **Bug Fixes**
  * Charts now ignore non-finite quota values (NaN/Infinity).

* **Tests**
  * Expanded tests covering sampling, discovery, IPC wiring, stores, and dashboard UIs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RunMaestro/Maestro/pull/1039?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->