### PR TITLE
fix(renderer): guard window.maestro accesses in useAppInitialization

### DIFF
--- a/src/renderer/hooks/ui/useAppInitialization.ts
+++ b/src/renderer/hooks/ui/useAppInitialization.ts
@@ -116,9 +116,9 @@ export function useAppInitialization(): AppInitializationReturn {
 
 	// --- GitHub CLI availability check ---
 	useEffect(() => {
-		window.maestro.git
-			.checkGhCli()
-			.then((status) => {
+		window.maestro?.git
+			?.checkGhCli()
+			?.then((status) => {
 				setGhCliAvailable(status.installed && status.authenticated);
 			})
 			.catch(() => {
@@ -136,9 +136,9 @@ export function useAppInitialization(): AppInitializationReturn {
 		if (suppressWindowsWarning) return;
 		if (windowsWarningShownRef.current) return;
 
-		window.maestro.power
-			.getStatus()
-			.then((status) => {
+		window.maestro?.power
+			?.getStatus()
+			?.then((status) => {
 				if (status.platform === 'win32') {
 					windowsWarningShownRef.current = true;
 					setWindowsWarningModalOpen(true);
@@ -151,9 +151,9 @@ export function useAppInitialization(): AppInitializationReturn {
 
 	// --- Load file gist URLs from settings ---
 	useEffect(() => {
-		window.maestro.settings
-			.get('fileGistUrls')
-			.then((savedUrls) => {
+		window.maestro?.settings
+			?.get('fileGistUrls')
+			?.then((savedUrls) => {
 				if (savedUrls && typeof savedUrls === 'object') {
 					useTabStore.getState().setFileGistUrls(savedUrls as Record<string, GistInfo>);
 				}
@@ -168,13 +168,13 @@ export function useAppInitialization(): AppInitializationReturn {
 		const { fileGistUrls: current } = useTabStore.getState();
 		const updated = { ...current, [filePath]: gistInfo };
 		useTabStore.getState().setFileGistUrls(updated);
-		window.maestro.settings.set('fileGistUrls', updated);
+		window.maestro?.settings?.set?.('fileGistUrls', updated);
 	}, []);
 
 	// --- Sync beta updates setting to electron-updater ---
 	useEffect(() => {
 		if (settingsLoaded) {
-			window.maestro.updates.setAllowPrerelease(enableBetaUpdates);
+			window.maestro?.updates?.setAllowPrerelease?.(enableBetaUpdates);
 		}
 	}, [settingsLoaded, enableBetaUpdates]);
 
@@ -184,6 +184,7 @@ export function useAppInitialization(): AppInitializationReturn {
 
 		const runCheck = async () => {
 			try {
+				if (!window.maestro?.updates?.check) return;
 				const result = await window.maestro.updates.check(enableBetaUpdates);
 				if (result.updateAvailable && !result.error) {
 					getModalActions().setUpdateCheckModalOpen(true);
@@ -215,6 +216,7 @@ export function useAppInitialization(): AppInitializationReturn {
 
 		const timer = setTimeout(async () => {
 			try {
+				if (!window.maestro?.leaderboard?.sync) return;
 				const result = await window.maestro.leaderboard.sync({ email, authToken });
 
 				if (result.success && result.found && result.data) {


### PR DESCRIPTION
## Summary

Fixes the loading-screen error: `Error: Cannot read properties of undefined (reading 'git')` shown beneath the splash progress bar.

## Root cause

`useAppInitialization.ts` had several `useEffect` hooks that accessed `window.maestro.*` directly (e.g. `window.maestro.git.checkGhCli()`, `window.maestro.power.getStatus()`, `window.maestro.settings.get(...)`, `window.maestro.updates.setAllowPrerelease(...)`, `window.maestro.updates.check(...)`, `window.maestro.leaderboard.sync(...)`).

If the preload contextBridge had not finished wiring up `window.maestro` by the time React mounted, the renderer would throw, and `splash.js` would render the error text on the splash screen — preventing the app from ever loading.

## Fix

Apply optional chaining (`?.`) to all `window.maestro` accesses inside `useAppInitialization.ts` so the app tolerates a brief window where the preload contextBridge has not yet exposed the API. The previous design assumed a strict ordering that is not always honored at startup.

## Verification

- 730/730 test files pass, 28 521/28 521 tests pass (`npm test`)
- `npm run format:check:all` → clean
- `npm run lint` → clean

## Files changed

- `src/renderer/hooks/ui/useAppInitialization.ts` (13 insertions, 11 deletions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app initialization to gracefully handle unavailable or missing system APIs and dependencies throughout the startup process. The application now prevents crashes when certain features are not accessible, ensuring stable and reliable operation across different environments, system configurations, and various setups without affecting core functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->