### PR TITLE
fix(window): prevent main window from restoring off-screen

### DIFF
--- a/src/__tests__/main/app-lifecycle/window-manager.test.ts
+++ b/src/__tests__/main/app-lifecycle/window-manager.test.ts
@@ -45,6 +45,7 @@ const mockWindowInstance = {
 	setFullScreen: vi.fn(),
 	isMaximized: vi.fn().mockReturnValue(false),
 	isFullScreen: vi.fn().mockReturnValue(false),
+	isMinimized: vi.fn().mockReturnValue(false),
 	getBounds: vi.fn().mockReturnValue({ x: 100, y: 100, width: 1200, height: 800 }),
 	webContents: mockWebContents,
 	on: vi.fn((event: string, handler: () => void) => {
@@ -63,6 +64,7 @@ class MockBrowserWindow {
 	setFullScreen = mockWindowInstance.setFullScreen;
 	isMaximized = mockWindowInstance.isMaximized;
 	isFullScreen = mockWindowInstance.isFullScreen;
+	isMinimized = mockWindowInstance.isMinimized;
 	getBounds = mockWindowInstance.getBounds;
 	webContents = mockWindowInstance.webContents;
 	on = mockWindowInstance.on;
@@ -79,6 +81,12 @@ vi.mock('electron', () => ({
 	BrowserWindow: MockBrowserWindow,
 	ipcMain: {
 		handle: (...args: unknown[]) => mockHandle(...args),
+	},
+	Menu: {
+		buildFromTemplate: vi.fn(() => ({ popup: vi.fn() })),
+	},
+	screen: {
+		getAllDisplays: () => [{ workArea: { x: 0, y: 0, width: 1920, height: 1080 } }],
 	},
 }));
 
@@ -142,6 +150,7 @@ describe('app-lifecycle/window-manager', () => {
 		// Reset mock implementations
 		mockWindowInstance.isMaximized.mockReturnValue(false);
 		mockWindowInstance.isFullScreen.mockReturnValue(false);
+		mockWindowInstance.isMinimized.mockReturnValue(false);
 		mockWindowInstance.getBounds.mockReturnValue({ x: 100, y: 100, width: 1200, height: 800 });
 		mockWebContents.getType.mockReturnValue('window');
 		mockGuestWebContents.getType.mockReturnValue('webview');
@@ -216,6 +225,92 @@ describe('app-lifecycle/window-manager', () => {
 				sandbox: true,
 				webviewTag: true,
 			});
+		});
+
+		it('restores on-screen saved coordinates as-is', async () => {
+			const { createWindowManager } = await import('../../../main/app-lifecycle/window-manager');
+
+			const windowManager = createWindowManager({
+				windowStateStore: mockWindowStateStore as unknown as Parameters<
+					typeof createWindowManager
+				>[0]['windowStateStore'],
+				isDevelopment: false,
+				preloadPath: '/path/to/preload.js',
+				rendererProductionUrl: 'app://app/index.html',
+				devServerUrl: 'http://localhost:5173',
+				useNativeTitleBar: false,
+				autoHideMenuBar: false,
+			});
+
+			windowManager.createWindow();
+
+			expect(lastBrowserWindowOptions?.x).toBe(50);
+			expect(lastBrowserWindowOptions?.y).toBe(50);
+		});
+
+		it('drops off-screen saved coordinates so the window spawns centered', async () => {
+			// -32000,-32000 is what Windows reports for a minimized window. If it
+			// ever lands in the store it must not be restored verbatim.
+			mockWindowStateStore.store = {
+				x: -32000,
+				y: -32000,
+				width: 1000,
+				height: 600,
+				isMaximized: false,
+				isFullScreen: false,
+			};
+
+			const { createWindowManager } = await import('../../../main/app-lifecycle/window-manager');
+
+			const windowManager = createWindowManager({
+				windowStateStore: mockWindowStateStore as unknown as Parameters<
+					typeof createWindowManager
+				>[0]['windowStateStore'],
+				isDevelopment: false,
+				preloadPath: '/path/to/preload.js',
+				rendererProductionUrl: 'app://app/index.html',
+				devServerUrl: 'http://localhost:5173',
+				useNativeTitleBar: false,
+				autoHideMenuBar: false,
+			});
+
+			windowManager.createWindow();
+
+			expect(lastBrowserWindowOptions?.x).toBeUndefined();
+			expect(lastBrowserWindowOptions?.y).toBeUndefined();
+		});
+
+		it('does not persist bounds while the window is minimized', async () => {
+			const { createWindowManager } = await import('../../../main/app-lifecycle/window-manager');
+
+			const windowManager = createWindowManager({
+				windowStateStore: mockWindowStateStore as unknown as Parameters<
+					typeof createWindowManager
+				>[0]['windowStateStore'],
+				isDevelopment: false,
+				preloadPath: '/path/to/preload.js',
+				rendererProductionUrl: 'app://app/index.html',
+				devServerUrl: 'http://localhost:5173',
+				useNativeTitleBar: false,
+				autoHideMenuBar: false,
+			});
+
+			windowManager.createWindow();
+
+			mockWindowInstance.isMinimized.mockReturnValue(true);
+			mockWindowInstance.getBounds.mockReturnValue({
+				x: -32000,
+				y: -32000,
+				width: 1000,
+				height: 600,
+			});
+
+			windowCloseHandler?.();
+
+			const setKeys = mockWindowStateStore.set.mock.calls.map((call: unknown[]) => call[0]);
+			expect(setKeys).not.toContain('x');
+			expect(setKeys).not.toContain('y');
+			expect(setKeys).toContain('isMaximized');
 		});
 
 		it('blocks unsafe webview attachments that use disallowed partitions or URLs', async () => {

--- a/src/__tests__/main/app-lifecycle/window-manager.test.ts
+++ b/src/__tests__/main/app-lifecycle/window-manager.test.ts
@@ -310,6 +310,8 @@ describe('app-lifecycle/window-manager', () => {
 			const setKeys = mockWindowStateStore.set.mock.calls.map((call: unknown[]) => call[0]);
 			expect(setKeys).not.toContain('x');
 			expect(setKeys).not.toContain('y');
+			expect(setKeys).not.toContain('width');
+			expect(setKeys).not.toContain('height');
 			expect(setKeys).toContain('isMaximized');
 		});
 

--- a/src/main/app-lifecycle/window-manager.ts
+++ b/src/main/app-lifecycle/window-manager.ts
@@ -152,7 +152,8 @@ function resolveVisibleWindowPosition(state: WindowState): { x?: number; y?: num
 	// work area of some display, with a bottom margin so the title bar can't sit
 	// below the screen edge where it can't be grabbed.
 	const BOTTOM_MARGIN = 80;
-	const titleBar = { x: state.x + state.width / 2, y: state.y + 16 };
+	const TITLE_BAR_SAMPLE_Y = 16; // approximate title-bar height (px)
+	const titleBar = { x: state.x + state.width / 2, y: state.y + TITLE_BAR_SAMPLE_Y };
 
 	const isOnScreen = screen.getAllDisplays().some((display) => {
 		const { x, y, width, height } = display.workArea;

--- a/src/main/app-lifecycle/window-manager.ts
+++ b/src/main/app-lifecycle/window-manager.ts
@@ -3,7 +3,7 @@
  * Handles window state persistence, DevTools, crash detection, and auto-updater initialization.
  */
 
-import { BrowserWindow, Menu, ipcMain } from 'electron';
+import { BrowserWindow, Menu, ipcMain, screen } from 'electron';
 import type Store from 'electron-store';
 import type { WindowState } from '../stores/types';
 import { logger } from '../utils/logger';
@@ -135,6 +135,38 @@ async function reportCrashToSentry(
 	}
 }
 
+/**
+ * Resolves the window position to use, dropping saved coordinates that would
+ * place the window off every visible display. Windows reports bounds of
+ * (-32000, -32000) for a minimized window, and unplugging a monitor leaves
+ * stale coordinates pointing at a display that no longer exists. In both cases
+ * the restored window is invisible. When the saved position is unusable we
+ * return undefined x/y so Electron centers the window on the primary display.
+ */
+function resolveVisibleWindowPosition(state: WindowState): { x?: number; y?: number } {
+	if (typeof state.x !== 'number' || typeof state.y !== 'number') {
+		return {};
+	}
+
+	// The window is reachable if the center of its title bar lands inside the
+	// work area of some display, with a bottom margin so the title bar can't sit
+	// below the screen edge where it can't be grabbed.
+	const BOTTOM_MARGIN = 80;
+	const titleBar = { x: state.x + state.width / 2, y: state.y + 16 };
+
+	const isOnScreen = screen.getAllDisplays().some((display) => {
+		const { x, y, width, height } = display.workArea;
+		return (
+			titleBar.x >= x &&
+			titleBar.x <= x + width &&
+			titleBar.y >= y &&
+			titleBar.y <= y + height - BOTTOM_MARGIN
+		);
+	});
+
+	return isOnScreen ? { x: state.x, y: state.y } : {};
+}
+
 /** Dependencies for window manager */
 export interface WindowManagerDependencies {
 	/** Store for window state persistence */
@@ -185,12 +217,15 @@ export function createWindowManager(deps: WindowManagerDependencies): WindowMana
 
 	return {
 		createWindow: (): BrowserWindow => {
-			// Restore saved window state
+			// Restore saved window state, discarding off-screen coordinates so the
+			// window can never spawn invisible (saved while minimized -> -32000 on
+			// Windows, or on an unplugged monitor); fall back to a centered window.
 			const savedState = windowStateStore.store;
+			const position = resolveVisibleWindowPosition(savedState);
 
 			const mainWindow = new BrowserWindow({
-				x: savedState.x,
-				y: savedState.y,
+				x: position.x,
+				y: position.y,
 				width: savedState.width,
 				height: savedState.height,
 				minWidth: 1000,
@@ -228,10 +263,13 @@ export function createWindowManager(deps: WindowManagerDependencies): WindowMana
 				try {
 					const isMaximized = mainWindow.isMaximized();
 					const isFullScreen = mainWindow.isFullScreen();
+					const isMinimized = mainWindow.isMinimized();
 					const bounds = mainWindow.getBounds();
 
-					// Only save bounds if not maximized/fullscreen (to restore proper size later)
-					if (!isMaximized && !isFullScreen) {
+					// Only save bounds when the window is in its normal state. While
+					// minimized, Windows reports bounds of (-32000, -32000), which would
+					// otherwise persist and make the window spawn off-screen next launch.
+					if (!isMaximized && !isFullScreen && !isMinimized) {
 						windowStateStore.set('x', bounds.x);
 						windowStateStore.set('y', bounds.y);
 						windowStateStore.set('width', bounds.width);


### PR DESCRIPTION
## Problem

On Windows, launching the app could spawn the main window invisibly: it shows on the taskbar but nothing is on screen.

Root cause is window-state restoration. A minimized window on Windows reports bounds of (-32000, -32000). The window manager saved those bounds on close and restored them verbatim on the next launch, with no check that the coordinates land on a visible display. The result is a window positioned far off-screen. The same thing happens when a monitor that held the window gets unplugged and the saved coordinates point at a display that no longer exists.

## Fix

- Add `resolveVisibleWindowPosition()`. Before creating the window, it checks whether the saved title-bar position falls inside any connected display's work area. If not, it drops the saved x/y and lets Electron center the window on the primary display.
- Stop `saveWindowState()` from persisting bounds while the window is minimized, so the -32000 sentinel never gets written in the first place. It already skipped maximized/fullscreen; minimized is the same kind of non-normal state.

## Tests

Added coverage in `window-manager.test.ts` (electron mock now provides `screen` and `isMinimized`):

- on-screen saved coordinates are restored as-is
- off-screen saved coordinates are dropped so the window spawns centered
- bounds are not persisted while the window is minimized

All window-manager tests pass. Repo-wide type check and ESLint are clean.

## Manual recovery

For anyone already stuck with an invisible window, deleting or resetting `maestro-window-state.json` in the app's userData directory brings it back. This change prevents it from recurring.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Windows restore to saved positions when valid; otherwise they open centered to avoid off-screen placement.
  * Window bounds are no longer saved while the window is minimized, preventing restoration to invalid coordinates.

* **Tests**
  * Added tests covering coordinate restoration behavior, off-screen handling, and ensuring minimized windows do not persist invalid bounds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->