### PR TITLE
fix(test): make CLI path assertions OS-agnostic (fix last Windows-red tests)

### DIFF
--- a/src/__tests__/cli/commands/profiling.test.ts
+++ b/src/__tests__/cli/commands/profiling.test.ts
@@ -4,6 +4,8 @@
  */
 
 import { describe, it, expect, vi, beforeEach, type MockInstance } from 'vitest';
+import path from 'path';
+import os from 'os';
 
 vi.mock('../../../cli/services/maestro-client', () => ({ withMaestroClient: vi.fn() }));
 
@@ -69,8 +71,8 @@ describe('profiling commands', () => {
 			expect(cap.payload?.type).toBe('profiling_stop');
 			expect(cap.responseType).toBe('profiling_stop_result');
 			const outputPath = cap.payload?.outputPath as string;
-			expect(outputPath.startsWith('/')).toBe(true);
-			expect(outputPath.endsWith('/sub/out.zip')).toBe(true);
+			expect(path.isAbsolute(outputPath)).toBe(true);
+			expect(outputPath.endsWith(path.join('sub', 'out.zip'))).toBe(true);
 			// Compression is slow; the command must raise the default 10s timeout.
 			expect(cap.timeout ?? 0).toBeGreaterThan(60_000);
 		});
@@ -79,7 +81,7 @@ describe('profiling commands', () => {
 			const cap = mockSend({ success: true, path: '/x.zip' });
 			await profilingStop({ output: '~/Desktop/p.zip' });
 			const outputPath = cap.payload?.outputPath as string;
-			expect(outputPath).toBe(`${process.env.HOME}/Desktop/p.zip`);
+			expect(outputPath).toBe(path.join(os.homedir(), 'Desktop', 'p.zip'));
 		});
 
 		it('exits non-zero when the app reports failure', async () => {

--- a/src/__tests__/main/agents/claudeSpawnCore.test.ts
+++ b/src/__tests__/main/agents/claudeSpawnCore.test.ts
@@ -9,6 +9,8 @@
  */
 
 import { describe, it, expect } from 'vitest';
+import path from 'path';
+import os from 'os';
 import {
 	resolveClaudeSpawnModeCore,
 	isMaestroPBinaryPath,
@@ -59,8 +61,9 @@ describe('isMaestroPBinaryPath', () => {
 
 describe('resolveConfigDirKeyFromEnv', () => {
 	it('uses CLAUDE_CONFIG_DIR when set (resolved to absolute)', () => {
-		const key = resolveConfigDirKeyFromEnv({ CLAUDE_CONFIG_DIR: '/home/u/.claude' });
-		expect(key).toBe('/home/u/.claude');
+		const configDir = path.join(os.tmpdir(), '.claude-test');
+		const key = resolveConfigDirKeyFromEnv({ CLAUDE_CONFIG_DIR: configDir });
+		expect(key).toBe(path.resolve(configDir));
 	});
 
 	it('falls back to ~/.claude when unset', () => {


### PR DESCRIPTION
## Problem

`test (windows-latest)` was the only remaining red CI job on `rc`, failing **3 tests** in 2 files:
- `cli/commands/profiling.test.ts` (2): "resolves a relative output path to absolute", "expands a leading ~ to the home directory"
- `main/agents/claudeSpawnCore.test.ts` (1): "uses CLAUDE_CONFIG_DIR when set (resolved to absolute)"

## Root cause

Test-side POSIX assumptions, not product bugs. The production code (`resolveOutputPath`, `resolveConfigDirKeyFromEnv`) correctly uses `path.resolve`/`path.join`/`os.homedir()` and emits **native** paths. The tests hardcoded POSIX shapes:
- `outputPath.startsWith('/')` — false on Windows (`C:\…`)
- `outputPath.endsWith('/sub/out.zip')` — Windows uses `\`
- `` `${process.env.HOME}/Desktop/p.zip` `` — `HOME` unset on Windows; code uses `os.homedir()`
- expecting `'/home/u/.claude'` verbatim — Windows resolves a drive-relative `/home/u/.claude` to `D:\home\u\.claude`

## Fix

Assert behavior with the platform-aware `path` API instead of literal separators:
- `path.isAbsolute(outputPath)` and `outputPath.endsWith(path.join('sub', 'out.zip'))`
- `path.join(os.homedir(), 'Desktop', 'p.zip')`
- native absolute fixture `path.join(os.tmpdir(), '.claude-test')`, expect `path.resolve(configDir)`

Test-only change (+10/-5). No product code touched.

## Verification

Verified on **Windows** (the failing platform): `profiling.test.ts` + `claudeSpawnCore.test.ts` → **18/18 pass, exit 0**. OS-agnostic by construction, so they pass on Linux/macOS too. Prettier clean.

With this, all rc `test` failures on both runners are resolved (history suites fixed in #1163; these were the last Windows-only reds).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved path handling in CLI and configuration-related workflows so relative paths and home-directory shortcuts resolve consistently across platforms.
  * Updated path validation to better support absolute path checks and platform-specific path separators, reducing environment-specific test failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->