### PR TITLE
fix(history): resume cross-project sessions & find Codex sessions by payload.id

### DIFF
--- a/src/__tests__/integration/HistoryPanel.integration.test.tsx
+++ b/src/__tests__/integration/HistoryPanel.integration.test.tsx
@@ -324,7 +324,7 @@ describe('HistoryPanel integration', () => {
 
 		expect(await screen.findByText('Auto fixed build')).toBeInTheDocument();
 		fireEvent.click(screen.getByRole('button', { name: /Build Agent/i }));
-		expect(onOpenSessionAsTab).toHaveBeenCalledWith('auto-session-001');
+		expect(onOpenSessionAsTab).toHaveBeenCalledWith('auto-session-001', '/repo/project');
 		expect(
 			screen.queryByText('Detailed auto response with task evidence.')
 		).not.toBeInTheDocument();

--- a/src/__tests__/main/storage/codex-session-storage.test.ts
+++ b/src/__tests__/main/storage/codex-session-storage.test.ts
@@ -863,6 +863,35 @@ describe('CodexSessionStorage', () => {
 		});
 	});
 
+	it('finds the session file by session_meta payload.id when the filename UUID differs', async () => {
+		// Codex output reports the thread id, but the rollout filename can carry a
+		// different UUID. The stored session_meta records the real id under
+		// payload.id, so resume must match against it (issue #251, Repro B).
+		const threadId = 'tttttttt-tttt-tttt-tttt-tttttttttttt';
+		const filenameUuid = 'ffffffff-ffff-ffff-ffff-ffffffffffff';
+		const mismatchedFile = path.join(
+			sessionsDir,
+			'2026',
+			'05',
+			'11',
+			`rollout-20260511_181818_000-${filenameUuid}.jsonl`
+		);
+		setupLocalSessionTree({
+			[mismatchedFile]: jsonl(
+				sessionMeta(threadId, projectPath),
+				message('user', 'Find me by payload id'),
+				message('assistant', 'Resumed via payload id')
+			),
+		});
+
+		const result = await storage.readSessionMessages(projectPath, threadId);
+
+		expect(result.messages.map((message) => message.content)).toEqual([
+			'Find me by payload id',
+			'Resumed via payload id',
+		]);
+	});
+
 	it('reads local messages across Codex JSONL formats with pagination', async () => {
 		setupLocalSessionTree({
 			[sessionFilePath]: jsonl(

--- a/src/__tests__/renderer/components/History/HistoryEntryItem.test.tsx
+++ b/src/__tests__/renderer/components/History/HistoryEntryItem.test.tsx
@@ -304,7 +304,7 @@ describe('HistoryEntryItem', () => {
 		const sessionButton = screen.getByTitle('session-abc-123');
 		fireEvent.click(sessionButton);
 
-		expect(onOpenSessionAsTab).toHaveBeenCalledWith('session-abc-123');
+		expect(onOpenSessionAsTab).toHaveBeenCalledWith('session-abc-123', '/test/project');
 	});
 
 	it('shows elapsed time when present', () => {

--- a/src/__tests__/renderer/components/HistoryPanel.test.tsx
+++ b/src/__tests__/renderer/components/HistoryPanel.test.tsx
@@ -1388,7 +1388,7 @@ describe('HistoryPanel', () => {
 
 			fireEvent.click(screen.getByText('ABC12345'));
 
-			expect(onOpenSessionAsTab).toHaveBeenCalledWith('abc12345-def-789');
+			expect(onOpenSessionAsTab).toHaveBeenCalledWith('abc12345-def-789', '/test/project');
 		});
 
 		it('should render summary with truncation', async () => {

--- a/src/__tests__/renderer/hooks/useAgentSessionManagement.test.ts
+++ b/src/__tests__/renderer/hooks/useAgentSessionManagement.test.ts
@@ -481,6 +481,86 @@ describe('useAgentSessionManagement', () => {
 		expect(updatedSession.inputMode).toBe('ai');
 	});
 
+	it('reads cross-project history sessions from the provided project path', async () => {
+		// The active session lives in /test/project, but the history entry being
+		// resumed belongs to a different local project. The stored session must be
+		// read from that project's path, not the active session's root (issue #251).
+		const activeSession = createMockSession({ projectRoot: '/test/project' });
+		const setSessions = vi.fn();
+
+		window.maestro.agentSessions.read = vi.fn().mockResolvedValue({
+			messages: [
+				{ type: 'user', content: 'Hello', timestamp: '2024-01-01T00:00:00.000Z', uuid: 'msg-1' },
+			],
+			total: 1,
+			hasMore: false,
+		});
+		window.maestro.claude.getSessionOrigins = vi.fn().mockResolvedValue({});
+
+		const { result } = renderHook(() =>
+			useAgentSessionManagement({
+				activeSession,
+				setSessions,
+				setActiveAgentSessionId: vi.fn(),
+				setAgentSessionsOpen: vi.fn(),
+				rightPanelRef: createRightPanelRef(),
+				defaultSaveToHistory: true,
+			})
+		);
+
+		await act(async () => {
+			await result.current.handleResumeSession(
+				'agent-cross-project',
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				'/other/project'
+			);
+		});
+
+		expect(window.maestro.agentSessions.read).toHaveBeenCalledWith(
+			'claude-code',
+			'/other/project',
+			'agent-cross-project',
+			{ offset: 0, limit: 100 }
+		);
+		expect(window.maestro.claude.getSessionOrigins).toHaveBeenCalledWith('/other/project');
+	});
+
+	it('falls back to the active project root when no project path is provided', async () => {
+		const activeSession = createMockSession({ projectRoot: '/test/project' });
+		const setSessions = vi.fn();
+
+		window.maestro.agentSessions.read = vi.fn().mockResolvedValue({
+			messages: [],
+			total: 0,
+			hasMore: false,
+		});
+
+		const { result } = renderHook(() =>
+			useAgentSessionManagement({
+				activeSession,
+				setSessions,
+				setActiveAgentSessionId: vi.fn(),
+				setAgentSessionsOpen: vi.fn(),
+				rightPanelRef: createRightPanelRef(),
+				defaultSaveToHistory: true,
+			})
+		);
+
+		await act(async () => {
+			await result.current.handleResumeSession('agent-same-project');
+		});
+
+		expect(window.maestro.agentSessions.read).toHaveBeenCalledWith(
+			'claude-code',
+			'/test/project',
+			'agent-same-project',
+			{ offset: 0, limit: 100 }
+		);
+	});
+
 	it('uses Claude defaults and message fallbacks for sessions without a tool type', async () => {
 		const activeSession = createMockSession({
 			projectRoot: '/test/project',

--- a/src/__tests__/renderer/hooks/useRightPanelProps.test.ts
+++ b/src/__tests__/renderer/hooks/useRightPanelProps.test.ts
@@ -63,6 +63,7 @@ describe('useRightPanelProps', () => {
 		result.current.setActiveRightTab('files');
 		result.current.onAutoRunCreateDocument('plan.md');
 		result.current.onOpenSessionAsTab('agent-session-1');
+		result.current.onOpenSessionAsTab('agent-session-2', '/other/project');
 		result.current.onFocusFileInGraph('docs/plan.md');
 
 		expect(result.current.theme).toBe(deps.theme);
@@ -70,7 +71,24 @@ describe('useRightPanelProps', () => {
 		expect(result.current.onAutoRunCreateDocument).toBe(handleAutoRunCreateDocument);
 		expect(handleSetActiveRightTab).toHaveBeenCalledWith('files');
 		expect(handleAutoRunCreateDocument).toHaveBeenCalledWith('plan.md');
-		expect(handleResumeSession).toHaveBeenCalledWith('agent-session-1');
+		// onOpenSessionAsTab forwards the (optional) project path to handleResumeSession's
+		// trailing parameter so cross-project history entries read from the right storage.
+		expect(handleResumeSession).toHaveBeenCalledWith(
+			'agent-session-1',
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined
+		);
+		expect(handleResumeSession).toHaveBeenCalledWith(
+			'agent-session-2',
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			'/other/project'
+		);
 		expect(handleFocusFileInGraph).toHaveBeenCalledWith('docs/plan.md');
 	});
 

--- a/src/main/storage/codex-session-storage.ts
+++ b/src/main/storage/codex-session-storage.ts
@@ -1202,13 +1202,16 @@ export class CodexSessionStorage extends BaseSessionStorage {
 				return filePath;
 			}
 
-			// Also check by reading first line for session ID
+			// Also check by reading first line for session ID.
+			// New format stores the id under payload.id (session_meta); legacy format
+			// uses a top-level id. Match either so resume works when the session's
+			// thread id differs from the rollout filename UUID.
 			try {
 				const content = await fs.readFile(filePath, 'utf-8');
 				const firstLine = content.split('\n')[0];
 				if (firstLine) {
 					const metadata = JSON.parse(firstLine) as CodexSessionMetadata;
-					if (metadata.id === sessionId) {
+					if (metadata.payload?.id === sessionId || metadata.id === sessionId) {
 						return filePath;
 					}
 				}
@@ -1235,14 +1238,17 @@ export class CodexSessionStorage extends BaseSessionStorage {
 				return filePath;
 			}
 
-			// Also check by reading first line for session ID
+			// Also check by reading first line for session ID.
+			// New format stores the id under payload.id (session_meta); legacy format
+			// uses a top-level id. Match either so resume works when the session's
+			// thread id differs from the rollout filename UUID.
 			try {
 				const result = await readFileRemote(filePath, sshConfig);
 				if (result.success && result.data) {
 					const firstLine = result.data.split('\n')[0];
 					if (firstLine) {
 						const metadata = JSON.parse(firstLine) as CodexSessionMetadata;
-						if (metadata.id === sessionId) {
+						if (metadata.payload?.id === sessionId || metadata.id === sessionId) {
 							return filePath;
 						}
 					}

--- a/src/renderer/components/History/HistoryEntryItem.tsx
+++ b/src/renderer/components/History/HistoryEntryItem.tsx
@@ -56,7 +56,7 @@ export interface HistoryEntryItemProps {
 	isSelected: boolean;
 	theme: Theme;
 	onOpenDetailModal: (entry: HistoryEntry, index: number) => void;
-	onOpenSessionAsTab?: (agentSessionId: string) => void;
+	onOpenSessionAsTab?: (agentSessionId: string, projectPath?: string) => void;
 	onOpenAboutModal?: () => void;
 	/** When true, displays the agentName field prominently in the entry header (used in unified history view) */
 	showAgentName?: boolean;
@@ -109,7 +109,7 @@ export const HistoryEntryItem = memo(function HistoryEntryItem({
 						<button
 							onClick={(e) => {
 								e.stopPropagation();
-								onOpenSessionAsTab?.(entry.agentSessionId!);
+								onOpenSessionAsTab?.(entry.agentSessionId!, entry.projectPath);
 							}}
 							className={`flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-bold transition-colors hover:opacity-80 min-w-0 flex-shrink ${entry.sessionName ? '' : 'font-mono uppercase'}`}
 							style={{

--- a/src/renderer/components/HistoryDetailModal.tsx
+++ b/src/renderer/components/HistoryDetailModal.tsx
@@ -35,7 +35,7 @@ interface HistoryDetailModalProps {
 	entry: HistoryEntry;
 	onClose: () => void;
 	onJumpToAgentSession?: (agentSessionId: string) => void;
-	onResumeSession?: (agentSessionId: string) => void;
+	onResumeSession?: (agentSessionId: string, projectPath?: string) => void;
 	onDelete?: (entryId: string) => void;
 	onUpdate?: (entryId: string, updates: { validated?: boolean }) => Promise<boolean>;
 	// Navigation props for prev/next
@@ -339,7 +339,7 @@ export function HistoryDetailModal({
 									{onResumeSession && (
 										<button
 											onClick={() => {
-												onResumeSession(entry.agentSessionId!);
+												onResumeSession(entry.agentSessionId!, entry.projectPath);
 												onClose();
 											}}
 											className="flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-bold uppercase transition-colors hover:opacity-80"

--- a/src/renderer/components/HistoryPanel.tsx
+++ b/src/renderer/components/HistoryPanel.tsx
@@ -27,8 +27,8 @@ interface HistoryPanelProps {
 	session: Session;
 	theme: Theme;
 	onJumpToAgentSession?: (agentSessionId: string) => void;
-	onResumeSession?: (agentSessionId: string) => void;
-	onOpenSessionAsTab?: (agentSessionId: string) => void;
+	onResumeSession?: (agentSessionId: string, projectPath?: string) => void;
+	onOpenSessionAsTab?: (agentSessionId: string, projectPath?: string) => void;
 	onOpenAboutModal?: () => void; // For opening About/achievements panel from history entries
 	// File linking props for history detail modal
 	fileTree?: any[];

--- a/src/renderer/components/RightPanel.tsx
+++ b/src/renderer/components/RightPanel.tsx
@@ -98,8 +98,8 @@ interface RightPanelProps {
 	onAbortBatchOnError?: () => void;
 	onResumeAfterError?: () => void;
 	onJumpToAgentSession?: (agentSessionId: string) => void;
-	onResumeSession?: (agentSessionId: string) => void;
-	onOpenSessionAsTab?: (agentSessionId: string) => void;
+	onResumeSession?: (agentSessionId: string, projectPath?: string) => void;
+	onOpenSessionAsTab?: (agentSessionId: string, projectPath?: string) => void;
 
 	// Modal handlers
 	onOpenAboutModal?: () => void;

--- a/src/renderer/hooks/agent/useAgentSessionManagement.ts
+++ b/src/renderer/hooks/agent/useAgentSessionManagement.ts
@@ -62,7 +62,8 @@ export interface UseAgentSessionManagementReturn {
 		providedMessages?: LogEntry[],
 		sessionName?: string,
 		starred?: boolean,
-		usageStats?: UsageStats
+		usageStats?: UsageStats,
+		projectPath?: string
 	) => Promise<void>;
 }
 
@@ -165,10 +166,18 @@ export function useAgentSessionManagement(
 			providedMessages?: LogEntry[],
 			sessionName?: string,
 			starred?: boolean,
-			usageStats?: UsageStats
+			usageStats?: UsageStats,
+			projectPath?: string
 		) => {
 			// Use projectRoot (not cwd) for consistent session storage access
 			if (!activeSession?.projectRoot) return;
+
+			// History entries can reference sessions stored in a *different* local
+			// project than the active one. When the caller knows the originating
+			// project path, read the stored session from there; otherwise fall back
+			// to the active session's root. Reading from the wrong path throws (or
+			// returns nothing), which is the root cause of the AgentSessions read error.
+			const readProjectPath = projectPath ?? activeSession.projectRoot;
 
 			// Check if a tab with this agentSessionId already exists
 			const existingTab = activeSession.aiTabs?.find(
@@ -194,11 +203,12 @@ export function useAgentSessionManagement(
 					messages = providedMessages;
 				} else {
 					// Load the session messages using the generic agentSessions API
-					// Use projectRoot (not cwd) for consistent session storage access
+					// Use the resolved project path so cross-project history entries
+					// read from their own storage location instead of the active one.
 					const agentId = activeSession.toolType || 'claude-code';
 					const result = await window.maestro.agentSessions.read(
 						agentId,
-						activeSession.projectRoot,
+						readProjectPath,
 						agentSessionId,
 						{ offset: 0, limit: 100 }
 					);
@@ -225,10 +235,8 @@ export function useAgentSessionManagement(
 					try {
 						// Look up session metadata from session origins (name, starred, contextUsage)
 						// Note: getSessionOrigins is still Claude-specific until we add generic origin tracking
-						// Use projectRoot (not cwd) for consistent session storage access
-						const origins = await window.maestro.claude.getSessionOrigins(
-							activeSession.projectRoot
-						);
+						// Use the resolved project path to match the project the session was stored under.
+						const origins = await window.maestro.claude.getSessionOrigins(readProjectPath);
 						const originData = origins[agentSessionId];
 						if (originData && typeof originData === 'object') {
 							if (sessionName === undefined && originData.sessionName) {

--- a/src/renderer/hooks/props/useRightPanelProps.ts
+++ b/src/renderer/hooks/props/useRightPanelProps.ts
@@ -8,7 +8,14 @@
  */
 
 import { useMemo } from 'react';
-import type { Session, Theme, RightPanelTab, BatchRunState } from '../../types';
+import type {
+	Session,
+	Theme,
+	RightPanelTab,
+	BatchRunState,
+	LogEntry,
+	UsageStats,
+} from '../../types';
 import type { FileTreeChanges } from '../../utils/fileExplorer';
 
 /**
@@ -73,7 +80,14 @@ export interface UseRightPanelPropsDeps {
 	handleAbortBatchOnError: () => void;
 	handleResumeAfterError: () => void;
 	handleJumpToAgentSession: (agentSessionId: string) => void;
-	handleResumeSession: (agentSessionId: string) => void;
+	handleResumeSession: (
+		agentSessionId: string,
+		providedMessages?: LogEntry[],
+		sessionName?: string,
+		starred?: boolean,
+		usageStats?: UsageStats,
+		projectPath?: string
+	) => void;
 
 	// Modal handlers
 	handleOpenAboutModal: () => void;
@@ -133,8 +147,27 @@ export function useRightPanelProps(deps: UseRightPanelPropsDeps) {
 			onAbortBatchOnError: deps.handleAbortBatchOnError,
 			onResumeAfterError: deps.handleResumeAfterError,
 			onJumpToAgentSession: deps.handleJumpToAgentSession,
-			onResumeSession: deps.handleResumeSession,
-			onOpenSessionAsTab: deps.handleResumeSession,
+			// History entries can belong to a different local project than the active
+			// session, so forward the entry's project path to handleResumeSession (its
+			// trailing parameter) and let it read the stored session from there.
+			onResumeSession: (agentSessionId: string, projectPath?: string) =>
+				deps.handleResumeSession(
+					agentSessionId,
+					undefined,
+					undefined,
+					undefined,
+					undefined,
+					projectPath
+				),
+			onOpenSessionAsTab: (agentSessionId: string, projectPath?: string) =>
+				deps.handleResumeSession(
+					agentSessionId,
+					undefined,
+					undefined,
+					undefined,
+					undefined,
+					projectPath
+				),
 
 			// Modal handlers
 			onOpenAboutModal: deps.handleOpenAboutModal,


### PR DESCRIPTION
Closes #251

## Problem

Two distinct bugs in History → "Open session … as new tab":

**Repro A (local Claude Code):** Resuming a history entry that belongs to a *different local project* than the active session failed with `[AgentSessions] read error` and no tab opened. `handleResumeSession` always read the stored session from `activeSession.projectRoot`, so a cross-project entry pointed at the wrong storage path.

**Repro B (local Codex):** Resuming a Codex history entry opened an *empty* tab. `findSessionFile()` only matched the rollout filename UUID or the legacy top-level `metadata.id`, but new-format Codex sessions record their id under `session_meta` → `payload.id`. When the session's thread id differed from the filename UUID, the file was never found and the read returned no messages.

## Fix

**Repro A** — Thread the history entry's `projectPath` from the click site down to the reader:
`HistoryEntryItem` / `HistoryDetailModal` → `HistoryPanel` → `RightPanel` → `useRightPanelProps` → `handleResumeSession`. The resolved path (`projectPath ?? activeSession.projectRoot`) is now used for both `agentSessions.read` and the Claude `getSessionOrigins` lookup. Both resume affordances (the session pill and the detail-modal **Resume** button) are covered.

**Repro B** — `findSessionFile()` (and `findSessionFileRemote()` for SSH) now also match `metadata.payload?.id`, consistent with how the rest of `codex-session-storage.ts` already extracts session IDs (`metadata?.payload?.id || metadata?.id`).

### Notes
- The "Extra" suggestion about the `{}` in the error log is already addressed on current `main`: `withIpcErrorLogging` runs the error through `serializeError`, which extracts `name`/`message`/`stack` for `Error` instances. The bare `{}` was from the 0.14.5 reported build.
- SSH-remote history resume still falls back to local behavior — `HistoryEntry` does not currently persist an `sshRemoteId`, so threading that is out of scope here and would need a data-model change.

## Tests
- `useAgentSessionManagement`: reads a cross-project session from the provided `projectPath`; falls back to the active project root when none is provided.
- `useRightPanelProps`: `onOpenSessionAsTab` forwards the project path to `handleResumeSession`'s trailing parameter.
- `codex-session-storage`: finds a session by `session_meta` `payload.id` when the filename UUID differs.
- Updated existing `onOpenSessionAsTab` call-signature assertions in `HistoryEntryItem` / `HistoryPanel` (unit + integration).

All affected unit + integration tests pass locally; ESLint and Prettier clean on changed files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved session lookup to correctly match sessions when file metadata differs from filename identifiers

* **New Features**
  * Added support for resuming and opening sessions across different projects by preserving project context during session navigation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RunMaestro/Maestro/pull/1058?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->