### PR TITLE
feat(plugins): groupings contribution — plugin-defined virtual agent groupings

### DIFF
--- a/CLAUDE-PLUGINS.md
+++ b/CLAUDE-PLUGINS.md
@@ -216,3 +216,21 @@ External authors do not read this repo; two artifacts hand them the contract:
 - [docs/agent-guides/PLUGIN-DEVELOPMENT.md](docs/agent-guides/PLUGIN-DEVELOPMENT.md) - the practical authoring guide.
 - `packages/plugin-sdk/` - the `@maestro/plugin-sdk` typed authoring package (vendored contracts + drift guard).
 - `src/cli/commands/plugin.ts` - the `maestro plugin` init/validate/sign/pack CLI.
+
+## Virtual session groupings (HOST_API 1.9.0)
+
+`contributes.groupings` adds a presentation-only sidebar mode. A tier-0 grouping
+declares `{ id, label, description?, rules? }`; rules are first-match-wins and
+may match `toolType`, `cwdGlob`, and `namePattern`, assigning display `group`
+and optional `parentGroup` labels. Unmatched sessions appear in **Other**.
+Patterns use only the bounded `*` wildcard grammar (all other characters are
+literal); no plugin-supplied regular expression is compiled. Groupings never
+write `session.groupId` or create, rename, or delete persisted groups.
+
+Tier-1 code may publish a validated metadata-only snapshot through
+`ui:grouping`: `maestro.ui.grouping.publish({ id, groups, assignments })` and
+`maestro.ui.grouping.clear(id)`. The id must be this plugin's declared local
+grouping id; group ids are local, depth is at most two, unknown session ids are
+dropped, and snapshots are process-local and purged when the sandbox stops,
+the plugin is disabled/uninstalled, or the feature flag is off. `ui:grouping`
+is low-risk and unscoped because its only output is virtual presentation.

--- a/docs/agent-guides/PLUGIN-DEVELOPMENT.md
+++ b/docs/agent-guides/PLUGIN-DEVELOPMENT.md
@@ -608,3 +608,41 @@ Typical flow: `init` -> edit -> `validate` -> `sign --gen-key --key-out key.pem`
 - `src/renderer/components/plugins/PluginPanelFrame.tsx` + `src/main/plugins/plugin-panel-host.ts` - the panel render host (isolated webview), CSP, and the postMessage bridge.
 - `packages/plugin-sdk/` - the `@maestro/plugin-sdk` typed authoring package.
 - `src/cli/commands/plugin.ts` - the `maestro plugin` init/validate/sign/pack CLI.
+
+## Virtual sidebar groupings
+
+Groupings are virtual views of session metadata: they never change persisted
+groups or a session's `groupId`. A tier-0 manifest can provide a rule-based mode:
+
+```json
+{
+	"contributes": {
+		"groupings": [
+			{
+				"id": "by-agent-type",
+				"label": "Group by agent type",
+				"rules": [
+					{ "match": { "toolType": "claude" }, "group": "Claude" },
+					{ "match": { "toolType": "codex" }, "group": "Codex" }
+				]
+			}
+		]
+	}
+}
+```
+
+Rules are evaluated in order and unmatched sessions are shown in `Other`.
+`cwdGlob` and `namePattern` use only the safe `*` wildcard grammar, not regular
+expressions. A tier-1 plugin with the `ui:grouping` permission can publish a
+computed version of one of its declared grouping ids:
+
+```ts
+await maestro.ui.grouping.publish({
+	id: 'by-agent-type',
+	groups: [{ id: 'claude', label: 'Claude' }],
+	assignments: { 'session-id': 'claude' },
+});
+```
+
+Published group ids are local to the declared grouping, may nest only one level,
+and use session metadata only. The host silently drops unknown session ids.

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -1,8 +1,8 @@
 {
 	"name": "@maestro/plugin-sdk",
-	"version": "0.5.0",
+	"version": "0.6.0",
 	"description": "Typed authoring surface for Maestro plugins (manifest, contributions, permissions, events, and the sandbox runtime API).",
-	"//": "Self-contained, dependency-free. The vendored plugin contracts track the Maestro plugin HOST_API_VERSION (1.10.0) from src/shared/plugins/host-api.ts; a drift-guard test asserts parity with those sources. Bump in lockstep with that contract: MINOR when the host adds a backward-compatible capability/contribution/method, MAJOR when one changes meaning or is removed.",
+	"//": "Self-contained, dependency-free. The vendored plugin contracts track the Maestro plugin HOST_API_VERSION (1.11.0) from src/shared/plugins/host-api.ts; a drift-guard test asserts parity with those sources. Bump in lockstep with that contract: MINOR when the host adds a backward-compatible capability/contribution/method, MAJOR when one changes meaning or is removed.",
 	"type": "module",
 	"license": "AGPL-3.0-only",
 	"main": "dist/index.js",

--- a/packages/plugin-sdk/src/__tests__/drift.test.ts
+++ b/packages/plugin-sdk/src/__tests__/drift.test.ts
@@ -12,11 +12,7 @@ import {
 	HOST_API_VERSION,
 	PLUGIN_ID_PATTERN,
 	UI_SURFACES,
-	HOST_VIEW_SURFACES,
-	MAX_HOST_VIEW_BLOCKS_BYTES,
-	serializedJsonByteLength,
 	capabilityRisk,
-	isHostViewBlocks,
 	describeCapability,
 	isPluginCategory,
 	validatePluginManifest,
@@ -43,13 +39,7 @@ import {
 	HOST_METHOD_CAPABILITY as SRC_HOST_METHOD_CAPABILITY,
 } from '../../../../src/shared/plugins/rpc-protocol';
 import { HOST_API_VERSION as SRC_HOST_API_VERSION } from '../../../../src/shared/plugins/host-api';
-import {
-	HOST_VIEW_SURFACES as SRC_HOST_VIEW_SURFACES,
-	MAX_HOST_VIEW_BLOCKS_BYTES as SRC_MAX_HOST_VIEW_BLOCKS_BYTES,
-	serializedJsonByteLength as srcSerializedJsonByteLength,
-	UI_SURFACES as SRC_UI_SURFACES,
-	isHostViewBlocks as srcIsHostViewBlocks,
-} from '../../../../src/shared/plugins/contributions';
+import { UI_SURFACES as SRC_UI_SURFACES } from '../../../../src/shared/plugins/contributions';
 
 // This package VENDORS the frozen plugin contracts so it can publish standalone
 // (no imports outside the package). That copy must never silently fall behind
@@ -86,9 +76,9 @@ describe('@maestro/plugin-sdk vendored-contract drift guard', () => {
 		expect(HOST_METHOD_CAPABILITY).toEqual(SRC_HOST_METHOD_CAPABILITY);
 	});
 
-	it('HOST_API_VERSION matches the source and is pinned to 1.10.0', () => {
+	it('HOST_API_VERSION matches the source and is pinned to 1.9.0', () => {
 		expect(HOST_API_VERSION).toBe(SRC_HOST_API_VERSION);
-		expect(HOST_API_VERSION).toBe('1.10.0');
+		expect(HOST_API_VERSION).toBe('1.9.0');
 	});
 
 	it('capability risk and descriptions match the source', () => {
@@ -100,28 +90,6 @@ describe('@maestro/plugin-sdk vendored-contract drift guard', () => {
 
 	it('UI_SURFACES matches the source render-surface catalog', () => {
 		expect(UI_SURFACES).toEqual(SRC_UI_SURFACES);
-	});
-
-	it('host view surfaces and serialized-block cap match the source', () => {
-		expect(HOST_VIEW_SURFACES).toEqual(SRC_HOST_VIEW_SURFACES);
-		expect(MAX_HOST_VIEW_BLOCKS_BYTES).toBe(SRC_MAX_HOST_VIEW_BLOCKS_BYTES);
-	});
-
-	it('serialized JSON byte measurement matches the source contract', () => {
-		for (const value of [[], { blocks: [{ kind: 'text', content: '🪄' }] }]) {
-			expect(serializedJsonByteLength(value)).toBe(srcSerializedJsonByteLength(value));
-		}
-	});
-
-	it('host view block-shape validation matches the source contract', () => {
-		for (const value of [
-			[],
-			{ blocks: [] },
-			{ blocks: [], extra: true },
-			{ viewType: 'decision', blocks: [] },
-		]) {
-			expect(isHostViewBlocks(value)).toBe(srcIsHostViewBlocks(value));
-		}
 	});
 
 	it('PLUGIN_ID_PATTERN source string matches', () => {

--- a/packages/plugin-sdk/src/__tests__/drift.test.ts
+++ b/packages/plugin-sdk/src/__tests__/drift.test.ts
@@ -12,7 +12,11 @@ import {
 	HOST_API_VERSION,
 	PLUGIN_ID_PATTERN,
 	UI_SURFACES,
+	HOST_VIEW_SURFACES,
+	MAX_HOST_VIEW_BLOCKS_BYTES,
+	serializedJsonByteLength,
 	capabilityRisk,
+	isHostViewBlocks,
 	describeCapability,
 	isPluginCategory,
 	validatePluginManifest,
@@ -39,7 +43,13 @@ import {
 	HOST_METHOD_CAPABILITY as SRC_HOST_METHOD_CAPABILITY,
 } from '../../../../src/shared/plugins/rpc-protocol';
 import { HOST_API_VERSION as SRC_HOST_API_VERSION } from '../../../../src/shared/plugins/host-api';
-import { UI_SURFACES as SRC_UI_SURFACES } from '../../../../src/shared/plugins/contributions';
+import {
+	HOST_VIEW_SURFACES as SRC_HOST_VIEW_SURFACES,
+	MAX_HOST_VIEW_BLOCKS_BYTES as SRC_MAX_HOST_VIEW_BLOCKS_BYTES,
+	serializedJsonByteLength as srcSerializedJsonByteLength,
+	UI_SURFACES as SRC_UI_SURFACES,
+	isHostViewBlocks as srcIsHostViewBlocks,
+} from '../../../../src/shared/plugins/contributions';
 
 // This package VENDORS the frozen plugin contracts so it can publish standalone
 // (no imports outside the package). That copy must never silently fall behind
@@ -76,9 +86,9 @@ describe('@maestro/plugin-sdk vendored-contract drift guard', () => {
 		expect(HOST_METHOD_CAPABILITY).toEqual(SRC_HOST_METHOD_CAPABILITY);
 	});
 
-	it('HOST_API_VERSION matches the source and is pinned to 1.9.0', () => {
+	it('HOST_API_VERSION matches the source and is pinned to 1.11.0', () => {
 		expect(HOST_API_VERSION).toBe(SRC_HOST_API_VERSION);
-		expect(HOST_API_VERSION).toBe('1.9.0');
+		expect(HOST_API_VERSION).toBe('1.11.0');
 	});
 
 	it('capability risk and descriptions match the source', () => {
@@ -90,6 +100,28 @@ describe('@maestro/plugin-sdk vendored-contract drift guard', () => {
 
 	it('UI_SURFACES matches the source render-surface catalog', () => {
 		expect(UI_SURFACES).toEqual(SRC_UI_SURFACES);
+	});
+
+	it('host view surfaces and serialized-block cap match the source', () => {
+		expect(HOST_VIEW_SURFACES).toEqual(SRC_HOST_VIEW_SURFACES);
+		expect(MAX_HOST_VIEW_BLOCKS_BYTES).toBe(SRC_MAX_HOST_VIEW_BLOCKS_BYTES);
+	});
+
+	it('serialized JSON byte measurement matches the source contract', () => {
+		for (const value of [[], { blocks: [{ kind: 'text', content: '🪄' }] }]) {
+			expect(serializedJsonByteLength(value)).toBe(srcSerializedJsonByteLength(value));
+		}
+	});
+
+	it('host view block-shape validation matches the source contract', () => {
+		for (const value of [
+			[],
+			{ blocks: [] },
+			{ blocks: [], extra: true },
+			{ viewType: 'decision', blocks: [] },
+		]) {
+			expect(isHostViewBlocks(value)).toBe(srcIsHostViewBlocks(value));
+		}
 	});
 
 	it('PLUGIN_ID_PATTERN source string matches', () => {

--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -21,40 +21,6 @@ function isNonEmptyString(value: unknown): value is string {
 	return typeof value === 'string' && value.trim() !== '';
 }
 
-/**
- * Maximum UTF-8 size of one host view's serialized BlockView data. This pure
- * contract matches the host declaration and runtime update limits.
- */
-export const MAX_HOST_VIEW_BLOCKS_BYTES = 1_000_000;
-
-/** Size of JSON data as it crosses a UTF-8 message boundary. */
-export function serializedJsonByteLength(value: unknown): number | null {
-	let serialized: string | undefined;
-	try {
-		serialized = JSON.stringify(value);
-	} catch {
-		return null;
-	}
-	if (typeof serialized !== 'string') return null;
-
-	let bytes = 0;
-	for (let index = 0; index < serialized.length; index += 1) {
-		const codePoint = serialized.codePointAt(index);
-		if (codePoint === undefined) continue;
-		if (codePoint <= 0x7f) {
-			bytes += 1;
-		} else if (codePoint <= 0x7ff) {
-			bytes += 2;
-		} else if (codePoint <= 0xffff) {
-			bytes += 3;
-		} else {
-			bytes += 4;
-			index += 1;
-		}
-	}
-	return bytes;
-}
-
 // --- Permissions / capabilities (from shared/plugins/permissions.ts) --------
 
 /** The fixed vocabulary of things a sandboxed plugin can ask to do. Adding a
@@ -88,7 +54,7 @@ export type PluginCapability =
 	| 'background:service' // register supervised background service work
 	| 'ui:contribute' // add host-rendered items to Maestro's UI (menus, panels, theming, …)
 	| 'ui:panel' // show its own sandboxed interactive panels
-	| 'ui:hostView' // contribute and update host-rendered BlockView data
+	| 'ui:grouping' // publish virtual session grouping snapshots (presentation only)
 	| 'ui:render-unsafe'; // render arbitrary UI with full interface access (escape hatch)
 
 export const PLUGIN_CAPABILITIES: readonly PluginCapability[] = [
@@ -120,7 +86,7 @@ export const PLUGIN_CAPABILITIES: readonly PluginCapability[] = [
 	'background:service',
 	'ui:contribute',
 	'ui:panel',
-	'ui:hostView',
+	'ui:grouping',
 	'ui:render-unsafe',
 ];
 
@@ -156,8 +122,8 @@ const CAPABILITY_RISK: Record<PluginCapability, CapabilityRisk> = {
 	'background:service': 'high',
 	'ui:contribute': 'medium',
 	'ui:panel': 'medium',
-	'ui:hostView': 'medium',
 	'ui:render-unsafe': 'high',
+	'ui:grouping': 'low',
 };
 
 /**
@@ -206,7 +172,7 @@ const CAPABILITY_SCOPE_KIND: Record<PluginCapability, ScopeKind> = {
 	'transcripts:write': 'path', // scope is a project path; the handler enforces the session's projectPath against the grant
 	'ui:contribute': 'none',
 	'ui:panel': 'none',
-	'ui:hostView': 'none',
+	'ui:grouping': 'none',
 	'ui:render-unsafe': 'none',
 };
 
@@ -380,8 +346,8 @@ export function describeCapability(capability: PluginCapability): string {
 			return "Add items to Maestro's interface (menus, sidebar, status bar, settings, themes)";
 		case 'ui:panel':
 			return 'Show its own panels inside Maestro';
-		case 'ui:hostView':
-			return 'Show and update host-rendered BlockView data in Maestro';
+		case 'ui:grouping':
+			return 'Organize session metadata into virtual sidebar groups';
 		case 'ui:render-unsafe':
 			return "Render its own custom UI with full access to Maestro's interface (advanced — only enable for authors you fully trust)";
 	}
@@ -389,21 +355,11 @@ export function describeCapability(capability: PluginCapability): string {
 
 // --- Host API version (from shared/plugins/host-api.ts) ---------------------
 
-/**
- * The host API version this Maestro build implements. Bumped to 1.10.0 for the
- * backward-compatible, data-only `iconPacks` contribution. (1.9.0 added
- * host-rendered `hostViews`, their `ui:hostView` capability, and the
- * `ui.hostViewUpdate` / `ui.hostViewRemove` RPC methods; 1.8.0 added
- * `background.list`; 1.7.0 added history/session/tab/transcript
- * write/decision/shell/storage SQL/fs watch/power/background capabilities plus
- * `history.entryAdded` and metadata-only `agent.completed` events; 1.6.0 added
- * `cue.runStarted` / `cue.runFinished`; 1.5.0 added `agent.exited` /
- * `agent.error` / `usage.updated` / `run.completed` + functional
- * `sidebar`/`activity-bar`/`toolbar` uiItem surfaces; 1.4.0 added the
- * `ui:contribute` / `ui:panel` / `ui:render-unsafe` UI capabilities; 1.3.0
- * added `tools` + `keybindings`; 1.2.0 added `transcripts:read`.)
- */
-export const HOST_API_VERSION = '1.10.0';
+/** The host API version this Maestro build implements. Bumped to 1.9.0 for
+ * virtual `groupings` contributions and the presentation-only `ui:grouping`
+ * publish/clear methods. 1.8.0 added `background.list` under the existing
+ * `background:service` capability. */
+export const HOST_API_VERSION = '1.9.0';
 
 /** Result of checking a plugin's declared host-API requirement. */
 export interface HostApiCompatibility {
@@ -743,39 +699,6 @@ export interface ThemeContribution {
 	colors: Record<string, string>;
 }
 
-/** A single safe SVG path within an icon pack. The host owns all SVG markup. */
-export interface IconPackIconContribution {
-	/** Namespaced id: `<pluginId>/<packId>/<localId>`. */
-	id: string;
-	localId: string;
-	label: string;
-	/** Validated SVG path `d` data only; never arbitrary SVG markup. */
-	path: string;
-	/** Optional validated four-number SVG viewBox string. */
-	viewBox?: string;
-}
-
-/** A label color within an icon pack. */
-export interface IconPackColorContribution {
-	/** Namespaced id: `<pluginId>/<packId>/<localId>`. */
-	id: string;
-	localId: string;
-	label: string;
-	/** Validated `#rrggbb` color value. */
-	value: string;
-}
-
-/** A tier-0 pack of host-rendered group icons and label colors. */
-export interface IconPackContribution {
-	/** Namespaced id: `<pluginId>/<localId>`. */
-	id: string;
-	localId: string;
-	pluginId: string;
-	label: string;
-	icons: IconPackIconContribution[];
-	colors: IconPackColorContribution[];
-}
-
 /** A reusable prompt a plugin adds to the prompt catalog. */
 export interface PromptContribution {
 	id: string;
@@ -928,43 +851,26 @@ export interface UiItemContribution {
 	priority?: number;
 }
 
-/** The host-owned view surfaces that render only BlockView data. */
-export type HostViewSurface = 'movement' | 'cadenza';
-
-export const HOST_VIEW_SURFACES: readonly HostViewSurface[] = ['movement', 'cadenza'];
-
-/** Type guard for the two host-rendered view surfaces. */
-export function isHostViewSurface(value: unknown): value is HostViewSurface {
-	return typeof value === 'string' && (HOST_VIEW_SURFACES as readonly string[]).includes(value);
+/** A metadata-only virtual grouping supplied by a plugin. */
+export interface GroupingRule {
+	match: { toolType?: string; cwdGlob?: string; namePattern?: string };
+	group: string;
+	parentGroup?: string;
 }
 
-/** The only data accepted for a host view: the BlockView block array the host
- * renders, never a cadenza command/prompt payload or plugin UI. */
-export type HostViewBlocks = unknown[];
-
-export function isHostViewBlocks(value: unknown): value is HostViewBlocks {
-	return Array.isArray(value);
-}
-
-/**
- * A host-rendered view declared by a data-only or code plugin. The host owns its
- * renderer; a code plugin may later update/remove that declared view through the
- * brokered `ui:hostView` RPC methods.
- */
-export interface HostViewContribution {
+export interface GroupingContribution {
 	id: string;
 	localId: string;
 	pluginId: string;
-	surface: HostViewSurface;
-	title: string;
+	pluginName: string;
+	label: string;
 	description?: string;
-	blocks?: HostViewBlocks;
+	rules?: GroupingRule[];
 }
 
 /** All contributions a single plugin declared, plus any per-item errors. */
 export interface PluginContributions {
 	themes: ThemeContribution[];
-	iconPacks: IconPackContribution[];
 	prompts: PromptContribution[];
 	settings: SettingContribution[];
 	commandMacros: CommandMacroContribution[];
@@ -975,14 +881,13 @@ export interface PluginContributions {
 	tools: AgentToolContribution[];
 	keybindings: KeybindingContribution[];
 	uiItems: UiItemContribution[];
-	hostViews: HostViewContribution[];
+	groupings: GroupingContribution[];
 	errors: string[];
 }
 
 /** Contributions aggregated across every active plugin. */
 export interface AggregatedContributions {
 	themes: ThemeContribution[];
-	iconPacks: IconPackContribution[];
 	prompts: PromptContribution[];
 	settings: SettingContribution[];
 	commandMacros: CommandMacroContribution[];
@@ -993,7 +898,7 @@ export interface AggregatedContributions {
 	tools: AgentToolContribution[];
 	keybindings: KeybindingContribution[];
 	uiItems: UiItemContribution[];
-	hostViews: HostViewContribution[];
+	groupings: GroupingContribution[];
 	/** Per-plugin errors keyed by plugin id (only plugins with errors appear). */
 	errorsByPlugin: Record<string, string[]>;
 }
@@ -1141,8 +1046,6 @@ export const HOST_API = {
 	'storage.sql': { capability: 'storage:sql' },
 	'fs.watch': { capability: 'fs:watch' },
 	'ui.runCommand': { capability: 'ui:command' },
-	'ui.hostViewUpdate': { capability: 'ui:hostView' },
-	'ui.hostViewRemove': { capability: 'ui:hostView' },
 	'tabs.list': { capability: 'tabs:manage' },
 	'tabs.create': { capability: 'tabs:manage' },
 	'tabs.focus': { capability: 'tabs:manage' },
@@ -1157,6 +1060,8 @@ export const HOST_API = {
 	'background.register': { capability: 'background:service' },
 	'background.unregister': { capability: 'background:service' },
 	'background.list': { capability: 'background:service' },
+	'ui.groupingPublish': { capability: 'ui:grouping' },
+	'ui.groupingClear': { capability: 'ui:grouping' },
 } as const satisfies Record<string, { capability: PluginCapability }>;
 
 /** The fixed set of host methods a sandbox may call (derived from HOST_API). */
@@ -1341,17 +1246,19 @@ export interface MaestroStorageApi {
 	): Promise<MaestroSqlResult<Row>>;
 }
 
-/** Update or remove a previously declared host-rendered BlockView (`ui:hostView`). */
-export interface MaestroHostViewApi {
-	update(id: string, blocks: HostViewBlocks): Promise<void>;
-	remove(id: string): Promise<void>;
-}
-
-/** Invoke a registered command-palette command (`ui:command`) or access
- * host-rendered BlockViews. */
+/** Invoke host-rendered UI behavior (`ui:command` / `ui:grouping`). */
 export interface MaestroUiApi {
 	runCommand(commandId: string, args?: unknown): Promise<unknown>;
-	readonly hostView: MaestroHostViewApi;
+	readonly grouping: MaestroGroupingApi;
+}
+
+export interface MaestroGroupingApi {
+	publish(params: {
+		id: string;
+		groups: readonly { id: string; label: string; parentId?: string }[];
+		assignments: Record<string, string>;
+	}): Promise<void>;
+	clear(id: string): Promise<void>;
 }
 
 /** Manage Maestro tabs (`tabs:manage`). */

--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -21,6 +21,40 @@ function isNonEmptyString(value: unknown): value is string {
 	return typeof value === 'string' && value.trim() !== '';
 }
 
+/**
+ * Maximum UTF-8 size of one host view's serialized BlockView data. This pure
+ * contract matches the host declaration and runtime update limits.
+ */
+export const MAX_HOST_VIEW_BLOCKS_BYTES = 1_000_000;
+
+/** Size of JSON data as it crosses a UTF-8 message boundary. */
+export function serializedJsonByteLength(value: unknown): number | null {
+	let serialized: string | undefined;
+	try {
+		serialized = JSON.stringify(value);
+	} catch {
+		return null;
+	}
+	if (typeof serialized !== 'string') return null;
+
+	let bytes = 0;
+	for (let index = 0; index < serialized.length; index += 1) {
+		const codePoint = serialized.codePointAt(index);
+		if (codePoint === undefined) continue;
+		if (codePoint <= 0x7f) {
+			bytes += 1;
+		} else if (codePoint <= 0x7ff) {
+			bytes += 2;
+		} else if (codePoint <= 0xffff) {
+			bytes += 3;
+		} else {
+			bytes += 4;
+			index += 1;
+		}
+	}
+	return bytes;
+}
+
 // --- Permissions / capabilities (from shared/plugins/permissions.ts) --------
 
 /** The fixed vocabulary of things a sandboxed plugin can ask to do. Adding a
@@ -54,6 +88,7 @@ export type PluginCapability =
 	| 'background:service' // register supervised background service work
 	| 'ui:contribute' // add host-rendered items to Maestro's UI (menus, panels, theming, …)
 	| 'ui:panel' // show its own sandboxed interactive panels
+	| 'ui:hostView' // contribute and update host-rendered BlockView data
 	| 'ui:grouping' // publish virtual session grouping snapshots (presentation only)
 	| 'ui:render-unsafe'; // render arbitrary UI with full interface access (escape hatch)
 
@@ -86,6 +121,7 @@ export const PLUGIN_CAPABILITIES: readonly PluginCapability[] = [
 	'background:service',
 	'ui:contribute',
 	'ui:panel',
+	'ui:hostView',
 	'ui:grouping',
 	'ui:render-unsafe',
 ];
@@ -122,8 +158,9 @@ const CAPABILITY_RISK: Record<PluginCapability, CapabilityRisk> = {
 	'background:service': 'high',
 	'ui:contribute': 'medium',
 	'ui:panel': 'medium',
-	'ui:render-unsafe': 'high',
+	'ui:hostView': 'medium',
 	'ui:grouping': 'low',
+	'ui:render-unsafe': 'high',
 };
 
 /**
@@ -172,6 +209,7 @@ const CAPABILITY_SCOPE_KIND: Record<PluginCapability, ScopeKind> = {
 	'transcripts:write': 'path', // scope is a project path; the handler enforces the session's projectPath against the grant
 	'ui:contribute': 'none',
 	'ui:panel': 'none',
+	'ui:hostView': 'none',
 	'ui:grouping': 'none',
 	'ui:render-unsafe': 'none',
 };
@@ -346,6 +384,8 @@ export function describeCapability(capability: PluginCapability): string {
 			return "Add items to Maestro's interface (menus, sidebar, status bar, settings, themes)";
 		case 'ui:panel':
 			return 'Show its own panels inside Maestro';
+		case 'ui:hostView':
+			return 'Show and update host-rendered BlockView data in Maestro';
 		case 'ui:grouping':
 			return 'Organize session metadata into virtual sidebar groups';
 		case 'ui:render-unsafe':
@@ -355,11 +395,23 @@ export function describeCapability(capability: PluginCapability): string {
 
 // --- Host API version (from shared/plugins/host-api.ts) ---------------------
 
-/** The host API version this Maestro build implements. Bumped to 1.9.0 for
- * virtual `groupings` contributions and the presentation-only `ui:grouping`
- * publish/clear methods. 1.8.0 added `background.list` under the existing
- * `background:service` capability. */
-export const HOST_API_VERSION = '1.9.0';
+/**
+ * The host API version this Maestro build implements. Bumped to 1.11.0 for virtual
+ * `groupings` contributions and the presentation-only `ui:grouping` publish/clear
+ * methods. 1.10.0 added the backward-compatible, data-only `iconPacks` contribution.
+ * 1.9.0 added
+ * host-rendered `hostViews`, their `ui:hostView` capability, and the
+ * `ui.hostViewUpdate` / `ui.hostViewRemove` RPC methods; 1.8.0 added
+ * `background.list`; 1.7.0 added history/session/tab/transcript
+ * write/decision/shell/storage SQL/fs watch/power/background capabilities plus
+ * `history.entryAdded` and metadata-only `agent.completed` events; 1.6.0 added
+ * `cue.runStarted` / `cue.runFinished`; 1.5.0 added `agent.exited` /
+ * `agent.error` / `usage.updated` / `run.completed` + functional
+ * `sidebar`/`activity-bar`/`toolbar` uiItem surfaces; 1.4.0 added the
+ * `ui:contribute` / `ui:panel` / `ui:render-unsafe` UI capabilities; 1.3.0
+ * added `tools` + `keybindings`; 1.2.0 added `transcripts:read`.)
+ */
+export const HOST_API_VERSION = '1.11.0';
 
 /** Result of checking a plugin's declared host-API requirement. */
 export interface HostApiCompatibility {
@@ -699,6 +751,39 @@ export interface ThemeContribution {
 	colors: Record<string, string>;
 }
 
+/** A single safe SVG path within an icon pack. The host owns all SVG markup. */
+export interface IconPackIconContribution {
+	/** Namespaced id: `<pluginId>/<packId>/<localId>`. */
+	id: string;
+	localId: string;
+	label: string;
+	/** Validated SVG path `d` data only; never arbitrary SVG markup. */
+	path: string;
+	/** Optional validated four-number SVG viewBox string. */
+	viewBox?: string;
+}
+
+/** A label color within an icon pack. */
+export interface IconPackColorContribution {
+	/** Namespaced id: `<pluginId>/<packId>/<localId>`. */
+	id: string;
+	localId: string;
+	label: string;
+	/** Validated `#rrggbb` color value. */
+	value: string;
+}
+
+/** A tier-0 pack of host-rendered group icons and label colors. */
+export interface IconPackContribution {
+	/** Namespaced id: `<pluginId>/<localId>`. */
+	id: string;
+	localId: string;
+	pluginId: string;
+	label: string;
+	icons: IconPackIconContribution[];
+	colors: IconPackColorContribution[];
+}
+
 /** A reusable prompt a plugin adds to the prompt catalog. */
 export interface PromptContribution {
 	id: string;
@@ -851,7 +936,40 @@ export interface UiItemContribution {
 	priority?: number;
 }
 
-/** A metadata-only virtual grouping supplied by a plugin. */
+/** The host-owned view surfaces that render only BlockView data. */
+export type HostViewSurface = 'movement' | 'cadenza';
+
+export const HOST_VIEW_SURFACES: readonly HostViewSurface[] = ['movement', 'cadenza'];
+
+/** Type guard for the two host-rendered view surfaces. */
+export function isHostViewSurface(value: unknown): value is HostViewSurface {
+	return typeof value === 'string' && (HOST_VIEW_SURFACES as readonly string[]).includes(value);
+}
+
+/** The only data accepted for a host view: the BlockView block array the host
+ * renders, never a cadenza command/prompt payload or plugin UI. */
+export type HostViewBlocks = unknown[];
+
+export function isHostViewBlocks(value: unknown): value is HostViewBlocks {
+	return Array.isArray(value);
+}
+
+/**
+ * A host-rendered view declared by a data-only or code plugin. The host owns its
+ * renderer; a code plugin may later update/remove that declared view through the
+ * brokered `ui:hostView` RPC methods.
+ */
+export interface HostViewContribution {
+	id: string;
+	localId: string;
+	pluginId: string;
+	surface: HostViewSurface;
+	title: string;
+	description?: string;
+	blocks?: HostViewBlocks;
+}
+/** A metadata-only virtual grouping supplied by a plugin. Rules use a deliberately
+ * small `*` wildcard grammar; patterns are never compiled as user RegExp. */
 export interface GroupingRule {
 	match: { toolType?: string; cwdGlob?: string; namePattern?: string };
 	group: string;
@@ -871,6 +989,7 @@ export interface GroupingContribution {
 /** All contributions a single plugin declared, plus any per-item errors. */
 export interface PluginContributions {
 	themes: ThemeContribution[];
+	iconPacks: IconPackContribution[];
 	prompts: PromptContribution[];
 	settings: SettingContribution[];
 	commandMacros: CommandMacroContribution[];
@@ -881,6 +1000,7 @@ export interface PluginContributions {
 	tools: AgentToolContribution[];
 	keybindings: KeybindingContribution[];
 	uiItems: UiItemContribution[];
+	hostViews: HostViewContribution[];
 	groupings: GroupingContribution[];
 	errors: string[];
 }
@@ -888,6 +1008,7 @@ export interface PluginContributions {
 /** Contributions aggregated across every active plugin. */
 export interface AggregatedContributions {
 	themes: ThemeContribution[];
+	iconPacks: IconPackContribution[];
 	prompts: PromptContribution[];
 	settings: SettingContribution[];
 	commandMacros: CommandMacroContribution[];
@@ -898,6 +1019,7 @@ export interface AggregatedContributions {
 	tools: AgentToolContribution[];
 	keybindings: KeybindingContribution[];
 	uiItems: UiItemContribution[];
+	hostViews: HostViewContribution[];
 	groupings: GroupingContribution[];
 	/** Per-plugin errors keyed by plugin id (only plugins with errors appear). */
 	errorsByPlugin: Record<string, string[]>;
@@ -1046,6 +1168,8 @@ export const HOST_API = {
 	'storage.sql': { capability: 'storage:sql' },
 	'fs.watch': { capability: 'fs:watch' },
 	'ui.runCommand': { capability: 'ui:command' },
+	'ui.hostViewUpdate': { capability: 'ui:hostView' },
+	'ui.hostViewRemove': { capability: 'ui:hostView' },
 	'tabs.list': { capability: 'tabs:manage' },
 	'tabs.create': { capability: 'tabs:manage' },
 	'tabs.focus': { capability: 'tabs:manage' },
@@ -1246,12 +1370,14 @@ export interface MaestroStorageApi {
 	): Promise<MaestroSqlResult<Row>>;
 }
 
-/** Invoke host-rendered UI behavior (`ui:command` / `ui:grouping`). */
-export interface MaestroUiApi {
-	runCommand(commandId: string, args?: unknown): Promise<unknown>;
-	readonly grouping: MaestroGroupingApi;
+/** Update or remove a previously declared host-rendered BlockView (`ui:hostView`). */
+export interface MaestroHostViewApi {
+	update(id: string, blocks: HostViewBlocks): Promise<void>;
+	remove(id: string): Promise<void>;
 }
 
+/** Invoke a registered command-palette command (`ui:command`) or access
+ * host-rendered BlockViews. */
 export interface MaestroGroupingApi {
 	publish(params: {
 		id: string;
@@ -1259,6 +1385,12 @@ export interface MaestroGroupingApi {
 		assignments: Record<string, string>;
 	}): Promise<void>;
 	clear(id: string): Promise<void>;
+}
+
+export interface MaestroUiApi {
+	runCommand(commandId: string, args?: unknown): Promise<unknown>;
+	readonly hostView: MaestroHostViewApi;
+	readonly grouping: MaestroGroupingApi;
 }
 
 /** Manage Maestro tabs (`tabs:manage`). */

--- a/src/__tests__/main/plugins/plugin-grouping-registry.test.ts
+++ b/src/__tests__/main/plugins/plugin-grouping-registry.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+	PluginGroupingRegistry,
+	validatePublishedGrouping,
+} from '../../../main/plugins/plugin-grouping-registry';
+
+const sessions = new Set(['session-1', 'session-2']);
+
+function payload(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+	return {
+		id: 'by-agent-type',
+		groups: [
+			{ id: 'agents', label: 'Agents' },
+			{ id: 'claude', label: 'Claude', parentId: 'agents' },
+		],
+		assignments: { 'session-1': 'claude', unknown: 'claude' },
+		...overrides,
+	};
+}
+
+describe('validatePublishedGrouping', () => {
+	it('drops unknown sessions without changing virtual group ownership', () => {
+		const result = validatePublishedGrouping('com.acme', 'by-agent-type', payload(), sessions);
+
+		expect(result).toMatchObject({
+			id: 'com.acme/by-agent-type',
+			assignments: { 'session-1': 'claude' },
+		});
+		expect(result.assignments).not.toHaveProperty('unknown');
+	});
+
+	it('rejects nested schema extras, cycles, and hierarchies deeper than two levels', () => {
+		expect(() =>
+			validatePublishedGrouping(
+				'com.acme',
+				'by-agent-type',
+				payload({ groups: [{ id: 'root', label: 'Root', unexpected: true }] }),
+				sessions
+			)
+		).toThrow(/invalid group/);
+		expect(() =>
+			validatePublishedGrouping(
+				'com.acme',
+				'by-agent-type',
+				payload({
+					groups: [
+						{ id: 'a', label: 'A', parentId: 'b' },
+						{ id: 'b', label: 'B', parentId: 'a' },
+					],
+				}),
+				sessions
+			)
+		).toThrow(/cycle/);
+		expect(() =>
+			validatePublishedGrouping(
+				'com.acme',
+				'by-agent-type',
+				payload({
+					groups: [
+						{ id: 'root', label: 'Root' },
+						{ id: 'child', label: 'Child', parentId: 'root' },
+						{ id: 'grandchild', label: 'Grandchild', parentId: 'child' },
+					],
+				}),
+				sessions
+			)
+		).toThrow(/depth/);
+	});
+});
+
+describe('PluginGroupingRegistry', () => {
+	it('purges every snapshot for a stopped or disabled plugin and never leaks mutable state', () => {
+		const onChanged = vi.fn();
+		const registry = new PluginGroupingRegistry(onChanged);
+		registry.publish(validatePublishedGrouping('com.acme', 'by-agent-type', payload(), sessions));
+		registry.publish(
+			validatePublishedGrouping(
+				'com.other',
+				'by-agent-type',
+				payload({ id: 'by-agent-type' }),
+				sessions
+			)
+		);
+
+		const snapshot = registry.snapshot();
+		snapshot[0].assignments['session-2'] = 'claude';
+		expect(registry.snapshot()[0].assignments).not.toHaveProperty('session-2');
+
+		registry.removePlugin('com.acme');
+		expect(registry.snapshot()).toHaveLength(1);
+		expect(registry.snapshot()[0].pluginId).toBe('com.other');
+		expect(onChanged).toHaveBeenCalledTimes(3);
+	});
+
+	it('clears all snapshots when the plugins feature is switched off', () => {
+		const registry = new PluginGroupingRegistry();
+		registry.publish(validatePublishedGrouping('com.acme', 'by-agent-type', payload(), sessions));
+
+		registry.clearAll();
+
+		expect(registry.snapshot()).toEqual([]);
+	});
+});

--- a/src/__tests__/main/plugins/plugin-grouping-registry.test.ts
+++ b/src/__tests__/main/plugins/plugin-grouping-registry.test.ts
@@ -4,8 +4,6 @@ import {
 	validatePublishedGrouping,
 } from '../../../main/plugins/plugin-grouping-registry';
 
-const sessions = new Set(['session-1', 'session-2']);
-
 function payload(overrides: Record<string, unknown> = {}): Record<string, unknown> {
 	return {
 		id: 'by-agent-type',
@@ -19,14 +17,21 @@ function payload(overrides: Record<string, unknown> = {}): Record<string, unknow
 }
 
 describe('validatePublishedGrouping', () => {
-	it('drops unknown sessions without changing virtual group ownership', () => {
-		const result = validatePublishedGrouping('com.acme', 'by-agent-type', payload(), sessions);
+	it('preserves a fake session id in snapshot readback without checking host sessions', () => {
+		const registry = new PluginGroupingRegistry();
+		registry.publish(
+			validatePublishedGrouping(
+				'com.acme',
+				'by-agent-type',
+				payload({ assignments: { 'fake-session-id': 'claude' } })
+			)
+		);
 
-		expect(result).toMatchObject({
-			id: 'com.acme/by-agent-type',
-			assignments: { 'session-1': 'claude' },
-		});
-		expect(result.assignments).not.toHaveProperty('unknown');
+		expect(registry.snapshot()).toEqual([
+			expect.objectContaining({
+				assignments: { 'fake-session-id': 'claude' },
+			}),
+		]);
 	});
 
 	it('rejects nested schema extras, cycles, and hierarchies deeper than two levels', () => {
@@ -34,8 +39,7 @@ describe('validatePublishedGrouping', () => {
 			validatePublishedGrouping(
 				'com.acme',
 				'by-agent-type',
-				payload({ groups: [{ id: 'root', label: 'Root', unexpected: true }] }),
-				sessions
+				payload({ groups: [{ id: 'root', label: 'Root', unexpected: true }] })
 			)
 		).toThrow(/invalid group/);
 		expect(() =>
@@ -47,8 +51,7 @@ describe('validatePublishedGrouping', () => {
 						{ id: 'a', label: 'A', parentId: 'b' },
 						{ id: 'b', label: 'B', parentId: 'a' },
 					],
-				}),
-				sessions
+				})
 			)
 		).toThrow(/cycle/);
 		expect(() =>
@@ -61,8 +64,7 @@ describe('validatePublishedGrouping', () => {
 						{ id: 'child', label: 'Child', parentId: 'root' },
 						{ id: 'grandchild', label: 'Grandchild', parentId: 'child' },
 					],
-				}),
-				sessions
+				})
 			)
 		).toThrow(/depth/);
 	});
@@ -72,14 +74,9 @@ describe('PluginGroupingRegistry', () => {
 	it('purges every snapshot for a stopped or disabled plugin and never leaks mutable state', () => {
 		const onChanged = vi.fn();
 		const registry = new PluginGroupingRegistry(onChanged);
-		registry.publish(validatePublishedGrouping('com.acme', 'by-agent-type', payload(), sessions));
+		registry.publish(validatePublishedGrouping('com.acme', 'by-agent-type', payload()));
 		registry.publish(
-			validatePublishedGrouping(
-				'com.other',
-				'by-agent-type',
-				payload({ id: 'by-agent-type' }),
-				sessions
-			)
+			validatePublishedGrouping('com.other', 'by-agent-type', payload({ id: 'by-agent-type' }))
 		);
 
 		const snapshot = registry.snapshot();
@@ -94,7 +91,7 @@ describe('PluginGroupingRegistry', () => {
 
 	it('clears all snapshots when the plugins feature is switched off', () => {
 		const registry = new PluginGroupingRegistry();
-		registry.publish(validatePublishedGrouping('com.acme', 'by-agent-type', payload(), sessions));
+		registry.publish(validatePublishedGrouping('com.acme', 'by-agent-type', payload()));
 
 		registry.clearAll();
 

--- a/src/__tests__/main/plugins/plugin-host-handlers.test.ts
+++ b/src/__tests__/main/plugins/plugin-host-handlers.test.ts
@@ -1214,7 +1214,7 @@ describe('resource cleanup on plugin stop', () => {
 });
 
 describe('ui.groupingPublish / ui.groupingClear', () => {
-	it('requires a declared grouping, drops unknown sessions, and retains no session mutations', async () => {
+	it('requires a declared grouping and preserves published assignments without session mutations', async () => {
 		const groupingRegistry = new PluginGroupingRegistry();
 		const sessions: PluginSessionMetadata[] = [
 			{ id: 'known', title: 'Known session' },
@@ -1236,7 +1236,7 @@ describe('ui.groupingPublish / ui.groupingClear', () => {
 		});
 
 		expect(groupingRegistry.snapshot()).toEqual([
-			expect.objectContaining({ assignments: { known: 'claude' } }),
+			expect.objectContaining({ assignments: { known: 'claude', missing: 'claude' } }),
 		]);
 		expect(sessions).toEqual([
 			{ id: 'known', title: 'Known session' },

--- a/src/__tests__/main/plugins/plugin-host-handlers.test.ts
+++ b/src/__tests__/main/plugins/plugin-host-handlers.test.ts
@@ -21,6 +21,7 @@ import { PluginKvStore } from '../../../main/plugins/plugin-kv-store';
 import { PluginEventBusImpl } from '../../../main/plugins/plugin-event-bus';
 import { PermissionBroker } from '../../../main/plugins/permission-broker';
 import { PluginBackgroundSupervisor } from '../../../main/plugins/plugin-background-supervisor';
+import { PluginGroupingRegistry } from '../../../main/plugins/plugin-grouping-registry';
 import type { PermissionGrant } from '../../../shared/plugins/permissions';
 
 let kvBase: string;
@@ -1209,5 +1210,70 @@ describe('resource cleanup on plugin stop', () => {
 			fs.rmSync(tmpA, { recursive: true, force: true });
 			fs.rmSync(tmpB, { recursive: true, force: true });
 		}
+	});
+});
+
+describe('ui.groupingPublish / ui.groupingClear', () => {
+	it('requires a declared grouping, drops unknown sessions, and retains no session mutations', async () => {
+		const groupingRegistry = new PluginGroupingRegistry();
+		const sessions: PluginSessionMetadata[] = [
+			{ id: 'known', title: 'Known session' },
+			{ id: 'other', title: 'Other session' },
+		];
+		const h = buildHostCallHandlers(
+			makeDeps({
+				groupingRegistry,
+				isDeclaredGrouping: (pluginId, localId) =>
+					pluginId === 'com.acme' && localId === 'by-agent-type',
+				sessionsList: () => sessions,
+			})
+		);
+
+		await h['ui.groupingPublish']!('com.acme', {
+			id: 'by-agent-type',
+			groups: [{ id: 'claude', label: 'Claude' }],
+			assignments: { known: 'claude', missing: 'claude' },
+		});
+
+		expect(groupingRegistry.snapshot()).toEqual([
+			expect.objectContaining({ assignments: { known: 'claude' } }),
+		]);
+		expect(sessions).toEqual([
+			{ id: 'known', title: 'Known session' },
+			{ id: 'other', title: 'Other session' },
+		]);
+		await expect(
+			h['ui.groupingPublish']!('com.acme', {
+				id: 'not-declared',
+				groups: [],
+				assignments: {},
+			})
+		).rejects.toThrow(/not declared/);
+	});
+
+	it('denies publication without ui:grouping and rejects unknown payload fields', async () => {
+		const h = buildHostCallHandlers(
+			makeDeps({
+				broker: brokerFor(() => []),
+				groupingRegistry: new PluginGroupingRegistry(),
+				isDeclaredGrouping: () => true,
+			})
+		);
+
+		await expect(
+			h['ui.groupingPublish']!('com.acme', {
+				id: 'by-agent-type',
+				groups: [],
+				assignments: {},
+				extra: true,
+			})
+		).rejects.toThrow(/unexpected field/);
+		await expect(
+			h['ui.groupingPublish']!('com.acme', {
+				id: 'by-agent-type',
+				groups: [],
+				assignments: {},
+			})
+		).rejects.toThrow(/permission denied/);
 	});
 });

--- a/src/__tests__/renderer/components/SessionList.test.tsx
+++ b/src/__tests__/renderer/components/SessionList.test.tsx
@@ -19,6 +19,7 @@ import { createMockSession as baseCreateMockSession } from '../../helpers/mockSe
 import { useUIStore } from '../../../renderer/stores/uiStore';
 import { useSessionStore } from '../../../renderer/stores/sessionStore';
 import { useSettingsStore } from '../../../renderer/stores/settingsStore';
+import type { AggregatedContributions } from '../../../shared/plugins/contributions';
 
 // Deep-cloned default autoRunStats captured from a fresh store (no longer exported).
 const DEFAULT_AUTO_RUN_STATS = JSON.parse(JSON.stringify(useSettingsStore.getState().autoRunStats));
@@ -180,7 +181,7 @@ const defaultTheme: Theme = {
 };
 
 // Default shortcuts
-const defaultShortcuts: Record<string, any> = {
+const defaultShortcuts = {
 	help: { keys: ['?'], description: 'Show help' },
 	settings: { keys: ['meta', ','], description: 'Settings' },
 	systemLogs: { keys: ['meta', 'shift', 'l'], description: 'System logs' },
@@ -188,6 +189,22 @@ const defaultShortcuts: Record<string, any> = {
 	usageDashboard: { keys: ['alt', 'meta', 'u'], description: 'Usage dashboard' },
 	toggleSidebar: { keys: ['meta', 'b'], description: 'Toggle sidebar' },
 	filterUnreadAgents: { keys: ['alt', 'u'], description: 'Filter unread agents' },
+};
+
+const EMPTY_PLUGIN_CONTRIBUTIONS: AggregatedContributions = {
+	themes: [],
+	prompts: [],
+	settings: [],
+	commandMacros: [],
+	cueTriggers: [],
+	commands: [],
+	panels: [],
+	agents: [],
+	tools: [],
+	keybindings: [],
+	uiItems: [],
+	groupings: [],
+	errorsByPlugin: {},
 };
 
 const createMockSession = (overrides: Partial<Session> = {}): Session =>
@@ -260,6 +277,10 @@ const createDefaultProps = (overrides: Partial<Parameters<typeof SessionList>[0]
 describe('SessionList', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		vi.mocked(window.maestro.plugins.contributions).mockResolvedValue(EMPTY_PLUGIN_CONTRIBUTIONS);
+		vi.mocked(window.maestro.plugins.getGroupings).mockResolvedValue([]);
+		vi.mocked(window.maestro.plugins.onChanged).mockImplementation(() => () => {});
+		vi.mocked(window.maestro.plugins.onGroupingsChanged).mockImplementation(() => () => {});
 		// Reset all stores to clean test state
 		useUIStore.setState({
 			leftSidebarOpen: true,
@@ -831,32 +852,6 @@ describe('SessionList', () => {
 			expect(screen.getByText('Project')).not.toHaveStyle({ color: '#22C55E' });
 		});
 
-		it('falls back to the default folder without rewriting a disabled plugin appearance', () => {
-			enableGroupsPlus();
-			const group = createMockGroup({
-				id: 'g1',
-				name: 'Plugin Group',
-				emoji: '',
-				icon: 'com.acme/bright/bolt',
-				color: 'com.acme/bright/lime',
-			});
-			const sessions = [createMockSession({ id: 's1', name: 'Session in Group', groupId: 'g1' })];
-			useSessionStore.setState({ sessions, groups: [group] });
-			useUIStore.setState({ leftSidebarOpen: true });
-
-			render(<SessionList {...createDefaultProps({ sortedSessions: sessions })} />);
-
-			expect(screen.getByTestId('icon-folder')).toHaveStyle({ color: defaultTheme.colors.textDim });
-			expect(screen.getByText('Plugin Group')).not.toHaveAttribute(
-				'style',
-				`color: ${group.color};`
-			);
-			expect(group).toMatchObject({
-				icon: 'com.acme/bright/bolt',
-				color: 'com.acme/bright/lime',
-			});
-		});
-
 		it('renders child groups indented beneath their parent', () => {
 			enableGroupsPlus();
 			const parent = createMockGroup({ id: 'company', name: 'Company' });
@@ -1040,6 +1035,77 @@ describe('SessionList', () => {
 			expect(screen.queryByText('Ungrouped Agents')).not.toBeInTheDocument();
 			// The New Group button still renders so the user can keep organizing.
 			expect(screen.getByText('New Group')).toBeInTheDocument();
+		});
+
+		it('renders plugin virtual groups without persisted group controls and falls back to Manual', async () => {
+			let notifyPluginChange: (() => void) | undefined;
+			vi.mocked(window.maestro.plugins.contributions).mockResolvedValue({
+				...EMPTY_PLUGIN_CONTRIBUTIONS,
+				groupings: [
+					{
+						id: 'com.acme/by-agent-type',
+						localId: 'by-agent-type',
+						pluginId: 'com.acme',
+						pluginName: 'Agent Classifier',
+						label: 'Group by agent type',
+						rules: [
+							{
+								match: { toolType: 'claude-code' },
+								group: 'Claude',
+								parentGroup: 'AI Agents',
+							},
+						],
+					},
+				],
+			});
+			vi.mocked(window.maestro.plugins.onChanged).mockImplementation((callback) => {
+				notifyPluginChange = callback;
+				return () => {};
+			});
+			const persistedGroup = createMockGroup({ id: 'persisted', name: 'Persisted Group' });
+			const sessions = [
+				createMockSession({
+					id: 'claude',
+					name: 'Claude Agent',
+					toolType: 'claude-code',
+					groupId: 'persisted',
+				}),
+				createMockSession({ id: 'codex', name: 'Codex Agent', toolType: 'codex' }),
+			];
+			useSessionStore.setState({ sessions, groups: [persistedGroup] });
+			useSettingsStore.setState({
+				encoreFeatures: { ...DEFAULT_ENCORE_FEATURES, groupsPlus: false },
+			});
+
+			render(<SessionList {...createDefaultProps({ sortedSessions: sessions })} />);
+
+			const selector = await screen.findByRole('combobox', { name: 'Session grouping mode' });
+			fireEvent.change(selector, { target: { value: 'com.acme/by-agent-type' } });
+
+			await waitFor(() => {
+				expect(screen.getByText('Claude')).toBeInTheDocument();
+				expect(screen.getByText('Other')).toBeInTheDocument();
+			});
+			expect(screen.getByText('Claude').closest('.ml-4')).not.toBeNull();
+			expect(screen.getAllByText('from Agent Classifier')).toHaveLength(3);
+			expect(screen.queryByText('Persisted Group')).not.toBeInTheDocument();
+			expect(screen.queryByText('New Group')).not.toBeInTheDocument();
+			expect(useSessionStore.getState().sessions[0].groupId).toBe('persisted');
+			expect(useSessionStore.getState().groups).toEqual([persistedGroup]);
+
+			fireEvent.contextMenu(screen.getByText('Claude Agent'), { clientX: 100, clientY: 100 });
+			expect(screen.queryByText('Move to Group')).not.toBeInTheDocument();
+
+			vi.mocked(window.maestro.plugins.contributions).mockResolvedValue(EMPTY_PLUGIN_CONTRIBUTIONS);
+			act(() => notifyPluginChange?.());
+			await waitFor(() => {
+				expect(screen.getByText('Persisted Group')).toBeInTheDocument();
+				expect(screen.getByText('New Group')).toBeInTheDocument();
+			});
+			expect(window.maestro.settings.set).toHaveBeenLastCalledWith(
+				'leftSidebarGroupingMode',
+				'manual'
+			);
 		});
 	});
 
@@ -3408,7 +3474,7 @@ describe('SessionList', () => {
 	describe('Resize Handle', () => {
 		it('saves sidebar width on mouseup', async () => {
 			const mockSettingsSet = vi.fn();
-			(window.maestro.settings.set as ReturnType<typeof vi.fn>).mockImplementation(mockSettingsSet);
+			vi.mocked(window.maestro.settings.set).mockImplementation(mockSettingsSet);
 
 			useUIStore.setState({ leftSidebarOpen: true });
 			useSettingsStore.setState({ leftSidebarWidth: 300 });

--- a/src/__tests__/renderer/components/SessionList.test.tsx
+++ b/src/__tests__/renderer/components/SessionList.test.tsx
@@ -1107,6 +1107,47 @@ describe('SessionList', () => {
 				'manual'
 			);
 		});
+
+		it('renders every session from a sparse computed snapshot by placing extras in Other', async () => {
+			vi.mocked(window.maestro.plugins.contributions).mockResolvedValue({
+				...EMPTY_PLUGIN_CONTRIBUTIONS,
+				groupings: [
+					{
+						id: 'com.acme/by-agent-type',
+						localId: 'by-agent-type',
+						pluginId: 'com.acme',
+						pluginName: 'Agent Classifier',
+						label: 'Group by agent type',
+					},
+				],
+			});
+			vi.mocked(window.maestro.plugins.getGroupings).mockResolvedValue([
+				{
+					id: 'com.acme/by-agent-type',
+					pluginId: 'com.acme',
+					localId: 'by-agent-type',
+					groups: [{ id: 'claude', label: 'Claude' }],
+					assignments: { claude: 'claude' },
+				},
+			]);
+			const sessions = [
+				createMockSession({ id: 'claude', name: 'Claude Agent' }),
+				createMockSession({ id: 'unassigned', name: 'Unassigned Agent' }),
+			];
+			useSessionStore.setState({ sessions });
+
+			render(<SessionList {...createDefaultProps({ sortedSessions: sessions })} />);
+
+			const selector = await screen.findByRole('combobox', { name: 'Session grouping mode' });
+			fireEvent.change(selector, { target: { value: 'com.acme/by-agent-type' } });
+
+			await waitFor(() => {
+				expect(screen.getByText('Claude')).toBeInTheDocument();
+				expect(screen.getByText('Other')).toBeInTheDocument();
+				expect(screen.getByText('Claude Agent')).toBeInTheDocument();
+				expect(screen.getByText('Unassigned Agent')).toBeInTheDocument();
+			});
+		});
 	});
 
 	// ============================================================================

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -453,6 +453,7 @@ const mockMaestro = {
 			tools: [],
 			keybindings: [],
 			uiItems: [],
+			groupings: [],
 			errorsByPlugin: {},
 		}),
 		getGrants: vi.fn().mockResolvedValue({ requested: [], granted: [] }),
@@ -461,7 +462,9 @@ const mockMaestro = {
 		invokeCommand: vi.fn().mockResolvedValue({ dispatched: true }),
 		invokeTool: vi.fn().mockResolvedValue({ result: null }),
 		getActivity: vi.fn().mockResolvedValue({}),
+		getGroupings: vi.fn().mockResolvedValue([]),
 		onChanged: vi.fn().mockReturnValue(() => {}),
+		onGroupingsChanged: vi.fn().mockReturnValue(() => {}),
 		onRunUiCommand: vi.fn().mockReturnValue(() => {}),
 	},
 	agentRun: {

--- a/src/__tests__/shared/plugins/contributions.test.ts
+++ b/src/__tests__/shared/plugins/contributions.test.ts
@@ -3,7 +3,8 @@ import {
 	collectContributions,
 	aggregateContributions,
 	gateContributions,
-	MAX_HOST_VIEW_BLOCKS_BYTES,
+	groupingRuleMatches,
+	matchesGroupingPattern,
 } from '../../../shared/plugins/contributions';
 import type { PluginManifest } from '../../../shared/plugins/plugin-manifest';
 
@@ -41,81 +42,6 @@ describe('collectContributions', () => {
 		expect(c.themes[0].id).toBe('com.acme/midnight');
 		expect(c.themes[0].localId).toBe('midnight');
 		expect(c.themes[0].pluginId).toBe('com.acme');
-	});
-	it('collects namespaced icon packs for tier-0 plugins', () => {
-		const c = collectContributions(
-			manifest('com.acme', {
-				iconPacks: [
-					{
-						id: 'starter',
-						label: 'Starter pack',
-						icons: [
-							{
-								id: 'spark',
-								label: 'Spark',
-								path: 'M12 2L15 9L22 12L15 15L12 22',
-								viewBox: '0 0 24 24',
-							},
-						],
-						colors: [{ id: 'lime', label: 'Lime', value: '#22C55E' }],
-					},
-				],
-			})
-		);
-
-		expect(c.iconPacks).toEqual([
-			{
-				id: 'com.acme/starter',
-				localId: 'starter',
-				pluginId: 'com.acme',
-				label: 'Starter pack',
-				icons: [
-					{
-						id: 'com.acme/starter/spark',
-						localId: 'spark',
-						label: 'Spark',
-						path: 'M12 2L15 9L22 12L15 15L12 22',
-						viewBox: '0 0 24 24',
-					},
-				],
-				colors: [
-					{
-						id: 'com.acme/starter/lime',
-						localId: 'lime',
-						label: 'Lime',
-						value: '#22C55E',
-					},
-				],
-			},
-		]);
-		expect(c.errors).toEqual([]);
-	});
-
-	it('drops unsafe or oversized icon-pack entries while keeping valid siblings', () => {
-		const c = collectContributions(
-			manifest('com.acme', {
-				iconPacks: [
-					{
-						id: 'starter',
-						label: 'Starter pack',
-						icons: [
-							{ id: 'good', label: 'Good', path: 'M3 12H21' },
-							{ id: 'markup', label: 'Markup', path: 'M3 12<foreignObject />' },
-							{ id: 'large', label: 'Large', path: `M${'0 '.repeat(4096)}` },
-							{ id: 'viewbox', label: 'ViewBox', path: 'M3 12H21', viewBox: '0 0 24 nope' },
-						],
-						colors: [
-							{ id: 'good', label: 'Good', value: '#22C55E' },
-							{ id: 'bad', label: 'Bad', value: 'green' },
-						],
-					},
-				],
-			})
-		);
-
-		expect(c.iconPacks[0].icons.map((icon) => icon.localId)).toEqual(['good']);
-		expect(c.iconPacks[0].colors.map((color) => color.localId)).toEqual(['good']);
-		expect(c.errors).toHaveLength(4);
 	});
 
 	it('validates each contribution type and drops bad ones with an error', () => {
@@ -355,31 +281,6 @@ describe('aggregateContributions', () => {
 		]);
 		expect(agg.themes.map((t) => t.id).sort()).toEqual(['com.a/midnight', 'com.b/midnight']);
 	});
-
-	it('keeps the first icon pack when a plugin declares the same pack id twice', () => {
-		const agg = aggregateContributions([
-			manifest('com.acme', {
-				iconPacks: [
-					{
-						id: 'starter',
-						label: 'First pack',
-						icons: [{ id: 'spark', label: 'Spark', path: 'M3 12H21' }],
-					},
-					{
-						id: 'starter',
-						label: 'Second pack',
-						icons: [{ id: 'bolt', label: 'Bolt', path: 'M12 2L12 22' }],
-					},
-				],
-			}),
-		]);
-
-		expect(agg.iconPacks).toHaveLength(1);
-		expect(agg.iconPacks[0].label).toBe('First pack');
-		expect(agg.errorsByPlugin['com.acme']).toContain(
-			'duplicate iconPacks contribution id "com.acme/starter"'
-		);
-	});
 });
 
 describe('contributed setting key validation', () => {
@@ -553,96 +454,6 @@ describe('uiItems contribution (ui:contribute surface items)', () => {
 	});
 });
 
-describe('hostViews contribution (host-rendered BlockView data)', () => {
-	const hostView = (overrides: Record<string, unknown> = {}) =>
-		manifest(
-			'com.host-view',
-			{
-				hostViews: [
-					{
-						id: 'status',
-						surface: 'movement',
-						title: 'Status',
-						blocks: [{ kind: 'text', content: 'Rendered by the host.' }],
-						...overrides,
-					},
-				],
-			},
-			0
-		);
-
-	it.each([
-		['movement', [{ kind: 'text', content: 'Movement data' }]],
-		['cadenza', [{ kind: 'heading', text: 'Cadenza data' }]],
-	])('parses and namespaces a valid %s host view', (surface, blocks) => {
-		const c = collectContributions(hostView({ surface, blocks }));
-
-		expect(c.errors).toEqual([]);
-		expect(c.hostViews).toEqual([
-			{
-				id: 'com.host-view/status',
-				localId: 'status',
-				pluginId: 'com.host-view',
-				surface,
-				title: 'Status',
-				blocks,
-			},
-		]);
-	});
-
-	it('drops a host view with an invalid surface', () => {
-		const c = collectContributions(hostView({ surface: 'sidebar' }));
-
-		expect(c.hostViews).toEqual([]);
-		expect(c.errors.join(' ')).toContain('surface');
-	});
-
-	it('rejects non-BlockView data, including a decision cadenza payload', () => {
-		const c = collectContributions(
-			hostView({ blocks: { op: 'open', viewType: 'decision', options: [{ label: 'Allow' }] } })
-		);
-
-		expect(c.hostViews).toEqual([]);
-		expect(c.errors.join(' ')).toContain('blocks');
-	});
-
-	it('drops blocks whose serialized UTF-8 payload exceeds the pure size cap', () => {
-		const c = collectContributions(
-			hostView({ blocks: [{ kind: 'text', content: 'x'.repeat(MAX_HOST_VIEW_BLOCKS_BYTES) }] })
-		);
-
-		expect(c.hostViews).toEqual([]);
-		expect(c.errors.join(' ')).toContain('size limit');
-	});
-
-	it('keeps the first host view on a same-id collision during aggregation', () => {
-		const agg = aggregateContributions([
-			manifest(
-				'com.host-view',
-				{
-					hostViews: [
-						{ id: 'status', surface: 'movement', title: 'First' },
-						{ id: 'status', surface: 'cadenza', title: 'Second' },
-					],
-				},
-				1
-			),
-		]);
-
-		expect(agg.hostViews).toMatchObject([{ id: 'com.host-view/status', title: 'First' }]);
-		expect(agg.errorsByPlugin['com.host-view']?.join(' ')).toContain('duplicate hostViews');
-	});
-
-	it('keeps static host views when no ui:hostView grant exists', () => {
-		const collected = collectContributions(hostView());
-
-		expect(gateContributions(collected, () => false).hostViews).toHaveLength(1);
-		expect(
-			gateContributions(collected, (cap) => cap === 'ui:render-unsafe').hostViews
-		).toHaveLength(1);
-	});
-});
-
 describe('gateContributions (per-capability customization gate)', () => {
 	const built = collectContributions(
 		manifest(
@@ -700,5 +511,58 @@ describe('aggregateContributions — gated aggregation', () => {
 		const gated = aggregateContributions([m], () => false);
 		expect(gated.uiItems).toEqual([]); // gated out without ui:contribute
 		expect(gated.commands).toHaveLength(1); // ungated category survives
+	});
+});
+
+describe('groupings contribution', () => {
+	it('collects tier-0 rules, namespaces its id, and rejects unsafe patterns', () => {
+		const c = collectContributions(
+			manifest('com.acme', {
+				groupings: [
+					{
+						id: 'by-type',
+						label: 'Group by agent type',
+						rules: [
+							{ match: { toolType: 'claude' }, group: 'Claude' },
+							{ match: { cwdGlob: 'C:/work/*', namePattern: 'API *' }, group: 'API' },
+						],
+					},
+					{
+						id: 'bad-pattern',
+						label: 'Bad',
+						rules: [{ match: { namePattern: 'x'.repeat(257) }, group: 'Nope' }],
+					},
+				],
+			})
+		);
+
+		expect(c.groupings).toEqual([
+			expect.objectContaining({
+				id: 'com.acme/by-type',
+				localId: 'by-type',
+				pluginId: 'com.acme',
+			}),
+		]);
+		expect(c.errors.join(' ')).toContain('pattern');
+	});
+
+	it('evaluates each matcher with literal-safe wildcards', () => {
+		const session = {
+			id: 'session-1',
+			toolType: 'claude-code',
+			cwd: 'C:/work/api',
+			name: 'API [draft]',
+		};
+
+		expect(
+			groupingRuleMatches(session, { match: { toolType: 'claude-code' }, group: 'Tool' })
+		).toBe(true);
+		expect(groupingRuleMatches(session, { match: { cwdGlob: 'C:/work/*' }, group: 'Cwd' })).toBe(
+			true
+		);
+		expect(groupingRuleMatches(session, { match: { namePattern: 'API [*]' }, group: 'Name' })).toBe(
+			true
+		);
+		expect(matchesGroupingPattern('abc', 'a.c')).toBe(false);
 	});
 });

--- a/src/__tests__/shared/plugins/contributions.test.ts
+++ b/src/__tests__/shared/plugins/contributions.test.ts
@@ -3,6 +3,7 @@ import {
 	collectContributions,
 	aggregateContributions,
 	gateContributions,
+	MAX_HOST_VIEW_BLOCKS_BYTES,
 	groupingRuleMatches,
 	matchesGroupingPattern,
 } from '../../../shared/plugins/contributions';
@@ -42,6 +43,81 @@ describe('collectContributions', () => {
 		expect(c.themes[0].id).toBe('com.acme/midnight');
 		expect(c.themes[0].localId).toBe('midnight');
 		expect(c.themes[0].pluginId).toBe('com.acme');
+	});
+	it('collects namespaced icon packs for tier-0 plugins', () => {
+		const c = collectContributions(
+			manifest('com.acme', {
+				iconPacks: [
+					{
+						id: 'starter',
+						label: 'Starter pack',
+						icons: [
+							{
+								id: 'spark',
+								label: 'Spark',
+								path: 'M12 2L15 9L22 12L15 15L12 22',
+								viewBox: '0 0 24 24',
+							},
+						],
+						colors: [{ id: 'lime', label: 'Lime', value: '#22C55E' }],
+					},
+				],
+			})
+		);
+
+		expect(c.iconPacks).toEqual([
+			{
+				id: 'com.acme/starter',
+				localId: 'starter',
+				pluginId: 'com.acme',
+				label: 'Starter pack',
+				icons: [
+					{
+						id: 'com.acme/starter/spark',
+						localId: 'spark',
+						label: 'Spark',
+						path: 'M12 2L15 9L22 12L15 15L12 22',
+						viewBox: '0 0 24 24',
+					},
+				],
+				colors: [
+					{
+						id: 'com.acme/starter/lime',
+						localId: 'lime',
+						label: 'Lime',
+						value: '#22C55E',
+					},
+				],
+			},
+		]);
+		expect(c.errors).toEqual([]);
+	});
+
+	it('drops unsafe or oversized icon-pack entries while keeping valid siblings', () => {
+		const c = collectContributions(
+			manifest('com.acme', {
+				iconPacks: [
+					{
+						id: 'starter',
+						label: 'Starter pack',
+						icons: [
+							{ id: 'good', label: 'Good', path: 'M3 12H21' },
+							{ id: 'markup', label: 'Markup', path: 'M3 12<foreignObject />' },
+							{ id: 'large', label: 'Large', path: `M${'0 '.repeat(4096)}` },
+							{ id: 'viewbox', label: 'ViewBox', path: 'M3 12H21', viewBox: '0 0 24 nope' },
+						],
+						colors: [
+							{ id: 'good', label: 'Good', value: '#22C55E' },
+							{ id: 'bad', label: 'Bad', value: 'green' },
+						],
+					},
+				],
+			})
+		);
+
+		expect(c.iconPacks[0].icons.map((icon) => icon.localId)).toEqual(['good']);
+		expect(c.iconPacks[0].colors.map((color) => color.localId)).toEqual(['good']);
+		expect(c.errors).toHaveLength(4);
 	});
 
 	it('validates each contribution type and drops bad ones with an error', () => {
@@ -281,6 +357,31 @@ describe('aggregateContributions', () => {
 		]);
 		expect(agg.themes.map((t) => t.id).sort()).toEqual(['com.a/midnight', 'com.b/midnight']);
 	});
+
+	it('keeps the first icon pack when a plugin declares the same pack id twice', () => {
+		const agg = aggregateContributions([
+			manifest('com.acme', {
+				iconPacks: [
+					{
+						id: 'starter',
+						label: 'First pack',
+						icons: [{ id: 'spark', label: 'Spark', path: 'M3 12H21' }],
+					},
+					{
+						id: 'starter',
+						label: 'Second pack',
+						icons: [{ id: 'bolt', label: 'Bolt', path: 'M12 2L12 22' }],
+					},
+				],
+			}),
+		]);
+
+		expect(agg.iconPacks).toHaveLength(1);
+		expect(agg.iconPacks[0].label).toBe('First pack');
+		expect(agg.errorsByPlugin['com.acme']).toContain(
+			'duplicate iconPacks contribution id "com.acme/starter"'
+		);
+	});
 });
 
 describe('contributed setting key validation', () => {
@@ -454,6 +555,96 @@ describe('uiItems contribution (ui:contribute surface items)', () => {
 	});
 });
 
+describe('hostViews contribution (host-rendered BlockView data)', () => {
+	const hostView = (overrides: Record<string, unknown> = {}) =>
+		manifest(
+			'com.host-view',
+			{
+				hostViews: [
+					{
+						id: 'status',
+						surface: 'movement',
+						title: 'Status',
+						blocks: [{ kind: 'text', content: 'Rendered by the host.' }],
+						...overrides,
+					},
+				],
+			},
+			0
+		);
+
+	it.each([
+		['movement', [{ kind: 'text', content: 'Movement data' }]],
+		['cadenza', [{ kind: 'heading', text: 'Cadenza data' }]],
+	])('parses and namespaces a valid %s host view', (surface, blocks) => {
+		const c = collectContributions(hostView({ surface, blocks }));
+
+		expect(c.errors).toEqual([]);
+		expect(c.hostViews).toEqual([
+			{
+				id: 'com.host-view/status',
+				localId: 'status',
+				pluginId: 'com.host-view',
+				surface,
+				title: 'Status',
+				blocks,
+			},
+		]);
+	});
+
+	it('drops a host view with an invalid surface', () => {
+		const c = collectContributions(hostView({ surface: 'sidebar' }));
+
+		expect(c.hostViews).toEqual([]);
+		expect(c.errors.join(' ')).toContain('surface');
+	});
+
+	it('rejects non-BlockView data, including a decision cadenza payload', () => {
+		const c = collectContributions(
+			hostView({ blocks: { op: 'open', viewType: 'decision', options: [{ label: 'Allow' }] } })
+		);
+
+		expect(c.hostViews).toEqual([]);
+		expect(c.errors.join(' ')).toContain('blocks');
+	});
+
+	it('drops blocks whose serialized UTF-8 payload exceeds the pure size cap', () => {
+		const c = collectContributions(
+			hostView({ blocks: [{ kind: 'text', content: 'x'.repeat(MAX_HOST_VIEW_BLOCKS_BYTES) }] })
+		);
+
+		expect(c.hostViews).toEqual([]);
+		expect(c.errors.join(' ')).toContain('size limit');
+	});
+
+	it('keeps the first host view on a same-id collision during aggregation', () => {
+		const agg = aggregateContributions([
+			manifest(
+				'com.host-view',
+				{
+					hostViews: [
+						{ id: 'status', surface: 'movement', title: 'First' },
+						{ id: 'status', surface: 'cadenza', title: 'Second' },
+					],
+				},
+				1
+			),
+		]);
+
+		expect(agg.hostViews).toMatchObject([{ id: 'com.host-view/status', title: 'First' }]);
+		expect(agg.errorsByPlugin['com.host-view']?.join(' ')).toContain('duplicate hostViews');
+	});
+
+	it('keeps static host views when no ui:hostView grant exists', () => {
+		const collected = collectContributions(hostView());
+
+		expect(gateContributions(collected, () => false).hostViews).toHaveLength(1);
+		expect(
+			gateContributions(collected, (cap) => cap === 'ui:render-unsafe').hostViews
+		).toHaveLength(1);
+	});
+});
+
 describe('gateContributions (per-capability customization gate)', () => {
 	const built = collectContributions(
 		manifest(
@@ -522,10 +713,7 @@ describe('groupings contribution', () => {
 					{
 						id: 'by-type',
 						label: 'Group by agent type',
-						rules: [
-							{ match: { toolType: 'claude' }, group: 'Claude' },
-							{ match: { cwdGlob: 'C:/work/*', namePattern: 'API *' }, group: 'API' },
-						],
+						rules: [{ match: { toolType: 'claude' }, group: 'Claude' }],
 					},
 					{
 						id: 'bad-pattern',
@@ -535,13 +723,8 @@ describe('groupings contribution', () => {
 				],
 			})
 		);
-
 		expect(c.groupings).toEqual([
-			expect.objectContaining({
-				id: 'com.acme/by-type',
-				localId: 'by-type',
-				pluginId: 'com.acme',
-			}),
+			expect.objectContaining({ id: 'com.acme/by-type', localId: 'by-type', pluginId: 'com.acme' }),
 		]);
 		expect(c.errors.join(' ')).toContain('pattern');
 	});
@@ -553,7 +736,6 @@ describe('groupings contribution', () => {
 			cwd: 'C:/work/api',
 			name: 'API [draft]',
 		};
-
 		expect(
 			groupingRuleMatches(session, { match: { toolType: 'claude-code' }, group: 'Tool' })
 		).toBe(true);
@@ -564,5 +746,33 @@ describe('groupings contribution', () => {
 			true
 		);
 		expect(matchesGroupingPattern('abc', 'a.c')).toBe(false);
+	});
+});
+
+describe('combined contribution surfaces', () => {
+	it('collects hostViews, iconPacks, and groupings together', () => {
+		const c = collectContributions(
+			manifest('com.acme', {
+				iconPacks: [
+					{
+						id: 'pack',
+						label: 'Pack',
+						icons: [{ id: 'folder', label: 'Folder', path: 'M1 1h2v2H1z' }],
+						colors: [],
+					},
+				],
+				hostViews: [{ id: 'status', surface: 'movement', title: 'Status', blocks: [] }],
+				groupings: [
+					{
+						id: 'by-tool',
+						label: 'By tool',
+						rules: [{ match: { toolType: 'claude' }, group: 'Claude' }],
+					},
+				],
+			})
+		);
+		expect(c.iconPacks).toHaveLength(1);
+		expect(c.hostViews).toHaveLength(1);
+		expect(c.groupings).toHaveLength(1);
 	});
 });

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -45,6 +45,7 @@ import { evaluateScheduledDispatch } from '../shared/plugins/plugin-dispatch-gat
 import { PermissionBroker } from './plugins/permission-broker';
 import { PluginSandboxHost } from './plugins/plugin-sandbox-host';
 import { PluginBackgroundSupervisor } from './plugins/plugin-background-supervisor';
+import { PluginGroupingRegistry } from './plugins/plugin-grouping-registry';
 import { setActivePluginManager } from './plugins/plugin-manager-singleton';
 import { PluginSchedulerHost } from './plugins/plugin-scheduler-host';
 import {
@@ -53,9 +54,6 @@ import {
 	type PluginSessionMetadata,
 	type PluginTabMetadata,
 } from './plugins/plugin-host-handlers';
-import { PluginHostViewRegistry, type HostViewMutation } from './plugins/plugin-host-view-registry';
-import type { MovementPayload } from '../shared/movement-types';
-import type { CadenzaPayload } from '../shared/cadenza-types';
 import { ActionGuard } from './plugins/action-guard';
 import { PluginKvStore } from './plugins/plugin-kv-store';
 import { PluginEventBusImpl } from './plugins/plugin-event-bus';
@@ -241,7 +239,6 @@ import {
 	createWindowManager,
 	createQuitHandler,
 	deliverCadenzaToHud,
-	deliverCadenzaToExistingHud,
 	closeCadenzaHudWindow,
 	getCadenzaHudWindow,
 	type QuitHandler,
@@ -492,6 +489,7 @@ let pianolaRelearnScheduler: PianolaRelearnScheduler | null = null;
 let pluginManager: PluginManager | null = null;
 let pluginScheduler: PluginSchedulerHost | null = null;
 let pluginSandboxHost: PluginSandboxHost | null = null;
+let pluginGroupingRegistry: PluginGroupingRegistry | null = null;
 let pluginBackgroundSupervisor: PluginBackgroundSupervisor | null = null;
 let pluginAuthStore: AuthorizationStore | null = null;
 let pluginEventBus: PluginEventBusImpl | null = null;
@@ -645,6 +643,17 @@ const cadenzaHudDeps = {
 	windowRegistry,
 };
 
+// Disabling Concerto must tear down the already-running always-on-top HUD, not
+// merely reject future payloads. Without this listener, existing cards and the
+// cursor hover poll survive after the user turns the extension off.
+store.onDidChange('encoreFeatures', (encoreFeatures) => {
+	if (encoreFeatures?.concerto !== true) closeCadenzaHudWindow();
+	if (encoreFeatures?.plugins !== true) {
+		pluginSandboxHost?.stopAll();
+		pluginGroupingRegistry?.clearAll();
+	}
+});
+
 /**
  * Route a cadenza payload to the HUD window (creating it lazily). Returns
  * false when there's no main window to parent it, so the caller can fall back
@@ -665,90 +674,6 @@ function deliverCadenza(payload: Parameters<typeof deliverCadenzaToHud>[2]): boo
 	}
 	return deliverCadenzaToHud(mainWindow, cadenzaHudDeps, stamped);
 }
-
-/** Host views are a bridge between two opt-in Encore features. Re-read both
- * flags on every mutation: a disabled feature must never retain a pending view. */
-function arePluginHostViewsEnabled(): boolean {
-	const features = store.get('encoreFeatures', {}) as Record<string, boolean>;
-	return features.plugins === true && features.concerto === true;
-}
-
-/** Forward one host-owned mutation over the exact Concerto renderer channels
- * used by the CLI bridge. No renderer handles or plugin code cross this seam. */
-function forwardPluginHostView(mutation: HostViewMutation): boolean {
-	if (!(mutation.kind === 'remove' && mutation.force) && !arePluginHostViewsEnabled()) return false;
-	if (!mainWindow || mainWindow.isDestroyed() || !isWebContentsAvailable(mainWindow)) return false;
-	const sourcePlugin =
-		pluginManager?.getRegistry().records.find((record) => record.id === mutation.view.pluginId)
-			?.manifest?.name ?? mutation.view.pluginId;
-	let body: string | undefined;
-	if (mutation.kind === 'upsert') {
-		try {
-			body = JSON.stringify(mutation.blocks);
-		} catch {
-			return false;
-		}
-	}
-
-	if (mutation.view.surface === 'movement') {
-		const payload: MovementPayload =
-			mutation.kind === 'upsert'
-				? {
-						op: 'add',
-						id: mutation.view.id,
-						title: mutation.view.title,
-						body,
-						sourcePlugin,
-					}
-				: { op: 'remove', id: mutation.view.id };
-		mainWindow.webContents.send('remote:movement', payload);
-		return true;
-	}
-
-	const payload: CadenzaPayload =
-		mutation.kind === 'upsert'
-			? {
-					op: 'open',
-					id: mutation.view.id,
-					viewType: 'view',
-					title: mutation.view.title,
-					body,
-					sourcePlugin,
-				}
-			: { op: 'close', id: mutation.view.id };
-
-	// Closing a view must never create a new always-on-top HUD. Deliver a close
-	// to an existing HUD (including its pre-ready queue) or the main fallback only.
-	if (mutation.kind === 'remove') {
-		if (deliverCadenzaToExistingHud(payload)) return true;
-		mainWindow.webContents.send('remote:cadenza', payload);
-		return true;
-	}
-
-	// Match the CLI cadenza bridge: open/upsert prefers the HUD and creates it
-	// lazily, then falls back to the main renderer.
-	if (store.get('encoreFeatures', {})?.concerto === true && deliverCadenza(payload)) return true;
-	mainWindow.webContents.send('remote:cadenza', payload);
-	return true;
-}
-
-const pluginHostViews = new PluginHostViewRegistry({
-	isEnabled: arePluginHostViewsEnabled,
-	getHostViews: () => pluginManager?.getContributions().hostViews ?? [],
-	forward: forwardPluginHostView,
-});
-
-// Disabling either side of the bridge purges any live views immediately. If both
-// are enabled after a flag change, re-sync static data without asking a renderer
-// read path to refresh plugin discovery.
-store.onDidChange('encoreFeatures', (encoreFeatures) => {
-	if (encoreFeatures?.concerto !== true) closeCadenzaHudWindow();
-	if (!arePluginHostViewsEnabled()) {
-		pluginHostViews.purgeAll();
-		return;
-	}
-	pluginHostViews.sync();
-});
 
 // A `decision` cadenza's chosen option replies to the owning agent: inject the
 // value as a live prompt into that agent's session via the main renderer's
@@ -814,9 +739,6 @@ const createWebServer = createWebServerFactory({
 // - Auto-updater initialization in production
 function createWindow(options?: { sessionIds?: string[]; bounds?: Partial<SharedWindowState> }) {
 	mainWindow = windowManager.createWindow(options);
-	// The plugin registry may have discovered static views before the renderer
-	// existed. Re-forward host-owned data after every renderer load/reload.
-	mainWindow.webContents.on('did-finish-load', () => pluginHostViews.replay());
 	// Handle closed event to clear the reference
 	mainWindow.on('closed', () => {
 		mainWindow = null;
@@ -2098,6 +2020,14 @@ app
 		}
 
 		let pluginResourceCleanup: ((pluginId: string) => void) | undefined;
+		const groupingRegistry = new PluginGroupingRegistry(() => {
+			try {
+				mainWindow?.webContents.send('plugins:groupings-changed');
+			} catch {
+				// The renderer can disappear while plugins are stopping.
+			}
+		});
+		pluginGroupingRegistry = groupingRegistry;
 		const sandboxHost = new PluginSandboxHost({
 			broker: pluginBroker,
 			handlers: buildHostCallHandlers({
@@ -2111,6 +2041,13 @@ app
 				settingsDeleteNamespace: pluginSettingsDeleteNamespace,
 				sessionsList: pluginSessionsList,
 				sessionsGet: pluginSessionsGet,
+				groupingRegistry,
+				isDeclaredGrouping: (pluginId, localId) =>
+					pluginManager
+						?.getContributions()
+						.groupings.some(
+							(grouping) => grouping.pluginId === pluginId && grouping.localId === localId
+						) ?? false,
 				sessionsCreate: pluginSessionsCreate,
 				sessionsUpdate: pluginSessionsUpdate,
 				sessionsDelete: pluginSessionsDelete,
@@ -2174,12 +2111,6 @@ app
 				// stub no longer type-checks; this round-trips to the renderer's shared
 				// command registry (the SAME registry the command palette is built from).
 				runUiCommand: createRunUiCommand(() => mainWindow),
-				isHostViewsEnabled: arePluginHostViewsEnabled,
-				getHostView: (pluginId, localId) => pluginHostViews.getDeclared(pluginId, localId),
-				forwardHostView: (pluginId, operation, localId, blocks) => {
-					if (operation === 'remove') return pluginHostViews.remove(pluginId, localId);
-					return blocks === undefined ? false : pluginHostViews.update(pluginId, localId, blocks);
-				},
 				listAgents: () => {
 					const sessions = sessionsStore.get('sessions', []) as Array<{
 						id?: string;
@@ -2251,13 +2182,13 @@ app
 			},
 			onCrash: (pluginId, code) => {
 				pluginResourceCleanup?.(pluginId);
-				pluginHostViews.purge(pluginId);
+				groupingRegistry.removePlugin(pluginId);
 				logger.warn(`[Plugins] plugin "${pluginId}" crashed (code ${code})`, '[Plugins]');
 				backgroundSupervisor.onPluginCrash(pluginId, code);
 			},
 			onStop: (pluginId) => {
 				pluginResourceCleanup?.(pluginId);
-				pluginHostViews.purge(pluginId);
+				groupingRegistry.removePlugin(pluginId);
 				backgroundSupervisor.onPluginStopped(pluginId);
 			},
 		});
@@ -2294,12 +2225,11 @@ app
 					kvStore: pluginKvStore,
 					settingsDeleteNamespace: pluginSettingsDeleteNamespace,
 					eventBus,
-					hostViews: pluginHostViews,
 				});
+				groupingRegistry.removePlugin(id);
 				backgroundSupervisor.teardown(id);
 			},
 			onChange: (registry) => {
-				pluginHostViews.sync();
 				try {
 					mainWindow?.webContents.send('plugins:changed', registry);
 				} catch {
@@ -3096,6 +3026,7 @@ function setupIpcHandlers() {
 			manager: pluginManager,
 			sandboxHost: pluginSandboxHost ?? undefined,
 			authStore: pluginAuthStore,
+			groupingRegistry: pluginGroupingRegistry ?? undefined,
 		});
 	}
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -54,6 +54,9 @@ import {
 	type PluginSessionMetadata,
 	type PluginTabMetadata,
 } from './plugins/plugin-host-handlers';
+import { PluginHostViewRegistry, type HostViewMutation } from './plugins/plugin-host-view-registry';
+import type { MovementPayload } from '../shared/movement-types';
+import type { CadenzaPayload } from '../shared/cadenza-types';
 import { ActionGuard } from './plugins/action-guard';
 import { PluginKvStore } from './plugins/plugin-kv-store';
 import { PluginEventBusImpl } from './plugins/plugin-event-bus';
@@ -239,6 +242,7 @@ import {
 	createWindowManager,
 	createQuitHandler,
 	deliverCadenzaToHud,
+	deliverCadenzaToExistingHud,
 	closeCadenzaHudWindow,
 	getCadenzaHudWindow,
 	type QuitHandler,
@@ -643,17 +647,6 @@ const cadenzaHudDeps = {
 	windowRegistry,
 };
 
-// Disabling Concerto must tear down the already-running always-on-top HUD, not
-// merely reject future payloads. Without this listener, existing cards and the
-// cursor hover poll survive after the user turns the extension off.
-store.onDidChange('encoreFeatures', (encoreFeatures) => {
-	if (encoreFeatures?.concerto !== true) closeCadenzaHudWindow();
-	if (encoreFeatures?.plugins !== true) {
-		pluginSandboxHost?.stopAll();
-		pluginGroupingRegistry?.clearAll();
-	}
-});
-
 /**
  * Route a cadenza payload to the HUD window (creating it lazily). Returns
  * false when there's no main window to parent it, so the caller can fall back
@@ -674,6 +667,94 @@ function deliverCadenza(payload: Parameters<typeof deliverCadenzaToHud>[2]): boo
 	}
 	return deliverCadenzaToHud(mainWindow, cadenzaHudDeps, stamped);
 }
+
+/** Host views are a bridge between two opt-in Encore features. Re-read both
+ * flags on every mutation: a disabled feature must never retain a pending view. */
+function arePluginHostViewsEnabled(): boolean {
+	const features = store.get('encoreFeatures', {}) as Record<string, boolean>;
+	return features.plugins === true && features.concerto === true;
+}
+
+/** Forward one host-owned mutation over the exact Concerto renderer channels
+ * used by the CLI bridge. No renderer handles or plugin code cross this seam. */
+function forwardPluginHostView(mutation: HostViewMutation): boolean {
+	if (!(mutation.kind === 'remove' && mutation.force) && !arePluginHostViewsEnabled()) return false;
+	if (!mainWindow || mainWindow.isDestroyed() || !isWebContentsAvailable(mainWindow)) return false;
+	const sourcePlugin =
+		pluginManager?.getRegistry().records.find((record) => record.id === mutation.view.pluginId)
+			?.manifest?.name ?? mutation.view.pluginId;
+	let body: string | undefined;
+	if (mutation.kind === 'upsert') {
+		try {
+			body = JSON.stringify(mutation.blocks);
+		} catch {
+			return false;
+		}
+	}
+
+	if (mutation.view.surface === 'movement') {
+		const payload: MovementPayload =
+			mutation.kind === 'upsert'
+				? {
+						op: 'add',
+						id: mutation.view.id,
+						title: mutation.view.title,
+						body,
+						sourcePlugin,
+					}
+				: { op: 'remove', id: mutation.view.id };
+		mainWindow.webContents.send('remote:movement', payload);
+		return true;
+	}
+
+	const payload: CadenzaPayload =
+		mutation.kind === 'upsert'
+			? {
+					op: 'open',
+					id: mutation.view.id,
+					viewType: 'view',
+					title: mutation.view.title,
+					body,
+					sourcePlugin,
+				}
+			: { op: 'close', id: mutation.view.id };
+
+	// Closing a view must never create a new always-on-top HUD. Deliver a close
+	// to an existing HUD (including its pre-ready queue) or the main fallback only.
+	if (mutation.kind === 'remove') {
+		if (deliverCadenzaToExistingHud(payload)) return true;
+		mainWindow.webContents.send('remote:cadenza', payload);
+		return true;
+	}
+
+	// Match the CLI cadenza bridge: open/upsert prefers the HUD and creates it
+	// lazily, then falls back to the main renderer.
+	if (store.get('encoreFeatures', {})?.concerto === true && deliverCadenza(payload)) return true;
+	mainWindow.webContents.send('remote:cadenza', payload);
+	return true;
+}
+
+const pluginHostViews = new PluginHostViewRegistry({
+	isEnabled: arePluginHostViewsEnabled,
+	getHostViews: () => pluginManager?.getContributions().hostViews ?? [],
+	forward: forwardPluginHostView,
+});
+
+// Disabling either side of the bridge purges any live views immediately. If both
+// are enabled after a flag change, re-sync static data without asking a renderer
+// read path to refresh plugin discovery.
+store.onDidChange('encoreFeatures', (encoreFeatures) => {
+	if (encoreFeatures?.concerto !== true) closeCadenzaHudWindow();
+	if (encoreFeatures?.plugins !== true) {
+		pluginSandboxHost?.stopAll();
+		pluginGroupingRegistry?.clearAll();
+	}
+	if (!arePluginHostViewsEnabled()) {
+		pluginHostViews.purgeAll();
+		return;
+	}
+	pluginHostViews.sync();
+});
 
 // A `decision` cadenza's chosen option replies to the owning agent: inject the
 // value as a live prompt into that agent's session via the main renderer's
@@ -739,6 +820,9 @@ const createWebServer = createWebServerFactory({
 // - Auto-updater initialization in production
 function createWindow(options?: { sessionIds?: string[]; bounds?: Partial<SharedWindowState> }) {
 	mainWindow = windowManager.createWindow(options);
+	// The plugin registry may have discovered static views before the renderer
+	// existed. Re-forward host-owned data after every renderer load/reload.
+	mainWindow.webContents.on('did-finish-load', () => pluginHostViews.replay());
 	// Handle closed event to clear the reference
 	mainWindow.on('closed', () => {
 		mainWindow = null;
@@ -2024,7 +2108,7 @@ app
 			try {
 				mainWindow?.webContents.send('plugins:groupings-changed');
 			} catch {
-				// The renderer can disappear while plugins are stopping.
+				// Renderer may be gone during shutdown; ignore.
 			}
 		});
 		pluginGroupingRegistry = groupingRegistry;
@@ -2111,6 +2195,12 @@ app
 				// stub no longer type-checks; this round-trips to the renderer's shared
 				// command registry (the SAME registry the command palette is built from).
 				runUiCommand: createRunUiCommand(() => mainWindow),
+				isHostViewsEnabled: arePluginHostViewsEnabled,
+				getHostView: (pluginId, localId) => pluginHostViews.getDeclared(pluginId, localId),
+				forwardHostView: (pluginId, operation, localId, blocks) => {
+					if (operation === 'remove') return pluginHostViews.remove(pluginId, localId);
+					return blocks === undefined ? false : pluginHostViews.update(pluginId, localId, blocks);
+				},
 				listAgents: () => {
 					const sessions = sessionsStore.get('sessions', []) as Array<{
 						id?: string;
@@ -2182,12 +2272,14 @@ app
 			},
 			onCrash: (pluginId, code) => {
 				pluginResourceCleanup?.(pluginId);
+				pluginHostViews.purge(pluginId);
 				groupingRegistry.removePlugin(pluginId);
 				logger.warn(`[Plugins] plugin "${pluginId}" crashed (code ${code})`, '[Plugins]');
 				backgroundSupervisor.onPluginCrash(pluginId, code);
 			},
 			onStop: (pluginId) => {
 				pluginResourceCleanup?.(pluginId);
+				pluginHostViews.purge(pluginId);
 				groupingRegistry.removePlugin(pluginId);
 				backgroundSupervisor.onPluginStopped(pluginId);
 			},
@@ -2225,11 +2317,13 @@ app
 					kvStore: pluginKvStore,
 					settingsDeleteNamespace: pluginSettingsDeleteNamespace,
 					eventBus,
+					hostViews: pluginHostViews,
 				});
 				groupingRegistry.removePlugin(id);
 				backgroundSupervisor.teardown(id);
 			},
 			onChange: (registry) => {
+				pluginHostViews.sync();
 				try {
 					mainWindow?.webContents.send('plugins:changed', registry);
 				} catch {

--- a/src/main/ipc/handlers/plugins.ts
+++ b/src/main/ipc/handlers/plugins.ts
@@ -19,6 +19,7 @@ import type { AggregatedContributions } from '../../../shared/plugins/contributi
 import type { PermissionRequest, PermissionGrant } from '../../../shared/plugins/permissions';
 import type { PluginManager, InstallResult } from '../../plugins/plugin-manager';
 import type { ActivitySnapshot } from '../../plugins/plugin-sandbox-host';
+import type { PluginPublishedGrouping } from '../../plugins/plugin-grouping-registry';
 import { PLUGIN_ID_PATTERN } from '../../../shared/plugins/plugin-manifest';
 import { setPanelHtmlProvider } from '../../plugins/plugin-panel-host';
 import { getFirstPartyBridge, type FirstPartyBridgeState } from '../../plugins/first-party-bridge';
@@ -49,6 +50,7 @@ export interface PluginGrantsSnapshot {
 /** Per-plugin read-only observability keyed by plugin id (running tier-1 only). */
 export type PluginActivityMap = Record<string, ActivitySnapshot>;
 export type { ActivitySnapshot };
+export type PluginGroupingSnapshot = readonly PluginPublishedGrouping[];
 
 export interface PluginsHandlerDependencies {
 	settingsStore: {
@@ -58,6 +60,8 @@ export interface PluginsHandlerDependencies {
 	/** Optional read-only observability source for running tier-1 plugins. When
 	 *  absent (e.g. before the sandbox host is constructed), activity reads as {}. */
 	sandboxHost?: { getActivity(): PluginActivityMap };
+	/** Process-local presentation snapshots published by running plugins. */
+	groupingRegistry?: { snapshot(): PluginGroupingSnapshot };
 	/** The sealed authorization ledger - the live grant source. `get-grants` reads
 	 * it, `revoke`/`uninstall` mutate it, and `set-enabled` gates code-tier
 	 * activation on it (a tier>=1 plugin may only be enabled once it holds a
@@ -81,7 +85,7 @@ function snapshotOf(registry: PluginRegistry): PluginListSnapshot {
 }
 
 export function registerPluginsHandlers(deps: PluginsHandlerDependencies): void {
-	const { settingsStore, manager, sandboxHost, authStore } = deps;
+	const { settingsStore, manager, sandboxHost, authStore, groupingRegistry } = deps;
 
 	const wrappedList = withIpcErrorLogging(
 		handlerOpts('list'),
@@ -152,6 +156,10 @@ export function registerPluginsHandlers(deps: PluginsHandlerDependencies): void 
 				granted: authStore.readGrants(id),
 			};
 		}
+	);
+	const wrappedGetGroupings = withIpcErrorLogging(
+		handlerOpts('getGroupings'),
+		async (): Promise<PluginGroupingSnapshot> => groupingRegistry?.snapshot() ?? []
 	);
 	const wrappedRevokeGrants = withIpcErrorLogging(
 		handlerOpts('revokeGrants'),
@@ -289,6 +297,11 @@ export function registerPluginsHandlers(deps: PluginsHandlerDependencies): void 
 	ipcMain.handle('plugins:get-activity', async (event): Promise<PluginActivityMap> => {
 		if (!isPluginsEnabled(settingsStore)) throw new Error('PluginsDisabled');
 		return wrappedGetActivity(event);
+	});
+
+	ipcMain.handle('plugins:get-groupings', async (event): Promise<PluginGroupingSnapshot> => {
+		if (!isPluginsEnabled(settingsStore)) throw new Error('PluginsDisabled');
+		return wrappedGetGroupings(event);
 	});
 
 	ipcMain.handle(

--- a/src/main/plugins/plugin-grouping-registry.ts
+++ b/src/main/plugins/plugin-grouping-registry.ts
@@ -54,8 +54,7 @@ function hasOnlyKeys(value: Record<string, unknown>, allowed: readonly string[])
 export function validatePublishedGrouping(
 	pluginId: string,
 	localId: string,
-	input: unknown,
-	sessionIds: ReadonlySet<string>
+	input: unknown
 ): PluginPublishedGrouping {
 	if (!input || typeof input !== 'object' || Array.isArray(input))
 		throw new Error('grouping payload required');
@@ -123,8 +122,9 @@ export function validatePublishedGrouping(
 	const validGroups = new Set(groups.map((group) => group.id));
 	const assignments: Record<string, string> = {};
 	for (const [sessionId, groupId] of assignmentEntries) {
-		if (sessionIds.has(sessionId) && typeof groupId === 'string' && validGroups.has(groupId))
-			assignments[sessionId] = groupId;
+		// Preserve published ids: filtering by host sessions would let a grouping plugin
+		// infer session existence from snapshot readback. Unknown ids simply render nowhere.
+		if (typeof groupId === 'string' && validGroups.has(groupId)) assignments[sessionId] = groupId;
 	}
 	return { id: `${pluginId}/${localId}`, pluginId, localId, groups, assignments };
 }

--- a/src/main/plugins/plugin-grouping-registry.ts
+++ b/src/main/plugins/plugin-grouping-registry.ts
@@ -1,0 +1,130 @@
+export interface PluginPublishedGrouping {
+	id: string;
+	pluginId: string;
+	localId: string;
+	groups: Array<{ id: string; label: string; parentId?: string }>;
+	assignments: Record<string, string>;
+}
+
+/** Process-local, presentation-only snapshots emitted by live plugin sandboxes. */
+export class PluginGroupingRegistry {
+	private readonly entries = new Map<string, PluginPublishedGrouping>();
+
+	public constructor(private readonly onChanged: () => void = () => undefined) {}
+
+	public publish(grouping: PluginPublishedGrouping): void {
+		this.entries.set(`${grouping.pluginId}/${grouping.localId}`, structuredClone(grouping));
+		this.onChanged();
+	}
+
+	public clear(pluginId: string, localId: string): void {
+		if (this.entries.delete(`${pluginId}/${localId}`)) this.onChanged();
+	}
+
+	public removePlugin(pluginId: string): void {
+		let changed = false;
+		for (const [key, grouping] of this.entries) {
+			if (grouping.pluginId !== pluginId) continue;
+			this.entries.delete(key);
+			changed = true;
+		}
+		if (changed) this.onChanged();
+	}
+	public clearAll(): void {
+		if (this.entries.size === 0) return;
+		this.entries.clear();
+		this.onChanged();
+	}
+
+	public snapshot(): PluginPublishedGrouping[] {
+		return Array.from(this.entries.values(), (grouping) => structuredClone(grouping));
+	}
+}
+
+const MAX_GROUPS = 200;
+const MAX_LABEL_LENGTH = 120;
+const MAX_PAYLOAD_BYTES = 256 * 1024;
+const LOCAL_GROUP_ID = /^[a-zA-Z][a-zA-Z0-9._-]{0,63}$/;
+const MAX_ASSIGNMENTS = 10_000;
+
+function hasOnlyKeys(value: Record<string, unknown>, allowed: readonly string[]): boolean {
+	return Object.keys(value).every((key) => allowed.includes(key));
+}
+
+export function validatePublishedGrouping(
+	pluginId: string,
+	localId: string,
+	input: unknown,
+	sessionIds: ReadonlySet<string>
+): PluginPublishedGrouping {
+	if (!input || typeof input !== 'object' || Array.isArray(input))
+		throw new Error('grouping payload required');
+	const payload = input as Record<string, unknown>;
+	if (!hasOnlyKeys(payload, ['id', 'groups', 'assignments']))
+		throw new Error('invalid grouping payload');
+	if (payload.id !== localId) throw new Error('grouping id must match the declared local id');
+	if (!Array.isArray(payload.groups) || payload.groups.length > MAX_GROUPS)
+		throw new Error('invalid groups');
+	if (
+		!payload.assignments ||
+		typeof payload.assignments !== 'object' ||
+		Array.isArray(payload.assignments)
+	) {
+		throw new Error('invalid assignments');
+	}
+	const assignmentEntries = Object.entries(payload.assignments);
+	if (assignmentEntries.length > MAX_ASSIGNMENTS) throw new Error('too many assignments');
+	let encodedPayload: string;
+	try {
+		encodedPayload = JSON.stringify(payload);
+	} catch {
+		throw new Error('grouping payload must be JSON serializable');
+	}
+	if (Buffer.byteLength(encodedPayload, 'utf8') > MAX_PAYLOAD_BYTES) {
+		throw new Error('grouping payload exceeds size cap');
+	}
+	const groups = payload.groups.map((value) => {
+		if (!value || typeof value !== 'object' || Array.isArray(value))
+			throw new Error('invalid group');
+		const group = value as Record<string, unknown>;
+		if (
+			!hasOnlyKeys(group, ['id', 'label', 'parentId']) ||
+			typeof group.id !== 'string' ||
+			!LOCAL_GROUP_ID.test(group.id) ||
+			typeof group.label !== 'string' ||
+			group.label.trim().length === 0 ||
+			group.label.length > MAX_LABEL_LENGTH ||
+			(group.parentId !== undefined &&
+				(typeof group.parentId !== 'string' || !LOCAL_GROUP_ID.test(group.parentId)))
+		) {
+			throw new Error('invalid group');
+		}
+		return {
+			id: group.id,
+			label: group.label.trim(),
+			...(group.parentId ? { parentId: group.parentId } : {}),
+		};
+	});
+	const parentById = new Map(groups.map((group) => [group.id, group.parentId]));
+	if (parentById.size !== groups.length) throw new Error('duplicate virtual group id');
+	for (const group of groups) {
+		if (group.parentId && !parentById.has(group.parentId)) throw new Error('unknown group parent');
+		let depth = 0;
+		let current = group.parentId;
+		const seen = new Set<string>([group.id]);
+		while (current) {
+			if (seen.has(current)) throw new Error('virtual group hierarchy has a cycle');
+			seen.add(current);
+			depth += 1;
+			if (depth > 1) throw new Error('virtual group depth exceeds two');
+			current = parentById.get(current);
+		}
+	}
+	const validGroups = new Set(groups.map((group) => group.id));
+	const assignments: Record<string, string> = {};
+	for (const [sessionId, groupId] of assignmentEntries) {
+		if (sessionIds.has(sessionId) && typeof groupId === 'string' && validGroups.has(groupId))
+			assignments[sessionId] = groupId;
+	}
+	return { id: `${pluginId}/${localId}`, pluginId, localId, groups, assignments };
+}

--- a/src/main/plugins/plugin-host-handlers.ts
+++ b/src/main/plugins/plugin-host-handlers.ts
@@ -25,6 +25,7 @@ import type { PluginKvStore } from './plugin-kv-store';
 import type { EgressGuard } from './net-egress-guard';
 import type { PluginBackgroundHealth } from './plugin-background-supervisor';
 import type { SpawnBinaryEntry } from './spawn-binary-registry';
+import { validatePublishedGrouping, type PluginGroupingRegistry } from './plugin-grouping-registry';
 import {
 	isPluginEventTopic,
 	type PluginEvent,
@@ -132,6 +133,9 @@ export interface HostHandlerDeps {
 	/** Session METADATA listing (NEVER transcript/message content). */
 	sessionsList: () => PluginSessionMetadata[];
 	sessionsGet: (sessionId: string) => PluginSessionMetadata | null;
+	/** Process-local virtual grouping registry; never backed by persisted groups. */
+	groupingRegistry?: PluginGroupingRegistry;
+	isDeclaredGrouping?: (pluginId: string, localId: string) => boolean;
 	/** Optional session mutators. When omitted the handlers fail closed. */
 	sessionsCreate?: (params: Record<string, unknown>) => Promise<PluginSessionMetadata>;
 	sessionsUpdate?: (
@@ -1201,6 +1205,35 @@ export function buildHostCallHandlers(deps: HostHandlerDeps): HostCallHandlers {
 				restarts: 0,
 				services: services.map((s) => ({ id: s.id, ...(s.name ? { name: s.name } : {}) })),
 			};
+		},
+		'ui.groupingPublish': async (pluginId, params) => {
+			const p = asObject(params);
+			assertClosedSchema('ui.groupingPublish', p, { id: true, groups: true, assignments: true });
+			if (typeof p.id !== 'string' || !deps.isDeclaredGrouping?.(pluginId, p.id)) {
+				throw new Error('grouping id is not declared by this plugin');
+			}
+			assertBrokerAllowed(deps, pluginId, 'ui.groupingPublish', p);
+			if (!deps.groupingRegistry) throw new Error('grouping registry unavailable');
+			deps.groupingRegistry.publish(
+				validatePublishedGrouping(
+					pluginId,
+					p.id,
+					p,
+					new Set(deps.sessionsList().map((session) => session.id))
+				)
+			);
+			return { ok: true };
+		},
+
+		'ui.groupingClear': async (pluginId, params) => {
+			const p = asObject(params);
+			assertClosedSchema('ui.groupingClear', p, { id: true });
+			if (typeof p.id !== 'string' || !deps.isDeclaredGrouping?.(pluginId, p.id)) {
+				throw new Error('grouping id is not declared by this plugin');
+			}
+			assertBrokerAllowed(deps, pluginId, 'ui.groupingClear', p);
+			deps.groupingRegistry?.clear(pluginId, p.id);
+			return { ok: true };
 		},
 	};
 

--- a/src/main/plugins/plugin-host-handlers.ts
+++ b/src/main/plugins/plugin-host-handlers.ts
@@ -1214,14 +1214,7 @@ export function buildHostCallHandlers(deps: HostHandlerDeps): HostCallHandlers {
 			}
 			assertBrokerAllowed(deps, pluginId, 'ui.groupingPublish', p);
 			if (!deps.groupingRegistry) throw new Error('grouping registry unavailable');
-			deps.groupingRegistry.publish(
-				validatePublishedGrouping(
-					pluginId,
-					p.id,
-					p,
-					new Set(deps.sessionsList().map((session) => session.id))
-				)
-			);
+			deps.groupingRegistry.publish(validatePublishedGrouping(pluginId, p.id, p));
 			return { ok: true };
 		},
 

--- a/src/main/plugins/plugin-sandbox-entry.ts
+++ b/src/main/plugins/plugin-sandbox-entry.ts
@@ -287,9 +287,9 @@ const BOOTSTRAP_SOURCE = String.raw`(function bootstrap(bridge) {
 			}),
 			ui: Object.freeze({
 				runCommand: function (commandId, args) { return hostCall('ui.runCommand', { commandId: commandId, args: args }); },
-				hostView: Object.freeze({
-					update: function (id, blocks) { return hostCall('ui.hostViewUpdate', { id: id, blocks: blocks }); },
-					remove: function (id) { return hostCall('ui.hostViewRemove', { id: id }); }
+				grouping: Object.freeze({
+					publish: function (params) { return hostCall('ui.groupingPublish', params); },
+					clear: function (id) { return hostCall('ui.groupingClear', { id: id }); }
 				})
 			}),
 			tabs: Object.freeze({

--- a/src/main/plugins/plugin-sandbox-entry.ts
+++ b/src/main/plugins/plugin-sandbox-entry.ts
@@ -287,6 +287,10 @@ const BOOTSTRAP_SOURCE = String.raw`(function bootstrap(bridge) {
 			}),
 			ui: Object.freeze({
 				runCommand: function (commandId, args) { return hostCall('ui.runCommand', { commandId: commandId, args: args }); },
+				hostView: Object.freeze({
+					update: function (id, blocks) { return hostCall('ui.hostViewUpdate', { id: id, blocks: blocks }); },
+					remove: function (id) { return hostCall('ui.hostViewRemove', { id: id }); }
+				}),
 				grouping: Object.freeze({
 					publish: function (params) { return hostCall('ui.groupingPublish', params); },
 					clear: function (id) { return hostCall('ui.groupingClear', { id: id }); }

--- a/src/main/preload/plugins.ts
+++ b/src/main/preload/plugins.ts
@@ -16,6 +16,7 @@ import type {
 	PluginListSnapshot,
 	PluginGrantsSnapshot,
 	PluginActivityMap,
+	PluginGroupingSnapshot,
 } from '../ipc/handlers/plugins';
 import type { InstallResult } from '../plugins/plugin-manager';
 import type { AggregatedContributions } from '../../shared/plugins/contributions';
@@ -108,6 +109,10 @@ export function createPluginsApi() {
 		 */
 		getActivity: (): Promise<PluginActivityMap> => ipcRenderer.invoke('plugins:get-activity'),
 
+		/** Presentation-only virtual groupings from currently running plugins. */
+		getGroupings: (): Promise<PluginGroupingSnapshot> =>
+			ipcRenderer.invoke('plugins:get-groupings'),
+
 		/**
 		 * Subscribe to plugin-registry changes (install/uninstall/enable/disable/
 		 * refresh). The callback receives no payload - it is a signal to re-read
@@ -119,6 +124,12 @@ export function createPluginsApi() {
 			return () => {
 				ipcRenderer.removeListener('plugins:changed', handler);
 			};
+		},
+
+		onGroupingsChanged: (callback: () => void): (() => void) => {
+			const handler = (): void => callback();
+			ipcRenderer.on('plugins:groupings-changed', handler);
+			return () => ipcRenderer.removeListener('plugins:groupings-changed', handler);
 		},
 
 		/**

--- a/src/renderer/components/SessionList/SessionContextMenu.tsx
+++ b/src/renderer/components/SessionList/SessionContextMenu.tsx
@@ -43,6 +43,8 @@ interface SessionContextMenuProps {
 	onConfigureWorktrees?: () => void;
 	onDeleteWorktree?: () => void;
 	onCreateGroup?: () => void;
+	/** Hide persisted-group mutation controls in a virtual grouping mode. */
+	showGroupActions?: boolean;
 	onConfigureCue?: () => void;
 	/**
 	 * Multi-window: every window this agent can move into, labeled by number
@@ -140,6 +142,7 @@ export function SessionContextMenu({
 	onConfigureWorktrees,
 	onDeleteWorktree,
 	onCreateGroup,
+	showGroupActions = true,
 	onConfigureCue,
 	windowTargets,
 	onMoveToNewWindow,
@@ -280,7 +283,7 @@ export function SessionContextMenu({
 				</button>
 			)}
 
-			{!session.parentSessionId && !session.isPianola && (
+			{showGroupActions && !session.parentSessionId && !session.isPianola && (
 				<div
 					ref={moveToGroup.containerRef}
 					className="relative"

--- a/src/renderer/components/SessionList/SessionList.tsx
+++ b/src/renderer/components/SessionList/SessionList.tsx
@@ -27,8 +27,7 @@ import { HamburgerDropdown } from './HamburgerDropdown';
 import type { Session, Group, Theme } from '../../types';
 import { isWorktreeGroup } from '../../../shared/types';
 import { canSetGroupParent, removeGroupAndPromoteChildren } from '../../../shared/groupHierarchy';
-import { resolveGroupAppearance } from '../ui/groupAppearanceOptions';
-import { SafeSvgIcon } from '../ui/SafeSvgIcon';
+import { GROUP_ICON_OPTIONS } from '../ui/groupAppearanceOptions';
 import { getBadgeForTime } from '../../constants/conductorBadges';
 import { SessionItem } from '../SessionItem';
 import { LongPressable, longPressMouseEvent } from '../shared/LongPressable';
@@ -63,7 +62,8 @@ import { captureException } from '../../utils/sentry';
 import { isWebDesktop } from '../../utils/runtimeContext';
 import { useEventListener } from '../../hooks/utils/useEventListener';
 import type { StarredItem } from '../../hooks/session/useStarredItems';
-import { usePluginContributions } from '../../hooks/usePluginContributions';
+import { usePluginGroupings } from '../../hooks/usePluginGroupings';
+import { buildVirtualGrouping } from '../../utils/pluginGroupings';
 
 // ============================================================================
 // SessionContextMenu - Right-click context menu for session items
@@ -155,7 +155,6 @@ interface SessionListProps {
 const UNGROUPED_DROP_TARGET = '__ungrouped__';
 
 function SessionListInner(props: SessionListProps) {
-	const pluginContributions = usePluginContributions();
 	// Store subscriptions
 	// PERF: Equality fn skips re-renders driven purely by streaming log/usage
 	// updates. The sidebar only reads name/state/bookmarked/groupId/aiTabs.hasUnread,
@@ -753,6 +752,32 @@ function SessionListInner(props: SessionListProps) {
 		stuckOutageSignature
 	);
 
+	const pluginGroupings = usePluginGroupings();
+	const [groupingMode, setGroupingMode] = useState('manual');
+	const [virtualCollapsed, setVirtualCollapsed] = useState<Record<string, boolean>>({});
+	useEffect(() => {
+		void window.maestro.settings.get('leftSidebarGroupingMode').then((value) => {
+			if (typeof value === 'string') setGroupingMode(value);
+		});
+	}, []);
+	const activeVirtualGrouping = pluginGroupings.find((grouping) => grouping.id === groupingMode);
+	useEffect(() => {
+		if (groupingMode === 'manual' || activeVirtualGrouping) return;
+		setGroupingMode('manual');
+		void window.maestro.settings.set('leftSidebarGroupingMode', 'manual');
+	}, [activeVirtualGrouping, groupingMode]);
+	const virtualGrouping = useMemo(
+		() =>
+			activeVirtualGrouping
+				? buildVirtualGrouping(activeVirtualGrouping, sortedFilteredSessions)
+				: undefined,
+		[activeVirtualGrouping, sortedFilteredSessions]
+	);
+	const selectGroupingMode = useCallback((id: string) => {
+		setGroupingMode(id);
+		void window.maestro.settings.set('leftSidebarGroupingMode', id);
+	}, []);
+
 	const { orderedGroups, groupById, childrenByParentId } = useMemo(() => {
 		const groupById = new Map(sortedGroups.map((group) => [group.id, group]));
 		if (!groupsPlusEnabled) {
@@ -952,10 +977,9 @@ function SessionListInner(props: SessionListProps) {
 		// When wrapped, use 'ungrouped' styling for flat sessions (no mx-3, consistent with grouped look)
 		const effectiveVariant = needsWorktreeWrapper && variant === 'flat' ? 'ungrouped' : variant;
 
-		// The Bookmarks section is a filtered view, not a real container - dragging
-		// agents out of it or dropping them into it has no meaningful target (drops
-		// previously fell through to "ungroup"). Disable drag/drop for those rows.
-		const dragDisabled = variant === 'bookmark';
+		// Bookmarks and virtual groupings are presentation-only views, not real
+		// containers. Dragging in either would mutate persisted session.groupId.
+		const dragDisabled = variant === 'bookmark' || activeVirtualGrouping !== undefined;
 
 		const content = (
 			<>
@@ -1354,6 +1378,29 @@ function SessionListInner(props: SessionListProps) {
 						</div>
 					)}
 
+					{pluginGroupings.length > 0 && !isSecondaryWindow && (
+						<label
+							className="mx-3 mb-2 flex items-center gap-2 text-xs"
+							style={{ color: theme.colors.textDim }}
+						>
+							<span>Grouping</span>
+							<select
+								aria-label="Session grouping mode"
+								value={activeVirtualGrouping?.id ?? 'manual'}
+								onChange={(event) => selectGroupingMode(event.target.value)}
+								className="min-w-0 flex-1 rounded border bg-transparent px-1 py-0.5"
+								style={{ borderColor: theme.colors.border, color: theme.colors.textMain }}
+							>
+								<option value="manual">Manual</option>
+								{pluginGroupings.map((grouping) => (
+									<option key={grouping.id} value={grouping.id}>
+										{grouping.label ?? grouping.localId}
+									</option>
+								))}
+							</select>
+						</label>
+					)}
+
 					{/* Empty state for unread agents filter */}
 					{showUnreadAgentsOnly && sortedFilteredSessions.length === 0 && (
 						<div
@@ -1534,226 +1581,293 @@ function SessionListInner(props: SessionListProps) {
 						</div>
 					)}
 
-					{/* GROUPS - hidden in a secondary window, which renders its owned agents
-					    as a flat focused list (see the flat-list branch below). */}
-					{(isSecondaryWindow ? [] : orderedGroups).map((group) => {
-						const groupSessions = sortedGroupSessionsById.get(group.id) || [];
-						const parentGroup =
-							groupsPlusEnabled && group.parentGroupId
-								? groupById.get(group.parentGroupId)
-								: undefined;
-						const isNestedGroup = Boolean(parentGroup && !parentGroup.parentGroupId);
-						if (isNestedGroup && parentGroup?.collapsed && !showUnreadAgentsOnly) return null;
-						const childGroups = groupsPlusEnabled ? (childrenByParentId.get(group.id) ?? []) : [];
-						const hasVisibleChild = childGroups.some(
-							(childGroup) => (sortedGroupSessionsById.get(childGroup.id) || []).length > 0
-						);
-						// Keep a parent visible for a matching child while filtering by unread agents.
-						if (showUnreadAgentsOnly && groupSessions.length === 0 && !hasVisibleChild) return null;
-						const groupCollapsedPills = groupSessions.filter((session) => !session.parentSessionId);
-						const appearance = resolveGroupAppearance(
-							groupsPlusEnabled ? group.icon : undefined,
-							groupsPlusEnabled ? group.color : undefined,
-							groupsPlusEnabled ? pluginContributions.iconPacks : []
-						);
-						return (
-							<div
-								key={group.id}
-								data-group-depth={isNestedGroup ? 1 : 0}
-								className={`${isNestedGroup ? 'ml-4 ' : ''}mb-1 rounded`}
-								style={
-									dragOverTarget === group.id
-										? {
-												outline: `1px dashed ${theme.colors.accent}`,
-												outlineOffset: '-2px',
-												backgroundColor: `${theme.colors.accent}14`,
+					{activeVirtualGrouping &&
+						virtualGrouping &&
+						virtualGrouping.groups
+							.filter(
+								(group) =>
+									!group.parentGroupId ||
+									!virtualGrouping.groups.some((candidate) => candidate.id === group.parentGroupId)
+							)
+							.flatMap((group) => [
+								group,
+								...virtualGrouping.groups.filter(
+									(candidate) => candidate.parentGroupId === group.id
+								),
+							])
+							.map((group) => {
+								const parent = group.parentGroupId
+									? virtualGrouping.groups.find((candidate) => candidate.id === group.parentGroupId)
+									: undefined;
+								const collapsed = virtualCollapsed[group.id] === true;
+								if (parent && virtualCollapsed[parent.id] === true) return null;
+								const groupSessions = sortedFilteredSessions.filter(
+									(session) => virtualGrouping.assignments[session.id] === group.id
+								);
+								return (
+									<div key={group.id} className={`${parent ? 'ml-4 ' : ''}mb-1 rounded`}>
+										<button
+											type="button"
+											className="w-full px-3 py-1.5 flex items-center gap-2 text-xs font-bold uppercase tracking-wider hover:bg-opacity-50"
+											style={{ color: theme.colors.textDim }}
+											aria-expanded={!collapsed}
+											onClick={() =>
+												setVirtualCollapsed((previous) => ({
+													...previous,
+													[group.id]: !collapsed,
+												}))
 											}
-										: undefined
-								}
-								onDragEnter={() => handleDropTargetEnter(group.id)}
-								onDragLeave={handleDropTargetLeave}
-							>
-								<LongPressable
-									role="button"
-									tabIndex={0}
-									draggable={groupsPlusEnabled && editingGroupId !== group.id}
-									onDragStart={
-										groupsPlusEnabled
-											? (event) => {
-													event.dataTransfer.effectAllowed = 'move';
-													event.dataTransfer.setData('text/plain', group.id);
-													setDraggingGroupId(group.id);
-												}
-											: undefined
-									}
-									onDragEnd={
-										groupsPlusEnabled
-											? () => {
-													setDraggingGroupId(null);
-													setDragOverTarget(null);
-												}
-											: undefined
-									}
-									aria-expanded={!group.collapsed}
-									onKeyDown={(e) => {
-										if (e.key === 'Enter' || e.key === ' ') {
-											e.preventDefault();
-											toggleGroup(group.id);
-										}
-									}}
-									className="px-3 py-1.5 flex items-center justify-between cursor-pointer hover:bg-opacity-50 group"
+										>
+											{collapsed ? (
+												<ChevronRight className="w-3 h-3" />
+											) : (
+												<ChevronDown className="w-3 h-3" />
+											)}
+											<Folder className="w-3.5 h-3.5" />
+											<span>{group.name}</span>
+											<span className="normal-case font-normal opacity-60">
+												from {activeVirtualGrouping.pluginName ?? activeVirtualGrouping.pluginId}
+											</span>
+										</button>
+										{!collapsed && (
+											<div
+												className="flex flex-col border-l ml-4"
+												style={{ borderColor: theme.colors.border }}
+											>
+												{groupSessions.map((session) =>
+													renderSessionWithWorktrees(session, 'group', {
+														keyPrefix: `virtual-${group.id}`,
+													})
+												)}
+											</div>
+										)}
+									</div>
+								);
+							})}
+
+					{/* Persisted groups are hidden while a virtual grouping is active. */}
+					{!activeVirtualGrouping &&
+						(isSecondaryWindow ? [] : orderedGroups).map((group) => {
+							const groupSessions = sortedGroupSessionsById.get(group.id) || [];
+							const parentGroup =
+								groupsPlusEnabled && group.parentGroupId
+									? groupById.get(group.parentGroupId)
+									: undefined;
+							const isNestedGroup = Boolean(parentGroup && !parentGroup.parentGroupId);
+							if (isNestedGroup && parentGroup?.collapsed && !showUnreadAgentsOnly) return null;
+							const childGroups = groupsPlusEnabled ? (childrenByParentId.get(group.id) ?? []) : [];
+							const hasVisibleChild = childGroups.some(
+								(childGroup) => (sortedGroupSessionsById.get(childGroup.id) || []).length > 0
+							);
+							// Keep a parent visible for a matching child while filtering by unread agents.
+							if (showUnreadAgentsOnly && groupSessions.length === 0 && !hasVisibleChild)
+								return null;
+							const groupCollapsedPills = groupSessions.filter(
+								(session) => !session.parentSessionId
+							);
+							const GroupIcon =
+								groupsPlusEnabled && group.icon
+									? GROUP_ICON_OPTIONS.find((option) => option.id === group.icon)?.Icon
+									: undefined;
+							return (
+								<div
+									key={group.id}
+									data-group-depth={isNestedGroup ? 1 : 0}
+									className={`${isNestedGroup ? 'ml-4 ' : ''}mb-1 rounded`}
 									style={
 										dragOverTarget === group.id
-											? { backgroundColor: `${theme.colors.accent}33` }
+											? {
+													outline: `1px dashed ${theme.colors.accent}`,
+													outlineOffset: '-2px',
+													backgroundColor: `${theme.colors.accent}14`,
+												}
 											: undefined
 									}
-									onClick={() => toggleGroup(group.id)}
-									onContextMenu={(e) => handleGroupContextMenu(e, group.id)}
-									// Touch: a long-press opens the same group context menu right-click opens.
-									onLongPress={(rect) =>
-										handleGroupContextMenu(longPressMouseEvent(rect), group.id)
-									}
-									onDragOver={handleDragOver}
-									onDrop={() => handleGroupDrop(group.id)}
+									onDragEnter={() => handleDropTargetEnter(group.id)}
+									onDragLeave={handleDropTargetLeave}
 								>
-									<div
-										className="flex items-center gap-2 text-xs font-bold uppercase tracking-wider flex-1"
-										style={{ color: theme.colors.textDim }}
+									<LongPressable
+										role="button"
+										tabIndex={0}
+										draggable={groupsPlusEnabled && editingGroupId !== group.id}
+										onDragStart={
+											groupsPlusEnabled
+												? (event) => {
+														event.dataTransfer.effectAllowed = 'move';
+														event.dataTransfer.setData('text/plain', group.id);
+														setDraggingGroupId(group.id);
+													}
+												: undefined
+										}
+										onDragEnd={
+											groupsPlusEnabled
+												? () => {
+														setDraggingGroupId(null);
+														setDragOverTarget(null);
+													}
+												: undefined
+										}
+										aria-expanded={!group.collapsed}
+										onKeyDown={(e) => {
+											if (e.key === 'Enter' || e.key === ' ') {
+												e.preventDefault();
+												toggleGroup(group.id);
+											}
+										}}
+										className="px-3 py-1.5 flex items-center justify-between cursor-pointer hover:bg-opacity-50 group"
+										style={
+											dragOverTarget === group.id
+												? { backgroundColor: `${theme.colors.accent}33` }
+												: undefined
+										}
+										onClick={() => toggleGroup(group.id)}
+										onContextMenu={(e) => handleGroupContextMenu(e, group.id)}
+										// Touch: a long-press opens the same group context menu right-click opens.
+										onLongPress={(rect) =>
+											handleGroupContextMenu(longPressMouseEvent(rect), group.id)
+										}
+										onDragOver={handleDragOver}
+										onDrop={() => handleGroupDrop(group.id)}
 									>
-										{group.collapsed && !showUnreadAgentsOnly ? (
-											<ChevronRight className="w-3 h-3" />
-										) : (
-											<ChevronDown className="w-3 h-3" />
-										)}
-										{appearance.icon ? (
-											appearance.icon.kind === 'plugin' ? (
-												<SafeSvgIcon
+										<div
+											className="flex items-center gap-2 text-xs font-bold uppercase tracking-wider flex-1"
+											style={{ color: theme.colors.textDim }}
+										>
+											{group.collapsed && !showUnreadAgentsOnly ? (
+												<ChevronRight className="w-3 h-3" />
+											) : (
+												<ChevronDown className="w-3 h-3" />
+											)}
+											{GroupIcon ? (
+												<GroupIcon
 													className="w-4 h-4"
-													path={appearance.icon.path}
-													viewBox={appearance.icon.viewBox}
-													style={{ color: appearance.color || theme.colors.textDim }}
+													style={{
+														color: groupsPlusEnabled
+															? group.color || theme.colors.textDim
+															: theme.colors.textDim,
+													}}
+												/>
+											) : group.emoji ? (
+												<span className="text-sm">{group.emoji}</span>
+											) : (
+												<Folder className="w-4 h-4" />
+											)}
+											{editingGroupId === group.id ? (
+												<input
+													autoFocus
+													className="bg-transparent outline-none w-full border-b border-indigo-500"
+													defaultValue={group.name}
+													onClick={(e) => e.stopPropagation()}
+													onBlur={(e) => {
+														if (ignoreNextBlurRef.current) {
+															ignoreNextBlurRef.current = false;
+															return;
+														}
+														finishRenamingGroup(group.id, e.target.value);
+													}}
+													onKeyDown={(e) => {
+														e.stopPropagation();
+														if (e.key === 'Enter') {
+															ignoreNextBlurRef.current = true;
+															finishRenamingGroup(group.id, e.currentTarget.value);
+														}
+													}}
 												/>
 											) : (
-												<appearance.icon.Icon
-													className="w-4 h-4"
-													style={{ color: appearance.color || theme.colors.textDim }}
-												/>
-											)
-										) : group.emoji ? (
-											<span className="text-sm">{group.emoji}</span>
-										) : (
-											<Folder className="w-4 h-4" />
-										)}
-										{editingGroupId === group.id ? (
-											<input
-												autoFocus
-												className="bg-transparent outline-none w-full border-b border-indigo-500"
-												defaultValue={group.name}
-												onClick={(e) => e.stopPropagation()}
-												onBlur={(e) => {
-													if (ignoreNextBlurRef.current) {
-														ignoreNextBlurRef.current = false;
-														return;
+												<span
+													onDoubleClick={() => startRenamingGroup(group.id)}
+													style={
+														groupsPlusEnabled && group.color ? { color: group.color } : undefined
 													}
-													finishRenamingGroup(group.id, e.target.value);
-												}}
-												onKeyDown={(e) => {
-													e.stopPropagation();
-													if (e.key === 'Enter') {
-														ignoreNextBlurRef.current = true;
-														finishRenamingGroup(group.id, e.currentTarget.value);
-													}
-												}}
+												>
+													{group.name}
+													{showLeftPanelGroupMemberCount && groupCollapsedPills.length > 0 && (
+														<span className="ml-1 opacity-60">({groupCollapsedPills.length})</span>
+													)}
+												</span>
+											)}
+											<WizardIndicator
+												active={wizardRollup.groups.has(group.id)}
+												generatingDocs={!!wizardRollup.groups.get(group.id)?.isGeneratingDocs}
 											/>
-										) : (
-											<span
-												onDoubleClick={() => startRenamingGroup(group.id)}
-												style={appearance.color ? { color: appearance.color } : undefined}
+										</div>
+										{/* Delete button for empty groups */}
+										{groupSessions.length === 0 && (
+											<button
+												onClick={(e) => {
+													e.stopPropagation();
+													showConfirmation(
+														`Are you sure you want to delete the group "${group.name}"?`,
+														() => {
+															setGroups((prev) => removeGroupAndPromoteChildren(prev, group.id));
+														}
+													);
+												}}
+												className="p-1 rounded hover:bg-red-500/20 opacity-0 group-hover:opacity-100 transition-opacity"
+												style={{ color: theme.colors.error }}
+												title="Delete empty group"
 											>
-												{group.name}
-												{showLeftPanelGroupMemberCount && groupCollapsedPills.length > 0 && (
-													<span className="ml-1 opacity-60">({groupCollapsedPills.length})</span>
-												)}
-											</span>
+												<X className="w-3 h-3" />
+											</button>
 										)}
-										<WizardIndicator
-											active={wizardRollup.groups.has(group.id)}
-											generatingDocs={!!wizardRollup.groups.get(group.id)?.isGeneratingDocs}
-										/>
-									</div>
-									{/* Delete button for empty groups */}
-									{groupSessions.length === 0 && (
-										<button
-											onClick={(e) => {
-												e.stopPropagation();
-												showConfirmation(
-													`Are you sure you want to delete the group "${group.name}"?`,
-													() => {
-														setGroups((prev) => removeGroupAndPromoteChildren(prev, group.id));
-													}
-												);
-											}}
-											className="p-1 rounded hover:bg-red-500/20 opacity-0 group-hover:opacity-100 transition-opacity"
-											style={{ color: theme.colors.error }}
-											title="Delete empty group"
-										>
-											<X className="w-3 h-3" />
-										</button>
-									)}
-									{/* Delete button for worktree groups with agents */}
-									{isWorktreeGroup(group) && groupSessions.length > 0 && onDeleteWorktreeGroup && (
-										<button
-											onClick={(e) => {
-												e.stopPropagation();
-												onDeleteWorktreeGroup(group.id);
-											}}
-											className="p-1 rounded hover:bg-red-500/20 opacity-0 group-hover:opacity-100 transition-opacity"
-											style={{ color: theme.colors.error }}
-											title="Remove group and all agents"
-										>
-											<Trash2 className="w-3 h-3" />
-										</button>
-									)}
-								</LongPressable>
+										{/* Delete button for worktree groups with agents */}
+										{isWorktreeGroup(group) &&
+											groupSessions.length > 0 &&
+											onDeleteWorktreeGroup && (
+												<button
+													onClick={(e) => {
+														e.stopPropagation();
+														onDeleteWorktreeGroup(group.id);
+													}}
+													className="p-1 rounded hover:bg-red-500/20 opacity-0 group-hover:opacity-100 transition-opacity"
+													style={{ color: theme.colors.error }}
+													title="Remove group and all agents"
+												>
+													<Trash2 className="w-3 h-3" />
+												</button>
+											)}
+									</LongPressable>
 
-								{!group.collapsed || showUnreadAgentsOnly ? (
-									<div
-										className="flex flex-col border-l ml-4"
-										style={{ borderColor: theme.colors.border }}
-									>
-										{groupSessions.map((session) =>
-											renderSessionWithWorktrees(session, 'group', {
-												keyPrefix: `group-${group.id}`,
-												groupId: group.id,
-												onDrop: dropOnGroupHandlers.get(group.id),
-											})
-										)}
-									</div>
-								) : groupCollapsedPills.length > 0 ? (
-									/* Collapsed Group Palette - uses subdivided pills for worktrees */
-									<CollapsedSessionPillRows
-										sessions={groupCollapsedPills}
-										keyPrefix={`group-collapsed-${group.id}`}
-										maxPerRow={leftPanelCollapsedPillsPerRow}
-										onContainerClick={() => toggleGroup(group.id)}
-										theme={theme}
-										activeBatchSessionIds={activeBatchSessionIds}
-										leftSidebarWidth={leftSidebarWidthState}
-										contextWarningYellowThreshold={contextWarningYellowThreshold}
-										contextWarningRedThreshold={contextWarningRedThreshold}
-										getFileCount={getFileCount}
-										getWorktreeChildren={getWorktreeChildren}
-										setActiveSessionId={setActiveSessionId}
-									/>
-								) : null}
-							</div>
-						);
-					})}
+									{!group.collapsed || showUnreadAgentsOnly ? (
+										<div
+											className="flex flex-col border-l ml-4"
+											style={{ borderColor: theme.colors.border }}
+										>
+											{groupSessions.map((session) =>
+												renderSessionWithWorktrees(session, 'group', {
+													keyPrefix: `group-${group.id}`,
+													groupId: group.id,
+													onDrop: dropOnGroupHandlers.get(group.id),
+												})
+											)}
+										</div>
+									) : groupCollapsedPills.length > 0 ? (
+										/* Collapsed Group Palette - uses subdivided pills for worktrees */
+										<CollapsedSessionPillRows
+											sessions={groupCollapsedPills}
+											keyPrefix={`group-collapsed-${group.id}`}
+											maxPerRow={leftPanelCollapsedPillsPerRow}
+											onContainerClick={() => toggleGroup(group.id)}
+											theme={theme}
+											activeBatchSessionIds={activeBatchSessionIds}
+											leftSidebarWidth={leftSidebarWidthState}
+											contextWarningYellowThreshold={contextWarningYellowThreshold}
+											contextWarningRedThreshold={contextWarningRedThreshold}
+											getFileCount={getFileCount}
+											getWorktreeChildren={getWorktreeChildren}
+											setActiveSessionId={setActiveSessionId}
+										/>
+									) : null}
+								</div>
+							);
+						})}
 
 					{/* SESSIONS - Flat list when no groups exist (or in a secondary window, which
 					    always shows its owned agents as a flat focused list), otherwise the
 					    Ungrouped folder. */}
-					{sessions.length > 0 && (groups.length === 0 || isSecondaryWindow) ? (
+					{!activeVirtualGrouping &&
+					sessions.length > 0 &&
+					(groups.length === 0 || isSecondaryWindow) ? (
 						/* FLAT LIST - No groups exist yet, show sessions directly with New Group button */
 						<>
 							<div className="flex flex-col">
@@ -1779,7 +1893,10 @@ function SessionListInner(props: SessionListProps) {
 								</div>
 							)}
 						</>
-					) : !isSecondaryWindow && groups.length > 0 && ungroupedSessions.length > 0 ? (
+					) : !activeVirtualGrouping &&
+					  !isSecondaryWindow &&
+					  groups.length > 0 &&
+					  ungroupedSessions.length > 0 ? (
 						/* UNGROUPED FOLDER - Groups exist and there are ungrouped agents */
 						<div
 							className="mb-1 mt-4 rounded"
@@ -1876,7 +1993,10 @@ function SessionListInner(props: SessionListProps) {
 								/>
 							)}
 						</div>
-					) : !isSecondaryWindow && groups.length > 0 && !showUnreadAgentsOnly ? (
+					) : !activeVirtualGrouping &&
+					  !isSecondaryWindow &&
+					  groups.length > 0 &&
+					  !showUnreadAgentsOnly ? (
 						/* NO UNGROUPED AGENTS - Show drop zone for ungrouping + New Group button */
 						<div
 							className="mt-4 px-3"
@@ -2012,6 +2132,7 @@ function SessionListInner(props: SessionListProps) {
 						setContextMenu(null);
 					}}
 					onToggleBookmark={() => toggleBookmark(contextMenuSession.id)}
+					showGroupActions={!activeVirtualGrouping}
 					onMoveToGroup={(groupId) => handleMoveToGroup(contextMenuSession.id, groupId)}
 					onDelete={() => handleDeleteSession(contextMenuSession.id)}
 					onDismiss={() => setContextMenu(null)}

--- a/src/renderer/components/SessionList/SessionList.tsx
+++ b/src/renderer/components/SessionList/SessionList.tsx
@@ -27,7 +27,8 @@ import { HamburgerDropdown } from './HamburgerDropdown';
 import type { Session, Group, Theme } from '../../types';
 import { isWorktreeGroup } from '../../../shared/types';
 import { canSetGroupParent, removeGroupAndPromoteChildren } from '../../../shared/groupHierarchy';
-import { GROUP_ICON_OPTIONS } from '../ui/groupAppearanceOptions';
+import { resolveGroupAppearance } from '../ui/groupAppearanceOptions';
+import { SafeSvgIcon } from '../ui/SafeSvgIcon';
 import { getBadgeForTime } from '../../constants/conductorBadges';
 import { SessionItem } from '../SessionItem';
 import { LongPressable, longPressMouseEvent } from '../shared/LongPressable';
@@ -62,6 +63,7 @@ import { captureException } from '../../utils/sentry';
 import { isWebDesktop } from '../../utils/runtimeContext';
 import { useEventListener } from '../../hooks/utils/useEventListener';
 import type { StarredItem } from '../../hooks/session/useStarredItems';
+import { usePluginContributions } from '../../hooks/usePluginContributions';
 import { usePluginGroupings } from '../../hooks/usePluginGroupings';
 import { buildVirtualGrouping } from '../../utils/pluginGroupings';
 
@@ -155,6 +157,7 @@ interface SessionListProps {
 const UNGROUPED_DROP_TARGET = '__ungrouped__';
 
 function SessionListInner(props: SessionListProps) {
+	const pluginContributions = usePluginContributions();
 	// Store subscriptions
 	// PERF: Equality fn skips re-renders driven purely by streaming log/usage
 	// updates. The sidebar only reads name/state/bookmarked/groupId/aiTabs.hasUnread,
@@ -977,8 +980,9 @@ function SessionListInner(props: SessionListProps) {
 		// When wrapped, use 'ungrouped' styling for flat sessions (no mx-3, consistent with grouped look)
 		const effectiveVariant = needsWorktreeWrapper && variant === 'flat' ? 'ungrouped' : variant;
 
-		// Bookmarks and virtual groupings are presentation-only views, not real
-		// containers. Dragging in either would mutate persisted session.groupId.
+		// The Bookmarks section is a filtered view, not a real container - dragging
+		// agents out of it or dropping them into it has no meaningful target (drops
+		// previously fell through to "ungroup"). Disable drag/drop for those rows.
 		const dragDisabled = variant === 'bookmark' || activeVirtualGrouping !== undefined;
 
 		const content = (
@@ -1383,7 +1387,7 @@ function SessionListInner(props: SessionListProps) {
 							className="mx-3 mb-2 flex items-center gap-2 text-xs"
 							style={{ color: theme.colors.textDim }}
 						>
-							<span>Grouping</span>
+							<span>Session grouping</span>
 							<select
 								aria-label="Session grouping mode"
 								value={activeVirtualGrouping?.id ?? 'manual'}
@@ -1394,7 +1398,7 @@ function SessionListInner(props: SessionListProps) {
 								<option value="manual">Manual</option>
 								{pluginGroupings.map((grouping) => (
 									<option key={grouping.id} value={grouping.id}>
-										{grouping.label ?? grouping.localId}
+										{grouping.label}
 									</option>
 								))}
 							</select>
@@ -1605,17 +1609,14 @@ function SessionListInner(props: SessionListProps) {
 									(session) => virtualGrouping.assignments[session.id] === group.id
 								);
 								return (
-									<div key={group.id} className={`${parent ? 'ml-4 ' : ''}mb-1 rounded`}>
+									<div key={group.id} className={parent ? 'ml-4 mb-1 rounded' : 'mb-1 rounded'}>
 										<button
 											type="button"
 											className="w-full px-3 py-1.5 flex items-center gap-2 text-xs font-bold uppercase tracking-wider hover:bg-opacity-50"
 											style={{ color: theme.colors.textDim }}
 											aria-expanded={!collapsed}
 											onClick={() =>
-												setVirtualCollapsed((previous) => ({
-													...previous,
-													[group.id]: !collapsed,
-												}))
+												setVirtualCollapsed((previous) => ({ ...previous, [group.id]: !collapsed }))
 											}
 										>
 											{collapsed ? (
@@ -1636,7 +1637,7 @@ function SessionListInner(props: SessionListProps) {
 											>
 												{groupSessions.map((session) =>
 													renderSessionWithWorktrees(session, 'group', {
-														keyPrefix: `virtual-${group.id}`,
+														keyPrefix: ['virtual', group.id].join('-'),
 													})
 												)}
 											</div>
@@ -1645,7 +1646,8 @@ function SessionListInner(props: SessionListProps) {
 								);
 							})}
 
-					{/* Persisted groups are hidden while a virtual grouping is active. */}
+					{/* GROUPS - hidden in a secondary window, which renders its owned agents
+					    as a flat focused list (see the flat-list branch below). */}
 					{!activeVirtualGrouping &&
 						(isSecondaryWindow ? [] : orderedGroups).map((group) => {
 							const groupSessions = sortedGroupSessionsById.get(group.id) || [];
@@ -1665,10 +1667,11 @@ function SessionListInner(props: SessionListProps) {
 							const groupCollapsedPills = groupSessions.filter(
 								(session) => !session.parentSessionId
 							);
-							const GroupIcon =
-								groupsPlusEnabled && group.icon
-									? GROUP_ICON_OPTIONS.find((option) => option.id === group.icon)?.Icon
-									: undefined;
+							const appearance = resolveGroupAppearance(
+								groupsPlusEnabled ? group.icon : undefined,
+								groupsPlusEnabled ? group.color : undefined,
+								groupsPlusEnabled ? (pluginContributions.iconPacks ?? []) : []
+							);
 							return (
 								<div
 									key={group.id}
@@ -1738,15 +1741,20 @@ function SessionListInner(props: SessionListProps) {
 											) : (
 												<ChevronDown className="w-3 h-3" />
 											)}
-											{GroupIcon ? (
-												<GroupIcon
-													className="w-4 h-4"
-													style={{
-														color: groupsPlusEnabled
-															? group.color || theme.colors.textDim
-															: theme.colors.textDim,
-													}}
-												/>
+											{appearance.icon ? (
+												appearance.icon.kind === 'plugin' ? (
+													<SafeSvgIcon
+														className="w-4 h-4"
+														path={appearance.icon.path}
+														viewBox={appearance.icon.viewBox}
+														style={{ color: appearance.color || theme.colors.textDim }}
+													/>
+												) : (
+													<appearance.icon.Icon
+														className="w-4 h-4"
+														style={{ color: appearance.color || theme.colors.textDim }}
+													/>
+												)
 											) : group.emoji ? (
 												<span className="text-sm">{group.emoji}</span>
 											) : (
@@ -1776,9 +1784,7 @@ function SessionListInner(props: SessionListProps) {
 											) : (
 												<span
 													onDoubleClick={() => startRenamingGroup(group.id)}
-													style={
-														groupsPlusEnabled && group.color ? { color: group.color } : undefined
-													}
+													style={appearance.color ? { color: appearance.color } : undefined}
 												>
 													{group.name}
 													{showLeftPanelGroupMemberCount && groupCollapsedPills.length > 0 && (

--- a/src/renderer/components/plugins/__tests__/PluginPanelSlot.test.tsx
+++ b/src/renderer/components/plugins/__tests__/PluginPanelSlot.test.tsx
@@ -12,7 +12,6 @@ const theme = THEMES.dracula;
 
 const EMPTY: AggregatedContributions = {
 	themes: [],
-	iconPacks: [],
 	prompts: [],
 	settings: [],
 	commandMacros: [],
@@ -23,7 +22,7 @@ const EMPTY: AggregatedContributions = {
 	tools: [],
 	keybindings: [],
 	uiItems: [],
-	hostViews: [],
+	groupings: [],
 	errorsByPlugin: {},
 };
 

--- a/src/renderer/components/plugins/__tests__/PluginPanelSlot.test.tsx
+++ b/src/renderer/components/plugins/__tests__/PluginPanelSlot.test.tsx
@@ -12,6 +12,7 @@ const theme = THEMES.dracula;
 
 const EMPTY: AggregatedContributions = {
 	themes: [],
+	iconPacks: [],
 	prompts: [],
 	settings: [],
 	commandMacros: [],
@@ -22,6 +23,7 @@ const EMPTY: AggregatedContributions = {
 	tools: [],
 	keybindings: [],
 	uiItems: [],
+	hostViews: [],
 	groupings: [],
 	errorsByPlugin: {},
 };

--- a/src/renderer/components/plugins/__tests__/PluginUiItemsSlot.test.tsx
+++ b/src/renderer/components/plugins/__tests__/PluginUiItemsSlot.test.tsx
@@ -9,7 +9,6 @@ import type {
 
 const EMPTY: AggregatedContributions = {
 	themes: [],
-	iconPacks: [],
 	prompts: [],
 	settings: [],
 	commandMacros: [],
@@ -20,7 +19,7 @@ const EMPTY: AggregatedContributions = {
 	tools: [],
 	keybindings: [],
 	uiItems: [],
-	hostViews: [],
+	groupings: [],
 	errorsByPlugin: {},
 };
 

--- a/src/renderer/components/plugins/__tests__/PluginUiItemsSlot.test.tsx
+++ b/src/renderer/components/plugins/__tests__/PluginUiItemsSlot.test.tsx
@@ -9,6 +9,7 @@ import type {
 
 const EMPTY: AggregatedContributions = {
 	themes: [],
+	iconPacks: [],
 	prompts: [],
 	settings: [],
 	commandMacros: [],
@@ -19,6 +20,7 @@ const EMPTY: AggregatedContributions = {
 	tools: [],
 	keybindings: [],
 	uiItems: [],
+	hostViews: [],
 	groupings: [],
 	errorsByPlugin: {},
 };

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -176,6 +176,7 @@ import type {
 	PluginListSnapshot,
 	PluginGrantsSnapshot,
 	PluginActivityMap,
+	PluginGroupingSnapshot,
 } from '../main/ipc/handlers/plugins';
 import type { InstallResult as PluginInstallResult } from '../main/plugins/plugin-manager';
 import type { AggregatedContributions as PluginContributions } from '../shared/plugins/contributions';
@@ -3809,7 +3810,9 @@ interface MaestroAPI {
 		invokeCommand: (commandId: string, args?: unknown) => Promise<{ dispatched: boolean }>;
 		invokeTool: (toolId: string, args?: unknown) => Promise<{ result: unknown }>;
 		getActivity: () => Promise<PluginActivityMap>;
+		getGroupings: () => Promise<PluginGroupingSnapshot>;
 		onChanged: (callback: () => void) => () => void;
+		onGroupingsChanged: (callback: () => void) => () => void;
 		onRunUiCommand: (
 			callback: (commandId: string, args: unknown) => boolean | Promise<boolean>
 		) => () => void;

--- a/src/renderer/hooks/usePluginContributions.ts
+++ b/src/renderer/hooks/usePluginContributions.ts
@@ -14,7 +14,6 @@ import type { AggregatedContributions } from '../../shared/plugins/contributions
 
 const EMPTY: AggregatedContributions = {
 	themes: [],
-	iconPacks: [],
 	prompts: [],
 	settings: [],
 	commandMacros: [],
@@ -25,7 +24,7 @@ const EMPTY: AggregatedContributions = {
 	tools: [],
 	keybindings: [],
 	uiItems: [],
-	hostViews: [],
+	groupings: [],
 	errorsByPlugin: {},
 };
 

--- a/src/renderer/hooks/usePluginContributions.ts
+++ b/src/renderer/hooks/usePluginContributions.ts
@@ -14,6 +14,7 @@ import type { AggregatedContributions } from '../../shared/plugins/contributions
 
 const EMPTY: AggregatedContributions = {
 	themes: [],
+	iconPacks: [],
 	prompts: [],
 	settings: [],
 	commandMacros: [],
@@ -24,6 +25,7 @@ const EMPTY: AggregatedContributions = {
 	tools: [],
 	keybindings: [],
 	uiItems: [],
+	hostViews: [],
 	groupings: [],
 	errorsByPlugin: {},
 };

--- a/src/renderer/hooks/usePluginGroupings.ts
+++ b/src/renderer/hooks/usePluginGroupings.ts
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react';
+import { usePluginContributions } from './usePluginContributions';
+import type { VirtualGrouping } from '../utils/pluginGroupings';
+
+/** Merges declarative manifest groupings with live, presentation-only snapshots. */
+export function usePluginGroupings(): VirtualGrouping[] {
+	const { groupings } = usePluginContributions();
+	const [published, setPublished] = useState<VirtualGrouping[]>([]);
+
+	useEffect(() => {
+		const plugins = window.maestro?.plugins;
+		if (!plugins) return;
+		let cancelled = false;
+		const load = async (): Promise<void> => {
+			try {
+				const snapshots = await plugins.getGroupings();
+				if (!cancelled) setPublished([...snapshots]);
+			} catch {
+				if (!cancelled) setPublished([]);
+			}
+		};
+		void load();
+		const unsubscribe = plugins.onGroupingsChanged(() => void load());
+		return () => {
+			cancelled = true;
+			unsubscribe();
+		};
+	}, []);
+
+	const snapshotsById = new Map(published.map((grouping) => [grouping.id, grouping]));
+	return groupings.map((grouping) => {
+		const publishedGrouping = snapshotsById.get(grouping.id);
+		return publishedGrouping
+			? {
+					...grouping,
+					groups: publishedGrouping.groups,
+					assignments: publishedGrouping.assignments,
+				}
+			: { ...grouping };
+	});
+}

--- a/src/renderer/utils/pluginGroupings.test.ts
+++ b/src/renderer/utils/pluginGroupings.test.ts
@@ -31,4 +31,29 @@ describe('buildVirtualGrouping', () => {
 			cwd: 'C:/work/api',
 		});
 	});
+
+	it('places sessions omitted from a computed snapshot in Other', () => {
+		const model = buildVirtualGrouping(
+			{
+				id: 'com.test/by-agent',
+				pluginId: 'com.test',
+				localId: 'by-agent',
+				groups: [{ id: 'claude', label: 'Claude' }],
+				assignments: { claude: 'claude' },
+			},
+			[
+				{ id: 'claude', name: 'Claude task' },
+				{ id: 'unassigned', name: 'Unassigned task' },
+			]
+		);
+
+		expect(model.groups).toEqual([
+			{ id: 'virtual:com.test/by-agent:claude', name: 'Claude' },
+			{ id: 'virtual:com.test/by-agent:Other', name: 'Other' },
+		]);
+		expect(model.assignments).toEqual({
+			claude: 'virtual:com.test/by-agent:claude',
+			unassigned: 'virtual:com.test/by-agent:Other',
+		});
+	});
 });

--- a/src/renderer/utils/pluginGroupings.test.ts
+++ b/src/renderer/utils/pluginGroupings.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { buildVirtualGrouping } from './pluginGroupings';
+
+describe('buildVirtualGrouping', () => {
+	it('uses first matching rule and places unmatched sessions in Other without mutating session metadata', () => {
+		const sessions = [
+			{ id: 'a', name: 'API task', toolType: 'claude', cwd: 'C:/work/api' },
+			{ id: 'b', name: 'Other', toolType: 'codex', cwd: 'C:/elsewhere' },
+		];
+		const model = buildVirtualGrouping(
+			{
+				id: 'com.test/by-type',
+				pluginId: 'com.test',
+				localId: 'by-type',
+				label: 'By type',
+				rules: [
+					{ match: { toolType: 'claude' }, group: 'Claude' },
+					{ match: { cwdGlob: 'C:/work/*', namePattern: 'API *' }, group: 'API' },
+				],
+			},
+			sessions
+		);
+		expect(model.assignments).toEqual({
+			a: 'virtual:com.test/by-type:Claude',
+			b: 'virtual:com.test/by-type:Other',
+		});
+		expect(sessions[0]).toEqual({
+			id: 'a',
+			name: 'API task',
+			toolType: 'claude',
+			cwd: 'C:/work/api',
+		});
+	});
+});

--- a/src/renderer/utils/pluginGroupings.ts
+++ b/src/renderer/utils/pluginGroupings.ts
@@ -35,15 +35,23 @@ export function buildVirtualGrouping(
 			...(group.parentId ? { parentGroupId: virtualId(grouping.id, group.parentId) } : {}),
 		}));
 		const validIds = new Set(groups.map((group) => group.id));
-		return {
-			groups,
-			assignments: Object.fromEntries(
-				Object.entries(grouping.assignments).flatMap(([sessionId, groupId]) => {
-					const id = virtualId(grouping.id, groupId);
-					return validIds.has(id) ? [[sessionId, id]] : [];
-				})
-			),
-		};
+		const otherId = virtualId(grouping.id, 'Other');
+		const assignments: Record<string, string> = {};
+		let hasUnassignedSession = false;
+		for (const session of sessions) {
+			const groupId = grouping.assignments[session.id];
+			const id = virtualId(grouping.id, groupId ?? 'Other');
+			if (validIds.has(id)) {
+				assignments[session.id] = id;
+			} else {
+				assignments[session.id] = otherId;
+				hasUnassignedSession = true;
+			}
+		}
+		if (hasUnassignedSession && !validIds.has(otherId)) {
+			groups.push({ id: otherId, name: 'Other' });
+		}
+		return { groups, assignments };
 	}
 
 	const groups = new Map<string, { id: string; name: string; parentGroupId?: string }>();

--- a/src/renderer/utils/pluginGroupings.ts
+++ b/src/renderer/utils/pluginGroupings.ts
@@ -1,0 +1,69 @@
+import {
+	groupingRuleMatches,
+	type GroupingContribution,
+	type GroupingSessionMetadata,
+} from '../../shared/plugins/contributions';
+
+export interface VirtualGrouping {
+	id: string;
+	pluginId: string;
+	pluginName?: string;
+	localId: string;
+	label?: string;
+	rules?: GroupingContribution['rules'];
+	groups?: Array<{ id: string; label: string; parentId?: string }>;
+	assignments?: Record<string, string>;
+}
+
+export interface VirtualGroupingModel {
+	groups: Array<{ id: string; name: string; parentGroupId?: string }>;
+	assignments: Record<string, string>;
+}
+
+const virtualId = (groupingId: string, groupId: string): string =>
+	`virtual:${groupingId}:${groupId}`;
+
+/** Builds an ephemeral view model only; it deliberately has no access to session/group stores. */
+export function buildVirtualGrouping(
+	grouping: VirtualGrouping,
+	sessions: readonly GroupingSessionMetadata[]
+): VirtualGroupingModel {
+	if (grouping.groups && grouping.assignments) {
+		const groups = grouping.groups.map((group) => ({
+			id: virtualId(grouping.id, group.id),
+			name: group.label,
+			...(group.parentId ? { parentGroupId: virtualId(grouping.id, group.parentId) } : {}),
+		}));
+		const validIds = new Set(groups.map((group) => group.id));
+		return {
+			groups,
+			assignments: Object.fromEntries(
+				Object.entries(grouping.assignments).flatMap(([sessionId, groupId]) => {
+					const id = virtualId(grouping.id, groupId);
+					return validIds.has(id) ? [[sessionId, id]] : [];
+				})
+			),
+		};
+	}
+
+	const groups = new Map<string, { id: string; name: string; parentGroupId?: string }>();
+	const assignments: Record<string, string> = {};
+	for (const session of sessions) {
+		const rule = grouping.rules?.find((candidate) => groupingRuleMatches(session, candidate));
+		const label = rule?.group ?? 'Other';
+		const id = virtualId(grouping.id, label);
+		if (!groups.has(id)) {
+			groups.set(id, {
+				id,
+				name: label,
+				...(rule?.parentGroup ? { parentGroupId: virtualId(grouping.id, rule.parentGroup) } : {}),
+			});
+			if (rule?.parentGroup) {
+				const parentId = virtualId(grouping.id, rule.parentGroup);
+				if (!groups.has(parentId)) groups.set(parentId, { id: parentId, name: rule.parentGroup });
+			}
+		}
+		assignments[session.id] = id;
+	}
+	return { groups: Array.from(groups.values()), assignments };
+}

--- a/src/shared/plugins/contributions.ts
+++ b/src/shared/plugins/contributions.ts
@@ -15,44 +15,6 @@
 import type { PluginManifest } from './plugin-manifest';
 import type { PluginCapability } from './permissions';
 
-/**
- * Maximum UTF-8 size of one host view's serialized BlockView data. This pure
- * contract is shared by declaration parsing and runtime host-view updates so
- * plugin input cannot bypass the sandbox RPC message limit.
- */
-export const MAX_HOST_VIEW_BLOCKS_BYTES = 1_000_000;
-
-/**
- * Size of JSON data as it crosses a UTF-8 message boundary. Returns null when
- * the value is not serializable, rather than throwing from an input validator.
- */
-export function serializedJsonByteLength(value: unknown): number | null {
-	let serialized: string | undefined;
-	try {
-		serialized = JSON.stringify(value);
-	} catch {
-		return null;
-	}
-	if (typeof serialized !== 'string') return null;
-
-	let bytes = 0;
-	for (let index = 0; index < serialized.length; index += 1) {
-		const codePoint = serialized.codePointAt(index);
-		if (codePoint === undefined) continue;
-		if (codePoint <= 0x7f) {
-			bytes += 1;
-		} else if (codePoint <= 0x7ff) {
-			bytes += 2;
-		} else if (codePoint <= 0xffff) {
-			bytes += 3;
-		} else {
-			bytes += 4;
-			index += 1;
-		}
-	}
-	return bytes;
-}
-
 /** A theme a plugin adds to the theme picker. Colors are validated loosely
  * (a string map) here; the renderer maps them onto its ThemeColors shape. */
 export interface ThemeContribution {
@@ -65,39 +27,6 @@ export interface ThemeContribution {
 	name: string;
 	mode: 'light' | 'dark';
 	colors: Record<string, string>;
-}
-
-/** A single safe SVG path within an icon pack. The host owns all SVG markup. */
-export interface IconPackIconContribution {
-	/** Namespaced id: `<pluginId>/<packId>/<localId>`. */
-	id: string;
-	localId: string;
-	label: string;
-	/** Validated SVG path `d` data only; never arbitrary SVG markup. */
-	path: string;
-	/** Optional validated four-number SVG viewBox string. */
-	viewBox?: string;
-}
-
-/** A label color within an icon pack. */
-export interface IconPackColorContribution {
-	/** Namespaced id: `<pluginId>/<packId>/<localId>`. */
-	id: string;
-	localId: string;
-	label: string;
-	/** Validated `#rrggbb` color value. */
-	value: string;
-}
-
-/** A tier-0 pack of host-rendered group icons and label colors. */
-export interface IconPackContribution {
-	/** Namespaced id: `<pluginId>/<localId>`. */
-	id: string;
-	localId: string;
-	pluginId: string;
-	label: string;
-	icons: IconPackIconContribution[];
-	colors: IconPackColorContribution[];
 }
 
 /** A reusable prompt a plugin adds to the prompt catalog. */
@@ -279,39 +208,62 @@ export interface UiItemContribution {
 	priority?: number;
 }
 
-/** The host-owned view surfaces that render only BlockView data. */
-export type HostViewSurface = 'movement' | 'cadenza';
-
-export const HOST_VIEW_SURFACES: readonly HostViewSurface[] = ['movement', 'cadenza'];
-
-/** Type guard for the two host-rendered view surfaces. */
-export function isHostViewSurface(value: unknown): value is HostViewSurface {
-	return typeof value === 'string' && (HOST_VIEW_SURFACES as readonly string[]).includes(value);
+/** A metadata-only virtual grouping supplied by a plugin. Rules use a deliberately
+ * small `*` wildcard grammar; patterns are never compiled as user RegExp. */
+export interface GroupingRule {
+	match: { toolType?: string; cwdGlob?: string; namePattern?: string };
+	group: string;
+	parentGroup?: string;
 }
 
-/** The only data accepted for a host view: the BlockView block array the host
- * renders, never a cadenza command/prompt payload or plugin UI. */
-export type HostViewBlocks = unknown[];
-
-/**
- * A host-rendered view declared by a data-only or code plugin. The host owns its
- * renderer; a code plugin may later update/remove that declared view through the
- * brokered `ui:hostView` RPC methods.
- */
-export interface HostViewContribution {
+export interface GroupingContribution {
 	id: string;
 	localId: string;
 	pluginId: string;
-	surface: HostViewSurface;
-	title: string;
+	pluginName: string;
+	label: string;
 	description?: string;
-	blocks?: HostViewBlocks;
+	rules?: GroupingRule[];
+}
+
+/** Session metadata used to evaluate a declarative virtual grouping. */
+export interface GroupingSessionMetadata {
+	id: string;
+	name?: string;
+	toolType?: string;
+	cwd?: string;
+}
+
+/** Safe, linear wildcard matching: `*` matches any characters, everything else is literal. */
+export function matchesGroupingPattern(value: string, pattern: string): boolean {
+	const parts = pattern.split('*');
+	let offset = 0;
+	if (!pattern.startsWith('*')) {
+		if (!value.startsWith(parts[0])) return false;
+		offset = parts[0].length;
+	}
+	for (let index = pattern.startsWith('*') ? 0 : 1; index < parts.length; index += 1) {
+		const part = parts[index];
+		if (!part) continue;
+		const found = value.indexOf(part, offset);
+		if (found === -1) return false;
+		offset = found + part.length;
+	}
+	return pattern.endsWith('*') || offset === value.length;
+}
+
+export function groupingRuleMatches(session: GroupingSessionMetadata, rule: GroupingRule): boolean {
+	const { toolType, cwdGlob, namePattern } = rule.match;
+	return (
+		(toolType === undefined || session.toolType === toolType) &&
+		(cwdGlob === undefined || matchesGroupingPattern(session.cwd ?? '', cwdGlob)) &&
+		(namePattern === undefined || matchesGroupingPattern(session.name ?? '', namePattern))
+	);
 }
 
 /** All contributions a single plugin declared, plus any per-item errors. */
 export interface PluginContributions {
 	themes: ThemeContribution[];
-	iconPacks: IconPackContribution[];
 	prompts: PromptContribution[];
 	settings: SettingContribution[];
 	commandMacros: CommandMacroContribution[];
@@ -322,7 +274,7 @@ export interface PluginContributions {
 	tools: AgentToolContribution[];
 	keybindings: KeybindingContribution[];
 	uiItems: UiItemContribution[];
-	hostViews: HostViewContribution[];
+	groupings: GroupingContribution[];
 	/** Human-readable reasons individual contributions were dropped. */
 	errors: string[];
 }
@@ -330,7 +282,6 @@ export interface PluginContributions {
 /** Contributions aggregated across every active plugin. */
 export interface AggregatedContributions {
 	themes: ThemeContribution[];
-	iconPacks: IconPackContribution[];
 	prompts: PromptContribution[];
 	settings: SettingContribution[];
 	commandMacros: CommandMacroContribution[];
@@ -341,7 +292,7 @@ export interface AggregatedContributions {
 	tools: AgentToolContribution[];
 	keybindings: KeybindingContribution[];
 	uiItems: UiItemContribution[];
-	hostViews: HostViewContribution[];
+	groupings: GroupingContribution[];
 	/** Per-plugin errors keyed by plugin id (only plugins with errors appear). */
 	errorsByPlugin: Record<string, string[]>;
 }
@@ -373,7 +324,6 @@ function asArray(value: unknown): unknown[] {
 export function collectContributions(manifest: PluginManifest): PluginContributions {
 	const out: PluginContributions = {
 		themes: [],
-		iconPacks: [],
 		prompts: [],
 		settings: [],
 		commandMacros: [],
@@ -384,7 +334,7 @@ export function collectContributions(manifest: PluginManifest): PluginContributi
 		tools: [],
 		keybindings: [],
 		uiItems: [],
-		hostViews: [],
+		groupings: [],
 		errors: [],
 	};
 	const contributes = manifest.contributes;
@@ -396,10 +346,6 @@ export function collectContributions(manifest: PluginManifest): PluginContributi
 	for (const raw of asArray(contributes.themes)) {
 		const t = parseTheme(pluginId, raw, out.errors);
 		if (t) out.themes.push(t);
-	}
-	for (const raw of asArray(contributes.iconPacks)) {
-		const pack = parseIconPack(pluginId, raw, out.errors);
-		if (pack) out.iconPacks.push(pack);
 	}
 	for (const raw of asArray(contributes.prompts)) {
 		const p = parsePrompt(pluginId, raw, out.errors);
@@ -416,6 +362,10 @@ export function collectContributions(manifest: PluginManifest): PluginContributi
 	for (const raw of asArray(contributes.cueTriggers)) {
 		const t = parseCueTrigger(pluginId, raw, out.errors);
 		if (t) out.cueTriggers.push(t);
+	}
+	for (const raw of asArray(contributes.groupings)) {
+		const grouping = parseGrouping(pluginId, manifest.name, raw, out.errors);
+		if (grouping) out.groupings.push(grouping);
 	}
 	if (contributes.commands !== undefined) {
 		if (!isCodeTier) {
@@ -477,12 +427,6 @@ export function collectContributions(manifest: PluginManifest): PluginContributi
 			}
 		}
 	}
-	if (contributes.hostViews !== undefined) {
-		for (const raw of asArray(contributes.hostViews)) {
-			const hostView = parseHostView(pluginId, raw, out.errors);
-			if (hostView) out.hostViews.push(hostView);
-		}
-	}
 	return out;
 }
 
@@ -500,7 +444,6 @@ export function aggregateContributions(
 ): AggregatedContributions {
 	const agg: AggregatedContributions = {
 		themes: [],
-		iconPacks: [],
 		prompts: [],
 		settings: [],
 		commandMacros: [],
@@ -511,7 +454,7 @@ export function aggregateContributions(
 		tools: [],
 		keybindings: [],
 		uiItems: [],
-		hostViews: [],
+		groupings: [],
 		errorsByPlugin: {},
 	};
 	const seen = new Set<string>();
@@ -543,7 +486,6 @@ export function aggregateContributions(
 			(agg.errorsByPlugin[manifest.id] ??= []).push(...c.errors);
 		}
 		c.themes.forEach((t) => pushUnique('themes', agg.themes, t));
-		c.iconPacks.forEach((pack) => pushUnique('iconPacks', agg.iconPacks, pack));
 		c.prompts.forEach((p) => pushUnique('prompts', agg.prompts, p));
 		c.settings.forEach((s) => pushUnique('settings', agg.settings, s));
 		c.commandMacros.forEach((m) => pushUnique('commandMacros', agg.commandMacros, m));
@@ -554,7 +496,7 @@ export function aggregateContributions(
 		c.tools.forEach((t) => pushUnique('tools', agg.tools, t));
 		c.keybindings.forEach((k) => pushUnique('keybindings', agg.keybindings, k));
 		c.uiItems.forEach((u) => pushUnique('uiItems', agg.uiItems, u));
-		c.hostViews.forEach((view) => pushUnique('hostViews', agg.hostViews, view));
+		c.groupings.forEach((grouping) => pushUnique('groupings', agg.groupings, grouping));
 	}
 	return agg;
 }
@@ -611,165 +553,6 @@ function parseTheme(pluginId: string, raw: unknown, errors: string[]): ThemeCont
 		mode: raw.mode,
 		colors,
 	};
-}
-
-const MAX_SVG_PATH_LENGTH = 4096;
-const SVG_PATH_DATA_PATTERN = /^[MmLlHhVvCcSsQqTtAaZz0-9 ,.+\-eE]+$/;
-const HEX_COLOR_PATTERN = /^#[0-9a-fA-F]{6}$/;
-const SVG_NUMBER_PATTERN = /^[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?$/;
-
-function parseSvgViewBox(
-	pluginId: string,
-	packLocalId: string,
-	iconLocalId: string,
-	value: unknown,
-	errors: string[]
-): string | undefined | null {
-	if (value === undefined) return undefined;
-	if (typeof value !== 'string') {
-		errors.push(
-			`[${pluginId}] icon pack "${packLocalId}" icon "${iconLocalId}" viewBox must be four numbers`
-		);
-		return null;
-	}
-	const parts = value.trim().split(/[ ,]+/);
-	if (
-		parts.length !== 4 ||
-		parts.some((part) => !SVG_NUMBER_PATTERN.test(part) || !Number.isFinite(Number(part)))
-	) {
-		errors.push(
-			`[${pluginId}] icon pack "${packLocalId}" icon "${iconLocalId}" viewBox must be four numbers`
-		);
-		return null;
-	}
-	return value.trim();
-}
-
-function parseIconPackIcon(
-	pluginId: string,
-	packId: string,
-	packLocalId: string,
-	raw: unknown,
-	errors: string[]
-): IconPackIconContribution | null {
-	if (!isPlainObject(raw)) {
-		errors.push(`[${pluginId}] an icon pack icon is not an object`);
-		return null;
-	}
-	const localId = parseLocalId(pluginId, raw, errors);
-	if (!localId) return null;
-	if (!isNonEmptyString(raw.label)) {
-		errors.push(`[${pluginId}] icon pack "${packLocalId}" icon "${localId}" is missing a label`);
-		return null;
-	}
-	if (
-		!isNonEmptyString(raw.path) ||
-		raw.path.length > MAX_SVG_PATH_LENGTH ||
-		!SVG_PATH_DATA_PATTERN.test(raw.path)
-	) {
-		errors.push(
-			`[${pluginId}] icon pack "${packLocalId}" icon "${localId}" path must be safe SVG path data`
-		);
-		return null;
-	}
-	const viewBox = parseSvgViewBox(pluginId, packLocalId, localId, raw.viewBox, errors);
-	if (viewBox === null) return null;
-	return {
-		id: namespaced(packId, localId),
-		localId,
-		label: raw.label.trim(),
-		path: raw.path,
-		...(viewBox !== undefined ? { viewBox } : {}),
-	};
-}
-
-function parseIconPackColor(
-	pluginId: string,
-	packId: string,
-	packLocalId: string,
-	raw: unknown,
-	errors: string[]
-): IconPackColorContribution | null {
-	if (!isPlainObject(raw)) {
-		errors.push(`[${pluginId}] an icon pack color is not an object`);
-		return null;
-	}
-	const localId = parseLocalId(pluginId, raw, errors);
-	if (!localId) return null;
-	if (!isNonEmptyString(raw.label)) {
-		errors.push(`[${pluginId}] icon pack "${packLocalId}" color "${localId}" is missing a label`);
-		return null;
-	}
-	if (!isNonEmptyString(raw.value) || !HEX_COLOR_PATTERN.test(raw.value)) {
-		errors.push(
-			`[${pluginId}] icon pack "${packLocalId}" color "${localId}" value must be #rrggbb`
-		);
-		return null;
-	}
-	return {
-		id: namespaced(packId, localId),
-		localId,
-		label: raw.label.trim(),
-		value: raw.value,
-	};
-}
-
-function parseIconPack(
-	pluginId: string,
-	raw: unknown,
-	errors: string[]
-): IconPackContribution | null {
-	if (!isPlainObject(raw)) {
-		errors.push(`[${pluginId}] an icon pack contribution is not an object`);
-		return null;
-	}
-	const localId = parseLocalId(pluginId, raw, errors);
-	if (!localId) return null;
-	if (!isNonEmptyString(raw.label)) {
-		errors.push(`[${pluginId}] icon pack "${localId}" is missing a label`);
-		return null;
-	}
-	const id = namespaced(pluginId, localId);
-	const icons: IconPackIconContribution[] = [];
-	const colors: IconPackColorContribution[] = [];
-	const iconIds = new Set<string>();
-	const colorIds = new Set<string>();
-
-	if (raw.icons !== undefined && !Array.isArray(raw.icons)) {
-		errors.push(`[${pluginId}] icon pack "${localId}" icons must be an array`);
-	} else {
-		for (const item of asArray(raw.icons)) {
-			const icon = parseIconPackIcon(pluginId, id, localId, item, errors);
-			if (!icon) continue;
-			if (iconIds.has(icon.id)) {
-				errors.push(`[${pluginId}] icon pack "${localId}" has duplicate icon id "${icon.localId}"`);
-				continue;
-			}
-			iconIds.add(icon.id);
-			icons.push(icon);
-		}
-	}
-	if (raw.colors !== undefined && !Array.isArray(raw.colors)) {
-		errors.push(`[${pluginId}] icon pack "${localId}" colors must be an array`);
-	} else {
-		for (const item of asArray(raw.colors)) {
-			const color = parseIconPackColor(pluginId, id, localId, item, errors);
-			if (!color) continue;
-			if (colorIds.has(color.id)) {
-				errors.push(
-					`[${pluginId}] icon pack "${localId}" has duplicate color id "${color.localId}"`
-				);
-				continue;
-			}
-			colorIds.add(color.id);
-			colors.push(color);
-		}
-	}
-	if (icons.length === 0 && colors.length === 0) {
-		errors.push(`[${pluginId}] icon pack "${localId}" has no valid icons or colors`);
-		return null;
-	}
-	return { id, localId, pluginId, label: raw.label.trim(), icons, colors };
 }
 
 function parsePrompt(pluginId: string, raw: unknown, errors: string[]): PromptContribution | null {
@@ -1078,54 +861,80 @@ function parseUiItem(pluginId: string, raw: unknown, errors: string[]): UiItemCo
 	};
 }
 
-export function isHostViewBlocks(value: unknown): value is HostViewBlocks {
-	return Array.isArray(value);
+const MAX_GROUPING_PATTERN_LENGTH = 256;
+const MAX_GROUPING_LABEL_LENGTH = 120;
+
+function isSafeGroupingPattern(value: unknown): value is string {
+	return (
+		typeof value === 'string' &&
+		value.length > 0 &&
+		value.length <= MAX_GROUPING_PATTERN_LENGTH &&
+		!/[\0\r\n]/.test(value)
+	);
 }
 
-function parseHostView(
+function parseGrouping(
 	pluginId: string,
+	pluginName: string,
 	raw: unknown,
 	errors: string[]
-): HostViewContribution | null {
+): GroupingContribution | null {
 	if (!isPlainObject(raw)) {
-		errors.push(`[${pluginId}] a hostView contribution is not an object`);
+		errors.push(`[${pluginId}] a grouping contribution is not an object`);
 		return null;
 	}
 	const localId = parseLocalId(pluginId, raw, errors);
 	if (!localId) return null;
-	if (!isHostViewSurface(raw.surface)) {
-		errors.push(`[${pluginId}] hostView "${localId}" has an invalid or missing surface`);
+	if (!isNonEmptyString(raw.label) || raw.label.trim().length > MAX_GROUPING_LABEL_LENGTH) {
+		errors.push(`[${pluginId}] grouping "${localId}" has an invalid label`);
 		return null;
 	}
-	if (!isNonEmptyString(raw.title)) {
-		errors.push(`[${pluginId}] hostView "${localId}" is missing a title`);
-		return null;
-	}
-	if (raw.blocks !== undefined) {
-		if (!isHostViewBlocks(raw.blocks)) {
-			errors.push(`[${pluginId}] hostView "${localId}" blocks must be BlockView data`);
+	let rules: GroupingRule[] | undefined;
+	if (raw.rules !== undefined) {
+		if (!Array.isArray(raw.rules)) {
+			errors.push(`[${pluginId}] grouping "${localId}" rules must be an array`);
 			return null;
 		}
-		const blockBytes = serializedJsonByteLength(raw.blocks);
-		if (blockBytes === null) {
-			errors.push(`[${pluginId}] hostView "${localId}" blocks must be JSON-serializable`);
-			return null;
-		}
-		if (blockBytes > MAX_HOST_VIEW_BLOCKS_BYTES) {
-			errors.push(
-				`[${pluginId}] hostView "${localId}" blocks exceed the ${MAX_HOST_VIEW_BLOCKS_BYTES}-byte size limit`
-			);
-			return null;
+		rules = [];
+		for (const rawRule of raw.rules) {
+			if (
+				!isPlainObject(rawRule) ||
+				!isPlainObject(rawRule.match) ||
+				!isNonEmptyString(rawRule.group)
+			) {
+				errors.push(`[${pluginId}] grouping "${localId}" has an invalid rule`);
+				return null;
+			}
+			const { toolType, cwdGlob, namePattern } = rawRule.match;
+			if (
+				(toolType !== undefined && !isNonEmptyString(toolType)) ||
+				(cwdGlob !== undefined && !isSafeGroupingPattern(cwdGlob)) ||
+				(namePattern !== undefined && !isSafeGroupingPattern(namePattern)) ||
+				(rawRule.parentGroup !== undefined && !isNonEmptyString(rawRule.parentGroup)) ||
+				rawRule.group.trim().length > MAX_GROUPING_LABEL_LENGTH
+			) {
+				errors.push(`[${pluginId}] grouping "${localId}" has an invalid rule pattern or label`);
+				return null;
+			}
+			rules.push({
+				match: {
+					...(toolType !== undefined ? { toolType: toolType.trim() } : {}),
+					...(cwdGlob !== undefined ? { cwdGlob } : {}),
+					...(namePattern !== undefined ? { namePattern } : {}),
+				},
+				group: rawRule.group.trim(),
+				...(rawRule.parentGroup !== undefined ? { parentGroup: rawRule.parentGroup.trim() } : {}),
+			});
 		}
 	}
 	return {
 		id: namespaced(pluginId, localId),
 		localId,
 		pluginId,
-		surface: raw.surface,
-		title: raw.title.trim(),
+		pluginName,
+		label: raw.label.trim(),
 		...(isNonEmptyString(raw.description) ? { description: raw.description.trim() } : {}),
-		...(raw.blocks !== undefined ? { blocks: raw.blocks } : {}),
+		...(rules !== undefined ? { rules } : {}),
 	};
 }
 
@@ -1133,9 +942,7 @@ function parseHostView(
  * Drop capability-gated contributions a plugin does NOT hold the grant for. The
  * render host calls this with the plugin's VERIFIED grants so customization is
  * gated per-capability, not merely by the plugin being enabled: UI items need
- * `ui:contribute` and panels need `ui:panel`. `hostViews` are data-only
- * contributions, so static views are deliberately available to tier-0 plugins;
- * `ui:hostView` gates only their tier-1 runtime update/remove methods.
+ * `ui:contribute`, panels need `ui:panel`. Other categories pass through.
  */
 export function gateContributions(
 	plugin: PluginContributions,

--- a/src/shared/plugins/contributions.ts
+++ b/src/shared/plugins/contributions.ts
@@ -15,6 +15,44 @@
 import type { PluginManifest } from './plugin-manifest';
 import type { PluginCapability } from './permissions';
 
+/**
+ * Maximum UTF-8 size of one host view's serialized BlockView data. This pure
+ * contract is shared by declaration parsing and runtime host-view updates so
+ * plugin input cannot bypass the sandbox RPC message limit.
+ */
+export const MAX_HOST_VIEW_BLOCKS_BYTES = 1_000_000;
+
+/**
+ * Size of JSON data as it crosses a UTF-8 message boundary. Returns null when
+ * the value is not serializable, rather than throwing from an input validator.
+ */
+export function serializedJsonByteLength(value: unknown): number | null {
+	let serialized: string | undefined;
+	try {
+		serialized = JSON.stringify(value);
+	} catch {
+		return null;
+	}
+	if (typeof serialized !== 'string') return null;
+
+	let bytes = 0;
+	for (let index = 0; index < serialized.length; index += 1) {
+		const codePoint = serialized.codePointAt(index);
+		if (codePoint === undefined) continue;
+		if (codePoint <= 0x7f) {
+			bytes += 1;
+		} else if (codePoint <= 0x7ff) {
+			bytes += 2;
+		} else if (codePoint <= 0xffff) {
+			bytes += 3;
+		} else {
+			bytes += 4;
+			index += 1;
+		}
+	}
+	return bytes;
+}
+
 /** A theme a plugin adds to the theme picker. Colors are validated loosely
  * (a string map) here; the renderer maps them onto its ThemeColors shape. */
 export interface ThemeContribution {
@@ -27,6 +65,39 @@ export interface ThemeContribution {
 	name: string;
 	mode: 'light' | 'dark';
 	colors: Record<string, string>;
+}
+
+/** A single safe SVG path within an icon pack. The host owns all SVG markup. */
+export interface IconPackIconContribution {
+	/** Namespaced id: `<pluginId>/<packId>/<localId>`. */
+	id: string;
+	localId: string;
+	label: string;
+	/** Validated SVG path `d` data only; never arbitrary SVG markup. */
+	path: string;
+	/** Optional validated four-number SVG viewBox string. */
+	viewBox?: string;
+}
+
+/** A label color within an icon pack. */
+export interface IconPackColorContribution {
+	/** Namespaced id: `<pluginId>/<packId>/<localId>`. */
+	id: string;
+	localId: string;
+	label: string;
+	/** Validated `#rrggbb` color value. */
+	value: string;
+}
+
+/** A tier-0 pack of host-rendered group icons and label colors. */
+export interface IconPackContribution {
+	/** Namespaced id: `<pluginId>/<localId>`. */
+	id: string;
+	localId: string;
+	pluginId: string;
+	label: string;
+	icons: IconPackIconContribution[];
+	colors: IconPackColorContribution[];
 }
 
 /** A reusable prompt a plugin adds to the prompt catalog. */
@@ -208,6 +279,34 @@ export interface UiItemContribution {
 	priority?: number;
 }
 
+/** The host-owned view surfaces that render only BlockView data. */
+export type HostViewSurface = 'movement' | 'cadenza';
+
+export const HOST_VIEW_SURFACES: readonly HostViewSurface[] = ['movement', 'cadenza'];
+
+/** Type guard for the two host-rendered view surfaces. */
+export function isHostViewSurface(value: unknown): value is HostViewSurface {
+	return typeof value === 'string' && (HOST_VIEW_SURFACES as readonly string[]).includes(value);
+}
+
+/** The only data accepted for a host view: the BlockView block array the host
+ * renders, never a cadenza command/prompt payload or plugin UI. */
+export type HostViewBlocks = unknown[];
+
+/**
+ * A host-rendered view declared by a data-only or code plugin. The host owns its
+ * renderer; a code plugin may later update/remove that declared view through the
+ * brokered `ui:hostView` RPC methods.
+ */
+export interface HostViewContribution {
+	id: string;
+	localId: string;
+	pluginId: string;
+	surface: HostViewSurface;
+	title: string;
+	description?: string;
+	blocks?: HostViewBlocks;
+}
 /** A metadata-only virtual grouping supplied by a plugin. Rules use a deliberately
  * small `*` wildcard grammar; patterns are never compiled as user RegExp. */
 export interface GroupingRule {
@@ -264,6 +363,7 @@ export function groupingRuleMatches(session: GroupingSessionMetadata, rule: Grou
 /** All contributions a single plugin declared, plus any per-item errors. */
 export interface PluginContributions {
 	themes: ThemeContribution[];
+	iconPacks: IconPackContribution[];
 	prompts: PromptContribution[];
 	settings: SettingContribution[];
 	commandMacros: CommandMacroContribution[];
@@ -274,6 +374,7 @@ export interface PluginContributions {
 	tools: AgentToolContribution[];
 	keybindings: KeybindingContribution[];
 	uiItems: UiItemContribution[];
+	hostViews: HostViewContribution[];
 	groupings: GroupingContribution[];
 	/** Human-readable reasons individual contributions were dropped. */
 	errors: string[];
@@ -282,6 +383,7 @@ export interface PluginContributions {
 /** Contributions aggregated across every active plugin. */
 export interface AggregatedContributions {
 	themes: ThemeContribution[];
+	iconPacks: IconPackContribution[];
 	prompts: PromptContribution[];
 	settings: SettingContribution[];
 	commandMacros: CommandMacroContribution[];
@@ -292,6 +394,7 @@ export interface AggregatedContributions {
 	tools: AgentToolContribution[];
 	keybindings: KeybindingContribution[];
 	uiItems: UiItemContribution[];
+	hostViews: HostViewContribution[];
 	groupings: GroupingContribution[];
 	/** Per-plugin errors keyed by plugin id (only plugins with errors appear). */
 	errorsByPlugin: Record<string, string[]>;
@@ -324,6 +427,7 @@ function asArray(value: unknown): unknown[] {
 export function collectContributions(manifest: PluginManifest): PluginContributions {
 	const out: PluginContributions = {
 		themes: [],
+		iconPacks: [],
 		prompts: [],
 		settings: [],
 		commandMacros: [],
@@ -334,6 +438,7 @@ export function collectContributions(manifest: PluginManifest): PluginContributi
 		tools: [],
 		keybindings: [],
 		uiItems: [],
+		hostViews: [],
 		groupings: [],
 		errors: [],
 	};
@@ -346,6 +451,10 @@ export function collectContributions(manifest: PluginManifest): PluginContributi
 	for (const raw of asArray(contributes.themes)) {
 		const t = parseTheme(pluginId, raw, out.errors);
 		if (t) out.themes.push(t);
+	}
+	for (const raw of asArray(contributes.iconPacks)) {
+		const pack = parseIconPack(pluginId, raw, out.errors);
+		if (pack) out.iconPacks.push(pack);
 	}
 	for (const raw of asArray(contributes.prompts)) {
 		const p = parsePrompt(pluginId, raw, out.errors);
@@ -427,6 +536,12 @@ export function collectContributions(manifest: PluginManifest): PluginContributi
 			}
 		}
 	}
+	if (contributes.hostViews !== undefined) {
+		for (const raw of asArray(contributes.hostViews)) {
+			const hostView = parseHostView(pluginId, raw, out.errors);
+			if (hostView) out.hostViews.push(hostView);
+		}
+	}
 	return out;
 }
 
@@ -444,6 +559,7 @@ export function aggregateContributions(
 ): AggregatedContributions {
 	const agg: AggregatedContributions = {
 		themes: [],
+		iconPacks: [],
 		prompts: [],
 		settings: [],
 		commandMacros: [],
@@ -454,6 +570,7 @@ export function aggregateContributions(
 		tools: [],
 		keybindings: [],
 		uiItems: [],
+		hostViews: [],
 		groupings: [],
 		errorsByPlugin: {},
 	};
@@ -486,6 +603,7 @@ export function aggregateContributions(
 			(agg.errorsByPlugin[manifest.id] ??= []).push(...c.errors);
 		}
 		c.themes.forEach((t) => pushUnique('themes', agg.themes, t));
+		c.iconPacks.forEach((pack) => pushUnique('iconPacks', agg.iconPacks, pack));
 		c.prompts.forEach((p) => pushUnique('prompts', agg.prompts, p));
 		c.settings.forEach((s) => pushUnique('settings', agg.settings, s));
 		c.commandMacros.forEach((m) => pushUnique('commandMacros', agg.commandMacros, m));
@@ -496,6 +614,7 @@ export function aggregateContributions(
 		c.tools.forEach((t) => pushUnique('tools', agg.tools, t));
 		c.keybindings.forEach((k) => pushUnique('keybindings', agg.keybindings, k));
 		c.uiItems.forEach((u) => pushUnique('uiItems', agg.uiItems, u));
+		c.hostViews.forEach((view) => pushUnique('hostViews', agg.hostViews, view));
 		c.groupings.forEach((grouping) => pushUnique('groupings', agg.groupings, grouping));
 	}
 	return agg;
@@ -553,6 +672,165 @@ function parseTheme(pluginId: string, raw: unknown, errors: string[]): ThemeCont
 		mode: raw.mode,
 		colors,
 	};
+}
+
+const MAX_SVG_PATH_LENGTH = 4096;
+const SVG_PATH_DATA_PATTERN = /^[MmLlHhVvCcSsQqTtAaZz0-9 ,.+\-eE]+$/;
+const HEX_COLOR_PATTERN = /^#[0-9a-fA-F]{6}$/;
+const SVG_NUMBER_PATTERN = /^[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?$/;
+
+function parseSvgViewBox(
+	pluginId: string,
+	packLocalId: string,
+	iconLocalId: string,
+	value: unknown,
+	errors: string[]
+): string | undefined | null {
+	if (value === undefined) return undefined;
+	if (typeof value !== 'string') {
+		errors.push(
+			`[${pluginId}] icon pack "${packLocalId}" icon "${iconLocalId}" viewBox must be four numbers`
+		);
+		return null;
+	}
+	const parts = value.trim().split(/[ ,]+/);
+	if (
+		parts.length !== 4 ||
+		parts.some((part) => !SVG_NUMBER_PATTERN.test(part) || !Number.isFinite(Number(part)))
+	) {
+		errors.push(
+			`[${pluginId}] icon pack "${packLocalId}" icon "${iconLocalId}" viewBox must be four numbers`
+		);
+		return null;
+	}
+	return value.trim();
+}
+
+function parseIconPackIcon(
+	pluginId: string,
+	packId: string,
+	packLocalId: string,
+	raw: unknown,
+	errors: string[]
+): IconPackIconContribution | null {
+	if (!isPlainObject(raw)) {
+		errors.push(`[${pluginId}] an icon pack icon is not an object`);
+		return null;
+	}
+	const localId = parseLocalId(pluginId, raw, errors);
+	if (!localId) return null;
+	if (!isNonEmptyString(raw.label)) {
+		errors.push(`[${pluginId}] icon pack "${packLocalId}" icon "${localId}" is missing a label`);
+		return null;
+	}
+	if (
+		!isNonEmptyString(raw.path) ||
+		raw.path.length > MAX_SVG_PATH_LENGTH ||
+		!SVG_PATH_DATA_PATTERN.test(raw.path)
+	) {
+		errors.push(
+			`[${pluginId}] icon pack "${packLocalId}" icon "${localId}" path must be safe SVG path data`
+		);
+		return null;
+	}
+	const viewBox = parseSvgViewBox(pluginId, packLocalId, localId, raw.viewBox, errors);
+	if (viewBox === null) return null;
+	return {
+		id: namespaced(packId, localId),
+		localId,
+		label: raw.label.trim(),
+		path: raw.path,
+		...(viewBox !== undefined ? { viewBox } : {}),
+	};
+}
+
+function parseIconPackColor(
+	pluginId: string,
+	packId: string,
+	packLocalId: string,
+	raw: unknown,
+	errors: string[]
+): IconPackColorContribution | null {
+	if (!isPlainObject(raw)) {
+		errors.push(`[${pluginId}] an icon pack color is not an object`);
+		return null;
+	}
+	const localId = parseLocalId(pluginId, raw, errors);
+	if (!localId) return null;
+	if (!isNonEmptyString(raw.label)) {
+		errors.push(`[${pluginId}] icon pack "${packLocalId}" color "${localId}" is missing a label`);
+		return null;
+	}
+	if (!isNonEmptyString(raw.value) || !HEX_COLOR_PATTERN.test(raw.value)) {
+		errors.push(
+			`[${pluginId}] icon pack "${packLocalId}" color "${localId}" value must be #rrggbb`
+		);
+		return null;
+	}
+	return {
+		id: namespaced(packId, localId),
+		localId,
+		label: raw.label.trim(),
+		value: raw.value,
+	};
+}
+
+function parseIconPack(
+	pluginId: string,
+	raw: unknown,
+	errors: string[]
+): IconPackContribution | null {
+	if (!isPlainObject(raw)) {
+		errors.push(`[${pluginId}] an icon pack contribution is not an object`);
+		return null;
+	}
+	const localId = parseLocalId(pluginId, raw, errors);
+	if (!localId) return null;
+	if (!isNonEmptyString(raw.label)) {
+		errors.push(`[${pluginId}] icon pack "${localId}" is missing a label`);
+		return null;
+	}
+	const id = namespaced(pluginId, localId);
+	const icons: IconPackIconContribution[] = [];
+	const colors: IconPackColorContribution[] = [];
+	const iconIds = new Set<string>();
+	const colorIds = new Set<string>();
+
+	if (raw.icons !== undefined && !Array.isArray(raw.icons)) {
+		errors.push(`[${pluginId}] icon pack "${localId}" icons must be an array`);
+	} else {
+		for (const item of asArray(raw.icons)) {
+			const icon = parseIconPackIcon(pluginId, id, localId, item, errors);
+			if (!icon) continue;
+			if (iconIds.has(icon.id)) {
+				errors.push(`[${pluginId}] icon pack "${localId}" has duplicate icon id "${icon.localId}"`);
+				continue;
+			}
+			iconIds.add(icon.id);
+			icons.push(icon);
+		}
+	}
+	if (raw.colors !== undefined && !Array.isArray(raw.colors)) {
+		errors.push(`[${pluginId}] icon pack "${localId}" colors must be an array`);
+	} else {
+		for (const item of asArray(raw.colors)) {
+			const color = parseIconPackColor(pluginId, id, localId, item, errors);
+			if (!color) continue;
+			if (colorIds.has(color.id)) {
+				errors.push(
+					`[${pluginId}] icon pack "${localId}" has duplicate color id "${color.localId}"`
+				);
+				continue;
+			}
+			colorIds.add(color.id);
+			colors.push(color);
+		}
+	}
+	if (icons.length === 0 && colors.length === 0) {
+		errors.push(`[${pluginId}] icon pack "${localId}" has no valid icons or colors`);
+		return null;
+	}
+	return { id, localId, pluginId, label: raw.label.trim(), icons, colors };
 }
 
 function parsePrompt(pluginId: string, raw: unknown, errors: string[]): PromptContribution | null {
@@ -861,6 +1139,57 @@ function parseUiItem(pluginId: string, raw: unknown, errors: string[]): UiItemCo
 	};
 }
 
+export function isHostViewBlocks(value: unknown): value is HostViewBlocks {
+	return Array.isArray(value);
+}
+
+function parseHostView(
+	pluginId: string,
+	raw: unknown,
+	errors: string[]
+): HostViewContribution | null {
+	if (!isPlainObject(raw)) {
+		errors.push(`[${pluginId}] a hostView contribution is not an object`);
+		return null;
+	}
+	const localId = parseLocalId(pluginId, raw, errors);
+	if (!localId) return null;
+	if (!isHostViewSurface(raw.surface)) {
+		errors.push(`[${pluginId}] hostView "${localId}" has an invalid or missing surface`);
+		return null;
+	}
+	if (!isNonEmptyString(raw.title)) {
+		errors.push(`[${pluginId}] hostView "${localId}" is missing a title`);
+		return null;
+	}
+	if (raw.blocks !== undefined) {
+		if (!isHostViewBlocks(raw.blocks)) {
+			errors.push(`[${pluginId}] hostView "${localId}" blocks must be BlockView data`);
+			return null;
+		}
+		const blockBytes = serializedJsonByteLength(raw.blocks);
+		if (blockBytes === null) {
+			errors.push(`[${pluginId}] hostView "${localId}" blocks must be JSON-serializable`);
+			return null;
+		}
+		if (blockBytes > MAX_HOST_VIEW_BLOCKS_BYTES) {
+			errors.push(
+				`[${pluginId}] hostView "${localId}" blocks exceed the ${MAX_HOST_VIEW_BLOCKS_BYTES}-byte size limit`
+			);
+			return null;
+		}
+	}
+	return {
+		id: namespaced(pluginId, localId),
+		localId,
+		pluginId,
+		surface: raw.surface,
+		title: raw.title.trim(),
+		...(isNonEmptyString(raw.description) ? { description: raw.description.trim() } : {}),
+		...(raw.blocks !== undefined ? { blocks: raw.blocks } : {}),
+	};
+}
+
 const MAX_GROUPING_PATTERN_LENGTH = 256;
 const MAX_GROUPING_LABEL_LENGTH = 120;
 
@@ -937,12 +1266,13 @@ function parseGrouping(
 		...(rules !== undefined ? { rules } : {}),
 	};
 }
-
 /**
  * Drop capability-gated contributions a plugin does NOT hold the grant for. The
  * render host calls this with the plugin's VERIFIED grants so customization is
  * gated per-capability, not merely by the plugin being enabled: UI items need
- * `ui:contribute`, panels need `ui:panel`. Other categories pass through.
+ * `ui:contribute` and panels need `ui:panel`. `hostViews` are data-only
+ * contributions, so static views are deliberately available to tier-0 plugins;
+ * `ui:hostView` gates only their tier-1 runtime update/remove methods.
  */
 export function gateContributions(
 	plugin: PluginContributions,

--- a/src/shared/plugins/host-api.ts
+++ b/src/shared/plugins/host-api.ts
@@ -20,21 +20,11 @@
 
 import semver from 'semver';
 
-/**
- * The host API version this Maestro build implements. Bumped to 1.10.0 for the
- * backward-compatible, data-only `iconPacks` contribution. (1.9.0 added
- * host-rendered `hostViews`, their `ui:hostView` capability, and the
- * `ui.hostViewUpdate` / `ui.hostViewRemove` RPC methods; 1.8.0 added
- * `background.list`; 1.7.0 added history/session/tab/transcript
- * write/decision/shell/storage SQL/fs watch/power/background capabilities plus
- * `history.entryAdded` and metadata-only `agent.completed` events; 1.6.0 added
- * `cue.runStarted` / `cue.runFinished`; 1.5.0 added `agent.exited` /
- * `agent.error` / `usage.updated` / `run.completed` + functional
- * `sidebar`/`activity-bar`/`toolbar` uiItem surfaces; 1.4.0 added the
- * `ui:contribute` / `ui:panel` / `ui:render-unsafe` UI capabilities; 1.3.0
- * added `tools` + `keybindings`; 1.2.0 added `transcripts:read`.)
- */
-export const HOST_API_VERSION = '1.10.0';
+/** The host API version this Maestro build implements. Bumped to 1.9.0 for
+ * virtual `groupings` contributions and the presentation-only `ui:grouping`
+ * publish/clear methods. 1.8.0 added `background.list` under the existing
+ * `background:service` capability. */
+export const HOST_API_VERSION = '1.9.0';
 
 /** Result of checking a plugin's declared host-API requirement. */
 export interface HostApiCompatibility {

--- a/src/shared/plugins/host-api.ts
+++ b/src/shared/plugins/host-api.ts
@@ -20,11 +20,23 @@
 
 import semver from 'semver';
 
-/** The host API version this Maestro build implements. Bumped to 1.9.0 for
- * virtual `groupings` contributions and the presentation-only `ui:grouping`
- * publish/clear methods. 1.8.0 added `background.list` under the existing
- * `background:service` capability. */
-export const HOST_API_VERSION = '1.9.0';
+/**
+ * The host API version this Maestro build implements. Bumped to 1.11.0 for virtual
+ * `groupings` contributions and the presentation-only `ui:grouping` publish/clear
+ * methods. 1.10.0 added the backward-compatible, data-only `iconPacks` contribution.
+ * 1.9.0 added
+ * host-rendered `hostViews`, their `ui:hostView` capability, and the
+ * `ui.hostViewUpdate` / `ui.hostViewRemove` RPC methods; 1.8.0 added
+ * `background.list`; 1.7.0 added history/session/tab/transcript
+ * write/decision/shell/storage SQL/fs watch/power/background capabilities plus
+ * `history.entryAdded` and metadata-only `agent.completed` events; 1.6.0 added
+ * `cue.runStarted` / `cue.runFinished`; 1.5.0 added `agent.exited` /
+ * `agent.error` / `usage.updated` / `run.completed` + functional
+ * `sidebar`/`activity-bar`/`toolbar` uiItem surfaces; 1.4.0 added the
+ * `ui:contribute` / `ui:panel` / `ui:render-unsafe` UI capabilities; 1.3.0
+ * added `tools` + `keybindings`; 1.2.0 added `transcripts:read`.)
+ */
+export const HOST_API_VERSION = '1.11.0';
 
 /** Result of checking a plugin's declared host-API requirement. */
 export interface HostApiCompatibility {

--- a/src/shared/plugins/permissions.ts
+++ b/src/shared/plugins/permissions.ts
@@ -56,7 +56,7 @@ export type PluginCapability =
 	| 'background:service' // register supervised background service work
 	| 'ui:contribute' // add host-rendered items to Maestro's UI (menus, panels, theming, …)
 	| 'ui:panel' // show its own sandboxed interactive panels
-	| 'ui:hostView' // contribute and update host-rendered BlockView data
+	| 'ui:grouping' // publish virtual session grouping snapshots (presentation only)
 	| 'ui:render-unsafe'; // render arbitrary UI with full interface access (escape hatch)
 
 export const PLUGIN_CAPABILITIES: readonly PluginCapability[] = [
@@ -88,7 +88,7 @@ export const PLUGIN_CAPABILITIES: readonly PluginCapability[] = [
 	'background:service',
 	'ui:contribute',
 	'ui:panel',
-	'ui:hostView',
+	'ui:grouping',
 	'ui:render-unsafe',
 ];
 
@@ -124,8 +124,8 @@ const CAPABILITY_RISK: Record<PluginCapability, CapabilityRisk> = {
 	'background:service': 'high',
 	'ui:contribute': 'medium',
 	'ui:panel': 'medium',
-	'ui:hostView': 'medium',
 	'ui:render-unsafe': 'high',
+	'ui:grouping': 'low',
 };
 
 /**
@@ -175,7 +175,7 @@ const CAPABILITY_SCOPE_KIND: Record<PluginCapability, ScopeKind> = {
 	'transcripts:write': 'path', // scope is a project path; the handler enforces the session's projectPath against the grant
 	'ui:contribute': 'none',
 	'ui:panel': 'none',
-	'ui:hostView': 'none',
+	'ui:grouping': 'none',
 	'ui:render-unsafe': 'none',
 };
 
@@ -522,8 +522,8 @@ export function describeCapability(capability: PluginCapability): string {
 			return "Add items to Maestro's interface (menus, sidebar, status bar, settings, themes)";
 		case 'ui:panel':
 			return 'Show its own panels inside Maestro';
-		case 'ui:hostView':
-			return 'Show and update host-rendered BlockView data in Maestro';
+		case 'ui:grouping':
+			return 'Organize session metadata into virtual sidebar groups';
 		case 'ui:render-unsafe':
 			return "Render its own custom UI with full access to Maestro's interface (advanced — only enable for authors you fully trust)";
 	}

--- a/src/shared/plugins/permissions.ts
+++ b/src/shared/plugins/permissions.ts
@@ -56,6 +56,7 @@ export type PluginCapability =
 	| 'background:service' // register supervised background service work
 	| 'ui:contribute' // add host-rendered items to Maestro's UI (menus, panels, theming, …)
 	| 'ui:panel' // show its own sandboxed interactive panels
+	| 'ui:hostView' // contribute and update host-rendered BlockView data
 	| 'ui:grouping' // publish virtual session grouping snapshots (presentation only)
 	| 'ui:render-unsafe'; // render arbitrary UI with full interface access (escape hatch)
 
@@ -88,6 +89,7 @@ export const PLUGIN_CAPABILITIES: readonly PluginCapability[] = [
 	'background:service',
 	'ui:contribute',
 	'ui:panel',
+	'ui:hostView',
 	'ui:grouping',
 	'ui:render-unsafe',
 ];
@@ -124,8 +126,9 @@ const CAPABILITY_RISK: Record<PluginCapability, CapabilityRisk> = {
 	'background:service': 'high',
 	'ui:contribute': 'medium',
 	'ui:panel': 'medium',
-	'ui:render-unsafe': 'high',
+	'ui:hostView': 'medium',
 	'ui:grouping': 'low',
+	'ui:render-unsafe': 'high',
 };
 
 /**
@@ -175,6 +178,7 @@ const CAPABILITY_SCOPE_KIND: Record<PluginCapability, ScopeKind> = {
 	'transcripts:write': 'path', // scope is a project path; the handler enforces the session's projectPath against the grant
 	'ui:contribute': 'none',
 	'ui:panel': 'none',
+	'ui:hostView': 'none',
 	'ui:grouping': 'none',
 	'ui:render-unsafe': 'none',
 };
@@ -522,6 +526,8 @@ export function describeCapability(capability: PluginCapability): string {
 			return "Add items to Maestro's interface (menus, sidebar, status bar, settings, themes)";
 		case 'ui:panel':
 			return 'Show its own panels inside Maestro';
+		case 'ui:hostView':
+			return 'Show and update host-rendered BlockView data in Maestro';
 		case 'ui:grouping':
 			return 'Organize session metadata into virtual sidebar groups';
 		case 'ui:render-unsafe':

--- a/src/shared/plugins/rpc-protocol.ts
+++ b/src/shared/plugins/rpc-protocol.ts
@@ -65,6 +65,8 @@ export const HOST_API = {
 	'background.register': { capability: 'background:service' },
 	'background.unregister': { capability: 'background:service' },
 	'background.list': { capability: 'background:service' },
+	'ui.groupingPublish': { capability: 'ui:grouping' },
+	'ui.groupingClear': { capability: 'ui:grouping' },
 } as const satisfies Record<string, { capability: PluginCapability }>;
 
 /** The fixed set of host methods a sandbox may call (derived from HOST_API). */


### PR DESCRIPTION
## What & why

Continues the direction of shrinking core to the security kernel: plugins can now define **custom agent groupings** for the sessions sidebar. A plugin adds grouping *modes* (e.g. 'By agent type', 'By company/project') that the user switches between — the user's manual folders are never touched.

**Stacked on #1193** (needs its two-level nested render machinery) — retargets to `rc` when it merges. Sibling of #1199 (iconPacks).

## Design

**Two tiers:**
- **Tier-0 declarative**: `groupings: [{ id, label, rules }]` — ordered matchers (`toolType`, `cwdGlob`, `namePattern`) with first-match-wins and an implicit *Other* bucket; depth ≤ 2 by construction; zero plugin code.
- **Tier-1 computed**: new `ui:grouping` capability (low risk — presentation-only output) gating `maestro.ui.grouping.publish({ id, groups, assignments })` / `.clear()` through the standard broker. Handler enforces closed schema, caller-declared grouping ids, depth ≤ 2 / cycle rejection, drops unknown session ids, size caps.

**Non-destructive by contract:** grouping modes render **virtual** groups (`virtual:`-namespaced) reusing the nested render path with provenance (`from <plugin name>`). Switching modes never writes `session.groupId` or persisted groups; group CRUD affordances (rename/delete/move/drag) are disabled in virtual modes — covered by tests. Manual mode remains the untouched default; mode preference persists and falls back to Manual when the contributing plugin disappears.

**Lifecycle:** main-owned grouping registry with purge on disable/uninstall/sandbox stop/flag-off and replay on renderer load. Session data reaches plugins only through the existing metadata projection — never transcript content.

**Versioning:** HOST_API MINOR bump; plugin-sdk vendored contracts in lockstep (drift guard green).

## Testing

- Feature: 7 files / 250 tests — contract validation, rule evaluation (first-match/Other/every matcher), publish handler rejection paths, capability deny, lifecycle purge + fallback-to-Manual, virtual render with no CRUD affordances, non-destructiveness across mode switches.
- Regression: SessionList + groupHierarchy (162 tests), full existing plugin suites (246 tests), SDK drift (24 tests, no type errors).
- Typecheck (3 tsc projects), eslint, prettier clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added virtual session groupings in the sidebar using rule-based matching with an **Other** fallback.
  * Added a presentation-only `ui:grouping` permission for eligible plugins to publish/clear virtual grouping snapshots (up to two-level nesting).
  * Added the **Insights** marketplace category.
* **Documentation**
  * Documented virtual grouping behavior, wildcard matching, and the plugins APIs for reading grouped snapshots.
* **Bug Fixes**
  * Improved sidebar behavior when virtual grouping is active (reduced unintended group edits).
* **Tests**
  * Added/extended tests for validation, rendering, fallback behavior, permissions, and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->