### PR TITLE
fix(browser-tab): paste into webview form fields via guest.paste() on cmd/ctrl+v

### DIFF
--- a/src/__tests__/main/app-lifecycle/window-manager.test.ts
+++ b/src/__tests__/main/app-lifecycle/window-manager.test.ts
@@ -1381,7 +1381,16 @@ describe('app-lifecycle/window-manager', () => {
 				shift: true,
 			});
 
+			// Cmd+Shift+V is not the plain paste chord, so the handler must NOT
+			// drive the privileged paste path. It is also not a text-editing
+			// passthrough, so it is consumed (preventDefault) and forwarded to the
+			// renderer as an app shortcut rather than reaching the page.
 			expect(mockGuestWebContents.paste).not.toHaveBeenCalled();
+			expect(shiftEvent.preventDefault).toHaveBeenCalled();
+			expect(mockWebContents.send).toHaveBeenCalledWith(
+				'browser-tab:shortcutKey',
+				expect.objectContaining({ key: 'v', shift: true })
+			);
 		});
 
 		// Electron 41 removed the legacy `'crashed'` event in favor of

--- a/src/__tests__/main/app-lifecycle/window-manager.test.ts
+++ b/src/__tests__/main/app-lifecycle/window-manager.test.ts
@@ -1263,6 +1263,119 @@ describe('app-lifecycle/window-manager', () => {
 			);
 		});
 
+		it('pastes into browser-tab form fields via guest.paste() on Cmd/Ctrl+V (#1063)', async () => {
+			// The permission handler denies `clipboard-read` to webviews, so
+			// Chromium's native Cmd/Ctrl+V silently fails inside browser-tab form
+			// fields. The before-input-event handler must intercept the paste chord
+			// and drive the privileged guest.paste() instead.
+			const { createWindowManager } = await import('../../../main/app-lifecycle/window-manager');
+
+			const windowManager = createWindowManager({
+				windowStateStore: mockWindowStateStore as unknown as Parameters<
+					typeof createWindowManager
+				>[0]['windowStateStore'],
+				isDevelopment: false,
+				preloadPath: '/path/to/preload.js',
+				rendererProductionUrl: 'app://app/index.html',
+				devServerUrl: 'http://localhost:5173',
+				useNativeTitleBar: false,
+				autoHideMenuBar: false,
+			});
+
+			windowManager.createWindow();
+
+			const attachHandler = webContentsEventHandlers.get('did-attach-webview');
+			attachHandler?.({} as any, mockGuestWebContents as any);
+
+			const beforeInputHandler = guestWebContentsEventHandlers.get('before-input-event');
+			expect(beforeInputHandler).toBeDefined();
+
+			// Cmd+V (macOS)
+			const metaEvent = { preventDefault: vi.fn() };
+			beforeInputHandler?.(metaEvent, {
+				type: 'keyDown',
+				key: 'v',
+				code: 'KeyV',
+				meta: true,
+				control: false,
+				alt: false,
+				shift: false,
+			});
+			expect(metaEvent.preventDefault).toHaveBeenCalled();
+			expect(mockGuestWebContents.paste).toHaveBeenCalledTimes(1);
+
+			// Ctrl+V (Windows/Linux)
+			const ctrlEvent = { preventDefault: vi.fn() };
+			beforeInputHandler?.(ctrlEvent, {
+				type: 'keyDown',
+				key: 'v',
+				code: 'KeyV',
+				meta: false,
+				control: true,
+				alt: false,
+				shift: false,
+			});
+			expect(ctrlEvent.preventDefault).toHaveBeenCalled();
+			expect(mockGuestWebContents.paste).toHaveBeenCalledTimes(2);
+
+			// The paste chord must NOT also be forwarded to the renderer as an app
+			// shortcut - it is fully consumed here.
+			expect(mockWebContents.send).not.toHaveBeenCalledWith(
+				'browser-tab:shortcutKey',
+				expect.objectContaining({ key: 'v' })
+			);
+		});
+
+		it('does not hijack non-paste edit chords or plain "v" on browser-tab guests', async () => {
+			const { createWindowManager } = await import('../../../main/app-lifecycle/window-manager');
+
+			const windowManager = createWindowManager({
+				windowStateStore: mockWindowStateStore as unknown as Parameters<
+					typeof createWindowManager
+				>[0]['windowStateStore'],
+				isDevelopment: false,
+				preloadPath: '/path/to/preload.js',
+				rendererProductionUrl: 'app://app/index.html',
+				devServerUrl: 'http://localhost:5173',
+				useNativeTitleBar: false,
+				autoHideMenuBar: false,
+			});
+
+			windowManager.createWindow();
+
+			const attachHandler = webContentsEventHandlers.get('did-attach-webview');
+			attachHandler?.({} as any, mockGuestWebContents as any);
+
+			const beforeInputHandler = guestWebContentsEventHandlers.get('before-input-event');
+
+			// Plain "v" (no modifier) is normal typing - must pass through untouched.
+			const plainEvent = { preventDefault: vi.fn() };
+			beforeInputHandler?.(plainEvent, {
+				type: 'keyDown',
+				key: 'v',
+				code: 'KeyV',
+				meta: false,
+				control: false,
+				alt: false,
+				shift: false,
+			});
+			expect(plainEvent.preventDefault).not.toHaveBeenCalled();
+
+			// Cmd+Shift+V (paste-and-match-style etc.) is not the plain paste chord.
+			const shiftEvent = { preventDefault: vi.fn() };
+			beforeInputHandler?.(shiftEvent, {
+				type: 'keyDown',
+				key: 'v',
+				code: 'KeyV',
+				meta: true,
+				control: false,
+				alt: false,
+				shift: true,
+			});
+
+			expect(mockGuestWebContents.paste).not.toHaveBeenCalled();
+		});
+
 		// Electron 41 removed the legacy `'crashed'` event in favor of
 		// `'render-process-gone'`. These tests pin the wiring so a future
 		// revert can't silently drop renderer-crash reporting.

--- a/src/__tests__/main/app-lifecycle/window-manager.test.ts
+++ b/src/__tests__/main/app-lifecycle/window-manager.test.ts
@@ -22,6 +22,7 @@ const mockGuestWebContents = {
 		guestWebContentsEventHandlers.set(event, handler);
 	}),
 	executeJavaScript: vi.fn().mockResolvedValue(undefined),
+	paste: vi.fn(),
 };
 
 // Mock BrowserWindow instance methods
@@ -1324,6 +1325,13 @@ describe('app-lifecycle/window-manager', () => {
 				'browser-tab:shortcutKey',
 				expect.objectContaining({ key: 'v' })
 			);
+
+			// The page-level fallback must also exclude V from its passthrough
+			// list. Otherwise it can race the privileged paste path above.
+			guestWebContentsEventHandlers.get('dom-ready')?.();
+			const injectedScript = mockGuestWebContents.executeJavaScript.mock.calls.at(-1)?.[0];
+			expect(injectedScript).toContain("'acxz'.indexOf(k)");
+			expect(injectedScript).not.toContain("'acvxz'.indexOf(k)");
 		});
 
 		it('does not hijack non-paste edit chords or plain "v" on browser-tab guests', async () => {

--- a/src/main/app-lifecycle/window-manager.ts
+++ b/src/main/app-lifecycle/window-manager.ts
@@ -399,7 +399,7 @@ export function createWindowManager(deps: WindowManagerDependencies): WindowMana
 						var hasAlt=e.altKey;
 						if(!hasMod&&!hasAlt)return;
 						var k=e.key.toLowerCase();
-						var te=hasMod&&!hasAlt&&!e.shiftKey&&'acvxz'.indexOf(k)!==-1;
+						var te=hasMod&&!hasAlt&&!e.shiftKey&&'acxz'.indexOf(k)!==-1;
 						var re=hasMod&&!hasAlt&&e.shiftKey&&k==='z';
 						if(te||re)return;
 						e.preventDefault();

--- a/src/main/app-lifecycle/window-manager.ts
+++ b/src/main/app-lifecycle/window-manager.ts
@@ -54,6 +54,9 @@ interface BrowserTabGuestContents {
 	): void;
 	on(event: string, handler: (...args: any[]) => void): void;
 	executeJavaScript(code: string): Promise<unknown>;
+	// Privileged Electron paste: bypasses the web-facing `clipboard-read`
+	// permission that the permission handler denies to webviews (issue #1063).
+	paste(): void;
 }
 
 function isAllowedBrowserTabUrl(rawUrl: string): boolean {
@@ -354,11 +357,24 @@ export function createWindowManager(deps: WindowManagerDependencies): WindowMana
 					if (!input.meta && !input.control && !input.alt) return;
 					if (input.type !== 'keyDown') return;
 					const k = input.key.toLowerCase();
-					// Let standard text-editing shortcuts pass through to the page.
-					// `f` is intentionally NOT in this list: Cmd+F must reach the
-					// renderer so the in-page find bar can open.
+					// Cmd/Ctrl+V: drive paste through the trusted guest webContents API.
+					// Chromium's native paste needs the `clipboard-read` permission, which
+					// the permission handler denies to webviews as a security boundary, so
+					// native paste silently fails inside browser-tab form fields (issue
+					// #1063). guest.paste() is a privileged Electron call that bypasses
+					// that web-facing permission, mirroring the right-click Paste menu
+					// item (issue #1065).
+					const isPaste = (input.meta || input.control) && !input.alt && !input.shift && k === 'v';
+					if (isPaste) {
+						event.preventDefault();
+						guest.paste();
+						return;
+					}
+					// Let the remaining standard text-editing shortcuts pass through to
+					// the page. `f` is intentionally NOT in this list: Cmd+F must reach
+					// the renderer so the in-page find bar can open.
 					const isTextEditing =
-						(input.meta || input.control) && !input.alt && !input.shift && 'acvxz'.includes(k);
+						(input.meta || input.control) && !input.alt && !input.shift && 'acxz'.includes(k);
 					const isRedo = (input.meta || input.control) && !input.alt && input.shift && k === 'z';
 					if (isTextEditing || isRedo) return;
 					event.preventDefault();

--- a/src/renderer/components/MainPanel/BrowserTabView.tsx
+++ b/src/renderer/components/MainPanel/BrowserTabView.tsx
@@ -378,9 +378,11 @@ export const BrowserTabView = React.memo(
 			// Uses stopImmediatePropagation to prevent any other listener
 			// (including the main-process-injected bubble-phase one) from
 			// double-firing.
-			// `f` is intentionally NOT in the text-editing pass-through list: Cmd+F
-			// must reach the app so the in-page find bar can open. The remaining
-			// letters (a/c/v/x/z) keep their native text-editing behavior inside
+			// `f` and `v` are intentionally NOT in the text-editing pass-through
+			// list. Cmd+F must reach the app so the in-page find bar can open, and
+			// Cmd/Ctrl+V is handled separately via the privileged paste path
+			// (guest.paste()) so paste works inside the webview. The remaining
+			// letters (a/c/x/z) keep their native text-editing behavior inside
 			// page inputs.
 			const keyboardInjection = `(function(){
 			if(window.__maestroShortcutCaptureInstalled)return;
@@ -390,7 +392,7 @@ export const BrowserTabView = React.memo(
 				var hasAlt=e.altKey;
 				if(!hasMod&&!hasAlt)return;
 				var k=e.key.toLowerCase();
-				var te=hasMod&&!hasAlt&&!e.shiftKey&&'acvxz'.indexOf(k)!==-1;
+				var te=hasMod&&!hasAlt&&!e.shiftKey&&'acxz'.indexOf(k)!==-1;
 				var re=hasMod&&!hasAlt&&e.shiftKey&&k==='z';
 				if(te||re)return;
 				e.preventDefault();


### PR DESCRIPTION
Fixes #1063

## Problem
Pasting (Cmd/Ctrl+V) clipboard text into a focused input/textarea/contenteditable inside an embedded browser tab (Electron `<webview>`) did nothing. The webview permission handler denies `clipboard-read` to webviews as a security boundary, so Chromium's native paste silently fails inside browser-tab form fields.

## Fix
`src/main/app-lifecycle/window-manager.ts`, in the webview `before-input-event` handler:
- Detect the paste chord `(meta || control) && !alt && !shift && key === 'v'`, call `event.preventDefault()`, and invoke `guest.paste()` - a privileged main-process Electron call that performs the paste without granting the page web-facing clipboard-read access.
- Removed `v` from the residual text-editing passthrough list (now handled explicitly) in both the native handler and the injected in-page capture listener, keeping the two layers consistent.

## Security
The `clipboard-read` permission denial is left intact. `guest.paste()` fires only in response to a real user keystroke and does not grant the page clipboard-read, so a malicious page cannot read the clipboard on demand. Mirrors how the right-click Paste menu item works.

## Tests
- Added tests asserting meta+v and control+v each call `guest.paste()` once with `preventDefault`, and that plain `v` / Cmd+Shift+V do not.
- Full vitest suite on this branch: identical failed-file set to pristine `rc` baseline (zero regression); `window-manager.test.ts` passes.

## Notes
- The `BrowserTabGuestContents` / `before-input-event` webview infrastructure already exists on `rc`, so this change is self-contained and merges independently (no dependency on the #1065/#1066 context-menu PR).
- Not covered by automated tests: real Electron webview paste on Windows and macOS. Recommended before release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cmd/Ctrl+V in embedded/guest browser views is now correctly intercepted to perform a privileged paste action; plain "v" and other shortcuts retain expected handling and forwarding.

* **Tests**
  * Added tests covering paste shortcut interception and fallback script behavior across modifier combinations, including ensured non-paste cases are handled/forwarded appropriately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->