### PR TITLE
feat(command-k): tab-aware Context/Buffer/Content actions

### DIFF
--- a/src/__tests__/renderer/components/QuickActionsModal/commands/commandBuilders.test.ts
+++ b/src/__tests__/renderer/components/QuickActionsModal/commands/commandBuilders.test.ts
@@ -173,6 +173,7 @@ describe('QuickActions command builders', () => {
 					hasActiveTab: true,
 					activeUnifiedIndex: 0,
 					unifiedTabCount: 2,
+					activeTabType: 'ai',
 				},
 				enterToSendAI: true,
 				onRenameTab: vi.fn(),
@@ -187,7 +188,7 @@ describe('QuickActions command builders', () => {
 		const context = buildActiveTabContextCommands({
 			activeSession: session,
 			activeSessionId: 's1',
-			isAiMode: true,
+			activeTabType: 'ai',
 			ghCliAvailable: true,
 			setSessions,
 			setQuickActionOpen: close,
@@ -231,6 +232,101 @@ describe('QuickActions command builders', () => {
 		).toEqual(['searchAgents', 'searchMessages', 'searchFiles', 'searchHistory']);
 	});
 
+	it('builds tab-type-aware Context / Buffer / Content commands', () => {
+		const session = createMockSession({
+			id: 's1',
+			activeTabId: 'tab-1',
+			aiTabs: [{ id: 'tab-1', name: 'Tab', logs: [{ id: 'l1' }], agentSessionId: 'p1' }] as any,
+		});
+		const baseArgs = {
+			activeSession: session,
+			activeSessionId: 's1',
+			ghCliAvailable: true,
+			setSessions,
+			setQuickActionOpen: close,
+			safeClipboardWrite: async () => true,
+			flashCopiedToClipboard: vi.fn(),
+			onCopyTabContext: vi.fn(),
+			onExportTabHtml: vi.fn(),
+			onPublishTabGist: vi.fn(),
+		};
+
+		// Terminal tab -> "Buffer" actions routed through the MainPanel handle.
+		const sendActiveTerminalBufferToAgent = vi.fn();
+		const terminalRef = {
+			current: {
+				copyActiveTerminalBuffer: vi.fn(),
+				sendActiveTerminalBufferToAgent,
+				publishActiveTerminalBufferGist: vi.fn(),
+			},
+		} as any;
+		const terminal = buildActiveTabContextCommands({
+			...baseArgs,
+			activeTabType: 'terminal',
+			mainPanelRef: terminalRef,
+		});
+		expect(terminal.map((a) => a.id)).toEqual([
+			'copyTerminalBuffer',
+			'sendTerminalBufferToAgent',
+			'publishTerminalBufferGist',
+		]);
+		terminal.find((a) => a.id === 'sendTerminalBufferToAgent')!.action();
+		expect(sendActiveTerminalBufferToAgent).toHaveBeenCalled();
+
+		// Browser tab -> "Content" actions, no Gist option.
+		const copyActiveBrowserContent = vi.fn();
+		const browserRef = {
+			current: { copyActiveBrowserContent, sendActiveBrowserContentToAgent: vi.fn() },
+		} as any;
+		const browser = buildActiveTabContextCommands({
+			...baseArgs,
+			activeTabType: 'browser',
+			mainPanelRef: browserRef,
+		});
+		expect(browser.map((a) => a.id)).toEqual(['copyBrowserContent', 'sendBrowserContentToAgent']);
+		browser.find((a) => a.id === 'copyBrowserContent')!.action();
+		expect(copyActiveBrowserContent).toHaveBeenCalled();
+
+		// File previews expose no context/buffer/content actions.
+		expect(buildActiveTabContextCommands({ ...baseArgs, activeTabType: 'file' })).toEqual([]);
+
+		// AI-context feature commands (Compact / Merge / Send) hide on non-AI tabs.
+		const featureArgs = {
+			activeSession: session,
+			canSummarizeActiveTab: true,
+			hasActiveSessionCapability: () => true,
+			setQuickActionOpen: close,
+			setSuccessFlashNotification: vi.fn(),
+			setAgentSessionsOpen: vi.fn(),
+			setActiveAgentSessionId: vi.fn(),
+			onSummarizeAndContinue: vi.fn(),
+			onOpenMergeSession: vi.fn(),
+			onOpenSendToAgent: vi.fn(),
+			bionifyReadingMode: false,
+			setBionifyReadingMode: vi.fn(),
+			audioFeedbackEnabled: false,
+			setAudioFeedbackEnabled: vi.fn(),
+			idleNotificationEnabled: false,
+			setIdleNotificationEnabled: vi.fn(),
+			showStarredSessionsSection: true,
+			setShowStarredSessionsSection: vi.fn(),
+			shortcuts: {},
+		};
+		const aiFeatureIds = buildFeatureCommands({ ...featureArgs, activeTabType: 'ai' }).map(
+			(a) => a.id
+		);
+		expect(aiFeatureIds).toEqual(
+			expect.arrayContaining(['summarizeAndContinue', 'mergeSession', 'sendToAgent'])
+		);
+		const terminalFeatureIds = buildFeatureCommands({
+			...featureArgs,
+			activeTabType: 'terminal',
+		}).map((a) => a.id);
+		expect(terminalFeatureIds).not.toContain('summarizeAndContinue');
+		expect(terminalFeatureIds).not.toContain('mergeSession');
+		expect(terminalFeatureIds).not.toContain('sendToAgent');
+	});
+
 	it('builds git/worktree, feature, support, and debug commands', async () => {
 		const session = createMockSession({
 			id: 's1',
@@ -264,7 +360,7 @@ describe('QuickActions command builders', () => {
 		expect(
 			buildFeatureCommands({
 				activeSession: session,
-				isAiMode: true,
+				activeTabType: 'ai',
 				canSummarizeActiveTab: true,
 				isFilePreviewOpen: true,
 				ghCliAvailable: true,

--- a/src/__tests__/renderer/components/QuickActionsModal/utils/activeTabInfo.test.ts
+++ b/src/__tests__/renderer/components/QuickActionsModal/utils/activeTabInfo.test.ts
@@ -9,6 +9,7 @@ describe('getActiveTabInfo', () => {
 			hasActiveTab: false,
 			activeUnifiedIndex: -1,
 			unifiedTabCount: 0,
+			activeTabType: null,
 		});
 	});
 
@@ -25,6 +26,7 @@ describe('getActiveTabInfo', () => {
 			hasActiveTab: true,
 			activeUnifiedIndex: 1,
 			unifiedTabCount: 2,
+			activeTabType: 'ai',
 		});
 	});
 
@@ -47,6 +49,22 @@ describe('getActiveTabInfo', () => {
 			isTerminalMode: true,
 			hasActiveTab: true,
 			activeUnifiedIndex: 3,
+			activeTabType: 'browser',
 		});
+	});
+
+	it('resolves terminal and file active tab types', () => {
+		const terminalSession = createMockSession({
+			inputMode: 'terminal',
+			activeTabId: 'ai-1',
+			activeTerminalTabId: 'terminal-1',
+		});
+		expect(getActiveTabInfo(terminalSession)).toMatchObject({ activeTabType: 'terminal' });
+
+		const fileSession = createMockSession({
+			activeTabId: 'ai-1',
+			activeFileTabId: 'file-1',
+		});
+		expect(getActiveTabInfo(fileSession)).toMatchObject({ activeTabType: 'file' });
 	});
 });

--- a/src/__tests__/renderer/components/ThinkingStatusPill.test.tsx
+++ b/src/__tests__/renderer/components/ThinkingStatusPill.test.tsx
@@ -449,6 +449,50 @@ describe('ThinkingStatusPill', () => {
 			// Agent name appears multiple times (pill + 2 dropdown rows)
 			expect(screen.getAllByText('Agent A').length).toBeGreaterThanOrEqual(2);
 		});
+
+		// Forced-parallel: two busy tabs share the active session. The primary pill must
+		// follow the active tab so its display matches the tab Stop interrupts. The dropdown
+		// is collapsed (not hovered) here, so only the primary pill renders a tab name.
+		it('follows activeTabId when two busy tabs share the active session', () => {
+			const session = createThinkingSession({ id: 'sess-1', name: 'Agent A' });
+			const tab1 = createMockAITab({ id: 'tab-1', name: 'Write', state: 'busy' });
+			const tab2 = createMockAITab({ id: 'tab-2', name: 'Read', state: 'busy' });
+			const items: ThinkingItem[] = [
+				{ session, tab: tab1 },
+				{ session, tab: tab2 },
+			];
+			render(
+				<ThinkingStatusPill
+					thinkingItems={items}
+					theme={mockTheme}
+					activeSessionId="sess-1"
+					activeTabId="tab-2"
+				/>
+			);
+
+			// Primary pill follows the active tab (tab-2 → 'Read'); the other tab's name
+			// stays hidden in the collapsed dropdown.
+			expect(screen.getByText('Read')).toBeInTheDocument();
+			expect(screen.queryByText('Write')).not.toBeInTheDocument();
+		});
+
+		// Active tab itself is idle: fall back to a busy tab in the active session.
+		it('falls back to a busy tab in the active session when the active tab is idle', () => {
+			const session = createThinkingSession({ id: 'sess-1', name: 'Agent A' });
+			const tab1 = createMockAITab({ id: 'tab-1', name: 'Write', state: 'busy' });
+			const items: ThinkingItem[] = [{ session, tab: tab1 }];
+			render(
+				<ThinkingStatusPill
+					thinkingItems={items}
+					theme={mockTheme}
+					activeSessionId="sess-1"
+					activeTabId="tab-idle"
+				/>
+			);
+
+			// No item matches the idle active tab, so the busy tab still surfaces.
+			expect(screen.getByText('Write')).toBeInTheDocument();
+		});
 	});
 
 	describe('ThinkingItemRow component (via dropdown)', () => {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -3034,6 +3034,7 @@ function MaestroConsoleInner() {
 					onCopyTabContext={handleQuickActionsCopyTabContext}
 					onExportTabHtml={handleQuickActionsExportTabHtml}
 					onPublishTabGist={handleQuickActionsPublishTabGist}
+					mainPanelRef={mainPanelRef}
 					isFilePreviewOpen={!!activeSession?.activeFileTabId}
 					ghCliAvailable={ghCliAvailable}
 					onPublishGist={() => setGistPublishModalOpen(true)}

--- a/src/renderer/components/AppModals/AppModals.tsx
+++ b/src/renderer/components/AppModals/AppModals.tsx
@@ -1,4 +1,6 @@
 import { memo, useMemo } from 'react';
+import type React from 'react';
+import type { MainPanelHandle } from '../MainPanel/types';
 import { useShallow } from 'zustand/react/shallow';
 import { useSessionStore, selectActiveSession } from '../../stores/sessionStore';
 import { useGroupChatStore } from '../../stores/groupChatStore';
@@ -263,6 +265,7 @@ export interface AppModalsProps {
 	onCopyTabContext?: (tabId: string) => void;
 	onExportTabHtml?: (tabId: string) => void;
 	onPublishTabGist?: (tabId: string) => void;
+	mainPanelRef?: React.RefObject<MainPanelHandle | null>;
 	// Gist publishing
 	isFilePreviewOpen: boolean;
 	ghCliAvailable: boolean;
@@ -728,6 +731,7 @@ export const AppModals = memo(function AppModals(props: AppModalsProps) {
 		onCopyTabContext,
 		onExportTabHtml,
 		onPublishTabGist,
+		mainPanelRef,
 		// Gist publishing
 		isFilePreviewOpen,
 		ghCliAvailable,
@@ -1081,6 +1085,7 @@ export const AppModals = memo(function AppModals(props: AppModalsProps) {
 				onCopyTabContext={onCopyTabContext}
 				onExportTabHtml={onExportTabHtml}
 				onPublishTabGist={onPublishTabGist}
+				mainPanelRef={mainPanelRef}
 				isFilePreviewOpen={isFilePreviewOpen}
 				ghCliAvailable={ghCliAvailable}
 				onPublishGist={onPublishGist}

--- a/src/renderer/components/AppModals/AppUtilityModals.tsx
+++ b/src/renderer/components/AppModals/AppUtilityModals.tsx
@@ -1,4 +1,5 @@
 import { lazy, Suspense, memo } from 'react';
+import type React from 'react';
 import type {
 	Theme,
 	Session,
@@ -11,6 +12,7 @@ import type {
 	ThinkingMode,
 } from '../../types';
 import type { FileNode } from '../../types/fileTree';
+import type { MainPanelHandle } from '../MainPanel/types';
 import type { WizardStep } from '../Wizard/WizardContext';
 import type { FlatFileItem } from '../FileSearchModal';
 
@@ -144,6 +146,7 @@ export interface AppUtilityModalsProps {
 	onCopyTabContext?: (tabId: string) => void;
 	onExportTabHtml?: (tabId: string) => void;
 	onPublishTabGist?: (tabId: string) => void;
+	mainPanelRef?: React.RefObject<MainPanelHandle | null>;
 
 	// Gist publishing (for QuickActionsModal)
 	isFilePreviewOpen: boolean;
@@ -384,6 +387,7 @@ export const AppUtilityModals = memo(function AppUtilityModals({
 	onCopyTabContext,
 	onExportTabHtml,
 	onPublishTabGist,
+	mainPanelRef,
 	// Gist publishing
 	isFilePreviewOpen,
 	ghCliAvailable,
@@ -582,6 +586,7 @@ export const AppUtilityModals = memo(function AppUtilityModals({
 					onCopyTabContext={onCopyTabContext}
 					onExportTabHtml={onExportTabHtml}
 					onPublishTabGist={onPublishTabGist}
+					mainPanelRef={mainPanelRef}
 					isFilePreviewOpen={isFilePreviewOpen}
 					ghCliAvailable={ghCliAvailable}
 					onPublishGist={onPublishGist}

--- a/src/renderer/components/InputArea/InputArea.tsx
+++ b/src/renderer/components/InputArea/InputArea.tsx
@@ -327,6 +327,7 @@ export const InputArea = React.memo(function InputArea(props: InputAreaProps) {
 					namedSessions={namedSessions}
 					autoRunState={autoRunState}
 					activeSessionId={session.id}
+					activeTabId={session.activeTabId}
 					onStopAutoRun={onStopAutoRun}
 					onInterrupt={handleInterrupt}
 				/>

--- a/src/renderer/components/MainPanel/MainPanel.tsx
+++ b/src/renderer/components/MainPanel/MainPanel.tsx
@@ -338,6 +338,18 @@ export const MainPanel = React.memo(
 		);
 
 		// Expose methods to parent via ref
+		// Holds the latest terminal/browser buffer-action handlers. The imperative
+		// handle only rebuilds on session-id change, so it reads these through a ref
+		// (populated every render below) to avoid calling a stale closure after tabs
+		// change within the same session.
+		const tabBufferActionsRef = useRef<{
+			copyTerminalBuffer: (tabId: string) => void;
+			sendTerminalBufferToAgent: (tabId: string) => void;
+			publishTerminalBufferGist: (tabId: string) => void;
+			copyBrowserContent: (tabId: string) => void | Promise<void>;
+			sendBrowserContentToAgent: (tabId: string) => void | Promise<void>;
+		} | null>(null);
+
 		useImperativeHandle(
 			ref,
 			() => ({
@@ -443,6 +455,31 @@ export const MainPanel = React.memo(
 				},
 				openTerminalSearch: () => {
 					setTerminalSearchOpen(true);
+				},
+				copyActiveTerminalBuffer: () => {
+					const session = selectActiveSession(useSessionStore.getState());
+					if (session?.activeTerminalTabId)
+						tabBufferActionsRef.current?.copyTerminalBuffer(session.activeTerminalTabId);
+				},
+				sendActiveTerminalBufferToAgent: () => {
+					const session = selectActiveSession(useSessionStore.getState());
+					if (session?.activeTerminalTabId)
+						tabBufferActionsRef.current?.sendTerminalBufferToAgent(session.activeTerminalTabId);
+				},
+				publishActiveTerminalBufferGist: () => {
+					const session = selectActiveSession(useSessionStore.getState());
+					if (session?.activeTerminalTabId)
+						tabBufferActionsRef.current?.publishTerminalBufferGist(session.activeTerminalTabId);
+				},
+				copyActiveBrowserContent: () => {
+					const session = selectActiveSession(useSessionStore.getState());
+					if (session?.activeBrowserTabId)
+						void tabBufferActionsRef.current?.copyBrowserContent(session.activeBrowserTabId);
+				},
+				sendActiveBrowserContentToAgent: () => {
+					const session = selectActiveSession(useSessionStore.getState());
+					if (session?.activeBrowserTabId)
+						void tabBufferActionsRef.current?.sendBrowserContentToAgent(session.activeBrowserTabId);
 				},
 			}),
 			[refreshGitStatus, activeSession?.id]
@@ -574,6 +611,16 @@ export const MainPanel = React.memo(
 			},
 			[resolveBrowserContent, props.onSendTextToAgent]
 		);
+
+		// Keep the imperative handle's buffer/content actions pointed at the latest
+		// closures so Command K runs them against the current session's tabs.
+		tabBufferActionsRef.current = {
+			copyTerminalBuffer: handleCopyTerminalBuffer,
+			sendTerminalBufferToAgent: handleSendTerminalBufferToAgent,
+			publishTerminalBufferGist: handlePublishTerminalBufferGist,
+			copyBrowserContent: handleCopyBrowserContent,
+			sendBrowserContentToAgent: handleSendBrowserContentToAgent,
+		};
 
 		// Handler for input focus - select session in sidebar
 		// Memoized to avoid recreating on every render

--- a/src/renderer/components/MainPanel/types.ts
+++ b/src/renderer/components/MainPanel/types.ts
@@ -43,6 +43,16 @@ export interface MainPanelHandle {
 	focusActiveTab: () => void;
 	/** Reload the active browser tab (or stop loading if in progress) */
 	reloadBrowserTab: () => void;
+	/** Copy the active terminal tab's buffer (scrollback) to the clipboard */
+	copyActiveTerminalBuffer: () => void;
+	/** Send the active terminal tab's buffer to another agent */
+	sendActiveTerminalBufferToAgent: () => void;
+	/** Publish the active terminal tab's buffer as a GitHub Gist */
+	publishActiveTerminalBufferGist: () => void;
+	/** Copy the active browser tab's rendered page content to the clipboard */
+	copyActiveBrowserContent: () => void;
+	/** Send the active browser tab's rendered page content to another agent */
+	sendActiveBrowserContentToAgent: () => void;
 }
 
 export interface MainPanelProps {

--- a/src/renderer/components/QuickActionsModal/QuickActionsModal.tsx
+++ b/src/renderer/components/QuickActionsModal/QuickActionsModal.tsx
@@ -135,6 +135,7 @@ export const QuickActionsModal = memo(function QuickActionsModal(props: QuickAct
 		onCopyTabContext,
 		onExportTabHtml,
 		onPublishTabGist,
+		mainPanelRef,
 		isFilePreviewOpen,
 		ghCliAvailable,
 		onPublishGist,
@@ -231,6 +232,7 @@ export const QuickActionsModal = memo(function QuickActionsModal(props: QuickAct
 	);
 
 	const activeTabInfo = getActiveTabInfo(activeSession, isAiMode);
+	const activeTabType = activeTabInfo.activeTabType;
 
 	// Register layer on mount - escape behavior depends on current mode.
 	// Only fall back to the main menu if the user actually came from there;
@@ -453,7 +455,7 @@ export const QuickActionsModal = memo(function QuickActionsModal(props: QuickAct
 		}),
 		...buildFeatureCommands({
 			activeSession,
-			isAiMode,
+			activeTabType,
 			canSummarizeActiveTab,
 			markdownEditMode,
 			isFilePreviewOpen,
@@ -505,7 +507,7 @@ export const QuickActionsModal = memo(function QuickActionsModal(props: QuickAct
 		...buildActiveTabContextCommands({
 			activeSession,
 			activeSessionId,
-			isAiMode,
+			activeTabType,
 			ghCliAvailable,
 			setSessions,
 			setQuickActionOpen,
@@ -514,6 +516,7 @@ export const QuickActionsModal = memo(function QuickActionsModal(props: QuickAct
 			onCopyTabContext,
 			onExportTabHtml,
 			onPublishTabGist,
+			mainPanelRef,
 			toggleTabStarShortcut: shortcuts.toggleTabStar,
 			toggleTabUnreadShortcut: tabShortcuts?.toggleTabUnread,
 		}),

--- a/src/renderer/components/QuickActionsModal/commands/contextCommands.ts
+++ b/src/renderer/components/QuickActionsModal/commands/contextCommands.ts
@@ -1,12 +1,17 @@
 import type React from 'react';
 import { buildSessionDeepLink } from '../../../../shared/deep-link-urls';
 import type { Session } from '../../../types';
-import type { QuickAction } from '../types';
+import type { MainPanelHandle } from '../../MainPanel/types';
+import type { ActiveTabInfo, QuickAction } from '../types';
 
 interface BuildActiveTabContextCommandsArgs {
 	activeSession: Session | undefined;
 	activeSessionId: string;
-	isAiMode?: boolean;
+	/**
+	 * Resolved type of the active tab. Selects the action noun and command set:
+	 * Context (ai) / Buffer (terminal) / Content (browser) / none (file).
+	 */
+	activeTabType?: ActiveTabInfo['activeTabType'];
 	ghCliAvailable?: boolean;
 	setSessions: React.Dispatch<React.SetStateAction<Session[]>>;
 	setQuickActionOpen: (open: boolean) => void;
@@ -15,6 +20,8 @@ interface BuildActiveTabContextCommandsArgs {
 	onCopyTabContext?: (tabId: string) => void;
 	onExportTabHtml?: (tabId: string) => void;
 	onPublishTabGist?: (tabId: string) => void;
+	/** Imperative handle used to run terminal Buffer / browser Content actions. */
+	mainPanelRef?: React.RefObject<MainPanelHandle | null>;
 	toggleTabStarShortcut?: QuickAction['shortcut'];
 	toggleTabUnreadShortcut?: QuickAction['shortcut'];
 }
@@ -22,7 +29,7 @@ interface BuildActiveTabContextCommandsArgs {
 export function buildActiveTabContextCommands({
 	activeSession,
 	activeSessionId,
-	isAiMode,
+	activeTabType,
 	ghCliAvailable,
 	setSessions,
 	setQuickActionOpen,
@@ -31,12 +38,71 @@ export function buildActiveTabContextCommands({
 	onCopyTabContext,
 	onExportTabHtml,
 	onPublishTabGist,
+	mainPanelRef,
 	toggleTabStarShortcut,
 	toggleTabUnreadShortcut,
 }: BuildActiveTabContextCommandsArgs): QuickAction[] {
-	if (!isAiMode || !activeSession) return [];
-	const activeTab = activeSession.aiTabs.find((tab) => tab.id === activeSession.activeTabId);
+	if (!activeSession) return [];
 	const commands: QuickAction[] = [];
+
+	// Terminal tab -> "Buffer" actions on the live scrollback (via MainPanel).
+	if (activeTabType === 'terminal') {
+		if (!mainPanelRef) return commands;
+		commands.push({
+			id: 'copyTerminalBuffer',
+			label: 'Buffer: Copy to Clipboard',
+			action: () => {
+				mainPanelRef.current?.copyActiveTerminalBuffer();
+				setQuickActionOpen(false);
+			},
+		});
+		commands.push({
+			id: 'sendTerminalBufferToAgent',
+			label: 'Buffer: Send to Agent',
+			action: () => {
+				mainPanelRef.current?.sendActiveTerminalBufferToAgent();
+				setQuickActionOpen(false);
+			},
+		});
+		if (ghCliAvailable) {
+			commands.push({
+				id: 'publishTerminalBufferGist',
+				label: 'Buffer: Publish as GitHub Gist',
+				action: () => {
+					mainPanelRef.current?.publishActiveTerminalBufferGist();
+					setQuickActionOpen(false);
+				},
+			});
+		}
+		return commands;
+	}
+
+	// Browser tab -> "Content" actions on the rendered page text (via MainPanel).
+	if (activeTabType === 'browser') {
+		if (!mainPanelRef) return commands;
+		commands.push({
+			id: 'copyBrowserContent',
+			label: 'Content: Copy to Clipboard',
+			action: () => {
+				mainPanelRef.current?.copyActiveBrowserContent();
+				setQuickActionOpen(false);
+			},
+		});
+		commands.push({
+			id: 'sendBrowserContentToAgent',
+			label: 'Content: Send to Agent',
+			action: () => {
+				mainPanelRef.current?.sendActiveBrowserContentToAgent();
+				setQuickActionOpen(false);
+			},
+		});
+		return commands;
+	}
+
+	// File previews have no buffer/content actions; only AI tabs get Context.
+	if (activeTabType !== 'ai') return commands;
+
+	const activeTab = activeSession.aiTabs.find((tab) => tab.id === activeSession.activeTabId);
 
 	if (activeTab?.agentSessionId) {
 		commands.push({

--- a/src/renderer/components/QuickActionsModal/commands/featureCommands.ts
+++ b/src/renderer/components/QuickActionsModal/commands/featureCommands.ts
@@ -1,10 +1,11 @@
 import type { Session } from '../../../types';
-import type { QuickAction } from '../types';
+import type { ActiveTabInfo, QuickAction } from '../types';
 import { editClipboardImage } from '../../ImageAnnotator/editClipboardImage';
 
 interface BuildFeatureCommandsArgs {
 	activeSession: Session | undefined;
-	isAiMode?: boolean;
+	/** Resolved active tab type; AI-context commands only apply when this is 'ai'. */
+	activeTabType?: ActiveTabInfo['activeTabType'];
 	canSummarizeActiveTab?: boolean;
 	markdownEditMode?: boolean;
 	isFilePreviewOpen?: boolean;
@@ -71,7 +72,7 @@ function flash(
 
 export function buildFeatureCommands({
 	activeSession,
-	isAiMode,
+	activeTabType,
 	canSummarizeActiveTab,
 	markdownEditMode,
 	isFilePreviewOpen,
@@ -232,7 +233,7 @@ export function buildFeatureCommands({
 		});
 	}
 
-	if (isAiMode && canSummarizeActiveTab && onSummarizeAndContinue) {
+	if (activeTabType === 'ai' && canSummarizeActiveTab && onSummarizeAndContinue) {
 		commands.push({
 			id: 'summarizeAndContinue',
 			label: 'Context: Compact',
@@ -245,7 +246,12 @@ export function buildFeatureCommands({
 		});
 	}
 
-	if (activeSession && hasActiveSessionCapability?.('supportsContextMerge') && onOpenMergeSession) {
+	if (
+		activeTabType === 'ai' &&
+		activeSession &&
+		hasActiveSessionCapability?.('supportsContextMerge') &&
+		onOpenMergeSession
+	) {
 		commands.push({
 			id: 'mergeSession',
 			label: 'Context: Merge Into',
@@ -258,7 +264,12 @@ export function buildFeatureCommands({
 		});
 	}
 
-	if (activeSession && hasActiveSessionCapability?.('supportsContextMerge') && onOpenSendToAgent) {
+	if (
+		activeTabType === 'ai' &&
+		activeSession &&
+		hasActiveSessionCapability?.('supportsContextMerge') &&
+		onOpenSendToAgent
+	) {
 		commands.push({
 			id: 'sendToAgent',
 			label: 'Context: Send to Agent',

--- a/src/renderer/components/QuickActionsModal/types.ts
+++ b/src/renderer/components/QuickActionsModal/types.ts
@@ -10,6 +10,7 @@ import type {
 	Theme,
 } from '../../types';
 import type { WizardStep } from '../Wizard/WizardContext';
+import type { MainPanelHandle } from '../MainPanel/types';
 
 export type QuickActionMode = 'main' | 'move-to-group' | 'agents';
 
@@ -42,6 +43,13 @@ export interface ActiveTabInfo {
 	hasActiveTab: boolean;
 	activeUnifiedIndex: number;
 	unifiedTabCount: number;
+	/**
+	 * Resolved type of the currently-visible tab (browser > terminal > file > ai
+	 * precedence). Null only when there is no active session. Drives which
+	 * noun the Command K palette uses: Context (ai) / Buffer (terminal) /
+	 * Content (browser) / none (file).
+	 */
+	activeTabType: 'ai' | 'file' | 'terminal' | 'browser' | null;
 }
 
 export interface QuickActionsModalProps {
@@ -138,6 +146,12 @@ export interface QuickActionsModalProps {
 	onCopyTabContext?: (tabId: string) => void;
 	onExportTabHtml?: (tabId: string) => void;
 	onPublishTabGist?: (tabId: string) => void;
+	/**
+	 * Imperative handle to MainPanel, used to run terminal "Buffer" and browser
+	 * "Content" actions on the active tab (the underlying scrollback / page text
+	 * lives behind refs that only MainPanel can reach).
+	 */
+	mainPanelRef?: React.RefObject<MainPanelHandle | null>;
 	isFilePreviewOpen?: boolean;
 	ghCliAvailable?: boolean;
 	onPublishGist?: () => void;

--- a/src/renderer/components/QuickActionsModal/utils/activeTabInfo.ts
+++ b/src/renderer/components/QuickActionsModal/utils/activeTabInfo.ts
@@ -13,6 +13,7 @@ export function getActiveTabInfo(
 		activeSession?.activeBrowserTabId
 	);
 
+	let activeTabType: 'ai' | 'file' | 'terminal' | 'browser' | null = null;
 	let activeUnifiedIndex = -1;
 	if (activeSession) {
 		let type: 'ai' | 'file' | 'terminal' | 'browser';
@@ -30,6 +31,7 @@ export function getActiveTabInfo(
 			type = 'ai';
 			id = activeSession.activeTabId;
 		}
+		activeTabType = type;
 		if (id) {
 			activeUnifiedIndex = (activeSession.unifiedTabOrder ?? []).findIndex(
 				(ref) => ref.type === type && ref.id === id
@@ -42,5 +44,6 @@ export function getActiveTabInfo(
 		hasActiveTab,
 		activeUnifiedIndex,
 		unifiedTabCount: activeSession?.unifiedTabOrder?.length ?? 0,
+		activeTabType,
 	};
 }

--- a/src/renderer/components/ThinkingStatusPill.tsx
+++ b/src/renderer/components/ThinkingStatusPill.tsx
@@ -20,6 +20,9 @@ interface ThinkingStatusPillProps {
 	// AutoRun state for the active session - when provided and running, shows AutoRun pill instead
 	autoRunState?: BatchRunState;
 	activeSessionId?: string;
+	// Active AI tab within the active session. When forced-parallel runs two busy tabs in
+	// the same agent, the pill follows this tab so the display matches what Stop interrupts.
+	activeTabId?: string;
 	// Callback to stop auto-run (shows stop button in AutoRunPill when provided)
 	onStopAutoRun?: () => void;
 	// Callback to interrupt the current AI session
@@ -404,6 +407,7 @@ function ThinkingStatusPillInner({
 	namedSessions,
 	autoRunState,
 	activeSessionId,
+	activeTabId,
 	onStopAutoRun,
 	onInterrupt,
 }: ThinkingStatusPillProps) {
@@ -456,10 +460,18 @@ function ThinkingStatusPillInner({
 		return null;
 	}
 
-	// Primary item: prioritize an item from the active session,
-	// otherwise fall back to first thinking item.
-	// This ensures Stop button stops the session the user is currently viewing.
-	const activeItem = thinkingItems.find((item) => item.session.id === activeSessionId);
+	// Primary item selection (each layer falls back to the next):
+	//   1. The exact active tab in the active session — when forced-parallel runs two busy
+	//      tabs in the same agent, this keeps the pill (name, elapsed time) describing the
+	//      tab the user is viewing, which is also the tab Stop will interrupt.
+	//   2. Any busy tab in the active session (active tab itself isn't busy).
+	//   3. The first thinking item anywhere.
+	const activeItem =
+		(activeTabId &&
+			thinkingItems.find(
+				(item) => item.session.id === activeSessionId && item.tab?.id === activeTabId
+			)) ||
+		thinkingItems.find((item) => item.session.id === activeSessionId);
 	const primaryItem = activeItem || thinkingItems[0];
 	const additionalItems = thinkingItems.filter((item) => item !== primaryItem);
 	const hasMultiple = additionalItems.length > 0;
@@ -699,8 +711,11 @@ export const ThinkingStatusPill = memo(ThinkingStatusPillInner, (prevProps, next
 		return prevProps.theme === nextProps.theme;
 	}
 
-	// Check if activeSessionId changed - this affects which item shows as primary
+	// Check if active session/tab changed - both affect which item shows as primary.
+	// activeTabId matters when two busy tabs share the active session (forced parallel):
+	// the busy-tab set is identical, so only the active-tab change should re-render the pill.
 	if (prevProps.activeSessionId !== nextProps.activeSessionId) return false;
+	if (prevProps.activeTabId !== nextProps.activeTabId) return false;
 
 	// thinkingItems is pre-filtered by caller - just compare directly
 	const prevItems = prevProps.thinkingItems;


### PR DESCRIPTION
## Problem

The Command K palette always showed the AI **Context:** actions regardless of which tab was active. On a terminal or browser tab you'd see mislabeled `Context: Send to Agent` / `Context: Merge Into` / `Context: Compact` that operated on **AI conversation context** instead of the thing in front of you. File previews showed AI context actions too, despite having no such option in the right-click menu.

## Fix

The palette now resolves the active tab type and offers the matching action set, mirroring the right-click tab overlay menus:

| Active tab | Noun | Actions |
| --- | --- | --- |
| AI | **Context** | Copy, Compact, Merge Into, Send to Agent, Publish Gist |
| Terminal | **Buffer** | Copy, Send to Agent, Publish Gist |
| Browser | **Content** | Copy, Send to Agent |
| File preview | *(none)* | - |

## Implementation

- `getActiveTabInfo` now surfaces the resolved `activeTabType` (browser > terminal > file > ai precedence, matching render precedence).
- `contextCommands` / `featureCommands` gate the Context set on `activeTabType === 'ai'` and add the Buffer (terminal) and Content (browser) command sets.
- Terminal scrollback and browser page text live behind refs only `MainPanel` can reach, so 5 new `MainPanelHandle` methods run them on the active tab. The handle reads the latest closures through a ref so it stays correct after tabs change within a session (the handle itself only rebuilds on session-id change).
- `mainPanelRef` threaded `App` -> `AppModals` -> `AppUtilityModals` -> `QuickActionsModal`.

## Tests

- New unit coverage for the tab-type branches (terminal Buffer, browser Content, file = empty) and for the AI-context feature commands hiding on non-AI tabs.
- Full repo gate green locally: format, tsc, ESLint, and the full suite (31,205 passed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Quick Actions modal now enables tab-specific actions: copy and send terminal buffer operations; copy and send browser content commands.

* **Improvements**
  * Enhanced thinking status indicator to accurately display active tab information when multiple tabs are active in the same session.

* **Tests**
  * Updated tests for Quick Actions command builders, active tab detection, and thinking status display across multiple tab types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->