### PR TITLE
fix(ssh): actionable error when an SSH agent targets a Windows remote (#995)

### DIFF
--- a/src/__tests__/main/parsers/error-patterns.test.ts
+++ b/src/__tests__/main/parsers/error-patterns.test.ts
@@ -783,6 +783,59 @@ describe('error-patterns', () => {
 			});
 		});
 
+		describe('Windows remote host (issue #995)', () => {
+			// Maestro builds the remote command for a POSIX shell
+			// (/bin/bash --norc --noprofile). On a Windows SSH remote the default
+			// shell (cmd.exe or PowerShell) cannot run it and the agent dies with a
+			// bare exit 1. These cases prove the cryptic crash now maps to a clear,
+			// actionable message. Full Windows-remote support is deferred (needs a
+			// live Windows SSH host to verify the generated command).
+			it('should map cmd.exe "is not recognized as an internal or external command" to the actionable message', () => {
+				const result = matchSshErrorPattern(
+					"'/bin/bash' is not recognized as an internal or external command, operable program or batch file."
+				);
+				expect(result).not.toBeNull();
+				expect(result?.type).toBe('agent_crashed');
+				expect(result?.recoverable).toBe(false);
+				expect(result?.message).toContain('Windows remote');
+				expect(result?.message).toContain('not yet supported');
+				expect(result?.message).toContain('#995');
+			});
+
+			it('should map PowerShell "is not recognized as the name of a cmdlet" to the actionable message', () => {
+				const result = matchSshErrorPattern(
+					"/bin/bash : The term '/bin/bash' is not recognized as the name of a cmdlet, function, script file, or operable program."
+				);
+				expect(result).not.toBeNull();
+				expect(result?.type).toBe('agent_crashed');
+				expect(result?.message).toContain('Windows remote');
+				expect(result?.message).toContain('#995');
+			});
+
+			it('should map Windows "The system cannot find the path specified" to the actionable message', () => {
+				const result = matchSshErrorPattern('The system cannot find the path specified.');
+				expect(result).not.toBeNull();
+				expect(result?.type).toBe('agent_crashed');
+				expect(result?.message).toContain('Windows remote');
+				expect(result?.message).toContain('#995');
+			});
+
+			it('should NOT apply the Windows message to a POSIX remote failure (POSIX remotes unaffected)', () => {
+				// A real POSIX-remote "command not found" still maps to its own
+				// agent-specific message, never the Windows-remote message.
+				const result = matchSshErrorPattern('bash: claude: command not found');
+				expect(result).not.toBeNull();
+				expect(result?.type).toBe('agent_crashed');
+				expect(result?.message).toContain('Claude command not found');
+				expect(result?.message).not.toContain('Windows remote');
+			});
+
+			it('should return null for normal POSIX output mentioning bash (no false positive)', () => {
+				const result = matchSshErrorPattern('Running /bin/bash to set up the environment');
+				expect(result).toBeNull();
+			});
+		});
+
 		describe('non-matching lines', () => {
 			it('should return null for normal SSH output', () => {
 				const result = matchSshErrorPattern('Connected to example.com');

--- a/src/main/parsers/error-patterns.ts
+++ b/src/main/parsers/error-patterns.ts
@@ -690,6 +690,15 @@ const FACTORY_DROID_ERROR_PATTERNS: AgentErrorPatterns = {
 // ============================================================================
 
 /**
+ * Actionable message shown when an SSH remote host appears to be Windows.
+ * Maestro currently builds the remote command for a POSIX shell only
+ * (see ssh-command-builder.ts: /bin/bash --norc --noprofile + single-quote
+ * escaping), so Windows remotes are not yet supported. Tracked by issue #995.
+ */
+const WINDOWS_REMOTE_UNSUPPORTED_MESSAGE =
+	'SSH execution to Windows remote hosts is not yet supported (Maestro builds the remote command for a POSIX shell). See issue #995.';
+
+/**
  * Error patterns for SSH remote execution errors.
  * These are checked separately from agent-specific patterns because they can
  * occur when ANY agent runs via SSH remote execution.
@@ -793,6 +802,30 @@ export const SSH_ERROR_PATTERNS: AgentErrorPatterns = {
 	],
 
 	agent_crashed: [
+		// Windows remote host detection (issue #995).
+		// Maestro builds the remote command for a POSIX shell. When the SSH
+		// remote is Windows, its default shell (cmd.exe or PowerShell) cannot
+		// run /bin/bash and the process dies with a bare exit 1. The phrases
+		// below are emitted ONLY by Windows shells, never by a POSIX shell, so
+		// POSIX remotes are never affected by these patterns.
+		{
+			// cmd.exe: "'/bin/bash' is not recognized as an internal or external command"
+			pattern: /is not recognized as an internal or external command/i,
+			message: WINDOWS_REMOTE_UNSUPPORTED_MESSAGE,
+			recoverable: false,
+		},
+		{
+			// PowerShell: "The term '/bin/bash' is not recognized as the name of a cmdlet"
+			pattern: /is not recognized as the name of a cmdlet/i,
+			message: WINDOWS_REMOTE_UNSUPPORTED_MESSAGE,
+			recoverable: false,
+		},
+		{
+			// cmd.exe / Windows API: "The system cannot find the path specified"
+			pattern: /the system cannot find the path specified/i,
+			message: WINDOWS_REMOTE_UNSUPPORTED_MESSAGE,
+			recoverable: false,
+		},
 		{
 			// Agent command not found (shell reports command not found)
 			// bash/sh format: "bash: claude: command not found"


### PR DESCRIPTION
## Summary

Addresses #995. Root cause (high confidence): Maestro's SSH command builders are POSIX-only (they hardcode `/bin/bash --norc --noprofile` and POSIX quoting), so any agent (including Copilot CLI) crashes with a cryptic `exit 1` when the SSH remote host is Windows.

This PR converts that cryptic crash into a clear, actionable failure.

## Changes

- Detect Windows-shell failure signatures (cmd.exe / PowerShell "is not recognized...", "the system cannot find the path specified") in the SSH error-pattern layer and surface: "SSH execution to Windows remote hosts is not yet supported ... See issue #995."
- POSIX (Linux/macOS) remotes are unaffected; the signatures are Windows-exclusive (a POSIX `command not found` still maps to its own message).
- 5 new unit tests.

## Scope / deferred

Full Windows-remote command generation (cmd.exe vs PowerShell selection, quoting of args/cwd/env, remote PATH and `copilot.exe` resolution) is intentionally deferred: it cannot be verified without a live Windows SSH host, and shipping a speculative command into a security-sensitive execution path would be a guess. This PR is the verifiable guardrail; the full fix can follow once a Windows SSH test target is available.

## Verification

- `npm run lint` (tsc x3): clean
- `vitest run error-patterns`: 130 tests pass (incl. 5 new)
- `eslint` + `prettier`: clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSH error handling to give a clearer message when connecting to a Windows remote host that doesn’t support the expected shell environment.
  * These failures are now marked as non-recoverable and explain that the remote setup is not yet supported.
* **Tests**
  * Added regression coverage for Windows-specific SSH failures and checks to avoid false positives on normal POSIX remote errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->