### PR TITLE
fix(cue): keep task.pending scanner running while the window is hidden (#1164)

### DIFF
--- a/src/__tests__/main/cue/triggers/cue-task-scanner-trigger-source.test.ts
+++ b/src/__tests__/main/cue/triggers/cue-task-scanner-trigger-source.test.ts
@@ -99,6 +99,26 @@ describe('cue-task-scanner-trigger-source', () => {
 		source.stop();
 	});
 
+	it('start() does NOT pass an isActive visibility gate (task.pending must scan while hidden)', () => {
+		// Regression guard for #1164: task.pending is the unattended-automation
+		// case, so it must keep scanning while the window is hidden. Unlike the
+		// file.changed / github.* sources, it must not forward isCueActive.
+		const source = createCueTaskScannerTriggerSource({
+			session: makeSession(),
+			subscription: makeSub(),
+			registry: createCueSessionRegistry(),
+			enabled: () => true,
+			onLog: vi.fn(),
+			emit: vi.fn(),
+		})!;
+
+		source.start();
+		const config = mockCreateCueTaskScanner.mock.calls[0][0] as { isActive?: () => boolean };
+		expect(config.isActive).toBeUndefined();
+
+		source.stop();
+	});
+
 	it('start() defaults pollMinutes to 1 when subscription does not specify', () => {
 		const source = createCueTaskScannerTriggerSource({
 			session: makeSession(),

--- a/src/main/cue/triggers/cue-task-scanner-trigger-source.ts
+++ b/src/main/cue/triggers/cue-task-scanner-trigger-source.ts
@@ -4,9 +4,16 @@
  * Thin wrapper around `createCueTaskScanner` that adapts its callback shape
  * to the {@link CueTriggerSource} interface and routes events through the
  * centralized `passesFilter` helper before emitting.
+ *
+ * Unlike the `file.changed` and `github.*` sources, the task scanner is
+ * intentionally NOT gated on the Cue visibility flag (`isCueActive`). A
+ * `task.pending` subscription is the unattended-automation case the feature
+ * exists for: the app window is usually backgrounded while a queue drains, so
+ * pausing the scan while hidden stalls exactly the workflow the user wants
+ * running. The scan itself is a cheap 1-minute poll of a single glob, so the
+ * CPU cost of keeping it live while hidden is negligible. See issue #1164.
  */
 
-import { isCueActive } from '../cue-active-state';
 import { createCueTaskScanner } from '../cue-task-scanner';
 import { passesFilter } from './cue-trigger-filter';
 import type { CueTriggerSource, CueTriggerSourceContext } from './cue-trigger-source';
@@ -30,7 +37,8 @@ export function createCueTaskScannerTriggerSource(
 				projectRoot: ctx.session.projectRoot,
 				triggerName: ctx.subscription.name,
 				onLog: (level, message) => ctx.onLog(level as Parameters<typeof ctx.onLog>[0], message),
-				isActive: isCueActive,
+				// Deliberately no `isActive` gate (see the file header): task.pending
+				// must keep scanning while the window is hidden.
 				onEvent: (event) => {
 					if (!ctx.enabled()) return;
 					if (!passesFilter(ctx.subscription, event, ctx.onLog)) return;
@@ -53,7 +61,7 @@ export function createCueTaskScannerTriggerSource(
 
 		nextTriggerAt() {
 			// Task scanners poll on a fixed interval but the next *fire* depends
-			// on whether any matching files have pending tasks — not predictable.
+			// on whether any matching files have pending tasks (not predictable).
 			return null;
 		},
 	};


### PR DESCRIPTION
Closes #1164

## Problem

`task.pending` scanning was gated on the Cue visibility flag (`isCueActive`),
which the renderer drives from `document.hidden`. The task-scanner trigger
source forwarded that flag into `createCueTaskScanner`
(`isActive: isCueActive`), and the scanner early-returns its entire tick when
the flag is false (`if (!isActive()) return;`).

The result: whenever the Maestro window is minimized / occluded / on another
Space, the `task.pending` scanner does no file walk and fires nothing. On a
machine that runs Cue unattended (window backgrounded most of the time), the
research/task queue is paused most of the time. Bringing the window to the
foreground flips `setCueActive(true)` and the scanner resumes within one poll
interval, which is the "opening the Cue window makes it run" behavior reported
in the issue.

This is the primary root cause identified in #1164. It is distinct from #1151 /
#1152, which fixed only the manual-trigger empty-payload path.

## Fix

Stop forwarding the visibility gate for `task.pending`. The scanner's
`isActive` param already defaults to always-active when omitted, so dropping
`isActive: isCueActive` from `cue-task-scanner-trigger-source.ts` restores
unattended behavior. This is the highest-leverage change the reporter suggested.

`file.changed` and `github.*` stay gated: their CPU cost (directory walks, `gh`
CLI fetches) is real and they are not the unattended-automation case. The task
scanner is a cheap 1-minute poll of a single glob, so keeping it live while
hidden is negligible.

The generic `isActive` capability on `createCueTaskScanner` is left intact (it
is shared infra with the github/file-watcher scanners and has its own direct
tests); only the task trigger source opts out.

## Scope

This addresses the **primary** root cause (the visibility gate). The secondary
issues the reporter also raised (in-memory hash reset seeding-without-firing on
reload, whole-file-hash fire keying, and reconciler not covering `task.pending`
after wake) are larger, separate changes (persisting per-file hashes to
`cue.db`, changing the fire-key model) and are intentionally out of scope here
so this stays a surgical, low-risk fix.

## Testing

- Added a regression test in `cue-task-scanner-trigger-source.test.ts` asserting
  the task source passes **no** `isActive` gate to the scanner.
- `npx vitest run src/__tests__/main/cue/triggers/cue-task-scanner-trigger-source.test.ts src/__tests__/main/cue/cue-task-scanner.test.ts` -> 30 passed.
- `npx tsc -p tsconfig.main.json --noEmit` clean; ESLint clean on the changed source file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task scanning so pending cue tasks continue to be detected even when the app window is hidden.
  * Removed an unintended visibility gate from the scanner configuration.
  * Added a regression test to confirm the scanner remains active as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->