### PR TITLE
fix(sentry): unpack better-sqlite3 native chain + skip recoverable groom/oversized-session telemetry

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,9 @@
 		],
 		"asarUnpack": [
 			"node_modules/node-pty/**/*",
-			"node_modules/better-sqlite3/**/*"
+			"node_modules/better-sqlite3/**/*",
+			"node_modules/bindings/**/*",
+			"node_modules/file-uri-to-path/**/*"
 		],
 		"mac": {
 			"category": "public.app-category.developer-tools",

--- a/src/main/ipc/handlers/agentSessions.ts
+++ b/src/main/ipc/handlers/agentSessions.ts
@@ -999,8 +999,19 @@ export function registerAgentSessionsHandlers(deps?: AgentSessionsHandlerDepende
 						sendUpdate(cache, false);
 					}
 				} catch (error) {
-					void captureException(error);
-					logger.warn(`Failed to parse Claude session: ${file.sessionKey}`, LOG_CONTEXT, { error });
+					// A session file too large to read into a single V8 string throws
+					// `RangeError: Invalid string length` (MAESTRO-M9). That's an expected
+					// boundary for huge sessions, not a bug - skip it and keep aggregating
+					// the rest. Mirrors the storage-layer carve-out in
+					// claude-/codex-session-storage.ts.
+					if (error instanceof RangeError) {
+						logger.warn(`Claude session file too large to parse: ${file.sessionKey}`, LOG_CONTEXT);
+					} else {
+						void captureException(error);
+						logger.warn(`Failed to parse Claude session: ${file.sessionKey}`, LOG_CONTEXT, {
+							error,
+						});
+					}
 				}
 			}
 
@@ -1024,8 +1035,17 @@ export function registerAgentSessionsHandlers(deps?: AgentSessionsHandlerDepende
 						sendUpdate(cache, false);
 					}
 				} catch (error) {
-					void captureException(error);
-					logger.warn(`Failed to parse Codex session: ${file.sessionKey}`, LOG_CONTEXT, { error });
+					// See the Claude loop above: oversized session files throw
+					// `RangeError: Invalid string length` (MAESTRO-M9), an expected
+					// boundary we skip rather than report.
+					if (error instanceof RangeError) {
+						logger.warn(`Codex session file too large to parse: ${file.sessionKey}`, LOG_CONTEXT);
+					} else {
+						void captureException(error);
+						logger.warn(`Failed to parse Codex session: ${file.sessionKey}`, LOG_CONTEXT, {
+							error,
+						});
+					}
 				}
 			}
 

--- a/src/main/ipc/handlers/groupChat.ts
+++ b/src/main/ipc/handlers/groupChat.ts
@@ -760,7 +760,15 @@ Respond with ONLY the summary text, no additional commentary.`;
 						durationMs: result.durationMs,
 					});
 				} catch (error) {
-					void captureException(error);
+					// A summary that fails because the participant's session was already
+					// deleted ("Session not found ...") is an expected, fully-recovered
+					// condition - we fall back to a fresh session just below. Don't
+					// report that to Sentry (MAESTRO-JB); only surface unexpected
+					// grooming failures.
+					const message = error instanceof Error ? error.message : String(error);
+					if (!/Session not found/i.test(message)) {
+						void captureException(error);
+					}
 					logger.warn(`Summary generation failed for ${participantName}: ${error}`, LOG_CONTEXT);
 					summaryResponse = 'No summary available - starting fresh session.';
 				}


### PR DESCRIPTION
## Summary

Three field-crash fixes for the **stable (main) channel**, sourced from Sentry (`smash-labs/maestro`) and validated against the code + the affected releases (0.17.1 / 0.17.2, `channel:stable`). Fixes 2 and 3 are **byte-identical mirrors of rc PR #1141** so the rc->main merge converges with no conflict; fix 1 is unique to main.

## 1. Native bindings packaging (escalating on current main)

**Sentry:** MAESTRO-TE (`Cannot find module 'file-uri-to-path'`, escalating), MAESTRO-Q3 / MAESTRO-JV / MAESTRO-TC / MAESTRO-TD (`Could not locate the bindings file`). ~40+ events on 0.17.2.

`better-sqlite3` -> `bindings` -> `file-uri-to-path`, but `asarUnpack` only listed `better-sqlite3` and `node-pty`:

- The unpacked `bindings.js` does `require('file-uri-to-path')` at load. With `file-uri-to-path` still inside `app.asar`, resolution from `app.asar.unpacked` cannot cross back into the archive -> **"Cannot find module 'file-uri-to-path'"** (MAESTRO-TE). The require stack confirms it: `app.asar.unpacked/.../bindings/bindings.js` failing to load a module left in the asar.
- The mixed packed/unpacked layout also makes `bindings` compute an in-archive search root for the compiled `.node`, producing **"Could not locate the bindings file. Tried: .../app.asar/.../better_sqlite3.node"** (MAESTRO-Q3/JV, via `StatsDB.initialize` and `initCueDb`).

**Fix:** unpack the full native dependency closure so the whole chain resolves consistently from `app.asar.unpacked`:

```json
"asarUnpack": [
  "node_modules/node-pty/**/*",
  "node_modules/better-sqlite3/**/*",
  "node_modules/bindings/**/*",
  "node_modules/file-uri-to-path/**/*"
]
```

`node-pty` needs nothing extra (its only dep, `node-addon-api`, is build-time headers; it loads its `.node` directly).

## 2. Recoverable grooming session loss (MAESTRO-JB, 65 events, stable)

Group-chat context summary spawns a batch agent. If the participant's provider session was deleted mid-summary, the agent emits a **recoverable** `Session not found` error (`error-patterns.ts` `session_not_found`, `recoverable: true`) and the code already falls back to a fresh session. The explicit `captureException` in `groupChat.ts` reported it anyway. Skip it for that message; real summary failures still report. (Mirrors rc #1141.)

## 3. Oversized session files (MAESTRO-M9, regressed onto stable)

`getGlobalStats` reads each session file into a single string; a file too large throws `RangeError: Invalid string length`. The #1115 carve-out was lost when `getGlobalStats` was refactored onto `statsCache` (that refactor reached main, so M9 came back on `channel:stable`, release 0.17.1). Re-skip the expected `RangeError` in both the Claude and Codex parse loops in `agentSessions.ts`, mirroring the storage-layer pattern (`claude-/codex-session-storage.ts`). (Mirrors rc #1141.)

## Out of scope (intentionally not touched)

- **MAESTRO-FM** (shared-history write EACCES/EROFS): Sentry shows it is **100% `channel:rc`** (zero stable events). The code is latent on main but does not fire on stable; rc #1141 fixes it and it reaches main on the next merge. Not a main field issue.
- **MAESTRO-RA** (`agent-probe-failed`): `markFailed` already guards with `isExpectedConnectionFailure`; residual events are genuine signal.
- **MAESTRO-J0** (`Failed to load required prompt`), **MAESTRO-T8/T9** (`shellLogs is not iterable`): root cause not obvious enough to fix confidently.
- Native crashes, GLIBC/build-infra (MAESTRO-RS), `spawn E2BIG/EINVAL`, ENOSPC: already filtered or build/environment issues.

## Testing

- `vitest run` for `agentSessions.test.ts` (20) + `groupChat.test.ts` (54) -> all pass.
- `prettier --check` and `eslint` clean on changed files; type-check shows no errors in changed files.
- The packaging change is build-config; recommend a packaged smoke build before release to confirm the bindings chain loads.

The added lines in fixes 2 and 3 are verified byte-identical to rc PR #1141.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of oversized session data so affected sessions are skipped more gracefully instead of causing unnecessary errors.
  * Reduced noisy error reporting for expected recovery cases when resetting chat participant context, while still reporting unexpected failures.
  * Expanded app packaging coverage to include additional native dependencies, helping the desktop app start more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->