### PR TITLE
fix(input-area): auto-scroll compact prompt editor to caret while typing (#1169)

### DIFF
--- a/src/__tests__/renderer/components/InputArea/hooks/useInputAreaTextChange.test.tsx
+++ b/src/__tests__/renderer/components/InputArea/hooks/useInputAreaTextChange.test.tsx
@@ -91,4 +91,22 @@ describe('useInputAreaTextChange', () => {
 
 		expect(handlers.setAtMentionOpen).not.toHaveBeenCalled();
 	});
+
+	it('scrolls the textarea to the caret after the keystroke resize (issue #1169)', () => {
+		const handlers = createHandlers();
+		const rafSpy = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+			cb(0);
+			return 0;
+		});
+		render(<Harness handlers={handlers} />);
+		const textarea = screen.getByLabelText('input') as HTMLTextAreaElement;
+		Object.defineProperty(textarea, 'scrollHeight', { value: 400, configurable: true });
+
+		fireEvent.change(textarea, {
+			target: { value: 'a'.repeat(500), selectionStart: 500, selectionEnd: 500 },
+		});
+
+		expect(textarea.scrollTop).toBe(400);
+		rafSpy.mockRestore();
+	});
 });

--- a/src/__tests__/renderer/components/InputArea/utils/textareaSizing.test.ts
+++ b/src/__tests__/renderer/components/InputArea/utils/textareaSizing.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
 	resizeTextareaToContent,
+	scrollTextareaToCaretEnd,
 	shouldScrollTextareaToEnd,
 } from '../../../../../renderer/components/InputArea/utils/textareaSizing';
 
@@ -33,5 +34,27 @@ describe('InputArea textareaSizing utils', () => {
 
 	it('does not scroll normal mid-text typing', () => {
 		expect(shouldScrollTextareaToEnd(2, 5, 6)).toBe(false);
+	});
+
+	it('scrolls to the bottom when the caret is at the end (issue #1169)', () => {
+		const textarea = document.createElement('textarea');
+		textarea.value = 'a'.repeat(500);
+		Object.defineProperty(textarea, 'scrollHeight', { value: 400, configurable: true });
+		Object.defineProperty(textarea, 'selectionEnd', { value: 500, configurable: true });
+
+		scrollTextareaToCaretEnd(textarea);
+
+		expect(textarea.scrollTop).toBe(400);
+	});
+
+	it('leaves the scroll position untouched when the caret is mid-text', () => {
+		const textarea = document.createElement('textarea');
+		textarea.value = 'a'.repeat(500);
+		Object.defineProperty(textarea, 'scrollHeight', { value: 400, configurable: true });
+		Object.defineProperty(textarea, 'selectionEnd', { value: 10, configurable: true });
+
+		scrollTextareaToCaretEnd(textarea);
+
+		expect(textarea.scrollTop).toBe(0);
 	});
 });

--- a/src/renderer/components/InputArea/hooks/useInputAreaTextChange.ts
+++ b/src/renderer/components/InputArea/hooks/useInputAreaTextChange.ts
@@ -1,6 +1,10 @@
 import { startTransition, useCallback } from 'react';
 import type React from 'react';
-import { KEYSTROKE_TEXTAREA_MAX_HEIGHT, resizeTextareaToContent } from '../utils/textareaSizing';
+import {
+	KEYSTROKE_TEXTAREA_MAX_HEIGHT,
+	resizeTextareaToContent,
+	scrollTextareaToCaretEnd,
+} from '../utils/textareaSizing';
 import { getAtMentionTrigger, shouldOpenSlashCommand } from '../utils/inputTriggers';
 
 interface UseInputAreaTextChangeArgs {
@@ -77,6 +81,10 @@ export function useInputAreaTextChange({
 			keystrokeResizeScheduledRef.current = true;
 			requestAnimationFrame(() => {
 				resizeTextareaToContent(textarea, KEYSTROKE_TEXTAREA_MAX_HEIGHT);
+				// resizeTextareaToContent resets scrollTop (via height:'auto'), so the
+				// keystroke path must re-scroll to the caret or newly typed text past the
+				// max height stays hidden until the user adds line breaks (issue #1169).
+				scrollTextareaToCaretEnd(textarea);
 				keystrokeResizeScheduledRef.current = false;
 			});
 		},

--- a/src/renderer/components/InputArea/utils/textareaSizing.ts
+++ b/src/renderer/components/InputArea/utils/textareaSizing.ts
@@ -6,6 +6,20 @@ export function resizeTextareaToContent(textarea: HTMLTextAreaElement, maxHeight
 	textarea.style.height = `${Math.min(textarea.scrollHeight, maxHeight)}px`;
 }
 
+/**
+ * Keep the caret visible after a keystroke resize. resizeTextareaToContent sets
+ * height:'auto' first, which resets the textarea's scrollTop, so once the box hits
+ * its max height and scrolls internally the freshly typed text at the end would
+ * otherwise fall out of view. Snap the scroll to the bottom when the caret sits at
+ * the end of the content (the continuous-typing case); leave it untouched for
+ * mid-text edits so the viewport does not jump.
+ */
+export function scrollTextareaToCaretEnd(textarea: HTMLTextAreaElement): void {
+	if (textarea.selectionEnd >= textarea.value.length) {
+		textarea.scrollTop = textarea.scrollHeight;
+	}
+}
+
 export function shouldScrollTextareaToEnd(
 	selectionEnd: number,
 	previousValueLength: number,


### PR DESCRIPTION
Closes #1169

## Problem

In the compact prompt editor (the chat input, not the expanded `Cmd+Shift+P` composer), typing continuously past the editor's visible height made the newly typed text disappear. The editor did not scroll to follow the caret, and the hidden text only reappeared erratically after the user added line breaks. Pasting long text was unaffected, and the expanded editor was unaffected.

## Root cause

On every keystroke the compact editor resizes its `<textarea>` in a `requestAnimationFrame` via `resizeTextareaToContent`, which sets `style.height = 'auto'` before measuring `scrollHeight`. Setting the height to `auto` resets the textarea's `scrollTop`. Once content exceeds the `11rem` max height the box scrolls internally, but the keystroke resize path never re-scrolled to the caret, so the freshly typed text at the bottom was left out of view.

The autosize effect (`useInputAreaAutosize`) does scroll to the end for programmatic inserts (paste, draft restore, voice-to-text), which is why pasting worked. But during typing it now defers the resize to the keystroke rAF (via `keystrokeResizeScheduledRef`), and that rAF's `height:'auto'` reset undid the effect's scroll with nothing to restore it. The expanded composer is a plain fixed-height `h-full` textarea with no JS touching its height, so the browser's native caret-follow keeps working there.

## Fix

Add a small `scrollTextareaToCaretEnd` helper and call it inside the keystroke rAF right after the resize. It snaps the scroll to the bottom only when the caret is at the end of the content (the continuous-typing case) and leaves the scroll position untouched for mid-text edits, so the viewport does not jump. This mirrors the existing scroll-to-end behavior the autosize effect already applies for programmatic inserts.

## Testing

- New unit tests for `scrollTextareaToCaretEnd` (caret-at-end scrolls to bottom; mid-text caret is a no-op).
- New hook-level test for `useInputAreaTextChange` asserting the keystroke rAF scrolls to the caret.
- Existing `useInputAreaAutosize` / `textareaSizing` / `useInputAreaTextChange` tests still pass.

## Note on branch target

This PR targets `main`, where the affected code exists identically. On `rc` this file has diverged (mention-picker rework), so the same one-line rAF change may need a trivial forward-port when this lands there; the shared `textareaSizing.ts` helper merges cleanly.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed textarea behavior so the cursor stays visible after typing into a growing input.
  * Improved scrolling when entering long text, including after the input resizes.
  * Added coverage for caret-position scrolling to help prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->