### PR TITLE
fix: prevent field crashes in history add and fs stat/readFile

### DIFF
--- a/src/__tests__/integration/filesystem-ipc.integration.test.ts
+++ b/src/__tests__/integration/filesystem-ipc.integration.test.ts
@@ -460,9 +460,9 @@ describe('filesystem IPC integration', () => {
 		});
 		await expect(invoke('fs:delete', defaultDeleteDir)).resolves.toEqual({ success: true });
 
-		await expect(invoke('fs:stat', path.join(workspace, 'missing.txt'))).rejects.toThrow(
-			'Failed to get file stats:'
-		);
+		// Missing files now resolve to null instead of throwing so callers can
+		// handle absence without an unhandled IPC rejection. (MAESTRO-MH/ME)
+		await expect(invoke('fs:stat', path.join(workspace, 'missing.txt'))).resolves.toBeNull();
 		await expect(
 			invoke('fs:writeFile', path.join(workspace, 'missing', 'file.txt'), 'x')
 		).rejects.toThrow('Failed to write file:');

--- a/src/__tests__/main/history-manager.test.ts
+++ b/src/__tests__/main/history-manager.test.ts
@@ -625,6 +625,47 @@ describe('HistoryManager', () => {
 			expect(written.entries[0].id).toBe('new-entry');
 		});
 
+		// Regression: a file that parses as valid JSON but has no `entries` array
+		// (legacy/partial write) must not crash with "Cannot read properties of
+		// undefined (reading 'unshift')". (MAESTRO-QK)
+		it('should recover when existing file parses but lacks an entries array', () => {
+			const filePath = path.join(
+				'/mock/userData',
+				'history',
+				`${sanitizeSessionId('session-1')}.json`
+			);
+			mockExistsSync.mockImplementation((p: fs.PathLike) => p.toString() === filePath);
+			mockReadFileSync.mockReturnValue(
+				JSON.stringify({ version: HISTORY_VERSION, sessionId: 'session-1' })
+			);
+
+			const entry = createMockEntry({ id: 'recovered' });
+			// Should not throw
+			manager.addEntry('session-1', '/test/project', entry);
+
+			const written = JSON.parse(mockWriteFileSync.mock.calls[0][1] as string);
+			expect(written.entries).toHaveLength(1);
+			expect(written.entries[0].id).toBe('recovered');
+		});
+
+		it('should recover when existing file parses to null or a non-object', () => {
+			const filePath = path.join(
+				'/mock/userData',
+				'history',
+				`${sanitizeSessionId('session-1')}.json`
+			);
+			mockExistsSync.mockImplementation((p: fs.PathLike) => p.toString() === filePath);
+			mockReadFileSync.mockReturnValue('null');
+
+			const entry = createMockEntry({ id: 'from-null' });
+			// Should not throw "Cannot set/read properties of null"
+			manager.addEntry('session-1', '/test/project', entry);
+
+			const written = JSON.parse(mockWriteFileSync.mock.calls[0][1] as string);
+			expect(written.entries).toHaveLength(1);
+			expect(written.entries[0].id).toBe('from-null');
+		});
+
 		it('should log error on write failure', () => {
 			mockExistsSync.mockReturnValue(false);
 			mockWriteFileSync.mockImplementation(() => {

--- a/src/__tests__/main/ipc/handlers/filesystem.test.ts
+++ b/src/__tests__/main/ipc/handlers/filesystem.test.ts
@@ -470,6 +470,20 @@ describe('filesystem handlers', () => {
 				'Failed to read file: Error: Permission denied'
 			);
 		});
+
+		it('should return null when a remote file is missing', async () => {
+			// Remote not-found mirrors the local ENOENT path: return null instead of
+			// throwing so the IPC promise does not reject and reach Sentry. (MAESTRO-MG/MF)
+			const mockSshConfig = { id: 'remote-1', host: 'server.com', username: 'user' };
+			vi.mocked(getSshRemoteById).mockReturnValue(mockSshConfig as any);
+			vi.mocked(readFileRemote).mockResolvedValue({
+				success: false,
+				error: 'File not found: /remote/missing.md',
+			});
+
+			const handler = registeredHandlers.get('fs:readFile');
+			await expect(handler!({}, '/remote/missing.md', 'remote-1')).resolves.toBeNull();
+		});
 	});
 
 	describe('fs:stat', () => {
@@ -551,6 +565,27 @@ describe('filesystem handlers', () => {
 
 			const handler = registeredHandlers.get('fs:stat');
 			await expect(handler!({}, '/private/file.txt')).rejects.toThrow('Failed to get file stats');
+		});
+
+		it('should return null when a local path is missing (ENOENT)', async () => {
+			// Missing files return null instead of throwing so callers can handle
+			// absence without an unhandled IPC rejection reaching Sentry. (MAESTRO-MH/ME)
+			vi.mocked(fs.stat).mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
+
+			const handler = registeredHandlers.get('fs:stat');
+			await expect(handler!({}, '/missing/file.txt')).resolves.toBeNull();
+		});
+
+		it('should return null when a remote path is missing', async () => {
+			const mockSshConfig = { id: 'remote-1', host: 'server.com', username: 'user' };
+			vi.mocked(getSshRemoteById).mockReturnValue(mockSshConfig as any);
+			vi.mocked(statRemote).mockResolvedValue({
+				success: false,
+				error: 'Path not found: /remote/missing.md',
+			});
+
+			const handler = registeredHandlers.get('fs:stat');
+			await expect(handler!({}, '/remote/missing.md', 'remote-1')).resolves.toBeNull();
 		});
 	});
 

--- a/src/main/history-manager.ts
+++ b/src/main/history-manager.ts
@@ -206,6 +206,14 @@ export class HistoryManager {
 			data = { version: HISTORY_VERSION, sessionId, projectPath, entries: [] };
 		}
 
+		// A file can parse as valid JSON yet still lack a usable `entries` array
+		// (legacy/partial writes, hand-edited files, or `null`/non-object content).
+		// The catch above only covers JSON.parse throwing, so guard the shape here
+		// before unshift can throw "Cannot read properties of undefined". (MAESTRO-QK)
+		if (!data || typeof data !== 'object' || !Array.isArray(data.entries)) {
+			data = { version: HISTORY_VERSION, sessionId, projectPath, entries: [] };
+		}
+
 		// Add to beginning (most recent first)
 		data.entries.unshift(entry);
 

--- a/src/main/ipc/handlers/filesystem.ts
+++ b/src/main/ipc/handlers/filesystem.ts
@@ -147,6 +147,12 @@ export function registerFilesystemHandlers(): void {
 				}
 				const result = await readFileRemote(filePath, sshConfig);
 				if (!result.success) {
+					// Missing remote files mirror the local ENOENT path below: return
+					// null instead of throwing so callers can handle absence cleanly
+					// without surfacing an unhandled IPC rejection. (MAESTRO-MG/MF)
+					if (result.error?.startsWith('File not found:')) {
+						return null;
+					}
 					throw new Error(result.error || 'Failed to read remote file');
 				}
 				// For images over SSH, we'd need to base64 encode on remote and decode here
@@ -207,6 +213,12 @@ export function registerFilesystemHandlers(): void {
 				}
 				const result = await statRemote(filePath, sshConfig);
 				if (!result.success) {
+					// Missing remote paths return null instead of throwing (mirrors the
+					// local ENOENT handling below and fs:readFile) so callers can handle
+					// absence without an unhandled IPC rejection. (MAESTRO-MH/ME)
+					if (result.error?.startsWith('Path not found:')) {
+						return null;
+					}
 					throw new Error(result.error || 'Failed to get remote file stats');
 				}
 				// Map remote stat result to match local format
@@ -230,7 +242,13 @@ export function registerFilesystemHandlers(): void {
 				isDirectory: stats.isDirectory(),
 				isFile: stats.isFile(),
 			};
-		} catch (error) {
+		} catch (error: any) {
+			// Missing files return null instead of throwing (mirrors fs:readFile) so
+			// callers can handle absence cleanly without an unhandled IPC rejection
+			// reaching Sentry. (MAESTRO-MH/ME)
+			if (error?.code === 'ENOENT') {
+				return null;
+			}
 			throw new Error(`Failed to get file stats: ${error}`);
 		}
 	});

--- a/src/main/preload/fs.ts
+++ b/src/main/preload/fs.ts
@@ -81,9 +81,9 @@ export function createFsApi() {
 			ipcRenderer.invoke('fs:writeFile', filePath, content, sshRemoteId),
 
 		/**
-		 * Get file/directory stats
+		 * Get file/directory stats. Resolves to null when the path does not exist.
 		 */
-		stat: (filePath: string, sshRemoteId?: string): Promise<FileStat> =>
+		stat: (filePath: string, sshRemoteId?: string): Promise<FileStat | null> =>
 			ipcRenderer.invoke('fs:stat', filePath, sshRemoteId),
 
 		/**

--- a/src/renderer/components/DocumentGraph/DocumentGraphView.tsx
+++ b/src/renderer/components/DocumentGraph/DocumentGraphView.tsx
@@ -772,6 +772,10 @@ export function DocumentGraphView({
 		window.maestro.fs
 			.stat(fullPath, sshRemoteId)
 			.then((stats) => {
+				if (!stats) {
+					setSelectedNodeStats(null);
+					return;
+				}
 				setSelectedNodeStats({
 					createdAt: stats.createdAt ? new Date(stats.createdAt) : null,
 					modifiedAt: stats.modifiedAt ? new Date(stats.modifiedAt) : null,

--- a/src/renderer/components/FilePreview.tsx
+++ b/src/renderer/components/FilePreview.tsx
@@ -1023,11 +1023,15 @@ export const FilePreview = React.memo(
 				window.maestro.fs
 					.stat(file.path, sshRemoteId)
 					.then((stats) =>
-						setFileStats({
-							size: stats.size,
-							createdAt: stats.createdAt,
-							modifiedAt: stats.modifiedAt,
-						})
+						setFileStats(
+							stats
+								? {
+										size: stats.size,
+										createdAt: stats.createdAt,
+										modifiedAt: stats.modifiedAt,
+									}
+								: null
+						)
 					)
 					.catch((err) => {
 						console.error('Failed to get file stats:', err);

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -639,7 +639,7 @@ interface MaestroAPI {
 			modifiedAt: string;
 			isDirectory: boolean;
 			isFile: boolean;
-		}>;
+		} | null>;
 		directorySize: (
 			dirPath: string,
 			sshRemoteId?: string


### PR DESCRIPTION
## Summary

Fixes obvious field crashes reported via Sentry that affect the **stable (`main`) release channel**. Issues were triaged from the `maestro` project in Sentry (org `smash-labs`), filtered to `channel:stable` (the `main` channel — `channel:rc` is the `rc` branch, per `src/main/index.ts` `setTag('channel', version.includes('-RC') ? 'rc' : 'stable')`), and each was validated against current `main` code before fixing.

Each fix targets a clear bug with an obvious resolution. Native/environmental crashes (renderer GPU/EGL, `uv_mutex_lock`, GLIBC, `WebContents crashed`, `ENOSPC`, etc.) and issues whose code path isn't on current `main` were intentionally left out.

## Fixes

### MAESTRO-QK — `history:add` → `Cannot read properties of undefined (reading 'unshift')`
`HistoryManager.addEntry` only guarded against `JSON.parse` *throwing*. A file that parses to valid JSON but lacks a usable `entries` array (legacy/partial write, hand-edited file, or `null`/non-object content) reached `data.entries.unshift(entry)` and crashed. Added a shape guard before the `unshift`.

### MAESTRO-MH / MAESTRO-ME — `fs:stat` crashes on missing paths
`fs:stat` rethrew on missing files for **both** the local (`ENOENT`) and remote (`Path not found`) paths, surfacing as unhandled IPC rejections in the renderer. It now returns `null` for missing paths — mirroring the existing `fs:readFile` ENOENT handling (`// Fixes MAESTRO-JP`).

### MAESTRO-MG / MAESTRO-MF — `fs:readFile` remote branch crashes on missing files
The local `fs:readFile` branch already returned `null` for ENOENT, but the **remote** branch rethrew `File not found`. Made the remote branch consistent (return `null`).

## Type/API change

`window.maestro.fs.stat` is now typed `Promise<FileStat | null>` (it could already return effectively-absent results). Every call site was audited — all but two already null-checked the result (e.g. `graphDataBuilder.ts` even logs `"stat returned null"`). The two that didn't (`DocumentGraphView`, `FilePreview`) are updated to treat a missing file the same as their existing error path.

## Testing

- New regression tests: `addEntry` recovers from a parsed-but-entries-less file and from `null` content; `fs:stat`/`fs:readFile` return `null` for missing local and remote paths.
- Updated one integration assertion to reflect `fs:stat` returning `null` on a missing path.
- Validated locally: `tsc` (all configs) ✅, `eslint src/` ✅, `prettier --check .` ✅, full unit suite (**28,525 passing**) and relevant integration tests ✅.
  - One unrelated, pre-existing failure remains in `SessionActivityGraph.test.tsx` (a hardcoded `'May 13'` date assertion that fails based on the current date) — confirmed failing identically on `main` with these changes stashed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * File operations now gracefully return `null` for missing files instead of throwing errors
  * UI components updated to handle missing file data without crashing
  * History manager now safely handles malformed history files by recovering with fresh data

* **Tests**
  * Added regression tests for missing file scenarios and malformed history file handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->