### PR TITLE
feat(tabs): scroll tab strip with the mouse wheel

### DIFF
--- a/src/renderer/components/Settings/searchableSettings.ts
+++ b/src/renderer/components/Settings/searchableSettings.ts
@@ -788,7 +788,7 @@ export const DISPLAY_SETTINGS: SearchableSetting[] = [
 		tabLabel: 'Display',
 		label: 'Tab Options',
 		description:
-			'Show starred and file preview tabs when filtering by unread; Command+0 vs Command+9 last-tab shortcut; browser tab domain pill',
+			'Show starred and file preview tabs when filtering by unread; Command+0 vs Command+9 last-tab shortcut; browser tab domain pill; scroll tabs with the mouse wheel',
 		keywords: [
 			'tab',
 			'filter',
@@ -811,6 +811,13 @@ export const DISPLAY_SETTINGS: SearchableSetting[] = [
 			'hostname',
 			'url',
 			'pill',
+			'wheel',
+			'mouse wheel',
+			'scroll',
+			'scroll tabs',
+			'pan',
+			'tab bar',
+			'tab strip',
 		],
 	},
 	{

--- a/src/renderer/components/Settings/tabs/DisplayTab/DisplayTab.tsx
+++ b/src/renderer/components/Settings/tabs/DisplayTab/DisplayTab.tsx
@@ -134,6 +134,8 @@ export function DisplayTab({ theme }: DisplayTabProps) {
 				setUseCmd0AsLastTab={settings.setUseCmd0AsLastTab}
 				showBrowserTabDomain={settings.showBrowserTabDomain}
 				setShowBrowserTabDomain={settings.setShowBrowserTabDomain}
+				tabBarWheelScroll={settings.tabBarWheelScroll}
+				setTabBarWheelScroll={settings.setTabBarWheelScroll}
 			/>
 			<DocumentGraphSection
 				theme={theme}

--- a/src/renderer/components/Settings/tabs/DisplayTab/components/TabOptionsSection.tsx
+++ b/src/renderer/components/Settings/tabs/DisplayTab/components/TabOptionsSection.tsx
@@ -82,7 +82,7 @@ export function TabOptionsSection({
 				<ToggleSettingRow
 					theme={theme}
 					title="Scroll tabs with the mouse wheel"
-					description="When the tab strip overflows, hover over it and scroll the mouse wheel to pan the tabs left and right. Disable to ignore the wheel over the tab bar."
+					description="When the tab strip overflows, hover over it and scroll the mouse wheel to pan the tabs left and right. Disable to stop translating vertical wheel movement into tab scrolling; native horizontal gestures like trackpad swipes are unaffected."
 					checked={tabBarWheelScroll}
 					onChange={setTabBarWheelScroll}
 					ariaLabel="Scroll tabs with the mouse wheel"

--- a/src/renderer/components/Settings/tabs/DisplayTab/components/TabOptionsSection.tsx
+++ b/src/renderer/components/Settings/tabs/DisplayTab/components/TabOptionsSection.tsx
@@ -15,6 +15,8 @@ interface TabOptionsSectionProps {
 	setUseCmd0AsLastTab: (enabled: boolean) => void;
 	showBrowserTabDomain: boolean;
 	setShowBrowserTabDomain: (enabled: boolean) => void;
+	tabBarWheelScroll: boolean;
+	setTabBarWheelScroll: (enabled: boolean) => void;
 }
 
 export function TabOptionsSection({
@@ -27,6 +29,8 @@ export function TabOptionsSection({
 	setUseCmd0AsLastTab,
 	showBrowserTabDomain,
 	setShowBrowserTabDomain,
+	tabBarWheelScroll,
+	setTabBarWheelScroll,
 }: TabOptionsSectionProps) {
 	const shortcutPrefix = isMacOS() ? 'Command' : 'Ctrl';
 
@@ -73,6 +77,15 @@ export function TabOptionsSection({
 					checked={showBrowserTabDomain}
 					onChange={setShowBrowserTabDomain}
 					ariaLabel="Show domain on browser tabs"
+					borderTop
+				/>
+				<ToggleSettingRow
+					theme={theme}
+					title="Scroll tabs with the mouse wheel"
+					description="When the tab strip overflows, hover over it and scroll the mouse wheel to pan the tabs left and right. Disable to ignore the wheel over the tab bar."
+					checked={tabBarWheelScroll}
+					onChange={setTabBarWheelScroll}
+					ariaLabel="Scroll tabs with the mouse wheel"
 					borderTop
 				/>
 			</SectionCard>

--- a/src/renderer/components/TabBar/TabBar.tsx
+++ b/src/renderer/components/TabBar/TabBar.tsx
@@ -21,6 +21,7 @@ import { NewTabPopover } from './NewTabPopover';
 import { SearchPopover } from './SearchPopover';
 import { isUnifiedTabActive, getShortcutHint } from './tabBarUtils';
 import { buildFileTabDisplayNames } from '../../hooks/tabs/internal/filePreviewTabHelpers';
+import { useEventListener } from '../../hooks/utils/useEventListener';
 import { useWindowOwnsSession } from '../../contexts/WindowContext';
 import type { TabBarProps } from './types';
 import { logger } from '../../utils/logger';
@@ -192,22 +193,30 @@ function TabBarInner({
 	// Pan the horizontally-overflowing tab strip with the mouse wheel. A plain
 	// vertical wheel (deltaY) is translated into horizontal scroll, matching the
 	// VS Code convention; trackpads and Shift+wheel emit deltaX, so we follow
-	// whichever axis the device reports. Attached as a native, non-passive
-	// listener because React's synthetic onWheel runs passively and cannot call
-	// preventDefault — without it the wheel would also scroll an outer container.
-	useEffect(() => {
-		const el = tabBarRef.current;
-		if (!el || !tabBarWheelScroll) return;
-		const handleWheel = (e: WheelEvent) => {
-			if (el.scrollWidth <= el.clientWidth) return; // nothing to pan
+	// whichever axis the device reports. Bound with passive: false because the
+	// handler calls preventDefault(), which passive wheel listeners (the browser
+	// default, and React's synthetic onWheel) are not allowed to do.
+	useEventListener(
+		'wheel',
+		(event) => {
+			const el = tabBarRef.current;
+			if (!el) return;
+			const e = event as WheelEvent;
 			const delta = Math.abs(e.deltaX) > Math.abs(e.deltaY) ? e.deltaX : e.deltaY;
 			if (delta === 0) return;
+			// Only claim the event when the strip can actually move in the delta's
+			// direction. At a clamped edge (or with no overflow at all) the wheel
+			// falls through to the surrounding content instead of being swallowed.
+			// The 1px slack absorbs fractional scrollLeft values.
+			const maxScrollLeft = el.scrollWidth - el.clientWidth;
+			const canPan =
+				maxScrollLeft > 0 && (delta > 0 ? el.scrollLeft < maxScrollLeft - 1 : el.scrollLeft > 1);
+			if (!canPan) return;
 			el.scrollLeft += delta;
 			e.preventDefault();
-		};
-		el.addEventListener('wheel', handleWheel, { passive: false });
-		return () => el.removeEventListener('wheel', handleWheel);
-	}, [tabBarWheelScroll]);
+		},
+		{ target: tabBarRef.current, enabled: tabBarWheelScroll, passive: false }
+	);
 
 	// Filter tabs for display. Memoized so the filter only re-runs when the
 	// inputs actually change - without this, every TabBar render (e.g. on input

--- a/src/renderer/components/TabBar/TabBar.tsx
+++ b/src/renderer/components/TabBar/TabBar.tsx
@@ -124,6 +124,7 @@ function TabBarInner({
 	const showStarredInUnreadFilter = useSettingsStore((s) => s.showStarredInUnreadFilter);
 	const showFilePreviewsInUnreadFilter = useSettingsStore((s) => s.showFilePreviewsInUnreadFilter);
 	const useCmd0AsLastTab = useSettingsStore((s) => s.useCmd0AsLastTab);
+	const tabBarWheelScroll = useSettingsStore((s) => s.tabBarWheelScroll);
 
 	const tabBarRef = useRef<HTMLDivElement>(null);
 	const stickyLeftRef = useRef<HTMLDivElement>(null);
@@ -187,6 +188,26 @@ function TabBarInner({
 		activeTabName,
 		showUnreadOnly,
 	]);
+
+	// Pan the horizontally-overflowing tab strip with the mouse wheel. A plain
+	// vertical wheel (deltaY) is translated into horizontal scroll, matching the
+	// VS Code convention; trackpads and Shift+wheel emit deltaX, so we follow
+	// whichever axis the device reports. Attached as a native, non-passive
+	// listener because React's synthetic onWheel runs passively and cannot call
+	// preventDefault — without it the wheel would also scroll an outer container.
+	useEffect(() => {
+		const el = tabBarRef.current;
+		if (!el || !tabBarWheelScroll) return;
+		const handleWheel = (e: WheelEvent) => {
+			if (el.scrollWidth <= el.clientWidth) return; // nothing to pan
+			const delta = Math.abs(e.deltaX) > Math.abs(e.deltaY) ? e.deltaX : e.deltaY;
+			if (delta === 0) return;
+			el.scrollLeft += delta;
+			e.preventDefault();
+		};
+		el.addEventListener('wheel', handleWheel, { passive: false });
+		return () => el.removeEventListener('wheel', handleWheel);
+	}, [tabBarWheelScroll]);
 
 	// Filter tabs for display. Memoized so the filter only re-runs when the
 	// inputs actually change - without this, every TabBar render (e.g. on input

--- a/src/renderer/hooks/settings/useSettings.ts
+++ b/src/renderer/hooks/settings/useSettings.ts
@@ -284,6 +284,8 @@ export interface UseSettingsReturn {
 	setUseCmd0AsLastTab: (value: boolean) => void;
 	showBrowserTabDomain: boolean;
 	setShowBrowserTabDomain: (value: boolean) => void;
+	tabBarWheelScroll: boolean;
+	setTabBarWheelScroll: (value: boolean) => void;
 
 	// Document Graph settings
 	documentGraphShowExternalLinks: boolean;

--- a/src/renderer/hooks/utils/useEventListener.ts
+++ b/src/renderer/hooks/utils/useEventListener.ts
@@ -25,6 +25,13 @@ export interface UseEventListenerOptions {
 	 * `false` re-attaches / detaches the listener cleanly. Defaults to `true`.
 	 */
 	enabled?: boolean;
+	/**
+	 * Passed through as `AddEventListenerOptions.passive`. Set to `false` for
+	 * handlers that must call `preventDefault()` on events browsers treat as
+	 * passive by default (wheel, touchstart, touchmove). Left undefined, the
+	 * browser default applies.
+	 */
+	passive?: boolean;
 }
 
 /**
@@ -50,7 +57,11 @@ export function useEventListener(
 	handler: (event: Event) => void,
 	options?: UseEventListenerOptions
 ): void {
-	const { target = typeof window !== 'undefined' ? window : null, enabled = true } = options ?? {};
+	const {
+		target = typeof window !== 'undefined' ? window : null,
+		enabled = true,
+		passive,
+	} = options ?? {};
 
 	// Keep a stable ref to the handler so the effect only re-runs when
 	// eventType / target / enabled change, not on every render where the
@@ -61,9 +72,10 @@ export function useEventListener(
 	useEffect(() => {
 		if (!enabled || !target) return;
 		const listener = (event: Event) => handlerRef.current(event);
-		target.addEventListener(eventType, listener);
+		const listenerOptions = passive === undefined ? undefined : { passive };
+		target.addEventListener(eventType, listener, listenerOptions);
 		return () => {
 			target.removeEventListener(eventType, listener);
 		};
-	}, [eventType, target, enabled]);
+	}, [eventType, target, enabled, passive]);
 }

--- a/src/renderer/stores/settingsStore.ts
+++ b/src/renderer/stores/settingsStore.ts
@@ -389,6 +389,7 @@ export interface SettingsStoreState {
 	showFilePreviewsInUnreadFilter: boolean;
 	useCmd0AsLastTab: boolean;
 	showBrowserTabDomain: boolean;
+	tabBarWheelScroll: boolean;
 	documentGraphShowExternalLinks: boolean;
 	documentGraphMaxNodes: number;
 	documentGraphPreviewCharLimit: number;
@@ -542,6 +543,7 @@ export interface SettingsStoreActions {
 	setShowFilePreviewsInUnreadFilter: (value: boolean) => void;
 	setUseCmd0AsLastTab: (value: boolean) => void;
 	setShowBrowserTabDomain: (value: boolean) => void;
+	setTabBarWheelScroll: (value: boolean) => void;
 	setDocumentGraphShowExternalLinks: (value: boolean) => void;
 	setDocumentGraphMaxNodes: (value: number) => void;
 	setDocumentGraphPreviewCharLimit: (value: number) => void;
@@ -805,6 +807,7 @@ export const useSettingsStore = create<SettingsStore>()((set, get) => {
 		showFilePreviewsInUnreadFilter: false,
 		useCmd0AsLastTab: true,
 		showBrowserTabDomain: true,
+		tabBarWheelScroll: true,
 		documentGraphShowExternalLinks: false,
 		documentGraphMaxNodes: 50,
 		documentGraphPreviewCharLimit: 100,
@@ -1312,6 +1315,11 @@ export const useSettingsStore = create<SettingsStore>()((set, get) => {
 		setUseCmd0AsLastTab: (value) => {
 			set({ useCmd0AsLastTab: value });
 			window.maestro.settings.set('useCmd0AsLastTab', value);
+		},
+
+		setTabBarWheelScroll: (value) => {
+			set({ tabBarWheelScroll: value });
+			window.maestro.settings.set('tabBarWheelScroll', value);
 		},
 
 		setShowBrowserTabDomain: (value) => {
@@ -2691,6 +2699,9 @@ export async function loadAllSettings(): Promise<void> {
 
 		if (allSettings['showBrowserTabDomain'] !== undefined)
 			patch.showBrowserTabDomain = allSettings['showBrowserTabDomain'] as boolean;
+
+		if (allSettings['tabBarWheelScroll'] !== undefined)
+			patch.tabBarWheelScroll = allSettings['tabBarWheelScroll'] as boolean;
 
 		// Document Graph settings (with validation)
 		if (allSettings['documentGraphShowExternalLinks'] !== undefined)

--- a/src/renderer/stores/settingsStore.ts
+++ b/src/renderer/stores/settingsStore.ts
@@ -2700,8 +2700,8 @@ export async function loadAllSettings(): Promise<void> {
 		if (allSettings['showBrowserTabDomain'] !== undefined)
 			patch.showBrowserTabDomain = allSettings['showBrowserTabDomain'] as boolean;
 
-		if (allSettings['tabBarWheelScroll'] !== undefined)
-			patch.tabBarWheelScroll = allSettings['tabBarWheelScroll'] as boolean;
+		if (typeof allSettings['tabBarWheelScroll'] === 'boolean')
+			patch.tabBarWheelScroll = allSettings['tabBarWheelScroll'];
 
 		// Document Graph settings (with validation)
 		if (allSettings['documentGraphShowExternalLinks'] !== undefined)

--- a/src/shared/settingsMetadata.ts
+++ b/src/shared/settingsMetadata.ts
@@ -127,6 +127,13 @@ export const SETTINGS_METADATA: Record<string, SettingMetadata> = {
 		default: false,
 		category: 'appearance',
 	},
+	tabBarWheelScroll: {
+		description:
+			'Pan an overflowing tab strip horizontally with the mouse wheel while hovering over the tab bar.',
+		type: 'boolean',
+		default: true,
+		category: 'appearance',
+	},
 	autoHideMenuBar: {
 		description: 'Auto-hide the menu bar (press Alt to show). Only applies on Windows/Linux.',
 		type: 'boolean',


### PR DESCRIPTION
## What

When the tab strip overflows, hovering over it and using the mouse wheel now pans the tabs horizontally (VS Code style). A plain vertical wheel (`deltaY`) is translated into horizontal scroll; trackpads and Shift+wheel emit `deltaX`, so the handler follows whichever axis the device reports.

Gated behind a new **Scroll tabs with the mouse wheel** toggle in **Settings -> Display** (`tabBarWheelScroll`, default on).

## Why

With a normal mouse (no horizontal wheel), there was no quick way to reach off-screen tabs without dragging or using keyboard shortcuts. This matches the tab-strip behavior users expect from VS Code and modern browsers.

## How

- `TabBar.tsx`: reads the new setting and attaches a native, non-passive `wheel` listener to the existing scroll container. It only acts when the strip actually overflows (`scrollWidth > clientWidth`), adjusts `scrollLeft`, and calls `preventDefault()` so the wheel doesn't also scroll an outer container.
  - The listener is attached natively with `{ passive: false }` because React's synthetic `onWheel` runs passively and cannot call `preventDefault()`.
- `settingsStore.ts`: new `tabBarWheelScroll` boolean (default `true`) + setter + load-from-disk patch, mirroring the existing `showBrowserTabDomain` tab setting.
- `useSettings.ts`: added field + setter to `UseSettingsReturn` (the hook spreads `...store`).
- `DisplayTab.tsx`: new toggle in the tab-display section.

## Testing

- `TabBar.test.tsx` + `DisplayTab.test.tsx`: 272 passed.
- ESLint clean on all four changed files.
- Type-check clean on all four changed files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Scroll tabs with the mouse wheel” option to Display settings, persisted across sessions (default: on) for overflowed tabs.
  * Added a toggle switch to enable or disable this behavior.
* **Bug Fixes**
  * Improved tab-strip wheel handling by converting wheel movement into horizontal scrolling, preferring the dominant wheel axis, and preventing the wheel from scrolling surrounding content when enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->