### PR TITLE
feat(themes): add themeable bgTitleBar token for the window title bar

### DIFF
--- a/src/__tests__/renderer/constants/themes.test.ts
+++ b/src/__tests__/renderer/constants/themes.test.ts
@@ -15,6 +15,7 @@ const REQUIRED_COLORS: (keyof ThemeColors)[] = [
 	'bgMain',
 	'bgSidebar',
 	'bgActivity',
+	'bgTitleBar',
 	'border',
 	'textMain',
 	'textDim',

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -2818,6 +2818,9 @@ function MaestroConsoleInner() {
 						style={
 							{
 								WebkitAppRegion: 'drag',
+								// Falls back to bgMain (the historical see-through behavior)
+								// for themes/saved customs that predate the bgTitleBar token.
+								backgroundColor: theme.colors.bgTitleBar ?? theme.colors.bgMain,
 							} as React.CSSProperties
 						}
 					>

--- a/src/renderer/components/CustomThemeBuilder.tsx
+++ b/src/renderer/components/CustomThemeBuilder.tsx
@@ -37,6 +37,7 @@ const COLOR_CONFIG: { key: keyof ThemeColors; label: string; description: string
 	{ key: 'bgMain', label: 'Main Background', description: 'Primary content area' },
 	{ key: 'bgSidebar', label: 'Sidebar Background', description: 'Left & right panels' },
 	{ key: 'bgActivity', label: 'Activity Background', description: 'Hover, active states' },
+	{ key: 'bgTitleBar', label: 'Title Bar Background', description: 'Top draggable window strip' },
 	{ key: 'border', label: 'Border', description: 'Dividers & outlines' },
 	{ key: 'textMain', label: 'Main Text', description: 'Primary text color' },
 	{ key: 'textDim', label: 'Dimmed Text', description: 'Secondary text' },
@@ -53,15 +54,23 @@ const COLOR_CONFIG: { key: keyof ThemeColors; label: string; description: string
 function MiniUIPreview({ colors }: { colors: ThemeColors }) {
 	return (
 		<div
-			className="rounded-lg overflow-hidden border"
+			className="rounded-lg overflow-hidden border flex flex-col"
 			style={{
 				borderColor: colors.border,
 				width: '100%',
 				height: 140,
 			}}
 		>
+			{/* Draggable title bar strip */}
+			<div
+				className="h-3 shrink-0 border-b"
+				style={{
+					backgroundColor: colors.bgTitleBar ?? colors.bgMain,
+					borderColor: colors.border,
+				}}
+			/>
 			{/* Mini UI layout */}
-			<div className="flex h-full">
+			<div className="flex flex-1 min-h-0">
 				{/* Left sidebar */}
 				<div className="w-12 flex flex-col gap-1 p-1" style={{ backgroundColor: colors.bgSidebar }}>
 					{/* Session items */}
@@ -595,7 +604,9 @@ export function CustomThemeBuilder({
 								colorKey={key}
 								label={label}
 								description={description}
-								value={customThemeColors[key] ?? ''}
+								value={
+									customThemeColors[key] ?? (key === 'bgTitleBar' ? customThemeColors.bgMain : '')
+								}
 								onChange={handleColorChange}
 								theme={theme}
 							/>

--- a/src/shared/theme-types.ts
+++ b/src/shared/theme-types.ts
@@ -50,6 +50,14 @@ export interface ThemeColors {
 	bgSidebar: string;
 	/** Background for interactive/activity elements */
 	bgActivity: string;
+	/**
+	 * Background for the draggable window title bar (the top strip that holds
+	 * the traffic-light buttons and the centered agent title). Optional: when
+	 * unset the title bar renders transparent and shows `bgMain` behind it,
+	 * which is the historical behavior. Built-in themes set it explicitly to
+	 * their `bgMain` so existing themes look unchanged.
+	 */
+	bgTitleBar?: string;
 	/** Border color for dividers and outlines */
 	border: string;
 	/** Primary text color */

--- a/src/shared/themes.ts
+++ b/src/shared/themes.ts
@@ -403,6 +403,7 @@ export const THEMES: Record<ThemeId, Theme> = {
 		mode: 'dark',
 		colors: {
 			bgMain: '#282a36',
+			bgTitleBar: '#282a36',
 			bgSidebar: '#21222c',
 			bgActivity: '#343746',
 			border: '#44475a',
@@ -424,6 +425,7 @@ export const THEMES: Record<ThemeId, Theme> = {
 		mode: 'dark',
 		colors: {
 			bgMain: '#272822',
+			bgTitleBar: '#272822',
 			bgSidebar: '#1e1f1c',
 			bgActivity: '#3e3d32',
 			border: '#49483e',
@@ -445,6 +447,7 @@ export const THEMES: Record<ThemeId, Theme> = {
 		mode: 'dark',
 		colors: {
 			bgMain: '#2e3440',
+			bgTitleBar: '#2e3440',
 			bgSidebar: '#3b4252',
 			bgActivity: '#434c5e',
 			border: '#4c566a',
@@ -466,6 +469,7 @@ export const THEMES: Record<ThemeId, Theme> = {
 		mode: 'dark',
 		colors: {
 			bgMain: '#1a1b26',
+			bgTitleBar: '#1a1b26',
 			bgSidebar: '#16161e',
 			bgActivity: '#24283b',
 			border: '#414868',
@@ -487,6 +491,7 @@ export const THEMES: Record<ThemeId, Theme> = {
 		mode: 'dark',
 		colors: {
 			bgMain: '#1e1e2e',
+			bgTitleBar: '#1e1e2e',
 			bgSidebar: '#181825',
 			bgActivity: '#313244',
 			border: '#45475a',
@@ -508,6 +513,7 @@ export const THEMES: Record<ThemeId, Theme> = {
 		mode: 'dark',
 		colors: {
 			bgMain: '#282828',
+			bgTitleBar: '#282828',
 			bgSidebar: '#1d2021',
 			bgActivity: '#3c3836',
 			border: '#504945',
@@ -529,6 +535,7 @@ export const THEMES: Record<ThemeId, Theme> = {
 		mode: 'dark',
 		colors: {
 			bgMain: '#002b36',
+			bgTitleBar: '#002b36',
 			bgSidebar: '#073642',
 			bgActivity: '#0a4050',
 			border: '#2f4f56',
@@ -549,6 +556,7 @@ export const THEMES: Record<ThemeId, Theme> = {
 		mode: 'dark',
 		colors: {
 			bgMain: '#0a0b0a',
+			bgTitleBar: '#0a0b0a',
 			bgSidebar: '#0a0a0a',
 			bgActivity: '#111311',
 			border: '#0f0f0f',
@@ -570,6 +578,7 @@ export const THEMES: Record<ThemeId, Theme> = {
 		mode: 'light',
 		colors: {
 			bgMain: '#ffffff',
+			bgTitleBar: '#ffffff',
 			bgSidebar: '#f6f8fa',
 			bgActivity: '#eff2f5',
 			border: '#d0d7de',
@@ -591,6 +600,7 @@ export const THEMES: Record<ThemeId, Theme> = {
 		mode: 'light',
 		colors: {
 			bgMain: '#fdf6e3',
+			bgTitleBar: '#fdf6e3',
 			bgSidebar: '#eee8d5',
 			bgActivity: '#e6dfc8',
 			border: '#d3cbb7',
@@ -612,6 +622,7 @@ export const THEMES: Record<ThemeId, Theme> = {
 		mode: 'light',
 		colors: {
 			bgMain: '#fafafa',
+			bgTitleBar: '#fafafa',
 			bgSidebar: '#eaeaeb',
 			bgActivity: '#dbdbdc',
 			border: '#c8c8c9',
@@ -633,6 +644,7 @@ export const THEMES: Record<ThemeId, Theme> = {
 		mode: 'light',
 		colors: {
 			bgMain: '#fbf1c7',
+			bgTitleBar: '#fbf1c7',
 			bgSidebar: '#ebdbb2',
 			bgActivity: '#d5c4a1',
 			border: '#bdae93',
@@ -654,6 +666,7 @@ export const THEMES: Record<ThemeId, Theme> = {
 		mode: 'light',
 		colors: {
 			bgMain: '#eff1f5',
+			bgTitleBar: '#eff1f5',
 			bgSidebar: '#e6e9ef',
 			bgActivity: '#dce0e8',
 			border: '#acb0be',
@@ -675,6 +688,7 @@ export const THEMES: Record<ThemeId, Theme> = {
 		mode: 'light',
 		colors: {
 			bgMain: '#fafafa',
+			bgTitleBar: '#fafafa',
 			bgSidebar: '#f3f4f5',
 			bgActivity: '#e7e8e9',
 			border: '#d9d9d9',
@@ -697,6 +711,7 @@ export const THEMES: Record<ThemeId, Theme> = {
 		mode: 'vibe',
 		colors: {
 			bgMain: '#1a0f24',
+			bgTitleBar: '#1a0f24',
 			bgSidebar: '#140a1c',
 			bgActivity: '#2a1a3a',
 			border: '#4a2a6a',
@@ -718,6 +733,7 @@ export const THEMES: Record<ThemeId, Theme> = {
 		mode: 'vibe',
 		colors: {
 			bgMain: '#1a1a24',
+			bgTitleBar: '#1a1a24',
 			bgSidebar: '#141420',
 			bgActivity: '#24243a',
 			border: '#3a3a5a',
@@ -739,6 +755,7 @@ export const THEMES: Record<ThemeId, Theme> = {
 		mode: 'vibe',
 		colors: {
 			bgMain: '#0d0221',
+			bgTitleBar: '#0d0221',
 			bgSidebar: '#0a0118',
 			bgActivity: '#150530',
 			border: '#00d4aa',
@@ -760,6 +777,7 @@ export const THEMES: Record<ThemeId, Theme> = {
 		mode: 'vibe',
 		colors: {
 			bgMain: '#0a0a0a',
+			bgTitleBar: '#0a0a0a',
 			bgSidebar: '#252323',
 			bgActivity: '#141414',
 			border: '#4a3838',
@@ -781,6 +799,7 @@ export const THEMES: Record<ThemeId, Theme> = {
 		mode: 'vibe',
 		colors: {
 			bgMain: '#232323',
+			bgTitleBar: '#232323',
 			bgSidebar: '#1a1a1a',
 			bgActivity: '#3a3a3a',
 			border: '#4a4a4a',
@@ -803,6 +822,7 @@ export const THEMES: Record<ThemeId, Theme> = {
 		mode: 'dark',
 		colors: {
 			bgMain: '#282a36',
+			bgTitleBar: '#282a36',
 			bgSidebar: '#21222c',
 			bgActivity: '#343746',
 			border: '#44475a',


### PR DESCRIPTION
## Summary

The draggable window title bar (the top strip with the traffic-light buttons and the centered agent title) rendered **transparent** and showed `bgMain` behind it. Themes had no way to color that strip independently, so on light themes it always read as the lightest color in the palette.

This adds a themeable `bgTitleBar` token so the title bar can be colored per-theme.

## What changed

- **`src/shared/theme-types.ts`** - new optional `bgTitleBar?` field on `ThemeColors`. Optional (like the ANSI keys) so pre-existing saved/imported custom themes degrade gracefully.
- **`src/shared/themes.ts`** - set `bgTitleBar` on **all 20 built-in themes**, each mirroring its own `bgMain`, so every existing theme looks **pixel-identical** after this change.
- **`src/renderer/App.tsx`** - wire the title bar background to `bgTitleBar ?? bgMain` (the fallback reproduces today's behavior for any theme lacking the key).
- **`src/renderer/components/CustomThemeBuilder.tsx`** - new editable "Title Bar Background" field + a title-bar strip in the live preview.
- **`src/__tests__/renderer/constants/themes.test.ts`** - add `bgTitleBar` to `REQUIRED_COLORS`.

## Backward compatibility

`bgTitleBar` defaults to `bgMain` everywhere it is unset (built-in themes set it explicitly; the runtime falls back via `?? bgMain`). No theme changes appearance unless its `bgTitleBar` is deliberately set to something different.

## Validation

- Theme test suite: 11 pass / 0 fail
- Touched files: 0 TypeScript errors, 0 ESLint errors
- prettier + eslint --fix ran clean via lint-staged on commit

## Notes

- Requires an app restart (not just a theme re-import) to pick up the new `App.tsx` wiring.
- A parallel PR targets `rc` with the same single commit cherry-picked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Title bar background color is now customizable in the theme builder with a dedicated preview.
  * All built-in themes now include explicit title bar color configuration for consistent appearance.
  * Custom theme builder extends color options to include dedicated title bar styling.
  * Theme system validates title bar color requirements for all themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->