### PR TITLE
Backport rc Tier-1 fixes to main

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -2,4 +2,25 @@
 
 # Run repo-wide validation before allowing a push.
 # This mirrors the main CI gate: prompts, repo-wide Prettier, type checks, ESLint, and tests.
+#
+# Skip validation when the push only DELETES refs (no new commits to validate).
+# Git feeds ref updates on stdin as: <local ref> <local sha> <remote ref> <remote sha>
+# For a deletion the local sha is all zeros, so there is nothing to lint or test.
+z40=0000000000000000000000000000000000000000
+only_deletes=1
+saw_ref=0
+while read -r local_ref local_sha remote_ref remote_sha; do
+	[ -z "$local_ref$remote_ref" ] && continue
+	saw_ref=1
+	case "$local_sha" in
+		"$z40" | "") : ;; # deletion, nothing to validate
+		*) only_deletes=0 ;;
+	esac
+done
+
+if [ "$saw_ref" -eq 1 ] && [ "$only_deletes" -eq 1 ]; then
+	echo "[pre-push] Delete-only push detected; skipping validate:push."
+	exit 0
+fi
+
 npm run validate:push

--- a/src/__tests__/helpers/mockTheme.ts
+++ b/src/__tests__/helpers/mockTheme.ts
@@ -38,6 +38,7 @@ export const mockThemeColors: ThemeColors = {
 	bgMain: '#282a36',
 	bgSidebar: '#21222c',
 	bgActivity: '#343746',
+	bgTitleBar: '#191a21',
 	border: '#44475a',
 	textMain: '#f8f8f2',
 	textDim: '#6272a4',

--- a/src/__tests__/main/cue/cue-spawn-builder.test.ts
+++ b/src/__tests__/main/cue/cue-spawn-builder.test.ts
@@ -5,7 +5,7 @@
  * config overrides, SSH wrapping, and prompt appending.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { CueExecutionConfig } from '../../../main/cue/cue-executor';
 import type { CueEvent, CueSubscription } from '../../../main/cue/cue-types';
 import type { SessionInfo } from '../../../shared/types';
@@ -132,6 +132,15 @@ describe('cue-spawn-builder', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		mockGetAgentDefinition.mockReturnValue(defaultAgentDef);
+		// The spec env spreads process.env, so an ambient MAESTRO_CLAUDE_BIN
+		// (leaked when these tests run inside a maestro/claude agent) would bleed
+		// into specs and trip the "maestro-p disabled -> undefined" assertion.
+		// Clear it so the suite asserts only what the builder itself injects.
+		vi.stubEnv('MAESTRO_CLAUDE_BIN', undefined as unknown as string);
+	});
+
+	afterEach(() => {
+		vi.unstubAllEnvs();
 	});
 
 	describe('buildSpawnSpec', () => {

--- a/src/__tests__/main/stores/migrations/adaptive-mode-default.test.ts
+++ b/src/__tests__/main/stores/migrations/adaptive-mode-default.test.ts
@@ -33,12 +33,15 @@ describe('migrateAdaptiveModeDefault', () => {
 		vi.clearAllMocks();
 	});
 
-	it('enables Adaptive Mode on existing Claude Code agents and leaves others untouched', () => {
+	it('backfills only never-configured Claude Code agents, preserving explicit choices and other agents', () => {
 		const sessionsStore = makeStore({
 			sessions: [
 				{ id: 'a', toolType: 'claude-code', name: 'Claude' },
 				{ id: 'b', toolType: 'codex', name: 'Codex' },
 				{ id: 'c', toolType: 'claude-code', name: 'Already on', enableMaestroP: true },
+				// Explicit API choice (false) must survive the backfill - flipping it
+				// on would silently revert the user's token source to Dynamic.
+				{ id: 'd', toolType: 'claude-code', name: 'Picked API', enableMaestroP: false },
 			],
 		});
 		mockedGetSessionsStore.mockReturnValue(sessionsStore as any);
@@ -51,7 +54,24 @@ describe('migrateAdaptiveModeDefault', () => {
 			{ id: 'a', toolType: 'claude-code', name: 'Claude', enableMaestroP: true },
 			{ id: 'b', toolType: 'codex', name: 'Codex' },
 			{ id: 'c', toolType: 'claude-code', name: 'Already on', enableMaestroP: true },
+			{ id: 'd', toolType: 'claude-code', name: 'Picked API', enableMaestroP: false },
 		]);
+		expect(settingsStore.data[ADAPTIVE_MODE_DEFAULT_MIGRATION_MARKER]).toBe(true);
+	});
+
+	it('sets the marker without writing sessions when every agent already has an explicit choice', () => {
+		const sessionsStore = makeStore({
+			sessions: [
+				{ id: 'c', toolType: 'claude-code', name: 'On', enableMaestroP: true },
+				{ id: 'd', toolType: 'claude-code', name: 'API', enableMaestroP: false },
+			],
+		});
+		mockedGetSessionsStore.mockReturnValue(sessionsStore as any);
+		const settingsStore = makeStore();
+
+		migrateAdaptiveModeDefault(settingsStore as any);
+
+		expect(sessionsStore.set).not.toHaveBeenCalled();
 		expect(settingsStore.data[ADAPTIVE_MODE_DEFAULT_MIGRATION_MARKER]).toBe(true);
 	});
 

--- a/src/__tests__/main/utils/ssh-command-builder.test.ts
+++ b/src/__tests__/main/utils/ssh-command-builder.test.ts
@@ -366,6 +366,21 @@ describe('ssh-command-builder', () => {
 			expect(lastArg).toContain('hello world');
 		});
 
+		it('exposes the bare remote agent invocation via remoteCommandLine', async () => {
+			const result = await buildSshCommand(baseConfig, {
+				command: 'claude',
+				args: ['--print', 'hello world'],
+				cwd: '/home/user/project',
+				env: { API_KEY: 'test-key' },
+			});
+
+			// remoteCommandLine is the agent invocation only - no cd/env prefix, no
+			// /bin/bash PATH bootstrap wrapper - for display in Process Details.
+			expect(result.remoteCommandLine).toBe("claude '--print' 'hello world'");
+			expect(result.remoteCommandLine).not.toContain('cd ');
+			expect(result.remoteCommandLine).not.toContain('export PATH=');
+		});
+
 		it('properly formats the SSH command for spawning', async () => {
 			const result = await buildSshCommand(baseConfig, {
 				command: 'claude',
@@ -712,6 +727,19 @@ describe('ssh-command-builder', () => {
 			expect(result.args).toEqual(
 				expect.arrayContaining(['/bin/bash', '--norc', '--noprofile', '-s'])
 			);
+		});
+
+		it('exposes the bare remote agent invocation via remoteCommandLine', async () => {
+			const result = await buildSshCommandWithStdin(baseConfig, {
+				command: 'opencode',
+				args: ['run', '--format', 'json'],
+			});
+
+			// The remote command line is the agent invocation only - no PATH bootstrap,
+			// no `exec` wrapper - so the Process Details modal can show what runs remotely.
+			expect(result.remoteCommandLine).toBe("opencode 'run' '--format' 'json'");
+			expect(result.remoteCommandLine).not.toContain('exec ');
+			expect(result.remoteCommandLine).not.toContain('export PATH=');
 		});
 
 		it('includes PATH setup in stdin script', async () => {

--- a/src/__tests__/renderer/components/CustomThemeBuilder.test.tsx
+++ b/src/__tests__/renderer/components/CustomThemeBuilder.test.tsx
@@ -356,6 +356,66 @@ describe('CustomThemeBuilder', () => {
 				});
 			});
 
+			it('should import a theme that omits the optional bgTitleBar key', async () => {
+				// Older/partial exports may omit the optional bgTitleBar key and
+				// must still import successfully (the UI falls back to bgMain).
+				const colorsWithoutTitleBar = { ...mockThemeColors } as ThemeColors;
+				delete colorsWithoutTitleBar.bgTitleBar;
+
+				render(
+					<CustomThemeBuilder
+						theme={mockTheme}
+						customThemeColors={mockThemeColors}
+						setCustomThemeColors={setCustomThemeColors}
+						customThemeBaseId="dracula"
+						setCustomThemeBaseId={setCustomThemeBaseId}
+						isSelected={false}
+						onSelect={onSelect}
+						onImportError={onImportError}
+						onImportSuccess={onImportSuccess}
+					/>
+				);
+
+				const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+				const file = createFileFromJSON(createValidThemeJSON(colorsWithoutTitleBar));
+				await simulateFileUpload(fileInput, file);
+
+				await waitFor(() => {
+					expect(setCustomThemeColors).toHaveBeenCalledWith(colorsWithoutTitleBar);
+					expect(onImportError).not.toHaveBeenCalled();
+				});
+			});
+
+			it('should reject a theme whose optional bgTitleBar value is invalid', async () => {
+				const colorsWithBadTitleBar = {
+					...mockThemeColors,
+					bgTitleBar: 'not-a-color',
+				};
+
+				render(
+					<CustomThemeBuilder
+						theme={mockTheme}
+						customThemeColors={mockThemeColors}
+						setCustomThemeColors={setCustomThemeColors}
+						customThemeBaseId="dracula"
+						setCustomThemeBaseId={setCustomThemeBaseId}
+						isSelected={false}
+						onSelect={onSelect}
+						onImportError={onImportError}
+						onImportSuccess={onImportSuccess}
+					/>
+				);
+
+				const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+				const file = createFileFromJSON(createValidThemeJSON(colorsWithBadTitleBar));
+				await simulateFileUpload(fileInput, file);
+
+				await waitFor(() => {
+					expect(onImportError).toHaveBeenCalled();
+					expect(setCustomThemeColors).not.toHaveBeenCalled();
+				});
+			});
+
 			it('should accept valid CSS color names', async () => {
 				const namedColors = {
 					...mockThemeColors,

--- a/src/__tests__/renderer/components/ProcessMonitor/ProcessDetailView.test.tsx
+++ b/src/__tests__/renderer/components/ProcessMonitor/ProcessDetailView.test.tsx
@@ -45,6 +45,9 @@ describe('ProcessDetailView', () => {
 		expect(screen.getByText('claude-code')).toBeInTheDocument();
 		expect(screen.getByText('/Users/test/project')).toBeInTheDocument();
 		expect(screen.getByText('/usr/bin/claude --no-color chat')).toBeInTheDocument();
+		// Local process: command tile labeled "Command Line", no Remote Command tile.
+		expect(screen.getByText('Command Line')).toBeInTheDocument();
+		expect(screen.queryByText('Remote Command')).not.toBeInTheDocument();
 	});
 
 	it('hides optional fields when not provided', () => {
@@ -55,6 +58,31 @@ describe('ProcessDetailView', () => {
 		expect(screen.queryByText('Tab Name')).not.toBeInTheDocument();
 		expect(screen.queryByText('Cue Subscription')).not.toBeInTheDocument();
 		expect(screen.queryByText('AUTO RUN')).not.toBeInTheDocument();
+		expect(screen.queryByText('Remote Command')).not.toBeInTheDocument();
+	});
+
+	it('shows the remote agent command above the SSH command for SSH spawns', () => {
+		render(
+			<ProcessDetailView
+				theme={theme}
+				detail={{
+					...baseDetail,
+					command: '/usr/bin/ssh',
+					args: ['-o', 'BatchMode=yes', 'host', '/bin/bash', '--norc', '--noprofile', '-s'],
+					sshRemoteCommand: "claude '--print' '--output-format' 'stream-json'",
+				}}
+				onBack={() => {}}
+				onClose={() => {}}
+			/>
+		);
+		// Remote agent invocation is surfaced...
+		expect(screen.getByText('Remote Command')).toBeInTheDocument();
+		expect(
+			screen.getByText("claude '--print' '--output-format' 'stream-json'")
+		).toBeInTheDocument();
+		// ...and the local SSH wrapper tile is relabeled "SSH Command".
+		expect(screen.getByText('SSH Command')).toBeInTheDocument();
+		expect(screen.queryByText('Command Line')).not.toBeInTheDocument();
 	});
 
 	it('renders Cue-specific fields when present', () => {

--- a/src/__tests__/renderer/components/TerminalView.test.tsx
+++ b/src/__tests__/renderer/components/TerminalView.test.tsx
@@ -309,7 +309,7 @@ describe('TerminalView — auto-close on shell exit', () => {
 			vi.advanceTimersByTime(1);
 		});
 
-		expect(mockCloseTerminalTab).toHaveBeenCalledWith('tab-1');
+		expect(mockCloseTerminalTab).toHaveBeenCalledWith('tab-1', 'pty-exit');
 		vi.useRealTimers();
 	});
 
@@ -336,7 +336,7 @@ describe('TerminalView — auto-close on shell exit', () => {
 		});
 
 		// Tab should be closed
-		expect(mockCloseTerminalTab).toHaveBeenCalledWith('tab-1');
+		expect(mockCloseTerminalTab).toHaveBeenCalledWith('tab-1', 'pty-exit');
 
 		// Toast is debounced (200ms) — advance past the dedup window
 		act(() => {
@@ -389,8 +389,8 @@ describe('TerminalView — auto-close on shell exit', () => {
 		});
 
 		// Both tabs should be closed
-		expect(mockCloseTerminalTab).toHaveBeenCalledWith('tab-1');
-		expect(mockCloseTerminalTab).toHaveBeenCalledWith('tab-2');
+		expect(mockCloseTerminalTab).toHaveBeenCalledWith('tab-1', 'pty-exit');
+		expect(mockCloseTerminalTab).toHaveBeenCalledWith('tab-2', 'pty-exit');
 
 		// Before dedup timer fires, no toast yet
 		expect(mockNotifyToast).not.toHaveBeenCalled();
@@ -408,6 +408,76 @@ describe('TerminalView — auto-close on shell exit', () => {
 				title: 'Failed to start 2 terminals',
 			})
 		);
+		vi.useRealTimers();
+	});
+
+	it('does NOT close a tab with a startup command on exit (kept for restart)', () => {
+		vi.useFakeTimers();
+		// A startup-command tab is "persistent" - exiting must not destroy its config.
+		const tab = makeTab({
+			pid: 1234,
+			state: 'busy',
+			createdAt: Date.now() - 5000,
+			startupCommand: 'npm run dev',
+		});
+		const session = makeSession([tab]);
+
+		const { rerender } = render(
+			<TerminalView {...defaultProps} session={session} isVisible={true} />
+		);
+
+		const exitedTab = makeTab({
+			pid: 1234,
+			state: 'exited',
+			exitCode: 0,
+			createdAt: Date.now() - 5000,
+			startupCommand: 'npm run dev',
+		});
+		act(() => {
+			rerender(
+				<TerminalView {...defaultProps} session={makeSession([exitedTab])} isVisible={true} />
+			);
+		});
+		act(() => {
+			vi.advanceTimersByTime(1);
+		});
+
+		expect(mockCloseTerminalTab).not.toHaveBeenCalled();
+		vi.useRealTimers();
+	});
+
+	it('does NOT close a tab under an SSH session on exit (kept for restart)', () => {
+		vi.useFakeTimers();
+		// A remote tab's PTY can exit when the SSH transport drops - that must not
+		// silently discard the tab. This is the root cause of vanishing terminals.
+		const tab = makeTab({ pid: 1234, state: 'busy', createdAt: Date.now() - 5000 });
+		const remoteSession = {
+			...makeSession([tab]),
+			sshRemoteId: 'remote-1',
+		} as unknown as Session;
+
+		const { rerender } = render(
+			<TerminalView {...defaultProps} session={remoteSession} isVisible={true} />
+		);
+
+		const exitedTab = makeTab({
+			pid: 1234,
+			state: 'exited',
+			exitCode: 255,
+			createdAt: Date.now() - 5000,
+		});
+		const exitedRemoteSession = {
+			...makeSession([exitedTab]),
+			sshRemoteId: 'remote-1',
+		} as unknown as Session;
+		act(() => {
+			rerender(<TerminalView {...defaultProps} session={exitedRemoteSession} isVisible={true} />);
+		});
+		act(() => {
+			vi.advanceTimersByTime(1);
+		});
+
+		expect(mockCloseTerminalTab).not.toHaveBeenCalled();
 		vi.useRealTimers();
 	});
 });

--- a/src/__tests__/renderer/hooks/useSessionCategories.test.ts
+++ b/src/__tests__/renderer/hooks/useSessionCategories.test.ts
@@ -293,6 +293,45 @@ describe('useSessionCategories', () => {
 			expect(names).toContain('Busy Agent');
 		});
 
+		it('includes auto-running agents (AUTO badge) even when idle without unread tabs', () => {
+			const s1 = makeSession({
+				name: 'Has Unread',
+				aiTabs: [{ id: 't1', hasUnread: true } as any],
+			});
+			const s2 = makeSession({
+				name: 'Auto Run Agent',
+				aiTabs: [{ id: 't2', hasUnread: false } as any],
+			});
+			const s3 = makeSession({ name: 'Idle No Unread' });
+			resetStore([s1, s2, s3]);
+
+			const { result } = renderHook(() =>
+				useSessionCategories('', [s1, s2, s3], true, null, [s2.id])
+			);
+
+			expect(result.current.sortedFilteredSessions).toHaveLength(2);
+			const names = result.current.sortedFilteredSessions.map((s) => s.name);
+			expect(names).toContain('Has Unread');
+			expect(names).toContain('Auto Run Agent');
+		});
+
+		it('keeps parent visible when a worktree child is auto-running', () => {
+			const parent = makeSession({ name: 'Parent' });
+			const child = makeSession({
+				name: 'Worktree Child',
+				parentSessionId: parent.id,
+				aiTabs: [{ id: 't1', hasUnread: false } as any],
+			});
+			resetStore([parent, child]);
+
+			const { result } = renderHook(() =>
+				useSessionCategories('', [parent, child], true, null, [child.id])
+			);
+
+			expect(result.current.sortedFilteredSessions).toHaveLength(1);
+			expect(result.current.sortedFilteredSessions[0].name).toBe('Parent');
+		});
+
 		it('keeps parent visible when active session is a worktree child without unread', () => {
 			const parent = makeSession({ name: 'Parent' });
 			const child = makeSession({

--- a/src/__tests__/renderer/stores/tabStore.test.ts
+++ b/src/__tests__/renderer/stores/tabStore.test.ts
@@ -965,3 +965,54 @@ describe('closeTerminalTab', () => {
 		expect(session.inputMode).toBe('ai');
 	});
 });
+
+describe('restartTerminalTab', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		useSessionStore.setState({ sessions: [], activeSessionId: null });
+	});
+
+	it('resets the exited tab, selects it, and switches to terminal mode', () => {
+		const tab = createMockTerminalTabForStore({
+			id: 'term-1',
+			pid: 4242,
+			state: 'exited',
+			exitCode: 255,
+		});
+		setupSessionWithTerminalTabs([tab]);
+
+		act(() => {
+			useTabStore.getState().restartTerminalTab('term-1');
+		});
+
+		const session = useSessionStore.getState().sessions[0];
+		expect(session.terminalTabs![0].pid).toBe(0);
+		expect(session.terminalTabs![0].state).toBe('idle');
+		expect(session.terminalTabs![0].exitCode).toBeUndefined();
+		expect(session.activeTerminalTabId).toBe('term-1');
+		expect(session.inputMode).toBe('terminal');
+	});
+
+	it('kills any lingering PTY before respawn', () => {
+		const tab = createMockTerminalTabForStore({ id: 'term-1', pid: 4242, state: 'exited' });
+		setupSessionWithTerminalTabs([tab]);
+
+		act(() => {
+			useTabStore.getState().restartTerminalTab('term-1');
+		});
+
+		expect(window.maestro.process.kill).toHaveBeenCalledTimes(1);
+		expect(window.maestro.process.kill).toHaveBeenCalledWith(expect.stringContaining('term-1'));
+	});
+
+	it('does nothing when the tab does not exist', () => {
+		const tab = createMockTerminalTabForStore({ id: 'term-1', state: 'exited' });
+		setupSessionWithTerminalTabs([tab]);
+
+		act(() => {
+			useTabStore.getState().restartTerminalTab('nonexistent');
+		});
+
+		expect(window.maestro.process.kill).not.toHaveBeenCalled();
+	});
+});

--- a/src/__tests__/renderer/utils/terminalTabHelpers.test.ts
+++ b/src/__tests__/renderer/utils/terminalTabHelpers.test.ts
@@ -25,6 +25,7 @@ import {
 	addTerminalTab,
 	closeTerminalTab,
 	selectTerminalTab,
+	restartTerminalTab,
 	updateTerminalTabState,
 	updateTerminalTabPid,
 	updateTerminalTabCwd,
@@ -442,6 +443,54 @@ describe('selectTerminalTab', () => {
 	it('returns original session when tab not found', () => {
 		const session = createMockSession({ terminalTabs: [] });
 		const updated = selectTerminalTab(session, 'nonexistent');
+		expect(updated).toBe(session);
+	});
+});
+
+describe('restartTerminalTab', () => {
+	it('resets an exited tab to a spawnable state', () => {
+		const tab = createMockTerminalTab({
+			id: 'tab-1',
+			pid: 4242,
+			state: 'exited',
+			exitCode: 255,
+		});
+		const session = createMockSession({ terminalTabs: [tab], activeTerminalTabId: null });
+		const updated = restartTerminalTab(session, 'tab-1');
+		expect(updated.terminalTabs![0].pid).toBe(0);
+		expect(updated.terminalTabs![0].state).toBe('idle');
+		expect(updated.terminalTabs![0].exitCode).toBeUndefined();
+	});
+
+	it('preserves the startup command so the restart re-runs it', () => {
+		const tab = createMockTerminalTab({
+			id: 'tab-1',
+			pid: 99,
+			state: 'exited',
+			startupCommand: 'ssh prod',
+		});
+		const session = createMockSession({ terminalTabs: [tab] });
+		const updated = restartTerminalTab(session, 'tab-1');
+		expect(updated.terminalTabs![0].startupCommand).toBe('ssh prod');
+	});
+
+	it('selects the restarted tab and clears other active tab kinds', () => {
+		const tab = createMockTerminalTab({ id: 'tab-1', state: 'exited' });
+		const session = createMockSession({
+			terminalTabs: [tab],
+			activeTerminalTabId: null,
+			activeFileTabId: 'file-tab-1',
+			activeBrowserTabId: 'browser-tab-1',
+		});
+		const updated = restartTerminalTab(session, 'tab-1');
+		expect(updated.activeTerminalTabId).toBe('tab-1');
+		expect(updated.activeFileTabId).toBeNull();
+		expect(updated.activeBrowserTabId).toBeNull();
+	});
+
+	it('returns original session when tab not found', () => {
+		const session = createMockSession({ terminalTabs: [] });
+		const updated = restartTerminalTab(session, 'nonexistent');
 		expect(updated).toBe(session);
 	});
 });

--- a/src/__tests__/shared/cssColor.test.ts
+++ b/src/__tests__/shared/cssColor.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { isValidCssColor } from '../../shared/cssColor';
+
+describe('isValidCssColor', () => {
+	describe('hex colors', () => {
+		it('accepts 6- and 8-digit hex', () => {
+			expect(isValidCssColor('#282a36')).toBe(true);
+			expect(isValidCssColor('#bd93f9')).toBe(true);
+			expect(isValidCssColor('#282a36ff')).toBe(true);
+		});
+
+		it('accepts 3- and 4-digit hex', () => {
+			expect(isValidCssColor('#abc')).toBe(true);
+			expect(isValidCssColor('#abcd')).toBe(true);
+		});
+
+		it('rejects malformed hex', () => {
+			expect(isValidCssColor('#12')).toBe(false);
+			expect(isValidCssColor('#xyzxyz')).toBe(false);
+			expect(isValidCssColor('282a36')).toBe(false);
+		});
+	});
+
+	describe('functional notations', () => {
+		it('accepts rgb() and rgba()', () => {
+			expect(isValidCssColor('rgb(26, 26, 46)')).toBe(true);
+			expect(isValidCssColor('rgba(189, 147, 249, 0.2)')).toBe(true);
+		});
+
+		it('accepts hsl() and hsla()', () => {
+			expect(isValidCssColor('hsl(262, 83%, 58%)')).toBe(true);
+			expect(isValidCssColor('hsla(262, 83%, 58%, 0.5)')).toBe(true);
+		});
+	});
+
+	describe('named colors', () => {
+		it('accepts CSS named colors (case-insensitive)', () => {
+			expect(isValidCssColor('darkblue')).toBe(true);
+			expect(isValidCssColor('rebeccapurple')).toBe(true);
+			expect(isValidCssColor('Transparent')).toBe(true);
+		});
+
+		it('rejects arbitrary words that are not named colors', () => {
+			expect(isValidCssColor('not-a-color')).toBe(false);
+			expect(isValidCssColor('bluish')).toBe(false);
+		});
+	});
+
+	describe('invalid input', () => {
+		it('rejects empty and whitespace-only strings', () => {
+			expect(isValidCssColor('')).toBe(false);
+			expect(isValidCssColor('   ')).toBe(false);
+		});
+
+		it('rejects non-string input', () => {
+			expect(isValidCssColor(null)).toBe(false);
+			expect(isValidCssColor(undefined)).toBe(false);
+			expect(isValidCssColor(42)).toBe(false);
+		});
+	});
+});

--- a/src/main/cue/cue-process-lifecycle.ts
+++ b/src/main/cue/cue-process-lifecycle.ts
@@ -29,6 +29,8 @@ interface CueActiveProcess {
 	cwd: string;
 	toolType: string;
 	startTime: number;
+	/** For SSH spawns: the agent invocation running on the remote host. */
+	sshRemoteCommand?: string;
 	/** Live ref to the accumulating stdout buffer — filled by the runProcess
 	 *  closure as chunks arrive. Exposed via `getActiveProcessOutput` so the
 	 *  renderer can poll for in-flight logs without a separate subscription
@@ -47,6 +49,8 @@ export interface CueProcessInfo {
 	cwd: string;
 	toolType: string;
 	startTime: number;
+	/** For SSH spawns: the agent invocation running on the remote host. */
+	sshRemoteCommand?: string;
 }
 
 /** Result of a process execution */
@@ -272,6 +276,7 @@ export function runProcess(
 			cwd: spec.cwd,
 			toolType,
 			startTime: Date.now(),
+			sshRemoteCommand: spec.sshRemoteCommand,
 			getStdout: () => stdout,
 			getStderr: () => stderr,
 		});
@@ -414,6 +419,7 @@ export function getProcessList(): CueProcessInfo[] {
 				cwd: entry.cwd,
 				toolType: entry.toolType,
 				startTime: entry.startTime,
+				sshRemoteCommand: entry.sshRemoteCommand,
 			});
 		}
 	}

--- a/src/main/cue/cue-spawn-builder.ts
+++ b/src/main/cue/cue-spawn-builder.ts
@@ -31,6 +31,8 @@ export interface SpawnSpec {
 	env: Record<string, string>;
 	/** For SSH stdin-script mode: full bash script to send via stdin */
 	sshStdinScript?: string;
+	/** Human-readable remote agent invocation (shown in Process Details for SSH spawns) */
+	sshRemoteCommand?: string;
 	/** For SSH small-prompt mode: raw prompt to send via stdin */
 	stdinPrompt?: string;
 	/** Whether SSH remote execution was actually used */
@@ -139,6 +141,7 @@ export async function buildSpawnSpec(
 	// at the end of the function already handles the undefined case via `|| {}`.
 	let spawnEnvVars: Record<string, string> | undefined = effectiveEnvVars;
 	let sshStdinScript: string | undefined;
+	let sshRemoteCommand: string | undefined;
 	let stdinPrompt: string | undefined;
 	let sshRemoteUsed: SpawnSpec['sshRemoteUsed'];
 
@@ -220,6 +223,7 @@ export async function buildSpawnSpec(
 		spawnCwd = sshResult.cwd;
 		spawnEnvVars = sshResult.customEnvVars;
 		sshStdinScript = sshResult.sshStdinScript;
+		sshRemoteCommand = sshResult.sshRemoteCommand;
 		stdinPrompt = sshResult.prompt;
 
 		if (sshResult.sshRemoteUsed) {
@@ -279,6 +283,7 @@ export async function buildSpawnSpec(
 				...(spawnEnvVars || {}),
 			} as Record<string, string>,
 			sshStdinScript,
+			sshRemoteCommand,
 			stdinPrompt,
 			sshRemoteUsed,
 		},

--- a/src/main/group-chat/group-chat-moderator.ts
+++ b/src/main/group-chat/group-chat-moderator.ts
@@ -44,6 +44,8 @@ export interface IProcessManager {
 		sendPromptViaStdinRaw?: boolean;
 		/** Script to send via stdin for SSH execution (bypasses shell escaping) */
 		sshStdinScript?: string;
+		/** Human-readable remote agent invocation (shown in Process Details for SSH spawns) */
+		sshRemoteCommand?: string;
 	}): { pid: number; success: boolean };
 
 	write(sessionId: string, data: string): boolean;

--- a/src/main/group-chat/spawnGroupChatAgent.ts
+++ b/src/main/group-chat/spawnGroupChatAgent.ts
@@ -107,6 +107,7 @@ export async function spawnGroupChatAgent(
 	let spawnPrompt: string | undefined = prompt;
 	let spawnEnvVars = customEnvVars;
 	let spawnSshStdinScript: string | undefined;
+	let spawnSshRemoteCommand: string | undefined;
 
 	// Over SSH, warm the remote maestro-p probe BEFORE resolving so a remote TUI
 	// selection falls back to API instead of exiting 127 when maestro-p isn't
@@ -201,6 +202,7 @@ export async function spawnGroupChatAgent(
 		spawnPrompt = sshWrapped.prompt;
 		spawnEnvVars = sshWrapped.customEnvVars;
 		spawnSshStdinScript = sshWrapped.sshStdinScript;
+		spawnSshRemoteCommand = sshWrapped.sshRemoteCommand;
 		if (sshWrapped.sshRemoteUsed && debugLabel) {
 			console.log(
 				`[GroupChat:Debug] SSH remote used for ${debugLabel}: ${sshWrapped.sshRemoteUsed.name}`
@@ -231,6 +233,7 @@ export async function spawnGroupChatAgent(
 		sendPromptViaStdin: winConfig.sendPromptViaStdin,
 		sendPromptViaStdinRaw: winConfig.sendPromptViaStdinRaw,
 		sshStdinScript: spawnSshStdinScript,
+		sshRemoteCommand: spawnSshRemoteCommand,
 	});
 
 	return spawnResult;

--- a/src/main/ipc/handlers/process.ts
+++ b/src/main/ipc/handlers/process.ts
@@ -119,6 +119,8 @@ export interface CueProcessEntry {
 	sessionName: string;
 	subscriptionName: string;
 	eventType: string;
+	/** For SSH spawns: the agent invocation running on the remote host. */
+	sshRemoteCommand?: string;
 }
 
 export interface ProcessHandlerDependencies {
@@ -734,6 +736,7 @@ export function registerProcessHandlers(deps: ProcessHandlerDependencies): void 
 				let sshRemoteUsed: SshRemoteConfig | null = null;
 				let customEnvVarsToPass: Record<string, string> | undefined = effectiveCustomEnvVars;
 				let sshStdinScript: string | undefined;
+				let sshRemoteCommand: string | undefined;
 
 				// When interactive mode resolved, thread the underlying claude binary
 				// through `MAESTRO_CLAUDE_BIN` so maestro-p knows which TUI to drive.
@@ -1031,6 +1034,7 @@ export function registerProcessHandlers(deps: ProcessHandlerDependencies): void 
 						commandToSpawn = sshCommand.command;
 						argsToSpawn = sshCommand.args;
 						sshStdinScript = sshCommand.stdinScript;
+						sshRemoteCommand = sshCommand.remoteCommandLine;
 
 						// For SSH, env vars are passed in the stdin script, not locally
 						customEnvVarsToPass = undefined;
@@ -1119,6 +1123,8 @@ export function registerProcessHandlers(deps: ProcessHandlerDependencies): void 
 					sshRemoteHost: sshRemoteUsed?.host,
 					// SSH stdin script - the entire command is sent via stdin to /bin/bash on remote
 					sshStdinScript,
+					// Human-readable remote agent invocation (shown in Process Details)
+					sshRemoteCommand,
 					// Extra dirs to prepend to spawn PATH (local non-SSH only)
 					extraPathDirs: localAgentBinDir ? [localAgentBinDir] : undefined,
 				});
@@ -1339,6 +1345,7 @@ export function registerProcessHandlers(deps: ProcessHandlerDependencies): void 
 						command: p.command,
 						args: p.args,
 						maestroEnvVars: p.maestroEnvVars,
+						sshRemoteCommand: p.sshRemoteCommand,
 					};
 					if (p.isTerminal && p.pid) {
 						const children = await getChildProcesses(p.pid);
@@ -1363,6 +1370,7 @@ export function registerProcessHandlers(deps: ProcessHandlerDependencies): void 
 					startTime: cue.startTime,
 					command: cue.command,
 					args: cue.args,
+					sshRemoteCommand: cue.sshRemoteCommand,
 					isCueRun: true,
 					cueRunId: cue.runId,
 					cueSessionName: cue.sessionName,

--- a/src/main/process-listeners/exit-listener.ts
+++ b/src/main/process-listeners/exit-listener.ts
@@ -534,6 +534,17 @@ export function setupExitListener(
 			return;
 		}
 
+		// Diagnostic: log terminal PTY exits at the source (the ground truth for the
+		// "terminal tabs vanish" reports). A non-zero code on a remote terminal that
+		// the user didn't `exit` is the signature of a dropped SSH transport. Pairs
+		// with the renderer-side 'Terminal PTY exited' / 'Closing terminal tab' logs.
+		if (sessionId.includes('-terminal-')) {
+			logger.info('Terminal PTY process exited', 'ProcessListener', {
+				sessionId,
+				exitCode: code,
+			});
+		}
+
 		safeSend('process:exit', sessionId, code);
 
 		// Broadcast exit to web clients

--- a/src/main/process-manager/spawners/ChildProcessSpawner.ts
+++ b/src/main/process-manager/spawners/ChildProcessSpawner.ts
@@ -444,6 +444,7 @@ export class ChildProcessSpawner {
 				projectPath: config.projectPath,
 				sshRemoteId: config.sshRemoteId,
 				sshRemoteHost: config.sshRemoteHost,
+				sshRemoteCommand: config.sshRemoteCommand,
 				// Seed from config on resume. Copilot emits `session.resume`
 				// (no sessionId) instead of `session.start` when --resume=<id>
 				// is set, so StdoutHandler can't populate this from the stream

--- a/src/main/process-manager/types.ts
+++ b/src/main/process-manager/types.ts
@@ -42,6 +42,9 @@ export interface ProcessConfig {
 	promptAlreadyInArgs?: boolean;
 	/** Script to send via stdin for SSH execution (bypasses shell escaping) */
 	sshStdinScript?: string;
+	/** Human-readable remote command line (the actual agent invocation running on the
+	 *  remote host). Surfaced in Process Details above the local SSH command. */
+	sshRemoteCommand?: string;
 	/** PTY terminal width in columns (default 80) */
 	cols?: number;
 	/** PTY terminal height in rows (default 24) */
@@ -106,6 +109,9 @@ export interface ManagedProcess {
 	projectPath?: string;
 	sshRemoteId?: string;
 	sshRemoteHost?: string;
+	/** Human-readable remote command line for SSH spawns (the agent invocation that
+	 *  runs on the remote host). Shown in Process Details above the local SSH command. */
+	sshRemoteCommand?: string;
 	dataBuffer?: string;
 	dataBufferTimeout?: NodeJS.Timeout;
 	/** Env vars Maestro explicitly set on this process (global + agent + session overrides),

--- a/src/main/stores/migrations/adaptive-mode-default.ts
+++ b/src/main/stores/migrations/adaptive-mode-default.ts
@@ -2,8 +2,11 @@
  * Adaptive Mode Default Migration
  *
  * One-shot backfill that turns Adaptive Mode (`enableMaestroP`) on for every
- * existing Claude Code agent, matching the new "default on for new agents"
- * behavior (see `isAdaptiveModeDefaultOn` in `src/shared/agentConstants.ts`).
+ * existing Claude Code agent that has NEVER configured a token source, matching
+ * the new "default on for new agents" behavior (see `isAdaptiveModeDefaultOn`
+ * in `src/shared/agentConstants.ts`). Agents with an explicit `false` (the user
+ * deliberately picked the API token source) are left untouched - flipping them
+ * on would silently revert their choice to Dynamic.
  *
  * Idempotent via a marker in the settings store — once the marker is set the
  * migration never runs again, so a user who later turns Adaptive Mode off on a
@@ -34,7 +37,11 @@ export function migrateAdaptiveModeDefault(store: Store<MaestroSettings>): void 
 
 	let updated = 0;
 	const nextSessions = sessions.map((session) => {
-		if (isAdaptiveModeDefaultOn(session.toolType) && session.enableMaestroP !== true) {
+		// Only backfill the NEVER-CONFIGURED state (`undefined`). An explicit
+		// `false` means the user deliberately picked API as their token source -
+		// forcing Adaptive Mode back on would silently revert their choice to
+		// Dynamic on the next app launch. `!== true` would wrongly catch both.
+		if (isAdaptiveModeDefaultOn(session.toolType) && session.enableMaestroP === undefined) {
 			updated++;
 			return { ...session, enableMaestroP: true };
 		}

--- a/src/main/utils/ssh-command-builder.ts
+++ b/src/main/utils/ssh-command-builder.ts
@@ -150,6 +150,10 @@ export interface SshCommandResult {
 	stdinScript?: string;
 	/** Remote temp file paths created during image decoding (for informational/logging purposes) */
 	remoteTempImagePaths?: string[];
+	/** Human-readable remote command line (the actual agent invocation that runs on the
+	 *  remote host, without the PATH/version-manager bootstrap or the `exec` wrapper).
+	 *  Surfaced in the Process Details modal above the local SSH command. */
+	remoteCommandLine?: string;
 }
 
 /**
@@ -450,6 +454,10 @@ export async function buildSshCommandWithStdin(
 		cmdParts.push(shellEscape(remoteOptions.prompt));
 	}
 
+	// Capture the bare agent invocation (command + args) for display in Process Details.
+	// This excludes the PATH bootstrap, the `exec` wrapper, and any temp-file cleanup.
+	const remoteCommandLine = cmdParts.join(' ');
+
 	// When remote temp files exist, don't use exec (which replaces the shell) so that
 	// cleanup commands can run after the agent exits. When no temp files, use exec for
 	// a cleaner process tree. When stdinInput is provided, the prompt will be appended
@@ -491,6 +499,7 @@ export async function buildSshCommandWithStdin(
 		args,
 		stdinScript,
 		remoteTempImagePaths: allRemoteTempPaths.length > 0 ? allRemoteTempPaths : undefined,
+		remoteCommandLine,
 	};
 }
 
@@ -686,5 +695,8 @@ export async function buildSshCommand(
 	return {
 		command: sshPath,
 		args,
+		// Bare agent invocation (command + args) for display in Process Details,
+		// without the cd/env prefix or the bash PATH bootstrap wrapper.
+		remoteCommandLine: buildShellCommand(remoteOptions.command, remoteOptions.args),
 	};
 }

--- a/src/main/utils/ssh-spawn-wrapper.ts
+++ b/src/main/utils/ssh-spawn-wrapper.ts
@@ -56,6 +56,8 @@ export interface SshSpawnWrapResult {
 	prompt?: string;
 	/** Script to send via stdin for SSH execution (includes PATH setup + prompt passthrough) */
 	sshStdinScript?: string;
+	/** Human-readable remote agent invocation (shown in Process Details above the SSH command) */
+	sshRemoteCommand?: string;
 	/** Whether SSH remote was used */
 	sshRemoteUsed: SshRemoteConfig | null;
 }
@@ -163,6 +165,7 @@ export async function wrapSpawnWithSsh(
 			customEnvVars: undefined,
 			prompt: undefined,
 			sshStdinScript: sshCommand.stdinScript,
+			sshRemoteCommand: sshCommand.remoteCommandLine,
 			sshRemoteUsed: sshResult.config,
 		};
 	}
@@ -200,6 +203,7 @@ export async function wrapSpawnWithSsh(
 		cwd: os.homedir(),
 		customEnvVars: undefined,
 		prompt: undefined,
+		sshRemoteCommand: sshCommand.remoteCommandLine,
 		sshRemoteUsed: sshResult.config,
 	};
 }

--- a/src/renderer/components/CustomThemeBuilder.tsx
+++ b/src/renderer/components/CustomThemeBuilder.tsx
@@ -5,20 +5,7 @@ import { THEMES, DEFAULT_CUSTOM_THEME_COLORS } from '../constants/themes';
 import { ConfirmModal } from './ConfirmModal';
 import { useModalLayer } from '../hooks/ui/useModalLayer';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
-
-/**
- * Validates that a string is a valid CSS color value
- */
-function isValidColor(color: string): boolean {
-	// Handle empty strings
-	if (!color || typeof color !== 'string') return false;
-
-	// Use the DOM to validate - create an option element and try to set its color
-	const testElement = new Option().style;
-	testElement.color = color;
-	// If the browser accepts the color, it will be non-empty
-	return testElement.color !== '';
-}
+import { isValidCssColor } from '../../shared/cssColor';
 
 interface CustomThemeBuilderProps {
 	theme: Theme; // Current active theme for styling the builder
@@ -390,7 +377,7 @@ export function CustomThemeBuilder({
 						}
 
 						// Validate all color values are valid CSS colors
-						const invalidColors = requiredKeys.filter((key) => !isValidColor(data.colors[key]));
+						const invalidColors = requiredKeys.filter((key) => !isValidCssColor(data.colors[key]));
 						if (invalidColors.length > 0) {
 							const errorMsg = `Invalid theme file: invalid color values for ${invalidColors.slice(0, 3).join(', ')}${invalidColors.length > 3 ? '...' : ''}`;
 							onImportError?.(errorMsg);

--- a/src/renderer/components/CustomThemeBuilder.tsx
+++ b/src/renderer/components/CustomThemeBuilder.tsx
@@ -365,8 +365,12 @@ export function CustomThemeBuilder({
 				try {
 					const data = JSON.parse(e.target?.result as string);
 					if (data.colors && typeof data.colors === 'object') {
-						// Validate all required color keys exist
-						const requiredKeys = COLOR_CONFIG.map((c) => c.key);
+						// Validate all required color keys exist. bgTitleBar is
+						// optional (older/partial theme exports may omit it; the UI
+						// falls back to bgMain), so it must not be required here.
+						const requiredKeys = COLOR_CONFIG.map((c) => c.key).filter(
+							(key) => key !== 'bgTitleBar'
+						);
 						const hasAllKeys = requiredKeys.every((key) => key in data.colors);
 
 						if (!hasAllKeys) {
@@ -376,8 +380,10 @@ export function CustomThemeBuilder({
 							return;
 						}
 
-						// Validate all color values are valid CSS colors
-						const invalidColors = requiredKeys.filter((key) => !isValidCssColor(data.colors[key]));
+						// Validate color values for every key that is present (including
+						// the optional bgTitleBar when supplied).
+						const presentKeys = COLOR_CONFIG.map((c) => c.key).filter((key) => key in data.colors);
+						const invalidColors = presentKeys.filter((key) => !isValidCssColor(data.colors[key]));
 						if (invalidColors.length > 0) {
 							const errorMsg = `Invalid theme file: invalid color values for ${invalidColors.slice(0, 3).join(', ')}${invalidColors.length > 3 ? '...' : ''}`;
 							onImportError?.(errorMsg);

--- a/src/renderer/components/ProcessMonitor/ProcessDetailView.tsx
+++ b/src/renderer/components/ProcessMonitor/ProcessDetailView.tsx
@@ -9,6 +9,7 @@ import {
 	FolderOpen,
 	Hash,
 	Play,
+	Server,
 	Tag,
 	Terminal,
 	Variable,
@@ -379,7 +380,39 @@ export function ProcessDetailView({ theme, detail, onBack, onClose }: ProcessDet
 						</code>
 					</div>
 
-					{/* Command Line — full width (very long) */}
+					{/* Remote Command — full width. Shown only for SSH spawns: the actual agent
+					    invocation running on the remote host, displayed above the local SSH
+					    command line below so it's clear what is executing remotely. */}
+					{detail.sshRemoteCommand && (
+						<div
+							className="col-span-2 lg:col-span-4 p-4 rounded-lg"
+							style={{ backgroundColor: theme.colors.bgMain }}
+						>
+							<div className="flex items-center gap-2 mb-2">
+								<Server className="w-4 h-4" style={{ color: theme.colors.accent }} />
+								<span
+									className="text-xs font-medium uppercase tracking-wide"
+									style={{ color: theme.colors.textDim }}
+								>
+									Remote Command
+								</span>
+							</div>
+							<code
+								className="text-sm font-mono break-all block whitespace-pre-wrap overflow-y-auto"
+								style={{
+									color: theme.colors.textMain,
+									userSelect: 'text',
+									cursor: 'text',
+									maxHeight: '300px',
+								}}
+							>
+								{detail.sshRemoteCommand}
+							</code>
+						</div>
+					)}
+
+					{/* Command Line — full width (very long). For SSH spawns this is the local
+					    `ssh ... /bin/bash` invocation; the remote agent command is shown above. */}
 					<div
 						className="col-span-2 lg:col-span-4 p-4 rounded-lg"
 						style={{ backgroundColor: theme.colors.bgMain }}
@@ -390,7 +423,7 @@ export function ProcessDetailView({ theme, detail, onBack, onClose }: ProcessDet
 								className="text-xs font-medium uppercase tracking-wide"
 								style={{ color: theme.colors.textDim }}
 							>
-								Command Line
+								{detail.sshRemoteCommand ? 'SSH Command' : 'Command Line'}
 							</span>
 						</div>
 						<code

--- a/src/renderer/components/ProcessMonitor/ProcessMonitor.tsx
+++ b/src/renderer/components/ProcessMonitor/ProcessMonitor.tsx
@@ -81,6 +81,7 @@ export function ProcessMonitor(props: ProcessMonitorProps) {
 			tabName: node.tabName,
 			childProcesses: node.childProcesses,
 			maestroEnvVars: node.maestroEnvVars,
+			sshRemoteCommand: node.sshRemoteCommand,
 		});
 	}, []);
 

--- a/src/renderer/components/ProcessMonitor/processTree.ts
+++ b/src/renderer/components/ProcessMonitor/processTree.ts
@@ -230,6 +230,7 @@ export function buildProcessTree(input: BuildProcessTreeInput): ProcessNode[] {
 				tabName,
 				childProcesses: proc.childProcesses,
 				maestroEnvVars: proc.maestroEnvVars,
+				sshRemoteCommand: proc.sshRemoteCommand,
 				children: childNodes.length > 0 ? childNodes : undefined,
 			};
 
@@ -339,6 +340,7 @@ export function buildProcessTree(input: BuildProcessTreeInput): ProcessNode[] {
 						command: proc.command,
 						args: proc.args,
 						maestroEnvVars: proc.maestroEnvVars,
+						sshRemoteCommand: proc.sshRemoteCommand,
 					};
 				});
 
@@ -393,6 +395,7 @@ export function buildProcessTree(input: BuildProcessTreeInput): ProcessNode[] {
 				command: proc.command,
 				args: proc.args,
 				maestroEnvVars: proc.maestroEnvVars,
+				sshRemoteCommand: proc.sshRemoteCommand,
 			};
 		});
 
@@ -428,6 +431,7 @@ export function buildProcessTree(input: BuildProcessTreeInput): ProcessNode[] {
 			cueEventType: proc.cueEventType,
 			cueSessionName: proc.cueSessionName,
 			maestroEnvVars: proc.maestroEnvVars,
+			sshRemoteCommand: proc.sshRemoteCommand,
 		}));
 
 		const cueSectionNode: ProcessNode = {

--- a/src/renderer/components/ProcessMonitor/types.ts
+++ b/src/renderer/components/ProcessMonitor/types.ts
@@ -28,6 +28,8 @@ export interface ActiveProcess {
 	childProcesses?: Array<{ pid: number; command: string }>;
 	/** Env vars Maestro is explicitly setting on this process (global + agent + session overrides). */
 	maestroEnvVars?: Record<string, string>;
+	/** For SSH spawns: the agent invocation running on the remote host. */
+	sshRemoteCommand?: string;
 }
 
 export type ProcessTypeTag =
@@ -71,6 +73,8 @@ export interface ProcessNode {
 	tabName?: string;
 	childProcesses?: Array<{ pid: number; command: string }>;
 	maestroEnvVars?: Record<string, string>;
+	/** For SSH spawns: the agent invocation running on the remote host. */
+	sshRemoteCommand?: string;
 }
 
 export interface ProcessDetailData {
@@ -92,4 +96,6 @@ export interface ProcessDetailData {
 	tabName?: string;
 	childProcesses?: Array<{ pid: number; command: string }>;
 	maestroEnvVars?: Record<string, string>;
+	/** For SSH spawns: the agent invocation running on the remote host. */
+	sshRemoteCommand?: string;
 }

--- a/src/renderer/components/SessionList/SessionList.tsx
+++ b/src/renderer/components/SessionList/SessionList.tsx
@@ -632,7 +632,8 @@ function SessionListInner(props: SessionListProps) {
 		deferredSessionFilter,
 		sortedSessions,
 		showUnreadAgentsOnly,
-		activeSessionId
+		activeSessionId,
+		activeBatchSessionIds
 	);
 
 	// PERF: Cached callback maps to prevent SessionItem re-renders.

--- a/src/renderer/components/TabBar/TerminalTabItem.tsx
+++ b/src/renderer/components/TabBar/TerminalTabItem.tsx
@@ -10,11 +10,13 @@ import {
 	ArrowRightCircle,
 	Share2,
 	Play,
+	RotateCw,
 } from 'lucide-react';
 import type { TerminalTab, Theme } from '../../types';
 import { getTerminalTabDisplayName } from '../../utils/terminalTabHelpers';
 import { useTabHoverOverlay } from '../../hooks/tabs/useTabHoverOverlay';
 import { useSettingsStore } from '../../stores/settingsStore';
+import { useTabStore } from '../../stores/tabStore';
 import { formatShortcutKeys } from '../../utils/shortcutFormatter';
 
 /**
@@ -108,6 +110,15 @@ export const TerminalTabItem = memo(function TerminalTabItem({
 	} = useTabHoverOverlay({ registerRef });
 
 	const tabShortcuts = useSettingsStore((s) => s.tabShortcuts);
+	const restartTerminalTab = useTabStore((s) => s.restartTerminalTab);
+
+	const handleRestartClick = useCallback(
+		(e: React.MouseEvent) => {
+			e.stopPropagation();
+			restartTerminalTab(tab.id);
+		},
+		[restartTerminalTab, tab.id]
+	);
 
 	const ShortcutHint = ({ keys }: { keys: string[] }) => (
 		<span
@@ -373,6 +384,18 @@ export const TerminalTabItem = memo(function TerminalTabItem({
 				>
 					{tab.exitCode}
 				</span>
+			)}
+
+			{/* Restart button — only for an exited terminal, so the tab is recoverable
+				 (e.g. after an SSH drop) instead of being a dead husk. */}
+			{tab.state === 'exited' && (
+				<button
+					onClick={handleRestartClick}
+					className="p-0.5 rounded hover:bg-white/10 transition-colors shrink-0"
+					title="Restart terminal"
+				>
+					<RotateCw className="w-3 h-3" style={{ color: theme.colors.accent }} />
+				</button>
 			)}
 
 			{/* Close button — visible on hover or active */}

--- a/src/renderer/components/TerminalView.tsx
+++ b/src/renderer/components/TerminalView.tsx
@@ -91,6 +91,8 @@ export const TerminalView = memo(
 		// identity on every render, which would re-trigger the spawn useEffect in a loop.
 		const onTabPidChangeRef = useRef(onTabPidChange);
 		onTabPidChangeRef.current = onTabPidChange;
+		const onTabStateChangeRef = useRef(onTabStateChange);
+		onTabStateChangeRef.current = onTabStateChange;
 
 		const closeTerminalTab = useTabStore((s) => s.closeTerminalTab);
 
@@ -124,6 +126,33 @@ export const TerminalView = memo(
 				});
 			}, 200);
 		}, []);
+
+		// Handle a PTY spawn failure. Scratch tabs are closed (their config is
+		// disposable); persistent tabs are kept and marked 'exited' so they survive
+		// a transient failure (e.g. an SSH remote that is briefly unreachable) and
+		// can be restarted by the user instead of vanishing. Marking 'exited' (rather
+		// than leaving 'idle') also stops the spawn effects from retrying in a loop.
+		const handleSpawnFailure = useCallback(
+			(tabId: string, isPersistent: boolean, message: string) => {
+				logger.warn('Terminal PTY spawn failed', 'TerminalView', {
+					sessionId: session.id,
+					tabId,
+					isPersistent,
+					message,
+					decision: isPersistent ? 'keep-for-restart' : 'close',
+				});
+				if (isPersistent) {
+					onTabStateChangeRef.current(tabId, 'exited');
+					terminalRefs.current
+						.get(tabId)
+						?.write('\r\n\x1b[2m[failed to start] - restart from the tab menu\x1b[0m\r\n');
+				} else {
+					setTimeout(() => closeTerminalTab(tabId, 'spawn-failure'), 0);
+				}
+				notifySpawnFailure(message);
+			},
+			[session.id, closeTerminalTab, notifySpawnFailure]
+		);
 
 		const activeTab = getActiveTerminalTab(session);
 
@@ -174,6 +203,15 @@ export const TerminalView = memo(
 				// Guard: skip if a spawn is already in flight for this tab
 				if (spawnInFlightRef.current.has(tabId)) return;
 				spawnInFlightRef.current.add(tabId);
+
+				// "Persistent" tabs carry user intent to keep running: a configured
+				// startup command, or any tab under an SSH/remote session (whose
+				// transport can drop for reasons unrelated to the user). We never
+				// silently discard these on failure - we keep them as a restartable
+				// exited husk instead of closing the tab and losing its config.
+				const isPersistent =
+					!!tab.startupCommand ||
+					!!(session.sessionSshRemoteConfig?.enabled || session.sshRemoteId);
 
 				const terminalSessionId = getTerminalSessionId(session.id, tabId);
 
@@ -242,9 +280,11 @@ export const TerminalView = memo(
 									});
 							}
 						} else {
-							// Spawn failed — close the tab and notify via batched toast
-							setTimeout(() => closeTerminalTab(tabId), 0);
-							notifySpawnFailure(
+							// Spawn failed. Persistent tabs are kept (marked exited so the
+							// spawn effects stop retrying in a loop); scratch tabs are closed.
+							handleSpawnFailure(
+								tabId,
+								isPersistent,
 								effectiveSshConfig?.enabled
 									? 'SSH terminal could not be started. Check that the SSH remote is enabled and reachable.'
 									: 'The shell process could not be started. Check system PTY availability.'
@@ -259,9 +299,10 @@ export const TerminalView = memo(
 								operation: 'spawnTerminalTab',
 							},
 						});
-						// Spawn threw — close the tab and notify via batched toast
-						setTimeout(() => closeTerminalTab(tabId), 0);
-						notifySpawnFailure(
+						// Spawn threw — same persistent-vs-scratch handling as a failed spawn.
+						handleSpawnFailure(
+							tabId,
+							isPersistent,
 							err instanceof Error ? err.message : 'An unexpected error occurred.'
 						);
 					})
@@ -278,10 +319,8 @@ export const TerminalView = memo(
 				defaultShell,
 				shellArgs,
 				shellEnvVars,
-				// onTabPidChange accessed via stable ref — not a dep
-				// onTabStateChange not used in this callback
-				closeTerminalTab,
-				notifySpawnFailure,
+				// onTabPidChange / onTabStateChange accessed via stable refs — not deps
+				handleSpawnFailure,
 			]
 		);
 
@@ -362,32 +401,65 @@ export const TerminalView = memo(
 			return cleanup;
 		}, [session.id]);
 
-		// Auto-close terminal tabs when the shell process exits.
-		// Startup failures (exit within 2s) show an error toast; normal exits close silently.
+		// Handle a terminal's PTY exiting. A plain scratch shell is closed (the user
+		// typed `exit` / Ctrl-D, or the shell died - that's disposable). A "persistent"
+		// tab is NOT auto-closed: a tab with a startup command, or any tab under an
+		// SSH/remote session whose transport can drop for reasons unrelated to the user
+		// (sleep, network blip, server timeout). Silently destroying those discards the
+		// user's config and is the root cause of the long-standing "terminal tabs vanish"
+		// reports. Instead we keep them as a restartable exited husk with a visible notice.
+		//
+		// pid === 0 means the PTY never spawned, i.e. this 'exited' transition came from
+		// a spawn failure already handled at the spawn site - skip it here to avoid a
+		// duplicate toast/notice.
 		useEffect(() => {
 			const terminalTabs = session.terminalTabs || [];
+			const isRemoteSession = !!(session.sessionSshRemoteConfig?.enabled || session.sshRemoteId);
 			for (const tab of terminalTabs) {
 				const prev = prevTabStatesRef.current.get(tab.id);
-				if (prev !== undefined && prev !== 'exited' && tab.state === 'exited') {
+				if (prev !== undefined && prev !== 'exited' && tab.state === 'exited' && tab.pid !== 0) {
 					const age = Date.now() - tab.createdAt;
 					const tabId = tab.id;
+					const isPersistent = !!tab.startupCommand || isRemoteSession;
+					// Diagnostic: every PTY exit logs why the tab was kept or closed. This
+					// is the signal for the "terminal tabs vanish" reports - e.g. an SSH
+					// transport dropping logs exitCode here with isRemote:true / kept.
+					logger.info('Terminal PTY exited', 'TerminalView', {
+						sessionId: session.id,
+						tabId,
+						exitCode: tab.exitCode,
+						ageMs: age,
+						hasStartupCommand: !!tab.startupCommand,
+						isRemote: isRemoteSession,
+						decision: isPersistent ? 'keep-for-restart' : 'close',
+					});
 					if (age < 2000) {
-						// Startup failure — close tab and show error toast
-						logger.warn(
-							`[TerminalView] Shell exited ${age}ms after creation (exit code: ${tab.exitCode ?? '?'}). Closing tab.`
-						);
-						setTimeout(() => closeTerminalTab(tabId), 0);
+						// Exited almost immediately - surface as a startup failure toast.
 						notifySpawnFailure(
 							`Shell exited immediately${tab.exitCode != null ? ` (exit code: ${tab.exitCode})` : ''}.`
 						);
+					}
+					if (isPersistent) {
+						// Keep the tab; show a visible notice instead of a silent dead husk.
+						terminalRefs.current
+							.get(tabId)
+							?.write(
+								`\r\n\x1b[2m[process exited${tab.exitCode != null ? ` (code ${tab.exitCode})` : ''}] - restart from the tab menu\x1b[0m\r\n`
+							);
 					} else {
-						// Close on next tick to avoid mutating state mid-render
-						setTimeout(() => closeTerminalTab(tabId), 0);
+						// Close on next tick to avoid mutating state mid-render.
+						setTimeout(() => closeTerminalTab(tabId, 'pty-exit'), 0);
 					}
 				}
 				prevTabStatesRef.current.set(tab.id, tab.state);
 			}
-		}, [session.terminalTabs, closeTerminalTab]);
+		}, [
+			session.terminalTabs,
+			session.sessionSshRemoteConfig,
+			session.sshRemoteId,
+			closeTerminalTab,
+			notifySpawnFailure,
+		]);
 
 		const terminalTabs = session.terminalTabs || [];
 

--- a/src/renderer/hooks/session/useSessionCategories.ts
+++ b/src/renderer/hooks/session/useSessionCategories.ts
@@ -26,7 +26,8 @@ export function useSessionCategories(
 	sessionFilter: string,
 	sortedSessions: Session[],
 	showUnreadAgentsOnly = false,
-	activeSessionId?: string | null
+	activeSessionId?: string | null,
+	activeBatchSessionIds: string[] = []
 ): SessionCategories {
 	// PERF: Match SessionList's sidebar-only equality so categorization doesn't
 	// recompute on every streaming flush — only when a sidebar-relevant field
@@ -94,6 +95,11 @@ export function useSessionCategories(
 		const query = sessionFilter?.toLowerCase() ?? '';
 		const filtered: Session[] = [];
 
+		// Auto Run agents (the AUTO badge) sit between prompts in state 'idle', so
+		// the busy/unread checks below would drop them. Keep them visible in the
+		// unread filter using the same set that drives the badge.
+		const batchSessionIds = new Set(activeBatchSessionIds);
+
 		for (const s of sessions) {
 			// Exclude worktree children from main list (they appear under parent)
 			if (s.parentSessionId) continue;
@@ -106,12 +112,16 @@ export function useSessionCategories(
 			if (showUnreadAgentsOnly && !isActiveOrParentOfActive) {
 				const hasUnread = s.aiTabs?.some((tab) => tab.hasUnread);
 				const isBusy = s.state === 'busy';
-				// Also check if any worktree children have unread or are busy
+				const isAutoRunning = batchSessionIds.has(s.id);
+				// Also check if any worktree children have unread, are busy, or are auto-running
 				const children = worktreeChildrenByParentId.get(s.id);
-				const hasUnreadChildren = children?.some(
-					(child) => child.aiTabs?.some((tab) => tab.hasUnread) || child.state === 'busy'
+				const hasActiveChildren = children?.some(
+					(child) =>
+						child.aiTabs?.some((tab) => tab.hasUnread) ||
+						child.state === 'busy' ||
+						batchSessionIds.has(child.id)
 				);
-				if (!hasUnread && !isBusy && !hasUnreadChildren) continue;
+				if (!hasUnread && !isBusy && !isAutoRunning && !hasActiveChildren) continue;
 			}
 
 			if (!query) {
@@ -193,6 +203,7 @@ export function useSessionCategories(
 		sessionFilter,
 		showUnreadAgentsOnly,
 		activeSessionId,
+		activeBatchSessionIds,
 		sessions,
 		worktreeChildrenByParentId,
 		groupIds,

--- a/src/renderer/hooks/tabs/internal/useUnifiedTabHandlers.ts
+++ b/src/renderer/hooks/tabs/internal/useUnifiedTabHandlers.ts
@@ -90,6 +90,19 @@ export function useUnifiedTabHandlers({
 			);
 
 			for (const tabId of terminalTabIds) {
+				// Diagnostic: bulk close is a separate terminal-removal path from the
+				// store's closeTerminalTab. Log it with the same shape so every closed
+				// terminal is accounted for in the logs (see "Closing terminal tab").
+				const tab = (session.terminalTabs || []).find((t) => t.id === tabId);
+				logger.info('Closing terminal tab', 'TerminalView', {
+					sessionId: session.id,
+					tabId,
+					reason: wizardWarningLabel,
+					pid: tab?.pid,
+					state: tab?.state,
+					hasStartupCommand: !!tab?.startupCommand,
+					isRemote: !!(session.sessionSshRemoteConfig?.enabled || session.sshRemoteId),
+				});
 				window.maestro.process.kill(getTerminalSessionId(session.id, tabId));
 			}
 

--- a/src/renderer/hooks/utils/useDebouncedPersistence.ts
+++ b/src/renderer/hooks/utils/useDebouncedPersistence.ts
@@ -39,6 +39,16 @@ import { captureException } from '../../utils/sentry';
 // Maximum persisted logs per AI tab (matches session persistence limit)
 const MAX_PERSISTED_LOGS_PER_TAB = 100;
 
+// Maximum persisted file-preview content per tab. Preview tabs hold the full
+// file in `content`, but the viewer only renders a truncated slice (see
+// LARGE_FILE_PREVIEW_LIMIT) and re-reads from disk on activation. Persisting
+// whole files is pure bloat: a single 500k-line .jsonl stored 363MB in one tab,
+// ballooning sessions.json to 500MB+ and OOM-ing the main process on startup
+// (it JSON.parses the whole file at boot). Tabs over this cap persist with
+// content stripped and reload from disk when opened. Small files persist as-is
+// so unsaved edit state survives a restart.
+const MAX_PERSISTED_PREVIEW_CONTENT = 256 * 1024;
+
 /**
  * Prepare a session for persistence by:
  * 1. Filtering out tabs with active wizard state (incomplete wizards should not persist)
@@ -150,10 +160,22 @@ const prepareSessionForPersistence = (session: Session): Session => {
 	);
 	const newActiveBrowserTabId = activeBrowserTabExists ? session.activeBrowserTabId : null;
 
+	// Strip oversized file-preview content. Preview tabs hold the full file in
+	// `content`, which the viewer truncates at render time and re-reads from disk
+	// on activation, so persisting megabytes of file bytes is pure bloat (a 363MB
+	// .jsonl OOM'd startup). Keep the tab so it reopens; just drop the heavy
+	// content (and stale editContent) for tabs over the cap.
+	const cleanedFilePreviewTabs = (session.filePreviewTabs || []).map((tab) =>
+		tab.content && tab.content.length > MAX_PERSISTED_PREVIEW_CONTENT
+			? { ...tab, content: '', editContent: undefined }
+			: tab
+	);
+
 	return {
 		...sessionWithoutRuntimeFields,
 		aiTabs: truncatedTabs,
 		activeTabId: newActiveTabId,
+		filePreviewTabs: cleanedFilePreviewTabs,
 		// Reset terminal tab runtime state
 		terminalTabs: cleanedTerminalTabs,
 		activeTerminalTabId: newActiveTerminalTabId,

--- a/src/renderer/stores/tabStore.ts
+++ b/src/renderer/stores/tabStore.ts
@@ -51,11 +51,26 @@ import {
 	addTerminalTab as addTerminalTabHelper,
 	closeTerminalTab as closeTerminalTabHelper,
 	selectTerminalTab as selectTerminalTabHelper,
+	restartTerminalTab as restartTerminalTabHelper,
 	renameTerminalTab as renameTerminalTabHelper,
 	setTerminalTabStartupCommand as setTerminalTabStartupCommandHelper,
 	getTerminalSessionId,
 } from '../utils/terminalTabHelpers';
 import { useSessionStore, selectActiveSession } from './sessionStore';
+import { logger } from '../utils/logger';
+
+/**
+ * Why a terminal tab is being closed. Logged at every close site so a vanished
+ * terminal can be explained from the logs instead of guessed at. 'user-action'
+ * covers the X button, middle-click, overlay menu, and close-others/left/right.
+ */
+export type TerminalCloseReason =
+	| 'user-action'
+	| 'pty-exit'
+	| 'spawn-failure'
+	| 'close-others'
+	| 'close-left'
+	| 'close-right';
 
 // ============================================================================
 // Store Types
@@ -223,15 +238,25 @@ export interface TabStoreActions {
 
 	/**
 	 * Close a terminal tab in the active session.
-	 * Kills the associated PTY process. Refuses to close the last terminal tab.
+	 * Kills the associated PTY process.
+	 *
+	 * @param reason - Why the tab is closing. Logged for diagnostics so a
+	 *   disappearing terminal can be traced to its cause. Defaults to 'user-action'.
 	 */
-	closeTerminalTab: (tabId: string) => void;
+	closeTerminalTab: (tabId: string, reason?: TerminalCloseReason) => void;
 
 	/**
 	 * Set the active terminal tab in the active session.
 	 * Switches inputMode to 'terminal'.
 	 */
 	selectTerminalTab: (tabId: string) => void;
+
+	/**
+	 * Restart an exited terminal tab in the active session.
+	 * Resets the tab to a spawnable state and selects it; the spawn effects in
+	 * TerminalView re-create the PTY (re-running any configured startup command).
+	 */
+	restartTerminalTab: (tabId: string) => void;
 
 	/**
 	 * Rename a terminal tab in the active session.
@@ -562,11 +587,26 @@ export const useTabStore = create<TabStore>()((set) => ({
 		updateActiveSession({ ...updatedSession, inputMode: 'terminal' });
 	},
 
-	closeTerminalTab: (tabId) => {
+	closeTerminalTab: (tabId, reason = 'user-action') => {
 		const session = getActiveSession();
 		if (!session) return;
+		const tab = (session.terminalTabs || []).find((t) => t.id === tabId);
 		const updatedSession = closeTerminalTabHelper(session, tabId);
 		if (updatedSession === session) return; // Tab not found
+		// Diagnostic: record exactly why a terminal tab was removed. This is the
+		// single chokepoint for terminal-tab destruction, so this log explains every
+		// vanished terminal (especially the non-user-initiated 'pty-exit' path).
+		logger.info('Closing terminal tab', 'TerminalView', {
+			sessionId: session.id,
+			tabId,
+			reason,
+			pid: tab?.pid,
+			state: tab?.state,
+			exitCode: tab?.exitCode,
+			hasStartupCommand: !!tab?.startupCommand,
+			isRemote: !!(session.sessionSshRemoteConfig?.enabled || session.sshRemoteId),
+			ageMs: tab ? Date.now() - tab.createdAt : undefined,
+		});
 		// Kill the PTY process after confirming the tab will be removed
 		window.maestro.process.kill(getTerminalSessionId(session.id, tabId));
 		updateActiveSession(updatedSession);
@@ -576,6 +616,18 @@ export const useTabStore = create<TabStore>()((set) => ({
 		const session = getActiveSession();
 		if (!session) return;
 		const updatedSession = selectTerminalTabHelper(session, tabId);
+		updateActiveSession({ ...updatedSession, inputMode: 'terminal' });
+	},
+
+	restartTerminalTab: (tabId) => {
+		const session = getActiveSession();
+		if (!session) return;
+		const updatedSession = restartTerminalTabHelper(session, tabId);
+		if (updatedSession === session) return; // Tab not found
+		// Defensive: kill any lingering PTY for this tab before the spawn effects
+		// re-create it. On a clean exit the process map entry is already gone, so
+		// this is a no-op (and emits no exit event) in the common case.
+		window.maestro.process.kill(getTerminalSessionId(session.id, tabId));
 		updateActiveSession({ ...updatedSession, inputMode: 'terminal' });
 	},
 

--- a/src/renderer/utils/terminalTabHelpers.ts
+++ b/src/renderer/utils/terminalTabHelpers.ts
@@ -352,6 +352,32 @@ export function updateTerminalTabPid(session: Session, tabId: string, pid: numbe
 }
 
 /**
+ * Reset an exited terminal tab so it can be re-spawned, and select it.
+ * Clears the dead PID and exit code and returns the tab to 'idle' so the spawn
+ * effects in TerminalView pick it up again. Selecting the tab ensures the
+ * active-tab spawn path fires even for a terminal with no startup command.
+ *
+ * @param session - The Maestro session
+ * @param tabId - The ID of the terminal tab to restart
+ * @returns New session with the tab reset and selected, or original if not found
+ */
+export function restartTerminalTab(session: Session, tabId: string): Session {
+	const terminalTabs = session.terminalTabs || [];
+	if (!terminalTabs.find((tab) => tab.id === tabId)) {
+		return session;
+	}
+	return {
+		...session,
+		terminalTabs: terminalTabs.map((tab) =>
+			tab.id === tabId ? { ...tab, pid: 0, state: 'idle', exitCode: undefined } : tab
+		),
+		activeTerminalTabId: tabId,
+		activeFileTabId: null,
+		activeBrowserTabId: null,
+	};
+}
+
+/**
  * Configure the startup command and (optional) cwd for a terminal tab.
  * Empty `command` clears the configuration.
  * Empty `cwd` clears the override (PTY falls back to tab.cwd / session.cwd).

--- a/src/shared/cssColor.ts
+++ b/src/shared/cssColor.ts
@@ -1,0 +1,190 @@
+/**
+ * Deterministic CSS color validation.
+ *
+ * Previously theme-import validation relied on a DOM round-trip
+ * (`new Option().style.color = value`), which is non-deterministic across
+ * environments: jsdom's CSS parser accepts/rejects values differently than
+ * Chromium and even varies under load on CI. This pure validator behaves
+ * identically everywhere - production, local tests, and CI.
+ *
+ * Supported forms: hex (#RGB, #RGBA, #RRGGBB, #RRGGBBAA), rgb()/rgba(),
+ * hsl()/hsla(), and CSS named colors (CSS Color Module Level 4).
+ */
+
+const HEX_COLOR = /^#(?:[0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/;
+// Functional notations: rgb(), rgba(), hsl(), hsla(). Permissive on the inner
+// arguments (numbers, %, commas, slashes, whitespace) - we only need to
+// distinguish "looks like a color" from arbitrary strings like "not-a-color".
+const RGB_COLOR = /^rgba?\(\s*[0-9.,%\s/]+\)$/i;
+const HSL_COLOR = /^hsla?\(\s*[0-9.,%\s/deg]+\)$/i;
+
+/**
+ * CSS named colors (CSS Color Module Level 4), plus `transparent` and
+ * `currentcolor`. Used to validate named values without a DOM round-trip.
+ */
+const CSS_NAMED_COLORS = new Set<string>([
+	'transparent',
+	'currentcolor',
+	'aliceblue',
+	'antiquewhite',
+	'aqua',
+	'aquamarine',
+	'azure',
+	'beige',
+	'bisque',
+	'black',
+	'blanchedalmond',
+	'blue',
+	'blueviolet',
+	'brown',
+	'burlywood',
+	'cadetblue',
+	'chartreuse',
+	'chocolate',
+	'coral',
+	'cornflowerblue',
+	'cornsilk',
+	'crimson',
+	'cyan',
+	'darkblue',
+	'darkcyan',
+	'darkgoldenrod',
+	'darkgray',
+	'darkgreen',
+	'darkgrey',
+	'darkkhaki',
+	'darkmagenta',
+	'darkolivegreen',
+	'darkorange',
+	'darkorchid',
+	'darkred',
+	'darksalmon',
+	'darkseagreen',
+	'darkslateblue',
+	'darkslategray',
+	'darkslategrey',
+	'darkturquoise',
+	'darkviolet',
+	'deeppink',
+	'deepskyblue',
+	'dimgray',
+	'dimgrey',
+	'dodgerblue',
+	'firebrick',
+	'floralwhite',
+	'forestgreen',
+	'fuchsia',
+	'gainsboro',
+	'ghostwhite',
+	'gold',
+	'goldenrod',
+	'gray',
+	'green',
+	'greenyellow',
+	'grey',
+	'honeydew',
+	'hotpink',
+	'indianred',
+	'indigo',
+	'ivory',
+	'khaki',
+	'lavender',
+	'lavenderblush',
+	'lawngreen',
+	'lemonchiffon',
+	'lightblue',
+	'lightcoral',
+	'lightcyan',
+	'lightgoldenrodyellow',
+	'lightgray',
+	'lightgreen',
+	'lightgrey',
+	'lightpink',
+	'lightsalmon',
+	'lightseagreen',
+	'lightskyblue',
+	'lightslategray',
+	'lightslategrey',
+	'lightsteelblue',
+	'lightyellow',
+	'lime',
+	'limegreen',
+	'linen',
+	'magenta',
+	'maroon',
+	'mediumaquamarine',
+	'mediumblue',
+	'mediumorchid',
+	'mediumpurple',
+	'mediumseagreen',
+	'mediumslateblue',
+	'mediumspringgreen',
+	'mediumturquoise',
+	'mediumvioletred',
+	'midnightblue',
+	'mintcream',
+	'mistyrose',
+	'moccasin',
+	'navajowhite',
+	'navy',
+	'oldlace',
+	'olive',
+	'olivedrab',
+	'orange',
+	'orangered',
+	'orchid',
+	'palegoldenrod',
+	'palegreen',
+	'paleturquoise',
+	'palevioletred',
+	'papayawhip',
+	'peachpuff',
+	'peru',
+	'pink',
+	'plum',
+	'powderblue',
+	'purple',
+	'rebeccapurple',
+	'red',
+	'rosybrown',
+	'royalblue',
+	'saddlebrown',
+	'salmon',
+	'sandybrown',
+	'seagreen',
+	'seashell',
+	'sienna',
+	'silver',
+	'skyblue',
+	'slateblue',
+	'slategray',
+	'slategrey',
+	'snow',
+	'springgreen',
+	'steelblue',
+	'tan',
+	'teal',
+	'thistle',
+	'tomato',
+	'turquoise',
+	'violet',
+	'wheat',
+	'white',
+	'whitesmoke',
+	'yellow',
+	'yellowgreen',
+]);
+
+/**
+ * Returns true if `color` is a valid CSS color value (hex, rgb/rgba, hsl/hsla,
+ * or a CSS named color). Deterministic and environment-independent.
+ */
+export function isValidCssColor(color: unknown): boolean {
+	if (!color || typeof color !== 'string') return false;
+	const value = color.trim();
+	if (value === '') return false;
+	if (HEX_COLOR.test(value)) return true;
+	if (RGB_COLOR.test(value)) return true;
+	if (HSL_COLOR.test(value)) return true;
+	return CSS_NAMED_COLORS.has(value.toLowerCase());
+}

--- a/src/shared/cssColor.ts
+++ b/src/shared/cssColor.ts
@@ -1,11 +1,12 @@
 /**
  * Deterministic CSS color validation.
  *
- * Previously theme-import validation relied on a DOM round-trip
- * (`new Option().style.color = value`), which is non-deterministic across
- * environments: jsdom's CSS parser accepts/rejects values differently than
- * Chromium and even varies under load on CI. This pure validator behaves
- * identically everywhere - production, local tests, and CI.
+ * Theme-import validation previously relied on a DOM round-trip
+ * (`new Option().style.color = value`), which is non-deterministic: jsdom's CSS
+ * parser behaves differently than Chromium, and in tests it is corrupted when
+ * a sibling test spies on `document.createElement` (the round-trip then rejects
+ * every color). This pure validator behaves identically everywhere -
+ * production, local tests, and CI - with no DOM dependency.
  *
  * Supported forms: hex (#RGB, #RGBA, #RRGGBB, #RRGGBBAA), rgb()/rgba(),
  * hsl()/hsla(), and CSS named colors (CSS Color Module Level 4).


### PR DESCRIPTION
Backports three isolated, tested bug fixes from \`0.15.0-rc\` to \`main\`, plus one supporting test-isolation fix.

## What's included
- **fix(left-bar):** keep Auto Run agents visible in the unread filter (\`34b2401db\`)
- **feat(process-monitor):** show the remote agent command for SSH spawns (\`089250c1e\`)
- **fix(terminal):** stop SSH/startup terminal tabs vanishing on PTY exit, add close diagnostics (\`a95fe655e\`)
- **test(cue):** isolate cue-spawn-builder from ambient \`MAESTRO_CLAUDE_BIN\` (\`794b19ef4\`)

## Dropped during backport
- \`7c4efbaa9\` (test: align useCue activity-log expectation to 1000) was intentionally dropped. It is a test-only alignment for the activity-log limit bump (100 to 1000) that lives in a separate rc commit (\`557013aae\`) which is out of scope for this backport. Including the test without its source change broke the suite; dropping it keeps the limit at 100 on main with a green test.

## Validation
- \`npm run lint\` passes (all three tsconfigs).
- Full pre-push test suite passes: 31,188 passed, 108 skipped.

Cherry-picked cleanly with no conflicts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * SSH spawns now display the remote agent invocation in Process Details, alongside the local SSH command.
  * Exited terminal tabs can be restarted from the terminal tab UI.

* **Improvements**
  * Terminal auto-close behavior was refined to avoid closing restartable (persistent) terminals on exit.
  * Session filtering now accounts for auto-running batch sessions.
  * Theme color validation is more reliable, including optional `bgTitleBar`.
  * Persisted file preview content is now capped to prevent overly large saves.

* **Tests**
  * Expanded regression coverage for SSH command display and terminal restart/exit handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->