### PR TITLE
fix: RC bug-fix batch — idle perf, terminal cwd, cue scanner, starred nav, compact editor, auto-scroll

### DIFF
--- a/src/__tests__/main/cue/triggers/cue-task-scanner-trigger-source.test.ts
+++ b/src/__tests__/main/cue/triggers/cue-task-scanner-trigger-source.test.ts
@@ -99,6 +99,25 @@ describe('cue-task-scanner-trigger-source', () => {
 		source.stop();
 	});
 
+	it('start() does not forward an isActive visibility gate to the task scanner', () => {
+		const source = createCueTaskScannerTriggerSource({
+			session: makeSession(),
+			subscription: makeSub(),
+			registry: createCueSessionRegistry(),
+			enabled: () => false,
+			onLog: vi.fn(),
+			emit: vi.fn(),
+		})!;
+
+		source.start();
+
+		expect(mockCreateCueTaskScanner).toHaveBeenCalledOnce();
+		const config = mockCreateCueTaskScanner.mock.calls[0][0] as { isActive?: unknown };
+		expect(config.isActive).toBeUndefined();
+
+		source.stop();
+	});
+
 	it('start() defaults pollMinutes to 1 when subscription does not specify', () => {
 		const source = createCueTaskScannerTriggerSource({
 			session: makeSession(),

--- a/src/__tests__/main/process-manager/ProcessManager.cwd.test.ts
+++ b/src/__tests__/main/process-manager/ProcessManager.cwd.test.ts
@@ -1,0 +1,163 @@
+import { EventEmitter } from 'events';
+import * as os from 'os';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ChildProcess, SpawnOptionsWithoutStdio } from 'child_process';
+
+const { mockPtySpawn, mockChildSpawn, mockGetBridgeSocketPath } = vi.hoisted(() => ({
+	mockPtySpawn: vi.fn(),
+	mockChildSpawn: vi.fn(),
+	mockGetBridgeSocketPath: vi.fn(() => '/tmp/maestro-test-coworking.sock'),
+}));
+
+vi.mock('node-pty', () => ({
+	spawn: mockPtySpawn,
+}));
+
+vi.mock('child_process', () => ({
+	spawn: mockChildSpawn,
+	execFile: vi.fn(),
+	execFileSync: vi.fn(),
+}));
+
+vi.mock('../../../main/utils/logger', () => ({
+	logger: {
+		debug: vi.fn(),
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+	},
+}));
+
+vi.mock('../../../shared/platformDetection', () => ({
+	isWindows: () => false,
+}));
+
+vi.mock('../../../main/coworking/coworking-socket-path', () => ({
+	getBridgeSocketPath: () => mockGetBridgeSocketPath(),
+}));
+
+import { ProcessManager } from '../../../main/process-manager';
+
+type PtySpawnOptions = {
+	cwd?: string;
+};
+
+type ChildSpawnCall = [command: string, args: string[], options: SpawnOptionsWithoutStdio];
+
+class FakeReadable extends EventEmitter {
+	setEncoding = vi.fn();
+}
+
+class FakeWritable extends EventEmitter {
+	write = vi.fn();
+	end = vi.fn();
+}
+
+class FakeChildProcess extends EventEmitter {
+	pid = 24680;
+	stdout = new FakeReadable();
+	stderr = new FakeReadable();
+	stdin = new FakeWritable();
+	killed = false;
+	exitCode: number | null = null;
+	kill = vi.fn(() => {
+		this.killed = true;
+		return true;
+	});
+}
+
+function makeFakePty() {
+	return {
+		pid: 13579,
+		onData: vi.fn(),
+		onExit: vi.fn(),
+		write: vi.fn(),
+		resize: vi.fn(),
+		kill: vi.fn(),
+	};
+}
+
+function spawnTerminal(pm: ProcessManager, cwd: string, sessionId = `term-${cwd}`) {
+	return pm.spawn({
+		sessionId,
+		toolType: 'terminal',
+		cwd,
+		command: 'bash',
+		args: [],
+	});
+}
+
+describe('ProcessManager cwd tilde expansion', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockGetBridgeSocketPath.mockReturnValue('/tmp/maestro-test-coworking.sock');
+		mockPtySpawn.mockReturnValue(makeFakePty());
+		mockChildSpawn.mockReturnValue(new FakeChildProcess() as unknown as ChildProcess);
+	});
+
+	it('expands a leading ~/ cwd before spawning a PTY process', () => {
+		const pm = new ProcessManager();
+		const cwd = '~/Documents/x';
+		const expandedCwd = `${os.homedir()}/Documents/x`;
+
+		const result = spawnTerminal(pm, cwd, 'pty-leading-tilde');
+
+		expect(result).toEqual({ pid: 13579, success: true });
+		expect(mockPtySpawn).toHaveBeenCalledOnce();
+		const options = mockPtySpawn.mock.calls[0][2] as PtySpawnOptions;
+		expect(options.cwd).toBe(expandedCwd);
+	});
+
+	it('expands a bare ~ cwd to the user home before spawning a PTY process', () => {
+		const pm = new ProcessManager();
+
+		spawnTerminal(pm, '~', 'pty-bare-tilde');
+
+		expect(mockPtySpawn).toHaveBeenCalledOnce();
+		const options = mockPtySpawn.mock.calls[0][2] as PtySpawnOptions;
+		expect(options.cwd).toBe(os.homedir());
+	});
+
+	it('passes an absolute cwd through unchanged for PTY processes', () => {
+		const pm = new ProcessManager();
+		const cwd = '/var/tmp/maestro-project';
+
+		spawnTerminal(pm, cwd, 'pty-absolute');
+
+		expect(mockPtySpawn).toHaveBeenCalledOnce();
+		const options = mockPtySpawn.mock.calls[0][2] as PtySpawnOptions;
+		expect(options.cwd).toBe(cwd);
+	});
+
+	it('records the expanded cwd on the tracked managed process', () => {
+		const pm = new ProcessManager();
+		const sessionId = 'tracked-expanded-cwd';
+		const expandedCwd = `${os.homedir()}/Documents/x`;
+
+		spawnTerminal(pm, '~/Documents/x', sessionId);
+
+		expect(pm.get(sessionId)?.cwd).toBe(expandedCwd);
+	});
+
+	it('expands cwd before the non-PTY child_process spawn path receives it', () => {
+		const pm = new ProcessManager();
+		const expandedCwd = `${os.homedir()}/Documents/x`;
+
+		const result = pm.spawn({
+			sessionId: 'child-expanded-cwd',
+			toolType: 'claude-code',
+			cwd: '~/Documents/x',
+			command: 'claude',
+			args: [],
+			requiresPty: false,
+			prompt: 'summarize this repository',
+		});
+
+		expect(result).toEqual({ pid: 24680, success: true });
+		expect(mockPtySpawn).not.toHaveBeenCalled();
+		expect(mockChildSpawn).toHaveBeenCalledOnce();
+		const [, , options] = mockChildSpawn.mock.calls[0] as ChildSpawnCall;
+		expect(options.cwd).toBe(expandedCwd);
+		expect(pm.get('child-expanded-cwd')?.cwd).toBe(expandedCwd);
+	});
+});

--- a/src/__tests__/renderer/components/InputArea/hooks/useInputAreaTextChange.test.tsx
+++ b/src/__tests__/renderer/components/InputArea/hooks/useInputAreaTextChange.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { useRef } from 'react';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { useInputAreaTextChange } from '../../../../../renderer/components/InputArea/hooks/useInputAreaTextChange';
 
 function Harness({
@@ -30,6 +30,10 @@ function Harness({
 }
 
 describe('useInputAreaTextChange', () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
 	function createHandlers() {
 		return {
 			setInputValue: vi.fn(),
@@ -90,5 +94,27 @@ describe('useInputAreaTextChange', () => {
 		});
 
 		expect(handlers.setAtMentionOpen).not.toHaveBeenCalled();
+	});
+
+	it('scrolls the resized textarea to the caret at the end during the keystroke frame', () => {
+		const handlers = createHandlers();
+		const runAnimationFrame = vi.fn((callback: FrameRequestCallback): number => {
+			callback(0);
+			return 1;
+		});
+		vi.stubGlobal('requestAnimationFrame', runAnimationFrame);
+		render(<Harness handlers={handlers} />);
+		const textarea = screen.getByLabelText('input') as HTMLTextAreaElement;
+		const value = `${'line\n'.repeat(80)}end`;
+		textarea.scrollTop = 0;
+		Object.defineProperty(textarea, 'scrollHeight', { value: 640, configurable: true });
+		Object.defineProperty(textarea, 'selectionEnd', { value: value.length, configurable: true });
+
+		fireEvent.change(textarea, {
+			target: { value, selectionStart: value.length },
+		});
+
+		expect(runAnimationFrame).toHaveBeenCalledTimes(1);
+		expect(textarea.scrollTop).toBe(640);
 	});
 });

--- a/src/__tests__/renderer/components/InputArea/utils/textareaSizing.test.ts
+++ b/src/__tests__/renderer/components/InputArea/utils/textareaSizing.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
 	resizeTextareaToContent,
+	scrollTextareaToCaretEnd,
 	shouldScrollTextareaToEnd,
 } from '../../../../../renderer/components/InputArea/utils/textareaSizing';
 
@@ -23,6 +24,32 @@ describe('InputArea textareaSizing utils', () => {
 		expect(textarea.style.height).toBe('80px');
 	});
 
+	it('scrolls the textarea to the bottom when the caret is at the end', () => {
+		const textarea = document.createElement('textarea');
+		textarea.value = 'hello';
+		textarea.scrollTop = 12;
+		Object.defineProperty(textarea, 'scrollHeight', { value: 240, configurable: true });
+		Object.defineProperty(textarea, 'selectionEnd', {
+			value: textarea.value.length,
+			configurable: true,
+		});
+
+		scrollTextareaToCaretEnd(textarea);
+
+		expect(textarea.scrollTop).toBe(240);
+	});
+
+	it('leaves textarea scroll position untouched when the caret is mid-text', () => {
+		const textarea = document.createElement('textarea');
+		textarea.value = 'hello';
+		textarea.scrollTop = 12;
+		Object.defineProperty(textarea, 'scrollHeight', { value: 240, configurable: true });
+		Object.defineProperty(textarea, 'selectionEnd', { value: 2, configurable: true });
+
+		scrollTextareaToCaretEnd(textarea);
+
+		expect(textarea.scrollTop).toBe(12);
+	});
 	it('scrolls when caret was at previous end', () => {
 		expect(shouldScrollTextareaToEnd(5, 5, 6)).toBe(true);
 	});

--- a/src/__tests__/renderer/components/auto-scroll.test.tsx
+++ b/src/__tests__/renderer/components/auto-scroll.test.tsx
@@ -17,6 +17,12 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { TerminalOutput } from '../../../renderer/components/TerminalOutput';
 import type { Session, Theme, LogEntry } from '../../../renderer/types';
 
+declare global {
+	interface Window {
+		__mutationCallback?: () => void;
+	}
+}
+
 // Mock dependencies (same pattern as TerminalOutput.test.tsx)
 vi.mock('react-syntax-highlighter', () => ({
 	Prism: ({ children }: { children: string }) => (
@@ -70,8 +76,11 @@ vi.mock('../../../renderer/utils/tabHelpers', () => ({
 class MockMutationObserver {
 	private callback: MutationCallback;
 	observe = vi.fn(() => {
-		// Store callback so rerender-triggered DOM changes can flush it
-		(window as any).__mutationCallback = this.callback;
+		// Store callback so rerender-triggered DOM changes can flush it.
+		window.__mutationCallback = () => {
+			// Test double implements the MutationObserver methods the component uses.
+			this.callback([], this as unknown as MutationObserver);
+		};
 	});
 	disconnect = vi.fn();
 	takeRecords = vi.fn().mockReturnValue([]);
@@ -83,7 +92,7 @@ vi.stubGlobal('MutationObserver', MockMutationObserver);
 
 // Default theme for testing
 const defaultTheme: Theme = {
-	id: 'test-theme' as any,
+	id: 'custom',
 	name: 'Test Theme',
 	mode: 'dark',
 	colors: {
@@ -228,7 +237,7 @@ describe('Auto-scroll feature', () => {
 			rerender(<TerminalOutput {...createDefaultProps({ session: updatedSession })} />);
 
 			// Trigger MutationObserver callback (simulates DOM mutation)
-			(window as any).__mutationCallback?.([]);
+			window.__mutationCallback?.();
 
 			await act(async () => {
 				vi.advanceTimersByTime(20); // Flush RAF + any timers
@@ -322,13 +331,74 @@ describe('Auto-scroll feature', () => {
 			rerender(<TerminalOutput {...createDefaultProps({ session: updatedSession })} />);
 
 			// Trigger MutationObserver callback (simulates DOM mutation from new node)
-			(window as any).__mutationCallback?.([]);
+			window.__mutationCallback?.();
 
 			await act(async () => {
 				vi.advanceTimersByTime(20);
 			});
 
 			expect(scrollToSpy).toHaveBeenCalled();
+		});
+
+		it('gates MutationObserver auto-scroll on the latest at-bottom position', async () => {
+			const session = createDefaultSession({
+				tabs: [
+					{
+						id: 'tab-1',
+						agentSessionId: 'claude-123',
+						logs: [createLogEntry({ id: 'initial-log', text: 'Initial output' })],
+						isUnread: false,
+					},
+				],
+				activeTabId: 'tab-1',
+			});
+			const { container } = render(<TerminalOutput {...createDefaultProps({ session })} />);
+			const scrollContainer = container.querySelector('.overflow-y-auto') as HTMLElement;
+			const scrollToSpy = vi.fn();
+			let scrollTop = 1600;
+			scrollContainer.scrollTo = scrollToSpy;
+			Object.defineProperty(scrollContainer, 'scrollHeight', { value: 2000, configurable: true });
+			Object.defineProperty(scrollContainer, 'clientHeight', { value: 400, configurable: true });
+			Object.defineProperty(scrollContainer, 'scrollTop', {
+				get: () => scrollTop,
+				set: (next: number) => {
+					scrollTop = next;
+				},
+				configurable: true,
+			});
+
+			await act(async () => {
+				vi.advanceTimersByTime(50);
+			});
+			scrollToSpy.mockClear();
+
+			scrollTop = 500;
+			fireEvent.scroll(scrollContainer);
+			await act(async () => {
+				vi.advanceTimersByTime(20);
+			});
+			scrollToSpy.mockClear();
+
+			window.__mutationCallback?.();
+			await act(async () => {
+				vi.advanceTimersByTime(50);
+			});
+
+			expect(scrollToSpy).not.toHaveBeenCalled();
+
+			scrollTop = 1600;
+			fireEvent.scroll(scrollContainer);
+			await act(async () => {
+				vi.advanceTimersByTime(20);
+			});
+			scrollToSpy.mockClear();
+
+			window.__mutationCallback?.();
+			await act(async () => {
+				vi.advanceTimersByTime(50);
+			});
+
+			expect(scrollToSpy).toHaveBeenCalledWith({ top: 2000, behavior: 'auto' });
 		});
 	});
 });

--- a/src/__tests__/renderer/hooks/useFileTreeManagement.test.ts
+++ b/src/__tests__/renderer/hooks/useFileTreeManagement.test.ts
@@ -156,6 +156,97 @@ describe('useFileTreeManagement', () => {
 		expect(state.getSessions()[0].fileTreeError).toBeUndefined();
 	});
 
+	describe('refreshFileTree fileTree identity (#1180)', () => {
+		it('preserves the existing fileTree reference when a refresh reports no structural changes', async () => {
+			const existingTree: FileNode[] = [
+				{
+					name: 'src',
+					type: 'folder',
+					children: [{ name: 'index.ts', type: 'file' }],
+				},
+			];
+			const reloadedTree: FileNode[] = [
+				{
+					name: 'src',
+					type: 'folder',
+					children: [{ name: 'index.ts', type: 'file' }],
+				},
+			];
+			const noChanges = {
+				totalChanges: 0,
+				newFiles: 0,
+				newFolders: 0,
+				removedFiles: 0,
+				removedFolders: 0,
+			};
+
+			vi.mocked(loadFileTree).mockResolvedValue(asResult(reloadedTree));
+			vi.mocked(compareFileTrees).mockReturnValue(noChanges);
+
+			const session = createMockSession({
+				fileTree: existingTree,
+				fileTreeStats: {
+					fileCount: 1,
+					folderCount: 1,
+					totalSize: 128,
+				},
+			});
+			const state = createSessionsState([session]);
+			const deps = createDeps(state);
+			const { result } = renderHook(() => useFileTreeManagement(deps));
+
+			let returnedChanges: typeof noChanges | undefined;
+			await act(async () => {
+				returnedChanges = await result.current.refreshFileTree(session.id);
+			});
+
+			expect(compareFileTrees).toHaveBeenCalledWith(existingTree, reloadedTree);
+			expect(returnedChanges).toEqual(noChanges);
+			expect(state.getSessions()[0].fileTree).toBe(existingTree);
+			expect(state.getSessions()[0].fileTree).not.toBe(reloadedTree);
+		});
+
+		it('replaces the fileTree reference when a refresh reports structural changes', async () => {
+			const existingTree: FileNode[] = [{ name: 'old.txt', type: 'file' }];
+			const reloadedTree: FileNode[] = [
+				{ name: 'old.txt', type: 'file' },
+				{ name: 'new.txt', type: 'file' },
+			];
+			const changes = {
+				totalChanges: 2,
+				newFiles: 1,
+				newFolders: 0,
+				removedFiles: 1,
+				removedFolders: 0,
+			};
+
+			vi.mocked(loadFileTree).mockResolvedValue(asResult(reloadedTree));
+			vi.mocked(compareFileTrees).mockReturnValue(changes);
+
+			const session = createMockSession({
+				fileTree: existingTree,
+				fileTreeStats: {
+					fileCount: 1,
+					folderCount: 0,
+					totalSize: 64,
+				},
+			});
+			const state = createSessionsState([session]);
+			const deps = createDeps(state);
+			const { result } = renderHook(() => useFileTreeManagement(deps));
+
+			let returnedChanges: typeof changes | undefined;
+			await act(async () => {
+				returnedChanges = await result.current.refreshFileTree(session.id);
+			});
+
+			expect(compareFileTrees).toHaveBeenCalledWith(existingTree, reloadedTree);
+			expect(returnedChanges).toEqual(changes);
+			expect(state.getSessions()[0].fileTree).toBe(reloadedTree);
+			expect(state.getSessions()[0].fileTree).not.toBe(existingTree);
+		});
+	});
+
 	it('refreshFileTree handles load errors', async () => {
 		vi.mocked(loadFileTree).mockRejectedValue(new Error('boom'));
 

--- a/src/__tests__/renderer/hooks/useStarredItems.test.ts
+++ b/src/__tests__/renderer/hooks/useStarredItems.test.ts
@@ -20,6 +20,7 @@ import { renderHook, act, cleanup, waitFor } from '@testing-library/react';
 import { useStarredItems } from '../../../renderer/hooks/session/useStarredItems';
 import { useSessionStore } from '../../../renderer/stores/sessionStore';
 import { useSettingsStore } from '../../../renderer/stores/settingsStore';
+import { useGroupChatStore } from '../../../renderer/stores/groupChatStore';
 import type { Session } from '../../../renderer/types';
 
 // ============================================================================
@@ -61,6 +62,7 @@ beforeEach(() => {
 	mockNamedSessions([]);
 	useSessionStore.setState({ sessions: [], activeSessionId: null } as never);
 	useSettingsStore.setState({ showStarredSessionsSection: true } as never);
+	useGroupChatStore.setState({ activeGroupChatId: null } as never);
 });
 
 afterEach(() => {
@@ -227,6 +229,55 @@ describe('useStarredItems', () => {
 		expect(useSessionStore.getState().activeSessionId).toBe('s1');
 		expect(session?.activeTabId).toBe('t1');
 		expect(session?.inputMode).toBe('ai');
+	});
+
+	it('activateStarredItem clears active group chat before focusing an open starred tab', async () => {
+		useGroupChatStore.setState({ activeGroupChatId: 'group-1' } as never);
+		useSessionStore.setState({
+			sessions: [
+				makeSession({
+					id: 's1',
+					aiTabs: [{ id: 't1', starred: true, agentSessionId: 'asid-1', name: 'Tab One' }] as never,
+				}),
+			],
+		} as never);
+
+		const { result } = renderHook(() => useStarredItems({}));
+		const row = result.current.starredItems[0];
+
+		await act(async () => {
+			await result.current.activateStarredItem(row);
+		});
+
+		expect(useGroupChatStore.getState().activeGroupChatId).toBeNull();
+		expect(useSessionStore.getState().activeSessionId).toBe('s1');
+	});
+
+	it('activateStarredItem clears active group chat before resuming a closed starred session', async () => {
+		const onJumpToStarredSession = vi.fn().mockResolvedValue(true);
+		useGroupChatStore.setState({ activeGroupChatId: 'group-1' } as never);
+		mockNamedSessions([makeNamed({ agentSessionId: 'asid-closed', sessionName: 'Closed One' })]);
+		useSessionStore.setState({
+			sessions: [makeSession({ id: 's1', projectRoot: '/proj' })],
+		} as never);
+
+		const { result } = renderHook(() => useStarredItems({ onJumpToStarredSession }));
+		await waitFor(() => expect(result.current.starredItems).toHaveLength(1));
+		const closedRow = result.current.starredItems[0];
+
+		await act(async () => {
+			await result.current.activateStarredItem(closedRow);
+		});
+
+		expect(useGroupChatStore.getState().activeGroupChatId).toBeNull();
+		expect(useSessionStore.getState().activeSessionId).toBe('s1');
+		expect(onJumpToStarredSession).toHaveBeenCalledWith(
+			'claude-code',
+			'/proj',
+			'asid-closed',
+			'Closed One',
+			's1'
+		);
 	});
 
 	it('offers to remove an aged-out star when the closed session can no longer be resumed', async () => {

--- a/src/main/cue/triggers/cue-task-scanner-trigger-source.ts
+++ b/src/main/cue/triggers/cue-task-scanner-trigger-source.ts
@@ -4,9 +4,16 @@
  * Thin wrapper around `createCueTaskScanner` that adapts its callback shape
  * to the {@link CueTriggerSource} interface and routes events through the
  * centralized `passesFilter` helper before emitting.
+ *
+ * Unlike the `file.changed` and `github.*` sources, the task scanner is
+ * intentionally NOT gated on the Cue visibility flag (`isCueActive`). A
+ * `task.pending` subscription is the unattended-automation case the feature
+ * exists for: the app window is usually backgrounded while a queue drains, so
+ * pausing the scan while hidden stalls exactly the workflow the user wants
+ * running. The scan itself is a cheap 1-minute poll of a single glob, so the
+ * CPU cost of keeping it live while hidden is negligible. See issue #1164.
  */
 
-import { isCueActive } from '../cue-active-state';
 import { createCueTaskScanner } from '../cue-task-scanner';
 import { passesFilter } from './cue-trigger-filter';
 import type { CueTriggerSource, CueTriggerSourceContext } from './cue-trigger-source';
@@ -30,7 +37,8 @@ export function createCueTaskScannerTriggerSource(
 				projectRoot: ctx.session.projectRoot,
 				triggerName: ctx.subscription.name,
 				onLog: (level, message) => ctx.onLog(level as Parameters<typeof ctx.onLog>[0], message),
-				isActive: isCueActive,
+				// Deliberately no `isActive` gate (see the file header): task.pending
+				// must keep scanning while the window is hidden.
 				onEvent: (event) => {
 					if (!ctx.enabled()) return;
 					if (!passesFilter(ctx.subscription, event, ctx.onLog)) return;

--- a/src/main/process-manager/ProcessManager.ts
+++ b/src/main/process-manager/ProcessManager.ts
@@ -19,6 +19,7 @@ import { SshCommandRunner } from './runners/SshCommandRunner';
 import { opencodeServerManager } from '../opencode-server/OpencodeServerManager';
 import { logger } from '../utils/logger';
 import { isWindows } from '../../shared/platformDetection';
+import { expandTilde } from '../../shared/pathUtils';
 import type { SshRemoteConfig } from '../../shared/types';
 import { getDefaultShell } from '../stores/defaults';
 import { captureException } from '../utils/sentry';
@@ -82,6 +83,22 @@ export class ProcessManager extends EventEmitter {
 	 * to prevent orphaned PTY/child processes that are no longer tracked.
 	 */
 	spawn(config: ProcessConfig): SpawnResult {
+		// Expand a leading `~` in the working directory before spawning. node-pty
+		// and child_process hand `cwd` straight to the OS, which - unlike a shell -
+		// does not expand `~`. A session whose cwd is persisted as `~/project` (or
+		// bare `~`) would otherwise make the child's chdir() fail, leaving the shell
+		// in an invalid/unreadable directory. On macOS that surfaces on every shell
+		// startup as `Error: The current working directory must be readable to
+		// <user> to run brew`. The spawned process is always local (even the SSH
+		// client runs locally, with the remote `cd` injected into its args), so a
+		// literal `~` cwd is never intentional here. See issue #1173.
+		if (config.cwd) {
+			const expandedCwd = expandTilde(config.cwd);
+			if (expandedCwd !== config.cwd) {
+				config = { ...config, cwd: expandedCwd };
+			}
+		}
+
 		// Kill any existing process for this sessionId to prevent orphans.
 		// This guards against double-spawn race conditions where a second spawn
 		// overwrites the map entry and the first process becomes untracked.

--- a/src/renderer/components/InputArea/hooks/useInputAreaTextChange.ts
+++ b/src/renderer/components/InputArea/hooks/useInputAreaTextChange.ts
@@ -1,6 +1,10 @@
 import { startTransition, useCallback } from 'react';
 import type React from 'react';
-import { KEYSTROKE_TEXTAREA_MAX_HEIGHT, resizeTextareaToContent } from '../utils/textareaSizing';
+import {
+	KEYSTROKE_TEXTAREA_MAX_HEIGHT,
+	resizeTextareaToContent,
+	scrollTextareaToCaretEnd,
+} from '../utils/textareaSizing';
 import { getAtMentionTrigger, shouldOpenSlashCommand } from '../utils/inputTriggers';
 import type { MentionCategory } from '../../../hooks/input/useMentionPicker';
 
@@ -89,6 +93,10 @@ export function useInputAreaTextChange({
 			keystrokeResizeScheduledRef.current = true;
 			requestAnimationFrame(() => {
 				resizeTextareaToContent(textarea, KEYSTROKE_TEXTAREA_MAX_HEIGHT);
+				// resizeTextareaToContent resets scrollTop (via height:'auto'), so the
+				// keystroke path must re-scroll to the caret or newly typed text past the
+				// max height stays hidden until the user adds line breaks (issue #1169).
+				scrollTextareaToCaretEnd(textarea);
 				keystrokeResizeScheduledRef.current = false;
 			});
 		},

--- a/src/renderer/components/InputArea/utils/textareaSizing.ts
+++ b/src/renderer/components/InputArea/utils/textareaSizing.ts
@@ -6,6 +6,20 @@ export function resizeTextareaToContent(textarea: HTMLTextAreaElement, maxHeight
 	textarea.style.height = `${Math.min(textarea.scrollHeight, maxHeight)}px`;
 }
 
+/**
+ * Keep the caret visible after a keystroke resize. resizeTextareaToContent sets
+ * height:'auto' first, which resets the textarea's scrollTop, so once the box hits
+ * its max height and scrolls internally the freshly typed text at the end would
+ * otherwise fall out of view. Snap the scroll to the bottom when the caret sits at
+ * the end of the content (the continuous-typing case); leave it untouched for
+ * mid-text edits so the viewport does not jump. See issue #1169.
+ */
+export function scrollTextareaToCaretEnd(textarea: HTMLTextAreaElement): void {
+	if (textarea.selectionEnd >= textarea.value.length) {
+		textarea.scrollTop = textarea.scrollHeight;
+	}
+}
+
 export function shouldScrollTextareaToEnd(
 	selectionEnd: number,
 	previousValueLength: number,

--- a/src/renderer/components/Markdown/Markdown.tsx
+++ b/src/renderer/components/Markdown/Markdown.tsx
@@ -258,15 +258,23 @@ export const Markdown = memo(function Markdown({
 		codeBlockStyle,
 	]);
 
-	const markdown = (
-		<ReactMarkdown
-			remarkPlugins={remarkPlugins}
-			rehypePlugins={rehypePlugins}
-			urlTransform={urlTransformAllowingMaestro}
-			components={components}
-		>
-			{processedContent}
-		</ReactMarkdown>
+	// Memoize the ReactMarkdown element: react-markdown re-runs the full remark+
+	// rehype parse/runSync on every render (no internal memoization), so without
+	// this a re-render with referentially-stable inputs still re-parses the whole
+	// message. Keyed on the already-memoized plugin arrays, components, and
+	// content (urlTransform is a module constant). (#1180)
+	const markdown = useMemo(
+		() => (
+			<ReactMarkdown
+				remarkPlugins={remarkPlugins}
+				rehypePlugins={rehypePlugins}
+				urlTransform={urlTransformAllowingMaestro}
+				components={components}
+			>
+				{processedContent}
+			</ReactMarkdown>
+		),
+		[remarkPlugins, rehypePlugins, components, processedContent]
 	);
 
 	// Chat owns its prose container + context menus. Other presets render bare so

--- a/src/renderer/components/TerminalOutput/hooks/useTerminalOutputScroll.ts
+++ b/src/renderer/components/TerminalOutput/hooks/useTerminalOutputScroll.ts
@@ -29,8 +29,6 @@ export function useTerminalOutputScroll({
 	isAtBottomRef.current = isAtBottom;
 
 	const [autoScrollPaused, setAutoScrollPaused] = useState(false);
-	const autoScrollPausedRef = useRef(false);
-	autoScrollPausedRef.current = autoScrollPaused;
 
 	const isProgrammaticScrollRef = useRef(false);
 	const tabReadStateRef = useRef<Map<string, number>>(new Map());
@@ -42,6 +40,9 @@ export function useTerminalOutputScroll({
 		const { scrollTop, scrollHeight, clientHeight } = scrollContainerRef.current;
 		const atBottom = scrollHeight - scrollTop - clientHeight < 50;
 		setIsAtBottom(atBottom);
+		// Mirror into the ref synchronously so MutationObserver sees the user's
+		// new position before a content re-render can yank to bottom (#1140).
+		isAtBottomRef.current = atBottom;
 
 		if (atBottom !== prevIsAtBottomRef.current) {
 			prevIsAtBottomRef.current = atBottom;
@@ -139,12 +140,12 @@ export function useTerminalOutputScroll({
 		const container = scrollContainerRef.current;
 		if (!container) return;
 
-		const shouldAutoScroll = () => !autoScrollPausedRef.current || isAtBottomRef.current;
-
 		const scrollToBottom = () => {
 			if (!scrollContainerRef.current) return;
 			requestAnimationFrame(() => {
-				if (scrollContainerRef.current) {
+				// Re-check isAtBottomRef inside the rAF so a scroll-up that happens
+				// after schedule but before paint cancels the yank (#1140).
+				if (scrollContainerRef.current && isAtBottomRef.current) {
 					isProgrammaticScrollRef.current = true;
 					scrollContainerRef.current.scrollTo({
 						top: scrollContainerRef.current.scrollHeight,
@@ -157,12 +158,16 @@ export function useTerminalOutputScroll({
 			});
 		};
 
-		if (shouldAutoScroll()) {
+		// Only auto-scroll when the user's tracked position is at the bottom.
+		// Gating on isAtBottom (not `!autoScrollPaused`) keeps a content re-render
+		// after generation finishes — code-block re-highlight, markdown reflow —
+		// from yanking the view down while the user reads earlier output. (#1140)
+		if (isAtBottomRef.current) {
 			scrollToBottom();
 		}
 
 		const observer = new MutationObserver(() => {
-			if (shouldAutoScroll()) {
+			if (isAtBottomRef.current) {
 				scrollToBottom();
 			}
 		});
@@ -185,7 +190,8 @@ export function useTerminalOutputScroll({
 					const maxScroll = Math.max(0, scrollHeight - clientHeight);
 					const targetScroll = Math.min(initialScrollTop, maxScroll);
 					if (targetScroll < maxScroll - 50) {
-						autoScrollPausedRef.current = true;
+						// Flip isAtBottomRef first so the observer's live at-bottom
+						// check sees the restored position this frame (#1140).
 						isAtBottomRef.current = false;
 						setAutoScrollPaused(true);
 						setIsAtBottom(false);

--- a/src/renderer/hooks/git/useFileTreeManagement.ts
+++ b/src/renderer/hooks/git/useFileTreeManagement.ts
@@ -31,6 +31,14 @@ import {
 const FILE_TREE_RETRY_DELAY_MS = 20000;
 
 /**
+ * Stable, shared empty tree. Failed loads and 20s retries reuse this ONE
+ * reference instead of a fresh `[]`, so a permanently-failing load can't churn
+ * fileTree identity every retry. A new array identity invalidates every
+ * message's markdown memo and forces a full transcript re-parse (#1180).
+ */
+const EMPTY_FILE_TREE: FileTreeNode[] = [];
+
+/**
  * Options for building SSH context
  */
 interface SshContextOptions {
@@ -403,18 +411,26 @@ export function useFileTreeManagement(
 					.then((stats) => {
 						if (isStale(sessionId, seq)) return;
 						setSessions((prev) =>
-							prev.map((s) =>
-								s.id === sessionId
-									? {
-											...s,
-											fileTreeStats: {
-												fileCount: stats.fileCount,
-												folderCount: stats.folderCount,
-												totalSize: stats.totalSize,
-											},
-										}
-									: s
-							)
+							prev.map((s) => {
+								if (s.id !== sessionId) return s;
+								const cur = s.fileTreeStats;
+								if (
+									cur &&
+									cur.fileCount === stats.fileCount &&
+									cur.folderCount === stats.folderCount &&
+									cur.totalSize === stats.totalSize
+								) {
+									return s; // unchanged — preserve identity, skip re-render (#1180)
+								}
+								return {
+									...s,
+									fileTreeStats: {
+										fileCount: stats.fileCount,
+										folderCount: stats.folderCount,
+										totalSize: stats.totalSize,
+									},
+								};
+							})
 						);
 					})
 					.catch((err) => {
@@ -431,18 +447,31 @@ export function useFileTreeManagement(
 				const oldTree = session.fileTree || [];
 				const changes = compareFileTrees(oldTree, loadResult.tree);
 
+				const treeUnchanged = changes.totalChanges === 0;
 				setSessions((prev) =>
-					prev.map((s) =>
-						s.id === sessionId
-							? {
-									...s,
-									fileTree: loadResult.tree,
-									fileTreeError: undefined,
-									fileTreeTruncated: loadResult.truncated,
-									fileTreeLoadedCap: maxEntriesForRefresh,
-								}
-							: s
-					)
+					prev.map((s) => {
+						if (s.id !== sessionId) return s;
+						// Preserve the existing fileTree reference when the structure is
+						// unchanged so buildFileTreeIndices, the remark plugin array, and
+						// every message's markdown memo stay valid — otherwise each idle
+						// auto-refresh re-parses the whole transcript and freezes typing (#1180).
+						const nextTree = treeUnchanged ? (s.fileTree ?? loadResult.tree) : loadResult.tree;
+						if (
+							nextTree === s.fileTree &&
+							s.fileTreeError === undefined &&
+							s.fileTreeTruncated === loadResult.truncated &&
+							s.fileTreeLoadedCap === maxEntriesForRefresh
+						) {
+							return s; // nothing changed — skip the write entirely
+						}
+						return {
+							...s,
+							fileTree: nextTree,
+							fileTreeError: undefined,
+							fileTreeTruncated: loadResult.truncated,
+							fileTreeLoadedCap: maxEntriesForRefresh,
+						};
+					})
 				);
 
 				return changes;
@@ -516,18 +545,26 @@ export function useFileTreeManagement(
 					.then((stats) => {
 						if (isStale(sessionId, seq)) return;
 						setSessions((prev) =>
-							prev.map((s) =>
-								s.id === sessionId
-									? {
-											...s,
-											fileTreeStats: {
-												fileCount: stats.fileCount,
-												folderCount: stats.folderCount,
-												totalSize: stats.totalSize,
-											},
-										}
-									: s
-							)
+							prev.map((s) => {
+								if (s.id !== sessionId) return s;
+								const cur = s.fileTreeStats;
+								if (
+									cur &&
+									cur.fileCount === stats.fileCount &&
+									cur.folderCount === stats.folderCount &&
+									cur.totalSize === stats.totalSize
+								) {
+									return s; // unchanged — preserve identity (#1180)
+								}
+								return {
+									...s,
+									fileTreeStats: {
+										fileCount: stats.fileCount,
+										folderCount: stats.folderCount,
+										totalSize: stats.totalSize,
+									},
+								};
+							})
 						);
 					})
 					.catch((err) => {
@@ -566,12 +603,16 @@ export function useFileTreeManagement(
 				// Re-check after additional awaits (branches/tags fetch)
 				if (isStale(sessionId, seq)) return;
 
+				const treeUnchanged =
+					compareFileTrees(session.fileTree || [], loadResult.tree).totalChanges === 0;
 				setSessions((prev) =>
 					prev.map((s) =>
 						s.id === sessionId
 							? {
 									...s,
-									fileTree: loadResult.tree,
+									// Preserve fileTree identity on no-change so a git refresh
+									// doesn't force a full markdown re-parse of the transcript (#1180).
+									fileTree: treeUnchanged ? (s.fileTree ?? loadResult.tree) : loadResult.tree,
 									fileTreeError: undefined,
 									fileTreeTruncated: loadResult.truncated,
 									fileTreeLoadedCap: maxEntriesForRefresh,
@@ -876,7 +917,7 @@ export function useFileTreeManagement(
 							s.id === sessionId
 								? {
 										...s,
-										fileTree: [],
+										fileTree: EMPTY_FILE_TREE,
 										fileTreeError: `Cannot access directory: ${treeRoot}\n${errorMsg}`,
 										fileTreeRetryAt: Date.now() + FILE_TREE_RETRY_DELAY_MS,
 										fileTreeLoading: false,

--- a/src/renderer/hooks/session/useStarredItems.ts
+++ b/src/renderer/hooks/session/useStarredItems.ts
@@ -17,6 +17,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSessionStore } from '../../stores/sessionStore';
 import { useSettingsStore } from '../../stores/settingsStore';
+import { useGroupChatStore } from '../../stores/groupChatStore';
 import { updateSessionWith } from '../../stores/sessionStore';
 import { getTabDisplayName } from '../../utils/tabHelpers';
 import {
@@ -198,6 +199,13 @@ export function useStarredItems(deps: UseStarredItemsDeps): UseStarredItemsRetur
 
 	const activateStarredItem = useCallback(
 		async (item: StarredItem) => {
+			// Dismiss any active group chat first. App gates the group chat view on a
+			// truthy activeGroupChatId and renders it on top of the session view, so
+			// setting activeSessionId alone leaves the group chat covering everything
+			// and the click appears to do nothing. Agent-row clicks clear it via a
+			// wrapper (SessionList); mirror that here so both the open (early-return)
+			// and closed paths navigate out of group chat. See issue #1175.
+			useGroupChatStore.getState().setActiveGroupChatId(null);
 			useSessionStore.getState().setActiveSessionId(item.parentSessionId);
 			if (item.kind === 'open') {
 				updateSessionWith(item.parentSessionId, (s) => ({


### PR DESCRIPTION
Consolidated bug-fix batch on top of latest `rc`. Each fix is a separate commit with regression tests.

Fixes #1180, #1173, #1164, #1175, #1169, #1140.

## Fixes

| Issue | Fix | Commit | Supersedes |
|---|---|---|---|
| #1180 | Idle file-tree auto-refresh churned `fileTree` identity → full markdown re-parse per message (~2.7s freeze). Preserve identity on no-change refresh; reuse a shared empty tree on load failure; memoize the ReactMarkdown element. | `fe49a51` | — |
| #1173 | Terminals fail with \"working directory must be readable\" (regression): sessions persist `~`, which the OS doesn't expand. Expand leading `~` at the `ProcessManager.spawn()` choke point (terminals + agents). | `add3c76` | #1174 |
| #1164 | Cue `task.pending` scanner paused while the window was hidden (unattended queues stalled). Drop the `isCueActive` visibility gate for the task scanner only. | `2bccf4a` | #1165 |
| #1175 | Clicking a Starred Session from group chat did nothing. Clear `activeGroupChatId` before activating (both open + closed paths). | `1fe3da9` | #1177 |
| #1169 | Compact prompt editor hid typed text past its max height. Scroll to the caret after the keystroke resize when the caret is at the end. | `21eb53f` | #1170 |
| #1140 | AI output pane yanked to the bottom on content re-render (code-block re-highlight) after scrolling up. Gate auto-scroll on the live at-bottom position only; update `isAtBottomRef` synchronously. | `e3a3529` | — (new) |

## Provenance

- #1147 (Codex thought streaming, PR #1148) is already merged to `rc` — excluded.
- The four prior fixes for #1173/#1164/#1175/#1169 (PRs #1174/#1165/#1177/#1170 by the pedram bot) targeted `main`, not the active `rc` line. Reviewed them (small, correct, well-tested) and re-applied onto `rc` here — forward-porting where needed and closing the review-flagged test gaps (closed-starred-session path for #1175; non-PTY child-process cwd path for #1173). Those four PRs can be closed in favor of this batch.

## Verification

- New/extended regression tests for all six fixes (43 passing across the changed test files, incl. real component regressions for #1140 auto-scroll and #1180 fileTree identity; tooth-checked where applicable).
- `tsc` (main + lint configs), ESLint, and Prettier clean on all changed files.
- Per-fix commits keep the batch reviewable and individually revertable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Text input now keeps the latest text visible while typing in long messages.
  - Terminal output scrolling responds more reliably to whether you are at the bottom, avoiding unwanted jumps when reviewing earlier output.
  - Activating a starred item now closes any active group chat so navigation reaches the selected session.
  - Background task scanning continues even when the Cue window is hidden.
  - Processes launched from `~` working directories now start correctly.
  - File-tree and Markdown updates are smoother and avoid unnecessary refreshes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->