### PR TITLE
feat(agents): Claude Code standard permission mode with live permission relay

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,12 +26,13 @@
 		"dev:web-desktop": "vite --config vite.config.web-desktop.mts",
 		"build:web-desktop": "vite build --config vite.config.web-desktop.mts",
 		"dev:win": "powershell -NoProfile -ExecutionPolicy Bypass -File ./scripts/start-dev.ps1",
-		"build": "npm run build:main && npm run build:preload && npm run build:renderer && npm run build:web-desktop && npm run build:cli && npm run build:maestro-p",
+		"build": "npm run build:main && npm run build:preload && npm run build:renderer && npm run build:web-desktop && npm run build:cli && npm run build:maestro-p && npm run build:permission-relay-bridge",
 		"build:main": "tsc -p tsconfig.main.json",
 		"build:preload": "node scripts/build-preload.mjs",
 		"build:cli": "node scripts/build-cli.mjs",
 		"gen:cli-reference": "node scripts/gen-cli-reference.mjs",
 		"build:maestro-p": "node scripts/build-maestro-p.mjs",
+		"build:permission-relay-bridge": "node scripts/build-permission-relay-bridge.mjs",
 		"build:renderer": "vite build",
 		"package": "node scripts/set-version.mjs npm run build && node scripts/set-version.mjs electron-builder --mac --win --linux",
 		"package:mac": "node scripts/set-version.mjs npm run build && node scripts/set-version.mjs electron-builder --mac",
@@ -118,6 +119,10 @@
 					"to": "maestro-p.js"
 				},
 				{
+					"from": "dist/cli/permission-relay-bridge.js",
+					"to": "permission-relay-bridge.js"
+				},
+				{
 					"from": "src/prompts",
 					"to": "prompts/core",
 					"filter": [
@@ -165,6 +170,10 @@
 					"to": "maestro-p.js"
 				},
 				{
+					"from": "dist/cli/permission-relay-bridge.js",
+					"to": "permission-relay-bridge.js"
+				},
+				{
 					"from": "src/prompts",
 					"to": "prompts/core",
 					"filter": [
@@ -202,6 +211,10 @@
 				{
 					"from": "dist/cli/maestro-p.js",
 					"to": "maestro-p.js"
+				},
+				{
+					"from": "dist/cli/permission-relay-bridge.js",
+					"to": "permission-relay-bridge.js"
 				},
 				{
 					"from": "src/prompts",

--- a/scripts/build-permission-relay-bridge.mjs
+++ b/scripts/build-permission-relay-bridge.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+/**
+ * Build script for the permission-relay stdio MCP bridge using esbuild.
+ *
+ * Bundles src/main/permission-relay/bridge.ts into a single self-contained
+ * Node.js script at dist/cli/permission-relay-bridge.js. Mirrors
+ * scripts/build-maestro-p.mjs.
+ *
+ * Why a bundle (not the tsc output at dist/main/permission-relay/bridge.js):
+ * Claude Code spawns this bridge as an MCP server via `process.execPath` with
+ * ELECTRON_RUN_AS_NODE=1. In a PACKAGED app that plain-Node process cannot read
+ * inside app.asar, so the bridge must ship OUTSIDE the asar (via
+ * extraResources, same as maestro-p.js). A standalone file at the resources
+ * root also can't resolve a sibling `require('./types')`, so it must be bundled
+ * into one file with no relative imports. The bridge uses only Node builtins,
+ * so there are no externals to leave out.
+ */
+
+import * as esbuild from 'esbuild';
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.resolve(__dirname, '..');
+
+const outfile = path.join(rootDir, 'dist/cli/permission-relay-bridge.js');
+
+async function build() {
+	console.log('Building permission-relay bridge with esbuild...');
+
+	try {
+		await esbuild.build({
+			entryPoints: [path.join(rootDir, 'src/main/permission-relay/bridge.ts')],
+			bundle: true,
+			platform: 'node',
+			target: 'node20',
+			outfile,
+			format: 'cjs',
+			sourcemap: true,
+			minify: false, // Keep readable for debugging
+		});
+
+		fs.chmodSync(outfile, 0o755);
+
+		const stats = fs.statSync(outfile);
+		const sizeKB = (stats.size / 1024).toFixed(1);
+		console.log(`✓ Built ${outfile} (${sizeKB} KB)`);
+	} catch (error) {
+		console.error('Build failed:', error);
+		process.exit(1);
+	}
+}
+
+build();

--- a/src/__tests__/main/agents/definitions.test.ts
+++ b/src/__tests__/main/agents/definitions.test.ts
@@ -67,7 +67,10 @@ describe('agent-definitions', () => {
 			expect(claudeCode?.args).toContain('--verbose');
 			expect(claudeCode?.args).toContain('--output-format');
 			expect(claudeCode?.args).toContain('stream-json');
-			expect(claudeCode?.args).toContain('--dangerously-skip-permissions');
+			// Base args are the standard-permission default; --dangerously-skip-permissions
+			// only applies in full permission mode via fullAccessArgs.
+			expect(claudeCode?.args).not.toContain('--dangerously-skip-permissions');
+			expect(claudeCode?.fullAccessArgs).toContain('--dangerously-skip-permissions');
 		});
 
 		it('should have codex with batch mode configuration', () => {

--- a/src/__tests__/main/agents/detector.test.ts
+++ b/src/__tests__/main/agents/detector.test.ts
@@ -462,7 +462,7 @@ describe('agent-detector', () => {
 			expect(claudeAgent?.command).toBe('claude');
 			expect(claudeAgent?.args).toContain('--print');
 			expect(claudeAgent?.args).toContain('--verbose');
-			expect(claudeAgent?.args).toContain('--dangerously-skip-permissions');
+			expect(claudeAgent?.fullAccessArgs).toContain('--dangerously-skip-permissions');
 		});
 
 		it('should include terminal as hidden agent', async () => {

--- a/src/__tests__/main/cue/cue-spawn-builder.test.ts
+++ b/src/__tests__/main/cue/cue-spawn-builder.test.ts
@@ -222,7 +222,7 @@ describe('cue-spawn-builder', () => {
 
 			expect(mockBuildAgentArgs).toHaveBeenCalledWith(
 				expect.objectContaining({ id: 'claude-code' }),
-				expect.objectContaining({ yoloMode: true })
+				expect.objectContaining({ yoloMode: true, permissionMode: 'full' })
 			);
 		});
 

--- a/src/__tests__/main/ipc/handlers/process.test.ts
+++ b/src/__tests__/main/ipc/handlers/process.test.ts
@@ -365,6 +365,7 @@ describe('process IPC handlers', () => {
 				'process:isTerminalBusy',
 				'process:spawnTerminalTab',
 				'process:runCommand',
+				'permission:respond',
 			];
 
 			for (const channel of expectedChannels) {

--- a/src/__tests__/main/permission-relay/relay-core.test.ts
+++ b/src/__tests__/main/permission-relay/relay-core.test.ts
@@ -1,4 +1,7 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import {
 	registerSpawn,
 	lookupBinding,
@@ -74,24 +77,34 @@ describe('permission-relay registry', () => {
 });
 
 describe('permission-relay spawn-args', () => {
-	it('builds the permission-prompt-tool + mcp-config args', () => {
-		const { args } = buildRelayArgs(
-			'/path/to/node',
-			'/path/to/bridge.js',
-			'/tmp/relay.sock',
-			'tok'
-		);
-		expect(args[0]).toBe('--permission-prompt-tool');
-		expect(args[1]).toBe(RELAY_PERMISSION_PROMPT_TOOL);
-		expect(args[2]).toBe('--mcp-config');
+	it('writes the mcp config to a file and passes it by path (shell-safe)', () => {
+		const configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-args-'));
+		try {
+			const { args, configPath } = buildRelayArgs(
+				'/path/to/node',
+				'/path/to/bridge.js',
+				'/tmp/relay.sock',
+				'toktokreallylong0123456789abcdef',
+				configDir
+			);
+			expect(args[0]).toBe('--permission-prompt-tool');
+			expect(args[1]).toBe(RELAY_PERMISSION_PROMPT_TOOL);
+			expect(args[2]).toBe('--mcp-config');
+			// The 4th arg is a FILE PATH, not inline JSON (no shell metacharacters).
+			expect(args[3]).toBe(configPath);
+			expect(configPath.startsWith(configDir)).toBe(true);
+			expect(args[3]).not.toContain('{');
 
-		const config = JSON.parse(args[3]);
-		const server = config.mcpServers[RELAY_MCP_SERVER_NAME];
-		expect(server.command).toBe('/path/to/node');
-		expect(server.args).toEqual(['/path/to/bridge.js']);
-		expect(server.env.ELECTRON_RUN_AS_NODE).toBe('1');
-		expect(server.env.MAESTRO_RELAY_SOCKET).toBe('/tmp/relay.sock');
-		expect(server.env.MAESTRO_RELAY_TOKEN).toBe('tok');
+			const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+			const server = config.mcpServers[RELAY_MCP_SERVER_NAME];
+			expect(server.command).toBe('/path/to/node');
+			expect(server.args).toEqual(['/path/to/bridge.js']);
+			expect(server.env.ELECTRON_RUN_AS_NODE).toBe('1');
+			expect(server.env.MAESTRO_RELAY_SOCKET).toBe('/tmp/relay.sock');
+			expect(server.env.MAESTRO_RELAY_TOKEN).toBe('toktokreallylong0123456789abcdef');
+		} finally {
+			fs.rmSync(configDir, { recursive: true, force: true });
+		}
 	});
 
 	it('uses the mcp__server__tool naming for the prompt tool', () => {

--- a/src/__tests__/main/permission-relay/relay-core.test.ts
+++ b/src/__tests__/main/permission-relay/relay-core.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+	registerSpawn,
+	lookupBinding,
+	createPending,
+	resolvePending,
+	relayRegistryStats,
+} from '../../../main/permission-relay/registry';
+import { buildRelayArgs } from '../../../main/permission-relay/spawn-args';
+import {
+	RELAY_PERMISSION_PROMPT_TOOL,
+	RELAY_MCP_SERVER_NAME,
+} from '../../../main/permission-relay/types';
+
+describe('permission-relay registry', () => {
+	it('registers a spawn and looks up its binding', () => {
+		const { token, cleanup } = registerSpawn({ sessionId: 's1', tabId: 't1' });
+		expect(lookupBinding(token)).toEqual({ sessionId: 's1', tabId: 't1' });
+		cleanup();
+		expect(lookupBinding(token)).toBeUndefined();
+	});
+
+	it('generates unique tokens per spawn', () => {
+		const a = registerSpawn({ sessionId: 's1' });
+		const b = registerSpawn({ sessionId: 's1' });
+		expect(a.token).not.toBe(b.token);
+		a.cleanup();
+		b.cleanup();
+	});
+
+	it('resolves a pending request via resolvePending', async () => {
+		const { token, cleanup } = registerSpawn({ sessionId: 's1' });
+		const promise = createPending('req-1', token, 10_000);
+		expect(resolvePending('req-1', { behavior: 'allow' })).toBe(true);
+		await expect(promise).resolves.toEqual({ behavior: 'allow' });
+		cleanup();
+	});
+
+	it('returns false when resolving an unknown request', () => {
+		expect(resolvePending('does-not-exist', { behavior: 'allow' })).toBe(false);
+	});
+
+	it('auto-denies a pending request after the timeout', async () => {
+		vi.useFakeTimers();
+		try {
+			const { token, cleanup } = registerSpawn({ sessionId: 's1' });
+			const promise = createPending('req-timeout', token, 1_000);
+			vi.advanceTimersByTime(1_001);
+			await expect(promise).resolves.toEqual({
+				behavior: 'deny',
+				message: 'Permission request timed out with no response.',
+			});
+			cleanup();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it('cleanup denies any still-pending requests for that spawn', async () => {
+		const { token, cleanup } = registerSpawn({ sessionId: 's1' });
+		const promise = createPending('req-live', token, 10_000);
+		cleanup();
+		await expect(promise).resolves.toEqual({
+			behavior: 'deny',
+			message: 'Agent process exited.',
+		});
+	});
+
+	afterEach(() => {
+		// Sanity: no bindings should leak across tests that clean up.
+		// (Not strict - other tests may register; just ensure it's callable.)
+		expect(typeof relayRegistryStats().bindings).toBe('number');
+	});
+});
+
+describe('permission-relay spawn-args', () => {
+	it('builds the permission-prompt-tool + mcp-config args', () => {
+		const { args } = buildRelayArgs(
+			'/path/to/node',
+			'/path/to/bridge.js',
+			'/tmp/relay.sock',
+			'tok'
+		);
+		expect(args[0]).toBe('--permission-prompt-tool');
+		expect(args[1]).toBe(RELAY_PERMISSION_PROMPT_TOOL);
+		expect(args[2]).toBe('--mcp-config');
+
+		const config = JSON.parse(args[3]);
+		const server = config.mcpServers[RELAY_MCP_SERVER_NAME];
+		expect(server.command).toBe('/path/to/node');
+		expect(server.args).toEqual(['/path/to/bridge.js']);
+		expect(server.env.ELECTRON_RUN_AS_NODE).toBe('1');
+		expect(server.env.MAESTRO_RELAY_SOCKET).toBe('/tmp/relay.sock');
+		expect(server.env.MAESTRO_RELAY_TOKEN).toBe('tok');
+	});
+
+	it('uses the mcp__server__tool naming for the prompt tool', () => {
+		expect(RELAY_PERMISSION_PROMPT_TOOL).toBe(`mcp__${RELAY_MCP_SERVER_NAME}__approve`);
+	});
+});

--- a/src/__tests__/main/permission-relay/relay-core.test.ts
+++ b/src/__tests__/main/permission-relay/relay-core.test.ts
@@ -31,6 +31,31 @@ describe('permission-relay registry', () => {
 		b.cleanup();
 	});
 
+	it('isolates spawns: cleaning up one leaves the other binding + pending intact', async () => {
+		const a = registerSpawn({ sessionId: 'sA', tabId: 'tA' });
+		const b = registerSpawn({ sessionId: 'sB', tabId: 'tB' });
+		const aPending = createPending('req-a', a.token, 10_000);
+		const bPending = createPending('req-b', b.token, 10_000);
+
+		// Tearing down spawn A must not touch spawn B's binding or pending request.
+		a.cleanup();
+		expect(lookupBinding(a.token)).toBeUndefined();
+		expect(lookupBinding(b.token)).toEqual({ sessionId: 'sB', tabId: 'tB' });
+
+		// A's pending was denied by its cleanup; B's is still live and resolvable.
+		await expect(aPending).resolves.toEqual({
+			behavior: 'deny',
+			message: 'Agent process exited.',
+		});
+		expect(resolvePending('req-b', { behavior: 'allow' })).toBe(true);
+		await expect(bPending).resolves.toEqual({ behavior: 'allow' });
+		b.cleanup();
+	});
+
+	it('rejects lookups for unknown/forged tokens', () => {
+		expect(lookupBinding('not-a-real-token')).toBeUndefined();
+	});
+
 	it('resolves a pending request via resolvePending', async () => {
 		const { token, cleanup } = registerSpawn({ sessionId: 's1' });
 		const promise = createPending('req-1', token, 10_000);

--- a/src/__tests__/main/utils/agent-args.test.ts
+++ b/src/__tests__/main/utils/agent-args.test.ts
@@ -278,6 +278,74 @@ describe('buildAgentArgs', () => {
 		expect(result).toEqual(['--print']);
 	});
 
+	// -- permissionMode --
+	it('adds fullAccessArgs when permissionMode is full', () => {
+		const agent = makeAgent({ fullAccessArgs: ['--bypass-all'] });
+		const result = buildAgentArgs(agent, {
+			baseArgs: ['--print'],
+			permissionMode: 'full',
+		});
+		expect(result).toContain('--bypass-all');
+	});
+
+	it('falls back to yoloModeArgs when permissionMode is full and fullAccessArgs absent', () => {
+		const agent = makeAgent({ yoloModeArgs: ['--dangerously-bypass'] });
+		const result = buildAgentArgs(agent, {
+			baseArgs: ['--print'],
+			permissionMode: 'full',
+		});
+		expect(result).toContain('--dangerously-bypass');
+	});
+
+	it('adds no bypass args when permissionMode is standard', () => {
+		const agent = makeAgent({
+			fullAccessArgs: ['--bypass-all'],
+			yoloModeArgs: ['--dangerously-bypass'],
+			readOnlyArgs: ['--plan'],
+		});
+		const result = buildAgentArgs(agent, {
+			baseArgs: ['--print'],
+			permissionMode: 'standard',
+		});
+		expect(result).not.toContain('--bypass-all');
+		expect(result).not.toContain('--dangerously-bypass');
+		expect(result).not.toContain('--plan');
+	});
+
+	it('adds readOnlyArgs when permissionMode is readonly', () => {
+		const agent = makeAgent({ readOnlyArgs: ['--permission-mode', 'plan'] });
+		const result = buildAgentArgs(agent, {
+			baseArgs: ['--print'],
+			permissionMode: 'readonly',
+		});
+		expect(result).toContain('--permission-mode');
+		expect(result).toContain('plan');
+	});
+
+	it('permissionMode full takes precedence over legacy readOnlyMode: true', () => {
+		const agent = makeAgent({
+			fullAccessArgs: ['--bypass-all'],
+			readOnlyArgs: ['--plan'],
+		});
+		const result = buildAgentArgs(agent, {
+			baseArgs: ['--print'],
+			permissionMode: 'full',
+			readOnlyMode: true, // should be ignored when permissionMode is set
+		});
+		expect(result).toContain('--bypass-all');
+		expect(result).not.toContain('--plan');
+	});
+
+	it('permissionMode standard suppresses bypass args even when yoloMode: true is also passed', () => {
+		const agent = makeAgent({ yoloModeArgs: ['--dangerously-bypass'] });
+		const result = buildAgentArgs(agent, {
+			baseArgs: ['--print'],
+			permissionMode: 'standard',
+			yoloMode: true, // should be ignored when permissionMode is set
+		});
+		expect(result).not.toContain('--dangerously-bypass');
+	});
+
 	it('deduplicates Codex bypass flag when batch and yolo args both include it', () => {
 		const agent = makeAgent({
 			batchModeArgs: ['--dangerously-bypass-approvals-and-sandbox', '--skip-git-repo-check'],
@@ -329,7 +397,7 @@ describe('buildAgentArgs', () => {
 	});
 
 	// -- combined --
-	it('combines multiple options together', () => {
+	it('combines options in read-only mode', () => {
 		const agent = makeAgent({
 			batchModePrefix: ['run'],
 			batchModeArgs: ['--skip-git'],
@@ -347,7 +415,6 @@ describe('buildAgentArgs', () => {
 			cwd: '/tmp',
 			readOnlyMode: true,
 			modelId: 'gpt-4',
-			yoloMode: true,
 			agentSessionId: 'abc',
 		});
 
@@ -366,7 +433,47 @@ describe('buildAgentArgs', () => {
 			'plan',
 			'--model',
 			'gpt-4',
+			'--resume',
+			'abc',
+		]);
+	});
+
+	it('combines options in full-access mode', () => {
+		const agent = makeAgent({
+			batchModePrefix: ['run'],
+			batchModeArgs: ['--skip-git'],
+			jsonOutputArgs: ['--format', 'json'],
+			workingDirArgs: (dir: string) => ['-C', dir],
+			readOnlyArgs: ['--agent', 'plan'],
+			modelArgs: (model: string) => ['--model', model],
+			yoloModeArgs: ['--yolo'],
+			resumeArgs: (sid: string) => ['--resume', sid],
+		});
+
+		const result = buildAgentArgs(agent, {
+			baseArgs: ['--print'],
+			prompt: 'do stuff',
+			cwd: '/tmp',
+			modelId: 'gpt-4',
+			yoloMode: true,
+			agentSessionId: 'abc',
+		});
+
+		// batchModeArgs (--skip-git) IS included when not in read-only mode.
+		// workingDirArgs (-C /tmp) is prepended so the directory flag lands before
+		// the batchModePrefix subcommand (#959).
+		// readOnlyArgs are NOT included in full-access mode.
+		expect(result).toEqual([
+			'-C',
+			'/tmp',
+			'run',
+			'--print',
+			'--skip-git',
+			'--format',
+			'json',
 			'--yolo',
+			'--model',
+			'gpt-4',
 			'--resume',
 			'abc',
 		]);

--- a/src/__tests__/main/utils/context-groomer.test.ts
+++ b/src/__tests__/main/utils/context-groomer.test.ts
@@ -146,6 +146,7 @@ describe('groomContext', () => {
 			readOnlyMode: false,
 			modelId: undefined,
 			yoloMode: false,
+			permissionMode: 'standard',
 			agentSessionId: undefined,
 		});
 	});

--- a/src/__tests__/renderer/components/InputArea.test.tsx
+++ b/src/__tests__/renderer/components/InputArea.test.tsx
@@ -11,12 +11,25 @@ import { mockTheme } from '../../helpers/mockTheme';
 // Mock scrollIntoView since jsdom doesn't support it
 Element.prototype.scrollIntoView = vi.fn();
 
+const mockUpdateSessionWith = vi.fn();
+vi.mock('../../../renderer/stores/sessionStore', async (importActual) => {
+	// Preserve real exports (e.g. useSessionStore, which child components like
+	// InputTextarea subscribe to) and override only updateSessionWith so the
+	// permission-mode toggle assertions can observe it.
+	const actual = await importActual<typeof import('../../../renderer/stores/sessionStore')>();
+	return {
+		...actual,
+		updateSessionWith: (...args: unknown[]) => mockUpdateSessionWith(...args),
+	};
+});
+
 // Mock useAgentCapabilities hook - return claude-code capabilities by default
 vi.mock('../../../renderer/hooks/agent/useAgentCapabilities', () => ({
 	useAgentCapabilities: vi.fn(() => ({
 		capabilities: {
 			supportsResume: true,
 			supportsReadOnlyMode: true,
+			supportsStandardPermissionMode: true,
 			supportsJsonOutput: true,
 			supportsSessionId: true,
 			supportsImageInput: true,
@@ -40,6 +53,7 @@ vi.mock('../../../renderer/hooks/agent/useAgentCapabilities', () => ({
 			const capabilities: Record<string, boolean> = {
 				supportsResume: true,
 				supportsReadOnlyMode: true,
+				supportsStandardPermissionMode: true,
 				supportsJsonOutput: true,
 				supportsSessionId: true,
 				supportsImageInput: true,
@@ -202,6 +216,7 @@ describe('InputArea', () => {
 
 	afterEach(() => {
 		vi.restoreAllMocks();
+		mockUpdateSessionWith.mockClear();
 	});
 
 	describe('Basic Rendering', () => {
@@ -342,9 +357,9 @@ describe('InputArea', () => {
 			});
 			render(<InputArea {...props} />);
 
-			const toggle = screen.getByTitle(/Toggle plan mode/);
+			const toggle = screen.getByTitle(/Full Access/);
 			expect(toggle).toBeInTheDocument();
-			expect(toggle).toHaveTextContent('Plan-Mode');
+			expect(toggle).toHaveTextContent('Full Access');
 		});
 
 		it('hides read-only toggle when agent does not support read-only mode', async () => {
@@ -561,18 +576,24 @@ describe('InputArea', () => {
 
 		it('keeps read-only toggle enabled when AutoRun is active', () => {
 			const onToggleTabReadOnlyMode = vi.fn();
+			const session = createMockSession({ inputMode: 'ai' });
 			const props = createDefaultProps({
-				session: createMockSession({ inputMode: 'ai' }),
+				session,
 				isAutoModeActive: true,
 				onToggleTabReadOnlyMode,
 			});
 			render(<InputArea {...props} />);
 
-			const toggle = screen.getByTitle('Toggle plan mode (agent will plan but not modify files)');
+			const toggle = screen.getByTitle(/Full Access/);
 			expect(toggle).not.toBeDisabled();
 
 			fireEvent.click(toggle);
-			expect(onToggleTabReadOnlyMode).toHaveBeenCalled();
+			expect(mockUpdateSessionWith).toHaveBeenCalled();
+			const updater = mockUpdateSessionWith.mock.calls[0][1];
+			const updatedSession = updater(session);
+			const updatedTab = updatedSession.aiTabs.find((t: { id: string }) => t.id === 'tab-1');
+			expect(updatedTab.permissionMode).toBe('standard');
+			expect(updatedTab.readOnlyMode).toBe(false);
 		});
 
 		it('shows the standard tooltip when AutoRun is active', () => {
@@ -584,7 +605,9 @@ describe('InputArea', () => {
 			render(<InputArea {...props} />);
 
 			expect(
-				screen.getByTitle('Toggle plan mode (agent will plan but not modify files)')
+				screen.getByTitle(
+					'Full Access: All permission prompts bypassed. Agent can read, write, and execute without confirmation.'
+				)
 			).toBeInTheDocument();
 		});
 
@@ -597,8 +620,8 @@ describe('InputArea', () => {
 			});
 			render(<InputArea {...props} />);
 
-			const toggle = screen.getByTitle('Toggle plan mode (agent will plan but not modify files)');
-			expect(toggle).toHaveStyle({ color: mockTheme.colors.textDim });
+			const toggle = screen.getByTitle(/Full Access/);
+			expect(toggle).toHaveStyle({ color: mockTheme.colors.accent });
 		});
 	});
 
@@ -1550,17 +1573,22 @@ describe('InputArea', () => {
 			expect(setEnterToSend).toHaveBeenCalledWith(false);
 		});
 
-		it('calls onToggleTabReadOnlyMode when clicking read-only toggle', () => {
-			const onToggleTabReadOnlyMode = vi.fn();
+		it('cycles permission mode when clicking the toggle', () => {
+			const session = createMockSession({ inputMode: 'ai' });
 			const props = createDefaultProps({
-				session: createMockSession({ inputMode: 'ai' }),
-				onToggleTabReadOnlyMode,
+				session,
+				onToggleTabReadOnlyMode: vi.fn(),
 			});
 			render(<InputArea {...props} />);
 
-			fireEvent.click(screen.getByTitle(/Toggle plan mode/));
+			fireEvent.click(screen.getByTitle(/Full Access/));
 
-			expect(onToggleTabReadOnlyMode).toHaveBeenCalled();
+			expect(mockUpdateSessionWith).toHaveBeenCalled();
+			const updater = mockUpdateSessionWith.mock.calls[0][1];
+			const updatedSession = updater(session);
+			const updatedTab = updatedSession.aiTabs.find((t: { id: string }) => t.id === 'tab-1');
+			expect(updatedTab.permissionMode).toBe('standard');
+			expect(updatedTab.readOnlyMode).toBe(false);
 		});
 
 		it('calls onToggleTabSaveToHistory when clicking history toggle', () => {
@@ -1791,13 +1819,37 @@ describe('InputArea', () => {
 	describe('Toggle Button Styling', () => {
 		it('applies active styling to read-only toggle when enabled', () => {
 			const props = createDefaultProps({
-				session: createMockSession({ inputMode: 'ai' }),
+				// ToolbarControls derives its mode from activeTab.permissionMode /
+				// activeTab.readOnlyMode directly, not from the disconnected
+				// tabReadOnlyMode prop, so the tab itself must be marked readonly.
+				session: createMockSession({
+					inputMode: 'ai',
+					aiTabs: [
+						{
+							id: 'tab-1',
+							logs: [],
+							agentSessionId: null,
+							lastActivityAt: 0,
+							scrollTop: 0,
+							busyStartTime: null,
+							statusMessage: null,
+							contextUsage: null,
+							isStarred: false,
+							name: null,
+							readOnlyMode: true,
+							permissionMode: 'readonly',
+							draftInput: '',
+							saveToHistory: false,
+						},
+					] as any,
+					activeTabId: 'tab-1',
+				}),
 				tabReadOnlyMode: true,
 				onToggleTabReadOnlyMode: vi.fn(),
 			});
 			render(<InputArea {...props} />);
 
-			const toggle = screen.getByTitle(/Toggle plan mode/);
+			const toggle = screen.getByTitle(/Plan-Mode|plan mode/i);
 			// Should have warning color and background
 			expect(toggle).toHaveStyle({ color: mockTheme.colors.warning });
 		});

--- a/src/__tests__/renderer/components/InputArea/components/ToolbarControls.test.tsx
+++ b/src/__tests__/renderer/components/InputArea/components/ToolbarControls.test.tsx
@@ -3,6 +3,11 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ToolbarControls } from '../../../../../renderer/components/InputArea/components/ToolbarControls';
 import { createInputAreaSession, inputAreaTheme } from '../_fixtures';
 
+const mockUpdateSessionWith = vi.fn();
+vi.mock('../../../../../renderer/stores/sessionStore', () => ({
+	updateSessionWith: (...args: unknown[]) => mockUpdateSessionWith(...args),
+}));
+
 describe('ToolbarControls', () => {
 	const originalMatchMedia = window.matchMedia;
 
@@ -33,6 +38,7 @@ describe('ToolbarControls', () => {
 			configurable: true,
 			value: originalMatchMedia,
 		});
+		mockUpdateSessionWith.mockClear();
 	});
 
 	function renderToolbar(overrides = {}) {
@@ -44,6 +50,7 @@ describe('ToolbarControls', () => {
 				isReadOnlyMode={false}
 				canAttachImages
 				hasReadOnlyCapability
+				hasStandardCapability
 				enterToSend
 				setEnterToSend={vi.fn()}
 				setStagedImages={vi.fn()}
@@ -52,7 +59,6 @@ describe('ToolbarControls', () => {
 				showFlashNotification={vi.fn()}
 				tabSaveToHistory={false}
 				onToggleTabSaveToHistory={vi.fn()}
-				onToggleTabReadOnlyMode={vi.fn()}
 				tabShowThinking="off"
 				onToggleTabShowThinking={vi.fn()}
 				supportsThinking
@@ -95,27 +101,34 @@ describe('ToolbarControls', () => {
 		expect(click).toHaveBeenCalled();
 	});
 
-	it('toggles history, read-only, thinking, and enter-to-send controls', () => {
+	it('toggles history, permission mode, thinking, and enter-to-send controls', () => {
 		const onToggleTabSaveToHistory = vi.fn();
-		const onToggleTabReadOnlyMode = vi.fn();
 		const onToggleTabShowThinking = vi.fn();
 		const setEnterToSend = vi.fn();
+		const session = createInputAreaSession();
 		renderToolbar({
+			session,
 			onToggleTabSaveToHistory,
-			onToggleTabReadOnlyMode,
 			onToggleTabShowThinking,
 			setEnterToSend,
 		});
 
 		fireEvent.click(screen.getByTitle(/Save to History/));
-		fireEvent.click(screen.getByTitle(/Toggle plan mode/));
+		// Permission mode starts at 'full'; clicking cycles it to 'standard'.
+		fireEvent.click(screen.getByTitle(/^Full Access/));
 		fireEvent.click(screen.getByTitle(/Show Thinking/));
 		fireEvent.click(screen.getByTitle(/Switch to/));
 
 		expect(onToggleTabSaveToHistory).toHaveBeenCalled();
-		expect(onToggleTabReadOnlyMode).toHaveBeenCalled();
 		expect(onToggleTabShowThinking).toHaveBeenCalled();
 		expect(setEnterToSend).toHaveBeenCalledWith(false);
+
+		expect(mockUpdateSessionWith).toHaveBeenCalledWith(session.id, expect.any(Function));
+		const updater = mockUpdateSessionWith.mock.calls[0][1];
+		const updatedSession = updater(session);
+		const updatedTab = updatedSession.aiTabs.find((t: { id: string }) => t.id === 'tab-1');
+		expect(updatedTab.permissionMode).toBe('standard');
+		expect(updatedTab.readOnlyMode).toBe(false);
 	});
 
 	it('hides AI-only controls in terminal mode', () => {

--- a/src/__tests__/renderer/hooks/useInputProcessing.test.ts
+++ b/src/__tests__/renderer/hooks/useInputProcessing.test.ts
@@ -1417,6 +1417,66 @@ describe('useInputProcessing', () => {
 			mockGetBatchState.mockReturnValue(defaultBatchState);
 		});
 
+		it('sends permissionMode "readonly" when Auto Run forces read-only despite tab permissionMode "full"', async () => {
+			const runningBatchState: BatchRunState = {
+				...defaultBatchState,
+				isRunning: true,
+				worktreeActive: false,
+			};
+			mockGetBatchState.mockReturnValue(runningBatchState);
+
+			// Tab explicitly opts into full permissions, but Auto Run without a
+			// worktree must still force the spawn config to readonly.
+			const fullPermissionTab = createMockTab({ readOnlyMode: true, permissionMode: 'full' });
+			const session = createMockSession({
+				aiTabs: [fullPermissionTab],
+				activeTabId: fullPermissionTab.id,
+			});
+			const deps = createDeps({
+				activeSession: session,
+				sessionsRef: { current: [session] },
+				inputValue: 'what does this function do',
+				activeBatchRunState: runningBatchState,
+			});
+			const { result } = renderHook(() => useInputProcessing(deps));
+
+			await act(async () => {
+				await result.current.processInput();
+			});
+
+			expect(window.maestro.process.spawn).toHaveBeenCalled();
+			const spawnCall = (window.maestro.process.spawn as ReturnType<typeof vi.fn>).mock.calls[0][0];
+			expect(spawnCall.readOnlyMode).toBe(true);
+			expect(spawnCall.permissionMode).toBe('readonly');
+		});
+
+		it('sends permissionMode "full" when tab permissionMode is "full" and Auto Run is not forcing read-only', async () => {
+			// Use a tab WITH agentSessionId so the message sends immediately (not queued)
+			const fullPermissionTab = createMockTab({
+				readOnlyMode: false,
+				permissionMode: 'full',
+				agentSessionId: 'existing-session-789',
+			});
+			const session = createMockSession({
+				aiTabs: [fullPermissionTab],
+				activeTabId: fullPermissionTab.id,
+			});
+			const deps = createDeps({
+				activeSession: session,
+				sessionsRef: { current: [session] },
+				inputValue: 'refactor this module',
+			});
+			const { result } = renderHook(() => useInputProcessing(deps));
+
+			await act(async () => {
+				await result.current.processInput();
+			});
+
+			expect(window.maestro.process.spawn).toHaveBeenCalled();
+			const spawnCall = (window.maestro.process.spawn as ReturnType<typeof vi.fn>).mock.calls[0][0];
+			expect(spawnCall.permissionMode).toBe('full');
+		});
+
 		it('does not append read-only suffix when in normal write mode', async () => {
 			// Use a tab WITH agentSessionId to skip system prompt prepending
 			const writeTab = createMockTab({

--- a/src/__tests__/renderer/hooks/useInputProcessing.test.ts
+++ b/src/__tests__/renderer/hooks/useInputProcessing.test.ts
@@ -1477,6 +1477,34 @@ describe('useInputProcessing', () => {
 			expect(spawnCall.permissionMode).toBe('full');
 		});
 
+		it('sends permissionMode "standard" when tab permissionMode is "standard"', async () => {
+			// standard mode must propagate to the spawn config so the main process
+			// can wire up the permission relay (rather than defaulting to full).
+			const standardTab = createMockTab({
+				readOnlyMode: false,
+				permissionMode: 'standard',
+				agentSessionId: 'existing-session-standard',
+			});
+			const session = createMockSession({
+				aiTabs: [standardTab],
+				activeTabId: standardTab.id,
+			});
+			const deps = createDeps({
+				activeSession: session,
+				sessionsRef: { current: [session] },
+				inputValue: 'refactor this module',
+			});
+			const { result } = renderHook(() => useInputProcessing(deps));
+
+			await act(async () => {
+				await result.current.processInput();
+			});
+
+			expect(window.maestro.process.spawn).toHaveBeenCalled();
+			const spawnCall = (window.maestro.process.spawn as ReturnType<typeof vi.fn>).mock.calls[0][0];
+			expect(spawnCall.permissionMode).toBe('standard');
+		});
+
 		it('does not append read-only suffix when in normal write mode', async () => {
 			// Use a tab WITH agentSessionId to skip system prompt prepending
 			const writeTab = createMockTab({

--- a/src/__tests__/renderer/hooks/useRemoteHandlers.test.ts
+++ b/src/__tests__/renderer/hooks/useRemoteHandlers.test.ts
@@ -1221,6 +1221,42 @@ describe('useRemoteHandlers', () => {
 			expect(spawnCall.args).not.toContain('--dangerously-bypass-approvals-and-sandbox');
 		});
 
+		it('sends permissionMode "readonly" when tab.readOnlyMode forces read-only despite tab.permissionMode "full"', async () => {
+			const session = createMockSession({
+				inputMode: 'ai',
+				aiTabs: [
+					{
+						id: 'tab-1',
+						name: 'Tab 1',
+						inputValue: '',
+						data: [],
+						logs: [],
+						stagedImages: [],
+						readOnlyMode: true,
+						permissionMode: 'full',
+					},
+				],
+				activeTabId: 'tab-1',
+			});
+			useSessionStore.setState({ sessions: [session], activeSessionId: 'session-1' } as any);
+			const deps = createMockDeps({ sessionsRef: { current: [session] } });
+
+			renderHook(() => useRemoteHandlers(deps));
+			const handler = getRemoteCommandHandler();
+
+			await act(async () => {
+				await handler(
+					new CustomEvent('maestro:remoteCommand', {
+						detail: { sessionId: 'session-1', command: 'explain code', inputMode: 'ai' },
+					})
+				);
+			});
+
+			const spawnCall = (window.maestro.process.spawn as any).mock.calls[0][0];
+			expect(spawnCall.readOnlyMode).toBe(true);
+			expect(spawnCall.permissionMode).toBe('readonly');
+		});
+
 		it('sets session state to busy with busySource=ai for AI commands', async () => {
 			const session = createMockSession({ inputMode: 'ai' });
 			useSessionStore.setState({ sessions: [session], activeSessionId: 'session-1' } as any);

--- a/src/__tests__/renderer/stores/agentStore.test.ts
+++ b/src/__tests__/renderer/stores/agentStore.test.ts
@@ -1373,6 +1373,40 @@ describe('agentStore', () => {
 			expect(spawnCall.readOnlyMode).toBe(true);
 		});
 
+		it('sends permissionMode "readonly" when queued item forces read-only despite tab permissionMode "full"', async () => {
+			const session = createMockSession({
+				id: 'session-1',
+				aiTabs: [
+					{
+						id: 'tab-1',
+						agentSessionId: 'conv-1',
+						name: null,
+						starred: false,
+						logs: [],
+						inputValue: '',
+						stagedImages: [],
+						createdAt: Date.now(),
+						state: 'idle',
+						permissionMode: 'full',
+					},
+				],
+				activeTabId: 'tab-1',
+			});
+			useSessionStore.getState().setSessions([session]);
+
+			const item = createQueuedItem({
+				tabId: 'tab-1',
+				text: 'Read only query',
+				readOnlyMode: true,
+			});
+
+			await useAgentStore.getState().processQueuedItem('session-1', item, defaultDeps);
+
+			const spawnCall = mockSpawn.mock.calls[0][0];
+			expect(spawnCall.readOnlyMode).toBe(true);
+			expect(spawnCall.permissionMode).toBe('readonly');
+		});
+
 		it('processes slash command and spawns agent', async () => {
 			const session = createMockSession({
 				id: 'session-1',

--- a/src/__tests__/shared/agentMetadata.test.ts
+++ b/src/__tests__/shared/agentMetadata.test.ts
@@ -8,6 +8,8 @@ import {
 	isBetaAgent,
 	getReadOnlyModeLabel,
 	getReadOnlyModeTooltip,
+	getPermissionModeLabel,
+	getPermissionModeTooltip,
 	AGENT_DISPLAY_NAMES,
 	BETA_AGENTS,
 } from '../../shared/agentMetadata';
@@ -155,6 +157,50 @@ describe('agentMetadata', () => {
 		it('should return read-only tooltip for other agents', () => {
 			expect(getReadOnlyModeTooltip('codex')).toContain('Read-Only');
 			expect(getReadOnlyModeTooltip('factory-droid')).toContain('Read-Only');
+		});
+	});
+
+	describe('getPermissionModeLabel', () => {
+		it('should return "Full Access" for full mode regardless of agent', () => {
+			expect(getPermissionModeLabel('full')).toBe('Full Access');
+			expect(getPermissionModeLabel('full', 'claude-code')).toBe('Full Access');
+		});
+
+		it('should return "Standard" for standard mode regardless of agent', () => {
+			expect(getPermissionModeLabel('standard')).toBe('Standard');
+			expect(getPermissionModeLabel('standard', 'claude-code')).toBe('Standard');
+		});
+
+		it('should return "Read Only" for readonly mode when no agentId is given', () => {
+			expect(getPermissionModeLabel('readonly')).toBe('Read Only');
+		});
+
+		it('should delegate to getReadOnlyModeLabel for readonly mode when agentId is given', () => {
+			expect(getPermissionModeLabel('readonly', 'claude-code')).toBe('Plan-Mode');
+			expect(getPermissionModeLabel('readonly', 'codex')).toBe('Read-Only');
+			expect(getPermissionModeLabel('readonly', 'factory-droid')).toBe('Read-Only');
+		});
+	});
+
+	describe('getPermissionModeTooltip', () => {
+		it('should return the generic full access tooltip regardless of agent', () => {
+			expect(getPermissionModeTooltip('full')).toContain('Full Access');
+			expect(getPermissionModeTooltip('full', 'claude-code')).toContain('Full Access');
+		});
+
+		it('should return the generic standard tooltip regardless of agent', () => {
+			expect(getPermissionModeTooltip('standard')).toContain('Standard');
+			expect(getPermissionModeTooltip('standard', 'claude-code')).toContain('Standard');
+		});
+
+		it('should return the generic readonly tooltip when no agentId is given', () => {
+			expect(getPermissionModeTooltip('readonly')).toContain('Read Only');
+		});
+
+		it('should delegate to getReadOnlyModeTooltip for readonly mode when agentId is given', () => {
+			expect(getPermissionModeTooltip('readonly', 'claude-code')).toContain('plan mode');
+			expect(getPermissionModeTooltip('readonly', 'codex')).toContain('Read-Only');
+			expect(getPermissionModeTooltip('readonly', 'factory-droid')).toContain('Read-Only');
 		});
 	});
 });

--- a/src/main/agents/capabilities.ts
+++ b/src/main/agents/capabilities.ts
@@ -38,6 +38,7 @@ export const AGENT_CAPABILITIES: Record<string, AgentCapabilities> = {
 	'claude-code': {
 		supportsResume: true, // --resume flag
 		supportsReadOnlyMode: true, // --permission-mode plan
+		supportsStandardPermissionMode: true, // standard mode via the permission relay (--permission-prompt-tool)
 		supportsJsonOutput: true, // --output-format stream-json
 		supportsSessionId: true, // session_id in JSON output
 		supportsImageInput: true, // Supports image attachments

--- a/src/main/agents/definitions.ts
+++ b/src/main/agents/definitions.ts
@@ -166,25 +166,15 @@ export const AGENT_DEFINITIONS: AgentDefinition[] = [
 		// desktop spawner (see `src/main/ipc/handlers/process.ts`) to pick a binary per turn
 		// based on per-tab Claude interactive mode state.
 		command: 'claude',
-		// YOLO mode (--dangerously-skip-permissions) is always enabled - Maestro requires it
-		args: [
-			'--print',
-			'--verbose',
-			'--output-format',
-			'stream-json',
-			'--dangerously-skip-permissions',
-		],
+		args: ['--print', '--verbose', '--output-format', 'stream-json'],
 		apiCommand: 'claude',
-		apiModeArgs: [
-			'--print',
-			'--verbose',
-			'--output-format',
-			'stream-json',
-			'--dangerously-skip-permissions',
-		],
+		apiModeArgs: ['--print', '--verbose', '--output-format', 'stream-json'],
 		interactiveCommand: 'maestro-p',
 		// maestro-p forwards these to the underlying claude TUI invocation.
-		interactiveModeArgs: ['--dangerously-skip-permissions'],
+		interactiveModeArgs: [],
+		// Full permission mode: bypass all Claude permission checks. In 'standard'
+		// mode the permission relay mediates each tool call instead.
+		fullAccessArgs: ['--dangerously-skip-permissions'],
 		resumeArgs: (sessionId: string) => ['--resume', sessionId], // Resume with session ID; works for both api and interactive (forwarded by maestro-p)
 		readOnlyArgs: ['--permission-mode', 'plan'], // Read-only/plan mode
 		readOnlyCliEnforced: true, // CLI enforces read-only via --permission-mode plan

--- a/src/main/cue/cue-spawn-builder.ts
+++ b/src/main/cue/cue-spawn-builder.ts
@@ -101,6 +101,7 @@ export async function buildSpawnSpec(
 		prompt: substitutedPrompt,
 		cwd: projectRoot,
 		yoloMode: true, // Cue runs always use YOLO mode like Auto Run
+		permissionMode: 'full' as const,
 		// Cue spawns with `stdio: ['ignore', 'pipe', 'pipe']` and no TTY, so the
 		// agent must run in batch mode every time. Without this, a prompt that
 		// substituted to `""` (e.g. `{{CUE_SOURCE_OUTPUT}}` when the upstream
@@ -119,6 +120,7 @@ export async function buildSpawnSpec(
 		sessionCustomEnvVars: customEnvVars,
 	});
 	finalArgs = configResolution.args;
+
 	// Sanitize custom env vars BEFORE they reach the spawn environment. This
 	// drops blocklisted names (PATH, HOME, USER, SHELL, LD_PRELOAD,
 	// DYLD_INSERT_LIBRARIES, NODE_OPTIONS) and any name that does not match the

--- a/src/main/ipc/handlers/process.ts
+++ b/src/main/ipc/handlers/process.ts
@@ -24,6 +24,11 @@ import { MaestroSettings } from './persistence';
 import { getDefaultShell } from '../../stores/defaults';
 import { handleProcessSpawn } from './process/handle-spawn';
 import type { SpawnProcessConfig } from './process/spawn-types';
+import {
+	initPermissionRelay,
+	resolvePermissionResponse,
+	type PermissionDecision,
+} from '../../permission-relay';
 
 const LOG_CONTEXT = '[ProcessManager]';
 
@@ -101,6 +106,18 @@ export function registerProcessHandlers(deps: ProcessHandlerDependencies): void 
 		getMainWindow,
 		safeSend,
 	} = deps;
+
+	// Wire the Claude Code permission relay: surface requests to the renderer
+	// and clean up per-spawn bindings when a process exits.
+	initPermissionRelay(getMainWindow, getProcessManager());
+
+	// Renderer -> main: the user's allow/deny decision for a relayed request.
+	ipcMain.handle(
+		'permission:respond',
+		(_event, requestId: string, decision: PermissionDecision) => {
+			return resolvePermissionResponse(requestId, decision);
+		}
+	);
 
 	// Spawn a new process for a session
 	// Supports agent-specific argument builders for batch mode, JSON output, resume, read-only mode, YOLO mode

--- a/src/main/ipc/handlers/process/handle-spawn.ts
+++ b/src/main/ipc/handlers/process/handle-spawn.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow } from 'electron';
+import { app, BrowserWindow } from 'electron';
 import Store from 'electron-store';
 import * as os from 'os';
 import * as fsp from 'fs/promises';
@@ -40,6 +40,7 @@ import { resolveClaudeSpawnContext } from './resolve-claude-spawn-context';
 import { applyLocalInteractiveSpawnDecision } from './apply-local-interactive-spawn';
 import { persistClaudeInteractiveMode } from './persist-claude-interactive-mode';
 import { wrapSpawnForSsh } from './wrap-spawn-for-ssh';
+import { preparePermissionRelayArgs } from '../../../permission-relay';
 import type { SpawnProcessConfig } from './spawn-types';
 
 const LOG_CONTEXT = '[ProcessManager]';
@@ -116,8 +117,14 @@ export async function handleProcessSpawn(
 		sessionsStore: deps.sessionsStore,
 		settingsStore,
 	});
-	const { baseSessionId, claudeResolvedMode, resolvedMaestroPBinPath, resolvedConfigDirKey } =
-		claudeContext;
+	const {
+		baseSessionId,
+		claudeResolvedMode,
+		resolvedMaestroPBinPath,
+		resolvedConfigDirKey,
+		isClaudeCode,
+		isSshEnabled,
+	} = claudeContext;
 
 	let finalArgs = buildAgentArgs(agent, {
 		baseArgs: config.args,
@@ -126,6 +133,7 @@ export async function handleProcessSpawn(
 		readOnlyMode: config.readOnlyMode,
 		modelId: config.modelId,
 		yoloMode: config.yoloMode,
+		permissionMode: config.permissionMode,
 		agentSessionId: config.agentSessionId,
 	});
 
@@ -157,10 +165,17 @@ export async function handleProcessSpawn(
 		);
 	}
 
-	// In read-only mode, apply agent-specific env var overrides to strip
-	// blanket permission grants (e.g., OpenCode's "*":"allow" YOLO config)
+	// Derive effective read-only state, honoring the legacy boolean flag only
+	// when permissionMode wasn't explicitly set (back-compat for older configs).
+	const hasExplicitPermissionMode = config.permissionMode !== undefined;
+	const isReadOnly =
+		config.permissionMode === 'readonly' ||
+		(!hasExplicitPermissionMode && config.readOnlyMode === true);
+
+	// In read-only mode, apply agent-specific env var overrides to strip blanket
+	// permission grants.
 	let effectiveCustomEnvVars = configResolution.effectiveCustomEnvVars;
-	if (config.readOnlyMode && agent?.readOnlyEnvOverrides) {
+	if (isReadOnly && agent?.readOnlyEnvOverrides) {
 		effectiveCustomEnvVars = {
 			...(effectiveCustomEnvVars || {}),
 			...agent.readOnlyEnvOverrides,
@@ -263,6 +278,67 @@ export async function handleProcessSpawn(
 				`[Plugins] MCP tool bridge enabled for ${config.toolType} (${mcpTools.length} tools)`,
 				LOG_CONTEXT
 			);
+		}
+	}
+
+	// ========================================================================
+	// Standard permission mode (Claude Code, API/print path): route tool
+	// permission prompts through the Maestro relay. Without this, Claude
+	// aborts the whole run on the first non-allowed tool call. The relay
+	// injects `--permission-prompt-tool` + `--mcp-config` pointing at a
+	// stdio bridge that dials Maestro's loopback socket for a user
+	// decision. Not applicable to full/read-only modes, non-claude agents,
+	// or the interactive (maestro-p/TUI) path, which renders its own
+	// native prompts.
+	// ========================================================================
+	if (isClaudeCode && claudeResolvedMode === 'api' && config.permissionMode === 'standard') {
+		if (isSshEnabled) {
+			// Fail loud: never silently downgrade to full/unsafe over SSH.
+			// The relay socket is local-only, so it cannot mediate a remote
+			// spawn's tool calls; running standard mode remotely without it
+			// would leave the agent unable to act. Matches the SSH fail-loud
+			// convention (see CLAUDE.md / agent-spawner sshUnresolvedFailure).
+			logger.error(
+				'Claude Code standard permission mode is not supported over SSH',
+				LOG_CONTEXT,
+				{ sessionId: config.sessionId }
+			);
+			const win = getMainWindow();
+			if (win && isWebContentsAvailable(win)) {
+				win.webContents.send(
+					'process:data',
+					config.sessionId,
+					'\r\n[Maestro] Standard permission mode is not available for Claude Code over SSH. ' +
+						'Switch this agent to Full Access or Read-Only, or disable SSH.\r\n'
+				);
+			}
+			return { success: false, pid: 0 };
+		}
+		try {
+			const relayArgs = await preparePermissionRelayArgs({
+				sessionId: config.sessionId,
+				tabId: config.tabId,
+				userDataDir: app.getPath('userData'),
+				execPath: process.execPath,
+			});
+			finalArgs = [...finalArgs, ...relayArgs];
+		} catch (e) {
+			// Fail loud: don't spawn standard mode without the relay (it would
+			// abort on the first tool call).
+			logger.error('Failed to prepare permission relay', LOG_CONTEXT, {
+				sessionId: config.sessionId,
+				error: e instanceof Error ? e.message : String(e),
+			});
+			const win = getMainWindow();
+			if (win && isWebContentsAvailable(win)) {
+				win.webContents.send(
+					'process:data',
+					config.sessionId,
+					'\r\n[Maestro] Could not start the permission relay for Standard mode. ' +
+						'Switch to Full Access or Read-Only to continue.\r\n'
+				);
+			}
+			return { success: false, pid: 0 };
 		}
 	}
 
@@ -483,6 +559,7 @@ export async function handleProcessSpawn(
 		...(agentSessionId && { agentSessionId }),
 		...(config.readOnlyMode && { readOnlyMode: true }),
 		...(config.yoloMode && { yoloMode: true }),
+		...(config.permissionMode && { permissionMode: config.permissionMode }),
 		...(config.modelId && { modelId: config.modelId }),
 		...(config.prompt && {
 			prompt: config.prompt.length > 500 ? config.prompt.substring(0, 500) + '...' : config.prompt,
@@ -745,6 +822,7 @@ export async function handleProcessSpawn(
 					readOnlyMode: originalConfig.readOnlyMode,
 					modelId: originalConfig.modelId,
 					yoloMode: originalConfig.yoloMode,
+					permissionMode: originalConfig.permissionMode,
 					agentSessionId: freshAgentSessionId,
 				});
 

--- a/src/main/ipc/handlers/process/handle-spawn.ts
+++ b/src/main/ipc/handlers/process/handle-spawn.ts
@@ -298,11 +298,9 @@ export async function handleProcessSpawn(
 			// spawn's tool calls; running standard mode remotely without it
 			// would leave the agent unable to act. Matches the SSH fail-loud
 			// convention (see CLAUDE.md / agent-spawner sshUnresolvedFailure).
-			logger.error(
-				'Claude Code standard permission mode is not supported over SSH',
-				LOG_CONTEXT,
-				{ sessionId: config.sessionId }
-			);
+			logger.error('Claude Code standard permission mode is not supported over SSH', LOG_CONTEXT, {
+				sessionId: config.sessionId,
+			});
 			const win = getMainWindow();
 			if (win && isWebContentsAvailable(win)) {
 				win.webContents.send(

--- a/src/main/ipc/handlers/process/spawn-types.ts
+++ b/src/main/ipc/handlers/process/spawn-types.ts
@@ -20,6 +20,7 @@ export interface SpawnProcessConfig {
 	readOnlyMode?: boolean; // For read-only/plan mode
 	modelId?: string; // For model selection
 	yoloMode?: boolean; // For YOLO/full-access mode (bypasses confirmations)
+	permissionMode?: 'full' | 'standard' | 'readonly'; // 3-way permission mode (overrides readOnlyMode/yoloMode)
 	// Per-session overrides (take precedence over agent-level config)
 	sessionCustomPath?: string; // Session-specific custom path
 	sessionCustomArgs?: string; // Session-specific custom args

--- a/src/main/permission-relay/PermissionRelayServer.ts
+++ b/src/main/permission-relay/PermissionRelayServer.ts
@@ -92,15 +92,29 @@ export class PermissionRelayServer {
 
 		const server = net.createServer((socket) => this.handleConnection(socket));
 
-		await new Promise<void>((resolve, reject) => {
-			server.once('error', reject);
-			server.listen(socketPath, () => {
-				server.removeListener('error', reject);
-				resolve();
+		// Create the socket with 0600 from the start. listen() creates the socket
+		// file immediately, so a later chmod leaves a window where another local
+		// user could connect (on a permissive umask like 022). Constraining the
+		// umask around listen() makes the file restrictive at creation time; the
+		// chmod below is a belt-and-suspenders backstop. Not applicable on win32
+		// (named pipes are per-user by ACL and umask has no effect).
+		const prevUmask =
+			process.platform !== 'win32' ? process.umask(0o177) : undefined;
+		try {
+			await new Promise<void>((resolve, reject) => {
+				server.once('error', reject);
+				server.listen(socketPath, () => {
+					server.removeListener('error', reject);
+					resolve();
+				});
 			});
-		});
+		} finally {
+			if (prevUmask !== undefined) {
+				process.umask(prevUmask);
+			}
+		}
 
-		// Lock the socket down to the current user (no-op / unsupported on win32).
+		// Backstop: ensure 0600 even if the umask path was ineffective.
 		if (process.platform !== 'win32') {
 			try {
 				fs.chmodSync(socketPath, 0o600);

--- a/src/main/permission-relay/PermissionRelayServer.ts
+++ b/src/main/permission-relay/PermissionRelayServer.ts
@@ -1,0 +1,252 @@
+/**
+ * PermissionRelayServer: a Maestro-owned unix-domain socket (named pipe on
+ * Windows) that the stdio MCP bridge dials back to.
+ *
+ * Security model: the socket file is created with 0600 permissions in the
+ * app's userData dir, so only the current OS user can connect - filesystem
+ * permissions are the auth boundary. There is NO TCP port and NO network
+ * surface. Every message additionally carries a per-spawn token; an unknown
+ * token is rejected. This is deliberately different from
+ * `src/main/web-server/WebServer.ts`, which binds 0.0.0.0 and must not be
+ * reused for permission decisions.
+ *
+ * The server is transport-only: it forwards each request to an injected
+ * `onRequest` callback (which surfaces it to the renderer) and awaits the
+ * user's decision via the registry's pending map. It has no Electron
+ * dependency, which keeps it unit-testable.
+ */
+
+import * as net from 'net';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { randomUUID } from 'crypto';
+import { logger } from '../utils/logger';
+import { createPending, lookupBinding } from './registry';
+import type { BridgeToServerMessage, PermissionRequest, ServerToBridgeMessage } from './types';
+
+const LOG_CONTEXT = '[PermissionRelay]';
+
+/** Called for each validated request; must surface it to the user. */
+export type OnPermissionRequest = (request: PermissionRequest) => void;
+
+export class PermissionRelayServer {
+	private server: net.Server | null = null;
+	private socketPath: string | null = null;
+	private onRequest: OnPermissionRequest | null = null;
+	private starting: Promise<string> | null = null;
+
+	/** Set the callback that surfaces requests to the user (renderer). */
+	setOnRequest(cb: OnPermissionRequest): void {
+		this.onRequest = cb;
+	}
+
+	/** True once the socket is listening. */
+	isRunning(): boolean {
+		return this.server !== null && this.socketPath !== null;
+	}
+
+	/**
+	 * Lazily start the socket. Idempotent: concurrent callers share one start.
+	 * Returns the socket path (or named-pipe path on Windows) to embed in the
+	 * bridge env.
+	 */
+	async ensureStarted(userDataDir: string): Promise<string> {
+		if (this.socketPath && this.server) {
+			return this.socketPath;
+		}
+		if (this.starting) {
+			return this.starting;
+		}
+		this.starting = this.start(userDataDir).finally(() => {
+			this.starting = null;
+		});
+		return this.starting;
+	}
+
+	private resolveSocketPath(userDataDir: string): string {
+		if (process.platform === 'win32') {
+			// Named pipes are per-user by default ACL; unique per app instance.
+			return `\\\\.\\pipe\\maestro-permission-relay-${process.pid}`;
+		}
+		// Prefer userData, but macOS caps unix socket paths at ~104 bytes. Fall
+		// back to tmpdir when the userData-based path would be too long.
+		const preferred = path.join(userDataDir, 'permission-relay.sock');
+		if (preferred.length <= 100) {
+			return preferred;
+		}
+		return path.join(os.tmpdir(), `maestro-relay-${process.pid}.sock`);
+	}
+
+	private async start(userDataDir: string): Promise<string> {
+		const socketPath = this.resolveSocketPath(userDataDir);
+
+		// Remove any stale socket file from a previous unclean shutdown.
+		if (process.platform !== 'win32') {
+			try {
+				fs.unlinkSync(socketPath);
+			} catch {
+				// Not present - fine.
+			}
+		}
+
+		const server = net.createServer((socket) => this.handleConnection(socket));
+
+		await new Promise<void>((resolve, reject) => {
+			server.once('error', reject);
+			server.listen(socketPath, () => {
+				server.removeListener('error', reject);
+				resolve();
+			});
+		});
+
+		// Lock the socket down to the current user (no-op / unsupported on win32).
+		if (process.platform !== 'win32') {
+			try {
+				fs.chmodSync(socketPath, 0o600);
+			} catch (e) {
+				logger.warn('Failed to chmod relay socket to 0600', LOG_CONTEXT, {
+					socketPath,
+					error: e instanceof Error ? e.message : String(e),
+				});
+			}
+		}
+
+		this.server = server;
+		this.socketPath = socketPath;
+		logger.info('Permission relay socket listening', LOG_CONTEXT, { socketPath });
+		return socketPath;
+	}
+
+	private handleConnection(socket: net.Socket): void {
+		let buffer = '';
+		socket.setEncoding('utf8');
+
+		socket.on('data', (chunk: string) => {
+			buffer += chunk;
+			let newlineIndex: number;
+			while ((newlineIndex = buffer.indexOf('\n')) !== -1) {
+				const line = buffer.slice(0, newlineIndex).trim();
+				buffer = buffer.slice(newlineIndex + 1);
+				if (line.length === 0) {
+					continue;
+				}
+				this.handleLine(socket, line);
+			}
+		});
+
+		socket.on('error', (err) => {
+			logger.debug('Relay socket connection error', LOG_CONTEXT, { error: err.message });
+		});
+	}
+
+	private handleLine(socket: net.Socket, line: string): void {
+		let msg: BridgeToServerMessage;
+		try {
+			msg = JSON.parse(line) as BridgeToServerMessage;
+		} catch {
+			logger.warn('Relay received unparseable line', LOG_CONTEXT);
+			return;
+		}
+
+		if (msg.type === 'hello') {
+			const ok = lookupBinding(msg.token) !== undefined;
+			this.send(socket, {
+				type: 'hello-ack',
+				ok,
+				...(ok ? {} : { error: 'unknown token' }),
+			});
+			return;
+		}
+
+		if (msg.type === 'permission-request') {
+			void this.handlePermissionRequest(socket, msg);
+			return;
+		}
+	}
+
+	private async handlePermissionRequest(
+		socket: net.Socket,
+		msg: Extract<BridgeToServerMessage, { type: 'permission-request' }>
+	): Promise<void> {
+		const binding = lookupBinding(msg.token);
+		// The bridge's `requestId` is its local correlation id; echo it back so
+		// the bridge can match the response to its outstanding tools/call.
+		const bridgeRequestId = msg.requestId;
+
+		if (!binding) {
+			// Unknown/expired token: deny. Never leak that the token was invalid
+			// as an "allow".
+			this.send(socket, {
+				type: 'permission-response',
+				requestId: bridgeRequestId,
+				decision: { behavior: 'deny', message: 'Unrecognized permission relay token.' },
+			});
+			return;
+		}
+
+		if (!this.onRequest) {
+			// No UI wired: fail closed.
+			this.send(socket, {
+				type: 'permission-response',
+				requestId: bridgeRequestId,
+				decision: { behavior: 'deny', message: 'Permission UI unavailable.' },
+			});
+			return;
+		}
+
+		// Server-side globally-unique id used as the pending key + renderer id.
+		const requestId = randomUUID();
+		const request: PermissionRequest = {
+			requestId,
+			token: msg.token,
+			sessionId: binding.sessionId,
+			tabId: binding.tabId,
+			toolName: msg.toolName,
+			input: msg.input ?? {},
+			createdAt: Date.now(),
+		};
+
+		const decisionPromise = createPending(requestId, msg.token);
+		this.onRequest(request);
+		const decision = await decisionPromise;
+
+		this.send(socket, {
+			type: 'permission-response',
+			requestId: bridgeRequestId,
+			decision,
+		});
+	}
+
+	private send(socket: net.Socket, msg: ServerToBridgeMessage): void {
+		if (socket.destroyed) {
+			return;
+		}
+		try {
+			socket.write(JSON.stringify(msg) + '\n');
+		} catch (e) {
+			logger.debug('Failed to write to relay socket', LOG_CONTEXT, {
+				error: e instanceof Error ? e.message : String(e),
+			});
+		}
+	}
+
+	/** Stop the server and remove the socket file. */
+	stop(): void {
+		if (this.server) {
+			this.server.close();
+			this.server = null;
+		}
+		if (this.socketPath && process.platform !== 'win32') {
+			try {
+				fs.unlinkSync(this.socketPath);
+			} catch {
+				// Already gone.
+			}
+		}
+		this.socketPath = null;
+	}
+}
+
+/** Singleton used by the main process. */
+export const permissionRelayServer = new PermissionRelayServer();

--- a/src/main/permission-relay/PermissionRelayServer.ts
+++ b/src/main/permission-relay/PermissionRelayServer.ts
@@ -98,8 +98,7 @@ export class PermissionRelayServer {
 		// umask around listen() makes the file restrictive at creation time; the
 		// chmod below is a belt-and-suspenders backstop. Not applicable on win32
 		// (named pipes are per-user by ACL and umask has no effect).
-		const prevUmask =
-			process.platform !== 'win32' ? process.umask(0o177) : undefined;
+		const prevUmask = process.platform !== 'win32' ? process.umask(0o177) : undefined;
 		try {
 			await new Promise<void>((resolve, reject) => {
 				server.once('error', reject);

--- a/src/main/permission-relay/bridge.ts
+++ b/src/main/permission-relay/bridge.ts
@@ -1,0 +1,282 @@
+/**
+ * Stdio MCP bridge for the Claude Code permission relay.
+ *
+ * Claude Code spawns this script as an MCP server (via `--mcp-config`) and is
+ * told to use its `approve` tool for permission prompts (via
+ * `--permission-prompt-tool`). When Claude wants to run a non-allowed tool it
+ * calls `approve`; this bridge forwards the request over a unix-domain socket
+ * to the Maestro main process, waits for the user's decision, and returns it.
+ *
+ * Runs as a standalone Node process (under Electron via ELECTRON_RUN_AS_NODE),
+ * so it must use ONLY Node builtins. It imports runtime constants from
+ * `./types`, which is likewise builtins-only, keeping the compiled
+ * `dist/main/permission-relay/bridge.js` self-contained.
+ *
+ * PROTOCOL DISCIPLINE: stdout carries ONLY newline-delimited JSON-RPC. All
+ * diagnostics go to stderr.
+ */
+
+import * as net from 'net';
+import type { BridgeToServerMessage, PermissionDecision, ServerToBridgeMessage } from './types';
+import {
+	RELAY_MCP_TOOL_NAME,
+	RELAY_SOCKET_ENV,
+	RELAY_TOKEN_ENV,
+	RELAY_DECISION_TIMEOUT_MS,
+} from './types';
+
+const PROTOCOL_VERSION_DEFAULT = '2024-11-05';
+const SERVER_INFO = { name: 'maestro-permissions', version: '1.0.0' };
+
+function logStderr(message: string): void {
+	process.stderr.write(`[maestro-relay-bridge] ${message}\n`);
+}
+
+// --- JSON-RPC output (stdout) ---
+
+function writeMessage(msg: Record<string, unknown>): void {
+	process.stdout.write(JSON.stringify(msg) + '\n');
+}
+
+function writeResult(id: unknown, result: unknown): void {
+	writeMessage({ jsonrpc: '2.0', id, result });
+}
+
+function writeError(id: unknown, code: number, message: string): void {
+	writeMessage({ jsonrpc: '2.0', id, error: { code, message } });
+}
+
+// --- Socket to Maestro ---
+
+const socketPath = process.env[RELAY_SOCKET_ENV];
+const token = process.env[RELAY_TOKEN_ENV];
+
+let socket: net.Socket | null = null;
+let socketReady: Promise<net.Socket> | null = null;
+let localReqCounter = 0;
+const pending = new Map<string, (decision: PermissionDecision) => void>();
+
+function connectSocket(): Promise<net.Socket> {
+	if (socketReady) {
+		return socketReady;
+	}
+	socketReady = new Promise<net.Socket>((resolve, reject) => {
+		if (!socketPath || !token) {
+			reject(new Error('relay socket path/token missing from env'));
+			return;
+		}
+		const s = net.createConnection(socketPath);
+		s.setEncoding('utf8');
+		let buffer = '';
+
+		s.on('connect', () => {
+			socket = s;
+			sendToServer(s, { type: 'hello', token });
+			resolve(s);
+		});
+		s.on('data', (chunk: string) => {
+			buffer += chunk;
+			let idx: number;
+			while ((idx = buffer.indexOf('\n')) !== -1) {
+				const line = buffer.slice(0, idx).trim();
+				buffer = buffer.slice(idx + 1);
+				if (line.length > 0) {
+					handleServerLine(line);
+				}
+			}
+		});
+		s.on('error', (err) => {
+			logStderr(`socket error: ${err.message}`);
+			reject(err);
+		});
+		s.on('close', () => {
+			socket = null;
+			socketReady = null;
+			// Deny anything still waiting - the relay is gone.
+			for (const [, resolvePending] of pending) {
+				resolvePending({ behavior: 'deny', message: 'Permission relay disconnected.' });
+			}
+			pending.clear();
+		});
+	});
+	return socketReady;
+}
+
+function sendToServer(s: net.Socket, msg: BridgeToServerMessage): void {
+	s.write(JSON.stringify(msg) + '\n');
+}
+
+function handleServerLine(line: string): void {
+	let msg: ServerToBridgeMessage;
+	try {
+		msg = JSON.parse(line) as ServerToBridgeMessage;
+	} catch {
+		logStderr('unparseable line from server');
+		return;
+	}
+	if (msg.type === 'permission-response') {
+		const resolvePending = pending.get(msg.requestId);
+		if (resolvePending) {
+			pending.delete(msg.requestId);
+			resolvePending(msg.decision);
+		}
+	}
+	// hello-ack is informational; nothing to do.
+}
+
+/** Forward a permission request to Maestro and await the decision. */
+async function requestDecision(
+	toolName: string,
+	input: Record<string, unknown>
+): Promise<PermissionDecision> {
+	let s: net.Socket;
+	try {
+		s = await connectSocket();
+	} catch (e) {
+		return {
+			behavior: 'deny',
+			message: `Could not reach Maestro permission relay: ${
+				e instanceof Error ? e.message : String(e)
+			}`,
+		};
+	}
+
+	const requestId = `b${++localReqCounter}`;
+	return new Promise<PermissionDecision>((resolve) => {
+		const timer = setTimeout(() => {
+			pending.delete(requestId);
+			resolve({ behavior: 'deny', message: 'Permission request timed out.' });
+		}, RELAY_DECISION_TIMEOUT_MS + 5_000);
+		if (typeof timer.unref === 'function') {
+			timer.unref();
+		}
+		pending.set(requestId, (decision) => {
+			clearTimeout(timer);
+			resolve(decision);
+		});
+		sendToServer(s, {
+			type: 'permission-request',
+			token: token as string,
+			requestId,
+			toolName,
+			input,
+		});
+	});
+}
+
+// --- MCP request handling (stdin) ---
+
+async function handleRpc(msg: Record<string, unknown>): Promise<void> {
+	const { id, method, params } = msg as {
+		id?: unknown;
+		method?: string;
+		params?: Record<string, unknown>;
+	};
+
+	// Notifications (no id) require no response.
+	if (id === undefined || id === null) {
+		return;
+	}
+
+	switch (method) {
+		case 'initialize': {
+			const clientProtocol =
+				(params?.protocolVersion as string | undefined) ?? PROTOCOL_VERSION_DEFAULT;
+			writeResult(id, {
+				protocolVersion: clientProtocol,
+				capabilities: { tools: {} },
+				serverInfo: SERVER_INFO,
+			});
+			return;
+		}
+		case 'ping': {
+			writeResult(id, {});
+			return;
+		}
+		case 'tools/list': {
+			writeResult(id, {
+				tools: [
+					{
+						name: RELAY_MCP_TOOL_NAME,
+						description:
+							'Maestro permission prompt. Routes Claude Code tool-permission ' +
+							'requests to the Maestro UI for an interactive allow/deny decision.',
+						inputSchema: {
+							type: 'object',
+							properties: {
+								tool_name: {
+									type: 'string',
+									description: 'The tool Claude is requesting permission to use.',
+								},
+								input: {
+									type: 'object',
+									description: 'The proposed input for that tool.',
+								},
+							},
+							required: ['tool_name', 'input'],
+						},
+					},
+				],
+			});
+			return;
+		}
+		case 'tools/call': {
+			const name = params?.name as string | undefined;
+			const args = (params?.arguments as Record<string, unknown> | undefined) ?? {};
+			if (name !== RELAY_MCP_TOOL_NAME) {
+				writeError(id, -32602, `Unknown tool: ${String(name)}`);
+				return;
+			}
+			const toolName = (args.tool_name as string | undefined) ?? 'unknown';
+			const toolInput = (args.input as Record<string, unknown> | undefined) ?? {};
+			const decision = await requestDecision(toolName, toolInput);
+			// The permission-prompt-tool contract: result text is the JSON of the
+			// PermissionResult. On allow, echo the (unchanged) input as updatedInput.
+			const payload =
+				decision.behavior === 'allow'
+					? { behavior: 'allow', updatedInput: decision.updatedInput ?? toolInput }
+					: { behavior: 'deny', message: decision.message };
+			writeResult(id, {
+				content: [{ type: 'text', text: JSON.stringify(payload) }],
+			});
+			return;
+		}
+		default: {
+			writeError(id, -32601, `Method not found: ${String(method)}`);
+			return;
+		}
+	}
+}
+
+function main(): void {
+	let buffer = '';
+	process.stdin.setEncoding('utf8');
+	process.stdin.on('data', (chunk: string) => {
+		buffer += chunk;
+		let idx: number;
+		while ((idx = buffer.indexOf('\n')) !== -1) {
+			const line = buffer.slice(0, idx).trim();
+			buffer = buffer.slice(idx + 1);
+			if (line.length === 0) {
+				continue;
+			}
+			let msg: Record<string, unknown>;
+			try {
+				msg = JSON.parse(line);
+			} catch {
+				logStderr('unparseable rpc line from stdin');
+				continue;
+			}
+			void handleRpc(msg);
+		}
+	});
+	process.stdin.on('end', () => {
+		if (socket) {
+			socket.end();
+		}
+		process.exit(0);
+	});
+	logStderr('bridge started');
+}
+
+main();

--- a/src/main/permission-relay/index.ts
+++ b/src/main/permission-relay/index.ts
@@ -1,0 +1,10 @@
+/** Public entry points for the Claude Code permission relay. */
+export {
+	initPermissionRelay,
+	preparePermissionRelayArgs,
+	resolvePermissionResponse,
+	cleanupSessionRelay,
+	PERMISSION_REQUEST_CHANNEL,
+} from './integration';
+export { permissionRelayServer } from './PermissionRelayServer';
+export type { PermissionDecision, PermissionRequest } from './types';

--- a/src/main/permission-relay/integration.ts
+++ b/src/main/permission-relay/integration.ts
@@ -10,6 +10,7 @@
 
 import type { BrowserWindow } from 'electron';
 import type { EventEmitter } from 'events';
+import * as fs from 'fs';
 import { logger } from '../utils/logger';
 import { permissionRelayServer } from './PermissionRelayServer';
 import { registerSpawn, resolvePending } from './registry';
@@ -107,12 +108,29 @@ export async function preparePermissionRelayArgs(params: {
 		sessionId: params.sessionId,
 		tabId: params.tabId,
 	});
-	sessionCleanups.set(params.sessionId, cleanup);
+
+	const { args, configPath } = buildRelayArgs(
+		params.execPath,
+		bridgeScriptPath,
+		socketPath,
+		token,
+		params.userDataDir
+	);
+
+	// Wrap the registry cleanup so process exit also deletes the temp MCP config.
+	sessionCleanups.set(params.sessionId, () => {
+		cleanup();
+		try {
+			fs.unlinkSync(configPath);
+		} catch {
+			// Already gone - fine.
+		}
+	});
 
 	logger.debug('Prepared permission relay for spawn', LOG_CONTEXT, {
 		sessionId: params.sessionId,
 		socketPath,
 	});
 
-	return buildRelayArgs(params.execPath, bridgeScriptPath, socketPath, token).args;
+	return args;
 }

--- a/src/main/permission-relay/integration.ts
+++ b/src/main/permission-relay/integration.ts
@@ -1,0 +1,118 @@
+/**
+ * Main-process integration for the permission relay: connects the transport
+ * (PermissionRelayServer + registry) to Electron - surfacing requests to the
+ * renderer, cleaning up per-spawn bindings on process exit, and preparing the
+ * CLI args injected at spawn time.
+ *
+ * Kept separate from PermissionRelayServer (which has no Electron dependency)
+ * so the server stays unit-testable.
+ */
+
+import type { BrowserWindow } from 'electron';
+import type { EventEmitter } from 'events';
+import { logger } from '../utils/logger';
+import { permissionRelayServer } from './PermissionRelayServer';
+import { registerSpawn, resolvePending } from './registry';
+import { buildRelayArgs, resolveBridgeScriptPath } from './spawn-args';
+import type { PermissionDecision } from './types';
+
+const LOG_CONTEXT = '[PermissionRelay]';
+
+/** IPC channel: main -> renderer, "please decide on this request". */
+export const PERMISSION_REQUEST_CHANNEL = 'process:permission-request';
+
+/** Per-spawn token cleanups, keyed by the (compound) spawn session id. */
+const sessionCleanups = new Map<string, () => void>();
+
+let initialized = false;
+
+/**
+ * Wire the relay into Electron. Idempotent. `getMainWindow` supplies the
+ * window to forward requests to; `processManager` is the EventEmitter whose
+ * `exit` event (sessionId, code) triggers per-spawn cleanup.
+ */
+export function initPermissionRelay(
+	getMainWindow: () => BrowserWindow | null,
+	processManager: EventEmitter | null
+): void {
+	if (initialized) {
+		return;
+	}
+	initialized = true;
+
+	permissionRelayServer.setOnRequest((request) => {
+		const win = getMainWindow();
+		if (!win || win.isDestroyed() || win.webContents.isDestroyed()) {
+			// No window to prompt: deny so the agent gets a clear answer instead
+			// of hanging until the timeout.
+			resolvePending(request.requestId, {
+				behavior: 'deny',
+				message: 'Maestro window unavailable to prompt for permission.',
+			});
+			return;
+		}
+		win.webContents.send(PERMISSION_REQUEST_CHANNEL, request);
+	});
+
+	// Best-effort per-spawn cleanup on process exit. Not fatal if the emitter
+	// isn't ready yet: the registry auto-denies pending requests on timeout and
+	// each new spawn clears its session's prior binding.
+	if (processManager && typeof processManager.on === 'function') {
+		processManager.on('exit', (sessionId: string) => {
+			cleanupSessionRelay(sessionId);
+		});
+	}
+}
+
+/** Resolve a pending request with the user's decision (called from IPC). */
+export function resolvePermissionResponse(
+	requestId: string,
+	decision: PermissionDecision
+): boolean {
+	return resolvePending(requestId, decision);
+}
+
+/** Clean up a spawn's relay binding (on process exit or re-spawn). */
+export function cleanupSessionRelay(sessionId: string): void {
+	const cleanup = sessionCleanups.get(sessionId);
+	if (cleanup) {
+		sessionCleanups.delete(sessionId);
+		cleanup();
+	}
+}
+
+/**
+ * Prepare the relay CLI args for a claude-code standard-mode API spawn.
+ * Ensures the socket is listening and registers a fresh per-spawn token
+ * (cleaning up any prior token for the same session). Throws if the bridge
+ * script can't be located - callers MUST fail loud rather than spawn without
+ * the relay (which would abort on the first tool call).
+ */
+export async function preparePermissionRelayArgs(params: {
+	sessionId: string;
+	tabId?: string;
+	userDataDir: string;
+	execPath: string;
+}): Promise<string[]> {
+	const bridgeScriptPath = resolveBridgeScriptPath();
+	if (!bridgeScriptPath) {
+		throw new Error('permission relay bridge script not found');
+	}
+
+	const socketPath = await permissionRelayServer.ensureStarted(params.userDataDir);
+
+	// Replace any stale binding for this session before registering a new one.
+	cleanupSessionRelay(params.sessionId);
+	const { token, cleanup } = registerSpawn({
+		sessionId: params.sessionId,
+		tabId: params.tabId,
+	});
+	sessionCleanups.set(params.sessionId, cleanup);
+
+	logger.debug('Prepared permission relay for spawn', LOG_CONTEXT, {
+		sessionId: params.sessionId,
+		socketPath,
+	});
+
+	return buildRelayArgs(params.execPath, bridgeScriptPath, socketPath, token).args;
+}

--- a/src/main/permission-relay/integration.ts
+++ b/src/main/permission-relay/integration.ts
@@ -52,7 +52,21 @@ export function initPermissionRelay(
 			});
 			return;
 		}
-		win.webContents.send(PERMISSION_REQUEST_CHANNEL, request);
+		try {
+			win.webContents.send(PERMISSION_REQUEST_CHANNEL, request);
+		} catch (e) {
+			// The destroyed-window guard above covers the realistic case; this
+			// catches a rare teardown race between the check and the send. Deny so
+			// the awaiting bridge call unblocks instead of waiting on the timeout.
+			logger.warn('Failed to deliver permission request to renderer; denying', LOG_CONTEXT, {
+				requestId: request.requestId,
+				error: e instanceof Error ? e.message : String(e),
+			});
+			resolvePending(request.requestId, {
+				behavior: 'deny',
+				message: 'Failed to deliver permission request to the Maestro window.',
+			});
+		}
 	});
 
 	// Best-effort per-spawn cleanup on process exit. Not fatal if the emitter

--- a/src/main/permission-relay/registry.ts
+++ b/src/main/permission-relay/registry.ts
@@ -1,0 +1,110 @@
+/**
+ * In-memory registry for the permission relay.
+ *
+ * Tracks two things:
+ *  1. Spawn bindings: token -> which session/tab a Claude spawn belongs to.
+ *     A token is a per-spawn nonce. The bridge presents it on every message;
+ *     an unknown token is rejected (the token is the socket's auth).
+ *  2. Pending requests: requestId -> the promise resolver awaiting the user's
+ *     decision, with an auto-deny timeout.
+ *
+ * Purely in-memory; nothing is persisted. Cleared per-spawn on process exit
+ * via the cleanup returned by `registerSpawn`.
+ */
+
+import { randomBytes } from 'crypto';
+import type { PermissionDecision, RelaySpawnBinding } from './types';
+import { RELAY_DECISION_TIMEOUT_MS } from './types';
+
+interface PendingRequest {
+	resolve: (decision: PermissionDecision) => void;
+	timer: NodeJS.Timeout;
+	token: string;
+}
+
+const bindings = new Map<string, RelaySpawnBinding>();
+const pending = new Map<string, PendingRequest>();
+
+/** Generate a cryptographically-strong per-spawn token. */
+export function generateRelayToken(): string {
+	return randomBytes(32).toString('hex');
+}
+
+/**
+ * Register a spawn's token -> session/tab binding. Returns the token to embed
+ * in the bridge env and a cleanup that removes the binding and denies any of
+ * its still-pending requests (called when the Claude process exits).
+ */
+export function registerSpawn(binding: RelaySpawnBinding): {
+	token: string;
+	cleanup: () => void;
+} {
+	const token = generateRelayToken();
+	bindings.set(token, binding);
+
+	const cleanup = () => {
+		bindings.delete(token);
+		// Deny any requests still waiting on this dead spawn so the bridge's
+		// socket handler (if somehow still open) doesn't hang forever.
+		for (const [requestId, req] of pending) {
+			if (req.token === token) {
+				clearTimeout(req.timer);
+				pending.delete(requestId);
+				req.resolve({ behavior: 'deny', message: 'Agent process exited.' });
+			}
+		}
+	};
+
+	return { token, cleanup };
+}
+
+/** Look up which session/tab a token belongs to, or undefined if unknown. */
+export function lookupBinding(token: string): RelaySpawnBinding | undefined {
+	return bindings.get(token);
+}
+
+/**
+ * Create a pending request that resolves when `resolvePending` is called with
+ * its `requestId`, or auto-denies after `timeoutMs`. Returns the decision
+ * promise.
+ */
+export function createPending(
+	requestId: string,
+	token: string,
+	timeoutMs: number = RELAY_DECISION_TIMEOUT_MS
+): Promise<PermissionDecision> {
+	return new Promise<PermissionDecision>((resolve) => {
+		const timer = setTimeout(() => {
+			pending.delete(requestId);
+			resolve({
+				behavior: 'deny',
+				message: 'Permission request timed out with no response.',
+			});
+		}, timeoutMs);
+		// Don't keep the event loop alive purely for a pending prompt.
+		if (typeof timer.unref === 'function') {
+			timer.unref();
+		}
+		pending.set(requestId, { resolve, timer, token });
+	});
+}
+
+/**
+ * Resolve a pending request with a decision. No-op if the request is unknown
+ * (already resolved, timed out, or cleaned up). Returns whether it matched.
+ */
+export function resolvePending(requestId: string, decision: PermissionDecision): boolean {
+	const req = pending.get(requestId);
+	if (!req) {
+		return false;
+	}
+	clearTimeout(req.timer);
+	pending.delete(requestId);
+	req.resolve(decision);
+	return true;
+}
+
+/** Test/inspection helper: current counts. */
+export function relayRegistryStats(): { bindings: number; pending: number } {
+	return { bindings: bindings.size, pending: pending.size };
+}

--- a/src/main/permission-relay/spawn-args.ts
+++ b/src/main/permission-relay/spawn-args.ts
@@ -1,0 +1,105 @@
+/**
+ * Builds the Claude Code CLI arguments that route tool-permission decisions
+ * through the Maestro relay, and resolves the bundled bridge script path.
+ *
+ * These args are injected only for claude-code, only on the API/print path,
+ * only when `permissionMode === 'standard'`, and never over SSH (see
+ * `process.ts`). Without them, Claude aborts the run on the first non-allowed
+ * tool call.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { logger } from '../utils/logger';
+import {
+	RELAY_MCP_SERVER_NAME,
+	RELAY_PERMISSION_PROMPT_TOOL,
+	RELAY_SOCKET_ENV,
+	RELAY_TOKEN_ENV,
+} from './types';
+
+const LOG_CONTEXT = '[PermissionRelay]';
+
+/**
+ * Locate the bridge script that Claude spawns as its MCP server.
+ *
+ * Packaged builds MUST list the resources-root candidate first. The bridge is
+ * launched via `process.execPath` + ELECTRON_RUN_AS_NODE=1, and that plain-Node
+ * process cannot read inside app.asar - so it ships OUTSIDE the asar as a
+ * single bundled file at `<resources>/permission-relay-bridge.js` (via
+ * extraResources, same as maestro-p.js). The main process's own `fs` IS
+ * asar-aware, so if we checked the in-asar `__dirname/bridge.js` first,
+ * accessSync would happily succeed and hand the spawned Node an unreadable
+ * path. Checking resourcesPath first avoids that trap; in dev `resourcesPath`
+ * points at Electron's own resources (no bridge there), so it falls through to
+ * the tsc-compiled `__dirname/bridge.js` sibling, which dev spawns fine.
+ */
+export function resolveBridgeScriptPath(): string | null {
+	const candidates: string[] = [];
+
+	// Packaged: bundled single-file bridge at the resources root (outside asar).
+	if (typeof process.resourcesPath === 'string' && process.resourcesPath.length > 0) {
+		candidates.push(path.join(process.resourcesPath, 'permission-relay-bridge.js'));
+	}
+
+	// Dev: tsc output next to this module (has a `require('./types')` sibling).
+	candidates.push(
+		path.join(__dirname, 'bridge.js'),
+		path.resolve(__dirname, '..', 'permission-relay', 'bridge.js')
+	);
+
+	for (const candidate of candidates) {
+		try {
+			fs.accessSync(candidate, fs.constants.R_OK);
+			return candidate;
+		} catch {
+			continue;
+		}
+	}
+	logger.warn('No readable permission-relay bridge script candidate found', LOG_CONTEXT, {
+		candidates,
+	});
+	return null;
+}
+
+export interface RelayArgsResult {
+	/** Args to append to the Claude spawn (permission-prompt-tool + mcp-config). */
+	args: string[];
+}
+
+/**
+ * Build the relay CLI args. `execPath` is the Node/Electron binary the bridge
+ * runs under (pass `process.execPath`); `bridgeScriptPath` from
+ * `resolveBridgeScriptPath()`. Returns null if the bridge can't be located
+ * (caller must fail loud rather than silently spawn without the relay).
+ */
+export function buildRelayArgs(
+	execPath: string,
+	bridgeScriptPath: string,
+	socketPath: string,
+	token: string
+): RelayArgsResult {
+	const mcpConfig = {
+		mcpServers: {
+			[RELAY_MCP_SERVER_NAME]: {
+				command: execPath,
+				args: [bridgeScriptPath],
+				env: {
+					// Run the bridge as plain Node under the Electron binary.
+					ELECTRON_RUN_AS_NODE: '1',
+					[RELAY_SOCKET_ENV]: socketPath,
+					[RELAY_TOKEN_ENV]: token,
+				},
+			},
+		},
+	};
+
+	return {
+		args: [
+			'--permission-prompt-tool',
+			RELAY_PERMISSION_PROMPT_TOOL,
+			'--mcp-config',
+			JSON.stringify(mcpConfig),
+		],
+	};
+}

--- a/src/main/permission-relay/spawn-args.ts
+++ b/src/main/permission-relay/spawn-args.ts
@@ -65,21 +65,13 @@ export function resolveBridgeScriptPath(): string | null {
 export interface RelayArgsResult {
 	/** Args to append to the Claude spawn (permission-prompt-tool + mcp-config). */
 	args: string[];
+	/** Temp file holding the MCP config JSON; caller deletes it on cleanup. */
+	configPath: string;
 }
 
-/**
- * Build the relay CLI args. `execPath` is the Node/Electron binary the bridge
- * runs under (pass `process.execPath`); `bridgeScriptPath` from
- * `resolveBridgeScriptPath()`. Returns null if the bridge can't be located
- * (caller must fail loud rather than silently spawn without the relay).
- */
-export function buildRelayArgs(
-	execPath: string,
-	bridgeScriptPath: string,
-	socketPath: string,
-	token: string
-): RelayArgsResult {
-	const mcpConfig = {
+/** Build the MCP server config object Claude loads via --mcp-config. */
+function buildMcpConfig(execPath: string, bridgeScriptPath: string, socketPath: string, token: string) {
+	return {
 		mcpServers: {
 			[RELAY_MCP_SERVER_NAME]: {
 				command: execPath,
@@ -93,13 +85,43 @@ export function buildRelayArgs(
 			},
 		},
 	};
+}
+
+/**
+ * Build the relay CLI args. `execPath` is the Node/Electron binary the bridge
+ * runs under (pass `process.execPath`); `bridgeScriptPath` from
+ * `resolveBridgeScriptPath()`; `configDir` a writable dir for the temp config
+ * (pass the app's userData dir).
+ *
+ * The MCP config is written to a temp JSON file and passed to --mcp-config by
+ * PATH rather than as an inline JSON string. On Windows, non-SSH agent spawns
+ * run through a shell (`useShell: true`, to dodge cmd.exe length limits), and a
+ * raw `JSON.stringify(...)` arg's embedded quotes would not be re-escaped for
+ * PowerShell/cmd - Claude would receive a malformed --mcp-config and standard
+ * mode would silently abort on the first tool call. A file path has no shell
+ * metacharacters, so it survives quoting on every platform. `--mcp-config` has
+ * accepted a file path since the flag was introduced.
+ */
+export function buildRelayArgs(
+	execPath: string,
+	bridgeScriptPath: string,
+	socketPath: string,
+	token: string,
+	configDir: string
+): RelayArgsResult {
+	const mcpConfig = buildMcpConfig(execPath, bridgeScriptPath, socketPath, token);
+	// Token is a 64-hex-char nonce; a short prefix keeps the filename unique
+	// per spawn without leaking the full auth token into a predictable path.
+	const configPath = path.join(configDir, `permission-relay-mcp-${token.slice(0, 16)}.json`);
+	fs.writeFileSync(configPath, JSON.stringify(mcpConfig), { mode: 0o600 });
 
 	return {
 		args: [
 			'--permission-prompt-tool',
 			RELAY_PERMISSION_PROMPT_TOOL,
 			'--mcp-config',
-			JSON.stringify(mcpConfig),
+			configPath,
 		],
+		configPath,
 	};
 }

--- a/src/main/permission-relay/spawn-args.ts
+++ b/src/main/permission-relay/spawn-args.ts
@@ -70,7 +70,12 @@ export interface RelayArgsResult {
 }
 
 /** Build the MCP server config object Claude loads via --mcp-config. */
-function buildMcpConfig(execPath: string, bridgeScriptPath: string, socketPath: string, token: string) {
+function buildMcpConfig(
+	execPath: string,
+	bridgeScriptPath: string,
+	socketPath: string,
+	token: string
+) {
 	return {
 		mcpServers: {
 			[RELAY_MCP_SERVER_NAME]: {
@@ -116,12 +121,7 @@ export function buildRelayArgs(
 	fs.writeFileSync(configPath, JSON.stringify(mcpConfig), { mode: 0o600 });
 
 	return {
-		args: [
-			'--permission-prompt-tool',
-			RELAY_PERMISSION_PROMPT_TOOL,
-			'--mcp-config',
-			configPath,
-		],
+		args: ['--permission-prompt-tool', RELAY_PERMISSION_PROMPT_TOOL, '--mcp-config', configPath],
 		configPath,
 	};
 }

--- a/src/main/permission-relay/types.ts
+++ b/src/main/permission-relay/types.ts
@@ -1,0 +1,84 @@
+/**
+ * Shared types for the Claude Code permission relay.
+ *
+ * When Claude Code runs in `standard` permission mode on the API/print path,
+ * it aborts the entire run on the first non-allowed tool call unless a
+ * `--permission-prompt-tool` MCP tool answers the request. Maestro supplies
+ * that tool via a tiny stdio MCP bridge (`bridge.ts`) that Claude spawns; the
+ * bridge dials back to a Maestro-owned unix-domain socket
+ * (`PermissionRelayServer`) which surfaces the request to the user and returns
+ * their decision.
+ *
+ * See `docs/agent-guides/` and PR #1155 for the wider 3-way permission-mode
+ * design. This module is claude-code-only; other agents do not use the relay.
+ */
+
+/**
+ * The decision returned to Claude Code for a single tool-permission request.
+ * Mirrors the Claude Code permission-prompt-tool contract: the tool result's
+ * text content must be a JSON string of exactly this shape.
+ */
+export type PermissionDecision =
+	| { behavior: 'allow'; updatedInput?: Record<string, unknown> }
+	| { behavior: 'deny'; message: string };
+
+/**
+ * A pending permission request, surfaced to the renderer for a user decision.
+ * `requestId` is unique per request; `token` identifies the spawn (and thus
+ * the session/tab) that produced it.
+ */
+export interface PermissionRequest {
+	requestId: string;
+	token: string;
+	sessionId: string;
+	tabId?: string;
+	/** The tool Claude wants to run, e.g. "Bash", "Edit", "Write". */
+	toolName: string;
+	/** The tool input Claude proposed (command, file path + contents, etc.). */
+	input: Record<string, unknown>;
+	createdAt: number;
+}
+
+/** Identifies which session/tab a spawn's relay token belongs to. */
+export interface RelaySpawnBinding {
+	sessionId: string;
+	tabId?: string;
+}
+
+// --- Wire protocol: bridge (client) <-> Maestro (server) over the UDS. ---
+// Newline-delimited JSON. Each line is one message object below.
+
+/** Messages sent from the bridge to Maestro. */
+export type BridgeToServerMessage =
+	| { type: 'hello'; token: string }
+	| {
+			type: 'permission-request';
+			token: string;
+			requestId: string;
+			toolName: string;
+			input: Record<string, unknown>;
+	  };
+
+/** Messages sent from Maestro to the bridge. */
+export type ServerToBridgeMessage =
+	| { type: 'hello-ack'; ok: boolean; error?: string }
+	| { type: 'permission-response'; requestId: string; decision: PermissionDecision };
+
+/** The MCP server name Maestro registers for the relay. */
+export const RELAY_MCP_SERVER_NAME = 'maestro_permissions';
+
+/** The MCP tool name (unprefixed) the bridge exposes for approvals. */
+export const RELAY_MCP_TOOL_NAME = 'approve';
+
+/**
+ * The fully-qualified tool name Claude expects for `--permission-prompt-tool`.
+ * Claude prefixes MCP tools with `mcp__<serverName>__<toolName>`.
+ */
+export const RELAY_PERMISSION_PROMPT_TOOL = `mcp__${RELAY_MCP_SERVER_NAME}__${RELAY_MCP_TOOL_NAME}`;
+
+/** Env var names the bridge reads to find + authenticate to the socket. */
+export const RELAY_SOCKET_ENV = 'MAESTRO_RELAY_SOCKET';
+export const RELAY_TOKEN_ENV = 'MAESTRO_RELAY_TOKEN';
+
+/** How long a request waits for a user decision before auto-denying (ms). */
+export const RELAY_DECISION_TIMEOUT_MS = 300_000;

--- a/src/main/preload/process.ts
+++ b/src/main/preload/process.ts
@@ -40,6 +40,7 @@ export interface ProcessConfig {
 	readOnlyMode?: boolean; // For read-only/plan mode (uses agent's readOnlyArgs)
 	modelId?: string; // For model selection (uses agent's modelArgs builder)
 	yoloMode?: boolean; // For YOLO/full-access mode (uses agent's yoloModeArgs)
+	permissionMode?: 'full' | 'standard' | 'readonly'; // 3-way permission mode (overrides readOnlyMode/yoloMode)
 	// System prompt delivery (separate from user message for token efficiency)
 	appendSystemPrompt?: string; // System prompt to pass via --append-system-prompt or embed in prompt
 	// Stdin-based prompt delivery (Windows workaround for CLI length limits)
@@ -262,6 +263,35 @@ export function createProcessApi() {
 			ipcRenderer.on('process:exit', handler);
 			return () => ipcRenderer.removeListener('process:exit', handler);
 		},
+
+		/**
+		 * Subscribe to Claude Code permission-relay requests (standard mode).
+		 * The renderer shows a prompt and replies via respondPermission().
+		 */
+		onPermissionRequest: (
+			callback: (request: {
+				requestId: string;
+				sessionId: string;
+				tabId?: string;
+				toolName: string;
+				input: Record<string, unknown>;
+				createdAt: number;
+			}) => void
+		): (() => void) => {
+			const handler = (_: unknown, request: Parameters<typeof callback>[0]) => callback(request);
+			ipcRenderer.on('process:permission-request', handler);
+			return () => ipcRenderer.removeListener('process:permission-request', handler);
+		},
+
+		/**
+		 * Send the user's allow/deny decision for a relayed permission request.
+		 */
+		respondPermission: (
+			requestId: string,
+			decision:
+				| { behavior: 'allow'; updatedInput?: Record<string, unknown> }
+				| { behavior: 'deny'; message: string }
+		): Promise<boolean> => ipcRenderer.invoke('permission:respond', requestId, decision),
 
 		/**
 		 * Subscribe to agent session ID events

--- a/src/main/utils/agent-args.ts
+++ b/src/main/utils/agent-args.ts
@@ -14,6 +14,7 @@ type BuildAgentArgsOptions = {
 	readOnlyMode?: boolean;
 	modelId?: string;
 	yoloMode?: boolean;
+	permissionMode?: 'full' | 'standard' | 'readonly';
 	agentSessionId?: string;
 	/**
 	 * Force the agent's batch-mode args (batchModePrefix / batchModeArgs /
@@ -99,6 +100,15 @@ export function buildAgentArgs(
 		return finalArgs;
 	}
 
+	// Resolve effective permission level. permissionMode takes precedence over the
+	// legacy readOnlyMode/yoloMode booleans when set explicitly.
+	const isFullAccess =
+		options.permissionMode === 'full' ||
+		(options.permissionMode === undefined && options.yoloMode === true);
+	const isReadOnly =
+		options.permissionMode === 'readonly' ||
+		(options.permissionMode === undefined && options.readOnlyMode === true);
+
 	// Batch-mode gate: normally we infer "batch mode" from the presence of a
 	// truthy prompt, so a bare interactive launch (no prompt) doesn't get batch
 	// args it never asked for. Callers that never launch interactive mode pass
@@ -112,10 +122,10 @@ export function buildAgentArgs(
 
 	if (agent.batchModeArgs && inBatchMode) {
 		// Skip batch mode args (e.g. -y, --dangerously-bypass-approvals-and-sandbox)
-		// when readOnlyMode is active. Batch mode args grant write/approval permissions
+		// when in read-only mode. Batch mode args grant write/approval permissions
 		// that conflict with read-only intent, regardless of whether the agent has
 		// CLI-enforced read-only mode or prompt-only enforcement.
-		if (!options.readOnlyMode) {
+		if (!isReadOnly) {
 			finalArgs = [...finalArgs, ...agent.batchModeArgs];
 		}
 	}
@@ -135,24 +145,28 @@ export function buildAgentArgs(
 		finalArgs = [...agent.workingDirArgs(options.cwd), ...finalArgs];
 	}
 
-	if (options.readOnlyMode && agent.readOnlyArgs) {
-		finalArgs = [...finalArgs, ...agent.readOnlyArgs];
+	if (isFullAccess) {
+		// Prefer fullAccessArgs over the legacy yoloModeArgs alias.
+		const fullArgs = agent.fullAccessArgs ?? agent.yoloModeArgs;
+		if (fullArgs) {
+			finalArgs = [...finalArgs, ...fullArgs];
+		}
+	} else if (isReadOnly) {
+		if (agent.readOnlyArgs) {
+			finalArgs = [...finalArgs, ...agent.readOnlyArgs];
+		}
+		if (agent.readOnlyCliEnforced === false) {
+			logger.warn(
+				`Agent ${agent.name}: read-only mode requested but no CLI-level enforcement available`,
+				LOG_CONTEXT,
+				{ agentId: agent.id }
+			);
+		}
 	}
-
-	if (options.readOnlyMode && agent.readOnlyCliEnforced === false) {
-		logger.warn(
-			`Agent ${agent.name}: read-only mode requested but no CLI-level enforcement available`,
-			LOG_CONTEXT,
-			{ agentId: agent.id }
-		);
-	}
+	// standard mode: no bypass args, no read-only args - agent uses its default permission model
 
 	if (options.modelId && agent.modelArgs) {
 		finalArgs = [...finalArgs, ...agent.modelArgs(options.modelId)];
-	}
-
-	if (options.yoloMode && agent.yoloModeArgs) {
-		finalArgs = [...finalArgs, ...agent.yoloModeArgs];
 	}
 
 	if (options.agentSessionId && agent.resumeArgs) {

--- a/src/main/utils/context-groomer.ts
+++ b/src/main/utils/context-groomer.ts
@@ -220,6 +220,7 @@ export async function groomContext(
 		readOnlyMode,
 		modelId: undefined,
 		yoloMode: false,
+		permissionMode: 'standard' as const,
 		agentSessionId,
 	});
 

--- a/src/renderer/components/AppShell.tsx
+++ b/src/renderer/components/AppShell.tsx
@@ -19,6 +19,7 @@ import { PluginPanelSlot } from './plugins/PluginPanelSlot';
 import { ToastContainer } from './Toast';
 import { CenterFlash } from './CenterFlash';
 import { ThoughtStreamPanel } from './ThoughtStreamPanel';
+import { PermissionPrompt } from './PermissionPrompt';
 import type { Group, GroupChat, Session, Theme } from '../types';
 
 type SessionListProps = ComponentProps<typeof SessionList>;
@@ -245,6 +246,8 @@ export function AppShell({
 			<ToastContainer theme={theme} onSessionClick={onToastSessionClick} />
 			<CenterFlash theme={theme} />
 			<ThoughtStreamPanel theme={theme} />
+			{/* --- PERMISSION PROMPT (Claude Code standard mode; portal) --- */}
+			<PermissionPrompt theme={theme} />
 		</div>
 	);
 }

--- a/src/renderer/components/InputArea/InputArea.tsx
+++ b/src/renderer/components/InputArea/InputArea.tsx
@@ -88,7 +88,6 @@ export const InputArea = React.memo(function InputArea(props: InputAreaProps) {
 		onStopAutoRun,
 		onOpenQueueBrowser,
 		tabReadOnlyMode = false,
-		onToggleTabReadOnlyMode,
 		tabSaveToHistory = false,
 		onToggleTabSaveToHistory,
 		onOpenPromptComposer,
@@ -165,7 +164,7 @@ export const InputArea = React.memo(function InputArea(props: InputAreaProps) {
 	}, [isResumingSession, hasCapability]);
 
 	// PERF: Memoize mode-related derived state
-	const { isReadOnlyMode, showQueueingBorder } = useMemo(() => {
+	const { showQueueingBorder } = useMemo(() => {
 		// Check if we're in read-only mode (manual toggle only - Claude will be in plan mode)
 		// NOTE: Auto Run no longer forces read-only mode. Instead:
 		// - Yellow border shows during Auto Run to indicate queuing will happen for write messages
@@ -510,9 +509,9 @@ export const InputArea = React.memo(function InputArea(props: InputAreaProps) {
 							session={session}
 							theme={theme}
 							isTerminalMode={isTerminalMode}
-							isReadOnlyMode={isReadOnlyMode}
 							canAttachImages={canAttachImages}
 							hasReadOnlyCapability={hasCapability('supportsReadOnlyMode')}
+							hasStandardCapability={hasCapability('supportsStandardPermissionMode')}
 							enterToSend={enterToSend}
 							setEnterToSend={setEnterToSend}
 							setStagedImages={setStagedImages}
@@ -524,7 +523,6 @@ export const InputArea = React.memo(function InputArea(props: InputAreaProps) {
 							showFlashNotification={showFlashNotification}
 							tabSaveToHistory={tabSaveToHistory}
 							onToggleTabSaveToHistory={onToggleTabSaveToHistory}
-							onToggleTabReadOnlyMode={onToggleTabReadOnlyMode}
 							tabShowThinking={tabShowThinking}
 							onToggleTabShowThinking={onToggleTabShowThinking}
 							supportsThinking={supportsThinking}

--- a/src/renderer/components/InputArea/components/ToolbarControls.tsx
+++ b/src/renderer/components/InputArea/components/ToolbarControls.tsx
@@ -17,7 +17,8 @@ import {
 	formatEnterToSendTooltip,
 	formatShortcutKeys,
 } from '../../../utils/shortcutFormatter';
-import { getReadOnlyModeLabel, getReadOnlyModeTooltip } from '../../../../shared/agentMetadata';
+import { getPermissionModeLabel, getPermissionModeTooltip } from '../../../../shared/agentMetadata';
+import { updateSessionWith } from '../../../stores/sessionStore';
 import { captureException } from '../../../utils/sentry';
 import { isCoarsePointer } from '../../../utils/touch';
 import { useViewportBreakpoint } from '../../../hooks/ui';
@@ -29,9 +30,10 @@ interface ToolbarControlsProps {
 	session: Session;
 	theme: Theme;
 	isTerminalMode: boolean;
-	isReadOnlyMode: boolean;
 	canAttachImages: boolean;
 	hasReadOnlyCapability: boolean;
+	/** Whether `standard` mode is functional for this agent (has a working relay). */
+	hasStandardCapability: boolean;
 	enterToSend: boolean;
 	setEnterToSend: (value: boolean) => void;
 	setStagedImages: React.Dispatch<React.SetStateAction<string[]>>;
@@ -46,7 +48,6 @@ interface ToolbarControlsProps {
 	showFlashNotification?: (message: string) => void;
 	tabSaveToHistory: boolean;
 	onToggleTabSaveToHistory?: () => void;
-	onToggleTabReadOnlyMode?: () => void;
 	tabShowThinking: ThinkingMode;
 	onToggleTabShowThinking?: () => void;
 	supportsThinking: boolean;
@@ -68,9 +69,9 @@ export const ToolbarControls = memo(function ToolbarControls({
 	session,
 	theme,
 	isTerminalMode,
-	isReadOnlyMode,
 	canAttachImages,
 	hasReadOnlyCapability,
+	hasStandardCapability,
 	enterToSend,
 	setEnterToSend,
 	setStagedImages,
@@ -82,7 +83,6 @@ export const ToolbarControls = memo(function ToolbarControls({
 	showFlashNotification,
 	tabSaveToHistory,
 	onToggleTabSaveToHistory,
-	onToggleTabReadOnlyMode,
 	tabShowThinking,
 	onToggleTabShowThinking,
 	supportsThinking,
@@ -111,6 +111,15 @@ export const ToolbarControls = memo(function ToolbarControls({
 	// supported AND the primary pointer is coarse (touch), so mouse/keyboard
 	// desktop users never see it.
 	const showVoiceButton = isAiMode && !!voiceSupported && !!onToggleVoiceInput && isCoarsePointer();
+
+	const activeTab = session.aiTabs?.find((t) => t.id === session.activeTabId);
+	const rawPermissionMode: 'full' | 'standard' | 'readonly' =
+		activeTab?.permissionMode ?? (activeTab?.readOnlyMode ? 'readonly' : 'full');
+	// Hide `standard` for agents without a working relay: if a stale tab is
+	// somehow in `standard`, display it as `full` so we never surface a
+	// non-functional mode.
+	const currentPermissionMode: 'full' | 'standard' | 'readonly' =
+		rawPermissionMode === 'standard' && !hasStandardCapability ? 'full' : rawPermissionMode;
 
 	return (
 		<div className="flex min-w-0 flex-wrap items-center gap-1 px-2 pb-2 pt-1">
@@ -269,23 +278,60 @@ export const ToolbarControls = memo(function ToolbarControls({
 						<span>History</span>
 					</button>
 				)}
-				{isAiMode && onToggleTabReadOnlyMode && hasReadOnlyCapability && (
+				{isAiMode && hasReadOnlyCapability && (
 					<button
-						onClick={onToggleTabReadOnlyMode}
+						onClick={() => {
+							if (!activeTab) return;
+							// Cycle full -> standard -> readonly -> full. Agents without a
+							// working relay skip `standard` (full -> readonly -> full).
+							const nextMode: 'full' | 'standard' | 'readonly' =
+								currentPermissionMode === 'full'
+									? hasStandardCapability
+										? 'standard'
+										: 'readonly'
+									: currentPermissionMode === 'standard'
+										? 'readonly'
+										: 'full';
+							updateSessionWith(session.id, (s) => ({
+								...s,
+								aiTabs: s.aiTabs.map((t) =>
+									t.id === activeTab.id
+										? {
+												...t,
+												permissionMode: nextMode,
+												readOnlyMode: nextMode === 'readonly',
+											}
+										: t
+								),
+							}));
+						}}
 						className={`flex items-center gap-1.5 text-[10px] px-2 py-1 rounded-full cursor-pointer transition-all whitespace-nowrap ${
-							isReadOnlyMode ? '' : 'opacity-40 hover:opacity-70'
+							currentPermissionMode === 'standard' ? 'opacity-40 hover:opacity-70' : ''
 						}`}
 						style={{
-							backgroundColor: isReadOnlyMode ? `${theme.colors.warning}25` : 'transparent',
-							color: isReadOnlyMode ? theme.colors.warning : theme.colors.textDim,
-							border: isReadOnlyMode
-								? `1px solid ${theme.colors.warning}50`
-								: '1px solid transparent',
+							backgroundColor:
+								currentPermissionMode === 'readonly'
+									? `${theme.colors.warning}25`
+									: currentPermissionMode === 'full'
+										? `${theme.colors.accent}25`
+										: 'transparent',
+							color:
+								currentPermissionMode === 'readonly'
+									? theme.colors.warning
+									: currentPermissionMode === 'full'
+										? theme.colors.accent
+										: theme.colors.textDim,
+							border:
+								currentPermissionMode === 'readonly'
+									? `1px solid ${theme.colors.warning}50`
+									: currentPermissionMode === 'full'
+										? `1px solid ${theme.colors.accent}50`
+										: '1px solid transparent',
 						}}
-						title={getReadOnlyModeTooltip(session.toolType)}
+						title={getPermissionModeTooltip(currentPermissionMode, session.toolType)}
 					>
 						<Eye className="w-3 h-3" />
-						<span>{getReadOnlyModeLabel(session.toolType)}</span>
+						<span>{getPermissionModeLabel(currentPermissionMode, session.toolType)}</span>
 					</button>
 				)}
 				{isAiMode && supportsThinking && onToggleTabShowThinking && (

--- a/src/renderer/components/MainPanel/MainPanelContent.tsx
+++ b/src/renderer/components/MainPanel/MainPanelContent.tsx
@@ -942,7 +942,9 @@ export const MainPanelContent = React.memo(function MainPanelContent(props: Main
 						autoRunState={currentSessionBatchState || undefined}
 						onStopAutoRun={() => onStopBatchRun?.(activeSession.id)}
 						onOpenQueueBrowser={onOpenQueueBrowser}
-						tabReadOnlyMode={activeTab?.readOnlyMode ?? false}
+						tabReadOnlyMode={
+							(activeTab?.readOnlyMode ?? false) || activeTab?.permissionMode === 'readonly'
+						}
 						onToggleTabReadOnlyMode={onToggleTabReadOnlyMode}
 						tabSaveToHistory={activeTab?.saveToHistory ?? false}
 						onToggleTabSaveToHistory={onToggleTabSaveToHistory}

--- a/src/renderer/components/PermissionPrompt/PermissionPrompt.tsx
+++ b/src/renderer/components/PermissionPrompt/PermissionPrompt.tsx
@@ -1,0 +1,161 @@
+/**
+ * PermissionPrompt - app-wide modal for Claude Code standard-mode tool
+ * permission requests.
+ *
+ * Mounted once near the app root (alongside CenterFlash). It:
+ *   - subscribes to `window.maestro.process.onPermissionRequest` and enqueues
+ *     each request into permissionRequestStore,
+ *   - drops a session's pending requests when its process exits,
+ *   - renders the head-of-queue request with Allow / Deny actions.
+ *
+ * Answering sends the decision back through the relay
+ * (`respondPermission`), which unblocks the awaiting Claude tool call.
+ * Escape denies (fail-safe: the agent gets a clear "no", never a hang).
+ */
+
+import { memo, useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import { ShieldQuestion, Check, X } from 'lucide-react';
+import type { Theme } from '../../types';
+import { MODAL_PRIORITIES } from '../../constants/modalPriorities';
+import { useModalLayer } from '../../hooks/ui/useModalLayer';
+import {
+	usePermissionRequestStore,
+	selectActivePermissionRequest,
+	type PermissionRequestUI,
+} from '../../stores/permissionRequestStore';
+
+interface PermissionPromptProps {
+	theme: Theme;
+}
+
+/** Best-effort one-line summary of the requested tool action. */
+function describeAction(request: PermissionRequestUI): string {
+	const input = request.input || {};
+	const command = input.command;
+	if (typeof command === 'string' && command.trim().length > 0) {
+		return command;
+	}
+	const filePath = input.file_path ?? input.path ?? input.filePath;
+	if (typeof filePath === 'string' && filePath.length > 0) {
+		return filePath;
+	}
+	try {
+		return JSON.stringify(input);
+	} catch {
+		return '(unable to display input)';
+	}
+}
+
+function PermissionPromptInner({ theme }: PermissionPromptProps) {
+	const enqueue = usePermissionRequestStore((s) => s.enqueue);
+	const respond = usePermissionRequestStore((s) => s.respond);
+	const clearSession = usePermissionRequestStore((s) => s.clearSession);
+	const request = usePermissionRequestStore(selectActivePermissionRequest);
+
+	// Wire the IPC listeners once.
+	useEffect(() => {
+		const offRequest = window.maestro?.process?.onPermissionRequest?.((req) => enqueue(req));
+		const offExit = window.maestro?.process?.onExit?.((sessionId: string) =>
+			clearSession(sessionId)
+		);
+		return () => {
+			offRequest?.();
+			offExit?.();
+		};
+	}, [enqueue, clearSession]);
+
+	const isOpen = !!request;
+
+	const onDeny = () => {
+		if (request) {
+			respond(request.requestId, { behavior: 'deny', message: 'Denied by user.' });
+		}
+	};
+	const onAllow = () => {
+		if (request) {
+			respond(request.requestId, { behavior: 'allow' });
+		}
+	};
+
+	// Escape denies (fail-safe). Registered only while a request is shown.
+	useModalLayer(MODAL_PRIORITIES.PERMISSION_PROMPT, 'Permission request', onDeny, {
+		enabled: isOpen,
+	});
+
+	if (!request) {
+		return null;
+	}
+
+	const action = describeAction(request);
+
+	return createPortal(
+		<div
+			className="fixed inset-0 z-[1008] flex items-center justify-center select-none"
+			style={{ backgroundColor: 'rgba(0,0,0,0.45)' }}
+		>
+			<div
+				role="dialog"
+				aria-label="Permission request"
+				className="w-[520px] max-w-[90vw] rounded-xl shadow-2xl border p-5"
+				style={{
+					backgroundColor: theme.colors.bgSidebar,
+					borderColor: theme.colors.border,
+					color: theme.colors.textMain,
+				}}
+			>
+				<div className="flex items-center gap-2 mb-3">
+					<ShieldQuestion className="w-5 h-5" style={{ color: theme.colors.accent }} />
+					<h2 className="text-sm font-semibold">Permission required</h2>
+				</div>
+				<p className="text-xs mb-2" style={{ color: theme.colors.textDim }}>
+					Claude Code wants to use{' '}
+					<span className="font-semibold" style={{ color: theme.colors.textMain }}>
+						{request.toolName}
+					</span>
+					.
+				</p>
+				<pre
+					className="text-xs rounded-md p-3 mb-4 overflow-auto max-h-48 select-text whitespace-pre-wrap break-words"
+					style={{
+						backgroundColor: theme.colors.bgMain,
+						color: theme.colors.textMain,
+						border: `1px solid ${theme.colors.border}`,
+					}}
+				>
+					{action}
+				</pre>
+				<div className="flex justify-end gap-2">
+					<button
+						onClick={onDeny}
+						className="flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-md cursor-pointer transition-colors"
+						style={{
+							backgroundColor: 'transparent',
+							color: theme.colors.error,
+							border: `1px solid ${theme.colors.error}60`,
+						}}
+					>
+						<X className="w-3.5 h-3.5" />
+						Deny
+					</button>
+					<button
+						onClick={onAllow}
+						autoFocus
+						className="flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-md cursor-pointer transition-colors"
+						style={{
+							backgroundColor: theme.colors.accent,
+							color: theme.colors.accentForeground,
+							border: `1px solid ${theme.colors.accent}`,
+						}}
+					>
+						<Check className="w-3.5 h-3.5" />
+						Allow
+					</button>
+				</div>
+			</div>
+		</div>,
+		document.body
+	);
+}
+
+export const PermissionPrompt = memo(PermissionPromptInner);

--- a/src/renderer/components/PermissionPrompt/PermissionPrompt.tsx
+++ b/src/renderer/components/PermissionPrompt/PermissionPrompt.tsx
@@ -126,8 +126,12 @@ function PermissionPromptInner({ theme }: PermissionPromptProps) {
 					{action}
 				</pre>
 				<div className="flex justify-end gap-2">
+					{/* Deny is the default-focused action: this is a fail-safe prompt, so a
+					    stray Enter/Space must NOT approve a potentially destructive tool
+					    call. Matches the Escape-denies behavior above. */}
 					<button
 						onClick={onDeny}
+						autoFocus
 						className="flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-md cursor-pointer transition-colors"
 						style={{
 							backgroundColor: 'transparent',
@@ -140,7 +144,6 @@ function PermissionPromptInner({ theme }: PermissionPromptProps) {
 					</button>
 					<button
 						onClick={onAllow}
-						autoFocus
 						className="flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-md cursor-pointer transition-colors"
 						style={{
 							backgroundColor: theme.colors.accent,

--- a/src/renderer/components/PermissionPrompt/index.ts
+++ b/src/renderer/components/PermissionPrompt/index.ts
@@ -1,0 +1,1 @@
+export { PermissionPrompt } from './PermissionPrompt';

--- a/src/renderer/components/WelcomeContent.tsx
+++ b/src/renderer/components/WelcomeContent.tsx
@@ -99,8 +99,8 @@ export function WelcomeContent({
 					they do when running the provider directly.
 				</p>
 				<p>
-					Agents run in auto-approve mode with tool calls accepted automatically. Toggle Read-Only
-					mode for guardrails.
+					Agents default to Full Access mode with tool calls accepted automatically. Switch to
+					Standard or Read Only mode via the toolbar for guardrails.
 				</p>
 			</div>
 

--- a/src/renderer/components/Wizard/screens/DirectorySelectionScreen/components/DirectorySelectionHeader.tsx
+++ b/src/renderer/components/Wizard/screens/DirectorySelectionScreen/components/DirectorySelectionHeader.tsx
@@ -28,7 +28,7 @@ export function DirectorySelectionHeader({
 					className="px-1.5 py-0.5 rounded text-xs"
 					style={{ backgroundColor: theme.colors.warning, color: theme.colors.bgMain }}
 				>
-					YOLO
+					Full Access
 				</code>{' '}
 				mode, aka:
 			</p>

--- a/src/renderer/constants/modalPriorities.ts
+++ b/src/renderer/constants/modalPriorities.ts
@@ -32,6 +32,9 @@ export const MODAL_PRIORITIES = {
 	/** Forced parallel execution warning - one-time acknowledgment */
 	FORCED_PARALLEL_WARNING: 1005,
 
+	/** Claude Code standard-mode permission prompt - blocks until the user decides */
+	PERMISSION_PROMPT: 1008,
+
 	/** Confirmation dialogs - highest priority, always on top */
 	CONFIRM: 1000,
 

--- a/src/renderer/constants/modalPriorities.ts
+++ b/src/renderer/constants/modalPriorities.ts
@@ -29,11 +29,11 @@ export const MODAL_PRIORITIES = {
 	/** Agent error modal - critical, shows recovery options */
 	AGENT_ERROR: 1010,
 
-	/** Forced parallel execution warning - one-time acknowledgment */
-	FORCED_PARALLEL_WARNING: 1005,
-
 	/** Claude Code standard-mode permission prompt - blocks until the user decides */
 	PERMISSION_PROMPT: 1008,
+
+	/** Forced parallel execution warning - one-time acknowledgment */
+	FORCED_PARALLEL_WARNING: 1005,
 
 	/** Confirmation dialogs - highest priority, always on top */
 	CONFIRM: 1000,

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -57,6 +57,7 @@ interface ProcessConfig {
 	readOnlyMode?: boolean;
 	modelId?: string;
 	yoloMode?: boolean;
+	permissionMode?: 'full' | 'standard' | 'readonly';
 	// Per-session overrides (take precedence over agent-level config)
 	sessionCustomPath?: string;
 	sessionCustomArgs?: string;
@@ -328,6 +329,22 @@ interface MaestroAPI {
 			}) => void
 		) => () => void;
 		onExit: (callback: (sessionId: string, code: number) => void) => () => void;
+		onPermissionRequest: (
+			callback: (request: {
+				requestId: string;
+				sessionId: string;
+				tabId?: string;
+				toolName: string;
+				input: Record<string, unknown>;
+				createdAt: number;
+			}) => void
+		) => () => void;
+		respondPermission: (
+			requestId: string,
+			decision:
+				| { behavior: 'allow'; updatedInput?: Record<string, unknown> }
+				| { behavior: 'deny'; message: string }
+		) => Promise<boolean>;
 		onSessionId: (callback: (sessionId: string, agentSessionId: string) => void) => () => void;
 		onSlashCommands: (callback: (sessionId: string, slashCommands: string[]) => void) => () => void;
 		onThinkingChunk: (callback: (sessionId: string, content: string) => void) => () => void;

--- a/src/renderer/hooks/input/useInputProcessing.ts
+++ b/src/renderer/hooks/input/useInputProcessing.ts
@@ -1157,7 +1157,13 @@ export function useInputProcessing(deps: UseInputProcessingDeps): UseInputProces
 							currentSessionBatchState.isRunning &&
 							!currentSessionBatchState.worktreeActive &&
 							!isForceParallel;
-						const isReadOnly = isAutoRunReadOnly || freshActiveTab?.readOnlyMode;
+						const isReadOnly =
+							isAutoRunReadOnly ||
+							freshActiveTab?.readOnlyMode === true ||
+							freshActiveTab?.permissionMode === 'readonly';
+						const effectivePermissionMode = isReadOnly
+							? 'readonly'
+							: freshActiveTab?.permissionMode;
 
 						// For read-only mode, filter out any YOLO/skip-permissions flags from base args
 						// (they would override the read-only mode we're requesting)
@@ -1250,6 +1256,7 @@ export function useInputProcessing(deps: UseInputProcessingDeps): UseInputProces
 							// Generic spawn options - main process builds agent-specific args
 							agentSessionId: tabAgentSessionId ?? undefined,
 							readOnlyMode: isReadOnly,
+							permissionMode: effectivePermissionMode,
 							// Per-session config overrides (if set)
 							sessionCustomPath: freshSession.customPath,
 							sessionCustomArgs: freshSession.customArgs,

--- a/src/renderer/hooks/remote/useRemoteHandlers.ts
+++ b/src/renderer/hooks/remote/useRemoteHandlers.ts
@@ -412,7 +412,9 @@ export function useRemoteHandlers(deps: UseRemoteHandlersDeps): UseRemoteHandler
 				}
 
 				const tabAgentSessionId = targetTab?.agentSessionId;
-				const isReadOnly = targetTab?.readOnlyMode;
+				const isReadOnly =
+					targetTab?.readOnlyMode === true || targetTab?.permissionMode === 'readonly';
+				const effectivePermissionMode = isReadOnly ? 'readonly' : targetTab?.permissionMode;
 
 				// Filter out YOLO/skip-permissions flags when read-only mode is active
 				const agentArgs = agent.args ?? [];
@@ -516,6 +518,7 @@ export function useRemoteHandlers(deps: UseRemoteHandlersDeps): UseRemoteHandler
 					appendSystemPrompt,
 					agentSessionId: tabAgentSessionId ?? undefined,
 					readOnlyMode: isReadOnly,
+					permissionMode: effectivePermissionMode,
 					sessionCustomPath: session.customPath,
 					sessionCustomArgs: session.customArgs,
 					sessionCustomEnvVars: session.customEnvVars,

--- a/src/renderer/stores/agentStore.ts
+++ b/src/renderer/stores/agentStore.ts
@@ -380,7 +380,11 @@ export const useAgentStore = create<AgentStore>()((set, get) => ({
 
 			// Get the TARGET TAB's agentSessionId for session continuity
 			const tabAgentSessionId = targetTab.agentSessionId;
-			const isReadOnly = item.readOnlyMode || targetTab.readOnlyMode;
+			const isReadOnly =
+				item.readOnlyMode === true ||
+				targetTab.readOnlyMode === true ||
+				targetTab.permissionMode === 'readonly';
+			const effectivePermissionMode = isReadOnly ? 'readonly' : targetTab.permissionMode;
 
 			// Filter out YOLO/skip-permissions flags when read-only mode is active
 			const spawnArgs = isReadOnly
@@ -439,6 +443,7 @@ export const useAgentStore = create<AgentStore>()((set, get) => ({
 					appendSystemPrompt,
 					agentSessionId: tabAgentSessionId ?? undefined,
 					readOnlyMode: isReadOnly,
+					permissionMode: effectivePermissionMode,
 					sessionCustomPath: session.customPath,
 					sessionCustomArgs: session.customArgs,
 					sessionCustomEnvVars: session.customEnvVars,
@@ -536,6 +541,7 @@ export const useAgentStore = create<AgentStore>()((set, get) => ({
 						appendSystemPrompt: appendSystemPromptForCommand,
 						agentSessionId: tabAgentSessionId ?? undefined,
 						readOnlyMode: isReadOnly,
+						permissionMode: effectivePermissionMode,
 						sessionCustomPath: session.customPath,
 						sessionCustomArgs: session.customArgs,
 						sessionCustomEnvVars: session.customEnvVars,

--- a/src/renderer/stores/permissionRequestStore.ts
+++ b/src/renderer/stores/permissionRequestStore.ts
@@ -1,0 +1,63 @@
+/**
+ * permissionRequestStore - Zustand store for Claude Code standard-mode
+ * permission prompts.
+ *
+ * When Claude Code runs in `standard` permission mode (API/print path), the
+ * main-process relay forwards each tool-permission request here via
+ * `window.maestro.process.onPermissionRequest`. The PermissionPrompt modal
+ * renders the head of the queue; the user's decision is sent back through
+ * `window.maestro.process.respondPermission`.
+ *
+ * Requests are queued (one prompt shown at a time) and answered FIFO.
+ */
+
+import { create } from 'zustand';
+
+export interface PermissionRequestUI {
+	requestId: string;
+	sessionId: string;
+	tabId?: string;
+	toolName: string;
+	input: Record<string, unknown>;
+	createdAt: number;
+}
+
+export type PermissionDecision =
+	| { behavior: 'allow'; updatedInput?: Record<string, unknown> }
+	| { behavior: 'deny'; message: string };
+
+interface PermissionRequestState {
+	queue: PermissionRequestUI[];
+	/** Add a request to the queue (from the IPC listener). */
+	enqueue: (request: PermissionRequestUI) => void;
+	/** Answer a request: send the decision to main, then dequeue it. */
+	respond: (requestId: string, decision: PermissionDecision) => void;
+	/** Drop all requests for a session (e.g. when its process exits). */
+	clearSession: (sessionId: string) => void;
+}
+
+export const usePermissionRequestStore = create<PermissionRequestState>((set) => ({
+	queue: [],
+	enqueue: (request) =>
+		set((state) => {
+			// Ignore duplicates (defensive against double-delivery).
+			if (state.queue.some((r) => r.requestId === request.requestId)) {
+				return state;
+			}
+			return { queue: [...state.queue, request] };
+		}),
+	respond: (requestId, decision) => {
+		// Fire-and-forget to main; the relay resolves the awaiting bridge call.
+		void window.maestro?.process?.respondPermission?.(requestId, decision);
+		set((state) => ({ queue: state.queue.filter((r) => r.requestId !== requestId) }));
+	},
+	clearSession: (sessionId) =>
+		set((state) => ({ queue: state.queue.filter((r) => r.sessionId !== sessionId) })),
+}));
+
+/** Selector: the request currently shown (head of the queue), or undefined. */
+export function selectActivePermissionRequest(
+	state: PermissionRequestState
+): PermissionRequestUI | undefined {
+	return state.queue[0];
+}

--- a/src/renderer/stores/permissionRequestStore.ts
+++ b/src/renderer/stores/permissionRequestStore.ts
@@ -52,7 +52,21 @@ export const usePermissionRequestStore = create<PermissionRequestState>((set) =>
 		set((state) => ({ queue: state.queue.filter((r) => r.requestId !== requestId) }));
 	},
 	clearSession: (sessionId) =>
-		set((state) => ({ queue: state.queue.filter((r) => r.sessionId !== sessionId) })),
+		set((state) => {
+			// Explicitly deny any queued requests for the exiting session so the
+			// awaiting bridge call unblocks immediately, rather than waiting on the
+			// main-side exit cleanup or the ~300s registry timeout. Denying an
+			// already-resolved request is a harmless no-op in the registry.
+			for (const r of state.queue) {
+				if (r.sessionId === sessionId) {
+					void window.maestro?.process?.respondPermission?.(r.requestId, {
+						behavior: 'deny',
+						message: 'Agent exited.',
+					});
+				}
+			}
+			return { queue: state.queue.filter((r) => r.sessionId !== sessionId) };
+		}),
 }));
 
 /** Selector: the request currently shown (head of the queue), or undefined. */

--- a/src/renderer/stores/permissionRequestStore.ts
+++ b/src/renderer/stores/permissionRequestStore.ts
@@ -36,6 +36,17 @@ interface PermissionRequestState {
 	clearSession: (sessionId: string) => void;
 }
 
+/**
+ * Send a decision to the main-process relay. Errors are swallowed (logged) so
+ * an IPC rejection doesn't surface as an unhandled promise rejection - the
+ * relay's ~300s auto-deny timeout is the backstop if a decision never lands.
+ */
+function sendDecision(requestId: string, decision: PermissionDecision): void {
+	void window.maestro?.process?.respondPermission?.(requestId, decision)?.catch((err: unknown) => {
+		console.error('[permissionRequestStore] respondPermission failed', requestId, err);
+	});
+}
+
 export const usePermissionRequestStore = create<PermissionRequestState>((set) => ({
 	queue: [],
 	enqueue: (request) =>
@@ -48,7 +59,7 @@ export const usePermissionRequestStore = create<PermissionRequestState>((set) =>
 		}),
 	respond: (requestId, decision) => {
 		// Fire-and-forget to main; the relay resolves the awaiting bridge call.
-		void window.maestro?.process?.respondPermission?.(requestId, decision);
+		sendDecision(requestId, decision);
 		set((state) => ({ queue: state.queue.filter((r) => r.requestId !== requestId) }));
 	},
 	clearSession: (sessionId) =>
@@ -59,10 +70,7 @@ export const usePermissionRequestStore = create<PermissionRequestState>((set) =>
 			// already-resolved request is a harmless no-op in the registry.
 			for (const r of state.queue) {
 				if (r.sessionId === sessionId) {
-					void window.maestro?.process?.respondPermission?.(r.requestId, {
-						behavior: 'deny',
-						message: 'Agent exited.',
-					});
+					sendDecision(r.requestId, { behavior: 'deny', message: 'Agent exited.' });
 				}
 			}
 			return { queue: state.queue.filter((r) => r.sessionId !== sessionId) };

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -520,6 +520,7 @@ export interface AITab {
 	createdAt: number; // Timestamp for ordering
 	state: 'idle' | 'busy'; // Tab-level state for write-mode tracking
 	readOnlyMode?: boolean; // When true, agent operates in plan/read-only mode
+	permissionMode?: 'full' | 'standard' | 'readonly'; // Controls agent permission handling: full (bypass all), standard (default permission model), readonly (plan mode)
 	saveToHistory?: boolean; // When true, synopsis is requested after each completion and saved to History
 	lastSynopsisTime?: number; // Timestamp of last synopsis generation (for time-window context in prompts)
 	showThinking?: ThinkingMode; // Controls thinking display: 'off' | 'on' (temporary) | 'sticky' (persistent)
@@ -1066,6 +1067,7 @@ export interface ProcessConfig {
 	readOnlyMode?: boolean; // For read-only/plan mode (uses agent's readOnlyArgs)
 	modelId?: string; // For model selection (uses agent's modelArgs builder)
 	yoloMode?: boolean; // For YOLO/full-access mode (uses agent's yoloModeArgs)
+	permissionMode?: 'full' | 'standard' | 'readonly'; // Preferred over readOnlyMode + yoloMode
 	// Per-session overrides (take precedence over agent-level config)
 	sessionCustomPath?: string;
 	sessionCustomArgs?: string;

--- a/src/renderer/utils/agentArgs.ts
+++ b/src/renderer/utils/agentArgs.ts
@@ -15,6 +15,7 @@ const KNOWN_YOLO_FLAGS = new Set([
 	'--dangerously-bypass-approvals-and-sandbox',
 	'--skip-permissions-unsafe',
 	'-y',
+	'--allow-all',
 ]);
 
 /**

--- a/src/renderer/utils/sessionHelpers.ts
+++ b/src/renderer/utils/sessionHelpers.ts
@@ -64,6 +64,8 @@ export interface BuildSpawnConfigOptions {
 	modelId?: string;
 	/** Whether to use YOLO/full-access mode */
 	yoloMode?: boolean;
+	/** 3-way permission mode ('full' | 'standard' | 'readonly') */
+	permissionMode?: 'full' | 'standard' | 'readonly';
 	/** Per-session custom path override */
 	sessionCustomPath?: string;
 	/** Per-session custom args override */
@@ -121,6 +123,7 @@ export async function buildSpawnConfigForAgent(
 		readOnlyMode,
 		modelId,
 		yoloMode,
+		permissionMode,
 		sessionCustomPath,
 		sessionCustomArgs,
 		sessionCustomEnvVars,
@@ -176,6 +179,7 @@ export async function buildSpawnConfigForAgent(
 		readOnlyMode,
 		modelId,
 		yoloMode,
+		permissionMode,
 		// Per-session config overrides
 		sessionCustomPath,
 		sessionCustomArgs,

--- a/src/shared/agentMetadata.ts
+++ b/src/shared/agentMetadata.ts
@@ -66,6 +66,48 @@ export function getReadOnlyModeTooltip(agentId: AgentId | string): string {
 }
 
 /**
+ * Get the UI label for a permission mode pill.
+ * For readonly mode, delegates to getReadOnlyModeLabel() when an agentId is
+ * given so agents that use plan-mode terminology (e.g. Claude Code's
+ * "Plan-Mode") keep it instead of the generic "Read Only" label.
+ */
+export function getPermissionModeLabel(
+	mode: 'full' | 'standard' | 'readonly',
+	agentId?: AgentId | string
+): string {
+	switch (mode) {
+		case 'full':
+			return 'Full Access';
+		case 'standard':
+			return 'Standard';
+		case 'readonly':
+			return agentId ? getReadOnlyModeLabel(agentId) : 'Read Only';
+	}
+}
+
+/**
+ * Get the tooltip text for a permission mode button.
+ * For readonly mode, delegates to getReadOnlyModeTooltip() when an agentId is
+ * given so agents that use plan-mode terminology (e.g. Claude Code) keep their
+ * plan-mode-specific tooltip.
+ */
+export function getPermissionModeTooltip(
+	mode: 'full' | 'standard' | 'readonly',
+	agentId?: AgentId | string
+): string {
+	switch (mode) {
+		case 'full':
+			return 'Full Access: All permission prompts bypassed. Agent can read, write, and execute without confirmation.';
+		case 'standard':
+			return 'Standard: Agent uses default permission model. File edits and commands may be silently denied if not pre-approved.';
+		case 'readonly':
+			return agentId
+				? getReadOnlyModeTooltip(agentId)
+				: 'Read Only: Agent runs in plan/exploration mode only. No file writes or command execution.';
+	}
+}
+
+/**
  * Agents currently in beta/experimental status.
  * Used to render "(Beta)" badges throughout the UI.
  *

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -48,6 +48,15 @@ export interface AgentCapabilities {
 	/** Agent supports read-only/plan mode (e.g., --permission-mode plan) */
 	supportsReadOnlyMode: boolean;
 
+	/**
+	 * Agent supports the `standard` permission mode with a working live
+	 * permission relay (interactive allow/deny). Optional: only set true for
+	 * agents whose relay is implemented and verified (currently Claude Code).
+	 * When false/undefined, the UI hides `standard` from the permission toggle
+	 * rather than expose a non-functional option (it would abort/auto-deny).
+	 */
+	supportsStandardPermissionMode?: boolean;
+
 	/** Agent outputs JSON-formatted responses (for parsing) */
 	supportsJsonOutput: boolean;
 
@@ -393,6 +402,7 @@ export interface AgentConfig {
 	configOptions?: AgentConfigOption[];
 	capabilities?: AgentCapabilities;
 	yoloModeArgs?: string[];
+	fullAccessArgs?: string[]; // Same as yoloModeArgs - preferred name. Args added in 'full' permission mode.
 	readOnlyCliEnforced?: boolean;
 	/**
 	 * Latest persisted capability snapshot for this agent in the requested


### PR DESCRIPTION
## What & why

Adds a **`standard` permission mode for Claude Code** backed by a live, interactive **allow/deny relay** - the missing piece that makes standard mode actually usable.

On Claude Code's API/print path, `standard` mode is non-functional without something to answer permission questions: Claude **aborts the whole run** on the first non-allowed tool call. This PR wires Claude's `--permission-prompt-tool` up to a Maestro UI prompt so the user can approve or deny each tool call interactively.

Supersedes #1155 (3-way permission mode), rebuilt cleanly on `main` and **scoped to Claude Code only** - no other-agent changes.

## Permission model (3-way)

- **Full Access** - bypass all prompts (`--dangerously-skip-permissions`)
- **Standard** - ask per tool call, via the relay (new)
- **Read-Only** - plan mode (`--permission-mode plan`)

`permissionMode` takes precedence over the legacy `yoloMode`/`readOnlyMode` booleans, which remain as a fallback for older configs. **Default behavior is unchanged** (unset resolves to full access).

## How the relay works

```
claude --print                         Maestro (main)
  │  --permission-prompt-tool mcp__maestro_permissions__approve
  │  --mcp-config {stdio: bridge.js}
  ▼
bridge.js (stdio MCP server) ──unix socket (0600)──▶ PermissionRelayServer
                                                          │
                                                     IPC  ▼
                                              PermissionPrompt modal
                                              [Allow]   [Deny]
```

- Claude spawns a tiny **stdio MCP bridge**; when it wants a non-allowed tool it calls the bridge's `approve` tool.
- The bridge dials back to a Maestro-owned **unix-domain socket** (`0600`, no TCP / no network surface; named pipe on Windows). A per-spawn token gates the connection.
- The main process surfaces the request to the renderer over the existing `responseChannel`-style IPC; a Zustand store + `PermissionPrompt` modal render it. The decision routes back through the socket to unblock Claude.
- ~300s auto-deny; **Escape denies** (fail-safe).

## Safety

- **claude-code API path only.** The interactive (maestro-p/TUI) path renders its own native prompts.
- **SSH + standard fails loud** - the local socket can't mediate a remote spawn, so it never silently downgrades.
- New **`supportsStandardPermissionMode`** capability gates the toggle so `standard` is hidden for agents without a working relay (only claude-code today) rather than exposing a non-functional option.

## Packaging

The bridge is bundled to a single self-contained file (`build-permission-relay-bridge.mjs`) and shipped **outside `app.asar`** via `extraResources`, because it runs as plain Node (`ELECTRON_RUN_AS_NODE`) and can't read inside the asar - same constraint as `maestro-p`.

## Verification

Verified end to end:
- Unit tests (relay core, arg building, capability gating)
- Transport round-trip (JSON-RPC over the socket)
- The **real `claude` 2.1.185 CLI** (Write triggers the relay; safe read-only Bash is auto-approved by Claude itself)
- The **live Electron UI** - Allow writes the file, Deny suppresses it, Claude reports each outcome
- A **packaged `.app`** - the bridge resolves outside asar under the real `resourcesPath`

Full suite: **31,615 passing**, lint + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a permission approval modal with **Allow/Deny** and Escape-to-deny.
  * Introduced **Full Access**, **Standard**, and **Read Only** permission modes with toolbar cycling, capability-aware visibility, and updated labels/tooltips.
  * Added a desktop permission-relay bridge so **Standard** tool access is handled consistently during spawning and replay.
* **Bug Fixes**
  * Made permission-mode behavior consistent across Auto Run, queued actions, remote spawns, and interactive replay, including correct coercion to **Read Only** when forced.
* **Chores**
  * Updated desktop packaging/build to include the new permission-relay bridge artifact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->