### PR TITLE
fix(git): show branch name for SSH/container agents in header

### DIFF
--- a/src/__tests__/renderer/components/MainPanel/MainPanelHeader.test.tsx
+++ b/src/__tests__/renderer/components/MainPanel/MainPanelHeader.test.tsx
@@ -157,6 +157,48 @@ describe('MainPanelHeader', () => {
 		expect(screen.getByText('prod-server')).toBeInTheDocument();
 	});
 
+	it('shows the branch name alongside the SSH pill for remote/container git agents', () => {
+		// Regression for #1124: the SSH host pill replaced the branch badge, so
+		// agents running in a container over SSH lost the branch name that local
+		// agents show. Both the remote name and the branch must be visible.
+		render(
+			<MainPanelHeader
+				{...defaultProps}
+				activeSession={makeSession({
+					isGitRepo: true,
+					sessionSshRemoteConfig: { enabled: true, remoteId: 'remote-1' },
+				} as any)}
+				sshRemoteName="harness-sandbox"
+				gitInfo={{
+					branch: 'feature/login',
+					remote: '',
+					ahead: 0,
+					behind: 0,
+					uncommittedChanges: 0,
+				}}
+			/>
+		);
+		expect(screen.getByText('harness-sandbox')).toBeInTheDocument();
+		expect(screen.getByText('feature/login')).toBeInTheDocument();
+	});
+
+	it('does not render a branch badge for a non-git SSH agent', () => {
+		render(
+			<MainPanelHeader
+				{...defaultProps}
+				activeSession={makeSession({
+					isGitRepo: false,
+					sessionSshRemoteConfig: { enabled: true, remoteId: 'remote-1' },
+				} as any)}
+				sshRemoteName="prod-server"
+				gitInfo={null}
+			/>
+		);
+		expect(screen.getByText('prod-server')).toBeInTheDocument();
+		// No GIT fallback badge when the remote dir isn't a repo.
+		expect(screen.queryByText('GIT')).not.toBeInTheDocument();
+	});
+
 	it('renders AUTO mode indicator when batch is running', () => {
 		render(
 			<MainPanelHeader

--- a/src/renderer/components/MainPanel/MainPanelHeader.tsx
+++ b/src/renderer/components/MainPanel/MainPanelHeader.tsx
@@ -141,7 +141,7 @@ export const MainPanelHeader = React.memo(function MainPanelHeader({
 						/>
 					)}
 					<div
-						className="relative shrink-0"
+						className="relative shrink-0 flex items-center gap-2"
 						onMouseEnter={
 							activeSession.isGitRepo ? gitTooltip.triggerHandlers.onMouseEnter : undefined
 						}
@@ -149,7 +149,10 @@ export const MainPanelHeader = React.memo(function MainPanelHeader({
 						onFocus={activeSession.isGitRepo ? gitTooltip.triggerHandlers.onMouseEnter : undefined}
 						onBlur={gitTooltip.triggerHandlers.onMouseLeave}
 					>
-						{/* SSH Host Pill - show SSH remote name when running remotely (replaces GIT/LOCAL badge) */}
+						{/* SSH Host Pill - show SSH remote name when running remotely (replaces the
+						    GIT/LOCAL badge). For git repos the branch name is rendered in a separate
+						    badge just after this pill (see below) so SSH/container agents still surface
+						    the branch the same way local agents do. */}
 						{activeSession.sessionSshRemoteConfig?.enabled && sshRemoteName ? (
 							<button
 								className={`flex items-center gap-1 text-xs px-2 py-0.5 rounded-full border border-purple-500/30 text-purple-500 bg-purple-500/10 max-w-[120px] outline-none ${
@@ -196,6 +199,29 @@ export const MainPanelHeader = React.memo(function MainPanelHeader({
 								)}
 							</button>
 						)}
+						{/* Branch badge for SSH/container git agents. The SSH host pill above
+						    replaces the GIT/branch badge, so without this remote agents lose the
+						    branch name that local agents show. Render it alongside the host pill,
+						    styled like the local git badge, reusing the same git-log click. */}
+						{activeSession.sessionSshRemoteConfig?.enabled &&
+							sshRemoteName &&
+							activeSession.isGitRepo && (
+								<button
+									className="flex items-center gap-1.5 text-xs px-2 py-0.5 rounded-full border border-orange-500/30 text-orange-500 bg-orange-500/10 hover:bg-orange-500/20 cursor-pointer outline-none"
+									title={gitInfo?.branch || undefined}
+									onClick={(e) => {
+										e.stopPropagation();
+										refreshGitStatus(); // Refresh git info immediately on click
+										setGitLogOpen?.(true);
+									}}
+								>
+									<GitBranch className="w-3 h-3 shrink-0" />
+									{/* Hide branch name text at narrow widths via CSS container query */}
+									<span className="header-git-branch-text truncate">
+										{gitInfo?.branch || 'GIT'}
+									</span>
+								</button>
+							)}
 						{activeSession.isGitRepo && gitTooltip.isOpen && gitInfo && (
 							<>
 								{/* Invisible bridge to prevent hover gap */}


### PR DESCRIPTION
closes #1124

## Problem

When an agent runs inside a container over SSH (the reporter's "vssh" setup), the **branch name was missing** next to the agent name in the main panel header. Only the SSH remote / sandbox name (e.g. `HARNESS-SANDBOX`) was shown. For local agents the branch name appears as expected.

## Root cause

In `MainPanelHeader.tsx`, the header pill is an either/or:

- When `sessionSshRemoteConfig.enabled && sshRemoteName` is set, it renders an **SSH host pill** (`Server` icon + uppercase remote name) that **replaces** the GIT/branch badge entirely.
- Otherwise it renders the git badge (`GitBranch` icon + `gitInfo.branch`).

So any SSH-backed git repo lost the inline branch name. The branch was only available in the host pill's hover tooltip (`SSH Remote: <name> (<branch>)`), confirming the data is fetched fine over SSH - it just wasn't rendered.

## Fix

Render a dedicated branch badge **next to** the SSH host pill for SSH-backed git repos. It's styled like the existing local git badge (orange `GitBranch` + branch name, `header-git-branch-text` so it still collapses at narrow widths) and reuses the same click-to-open-git-log behavior. Non-git SSH agents are unaffected (no badge). Local agents are unchanged.

Result for a container/SSH git agent: `[🖧 HARNESS-SANDBOX] [⎇ main]` instead of just `[🖧 HARNESS-SANDBOX]`.

## Tests

Added two cases to `MainPanelHeader.test.tsx`:
- branch name renders alongside the SSH pill for a remote git agent
- no branch badge for a non-git SSH agent

All 21 header tests pass. Type-check is clean for the changed files (only the repo's pre-existing `@codemirror/*` module-resolution errors remain, unrelated to this change).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the main panel header to better show SSH remote information and branch status together.
  * Added a branch badge for SSH-backed git sessions that opens the git log and refreshes status when clicked.

* **Bug Fixes**
  * Fixed an issue where non-git SSH sessions could incorrectly show a git branch badge.
  * Updated hover and focus behavior so tooltips work more reliably in the SSH/remote area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->