### PR TITLE
fix(stats): stop reporting oversized session files to Sentry (MAESTRO-M9)

### DIFF
--- a/src/main/ipc/handlers/agentSessions.ts
+++ b/src/main/ipc/handlers/agentSessions.ts
@@ -999,8 +999,19 @@ export function registerAgentSessionsHandlers(deps?: AgentSessionsHandlerDepende
 						sendUpdate(cache, false);
 					}
 				} catch (error) {
-					void captureException(error);
-					logger.warn(`Failed to parse Claude session: ${file.sessionKey}`, LOG_CONTEXT, { error });
+					// RangeError: Invalid string length is thrown when a session file is too
+					// large for V8 to read into a single string. This is an expected, recoverable
+					// data condition (the file is simply skipped), not worth reporting to Sentry.
+					if (error instanceof RangeError) {
+						logger.warn(`Claude session file too large to parse: ${file.sessionKey}`, LOG_CONTEXT, {
+							filePath: file.filePath,
+						});
+					} else {
+						void captureException(error);
+						logger.warn(`Failed to parse Claude session: ${file.sessionKey}`, LOG_CONTEXT, {
+							error,
+						});
+					}
 				}
 			}
 
@@ -1024,8 +1035,19 @@ export function registerAgentSessionsHandlers(deps?: AgentSessionsHandlerDepende
 						sendUpdate(cache, false);
 					}
 				} catch (error) {
-					void captureException(error);
-					logger.warn(`Failed to parse Codex session: ${file.sessionKey}`, LOG_CONTEXT, { error });
+					// RangeError: Invalid string length is thrown when a session file is too
+					// large for V8 to read into a single string. This is an expected, recoverable
+					// data condition (the file is simply skipped), not worth reporting to Sentry.
+					if (error instanceof RangeError) {
+						logger.warn(`Codex session file too large to parse: ${file.sessionKey}`, LOG_CONTEXT, {
+							filePath: file.filePath,
+						});
+					} else {
+						void captureException(error);
+						logger.warn(`Failed to parse Codex session: ${file.sessionKey}`, LOG_CONTEXT, {
+							error,
+						});
+					}
 				}
 			}
 


### PR DESCRIPTION
## Summary

Resolves Sentry issue **[MAESTRO-M9](https://smash-labs.sentry.io/issues/MAESTRO-M9)** - `RangeError: Invalid string length` in the `agentSessions` global-stats handler (events on both `channel:rc` and `channel:stable`).

The two incremental parse loops in `getGlobalStats` (`agentSessions.ts`) called `captureException(error)` on **every** parse failure. That includes the expected `RangeError: Invalid string length`, which V8 throws when `fs.readFile(file, 'utf-8')` hits a session file too large to read into a single string (> ~512 MB). The result was Sentry noise for a condition we already recover from gracefully: the oversized file is skipped and global stats continue for every other session.

## Fix

Treat `RangeError` as the expected "file too large to parse" condition - log a warning and skip - while still reporting genuinely unexpected errors to Sentry. This mirrors the exact pattern already used in the per-agent storage layer:

- `src/main/storage/claude-session-storage.ts` (`parseSessionFile`)
- `src/main/storage/codex-session-storage.ts` (`readSessionFile`)

Both global-stats loops (Claude + Codex) now follow the same convention. No behavior change for any readable file; this only silences telemetry on an expected, recoverable data condition (consistent with the project's error-handling guidance in `CLAUDE.md` and the earlier rc telemetry-noise cleanup in #1094).

## Validation

- `tsc -p tsconfig.main.json --noEmit` - 0 errors
- `eslint` + `prettier --check` on the changed file - clean
- `vitest run src/__tests__/main/ipc/handlers/agentSessions.test.ts` - 20/20 pass

## Notes

- Targets `rc` (the affected code lives on both `rc` and `main`; this PR fixes the branch of focus).
- Other currently-unresolved Sentry issues were triaged and intentionally left out of this PR because they lack an obvious code-level fix: renderer/WebContents crashes (MAESTRO-5A/4Y, real crash symptoms), `partition_alloc::OnNoMemoryInternal` OOM crashes (MAESTRO-9J/4T/5W), `Window unresponsive` (MAESTRO-62), the Linux glibc 2.38 packaging error for `better-sqlite3` (MAESTRO-RS), a different project's cron (CAM-WORKERS-9), and `maestro-p --status` (MAESTRO-Q2, previously deliberately deferred).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for oversized session files—large files now log a warning without triggering error reports, preventing unnecessary alerts while maintaining proper logging for other error conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->