### PR TITLE
feat(left-bar): setting to show full vs abbreviated group label on bookmarked agents

### DIFF
--- a/src/renderer/components/SessionItem.tsx
+++ b/src/renderer/components/SessionItem.tsx
@@ -177,6 +177,7 @@ export const SessionItem = memo(function SessionItem({
 	const showLeftPanelStartupCommandIndicator = useSettingsStore(
 		(s) => s.showLeftPanelStartupCommandIndicator
 	);
+	const showFullGroupLabelInBookmarks = useSettingsStore((s) => s.showFullGroupLabelInBookmarks);
 	const maestroCueEnabled = useSettingsStore((s) => s.encoreFeatures.maestroCue);
 	const colorBlindMode = useSettingsStore((s) => s.colorBlindMode);
 	const cueIndicatorVisible = maestroCueEnabled && showLeftPanelCueIndicator;
@@ -378,14 +379,18 @@ export const SessionItem = memo(function SessionItem({
 
 			{/* Right side: Indicators and actions */}
 			<div className="flex items-center gap-2 ml-2">
-				{/* Group badge (only in bookmark variant when session belongs to a group) */}
+				{/* Group badge (only in bookmark variant when session belongs to a group).
+				    Abbreviated by default; the showFullGroupLabelInBookmarks setting swaps in
+				    the full group name, truncated with the complete value available on hover. */}
 				{variant === 'bookmark' && group && (
 					<span
-						className="text-[9px] px-1 py-0.5 rounded"
+						className={`text-[9px] px-1 py-0.5 rounded${
+							showFullGroupLabelInBookmarks ? ' max-w-[140px] truncate' : ''
+						}`}
 						style={{ backgroundColor: theme.colors.bgActivity, color: theme.colors.textDim }}
 						title={group.name}
 					>
-						{abbreviateGroupName(group.name)}
+						{showFullGroupLabelInBookmarks ? group.name : abbreviateGroupName(group.name)}
 					</span>
 				)}
 				{/* Git Dirty Indicator (only in wide mode) - placed before GIT/LOCAL for vertical alignment */}

--- a/src/renderer/components/Settings/searchableSettings.ts
+++ b/src/renderer/components/Settings/searchableSettings.ts
@@ -607,7 +607,7 @@ export const DISPLAY_SETTINGS: SearchableSetting[] = [
 		tabLabel: 'Display',
 		label: 'Left Side Panel',
 		description:
-			'Configure the left side bar: group member counts, collapsed pills per row, location pills, git change indicator, Cue indicator, and worktree badges',
+			'Configure the left side bar: group member counts, collapsed pills per row, location pills, git change indicator, Cue indicator, worktree badges, and full vs abbreviated group labels on bookmarked agents',
 		keywords: [
 			'left',
 			'side',
@@ -653,6 +653,16 @@ export const DISPLAY_SETTINGS: SearchableSetting[] = [
 			'branch name',
 			'agent list',
 			'session list',
+			'bookmark',
+			'bookmarks',
+			'bookmarked',
+			'full',
+			'full name',
+			'full label',
+			'abbreviated',
+			'abbreviation',
+			'tag',
+			'label',
 		],
 	},
 	{

--- a/src/renderer/components/Settings/tabs/DisplayTab.tsx
+++ b/src/renderer/components/Settings/tabs/DisplayTab.tsx
@@ -125,6 +125,8 @@ export function DisplayTab({ theme }: DisplayTabProps) {
 		setShowLeftPanelCueIndicator,
 		showLeftPanelStartupCommandIndicator,
 		setShowLeftPanelStartupCommandIndicator,
+		showFullGroupLabelInBookmarks,
+		setShowFullGroupLabelInBookmarks,
 		fileEditWordWrap,
 		setFileEditWordWrap,
 		fileEditShowLineNumbers,
@@ -753,6 +755,43 @@ export function DisplayTab({ theme }: DisplayTabProps) {
 							<span
 								className={`absolute left-0 top-0.5 w-4 h-4 rounded-full bg-white transition-transform ${
 									showLeftPanelStartupCommandIndicator ? 'translate-x-5' : 'translate-x-0.5'
+								}`}
+							/>
+						</button>
+					</div>
+
+					{/* Show full group label on bookmarked agents */}
+					<div
+						className="flex items-center justify-between pt-3 border-t"
+						style={{ borderColor: theme.colors.border }}
+					>
+						<div>
+							<p className="text-sm" style={{ color: theme.colors.textMain }}>
+								Show full group label on bookmarked agents
+							</p>
+							<p className="text-xs opacity-50 mt-0.5">
+								Display the full group name (e.g.{' '}
+								<span className="font-mono">[2] CASE/CONTENT-SYSTEM</span>) instead of the
+								abbreviated badge (e.g. <span className="font-mono">CCS</span>) next to bookmarked
+								agents. Long names are truncated with the full value on hover.
+							</p>
+						</div>
+						<button
+							onClick={() => setShowFullGroupLabelInBookmarks(!showFullGroupLabelInBookmarks)}
+							className="relative w-10 h-5 rounded-full transition-colors flex-shrink-0 outline-none"
+							tabIndex={0}
+							style={{
+								backgroundColor: showFullGroupLabelInBookmarks
+									? theme.colors.accent
+									: theme.colors.bgActivity,
+							}}
+							role="switch"
+							aria-checked={showFullGroupLabelInBookmarks}
+							aria-label="Show full group label on bookmarked agents in left side bar"
+						>
+							<span
+								className={`absolute left-0 top-0.5 w-4 h-4 rounded-full bg-white transition-transform ${
+									showFullGroupLabelInBookmarks ? 'translate-x-5' : 'translate-x-0.5'
 								}`}
 							/>
 						</button>

--- a/src/renderer/hooks/settings/useSettings.ts
+++ b/src/renderer/hooks/settings/useSettings.ts
@@ -418,6 +418,8 @@ export interface UseSettingsReturn {
 	setShowLeftPanelCueIndicator: (value: boolean) => void;
 	showLeftPanelStartupCommandIndicator: boolean;
 	setShowLeftPanelStartupCommandIndicator: (value: boolean) => void;
+	showFullGroupLabelInBookmarks: boolean;
+	setShowFullGroupLabelInBookmarks: (value: boolean) => void;
 
 	// File Edit & Preview
 	fileEditWordWrap: boolean;

--- a/src/renderer/stores/settingsStore.ts
+++ b/src/renderer/stores/settingsStore.ts
@@ -421,6 +421,7 @@ export interface SettingsStoreState {
 	showLeftPanelGitIndicator: boolean;
 	showLeftPanelCueIndicator: boolean;
 	showLeftPanelStartupCommandIndicator: boolean;
+	showFullGroupLabelInBookmarks: boolean;
 	// File Edit & Preview
 	fileEditWordWrap: boolean;
 	fileEditShowLineNumbers: boolean;
@@ -560,6 +561,7 @@ export interface SettingsStoreActions {
 	setShowLeftPanelGitIndicator: (value: boolean) => void;
 	setShowLeftPanelCueIndicator: (value: boolean) => void;
 	setShowLeftPanelStartupCommandIndicator: (value: boolean) => void;
+	setShowFullGroupLabelInBookmarks: (value: boolean) => void;
 	setFileEditWordWrap: (value: boolean) => void;
 	setFileEditShowLineNumbers: (value: boolean) => void;
 	setFilePreviewToolbarButtonVisibility: (button: FilePreviewToolbarButton, value: boolean) => void;
@@ -778,6 +780,7 @@ export const useSettingsStore = create<SettingsStore>()((set, get) => {
 		showLeftPanelGitIndicator: true,
 		showLeftPanelCueIndicator: true,
 		showLeftPanelStartupCommandIndicator: true,
+		showFullGroupLabelInBookmarks: false,
 		fileEditWordWrap: true,
 		fileEditShowLineNumbers: true,
 		filePreviewToolbarVisibility: { ...DEFAULT_FILE_PREVIEW_TOOLBAR_VISIBILITY },
@@ -1458,6 +1461,11 @@ export const useSettingsStore = create<SettingsStore>()((set, get) => {
 		setShowLeftPanelStartupCommandIndicator: (value) => {
 			set({ showLeftPanelStartupCommandIndicator: value });
 			window.maestro.settings.set('showLeftPanelStartupCommandIndicator', value);
+		},
+
+		setShowFullGroupLabelInBookmarks: (value) => {
+			set({ showFullGroupLabelInBookmarks: value });
+			window.maestro.settings.set('showFullGroupLabelInBookmarks', value);
 		},
 
 		setFileEditWordWrap: (value) => {
@@ -2761,6 +2769,9 @@ export async function loadAllSettings(): Promise<void> {
 			patch.showLeftPanelStartupCommandIndicator = allSettings[
 				'showLeftPanelStartupCommandIndicator'
 			] as boolean;
+
+		if (allSettings['showFullGroupLabelInBookmarks'] !== undefined)
+			patch.showFullGroupLabelInBookmarks = allSettings['showFullGroupLabelInBookmarks'] as boolean;
 
 		if (allSettings['fileEditWordWrap'] !== undefined)
 			patch.fileEditWordWrap = allSettings['fileEditWordWrap'] as boolean;

--- a/src/shared/settingsMetadata.ts
+++ b/src/shared/settingsMetadata.ts
@@ -213,6 +213,13 @@ export const SETTINGS_METADATA: Record<string, SettingMetadata> = {
 		default: true,
 		category: 'appearance',
 	},
+	showFullGroupLabelInBookmarks: {
+		description:
+			'Show the full group name (e.g. "[2] CASE/CONTENT-SYSTEM") instead of the abbreviated badge (e.g. "CCS") next to bookmarked agents in the left side bar. Long names are truncated with the complete value available on hover.',
+		type: 'boolean',
+		default: false,
+		category: 'appearance',
+	},
 	fileEditWordWrap: {
 		description:
 			'Wrap long lines in the file editor at whitespace boundaries instead of scrolling horizontally.',


### PR DESCRIPTION
## Summary

Adds a **Settings → Display → Left Side Panel** toggle, **"Show full group label on bookmarked agents"** (`showFullGroupLabelInBookmarks`), letting users choose whether the group badge next to bookmarked agents in the Left Bar shows the abbreviated form or the full group name.

- **Off (default):** current behavior - abbreviated badge (e.g. `CCS`).
- **On:** full group name (e.g. `[2] CASE/CONTENT-SYSTEM`), truncated with the complete value available on hover.

The default is off, so existing users see no change unless they opt in.

## Motivation

When managing dozens of groups, the abbreviation can be ambiguous and hard to recognize at a glance (it's unclear what "CCS" stands for without expanding context). This gives users who organize groups with descriptive names the option to see the full label.

## Changes

- `src/shared/settingsMetadata.ts` - new `showFullGroupLabelInBookmarks` boolean metadata (default `false`, `appearance`).
- `src/renderer/stores/settingsStore.ts` - state field, default, setter (persists via `window.maestro.settings.set`), and load wiring.
- `src/renderer/hooks/settings/useSettings.ts` - getter/setter on the hook interface.
- `src/renderer/components/Settings/tabs/DisplayTab.tsx` - the toggle UI under Left Side Panel.
- `src/renderer/components/Settings/searchableSettings.ts` - keywords/description so the toggle is discoverable in settings search.
- `src/renderer/components/SessionItem.tsx` - the bookmark group badge renders the full name when enabled; `max-w-[140px] truncate` keeps long names from blowing out the row, and the existing `title={group.name}` provides the full value on hover.

## Testing

- `npm run lint` (tsc, all three configs) - clean
- ESLint + Prettier on changed files - clean
- `vitest run` on Settings, SessionItem, and formatters suites - 494 passed (includes the `searchableSettings` registry/DOM parity test and `DisplayTab` test)

## Note on branch target

Targets `rc` (this repo's RC line), consistent with the related bug fix #1020. Because it doesn't target the default branch, GitHub won't auto-close the issue on merge - the linked issue will need a manual close, same as #1017.

Closes #1082


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new display setting "Show full group label on bookmarked agents" that lets users toggle between displaying full or abbreviated group names on bookmarked agents. When enabled, full group names display with truncation and hover tooltip support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->