### PR TITLE
fix(chat): open URL on cmd-click (metaKey) not just ctrl-click

### DIFF
--- a/src/__tests__/renderer/components/MarkdownRenderer.test.tsx
+++ b/src/__tests__/renderer/components/MarkdownRenderer.test.tsx
@@ -50,6 +50,18 @@ const mockMaestro = {
 };
 Object.defineProperty(window, 'maestro', { value: mockMaestro, writable: true });
 
+// Mock openUrl so link-click tests can assert the exact options passed through
+// (specifically the translated `ctrlKey` modifier) without depending on the
+// settings store's useSystemBrowser default or whether an active session
+// exists. See bug #1060: cmd-click (metaKey) on macOS must translate to the
+// same ctrlKey:true inversion as ctrl-click.
+const { mockOpenUrl } = vi.hoisted(() => ({ mockOpenUrl: vi.fn() }));
+vi.mock('../../../renderer/utils/openUrl', () => ({
+	openUrl: mockOpenUrl,
+	openInSystemBrowser: vi.fn(),
+	openInMaestroBrowser: vi.fn(),
+}));
+
 // Mock fileExplorerStore for FileContextMenu's Document Graph action
 vi.mock('../../../renderer/stores/fileExplorerStore', () => ({
 	useFileExplorerStore: {
@@ -364,12 +376,12 @@ describe('MarkdownRenderer', () => {
 			expect(link!.getAttribute('href')).toBe('https://example.com');
 		});
 
-		it('opens external links via shell.openExternal', () => {
-			mockMaestro.shell.openExternal.mockClear();
+		it('opens external links via openUrl', () => {
+			mockOpenUrl.mockClear();
 			const { container } = renderMd('[Link](https://example.com)');
 			const link = container.querySelector('a');
 			fireEvent.click(link!);
-			expect(mockMaestro.shell.openExternal).toHaveBeenCalledWith('https://example.com');
+			expect(mockOpenUrl).toHaveBeenCalledWith('https://example.com', { ctrlKey: false });
 		});
 
 		it('renders link with inline code in label', () => {
@@ -1411,6 +1423,40 @@ describe('MarkdownRenderer', () => {
 			);
 			expect(container.querySelector('.katex')).toBeNull();
 			expect(container.textContent).toContain('$$not math$$');
+		});
+	});
+
+	// ========================================================================
+	// Cmd/Ctrl-click modifier handling (#1060)
+	// ========================================================================
+	describe('cmd/ctrl-click URL opening (#1060)', () => {
+		// openUrl inverts the default browser choice when ctrlKey is true. On
+		// macOS a Cmd+click sets metaKey (not ctrlKey), so the link handler must
+		// translate `metaKey || ctrlKey` into the ctrlKey option. Otherwise the
+		// modifier is silently dropped on macOS and the URL opens in the wrong
+		// target.
+		it('passes ctrlKey:true when Cmd (metaKey) is held', () => {
+			mockOpenUrl.mockClear();
+			const { container } = renderMd('[Link](https://example.com)');
+			const link = container.querySelector('a');
+			fireEvent.click(link!, { metaKey: true });
+			expect(mockOpenUrl).toHaveBeenCalledWith('https://example.com', { ctrlKey: true });
+		});
+
+		it('passes ctrlKey:true when Ctrl is held', () => {
+			mockOpenUrl.mockClear();
+			const { container } = renderMd('[Link](https://example.com)');
+			const link = container.querySelector('a');
+			fireEvent.click(link!, { ctrlKey: true });
+			expect(mockOpenUrl).toHaveBeenCalledWith('https://example.com', { ctrlKey: true });
+		});
+
+		it('passes ctrlKey:false on a plain click (no modifier)', () => {
+			mockOpenUrl.mockClear();
+			const { container } = renderMd('[Link](https://example.com)');
+			const link = container.querySelector('a');
+			fireEvent.click(link!);
+			expect(mockOpenUrl).toHaveBeenCalledWith('https://example.com', { ctrlKey: false });
 		});
 	});
 });

--- a/src/__tests__/renderer/utils/markdownConfig.test.ts
+++ b/src/__tests__/renderer/utils/markdownConfig.test.ts
@@ -860,7 +860,7 @@ describe('createMarkdownComponents link handling', () => {
 });
 
 // ---------------------------------------------------------------------------
-// createWizardBubbleMarkdownComponents — link handling (#1060)
+// createWizardBubbleMarkdownComponents - link handling (#1060)
 // ---------------------------------------------------------------------------
 
 describe('createWizardBubbleMarkdownComponents link handling', () => {
@@ -892,7 +892,7 @@ describe('createWizardBubbleMarkdownComponents link handling', () => {
 });
 
 // ---------------------------------------------------------------------------
-// createReleaseNotesMarkdownComponents — link handling (#1060)
+// createReleaseNotesMarkdownComponents - link handling (#1060)
 // ---------------------------------------------------------------------------
 
 describe('createReleaseNotesMarkdownComponents link handling', () => {

--- a/src/__tests__/renderer/utils/markdownConfig.test.ts
+++ b/src/__tests__/renderer/utils/markdownConfig.test.ts
@@ -11,6 +11,18 @@ vi.mock('react-syntax-highlighter/dist/esm/styles/prism', () => ({
 	vs: {},
 }));
 
+// Mock openUrl so link-click tests can assert the exact options passed through
+// (specifically the translated `ctrlKey` modifier) without depending on the
+// settings store's useSystemBrowser default or whether an active session
+// exists. See bug #1060: cmd-click (metaKey) on macOS must translate to the
+// same ctrlKey:true inversion as ctrl-click.
+const { mockOpenUrl } = vi.hoisted(() => ({ mockOpenUrl: vi.fn() }));
+vi.mock('../../../renderer/utils/openUrl', () => ({
+	openUrl: mockOpenUrl,
+	openInSystemBrowser: vi.fn(),
+	openInMaestroBrowser: vi.fn(),
+}));
+
 import {
 	generateProseStyles,
 	generateAutoRunProseStyles,
@@ -759,6 +771,38 @@ describe('createMarkdownComponents link handling', () => {
 		});
 	});
 
+	// Bug #1060: on macOS a Cmd+click sets metaKey (not ctrlKey). The handler
+	// must translate `metaKey || ctrlKey` into the ctrlKey option so the
+	// open-in-browser inversion still fires. Under the old `{ ctrlKey: e.ctrlKey }`
+	// code a metaKey-only click yielded ctrlKey:false, so this would fail.
+	it('should translate Cmd-click (metaKey) into ctrlKey:true for onExternalLinkClick', () => {
+		const onExternalLinkClick = vi.fn();
+		const components = createMarkdownComponents({
+			theme: mockTheme,
+			onExternalLinkClick,
+		});
+		const aComponent = components.a as any;
+
+		const element = aComponent({ node: null, href: 'https://example.com', children: 'link' });
+		const clickEvent = { preventDefault: vi.fn(), metaKey: true, ctrlKey: false } as any;
+		element.props.onClick(clickEvent);
+		expect(onExternalLinkClick).toHaveBeenCalledWith('https://example.com', { ctrlKey: true });
+	});
+
+	it('should pass ctrlKey:false to onExternalLinkClick on a plain click', () => {
+		const onExternalLinkClick = vi.fn();
+		const components = createMarkdownComponents({
+			theme: mockTheme,
+			onExternalLinkClick,
+		});
+		const aComponent = components.a as any;
+
+		const element = aComponent({ node: null, href: 'https://example.com', children: 'link' });
+		const clickEvent = { preventDefault: vi.fn(), metaKey: false, ctrlKey: false } as any;
+		element.props.onClick(clickEvent);
+		expect(onExternalLinkClick).toHaveBeenCalledWith('https://example.com', { ctrlKey: false });
+	});
+
 	it('should NOT call onExternalLinkClick for relative paths', () => {
 		const onExternalLinkClick = vi.fn();
 		const components = createMarkdownComponents({
@@ -812,6 +856,70 @@ describe('createMarkdownComponents link handling', () => {
 		element.props.onClick(clickEvent);
 		expect(onFileClick).toHaveBeenCalledWith('LICENSE', { openInNewTab: false });
 		expect(onExternalLinkClick).not.toHaveBeenCalled();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// createWizardBubbleMarkdownComponents — link handling (#1060)
+// ---------------------------------------------------------------------------
+
+describe('createWizardBubbleMarkdownComponents link handling', () => {
+	beforeEach(() => {
+		mockOpenUrl.mockClear();
+	});
+
+	// Under the old `{ ctrlKey: e.ctrlKey }` code a metaKey-only click yielded
+	// ctrlKey:false, so this guard would fail. See bug #1060.
+	it('should translate Cmd-click (metaKey) into ctrlKey:true for openUrl', () => {
+		const components = createWizardBubbleMarkdownComponents(mockTheme);
+		const aComponent = components.a as any;
+
+		const element = aComponent({ href: 'https://example.com', children: 'link' });
+		const clickEvent = { preventDefault: vi.fn(), metaKey: true, ctrlKey: false } as any;
+		element.props.onClick(clickEvent);
+		expect(mockOpenUrl).toHaveBeenCalledWith('https://example.com', { ctrlKey: true });
+	});
+
+	it('should pass ctrlKey:false to openUrl on a plain click', () => {
+		const components = createWizardBubbleMarkdownComponents(mockTheme);
+		const aComponent = components.a as any;
+
+		const element = aComponent({ href: 'https://example.com', children: 'link' });
+		const clickEvent = { preventDefault: vi.fn(), metaKey: false, ctrlKey: false } as any;
+		element.props.onClick(clickEvent);
+		expect(mockOpenUrl).toHaveBeenCalledWith('https://example.com', { ctrlKey: false });
+	});
+});
+
+// ---------------------------------------------------------------------------
+// createReleaseNotesMarkdownComponents — link handling (#1060)
+// ---------------------------------------------------------------------------
+
+describe('createReleaseNotesMarkdownComponents link handling', () => {
+	beforeEach(() => {
+		mockOpenUrl.mockClear();
+	});
+
+	// Under the old `{ ctrlKey: e.ctrlKey }` code a metaKey-only click yielded
+	// ctrlKey:false, so this guard would fail. See bug #1060.
+	it('should translate Cmd-click (metaKey) into ctrlKey:true for openUrl', () => {
+		const components = createReleaseNotesMarkdownComponents(mockTheme);
+		const aComponent = components.a as any;
+
+		const element = aComponent({ href: 'https://example.com', children: 'link' });
+		const clickEvent = { preventDefault: vi.fn(), metaKey: true, ctrlKey: false } as any;
+		element.props.onClick(clickEvent);
+		expect(mockOpenUrl).toHaveBeenCalledWith('https://example.com', { ctrlKey: true });
+	});
+
+	it('should pass ctrlKey:false to openUrl on a plain click', () => {
+		const components = createReleaseNotesMarkdownComponents(mockTheme);
+		const aComponent = components.a as any;
+
+		const element = aComponent({ href: 'https://example.com', children: 'link' });
+		const clickEvent = { preventDefault: vi.fn(), metaKey: false, ctrlKey: false } as any;
+		element.props.onClick(clickEvent);
+		expect(mockOpenUrl).toHaveBeenCalledWith('https://example.com', { ctrlKey: false });
 	});
 });
 

--- a/src/renderer/components/MarkdownRenderer.tsx
+++ b/src/renderer/components/MarkdownRenderer.tsx
@@ -453,7 +453,7 @@ export const MarkdownRenderer = memo(
 											} else if (/^file:\/\//.test(href)) {
 												window.maestro.shell.openPath(href.replace(/^file:\/\//, ''));
 											} else if (/^https?:\/\//.test(href)) {
-												openUrl(href, { ctrlKey: e.ctrlKey });
+												openUrl(href, { ctrlKey: e.metaKey || e.ctrlKey });
 											} else {
 												// Attempt to convert non-standard URLs (e.g. git@host:user/repo)
 												try {
@@ -464,7 +464,7 @@ export const MarkdownRenderer = memo(
 																.replace(/\.git$/, '')
 														: href;
 													if (/^https?:\/\//.test(converted)) {
-														openUrl(converted, { ctrlKey: e.ctrlKey });
+														openUrl(converted, { ctrlKey: e.metaKey || e.ctrlKey });
 													}
 												} catch {
 													// Silently ignore unparseable URLs

--- a/src/renderer/utils/markdownConfig.ts
+++ b/src/renderer/utils/markdownConfig.ts
@@ -576,7 +576,7 @@ export function createMarkdownComponents(options: MarkdownComponentsOptions): Pa
 								}
 							}
 						} else if (href && onExternalLinkClick && /^https?:\/\/|^mailto:/.test(href)) {
-							onExternalLinkClick(href, { ctrlKey: e.ctrlKey });
+							onExternalLinkClick(href, { ctrlKey: e.metaKey || e.ctrlKey });
 						} else if (
 							href &&
 							onFileClick &&
@@ -759,7 +759,7 @@ export function createWizardBubbleMarkdownComponents(theme: Theme): Partial<Comp
 					style: { color: theme.colors.accent },
 					onClick: (e: React.MouseEvent) => {
 						if (href && /^https?:\/\/|^mailto:/.test(href)) {
-							openUrl(href, { ctrlKey: e.ctrlKey });
+							openUrl(href, { ctrlKey: e.metaKey || e.ctrlKey });
 						}
 					},
 				},
@@ -878,7 +878,7 @@ export function createReleaseNotesMarkdownComponents(theme: Theme): Partial<Comp
 					onClick: (e: React.MouseEvent) => {
 						e.preventDefault();
 						if (href && /^https?:\/\/|^mailto:/.test(href)) {
-							openUrl(href, { ctrlKey: e.ctrlKey });
+							openUrl(href, { ctrlKey: e.metaKey || e.ctrlKey });
 						}
 					},
 					className: 'hover:underline cursor-pointer',


### PR DESCRIPTION
Fixes #1060

## Problem
Command-clicking a URL in the AI chat copied/opened the wrong target instead of opening the browser. On macOS a Cmd-click sets `e.metaKey` (not `e.ctrlKey`), but the link handlers passed `{ ctrlKey: e.ctrlKey }`, dropping the modifier on macOS. `openUrl`'s `ctrlKey: true` inverts the default browser target (XOR), so the inversion never fired for Cmd-click.

## Fix
Changed five link-click sites to pass `{ ctrlKey: e.metaKey || e.ctrlKey }`, matching the canonical idiom already used for file-link clicks (`markdownConfig.ts`):
- `src/renderer/components/MarkdownRenderer.tsx` (2 sites)
- `src/renderer/utils/markdownConfig.ts` (3 sites: external-link callback, wizard bubble, release notes)

## Tests
- Added metaKey/ctrlKey/plain-click regression tests in `MarkdownRenderer.test.tsx` and `markdownConfig.test.ts` (9 new). Each metaKey test was confirmed to FAIL under the old code and pass with the fix.
- Full vitest suite run on this branch: no regressions vs a pristine `rc` baseline.

## Notes
- A sixth `{ ctrlKey: e.ctrlKey }` exists at `XTerminal.tsx` (terminal link clicks). Left out of scope as a follow-up; same latent macOS behavior.
- Not covered by automated tests: visual confirmation in-app is trivial but optional.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Treats Cmd+click on macOS as the control modifier when opening links so external links open consistently across platforms.

* **Tests**
  * Expanded tests to verify Cmd/Ctrl modifier translation and exact link-opening behavior across markdown, chat bubble, and release notes paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->