### PR TITLE
fix(sentry): silence expected-condition telemetry noise on rc

### DIFF
--- a/src/__tests__/main/shared-history-manager.test.ts
+++ b/src/__tests__/main/shared-history-manager.test.ts
@@ -60,6 +60,7 @@ import {
 	__resetSharedHistoryCacheForTest,
 } from '../../main/shared-history-manager';
 import * as remoteFs from '../../main/utils/remote-fs';
+import { captureException } from '../../main/utils/sentry';
 import type { HistoryEntry, SshRemoteConfig } from '../../shared/types';
 
 const LOCAL_HOSTNAME = os.hostname();
@@ -110,6 +111,33 @@ describe('SharedHistoryManager', () => {
 			const parsed = JSON.parse(writtenContent.trim());
 			expect(parsed.id).toBe('entry-1');
 			expect(parsed.hostname).toBe(LOCAL_HOSTNAME);
+		});
+
+		// MAESTRO-FM: best-effort sync writes into a permission-restricted or
+		// non-existent project dir must not spam Sentry with expected fs errors.
+		it('does not report expected filesystem errors (EACCES) to Sentry', () => {
+			vi.mocked(fs.existsSync).mockReturnValue(false);
+			const eacces = Object.assign(new Error('EACCES: permission denied, mkdir'), {
+				code: 'EACCES',
+			});
+			vi.mocked(fs.mkdirSync).mockImplementation(() => {
+				throw eacces;
+			});
+
+			// Best-effort write swallows the error (does not throw).
+			expect(() => writeEntryLocal('/test/project', createMockEntry())).not.toThrow();
+			expect(captureException).not.toHaveBeenCalled();
+		});
+
+		it('still reports unexpected write errors to Sentry', () => {
+			vi.mocked(fs.existsSync).mockReturnValue(false);
+			vi.mocked(fs.mkdirSync).mockReturnValue(undefined);
+			vi.mocked(fs.appendFileSync).mockImplementation(() => {
+				throw new TypeError('unexpected non-fs failure');
+			});
+
+			expect(() => writeEntryLocal('/test/project', createMockEntry())).not.toThrow();
+			expect(captureException).toHaveBeenCalledTimes(1);
 		});
 	});
 

--- a/src/main/ipc/handlers/agentSessions.ts
+++ b/src/main/ipc/handlers/agentSessions.ts
@@ -999,8 +999,19 @@ export function registerAgentSessionsHandlers(deps?: AgentSessionsHandlerDepende
 						sendUpdate(cache, false);
 					}
 				} catch (error) {
-					void captureException(error);
-					logger.warn(`Failed to parse Claude session: ${file.sessionKey}`, LOG_CONTEXT, { error });
+					// A session file too large to read into a single V8 string throws
+					// `RangeError: Invalid string length` (MAESTRO-M9). That's an expected
+					// boundary for huge sessions, not a bug - skip it and keep aggregating
+					// the rest. Mirrors the storage-layer carve-out in
+					// claude-/codex-session-storage.ts.
+					if (error instanceof RangeError) {
+						logger.warn(`Claude session file too large to parse: ${file.sessionKey}`, LOG_CONTEXT);
+					} else {
+						void captureException(error);
+						logger.warn(`Failed to parse Claude session: ${file.sessionKey}`, LOG_CONTEXT, {
+							error,
+						});
+					}
 				}
 			}
 
@@ -1024,8 +1035,17 @@ export function registerAgentSessionsHandlers(deps?: AgentSessionsHandlerDepende
 						sendUpdate(cache, false);
 					}
 				} catch (error) {
-					void captureException(error);
-					logger.warn(`Failed to parse Codex session: ${file.sessionKey}`, LOG_CONTEXT, { error });
+					// See the Claude loop above: oversized session files throw
+					// `RangeError: Invalid string length` (MAESTRO-M9), an expected
+					// boundary we skip rather than report.
+					if (error instanceof RangeError) {
+						logger.warn(`Codex session file too large to parse: ${file.sessionKey}`, LOG_CONTEXT);
+					} else {
+						void captureException(error);
+						logger.warn(`Failed to parse Codex session: ${file.sessionKey}`, LOG_CONTEXT, {
+							error,
+						});
+					}
 				}
 			}
 

--- a/src/main/ipc/handlers/groupChat.ts
+++ b/src/main/ipc/handlers/groupChat.ts
@@ -760,7 +760,15 @@ Respond with ONLY the summary text, no additional commentary.`;
 						durationMs: result.durationMs,
 					});
 				} catch (error) {
-					void captureException(error);
+					// A summary that fails because the participant's session was already
+					// deleted ("Session not found ...") is an expected, fully-recovered
+					// condition - we fall back to a fresh session just below. Don't
+					// report that to Sentry (MAESTRO-JB); only surface unexpected
+					// grooming failures.
+					const message = error instanceof Error ? error.message : String(error);
+					if (!/Session not found/i.test(message)) {
+						void captureException(error);
+					}
 					logger.warn(`Summary generation failed for ${participantName}: ${error}`, LOG_CONTEXT);
 					summaryResponse = 'No summary available - starting fresh session.';
 				}

--- a/src/main/shared-history-manager.ts
+++ b/src/main/shared-history-manager.ts
@@ -32,6 +32,27 @@ const LOG_CONTEXT = '[SharedHistory]';
 const LOCAL_HOSTNAME = os.hostname();
 
 /**
+ * Node fs error codes we expect from a best-effort write into a user-chosen
+ * project directory. The location may be permission-restricted (read-only
+ * Dropbox / CloudStorage team folders), read-only, or simply not exist. These
+ * are environmental, never a Maestro bug, so we keep the local warn but skip
+ * Sentry to avoid telemetry noise (MAESTRO-FM).
+ */
+const EXPECTED_FS_ERROR_CODES = new Set([
+	'EACCES',
+	'EPERM',
+	'EROFS',
+	'ENOENT',
+	'ENOTDIR',
+	'ENOSPC',
+]);
+
+function isExpectedFsError(error: unknown): boolean {
+	const code = (error as NodeJS.ErrnoException | null)?.code;
+	return typeof code === 'string' && EXPECTED_FS_ERROR_CODES.has(code);
+}
+
+/**
  * Per-file cache of parsed shared-history entries keyed by `(host, dir, filename)`.
  *
  * SSH-shared history reads were dominated by re-fetching every JSONL file on
@@ -134,7 +155,13 @@ export function writeEntryLocal(
 		logger.debug(`Wrote shared history entry to ${filePath}`, LOG_CONTEXT);
 	} catch (error) {
 		logger.warn(`Failed to write local shared history: ${error}`, LOG_CONTEXT);
-		captureException(error, { operation: 'sharedHistory:writeLocal', projectPath });
+		// Best-effort cross-host sync write - the primary history store is
+		// unaffected when this fails. Don't report expected filesystem errors
+		// (permission-denied / missing-path on a user-chosen project dir) to
+		// Sentry; only surface genuinely unexpected failures (MAESTRO-FM).
+		if (!isExpectedFsError(error)) {
+			captureException(error, { operation: 'sharedHistory:writeLocal', projectPath });
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Triage of Sentry field crashes on the **rc** channel. Three issues were best-effort or fully-recovered conditions being reported to Sentry as if they were bugs (the same telemetry-noise-on-expected-condition family addressed in prior triages). Fixed in one branch:

### MAESTRO-M9 - `RangeError: Invalid string length` (regression)
`agentSessions.getGlobalStats` lost its `RangeError` carve-out when it was refactored onto `statsCache`. A session file too large to read into a single V8 string throws `RangeError: Invalid string length`, and both the Claude and Codex incremental read loops captured it unconditionally. Re-added the guard, mirroring the storage-layer pattern already present in `claude-session-storage.ts` / `codex-session-storage.ts`. Still live on `0.18.2-RC` (12 recent events).

### MAESTRO-FM - `EACCES`/`ENOENT` mkdir `.maestro/history` (553 occ)
`writeEntryLocal` is a best-effort cross-host history sync write. When the project lives in a permission-restricted or non-existent directory (read-only Dropbox / CloudStorage team folders, `/home/.maestro/history`), `mkdir` throws `EACCES`/`ENOENT`. The primary history store is unaffected, so we now skip Sentry for expected filesystem error codes and only report genuinely unexpected failures. Added regression tests.

### MAESTRO-JB - "Grooming error: Session not found" (65 occ)
`groupChat` `resetContext` already recovers from a grooming failure by falling back to a fresh session. When the failure is "Session not found" (the participant's session was deleted mid-summary), that's an expected, fully-recovered condition - skip the Sentry report; unexpected grooming failures still surface.

## Validation
- `tsc -p tsconfig.main.json` clean
- ESLint + Prettier clean on changed files
- `vitest` green: shared-history-manager (12, +2 new), agentSessions + groupChat (74)

## Deliberately not included
- **MAESTRO-Q2** (`maestro-p --status sample failed`, ~5.7k occ): a periodic best-effort sampler reporting every failure mode as a Sentry warning. Deferred in two prior triages pending a human call on `maestro-p` exit semantics; the `reason`/`stage` context isn't indexed as queryable tags, so there's no data-backed clean expected-boundary to carve out. Flagging for a decision rather than guessing.
- **MAESTRO-TP** (`No handler registered for 'pianola:get-rules'`): `pianola` has zero references in the codebase (unmerged dev-environment feature) - no handler or caller to fix here.
- Native/build issues (renderer/GPU crashes, spawn EINVAL/E2BIG, GLIBC_2.38) - genuine signal or build-infra, not app-fixable noise.

Note: merged into `rc`, so GitHub will reference but not auto-close the issues until `rc` reaches `main`. The M9/FM/JB code also exists on `main`; this PR is scoped to `rc` per request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unnecessary error reporting for expected filesystem issues and oversized session data.
  * Improved handling of session and context reset failures so common “not found” cases no longer create noisy alerts.
  * Continued to safely fall back when writes or session parsing fail, while still surfacing unexpected errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->