### PR TITLE
fix(sidebar): stop re-rendering every agent row on folder/group toggle

### DIFF
--- a/src/__tests__/renderer/components/SessionList/SessionListMemoization.test.tsx
+++ b/src/__tests__/renderer/components/SessionList/SessionListMemoization.test.tsx
@@ -1,0 +1,227 @@
+/**
+ * @fileoverview Regression tests for Left Bar re-render cost (#1186).
+ *
+ * Collapsing or expanding a sidebar folder / agent group re-renders SessionList.
+ * That is unavoidable, but it must NOT re-render the agent rows that the toggle
+ * does not affect. SessionItem is `React.memo`'d, so the contract is simply that
+ * every prop handed to an unaffected row keeps its identity across the toggle.
+ *
+ * Two props used to break that contract by building a fresh closure per row per
+ * render - `onStartRename` (all rows) and `onDrop` (grouped rows) - which
+ * defeated the memo bail-out and re-rendered every visible agent on every
+ * toggle. These tests pin the prop identities rather than a render count, since
+ * identity is what memo actually compares.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, act } from '@testing-library/react';
+import { SessionList } from '../../../../renderer/components/SessionList';
+import { useSessionStore } from '../../../../renderer/stores/sessionStore';
+import { useUIStore } from '../../../../renderer/stores/uiStore';
+import { useSettingsStore } from '../../../../renderer/stores/settingsStore';
+import { createMockSession } from '../../../helpers/mockSession';
+import { mockTheme } from '../../../helpers/mockTheme';
+import type { Group, Session } from '../../../../renderer/types';
+
+// Capture the props SessionItem is called with, per session id. `vi.hoisted` so
+// the map exists before the hoisted `vi.mock` factory runs.
+const { capturedProps } = vi.hoisted(() => ({
+	capturedProps: new Map<string, Record<string, unknown>[]>(),
+}));
+
+// Swap only the component; the module also exports helpers that other Left Bar
+// children (CollapsedSessionPill) import.
+vi.mock('../../../../renderer/components/SessionItem', async (importOriginal) => ({
+	...(await importOriginal<typeof import('../../../../renderer/components/SessionItem')>()),
+	SessionItem: (props: { session: Session }) => {
+		const bucket = capturedProps.get(props.session.id) ?? [];
+		bucket.push(props as unknown as Record<string, unknown>);
+		capturedProps.set(props.session.id, bucket);
+		return null;
+	},
+}));
+
+// Context providers SessionList reads from; mocked to avoid wrapping in Providers.
+vi.mock('../../../../renderer/contexts/InlineWizardContext', () => ({
+	useInlineWizardContext: () => ({ wizardActiveSessions: new Map() }),
+}));
+
+vi.mock('../../../../renderer/contexts/GitStatusContext', () => ({
+	useGitStatus: () => ({
+		gitStatusMap: new Map(),
+		refreshGitStatus: vi.fn().mockResolvedValue(undefined),
+		isLoading: false,
+		getFileCount: () => 0,
+		getStatus: () => undefined,
+	}),
+	useGitFileStatus: () => ({ getFileCount: () => 0, hasChanges: () => false }),
+	useGitBranch: () => ({ getBranchInfo: () => undefined }),
+	useGitDetail: () => ({
+		getFileDetails: () => undefined,
+		refreshGitStatus: vi.fn().mockResolvedValue(undefined),
+	}),
+}));
+
+const lastPropsFor = (sessionId: string): Record<string, unknown> => {
+	const bucket = capturedProps.get(sessionId);
+	if (!bucket?.length) throw new Error(`SessionItem never rendered for "${sessionId}"`);
+	return bucket[bucket.length - 1];
+};
+
+const renderCountFor = (sessionId: string): number => capturedProps.get(sessionId)?.length ?? 0;
+
+/**
+ * Assert every prop kept its identity. This is exactly what `React.memo`'s
+ * default shallow comparison checks, so an all-identical prop set means the
+ * real SessionItem would have bailed out of re-rendering.
+ */
+const expectPropsIdentical = (
+	before: Record<string, unknown>,
+	after: Record<string, unknown>,
+	label: string
+) => {
+	const changed = Object.keys({ ...before, ...after }).filter(
+		(key) => !Object.is(before[key], after[key])
+	);
+	expect(changed, `${label}: props lost identity and would defeat React.memo`).toEqual([]);
+};
+
+const makeGroup = (overrides: Partial<Group> = {}): Group => ({
+	id: 'g',
+	name: 'Group',
+	emoji: '📁',
+	collapsed: false,
+	...overrides,
+});
+
+// SessionList takes a large handler surface; all of it is stable across renders
+// in the app (useCallback) and stable here (one vi.fn per key, built once).
+const createProps = (sortedSessions: Session[]) =>
+	({
+		theme: mockTheme,
+		sortedSessions,
+		visibleSessions: sortedSessions,
+		isLiveMode: false,
+		webInterfaceUrl: null,
+		showSessionJumpNumbers: false,
+		starredItems: [],
+		activateStarredItem: vi.fn(),
+		toggleGlobalLive: vi.fn(),
+		restartWebServer: vi.fn().mockResolvedValue(null),
+		toggleGroup: vi.fn(),
+		handleDragStart: vi.fn(),
+		handleDragOver: vi.fn(),
+		handleDropOnGroup: vi.fn(),
+		handleDropOnUngrouped: vi.fn(),
+		finishRenamingGroup: vi.fn(),
+		finishRenamingSession: vi.fn(),
+		startRenamingGroup: vi.fn(),
+		startRenamingSession: vi.fn(),
+		showConfirmation: vi.fn(),
+		createNewGroup: vi.fn(),
+		onCreateGroupAndMove: vi.fn(),
+		addNewSession: vi.fn(),
+		onDeleteWorktreeGroup: vi.fn(),
+		onEditAgent: vi.fn(),
+		onNewAgentSession: vi.fn(),
+		onToggleWorktreeExpanded: vi.fn(),
+		onOpenCreatePR: vi.fn(),
+		onQuickCreateWorktree: vi.fn(),
+		onOpenWorktreeConfig: vi.fn(),
+		onDeleteWorktree: vi.fn(),
+		openWizard: vi.fn(),
+		startTour: vi.fn(),
+		onOpenGroupChat: vi.fn(),
+		onNewGroupChat: vi.fn(),
+		onEditGroupChat: vi.fn(),
+		onRenameGroupChat: vi.fn(),
+		onDeleteGroupChat: vi.fn(),
+	}) as unknown as React.ComponentProps<typeof SessionList>;
+
+describe('SessionList memoization (#1186)', () => {
+	beforeEach(() => {
+		capturedProps.clear();
+		useUIStore.setState({
+			leftSidebarOpen: true,
+			activeFocus: 'main',
+			selectedSidebarIndex: -1,
+			sidebarExtraSelection: null,
+			editingGroupId: null,
+			editingSessionId: null,
+			draggingSessionId: null,
+			bookmarksCollapsed: false,
+		} as never);
+		useSettingsStore.setState({ ungroupedCollapsed: false } as never);
+	});
+
+	it('keeps row props identity-stable when a different group is expanded', () => {
+		// gA stays expanded throughout; gB is the group the user expands.
+		const groupA = makeGroup({ id: 'gA', name: 'Alpha', collapsed: false });
+		const groupB = makeGroup({ id: 'gB', name: 'Bravo', collapsed: true });
+		const inA = createMockSession({ id: 'a1', name: 'In Alpha', groupId: 'gA' });
+		const inB = createMockSession({ id: 'b1', name: 'In Bravo', groupId: 'gB' });
+		const loose = createMockSession({ id: 'u1', name: 'Ungrouped' });
+		const sorted = [inA, inB, loose];
+
+		useSessionStore.setState({ sessions: sorted, groups: [groupA, groupB], activeSessionId: '' });
+		render(<SessionList {...createProps(sorted)} />);
+
+		const beforeA = lastPropsFor('a1');
+		const beforeLoose = lastPropsFor('u1');
+		const rendersBefore = { a1: renderCountFor('a1'), u1: renderCountFor('u1') };
+
+		// The user expands Bravo. Only `groups` changes; the agents themselves,
+		// and the set of group ids, are untouched.
+		act(() => {
+			useSessionStore.setState({ groups: [groupA, { ...groupB, collapsed: false }] });
+		});
+
+		// Sanity: the toggle really did re-render SessionList and reveal Bravo's row.
+		expect(renderCountFor('a1')).toBeGreaterThan(rendersBefore.a1);
+		expect(renderCountFor('b1')).toBeGreaterThan(0);
+
+		// ...but Alpha's and the ungrouped rows got byte-for-byte identical props,
+		// so the real (memo'd) SessionItem would not have re-rendered them.
+		expectPropsIdentical(beforeA, lastPropsFor('a1'), 'grouped row a1');
+		expectPropsIdentical(beforeLoose, lastPropsFor('u1'), 'ungrouped row u1');
+		expect(renderCountFor('u1')).toBeGreaterThan(rendersBefore.u1);
+	});
+
+	it('keeps row props identity-stable when the Bookmarks folder is collapsed', () => {
+		const group = makeGroup({ id: 'gA', name: 'Alpha' });
+		const inGroup = createMockSession({ id: 'a1', name: 'In Alpha', groupId: 'gA' });
+		const starred = createMockSession({ id: 'bm1', name: 'Bookmarked', bookmarked: true });
+		const sorted = [inGroup, starred];
+
+		useSessionStore.setState({ sessions: sorted, groups: [group], activeSessionId: '' });
+		render(<SessionList {...createProps(sorted)} />);
+
+		const beforeGroupRow = lastPropsFor('a1');
+
+		// Collapsing the Bookmarks folder re-renders SessionList top-to-bottom.
+		act(() => {
+			useUIStore.setState({ bookmarksCollapsed: true });
+		});
+
+		expectPropsIdentical(beforeGroupRow, lastPropsFor('a1'), 'grouped row a1');
+	});
+
+	it('hands grouped rows the same onDrop reference across a group toggle', () => {
+		const groupA = makeGroup({ id: 'gA', name: 'Alpha', collapsed: false });
+		const groupB = makeGroup({ id: 'gB', name: 'Bravo', collapsed: true });
+		const inA = createMockSession({ id: 'a1', name: 'In Alpha', groupId: 'gA' });
+		const sorted = [inA];
+
+		useSessionStore.setState({ sessions: sorted, groups: [groupA, groupB], activeSessionId: '' });
+		render(<SessionList {...createProps(sorted)} />);
+
+		const beforeDrop = lastPropsFor('a1').onDrop;
+		expect(typeof beforeDrop).toBe('function');
+
+		act(() => {
+			useSessionStore.setState({ groups: [groupA, { ...groupB, collapsed: false }] });
+		});
+
+		expect(lastPropsFor('a1').onDrop).toBe(beforeDrop);
+	});
+});

--- a/src/__tests__/renderer/hooks/useSessionCategories.test.ts
+++ b/src/__tests__/renderer/hooks/useSessionCategories.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { renderHook } from '@testing-library/react';
+import { renderHook, act } from '@testing-library/react';
 import { useSessionCategories } from '../../../renderer/hooks/session/useSessionCategories';
 import { useSessionStore } from '../../../renderer/stores/sessionStore';
 import type { Session, Group } from '../../../renderer/types';
@@ -775,6 +775,73 @@ describe('useSessionCategories', () => {
 			);
 			expect(result.current.sortedSessionIndexById).toBe(firstRun.sortedSessionIndexById);
 			expect(result.current.getWorktreeChildren).toBe(firstRun.getWorktreeChildren);
+		});
+	});
+
+	// -----------------------------------------------------------------------
+	// Group collapse/expand must not re-categorize (#1186)
+	// -----------------------------------------------------------------------
+	describe('group collapse/expand', () => {
+		// Hoisted so `sortedSessions` / `activeBatchSessionIds` keep a stable
+		// identity across renders - both feed the categorization memo, so fresh
+		// literals would invalidate it no matter what `groupIds` does.
+		const batchIds: string[] = [];
+
+		it('keeps categorized collections reference-stable when a group is only collapsed', () => {
+			const group = makeGroup({ id: 'g1', collapsed: false });
+			const grouped = makeSession({ id: 's1', groupId: 'g1' });
+			const loose = makeSession({ id: 's2' });
+			const sorted = [grouped, loose];
+			resetStore(sorted, [group]);
+
+			const { result, rerender } = renderHook(() =>
+				useSessionCategories('', sorted, false, null, batchIds, '')
+			);
+
+			const before = {
+				grouped: result.current.sortedGroupSessionsById,
+				ungrouped: result.current.ungroupedSessions,
+				sortedFiltered: result.current.sortedFilteredSessions,
+				bookmarked: result.current.bookmarkedSessions,
+			};
+
+			// Collapsing rebuilds `groups` with a new array + new group object, but
+			// the set of group ids is untouched. Categorization must not re-run.
+			act(() => {
+				useSessionStore.setState({ groups: [{ ...group, collapsed: true }] } as any);
+			});
+			rerender();
+
+			expect(result.current.sortedGroupSessionsById).toBe(before.grouped);
+			expect(result.current.ungroupedSessions).toBe(before.ungrouped);
+			expect(result.current.sortedFilteredSessions).toBe(before.sortedFiltered);
+			expect(result.current.bookmarkedSessions).toBe(before.bookmarked);
+		});
+
+		it('re-categorizes when the set of group ids actually changes', () => {
+			const group = makeGroup({ id: 'g1', collapsed: false });
+			const grouped = makeSession({ id: 's1', groupId: 'g1' });
+			const orphan = makeSession({ id: 's2', groupId: 'g2' });
+			const sorted = [grouped, orphan];
+			resetStore(sorted, [group]);
+
+			const { result, rerender } = renderHook(() =>
+				useSessionCategories('', sorted, false, null, batchIds, '')
+			);
+
+			// 's2' points at a group that does not exist yet, so it lands in Ungrouped.
+			expect(result.current.ungroupedSessions.map((s) => s.id)).toEqual(['s2']);
+			const beforeGrouped = result.current.sortedGroupSessionsById;
+
+			act(() => {
+				useSessionStore.setState({ groups: [group, makeGroup({ id: 'g2' })] } as any);
+			});
+			rerender();
+
+			// New id in the signature → memo invalidates and 's2' moves into g2.
+			expect(result.current.sortedGroupSessionsById).not.toBe(beforeGrouped);
+			expect(result.current.ungroupedSessions).toEqual([]);
+			expect(result.current.sortedGroupSessionsById.get('g2')?.map((s) => s.id)).toEqual(['s2']);
 		});
 	});
 });

--- a/src/renderer/components/SessionList/SessionList.tsx
+++ b/src/renderer/components/SessionList/SessionList.tsx
@@ -698,6 +698,44 @@ function SessionListInner(props: SessionListProps) {
 		return map;
 	}, [sessionIdsKey, toggleBookmark]);
 
+	// `onStartRename` was the one row prop still built inline, so every row got a
+	// fresh callback identity on each SessionList render and SessionItem's memo
+	// bail-out never fired - undoing the maps above. Collapsing/expanding a
+	// sidebar folder or an agent group re-renders this component, so a toggle
+	// that changes nothing about the rows still re-rendered every visible agent
+	// (a dozen icons and ~11 store subscriptions each) (#1186). Rename keys are
+	// per-row strings (they encode the variant), so cache one callback per key;
+	// the cache resets when the session id-set changes.
+	const startRenamingSessionRef = useRef(startRenamingSession);
+	startRenamingSessionRef.current = startRenamingSession;
+
+	const getStartRenameHandler = useMemo(() => {
+		const cache = new Map<string, () => void>();
+		return (renameKey: string) => {
+			let handler = cache.get(renameKey);
+			if (!handler) {
+				handler = () => startRenamingSessionRef.current(renameKey);
+				cache.set(renameKey, handler);
+			}
+			return handler;
+		};
+	}, [sessionIdsKey]);
+
+	// Same story for the grouped rows' drop target: an inline
+	// `() => handleDropOnGroup(group.id)` per row per render. Keyed on the group
+	// id-set so a collapse/expand toggle (which only flips `collapsed`) reuses it.
+	const groupIdsKey = useMemo(() => groups.map((g) => g.id).join('|'), [groups]);
+
+	const dropOnGroupHandlers = useMemo(() => {
+		const map = new Map<string, () => void>();
+		if (groupIdsKey) {
+			groupIdsKey.split('|').forEach((id) => {
+				map.set(id, () => handleDropOnGroup(id));
+			});
+		}
+		return map;
+	}, [groupIdsKey, handleDropOnGroup]);
+
 	// Helper: compute navIndexMap key for a session based on render context
 	const getNavKey = (variant: string, session: Session, groupId?: string): string => {
 		if (variant === 'bookmark') return `bookmark:${session.id}`;
@@ -795,7 +833,7 @@ function SessionListInner(props: SessionListProps) {
 					onDrop={options.onDrop || handleDropOnUngrouped}
 					onContextMenu={contextMenuHandlers.get(session.id)!}
 					onFinishRename={finishRenameHandlers.get(session.id)!}
-					onStartRename={() => startRenamingSession(`${options.keyPrefix}-${session.id}`)}
+					onStartRename={getStartRenameHandler(`${options.keyPrefix}-${session.id}`)}
 					onToggleBookmark={toggleBookmarkHandlers.get(session.id)!}
 					onToggleWorktrees={onToggleWorktreeExpanded}
 				/>
@@ -853,7 +891,7 @@ function SessionListInner(props: SessionListProps) {
 										onDragStart={dragStartHandlers.get(child.id)!}
 										onContextMenu={contextMenuHandlers.get(child.id)!}
 										onFinishRename={finishRenameHandlers.get(child.id)!}
-										onStartRename={() => startRenamingSession(`worktree-${session.id}-${child.id}`)}
+										onStartRename={getStartRenameHandler(`worktree-${session.id}-${child.id}`)}
 										onToggleBookmark={toggleBookmarkHandlers.get(child.id)!}
 									/>
 								</div>
@@ -1451,7 +1489,7 @@ function SessionListInner(props: SessionListProps) {
 											renderSessionWithWorktrees(session, 'group', {
 												keyPrefix: `group-${group.id}`,
 												groupId: group.id,
-												onDrop: () => handleDropOnGroup(group.id),
+												onDrop: dropOnGroupHandlers.get(group.id),
 											})
 										)}
 									</div>

--- a/src/renderer/hooks/session/useSessionCategories.ts
+++ b/src/renderer/hooks/session/useSessionCategories.ts
@@ -91,8 +91,17 @@ export function useSessionCategories(
 		[worktreeChildrenByParentId]
 	);
 
-	// Consolidated session categorization and sorting - computed in a single pass
-	const groupIds = useMemo(() => new Set(groups.map((g) => g.id)), [groups]);
+	// Consolidated session categorization and sorting - computed in a single pass.
+	// `groupIds` is only ever membership-tested below, so key it on a signature of
+	// the ids rather than the `groups` array reference. Collapsing or expanding a
+	// group rebuilds `groups` without changing which ids exist; keying on the array
+	// handed the categorization memo a fresh Set and re-ran the whole
+	// filter/categorize/sort pass over every agent on each toggle (#1186).
+	const groupIdsSignature = useMemo(() => groups.map((g) => g.id).join('|'), [groups]);
+	const groupIds = useMemo(
+		() => new Set(groupIdsSignature ? groupIdsSignature.split('|') : []),
+		[groupIdsSignature]
+	);
 
 	// Stable Set of stuck (outage) agent ids, recomputed only when the signature
 	// changes so the categorization memo isn't invalidated on unrelated renders.


### PR DESCRIPTION
Closes #1186

## Problem

Expanding a sidebar folder or an agent group in the Left Bar re-rendered **every visible agent row**, and separately re-ran the full categorize/sort pipeline over **every agent**. On a large sidebar that is enough synchronous main-thread work to read as a freeze.

The reporter suspected this shared a root cause with the code-block flicker freeze (#1180). It does not. I traced the group-toggle render path: `MainPanel` is `React.memo`'d and `groups` is not a dependency of `useMainPanelProps`, so the chat transcript and `Markdown` do not re-render on a toggle. The chat `onFileClick` reads sessions through refs and stays identity-stable. This bug lives entirely in the Left Bar. (#1180's flicker almost certainly made it *feel* coupled, since that pulse was already blocking the main thread.)

## Root cause: two identity-churn bugs

**1. `SessionList` defeated `SessionItem`'s `React.memo`.**

`SessionList` goes to real trouble to build cached, id-keyed handler maps (`selectHandlers`, `dragStartHandlers`, `contextMenuHandlers`, `finishRenameHandlers`, `toggleBookmarkHandlers`), with a `PERF:` comment stating they exist to "prevent SessionItem re-renders" and that a fresh reference "busts memo."

Two props bypassed that scheme and were rebuilt inline on every render:

- `onStartRename={() => startRenamingSession(...)}` - on **every** row (parent and worktree child)
- `onDrop: () => handleDropOnGroup(group.id)` - on every **grouped** row

Because a group collapse/expand re-renders `SessionListInner`, those two closures handed each `SessionItem` a new prop identity, so the memo bail-out never fired and all rows re-rendered (each one mounting ~a dozen lucide SVG icons and ~11 store subscriptions). The five cached maps were effectively dead weight.

**2. `useSessionCategories` re-categorized on a mere collapse.**

```ts
const groupIds = useMemo(() => new Set(groups.map((g) => g.id)), [groups]);
```

`groupIds` is only ever membership-tested (`groupIds.has(s.groupId)`), but it was keyed on the `groups` **array reference**. Collapsing a group rebuilds `groups` without changing which ids exist, so `groupIds` became a fresh `Set`, which invalidated the `sessionCategories` memo that lists it as a dep, which re-ran the entire filter -> categorize -> sort pass over all agents. The `stuckOutageSessionIds` memo immediately below already uses the correct signature-keyed idiom for exactly this reason.

## Fix

- Cache one `onStartRename` callback per rename key (reset when the session id-set changes), reading `startRenamingSession` through a ref so the identity stays stable, mirroring the existing `getSessionWindowRef` pattern in the same file.
- Cache `onDrop` per group id, keyed on a group id-set signature.
- Key `groupIds` on a joined id signature instead of the array reference, matching the `stuckOutageSignature` idiom directly below it.

Net effect: a folder/group toggle now re-renders only the rows the toggle actually affects, and skips the categorize/sort pass entirely.

## Tests

Both new suites are tooth-checked (verified failing without the fix, passing with it):

- `SessionListMemoization.test.tsx` (new) pins the invariant `React.memo` actually compares: an unaffected row's props must keep identity across a toggle. Reverted against `main`, it fails naming exactly `['onDrop', 'onStartRename']`. Covers group expand, Bookmarks-folder collapse, and the `onDrop` reference directly.
- `useSessionCategories.test.ts` adds: categorized collections stay reference-stable when a group is only collapsed, **and** still recompute when the group id-set genuinely changes (guards against over-memoizing).

Full suite green: 31,654 passed / 0 failed (1104 files). `tsc`, ESLint, and Prettier clean on all changed files.

## Note on base branch

Opened against `main`, where the defect is present verbatim (same inline `onStartRename`, same `groupIds` memo key). The report is against `0.18.4-RC`, and these files have diverged substantially on `rc`. `main` merges into `rc` regularly, so this should reach RC users that way, but if you would rather land it directly on the active RC line, retarget the base and I will rebase the two hunks onto the `rc` versions.

## Known remaining (not fixed here, out of scope)

Bookmarked rows belonging to the *toggled* group still re-render, because the bookmark variant passes `group={groups.find(...)}` and the toggled group object is new. It is bounded to that group's bookmarked members and the badge only reads `name`/`color`, so I left it alone rather than widen the diff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session list performance by keeping row actions stable across re-renders, reducing unnecessary UI updates.
  * Preserved session grouping and collapse state behavior so items don’t reshuffle or re-render unexpectedly when sidebar state changes.
  * Fixed memoization so renaming and drag-and-drop actions remain consistent for grouped sessions and worktree rows.

* **Tests**
  * Added regression coverage for memoization and grouping behavior to prevent future UI instability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->