### PR TITLE
fix(worktree-modal): contain long error text to prevent layout overflow

### DIFF
--- a/src/__tests__/renderer/components/CreateWorktreeModal.test.tsx
+++ b/src/__tests__/renderer/components/CreateWorktreeModal.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { CreateWorktreeModal } from '../../../renderer/components/CreateWorktreeModal';
 import { createMockSession } from '../../helpers/mockSession';
 import { mockTheme } from '../../helpers/mockTheme';
@@ -15,6 +15,17 @@ vi.mock('../../../renderer/services/git', () => ({
 }));
 
 describe('CreateWorktreeModal', () => {
+	// These tests reassign window.maestro.git methods directly (not via vi.spyOn),
+	// so vi.restoreAllMocks() cannot revert them. Capture the originals and restore
+	// them in afterEach so the mocks do not leak into other tests in this file.
+	const originalCheckGhCli = window.maestro.git.checkGhCli;
+	const originalBranch = window.maestro.git.branch;
+
+	afterEach(() => {
+		window.maestro.git.checkGhCli = originalCheckGhCli;
+		window.maestro.git.branch = originalBranch;
+	});
+
 	it('wraps a long spaceless creation error without overflowing the modal', async () => {
 		const longError = 'failedtoaddworktreeoversshaborting'.repeat(20);
 		window.maestro.git.checkGhCli = vi

--- a/src/__tests__/renderer/components/CreateWorktreeModal.test.tsx
+++ b/src/__tests__/renderer/components/CreateWorktreeModal.test.tsx
@@ -1,0 +1,46 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { CreateWorktreeModal } from '../../../renderer/components/CreateWorktreeModal';
+import { createMockSession } from '../../helpers/mockSession';
+import { mockTheme } from '../../helpers/mockTheme';
+
+vi.mock('../../../renderer/hooks/ui/useModalLayer', () => ({
+	useModalLayer: vi.fn(),
+}));
+
+vi.mock('../../../renderer/services/git', () => ({
+	gitService: {
+		getBranches: vi.fn().mockResolvedValue(['rc']),
+	},
+}));
+
+describe('CreateWorktreeModal', () => {
+	it('wraps a long spaceless creation error without overflowing the modal', async () => {
+		const longError = 'failedtoaddworktreeoversshaborting'.repeat(20);
+		window.maestro.git.checkGhCli = vi
+			.fn()
+			.mockResolvedValue({ installed: true, authenticated: true });
+		window.maestro.git.branch = vi
+			.fn()
+			.mockResolvedValue({ stdout: 'rc', stderr: '', exitCode: 0 });
+
+		render(
+			<CreateWorktreeModal
+				isOpen
+				onClose={vi.fn()}
+				theme={mockTheme}
+				session={createMockSession({ cwd: '/repo' })}
+				onCreateWorktree={vi.fn().mockRejectedValue(new Error(longError))}
+			/>
+		);
+
+		fireEvent.change(screen.getByPlaceholderText('feature-xyz'), {
+			target: { value: 'fix/overflow' },
+		});
+		fireEvent.click(screen.getByRole('button', { name: 'Create' }));
+
+		const errorParagraph = await screen.findByText(longError);
+		expect(errorParagraph).toHaveClass('break-all', 'min-w-0');
+		expect(errorParagraph.parentElement).toHaveClass('overflow-hidden');
+	});
+});

--- a/src/renderer/components/CreateWorktreeModal.tsx
+++ b/src/renderer/components/CreateWorktreeModal.tsx
@@ -313,7 +313,7 @@ export function CreateWorktreeModal({
 								className="w-4 h-4 mt-0.5 shrink-0"
 								style={{ color: theme.colors.error }}
 							/>
-							<p className="text-sm break-words min-w-0" style={{ color: theme.colors.error }}>
+							<p className="text-sm break-all min-w-0" style={{ color: theme.colors.error }}>
 								{error}
 							</p>
 						</div>

--- a/src/renderer/components/CreateWorktreeModal.tsx
+++ b/src/renderer/components/CreateWorktreeModal.tsx
@@ -303,7 +303,7 @@ export function CreateWorktreeModal({
 					{/* Error message */}
 					{error && (
 						<div
-							className="flex items-start gap-2 p-3 rounded border"
+							className="flex items-start gap-2 p-3 rounded border overflow-hidden"
 							style={{
 								backgroundColor: theme.colors.error + '10',
 								borderColor: theme.colors.error,
@@ -313,7 +313,7 @@ export function CreateWorktreeModal({
 								className="w-4 h-4 mt-0.5 shrink-0"
 								style={{ color: theme.colors.error }}
 							/>
-							<p className="text-sm" style={{ color: theme.colors.error }}>
+							<p className="text-sm break-words min-w-0" style={{ color: theme.colors.error }}>
 								{error}
 							</p>
 						</div>


### PR DESCRIPTION
Fixes #1051

## Problem
When worktree creation fails (e.g. a failed SSH `git worktree add`), a long single-line error string overflowed the error box in `CreateWorktreeModal` and broke the surrounding window layout.

## Fix
`src/renderer/components/CreateWorktreeModal.tsx`:
- Added `overflow-hidden` to the error container `<div>`.
- Added `break-all min-w-0` to the error `<p>` so long spaceless tokens (paths, ssh:// URLs with no break opportunities) wrap and stay fully visible rather than overflowing or being clipped.

`break-all` (not `break-words`) is used deliberately: `overflow-wrap: break-word` does not break a spaceless token, which is exactly the shape of these errors. This matches the existing `break-all` idiom used for paths/commands in `ProcessMonitor.tsx`.

## Tests
- Added `CreateWorktreeModal.test.tsx` with a guard that renders a long spaceless error and asserts the wrapping classes (`break-all`, `min-w-0`, `overflow-hidden`). New file (none existed on `rc`).
- Full vitest suite on this branch: no regressions vs pristine `rc` baseline.

## Notes
- Not covered by automated tests: visual confirmation of the modal with a long URL/token (JSDOM does not lay out). Quick manual check recommended before release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error message display so very long error strings wrap and stay contained within their container, preventing layout overflow.

* **Tests**
  * Added UI tests that verify long error messages render correctly with wrapping and overflow containment behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->