### PR TITLE
perf(renderer): cut MaestroConsoleInner re-renders from cycling and queue recovery

### DIFF
--- a/docs/agent-guides/TEST-PATTERNS.md
+++ b/docs/agent-guides/TEST-PATTERNS.md
@@ -270,7 +270,7 @@ beforeEach(() => {
 });
 ```
 
-`resetAllStores()` / `resetStore()` / `resetStores(...)` live in `src/__tests__/helpers/resetStores.ts` (re-exported from `src/__tests__/helpers`). They use Zustand v5 `getInitialState()` with replace mode and clone top-level `Set`/`Map` values so in-place mutations cannot poison later tests.
+`resetAllStores()` / `resetStore()` / `resetStores(...)` live in `src/__tests__/helpers/resetStores.ts` (re-exported from `src/__tests__/helpers`). They use Zustand v5 `getInitialState()` with replace mode and deep-clone `Set`/`Map`/array/plain-object defaults so in-place mutations cannot poison later tests. Store actions keep their original function references.
 
 For a single-store unit suite, `resetStore(useSessionStore)` (or `resetStores(useSessionStore, useUIStore)`) is enough.
 

--- a/docs/agent-guides/TEST-PATTERNS.md
+++ b/docs/agent-guides/TEST-PATTERNS.md
@@ -253,24 +253,28 @@ Never hardcode `/`, `\`, or `process.env.HOME` in path assertions or path fixtur
 
 ### Mocking Zustand Stores
 
-Zustand stores are singletons. Two approaches:
+Zustand stores are singletons. Prefer seeding the **real** store with `setState` after a full reset. Do not hand-roll partial default snapshots that drift from each store's create-time initial state.
 
-**Approach 1: Direct setState (preferred for store tests)**
+**Approach 1: `resetAllStores()` then seed (preferred)**
 
 ```typescript
+import { resetAllStores } from '../../helpers';
+import { useSessionStore } from '../../../renderer/stores/sessionStore';
 import { useSettingsStore } from '../../../renderer/stores/settingsStore';
 
 beforeEach(() => {
-	useSettingsStore.setState({
-		settingsLoaded: false,
-		activeThemeId: 'dracula',
-		fontSize: 14,
-		// ... reset all fields to initial values
-	});
+	resetAllStores();
+	// Optional: seed only what this test needs
+	useSessionStore.setState({ sessions: [createMockSession()], activeSessionId: 's1' });
+	useSettingsStore.setState({ activeThemeId: 'dracula' });
 });
 ```
 
-**Approach 2: vi.mock with selector function (for hook/component tests)**
+`resetAllStores()` / `resetStore()` / `resetStores(...)` live in `src/__tests__/helpers/resetStores.ts` (re-exported from `src/__tests__/helpers`). They use Zustand v5 `getInitialState()` with replace mode and clone top-level `Set`/`Map` values so in-place mutations cannot poison later tests.
+
+For a single-store unit suite, `resetStore(useSessionStore)` (or `resetStores(useSessionStore, useUIStore)`) is enough.
+
+**Approach 2: vi.mock with selector function (legacy; avoid for new tests)**
 
 ```typescript
 const mockSettingsState: Record<string, unknown> = {
@@ -807,7 +811,7 @@ describe('myStore', () => {
 
 1. **Always wrap modal components** in `<LayerStackProvider>`.
 2. **Use `vi.clearAllMocks()`** in `beforeEach` and `vi.restoreAllMocks()` in `afterEach`.
-3. **Reset Zustand stores** explicitly since they persist across tests.
+3. **Reset Zustand stores** with `resetAllStores()` (or `resetStore` / `resetStores`) from `src/__tests__/helpers` since stores persist across tests.
 4. **Use `vi.useFakeTimers()`** when testing timeouts, intervals, or debouncing.
 5. **Mock `window.maestro`** at the setup level; override specific methods per test.
 6. **Use `data-testid`** for elements that lack accessible roles.

--- a/src/__tests__/helpers/index.ts
+++ b/src/__tests__/helpers/index.ts
@@ -8,3 +8,4 @@
 export { createMockAITab, createMockFileTab } from './mockTab';
 export { createMockSession } from './mockSession';
 export { installLocalStorageMock } from './mockLocalStorage';
+export { ALL_RENDERER_STORES, resetAllStores, resetStore, resetStores } from './resetStores';

--- a/src/__tests__/helpers/resetStores.ts
+++ b/src/__tests__/helpers/resetStores.ts
@@ -5,11 +5,13 @@
  * unless reset. Prefer this helper over hand-rolled partial `setState`
  * snapshots that drift from each store's real initial state.
  *
- * Uses `getInitialState()` + replace (`setState(..., true)`), and clones
- * top-level `Set` / `Map` values so in-place mutations in one test cannot
- * poison the shared initial collections.
+ * Uses `getInitialState()` + replace (`setState(..., true)`), and deep-clones
+ * `Set` / `Map` / arrays / plain objects so in-place mutations in one test
+ * cannot poison the shared initial collections. Functions (store actions)
+ * keep their original references.
  */
 
+import { useImageAnnotatorStore } from '../../renderer/components/ImageAnnotator/imageAnnotatorStore';
 import { useAgentStore } from '../../renderer/stores/agentStore';
 import { useBatchStore } from '../../renderer/stores/batchStore';
 import { useCenterFlashStore } from '../../renderer/stores/centerFlashStore';
@@ -51,14 +53,37 @@ export type ResettableStore = {
 	setState: (...args: any[]) => void;
 };
 
+function isPlainObject(value: object): boolean {
+	const proto = Object.getPrototypeOf(value);
+	return proto === Object.prototype || proto === null;
+}
+
+/**
+ * Deep-clone mutable collection defaults from `getInitialState()`.
+ * Leaves functions and non-plain objects (class instances, etc.) shared.
+ */
 function cloneCollections(value: unknown): unknown {
 	if (value instanceof Set) {
-		return new Set(value);
+		const next = new Set();
+		for (const entry of value) {
+			next.add(cloneCollections(entry));
+		}
+		return next;
 	}
 	if (value instanceof Map) {
 		const next = new Map();
 		for (const [key, entry] of value) {
 			next.set(key, cloneCollections(entry));
+		}
+		return next;
+	}
+	if (Array.isArray(value)) {
+		return value.map((entry) => cloneCollections(entry));
+	}
+	if (value && typeof value === 'object' && isPlainObject(value)) {
+		const next: Record<string, unknown> = {};
+		for (const [key, entry] of Object.entries(value)) {
+			next[key] = cloneCollections(entry);
 		}
 		return next;
 	}
@@ -106,6 +131,7 @@ export const ALL_RENDERER_STORES: ResettableStore[] = [
 	useCoworkingApprovalStore,
 	useCoworkingBackgroundBrowserStore,
 	useCoworkingBrowserKeepAliveStore,
+	useImageAnnotatorStore,
 ];
 
 /**

--- a/src/__tests__/helpers/resetStores.ts
+++ b/src/__tests__/helpers/resetStores.ts
@@ -1,0 +1,130 @@
+/**
+ * Shared Zustand store reset for tests.
+ *
+ * Stores are module singletons: state leaks across tests in the same file
+ * unless reset. Prefer this helper over hand-rolled partial `setState`
+ * snapshots that drift from each store's real initial state.
+ *
+ * Uses `getInitialState()` + replace (`setState(..., true)`), and clones
+ * top-level `Set` / `Map` values so in-place mutations in one test cannot
+ * poison the shared initial collections.
+ */
+
+import { useAgentStore } from '../../renderer/stores/agentStore';
+import { useBatchStore } from '../../renderer/stores/batchStore';
+import { useCenterFlashStore } from '../../renderer/stores/centerFlashStore';
+import { useClaudeUsageStore } from '../../renderer/stores/claudeUsageStore';
+import { useCodexUsageStore } from '../../renderer/stores/codexUsageStore';
+import { useComposerInputStore } from '../../renderer/stores/composerInputStore';
+import { useCoworkingApprovalStore } from '../../renderer/stores/coworkingApprovalStore';
+import { useCoworkingBackgroundBrowserStore } from '../../renderer/stores/coworkingBackgroundBrowserStore';
+import { useCoworkingBrowserKeepAliveStore } from '../../renderer/stores/coworkingBrowserKeepAliveStore';
+import { useCrossAgentInFlightStore } from '../../renderer/stores/crossAgentInFlightStore';
+import { useCueDirtyStore } from '../../renderer/stores/cueDirtyStore';
+import { useFeedbackDraftStore } from '../../renderer/stores/feedbackDraftStore';
+import { useFileExplorerStore } from '../../renderer/stores/fileExplorerStore';
+import { useGroupChatStore } from '../../renderer/stores/groupChatStore';
+import { useMessageGistStore } from '../../renderer/stores/messageGistStore';
+import { useModalStore } from '../../renderer/stores/modalStore';
+import { useNotificationStore } from '../../renderer/stores/notificationStore';
+import { useOperationStore } from '../../renderer/stores/operationStore';
+import { useQuitWhenIdleStore } from '../../renderer/stores/quitWhenIdleStore';
+import { useRestartPendingStore } from '../../renderer/stores/restartPendingStore';
+import { useRetryStore } from '../../renderer/stores/retryStore';
+import { useSessionStore } from '../../renderer/stores/sessionStore';
+import { useSettingsStore } from '../../renderer/stores/settingsStore';
+import { useTabStore } from '../../renderer/stores/tabStore';
+import { useThoughtStreamStore } from '../../renderer/stores/thoughtStreamStore';
+import { useUIStore } from '../../renderer/stores/uiStore';
+
+/**
+ * Minimal store shape for reset (Zustand v5 `getInitialState`).
+ *
+ * - `getInitialState` returns `unknown` (not `Record<string, unknown>`) so
+ *   interface state types without an index signature stay assignable.
+ * - `setState` uses a rest `any[]` signature so Zustand's replace/partial
+ *   overloads remain assignable under `strictFunctionTypes`.
+ */
+export type ResettableStore = {
+	getInitialState: () => unknown;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- see note above
+	setState: (...args: any[]) => void;
+};
+
+function cloneCollections(value: unknown): unknown {
+	if (value instanceof Set) {
+		return new Set(value);
+	}
+	if (value instanceof Map) {
+		const next = new Map();
+		for (const [key, entry] of value) {
+			next.set(key, cloneCollections(entry));
+		}
+		return next;
+	}
+	return value;
+}
+
+/**
+ * Reset one Zustand store to a fresh copy of its create-time initial state.
+ * Actions keep their original function references from `getInitialState()`.
+ */
+export function resetStore(store: ResettableStore): void {
+	const initial = store.getInitialState() as Record<string, unknown>;
+	const next: Record<string, unknown> = { ...initial };
+	for (const key of Object.keys(next)) {
+		next[key] = cloneCollections(next[key]);
+	}
+	store.setState(next, true);
+}
+
+/** All renderer Zustand stores that tests commonly seed or assert against. */
+export const ALL_RENDERER_STORES: ResettableStore[] = [
+	useSessionStore,
+	useUIStore,
+	useSettingsStore,
+	useModalStore,
+	useGroupChatStore,
+	useAgentStore,
+	useTabStore,
+	useBatchStore,
+	useFileExplorerStore,
+	useNotificationStore,
+	useOperationStore,
+	useComposerInputStore,
+	useThoughtStreamStore,
+	useCenterFlashStore,
+	useRetryStore,
+	useRestartPendingStore,
+	useQuitWhenIdleStore,
+	useCueDirtyStore,
+	useFeedbackDraftStore,
+	useMessageGistStore,
+	useClaudeUsageStore,
+	useCodexUsageStore,
+	useCrossAgentInFlightStore,
+	useCoworkingApprovalStore,
+	useCoworkingBackgroundBrowserStore,
+	useCoworkingBrowserKeepAliveStore,
+];
+
+/**
+ * Reset every renderer Zustand store to its initial state.
+ * Call from `beforeEach` in suites that touch real stores (preferred over
+ * `vi.mock` of store modules).
+ */
+export function resetAllStores(): void {
+	for (const store of ALL_RENDERER_STORES) {
+		resetStore(store);
+	}
+}
+
+/**
+ * Reset only the listed stores. Prefer `resetAllStores()` unless a suite
+ * intentionally leaves unrelated store state alone for speed.
+ */
+export function resetStores(...stores: ResettableStore[]): void {
+	for (const store of stores) {
+		resetStore(store);
+	}
+}

--- a/src/__tests__/renderer/helpers/resetStores.test.ts
+++ b/src/__tests__/renderer/helpers/resetStores.test.ts
@@ -3,10 +3,16 @@
  */
 
 import { describe, it, expect, beforeEach } from 'vitest';
+import { useImageAnnotatorStore } from '../../../renderer/components/ImageAnnotator/imageAnnotatorStore';
 import { useSessionStore } from '../../../renderer/stores/sessionStore';
 import { useUIStore } from '../../../renderer/stores/uiStore';
 import { useModalStore } from '../../../renderer/stores/modalStore';
-import { resetAllStores, resetStore, resetStores } from '../../helpers/resetStores';
+import {
+	ALL_RENDERER_STORES,
+	resetAllStores,
+	resetStore,
+	resetStores,
+} from '../../helpers/resetStores';
 
 describe('resetStores helpers', () => {
 	beforeEach(() => {
@@ -36,6 +42,15 @@ describe('resetStores helpers', () => {
 		expect(useSessionStore.getState().removedWorktreePaths.has('/tmp/poison')).toBe(false);
 	});
 
+	it('resetStore clones array and plain-object defaults so in-place mutations do not leak', () => {
+		const sessions = useSessionStore.getState().sessions;
+		sessions.push({ id: 'poison' } as any);
+
+		resetStore(useSessionStore);
+		expect(useSessionStore.getState().sessions).toEqual([]);
+		expect(useSessionStore.getState().sessions).not.toBe(sessions);
+	});
+
 	it('resetStores only touches the listed stores', () => {
 		useSessionStore.setState({ activeSessionId: 'keep-me-reset' });
 		useUIStore.setState({ leftSidebarOpen: false });
@@ -54,5 +69,18 @@ describe('resetStores helpers', () => {
 
 		expect(useModalStore.getState().isOpen('about')).toBe(false);
 		expect(useModalStore.getState().modals.size).toBe(0);
+	});
+
+	it('resetAllStores includes and clears the image annotator store', () => {
+		expect(ALL_RENDERER_STORES).toContain(useImageAnnotatorStore);
+
+		useImageAnnotatorStore.getState().openAnnotator('data:image/png;base64,xx', () => {});
+		expect(useImageAnnotatorStore.getState().isOpen).toBe(true);
+
+		resetAllStores();
+
+		expect(useImageAnnotatorStore.getState().isOpen).toBe(false);
+		expect(useImageAnnotatorStore.getState().imageDataUrl).toBeNull();
+		expect(useImageAnnotatorStore.getState().onSave).toBeNull();
 	});
 });

--- a/src/__tests__/renderer/helpers/resetStores.test.ts
+++ b/src/__tests__/renderer/helpers/resetStores.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Tests for shared Zustand store reset helpers.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useSessionStore } from '../../../renderer/stores/sessionStore';
+import { useUIStore } from '../../../renderer/stores/uiStore';
+import { useModalStore } from '../../../renderer/stores/modalStore';
+import { resetAllStores, resetStore, resetStores } from '../../helpers/resetStores';
+
+describe('resetStores helpers', () => {
+	beforeEach(() => {
+		resetAllStores();
+	});
+
+	it('resetStore restores sessionStore defaults including a fresh Set', () => {
+		useSessionStore.setState({
+			sessions: [{ id: 's1' } as any],
+			activeSessionId: 's1',
+			cyclePosition: 3,
+		});
+		useSessionStore.getState().removedWorktreePaths.add('/tmp/wt');
+
+		resetStore(useSessionStore);
+
+		const state = useSessionStore.getState();
+		expect(state.sessions).toEqual([]);
+		expect(state.activeSessionId).toBe('');
+		expect(state.cyclePosition).toBe(-1);
+		expect(state.removedWorktreePaths.size).toBe(0);
+
+		// Mutating the live Set must not poison the next reset
+		state.removedWorktreePaths.add('/tmp/poison');
+		resetStore(useSessionStore);
+		expect(useSessionStore.getState().removedWorktreePaths.size).toBe(0);
+		expect(useSessionStore.getState().removedWorktreePaths.has('/tmp/poison')).toBe(false);
+	});
+
+	it('resetStores only touches the listed stores', () => {
+		useSessionStore.setState({ activeSessionId: 'keep-me-reset' });
+		useUIStore.setState({ leftSidebarOpen: false });
+
+		resetStores(useSessionStore);
+
+		expect(useSessionStore.getState().activeSessionId).toBe('');
+		expect(useUIStore.getState().leftSidebarOpen).toBe(false);
+	});
+
+	it('resetAllStores clears modal Map entries', () => {
+		useModalStore.getState().openModal('about');
+		expect(useModalStore.getState().isOpen('about')).toBe(true);
+
+		resetAllStores();
+
+		expect(useModalStore.getState().isOpen('about')).toBe(false);
+		expect(useModalStore.getState().modals.size).toBe(0);
+	});
+});

--- a/src/__tests__/renderer/hooks/useCycleSession.test.ts
+++ b/src/__tests__/renderer/hooks/useCycleSession.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for useCycleSession hook
+ * Tests for cycleSession (event-time store reads)
  *
  * Tests:
  *   - Next cycling through ungrouped sessions in alphabetical order
@@ -21,8 +21,7 @@
  *   - Unread filter restricts cycling to unread/busy agents only
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { renderHook, act, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // ============================================================================
 // Mocks
@@ -38,8 +37,8 @@ vi.mock('../../../renderer/hooks/session/useSortedSessions', () => ({
 // Imports (after mocks)
 // ============================================================================
 
-import { useCycleSession } from '../../../renderer/hooks/session/useCycleSession';
-import type { UseCycleSessionDeps } from '../../../renderer/hooks/session/useCycleSession';
+import { cycleSession } from '../../../renderer/hooks/session/useCycleSession';
+import type { CycleSessionDeps } from '../../../renderer/hooks/session/useCycleSession';
 import { useSessionStore } from '../../../renderer/stores/sessionStore';
 import { useGroupChatStore } from '../../../renderer/stores/groupChatStore';
 import { useUIStore } from '../../../renderer/stores/uiStore';
@@ -51,7 +50,7 @@ import { resetStores } from '../../helpers';
 // Helpers
 // ============================================================================
 
-/** Build a minimal Session object. Only the fields useCycleSession actually reads. */
+/** Build a minimal Session object. Only the fields cycleSession actually reads. */
 function makeSession(overrides: Partial<Session> & { id: string; name: string }): Session {
 	return {
 		id: overrides.id,
@@ -109,8 +108,8 @@ function makeGroup(id: string, name: string, collapsed = false) {
 	return { id, name, collapsed } as any;
 }
 
-/** Create default deps for the hook. */
-function makeDeps(overrides: Partial<UseCycleSessionDeps> = {}): UseCycleSessionDeps {
+/** Create default deps for cycleSession. */
+function makeDeps(overrides: Partial<CycleSessionDeps> = {}): CycleSessionDeps {
 	return {
 		sortedSessions: [],
 		handleOpenGroupChat: vi.fn(),
@@ -142,22 +141,17 @@ beforeEach(() => {
 	resetStores(useSessionStore, useGroupChatStore, useUIStore, useSettingsStore);
 });
 
-afterEach(() => {
-	cleanup();
-});
-
 // ============================================================================
 // Tests
 // ============================================================================
 
-describe('useCycleSession', () => {
+describe('cycleSession', () => {
 	// =========================================================================
-	// Return type
+	// Export
 	// =========================================================================
-	describe('return type', () => {
-		it('returns cycleSession function', () => {
-			const { result } = renderHook(() => useCycleSession(makeDeps()));
-			expect(typeof result.current.cycleSession).toBe('function');
+	describe('export', () => {
+		it('exports cycleSession function', () => {
+			expect(typeof cycleSession).toBe('function');
 		});
 	});
 
@@ -167,11 +161,8 @@ describe('useCycleSession', () => {
 	describe('empty visual order', () => {
 		it('does nothing when no sessions, groups, or group chats exist', () => {
 			const deps = makeDeps();
-			const { result } = renderHook(() => useCycleSession(deps));
 
-			act(() => {
-				result.current.cycleSession('next');
-			});
+			cycleSession('next', deps);
 
 			// No active session should have been set
 			expect(useSessionStore.getState().activeSessionId).toBe('');
@@ -186,11 +177,8 @@ describe('useCycleSession', () => {
 			useSessionStore.setState({ sessions: [sessA], activeSessionId: 'a' } as any);
 
 			const deps = makeDeps();
-			const { result } = renderHook(() => useCycleSession(deps));
 
-			act(() => {
-				result.current.cycleSession('next');
-			});
+			cycleSession('next', deps);
 
 			// activeSessionId should remain 'a' because visual order is empty — no-op
 			expect(useSessionStore.getState().activeSessionId).toBe('a');
@@ -218,11 +206,8 @@ describe('useCycleSession', () => {
 			useSettingsStore.setState({ groupChatsExpanded: false } as any);
 
 			const deps = makeDeps();
-			const { result } = renderHook(() => useCycleSession(deps));
 
-			act(() => {
-				result.current.cycleSession('next');
-			});
+			cycleSession('next', deps);
 
 			// Alpha → Beta (alphabetical order)
 			expect(useSessionStore.getState().activeSessionId).toBe('b');
@@ -245,16 +230,11 @@ describe('useCycleSession', () => {
 			useSettingsStore.setState({ groupChatsExpanded: false } as any);
 
 			const deps = makeDeps();
-			const { result } = renderHook(() => useCycleSession(deps));
 
-			act(() => {
-				result.current.cycleSession('next');
-			});
+			cycleSession('next', deps);
 			expect(useSessionStore.getState().activeSessionId).toBe('b');
 
-			act(() => {
-				result.current.cycleSession('next');
-			});
+			cycleSession('next', deps);
 			expect(useSessionStore.getState().activeSessionId).toBe('c');
 		});
 	});
@@ -280,11 +260,8 @@ describe('useCycleSession', () => {
 			useSettingsStore.setState({ groupChatsExpanded: false } as any);
 
 			const deps = makeDeps();
-			const { result } = renderHook(() => useCycleSession(deps));
 
-			act(() => {
-				result.current.cycleSession('prev');
-			});
+			cycleSession('prev', deps);
 
 			// Beta → Alpha
 			expect(useSessionStore.getState().activeSessionId).toBe('a');
@@ -307,16 +284,11 @@ describe('useCycleSession', () => {
 			useSettingsStore.setState({ groupChatsExpanded: false } as any);
 
 			const deps = makeDeps();
-			const { result } = renderHook(() => useCycleSession(deps));
 
-			act(() => {
-				result.current.cycleSession('prev');
-			});
+			cycleSession('prev', deps);
 			expect(useSessionStore.getState().activeSessionId).toBe('b');
 
-			act(() => {
-				result.current.cycleSession('prev');
-			});
+			cycleSession('prev', deps);
 			expect(useSessionStore.getState().activeSessionId).toBe('a');
 		});
 	});
@@ -342,11 +314,8 @@ describe('useCycleSession', () => {
 			useSettingsStore.setState({ groupChatsExpanded: false } as any);
 
 			const deps = makeDeps();
-			const { result } = renderHook(() => useCycleSession(deps));
 
-			act(() => {
-				result.current.cycleSession('next');
-			});
+			cycleSession('next', deps);
 
 			// Gamma (last) → Alpha (first)
 			expect(useSessionStore.getState().activeSessionId).toBe('a');
@@ -369,11 +338,8 @@ describe('useCycleSession', () => {
 			useSettingsStore.setState({ groupChatsExpanded: false } as any);
 
 			const deps = makeDeps();
-			const { result } = renderHook(() => useCycleSession(deps));
 
-			act(() => {
-				result.current.cycleSession('prev');
-			});
+			cycleSession('prev', deps);
 
 			// Alpha (first) → Gamma (last)
 			expect(useSessionStore.getState().activeSessionId).toBe('c');
@@ -401,13 +367,10 @@ describe('useCycleSession', () => {
 			useSettingsStore.setState({ groupChatsExpanded: false } as any);
 
 			const deps = makeDeps();
-			const { result } = renderHook(() => useCycleSession(deps));
 
 			// Active = Alpha (index 1 in visualOrder: [Beta-bookmark, Alpha, Beta-ungrouped])
 			// prev from Alpha → Beta-bookmark (index 0)
-			act(() => {
-				result.current.cycleSession('prev');
-			});
+			cycleSession('prev', deps);
 
 			expect(useSessionStore.getState().activeSessionId).toBe('b');
 			// cyclePosition should be 0 (first occurrence — bookmark slot)
@@ -432,19 +395,14 @@ describe('useCycleSession', () => {
 			useSettingsStore.setState({ groupChatsExpanded: false } as any);
 
 			const deps = makeDeps();
-			const { result } = renderHook(() => useCycleSession(deps));
 
 			// next from B-bookmark(0) → A-ungrouped(1)
-			act(() => {
-				result.current.cycleSession('next');
-			});
+			cycleSession('next', deps);
 			expect(useSessionStore.getState().activeSessionId).toBe('a');
 			expect(useSessionStore.getState().cyclePosition).toBe(1);
 
 			// next from A-ungrouped(1) → B-ungrouped(2)
-			act(() => {
-				result.current.cycleSession('next');
-			});
+			cycleSession('next', deps);
 			expect(useSessionStore.getState().activeSessionId).toBe('b');
 			expect(useSessionStore.getState().cyclePosition).toBe(2);
 		});
@@ -465,12 +423,9 @@ describe('useCycleSession', () => {
 			useSettingsStore.setState({ groupChatsExpanded: false } as any);
 
 			const deps = makeDeps();
-			const { result } = renderHook(() => useCycleSession(deps));
 
 			// Visual order without bookmarks: [Alpha, Beta]; next from Alpha → Beta
-			act(() => {
-				result.current.cycleSession('next');
-			});
+			cycleSession('next', deps);
 
 			expect(useSessionStore.getState().activeSessionId).toBe('b');
 			expect(useSessionStore.getState().cyclePosition).toBe(1);
@@ -510,13 +465,10 @@ describe('useCycleSession', () => {
 				['group:grp-1:b', 2],
 			]);
 			const deps = makeDeps({ navIndexMap });
-			const { result } = renderHook(() => useCycleSession(deps));
 
 			// Visual order: [bookmark Beta(0), group Alpha(1), group Beta(2)].
 			// Active Alpha → first session occurrence is group Alpha(1). next → group Beta(2).
-			act(() => {
-				result.current.cycleSession('next');
-			});
+			cycleSession('next', deps);
 
 			expect(useSessionStore.getState().activeSessionId).toBe('b');
 			// Highlight must be the GROUP occurrence (navIndex 2), NOT the bookmark row (0).
@@ -547,13 +499,10 @@ describe('useCycleSession', () => {
 				['ungrouped:b', 2],
 			]);
 			const deps = makeDeps({ navIndexMap });
-			const { result } = renderHook(() => useCycleSession(deps));
 
 			// Visual order: [bookmark Beta(0), Alpha(1), Beta(2)]. Active Alpha is at
 			// visual index 1; prev → bookmark Beta(0).
-			act(() => {
-				result.current.cycleSession('prev');
-			});
+			cycleSession('prev', deps);
 
 			expect(useSessionStore.getState().activeSessionId).toBe('b');
 			// Bookmark occurrence highlighted (navIndex 0).
@@ -588,12 +537,9 @@ describe('useCycleSession', () => {
 			const activateStarredItem = vi.fn();
 			const starredItems = [makeOpenStarred('b', 't1', 'Zstar')];
 			const deps = makeDeps({ starredItems, activateStarredItem });
-			const { result } = renderHook(() => useCycleSession(deps));
 
 			// Active = Alpha (session slot at index 1). prev → starred slot at index 0.
-			act(() => {
-				result.current.cycleSession('prev');
-			});
+			cycleSession('prev', deps);
 
 			expect(activateStarredItem).toHaveBeenCalledWith(starredItems[0]);
 			expect(useSessionStore.getState().cyclePosition).toBe(0);
@@ -635,14 +581,11 @@ describe('useCycleSession', () => {
 			// active); the cycle owns sidebarExtraSelection regardless.
 			const activateStarredItem = vi.fn();
 			const deps = makeDeps({ starredItems, activateStarredItem });
-			const { result } = renderHook(() => useCycleSession(deps));
 
 			// Visual order: [Package(0), Slack(1), bookmark Chat(2)].
 			// Active 'chat' with no extra cursor → first session occurrence = bookmark(2).
 			// prev → Slack starred(1).
-			act(() => {
-				result.current.cycleSession('prev');
-			});
+			cycleSession('prev', deps);
 			expect(activateStarredItem).toHaveBeenLastCalledWith(starredItems[1]);
 			expect(useUIStore.getState().sidebarExtraSelection).toEqual({
 				kind: 'starred',
@@ -650,9 +593,7 @@ describe('useCycleSession', () => {
 			});
 
 			// prev again must ADVANCE to Package starred(0), not bounce back to Slack.
-			act(() => {
-				result.current.cycleSession('prev');
-			});
+			cycleSession('prev', deps);
 			expect(activateStarredItem).toHaveBeenLastCalledWith(starredItems[0]);
 			expect(useUIStore.getState().sidebarExtraSelection).toEqual({
 				kind: 'starred',
@@ -680,12 +621,9 @@ describe('useCycleSession', () => {
 			} as any);
 
 			const deps = makeDeps({ starredItems });
-			const { result } = renderHook(() => useCycleSession(deps));
 
 			// Visual order: [Star A(0), Alpha(1)]. On starred(0), next → Alpha(1) agent.
-			act(() => {
-				result.current.cycleSession('next');
-			});
+			cycleSession('next', deps);
 
 			expect(useSessionStore.getState().activeSessionId).toBe('a');
 			expect(useUIStore.getState().sidebarExtraSelection).toBeNull();
@@ -712,12 +650,9 @@ describe('useCycleSession', () => {
 			const activateStarredItem = vi.fn();
 			const starredItems = [makeOpenStarred('b', 't1', 'Zstar')];
 			const deps = makeDeps({ starredItems, activateStarredItem });
-			const { result } = renderHook(() => useCycleSession(deps));
 
 			// Visual order: [Alpha, Beta] only. prev from Alpha(0) wraps to Beta(1).
-			act(() => {
-				result.current.cycleSession('prev');
-			});
+			cycleSession('prev', deps);
 
 			expect(activateStarredItem).not.toHaveBeenCalled();
 			expect(useSessionStore.getState().activeSessionId).toBe('b');
@@ -747,11 +682,8 @@ describe('useCycleSession', () => {
 			const activateStarredItem = vi.fn();
 			const starredItems = [makeOpenStarred('b', 't1', 'Zstar')];
 			const deps = makeDeps({ starredItems, activateStarredItem });
-			const { result } = renderHook(() => useCycleSession(deps));
 
-			act(() => {
-				result.current.cycleSession('next');
-			});
+			cycleSession('next', deps);
 
 			expect(activateStarredItem).not.toHaveBeenCalled();
 			// Alpha → Beta (both unread); starred row excluded.
@@ -778,12 +710,9 @@ describe('useCycleSession', () => {
 			const activateStarredItem = vi.fn();
 			const starredItems = [makeOpenStarred('a', 't1', 'Star One')];
 			const deps = makeDeps({ starredItems, activateStarredItem });
-			const { result } = renderHook(() => useCycleSession(deps));
 
 			// Visual order: [starred(0), Alpha(1)]. next from 1 wraps to starred(0).
-			act(() => {
-				result.current.cycleSession('next');
-			});
+			cycleSession('next', deps);
 
 			expect(activateStarredItem).toHaveBeenCalledWith(starredItems[0]);
 			expect(useSessionStore.getState().cyclePosition).toBe(0);
@@ -814,18 +743,13 @@ describe('useCycleSession', () => {
 			useSettingsStore.setState({ ungroupedCollapsed: true } as any);
 
 			const deps = makeDeps();
-			const { result } = renderHook(() => useCycleSession(deps));
 
 			// next from Alice → Bob
-			act(() => {
-				result.current.cycleSession('next');
-			});
+			cycleSession('next', deps);
 			expect(useSessionStore.getState().activeSessionId).toBe('b');
 
 			// next from Bob → Charlie
-			act(() => {
-				result.current.cycleSession('next');
-			});
+			cycleSession('next', deps);
 			expect(useSessionStore.getState().activeSessionId).toBe('c');
 		});
 
@@ -850,13 +774,10 @@ describe('useCycleSession', () => {
 			useSettingsStore.setState({ ungroupedCollapsed: true } as any);
 
 			const deps = makeDeps();
-			const { result } = renderHook(() => useCycleSession(deps));
 
 			// Visual order: Ants-group [Ant-One], Bees-group [Bee-One]
 			// next from Ant-One → Bee-One
-			act(() => {
-				result.current.cycleSession('next');
-			});
+			cycleSession('next', deps);
 			expect(useSessionStore.getState().activeSessionId).toBe('b1');
 		});
 	});
@@ -887,18 +808,13 @@ describe('useCycleSession', () => {
 			useSettingsStore.setState({ ungroupedCollapsed: true } as any);
 
 			const deps = makeDeps();
-			const { result } = renderHook(() => useCycleSession(deps));
 
 			// Visual order: [Alpha, Beta] (Hidden is in collapsed group → skipped)
-			act(() => {
-				result.current.cycleSession('next');
-			});
+			cycleSession('next', deps);
 			expect(useSessionStore.getState().activeSessionId).toBe('b');
 
 			// wrap around — Beta → Alpha (not Hidden)
-			act(() => {
-				result.current.cycleSession('next');
-			});
+			cycleSession('next', deps);
 			expect(useSessionStore.getState().activeSessionId).toBe('a');
 		});
 
@@ -920,11 +836,8 @@ describe('useCycleSession', () => {
 			useSettingsStore.setState({ ungroupedCollapsed: true } as any);
 
 			const deps = makeDeps();
-			const { result } = renderHook(() => useCycleSession(deps));
 
-			act(() => {
-				result.current.cycleSession('next');
-			});
+			cycleSession('next', deps);
 
 			// visual order empty → no-op
 			expect(useSessionStore.getState().activeSessionId).toBe('a');
@@ -954,13 +867,10 @@ describe('useCycleSession', () => {
 			useSettingsStore.setState({ ungroupedCollapsed: true } as any);
 
 			const deps = makeDeps();
-			const { result } = renderHook(() => useCycleSession(deps));
 
 			// Visual order: [Grouped] only (Ungrouped is hidden)
 			// next from Grouped → wraps back to Grouped (single item)
-			act(() => {
-				result.current.cycleSession('next');
-			});
+			cycleSession('next', deps);
 			expect(useSessionStore.getState().activeSessionId).toBe('g');
 		});
 
@@ -983,12 +893,9 @@ describe('useCycleSession', () => {
 			useSettingsStore.setState({ ungroupedCollapsed: false } as any);
 
 			const deps = makeDeps();
-			const { result } = renderHook(() => useCycleSession(deps));
 
 			// Visual order: [Grouped, Zed-Ungrouped]; next from Grouped → Zed-Ungrouped
-			act(() => {
-				result.current.cycleSession('next');
-			});
+			cycleSession('next', deps);
 			expect(useSessionStore.getState().activeSessionId).toBe('u');
 		});
 	});
@@ -1018,12 +925,9 @@ describe('useCycleSession', () => {
 
 			const handleOpenGroupChat = vi.fn();
 			const deps = makeDeps({ handleOpenGroupChat });
-			const { result } = renderHook(() => useCycleSession(deps));
 
 			// Visual order: [Alpha, Chat One]; next from Alpha → Chat One
-			act(() => {
-				result.current.cycleSession('next');
-			});
+			cycleSession('next', deps);
 
 			expect(handleOpenGroupChat).toHaveBeenCalledWith('gc-1');
 			expect(useSessionStore.getState().cyclePosition).toBe(1);
@@ -1051,24 +955,17 @@ describe('useCycleSession', () => {
 
 			const handleOpenGroupChat = vi.fn();
 			const deps = makeDeps({ handleOpenGroupChat });
-			const { result } = renderHook(() => useCycleSession(deps));
 
 			// Visual order: [Alpha(0), Ant Chat(1), Zebra Chat(2)]
 			// next from Alpha → Ant Chat
-			act(() => {
-				result.current.cycleSession('next');
-			});
+			cycleSession('next', deps);
 			expect(handleOpenGroupChat).toHaveBeenCalledWith('gc-a');
 
-			// Simulate Ant Chat now being active (must be inside act for reactive update)
-			act(() => {
-				useGroupChatStore.setState({ activeGroupChatId: 'gc-a' } as any);
-			});
+			// Simulate Ant Chat now being active
+			useGroupChatStore.setState({ activeGroupChatId: 'gc-a' } as any);
 
 			// next from Ant Chat → Zebra Chat
-			act(() => {
-				result.current.cycleSession('next');
-			});
+			cycleSession('next', deps);
 			expect(handleOpenGroupChat).toHaveBeenCalledWith('gc-z');
 		});
 
@@ -1093,12 +990,9 @@ describe('useCycleSession', () => {
 
 			const handleOpenGroupChat = vi.fn();
 			const deps = makeDeps({ handleOpenGroupChat });
-			const { result } = renderHook(() => useCycleSession(deps));
 
 			// next from Alpha → wraps back to Alpha (only one item)
-			act(() => {
-				result.current.cycleSession('next');
-			});
+			cycleSession('next', deps);
 			expect(handleOpenGroupChat).not.toHaveBeenCalled();
 			expect(useSessionStore.getState().activeSessionId).toBe('a');
 		});
@@ -1123,11 +1017,8 @@ describe('useCycleSession', () => {
 
 			const handleOpenGroupChat = vi.fn();
 			const deps = makeDeps({ handleOpenGroupChat });
-			const { result } = renderHook(() => useCycleSession(deps));
 
-			act(() => {
-				result.current.cycleSession('next');
-			});
+			cycleSession('next', deps);
 
 			expect(handleOpenGroupChat).not.toHaveBeenCalled();
 			// Single item → wraps back to itself
@@ -1158,12 +1049,9 @@ describe('useCycleSession', () => {
 
 			const handleOpenGroupChat = vi.fn();
 			const deps = makeDeps({ handleOpenGroupChat });
-			const { result } = renderHook(() => useCycleSession(deps));
 
 			// next from Chat One(1) → wraps to Alpha(0)
-			act(() => {
-				result.current.cycleSession('next');
-			});
+			cycleSession('next', deps);
 
 			expect(useSessionStore.getState().activeSessionId).toBe('a');
 			expect(handleOpenGroupChat).not.toHaveBeenCalled();
@@ -1191,25 +1079,18 @@ describe('useCycleSession', () => {
 
 			const handleOpenGroupChat = vi.fn();
 			const deps = makeDeps({ handleOpenGroupChat });
-			const { result } = renderHook(() => useCycleSession(deps));
 
 			// Visual order: [Alpha(0), Active Chat(1)] — Archived Chat excluded
 			// next from Alpha → Active Chat
-			act(() => {
-				result.current.cycleSession('next');
-			});
+			cycleSession('next', deps);
 			expect(handleOpenGroupChat).toHaveBeenCalledWith('gc-active');
 
 			// Simulate being on Active Chat
-			act(() => {
-				useGroupChatStore.setState({ activeGroupChatId: 'gc-active' } as any);
-				useSessionStore.setState({ cyclePosition: 1 } as any);
-			});
+			useGroupChatStore.setState({ activeGroupChatId: 'gc-active' } as any);
+			useSessionStore.setState({ cyclePosition: 1 } as any);
 
 			// next from Active Chat → wraps to Alpha (skips archived)
-			act(() => {
-				result.current.cycleSession('next');
-			});
+			cycleSession('next', deps);
 			expect(useSessionStore.getState().activeSessionId).toBe('a');
 		});
 	});
@@ -1236,13 +1117,10 @@ describe('useCycleSession', () => {
 
 			// sortedSessions provided by deps in a specific custom order
 			const deps = makeDeps({ sortedSessions: [sessC, sessB, sessA] });
-			const { result } = renderHook(() => useCycleSession(deps));
 
 			// Visual order when sidebar closed = sortedSessions order: [Gamma, Beta, Alpha]
 			// Active is 'a' (Alpha at index 2), next → wraps to Gamma(0)
-			act(() => {
-				result.current.cycleSession('next');
-			});
+			cycleSession('next', deps);
 			expect(useSessionStore.getState().activeSessionId).toBe('c');
 		});
 
@@ -1267,12 +1145,9 @@ describe('useCycleSession', () => {
 
 			const handleOpenGroupChat = vi.fn();
 			const deps = makeDeps({ sortedSessions: [sessA], handleOpenGroupChat });
-			const { result } = renderHook(() => useCycleSession(deps));
 
 			// Visual order = [Alpha] only; next → wraps to Alpha
-			act(() => {
-				result.current.cycleSession('next');
-			});
+			cycleSession('next', deps);
 			expect(handleOpenGroupChat).not.toHaveBeenCalled();
 			expect(useSessionStore.getState().activeSessionId).toBe('a');
 		});
@@ -1309,11 +1184,8 @@ describe('useCycleSession', () => {
 			useSettingsStore.setState({ ungroupedCollapsed: true } as any);
 
 			const deps = makeDeps();
-			const { result } = renderHook(() => useCycleSession(deps));
 
-			act(() => {
-				result.current.cycleSession('next');
-			});
+			cycleSession('next', deps);
 
 			// Since 'hidden' is not in visual order, first item 'first' is selected
 			expect(useSessionStore.getState().activeSessionId).toBe('first');
@@ -1345,11 +1217,8 @@ describe('useCycleSession', () => {
 
 			const handleOpenGroupChat = vi.fn();
 			const deps = makeDeps({ handleOpenGroupChat });
-			const { result } = renderHook(() => useCycleSession(deps));
 
-			act(() => {
-				result.current.cycleSession('next');
-			});
+			cycleSession('next', deps);
 
 			expect(handleOpenGroupChat).toHaveBeenCalledWith('gc-1');
 			expect(useSessionStore.getState().cyclePosition).toBe(0);
@@ -1373,11 +1242,8 @@ describe('useCycleSession', () => {
 			useSettingsStore.setState({ groupChatsExpanded: false } as any);
 
 			const deps = makeDeps();
-			const { result } = renderHook(() => useCycleSession(deps));
 
-			act(() => {
-				result.current.cycleSession('prev');
-			});
+			cycleSession('prev', deps);
 
 			// First item alphabetically is Alpha
 			expect(useSessionStore.getState().activeSessionId).toBe('a');
@@ -1417,19 +1283,14 @@ describe('useCycleSession', () => {
 			useSettingsStore.setState({ groupChatsExpanded: false } as any);
 
 			const deps = makeDeps();
-			const { result } = renderHook(() => useCycleSession(deps));
 
 			// Visual order: [Parent, Child-branch-a(c1), Child-branch-b(c2)]
 			// next from Parent → c1
-			act(() => {
-				result.current.cycleSession('next');
-			});
+			cycleSession('next', deps);
 			expect(useSessionStore.getState().activeSessionId).toBe('c1');
 
 			// next from c1 → c2
-			act(() => {
-				result.current.cycleSession('next');
-			});
+			cycleSession('next', deps);
 			expect(useSessionStore.getState().activeSessionId).toBe('c2');
 		});
 
@@ -1454,11 +1315,8 @@ describe('useCycleSession', () => {
 			useSettingsStore.setState({ groupChatsExpanded: false } as any);
 
 			const deps = makeDeps();
-			const { result } = renderHook(() => useCycleSession(deps));
 
-			act(() => {
-				result.current.cycleSession('next');
-			});
+			cycleSession('next', deps);
 			expect(useSessionStore.getState().activeSessionId).toBe('c');
 		});
 
@@ -1484,13 +1342,10 @@ describe('useCycleSession', () => {
 			useSettingsStore.setState({ groupChatsExpanded: false } as any);
 
 			const deps = makeDeps();
-			const { result } = renderHook(() => useCycleSession(deps));
 
 			// Visual order: [Beta, Parent] — child is excluded, parent is ungrouped
 			// Active = 'p' (Parent, index 1), next → wraps to Beta(0)
-			act(() => {
-				result.current.cycleSession('next');
-			});
+			cycleSession('next', deps);
 			expect(useSessionStore.getState().activeSessionId).toBe('b');
 		});
 
@@ -1525,19 +1380,14 @@ describe('useCycleSession', () => {
 			useSettingsStore.setState({ groupChatsExpanded: false } as any);
 
 			const deps = makeDeps();
-			const { result } = renderHook(() => useCycleSession(deps));
 
 			// Visual order by name: [Parent, apple-agent(ca), zebra-agent(cz)]
 			// next from Parent → ca (apple-agent comes first alphabetically by name)
-			act(() => {
-				result.current.cycleSession('next');
-			});
+			cycleSession('next', deps);
 			expect(useSessionStore.getState().activeSessionId).toBe('ca');
 
 			// next from ca → cz (zebra-agent)
-			act(() => {
-				result.current.cycleSession('next');
-			});
+			cycleSession('next', deps);
 			expect(useSessionStore.getState().activeSessionId).toBe('cz');
 		});
 
@@ -1563,13 +1413,10 @@ describe('useCycleSession', () => {
 			useSettingsStore.setState({ groupChatsExpanded: false } as any);
 
 			const deps = makeDeps();
-			const { result } = renderHook(() => useCycleSession(deps));
 
 			// Visual order: [Parent(0), child(1)] — child appears once, under parent
 			// Active = c (index 1); next → wraps to Parent(0)
-			act(() => {
-				result.current.cycleSession('next');
-			});
+			cycleSession('next', deps);
 			expect(useSessionStore.getState().activeSessionId).toBe('p');
 			expect(useSessionStore.getState().cyclePosition).toBe(0);
 		});
@@ -1596,22 +1443,15 @@ describe('useCycleSession', () => {
 			useSettingsStore.setState({ groupChatsExpanded: false } as any);
 
 			const deps = makeDeps();
-			const { result } = renderHook(() => useCycleSession(deps));
 
-			act(() => {
-				result.current.cycleSession('next');
-			});
+			cycleSession('next', deps);
 			expect(useSessionStore.getState().cyclePosition).toBe(1); // Beta at index 1
 
-			act(() => {
-				result.current.cycleSession('next');
-			});
+			cycleSession('next', deps);
 			expect(useSessionStore.getState().cyclePosition).toBe(2); // Gamma at index 2
 
 			// Wrap around
-			act(() => {
-				result.current.cycleSession('next');
-			});
+			cycleSession('next', deps);
 			expect(useSessionStore.getState().cyclePosition).toBe(0); // Alpha at index 0
 		});
 
@@ -1634,11 +1474,8 @@ describe('useCycleSession', () => {
 			useSettingsStore.setState({ groupChatsExpanded: false } as any);
 
 			const deps = makeDeps();
-			const { result } = renderHook(() => useCycleSession(deps));
 
-			act(() => {
-				result.current.cycleSession('next');
-			});
+			cycleSession('next', deps);
 			// Uses stored position 1 → next is Gamma at index 2
 			expect(useSessionStore.getState().activeSessionId).toBe('c');
 			expect(useSessionStore.getState().cyclePosition).toBe(2);
@@ -1662,11 +1499,8 @@ describe('useCycleSession', () => {
 			useSettingsStore.setState({ groupChatsExpanded: false } as any);
 
 			const deps = makeDeps();
-			const { result } = renderHook(() => useCycleSession(deps));
 
-			act(() => {
-				result.current.cycleSession('next');
-			});
+			cycleSession('next', deps);
 			// Falls back to findIndex — Alpha found at 0 → next is Beta at 1
 			expect(useSessionStore.getState().activeSessionId).toBe('b');
 			expect(useSessionStore.getState().cyclePosition).toBe(1);
@@ -1688,11 +1522,8 @@ describe('useCycleSession', () => {
 			useSettingsStore.setState({ groupChatsExpanded: false } as any);
 
 			const deps = makeDeps();
-			const { result } = renderHook(() => useCycleSession(deps));
 
-			act(() => {
-				result.current.cycleSession('next');
-			});
+			cycleSession('next', deps);
 			// Falls back to findIndex — Alpha at 0, next is Beta at 1
 			expect(useSessionStore.getState().activeSessionId).toBe('b');
 			expect(useSessionStore.getState().cyclePosition).toBe(1);
@@ -1715,11 +1546,8 @@ describe('useCycleSession', () => {
 			useSettingsStore.setState({ groupChatsExpanded: false } as any);
 
 			const deps = makeDeps();
-			const { result } = renderHook(() => useCycleSession(deps));
 
-			act(() => {
-				result.current.cycleSession('prev');
-			});
+			cycleSession('prev', deps);
 			// Gamma(2) → Beta(1)
 			expect(useSessionStore.getState().cyclePosition).toBe(1);
 		});
@@ -1749,13 +1577,10 @@ describe('useCycleSession', () => {
 			useSettingsStore.setState({ groupChatsExpanded: true } as any);
 
 			const deps = makeDeps();
-			const { result } = renderHook(() => useCycleSession(deps));
 
 			// Visual order: [Alpha(0), Chat One(1)]
 			// Active on Chat One (index 1), next → wraps to Alpha(0)
-			act(() => {
-				result.current.cycleSession('next');
-			});
+			cycleSession('next', deps);
 
 			expect(useSessionStore.getState().activeSessionId).toBe('a');
 			expect(useGroupChatStore.getState().activeGroupChatId).toBeNull();
@@ -1781,11 +1606,8 @@ describe('useCycleSession', () => {
 			useSettingsStore.setState({ groupChatsExpanded: false } as any);
 
 			const deps = makeDeps();
-			const { result } = renderHook(() => useCycleSession(deps));
 
-			act(() => {
-				result.current.cycleSession('next');
-			});
+			cycleSession('next', deps);
 
 			expect(useSessionStore.getState().activeSessionId).toBe('a');
 			expect(useSessionStore.getState().cyclePosition).toBe(0);
@@ -1806,11 +1628,8 @@ describe('useCycleSession', () => {
 			useSettingsStore.setState({ groupChatsExpanded: false } as any);
 
 			const deps = makeDeps();
-			const { result } = renderHook(() => useCycleSession(deps));
 
-			act(() => {
-				result.current.cycleSession('prev');
-			});
+			cycleSession('prev', deps);
 
 			expect(useSessionStore.getState().activeSessionId).toBe('a');
 			expect(useSessionStore.getState().cyclePosition).toBe(0);
@@ -1839,11 +1658,8 @@ describe('useCycleSession', () => {
 			useSettingsStore.setState({ groupChatsExpanded: false } as any);
 
 			const deps = makeDeps();
-			const { result } = renderHook(() => useCycleSession(deps));
 
-			act(() => {
-				result.current.cycleSession('next');
-			});
+			cycleSession('next', deps);
 
 			// Alpha → Gamma (skips Beta which has no unread)
 			expect(useSessionStore.getState().activeSessionId).toBe('c');
@@ -1867,11 +1683,8 @@ describe('useCycleSession', () => {
 			useSettingsStore.setState({ groupChatsExpanded: false } as any);
 
 			const deps = makeDeps();
-			const { result } = renderHook(() => useCycleSession(deps));
 
-			act(() => {
-				result.current.cycleSession('next');
-			});
+			cycleSession('next', deps);
 
 			// Alpha → Beta (busy counts as visible)
 			expect(useSessionStore.getState().activeSessionId).toBe('b');
@@ -1897,12 +1710,9 @@ describe('useCycleSession', () => {
 			useSettingsStore.setState({ groupChatsExpanded: false } as any);
 
 			const deps = makeDeps();
-			const { result } = renderHook(() => useCycleSession(deps));
 
 			// 'a' is active (not unread) → included. Filtered list: [a, b, c]
-			act(() => {
-				result.current.cycleSession('next');
-			});
+			cycleSession('next', deps);
 			expect(useSessionStore.getState().activeSessionId).toBe('b');
 		});
 
@@ -1924,11 +1734,8 @@ describe('useCycleSession', () => {
 			useSettingsStore.setState({ groupChatsExpanded: false } as any);
 
 			const deps = makeDeps();
-			const { result } = renderHook(() => useCycleSession(deps));
 
-			act(() => {
-				result.current.cycleSession('next');
-			});
+			cycleSession('next', deps);
 
 			// Gamma is last unread → wraps to Alpha (active Gamma + unread Alpha + unread Gamma)
 			expect(useSessionStore.getState().activeSessionId).toBe('a');
@@ -1958,11 +1765,8 @@ describe('useCycleSession', () => {
 			useSettingsStore.setState({ groupChatsExpanded: false } as any);
 
 			const deps = makeDeps();
-			const { result } = renderHook(() => useCycleSession(deps));
 
-			act(() => {
-				result.current.cycleSession('next');
-			});
+			cycleSession('next', deps);
 
 			// Other → Parent (parent included because child has unread)
 			expect(useSessionStore.getState().activeSessionId).toBe('p');
@@ -1985,11 +1789,8 @@ describe('useCycleSession', () => {
 			useSettingsStore.setState({ groupChatsExpanded: false } as any);
 
 			const deps = makeDeps();
-			const { result } = renderHook(() => useCycleSession(deps));
 
-			act(() => {
-				result.current.cycleSession('next');
-			});
+			cycleSession('next', deps);
 
 			// All sessions visible — Alpha → Beta
 			expect(useSessionStore.getState().activeSessionId).toBe('b');
@@ -2022,11 +1823,8 @@ describe('useCycleSession', () => {
 
 			// No ownsSession in deps → unscoped, behaves exactly as before.
 			const deps = makeDeps();
-			const { result } = renderHook(() => useCycleSession(deps));
 
-			act(() => {
-				result.current.cycleSession('next');
-			});
+			cycleSession('next', deps);
 			expect(useSessionStore.getState().activeSessionId).toBe('b');
 		});
 
@@ -2045,18 +1843,13 @@ describe('useCycleSession', () => {
 
 			// This window owns Alpha and Gamma, but NOT Beta.
 			const deps = makeDeps({ ownsSession: ownsOnly('a', 'c') });
-			const { result } = renderHook(() => useCycleSession(deps));
 
 			// Scoped visual order: [Alpha, Gamma] — Beta is dropped.
-			act(() => {
-				result.current.cycleSession('next');
-			});
+			cycleSession('next', deps);
 			expect(useSessionStore.getState().activeSessionId).toBe('c');
 
 			// prev from Gamma → Alpha (still skipping Beta).
-			act(() => {
-				result.current.cycleSession('prev');
-			});
+			cycleSession('prev', deps);
 			expect(useSessionStore.getState().activeSessionId).toBe('a');
 		});
 
@@ -2077,12 +1870,9 @@ describe('useCycleSession', () => {
 			// Predicate owns only Alpha; it would return false for the group chat id, but
 			// group chats are not window-owned agents and must stay in the cycle.
 			const deps = makeDeps({ handleOpenGroupChat, ownsSession: ownsOnly('a') });
-			const { result } = renderHook(() => useCycleSession(deps));
 
 			// Visual order: [Alpha, Chat One]; next from Alpha → Chat One.
-			act(() => {
-				result.current.cycleSession('next');
-			});
+			cycleSession('next', deps);
 			expect(handleOpenGroupChat).toHaveBeenCalledWith('gc-1');
 		});
 
@@ -2106,13 +1896,10 @@ describe('useCycleSession', () => {
 
 			// This window owns Parent and Zed, but not the worktree child.
 			const deps = makeDeps({ ownsSession: ownsOnly('p', 'z') });
-			const { result } = renderHook(() => useCycleSession(deps));
 
 			// Unscoped order: [Parent, Child, Zed]; scoped drops Child → [Parent, Zed].
 			// next from Parent → Zed (the child is skipped).
-			act(() => {
-				result.current.cycleSession('next');
-			});
+			cycleSession('next', deps);
 			expect(useSessionStore.getState().activeSessionId).toBe('z');
 		});
 
@@ -2140,13 +1927,10 @@ describe('useCycleSession', () => {
 				activateStarredItem,
 				ownsSession: ownsOnly('a', 'c'),
 			});
-			const { result } = renderHook(() => useCycleSession(deps));
 
 			// Unscoped order: [Star X, Alpha, Gamma]; scoped drops the starred row →
 			// [Alpha, Gamma]. prev from Alpha wraps to Gamma; the starred row is never hit.
-			act(() => {
-				result.current.cycleSession('prev');
-			});
+			cycleSession('prev', deps);
 			expect(activateStarredItem).not.toHaveBeenCalled();
 			expect(useSessionStore.getState().activeSessionId).toBe('c');
 		});
@@ -2165,11 +1949,8 @@ describe('useCycleSession', () => {
 
 			// Window owns nothing → scoped visual order is empty.
 			const deps = makeDeps({ ownsSession: ownsOnly() });
-			const { result } = renderHook(() => useCycleSession(deps));
 
-			act(() => {
-				result.current.cycleSession('next');
-			});
+			cycleSession('next', deps);
 			// Empty visual order → no-op; active session is untouched.
 			expect(useSessionStore.getState().activeSessionId).toBe('a');
 		});
@@ -2191,12 +1972,9 @@ describe('useCycleSession', () => {
 			useSettingsStore.setState({ groupChatsExpanded: false } as any);
 
 			const deps = makeDeps({ ownsSession: ownsOnly('b', 'c') });
-			const { result } = renderHook(() => useCycleSession(deps));
 
 			// Scoped order: [Beta, Gamma]; 'a' not present → first owned item (Beta).
-			act(() => {
-				result.current.cycleSession('next');
-			});
+			cycleSession('next', deps);
 			expect(useSessionStore.getState().activeSessionId).toBe('b');
 			expect(useSessionStore.getState().cyclePosition).toBe(0);
 		});

--- a/src/__tests__/renderer/hooks/useCycleSession.test.ts
+++ b/src/__tests__/renderer/hooks/useCycleSession.test.ts
@@ -45,6 +45,7 @@ import { useGroupChatStore } from '../../../renderer/stores/groupChatStore';
 import { useUIStore } from '../../../renderer/stores/uiStore';
 import { useSettingsStore } from '../../../renderer/stores/settingsStore';
 import type { Session } from '../../../renderer/types';
+import { resetStores } from '../../helpers';
 
 // ============================================================================
 // Helpers
@@ -133,49 +134,12 @@ function makeOpenStarred(parentSessionId: string, tabId: string, displayName: st
 }
 
 // ============================================================================
-// Store reset helpers
-// ============================================================================
-
-const defaultSessionStoreState = {
-	sessions: [],
-	groups: [],
-	activeSessionId: '',
-	cyclePosition: -1,
-};
-
-const defaultGroupChatStoreState = {
-	groupChats: [],
-	activeGroupChatId: null,
-};
-
-const defaultUIStoreState = {
-	leftSidebarOpen: true,
-	bookmarksCollapsed: false,
-	showUnreadAgentsOnly: false,
-	// Cycle reads this for starred-row position tracking; reset so a starred
-	// selection from a prior test doesn't leak into the next.
-	sidebarExtraSelection: null,
-};
-
-const defaultSettingsStoreState = {
-	ungroupedCollapsed: false,
-	groupChatsExpanded: true,
-};
-
-function resetStores() {
-	useSessionStore.setState(defaultSessionStoreState as any);
-	useGroupChatStore.setState(defaultGroupChatStoreState as any);
-	useUIStore.setState(defaultUIStoreState as any);
-	useSettingsStore.setState(defaultSettingsStoreState as any);
-}
-
-// ============================================================================
 // Setup / Teardown
 // ============================================================================
 
 beforeEach(() => {
 	vi.clearAllMocks();
-	resetStores();
+	resetStores(useSessionStore, useGroupChatStore, useUIStore, useSettingsStore);
 });
 
 afterEach(() => {

--- a/src/__tests__/renderer/hooks/useQueueProcessing.test.ts
+++ b/src/__tests__/renderer/hooks/useQueueProcessing.test.ts
@@ -9,6 +9,7 @@
  *   - Startup recovery: sets session + target tab to busy state
  *   - Startup recovery: removes first item from executionQueue
  *   - Startup recovery: calls processQueuedItem for each eligible session
+ *   - Startup recovery: re-scans at timer fire for sessions that become idle during the delay
  *   - Startup recovery: on processing error, re-queues the item and resets to idle
  *   - Startup recovery: skips sessions when sessionsLoaded is false
  *   - Startup recovery: runs only once (ref guard prevents repeat runs)
@@ -766,6 +767,66 @@ describe('startup recovery — happy path', () => {
 		const calledSessionIds = mockAgentStoreProcessQueuedItem.mock.calls.map((call) => call[0]);
 		expect(calledSessionIds).toContain('sess-1');
 		expect(calledSessionIds).toContain('sess-2');
+	});
+
+	it('re-scans at timer fire so a session that becomes idle+runnable during the delay is recovered', async () => {
+		vi.useFakeTimers();
+
+		const tab1 = createTab({ id: 'tab-1' });
+		const item1 = createQueuedItem({ id: 'item-early', tabId: 'tab-1' });
+		const session1 = createSession({
+			id: 'sess-early',
+			state: 'idle',
+			aiTabs: [tab1],
+			activeTabId: 'tab-1',
+			executionQueue: [item1],
+		});
+
+		// Second session is busy at mount — not in the startup snapshot.
+		const tab2 = createTab({ id: 'tab-2' });
+		const item2 = createQueuedItem({ id: 'item-late', tabId: 'tab-2' });
+		const session2Busy = createSession({
+			id: 'sess-late',
+			state: 'busy',
+			aiTabs: [tab2],
+			activeTabId: 'tab-2',
+			executionQueue: [item2],
+		});
+
+		mockSessionStoreState.sessionsLoaded = true;
+		mockSessionStoreState.sessions = [session1, session2Busy];
+		mockGetActiveTab.mockImplementation((session: Session) => session.aiTabs[0]);
+		mockSetSessions.mockImplementation(() => {});
+
+		const { rerender } = renderHook(() => useQueueProcessing(createDeps()));
+
+		// Mid-delay: late session becomes idle with a runnable item. Runtime
+		// recovery bails while startupRecoveryComplete is still false.
+		mockSessionStoreState.sessions = [
+			session1,
+			createSession({
+				id: 'sess-late',
+				state: 'idle',
+				aiTabs: [tab2],
+				activeTabId: 'tab-2',
+				executionQueue: [item2],
+			}),
+		];
+		act(() => {
+			rerender();
+		});
+		expect(mockAgentStoreProcessQueuedItem).not.toHaveBeenCalled();
+
+		await act(async () => {
+			vi.advanceTimersByTime(500);
+			await Promise.resolve();
+		});
+
+		// Timer re-scan must pick up both the original and the late session.
+		expect(mockAgentStoreProcessQueuedItem).toHaveBeenCalledTimes(2);
+		const calledSessionIds = mockAgentStoreProcessQueuedItem.mock.calls.map((call) => call[0]);
+		expect(calledSessionIds).toContain('sess-early');
+		expect(calledSessionIds).toContain('sess-late');
 	});
 
 	it('does not touch sessions without queued items when others are processed', async () => {

--- a/src/__tests__/renderer/hooks/useSessionFilterMode.test.ts
+++ b/src/__tests__/renderer/hooks/useSessionFilterMode.test.ts
@@ -4,6 +4,7 @@ import { useSessionFilterMode } from '../../../renderer/hooks/session/useSession
 import { useUIStore } from '../../../renderer/stores/uiStore';
 import { useSessionStore } from '../../../renderer/stores/sessionStore';
 import type { Session, Group } from '../../../renderer/types';
+import { resetStores } from '../../helpers';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -49,12 +50,9 @@ function makeGroup(overrides: Partial<Group> = {}): Group {
 	};
 }
 
-function resetStores(sessions: Session[] = [], groups: Group[] = []) {
-	useSessionStore.setState({ sessions, groups } as any);
-	useUIStore.setState({
-		sessionFilterOpen: false,
-		bookmarksCollapsed: false,
-	} as any);
+function seedStores(sessions: Session[] = [], groups: Group[] = []) {
+	resetStores(useSessionStore, useUIStore);
+	useSessionStore.setState({ sessions, groups });
 }
 
 // ---------------------------------------------------------------------------
@@ -64,7 +62,7 @@ function resetStores(sessions: Session[] = [], groups: Group[] = []) {
 describe('useSessionFilterMode', () => {
 	beforeEach(() => {
 		idCounter = 0;
-		resetStores();
+		seedStores();
 	});
 
 	// -----------------------------------------------------------------------
@@ -96,7 +94,7 @@ describe('useSessionFilterMode', () => {
 		it('collapses all groups on first open (default behavior)', () => {
 			const g1 = makeGroup({ id: 'g1', collapsed: false });
 			const g2 = makeGroup({ id: 'g2', collapsed: false });
-			resetStores([], [g1, g2]);
+			seedStores([], [g1, g2]);
 
 			renderHook(() => useSessionFilterMode());
 
@@ -129,7 +127,7 @@ describe('useSessionFilterMode', () => {
 		it('restores original group collapse states', () => {
 			const g1 = makeGroup({ id: 'g1', collapsed: false });
 			const g2 = makeGroup({ id: 'g2', collapsed: true });
-			resetStores([], [g1, g2]);
+			seedStores([], [g1, g2]);
 
 			renderHook(() => useSessionFilterMode());
 
@@ -182,7 +180,7 @@ describe('useSessionFilterMode', () => {
 		it('remembers user changes to group states across filter open/close cycles', () => {
 			const g1 = makeGroup({ id: 'g1', collapsed: false });
 			const g2 = makeGroup({ id: 'g2', collapsed: false });
-			resetStores([], [g1, g2]);
+			seedStores([], [g1, g2]);
 
 			renderHook(() => useSessionFilterMode());
 
@@ -226,7 +224,7 @@ describe('useSessionFilterMode', () => {
 			const g2 = makeGroup({ id: 'g2', collapsed: true });
 			const s1 = makeSession({ name: 'API Work', groupId: 'g1' });
 			const s2 = makeSession({ name: 'UI Work', groupId: 'g2' });
-			resetStores([s1, s2], [g1, g2]);
+			seedStores([s1, s2], [g1, g2]);
 
 			// Open filter first
 			act(() => {
@@ -247,7 +245,7 @@ describe('useSessionFilterMode', () => {
 
 		it('expands bookmarks when matching bookmarked sessions exist', () => {
 			const s1 = makeSession({ name: 'API Work', bookmarked: true });
-			resetStores([s1]);
+			seedStores([s1]);
 			useUIStore.setState({ bookmarksCollapsed: true } as any);
 
 			// Open filter
@@ -266,7 +264,7 @@ describe('useSessionFilterMode', () => {
 
 		it('collapses all groups when filter is cleared but input is still open', () => {
 			const g1 = makeGroup({ id: 'g1', collapsed: false });
-			resetStores([makeSession({ name: 'Test', groupId: 'g1' })], [g1]);
+			seedStores([makeSession({ name: 'Test', groupId: 'g1' })], [g1]);
 
 			// Open filter
 			act(() => {
@@ -293,7 +291,7 @@ describe('useSessionFilterMode', () => {
 				groupId: 'g1',
 				aiTabs: [{ name: 'refactoring-session' } as any],
 			});
-			resetStores([s1], [g1]);
+			seedStores([s1], [g1]);
 
 			// Open filter
 			act(() => {

--- a/src/__tests__/renderer/stores/agentStore.test.ts
+++ b/src/__tests__/renderer/stores/agentStore.test.ts
@@ -13,6 +13,7 @@ import type { ProcessQueuedItemDeps } from '../../../renderer/stores/agentStore'
 import { useSessionStore } from '../../../renderer/stores/sessionStore';
 import type { Session, AgentConfig, QueuedItem } from '../../../renderer/types';
 import { createMockSession as baseCreateMockSession } from '../../helpers/mockSession';
+import { resetStores } from '../../helpers';
 
 // ============================================================================
 // Helpers
@@ -111,24 +112,8 @@ vi.mock('../../../renderer/utils/templateVariables', () => ({
 	substituteTemplateVariables: vi.fn((template: string) => template),
 }));
 
-function resetStores() {
-	useAgentStore.setState({
-		availableAgents: [],
-		agentsDetected: false,
-	});
-	useSessionStore.setState({
-		sessions: [],
-		groups: [],
-		activeSessionId: '',
-		sessionsLoaded: false,
-		initialLoadComplete: false,
-		removedWorktreePaths: new Set(),
-		cyclePosition: -1,
-	});
-}
-
-beforeEach(async () => {
-	resetStores();
+beforeEach(() => {
+	resetStores(useAgentStore, useSessionStore);
 	vi.clearAllMocks();
 });
 
@@ -1163,7 +1148,7 @@ describe('agentStore', () => {
 			expect(useAgentStore.getState().agentsDetected).toBe(true);
 
 			// Reset
-			resetStores();
+			resetStores(useAgentStore, useSessionStore);
 
 			expect(useAgentStore.getState().availableAgents).toEqual([]);
 			expect(useAgentStore.getState().agentsDetected).toBe(false);
@@ -1176,7 +1161,7 @@ describe('agentStore', () => {
 			useAgentStore.getState().clearAgentError('session-1');
 
 			// Reset
-			resetStores();
+			resetStores(useAgentStore, useSessionStore);
 
 			// Set up again and use
 			const newSession = createMockSession({ id: 'session-2', state: 'error' });

--- a/src/__tests__/renderer/stores/groupChatStore.test.ts
+++ b/src/__tests__/renderer/stores/groupChatStore.test.ts
@@ -17,6 +17,7 @@ import type {
 } from '../../../renderer/stores/groupChatStore';
 import type { GroupChat, GroupChatMessage, GroupChatState } from '../../../renderer/types';
 import type { QueuedItem } from '../../../renderer/types';
+import { resetStore } from '../../helpers';
 
 // ============================================================================
 // Helpers
@@ -62,32 +63,12 @@ function createMockError(overrides: Partial<GroupChatErrorState> = {}): GroupCha
 	} as GroupChatErrorState;
 }
 
-function resetStore() {
-	useGroupChatStore.setState({
-		groupChats: [],
-		activeGroupChatId: null,
-		groupChatMessages: [],
-		groupChatState: 'idle',
-		participantStates: new Map(),
-		moderatorUsage: null,
-		groupChatStates: new Map(),
-		allGroupChatParticipantStates: new Map(),
-		groupChatExecutionQueue: [],
-		groupChatReadOnlyMode: false,
-		groupChatRightTab: 'participants',
-		groupChatParticipantColors: {},
-		groupChatStagedImages: [],
-		groupChatError: null,
-		initiatorWindowId: null,
-	});
-}
-
 // ============================================================================
 // Setup
 // ============================================================================
 
 beforeEach(() => {
-	resetStore();
+	resetStore(useGroupChatStore);
 });
 
 // ============================================================================
@@ -587,7 +568,7 @@ describe('groupChatStore', () => {
 			useGroupChatStore.getState().setInitiatorWindowId('window-1');
 
 			// Reset
-			resetStore();
+			resetStore(useGroupChatStore);
 
 			// Verify all fields are at defaults
 			const state = useGroupChatStore.getState();

--- a/src/__tests__/renderer/stores/sessionStore.test.ts
+++ b/src/__tests__/renderer/stores/sessionStore.test.ts
@@ -7,7 +7,7 @@ import {
 	selectSessionById,
 } from '../../../renderer/stores/sessionStore';
 import type { Session, Group, FilePreviewTab } from '../../../renderer/types';
-import { createMockSession } from '../../helpers/mockSession';
+import { createMockSession, resetStore } from '../../helpers';
 
 // ============================================================================
 // Test Helpers
@@ -43,29 +43,13 @@ function createMockGroup(overrides: Partial<Group> = {}): Group {
 	};
 }
 
-/**
- * Reset the Zustand store to initial state between tests.
- * Zustand stores are singletons, so state persists across tests unless explicitly reset.
- */
-function resetStore() {
-	useSessionStore.setState({
-		sessions: [],
-		groups: [],
-		activeSessionId: '',
-		sessionsLoaded: false,
-		initialLoadComplete: false,
-		removedWorktreePaths: new Set(),
-		cyclePosition: -1,
-	});
-}
-
 // ============================================================================
 // Tests
 // ============================================================================
 
 describe('sessionStore', () => {
 	beforeEach(() => {
-		resetStore();
+		resetStore(useSessionStore);
 	});
 
 	// ========================================================================

--- a/src/__tests__/renderer/stores/uiStore.test.ts
+++ b/src/__tests__/renderer/stores/uiStore.test.ts
@@ -1,36 +1,11 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useUIStore } from '../../../renderer/stores/uiStore';
-
-/**
- * Reset the Zustand store to initial state between tests.
- * Zustand stores are singletons, so state persists across tests unless explicitly reset.
- */
-function resetStore() {
-	useUIStore.setState({
-		leftSidebarOpen: true,
-		rightPanelOpen: true,
-		activeFocus: 'main',
-		activeRightTab: 'files',
-		bookmarksCollapsed: false,
-		showUnreadOnly: false,
-		showUnreadAgentsOnly: false,
-		preFilterActiveTabId: null,
-		preTerminalFileTabId: null,
-		selectedSidebarIndex: 0,
-		outputSearchByKey: {},
-		sessionFilterOpen: false,
-		historySearchFilterOpen: false,
-		draggingSessionId: null,
-		editingGroupId: null,
-		editingSessionId: null,
-		usageDashboardViewMode: 'overview',
-	});
-}
+import { resetStore } from '../../helpers';
 
 describe('uiStore', () => {
 	beforeEach(() => {
-		resetStore();
+		resetStore(useUIStore);
 	});
 
 	describe('initial state', () => {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -2179,7 +2179,8 @@ function MaestroConsoleInner() {
 	// Restart-when-idle — installs a downloaded update once the app is idle
 	useRestartWhenIdle();
 
-	// Queue processing (execution, startup recovery) — extracted to useQueueProcessing hook
+	// Queue processing — narrow idle-queue signature (not full sessions) so
+	// streaming updates do not re-render MaestroConsoleInner
 	const { processQueuedItem } = useQueueProcessing({
 		conductorProfile,
 		customAICommandsRef,

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -2036,7 +2036,7 @@ function MaestroConsoleInner() {
 		ownsSession,
 	});
 
-	// cycleSession — provided by useCycleSession hook
+	// cycleSession — event-time getState() via useCycleSession (no store subscriptions)
 	const { cycleSession } = useCycleSession({
 		sortedSessions,
 		handleOpenGroupChat,

--- a/src/renderer/hooks/agent/index.ts
+++ b/src/renderer/hooks/agent/index.ts
@@ -115,7 +115,7 @@ export { useQueueHandlers } from './useQueueHandlers';
 export type { UseQueueHandlersReturn } from './useQueueHandlers';
 
 // Queue processing (execution queue processing and startup recovery)
-export { useQueueProcessing } from './useQueueProcessing';
+export { useQueueProcessing, selectIdleQueuedSignature } from './useQueueProcessing';
 export type { UseQueueProcessingDeps, UseQueueProcessingReturn } from './useQueueProcessing';
 
 // Agent configuration state management (detection, config, models, SSH)

--- a/src/renderer/hooks/agent/useQueueProcessing.ts
+++ b/src/renderer/hooks/agent/useQueueProcessing.ts
@@ -6,7 +6,13 @@
  *   - Maintains processQueuedItemRef for batch exit handler
  *   - Recovers stuck queued items from previous app session on startup
  *
- * Reads from: sessionStore (sessionsLoaded, sessions), agentStore, settingsStore
+ * PERF: Does not subscribe to the full `sessions` array. A compact
+ * `idleQueuedSignature` string only changes when an idle session gains or
+ * loses a runnable queue item, so MaestroConsoleInner is not re-rendered on
+ * log/token/busy streaming updates. Session objects are read via getState()
+ * inside effects at event time.
+ *
+ * Reads from: sessionStore (sessionsLoaded, idle-queue signature), agentStore
  */
 
 import { useEffect, useRef, useCallback } from 'react';
@@ -17,6 +23,7 @@ import type {
 	SpecKitCommand,
 	OpenSpecCommand,
 	BmadCommand,
+	Session,
 } from '../../types';
 import { useSessionStore } from '../../stores/sessionStore';
 import { useAgentStore } from '../../stores/agentStore';
@@ -59,43 +66,52 @@ export interface UseQueueProcessingReturn {
 }
 
 // ============================================================================
+// Selectors
+// ============================================================================
+
+/**
+ * Stable string that changes only when the set of idle sessions with a
+ * runnable queue item changes (session id + next runnable item id).
+ */
+export function selectIdleQueuedSignature(state: { sessions: Session[] }): string {
+	return state.sessions
+		.filter((sess) => sess.state === 'idle' && hasRunnableQueueItem(sess.executionQueue ?? []))
+		.map((sess) => {
+			const item = nextRunnableQueueItem(sess.executionQueue ?? []);
+			return `${sess.id}:${item?.id ?? ''}`;
+		})
+		.join('|');
+}
+
+// ============================================================================
 // Hook implementation
 // ============================================================================
 
 export function useQueueProcessing(deps: UseQueueProcessingDeps): UseQueueProcessingReturn {
-	const {
-		conductorProfile,
-		customAICommandsRef,
-		speckitCommandsRef,
-		openspecCommandsRef,
-		bmadCommandsRef,
-	} = deps;
+	const depsRef = useRef(deps);
+	depsRef.current = deps;
 
-	// --- Reactive subscriptions ---
+	// --- Narrow reactive subscriptions (not the full sessions array) ---
 	const sessionsLoaded = useSessionStore((s) => s.sessionsLoaded);
-	const sessions = useSessionStore((s) => s.sessions);
-
-	// --- Store actions (stable via getState) ---
-	const { setSessions } = useSessionStore.getState();
+	const idleQueuedSignature = useSessionStore(selectIdleQueuedSignature);
 
 	// --- Refs ---
 	const processQueuedItemRef = useRef<
 		((sessionId: string, item: QueuedItem) => Promise<void>) | null
 	>(null);
 
-	// Process a queued item - delegates to agentStore action
-	const processQueuedItem = useCallback(
-		async (sessionId: string, item: QueuedItem) => {
-			await useAgentStore.getState().processQueuedItem(sessionId, item, {
-				conductorProfile,
-				customAICommands: customAICommandsRef.current ?? [],
-				speckitCommands: speckitCommandsRef.current ?? [],
-				openspecCommands: openspecCommandsRef.current ?? [],
-				bmadCommands: bmadCommandsRef?.current ?? [],
-			});
-		},
-		[conductorProfile, bmadCommandsRef]
-	);
+	// Process a queued item - delegates to agentStore action.
+	// Stable identity: conductor profile + command refs read from depsRef.
+	const processQueuedItem = useCallback(async (sessionId: string, item: QueuedItem) => {
+		const d = depsRef.current;
+		await useAgentStore.getState().processQueuedItem(sessionId, item, {
+			conductorProfile: d.conductorProfile,
+			customAICommands: d.customAICommandsRef.current ?? [],
+			speckitCommands: d.speckitCommandsRef.current ?? [],
+			openspecCommands: d.openspecCommandsRef.current ?? [],
+			bmadCommands: d.bmadCommandsRef?.current ?? [],
+		});
+	}, []);
 
 	// Update ref for processQueuedItem so batch exit handler can use it
 	processQueuedItemRef.current = processQueuedItem;
@@ -104,6 +120,8 @@ export function useQueueProcessing(deps: UseQueueProcessingDeps): UseQueueProces
 	// Shared by startup recovery and runtime queue recovery.
 	const dispatchQueuedItem = useCallback(
 		(session: { id: string; executionQueue: QueuedItem[] }) => {
+			const { setSessions } = useSessionStore.getState();
+
 			// Skip paused items: dispatch the first runnable one. If all items are
 			// held, there's nothing to do.
 			const firstItem = nextRunnableQueueItem(session.executionQueue);
@@ -160,7 +178,7 @@ export function useQueueProcessing(deps: UseQueueProcessingDeps): UseQueueProces
 			processQueuedItem(session.id, firstItem).catch((err) => {
 				console.error(`[QueueProcessing] Failed for session ${session.id}:`, err);
 				// Reset session busy state and re-queue the failed item so it isn't lost
-				setSessions((prev) =>
+				useSessionStore.getState().setSessions((prev) =>
 					prev.map((s) => {
 						if (s.id !== session.id) return s;
 						return {
@@ -183,7 +201,7 @@ export function useQueueProcessing(deps: UseQueueProcessingDeps): UseQueueProces
 				);
 			});
 		},
-		[processQueuedItem, setSessions]
+		[processQueuedItem]
 	);
 
 	// Process any queued items left over from previous session (after app restart)
@@ -195,6 +213,7 @@ export function useQueueProcessing(deps: UseQueueProcessingDeps): UseQueueProces
 		if (!sessionsLoaded || startupRecoveryRan.current) return;
 		startupRecoveryRan.current = true;
 
+		const sessions = useSessionStore.getState().sessions;
 		const sessionsWithQueuedItems = sessions.filter(
 			(s) => s.state === 'idle' && hasRunnableQueueItem(s.executionQueue ?? [])
 		);
@@ -225,7 +244,7 @@ export function useQueueProcessing(deps: UseQueueProcessingDeps): UseQueueProces
 			// No startup items to process — runtime recovery can start immediately
 			startupRecoveryComplete.current = true;
 		}
-	}, [sessionsLoaded, sessions, dispatchQueuedItem]);
+	}, [sessionsLoaded, dispatchQueuedItem]);
 
 	// Runtime queue recovery: process queued items when sessions transition to idle
 	// while items remain in the queue. This handles cases where onExit skipped queue
@@ -240,9 +259,13 @@ export function useQueueProcessing(deps: UseQueueProcessingDeps): UseQueueProces
 	// limit isn't in the queue, so it's captured separately as
 	// `recoveryAction.lastUserPrompt` in useAgentErrorListener for the coordinator
 	// to re-fire.
+	//
+	// Triggered by idleQueuedSignature (not full sessions) so streaming updates
+	// do not re-enter this effect or re-render MaestroConsoleInner.
 	useEffect(() => {
 		if (!sessionsLoaded || !startupRecoveryComplete.current) return;
 
+		const sessions = useSessionStore.getState().sessions;
 		for (const session of sessions) {
 			if (session.state === 'idle' && hasRunnableQueueItem(session.executionQueue ?? [])) {
 				console.log(
@@ -251,7 +274,7 @@ export function useQueueProcessing(deps: UseQueueProcessingDeps): UseQueueProces
 				dispatchQueuedItem(session);
 			}
 		}
-	}, [sessionsLoaded, sessions, dispatchQueuedItem]);
+	}, [sessionsLoaded, idleQueuedSignature, dispatchQueuedItem]);
 
 	return {
 		processQueuedItem,

--- a/src/renderer/hooks/agent/useQueueProcessing.ts
+++ b/src/renderer/hooks/agent/useQueueProcessing.ts
@@ -214,18 +214,28 @@ export function useQueueProcessing(deps: UseQueueProcessingDeps): UseQueueProces
 		startupRecoveryRan.current = true;
 
 		const sessions = useSessionStore.getState().sessions;
-		const sessionsWithQueuedItems = sessions.filter(
+		const hasStartupItems = sessions.some(
 			(s) => s.state === 'idle' && hasRunnableQueueItem(s.executionQueue ?? [])
 		);
 
-		if (sessionsWithQueuedItems.length > 0) {
+		if (hasStartupItems) {
 			logger.info(
-				`[QueueProcessing] Found ${sessionsWithQueuedItems.length} session(s) with leftover queued items from previous session`
+				`[QueueProcessing] Found idle session(s) with leftover queued items from previous session`
 			);
 
-			// Delay to ensure all refs and handlers are set up
+			// Delay to ensure all refs and handlers are set up. Re-scan at fire
+			// time (do not close over the mount-time list): a session can become
+			// idle+runnable during the 500ms window, and the runtime-recovery
+			// effect may have already bailed while startupRecoveryComplete was
+			// false with a settled signature, so it would never retry. The old
+			// full-sessions subscription masked that; the narrow signature does not.
 			const startupTimerId = setTimeout(() => {
-				sessionsWithQueuedItems.forEach((session) => {
+				const toRecover = useSessionStore
+					.getState()
+					.sessions.filter(
+						(s) => s.state === 'idle' && hasRunnableQueueItem(s.executionQueue ?? [])
+					);
+				toRecover.forEach((session) => {
 					logger.info(
 						`[QueueProcessing] Startup recovery for session ${session.id.substring(0, 8)}:`,
 						undefined,

--- a/src/renderer/hooks/session/index.ts
+++ b/src/renderer/hooks/session/index.ts
@@ -53,8 +53,12 @@ export { useSessionCrud } from './useSessionCrud';
 export type { UseSessionCrudDeps, UseSessionCrudReturn } from './useSessionCrud';
 
 // Session cycling (Cmd+Shift+[/])
-export { useCycleSession } from './useCycleSession';
-export type { UseCycleSessionDeps, UseCycleSessionReturn } from './useCycleSession';
+export { useCycleSession, cycleSession } from './useCycleSession';
+export type {
+	CycleSessionDeps,
+	UseCycleSessionDeps,
+	UseCycleSessionReturn,
+} from './useCycleSession';
 
 // Starred Sessions list + activation (Left Bar section, shared with cycling)
 export { useStarredItems } from './useStarredItems';

--- a/src/renderer/hooks/session/index.ts
+++ b/src/renderer/hooks/session/index.ts
@@ -54,11 +54,7 @@ export type { UseSessionCrudDeps, UseSessionCrudReturn } from './useSessionCrud'
 
 // Session cycling (Cmd+Shift+[/])
 export { useCycleSession, cycleSession } from './useCycleSession';
-export type {
-	CycleSessionDeps,
-	UseCycleSessionDeps,
-	UseCycleSessionReturn,
-} from './useCycleSession';
+export type { CycleSessionDeps, UseCycleSessionReturn } from './useCycleSession';
 
 // Starred Sessions list + activation (Left Bar section, shared with cycling)
 export { useStarredItems } from './useStarredItems';

--- a/src/renderer/hooks/session/useCycleSession.ts
+++ b/src/renderer/hooks/session/useCycleSession.ts
@@ -1,29 +1,33 @@
 /**
- * useCycleSession — extracted from App.tsx
+ * cycleSession — Cmd+Shift+[/] agent / group-chat cycling.
  *
- * Provides session cycling functionality (Cmd+Shift+[/]):
- *   - Cycles through sessions and group chats in visual sidebar order
- *   - Handles bookmarks (sessions appearing in both locations)
- *   - Handles worktree children, collapsed groups, collapsed sidebar
- *   - Handles group chat cycling
+ * PERF: All store reads happen at event time via `getState()`. No React
+ * subscriptions, so MaestroConsoleInner does not re-render when sessions,
+ * groups, or UI layout change. A thin `useCycleSession` wrapper keeps a
+ * stable callback identity for the keyboard handler.
+ *
+ * Cycles through sessions and group chats in visual Left Bar order:
+ *   - Bookmarks (sessions can appear in both bookmark + regular location)
+ *   - Worktree children, collapsed groups, collapsed sidebar
+ *   - Group chats and starred rows
  *
  * Reads from: sessionStore, groupChatStore, uiStore, settingsStore
  */
 
-import { useCallback } from 'react';
+import { useCallback, useRef } from 'react';
 import type { Session } from '../../types';
 import { useSessionStore } from '../../stores/sessionStore';
 import { useGroupChatStore } from '../../stores/groupChatStore';
 import { useUIStore } from '../../stores/uiStore';
 import { useSettingsStore } from '../../stores/settingsStore';
-import { compareNamesIgnoringEmojis } from '../session/useSortedSessions';
+import { compareNamesIgnoringEmojis } from './useSortedSessions';
 import type { StarredItem } from './useStarredItems';
 
 // ============================================================================
-// Dependencies interface
+// Dependencies
 // ============================================================================
 
-export interface UseCycleSessionDeps {
+export interface CycleSessionDeps {
 	/** Sorted sessions array (used when sidebar is collapsed) */
 	sortedSessions: Session[];
 	/** Open a group chat (loads messages etc.) */
@@ -57,20 +61,28 @@ export interface UseCycleSessionDeps {
 	ownsSession?: (sessionId: string) => boolean;
 }
 
-// ============================================================================
-// Return type
-// ============================================================================
+/** @deprecated Prefer {@link CycleSessionDeps} */
+export type UseCycleSessionDeps = CycleSessionDeps;
 
 export interface UseCycleSessionReturn {
 	/** Cycle to next or previous session/group chat in visual order */
 	cycleSession: (dir: 'next' | 'prev') => void;
 }
 
+type VisualOrderItem =
+	| { type: 'session'; id: string; name: string; navKey: string }
+	| { type: 'groupChat'; id: string; name: string }
+	| { type: 'starred'; id: string; name: string; starredKey: string };
+
 // ============================================================================
-// Hook implementation
+// Event-time implementation (no React)
 // ============================================================================
 
-export function useCycleSession(deps: UseCycleSessionDeps): UseCycleSessionReturn {
+/**
+ * Cycle to the next or previous agent / group chat / starred row in visual
+ * Left Bar order. Reads all store state at call time.
+ */
+export function cycleSession(dir: 'next' | 'prev', deps: CycleSessionDeps): void {
 	const {
 		sortedSessions,
 		handleOpenGroupChat,
@@ -80,322 +92,302 @@ export function useCycleSession(deps: UseCycleSessionDeps): UseCycleSessionRetur
 		ownsSession,
 	} = deps;
 
-	// --- Reactive subscriptions ---
-	const sessions = useSessionStore((s) => s.sessions);
-	const groups = useSessionStore((s) => s.groups);
-	const activeSessionId = useSessionStore((s) => s.activeSessionId);
-	// cyclePosition tracks where we are in the visual order for cycling
-	const groupChats = useGroupChatStore((s) => s.groupChats);
-	const activeGroupChatId = useGroupChatStore((s) => s.activeGroupChatId);
-	const leftSidebarOpen = useUIStore((s) => s.leftSidebarOpen);
-	const bookmarksCollapsed = useUIStore((s) => s.bookmarksCollapsed);
-	const showUnreadAgentsOnly = useUIStore((s) => s.showUnreadAgentsOnly);
+	const {
+		sessions,
+		groups,
+		activeSessionId,
+		cyclePosition,
+		setActiveSessionIdInternal,
+		setCyclePosition,
+	} = useSessionStore.getState();
+	const { groupChats, activeGroupChatId, setActiveGroupChatId } = useGroupChatStore.getState();
+	const {
+		leftSidebarOpen,
+		bookmarksCollapsed,
+		showUnreadAgentsOnly,
+		sidebarExtraSelection,
+		setSidebarExtraSelection,
+		setSelectedSidebarIndex,
+	} = useUIStore.getState();
+	const { ungroupedCollapsed, groupChatsExpanded, starredSessionsCollapsed } =
+		useSettingsStore.getState();
 
-	// --- Store actions (stable via getState) ---
-	const { setActiveSessionIdInternal, setCyclePosition } = useSessionStore.getState();
-	const { setActiveGroupChatId } = useGroupChatStore.getState();
-	const { setSidebarExtraSelection, setSelectedSidebarIndex } = useUIStore.getState();
+	// Build the visual order of items as they appear in the sidebar.
+	// This matches the actual rendering order in SessionList.tsx:
+	// 1. Starred Sessions section (if shown + expanded) - sorted by display name
+	// 2. Bookmarks section (if open) - sorted alphabetically
+	// 3. Groups (sorted alphabetically) - each with sessions sorted alphabetically
+	// 4. Ungrouped sessions - sorted alphabetically
+	// 5. Group Chats section (if expanded) - sorted alphabetically
+	//
+	// A bookmarked session visually appears in BOTH the bookmarks section AND its
+	// regular location (group or ungrouped). The same session can appear twice in
+	// the visual order. We track the current position with cyclePosition to
+	// allow cycling through duplicate occurrences correctly.
+	//
+	// Starred rows are similar: a starred row's `id` is its parent agent's session
+	// id, so the same agent can appear in the starred section AND its regular
+	// location. cyclePosition keeps the two occurrences distinct.
 
-	// --- Settings ---
-	const ungroupedCollapsed = useSettingsStore((s) => s.ungroupedCollapsed);
-	const groupChatsExpanded = useSettingsStore((s) => s.groupChatsExpanded);
-	const starredSectionCollapsed = useSettingsStore((s) => s.starredSessionsCollapsed);
+	const visualOrder: VisualOrderItem[] = [];
 
-	const cycleSession = useCallback(
-		(dir: 'next' | 'prev') => {
-			// Build the visual order of items as they appear in the sidebar.
-			// This matches the actual rendering order in SessionList.tsx:
-			// 1. Starred Sessions section (if shown + expanded) - sorted by display name
-			// 2. Bookmarks section (if open) - sorted alphabetically
-			// 3. Groups (sorted alphabetically) - each with sessions sorted alphabetically
-			// 4. Ungrouped sessions - sorted alphabetically
-			// 5. Group Chats section (if expanded) - sorted alphabetically
-			//
-			// A bookmarked session visually appears in BOTH the bookmarks section AND its
-			// regular location (group or ungrouped). The same session can appear twice in
-			// the visual order. We track the current position with cyclePosition to
-			// allow cycling through duplicate occurrences correctly.
-			//
-			// Starred rows are similar: a starred row's `id` is its parent agent's session
-			// id, so the same agent can appear in the starred section AND its regular
-			// location. cyclePosition keeps the two occurrences distinct.
+	// Helper to get worktree children for a session.
+	// Sort by `name` to match the agent name shown in the Left Bar (SessionItem
+	// renders `session.name` as the primary label; `worktreeBranch` is only a subtitle).
+	// Sorting by branch name would make Cmd+Shift+[/] cycling bounce around relative
+	// to the visible alphabetical order.
+	const getWorktreeChildren = (parentId: string) =>
+		sessions
+			.filter((s) => s.parentSessionId === parentId)
+			.sort((a, b) => compareNamesIgnoringEmojis(a.name, b.name));
 
-			// Visual order item can be a session, a group chat, or a starred row.
-			// `navKey` on session entries maps the entry to its exact row in
-			// navSessions (via navIndexMap), so activating it can highlight/scroll the
-			// SAME occurrence the cycle landed on. Without it the render falls back to
-			// navSessions.findIndex (first occurrence), which for a bookmarked agent is
-			// its bookmark row at the top - making the panel jump up when you cycle onto
-			// the agent's group/ungrouped occurrence below.
-			type VisualOrderItem =
-				| { type: 'session'; id: string; name: string; navKey: string }
-				| { type: 'groupChat'; id: string; name: string }
-				| { type: 'starred'; id: string; name: string; starredKey: string };
+	// Helper to add session with its worktree children to visual order.
+	// keyPrefix selects the navIndexMap namespace for this occurrence
+	// ('bookmark' | `group:${groupId}` | 'ungrouped'), matching the keys built
+	// in useSortedSessions.
+	const addSessionWithWorktrees = (session: Session, keyPrefix: string) => {
+		// Skip worktree children - they're added with their parent
+		if (session.parentSessionId) return;
 
-			const visualOrder: VisualOrderItem[] = [];
+		visualOrder.push({
+			type: 'session' as const,
+			id: session.id,
+			name: session.name,
+			navKey: `${keyPrefix}:${session.id}`,
+		});
 
-			// Helper to get worktree children for a session.
-			// Sort by `name` to match the agent name shown in the Left Bar (SessionItem
-			// renders `session.name` as the primary label; `worktreeBranch` is only a subtitle).
-			// Sorting by branch name would make Cmd+Shift+[/] cycling bounce around relative
-			// to the visible alphabetical order.
-			const getWorktreeChildren = (parentId: string) =>
-				sessions
-					.filter((s) => s.parentSessionId === parentId)
-					.sort((a, b) => compareNamesIgnoringEmojis(a.name, b.name));
-
-			// Helper to add session with its worktree children to visual order.
-			// keyPrefix selects the navIndexMap namespace for this occurrence
-			// ('bookmark' | `group:${groupId}` | 'ungrouped'), matching the keys built
-			// in useSortedSessions.
-			const addSessionWithWorktrees = (session: Session, keyPrefix: string) => {
-				// Skip worktree children - they're added with their parent
-				if (session.parentSessionId) return;
-
-				visualOrder.push({
+		// Add worktree children if expanded
+		if (session.worktreesExpanded !== false) {
+			const children = getWorktreeChildren(session.id);
+			visualOrder.push(
+				...children.map((s) => ({
 					type: 'session' as const,
-					id: session.id,
-					name: session.name,
-					navKey: `${keyPrefix}:${session.id}`,
-				});
+					id: s.id,
+					name: s.name,
+					navKey: `${keyPrefix}:wt:${s.id}`,
+				}))
+			);
+		}
+	};
 
-				// Add worktree children if expanded
-				if (session.worktreesExpanded !== false) {
-					const children = getWorktreeChildren(session.id);
-					visualOrder.push(
-						...children.map((s) => ({
-							type: 'session' as const,
-							id: s.id,
-							name: s.name,
-							navKey: `${keyPrefix}:wt:${s.id}`,
-						}))
-					);
-				}
-			};
+	if (leftSidebarOpen) {
+		// Starred Sessions section (if shown, expanded, and non-empty). Hidden
+		// while the unread-agents filter is active, mirroring SessionList which
+		// drops the section under that filter. starredItems is already sorted by
+		// display name to match the rendered order.
+		if (!starredSessionsCollapsed && !showUnreadAgentsOnly && starredItems.length > 0) {
+			visualOrder.push(
+				...starredItems.map((item) => ({
+					type: 'starred' as const,
+					id: item.parentSessionId,
+					name: item.displayName,
+					starredKey: item.key,
+				}))
+			);
+		}
 
-			if (leftSidebarOpen) {
-				// Starred Sessions section (if shown, expanded, and non-empty). Hidden
-				// while the unread-agents filter is active, mirroring SessionList which
-				// drops the section under that filter. starredItems is already sorted by
-				// display name to match the rendered order.
-				if (!starredSectionCollapsed && !showUnreadAgentsOnly && starredItems.length > 0) {
-					visualOrder.push(
-						...starredItems.map((item) => ({
-							type: 'starred' as const,
-							id: item.parentSessionId,
-							name: item.displayName,
-							starredKey: item.key,
-						}))
-					);
-				}
+		// Bookmarks section (if expanded and has bookmarked sessions)
+		if (!bookmarksCollapsed) {
+			const bookmarkedSessions = sessions
+				.filter((s) => s.bookmarked && !s.parentSessionId)
+				.sort((a, b) => compareNamesIgnoringEmojis(a.name, b.name));
+			bookmarkedSessions.forEach((s) => addSessionWithWorktrees(s, 'bookmark'));
+		}
 
-				// Bookmarks section (if expanded and has bookmarked sessions)
-				if (!bookmarksCollapsed) {
-					const bookmarkedSessions = sessions
-						.filter((s) => s.bookmarked && !s.parentSessionId)
-						.sort((a, b) => compareNamesIgnoringEmojis(a.name, b.name));
-					bookmarkedSessions.forEach((s) => addSessionWithWorktrees(s, 'bookmark'));
-				}
-
-				// Groups (sorted alphabetically), with each group's sessions
-				const sortedGroups = [...groups].sort((a, b) => compareNamesIgnoringEmojis(a.name, b.name));
-				for (const group of sortedGroups) {
-					if (!group.collapsed) {
-						const groupSessions = sessions
-							.filter((s) => s.groupId === group.id && !s.parentSessionId)
-							.sort((a, b) => compareNamesIgnoringEmojis(a.name, b.name));
-						groupSessions.forEach((s) => addSessionWithWorktrees(s, `group:${group.id}`));
-					}
-				}
-
-				// Ungrouped sessions (sorted alphabetically) - only if not collapsed
-				if (!ungroupedCollapsed) {
-					const ungroupedSessions = sessions
-						.filter((s) => !s.groupId && !s.parentSessionId)
-						.sort((a, b) => compareNamesIgnoringEmojis(a.name, b.name));
-					ungroupedSessions.forEach((s) => addSessionWithWorktrees(s, 'ungrouped'));
-				}
-
-				// Group Chats section (if expanded and has non-archived group chats)
-				const activeGroupChats = groupChats.filter((gc) => !gc.archived);
-				if (groupChatsExpanded && activeGroupChats.length > 0) {
-					const sortedGroupChats = [...activeGroupChats].sort((a, b) =>
-						compareNamesIgnoringEmojis(a.name, b.name)
-					);
-					visualOrder.push(
-						...sortedGroupChats.map((gc) => ({
-							type: 'groupChat' as const,
-							id: gc.id,
-							name: gc.name,
-						}))
-					);
-				}
-			} else {
-				// Sidebar collapsed: cycle through all sessions in their sorted order.
-				// No expanded list is rendered, so the navKey is unused here (left empty
-				// - it won't resolve in navIndexMap and activation skips the highlight set).
-				visualOrder.push(
-					...sortedSessions.map((s) => ({
-						type: 'session' as const,
-						id: s.id,
-						name: s.name,
-						navKey: '',
-					}))
-				);
+		// Groups (sorted alphabetically), with each group's sessions
+		const sortedGroups = [...groups].sort((a, b) => compareNamesIgnoringEmojis(a.name, b.name));
+		for (const group of sortedGroups) {
+			if (!group.collapsed) {
+				const groupSessions = sessions
+					.filter((s) => s.groupId === group.id && !s.parentSessionId)
+					.sort((a, b) => compareNamesIgnoringEmojis(a.name, b.name));
+				groupSessions.forEach((s) => addSessionWithWorktrees(s, `group:${group.id}`));
 			}
+		}
 
-			// When unread filter is active, restrict cycling to unread/busy agents only
-			// (plus the currently active agent so you don't get lost)
-			if (showUnreadAgentsOnly) {
-				const currentActiveId = activeGroupChatId || activeSessionId;
-				const filteredOrder = visualOrder.filter((item) => {
-					// Always keep the currently active item
-					if (item.id === currentActiveId) return true;
-					// Group chats pass through (they have their own unread badges)
-					if (item.type === 'groupChat') return true;
-					// Check if session is unread or busy
-					const session = sessions.find((s) => s.id === item.id);
-					if (!session) return false;
-					if (session.aiTabs?.some((tab) => tab.hasUnread)) return true;
-					if (session.state === 'busy') return true;
-					// Check worktree children for unread/busy
-					const children = sessions.filter((s) => s.parentSessionId === session.id);
-					if (
-						children.some(
-							(child) => child.aiTabs?.some((tab) => tab.hasUnread) || child.state === 'busy'
-						)
-					)
-						return true;
-					return false;
-				});
-				visualOrder.length = 0;
-				visualOrder.push(...filteredOrder);
+		// Ungrouped sessions (sorted alphabetically) - only if not collapsed
+		if (!ungroupedCollapsed) {
+			const ungroupedSessions = sessions
+				.filter((s) => !s.groupId && !s.parentSessionId)
+				.sort((a, b) => compareNamesIgnoringEmojis(a.name, b.name));
+			ungroupedSessions.forEach((s) => addSessionWithWorktrees(s, 'ungrouped'));
+		}
+
+		// Group Chats section (if expanded and has non-archived group chats)
+		const activeGroupChats = groupChats.filter((gc) => !gc.archived);
+		if (groupChatsExpanded && activeGroupChats.length > 0) {
+			const sortedGroupChats = [...activeGroupChats].sort((a, b) =>
+				compareNamesIgnoringEmojis(a.name, b.name)
+			);
+			visualOrder.push(
+				...sortedGroupChats.map((gc) => ({
+					type: 'groupChat' as const,
+					id: gc.id,
+					name: gc.name,
+				}))
+			);
+		}
+	} else {
+		// Sidebar collapsed: cycle through all sessions in their sorted order.
+		// No expanded list is rendered, so the navKey is unused here (left empty
+		// - it won't resolve in navIndexMap and activation skips the highlight set).
+		visualOrder.push(
+			...sortedSessions.map((s) => ({
+				type: 'session' as const,
+				id: s.id,
+				name: s.name,
+				navKey: '',
+			}))
+		);
+	}
+
+	// When unread filter is active, restrict cycling to unread/busy agents only
+	// (plus the currently active agent so you don't get lost)
+	if (showUnreadAgentsOnly) {
+		const currentActiveId = activeGroupChatId || activeSessionId;
+		const filteredOrder = visualOrder.filter((item) => {
+			// Always keep the currently active item
+			if (item.id === currentActiveId) return true;
+			// Group chats pass through (they have their own unread badges)
+			if (item.type === 'groupChat') return true;
+			// Check if session is unread or busy
+			const session = sessions.find((s) => s.id === item.id);
+			if (!session) return false;
+			if (session.aiTabs?.some((tab) => tab.hasUnread)) return true;
+			if (session.state === 'busy') return true;
+			// Check worktree children for unread/busy
+			const children = sessions.filter((s) => s.parentSessionId === session.id);
+			if (
+				children.some(
+					(child) => child.aiTabs?.some((tab) => tab.hasUnread) || child.state === 'busy'
+				)
+			)
+				return true;
+			return false;
+		});
+		visualOrder.length = 0;
+		visualOrder.push(...filteredOrder);
+	}
+
+	// Multi-window: drop agent rows this window does not own so Cmd+[/] cycles
+	// only within the window's own tab strip, never jumping to an agent another
+	// window surfaces. Group chats are not window-owned agents (each renderer
+	// holds all of them), so they stay in the cycle. Null-safe: outside a
+	// WindowProvider `ownsSession` is undefined and every row is kept, preserving
+	// single-window/web/test behaviour. Pure synchronous array work composed with
+	// the unread filter above - cycling stays deterministic (keyboard reliability).
+	if (ownsSession) {
+		const scopedOrder = visualOrder.filter(
+			(item) => item.type === 'groupChat' || ownsSession(item.id)
+		);
+		visualOrder.length = 0;
+		visualOrder.push(...scopedOrder);
+	}
+
+	if (visualOrder.length === 0) return;
+
+	// Determine what is currently active (session or group chat)
+	const currentActiveId = activeGroupChatId || activeSessionId;
+	const currentIsGroupChat = activeGroupChatId !== null;
+
+	// Determine current position in visual order.
+	// A starred row's parent agent == its id, so activating one sets that
+	// agent active (and clobbers cyclePosition via the public setActiveSessionId).
+	// When the cursor is parked on a starred row we therefore track position via
+	// sidebarExtraSelection rather than cyclePosition/findIndex - otherwise a
+	// session occurrence of the same agent would be matched and cycling would get
+	// stuck bouncing onto the same starred row.
+	let currentIndex: number;
+	if (sidebarExtraSelection?.kind === 'starred') {
+		currentIndex = visualOrder.findIndex(
+			(item) => item.type === 'starred' && item.starredKey === sidebarExtraSelection.key
+		);
+	} else {
+		// If cyclePosition is valid and points to our current item, use it.
+		// Otherwise, find the first occurrence of our current item.
+		currentIndex = cyclePosition;
+		if (
+			currentIndex < 0 ||
+			currentIndex >= visualOrder.length ||
+			visualOrder[currentIndex].id !== currentActiveId ||
+			visualOrder[currentIndex].type === 'starred'
+		) {
+			currentIndex = visualOrder.findIndex(
+				(item) =>
+					item.id === currentActiveId &&
+					(currentIsGroupChat ? item.type === 'groupChat' : item.type === 'session')
+			);
+		}
+	}
+
+	// Dispatch activation for a slot in the visual order. A session sets the
+	// active session directly; a group chat loads its messages; a starred row
+	// focuses its tab or resumes its closed session (activateStarredItem sets
+	// the active session itself).
+	const activateVisualItem = (item: VisualOrderItem) => {
+		if (item.type === 'session') {
+			setActiveGroupChatId(null);
+			// Landing on a plain agent clears the non-agent cursor so the agent's
+			// own active highlight is the sole indicator.
+			setSidebarExtraSelection(null);
+			// Highlight + auto-scroll the EXACT occurrence we landed on (e.g. a
+			// bookmarked agent's group row), not the first navSessions occurrence
+			// the sync effect would otherwise pick (its bookmark row up top).
+			const navIdx = navIndexMap.get(item.navKey);
+			if (navIdx !== undefined) setSelectedSidebarIndex(navIdx);
+			setActiveSessionIdInternal(item.id);
+		} else if (item.type === 'starred') {
+			const starred = starredItems.find((s) => s.key === item.starredKey);
+			if (starred) {
+				setActiveGroupChatId(null);
+				// activateStarredItem sets the PARENT agent active (and resets
+				// cyclePosition via the public setter); set the starred cursor AFTER
+				// so it survives and visibly marks the row regardless of focus.
+				void activateStarredItem(starred);
+				setSidebarExtraSelection({ kind: 'starred', key: item.starredKey });
 			}
+		} else {
+			// Group chats have their own active highlight (activeGroupChatId), so the
+			// non-agent cursor is cleared when one is opened.
+			setSidebarExtraSelection(null);
+			handleOpenGroupChat(item.id);
+		}
+	};
 
-			// Multi-window: drop agent rows this window does not own so Cmd+[/] cycles
-			// only within the window's own tab strip, never jumping to an agent another
-			// window surfaces. Group chats are not window-owned agents (each renderer
-			// holds all of them), so they stay in the cycle. Null-safe: outside a
-			// WindowProvider `ownsSession` is undefined and every row is kept, preserving
-			// single-window/web/test behaviour. Pure synchronous array work composed with
-			// the unread filter above - cycling stays deterministic (keyboard reliability).
-			if (ownsSession) {
-				const scopedOrder = visualOrder.filter(
-					(item) => item.type === 'groupChat' || ownsSession(item.id)
-				);
-				visualOrder.length = 0;
-				visualOrder.push(...scopedOrder);
-			}
+	if (currentIndex === -1) {
+		// Current item not visible, select first visible item
+		setCyclePosition(0);
+		activateVisualItem(visualOrder[0]);
+		return;
+	}
 
-			if (visualOrder.length === 0) return;
+	// Move to next/prev in visual order
+	let nextIndex;
+	if (dir === 'next') {
+		nextIndex = currentIndex === visualOrder.length - 1 ? 0 : currentIndex + 1;
+	} else {
+		nextIndex = currentIndex === 0 ? visualOrder.length - 1 : currentIndex - 1;
+	}
 
-			// Determine what is currently active (session or group chat)
-			const currentActiveId = activeGroupChatId || activeSessionId;
-			const currentIsGroupChat = activeGroupChatId !== null;
+	setCyclePosition(nextIndex);
+	activateVisualItem(visualOrder[nextIndex]);
+}
 
-			// Determine current position in visual order.
-			// A starred row's parent agent == its id, so activating one sets that
-			// agent active (and clobbers cyclePosition via the public setActiveSessionId).
-			// When the cursor is parked on a starred row we therefore track position via
-			// sidebarExtraSelection rather than cyclePosition/findIndex - otherwise a
-			// session occurrence of the same agent would be matched and cycling would get
-			// stuck bouncing onto the same starred row.
-			const extraSelection = useUIStore.getState().sidebarExtraSelection;
-			let currentIndex: number;
-			if (extraSelection?.kind === 'starred') {
-				currentIndex = visualOrder.findIndex(
-					(item) => item.type === 'starred' && item.starredKey === extraSelection.key
-				);
-			} else {
-				// If cyclePosition is valid and points to our current item, use it.
-				// Otherwise, find the first occurrence of our current item.
-				currentIndex = useSessionStore.getState().cyclePosition;
-				if (
-					currentIndex < 0 ||
-					currentIndex >= visualOrder.length ||
-					visualOrder[currentIndex].id !== currentActiveId ||
-					visualOrder[currentIndex].type === 'starred'
-				) {
-					currentIndex = visualOrder.findIndex(
-						(item) =>
-							item.id === currentActiveId &&
-							(currentIsGroupChat ? item.type === 'groupChat' : item.type === 'session')
-					);
-				}
-			}
+// ============================================================================
+// Thin React adapter (stable callback, no store subscriptions)
+// ============================================================================
 
-			// Dispatch activation for a slot in the visual order. A session sets the
-			// active session directly; a group chat loads its messages; a starred row
-			// focuses its tab or resumes its closed session (activateStarredItem sets
-			// the active session itself).
-			const activateVisualItem = (item: VisualOrderItem) => {
-				if (item.type === 'session') {
-					setActiveGroupChatId(null);
-					// Landing on a plain agent clears the non-agent cursor so the agent's
-					// own active highlight is the sole indicator.
-					setSidebarExtraSelection(null);
-					// Highlight + auto-scroll the EXACT occurrence we landed on (e.g. a
-					// bookmarked agent's group row), not the first navSessions occurrence
-					// the sync effect would otherwise pick (its bookmark row up top).
-					const navIdx = navIndexMap.get(item.navKey);
-					if (navIdx !== undefined) setSelectedSidebarIndex(navIdx);
-					setActiveSessionIdInternal(item.id);
-				} else if (item.type === 'starred') {
-					const starred = starredItems.find((s) => s.key === item.starredKey);
-					if (starred) {
-						setActiveGroupChatId(null);
-						// activateStarredItem sets the PARENT agent active (and resets
-						// cyclePosition via the public setter); set the starred cursor AFTER
-						// so it survives and visibly marks the row regardless of focus.
-						void activateStarredItem(starred);
-						setSidebarExtraSelection({ kind: 'starred', key: item.starredKey });
-					}
-				} else {
-					// Group chats have their own active highlight (activeGroupChatId), so the
-					// non-agent cursor is cleared when one is opened.
-					setSidebarExtraSelection(null);
-					handleOpenGroupChat(item.id);
-				}
-			};
+/**
+ * Stable `cycleSession` for keyboard handlers. Does not subscribe to stores;
+ * deps are read from a ref so the callback identity stays fixed across renders.
+ */
+export function useCycleSession(deps: CycleSessionDeps): UseCycleSessionReturn {
+	const depsRef = useRef(deps);
+	depsRef.current = deps;
 
-			if (currentIndex === -1) {
-				// Current item not visible, select first visible item
-				setCyclePosition(0);
-				activateVisualItem(visualOrder[0]);
-				return;
-			}
+	const cycle = useCallback((dir: 'next' | 'prev') => {
+		cycleSession(dir, depsRef.current);
+	}, []);
 
-			// Move to next/prev in visual order
-			let nextIndex;
-			if (dir === 'next') {
-				nextIndex = currentIndex === visualOrder.length - 1 ? 0 : currentIndex + 1;
-			} else {
-				nextIndex = currentIndex === 0 ? visualOrder.length - 1 : currentIndex - 1;
-			}
-
-			setCyclePosition(nextIndex);
-			activateVisualItem(visualOrder[nextIndex]);
-		},
-		[
-			sessions,
-			groups,
-			activeSessionId,
-			activeGroupChatId,
-			leftSidebarOpen,
-			bookmarksCollapsed,
-			groupChatsExpanded,
-			ungroupedCollapsed,
-			showUnreadAgentsOnly,
-			groupChats,
-			sortedSessions,
-			handleOpenGroupChat,
-			starredSectionCollapsed,
-			starredItems,
-			activateStarredItem,
-			navIndexMap,
-			ownsSession,
-		]
-	);
-
-	return { cycleSession };
+	return { cycleSession: cycle };
 }

--- a/src/renderer/hooks/session/useCycleSession.ts
+++ b/src/renderer/hooks/session/useCycleSession.ts
@@ -61,9 +61,6 @@ export interface CycleSessionDeps {
 	ownsSession?: (sessionId: string) => boolean;
 }
 
-/** @deprecated Prefer {@link CycleSessionDeps} */
-export type UseCycleSessionDeps = CycleSessionDeps;
-
 export interface UseCycleSessionReturn {
 	/** Cycle to next or previous session/group chat in visual order */
 	cycleSession: (dir: 'next' | 'prev') => void;

--- a/src/renderer/hooks/session/useStarredItems.ts
+++ b/src/renderer/hooks/session/useStarredItems.ts
@@ -7,7 +7,7 @@
  * locally inside SessionList.tsx. Keyboard navigation lives in App.tsx and
  * could not see that list, so Cmd+[ / Cmd+] cycling skipped starred sessions
  * entirely. Lifting it here lets the render (SessionList) and the cycle
- * (useCycleSession) consume one owner.
+ * (cycleSession / useCycleSession) consume one owner.
  *
  * Reads sessions + showStarredSessionsSection directly from the stores; takes
  * the cross-agent jump + confirmation primitives (which originate in App) as


### PR DESCRIPTION
`MaestroConsoleInner` still re-renders on many store updates because handler hooks subscribe to broad Zustand slices. This PR is an early slice of peeling that work toward event-time `getState()` reads and narrow selectors, so App only re-renders when the shell actually needs to paint.

## Summary
- **Test infra:** shared `resetAllStores` / `resetStore` / `resetStores` helpers (Zustand v5 `getInitialState` + Set/Map cloning) and TEST-PATTERNS guidance; adopt in a few suites so resets stop drifting from hand-rolled snapshots.
- **Cycling:** extract plain `cycleSession(dir, deps)` that reads stores at keypress time; keep a thin `useCycleSession` wrapper with a stable callback for the keyboard handler (no reactive store subscriptions).
- **Queue recovery:** stop selecting the full `sessions` array in `useQueueProcessing`; subscribe only to `sessionsLoaded` + an idle-queue signature, and read session objects via `getState()` inside effects.
- Drop the unused `UseCycleSessionDeps` alias in favor of `CycleSessionDeps` only.

## Future Work
Keep cutting App’s session-store subscriptions so streaming and sidebar updates don’t re-render the whole console. Handlers and persistence should read via getState() at event time; only components that paint data should subscribe. Same pattern for useActiveSession and the remaining App-mounted hooks, plus broader resetAllStores adoption in tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Refined session cycling so navigation stays consistent across starred items, bookmarks, group chats, active filters, and multi-window contexts.
  * Reduced unnecessary UI re-renders during queued agent processing for smoother streaming/console interaction.
  * Strengthened queued-task recovery when sessions move from busy to idle.
* **Documentation**
  * Updated testing guidance with safer, clearer instructions for resetting Zustand store state between test runs.
* **Tests**
  * Added shared store reset helpers and expanded coverage to confirm resets fully isolate state per test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->