### PR TITLE
fix(cue): scan watched files on manual task.pending trigger (#1151)

### DIFF
--- a/src/__tests__/main/cue/cue-engine.test.ts
+++ b/src/__tests__/main/cue/cue-engine.test.ts
@@ -44,11 +44,27 @@ vi.mock('../../../main/cue/cue-github-poller', () => ({
 	createCueGitHubPoller: (...args: unknown[]) => mockCreateCueGitHubPoller(args[0]),
 }));
 
-// Mock the task scanner
+// Mock the task scanner. `scanTaskFilesNow` is mocked so manual task.pending
+// triggers can be exercised without touching the filesystem; the real
+// `buildTaskPendingPayload` is reused so the asserted payload shape is genuine.
 const mockCreateCueTaskScanner = vi.fn<(config: unknown) => () => void>();
-vi.mock('../../../main/cue/cue-task-scanner', () => ({
-	createCueTaskScanner: (...args: unknown[]) => mockCreateCueTaskScanner(args[0]),
-}));
+const mockScanTaskFilesNow = vi.fn<
+	(
+		projectRoot: string,
+		watchGlob: string
+	) => import('../../../main/cue/cue-task-scanner').ScannedTaskFile[]
+>(() => []);
+vi.mock('../../../main/cue/cue-task-scanner', async () => {
+	const actual = await vi.importActual<typeof import('../../../main/cue/cue-task-scanner')>(
+		'../../../main/cue/cue-task-scanner'
+	);
+	return {
+		createCueTaskScanner: (...args: unknown[]) => mockCreateCueTaskScanner(args[0]),
+		scanTaskFilesNow: (projectRoot: string, watchGlob: string) =>
+			mockScanTaskFilesNow(projectRoot, watchGlob),
+		buildTaskPendingPayload: actual.buildTaskPendingPayload,
+	};
+});
 
 // Mock the database
 const mockInitCueDb = vi.fn();
@@ -3404,6 +3420,88 @@ describe('CueEngine', () => {
 			const result = engine.triggerSubscription('nonexistent', undefined, 'agent-xyz');
 			expect(result).toBe(false);
 			expect(deps.onCueRun).not.toHaveBeenCalled();
+
+			engine.stop();
+		});
+	});
+
+	describe('triggerSubscription enriches task.pending payload (issue #1151)', () => {
+		it('scans the watched file and populates task variables on manual trigger', () => {
+			const config = createMockConfig({
+				subscriptions: [
+					{
+						name: 'research queue',
+						event: 'task.pending',
+						watch: 'research.md',
+						enabled: true,
+						prompt: 'Process {{CUE_TASK_LIST}}',
+					},
+				],
+			});
+			mockLoadCueConfig.mockReturnValue(config);
+
+			mockScanTaskFilesNow.mockReturnValue([
+				{
+					relPath: 'research.md',
+					absPath: '/projects/test/research.md',
+					content: '- [ ] write the report\n',
+					tasks: [{ line: 1, text: 'write the report' }],
+				},
+			]);
+
+			const deps = createMockDeps();
+			const engine = new CueEngine(deps);
+			engine.start();
+
+			const result = engine.triggerSubscription('research queue');
+			expect(result).toBe(true);
+
+			// Scanned against the owning session's project root + the sub's glob.
+			expect(mockScanTaskFilesNow).toHaveBeenCalledWith('/projects/test', 'research.md');
+
+			// The dispatched event now carries the real task payload, so the
+			// {{CUE_TASK_*}} variables resolve instead of rendering empty.
+			expect(deps.onCueRun).toHaveBeenCalledWith(
+				expect.objectContaining({
+					event: expect.objectContaining({
+						payload: expect.objectContaining({
+							manual: true,
+							taskCount: 1,
+							taskList: 'L1: write the report',
+							filename: 'research.md',
+							path: '/projects/test/research.md',
+						}),
+					}),
+				})
+			);
+
+			engine.stop();
+		});
+
+		it('leaves the payload unenriched when no watched file has pending tasks', () => {
+			const config = createMockConfig({
+				subscriptions: [
+					{
+						name: 'research queue',
+						event: 'task.pending',
+						watch: 'research.md',
+						enabled: true,
+						prompt: 'Process tasks',
+					},
+				],
+			});
+			mockLoadCueConfig.mockReturnValue(config);
+			mockScanTaskFilesNow.mockReturnValue([]);
+
+			const deps = createMockDeps();
+			const engine = new CueEngine(deps);
+			engine.start();
+
+			engine.triggerSubscription('research queue');
+
+			const callArgs = (deps.onCueRun as ReturnType<typeof vi.fn>).mock.calls[0][0];
+			expect(callArgs.event.payload).toMatchObject({ manual: true });
+			expect(callArgs.event.payload).not.toHaveProperty('taskCount');
 
 			engine.stop();
 		});

--- a/src/__tests__/main/cue/cue-task-scanner.test.ts
+++ b/src/__tests__/main/cue/cue-task-scanner.test.ts
@@ -37,7 +37,12 @@ vi.mock('crypto', () => ({
 	}),
 }));
 
-import { extractPendingTasks, createCueTaskScanner } from '../../../main/cue/cue-task-scanner';
+import {
+	extractPendingTasks,
+	createCueTaskScanner,
+	scanTaskFilesNow,
+	buildTaskPendingPayload,
+} from '../../../main/cue/cue-task-scanner';
 
 describe('cue-task-scanner', () => {
 	describe('extractPendingTasks', () => {
@@ -104,6 +109,86 @@ describe('cue-task-scanner', () => {
 			const tasks = extractPendingTasks(content);
 			expect(tasks).toHaveLength(1);
 			expect(tasks[0].text).toBe('Not done');
+		});
+	});
+
+	describe('buildTaskPendingPayload', () => {
+		it('maps a file and its tasks into the task.pending payload shape', () => {
+			const tasks = [
+				{ line: 2, text: 'First' },
+				{ line: 5, text: 'Second' },
+			];
+			const payload = buildTaskPendingPayload(
+				'/project/research.md',
+				'research.md',
+				'- [ ] First\n',
+				tasks
+			);
+			expect(payload).toMatchObject({
+				path: '/project/research.md',
+				filename: 'research.md',
+				directory: '/project',
+				extension: '.md',
+				taskCount: 2,
+				taskList: 'L2: First\nL5: Second',
+				tasks,
+			});
+		});
+
+		it('truncates content to 10K chars', () => {
+			const long = 'x'.repeat(20000);
+			const payload = buildTaskPendingPayload('/p/a.md', 'a.md', long, [{ line: 1, text: 't' }]);
+			expect((payload.content as string).length).toBe(10000);
+		});
+	});
+
+	describe('scanTaskFilesNow', () => {
+		beforeEach(() => {
+			vi.clearAllMocks();
+		});
+
+		it('returns files that currently have pending tasks, with no hash dedup', () => {
+			mockReaddirSync.mockImplementation((_dir: string, opts: { withFileTypes: boolean }) => {
+				if (opts?.withFileTypes) {
+					return [{ name: 'research.md', isDirectory: () => false, isFile: () => true }];
+				}
+				return [];
+			});
+			mockReadFileSync.mockReturnValue('- [ ] open task\n');
+
+			const result = scanTaskFilesNow('/project', '**/*.md');
+			expect(result).toHaveLength(1);
+			expect(result[0].relPath).toBe('research.md');
+			expect(result[0].tasks).toHaveLength(1);
+			expect(result[0].tasks[0].text).toBe('open task');
+
+			// Calling again returns the same result — unlike the polling scanner,
+			// there is no seeding or content-hash suppression.
+			expect(scanTaskFilesNow('/project', '**/*.md')).toHaveLength(1);
+		});
+
+		it('skips files with no pending tasks', () => {
+			mockReaddirSync.mockImplementation((_dir: string, opts: { withFileTypes: boolean }) => {
+				if (opts?.withFileTypes) {
+					return [{ name: 'done.md', isDirectory: () => false, isFile: () => true }];
+				}
+				return [];
+			});
+			mockReadFileSync.mockReturnValue('- [x] done\n');
+
+			expect(scanTaskFilesNow('/project', '**/*.md')).toHaveLength(0);
+		});
+
+		it('skips files that do not match the watch glob', () => {
+			mockReaddirSync.mockImplementation((_dir: string, opts: { withFileTypes: boolean }) => {
+				if (opts?.withFileTypes) {
+					return [{ name: 'notes.txt', isDirectory: () => false, isFile: () => true }];
+				}
+				return [];
+			});
+			mockReadFileSync.mockReturnValue('- [ ] open\n');
+
+			expect(scanTaskFilesNow('/project', '**/*.md')).toHaveLength(0);
 		});
 	});
 

--- a/src/main/cue/cue-engine.ts
+++ b/src/main/cue/cue-engine.ts
@@ -39,6 +39,7 @@ import {
 	type CueSubscription,
 } from './cue-types';
 import { getCueRunLiveOutput } from './cue-executor';
+import { scanTaskFilesNow, buildTaskPendingPayload } from './cue-task-scanner';
 import { createCueActivityLog } from './cue-activity-log';
 import type { CueActivityLog } from './cue-activity-log';
 import { createCueHeartbeat } from './cue-heartbeat';
@@ -1152,8 +1153,20 @@ export class CueEngine {
 
 		let totalDispatched = 0;
 		for (const { ownerSessionId, state, sub } of toDispatch) {
+			// task.pending template variables ({{CUE_TASK_LIST}}, {{CUE_TASK_COUNT}},
+			// ...) are populated purely from the event payload. The polling scanner
+			// fills it in; a manual trigger does not, so without this enrichment the
+			// agent receives an empty task list and reports "nothing to do" even when
+			// the watched file has open tasks (issue #1151). Scan the watched file(s)
+			// now so Run Now / `maestro-cli cue trigger` behaves like the auto scan.
+			const taskPayload =
+				sub.event === 'task.pending' && sub.watch
+					? this.buildManualTaskPendingPayload(ownerSessionId, sub.watch)
+					: {};
+
 			const event = createCueEvent(sub.event, sub.name, {
 				manual: true,
+				...taskPayload,
 				...(sourceAgentId ? { sourceAgentId } : {}),
 				...(promptOverride ? { cliPrompt: promptOverride } : {}),
 			});
@@ -1174,6 +1187,35 @@ export class CueEngine {
 			if (dispatched > 0) totalDispatched++;
 		}
 		return totalDispatched > 0;
+	}
+
+	/**
+	 * Scan a task.pending subscription's watched files at manual-trigger time and
+	 * return the task payload for the first file that has pending tasks.
+	 *
+	 * Returns an empty object when nothing is watched, the project root is
+	 * unknown, or no file currently has open tasks (the agent then legitimately
+	 * reports "nothing to do"). Anchors on the first matching file, which covers
+	 * the dominant single-file `watch` case; the polling scanner fires one event
+	 * per file, whereas a manual trigger is a single dispatch.
+	 */
+	private buildManualTaskPendingPayload(
+		sessionId: string,
+		watchGlob: string
+	): Record<string, unknown> {
+		const projectRoot = this.deps.getSessions().find((s) => s.id === sessionId)?.projectRoot;
+		if (!projectRoot) return {};
+
+		try {
+			const scanned = scanTaskFilesNow(projectRoot, watchGlob);
+			if (scanned.length === 0) return {};
+			const first = scanned[0];
+			return buildTaskPendingPayload(first.absPath, first.relPath, first.content, first.tasks);
+		} catch (err) {
+			const message = err instanceof Error ? err.message : String(err);
+			this.deps.onLog('error', `[CUE] Manual task scan failed for "${watchGlob}": ${message}`);
+			return {};
+		}
 	}
 
 	/** Clears queued events for a session */

--- a/src/main/cue/cue-task-scanner.ts
+++ b/src/main/cue/cue-task-scanner.ts
@@ -59,6 +59,31 @@ export function extractPendingTasks(content: string): PendingTask[] {
 }
 
 /**
+ * Build the CueEvent payload for a markdown file that has pending tasks.
+ *
+ * Shared by the polling scanner and the manual-trigger path (Run Now / CLI)
+ * so both surfaces produce identical `task.pending` template variables
+ * ({{CUE_TASK_LIST}}, {{CUE_TASK_COUNT}}, {{CUE_TASK_FILE}}, etc.).
+ */
+export function buildTaskPendingPayload(
+	absPath: string,
+	relPath: string,
+	content: string,
+	tasks: PendingTask[]
+): Record<string, unknown> {
+	return {
+		path: absPath,
+		filename: path.basename(relPath),
+		directory: path.dirname(absPath),
+		extension: path.extname(relPath),
+		taskCount: tasks.length,
+		taskList: tasks.map((t) => `L${t.line}: ${t.text}`).join('\n'),
+		tasks,
+		content: content.slice(0, 10000),
+	};
+}
+
+/**
  * Recursively walk a directory and return all file paths (relative to root).
  */
 function walkDir(dir: string, root: string): string[] {
@@ -82,6 +107,48 @@ function walkDir(dir: string, root: string): string[] {
 		} else if (entry.isFile()) {
 			results.push(path.relative(root, fullPath));
 		}
+	}
+
+	return results;
+}
+
+/** A markdown file under the project root that currently has pending tasks. */
+export interface ScannedTaskFile {
+	relPath: string;
+	absPath: string;
+	content: string;
+	tasks: PendingTask[];
+}
+
+/**
+ * Walk `projectRoot`, match files against `watchGlob`, and return every file
+ * that currently has at least one pending task.
+ *
+ * Unlike the polling scanner, this does NO content-hash dedup: it always
+ * reports the current task state. It is the "scan right now" primitive used by
+ * manual triggers (dashboard Run Now, `maestro-cli cue trigger`), where the
+ * user explicitly asked to act on whatever tasks are open this instant,
+ * regardless of whether the polling scanner has already seen the file.
+ */
+export function scanTaskFilesNow(projectRoot: string, watchGlob: string): ScannedTaskFile[] {
+	const isMatch = picomatch(watchGlob);
+	const results: ScannedTaskFile[] = [];
+
+	for (const relPath of walkDir(projectRoot, projectRoot)) {
+		if (!isMatch(relPath)) continue;
+
+		const absPath = path.resolve(projectRoot, relPath);
+		let content: string;
+		try {
+			content = fs.readFileSync(absPath, 'utf-8');
+		} catch {
+			continue;
+		}
+
+		const tasks = extractPendingTasks(content);
+		if (tasks.length === 0) continue;
+
+		results.push({ relPath, absPath, content, tasks });
 	}
 
 	return results;
@@ -153,18 +220,11 @@ export function createCueTaskScanner(config: CueTaskScannerConfig): () => void {
 					continue;
 				}
 
-				const taskList = pendingTasks.map((t) => `L${t.line}: ${t.text}`).join('\n');
-
-				const event = createCueEvent('task.pending', triggerName, {
-					path: absPath,
-					filename: path.basename(relPath),
-					directory: path.dirname(absPath),
-					extension: path.extname(relPath),
-					taskCount: pendingTasks.length,
-					taskList,
-					tasks: pendingTasks,
-					content: content.slice(0, 10000),
-				});
+				const event = createCueEvent(
+					'task.pending',
+					triggerName,
+					buildTaskPendingPayload(absPath, relPath, content, pendingTasks)
+				);
 
 				onEvent(event);
 			}


### PR DESCRIPTION
Closes #1151

## Problem

`task.pending` template variables (`{{CUE_TASK_LIST}}`, `{{CUE_TASK_COUNT}}`, `{{CUE_TASK_FILE}}`, `{{CUE_TASK_CONTENT}}`, ...) are populated **entirely from the event payload** (`cue-template-context-builder.ts` → the `task.pending` enricher).

The polling task scanner fills that payload by reading the watched file and running `extractPendingTasks`. But the **manual-trigger** path does not. Both the dashboard **Run Now** button and `maestro-cli cue trigger` route through `CueEngine.triggerSubscription`, which built the event with payload `{ manual: true }` only and never scanned the file.

Result: on a manual trigger, every `CUE_TASK_*` variable renders empty, so the agent receives a prompt with no tasks and reports something like:

> Research queue check: no pending tasks found, nothing to process.

...even though the watched file has open `- [ ]` items. This matches the reporter's symptoms (manual run "does nothing" / "nothing to do" with an open task). It is also the exact workaround issue #865 recommended ("use Run Now to bootstrap a subscription against a file that already contains tasks"), which never actually worked.

## Fix

On a manual `task.pending` trigger, scan the watched file(s) **now** and enrich the event payload, so Run Now / CLI behave like the automatic scan.

- Extract two helpers in `cue-task-scanner.ts`:
  - `buildTaskPendingPayload(...)` - the single source of truth for the `task.pending` payload shape. The polling scanner now reuses it (no behavior change there).
  - `scanTaskFilesNow(projectRoot, watchGlob)` - a "scan right now" primitive with **no** content-hash dedup (a manual trigger should act on whatever is open this instant).
- `CueEngine.triggerSubscription` calls a small private helper that resolves the owning session's `projectRoot`, scans, and merges the payload for the first file with pending tasks (covers the dominant single-file `watch` case).

### Deliberately out of scope

- First-scan **seeding** behavior (issue #865, closed as intended).
- The polling **hash-dedup** model.

This is a surgical fix for the manual/Run-Now path only.

## Testing

- New unit tests for `scanTaskFilesNow` and `buildTaskPendingPayload` (`cue-task-scanner.test.ts`).
- New engine wiring tests that a manual `task.pending` trigger scans and populates `CUE_TASK_*`, and leaves the payload unenriched when nothing is pending (`cue-engine.test.ts`).
- Full Cue suite green: `npx vitest run src/__tests__/main/cue/ src/__tests__/shared/cue/` → 75 files, 1537 passed.
- `tsc -p tsconfig.main.json --noEmit` clean; ESLint clean on changed files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Manual triggers for task updates now include current task information from watched files, making the returned event data match the live scanner more closely.

* **Bug Fixes**
  * Improved task update payloads so they include file details, task counts, and task lists when pending tasks are found.
  * If no pending tasks are present, the event now stays uncluttered and omits task-specific fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->