### PR TITLE
fix: eliminate group chat typing lag under load

### DIFF
--- a/src/__tests__/renderer/components/GroupChatInput.test.tsx
+++ b/src/__tests__/renderer/components/GroupChatInput.test.tsx
@@ -140,6 +140,26 @@ describe('GroupChatInput', () => {
 			expect(onDraftChange).toHaveBeenCalledWith('keep this draft', 'test-group-chat');
 		});
 
+		it('cancels a pending local draft when an external draft arrives', () => {
+			vi.useFakeTimers();
+			const onDraftChange = vi.fn();
+			const { rerender } = render(
+				<GroupChatInput {...createDefaultProps({ draftMessage: '', onDraftChange })} />
+			);
+
+			const textarea = screen.getByPlaceholderText(/Type a message/i) as HTMLTextAreaElement;
+			typeInTextarea(textarea, 'stale local draft');
+			rerender(
+				<GroupChatInput
+					{...createDefaultProps({ draftMessage: 'new external draft', onDraftChange })}
+				/>
+			);
+			vi.advanceTimersByTime(300);
+
+			expect(textarea.value).toBe('new external draft');
+			expect(onDraftChange).not.toHaveBeenCalled();
+		});
+
 		it('publishes fresh text before opening Prompt Composer', () => {
 			vi.useFakeTimers();
 			const onDraftChange = vi.fn();

--- a/src/__tests__/renderer/components/GroupChatInput.test.tsx
+++ b/src/__tests__/renderer/components/GroupChatInput.test.tsx
@@ -10,7 +10,7 @@
  * Regression test for: Group chat @mention tab completion
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { GroupChatInput } from '../../../renderer/components/GroupChatInput';
 import type { Session, Group, GroupChatParticipant } from '../../../renderer/types';
@@ -79,6 +79,68 @@ function typeInTextarea(textarea: HTMLTextAreaElement, value: string) {
 // =============================================================================
 
 describe('GroupChatInput', () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	describe('draft persistence', () => {
+		it('keeps typing local and persists only the latest draft after the debounce', () => {
+			vi.useFakeTimers();
+			const onDraftChange = vi.fn();
+			render(<GroupChatInput {...createDefaultProps({ onDraftChange })} />);
+
+			const textarea = screen.getByPlaceholderText(/Type a message/i) as HTMLTextAreaElement;
+			typeInTextarea(textarea, 'a');
+			typeInTextarea(textarea, 'ab');
+			typeInTextarea(textarea, 'abc');
+
+			expect(textarea.value).toBe('abc');
+			expect(onDraftChange).not.toHaveBeenCalled();
+
+			vi.advanceTimersByTime(300);
+
+			expect(onDraftChange).toHaveBeenCalledTimes(1);
+			expect(onDraftChange).toHaveBeenCalledWith('abc', 'test-group-chat');
+		});
+
+		it('flushes the pending draft to its original chat when switching chats', () => {
+			vi.useFakeTimers();
+			const onDraftChange = vi.fn();
+			const { rerender } = render(
+				<GroupChatInput {...createDefaultProps({ groupChatId: 'chat-a', onDraftChange })} />
+			);
+
+			const textarea = screen.getByPlaceholderText(/Type a message/i) as HTMLTextAreaElement;
+			typeInTextarea(textarea, 'draft for a');
+
+			rerender(
+				<GroupChatInput
+					{...createDefaultProps({
+						groupChatId: 'chat-b',
+						draftMessage: 'draft for b',
+						onDraftChange,
+					})}
+				/>
+			);
+
+			expect(onDraftChange).toHaveBeenCalledWith('draft for a', 'chat-a');
+			expect(textarea.value).toBe('draft for b');
+		});
+
+		it('flushes the pending draft when the input unmounts', () => {
+			vi.useFakeTimers();
+			const onDraftChange = vi.fn();
+			const { unmount } = render(<GroupChatInput {...createDefaultProps({ onDraftChange })} />);
+
+			const textarea = screen.getByPlaceholderText(/Type a message/i) as HTMLTextAreaElement;
+			typeInTextarea(textarea, 'keep this draft');
+			unmount();
+
+			expect(onDraftChange).toHaveBeenCalledOnce();
+			expect(onDraftChange).toHaveBeenCalledWith('keep this draft', 'test-group-chat');
+		});
+	});
+
 	describe('@mention autocomplete', () => {
 		it('shows mention dropdown when typing @', () => {
 			const sessions = [

--- a/src/__tests__/renderer/components/GroupChatInput.test.tsx
+++ b/src/__tests__/renderer/components/GroupChatInput.test.tsx
@@ -139,6 +139,55 @@ describe('GroupChatInput', () => {
 			expect(onDraftChange).toHaveBeenCalledOnce();
 			expect(onDraftChange).toHaveBeenCalledWith('keep this draft', 'test-group-chat');
 		});
+
+		it('publishes fresh text before opening Prompt Composer', () => {
+			vi.useFakeTimers();
+			const onDraftChange = vi.fn();
+			const onOpenPromptComposer = vi.fn();
+			render(<GroupChatInput {...createDefaultProps({ onDraftChange, onOpenPromptComposer })} />);
+
+			const textarea = screen.getByPlaceholderText(/Type a message/i) as HTMLTextAreaElement;
+			typeInTextarea(textarea, 'fresh composer text');
+			expect(onDraftChange).not.toHaveBeenCalled();
+			fireEvent.click(screen.getByTitle('Open Prompt Composer'));
+
+			expect(onDraftChange).toHaveBeenLastCalledWith('fresh composer text', 'test-group-chat');
+			expect(onDraftChange.mock.invocationCallOrder.at(-1)).toBeLessThan(
+				onOpenPromptComposer.mock.invocationCallOrder[0]
+			);
+		});
+
+		it('publishes fresh text before delegating an external file drop', () => {
+			vi.useFakeTimers();
+			const onDraftChange = vi.fn();
+			const handleDrop = vi.fn();
+			render(<GroupChatInput {...createDefaultProps({ onDraftChange, handleDrop })} />);
+
+			const textarea = screen.getByPlaceholderText(/Type a message/i) as HTMLTextAreaElement;
+			typeInTextarea(textarea, 'fresh drop text');
+			expect(onDraftChange).not.toHaveBeenCalled();
+			fireEvent.drop(textarea, { dataTransfer: { files: [] } });
+
+			expect(onDraftChange).toHaveBeenLastCalledWith('fresh drop text', 'test-group-chat');
+			expect(onDraftChange.mock.invocationCallOrder.at(-1)).toBeLessThan(
+				handleDrop.mock.invocationCallOrder[0]
+			);
+		});
+
+		it('exposes a flush ref for global shortcuts and outer drop zones', () => {
+			vi.useFakeTimers();
+			const onDraftChange = vi.fn();
+			const draftFlushRef = { current: null as (() => void) | null };
+			render(<GroupChatInput {...createDefaultProps({ onDraftChange, draftFlushRef })} />);
+
+			const textarea = screen.getByPlaceholderText(/Type a message/i) as HTMLTextAreaElement;
+			typeInTextarea(textarea, 'global path text');
+			expect(onDraftChange).not.toHaveBeenCalled();
+
+			draftFlushRef.current?.();
+
+			expect(onDraftChange).toHaveBeenCalledWith('global path text', 'test-group-chat');
+		});
 	});
 
 	describe('@mention autocomplete', () => {

--- a/src/__tests__/renderer/components/GroupChatMessages.test.tsx
+++ b/src/__tests__/renderer/components/GroupChatMessages.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { render, act } from '@testing-library/react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, act, waitFor } from '@testing-library/react';
 import { createRef } from 'react';
 
 import {
@@ -71,6 +71,10 @@ describe('GroupChatMessages auto-scroll setting', () => {
 		useSettingsStore.setState({ groupChatAutoScroll: true });
 	});
 
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
 	it('skips rendering message content when stable props are rerendered', () => {
 		const messages = makeMessages(3);
 		const onToggleMarkdownEditMode = vi.fn();
@@ -105,6 +109,26 @@ describe('GroupChatMessages auto-scroll setting', () => {
 		expect(container.querySelectorAll('[data-message-timestamp]').length).toBeLessThan(20);
 	});
 
+	it('virtualizes the typing indicator as the final scrollable row', async () => {
+		const result = render(
+			<GroupChatMessages
+				theme={mockTheme}
+				messages={makeMessages(3)}
+				participants={participants}
+				state="moderator-thinking"
+			/>
+		);
+		const indicator = await waitFor(() => {
+			const element = result.container.querySelector('[data-typing-indicator]');
+			expect(element).toBeInTheDocument();
+			return element as HTMLElement;
+		});
+
+		expect(indicator.dataset.index).toBe('3');
+		expect(indicator.style.position).toBe('absolute');
+		expect(indicator.textContent).toContain('Moderator is thinking...');
+	});
+
 	it('scrolls to messages whose timestamp is a numeric string', () => {
 		const ref = createRef<GroupChatMessagesHandle>();
 		const timestamp = 1700000000000;
@@ -126,6 +150,38 @@ describe('GroupChatMessages auto-scroll setting', () => {
 		expect(scrollTo).toHaveBeenCalled();
 	});
 
+	it('retries highlighting until an offscreen target row mounts', async () => {
+		const ref = createRef<GroupChatMessagesHandle>();
+		const timestamp = 1700000000000;
+		const result = render(
+			<GroupChatMessages
+				ref={ref}
+				theme={mockTheme}
+				messages={[{ timestamp: String(timestamp), from: 'Alice', content: 'target' }]}
+				participants={participants}
+				state="idle"
+			/>
+		);
+		const container = result.container.querySelector('[role="region"]') as HTMLElement;
+		const target = document.createElement('div');
+		const originalQuerySelector = container.querySelector.bind(container);
+		let attempts = 0;
+		container.scrollTo = vi.fn();
+		const querySpy = vi.spyOn(container, 'querySelector').mockImplementation((selector: string) => {
+			if (selector === '[data-message-index="0"]') {
+				attempts += 1;
+				return attempts < 4 ? null : target;
+			}
+			return originalQuerySelector(selector);
+		});
+
+		act(() => ref.current?.scrollToMessage(timestamp));
+
+		await waitFor(() => expect(attempts).toBe(4));
+		expect(target.style.backgroundColor).toBe('rgba(255, 255, 255, 0.1)');
+		querySpy.mockRestore();
+	});
+
 	it('scrolls to the bottom on new messages when auto-scroll is enabled', () => {
 		const { rerender, container } = renderChat(makeMessages(2));
 		const scroll = instrumentScroll(container);
@@ -141,6 +197,34 @@ describe('GroupChatMessages auto-scroll setting', () => {
 		);
 
 		expect(scroll.scrollTop).toBe(1000);
+	});
+
+	it('keeps the virtual typing indicator at the bottom when a message arrives', async () => {
+		const result = render(
+			<GroupChatMessages
+				theme={mockTheme}
+				messages={makeMessages(2)}
+				participants={participants}
+				state="moderator-thinking"
+			/>
+		);
+		const container = result.container.querySelector('[role="region"]') as HTMLElement;
+		const scroll = instrumentScroll(container);
+		scroll.scrollTop = 0;
+
+		result.rerender(
+			<GroupChatMessages
+				theme={mockTheme}
+				messages={makeMessages(3)}
+				participants={participants}
+				state="moderator-thinking"
+			/>
+		);
+
+		expect(scroll.scrollTop).toBe(1000);
+		await waitFor(() => {
+			expect(container.querySelector('[data-typing-indicator]')).toBeInTheDocument();
+		});
 	});
 
 	it('does not scroll on new messages when auto-scroll is disabled', () => {

--- a/src/__tests__/renderer/components/GroupChatMessages.test.tsx
+++ b/src/__tests__/renderer/components/GroupChatMessages.test.tsx
@@ -6,10 +6,15 @@ import { useSettingsStore } from '../../../renderer/stores/settingsStore';
 import { mockTheme } from '../../helpers/mockTheme';
 import type { GroupChatMessage, GroupChatParticipant } from '../../../shared/group-chat-types';
 
+const { markdownRenderSpy } = vi.hoisted(() => ({ markdownRenderSpy: vi.fn() }));
+
 // MarkdownRenderer pulls in react-markdown; stub it to plain text so these
 // tests stay focused on the auto-scroll behaviour rather than markdown output.
 vi.mock('../../../renderer/components/MarkdownRenderer', () => ({
-	MarkdownRenderer: ({ content }: { content: string }) => <div>{content}</div>,
+	MarkdownRenderer: ({ content }: { content: string }) => {
+		markdownRenderSpy(content);
+		return <div>{content}</div>;
+	},
 }));
 
 const participants: GroupChatParticipant[] = [
@@ -58,7 +63,42 @@ function renderChat(messages: GroupChatMessage[], chatId?: string) {
 
 describe('GroupChatMessages auto-scroll setting', () => {
 	beforeEach(() => {
+		markdownRenderSpy.mockClear();
 		useSettingsStore.setState({ groupChatAutoScroll: true });
+	});
+
+	it('skips rendering message content when stable props are rerendered', () => {
+		const messages = makeMessages(3);
+		const onToggleMarkdownEditMode = vi.fn();
+		const { rerender } = render(
+			<GroupChatMessages
+				theme={mockTheme}
+				messages={messages}
+				participants={participants}
+				state="idle"
+				onToggleMarkdownEditMode={onToggleMarkdownEditMode}
+			/>
+		);
+		const initialRenderCount = markdownRenderSpy.mock.calls.length;
+
+		rerender(
+			<GroupChatMessages
+				theme={mockTheme}
+				messages={messages}
+				participants={participants}
+				state="idle"
+				onToggleMarkdownEditMode={onToggleMarkdownEditMode}
+			/>
+		);
+
+		expect(markdownRenderSpy).toHaveBeenCalledTimes(initialRenderCount);
+	});
+
+	it('renders only a small virtual window for a large chat history', () => {
+		const messages = makeMessages(423);
+		const { container } = renderChat(messages, 'large-chat');
+
+		expect(container.querySelectorAll('[data-message-timestamp]').length).toBeLessThan(20);
 	});
 
 	it('scrolls to the bottom on new messages when auto-scroll is enabled', () => {

--- a/src/__tests__/renderer/components/GroupChatMessages.test.tsx
+++ b/src/__tests__/renderer/components/GroupChatMessages.test.tsx
@@ -1,7 +1,11 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, act } from '@testing-library/react';
+import { createRef } from 'react';
 
-import { GroupChatMessages } from '../../../renderer/components/GroupChatMessages';
+import {
+	GroupChatMessages,
+	type GroupChatMessagesHandle,
+} from '../../../renderer/components/GroupChatMessages';
 import { useSettingsStore } from '../../../renderer/stores/settingsStore';
 import { mockTheme } from '../../helpers/mockTheme';
 import type { GroupChatMessage, GroupChatParticipant } from '../../../shared/group-chat-types';
@@ -99,6 +103,27 @@ describe('GroupChatMessages auto-scroll setting', () => {
 		const { container } = renderChat(messages, 'large-chat');
 
 		expect(container.querySelectorAll('[data-message-timestamp]').length).toBeLessThan(20);
+	});
+
+	it('scrolls to messages whose timestamp is a numeric string', () => {
+		const ref = createRef<GroupChatMessagesHandle>();
+		const timestamp = 1700000000000;
+		const result = render(
+			<GroupChatMessages
+				ref={ref}
+				theme={mockTheme}
+				messages={[{ timestamp: String(timestamp), from: 'Alice', content: 'target' }]}
+				participants={participants}
+				state="idle"
+			/>
+		);
+		const container = result.container.querySelector('[role="region"]') as HTMLElement;
+		const scrollTo = vi.fn();
+		container.scrollTo = scrollTo;
+
+		act(() => ref.current?.scrollToMessage(timestamp));
+
+		expect(scrollTo).toHaveBeenCalled();
 	});
 
 	it('scrolls to the bottom on new messages when auto-scroll is enabled', () => {

--- a/src/__tests__/renderer/hooks/useMainKeyboardHandler.test.ts
+++ b/src/__tests__/renderer/hooks/useMainKeyboardHandler.test.ts
@@ -61,6 +61,7 @@ describe('useMainKeyboardHandler', () => {
 		});
 		// Reset modal store so draft/wizard confirmation tests start clean
 		useModalStore.getState().closeModal('confirm');
+		useModalStore.getState().closeModal('promptComposer');
 	});
 
 	afterEach(() => {
@@ -134,6 +135,35 @@ describe('useMainKeyboardHandler', () => {
 			});
 
 			expect(preventDefaultSpy).toHaveBeenCalled();
+		});
+	});
+
+	describe('Prompt Composer shortcut', () => {
+		it('flushes the active group chat draft before opening the composer', () => {
+			const { result } = renderHook(() => useMainKeyboardHandler());
+			const flushGroupChatDraft = vi.fn(() => {
+				expect(useModalStore.getState().isOpen('promptComposer')).toBe(false);
+			});
+
+			result.current.keyboardHandlerRef.current = createMockContext({
+				isShortcut: (_e: KeyboardEvent, actionId: string) => actionId === 'openPromptComposer',
+				activeSession: { id: 'session-1', inputMode: 'ai' },
+				activeGroupChatId: 'group-chat-1',
+				flushGroupChatDraft,
+			});
+
+			act(() => {
+				window.dispatchEvent(
+					new KeyboardEvent('keydown', {
+						key: 'p',
+						metaKey: true,
+						bubbles: true,
+					})
+				);
+			});
+
+			expect(flushGroupChatDraft).toHaveBeenCalledOnce();
+			expect(useModalStore.getState().isOpen('promptComposer')).toBe(true);
 		});
 	});
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1095,6 +1095,24 @@ function MaestroConsoleInner() {
 		handleCloseGroupChatInfo,
 	} = useGroupChatHandlers();
 
+	const handleToggleGroupChatMarkdownMode = useCallback(() => {
+		const { chatRawTextMode: currentMode, setChatRawTextMode: setCurrentMode } =
+			useSettingsStore.getState();
+		setCurrentMode(!currentMode);
+	}, []);
+
+	const handleGroupChatFlashNotification = useCallback((message: string) => {
+		setSuccessFlashNotification(message);
+		setTimeout(() => setSuccessFlashNotification(null), 2000);
+	}, []);
+
+	const handlePublishGroupChatMessageGist = useCallback((text: string, messageId?: string) => {
+		if (!text.trim()) return;
+		const filename = `group_chat_response_${Date.now()}.md`;
+		useTabStore.getState().setTabGistContent({ filename, content: text, messageId });
+		setGistPublishModalOpen(true);
+	}, []);
+
 	// --- MODAL HANDLERS (open/close, error recovery, lightbox, celebrations) ---
 	const {
 		errorSession,
@@ -3053,23 +3071,15 @@ function MaestroConsoleInner() {
 								onRemoveQueuedItem={handleRemoveGroupChatQueueItem}
 								onReorderQueuedItems={handleReorderGroupChatQueueItems}
 								markdownEditMode={chatRawTextMode}
-								onToggleMarkdownEditMode={() => setChatRawTextMode(!chatRawTextMode)}
+								onToggleMarkdownEditMode={handleToggleGroupChatMarkdownMode}
 								maxOutputLines={maxOutputLines}
 								enterToSendAI={enterToSendAI}
 								setEnterToSendAI={setEnterToSendAI}
-								showFlashNotification={(message: string) => {
-									setSuccessFlashNotification(message);
-									setTimeout(() => setSuccessFlashNotification(null), 2000);
-								}}
+								showFlashNotification={handleGroupChatFlashNotification}
 								participantColors={groupChatParticipantColors}
 								messagesRef={groupChatMessagesRef}
 								ghCliAvailable={ghCliAvailable}
-								onPublishMessageGist={(text: string, messageId?: string) => {
-									if (!text.trim()) return;
-									const filename = `group_chat_response_${Date.now()}.md`;
-									useTabStore.getState().setTabGistContent({ filename, content: text, messageId });
-									setGistPublishModalOpen(true);
-								}}
+								onPublishMessageGist={handlePublishGroupChatMessageGist}
 							/>
 						</div>
 						<GroupChatRightPanel

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -863,6 +863,7 @@ function MaestroConsoleInner() {
 	const fileTreeKeyboardNavRef = useRef(false); // Shared between useInputHandlers and useFileExplorerEffects
 	const rightPanelRef = useRef<RightPanelHandle>(null);
 	const mainPanelRef = useRef<MainPanelHandle>(null);
+	const groupChatDraftFlushRef = useRef<(() => void) | null>(null);
 
 	// Refs for accessing latest values in event handlers
 	const customAICommandsRef = useRef(customAICommands);
@@ -1763,6 +1764,23 @@ function MaestroConsoleInner() {
 		activeSessionIdRef,
 	});
 
+	const flushGroupChatDraft = useCallback(() => {
+		groupChatDraftFlushRef.current?.();
+	}, []);
+
+	const handleOpenGroupChatPromptComposer = useCallback(() => {
+		flushGroupChatDraft();
+		setPromptComposerOpen(true);
+	}, [flushGroupChatDraft, setPromptComposerOpen]);
+
+	const handleGroupChatDrop = useCallback(
+		(e: React.DragEvent) => {
+			flushGroupChatDraft();
+			handleDrop(e);
+		},
+		[flushGroupChatDraft, handleDrop]
+	);
+
 	// In-place recovery from session_not_found errors. The hook drives the
 	// inline SessionRecoveryCard surfaced by useAgentErrorListener — it grooms
 	// (or passes raw) the tab's prior conversation, sets pendingMergedContext,
@@ -2477,6 +2495,7 @@ function MaestroConsoleInner() {
 		// Group chat context
 		activeGroupChatId,
 		groupChatInputRef,
+		flushGroupChatDraft,
 		groupChatStagedImages,
 		setGroupChatRightTab,
 		// Navigation handlers from useKeyboardNavigation hook
@@ -2939,7 +2958,7 @@ function MaestroConsoleInner() {
 
 	// Chat-attach drop zone for the group chat view (parity with the main panel).
 	// Scoped to the group chat container so only that region reacts.
-	const groupChatDropZone = useChatFileDropZone(theme, handleDrop);
+	const groupChatDropZone = useChatFileDropZone(theme, handleGroupChatDrop);
 
 	const handleCloseDrawers = useCallback(() => {
 		setLeftSidebarOpen(false);
@@ -3056,14 +3075,15 @@ function MaestroConsoleInner() {
 								shortcuts={shortcuts}
 								sessions={sessions}
 								onDraftChange={handleGroupChatDraftChange}
-								onOpenPromptComposer={() => setPromptComposerOpen(true)}
+								onOpenPromptComposer={handleOpenGroupChatPromptComposer}
+								draftFlushRef={groupChatDraftFlushRef}
 								stagedImages={groupChatStagedImages}
 								setStagedImages={setGroupChatStagedImages}
 								readOnlyMode={groupChatReadOnlyMode}
 								setReadOnlyMode={setGroupChatReadOnlyMode}
 								inputRef={groupChatInputRef}
 								handlePaste={handlePaste}
-								handleDrop={handleDrop}
+								handleDrop={handleGroupChatDrop}
 								onOpenLightbox={handleSetLightboxImage}
 								executionQueue={groupChatExecutionQueue.filter(
 									(item) => item.tabId === activeGroupChatId

--- a/src/renderer/components/GroupChatInput.tsx
+++ b/src/renderer/components/GroupChatInput.tsx
@@ -34,6 +34,7 @@ import { NotificationPopover } from './NotificationPopover';
 import { useImageAnnotatorStore } from './ImageAnnotator/imageAnnotatorStore';
 import { normalizeMentionName, getMentionNameForContext } from '../utils/participantColors';
 import { logger } from '../utils/logger';
+import { useDebouncedCallback } from '../hooks/utils/useThrottle';
 
 /** Maximum image file size in bytes (10MB) */
 const MAX_IMAGE_SIZE = 10 * 1024 * 1024;
@@ -61,7 +62,7 @@ interface GroupChatInputProps {
 	groups?: Group[];
 	groupChatId: string;
 	draftMessage?: string;
-	onDraftChange?: (draft: string) => void;
+	onDraftChange?: (draft: string, groupChatId: string) => void;
 	onOpenPromptComposer?: () => void;
 	// Lifted state for sync with PromptComposer
 	stagedImages?: string[];
@@ -140,6 +141,19 @@ export const GroupChatInput = React.memo(function GroupChatInput({
 	const prevGroupChatIdRef = useRef(groupChatId);
 	const [notificationPopoverOpen, setNotificationPopoverOpen] = useState(false);
 	const notificationBtnRef = useRef<HTMLButtonElement>(null);
+	const lastPersistedDraftRef = useRef<{ groupChatId: string; draft: string } | null>(null);
+	const {
+		debouncedCallback: persistDraft,
+		flush: flushDraft,
+		cancel: cancelDraft,
+	} = useDebouncedCallback(
+		(draft: string, targetGroupChatId: string) => {
+			lastPersistedDraftRef.current = { groupChatId: targetGroupChatId, draft };
+			onDraftChange?.(draft, targetGroupChatId);
+		},
+		300,
+		{ flushOnUnmount: true }
+	);
 
 	// Build list of mentionable items: groups first, then individual agents
 	// Groups expand into all their member @mentions when selected
@@ -218,28 +232,33 @@ export const GroupChatInput = React.memo(function GroupChatInput({
 	// Sync message state when switching to a different group chat
 	useEffect(() => {
 		if (groupChatId !== prevGroupChatIdRef.current) {
+			flushDraft();
 			setMessage(draftMessage || '');
 			prevGroupChatIdRef.current = groupChatId;
 		}
-	}, [groupChatId, draftMessage]);
+	}, [groupChatId, draftMessage, flushDraft]);
 
 	// Sync message when draftMessage changes externally (e.g., from PromptComposer)
 	useEffect(() => {
-		// Only sync if the draft differs from current message (external change)
-		if (draftMessage !== undefined && draftMessage !== message) {
-			setMessage(draftMessage);
+		if (draftMessage === undefined) return;
+		const lastPersisted = lastPersistedDraftRef.current;
+		if (lastPersisted?.groupChatId === groupChatId && lastPersisted.draft === draftMessage) {
+			lastPersistedDraftRef.current = null;
+			return;
 		}
-	}, [draftMessage]);
+		setMessage((current) => (current === draftMessage ? current : draftMessage));
+	}, [draftMessage, groupChatId]);
 
 	const handleSend = useCallback(() => {
 		// Allow sending even when busy - messages will be queued in App.tsx
 		if (message.trim()) {
 			onSend(message.trim(), stagedImages.length > 0 ? stagedImages : undefined, readOnlyMode);
+			cancelDraft();
 			setMessage('');
 			setStagedImages([]);
-			onDraftChange?.('');
+			onDraftChange?.('', groupChatId);
 		}
-	}, [message, onSend, readOnlyMode, onDraftChange, stagedImages]);
+	}, [message, onSend, readOnlyMode, cancelDraft, onDraftChange, groupChatId, stagedImages]);
 
 	const handleKeyDown = useCallback(
 		(e: React.KeyboardEvent) => {
@@ -327,7 +346,7 @@ export const GroupChatInput = React.memo(function GroupChatInput({
 		(e: React.ChangeEvent<HTMLTextAreaElement>) => {
 			const value = e.target.value;
 			setMessage(value);
-			onDraftChange?.(value);
+			persistDraft(value, groupChatId);
 
 			// Check for @mention trigger
 			const lastAtIndex = value.lastIndexOf('@');
@@ -348,7 +367,7 @@ export const GroupChatInput = React.memo(function GroupChatInput({
 				setShowMentions(false);
 			}
 		},
-		[onDraftChange]
+		[persistDraft, groupChatId]
 	);
 
 	const insertMention = useCallback(
@@ -364,11 +383,11 @@ export const GroupChatInput = React.memo(function GroupChatInput({
 			}
 			const newMessage = prefix + insertion;
 			setMessage(newMessage);
-			onDraftChange?.(newMessage);
+			persistDraft(newMessage, groupChatId);
 			setShowMentions(false);
 			inputRef.current?.focus();
 		},
-		[message, onDraftChange]
+		[message, persistDraft, groupChatId]
 	);
 
 	// Wrapped paste handler that trims text and delegates images to prop handler
@@ -390,7 +409,7 @@ export const GroupChatInput = React.memo(function GroupChatInput({
 						const end = target.selectionEnd ?? 0;
 						const newValue = message.slice(0, start) + trimmedText + message.slice(end);
 						setMessage(newValue);
-						onDraftChange?.(newValue);
+						persistDraft(newValue, groupChatId);
 						// Set cursor position after the pasted text
 						requestAnimationFrame(() => {
 							target.selectionStart = target.selectionEnd = start + trimmedText.length;
@@ -403,7 +422,7 @@ export const GroupChatInput = React.memo(function GroupChatInput({
 			// Delegate image handling to prop handler
 			handlePaste?.(e);
 		},
-		[message, onDraftChange, handlePaste]
+		[message, persistDraft, groupChatId, handlePaste]
 	);
 
 	const handleImageSelect = useCallback(

--- a/src/renderer/components/GroupChatInput.tsx
+++ b/src/renderer/components/GroupChatInput.tsx
@@ -256,8 +256,9 @@ export const GroupChatInput = React.memo(function GroupChatInput({
 			lastPersistedDraftRef.current = null;
 			return;
 		}
+		cancelDraft();
 		setMessage((current) => (current === draftMessage ? current : draftMessage));
-	}, [draftMessage, groupChatId]);
+	}, [draftMessage, groupChatId, cancelDraft]);
 
 	const handleSend = useCallback(() => {
 		// Allow sending even when busy - messages will be queued in App.tsx

--- a/src/renderer/components/GroupChatInput.tsx
+++ b/src/renderer/components/GroupChatInput.tsx
@@ -64,6 +64,7 @@ interface GroupChatInputProps {
 	draftMessage?: string;
 	onDraftChange?: (draft: string, groupChatId: string) => void;
 	onOpenPromptComposer?: () => void;
+	draftFlushRef?: React.MutableRefObject<(() => void) | null>;
 	// Lifted state for sync with PromptComposer
 	stagedImages?: string[];
 	setStagedImages?: React.Dispatch<React.SetStateAction<string[]>>;
@@ -102,6 +103,7 @@ export const GroupChatInput = React.memo(function GroupChatInput({
 	draftMessage,
 	onDraftChange,
 	onOpenPromptComposer,
+	draftFlushRef,
 	stagedImages: stagedImagesProp,
 	setStagedImages: setStagedImagesProp,
 	readOnlyMode: readOnlyModeProp,
@@ -154,6 +156,14 @@ export const GroupChatInput = React.memo(function GroupChatInput({
 		300,
 		{ flushOnUnmount: true }
 	);
+
+	useEffect(() => {
+		if (!draftFlushRef) return;
+		draftFlushRef.current = flushDraft;
+		return () => {
+			if (draftFlushRef.current === flushDraft) draftFlushRef.current = null;
+		};
+	}, [draftFlushRef, flushDraft]);
 
 	// Build list of mentionable items: groups first, then individual agents
 	// Groups expand into all their member @mentions when selected
@@ -425,6 +435,20 @@ export const GroupChatInput = React.memo(function GroupChatInput({
 		[message, persistDraft, groupChatId, handlePaste]
 	);
 
+	const handleDropWrapped = useCallback(
+		(e: React.DragEvent<HTMLTextAreaElement>) => {
+			e.stopPropagation();
+			flushDraft();
+			handleDrop?.(e);
+		},
+		[flushDraft, handleDrop]
+	);
+
+	const handleOpenPromptComposer = useCallback(() => {
+		flushDraft();
+		onOpenPromptComposer?.();
+	}, [flushDraft, onOpenPromptComposer]);
+
 	const handleImageSelect = useCallback(
 		(e: React.ChangeEvent<HTMLInputElement>) => {
 			const files = Array.from(e.target.files || []);
@@ -613,10 +637,7 @@ export const GroupChatInput = React.memo(function GroupChatInput({
 							onChange={handleChange}
 							onKeyDown={handleKeyDown}
 							onPaste={handlePasteWrapped}
-							onDrop={(e) => {
-								e.stopPropagation();
-								handleDrop?.(e);
-							}}
+							onDrop={handleDropWrapped}
 							onDragOver={(e) => e.preventDefault()}
 							placeholder={
 								isBusy ? 'Type to queue message...' : 'Type a message... (@ to mention agent)'
@@ -637,7 +658,7 @@ export const GroupChatInput = React.memo(function GroupChatInput({
 						<div className="flex gap-1 items-center">
 							{onOpenPromptComposer && (
 								<button
-									onClick={onOpenPromptComposer}
+									onClick={handleOpenPromptComposer}
 									className="p-1 hover:bg-white/10 rounded opacity-50 hover:opacity-100"
 									title={`Open Prompt Composer${shortcuts?.openPromptComposer ? ` (${formatShortcutKeys(shortcuts.openPromptComposer.keys)})` : ''}`}
 								>

--- a/src/renderer/components/GroupChatMessages.tsx
+++ b/src/renderer/components/GroupChatMessages.tsx
@@ -79,8 +79,11 @@ export const GroupChatMessages = memo(
 	) {
 		const containerRef = useRef<HTMLDivElement>(null);
 		const [expandedMessages, setExpandedMessages] = useState<Set<string>>(new Set());
+		const hasVirtualTypingIndicator = state !== 'idle' && messages.length > 0;
+		const virtualItemCount = messages.length + (hasVirtualTypingIndicator ? 1 : 0);
 		const estimateMessageHeight = useCallback(
 			(index: number) => {
+				if (index === messages.length) return 72;
 				const message = messages[index];
 				if (!message) return 140;
 				const lineCount = message.content.split('\n').length;
@@ -92,10 +95,13 @@ export const GroupChatMessages = memo(
 			[messages, maxOutputLines]
 		);
 		const virtualizer = useVirtualizer({
-			count: messages.length,
+			count: virtualItemCount,
 			getScrollElement: () => containerRef.current,
 			estimateSize: estimateMessageHeight,
-			getItemKey: (index) => `${messages[index]?.timestamp ?? 'message'}-${index}`,
+			getItemKey: (index) =>
+				index === messages.length
+					? 'typing-indicator'
+					: `${messages[index]?.timestamp ?? 'message'}-${index}`,
 			overscan: 5,
 			initialRect: { width: 900, height: 700 },
 		});
@@ -121,20 +127,24 @@ export const GroupChatMessages = memo(
 					});
 					if (targetIndex < 0 || closestDiff >= 5000) return;
 					virtualizer.scrollToIndex(targetIndex, { align: 'center' });
-					requestAnimationFrame(() => {
-						requestAnimationFrame(() => {
-							const element = containerRef.current?.querySelector(
-								`[data-message-index="${targetIndex}"]`
-							) as HTMLElement | null;
-							if (!element) return;
-							element.style.transition = 'background-color 0.3s ease';
-							const originalBg = element.style.backgroundColor;
-							element.style.backgroundColor = 'rgba(255, 255, 255, 0.1)';
-							setTimeout(() => {
-								element.style.backgroundColor = originalBg;
-							}, 1000);
-						});
-					});
+					let remainingFrames = 12;
+					const highlightWhenMounted = () => {
+						const element = containerRef.current?.querySelector(
+							`[data-message-index="${targetIndex}"]`
+						) as HTMLElement | null;
+						if (!element) {
+							remainingFrames -= 1;
+							if (remainingFrames > 0) requestAnimationFrame(highlightWhenMounted);
+							return;
+						}
+						element.style.transition = 'background-color 0.3s ease';
+						const originalBg = element.style.backgroundColor;
+						element.style.backgroundColor = 'rgba(255, 255, 255, 0.1)';
+						setTimeout(() => {
+							element.style.backgroundColor = originalBg;
+						}, 1000);
+					};
+					requestAnimationFrame(highlightWhenMounted);
 				},
 			}),
 			[messages, virtualizer]
@@ -194,9 +204,9 @@ export const GroupChatMessages = memo(
 			hasAutoScrolledRef.current = true;
 			if (containerRef.current) {
 				containerRef.current.scrollTop = containerRef.current.scrollHeight;
-				virtualizer.scrollToIndex(messages.length - 1, { align: 'end' });
+				virtualizer.scrollToIndex(virtualItemCount - 1, { align: 'end' });
 			}
-		}, [messages, virtualizer]);
+		}, [messages, virtualizer, virtualItemCount]);
 
 		// Use external colors if provided, otherwise generate locally
 		// Include 'Moderator' at index 0 to match the participant panel's color assignment
@@ -232,6 +242,25 @@ export const GroupChatMessages = memo(
 				</>
 			);
 		};
+		const typingIndicatorContent = state !== 'idle' && (
+			<>
+				<div className="w-20 shrink-0" />
+				<div
+					className="flex-1 min-w-0 p-4 rounded-xl border rounded-tl-none"
+					style={{ backgroundColor: theme.colors.bgActivity, borderColor: theme.colors.border }}
+				>
+					<div className="flex items-center gap-2">
+						<div
+							className="w-2 h-2 rounded-full animate-pulse"
+							style={{ backgroundColor: theme.colors.warning }}
+						/>
+						<span className="text-sm" style={{ color: theme.colors.textDim }}>
+							{state === 'moderator-thinking' ? 'Moderator is thinking...' : 'Agent is working...'}
+						</span>
+					</div>
+				</div>
+			</>
+		);
 
 		return (
 			<div
@@ -315,6 +344,26 @@ export const GroupChatMessages = memo(
 					>
 						{virtualMessages.map((virtualMessage) => {
 							const index = virtualMessage.index;
+							if (index === messages.length) {
+								return (
+									<div
+										key="typing-indicator"
+										ref={virtualizer.measureElement}
+										data-index={index}
+										data-typing-indicator
+										className="flex gap-4 px-6 py-2"
+										style={{
+											position: 'absolute',
+											top: 0,
+											left: 0,
+											width: '100%',
+											transform: `translateY(${virtualMessage.start}px)`,
+										}}
+									>
+										{typingIndicatorContent}
+									</div>
+								);
+							}
 							const msg = messages[index];
 							const isUser = msg.from === 'user';
 							const isSystem = msg.from === 'system';
@@ -595,27 +644,9 @@ export const GroupChatMessages = memo(
 					</div>
 				)}
 
-				{/* Typing indicator */}
-				{state !== 'idle' && (
-					<div className="flex gap-4 px-6 py-2">
-						<div className="w-20 shrink-0" />
-						<div
-							className="flex-1 min-w-0 p-4 rounded-xl border rounded-tl-none"
-							style={{ backgroundColor: theme.colors.bgActivity, borderColor: theme.colors.border }}
-						>
-							<div className="flex items-center gap-2">
-								<div
-									className="w-2 h-2 rounded-full animate-pulse"
-									style={{ backgroundColor: theme.colors.warning }}
-								/>
-								<span className="text-sm" style={{ color: theme.colors.textDim }}>
-									{state === 'moderator-thinking'
-										? 'Moderator is thinking...'
-										: 'Agent is working...'}
-								</span>
-							</div>
-						</div>
-					</div>
+				{/* Empty chats do not create a virtual list, so keep their indicator inline. */}
+				{messages.length === 0 && state !== 'idle' && (
+					<div className="flex gap-4 px-6 py-2">{typingIndicatorContent}</div>
 				)}
 			</div>
 		);

--- a/src/renderer/components/GroupChatMessages.tsx
+++ b/src/renderer/components/GroupChatMessages.tsx
@@ -13,6 +13,7 @@ import {
 	useState,
 	forwardRef,
 	useImperativeHandle,
+	memo,
 } from 'react';
 import { Eye, FileText, Copy, ChevronDown, ChevronUp, Share2 } from 'lucide-react';
 import type { GroupChatMessage, GroupChatParticipant, GroupChatState, Theme } from '../types';
@@ -25,8 +26,9 @@ import { safeClipboardWrite } from '../utils/clipboard';
 import { formatTimestamp as formatTimestampShared } from '../../shared/formatters';
 import { useMessageGistStore } from '../stores/messageGistStore';
 import { useSettingsStore } from '../stores/settingsStore';
-import { jumpToMessageEdge, isTextInputTarget } from '../utils/messageScrollNavigation';
+import { isTextInputTarget } from '../utils/messageScrollNavigation';
 import { JumpToMessageTopButton } from './JumpToMessageTopButton';
+import { useVirtualizer } from '@tanstack/react-virtual';
 
 interface GroupChatMessagesProps {
 	theme: Theme;
@@ -57,8 +59,8 @@ export interface GroupChatMessagesHandle {
 	scrollToMessage: (timestamp: number) => void;
 }
 
-export const GroupChatMessages = forwardRef<GroupChatMessagesHandle, GroupChatMessagesProps>(
-	function GroupChatMessages(
+export const GroupChatMessages = memo(
+	forwardRef<GroupChatMessagesHandle, GroupChatMessagesProps>(function GroupChatMessages(
 		{
 			theme,
 			messages,
@@ -77,62 +79,62 @@ export const GroupChatMessages = forwardRef<GroupChatMessagesHandle, GroupChatMe
 	) {
 		const containerRef = useRef<HTMLDivElement>(null);
 		const [expandedMessages, setExpandedMessages] = useState<Set<string>>(new Set());
+		const estimateMessageHeight = useCallback(
+			(index: number) => {
+				const message = messages[index];
+				if (!message) return 140;
+				const lineCount = message.content.split('\n').length;
+				const visibleLines =
+					maxOutputLines === Infinity ? lineCount : Math.min(lineCount, maxOutputLines);
+				const imageHeight = message.images?.length ? 96 : 0;
+				return Math.max(112, Math.min(visibleLines, 24) * 22 + 88 + imageHeight);
+			},
+			[messages, maxOutputLines]
+		);
+		const virtualizer = useVirtualizer({
+			count: messages.length,
+			getScrollElement: () => containerRef.current,
+			estimateSize: estimateMessageHeight,
+			getItemKey: (index) => `${messages[index]?.timestamp ?? 'message'}-${index}`,
+			overscan: 5,
+			initialRect: { width: 900, height: 700 },
+		});
+		const virtualMessages = virtualizer.getVirtualItems();
 
 		// Expose scrollToMessage method via ref
 		useImperativeHandle(
 			ref,
 			() => ({
 				scrollToMessage: (timestamp: number) => {
-					if (!containerRef.current) return;
-
-					// Find the message element by timestamp
-					// Try exact match first, then find closest message
-					let targetElement = containerRef.current.querySelector(
-						`[data-message-timestamp="${timestamp}"]`
-					);
-
-					// If no exact match, find the closest message by timestamp
-					if (!targetElement) {
-						const allMessages = containerRef.current.querySelectorAll('[data-message-timestamp]');
-						let closestElement: Element | null = null;
-						let closestDiff = Infinity;
-
-						allMessages.forEach((el) => {
-							const msgTimestamp = el.getAttribute('data-message-timestamp');
-							if (msgTimestamp) {
-								// Handle both ISO string and numeric timestamp formats
-								const msgTime = isNaN(Number(msgTimestamp))
-									? new Date(msgTimestamp).getTime()
-									: Number(msgTimestamp);
-								const diff = Math.abs(msgTime - timestamp);
-								if (diff < closestDiff) {
-									closestDiff = diff;
-									closestElement = el;
-								}
-							}
-						});
-
-						// Only use closest if within 5 seconds
-						if (closestElement && closestDiff < 5000) {
-							targetElement = closestElement;
+					let targetIndex = -1;
+					let closestDiff = Infinity;
+					messages.forEach((message, index) => {
+						const messageTime = new Date(message.timestamp).getTime();
+						const diff = Math.abs(messageTime - timestamp);
+						if (diff < closestDiff) {
+							closestDiff = diff;
+							targetIndex = index;
 						}
-					}
-
-					if (targetElement) {
-						targetElement.scrollIntoView({ behavior: 'smooth', block: 'center' });
-
-						// Flash highlight effect
-						const element = targetElement as HTMLElement;
-						element.style.transition = 'background-color 0.3s ease';
-						const originalBg = element.style.backgroundColor;
-						element.style.backgroundColor = 'rgba(255, 255, 255, 0.1)';
-						setTimeout(() => {
-							element.style.backgroundColor = originalBg;
-						}, 1000);
-					}
+					});
+					if (targetIndex < 0 || closestDiff >= 5000) return;
+					virtualizer.scrollToIndex(targetIndex, { align: 'center' });
+					requestAnimationFrame(() => {
+						requestAnimationFrame(() => {
+							const element = containerRef.current?.querySelector(
+								`[data-message-index="${targetIndex}"]`
+							) as HTMLElement | null;
+							if (!element) return;
+							element.style.transition = 'background-color 0.3s ease';
+							const originalBg = element.style.backgroundColor;
+							element.style.backgroundColor = 'rgba(255, 255, 255, 0.1)';
+							setTimeout(() => {
+								element.style.backgroundColor = originalBg;
+							}, 1000);
+						});
+					});
 				},
 			}),
-			[]
+			[messages, virtualizer]
 		);
 
 		const copyToClipboard = useCallback(async (text: string) => {
@@ -189,8 +191,9 @@ export const GroupChatMessages = forwardRef<GroupChatMessagesHandle, GroupChatMe
 			hasAutoScrolledRef.current = true;
 			if (containerRef.current) {
 				containerRef.current.scrollTop = containerRef.current.scrollHeight;
+				virtualizer.scrollToIndex(messages.length - 1, { align: 'end' });
 			}
-		}, [messages]);
+		}, [messages, virtualizer]);
 
 		// Use external colors if provided, otherwise generate locally
 		// Include 'Moderator' at index 0 to match the participant panel's color assignment
@@ -249,11 +252,21 @@ export const GroupChatMessages = forwardRef<GroupChatMessagesHandle, GroupChatMe
 					// Shift+Arrow: jump message-by-message.
 					if (e.shiftKey) {
 						e.preventDefault();
-						jumpToMessageEdge(
-							container,
-							'[data-message-timestamp]',
-							e.key === 'ArrowUp' ? 'up' : 'down'
-						);
+						const visible = virtualizer.getVirtualItems();
+						const viewportStart = container.scrollTop;
+						const viewportEnd = viewportStart + container.clientHeight;
+						const firstVisible = visible.find((item) => item.end > viewportStart) ?? visible[0];
+						const lastVisible =
+							[...visible].reverse().find((item) => item.start < viewportEnd) ??
+							visible[visible.length - 1];
+						const edgeIndex =
+							e.key === 'ArrowUp'
+								? Math.max(0, (firstVisible?.index ?? 0) - 1)
+								: Math.min(messages.length - 1, (lastVisible?.index ?? 0) + 1);
+						virtualizer.scrollToIndex(edgeIndex, {
+							align: e.key === 'ArrowUp' ? 'start' : 'end',
+							behavior: 'smooth',
+						});
 						return;
 					}
 					// Plain Arrow: nudge scroll by ~100px.
@@ -290,273 +303,293 @@ export const GroupChatMessages = forwardRef<GroupChatMessagesHandle, GroupChatMe
 						</div>
 					</div>
 				) : (
-					messages.map((msg, index) => {
-						const isUser = msg.from === 'user';
-						const isSystem = msg.from === 'system';
-						const msgKey = `${msg.timestamp}-${index}`;
-						const isExpanded = expandedMessages.has(msgKey);
+					<div
+						style={{
+							height: `${virtualizer.getTotalSize()}px`,
+							position: 'relative',
+							width: '100%',
+						}}
+					>
+						{virtualMessages.map((virtualMessage) => {
+							const index = virtualMessage.index;
+							const msg = messages[index];
+							const isUser = msg.from === 'user';
+							const isSystem = msg.from === 'system';
+							const msgKey = `${msg.timestamp}-${index}`;
+							const isExpanded = expandedMessages.has(msgKey);
 
-						// Calculate if content should be collapsed
-						const lineCount = msg.content.split('\n').length;
-						const shouldCollapse =
-							!isUser && !isSystem && lineCount > maxOutputLines && maxOutputLines !== Infinity;
-						const displayContent =
-							shouldCollapse && !isExpanded
-								? msg.content.split('\n').slice(0, maxOutputLines).join('\n')
-								: msg.content;
+							// Calculate if content should be collapsed
+							const lineCount = msg.content.split('\n').length;
+							const shouldCollapse =
+								!isUser && !isSystem && lineCount > maxOutputLines && maxOutputLines !== Infinity;
+							const displayContent =
+								shouldCollapse && !isExpanded
+									? msg.content.split('\n').slice(0, maxOutputLines).join('\n')
+									: msg.content;
 
-						// Get sender color for non-user messages
-						// Use 'Moderator' (capitalized) to match the color map key
-						// System messages use error color
-						const senderColor = isSystem
-							? theme.colors.error
-							: msg.from === 'moderator'
-								? getParticipantColor('Moderator')
-								: getParticipantColor(msg.from);
+							// Get sender color for non-user messages
+							// Use 'Moderator' (capitalized) to match the color map key
+							// System messages use error color
+							const senderColor = isSystem
+								? theme.colors.error
+								: msg.from === 'moderator'
+									? getParticipantColor('Moderator')
+									: getParticipantColor(msg.from);
 
-						return (
-							<div
-								key={msgKey}
-								data-message-timestamp={msg.timestamp}
-								className={`flex gap-4 group ${isUser ? 'flex-row-reverse' : ''} px-6 py-2`}
-							>
-								{/* Timestamp - outside bubble, like AI Terminal */}
+							return (
 								<div
-									className={`w-20 shrink-0 text-[10px] pt-2 ${isUser ? 'text-right' : 'text-left'}`}
-									style={{ color: theme.colors.textDim, opacity: 0.6 }}
-								>
-									{formatTimestamp(msg.timestamp)}
-								</div>
-
-								{/* Message bubble */}
-								<div
-									className={`flex-1 min-w-0 p-4 pb-10 rounded-xl border ${isUser ? 'rounded-tr-none' : 'rounded-tl-none'} relative overflow-hidden`}
+									key={msgKey}
+									ref={virtualizer.measureElement}
+									data-index={index}
+									data-message-index={index}
+									data-message-timestamp={msg.timestamp}
+									className={`flex gap-4 group ${isUser ? 'flex-row-reverse' : ''} px-6 py-2`}
 									style={{
-										backgroundColor: isUser
-											? `color-mix(in srgb, ${theme.colors.accent} 20%, ${theme.colors.bgSidebar})`
-											: theme.colors.bgActivity,
-										borderColor: isUser ? theme.colors.accent + '40' : theme.colors.border,
-										borderLeftWidth: !isUser ? '3px' : undefined,
-										borderLeftColor: !isUser ? senderColor : undefined,
-										color: theme.colors.textMain,
+										position: 'absolute',
+										top: 0,
+										left: 0,
+										width: '100%',
+										transform: `translateY(${virtualMessage.start}px)`,
 									}}
 								>
-									{/* Sender label for non-user messages */}
-									{!isUser && (
-										<div className="text-xs font-medium mb-2" style={{ color: senderColor }}>
-											{msg.from === 'moderator'
-												? 'Moderator'
-												: msg.from === 'system'
-													? 'System'
-													: msg.from}
-										</div>
-									)}
+									{/* Timestamp - outside bubble, like AI Terminal */}
+									<div
+										className={`w-20 shrink-0 text-[10px] pt-2 ${isUser ? 'text-right' : 'text-left'}`}
+										style={{ color: theme.colors.textDim, opacity: 0.6 }}
+									>
+										{formatTimestamp(msg.timestamp)}
+									</div>
 
-									{/* Attached images */}
-									{msg.images && msg.images.length > 0 && (
-										<div
-											className="flex gap-2 mb-2 overflow-x-auto scrollbar-thin"
-											style={{ overscrollBehavior: 'contain' }}
-										>
-											{msg.images.map((img, imgIdx) => (
-												<button
-													key={`${msgKey}-img-${imgIdx}`}
-													type="button"
-													className="shrink-0 p-0 bg-transparent outline-none focus:ring-2 focus:ring-accent rounded"
-													onClick={() => onOpenLightbox?.(img, msg.images, 'history')}
+									{/* Message bubble */}
+									<div
+										className={`flex-1 min-w-0 p-4 pb-10 rounded-xl border ${isUser ? 'rounded-tr-none' : 'rounded-tl-none'} relative overflow-hidden`}
+										style={{
+											backgroundColor: isUser
+												? `color-mix(in srgb, ${theme.colors.accent} 20%, ${theme.colors.bgSidebar})`
+												: theme.colors.bgActivity,
+											borderColor: isUser ? theme.colors.accent + '40' : theme.colors.border,
+											borderLeftWidth: !isUser ? '3px' : undefined,
+											borderLeftColor: !isUser ? senderColor : undefined,
+											color: theme.colors.textMain,
+										}}
+									>
+										{/* Sender label for non-user messages */}
+										{!isUser && (
+											<div className="text-xs font-medium mb-2" style={{ color: senderColor }}>
+												{msg.from === 'moderator'
+													? 'Moderator'
+													: msg.from === 'system'
+														? 'System'
+														: msg.from}
+											</div>
+										)}
+
+										{/* Attached images */}
+										{msg.images && msg.images.length > 0 && (
+											<div
+												className="flex gap-2 mb-2 overflow-x-auto scrollbar-thin"
+												style={{ overscrollBehavior: 'contain' }}
+											>
+												{msg.images.map((img, imgIdx) => (
+													<button
+														key={`${msgKey}-img-${imgIdx}`}
+														type="button"
+														className="shrink-0 p-0 bg-transparent outline-none focus:ring-2 focus:ring-accent rounded"
+														onClick={() => onOpenLightbox?.(img, msg.images, 'history')}
+													>
+														<img
+															src={img}
+															alt={`Attached image ${imgIdx + 1}`}
+															className="h-20 rounded border cursor-zoom-in block"
+															style={{
+																objectFit: 'contain',
+																maxWidth: '200px',
+																borderColor: theme.colors.border,
+															}}
+														/>
+													</button>
+												))}
+											</div>
+										)}
+
+										{/* Message content */}
+										{shouldCollapse && !isExpanded ? (
+											// Collapsed view
+											<div>
+												<div
+													className="text-sm overflow-hidden"
+													style={{ maxHeight: `${maxOutputLines * 1.5}em` }}
 												>
-													<img
-														src={img}
-														alt={`Attached image ${imgIdx + 1}`}
-														className="h-20 rounded border cursor-zoom-in block"
-														style={{
-															objectFit: 'contain',
-															maxWidth: '200px',
-															borderColor: theme.colors.border,
-														}}
-													/>
+													{!markdownEditMode ? (
+														<MarkdownRenderer
+															content={displayContent}
+															theme={theme}
+															onCopy={copyToClipboard}
+															chatLineBreaks
+															chatMath
+														/>
+													) : (
+														<div className="whitespace-pre-wrap">
+															{isUser ? displayContent : stripMarkdown(displayContent)}
+														</div>
+													)}
+												</div>
+												<button
+													onClick={() => toggleExpanded(msgKey)}
+													className="flex items-center gap-2 mt-2 text-xs px-3 py-1.5 rounded border hover:opacity-70 transition-opacity"
+													style={{
+														borderColor: theme.colors.border,
+														backgroundColor: theme.colors.bgActivity,
+														color: theme.colors.accent,
+													}}
+												>
+													<ChevronDown className="w-3 h-3" />
+													Show all {lineCount} lines
 												</button>
-											))}
-										</div>
-									)}
-
-									{/* Message content */}
-									{shouldCollapse && !isExpanded ? (
-										// Collapsed view
-										<div>
-											<div
-												className="text-sm overflow-hidden"
-												style={{ maxHeight: `${maxOutputLines * 1.5}em` }}
-											>
-												{!markdownEditMode ? (
-													<MarkdownRenderer
-														content={displayContent}
-														theme={theme}
-														onCopy={copyToClipboard}
-														chatLineBreaks
-														chatMath
-													/>
-												) : (
-													<div className="whitespace-pre-wrap">
-														{isUser ? displayContent : stripMarkdown(displayContent)}
-													</div>
-												)}
 											</div>
-											<button
-												onClick={() => toggleExpanded(msgKey)}
-												className="flex items-center gap-2 mt-2 text-xs px-3 py-1.5 rounded border hover:opacity-70 transition-opacity"
-												style={{
-													borderColor: theme.colors.border,
-													backgroundColor: theme.colors.bgActivity,
-													color: theme.colors.accent,
-												}}
-											>
-												<ChevronDown className="w-3 h-3" />
-												Show all {lineCount} lines
-											</button>
-										</div>
-									) : shouldCollapse && isExpanded ? (
-										// Expanded view (was collapsed)
-										<div>
-											<div
-												className="text-sm overflow-auto scrollbar-thin"
-												style={{ maxHeight: '600px', overscrollBehavior: 'contain' }}
-												onWheel={(e) => {
-													const el = e.currentTarget;
-													const { scrollTop, scrollHeight, clientHeight } = el;
-													const atTop = scrollTop <= 0;
-													const atBottom = scrollTop + clientHeight >= scrollHeight - 1;
-													if ((e.deltaY < 0 && !atTop) || (e.deltaY > 0 && !atBottom)) {
-														e.stopPropagation();
-													}
-												}}
-											>
-												{!markdownEditMode ? (
-													<MarkdownRenderer
-														content={msg.content}
-														theme={theme}
-														onCopy={copyToClipboard}
-														chatLineBreaks
-														chatMath
-													/>
-												) : (
-													<div className="whitespace-pre-wrap">
-														{isUser ? msg.content : stripMarkdown(msg.content)}
-													</div>
-												)}
+										) : shouldCollapse && isExpanded ? (
+											// Expanded view (was collapsed)
+											<div>
+												<div
+													className="text-sm overflow-auto scrollbar-thin"
+													style={{ maxHeight: '600px', overscrollBehavior: 'contain' }}
+													onWheel={(e) => {
+														const el = e.currentTarget;
+														const { scrollTop, scrollHeight, clientHeight } = el;
+														const atTop = scrollTop <= 0;
+														const atBottom = scrollTop + clientHeight >= scrollHeight - 1;
+														if ((e.deltaY < 0 && !atTop) || (e.deltaY > 0 && !atBottom)) {
+															e.stopPropagation();
+														}
+													}}
+												>
+													{!markdownEditMode ? (
+														<MarkdownRenderer
+															content={msg.content}
+															theme={theme}
+															onCopy={copyToClipboard}
+															chatLineBreaks
+															chatMath
+														/>
+													) : (
+														<div className="whitespace-pre-wrap">
+															{isUser ? msg.content : stripMarkdown(msg.content)}
+														</div>
+													)}
+												</div>
+												<button
+													onClick={() => toggleExpanded(msgKey)}
+													className="flex items-center gap-2 mt-2 text-xs px-3 py-1.5 rounded border hover:opacity-70 transition-opacity"
+													style={{
+														borderColor: theme.colors.border,
+														backgroundColor: theme.colors.bgActivity,
+														color: theme.colors.accent,
+													}}
+												>
+													<ChevronUp className="w-3 h-3" />
+													Show less
+												</button>
 											</div>
-											<button
-												onClick={() => toggleExpanded(msgKey)}
-												className="flex items-center gap-2 mt-2 text-xs px-3 py-1.5 rounded border hover:opacity-70 transition-opacity"
-												style={{
-													borderColor: theme.colors.border,
-													backgroundColor: theme.colors.bgActivity,
-													color: theme.colors.accent,
-												}}
-											>
-												<ChevronUp className="w-3 h-3" />
-												Show less
-											</button>
-										</div>
-									) : !markdownEditMode ? (
-										// Normal non-collapsed markdown view (#622: user
-										// messages get the same markdown treatment as
-										// assistant messages by default — toggle exposes
-										// the raw view consistently for both)
-										<div className="text-sm">
-											<MarkdownRenderer
-												content={msg.content}
-												theme={theme}
-												onCopy={copyToClipboard}
-												chatLineBreaks
-												chatMath
-											/>
-										</div>
-									) : (
-										// Raw mode — user sees their literal input; for
-										// assistant content we strip markdown so the raw
-										// view is readable as plain text.
-										<div className="text-sm whitespace-pre-wrap">
-											{isUser ? msg.content : stripMarkdown(msg.content)}
-										</div>
-									)}
+										) : !markdownEditMode ? (
+											// Normal non-collapsed markdown view (#622: user
+											// messages get the same markdown treatment as
+											// assistant messages by default - toggle exposes
+											// the raw view consistently for both)
+											<div className="text-sm">
+												<MarkdownRenderer
+													content={msg.content}
+													theme={theme}
+													onCopy={copyToClipboard}
+													chatLineBreaks
+													chatMath
+												/>
+											</div>
+										) : (
+											// Raw mode - user sees their literal input; for
+											// assistant content we strip markdown so the raw
+											// view is readable as plain text.
+											<div className="text-sm whitespace-pre-wrap">
+												{isUser ? msg.content : stripMarkdown(msg.content)}
+											</div>
+										)}
 
-									{/* Jump to top of this message - bottom left corner */}
-									<JumpToMessageTopButton
-										scrollContainerRef={containerRef}
-										messageAncestorSelector="[data-message-timestamp]"
-										theme={theme}
-									/>
-									{/* Action buttons - bottom right corner. Available on
+										{/* Jump to top of this message - bottom left corner */}
+										<JumpToMessageTopButton
+											scrollContainerRef={containerRef}
+											messageAncestorSelector="[data-message-timestamp]"
+											theme={theme}
+										/>
+										{/* Action buttons - bottom right corner. Available on
 									    user messages too so the markdown/raw toggle and
 									    copy behavior is consistent with assistant
 									    messages (#622). */}
-									<div
-										className="absolute bottom-2 right-2 flex items-center gap-1"
-										style={{ transition: 'opacity 0.15s ease-in-out' }}
-									>
-										{/* Markdown toggle button */}
-										{onToggleMarkdownEditMode && (
-											<button
-												onClick={onToggleMarkdownEditMode}
-												className="p-1.5 rounded opacity-0 group-hover:opacity-50 hover:!opacity-100"
-												style={{
-													color: markdownEditMode ? theme.colors.accent : theme.colors.textDim,
-												}}
-												title={
-													markdownEditMode
-														? `Show formatted (${formatShortcutKeys(['Meta', 'e'])})`
-														: `Show plain text (${formatShortcutKeys(['Meta', 'e'])})`
-												}
-											>
-												{markdownEditMode ? (
-													<Eye className="w-4 h-4" />
-												) : (
-													<FileText className="w-4 h-4" />
-												)}
-											</button>
-										)}
-										{/* Copy to Clipboard Button */}
-										<button
-											onClick={() => copyToClipboard(msg.content)}
-											className="p-1.5 rounded opacity-0 group-hover:opacity-50 hover:!opacity-100"
-											style={{ color: theme.colors.textDim }}
-											title="Copy to clipboard"
+										<div
+											className="absolute bottom-2 right-2 flex items-center gap-1"
+											style={{ transition: 'opacity 0.15s ease-in-out' }}
 										>
-											<Copy className="w-3.5 h-3.5" />
-										</button>
-										{/* Publish to GitHub Gist (non-user messages only;
+											{/* Markdown toggle button */}
+											{onToggleMarkdownEditMode && (
+												<button
+													onClick={onToggleMarkdownEditMode}
+													className="p-1.5 rounded opacity-0 group-hover:opacity-50 hover:!opacity-100"
+													style={{
+														color: markdownEditMode ? theme.colors.accent : theme.colors.textDim,
+													}}
+													title={
+														markdownEditMode
+															? `Show formatted (${formatShortcutKeys(['Meta', 'e'])})`
+															: `Show plain text (${formatShortcutKeys(['Meta', 'e'])})`
+													}
+												>
+													{markdownEditMode ? (
+														<Eye className="w-4 h-4" />
+													) : (
+														<FileText className="w-4 h-4" />
+													)}
+												</button>
+											)}
+											{/* Copy to Clipboard Button */}
+											<button
+												onClick={() => copyToClipboard(msg.content)}
+												className="p-1.5 rounded opacity-0 group-hover:opacity-50 hover:!opacity-100"
+												style={{ color: theme.colors.textDim }}
+												title="Copy to clipboard"
+											>
+												<Copy className="w-3.5 h-3.5" />
+											</button>
+											{/* Publish to GitHub Gist (non-user messages only;
 										    users would publish their own input via the
 										    feedback flow instead) */}
-										{!isUser &&
-											ghCliAvailable &&
-											onPublishGist &&
-											(() => {
-												const publishedUrl = publishedGists[msgKey]?.gistUrl;
-												return (
-													<button
-														onClick={() => onPublishGist(msg.content, msgKey)}
-														className={`p-1.5 rounded hover:!opacity-100 ${
-															publishedUrl ? 'opacity-100' : 'opacity-0 group-hover:opacity-50'
-														}`}
-														style={{
-															color: publishedUrl ? theme.colors.accent : theme.colors.textDim,
-														}}
-														title={
-															publishedUrl
-																? `Published as Gist: ${publishedUrl}`
-																: 'Publish as GitHub Gist'
-														}
-													>
-														<Share2 className="w-3.5 h-3.5" />
-													</button>
-												);
-											})()}
+											{!isUser &&
+												ghCliAvailable &&
+												onPublishGist &&
+												(() => {
+													const publishedUrl = publishedGists[msgKey]?.gistUrl;
+													return (
+														<button
+															onClick={() => onPublishGist(msg.content, msgKey)}
+															className={`p-1.5 rounded hover:!opacity-100 ${
+																publishedUrl ? 'opacity-100' : 'opacity-0 group-hover:opacity-50'
+															}`}
+															style={{
+																color: publishedUrl ? theme.colors.accent : theme.colors.textDim,
+															}}
+															title={
+																publishedUrl
+																	? `Published as Gist: ${publishedUrl}`
+																	: 'Publish as GitHub Gist'
+															}
+														>
+															<Share2 className="w-3.5 h-3.5" />
+														</button>
+													);
+												})()}
+										</div>
 									</div>
 								</div>
-							</div>
-						);
-					})
+							);
+						})}
+					</div>
 				)}
 
 				{/* Typing indicator */}
@@ -583,5 +616,5 @@ export const GroupChatMessages = forwardRef<GroupChatMessagesHandle, GroupChatMe
 				)}
 			</div>
 		);
-	}
+	})
 );

--- a/src/renderer/components/GroupChatMessages.tsx
+++ b/src/renderer/components/GroupChatMessages.tsx
@@ -109,7 +109,10 @@ export const GroupChatMessages = memo(
 					let targetIndex = -1;
 					let closestDiff = Infinity;
 					messages.forEach((message, index) => {
-						const messageTime = new Date(message.timestamp).getTime();
+						const numericTimestamp = Number(message.timestamp);
+						const messageTime = Number.isNaN(numericTimestamp)
+							? new Date(message.timestamp).getTime()
+							: numericTimestamp;
 						const diff = Math.abs(messageTime - timestamp);
 						if (diff < closestDiff) {
 							closestDiff = diff;

--- a/src/renderer/components/GroupChatPanel.tsx
+++ b/src/renderer/components/GroupChatPanel.tsx
@@ -38,7 +38,7 @@ interface GroupChatPanelProps {
 	shortcuts: Record<string, Shortcut>;
 	sessions: Session[];
 	groups?: Group[];
-	onDraftChange?: (draft: string) => void;
+	onDraftChange?: (draft: string, groupChatId: string) => void;
 	onOpenPromptComposer?: () => void;
 	// Lifted state for sync with PromptComposer
 	stagedImages?: string[];

--- a/src/renderer/components/GroupChatPanel.tsx
+++ b/src/renderer/components/GroupChatPanel.tsx
@@ -40,6 +40,7 @@ interface GroupChatPanelProps {
 	groups?: Group[];
 	onDraftChange?: (draft: string, groupChatId: string) => void;
 	onOpenPromptComposer?: () => void;
+	draftFlushRef?: React.MutableRefObject<(() => void) | null>;
 	// Lifted state for sync with PromptComposer
 	stagedImages?: string[];
 	setStagedImages?: React.Dispatch<React.SetStateAction<string[]>>;
@@ -95,6 +96,7 @@ export function GroupChatPanel({
 	groups,
 	onDraftChange,
 	onOpenPromptComposer,
+	draftFlushRef,
 	stagedImages,
 	setStagedImages,
 	readOnlyMode,
@@ -161,6 +163,7 @@ export function GroupChatPanel({
 				draftMessage={groupChat.draftMessage}
 				onDraftChange={onDraftChange}
 				onOpenPromptComposer={onOpenPromptComposer}
+				draftFlushRef={draftFlushRef}
 				stagedImages={stagedImages}
 				setStagedImages={setStagedImages}
 				readOnlyMode={readOnlyMode}

--- a/src/renderer/hooks/groupChat/useGroupChatHandlers.ts
+++ b/src/renderer/hooks/groupChat/useGroupChatHandlers.ts
@@ -92,7 +92,7 @@ export interface GroupChatHandlersReturn {
 		images?: string[],
 		readOnly?: boolean
 	) => Promise<void>;
-	handleGroupChatDraftChange: (draft: string) => void;
+	handleGroupChatDraftChange: (draft: string, groupChatId?: string) => void;
 	handleRemoveGroupChatQueueItem: (itemId: string) => void;
 	handleReorderGroupChatQueueItems: (fromIndex: number, toIndex: number) => void;
 
@@ -792,11 +792,12 @@ export function useGroupChatHandlers(): GroupChatHandlersReturn {
 		}
 	}, []);
 
-	const handleGroupChatDraftChange = useCallback((draft: string) => {
+	const handleGroupChatDraftChange = useCallback((draft: string, groupChatId?: string) => {
 		const { activeGroupChatId, setGroupChats } = useGroupChatStore.getState();
-		if (!activeGroupChatId) return;
+		const targetGroupChatId = groupChatId ?? activeGroupChatId;
+		if (!targetGroupChatId) return;
 		setGroupChats((prev) =>
-			prev.map((c) => (c.id === activeGroupChatId ? { ...c, draftMessage: draft } : c))
+			prev.map((c) => (c.id === targetGroupChatId ? { ...c, draftMessage: draft } : c))
 		);
 	}, []);
 

--- a/src/renderer/hooks/keyboard/useMainKeyboardHandler.ts
+++ b/src/renderer/hooks/keyboard/useMainKeyboardHandler.ts
@@ -670,6 +670,8 @@ export function useMainKeyboardHandler(): UseMainKeyboardHandlerReturn {
 				// open, the hotkey cycles between windowed and full-screen instead of
 				// being a no-op.
 				if (ctx.activeSession?.inputMode === 'ai') {
+					const composerOpen = useModalStore.getState().modals.get('promptComposer')?.open === true;
+					if (ctx.activeGroupChatId && !composerOpen) ctx.flushGroupChatDraft?.();
 					useModalStore.getState().cyclePromptComposer();
 					trackShortcut('openPromptComposer');
 				}

--- a/src/renderer/hooks/utils/useThrottle.ts
+++ b/src/renderer/hooks/utils/useThrottle.ts
@@ -93,11 +93,13 @@ export function useThrottledCallback<T extends (...args: unknown[]) => void>(
  *
  * @param callback - The callback to debounce
  * @param delay - Delay in milliseconds before executing
- * @returns Debounced callback and flush function
+ * @param options.flushOnUnmount - Flush pending arguments instead of discarding them on unmount
+ * @returns Debounced callback, flush function, and cancel function
  */
-export function useDebouncedCallback<T extends (...args: unknown[]) => void>(
+export function useDebouncedCallback<T extends (...args: never[]) => void>(
 	callback: T,
-	delay: number
+	delay: number,
+	options: { flushOnUnmount?: boolean } = {}
 ): { debouncedCallback: T; flush: () => void; cancel: () => void } {
 	const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 	const callbackRef = useRef(callback);
@@ -143,11 +145,16 @@ export function useDebouncedCallback<T extends (...args: unknown[]) => void>(
 	// Cleanup on unmount
 	useEffect(() => {
 		return () => {
-			if (timeoutRef.current) {
+			if (timeoutRef.current && pendingArgsRef.current && options.flushOnUnmount) {
+				clearTimeout(timeoutRef.current);
+				callbackRef.current(...pendingArgsRef.current);
+				timeoutRef.current = null;
+				pendingArgsRef.current = null;
+			} else if (timeoutRef.current) {
 				clearTimeout(timeoutRef.current);
 			}
 		};
-	}, []);
+	}, [options.flushOnUnmount]);
 
 	return { debouncedCallback, flush, cancel };
 }


### PR DESCRIPTION
## Summary
- Keep the Group Chat draft local while typing and debounce global persistence.
- Memoize the message history with stable callbacks so draft updates do not rebuild it.
- Virtualize long histories while preserving auto-scroll, message jumps, and keyboard navigation.

## Measured result
Target: Group Chat bcb41d92-c7e6-4c80-a851-90899ae01422 with 423 messages.

- Input p50: 246.72 ms to 2.10 ms.
- Input p95: 381.81 ms to 2.44 ms.
- DOM nodes: about 130,340 to 1,150.
- Rendered message rows: 423 to 6.
- Typing-related long tasks over 50 ms: 73 to 0.

## Validation
- 33,657 tests passed, 108 skipped, 0 failed.
- TypeScript lint passed.
- ESLint passed.
- Prettier passed.
- Full production build passed.
- Live top, bottom, Shift+Arrow navigation, draft restoration, and no-send probe passed.

ClickUp: https://app.clickup.com/t/86ajfwjh8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Group chat drafts are now saved with debouncing and flush correctly when switching chats, sending, closing/unmounting, and when opening the Prompt Composer (including the Cmd+P shortcut).
  * Improved draft reliability when handling drop actions and external draft updates.
  * Enhanced group chat actions: quick mode toggling (markdown/raw), success flash feedback, and publishing group chat text as a gist.
* **Performance**
  * Group chat messages are fully virtualized for faster rendering, smoother scrolling/navigation, and visible scroll-to-message highlighting, including the typing indicator.
* **Tests**
  * Added/expanded coverage for draft persistence/flush behavior and virtualization-based scrolling/auto-scroll.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->