### PR TITLE
build(choco): add Chocolatey package definition for Windows install

### DIFF
--- a/chocolatey/README.md
+++ b/chocolatey/README.md
@@ -1,0 +1,74 @@
+# Maestro Chocolatey package
+
+Packaging definition that lets Windows users install Maestro via
+[Chocolatey](https://chocolatey.org/):
+
+```powershell
+choco install maestro-ai
+```
+
+The package downloads the official signed NSIS installer
+(`Maestro-Setup-<version>-x64.exe`) from
+[GitHub Releases](https://github.com/RunMaestro/Maestro/releases) and installs it
+silently. The installer binary is never bundled or modified — see
+[`tools/VERIFICATION.txt`](tools/VERIFICATION.txt).
+
+> **Status:** this provides the package definition. Listing `maestro-ai` on the
+> [Chocolatey Community Repository](https://community.chocolatey.org/packages)
+> is a one-time maintainer step (requires a chocolatey.org account + API key) —
+> see [Publishing](#publishing) below.
+
+## Contents
+
+| File                            | Purpose                                                     |
+| ------------------------------- | ----------------------------------------------------------- |
+| `maestro-ai.nuspec`             | Package metadata (id, version, description, links)          |
+| `tools/chocolateyinstall.ps1`   | Downloads + verifies + silently installs the NSIS installer |
+| `tools/chocolateyuninstall.ps1` | Silently uninstalls via the registry uninstall entry        |
+| `tools/VERIFICATION.txt`        | How moderators/users verify the downloaded binary           |
+
+## Build & test locally
+
+Requires Chocolatey on a Windows machine.
+
+```powershell
+cd chocolatey
+
+# Build the .nupkg
+choco pack
+
+# Install from the local package to test
+choco install maestro-ai --source . --yes
+
+# Test uninstall
+choco uninstall maestro-ai --yes
+```
+
+## Updating for a new release
+
+1. Bump `<version>` in `maestro-ai.nuspec` to match the release.
+2. Update `$url64` and `$checksum64` in `tools/chocolateyinstall.ps1` (and the
+   matching url/checksum in `tools/VERIFICATION.txt`).
+
+Grab the checksum without downloading the 100+ MB installer using GitHub's
+published asset digest:
+
+```bash
+gh api repos/RunMaestro/Maestro/releases/tags/<tag> \
+  --jq '.assets[] | select(.name|test("Setup.*exe")) | {name, digest}'
+```
+
+The `digest` field is `sha256:<hash>`; use the `<hash>` portion.
+
+## Publishing
+
+One-time maintainer step (not done by this PR):
+
+```powershell
+choco apikey --key <YOUR_API_KEY> --source https://push.chocolatey.org/
+choco push maestro-ai.<version>.nupkg --source https://push.chocolatey.org/
+```
+
+New community packages go through Chocolatey's moderation review before they
+appear in search. After the initial listing, this can be wired into the release
+pipeline (`.github/workflows/release.yml`) to push automatically on each tag.

--- a/chocolatey/maestro-ai.nuspec
+++ b/chocolatey/maestro-ai.nuspec
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Chocolatey package definition for Maestro. See chocolatey/README.md for build/publish steps. -->
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+	<metadata>
+		<id>maestro-ai</id>
+		<!-- Keep in sync with the GitHub release pinned in tools/chocolateyinstall.ps1. -->
+		<version>0.15.4</version>
+		<packageSourceUrl>https://github.com/RunMaestro/Maestro/tree/main/chocolatey</packageSourceUrl>
+		<owners>RunMaestro</owners>
+
+		<title>Maestro</title>
+		<authors>Pedram Amini, RunMaestro</authors>
+		<projectUrl>https://runmaestro.ai</projectUrl>
+		<iconUrl>https://raw.githubusercontent.com/RunMaestro/Maestro/main/build/icon.png</iconUrl>
+		<copyright>RunMaestro</copyright>
+		<licenseUrl>https://github.com/RunMaestro/Maestro/blob/main/LICENSE</licenseUrl>
+		<requireLicenseAcceptance>false</requireLicenseAcceptance>
+		<projectSourceUrl>https://github.com/RunMaestro/Maestro</projectSourceUrl>
+		<docsUrl>https://docs.runmaestro.ai</docsUrl>
+		<bugTrackerUrl>https://github.com/RunMaestro/Maestro/issues</bugTrackerUrl>
+		<tags>maestro maestro-ai ai coding-assistant claude-code codex opencode electron developer-tools cross-platform admin</tags>
+		<summary>Maestro hones fractured attention into focused intent.</summary>
+		<description><![CDATA[
+Maestro is a keyboard-first desktop app for managing multiple AI coding assistants
+(Claude Code, OpenAI Codex, OpenCode, Factory Droid, and more) simultaneously.
+
+Each agent gets its own workspace, tabs, and configuration so you can orchestrate
+parallel AI work without losing context.
+
+### Features
+
+- Manage many AI coding agents side by side from a single window
+- Per-agent workspaces, tabs, sessions, and git worktrees
+- Auto Run, playbooks, and batch automation
+- SSH remote execution support
+- Usage dashboard and document graph
+
+This package downloads and installs the official signed Windows installer published
+on the [Maestro GitHub Releases](https://github.com/RunMaestro/Maestro/releases) page.
+
+## Notes
+
+Maestro is licensed under the GNU Affero General Public License v3.0.
+]]></description>
+		<releaseNotes>https://github.com/RunMaestro/Maestro/releases/tag/v0.15.4-RC</releaseNotes>
+	</metadata>
+	<files>
+		<file src="tools\**" target="tools" />
+	</files>
+</package>

--- a/chocolatey/tools/VERIFICATION.txt
+++ b/chocolatey/tools/VERIFICATION.txt
@@ -1,0 +1,30 @@
+VERIFICATION
+
+Verification is intended to assist the Chocolatey moderators and community in
+verifying that this package's contents are trustworthy.
+
+This package downloads the official Maestro Windows installer directly from the
+project's GitHub Releases. The binary is NOT bundled inside this package and is
+not modified or repackaged in any way.
+
+Package binary source:
+  https://github.com/RunMaestro/Maestro/releases
+
+The installer downloaded by tools/chocolateyinstall.ps1:
+  url:      https://github.com/RunMaestro/Maestro/releases/download/v0.15.4-RC/Maestro-Setup-0.15.4-RC-x64.exe
+  checksum: 38903F98B940D46E562A37A6659044AC16A6D43361304E57656A727A18123346 (SHA256)
+
+To verify the checksum yourself:
+
+  PowerShell:
+    Get-FileHash .\Maestro-Setup-0.15.4-RC-x64.exe -Algorithm SHA256
+
+  Or read GitHub's published digest for the asset (no download required):
+    gh api repos/RunMaestro/Maestro/releases/tags/v0.15.4-RC \
+      --jq '.assets[] | select(.name|test("Setup.*exe")) | .digest'
+
+The hash printed must match the checksum listed above and in
+tools/chocolateyinstall.ps1.
+
+Maestro is licensed under the GNU Affero General Public License v3.0:
+  https://github.com/RunMaestro/Maestro/blob/main/LICENSE

--- a/chocolatey/tools/chocolateyinstall.ps1
+++ b/chocolatey/tools/chocolateyinstall.ps1
@@ -1,0 +1,32 @@
+$ErrorActionPreference = 'Stop'
+
+# ---------------------------------------------------------------------------
+# To update this package for a new Maestro release:
+#   1. Bump <version> in ../maestro-ai.nuspec to the release version.
+#   2. Update $url64 below to the new Maestro-Setup-<version>-x64.exe asset.
+#   3. Update $checksum64 below. Grab it without downloading the installer via:
+#        gh api repos/RunMaestro/Maestro/releases/tags/<tag> \
+#          --jq '.assets[] | select(.name|test("Setup.*exe")) | .digest'
+#      (returns "sha256:<hash>"), or locally: Get-FileHash <installer> -Algorithm SHA256
+# ---------------------------------------------------------------------------
+
+$packageName = 'maestro-ai'
+$softwareName = 'Maestro*'
+
+# Official NSIS installer published on GitHub Releases.
+$url64      = 'https://github.com/RunMaestro/Maestro/releases/download/v0.15.4-RC/Maestro-Setup-0.15.4-RC-x64.exe'
+$checksum64 = '38903F98B940D46E562A37A6659044AC16A6D43361304E57656A727A18123346'
+
+$packageArgs = @{
+	packageName    = $packageName
+	softwareName   = $softwareName
+	fileType       = 'exe'
+	url64bit       = $url64
+	checksum64     = $checksum64
+	checksumType64 = 'sha256'
+	# electron-builder NSIS installer: '/S' performs a silent install.
+	silentArgs     = '/S'
+	validExitCodes = @(0)
+}
+
+Install-ChocolateyPackage @packageArgs

--- a/chocolatey/tools/chocolateyuninstall.ps1
+++ b/chocolatey/tools/chocolateyuninstall.ps1
@@ -1,0 +1,30 @@
+$ErrorActionPreference = 'Stop'
+
+$packageName  = 'maestro-ai'
+$softwareName = 'Maestro*'
+
+[array]$key = Get-UninstallRegistryKey -SoftwareName $softwareName
+
+if ($key.Count -eq 1) {
+	$key | ForEach-Object {
+		$packageArgs = @{
+			packageName    = $packageName
+			fileType       = 'exe'
+			# electron-builder NSIS uninstaller: '/S' performs a silent uninstall.
+			silentArgs     = '/S'
+			validExitCodes = @(0)
+			file           = "$($_.UninstallString)"
+		}
+
+		Uninstall-ChocolateyPackage @packageArgs
+	}
+}
+elseif ($key.Count -eq 0) {
+	Write-Warning "$packageName has already been uninstalled by other means."
+}
+elseif ($key.Count -gt 1) {
+	Write-Warning "$($key.Count) matches found!"
+	Write-Warning "To prevent accidental data loss, no programs will be uninstalled."
+	Write-Warning "Please alert package maintainer the following keys were matched:"
+	$key | ForEach-Object { Write-Warning "- $($_.DisplayName)" }
+}


### PR DESCRIPTION
Closes #260

## What

Adds a `chocolatey/` package definition so Windows users can install Maestro via Chocolatey:

```powershell
choco install maestro-ai
```

The package **downloads the official signed NSIS installer** (`Maestro-Setup-<version>-x64.exe`) straight from [GitHub Releases](https://github.com/RunMaestro/Maestro/releases), verifies its SHA256, and installs it silently. No binary is bundled or modified.

## Why

Per the triage on #260, `choco install` is a natural fit for Windows users who manage their machines declaratively. This implements steps 1–2 of that plan (nuspec + install/uninstall scripts).

## Files

| File | Purpose |
| --- | --- |
| `chocolatey/maestro-ai.nuspec` | Package metadata (id `maestro-ai`, pinned to v0.15.4) |
| `chocolatey/tools/chocolateyinstall.ps1` | Download + checksum-verify + silent install |
| `chocolatey/tools/chocolateyuninstall.ps1` | Silent uninstall via the registry uninstall entry |
| `chocolatey/tools/VERIFICATION.txt` | How moderators/users verify the downloaded binary |
| `chocolatey/README.md` | Build, test, version-bump, and publish instructions |

The pinned checksum (`38903F98…123346`) matches GitHub's published digest for `Maestro-Setup-0.15.4-RC-x64.exe`, so the package is ready to `choco pack` / `choco install -s .` and test on a Windows box.

## Not in this PR (maintainer steps)

- **Submitting to the [Chocolatey Community Repository](https://community.chocolatey.org/packages)** — one-time, requires a chocolatey.org account + API key (`choco push`), then moderation review.
- **CI automation** — once listed, the version bump + push can be wired into `release.yml` to publish on each tag. The README documents how.

## Test notes

- `maestro-ai.nuspec` validated as well-formed XML.
- PowerShell scripts use the standard Chocolatey helper template (`Install-ChocolateyPackage`, `Get-UninstallRegistryKey`, `Uninstall-ChocolateyPackage`); full `choco pack` + install test requires a Windows runner.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Maestro is now available for installation via Chocolatey on Windows systems.

* **Documentation**
  * Added comprehensive Chocolatey package documentation and verification procedures for security.
  * Included installation and uninstallation configuration guides for the Windows package manager.

* **Chores**
  * Added Chocolatey package metadata and automation scripts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RunMaestro/Maestro/pull/1056?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->