### PR TITLE
fix(web-desktop): copy messages to the browser's machine, not the host

### DIFF
--- a/src/__tests__/renderer/utils/clipboard.test.ts
+++ b/src/__tests__/renderer/utils/clipboard.test.ts
@@ -104,10 +104,41 @@ describe('safeClipboardWrite', () => {
 			expect(shellMock.copyTextToClipboard).not.toHaveBeenCalled();
 		});
 
-		it('falls back to the host bridge when the navigator API throws', async () => {
+		it('falls back to the legacy copy (not the host bridge) when the navigator API throws', async () => {
+			// The host bridge would write to the HOST machine, not the browser the
+			// user is on, so in web-desktop we keep the copy local via execCommand.
 			clipboardMock.writeText.mockRejectedValue(new Error('not focused'));
+			const execCommand = vi.fn().mockReturnValue(true);
+			Object.assign(document, { execCommand });
+
 			expect(await safeClipboardWrite('hello')).toBe(true);
-			expect(shellMock.copyTextToClipboard).toHaveBeenCalledWith('hello');
+			expect(execCommand).toHaveBeenCalledWith('copy');
+			expect(shellMock.copyTextToClipboard).not.toHaveBeenCalled();
+		});
+
+		it('falls back to execCommand copy in an insecure context (no navigator.clipboard)', async () => {
+			// Plain-HTTP context (e.g. Tailscale/LAN IP): the secure-context async
+			// Clipboard API is undefined, so the legacy execCommand path must run.
+			// No host bridge should be reached - the copy stays on the user's machine.
+			Object.defineProperty(navigator, 'clipboard', {
+				configurable: true,
+				writable: true,
+				value: undefined,
+			});
+			const execCommand = vi.fn().mockReturnValue(true);
+			Object.assign(document, { execCommand });
+
+			expect(await safeClipboardWrite('hello')).toBe(true);
+			expect(execCommand).toHaveBeenCalledWith('copy');
+			expect(shellMock.copyTextToClipboard).not.toHaveBeenCalled();
+		});
+
+		it('returns false when even the legacy copy fails', async () => {
+			clipboardMock.writeText.mockRejectedValue(new Error('NotAllowedError'));
+			const execCommand = vi.fn().mockReturnValue(false);
+			Object.assign(document, { execCommand });
+
+			expect(await safeClipboardWrite('hello')).toBe(false);
 		});
 	});
 });

--- a/src/__tests__/renderer/utils/clipboard.test.ts
+++ b/src/__tests__/renderer/utils/clipboard.test.ts
@@ -140,6 +140,24 @@ describe('safeClipboardWrite', () => {
 
 			expect(await safeClipboardWrite('hello')).toBe(false);
 		});
+
+		it('restores focus to the originating control after the legacy copy', async () => {
+			// The hidden textarea steals focus; it must be handed back so the next
+			// keystroke returns to the control that triggered the copy.
+			clipboardMock.writeText.mockRejectedValue(new Error('not focused'));
+			const execCommand = vi.fn().mockReturnValue(true);
+			Object.assign(document, { execCommand });
+
+			const input = document.createElement('input');
+			document.body.appendChild(input);
+			input.focus();
+			expect(document.activeElement).toBe(input);
+
+			expect(await safeClipboardWrite('hello')).toBe(true);
+			expect(document.activeElement).toBe(input);
+
+			document.body.removeChild(input);
+		});
 	});
 });
 

--- a/src/renderer/utils/clipboard.ts
+++ b/src/renderer/utils/clipboard.ts
@@ -26,6 +26,9 @@ import { isWebDesktop } from './runtimeContext';
  * Returns true on success.
  */
 function legacyExecCommandCopy(text: string): boolean {
+	// Remember what had focus so we can hand it back; selecting the hidden
+	// textarea steals focus from the control that initiated the copy.
+	const previouslyFocused = document.activeElement as HTMLElement | null;
 	const textarea = document.createElement('textarea');
 	textarea.value = text;
 	// Keep it out of view and from scrolling/zooming the page.
@@ -49,6 +52,11 @@ function legacyExecCommandCopy(text: string): boolean {
 		return false;
 	} finally {
 		document.body.removeChild(textarea);
+		// Restore focus to whatever held it before the copy so the next
+		// keystroke returns to the originating control.
+		if (previouslyFocused && typeof previouslyFocused.focus === 'function') {
+			previouslyFocused.focus();
+		}
 	}
 }
 

--- a/src/renderer/utils/clipboard.ts
+++ b/src/renderer/utils/clipboard.ts
@@ -18,8 +18,50 @@
 import { isWebDesktop } from './runtimeContext';
 
 /**
+ * Legacy clipboard write via a hidden textarea + document.execCommand('copy').
+ * The async Clipboard API (navigator.clipboard) is gated to secure contexts,
+ * so it is undefined when web-desktop is served over plain HTTP (e.g. a
+ * Tailscale/LAN IP without TLS). execCommand is deprecated but still works in
+ * insecure contexts and is the only browser-side path left there.
+ * Returns true on success.
+ */
+function legacyExecCommandCopy(text: string): boolean {
+	const textarea = document.createElement('textarea');
+	textarea.value = text;
+	// Keep it out of view and from scrolling/zooming the page.
+	textarea.style.position = 'fixed';
+	textarea.style.top = '0';
+	textarea.style.left = '0';
+	textarea.style.width = '1px';
+	textarea.style.height = '1px';
+	textarea.style.padding = '0';
+	textarea.style.border = 'none';
+	textarea.style.outline = 'none';
+	textarea.style.boxShadow = 'none';
+	textarea.style.background = 'transparent';
+	textarea.setAttribute('readonly', '');
+	document.body.appendChild(textarea);
+	try {
+		textarea.focus();
+		textarea.select();
+		return document.execCommand('copy');
+	} catch {
+		return false;
+	} finally {
+		document.body.removeChild(textarea);
+	}
+}
+
+/**
  * Safely write text to the clipboard.
  * Returns true on success, false if the document is not focused or clipboard is unavailable.
+ *
+ * In web-desktop mode the Electron IPC clipboard writes to the HOST machine
+ * (where the Electron app runs), not the browser the user is on. Skip the IPC
+ * path there and use the browser Clipboard API so the copy lands on the user's
+ * own machine. When that browser API is unavailable (insecure context, e.g.
+ * web-desktop over a plain-HTTP Tailscale/LAN IP), fall back to the legacy
+ * execCommand copy so the copy still lands on the user's machine.
  */
 export async function safeClipboardWrite(text: string): Promise<boolean> {
 	if (isWebDesktop()) {
@@ -27,20 +69,27 @@ export async function safeClipboardWrite(text: string): Promise<boolean> {
 			await navigator.clipboard.writeText(text);
 			return true;
 		} catch {
-			// Browser clipboard unavailable/denied - fall back to the host bridge below.
+			// Browser clipboard unavailable/denied - fall back below. In web-desktop
+			// we keep the copy on the user's own machine via the legacy path rather
+			// than routing to the host bridge.
 		}
 	}
 	try {
-		if (window.maestro?.shell?.copyTextToClipboard) {
+		if (!isWebDesktop() && window.maestro?.shell?.copyTextToClipboard) {
 			await window.maestro.shell.copyTextToClipboard(text);
 			return true;
 		}
-		await navigator.clipboard.writeText(text);
-		return true;
+		if (navigator.clipboard?.writeText) {
+			await navigator.clipboard.writeText(text);
+			return true;
+		}
+		// Insecure context: navigator.clipboard is undefined. Use the legacy path.
+		return legacyExecCommandCopy(text);
 	} catch {
-		// NotAllowedError when document not focused, or other clipboard failures.
-		// Not actionable - the user can retry when the window is focused.
-		return false;
+		// NotAllowedError when document not focused, or async API blocked in an
+		// insecure context. Try the legacy path before giving up; the user can
+		// retry when the window is focused if even that fails.
+		return legacyExecCommandCopy(text);
 	}
 }
 


### PR DESCRIPTION
## Problem

Clicking **Copy** on a message while accessing Maestro through **web-desktop** (the browser interface) copied the text to the clipboard of the machine running the Electron host, not the PC the user is browsing from.

## Root cause

`safeClipboardWrite()` in `src/renderer/utils/clipboard.ts` always preferred `window.maestro.shell.copyTextToClipboard`, which routes over IPC to the host's Electron `clipboard.writeText()`. In web-desktop the renderer runs in the browser but the preload shim still exposes that method, so the browser-native fallback was never reached. Result: the copy landed on the **server's** machine.

## Fix

1. **Route web-desktop through the browser clipboard.** Guard the Electron IPC path with the existing `isWebDesktop()` helper (`src/renderer/utils/runtimeContext.ts`) so web-desktop uses `navigator.clipboard` instead. Applied to all three helpers that had the same flaw: `safeClipboardWrite` (text), `safeClipboardWriteImage`, and `safeClipboardReadImage`.

2. **Insecure-context fallback.** The async Clipboard API is gated to secure contexts, so `navigator.clipboard` is `undefined` when web-desktop is served over plain HTTP (e.g. a **Tailscale**/LAN IP without TLS). Added a legacy `execCommand('copy')` fallback for the text path that runs when `navigator.clipboard` is missing or the async write throws, so the copy still lands on the user's own machine.

## Behavior matrix (text copy)

| Context | Path used |
| --- | --- |
| Electron desktop app | Electron IPC -> host clipboard (unchanged) |
| web-desktop over HTTPS / localhost | navigator.clipboard.writeText (browser) |
| web-desktop over plain HTTP (Tailscale/LAN) | execCommand('copy') fallback (browser) |

## Tests

Added `src/__tests__/renderer/utils/clipboard.test.ts` (5 cases, all passing): desktop uses IPC; web-desktop uses the browser API; insecure context falls back to execCommand; thrown async write falls back to execCommand; returns false only when even the legacy copy fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clipboard read/write behavior across desktop app and web-desktop environments.
  * Added/strengthened legacy copy fallback (`execCommand`) and retry behavior when browser clipboard access fails.
  * Ensured text and image clipboard operations route correctly per environment.

* **Tests**
  * Added Vitest coverage to verify environment-specific clipboard pathways and fallback scenarios for both text and images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->