### PR TITLE
fix(codex): render reasoning summaries from both CLI output shapes

### DIFF
--- a/src/__tests__/main/parsers/codex-output-parser.test.ts
+++ b/src/__tests__/main/parsers/codex-output-parser.test.ts
@@ -1238,13 +1238,62 @@ describe('CodexOutputParser', () => {
 		});
 
 		describe('reasoning type', () => {
-			it('should parse reasoning as system event', () => {
+			it('should parse string[] summary as partial text with isReasoning', () => {
 				const line = JSON.stringify({
 					type: 'response_item',
 					payload: {
 						type: 'reasoning',
 						summary: ['step 1', 'step 2'],
 						encrypted_content: 'base64data...',
+					},
+				});
+
+				const event = parser.parseJsonLine(line);
+				expect(event?.type).toBe('text');
+				expect(event?.isPartial).toBe(true);
+				expect(event?.isReasoning).toBe(true);
+				expect(event?.text).toBe('step 1\nstep 2');
+			});
+
+			it('should parse summary_text object array (Responses API shape) as partial text', () => {
+				const line = JSON.stringify({
+					type: 'response_item',
+					payload: {
+						type: 'reasoning',
+						summary: [
+							{ type: 'summary_text', text: '**Thinking**\nfirst step' },
+							{ type: 'summary_text', text: 'second step' },
+						],
+					},
+				});
+
+				const event = parser.parseJsonLine(line);
+				expect(event?.type).toBe('text');
+				expect(event?.isPartial).toBe(true);
+				expect(event?.isReasoning).toBe(true);
+				// formatReasoningText adds \n\n before **section** markers for readability
+				expect(event?.text).toBe('\n\n**Thinking**\nfirst step\nsecond step');
+			});
+
+			it('should fall back to system event when only encrypted_content is present', () => {
+				const line = JSON.stringify({
+					type: 'response_item',
+					payload: {
+						type: 'reasoning',
+						encrypted_content: 'base64data...',
+					},
+				});
+
+				const event = parser.parseJsonLine(line);
+				expect(event?.type).toBe('system');
+			});
+
+			it('should fall back to system event when summary contains only blank strings', () => {
+				const line = JSON.stringify({
+					type: 'response_item',
+					payload: {
+						type: 'reasoning',
+						summary: ['   ', ''],
 					},
 				});
 

--- a/src/main/parsers/codex-output-parser.ts
+++ b/src/main/parsers/codex-output-parser.ts
@@ -257,6 +257,34 @@ function extractErrorText(error: CodexRawMessage['error'], fallback = 'Unknown e
 }
 
 /**
+ * Extract the human-readable reasoning text from a `response_item` reasoning payload.
+ *
+ * Codex emits `summary` in two shapes depending on the CLI version:
+ *  - string[]                                                       (older app-server)
+ *  - Array<{ type: 'summary_text'; text: string }>                  (newer Responses API)
+ *
+ * If `summary` is absent, empty, or only contains blank strings, returns '' so the
+ * caller can fall back to a non-displayable `system` event (encrypted_content only).
+ */
+function extractReasoningSummaryText(summary: unknown): string {
+	if (!Array.isArray(summary) || summary.length === 0) {
+		return '';
+	}
+	const parts: string[] = [];
+	for (const entry of summary) {
+		if (typeof entry === 'string') {
+			if (entry.trim()) parts.push(entry);
+		} else if (entry && typeof entry === 'object') {
+			const obj = entry as { type?: unknown; text?: unknown };
+			if (obj.type === 'summary_text' && typeof obj.text === 'string' && obj.text.trim()) {
+				parts.push(obj.text);
+			}
+		}
+	}
+	return parts.join('\n').trim();
+}
+
+/**
  * Codex CLI Output Parser Implementation
  *
  * Transforms Codex's JSON format into normalized ParsedEvents.
@@ -531,9 +559,24 @@ export class CodexOutputParser implements AgentOutputParser {
 			};
 		}
 
-		// reasoning: model's thinking process (may be encrypted/empty)
+		// reasoning: model's thinking process.
+		// Codex emits reasoning in two shapes depending on version:
+		//   - summary: string[]                              (older app-server shape)
+		//   - summary: Array<{ type: 'summary_text', text }> (newer Responses API shape)
+		// If only `encrypted_content` is present (no plain-text summary), there is
+		// nothing to show, so fall through to a system event so the line is preserved
+		// in the raw buffer for debugging.
 		if (payload.type === 'reasoning') {
-			// Reasoning content may be encrypted; emit summary if available
+			const summaryText = extractReasoningSummaryText(payload.summary);
+			if (summaryText) {
+				return {
+					type: 'text',
+					text: this.formatReasoningText(summaryText),
+					isPartial: true,
+					isReasoning: true,
+					raw: msg,
+				};
+			}
 			return {
 				type: 'system',
 				raw: msg,


### PR DESCRIPTION
@-

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced parser handling of reasoning content from Codex responses with support for multiple data formats and structures.
* Improved event streaming for reasoning summaries with proper text formatting and robust fallback behavior when content is unavailable, encrypted, or blank.
* Better compatibility with both legacy and modern reasoning data formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->