### PR TITLE
feat(settings): dropdown of known auth accounts for CLAUDE_CONFIG_DIR / CODEX_HOME

### DIFF
--- a/src/__tests__/main/ipc/handlers/agents.test.ts
+++ b/src/__tests__/main/ipc/handlers/agents.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import path from 'path';
 import { ipcMain } from 'electron';
 import {
 	registerAgentsHandlers,
@@ -186,6 +187,7 @@ describe('agents IPC handlers', () => {
 				'agents:getRemoteMaestroPAvailable',
 				'agents:getClaudeUsageSnapshots',
 				'agents:getClaudeUsageAccountKeys',
+				'agents:getKnownAuthDirs',
 				'agents:getLimitResetAt',
 				'claude:usage:refresh-all',
 				'agents:getCodexUsageSnapshots',
@@ -197,6 +199,72 @@ describe('agents IPC handlers', () => {
 				expect(handlers.has(channel)).toBe(true);
 			}
 			expect(handlers.size).toBe(expectedChannels.length);
+		});
+	});
+
+	describe('agents:getKnownAuthDirs', () => {
+		it('returns canonical local auth paths from agent and session env vars', async () => {
+			mockAgentConfigsStore.get.mockImplementation((key: string, fallback?: unknown) => {
+				if (key !== 'configs') return fallback;
+				return {
+					'claude-code': {
+						customEnvVars: { CLAUDE_CONFIG_DIR: '/Users/me/.claude-agent' },
+					},
+					codex: {
+						customEnvVars: { CODEX_HOME: '/Users/me/.codex-agent' },
+					},
+				};
+			});
+			const sessionsStore = {
+				get: vi.fn().mockReturnValue([
+					{
+						toolType: 'claude-code',
+						cwd: '/Users/me/project',
+						customEnvVars: {
+							CLAUDE_CONFIG_DIR: '/Users/me/work/../.claude-session',
+						},
+					},
+					{
+						toolType: 'codex',
+						cwd: '/Users/me/project',
+						customEnvVars: { CODEX_HOME: '/Users/me/.codex-session' },
+					},
+					{
+						toolType: 'claude-code',
+						cwd: 'ssh://host/project',
+						sshRemoteId: 'remote-1',
+						customEnvVars: { CLAUDE_CONFIG_DIR: '/remote/.claude' },
+					},
+					{
+						toolType: 'codex',
+						cwd: '/Users/me/project',
+						sessionSshRemoteConfig: { enabled: true },
+						customEnvVars: { CODEX_HOME: '/remote/.codex' },
+					},
+				]),
+			};
+			// The handler accepts electron-store's full Store shape, but reads only get().
+			registerAgentsHandlers({
+				...deps,
+				sessionsStore: sessionsStore as unknown as NonNullable<
+					AgentsHandlerDependencies['sessionsStore']
+				>,
+			});
+
+			const handler = handlers.get('agents:getKnownAuthDirs');
+			expect(handler).toBeDefined();
+			const result = await handler?.({});
+
+			expect(result).toEqual({
+				claudeConfigDirs: [
+					path.resolve('/Users/me/.claude-agent'),
+					path.resolve('/Users/me/.claude-session'),
+				],
+				codexHomes: [
+					path.resolve('/Users/me/.codex-agent'),
+					path.resolve('/Users/me/.codex-session'),
+				],
+			});
 		});
 	});
 

--- a/src/__tests__/main/preload/agents.test.ts
+++ b/src/__tests__/main/preload/agents.test.ts
@@ -421,5 +421,18 @@ describe('Agents Preload API', () => {
 			expect(mockInvoke).toHaveBeenCalledWith('agents:getCodexUsageAccountKeys');
 			expect(result).toEqual(keys);
 		});
+
+		it('should invoke agents:getKnownAuthDirs', async () => {
+			const dirs = {
+				claudeConfigDirs: ['/Users/me/.claude-work'],
+				codexHomes: ['/Users/me/.codex-work'],
+			};
+			mockInvoke.mockResolvedValue(dirs);
+
+			const result = await api.getKnownAuthDirs();
+
+			expect(mockInvoke).toHaveBeenCalledWith('agents:getKnownAuthDirs');
+			expect(result).toEqual(dirs);
+		});
 	});
 });

--- a/src/__tests__/renderer/components/Settings/EnvVarsEditor.test.tsx
+++ b/src/__tests__/renderer/components/Settings/EnvVarsEditor.test.tsx
@@ -397,6 +397,100 @@ describe('EnvVarsEditor', () => {
 		expect(lastCall['CLAUDE_CONFIG_DIR']).toBe('/Users/me/.claude-smash');
 	});
 
+	it('renders known account selects for auth path keys only', () => {
+		render(
+			<EnvVarsEditor
+				envVars={{
+					CLAUDE_CONFIG_DIR: '/Users/me/.claude-work',
+					CODEX_HOME: '/Users/me/.codex-work',
+					OTHER_PATH: '/usr/local/bin',
+				}}
+				setEnvVars={mockSetEnvVars}
+				theme={mockTheme}
+				knownAuthDirs={{
+					claudeConfigDirs: ['/Users/me/.claude-work'],
+					codexHomes: ['/Users/me/.codex-work'],
+				}}
+			/>
+		);
+
+		expect(screen.getByLabelText('Known CLAUDE_CONFIG_DIR paths')).toHaveValue(
+			'/Users/me/.claude-work'
+		);
+		expect(screen.getByLabelText('Known CODEX_HOME paths')).toHaveValue('/Users/me/.codex-work');
+		expect(screen.getAllByPlaceholderText('value')).toHaveLength(1);
+	});
+
+	it('reveals the validated text input for a custom auth path', () => {
+		render(
+			<EnvVarsEditor
+				envVars={{ CLAUDE_CONFIG_DIR: '/Users/me/.claude-work' }}
+				setEnvVars={mockSetEnvVars}
+				theme={mockTheme}
+				knownAuthDirs={{ claudeConfigDirs: ['/Users/me/.claude-work'], codexHomes: [] }}
+			/>
+		);
+
+		fireEvent.change(screen.getByLabelText('Known CLAUDE_CONFIG_DIR paths'), {
+			target: { value: '__custom__' },
+		});
+		const valueInput = screen.getByPlaceholderText('value');
+		expect(valueInput).toHaveValue('/Users/me/.claude-work');
+
+		fireEvent.change(valueInput, { target: { value: 'relative/.claude' } });
+		expect(screen.getByText(/CLAUDE_CONFIG_DIR must be an absolute path/)).toBeInTheDocument();
+	});
+
+	it('falls back to a text input when no known auth paths exist', () => {
+		render(
+			<EnvVarsEditor
+				envVars={{ CODEX_HOME: '/Users/me/.codex-work' }}
+				setEnvVars={mockSetEnvVars}
+				theme={mockTheme}
+				knownAuthDirs={{ claudeConfigDirs: [], codexHomes: [] }}
+			/>
+		);
+
+		expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+		expect(screen.getByPlaceholderText('value')).toHaveValue('/Users/me/.codex-work');
+	});
+
+	it('commits a selected known auth path through the existing change callback', () => {
+		render(
+			<EnvVarsEditor
+				envVars={{ CLAUDE_CONFIG_DIR: '/Users/me/.claude-work' }}
+				setEnvVars={mockSetEnvVars}
+				theme={mockTheme}
+				knownAuthDirs={{
+					claudeConfigDirs: ['/Users/me/.claude-work', '/Users/me/.claude-personal'],
+					codexHomes: [],
+				}}
+			/>
+		);
+
+		fireEvent.change(screen.getByLabelText('Known CLAUDE_CONFIG_DIR paths'), {
+			target: { value: '/Users/me/.claude-personal' },
+		});
+
+		expect(mockSetEnvVars).toHaveBeenLastCalledWith({
+			CLAUDE_CONFIG_DIR: '/Users/me/.claude-personal',
+		});
+	});
+
+	it('validates custom CODEX_HOME values as absolute paths', () => {
+		render(<EnvVarsEditor envVars={{}} setEnvVars={mockSetEnvVars} theme={mockTheme} />);
+
+		fireEvent.click(screen.getByRole('button', { name: 'Add Variable' }));
+		fireEvent.change(screen.getByPlaceholderText('VARIABLE_NAME'), {
+			target: { value: 'CODEX_HOME' },
+		});
+		fireEvent.change(screen.getByPlaceholderText('value'), {
+			target: { value: 'relative/.codex' },
+		});
+
+		expect(screen.getByText(/CODEX_HOME must be an absolute path/)).toBeInTheDocument();
+	});
+
 	it('should show = separator between key and value', () => {
 		render(
 			<EnvVarsEditor envVars={{ MY_VAR: 'hello' }} setEnvVars={mockSetEnvVars} theme={mockTheme} />

--- a/src/__tests__/renderer/components/shared/AgentConfigPanel.test.tsx
+++ b/src/__tests__/renderer/components/shared/AgentConfigPanel.test.tsx
@@ -175,6 +175,32 @@ describe('AgentConfigPanel', () => {
 		});
 	});
 
+	it('selects a known local auth path for agent environment variables', async () => {
+		vi.mocked(window.maestro.agents.getKnownAuthDirs).mockResolvedValueOnce({
+			claudeConfigDirs: ['/Users/me/.claude-work', '/Users/me/.claude-personal'],
+			codexHomes: [],
+		});
+		const onEnvVarValueChange = vi.fn();
+
+		render(
+			<AgentConfigPanel
+				{...createDefaultProps({
+					customEnvVars: { CLAUDE_CONFIG_DIR: '/Users/me/.claude-work' },
+					onEnvVarValueChange,
+				})}
+			/>
+		);
+
+		fireEvent.change(await screen.findByLabelText('Known CLAUDE_CONFIG_DIR paths'), {
+			target: { value: '/Users/me/.claude-personal' },
+		});
+
+		expect(onEnvVarValueChange).toHaveBeenCalledWith(
+			'CLAUDE_CONFIG_DIR',
+			'/Users/me/.claude-personal'
+		);
+	});
+
 	describe('Model field clear button', () => {
 		const modelAgent = createMockAgent({
 			configOptions: [

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -350,6 +350,7 @@ const mockMaestro = {
 		getClaudeUsageAccountKeys: vi.fn().mockResolvedValue([]),
 		getCodexUsageSnapshots: vi.fn().mockResolvedValue({}),
 		getCodexUsageAccountKeys: vi.fn().mockResolvedValue([]),
+		getKnownAuthDirs: vi.fn().mockResolvedValue({ claudeConfigDirs: [], codexHomes: [] }),
 		refreshClaudeUsageSnapshots: vi.fn().mockResolvedValue({ refreshed: 0 }),
 		refreshCodexUsageSnapshots: vi.fn().mockResolvedValue({ refreshed: 0 }),
 	},

--- a/src/main/ipc/handlers/agents.ts
+++ b/src/main/ipc/handlers/agents.ts
@@ -44,6 +44,7 @@ import {
 	discoverClaudeConfigDirs,
 } from '../../agents/claude-usage-startup';
 import { runCodexUsageSampling, discoverCodexHomes } from '../../agents/codex-usage-startup';
+import type { KnownAuthDirs } from '../../../shared/authPaths';
 
 const LOG_CONTEXT = '[AgentDetector]';
 const CONFIG_LOG_CONTEXT = '[AgentConfig]';
@@ -57,6 +58,59 @@ const handlerOpts = (
 	operation,
 });
 
+type AuthPathResolver = (env: NodeJS.ProcessEnv) => string;
+
+function getCustomEnvVars(value: unknown): Record<string, unknown> {
+	if (!value || typeof value !== 'object' || !('customEnvVars' in value)) {
+		return {};
+	}
+	const customEnvVars = value.customEnvVars;
+	return customEnvVars && typeof customEnvVars === 'object'
+		? (customEnvVars as Record<string, unknown>)
+		: {};
+}
+
+function isLocalSession(session: Record<string, unknown>): boolean {
+	if (typeof session.sshRemoteId === 'string' && session.sshRemoteId.length > 0) {
+		return false;
+	}
+	const sshRemoteConfig = session.sessionSshRemoteConfig;
+	if (
+		sshRemoteConfig &&
+		typeof sshRemoteConfig === 'object' &&
+		'enabled' in sshRemoteConfig &&
+		sshRemoteConfig.enabled === true
+	) {
+		return false;
+	}
+	return typeof session.cwd !== 'string' || !session.cwd.includes('://');
+}
+
+function collectKnownAuthPaths(
+	agentEnvVars: Record<string, unknown>,
+	sessions: Array<Record<string, unknown>>,
+	toolType: string,
+	envVarName: 'CLAUDE_CONFIG_DIR' | 'CODEX_HOME',
+	resolveKey: AuthPathResolver
+): string[] {
+	const pathsByKey = new Map<string, string>();
+	const addPath = (envVars: Record<string, unknown>) => {
+		const value = envVars[envVarName];
+		if (typeof value !== 'string' || value.length === 0) return;
+		const canonicalPath = resolveKey({ [envVarName]: value });
+		if (!pathsByKey.has(canonicalPath)) {
+			pathsByKey.set(canonicalPath, canonicalPath);
+		}
+	};
+
+	addPath(agentEnvVars);
+	for (const session of sessions) {
+		if (session.toolType !== toolType || !isLocalSession(session)) continue;
+		addPath({ ...agentEnvVars, ...getCustomEnvVars(session) });
+	}
+
+	return Array.from(pathsByKey.values()).sort((a, b) => a.localeCompare(b));
+}
 // Copilot CLI built-in slash commands (always available in interactive mode)
 const COPILOT_BUILTIN_COMMANDS = [
 	'help',
@@ -1382,6 +1436,36 @@ export function registerAgentsHandlers(deps: AgentsHandlerDependencies): void {
 			}
 			return customEnvVars;
 		})
+	);
+
+	// Return only account paths explicitly configured on local sessions or
+	// agent settings. This deliberately does not inspect the filesystem: stale
+	// config directories can trigger provider OAuth flows when sampled.
+	ipcMain.handle(
+		'agents:getKnownAuthDirs',
+		withIpcErrorLogging(
+			handlerOpts('getKnownAuthDirs', CONFIG_LOG_CONTEXT),
+			async (): Promise<KnownAuthDirs> => {
+				const allConfigs = agentConfigsStore.get('configs', {});
+				const sessions = sessionsStore?.get('sessions', []) ?? [];
+				return {
+					claudeConfigDirs: collectKnownAuthPaths(
+						getCustomEnvVars(allConfigs['claude-code']),
+						sessions,
+						'claude-code',
+						'CLAUDE_CONFIG_DIR',
+						resolveConfigDirKey
+					),
+					codexHomes: collectKnownAuthPaths(
+						getCustomEnvVars(allConfigs.codex),
+						sessions,
+						'codex',
+						'CODEX_HOME',
+						resolveCodexHomeKey
+					),
+				};
+			}
+		)
 	);
 
 	// Discover available models for an agent that supports model selection

--- a/src/main/preload/agents.ts
+++ b/src/main/preload/agents.ts
@@ -18,6 +18,7 @@ import {
 } from '../../shared/agentCapabilities';
 import type { UsageSnapshot } from '../agents/claude-mode-selector';
 import type { CodexUsageSnapshot } from '../stores/codexUsageStore';
+import type { KnownAuthDirs } from '../../shared/authPaths';
 
 // Re-export for consumers that import from preload. `AgentStatus` is
 // re-exported only (no local usage in this file); TypeScript's
@@ -152,6 +153,12 @@ export function createAgentsApi() {
 		 */
 		getAllCustomEnvVars: (): Promise<Record<string, Record<string, string>>> =>
 			ipcRenderer.invoke('agents:getAllCustomEnvVars'),
+
+		/**
+		 * Return locally configured Claude and Codex account paths without
+		 * enumerating provider directories on disk.
+		 */
+		getKnownAuthDirs: (): Promise<KnownAuthDirs> => ipcRenderer.invoke('agents:getKnownAuthDirs'),
 
 		/**
 		 * Discover available models for agents that support model selection

--- a/src/renderer/components/Settings/EnvVarsEditor.tsx
+++ b/src/renderer/components/Settings/EnvVarsEditor.tsx
@@ -16,6 +16,8 @@ import { Plus, Trash2 } from 'lucide-react';
 import { GhostIconButton } from '../ui/GhostIconButton';
 import { isAbsolutePath } from '../../../shared/formatters';
 import type { Theme } from '../../types';
+import { AuthPathValueInput } from '../shared/AuthPathValueInput';
+import { EMPTY_KNOWN_AUTH_DIRS, type KnownAuthDirs } from '../../../shared/authPaths';
 
 /**
  * Variable names whose values MUST be absolute filesystem paths. A relative
@@ -25,7 +27,10 @@ import type { Theme } from '../../types';
  * confusing dashboard tabs. Validating here rejects the bad value at write
  * time so the typo never lands on disk.
  */
-const ABSOLUTE_PATH_KEYS = new Set<string>(['CLAUDE_CONFIG_DIR']);
+const ABSOLUTE_PATH_KEYS: Record<string, true> = {
+	CLAUDE_CONFIG_DIR: true,
+	CODEX_HOME: true,
+};
 
 export interface EnvVarEntry {
 	id: number;
@@ -41,6 +46,8 @@ export interface EnvVarsEditorProps {
 	label?: string | null;
 	/** Optional description displayed below the editor. Pass null to hide. */
 	description?: string | null;
+	/** Local account directories previously configured for Claude and Codex. */
+	knownAuthDirs?: KnownAuthDirs;
 }
 
 export function EnvVarsEditor({
@@ -49,6 +56,7 @@ export function EnvVarsEditor({
 	theme,
 	label = 'Environment Variables (optional)',
 	description = 'Environment variables passed to all terminal sessions and AI agent processes.',
+	knownAuthDirs = EMPTY_KNOWN_AUTH_DIRS,
 }: EnvVarsEditorProps) {
 	// Convert object to array with stable IDs for editing
 	const [entries, setEntries] = useState<EnvVarEntry[]>(() => {
@@ -82,7 +90,7 @@ export function EnvVarsEditor({
 		// Variables that are consumed as filesystem paths must be absolute —
 		// relative values get resolved against the main-process cwd at runtime
 		// (often `/`) and silently point at a non-existent directory.
-		if (ABSOLUTE_PATH_KEYS.has(entry.key) && entry.value && !isAbsolutePath(entry.value)) {
+		if (ABSOLUTE_PATH_KEYS[entry.key] && entry.value && !isAbsolutePath(entry.value)) {
 			return `${entry.key} must be an absolute path (starting with /).`;
 		}
 		return null;
@@ -200,12 +208,13 @@ export function EnvVarsEditor({
 								<span className="flex items-center text-xs" style={{ color: theme.colors.textDim }}>
 									=
 								</span>
-								<input
-									type="text"
+								<AuthPathValueInput
+									envVarKey={entry.key}
 									value={entry.value}
-									onChange={(e) => updateEntry(entry.id, 'value', e.target.value)}
-									placeholder="value"
+									knownAuthDirs={knownAuthDirs}
+									onChange={(value) => updateEntry(entry.id, 'value', value)}
 									className="flex-1 p-2 rounded border bg-transparent outline-none text-xs font-mono"
+									containerClassName="flex-1 min-w-0"
 									style={{ borderColor: theme.colors.border, color: theme.colors.textMain }}
 								/>
 								<GhostIconButton

--- a/src/renderer/components/Settings/tabs/EnvironmentTab.tsx
+++ b/src/renderer/components/Settings/tabs/EnvironmentTab.tsx
@@ -8,6 +8,7 @@
 
 import { Globe } from 'lucide-react';
 import { useSettings } from '../../../hooks';
+import { useKnownAuthDirs } from '../../../hooks/agent/useKnownAuthDirs';
 import type { Theme } from '../../../types';
 import { EnvVarsEditor } from '../EnvVarsEditor';
 
@@ -17,6 +18,7 @@ export interface EnvironmentTabProps {
 
 export function EnvironmentTab({ theme }: EnvironmentTabProps) {
 	const { shellEnvVars, setShellEnvVars } = useSettings();
+	const knownAuthDirs = useKnownAuthDirs();
 
 	return (
 		<div className="space-y-5">
@@ -39,6 +41,7 @@ export function EnvironmentTab({ theme }: EnvironmentTabProps) {
 					theme={theme}
 					label={null}
 					description={null}
+					knownAuthDirs={knownAuthDirs}
 				/>
 			</div>
 		</div>

--- a/src/renderer/components/shared/AgentConfigPanel.tsx
+++ b/src/renderer/components/shared/AgentConfigPanel.tsx
@@ -26,6 +26,8 @@ import {
 import { useRemoteMaestroPAvailable } from '../../hooks/agent/useRemoteMaestroPAvailable';
 import { openUrl } from '../../utils/openUrl';
 import { logger } from '../../utils/logger';
+import { useKnownAuthDirs } from '../../hooks/agent/useKnownAuthDirs';
+import { AuthPathValueInput } from './AuthPathValueInput';
 
 const MAESTRO_P_INSTALL_URL = 'https://runmaestro.ai/maestro-p/';
 
@@ -412,6 +414,7 @@ export function AgentConfigPanel({
 		refresh: refreshRemoteMaestroP,
 	} = useRemoteMaestroPAvailable(isSshEnabled ? sshRemoteId : undefined);
 	const remoteMaestroPMissing = isSshEnabled && remoteMaestroPAvailable === false;
+	const knownAuthDirs = useKnownAuthDirs(!isSshEnabled);
 	// Collapse the stored (enableMaestroP, maestroPMode) pair into the tri-state the
 	// segmented "Claude Token Source" selector renders. Source not API => show the
 	// maestro-p path input and the live Time/API-limits pill.
@@ -770,14 +773,14 @@ export function AgentConfigPanel({
 							<span className="flex items-center text-xs" style={{ color: theme.colors.textDim }}>
 								=
 							</span>
-							<input
-								type="text"
+							<AuthPathValueInput
+								envVarKey={key}
 								value={value}
-								onChange={(e) => onEnvVarValueChange(key, e.target.value)}
+								knownAuthDirs={knownAuthDirs}
+								onChange={(updatedValue) => onEnvVarValueChange(key, updatedValue)}
 								onBlur={onEnvVarsBlur}
-								onClick={(e) => e.stopPropagation()}
-								placeholder="value"
 								className="flex-[2] p-2 rounded border bg-transparent outline-none text-xs font-mono"
+								containerClassName="flex-[2] min-w-0"
 								style={{ borderColor: theme.colors.border, color: theme.colors.textMain }}
 							/>
 							<GhostIconButton

--- a/src/renderer/components/shared/AuthPathValueInput.tsx
+++ b/src/renderer/components/shared/AuthPathValueInput.tsx
@@ -1,0 +1,122 @@
+import { useEffect, useState } from 'react';
+import type { CSSProperties } from 'react';
+import { type KnownAuthDirs } from '../../../shared/authPaths';
+import { getHomeDir, getHomeDirAsync } from '../../utils/homeDir';
+
+const CUSTOM_AUTH_PATH_OPTION = '__custom__';
+
+export interface AuthPathValueInputProps {
+	envVarKey: string;
+	value: string;
+	knownAuthDirs: KnownAuthDirs;
+	onChange: (value: string) => void;
+	onBlur?: () => void;
+	className: string;
+	containerClassName: string;
+	style: CSSProperties;
+}
+
+export function AuthPathValueInput({
+	envVarKey,
+	value,
+	knownAuthDirs,
+	onChange,
+	onBlur,
+	className,
+	containerClassName,
+	style,
+}: AuthPathValueInputProps) {
+	const knownPaths =
+		envVarKey === 'CLAUDE_CONFIG_DIR'
+			? knownAuthDirs.claudeConfigDirs
+			: envVarKey === 'CODEX_HOME'
+				? knownAuthDirs.codexHomes
+				: [];
+	const hasKnownValue = knownPaths.includes(value);
+	const [showCustomInput, setShowCustomInput] = useState(() => !hasKnownValue);
+	const [homeDir, setHomeDir] = useState(getHomeDir);
+
+	useEffect(() => {
+		setShowCustomInput(!hasKnownValue);
+	}, [hasKnownValue]);
+
+	useEffect(() => {
+		if (homeDir) return;
+		const homeDirPromise = getHomeDirAsync();
+		if (!homeDirPromise) return;
+
+		let cancelled = false;
+		void homeDirPromise.then((dir) => {
+			if (!cancelled) setHomeDir(dir);
+		});
+		return () => {
+			cancelled = true;
+		};
+	}, [homeDir]);
+
+	if (knownPaths.length === 0) {
+		return (
+			<input
+				type="text"
+				value={value}
+				onChange={(event) => onChange(event.target.value)}
+				onBlur={onBlur}
+				onClick={(event) => event.stopPropagation()}
+				placeholder="value"
+				className={className}
+				style={style}
+			/>
+		);
+	}
+
+	const normalizedHomeDir = homeDir?.replace(/[\\/]+$/, '');
+
+	return (
+		<div className={containerClassName}>
+			<select
+				aria-label={`Known ${envVarKey} paths`}
+				value={showCustomInput ? CUSTOM_AUTH_PATH_OPTION : value}
+				onChange={(event) => {
+					if (event.target.value === CUSTOM_AUTH_PATH_OPTION) {
+						setShowCustomInput(true);
+						return;
+					}
+					setShowCustomInput(false);
+					onChange(event.target.value);
+				}}
+				onBlur={onBlur}
+				onClick={(event) => event.stopPropagation()}
+				className={`${className} w-full`}
+				style={style}
+			>
+				{knownPaths.map((path) => {
+					const displayPath =
+						normalizedHomeDir &&
+						(path === normalizedHomeDir ||
+							path.startsWith(`${normalizedHomeDir}/`) ||
+							path.startsWith(`${normalizedHomeDir}\\`))
+							? `~${path.slice(normalizedHomeDir.length)}`
+							: path;
+					return (
+						<option key={path} value={path}>
+							{displayPath}
+						</option>
+					);
+				})}
+				<option value={CUSTOM_AUTH_PATH_OPTION}>Custom…</option>
+			</select>
+			{showCustomInput && (
+				<input
+					type="text"
+					value={value}
+					onChange={(event) => onChange(event.target.value)}
+					onBlur={onBlur}
+					onClick={(event) => event.stopPropagation()}
+					placeholder="value"
+					className={`${className} w-full mt-2`}
+					style={style}
+				/>
+			)}
+		</div>
+	);
+}

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -1283,6 +1283,7 @@ interface MaestroAPI {
 		) => Promise<boolean>;
 		getCustomEnvVars: (agentId: string) => Promise<Record<string, string> | null>;
 		getAllCustomEnvVars: () => Promise<Record<string, Record<string, string>>>;
+		getKnownAuthDirs: () => Promise<{ claudeConfigDirs: string[]; codexHomes: string[] }>;
 		getModels: (agentId: string, forceRefresh?: boolean, sshRemoteId?: string) => Promise<string[]>;
 		getConfigOptions: (
 			agentId: string,

--- a/src/renderer/hooks/agent/useKnownAuthDirs.ts
+++ b/src/renderer/hooks/agent/useKnownAuthDirs.ts
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react';
+import { EMPTY_KNOWN_AUTH_DIRS, type KnownAuthDirs } from '../../../shared/authPaths';
+
+function isKnownAuthDirs(value: unknown): value is KnownAuthDirs {
+	if (!value || typeof value !== 'object') return false;
+	if (!('claudeConfigDirs' in value) || !('codexHomes' in value)) return false;
+	return (
+		Array.isArray(value.claudeConfigDirs) &&
+		value.claudeConfigDirs.every((dir) => typeof dir === 'string') &&
+		Array.isArray(value.codexHomes) &&
+		value.codexHomes.every((dir) => typeof dir === 'string')
+	);
+}
+
+export function useKnownAuthDirs(enabled = true): KnownAuthDirs {
+	const [knownAuthDirs, setKnownAuthDirs] = useState<KnownAuthDirs>(EMPTY_KNOWN_AUTH_DIRS);
+
+	useEffect(() => {
+		if (!enabled) return;
+		const getKnownAuthDirs = window.maestro?.agents?.getKnownAuthDirs;
+		if (!getKnownAuthDirs) return;
+
+		let cancelled = false;
+		void getKnownAuthDirs()
+			.then((dirs) => {
+				if (!cancelled && isKnownAuthDirs(dirs)) {
+					setKnownAuthDirs(dirs);
+				}
+			})
+			.catch(() => {
+				// Account suggestions are optional; manual path entry remains available.
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, [enabled]);
+
+	return knownAuthDirs;
+}

--- a/src/shared/authPaths.ts
+++ b/src/shared/authPaths.ts
@@ -1,0 +1,9 @@
+export interface KnownAuthDirs {
+	claudeConfigDirs: string[];
+	codexHomes: string[];
+}
+
+export const EMPTY_KNOWN_AUTH_DIRS: KnownAuthDirs = {
+	claudeConfigDirs: [],
+	codexHomes: [],
+};


### PR DESCRIPTION
## What & why

Community request ([Discord](https://discord.com)): people running multiple Claude/Codex accounts currently have to remember and hand-type `CLAUDE_CONFIG_DIR` / `CODEX_HOME` paths in agent settings. This turns those two env values into a **dropdown of already-known account paths** with a `Custom…` free-text escape hatch.

## How

- New `agents:getKnownAuthDirs` IPC handler enumerates known paths **only from persisted agent/session `customEnvVars`**, canonicalized/deduped via the existing `resolveConfigDirKey`/`resolveCodexHomeKey` resolvers. **No disk scanning** — preserves the deliberate invariant that avoids triggering OAuth popups.
- SSH/URI-backed sessions are excluded (remote paths live on the remote host); SSH agent configs keep plain manual input.
- Shared `AuthPathValueInput` select+custom component used in both global Environment settings and agent config panels. Known value preselected; empty known-list falls back to exactly today's text input.
- Extended the existing absolute-path validation to `CODEX_HOME` (previously `CLAUDE_CONFIG_DIR` only).

## Scope

Local paths only. SSH-side enumeration and sessions-list override badges are follow-ups.

## Testing

- 4 test files / 167 tests: IPC handler shape, preload exposure, EnvVarsEditor dropdown behavior (magic keys only, custom reveal, empty-list fallback), AgentConfigPanel integration.
- Typecheck (3 tsc projects), eslint, prettier clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added known authentication path suggestions for Claude Code and Codex environment variables.
  * Users can select a known path or enter a custom path in environment settings.
  * Authentication paths are displayed using a shorter home-directory format when applicable.
* **Bug Fixes**
  * Added validation to ensure custom Codex home paths are absolute.
  * Excluded remote or non-local sessions from local path suggestions.
* **Tests**
  * Expanded coverage for path discovery, selection, validation, and environment variable updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->