### PR TITLE
fix(telemetry): handle obvious main-branch field crashes

### DIFF
--- a/src/__tests__/main/agents/codex-usage-sampler.test.ts
+++ b/src/__tests__/main/agents/codex-usage-sampler.test.ts
@@ -148,6 +148,23 @@ describe('codex-usage-sampler', () => {
 		expect(captureMessageMock).not.toHaveBeenCalled();
 	});
 
+	it('does not report network request failures to Sentry (MAESTRO-RR)', async () => {
+		await fs.writeFile(
+			path.join(TEST_ROOT, 'auth.json'),
+			JSON.stringify({ tokens: { access_token: 'redacted-token' } })
+		);
+		// A thrown fetch (offline, DNS/TLS failure, unreachable endpoint, or our
+		// own abort timeout) is the dominant MAESTRO-RR cause - an expected,
+		// recoverable user-environment condition, not a Sentry-worthy crash.
+		vi.mocked(globalThis.fetch).mockRejectedValue(new TypeError('fetch failed'));
+
+		const snapshot = await sampleCodexUsage({ codexHome: TEST_ROOT });
+
+		expect(snapshot.authState).toBe('error');
+		expect(snapshot.error).toContain('Failed to request Codex quota metadata');
+		expect(captureMessageMock).not.toHaveBeenCalled();
+	});
+
 	it('reports unexpected HTTP errors to Sentry (MAESTRO-RR)', async () => {
 		await fs.writeFile(
 			path.join(TEST_ROOT, 'auth.json'),

--- a/src/__tests__/main/ipc/handlers/stats.test.ts
+++ b/src/__tests__/main/ipc/handlers/stats.test.ts
@@ -102,6 +102,8 @@ describe('stats IPC handlers', () => {
 			recordSessionCreated: vi.fn().mockReturnValue('session-lifecycle-id'),
 			recordSessionClosed: vi.fn().mockReturnValue(true),
 			getSessionLifecycleEvents: vi.fn().mockReturnValue([]),
+			incrementShortcutUsage: vi.fn().mockReturnValue('2026-06-21'),
+			isReady: vi.fn().mockReturnValue(true),
 		};
 
 		vi.mocked(statsDbModule.getStatsDB).mockReturnValue(mockStatsDB as unknown as StatsDB);
@@ -321,6 +323,34 @@ describe('stats IPC handlers', () => {
 				expect(mockStatsDB.insertAutoRunTask).toHaveBeenCalledWith(task);
 				expect(mockMainWindow.webContents.send).toHaveBeenCalledWith('stats:updated');
 				expect(mockMainWindow.webContents.send).toHaveBeenCalledTimes(1);
+			});
+		});
+
+		describe('stats:record-shortcut-usage', () => {
+			it('records usage and broadcasts when the stats DB is ready', async () => {
+				const handler = handlers.get('stats:record-shortcut-usage');
+				const firedAt = Date.UTC(2026, 5, 21, 12, 0, 0);
+
+				const result = await handler!({} as any, firedAt);
+
+				expect(result).toBe('2026-06-21');
+				expect(mockStatsDB.incrementShortcutUsage).toHaveBeenCalledWith(firedAt);
+				expect(mockMainWindow.webContents.send).toHaveBeenCalledWith('stats:updated');
+			});
+
+			// MAESTRO-SP: a shortcut can fire before the stats DB finishes
+			// initializing. The handler must skip silently rather than throw
+			// "Database not initialized" (which would otherwise propagate across
+			// the IPC bridge into the renderer and Sentry).
+			it('skips silently without throwing when the stats DB is not yet ready', async () => {
+				vi.mocked(mockStatsDB.isReady!).mockReturnValue(false);
+				const handler = handlers.get('stats:record-shortcut-usage');
+
+				const result = await handler!({} as any, Date.now());
+
+				expect(result).toBeNull();
+				expect(mockStatsDB.incrementShortcutUsage).not.toHaveBeenCalled();
+				expect(mockMainWindow.webContents.send).not.toHaveBeenCalled();
 			});
 		});
 	});

--- a/src/__tests__/renderer/hooks/utils/useDebouncedPersistence.test.ts
+++ b/src/__tests__/renderer/hooks/utils/useDebouncedPersistence.test.ts
@@ -14,6 +14,15 @@ import type {
 	BrowserTab,
 } from '../../../../renderer/types';
 
+// The renderer sentry module only exports these two helpers, so a full mock is
+// safe and avoids pulling @sentry/electron/renderer into jsdom. Lets us assert
+// what does / doesn't reach Sentry on a failed flush (MAESTRO-QF).
+const { captureExceptionMock } = vi.hoisted(() => ({ captureExceptionMock: vi.fn() }));
+vi.mock('../../../../renderer/utils/sentry', () => ({
+	captureException: captureExceptionMock,
+	captureMessage: vi.fn(),
+}));
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -2252,6 +2261,44 @@ describe('useDebouncedPersistence', () => {
 			});
 
 			expect(window.maestro.sessions.setMany).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('failed-flush Sentry reporting (MAESTRO-QF)', () => {
+		it('does not report a recoverable disk error to Sentry', async () => {
+			// `setAll` returning false is the main process deliberately signalling a
+			// recoverable disk error (e.g. transient ENOSPC). persistInternal throws
+			// only to preserve `isPending` for retry — it's an expected user-env
+			// condition, not a Maestro bug, so it must stay out of Sentry.
+			vi.mocked(window.maestro.sessions.setAll).mockResolvedValueOnce(false);
+			const session = makeSession({ id: 'session-qf' });
+			const initialLoadRef = makeInitialLoadRef(true);
+			const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+
+			await act(async () => {
+				result.current.flushNow([session]);
+				await vi.runAllTimersAsync();
+			});
+
+			expect(window.maestro.sessions.setAll).toHaveBeenCalled();
+			expect(captureExceptionMock).not.toHaveBeenCalled();
+		});
+
+		it('reports a genuine flush failure to Sentry', async () => {
+			vi.mocked(window.maestro.sessions.setAll).mockRejectedValueOnce(new Error('boom'));
+			const session = makeSession({ id: 'session-qf-2' });
+			const initialLoadRef = makeInitialLoadRef(true);
+			const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+
+			await act(async () => {
+				result.current.flushNow([session]);
+				await vi.runAllTimersAsync();
+			});
+
+			expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+			const reported = captureExceptionMock.mock.calls[0][0] as Error;
+			expect(reported).toBeInstanceOf(Error);
+			expect(reported.message).toBe('boom');
 		});
 	});
 });

--- a/src/main/agents/codex-usage-sampler.ts
+++ b/src/main/agents/codex-usage-sampler.ts
@@ -96,9 +96,13 @@ export async function sampleCodexUsage(opts: SampleCodexUsageOptions): Promise<C
 			},
 			signal: controller.signal,
 		});
-	} catch (err) {
+	} catch {
 		clearTimeout(timeout);
-		void reportCodexUsageFailure(codexHomeKey, `request: ${formatError(err)}`);
+		// A thrown fetch means the request never completed: the user is offline,
+		// DNS/TLS failed, the endpoint is unreachable, or our own abort timeout
+		// fired. All are expected, recoverable, user-environment conditions - not
+		// Maestro bugs - so don't report them to Sentry. The UI still reflects the
+		// failure via the returned `error` field. (MAESTRO-RR)
 		return {
 			sampledAt,
 			codexHomeKey,

--- a/src/main/ipc/handlers/stats.ts
+++ b/src/main/ipc/handlers/stats.ts
@@ -345,6 +345,14 @@ export function registerStatsHandlers(deps: StatsHandlerDependencies): void {
 			}
 
 			const db = getStatsDB();
+			// Shortcut usage is fire-and-forget analytics. A shortcut can fire
+			// during early startup before the stats DB has finished initializing;
+			// skip silently in that window rather than throwing "Database not
+			// initialized" - an unactionable error that otherwise propagates
+			// across the IPC bridge and into Sentry. (MAESTRO-SP)
+			if (!db.isReady()) {
+				return null;
+			}
 			const date = db.incrementShortcutUsage(firedAt);
 			broadcastStatsUpdate(getMainWindow);
 			return date;

--- a/src/renderer/hooks/utils/useDebouncedPersistence.ts
+++ b/src/renderer/hooks/utils/useDebouncedPersistence.ts
@@ -381,9 +381,18 @@ export function useDebouncedPersistence(
 				undefined,
 				err
 			);
-			captureException(err instanceof Error ? err : new Error(String(err)), {
-				extra: { operation: 'useDebouncedPersistence.persistSessions' },
-			});
+			// persistInternal throws a "recoverable disk error" only when the main
+			// process deliberately returned false from setAll/setMany (e.g. a
+			// transient ENOSPC) - it throws purely to preserve `isPending` for the
+			// retry below. That's an expected, user-environment condition, not a
+			// Maestro bug, so keep it out of Sentry. Genuine flush failures (real
+			// exceptions) still report. (MAESTRO-QF)
+			const message = err instanceof Error ? err.message : String(err);
+			if (!message.includes('recoverable disk error')) {
+				captureException(err instanceof Error ? err : new Error(String(err)), {
+					extra: { operation: 'useDebouncedPersistence.persistSessions' },
+				});
+			}
 			// Deliberately do NOT setIsPending(false) — the failed write is
 			// still pending. Next mutation OR beforeunload will retry.
 		} finally {


### PR DESCRIPTION
## Summary

Triages the `channel:stable` (= `main`) Sentry issues for Maestro and fixes the four that affect the **current 0.17.x release** and have an obvious bug + path to resolution. All four are the same family the prior triages addressed: **expected/recoverable conditions being reported to Sentry as crashes**.

Validated each against current `main` code (not `rc`) before fixing. Issues that are build/packaging (`MAESTRO-RS` glibc), native Chromium crashes (`SG`/`RB`/`SZ`/`Y`), already-archived (`1G`), genuine spawn failures worth surfacing (`R0`/`NM`), or already-fixed-on-main but still trickling from old 0.15.x builds (`4Y`, `BH`) were deliberately left out of scope.

## Fixes

| Issue | Symptom (current release) | Fix |
| --- | --- | --- |
| [MAESTRO-RR](https://smash-labs.sentry.io/issues/MAESTRO-RR) | "codex usage sample failed" — ~375 events, all `reason: request: fetch failed` | The Codex usage sampler is best-effort; a thrown `fetch` (offline / DNS / TLS / abort-timeout) is expected. Stop reporting it to Sentry. The 401/403 carve-out and unexpected-HTTP reporting are unchanged. |
| [MAESTRO-M9](https://smash-labs.sentry.io/issues/MAESTRO-M9) | `RangeError: Invalid string length` in `agentSessions` global-stats refresh | V8 throws this when a session log is too large to read into one string. Treat it as an expected, recoverable data condition (skip the file + warn) rather than a Sentry crash. **Matches the rc fix in #1114** (and the storage-layer pattern) so the two converge cleanly on the next `rc` → `main` merge. |
| [MAESTRO-SP](https://smash-labs.sentry.io/issues/MAESTRO-SP) | `stats:record-shortcut-usage … Database not initialized` | A shortcut can fire before the stats DB finishes init. Skip the fire-and-forget analytics write when the DB isn't ready (new `StatsDB.isReady()`). |
| [MAESTRO-QF](https://smash-labs.sentry.io/issues/MAESTRO-QF) | `sessions:setMany returned false (recoverable disk error)` | The debounced persistence flush throws this deliberately (to preserve `isPending` for retry) when the main process returns a recoverable disk error. Keep that expected user-environment condition out of Sentry; genuine flush failures still report. |

## Tests

Adds regression tests for RR (network failure not reported), SP (skips silently when DB not ready; records + broadcasts when ready), and QF (recoverable disk error not reported; genuine failure still reported).

- `npm run lint` (tsc) — no new errors in changed files
- `npm run lint:eslint` — clean
- `prettier --check` — clean
- Affected suites: **194 passed** (codex-usage-sampler, stats handlers, stats-db, agentSessions, useDebouncedPersistence)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when usage data or session persistence encounters network, disk, or startup timing issues.
  * Prevented unnecessary error reporting for expected recoverable failures.
  * Shortcut usage is now safely skipped until stats are ready, avoiding early-startup errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->