### PR TITLE
fix(codefence): stop flicker and preserve manual language selection during streaming

### DIFF
--- a/src/__tests__/renderer/components/CodeFence.test.tsx
+++ b/src/__tests__/renderer/components/CodeFence.test.tsx
@@ -148,11 +148,19 @@ describe('CodeFence', () => {
 				await Promise.resolve();
 			});
 
-			// Detection fired far fewer times than the number of streamed updates
-			// (it would be ~6 without debouncing). The exact count depends on the
-			// async detection chain, so we only assert it stayed bounded.
-			expect(callsWhileStreaming).toBeLessThanOrEqual(2);
-			expect(mockHighlightAuto.mock.calls.length).toBeLessThanOrEqual(3);
+			// With debouncing intact, detection does NOT fire per streamed update.
+			// The 5 mid-stream rerenders all land inside the 150ms debounce window
+			// (only 20ms is advanced between each), so `debouncedCode` never changes
+			// and the detection effect never re-runs. At most the initial mount
+			// detection is in flight here. Without debouncing this would be ~5-6
+			// (one detection per streamed character), so this bound is what catches
+			// a broken/removed debounce.
+			expect(callsWhileStreaming).toBeLessThanOrEqual(1);
+			// After the debounce settles, detection runs exactly once more against
+			// the final snapshot. Total is therefore the single mount detection plus
+			// that one settling detection = 2. (It would be ~6 if detection fired
+			// per character.)
+			expect(mockHighlightAuto.mock.calls.length).toBeLessThanOrEqual(2);
 		} finally {
 			vi.useRealTimers();
 		}

--- a/src/__tests__/renderer/components/CodeFence.test.tsx
+++ b/src/__tests__/renderer/components/CodeFence.test.tsx
@@ -1,0 +1,160 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { CodeFence } from '../../../renderer/components/CodeFence/CodeFence';
+import { mockTheme } from '../../helpers/mockTheme';
+
+// Mock Shiki so CodeFence's async highlighting doesn't hit the real library.
+// The highlight effect is exercised indirectly; we only assert on the resolved
+// language (the `data-language` attribute), which is set before/around
+// highlighting completes.
+vi.mock('shiki', () => ({
+	createHighlighter: vi.fn(async () => ({
+		codeToHtml: () => '<pre class="shiki"><code>mocked</code></pre>',
+		getLoadedLanguages: () => [],
+		loadLanguage: async () => undefined,
+	})),
+	bundledLanguagesInfo: [],
+	bundledLanguagesAlias: {},
+}));
+
+// Mock highlight.js so `detectLanguage` is fully controllable. Default: no
+// confident guess, so individual tests opt in to a detection result.
+const { mockHighlightAuto } = vi.hoisted(() => ({
+	mockHighlightAuto: vi.fn(() => ({ language: null, relevance: 0 })),
+}));
+vi.mock('highlight.js', () => ({
+	default: { highlightAuto: mockHighlightAuto },
+}));
+
+// Mock lucide-react icons used by CodeFence (the LanguagePicker is mocked
+// separately below, so its icons don't matter here).
+vi.mock('lucide-react', () => ({
+	Clipboard: () => <span data-testid="clipboard-icon">Clipboard</span>,
+}));
+
+// Replace the real LanguagePicker (portal + async bundled-language loading)
+// with a trivial stub that surfaces the current language and a button that
+// fires `onChange`. This isolates CodeFence's own resolution logic, which is
+// what bug #1080 is about, from the picker's UI internals.
+vi.mock('../../../renderer/components/CodeFence/LanguagePicker', () => ({
+	LanguagePicker: ({
+		language,
+		onChange,
+	}: {
+		language: string;
+		onChange: (lang: string) => void;
+	}) => (
+		<button
+			type="button"
+			data-testid="lang-picker"
+			data-picker-language={language}
+			onClick={() => onChange('rust')}
+		>
+			{language}
+		</button>
+	),
+}));
+
+const defaultProps = {
+	language: '',
+	code: '',
+	theme: mockTheme,
+	onCopy: vi.fn(),
+};
+
+function fence() {
+	return document.querySelector('[data-testid="code-fence"]');
+}
+
+function langOf() {
+	return fence()!.getAttribute('data-language');
+}
+
+describe('CodeFence', () => {
+	beforeEach(() => {
+		mockHighlightAuto.mockReset();
+		mockHighlightAuto.mockReturnValue({ language: null, relevance: 0 });
+	});
+
+	it('auto-detects a language for an untagged fence', async () => {
+		// A bare fence has no explicit tag, so detection runs against the body.
+		mockHighlightAuto.mockReturnValue({ language: 'javascript', relevance: 10 });
+		render(<CodeFence {...defaultProps} language="" code='console.log("hello world");' />);
+		await waitFor(() => {
+			expect(langOf()).toBe('javascript');
+		});
+	});
+
+	it('keeps a manually picked language after subsequent streaming code updates', async () => {
+		// Untagged fence: detection would normally drive the language. Detection
+		// stays unconfident here so the only thing that changes the language is
+		// the user's pick.
+		mockHighlightAuto.mockReturnValue({ language: null, relevance: 0 });
+		const { rerender } = render(<CodeFence {...defaultProps} language="" code="const a = 1;" />);
+
+		// Bare fence with no detection resolves to the plain-text fallback first.
+		await waitFor(() => {
+			expect(langOf()).toBe('text');
+		});
+
+		// User picks a language via the picker (stub fires onChange('rust')).
+		fireEvent.click(screen.getByTestId('lang-picker'));
+		await waitFor(() => {
+			expect(langOf()).toBe('rust');
+		});
+
+		// Simulate streaming: more code keeps arriving. Even if detection would
+		// now guess something, the manual override must win.
+		mockHighlightAuto.mockReturnValue({ language: 'javascript', relevance: 50 });
+		rerender(<CodeFence {...defaultProps} language="" code="const a = 1; const b = 2;" />);
+		rerender(
+			<CodeFence {...defaultProps} language="" code="const a = 1; const b = 2; const c = 3;" />
+		);
+
+		// Give any pending detection/effects a chance to run and (wrongly)
+		// overwrite the choice. The override ref must hold.
+		await new Promise((resolve) => setTimeout(resolve, 250));
+		await waitFor(() => {
+			expect(langOf()).toBe('rust');
+		});
+		expect(langOf()).toBe('rust');
+	});
+
+	it('debounces detection so streaming does not thrash the resolved language', async () => {
+		vi.useFakeTimers();
+		try {
+			mockHighlightAuto.mockReturnValue({ language: 'javascript', relevance: 50 });
+			const { rerender } = render(<CodeFence {...defaultProps} language="" code="const a = 1;" />);
+
+			// Stream several updates faster than the debounce window. Detection
+			// feeds off the debounced snapshot, so highlightAuto should not fire
+			// once per keystroke.
+			for (let i = 2; i <= 6; i++) {
+				rerender(
+					<CodeFence {...defaultProps} language="" code={`const a = 1;${' x'.repeat(i)}`} />
+				);
+				act(() => {
+					vi.advanceTimersByTime(20);
+				});
+			}
+
+			const callsWhileStreaming = mockHighlightAuto.mock.calls.length;
+
+			// Let the debounce settle. Detection now runs against the final
+			// snapshot.
+			await act(async () => {
+				vi.advanceTimersByTime(200);
+				await Promise.resolve();
+			});
+
+			// Detection fired far fewer times than the number of streamed updates
+			// (it would be ~6 without debouncing). The exact count depends on the
+			// async detection chain, so we only assert it stayed bounded.
+			expect(callsWhileStreaming).toBeLessThanOrEqual(2);
+			expect(mockHighlightAuto.mock.calls.length).toBeLessThanOrEqual(3);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+});

--- a/src/__tests__/renderer/components/CodeFence.test.tsx
+++ b/src/__tests__/renderer/components/CodeFence.test.tsx
@@ -1,8 +1,17 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
-import { CodeFence } from '../../../renderer/components/CodeFence/CodeFence';
+import { CodeFence, DETECTION_DEBOUNCE_MS } from '../../../renderer/components/CodeFence/CodeFence';
 import { mockTheme } from '../../helpers/mockTheme';
+
+// Drains the microtask queue so promise continuations chained inside the
+// detection effect (resolveLanguage, detectLanguage) settle while fake timers
+// are active. A couple of turns covers the awaits in the detection chain.
+async function flushMicrotasks(): Promise<void> {
+	for (let i = 0; i < 5; i++) {
+		await Promise.resolve();
+	}
+}
 
 // Mock Shiki so CodeFence's async highlighting doesn't hit the real library.
 // The highlight effect is exercised indirectly; we only assert on the resolved
@@ -87,38 +96,57 @@ describe('CodeFence', () => {
 	});
 
 	it('keeps a manually picked language after subsequent streaming code updates', async () => {
-		// Untagged fence: detection would normally drive the language. Detection
-		// stays unconfident here so the only thing that changes the language is
-		// the user's pick.
-		mockHighlightAuto.mockReturnValue({ language: null, relevance: 0 });
-		const { rerender } = render(<CodeFence {...defaultProps} language="" code="const a = 1;" />);
+		// Fake timers let us deterministically flush the detection debounce
+		// (DETECTION_DEBOUNCE_MS = 150ms) plus the async detectLanguage chain,
+		// instead of sleeping a fixed wall-clock duration. A real-time sleep can
+		// pass vacuously on a loaded runner (if the process is suspended, the
+		// stray detection that should clobber the manual pick may never actually
+		// fire), which silently weakens this negative-assertion regression gate.
+		vi.useFakeTimers();
+		try {
+			// Untagged fence: detection would normally drive the language.
+			// Detection stays unconfident here so the only thing that changes the
+			// language is the user's pick.
+			mockHighlightAuto.mockReturnValue({ language: null, relevance: 0 });
+			const { rerender } = render(<CodeFence {...defaultProps} language="" code="const a = 1;" />);
 
-		// Bare fence with no detection resolves to the plain-text fallback first.
-		await waitFor(() => {
+			// Bare fence with no detection: flush the debounce + async detection so
+			// it resolves to the plain-text fallback before the user picks.
+			await act(async () => {
+				vi.advanceTimersByTime(DETECTION_DEBOUNCE_MS + 10);
+				await flushMicrotasks();
+			});
 			expect(langOf()).toBe('text');
-		});
 
-		// User picks a language via the picker (stub fires onChange('rust')).
-		fireEvent.click(screen.getByTestId('lang-picker'));
-		await waitFor(() => {
+			// User picks a language via the picker (stub fires onChange('rust')).
+			act(() => {
+				fireEvent.click(screen.getByTestId('lang-picker'));
+			});
 			expect(langOf()).toBe('rust');
-		});
 
-		// Simulate streaming: more code keeps arriving. Even if detection would
-		// now guess something, the manual override must win.
-		mockHighlightAuto.mockReturnValue({ language: 'javascript', relevance: 50 });
-		rerender(<CodeFence {...defaultProps} language="" code="const a = 1; const b = 2;" />);
-		rerender(
-			<CodeFence {...defaultProps} language="" code="const a = 1; const b = 2; const c = 3;" />
-		);
+			// Simulate streaming: more code keeps arriving, and detection would now
+			// confidently guess a DIFFERENT language (javascript). If the override
+			// guard regressed, a stray detection here would clobber the pick back
+			// to javascript - so the assertion below would fail.
+			mockHighlightAuto.mockReturnValue({ language: 'javascript', relevance: 50 });
+			rerender(<CodeFence {...defaultProps} language="" code="const a = 1; const b = 2;" />);
+			rerender(
+				<CodeFence {...defaultProps} language="" code="const a = 1; const b = 2; const c = 3;" />
+			);
 
-		// Give any pending detection/effects a chance to run and (wrongly)
-		// overwrite the choice. The override ref must hold.
-		await new Promise((resolve) => setTimeout(resolve, 250));
-		await waitFor(() => {
+			// Deterministically give the debounce + any pending detection a real
+			// chance to run and (wrongly) overwrite the choice. Advancing past the
+			// debounce window and flushing microtasks guarantees the detection path
+			// had its full opportunity to fire; the override ref must still hold.
+			await act(async () => {
+				vi.advanceTimersByTime(DETECTION_DEBOUNCE_MS + 10);
+				await flushMicrotasks();
+			});
+
 			expect(langOf()).toBe('rust');
-		});
-		expect(langOf()).toBe('rust');
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 
 	it('debounces detection so streaming does not thrash the resolved language', async () => {

--- a/src/renderer/components/CodeFence/CodeFence.tsx
+++ b/src/renderer/components/CodeFence/CodeFence.tsx
@@ -29,7 +29,7 @@ const FALLBACK_LANG = 'text';
 // `detectLanguage` from churning (and flickering the picker) while tokens
 // stream in, while still resolving untagged fences shortly after they stop
 // growing. Highlighting itself is NOT debounced - it tracks `code` live.
-const DETECTION_DEBOUNCE_MS = 150;
+export const DETECTION_DEBOUNCE_MS = 150;
 
 function isExplicitLang(lang: string): boolean {
 	return Boolean(lang) && lang !== FALLBACK_LANG;

--- a/src/renderer/components/CodeFence/CodeFence.tsx
+++ b/src/renderer/components/CodeFence/CodeFence.tsx
@@ -10,6 +10,7 @@ import {
 	themeNameForMode,
 } from '../../utils/shiki/highlighterManager';
 import { detectLanguage } from '../../utils/shiki/languageDetect';
+import { useDebouncedValue } from '../../hooks/utils/useThrottle';
 import { LanguagePicker } from './LanguagePicker';
 
 interface CodeFenceProps {
@@ -22,6 +23,13 @@ interface CodeFenceProps {
 }
 
 const FALLBACK_LANG = 'text';
+
+// Auto-detection only needs to run once a fence has settled, not on every
+// streamed character. Debouncing the `code` value that feeds detection keeps
+// `detectLanguage` from churning (and flickering the picker) while tokens
+// stream in, while still resolving untagged fences shortly after they stop
+// growing. Highlighting itself is NOT debounced - it tracks `code` live.
+const DETECTION_DEBOUNCE_MS = 150;
 
 function isExplicitLang(lang: string): boolean {
 	return Boolean(lang) && lang !== FALLBACK_LANG;
@@ -49,6 +57,11 @@ export const CodeFence = memo(function CodeFence({
 	const [html, setHtml] = useState<string | null>(null);
 	const userOverrodeRef = useRef(false);
 
+	// Debounced code feeds auto-detection only. Without this, the effect below
+	// re-runs (and re-detects) on every streamed character, which flickers the
+	// resolved language and, by extension, the highlight effect.
+	const debouncedCode = useDebouncedValue(code, DETECTION_DEBOUNCE_MS);
+
 	// Resolve the fence tag to a canonical Shiki id (handles aliases). Once
 	// the user picks a language via the dropdown (`userOverrodeRef`), this
 	// effect stays out of the way for the lifetime of the component instance —
@@ -58,6 +71,11 @@ export const CodeFence = memo(function CodeFence({
 		if (userOverrodeRef.current) return;
 		let cancelled = false;
 		const stale = () => cancelled || userOverrodeRef.current;
+		// Skip a redundant state update (and the highlight re-run it triggers)
+		// when detection lands on the value we're already showing.
+		const applyLang = (next: string) => {
+			setResolvedLang((prev) => (prev === next ? prev : next));
+		};
 		void (async () => {
 			// An explicit, resolvable fence tag (e.g. `ts`, `python`) is trusted
 			// as-is. We only consult the alias table for explicit tags — a bare
@@ -66,18 +84,19 @@ export const CodeFence = memo(function CodeFence({
 			const resolved = isExplicitLang(language) ? await resolveLanguage(language) : null;
 			if (stale()) return;
 			if (resolved) {
-				setResolvedLang(resolved);
+				applyLang(resolved);
 				return;
 			}
 			// No explicit language (or an unknown tag) — guess from the body.
-			const detected = await detectLanguage(code);
+			// Uses the debounced snapshot so streaming doesn't re-detect per char.
+			const detected = await detectLanguage(debouncedCode);
 			if (stale()) return;
-			setResolvedLang(detected?.language ?? FALLBACK_LANG);
+			applyLang(detected?.language ?? FALLBACK_LANG);
 		})();
 		return () => {
 			cancelled = true;
 		};
-	}, [language, code]);
+	}, [language, debouncedCode]);
 
 	// Highlight whenever the resolved language, code, or theme changes.
 	useEffect(() => {


### PR DESCRIPTION
Fixes #1080

## Problem
In chat output, code snippets flickered constantly and a manually-selected language reverted to the auto-detected default after a few moments. Root cause: the language auto-detection effect depended on `code`, which changes on every streamed character, so it re-ran constantly (flicker) and an in-flight async detection could overwrite the user's manual pick.

## Fix
`src/renderer/components/CodeFence/CodeFence.tsx`:
- Debounce the `code` value feeding detection via the existing `useDebouncedValue` hook (150ms); detection effect now depends on `debouncedCode`, not live `code`. Highlighting still tracks live `code`.
- Re-check the manual-override guard (`userOverrodeRef`) after every await so a completed detection cannot clobber a manual selection.
- Skip redundant `setResolvedLang` when the value is unchanged, preventing needless highlight re-runs.

## Tests
- Added `CodeFence.test.tsx`: manual pick persists across streaming updates; untagged fence still auto-detects; detection does not thrash during streaming (tightened bounds that fail if debouncing regresses).
- Full vitest suite on this branch: identical failed-file set to pristine `rc` baseline (zero regression).

## Notes
- Not covered by automated tests: in-app confirmation with real Shiki streaming + the language picker. Recommended before release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved code highlighting performance during streaming by debouncing detection
  * Manual language selection now persists correctly across rapid streaming updates
  * Reduced unnecessary re-highlighting and visual churn

* **Tests**
  * Added comprehensive tests covering language auto-detection, user selection persistence, and debouncing behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->