### PR TITLE
fix(telemetry): stop reporting expected conditions as Sentry crashes

### DIFF
--- a/src/__tests__/main/agents/capability-snapshot.test.ts
+++ b/src/__tests__/main/agents/capability-snapshot.test.ts
@@ -26,8 +26,10 @@ function makeFakeStore(initial: AgentCapabilitiesSnapshotMap = {}) {
 // Silence Sentry calls — captureMessage is fire-and-forget so the implementation
 // just `void`-awaits it. Vitest will still log unhandled promise rejections
 // otherwise (the real impl tries to use `electron.app` which is unavailable here).
+// The hoisted handle lets us assert which failures DO and DON'T get reported.
+const { captureMessageMock } = vi.hoisted(() => ({ captureMessageMock: vi.fn() }));
 vi.mock('../../../main/utils/sentry', () => ({
-	captureMessage: vi.fn(),
+	captureMessage: captureMessageMock,
 	captureException: vi.fn(),
 }));
 
@@ -40,6 +42,7 @@ describe('CapabilitySnapshotManager', () => {
 		manager = new CapabilitySnapshotManager();
 		store = makeFakeStore();
 		broadcast = vi.fn();
+		captureMessageMock.mockReset();
 	});
 
 	it('starts empty before init()', () => {
@@ -166,5 +169,31 @@ describe('CapabilitySnapshotManager', () => {
 		const result = manager.markFailed('claude-code', 'boom');
 		expect(result.status).toBe('failed');
 		expect(result.lastError).toBe('boom');
+	});
+
+	it('markFailed reports unexpected probe errors to Sentry', () => {
+		manager.init(store, broadcast);
+		manager.markFailed('claude-code', 'boom');
+		expect(captureMessageMock).toHaveBeenCalledWith(
+			'agent-probe-failed',
+			'warning',
+			expect.objectContaining({ agentId: 'claude-code' })
+		);
+	});
+
+	it('markFailed skips Sentry for expected SSH/network failures but still persists (MAESTRO-RA)', () => {
+		manager.init(store, broadcast);
+		const expectedFailures = [
+			'SSH connection timed out after 10s',
+			'ssh: connect to host example.com port 22: Connection refused',
+			'ssh: Could not resolve hostname badhost',
+			'ssh: connect to host 10.0.0.1 port 22: No route to host',
+		];
+		for (const error of expectedFailures) {
+			const result = manager.markFailed('claude-code', error, 'remote-1');
+			expect(result.status).toBe('failed');
+			expect(result.lastError).toBe(error);
+		}
+		expect(captureMessageMock).not.toHaveBeenCalled();
 	});
 });

--- a/src/__tests__/main/agents/codex-usage-sampler.test.ts
+++ b/src/__tests__/main/agents/codex-usage-sampler.test.ts
@@ -134,4 +134,34 @@ describe('codex-usage-sampler', () => {
 		expect(snapshot.weekly).toBeUndefined();
 		expect(snapshot.additionalLimits).toEqual([]);
 	});
+
+	it('treats HTTP 401 as unauthenticated without reporting to Sentry (MAESTRO-RR)', async () => {
+		await fs.writeFile(
+			path.join(TEST_ROOT, 'auth.json'),
+			JSON.stringify({ tokens: { access_token: 'expired-token' } })
+		);
+		vi.mocked(globalThis.fetch).mockResolvedValue(new Response('Unauthorized', { status: 401 }));
+
+		const snapshot = await sampleCodexUsage({ codexHome: TEST_ROOT });
+
+		expect(snapshot.authState).toBe('unauthenticated');
+		expect(captureMessageMock).not.toHaveBeenCalled();
+	});
+
+	it('reports unexpected HTTP errors to Sentry (MAESTRO-RR)', async () => {
+		await fs.writeFile(
+			path.join(TEST_ROOT, 'auth.json'),
+			JSON.stringify({ tokens: { access_token: 'redacted-token' } })
+		);
+		vi.mocked(globalThis.fetch).mockResolvedValue(new Response('Server error', { status: 500 }));
+
+		const snapshot = await sampleCodexUsage({ codexHome: TEST_ROOT });
+
+		expect(snapshot.authState).toBe('error');
+		expect(captureMessageMock).toHaveBeenCalledWith(
+			'codex usage sample failed',
+			'warning',
+			expect.objectContaining({ reason: 'http 500' })
+		);
+	});
 });

--- a/src/__tests__/main/app-lifecycle/window-manager.test.ts
+++ b/src/__tests__/main/app-lifecycle/window-manager.test.ts
@@ -115,6 +115,14 @@ vi.mock('electron-devtools-installer', () => ({
 	REACT_DEVELOPER_TOOLS: 'REACT_DEVELOPER_TOOLS',
 }));
 
+// Mock Sentry main so we can assert which renderer terminations get reported.
+const { sentryCaptureMessageMock } = vi.hoisted(() => ({
+	sentryCaptureMessageMock: vi.fn(),
+}));
+vi.mock('@sentry/electron/main', () => ({
+	captureMessage: sentryCaptureMessageMock,
+}));
+
 describe('app-lifecycle/window-manager', () => {
 	let mockWindowStateStore: {
 		store: {
@@ -1435,6 +1443,48 @@ describe('app-lifecycle/window-manager', () => {
 				windowManager.createWindow();
 
 				expect(webContentsEventHandlers.has('crashed')).toBe(false);
+			});
+
+			async function fireRenderProcessGone(reason: string, exitCode: number) {
+				const { createWindowManager } = await import('../../../main/app-lifecycle/window-manager');
+				const windowManager = createWindowManager({
+					windowStateStore: mockWindowStateStore as unknown as Parameters<
+						typeof createWindowManager
+					>[0]['windowStateStore'],
+					isDevelopment: false,
+					preloadPath: '/path/to/preload.js',
+					rendererProductionUrl: 'app://app/index.html',
+					devServerUrl: 'http://localhost:5173',
+					useNativeTitleBar: false,
+					autoHideMenuBar: false,
+				});
+				windowManager.createWindow();
+				const handler = webContentsEventHandlers.get('render-process-gone');
+				handler?.({}, { reason, exitCode });
+			}
+
+			// MAESTRO-4X/4Y: intentional terminations (signal-killed / clean exit)
+			// must not be reported as fatal crashes - that buries real crashes.
+			it('does not report Sentry for an intentionally killed renderer (MAESTRO-4X)', async () => {
+				await fireRenderProcessGone('killed', 15);
+				await Promise.resolve();
+				expect(sentryCaptureMessageMock).not.toHaveBeenCalled();
+			});
+
+			it('does not report Sentry for a clean-exit renderer', async () => {
+				await fireRenderProcessGone('clean-exit', 0);
+				await Promise.resolve();
+				expect(sentryCaptureMessageMock).not.toHaveBeenCalled();
+			});
+
+			it('reports Sentry for a genuine renderer crash', async () => {
+				await fireRenderProcessGone('crashed', 139);
+				await vi.waitFor(() =>
+					expect(sentryCaptureMessageMock).toHaveBeenCalledWith(
+						'Renderer process gone: crashed',
+						expect.objectContaining({ level: 'fatal' })
+					)
+				);
 			});
 		});
 	});

--- a/src/main/agents/capability-snapshot.ts
+++ b/src/main/agents/capability-snapshot.ts
@@ -27,6 +27,21 @@ import { captureMessage } from '../utils/sentry';
 
 const LOG_CONTEXT = 'CapabilitySnapshot';
 
+/**
+ * Connection-level probe failures (SSH timeout, refused, unreachable host,
+ * DNS miss, reset) are expected and recoverable - they just mean a configured
+ * remote is currently offline or unreachable. They fire on every periodic
+ * reprobe of a down host, so reporting each one to Sentry buries genuinely
+ * unexpected probe failures under network noise. We still persist the `failed`
+ * status (red pill) so the UI reflects reality; we just skip the breadcrumb.
+ * Fixes MAESTRO-RA.
+ */
+function isExpectedConnectionFailure(error: string): boolean {
+	return /connection timed out|operation timed out|connection refused|connection reset|connection closed|network is unreachable|no route to host|could not resolve hostname|host key verification failed|timed out after \d+s/i.test(
+		error
+	);
+}
+
 // Re-export so main-process call sites have a single import path.
 export { SNAPSHOT_UPDATED_CHANNEL, type SnapshotUpdatedPayload };
 
@@ -138,11 +153,13 @@ export class CapabilitySnapshotManager {
 	 * Sends a low-volume Sentry breadcrumb so real-world failure modes surface.
 	 */
 	markFailed(agentId: string, error: string, remoteId?: string | null): AgentCapabilitiesSnapshot {
-		void captureMessage('agent-probe-failed', 'warning', {
-			agentId,
-			remoteId: remoteId ?? null,
-			error: error.slice(0, 500), // cap to avoid bloating sentry events
-		});
+		if (!isExpectedConnectionFailure(error)) {
+			void captureMessage('agent-probe-failed', 'warning', {
+				agentId,
+				remoteId: remoteId ?? null,
+				error: error.slice(0, 500), // cap to avoid bloating sentry events
+			});
+		}
 		return this.write(agentId, { status: 'failed', lastError: error }, remoteId);
 	}
 

--- a/src/main/agents/codex-usage-sampler.ts
+++ b/src/main/agents/codex-usage-sampler.ts
@@ -112,7 +112,13 @@ export async function sampleCodexUsage(opts: SampleCodexUsageOptions): Promise<C
 
 	if (!response.ok) {
 		const status = response.status;
-		void reportCodexUsageFailure(codexHomeKey, `http ${status}`);
+		// 401/403 just mean the CODEX_HOME isn't logged in - an expected,
+		// recoverable state we surface to the UI as `unauthenticated`, not a
+		// failure worth a Sentry breadcrumb. Only report genuinely unexpected
+		// HTTP errors. Fixes MAESTRO-RR.
+		if (status !== 401 && status !== 403) {
+			void reportCodexUsageFailure(codexHomeKey, `http ${status}`);
+		}
 		return {
 			sampledAt,
 			codexHomeKey,

--- a/src/main/app-lifecycle/window-manager.ts
+++ b/src/main/app-lifecycle/window-manager.ts
@@ -558,11 +558,22 @@ export function createWindowManager(deps: WindowManagerDependencies): WindowMana
 					exitCode: details.exitCode,
 				});
 
-				// Report to Sentry from main process (always available)
-				reportCrashToSentry(`Renderer process gone: ${details.reason}`, 'fatal', {
-					reason: details.reason,
-					exitCode: details.exitCode,
-				});
+				// `killed` (signal-terminated, e.g. app quit / OS shutdown / user
+				// force-quit) and `clean-exit` are intentional terminations, not
+				// crashes - the auto-reload guard below already treats them as such.
+				// Reporting them as `fatal` Sentry events is pure noise; genuine
+				// out-of-memory kills surface separately as reason `oom`. Only the
+				// real crash reasons (`crashed`, `oom`, `abnormal-exit`, etc.) are
+				// worth a breadcrumb. Fixes MAESTRO-4X/4Y.
+				const intentionalTermination =
+					details.reason === 'killed' || details.reason === 'clean-exit';
+				if (!intentionalTermination) {
+					// Report to Sentry from main process (always available)
+					reportCrashToSentry(`Renderer process gone: ${details.reason}`, 'fatal', {
+						reason: details.reason,
+						exitCode: details.exitCode,
+					});
+				}
 
 				// Auto-reload unless the process was intentionally killed
 				if (details.reason !== 'killed' && details.reason !== 'clean-exit') {


### PR DESCRIPTION
## Summary

Triaged the unresolved `channel:rc` Sentry issues and fixed three that are best-effort telemetry/crash breadcrumbs firing on **expected, recoverable** conditions. These bury genuine failures in noise and contradict the CLAUDE.md error-handling guidance ("handle expected/recoverable errors gracefully, don't capture them to Sentry"). Each capture site was validated against the actual code on `rc` before changing.

| Issue | Title | Events | Fix |
| --- | --- | --- | --- |
| [MAESTRO-RR](https://smash-labs.sentry.io/issues/MAESTRO-RR) | codex usage sample failed (`http 401`) | 321 | Don't report 401/403 - that's just an un-logged-in `CODEX_HOME`, already surfaced to the UI as `unauthenticated`. Still report unexpected statuses (500, etc.). |
| [MAESTRO-RA](https://smash-labs.sentry.io/issues/MAESTRO-RA) | agent-probe-failed (`SSH connection timed out`) | 147 | Skip the breadcrumb for connection-level failures (timeout / refused / unreachable / DNS / reset) that fire on every reprobe of an offline remote. Still persists the `failed` status pill, and still reports genuinely unexpected probe errors. |
| [MAESTRO-4X](https://smash-labs.sentry.io/issues/MAESTRO-4X) / [MAESTRO-4Y](https://smash-labs.sentry.io/issues/MAESTRO-4Y) | Renderer process gone: killed / WebContents crashed | 263 / 1014 | Don't report `killed`/`clean-exit` (intentional terminations the auto-reload guard already treats as such) as `fatal` crashes. Real OOM kills still surface separately as reason `oom`; real crashes (`crashed`, `abnormal-exit`, ...) still report. |

## Not addressed (deliberately)

- **MAESTRO-Q2** (`maestro-p --status sample failed`, `exit: 1`): `exit 1` is a generic exit code with no clean "expected" boundary - suppressing it risks masking a real spawn regression. Needs a human call on maestro-p's exit-code semantics.
- **MAESTRO-QH** (`shell:openPath ... reply was never sent`): only 5 events, a frame-teardown race; the main handler is already defensive (validates path, returns gracefully on missing files).

## Testing

- Added regression tests for all three fixes (401-vs-500 reporting, expected-vs-unexpected probe failures, intentional-vs-crash renderer terminations).
- `npx vitest run` for the three suites: **64 passed**.
- `tsc -p tsconfig.main.json`: clean. ESLint + Prettier: clean.

## Notes

- Targets `rc` (the buggy code lives only on `rc`). Because GitHub `Fixes` keywords auto-close only on merge into the default branch, these will close once `rc` reaches `main`.

Fixes MAESTRO-RR
Fixes MAESTRO-RA
Fixes MAESTRO-4X
Fixes MAESTRO-4Y

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling for authentication-related failures to prevent unnecessary error reporting.
  * Enhanced crash detection to distinguish between intentional process terminations and genuine crashes.
  * Refined error classification to better identify expected vs. unexpected connection failures, improving diagnostic accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->