### PR TITLE
fix: navigate to Starred Session directly from group chat

### DIFF
--- a/src/__tests__/renderer/hooks/useStarredItems.test.ts
+++ b/src/__tests__/renderer/hooks/useStarredItems.test.ts
@@ -20,6 +20,7 @@ import { renderHook, act, cleanup, waitFor } from '@testing-library/react';
 import { useStarredItems } from '../../../renderer/hooks/session/useStarredItems';
 import { useSessionStore } from '../../../renderer/stores/sessionStore';
 import { useSettingsStore } from '../../../renderer/stores/settingsStore';
+import { useGroupChatStore } from '../../../renderer/stores/groupChatStore';
 import type { Session } from '../../../renderer/types';
 
 // ============================================================================
@@ -61,6 +62,7 @@ beforeEach(() => {
 	mockNamedSessions([]);
 	useSessionStore.setState({ sessions: [], activeSessionId: null } as never);
 	useSettingsStore.setState({ showStarredSessionsSection: true } as never);
+	useGroupChatStore.setState({ activeGroupChatId: null } as never);
 });
 
 afterEach(() => {
@@ -227,6 +229,32 @@ describe('useStarredItems', () => {
 		expect(useSessionStore.getState().activeSessionId).toBe('s1');
 		expect(session?.activeTabId).toBe('t1');
 		expect(session?.inputMode).toBe('ai');
+	});
+
+	it('dismisses an active group chat when activating a starred item (regression #1175)', async () => {
+		// Bug: clicking a Starred Session while a group chat was open did nothing.
+		// The group chat view is gated on a truthy activeGroupChatId and renders on
+		// top of the session view, so activating a starred tab without clearing it
+		// left the group chat covering the screen. Activation must clear it.
+		useGroupChatStore.setState({ activeGroupChatId: 'gc-1' } as never);
+		useSessionStore.setState({
+			sessions: [
+				makeSession({
+					id: 's1',
+					aiTabs: [{ id: 't1', starred: true, agentSessionId: 'asid-1', name: 'Tab One' }] as never,
+				}),
+			],
+		} as never);
+
+		const { result } = renderHook(() => useStarredItems({}));
+		const row = result.current.starredItems[0];
+
+		await act(async () => {
+			await result.current.activateStarredItem(row);
+		});
+
+		expect(useGroupChatStore.getState().activeGroupChatId).toBeNull();
+		expect(useSessionStore.getState().activeSessionId).toBe('s1');
 	});
 
 	it('offers to remove an aged-out star when the closed session can no longer be resumed', async () => {

--- a/src/renderer/hooks/session/useStarredItems.ts
+++ b/src/renderer/hooks/session/useStarredItems.ts
@@ -17,6 +17,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSessionStore } from '../../stores/sessionStore';
 import { useSettingsStore } from '../../stores/settingsStore';
+import { useGroupChatStore } from '../../stores/groupChatStore';
 import { updateSessionWith } from '../../stores/sessionStore';
 import { getTabDisplayName } from '../../utils/tabHelpers';
 import {
@@ -186,6 +187,13 @@ export function useStarredItems(deps: UseStarredItemsDeps): UseStarredItemsRetur
 
 	const activateStarredItem = useCallback(
 		async (item: StarredItem) => {
+			// Dismiss any active group chat first. App gates the group chat view on a
+			// truthy activeGroupChatId and renders it on top of the session view, so
+			// setting activeSessionId alone leaves the group chat covering everything
+			// and the click appears to do nothing. Agent-row clicks clear it via a
+			// wrapper (SessionList); mirror that here so both the open (early-return)
+			// and closed paths navigate out of group chat.
+			useGroupChatStore.getState().setActiveGroupChatId(null);
 			useSessionStore.getState().setActiveSessionId(item.parentSessionId);
 			if (item.kind === 'open') {
 				updateSessionWith(item.parentSessionId, (s) => ({


### PR DESCRIPTION
Closes #1175

## Problem

Clicking a **Starred Session** in the Left Bar while a group chat was open did nothing - no navigation occurred. The workaround was to click an agent first (which dismisses the group chat) and then click the Starred Session.

## Root cause

The group chat view is gated on a truthy `activeGroupChatId` and renders *on top of* the normal session view (`App.tsx` renders `<GroupChatPanel>` when `activeGroupChatId` is set, and the session view is gated on `!activeGroupChatId`).

`activateStarredItem` in `useStarredItems.ts` set `activeSessionId` but never cleared `activeGroupChatId`, so the group chat stayed on screen and the click appeared to do nothing. The open-tab branch also early-returns, so nothing downstream cleared it either.

Agent-row clicks already work because they route through a wrapper that calls `setActiveGroupChatId(null)` before setting the session; the starred path used the raw store action instead. Clicking an agent first is exactly why the workaround unblocks navigation.

## Fix

Clear `activeGroupChatId` at the top of `activateStarredItem`, mirroring the agent-row wrapper. This covers both the open (early-return) and closed starred-session paths.

## Testing

- Added a regression test to `useStarredItems.test.ts` asserting activation clears an active `activeGroupChatId` while still setting `activeSessionId`.
- Full `useStarredItems` suite passes (10/10).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Activating a starred session now closes any open group chat first, so the app switches cleanly to the selected conversation or tab.
  * Improved handling for both resumed and newly opened starred items to avoid leaving the group chat view in place.

* **Tests**
  * Added coverage to verify starred-item activation dismisses an active group chat and sets the correct active session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->