### PR TITLE
perf(input): decouple composer draft from App to kill keyboard lag

### DIFF
--- a/src/__tests__/renderer/components/AppModals-selfSourced.test.tsx
+++ b/src/__tests__/renderer/components/AppModals-selfSourced.test.tsx
@@ -12,6 +12,7 @@ import { render, screen, act } from '@testing-library/react';
 import { useSessionStore } from '../../../renderer/stores/sessionStore';
 import { useGroupChatStore } from '../../../renderer/stores/groupChatStore';
 import { useModalStore } from '../../../renderer/stores/modalStore';
+import { useComposerInputStore } from '../../../renderer/stores/composerInputStore';
 import type { Session, Shortcut, Group, GroupChat } from '../../../renderer/types';
 import { createMockSession as baseCreateMockSession } from '../../helpers/mockSession';
 
@@ -25,6 +26,10 @@ let capturedWorktreeProps: Record<string, unknown> = {};
 let capturedUtilityProps: Record<string, unknown> = {};
 let capturedGroupChatProps: Record<string, unknown> = {};
 let capturedAgentProps: Record<string, unknown> = {};
+
+const promptComposerModalMock = vi.hoisted(() => ({
+	props: undefined as Record<string, unknown> | undefined,
+}));
 
 // Mock ALL sub-components to capture props
 vi.mock('../../../renderer/components/AboutModal', () => ({ AboutModal: () => null }));
@@ -68,7 +73,10 @@ vi.mock('../../../renderer/components/FileSearchModal', () => ({
 	FileSearchModal: () => null,
 }));
 vi.mock('../../../renderer/components/PromptComposerModal', () => ({
-	PromptComposerModal: () => null,
+	PromptComposerModal: (props: Record<string, unknown>) => {
+		promptComposerModalMock.props = props;
+		return null;
+	},
 }));
 vi.mock('../../../renderer/components/ExecutionQueueBrowser', () => ({
 	ExecutionQueueBrowser: () => null,
@@ -379,6 +387,8 @@ describe('AppModals (Tier 1B self-sourcing)', () => {
 			activeGroupChatId: null,
 		});
 		useModalStore.setState({ modals: new Map() });
+		useComposerInputStore.setState({ aiValue: '', terminalValue: '' });
+		promptComposerModalMock.props = undefined;
 	});
 
 	describe('sessionStore self-sourcing', () => {
@@ -553,6 +563,50 @@ describe('AppModals (Tier 1B self-sourcing)', () => {
 				useModalStore.getState().openModal('about');
 			});
 
+			unmount();
+		});
+
+		it('seeds Prompt Composer from the live AI draft when opened after initial render', () => {
+			const session = createMockSession({ id: 's1', inputMode: 'ai' });
+			useSessionStore.setState({
+				sessions: [session],
+				activeSessionId: 's1',
+			});
+			const { unmount } = render(<AppModals {...createDefaultProps()} />);
+
+			act(() => {
+				useComposerInputStore.setState({
+					aiValue: 'live AI draft typed after parent render',
+					terminalValue: 'terminal draft',
+				});
+				useModalStore.getState().openModal('promptComposer');
+			});
+
+			expect(promptComposerModalMock.props?.initialValue).toBe(
+				'live AI draft typed after parent render'
+			);
+			unmount();
+		});
+
+		it('seeds Prompt Composer from the live terminal draft when opened after initial render', () => {
+			const session = createMockSession({ id: 's1', inputMode: 'terminal' });
+			useSessionStore.setState({
+				sessions: [session],
+				activeSessionId: 's1',
+			});
+			const { unmount } = render(<AppModals {...createDefaultProps()} />);
+
+			act(() => {
+				useComposerInputStore.setState({
+					aiValue: 'AI draft',
+					terminalValue: 'live terminal draft typed after parent render',
+				});
+				useModalStore.getState().openModal('promptComposer');
+			});
+
+			expect(promptComposerModalMock.props?.initialValue).toBe(
+				'live terminal draft typed after parent render'
+			);
 			unmount();
 		});
 	});

--- a/src/__tests__/renderer/components/InputArea.test.tsx
+++ b/src/__tests__/renderer/components/InputArea.test.tsx
@@ -256,6 +256,27 @@ describe('InputArea', () => {
 			).toBeInTheDocument();
 		});
 
+		it('updates the textarea from the live AI store slice after render', () => {
+			const props = createDefaultProps({
+				session: createMockSession({ inputMode: 'ai' }),
+				inputValue: 'initial AI draft',
+			});
+			render(<InputArea {...props} />);
+			const textarea = screen.getByRole('textbox');
+
+			expect(textarea).toHaveValue('initial AI draft');
+
+			act(() => {
+				useComposerInputStore.getState().setTerminalValue('terminal draft ignored in AI mode');
+			});
+			expect(textarea).toHaveValue('initial AI draft');
+
+			act(() => {
+				useComposerInputStore.getState().setAiValue('updated AI draft');
+			});
+			expect(textarea).toHaveValue('updated AI draft');
+		});
+
 		it('shows attach image button in AI mode when agent supports image input', () => {
 			const props = createDefaultProps({
 				session: createMockSession({ inputMode: 'ai' }),
@@ -426,6 +447,27 @@ describe('InputArea', () => {
 			render(<InputArea {...props} />);
 
 			expect(screen.getByPlaceholderText('Run shell command...')).toBeInTheDocument();
+		});
+
+		it('updates the textarea from the live terminal store slice after render', () => {
+			const props = createDefaultProps({
+				session: createMockSession({ inputMode: 'terminal' }),
+				inputValue: 'initial terminal draft',
+			});
+			render(<InputArea {...props} />);
+			const textarea = screen.getByRole('textbox');
+
+			expect(textarea).toHaveValue('initial terminal draft');
+
+			act(() => {
+				useComposerInputStore.getState().setAiValue('AI draft ignored in terminal mode');
+			});
+			expect(textarea).toHaveValue('initial terminal draft');
+
+			act(() => {
+				useComposerInputStore.getState().setTerminalValue('updated terminal draft');
+			});
+			expect(textarea).toHaveValue('updated terminal draft');
 		});
 
 		it('shows $ prefix in terminal mode', () => {

--- a/src/__tests__/renderer/components/InputArea.test.tsx
+++ b/src/__tests__/renderer/components/InputArea.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, act, within, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { InputArea } from '../../../renderer/components/InputArea';
+import { useComposerInputStore } from '../../../renderer/stores/composerInputStore';
 import { formatEnterToSend } from '../../../renderer/utils/shortcutFormatter';
 import type { Session } from '../../../renderer/types';
 import { createMockSession as baseCreateMockSession } from '../../helpers/mockSession';
@@ -146,13 +147,19 @@ const createMockSession = (overrides: Partial<Session> & { wizardState?: any } =
 	});
 };
 
-// Default props factory
-const createDefaultProps = (overrides: Partial<Parameters<typeof InputArea>[0]> = {}) => {
+// Default props factory.
+// InputArea reads the live draft from useComposerInputStore now (the value moved
+// out of props for perf), so an `inputValue` override is seeded into the store
+// here rather than passed as a prop. Call sites stay unchanged.
+const createDefaultProps = (
+	overrides: Partial<Parameters<typeof InputArea>[0]> & { inputValue?: string } = {}
+) => {
+	const { inputValue = '', ...rest } = overrides;
+	useComposerInputStore.setState({ aiValue: inputValue, terminalValue: inputValue });
 	const inputRef = { current: null } as React.RefObject<HTMLTextAreaElement>;
 	return {
 		session: createMockSession(),
 		theme: mockTheme,
-		inputValue: '',
 		setInputValue: vi.fn(),
 		enterToSend: true,
 		setEnterToSend: vi.fn(),

--- a/src/__tests__/renderer/components/MainPanel.test.tsx
+++ b/src/__tests__/renderer/components/MainPanel.test.tsx
@@ -409,7 +409,6 @@ describe('MainPanel', () => {
 		thinkingItems: [] as ThinkingItem[],
 		theme,
 		isMobileLandscape: false,
-		inputValue: '',
 		stagedImages: [],
 		commandHistoryOpen: false,
 		commandHistoryFilter: '',

--- a/src/__tests__/renderer/components/MainPanel/MainPanelContent.test.tsx
+++ b/src/__tests__/renderer/components/MainPanel/MainPanelContent.test.tsx
@@ -151,7 +151,6 @@ function makeDefaultProps() {
 		isCurrentSessionAutoMode: false,
 		currentSessionBatchState: undefined,
 		hasCapability: vi.fn(() => true) as any,
-		inputValue: '',
 		setInputValue: vi.fn(),
 		stagedImages: [] as string[],
 		setStagedImages: vi.fn(),

--- a/src/__tests__/renderer/components/PromptComposerModal.test.tsx
+++ b/src/__tests__/renderer/components/PromptComposerModal.test.tsx
@@ -211,7 +211,7 @@ describe('PromptComposerModal', () => {
 				/>
 			);
 
-			expect(screen.getByText('— Claude')).toBeInTheDocument();
+			expect(screen.getByText('- Claude')).toBeInTheDocument();
 		});
 
 		it('should render with custom session name', () => {
@@ -227,7 +227,7 @@ describe('PromptComposerModal', () => {
 				/>
 			);
 
-			expect(screen.getByText('— My Custom Session')).toBeInTheDocument();
+			expect(screen.getByText('- My Custom Session')).toBeInTheDocument();
 		});
 
 		it('should render keyboard shortcut hint when onToggleEnterToSend is provided', () => {
@@ -1115,7 +1115,7 @@ describe('PromptComposerModal', () => {
 				/>
 			);
 
-			expect(screen.getByText('—')).toBeInTheDocument();
+			expect(screen.getByText('-')).toBeInTheDocument();
 		});
 
 		it('should handle very long text', () => {
@@ -1168,7 +1168,7 @@ describe('PromptComposerModal', () => {
 			);
 
 			// React escapes these by default
-			expect(screen.getByText("— Test <script>alert('xss')</script>")).toBeInTheDocument();
+			expect(screen.getByText("- Test <script>alert('xss')</script>")).toBeInTheDocument();
 		});
 
 		it('should handle newlines in text', () => {

--- a/src/__tests__/renderer/hooks/props/useSessionListProps.test.ts
+++ b/src/__tests__/renderer/hooks/props/useSessionListProps.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import {
+	useSessionListProps,
+	type UseSessionListPropsDeps,
+} from '../../../../renderer/hooks/props';
+import { mockTheme } from '../../../helpers/mockTheme';
+
+function createDeps(overrides: Partial<UseSessionListPropsDeps> = {}): UseSessionListPropsDeps {
+	return {
+		theme: mockTheme,
+		sortedSessions: [],
+		isLiveMode: false,
+		webInterfaceUrl: null,
+		showSessionJumpNumbers: false,
+		visibleSessions: [],
+		navIndexMap: new Map(),
+		starredItems: [],
+		activateStarredItem: vi.fn(),
+		sidebarContainerRef: { current: null },
+		toggleGlobalLive: vi.fn().mockResolvedValue(undefined),
+		restartWebServer: vi.fn().mockResolvedValue(null),
+		toggleGroup: vi.fn(),
+		handleDragStart: vi.fn(),
+		handleDragOver: vi.fn(),
+		handleDropOnGroup: vi.fn(),
+		handleDropOnUngrouped: vi.fn(),
+		finishRenamingGroup: vi.fn(),
+		finishRenamingSession: vi.fn(),
+		startRenamingGroup: vi.fn(),
+		startRenamingSession: vi.fn(),
+		showConfirmation: vi.fn(),
+		createNewGroup: vi.fn(),
+		handleCreateGroupAndMove: vi.fn(),
+		addNewSession: vi.fn(),
+		deleteSession: vi.fn(),
+		deleteWorktreeGroup: vi.fn(),
+		handleEditAgent: vi.fn(),
+		handleOpenCreatePRSession: vi.fn(),
+		handleQuickCreateWorktree: vi.fn(),
+		handleOpenWorktreeConfigSession: vi.fn(),
+		handleDeleteWorktreeSession: vi.fn(),
+		handleToggleWorktreeExpanded: vi.fn(),
+		handleConfigureCue: vi.fn(),
+		maestroCueEnabled: false,
+		handleJumpToStarredSession: vi.fn().mockResolvedValue(false),
+		openWizardModal: vi.fn(),
+		handleOpenFeedbackModal: vi.fn(),
+		handleStartTour: vi.fn(),
+		handleOpenGroupChat: vi.fn(),
+		handleNewGroupChat: vi.fn(),
+		handleEditGroupChat: vi.fn(),
+		handleOpenRenameGroupChatModal: vi.fn(),
+		handleOpenDeleteGroupChatModal: vi.fn(),
+		handleArchiveGroupChat: vi.fn(),
+		handleDeleteAllArchivedGroupChats: vi.fn(),
+		...overrides,
+	};
+}
+
+describe('useSessionListProps', () => {
+	it('hides the Maestro Cue configure action when the Encore Feature is disabled', () => {
+		const handleConfigureCue = vi.fn();
+
+		const { result } = renderHook(() =>
+			useSessionListProps(createDeps({ handleConfigureCue, maestroCueEnabled: false }))
+		);
+
+		expect(result.current.onConfigureCue).toBeUndefined();
+	});
+
+	it('passes the Maestro Cue configure action when the Encore Feature is enabled', () => {
+		const handleConfigureCue = vi.fn();
+
+		const { result } = renderHook(() =>
+			useSessionListProps(createDeps({ handleConfigureCue, maestroCueEnabled: true }))
+		);
+
+		expect(result.current.onConfigureCue).toBe(handleConfigureCue);
+	});
+});

--- a/src/__tests__/renderer/hooks/useInputHandlers.test.ts
+++ b/src/__tests__/renderer/hooks/useInputHandlers.test.ts
@@ -122,6 +122,8 @@ import { useSettingsStore } from '../../../renderer/stores/settingsStore';
 import { useGroupChatStore } from '../../../renderer/stores/groupChatStore';
 import { useUIStore } from '../../../renderer/stores/uiStore';
 import { useFileExplorerStore } from '../../../renderer/stores/fileExplorerStore';
+import { clearLiveDraft, getLiveDraft, setLiveDraft } from '../../../renderer/utils/liveDraftStore';
+import { hasDraft } from '../../../renderer/utils/tabHelpers';
 
 // ============================================================================
 // Helpers
@@ -217,6 +219,8 @@ beforeEach(() => {
 	vi.clearAllMocks();
 	vi.useFakeTimers();
 	useComposerInputStore.setState({ aiValue: '', terminalValue: '' });
+	clearLiveDraft('tab-1');
+	clearLiveDraft('tab-2');
 
 	// Reset InputContext mock
 	Object.assign(mockInputContext, {
@@ -299,6 +303,46 @@ describe('useInputHandlers', () => {
 		it('initializes with empty input value in AI mode', () => {
 			renderHook(() => useInputHandlers(createMockDeps()));
 			expect(inputVal()).toBe('');
+		});
+
+		it('hydrates AI input from the active tab on first mount', () => {
+			useSessionStore.setState({
+				sessions: [
+					createMockSession({
+						aiTabs: [
+							{
+								id: 'tab-1',
+								name: 'Tab 1',
+								inputValue: 'restored AI draft',
+								data: [],
+								stagedImages: [],
+							} as any,
+						],
+					}),
+				],
+				activeSessionId: 'session-1',
+			} as any);
+
+			renderHook(() => useInputHandlers(createMockDeps()));
+
+			expect(useComposerInputStore.getState().aiValue).toBe('restored AI draft');
+			expect(getLiveDraft('tab-1')).toBe('restored AI draft');
+		});
+
+		it('hydrates terminal input from the active session on first mount', () => {
+			useSessionStore.setState({
+				sessions: [
+					createMockSession({
+						inputMode: 'terminal',
+						terminalDraftInput: 'npm run test',
+					}),
+				],
+				activeSessionId: 'session-1',
+			} as any);
+
+			renderHook(() => useInputHandlers(createMockDeps()));
+
+			expect(useComposerInputStore.getState().terminalValue).toBe('npm run test');
 		});
 
 		it('initializes with empty staged images', () => {
@@ -533,8 +577,7 @@ describe('useInputHandlers', () => {
 
 			const { result, rerender } = renderHook(() => useInputHandlers(createMockDeps()));
 
-			// Initially empty (hook doesn't load on first mount, only on tab switch)
-			expect(inputVal()).toBe('');
+			expect(inputVal()).toBe('tab1 text');
 
 			// Switch to tab-2 — this triggers the effect
 			act(() => {
@@ -566,6 +609,73 @@ describe('useInputHandlers', () => {
 
 			rerender();
 			expect(inputVal()).toBe('tab2 text');
+		});
+
+		it('mirrors the active tab draft on tab switch when the text value is unchanged', () => {
+			const sharedDraft = 'same persisted draft';
+			setLiveDraft('tab-2', '');
+			useSessionStore.setState({
+				sessions: [
+					createMockSession({
+						aiTabs: [
+							{
+								id: 'tab-1',
+								name: 'Tab 1',
+								inputValue: sharedDraft,
+								data: [],
+								stagedImages: [],
+							} as any,
+							{
+								id: 'tab-2',
+								name: 'Tab 2',
+								inputValue: sharedDraft,
+								data: [],
+								stagedImages: [],
+							} as any,
+						],
+						activeTabId: 'tab-1',
+					}),
+				],
+				activeSessionId: 'session-1',
+			} as any);
+
+			const { rerender } = renderHook(() => useInputHandlers(createMockDeps()));
+			expect(useComposerInputStore.getState().aiValue).toBe(sharedDraft);
+
+			act(() => {
+				useSessionStore.setState({
+					sessions: [
+						createMockSession({
+							aiTabs: [
+								{
+									id: 'tab-1',
+									name: 'Tab 1',
+									inputValue: sharedDraft,
+									data: [],
+									stagedImages: [],
+								} as any,
+								{
+									id: 'tab-2',
+									name: 'Tab 2',
+									inputValue: sharedDraft,
+									data: [],
+									stagedImages: [],
+								} as any,
+							],
+							activeTabId: 'tab-2',
+						}),
+					],
+					activeSessionId: 'session-1',
+				} as any);
+			});
+
+			rerender();
+
+			const tab2 = useSessionStore
+				.getState()
+				.sessions[0].aiTabs.find((tab: any) => tab.id === 'tab-2');
+			expect(getLiveDraft('tab-2')).toBe(sharedDraft);
+			expect(hasDraft(tab2 as any)).toBe(true);
 		});
 
 		it('saves current input to previous tab on switch', () => {
@@ -644,6 +754,7 @@ describe('useInputHandlers', () => {
 
 			const deps = createMockDeps();
 			const { result, rerender } = renderHook(() => useInputHandlers(deps));
+			expect(inputVal()).toBe('session1 cmd');
 
 			// Switch to session-2
 			act(() => {
@@ -1437,9 +1548,12 @@ describe('useInputHandlers', () => {
 			} as any);
 
 			const deps = createMockDeps();
-			const { rerender } = renderHook(() => useInputHandlers(deps));
+			const { result, rerender } = renderHook(() => useInputHandlers(deps));
 
-			// Do NOT type anything (terminal input remains empty '')
+			expect(inputVal()).toBe('previously saved');
+			act(() => {
+				result.current.setInputValue('');
+			});
 
 			// Switch to session-2
 			act(() => {

--- a/src/__tests__/renderer/hooks/useInputHandlers.test.ts
+++ b/src/__tests__/renderer/hooks/useInputHandlers.test.ts
@@ -355,6 +355,69 @@ describe('useInputHandlers', () => {
 
 			expect(inputVal()).toBe('hello world');
 		});
+
+		it('updates AI composer store without re-rendering the hook when completion is closed', () => {
+			let renderCount = 0;
+			const { result } = renderHook(() => {
+				renderCount += 1;
+				return useInputHandlers(createMockDeps());
+			});
+			const initialRenderCount = renderCount;
+
+			act(() => {
+				result.current.setInputValue('live AI draft');
+			});
+
+			expect(useComposerInputStore.getState().aiValue).toBe('live AI draft');
+			expect(renderCount).toBe(initialRenderCount);
+		});
+
+		it('updates terminal composer store without re-rendering the hook when tab completion is closed', () => {
+			useSessionStore.setState({
+				sessions: [createMockSession({ inputMode: 'terminal' })],
+				activeSessionId: 'session-1',
+			} as any);
+
+			let renderCount = 0;
+			const { result } = renderHook(() => {
+				renderCount += 1;
+				return useInputHandlers(createMockDeps());
+			});
+			const initialRenderCount = renderCount;
+
+			act(() => {
+				result.current.setInputValue('git status');
+			});
+
+			expect(useComposerInputStore.getState().terminalValue).toBe('git status');
+			expect(renderCount).toBe(initialRenderCount);
+		});
+
+		it('re-renders the hook for live terminal suggestions while tab completion is open', () => {
+			mockInputContext.tabCompletionOpen = true;
+			useSessionStore.setState({
+				sessions: [createMockSession({ inputMode: 'terminal' })],
+				activeSessionId: 'session-1',
+			} as any);
+			mockGetTabCompletionSuggestions.mockReturnValue([
+				{ type: 'history', value: 'git status', display: 'git status' },
+			]);
+
+			let renderCount = 0;
+			const { result } = renderHook(() => {
+				renderCount += 1;
+				return useInputHandlers(createMockDeps());
+			});
+			const initialRenderCount = renderCount;
+			mockGetTabCompletionSuggestions.mockClear();
+
+			act(() => {
+				result.current.setInputValue('git status');
+			});
+
+			expect(renderCount).toBeGreaterThan(initialRenderCount);
+			expect(mockGetTabCompletionSuggestions).toHaveBeenCalledWith('git status', 'all');
+		});
 	});
 
 	// ========================================================================

--- a/src/__tests__/renderer/hooks/useInputHandlers.test.ts
+++ b/src/__tests__/renderer/hooks/useInputHandlers.test.ts
@@ -117,6 +117,7 @@ import {
 	type UseInputHandlersDeps,
 } from '../../../renderer/hooks/input/useInputHandlers';
 import { useSessionStore } from '../../../renderer/stores/sessionStore';
+import { useComposerInputStore } from '../../../renderer/stores/composerInputStore';
 import { useSettingsStore } from '../../../renderer/stores/settingsStore';
 import { useGroupChatStore } from '../../../renderer/stores/groupChatStore';
 import { useUIStore } from '../../../renderer/stores/uiStore';
@@ -202,9 +203,20 @@ function createMockDeps(overrides: Partial<UseInputHandlersDeps> = {}): UseInput
 // Setup / Teardown
 // ============================================================================
 
+// Faithful drop-in for the old `inputVal()`: the live draft now
+// lives in useComposerInputStore, read by the active session's mode - exactly
+// what the hook's (removed) `inputValue` used to derive.
+const inputVal = (): string => {
+	const { sessions, activeSessionId } = useSessionStore.getState();
+	const mode = sessions.find((s) => s.id === activeSessionId)?.inputMode;
+	const composer = useComposerInputStore.getState();
+	return mode === 'terminal' ? composer.terminalValue : composer.aiValue;
+};
+
 beforeEach(() => {
 	vi.clearAllMocks();
 	vi.useFakeTimers();
+	useComposerInputStore.setState({ aiValue: '', terminalValue: '' });
 
 	// Reset InputContext mock
 	Object.assign(mockInputContext, {
@@ -266,8 +278,9 @@ describe('useInputHandlers', () => {
 		it('returns all expected properties', () => {
 			const { result } = renderHook(() => useInputHandlers(createMockDeps()));
 
-			expect(result.current).toHaveProperty('inputValue');
-			expect(result.current).toHaveProperty('deferredInputValue');
+			// inputValue / deferredInputValue intentionally removed: the live draft
+			// now lives in useComposerInputStore (read by InputArea), not on the
+			// hook return. setInputValue still dispatches writes into that store.
 			expect(result.current).toHaveProperty('setInputValue');
 			expect(result.current).toHaveProperty('stagedImages');
 			expect(result.current).toHaveProperty('setStagedImages');
@@ -284,8 +297,8 @@ describe('useInputHandlers', () => {
 		});
 
 		it('initializes with empty input value in AI mode', () => {
-			const { result } = renderHook(() => useInputHandlers(createMockDeps()));
-			expect(result.current.inputValue).toBe('');
+			renderHook(() => useInputHandlers(createMockDeps()));
+			expect(inputVal()).toBe('');
 		});
 
 		it('initializes with empty staged images', () => {
@@ -312,7 +325,7 @@ describe('useInputHandlers', () => {
 				result.current.setInputValue('hello AI');
 			});
 
-			expect(result.current.inputValue).toBe('hello AI');
+			expect(inputVal()).toBe('hello AI');
 		});
 
 		it('setInputValue updates terminal input in terminal mode', () => {
@@ -327,7 +340,7 @@ describe('useInputHandlers', () => {
 				result.current.setInputValue('ls -la');
 			});
 
-			expect(result.current.inputValue).toBe('ls -la');
+			expect(inputVal()).toBe('ls -la');
 		});
 
 		it('setInputValue accepts function updater', () => {
@@ -340,18 +353,7 @@ describe('useInputHandlers', () => {
 				result.current.setInputValue((prev) => prev + ' world');
 			});
 
-			expect(result.current.inputValue).toBe('hello world');
-		});
-
-		it('deferredInputValue matches inputValue', () => {
-			const { result } = renderHook(() => useInputHandlers(createMockDeps()));
-
-			act(() => {
-				result.current.setInputValue('test input');
-			});
-
-			// useDeferredValue in tests should match (no concurrent rendering)
-			expect(result.current.deferredInputValue).toBe('test input');
+			expect(inputVal()).toBe('hello world');
 		});
 	});
 
@@ -469,7 +471,7 @@ describe('useInputHandlers', () => {
 			const { result, rerender } = renderHook(() => useInputHandlers(createMockDeps()));
 
 			// Initially empty (hook doesn't load on first mount, only on tab switch)
-			expect(result.current.inputValue).toBe('');
+			expect(inputVal()).toBe('');
 
 			// Switch to tab-2 — this triggers the effect
 			act(() => {
@@ -500,7 +502,7 @@ describe('useInputHandlers', () => {
 			});
 
 			rerender();
-			expect(result.current.inputValue).toBe('tab2 text');
+			expect(inputVal()).toBe('tab2 text');
 		});
 
 		it('saves current input to previous tab on switch', () => {
@@ -589,7 +591,7 @@ describe('useInputHandlers', () => {
 			});
 
 			rerender();
-			expect(result.current.inputValue).toBe('session2 cmd');
+			expect(inputVal()).toBe('session2 cmd');
 		});
 	});
 
@@ -884,7 +886,7 @@ describe('useInputHandlers', () => {
 			});
 
 			expect(mockPreventDefault).toHaveBeenCalled();
-			expect(result.current.inputValue).toBe('trimmed text');
+			expect(inputVal()).toBe('trimmed text');
 		});
 
 		it('does not intercept text paste when no trimming needed', () => {
@@ -1126,7 +1128,7 @@ describe('useInputHandlers', () => {
 				result.current.setInputValue('terminal text');
 			});
 
-			expect(result.current.inputValue).toBe('terminal text');
+			expect(inputVal()).toBe('terminal text');
 		});
 	});
 
@@ -1304,7 +1306,7 @@ describe('useInputHandlers', () => {
 			rerender();
 
 			// Should default to empty string
-			expect(result.current.inputValue).toBe('');
+			expect(inputVal()).toBe('');
 		});
 	});
 
@@ -1632,7 +1634,7 @@ describe('useInputHandlers', () => {
 				result.current.handleDrop(dropEvent);
 			});
 
-			expect(result.current.inputValue).toBe('@src/main/index.ts ');
+			expect(inputVal()).toBe('@src/main/index.ts ');
 		});
 
 		it('inserts one @<path> per file when a multi-selection Files-panel drag is dropped', () => {
@@ -1658,7 +1660,7 @@ describe('useInputHandlers', () => {
 				result.current.handleDrop(dropEvent);
 			});
 
-			expect(result.current.inputValue).toBe('@src/a.ts @src/b.ts @src/c.ts ');
+			expect(inputVal()).toBe('@src/a.ts @src/b.ts @src/c.ts ');
 		});
 
 		it('appends @<path> with a separating space when input already has content', () => {
@@ -1682,7 +1684,7 @@ describe('useInputHandlers', () => {
 				result.current.handleDrop(dropEvent);
 			});
 
-			expect(result.current.inputValue).toBe('look at @README.md ');
+			expect(inputVal()).toBe('look at @README.md ');
 		});
 
 		it('ignores internal Files-panel drag when group chat is active', () => {
@@ -1707,7 +1709,7 @@ describe('useInputHandlers', () => {
 				result.current.handleDrop(dropEvent);
 			});
 
-			expect(result.current.inputValue).toBe('');
+			expect(inputVal()).toBe('');
 		});
 
 		it('inserts @<relative-path> when an external file inside the project is dropped in AI mode', () => {
@@ -1729,7 +1731,7 @@ describe('useInputHandlers', () => {
 				result.current.handleDrop(dropEvent);
 			});
 
-			expect(result.current.inputValue).toBe('@docs/README.md ');
+			expect(inputVal()).toBe('@docs/README.md ');
 		});
 
 		it('inserts an absolute @<path> when an external file outside the project is dropped', () => {
@@ -1751,7 +1753,7 @@ describe('useInputHandlers', () => {
 				result.current.handleDrop(dropEvent);
 			});
 
-			expect(result.current.inputValue).toBe('@/Users/somebody/notes ');
+			expect(inputVal()).toBe('@/Users/somebody/notes ');
 		});
 
 		it('joins multiple external file drops with spaces', () => {
@@ -1774,7 +1776,7 @@ describe('useInputHandlers', () => {
 				result.current.handleDrop(dropEvent);
 			});
 
-			expect(result.current.inputValue).toBe('@src/a.ts @docs ');
+			expect(inputVal()).toBe('@src/a.ts @docs ');
 		});
 
 		it('updates group chat draftMessage when external files are dropped during group chat', () => {
@@ -1882,7 +1884,7 @@ describe('useInputHandlers', () => {
 				result.current.handleDrop(dropEvent);
 			});
 
-			expect(result.current.inputValue).toBe('');
+			expect(inputVal()).toBe('');
 		});
 
 		it('stages an image when an image path is dragged from the Files panel', async () => {
@@ -1912,7 +1914,7 @@ describe('useInputHandlers', () => {
 			const tab = sessions[0].aiTabs.find((t: any) => t.id === 'tab-1');
 			expect(tab?.stagedImages).toEqual([dataUrl]);
 			// Image staging path must NOT also insert an @-mention.
-			expect(result.current.inputValue).toBe('');
+			expect(inputVal()).toBe('');
 		});
 
 		it('does not stage anything when the IPC returns a non-data-url string for an image path', async () => {
@@ -1939,7 +1941,7 @@ describe('useInputHandlers', () => {
 			const sessions = useSessionStore.getState().sessions;
 			const tab = sessions[0].aiTabs.find((t: any) => t.id === 'tab-1');
 			expect(tab?.stagedImages ?? []).toEqual([]);
-			expect(result.current.inputValue).toBe('');
+			expect(inputVal()).toBe('');
 		});
 
 		it('still inserts @<path> for non-image extensions dragged from the Files panel', () => {
@@ -1959,7 +1961,7 @@ describe('useInputHandlers', () => {
 				result.current.handleDrop(dropEvent);
 			});
 
-			expect(result.current.inputValue).toBe('@src/util.ts ');
+			expect(inputVal()).toBe('@src/util.ts ');
 			expect(window.maestro.fs.readFile).not.toHaveBeenCalled();
 		});
 
@@ -1995,7 +1997,7 @@ describe('useInputHandlers', () => {
 				result.current.handleDrop(dropEvent);
 			});
 
-			expect(result.current.inputValue).toBe('@src/index.ts ');
+			expect(inputVal()).toBe('@src/index.ts ');
 		});
 
 		it('falls back to the absolute (forward-slash) path when Windows casing does not match', () => {
@@ -2032,7 +2034,7 @@ describe('useInputHandlers', () => {
 
 			// Casing differs from projectRoot — relative match must NOT fire.
 			// The path is still emitted, just absolute, slash-normalised.
-			expect(result.current.inputValue).toBe('@c:/users/alice/proj/src/index.ts ');
+			expect(inputVal()).toBe('@c:/users/alice/proj/src/index.ts ');
 		});
 	});
 
@@ -2067,7 +2069,7 @@ describe('useInputHandlers', () => {
 				result.current.setInputValue('my draft message');
 			});
 
-			expect(result.current.inputValue).toBe('my draft message');
+			expect(inputVal()).toBe('my draft message');
 
 			// Simulate processInput clearing the input (as it does in real usage)
 			mockProcessInput.mockImplementation(() => {
@@ -2084,7 +2086,7 @@ describe('useInputHandlers', () => {
 			});
 
 			// Draft should be restored after replay
-			expect(result.current.inputValue).toBe('my draft message');
+			expect(inputVal()).toBe('my draft message');
 			expect(mockProcessInput).toHaveBeenCalledWith('replayed message');
 
 			// Clean up mock

--- a/src/__tests__/renderer/hooks/useInputKeyDown.test.ts
+++ b/src/__tests__/renderer/hooks/useInputKeyDown.test.ts
@@ -58,9 +58,15 @@ import type { InputKeyDownDeps } from '../../../renderer/hooks/input/useInputKey
 // Test Helpers
 // ============================================================================
 
-function createMockDeps(overrides: Partial<InputKeyDownDeps> = {}): InputKeyDownDeps {
+// `inputValue` is a test convenience: the hook reads the live value via
+// getInputValue() (the draft moved to useComposerInputStore for perf), so we
+// translate the override into a getter and keep call sites unchanged.
+function createMockDeps(
+	overrides: Partial<InputKeyDownDeps> & { inputValue?: string } = {}
+): InputKeyDownDeps {
+	const { inputValue = '', ...rest } = overrides;
 	return {
-		inputValue: '',
+		getInputValue: () => inputValue,
 		setInputValue: vi.fn(),
 		tabCompletionSuggestions: [],
 		atMentionSuggestions: [],
@@ -70,7 +76,7 @@ function createMockDeps(overrides: Partial<InputKeyDownDeps> = {}): InputKeyDown
 		getTabCompletionSuggestions: vi.fn().mockReturnValue([]),
 		inputRef: { current: { focus: vi.fn(), blur: vi.fn() } } as any,
 		terminalOutputRef: { current: { focus: vi.fn() } } as any,
-		...overrides,
+		...rest,
 	};
 }
 

--- a/src/__tests__/renderer/hooks/useInputProcessing.test.ts
+++ b/src/__tests__/renderer/hooks/useInputProcessing.test.ts
@@ -115,8 +115,14 @@ describe('useInputProcessing', () => {
 		Object.assign(window.maestro, originalMaestro);
 	});
 
-	// Helper to create hook dependencies
-	const createDeps = (overrides: Partial<Parameters<typeof useInputProcessing>[0]> = {}) => {
+	// Helper to create hook dependencies.
+	// `inputValue` is a test convenience: the hook now reads the live value via
+	// getInputValue() (the draft moved to useComposerInputStore for perf), so we
+	// translate the override into a getter and keep call sites unchanged.
+	const createDeps = (
+		overrides: Partial<Parameters<typeof useInputProcessing>[0]> & { inputValue?: string } = {}
+	) => {
+		const { inputValue = '', ...rest } = overrides;
 		const session = createMockSession();
 		const sessionsRef = { current: [session] };
 
@@ -124,7 +130,7 @@ describe('useInputProcessing', () => {
 			activeSession: session,
 			activeSessionId: session.id,
 			setSessions: mockSetSessions,
-			inputValue: '',
+			getInputValue: () => inputValue,
 			setInputValue: mockSetInputValue,
 			stagedImages: [],
 			setStagedImages: mockSetStagedImages,
@@ -140,7 +146,7 @@ describe('useInputProcessing', () => {
 			processQueuedItemRef: mockProcessQueuedItemRef,
 			flushBatchedUpdates: mockFlushBatchedUpdates,
 			onHistoryCommand: mockOnHistoryCommand,
-			...overrides,
+			...rest,
 		};
 	};
 

--- a/src/__tests__/renderer/hooks/usePromptComposerHandlers.test.ts
+++ b/src/__tests__/renderer/hooks/usePromptComposerHandlers.test.ts
@@ -31,12 +31,14 @@ vi.mock('../../../renderer/utils/tabHelpers', async () => {
 // ============================================================================
 
 import {
+	getPromptComposerInitialValue,
 	usePromptComposerHandlers,
 	type UsePromptComposerHandlersDeps,
 } from '../../../renderer/hooks/modal/usePromptComposerHandlers';
 import { useSessionStore } from '../../../renderer/stores/sessionStore';
 import { useGroupChatStore } from '../../../renderer/stores/groupChatStore';
 import { useSettingsStore } from '../../../renderer/stores/settingsStore';
+import { useComposerInputStore } from '../../../renderer/stores/composerInputStore';
 
 // ============================================================================
 // Helpers
@@ -161,6 +163,8 @@ beforeEach(() => {
 		enterToSendAI: true,
 		enterToSendAIExpanded: false,
 	} as any);
+
+	useComposerInputStore.setState({ aiValue: '', terminalValue: '' });
 });
 
 afterEach(() => {
@@ -172,6 +176,53 @@ afterEach(() => {
 // ============================================================================
 
 describe('usePromptComposerHandlers', () => {
+	describe('getPromptComposerInitialValue', () => {
+		it('seeds AI composer from the live store instead of a stale persisted tab draft', () => {
+			const session = createSession({
+				aiTabs: [createTab({ inputValue: 'stale persisted draft' })],
+				inputMode: 'ai',
+			});
+			useComposerInputStore.setState({ aiValue: 'live AI draft', terminalValue: 'ls -la' });
+
+			expect(
+				getPromptComposerInitialValue({
+					activeGroupChatId: null,
+					groupChats: [],
+					activeInputMode: session.inputMode,
+				})
+			).toBe('live AI draft');
+		});
+
+		it('seeds terminal composer from the live terminal store slice', () => {
+			useComposerInputStore.setState({ aiValue: 'AI draft', terminalValue: 'git status' });
+
+			expect(
+				getPromptComposerInitialValue({
+					activeGroupChatId: null,
+					groupChats: [],
+					activeInputMode: 'terminal',
+				})
+			).toBe('git status');
+		});
+
+		it('uses the active group chat draft when group chat is active', () => {
+			useComposerInputStore.setState({ aiValue: 'AI draft', terminalValue: 'terminal draft' });
+
+			expect(
+				getPromptComposerInitialValue({
+					activeGroupChatId: 'group-chat-1',
+					groupChats: [
+						{
+							id: 'group-chat-1',
+							draftMessage: 'group chat draft',
+						},
+					],
+					activeInputMode: 'ai',
+				})
+			).toBe('group chat draft');
+		});
+	});
+
 	// ========================================================================
 	// Return shape
 	// ========================================================================

--- a/src/__tests__/renderer/stores/composerInputStore.test.ts
+++ b/src/__tests__/renderer/stores/composerInputStore.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Tests for the composer draft store.
+ *
+ * This store holds the live AI / terminal input text that used to live in
+ * useState inside useInputHandlers. It exists for keyboard performance: only the
+ * memoized InputArea subscribes, so a keystroke no longer re-renders App. These
+ * tests pin the setter / updater semantics the input subsystem relies on.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+	useComposerInputStore,
+	selectAiComposerValue,
+	selectTerminalComposerValue,
+} from '../../../renderer/stores/composerInputStore';
+
+describe('composerInputStore', () => {
+	beforeEach(() => {
+		useComposerInputStore.setState({ aiValue: '', terminalValue: '' });
+	});
+
+	it('initializes both slices empty', () => {
+		const s = useComposerInputStore.getState();
+		expect(s.aiValue).toBe('');
+		expect(s.terminalValue).toBe('');
+	});
+
+	it('setAiValue sets a literal value without touching the terminal slice', () => {
+		useComposerInputStore.getState().setAiValue('hello AI');
+		expect(useComposerInputStore.getState().aiValue).toBe('hello AI');
+		expect(useComposerInputStore.getState().terminalValue).toBe('');
+	});
+
+	it('setTerminalValue sets a literal value without touching the AI slice', () => {
+		useComposerInputStore.getState().setTerminalValue('ls -la');
+		expect(useComposerInputStore.getState().terminalValue).toBe('ls -la');
+		expect(useComposerInputStore.getState().aiValue).toBe('');
+	});
+
+	it('setAiValue accepts a functional updater that sees the previous value', () => {
+		useComposerInputStore.getState().setAiValue('hello');
+		useComposerInputStore.getState().setAiValue((prev) => prev + ' world');
+		expect(useComposerInputStore.getState().aiValue).toBe('hello world');
+	});
+
+	it('setTerminalValue accepts a functional updater', () => {
+		useComposerInputStore.getState().setTerminalValue('git');
+		useComposerInputStore.getState().setTerminalValue((prev) => `${prev} status`);
+		expect(useComposerInputStore.getState().terminalValue).toBe('git status');
+	});
+
+	it('selectors read the matching slice', () => {
+		useComposerInputStore.setState({ aiValue: 'a', terminalValue: 't' });
+		const s = useComposerInputStore.getState();
+		expect(selectAiComposerValue(s)).toBe('a');
+		expect(selectTerminalComposerValue(s)).toBe('t');
+	});
+
+	it('notifies subscribers only when a slice actually changes', () => {
+		let calls = 0;
+		const unsub = useComposerInputStore.subscribe(() => {
+			calls += 1;
+		});
+		useComposerInputStore.getState().setAiValue('x');
+		expect(calls).toBe(1);
+		unsub();
+	});
+});

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -159,7 +159,6 @@ import {
 	updateSessionWith,
 	updateAiTab,
 } from './stores/sessionStore';
-import { useComposerInputStore } from './stores/composerInputStore';
 import { useStoreWithEqualityFn } from 'zustand/traditional';
 import { sidebarSessionEquality } from './stores/sessionEquality';
 import { useActiveSession } from './hooks/session/useActiveSession';
@@ -3092,15 +3091,6 @@ function MaestroConsoleInner() {
 					onCloseFileSearch={handleCloseFileSearch}
 					onFileSearchSelect={handleFileSearchSelect}
 					onClosePromptComposer={handleClosePromptComposer}
-					promptComposerInitialValue={
-						activeGroupChatId
-							? groupChats.find((c) => c.id === activeGroupChatId)?.draftMessage || ''
-							: // Non-reactive read: PromptComposerModal seeds its value only when it
-								// opens (which re-renders App), so getState() is fresh at that moment.
-								useComposerInputStore.getState()[
-									activeSession?.inputMode === 'terminal' ? 'terminalValue' : 'aiValue'
-								]
-					}
 					onPromptComposerSubmit={handlePromptComposerSubmit}
 					onPromptComposerSend={handlePromptComposerSend}
 					promptComposerSessionName={

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -2724,6 +2724,7 @@ function MaestroConsoleInner() {
 		handleDeleteWorktreeSession,
 		handleToggleWorktreeExpanded,
 		handleConfigureCue,
+		maestroCueEnabled: encoreFeatures.maestroCue,
 		handleJumpToStarredSession,
 		openWizardModal,
 		handleOpenFeedbackModal,

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -159,6 +159,7 @@ import {
 	updateSessionWith,
 	updateAiTab,
 } from './stores/sessionStore';
+import { useComposerInputStore } from './stores/composerInputStore';
 import { useStoreWithEqualityFn } from 'zustand/traditional';
 import { sidebarSessionEquality } from './stores/sessionEquality';
 import { useActiveSession } from './hooks/session/useActiveSession';
@@ -1565,8 +1566,6 @@ function MaestroConsoleInner() {
 
 	// --- INPUT HANDLERS (state, completion, processing, keyboard, paste/drop) ---
 	const {
-		inputValue,
-		deferredInputValue,
 		setInputValue,
 		stagedImages,
 		setStagedImages,
@@ -2453,7 +2452,6 @@ function MaestroConsoleInner() {
 		thinkingItems,
 		theme,
 		isMobileLandscape,
-		inputValue,
 		stagedImages,
 		commandHistoryOpen,
 		commandHistoryFilter,
@@ -3097,7 +3095,11 @@ function MaestroConsoleInner() {
 					promptComposerInitialValue={
 						activeGroupChatId
 							? groupChats.find((c) => c.id === activeGroupChatId)?.draftMessage || ''
-							: deferredInputValue
+							: // Non-reactive read: PromptComposerModal seeds its value only when it
+								// opens (which re-renders App), so getState() is fresh at that moment.
+								useComposerInputStore.getState()[
+									activeSession?.inputMode === 'terminal' ? 'terminalValue' : 'aiValue'
+								]
 					}
 					onPromptComposerSubmit={handlePromptComposerSubmit}
 					onPromptComposerSend={handlePromptComposerSend}

--- a/src/renderer/components/AppModals/AppModals.tsx
+++ b/src/renderer/components/AppModals/AppModals.tsx
@@ -41,6 +41,7 @@ import { AppUtilityModals } from './AppUtilityModals';
 import { AppGroupChatModals } from './AppGroupChatModals';
 import { AppAgentModals } from './AppAgentModals';
 import type { GroupChatErrorInfo } from './AppAgentModals';
+import { getPromptComposerInitialValue } from '../../hooks/modal/usePromptComposerHandlers';
 
 /**
  * Combined props interface for the unified AppModals component.
@@ -327,7 +328,6 @@ export interface AppModalsProps {
 	onCloseFileSearch: () => void;
 	onFileSearchSelect: (file: FlatFileItem) => void;
 	onClosePromptComposer: () => void;
-	promptComposerInitialValue: string;
 	onPromptComposerSubmit: (value: string) => void;
 	onPromptComposerSend: (value: string) => void;
 	promptComposerSessionName?: string;
@@ -459,6 +459,11 @@ export const AppModals = memo(function AppModals(props: AppModalsProps) {
 			activeGroupChatId: s.activeGroupChatId,
 		}))
 	);
+	const promptComposerInitialValue = getPromptComposerInitialValue({
+		activeGroupChatId,
+		groupChats,
+		activeInputMode: activeSession?.inputMode,
+	});
 
 	// Self-source modal boolean states from modalStore (Tier 1B)
 	const {
@@ -783,7 +788,6 @@ export const AppModals = memo(function AppModals(props: AppModalsProps) {
 		onCloseFileSearch,
 		onFileSearchSelect,
 		onClosePromptComposer,
-		promptComposerInitialValue,
 		onPromptComposerSubmit,
 		onPromptComposerSend,
 		promptComposerSessionName,

--- a/src/renderer/components/InputArea/InputArea.tsx
+++ b/src/renderer/components/InputArea/InputArea.tsx
@@ -1,5 +1,10 @@
 import React, { useEffect, useMemo } from 'react';
 import { useSettingsStore } from '../../stores/settingsStore';
+import {
+	useComposerInputStore,
+	selectAiComposerValue,
+	selectTerminalComposerValue,
+} from '../../stores/composerInputStore';
 import { ThinkingStatusPill } from '../ThinkingStatusPill';
 import { QuitWhenIdleIndicator } from '../QuitWhenIdleIndicator';
 import { MergeProgressOverlay } from '../MergeProgressOverlay';
@@ -28,7 +33,6 @@ export const InputArea = React.memo(function InputArea(props: InputAreaProps) {
 	const {
 		session,
 		theme,
-		inputValue,
 		setInputValue,
 		enterToSend,
 		setEnterToSend,
@@ -175,6 +179,13 @@ export const InputArea = React.memo(function InputArea(props: InputAreaProps) {
 
 	// Filter slash commands based on input and current mode
 	const isTerminalMode = session.inputMode === 'terminal';
+
+	// Live composer text. This is the SOLE subscriber to the draft store: a
+	// keystroke re-renders only this (memoized) leaf, not App. See
+	// useComposerInputStore / CLAUDE-PERFORMANCE.md.
+	const inputValue = useComposerInputStore(
+		isTerminalMode ? selectTerminalComposerValue : selectAiComposerValue
+	);
 
 	// thinkingItems is now passed directly from App.tsx (pre-filtered) for better performance
 

--- a/src/renderer/components/InputArea/types.ts
+++ b/src/renderer/components/InputArea/types.ts
@@ -33,7 +33,6 @@ export interface AtMentionSuggestion {
 export interface InputAreaProps {
 	session: Session;
 	theme: Theme;
-	inputValue: string;
 	setInputValue: (value: string) => void;
 	enterToSend: boolean;
 	setEnterToSend: (value: boolean) => void;

--- a/src/renderer/components/MainPanel/MainPanel.tsx
+++ b/src/renderer/components/MainPanel/MainPanel.tsx
@@ -47,7 +47,6 @@ export const MainPanel = React.memo(
 			activeSession,
 			thinkingItems,
 			theme,
-			inputValue,
 			stagedImages,
 			commandHistoryOpen,
 			commandHistoryFilter,
@@ -945,7 +944,6 @@ export const MainPanel = React.memo(
 							isCurrentSessionAutoMode={isCurrentSessionAutoMode}
 							currentSessionBatchState={currentSessionBatchState}
 							hasCapability={hasCapability}
-							inputValue={inputValue}
 							setInputValue={setInputValue}
 							stagedImages={stagedImages}
 							setStagedImages={setStagedImages}

--- a/src/renderer/components/MainPanel/MainPanelContent.tsx
+++ b/src/renderer/components/MainPanel/MainPanelContent.tsx
@@ -111,7 +111,6 @@ export interface MainPanelContentProps {
 
 	// Pass-through props from MainPanelProps
 	// (grouped to avoid enumerating every single prop)
-	inputValue: string;
 	setInputValue: (value: string) => void;
 	stagedImages: string[];
 	setStagedImages: React.Dispatch<React.SetStateAction<string[]>>;
@@ -303,7 +302,6 @@ export const MainPanelContent = React.memo(function MainPanelContent(props: Main
 		isCurrentSessionAutoMode,
 		currentSessionBatchState,
 		hasCapability,
-		inputValue,
 		setInputValue,
 		stagedImages,
 		setStagedImages,
@@ -702,7 +700,6 @@ export const MainPanelContent = React.memo(function MainPanelContent(props: Main
 								<InputArea
 									session={activeSession}
 									theme={theme}
-									inputValue={inputValue}
 									setInputValue={setInputValue}
 									enterToSend={activeTab?.enterToSend ?? enterToSendAI}
 									setEnterToSend={

--- a/src/renderer/components/MainPanel/types.ts
+++ b/src/renderer/components/MainPanel/types.ts
@@ -67,7 +67,6 @@ export interface MainPanelProps {
 	thinkingItems: ThinkingItem[];
 	theme: Theme;
 	isMobileLandscape?: boolean;
-	inputValue: string;
 	stagedImages: string[];
 	commandHistoryOpen: boolean;
 	commandHistoryFilter: string;

--- a/src/renderer/components/PromptComposerModal.tsx
+++ b/src/renderer/components/PromptComposerModal.tsx
@@ -133,9 +133,9 @@ export function PromptComposerModal({
 	const showMentionsRef = useRef(showMentions);
 	showMentionsRef.current = showMentions;
 
-	// Sync value only on mount — while open, the composer owns the value
-	// and syncs back to parent via onSubmit on each keystroke.
-	// Excluding initialValue prevents useDeferredValue lag from overwriting edits.
+	// Sync value when the modal opens. While open, the composer owns the
+	// value and syncs each edit back to the parent via onSubmit.
+	// Excluding initialValue prevents parent draft updates from overwriting edits.
 	useEffect(() => {
 		if (isOpen) {
 			setValue(initialValue);
@@ -276,7 +276,7 @@ export function PromptComposerModal({
 
 	const handleValueChange = useCallback((newValue: string) => {
 		setValue(newValue);
-		// Sync every keystroke to parent so the composer is transparent —
+		// Sync every keystroke to parent so the composer is transparent -
 		// typing here is equivalent to typing in the standard input box
 		onSubmitRef.current(newValue);
 
@@ -501,7 +501,7 @@ export function PromptComposerModal({
 							Prompt Composer
 						</span>
 						<span className="text-sm opacity-60" style={{ color: theme.colors.textDim }}>
-							— {sessionName}
+							- {sessionName}
 						</span>
 					</div>
 					<div className="flex items-center gap-1">

--- a/src/renderer/hooks/input/useInputHandlers.ts
+++ b/src/renderer/hooks/input/useInputHandlers.ts
@@ -236,9 +236,6 @@ export function useInputHandlers(deps: UseInputHandlersDeps): UseInputHandlersRe
 	// correct tab, and the tab-switch effect can flush the OLD tab's text without
 	// re-triggering on tab-switch alone.
 	const activeTabIdRef = useRef<string | undefined>(activeTab?.id);
-	useEffect(() => {
-		activeTabIdRef.current = activeTab?.id;
-	}, [activeTab?.id]);
 
 	// Ref-mirror of the current mode so non-reactive readers (getInputValue) pick
 	// the right slice at call time without subscribing.
@@ -251,6 +248,7 @@ export function useInputHandlers(deps: UseInputHandlersDeps): UseInputHandlersRe
 	// on screen for the active tab (tab.inputValue only updates on blur/submit).
 	// Subscribing outside React render keeps this off the re-render path.
 	useEffect(() => {
+		activeTabIdRef.current = activeTab?.id;
 		const mirror = (aiValue: string) => {
 			const currentTabId = activeTabIdRef.current;
 			if (currentTabId) setLiveDraft(currentTabId, aiValue);
@@ -259,7 +257,7 @@ export function useInputHandlers(deps: UseInputHandlersDeps): UseInputHandlersRe
 		return useComposerInputStore.subscribe((state, prev) => {
 			if (state.aiValue !== prev.aiValue) mirror(state.aiValue);
 		});
-	}, []);
+	}, [activeTab?.id]);
 
 	// Read the live value non-reactively (at call time) for handlers and sub-hooks
 	// so they never need a reactive `inputValue` dependency.
@@ -334,6 +332,20 @@ export function useInputHandlers(deps: UseInputHandlersDeps): UseInputHandlersRe
 
 	const prevActiveTabIdRef = useRef<string | undefined>(activeTab?.id);
 	const prevActiveSessionIdRef = useRef<string | undefined>(activeSession?.id);
+	const didHydrateAiInputRef = useRef(false);
+	const didHydrateTerminalInputRef = useRef(false);
+
+	useEffect(() => {
+		if (!activeTab || didHydrateAiInputRef.current) return;
+		setAiValue(activeTab.inputValue ?? '');
+		didHydrateAiInputRef.current = true;
+	}, [activeTab?.id, setAiValue]);
+
+	useEffect(() => {
+		if (!activeSession || didHydrateTerminalInputRef.current) return;
+		setTerminalValue(activeSession.terminalDraftInput ?? '');
+		didHydrateTerminalInputRef.current = true;
+	}, [activeSession?.id, setTerminalValue]);
 
 	// Sync local AI input with tab's persisted value when switching tabs
 	useEffect(() => {

--- a/src/renderer/hooks/input/useInputHandlers.ts
+++ b/src/renderer/hooks/input/useInputHandlers.ts
@@ -13,7 +13,7 @@
  *             fileExplorerStore, InputContext
  */
 
-import { useState, useCallback, useEffect, useRef, useMemo, useDeferredValue } from 'react';
+import { useCallback, useEffect, useRef, useMemo } from 'react';
 import type { Session, BatchRunState, QueuedItem, CustomAICommand } from '../../types';
 import { useSessionStore, selectActiveSession } from '../../stores/sessionStore';
 import { useSettingsStore } from '../../stores/settingsStore';
@@ -23,6 +23,7 @@ import { useFileExplorerStore } from '../../stores/fileExplorerStore';
 import { useInputContext } from '../../contexts/InputContext';
 import { getActiveTab } from '../../utils/tabHelpers';
 import { setLiveDraft } from '../../utils/liveDraftStore';
+import { useComposerInputStore } from '../../stores/composerInputStore';
 import { useDebouncedValue } from '../utils';
 import { useInputSync } from './useInputSync';
 import { useTabCompletion } from './useTabCompletion';
@@ -117,11 +118,11 @@ export interface UseInputHandlersDeps {
 // ============================================================================
 
 export interface UseInputHandlersReturn {
-	/** Current input value (AI or terminal, depending on mode) */
-	inputValue: string;
-	/** Deferred input value for expensive consumers (slash command filtering, etc.) */
-	deferredInputValue: string;
-	/** Set current input value (dispatches to AI or terminal state based on mode) */
+	/**
+	 * Set current input value (dispatches to AI or terminal slice based on mode).
+	 * The live value itself lives in useComposerInputStore; read it there
+	 * (InputArea subscribes; non-reactive readers use getState()).
+	 */
 	setInputValue: (value: string | ((prev: string) => string)) => void;
 	/** Staged images for the current message */
 	stagedImages: string[];
@@ -224,46 +225,59 @@ export function useInputHandlers(deps: UseInputHandlersDeps): UseInputHandlersRe
 	// Input State
 	// ====================================================================
 
-	const [terminalInputValue, setTerminalInputValue] = useState('');
-	const [aiInputValueLocal, setAiInputValueLocal] = useState('');
+	// PERF: live composer text lives in useComposerInputStore, NOT useState here.
+	// A keystroke updates the store, which re-renders only the memoized InputArea
+	// leaf that subscribes to it - this hook (and App) no longer re-render per
+	// keystroke. The store setters are stable; grab them once.
+	const setAiValue = useMemo(() => useComposerInputStore.getState().setAiValue, []);
+	const setTerminalValue = useMemo(() => useComposerInputStore.getState().setTerminalValue, []);
 
-	// PERF: Refs to access current input values without triggering re-renders
-	const terminalInputValueRef = useRef(terminalInputValue);
-	const aiInputValueLocalRef = useRef(aiInputValueLocal);
-	// Ref-mirror of activeTab.id so the live-draft sync below isn't re-triggered
-	// on tab-switch alone (which would briefly write the OLD tab's text into the
-	// NEW tab's slot before setAiInputValueLocal lands).
+	// Ref-mirror of activeTab.id so the live-draft mirror attributes text to the
+	// correct tab, and the tab-switch effect can flush the OLD tab's text without
+	// re-triggering on tab-switch alone.
 	const activeTabIdRef = useRef<string | undefined>(activeTab?.id);
 	useEffect(() => {
 		activeTabIdRef.current = activeTab?.id;
 	}, [activeTab?.id]);
-	useEffect(() => {
-		terminalInputValueRef.current = terminalInputValue;
-	}, [terminalInputValue]);
-	useEffect(() => {
-		aiInputValueLocalRef.current = aiInputValueLocal;
-		// Mirror the live value into liveDraftStore so hasDraft() reflects what's
-		// on screen for the active tab (tab.inputValue only updates on blur/submit).
-		const currentTabId = activeTabIdRef.current;
-		if (currentTabId) {
-			setLiveDraft(currentTabId, aiInputValueLocal);
-		}
-	}, [aiInputValueLocal]);
 
-	// Derived input value
-	const inputValue = isAiMode ? aiInputValueLocal : terminalInputValue;
-	const deferredInputValue = useDeferredValue(inputValue);
+	// Ref-mirror of the current mode so non-reactive readers (getInputValue) pick
+	// the right slice at call time without subscribing.
+	const isAiModeRef = useRef(isAiMode);
+	useEffect(() => {
+		isAiModeRef.current = isAiMode;
+	}, [isAiMode]);
 
-	// Memoized setter that dispatches to the correct state
+	// Mirror the live AI draft into liveDraftStore so hasDraft() reflects what's
+	// on screen for the active tab (tab.inputValue only updates on blur/submit).
+	// Subscribing outside React render keeps this off the re-render path.
+	useEffect(() => {
+		const mirror = (aiValue: string) => {
+			const currentTabId = activeTabIdRef.current;
+			if (currentTabId) setLiveDraft(currentTabId, aiValue);
+		};
+		mirror(useComposerInputStore.getState().aiValue);
+		return useComposerInputStore.subscribe((state, prev) => {
+			if (state.aiValue !== prev.aiValue) mirror(state.aiValue);
+		});
+	}, []);
+
+	// Read the live value non-reactively (at call time) for handlers and sub-hooks
+	// so they never need a reactive `inputValue` dependency.
+	const getInputValue = useCallback(() => {
+		const s = useComposerInputStore.getState();
+		return isAiModeRef.current ? s.aiValue : s.terminalValue;
+	}, []);
+
+	// Memoized setter that dispatches to the correct slice based on current mode.
 	const setInputValue = useCallback(
 		(value: string | ((prev: string) => string)) => {
 			if (activeSession?.inputMode === 'ai') {
-				setAiInputValueLocal(value);
+				setAiValue(value);
 			} else {
-				setTerminalInputValue(value);
+				setTerminalValue(value);
 			}
 		},
-		[activeSession?.inputMode]
+		[activeSession?.inputMode, setAiValue, setTerminalValue]
 	);
 
 	// ====================================================================
@@ -328,18 +342,19 @@ export function useInputHandlers(deps: UseInputHandlersDeps): UseInputHandlersRe
 
 			// Save current AI input to the PREVIOUS tab
 			if (prevTabId) {
+				const currentAiValue = useComposerInputStore.getState().aiValue;
 				setSessions((prev) =>
 					prev.map((s) => ({
 						...s,
 						aiTabs: s.aiTabs.map((tab) =>
-							tab.id === prevTabId ? { ...tab, inputValue: aiInputValueLocal } : tab
+							tab.id === prevTabId ? { ...tab, inputValue: currentAiValue } : tab
 						),
 					}))
 				);
 			}
 
 			// Load new tab's persisted input value
-			setAiInputValueLocal(activeTab.inputValue ?? '');
+			setAiValue(activeTab.inputValue ?? '');
 			prevActiveTabIdRef.current = activeTab.id;
 
 			// Clear hasUnread indicator on newly active tab
@@ -365,15 +380,16 @@ export function useInputHandlers(deps: UseInputHandlersDeps): UseInputHandlersRe
 
 			// Save terminal input to the previous session (including empty string to persist cleared input)
 			if (prevSessionId) {
+				const currentTerminalValue = useComposerInputStore.getState().terminalValue;
 				setSessions((prev) =>
 					prev.map((s) =>
-						s.id === prevSessionId ? { ...s, terminalDraftInput: terminalInputValue } : s
+						s.id === prevSessionId ? { ...s, terminalDraftInput: currentTerminalValue } : s
 					)
 				);
 			}
 
 			// Load terminal input from the new session
-			setTerminalInputValue(activeSession.terminalDraftInput ?? '');
+			setTerminalValue(activeSession.terminalDraftInput ?? '');
 			prevActiveSessionIdRef.current = activeSession.id;
 		}
 	}, [activeSession?.id]);
@@ -382,7 +398,14 @@ export function useInputHandlers(deps: UseInputHandlersDeps): UseInputHandlersRe
 	// Completion suggestions (memoized)
 	// ====================================================================
 
-	const debouncedInputForTabCompletion = useDebouncedValue(tabCompletionOpen ? inputValue : '', 50);
+	// Gated store subscription: returns '' (a stable primitive) unless the
+	// terminal tab-completion dropdown is open, so zustand's Object.is bail-out
+	// means normal typing does NOT re-render this hook. Only while the dropdown
+	// is open do we track the live text to refresh suggestions.
+	const tabCompletionInput = useComposerInputStore((s) =>
+		tabCompletionOpen ? s.terminalValue : ''
+	);
+	const debouncedInputForTabCompletion = useDebouncedValue(tabCompletionInput, 50);
 	const tabCompletionSuggestions = useMemo(() => {
 		if (!tabCompletionOpen || !activeSessionId || activeSessionInputMode !== 'terminal') {
 			return [];
@@ -439,7 +462,7 @@ export function useInputHandlers(deps: UseInputHandlersDeps): UseInputHandlersRe
 		activeSession,
 		activeSessionId,
 		setSessions,
-		inputValue,
+		getInputValue,
 		setInputValue,
 		stagedImages,
 		setStagedImages,
@@ -476,7 +499,7 @@ export function useInputHandlers(deps: UseInputHandlersDeps): UseInputHandlersRe
 	// ====================================================================
 
 	const { handleInputKeyDown } = useInputKeyDown({
-		inputValue,
+		getInputValue,
 		setInputValue,
 		tabCompletionSuggestions,
 		atMentionSuggestions,
@@ -495,17 +518,18 @@ export function useInputHandlers(deps: UseInputHandlersDeps): UseInputHandlersRe
 	const handleMainPanelInputBlur = useCallback(() => {
 		const currentIsAiMode =
 			sessionsRef.current.find((s) => s.id === activeSessionIdRef.current)?.inputMode === 'ai';
+		const composer = useComposerInputStore.getState();
 		if (currentIsAiMode) {
-			syncAiInputToSession(aiInputValueLocalRef.current);
+			syncAiInputToSession(composer.aiValue);
 		} else {
-			syncTerminalInputToSession(terminalInputValueRef.current);
+			syncTerminalInputToSession(composer.terminalValue);
 		}
 	}, [syncAiInputToSession, syncTerminalInputToSession]);
 
 	const handleReplayMessage = useCallback(
 		(text: string, images?: string[]) => {
 			// Preserve draft input so replay doesn't clobber what the user was typing
-			const draftInput = aiInputValueLocalRef.current;
+			const draftInput = useComposerInputStore.getState().aiValue;
 			const draftImages = activeTab?.stagedImages ? [...activeTab.stagedImages] : [];
 
 			if (images && images.length > 0) {
@@ -779,8 +803,6 @@ export function useInputHandlers(deps: UseInputHandlersDeps): UseInputHandlersRe
 	// ====================================================================
 
 	return {
-		inputValue,
-		deferredInputValue,
 		setInputValue,
 		stagedImages,
 		setStagedImages,

--- a/src/renderer/hooks/input/useInputKeyDown.ts
+++ b/src/renderer/hooks/input/useInputKeyDown.ts
@@ -26,8 +26,8 @@ import { outputSearchKeyFor } from '../../utils/outputSearch';
 // ============================================================================
 
 export interface InputKeyDownDeps {
-	/** Current input value */
-	inputValue: string;
+	/** Read the current input value at call time (non-reactive; reads the store) */
+	getInputValue: () => string;
 	/** Set input value */
 	setInputValue: (value: string | ((prev: string) => string)) => void;
 	/** Memoized tab completion suggestions (already filtered) */
@@ -67,7 +67,7 @@ export interface InputKeyDownReturn {
 
 export function useInputKeyDown(deps: InputKeyDownDeps): InputKeyDownReturn {
 	const {
-		inputValue,
+		getInputValue,
 		setInputValue,
 		tabCompletionSuggestions,
 		atMentionSuggestions,
@@ -108,6 +108,9 @@ export function useInputKeyDown(deps: InputKeyDownDeps): InputKeyDownReturn {
 	const handleInputKeyDown = useCallback(
 		(e: React.KeyboardEvent) => {
 			const activeSession = selectActiveSession(useSessionStore.getState());
+			// Snapshot the live composer text once at call time (it lives in the
+			// store now, not in a reactive prop).
+			const inputValue = getInputValue();
 
 			// Cmd+F opens output search from input field. Search is scoped per
 			// agent+AI-tab, so target the active window's slot.
@@ -341,7 +344,7 @@ export function useInputKeyDown(deps: InputKeyDownDeps): InputKeyDownReturn {
 			}
 		},
 		[
-			inputValue,
+			getInputValue,
 			setInputValue,
 			tabCompletionSuggestions,
 			atMentionSuggestions,

--- a/src/renderer/hooks/input/useInputProcessing.ts
+++ b/src/renderer/hooks/input/useInputProcessing.ts
@@ -54,8 +54,8 @@ export interface UseInputProcessingDeps {
 	activeSessionId: string;
 	/** Session state setter */
 	setSessions: React.Dispatch<React.SetStateAction<Session[]>>;
-	/** Current input value */
-	inputValue: string;
+	/** Read the current input value at call time (non-reactive; reads the store) */
+	getInputValue: () => string;
 	/** Input value setter */
 	setInputValue: (value: string) => void;
 	/** Staged images for the current message */
@@ -144,7 +144,7 @@ export function useInputProcessing(deps: UseInputProcessingDeps): UseInputProces
 		activeSession,
 		activeSessionId,
 		setSessions,
-		inputValue,
+		getInputValue,
 		setInputValue,
 		stagedImages,
 		setStagedImages,
@@ -189,7 +189,7 @@ export function useInputProcessing(deps: UseInputProcessingDeps): UseInputProces
 			// This ensures AI output appears before the user's new message
 			flushBatchedUpdates?.();
 
-			const effectiveInputValue = overrideInputValue ?? inputValue;
+			const effectiveInputValue = overrideInputValue ?? getInputValue();
 			// When the caller passes explicit images (e.g. Force Send button replaying a
 			// queued item), use those instead of the active tab's stagedImages. This avoids
 			// the stale-closure race when the caller does setStagedImages() right before
@@ -1303,7 +1303,7 @@ export function useInputProcessing(deps: UseInputProcessingDeps): UseInputProces
 		[
 			activeSession,
 			activeSessionId,
-			inputValue,
+			getInputValue,
 			stagedImages,
 			customAICommands,
 			setInputValue,

--- a/src/renderer/hooks/modal/index.ts
+++ b/src/renderer/hooks/modal/index.ts
@@ -1,8 +1,12 @@
 export { useModalHandlers, type ModalHandlersReturn } from './useModalHandlers';
 
 // Prompt Composer modal handlers
-export { usePromptComposerHandlers } from './usePromptComposerHandlers';
+export {
+	getPromptComposerInitialValue,
+	usePromptComposerHandlers,
+} from './usePromptComposerHandlers';
 export type {
+	PromptComposerInitialValueDeps,
 	UsePromptComposerHandlersDeps,
 	UsePromptComposerHandlersReturn,
 } from './usePromptComposerHandlers';

--- a/src/renderer/hooks/modal/usePromptComposerHandlers.ts
+++ b/src/renderer/hooks/modal/usePromptComposerHandlers.ts
@@ -9,10 +9,11 @@
  */
 
 import { useCallback } from 'react';
-import type { ThinkingMode } from '../../types';
+import type { GroupChat, ThinkingMode } from '../../types';
 import { useSessionStore, selectActiveSession } from '../../stores/sessionStore';
 import { useGroupChatStore } from '../../stores/groupChatStore';
 import { useSettingsStore } from '../../stores/settingsStore';
+import { useComposerInputStore } from '../../stores/composerInputStore';
 import { getActiveTab } from '../../utils/tabHelpers';
 
 // ============================================================================
@@ -50,6 +51,25 @@ export interface UsePromptComposerHandlersReturn {
 // ============================================================================
 // Hook implementation
 // ============================================================================
+
+export interface PromptComposerInitialValueDeps {
+	activeGroupChatId: string | null;
+	groupChats: Pick<GroupChat, 'id' | 'draftMessage'>[];
+	activeInputMode?: 'ai' | 'terminal';
+}
+
+export function getPromptComposerInitialValue({
+	activeGroupChatId,
+	groupChats,
+	activeInputMode,
+}: PromptComposerInitialValueDeps): string {
+	if (activeGroupChatId) {
+		return groupChats.find((c) => c.id === activeGroupChatId)?.draftMessage || '';
+	}
+
+	const composer = useComposerInputStore.getState();
+	return activeInputMode === 'terminal' ? composer.terminalValue : composer.aiValue;
+}
 
 export function usePromptComposerHandlers(
 	deps: UsePromptComposerHandlersDeps

--- a/src/renderer/hooks/props/useMainPanelProps.ts
+++ b/src/renderer/hooks/props/useMainPanelProps.ts
@@ -49,7 +49,6 @@ export interface UseMainPanelPropsDeps {
 	thinkingItems: ThinkingItem[];
 	theme: Theme;
 	isMobileLandscape: boolean;
-	inputValue: string;
 	stagedImages: string[];
 	commandHistoryOpen: boolean;
 	commandHistoryFilter: string;
@@ -340,7 +339,6 @@ export function useMainPanelProps(deps: UseMainPanelPropsDeps) {
 			thinkingItems: deps.thinkingItems,
 			theme: deps.theme,
 			isMobileLandscape: deps.isMobileLandscape,
-			inputValue: deps.inputValue,
 			stagedImages: deps.stagedImages,
 			commandHistoryOpen: deps.commandHistoryOpen,
 			commandHistoryFilter: deps.commandHistoryFilter,
@@ -576,7 +574,6 @@ export function useMainPanelProps(deps: UseMainPanelPropsDeps) {
 			deps.thinkingItems,
 			deps.theme,
 			deps.isMobileLandscape,
-			deps.inputValue,
 			deps.stagedImages,
 			deps.commandHistoryOpen,
 			deps.commandHistoryFilter,

--- a/src/renderer/hooks/props/useSessionListProps.ts
+++ b/src/renderer/hooks/props/useSessionListProps.ts
@@ -59,6 +59,8 @@ export interface UseSessionListPropsDeps {
 	handleDeleteWorktreeSession: (session: Session) => void;
 	handleToggleWorktreeExpanded: (sessionId: string) => void;
 	handleConfigureCue: (session: Session) => void;
+	/** Whether the Maestro Cue Encore Feature is enabled. Gates the "Configure Maestro Cue" context-menu action. */
+	maestroCueEnabled: boolean;
 	handleJumpToStarredSession: (
 		agentId: string,
 		projectPath: string,
@@ -128,7 +130,10 @@ export function useSessionListProps(deps: UseSessionListPropsDeps) {
 			onQuickCreateWorktree: deps.handleQuickCreateWorktree,
 			onOpenWorktreeConfig: deps.handleOpenWorktreeConfigSession,
 			onDeleteWorktree: deps.handleDeleteWorktreeSession,
-			onConfigureCue: deps.handleConfigureCue,
+			// Gate on the Encore Feature flag: when Cue is disabled, leave this
+			// undefined so the "Configure Maestro Cue" context-menu item is hidden
+			// (the item renders only when onConfigureCue is defined).
+			onConfigureCue: deps.maestroCueEnabled ? deps.handleConfigureCue : undefined,
 			onJumpToStarredSession: deps.handleJumpToStarredSession,
 			openWizard: deps.openWizardModal,
 			openFeedback: deps.handleOpenFeedbackModal,
@@ -178,6 +183,7 @@ export function useSessionListProps(deps: UseSessionListPropsDeps) {
 			deps.handleOpenWorktreeConfigSession,
 			deps.handleDeleteWorktreeSession,
 			deps.handleConfigureCue,
+			deps.maestroCueEnabled,
 			deps.handleJumpToStarredSession,
 			deps.handleToggleWorktreeExpanded,
 			deps.openWizardModal,

--- a/src/renderer/stores/composerInputStore.ts
+++ b/src/renderer/stores/composerInputStore.ts
@@ -1,0 +1,52 @@
+/**
+ * Live composer draft text (the main input textarea).
+ *
+ * WHY THIS EXISTS - keyboard performance:
+ * The AI prompt / terminal command draft used to live in `useState` inside
+ * `useInputHandlers`, which runs in `MaestroConsoleInner` (App.tsx). Every
+ * keystroke called that setter and re-rendered the entire app tree, which is
+ * the keyboard lag users felt (characters appearing slower than typed).
+ *
+ * Moving the draft here lets the single leaf that displays it (`InputArea`,
+ * already `React.memo`) subscribe directly, while everything else reads the
+ * current value non-reactively via `getState()`. App no longer re-renders per
+ * keystroke. See CLAUDE-PERFORMANCE.md -> "React State Bail-out".
+ *
+ * Two slices, mirroring the previous dual `useState`:
+ *  - `aiValue`: the active AI tab's draft. Flushed to `tab.inputValue` on
+ *    blur / submit / tab-switch (owned by useInputHandlers).
+ *  - `terminalValue`: the active session's terminal command draft. Flushed to
+ *    `session.terminalDraftInput` on blur / session-switch.
+ *
+ * This store holds only the *active* surface's live text; per-tab and
+ * per-session persistence still lives on the session model, exactly as before.
+ */
+
+import { create } from 'zustand';
+
+type Updater = string | ((prev: string) => string);
+
+const resolve = (next: Updater, prev: string): string =>
+	typeof next === 'function' ? next(prev) : next;
+
+interface ComposerInputState {
+	/** Live AI prompt draft for the active tab. */
+	aiValue: string;
+	/** Live terminal command draft for the active session. */
+	terminalValue: string;
+	setAiValue: (value: Updater) => void;
+	setTerminalValue: (value: Updater) => void;
+}
+
+export const useComposerInputStore = create<ComposerInputState>()((set) => ({
+	aiValue: '',
+	terminalValue: '',
+	setAiValue: (value) => set((s) => ({ aiValue: resolve(value, s.aiValue) })),
+	setTerminalValue: (value) => set((s) => ({ terminalValue: resolve(value, s.terminalValue) })),
+}));
+
+/** Selector: the live AI draft. */
+export const selectAiComposerValue = (s: ComposerInputState): string => s.aiValue;
+
+/** Selector: the live terminal draft. */
+export const selectTerminalComposerValue = (s: ComposerInputState): string => s.terminalValue;


### PR DESCRIPTION
## Problem

Typing in the AI prompt (or terminal) lagged: characters appeared slower than typed. Root cause: the live draft text lived in `useState` inside `useInputHandlers`, which runs in `MaestroConsoleInner` (`App.tsx`). **Every keystroke re-rendered the entire app tree.**

## Fix

Move the live draft into a dedicated `useComposerInputStore` (zustand, two slices: `aiValue` / `terminalValue`).

- **`InputArea`** (already `React.memo`) is now the *sole* subscriber, so a keystroke re-renders only that leaf.
- **`useInputHandlers`** and the sub-hooks (`useInputProcessing`, `useInputKeyDown`) read the value non-reactively via a `getInputValue()` getter / `getState()`, so they no longer take a reactive `inputValue` dependency.
- The key trick for terminal tab-completion: a **gated selector** `useComposerInputStore((s) => tabCompletionOpen ? s.terminalValue : '')`. When the dropdown is closed it returns a stable `''`, so zustand's `Object.is` bail-out means **normal typing does not re-render the hook**. Live suggestions still work while the dropdown is open.

Net result: `App` no longer re-renders per keystroke; only the memoized composer leaf does.

## Preserved behavior

Per-tab and per-session draft persistence (flush on blur/submit/tab-switch/session-switch), the `liveDraftStore` mirror (now via a `store.subscribe` outside render), and paste/drop/replay handlers are all unchanged. The `inputValue` prop was pure pass-through (`App` → `useMainPanelProps` → `MainPanel` → `MainPanelContent` → `InputArea`); that chain is removed.

## API change

`useInputHandlers` no longer returns `inputValue` / `deferredInputValue` (read the store instead). `InputArea` no longer takes an `inputValue` prop. Sub-hook deps take `getInputValue: () => string` in place of `inputValue: string`.

## Testing

- New `composerInputStore` unit suite (setters, functional updaters, selectors, subscription).
- Migrated the input-subsystem test suites; **full pre-push suite green: 31,336 passed, 0 failed**.
- `tsc` (lint/main/cli) and ESLint clean.

## Suggested manual check

Worth a quick in-app type-test before merge: fast typing in the AI prompt, switching tabs/agents mid-draft (draft should persist per tab), terminal tab-completion, and the prompt-composer expand (Cmd-click / shortcut) seeding the current draft. A before/after Cmd+K performance trace (the new field-profiling feature) would quantify the win.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Composer input now maintains separate live drafts for AI and terminal modes, preserving the correct text when you switch.
  * Prompt Composer now initializes from the active session/group chat draft for the current input mode.
  * Session list “configure” behavior now depends on Maestro Cue availability.

* **Bug Fixes**
  * Improved live syncing so the editor reflects draft updates correctly based on the active mode.
  * Updated Prompt Composer header/session name separator to a consistent hyphen.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->