### PR TITLE
fix(web-desktop): resolve senderless window IPC to the primary window

### DIFF
--- a/src/__tests__/main/ipc/handlers/windows.test.ts
+++ b/src/__tests__/main/ipc/handlers/windows.test.ts
@@ -427,6 +427,38 @@ describe('Windows IPC Handlers', () => {
 			expect(result.registered).toBe(true);
 			expect(registry.get(primaryId)?.sessionIds).toEqual(['agent-web']);
 		});
+
+		it('windows:setPanelState writes to the primary window on a senderless invoke', async () => {
+			registry.create({ browserWindow: makeFakeWindow(), sessionIds: ['b'], isMain: false });
+			const primaryId = registry.create({
+				browserWindow: makeFakeWindow(),
+				sessionIds: ['a'],
+				isMain: true,
+			});
+
+			await handlers.get('windows:setPanelState')!(bridgeEvent, {
+				leftPanelCollapsed: true,
+				rightPanelCollapsed: true,
+			});
+
+			expect(BrowserWindow.fromWebContents).not.toHaveBeenCalled();
+			const state = registry.get(primaryId);
+			expect(state?.leftPanelCollapsed).toBe(true);
+			expect(state?.rightPanelCollapsed).toBe(true);
+		});
+
+		it('windows:getBounds resolves a senderless invoke to the primary window', async () => {
+			registry.create({ browserWindow: makeFakeWindow(), sessionIds: ['b'], isMain: false });
+			const primaryWin = makeFakeWindow({
+				getBounds: vi.fn(() => ({ x: 5, y: 6, width: 1280, height: 800 })),
+			});
+			registry.create({ browserWindow: primaryWin, sessionIds: ['a'], isMain: true });
+
+			const result = await handlers.get('windows:getBounds')!(bridgeEvent);
+
+			expect(BrowserWindow.fromWebContents).not.toHaveBeenCalled();
+			expect(result).toEqual({ x: 5, y: 6, width: 1280, height: 800 });
+		});
 	});
 
 	describe('windows:registerSession', () => {

--- a/src/__tests__/main/ipc/handlers/windows.test.ts
+++ b/src/__tests__/main/ipc/handlers/windows.test.ts
@@ -370,6 +370,65 @@ describe('Windows IPC Handlers', () => {
 		});
 	});
 
+	describe('web-desktop bridge (senderless event)', () => {
+		// The web-desktop WS bridge dispatches ipcMain handlers with a synthetic
+		// event that has no `sender` (bridgeHandlers.ts FAKE_EVENT). Passing an
+		// undefined webContents to BrowserWindow.fromWebContents throws
+		// "Cannot read properties of undefined (reading 'getOwnerBrowserWindow')",
+		// which crashed WindowContext's boot hydrate() and broke the whole page.
+		// A senderless invoke must resolve to the primary window instead.
+		const bridgeEvent = {} as unknown as Electron.IpcMainInvokeEvent;
+
+		it('windows:getState resolves a senderless invoke to the primary window', async () => {
+			const secondary = makeFakeWindow();
+			const primaryWin = makeFakeWindow({
+				getBounds: vi.fn(() => ({ x: 1, y: 2, width: 1000, height: 700 })),
+			});
+			registry.create({ browserWindow: secondary, sessionIds: ['b'], isMain: false });
+			const primaryId = registry.create({
+				browserWindow: primaryWin,
+				sessionIds: ['a'],
+				isMain: true,
+			});
+
+			const result = (await handlers.get('windows:getState')!(bridgeEvent)) as {
+				id: string;
+				sessionIds: string[];
+			} | null;
+
+			// fromWebContents must never be called for a senderless invoke - calling
+			// it with undefined is exactly the crash we are guarding against.
+			expect(BrowserWindow.fromWebContents).not.toHaveBeenCalled();
+			expect(result).not.toBeNull();
+			expect(result!.id).toBe(primaryId);
+			expect(result!.sessionIds).toEqual(['a']);
+		});
+
+		it('windows:getState returns null when no primary window is registered', async () => {
+			registry.create({ browserWindow: makeFakeWindow(), sessionIds: [], isMain: false });
+
+			const result = await handlers.get('windows:getState')!(bridgeEvent);
+
+			expect(result).toBeNull();
+		});
+
+		it('windows:registerSession claims the agent into the primary window', async () => {
+			const primaryWin = makeFakeWindow();
+			const primaryId = registry.create({
+				browserWindow: primaryWin,
+				sessionIds: [],
+				isMain: true,
+			});
+
+			const result = (await handlers.get('windows:registerSession')!(bridgeEvent, 'agent-web')) as {
+				registered: boolean;
+			};
+
+			expect(result.registered).toBe(true);
+			expect(registry.get(primaryId)?.sessionIds).toEqual(['agent-web']);
+		});
+	});
+
 	describe('windows:registerSession', () => {
 		it('claims a new agent for the calling window resolved from event.sender', async () => {
 			const win = makeFakeWindow();

--- a/src/main/ipc/handlers/windows.ts
+++ b/src/main/ipc/handlers/windows.ts
@@ -77,6 +77,12 @@ function resolveCallingWindow(
 	event: Electron.IpcMainInvokeEvent,
 	registry: WindowRegistry
 ): RegisteredWindow | undefined {
+	// The web-desktop bridge dispatches ipcMain handlers with a synthetic event
+	// that has no `sender` (see web-server/handlers/bridgeHandlers.ts FAKE_EVENT).
+	// Electron implements BrowserWindow.fromWebContents(wc) as wc.getOwnerBrowserWindow(),
+	// which throws on an undefined webContents. A browser client remote-controls the
+	// desktop's primary window, so resolve a senderless invoke to it rather than crash.
+	if (!event.sender) return registry.getPrimary();
 	const browserWindow = BrowserWindow.fromWebContents(event.sender);
 	if (!browserWindow) return undefined;
 	return registry.getAll().find((entry) => entry.browserWindow === browserWindow);


### PR DESCRIPTION
## Problem

Loading the web-desktop interface (0.18.4-RC) fails immediately with:

```
Maestro web-desktop failed to load
Error: Cannot read properties of undefined (reading 'getOwnerBrowserWindow')
    at WebSocket.<anonymous> (.../desktop/assets/preload-*.js)
```

The on-screen hint blames the network ("different Wi-Fi network... device-to-device traffic"), but it is not a networking problem - it is a server-side IPC crash relayed to the browser over the WS bridge.

## Root cause

`resolveCallingWindow` in `src/main/ipc/handlers/windows.ts` (added in 0.18.4) does:

```ts
const browserWindow = BrowserWindow.fromWebContents(event.sender);
```

Electron implements `BrowserWindow.fromWebContents(wc)` as `wc.getOwnerBrowserWindow()`. The web-desktop WS bridge dispatches every `ipcMain` handler with a synthetic event that has **no `sender`** (`FAKE_EVENT` in `src/main/web-server/handlers/bridgeHandlers.ts` only sets `senderFrame`/`frameId`/`processId`/`type`). Passing `undefined` throws `Cannot read properties of undefined (reading 'getOwnerBrowserWindow')`.

`WindowContext.tsx` calls `window.maestro.windows.getState()` during its boot `hydrate()`, so the throw fires on first load and the whole page fails.

## Fix

Resolve a senderless invoke to the registry's primary window (`registry.getPrimary()`, already present) - a browser client remote-controls the desktop's main window - instead of calling `fromWebContents(undefined)`. This also fixes the sibling handlers sharing the helper: `windows:registerSession`, `windows:setPanelState`, `windows:getBounds`.

```ts
if (!event.sender) return registry.getPrimary();
```

## Tests

Added a `web-desktop bridge (senderless event)` block to `windows.test.ts`:
- `windows:getState` resolves a senderless invoke to the primary window (and asserts `fromWebContents` is never called with undefined)
- returns `null` when no primary window is registered
- `windows:registerSession` claims the agent into the primary window

Scoped suite: 49/49 passing. Prettier clean; changed files type-check clean.

## Scope note

Other bridge-invoked handlers also assume a real `event.sender` (`browser-session.ts` `getType()`, `filesystem.ts` `startDrag()`, the consent check in `index.ts`). Those aren't hit at boot, so they don't cause this crash, but the class is latent. A broader fix would give the bridge's `FAKE_EVENT` a real `sender` (the primary window's `webContents`) to harden all of them at once - deferred here because it changes the trust semantics of the consent handler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved window-related IPC handlers to work when invoke events arrive without a sender, preventing crashes.
  * Updated state, session registration, panel state, and bounds lookups to correctly fall back to the primary window in this senderless scenario.

* **Tests**
  * Added a new test suite covering senderless event handling, including primary-window resolution, null behavior when no primary window exists, and session registration/state persistence updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->