### PR TITLE
feat(opencode): run local OpenCode via the SDK server instead of the CLI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
 				"@fastify/websocket": "^9.0.0",
 				"@lezer/highlight": "^1.2.3",
 				"@napi-rs/keyring": "1.3.0",
+				"@opencode-ai/sdk": "^1.17.13",
 				"@sentry/electron": "^7.13.0",
 				"@tanstack/react-virtual": "^3.13.13",
 				"@types/d3-force": "^3.0.10",
@@ -3193,6 +3194,15 @@
 			},
 			"engines": {
 				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+			}
+		},
+		"node_modules/@opencode-ai/sdk": {
+			"version": "1.17.13",
+			"resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.17.13.tgz",
+			"integrity": "sha512-VItOGjMzRQx3zypwmeFLNhCiIx32kxS7FqzIJvVZLfyNGCifs3rfGC9qzNKWcxQo4SjNvAw++v4gWWU6Inv+JQ==",
+			"license": "MIT",
+			"dependencies": {
+				"cross-spawn": "7.0.6"
 			}
 		},
 		"node_modules/@opentelemetry/api": {

--- a/package.json
+++ b/package.json
@@ -293,6 +293,7 @@
 		"@fastify/static": "^7.0.4",
 		"@fastify/websocket": "^9.0.0",
 		"@lezer/highlight": "^1.2.3",
+		"@opencode-ai/sdk": "^1.17.13",
 		"@sentry/electron": "^7.13.0",
 		"@tanstack/react-virtual": "^3.13.13",
 		"@types/d3-force": "^3.0.10",

--- a/src/__tests__/integration/opencode-sdk.integration.test.ts
+++ b/src/__tests__/integration/opencode-sdk.integration.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Live integration test for the OpenCode SDK execution path.
+ *
+ * Unlike the unit tests (which feed hand-built SDK events through the translator),
+ * this test stands up a REAL `opencode serve` via `@opencode-ai/sdk`, sends a real
+ * prompt, and drives the actual production translator + parser over the live SSE
+ * stream. It proves the end-to-end contract that unit tests can't: that the real
+ * server's event/Part shapes match what `OpencodeEventTranslator` expects and that
+ * the round-trip yields a usable result + usage.
+ *
+ * This is the pure-Node slice of the SDK path (server manager logic + translator +
+ * parser) - it needs neither Electron nor the app's native modules, so it runs on
+ * any machine with `opencode` installed and authenticated.
+ *
+ * Opt-in only (real network + token cost + local binary): it is SKIPPED unless
+ *   OPENCODE_LIVE=1
+ * is set. Run with:
+ *   OPENCODE_LIVE=1 npm run test:integration -- opencode-sdk.integration.test.ts
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createOpencodeServer, createOpencodeClient, type Event } from '@opencode-ai/sdk';
+import { OpencodeEventTranslator } from '../../main/opencode-server/event-translator';
+import { OpenCodeOutputParser } from '../../main/parsers/opencode-output-parser';
+import type { ParsedEvent } from '../../main/parsers';
+
+const LIVE = process.env.OPENCODE_LIVE === '1';
+
+describe.skipIf(!LIVE)('OpenCode SDK live integration', () => {
+	it('drives a real turn through the production translator + parser', async () => {
+		const server = await createOpencodeServer({
+			hostname: '127.0.0.1',
+			port: 0,
+			timeout: 20000,
+		});
+
+		try {
+			const client = createOpencodeClient({ baseUrl: server.url });
+
+			const created = await client.session.create({ query: { directory: process.cwd() } });
+			const sessionId = created.data?.id;
+			expect(sessionId, 'session.create should return an id').toBeTruthy();
+
+			const translator = new OpencodeEventTranslator(sessionId as string);
+			const parser = new OpenCodeOutputParser();
+
+			// Exactly the production pipeline: SSE Event -> translator -> JSONL line ->
+			// parser -> normalized ParsedEvent.
+			const parsedEvents: ParsedEvent[] = [];
+			const rawEventTypes: string[] = [];
+
+			const subscription = await client.event.subscribe();
+			const pump = (async () => {
+				for await (const event of subscription.stream as AsyncIterable<Event>) {
+					rawEventTypes.push(event.type);
+					const { lines, idle, errored } = translator.handle(event);
+					for (const line of lines) {
+						const parsed = parser.parseJsonLine(line);
+						if (parsed) parsedEvents.push(parsed);
+					}
+					if (idle || errored) break;
+				}
+			})();
+
+			await client.session.promptAsync({
+				path: { id: sessionId as string },
+				query: { directory: process.cwd() },
+				body: { parts: [{ type: 'text', text: 'Reply with exactly one word: PONG' }] },
+			});
+
+			await Promise.race([
+				pump,
+				new Promise((_, reject) =>
+					setTimeout(() => reject(new Error('timed out waiting for session.idle')), 120000)
+				),
+			]);
+
+			// The translator must have emitted a step_start (-> init) at minimum.
+			expect(parsedEvents.some((e) => e.type === 'init')).toBe(true);
+
+			// A real result must round-trip out with the model's text.
+			const result = parsedEvents.find((e) => e.type === 'result');
+			expect(result, 'expected a result event from the text part').toBeDefined();
+			expect(result?.text).toBeTruthy();
+			expect(result?.text?.toUpperCase()).toContain('PONG');
+
+			// And the step-finish must round-trip into usage stats.
+			const withUsage = parsedEvents.find((e) => e.type === 'system' && e.usage);
+			expect(withUsage, 'expected a system event carrying usage').toBeDefined();
+			expect(withUsage?.usage?.inputTokens).toBeGreaterThanOrEqual(0);
+			expect(withUsage?.usage?.outputTokens).toBeGreaterThan(0);
+
+			// Every parsed event must carry our session id (proves stream filtering).
+			for (const e of parsedEvents) {
+				if (e.sessionId) expect(e.sessionId).toBe(sessionId);
+			}
+		} finally {
+			server.close();
+		}
+	});
+});

--- a/src/__tests__/main/opencode-server/event-translator.test.ts
+++ b/src/__tests__/main/opencode-server/event-translator.test.ts
@@ -175,6 +175,29 @@ describe('OpencodeEventTranslator', () => {
 			expect(res.errored).toBe(true);
 			expect(JSON.parse(res.lines[0]).type).toBe('error');
 		});
+
+		it('drops a session.error scoped to a different session', () => {
+			const t = new OpencodeEventTranslator(SID);
+			const res = t.handle({
+				type: 'session.error',
+				properties: {
+					sessionID: 'ses_other',
+					error: { name: 'APIError', data: { message: 'nope' } },
+				},
+			} as Event);
+			expect(res).toEqual({ lines: [], idle: false, errored: false });
+		});
+
+		it('drops a session-less error instead of aborting this turn', () => {
+			// On the shared server a session-less error is broadcast to every
+			// subscriber; treating it as ours would kill unrelated concurrent turns.
+			const t = new OpencodeEventTranslator(SID);
+			const res = t.handle({
+				type: 'session.error',
+				properties: { error: { name: 'UnknownError', data: { message: 'global' } } },
+			} as Event);
+			expect(res).toEqual({ lines: [], idle: false, errored: false });
+		});
 	});
 
 	describe('round-trip fidelity through OpenCodeOutputParser', () => {

--- a/src/__tests__/main/opencode-server/event-translator.test.ts
+++ b/src/__tests__/main/opencode-server/event-translator.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect } from 'vitest';
+import { OpencodeEventTranslator } from '../../../main/opencode-server/event-translator';
+import { OpenCodeOutputParser } from '../../../main/parsers/opencode-output-parser';
+import type { Event, Part } from '@opencode-ai/sdk';
+
+const SID = 'ses_abc123';
+
+/** Build a `message.part.updated` event for the given part. */
+function partEvent(part: Partial<Part> & { type: Part['type'] }): Event {
+	return {
+		type: 'message.part.updated',
+		properties: {
+			part: { id: 'prt_1', sessionID: SID, messageID: 'msg_1', ...part } as Part,
+		},
+	} as Event;
+}
+
+describe('OpencodeEventTranslator', () => {
+	describe('session filtering', () => {
+		it('ignores parts from other sessions on the shared server', () => {
+			const t = new OpencodeEventTranslator(SID);
+			const other = partEvent({ type: 'step-start' });
+			(other.properties as { part: Part }).part.sessionID = 'ses_other';
+			expect(t.handle(other)).toEqual({ lines: [], idle: false, errored: false });
+		});
+
+		it('ignores session.idle for a different session', () => {
+			const t = new OpencodeEventTranslator(SID);
+			const evt = { type: 'session.idle', properties: { sessionID: 'ses_other' } } as Event;
+			expect(t.handle(evt).idle).toBe(false);
+		});
+	});
+
+	describe('part translation -> CLI JSONL', () => {
+		it('translates step-start to a step_start line', () => {
+			const t = new OpencodeEventTranslator(SID);
+			const { lines } = t.handle(partEvent({ type: 'step-start' }));
+			expect(lines).toHaveLength(1);
+			expect(JSON.parse(lines[0])).toEqual({
+				type: 'step_start',
+				sessionID: SID,
+				part: { type: 'step-start' },
+			});
+		});
+
+		it('translates a completed text part exactly once', () => {
+			const t = new OpencodeEventTranslator(SID);
+			// Streaming update (no time.end) is buffered, not emitted.
+			const streaming = t.handle(partEvent({ type: 'text', text: 'Hel', time: { start: 1 } }));
+			expect(streaming.lines).toEqual([]);
+			// Completed update flushes the full text once.
+			const done = t.handle(
+				partEvent({ type: 'text', text: 'Hello world', time: { start: 1, end: 2 } })
+			);
+			expect(done.lines).toHaveLength(1);
+			expect(JSON.parse(done.lines[0])).toMatchObject({
+				type: 'text',
+				sessionID: SID,
+				part: { type: 'text', text: 'Hello world' },
+			});
+			// A duplicate completed update for the same part id is not re-emitted.
+			const dup = t.handle(
+				partEvent({ type: 'text', text: 'Hello world', time: { start: 1, end: 2 } })
+			);
+			expect(dup.lines).toEqual([]);
+		});
+
+		it('flushes buffered streaming text on session.idle if never completed', () => {
+			const t = new OpencodeEventTranslator(SID);
+			t.handle(partEvent({ type: 'text', text: 'partial answer', time: { start: 1 } }));
+			const idle = t.handle({
+				type: 'session.idle',
+				properties: { sessionID: SID },
+			} as Event);
+			expect(idle.idle).toBe(true);
+			expect(idle.lines).toHaveLength(1);
+			expect(JSON.parse(idle.lines[0])).toMatchObject({
+				type: 'text',
+				part: { text: 'partial answer' },
+			});
+		});
+
+		it('translates tool parts (skipping pending) to tool_use lines', () => {
+			const t = new OpencodeEventTranslator(SID);
+			const pending = t.handle(
+				partEvent({
+					type: 'tool',
+					tool: 'read',
+					callID: 'call_1',
+					state: { status: 'pending', input: {}, raw: '' },
+				} as Partial<Part> & { type: 'tool' })
+			);
+			expect(pending.lines).toEqual([]);
+
+			const completed = t.handle(
+				partEvent({
+					type: 'tool',
+					tool: 'read',
+					callID: 'call_1',
+					state: {
+						status: 'completed',
+						input: { path: '/a.ts' },
+						output: 'contents',
+						title: 'read /a.ts',
+						metadata: {},
+						time: { start: 1, end: 2 },
+					},
+				} as Partial<Part> & { type: 'tool' })
+			);
+			expect(completed.lines).toHaveLength(1);
+			expect(JSON.parse(completed.lines[0])).toMatchObject({
+				type: 'tool_use',
+				sessionID: SID,
+				part: { type: 'tool', tool: 'read', callID: 'call_1', state: { status: 'completed' } },
+			});
+		});
+
+		it('translates step-finish (with tokens/cost) to a step_finish line', () => {
+			const t = new OpencodeEventTranslator(SID);
+			const { lines } = t.handle(
+				partEvent({
+					type: 'step-finish',
+					reason: 'stop',
+					cost: 0.002,
+					tokens: { input: 100, output: 50, reasoning: 0, cache: { read: 10, write: 5 } },
+				} as Partial<Part> & { type: 'step-finish' })
+			);
+			expect(JSON.parse(lines[0])).toEqual({
+				type: 'step_finish',
+				sessionID: SID,
+				part: {
+					type: 'step-finish',
+					reason: 'stop',
+					cost: 0.002,
+					tokens: { input: 100, output: 50, reasoning: 0, cache: { read: 10, write: 5 } },
+				},
+			});
+		});
+
+		it('skips reasoning/other parts with no CLI equivalent', () => {
+			const t = new OpencodeEventTranslator(SID);
+			expect(
+				t.handle(
+					partEvent({ type: 'reasoning', text: 'thinking...' } as Partial<Part> & {
+						type: 'reasoning';
+					})
+				).lines
+			).toEqual([]);
+		});
+	});
+
+	describe('errors', () => {
+		it('translates session.error into a parseable error line', () => {
+			const t = new OpencodeEventTranslator(SID);
+			const res = t.handle({
+				type: 'session.error',
+				properties: {
+					sessionID: SID,
+					error: { name: 'APIError', data: { message: 'rate limited', isRetryable: true } },
+				},
+			} as Event);
+			expect(res.errored).toBe(true);
+			expect(JSON.parse(res.lines[0])).toMatchObject({
+				type: 'error',
+				error: { name: 'APIError', data: { message: 'rate limited' } },
+			});
+		});
+
+		it('surfaces a payload-less session error as a recognizable error line', () => {
+			const t = new OpencodeEventTranslator(SID);
+			const res = t.handle({
+				type: 'session.error',
+				properties: { sessionID: SID },
+			} as Event);
+			expect(res.errored).toBe(true);
+			expect(JSON.parse(res.lines[0]).type).toBe('error');
+		});
+	});
+
+	describe('round-trip fidelity through OpenCodeOutputParser', () => {
+		// The migration's core premise: translated lines parse identically to real
+		// CLI output. Feed a full turn through the translator, then the parser.
+		it('parses a full turn into the expected normalized events', () => {
+			const t = new OpencodeEventTranslator(SID);
+			const parser = new OpenCodeOutputParser();
+
+			const events: Event[] = [
+				partEvent({ type: 'step-start' }),
+				partEvent({
+					type: 'tool',
+					tool: 'read',
+					callID: 'c1',
+					state: {
+						status: 'completed',
+						input: { path: '/x.ts' },
+						output: 'ok',
+						title: 't',
+						metadata: {},
+						time: { start: 1, end: 2 },
+					},
+				} as Partial<Part> & { type: 'tool' }),
+				partEvent({ type: 'text', text: 'Final answer', time: { start: 3, end: 4 } }),
+				partEvent({
+					type: 'step-finish',
+					reason: 'stop',
+					cost: 0.01,
+					tokens: { input: 200, output: 80, reasoning: 0, cache: { read: 0, write: 0 } },
+				} as Partial<Part> & { type: 'step-finish' }),
+				{ type: 'session.idle', properties: { sessionID: SID } } as Event,
+			];
+
+			const parsed = events
+				.flatMap((e) => t.handle(e).lines)
+				.map((line) => parser.parseJsonLine(line));
+
+			const types = parsed.map((p) => p?.type);
+			expect(types).toEqual(['init', 'tool_use', 'result', 'system']);
+
+			const result = parsed.find((p) => p?.type === 'result');
+			expect(result?.text).toBe('Final answer');
+
+			const system = parsed.find((p) => p?.type === 'system');
+			expect(system?.usage?.inputTokens).toBe(200);
+			expect(system?.usage?.outputTokens).toBe(80);
+			expect(system?.usage?.costUsd).toBe(0.01);
+		});
+	});
+});

--- a/src/__tests__/main/process-manager-coworking-injection.test.ts
+++ b/src/__tests__/main/process-manager-coworking-injection.test.ts
@@ -137,14 +137,37 @@ describe('ProcessManager per-spawn coworking socket override', () => {
 		expect(mockGetBridgeSocketPath).not.toHaveBeenCalled();
 	});
 
-	it('does not inject coworking env on the OpenCode SDK-serve path', () => {
+	it('routes OpenCode prompts through the CLI child path with coworking env when the server gate is off', () => {
+		pm.spawn({
+			sessionId: 'oc-gate-off',
+			toolType: 'opencode',
+			cwd: '/tmp',
+			command: 'opencode',
+			args: [],
+			prompt: 'do a thing',
+		});
+
+		// The default-OFF server gate keeps local interactive OpenCode on the CLI path.
+		expect(captured.child).toHaveLength(1);
+		expect(captured.server).toHaveLength(0);
+		expect(captured.pty).toHaveLength(0);
+
+		const forwarded = captured.child[0];
+		const forwardedSessionId = forwarded.customEnvVars?.[SESSION_ID_ENV];
+		expect(forwardedSessionId).toEqual(expect.any(String));
+		expect(forwardedSessionId).not.toBe('');
+		expect(forwarded.customEnvVars?.[OVERRIDE_ENV]).toBe(SENTINEL_SOCKET);
+	});
+
+	it('does not inject coworking env on the OpenCode SDK-serve path when the server gate is on', () => {
 		// An OpenCode prompt turn routes to the shared `opencode serve` spawner.
 		// Coworking env MUST NOT be injected there: MAESTRO_COWORKING_SESSION_ID is
 		// per-session and would fingerprint into a separate server per session
 		// (OpencodeServerManager.buildServerKey), fragmenting the shared server. The
 		// serve decision runs on the raw config, before injection.
-		pm.spawn({
-			sessionId: 'oc-1',
+		const pmOn = new ProcessManager(() => true);
+		pmOn.spawn({
+			sessionId: 'oc-gate-on',
 			toolType: 'opencode',
 			cwd: '/tmp',
 			command: 'opencode',
@@ -153,9 +176,9 @@ describe('ProcessManager per-spawn coworking socket override', () => {
 		});
 
 		// Routes to the server spawner, not child/pty.
+		expect(captured.server).toHaveLength(1);
 		expect(captured.child).toHaveLength(0);
 		expect(captured.pty).toHaveLength(0);
-		expect(captured.server).toHaveLength(1);
 
 		const forwarded = captured.server[0];
 		expect(forwarded.customEnvVars?.[SESSION_ID_ENV]).toBeUndefined();

--- a/src/__tests__/main/process-manager-coworking-injection.test.ts
+++ b/src/__tests__/main/process-manager-coworking-injection.test.ts
@@ -37,6 +37,7 @@ const SPAWN_RESULT: SpawnResult = { pid: 4242, success: true };
 const captured = vi.hoisted(() => ({
 	child: [] as ProcessConfig[],
 	pty: [] as ProcessConfig[],
+	server: [] as ProcessConfig[],
 }));
 
 // Stub the owning-window bridge socket path with a controllable sentinel.
@@ -64,6 +65,14 @@ vi.mock('../../main/process-manager/spawners/PtySpawner', () => ({
 		}
 	},
 }));
+vi.mock('../../main/process-manager/spawners/OpencodeServerSpawner', () => ({
+	OpencodeServerSpawner: class {
+		spawn(config: ProcessConfig): SpawnResult {
+			captured.server.push(config);
+			return SPAWN_RESULT;
+		}
+	},
+}));
 
 // Avoid logger side effects (mirrors the existing process-manager test).
 vi.mock('../../main/utils/logger', () => ({
@@ -84,6 +93,7 @@ describe('ProcessManager per-spawn coworking socket override', () => {
 	beforeEach(() => {
 		captured.child.length = 0;
 		captured.pty.length = 0;
+		captured.server.length = 0;
 		mockGetBridgeSocketPath.mockReset();
 		mockGetBridgeSocketPath.mockReturnValue(SENTINEL_SOCKET);
 		pm = new ProcessManager();
@@ -124,6 +134,34 @@ describe('ProcessManager per-spawn coworking socket override', () => {
 		expect(forwarded.customEnvVars?.[OVERRIDE_ENV]).toBeUndefined();
 		// Pass-through means the session-id env is not injected either.
 		expect(forwarded.customEnvVars?.[SESSION_ID_ENV]).toBeUndefined();
+		expect(mockGetBridgeSocketPath).not.toHaveBeenCalled();
+	});
+
+	it('does not inject coworking env on the OpenCode SDK-serve path', () => {
+		// An OpenCode prompt turn routes to the shared `opencode serve` spawner.
+		// Coworking env MUST NOT be injected there: MAESTRO_COWORKING_SESSION_ID is
+		// per-session and would fingerprint into a separate server per session
+		// (OpencodeServerManager.buildServerKey), fragmenting the shared server. The
+		// serve decision runs on the raw config, before injection.
+		pm.spawn({
+			sessionId: 'oc-1',
+			toolType: 'opencode',
+			cwd: '/tmp',
+			command: 'opencode',
+			args: [],
+			prompt: 'do a thing',
+		});
+
+		// Routes to the server spawner, not child/pty.
+		expect(captured.child).toHaveLength(0);
+		expect(captured.pty).toHaveLength(0);
+		expect(captured.server).toHaveLength(1);
+
+		const forwarded = captured.server[0];
+		expect(forwarded.customEnvVars?.[SESSION_ID_ENV]).toBeUndefined();
+		expect(forwarded.customEnvVars?.[OVERRIDE_ENV]).toBeUndefined();
+		// The serve path short-circuits before the injection block, so the owning
+		// window socket is never even resolved.
 		expect(mockGetBridgeSocketPath).not.toHaveBeenCalled();
 	});
 

--- a/src/__tests__/renderer/components/Settings/Extensions/extensionModel.test.ts
+++ b/src/__tests__/renderer/components/Settings/Extensions/extensionModel.test.ts
@@ -92,6 +92,7 @@ describe('extensionModel first-party projection (all Encore features)', () => {
 			'directorNotes',
 			'pianola',
 			'coworking',
+			'opencodeServer',
 		]);
 
 		for (const def of BUILTIN_FEATURES) {

--- a/src/__tests__/shared/pianola/pianola-first-party-plugin.test.ts
+++ b/src/__tests__/shared/pianola/pianola-first-party-plugin.test.ts
@@ -54,6 +54,7 @@ describe('first-party plugin registry', () => {
 			['directorNotes', 'com.maestro.director-notes'],
 			['pianola', 'com.maestro.pianola'],
 			['coworking', 'com.maestro.coworking'],
+			['opencodeServer', 'com.maestro.opencode-server'],
 		]);
 	});
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -860,7 +860,12 @@ app
 
 		// Initialize core services
 		logger.info('Initializing core services', 'Startup');
-		processManager = new ProcessManager();
+		// Gate the OpenCode SDK-serve path behind the default-off
+		// `encoreFeatures.opencodeServer` plugin. Read live on every spawn so the
+		// Extensions toggle takes effect without an app restart.
+		processManager = new ProcessManager(
+			() => (store.get('encoreFeatures', {}) as Record<string, boolean>).opencodeServer === true
+		);
 		// Note: webServer is created on-demand when user enables web interface (see setupWebServerCallbacks)
 		agentDetector = new AgentDetector();
 

--- a/src/main/opencode-server/OpencodeServerManager.ts
+++ b/src/main/opencode-server/OpencodeServerManager.ts
@@ -34,6 +34,23 @@ const AUTO_APPROVE_CONFIG = {
 	tools: { question: false },
 } as const;
 
+// COWORKING FOLLOW-UP (gated behind encoreFeatures.opencodeServer): the shared
+// serve process gets no per-session coworking env, so its env-less MCP
+// subprocess fails the bridge handshake (ppid → serve PID, untracked) and
+// coworking tools are cleanly unavailable. The way around, when we want
+// coworking on this transport, is to move identity off the process env and onto
+// a per-session MCP *registration*: (1) add `mcp: { 'maestro-coworking': { enabled: false } }`
+// here so the global env-less entry never loads, then (2) per session call
+// `client.mcp.add({ query: { directory }, body: { name: 'maestro-coworking-<maestroSessionId>',
+// config: { type: 'local', command: [node, scriptPath], environment: {
+// MAESTRO_COWORKING_SESSION_ID, MAESTRO_COWORKING_SOCKET_OVERRIDE } } } })` so the
+// id rides the named server (existing bridge handshake + fail-closed logic work
+// unchanged), and (3) scope visibility with the per-prompt `tools` map on
+// `session.promptAsync` so one session can't see another's `maestro-coworking-*`
+// tools. Blockers to verify against the live opencode build first: mcp.add
+// scoping/persistence semantics, no de-registration endpoint (only disconnect),
+// and the tool-key wildcard semantics of the per-prompt `tools` filter.
+
 /** How long to wait for the server to print its readiness line before failing. */
 const SERVER_START_TIMEOUT_MS = 15000;
 

--- a/src/main/opencode-server/OpencodeServerManager.ts
+++ b/src/main/opencode-server/OpencodeServerManager.ts
@@ -17,7 +17,6 @@
  */
 
 import { spawn, type ChildProcess } from 'child_process';
-import * as net from 'net';
 import type { OpencodeClient } from '@opencode-ai/sdk';
 import { loadOpencodeSdk } from './sdk-loader';
 import { logger } from '../utils/logger';
@@ -99,7 +98,6 @@ class OpencodeServerManager {
 	}
 
 	private async startServer(opts: EnsureServerOptions, key: string): Promise<ServerInstance> {
-		const port = await findFreePort();
 		const hostname = '127.0.0.1';
 		const env = buildChildProcessEnv(
 			opts.customEnvVars,
@@ -112,11 +110,14 @@ class OpencodeServerManager {
 		logger.info('[OpencodeServer] Starting shared server', 'OpencodeServer', {
 			binaryPath: opts.binaryPath,
 			hostname,
-			port,
 			cwd: opts.cwd,
 		});
 
-		const child = spawn(opts.binaryPath, ['serve', `--hostname=${hostname}`, `--port=${port}`], {
+		// Bind to an OS-assigned port (`--port=0`) and read the real URL from the
+		// readiness banner. Pre-picking a "free" port and passing it separately is a
+		// TOCTOU race — the port can be taken between the probe and the server's
+		// bind, surfacing only as an opaque 15s startup timeout.
+		const child = spawn(opts.binaryPath, ['serve', `--hostname=${hostname}`, '--port=0'], {
 			cwd: opts.cwd,
 			env,
 			stdio: ['ignore', 'pipe', 'pipe'],
@@ -125,7 +126,7 @@ class OpencodeServerManager {
 		// Track the child so shutdown() can kill it even if readiness never resolves.
 		this.startupChildren.add(child);
 		try {
-			const url = await this.awaitReadiness(child, port, hostname);
+			const url = await this.awaitReadiness(child);
 
 			// Keep the pipes draining after readiness. awaitReadiness detaches its
 			// accumulating listeners, which would otherwise pause the streams and
@@ -162,9 +163,13 @@ class OpencodeServerManager {
 	 * Resolve when the server prints `opencode server listening on <url>`, or
 	 * reject on early exit / timeout. Mirrors the SDK's readiness detection.
 	 */
-	private awaitReadiness(child: ChildProcess, port: number, hostname: string): Promise<string> {
+	private awaitReadiness(child: ChildProcess): Promise<string> {
 		return new Promise<string>((resolve, reject) => {
 			let output = '';
+			// Unparsed remainder: only complete (newline-terminated) lines are scanned
+			// for the banner, so a banner split across chunks can't resolve on a
+			// truncated URL.
+			let lineBuf = '';
 			let settled = false;
 
 			// Named handlers so `finish` can detach them once the promise settles;
@@ -173,12 +178,18 @@ class OpencodeServerManager {
 			// readiness to keep the pipes draining.
 			const onStdout = (chunk: string) => {
 				output += chunk;
-				for (const line of output.split('\n')) {
+				lineBuf += chunk;
+				const lastNl = lineBuf.lastIndexOf('\n');
+				if (lastNl === -1) return;
+				const complete = lineBuf.slice(0, lastNl);
+				lineBuf = lineBuf.slice(lastNl + 1);
+				for (const line of complete.split('\n')) {
 					if (line.startsWith('opencode server listening')) {
 						const match = line.match(/on\s+(https?:\/\/[^\s]+)/);
-						// Fall back to the port we requested if the banner format changes.
-						finish(() => resolve(match?.[1] ?? `http://${hostname}:${port}`));
-						return;
+						if (match) {
+							finish(() => resolve(match[1]));
+							return;
+						}
 					}
 				}
 			};
@@ -277,24 +288,6 @@ function buildServerKey(opts: EnsureServerOptions): string {
 		fingerprint(opts.shellEnvVars),
 		(opts.extraPathDirs ?? []).join(':'),
 	].join('\u0001');
-}
-
-/** Find an available ephemeral TCP port on the loopback interface. */
-function findFreePort(): Promise<number> {
-	return new Promise((resolve, reject) => {
-		const srv = net.createServer();
-		srv.unref();
-		srv.on('error', reject);
-		srv.listen(0, '127.0.0.1', () => {
-			const addr = srv.address();
-			if (addr && typeof addr === 'object') {
-				const { port } = addr;
-				srv.close(() => resolve(port));
-			} else {
-				srv.close(() => reject(new Error('Failed to acquire a free port')));
-			}
-		});
-	});
 }
 
 /** Process-wide singleton. */

--- a/src/main/opencode-server/OpencodeServerManager.ts
+++ b/src/main/opencode-server/OpencodeServerManager.ts
@@ -1,0 +1,240 @@
+// src/main/opencode-server/OpencodeServerManager.ts
+
+/**
+ * Owns the long-lived `opencode serve` process(es) that back the SDK execution
+ * path, and the SDK client bound to each.
+ *
+ * OpenCode's server is project-scoped via a `directory` query param on every
+ * request, so a single server process serves every Maestro workspace - we key
+ * instances by the resolved binary path (a user could point different agents at
+ * different opencode builds; almost always there's just one). The server is
+ * spawned lazily on first prompt and torn down on app shutdown.
+ *
+ * We deliberately spawn the server ourselves instead of using the SDK's
+ * `createOpencodeServer`, because that helper hardcodes the `opencode` binary on
+ * PATH and Maestro must honor the user's resolved/custom binary and its spawn
+ * environment (version-manager PATH, shell env vars, etc.).
+ */
+
+import { spawn, type ChildProcess } from 'child_process';
+import * as net from 'net';
+import type { OpencodeClient } from '@opencode-ai/sdk';
+import { loadOpencodeSdk } from './sdk-loader';
+import { logger } from '../utils/logger';
+import { captureException } from '../utils/sentry';
+import { buildChildProcessEnv } from '../process-manager/utils/envBuilder';
+
+/**
+ * Auto-approve every tool. This mirrors the CLI path's `OPENCODE_CONFIG_CONTENT`
+ * so the SDK migration is behavior-preserving: no permission prompts today. When
+ * the permission-bubbling feature lands, this becomes per-tool `ask` and the
+ * `permission.updated` SSE events get surfaced to the renderer.
+ */
+const AUTO_APPROVE_CONFIG = {
+	permission: { '*': 'allow', external_directory: 'allow', question: 'deny' },
+	tools: { question: false },
+} as const;
+
+/** How long to wait for the server to print its readiness line before failing. */
+const SERVER_START_TIMEOUT_MS = 15000;
+
+export interface OpencodeServerHandle {
+	url: string;
+	client: OpencodeClient;
+}
+
+interface ServerInstance extends OpencodeServerHandle {
+	process: ChildProcess;
+}
+
+export interface EnsureServerOptions {
+	/** Resolved opencode binary path (ProcessConfig.command). */
+	binaryPath: string;
+	/** Session-level custom env vars (ProcessConfig.customEnvVars). */
+	customEnvVars?: Record<string, string>;
+	/** Global shell env vars (ProcessConfig.shellEnvVars). */
+	shellEnvVars?: Record<string, string>;
+	/** Extra PATH dirs (ProcessConfig.extraPathDirs). */
+	extraPathDirs?: string[];
+	/** Working directory to spawn the server in (any workspace; requests are
+	 *  scoped per-call via `directory`). */
+	cwd: string;
+}
+
+class OpencodeServerManager {
+	/** Ready server instances, keyed by resolved binary path. */
+	private servers = new Map<string, ServerInstance>();
+	/** In-flight startups, keyed by binary path, to dedupe concurrent spawns. */
+	private starting = new Map<string, Promise<OpencodeServerHandle>>();
+
+	/**
+	 * Ensure a server for the given binary is running and return its client.
+	 * Concurrent callers for the same binary share a single startup.
+	 */
+	async ensureServer(opts: EnsureServerOptions): Promise<OpencodeServerHandle> {
+		const key = opts.binaryPath;
+
+		const existing = this.servers.get(key);
+		if (existing) return { url: existing.url, client: existing.client };
+
+		const inFlight = this.starting.get(key);
+		if (inFlight) return inFlight;
+
+		const startup = this.startServer(opts)
+			.then((instance) => {
+				this.servers.set(key, instance);
+				this.starting.delete(key);
+				return { url: instance.url, client: instance.client };
+			})
+			.catch((err) => {
+				this.starting.delete(key);
+				throw err;
+			});
+
+		this.starting.set(key, startup);
+		return startup;
+	}
+
+	private async startServer(opts: EnsureServerOptions): Promise<ServerInstance> {
+		const port = await findFreePort();
+		const hostname = '127.0.0.1';
+		const env = buildChildProcessEnv(
+			opts.customEnvVars,
+			false,
+			opts.shellEnvVars,
+			opts.extraPathDirs
+		);
+		env.OPENCODE_CONFIG_CONTENT = JSON.stringify(AUTO_APPROVE_CONFIG);
+
+		logger.info('[OpencodeServer] Starting shared server', 'OpencodeServer', {
+			binaryPath: opts.binaryPath,
+			hostname,
+			port,
+			cwd: opts.cwd,
+		});
+
+		const child = spawn(opts.binaryPath, ['serve', `--hostname=${hostname}`, `--port=${port}`], {
+			cwd: opts.cwd,
+			env,
+			stdio: ['ignore', 'pipe', 'pipe'],
+		});
+
+		const url = await this.awaitReadiness(child, port, hostname);
+
+		// Once ready, drop the cached instance if the server ever exits so the next
+		// prompt re-spawns a fresh one instead of hitting a dead socket.
+		child.on('exit', (code, signal) => {
+			logger.warn('[OpencodeServer] Server process exited', 'OpencodeServer', {
+				binaryPath: opts.binaryPath,
+				code,
+				signal,
+			});
+			const current = this.servers.get(opts.binaryPath);
+			if (current?.process === child) {
+				this.servers.delete(opts.binaryPath);
+			}
+		});
+
+		const { createOpencodeClient } = await loadOpencodeSdk();
+		const client = createOpencodeClient({ baseUrl: url });
+		logger.info('[OpencodeServer] Server ready', 'OpencodeServer', { url });
+		return { url, client, process: child };
+	}
+
+	/**
+	 * Resolve when the server prints `opencode server listening on <url>`, or
+	 * reject on early exit / timeout. Mirrors the SDK's readiness detection.
+	 */
+	private awaitReadiness(child: ChildProcess, port: number, hostname: string): Promise<string> {
+		return new Promise<string>((resolve, reject) => {
+			let output = '';
+			let settled = false;
+
+			const finish = (fn: () => void) => {
+				if (settled) return;
+				settled = true;
+				clearTimeout(timer);
+				fn();
+			};
+
+			const timer = setTimeout(() => {
+				finish(() => {
+					try {
+						child.kill();
+					} catch {
+						// already dead
+					}
+					reject(
+						new Error(
+							`Timed out after ${SERVER_START_TIMEOUT_MS}ms waiting for opencode server.` +
+								(output.trim() ? `\nOutput: ${output.slice(-2000)}` : '')
+						)
+					);
+				});
+			}, SERVER_START_TIMEOUT_MS);
+
+			child.stdout?.setEncoding('utf8');
+			child.stdout?.on('data', (chunk: string) => {
+				output += chunk;
+				for (const line of output.split('\n')) {
+					if (line.startsWith('opencode server listening')) {
+						const match = line.match(/on\s+(https?:\/\/[^\s]+)/);
+						// Fall back to the port we requested if the banner format changes.
+						finish(() => resolve(match?.[1] ?? `http://${hostname}:${port}`));
+						return;
+					}
+				}
+			});
+			child.stderr?.setEncoding('utf8');
+			child.stderr?.on('data', (chunk: string) => {
+				output += chunk;
+			});
+
+			child.on('error', (err) => finish(() => reject(err)));
+			child.on('exit', (code) =>
+				finish(() =>
+					reject(
+						new Error(
+							`opencode server exited with code ${code} before becoming ready.` +
+								(output.trim() ? `\nOutput: ${output.slice(-2000)}` : '')
+						)
+					)
+				)
+			);
+		});
+	}
+
+	/** Kill every running server. Called on app shutdown. */
+	shutdown(): void {
+		for (const [key, instance] of this.servers) {
+			try {
+				instance.process.kill();
+			} catch (err) {
+				void captureException(err);
+			}
+			this.servers.delete(key);
+		}
+		this.starting.clear();
+	}
+}
+
+/** Find an available ephemeral TCP port on the loopback interface. */
+function findFreePort(): Promise<number> {
+	return new Promise((resolve, reject) => {
+		const srv = net.createServer();
+		srv.unref();
+		srv.on('error', reject);
+		srv.listen(0, '127.0.0.1', () => {
+			const addr = srv.address();
+			if (addr && typeof addr === 'object') {
+				const { port } = addr;
+				srv.close(() => resolve(port));
+			} else {
+				srv.close(() => reject(new Error('Failed to acquire a free port')));
+			}
+		});
+	});
+}
+
+/** Process-wide singleton. */
+export const opencodeServerManager = new OpencodeServerManager();

--- a/src/main/opencode-server/OpencodeServerManager.ts
+++ b/src/main/opencode-server/OpencodeServerManager.ts
@@ -62,17 +62,20 @@ export interface EnsureServerOptions {
 }
 
 class OpencodeServerManager {
-	/** Ready server instances, keyed by resolved binary path. */
+	/** Ready server instances, keyed by the composite server key (binary + env). */
 	private servers = new Map<string, ServerInstance>();
-	/** In-flight startups, keyed by binary path, to dedupe concurrent spawns. */
+	/** In-flight startups, keyed by the composite server key, to dedupe concurrent spawns. */
 	private starting = new Map<string, Promise<OpencodeServerHandle>>();
+	/** Startup child processes not yet promoted to `servers`, so shutdown can kill
+	 *  a server still waiting on its readiness banner. */
+	private startupChildren = new Set<ChildProcess>();
 
 	/**
-	 * Ensure a server for the given binary is running and return its client.
-	 * Concurrent callers for the same binary share a single startup.
+	 * Ensure a server for the given binary + environment is running and return its
+	 * client. Concurrent callers for the same key share a single startup.
 	 */
 	async ensureServer(opts: EnsureServerOptions): Promise<OpencodeServerHandle> {
-		const key = opts.binaryPath;
+		const key = buildServerKey(opts);
 
 		const existing = this.servers.get(key);
 		if (existing) return { url: existing.url, client: existing.client };
@@ -80,7 +83,7 @@ class OpencodeServerManager {
 		const inFlight = this.starting.get(key);
 		if (inFlight) return inFlight;
 
-		const startup = this.startServer(opts)
+		const startup = this.startServer(opts, key)
 			.then((instance) => {
 				this.servers.set(key, instance);
 				this.starting.delete(key);
@@ -95,7 +98,7 @@ class OpencodeServerManager {
 		return startup;
 	}
 
-	private async startServer(opts: EnsureServerOptions): Promise<ServerInstance> {
+	private async startServer(opts: EnsureServerOptions, key: string): Promise<ServerInstance> {
 		const port = await findFreePort();
 		const hostname = '127.0.0.1';
 		const env = buildChildProcessEnv(
@@ -119,26 +122,40 @@ class OpencodeServerManager {
 			stdio: ['ignore', 'pipe', 'pipe'],
 		});
 
-		const url = await this.awaitReadiness(child, port, hostname);
+		// Track the child so shutdown() can kill it even if readiness never resolves.
+		this.startupChildren.add(child);
+		try {
+			const url = await this.awaitReadiness(child, port, hostname);
 
-		// Once ready, drop the cached instance if the server ever exits so the next
-		// prompt re-spawns a fresh one instead of hitting a dead socket.
-		child.on('exit', (code, signal) => {
-			logger.warn('[OpencodeServer] Server process exited', 'OpencodeServer', {
-				binaryPath: opts.binaryPath,
-				code,
-				signal,
+			// Keep the pipes draining after readiness. awaitReadiness detaches its
+			// accumulating listeners, which would otherwise pause the streams and
+			// eventually block the server once the OS pipe buffer fills.
+			child.stdout?.resume();
+			child.stderr?.resume();
+
+			// Once ready, drop the cached instance if the server ever exits so the next
+			// prompt re-spawns a fresh one instead of hitting a dead socket.
+			child.on('exit', (code, signal) => {
+				logger.warn('[OpencodeServer] Server process exited', 'OpencodeServer', {
+					binaryPath: opts.binaryPath,
+					code,
+					signal,
+				});
+				const current = this.servers.get(key);
+				if (current?.process === child) {
+					this.servers.delete(key);
+				}
 			});
-			const current = this.servers.get(opts.binaryPath);
-			if (current?.process === child) {
-				this.servers.delete(opts.binaryPath);
-			}
-		});
 
-		const { createOpencodeClient } = await loadOpencodeSdk();
-		const client = createOpencodeClient({ baseUrl: url });
-		logger.info('[OpencodeServer] Server ready', 'OpencodeServer', { url });
-		return { url, client, process: child };
+			const { createOpencodeClient } = await loadOpencodeSdk();
+			const client = createOpencodeClient({ baseUrl: url });
+			logger.info('[OpencodeServer] Server ready', 'OpencodeServer', { url });
+			return { url, client, process: child };
+		} finally {
+			// Once promoted to `servers` (or dead on failure), it's no longer a
+			// pending startup child.
+			this.startupChildren.delete(child);
+		}
 	}
 
 	/**
@@ -150,10 +167,43 @@ class OpencodeServerManager {
 			let output = '';
 			let settled = false;
 
+			// Named handlers so `finish` can detach them once the promise settles;
+			// otherwise they keep appending the long-lived server's output to `output`
+			// forever (unbounded memory growth). The caller resumes the streams after
+			// readiness to keep the pipes draining.
+			const onStdout = (chunk: string) => {
+				output += chunk;
+				for (const line of output.split('\n')) {
+					if (line.startsWith('opencode server listening')) {
+						const match = line.match(/on\s+(https?:\/\/[^\s]+)/);
+						// Fall back to the port we requested if the banner format changes.
+						finish(() => resolve(match?.[1] ?? `http://${hostname}:${port}`));
+						return;
+					}
+				}
+			};
+			const onStderr = (chunk: string) => {
+				output += chunk;
+			};
+			const onError = (err: Error) => finish(() => reject(err));
+			const onExit = (code: number | null) =>
+				finish(() =>
+					reject(
+						new Error(
+							`opencode server exited with code ${code} before becoming ready.` +
+								(output.trim() ? `\nOutput: ${output.slice(-2000)}` : '')
+						)
+					)
+				);
+
 			const finish = (fn: () => void) => {
 				if (settled) return;
 				settled = true;
 				clearTimeout(timer);
+				child.stdout?.off('data', onStdout);
+				child.stderr?.off('data', onStderr);
+				child.off('error', onError);
+				child.off('exit', onExit);
 				fn();
 			};
 
@@ -174,37 +224,15 @@ class OpencodeServerManager {
 			}, SERVER_START_TIMEOUT_MS);
 
 			child.stdout?.setEncoding('utf8');
-			child.stdout?.on('data', (chunk: string) => {
-				output += chunk;
-				for (const line of output.split('\n')) {
-					if (line.startsWith('opencode server listening')) {
-						const match = line.match(/on\s+(https?:\/\/[^\s]+)/);
-						// Fall back to the port we requested if the banner format changes.
-						finish(() => resolve(match?.[1] ?? `http://${hostname}:${port}`));
-						return;
-					}
-				}
-			});
+			child.stdout?.on('data', onStdout);
 			child.stderr?.setEncoding('utf8');
-			child.stderr?.on('data', (chunk: string) => {
-				output += chunk;
-			});
-
-			child.on('error', (err) => finish(() => reject(err)));
-			child.on('exit', (code) =>
-				finish(() =>
-					reject(
-						new Error(
-							`opencode server exited with code ${code} before becoming ready.` +
-								(output.trim() ? `\nOutput: ${output.slice(-2000)}` : '')
-						)
-					)
-				)
-			);
+			child.stderr?.on('data', onStderr);
+			child.on('error', onError);
+			child.on('exit', onExit);
 		});
 	}
 
-	/** Kill every running server. Called on app shutdown. */
+	/** Kill every running server and any still-starting child. Called on app shutdown. */
 	shutdown(): void {
 		for (const [key, instance] of this.servers) {
 			try {
@@ -214,8 +242,41 @@ class OpencodeServerManager {
 			}
 			this.servers.delete(key);
 		}
+		// Kill servers still waiting on their readiness banner (tracked separately
+		// from `servers`, so the loop above misses them).
+		for (const child of this.startupChildren) {
+			try {
+				child.kill();
+			} catch (err) {
+				void captureException(err);
+			}
+		}
+		this.startupChildren.clear();
 		this.starting.clear();
 	}
+}
+
+/**
+ * Build the cache key for a server instance. Keying on the binary path alone
+ * would let agents/sessions with different environments (e.g. distinct API keys
+ * or PATH) reuse a server started with someone else's env, leaking credentials
+ * and config across sessions. Fold a stable fingerprint of the env inputs into
+ * the key so those get their own server.
+ */
+function buildServerKey(opts: EnsureServerOptions): string {
+	const fingerprint = (record?: Record<string, string>): string =>
+		record
+			? Object.keys(record)
+					.sort()
+					.map((k) => `${k}=${record[k]}`)
+					.join(' ')
+			: '';
+	return [
+		opts.binaryPath,
+		fingerprint(opts.customEnvVars),
+		fingerprint(opts.shellEnvVars),
+		(opts.extraPathDirs ?? []).join(':'),
+	].join('\u0001');
 }
 
 /** Find an available ephemeral TCP port on the loopback interface. */

--- a/src/main/opencode-server/event-translator.ts
+++ b/src/main/opencode-server/event-translator.ts
@@ -69,11 +69,14 @@ export class OpencodeEventTranslator {
 				return { lines: this.flushPendingText(), idle: true, errored: false };
 
 			case 'session.error': {
-				// session.error omits sessionID for some error kinds; treat a missing
-				// id as "belongs to us" so we never swallow a fatal error, but ignore
-				// errors explicitly tagged with a different session.
-				const sid = event.properties.sessionID;
-				if (sid && sid !== this.sessionId) return EMPTY;
+				// Only end this turn on an error explicitly scoped to our session. The
+				// SDK marks `session.error.sessionID` optional, and session-less errors
+				// (init/provider failures with no owning session) are broadcast to every
+				// subscriber on the shared server. Treating those as ours would abort
+				// unrelated concurrent turns, so we require an exact id match and drop
+				// the rest. (Trade-off: a truly global fatal error won't force-end this
+				// turn; it ends on the normal session.idle instead.)
+				if (event.properties.sessionID !== this.sessionId) return EMPTY;
 				const line = this.buildErrorLine(event.properties.error);
 				return { lines: line ? [line] : [], idle: false, errored: true };
 			}

--- a/src/main/opencode-server/event-translator.ts
+++ b/src/main/opencode-server/event-translator.ts
@@ -1,0 +1,191 @@
+// src/main/opencode-server/event-translator.ts
+
+/**
+ * OpenCode SSE -> CLI JSONL translator.
+ *
+ * The OpenCode SDK server streams a rich SSE event union (`message.part.updated`,
+ * `session.idle`, `session.error`, ...). Maestro's existing OpenCode pipeline -
+ * the main-process `OpenCodeOutputParser`, the renderer peek/wizard parsers, and
+ * everything downstream - was built against the JSONL that `opencode run --format
+ * json` writes to stdout, i.e. lines shaped like:
+ *
+ *   { type: 'step_start' | 'text' | 'tool_use' | 'step_finish' | 'error',
+ *     sessionID, part: { ... } }
+ *
+ * Rather than re-plumb the whole stack, this translator converts SDK events back
+ * into those identical JSONL lines so the server path reuses the CLI parse/render
+ * stack verbatim. The SDK `Part` shapes already match the CLI `part` fields
+ * one-to-one; the only real work is:
+ *   - mapping the SDK part.type (hyphenated: "step-start", "tool", "step-finish")
+ *     to the CLI top-level message type (underscored: "step_start", "tool_use",
+ *     "step_finish"),
+ *   - filtering the shared server's multiplexed stream down to a single session,
+ *   - gating streaming text so each completed text block is emitted exactly once
+ *     (the CLI emits one complete `text` message per block, not per delta).
+ *
+ * The translator is intentionally pure/stateful-per-session and free of any SDK
+ * client or process concerns so it can be unit-tested in isolation.
+ */
+
+import type { Event, Part } from '@opencode-ai/sdk';
+
+/** A single translated result of feeding one SDK event to the translator. */
+export interface TranslatedEvent {
+	/** CLI-format JSONL lines to feed through StdoutHandler (may be empty). */
+	lines: string[];
+	/** True when this event signals the target session has gone idle (turn done). */
+	idle: boolean;
+	/** True when this event carried a session error for the target session. */
+	errored: boolean;
+}
+
+const EMPTY: TranslatedEvent = { lines: [], idle: false, errored: false };
+
+/**
+ * Translate a single OpenCode server session's SSE events into CLI JSONL lines.
+ *
+ * One instance per spawned prompt. Construct it with the OpenCode session id so
+ * events belonging to other sessions/projects on the shared server are ignored.
+ */
+export class OpencodeEventTranslator {
+	/** Text part ids already flushed as a completed `text` line (dedup guard). */
+	private emittedTextPartIds = new Set<string>();
+	/** Latest cumulative text seen per text part id, for end-of-turn flushing. */
+	private pendingText = new Map<string, string>();
+
+	constructor(private readonly sessionId: string) {}
+
+	/**
+	 * Feed one SDK event. Returns the JSONL line(s) to forward plus idle/error
+	 * signals. Events for other sessions return an empty result.
+	 */
+	handle(event: Event): TranslatedEvent {
+		switch (event.type) {
+			case 'message.part.updated':
+				return this.handlePart(event.properties.part);
+
+			case 'session.idle':
+				if (event.properties.sessionID !== this.sessionId) return EMPTY;
+				return { lines: this.flushPendingText(), idle: true, errored: false };
+
+			case 'session.error': {
+				// session.error omits sessionID for some error kinds; treat a missing
+				// id as "belongs to us" so we never swallow a fatal error, but ignore
+				// errors explicitly tagged with a different session.
+				const sid = event.properties.sessionID;
+				if (sid && sid !== this.sessionId) return EMPTY;
+				const line = this.buildErrorLine(event.properties.error);
+				return { lines: line ? [line] : [], idle: false, errored: true };
+			}
+
+			default:
+				return EMPTY;
+		}
+	}
+
+	/** Flush any streamed-but-not-completed text blocks (called on idle). */
+	private flushPendingText(): string[] {
+		const lines: string[] = [];
+		for (const [partId, text] of this.pendingText) {
+			if (this.emittedTextPartIds.has(partId)) continue;
+			this.emittedTextPartIds.add(partId);
+			lines.push(this.buildTextLine(text));
+		}
+		this.pendingText.clear();
+		return lines;
+	}
+
+	private handlePart(part: Part): TranslatedEvent {
+		if (part.sessionID !== this.sessionId) return EMPTY;
+
+		switch (part.type) {
+			case 'step-start':
+				return {
+					lines: [this.buildLine('step_start', { type: 'step-start' })],
+					idle: false,
+					errored: false,
+				};
+
+			case 'text': {
+				// SDK emits `message.part.updated` repeatedly as text streams in, each
+				// carrying the cumulative text. The CLI emits one complete `text`
+				// message per block. Emit only when the block is complete (time.end set),
+				// exactly once; otherwise buffer for an end-of-turn flush.
+				const complete = part.time?.end !== undefined;
+				if (!complete) {
+					this.pendingText.set(part.id, part.text);
+					return EMPTY;
+				}
+				if (this.emittedTextPartIds.has(part.id)) return EMPTY;
+				this.emittedTextPartIds.add(part.id);
+				this.pendingText.delete(part.id);
+				return { lines: [this.buildTextLine(part.text, part.time)], idle: false, errored: false };
+			}
+
+			case 'tool': {
+				// The renderer merges running/completed/error updates by callID, so
+				// forwarding every non-pending state transition gives live tool status
+				// without duplicate log entries. Pending carries no useful detail yet.
+				if (part.state.status === 'pending') return EMPTY;
+				return {
+					lines: [
+						this.buildLine('tool_use', {
+							type: 'tool',
+							tool: part.tool,
+							callID: part.callID,
+							state: part.state,
+						}),
+					],
+					idle: false,
+					errored: false,
+				};
+			}
+
+			case 'step-finish':
+				return {
+					lines: [
+						this.buildLine('step_finish', {
+							type: 'step-finish',
+							reason: part.reason,
+							cost: part.cost,
+							tokens: part.tokens,
+						}),
+					],
+					idle: false,
+					errored: false,
+				};
+
+			// reasoning/file/snapshot/patch/agent/retry/compaction/subtask parts have
+			// no CLI-JSONL equivalent the existing parser consumes; skip for parity.
+			default:
+				return EMPTY;
+		}
+	}
+
+	/** Build a CLI JSONL message line: `{ type, sessionID, part }`. */
+	private buildLine(type: string, part: Record<string, unknown>): string {
+		return JSON.stringify({ type, sessionID: this.sessionId, part });
+	}
+
+	private buildTextLine(text: string, time?: { start: number; end?: number }): string {
+		return this.buildLine('text', { type: 'text', text, ...(time ? { time } : {}) });
+	}
+
+	/**
+	 * Build a CLI `error` line. The SDK error objects (`ApiError`, `UnknownError`,
+	 * `ProviderAuthError`, ...) already expose `{ name, data: { message } }`, which
+	 * is exactly the shape `OpenCodeOutputParser.detectErrorFromParsed` reads.
+	 */
+	private buildErrorLine(error: unknown): string | null {
+		if (!error) {
+			// A session error with no payload still needs to surface as an error so the
+			// turn doesn't silently succeed. Emit a minimal recognizable error object.
+			return JSON.stringify({
+				type: 'error',
+				sessionID: this.sessionId,
+				error: { name: 'UnknownError', data: { message: 'OpenCode session error' } },
+			});
+		}
+		return JSON.stringify({ type: 'error', sessionID: this.sessionId, error });
+	}
+}

--- a/src/main/opencode-server/sdk-loader.ts
+++ b/src/main/opencode-server/sdk-loader.ts
@@ -1,0 +1,29 @@
+// src/main/opencode-server/sdk-loader.ts
+
+/**
+ * Runtime loader for the ESM-only `@opencode-ai/sdk`.
+ *
+ * The Electron main process is compiled to CommonJS (`tsconfig.main.json` uses
+ * `module: CommonJS`). A static `import`/`require` of the SDK throws
+ * `ERR_REQUIRE_ESM`, and tsc downlevels a plain `await import(...)` to
+ * `require(...)` - which hits the same wall. Wrapping the dynamic import in an
+ * indirect `Function` call keeps a *native* `import()` in the emitted output, so
+ * the ESM module loads correctly at runtime. Types still come from the package
+ * via `import type`, resolved through the `paths` mapping in tsconfig.main.json.
+ */
+
+import type * as OpencodeSdk from '@opencode-ai/sdk';
+
+const dynamicImport = new Function('specifier', 'return import(specifier)') as (
+	specifier: string
+) => Promise<typeof OpencodeSdk>;
+
+let cached: Promise<typeof OpencodeSdk> | null = null;
+
+/** Load the OpenCode SDK once and cache the module namespace. */
+export function loadOpencodeSdk(): Promise<typeof OpencodeSdk> {
+	if (!cached) {
+		cached = dynamicImport('@opencode-ai/sdk');
+	}
+	return cached;
+}

--- a/src/main/opencode-server/sdk-loader.ts
+++ b/src/main/opencode-server/sdk-loader.ts
@@ -23,7 +23,13 @@ let cached: Promise<typeof OpencodeSdk> | null = null;
 /** Load the OpenCode SDK once and cache the module namespace. */
 export function loadOpencodeSdk(): Promise<typeof OpencodeSdk> {
 	if (!cached) {
-		cached = dynamicImport('@opencode-ai/sdk');
+		// Clear the cache on failure so a transient import error (e.g. a mid-install
+		// race) doesn't permanently poison every future load with the rejected
+		// promise. Successful loads stay cached.
+		cached = dynamicImport('@opencode-ai/sdk').catch((err) => {
+			cached = null;
+			throw err;
+		});
 	}
 	return cached;
 }

--- a/src/main/process-manager/ProcessManager.ts
+++ b/src/main/process-manager/ProcessManager.ts
@@ -50,7 +50,15 @@ export class ProcessManager extends EventEmitter {
 	private localCommandRunner: LocalCommandRunner;
 	private sshCommandRunner: SshCommandRunner;
 
-	constructor() {
+	constructor(
+		/**
+		 * Live read of the `encoreFeatures.opencodeServer` gate. Defaults to off so
+		 * tests and any caller that builds ProcessManager without the wiring never
+		 * route to the SDK-serve path. Read on every spawn so toggling the plugin
+		 * takes effect without an app restart.
+		 */
+		private readonly isOpencodeServerEnabled: () => boolean = () => false
+	) {
 		super();
 		this.bufferManager = new DataBufferManager(this.processes, this);
 		this.ptySpawner = new PtySpawner(this.processes, this, this.bufferManager);
@@ -155,7 +163,8 @@ export class ProcessManager extends EventEmitter {
 	}
 
 	/**
-	 * Route local, interactive OpenCode prompt turns through the SDK server path.
+	 * Route local, interactive OpenCode prompt turns through the SDK server path,
+	 * gated behind the default-off `encoreFeatures.opencodeServer` plugin.
 	 *
 	 * Excluded (stay on the CLI path):
 	 * - SSH-remote sessions (the SDK server spawn is local-only; deferred).
@@ -165,6 +174,10 @@ export class ProcessManager extends EventEmitter {
 	 */
 	private shouldUseOpencodeServer(config: ProcessConfig): boolean {
 		return (
+			// Default-off plugin gate (encoreFeatures.opencodeServer). While it is
+			// off, OpenCode stays on the CLI path — which keeps the Coworking MCP
+			// working, since the serve transport can't inject per-session env.
+			this.isOpencodeServerEnabled() &&
 			config.toolType === 'opencode' &&
 			!!config.prompt &&
 			!config.sshRemoteId &&

--- a/src/main/process-manager/ProcessManager.ts
+++ b/src/main/process-manager/ProcessManager.ts
@@ -12,9 +12,11 @@ import type {
 } from './types';
 import { PtySpawner } from './spawners/PtySpawner';
 import { ChildProcessSpawner } from './spawners/ChildProcessSpawner';
+import { OpencodeServerSpawner } from './spawners/OpencodeServerSpawner';
 import { DataBufferManager } from './handlers/DataBufferManager';
 import { LocalCommandRunner } from './runners/LocalCommandRunner';
 import { SshCommandRunner } from './runners/SshCommandRunner';
+import { opencodeServerManager } from '../opencode-server/OpencodeServerManager';
 import { logger } from '../utils/logger';
 import { isWindows } from '../../shared/platformDetection';
 import type { SshRemoteConfig } from '../../shared/types';
@@ -44,6 +46,7 @@ export class ProcessManager extends EventEmitter {
 	private bufferManager: DataBufferManager;
 	private ptySpawner: PtySpawner;
 	private childProcessSpawner: ChildProcessSpawner;
+	private opencodeServerSpawner: OpencodeServerSpawner;
 	private localCommandRunner: LocalCommandRunner;
 	private sshCommandRunner: SshCommandRunner;
 
@@ -52,6 +55,14 @@ export class ProcessManager extends EventEmitter {
 		this.bufferManager = new DataBufferManager(this.processes, this);
 		this.ptySpawner = new PtySpawner(this.processes, this, this.bufferManager);
 		this.childProcessSpawner = new ChildProcessSpawner(this.processes, this, this.bufferManager);
+		// The OpenCode SDK path falls back to the CLI spawner when the shared
+		// server can't start, so local OpenCode never regresses to "broken".
+		this.opencodeServerSpawner = new OpencodeServerSpawner(
+			this.processes,
+			this,
+			this.bufferManager,
+			(config) => this.childProcessSpawner.spawn(config)
+		);
 		this.localCommandRunner = new LocalCommandRunner(this);
 		this.sshCommandRunner = new SshCommandRunner(this);
 	}
@@ -107,6 +118,10 @@ export class ProcessManager extends EventEmitter {
 						},
 					};
 
+		if (this.shouldUseOpencodeServer(configWithCoworkingSession)) {
+			return this.opencodeServerSpawner.spawn(configWithCoworkingSession);
+		}
+
 		const usePty = this.shouldUsePty(configWithCoworkingSession);
 		const result = usePty
 			? this.ptySpawner.spawn(configWithCoworkingSession)
@@ -128,6 +143,24 @@ export class ProcessManager extends EventEmitter {
 	private shouldUsePty(config: ProcessConfig): boolean {
 		const { toolType, requiresPty, prompt } = config;
 		return (toolType === 'terminal' || requiresPty === true) && !prompt;
+	}
+
+	/**
+	 * Route local, interactive OpenCode prompt turns through the SDK server path.
+	 *
+	 * Excluded (stay on the CLI path):
+	 * - SSH-remote sessions (the SDK server spawn is local-only; deferred).
+	 * - Image prompts (handled by the CLI's file-based `-f` args; the SDK path is
+	 *   text-only for now and falls back anyway).
+	 * - Non-prompt spawns (the SDK path is prompt-driven).
+	 */
+	private shouldUseOpencodeServer(config: ProcessConfig): boolean {
+		return (
+			config.toolType === 'opencode' &&
+			!!config.prompt &&
+			!config.sshRemoteId &&
+			!(config.images && config.images.length > 0)
+		);
 	}
 
 	/**
@@ -199,7 +232,11 @@ export class ProcessManager extends EventEmitter {
 		if (!process) return false;
 
 		try {
-			if (process.isTerminal && process.ptyProcess) {
+			if (process.sdkController) {
+				// Server-backed (OpenCode SDK) process: abort the in-flight turn.
+				process.sdkController.interrupt();
+				return true;
+			} else if (process.isTerminal && process.ptyProcess) {
 				process.ptyProcess.write('\x03');
 				return true;
 			} else if (process.childProcess) {
@@ -290,7 +327,12 @@ export class ProcessManager extends EventEmitter {
 			}
 			this.bufferManager.flushDataBuffer(sessionId);
 
-			if (proc.isTerminal && proc.ptyProcess) {
+			if (proc.sdkController) {
+				// Server-backed (OpenCode SDK) process: no OS child to signal. Abort
+				// the turn and tear down the SSE subscription; the stream ending emits
+				// the exit event. Fall through to the map deletion below.
+				proc.sdkController.kill();
+			} else if (proc.isTerminal && proc.ptyProcess) {
 				if (isWindows() && proc.pid) {
 					// On Windows, node-pty's kill() only terminates the direct ConPTY
 					// child (the shell), not grandchild processes it spawned (e.g., dev
@@ -413,6 +455,8 @@ export class ProcessManager extends EventEmitter {
 			// on POSIX this has no effect (SIGTERM is already non-blocking).
 			this.kill(sessionId, { sync: true, shutdown });
 		}
+		// Tear down the shared OpenCode server(s) that back the SDK path.
+		opencodeServerManager.shutdown();
 	}
 
 	/**

--- a/src/main/process-manager/ProcessManager.ts
+++ b/src/main/process-manager/ProcessManager.ts
@@ -86,6 +86,19 @@ export class ProcessManager extends EventEmitter {
 			this.kill(config.sessionId);
 		}
 
+		// Decide the OpenCode SDK-serve path on the RAW config, before any coworking
+		// env injection. The serve transport uses a single, process-wide `opencode
+		// serve` keyed by an env fingerprint (OpencodeServerManager.buildServerKey);
+		// injecting the per-session MAESTRO_COWORKING_SESSION_ID here would fingerprint
+		// into a distinct server per session, fragmenting the shared server. Coworking
+		// over the serve transport needs a per-request mechanism (tracked follow-up),
+		// so we skip injection on this path. The coworking bridge fails closed for the
+		// resulting env-less MCP subprocess (its parent is the shared serve PID, not a
+		// tracked agent CLI), so the tools are cleanly unavailable, never mis-scoped.
+		if (this.shouldUseOpencodeServer(config)) {
+			return this.opencodeServerSpawner.spawn(config);
+		}
+
 		// Inject the *owning Maestro session id* into the agent CLI's env so the
 		// coworking MCP subprocess (spawned by the agent's MCP client, inheriting
 		// parent env) can announce the correct caller key to the bridge. We must
@@ -117,10 +130,6 @@ export class ProcessManager extends EventEmitter {
 							...(config.customEnvVars ?? {}),
 						},
 					};
-
-		if (this.shouldUseOpencodeServer(configWithCoworkingSession)) {
-			return this.opencodeServerSpawner.spawn(configWithCoworkingSession);
-		}
 
 		const usePty = this.shouldUsePty(configWithCoworkingSession);
 		const result = usePty

--- a/src/main/process-manager/spawners/OpencodeServerSpawner.ts
+++ b/src/main/process-manager/spawners/OpencodeServerSpawner.ts
@@ -1,0 +1,341 @@
+// src/main/process-manager/spawners/OpencodeServerSpawner.ts
+
+/**
+ * Spawns a local, interactive OpenCode "process" backed by the shared
+ * `opencode serve` server via `@opencode-ai/sdk`, instead of a one-shot
+ * `opencode run` child process.
+ *
+ * Why: the server exposes a live SSE event stream (including `permission.updated`),
+ * which is the foundation for bubbling permission requests up to the user. This
+ * spawner does the transport swap while preserving the existing pipeline: it
+ * registers a `ManagedProcess` (with no OS child), then translates the SDK's SSE
+ * events back into the CLI's JSONL lines and feeds them through the very same
+ * `StdoutHandler`/`ExitHandler` the CLI path uses. Everything downstream (parser,
+ * usage, tool-execution, session-id, renderer, peek, wizard) is reused verbatim.
+ *
+ * Scope (see task decisions): local + interactive + text prompts only. SSH-remote,
+ * headless automation edge cases, and image prompts remain on the CLI path via the
+ * caller's routing and the `fallbackToCli` safety net.
+ */
+
+import { EventEmitter } from 'events';
+import { logger } from '../../utils/logger';
+import { createOutputParser } from '../../parsers';
+import { captureException } from '../../utils/sentry';
+import type { ProcessConfig, ManagedProcess, SpawnResult } from '../types';
+import type { DataBufferManager } from '../handlers/DataBufferManager';
+import { StdoutHandler } from '../handlers/StdoutHandler';
+import { ExitHandler } from '../handlers/ExitHandler';
+import { opencodeServerManager } from '../../opencode-server/OpencodeServerManager';
+import { OpencodeEventTranslator } from '../../opencode-server/event-translator';
+import type { Event, OpencodeClient } from '@opencode-ai/sdk';
+
+/** Parsed agent invocation bits we need from the CLI-style args. */
+interface OpencodeInvocation {
+	/** Existing opencode session id to resume, if any. */
+	resumeId?: string;
+	/** `{ providerID, modelID }` when `--model provider/model` was supplied. */
+	model?: { providerID: string; modelID: string };
+	/** Agent name from `--agent <name>` (e.g. `plan` for read-only mode). */
+	agent?: string;
+}
+
+/** Per-spawn termination guard: emits exit exactly once via ExitHandler. */
+interface Lifecycle {
+	finish: (code: number) => void;
+	isFinished: () => boolean;
+}
+
+/**
+ * Extract resume id / model / agent from the CLI args the caller already built
+ * (via the agent definition's `resumeArgs`/`modelArgs`/`readOnlyArgs`). Parsing
+ * here keeps the SDK migration contained to the main process - no IPC/renderer
+ * contract changes.
+ */
+function parseInvocation(config: ProcessConfig): OpencodeInvocation {
+	const { args } = config;
+	const out: OpencodeInvocation = {};
+
+	const valueAfter = (flag: string): string | undefined => {
+		const i = args.indexOf(flag);
+		if (i !== -1 && i + 1 < args.length) return args[i + 1];
+		const eq = args.find((a) => a.startsWith(`${flag}=`));
+		return eq ? eq.slice(flag.length + 1) : undefined;
+	};
+
+	out.resumeId = config.agentSessionId || valueAfter('--session');
+
+	const model = valueAfter('--model');
+	if (model) {
+		const slash = model.indexOf('/');
+		out.model =
+			slash > 0
+				? { providerID: model.slice(0, slash), modelID: model.slice(slash + 1) }
+				: { providerID: model, modelID: model };
+	}
+
+	out.agent = valueAfter('--agent');
+	return out;
+}
+
+export class OpencodeServerSpawner {
+	private stdoutHandler: StdoutHandler;
+	private exitHandler: ExitHandler;
+
+	constructor(
+		private processes: Map<string, ManagedProcess>,
+		private emitter: EventEmitter,
+		bufferManager: DataBufferManager,
+		/** Fallback used when the server can't start / session can't be created,
+		 *  so local OpenCode never regresses to "broken". Provided by ProcessManager
+		 *  (its ChildProcessSpawner.spawn). */
+		private fallbackToCli: (config: ProcessConfig) => SpawnResult
+	) {
+		this.stdoutHandler = new StdoutHandler({
+			processes: this.processes,
+			emitter: this.emitter,
+			bufferManager,
+		});
+		this.exitHandler = new ExitHandler({
+			processes: this.processes,
+			emitter: this.emitter,
+			bufferManager,
+		});
+	}
+
+	/**
+	 * Register the managed process synchronously and kick off async SDK work.
+	 * Mirrors ChildProcessSpawner: returns immediately; events flow later.
+	 */
+	spawn(config: ProcessConfig): SpawnResult {
+		const { sessionId, toolType, cwd, command, args, prompt } = config;
+
+		const outputParser = createOutputParser(toolType) || undefined;
+
+		// SSE aborter for the kill path, plus a one-shot exit guard.
+		const streamAbort = new AbortController();
+		let finished = false;
+		const lifecycle: Lifecycle = {
+			isFinished: () => finished,
+			finish: (code: number) => {
+				if (finished) return;
+				finished = true;
+				void this.exitHandler.handleExit(sessionId, code).catch((err) => {
+					logger.error('[OpencodeServerSpawner] handleExit threw', 'OpencodeServer', {
+						sessionId,
+						error: String(err),
+					});
+				});
+			},
+		};
+
+		const managedProcess: ManagedProcess = {
+			sessionId,
+			toolType,
+			cwd,
+			pid: -1,
+			isTerminal: false,
+			isBatchMode: true,
+			isStreamJsonMode: true,
+			jsonBuffer: '',
+			startTime: Date.now(),
+			outputParser,
+			stderrBuffer: '',
+			stdoutBuffer: '',
+			contextWindow: config.contextWindow,
+			command,
+			args,
+			querySource: config.querySource,
+			tabId: config.tabId,
+			projectPath: config.projectPath,
+			agentSessionId: config.agentSessionId,
+			// Wire kill/interrupt into the SDK session + SSE stream.
+			sdkController: {
+				interrupt: () => {
+					// Abort the in-flight turn but keep the session/stream alive; the
+					// resulting session.idle drives the normal exit path.
+					this.abortActiveSession(managedProcess);
+				},
+				kill: () => {
+					// Hard stop: abort the turn and tear down the SSE subscription. The
+					// stream ending triggers finish() -> exit, matching child-process
+					// kill timing (ProcessManager deletes the map entry right after).
+					this.abortActiveSession(managedProcess);
+					streamAbort.abort();
+				},
+			},
+		};
+
+		this.processes.set(sessionId, managedProcess);
+
+		if (!prompt) {
+			logger.warn(
+				'[OpencodeServerSpawner] Spawn with no prompt; nothing to run',
+				'OpencodeServer',
+				{
+					sessionId,
+				}
+			);
+			lifecycle.finish(0);
+			return { pid: -1, success: true };
+		}
+
+		// run() owns its own error handling (CLI fallback for setup failures,
+		// agent-error for streaming failures). This catch is a last-resort net.
+		void this.run(config, managedProcess, streamAbort, lifecycle).catch((err) => {
+			void captureException(err);
+			if (!lifecycle.isFinished()) {
+				this.emitAgentError(sessionId, toolType, err);
+				lifecycle.finish(1);
+			}
+		});
+
+		return { pid: -1, success: true };
+	}
+
+	private emitAgentError(sessionId: string, toolType: string, err: unknown): void {
+		this.emitter.emit('agent-error', sessionId, {
+			type: 'agent_crashed',
+			message: `OpenCode server error: ${err instanceof Error ? err.message : String(err)}`,
+			recoverable: true,
+			agentId: toolType,
+			sessionId,
+			timestamp: Date.now(),
+		});
+	}
+
+	private abortActiveSession(managedProcess: ManagedProcess): void {
+		const client = managedProcess.opencodeClient;
+		const ocSessionId = managedProcess.opencodeSessionId;
+		if (!client || !ocSessionId) return;
+		try {
+			void client.session
+				.abort({ path: { id: ocSessionId }, query: { directory: managedProcess.cwd } })
+				.catch(() => {
+					/* best effort */
+				});
+		} catch {
+			/* best effort */
+		}
+	}
+
+	private async run(
+		config: ProcessConfig,
+		managedProcess: ManagedProcess,
+		streamAbort: AbortController,
+		lifecycle: Lifecycle
+	): Promise<void> {
+		const { sessionId, toolType, cwd, command, prompt } = config;
+		const invocation = parseInvocation(config);
+
+		// ── Setup phase ──────────────────────────────────────────────────────
+		// Failures here (server won't start, session can't be created, can't
+		// subscribe) happen before any output has streamed, so we can safely
+		// degrade to the CLI path and OpenCode still works. No pump exists yet,
+		// so there's no risk of the SDK and CLI paths both writing this session.
+		let client: OpencodeClient;
+		let ocSessionId: string;
+		let subscription: { stream: unknown };
+		try {
+			({ client } = await opencodeServerManager.ensureServer({
+				binaryPath: command,
+				customEnvVars: config.customEnvVars,
+				shellEnvVars: config.shellEnvVars,
+				extraPathDirs: config.extraPathDirs,
+				cwd,
+			}));
+			managedProcess.opencodeClient = client;
+
+			// Resume an existing session or create a new one.
+			let resolvedId = invocation.resumeId;
+			if (!resolvedId) {
+				const created = await client.session.create({ query: { directory: cwd } });
+				resolvedId = created.data?.id;
+				if (!resolvedId) {
+					throw new Error('OpenCode session.create returned no session id');
+				}
+			}
+			ocSessionId = resolvedId;
+			managedProcess.opencodeSessionId = ocSessionId;
+
+			// Subscribe to the shared server's event stream BEFORE firing the prompt
+			// so no early part events are missed. The stream is multiplexed across
+			// all sessions; the translator filters down to ours.
+			subscription = await client.event.subscribe({ signal: streamAbort.signal });
+		} catch (setupErr) {
+			logger.warn(
+				'[OpencodeServerSpawner] SDK setup failed; falling back to CLI',
+				'OpencodeServer',
+				{ sessionId, error: String(setupErr) }
+			);
+			this.processes.delete(sessionId);
+			try {
+				this.fallbackToCli(config);
+			} catch (fallbackErr) {
+				void captureException(fallbackErr);
+				this.emitAgentError(sessionId, toolType, setupErr);
+				lifecycle.finish(1);
+			}
+			return;
+		}
+
+		// ── Streaming phase ──────────────────────────────────────────────────
+		// From here the process is committed to the SDK path (no CLI fallback):
+		// falling back now would double-drive the session.
+		const translator = new OpencodeEventTranslator(ocSessionId);
+
+		const pump = (async () => {
+			try {
+				for await (const event of subscription.stream as AsyncIterable<Event>) {
+					if (lifecycle.isFinished()) break;
+					const { lines, idle, errored } = translator.handle(event);
+					for (const line of lines) {
+						this.stdoutHandler.handleData(sessionId, line + '\n');
+					}
+					if (idle || errored) {
+						lifecycle.finish(0);
+						break;
+					}
+				}
+				// Stream ended (server closed or aborted) without an explicit idle.
+				lifecycle.finish(0);
+			} catch (err) {
+				// Aborted subscriptions surface as errors; treat abort as a clean stop.
+				const aborted = streamAbort.signal.aborted;
+				if (!aborted) {
+					logger.warn('[OpencodeServerSpawner] Event stream error', 'OpencodeServer', {
+						sessionId,
+						error: String(err),
+					});
+				}
+				lifecycle.finish(aborted ? 0 : 1);
+			}
+		})();
+
+		// Fire the prompt (async: events stream live via the subscription above).
+		try {
+			await client.session.promptAsync({
+				path: { id: ocSessionId },
+				query: { directory: cwd },
+				body: {
+					parts: [{ type: 'text', text: prompt as string }],
+					...(invocation.model ? { model: invocation.model } : {}),
+					...(invocation.agent ? { agent: invocation.agent } : {}),
+				},
+			});
+		} catch (promptErr) {
+			// Surface the failure and stop the pump; the session errored, not the
+			// whole transport, so no CLI fallback (that would re-run the prompt).
+			logger.warn('[OpencodeServerSpawner] promptAsync failed', 'OpencodeServer', {
+				sessionId,
+				error: String(promptErr),
+			});
+			if (!managedProcess.errorEmitted) {
+				this.emitAgentError(sessionId, toolType, promptErr);
+			}
+			streamAbort.abort();
+		}
+
+		await pump;
+	}
+}

--- a/src/main/process-manager/spawners/OpencodeServerSpawner.ts
+++ b/src/main/process-manager/spawners/OpencodeServerSpawner.ts
@@ -236,6 +236,13 @@ export class OpencodeServerSpawner {
 		let client: OpencodeClient;
 		let ocSessionId: string;
 		let subscription: { stream: unknown };
+
+		// Bail if the spawn was interrupted/killed during an await below. Without
+		// this, stale setup work could fire a prompt on an abandoned session or
+		// delete a map slot that a respawn now owns. Emit exit so the renderer
+		// doesn't hang (the map entry may already be gone via ProcessManager.kill).
+		const cancelled = (): boolean => streamAbort.signal.aborted || lifecycle.isFinished();
+
 		try {
 			({ client } = await opencodeServerManager.ensureServer({
 				binaryPath: command,
@@ -244,6 +251,10 @@ export class OpencodeServerSpawner {
 				extraPathDirs: config.extraPathDirs,
 				cwd,
 			}));
+			if (cancelled()) {
+				lifecycle.finish(0);
+				return;
+			}
 			managedProcess.opencodeClient = client;
 
 			// Resume an existing session or create a new one.
@@ -255,6 +266,10 @@ export class OpencodeServerSpawner {
 					throw new Error('OpenCode session.create returned no session id');
 				}
 			}
+			if (cancelled()) {
+				lifecycle.finish(0);
+				return;
+			}
 			ocSessionId = resolvedId;
 			managedProcess.opencodeSessionId = ocSessionId;
 
@@ -262,20 +277,35 @@ export class OpencodeServerSpawner {
 			// so no early part events are missed. The stream is multiplexed across
 			// all sessions; the translator filters down to ours.
 			subscription = await client.event.subscribe({ signal: streamAbort.signal });
+			if (cancelled()) {
+				lifecycle.finish(0);
+				return;
+			}
 		} catch (setupErr) {
+			// A kill mid-setup surfaces as an aborted subscribe/create rejection —
+			// that's a clean stop, not a transport failure, so don't fall back to CLI.
+			if (cancelled()) {
+				lifecycle.finish(0);
+				return;
+			}
 			logger.warn(
 				'[OpencodeServerSpawner] SDK setup failed; falling back to CLI',
 				'OpencodeServer',
 				{ sessionId, error: String(setupErr) }
 			);
-			this.processes.delete(sessionId);
-			try {
-				this.fallbackToCli(config);
-			} catch (fallbackErr) {
-				void captureException(fallbackErr);
-				this.emitAgentError(sessionId, toolType, setupErr);
-				lifecycle.finish(1);
+			// Only reclaim the slot if it's still ours — a concurrent respawn for the
+			// same sessionId must not be clobbered by our fallback.
+			if (this.processes.get(sessionId) === managedProcess) {
+				this.processes.delete(sessionId);
+				try {
+					this.fallbackToCli(config);
+					return;
+				} catch (fallbackErr) {
+					void captureException(fallbackErr);
+				}
 			}
+			this.emitAgentError(sessionId, toolType, setupErr);
+			lifecycle.finish(1);
 			return;
 		}
 
@@ -293,7 +323,10 @@ export class OpencodeServerSpawner {
 						this.stdoutHandler.handleData(sessionId, line + '\n');
 					}
 					if (idle || errored) {
-						lifecycle.finish(0);
+						// A session error ends the turn with a non-zero code so exit-based
+						// consumers (stats/query-complete) see the failure; the error text
+						// itself was already surfaced via the emitted error line.
+						lifecycle.finish(errored ? 1 : 0);
 						break;
 					}
 				}
@@ -333,6 +366,9 @@ export class OpencodeServerSpawner {
 			if (!managedProcess.errorEmitted) {
 				this.emitAgentError(sessionId, toolType, promptErr);
 			}
+			// Finish non-zero before aborting so the failure exit code wins over the
+			// pump's abort-driven finish(0) (finish is idempotent, first call sticks).
+			lifecycle.finish(1);
 			streamAbort.abort();
 		}
 

--- a/src/main/process-manager/spawners/OpencodeServerSpawner.ts
+++ b/src/main/process-manager/spawners/OpencodeServerSpawner.ts
@@ -185,7 +185,7 @@ export class OpencodeServerSpawner {
 		void this.run(config, managedProcess, streamAbort, lifecycle).catch((err) => {
 			void captureException(err);
 			if (!lifecycle.isFinished()) {
-				this.emitAgentError(sessionId, toolType, err);
+				this.emitAgentError(managedProcess, err);
 				lifecycle.finish(1);
 			}
 		});
@@ -193,13 +193,20 @@ export class OpencodeServerSpawner {
 		return { pid: -1, success: true };
 	}
 
-	private emitAgentError(sessionId: string, toolType: string, err: unknown): void {
-		this.emitter.emit('agent-error', sessionId, {
+	/**
+	 * Emit an agent-error for this process, at most once. Sets `errorEmitted` so
+	 * ExitHandler's exit-based error detection doesn't then emit a duplicate
+	 * generic "exited with code 1" error on the finish(1) path.
+	 */
+	private emitAgentError(managedProcess: ManagedProcess, err: unknown): void {
+		if (managedProcess.errorEmitted) return;
+		managedProcess.errorEmitted = true;
+		this.emitter.emit('agent-error', managedProcess.sessionId, {
 			type: 'agent_crashed',
 			message: `OpenCode server error: ${err instanceof Error ? err.message : String(err)}`,
 			recoverable: true,
-			agentId: toolType,
-			sessionId,
+			agentId: managedProcess.toolType,
+			sessionId: managedProcess.sessionId,
 			timestamp: Date.now(),
 		});
 	}
@@ -225,7 +232,7 @@ export class OpencodeServerSpawner {
 		streamAbort: AbortController,
 		lifecycle: Lifecycle
 	): Promise<void> {
-		const { sessionId, toolType, cwd, command, prompt } = config;
+		const { sessionId, cwd, command, prompt } = config;
 		const invocation = parseInvocation(config);
 
 		// ── Setup phase ──────────────────────────────────────────────────────
@@ -304,7 +311,7 @@ export class OpencodeServerSpawner {
 					void captureException(fallbackErr);
 				}
 			}
-			this.emitAgentError(sessionId, toolType, setupErr);
+			this.emitAgentError(managedProcess, setupErr);
 			lifecycle.finish(1);
 			return;
 		}
@@ -363,9 +370,7 @@ export class OpencodeServerSpawner {
 				sessionId,
 				error: String(promptErr),
 			});
-			if (!managedProcess.errorEmitted) {
-				this.emitAgentError(sessionId, toolType, promptErr);
-			}
+			this.emitAgentError(managedProcess, promptErr);
 			// Finish non-zero before aborting so the failure exit code wins over the
 			// pump's abort-driven finish(0) (finish is idempotent, first call sticks).
 			lifecycle.finish(1);

--- a/src/main/process-manager/types.ts
+++ b/src/main/process-manager/types.ts
@@ -1,7 +1,20 @@
 import type { ChildProcess } from 'child_process';
 import type { IPty } from 'node-pty';
+import type { OpencodeClient } from '@opencode-ai/sdk';
 import type { AgentOutputParser } from '../parsers';
 import type { AgentError } from '../../shared/types';
+
+/**
+ * Kill/interrupt handle for server-backed processes that have no OS child
+ * (currently the OpenCode SDK path). ProcessManager routes kill()/interrupt()
+ * here when `ManagedProcess.sdkController` is set.
+ */
+export interface SdkProcessController {
+	/** Abort the in-flight turn; the session/stream stays alive. */
+	interrupt: () => void;
+	/** Hard stop: abort the turn and tear down the event subscription. */
+	kill: () => void;
+}
 
 /**
  * Configuration for spawning a new process
@@ -119,6 +132,14 @@ export interface ManagedProcess {
 	 *  Inherited system env is NOT included — this is the actionable set shown in the
 	 *  Process Details modal. */
 	maestroEnvVars?: Record<string, string>;
+	/** Kill/interrupt handle for server-backed processes (OpenCode SDK path). When
+	 *  set, this process has no `ptyProcess`/`childProcess`; ProcessManager routes
+	 *  lifecycle calls through here instead of OS signals. */
+	sdkController?: SdkProcessController;
+	/** OpenCode server session id for the SDK path (used to abort the turn). */
+	opencodeSessionId?: string;
+	/** OpenCode SDK client bound to the shared server, for abort calls. */
+	opencodeClient?: OpencodeClient;
 }
 
 export interface UsageTotals {

--- a/src/renderer/components/Settings/Extensions/extensionModel.ts
+++ b/src/renderer/components/Settings/Extensions/extensionModel.ts
@@ -92,7 +92,8 @@ export const BUILTIN_FEATURES: readonly BuiltinFeatureDef[] = FIRST_PARTY_PLUGIN
 			def.encoreFlag === 'maestroCue' ||
 			def.encoreFlag === 'directorNotes' ||
 			def.encoreFlag === 'pianola' ||
-			def.encoreFlag === 'coworking',
+			def.encoreFlag === 'coworking' ||
+			def.encoreFlag === 'opencodeServer',
 		pluginBacking: def,
 	})
 );

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -1220,6 +1220,11 @@ export interface EncoreFeatureFlags {
 	// Off by default. Optional so existing literals (older test fixtures, persisted
 	// settings without the key) continue to type-check.
 	coworking?: boolean;
+	// OpenCode Server - run local interactive OpenCode via a shared `opencode
+	// serve` process (SDK) instead of a per-prompt CLI spawn. Off by default.
+	// Optional so existing literals (older fixtures, persisted settings without
+	// the key) continue to type-check.
+	opencodeServer?: boolean;
 }
 
 // Director's Notes settings for synopsis generation

--- a/src/shared/plugins/first-party.ts
+++ b/src/shared/plugins/first-party.ts
@@ -36,7 +36,8 @@ export type FirstPartyEncoreFlag =
 	| 'symphony'
 	| 'maestroCue'
 	| 'pianola'
-	| 'coworking';
+	| 'coworking'
+	| 'opencodeServer';
 
 /** A supervised background service a first-party plugin runs. */
 export interface FirstPartyBackgroundService {
@@ -185,6 +186,33 @@ export const COWORKING_FIRST_PARTY_PLUGIN: FirstPartyPluginDefinition = {
 	// No supervised background service tied to the flag: the coworking IPC bridge
 	// is app-scoped (main startup/shutdown owns its lifecycle), so disable = flag
 	// off + per-agent MCP uninstall; nothing flag-supervised keeps running.
+	backgroundServices: [],
+};
+
+/** Broker capabilities the OpenCode Server path actually touches. It re-reads
+ * its own Encore flag to route each turn; the shared `opencode serve` process
+ * is spawned host-side (the user's resolved binary, same authority as the CLI
+ * path) and is app-scoped via OpencodeServerManager (lazy start, torn down on
+ * quit), so there is no broker verb and no flag-supervised background service. */
+export const OPENCODE_SERVER_FIRST_PARTY_PLUGIN: FirstPartyPluginDefinition = {
+	id: 'com.maestro.opencode-server',
+	name: 'OpenCode Server',
+	description:
+		'Run local, interactive OpenCode through a shared `opencode serve` process (SDK) instead of a per-prompt CLI spawn — the foundation for live permission prompts. Known limitation: the Coworking MCP is unavailable on this path (tracked follow-up).',
+	firstParty: true,
+	category: 'agents',
+	permissions: [
+		{
+			capability: 'settings:read',
+			reason:
+				'Re-read the OpenCode Server Encore flag before routing each OpenCode prompt turn to the shared server path.',
+		},
+	],
+	settingsNamespace: 'opencodeServer',
+	encoreFlag: 'opencodeServer',
+	// The shared `opencode serve` process is app-scoped (spawned lazily by
+	// OpencodeServerManager, torn down on quit), not flag-supervised: disable =
+	// flag off, and routing falls back to the CLI path. Nothing keeps running.
 	backgroundServices: [],
 };
 
@@ -494,6 +522,7 @@ export const FIRST_PARTY_PLUGIN_DEFINITIONS: readonly FirstPartyPluginDefinition
 	DIRECTOR_NOTES_FIRST_PARTY_PLUGIN,
 	PIANOLA_FIRST_PARTY_PLUGIN,
 	COWORKING_FIRST_PARTY_PLUGIN,
+	OPENCODE_SERVER_FIRST_PARTY_PLUGIN,
 ];
 
 /**
@@ -511,4 +540,5 @@ export const FIRST_PARTY_PLUGINS: Readonly<
 	maestroCue: MAESTRO_CUE_FIRST_PARTY_PLUGIN,
 	pianola: PIANOLA_FIRST_PARTY_PLUGIN,
 	coworking: COWORKING_FIRST_PARTY_PLUGIN,
+	opencodeServer: OPENCODE_SERVER_FIRST_PARTY_PLUGIN,
 };

--- a/src/shared/settingsMetadata.ts
+++ b/src/shared/settingsMetadata.ts
@@ -1033,6 +1033,7 @@ export const SETTINGS_METADATA: Record<string, SettingMetadata> = {
 			pianola: false,
 			plugins: false,
 			coworking: false,
+			opencodeServer: false,
 		},
 		category: 'advanced',
 	},

--- a/tsconfig.main.json
+++ b/tsconfig.main.json
@@ -10,6 +10,12 @@
 		"ignoreDeprecations": "6.0",
 		"outDir": "dist",
 		"rootDir": "src",
+		// @opencode-ai/sdk is ESM-only and exposes its types solely via the package
+		// "exports" map, which classic ("node"/node10) moduleResolution cannot read.
+		// Point tsc directly at the bundled declarations until the TODO above lands.
+		"paths": {
+			"@opencode-ai/sdk": ["./node_modules/@opencode-ai/sdk/dist/index.d.ts"]
+		},
 		"resolveJsonModule": true,
 		"esModuleInterop": true,
 		"skipLibCheck": true,


### PR DESCRIPTION
## What

Adds a third execution path for **local, interactive OpenCode** that runs against a shared `opencode serve` process via `@opencode-ai/sdk`, replacing the `opencode run --format json` batch spawn. This is the foundation for **bubbling permission requests to the user**: the SDK server exposes a live SSE `permission.updated` event stream that the one-shot CLI never surfaced. The permission approval UI lands separately (Maestro-side counterpart); this PR is behavior-preserving today (the server auto-approves, exactly like the CLI path did).

## How

The SDK's SSE event stream is translated back into the **exact JSONL lines** the existing `OpenCodeOutputParser` already consumes, so the entire downstream stack (parser, renderer, peek/wizard, usage, tool-execution, session-id) is reused unchanged.

- **`src/main/opencode-server/`** (new)
  - `event-translator.ts` — pure, stateful-per-session `Event → CLI JSONL` translator. Maps the SDK's hyphenated `part.type` to the CLI's underscored top-level `type`, filters the multiplexed stream to one session, and gates streaming text so each completed block emits exactly once.
  - `OpencodeServerManager.ts` — singleton owning the shared `opencode serve` process (spawns the user's **resolved** binary, keyed by path, readiness detection, torn down on quit).
  - `sdk-loader.ts` — indirect-`import()` loader so the ESM-only SDK loads from the CommonJS main process.
- **`spawners/OpencodeServerSpawner.ts`** (new) — registers a childless `ManagedProcess`, drives session create/resume + `promptAsync`, pumps translated lines through the existing `StdoutHandler`/`ExitHandler`, and wires kill/interrupt to `session.abort` + SSE teardown. Falls back to the CLI path if the server can't start.
- **`ProcessManager`** — routes local non-image opencode prompts to the new spawner, handles `sdkController` in `kill()`/`interrupt()`, tears the server down in `killAll()`.
- **`types.ts`** — adds `SdkProcessController` + `sdkController`/`opencodeSessionId`/`opencodeClient` to `ManagedProcess`.
- **`tsconfig.main.json`** — `paths` mapping for the SDK's `exports`-only types under classic module resolution.
- Adds `@opencode-ai/sdk@1.17.13`.

## Scope

- **In:** local, interactive, text prompts.
- **On the CLI path (unchanged):** SSH-remote and image prompts.
- **Deferred:** permission bubbling UI (server auto-approves for now; the `permission.updated` events are available for the follow-up).

## Testing

- **Unit:** `event-translator.test.ts` — 11 tests incl. a round-trip through the real `OpenCodeOutputParser`.
- **Live integration (opt-in):** `opencode-sdk.integration.test.ts` — drives the real translator+parser over a live `opencode serve` turn. Gated behind `OPENCODE_LIVE=1`; skipped by default.
- **Full app (manual):** verified end-to-end in the running Electron app over CDP — spawn routes to the SDK path (one shared `opencode serve`), result/usage/session-id/exit flow through the real IPC pipeline, kill stops a turn cleanly while the server persists, and resume reuses the session.
- **CI gate green locally:** `prettier --check`, all 3 tsc configs, repo-wide ESLint, and the full suite (31,599 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for running OpenCode-backed sessions, including live event streaming and permission prompts.
  * Improved process handling so OpenCode sessions can be started, reused, interrupted, and stopped more reliably.

* **Bug Fixes**
  * Better event translation ensures streamed output, errors, and session updates are shown more consistently.
  * Fixed cleanup behavior so shared OpenCode sessions shut down correctly when processes exit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->