### PR TITLE
fix(cli): capture copilot-cli sessionId from result events

### DIFF
--- a/src/__tests__/cli/services/agent-spawner.test.ts
+++ b/src/__tests__/cli/services/agent-spawner.test.ts
@@ -1457,21 +1457,20 @@ Some text with [x] in it that's not a checkbox
 			// promptArgs path replaces the '--' separator
 			expect(args).not.toContain('--');
 
-			// Emit a session.start init event
-			mockStdout.emit(
-				'data',
-				Buffer.from(JSON.stringify({ type: 'session.start', data: { sessionId: 'cop-1' } }) + '\n')
-			);
-			// Emit a final assistant.message (no toolRequests + non-empty content → result)
+			// Mirror real Copilot CLI batch-mode stdout: no session.start event;
+			// the sessionId arrives only on the terminal `result` line.
 			mockStdout.emit(
 				'data',
 				Buffer.from(
 					JSON.stringify({
 						type: 'assistant.message',
-						sessionId: 'cop-1',
 						data: { content: 'Final answer from copilot', toolRequests: [] },
 					}) + '\n'
 				)
+			);
+			mockStdout.emit(
+				'data',
+				Buffer.from(JSON.stringify({ type: 'result', sessionId: 'cop-1', exitCode: 0 }) + '\n')
 			);
 			await new Promise((resolve) => setTimeout(resolve, 0));
 			mockChild.emit('close', 0);
@@ -1480,6 +1479,39 @@ Some text with [x] in it that's not a checkbox
 			expect(result.success).toBe(true);
 			expect(result.response).toBe('Final answer from copilot');
 			expect(result.agentSessionId).toBe('cop-1');
+		});
+
+		it('should pass through --resume=<sessionId> when resuming a copilot-cli session', async () => {
+			const resultPromise = spawnAgent('copilot-cli', '/project', 'follow-up', 'cop-resume-1');
+			await new Promise((resolve) => setTimeout(resolve, 0));
+
+			const [, args] = mockSpawn.mock.calls[0];
+			// resumeArgs in the agent definition emits `--resume=<id>` as a single token.
+			expect(args).toContain('--resume=cop-resume-1');
+
+			mockStdout.emit(
+				'data',
+				Buffer.from(
+					JSON.stringify({
+						type: 'assistant.message',
+						data: { content: 'still remembers', toolRequests: [] },
+					}) + '\n'
+				)
+			);
+			mockStdout.emit(
+				'data',
+				Buffer.from(
+					JSON.stringify({ type: 'result', sessionId: 'cop-resume-1', exitCode: 0 }) + '\n'
+				)
+			);
+			await new Promise((resolve) => setTimeout(resolve, 0));
+			mockChild.emit('close', 0);
+
+			const result = await resultPromise;
+			expect(result.success).toBe(true);
+			// The resumed session id must round-trip through agentSessionId so the
+			// caller can persist it and keep the chain going.
+			expect(result.agentSessionId).toBe('cop-resume-1');
 		});
 
 		it('should let a pre-set CLAUDE_CODE_DISABLE_BACKGROUND_TASKS from shell env win', async () => {

--- a/src/cli/services/agent-spawner.ts
+++ b/src/cli/services/agent-spawner.ts
@@ -808,8 +808,16 @@ async function spawnJsonLineAgent(
 		const processEvent = (event: ReturnType<typeof parser.parseJsonLine>) => {
 			if (!event) return;
 
-			if (event.type === 'init' && event.sessionId && !sessionId) {
-				sessionId = event.sessionId;
+			// Route through parser.extractSessionId() rather than only checking
+			// init events. Some agents (e.g. copilot-cli batch mode) never emit
+			// a session.start on stdout — the sessionId arrives only on the
+			// final `result` event. extractSessionId() encapsulates each
+			// adapter's event shape, and the !sessionId guard keeps
+			// "first-wins" semantics for adapters (codex, opencode) that
+			// already populate sessionId on multiple event types.
+			if (!sessionId) {
+				const extracted = parser.extractSessionId(event);
+				if (extracted) sessionId = extracted;
 			}
 
 			if (event.type === 'result' && event.text) {


### PR DESCRIPTION
## Summary

`maestro-cli send <agent-id> -- <message>` against a `copilot-cli` agent always returned `SendResult.sessionId: null`, so callers that thread `--session <id>` for multi-turn continuity (e.g. the Maestro Relay's Discord bridge) lost context after every turn. Same code path works fine for `claude-code` and `codex`.

## Root cause

Copilot CLI's batch JSON output (`copilot --allow-all --output-format json -p`) does **not** emit a `session.start` event on stdout — verified against `copilot 1.0.56`. The sessionId arrives only on the terminal line:

```json
{"type":"result","timestamp":"...","sessionId":"5fa70e6e-...","exitCode":0,"usage":{...}}
```

The agent definition (`resumeArgs: --resume=<id>`) and the parser (`session.start` → `init`, `result` → carries `sessionId`) are both correct. The break was in the CLI's generic JSON-line spawn loop (`src/cli/services/agent-spawner.ts:processEvent`), which only captured sessionId when `event.type === 'init'` — so for copilot-cli, `sessionId` stayed `undefined`, `AgentResult.agentSessionId` was `undefined`, and `SendResult.sessionId` serialized as `null`.

Verified upstream `copilot --resume=<id>` works as expected: replaying the captured sessionId recalls prior context.

## Fix

Route the capture through `parser.extractSessionId(event)` rather than matching `init` directly. Each adapter already implements `extractSessionId()` with the correct event-shape semantics:

- **copilot-cli** falls back to `raw.sessionId` / `raw.data.sessionId`, so the terminal `result` event is now picked up.
- **codex** returns `event.sessionId` populated from its `session_meta` / `thread.started` init events — unchanged.
- **opencode** populates `event.sessionId` on most event types — first-wins via the `!sessionId` guard, unchanged.
- **factory-droid** likewise unchanged.

claude-code uses its own `spawnClaudeAgent` and is not on this path.

## Test plan

- [x] `npx vitest run src/__tests__/cli/services/agent-spawner.test.ts` — 123/123 pass
- [x] `npx vitest run src/__tests__/main/parsers/copilot-output-parser.test.ts` — 20/20 pass
- [x] Updated the existing copilot-cli spawner test to mirror real CLI output (no `session.start`, sessionId on the final `result`)
- [x] Added a regression test that asserts `--resume=<id>` is forwarded and that the resumed id round-trips through `agentSessionId`
- [x] Prettier clean on modified files
- [x] No new TS errors on modified files (the pre-existing shiki / @xterm / remark-math / semver errors on rc are untouched)
- [x] Live repro on `copilot 1.0.56`: send → captures id from `result` → `--resume=<id>` → agent recalls prior word

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated compatibility with revised Copilot CLI event sequence handling.
  * Improved session ID extraction logic to support identification from multiple event types.

* **Tests**
  * Added test coverage for session resumption functionality with resume token forwarding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->