### PR TITLE
feat(auto-run): honor agent halt marker in desktop Auto Run (closes #231)

### DIFF
--- a/src/cli/services/batch-processor.ts
+++ b/src/cli/services/batch-processor.ts
@@ -22,29 +22,12 @@ import { PROMPT_IDS } from '../../shared/promptDefinitions';
 import { getCliPrompt } from './prompt-loader';
 import { getGitBranch, isGitRepo } from './git-utils';
 import { prepareMaestroSystemPromptCli } from './system-prompt';
+import { detectHaltMarker } from '../../shared/autorun/haltMarker';
 
-/**
- * Detect the `<!-- maestro:halt -->` early-exit marker in a document.
- *
- * Agents write this marker into the current Auto Run document to abort the
- * entire playbook (skipping all remaining tasks in the current document and
- * all subsequent documents). The optional reason after the colon is surfaced
- * in the History panel and JSONL `halt` event.
- *
- * Accepts:
- *   <!-- maestro:halt -->
- *   <!-- maestro:halt: brief reason here -->
- *
- * Match is case-insensitive on the keyword to tolerate agent variations,
- * but the literal token `maestro:halt` is required to keep false positives
- * effectively zero.
- */
-export function detectHaltMarker(content: string): { halted: boolean; reason?: string } {
-	const match = content.match(/<!--\s*maestro:halt\s*(?::\s*([^>]*?))?\s*-->/i);
-	if (!match) return { halted: false };
-	const reason = match[1]?.trim();
-	return { halted: true, reason: reason || undefined };
-}
+// `detectHaltMarker` is re-exported so existing CLI consumers and tests that
+// reference it via this module keep resolving. The canonical implementation now
+// lives in `shared/autorun/haltMarker` so the desktop renderer can share it.
+export { detectHaltMarker };
 
 /**
  * Process a playbook and yield JSONL events

--- a/src/renderer/hooks/batch/internal/useBatchRunner.ts
+++ b/src/renderer/hooks/batch/internal/useBatchRunner.ts
@@ -18,6 +18,7 @@ import { useBatchStore } from '../../../stores/batchStore';
 import { useSessionStore, selectSessionById } from '../../../stores/sessionStore';
 import { useSettingsStore } from '../../../stores/settingsStore';
 import { countUnfinishedTasks, findPendingHitlGate, uncheckAllTasks } from '../batchUtils';
+import { detectHaltMarker } from '../../../../shared/autorun/haltMarker';
 import { DEFAULT_BATCH_STATE, type BatchAction } from '../batchReducer';
 import { createLoopSummaryEntry } from './batchLoopSummary';
 import {
@@ -465,6 +466,13 @@ export function useBatchRunner({
 
 			// Track stalled documents (document filename -> stall reason)
 			const stalledDocuments: Map<string, string> = new Map();
+
+			// Set when an agent writes a `<!-- maestro:halt: reason -->` marker into a
+			// document mid-run. A halt aborts the whole playbook immediately: no more
+			// tasks in the current document, no remaining documents, no further loop
+			// iterations. Mirrors the CLI batch processor so desktop Auto Run honors
+			// the same agent-driven early-exit contract. (#231)
+			let haltRequest: { document: string; reason: string } | null = null;
 
 			// Track the line of the currently-active HITL gate (null when none).
 			// Used to (a) dedupe the sticky toast on Resume-without-tick —
@@ -1106,6 +1114,26 @@ export function useBatchRunner({
 							docCheckedCount = newCheckedCount;
 							remainingTasks = newRemainingTasks;
 							docContent = taskResult.contentAfterTask;
+
+							// Halt marker: the agent can write `<!-- maestro:halt: reason -->`
+							// into the document to stop the whole run now. Checked on the
+							// post-task content (after the synopsis/history for this task was
+							// already recorded above) so the work that led to the halt is still
+							// captured. Breaks the task loop; the document and outer loops below
+							// pick up `haltRequest` and finalize. (#231)
+							const haltMarker = detectHaltMarker(taskResult.contentAfterTask);
+							if (haltMarker.halted) {
+								haltRequest = {
+									document: docEntry.filename,
+									reason: haltMarker.reason || 'Halted by agent',
+								};
+								window.maestro.logger.autorun('Auto Run halted by agent', session.name, {
+									document: docEntry.filename,
+									reason: haltRequest.reason,
+									loopNumber: loopIteration + 1,
+								});
+								break;
+							}
 						} catch (error) {
 							progressPoll.stop();
 							logger.error(
@@ -1151,6 +1179,12 @@ export function useBatchRunner({
 
 					// Check for stop request before moving to next document
 					if (stopRequestedRefs.current[sessionId]) {
+						break;
+					}
+
+					// An agent halted the run from inside this document - skip any remaining
+					// documents and let the outer loop finalize. (#231)
+					if (haltRequest) {
 						break;
 					}
 
@@ -1211,6 +1245,21 @@ export function useBatchRunner({
 						// Working copy still serves as record of the attempt
 						workingCopies.delete(docEntry.filename);
 					}
+				}
+
+				// An agent halted the run from inside a document - stop looping entirely,
+				// record the terminal reason in run history, and surface a toast so the
+				// user sees why Auto Run ended without opening the History panel. (#231)
+				if (haltRequest) {
+					addFinalLoopSummary(`Halted by agent: ${haltRequest.reason}`);
+					notifyToast({
+						color: 'theme',
+						title: 'Auto Run halted by agent',
+						message: haltRequest.reason,
+						project: session.name,
+						sessionId,
+					});
+					break;
 				}
 
 				// Note: We no longer break immediately when a document stalls.

--- a/src/shared/autorun/haltMarker.ts
+++ b/src/shared/autorun/haltMarker.ts
@@ -1,0 +1,27 @@
+/**
+ * Detect the `<!-- maestro:halt -->` early-exit marker in a document.
+ *
+ * Agents write this marker into the current Auto Run document to abort the
+ * entire playbook (skipping all remaining tasks in the current document and
+ * all subsequent documents). The optional reason after the colon is surfaced
+ * in the History panel and JSONL `halt` event.
+ *
+ * Accepts:
+ *   <!-- maestro:halt -->
+ *   <!-- maestro:halt: brief reason here -->
+ *
+ * Match is case-insensitive on the keyword to tolerate agent variations,
+ * but the literal token `maestro:halt` is required to keep false positives
+ * effectively zero.
+ *
+ * Lives in `shared/` so both the CLI batch processor and the desktop renderer's
+ * Auto Run loop apply the exact same contract - the default Auto Run prompt and
+ * the in-app help modal advertise this marker to agents regardless of where the
+ * run is driven from.
+ */
+export function detectHaltMarker(content: string): { halted: boolean; reason?: string } {
+	const match = content.match(/<!--\s*maestro:halt\s*(?::\s*([^>]*?))?\s*-->/i);
+	if (!match) return { halted: false };
+	const reason = match[1]?.trim();
+	return { halted: true, reason: reason || undefined };
+}


### PR DESCRIPTION
Closes #231

## Problem

Auto Run had no way for a playbook/agent to signal "I'm done, stop now" in the **desktop app**. It exited only on **Max Loops** or a **manual Stop**, so a completed playbook kept cycling (Loop 16, 17, 18...) burning compute, exactly what #231 reports.

The mechanism that's supposed to cover this, the `<!-- maestro:halt: reason -->` marker, already exists:

- It's documented in the user docs (`docs/autorun-playbooks.md`).
- It's advertised to agents in the default Auto Run prompt (`src/prompts/autorun-default.md`).
- It's described in the in-app **Auto Run help modal** (`AutoRunnerHelpModal.tsx`).

...but `detectHaltMarker` was only ever wired into the **CLI** batch processor (`src/cli/services/batch-processor.ts`). The desktop renderer's Auto Run loop (`useBatchRunner.ts`) **never checked for it**. So the app told agents to write the marker and then silently ignored it.

## Fix

- Move `detectHaltMarker` into `src/shared/autorun/haltMarker.ts` so the CLI and the renderer share one canonical implementation. The CLI re-exports it for backward compatibility (its existing tests are unchanged and pass).
- Wire halt detection into `useBatchRunner`. After each task, the post-task document content is checked for the marker. On a hit, the run stops immediately:
  - break out of the current document's task loop,
  - skip any remaining documents,
  - stop all further loop iterations,
  - write a terminal `Halted by agent: <reason>` entry to run history (via the existing `addFinalLoopSummary`), and
  - fire a toast so the user sees why Auto Run ended without opening the History panel.

This mirrors the CLI's halt handling so desktop and CLI Auto Run now honor the same agent-driven early-exit contract.

## Out of scope (CLI-only, possible follow-ups)

- **Stale-marker pre-scan refusal:** the CLI refuses to *start* a run if a doc still contains a halt marker. The desktop doesn't pre-scan yet, so a left-behind marker would halt the run again after one task rather than blocking startup. Flagging rather than expanding scope.
- **JSONL `halt`/`complete` events:** a CLI output concern; the desktop surfaces the halt via history + toast instead.

## Testing

- `detectHaltMarker` unit tests pass via the shared module (6 passed).
- `tsc` (lint/main/cli configs) and ESLint are clean on all changed files.
- No automated harness exists for the `useBatchRunner` hook itself; the wiring mirrors the well-tested CLI path.

> Note on base branch: targeting `rc` (the soak branch) per project convention, not `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Auto Run now recognizes halt markers in documents, allowing an agent to stop the run early when requested.
  * If a halt is triggered, the app shows a clear “Auto Run halted by agent” message and records the reason when provided.

* **Bug Fixes**
  * Halt-marker detection is now handled consistently across the app, improving reliability when stopping runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->