### PR TITLE
feat(agents): add Qwen Coder (qwen3-coder) and Oh My Pi (omp) agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Maestro is a cross-platform desktop app for orchestrating your fleet of AI agent
 
 Collaborate with AI to create detailed specification documents, then let Auto Run execute them automatically, each task in a fresh session with clean context. Allowing for long-running unattended sessions, my current record is nearly 24 hours of continuous runtime.
 
-Run multiple agents in parallel with a Linear/Superhuman-level responsive interface. Currently supporting **Claude Code**, **OpenAI Codex**, **OpenCode**, **Factory Droid**, and **Copilot-CLI** (beta) with plans for additional agentic coding tools (Gemini CLI) based on user demand.
+Run multiple agents in parallel with a Linear/Superhuman-level responsive interface. Currently supporting **Claude Code**, **OpenAI Codex**, **OpenCode**, **Factory Droid**, **Copilot-CLI** (beta), and **Qwen3 Coder** (beta) with plans for additional agentic coding tools (Gemini CLI) based on user demand.
 
 > **How It Works:** Maestro is a pass-through to your AI provider. Whatever MCP tools, skills, permissions, or authentication you have configured in Claude Code, Codex, or OpenCode works identically in Maestro. The only difference is we're not running interactively—each task gets a prompt and returns a response, whether it's a new session or resuming a prior one.
 
@@ -83,7 +83,7 @@ Run multiple agents in parallel with a Linear/Superhuman-level responsive interf
 
 Additional interactions: Drag nodes to reposition, scroll to zoom, use mini-map for overview.
 
-> **Note**: Maestro supports Claude Code, OpenAI Codex, OpenCode, Factory Droid, and Copilot-CLI (beta). Support for additional agents (Gemini CLI) may be added in future releases based on community demand.
+> **Note**: Maestro supports Claude Code, OpenAI Codex, OpenCode, Factory Droid, Copilot-CLI (beta), and Qwen3 Coder (beta). Support for additional agents (Gemini CLI) may be added in future releases based on community demand.
 
 ## Quick Start
 
@@ -107,6 +107,7 @@ npm run dev
   - [OpenAI Codex](https://github.com/openai/codex) - OpenAI's coding agent
   - [OpenCode](https://github.com/sst/opencode) - Open-source AI coding assistant
   - [Copilot-CLI](https://docs.github.com/copilot/how-tos/copilot-cli) - GitHub's terminal coding agent (beta, multi-model via [models.dev](https://models.dev))
+  - [Qwen3 Coder](https://github.com/QwenLM/qwen-code) - Alibaba's Qwen Code agent, a Gemini CLI fork (beta)
 - Git (optional, for git-aware features)
 
 ### Essential Keyboard Shortcuts

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Maestro is a cross-platform desktop app for orchestrating your fleet of AI agent
 
 Collaborate with AI to create detailed specification documents, then let Auto Run execute them automatically, each task in a fresh session with clean context. Allowing for long-running unattended sessions, my current record is nearly 24 hours of continuous runtime.
 
-Run multiple agents in parallel with a Linear/Superhuman-level responsive interface. Currently supporting **Claude Code**, **OpenAI Codex**, **OpenCode**, **Factory Droid**, and **Copilot-CLI** (beta) with plans for additional agentic coding tools (Gemini CLI) based on user demand.
+Run multiple agents in parallel with a Linear/Superhuman-level responsive interface. Currently supporting **Claude Code**, **OpenAI Codex**, **OpenCode**, **Factory Droid**, **Copilot-CLI** (beta), and **Oh My Pi** (beta) with plans for additional agentic coding tools (Gemini CLI) based on user demand.
 
 > **How It Works:** Maestro is a pass-through to your AI provider. Whatever MCP tools, skills, permissions, or authentication you have configured in Claude Code, Codex, or OpenCode works identically in Maestro. The only difference is we're not running interactively—each task gets a prompt and returns a response, whether it's a new session or resuming a prior one.
 
@@ -83,7 +83,7 @@ Run multiple agents in parallel with a Linear/Superhuman-level responsive interf
 
 Additional interactions: Drag nodes to reposition, scroll to zoom, use mini-map for overview.
 
-> **Note**: Maestro supports Claude Code, OpenAI Codex, OpenCode, Factory Droid, and Copilot-CLI (beta). Support for additional agents (Gemini CLI) may be added in future releases based on community demand.
+> **Note**: Maestro supports Claude Code, OpenAI Codex, OpenCode, Factory Droid, Copilot-CLI (beta), and Oh My Pi (beta). Support for additional agents (Gemini CLI) may be added in future releases based on community demand.
 
 ## Quick Start
 
@@ -107,6 +107,7 @@ npm run dev
   - [OpenAI Codex](https://github.com/openai/codex) - OpenAI's coding agent
   - [OpenCode](https://github.com/sst/opencode) - Open-source AI coding assistant
   - [Copilot-CLI](https://docs.github.com/copilot/how-tos/copilot-cli) - GitHub's terminal coding agent (beta, multi-model via [models.dev](https://models.dev))
+  - [Oh My Pi](https://www.npmjs.com/package/@oh-my-pi/pi-coding-agent) - Multi-model coding agent (beta, `omp` CLI)
 - Git (optional, for git-aware features)
 
 ### Essential Keyboard Shortcuts

--- a/src/__tests__/main/agents/capabilities.test.ts
+++ b/src/__tests__/main/agents/capabilities.test.ts
@@ -171,6 +171,24 @@ describe('agent-capabilities', () => {
 			expect(capabilities.usesJsonLineOutput).toBe(true);
 		});
 
+		it('should expose Oh My Pi capabilities backed by its JSON event protocol', () => {
+			const capabilities = AGENT_CAPABILITIES.omp;
+
+			expect(capabilities).toBeDefined();
+			expect(capabilities.supportsResume).toBe(true);
+			expect(capabilities.supportsJsonOutput).toBe(true);
+			expect(capabilities.supportsSessionId).toBe(true);
+			expect(capabilities.supportsImageInput).toBe(true);
+			expect(capabilities.supportsModelSelection).toBe(true);
+			expect(capabilities.supportsCostTracking).toBe(true);
+			expect(capabilities.supportsUsageStats).toBe(true);
+			expect(capabilities.supportsBatchMode).toBe(true);
+			expect(capabilities.supportsStreaming).toBe(true);
+			expect(capabilities.supportsResultMessages).toBe(true);
+			expect(capabilities.supportsThinkingDisplay).toBe(true);
+			expect(capabilities.usesJsonLineOutput).toBe(true);
+		});
+
 		it('should define capabilities for all known agents', () => {
 			const knownAgents = [
 				'claude-code',
@@ -181,6 +199,7 @@ describe('agent-capabilities', () => {
 				'opencode',
 				'factory-droid',
 				'copilot-cli',
+				'omp',
 			];
 
 			for (const agentId of knownAgents) {

--- a/src/__tests__/main/agents/capabilities.test.ts
+++ b/src/__tests__/main/agents/capabilities.test.ts
@@ -188,6 +188,7 @@ describe('agent-capabilities', () => {
 			expect(capabilities.supportsStreaming).toBe(true);
 			expect(capabilities.supportsResultMessages).toBe(true);
 			expect(capabilities.supportsThinkingDisplay).toBe(true);
+			expect(capabilities.supportsReadOnlyMode).toBe(true);
 			expect(capabilities.usesJsonLineOutput).toBe(true);
 		});
 

--- a/src/__tests__/main/agents/capabilities.test.ts
+++ b/src/__tests__/main/agents/capabilities.test.ts
@@ -117,9 +117,11 @@ describe('agent-capabilities', () => {
 		it('should have capabilities for qwen3-coder', () => {
 			const capabilities = AGENT_CAPABILITIES['qwen3-coder'];
 			expect(capabilities).toBeDefined();
-			// Local model - no cost tracking
+			// Local/plan model - no cost tracking
 			expect(capabilities.supportsCostTracking).toBe(false);
 			expect(capabilities.supportsStreaming).toBe(true);
+			expect(capabilities.supportsJsonOutput).toBe(true);
+			expect(capabilities.supportsModelSelection).toBe(true);
 		});
 
 		it('should have capabilities for opencode', () => {

--- a/src/__tests__/main/agents/definitions.test.ts
+++ b/src/__tests__/main/agents/definitions.test.ts
@@ -390,6 +390,21 @@ describe('agent-definitions', () => {
 			expect(modelOption?.argBuilder?.('')).toEqual([]);
 			expect(modelOption?.argBuilder?.('  ')).toEqual([]);
 		});
+
+		it('should use --approval-mode plan for CLI-enforced read-only (never -y)', () => {
+			const qwen = getAgentDefinition('qwen3-coder');
+			expect(qwen?.readOnlyArgs).toEqual(['--approval-mode', 'plan']);
+			expect(qwen?.readOnlyCliEnforced).toBe(true);
+			expect(qwen?.readOnlyArgs).not.toContain('-y');
+		});
+	});
+
+	describe('Oh My Pi agent', () => {
+		it('should restrict to read-only tools for CLI-enforced read-only', () => {
+			const omp = getAgentDefinition('omp');
+			expect(omp?.readOnlyArgs).toEqual(['--tools', 'read,grep,glob']);
+			expect(omp?.readOnlyCliEnforced).toBe(true);
+		});
 	});
 
 	describe('Type definitions', () => {

--- a/src/__tests__/main/agents/definitions.test.ts
+++ b/src/__tests__/main/agents/definitions.test.ts
@@ -348,6 +348,34 @@ describe('agent-definitions', () => {
 		});
 	});
 
+	describe('Qwen3 Coder agent', () => {
+		it('should be a visible, real agent (not hidden)', () => {
+			const qwen = getAgentDefinition('qwen3-coder');
+			expect(qwen).toBeDefined();
+			expect(qwen?.hidden).toBeFalsy();
+			expect(qwen?.binaryName).toBe('qwen');
+			expect(qwen?.command).toBe('qwen');
+		});
+
+		it('should build modelArgs and stream-json output args', () => {
+			const qwen = getAgentDefinition('qwen3-coder');
+			expect(qwen?.modelArgs?.('qwen3-coder-plus')).toEqual(['-m', 'qwen3-coder-plus']);
+			expect(qwen?.jsonOutputArgs).toEqual(['--output-format', 'stream-json']);
+			expect(qwen?.promptArgs?.('hello')).toEqual(['-p', 'hello']);
+		});
+
+		it('should expose a model select config option with trimming argBuilder', () => {
+			const qwen = getAgentDefinition('qwen3-coder');
+			const modelOption = qwen?.configOptions?.find((opt) => opt.key === 'model');
+			expect(modelOption).toBeDefined();
+			expect(modelOption?.type).toBe('select');
+			expect(modelOption?.default).toBe('');
+			expect(modelOption?.argBuilder?.('qwen3-coder-plus')).toEqual(['-m', 'qwen3-coder-plus']);
+			expect(modelOption?.argBuilder?.('')).toEqual([]);
+			expect(modelOption?.argBuilder?.('  ')).toEqual([]);
+		});
+	});
+
 	describe('Type definitions', () => {
 		it('should export AgentDefinition type', () => {
 			const def: AgentDefinition = {

--- a/src/__tests__/main/agents/definitions.test.ts
+++ b/src/__tests__/main/agents/definitions.test.ts
@@ -178,6 +178,7 @@ describe('agent-definitions', () => {
 				'gemini-cli',
 				'copilot-cli',
 				'omp',
+				'qwen3-coder',
 			];
 			for (const agentId of knownAgents) {
 				const def = getAgentDefinition(agentId);

--- a/src/__tests__/main/agents/definitions.test.ts
+++ b/src/__tests__/main/agents/definitions.test.ts
@@ -28,6 +28,20 @@ describe('agent-definitions', () => {
 			expect(agentIds).toContain('copilot-cli');
 			expect(agentIds).toContain('hermes');
 			expect(agentIds).toContain('pi');
+			expect(agentIds).toContain('omp');
+		});
+
+		it('should have omp with batch mode and json output configuration', () => {
+			const omp = AGENT_DEFINITIONS.find((def) => def.id === 'omp');
+			expect(omp).toBeDefined();
+			expect(omp?.name).toBe('Oh My Pi');
+			expect(omp?.command).toBe('omp');
+			expect(omp?.binaryName).toBe('omp');
+			expect(omp?.batchModePrefix).toEqual(['-p']);
+			expect(omp?.jsonOutputArgs).toEqual(['--mode', 'json']);
+			expect(omp?.resumeArgs?.('abc')).toEqual(['--resume', 'abc']);
+			expect(omp?.modelArgs?.('opus')).toEqual(['--model', 'opus']);
+			expect(omp?.hidden).toBeFalsy();
 		});
 
 		it('should have required properties on all definitions', () => {
@@ -163,6 +177,7 @@ describe('agent-definitions', () => {
 				'opencode',
 				'gemini-cli',
 				'copilot-cli',
+				'omp',
 			];
 			for (const agentId of knownAgents) {
 				const def = getAgentDefinition(agentId);

--- a/src/__tests__/main/agents/definitions.test.ts
+++ b/src/__tests__/main/agents/definitions.test.ts
@@ -364,11 +364,11 @@ describe('agent-definitions', () => {
 			expect(qwen?.promptArgs?.('hello')).toEqual(['-p', 'hello']);
 		});
 
-		it('should expose a model select config option with trimming argBuilder', () => {
+		it('should expose a free-text model config option with trimming argBuilder', () => {
 			const qwen = getAgentDefinition('qwen3-coder');
 			const modelOption = qwen?.configOptions?.find((opt) => opt.key === 'model');
 			expect(modelOption).toBeDefined();
-			expect(modelOption?.type).toBe('select');
+			expect(modelOption?.type).toBe('text');
 			expect(modelOption?.default).toBe('');
 			expect(modelOption?.argBuilder?.('qwen3-coder-plus')).toEqual(['-m', 'qwen3-coder-plus']);
 			expect(modelOption?.argBuilder?.('')).toEqual([]);

--- a/src/__tests__/main/agents/detector.test.ts
+++ b/src/__tests__/main/agents/detector.test.ts
@@ -1414,6 +1414,39 @@ describe('agent-detector', () => {
 			// Prefers the provider-qualified selector and de-duplicates entries
 			expect(models).toEqual(['anthropic/claude-opus-4-8', 'openai-codex/gpt-5.2']);
 		});
+
+		it('does not cache a transient empty omp discovery failure', async () => {
+			let attempt = 0;
+			mockExecFileNoThrow.mockImplementation(async (cmd, args) => {
+				if (cmd === '/usr/bin/omp' && args[0] === 'models' && args[1] === '--json') {
+					attempt += 1;
+					if (attempt === 1) {
+						return { stdout: '', stderr: 'transient failure', exitCode: 1 };
+					}
+					return {
+						stdout: JSON.stringify({ models: [{ selector: 'anthropic/claude-opus-4-8' }] }),
+						stderr: '',
+						exitCode: 0,
+					};
+				}
+				if (args[0] === 'omp') {
+					return { stdout: '/usr/bin/omp\n', stderr: '', exitCode: 0 };
+				}
+				return { stdout: '', stderr: '', exitCode: 1 };
+			});
+
+			detector.clearCache();
+			detector.clearModelCache();
+			await detector.detectAgents();
+
+			const first = await detector.discoverModels('omp');
+			expect(first).toEqual([]);
+
+			// The empty failure must NOT be cached: a second call (no forceRefresh)
+			// re-runs discovery and now succeeds.
+			const second = await detector.discoverModels('omp');
+			expect(second).toEqual(['anthropic/claude-opus-4-8']);
+		});
 	});
 
 	describe('OpenCode batch mode configuration', () => {

--- a/src/__tests__/main/agents/detector.test.ts
+++ b/src/__tests__/main/agents/detector.test.ts
@@ -1383,6 +1383,37 @@ describe('agent-detector', () => {
 
 			expect(models).toEqual(['model1', 'model2']);
 		});
+
+		it('should discover models for Oh My Pi from omp models --json', async () => {
+			mockExecFileNoThrow.mockImplementation(async (cmd, args) => {
+				if (cmd === '/usr/bin/omp' && args[0] === 'models' && args[1] === '--json') {
+					return {
+						stdout: JSON.stringify({
+							models: [
+								{ id: 'claude-opus-4-8', selector: 'anthropic/claude-opus-4-8' },
+								{ id: 'gpt-5.2', selector: 'openai-codex/gpt-5.2' },
+								{ id: 'gpt-5.2', selector: 'openai-codex/gpt-5.2' },
+							],
+						}),
+						stderr: '',
+						exitCode: 0,
+					};
+				}
+				if (args[0] === 'omp') {
+					return { stdout: '/usr/bin/omp\n', stderr: '', exitCode: 0 };
+				}
+				return { stdout: '', stderr: '', exitCode: 1 };
+			});
+
+			detector.clearCache();
+			detector.clearModelCache();
+			await detector.detectAgents();
+
+			const models = await detector.discoverModels('omp');
+
+			// Prefers the provider-qualified selector and de-duplicates entries
+			expect(models).toEqual(['anthropic/claude-opus-4-8', 'openai-codex/gpt-5.2']);
+		});
 	});
 
 	describe('OpenCode batch mode configuration', () => {

--- a/src/__tests__/main/ipc/handlers/agents.test.ts
+++ b/src/__tests__/main/ipc/handlers/agents.test.ts
@@ -29,6 +29,7 @@ vi.mock('../../../../main/agents', async () => {
 			{ id: 'claude-code', name: 'Claude Code', binaryName: 'claude', configOptions: [] },
 			{ id: 'codex', name: 'Codex', binaryName: 'codex', configOptions: [] },
 			{ id: 'opencode', name: 'OpenCode', binaryName: 'opencode', configOptions: [] },
+			{ id: 'omp', name: 'Oh My Pi', binaryName: 'omp', configOptions: [] },
 			{ id: 'terminal', name: 'Terminal', binaryName: 'bash', configOptions: [] },
 		],
 		DEFAULT_CAPABILITIES: {
@@ -1127,6 +1128,42 @@ describe('agents IPC handlers', () => {
 				);
 				expect(result).toEqual(['opencode/gpt-5-nano', 'ollama/qwen3:8b']);
 				expect(mockAgentDetector.discoverModels).not.toHaveBeenCalled();
+			});
+
+			it('should discover omp models over SSH via models --json', async () => {
+				mockSettingsStore.get.mockReturnValue([
+					{
+						id: 'remote-1',
+						host: 'dev.example.com',
+						user: 'dev',
+						enabled: true,
+					},
+				]);
+
+				vi.mocked(buildSshCommand).mockResolvedValue({
+					command: 'ssh',
+					args: ['-o', 'BatchMode=yes', 'dev@dev.example.com', 'omp models --json'],
+				});
+
+				vi.mocked(execFileNoThrow).mockResolvedValue({
+					exitCode: 0,
+					stdout: JSON.stringify({
+						models: [
+							{ id: 'claude-opus-4-8', selector: 'anthropic/claude-opus-4-8' },
+							{ id: 'gpt-5.2', selector: 'openai-codex/gpt-5.2' },
+						],
+					}),
+					stderr: '',
+				});
+
+				const handler = handlers.get('agents:getModels');
+				const result = await handler!({} as any, 'omp', false, 'remote-1');
+
+				expect(buildSshCommand).toHaveBeenCalledWith(
+					expect.objectContaining({ id: 'remote-1', host: 'dev.example.com' }),
+					expect.objectContaining({ command: 'omp', args: ['models', '--json'] })
+				);
+				expect(result).toEqual(['anthropic/claude-opus-4-8', 'openai-codex/gpt-5.2']);
 			});
 
 			it('should throw when SSH remote not found', async () => {

--- a/src/__tests__/main/parsers/index.test.ts
+++ b/src/__tests__/main/parsers/index.test.ts
@@ -11,6 +11,7 @@ import {
 	CopilotOutputParser,
 	PiOutputParser,
 	OmpOutputParser,
+	QwenOutputParser,
 } from '../../../main/parsers';
 
 describe('parsers/index', () => {
@@ -151,6 +152,11 @@ describe('parsers/index', () => {
 			expect(parser).not.toBeNull();
 			expect(parser).toBeInstanceOf(OmpOutputParser);
 		});
+		it('should return QwenOutputParser for qwen3-coder', () => {
+			const parser = getOutputParser('qwen3-coder');
+			expect(parser).not.toBeNull();
+			expect(parser).toBeInstanceOf(QwenOutputParser);
+		});
 	});
 
 	describe('parser exports', () => {
@@ -182,6 +188,10 @@ describe('parsers/index', () => {
 		it('should export OmpOutputParser class', () => {
 			const parser = new OmpOutputParser();
 			expect(parser.agentId).toBe('omp');
+		});
+		it('should export QwenOutputParser class', () => {
+			const parser = new QwenOutputParser();
+			expect(parser.agentId).toBe('qwen3-coder');
 		});
 	});
 

--- a/src/__tests__/main/parsers/index.test.ts
+++ b/src/__tests__/main/parsers/index.test.ts
@@ -10,6 +10,7 @@ import {
 	CodexOutputParser,
 	CopilotOutputParser,
 	PiOutputParser,
+	OmpOutputParser,
 } from '../../../main/parsers';
 
 describe('parsers/index', () => {
@@ -66,21 +67,29 @@ describe('parsers/index', () => {
 			expect(hasOutputParser('pi')).toBe(true);
 		});
 
-		it('should register exactly 6 parsers', () => {
+		it('should register Omp parser', () => {
+			expect(hasOutputParser('omp')).toBe(false);
+
+			initializeOutputParsers();
+
+			expect(hasOutputParser('omp')).toBe(true);
+		});
+
+		it('should register exactly 7 parsers', () => {
 			initializeOutputParsers();
 
 			const parsers = getAllOutputParsers();
-			expect(parsers.length).toBe(6);
+			expect(parsers.length).toBe(7);
 		});
 
 		it('should clear existing parsers before registering', () => {
 			// First initialization
 			initializeOutputParsers();
-			expect(getAllOutputParsers().length).toBe(6);
+			expect(getAllOutputParsers().length).toBe(7);
 
-			// Second initialization should still have exactly 5
+			// Second initialization should still have exactly 7
 			initializeOutputParsers();
-			expect(getAllOutputParsers().length).toBe(6);
+			expect(getAllOutputParsers().length).toBe(7);
 		});
 	});
 
@@ -128,6 +137,12 @@ describe('parsers/index', () => {
 			expect(parser).not.toBeNull();
 			expect(parser).toBeInstanceOf(PiOutputParser);
 		});
+
+		it('should return OmpOutputParser for omp', () => {
+			const parser = getOutputParser('omp');
+			expect(parser).not.toBeNull();
+			expect(parser).toBeInstanceOf(OmpOutputParser);
+		});
 	});
 
 	describe('parser exports', () => {
@@ -154,6 +169,11 @@ describe('parsers/index', () => {
 		it('should export PiOutputParser class', () => {
 			const parser = new PiOutputParser();
 			expect(parser.agentId).toBe('pi');
+		});
+
+		it('should export OmpOutputParser class', () => {
+			const parser = new OmpOutputParser();
+			expect(parser.agentId).toBe('omp');
 		});
 	});
 

--- a/src/__tests__/main/parsers/index.test.ts
+++ b/src/__tests__/main/parsers/index.test.ts
@@ -66,21 +66,29 @@ describe('parsers/index', () => {
 			expect(hasOutputParser('pi')).toBe(true);
 		});
 
-		it('should register exactly 6 parsers', () => {
+		it('should register Qwen parser', () => {
+			expect(hasOutputParser('qwen3-coder')).toBe(false);
+
+			initializeOutputParsers();
+
+			expect(hasOutputParser('qwen3-coder')).toBe(true);
+		});
+
+		it('should register exactly 7 parsers', () => {
 			initializeOutputParsers();
 
 			const parsers = getAllOutputParsers();
-			expect(parsers.length).toBe(6);
+			expect(parsers.length).toBe(7);
 		});
 
 		it('should clear existing parsers before registering', () => {
 			// First initialization
 			initializeOutputParsers();
-			expect(getAllOutputParsers().length).toBe(6);
+			expect(getAllOutputParsers().length).toBe(7);
 
-			// Second initialization should still have exactly 5
+			// Second initialization should still have exactly 7
 			initializeOutputParsers();
-			expect(getAllOutputParsers().length).toBe(6);
+			expect(getAllOutputParsers().length).toBe(7);
 		});
 	});
 

--- a/src/__tests__/main/parsers/omp-output-parser.test.ts
+++ b/src/__tests__/main/parsers/omp-output-parser.test.ts
@@ -6,7 +6,7 @@ import type { ParsedEvent } from '../../../main/parsers/agent-output-parser';
  * Captured `omp -p --mode json "Reply with exactly the two characters: ok"` output.
  * Source: local://omp-sample.jsonl (real run on this machine).
  */
-const OMP_SAMPLE = `{"type":"session","version":3,"id":"019f053e-8426-7000-8d2a-b62b4fb55545","timestamp":"2026-06-26T18:43:30.984Z","cwd":"C:\\\\Users\\\\sydor\\\\AppData\\\\Local\\\\Temp\\\\omp-probe"}
+const OMP_SAMPLE = `{"type":"session","version":3,"id":"019f053e-8426-7000-8d2a-b62b4fb55545","timestamp":"2026-06-26T18:43:30.984Z","cwd":"C:\\\\Users\\\\example\\\\AppData\\\\Local\\\\Temp\\\\omp-probe"}
 {"type":"agent_start"}
 {"type":"turn_start"}
 {"type":"message_start","message":{"role":"user","content":[{"type":"text","text":"Reply with exactly the two characters: ok"}],"attribution":"user","timestamp":1782499411936}}
@@ -106,5 +106,18 @@ describe('OmpOutputParser', () => {
 		expect(event).not.toBeNull();
 		expect(event!.type).toBe('system');
 		expect(parser.isResultMessage(event!)).toBe(false);
+	});
+	it('does not surface a retrying agent_end as a user-facing error', () => {
+		const retrying = {
+			type: 'agent_end',
+			willRetry: true,
+			error: 'overloaded: retrying request',
+		};
+
+		const event = parser.parseJsonObject(retrying);
+		expect(event).not.toBeNull();
+		expect(event!.type).toBe('system');
+
+		expect(parser.detectErrorFromParsed(retrying)).toBeNull();
 	});
 });

--- a/src/__tests__/main/parsers/omp-output-parser.test.ts
+++ b/src/__tests__/main/parsers/omp-output-parser.test.ts
@@ -80,4 +80,31 @@ describe('OmpOutputParser', () => {
 		expect(parser.isResultMessage(finalEvent!)).toBe(true);
 		expect(finalEvent).toMatchObject({ type: 'result', text: 'ok' });
 	});
+
+	it('does not emit an empty result when agent_end has an empty messages array', () => {
+		const event = parser.parseJsonObject({ type: 'agent_end', messages: [] });
+
+		expect(event).not.toBeNull();
+		expect(event!.type).toBe('system');
+		expect(parser.isResultMessage(event!)).toBe(false);
+	});
+
+	it('does not emit an empty result when agent_end omits the messages array', () => {
+		const event = parser.parseJsonObject({ type: 'agent_end' });
+
+		expect(event).not.toBeNull();
+		expect(event!.type).toBe('system');
+		expect(parser.isResultMessage(event!)).toBe(false);
+	});
+
+	it('does not emit a result when agent_end carries only a user message', () => {
+		const event = parser.parseJsonObject({
+			type: 'agent_end',
+			messages: [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }],
+		});
+
+		expect(event).not.toBeNull();
+		expect(event!.type).toBe('system');
+		expect(parser.isResultMessage(event!)).toBe(false);
+	});
 });

--- a/src/__tests__/main/parsers/omp-output-parser.test.ts
+++ b/src/__tests__/main/parsers/omp-output-parser.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import { OmpOutputParser } from '../../../main/parsers/omp-output-parser';
+import type { ParsedEvent } from '../../../main/parsers/agent-output-parser';
+
+/**
+ * Captured `omp -p --mode json "Reply with exactly the two characters: ok"` output.
+ * Source: local://omp-sample.jsonl (real run on this machine).
+ */
+const OMP_SAMPLE = `{"type":"session","version":3,"id":"019f053e-8426-7000-8d2a-b62b4fb55545","timestamp":"2026-06-26T18:43:30.984Z","cwd":"C:\\\\Users\\\\sydor\\\\AppData\\\\Local\\\\Temp\\\\omp-probe"}
+{"type":"agent_start"}
+{"type":"turn_start"}
+{"type":"message_start","message":{"role":"user","content":[{"type":"text","text":"Reply with exactly the two characters: ok"}],"attribution":"user","timestamp":1782499411936}}
+{"type":"message_end","message":{"role":"user","content":[{"type":"text","text":"Reply with exactly the two characters: ok"}],"attribution":"user","timestamp":1782499411936}}
+{"type":"message_start","message":{"role":"assistant","content":[{"type":"text","text":"ok"}],"api":"anthropic-messages","provider":"anthropic","model":"claude-opus-4-8","usage":{"input":2,"output":4,"cacheRead":0,"cacheWrite":14443,"totalTokens":14449,"cost":{"input":0.00001,"output":0.0001,"cacheRead":0,"cacheWrite":0.09026875000000001,"total":0.09037875000000001},"cttl":{"ephemeral1h":14443}},"stopReason":"stop","timestamp":1782499414886,"responseId":"msg_01CoMSHtJYk8HJTJPP1KC9Ua","duration":1930,"ttft":1929}}
+{"type":"message_update","assistantMessageEvent":{"type":"text_start","contentIndex":0,"partial":{"role":"assistant","content":[{"type":"text","text":"ok"}]}},"message":{"role":"assistant","content":[{"type":"text","text":"ok"}]}}
+{"type":"message_update","assistantMessageEvent":{"type":"text_delta","contentIndex":0,"delta":"ok","partial":{"role":"assistant","content":[{"type":"text","text":"ok"}]}},"message":{"role":"assistant","content":[{"type":"text","text":"ok"}]}}
+{"type":"message_update","assistantMessageEvent":{"type":"text_end","contentIndex":0,"content":"ok","partial":{"role":"assistant","content":[{"type":"text","text":"ok"}]}},"message":{"role":"assistant","content":[{"type":"text","text":"ok"}]}}
+{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"ok"}],"api":"anthropic-messages","provider":"anthropic","model":"claude-opus-4-8","usage":{"input":2,"output":4,"cacheRead":0,"cacheWrite":14443,"totalTokens":14449,"cost":{"input":0.00001,"output":0.0001,"cacheRead":0,"cacheWrite":0.09026875000000001,"total":0.09037875000000001}},"stopReason":"stop","timestamp":1782499414886,"responseId":"msg_01CoMSHtJYk8HJTJPP1KC9Ua","duration":1930,"ttft":1929}}
+{"type":"turn_end","message":{"role":"assistant","content":[{"type":"text","text":"ok"}],"usage":{"input":2,"output":4,"totalTokens":14449,"cost":{"total":0.09037875000000001}}},"toolResults":[]}
+{"type":"agent_end","messages":[{"role":"user","content":[{"type":"text","text":"Reply with exactly the two characters: ok"}],"attribution":"user","timestamp":1782499411936},{"role":"assistant","content":[{"type":"text","text":"ok"}],"model":"claude-opus-4-8","usage":{"input":2,"output":4,"totalTokens":14449,"cost":{"total":0.09037875000000001}},"stopReason":"stop"}]}`;
+
+describe('OmpOutputParser', () => {
+	const parser = new OmpOutputParser();
+
+	const parseSample = (): ParsedEvent[] =>
+		OMP_SAMPLE.split('\n')
+			.map((line) => parser.parseJsonLine(line))
+			.filter((event): event is ParsedEvent => event !== null);
+
+	it('identifies as the omp agent', () => {
+		expect(parser.agentId).toBe('omp');
+	});
+
+	it('extracts the resumable session id from the session line', () => {
+		const events = parseSample();
+		const init = events.find((event) => event.type === 'init');
+
+		expect(init).toBeDefined();
+		expect(parser.extractSessionId(init!)).toBe('019f053e-8426-7000-8d2a-b62b4fb55545');
+	});
+
+	it('assembles streamed assistant text from text_delta chunks', () => {
+		const events = parseSample();
+		const streamedText = events
+			.filter((event) => event.type === 'text' && event.isPartial && !event.isReasoning)
+			.map((event) => event.text || '')
+			.join('');
+
+		expect(streamedText).toBe('ok');
+	});
+
+	it('extracts usage with token totals and cost from the assistant message_end', () => {
+		const events = parseSample();
+		const usageEvent = events.find((event) => event.type === 'usage');
+
+		expect(usageEvent).toBeDefined();
+		const usage = parser.extractUsage(usageEvent!);
+		expect(usage).not.toBeNull();
+		expect(usage!.inputTokens).toBe(2);
+		expect(usage!.outputTokens).toBe(4);
+		expect(usage!.cacheReadTokens).toBe(0);
+		expect(usage!.cacheCreationTokens).toBe(14443);
+
+		// omp's totalTokens (14449) is the sum of input + output + cache read + cache write.
+		const totalTokens =
+			usage!.inputTokens +
+			usage!.outputTokens +
+			(usage!.cacheReadTokens || 0) +
+			(usage!.cacheCreationTokens || 0);
+		expect(totalTokens).toBe(14449);
+
+		expect(usage!.costUsd).toBeCloseTo(0.0904, 4);
+	});
+
+	it('treats agent_end as the authoritative final result', () => {
+		const events = parseSample();
+		const finalEvent = events.at(-1);
+
+		expect(finalEvent).toBeDefined();
+		expect(parser.isResultMessage(finalEvent!)).toBe(true);
+		expect(finalEvent).toMatchObject({ type: 'result', text: 'ok' });
+	});
+});

--- a/src/__tests__/main/parsers/qwen-output-parser.test.ts
+++ b/src/__tests__/main/parsers/qwen-output-parser.test.ts
@@ -140,6 +140,27 @@ describe('QwenOutputParser', () => {
 			const usage = parser.extractUsage(event!);
 			expect(usage?.contextWindow).toBe(262144);
 		});
+		it('preserves a model-reported 200000 context window (not the Claude fallback)', () => {
+			// 200000 equals the injected Claude fallback, but here a model reports it
+			// explicitly via modelUsage, so it must be preserved rather than stripped.
+			const event = parser.parseJsonLine(
+				JSON.stringify({
+					type: 'result',
+					subtype: 'success',
+					result: 'done',
+					modelUsage: {
+						'qwen-plus': {
+							inputTokens: 1000,
+							outputTokens: 500,
+							contextWindow: 200000,
+						},
+					},
+				})
+			);
+
+			const usage = parser.extractUsage(event!);
+			expect(usage?.contextWindow).toBe(200000);
+		});
 	});
 
 	describe('is_error handling', () => {

--- a/src/__tests__/main/parsers/qwen-output-parser.test.ts
+++ b/src/__tests__/main/parsers/qwen-output-parser.test.ts
@@ -161,6 +161,27 @@ describe('QwenOutputParser', () => {
 			const usage = parser.extractUsage(event!);
 			expect(usage?.contextWindow).toBe(200000);
 		});
+		it('preserves a model-reported context window below the Claude fallback', () => {
+			// A custom OpenAI-compatible model can report a window < 200000; the aggregator
+			// clamps it up to the fallback, so the parser must restore the real value.
+			const event = parser.parseJsonLine(
+				JSON.stringify({
+					type: 'result',
+					subtype: 'success',
+					result: 'done',
+					modelUsage: {
+						'custom/small-model': {
+							inputTokens: 1000,
+							outputTokens: 500,
+							contextWindow: 128000,
+						},
+					},
+				})
+			);
+
+			const usage = parser.extractUsage(event!);
+			expect(usage?.contextWindow).toBe(128000);
+		});
 	});
 
 	describe('is_error handling', () => {

--- a/src/__tests__/main/parsers/qwen-output-parser.test.ts
+++ b/src/__tests__/main/parsers/qwen-output-parser.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import { QwenOutputParser } from '../../../main/parsers/qwen-output-parser';
+
+describe('QwenOutputParser', () => {
+	const parser = new QwenOutputParser();
+
+	describe('agentId', () => {
+		it('should be qwen3-coder', () => {
+			expect(parser.agentId).toBe('qwen3-coder');
+		});
+	});
+
+	describe('parseJsonLine', () => {
+		it('should return null for empty lines', () => {
+			expect(parser.parseJsonLine('')).toBeNull();
+			expect(parser.parseJsonLine('   ')).toBeNull();
+		});
+
+		it('should surface session id from system session_start messages', () => {
+			const line = JSON.stringify({
+				type: 'system',
+				subtype: 'session_start',
+				session_id: 'qwen-sess-123',
+			});
+
+			const event = parser.parseJsonLine(line);
+			expect(event).not.toBeNull();
+			expect(event?.sessionId).toBe('qwen-sess-123');
+			expect(parser.extractSessionId(event!)).toBe('qwen-sess-123');
+		});
+
+		it('should parse assistant messages as partial text', () => {
+			const line = JSON.stringify({
+				type: 'assistant',
+				session_id: 'qwen-sess-123',
+				message: {
+					role: 'assistant',
+					content: [{ type: 'text', text: 'hi' }],
+				},
+			});
+
+			const event = parser.parseJsonLine(line);
+			expect(event).not.toBeNull();
+			expect(event?.type).toBe('text');
+			expect(event?.text).toBe('hi');
+			expect(event?.sessionId).toBe('qwen-sess-123');
+			expect(event?.isPartial).toBe(true);
+		});
+
+		it('should parse result messages', () => {
+			const line = JSON.stringify({
+				type: 'result',
+				subtype: 'success',
+				result: 'done',
+				session_id: 'qwen-sess-123',
+				usage: {
+					input_tokens: 1000,
+					output_tokens: 500,
+				},
+			});
+
+			const event = parser.parseJsonLine(line);
+			expect(event).not.toBeNull();
+			expect(event?.type).toBe('result');
+			expect(event?.text).toBe('done');
+			expect(event?.sessionId).toBe('qwen-sess-123');
+			expect(parser.isResultMessage(event!)).toBe(true);
+		});
+	});
+
+	describe('extractSessionId', () => {
+		it('should extract session id from result message', () => {
+			const event = parser.parseJsonLine(
+				JSON.stringify({ type: 'result', result: 'done', session_id: 'qwen-final' })
+			);
+			expect(parser.extractSessionId(event!)).toBe('qwen-final');
+		});
+	});
+
+	describe('extractUsage', () => {
+		it('should extract token counts from result usage', () => {
+			const event = parser.parseJsonLine(
+				JSON.stringify({
+					type: 'result',
+					subtype: 'success',
+					result: 'done',
+					session_id: 'qwen-sess-123',
+					usage: {
+						input_tokens: 1000,
+						output_tokens: 500,
+					},
+				})
+			);
+
+			const usage = parser.extractUsage(event!);
+			expect(usage).not.toBeNull();
+			expect(usage?.inputTokens).toBe(1000);
+			expect(usage?.outputTokens).toBe(500);
+		});
+	});
+});

--- a/src/__tests__/main/parsers/qwen-output-parser.test.ts
+++ b/src/__tests__/main/parsers/qwen-output-parser.test.ts
@@ -98,4 +98,76 @@ describe('QwenOutputParser', () => {
 			expect(usage?.outputTokens).toBe(500);
 		});
 	});
+
+	describe('is_error handling', () => {
+		it('reclassifies a failed result (is_error true) as an error event', () => {
+			const line = JSON.stringify({
+				type: 'result',
+				subtype: 'error_during_execution',
+				is_error: true,
+				result: 'something went wrong',
+				session_id: 'qwen-sess-err',
+			});
+
+			const event = parser.parseJsonLine(line);
+			expect(event).not.toBeNull();
+			expect(event?.type).toBe('error');
+			expect(event?.text).toBe('something went wrong');
+			expect(event?.sessionId).toBe('qwen-sess-err');
+			expect(parser.isResultMessage(event!)).toBe(false);
+		});
+
+		it('keeps a successful result (is_error false) as a result event', () => {
+			const line = JSON.stringify({
+				type: 'result',
+				subtype: 'success',
+				is_error: false,
+				result: 'done',
+				session_id: 'qwen-sess-ok',
+			});
+
+			const event = parser.parseJsonLine(line);
+			expect(event?.type).toBe('result');
+			expect(parser.isResultMessage(event!)).toBe(true);
+		});
+
+		it('falls back to agent_crashed for an unrecognized failure result', () => {
+			const error = parser.detectErrorFromParsed({
+				type: 'result',
+				subtype: 'error_during_execution',
+				is_error: true,
+				result: 'the task could not be completed',
+				session_id: 'qwen-sess-err',
+			});
+
+			expect(error).not.toBeNull();
+			expect(error?.type).toBe('agent_crashed');
+			expect(error?.recoverable).toBe(false);
+			expect(error?.message).toBe('the task could not be completed');
+			expect(error?.agentId).toBe('qwen3-coder');
+		});
+
+		it('classifies a missing session failure result as session_not_found', () => {
+			const error = parser.detectErrorFromParsed({
+				type: 'result',
+				subtype: 'error_during_execution',
+				is_error: true,
+				result: 'No conversation found with session id qwen-sess-gone',
+			});
+
+			expect(error?.type).toBe('session_not_found');
+			expect(error?.recoverable).toBe(true);
+		});
+
+		it('does not flag a successful result as an error', () => {
+			const error = parser.detectErrorFromParsed({
+				type: 'result',
+				subtype: 'success',
+				result: 'done',
+				session_id: 'qwen-sess-ok',
+			});
+
+			expect(error).toBeNull();
+		});
+	});
 });

--- a/src/__tests__/main/parsers/qwen-output-parser.test.ts
+++ b/src/__tests__/main/parsers/qwen-output-parser.test.ts
@@ -97,6 +97,49 @@ describe('QwenOutputParser', () => {
 			expect(usage?.inputTokens).toBe(1000);
 			expect(usage?.outputTokens).toBe(500);
 		});
+
+		it('does not carry the Claude 200000 fallback context window', () => {
+			// A Qwen result with only top-level usage should NOT inherit Claude's
+			// 200000 fallback context window: StdoutHandler.buildUsageStats prefers a
+			// parser-supplied window over the spawned process's configured 262144,
+			// so the fallback must be omitted to let the configured window win.
+			const event = parser.parseJsonLine(
+				JSON.stringify({
+					type: 'result',
+					subtype: 'success',
+					result: 'done',
+					usage: {
+						input_tokens: 1000,
+						output_tokens: 500,
+					},
+				})
+			);
+
+			const usage = parser.extractUsage(event!);
+			expect(usage).not.toBeNull();
+			expect(usage?.contextWindow).toBeUndefined();
+		});
+
+		it('preserves a genuinely larger reported context window', () => {
+			// When a model actually reports its own (larger) window, keep it.
+			const event = parser.parseJsonLine(
+				JSON.stringify({
+					type: 'result',
+					subtype: 'success',
+					result: 'done',
+					modelUsage: {
+						'qwen3-coder-plus': {
+							inputTokens: 1000,
+							outputTokens: 500,
+							contextWindow: 262144,
+						},
+					},
+				})
+			);
+
+			const usage = parser.extractUsage(event!);
+			expect(usage?.contextWindow).toBe(262144);
+		});
 	});
 
 	describe('is_error handling', () => {
@@ -115,6 +158,41 @@ describe('QwenOutputParser', () => {
 			expect(event?.text).toBe('something went wrong');
 			expect(event?.sessionId).toBe('qwen-sess-err');
 			expect(parser.isResultMessage(event!)).toBe(false);
+		});
+
+		it('populates error text from error.message when result is absent', () => {
+			// Qwen failures carry the actionable message in error.message; the base
+			// Claude extraction (result / message.content) misses it, so the error
+			// event would otherwise have empty text and downstream callers (which
+			// record errors from event.text) would lose the provider message.
+			const line = JSON.stringify({
+				type: 'result',
+				subtype: 'error_during_execution',
+				is_error: true,
+				error: { message: 'Qwen provider quota exceeded' },
+				session_id: 'qwen-sess-err2',
+			});
+
+			const event = parser.parseJsonLine(line);
+			expect(event?.type).toBe('error');
+			expect(event?.text).toBe('Qwen provider quota exceeded');
+			expect(event?.sessionId).toBe('qwen-sess-err2');
+		});
+
+		it('surfaces error.message through detectErrorFromParsed when result is absent', () => {
+			// A message with no known error-pattern match flows through verbatim,
+			// confirming detectErrorFromParsed now reads error.message (not just result).
+			const error = parser.detectErrorFromParsed({
+				type: 'result',
+				subtype: 'error_during_execution',
+				is_error: true,
+				error: { message: 'the upstream model returned an unexpected failure' },
+			});
+
+			expect(error).not.toBeNull();
+			expect(error?.type).toBe('agent_crashed');
+			expect(error?.message).toBe('the upstream model returned an unexpected failure');
+			expect(error?.agentId).toBe('qwen3-coder');
 		});
 
 		it('keeps a successful result (is_error false) as a result event', () => {

--- a/src/__tests__/main/utils/agent-args.test.ts
+++ b/src/__tests__/main/utils/agent-args.test.ts
@@ -437,6 +437,32 @@ describe('buildAgentArgs', () => {
 		).toEqual(['--model', 'gpt-5']);
 	});
 
+	it('builds Qwen read-only args with --approval-mode plan and never -y', () => {
+		const qwen = AGENT_DEFINITIONS.find((agent) => agent.id === 'qwen3-coder');
+		expect(qwen).toBeDefined();
+		const result = buildAgentArgs(qwen!, {
+			baseArgs: [],
+			prompt: 'review this code',
+			readOnlyMode: true,
+		});
+		// batchModeArgs (-y) is skipped in read-only; plan mode denies write/shell/edit
+		expect(result).toContain('--approval-mode');
+		expect(result).toContain('plan');
+		expect(result).not.toContain('-y');
+	});
+
+	it('builds omp read-only args restricting tools to read/search', () => {
+		const omp = AGENT_DEFINITIONS.find((agent) => agent.id === 'omp');
+		expect(omp).toBeDefined();
+		const result = buildAgentArgs(omp!, {
+			baseArgs: [],
+			prompt: 'review this code',
+			readOnlyMode: true,
+		});
+		expect(result).toContain('--tools');
+		expect(result).toContain('read,grep,glob');
+	});
+
 	// -- readOnlyMode + batchModeArgs interaction (TASK-S05) --
 	it('skips batchModeArgs when readOnlyMode is true even with empty readOnlyArgs', () => {
 		// Gemini CLI scenario: readOnlyArgs is [] but -y should still be skipped

--- a/src/__tests__/shared/agentIds.test.ts
+++ b/src/__tests__/shared/agentIds.test.ts
@@ -30,6 +30,7 @@ describe('agentIds', () => {
 
 		it('should contain beta agents', () => {
 			expect(AGENT_IDS).toContain('copilot-cli');
+			expect(AGENT_IDS).toContain('omp');
 		});
 
 		it('should have no duplicates', () => {

--- a/src/__tests__/shared/agentMetadata.test.ts
+++ b/src/__tests__/shared/agentMetadata.test.ts
@@ -33,6 +33,7 @@ describe('agentMetadata', () => {
 			expect(AGENT_DISPLAY_NAMES['gemini-cli']).toBe('Gemini CLI');
 			expect(AGENT_DISPLAY_NAMES['qwen3-coder']).toBe('Qwen3 Coder');
 			expect(AGENT_DISPLAY_NAMES['copilot-cli']).toBe('Copilot-CLI');
+			expect(AGENT_DISPLAY_NAMES['omp']).toBe('Oh My Pi');
 			expect(AGENT_DISPLAY_NAMES['terminal']).toBe('Terminal');
 		});
 
@@ -81,6 +82,7 @@ describe('agentMetadata', () => {
 			expect(BETA_AGENTS.has('hermes')).toBe(true);
 			expect(BETA_AGENTS.has('pi')).toBe(true);
 			expect(BETA_AGENTS.has('copilot-cli')).toBe(true);
+			expect(BETA_AGENTS.has('omp')).toBe(true);
 		});
 
 		it('should not contain non-beta agents', () => {
@@ -105,6 +107,7 @@ describe('agentMetadata', () => {
 			expect(isBetaAgent('hermes')).toBe(true);
 			expect(isBetaAgent('pi')).toBe(true);
 			expect(isBetaAgent('copilot-cli')).toBe(true);
+			expect(isBetaAgent('omp')).toBe(true);
 		});
 
 		it('should return false for non-beta agents', () => {

--- a/src/__tests__/shared/agentMetadata.test.ts
+++ b/src/__tests__/shared/agentMetadata.test.ts
@@ -81,6 +81,7 @@ describe('agentMetadata', () => {
 			expect(BETA_AGENTS.has('hermes')).toBe(true);
 			expect(BETA_AGENTS.has('pi')).toBe(true);
 			expect(BETA_AGENTS.has('copilot-cli')).toBe(true);
+			expect(BETA_AGENTS.has('qwen3-coder')).toBe(true);
 		});
 
 		it('should not contain non-beta agents', () => {
@@ -88,7 +89,6 @@ describe('agentMetadata', () => {
 			expect(BETA_AGENTS.has('claude-code')).toBe(false);
 			expect(BETA_AGENTS.has('terminal')).toBe(false);
 			expect(BETA_AGENTS.has('gemini-cli')).toBe(false);
-			expect(BETA_AGENTS.has('qwen3-coder')).toBe(false);
 		});
 
 		it('should only contain valid agent IDs', () => {
@@ -105,6 +105,7 @@ describe('agentMetadata', () => {
 			expect(isBetaAgent('hermes')).toBe(true);
 			expect(isBetaAgent('pi')).toBe(true);
 			expect(isBetaAgent('copilot-cli')).toBe(true);
+			expect(isBetaAgent('qwen3-coder')).toBe(true);
 		});
 
 		it('should return false for non-beta agents', () => {
@@ -112,7 +113,6 @@ describe('agentMetadata', () => {
 			expect(isBetaAgent('codex')).toBe(false);
 			expect(isBetaAgent('terminal')).toBe(false);
 			expect(isBetaAgent('gemini-cli')).toBe(false);
-			expect(isBetaAgent('qwen3-coder')).toBe(false);
 		});
 
 		it('should return false for unknown agents', () => {

--- a/src/main/agents/capabilities.ts
+++ b/src/main/agents/capabilities.ts
@@ -275,7 +275,7 @@ export const AGENT_CAPABILITIES: Record<string, AgentCapabilities> = {
 	 */
 	omp: {
 		supportsResume: true,
-		supportsReadOnlyMode: false,
+		supportsReadOnlyMode: true, // --tools read,grep,glob restricts to read-only tools - Verified
 		supportsJsonOutput: true,
 		supportsSessionId: true,
 		supportsImageInput: true,

--- a/src/main/agents/capabilities.ts
+++ b/src/main/agents/capabilities.ts
@@ -166,35 +166,37 @@ export const AGENT_CAPABILITIES: Record<string, AgentCapabilities> = {
 	},
 
 	/**
-	 * Qwen3 Coder - Alibaba's Qwen coding model
+	 * Qwen3 Coder - Alibaba's Qwen coding agent (Qwen Code CLI)
 	 *
-	 * PLACEHOLDER: Most capabilities set to false until Qwen3 Coder CLI is available
-	 * and can be tested. Update this configuration when integrating the agent.
+	 * Qwen Code is a Gemini CLI fork that exposes the same stream-json headless
+	 * interface. Capabilities mirror the Gemini/Claude stream-json integration.
+	 * Resume and session storage are deferred until verified against a live
+	 * Coding-plan account (beta scope).
 	 */
 	'qwen3-coder': {
-		supportsResume: false,
-		supportsReadOnlyMode: false,
-		supportsJsonOutput: false,
-		supportsSessionId: false,
-		supportsImageInput: false,
+		supportsResume: false, // Defer until --resume verified in headless mode
+		supportsReadOnlyMode: false, // Prompt-only enforcement via -y
+		supportsJsonOutput: true,
+		supportsSessionId: true,
+		supportsImageInput: true, // Qwen is multimodal; imageArgs unset for beta
 		supportsImageInputOnResume: false,
 		supportsSlashCommands: false,
-		supportsSessionStorage: false,
-		supportsCostTracking: false, // Local model - no cost
-		supportsUsageStats: false,
-		supportsBatchMode: false,
-		requiresPromptToStart: false, // Not yet investigated
-		supportsStreaming: true, // Likely streams
-		supportsResultMessages: false,
-		supportsModelSelection: false, // Not yet investigated
+		supportsSessionStorage: false, // Deferred to keep beta scope
+		supportsCostTracking: false, // Local/plan model - no cost
+		supportsUsageStats: true,
+		supportsBatchMode: true,
+		requiresPromptToStart: false,
+		supportsStreaming: true,
+		supportsResultMessages: true,
+		supportsModelSelection: true,
 		supportsStreamJsonInput: false,
-		supportsThinkingDisplay: false, // Not yet investigated
-		supportsContextMerge: false, // Not yet investigated - PLACEHOLDER
-		supportsContextExport: false, // Not yet investigated - PLACEHOLDER
-		supportsWizard: false, // PLACEHOLDER
-		supportsGroupChatModeration: false, // PLACEHOLDER
-		usesJsonLineOutput: false, // PLACEHOLDER
-		usesCombinedContextWindow: false, // PLACEHOLDER
+		supportsThinkingDisplay: true,
+		supportsContextMerge: true,
+		supportsContextExport: false,
+		supportsWizard: false,
+		supportsGroupChatModeration: false,
+		usesJsonLineOutput: true,
+		usesCombinedContextWindow: false,
 		supportsAppendSystemPrompt: false,
 		supportsProjectMemory: false,
 	},

--- a/src/main/agents/capabilities.ts
+++ b/src/main/agents/capabilities.ts
@@ -170,15 +170,15 @@ export const AGENT_CAPABILITIES: Record<string, AgentCapabilities> = {
 	 *
 	 * Qwen Code is a Gemini CLI fork that exposes the same stream-json headless
 	 * interface. Capabilities mirror the Gemini/Claude stream-json integration.
-	 * Resume and session storage are deferred until verified against a live
+	 * Session storage is deferred until verified against a live
 	 * Coding-plan account (beta scope).
 	 */
 	'qwen3-coder': {
-		supportsResume: false, // Defer until --resume verified in headless mode
+		supportsResume: true, // --resume <sessionId> headless resume (resumeArgs wired)
 		supportsReadOnlyMode: false, // Prompt-only enforcement via -y
 		supportsJsonOutput: true,
 		supportsSessionId: true,
-		supportsImageInput: true, // Qwen is multimodal; imageArgs unset for beta
+		supportsImageInput: false, // No image CLI args wired (imageArgs undefined); enable when wired
 		supportsImageInputOnResume: false,
 		supportsSlashCommands: false,
 		supportsSessionStorage: false, // Deferred to keep beta scope

--- a/src/main/agents/capabilities.ts
+++ b/src/main/agents/capabilities.ts
@@ -295,6 +295,10 @@ export const AGENT_CAPABILITIES: Record<string, AgentCapabilities> = {
 		supportsGroupChatModeration: false,
 		usesJsonLineOutput: true,
 		usesCombinedContextWindow: false,
+		// omp exposes only the inline `--append-system-prompt` flag, not the
+		// `--append-system-prompt-file` variant that Maestro's Windows-local
+		// delivery path emits when this is true. Enabling it would break omp on
+		// Windows (unknown flag), and the flag name is not overridable per agent.
 		supportsAppendSystemPrompt: false,
 		supportsProjectMemory: false,
 	},

--- a/src/main/agents/capabilities.ts
+++ b/src/main/agents/capabilities.ts
@@ -266,6 +266,40 @@ export const AGENT_CAPABILITIES: Record<string, AgentCapabilities> = {
 	},
 
 	/**
+	 * Oh My Pi - JSON event-stream batch integration via `omp -p --mode json`.
+	 * Oh My Pi emits a session id, streaming message deltas, tool lifecycle
+	 * events, and per-message usage/cost. It resumes sessions through `--resume`
+	 * and selects models with a fuzzy `--model` matcher.
+	 */
+	omp: {
+		supportsResume: true,
+		supportsReadOnlyMode: false,
+		supportsJsonOutput: true,
+		supportsSessionId: true,
+		supportsImageInput: true,
+		supportsImageInputOnResume: true,
+		supportsSlashCommands: false,
+		supportsSessionStorage: false,
+		supportsCostTracking: true,
+		supportsUsageStats: true,
+		supportsBatchMode: true,
+		requiresPromptToStart: true,
+		supportsStreaming: true,
+		supportsResultMessages: true,
+		supportsModelSelection: true,
+		supportsStreamJsonInput: false,
+		supportsThinkingDisplay: true,
+		supportsContextMerge: true,
+		supportsContextExport: false,
+		supportsWizard: false,
+		supportsGroupChatModeration: false,
+		usesJsonLineOutput: true,
+		usesCombinedContextWindow: false,
+		supportsAppendSystemPrompt: false,
+		supportsProjectMemory: false,
+	},
+
+	/**
 	 * OpenCode - Open source coding assistant
 	 * https://github.com/opencode-ai/opencode
 	 *

--- a/src/main/agents/definitions.ts
+++ b/src/main/agents/definitions.ts
@@ -369,18 +369,10 @@ export const AGENT_DEFINITIONS: AgentDefinition[] = [
 		configOptions: [
 			{
 				key: 'model',
-				type: 'select' as const,
+				type: 'text',
 				label: 'Model',
 				description:
-					'Model to use. Leave blank to use the Qwen Code default for your account or plan.',
-				options: [
-					'',
-					'qwen3-coder-plus',
-					'qwen3-coder-flash',
-					'qwen-max',
-					'qwen-plus',
-					'qwen-turbo',
-				],
+					'Model passed to -m. Qwen Code is multi-provider, so any model id works (e.g. coder-model, qwen3-coder-plus, qwen3.5-plus, or an OpenAI-compatible id like openai/gpt-4o). Leave blank for the account/plan default.',
 				default: '',
 				argBuilder: (value: string) => (value && value.trim() ? ['-m', value.trim()] : []),
 			},

--- a/src/main/agents/definitions.ts
+++ b/src/main/agents/definitions.ts
@@ -429,8 +429,11 @@ export const AGENT_DEFINITIONS: AgentDefinition[] = [
 		args: [],
 		batchModePrefix: ['-p'],
 		jsonOutputArgs: ['--mode', 'json'],
-		noPromptSeparator: true,
+		// No noPromptSeparator: use Maestro's default '--' end-of-options separator
+		// before the prompt. omp supports '--', so prompts beginning with '-' or
+		// '---' (markdown front matter) reach the model instead of being parsed as flags.
 		resumeArgs: (sessionId: string) => ['--resume', sessionId],
+		noToolsArgs: ['--no-tools'], // Tab naming disables all tools so a task-like first message yields a name, not a real agentic run (mirrors Pi)
 		modelArgs: (modelId: string) => ['--model', modelId],
 		workingDirArgs: (dir: string) => ['--cwd', dir],
 		imageArgs: (imagePath: string) => [`@${imagePath}`],

--- a/src/main/agents/definitions.ts
+++ b/src/main/agents/definitions.ts
@@ -440,11 +440,10 @@ export const AGENT_DEFINITIONS: AgentDefinition[] = [
 		configOptions: [
 			{
 				key: 'model',
-				type: 'select' as const,
+				type: 'text',
 				label: 'Model',
 				description:
-					'Fuzzy model selector passed to --model (for example, opus, sonnet, or anthropic/claude-opus-4-8). Leave empty for the CLI default.',
-				options: ['', 'opus', 'sonnet', 'haiku', 'gpt-5', 'gemini-2.5-pro'],
+					'Fuzzy model override passed to --model (for example, opus, gpt-5.2, or openai/gpt-5.2). Multi-provider; leave empty for the CLI default.',
 				default: '',
 				argBuilder: (value: string) => (value && value.trim() ? ['--model', value.trim()] : []),
 			},

--- a/src/main/agents/definitions.ts
+++ b/src/main/agents/definitions.ts
@@ -356,11 +356,12 @@ export const AGENT_DEFINITIONS: AgentDefinition[] = [
 		batchModeArgs: ['-y'],
 		jsonOutputArgs: ['--output-format', 'stream-json'],
 		resumeArgs: (sessionId: string) => ['--resume', sessionId],
-		// Qwen Code is a Gemini CLI fork; read-only behavior is enforced via system prompt
-		// instructions. The -y flag is still needed for non-interactive execution to prevent
-		// approval prompts from hanging batch mode.
-		readOnlyArgs: ['-y'],
-		readOnlyCliEnforced: false, // No CLI-level read-only enforcement; prompt-only
+		// Qwen Code (qwen-code v0.19.x) ships a first-class `--approval-mode plan` that denies
+		// write/shell/edit tools in non-interactive mode (read-only analysis). It does not need
+		// `-y` to avoid hangs (non-interactive plan/default denies tools rather than prompting),
+		// and `-y` (YOLO) would auto-approve writes, defeating read-only intent.
+		readOnlyArgs: ['--approval-mode', 'plan'],
+		readOnlyCliEnforced: true, // CLI enforces read-only via --approval-mode plan
 		yoloModeArgs: ['-y'],
 		workingDirArgs: (dir: string) => ['--include-directories', dir],
 		imageArgs: undefined,
@@ -465,6 +466,8 @@ export const AGENT_DEFINITIONS: AgentDefinition[] = [
 		// before the prompt. omp supports '--', so prompts beginning with '-' or
 		// '---' (markdown front matter) reach the model instead of being parsed as flags.
 		resumeArgs: (sessionId: string) => ['--resume', sessionId],
+		readOnlyArgs: ['--tools', 'read,grep,glob'], // Read-only: restrict to read/search tools (search->grep, find->glob aliases)
+		readOnlyCliEnforced: true,
 		noToolsArgs: ['--no-tools'], // Tab naming disables all tools so a task-like first message yields a name, not a real agentic run (mirrors Pi)
 		modelArgs: (modelId: string) => ['--model', modelId],
 		workingDirArgs: (dir: string) => ['--cwd', dir],

--- a/src/main/agents/definitions.ts
+++ b/src/main/agents/definitions.ts
@@ -422,6 +422,40 @@ export const AGENT_DEFINITIONS: AgentDefinition[] = [
 		],
 	},
 	{
+		id: 'omp',
+		name: 'Oh My Pi',
+		binaryName: 'omp',
+		command: 'omp',
+		args: [],
+		batchModePrefix: ['-p'],
+		jsonOutputArgs: ['--mode', 'json'],
+		noPromptSeparator: true,
+		resumeArgs: (sessionId: string) => ['--resume', sessionId],
+		modelArgs: (modelId: string) => ['--model', modelId],
+		workingDirArgs: (dir: string) => ['--cwd', dir],
+		imageArgs: (imagePath: string) => [`@${imagePath}`],
+		configOptions: [
+			{
+				key: 'model',
+				type: 'select' as const,
+				label: 'Model',
+				description:
+					'Fuzzy model selector passed to --model (for example, opus, sonnet, or anthropic/claude-opus-4-8). Leave empty for the CLI default.',
+				options: ['', 'opus', 'sonnet', 'haiku', 'gpt-5', 'gemini-2.5-pro'],
+				default: '',
+				argBuilder: (value: string) => (value && value.trim() ? ['--model', value.trim()] : []),
+			},
+			{
+				key: 'contextWindow',
+				type: 'number',
+				label: 'Context Window Size',
+				description:
+					'Fallback context window size in tokens until Oh My Pi reports a runtime-specific value.',
+				default: 200000,
+			},
+		],
+	},
+	{
 		id: 'opencode',
 		name: 'OpenCode',
 		binaryName: 'opencode',

--- a/src/main/agents/definitions.ts
+++ b/src/main/agents/definitions.ts
@@ -349,10 +349,50 @@ export const AGENT_DEFINITIONS: AgentDefinition[] = [
 	{
 		id: 'qwen3-coder',
 		name: 'Qwen3 Coder',
-		hidden: true, // Not shipping. Kept for type/back-compat, hidden from UI.
-		binaryName: 'qwen3-coder',
-		command: 'qwen3-coder',
+		binaryName: 'qwen',
+		command: 'qwen',
 		args: [],
+		batchModePrefix: [],
+		batchModeArgs: ['-y'],
+		jsonOutputArgs: ['--output-format', 'stream-json'],
+		resumeArgs: (sessionId: string) => ['--resume', sessionId],
+		// Qwen Code is a Gemini CLI fork; read-only behavior is enforced via system prompt
+		// instructions. The -y flag is still needed for non-interactive execution to prevent
+		// approval prompts from hanging batch mode.
+		readOnlyArgs: ['-y'],
+		readOnlyCliEnforced: false, // No CLI-level read-only enforcement; prompt-only
+		yoloModeArgs: ['-y'],
+		workingDirArgs: (dir: string) => ['--include-directories', dir],
+		imageArgs: undefined,
+		modelArgs: (modelId: string) => ['-m', modelId],
+		promptArgs: (prompt: string) => ['-p', prompt],
+		configOptions: [
+			{
+				key: 'model',
+				type: 'select' as const,
+				label: 'Model',
+				description:
+					'Model to use. Leave blank to use the Qwen Code default for your account or plan.',
+				options: [
+					'',
+					'qwen3-coder-plus',
+					'qwen3-coder-flash',
+					'qwen-max',
+					'qwen-plus',
+					'qwen-turbo',
+				],
+				default: '',
+				argBuilder: (value: string) => (value && value.trim() ? ['-m', value.trim()] : []),
+			},
+			{
+				key: 'contextWindow',
+				type: 'number' as const,
+				label: 'Context Window Size',
+				description:
+					'Maximum context window size in tokens. Qwen3-Coder supports a native 256K (262144) context window.',
+				default: 262144,
+			},
+		],
 	},
 	{
 		id: 'hermes',

--- a/src/main/agents/detector.ts
+++ b/src/main/agents/detector.ts
@@ -468,6 +468,43 @@ export class AgentDetector {
 					return userModel ? [userModel] : [];
 				}
 
+				case 'omp': {
+					// Oh My Pi: `omp models --json` returns { models: [{ id, selector, ... }] }
+					// across every configured provider. Prefer the provider-qualified `selector`
+					// (e.g. anthropic/claude-opus-4-8), which is unambiguous for --model.
+					const result = await execFileNoThrow(command, ['models', '--json'], undefined, env);
+					if (result.exitCode !== 0) {
+						logger.warn(
+							`CLI model discovery failed for ${agentId}: exit code ${result.exitCode}`,
+							LOG_CONTEXT,
+							{ stderr: result.stderr }
+						);
+						return [];
+					}
+					let parsed: { models?: Array<{ id?: string; selector?: string }> };
+					try {
+						parsed = parseJsonWithBom<{ models?: Array<{ id?: string; selector?: string }> }>(
+							result.stdout
+						);
+					} catch (parseError) {
+						logger.warn('Failed to parse omp models --json output', LOG_CONTEXT, {
+							error: parseError,
+						});
+						return [];
+					}
+					const seen = new Set<string>();
+					const models: string[] = [];
+					for (const entry of parsed.models ?? []) {
+						const modelId = entry.selector || entry.id;
+						if (modelId && !seen.has(modelId)) {
+							seen.add(modelId);
+							models.push(modelId);
+						}
+					}
+					logger.info(`Discovered ${models.length} models for ${agentId}`, LOG_CONTEXT);
+					return models;
+				}
+
 				default:
 					// For agents without model discovery implemented, return empty array
 					logger.debug(`No model discovery implemented for ${agentId}`, LOG_CONTEXT);

--- a/src/main/agents/detector.ts
+++ b/src/main/agents/detector.ts
@@ -319,6 +319,13 @@ export class AgentDetector {
 		// Run agent-specific model discovery command
 		const models = await this.runModelDiscovery(agentId, agent);
 
+		// A transient `omp models --json` failure returns an empty list. Don't cache
+		// that, or the picker stays empty for the whole TTL even after the CLI
+		// recovers; let the next call retry. (omp always has a non-empty catalog.)
+		if (agentId === 'omp' && models.length === 0) {
+			return models;
+		}
+
 		// Cache the results
 		this.modelCache.set(agentId, { models, timestamp: Date.now() });
 
@@ -487,6 +494,10 @@ export class AgentDetector {
 							result.stdout
 						);
 					} catch (parseError) {
+						captureException(parseError, {
+							operation: 'agent:modelDiscovery',
+							agentId,
+						});
 						logger.warn('Failed to parse omp models --json output', LOG_CONTEXT, {
 							error: parseError,
 						});

--- a/src/main/agents/path-prober.ts
+++ b/src/main/agents/path-prober.ts
@@ -349,6 +349,13 @@ function getWindowsKnownPaths(binaryName: string): string[] {
 			...npmGlobal('pi'),
 			...localBin('pi'),
 		],
+		omp: [
+			// Bun global installation (primary method for Oh My Pi)
+			path.join(home, '.bun', 'bin', 'omp.exe'),
+			// npm global installation
+			...npmGlobal('omp'),
+			...localBin('omp'),
+		],
 		gh: [
 			// GitHub CLI official installer (MSI)
 			path.join(programFiles, 'GitHub CLI', 'gh.exe'),
@@ -490,6 +497,15 @@ function getUnixKnownPaths(binaryName: string): string[] {
 			...npmGlobal('pi'),
 			path.join(home, 'bin', 'pi'),
 			...nodeVersionManagers('pi'),
+		],
+		omp: [
+			// Bun global installation (primary method for Oh My Pi)
+			path.join(home, '.bun', 'bin', 'omp'),
+			...localBin('omp'),
+			...homebrew('omp'),
+			...npmGlobal('omp'),
+			path.join(home, 'bin', 'omp'),
+			...nodeVersionManagers('omp'),
 		],
 		gh: [
 			// Homebrew (Apple Silicon + Intel)

--- a/src/main/ipc/handlers/agents.ts
+++ b/src/main/ipc/handlers/agents.ts
@@ -29,6 +29,7 @@ import { stripAnsi } from '../../utils/stripAnsi';
 import { SshRemoteConfig } from '../../../shared/types';
 import { MaestroSettings } from './persistence';
 import { captureException } from '../../utils/sentry';
+import { parseJsonWithBom } from '../../../shared/jsonUtils';
 import {
 	getAllSnapshots as getAllClaudeUsageSnapshots,
 	resolveConfigDirKey,
@@ -607,7 +608,7 @@ async function discoverModelsRemote(
 
 	const remoteOptions: RemoteCommandOptions = {
 		command: agentDef.binaryName,
-		args: ['models'],
+		args: agentId === 'omp' ? ['models', '--json'] : ['models'],
 		env: sshRemote.remoteEnv,
 	};
 
@@ -646,15 +647,38 @@ async function discoverModelsRemote(
 		const seen = new Set<string>();
 		const models: string[] = [];
 
-		// Source 1: CLI-discovered models
-		const cliModels = stripAnsi(result.stdout)
-			.split('\n')
-			.map((l) => l.trim())
-			.filter((l) => l.length > 0);
-		for (const m of cliModels) {
-			if (!seen.has(m)) {
-				seen.add(m);
-				models.push(m);
+		if (agentId === 'omp') {
+			// `omp models` prints a human table; the machine-readable form is
+			// `omp models --json` -> { models: [{ selector, id, ... }] }. Use the
+			// provider-qualified selector, mirroring the local discovery path so the
+			// remote picker is not filled with table headings/box rows.
+			try {
+				const parsed = parseJsonWithBom<{ models?: Array<{ id?: string; selector?: string }> }>(
+					result.stdout
+				);
+				for (const entry of parsed.models ?? []) {
+					const modelId = entry.selector || entry.id;
+					if (modelId && !seen.has(modelId)) {
+						seen.add(modelId);
+						models.push(modelId);
+					}
+				}
+			} catch (parseError) {
+				logger.warn('Failed to parse remote omp models --json output', LOG_CONTEXT, {
+					error: parseError,
+				});
+			}
+		} else {
+			// Source 1: CLI-discovered models (one per line)
+			const cliModels = stripAnsi(result.stdout)
+				.split('\n')
+				.map((l) => l.trim())
+				.filter((l) => l.length > 0);
+			for (const m of cliModels) {
+				if (!seen.has(m)) {
+					seen.add(m);
+					models.push(m);
+				}
 			}
 		}
 

--- a/src/main/ipc/handlers/agents.ts
+++ b/src/main/ipc/handlers/agents.ts
@@ -646,6 +646,7 @@ async function discoverModelsRemote(
 
 		const seen = new Set<string>();
 		const models: string[] = [];
+		const sanitizedStdout = stripAnsi(result.stdout);
 
 		if (agentId === 'omp') {
 			// `omp models` prints a human table; the machine-readable form is
@@ -654,7 +655,7 @@ async function discoverModelsRemote(
 			// remote picker is not filled with table headings/box rows.
 			try {
 				const parsed = parseJsonWithBom<{ models?: Array<{ id?: string; selector?: string }> }>(
-					result.stdout
+					sanitizedStdout
 				);
 				for (const entry of parsed.models ?? []) {
 					const modelId = entry.selector || entry.id;
@@ -670,7 +671,7 @@ async function discoverModelsRemote(
 			}
 		} else {
 			// Source 1: CLI-discovered models (one per line)
-			const cliModels = stripAnsi(result.stdout)
+			const cliModels = sanitizedStdout
 				.split('\n')
 				.map((l) => l.trim())
 				.filter((l) => l.length > 0);

--- a/src/main/parsers/error-patterns.ts
+++ b/src/main/parsers/error-patterns.ts
@@ -1062,6 +1062,18 @@ const QWEN_ERROR_PATTERNS: AgentErrorPatterns = {
 			recoverable: false,
 		},
 	],
+	session_not_found: [
+		{
+			pattern: /session.*not found|no conversation found with session id/i,
+			message: 'Session not found. Starting fresh conversation.',
+			recoverable: true,
+		},
+		{
+			pattern: /invalid.*session/i,
+			message: 'Invalid session. Starting fresh conversation.',
+			recoverable: true,
+		},
+	],
 };
 
 // ============================================================================

--- a/src/main/parsers/error-patterns.ts
+++ b/src/main/parsers/error-patterns.ts
@@ -1026,6 +1026,44 @@ const PI_ERROR_PATTERNS: AgentErrorPatterns = {
 	],
 };
 
+const QWEN_ERROR_PATTERNS: AgentErrorPatterns = {
+	auth_expired: [
+		{
+			pattern: /invalid api key|authentication failed|unauthorized|not authenticated|401/i,
+			message: 'Qwen Code authentication failed. Re-authenticate your Qwen account or API key.',
+			recoverable: true,
+		},
+	],
+	rate_limited: [
+		{
+			pattern: /rate limit|too many requests|\b429\b|quota exceeded/i,
+			message: 'Qwen Code rate limit exceeded. Please wait and try again.',
+			recoverable: true,
+		},
+	],
+	token_exhaustion: [
+		{
+			pattern: /context.*(exceeded|too long)|maximum.*tokens|prompt.*too long/i,
+			message: 'Qwen Code context limit exceeded. Start a new session.',
+			recoverable: true,
+		},
+	],
+	network_error: [
+		{
+			pattern: /connection (failed|refused|reset)|ECONNREFUSED|ECONNRESET|ETIMEDOUT|ENOTFOUND/i,
+			message: 'Qwen Code could not reach the model provider. Check your network connection.',
+			recoverable: true,
+		},
+	],
+	agent_crashed: [
+		{
+			pattern: /\b(fatal|unexpected|internal|unhandled)\s+error\b/i,
+			message: 'An unexpected error occurred in the agent.',
+			recoverable: false,
+		},
+	],
+};
+
 // ============================================================================
 // Pattern Registry
 // ============================================================================
@@ -1037,6 +1075,7 @@ const patternRegistry = new Map<ToolType, AgentErrorPatterns>([
 	['factory-droid', FACTORY_DROID_ERROR_PATTERNS],
 	['copilot-cli', COPILOT_ERROR_PATTERNS],
 	['pi', PI_ERROR_PATTERNS],
+	['qwen3-coder', QWEN_ERROR_PATTERNS],
 ]);
 
 /**

--- a/src/main/parsers/error-patterns.ts
+++ b/src/main/parsers/error-patterns.ts
@@ -1026,6 +1026,45 @@ const PI_ERROR_PATTERNS: AgentErrorPatterns = {
 	],
 };
 
+const OMP_ERROR_PATTERNS: AgentErrorPatterns = {
+	auth_expired: [
+		{
+			pattern:
+				/invalid api key|authentication failed|unauthorized|not authenticated|missing api key/i,
+			message: 'Oh My Pi authentication failed. Check the selected provider credentials.',
+			recoverable: true,
+		},
+	],
+	rate_limited: [
+		{
+			pattern: /rate limit|too many requests|\b429\b|quota exceeded/i,
+			message: 'Oh My Pi provider rate limit exceeded. Please wait and try again.',
+			recoverable: true,
+		},
+	],
+	token_exhaustion: [
+		{
+			pattern: /context.*(exceeded|too long)|maximum.*tokens|prompt.*too long/i,
+			message: 'Oh My Pi context limit exceeded. Start a new session.',
+			recoverable: true,
+		},
+	],
+	network_error: [
+		{
+			pattern: /connection (failed|refused|reset)|ECONNREFUSED|ECONNRESET|ETIMEDOUT|ENOTFOUND/i,
+			message: 'Oh My Pi could not reach the selected provider. Check your network connection.',
+			recoverable: true,
+		},
+	],
+	agent_crashed: [
+		{
+			pattern: /panic|fatal error|unhandled exception|segmentation fault/i,
+			message: 'Oh My Pi crashed unexpectedly. Check the logs and try again.',
+			recoverable: true,
+		},
+	],
+};
+
 // ============================================================================
 // Pattern Registry
 // ============================================================================
@@ -1037,6 +1076,7 @@ const patternRegistry = new Map<ToolType, AgentErrorPatterns>([
 	['factory-droid', FACTORY_DROID_ERROR_PATTERNS],
 	['copilot-cli', COPILOT_ERROR_PATTERNS],
 	['pi', PI_ERROR_PATTERNS],
+	['omp', OMP_ERROR_PATTERNS],
 ]);
 
 /**

--- a/src/main/parsers/index.ts
+++ b/src/main/parsers/index.ts
@@ -59,6 +59,7 @@ import { CodexOutputParser } from './codex-output-parser';
 import { FactoryDroidOutputParser } from './factory-droid-output-parser';
 import { CopilotOutputParser } from './copilot-output-parser';
 import { PiOutputParser } from './pi-output-parser';
+import { QwenOutputParser } from './qwen-output-parser';
 import {
 	registerOutputParser,
 	clearParserRegistry,
@@ -73,6 +74,7 @@ export { CodexOutputParser } from './codex-output-parser';
 export { FactoryDroidOutputParser } from './factory-droid-output-parser';
 export { CopilotOutputParser } from './copilot-output-parser';
 export { PiOutputParser } from './pi-output-parser';
+export { QwenOutputParser } from './qwen-output-parser';
 
 const LOG_CONTEXT = '[OutputParsers]';
 
@@ -91,6 +93,7 @@ export function initializeOutputParsers(): void {
 	registerOutputParser(new FactoryDroidOutputParser());
 	registerOutputParser(new CopilotOutputParser());
 	registerOutputParser(new PiOutputParser());
+	registerOutputParser(new QwenOutputParser());
 
 	// Log registered parsers for debugging
 	const registeredParsers = getAllOutputParsers().map((p) => p.agentId);

--- a/src/main/parsers/index.ts
+++ b/src/main/parsers/index.ts
@@ -59,6 +59,7 @@ import { CodexOutputParser } from './codex-output-parser';
 import { FactoryDroidOutputParser } from './factory-droid-output-parser';
 import { CopilotOutputParser } from './copilot-output-parser';
 import { PiOutputParser } from './pi-output-parser';
+import { OmpOutputParser } from './omp-output-parser';
 import {
 	registerOutputParser,
 	clearParserRegistry,
@@ -73,6 +74,7 @@ export { CodexOutputParser } from './codex-output-parser';
 export { FactoryDroidOutputParser } from './factory-droid-output-parser';
 export { CopilotOutputParser } from './copilot-output-parser';
 export { PiOutputParser } from './pi-output-parser';
+export { OmpOutputParser } from './omp-output-parser';
 
 const LOG_CONTEXT = '[OutputParsers]';
 
@@ -91,6 +93,7 @@ export function initializeOutputParsers(): void {
 	registerOutputParser(new FactoryDroidOutputParser());
 	registerOutputParser(new CopilotOutputParser());
 	registerOutputParser(new PiOutputParser());
+	registerOutputParser(new OmpOutputParser());
 
 	// Log registered parsers for debugging
 	const registeredParsers = getAllOutputParsers().map((p) => p.agentId);

--- a/src/main/parsers/omp-output-parser.ts
+++ b/src/main/parsers/omp-output-parser.ts
@@ -19,7 +19,7 @@
 import type { AgentError, ToolType } from '../../shared/types';
 import type { AgentOutputParser, ParsedEvent } from './agent-output-parser';
 import { getErrorPatterns, matchErrorPattern } from './error-patterns';
-import { stripAllAnsiCodes } from '../utils/terminalFilter';
+import { stripAnsiCodes } from '../../shared/stringUtils';
 
 interface OmpUsage {
 	input?: number;
@@ -95,7 +95,7 @@ export class OmpOutputParser implements AgentOutputParser {
 		const sessionId =
 			event.sessionId || event.session_id || (event.type === 'session' ? event.id : undefined);
 
-		if (event.error || event.message?.errorMessage) {
+		if ((event.error || event.message?.errorMessage) && !event.willRetry) {
 			return {
 				type: 'error',
 				text: this.extractErrorText(event),
@@ -243,6 +243,9 @@ export class OmpOutputParser implements AgentOutputParser {
 		}
 
 		const event = parsed as OmpRawEvent;
+		if (event.willRetry) {
+			return null;
+		}
 		const errorText = this.extractErrorText(event);
 		if (!errorText) {
 			return null;
@@ -264,7 +267,7 @@ export class OmpOutputParser implements AgentOutputParser {
 			return null;
 		}
 
-		const cleanedOutput = stripAllAnsiCodes(`${stderr}\n${stdout}`).trim();
+		const cleanedOutput = stripAnsiCodes(`${stderr}\n${stdout}`).trim();
 		const match = matchErrorPattern(getErrorPatterns(this.agentId), cleanedOutput, {
 			minLength: 0,
 		});

--- a/src/main/parsers/omp-output-parser.ts
+++ b/src/main/parsers/omp-output-parser.ts
@@ -156,9 +156,16 @@ export class OmpOutputParser implements AgentOutputParser {
 						raw: event,
 					};
 				}
+				if (!finalMessage) {
+					// No assistant message in the final transcript (empty or missing
+					// `messages`). Return a non-result event so the stdout handler does
+					// not mark output as emitted with an empty string; the exit fallback
+					// then flushes the assembled streamed text the user already saw.
+					return { type: 'system', sessionId, raw: event };
+				}
 				return {
 					type: 'result',
-					text: finalMessage ? this.extractMessageText(finalMessage) : '',
+					text: this.extractMessageText(finalMessage),
 					sessionId,
 					raw: event,
 				};

--- a/src/main/parsers/omp-output-parser.ts
+++ b/src/main/parsers/omp-output-parser.ts
@@ -1,0 +1,337 @@
+/**
+ * Parser for Oh My Pi's (`omp`) JSON event protocol (`omp -p --mode json ...`).
+ *
+ * Oh My Pi streams newline-delimited JSON, one event per line:
+ *   - `session`            first line, `.id` is the resumable session id.
+ *   - `agent_start` / `turn_start`
+ *   - `message_start` / `message_end` for user and assistant turns.
+ *   - `message_update`     carries streaming deltas via `assistantMessageEvent`
+ *                          (`text_delta` -> answer chunk, `thinking_delta` -> reasoning).
+ *   - `message_end` (assistant) carries the authoritative `usage` (tokens + cost).
+ *   - `turn_end`
+ *   - `agent_end`          final event; `.messages` holds the completed transcript.
+ *   - `tool_execution_start|update|end` for tool lifecycle.
+ *
+ * Oh My Pi shares Pi's documented JSON shape but is registered as its own agent
+ * with its own parser instance and error patterns.
+ */
+
+import type { AgentError, ToolType } from '../../shared/types';
+import type { AgentOutputParser, ParsedEvent } from './agent-output-parser';
+import { getErrorPatterns, matchErrorPattern } from './error-patterns';
+import { stripAllAnsiCodes } from '../utils/terminalFilter';
+
+interface OmpUsage {
+	input?: number;
+	output?: number;
+	cacheRead?: number;
+	cacheWrite?: number;
+	totalTokens?: number;
+	cost?: number | { total?: number };
+}
+
+interface OmpContentBlock {
+	type?: string;
+	text?: string;
+	thinking?: string;
+}
+
+interface OmpMessage {
+	role?: string;
+	content?: string | OmpContentBlock[];
+	usage?: OmpUsage;
+	errorMessage?: string;
+}
+
+interface OmpMessageDelta {
+	type?: string;
+	delta?: string;
+}
+
+interface OmpRawEvent {
+	type?: string;
+	id?: string;
+	sessionId?: string;
+	session_id?: string;
+	message?: OmpMessage;
+	messages?: OmpMessage[];
+	assistantMessageEvent?: OmpMessageDelta;
+	toolCallId?: string;
+	toolName?: string;
+	args?: unknown;
+	partialResult?: unknown;
+	result?: unknown;
+	isError?: boolean;
+	error?: unknown;
+	messageText?: string;
+	willRetry?: boolean;
+}
+
+export class OmpOutputParser implements AgentOutputParser {
+	readonly agentId: ToolType = 'omp';
+
+	parseJsonLine(line: string): ParsedEvent | null {
+		if (!line.trim()) {
+			return null;
+		}
+
+		try {
+			return this.parseJsonObject(JSON.parse(line));
+		} catch {
+			return {
+				type: 'text',
+				text: line,
+				raw: line,
+			};
+		}
+	}
+
+	parseJsonObject(parsed: unknown): ParsedEvent | null {
+		if (!parsed || typeof parsed !== 'object') {
+			return null;
+		}
+
+		const event = parsed as OmpRawEvent;
+		const sessionId =
+			event.sessionId || event.session_id || (event.type === 'session' ? event.id : undefined);
+
+		if (event.error || event.message?.errorMessage) {
+			return {
+				type: 'error',
+				text: this.extractErrorText(event),
+				sessionId,
+				raw: event,
+			};
+		}
+
+		switch (event.type) {
+			case 'session':
+				return { type: 'init', sessionId, raw: event };
+
+			case 'message_update': {
+				const update = event.assistantMessageEvent;
+				if (update?.type === 'text_delta') {
+					return {
+						type: 'text',
+						text: update.delta || '',
+						sessionId,
+						isPartial: true,
+						raw: event,
+					};
+				}
+				if (update?.type === 'thinking_delta') {
+					return {
+						type: 'text',
+						text: update.delta || '',
+						sessionId,
+						isPartial: true,
+						isReasoning: true,
+						raw: event,
+					};
+				}
+				return { type: 'system', sessionId, raw: event };
+			}
+
+			case 'message_end':
+				if (event.message?.role === 'assistant') {
+					return {
+						type: 'usage',
+						sessionId,
+						usage: this.extractUsageFromMessage(event.message),
+						raw: event,
+					};
+				}
+				return { type: 'system', sessionId, raw: event };
+
+			case 'agent_end': {
+				if (event.willRetry) {
+					return { type: 'system', sessionId, raw: event };
+				}
+				const finalMessage = this.findFinalAssistantMessage(event.messages);
+				if (finalMessage?.errorMessage) {
+					return {
+						type: 'error',
+						text: finalMessage.errorMessage,
+						sessionId,
+						raw: event,
+					};
+				}
+				return {
+					type: 'result',
+					text: finalMessage ? this.extractMessageText(finalMessage) : '',
+					sessionId,
+					raw: event,
+				};
+			}
+
+			case 'tool_execution_start':
+				return {
+					type: 'tool_use',
+					toolCallId: event.toolCallId,
+					toolName: event.toolName,
+					toolState: { status: 'running', input: event.args },
+					sessionId,
+					raw: event,
+				};
+
+			case 'tool_execution_update':
+				return {
+					type: 'tool_use',
+					toolCallId: event.toolCallId,
+					toolName: event.toolName,
+					toolState: { status: 'running', output: event.partialResult },
+					sessionId,
+					raw: event,
+				};
+
+			case 'tool_execution_end':
+				return {
+					type: 'tool_use',
+					toolCallId: event.toolCallId,
+					toolName: event.toolName,
+					toolState: {
+						status: event.isError ? 'failed' : 'completed',
+						output: event.result,
+					},
+					sessionId,
+					raw: event,
+				};
+
+			default:
+				return { type: 'system', sessionId, raw: event };
+		}
+	}
+
+	isResultMessage(event: ParsedEvent): boolean {
+		return event.type === 'result';
+	}
+
+	extractSessionId(event: ParsedEvent): string | null {
+		return event.sessionId || null;
+	}
+
+	extractUsage(event: ParsedEvent): ParsedEvent['usage'] | null {
+		return event.usage || null;
+	}
+
+	extractSlashCommands(event: ParsedEvent): string[] | null {
+		return event.slashCommands || null;
+	}
+
+	detectErrorFromLine(line: string): AgentError | null {
+		if (!line.trim()) {
+			return null;
+		}
+
+		try {
+			return this.detectErrorFromParsed(JSON.parse(line));
+		} catch {
+			return null;
+		}
+	}
+
+	detectErrorFromParsed(parsed: unknown): AgentError | null {
+		if (!parsed || typeof parsed !== 'object') {
+			return null;
+		}
+
+		const event = parsed as OmpRawEvent;
+		const errorText = this.extractErrorText(event);
+		if (!errorText) {
+			return null;
+		}
+
+		const match = matchErrorPattern(getErrorPatterns(this.agentId), errorText, { minLength: 0 });
+		return {
+			type: match?.type || 'unknown',
+			message: match?.message || errorText,
+			recoverable: match?.recoverable ?? true,
+			agentId: this.agentId,
+			timestamp: Date.now(),
+			parsedJson: parsed,
+		};
+	}
+
+	detectErrorFromExit(exitCode: number, stderr: string, stdout: string): AgentError | null {
+		if (exitCode === 0) {
+			return null;
+		}
+
+		const cleanedOutput = stripAllAnsiCodes(`${stderr}\n${stdout}`).trim();
+		const match = matchErrorPattern(getErrorPatterns(this.agentId), cleanedOutput, {
+			minLength: 0,
+		});
+		return {
+			type: match?.type || 'agent_crashed',
+			message:
+				match?.message ||
+				`Oh My Pi exited with code ${exitCode}${cleanedOutput ? `: ${cleanedOutput.split('\n')[0]}` : ''}`,
+			recoverable: match?.recoverable ?? true,
+			agentId: this.agentId,
+			timestamp: Date.now(),
+			raw: { exitCode, stderr, stdout },
+		};
+	}
+
+	private extractMessageText(message: OmpMessage): string {
+		if (typeof message.content === 'string') {
+			return message.content;
+		}
+		if (!Array.isArray(message.content)) {
+			return '';
+		}
+		return message.content
+			.filter((block) => block.type === 'text')
+			.map((block) => block.text || '')
+			.join('');
+	}
+
+	private findFinalAssistantMessage(messages?: OmpMessage[]): OmpMessage | undefined {
+		if (!messages) {
+			return undefined;
+		}
+		for (let index = messages.length - 1; index >= 0; index--) {
+			if (messages[index].role === 'assistant') {
+				return messages[index];
+			}
+		}
+		return undefined;
+	}
+
+	private extractUsageFromMessage(message: OmpMessage): ParsedEvent['usage'] | undefined {
+		const usage = message.usage;
+		if (!usage) {
+			return undefined;
+		}
+		return {
+			inputTokens: usage.input || 0,
+			outputTokens: usage.output || 0,
+			cacheReadTokens: usage.cacheRead || 0,
+			cacheCreationTokens: usage.cacheWrite || 0,
+			costUsd: typeof usage.cost === 'number' ? usage.cost : usage.cost?.total || 0,
+		};
+	}
+
+	private extractErrorText(event: OmpRawEvent): string {
+		if (event.message?.errorMessage) {
+			return event.message.errorMessage;
+		}
+		const finalMessage = this.findFinalAssistantMessage(event.messages);
+		if (finalMessage?.errorMessage) {
+			return finalMessage.errorMessage;
+		}
+		if (typeof event.error === 'string') {
+			return event.error;
+		}
+		if (event.error && typeof event.error === 'object') {
+			const error = event.error as Record<string, unknown>;
+			if (typeof error.errorMessage === 'string') {
+				return error.errorMessage;
+			}
+			if (typeof error.message === 'string') {
+				return error.message;
+			}
+		}
+		return event.messageText || '';
+	}
+}

--- a/src/main/parsers/parser-factory.ts
+++ b/src/main/parsers/parser-factory.ts
@@ -18,6 +18,7 @@ import { CodexOutputParser } from './codex-output-parser';
 import { FactoryDroidOutputParser } from './factory-droid-output-parser';
 import { CopilotOutputParser } from './copilot-output-parser';
 import { PiOutputParser } from './pi-output-parser';
+import { OmpOutputParser } from './omp-output-parser';
 
 const PARSER_CONSTRUCTORS: Record<string, () => AgentOutputParser> = {
 	'claude-code': () => new ClaudeOutputParser(),
@@ -26,6 +27,7 @@ const PARSER_CONSTRUCTORS: Record<string, () => AgentOutputParser> = {
 	'factory-droid': () => new FactoryDroidOutputParser(),
 	'copilot-cli': () => new CopilotOutputParser(),
 	pi: () => new PiOutputParser(),
+	omp: () => new OmpOutputParser(),
 };
 
 /**

--- a/src/main/parsers/parser-factory.ts
+++ b/src/main/parsers/parser-factory.ts
@@ -18,6 +18,7 @@ import { CodexOutputParser } from './codex-output-parser';
 import { FactoryDroidOutputParser } from './factory-droid-output-parser';
 import { CopilotOutputParser } from './copilot-output-parser';
 import { PiOutputParser } from './pi-output-parser';
+import { QwenOutputParser } from './qwen-output-parser';
 
 const PARSER_CONSTRUCTORS: Record<string, () => AgentOutputParser> = {
 	'claude-code': () => new ClaudeOutputParser(),
@@ -26,6 +27,7 @@ const PARSER_CONSTRUCTORS: Record<string, () => AgentOutputParser> = {
 	'factory-droid': () => new FactoryDroidOutputParser(),
 	'copilot-cli': () => new CopilotOutputParser(),
 	pi: () => new PiOutputParser(),
+	'qwen3-coder': () => new QwenOutputParser(),
 };
 
 /**

--- a/src/main/parsers/qwen-output-parser.ts
+++ b/src/main/parsers/qwen-output-parser.ts
@@ -5,9 +5,10 @@
  *
  * Qwen Code is a fork of Gemini CLI and emits the same stream-json schema that
  * Claude Code does (`type: system/assistant/result`), so parsing reuses the
- * ClaudeOutputParser implementation wholesale. The only difference is the
- * agentId, which is overridden so the registry and error-pattern lookups key
- * off 'qwen3-coder'.
+ * ClaudeOutputParser implementation. The agentId is overridden so the registry
+ * and error-pattern lookups key off 'qwen3-coder', and result handling is
+ * extended to honor Qwen's `is_error: true` failure flag (see below), which the
+ * base parser does not inspect.
  *
  * Note: Qwen's session init message uses subtype 'session_start' rather than
  * Claude's 'init'. The generic system branch in ClaudeOutputParser still
@@ -18,14 +19,72 @@
  */
 
 import { ClaudeOutputParser } from './claude-output-parser';
-import type { ToolType } from '../../shared/types';
+import type { ToolType, AgentError } from '../../shared/types';
+import type { ParsedEvent } from './agent-output-parser';
+import { getErrorPatterns, matchErrorPattern } from './error-patterns';
 
 /**
  * Qwen Code Output Parser Implementation
  *
  * Subclasses ClaudeOutputParser to reuse its stream-json handling while
  * identifying as the 'qwen3-coder' agent.
+ *
+ * Qwen marks a failed terminal result with `is_error: true` on the `result`
+ * event. The base ClaudeOutputParser treats every `type: 'result'` as a
+ * successful response, so these overrides reclassify a failed result as an
+ * error event and surface it as a structured AgentError. Without this, a
+ * failure payload would render as a normal assistant response and callers
+ * relying on parsed results would miss the failure state.
  */
 export class QwenOutputParser extends ClaudeOutputParser {
 	readonly agentId: ToolType = 'qwen3-coder';
+
+	parseJsonObject(parsed: unknown): ParsedEvent | null {
+		const event = super.parseJsonObject(parsed);
+		if (event && event.type === 'result' && this.isFailedResult(parsed)) {
+			// Reclassify a failed terminal result so downstream handlers (and
+			// isResultMessage) treat it as an error rather than a successful response.
+			return { ...event, type: 'error' };
+		}
+		return event;
+	}
+
+	detectErrorFromParsed(parsed: unknown): AgentError | null {
+		if (this.isFailedResult(parsed)) {
+			const errorText = this.extractResultErrorText(parsed);
+			const match = matchErrorPattern(getErrorPatterns(this.agentId), errorText, {
+				minLength: 0,
+			});
+			return {
+				type: match?.type ?? 'agent_crashed',
+				message: match?.message ?? errorText,
+				recoverable: match?.recoverable ?? false,
+				agentId: this.agentId,
+				timestamp: Date.now(),
+				parsedJson: parsed,
+			};
+		}
+		return super.detectErrorFromParsed(parsed);
+	}
+
+	/** A terminal `result` event flagged as a failure via `is_error: true`. */
+	private isFailedResult(parsed: unknown): boolean {
+		if (!parsed || typeof parsed !== 'object') {
+			return false;
+		}
+		const msg = parsed as { type?: unknown; is_error?: unknown };
+		return msg.type === 'result' && msg.is_error === true;
+	}
+
+	/** Human-readable error text from a failed result, with a stable fallback. */
+	private extractResultErrorText(parsed: unknown): string {
+		const msg = parsed as { result?: unknown; subtype?: unknown };
+		if (typeof msg.result === 'string' && msg.result.trim()) {
+			return msg.result;
+		}
+		if (typeof msg.subtype === 'string' && msg.subtype.trim()) {
+			return `Qwen Code result failed: ${msg.subtype}`;
+		}
+		return 'Qwen Code reported a failed result.';
+	}
 }

--- a/src/main/parsers/qwen-output-parser.ts
+++ b/src/main/parsers/qwen-output-parser.ts
@@ -22,6 +22,7 @@ import { ClaudeOutputParser } from './claude-output-parser';
 import type { ToolType, AgentError } from '../../shared/types';
 import type { ParsedEvent } from './agent-output-parser';
 import { getErrorPatterns, matchErrorPattern } from './error-patterns';
+import { FALLBACK_CONTEXT_WINDOW } from '../../shared/agentConstants';
 
 /**
  * Qwen Code Output Parser Implementation
@@ -34,17 +35,50 @@ import { getErrorPatterns, matchErrorPattern } from './error-patterns';
  * successful response, so these overrides reclassify a failed result as an
  * error event and surface it as a structured AgentError. Without this, a
  * failure payload would render as a normal assistant response and callers
- * relying on parsed results would miss the failure state.
+ * relying on parsed results would miss the failure state. The failed-result text
+ * is also populated from Qwen's `error.message` when no `result`/`message.content`
+ * is present, so the actionable provider message is surfaced rather than lost.
+ *
+ * Usage parsing additionally strips the Claude fallback context window (200000)
+ * that the inherited aggregateModelUsage injects, so Qwen's configured 256K
+ * (262144) window drives the context meter instead of Claude's default.
  */
 export class QwenOutputParser extends ClaudeOutputParser {
 	readonly agentId: ToolType = 'qwen3-coder';
 
 	parseJsonObject(parsed: unknown): ParsedEvent | null {
 		const event = super.parseJsonObject(parsed);
-		if (event && event.type === 'result' && this.isFailedResult(parsed)) {
+		if (!event) {
+			return event;
+		}
+
+		// Qwen's native context window is 256K (262144). The inherited
+		// ClaudeOutputParser routes usage through aggregateModelUsage, which injects
+		// a Claude fallback contextWindow of 200000 whenever a Qwen event reports
+		// only top-level usage (no per-model context window). StdoutHandler.buildUsageStats
+		// then prefers that parser-supplied window over the spawned process's configured
+		// Qwen window, so the context meter and summarization thresholds would be driven
+		// from the wrong limit. Drop the injected fallback so the configured 262144 window
+		// wins; keep any genuinely larger window a model actually reports.
+		if (event.usage && event.usage.contextWindow === FALLBACK_CONTEXT_WINDOW) {
+			const usage = { ...event.usage };
+			delete usage.contextWindow;
+			event.usage = usage;
+		}
+
+		if (event.type === 'result' && this.isFailedResult(parsed)) {
 			// Reclassify a failed terminal result so downstream handlers (and
 			// isResultMessage) treat it as an error rather than a successful response.
-			return { ...event, type: 'error' };
+			const errorEvent: ParsedEvent = { ...event, type: 'error' };
+			// Qwen carries its failure message in `error.message` (its stream-json
+			// protocol), which the inherited Claude text extraction (result /
+			// message.content) does not read. When the base text is empty, surface the
+			// provider message so callers that record errors from event.text get the
+			// actionable Qwen error instead of a generic exit/code fallback.
+			if (!errorEvent.text?.trim()) {
+				errorEvent.text = this.extractResultErrorText(parsed);
+			}
+			return errorEvent;
 		}
 		return event;
 	}
@@ -78,13 +112,34 @@ export class QwenOutputParser extends ClaudeOutputParser {
 
 	/** Human-readable error text from a failed result, with a stable fallback. */
 	private extractResultErrorText(parsed: unknown): string {
-		const msg = parsed as { result?: unknown; subtype?: unknown };
+		const msg = parsed as { result?: unknown; subtype?: unknown; error?: unknown };
 		if (typeof msg.result === 'string' && msg.result.trim()) {
 			return msg.result;
+		}
+		// Qwen's stream-json failure payload carries the provider message in
+		// `error.message` (mirrors the Qwen SDK's `error.get("message", ...)`),
+		// which the inherited Claude extraction (result / message.content) never inspects.
+		const errorMessage = this.extractErrorMessage(msg.error);
+		if (errorMessage) {
+			return errorMessage;
 		}
 		if (typeof msg.subtype === 'string' && msg.subtype.trim()) {
 			return `Qwen Code result failed: ${msg.subtype}`;
 		}
 		return 'Qwen Code reported a failed result.';
+	}
+
+	/** Non-empty message string from a Qwen `error` field (string or `{ message }`). */
+	private extractErrorMessage(error: unknown): string | null {
+		if (typeof error === 'string' && error.trim()) {
+			return error;
+		}
+		if (error && typeof error === 'object') {
+			const message = (error as { message?: unknown }).message;
+			if (typeof message === 'string' && message.trim()) {
+				return message;
+			}
+		}
+		return null;
 	}
 }

--- a/src/main/parsers/qwen-output-parser.ts
+++ b/src/main/parsers/qwen-output-parser.ts
@@ -60,7 +60,21 @@ export class QwenOutputParser extends ClaudeOutputParser {
 		// Qwen window, so the context meter and summarization thresholds would be driven
 		// from the wrong limit. Drop the injected fallback so the configured 262144 window
 		// wins; keep any genuinely larger window a model actually reports.
-		if (event.usage && event.usage.contextWindow === FALLBACK_CONTEXT_WINDOW) {
+		// Strip the parent-injected Claude fallback ONLY when the raw payload reported
+		// no per-model context window. If a Qwen model genuinely reports 200000 (equal
+		// to the fallback), preserve it instead of deleting a real limit.
+		const rawModelUsage = (parsed as { modelUsage?: Record<string, { contextWindow?: number }> })
+			.modelUsage;
+		const reportedContextWindow =
+			!!rawModelUsage &&
+			Object.values(rawModelUsage).some(
+				(m) => typeof m?.contextWindow === 'number' && m.contextWindow > 0
+			);
+		if (
+			event.usage &&
+			event.usage.contextWindow === FALLBACK_CONTEXT_WINDOW &&
+			!reportedContextWindow
+		) {
 			const usage = { ...event.usage };
 			delete usage.contextWindow;
 			event.usage = usage;

--- a/src/main/parsers/qwen-output-parser.ts
+++ b/src/main/parsers/qwen-output-parser.ts
@@ -52,32 +52,35 @@ export class QwenOutputParser extends ClaudeOutputParser {
 			return event;
 		}
 
-		// Qwen's native context window is 256K (262144). The inherited
-		// ClaudeOutputParser routes usage through aggregateModelUsage, which injects
-		// a Claude fallback contextWindow of 200000 whenever a Qwen event reports
-		// only top-level usage (no per-model context window). StdoutHandler.buildUsageStats
-		// then prefers that parser-supplied window over the spawned process's configured
-		// Qwen window, so the context meter and summarization thresholds would be driven
-		// from the wrong limit. Drop the injected fallback so the configured 262144 window
-		// wins; keep any genuinely larger window a model actually reports.
-		// Strip the parent-injected Claude fallback ONLY when the raw payload reported
-		// no per-model context window. If a Qwen model genuinely reports 200000 (equal
-		// to the fallback), preserve it instead of deleting a real limit.
+		// Qwen's native context window is 256K (262144). The inherited ClaudeOutputParser
+		// routes usage through aggregateModelUsage, which initializes contextWindow to the
+		// Claude fallback (200000) and only overrides it with a per-model value LARGER than
+		// the fallback. So any window a Qwen / OpenAI-compatible model actually reports at
+		// <= 200000 is collapsed to 200000, and a payload that reports no window stays at the
+		// injected fallback. StdoutHandler.buildUsageStats then prefers this parser-supplied
+		// window over the configured Qwen window, skewing the context meter.
+		//
+		// Recover the real value from the raw payload: if any model reported a positive
+		// contextWindow, use the largest reported value verbatim; otherwise drop the injected
+		// fallback so the configured 262144 window drives the meter.
 		const rawModelUsage = (parsed as { modelUsage?: Record<string, { contextWindow?: number }> })
 			.modelUsage;
-		const reportedContextWindow =
-			!!rawModelUsage &&
-			Object.values(rawModelUsage).some(
-				(m) => typeof m?.contextWindow === 'number' && m.contextWindow > 0
-			);
-		if (
-			event.usage &&
-			event.usage.contextWindow === FALLBACK_CONTEXT_WINDOW &&
-			!reportedContextWindow
-		) {
-			const usage = { ...event.usage };
-			delete usage.contextWindow;
-			event.usage = usage;
+		const reportedContextWindow = rawModelUsage
+			? Math.max(
+					0,
+					...Object.values(rawModelUsage).map((m) =>
+						typeof m?.contextWindow === 'number' ? m.contextWindow : 0
+					)
+				)
+			: 0;
+		if (event.usage) {
+			if (reportedContextWindow > 0) {
+				event.usage = { ...event.usage, contextWindow: reportedContextWindow };
+			} else if (event.usage.contextWindow === FALLBACK_CONTEXT_WINDOW) {
+				const usage = { ...event.usage };
+				delete usage.contextWindow;
+				event.usage = usage;
+			}
 		}
 
 		if (event.type === 'result' && this.isFailedResult(parsed)) {

--- a/src/main/parsers/qwen-output-parser.ts
+++ b/src/main/parsers/qwen-output-parser.ts
@@ -1,0 +1,31 @@
+/**
+ * Qwen Code Output Parser
+ *
+ * Parses stream-json output from the Qwen Code CLI (`qwen`).
+ *
+ * Qwen Code is a fork of Gemini CLI and emits the same stream-json schema that
+ * Claude Code does (`type: system/assistant/result`), so parsing reuses the
+ * ClaudeOutputParser implementation wholesale. The only difference is the
+ * agentId, which is overridden so the registry and error-pattern lookups key
+ * off 'qwen3-coder'.
+ *
+ * Note: Qwen's session init message uses subtype 'session_start' rather than
+ * Claude's 'init'. The generic system branch in ClaudeOutputParser still
+ * surfaces session_id on those events, and the final `result` event also
+ * carries session_id, so session capture works without a custom override.
+ *
+ * @see https://github.com/QwenLM/qwen-code
+ */
+
+import { ClaudeOutputParser } from './claude-output-parser';
+import type { ToolType } from '../../shared/types';
+
+/**
+ * Qwen Code Output Parser Implementation
+ *
+ * Subclasses ClaudeOutputParser to reuse its stream-json handling while
+ * identifying as the 'qwen3-coder' agent.
+ */
+export class QwenOutputParser extends ClaudeOutputParser {
+	readonly agentId: ToolType = 'qwen3-coder';
+}

--- a/src/renderer/components/NewInstanceModal/types.ts
+++ b/src/renderer/components/NewInstanceModal/types.ts
@@ -12,6 +12,7 @@ export const SUPPORTED_AGENTS = [
 	'codex',
 	'factory-droid',
 	'copilot-cli',
+	'omp',
 ];
 
 export interface AgentDebugInfo {

--- a/src/renderer/components/NewInstanceModal/types.ts
+++ b/src/renderer/components/NewInstanceModal/types.ts
@@ -12,6 +12,7 @@ export const SUPPORTED_AGENTS = [
 	'codex',
 	'factory-droid',
 	'copilot-cli',
+	'qwen3-coder',
 ];
 
 export interface AgentDebugInfo {

--- a/src/renderer/constants/agentIcons.ts
+++ b/src/renderer/constants/agentIcons.ts
@@ -44,6 +44,9 @@ export const AGENT_ICONS: Record<string, string> = {
 	hermes: '⚕',
 	pi: 'π',
 
+	// Oh My Pi
+	omp: '🦉',
+
 	// Enterprise
 	'factory-droid': '🏭',
 

--- a/src/shared/agentConstants.ts
+++ b/src/shared/agentConstants.ts
@@ -22,6 +22,7 @@ export const DEFAULT_CONTEXT_WINDOWS: Partial<Record<AgentId, number>> = {
 	hermes: 200000, // Conservative fallback until runtime-specific reporting lands
 	pi: 200000, // Conservative fallback until runtime-specific reporting lands
 	'copilot-cli': 200000, // Copilot-CLI (varies by model, defaults to Claude Sonnet)
+	omp: 200000, // Oh My Pi (fallback until runtime-specific reporting lands)
 	terminal: 0, // Terminal has no context window
 };
 

--- a/src/shared/agentConstants.ts
+++ b/src/shared/agentConstants.ts
@@ -22,6 +22,7 @@ export const DEFAULT_CONTEXT_WINDOWS: Partial<Record<AgentId, number>> = {
 	hermes: 200000, // Conservative fallback until runtime-specific reporting lands
 	pi: 200000, // Conservative fallback until runtime-specific reporting lands
 	'copilot-cli': 200000, // Copilot-CLI (varies by model, defaults to Claude Sonnet)
+	'qwen3-coder': 262144, // Qwen3-Coder native 256K context window
 	terminal: 0, // Terminal has no context window
 };
 

--- a/src/shared/agentIds.ts
+++ b/src/shared/agentIds.ts
@@ -24,6 +24,7 @@ export const AGENT_IDS = [
 	'hermes',
 	'pi',
 	'copilot-cli',
+	'omp',
 ] as const;
 
 /**

--- a/src/shared/agentMetadata.ts
+++ b/src/shared/agentMetadata.ts
@@ -76,6 +76,7 @@ export const BETA_AGENTS: ReadonlySet<AgentId> = new Set<AgentId>([
 	'hermes',
 	'pi',
 	'copilot-cli',
+	'qwen3-coder',
 ]);
 
 /**

--- a/src/shared/agentMetadata.ts
+++ b/src/shared/agentMetadata.ts
@@ -25,6 +25,7 @@ export const AGENT_DISPLAY_NAMES: Record<AgentId, string> = {
 	hermes: 'Hermes',
 	pi: 'Pi',
 	'copilot-cli': 'Copilot-CLI',
+	omp: 'Oh My Pi',
 };
 
 /**
@@ -76,6 +77,7 @@ export const BETA_AGENTS: ReadonlySet<AgentId> = new Set<AgentId>([
 	'hermes',
 	'pi',
 	'copilot-cli',
+	'omp',
 ]);
 
 /**


### PR DESCRIPTION
## Summary

Closes #803.

Bundles the two new CLI agents into a single PR. They were previously split across #1128 (Qwen Coder) and #1132 (Oh My Pi), but each adds an agent to the same shared registry files, so they cannot merge independently without conflicts (parser registry, agent metadata/constants, error patterns, the supported-agents list, and the "register exactly N parsers" count). Combining them here resolves that once: both agents registered, parser count is 8.

This supersedes and replaces #1128 and #1132.

## Qwen Coder (`qwen3-coder`)

- Promotes the hidden `qwen3-coder` stub to a real, selectable BETA agent (binary `qwen`), mirroring the `gemini-cli` integration: definition, capabilities, metadata, 256K context window, `QwenOutputParser`, error patterns, `--output-format stream-json`, `--resume`.
- Model selector is a free-text field (qwen-code's `-m/--model` is an unconstrained, multi-provider string per its source; a fixed dropdown would exclude valid models).

## Oh My Pi (`omp`)

- Adds `omp` (`@oh-my-pi/pi-coding-agent`) as a real, selectable BETA agent registered everywhere `gemini-cli` is: definition, capabilities, metadata, `OmpOutputParser` (modeled on the sibling `pi-output-parser`), error patterns, `-p --mode json`, `--resume`, `--model`.
- Model selector is free-text, and `runModelDiscovery` runs `omp models --json` to populate the model combobox with omp's full multi-provider catalog (provider-qualified selectors, de-duplicated, parsed with `parseJsonWithBom`).

## Verification

- `npm run lint` (tsc x3): clean.
- `vitest run` across parsers/index, agent definitions, agent-completeness, agentMetadata, detector (incl. omp discovery), capabilities: 252 tests pass.
- `eslint` + `prettier`: clean on the touched files.

## Notes

- Conflicts were resolved as a union of both agents; the parser-count assertion is set to 8 (6 base + qwen + omp).
- Independently exercised in a local integration build (both agents appear in New Instance; omp model picker populates).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for two additional AI coding agents: `qwen3-coder` and `omp` (beta), including UI display name/icon, agent setup, model discovery, and output parsing with session + streaming + usage/cost handling.
  * Added agent-specific error pattern handling for both agents, plus remote model discovery JSON parsing.
* **Bug Fixes**
  * Improved result/error/session classification for the new parsers.
  * Prevented caching empty model discovery results for `omp` to allow retries.
* **Documentation**
  * Updated README to include the expanded multi-agent support and requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->