### PR TITLE
Shard CI tests and add focused test commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
       - run: npx prettier --check .
       - run: npx eslint src/
       - run: npm run lint # TypeScript type checking
+      - run: npm run test:verify-shards
 
   test-ubuntu-shards:
     name: test shard (ubuntu-latest, ${{ matrix.shard }}/4)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,13 +20,13 @@ jobs:
       - run: npx eslint src/
       - run: npm run lint # TypeScript type checking
 
-  test:
+  test-ubuntu-shards:
+    name: test shard (ubuntu-latest, ${{ matrix.shard }}/4)
     strategy:
-      # Run the suite on both platforms; don't cancel one when the other fails.
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
+        shard: [1, 2, 3, 4]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -34,4 +34,41 @@ jobs:
           node-version: '22'
           cache: 'npm'
       - run: npm ci
-      - run: npm run test
+      - run: npm run test -- --shard=${{ matrix.shard }}/4
+
+  test-windows-shards:
+    name: test shard (windows-latest, ${{ matrix.shard }}/4)
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run test -- --shard=${{ matrix.shard }}/4
+
+  # Preserve the existing required check names while the suite runs in shards.
+  test-ubuntu:
+    name: test (ubuntu-latest)
+    if: ${{ always() }}
+    needs: test-ubuntu-shards
+    runs-on: ubuntu-latest
+    steps:
+      - name: Confirm all Ubuntu shards passed
+        if: ${{ needs.test-ubuntu-shards.result != 'success' }}
+        run: exit 1
+
+  test-windows:
+    name: test (windows-latest)
+    if: ${{ always() }}
+    needs: test-windows-shards
+    runs-on: ubuntu-latest
+    steps:
+      - name: Confirm all Windows shards passed
+        if: ${{ needs.test-windows-shards.result != 'success' }}
+        run: exit 1

--- a/docs/agent-guides/TEST-PATTERNS.md
+++ b/docs/agent-guides/TEST-PATTERNS.md
@@ -14,14 +14,16 @@ Config file: `vitest.config.mts`
 
 ```typescript
 // Key settings:
-environment: 'jsdom'; // Browser-like environment
 pool: 'forks'; // Process isolation between test files
 maxWorkers: 4; // Parallel execution
 setupFiles: ['./src/__tests__/setup.ts'];
-include: ['src/**/*.{test,spec}.{ts,tsx}'];
 testTimeout: 10000;
 hookTimeout: 10000;
 teardownTimeout: 5000;
+
+// Project environments:
+// - jsdom: TSX tests and renderer/web TS tests that need browser globals
+// - node: backend TS tests that do not need a browser environment
 
 // Excluded from default run (need separate config or flags):
 exclude: ['src/__tests__/integration/**', 'src/__tests__/e2e/**', 'src/__tests__/performance/**'];
@@ -33,8 +35,15 @@ Coverage uses `v8` provider with `text`, `text-summary`, `json`, and `html` repo
 
 ```bash
 npm run test          # Unit tests (excludes integration/e2e/performance)
+npm run test:changed  # Tests affected by uncommitted and branch changes
+npm run test:related -- src/path/to/file.ts # Tests related to specific source files
 npm run test:watch    # Watch mode
 ```
+
+CI divides the default unit suite into four Vitest shards on Ubuntu and four
+matching shards on Windows. The aggregate `test (ubuntu-latest)` and
+`test (windows-latest)` jobs preserve the required check names and pass only
+when every shard for that platform succeeds.
 
 ---
 

--- a/docs/agent-guides/TEST-PATTERNS.md
+++ b/docs/agent-guides/TEST-PATTERNS.md
@@ -37,13 +37,16 @@ Coverage uses `v8` provider with `text`, `text-summary`, `json`, and `html` repo
 npm run test          # Unit tests (excludes integration/e2e/performance)
 npm run test:changed  # Tests affected by uncommitted and branch changes
 npm run test:related -- src/path/to/file.ts # Tests related to specific source files
+npm run test:verify-shards # Verify CI shards cover every unit-test file exactly once
 npm run test:watch    # Watch mode
 ```
 
 CI divides the default unit suite into four Vitest shards on Ubuntu and four
 matching shards on Windows. The aggregate `test (ubuntu-latest)` and
 `test (windows-latest)` jobs preserve the required check names and pass only
-when every shard for that platform succeeds.
+when every shard for that platform succeeds. The lint job also compares
+Vitest's unsharded file list with all four shard lists, failing on missing,
+duplicated, unexpected, or empty shards.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
 		"test": "cross-env NODE_OPTIONS=--max-old-space-size=8192 vitest run",
 		"test:changed": "cross-env NODE_OPTIONS=--max-old-space-size=8192 vitest run --changed",
 		"test:related": "cross-env NODE_OPTIONS=--max-old-space-size=8192 vitest related",
+		"test:verify-shards": "node scripts/verify-test-shards.mjs",
 		"test:watch": "cross-env NODE_OPTIONS=--max-old-space-size=8192 vitest",
 		"test:coverage": "cross-env NODE_OPTIONS=--max-old-space-size=8192 vitest run --coverage",
 		"test:e2e": "bun run build:main && bun run build:renderer && playwright test",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,8 @@
 		"format:check:all": "prettier --check .",
 		"validate:push": "bun run format:check:all && bun run lint && bun run lint:eslint && bun run test",
 		"test": "cross-env NODE_OPTIONS=--max-old-space-size=8192 vitest run",
+		"test:changed": "cross-env NODE_OPTIONS=--max-old-space-size=8192 vitest run --changed",
+		"test:related": "cross-env NODE_OPTIONS=--max-old-space-size=8192 vitest related",
 		"test:watch": "cross-env NODE_OPTIONS=--max-old-space-size=8192 vitest",
 		"test:coverage": "cross-env NODE_OPTIONS=--max-old-space-size=8192 vitest run --coverage",
 		"test:e2e": "bun run build:main && bun run build:renderer && playwright test",

--- a/scripts/verify-test-shards.mjs
+++ b/scripts/verify-test-shards.mjs
@@ -1,0 +1,71 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createVitest } from 'vitest/node';
+
+const rootDir = path.resolve(fileURLToPath(new URL('..', import.meta.url)));
+const shardCount = 4;
+
+function testKey(specification) {
+	const relativePath = path.relative(rootDir, specification.moduleId).split(path.sep).join('/');
+	return `${specification.project.name}:${relativePath}`;
+}
+
+const vitest = await createVitest('test', { root: rootDir, run: true, watch: false });
+let allSpecifications;
+let shards;
+
+try {
+	allSpecifications = await vitest.globTestSpecifications();
+	const Sequencer = vitest.config.sequence.sequencer;
+	const sequencer = new Sequencer(vitest);
+
+	shards = [];
+	for (let index = 1; index <= shardCount; index += 1) {
+		vitest.config.shard = { index, count: shardCount };
+		shards.push((await sequencer.shard(allSpecifications)).map(testKey));
+	}
+} finally {
+	await vitest.close();
+}
+
+const allFiles = allSpecifications.map(testKey);
+
+const expected = new Set(allFiles);
+const owners = new Map();
+const duplicates = [];
+const unexpected = [];
+
+for (const [index, files] of shards.entries()) {
+	if (files.length === 0) {
+		throw new Error(`Vitest shard ${index + 1}/${shardCount} is empty`);
+	}
+
+	for (const file of files) {
+		if (!expected.has(file)) {
+			unexpected.push(file);
+		}
+
+		const previousShard = owners.get(file);
+		if (previousShard !== undefined) {
+			duplicates.push(`${file} (shards ${previousShard} and ${index + 1})`);
+		} else {
+			owners.set(file, index + 1);
+		}
+	}
+}
+
+const missing = allFiles.filter((file) => !owners.has(file));
+const errors = [
+	...missing.map((file) => `missing: ${file}`),
+	...duplicates.map((file) => `duplicate: ${file}`),
+	...unexpected.map((file) => `unexpected: ${file}`),
+];
+
+if (errors.length > 0) {
+	throw new Error(`Vitest shard coverage is invalid:\n${errors.join('\n')}`);
+}
+
+console.log(
+	`Verified ${shardCount} Vitest shards cover ${allFiles.length} files exactly once ` +
+		`(shard sizes: ${shards.map((files) => files.length).join(', ')}).`
+);

--- a/src/__tests__/main/ipc/handlers/marketplace.test.ts
+++ b/src/__tests__/main/ipc/handlers/marketplace.test.ts
@@ -52,6 +52,15 @@ vi.mock('crypto', () => ({
 	},
 }));
 
+const { mockHomedir } = vi.hoisted(() => ({
+	mockHomedir: vi.fn(),
+}));
+
+vi.mock('os', () => ({
+	default: { homedir: mockHomedir },
+	homedir: mockHomedir,
+}));
+
 // Mock electron-store
 vi.mock('electron-store', () => {
 	return {
@@ -190,6 +199,7 @@ describe('marketplace IPC handlers', () => {
 
 		// Default mock for crypto.randomUUID
 		vi.mocked(crypto.randomUUID).mockReturnValue('test-uuid-123');
+		mockHomedir.mockReset().mockReturnValue('/Users/testuser');
 
 		// Reset remote-fs mocks
 		mockWriteFileRemote.mockReset();
@@ -1059,13 +1069,7 @@ describe('marketplace IPC handlers', () => {
 				manifest: sampleManifest,
 			};
 
-			// Mock os.homedir() to return a predictable path. Marketplace
-			// service uses `import os from 'os'` (default import), so the
-			// mock must expose `default` plus the named export.
-			vi.mock('os', () => ({
-				default: { homedir: vi.fn().mockReturnValue('/Users/testuser') },
-				homedir: vi.fn().mockReturnValue('/Users/testuser'),
-			}));
+			mockHomedir.mockReturnValue('/Users/testuser');
 
 			// The tilde path ~/playbooks/my-tilde-playbook will be resolved to:
 			// /Users/testuser/playbooks/my-tilde-playbook (or similar based on os.homedir)

--- a/src/__tests__/renderer/components/UsageDashboard/ChartErrorBoundary.test.tsx
+++ b/src/__tests__/renderer/components/UsageDashboard/ChartErrorBoundary.test.tsx
@@ -3,7 +3,7 @@
  * Tests: error catching, retry functionality, error details, theming, accessibility
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach, afterAll } from 'vitest';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import { ChartErrorBoundary } from '../../../../renderer/components/UsageDashboard/ChartErrorBoundary';
 import type { Theme } from '../../../../renderer/types';
@@ -77,6 +77,29 @@ const WorkingComponent = () => <div data-testid="working-child">Working componen
 describe('ChartErrorBoundary', () => {
 	const theme = createTheme();
 	const originalConsoleError = console.error;
+	type JSDOMErrorListener = (...args: unknown[]) => void;
+	type JSDOMVirtualConsole = {
+		listeners: (event: string) => JSDOMErrorListener[];
+		removeAllListeners: (event: string) => void;
+		on: (event: string, listener: JSDOMErrorListener) => void;
+	};
+	const virtualConsole = (window as typeof window & { _virtualConsole?: JSDOMVirtualConsole })
+		._virtualConsole;
+	let jsdomErrorListeners: JSDOMErrorListener[] = [];
+
+	beforeAll(() => {
+		// These tests intentionally throw during render. React reports the caught
+		// errors through jsdom as well as console.error, producing large duplicate
+		// stacks that obscure real failures in the full suite.
+		jsdomErrorListeners = virtualConsole?.listeners('jsdomError') ?? [];
+		virtualConsole?.removeAllListeners('jsdomError');
+	});
+
+	afterAll(() => {
+		for (const listener of jsdomErrorListeners) {
+			virtualConsole?.on('jsdomError', listener);
+		}
+	});
 
 	beforeEach(() => {
 		vi.clearAllMocks();

--- a/src/__tests__/shared/pathUtils.test.ts
+++ b/src/__tests__/shared/pathUtils.test.ts
@@ -29,7 +29,7 @@ vi.mock('os', async () => {
 	return {
 		...actual,
 		homedir: vi.fn(() => '/Users/testuser'),
-		tmpdir: () => '/tmp',
+		tmpdir: vi.fn(() => actual.tmpdir()),
 	};
 });
 


### PR DESCRIPTION
## Summary

- Splits the default Vitest suite into four Ubuntu shards and four Windows shards.
- Preserves the existing required check names through per-platform aggregate jobs.
- Verifies that the configured shards cover every discovered unit-test file exactly once.
- Adds `npm run test:changed` and `npm run test:related -- <files>` for faster local feedback.
- Removes duplicate jsdom error-boundary stack output from the full suite.
- Moves a nested `vi.mock("os")` to a top-level hoisted mock before that pattern becomes a Vitest error.
- Fixes a pre-existing Windows temp-directory assumption exposed by the isolated shard runner.
- Updates the test-pattern documentation.

## Why

Increasing Vitest workers from four to eight improved a representative shard by only about 3 percent because jsdom startup, imports, and setup dominate. CI sharding attacks the wall-clock bottleneck directly while keeping the stable four-worker process-isolation configuration.

## Measured result

The hardened Windows `1/4` shard completed 338 files and 8,367 tests in 350 seconds locally. This suggests a more realistic Windows test phase of about 5-6 minutes, governed by the slowest shard, compared with roughly 12 minutes for the local unsharded suite. Runner setup, repeated `npm ci`, queue time, and shard imbalance will affect the final CI wall time.

The tradeoff is increased concurrent runner usage: four runners per operating system instead of one.

## Shard safety

`npm run test:verify-shards` asks Vitest for the configured test specifications and partitions them with Vitest's configured sequencer. It fails if any shard is empty or if any test file is missing, duplicated, or unexpected.

Current discovery result: 1,351 files covered exactly once across shard sizes 338, 338, 338, and 337.

## Validation

- Windows `1/4` shard: 338 files passed, 8,328 tests passed, 39 skipped.
- Focused Windows temp-path suite: 46 tests passed.
- Shard coverage verifier passed for all 1,351 files.
- TypeScript checks passed.
- ESLint passed.
- Prettier passed.
- `git diff --check` passed.