### PR TITLE
fix: Windows support - dev launcher, 94 test fixes, ~2x faster suite, Windows CI lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,12 @@ jobs:
       - run: npm run lint # TypeScript type checking
 
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      # Run the suite on both platforms; don't cancel one when the other fails.
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6

--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
 	},
 	"scripts": {
 		"dev": "node scripts/dev.mjs",
-		"dev:prod-data": "USE_PROD_DATA=1 node scripts/dev.mjs",
+		"dev:prod-data": "cross-env USE_PROD_DATA=1 node scripts/dev.mjs",
 		"dev:demo": "MAESTRO_DEMO_DIR=/tmp/maestro-demo npm run dev",
-		"dev:main": "tsc -p tsconfig.main.json && npm run build:preload && NODE_ENV=development electron .",
-		"dev:main:prod-data": "tsc -p tsconfig.main.json && npm run build:preload && NODE_ENV=development USE_PROD_DATA=1 electron .",
+		"dev:main": "tsc -p tsconfig.main.json && npm run build:preload && cross-env NODE_ENV=development electron .",
+		"dev:main:prod-data": "tsc -p tsconfig.main.json && npm run build:preload && cross-env NODE_ENV=development USE_PROD_DATA=1 electron .",
 		"dev:renderer": "vite",
 		"dev:web": "vite --config vite.config.web.mts",
 		"dev:web-desktop": "vite --config vite.config.web-desktop.mts",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 	"scripts": {
 		"dev": "node scripts/dev.mjs",
 		"dev:prod-data": "cross-env USE_PROD_DATA=1 node scripts/dev.mjs",
-		"dev:demo": "MAESTRO_DEMO_DIR=/tmp/maestro-demo npm run dev",
+		"dev:demo": "node scripts/dev-demo.mjs",
 		"dev:main": "tsc -p tsconfig.main.json && npm run build:preload && cross-env NODE_ENV=development electron .",
 		"dev:main:prod-data": "tsc -p tsconfig.main.json && npm run build:preload && cross-env NODE_ENV=development USE_PROD_DATA=1 electron .",
 		"dev:renderer": "vite",

--- a/scripts/dev-demo.mjs
+++ b/scripts/dev-demo.mjs
@@ -1,0 +1,12 @@
+import os from 'node:os';
+import path from 'node:path';
+
+// Demo mode: point the app at an isolated, throwaway data dir. Mirrors the
+// DEMO_MODE fallback in src/main/constants.ts and works on every OS (the old
+// hardcoded /tmp/maestro-demo did not exist on Windows). An explicit
+// MAESTRO_DEMO_DIR from the caller still wins.
+if (!process.env.MAESTRO_DEMO_DIR) {
+	process.env.MAESTRO_DEMO_DIR = path.join(os.tmpdir(), 'maestro-demo');
+}
+
+await import('./dev.mjs');

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -1,5 +1,5 @@
 import net from 'node:net';
-import { spawn } from 'node:child_process';
+import { spawn, execFileSync } from 'node:child_process';
 import { findAvailablePort } from './dev-port.mjs';
 
 const isWindows = process.platform === 'win32';
@@ -56,7 +56,22 @@ function waitForPort(port, timeoutMs = startupTimeoutMs) {
 
 function killChild(child) {
 	if (child.exitCode === null && !child.killed) {
-		child.kill('SIGTERM');
+		if (isWindows && child.pid) {
+			// spawnNpm() children are cmd.exe wrappers on Windows; SIGTERM would kill
+			// only the wrapper and leak npm/Vite/Electron (holding the Vite port).
+			// taskkill /t kills the whole tree; sync so shutdown() finishes the job
+			// before process.exit(). Non-zero exit (already dead) is fine.
+			try {
+				execFileSync('taskkill', ['/pid', String(child.pid), '/t', '/f'], {
+					timeout: 5000,
+					stdio: 'ignore',
+				});
+			} catch {
+				// process already exited
+			}
+		} else {
+			child.kill('SIGTERM');
+		}
 	}
 }
 

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -2,11 +2,24 @@ import net from 'node:net';
 import { spawn } from 'node:child_process';
 import { findAvailablePort } from './dev-port.mjs';
 
-const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+const isWindows = process.platform === 'win32';
+const npmCommand = isWindows ? 'npm.cmd' : 'npm';
 const rendererScript = 'dev:renderer';
 const mainScript = process.env.USE_PROD_DATA ? 'dev:main:prod-data' : 'dev:main';
 const startupTimeoutMs = 20000;
 const pollIntervalMs = 200;
+
+// Spawn an `npm run <script>` child. On Windows npm resolves to npm.cmd, which
+// Node >=22.12 refuses to spawn without a shell (post CVE-2024-27980, throwing
+// EINVAL). We pass a single shell command string there rather than an args
+// array, which both satisfies the shell requirement and avoids the DEP0190
+// "args with shell" warning. Args are static and trusted (no user input).
+function spawnNpm(args, options) {
+	if (isWindows) {
+		return spawn([npmCommand, ...args].join(' '), { ...options, shell: true });
+	}
+	return spawn(npmCommand, args, options);
+}
 
 function waitForPort(port, timeoutMs = startupTimeoutMs) {
 	return new Promise((resolve, reject) => {
@@ -52,7 +65,7 @@ const sharedEnv = { ...process.env, VITE_PORT: String(port) };
 
 console.log(`[dev] Using VITE_PORT=${port}`);
 
-const renderer = spawn(npmCommand, ['run', rendererScript], {
+const renderer = spawnNpm(['run', rendererScript], {
 	env: sharedEnv,
 	stdio: 'inherit',
 });
@@ -95,7 +108,7 @@ if (cdpPort) {
 	console.log(`[dev] Electron CDP enabled on port ${cdpPort}`);
 }
 
-main = spawn(npmCommand, mainArgs, {
+main = spawnNpm(mainArgs, {
 	env: sharedEnv,
 	stdio: 'inherit',
 });

--- a/src/__tests__/cli/commands/auto-run.test.ts
+++ b/src/__tests__/cli/commands/auto-run.test.ts
@@ -27,6 +27,7 @@ vi.mock('../../../cli/services/maestro-client', () => ({
 import { autoRun } from '../../../cli/commands/auto-run';
 import { withMaestroClient, resolveTargetSessionId } from '../../../cli/services/maestro-client';
 import { existsSync } from 'fs';
+import path from 'path';
 
 describe('auto-run command', () => {
 	let consoleSpy: MockInstance;
@@ -313,7 +314,7 @@ describe('auto-run command', () => {
 		expect(sentMessage).toBeDefined();
 		expect(sentMessage!.worktree).toEqual({
 			enabled: true,
-			path: '/tmp/wt',
+			path: path.resolve('/tmp/wt'),
 			branchName: 'feature/auto',
 			baseBranch: '', // --base-branch not supplied in this test
 			createPROnCompletion: true,

--- a/src/__tests__/cli/commands/run-doc.test.ts
+++ b/src/__tests__/cli/commands/run-doc.test.ts
@@ -61,6 +61,7 @@ vi.mock('../../../shared/cli-activity', () => ({
 
 import * as fs from 'fs';
 import * as os from 'os';
+import path from 'path';
 import { runDoc } from '../../../cli/commands/run-doc';
 import { getSessionById, resolveAgentId } from '../../../cli/services/storage';
 import { runPlaybook as executePlaybook } from '../../../cli/services/batch-processor';
@@ -126,7 +127,7 @@ describe('run-doc command', () => {
 		expect(executePlaybook).toHaveBeenCalledWith(
 			mockSession(),
 			expect.objectContaining({
-				documents: [{ filename: 'plans/frontend-plan', resetOnCompletion: false }],
+				documents: [{ filename: path.join('plans', 'frontend-plan'), resetOnCompletion: false }],
 				prompt: '',
 				loopEnabled: false,
 			}),

--- a/src/__tests__/cli/commands/update-agent.test.ts
+++ b/src/__tests__/cli/commands/update-agent.test.ts
@@ -4,6 +4,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, type MockInstance } from 'vitest';
+import path from 'path';
 
 vi.mock('../../../cli/services/maestro-client', () => ({
 	withMaestroClient: vi.fn(),
@@ -106,7 +107,7 @@ describe('update-agent command', () => {
 			expect.objectContaining({
 				type: 'update_session_cwd',
 				sessionId: 'full-session-id',
-				newCwd: '/tmp/some/path',
+				newCwd: path.resolve('/tmp/some/path'),
 			}),
 			'update_session_cwd_result'
 		);
@@ -396,7 +397,7 @@ describe('update-agent command', () => {
 			success: true,
 			agentId: 'full-session-id',
 			group: 'full-group-id',
-			cwd: '/tmp/foo',
+			cwd: path.resolve('/tmp/foo'),
 		});
 	});
 

--- a/src/__tests__/cli/services/agent-spawner.test.ts
+++ b/src/__tests__/cli/services/agent-spawner.test.ts
@@ -2306,17 +2306,32 @@ Some text with [x] in it that's not a checkbox
 		});
 
 		it('still injects the Maestro system prompt on resume (Claude reads it every turn)', async () => {
-			const p = spawnAgent('claude-code', '/p', 'follow-up', 'session-abc', {
-				appendSystemPrompt: 'maestro context',
-			});
-			await driveSpawnToCompletion(p, 0, CLAUDE_OK());
+			// Pin the platform to a POSIX value so this exercises the inline
+			// `--append-system-prompt` path deterministically. On Windows local
+			// spawns the product instead writes the prompt to a temp file and
+			// passes `--append-system-prompt-file` (see buildAppendSystemPromptArgs),
+			// which is correct but a different arg shape. On Unix this override is
+			// a no-op.
+			const originalPlatform = process.platform;
+			Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
+			try {
+				const p = spawnAgent('claude-code', '/p', 'follow-up', 'session-abc', {
+					appendSystemPrompt: 'maestro context',
+				});
+				await driveSpawnToCompletion(p, 0, CLAUDE_OK());
 
-			const { args } = spawnCall();
-			expect(args).toContain('--resume');
-			expect(args).toContain('session-abc');
-			const flagIdx = args.indexOf('--append-system-prompt');
-			expect(flagIdx).toBeGreaterThanOrEqual(0);
-			expect(args[flagIdx + 1]).toBe('maestro context');
+				const { args } = spawnCall();
+				expect(args).toContain('--resume');
+				expect(args).toContain('session-abc');
+				const flagIdx = args.indexOf('--append-system-prompt');
+				expect(flagIdx).toBeGreaterThanOrEqual(0);
+				expect(args[flagIdx + 1]).toBe('maestro context');
+			} finally {
+				Object.defineProperty(process, 'platform', {
+					value: originalPlatform,
+					configurable: true,
+				});
+			}
 		});
 
 		it('Codex (no native --append-system-prompt support) embeds the system prompt in the first user turn', async () => {

--- a/src/__tests__/helpers/pathExpect.ts
+++ b/src/__tests__/helpers/pathExpect.ts
@@ -29,15 +29,29 @@ export function asarNodePath(resources: string): string {
 
 /**
  * Run `fn` with `process.platform` overridden, restoring it afterward.
- * `platformDetection.getPlatform()` reads `process.platform` first (before
- * `window.maestro.platform`) under Node, so Unix-branch tests must force it.
+ * Supports async callbacks: when `fn` returns a promise, restoration waits for
+ * it to settle. `platformDetection.getPlatform()` reads `process.platform`
+ * first (before `window.maestro.platform`) under Node, so Unix-branch tests
+ * must force it.
  */
-export function withPlatform(value: NodeJS.Platform, fn: () => void): void {
+export function withPlatform(value: NodeJS.Platform, fn: () => void): void;
+export function withPlatform(value: NodeJS.Platform, fn: () => Promise<void>): Promise<void>;
+export function withPlatform(
+	value: NodeJS.Platform,
+	fn: () => void | Promise<void>
+): void | Promise<void> {
 	const original = process.platform;
+	const restore = () =>
+		Object.defineProperty(process, 'platform', { value: original, configurable: true });
 	Object.defineProperty(process, 'platform', { value, configurable: true });
 	try {
-		fn();
-	} finally {
-		Object.defineProperty(process, 'platform', { value: original, configurable: true });
+		const result = fn();
+		if (result instanceof Promise) {
+			return result.finally(restore);
+		}
+		restore();
+	} catch (error) {
+		restore();
+		throw error;
 	}
 }

--- a/src/__tests__/helpers/pathExpect.ts
+++ b/src/__tests__/helpers/pathExpect.ts
@@ -1,0 +1,43 @@
+/**
+ * Test helpers for platform-symmetric path assertions.
+ *
+ * The product code canonicalizes paths with `path.resolve` / `path.join` and
+ * joins PATH-like strings with `path.delimiter`. On Windows those primitives
+ * emit `\` separators and drive-anchor absolute paths, so tests that hardcode
+ * POSIX literals (`/Users/...`, `:` delimiter) fail even though the product is
+ * correct. Routing expected values through the SAME primitives keeps the tests
+ * green on macOS, Linux, and Windows without changing any behavior.
+ */
+
+import * as path from 'path';
+
+/**
+ * Canonical account key, matching the product's `path.resolve(raw)`.
+ * Use for `configDirKey` / `codexHomeKey` expectations.
+ */
+export function canonKey(p: string): string {
+	return path.resolve(p);
+}
+
+/**
+ * The in-asar node_modules path, matching the product's
+ * `path.join(resources, 'app.asar', 'node_modules')`.
+ */
+export function asarNodePath(resources: string): string {
+	return path.join(resources, 'app.asar', 'node_modules');
+}
+
+/**
+ * Run `fn` with `process.platform` overridden, restoring it afterward.
+ * `platformDetection.getPlatform()` reads `process.platform` first (before
+ * `window.maestro.platform`) under Node, so Unix-branch tests must force it.
+ */
+export function withPlatform(value: NodeJS.Platform, fn: () => void): void {
+	const original = process.platform;
+	Object.defineProperty(process, 'platform', { value, configurable: true });
+	try {
+		fn();
+	} finally {
+		Object.defineProperty(process, 'platform', { value: original, configurable: true });
+	}
+}

--- a/src/__tests__/main/agents/claude-usage-sampler.test.ts
+++ b/src/__tests__/main/agents/claude-usage-sampler.test.ts
@@ -73,8 +73,10 @@ vi.mock('../../../main/utils/sentry', () => ({
 	captureMessage: captureMessageMock,
 }));
 
+import os from 'os';
 import path from 'path';
 import { sampleUsage } from '../../../main/agents/claude-usage-sampler';
+import { asarNodePath, canonKey } from '../../helpers/pathExpect';
 
 const FROZEN_NOW = new Date('2026-05-15T12:00:00.000Z').getTime();
 const ORIGINAL_ENV = { ...process.env };
@@ -158,7 +160,7 @@ describe('claude-usage-sampler', () => {
 			});
 			expect(snap).toEqual({
 				sampledAt: new Date(FROZEN_NOW).toISOString(),
-				configDirKey: '/Users/test/.claude',
+				configDirKey: canonKey(path.join(os.homedir(), '.claude')),
 				authState: 'authenticated',
 				session: { percent: 42, resetsAt: '2026-05-15T17:00:00.000Z' },
 				weekAllModels: { percent: 73, resetsAt: '2026-05-22T12:00:00.000Z' },
@@ -265,7 +267,7 @@ describe('claude-usage-sampler', () => {
 				const inspect = primeSuccess(wireEnvelope());
 				await sampleUsage({ binPath: '/bin/maestro-p.js', cwd: '/tmp' });
 				const env = inspect()?.options.env as NodeJS.ProcessEnv;
-				const asar = '/Apps/Maestro.app/Contents/Resources/app.asar/node_modules';
+				const asar = asarNodePath('/Apps/Maestro.app/Contents/Resources');
 				expect(env.NODE_PATH).toBe(`${asar}${path.delimiter}/pre/existing`);
 			} finally {
 				Object.defineProperty(process, 'resourcesPath', {
@@ -317,7 +319,7 @@ describe('claude-usage-sampler', () => {
 				cwd: '/tmp',
 				configDir: '/Users/test/.claude-gmail',
 			});
-			expect(snap?.configDirKey).toBe('/Users/test/.claude-gmail');
+			expect(snap?.configDirKey).toBe(canonKey('/Users/test/.claude-gmail'));
 		});
 
 		it('canonicalizes a configDir with redundant separators in the key', async () => {
@@ -327,14 +329,14 @@ describe('claude-usage-sampler', () => {
 				cwd: '/tmp',
 				configDir: '/Users/test/./.claude-smash/',
 			});
-			expect(snap?.configDirKey).toBe('/Users/test/.claude-smash');
+			expect(snap?.configDirKey).toBe(canonKey('/Users/test/.claude-smash'));
 		});
 
 		it('falls back to ~/.claude when no configDir and no env var', async () => {
 			delete process.env.CLAUDE_CONFIG_DIR;
 			primeSuccess(wireEnvelope());
 			const snap = await sampleUsage({ binPath: '/bin/maestro-p.js', cwd: '/tmp' });
-			expect(snap?.configDirKey).toBe('/Users/test/.claude');
+			expect(snap?.configDirKey).toBe(canonKey(path.join(os.homedir(), '.claude')));
 		});
 
 		it('lets customEnvVars.CLAUDE_CONFIG_DIR drive the key when configDir is omitted', async () => {
@@ -344,7 +346,7 @@ describe('claude-usage-sampler', () => {
 				cwd: '/tmp',
 				customEnvVars: { CLAUDE_CONFIG_DIR: '/Users/test/.claude-via-env' },
 			});
-			expect(snap?.configDirKey).toBe('/Users/test/.claude-via-env');
+			expect(snap?.configDirKey).toBe(canonKey('/Users/test/.claude-via-env'));
 		});
 	});
 
@@ -521,7 +523,7 @@ describe('claude-usage-sampler', () => {
 			primeSuccess('garbage\n');
 			await sampleUsage({ binPath: '/bin/maestro-p.js', cwd: '/tmp' });
 			const extras = captureMessageMock.mock.calls[0][2] as Record<string, unknown>;
-			expect(extras.configDir).toBe('/Users/test/.claude');
+			expect(extras.configDir).toBe(path.join(os.homedir(), '.claude'));
 		});
 	});
 });

--- a/src/__tests__/main/agents/claude-usage-startup.test.ts
+++ b/src/__tests__/main/agents/claude-usage-startup.test.ts
@@ -95,6 +95,7 @@ import {
 	__resetForTests as resetUsageStore,
 	type UsageSnapshot,
 } from '../../../main/stores/claudeUsageStore';
+import { canonKey } from '../../helpers/pathExpect';
 
 const FROZEN_NOW = new Date('2026-05-15T12:00:00.000Z').getTime();
 const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
@@ -669,7 +670,7 @@ describe('claude-usage-startup → runStartupUsageSampling', () => {
 			expect(loggerWarnMock).toHaveBeenCalledWith(
 				expect.stringContaining('maestro-p --status sample failed'),
 				expect.any(String),
-				expect.objectContaining({ configDirKey: '/Users/test/.claude-broken' })
+				expect.objectContaining({ configDirKey: canonKey('/Users/test/.claude-broken') })
 			);
 		});
 	});

--- a/src/__tests__/main/agents/codex-usage-startup.test.ts
+++ b/src/__tests__/main/agents/codex-usage-startup.test.ts
@@ -9,7 +9,10 @@
  */
 
 import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { canonKey } from '../../helpers/pathExpect';
 
 const { sampleCodexUsageMock, loggerWarnMock, loggerInfoMock, captureExceptionMock } = vi.hoisted(
 	() => ({
@@ -184,7 +187,9 @@ describe('codex-usage-startup → discoverCodexHomes', () => {
 			});
 
 		try {
-			await expect(discoverCodexHomes('/Users/test')).resolves.toEqual(['/Users/test/.codex-good']);
+			await expect(discoverCodexHomes('/Users/test')).resolves.toEqual([
+				path.join('/Users/test', '.codex-good'),
+			]);
 			expect(captureExceptionMock).not.toHaveBeenCalled();
 		} finally {
 			readdirSpy.mockRestore();
@@ -203,8 +208,8 @@ describe('codex-usage-startup → discoverCodexHomes', () => {
 			await expect(discoverCodexHomes('/Users/test')).rejects.toThrow('disk failure');
 			expect(captureExceptionMock).toHaveBeenCalledWith(unexpected, {
 				operation: 'codexUsage:discoverCodexHomes.access',
-				codexHome: '/Users/test/.codex-broken',
-				authPath: '/Users/test/.codex-broken/auth.json',
+				codexHome: path.join('/Users/test', '.codex-broken'),
+				authPath: path.join('/Users/test', '.codex-broken', 'auth.json'),
 			});
 		} finally {
 			readdirSpy.mockRestore();
@@ -215,7 +220,9 @@ describe('codex-usage-startup → discoverCodexHomes', () => {
 
 describe('codexUsageStore → resolveCodexHomeKey', () => {
 	it('falls back to the default CODEX_HOME for an empty env value', () => {
-		expect(resolveCodexHomeKey({ CODEX_HOME: '' })).toBe('/Users/test/.codex');
+		expect(resolveCodexHomeKey({ CODEX_HOME: '' })).toBe(
+			canonKey(path.join(os.homedir(), '.codex'))
+		);
 	});
 });
 
@@ -247,7 +254,9 @@ describe('codex-usage-startup → runCodexUsageSampling', () => {
 			agentDetector: makeDetector(FAKE_AGENT) as never,
 		});
 
-		expect(sampleCodexUsageMock).toHaveBeenCalledWith({ codexHome: '/Users/test/.codex' });
+		expect(sampleCodexUsageMock).toHaveBeenCalledWith({
+			codexHome: path.join(os.homedir(), '.codex'),
+		});
 		expect(getAllCodexUsageSnapshots()).toHaveProperty('/Users/test/.codex');
 	});
 
@@ -290,7 +299,7 @@ describe('codex-usage-startup → runCodexUsageSampling', () => {
 			expect.stringContaining('Failed to sample Codex usage snapshot'),
 			expect.any(String),
 			expect.objectContaining({
-				codexHomeKey: '/Users/test/.codex-broken',
+				codexHomeKey: canonKey('/Users/test/.codex-broken'),
 				error: 'timed out',
 			})
 		);
@@ -335,13 +344,13 @@ describe('codex-usage-startup → runCodexUsageSampling', () => {
 		expect(captureExceptionMock).toHaveBeenCalledWith(unexpected, {
 			operation: 'codexUsage:runCodexUsageSampling.sample',
 			codexHome: '/Users/test/.codex-broken',
-			codexHomeKey: '/Users/test/.codex-broken',
+			codexHomeKey: canonKey('/Users/test/.codex-broken'),
 		});
 		expect(loggerWarnMock).toHaveBeenCalledWith(
 			expect.stringContaining('Unexpected failure while sampling Codex usage snapshot'),
 			expect.any(String),
 			expect.objectContaining({
-				codexHomeKey: '/Users/test/.codex-broken',
+				codexHomeKey: canonKey('/Users/test/.codex-broken'),
 				error: 'boom',
 			})
 		);

--- a/src/__tests__/main/agents/opencode-config.test.ts
+++ b/src/__tests__/main/agents/opencode-config.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import path from 'path';
 import {
 	getOpenCodeConfigPaths,
 	getOpenCodeCommandDirs,
@@ -135,11 +136,14 @@ describe('opencode-config', () => {
 		it('should return POSIX paths in correct order', () => {
 			vi.mocked(isWindows).mockReturnValue(false);
 			const paths = getOpenCodeConfigPaths('/project', {});
+			// The product assembles these with `path.join`, so route the expected
+			// values through the same primitive to stay platform-symmetric (`\`
+			// separators on Windows, `/` on POSIX).
 			expect(paths).toEqual([
-				'/project/opencode.json',
-				expect.stringContaining('.opencode/opencode.json'),
+				path.join('/project', 'opencode.json'),
+				expect.stringContaining(path.join('.opencode', 'opencode.json')),
 				expect.stringContaining('.opencode.json'),
-				expect.stringContaining('.config/opencode/opencode.json'),
+				expect.stringContaining(path.join('.config', 'opencode', 'opencode.json')),
 			]);
 		});
 
@@ -165,9 +169,9 @@ describe('opencode-config', () => {
 			vi.mocked(isWindows).mockReturnValue(false);
 			const dirs = getOpenCodeCommandDirs('/project');
 			expect(dirs).toEqual([
-				'/project/.opencode/commands',
-				expect.stringContaining('.opencode/commands'),
-				expect.stringContaining('.config/opencode/commands'),
+				path.join('/project', '.opencode', 'commands'),
+				expect.stringContaining(path.join('.opencode', 'commands')),
+				expect.stringContaining(path.join('.config', 'opencode', 'commands')),
 			]);
 		});
 
@@ -182,7 +186,9 @@ describe('opencode-config', () => {
 		it('should merge models from multiple config files', async () => {
 			// Simulate two config files found
 			vi.mocked(fs.promises.readFile).mockImplementation(async (filePath: any) => {
-				const p = String(filePath);
+				// Normalize separators: the product builds these paths with
+				// `path.join`, which emits `\` on Windows. On POSIX this is a no-op.
+				const p = String(filePath).replace(/\\/g, '/');
 				if (p.includes('.opencode/opencode.json')) {
 					return JSON.stringify({
 						provider: {
@@ -217,7 +223,7 @@ describe('opencode-config', () => {
 
 		it('should deduplicate models across config files', async () => {
 			vi.mocked(fs.promises.readFile).mockImplementation(async (filePath: any) => {
-				const p = String(filePath);
+				const p = String(filePath).replace(/\\/g, '/');
 				if (p.includes('.opencode/opencode.json') || p.includes('.config/opencode/opencode.json')) {
 					return JSON.stringify({
 						provider: {

--- a/src/__tests__/main/agents/resolveClaudeSpawnMode.test.ts
+++ b/src/__tests__/main/agents/resolveClaudeSpawnMode.test.ts
@@ -6,6 +6,7 @@ import {
 	REMOTE_MAESTRO_P_COMMAND,
 	type ResolveClaudeSpawnModeDeps,
 } from '../../../main/agents/resolveClaudeSpawnMode';
+import { asarNodePath } from '../../helpers/pathExpect';
 import type { UsageSnapshot } from '../../../main/agents/claude-mode-selector';
 
 const claudeAgent = {
@@ -461,7 +462,7 @@ describe('applyClaudeSpawnDecision (batch surfaces)', () => {
 			// spawn-helper, so handing it the unpacked path double-applies and the
 			// helper exec fails (posix_spawn ENOENT).
 			expect(result.customEnvVars?.NODE_PATH).toBe(
-				'/Applications/Maestro.app/Contents/Resources/app.asar/node_modules'
+				asarNodePath('/Applications/Maestro.app/Contents/Resources')
 			);
 		} finally {
 			Object.defineProperty(process, 'resourcesPath', {

--- a/src/__tests__/main/cue/cue-agent-delete-prune.test.ts
+++ b/src/__tests__/main/cue/cue-agent-delete-prune.test.ts
@@ -139,9 +139,13 @@ function simulateSaveAndPrune(pipelines: CuePipeline[]): {
 		walk(promptsDir);
 	}
 
+	// `path.relative` yields OS-native separators (`\` on Windows). Normalize to
+	// forward slashes so the assertions below can use POSIX-style literals on
+	// every platform (a no-op transform on POSIX).
+	const toPosix = (p: string) => p.replace(/\\/g, '/');
 	return {
-		keptOnDisk: keptOnDisk.sort(),
-		removed: removed.map((r) => path.relative(projectRoot, r)).sort(),
+		keptOnDisk: keptOnDisk.map(toPosix).sort(),
+		removed: removed.map((r) => toPosix(path.relative(projectRoot, r))).sort(),
 	};
 }
 

--- a/src/__tests__/main/cue/cue-cli-executor.test.ts
+++ b/src/__tests__/main/cue/cue-cli-executor.test.ts
@@ -39,14 +39,23 @@ const mockSpawn = vi.fn((..._args: unknown[]) => {
 	return mockChild as unknown as ChildProcess;
 });
 
+const { mockIsWindows, mockExecFile } = vi.hoisted(() => ({
+	mockIsWindows: vi.fn(() => false),
+	mockExecFile: vi.fn((_cmd: unknown, _args: unknown, cb?: unknown) => {
+		if (typeof cb === 'function') (cb as (e: Error | null) => void)(null);
+	}),
+}));
+
 vi.mock('child_process', async (importOriginal) => {
 	const actual = await importOriginal<typeof import('child_process')>();
 	return {
 		...actual,
 		spawn: (...args: unknown[]) => mockSpawn(...args),
+		execFile: (...args: unknown[]) => mockExecFile(...(args as [unknown, unknown, unknown?])),
 		default: {
 			...actual,
 			spawn: (...args: unknown[]) => mockSpawn(...args),
+			execFile: (...args: unknown[]) => mockExecFile(...(args as [unknown, unknown, unknown?])),
 		},
 	};
 });
@@ -55,6 +64,19 @@ const mockCaptureException = vi.fn();
 vi.mock('../../../main/utils/sentry', () => ({
 	captureException: (...args: unknown[]) => mockCaptureException(...args),
 }));
+
+// Platform is mockable per-test; default is the POSIX kill path
+// (child.kill('SIGTERM')) so signal-based assertions hold regardless of host
+// OS — mirroring what CI exercises on Unix. The Windows test flips it to true
+// to exercise the taskkill branch. (Note: the module-level output-size cap is
+// evaluated at import time under the default, i.e. the POSIX cap.)
+vi.mock('../../../shared/platformDetection', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('../../../shared/platformDetection')>();
+	return {
+		...actual,
+		isWindows: () => mockIsWindows(),
+	};
+});
 
 import { executeCueCli, stopCueCliRun } from '../../../main/cue/cue-cli-executor';
 
@@ -120,6 +142,8 @@ function createConfig(overrides: Record<string, unknown> = {}) {
 describe('cue-cli-executor', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		// Default to the POSIX branch; the Windows test opts in via mockReturnValue(true).
+		mockIsWindows.mockReturnValue(false);
 	});
 
 	it('substitutes {{CUE_FROM_AGENT}} in target before invoking maestro-cli dispatch', async () => {
@@ -292,6 +316,26 @@ describe('cue-cli-executor', () => {
 		const stopped = stopCueCliRun('run-1');
 		expect(stopped).toBe(true);
 		expect(mockChild.killed).toBe(true);
+
+		mockChild.emit('close', null);
+		await promise;
+	});
+
+	it('stopCueCliRun uses taskkill /t /f on Windows instead of POSIX signals', async () => {
+		mockIsWindows.mockReturnValue(true);
+		const config = createConfig();
+		const promise = executeCueCli(config as any);
+		await Promise.resolve();
+
+		const stopped = stopCueCliRun('run-1');
+		expect(stopped).toBe(true);
+		expect(mockExecFile).toHaveBeenCalledWith(
+			'taskkill',
+			['/pid', String(mockChild.pid), '/t', '/f'],
+			expect.any(Function)
+		);
+		// POSIX signals are a no-op for shell-spawned trees on Windows.
+		expect(mockChild.killed).toBe(false);
 
 		mockChild.emit('close', null);
 		await promise;

--- a/src/__tests__/main/cue/cue-cli-executor.test.ts
+++ b/src/__tests__/main/cue/cue-cli-executor.test.ts
@@ -67,7 +67,7 @@ vi.mock('../../../main/utils/sentry', () => ({
 
 // Platform is mockable per-test; default is the POSIX kill path
 // (child.kill('SIGTERM')) so signal-based assertions hold regardless of host
-// OS — mirroring what CI exercises on Unix. The Windows test flips it to true
+// OS - mirroring what CI exercises on Unix. The Windows test flips it to true
 // to exercise the taskkill branch. (Note: the module-level output-size cap is
 // evaluated at import time under the default, i.e. the POSIX cap.)
 vi.mock('../../../shared/platformDetection', async (importOriginal) => {

--- a/src/__tests__/main/cue/cue-config-repository.test.ts
+++ b/src/__tests__/main/cue/cue-config-repository.test.ts
@@ -56,7 +56,11 @@ const PROJECT_ROOT = '/projects/test';
 const CANONICAL = path.join(PROJECT_ROOT, '.maestro/cue.yaml');
 const LEGACY = path.join(PROJECT_ROOT, 'maestro-cue.yaml');
 const MAESTRO_DIR = path.join(PROJECT_ROOT, '.maestro');
-const PROMPTS_DIR = path.join(PROJECT_ROOT, '.maestro/prompts');
+// Prompt-file operations in the product canonicalize via `path.resolve(...)`
+// for their containment guard, so on Windows these carry the CWD drive letter.
+// Route the expected value through the same primitive so the assertion stays
+// platform-symmetric (a no-op transform on POSIX).
+const PROMPTS_DIR = path.resolve(path.join(PROJECT_ROOT, '.maestro/prompts'));
 
 describe('cue-config-repository', () => {
 	beforeEach(() => {
@@ -186,7 +190,7 @@ describe('cue-config-repository', () => {
 
 			const result = writeCuePromptFile(PROJECT_ROOT, '.maestro/prompts/sub-1.md', 'prompt body 1');
 
-			const expectedAbs = path.join(PROJECT_ROOT, '.maestro/prompts/sub-1.md');
+			const expectedAbs = path.resolve(path.join(PROJECT_ROOT, '.maestro/prompts/sub-1.md'));
 			expect(result).toBe(expectedAbs);
 			expect(mockWriteFileSync).toHaveBeenCalledWith(expectedAbs, 'prompt body 1', 'utf-8');
 		});
@@ -201,7 +205,7 @@ describe('cue-config-repository', () => {
 
 		it('creates parent directories for nested prompt paths', () => {
 			const nested = '.maestro/prompts/nested/dir/sub.md';
-			const expectedParent = path.join(PROJECT_ROOT, '.maestro/prompts/nested/dir');
+			const expectedParent = path.resolve(path.join(PROJECT_ROOT, '.maestro/prompts/nested/dir'));
 			mockExistsSync.mockImplementation((p: string) => p !== expectedParent);
 
 			writeCuePromptFile(PROJECT_ROOT, nested, 'nested body');
@@ -210,7 +214,7 @@ describe('cue-config-repository', () => {
 			// intermediate directories (including .maestro/prompts) in one call.
 			expect(mockMkdirSync).toHaveBeenCalledWith(expectedParent, { recursive: true });
 			expect(mockWriteFileSync).toHaveBeenCalledWith(
-				path.join(PROJECT_ROOT, nested),
+				path.resolve(path.join(PROJECT_ROOT, nested)),
 				'nested body',
 				'utf-8'
 			);
@@ -254,7 +258,7 @@ describe('cue-config-repository', () => {
 
 			expect(result).toBe('body on disk');
 			expect(mockReadFileSync).toHaveBeenCalledWith(
-				path.join(PROJECT_ROOT, '.maestro/prompts/sub-1.md'),
+				path.resolve(path.join(PROJECT_ROOT, '.maestro/prompts/sub-1.md')),
 				'utf-8'
 			);
 		});

--- a/src/__tests__/main/cue/cue-executor.test.ts
+++ b/src/__tests__/main/cue/cue-executor.test.ts
@@ -113,6 +113,18 @@ vi.mock('../../../main/parsers', () => ({
 	getOutputParser: (...args: unknown[]) => mockGetOutputParser(...args),
 }));
 
+// Force the POSIX kill path (child.kill('SIGTERM')) in the underlying
+// cue-process-lifecycle so these SIGTERM → SIGKILL assertions hold regardless of
+// host OS. On Windows the product correctly uses taskkill /t /f instead, which
+// these tests don't assert. This mirrors what CI exercises on Unix.
+vi.mock('../../../shared/platformDetection', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('../../../shared/platformDetection')>();
+	return {
+		...actual,
+		isWindows: () => false,
+	};
+});
+
 // Mock child_process.spawn
 class MockChildProcess extends EventEmitter {
 	pid = 12345;

--- a/src/__tests__/main/cue/cue-process-lifecycle.test.ts
+++ b/src/__tests__/main/cue/cue-process-lifecycle.test.ts
@@ -24,6 +24,25 @@ vi.mock('../../../main/utils/sentry', () => ({
 	captureException: (...args: unknown[]) => mockCaptureException(...args),
 }));
 
+// Platform is mockable per-test. Default is the POSIX kill path
+// (child.kill('SIGTERM')) so the SIGTERM → SIGKILL assertions hold regardless
+// of host OS — mirroring what CI exercises on Unix. The Windows process-tree
+// kill tests flip this to true to exercise the taskkill branch.
+const { mockIsWindows, mockExecFile, mockExecFileSync } = vi.hoisted(() => ({
+	mockIsWindows: vi.fn(() => false),
+	mockExecFile: vi.fn((_cmd: unknown, _args: unknown, cb?: unknown) => {
+		if (typeof cb === 'function') (cb as (e: Error | null) => void)(null);
+	}),
+	mockExecFileSync: vi.fn(),
+}));
+vi.mock('../../../shared/platformDetection', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('../../../shared/platformDetection')>();
+	return {
+		...actual,
+		isWindows: () => mockIsWindows(),
+	};
+});
+
 // Mock child_process.spawn
 class MockChildProcess extends EventEmitter {
 	pid = 12345;
@@ -60,9 +79,13 @@ vi.mock('child_process', async (importOriginal) => {
 	return {
 		...actual,
 		spawn: (...args: unknown[]) => mockSpawn(...args),
+		execFile: (...args: unknown[]) => mockExecFile(...(args as [unknown, unknown, unknown?])),
+		execFileSync: (...args: unknown[]) => mockExecFileSync(...args),
 		default: {
 			...actual,
 			spawn: (...args: unknown[]) => mockSpawn(...args),
+			execFile: (...args: unknown[]) => mockExecFile(...(args as [unknown, unknown, unknown?])),
+			execFileSync: (...args: unknown[]) => mockExecFileSync(...args),
 		},
 	};
 });
@@ -101,6 +124,8 @@ function createOptions(overrides = {}) {
 describe('cue-process-lifecycle', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		// Default to the POSIX branch; Windows tests opt in via mockReturnValue(true).
+		mockIsWindows.mockReturnValue(false);
 		vi.useFakeTimers();
 		getActiveProcessMap().clear();
 	});
@@ -519,6 +544,49 @@ describe('cue-process-lifecycle', () => {
 			// Process hasn't exited — SIGKILL should fire after delay
 			await vi.advanceTimersByTimeAsync(5000);
 			expect(childKill).toHaveBeenCalledWith('SIGKILL');
+
+			mockChild.emit('close', null);
+			await resultPromise;
+		});
+	});
+
+	describe('Windows process-tree kill (taskkill)', () => {
+		it('kills via taskkill /pid <pid> /t /f instead of POSIX signals', async () => {
+			mockIsWindows.mockReturnValue(true);
+
+			const resultPromise = runProcess('win-stop', createSpec(), createOptions());
+			await vi.advanceTimersByTimeAsync(0);
+
+			const childKill = vi.spyOn(mockChild, 'kill');
+
+			const stopped = stopProcess('win-stop');
+			expect(stopped).toBe(true);
+			expect(mockExecFile).toHaveBeenCalledWith(
+				'taskkill',
+				['/pid', String(mockChild.pid), '/t', '/f'],
+				expect.any(Function)
+			);
+			// POSIX signals must not be used on Windows (no-op for shell-spawned trees).
+			expect(childKill).not.toHaveBeenCalled();
+
+			mockChild.emit('close', null);
+			await resultPromise;
+		});
+
+		it('tolerates taskkill failing because the process is already dead', async () => {
+			mockIsWindows.mockReturnValue(true);
+			mockExecFile.mockImplementationOnce((_cmd: unknown, _args: unknown, cb?: unknown) => {
+				if (typeof cb === 'function') {
+					(cb as (e: Error | null) => void)(new Error('ERROR: The process "12345" not found.'));
+				}
+			});
+
+			const resultPromise = runProcess('win-dead', createSpec(), createOptions());
+			await vi.advanceTimersByTimeAsync(0);
+
+			stopProcess('win-dead');
+			// Already-dead is expected on Windows and must not be reported to Sentry.
+			expect(mockCaptureException).not.toHaveBeenCalled();
 
 			mockChild.emit('close', null);
 			await resultPromise;

--- a/src/__tests__/main/cue/cue-process-lifecycle.test.ts
+++ b/src/__tests__/main/cue/cue-process-lifecycle.test.ts
@@ -26,7 +26,7 @@ vi.mock('../../../main/utils/sentry', () => ({
 
 // Platform is mockable per-test. Default is the POSIX kill path
 // (child.kill('SIGTERM')) so the SIGTERM → SIGKILL assertions hold regardless
-// of host OS — mirroring what CI exercises on Unix. The Windows process-tree
+// of host OS - mirroring what CI exercises on Unix. The Windows process-tree
 // kill tests flip this to true to exercise the taskkill branch.
 const { mockIsWindows, mockExecFile, mockExecFileSync } = vi.hoisted(() => ({
 	mockIsWindows: vi.fn(() => false),

--- a/src/__tests__/main/cue/cue-shell-executor.test.ts
+++ b/src/__tests__/main/cue/cue-shell-executor.test.ts
@@ -34,6 +34,24 @@ vi.mock('../../../main/utils/ssh-spawn-wrapper', () => ({
 	wrapSpawnWithSsh: vi.fn(),
 }));
 
+// Platform is mockable per-test; default is the POSIX kill path
+// (child.kill('SIGTERM')) so signal-based assertions hold regardless of host
+// OS — mirroring what CI exercises on Unix. The Windows test flips it to true
+// to exercise the taskkill branch.
+const { mockIsWindows, mockExecFile } = vi.hoisted(() => ({
+	mockIsWindows: vi.fn(() => false),
+	mockExecFile: vi.fn((_cmd: unknown, _args: unknown, cb?: unknown) => {
+		if (typeof cb === 'function') (cb as (e: Error | null) => void)(null);
+	}),
+}));
+vi.mock('../../../shared/platformDetection', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('../../../shared/platformDetection')>();
+	return {
+		...actual,
+		isWindows: () => mockIsWindows(),
+	};
+});
+
 class MockChildProcess extends EventEmitter {
 	pid = 54321;
 	exitCode: number | null = null;
@@ -65,9 +83,11 @@ vi.mock('child_process', async (importOriginal) => {
 	return {
 		...actual,
 		spawn: (...args: unknown[]) => mockSpawn(...args),
+		execFile: (...args: unknown[]) => mockExecFile(...(args as [unknown, unknown, unknown?])),
 		default: {
 			...actual,
 			spawn: (...args: unknown[]) => mockSpawn(...args),
+			execFile: (...args: unknown[]) => mockExecFile(...(args as [unknown, unknown, unknown?])),
 		},
 	};
 });
@@ -133,6 +153,8 @@ function createConfig(overrides: Record<string, unknown> = {}) {
 describe('cue-shell-executor', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		// Default to the POSIX branch; the Windows test opts in via mockReturnValue(true).
+		mockIsWindows.mockReturnValue(false);
 		vi.useFakeTimers();
 	});
 
@@ -241,6 +263,26 @@ describe('cue-shell-executor', () => {
 		const stopped = stopCueShellRun('run-1');
 		expect(stopped).toBe(true);
 		expect(mockChild.killed).toBe(true);
+
+		mockChild.emit('close', null);
+		await promise;
+	});
+
+	it('stopCueShellRun uses taskkill /t /f on Windows instead of POSIX signals', async () => {
+		mockIsWindows.mockReturnValue(true);
+		const config = createConfig();
+		const promise = executeCueShell(config as any);
+		await vi.advanceTimersByTimeAsync(0);
+
+		const stopped = stopCueShellRun('run-1');
+		expect(stopped).toBe(true);
+		expect(mockExecFile).toHaveBeenCalledWith(
+			'taskkill',
+			['/pid', String(mockChild.pid), '/t', '/f'],
+			expect.any(Function)
+		);
+		// POSIX signals are a no-op for shell-spawned trees on Windows.
+		expect(mockChild.killed).toBe(false);
 
 		mockChild.emit('close', null);
 		await promise;

--- a/src/__tests__/main/cue/cue-shell-executor.test.ts
+++ b/src/__tests__/main/cue/cue-shell-executor.test.ts
@@ -36,7 +36,7 @@ vi.mock('../../../main/utils/ssh-spawn-wrapper', () => ({
 
 // Platform is mockable per-test; default is the POSIX kill path
 // (child.kill('SIGTERM')) so signal-based assertions hold regardless of host
-// OS — mirroring what CI exercises on Unix. The Windows test flips it to true
+// OS - mirroring what CI exercises on Unix. The Windows test flips it to true
 // to exercise the taskkill branch.
 const { mockIsWindows, mockExecFile } = vi.hoisted(() => ({
 	mockIsWindows: vi.fn(() => false),

--- a/src/__tests__/main/cue/cue-yaml-loader.test.ts
+++ b/src/__tests__/main/cue/cue-yaml-loader.test.ts
@@ -10,6 +10,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import path from 'path';
 
 // Mock chokidar
 const mockChokidarOn = vi.fn().mockReturnThis();
@@ -68,7 +69,9 @@ describe('cue-yaml-loader', () => {
 
 		it('loads from canonical .maestro/cue.yaml path first', () => {
 			// Canonical path exists
-			mockExistsSync.mockImplementation((p: string) => String(p).includes('.maestro/cue.yaml'));
+			mockExistsSync.mockImplementation((p: string) =>
+				String(p).replace(/\\/g, '/').includes('.maestro/cue.yaml')
+			);
 			mockReadFileSync.mockReturnValue(`
 subscriptions:
   - name: canonical-sub
@@ -139,9 +142,10 @@ subscriptions:
 
 		it('falls back to legacy maestro-cue.yaml when canonical does not exist', () => {
 			// Only legacy path exists
-			mockExistsSync.mockImplementation(
-				(p: string) => String(p).includes('maestro-cue.yaml') && !String(p).includes('.maestro/')
-			);
+			mockExistsSync.mockImplementation((p: string) => {
+				const norm = String(p).replace(/\\/g, '/');
+				return norm.includes('maestro-cue.yaml') && !norm.includes('.maestro/');
+			});
 			mockReadFileSync.mockReturnValue(`
 subscriptions:
   - name: legacy-sub
@@ -252,7 +256,7 @@ subscriptions:
 			mockExistsSync.mockReturnValue(true);
 			mockReadFileSync.mockImplementation((p: string) => {
 				readCallCount++;
-				if (String(p).endsWith('.maestro/prompts/worker-pipeline.md')) {
+				if (String(p).replace(/\\/g, '/').endsWith('.maestro/prompts/worker-pipeline.md')) {
 					return 'Prompt from external file';
 				}
 				return `
@@ -290,7 +294,7 @@ subscriptions:
 		it('resolves output_prompt_file to output_prompt content', () => {
 			mockExistsSync.mockReturnValue(true);
 			mockReadFileSync.mockImplementation((p: string) => {
-				if (String(p).endsWith('.maestro/prompts/format-output.md')) {
+				if (String(p).replace(/\\/g, '/').endsWith('.maestro/prompts/format-output.md')) {
 					return 'Format the output as markdown';
 				}
 				return `
@@ -329,7 +333,7 @@ subscriptions:
 		it('sets output_prompt to undefined when output_prompt_file is missing', () => {
 			mockExistsSync.mockReturnValue(true);
 			mockReadFileSync.mockImplementation((p: string) => {
-				if (String(p).endsWith('.maestro/prompts/missing.md')) {
+				if (String(p).replace(/\\/g, '/').endsWith('.maestro/prompts/missing.md')) {
 					throw new Error('ENOENT: no such file or directory');
 				}
 				return `
@@ -545,7 +549,7 @@ subscriptions:
 			mockExistsSync.mockReturnValue(true);
 			mockReadFileSync.mockImplementation((p: string) => {
 				readCount++;
-				if (String(p).endsWith('.maestro/prompts/missing.md')) {
+				if (String(p).replace(/\\/g, '/').endsWith('.maestro/prompts/missing.md')) {
 					throw new Error('ENOENT: no such file');
 				}
 				return `
@@ -571,7 +575,7 @@ subscriptions:
 		it('surfaces a warning when output_prompt_file references a missing file', () => {
 			mockExistsSync.mockReturnValue(true);
 			mockReadFileSync.mockImplementation((p: string) => {
-				if (String(p).endsWith('.maestro/prompts/missing-output.md')) {
+				if (String(p).replace(/\\/g, '/').endsWith('.maestro/prompts/missing-output.md')) {
 					throw new Error('ENOENT: no such file');
 				}
 				return `
@@ -597,7 +601,7 @@ subscriptions:
 		it('returns no warnings when prompt_file resolves successfully', () => {
 			mockExistsSync.mockReturnValue(true);
 			mockReadFileSync.mockImplementation((p: string) => {
-				if (String(p).endsWith('.maestro/prompts/exists.md')) {
+				if (String(p).replace(/\\/g, '/').endsWith('.maestro/prompts/exists.md')) {
 					return 'Resolved prompt body';
 				}
 				return `
@@ -625,7 +629,7 @@ subscriptions:
 			// Should watch both .maestro/cue.yaml (canonical) and maestro-cue.yaml (legacy)
 			expect(chokidar.watch).toHaveBeenCalledWith(
 				expect.arrayContaining([
-					expect.stringContaining('.maestro/cue.yaml'),
+					expect.stringContaining(path.join('.maestro', 'cue.yaml')),
 					expect.stringContaining('maestro-cue.yaml'),
 				]),
 				expect.objectContaining({ persistent: true, ignoreInitial: true })
@@ -638,7 +642,7 @@ subscriptions:
 			// strands the engine with empty cached prompts because the YAML
 			// watcher never fires again.
 			expect(chokidar.watch).toHaveBeenCalledWith(
-				expect.arrayContaining([expect.stringContaining('.maestro/prompts/*.md')]),
+				expect.arrayContaining([expect.stringContaining(path.join('.maestro', 'prompts', '*.md'))]),
 				expect.anything()
 			);
 		});

--- a/src/__tests__/main/ipc/handlers/agents.test.ts
+++ b/src/__tests__/main/ipc/handlers/agents.test.ts
@@ -1261,14 +1261,14 @@ describe('agents IPC handlers', () => {
 
 			// Project-level skill directory lists Research; user-level has nothing.
 			vi.mocked(fs.promises.readdir).mockImplementation(async (dir: any) => {
-				if (String(dir) === '/test/project/.claude/skills') {
+				if (String(dir).replace(/\\/g, '/') === '/test/project/.claude/skills') {
 					return [{ name: 'Research', isDirectory: () => true }] as any;
 				}
 				const enoent = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
 				throw enoent;
 			});
 			vi.mocked(fs.promises.readFile).mockImplementation(async (filePath: any) => {
-				const p = String(filePath);
+				const p = String(filePath).replace(/\\/g, '/');
 				// Canonical uppercase SKILL.md is what Claude Code actually writes.
 				if (p === '/test/project/.claude/skills/Research/SKILL.md') {
 					return '---\nname: Research\ndescription: Deep literature review\n---\n\nBody';
@@ -1440,7 +1440,7 @@ describe('agents IPC handlers', () => {
 			const enoent = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
 			// Project commands dir has custom .md files
 			vi.mocked(fs.promises.readdir).mockImplementation(async (dir) => {
-				if (String(dir).includes('/test/.opencode/commands')) {
+				if (String(dir).replace(/\\/g, '/').includes('/test/.opencode/commands')) {
 					return ['deploy.md', 'lint.md', 'README.txt'] as any;
 				}
 				throw enoent;
@@ -1477,7 +1477,10 @@ describe('agents IPC handlers', () => {
 			const enoent = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
 			const homeDir = require('os').homedir();
 			vi.mocked(fs.promises.readdir).mockImplementation(async (dir) => {
-				if (String(dir) === `${homeDir}/.opencode/commands`) {
+				if (
+					String(dir).replace(/\\/g, '/') ===
+					`${String(homeDir).replace(/\\/g, '/')}/.opencode/commands`
+				) {
 					return ['octest.md'] as any;
 				}
 				throw enoent;
@@ -1508,7 +1511,7 @@ describe('agents IPC handlers', () => {
 
 			const enoent = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
 			vi.mocked(fs.promises.readdir).mockImplementation(async (dir) => {
-				if (String(dir).includes('/test/.opencode/commands')) {
+				if (String(dir).replace(/\\/g, '/').includes('/test/.opencode/commands')) {
 					return ['deploy.md'] as any;
 				}
 				throw enoent;
@@ -1539,7 +1542,7 @@ describe('agents IPC handlers', () => {
 			const enoent = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
 			vi.mocked(fs.promises.readdir).mockRejectedValue(enoent);
 			vi.mocked(fs.promises.readFile).mockImplementation(async (filePath) => {
-				if (String(filePath).includes('/test/opencode.json')) {
+				if (String(filePath).replace(/\\/g, '/').includes('/test/opencode.json')) {
 					return JSON.stringify({ command: { 'my-cmd': { prompt: 'Do the thing' } } });
 				}
 				throw enoent;

--- a/src/__tests__/main/ipc/handlers/filesystem.test.ts
+++ b/src/__tests__/main/ipc/handlers/filesystem.test.ts
@@ -942,14 +942,15 @@ describe('filesystem handlers', () => {
 
 			// Root has: src/ (dir), .git/ (dir), file.txt (file)
 			vi.mocked(mockFs.readdir).mockImplementation(async (dirPath: any) => {
-				if (dirPath === '/project') {
+				const p = String(dirPath).replace(/\\/g, '/');
+				if (p === '/project') {
 					return [
 						{ name: 'src', isDirectory: () => true, isFile: () => false },
 						{ name: '.git', isDirectory: () => true, isFile: () => false },
 						{ name: 'file.txt', isDirectory: () => false, isFile: () => true },
 					] as any;
 				}
-				if (dirPath.includes('/src')) {
+				if (p.includes('/src')) {
 					return [{ name: 'index.ts', isDirectory: () => false, isFile: () => true }] as any;
 				}
 				return [];
@@ -966,14 +967,15 @@ describe('filesystem handlers', () => {
 
 			// With .git in ignore patterns — .git is excluded
 			vi.mocked(mockFs.readdir).mockImplementation(async (dirPath: any) => {
-				if (dirPath === '/project') {
+				const p = String(dirPath).replace(/\\/g, '/');
+				if (p === '/project') {
 					return [
 						{ name: 'src', isDirectory: () => true, isFile: () => false },
 						{ name: '.git', isDirectory: () => true, isFile: () => false },
 						{ name: 'file.txt', isDirectory: () => false, isFile: () => true },
 					] as any;
 				}
-				if (dirPath.includes('/src')) {
+				if (p.includes('/src')) {
 					return [{ name: 'index.ts', isDirectory: () => false, isFile: () => true }] as any;
 				}
 				return [];
@@ -1002,7 +1004,8 @@ describe('filesystem handlers', () => {
 			});
 
 			vi.mocked(mockFs.readdir).mockImplementation(async (dirPath: any) => {
-				if (dirPath === '/project') {
+				const p = String(dirPath).replace(/\\/g, '/');
+				if (p === '/project') {
 					return [
 						{ name: 'src', isDirectory: () => true, isFile: () => false },
 						{ name: 'dist', isDirectory: () => true, isFile: () => false },
@@ -1010,7 +1013,7 @@ describe('filesystem handlers', () => {
 						{ name: 'debug.log', isDirectory: () => false, isFile: () => true },
 					] as any;
 				}
-				if (dirPath.includes('/src')) {
+				if (p.includes('/src')) {
 					return [{ name: 'index.ts', isDirectory: () => false, isFile: () => true }] as any;
 				}
 				return [];

--- a/src/__tests__/main/ipc/handlers/git.test.ts
+++ b/src/__tests__/main/ipc/handlers/git.test.ts
@@ -55,7 +55,10 @@ vi.mock('fs/promises', () => ({
 		// and the chokidar discovery validator behave like a no-op in tests. Individual
 		// tests can override this via vi.mocked(fs.realpath).mockResolvedValue(...) to
 		// exercise the symlink-resolution behavior.
-		realpath: vi.fn().mockImplementation(async (p: string) => p),
+		// Separators are normalized to '/' so that on Windows, product paths built with
+		// path.join (backslashes) compare equal to the POSIX paths returned by the mocked
+		// `git rev-parse --show-toplevel`. On POSIX this is a no-op.
+		realpath: vi.fn().mockImplementation(async (p: string) => String(p).replace(/\\/g, '/')),
 	},
 }));
 
@@ -4134,7 +4137,7 @@ branch refs/heads/bugfix-123
 			] as any);
 
 			vi.mocked(execFile.execFileNoThrow).mockImplementation(async (cmd, args, cwd) => {
-				const cwdStr = String(cwd);
+				const cwdStr = String(cwd).replace(/\\/g, '/');
 
 				if (cwdStr.endsWith('actual-worktree')) {
 					if (args?.includes('--is-inside-work-tree')) {
@@ -4186,7 +4189,7 @@ branch refs/heads/bugfix-123
 			] as any);
 
 			vi.mocked(execFile.execFileNoThrow).mockImplementation(async (cmd, args, cwd) => {
-				const cwdStr = String(cwd);
+				const cwdStr = String(cwd).replace(/\\/g, '/');
 
 				if (cwdStr.endsWith('good-worktree')) {
 					if (args?.includes('--is-inside-work-tree')) {
@@ -4238,7 +4241,9 @@ branch refs/heads/bugfix-123
 			] as any);
 
 			vi.mocked(mockFs.realpath).mockImplementation(async (p: any) => {
-				const s = String(p);
+				// Normalize separators so the Windows product path (path.join → backslashes)
+				// matches these POSIX keys; on POSIX this is a no-op.
+				const s = String(p).replace(/\\/g, '/');
 				if (s === '/home/user/worktrees/feature-branch') {
 					return '/data/worktrees/feature-branch';
 				}

--- a/src/__tests__/main/process-manager.test.ts
+++ b/src/__tests__/main/process-manager.test.ts
@@ -442,7 +442,15 @@ describe('process-manager.ts', () => {
 		});
 
 		describe('kill() PTY signal handling', () => {
+			afterEach(() => {
+				// Restore default platform delegation so a forced value doesn't leak.
+				mockIsWindows.mockImplementation(() => process.platform === 'win32');
+			});
+
 			it('should send SIGTERM (not default SIGHUP) to PTY processes', () => {
+				// Force the POSIX branch so this signal assertion holds on any host
+				// (Windows correctly uses taskkill, which CI on Unix never exercises).
+				mockIsWindows.mockReturnValue(false);
 				const mockPtyKill = vi.fn();
 				const mockOnExit = vi.fn();
 				const processes = (processManager as any).processes as Map<string, any>;
@@ -469,6 +477,7 @@ describe('process-manager.ts', () => {
 			});
 
 			it('should schedule SIGKILL escalation for PTY processes', () => {
+				mockIsWindows.mockReturnValue(false);
 				vi.useFakeTimers();
 				const mockPtyKill = vi.fn();
 				const mockOnExit = vi.fn();
@@ -507,6 +516,7 @@ describe('process-manager.ts', () => {
 			});
 
 			it('should cancel SIGKILL escalation if PTY exits on its own', () => {
+				mockIsWindows.mockReturnValue(false);
 				vi.useFakeTimers();
 				const mockPtyKill = vi.fn();
 				let exitCallback: (() => void) | undefined;
@@ -650,7 +660,13 @@ describe('process-manager.ts', () => {
 		});
 
 		describe('spawn() kill-before-spawn guard', () => {
+			afterEach(() => {
+				mockIsWindows.mockImplementation(() => process.platform === 'win32');
+			});
+
 			it('should kill existing process before spawning with same sessionId', () => {
+				// Force the POSIX branch so the SIGTERM assertion holds on any host.
+				mockIsWindows.mockReturnValue(false);
 				const mockPtyKill = vi.fn();
 				const mockOnExit = vi.fn();
 				const processes = (processManager as any).processes as Map<string, any>;
@@ -689,6 +705,10 @@ describe('process-manager.ts', () => {
 		});
 
 		describe('killAll() map safety', () => {
+			afterEach(() => {
+				mockIsWindows.mockImplementation(() => process.platform === 'win32');
+			});
+
 			it('should kill all processes even when kill() deletes from the map', () => {
 				const kills: string[] = [];
 				const originalKill = processManager.kill.bind(processManager);
@@ -751,6 +771,10 @@ describe('process-manager.ts', () => {
 			});
 
 			it('should SIGKILL ptys directly when shutdown:true to avoid TSFN teardown race', () => {
+				// Force the POSIX branch: on Windows the taskkill path is taken first
+				// (correct behavior), so the shutdown-SIGKILL branch is only reachable
+				// off-Windows. This mirrors what CI exercises on Unix.
+				mockIsWindows.mockReturnValue(false);
 				const mockPtyKill = vi.fn();
 				const mockOnExit = vi.fn();
 

--- a/src/__tests__/main/process-manager/utils/pathResolver.test.ts
+++ b/src/__tests__/main/process-manager/utils/pathResolver.test.ts
@@ -1,8 +1,19 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { buildInteractiveShellArgs } from '../../../../main/process-manager/utils/pathResolver';
 
 describe('pathResolver', () => {
 	describe('buildInteractiveShellArgs', () => {
+		// These assertions model the Unix shell branch. `platformDetection`
+		// reads `process.platform` first, so force it to a Unix value; otherwise
+		// on Windows the product's `isWindows()` early-return yields `[command]`.
+		const originalPlatform = process.platform;
+		beforeEach(() => {
+			Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
+		});
+		afterEach(() => {
+			Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+		});
+
 		it('uses login + interactive flags for zsh commands', () => {
 			expect(buildInteractiveShellArgs('ls', 'zsh')).toEqual(['-l', '-i', '-c', 'ls']);
 		});

--- a/src/__tests__/main/storage/copilot-session-storage.test.ts
+++ b/src/__tests__/main/storage/copilot-session-storage.test.ts
@@ -434,7 +434,9 @@ describe('CopilotSessionStorage — paginated listing', () => {
 		});
 
 		vi.mocked(fs.stat).mockImplementation(async (filePath) => {
-			const p = String(filePath);
+			// Local paths are built with `path.join`, so normalize separators to
+			// `/` before matching (no-op on POSIX, converts `\` on Windows).
+			const p = String(filePath).replace(/\\/g, '/');
 			if (p.endsWith('/events.jsonl')) {
 				const id = p.split('/').slice(-2, -1)[0];
 				const idx = ids.indexOf(id);
@@ -444,7 +446,7 @@ describe('CopilotSessionStorage — paginated listing', () => {
 		});
 
 		vi.mocked(fs.readFile).mockImplementation(async (filePath) => {
-			const p = String(filePath);
+			const p = String(filePath).replace(/\\/g, '/');
 			const id = p.split('/').slice(-2, -1)[0];
 			if (p.endsWith('/workspace.yaml')) return workspaceYaml(id, projectPath);
 			return eventsJsonl();

--- a/src/__tests__/main/stores/claudeUsageStore.test.ts
+++ b/src/__tests__/main/stores/claudeUsageStore.test.ts
@@ -56,6 +56,8 @@ vi.mock('os', async () => {
 	};
 });
 
+import * as os from 'os';
+import * as path from 'path';
 import {
 	setSnapshot,
 	getSnapshot,
@@ -66,6 +68,7 @@ import {
 	__resetForTests,
 	type UsageSnapshot,
 } from '../../../main/stores/claudeUsageStore';
+import { canonKey } from '../../helpers/pathExpect';
 
 const FROZEN_NOW = new Date('2026-05-15T12:00:00.000Z').getTime();
 
@@ -283,28 +286,30 @@ describe('claudeUsageStore', () => {
 	describe('resolveConfigDirKey', () => {
 		it('returns the canonical resolved path when CLAUDE_CONFIG_DIR is set', () => {
 			expect(resolveConfigDirKey({ CLAUDE_CONFIG_DIR: '/Users/test/.claude-gmail' })).toBe(
-				'/Users/test/.claude-gmail'
+				canonKey('/Users/test/.claude-gmail')
 			);
 		});
 
 		it('falls back to ~/.claude when CLAUDE_CONFIG_DIR is unset', () => {
-			expect(resolveConfigDirKey({})).toBe('/Users/test/.claude');
+			expect(resolveConfigDirKey({})).toBe(canonKey(path.join(os.homedir(), '.claude')));
 		});
 
 		it('canonicalizes redundant separators and trailing slashes', () => {
 			expect(resolveConfigDirKey({ CLAUDE_CONFIG_DIR: '/Users/test/./.claude-gmail/' })).toBe(
-				'/Users/test/.claude-gmail'
+				canonKey('/Users/test/.claude-gmail')
 			);
 		});
 
 		it('canonicalizes ".." segments', () => {
 			expect(resolveConfigDirKey({ CLAUDE_CONFIG_DIR: '/Users/test/foo/../.claude-smash' })).toBe(
-				'/Users/test/.claude-smash'
+				canonKey('/Users/test/.claude-smash')
 			);
 		});
 
 		it('treats CLAUDE_CONFIG_DIR=undefined identically to unset', () => {
-			expect(resolveConfigDirKey({ CLAUDE_CONFIG_DIR: undefined })).toBe('/Users/test/.claude');
+			expect(resolveConfigDirKey({ CLAUDE_CONFIG_DIR: undefined })).toBe(
+				canonKey(path.join(os.homedir(), '.claude'))
+			);
 		});
 	});
 });

--- a/src/__tests__/main/utils/dirent-utils.test.ts
+++ b/src/__tests__/main/utils/dirent-utils.test.ts
@@ -110,7 +110,7 @@ describe('readDirWithResolvedTypes', () => {
 		] as any);
 
 		vi.mocked(fs.stat).mockImplementation((p: any) => {
-			if (p === '/proj/linked-lib') {
+			if (String(p).replace(/\\/g, '/') === '/proj/linked-lib') {
 				return Promise.resolve({
 					isDirectory: () => true,
 					isFile: () => false,

--- a/src/__tests__/main/web-server/handlers/messageHandlers.test.ts
+++ b/src/__tests__/main/web-server/handlers/messageHandlers.test.ts
@@ -46,7 +46,7 @@ vi.mock('../../../../main/utils/logger', () => ({
  * Symlink creation requires elevation / Developer Mode on Windows and throws
  * EPERM otherwise. Probe once and cache so the symlink-confinement tests run on
  * Unix/CI (where they're meaningful) but skip gracefully where the OS forbids
- * creating symlinks. This is purely an environment capability check — the
+ * creating symlinks. This is purely an environment capability check - the
  * product's realpath-based confinement is platform-neutral.
  */
 let _canSymlink: boolean | undefined;

--- a/src/__tests__/main/web-server/handlers/messageHandlers.test.ts
+++ b/src/__tests__/main/web-server/handlers/messageHandlers.test.ts
@@ -43,6 +43,35 @@ vi.mock('../../../../main/utils/logger', () => ({
 }));
 
 /**
+ * Symlink creation requires elevation / Developer Mode on Windows and throws
+ * EPERM otherwise. Probe once and cache so the symlink-confinement tests run on
+ * Unix/CI (where they're meaningful) but skip gracefully where the OS forbids
+ * creating symlinks. This is purely an environment capability check — the
+ * product's realpath-based confinement is platform-neutral.
+ */
+let _canSymlink: boolean | undefined;
+function canSymlink(): boolean {
+	if (_canSymlink !== undefined) return _canSymlink;
+	let probeDir: string | undefined;
+	try {
+		probeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'maestro-symlink-probe-'));
+		fs.symlinkSync(probeDir, path.join(probeDir, 'self-link'));
+		_canSymlink = true;
+	} catch {
+		_canSymlink = false;
+	} finally {
+		if (probeDir) {
+			try {
+				fs.rmSync(probeDir, { recursive: true, force: true });
+			} catch {
+				// best-effort cleanup
+			}
+		}
+	}
+	return _canSymlink;
+}
+
+/**
  * Create a mock WebSocket client
  */
 function createMockClient(id: string = 'test-client'): WebClient {
@@ -817,9 +846,12 @@ describe('WebSocketMessageHandler', () => {
 			});
 
 			await vi.waitFor(() => {
+				// The handler forwards `path.resolve(sessionRoot, filePath)`, which on
+				// Windows carries the CWD drive letter. Route the expectation through
+				// the same primitive so it stays platform-symmetric (no-op on POSIX).
 				expect(callbacks.openFileTab).toHaveBeenCalledWith(
 					'session-1',
-					'/home/user/project/src/index.ts',
+					path.resolve(path.resolve('/home/user/project'), '/home/user/project/src/index.ts'),
 					true
 				);
 			});
@@ -842,7 +874,7 @@ describe('WebSocketMessageHandler', () => {
 			await vi.waitFor(() => {
 				expect(callbacks.openFileTab).toHaveBeenCalledWith(
 					'session-1',
-					'/home/user/project/src/index.ts',
+					path.resolve(path.resolve('/home/user/project'), '/home/user/project/src/index.ts'),
 					false
 				);
 			});
@@ -903,7 +935,11 @@ describe('WebSocketMessageHandler', () => {
 			});
 
 			await vi.waitFor(() => {
-				expect(callbacks.openFileTab).toHaveBeenCalledWith('session-1', '/home/etc/passwd', true);
+				expect(callbacks.openFileTab).toHaveBeenCalledWith(
+					'session-1',
+					path.resolve(path.resolve('/home/user/project'), '/home/user/project/../../etc/passwd'),
+					true
+				);
 			});
 
 			const response = JSON.parse((client.socket.send as any).mock.calls[0][0]);
@@ -1071,7 +1107,9 @@ describe('WebSocketMessageHandler', () => {
 			expect(callbacks.openTerminalTab).not.toHaveBeenCalled();
 		});
 
-		describe('symlink-safe cwd confinement', () => {
+		// Skipped where the OS forbids symlink creation (e.g. Windows without
+		// Developer Mode), since the `beforeEach` below calls `fs.symlinkSync`.
+		describe.skipIf(!canSymlink())('symlink-safe cwd confinement', () => {
 			let sessionRoot: string;
 			let outside: string;
 			const createdPaths: string[] = [];

--- a/src/__tests__/main/web-server/handlers/messageHandlers.test.ts
+++ b/src/__tests__/main/web-server/handlers/messageHandlers.test.ts
@@ -1155,7 +1155,10 @@ describe('WebSocketMessageHandler', () => {
 					expect(callbacks.openTerminalTab).toHaveBeenCalledWith(
 						'session-real',
 						expect.objectContaining({
-							cwd: fs.realpathSync(path.join(sessionRoot, 'sub')),
+							// realpathSync.native, not realpathSync: the product resolves via
+							// fs.promises.realpath (native), which expands Windows 8.3 short
+							// names (RUNNER~1 -> runneradmin); the JS realpathSync does not.
+							cwd: fs.realpathSync.native(path.join(sessionRoot, 'sub')),
 						})
 					);
 				});

--- a/src/__tests__/renderer/components/BatchRunnerModal.test.tsx
+++ b/src/__tests__/renderer/components/BatchRunnerModal.test.tsx
@@ -14,7 +14,10 @@ vi.mock('../../../renderer/hooks/batch/batchUtils', async () => {
 	);
 	return {
 		...actual,
-		DEFAULT_BATCH_PROMPT: content,
+		// Normalize CRLF -> LF: a Windows git checkout may give the fixture CRLF
+		// terminators, but the DOM `<textarea>` reflects its value with LF-only
+		// endings, so the comparison would otherwise mismatch. No-op on LF.
+		DEFAULT_BATCH_PROMPT: content.replace(/\r\n/g, '\n'),
 	};
 });
 

--- a/src/__tests__/shared/cli-server-discovery.test.ts
+++ b/src/__tests__/shared/cli-server-discovery.test.ts
@@ -209,7 +209,13 @@ describe('cli-server-discovery', () => {
 				readCliServerInfo();
 
 				expect(mockFs.readFileSync).toHaveBeenCalledWith(
-					path.join('/Users/testuser/Library/Application Support/maestro-dev', 'cli-server.json'),
+					// Product resolves MAESTRO_USER_DATA with path.resolve, which prepends the
+					// current drive letter on Windows; mirror that here so the expectation matches
+					// on Windows while remaining a no-op on POSIX.
+					path.join(
+						path.resolve('/Users/testuser/Library/Application Support/maestro-dev'),
+						'cli-server.json'
+					),
 					'utf-8'
 				);
 			} finally {

--- a/src/__tests__/shared/pathUtils.test.ts
+++ b/src/__tests__/shared/pathUtils.test.ts
@@ -233,12 +233,13 @@ describe('buildExpandedPath', () => {
 		});
 
 		it('should not duplicate paths already in PATH', () => {
-			process.env.PATH = '/opt/homebrew/bin:/usr/bin';
+			// Seed and split with `path.delimiter` (the same primitive the product
+			// uses). `path.delimiter` is a platform constant that does NOT follow
+			// the `process.platform` mock, so a literal ':' breaks on Windows.
+			process.env.PATH = ['/opt/homebrew/bin', '/usr/bin'].join(path.delimiter);
 			const result = buildExpandedPath();
 
-			// Use hardcoded ':' since this test models Unix behavior
-			// (path.delimiter is a compile-time constant that doesn't follow process.platform mocks)
-			const pathParts = result.split(':');
+			const pathParts = result.split(path.delimiter);
 			const homebrewCount = pathParts.filter((p) => p === '/opt/homebrew/bin').length;
 			expect(homebrewCount).toBe(1);
 		});
@@ -264,7 +265,7 @@ describe('buildExpandedPath', () => {
 
 			try {
 				const result = buildExpandedPath();
-				const pathParts = result.split(':');
+				const pathParts = result.split(path.delimiter);
 				const currentBin = path.join(tempNvmDir, 'current', 'bin');
 				const versionedBin = path.join(tempNvmDir, 'versions', 'node', 'v22.10.0', 'bin');
 

--- a/src/main/process-listeners/__tests__/stats-listener.test.ts
+++ b/src/main/process-listeners/__tests__/stats-listener.test.ts
@@ -117,46 +117,53 @@ describe('Stats Listener', () => {
 	});
 
 	it('should log error when recording fails after retries', async () => {
-		vi.mocked(mockStatsDB.insertQueryEvent).mockImplementation(() => {
-			throw new Error('Database error');
-		});
+		// Use fake timers so the exponential-backoff retry delays (100ms + 200ms)
+		// are advanced deterministically. Relying on real timers + vi.waitFor is
+		// brittle: the fire-and-forget retry loop can exceed the poll budget on
+		// slower/high-granularity-timer hosts (e.g. Windows), causing flakes.
+		vi.useFakeTimers();
+		try {
+			vi.mocked(mockStatsDB.insertQueryEvent).mockImplementation(() => {
+				throw new Error('Database error');
+			});
 
-		setupStatsListener(mockProcessManager, {
-			safeSend: mockSafeSend,
-			getStatsDB: () => mockStatsDB,
-			logger: mockLogger,
-		});
+			setupStatsListener(mockProcessManager, {
+				safeSend: mockSafeSend,
+				getStatsDB: () => mockStatsDB,
+				logger: mockLogger,
+			});
 
-		const handler = eventHandlers.get('query-complete');
-		const testQueryData: QueryCompleteData = {
-			sessionId: 'session-789',
-			agentType: 'opencode',
-			source: 'user',
-			startTime: Date.now(),
-			duration: 2000,
-			projectPath: '/test/project',
-			tabId: 'tab-789',
-		};
+			const handler = eventHandlers.get('query-complete');
+			const testQueryData: QueryCompleteData = {
+				sessionId: 'session-789',
+				agentType: 'opencode',
+				source: 'user',
+				startTime: Date.now(),
+				duration: 2000,
+				projectPath: '/test/project',
+				tabId: 'tab-789',
+			};
 
-		handler?.('session-789', testQueryData);
+			handler?.('session-789', testQueryData);
 
-		// Wait for all retries to complete (100ms + 200ms + final attempt)
-		await vi.waitFor(
-			() => {
-				expect(mockLogger.error).toHaveBeenCalledWith(
-					expect.stringContaining('Failed to record query event after 3 attempts'),
-					'[Stats]',
-					expect.objectContaining({
-						sessionId: 'session-789',
-					})
-				);
-			},
-			{ timeout: 1000 }
-		);
-		// Should have tried 3 times
-		expect(mockStatsDB.insertQueryEvent).toHaveBeenCalledTimes(3);
-		// Should not have broadcasted update on failure
-		expect(mockSafeSend).not.toHaveBeenCalled();
+			// Advance through both backoff delays (100ms then 200ms). The async
+			// variant flushes the microtasks the retry loop awaits between timers.
+			await vi.advanceTimersByTimeAsync(300);
+
+			expect(mockLogger.error).toHaveBeenCalledWith(
+				expect.stringContaining('Failed to record query event after 3 attempts'),
+				'[Stats]',
+				expect.objectContaining({
+					sessionId: 'session-789',
+				})
+			);
+			// Should have tried 3 times
+			expect(mockStatsDB.insertQueryEvent).toHaveBeenCalledTimes(3);
+			// Should not have broadcasted update on failure
+			expect(mockSafeSend).not.toHaveBeenCalled();
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 
 	it('should log debug info when recording succeeds', async () => {

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -16,6 +16,11 @@ const sharedExclude = [
 // (renderer/web UI, plus a handful that pull in a browser global transitively).
 // These stay on the jsdom project; everything else backend runs on the much
 // faster `node` environment (no jsdom setup cost).
+//
+// If a backend .ts test fails under the node project with something like
+// "ReferenceError: document/window is not defined", it needs a DOM: add its
+// path here (or move the DOM dependency behind a mock). Everything matched
+// here runs under jsdom and nowhere else - the node project excludes this list.
 const jsdomOnlyTs = [
 	'src/__tests__/renderer/**/*.{test,spec}.ts',
 	'src/__tests__/web/**/*.{test,spec}.ts',

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -58,8 +58,9 @@ export default defineConfig({
 				test: {
 					name: 'node',
 					environment: 'node',
+					// include matches .ts only, so .tsx files can never land here.
 					include: ['src/**/*.{test,spec}.ts'],
-					exclude: [...sharedExclude, ...jsdomOnlyTs, 'src/**/*.{test,spec}.tsx'],
+					exclude: [...sharedExclude, ...jsdomOnlyTs],
 				},
 			},
 		],

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -2,27 +2,67 @@ import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 import path from 'path';
 
+// Directories excluded from the default unit-test run (have their own configs).
+const sharedExclude = [
+	'node_modules',
+	'dist',
+	'release',
+	'src/__tests__/integration/**',
+	'src/__tests__/e2e/**',
+	'src/__tests__/performance/**',
+];
+
+// Test files that live under an otherwise node-only path but still require a DOM
+// (renderer/web UI, plus a handful that pull in a browser global transitively).
+// These stay on the jsdom project; everything else backend runs on the much
+// faster `node` environment (no jsdom setup cost).
+const jsdomOnlyTs = [
+	'src/__tests__/renderer/**/*.{test,spec}.ts',
+	'src/__tests__/web/**/*.{test,spec}.ts',
+	'src/renderer/**/*.{test,spec}.ts',
+	'src/__tests__/main/stats/integration.test.ts',
+];
+
 export default defineConfig({
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	plugins: [react() as any],
 	test: {
 		globals: true,
-		environment: 'jsdom',
+		// forks (not threads): suites mutate process.platform / process.env (shared
+		// under threads), and native addons loaded from multiple worker threads in
+		// one process can segfault the whole run.
 		pool: 'forks',
 		maxWorkers: 4,
 		setupFiles: ['./src/__tests__/setup.ts'],
-		include: ['src/**/*.{test,spec}.{ts,tsx}'],
-		exclude: [
-			'node_modules',
-			'dist',
-			'release',
-			'src/__tests__/integration/**',
-			'src/__tests__/e2e/**',
-			'src/__tests__/performance/**',
-		],
 		testTimeout: 10000,
 		hookTimeout: 10000,
 		teardownTimeout: 5000,
+		// Split into two projects so the ~360 backend suites skip the expensive
+		// jsdom environment and run under plain node (dramatically faster); only
+		// DOM-dependent suites pay for jsdom.
+		projects: [
+			{
+				extends: true,
+				test: {
+					name: 'jsdom',
+					environment: 'jsdom',
+					// NOTE: stays on the forks pool. threads is ~19% faster here but
+					// intermittently SEGFAULTS the run (native addons loaded from
+					// multiple worker threads in one process are not context-aware).
+					include: ['src/**/*.{test,spec}.tsx', ...jsdomOnlyTs],
+					exclude: sharedExclude,
+				},
+			},
+			{
+				extends: true,
+				test: {
+					name: 'node',
+					environment: 'node',
+					include: ['src/**/*.{test,spec}.ts'],
+					exclude: [...sharedExclude, ...jsdomOnlyTs, 'src/**/*.{test,spec}.tsx'],
+				},
+			},
+		],
 		coverage: {
 			provider: 'v8',
 			reporter: ['text', 'text-summary', 'json', 'html'],


### PR DESCRIPTION
## Summary

Makes Maestro fully usable on Windows - both running the dev app and the test suite - and roughly halves the suite's runtime. **No product/runtime source is modified**: the app was already cross-platform correct; the changes are the dev launcher, test files, vitest config, and CI.

Four logical parts (separate commits):

### 1. `fix(dev)` - `npm run dev` works on Windows
The cross-platform dev launcher failed on Windows two ways:
1. `scripts/dev.mjs` spawned `npm.cmd` without a shell, which Node >=22.12 refuses (post [CVE-2024-27980](https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2)), throwing `spawn EINVAL`.
2. `dev:main`, `dev:main:prod-data`, and `dev:prod-data` set env vars with Unix `VAR=value` prefix syntax that Windows `cmd` doesn't understand (the reason a separate `dev:win` / `start-dev.ps1` existed).

Fix: a small `spawnNpm()` helper that passes a shell command string on Windows (also avoiding the `DEP0190` args-with-shell warning), and the already-present `cross-env` for the env-prefixed scripts. **No new dependencies.**

### 2. `test` - the suite passes on Windows
94 tests failed on Windows (all green on macOS/Linux CI). Every failure was a **test-only** POSIX assumption - **zero product bugs**. Categories:
- **Path separators / drive letters**: mocks and expectations hardcoded `/`-paths; product uses `path.join`/`path.resolve` correctly. Fixed by routing expectations through the same `path.*` primitive and normalizing separators in mock predicates.
- **POSIX signals**: process-kill tests didn't neutralize `isWindows()`, so on Windows the product correctly took its `taskkill /t /f` path and the POSIX-signal assertions never fired. Fixed by forcing the POSIX branch in those unit tests (exactly what CI does on Unix). Maestro's Windows process-tree killing is already correct.
- **CRLF vs LF**: one test read a `.md` fixture raw; normalized `\r\n` to `\n`.
- **Windows symlink privilege**: two tests create real symlinks (`EPERM` without Developer Mode); now `skipIf` a `canSymlink()` probe, so they still run on Unix/CI.

Every change is platform-symmetric (no-op on macOS/Linux). A small `src/__tests__/helpers/pathExpect.ts` (`canonKey`/`asarNodePath`/`withPlatform`) keeps future tests cross-platform.

Also added: **4 new tests** covering the cue executors' Windows `taskkill /t /f` process-tree kill paths (`cue-process-lifecycle`, `cue-cli-executor`, `cue-shell-executor`) - these branches previously had no coverage on any platform. The platform mocks in those files are now per-test switchable (default POSIX, as CI exercises on Unix).

### 3. `perf(test)` - suite ~2x faster via node/jsdom split
The suite ran **every** file under `jsdom` (`vitest.config.mts`), but ~360 backend suites (`main`/`cli`/`shared`/`maestro-p`) don't need a DOM and were paying the (dominant) jsdom environment-setup cost. Split into two vitest projects: a `node` project for backend and a `jsdom` project for renderer/web. Backend suites that transitively need a DOM are pinned back to jsdom by an explicit, minimal glob list (just one file plus the renderer/web dirs). The include globs cover `*.spec.*` as well as `*.test.*` so nothing is dropped.

Measured on the same Windows machine, same `maxWorkers: 4`:
- **Full suite: ~18.5 min before, ~9.3 min after** (summed jsdom environment setup 3011s to 735s, imports 1766s to 649s)
- **Backend only** (`npx vitest run --project node`): **~45s** - the day-to-day loop for main/cli/shared work
- No pool/isolation/worker changes: same forks pool, same worker count, full per-file isolation retained. (`threads` for the jsdom project was evaluated: ~19% faster but it intermittently segfaults - native addons loaded from multiple worker threads are not context-aware - so it was rejected; a comment in the config records this so it isn't re-attempted.)

### 4. `ci` - run the test suite on Windows
The `test` job becomes a two-OS matrix (`ubuntu-latest`, `windows-latest`, `fail-fast: false`). Without it, the 94 fixed tests will regress silently - they were only ever green because CI never ran them on Windows. The release workflow already builds on `windows-latest` (including the native-module rebuild), so the toolchain is proven on runners. If the extra CI minutes aren't wanted, this commit can be dropped without affecting the rest.

## Verification

- [x] `npm run lint` passes
- [x] `npm run lint:eslint` passes (includes all modified test files)
- [x] `npx prettier --check` clean on all changed files (as committed, LF)
- [x] Full suite green on **Windows 11 / Node 24**: 31,331 passed / 0 failed (was 94 failed), all 1,080 test files run, in 9m17s (was ~18.5 min)
- [x] Manually ran `npm run dev` on Windows - renderer + Electron boot cleanly, no `EINVAL`, no `DEP0190`
- [x] No new dependencies, no product/runtime source modified
- [x] Conventional commits

## Branch note

Targets `rc` per maintainer guidance. The dev-launcher and test issues exist identically on `main` (`scripts/dev.mjs` is byte-identical between the branches and the `dev:*` scripts match), so a cherry-pick to `main` is clean if wanted.

## Out of scope / possible follow-ups

- `dev:win` / `start-dev.ps1` could be retired now, but left in place to keep this minimal.
- The repo has no `.gitattributes`; adding one with `eol=lf` would prevent CRLF-on-checkout issues at the source (the one affected test now normalizes itself). Left out to avoid a repo-wide line-ending diff.
- Worker parallelism left at the original `maxWorkers: 4`; the speedup comes from the split, not from cranking concurrency. CI could raise it.
- The `integration` (7 files) and `e2e` (2 files) suites are excluded from `npm test` and not run by any workflow; they may be rotting silently.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multi-platform CI test execution (Windows + Ubuntu) for improved cross-platform reliability.
  * Introduced a dedicated demo runner that sets up a temporary demo workspace automatically.
* **Bug Fixes**
  * Improved Electron dev command behavior with consistent environment-variable handling.
  * Fixed Windows process shutdown to reliably terminate full process trees.
* **Tests**
  * Strengthened cross-platform test stability with OS-aware path handling and deterministic timing.
  * Updated the test runner setup to better separate `jsdom` vs node-based tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->