### PR TITLE
fix(autorun): forward per-session reasoning effort to Auto Run spawns (#1147)

### DIFF
--- a/src/renderer/hooks/agent/useAgentExecution.ts
+++ b/src/renderer/hooks/agent/useAgentExecution.ts
@@ -575,6 +575,12 @@ export function useAgentExecution(deps: UseAgentExecutionDeps): UseAgentExecutio
 							sessionCustomArgs: session.customArgs,
 							sessionCustomEnvVars: session.customEnvVars,
 							sessionCustomModel: session.customModel,
+							// Auto Run is session-level (no active tab), so the session's effort
+							// is the source. Interactive spawns pass this too; omitting it here
+							// dropped the user's configured reasoning effort in Auto Run, which for
+							// Codex meant no reasoning summary was streamed (Thought Stream stayed
+							// stuck on "Waiting for the agent to start thinking...") - see #1147.
+							sessionCustomEffort: session.customEffort,
 							sessionCustomContextWindow: session.customContextWindow,
 							// Per-session SSH remote config (takes precedence over agent-level SSH config)
 							sessionSshRemoteConfig: session.sessionSshRemoteConfig,


### PR DESCRIPTION
Closes #1147

## Problem

In Auto Run **Goal-Driven** mode with **Codex** selected, the Thought Stream panel stays stuck on "Waiting for the agent to start thinking..." for the whole session, even though history populates normally. Claude and other agents stream their reasoning fine in the same mode.

## Root cause

The Thought Stream panel is fed by `process:thinking-chunk` events. For Codex those come from reasoning summaries the CLI emits, gated by the reasoning effort passed via `-c reasoning.effort=...`.

Interactive spawns forward the user's configured effort:

```ts
// src/renderer/hooks/input/useInputProcessing.ts
sessionCustomEffort: freshActiveTab?.customEffort ?? freshSession.customEffort,
```

But the Auto Run / Goal-Driven spawn (`spawnAgentForSession` in `useAgentExecution.ts`) was missing that field. So Auto Run dropped the user's reasoning effort and fell back to the empty default, which for Codex can mean no reasoning summary is streamed, hence no `thinking-chunk` events and the stuck panel. It's a spawn-path parity gap that surfaces most visibly on Codex.

## Fix

Forward `session.customEffort` in the Auto Run spawn config, matching the interactive path. Auto Run is session-level (no active tab), so the session's effort is the correct source, consistent with the other `session.*` overrides already passed there. When effort is unset this is a no-op (falls back to the agent config exactly as before), so there is no regression for users who never configured an effort.

## Validation

- `eslint` clean on the changed file
- Type-check adds no new errors
- `useAgentExecution` + `useBatchHandlers` suites pass (77 tests)

I have not been able to reproduce against a live Codex run locally, so I would love the reporter to confirm this resolves it in their setup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Auto Run now preserves your selected reasoning effort when starting a batch session, so spawned runs follow the same effort setting as the original session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->