### PR TITLE
docs: require OS-agnostic path assertions + CI-matrix-green merge gate

### DIFF
--- a/CLAUDE-PLATFORM.md
+++ b/CLAUDE-PLATFORM.md
@@ -224,6 +224,8 @@ When making changes that involve any of the above areas, verify:
 - [ ] No hardcoded path separators (`/` or `\`)
 - [ ] Shell commands use platform-appropriate lookup (`which`/`where`)
 - [ ] Agent-specific code handles all supported agents, not just Claude
+- [ ] Path assertions in tests use the `path`/`os` API (`path.isAbsolute`, `path.join`, `path.resolve`, `os.homedir`, `os.tmpdir`), never literal `/`, `\`, or `process.env.HOME`
+- [ ] Both CI matrix legs (`test (ubuntu-latest)` and `test (windows-latest)`) are green before merge; a local single-OS run is not sufficient
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,8 @@ After refactoring: identify now-unreachable code, list it explicitly, ask "Shoul
 
 Before pushing any branch, re-run the relevant formatting, lint, type-check, and test commands for the changes you made. Fix any issues those commands surface, include the fixes in the branch, and only then push or update the PR.
 
+Local validation runs on a single OS and cannot catch platform-specific breakage (path separators, home directories, drive letters). A branch is not mergeable until both CI matrix legs, `test (ubuntu-latest)` and `test (windows-latest)`, are green; never merge on a local single-OS pass alone.
+
 ---
 
 ## Standardized Vernacular

--- a/docs/agent-guides/TEST-PATTERNS.md
+++ b/docs/agent-guides/TEST-PATTERNS.md
@@ -223,6 +223,32 @@ vi.mocked(window.maestro.settings.get).mockResolvedValue('custom-value');
 
 ---
 
+## Cross-Platform Path Assertions
+
+Tests run on the CI matrix (Linux + Windows), so any assertion about a filesystem path must be OS-agnostic. Production code emits native paths via `path.join`, `path.resolve`, and `os.homedir()`, which differ per platform (`/a/b` vs `C:\a\b`), and `os.homedir()` is not `process.env.HOME` on Windows.
+
+```typescript
+// WRONG - POSIX-only; passes on the Linux leg, fails on the Windows leg
+expect(outputPath.startsWith('/')).toBe(true);
+expect(outputPath.endsWith('/sub/out.zip')).toBe(true);
+expect(outputPath).toBe(`${process.env.HOME}/Desktop/p.zip`);
+expect(key).toBe('/home/u/.claude');
+
+// CORRECT - assert the behavior through the path/os API
+import path from 'path';
+import os from 'os';
+expect(path.isAbsolute(outputPath)).toBe(true);
+expect(outputPath.endsWith(path.join('sub', 'out.zip'))).toBe(true);
+expect(outputPath).toBe(path.join(os.homedir(), 'Desktop', 'p.zip'));
+const configDir = path.join(os.tmpdir(), '.claude-test'); // native absolute fixture
+const key = resolveConfigDirKeyFromEnv({ CLAUDE_CONFIG_DIR: configDir });
+expect(key).toBe(path.resolve(configDir));
+```
+
+Never hardcode `/`, `\`, or `process.env.HOME` in path assertions or path fixtures. Use `path.isAbsolute`, `path.join`, `path.resolve`, `os.homedir()`, and `os.tmpdir()` so the test verifies identical behavior on every OS.
+
+---
+
 ## Common Mock Patterns
 
 ### Mocking Zustand Stores


### PR DESCRIPTION
## Why

The recent Windows-only rc test failures (`startsWith('/')`, `process.env.HOME`, hardcoded `/home/u/.claude`) slipped through because the existing cross-platform guidance is (a) aimed at production code path handling, (b) a **conditional** checklist ("when making changes that involve any of the above areas"), and (c) pre-push validation is single-OS. Nothing required **test assertions** to be OS-agnostic, and nothing framed the CI matrix as a merge gate. TEST-PATTERNS.md even models POSIX/darwin fixtures, nudging the wrong way.

## Changes (docs only, +30 lines)

- **CLAUDE.md → "Validate Before Push"**: add that local validation is single-OS and a branch is not mergeable until **both** CI matrix legs (`test (ubuntu-latest)` + `test (windows-latest)`) are green.
- **CLAUDE-PLATFORM.md → Testing Checklist**: two new items — path assertions in tests must use the `path`/`os` API (never literal `/`, `\`, `process.env.HOME`), and both CI matrix legs green before merge.
- **docs/agent-guides/TEST-PATTERNS.md**: new "Cross-Platform Path Assertions" section with a WRONG/CORRECT example (`path.isAbsolute`/`path.join`/`path.resolve`/`os.homedir`/`os.tmpdir`).

No code changes. Prettier clean; no em/en-dashes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified testing guidance to require OS-agnostic path assertions in checks.
  * Added examples showing recommended cross-platform path validation approaches.
  * Reinforced that both Ubuntu and Windows CI runs must pass before merging.
  * Updated validation guidance to avoid relying on a single local platform run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->