### PR TITLE
fix(terminal): expand ~ in spawn cwd so shells start in a readable directory

### DIFF
--- a/src/__tests__/main/process-manager/ProcessManager.cwd.test.ts
+++ b/src/__tests__/main/process-manager/ProcessManager.cwd.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Tests for cwd tilde expansion in ProcessManager.spawn() (issue #1173).
+ *
+ * node-pty / child_process pass `cwd` straight to the OS, which does not expand
+ * `~`. A session whose cwd is persisted as `~/project` (or bare `~`) would make
+ * the child's chdir() fail and the shell would start in an unreadable directory,
+ * surfacing on macOS as Homebrew's "current working directory must be readable"
+ * error on every shell startup. spawn() must expand the leading `~` first.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as os from 'os';
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+
+const mockPtySpawn = vi.fn();
+const mockPtyProcess = {
+	pid: 4242,
+	onData: vi.fn(),
+	onExit: vi.fn(),
+	write: vi.fn(),
+	resize: vi.fn(),
+	kill: vi.fn(),
+};
+
+vi.mock('node-pty', () => ({
+	spawn: (...args: unknown[]) => {
+		mockPtySpawn(...args);
+		return mockPtyProcess;
+	},
+}));
+
+vi.mock('../../../main/utils/logger', () => ({
+	logger: {
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+		debug: vi.fn(),
+	},
+}));
+
+vi.mock('../../../shared/platformDetection', () => ({
+	isWindows: vi.fn(() => false),
+}));
+
+// ── Imports (after mocks) ──────────────────────────────────────────────────
+
+import { ProcessManager } from '../../../main/process-manager/ProcessManager';
+import type { ProcessConfig } from '../../../main/process-manager/types';
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function baseConfig(overrides: Partial<ProcessConfig> = {}): ProcessConfig {
+	return {
+		sessionId: 'sess-1',
+		toolType: 'terminal',
+		cwd: '/tmp/project',
+		command: 'zsh',
+		args: [],
+		shell: 'zsh',
+		...overrides,
+	};
+}
+
+/** The cwd option passed to the most recent node-pty spawn call. */
+function lastSpawnCwd(): string {
+	const call = mockPtySpawn.mock.calls.at(-1);
+	return (call?.[2] as { cwd: string }).cwd;
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('ProcessManager.spawn - cwd tilde expansion (issue #1173)', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockPtyProcess.onData.mockImplementation(() => {});
+		mockPtyProcess.onExit.mockImplementation(() => {});
+	});
+
+	it('expands a leading ~/ in cwd to the home directory before spawning', () => {
+		const pm = new ProcessManager();
+		pm.spawn(baseConfig({ cwd: '~/Documents/VibeworkV2', sessionId: 's-tilde-path' }));
+
+		expect(lastSpawnCwd()).toBe(`${os.homedir()}/Documents/VibeworkV2`);
+	});
+
+	it('expands a bare ~ to the home directory', () => {
+		const pm = new ProcessManager();
+		pm.spawn(baseConfig({ cwd: '~', sessionId: 's-bare-tilde' }));
+
+		expect(lastSpawnCwd()).toBe(os.homedir());
+	});
+
+	it('leaves an already-absolute cwd unchanged', () => {
+		const pm = new ProcessManager();
+		pm.spawn(baseConfig({ cwd: '/Users/someone/abs/path', sessionId: 's-abs' }));
+
+		expect(lastSpawnCwd()).toBe('/Users/someone/abs/path');
+	});
+
+	it('records the expanded cwd on the tracked managed process', () => {
+		const pm = new ProcessManager();
+		pm.spawn(baseConfig({ cwd: '~/proj', sessionId: 's-tracked' }));
+
+		expect(pm.get('s-tracked')?.cwd).toBe(`${os.homedir()}/proj`);
+	});
+});

--- a/src/main/process-manager/ProcessManager.ts
+++ b/src/main/process-manager/ProcessManager.ts
@@ -17,6 +17,7 @@ import { LocalCommandRunner } from './runners/LocalCommandRunner';
 import { SshCommandRunner } from './runners/SshCommandRunner';
 import { logger } from '../utils/logger';
 import { isWindows } from '../../shared/platformDetection';
+import { expandTilde } from '../../shared/pathUtils';
 import type { SshRemoteConfig } from '../../shared/types';
 import { getDefaultShell } from '../stores/defaults';
 import { captureException } from '../utils/sentry';
@@ -57,6 +58,22 @@ export class ProcessManager extends EventEmitter {
 	 * to prevent orphaned PTY/child processes that are no longer tracked.
 	 */
 	spawn(config: ProcessConfig): SpawnResult {
+		// Expand a leading `~` in the working directory before spawning. node-pty
+		// and child_process hand `cwd` straight to the OS, which - unlike a shell -
+		// does not expand `~`. A session whose cwd is persisted as `~/project` (or
+		// bare `~`) would otherwise make the child's chdir() fail, leaving the shell
+		// in an invalid/unreadable directory. On macOS that surfaces on every shell
+		// startup as `Error: The current working directory must be readable to
+		// <user> to run brew`. The spawned process is always local (even the SSH
+		// client runs locally, with the remote `cd` injected into its args), so a
+		// literal `~` cwd is never intentional here. See issue #1173.
+		if (config.cwd) {
+			const expandedCwd = expandTilde(config.cwd);
+			if (expandedCwd !== config.cwd) {
+				config = { ...config, cwd: expandedCwd };
+			}
+		}
+
 		// Kill any existing process for this sessionId to prevent orphans.
 		// This guards against double-spawn race conditions where a second spawn
 		// overwrites the map entry and the first process becomes untracked.


### PR DESCRIPTION
Closes #1173

## Problem

After starting any terminal or agent session, every shell prints on startup:

```
Error: The current working directory must be readable to <user> to run brew
```

The prompt shows no project path (e.g. `user@host %`), which means the shell was launched in a directory that does not exist or is not readable.

## Root cause

Sessions persist their working directory with a **literal `~`** (confirmed in the reporter's debug package: `processes.json` shows `cwd: "~"` and `cwd: "~/Documents/..."`, and every entry in `sessions.json` is `~`-prefixed).

`ProcessManager.spawn()` hands `cwd` straight to `node-pty` / `child_process`, which (unlike a shell) does **not** expand `~`. The child's `chdir()` to `~` fails, so the shell starts in an invalid/unreadable directory and Homebrew's `shellenv` init complains on every startup. This affects both terminals and agents regardless of provider, because they share the same spawn path.

## Fix

Expand a leading `~` in `config.cwd` at the `ProcessManager.spawn()` choke point, before dispatching to the PTY or child-process spawner. This:

- Covers terminals and agents (single shared entry point).
- Repairs sessions that already have a `~` persisted (so existing users are fixed without re-creating agents).
- Is safe for SSH: the spawned process is always local (the SSH client runs locally with the remote `cd` injected into its args), so a literal `~` local cwd is never intentional. SSH already passes an expanded `os.homedir()` as the local cwd, so this is a no-op there.

Uses the existing canonical `expandTilde()` helper from `src/shared/pathUtils.ts` (no new utility).

## Tests

Added `ProcessManager.cwd.test.ts` covering:
- `~/path` expands to `$HOME/path`
- bare `~` expands to `$HOME`
- absolute paths pass through unchanged
- the tracked managed process records the expanded cwd

All existing process-manager tests (268) still pass; main-process typecheck is clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Process launches now correctly handle paths that start with `~`, including the home directory shortcut and nested paths.
  * Improved reliability when starting managed processes by using the expanded home directory path instead of leaving it unexpanded.
  * Added coverage to verify the resolved working directory is tracked correctly for launched sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->