### PR TITLE
Fix(group-chat): debounce draft persistence to stop per-keystroke app re-render

### DIFF
--- a/src/renderer/components/GroupChatInput.tsx
+++ b/src/renderer/components/GroupChatInput.tsx
@@ -643,6 +643,7 @@ export const GroupChatInput = React.memo(function GroupChatInput({
 							ref={inputRef}
 							value={message}
 							onChange={handleChange}
+							onBlur={flushDraft}
 							onKeyDown={handleKeyDown}
 							onPaste={handlePasteWrapped}
 							onDrop={handleDropWrapped}


### PR DESCRIPTION
## Observed behavior
I set up a group chat and had two agents, `claude_fable` and `codex 5.6 sol`, take turns discussing a topic for three rounds each. Even though the conversation was only a handful of messages long, the whole UI became sluggish: typing in the message box lagged noticeably.

## Root cause
`GroupChatInput` calls `onDraftChange` on every keystroke, which rewrites the global `groupChats` array in the store. `App.tsx` subscribes to `groupChats`, so every character re-renders the entire app tree. With a large message mounted, reconciling that tree on each keystroke is what makes typing feel slow, regardless of how short the conversation is.

## Fix
- Keep the textarea responsive through local state and debounce (250ms) the store write, reusing the existing `useDebouncedCallback` hook.
- `flush()` on blur so the draft is persisted before leaving the field.
- `cancel()` on send and on chat switch so a stale pending write cannot repopulate the box or land on the wrong chat.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message draft saving by reducing unnecessary draft updates while typing via debounced persistence.
  * Ensured drafts are flushed to storage when leaving the message field and before switching chats.
  * Prevented stale/incorrect drafts from being written to the wrong chat after chat switches.
  * Cancelled pending draft writes and cleared saved drafts after sending a message.
* **Tests**
  * Added coverage for debounced draft persistence, flushing, cancellation, and unmount behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->