### PR TITLE
fix(cli): persist remove-agent + session rename before responding

### DIFF
--- a/src/renderer/hooks/remote/useAppRemoteEventListeners.ts
+++ b/src/renderer/hooks/remote/useAppRemoteEventListeners.ts
@@ -1063,6 +1063,17 @@ export function useAppRemoteEventListeners(deps: UseAppRemoteEventListenersDeps)
 			}
 			return filtered;
 		});
+
+		// Flush the removal to disk synchronously: useDebouncedPersistence
+		// runs on a 2s timer, so a CLI consumer that hits the disk-backed
+		// session store between this event and the next debounce window
+		// would otherwise read the pre-removal state. setMany is incremental
+		// and idempotent with the subsequent debounced flush.
+		try {
+			await window.maestro.sessions.setMany([], [sessionId]);
+		} catch (persistErr) {
+			logger.error('[Remote] Failed to persist session removal:', undefined, persistErr);
+		}
 	});
 
 	// Handle remote update session cwd from CLI/web. Mutates the UI-facing
@@ -1096,7 +1107,7 @@ export function useAppRemoteEventListeners(deps: UseAppRemoteEventListenersDeps)
 	});
 
 	// Handle remote rename session from web interface
-	useEventListener('maestro:remoteRenameSession', (e: Event) => {
+	useEventListener('maestro:remoteRenameSession', async (e: Event) => {
 		const { sessionId, newName, responseChannel } = (e as CustomEvent).detail;
 		const session = sessionsRef.current.find((s) => s.id === sessionId);
 		if (!session) {
@@ -1126,6 +1137,16 @@ export function useAppRemoteEventListeners(deps: UseAppRemoteEventListenersDeps)
 			}
 			return updated;
 		});
+
+		// Flush the rename to disk before signaling success: the renderer's
+		// 2s debounced persistence path would otherwise let a follow-up CLI
+		// read see the stale name. setMany merges incrementally so the next
+		// debounced flush is idempotent.
+		try {
+			await window.maestro.sessions.setMany([{ ...session, name: newName } as any], []);
+		} catch (persistErr) {
+			logger.error('[Remote] Failed to persist session rename:', undefined, persistErr);
+		}
 
 		window.maestro.process.sendRemoteRenameSessionResponse(responseChannel, true);
 	});


### PR DESCRIPTION
## Summary

Extends the synchronous `sessions:setMany` flush pattern introduced in #1014 to the two remaining CLI-driven IPC handlers that bypass the renderer's 2s debounced persistence path:

- `maestro:remoteDeleteSession` — was relying on `useDebouncedPersistence` to eventually persist the removal. A CLI `remove-agent` immediately followed by `list agents` could read the stale on-disk state until the debounce fired.
- `maestro:remoteRenameSession` — same race for the renamed name; `show agent` would see the old name for up to 2s.

Both handlers now await `window.maestro.sessions.setMany(updates, removeIds)` before signaling success. The subsequent debounced flush is idempotent (it just rewrites the same merged set), so there's no churn.

## Scope notes

The issue also called out that the web-server-factory's `setDeleteSessionCallback` is fire-and-forget (returns `true` before the renderer even sees the event), which is technically still a tiny race even with the disk flush in place. I left that pattern alone for now — the reporter rated it as low real-world impact, and the user-observable reproduction (CLI follow-up reads stale disk state) is fully closed by the renderer-side flush. Happy to follow up with a request-response refactor for the delete callback (matching rename / create / updateCwd) if desired.

Closes #1054
Refs #1013 #1014

## Test plan

- [x] `npm run lint` passes
- [x] `npx vitest run` unit tests pass (1570 in the related suites)
- [x] Pre-push full suite: 29,749 passed
- [ ] Manual smoke: start Maestro desktop, run `maestro-cli remove-agent <id>` → `list agents` immediately, confirm agent is gone
- [ ] Manual smoke: `maestro-cli session rename <id> "New Name"` → `show agent <id>` immediately, confirm new name surfaces
- [ ] Inspect `~/Library/Application Support/Maestro/maestro-sessions.json` between the CLI call and the 2s debounce window to confirm disk is up-to-date

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of session deletion and renaming operations by ensuring changes are immediately persisted to disk, preventing potential data loss if the app exits unexpectedly during these operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RunMaestro/Maestro/pull/1055?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->