### PR TITLE
ci: add stale issue/PR automation (#574)

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,14 +3,25 @@ name: Mark stale issues and PRs
 # Implements the policy requested in issue #574:
 #   - Mark issues/PRs stale after 60 days of inactivity
 #   - Auto-close 14 days after being marked stale (≈74 days total)
-#   - Exempt "pinned" and "security" (and a few maintainer-controlled labels)
-# Runs daily; also exposes workflow_dispatch so maintainers can trigger a
-# dry-run / manual pass and verify behaviour before relying on the schedule.
+#   - Exempt "security" plus the repo's active triage labels.
+#     ("pinned" is included for forward compatibility; it is a no-op until a
+#     maintainer creates/applies a "pinned" label, and GitHub's pinned-issue UI
+#     state is intentionally NOT covered by exempt-*-labels.)
+#
+# Runs daily. Manual runs (workflow_dispatch) default to a DRY RUN: actions/stale
+# is invoked with debug-only, so it logs what it *would* mark/close without
+# touching anything - maintainers can validate the policy safely, then re-dispatch
+# with dry_run=false (or wait for the schedule) to apply it for real.
 
 on:
   schedule:
     - cron: '0 0 * * *'
   workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run: log what would happen without labeling or closing anything'
+        type: boolean
+        default: true
 
 permissions:
   issues: write
@@ -25,8 +36,25 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
+      # actions/stale only *applies* the stale label; it does not create it. Make
+      # sure it exists (idempotent: --force creates or updates) so the policy
+      # actually takes effect on a repo that has no "stale" label yet.
+      - name: Ensure the "stale" label exists
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >
+          gh label create stale
+          --repo "$GITHUB_REPOSITORY"
+          --color ededed
+          --description "No recent activity; will be auto-closed if it stays inactive"
+          --force
+
       - uses: actions/stale@v9
         with:
+          # Manual dispatch defaults to a non-destructive dry run; the schedule
+          # always runs live.
+          debug-only: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
+
           # --- Issues ---
           days-before-issue-stale: 60
           days-before-issue-close: 14

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,65 @@
+name: Mark stale issues and PRs
+
+# Implements the policy requested in issue #574:
+#   - Mark issues/PRs stale after 60 days of inactivity
+#   - Auto-close 14 days after being marked stale (≈74 days total)
+#   - Exempt "pinned" and "security" (and a few maintainer-controlled labels)
+# Runs daily; also exposes workflow_dispatch so maintainers can trigger a
+# dry-run / manual pass and verify behaviour before relying on the schedule.
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+# Avoid overlapping runs if a manual dispatch lands during the scheduled one.
+concurrency:
+  group: stale
+  cancel-in-progress: false
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          # --- Issues ---
+          days-before-issue-stale: 60
+          days-before-issue-close: 14
+          stale-issue-label: stale
+          exempt-issue-labels: 'pinned,security,up next,back burner,approved,blocking'
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has had
+            no activity for 60 days. It will be closed in 14 days if no further
+            activity occurs. If it is still relevant, leave a comment or remove
+            the `stale` label to keep it open. Thank you for your contributions.
+          close-issue-message: >
+            This issue was closed automatically because it had no activity for
+            74 days. If it is still relevant, please reopen it or open a new
+            issue with updated details.
+
+          # --- Pull requests ---
+          days-before-pr-stale: 60
+          days-before-pr-close: 14
+          stale-pr-label: stale
+          exempt-pr-labels: 'pinned,security,approved,blocking,dependencies'
+          exempt-draft-pr: true
+          stale-pr-message: >
+            This pull request has been automatically marked as stale because it
+            has had no activity for 60 days. It will be closed in 14 days if no
+            further activity occurs. Push a commit or leave a comment to keep it
+            open. Thank you for your contributions.
+          close-pr-message: >
+            This pull request was closed automatically because it had no
+            activity for 74 days. Feel free to reopen it once you are ready to
+            continue.
+
+          # Remove the stale label as soon as someone interacts again.
+          remove-stale-when-updated: true
+          # Bound the work per run so a backlog can't exhaust the API budget.
+          operations-per-run: 200
+          ascending: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -24,6 +24,7 @@ on:
         default: true
 
 permissions:
+  actions: write
   issues: write
   pull-requests: write
 
@@ -40,6 +41,7 @@ jobs:
       # sure it exists (idempotent: --force creates or updates) so the policy
       # actually takes effect on a repo that has no "stale" label yet.
       - name: Ensure the "stale" label exists
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.dry_run == false }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: >
@@ -59,7 +61,7 @@ jobs:
           days-before-issue-stale: 60
           days-before-issue-close: 14
           stale-issue-label: stale
-          exempt-issue-labels: 'pinned,security,up next,back burner,approved,blocking'
+          exempt-issue-labels: 'pinned,security,up next,back burner,approved,blocking,high-priority'
           stale-issue-message: >
             This issue has been automatically marked as stale because it has had
             no activity for 60 days. It will be closed in 14 days if no further
@@ -74,7 +76,7 @@ jobs:
           days-before-pr-stale: 60
           days-before-pr-close: 14
           stale-pr-label: stale
-          exempt-pr-labels: 'pinned,security,approved,blocking,dependencies'
+          exempt-pr-labels: 'pinned,security,approved,blocking,dependencies,high-priority'
           exempt-draft-pr: true
           stale-pr-message: >
             This pull request has been automatically marked as stale because it


### PR DESCRIPTION
## Summary

Closes #574. Adds a GitHub Actions stale workflow implementing the policy requested in the issue: mark issues/PRs stale after 60 days of inactivity and close 14 days later (about 74 days total), exempting `security` and the repo's active triage labels.

## Changes

- New `.github/workflows/stale.yml` using `actions/stale@v9`.
- Runs daily (`cron`) and via `workflow_dispatch`. Manual dispatch defaults to a dry run (`debug-only`) so maintainers can validate the policy without labeling/closing anything; the scheduled run is live.
- Idempotent pre-step (`gh label create stale --force`) so the `stale` label exists before the action tries to apply it (actions/stale applies but does not create it).
- Explicit minimal `permissions`, concurrency guard, draft-PR exemption, and `operations-per-run` cap.

## Notes

- `pinned` is included in the exempt list for forward compatibility (a no-op until a maintainer creates/applies that label).
- Independently reviewed by `codex exec` (read-only); the two findings (missing `stale` label, misleading dry-run comment) are addressed above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated stale-item handling to keep issues and pull requests organized.
  * Enabled a manual dry-run option for safe testing without making changes.
  * Configured the process to skip draft pull requests, respect exempt labels, and avoid overlapping runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->