### PR TITLE
Add Requesty provider

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -170,6 +170,29 @@ To override a global variable for a specific agent:
 2. Add the variable with the override value
 3. This session-specific value takes precedence over the global setting
 
+## Built-in LLM Provider
+
+Some built-in AI features call an LLM directly (rather than going through a coding
+agent). The provider for these features is configured under **Settings → LLM** via the
+**LLM Provider** dropdown, a **Model Slug** field, and an **API Key** field. A **Test
+Connection** button sends a short prompt to verify connectivity and configuration.
+
+| Provider   | Base URL                              | API style        | Example model slug          |
+| ---------- | ------------------------------------- | ---------------- | --------------------------- |
+| OpenRouter | `https://openrouter.ai/api/v1`        | OpenAI-compatible | `anthropic/claude-3.5-sonnet` |
+| Requesty   | `https://router.requesty.ai/v1`       | OpenAI-compatible | `openai/gpt-4o-mini`        |
+| Anthropic  | `https://api.anthropic.com/v1`        | Messages API     | `claude-3-5-sonnet-20241022` |
+| Ollama     | `http://localhost:11434`              | Ollama (local)   | `llama3:latest`             |
+
+OpenRouter and Requesty both use OpenAI-compatible `provider/model` slugs and a
+`Bearer` API key. For Requesty, create a key at
+[app.requesty.ai/api-keys](https://app.requesty.ai/api-keys) and browse available
+models at [app.requesty.ai/router/list](https://app.requesty.ai/router/list). See the
+[Requesty docs](https://docs.requesty.ai) for details.
+
+API keys are stored locally in your Maestro settings file (see [Storage
+Location](#storage-location)).
+
 ## Checking for Updates
 
 Maestro checks for updates automatically on startup (configurable in Settings → General → **Check for updates on startup**).

--- a/src/renderer/components/Settings/SettingsModal.tsx
+++ b/src/renderer/components/Settings/SettingsModal.tsx
@@ -385,6 +385,39 @@ export const SettingsModal = memo(function SettingsModal(props: SettingsModalPro
 					status: 'success',
 					message: 'Successfully connected to OpenRouter!',
 				});
+			} else if (llmProvider === 'requesty') {
+				if (!apiKey) {
+					throw new Error('API key is required for Requesty');
+				}
+
+				response = await fetch('https://router.requesty.ai/v1/chat/completions', {
+					method: 'POST',
+					headers: {
+						Authorization: `Bearer ${apiKey}`,
+						'Content-Type': 'application/json',
+						'HTTP-Referer': 'https://maestro.local',
+					},
+					body: JSON.stringify({
+						model: modelSlug || 'openai/gpt-4o-mini',
+						messages: [{ role: 'user', content: testPrompt }],
+						max_tokens: 50,
+					}),
+				});
+
+				if (!response.ok) {
+					const error = await response.json();
+					throw new Error(error.error?.message || `Requesty API error: ${response.status}`);
+				}
+
+				const data = await response.json();
+				if (!data.choices?.[0]?.message?.content) {
+					throw new Error('Invalid response from Requesty');
+				}
+
+				setTestResult({
+					status: 'success',
+					message: 'Successfully connected to Requesty!',
+				});
 			} else if (llmProvider === 'anthropic') {
 				if (!apiKey) {
 					throw new Error('API key is required for Anthropic');
@@ -559,6 +592,7 @@ export const SettingsModal = memo(function SettingsModal(props: SettingsModalPro
 										style={{ borderColor: theme.colors.border }}
 									>
 										<option value="openrouter">OpenRouter</option>
+										<option value="requesty">Requesty</option>
 										<option value="anthropic">Anthropic</option>
 										<option value="ollama">Ollama (Local)</option>
 									</select>

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -84,7 +84,7 @@ export type SettingsTab =
 	| 'prompts';
 // Note: ScratchPadMode was removed as part of the Scratchpad → Auto Run migration
 export type FocusArea = 'sidebar' | 'main' | 'right';
-export type LLMProvider = 'openrouter' | 'anthropic' | 'ollama';
+export type LLMProvider = 'openrouter' | 'requesty' | 'anthropic' | 'ollama';
 
 // Inline wizard types for per-session/per-tab wizard state
 export type WizardMode = 'new' | 'iterate' | null;

--- a/src/shared/settingsMetadata.ts
+++ b/src/shared/settingsMetadata.ts
@@ -515,7 +515,8 @@ export const SETTINGS_METADATA: Record<string, SettingMetadata> = {
 
 	// --- LLM / Provider ---
 	llmProvider: {
-		description: 'LLM provider for built-in AI features. E.g., openrouter, anthropic, openai.',
+		description:
+			'LLM provider for built-in AI features. E.g., openrouter, requesty, anthropic, openai.',
 		type: 'string',
 		default: 'openrouter',
 		category: 'advanced',

--- a/src/shared/settingsMetadata.ts
+++ b/src/shared/settingsMetadata.ts
@@ -516,7 +516,7 @@ export const SETTINGS_METADATA: Record<string, SettingMetadata> = {
 	// --- LLM / Provider ---
 	llmProvider: {
 		description:
-			'LLM provider for built-in AI features. E.g., openrouter, requesty, anthropic, openai.',
+			'LLM provider for built-in AI features. E.g., openrouter, requesty, anthropic, ollama.',
 		type: 'string',
 		default: 'openrouter',
 		category: 'advanced',


### PR DESCRIPTION
## Add Requesty provider

This adds [Requesty](https://requesty.ai) as a built-in LLM provider, alongside the existing OpenRouter / Anthropic / Ollama options.

Requesty is an OpenAI-compatible model gateway that uses the same `provider/model` identifier format as OpenRouter, so it is implemented by mirroring the existing OpenRouter provider (only the base URL and env/key differ).

### Changes
- `src/renderer/types/index.ts` — extend `LLMProvider` union with `'requesty'`.
- `src/renderer/components/Settings/SettingsModal.tsx` — add the Requesty option and a `requesty` branch in `testLLMConnection()` that POSTs to `https://router.requesty.ai/v1/chat/completions` with the user's Requesty key (default model `openai/gpt-4o-mini`), mirroring the OpenRouter branch.
- `src/shared/settingsMetadata.ts` — include `requesty` in the `llmProvider` description.
- `docs/configuration.md` — document the built-in LLM providers including Requesty (key at https://app.requesty.ai/api-keys, models at https://app.requesty.ai/router/list).

Default provider is left as `openrouter` (this adds Requesty, doesn't replace anything).

### Testing
- `npm run lint` (tsc typecheck across the three tsconfigs) clean; defaults + SettingsModal test suites pass (148/148).
- Live endpoint: `POST https://router.requesty.ai/v1/chat/completions` with `model: openai/gpt-4o-mini` -> HTTP 200, real completion.

### Disclosure
I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust naming/placement or close it if it's not a fit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **Requesty** as an available LLM provider option, including **“Test Connection”** support.
* **Documentation**
  * Expanded the configuration documentation with a **Built-in LLM Provider** section, setup steps via **Settings → LLM**, supported provider details, and notes on **local API key storage**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->