### PR TITLE
fix(test): clear persisted history filters between tests (fix rc-red history suites)

### DIFF
--- a/src/__tests__/renderer/components/DirectorNotes/UnifiedHistoryTab.test.tsx
+++ b/src/__tests__/renderer/components/DirectorNotes/UnifiedHistoryTab.test.tsx
@@ -280,6 +280,10 @@ const createPaginatedResponse = (entries: any[], hasMore = false, total?: number
 });
 
 beforeEach(() => {
+	// Clear persisted history filters (localStorage) between tests so a filter
+	// toggle in one test can't leak a restrictive selection (UNIFIED_HISTORY_FILTERS_KEY)
+	// into later tests, which would hide entries and fail their assertions.
+	localStorage.clear();
 	mockDirNotesSettings.defaultLookbackDays = 7;
 	(window as any).maestro = {
 		directorNotes: {

--- a/src/__tests__/renderer/components/HistoryPanel.test.tsx
+++ b/src/__tests__/renderer/components/HistoryPanel.test.tsx
@@ -137,6 +137,12 @@ describe('HistoryPanel', () => {
 	beforeEach(() => {
 		vi.useFakeTimers({ shouldAdvanceTime: true });
 
+		// Clear persisted history filters (localStorage) between tests. Filter
+		// toggles persist under HISTORY_PANEL_FILTERS_KEY; without this, a test
+		// that deselects a type leaks the restrictive filter into every later
+		// test, hiding their entries and failing all entry-render assertions.
+		localStorage.clear();
+
 		// Reset uiStore state used by HistoryPanel
 		useUIStore.setState({ historySearchFilterOpen: false });
 


### PR DESCRIPTION
## Problem

`test` CI has been red on `rc` (both runners) with **51 failures** across two files:
- `src/__tests__/renderer/components/HistoryPanel.test.tsx` (~49)
- `src/__tests__/renderer/components/DirectorNotes/UnifiedHistoryTab.test.tsx` (2)

All failures were `waitFor(() => getByText(<entry text>))` timeouts — entries never rendered.

## Root cause

Test-isolation leak, not a product bug. Both `HistoryPanel` and the Director's Notes Unified History persist the source-type filter (USER/AUTO/CUE) to `localStorage` (`historyPanel.filters` / `directorNotes.historyFilters`) via `savePersistedHistoryFilters`, and rehydrate it on mount via `resolveInitialHistoryFilters`.

The suites toggle filters off in some tests but never cleared `localStorage` in `beforeEach`. jsdom's `localStorage` is shared across tests in a file, so once a test deselected a type, `resolveInitialHistoryFilters` restored that restrictive set for every subsequent test — entries of the hidden type never rendered, and all downstream entry-render assertions timed out. (Each test passed in isolation, which is why this only surfaced in full runs.)

## Fix

Clear `localStorage` in each suite's `beforeEach` so filter state can't leak between tests. Test-only change (+10 lines, no product code touched).

## Verification

- `HistoryPanel.test.tsx`: **72/72 pass** (was 49 failing)
- `UnifiedHistoryTab.test.tsx`: **35/35 pass** (was 2 failing)
- Combined: **107 passed, exit 0**
- Prettier + ESLint clean on both files

Platform-independent (localStorage leak), so it fixes the same failures on the Windows runner as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by resetting saved filter state before each test run.
  * Prevented leftover browser storage from affecting later test cases and causing inconsistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->