### PR TITLE
fix(agent-store): route queued agent-discovered commands and isolate unknown-command errors

### DIFF
--- a/src/__tests__/renderer/components/TerminalOutput.test.tsx
+++ b/src/__tests__/renderer/components/TerminalOutput.test.tsx
@@ -332,6 +332,32 @@ describe('TerminalOutput', () => {
 			const logItems = container.querySelectorAll('[data-log-index]');
 			expect(logItems.length).toBe(2);
 		});
+
+		it('keeps an error-source entry out of the surrounding response group', () => {
+			const logs: LogEntry[] = [
+				createLogEntry({ id: 'resp-1', text: 'Tail of an earlier response.', source: 'stdout' }),
+				createLogEntry({ id: 'err-1', text: 'Unknown command: /nonexistent', source: 'error' }),
+				createLogEntry({ id: 'resp-2', text: 'Start of a later response.', source: 'stdout' }),
+			];
+
+			const session = createDefaultSession({
+				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				activeTabId: 'tab-1',
+			});
+
+			const props = createDefaultProps({ session });
+			const { container } = render(<TerminalOutput {...props} />);
+
+			// The error entry must flush its own boundary rather than being
+			// stitched (via a no-separator join) between the two response groups.
+			const logItems = container.querySelectorAll('[data-log-index]');
+			expect(logItems.length).toBe(3);
+
+			const markdownBlocks = screen.getAllByTestId('react-markdown');
+			const combinedText = markdownBlocks.map((el) => el.textContent).join('|');
+			expect(combinedText).not.toContain('response.Unknown command');
+			expect(combinedText).not.toContain('/nonexistentStart of a later response.');
+		});
 	});
 
 	describe('search functionality', () => {

--- a/src/__tests__/renderer/hooks/useRemoteHandlers.test.ts
+++ b/src/__tests__/renderer/hooks/useRemoteHandlers.test.ts
@@ -1017,13 +1017,13 @@ describe('useRemoteHandlers', () => {
 			// Should NOT spawn — unknown slash command is early-returned
 			expect(window.maestro.process.spawn).not.toHaveBeenCalled();
 
-			// addLogToTab should have been called with system error about unknown command
+			// addLogToTab should have been called with an error log about the unknown command
 			const updated = useSessionStore.getState().sessions.find((s) => s.id === 'session-1');
 			const activeTab = updated?.aiTabs.find((t) => t.id === updated.activeTabId);
-			const systemLog = activeTab?.logs.find(
-				(l) => l.source === 'system' && l.text.includes('/nonexistent')
+			const errorLog = activeTab?.logs.find(
+				(l) => l.source === 'error' && l.text.includes('/nonexistent')
 			);
-			expect(systemLog).toBeTruthy();
+			expect(errorLog).toBeTruthy();
 		});
 
 		it('uses speckitCommandsRef for slash command matching', async () => {

--- a/src/__tests__/renderer/stores/agentStore.test.ts
+++ b/src/__tests__/renderer/stores/agentStore.test.ts
@@ -1748,6 +1748,64 @@ describe('agentStore', () => {
 
 			expect(tab1.logs).toHaveLength(1);
 			expect(tab1.logs[0].text).toContain('Failed to process queued');
+			expect(tab1.logs[0].source).toBe('error');
+			expect(tab2.logs).toHaveLength(0);
+
+			consoleSpy.mockRestore();
+		});
+
+		it('logs a diagnostic instead of silently dropping the error when the resolved tab no longer exists in aiTabs', async () => {
+			mockSpawn.mockRejectedValueOnce(new Error('Spawn failed'));
+			const consoleSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+
+			// tab-1 was closed while it had queued work, so it now lives in
+			// orphanedThinkingTabs (not aiTabs) - it's still a valid spawn target,
+			// but the catch block's error log has nowhere in aiTabs to land.
+			const session = createMockSession({
+				id: 'session-1',
+				state: 'busy',
+				aiTabs: [
+					{
+						id: 'tab-2',
+						agentSessionId: null,
+						name: null,
+						starred: false,
+						logs: [],
+						inputValue: '',
+						stagedImages: [],
+						createdAt: Date.now(),
+						state: 'idle',
+					},
+				],
+				orphanedThinkingTabs: [
+					{
+						id: 'tab-1',
+						agentSessionId: null,
+						name: null,
+						starred: false,
+						logs: [],
+						inputValue: '',
+						stagedImages: [],
+						createdAt: Date.now(),
+						state: 'busy',
+					},
+				],
+				activeTabId: 'tab-2',
+			});
+			useSessionStore.getState().setSessions([session]);
+
+			const item = createQueuedItem({ tabId: 'tab-1', text: 'Will fail' });
+
+			await useAgentStore.getState().processQueuedItem('session-1', item, defaultDeps);
+
+			expect(consoleSpy).toHaveBeenCalledWith(
+				'[processQueuedItem error] Target tab not found - error log dropped',
+				undefined,
+				{ sessionId: 'session-1', resolvedTabId: 'tab-1' }
+			);
+
+			const updated = useSessionStore.getState().sessions[0];
+			const tab2 = updated.aiTabs.find((t) => t.id === 'tab-2')!;
 			expect(tab2.logs).toHaveLength(0);
 
 			consoleSpy.mockRestore();

--- a/src/__tests__/renderer/stores/agentStore.test.ts
+++ b/src/__tests__/renderer/stores/agentStore.test.ts
@@ -1562,8 +1562,108 @@ describe('agentStore', () => {
 			expect(updated.state).toBe('idle');
 			expect(updated.busySource).toBeUndefined();
 			expect(updated.aiTabs[0].logs).toHaveLength(1);
-			expect(updated.aiTabs[0].logs[0].source).toBe('system');
+			expect(updated.aiTabs[0].logs[0].source).toBe('error');
 			expect(updated.aiTabs[0].logs[0].text).toContain('Unknown command: /nonexistent');
+		});
+
+		it('targets the queued item tab, not whatever tab is currently active, for unknown command errors', async () => {
+			const session = createMockSession({
+				id: 'session-1',
+				state: 'busy',
+				aiTabs: [
+					{
+						id: 'tab-1',
+						agentSessionId: null,
+						name: null,
+						starred: false,
+						logs: [],
+						inputValue: '',
+						stagedImages: [],
+						createdAt: Date.now(),
+						state: 'busy',
+					},
+					{
+						id: 'tab-2',
+						agentSessionId: null,
+						name: null,
+						starred: false,
+						logs: [],
+						inputValue: '',
+						stagedImages: [],
+						createdAt: Date.now(),
+						state: 'busy',
+					},
+				],
+				// Active tab is tab-2, but the queued item belongs to tab-1
+				activeTabId: 'tab-2',
+			});
+			useSessionStore.getState().setSessions([session]);
+
+			const item = createQueuedItem({
+				tabId: 'tab-1',
+				type: 'command',
+				command: '/nonexistent',
+				text: undefined,
+			});
+
+			await useAgentStore.getState().processQueuedItem('session-1', item, defaultDeps);
+
+			const updated = useSessionStore.getState().sessions[0];
+			const tab1 = updated.aiTabs.find((t) => t.id === 'tab-1')!;
+			const tab2 = updated.aiTabs.find((t) => t.id === 'tab-2')!;
+
+			expect(tab1.logs).toHaveLength(1);
+			expect(tab1.logs[0].text).toContain('Unknown command: /nonexistent');
+			expect(tab2.logs).toHaveLength(0);
+		});
+
+		it('resolves and dispatches a command matched via session.agentCommands', async () => {
+			const session = createMockSession({
+				id: 'session-1',
+				aiTabs: [
+					{
+						id: 'tab-1',
+						agentSessionId: 'conv-1',
+						name: null,
+						starred: false,
+						logs: [],
+						inputValue: '',
+						stagedImages: [],
+						createdAt: Date.now(),
+						state: 'idle',
+					},
+				],
+				activeTabId: 'tab-1',
+				agentCommands: [
+					{
+						command: '/implement',
+						description: 'Implement the plan',
+						prompt: 'Implement the approved plan now.',
+					},
+				],
+			});
+			useSessionStore.getState().setSessions([session]);
+
+			const item = createQueuedItem({
+				tabId: 'tab-1',
+				type: 'command',
+				command: '/implement',
+				text: undefined,
+			});
+
+			await useAgentStore.getState().processQueuedItem('session-1', item, defaultDeps);
+
+			expect(mockSpawn).toHaveBeenCalledTimes(1);
+			expect(mockSpawn).toHaveBeenCalledWith(
+				expect.objectContaining({
+					prompt: expect.stringContaining('Implement the approved plan now.'),
+				})
+			);
+
+			const updated = useSessionStore.getState().sessions[0];
+			expect(updated.aiTabs[0].logs).toHaveLength(1);
+			expect(updated.aiTabs[0].logs[0].source).toBe('user');
+			expect(updated.aiTabs[0].logs[0].aiCommand?.command).toBe('/implement');
 		});
 
 		it('handles spawn error gracefully', async () => {
@@ -1598,6 +1698,57 @@ describe('agentStore', () => {
 			const updated = useSessionStore.getState().sessions[0];
 			expect(updated.state).toBe('idle');
 			expect(updated.busySource).toBeUndefined();
+
+			consoleSpy.mockRestore();
+		});
+
+		it('targets the queued item tab, not whatever tab is currently active, when spawn throws', async () => {
+			mockSpawn.mockRejectedValueOnce(new Error('Spawn failed'));
+			const consoleSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+
+			const session = createMockSession({
+				id: 'session-1',
+				state: 'busy',
+				aiTabs: [
+					{
+						id: 'tab-1',
+						agentSessionId: null,
+						name: null,
+						starred: false,
+						logs: [],
+						inputValue: '',
+						stagedImages: [],
+						createdAt: Date.now(),
+						state: 'busy',
+					},
+					{
+						id: 'tab-2',
+						agentSessionId: null,
+						name: null,
+						starred: false,
+						logs: [],
+						inputValue: '',
+						stagedImages: [],
+						createdAt: Date.now(),
+						state: 'busy',
+					},
+				],
+				// Active tab is tab-2, but the queued item belongs to tab-1
+				activeTabId: 'tab-2',
+			});
+			useSessionStore.getState().setSessions([session]);
+
+			const item = createQueuedItem({ tabId: 'tab-1', text: 'Will fail' });
+
+			await useAgentStore.getState().processQueuedItem('session-1', item, defaultDeps);
+
+			const updated = useSessionStore.getState().sessions[0];
+			const tab1 = updated.aiTabs.find((t) => t.id === 'tab-1')!;
+			const tab2 = updated.aiTabs.find((t) => t.id === 'tab-2')!;
+
+			expect(tab1.logs).toHaveLength(1);
+			expect(tab1.logs[0].text).toContain('Failed to process queued');
+			expect(tab2.logs).toHaveLength(0);
 
 			consoleSpy.mockRestore();
 		});

--- a/src/renderer/components/TerminalOutput.tsx
+++ b/src/renderer/components/TerminalOutput.tsx
@@ -1665,8 +1665,8 @@ export const TerminalOutput = memo(
 					// Flush any accumulated response group before user message
 					flushResponseGroup();
 					result.push(log);
-				} else if (log.source === 'tool' || log.source === 'thinking') {
-					// Flush response group before tool/thinking, then add tool/thinking separately
+				} else if (log.source === 'tool' || log.source === 'thinking' || log.source === 'error') {
+					// Flush response group before tool/thinking/error, then add it separately
 					flushResponseGroup();
 					result.push(log);
 				} else {

--- a/src/renderer/hooks/remote/useRemoteHandlers.ts
+++ b/src/renderer/hooks/remote/useRemoteHandlers.ts
@@ -371,7 +371,7 @@ export function useRemoteHandlers(deps: UseRemoteHandlersDeps): UseRemoteHandler
 					addLogToTab(
 						sessionId,
 						{
-							source: 'system',
+							source: 'error',
 							text: `Unknown command: ${commandText}`,
 						},
 						writeTabId

--- a/src/renderer/stores/agentStore.ts
+++ b/src/renderer/stores/agentStore.ts
@@ -583,17 +583,17 @@ export const useAgentStore = create<AgentStore>()((set, get) => ({
 			const errorLogEntry: LogEntry = {
 				id: generateId(),
 				timestamp: Date.now(),
-				source: 'system',
+				source: 'error',
 				text: `Error: Failed to process queued ${item.type} - ${error.message}`,
 			};
 			useSessionStore.getState().setSessions((prev) =>
 				prev.map((s) => {
 					if (s.id !== sessionId) return s;
-					const activeTab = getActiveTab(s);
+					const resolvedTabId = item.tabId ?? s.activeTabId;
 					const updatedAiTabs =
 						s.aiTabs?.length > 0
 							? s.aiTabs.map((tab) =>
-									tab.id === (item.tabId ?? s.activeTabId)
+									tab.id === resolvedTabId
 										? {
 												...tab,
 												state: 'idle' as const,
@@ -604,9 +604,15 @@ export const useAgentStore = create<AgentStore>()((set, get) => ({
 								)
 							: s.aiTabs;
 
-					if (!activeTab) {
+					const targetTabExists = s.aiTabs?.some((tab) => tab.id === resolvedTabId);
+					if (!targetTabExists) {
 						logger.error(
-							'[processQueuedItem error] No active tab found - session has no aiTabs, this should not happen'
+							'[processQueuedItem error] Target tab not found - error log dropped',
+							undefined,
+							{
+								sessionId,
+								resolvedTabId,
+							}
 						);
 					}
 

--- a/src/renderer/stores/agentStore.ts
+++ b/src/renderer/stores/agentStore.ts
@@ -441,11 +441,21 @@ export const useAgentStore = create<AgentStore>()((set, get) => ({
 			} else if (item.type === 'command' && item.command) {
 				// Process a slash command - find matching command
 				// Check user-defined commands first, then agent-discovered commands with prompts
+				const matchingAgentCommand = session.agentCommands?.find(
+					(cmd) => cmd.command === item.command && cmd.prompt
+				);
 				const matchingCommand =
 					deps.customAICommands.find((cmd) => cmd.command === item.command) ||
 					deps.speckitCommands.find((cmd) => cmd.command === item.command) ||
 					deps.openspecCommands.find((cmd) => cmd.command === item.command) ||
-					deps.bmadCommands?.find((cmd) => cmd.command === item.command);
+					deps.bmadCommands?.find((cmd) => cmd.command === item.command) ||
+					(matchingAgentCommand
+						? {
+								command: matchingAgentCommand.command,
+								description: matchingAgentCommand.description,
+								prompt: matchingAgentCommand.prompt!,
+							}
+						: undefined);
 
 				if (matchingCommand) {
 					let gitBranch: string | undefined;
@@ -537,10 +547,14 @@ export const useAgentStore = create<AgentStore>()((set, get) => ({
 					});
 				} else {
 					// Unknown command - add error log and reset to idle
-					useSessionStore.getState().addLogToTab(sessionId, {
-						source: 'system',
-						text: `Unknown command: ${item.command}`,
-					});
+					useSessionStore.getState().addLogToTab(
+						sessionId,
+						{
+							source: 'error',
+							text: `Unknown command: ${item.command}`,
+						},
+						item.tabId
+					);
 					useSessionStore.getState().setSessions((prev) =>
 						prev.map((s) => {
 							if (s.id !== sessionId) return s;
@@ -579,7 +593,7 @@ export const useAgentStore = create<AgentStore>()((set, get) => ({
 					const updatedAiTabs =
 						s.aiTabs?.length > 0
 							? s.aiTabs.map((tab) =>
-									tab.id === s.activeTabId
+									tab.id === (item.tabId ?? s.activeTabId)
 										? {
 												...tab,
 												state: 'idle' as const,


### PR DESCRIPTION
Fixes two related bugs in OpenCode-backed (and other agent-discovered-command) sessions:

1. A valid agent-discovered slash command (e.g. one loaded from `.opencode/commands/*.md`) would incorrectly show "Unknown command" if it was typed while the agent/tab was busy and got queued. The queued-command re-match path in `agentStore.ts` never checked `session.agentCommands`, unlike the immediate-typing path.
2. The resulting "Unknown command" error log could render on the wrong tab and get silently concatenated (no separator) into a later, unrelated AI response, because it was logged without a `tabId` and used a log source that gets grouped with adjacent response text.

Changes:
- `agentStore.ts`: include `session.agentCommands` in the queued-command match chain; target the error log at `item.tabId`; fix the same tab-targeting bug in the catch-all error handler.
- `agentStore.ts` / `useRemoteHandlers.ts`: switch the "Unknown command" log to `source: 'error'`, which already has dedicated non-joining rendering.
- `TerminalOutput.tsx`: give `source: 'error'` its own flush boundary in the response-grouping logic so it can never be joined into surrounding text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Queued commands can now use session-provided custom commands when they include a prompt, expanding which slash commands the app can run.

- **Bug Fixes**
  - Unknown commands now produce dedicated error log entries (not system logs) on the correct target tab.
  - AI terminal rendering now keeps error logs separate from surrounding AI response grouping.
  - Queued command failures now log to the queued item’s target tab (not the currently active tab), with a diagnostic message when the target tab is missing.

- **Tests**
  - Added/updated coverage for error log routing and rendering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->