### PR TITLE
feat(plugins): broad mediated UI surfaces + trusted-chrome guard

### DIFF
--- a/CLAUDE-PLUGINS.md
+++ b/CLAUDE-PLUGINS.md
@@ -11,7 +11,7 @@ A plugin is one folder under `<userData>/plugins/` containing a `plugin.json` ma
 - Entire system is gated on `encoreFeatures.plugins === true` (off by default), re-read per call.
 - Every `plugins:*` IPC channel throws the sentinel `'PluginsDisabled'` when the flag is off, so the renderer can distinguish "feature off" from "no plugins installed". The gate runs OUTSIDE `withIpcErrorLogging` so the sentinel is not logged as a real failure.
 - `PluginManager.getActiveRecords()`, `getContributions()`, and `getAgentRegistry()` all return empty when the flag is off, regardless of what is on disk.
-- `HOST_API_VERSION = '1.12.0'` (`src/shared/plugins/host-api.ts`) is the single source of truth for the host surface version.
+- `HOST_API_VERSION = '1.13.0'` (`src/shared/plugins/host-api.ts`) is the single source of truth for the host surface version.
 
 ## File map
 
@@ -151,6 +151,12 @@ HostResponse { id, ok, result?, error? } <---postMessage---
 
 - `hostViews` are data-only contributions available to tier-0 and tier-1 plugins: `{ id, surface: 'movement' | 'cadenza', title, description?, blocks? }`. `blocks` is an optional BlockView block array, serialized UTF-8 is capped at 1,000,000 bytes, and the host renderer - not plugin code - draws it. Tier-1 runtime update/remove RPCs require `ui:hostView`, resolve only an already-declared local id, retain its title/surface, and reject cadenza decision/options or agent-routing payloads.
 
+- `uiItems` (tier 1) are declarative host-rendered controls gated by `ui:contribute`: `status-bar`, `menu`, `sidebar`, `activity-bar`, `toolbar`, `tabBar`, `sessionRowBadge`, `groupHeaderBadge`, `settingsSection`, `rightPanelTab`, `contextMenuItem`, and `emptyState`. Their `command` is plugin-local; content is only label/icon/tooltip data, never raw markup.
+
+### Trusted chrome (never plugin-accessible)
+
+`PROTECTED_UI_SURFACES` is an explicit denylist enforced while contributions are collected and again during aggregation; every `PluginUiItemsSlot` repeats the positive-allowlist check at the render boundary. Plugins must never target, nest into, replace, or visually occlude: (1) plugin management and enable/disable controls, (2) permission or consent dialogs, (3) uninstall or grant/revoke flows, or (4) security indicators, including SSH status, permission mode, and agent identity. Those semantic zones are deliberately absent from `PluginUiSurface`. `ui:render-unsafe` is subject to the same guard and does not unlock `ui:contribute` or `ui:panel`.
+
 ## IPC surface (`src/main/ipc/handlers/plugins.ts`)
 
 Channels (all gated on `encoreFeatures.plugins`):
@@ -201,7 +207,8 @@ whose surface they use.
 7. **Built-in wins.** Plugin agents/contributions can never shadow first-party ids.
 8. **Host views remain data-only.** A plugin may contribute or update only BlockView data for its own declared host view; it cannot supply HTML, renderer code, cadenza decision actions, or agent-routing data. Enforce `MAX_HOST_VIEW_BLOCKS_BYTES` in both declaration parsing and runtime updates.
 9. **Uninstall purges everything** (dir, toggle, grants, KV, `plugins.<id>.*` settings, event subs). Add any new per-plugin state to `purgePluginData`.
-10. **Live but fully gated.** `agents:dispatch`, `process:spawn`, and `net:connect` are wired and reachable, each behind the full gate stack (allowlist/host-scope grant + trusted signature + Pianola risk ceiling + ActionGuard + closed schema; `net:connect` adds wss-only + egress-pinning + socket/frame caps). The direct `agents.dispatch` handler ADDITIONALLY requires the separate unattended consent. These conditions are pinned by the AST wiring guard (`plugin-host-deps-wiring.test.ts`): removing a gate, wiring a partial `net.connect` surface, or dropping `dispatchUnattendedAllowed` fails the build and forces a security review. Do not loosen any of them in isolation.
+10. **Live but fully gated.** `agents:dispatch`, `process:spawn`, and `net:connect` are wired and reachable, each behind the full gate stack (allowlist/host-scope grant + trusted signature + Pianola risk ceiling + ActionGuard + closed schema; `net:connect` adds wss-only + egress-pinning + socket/frame caps). The direct `agents.dispatch` handler additionally requires separate unattended consent. These conditions are pinned by the AST wiring guard (`plugin-host-deps-wiring.test.ts`): removing a gate, wiring a partial `net.connect` surface, or dropping `dispatchUnattendedAllowed` fails the build and forces a security review. Do not loosen any of them in isolation.
+11. **Trusted chrome is permanent.** `PROTECTED_UI_SURFACES` applies to declarative items and every high-trust render tier in collection, aggregation, and at the render boundary. Never create a mount in plugin management/enable-disable, consent, uninstall/grant-revoke, or SSH/permission-mode/agent-identity chrome.
 
 ## Honest tier-1 trust model
 

--- a/CLAUDE-PLUGINS.md
+++ b/CLAUDE-PLUGINS.md
@@ -132,10 +132,10 @@ HostResponse { id, ok, result?, error? } <---postMessage---
 | `ui:command`          | low    | none  | invoke a registered palette command                                                                                                                                                                                                    |
 | `events:subscribe`    | medium | none  | metadata-only topics                                                                                                                                                                                                                   |
 | `process:spawn`       | high   | none  | LIVE, fully gated: allowlist grant + trusted signature + Pianola risk + ActionGuard + closed schema                                                                                                                                    |
-| `ui:contribute`       | medium | none  | gates accepting declarative `uiItems` into host surfaces (menus, sidebar, status bar)                                                                                                                                                  |
-| `ui:panel`            | medium | none  | gates accepting the plugin's sandboxed `panels`                                                                                                                                                                                        |
+| `ui:contribute`       | medium | none  | gates declarative `uiItems` in approved host-owned surfaces; every surface uses this same capability                                                                                                                                   |
+| `ui:panel`            | medium | none  | gates sandboxed `panels` in approved Maestro regions                                                                                                                                                                                   |
 | `ui:hostView`         | medium | none  | drives brokered updates/removals of the plugin's declared native BlockView data; no plugin renderer runs                                                                                                                               |
-| `ui:render-unsafe`    | high   | none  | escape hatch: full custom UI with interface access (high-trust)                                                                                                                                                                        |
+| `ui:render-unsafe`    | high   | none  | high-trust custom UI only in host-approved, non-protected regions; never a trusted-chrome bypass                                                                                                                                       |
 
 `PermissionRequest = { capability, scope?, reason? }`. Scopes narrow `fs:*` (a directory), `net:fetch` (a host), and `transcripts:read` (a project path); an absent scope means the broad form (the consent UI must present it as such). The user grants a subset at the consent dialog (`plugins:set-grants`).
 
@@ -189,8 +189,9 @@ Integrity ("files match what was signed") and trust ("key is recognized") are la
 
 `HOST_API_VERSION` is a permanent public contract once plugins ship. PATCH = host bug fix; MINOR = additive (new contribution point / manifest field / capability, older plugins keep working); MAJOR = remove or change the meaning of an existing one. A plugin pins `maestro.minHostApi`; the host loads it only when same-major and `host >= min`.
 
-The current host is `1.12.0`; it added the `net:connect` capability and the
-`net.connect` / `net.send` / `net.close` methods. Earlier: `1.11.0` added
+The current host is `1.13.0`; it adds the host-mediated `PluginUiSurface`
+registry and trusted-chrome guard. Earlier: `1.12.0` added `net:connect` and
+the `net.connect` / `net.send` / `net.close` methods; `1.11.0` added
 `groupings` + `ui:grouping`; `1.10.0` added `iconPacks`; `1.9.0` added
 `hostViews`, `ui:hostView`, and the `ui.hostViewUpdate` / `ui.hostViewRemove`
 methods. Plugins declare the `maestro.minHostApi` matching the lowest version

--- a/docs/agent-guides/PLUGIN-DEVELOPMENT.md
+++ b/docs/agent-guides/PLUGIN-DEVELOPMENT.md
@@ -287,7 +287,7 @@ Only `action: 'notify'` runs on tier 0. `action: 'dispatch'` needs `agents:dispa
 
 ### panels (tier 1)
 
-`{ id, title, entry, placement }` where `entry` is a plugin-relative `.html` file and `placement` is `'modal' | 'left' | 'right' | 'main' | 'settings'` (defaults to `modal`).
+`{ id, title, entry, placement }` where `entry` is a plugin-relative `.html` file and `placement` is `'modal' | 'left' | 'right' | 'main' | 'settings'` (defaults to `modal`). The `settings` placement renders only in the neutral Display settings host, never in plugin management, consent, uninstall, or grant/revoke UI.
 
 ```json
 { "id": "vet-panel", "title": "Vet Panel", "entry": "panel.html", "placement": "right" }
@@ -314,6 +314,27 @@ to update or remove a view after activation, and should declare `minHostApi: "1.
 	"blocks": [
 		{ "kind": "heading", "text": "Ready" },
 		{ "kind": "badge", "text": "Waiting for a run", "color": "neutral" }
+### uiItems (tier 1)
+
+`{ id, surface, label, command, icon?, tooltip?, group?, priority? }` adds a small host-rendered control. `surface` must be one of `'status-bar' | 'menu' | 'sidebar' | 'activity-bar' | 'toolbar' | 'tabBar' | 'sessionRowBadge' | 'groupHeaderBadge' | 'settingsSection' | 'rightPanelTab' | 'contextMenuItem' | 'emptyState'`. `command` must be one of YOUR plugin-local command ids; the host controls the frame, icon mapping, tooltip, and non-suppressible plugin provenance.
+
+```json
+{
+	"uiItems": [
+		{
+			"id": "open-dashboard",
+			"surface": "tabBar",
+			"label": "Open dashboard",
+			"icon": "panel",
+			"tooltip": "Open the plugin dashboard",
+			"command": "open-dashboard"
+		},
+		{
+			"id": "welcome-action",
+			"surface": "emptyState",
+			"label": "Get started",
+			"command": "open-dashboard"
+		}
 	]
 }
 ```
@@ -323,7 +344,6 @@ The manifest author writes the local `id`; Maestro namespaces it to
 granted tier-1 plugin may change only the blocks of one of its own declared views with
 `maestro.ui.hostView.update('run-status', blocks)`, or remove it with
 `maestro.ui.hostView.remove('run-status')`; it cannot change the title or surface.
-
 ### agents (tier 1)
 
 `{ id, displayName, binaryName, baseArgs?, capabilities? }`. `binaryName` is a bare command (no path, traversal, or shell metacharacters); `capabilities` is a boolean feature map. Registering an agent adds it to the registry but does NOT enable spawning it (arbitrary binary execution is a separate, security-reviewed step).
@@ -379,11 +399,11 @@ Request these in `permissions` as `{ capability, scope?, reason? }`. `scope` nar
 
 `transcripts:read` is project-scoped: `scope` is a project path, and an absent scope means all projects (presented as such at consent). It is refused for an untrusted plugin that also holds `net:fetch`, `net:connect`, or `process:spawn` (the content-exfiltration combination) - sign with a trusted key to allow both. Reads are rate-limited as a high-risk verb and every read is audited.
 
-The `ui:*` capabilities gate what the host accepts and renders: `ui:contribute` admits
-declarative `uiItems`, `ui:panel` admits sandboxed `panels`, and `ui:hostView` admits
-brokered updates/removals for declared host views. Static `hostViews` remain available to tier-0
-plugins because they are host-rendered data, not a plugin UI. `ui:render-unsafe` is the
-high-trust escape hatch for full custom UI, not a substitute for any of those grants.
+The `ui:*` capabilities gate what the host accepts and renders: `ui:contribute` admits declarative `uiItems` into approved host-owned surfaces, `ui:panel` admits sandboxed `panels` into approved Maestro regions, and `ui:hostView` admits brokered updates/removals for declared host views. Static `hostViews` remain available to tier-0 plugins because they are host-rendered data, not plugin UI. `ui:render-unsafe` is a high-trust policy for host-approved custom UI only; it neither grants another UI capability nor bypasses trusted chrome. An enabled plugin without the matching grant contributes none of that surface.
+
+### Trusted chrome (never plugin-accessible)
+
+The host permanently excludes plugin-management and enable/disable controls, permission or consent dialogs, uninstall or grant/revoke flows, and security indicators (SSH status, permission mode, and agent identity). These zones are not `uiItems` surfaces. The shared registry guard drops declarative and `ui:render-unsafe` attempts before rendering, and the renderer repeats the positive allowlist check. The current SDK exposes no generic `ui:render-unsafe` mount method.
 
 ---
 
@@ -621,6 +641,7 @@ An integral-but-untrusted plugin still runs once the user enables = consents. A 
 - **Setting-key rules are enforced twice** (declarative contributions and runtime `settings.set`): no prototype segments, no `encoreFeatures`, no secret-looking names, no path separators.
 - **`entry` rules:** required for tier >= 1, forbidden for tier 0, must stay inside the plugin folder.
 - **Inert capabilities:** `agents:dispatch` and `process:spawn` are declared but have no production handler; do not build on them yet.
+- **Trusted chrome cannot be extended.** Declarative `uiItems`, sandboxed panels, and any high-trust `ui:render-unsafe` UI must never target or cover plugin management/enable-disable controls, consent dialogs, uninstall/grant-revoke flows, or SSH/permission-mode/agent-identity indicators.
 
 ## 14. Tooling: the SDK package and the `maestro plugin` CLI
 

--- a/docs/agent-guides/PLUGIN-DEVELOPMENT.md
+++ b/docs/agent-guides/PLUGIN-DEVELOPMENT.md
@@ -314,9 +314,23 @@ to update or remove a view after activation, and should declare `minHostApi: "1.
 	"blocks": [
 		{ "kind": "heading", "text": "Ready" },
 		{ "kind": "badge", "text": "Waiting for a run", "color": "neutral" }
+	]
+}
+```
+
+The manifest author writes the local `id`; Maestro namespaces it to
+`<pluginId>/run-status`. An enabled plugin renders its declared static blocks. A running,
+granted tier-1 plugin may change only the blocks of one of its own declared views with
+`maestro.ui.hostView.update('run-status', blocks)`, or remove it with
+`maestro.ui.hostView.remove('run-status')`; it cannot change the title or surface.
+
 ### uiItems (tier 1)
 
-`{ id, surface, label, command, icon?, tooltip?, group?, priority? }` adds a small host-rendered control. `surface` must be one of `'status-bar' | 'menu' | 'sidebar' | 'activity-bar' | 'toolbar' | 'tabBar' | 'sessionRowBadge' | 'groupHeaderBadge' | 'settingsSection' | 'rightPanelTab' | 'contextMenuItem' | 'emptyState'`. `command` must be one of YOUR plugin-local command ids; the host controls the frame, icon mapping, tooltip, and non-suppressible plugin provenance.
+`{ id, surface, label, command, icon?, tooltip?, group?, priority? }` adds a small host-rendered
+control. `surface` must be one of `'status-bar' | 'menu' | 'sidebar' | 'activity-bar' | 'toolbar' |
+'tabBar' | 'sessionRowBadge' | 'groupHeaderBadge' | 'settingsSection' | 'rightPanelTab' |
+'contextMenuItem' | 'emptyState'`. `command` must be one of your plugin-local command ids; the
+host controls the frame, icon mapping, tooltip, and non-suppressible plugin provenance.
 
 ```json
 {
@@ -339,11 +353,6 @@ to update or remove a view after activation, and should declare `minHostApi: "1.
 }
 ```
 
-The manifest author writes the local `id`; Maestro namespaces it to
-`<pluginId>/run-status`. An enabled plugin renders its declared static blocks. A running,
-granted tier-1 plugin may change only the blocks of one of its own declared views with
-`maestro.ui.hostView.update('run-status', blocks)`, or remove it with
-`maestro.ui.hostView.remove('run-status')`; it cannot change the title or surface.
 ### agents (tier 1)
 
 `{ id, displayName, binaryName, baseArgs?, capabilities? }`. `binaryName` is a bare command (no path, traversal, or shell metacharacters); `capabilities` is a boolean feature map. Registering an agent adds it to the registry but does NOT enable spawning it (arbitrary binary execution is a separate, security-reviewed step).
@@ -390,10 +399,10 @@ Request these in `permissions` as `{ capability, scope?, reason? }`. `scope` nar
 | `ui:command`          | low    | none  | invoke a registered palette command                                                    | `{ "capability": "ui:command" }`                                 |
 | `events:subscribe`    | medium | none  | subscribe to metadata-only host topics                                                 | `{ "capability": "events:subscribe" }`                           |
 | `process:spawn`       | high   | none  | run a shell command (LIVE, gated: trusted + allowlisted + risk-capped)                 | `{ "capability": "process:spawn" }`                              |
-| `ui:contribute`       | medium | none  | add host-rendered items to Maestro's UI (menus, sidebar, status bar)                   | `{ "capability": "ui:contribute" }`                              |
-| `ui:panel`            | medium | none  | render its own sandboxed interactive panels                                            | `{ "capability": "ui:panel" }`                                   |
+| `ui:contribute`       | medium | none  | add declarative controls in approved host-owned surfaces                               | `{ "capability": "ui:contribute" }`                              |
+| `ui:panel`            | medium | none  | render sandboxed panels in approved Maestro regions                                    | `{ "capability": "ui:panel" }`                                   |
 | `ui:hostView`         | medium | none  | render/update declared host BlockView data                                             | `{ "capability": "ui:hostView" }`                                |
-| `ui:render-unsafe`    | high   | none  | render custom UI with full interface access (escape hatch)                             | `{ "capability": "ui:render-unsafe" }`                           |
+| `ui:render-unsafe`    | high   | none  | render custom UI only in host-approved, non-protected regions                          | `{ "capability": "ui:render-unsafe" }`                           |
 
 `agents:dispatch`, `process:spawn`, and `net:connect` are LIVE but fully gated: each requires a trusted (signed) plugin, an allowlist/host-scope grant, and passes a Pianola risk ceiling plus the ActionGuard rate cap. `agents:dispatch` from your own plugin code ALSO requires the separate unattended consent (plugin-initiated dispatch is never user-present). The broker re-reads grants on every call, so a revoke takes effect immediately, and it re-authorizes `fs:*` paths against the symlink-resolved real path. See "Persistent network connections" below for `net:connect`.
 

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -1,8 +1,8 @@
 {
 	"name": "@maestro/plugin-sdk",
-	"version": "0.7.0",
+	"version": "0.8.0",
 	"description": "Typed authoring surface for Maestro plugins (manifest, contributions, permissions, events, and the sandbox runtime API).",
-	"//": "Self-contained, dependency-free. The vendored plugin contracts track the Maestro plugin HOST_API_VERSION (1.12.0) from src/shared/plugins/host-api.ts; a drift-guard test asserts parity with those sources. Bump in lockstep with that contract: MINOR when the host adds a backward-compatible capability/contribution/method, MAJOR when one changes meaning or is removed.",
+	"//": "Self-contained, dependency-free. The vendored plugin contracts track the Maestro plugin HOST_API_VERSION (1.13.0) from src/shared/plugins/host-api.ts; a drift-guard test asserts parity with those sources. Bump in lockstep with that contract: MINOR when the host adds a backward-compatible capability/contribution/method, MAJOR when one changes meaning or is removed.",
 	"type": "module",
 	"license": "AGPL-3.0-only",
 	"main": "dist/index.js",

--- a/packages/plugin-sdk/src/__tests__/drift.test-d.ts
+++ b/packages/plugin-sdk/src/__tests__/drift.test-d.ts
@@ -19,10 +19,17 @@ import type {
 	HostViewBlocks,
 	PluginContributions,
 	AggregatedContributions,
-	PluginEventPayloads,
-	PluginCategory,
-	PluginManifest,
 	ManifestValidationResult,
+	PluginCategory,
+	PluginContributions,
+	PluginEventPayloads,
+	PluginManifest,
+	PluginUiMountAttempt,
+	PluginUiMountValidation,
+	PluginUiSurface,
+	ProtectedUiSurface,
+	UiItemContribution,
+	UiSurface,
 } from '../index';
 import type {
 	UiItemContribution as SrcUiItemContribution,
@@ -30,6 +37,13 @@ import type {
 	HostViewBlocks as SrcHostViewBlocks,
 	PluginContributions as SrcPluginContributions,
 	AggregatedContributions as SrcAggregatedContributions,
+	PluginContributions as SrcPluginContributions,
+	PluginUiMountAttempt as SrcPluginUiMountAttempt,
+	PluginUiMountValidation as SrcPluginUiMountValidation,
+	PluginUiSurface as SrcPluginUiSurface,
+	ProtectedUiSurface as SrcProtectedUiSurface,
+	UiItemContribution as SrcUiItemContribution,
+	UiSurface as SrcUiSurface,
 } from '../../../../src/shared/plugins/contributions';
 import type { PluginEventPayloads as SrcPluginEventPayloads } from '../../../../src/shared/plugins/events';
 import type {
@@ -42,6 +56,11 @@ expectTypeOf<HostViewContribution>().toEqualTypeOf<SrcHostViewContribution>();
 expectTypeOf<HostViewBlocks>().toEqualTypeOf<SrcHostViewBlocks>();
 expectTypeOf<PluginContributions>().toEqualTypeOf<SrcPluginContributions>();
 expectTypeOf<AggregatedContributions>().toEqualTypeOf<SrcAggregatedContributions>();
+expectTypeOf<PluginUiSurface>().toEqualTypeOf<SrcPluginUiSurface>();
+expectTypeOf<ProtectedUiSurface>().toEqualTypeOf<SrcProtectedUiSurface>();
+expectTypeOf<UiSurface>().toEqualTypeOf<SrcUiSurface>();
+expectTypeOf<PluginUiMountAttempt>().toEqualTypeOf<SrcPluginUiMountAttempt>();
+expectTypeOf<PluginUiMountValidation>().toEqualTypeOf<SrcPluginUiMountValidation>();
 expectTypeOf<PluginEventPayloads>().toEqualTypeOf<SrcPluginEventPayloads>();
 expectTypeOf<PluginCategory>().toEqualTypeOf<SrcPluginCategory>();
 expectTypeOf<PluginManifest>().toEqualTypeOf<SrcPluginManifest>();

--- a/packages/plugin-sdk/src/__tests__/drift.test.ts
+++ b/packages/plugin-sdk/src/__tests__/drift.test.ts
@@ -11,10 +11,14 @@ import {
 	HOST_METHOD_CAPABILITY,
 	HOST_API_VERSION,
 	PLUGIN_ID_PATTERN,
+	PROTECTED_UI_SURFACES,
 	UI_SURFACES,
 	HOST_VIEW_SURFACES,
 	MAX_HOST_VIEW_BLOCKS_BYTES,
 	serializedJsonByteLength,
+	isPluginUiSurface,
+	isProtectedUiSurface,
+	validatePluginUiMount,
 	capabilityRisk,
 	isHostViewBlocks,
 	describeCapability,
@@ -46,9 +50,13 @@ import { HOST_API_VERSION as SRC_HOST_API_VERSION } from '../../../../src/shared
 import {
 	HOST_VIEW_SURFACES as SRC_HOST_VIEW_SURFACES,
 	MAX_HOST_VIEW_BLOCKS_BYTES as SRC_MAX_HOST_VIEW_BLOCKS_BYTES,
-	serializedJsonByteLength as srcSerializedJsonByteLength,
+	PROTECTED_UI_SURFACES as SRC_PROTECTED_UI_SURFACES,
 	UI_SURFACES as SRC_UI_SURFACES,
 	isHostViewBlocks as srcIsHostViewBlocks,
+	isPluginUiSurface as srcIsPluginUiSurface,
+	isProtectedUiSurface as srcIsProtectedUiSurface,
+	serializedJsonByteLength as srcSerializedJsonByteLength,
+	validatePluginUiMount as srcValidatePluginUiMount,
 } from '../../../../src/shared/plugins/contributions';
 
 // This package VENDORS the frozen plugin contracts so it can publish standalone
@@ -86,9 +94,9 @@ describe('@maestro/plugin-sdk vendored-contract drift guard', () => {
 		expect(HOST_METHOD_CAPABILITY).toEqual(SRC_HOST_METHOD_CAPABILITY);
 	});
 
-	it('HOST_API_VERSION matches the source and is pinned to 1.12.0', () => {
+	it('HOST_API_VERSION matches the source and is pinned to 1.13.0', () => {
 		expect(HOST_API_VERSION).toBe(SRC_HOST_API_VERSION);
-		expect(HOST_API_VERSION).toBe('1.12.0');
+		expect(HOST_API_VERSION).toBe('1.13.0');
 	});
 
 	it('capability risk and descriptions match the source', () => {
@@ -121,6 +129,29 @@ describe('@maestro/plugin-sdk vendored-contract drift guard', () => {
 			{ viewType: 'decision', blocks: [] },
 		]) {
 			expect(isHostViewBlocks(value)).toBe(srcIsHostViewBlocks(value));
+		}
+	});
+
+	it('trusted-chrome catalog and mount policy match the source', () => {
+		expect(PROTECTED_UI_SURFACES).toEqual(SRC_PROTECTED_UI_SURFACES);
+		for (const protectedSurface of PROTECTED_UI_SURFACES) {
+			expect(isProtectedUiSurface(protectedSurface)).toBe(
+				srcIsProtectedUiSurface(protectedSurface)
+			);
+			expect(isPluginUiSurface(protectedSurface)).toBe(srcIsPluginUiSurface(protectedSurface));
+			expect(
+				validatePluginUiMount({
+					pluginId: 'com.acme',
+					tier: 'ui:render-unsafe',
+					target: protectedSurface,
+				})
+			).toEqual(
+				srcValidatePluginUiMount({
+					pluginId: 'com.acme',
+					tier: 'ui:render-unsafe',
+					target: protectedSurface,
+				})
+			);
 		}
 	});
 

--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -91,7 +91,7 @@ export type PluginCapability =
 	| 'ui:panel' // show its own sandboxed interactive panels
 	| 'ui:hostView' // contribute and update host-rendered BlockView data
 	| 'ui:grouping' // publish virtual session grouping snapshots (presentation only)
-	| 'ui:render-unsafe'; // render arbitrary UI with full interface access (escape hatch)
+	| 'ui:render-unsafe'; // high-trust custom UI in host-approved, non-protected regions
 
 export const PLUGIN_CAPABILITIES: readonly PluginCapability[] = [
 	'fs:read',
@@ -387,40 +387,38 @@ export function describeCapability(capability: PluginCapability): string {
 		case 'transcripts:write':
 			return 'Write brokered entries into session transcripts';
 		case 'ui:contribute':
-			return "Add items to Maestro's interface (menus, sidebar, status bar, settings, themes)";
+			return "Add declarative items to Maestro's approved host surfaces";
 		case 'ui:panel':
-			return 'Show its own panels inside Maestro';
+			return 'Show its own panels inside approved Maestro regions';
 		case 'ui:hostView':
 			return 'Show and update host-rendered BlockView data in Maestro';
 		case 'ui:grouping':
 			return 'Organize session metadata into virtual sidebar groups';
 		case 'ui:render-unsafe':
-			return "Render its own custom UI with full access to Maestro's interface (advanced - only enable for authors you fully trust)";
+			return 'Render high-trust custom UI only in host-approved, non-protected regions (advanced - only enable authors you fully trust)';
 	}
 }
 
 // --- Host API version (from shared/plugins/host-api.ts) ---------------------
 
 /**
- * The host API version this Maestro build implements. Bumped to 1.12.0 for the
- * backward-compatible additive `net:connect` capability plus its `net.connect`
- * / `net.send` / `net.close` host methods (hold an outbound persistent
- * websocket to a host scope, e.g. a Discord/Slack gateway; egress-classified).
- * 1.11.0 added virtual `groupings` contributions and the presentation-only
- * `ui:grouping` publish/clear methods; 1.10.0 added the backward-compatible,
- * data-only `iconPacks` contribution; 1.9.0 added host-rendered `hostViews`,
- * their `ui:hostView` capability, and the `ui.hostViewUpdate` /
- * `ui.hostViewRemove` RPC methods; 1.8.0 added `background.list`; 1.7.0 added
- * history/session/tab/transcript
- * write/decision/shell/storage SQL/fs watch/power/background capabilities plus
+ * The host API version this Maestro build implements. Bumped to 1.13.0 for the
+ * additive host-mediated `PluginUiSurface` registry and trusted-chrome guard.
+ * 1.12.0 added the backward-compatible `net:connect` capability plus its
+ * `net.connect` / `net.send` / `net.close` host methods; 1.11.0 added virtual
+ * `groupings` contributions and `ui:grouping`; 1.10.0 added data-only
+ * `iconPacks`; 1.9.0 added host-rendered `hostViews`, `ui:hostView`, and the
+ * `ui.hostViewUpdate` / `ui.hostViewRemove` RPC methods; 1.8.0 added
+ * `background.list`; 1.7.0 added history/session/tab/transcript write,
+ * decision/shell/storage SQL/fs watch/power/background capabilities plus
  * `history.entryAdded` and metadata-only `agent.completed` events; 1.6.0 added
  * `cue.runStarted` / `cue.runFinished`; 1.5.0 added `agent.exited` /
- * `agent.error` / `usage.updated` / `run.completed` + functional
- * `sidebar`/`activity-bar`/`toolbar` uiItem surfaces; 1.4.0 added the
- * `ui:contribute` / `ui:panel` / `ui:render-unsafe` UI capabilities; 1.3.0
- * added `tools` + `keybindings`; 1.2.0 added `transcripts:read`.
+ * `agent.error` / `usage.updated` / `run.completed` plus functional
+ * `sidebar`/`activity-bar`/`toolbar` uiItem surfaces; 1.4.0 added
+ * `ui:contribute` / `ui:panel` / `ui:render-unsafe`; 1.3.0 added `tools` +
+ * `keybindings`; 1.2.0 added `transcripts:read`.
  */
-export const HOST_API_VERSION = '1.12.0';
+export const HOST_API_VERSION = '1.13.0';
 
 /** Result of checking a plugin's declared host-API requirement. */
 export interface HostApiCompatibility {
@@ -906,27 +904,109 @@ export interface KeybindingContribution {
 	description?: string;
 }
 
-/** Where a `ui:contribute` item renders. The renderer maps each surface to a
- * concrete region (status bar, menus, sidebar/activity bar, toolbar). */
-export type UiSurface = 'status-bar' | 'menu' | 'sidebar' | 'activity-bar' | 'toolbar';
-
-export const UI_SURFACES: readonly UiSurface[] = [
+/**
+ * Host-mediated regions a plugin may target with a declarative `uiItem`.
+ * Add a future surface by appending one literal here; the union and all
+ * allowlist checks derive from this registry.
+ */
+export const UI_SURFACES = [
 	'status-bar',
 	'menu',
 	'sidebar',
 	'activity-bar',
 	'toolbar',
-];
+	'tabBar',
+	'sessionRowBadge',
+	'groupHeaderBadge',
+	'settingsSection',
+	'rightPanelTab',
+	'contextMenuItem',
+	'emptyState',
+] as const;
 
-/** Type guard: is `value` one of the known UI surfaces? */
-export function isUiSurface(value: unknown): value is UiSurface {
+/** Public union of the host-owned slots available to `ui:contribute`. */
+export type PluginUiSurface = (typeof UI_SURFACES)[number];
+
+/** Compatibility name retained for existing plugin authors. */
+export type UiSurface = PluginUiSurface;
+
+/**
+ * Host-owned chrome that is permanently unavailable to every plugin render
+ * tier. Keep these semantic targets separate from contribution ids: ids are
+ * only provenance/uniqueness, never an authority to mount into a region.
+ */
+export const PROTECTED_UI_SURFACES = [
+	'plugin-management',
+	'permission-consent',
+	'uninstall-grant-revoke',
+	'security-indicators',
+] as const;
+
+export type ProtectedUiSurface = (typeof PROTECTED_UI_SURFACES)[number];
+export type HostUiSurface = PluginUiSurface | ProtectedUiSurface;
+export type PluginUiMountTier = 'ui:contribute' | 'ui:render-unsafe';
+
+export interface PluginUiMountAttempt {
+	pluginId: string;
+	tier: PluginUiMountTier;
+	target: unknown;
+}
+
+export type PluginUiMountValidation =
+	| { allowed: true }
+	| {
+			allowed: false;
+			error: string;
+	  };
+
+/** Is `value` a host zone that plugins may never target or nest beneath? */
+export function isProtectedUiSurface(value: unknown): value is ProtectedUiSurface {
+	return typeof value === 'string' && (PROTECTED_UI_SURFACES as readonly string[]).includes(value);
+}
+
+/** Type guard for the positive allowlist of plugin-contributable host slots. */
+export function isPluginUiSurface(value: unknown): value is PluginUiSurface {
 	return typeof value === 'string' && (UI_SURFACES as readonly string[]).includes(value);
+}
+
+/** Host-internal target guard; unknown strings fail closed. */
+export function isHostUiSurface(value: unknown): value is HostUiSurface {
+	return isPluginUiSurface(value) || isProtectedUiSurface(value);
+}
+
+/** Backward-compatible name for the original public surface guard. */
+export const isUiSurface = isPluginUiSurface;
+
+/**
+ * Shared trusted-chrome admission policy for declarative items and the
+ * high-trust `ui:render-unsafe` tier. The latter has no current mount API, but
+ * any future unsafe renderer must use this exact registry-level check before it
+ * selects a host slot.
+ */
+export function validatePluginUiMount({
+	pluginId,
+	tier,
+	target,
+}: PluginUiMountAttempt): PluginUiMountValidation {
+	if (isProtectedUiSurface(target)) {
+		return {
+			allowed: false,
+			error: `[${pluginId}] ${tier} surface "${target}" is protected chrome and was dropped`,
+		};
+	}
+	if (!isPluginUiSurface(target)) {
+		return {
+			allowed: false,
+			error: `[${pluginId}] ${tier} surface "${String(target)}" is invalid or unavailable`,
+		};
+	}
+	return { allowed: true };
 }
 
 /**
  * A declarative UI item a (tier-1) plugin renders into a host surface. The item
- * is pure data (label / icon / placement) the host renders; activating it invokes
- * one of the plugin's OWN commands through the broker. Gated by the
+ * is pure data (label / icon / tooltip / placement) the host renders; activating
+ * it invokes one of the plugin's OWN commands through the broker. Gated by the
  * `ui:contribute` capability, so an enabled plugin WITHOUT that grant
  * contributes none.
  */
@@ -934,12 +1014,14 @@ export interface UiItemContribution {
 	id: string;
 	localId: string;
 	pluginId: string;
-	surface: UiSurface;
+	surface: PluginUiSurface;
 	label: string;
 	/** Plugin-local command id invoked on activation. */
 	command: string;
 	/** Optional icon keyword the renderer maps to its icon set. */
 	icon?: string;
+	/** Optional host-rendered tooltip; provenance is always appended by the host. */
+	tooltip?: string;
 	/** Optional grouping / ordering hints within the surface. */
 	group?: string;
 	priority?: number;

--- a/src/__tests__/renderer/components/RightPanel.test.tsx
+++ b/src/__tests__/renderer/components/RightPanel.test.tsx
@@ -76,7 +76,8 @@ vi.mock('../../../renderer/components/ConfirmModal', () => ({
 }));
 
 // Mock lucide-react
-vi.mock('lucide-react', () => ({
+vi.mock('lucide-react', async (importOriginal) => ({
+	...(await importOriginal()),
 	PanelRightClose: () => <span data-testid="panel-right-close">Close</span>,
 	PanelRightOpen: () => <span data-testid="panel-right-open">Open</span>,
 	Loader2: ({ className }: { className?: string }) => (

--- a/src/__tests__/renderer/components/SessionItemCue.test.tsx
+++ b/src/__tests__/renderer/components/SessionItemCue.test.tsx
@@ -13,7 +13,8 @@ import type { Session, Theme } from '../../../renderer/types';
 import { createMockSession as baseCreateMockSession } from '../../helpers/mockSession';
 
 // Mock lucide-react icons
-vi.mock('lucide-react', () => ({
+vi.mock('lucide-react', async (importOriginal) => ({
+	...(await importOriginal()),
 	Activity: () => <span data-testid="icon-activity" />,
 	GitBranch: () => <span data-testid="icon-git-branch" />,
 	Bot: () => <span data-testid="icon-bot" />,

--- a/src/__tests__/renderer/components/SessionList.test.tsx
+++ b/src/__tests__/renderer/components/SessionList.test.tsx
@@ -95,6 +95,11 @@ vi.mock('lucide-react', async (importOriginal) => ({
 	),
 }));
 
+vi.mock('../../../renderer/components/plugins/PluginUiItemsSlot', () => ({
+	PluginUiItemsSlot: ({ surface }: { surface: string }) =>
+		surface === 'groupHeaderBadge' ? <button type="button">Plugin group action</button> : null,
+}));
+
 // Mock gitService
 vi.mock('../../../renderer/services/git', () => ({
 	gitService: {
@@ -932,6 +937,19 @@ describe('SessionList', () => {
 			// Click on group header
 			fireEvent.click(screen.getByText('My Group'));
 			expect(toggleGroup).toHaveBeenCalledWith('g1');
+		});
+
+		it.each(['Enter', ' '])('does not toggle a group for %s on a contributed action', (key) => {
+			const toggleGroup = vi.fn();
+			const group = createMockGroup({ id: 'g1', name: 'My Group', collapsed: false });
+			const sessions = [createMockSession({ id: 's1', name: 'Session', groupId: 'g1' })];
+			useSessionStore.setState({ sessions, groups: [group] });
+			useUIStore.setState({ leftSidebarOpen: true });
+
+			render(<SessionList {...createDefaultProps({ sortedSessions: sessions, toggleGroup })} />);
+
+			fireEvent.keyDown(screen.getByRole('button', { name: 'Plugin group action' }), { key });
+			expect(toggleGroup).not.toHaveBeenCalled();
 		});
 
 		it('shows delete button for empty groups on hover', () => {

--- a/src/__tests__/renderer/components/TabBar.test.tsx
+++ b/src/__tests__/renderer/components/TabBar.test.tsx
@@ -15,7 +15,8 @@ vi.mock('../../../renderer/utils/runtimeContext', () => ({
 	isElectronDesktop: vi.fn(() => true),
 }));
 // Mock lucide-react icons
-vi.mock('lucide-react', () => ({
+vi.mock('lucide-react', async (importOriginal) => ({
+	...(await importOriginal()),
 	X: ({ className, style }: { className?: string; style?: React.CSSProperties }) => (
 		<span data-testid="x-icon" className={className} style={style}>
 			X

--- a/src/__tests__/shared/plugins/contributions.test.ts
+++ b/src/__tests__/shared/plugins/contributions.test.ts
@@ -1,11 +1,15 @@
 import { describe, it, expect } from 'vitest';
 import {
-	collectContributions,
 	aggregateContributions,
+	collectContributions,
 	gateContributions,
 	MAX_HOST_VIEW_BLOCKS_BYTES,
 	groupingRuleMatches,
+	isPluginUiSurface,
 	matchesGroupingPattern,
+	PROTECTED_UI_SURFACES,
+	UI_SURFACES,
+	validatePluginUiMount,
 } from '../../../shared/plugins/contributions';
 import type { PluginManifest } from '../../../shared/plugins/plugin-manifest';
 
@@ -642,6 +646,104 @@ describe('hostViews contribution (host-rendered BlockView data)', () => {
 		expect(
 			gateContributions(collected, (cap) => cap === 'ui:render-unsafe').hostViews
 		).toHaveLength(1);
+	});
+});
+
+describe('PluginUiSurface registry and trusted-chrome guard', () => {
+	function uiItemManifest(surface: string): PluginManifest {
+		const contribution = {
+			id: 'go',
+			surface,
+			label: 'Go',
+			command: 'run',
+			tooltip: 'Run Go',
+		};
+		return manifest('com.ui', { uiItems: [contribution] }, 1);
+	}
+
+	it.each([
+		'tabBar',
+		'sessionRowBadge',
+		'groupHeaderBadge',
+		'settingsSection',
+		'rightPanelTab',
+		'contextMenuItem',
+		'emptyState',
+	])('accepts the %s ui:contribute surface', (surface) => {
+		const collected = collectContributions(uiItemManifest(surface));
+
+		expect(collected.errors).toEqual([]);
+		expect(collected.uiItems).toMatchObject([{ surface, tooltip: 'Run Go' }]);
+		expect(isPluginUiSurface(surface)).toBe(true);
+	});
+
+	it('keeps every contributable surface in the positive allowlist', () => {
+		expect(UI_SURFACES).toEqual(
+			expect.arrayContaining([
+				'status-bar',
+				'menu',
+				'sidebar',
+				'activity-bar',
+				'toolbar',
+				'tabBar',
+				'sessionRowBadge',
+				'groupHeaderBadge',
+				'settingsSection',
+				'rightPanelTab',
+				'contextMenuItem',
+				'emptyState',
+			])
+		);
+		for (const protectedSurface of PROTECTED_UI_SURFACES) {
+			expect(UI_SURFACES).not.toContain(protectedSurface);
+			expect(isPluginUiSurface(protectedSurface)).toBe(false);
+		}
+	});
+
+	it.each(PROTECTED_UI_SURFACES)(
+		'drops declarative and ui:render-unsafe attempts at protected %s',
+		(protectedSurface) => {
+			const collected = collectContributions(uiItemManifest(protectedSurface));
+			const aggregated = aggregateContributions(
+				[uiItemManifest(protectedSurface)],
+				(pluginId, capability) => pluginId === 'com.ui' && capability === 'ui:contribute'
+			);
+			const unsafe = validatePluginUiMount({
+				pluginId: 'com.ui',
+				tier: 'ui:render-unsafe',
+				target: protectedSurface,
+			});
+
+			expect(collected.uiItems).toEqual([]);
+			expect(collected.errors.join(' ')).toContain('protected chrome');
+			expect(aggregated.uiItems).toEqual([]);
+			expect(aggregated.errorsByPlugin['com.ui']?.join(' ')).toContain('protected chrome');
+			expect(unsafe.allowed).toBe(false);
+			expect(unsafe.error).toContain('protected chrome');
+		}
+	);
+
+	it('does not infer target policy from a namespaced contribution id', () => {
+		const collected = collectContributions(
+			manifest(
+				'evil',
+				{
+					uiItems: [
+						{
+							id: 'permission-consent',
+							surface: 'permission-consent',
+							label: 'Spoof consent',
+							command: 'run',
+						},
+					],
+				},
+				1
+			)
+		);
+
+		expect(collected.uiItems).toEqual([]);
+		expect(collected.errors.join(' ')).toContain('permission-consent');
+		expect(isPluginUiSurface('evil/permission-consent')).toBe(false);
 	});
 });
 

--- a/src/__tests__/shared/plugins/host-api.test.ts
+++ b/src/__tests__/shared/plugins/host-api.test.ts
@@ -48,6 +48,11 @@ describe('isHostApiCompatible', () => {
 		expect(r.reason).toMatch(/host API version/);
 	});
 
+	it('keeps 1.8 plugins compatible while requiring 1.9 for new UI surfaces', () => {
+		expect(isHostApiCompatible('1.8.0', '1.9.0').compatible).toBe(true);
+		expect(isHostApiCompatible('1.9.0', '1.8.0').compatible).toBe(false);
+	});
+
 	it('uses HOST_API_VERSION as the default host', () => {
 		expect(isHostApiCompatible(HOST_API_VERSION).compatible).toBe(true);
 	});

--- a/src/renderer/components/EmptyStateView.tsx
+++ b/src/renderer/components/EmptyStateView.tsx
@@ -19,6 +19,7 @@ import { useClickOutside } from '../hooks';
 import { WelcomeContent } from './WelcomeContent';
 import { buildMaestroUrl } from '../utils/buildMaestroUrl';
 import { openUrl } from '../utils/openUrl';
+import { PluginUiItemsSlot } from './plugins/PluginUiItemsSlot';
 
 interface EmptyStateViewProps {
 	theme: Theme;
@@ -296,6 +297,8 @@ export function EmptyStateView({
 						Create your first agent
 					</button>
 				</div>
+
+				<PluginUiItemsSlot surface="emptyState" className="mt-3 justify-center" />
 			</div>
 		</div>
 	);

--- a/src/renderer/components/RightPanel.tsx
+++ b/src/renderer/components/RightPanel.tsx
@@ -39,6 +39,7 @@ import { useSessionStore, selectActiveSession } from '../stores/sessionStore';
 import { useWindowOwnsSession } from '../contexts/WindowContext';
 import type { FileNode } from '../types/fileTree';
 import { RIGHT_PANEL_MIN_WIDTH, RIGHT_PANEL_MAX_WIDTH } from '../constants/rightPanel';
+import { PluginUiItemsSlot } from './plugins/PluginUiItemsSlot';
 
 export interface RightPanelHandle {
 	refreshHistoryPanel: () => void;
@@ -488,6 +489,8 @@ export const RightPanel = memo(
 							{tab === 'autorun' ? 'Auto Run' : tab.charAt(0).toUpperCase() + tab.slice(1)}
 						</button>
 					))}
+
+					<PluginUiItemsSlot surface="rightPanelTab" className="px-1 shrink-0" />
 
 					<button
 						onClick={() => setRightPanelOpen(!rightPanelOpen)}

--- a/src/renderer/components/SessionItem.tsx
+++ b/src/renderer/components/SessionItem.tsx
@@ -17,6 +17,7 @@ import { CueIndicator } from './SessionList/CueIndicator';
 import { StartupCommandIndicator } from './SessionList/StartupCommandIndicator';
 import { WizardIndicator } from './SessionList/WizardIndicator';
 import { WindowBadge } from './SessionList/WindowBadge';
+import { PluginUiItemsSlot } from './plugins/PluginUiItemsSlot';
 import { useSettingsStore } from '../stores/settingsStore';
 import { useSessionHasActiveOutage } from '../stores/retryStore';
 import { COLORBLIND_STATUS_COLORS } from '../constants/colorblindPalettes';
@@ -428,6 +429,8 @@ export const SessionItem = memo(function SessionItem({
 						{session.sessionSshRemoteConfig?.enabled ? ' (SSH)' : ''}
 					</div>
 				)}
+				{/* Host-owned secondary actions stay outside session identity and SSH/status indicators. */}
+				{variant !== 'worktree' && <PluginUiItemsSlot surface="sessionRowBadge" className="mt-1" />}
 			</div>
 
 			{/* Right side: Indicators and actions */}

--- a/src/renderer/components/SessionList/SessionContextMenu.tsx
+++ b/src/renderer/components/SessionList/SessionContextMenu.tsx
@@ -638,7 +638,7 @@ export function SessionContextMenu({
 				</>
 			)}
 
-			<PluginUiItemsSlot surface="contextMenuItem" presentation="menu" />
+			<PluginUiItemsSlot surface="contextMenuItem" presentation="menu" onActivate={onDismiss} />
 
 			<div className="my-1 border-t" style={{ borderColor: theme.colors.border }} />
 

--- a/src/renderer/components/SessionList/SessionContextMenu.tsx
+++ b/src/renderer/components/SessionList/SessionContextMenu.tsx
@@ -23,6 +23,7 @@ import { useClickOutside, useContextMenuPosition } from '../../hooks';
 import { safeClipboardWrite } from '../../utils/clipboard';
 import { flashCopiedToClipboard } from '../../utils/flashCopiedToClipboard';
 import type { WindowMoveTarget } from '../../utils/windowTargets';
+import { PluginUiItemsSlot } from '../plugins/PluginUiItemsSlot';
 
 interface SessionContextMenuProps {
 	x: number;
@@ -636,6 +637,8 @@ export function SessionContextMenu({
 					)}
 				</>
 			)}
+
+			<PluginUiItemsSlot surface="contextMenuItem" presentation="menu" />
 
 			<div className="my-1 border-t" style={{ borderColor: theme.colors.border }} />
 

--- a/src/renderer/components/SessionList/SessionList.tsx
+++ b/src/renderer/components/SessionList/SessionList.tsx
@@ -51,6 +51,7 @@ import { SessionContextMenu } from './SessionContextMenu';
 import { buildWindowMoveTargets, scopeSessionsToOwningWindow } from '../../utils/windowTargets';
 import { GroupContextMenu } from './GroupContextMenu';
 import { WizardIndicator } from './WizardIndicator';
+import { PluginUiItemsSlot } from '../plugins/PluginUiItemsSlot';
 import { HamburgerMenuContent } from './HamburgerMenuContent';
 import { CollapsedSessionPillRows } from './CollapsedSessionPill';
 import { SidebarActions } from './SidebarActions';

--- a/src/renderer/components/SessionList/SessionList.tsx
+++ b/src/renderer/components/SessionList/SessionList.tsx
@@ -1713,6 +1713,7 @@ function SessionListInner(props: SessionListProps) {
 										}
 										aria-expanded={!group.collapsed}
 										onKeyDown={(e) => {
+											if (e.target !== e.currentTarget) return;
 											if (e.key === 'Enter' || e.key === ' ') {
 												e.preventDefault();
 												toggleGroup(group.id);
@@ -1798,6 +1799,7 @@ function SessionListInner(props: SessionListProps) {
 												generatingDocs={!!wizardRollup.groups.get(group.id)?.isGeneratingDocs}
 											/>
 										</div>
+										<PluginUiItemsSlot surface="groupHeaderBadge" className="mr-2 shrink-0" />
 										{/* Delete button for empty groups */}
 										{groupSessions.length === 0 && (
 											<button

--- a/src/renderer/components/Settings/PluginsPanel.tsx
+++ b/src/renderer/components/Settings/PluginsPanel.tsx
@@ -28,7 +28,6 @@ import type {
 } from '../../../shared/plugins/contributions';
 import { notifyToast } from '../../stores/notificationStore';
 import { PluginPanelHost } from './PluginPanelHost';
-import { PluginPanelSlot } from '../plugins/PluginPanelSlot';
 import { PluginActivityView } from './PluginActivityView';
 
 interface PluginsPanelProps {
@@ -402,14 +401,6 @@ export function PluginsPanel({ theme }: PluginsPanelProps) {
 
 			{/* Read-only per-plugin observability for running tier-1 plugins. */}
 			<PluginActivityView theme={theme} records={records} />
-
-			{/* Plugin panels that dock into Settings (placement: 'settings'). Each
-			    renders in the same locked-down sandboxed iframe with provenance. */}
-			<PluginPanelSlot
-				theme={theme}
-				placement="settings"
-				className="mt-4 flex flex-col overflow-hidden rounded-lg border h-[440px]"
-			/>
 
 			{openPanel && (
 				<PluginPanelHost theme={theme} panel={openPanel} onClose={() => setOpenPanel(null)} />

--- a/src/renderer/components/Settings/__tests__/PluginsPanel.test.tsx
+++ b/src/renderer/components/Settings/__tests__/PluginsPanel.test.tsx
@@ -9,12 +9,14 @@
 
 import '@testing-library/jest-dom';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, waitFor, cleanup } from '@testing-library/react';
+import { render, screen, waitFor, cleanup } from '@testing-library/react';
 
 // Isolate PluginsPanel from children that also hit the plugin bridge on mount.
 vi.mock('../PluginActivityView', () => ({ PluginActivityView: () => null }));
 vi.mock('../PluginPanelHost', () => ({ PluginPanelHost: () => null }));
-vi.mock('../../plugins/PluginPanelSlot', () => ({ PluginPanelSlot: () => null }));
+vi.mock('../../plugins/PluginPanelSlot', () => ({
+	PluginPanelSlot: () => <div data-testid="plugin-settings-panel-slot" />,
+}));
 vi.mock('../../../stores/notificationStore', () => ({ notifyToast: vi.fn() }));
 
 import { PluginsPanel } from '../PluginsPanel';
@@ -62,6 +64,13 @@ describe('PluginsPanel - plugins:changed subscription', () => {
 
 		// The panel must re-fetch so the toggle reflects the new enabled state.
 		await waitFor(() => expect(bridge.list).toHaveBeenCalledTimes(2));
+	});
+
+	it('never mounts a plugin panel inside plugin-management controls', async () => {
+		render(<PluginsPanel theme={theme} />);
+
+		await waitFor(() => expect(bridge.list).toHaveBeenCalledTimes(1));
+		expect(screen.queryByTestId('plugin-settings-panel-slot')).not.toBeInTheDocument();
 	});
 
 	it('unsubscribes on unmount (no leaked listener)', async () => {

--- a/src/renderer/components/Settings/tabs/DisplayTab/DisplayTab.tsx
+++ b/src/renderer/components/Settings/tabs/DisplayTab/DisplayTab.tsx
@@ -22,6 +22,8 @@ import {
 } from './components';
 import { useBionifyAlgorithmState, useFontConfigurationState } from './hooks';
 import type { DisplayTabProps } from './types';
+import { PluginPanelSlot } from '../../../plugins/PluginPanelSlot';
+import { PluginUiItemsSlot } from '../../../plugins/PluginUiItemsSlot';
 
 export type { DisplayTabProps } from './types';
 
@@ -171,6 +173,15 @@ export function DisplayTab({ theme }: DisplayTabProps) {
 				setSshReduceEntryCapEnabled={settings.setSshReduceEntryCapEnabled}
 				sshReduceEntryCapFraction={settings.sshReduceEntryCapFraction}
 				setSshReduceEntryCapFraction={settings.setSshReduceEntryCapFraction}
+			/>
+
+			{/* This neutral display-settings slot is deliberately outside plugin
+			    management, consent, uninstall, and grant/revoke flows. */}
+			<PluginUiItemsSlot surface="settingsSection" className="rounded-lg border p-3" />
+			<PluginPanelSlot
+				theme={theme}
+				placement="settings"
+				className="flex flex-col overflow-hidden rounded-lg border h-[440px]"
 			/>
 
 			{bionifyAlgorithmState.showInfoModal && (

--- a/src/renderer/components/TabBar/TabBar.tsx
+++ b/src/renderer/components/TabBar/TabBar.tsx
@@ -23,6 +23,7 @@ import { isUnifiedTabActive, getShortcutHint } from './tabBarUtils';
 import { buildFileTabDisplayNames } from '../../hooks/tabs/internal/filePreviewTabHelpers';
 import { useWindowOwnsSession } from '../../contexts/WindowContext';
 import type { TabBarProps } from './types';
+import { PluginUiItemsSlot } from '../plugins/PluginUiItemsSlot';
 import { logger } from '../../utils/logger';
 
 /** Approximate width of the sticky right "+" button area (px) */
@@ -856,6 +857,9 @@ function TabBarInner({
 			{/* Tab group chips render inline within the unified tab loop above (each
 			    tiled group is a first-class `group` unified tab, ordered by its ref in
 			    unifiedTabOrder), so no separate append here. */}
+
+			{/* Trailing plugin actions are host-rendered controls, never tab chips. */}
+			<PluginUiItemsSlot surface="tabBar" className="shrink-0 self-center mb-1" />
 
 			{/* New tab button + popover */}
 			<NewTabPopover

--- a/src/renderer/components/plugins/PluginUiItemsSlot.tsx
+++ b/src/renderer/components/plugins/PluginUiItemsSlot.tsx
@@ -38,11 +38,13 @@ interface PluginUiItemsSlotProps {
 	surface: PluginUiSurface;
 	className?: string;
 	presentation?: PluginUiItemsSlotPresentation;
+	onActivate?: () => void;
 }
 
 export function PluginUiItemsSlot({
 	surface,
 	className,
+	onActivate,
 	presentation = 'inline',
 }: PluginUiItemsSlotProps) {
 	const contributions = usePluginContributions();
@@ -99,6 +101,7 @@ export function PluginUiItemsSlot({
 						onClick={(event) => {
 							event.stopPropagation();
 							void activate(item);
+							onActivate?.();
 						}}
 						className={itemClass}
 						title={tooltip}

--- a/src/renderer/components/plugins/PluginUiItemsSlot.tsx
+++ b/src/renderer/components/plugins/PluginUiItemsSlot.tsx
@@ -5,9 +5,9 @@
  * fire-and-forget contract the menu surface (Quick Actions palette) and docked
  * panels use, so a uiItem can only ever dispatch a command its plugin registered.
  *
- * The `menu` surface is handled separately by the command palette; this slot
- * covers the in-chrome regions (sidebar, activity bar, toolbar). `status-bar`
- * has no host region today, so nothing mounts it.
+ * The `menu` surface is handled separately by the command palette; this shared
+ * host-owned slot covers the remaining approved mount points. `status-bar` has
+ * no host region today, so nothing mounts it.
  *
  * Renders nothing when the `plugins` Encore flag is off (then
  * `usePluginContributions` returns empty buckets) or when no item targets this
@@ -15,23 +15,53 @@
  */
 
 import { useMemo } from 'react';
-import type { UiSurface, UiItemContribution } from '../../../shared/plugins/contributions';
+import { Circle, Command, PanelRight, Puzzle, Settings } from 'lucide-react';
+import {
+	isPluginUiSurface,
+	type PluginUiSurface,
+	type UiItemContribution,
+} from '../../../shared/plugins/contributions';
 import { usePluginContributions } from '../../hooks/usePluginContributions';
 import { notifyToast } from '../../stores/notificationStore';
 
+const UI_ITEM_ICONS = {
+	action: Command,
+	panel: PanelRight,
+	plugin: Puzzle,
+	settings: Settings,
+	status: Circle,
+} as const;
+
+type PluginUiItemsSlotPresentation = 'inline' | 'menu';
+
 interface PluginUiItemsSlotProps {
-	surface: UiSurface;
+	surface: PluginUiSurface;
+	className?: string;
+	presentation?: PluginUiItemsSlotPresentation;
 }
 
-export function PluginUiItemsSlot({ surface }: PluginUiItemsSlotProps) {
+export function PluginUiItemsSlot({
+	surface,
+	className,
+	presentation = 'inline',
+}: PluginUiItemsSlotProps) {
 	const contributions = usePluginContributions();
+	// This is a render-boundary backstop, independent of main-process
+	// aggregation. A forged renderer object must never convert an arbitrary
+	// namespaced contribution id into an addressable trusted-chrome surface.
+	const surfaceIsAllowed = isPluginUiSurface(surface);
 
-	const items = useMemo(
-		() => contributions.uiItems.filter((item) => item.surface === surface),
-		[contributions.uiItems, surface]
-	);
+	const items = useMemo(() => {
+		if (!surfaceIsAllowed) return [];
+		return contributions.uiItems.filter(
+			(item) =>
+				item.surface === surface &&
+				isPluginUiSurface(item.surface) &&
+				item.id === `${item.pluginId}/${item.localId}`
+		);
+	}, [contributions.uiItems, surface, surfaceIsAllowed]);
 
-	if (items.length === 0) return null;
+	if (!surfaceIsAllowed || items.length === 0) return null;
 
 	const activate = async (item: UiItemContribution): Promise<void> => {
 		try {
@@ -46,19 +76,38 @@ export function PluginUiItemsSlot({ surface }: PluginUiItemsSlotProps) {
 		}
 	};
 
+	const isMenu = presentation === 'menu';
+	const containerClass = isMenu ? 'flex flex-col' : 'flex items-center gap-1 flex-wrap';
+	const itemClass = isMenu
+		? 'w-full text-left px-3 py-1.5 text-xs hover:bg-white/5 transition-colors flex items-center gap-2'
+		: 'text-xs px-2 py-1 rounded hover:bg-white/5 transition-colors inline-flex items-center gap-1';
+
 	return (
-		<div className="flex items-center gap-1 flex-wrap" data-plugin-uiitems-slot={surface}>
-			{items.map((item) => (
-				<button
-					key={item.id}
-					type="button"
-					onClick={() => void activate(item)}
-					className="text-xs px-2 py-1 rounded hover:bg-white/5 transition-colors"
-					title={`from ${item.pluginId}`}
-				>
-					{item.label}
-				</button>
-			))}
+		<div
+			className={className ? `${containerClass} ${className}` : containerClass}
+			data-plugin-uiitems-slot={surface}
+		>
+			{items.map((item) => {
+				const Icon = item.icon ? UI_ITEM_ICONS[item.icon as keyof typeof UI_ITEM_ICONS] : undefined;
+				const tooltip = item.tooltip
+					? `${item.tooltip} · from ${item.pluginId}`
+					: `from ${item.pluginId}`;
+				return (
+					<button
+						key={item.id}
+						type="button"
+						onClick={(event) => {
+							event.stopPropagation();
+							void activate(item);
+						}}
+						className={itemClass}
+						title={tooltip}
+					>
+						{Icon && <Icon className="w-3 h-3 shrink-0" aria-hidden="true" />}
+						{item.label}
+					</button>
+				);
+			})}
 		</div>
 	);
 }

--- a/src/renderer/components/plugins/__tests__/PluginUiItemsSlot.test.tsx
+++ b/src/renderer/components/plugins/__tests__/PluginUiItemsSlot.test.tsx
@@ -72,6 +72,21 @@ describe('PluginUiItemsSlot', () => {
 		await waitFor(() => expect(pluginBridge.invokeCommand).toHaveBeenCalledWith('p/go'));
 	});
 
+	it('notifies the menu owner after a contributed action activates', async () => {
+		const onActivate = vi.fn();
+		pluginBridge.contributions.mockResolvedValue({
+			...EMPTY,
+			uiItems: [uiItem({ surface: 'contextMenuItem', label: 'Plugin menu action' })],
+		});
+
+		render(
+			<PluginUiItemsSlot surface="contextMenuItem" presentation="menu" onActivate={onActivate} />
+		);
+
+		fireEvent.click(await screen.findByText('Plugin menu action'));
+		await waitFor(() => expect(onActivate).toHaveBeenCalledTimes(1));
+	});
+
 	it.each([
 		'tabBar',
 		'sessionRowBadge',

--- a/src/renderer/components/plugins/__tests__/PluginUiItemsSlot.test.tsx
+++ b/src/renderer/components/plugins/__tests__/PluginUiItemsSlot.test.tsx
@@ -5,6 +5,7 @@ import { PluginUiItemsSlot } from '../PluginUiItemsSlot';
 import type {
 	AggregatedContributions,
 	UiItemContribution,
+	UiSurface,
 } from '../../../../shared/plugins/contributions';
 
 const EMPTY: AggregatedContributions = {
@@ -41,7 +42,7 @@ function uiItem(over: Partial<UiItemContribution> = {}): UiItemContribution {
 // exercises. The global test setup defines window.maestro without `plugins`.
 const pluginBridge = {
 	contributions: vi.fn<() => Promise<AggregatedContributions>>(),
-	onChanged: vi.fn(() => () => {}),
+	onChanged: vi.fn<(listener: () => void) => () => void>(() => () => {}),
 	invokeCommand: vi.fn().mockResolvedValue({ dispatched: true }),
 };
 
@@ -71,6 +72,78 @@ describe('PluginUiItemsSlot', () => {
 		await waitFor(() => expect(pluginBridge.invokeCommand).toHaveBeenCalledWith('p/go'));
 	});
 
+	it.each([
+		'tabBar',
+		'sessionRowBadge',
+		'groupHeaderBadge',
+		'settingsSection',
+		'rightPanelTab',
+		'contextMenuItem',
+		'emptyState',
+	] as const)('renders only a matching %s host-owned slot', async (surface) => {
+		pluginBridge.contributions.mockResolvedValue({
+			...EMPTY,
+			uiItems: [uiItem({ surface, label: `Action for ${surface}` })],
+		});
+
+		const { container } = render(<PluginUiItemsSlot surface={surface} />);
+
+		await screen.findByText(`Action for ${surface}`);
+		expect(container.querySelector(`[data-plugin-uiitems-slot="${surface}"]`)).not.toBeNull();
+	});
+
+	it('removes items when the registry changes after disable or uninstall', async () => {
+		let current: AggregatedContributions = {
+			...EMPTY,
+			uiItems: [uiItem({ surface: 'toolbar', label: 'Will disappear' })],
+		};
+		let notifyChanged: (() => void) | undefined;
+		pluginBridge.contributions.mockImplementation(() => Promise.resolve(current));
+		pluginBridge.onChanged.mockImplementation((listener) => {
+			notifyChanged = listener;
+			return () => {};
+		});
+
+		render(<PluginUiItemsSlot surface="toolbar" />);
+		await screen.findByText('Will disappear');
+
+		current = EMPTY;
+		notifyChanged?.();
+
+		await waitFor(() => expect(screen.queryByText('Will disappear')).not.toBeInTheDocument());
+	});
+
+	it.each([
+		'plugin-management',
+		'permission-consent',
+		'uninstall-grant-revoke',
+		'security-indicators',
+	])('does not render a crafted contribution into protected %s', async (protectedSurface) => {
+		pluginBridge.contributions.mockResolvedValue({
+			...EMPTY,
+			uiItems: [
+				uiItem({
+					surface: protectedSurface as UiSurface,
+					label: `Spoof ${protectedSurface}`,
+				}),
+			],
+		});
+
+		const { container } = render(<PluginUiItemsSlot surface={protectedSurface as UiSurface} />);
+
+		await waitFor(() => expect(pluginBridge.contributions).toHaveBeenCalled());
+		expect(container.querySelector('[data-plugin-uiitems-slot]')).toBeNull();
+		expect(screen.queryByText(`Spoof ${protectedSurface}`)).not.toBeInTheDocument();
+	});
+
+	it('renders no plugin UI while the plugins Encore flag is off', async () => {
+		pluginBridge.contributions.mockRejectedValue(new Error('PluginsDisabled'));
+
+		const { container } = render(<PluginUiItemsSlot surface="emptyState" />);
+
+		await waitFor(() => expect(pluginBridge.contributions).toHaveBeenCalled());
+		expect(container.querySelector('[data-plugin-uiitems-slot]')).toBeNull();
+	});
 	it('does not leak an item into a non-matching surface', async () => {
 		pluginBridge.contributions.mockResolvedValue({
 			...EMPTY,

--- a/src/renderer/hooks/usePluginContributions.test.tsx
+++ b/src/renderer/hooks/usePluginContributions.test.tsx
@@ -1,0 +1,84 @@
+import '@testing-library/jest-dom';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { AggregatedContributions } from '../../shared/plugins/contributions';
+import { usePluginContributions } from './usePluginContributions';
+
+const EMPTY: AggregatedContributions = {
+	themes: [],
+	iconPacks: [],
+	prompts: [],
+	settings: [],
+	commandMacros: [],
+	cueTriggers: [],
+	commands: [],
+	panels: [],
+	agents: [],
+	tools: [],
+	keybindings: [],
+	uiItems: [],
+	hostViews: [],
+	groupings: [],
+	errorsByPlugin: {},
+};
+
+function Probe() {
+	const contributions = usePluginContributions();
+	return (
+		<>
+			{contributions.uiItems.map((item) => (
+				<span key={item.id}>{item.label}</span>
+			))}
+		</>
+	);
+}
+
+afterEach(() => {
+	window.maestro.plugins = undefined as unknown as typeof window.maestro.plugins;
+});
+
+describe('usePluginContributions', () => {
+	it('ignores an older active response after a changed event returns an empty snapshot', async () => {
+		let resolveInitial!: (value: AggregatedContributions) => void;
+		const initial = new Promise<AggregatedContributions>((resolve) => {
+			resolveInitial = resolve;
+		});
+		let notifyChanged!: () => void;
+		const plugins = {
+			contributions: vi.fn().mockReturnValueOnce(initial).mockResolvedValueOnce(EMPTY),
+			onChanged: vi.fn((listener: () => void) => {
+				notifyChanged = listener;
+				return () => {};
+			}),
+		};
+		window.maestro.plugins = plugins as unknown as typeof window.maestro.plugins;
+
+		render(<Probe />);
+		await waitFor(() => expect(plugins.contributions).toHaveBeenCalledTimes(1));
+
+		act(() => notifyChanged());
+		await waitFor(() => expect(plugins.contributions).toHaveBeenCalledTimes(2));
+		await act(async () => {
+			await Promise.resolve();
+		});
+
+		await act(async () => {
+			resolveInitial({
+				...EMPTY,
+				uiItems: [
+					{
+						id: 'p/open',
+						localId: 'open',
+						pluginId: 'p',
+						surface: 'emptyState',
+						label: 'Revoked action',
+						command: 'run',
+					},
+				],
+			});
+			await Promise.resolve();
+		});
+
+		await waitFor(() => expect(screen.queryByText('Revoked action')).not.toBeInTheDocument());
+	});
+});

--- a/src/renderer/hooks/usePluginContributions.ts
+++ b/src/renderer/hooks/usePluginContributions.ts
@@ -40,14 +40,16 @@ export function usePluginContributions(): AggregatedContributions {
 		if (!plugins) return;
 
 		let cancelled = false;
+		let requestGeneration = 0;
 
 		const load = async (): Promise<void> => {
+			const generation = ++requestGeneration;
 			try {
 				const next = await plugins.contributions();
-				if (!cancelled) setContributions(next);
+				if (!cancelled && generation === requestGeneration) setContributions(next);
 			} catch {
 				// 'PluginsDisabled' or any read failure -> behave as feature-off.
-				if (!cancelled) setContributions(EMPTY);
+				if (!cancelled && generation === requestGeneration) setContributions(EMPTY);
 			}
 		};
 
@@ -58,6 +60,7 @@ export function usePluginContributions(): AggregatedContributions {
 
 		return () => {
 			cancelled = true;
+			requestGeneration++;
 			unsubscribe();
 		};
 	}, []);

--- a/src/shared/plugins/contributions.ts
+++ b/src/shared/plugins/contributions.ts
@@ -240,27 +240,109 @@ export interface KeybindingContribution {
 	description?: string;
 }
 
-/** Where a `ui:contribute` item renders. The renderer maps each surface to a
- * concrete region (status bar, menus, sidebar/activity bar, toolbar). */
-export type UiSurface = 'status-bar' | 'menu' | 'sidebar' | 'activity-bar' | 'toolbar';
-
-export const UI_SURFACES: readonly UiSurface[] = [
+/**
+ * Host-mediated regions a plugin may target with a declarative `uiItem`.
+ * Add a future surface by appending one literal here; the union and all
+ * allowlist checks derive from this registry.
+ */
+export const UI_SURFACES = [
 	'status-bar',
 	'menu',
 	'sidebar',
 	'activity-bar',
 	'toolbar',
-];
+	'tabBar',
+	'sessionRowBadge',
+	'groupHeaderBadge',
+	'settingsSection',
+	'rightPanelTab',
+	'contextMenuItem',
+	'emptyState',
+] as const;
 
-/** Type guard: is `value` one of the known UI surfaces? */
-export function isUiSurface(value: unknown): value is UiSurface {
+/** Public union of the host-owned slots available to `ui:contribute`. */
+export type PluginUiSurface = (typeof UI_SURFACES)[number];
+
+/** Compatibility name retained for existing plugin authors. */
+export type UiSurface = PluginUiSurface;
+
+/**
+ * Host-owned chrome that is permanently unavailable to every plugin render
+ * tier. Keep these semantic targets separate from contribution ids: ids are
+ * only provenance/uniqueness, never an authority to mount into a region.
+ */
+export const PROTECTED_UI_SURFACES = [
+	'plugin-management',
+	'permission-consent',
+	'uninstall-grant-revoke',
+	'security-indicators',
+] as const;
+
+export type ProtectedUiSurface = (typeof PROTECTED_UI_SURFACES)[number];
+export type HostUiSurface = PluginUiSurface | ProtectedUiSurface;
+export type PluginUiMountTier = 'ui:contribute' | 'ui:render-unsafe';
+
+export interface PluginUiMountAttempt {
+	pluginId: string;
+	tier: PluginUiMountTier;
+	target: unknown;
+}
+
+export type PluginUiMountValidation =
+	| { allowed: true }
+	| {
+			allowed: false;
+			error: string;
+	  };
+
+/** Is `value` a host zone that plugins may never target or nest beneath? */
+export function isProtectedUiSurface(value: unknown): value is ProtectedUiSurface {
+	return typeof value === 'string' && (PROTECTED_UI_SURFACES as readonly string[]).includes(value);
+}
+
+/** Type guard for the positive allowlist of plugin-contributable host slots. */
+export function isPluginUiSurface(value: unknown): value is PluginUiSurface {
 	return typeof value === 'string' && (UI_SURFACES as readonly string[]).includes(value);
+}
+
+/** Host-internal target guard; unknown strings fail closed. */
+export function isHostUiSurface(value: unknown): value is HostUiSurface {
+	return isPluginUiSurface(value) || isProtectedUiSurface(value);
+}
+
+/** Backward-compatible name for the original public surface guard. */
+export const isUiSurface = isPluginUiSurface;
+
+/**
+ * Shared trusted-chrome admission policy for declarative items and the
+ * high-trust `ui:render-unsafe` tier. The latter has no current mount API, but
+ * any future unsafe renderer must use this exact registry-level check before it
+ * selects a host slot.
+ */
+export function validatePluginUiMount({
+	pluginId,
+	tier,
+	target,
+}: PluginUiMountAttempt): PluginUiMountValidation {
+	if (isProtectedUiSurface(target)) {
+		return {
+			allowed: false,
+			error: `[${pluginId}] ${tier} surface "${target}" is protected chrome and was dropped`,
+		};
+	}
+	if (!isPluginUiSurface(target)) {
+		return {
+			allowed: false,
+			error: `[${pluginId}] ${tier} surface "${String(target)}" is invalid or unavailable`,
+		};
+	}
+	return { allowed: true };
 }
 
 /**
  * A declarative UI item a (tier-1) plugin renders into a host surface. The item
- * is pure data (label / icon / placement) the host renders; activating it invokes
- * one of the plugin's OWN commands through the broker. Gated by the
+ * is pure data (label / icon / tooltip / placement) the host renders; activating
+ * it invokes one of the plugin's OWN commands through the broker. Gated by the
  * `ui:contribute` capability (see `gateContributions`), so an enabled plugin
  * WITHOUT that grant contributes none.
  */
@@ -268,12 +350,14 @@ export interface UiItemContribution {
 	id: string;
 	localId: string;
 	pluginId: string;
-	surface: UiSurface;
+	surface: PluginUiSurface;
 	label: string;
 	/** Plugin-local command id invoked on activation. */
 	command: string;
 	/** Optional icon keyword the renderer maps to its icon set. */
 	icon?: string;
+	/** Optional host-rendered tooltip; provenance is always appended by the host. */
+	tooltip?: string;
 	/** Optional grouping / ordering hints within the surface. */
 	group?: string;
 	priority?: number;
@@ -613,7 +697,22 @@ export function aggregateContributions(
 		c.agents.forEach((agent) => pushUnique('agents', agg.agents, agent));
 		c.tools.forEach((t) => pushUnique('tools', agg.tools, t));
 		c.keybindings.forEach((k) => pushUnique('keybindings', agg.keybindings, k));
-		c.uiItems.forEach((u) => pushUnique('uiItems', agg.uiItems, u));
+		c.uiItems.forEach((item) => {
+			// Defense in depth: collection already validates the raw surface, but
+			// aggregation is the last shared registry boundary before IPC exposes
+			// these records to every renderer. Never trust a forged intermediate
+			// object or a future collection path to have done that validation.
+			const mount = validatePluginUiMount({
+				pluginId: item.pluginId,
+				tier: 'ui:contribute',
+				target: item.surface,
+			});
+			if (!mount.allowed) {
+				(agg.errorsByPlugin[item.pluginId] ??= []).push(mount.error);
+				return;
+			}
+			pushUnique('uiItems', agg.uiItems, item);
+		});
 		c.hostViews.forEach((view) => pushUnique('hostViews', agg.hostViews, view));
 		c.groupings.forEach((grouping) => pushUnique('groupings', agg.groupings, grouping));
 	}
@@ -1112,8 +1211,13 @@ function parseUiItem(pluginId: string, raw: unknown, errors: string[]): UiItemCo
 	}
 	const localId = parseLocalId(pluginId, raw, errors);
 	if (!localId) return null;
-	if (!isUiSurface(raw.surface)) {
-		errors.push(`[${pluginId}] uiItem "${localId}" has an invalid or missing surface`);
+	const mount = validatePluginUiMount({
+		pluginId,
+		tier: 'ui:contribute',
+		target: raw.surface,
+	});
+	if (!mount.allowed) {
+		errors.push(mount.error);
 		return null;
 	}
 	if (!isNonEmptyString(raw.label)) {
@@ -1130,10 +1234,11 @@ function parseUiItem(pluginId: string, raw: unknown, errors: string[]): UiItemCo
 		id: namespaced(pluginId, localId),
 		localId,
 		pluginId,
-		surface: raw.surface,
+		surface: raw.surface as PluginUiSurface,
 		label: raw.label.trim(),
 		command: raw.command.trim(),
 		...(isNonEmptyString(raw.icon) ? { icon: raw.icon.trim() } : {}),
+		...(isNonEmptyString(raw.tooltip) ? { tooltip: raw.tooltip.trim() } : {}),
 		...(isNonEmptyString(raw.group) ? { group: raw.group.trim() } : {}),
 		...(priority !== undefined ? { priority } : {}),
 	};

--- a/src/shared/plugins/host-api.ts
+++ b/src/shared/plugins/host-api.ts
@@ -21,25 +21,22 @@
 import semver from 'semver';
 
 /**
- * The host API version this Maestro build implements. Bumped to 1.12.0 for the
- * backward-compatible additive `net:connect` capability plus its `net.connect`
- * / `net.send` / `net.close` host methods (hold an outbound persistent
- * websocket to a host scope, e.g. a Discord/Slack gateway; egress-classified).
- * 1.11.0 added virtual `groupings` contributions and the presentation-only
- * `ui:grouping` publish/clear methods; 1.10.0 added the backward-compatible,
- * data-only `iconPacks` contribution; 1.9.0 added host-rendered `hostViews`,
- * their `ui:hostView` capability, and the `ui.hostViewUpdate` /
- * `ui.hostViewRemove` RPC methods; 1.8.0 added `background.list`; 1.7.0 added
- * history/session/tab/transcript
- * write/decision/shell/storage SQL/fs watch/power/background capabilities plus
- * `history.entryAdded` and metadata-only `agent.completed` events; 1.6.0 added
- * `cue.runStarted` / `cue.runFinished`; 1.5.0 added `agent.exited` /
- * `agent.error` / `usage.updated` / `run.completed` + functional
- * `sidebar`/`activity-bar`/`toolbar` uiItem surfaces; 1.4.0 added the
- * `ui:contribute` / `ui:panel` / `ui:render-unsafe` UI capabilities; 1.3.0
- * added `tools` + `keybindings`; 1.2.0 added `transcripts:read`.
+ * The host API version this Maestro build implements. Bumped to 1.13.0 for the
+ * additive host-mediated `PluginUiSurface` registry and trusted-chrome guard.
+ * 1.12.0 added `net:connect` plus `net.connect` / `net.send` / `net.close`;
+ * 1.11.0 added virtual `groupings` and `ui:grouping`; 1.10.0 added data-only
+ * `iconPacks`; 1.9.0 added host-rendered `hostViews`, `ui:hostView`, and
+ * `ui.hostViewUpdate` / `ui.hostViewRemove`; 1.8.0 added `background.list`;
+ * 1.7.0 added history/session/tab/transcript write, decision/shell/storage
+ * SQL/fs watch/power/background capabilities plus `history.entryAdded` and
+ * metadata-only `agent.completed` events; 1.6.0 added `cue.runStarted` /
+ * `cue.runFinished`; 1.5.0 added `agent.exited` / `agent.error` /
+ * `usage.updated` / `run.completed` plus functional
+ * `sidebar`/`activity-bar`/`toolbar` uiItem surfaces; 1.4.0 added
+ * `ui:contribute` / `ui:panel` / `ui:render-unsafe`; 1.3.0 added `tools` +
+ * `keybindings`; 1.2.0 added `transcripts:read`.
  */
-export const HOST_API_VERSION = '1.12.0';
+export const HOST_API_VERSION = '1.13.0';
 
 /** Result of checking a plugin's declared host-API requirement. */
 export interface HostApiCompatibility {

--- a/src/shared/plugins/permissions.ts
+++ b/src/shared/plugins/permissions.ts
@@ -59,7 +59,7 @@ export type PluginCapability =
 	| 'ui:panel' // show its own sandboxed interactive panels
 	| 'ui:hostView' // contribute and update host-rendered BlockView data
 	| 'ui:grouping' // publish virtual session grouping snapshots (presentation only)
-	| 'ui:render-unsafe'; // render arbitrary UI with full interface access (escape hatch)
+	| 'ui:render-unsafe'; // high-trust custom UI in host-approved, non-protected regions
 
 export const PLUGIN_CAPABILITIES: readonly PluginCapability[] = [
 	'fs:read',
@@ -529,15 +529,15 @@ export function describeCapability(capability: PluginCapability): string {
 		case 'transcripts:write':
 			return 'Write brokered entries into session transcripts';
 		case 'ui:contribute':
-			return "Add items to Maestro's interface (menus, sidebar, status bar, settings, themes)";
+			return "Add declarative items to Maestro's approved host surfaces";
 		case 'ui:panel':
-			return 'Show its own panels inside Maestro';
+			return 'Show its own panels inside approved Maestro regions';
 		case 'ui:hostView':
 			return 'Show and update host-rendered BlockView data in Maestro';
 		case 'ui:grouping':
 			return 'Organize session metadata into virtual sidebar groups';
 		case 'ui:render-unsafe':
-			return "Render its own custom UI with full access to Maestro's interface (advanced - only enable for authors you fully trust)";
+			return 'Render high-trust custom UI only in host-approved, non-protected regions (advanced - only enable authors you fully trust)';
 	}
 }
 


### PR DESCRIPTION
## What & why

Extends the plugin interface so plugins can contribute UI into a broad set of **host-mediated** surfaces, while a hardcoded **trusted-chrome** set stays permanently off-limits to any plugin. Host owns every frame and theme; plugin code never runs in the main renderer. This is the "widen mediated mount points" model (chosen over arbitrary UI mutation) — the safe way to let plugins customize most of the app.

## New contributable surfaces

Extends the existing `ui:contribute`/`uiItems` mechanism (declarative label/icon/command/tooltip only) to: `toolbar`, `tabBar`, `sessionRowBadge`, `groupHeaderBadge`, `settingsSection`, `rightPanelTab`, `contextMenuItem`, `emptyState`. The surface union derives from one `UI_SURFACES` catalog — adding a future safe surface is a one-line entry. Items are host-rendered, themed, provenance-tagged (`from <plugin>`), and can only dispatch the plugin's own namespaced command.

## Trusted-chrome guard (the point of this PR)

Four zones are **permanently unavailable** to every plugin surface — declarative *and* the high-trust `ui:render-unsafe` tier:
1. **plugin-management** + enable/disable
2. **permission/consent dialogs**
3. **uninstall / grant-revoke flows**
4. **security indicators** (SSH status, permission-mode, agent identity)

Enforcement is layered:
- Protected zones are **not members** of the contributable `PluginUiSurface` allowlist to begin with.
- `validatePluginUiMount` rejects protected/unknown targets, called at BOTH `parseUiItem` and `aggregateContributions` (parse-time + pre-insertion revalidation), recording a "protected chrome" error.
- **Render-boundary backstop**: `PluginUiItemsSlot` re-checks the positive allowlist and requires canonical `<pluginId>/<localId>` provenance, so a forged renderer object can't address a protected surface.
- `ui:render-unsafe` cannot unlock `ui:contribute`/`ui:panel` (regression-tested).
- **Cutover**: the plugin-management screen previously hosted a sandboxed `PluginPanelSlot`; moved it to neutral Display settings, with a test asserting plugin panels are absent from management controls.

## Testing

- `it.each(PROTECTED_UI_SURFACES)`: every zone rejects declarative + render-unsafe attempts (the security regression test).
- Surface enum/schema validation, aggregation rules (namespacing, first-wins, built-in-wins), render-slot smoke, lifecycle purge (disable → items vanish), flag-off → no UI, SDK drift.
- `HOST_API_VERSION` 1.13.0 (additive/MINOR), `@maestro/plugin-sdk` 0.8.0 in lockstep. `bun run lint` + prettier + eslint clean.

Rebased onto current `rc`; the additive host API and SDK versions are linearized at 1.13.0 and 0.8.0 respectively.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added plugin UI extension points across empty states, tabs, session lists, context menus, settings, and panels.
  * Upgraded plugin UI actions with **inline/menu** presentation, per-item icons, and tooltips; added an additional UI item slot in the right-side tab header.

* **Improvements**
  * Advanced the plugin/host UI contract and **tightened “trusted chrome” protections** with an explicit protected-surface denylist.
  * Clarified that **`ui:render-unsafe` remains restricted** to host-approved, non-protected regions.
  * Updated special `placement: "settings"` behavior to render only in neutral display settings.

* **Documentation**
  * Refreshed plugin development guidance, including `uiItems` shape and trusted-chrome constraints.

* **Tests**
  * Expanded contract drift and UI mount-policy coverage, plus renderer hardening tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
