### PR TITLE
fix: resolve two rc-channel Sentry crashes (MAESTRO-Q8, MAESTRO-QA)

### DIFF
--- a/src/__tests__/main/history-manager.test.ts
+++ b/src/__tests__/main/history-manager.test.ts
@@ -26,6 +26,11 @@ vi.mock('../../main/utils/logger', () => ({
 	},
 }));
 
+// Mock Sentry so we can assert which failures are (and are not) reported.
+vi.mock('../../main/utils/sentry', () => ({
+	captureException: vi.fn(),
+}));
+
 // Mock fs module. PR-C 1.6 — history-manager now uses fs/promises, but the
 // existing assertions are written against the sync mocks. We bridge the
 // async API to the sync mocks below so the test surface stays compact:
@@ -82,6 +87,7 @@ import { logger } from '../../main/utils/logger';
 import { HistoryManager, getHistoryManager } from '../../main/history-manager';
 import { HISTORY_VERSION, MAX_ENTRIES_PER_SESSION, sanitizeSessionId } from '../../shared/history';
 import type { HistoryEntry } from '../../shared/types';
+import { captureException } from '../../main/utils/sentry';
 
 // Type the mocked fs functions
 const mockExistsSync = vi.mocked(fs.existsSync);
@@ -540,6 +546,11 @@ describe('HistoryManager', () => {
 			const result = await manager.getEntries('session-1');
 			expect(result).toEqual([]);
 			expect(vi.mocked(logger.warn)).toHaveBeenCalled();
+			// A non-JSON read failure is unexpected and should still be reported.
+			expect(vi.mocked(captureException)).toHaveBeenCalledWith(
+				expect.any(Error),
+				expect.objectContaining({ operation: 'history:read', sessionId: 'session-1' })
+			);
 		});
 
 		it('should return empty array when file contains malformed JSON', async () => {
@@ -553,6 +564,26 @@ describe('HistoryManager', () => {
 
 			const result = await manager.getEntries('session-1');
 			expect(result).toEqual([]);
+		});
+
+		it('does not report corrupt/truncated history JSON to Sentry (MAESTRO-QA)', async () => {
+			const filePath = path.join(
+				'/mock/userData',
+				'history',
+				`${sanitizeSessionId('session-1')}.json`
+			);
+			mockExistsSync.mockImplementation((p: fs.PathLike) => p.toString() === filePath);
+			// Simulate a write truncated mid-string (e.g. crash/power loss): the JSON
+			// object is opened but never terminated.
+			mockReadFileSync.mockReturnValue('{"version":1,"entries":[{"id":"e1","prompt":"hel');
+
+			const result = await manager.getEntries('session-1');
+			expect(result).toEqual([]);
+			expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
+				expect.stringContaining('corrupt JSON'),
+				expect.any(String)
+			);
+			expect(vi.mocked(captureException)).not.toHaveBeenCalled();
 		});
 	});
 

--- a/src/__tests__/main/process-manager/spawners/ChildProcessSpawner.test.ts
+++ b/src/__tests__/main/process-manager/spawners/ChildProcessSpawner.test.ts
@@ -90,6 +90,13 @@ vi.mock('../../../../main/process-manager/utils/shellEscape', () => ({
 	isPowerShellShell: vi.fn(() => false),
 }));
 
+// Default to non-Windows; individual tests opt into Windows via mockReturnValue(true).
+vi.mock('../../../../shared/platformDetection', () => ({
+	isWindows: vi.fn(() => false),
+	isMacOS: vi.fn(() => false),
+	isLinux: vi.fn(() => false),
+}));
+
 // ── Imports (after mocks) ──────────────────────────────────────────────────
 
 import { ChildProcessSpawner } from '../../../../main/process-manager/spawners/ChildProcessSpawner';
@@ -99,6 +106,7 @@ import { buildChildProcessEnv } from '../../../../main/process-manager/utils/env
 import { buildStreamJsonMessage } from '../../../../main/process-manager/utils/streamJsonBuilder';
 import { saveImageToTempFile } from '../../../../main/process-manager/utils/imageUtils';
 import { createOutputParser } from '../../../../main/parsers';
+import { isWindows } from '../../../../shared/platformDetection';
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -795,6 +803,74 @@ describe('ChildProcessSpawner', () => {
 			// Should have -f flag (uses default file-based args)
 			expect(spawnArgs).toContain('-f');
 			expect(spawnArgs).toContain('/tmp/maestro-image-0.png');
+		});
+	});
+
+	// ----------------------------------------------------------------
+	// Windows batch-file spawning (MAESTRO-Q8)
+	//
+	// Node.js throws "spawn EINVAL" when asked to spawn a .cmd/.bat file
+	// without a shell. npm-installed agent CLIs resolve to such shims on
+	// Windows, so the spawner must auto-enable shell for them.
+	// ----------------------------------------------------------------
+	describe('Windows batch-file handling (MAESTRO-Q8)', () => {
+		beforeEach(() => {
+			vi.mocked(isWindows).mockReturnValue(true);
+		});
+		afterEach(() => {
+			vi.mocked(isWindows).mockReturnValue(false);
+		});
+
+		it('auto-enables shell for a .cmd command on Windows', () => {
+			const { spawner } = createTestContext();
+
+			spawner.spawn(createBaseConfig({ command: 'claude.cmd' }));
+
+			const options = mockSpawn.mock.calls[0][2] as { shell?: boolean | string };
+			expect(options.shell).toBe(true);
+		});
+
+		it('auto-enables shell for a .bat command on Windows', () => {
+			const { spawner } = createTestContext();
+
+			spawner.spawn(createBaseConfig({ command: 'agent.bat' }));
+
+			const options = mockSpawn.mock.calls[0][2] as { shell?: boolean | string };
+			expect(options.shell).toBe(true);
+		});
+
+		it('quotes a batch-file command path that contains spaces', () => {
+			const { spawner } = createTestContext();
+			const cmdPath = 'C:\\Users\\First Last\\AppData\\Roaming\\npm\\claude.cmd';
+
+			spawner.spawn(createBaseConfig({ command: cmdPath }));
+
+			const spawnCommand = mockSpawn.mock.calls[0][0] as string;
+			const options = mockSpawn.mock.calls[0][2] as { shell?: boolean | string };
+			expect(options.shell).toBe(true);
+			expect(spawnCommand).toBe(`"${cmdPath}"`);
+		});
+
+		it('does not quote a batch-file command path without spaces', () => {
+			const { spawner } = createTestContext();
+			const cmdPath = 'C:\\npm\\claude.cmd';
+
+			spawner.spawn(createBaseConfig({ command: cmdPath }));
+
+			const spawnCommand = mockSpawn.mock.calls[0][0] as string;
+			const options = mockSpawn.mock.calls[0][2] as { shell?: boolean | string };
+			expect(options.shell).toBe(true);
+			expect(spawnCommand).toBe(cmdPath);
+		});
+
+		it('does not auto-enable shell for a .cmd command off Windows', () => {
+			vi.mocked(isWindows).mockReturnValue(false);
+			const { spawner } = createTestContext();
+
+			spawner.spawn(createBaseConfig({ command: 'claude.cmd' }));
+
+			const options = mockSpawn.mock.calls[0][2] as { shell?: boolean | string };
+			expect(options.shell).toBe(false);
 		});
 	});
 });

--- a/src/main/history-manager.ts
+++ b/src/main/history-manager.ts
@@ -277,6 +277,19 @@ export class HistoryManager {
 		} catch (error) {
 			const code = (error as NodeJS.ErrnoException).code;
 			if (code === 'ENOENT') return []; // Cold-cache miss is expected
+			// A malformed/truncated history file (e.g. a write interrupted by a crash
+			// or power loss) surfaces as a JSON SyntaxError once recovery fails. That's
+			// an expected, recoverable on-disk condition — not a code bug — so we degrade
+			// gracefully to an empty history rather than reporting it to Sentry, where it
+			// only piled up as non-actionable noise (MAESTRO-QA). Genuinely unexpected
+			// read failures (permissions, I/O, etc.) are still captured below.
+			if (error instanceof SyntaxError) {
+				logger.warn(
+					`Discarding unreadable history for session ${sessionId} (corrupt JSON): ${error}`,
+					LOG_CONTEXT
+				);
+				return [];
+			}
 			logger.warn(`Failed to read history for session ${sessionId}: ${error}`, LOG_CONTEXT);
 			captureException(error, { operation: 'history:read', sessionId });
 			return [];

--- a/src/main/process-manager/spawners/ChildProcessSpawner.ts
+++ b/src/main/process-manager/spawners/ChildProcessSpawner.ts
@@ -244,7 +244,7 @@ export class ChildProcessSpawner {
 			});
 
 			// Handle Windows shell requirements
-			const spawnCommand = command;
+			let spawnCommand = command;
 			let spawnArgs = finalArgs;
 			// Respect explicit request from caller, but also be defensive: if caller
 			// did not set runInShell and we're on Windows with a bare .exe basename,
@@ -260,6 +260,20 @@ export class ChildProcessSpawner {
 				useShell = true;
 				logger.info(
 					'[ProcessManager] Auto-enabling shell for Windows to allow PATH resolution of basename exe',
+					'ProcessManager',
+					{ command: spawnCommand }
+				);
+			}
+
+			// Auto-enable shell for Windows when command is a batch file (.cmd/.bat).
+			// Node.js refuses to spawn .cmd/.bat directly (throws "spawn EINVAL") after
+			// the CVE-2024-27980 fix — they must be launched through a shell. npm-installed
+			// agent CLIs resolve to shims like claude.cmd / codex.cmd / opencode.cmd, which
+			// is exactly what tab naming spawns on Windows. Fixes MAESTRO-Q8.
+			if (isWindows() && !useShell && (commandExt === '.cmd' || commandExt === '.bat')) {
+				useShell = true;
+				logger.info(
+					'[ProcessManager] Auto-enabling shell for Windows to spawn batch-file command',
 					'ProcessManager',
 					{ command: spawnCommand }
 				);
@@ -310,6 +324,22 @@ export class ChildProcessSpawner {
 			let spawnShell: boolean | string = !!useShell;
 			if (useShell && typeof config.shell === 'string' && config.shell.trim()) {
 				spawnShell = config.shell.trim();
+			}
+
+			// When spawning through the default Windows shell (cmd.exe via ComSpec),
+			// Node concatenates the command and args into a single command line without
+			// quoting the command itself. A command path that contains spaces — e.g. an
+			// npm shim under "C:\Users\First Last\AppData\Roaming\npm\claude.cmd" — would
+			// be split by cmd.exe and fail. Quote it defensively. We only do this for the
+			// boolean (cmd.exe) shell path; an explicit shell string carries its own
+			// quoting rules and is the caller's responsibility.
+			if (
+				isWindows() &&
+				spawnShell === true &&
+				/\s/.test(spawnCommand) &&
+				!spawnCommand.startsWith('"')
+			) {
+				spawnCommand = `"${spawnCommand}"`;
 			}
 
 			// Log spawn details


### PR DESCRIPTION
Addresses two field crashes reported on the **rc** channel (validated via the `channel: rc` / `*-RC` release tags in Sentry and by tracing the affected code).

## MAESTRO-Q8 — `Error: spawn EINVAL` (133 events, 100% Windows)
`ChildProcessSpawner` auto-enables `shell` on Windows for bare `.exe` commands and shebang scripts, but **not** for `.cmd`/`.bat`. Since Node's CVE-2024-27980 hardening, `child_process.spawn` throws `spawn EINVAL` when launching a batch file without `shell: true`. npm-installed agent CLIs resolve to shims like `claude.cmd` / `codex.cmd` / `opencode.cmd`, so **tab naming** (which spawns agents through `child_process`) failed for every affected Windows user.

**Fix:** add a `.cmd`/`.bat` auto-shell branch (mirroring the existing `.exe`/shebang branches), and quote command paths containing spaces under the default cmd.exe shell so npm shims under `C:\Users\First Last\...` resolve correctly.

## MAESTRO-QA — `SyntaxError: Unterminated string in JSON` (25 events)
`HistoryManager.getEntries` already degrades gracefully to an empty history when a session file is truncated/corrupt — but it also called `captureException` on the JSON `SyntaxError`. A history write interrupted by a crash or power loss is an **expected, recoverable** on-disk condition, not a code bug, so this only buried the Sentry dashboard in non-actionable noise.

**Fix:** treat `SyntaxError` as handled (log + return `[]`); genuinely unexpected read failures (permissions, I/O, etc.) are still reported.

## Excluded (investigated, not actionable here)
- **MAESTRO-R2** (EPIPE in `Logger.addLog`): already fixed — the console write is wrapped in try/catch ("Fixes MAESTRO-5C"); the lone event is from a stale `0.15.4-RC` build.
- **MAESTRO-NP** (WASM CSP): already fixed by `2e369c927` on rc.
- **MAESTRO-JV** (missing native bindings): native-module packaging issue, no obvious code fix.
- **MAESTRO-5A / 4Y / H1 / R1** (renderer/native crashes): no obvious code fix; memory-monitoring diagnostics already in place.

## Testing
- New unit tests in `ChildProcessSpawner.test.ts` (Windows `.cmd`/`.bat` shell + path quoting) and `history-manager.test.ts` (corrupt JSON not reported; real read errors still reported).
- `npm run lint` (all 3 tsconfigs) ✅ — `vitest` for both affected suites: 116 passed ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Session history files with corruption are now recovered gracefully
  * Batch files (.cmd/.bat) now execute reliably on Windows
  * Commands with executable paths containing spaces now work correctly on Windows

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RunMaestro/Maestro/pull/1041?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->