### PR TITLE
fix(settings): keep Settings modal within the viewport on short windows

### DIFF
--- a/src/renderer/components/Settings/SettingsModal.tsx
+++ b/src/renderer/components/Settings/SettingsModal.tsx
@@ -461,7 +461,7 @@ export const SettingsModal = memo(function SettingsModal(props: SettingsModalPro
 
 	return (
 		<div
-			className="fixed inset-0 modal-overlay flex items-center justify-center z-[9999]"
+			className="fixed inset-0 modal-overlay flex items-center justify-center z-[9999] p-4"
 			role="dialog"
 			aria-modal="true"
 			aria-label="Settings"
@@ -470,6 +470,7 @@ export const SettingsModal = memo(function SettingsModal(props: SettingsModalPro
 				className="h-[900px] rounded-xl border shadow-2xl overflow-hidden flex flex-col select-none"
 				style={{
 					width: 'min(calc(980px * var(--font-scale, 1)), 95vw)',
+					maxHeight: 'calc(100vh - 2rem)',
 					backgroundColor: theme.colors.bgSidebar,
 					borderColor: theme.colors.border,
 				}}


### PR DESCRIPTION
## Summary

On a window shorter than the modal, the Settings pane overflowed off the top of the screen and the cut-off top was unreachable.

Root cause: the modal box used a fixed `h-[900px]` with no `max-height`, inside a centered overlay (`flex items-center justify-center`). When the viewport was shorter than 900px the modal stayed 900px tall and centered, so it overflowed equally above and below; the header (search + close) scrolled off the top with no way to reach it. The inner sidebar/content panels already scroll, but the outer box did not shrink.

## Changes

- `SettingsModal.tsx`: cap the modal box height at `calc(100vh - 2rem)` via the existing `style` object, and add `p-4` padding to the overlay so the dialog shrinks to fit short windows and stays fully reachable. On tall windows it is unchanged (still 900px). Inner panels keep their existing `overflow-y-auto` scrolling.

## Verification

- `npm run lint` (tsc x3): clean.
- Manual: with a window shorter than ~900px, open Settings; the modal now fits within the viewport with the search/close header reachable, and content scrolls inside.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the settings modal layout to add consistent padding around the overlay.
  * Improved modal sizing so it stays within the viewport and is less likely to overflow vertically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->