### PR TITLE
feat(feedback): persistent, resumable Send Feedback drafts (#756)

### DIFF
--- a/src/__tests__/main/ipc/handlers/feedback.test.ts
+++ b/src/__tests__/main/ipc/handlers/feedback.test.ts
@@ -16,6 +16,7 @@ vi.mock('electron', () => ({
 		isPackaged: false,
 		getAppPath: () => '/mock/app',
 		getVersion: () => '0.15.3',
+		getPath: () => '/mock/userData',
 	},
 }));
 
@@ -24,6 +25,7 @@ vi.mock('fs/promises', () => ({
 		readFile: vi.fn(),
 		writeFile: vi.fn(),
 		unlink: vi.fn(),
+		mkdir: vi.fn(),
 	},
 }));
 
@@ -462,5 +464,116 @@ describe('feedback handlers', () => {
 		});
 		expect(setCachedGhStatus).toHaveBeenCalledWith(true, true);
 		expect(result).toEqual({ authenticated: true });
+	});
+});
+
+describe('feedback drafts handlers', () => {
+	const sampleDraft = {
+		id: 'draft-1',
+		suggestedName: 'App crashes on save',
+		category: 'bug_report' as const,
+		summary: 'App crashes on save',
+		confidence: 80,
+		agentType: 'claude-code',
+		messages: [{ role: 'user' as const, content: 'It crashes when I save', timestamp: 1000 }],
+		attachments: [
+			{ id: 'a1', name: 'shot.png', dataUrl: 'data:image/png;base64,abc123', sizeBytes: 42 },
+		],
+		inputDraft: 'more details to add',
+		includeDebugPackage: false,
+		createdAt: 1000,
+		updatedAt: 1000,
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		registeredHandlers.clear();
+		registerFeedbackHandlers({
+			getProcessManager: () => mockProcessManager as any,
+		});
+	});
+
+	it('registers the drafts list/save/delete handlers', () => {
+		expect(ipcMain.handle).toHaveBeenCalledWith('feedback:drafts:list', expect.any(Function));
+		expect(ipcMain.handle).toHaveBeenCalledWith('feedback:drafts:save', expect.any(Function));
+		expect(ipcMain.handle).toHaveBeenCalledWith('feedback:drafts:delete', expect.any(Function));
+	});
+
+	it('returns an empty list when the drafts file is missing', async () => {
+		vi.mocked(fs.readFile).mockRejectedValue(new Error('ENOENT'));
+
+		const handler = registeredHandlers.get('feedback:drafts:list');
+		const result = await handler!({});
+
+		expect(result).toEqual({ drafts: [] });
+	});
+
+	it('lists drafts sorted by updatedAt descending', async () => {
+		vi.mocked(fs.readFile).mockResolvedValue(
+			JSON.stringify({
+				drafts: [
+					{ ...sampleDraft, id: 'older', updatedAt: 100 },
+					{ ...sampleDraft, id: 'newer', updatedAt: 900 },
+				],
+			}) as any
+		);
+
+		const handler = registeredHandlers.get('feedback:drafts:list');
+		const result = await handler!({});
+
+		expect(result.drafts.map((d: { id: string }) => d.id)).toEqual(['newer', 'older']);
+	});
+
+	it('saves a new draft and writes it with timestamps', async () => {
+		vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify({ drafts: [] }) as any);
+		vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+
+		const handler = registeredHandlers.get('feedback:drafts:save');
+		const result = await handler!({}, sampleDraft);
+
+		expect(result.draft.id).toBe('draft-1');
+		expect(result.draft.updatedAt).toBeGreaterThan(0);
+
+		const writeCall = vi
+			.mocked(fs.writeFile)
+			.mock.calls.find(([p]) => String(p).includes('feedback-drafts.json'));
+		expect(writeCall).toBeDefined();
+		const written = JSON.parse(String(writeCall?.[1]));
+		expect(written.drafts).toHaveLength(1);
+		expect(written.drafts[0].id).toBe('draft-1');
+		expect(written.drafts[0].suggestedName).toBe('App crashes on save');
+		expect(written.drafts[0].attachments).toHaveLength(1);
+	});
+
+	it('upserts an existing draft instead of duplicating it', async () => {
+		vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify({ drafts: [sampleDraft] }) as any);
+		vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+
+		const handler = registeredHandlers.get('feedback:drafts:save');
+		await handler!({}, { ...sampleDraft, summary: 'Updated summary' });
+
+		const writeCall = vi
+			.mocked(fs.writeFile)
+			.mock.calls.find(([p]) => String(p).includes('feedback-drafts.json'));
+		const written = JSON.parse(String(writeCall?.[1]));
+		expect(written.drafts).toHaveLength(1);
+		expect(written.drafts[0].id).toBe('draft-1');
+		expect(written.drafts[0].summary).toBe('Updated summary');
+		expect(written.drafts[0].createdAt).toBe(1000);
+	});
+
+	it('deletes a draft by id and writes the remaining list', async () => {
+		vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify({ drafts: [sampleDraft] }) as any);
+		vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+
+		const handler = registeredHandlers.get('feedback:drafts:delete');
+		const result = await handler!({}, { id: 'draft-1' });
+
+		expect(result).toEqual({});
+		const writeCall = vi
+			.mocked(fs.writeFile)
+			.mock.calls.find(([p]) => String(p).includes('feedback-drafts.json'));
+		const written = JSON.parse(String(writeCall?.[1]));
+		expect(written.drafts).toEqual([]);
 	});
 });

--- a/src/__tests__/main/ipc/handlers/feedback.test.ts
+++ b/src/__tests__/main/ipc/handlers/feedback.test.ts
@@ -667,4 +667,47 @@ describe('feedback drafts handlers', () => {
 			.sort();
 		expect(ids).toEqual(['first', 'second']);
 	});
+
+	it('keeps the newest messages when trimming beyond the cap', async () => {
+		vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify({ drafts: [] }) as any);
+		vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+		vi.mocked(fs.rename).mockResolvedValue(undefined);
+
+		// 205 messages: only the last 200 (MAX_DRAFT_MESSAGES) survive, and they
+		// must be the newest ones, not the oldest. Trimming from the front would
+		// drop a user's most recent exchange on resume.
+		const messages = Array.from({ length: 205 }, (_, i) => ({
+			role: 'user' as const,
+			content: `msg-${i}`,
+			timestamp: 1000 + i,
+		}));
+
+		const handler = registeredHandlers.get('feedback:drafts:save');
+		const result = await handler!({}, { ...sampleDraft, messages });
+
+		expect(result.draft.messages).toHaveLength(200);
+		// Oldest five (msg-0..msg-4) dropped; newest message survives at the end.
+		expect(result.draft.messages[0].content).toBe('msg-5');
+		expect(result.draft.messages[199].content).toBe('msg-204');
+	});
+
+	it('preserves long unsent composer input up to the draft message cap', async () => {
+		vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify({ drafts: [] }) as any);
+		vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+		vi.mocked(fs.rename).mockResolvedValue(undefined);
+
+		const handler = registeredHandlers.get('feedback:drafts:save');
+
+		// 8000 chars exceeds the 5000 field cap but fits the 20000 message cap:
+		// composer text in that range must survive a save/resume round-trip
+		// instead of being silently truncated to the field limit.
+		const longInput = 'a'.repeat(8000);
+		const result = await handler!({}, { ...sampleDraft, inputDraft: longInput });
+		expect(result.draft.inputDraft).toHaveLength(8000);
+
+		// Beyond the message cap it is still clamped to MAX_DRAFT_MESSAGE_LENGTH.
+		const hugeInput = 'a'.repeat(25000);
+		const clamped = await handler!({}, { ...sampleDraft, inputDraft: hugeInput });
+		expect(clamped.draft.inputDraft).toHaveLength(20000);
+	});
 });

--- a/src/__tests__/main/ipc/handlers/feedback.test.ts
+++ b/src/__tests__/main/ipc/handlers/feedback.test.ts
@@ -20,14 +20,18 @@ vi.mock('electron', () => ({
 	},
 }));
 
-vi.mock('fs/promises', () => ({
-	default: {
+vi.mock('fs/promises', () => {
+	const mock = {
 		readFile: vi.fn(),
 		writeFile: vi.fn(),
 		unlink: vi.fn(),
 		mkdir: vi.fn(),
-	},
-}));
+		rename: vi.fn(),
+	};
+	// Provide both default (feedback.ts) and named (atomic-json-store) shapes,
+	// sharing the same vi.fn instances so assertions see every write.
+	return { ...mock, default: mock };
+});
 
 vi.mock('../../../../main/utils/logger', () => ({
 	logger: {
@@ -575,5 +579,92 @@ describe('feedback drafts handlers', () => {
 			.mock.calls.find(([p]) => String(p).includes('feedback-drafts.json'));
 		const written = JSON.parse(String(writeCall?.[1]));
 		expect(written.drafts).toEqual([]);
+	});
+
+	it('persists and clamps the submit-ready response on save', async () => {
+		vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify({ drafts: [] }) as any);
+		vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+		vi.mocked(fs.rename).mockResolvedValue(undefined);
+
+		const handler = registeredHandlers.get('feedback:drafts:save');
+		const result = await handler!(
+			{},
+			{
+				...sampleDraft,
+				lastResponse: {
+					confidence: 95,
+					ready: true,
+					message: 'Looks good',
+					category: 'bug_report',
+					summary: 'Crash on save',
+					structured: {
+						expectedBehavior: 'no crash',
+						actualBehavior: 'crash',
+						reproductionSteps: 'save',
+						additionalContext: '',
+					},
+				},
+			}
+		);
+
+		expect(result.draft.lastResponse?.ready).toBe(true);
+		expect(result.draft.lastResponse?.structured.expectedBehavior).toBe('no crash');
+
+		const writeCall = vi
+			.mocked(fs.writeFile)
+			.mock.calls.find(([p]) => String(p).includes('feedback-drafts.json'));
+		const written = JSON.parse(String(writeCall?.[1]));
+		expect(written.drafts[0].lastResponse.ready).toBe(true);
+		expect(written.drafts[0].lastResponse.structured.actualBehavior).toBe('crash');
+	});
+
+	it('normalizes a malformed lastResponse to null', async () => {
+		vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify({ drafts: [] }) as any);
+		vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+		vi.mocked(fs.rename).mockResolvedValue(undefined);
+
+		const handler = registeredHandlers.get('feedback:drafts:save');
+		const result = await handler!({}, { ...sampleDraft, lastResponse: 'not-an-object' });
+
+		expect(result.draft.lastResponse).toBeNull();
+	});
+
+	it('serializes overlapping saves so neither draft is lost (read-modify-write race)', async () => {
+		// Back the mocked fs with an in-memory file so an unserialized
+		// read-modify-write would clobber: both saves would read the empty base
+		// and the later write would drop the earlier draft.
+		const norm = (p: unknown): string => String(p).replace(/\\/g, '/');
+		const draftsFile = '/mock/userData/feedback-drafts.json';
+		const files = new Map<string, string>([[draftsFile, JSON.stringify({ drafts: [] })]]);
+		const tmps = new Map<string, string>();
+		vi.mocked(fs.mkdir).mockResolvedValue(undefined as any);
+		vi.mocked(fs.readFile).mockImplementation(async (p: any) => {
+			await new Promise((r) => setTimeout(r, 0));
+			const content = files.get(norm(p));
+			if (content === undefined) throw new Error('ENOENT');
+			return content as any;
+		});
+		vi.mocked(fs.writeFile).mockImplementation(async (p: any, data: any) => {
+			await new Promise((r) => setTimeout(r, 0));
+			tmps.set(norm(p), String(data));
+			return undefined as any;
+		});
+		vi.mocked(fs.rename).mockImplementation(async (from: any, to: any) => {
+			const content = tmps.get(norm(from));
+			if (content !== undefined) files.set(norm(to), content);
+			tmps.delete(norm(from));
+			return undefined as any;
+		});
+
+		const save = registeredHandlers.get('feedback:drafts:save');
+		await Promise.all([
+			save!({}, { ...sampleDraft, id: 'first' }),
+			save!({}, { ...sampleDraft, id: 'second' }),
+		]);
+
+		const ids = JSON.parse(String(files.get(draftsFile)))
+			.drafts.map((d: { id: string }) => d.id)
+			.sort();
+		expect(ids).toEqual(['first', 'second']);
 	});
 });

--- a/src/__tests__/main/preload/feedback.test.ts
+++ b/src/__tests__/main/preload/feedback.test.ts
@@ -62,4 +62,44 @@ describe('Feedback Preload API', () => {
 		});
 		expect(result.prompt).toBe('rendered prompt');
 	});
+
+	it('invokes feedback:drafts:list', async () => {
+		mockInvoke.mockResolvedValue({ drafts: [] });
+
+		const result = await api.drafts.list();
+
+		expect(mockInvoke).toHaveBeenCalledWith('feedback:drafts:list');
+		expect(result.drafts).toEqual([]);
+	});
+
+	it('invokes feedback:drafts:save with the draft payload', async () => {
+		const draft = {
+			id: 'draft-1',
+			suggestedName: 'Crash on save',
+			category: 'bug_report' as const,
+			summary: 'Crash on save',
+			confidence: 75,
+			agentType: 'claude-code',
+			messages: [{ role: 'user' as const, content: 'It crashes', timestamp: 1 }],
+			attachments: [],
+			inputDraft: '',
+			includeDebugPackage: false,
+			createdAt: 1,
+			updatedAt: 1,
+		};
+		mockInvoke.mockResolvedValue({ draft });
+
+		const result = await api.drafts.save(draft);
+
+		expect(mockInvoke).toHaveBeenCalledWith('feedback:drafts:save', draft);
+		expect(result.draft).toEqual(draft);
+	});
+
+	it('invokes feedback:drafts:delete with the id wrapped in an object', async () => {
+		mockInvoke.mockResolvedValue({});
+
+		await api.drafts.delete('draft-1');
+
+		expect(mockInvoke).toHaveBeenCalledWith('feedback:drafts:delete', { id: 'draft-1' });
+	});
 });

--- a/src/__tests__/renderer/components/FeedbackChatView.test.tsx
+++ b/src/__tests__/renderer/components/FeedbackChatView.test.tsx
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import { FeedbackChatView } from '../../../renderer/components/FeedbackChatView';
+import {
+	useFeedbackDraftStore,
+	type FeedbackDraft,
+} from '../../../renderer/stores/feedbackDraftStore';
 import type { Theme, Session } from '../../../renderer/types';
 
 const theme: Theme = {
@@ -201,5 +205,98 @@ describe('FeedbackChatView', () => {
 		expect(closeButton).toBeTruthy();
 		closeButton.click();
 		expect(onCancel).toHaveBeenCalledOnce();
+	});
+
+	it('hydrates the chat from a resumed draft (messages + attachments)', async () => {
+		const draft: FeedbackDraft = {
+			id: 'draft-1',
+			suggestedName: 'Crash on save',
+			category: 'bug_report',
+			summary: 'Crash on save',
+			confidence: 60,
+			agentType: 'claude-code',
+			messages: [{ role: 'user', content: 'Steps to reproduce the crash', timestamp: 1000 }],
+			attachments: [
+				{ id: 'a1', name: 'crash.png', dataUrl: 'data:image/png;base64,abc123', sizeBytes: 10 },
+			],
+			inputDraft: 'one more thing',
+			includeDebugPackage: false,
+			createdAt: 1000,
+			updatedAt: 1000,
+		};
+		useFeedbackDraftStore.setState({ drafts: [draft], activeDraftId: null, resumeDraftId: null });
+
+		window.maestro.feedback.checkGhAuth.mockResolvedValue({ authenticated: true });
+		window.maestro.agents.detect.mockResolvedValue([
+			{ id: 'claude-code', name: 'Claude Code', available: true },
+		]);
+		window.maestro.feedback.getConversationPrompt.mockResolvedValue({
+			prompt: 'system prompt',
+			environment: '- Maestro version: 1.0.0',
+		});
+
+		render(
+			<FeedbackChatView
+				theme={theme}
+				sessions={sessions}
+				onCancel={vi.fn()}
+				onSubmitSuccess={vi.fn()}
+				resumeDraftId="draft-1"
+			/>
+		);
+
+		await waitFor(() => {
+			expect(screen.getByText('Steps to reproduce the crash')).toBeTruthy();
+		});
+		expect(screen.getByAltText('crash.png')).toBeTruthy();
+	});
+
+	it('saves the current conversation as a draft when Save draft is clicked', async () => {
+		const draft: FeedbackDraft = {
+			id: 'draft-1',
+			suggestedName: 'Crash on save',
+			category: 'bug_report',
+			summary: 'Crash on save',
+			confidence: 60,
+			agentType: 'claude-code',
+			messages: [{ role: 'user', content: 'Steps to reproduce the crash', timestamp: 1000 }],
+			attachments: [
+				{ id: 'a1', name: 'crash.png', dataUrl: 'data:image/png;base64,abc123', sizeBytes: 10 },
+			],
+			inputDraft: '',
+			includeDebugPackage: false,
+			createdAt: 1000,
+			updatedAt: 1000,
+		};
+		useFeedbackDraftStore.setState({ drafts: [draft], activeDraftId: null, resumeDraftId: null });
+
+		window.maestro.feedback.checkGhAuth.mockResolvedValue({ authenticated: true });
+		window.maestro.agents.detect.mockResolvedValue([
+			{ id: 'claude-code', name: 'Claude Code', available: true },
+		]);
+		window.maestro.feedback.getConversationPrompt.mockResolvedValue({
+			prompt: 'system prompt',
+			environment: '- Maestro version: 1.0.0',
+		});
+
+		render(
+			<FeedbackChatView
+				theme={theme}
+				sessions={sessions}
+				onCancel={vi.fn()}
+				onSubmitSuccess={vi.fn()}
+				resumeDraftId="draft-1"
+			/>
+		);
+
+		const saveButton = await screen.findByText('Save draft');
+		saveButton.click();
+
+		await waitFor(() => {
+			expect(window.maestro.feedback.drafts.save).toHaveBeenCalled();
+		});
+		const payload = window.maestro.feedback.drafts.save.mock.calls[0][0];
+		expect(payload.messages[0].content).toBe('Steps to reproduce the crash');
+		expect(payload.attachments[0].name).toBe('crash.png');
 	});
 });

--- a/src/__tests__/renderer/components/FeedbackChatView.test.tsx
+++ b/src/__tests__/renderer/components/FeedbackChatView.test.tsx
@@ -6,6 +6,7 @@ import {
 	type FeedbackDraft,
 } from '../../../renderer/stores/feedbackDraftStore';
 import type { Theme, Session } from '../../../renderer/types';
+import { FeedbackConversationManager } from '../../../renderer/services/feedbackConversation';
 
 const theme: Theme = {
 	id: 'test-dark',
@@ -298,5 +299,111 @@ describe('FeedbackChatView', () => {
 		const payload = window.maestro.feedback.drafts.save.mock.calls[0][0];
 		expect(payload.messages[0].content).toBe('Steps to reproduce the crash');
 		expect(payload.attachments[0].name).toBe('crash.png');
+	});
+
+	it('falls back to an available provider when the resumed draft provider is gone', async () => {
+		const draft: FeedbackDraft = {
+			id: 'draft-codex',
+			suggestedName: 'Codex draft',
+			category: 'bug_report',
+			summary: '',
+			confidence: 0,
+			agentType: 'codex',
+			messages: [],
+			attachments: [],
+			inputDraft: 'half-written report',
+			includeDebugPackage: false,
+			createdAt: 1000,
+			updatedAt: 1000,
+		};
+		useFeedbackDraftStore.setState({ drafts: [draft], activeDraftId: null, resumeDraftId: null });
+
+		window.maestro.feedback.checkGhAuth.mockResolvedValue({ authenticated: true });
+		window.maestro.agents.detect.mockResolvedValue([
+			{ id: 'claude-code', name: 'Claude Code', available: true },
+			{ id: 'codex', name: 'Codex', available: false },
+		]);
+		window.maestro.feedback.getConversationPrompt.mockResolvedValue({
+			prompt: 'system prompt',
+			environment: '- Maestro version: 1.0.0',
+		});
+
+		const startSpy = vi.spyOn(FeedbackConversationManager.prototype, 'start');
+
+		render(
+			<FeedbackChatView
+				theme={theme}
+				sessions={sessions}
+				onCancel={vi.fn()}
+				onSubmitSuccess={vi.fn()}
+				resumeDraftId="draft-codex"
+			/>
+		);
+
+		await waitFor(() => {
+			expect(startSpy).toHaveBeenCalled();
+		});
+		// The saved provider ('codex') is no longer available, so the editor must
+		// start the conversation with the detected fallback instead of throwing.
+		expect(startSpy.mock.calls[0][0].agentType).toBe('claude-code');
+		startSpy.mockRestore();
+	});
+
+	it('keeps a resumed submit-ready draft submittable by rehydrating lastResponse', async () => {
+		const draft: FeedbackDraft = {
+			id: 'ready-1',
+			suggestedName: 'Ready report',
+			category: 'bug_report',
+			summary: 'Crash on save',
+			confidence: 90,
+			agentType: 'claude-code',
+			messages: [
+				{ role: 'user', content: 'It crashes', timestamp: 1000 },
+				{ role: 'assistant', content: 'Got it', timestamp: 1001 },
+			],
+			attachments: [],
+			inputDraft: '',
+			includeDebugPackage: false,
+			createdAt: 1000,
+			updatedAt: 1000,
+			lastResponse: {
+				confidence: 90,
+				ready: true,
+				message: 'Got it',
+				category: 'bug_report',
+				summary: 'Crash on save',
+				structured: {
+					expectedBehavior: 'no crash',
+					actualBehavior: 'crash',
+					reproductionSteps: 'save',
+					additionalContext: '',
+				},
+			},
+		};
+		useFeedbackDraftStore.setState({ drafts: [draft], activeDraftId: null, resumeDraftId: null });
+
+		window.maestro.feedback.checkGhAuth.mockResolvedValue({ authenticated: true });
+		window.maestro.agents.detect.mockResolvedValue([
+			{ id: 'claude-code', name: 'Claude Code', available: true },
+		]);
+		window.maestro.feedback.getConversationPrompt.mockResolvedValue({
+			prompt: 'system prompt',
+			environment: '- Maestro version: 1.0.0',
+		});
+		window.maestro.feedback.searchIssues.mockResolvedValue({ issues: [] });
+
+		render(
+			<FeedbackChatView
+				theme={theme}
+				sessions={sessions}
+				onCancel={vi.fn()}
+				onSubmitSuccess={vi.fn()}
+				resumeDraftId="ready-1"
+			/>
+		);
+
+		// Submit button is gated on isReady, which must be restored from the
+		// persisted ready response without sending another message.
+		expect(await screen.findByText('Submit Feedback')).toBeTruthy();
 	});
 });

--- a/src/__tests__/renderer/components/FeedbackModal.test.tsx
+++ b/src/__tests__/renderer/components/FeedbackModal.test.tsx
@@ -1,0 +1,199 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
+import * as React from 'react';
+import { FeedbackModal } from '../../../renderer/components/FeedbackModal';
+import type { FeedbackDraft } from '../../../renderer/stores/feedbackDraftStore';
+import type { Theme } from '../../../renderer/types';
+
+// Track how many times the (mocked) editor mounts. A remount means the editor
+// was rebuilt from the persisted copy, which would discard unsaved edits.
+const mockChat = { mountCount: 0 };
+
+// Controllable draft-store stand-in: FeedbackModal reads it both via selector
+// hooks and via getState(), so the mock supports both call shapes.
+const mockState = {
+	isMinimized: false,
+	hasDraft: false,
+	drafts: [] as FeedbackDraft[],
+	resumeDraftId: null as string | null,
+	activeDraftId: null as string | null,
+	activeDraft: null as FeedbackDraft | null,
+	setMinimized: vi.fn(),
+	setHasDraft: vi.fn(),
+	setActiveDraft: vi.fn(),
+	loadDrafts: vi.fn().mockResolvedValue(undefined),
+	saveDraft: vi.fn().mockResolvedValue('saved-id'),
+	deleteDraft: vi.fn().mockResolvedValue(undefined),
+	requestResume: vi.fn(),
+	clearResume: vi.fn(),
+	reset: vi.fn(),
+};
+
+vi.mock('../../../renderer/stores/feedbackDraftStore', () => ({
+	useFeedbackDraftStore: Object.assign(
+		(selector: (s: typeof mockState) => unknown) => selector(mockState),
+		{ getState: () => mockState }
+	),
+}));
+
+vi.mock('../../../renderer/stores/uiStore', () => ({
+	useUIStore: (selector: (s: { setLeftSidebarOpen: () => void }) => unknown) =>
+		selector({ setLeftSidebarOpen: vi.fn() }),
+}));
+
+vi.mock('../../../renderer/components/ui/Modal', () => ({
+	Modal: ({
+		children,
+		customHeader,
+	}: {
+		children?: React.ReactNode;
+		customHeader?: React.ReactNode;
+	}) => (
+		<div>
+			{customHeader}
+			{children}
+		</div>
+	),
+}));
+
+vi.mock('../../../renderer/components/ui/GhostIconButton', () => ({
+	GhostIconButton: ({
+		children,
+		onClick,
+		ariaLabel,
+		title,
+	}: {
+		children?: React.ReactNode;
+		onClick?: () => void;
+		ariaLabel?: string;
+		title?: string;
+	}) => (
+		<button aria-label={ariaLabel} title={title} onClick={onClick}>
+			{children}
+		</button>
+	),
+}));
+
+vi.mock('../../../renderer/components/FeedbackChatView', () => ({
+	FeedbackChatView: () => {
+		React.useEffect(() => {
+			mockChat.mountCount += 1;
+		}, []);
+		return <div data-testid="chat-view" />;
+	},
+}));
+
+vi.mock('../../../renderer/components/FeedbackDraftsList', () => ({
+	FeedbackDraftsList: ({
+		drafts,
+		onResume,
+	}: {
+		drafts: FeedbackDraft[];
+		onResume: (id: string) => void;
+	}) => (
+		<div>
+			{drafts.map((d) => (
+				<button key={d.id} aria-label={`resume-${d.id}`} onClick={() => onResume(d.id)}>
+					{d.suggestedName}
+				</button>
+			))}
+		</div>
+	),
+}));
+
+const theme = {
+	id: 'test-dark',
+	name: 'Test Dark',
+	mode: 'dark',
+	colors: {
+		bgMain: '#101322',
+		bgSidebar: '#14192d',
+		bgActivity: '#1b2140',
+		textMain: '#f5f7ff',
+		textDim: '#8d96b8',
+		accent: '#8b5cf6',
+		accentForeground: '#ffffff',
+		border: '#2a3154',
+		success: '#22c55e',
+		warning: '#f59e0b',
+		error: '#ef4444',
+	},
+} as Theme;
+
+function makeDraft(id: string): FeedbackDraft {
+	return {
+		id,
+		suggestedName: `Draft ${id}`,
+		category: 'general_feedback',
+		summary: '',
+		confidence: 0,
+		agentType: 'claude-code',
+		messages: [],
+		attachments: [],
+		inputDraft: '',
+		includeDebugPackage: false,
+		createdAt: 1000,
+		updatedAt: 1000,
+	};
+}
+
+function renderModal() {
+	return render(
+		<FeedbackModal theme={theme} sessions={[]} onClose={vi.fn()} onSwitchToSession={vi.fn()} />
+	);
+}
+
+describe('FeedbackModal draft resume', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockChat.mountCount = 0;
+		mockState.drafts = [];
+		mockState.activeDraftId = null;
+		mockState.activeDraft = null;
+		mockState.resumeDraftId = null;
+		mockState.saveDraft.mockResolvedValue('saved-id');
+	});
+
+	it('reopening the already-active draft is a no-op (no remount, no save, no resume)', async () => {
+		mockState.drafts = [makeDraft('draft-1'), makeDraft('draft-2')];
+		mockState.activeDraftId = 'draft-1';
+		mockState.activeDraft = makeDraft('draft-1');
+
+		renderModal();
+		expect(mockChat.mountCount).toBe(1);
+
+		await act(async () => {
+			fireEvent.click(screen.getByLabelText('View saved drafts'));
+		});
+		await act(async () => {
+			fireEvent.click(screen.getByLabelText('resume-draft-1'));
+		});
+
+		// The live editor must be left untouched: clicking the active draft must
+		// not rebuild it from the persisted copy (which would drop unsaved edits).
+		expect(mockChat.mountCount).toBe(1);
+		expect(mockState.requestResume).not.toHaveBeenCalled();
+		expect(mockState.saveDraft).not.toHaveBeenCalled();
+	});
+
+	it('switching to a different draft saves the current one then remounts the editor', async () => {
+		mockState.drafts = [makeDraft('draft-1'), makeDraft('draft-2')];
+		mockState.activeDraftId = 'draft-1';
+		mockState.activeDraft = makeDraft('draft-1');
+		mockState.saveDraft.mockResolvedValue('draft-1');
+
+		renderModal();
+		expect(mockChat.mountCount).toBe(1);
+
+		await act(async () => {
+			fireEvent.click(screen.getByLabelText('View saved drafts'));
+		});
+		await act(async () => {
+			fireEvent.click(screen.getByLabelText('resume-draft-2'));
+		});
+
+		expect(mockState.saveDraft).toHaveBeenCalledTimes(1);
+		expect(mockState.requestResume).toHaveBeenCalledWith('draft-2');
+		await waitFor(() => expect(mockChat.mountCount).toBe(2));
+	});
+});

--- a/src/__tests__/renderer/stores/feedbackDraftStore.test.ts
+++ b/src/__tests__/renderer/stores/feedbackDraftStore.test.ts
@@ -30,6 +30,7 @@ describe('feedbackDraftStore', () => {
 			resumeDraftId: null,
 			activeDraftId: null,
 			activeDraft: null,
+			saveError: null,
 		});
 		window.maestro.feedback.drafts.list.mockResolvedValue({ drafts: [] });
 		window.maestro.feedback.drafts.save.mockImplementation((draft: FeedbackDraft) =>
@@ -95,5 +96,28 @@ describe('feedbackDraftStore', () => {
 		expect(state.resumeDraftId).toBeNull();
 		// The persisted drafts list must survive a reset so it stays resumable.
 		expect(state.drafts).toEqual(drafts);
+	});
+
+	it('saveDraft surfaces a failure as null and records a saveError', async () => {
+		window.maestro.feedback.drafts.save.mockRejectedValue(new Error('disk full'));
+
+		const id = await useFeedbackDraftStore.getState().saveDraft(makeDraft());
+
+		expect(id).toBeNull();
+		expect(useFeedbackDraftStore.getState().saveError).toBeTruthy();
+	});
+
+	it('saveDraft patches the live snapshot id so later saves upsert instead of duplicating', async () => {
+		const snapshot = makeDraft({ id: '' });
+		useFeedbackDraftStore.setState({ activeDraft: snapshot, saveError: 'stale error' });
+		window.maestro.feedback.drafts.save.mockResolvedValue({ draft: makeDraft({ id: 'minted-1' }) });
+
+		const id = await useFeedbackDraftStore.getState().saveDraft(snapshot);
+
+		expect(id).toBe('minted-1');
+		const state = useFeedbackDraftStore.getState();
+		expect(state.activeDraftId).toBe('minted-1');
+		expect(state.activeDraft?.id).toBe('minted-1');
+		expect(state.saveError).toBeNull();
 	});
 });

--- a/src/__tests__/renderer/stores/feedbackDraftStore.test.ts
+++ b/src/__tests__/renderer/stores/feedbackDraftStore.test.ts
@@ -120,4 +120,34 @@ describe('feedbackDraftStore', () => {
 		expect(state.activeDraft?.id).toBe('minted-1');
 		expect(state.saveError).toBeNull();
 	});
+
+	it('dedupes concurrent first-saves of a new draft into a single draft row', async () => {
+		// Mirror the main-process handler: an empty id mints a fresh UUID per
+		// call, while an existing id upserts the matching row in place.
+		const persisted: FeedbackDraft[] = [];
+		let mintCounter = 0;
+		window.maestro.feedback.drafts.save.mockImplementation(async (incoming: FeedbackDraft) => {
+			const id = incoming.id || `minted-${++mintCounter}`;
+			const existing = persisted.findIndex((d) => d.id === id);
+			const saved = { ...incoming, id };
+			if (existing >= 0) persisted[existing] = saved;
+			else persisted.push(saved);
+			return { draft: saved };
+		});
+		window.maestro.feedback.drafts.list.mockImplementation(async () => ({
+			drafts: [...persisted],
+		}));
+
+		// Both saves fire before the first resolves, so both serialize an empty id.
+		const { saveDraft } = useFeedbackDraftStore.getState();
+		const newDraft = makeDraft({ id: '' });
+		const [id1, id2] = await Promise.all([saveDraft(newDraft), saveDraft(newDraft)]);
+
+		// Exactly one row is created and both calls resolve to the same minted id.
+		expect(mintCounter).toBe(1);
+		expect(persisted).toHaveLength(1);
+		expect(id1).toBe('minted-1');
+		expect(id2).toBe('minted-1');
+		expect(useFeedbackDraftStore.getState().activeDraftId).toBe('minted-1');
+	});
 });

--- a/src/__tests__/renderer/stores/feedbackDraftStore.test.ts
+++ b/src/__tests__/renderer/stores/feedbackDraftStore.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+	useFeedbackDraftStore,
+	type FeedbackDraft,
+} from '../../../renderer/stores/feedbackDraftStore';
+
+const makeDraft = (overrides: Partial<FeedbackDraft> = {}): FeedbackDraft => ({
+	id: 'd1',
+	suggestedName: 'Draft one',
+	category: 'bug_report',
+	summary: '',
+	confidence: 0,
+	agentType: 'claude-code',
+	messages: [],
+	attachments: [],
+	inputDraft: '',
+	includeDebugPackage: false,
+	createdAt: 1,
+	updatedAt: 1,
+	...overrides,
+});
+
+describe('feedbackDraftStore', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		useFeedbackDraftStore.setState({
+			isMinimized: false,
+			hasDraft: false,
+			drafts: [],
+			resumeDraftId: null,
+			activeDraftId: null,
+			activeDraft: null,
+		});
+		window.maestro.feedback.drafts.list.mockResolvedValue({ drafts: [] });
+		window.maestro.feedback.drafts.save.mockImplementation((draft: FeedbackDraft) =>
+			Promise.resolve({ draft })
+		);
+		window.maestro.feedback.drafts.delete.mockResolvedValue({});
+	});
+
+	it('loadDrafts populates the drafts list from the IPC bridge', async () => {
+		const draft = makeDraft();
+		window.maestro.feedback.drafts.list.mockResolvedValue({ drafts: [draft] });
+
+		await useFeedbackDraftStore.getState().loadDrafts();
+
+		expect(window.maestro.feedback.drafts.list).toHaveBeenCalled();
+		expect(useFeedbackDraftStore.getState().drafts).toEqual([draft]);
+	});
+
+	it('saveDraft persists, refreshes the list, and tracks the active id', async () => {
+		const draft = makeDraft({ id: 'saved-1' });
+		window.maestro.feedback.drafts.save.mockResolvedValue({ draft });
+		window.maestro.feedback.drafts.list.mockResolvedValue({ drafts: [draft] });
+
+		const id = await useFeedbackDraftStore.getState().saveDraft(draft);
+
+		expect(window.maestro.feedback.drafts.save).toHaveBeenCalledWith(draft);
+		expect(window.maestro.feedback.drafts.list).toHaveBeenCalled();
+		expect(id).toBe('saved-1');
+		expect(useFeedbackDraftStore.getState().activeDraftId).toBe('saved-1');
+		expect(useFeedbackDraftStore.getState().drafts).toEqual([draft]);
+	});
+
+	it('deleteDraft removes via IPC, refreshes, and clears a matching active id', async () => {
+		useFeedbackDraftStore.setState({ activeDraftId: 'd1' });
+		window.maestro.feedback.drafts.list.mockResolvedValue({ drafts: [] });
+
+		await useFeedbackDraftStore.getState().deleteDraft('d1');
+
+		expect(window.maestro.feedback.drafts.delete).toHaveBeenCalledWith('d1');
+		expect(window.maestro.feedback.drafts.list).toHaveBeenCalled();
+		expect(useFeedbackDraftStore.getState().drafts).toEqual([]);
+		expect(useFeedbackDraftStore.getState().activeDraftId).toBeNull();
+	});
+
+	it('reset clears the ephemeral session flags but preserves the persisted drafts', () => {
+		const drafts = [makeDraft()];
+		useFeedbackDraftStore.setState({
+			isMinimized: true,
+			hasDraft: true,
+			drafts,
+			activeDraftId: 'd1',
+			activeDraft: drafts[0],
+			resumeDraftId: 'd1',
+		});
+
+		useFeedbackDraftStore.getState().reset();
+
+		const state = useFeedbackDraftStore.getState();
+		expect(state.isMinimized).toBe(false);
+		expect(state.hasDraft).toBe(false);
+		expect(state.activeDraftId).toBeNull();
+		expect(state.activeDraft).toBeNull();
+		expect(state.resumeDraftId).toBeNull();
+		// The persisted drafts list must survive a reset so it stays resumable.
+		expect(state.drafts).toEqual(drafts);
+	});
+});

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -248,6 +248,11 @@ const mockMaestro = {
 		submitConversation: vi.fn().mockResolvedValue({ success: true }),
 		searchIssues: vi.fn().mockResolvedValue({ issues: [] }),
 		subscribeIssue: vi.fn().mockResolvedValue({ success: true }),
+		drafts: {
+			list: vi.fn().mockResolvedValue({ drafts: [] }),
+			save: vi.fn((draft: unknown) => Promise.resolve({ draft })),
+			delete: vi.fn().mockResolvedValue({}),
+		},
 	},
 	git: {
 		branch: vi.fn().mockResolvedValue({ stdout: 'main' }),

--- a/src/main/ipc/handlers/feedback.ts
+++ b/src/main/ipc/handlers/feedback.ts
@@ -10,6 +10,7 @@ import { ipcMain, app } from 'electron';
 import fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
+import { randomUUID } from 'crypto';
 import { logger } from '../../utils/logger';
 import { getPrompt } from '../../prompt-manager';
 import { withIpcErrorLogging, CreateHandlerOptions } from '../../utils/ipcHandler';
@@ -27,6 +28,11 @@ const LOG_CONTEXT = '[Feedback]';
 const ATTACHMENTS_REPO = 'maestro-feedback-attachments';
 const MAX_SUMMARY_LENGTH = 120;
 const MAX_FEEDBACK_FIELD_LENGTH = 5000;
+const MAX_DRAFTS = 30;
+const MAX_DRAFT_ATTACHMENTS = 5;
+const MAX_DRAFT_MESSAGES = 200;
+const MAX_DRAFT_MESSAGE_LENGTH = 20000;
+const DRAFTS_FILE_NAME = 'feedback-drafts.json';
 
 type FeedbackCategory = 'bug_report' | 'feature_request' | 'improvement' | 'general_feedback';
 
@@ -66,6 +72,37 @@ export interface FeedbackHandlerDependencies {
 export interface FeedbackAttachmentInput {
 	name: string;
 	dataUrl: string;
+}
+
+export interface FeedbackDraftAttachment {
+	id: string;
+	name: string;
+	dataUrl: string;
+	sizeBytes: number;
+}
+
+export interface FeedbackDraftMessage {
+	role: 'user' | 'assistant' | 'system';
+	content: string;
+	timestamp: number;
+	confidence?: number;
+	category?: FeedbackCategory;
+	summary?: string;
+}
+
+export interface FeedbackDraft {
+	id: string;
+	suggestedName: string;
+	category: FeedbackCategory;
+	summary: string;
+	confidence: number;
+	agentType: string;
+	messages: FeedbackDraftMessage[];
+	attachments: FeedbackDraftAttachment[];
+	inputDraft: string;
+	includeDebugPackage: boolean;
+	createdAt: number;
+	updatedAt: number;
 }
 
 interface FeedbackSubmitPayload {
@@ -154,6 +191,129 @@ function readOptionalField(
 	}
 
 	return { value: sanitized };
+}
+
+/**
+ * Resolve the path to the persisted feedback drafts file (a single
+ * app-global JSON document under userData, mirroring playbooks' storage).
+ */
+function getDraftsFilePath(): string {
+	return path.join(app.getPath('userData'), DRAFTS_FILE_NAME);
+}
+
+/**
+ * Read all persisted feedback drafts. Returns an empty array when the file is
+ * missing or malformed, matching readPlaybooks() in playbooks.ts.
+ */
+async function readDrafts(): Promise<FeedbackDraft[]> {
+	try {
+		const content = await fs.readFile(getDraftsFilePath(), 'utf-8');
+		const data = JSON.parse(content);
+		return Array.isArray(data.drafts) ? data.drafts : [];
+	} catch {
+		return [];
+	}
+}
+
+/**
+ * Persist the full drafts list. Ensures the parent directory exists for parity
+ * with writePlaybooks(); userData itself already exists at runtime.
+ */
+async function writeDrafts(drafts: FeedbackDraft[]): Promise<void> {
+	const filePath = getDraftsFilePath();
+	await fs.mkdir(path.dirname(filePath), { recursive: true });
+	await fs.writeFile(filePath, JSON.stringify({ drafts }, null, 2), 'utf-8');
+}
+
+/**
+ * Validate + clamp a single draft attachment, dropping anything that is not a
+ * base64 image data URL (reuses the submit handler's attachment filter style).
+ */
+function normalizeDraftAttachments(raw: unknown): FeedbackDraftAttachment[] {
+	if (!Array.isArray(raw)) return [];
+	return raw
+		.filter(
+			(a): a is FeedbackDraftAttachment =>
+				Boolean(a) &&
+				typeof a.id === 'string' &&
+				typeof a.name === 'string' &&
+				typeof a.dataUrl === 'string' &&
+				a.dataUrl.startsWith('data:image/') &&
+				typeof a.sizeBytes === 'number'
+		)
+		.slice(0, MAX_DRAFT_ATTACHMENTS)
+		.map((a) => ({
+			id: a.id,
+			name: sanitizeTextInput(a.name).slice(0, MAX_SUMMARY_LENGTH) || a.name,
+			dataUrl: a.dataUrl,
+			sizeBytes: a.sizeBytes,
+		}));
+}
+
+/**
+ * Validate + clamp a single draft message. Returns null for non-object input.
+ */
+function normalizeDraftMessage(raw: unknown): FeedbackDraftMessage | null {
+	if (!raw || typeof raw !== 'object') return null;
+	const m = raw as Record<string, unknown>;
+	const role: FeedbackDraftMessage['role'] =
+		m.role === 'assistant' ? 'assistant' : m.role === 'system' ? 'system' : 'user';
+	const content = typeof m.content === 'string' ? m.content.slice(0, MAX_DRAFT_MESSAGE_LENGTH) : '';
+	const message: FeedbackDraftMessage = {
+		role,
+		content,
+		timestamp: typeof m.timestamp === 'number' ? m.timestamp : Date.now(),
+	};
+	if (typeof m.confidence === 'number') {
+		message.confidence = m.confidence;
+	}
+	if (isFeedbackCategory(m.category)) {
+		message.category = m.category;
+	}
+	if (typeof m.summary === 'string') {
+		message.summary = m.summary.slice(0, MAX_SUMMARY_LENGTH);
+	}
+	return message;
+}
+
+/**
+ * Sanitize an incoming draft payload into a fully-formed FeedbackDraft,
+ * minting an id when one is not supplied (the renderer normally supplies it).
+ */
+function normalizeDraft(raw: unknown): FeedbackDraft {
+	const d = (raw && typeof raw === 'object' ? raw : {}) as Record<string, unknown>;
+	const now = Date.now();
+	const messages = Array.isArray(d.messages)
+		? (d.messages
+				.map(normalizeDraftMessage)
+				.filter((m): m is FeedbackDraftMessage => m !== null)
+				.slice(0, MAX_DRAFT_MESSAGES) as FeedbackDraftMessage[])
+		: [];
+	const confidence =
+		typeof d.confidence === 'number' ? Math.max(0, Math.min(100, Math.round(d.confidence))) : 0;
+	return {
+		id: typeof d.id === 'string' && d.id ? d.id : randomUUID(),
+		suggestedName:
+			typeof d.suggestedName === 'string'
+				? sanitizeTextInput(d.suggestedName).slice(0, MAX_SUMMARY_LENGTH)
+				: '',
+		category: isFeedbackCategory(d.category) ? d.category : 'general_feedback',
+		summary:
+			typeof d.summary === 'string'
+				? sanitizeTextInput(d.summary).slice(0, MAX_SUMMARY_LENGTH)
+				: '',
+		confidence,
+		agentType: typeof d.agentType === 'string' && d.agentType ? d.agentType : 'claude-code',
+		messages,
+		attachments: normalizeDraftAttachments(d.attachments),
+		inputDraft:
+			typeof d.inputDraft === 'string'
+				? sanitizeTextInput(d.inputDraft).slice(0, MAX_FEEDBACK_FIELD_LENGTH)
+				: '',
+		includeDebugPackage: d.includeDebugPackage === true,
+		createdAt: typeof d.createdAt === 'number' ? d.createdAt : now,
+		updatedAt: typeof d.updatedAt === 'number' ? d.updatedAt : now,
+	};
 }
 
 function getPlatformLabel(platform: NodeJS.Platform): string {
@@ -1033,6 +1193,66 @@ export function registerFeedbackHandlers(_deps: FeedbackHandlerDependencies): vo
 				const { prompt } = await composeFeedbackPrompt(trimmedFeedback, normalizedAttachments);
 
 				return { prompt };
+			}
+		)
+	);
+
+	// List persisted feedback drafts, most-recently-updated first so the
+	// renderer can treat drafts[0] as the "most recent" draft.
+	ipcMain.handle(
+		'feedback:drafts:list',
+		withIpcErrorLogging(
+			handlerOpts('drafts-list'),
+			async (): Promise<{ drafts: FeedbackDraft[] }> => {
+				const drafts = await readDrafts();
+				drafts.sort((a, b) => b.updatedAt - a.updatedAt);
+				return { drafts };
+			}
+		)
+	);
+
+	// Upsert a draft by id (renderer supplies the id; a new one is minted when
+	// missing), then persist the trimmed, most-recent-first list.
+	ipcMain.handle(
+		'feedback:drafts:save',
+		withIpcErrorLogging(
+			handlerOpts('drafts-save'),
+			async (draft: unknown): Promise<{ draft: FeedbackDraft }> => {
+				const incoming = normalizeDraft(draft);
+				const drafts = await readDrafts();
+				const now = Date.now();
+				const index = drafts.findIndex((d) => d.id === incoming.id);
+				let saved: FeedbackDraft;
+				if (index >= 0) {
+					saved = {
+						...drafts[index],
+						...incoming,
+						createdAt: drafts[index].createdAt,
+						updatedAt: now,
+					};
+					drafts[index] = saved;
+				} else {
+					saved = { ...incoming, createdAt: now, updatedAt: now };
+					drafts.push(saved);
+				}
+				drafts.sort((a, b) => b.updatedAt - a.updatedAt);
+				await writeDrafts(drafts.slice(0, MAX_DRAFTS));
+				return { draft: saved };
+			}
+		)
+	);
+
+	// Delete a draft by id, then persist the remaining list.
+	ipcMain.handle(
+		'feedback:drafts:delete',
+		withIpcErrorLogging(
+			handlerOpts('drafts-delete'),
+			async (payload: { id?: string }): Promise<Record<string, never>> => {
+				const id = typeof payload?.id === 'string' ? payload.id : '';
+				const drafts = await readDrafts();
+				const next = drafts.filter((d) => d.id !== id);
+				await writeDrafts(next);
+				return {};
 			}
 		)
 	);

--- a/src/main/ipc/handlers/feedback.ts
+++ b/src/main/ipc/handlers/feedback.ts
@@ -347,7 +347,7 @@ function normalizeDraft(raw: unknown): FeedbackDraft {
 		? (d.messages
 				.map(normalizeDraftMessage)
 				.filter((m): m is FeedbackDraftMessage => m !== null)
-				.slice(0, MAX_DRAFT_MESSAGES) as FeedbackDraftMessage[])
+				.slice(-MAX_DRAFT_MESSAGES) as FeedbackDraftMessage[])
 		: [];
 	const confidence =
 		typeof d.confidence === 'number' ? Math.max(0, Math.min(100, Math.round(d.confidence))) : 0;
@@ -368,7 +368,7 @@ function normalizeDraft(raw: unknown): FeedbackDraft {
 		attachments: normalizeDraftAttachments(d.attachments),
 		inputDraft:
 			typeof d.inputDraft === 'string'
-				? sanitizeTextInput(d.inputDraft).slice(0, MAX_FEEDBACK_FIELD_LENGTH)
+				? sanitizeTextInput(d.inputDraft).slice(0, MAX_DRAFT_MESSAGE_LENGTH)
 				: '',
 		includeDebugPackage: d.includeDebugPackage === true,
 		createdAt: typeof d.createdAt === 'number' ? d.createdAt : now,

--- a/src/main/ipc/handlers/feedback.ts
+++ b/src/main/ipc/handlers/feedback.ts
@@ -10,7 +10,7 @@ import { ipcMain, app } from 'electron';
 import fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
-import { randomUUID } from 'crypto';
+import { generateUUID } from '../../../shared/uuid';
 import { logger } from '../../utils/logger';
 import { getPrompt } from '../../prompt-manager';
 import { withIpcErrorLogging, CreateHandlerOptions } from '../../utils/ipcHandler';
@@ -23,6 +23,7 @@ import {
 import { execFileNoThrow } from '../../utils/execFile';
 import { generateDebugPackage, type DebugPackageDependencies } from '../../debug-package';
 import { captureException } from '../../utils/sentry';
+import { atomicWriteJson, createKeyedWriteQueue } from '../../utils/atomic-json-store';
 
 const LOG_CONTEXT = '[Feedback]';
 const ATTACHMENTS_REPO = 'maestro-feedback-attachments';
@@ -90,6 +91,27 @@ export interface FeedbackDraftMessage {
 	summary?: string;
 }
 
+export interface FeedbackDraftStructured {
+	expectedBehavior: string;
+	actualBehavior: string;
+	reproductionSteps: string;
+	additionalContext: string;
+}
+
+/**
+ * The parsed assistant response captured when a draft reaches the submit-ready
+ * state. Persisting it lets a resumed draft stay submittable without forcing
+ * the user to send another message to regenerate the structured fields.
+ */
+export interface FeedbackDraftResponse {
+	confidence: number;
+	ready: boolean;
+	message: string;
+	category: FeedbackCategory;
+	summary: string;
+	structured: FeedbackDraftStructured;
+}
+
 export interface FeedbackDraft {
 	id: string;
 	suggestedName: string;
@@ -103,6 +125,7 @@ export interface FeedbackDraft {
 	includeDebugPackage: boolean;
 	createdAt: number;
 	updatedAt: number;
+	lastResponse?: FeedbackDraftResponse | null;
 }
 
 interface FeedbackSubmitPayload {
@@ -201,6 +224,14 @@ function getDraftsFilePath(): string {
 	return path.join(app.getPath('userData'), DRAFTS_FILE_NAME);
 }
 
+// Serialize every read-modify-write cycle against the single drafts file so
+// concurrent autosave + manual saves (and deletes) cannot interleave and
+// clobber each other. Backed by the shared keyed-write-queue utility, with
+// atomicWriteJson giving partial-read-safe writes (mirrors group-chat-storage).
+const draftsWriteQueue = createKeyedWriteQueue();
+const enqueueDraftWrite = <T>(fn: () => Promise<T>): Promise<T> =>
+	draftsWriteQueue.enqueue(DRAFTS_FILE_NAME, fn);
+
 /**
  * Read all persisted feedback drafts. Returns an empty array when the file is
  * missing or malformed, matching readPlaybooks() in playbooks.ts.
@@ -222,7 +253,7 @@ async function readDrafts(): Promise<FeedbackDraft[]> {
 async function writeDrafts(drafts: FeedbackDraft[]): Promise<void> {
 	const filePath = getDraftsFilePath();
 	await fs.mkdir(path.dirname(filePath), { recursive: true });
-	await fs.writeFile(filePath, JSON.stringify({ drafts }, null, 2), 'utf-8');
+	await atomicWriteJson(filePath, { drafts });
 }
 
 /**
@@ -277,6 +308,35 @@ function normalizeDraftMessage(raw: unknown): FeedbackDraftMessage | null {
 }
 
 /**
+ * Validate + clamp the persisted submit-ready response. Returns null when the
+ * payload is absent or malformed so a resumed draft simply behaves as not-ready.
+ */
+function normalizeDraftResponse(raw: unknown): FeedbackDraftResponse | null {
+	if (!raw || typeof raw !== 'object') return null;
+	const r = raw as Record<string, unknown>;
+	const structuredRaw =
+		r.structured && typeof r.structured === 'object'
+			? (r.structured as Record<string, unknown>)
+			: {};
+	const clampField = (value: unknown): string =>
+		typeof value === 'string' ? value.slice(0, MAX_DRAFT_MESSAGE_LENGTH) : '';
+	return {
+		confidence:
+			typeof r.confidence === 'number' ? Math.max(0, Math.min(100, Math.round(r.confidence))) : 0,
+		ready: r.ready === true,
+		message: typeof r.message === 'string' ? r.message.slice(0, MAX_DRAFT_MESSAGE_LENGTH) : '',
+		category: isFeedbackCategory(r.category) ? r.category : 'general_feedback',
+		summary: typeof r.summary === 'string' ? r.summary.slice(0, MAX_SUMMARY_LENGTH) : '',
+		structured: {
+			expectedBehavior: clampField(structuredRaw.expectedBehavior),
+			actualBehavior: clampField(structuredRaw.actualBehavior),
+			reproductionSteps: clampField(structuredRaw.reproductionSteps),
+			additionalContext: clampField(structuredRaw.additionalContext),
+		},
+	};
+}
+
+/**
  * Sanitize an incoming draft payload into a fully-formed FeedbackDraft,
  * minting an id when one is not supplied (the renderer normally supplies it).
  */
@@ -292,7 +352,7 @@ function normalizeDraft(raw: unknown): FeedbackDraft {
 	const confidence =
 		typeof d.confidence === 'number' ? Math.max(0, Math.min(100, Math.round(d.confidence))) : 0;
 	return {
-		id: typeof d.id === 'string' && d.id ? d.id : randomUUID(),
+		id: typeof d.id === 'string' && d.id ? d.id : generateUUID(),
 		suggestedName:
 			typeof d.suggestedName === 'string'
 				? sanitizeTextInput(d.suggestedName).slice(0, MAX_SUMMARY_LENGTH)
@@ -313,6 +373,7 @@ function normalizeDraft(raw: unknown): FeedbackDraft {
 		includeDebugPackage: d.includeDebugPackage === true,
 		createdAt: typeof d.createdAt === 'number' ? d.createdAt : now,
 		updatedAt: typeof d.updatedAt === 'number' ? d.updatedAt : now,
+		lastResponse: normalizeDraftResponse(d.lastResponse),
 	};
 }
 
@@ -1219,25 +1280,27 @@ export function registerFeedbackHandlers(_deps: FeedbackHandlerDependencies): vo
 			handlerOpts('drafts-save'),
 			async (draft: unknown): Promise<{ draft: FeedbackDraft }> => {
 				const incoming = normalizeDraft(draft);
-				const drafts = await readDrafts();
-				const now = Date.now();
-				const index = drafts.findIndex((d) => d.id === incoming.id);
-				let saved: FeedbackDraft;
-				if (index >= 0) {
-					saved = {
-						...drafts[index],
-						...incoming,
-						createdAt: drafts[index].createdAt,
-						updatedAt: now,
-					};
-					drafts[index] = saved;
-				} else {
-					saved = { ...incoming, createdAt: now, updatedAt: now };
-					drafts.push(saved);
-				}
-				drafts.sort((a, b) => b.updatedAt - a.updatedAt);
-				await writeDrafts(drafts.slice(0, MAX_DRAFTS));
-				return { draft: saved };
+				return enqueueDraftWrite(async () => {
+					const drafts = await readDrafts();
+					const now = Date.now();
+					const index = drafts.findIndex((d) => d.id === incoming.id);
+					let saved: FeedbackDraft;
+					if (index >= 0) {
+						saved = {
+							...drafts[index],
+							...incoming,
+							createdAt: drafts[index].createdAt,
+							updatedAt: now,
+						};
+						drafts[index] = saved;
+					} else {
+						saved = { ...incoming, createdAt: now, updatedAt: now };
+						drafts.push(saved);
+					}
+					drafts.sort((a, b) => b.updatedAt - a.updatedAt);
+					await writeDrafts(drafts.slice(0, MAX_DRAFTS));
+					return { draft: saved };
+				});
 			}
 		)
 	);
@@ -1249,9 +1312,11 @@ export function registerFeedbackHandlers(_deps: FeedbackHandlerDependencies): vo
 			handlerOpts('drafts-delete'),
 			async (payload: { id?: string }): Promise<Record<string, never>> => {
 				const id = typeof payload?.id === 'string' ? payload.id : '';
-				const drafts = await readDrafts();
-				const next = drafts.filter((d) => d.id !== id);
-				await writeDrafts(next);
+				await enqueueDraftWrite(async () => {
+					const drafts = await readDrafts();
+					const next = drafts.filter((d) => d.id !== id);
+					await writeDrafts(next);
+				});
 				return {};
 			}
 		)

--- a/src/main/preload/feedback.ts
+++ b/src/main/preload/feedback.ts
@@ -36,6 +36,37 @@ export type FeedbackCategory =
 	| 'improvement'
 	| 'general_feedback';
 
+export interface FeedbackDraftAttachment {
+	id: string;
+	name: string;
+	dataUrl: string;
+	sizeBytes: number;
+}
+
+export interface FeedbackDraftMessage {
+	role: 'user' | 'assistant' | 'system';
+	content: string;
+	timestamp: number;
+	confidence?: number;
+	category?: FeedbackCategory;
+	summary?: string;
+}
+
+export interface FeedbackDraft {
+	id: string;
+	suggestedName: string;
+	category: FeedbackCategory;
+	summary: string;
+	confidence: number;
+	agentType: string;
+	messages: FeedbackDraftMessage[];
+	attachments: FeedbackDraftAttachment[];
+	inputDraft: string;
+	includeDebugPackage: boolean;
+	createdAt: number;
+	updatedAt: number;
+}
+
 export interface FeedbackSubmissionPayload {
 	sessionId: string;
 	category: FeedbackCategory;
@@ -107,6 +138,14 @@ export interface FeedbackApi {
 	 * Subscribe to an existing issue (+1 reaction) and optionally comment
 	 */
 	subscribeIssue: (issueNumber: number, comment?: string) => Promise<FeedbackSubmitResponse>;
+	/**
+	 * Persisted, resumable feedback drafts (list / upsert / delete)
+	 */
+	drafts: {
+		list: () => Promise<{ drafts: FeedbackDraft[] }>;
+		save: (draft: FeedbackDraft) => Promise<{ draft: FeedbackDraft }>;
+		delete: (id: string) => Promise<Record<string, never>>;
+	};
 }
 
 /**
@@ -140,5 +179,13 @@ export function createFeedbackApi(): FeedbackApi {
 
 		subscribeIssue: (issueNumber: number, comment?: string): Promise<FeedbackSubmitResponse> =>
 			ipcRenderer.invoke('feedback:subscribe-issue', { issueNumber, comment }),
+
+		drafts: {
+			list: (): Promise<{ drafts: FeedbackDraft[] }> => ipcRenderer.invoke('feedback:drafts:list'),
+			save: (draft: FeedbackDraft): Promise<{ draft: FeedbackDraft }> =>
+				ipcRenderer.invoke('feedback:drafts:save', draft),
+			delete: (id: string): Promise<Record<string, never>> =>
+				ipcRenderer.invoke('feedback:drafts:delete', { id }),
+		},
 	};
 }

--- a/src/main/preload/feedback.ts
+++ b/src/main/preload/feedback.ts
@@ -52,6 +52,22 @@ export interface FeedbackDraftMessage {
 	summary?: string;
 }
 
+export interface FeedbackDraftStructured {
+	expectedBehavior: string;
+	actualBehavior: string;
+	reproductionSteps: string;
+	additionalContext: string;
+}
+
+export interface FeedbackDraftResponse {
+	confidence: number;
+	ready: boolean;
+	message: string;
+	category: FeedbackCategory;
+	summary: string;
+	structured: FeedbackDraftStructured;
+}
+
 export interface FeedbackDraft {
 	id: string;
 	suggestedName: string;
@@ -65,6 +81,7 @@ export interface FeedbackDraft {
 	includeDebugPackage: boolean;
 	createdAt: number;
 	updatedAt: number;
+	lastResponse?: FeedbackDraftResponse | null;
 }
 
 export interface FeedbackSubmissionPayload {

--- a/src/renderer/components/FeedbackChatView.tsx
+++ b/src/renderer/components/FeedbackChatView.tsx
@@ -25,6 +25,7 @@ import {
 	PlusCircle,
 	Check,
 	Copy,
+	Save,
 } from 'lucide-react';
 import { Spinner } from './ui/Spinner';
 import { safeClipboardWrite } from '../utils/clipboard';
@@ -39,7 +40,7 @@ import {
 } from '../services/feedbackConversation';
 import { openUrl } from '../utils/openUrl';
 import { captureException } from '../utils/sentry';
-import { useFeedbackDraftStore } from '../stores/feedbackDraftStore';
+import { useFeedbackDraftStore, type FeedbackDraft } from '../stores/feedbackDraftStore';
 
 // ============================================================================
 // Constants
@@ -101,6 +102,8 @@ interface FeedbackChatViewProps {
 	onSubmitSuccess: (sessionId: string) => void;
 	/** Called when the view's desired modal width changes */
 	onWidthChange?: (width: number) => void;
+	/** When set, hydrate the view from this persisted draft on mount */
+	resumeDraftId?: string | null;
 }
 
 // ============================================================================
@@ -118,7 +121,21 @@ interface ExistingIssue {
 	commentCount: number;
 }
 
-export function FeedbackChatView({ theme, onCancel, onWidthChange }: FeedbackChatViewProps) {
+export function FeedbackChatView({
+	theme,
+	onCancel,
+	onWidthChange,
+	resumeDraftId,
+}: FeedbackChatViewProps) {
+	// Resolve the draft to resume exactly once, at mount, so initial state can
+	// be seeded synchronously before the auto-start effect picks an agent.
+	const resumeDraftRef = useRef<FeedbackDraft | null>(
+		resumeDraftId
+			? (useFeedbackDraftStore.getState().drafts.find((d) => d.id === resumeDraftId) ?? null)
+			: null
+	);
+	const resumeDraft = resumeDraftRef.current;
+
 	// --- State ---
 	const [step, setStep] = useState<'gh-check' | 'chat' | 'matching' | 'submitting' | 'done'>(
 		'gh-check'
@@ -127,25 +144,33 @@ export function FeedbackChatView({ theme, onCancel, onWidthChange }: FeedbackCha
 		checking: true,
 		ok: false,
 	});
-	const [selectedAgent, setSelectedAgent] = useState<ToolType>('claude-code');
+	const [selectedAgent, setSelectedAgent] = useState<ToolType>(
+		() => (resumeDraft?.agentType as ToolType) ?? 'claude-code'
+	);
 	const [detectedAgents, setDetectedAgents] = useState<Set<string>>(new Set());
 	const [agentsLoaded, setAgentsLoaded] = useState(false);
 	const [agentsDetectError, setAgentsDetectError] = useState<string | null>(null);
-	const [messages, setMessages] = useState<FeedbackMessage[]>([]);
-	const [inputValue, setInputValue] = useState('');
+	const [messages, setMessages] = useState<FeedbackMessage[]>(() => resumeDraft?.messages ?? []);
+	const [inputValue, setInputValue] = useState(() => resumeDraft?.inputDraft ?? '');
 	const [isLoading, setIsLoading] = useState(false);
-	const [confidence, setConfidence] = useState(0);
+	const [confidence, setConfidence] = useState(() => resumeDraft?.confidence ?? 0);
 	const [isReady, setIsReady] = useState(false);
 	const [lastResponse, setLastResponse] = useState<FeedbackParsedResponse | null>(null);
-	const [attachments, setAttachments] = useState<FeedbackAttachment[]>([]);
+	const [attachments, setAttachments] = useState<FeedbackAttachment[]>(
+		() => resumeDraft?.attachments ?? []
+	);
 	const [isDragging, setIsDragging] = useState(false);
-	const [includeDebugPackage, setIncludeDebugPackage] = useState(false);
+	const [includeDebugPackage, setIncludeDebugPackage] = useState(
+		() => resumeDraft?.includeDebugPackage ?? false
+	);
 	const [submitError, setSubmitError] = useState('');
 	const [matchingIssues, setMatchingIssues] = useState<ExistingIssue[]>([]);
 	const [searchingIssues, setSearchingIssues] = useState(false);
 	const [subscribingTo, setSubscribingTo] = useState<number | null>(null);
 	const [createdIssueUrl, setCreatedIssueUrl] = useState<string | null>(null);
 	const [copiedUrl, setCopiedUrl] = useState(false);
+	const [isSavingDraft, setIsSavingDraft] = useState(false);
+	const [draftSaved, setDraftSaved] = useState(false);
 	const lastSearchQueryRef = useRef<string | null>(null);
 	const searchAbortRef = useRef(0); // Monotonic counter to discard stale searches
 
@@ -192,7 +217,7 @@ export function FeedbackChatView({ theme, onCancel, onWidthChange }: FeedbackCha
 					setDetectedAgents(available);
 					// Auto-select first available
 					const firstAvailable = AGENT_TILES.find((t) => t.supported && available.has(t.id));
-					if (firstAvailable) setSelectedAgent(firstAvailable.id);
+					if (firstAvailable && !resumeDraft) setSelectedAgent(firstAvailable.id);
 					setAgentsLoaded(true);
 				}
 			} catch (error) {
@@ -233,16 +258,26 @@ export function FeedbackChatView({ theme, onCancel, onWidthChange }: FeedbackCha
 		};
 	}, []);
 
-	// --- Publish draft state so the sidebar Feedback button + close handler
-	//     know whether the user has unsaved work that would be lost. We only
-	//     count it as a draft once the user has actually sent a message —
-	//     unsubmitted typing or staged attachments don't count. Once the
-	//     issue is submitted (step === 'done') there's nothing left to lose.
+	// --- Resume bookkeeping: bind this editor to the resumed draft's id so
+	//     saves upsert (not duplicate), and consume the one-shot resume flag.
 	useEffect(() => {
-		const hasSentMessage = messages.some((m) => m.role === 'user');
-		const hasDraft = hasSentMessage && step !== 'done';
+		if (!resumeDraft) return;
+		useFeedbackDraftStore.setState({ activeDraftId: resumeDraft.id });
+		useFeedbackDraftStore.getState().clearResume();
+	}, [resumeDraft]);
+
+	// --- Publish draft state so the sidebar Feedback button + close handler
+	//     know whether the user has work worth keeping. Typed-but-unsent input
+	//     and staged attachments count too, so closing offers to save them.
+	//     Once the issue is submitted (step === 'done') there's nothing left.
+	useEffect(() => {
+		const hasContent =
+			messages.some((m) => m.role === 'user') ||
+			attachments.length > 0 ||
+			inputValue.trim().length > 0;
+		const hasDraft = hasContent && step !== 'done';
 		useFeedbackDraftStore.getState().setHasDraft(hasDraft);
-	}, [messages, step]);
+	}, [messages, attachments, inputValue, step]);
 
 	// --- Background issue search — fires after every agent response ---
 	const runIssueSearch = useCallback(async (query: string) => {
@@ -522,6 +557,58 @@ export function FeedbackChatView({ theme, onCancel, onWidthChange }: FeedbackCha
 		},
 		[sendMessage]
 	);
+
+	// --- Persisted draft helpers ---
+	const serializeDraft = useCallback((): FeedbackDraft => {
+		const firstUserMessage = messages.find((m) => m.role === 'user');
+		const rawName =
+			lastResponse?.summary || firstUserMessage?.content || inputValue || 'Untitled feedback';
+		const suggestedName = rawName.trim().slice(0, 60) || 'Untitled feedback';
+		const now = Date.now();
+		return {
+			id: useFeedbackDraftStore.getState().activeDraftId ?? '',
+			suggestedName,
+			category: lastResponse?.category ?? 'general_feedback',
+			summary: lastResponse?.summary ?? '',
+			confidence,
+			agentType: selectedAgent,
+			messages,
+			attachments,
+			inputDraft: inputValue,
+			includeDebugPackage,
+			createdAt: now,
+			updatedAt: now,
+		};
+	}, [
+		messages,
+		attachments,
+		inputValue,
+		lastResponse,
+		confidence,
+		selectedAgent,
+		includeDebugPackage,
+	]);
+
+	// Keep a live snapshot in the store so FeedbackModal can persist on
+	// minimize/close without reaching into this component's local state.
+	useEffect(() => {
+		const hasContent =
+			messages.some((m) => m.role === 'user') ||
+			attachments.length > 0 ||
+			inputValue.trim().length > 0;
+		useFeedbackDraftStore.getState().setActiveDraft(hasContent ? serializeDraft() : null);
+	}, [serializeDraft, messages, attachments, inputValue]);
+
+	const handleSaveDraft = useCallback(async () => {
+		setIsSavingDraft(true);
+		try {
+			await useFeedbackDraftStore.getState().saveDraft(serializeDraft());
+			setDraftSaved(true);
+			window.setTimeout(() => setDraftSaved(false), 2000);
+		} finally {
+			setIsSavingDraft(false);
+		}
+	}, [serializeDraft]);
 
 	// ========================================================================
 	// Render
@@ -889,6 +976,21 @@ export function FeedbackChatView({ theme, onCancel, onWidthChange }: FeedbackCha
 						</span>
 					)}
 					<div className="flex-1" />
+					<button
+						type="button"
+						onClick={handleSaveDraft}
+						disabled={isSavingDraft || step === 'submitting'}
+						className="flex items-center gap-1.5 px-3 py-1 rounded text-xs font-bold transition-colors hover:opacity-90 disabled:opacity-40 shrink-0 border"
+						style={{
+							backgroundColor: theme.colors.bgMain,
+							color: theme.colors.textDim,
+							borderColor: theme.colors.border,
+						}}
+						title="Save this feedback as a resumable draft"
+					>
+						{isSavingDraft ? <Spinner size={12} /> : <Save className="w-3 h-3" />}
+						{draftSaved ? 'Saved' : 'Save draft'}
+					</button>
 					{isReady && (
 						<button
 							type="button"

--- a/src/renderer/components/FeedbackChatView.tsx
+++ b/src/renderer/components/FeedbackChatView.tsx
@@ -154,8 +154,10 @@ export function FeedbackChatView({
 	const [inputValue, setInputValue] = useState(() => resumeDraft?.inputDraft ?? '');
 	const [isLoading, setIsLoading] = useState(false);
 	const [confidence, setConfidence] = useState(() => resumeDraft?.confidence ?? 0);
-	const [isReady, setIsReady] = useState(false);
-	const [lastResponse, setLastResponse] = useState<FeedbackParsedResponse | null>(null);
+	const [isReady, setIsReady] = useState(() => resumeDraft?.lastResponse?.ready ?? false);
+	const [lastResponse, setLastResponse] = useState<FeedbackParsedResponse | null>(
+		() => resumeDraft?.lastResponse ?? null
+	);
 	const [attachments, setAttachments] = useState<FeedbackAttachment[]>(
 		() => resumeDraft?.attachments ?? []
 	);
@@ -171,6 +173,11 @@ export function FeedbackChatView({
 	const [copiedUrl, setCopiedUrl] = useState(false);
 	const [isSavingDraft, setIsSavingDraft] = useState(false);
 	const [draftSaved, setDraftSaved] = useState(false);
+	// Subscribe so the live snapshot re-publishes with the freshly minted id
+	// after a save (preventing duplicate drafts) and so the editor can surface
+	// draft-save failures.
+	const activeDraftId = useFeedbackDraftStore((s) => s.activeDraftId);
+	const saveError = useFeedbackDraftStore((s) => s.saveError);
 	const lastSearchQueryRef = useRef<string | null>(null);
 	const searchAbortRef = useRef(0); // Monotonic counter to discard stale searches
 
@@ -215,9 +222,14 @@ export function FeedbackChatView({
 				if (mounted) {
 					const available = new Set<string>(agents.filter((a) => a.available).map((a) => a.id));
 					setDetectedAgents(available);
-					// Auto-select first available
+					// Auto-select the first available provider for a fresh editor. When
+					// resuming, keep the saved provider only if it is still available;
+					// otherwise fall back so submit/auto-start does not throw on a
+					// provider that is no longer installed.
 					const firstAvailable = AGENT_TILES.find((t) => t.supported && available.has(t.id));
-					if (firstAvailable && !resumeDraft) setSelectedAgent(firstAvailable.id);
+					if (firstAvailable && (!resumeDraft || !available.has(resumeDraft.agentType))) {
+						setSelectedAgent(firstAvailable.id);
+					}
 					setAgentsLoaded(true);
 				}
 			} catch (error) {
@@ -566,7 +578,7 @@ export function FeedbackChatView({
 		const suggestedName = rawName.trim().slice(0, 60) || 'Untitled feedback';
 		const now = Date.now();
 		return {
-			id: useFeedbackDraftStore.getState().activeDraftId ?? '',
+			id: activeDraftId ?? '',
 			suggestedName,
 			category: lastResponse?.category ?? 'general_feedback',
 			summary: lastResponse?.summary ?? '',
@@ -578,6 +590,7 @@ export function FeedbackChatView({
 			includeDebugPackage,
 			createdAt: now,
 			updatedAt: now,
+			lastResponse,
 		};
 	}, [
 		messages,
@@ -587,6 +600,7 @@ export function FeedbackChatView({
 		confidence,
 		selectedAgent,
 		includeDebugPackage,
+		activeDraftId,
 	]);
 
 	// Keep a live snapshot in the store so FeedbackModal can persist on
@@ -602,9 +616,13 @@ export function FeedbackChatView({
 	const handleSaveDraft = useCallback(async () => {
 		setIsSavingDraft(true);
 		try {
-			await useFeedbackDraftStore.getState().saveDraft(serializeDraft());
-			setDraftSaved(true);
-			window.setTimeout(() => setDraftSaved(false), 2000);
+			const savedId = await useFeedbackDraftStore.getState().saveDraft(serializeDraft());
+			if (savedId !== null) {
+				setDraftSaved(true);
+				window.setTimeout(() => setDraftSaved(false), 2000);
+			}
+			// On failure the store sets `saveError`, surfaced as a banner below;
+			// do not flash "Saved" for a write that did not persist.
 		} finally {
 			setIsSavingDraft(false);
 		}
@@ -1004,6 +1022,15 @@ export function FeedbackChatView({
 						</button>
 					)}
 				</div>
+				{saveError && (
+					<div
+						className="mt-1.5 text-[10px] font-medium"
+						style={{ color: theme.colors.error }}
+						role="alert"
+					>
+						{saveError}
+					</div>
+				)}
 				<div
 					className="h-1.5 rounded-full overflow-hidden"
 					style={{ backgroundColor: theme.colors.border }}

--- a/src/renderer/components/FeedbackDraftsList.tsx
+++ b/src/renderer/components/FeedbackDraftsList.tsx
@@ -1,0 +1,108 @@
+/**
+ * FeedbackDraftsList - Presentational list of persisted, resumable feedback
+ * drafts. Each row shows the suggested name, created/updated times, an
+ * attachment indicator, a resume click target, and a delete button. The
+ * most-recent draft (drafts[0] after the list handler's updatedAt-desc sort)
+ * is highlighted with an accent border.
+ */
+
+import { Paperclip, Trash2, MessageSquarePlus } from 'lucide-react';
+import type { Theme } from '../types';
+import { formatRelativeTime } from '../utils/formatters';
+import type { FeedbackDraft } from '../stores/feedbackDraftStore';
+
+interface FeedbackDraftsListProps {
+	theme: Theme;
+	drafts: FeedbackDraft[];
+	onResume: (id: string) => void;
+	onDelete: (id: string) => void;
+}
+
+export function FeedbackDraftsList({ theme, drafts, onResume, onDelete }: FeedbackDraftsListProps) {
+	if (drafts.length === 0) {
+		return (
+			<div className="flex flex-col items-center justify-center gap-2 py-12 px-6 text-center">
+				<MessageSquarePlus className="w-8 h-8" style={{ color: theme.colors.textDim }} />
+				<p className="text-sm font-semibold" style={{ color: theme.colors.textMain }}>
+					No saved drafts
+				</p>
+				<p className="text-xs leading-relaxed max-w-xs" style={{ color: theme.colors.textDim }}>
+					Drafts you save are kept here so you can resume your feedback later, even after closing
+					Maestro.
+				</p>
+			</div>
+		);
+	}
+
+	return (
+		<div className="flex flex-col gap-2 p-4 overflow-y-auto">
+			{drafts.map((draft, index) => {
+				const isMostRecent = index === 0;
+				return (
+					<div
+						key={draft.id}
+						className="flex items-start gap-3 px-3 py-2.5 rounded-lg border transition-colors"
+						style={{
+							borderColor: isMostRecent ? theme.colors.accent : theme.colors.border,
+							backgroundColor: theme.colors.bgMain,
+						}}
+					>
+						<button
+							type="button"
+							onClick={() => onResume(draft.id)}
+							className="flex-1 min-w-0 text-left transition-opacity hover:opacity-90"
+							title="Resume this draft"
+						>
+							<p
+								className="text-xs font-semibold truncate"
+								style={{ color: theme.colors.textMain }}
+								title={draft.suggestedName || 'Untitled feedback'}
+							>
+								{draft.suggestedName || 'Untitled feedback'}
+							</p>
+							<div className="flex items-center gap-2 mt-0.5 flex-wrap">
+								<span className="text-[10px]" style={{ color: theme.colors.textDim }}>
+									Created {formatRelativeTime(draft.createdAt)}
+								</span>
+								<span className="text-[10px]" style={{ color: theme.colors.textDim }}>
+									Updated {formatRelativeTime(draft.updatedAt)}
+								</span>
+								{draft.attachments.length > 0 && (
+									<span
+										className="flex items-center gap-0.5 text-[10px]"
+										style={{ color: theme.colors.textDim }}
+										title={`${draft.attachments.length} attachment${draft.attachments.length === 1 ? '' : 's'}`}
+									>
+										<Paperclip className="w-3 h-3" />
+										{draft.attachments.length}
+									</span>
+								)}
+								{isMostRecent && (
+									<span
+										className="text-[10px] px-1.5 py-0.5 rounded-full"
+										style={{
+											backgroundColor: `${theme.colors.accent}20`,
+											color: theme.colors.accent,
+										}}
+									>
+										Most recent
+									</span>
+								)}
+							</div>
+						</button>
+						<button
+							type="button"
+							onClick={() => onDelete(draft.id)}
+							className="p-1.5 rounded transition-colors hover:bg-white/5 shrink-0"
+							style={{ color: theme.colors.textDim }}
+							title="Delete draft"
+							aria-label="Delete draft"
+						>
+							<Trash2 className="w-3.5 h-3.5" />
+						</button>
+					</div>
+				);
+			})}
+		</div>
+	);
+}

--- a/src/renderer/components/FeedbackModal.tsx
+++ b/src/renderer/components/FeedbackModal.tsx
@@ -184,10 +184,17 @@ export function FeedbackModal({ theme, sessions, onClose, onSwitchToSession }: F
 	}, [onClose]);
 
 	const handleResume = useCallback(async (id: string) => {
+		const { activeDraft, activeDraftId, saveDraft } = useFeedbackDraftStore.getState();
+		// Clicking the already-active draft is a no-op: remounting the editor from
+		// the persisted copy would silently discard the user's unsaved in-progress
+		// edits, so leave the live editor untouched and just close the list.
+		if (activeDraftId === id) {
+			setShowDrafts(false);
+			return;
+		}
 		// Preserve any unsaved in-progress editor before we unmount it to resume a
 		// different draft, so switching drafts never silently discards work.
-		const { activeDraft, activeDraftId, saveDraft } = useFeedbackDraftStore.getState();
-		if (activeDraft && activeDraftId !== id) {
+		if (activeDraft) {
 			const savedId = await saveDraft(activeDraft);
 			if (savedId === null) {
 				// Saving the current draft failed; stay on the editor and surface

--- a/src/renderer/components/FeedbackModal.tsx
+++ b/src/renderer/components/FeedbackModal.tsx
@@ -1,11 +1,11 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
-import { Minimize2, X } from 'lucide-react';
+import { Minimize2, X, History, ArrowLeft } from 'lucide-react';
 import type { Session, Theme } from '../types';
 import { MODAL_PRIORITIES } from '../constants/modalPriorities';
 import { Modal } from './ui/Modal';
 import { GhostIconButton } from './ui/GhostIconButton';
-import { ConfirmModal } from './ConfirmModal';
 import { FeedbackChatView } from './FeedbackChatView';
+import { FeedbackDraftsList } from './FeedbackDraftsList';
 import { useFeedbackDraftStore } from '../stores/feedbackDraftStore';
 import { useUIStore } from '../stores/uiStore';
 
@@ -45,11 +45,20 @@ export function FeedbackModal({ theme, sessions, onClose, onSwitchToSession }: F
 	const [phase, setPhase] = useState<AnimPhase>('open');
 	const [confirmCloseOpen, setConfirmCloseOpen] = useState(false);
 	const cardRef = useRef<HTMLDivElement>(null);
+	const [showDrafts, setShowDrafts] = useState(false);
+	const [resumeNonce, setResumeNonce] = useState(0);
 
 	const isMinimized = useFeedbackDraftStore((s) => s.isMinimized);
 	const hasDraft = useFeedbackDraftStore((s) => s.hasDraft);
 	const setMinimized = useFeedbackDraftStore((s) => s.setMinimized);
 	const setLeftSidebarOpen = useUIStore((s) => s.setLeftSidebarOpen);
+	const drafts = useFeedbackDraftStore((s) => s.drafts);
+	const resumeDraftId = useFeedbackDraftStore((s) => s.resumeDraftId);
+
+	// Refresh persisted drafts when the modal mounts so the Drafts list is fresh.
+	useEffect(() => {
+		void useFeedbackDraftStore.getState().loadDrafts();
+	}, []);
 
 	// --- Apply / clear animation transforms on the card ---
 	const applyTransform = useCallback((anchor: MinimizeAnchor | null, animate: boolean) => {
@@ -77,6 +86,11 @@ export function FeedbackModal({ theme, sessions, onClose, onSwitchToSession }: F
 
 	// --- Minimize handler ---
 	const handleMinimize = useCallback(() => {
+		// Persist the in-flight draft so it survives an app restart, not just the
+		// in-memory minimized state.
+		const { activeDraft, saveDraft } = useFeedbackDraftStore.getState();
+		if (activeDraft) void saveDraft(activeDraft);
+
 		// Make sure the Feedback button is in the DOM so we have a target.
 		setLeftSidebarOpen(true);
 
@@ -145,10 +159,33 @@ export function FeedbackModal({ theme, sessions, onClose, onSwitchToSession }: F
 		onClose();
 	}, [hasDraft, onClose]);
 
-	const handleConfirmDiscard = useCallback(() => {
+	const handleSaveAndClose = useCallback(async () => {
 		setConfirmCloseOpen(false);
+		const { activeDraft, saveDraft } = useFeedbackDraftStore.getState();
+		if (activeDraft) {
+			await saveDraft(activeDraft);
+		}
 		onClose();
 	}, [onClose]);
+
+	const handleDiscard = useCallback(async () => {
+		setConfirmCloseOpen(false);
+		const { activeDraftId, deleteDraft } = useFeedbackDraftStore.getState();
+		if (activeDraftId) {
+			await deleteDraft(activeDraftId);
+		}
+		onClose();
+	}, [onClose]);
+
+	const handleResume = useCallback((id: string) => {
+		setShowDrafts(false);
+		useFeedbackDraftStore.getState().requestResume(id);
+		setResumeNonce((n) => n + 1);
+	}, []);
+
+	const handleDeleteDraft = useCallback((id: string) => {
+		void useFeedbackDraftStore.getState().deleteDraft(id);
+	}, []);
 
 	const isHidden = phase === 'minimized';
 
@@ -183,6 +220,27 @@ export function FeedbackModal({ theme, sessions, onClose, onSwitchToSession }: F
 							</h2>
 							<div className="flex items-center gap-1">
 								<GhostIconButton
+									onClick={() => setShowDrafts((v) => !v)}
+									ariaLabel="View saved drafts"
+									color={showDrafts ? theme.colors.accent : theme.colors.textDim}
+									title="Saved drafts"
+								>
+									<span className="relative inline-flex">
+										<History className="w-4 h-4" />
+										{drafts.length > 0 && (
+											<span
+												className="absolute -top-2 -right-2 text-[9px] font-bold rounded-full px-1 leading-tight"
+												style={{
+													backgroundColor: theme.colors.accent,
+													color: theme.colors.accentForeground,
+												}}
+											>
+												{drafts.length}
+											</span>
+										)}
+									</span>
+								</GhostIconButton>
+								<GhostIconButton
 									onClick={handleMinimize}
 									ariaLabel="Minimize feedback"
 									color={theme.colors.textDim}
@@ -201,28 +259,99 @@ export function FeedbackModal({ theme, sessions, onClose, onSwitchToSession }: F
 						</div>
 					}
 				>
-					<FeedbackChatView
-						theme={theme}
-						sessions={sessions}
-						onCancel={handleCloseRequest}
-						onWidthChange={setWidth}
-						onSubmitSuccess={(sessionId) => {
-							onSwitchToSession(sessionId);
-							onClose();
-						}}
-					/>
+					<div className="relative flex-1 flex flex-col min-h-0">
+						<FeedbackChatView
+							key={resumeNonce}
+							theme={theme}
+							sessions={sessions}
+							onCancel={handleCloseRequest}
+							onWidthChange={setWidth}
+							resumeDraftId={resumeDraftId}
+							onSubmitSuccess={(sessionId) => {
+								onSwitchToSession(sessionId);
+								onClose();
+							}}
+						/>
+						{showDrafts && (
+							<div
+								className="absolute inset-0 z-10 flex flex-col"
+								style={{ backgroundColor: theme.colors.bgSidebar }}
+							>
+								<div
+									className="flex items-center gap-2 p-3 border-b shrink-0"
+									style={{ borderColor: theme.colors.border }}
+								>
+									<GhostIconButton
+										onClick={() => setShowDrafts(false)}
+										ariaLabel="Back to feedback"
+										color={theme.colors.textDim}
+										title="Back"
+									>
+										<ArrowLeft className="w-4 h-4" />
+									</GhostIconButton>
+									<span className="text-xs font-bold" style={{ color: theme.colors.textMain }}>
+										Saved Drafts
+									</span>
+								</div>
+								<div className="flex-1 min-h-0 overflow-y-auto">
+									<FeedbackDraftsList
+										theme={theme}
+										drafts={drafts}
+										onResume={handleResume}
+										onDelete={handleDeleteDraft}
+									/>
+								</div>
+							</div>
+						)}
+					</div>
 				</Modal>
 			</div>
 			{confirmCloseOpen && (
-				<ConfirmModal
+				<Modal
 					theme={theme}
-					title="Discard Feedback?"
-					message="Closing will discard your in-progress feedback. Use Minimize if you want to keep it for later."
-					confirmLabel="Discard"
-					destructive
-					onConfirm={handleConfirmDiscard}
+					title="Save this draft?"
+					priority={MODAL_PRIORITIES.CONFIRM}
 					onClose={() => setConfirmCloseOpen(false)}
-				/>
+					width={460}
+					zIndex={10000}
+					footer={
+						<>
+							<button
+								type="button"
+								onClick={handleDiscard}
+								className="px-4 py-2 rounded border transition-colors hover:bg-white/5"
+								style={{ borderColor: theme.colors.border, color: theme.colors.error }}
+							>
+								Discard
+							</button>
+							<div className="flex-1" />
+							<button
+								type="button"
+								onClick={() => setConfirmCloseOpen(false)}
+								className="px-4 py-2 rounded border transition-colors hover:bg-white/5"
+								style={{ borderColor: theme.colors.border, color: theme.colors.textMain }}
+							>
+								Keep editing
+							</button>
+							<button
+								type="button"
+								onClick={handleSaveAndClose}
+								className="px-4 py-2 rounded transition-colors hover:opacity-90"
+								style={{
+									backgroundColor: theme.colors.accent,
+									color: theme.colors.accentForeground,
+								}}
+							>
+								Save & Close
+							</button>
+						</>
+					}
+				>
+					<p className="leading-relaxed text-sm" style={{ color: theme.colors.textMain }}>
+						Keep your in-progress feedback as a resumable draft, or discard it. Saved drafts can be
+						resumed from the Drafts list later.
+					</p>
+				</Modal>
 			)}
 		</>
 	);

--- a/src/renderer/components/FeedbackModal.tsx
+++ b/src/renderer/components/FeedbackModal.tsx
@@ -85,11 +85,15 @@ export function FeedbackModal({ theme, sessions, onClose, onSwitchToSession }: F
 	}, []);
 
 	// --- Minimize handler ---
-	const handleMinimize = useCallback(() => {
+	const handleMinimize = useCallback(async () => {
 		// Persist the in-flight draft so it survives an app restart, not just the
-		// in-memory minimized state.
+		// in-memory minimized state. If the write fails, do NOT minimize (which
+		// would hide the failure); keep the modal open so the error surfaces.
 		const { activeDraft, saveDraft } = useFeedbackDraftStore.getState();
-		if (activeDraft) void saveDraft(activeDraft);
+		if (activeDraft) {
+			const savedId = await saveDraft(activeDraft);
+			if (savedId === null) return;
+		}
 
 		// Make sure the Feedback button is in the DOM so we have a target.
 		setLeftSidebarOpen(true);
@@ -163,21 +167,35 @@ export function FeedbackModal({ theme, sessions, onClose, onSwitchToSession }: F
 		setConfirmCloseOpen(false);
 		const { activeDraft, saveDraft } = useFeedbackDraftStore.getState();
 		if (activeDraft) {
-			await saveDraft(activeDraft);
+			const savedId = await saveDraft(activeDraft);
+			// Persist failed: keep the modal open (the editor surfaces the error)
+			// instead of closing and losing the in-memory draft.
+			if (savedId === null) return;
 		}
 		onClose();
 	}, [onClose]);
 
-	const handleDiscard = useCallback(async () => {
+	const handleDiscard = useCallback(() => {
+		// "Discard" abandons the unsaved in-progress edits and closes. It must NOT
+		// delete an already-saved draft: a resumed draft keeps its last saved
+		// state, and deletion is an explicit action from the Drafts list.
 		setConfirmCloseOpen(false);
-		const { activeDraftId, deleteDraft } = useFeedbackDraftStore.getState();
-		if (activeDraftId) {
-			await deleteDraft(activeDraftId);
-		}
 		onClose();
 	}, [onClose]);
 
-	const handleResume = useCallback((id: string) => {
+	const handleResume = useCallback(async (id: string) => {
+		// Preserve any unsaved in-progress editor before we unmount it to resume a
+		// different draft, so switching drafts never silently discards work.
+		const { activeDraft, activeDraftId, saveDraft } = useFeedbackDraftStore.getState();
+		if (activeDraft && activeDraftId !== id) {
+			const savedId = await saveDraft(activeDraft);
+			if (savedId === null) {
+				// Saving the current draft failed; stay on the editor and surface
+				// the error rather than dropping the user's work.
+				setShowDrafts(false);
+				return;
+			}
+		}
 		setShowDrafts(false);
 		useFeedbackDraftStore.getState().requestResume(id);
 		setResumeNonce((n) => n + 1);

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -684,6 +684,19 @@ interface MaestroAPI {
 					includeDebugPackage: boolean;
 					createdAt: number;
 					updatedAt: number;
+					lastResponse?: {
+						confidence: number;
+						ready: boolean;
+						message: string;
+						category: 'bug_report' | 'feature_request' | 'improvement' | 'general_feedback';
+						summary: string;
+						structured: {
+							expectedBehavior: string;
+							actualBehavior: string;
+							reproductionSteps: string;
+							additionalContext: string;
+						};
+					} | null;
 				}>;
 			}>;
 			save: (draft: {
@@ -706,6 +719,19 @@ interface MaestroAPI {
 				includeDebugPackage: boolean;
 				createdAt: number;
 				updatedAt: number;
+				lastResponse?: {
+					confidence: number;
+					ready: boolean;
+					message: string;
+					category: 'bug_report' | 'feature_request' | 'improvement' | 'general_feedback';
+					summary: string;
+					structured: {
+						expectedBehavior: string;
+						actualBehavior: string;
+						reproductionSteps: string;
+						additionalContext: string;
+					};
+				} | null;
 			}) => Promise<{
 				draft: {
 					id: string;
@@ -727,6 +753,19 @@ interface MaestroAPI {
 					includeDebugPackage: boolean;
 					createdAt: number;
 					updatedAt: number;
+					lastResponse?: {
+						confidence: number;
+						ready: boolean;
+						message: string;
+						category: 'bug_report' | 'feature_request' | 'improvement' | 'general_feedback';
+						summary: string;
+						structured: {
+							expectedBehavior: string;
+							actualBehavior: string;
+							reproductionSteps: string;
+							additionalContext: string;
+						};
+					} | null;
 				};
 			}>;
 			delete: (id: string) => Promise<Record<string, never>>;

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -662,6 +662,75 @@ interface MaestroAPI {
 			issueNumber: number,
 			comment?: string
 		) => Promise<{ success: boolean; error?: string }>;
+		drafts: {
+			list: () => Promise<{
+				drafts: Array<{
+					id: string;
+					suggestedName: string;
+					category: 'bug_report' | 'feature_request' | 'improvement' | 'general_feedback';
+					summary: string;
+					confidence: number;
+					agentType: string;
+					messages: Array<{
+						role: 'user' | 'assistant' | 'system';
+						content: string;
+						timestamp: number;
+						confidence?: number;
+						category?: 'bug_report' | 'feature_request' | 'improvement' | 'general_feedback';
+						summary?: string;
+					}>;
+					attachments: Array<{ id: string; name: string; dataUrl: string; sizeBytes: number }>;
+					inputDraft: string;
+					includeDebugPackage: boolean;
+					createdAt: number;
+					updatedAt: number;
+				}>;
+			}>;
+			save: (draft: {
+				id: string;
+				suggestedName: string;
+				category: 'bug_report' | 'feature_request' | 'improvement' | 'general_feedback';
+				summary: string;
+				confidence: number;
+				agentType: string;
+				messages: Array<{
+					role: 'user' | 'assistant' | 'system';
+					content: string;
+					timestamp: number;
+					confidence?: number;
+					category?: 'bug_report' | 'feature_request' | 'improvement' | 'general_feedback';
+					summary?: string;
+				}>;
+				attachments: Array<{ id: string; name: string; dataUrl: string; sizeBytes: number }>;
+				inputDraft: string;
+				includeDebugPackage: boolean;
+				createdAt: number;
+				updatedAt: number;
+			}) => Promise<{
+				draft: {
+					id: string;
+					suggestedName: string;
+					category: 'bug_report' | 'feature_request' | 'improvement' | 'general_feedback';
+					summary: string;
+					confidence: number;
+					agentType: string;
+					messages: Array<{
+						role: 'user' | 'assistant' | 'system';
+						content: string;
+						timestamp: number;
+						confidence?: number;
+						category?: 'bug_report' | 'feature_request' | 'improvement' | 'general_feedback';
+						summary?: string;
+					}>;
+					attachments: Array<{ id: string; name: string; dataUrl: string; sizeBytes: number }>;
+					inputDraft: string;
+					includeDebugPackage: boolean;
+					createdAt: number;
+					updatedAt: number;
+				};
+			}>;
+			delete: (id: string) => Promise<Record<string, never>>;
+		};
 	};
 	agentError: {
 		clearError: (sessionId: string) => Promise<{ success: boolean }>;

--- a/src/renderer/hooks/modal/useModalHandlers.ts
+++ b/src/renderer/hooks/modal/useModalHandlers.ts
@@ -501,6 +501,8 @@ export function useModalHandlers(
 		// If the modal is minimized to the sidebar Feedback button, restore it
 		// instead of opening a fresh one (preserves the in-flight draft).
 		const draft = useFeedbackDraftStore.getState();
+		// Refresh the persisted drafts list so it is current when the modal opens.
+		void draft.loadDrafts();
 		if (draft.isMinimized) {
 			draft.setMinimized(false);
 			return;

--- a/src/renderer/stores/feedbackDraftStore.ts
+++ b/src/renderer/stores/feedbackDraftStore.ts
@@ -70,6 +70,10 @@ interface FeedbackDraftState {
 	reset: () => void;
 }
 
+// Tracks the in-flight save of a brand-new (unsaved) draft so concurrent first
+// saves reuse the minted id instead of each creating a duplicate draft row.
+let pendingNewDraftSave: Promise<string | null> | null = null;
+
 export const useFeedbackDraftStore = create<FeedbackDraftState>((set, get) => ({
 	isMinimized: false,
 	hasDraft: false,
@@ -90,22 +94,51 @@ export const useFeedbackDraftStore = create<FeedbackDraftState>((set, get) => ({
 		}
 	},
 	saveDraft: async (draft) => {
+		// A brand-new draft (no persisted id yet) can be saved from several
+		// paths at once - the Save Draft button plus minimize/Save & Close -
+		// before the first save resolves and patches the active id. Each such
+		// call would otherwise reach the IPC handler with an empty id, which
+		// mints a fresh UUID per call and creates a DUPLICATE row. Serialize
+		// new-draft saves: the first mints the id; a concurrent save reuses it
+		// to upsert the same row instead of creating another.
+		const isNewDraft = !draft.id;
+		if (isNewDraft && pendingNewDraftSave) {
+			const mintedId = await pendingNewDraftSave;
+			if (mintedId) {
+				return get().saveDraft({ ...draft, id: mintedId });
+			}
+			// The in-flight first save failed; fall through and retry as new.
+		}
+		const run = async (): Promise<string | null> => {
+			try {
+				const { draft: saved } = await window.maestro.feedback.drafts.save(draft);
+				await get().loadDrafts();
+				set((state) => ({
+					activeDraftId: saved.id,
+					// Patch the live snapshot's id too, so a later save/minimize without
+					// an intervening edit upserts this draft instead of duplicating it.
+					activeDraft: state.activeDraft
+						? { ...state.activeDraft, id: saved.id }
+						: state.activeDraft,
+					saveError: null,
+				}));
+				return saved.id;
+			} catch {
+				// Surface the failure so callers do NOT report success or close the
+				// modal while the draft only lives in memory.
+				set({ saveError: 'Could not save your draft. Your changes are still here; try again.' });
+				return null;
+			}
+		};
+		if (!isNewDraft) {
+			return run();
+		}
+		const pending = run();
+		pendingNewDraftSave = pending;
 		try {
-			const { draft: saved } = await window.maestro.feedback.drafts.save(draft);
-			await get().loadDrafts();
-			set((state) => ({
-				activeDraftId: saved.id,
-				// Patch the live snapshot's id too, so a later save/minimize without
-				// an intervening edit upserts this draft instead of duplicating it.
-				activeDraft: state.activeDraft ? { ...state.activeDraft, id: saved.id } : state.activeDraft,
-				saveError: null,
-			}));
-			return saved.id;
-		} catch {
-			// Surface the failure so callers do NOT report success or close the
-			// modal while the draft only lives in memory.
-			set({ saveError: 'Could not save your draft. Your changes are still here; try again.' });
-			return null;
+			return await pending;
+		} finally {
+			if (pendingNewDraftSave === pending) pendingNewDraftSave = null;
 		}
 	},
 	deleteDraft: async (id) => {

--- a/src/renderer/stores/feedbackDraftStore.ts
+++ b/src/renderer/stores/feedbackDraftStore.ts
@@ -8,7 +8,7 @@
  */
 
 import { create } from 'zustand';
-import type { FeedbackMessage } from '../services/feedbackConversation';
+import type { FeedbackMessage, FeedbackParsedResponse } from '../services/feedbackConversation';
 
 export type FeedbackDraftCategory =
 	| 'bug_report'
@@ -36,6 +36,8 @@ export interface FeedbackDraft {
 	includeDebugPackage: boolean;
 	createdAt: number;
 	updatedAt: number;
+	/** Parsed submit-ready response, persisted so a resumed draft stays submittable */
+	lastResponse?: FeedbackParsedResponse | null;
 }
 
 interface FeedbackDraftState {
@@ -51,6 +53,8 @@ interface FeedbackDraftState {
 	activeDraftId: string | null;
 	/** Live in-memory snapshot of the open editor, published by FeedbackChatView */
 	activeDraft: FeedbackDraft | null;
+	/** Last draft-save error, surfaced by the editor; null when the last save succeeded */
+	saveError: string | null;
 	setMinimized: (minimized: boolean) => void;
 	setHasDraft: (hasDraft: boolean) => void;
 	setActiveDraft: (draft: FeedbackDraft | null) => void;
@@ -73,6 +77,7 @@ export const useFeedbackDraftStore = create<FeedbackDraftState>((set, get) => ({
 	resumeDraftId: null,
 	activeDraftId: null,
 	activeDraft: null,
+	saveError: null,
 	setMinimized: (minimized) => set({ isMinimized: minimized }),
 	setHasDraft: (hasDraft) => set({ hasDraft }),
 	setActiveDraft: (draft) => set({ activeDraft: draft }),
@@ -88,9 +93,18 @@ export const useFeedbackDraftStore = create<FeedbackDraftState>((set, get) => ({
 		try {
 			const { draft: saved } = await window.maestro.feedback.drafts.save(draft);
 			await get().loadDrafts();
-			set({ activeDraftId: saved.id });
+			set((state) => ({
+				activeDraftId: saved.id,
+				// Patch the live snapshot's id too, so a later save/minimize without
+				// an intervening edit upserts this draft instead of duplicating it.
+				activeDraft: state.activeDraft ? { ...state.activeDraft, id: saved.id } : state.activeDraft,
+				saveError: null,
+			}));
 			return saved.id;
 		} catch {
+			// Surface the failure so callers do NOT report success or close the
+			// modal while the draft only lives in memory.
+			set({ saveError: 'Could not save your draft. Your changes are still here; try again.' });
 			return null;
 		}
 	},
@@ -114,5 +128,6 @@ export const useFeedbackDraftStore = create<FeedbackDraftState>((set, get) => ({
 			activeDraft: null,
 			activeDraftId: null,
 			resumeDraftId: null,
+			saveError: null,
 		}),
 }));

--- a/src/renderer/stores/feedbackDraftStore.ts
+++ b/src/renderer/stores/feedbackDraftStore.ts
@@ -8,21 +8,111 @@
  */
 
 import { create } from 'zustand';
+import type { FeedbackMessage } from '../services/feedbackConversation';
+
+export type FeedbackDraftCategory =
+	| 'bug_report'
+	| 'feature_request'
+	| 'improvement'
+	| 'general_feedback';
+
+export interface FeedbackDraftAttachment {
+	id: string;
+	name: string;
+	dataUrl: string;
+	sizeBytes: number;
+}
+
+export interface FeedbackDraft {
+	id: string;
+	suggestedName: string;
+	category: FeedbackDraftCategory;
+	summary: string;
+	confidence: number;
+	agentType: string;
+	messages: FeedbackMessage[];
+	attachments: FeedbackDraftAttachment[];
+	inputDraft: string;
+	includeDebugPackage: boolean;
+	createdAt: number;
+	updatedAt: number;
+}
 
 interface FeedbackDraftState {
 	/** Modal is minimized to the sidebar Feedback button (still mounted, hidden) */
 	isMinimized: boolean;
 	/** User has typed, attached, or exchanged at least one message */
 	hasDraft: boolean;
+	/** Persisted drafts, most-recently-updated first (drafts[0] is most recent) */
+	drafts: FeedbackDraft[];
+	/** A draft the user asked to resume; consumed by FeedbackChatView on mount */
+	resumeDraftId: string | null;
+	/** id of the draft the open editor maps to once it has been persisted */
+	activeDraftId: string | null;
+	/** Live in-memory snapshot of the open editor, published by FeedbackChatView */
+	activeDraft: FeedbackDraft | null;
 	setMinimized: (minimized: boolean) => void;
 	setHasDraft: (hasDraft: boolean) => void;
+	setActiveDraft: (draft: FeedbackDraft | null) => void;
+	/** Refresh the persisted drafts list from disk */
+	loadDrafts: () => Promise<void>;
+	/** Upsert a draft, refresh the list, and return its persisted id */
+	saveDraft: (draft: FeedbackDraft) => Promise<string | null>;
+	/** Delete a draft by id and refresh the list */
+	deleteDraft: (id: string) => Promise<void>;
+	requestResume: (id: string) => void;
+	clearResume: () => void;
+	/** Clear ephemeral session state; the persisted drafts list is preserved */
 	reset: () => void;
 }
 
-export const useFeedbackDraftStore = create<FeedbackDraftState>((set) => ({
+export const useFeedbackDraftStore = create<FeedbackDraftState>((set, get) => ({
 	isMinimized: false,
 	hasDraft: false,
+	drafts: [],
+	resumeDraftId: null,
+	activeDraftId: null,
+	activeDraft: null,
 	setMinimized: (minimized) => set({ isMinimized: minimized }),
 	setHasDraft: (hasDraft) => set({ hasDraft }),
-	reset: () => set({ isMinimized: false, hasDraft: false }),
+	setActiveDraft: (draft) => set({ activeDraft: draft }),
+	loadDrafts: async () => {
+		try {
+			const { drafts } = await window.maestro.feedback.drafts.list();
+			set({ drafts });
+		} catch {
+			// Leave the existing list in place if the read fails.
+		}
+	},
+	saveDraft: async (draft) => {
+		try {
+			const { draft: saved } = await window.maestro.feedback.drafts.save(draft);
+			await get().loadDrafts();
+			set({ activeDraftId: saved.id });
+			return saved.id;
+		} catch {
+			return null;
+		}
+	},
+	deleteDraft: async (id) => {
+		try {
+			await window.maestro.feedback.drafts.delete(id);
+		} catch {
+			// Refresh below regardless so the list reflects reality.
+		}
+		await get().loadDrafts();
+		set((state) => ({
+			activeDraftId: state.activeDraftId === id ? null : state.activeDraftId,
+		}));
+	},
+	requestResume: (id) => set({ resumeDraftId: id }),
+	clearResume: () => set({ resumeDraftId: null }),
+	reset: () =>
+		set({
+			isMinimized: false,
+			hasDraft: false,
+			activeDraft: null,
+			activeDraftId: null,
+			resumeDraftId: null,
+		}),
 }));


### PR DESCRIPTION
## Summary

Closes #756. Send Feedback drafts now persist across modal/app close and become a browsable, resumable list with metadata and attachments. Previously a draft was only ephemeral in-memory React state.

## Changes

- New `feedback:drafts:list|save|delete` IPC handlers backed by a `userData` JSON file (mirrors the playbooks persistence pattern: `crypto.randomUUID` ids, createdAt/updatedAt, upsert-by-id, capped, sorted by `updatedAt` desc).
- All four `window.maestro.feedback` lockstep touch-points updated: preload `FeedbackApi`, the inline `global.d.ts` literal, the store, and the test setup mock.
- `feedbackDraftStore` extended with `loadDrafts`/`saveDraft`/`deleteDraft`/resume tracking; `reset()` now clears only ephemeral session state and preserves the drafts list.
- New `FeedbackDraftsList` overlay (suggested name, created/updated times, attachment indicator, resume/delete), a Drafts header button with count badge in `FeedbackModal`, resume wiring, and a save-or-discard close dialog.

## Verification

- `npm run lint` (tsc x3): clean
- `vitest run`: IPC handler, preload, store, and view tests: 38 tests pass
- `eslint` + `prettier`: clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added saved feedback drafts with resume, edit, and delete capabilities in the feedback modal.
  * Introduced a drafts sidebar to view recent drafts (including attachments) and quickly resume or remove them.
  * Added draft persistence with “Save draft” and automatic snapshotting during minimize/close flows.
* **Bug Fixes**
  * Improved draft recovery by normalizing and clamping saved content and restoring last-response readiness state.
  * Added robust handling for concurrent saves to prevent duplicate or lost drafts.
* **Tests**
  * Expanded coverage for IPC, preload API, store logic, and UI draft-resume behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->