### PR TITLE
fix(cue): scan watched file on manual task.pending trigger

### DIFF
--- a/src/__tests__/main/cue/cue-engine.test.ts
+++ b/src/__tests__/main/cue/cue-engine.test.ts
@@ -1624,6 +1624,44 @@ describe('CueEngine', () => {
 
 			engine.stop();
 		});
+
+		it('manual trigger dispatches even when the scan throws (unreadable projectRoot)', () => {
+			const config = createMockConfig({
+				subscriptions: [
+					{
+						name: 'task-queue',
+						event: 'task.pending',
+						enabled: true,
+						prompt: 'process tasks',
+						watch: 'tasks/**/*.md',
+					},
+				],
+			});
+			mockLoadCueConfig.mockReturnValue(config);
+			// walkDir re-throws when projectRoot is unreadable; the engine must
+			// degrade gracefully rather than abort the trigger.
+			mockScanTaskFilesOnce.mockImplementation(() => {
+				throw new Error('ENOENT: projectRoot gone');
+			});
+
+			const deps = createMockDeps();
+			const engine = new CueEngine(deps);
+			engine.start();
+
+			const result = engine.triggerSubscription('task-queue');
+
+			// Still dispatched, with the bare manual payload (no task fields).
+			expect(result).toBe(true);
+			const callArgs = (deps.onCueRun as ReturnType<typeof vi.fn>).mock.calls[0][0];
+			expect(callArgs.event.payload).toMatchObject({ manual: true });
+			expect(callArgs.event.payload).not.toHaveProperty('taskCount');
+			expect(deps.onLog).toHaveBeenCalledWith(
+				'warn',
+				expect.stringContaining('manual trigger scan failed')
+			);
+
+			engine.stop();
+		});
 	});
 
 	describe('getStatus', () => {

--- a/src/__tests__/main/cue/cue-engine.test.ts
+++ b/src/__tests__/main/cue/cue-engine.test.ts
@@ -46,8 +46,12 @@ vi.mock('../../../main/cue/cue-github-poller', () => ({
 
 // Mock the task scanner
 const mockCreateCueTaskScanner = vi.fn<(config: unknown) => () => void>();
+const mockScanTaskFilesOnce =
+	vi.fn<(watchGlob: string, projectRoot: string) => Array<Record<string, unknown>>>();
 vi.mock('../../../main/cue/cue-task-scanner', () => ({
 	createCueTaskScanner: (...args: unknown[]) => mockCreateCueTaskScanner(args[0]),
+	scanTaskFilesOnce: (...args: unknown[]) =>
+		mockScanTaskFilesOnce(args[0] as string, args[1] as string),
 }));
 
 // Mock the database
@@ -113,6 +117,7 @@ describe('CueEngine', () => {
 
 		yamlWatcherCleanup = vi.fn();
 		mockWatchCueYaml.mockReturnValue(yamlWatcherCleanup);
+		mockScanTaskFilesOnce.mockReturnValue([]);
 
 		// Default loadCueConfigDetailed: derive from loadCueConfig for tests that
 		// only configure mockLoadCueConfig. Tests that need to inject warnings or
@@ -1534,6 +1539,88 @@ describe('CueEngine', () => {
 			engine.start();
 
 			expect(mockCreateCueTaskScanner).not.toHaveBeenCalled();
+
+			engine.stop();
+		});
+
+		it('manual trigger scans the watched file and populates the task payload', () => {
+			const config = createMockConfig({
+				subscriptions: [
+					{
+						name: 'task-queue',
+						event: 'task.pending',
+						enabled: true,
+						prompt: 'process tasks',
+						watch: 'tasks/**/*.md',
+					},
+				],
+			});
+			mockLoadCueConfig.mockReturnValue(config);
+			mockScanTaskFilesOnce.mockReturnValue([
+				{
+					path: '/projects/test/tasks/queue.md',
+					filename: 'queue.md',
+					taskCount: 2,
+					taskList: 'L3: first task\nL5: second task',
+					tasks: [
+						{ line: 3, text: 'first task' },
+						{ line: 5, text: 'second task' },
+					],
+				},
+			]);
+
+			const deps = createMockDeps();
+			const engine = new CueEngine(deps);
+			engine.start();
+
+			const result = engine.triggerSubscription('task-queue');
+			expect(result).toBe(true);
+
+			// Scanned with the sub's watch glob against the owner's projectRoot.
+			expect(mockScanTaskFilesOnce).toHaveBeenCalledWith('tasks/**/*.md', '/projects/test');
+
+			// The scanned task fields land in the dispatched event payload so the
+			// prompt's {{CUE_TASK_COUNT}}/{{CUE_TASK_LIST}} resolve to real tasks.
+			expect(deps.onCueRun).toHaveBeenCalledWith(
+				expect.objectContaining({
+					event: expect.objectContaining({
+						payload: expect.objectContaining({
+							manual: true,
+							taskCount: 2,
+							taskList: 'L3: first task\nL5: second task',
+							path: '/projects/test/tasks/queue.md',
+						}),
+					}),
+				})
+			);
+
+			engine.stop();
+		});
+
+		it('manual trigger with no pending tasks still dispatches without task fields', () => {
+			const config = createMockConfig({
+				subscriptions: [
+					{
+						name: 'task-queue',
+						event: 'task.pending',
+						enabled: true,
+						prompt: 'process tasks',
+						watch: 'tasks/**/*.md',
+					},
+				],
+			});
+			mockLoadCueConfig.mockReturnValue(config);
+			mockScanTaskFilesOnce.mockReturnValue([]);
+
+			const deps = createMockDeps();
+			const engine = new CueEngine(deps);
+			engine.start();
+
+			engine.triggerSubscription('task-queue');
+
+			const callArgs = (deps.onCueRun as ReturnType<typeof vi.fn>).mock.calls[0][0];
+			expect(callArgs.event.payload).toMatchObject({ manual: true });
+			expect(callArgs.event.payload).not.toHaveProperty('taskCount');
 
 			engine.stop();
 		});

--- a/src/main/cue/cue-engine.ts
+++ b/src/main/cue/cue-engine.ts
@@ -1163,20 +1163,36 @@ export class CueEngine {
 					.getSessions()
 					.find((s) => s.id === ownerSessionId)?.projectRoot;
 				if (projectRoot) {
-					const payloads = scanTaskFilesOnce(sub.watch, projectRoot);
-					if (payloads.length > 0) {
-						taskPayload = payloads[0];
-						if (payloads.length > 1) {
+					// walkDir re-throws when projectRoot itself is unreadable
+					// (deleted/unmounted/permission change). Mirror doScan's
+					// graceful degradation: log, report, and dispatch with an empty
+					// task payload rather than aborting the whole trigger group.
+					try {
+						const payloads = scanTaskFilesOnce(sub.watch, projectRoot);
+						if (payloads.length > 0) {
+							taskPayload = payloads[0];
+							if (payloads.length > 1) {
+								this.deps.onLog(
+									'cue',
+									`[CUE] "${sub.name}" manual trigger: ${payloads.length} files match "${sub.watch}"; using ${String(taskPayload.filename)}`
+								);
+							}
+						} else {
 							this.deps.onLog(
 								'cue',
-								`[CUE] "${sub.name}" manual trigger: ${payloads.length} files match "${sub.watch}"; using ${String(taskPayload.filename)}`
+								`[CUE] "${sub.name}" manual trigger: no pending tasks in "${sub.watch}"`
 							);
 						}
-					} else {
+					} catch (err) {
 						this.deps.onLog(
-							'cue',
-							`[CUE] "${sub.name}" manual trigger: no pending tasks in "${sub.watch}"`
+							'warn',
+							`[CUE] "${sub.name}" manual trigger scan failed: ${err instanceof Error ? err.message : String(err)}`
 						);
+						void captureException(err, {
+							operation: 'cue.triggerSubscription.scanTaskFilesOnce',
+							subscriptionName: sub.name,
+							ownerSessionId,
+						});
 					}
 				}
 			}

--- a/src/main/cue/cue-engine.ts
+++ b/src/main/cue/cue-engine.ts
@@ -73,6 +73,7 @@ import {
 	parseCueSubscriptionId,
 	pipelineKeyForSubscription,
 } from '../../shared/cue/subscription-id';
+import { scanTaskFilesOnce } from './cue-task-scanner';
 
 const MAX_CHAIN_DEPTH = 10;
 
@@ -1152,8 +1153,37 @@ export class CueEngine {
 
 		let totalDispatched = 0;
 		for (const { ownerSessionId, state, sub } of toDispatch) {
+			// task.pending subs carry their tasks in the event payload. A manual
+			// trigger has no scanner run behind it, so scan the watched file(s)
+			// now — otherwise the prompt's {{CUE_TASK_COUNT}}/{{CUE_TASK_LIST}}
+			// fall back to "0"/"" and the run sees no work to do.
+			let taskPayload: Record<string, unknown> = {};
+			if (sub.event === 'task.pending' && sub.watch) {
+				const projectRoot = this.deps
+					.getSessions()
+					.find((s) => s.id === ownerSessionId)?.projectRoot;
+				if (projectRoot) {
+					const payloads = scanTaskFilesOnce(sub.watch, projectRoot);
+					if (payloads.length > 0) {
+						taskPayload = payloads[0];
+						if (payloads.length > 1) {
+							this.deps.onLog(
+								'cue',
+								`[CUE] "${sub.name}" manual trigger: ${payloads.length} files match "${sub.watch}"; using ${String(taskPayload.filename)}`
+							);
+						}
+					} else {
+						this.deps.onLog(
+							'cue',
+							`[CUE] "${sub.name}" manual trigger: no pending tasks in "${sub.watch}"`
+						);
+					}
+				}
+			}
+
 			const event = createCueEvent(sub.event, sub.name, {
 				manual: true,
+				...taskPayload,
 				...(sourceAgentId ? { sourceAgentId } : {}),
 				...(promptOverride ? { cliPrompt: promptOverride } : {}),
 			});

--- a/src/main/cue/cue-task-scanner.ts
+++ b/src/main/cue/cue-task-scanner.ts
@@ -59,6 +59,69 @@ export function extractPendingTasks(content: string): PendingTask[] {
 }
 
 /**
+ * Build the `task.pending` event payload for a single file's content.
+ * Returns null when the file has no pending tasks (nothing to fire).
+ *
+ * Shared by the polling scanner and the manual-trigger path so both produce
+ * identical payloads (path/taskCount/taskList/tasks/content).
+ */
+export function buildTaskPendingPayload(
+	absPath: string,
+	relPath: string,
+	content: string
+): Record<string, unknown> | null {
+	const pendingTasks = extractPendingTasks(content);
+	if (pendingTasks.length === 0) {
+		return null;
+	}
+
+	const taskList = pendingTasks.map((t) => `L${t.line}: ${t.text}`).join('\n');
+
+	return {
+		path: absPath,
+		filename: path.basename(relPath),
+		directory: path.dirname(absPath),
+		extension: path.extname(relPath),
+		taskCount: pendingTasks.length,
+		taskList,
+		tasks: pendingTasks,
+		content: content.slice(0, 10000),
+	};
+}
+
+/**
+ * One-shot scan: walk `projectRoot`, read every file matching `watchGlob`, and
+ * return a `task.pending` payload for each file that currently has pending
+ * tasks. Unlike the polling scanner this ignores content hashes and seeding —
+ * it always reflects the live on-disk state. Used by the manual trigger
+ * (`maestro-cli cue trigger`) so a hand-fired run sees the same tasks a poll
+ * would.
+ */
+export function scanTaskFilesOnce(
+	watchGlob: string,
+	projectRoot: string
+): Array<Record<string, unknown>> {
+	const isMatch = picomatch(watchGlob);
+	const allFiles = walkDir(projectRoot, projectRoot);
+	const payloads: Array<Record<string, unknown>> = [];
+
+	for (const relPath of allFiles) {
+		if (!isMatch(relPath)) continue;
+		const absPath = path.resolve(projectRoot, relPath);
+		let content: string;
+		try {
+			content = fs.readFileSync(absPath, 'utf-8');
+		} catch {
+			continue;
+		}
+		const payload = buildTaskPendingPayload(absPath, relPath, content);
+		if (payload) payloads.push(payload);
+	}
+
+	return payloads;
+}
+
+/**
  * Recursively walk a directory and return all file paths (relative to root).
  */
 function walkDir(dir: string, root: string): string[] {
@@ -148,23 +211,12 @@ export function createCueTaskScanner(config: CueTaskScannerConfig): () => void {
 				}
 
 				// Extract pending tasks
-				const pendingTasks = extractPendingTasks(content);
-				if (pendingTasks.length === 0) {
+				const payload = buildTaskPendingPayload(absPath, relPath, content);
+				if (!payload) {
 					continue;
 				}
 
-				const taskList = pendingTasks.map((t) => `L${t.line}: ${t.text}`).join('\n');
-
-				const event = createCueEvent('task.pending', triggerName, {
-					path: absPath,
-					filename: path.basename(relPath),
-					directory: path.dirname(absPath),
-					extension: path.extname(relPath),
-					taskCount: pendingTasks.length,
-					taskList,
-					tasks: pendingTasks,
-					content: content.slice(0, 10000),
-				});
+				const event = createCueEvent('task.pending', triggerName, payload);
 
 				onEvent(event);
 			}


### PR DESCRIPTION
A manual `maestro-cli cue trigger` of a task.pending subscription built a bare event with no task payload, so the prompt's {{CUE_TASK_COUNT}} and {{CUE_TASK_LIST}} fell back to "0"/"" and the run saw no work. Only the polling scanner populated those fields, so the documented manual fallback was broken.

Extract `buildTaskPendingPayload` and add `scanTaskFilesOnce` in the task scanner (hash-free live scan), and have `CueEngine.triggerSubscription` scan the sub's watch glob against the owner's projectRoot before dispatch, merging the first matching file's task fields into the event payload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manual task triggering now performs a one-time scan of the watched project files for pending tasks and enriches the event payload with task metadata (count, list, path) when available.
  * When no pending tasks are found, the event payload is still dispatched with the manual indicator, omitting task metadata.
* **Bug Fixes**
  * If the scan fails, manual triggers still dispatch the bare manual payload and log a warning instead of breaking the workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->