### PR TITLE
fix(terminal): keep a terminal tab when its shell is killed, not exited

### DIFF
--- a/src/__tests__/renderer/components/TerminalView.test.tsx
+++ b/src/__tests__/renderer/components/TerminalView.test.tsx
@@ -482,6 +482,74 @@ describe('TerminalView — auto-close on shell exit', () => {
 	});
 });
 
+// ---------------------------------------------------------------------------
+// Regression: a plain local scratch tab whose shell is KILLED (not exited) must
+// survive. node-pty reports a signalled death as exitCode 0 + a signal number,
+// so only the signal distinguishes it from the user typing `exit`. (#1184)
+// ---------------------------------------------------------------------------
+
+describe('TerminalView — killed shell keeps the tab (issue #1184)', () => {
+	/** Renders, delivers a process:exit through the real onExit subscription, then
+	 *  rerenders with the tab flipped to 'exited' as the store would. */
+	function exitPlainTabWith(code: number, signal?: number) {
+		let onExitCb: ((sessionId: string, code: number, signal?: number) => void) | undefined;
+		maestro().process.onExit = vi.fn((cb: typeof onExitCb) => {
+			onExitCb = cb;
+			return () => {};
+		});
+
+		const createdAt = Date.now() - 5000;
+		const tab = makeTab({ pid: 1234, state: 'busy', createdAt });
+		const { rerender } = render(
+			<TerminalView {...defaultProps} session={makeSession([tab])} isVisible={true} />
+		);
+
+		// The PTY dies: main process broadcasts process:exit for this tab.
+		act(() => {
+			onExitCb?.('session-1-terminal-tab-1', code, signal);
+		});
+
+		// The store reacts by flipping the tab to 'exited'.
+		const exitedTab = makeTab({ pid: 1234, state: 'exited', exitCode: code, createdAt });
+		act(() => {
+			rerender(
+				<TerminalView {...defaultProps} session={makeSession([exitedTab])} isVisible={true} />
+			);
+		});
+		act(() => {
+			vi.advanceTimersByTime(1);
+		});
+	}
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	it('keeps a plain local tab when the shell is killed by a signal', () => {
+		// SIGKILL (9), e.g. the Linux OOM killer reaping a `bun run dev` shell.
+		exitPlainTabWith(0, 9);
+
+		expect(mockCloseTerminalTab).not.toHaveBeenCalled();
+		expect(mockWrite).toHaveBeenCalledWith(expect.stringContaining('process killed (signal 9)'));
+		vi.useRealTimers();
+	});
+
+	it('still closes a plain local tab when the user exits the shell cleanly', () => {
+		exitPlainTabWith(0, undefined);
+
+		expect(mockCloseTerminalTab).toHaveBeenCalledWith('tab-1', 'pty-exit');
+		vi.useRealTimers();
+	});
+
+	it('still closes a plain local tab when `exit` inherits a non-zero status', () => {
+		// `false; exit` exits with code 1 but is a deliberate user exit, not a kill.
+		exitPlainTabWith(1, undefined);
+
+		expect(mockCloseTerminalTab).toHaveBeenCalledWith('tab-1', 'pty-exit');
+		vi.useRealTimers();
+	});
+});
+
 describe('TerminalView — SSH terminal working directory (regression)', () => {
 	// Regression test suite: SSH terminals must cd to the correct remote directory.
 	// The workingDirOverride in sessionSshRemoteConfig must follow the fallback chain:

--- a/src/main/preload/process.ts
+++ b/src/main/preload/process.ts
@@ -230,10 +230,14 @@ export function createProcessApi() {
 		},
 
 		/**
-		 * Subscribe to process exit events
+		 * Subscribe to process exit events.
+		 * `signal` is present only when the process was killed by a signal.
 		 */
-		onExit: (callback: (sessionId: string, code: number) => void): (() => void) => {
-			const handler = (_: unknown, sessionId: string, code: number) => callback(sessionId, code);
+		onExit: (
+			callback: (sessionId: string, code: number, signal?: number) => void
+		): (() => void) => {
+			const handler = (_: unknown, sessionId: string, code: number, signal?: number) =>
+				callback(sessionId, code, signal);
 			ipcRenderer.on('process:exit', handler);
 			return () => ipcRenderer.removeListener('process:exit', handler);
 		},

--- a/src/main/process-listeners/__tests__/exit-listener.test.ts
+++ b/src/main/process-listeners/__tests__/exit-listener.test.ts
@@ -126,7 +126,21 @@ describe('Exit Listener', () => {
 
 			handler?.('regular-session-123', 0);
 
-			expect(mockDeps.safeSend).toHaveBeenCalledWith('process:exit', 'regular-session-123', 0);
+			expect(mockDeps.safeSend).toHaveBeenCalledWith(
+				'process:exit',
+				'regular-session-123',
+				0,
+				undefined
+			);
+		});
+
+		it('should forward the kill signal to the renderer when the process was signalled', () => {
+			setupListener();
+			const handler = eventHandlers.get('exit');
+
+			handler?.('regular-session-123', 0, 9);
+
+			expect(mockDeps.safeSend).toHaveBeenCalledWith('process:exit', 'regular-session-123', 0, 9);
 		});
 
 		it('should remove power block for non-group-chat sessions', () => {
@@ -193,7 +207,12 @@ describe('Exit Listener', () => {
 
 			handler?.('plain-session-xyz', 0);
 
-			expect(mockDeps.safeSend).toHaveBeenCalledWith('process:exit', 'plain-session-xyz', 0);
+			expect(mockDeps.safeSend).toHaveBeenCalledWith(
+				'process:exit',
+				'plain-session-xyz',
+				0,
+				undefined
+			);
 			expect(notifyAgentCompleted).toHaveBeenCalledWith('plain-session-xyz', {
 				status: 'completed',
 				exitCode: 0,

--- a/src/main/process-listeners/exit-listener.ts
+++ b/src/main/process-listeners/exit-listener.ts
@@ -101,7 +101,7 @@ export function setupExitListener(
 		}
 	}
 
-	processManager.on('exit', (sessionId: string, code: number) => {
+	processManager.on('exit', (sessionId: string, code: number, signal?: number) => {
 		// Remove power block reason for this session
 		// This allows system sleep when no AI sessions are active
 		powerManager.removeBlockReason(`session:${sessionId}`);
@@ -536,16 +536,18 @@ export function setupExitListener(
 
 		// Diagnostic: log terminal PTY exits at the source (the ground truth for the
 		// "terminal tabs vanish" reports). A non-zero code on a remote terminal that
-		// the user didn't `exit` is the signature of a dropped SSH transport. Pairs
-		// with the renderer-side 'Terminal PTY exited' / 'Closing terminal tab' logs.
+		// the user didn't `exit` is the signature of a dropped SSH transport; a set
+		// `signal` means the shell was killed rather than exited. Pairs with the
+		// renderer-side 'Terminal PTY exited' / 'Closing terminal tab' logs.
 		if (sessionId.includes('-terminal-')) {
 			logger.info('Terminal PTY process exited', 'ProcessListener', {
 				sessionId,
 				exitCode: code,
+				signal,
 			});
 		}
 
-		safeSend('process:exit', sessionId, code);
+		safeSend('process:exit', sessionId, code, signal);
 
 		// Broadcast exit to web clients
 		const webServer = getWebServer();

--- a/src/main/process-manager/spawners/PtySpawner.ts
+++ b/src/main/process-manager/spawners/PtySpawner.ts
@@ -180,15 +180,18 @@ export class PtySpawner {
 				}
 			});
 
-			ptyProcess.onExit(({ exitCode }) => {
+			ptyProcess.onExit(({ exitCode, signal }) => {
 				// Flush any remaining buffered data before exit
 				this.bufferManager.flushDataBuffer(sessionId);
 
 				logger.debug('[ProcessManager] PTY onExit', 'ProcessManager', {
 					sessionId,
 					exitCode,
+					signal,
 				});
-				this.emitter.emit('exit', sessionId, exitCode);
+				// Forward `signal` so consumers can tell a shell the user exited from
+				// one that was killed out from under them (OOM killer, SIGHUP, crash).
+				this.emitter.emit('exit', sessionId, exitCode, signal);
 				this.processes.delete(sessionId);
 			});
 

--- a/src/main/process-manager/types.ts
+++ b/src/main/process-manager/types.ts
@@ -148,7 +148,10 @@ export interface CommandResult {
 export interface ProcessManagerEvents {
 	data: (sessionId: string, data: string) => void;
 	stderr: (sessionId: string, data: string) => void;
-	exit: (sessionId: string, code: number) => void;
+	/** `signal` is set only when the process was terminated by a signal
+	 *  (WIFSIGNALED). node-pty reports those with `code` 0, so the code alone
+	 *  cannot distinguish a clean exit from a kill. */
+	exit: (sessionId: string, code: number, signal?: number) => void;
 	'command-exit': (sessionId: string, code: number) => void;
 	usage: (sessionId: string, stats: UsageStats) => void;
 	'session-id': (sessionId: string, agentSessionId: string) => void;

--- a/src/renderer/components/TerminalView.tsx
+++ b/src/renderer/components/TerminalView.tsx
@@ -79,6 +79,10 @@ export const TerminalView = memo(
 		const terminalRefs = useRef<Map<string, XTerminalHandle>>(new Map());
 		// Track previous tab states to detect transitions (for exit message)
 		const prevTabStatesRef = useRef<Map<string, TerminalTab['state']>>(new Map());
+		// tabId → the signal that killed the PTY, captured off the exit event. Held in a
+		// ref rather than on the tab so it stays out of the persisted session snapshot;
+		// it is only needed for the keep-or-close decision on the very next render.
+		const exitSignalsRef = useRef<Map<string, number | undefined>>(new Map());
 		// In-flight spawn guard: set of tabIds currently waiting for a PTY PID
 		const spawnInFlightRef = useRef<Set<string>>(new Set());
 		// Track which tabs have already had the loading message written to avoid duplicates
@@ -393,21 +397,35 @@ export const TerminalView = memo(
 
 		// Subscribe to PTY exit events for terminal tabs in this session
 		useEffect(() => {
-			const cleanup = window.maestro.process.onExit((exitSessionId: string, code: number) => {
-				const parsed = parseTerminalSessionId(exitSessionId);
-				if (!parsed || parsed.sessionId !== session.id) return;
-				onTabStateChange(parsed.tabId, 'exited', code);
-			});
+			const cleanup = window.maestro.process.onExit(
+				(exitSessionId: string, code: number, signal?: number) => {
+					const parsed = parseTerminalSessionId(exitSessionId);
+					if (!parsed || parsed.sessionId !== session.id) return;
+					exitSignalsRef.current.set(parsed.tabId, signal);
+					onTabStateChange(parsed.tabId, 'exited', code);
+				}
+			);
 			return cleanup;
 		}, [session.id]);
 
-		// Handle a terminal's PTY exiting. A plain scratch shell is closed (the user
-		// typed `exit` / Ctrl-D, or the shell died - that's disposable). A "persistent"
-		// tab is NOT auto-closed: a tab with a startup command, or any tab under an
-		// SSH/remote session whose transport can drop for reasons unrelated to the user
-		// (sleep, network blip, server timeout). Silently destroying those discards the
-		// user's config and is the root cause of the long-standing "terminal tabs vanish"
-		// reports. Instead we keep them as a restartable exited husk with a visible notice.
+		// Handle a terminal's PTY exiting. A tab is auto-closed ONLY when its shell
+		// exited of its own accord (the user typed `exit` / Ctrl-D) - that's a scratch
+		// shell the user is done with, and closing it is the expected affordance.
+		//
+		// Every other way a PTY can die keeps the tab as a restartable exited husk:
+		//   - the shell was killed by a signal (OOM killer, SIGHUP, SIGTERM from a
+		//     crashing parent) - the user never asked for this and losing the tab
+		//     silently discards their scrollback,
+		//   - the tab carries a startup command (its config is durable), or
+		//   - the tab is under an SSH/remote session whose transport can drop for
+		//     reasons unrelated to the user (sleep, network blip, server timeout).
+		//
+		// Distinguishing the first case is why we need `signal` and not just the exit
+		// code: node-pty reports a signalled death (WIFSIGNALED) as exitCode 0 with a
+		// signal number, which is indistinguishable from a clean `exit` on the code
+		// alone. Conversely we must NOT treat a non-zero code as abnormal - `exit` with
+		// no argument returns the *last command's* status, so `false; exit` legitimately
+		// yields code 1 and should still close the tab.
 		//
 		// pid === 0 means the PTY never spawned, i.e. this 'exited' transition came from
 		// a spawn failure already handled at the spawn site - skip it here to avoid a
@@ -420,7 +438,11 @@ export const TerminalView = memo(
 				if (prev !== undefined && prev !== 'exited' && tab.state === 'exited' && tab.pid !== 0) {
 					const age = Date.now() - tab.createdAt;
 					const tabId = tab.id;
+					const signal = exitSignalsRef.current.get(tabId);
+					exitSignalsRef.current.delete(tabId);
+					const wasKilled = signal != null && signal !== 0;
 					const isPersistent = !!tab.startupCommand || isRemoteSession;
+					const keepTab = isPersistent || wasKilled;
 					// Diagnostic: every PTY exit logs why the tab was kept or closed. This
 					// is the signal for the "terminal tabs vanish" reports - e.g. an SSH
 					// transport dropping logs exitCode here with isRemote:true / kept.
@@ -428,24 +450,27 @@ export const TerminalView = memo(
 						sessionId: session.id,
 						tabId,
 						exitCode: tab.exitCode,
+						signal,
 						ageMs: age,
 						hasStartupCommand: !!tab.startupCommand,
 						isRemote: isRemoteSession,
-						decision: isPersistent ? 'keep-for-restart' : 'close',
+						wasKilled,
+						decision: keepTab ? 'keep-for-restart' : 'close',
 					});
-					if (age < 2000) {
+					if (age < 2000 && !wasKilled) {
 						// Exited almost immediately - surface as a startup failure toast.
 						notifySpawnFailure(
 							`Shell exited immediately${tab.exitCode != null ? ` (exit code: ${tab.exitCode})` : ''}.`
 						);
 					}
-					if (isPersistent) {
+					if (keepTab) {
 						// Keep the tab; show a visible notice instead of a silent dead husk.
+						const reason = wasKilled
+							? `process killed (signal ${signal})`
+							: `process exited${tab.exitCode != null ? ` (code ${tab.exitCode})` : ''}`;
 						terminalRefs.current
 							.get(tabId)
-							?.write(
-								`\r\n\x1b[2m[process exited${tab.exitCode != null ? ` (code ${tab.exitCode})` : ''}] - restart from the tab menu\x1b[0m\r\n`
-							);
+							?.write(`\r\n\x1b[2m[${reason}] - restart from the tab menu\x1b[0m\r\n`);
 					} else {
 						// Close on next tick to avoid mutating state mid-render.
 						setTimeout(() => closeTerminalTab(tabId, 'pty-exit'), 0);

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -276,7 +276,8 @@ interface MaestroAPI {
 		>;
 		isTerminalBusy: (sessionId: string) => Promise<boolean>;
 		onData: (callback: (sessionId: string, data: string) => void) => () => void;
-		onExit: (callback: (sessionId: string, code: number) => void) => () => void;
+		/** `signal` is set only when the process was killed by a signal, never on a clean exit. */
+		onExit: (callback: (sessionId: string, code: number, signal?: number) => void) => () => void;
 		onSessionId: (callback: (sessionId: string, agentSessionId: string) => void) => () => void;
 		onSlashCommands: (callback: (sessionId: string, slashCommands: string[]) => void) => () => void;
 		onThinkingChunk: (callback: (sessionId: string, content: string) => void) => () => void;


### PR DESCRIPTION
Closes #1184

## Problem

A terminal tab whose PTY died was auto-closed unless the tab carried a startup command or belonged to an SSH session:

```ts
const isPersistent = !!tab.startupCommand || isRemoteSession;
...
} else {
    setTimeout(() => closeTerminalTab(tabId, 'pty-exit'), 0);  // tab + scrollback destroyed
}
```

So a plain local shell running something long-lived (the reporter's `bun run dev`) loses its tab, and all of its scrollback, the moment the shell is killed out from under the user: the Linux OOM killer reaping the process group, a SIGHUP, a SIGTERM from a crashing parent. From the outside that is exactly "terminal tabs disappear by magic".

`a95fe655e` already fixed this class of bug for SSH and startup-command tabs, and its comment names "the long-standing terminal tabs vanish reports" as the motivation. But it keyed the decision off tab *configuration*, and the case that actually matters, a plain scratch tab, was left closing.

## Root cause

The decision should key off *how the shell died*, not how the tab was configured. It could not, because that information was being thrown away.

`node-pty` reports a signalled death (`WIFSIGNALED`) as **`exitCode` 0 plus a `signal` number**. `PtySpawner` destructured only `exitCode`:

```ts
ptyProcess.onExit(({ exitCode }) => { ... this.emitter.emit('exit', sessionId, exitCode); });
```

A SIGKILLed shell and a user typing `exit` both arrive at the renderer as code 0, indistinguishable. This is also why the existing `Terminal PTY process exited` diagnostic in `exit-listener.ts` could never see the case it was added to catch: it only logged `exitCode`.

## Fix

Plumb `signal` from `node-pty` through the process-manager emitter, the exit listener, the `process:exit` IPC channel and the preload bridge (a trailing optional arg, so the ~12 existing `onExit` consumers are unaffected). Then decide on the real signal:

- **Shell exited on its own** (user typed `exit` / Ctrl-D) -> close the tab. Unchanged, and deliberately preserved for **every** exit code: bare `exit` returns the last command's status, so `false; exit` legitimately yields code 1 and must still close. Keying on "non-zero code" would have broken that very common flow.
- **Shell was killed by a signal** -> keep the tab as a restartable exited husk showing `[process killed (signal 9)] - restart from the tab menu`.

Windows/ConPTY reports no signal, so behavior there is unchanged.

Also stopped reporting a killed shell as `Shell exited immediately`, a misleading startup-failure toast for a tab that had started fine.

## Tests

Three regression tests in `TerminalView.test.tsx` that drive a real `process:exit` through the `onExit` subscription:

- a plain local tab killed by signal 9 is **kept**, with the notice written (fails on `main`, passes here)
- a plain local tab whose shell exits cleanly is still **closed**
- a plain local tab whose `exit` inherits a non-zero status is still **closed** (guards against over-correcting)

Plus a new `exit-listener` test asserting the signal reaches `process:exit`.

`npm run lint`, ESLint, Prettier and the full suite are green locally; CI covers the ubuntu/windows matrix.

## Note, not fixed here

The reporter's specific trigger (what kills the shell) is not yet known, and this change does not chase it. It makes the failure survivable and observable: the tab and its scrollback stay, and the signal number now lands in the `Terminal PTY exited` / `Terminal PTY process exited` logs, which should identify the killer on the next report.

Separately, `exit-listener.ts` still maps a signalled agent exit to Cue `status: 'completed'` because it checks `code === 0`. Now that `signal` is available there it could be tightened, but that is outside this issue and untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Terminal tabs now stay open when a shell is terminated by a signal, instead of being closed like a normal exit.
  * Exit handling now better distinguishes clean exits from signal-based kills, with clearer restart messages shown in the terminal.
  * Immediate “exited” notifications are reduced for killed terminals, improving the accuracy of terminal status behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->