### PR TITLE
fix: address Greptile findings from merged plugin-surface PRs

### DIFF
--- a/src/__tests__/main/ipc/handlers/agents.test.ts
+++ b/src/__tests__/main/ipc/handlers/agents.test.ts
@@ -101,7 +101,7 @@ import { buildSshCommand } from '../../../../main/utils/ssh-command-builder';
 import * as fs from 'fs';
 
 describe('agents IPC handlers', () => {
-	let handlers: Map<string, Function>;
+	let handlers: Map<string, (...args: never[]) => unknown>;
 	let mockAgentDetector: {
 		detectAgents: ReturnType<typeof vi.fn>;
 		getAgent: ReturnType<typeof vi.fn>;
@@ -264,6 +264,38 @@ describe('agents IPC handlers', () => {
 					path.resolve('/Users/me/.codex-agent'),
 					path.resolve('/Users/me/.codex-session'),
 				],
+			});
+		});
+
+		it('excludes sessions with a truthy migrated SSH enabled value', async () => {
+			mockAgentConfigsStore.get.mockReturnValue({
+				'claude-code': {
+					customEnvVars: { CLAUDE_CONFIG_DIR: '/Users/me/.claude-agent' },
+				},
+			});
+			const sessionsStore = {
+				get: vi.fn().mockReturnValue([
+					{
+						toolType: 'claude-code',
+						cwd: '/Users/me/project',
+						sessionSshRemoteConfig: { enabled: 'true' },
+						customEnvVars: { CLAUDE_CONFIG_DIR: '/remote/.claude-migrated' },
+					},
+				]),
+			};
+			registerAgentsHandlers({
+				...deps,
+				sessionsStore: sessionsStore as unknown as NonNullable<
+					AgentsHandlerDependencies['sessionsStore']
+				>,
+			});
+
+			const handler = handlers.get('agents:getKnownAuthDirs');
+			const result = await handler?.({});
+
+			expect(result).toEqual({
+				claudeConfigDirs: [path.resolve('/Users/me/.claude-agent')],
+				codexHomes: [],
 			});
 		});
 	});

--- a/src/__tests__/main/ipc/handlers/agents.test.ts
+++ b/src/__tests__/main/ipc/handlers/agents.test.ts
@@ -267,10 +267,13 @@ describe('agents IPC handlers', () => {
 			});
 		});
 
-		it('excludes sessions with a truthy migrated SSH enabled value', async () => {
+		it('excludes sessions whose migrated SSH enabled value explicitly enables SSH', async () => {
 			mockAgentConfigsStore.get.mockReturnValue({
 				'claude-code': {
 					customEnvVars: { CLAUDE_CONFIG_DIR: '/Users/me/.claude-agent' },
+				},
+				codex: {
+					customEnvVars: { CODEX_HOME: '/Users/me/.codex-agent' },
 				},
 			});
 			const sessionsStore = {
@@ -280,6 +283,18 @@ describe('agents IPC handlers', () => {
 						cwd: '/Users/me/project',
 						sessionSshRemoteConfig: { enabled: 'true' },
 						customEnvVars: { CLAUDE_CONFIG_DIR: '/remote/.claude-migrated' },
+					},
+					{
+						toolType: 'claude-code',
+						cwd: '/Users/me/project',
+						sessionSshRemoteConfig: { enabled: 'TRUE' },
+						customEnvVars: { CLAUDE_CONFIG_DIR: '/remote/.claude-uppercase' },
+					},
+					{
+						toolType: 'codex',
+						cwd: '/Users/me/project',
+						sessionSshRemoteConfig: { enabled: 1 },
+						customEnvVars: { CODEX_HOME: '/remote/.codex-migrated' },
 					},
 				]),
 			};
@@ -295,6 +310,41 @@ describe('agents IPC handlers', () => {
 
 			expect(result).toEqual({
 				claudeConfigDirs: [path.resolve('/Users/me/.claude-agent')],
+				codexHomes: [path.resolve('/Users/me/.codex-agent')],
+			});
+		});
+
+		it('includes session auth paths when a migrated SSH enabled value explicitly disables SSH', async () => {
+			mockAgentConfigsStore.get.mockReturnValue({
+				'claude-code': {
+					customEnvVars: { CLAUDE_CONFIG_DIR: '/Users/me/.claude-agent' },
+				},
+			});
+			const sessionsStore = {
+				get: vi.fn().mockReturnValue([
+					{
+						toolType: 'claude-code',
+						cwd: '/Users/me/project',
+						sessionSshRemoteConfig: { enabled: 'false' },
+						customEnvVars: { CLAUDE_CONFIG_DIR: '/Users/me/.claude-migrated' },
+					},
+				]),
+			};
+			registerAgentsHandlers({
+				...deps,
+				sessionsStore: sessionsStore as unknown as NonNullable<
+					AgentsHandlerDependencies['sessionsStore']
+				>,
+			});
+
+			const handler = handlers.get('agents:getKnownAuthDirs');
+			const result = await handler?.({});
+
+			expect(result).toEqual({
+				claudeConfigDirs: [
+					path.resolve('/Users/me/.claude-agent'),
+					path.resolve('/Users/me/.claude-migrated'),
+				],
 				codexHomes: [],
 			});
 		});

--- a/src/__tests__/main/plugins/plugin-host-view-registry.test.ts
+++ b/src/__tests__/main/plugins/plugin-host-view-registry.test.ts
@@ -63,7 +63,7 @@ describe('PluginHostViewRegistry', () => {
 		const registry = new PluginHostViewRegistry({
 			isEnabled: () => enabled,
 			getHostViews: () => (enabled ? views : []),
-			isPluginRecordLoaded: () => true,
+			isPluginRecordPresent: () => true,
 			forward: forwardToMovement,
 		});
 
@@ -88,7 +88,7 @@ describe('PluginHostViewRegistry', () => {
 		const registry = new PluginHostViewRegistry({
 			isEnabled: () => true,
 			getHostViews: () => views,
-			isPluginRecordLoaded: () => true,
+			isPluginRecordPresent: () => true,
 			forward,
 		});
 
@@ -128,7 +128,7 @@ describe('PluginHostViewRegistry', () => {
 		const registry = new PluginHostViewRegistry({
 			isEnabled: () => true,
 			getHostViews: () => views,
-			isPluginRecordLoaded: () => true,
+			isPluginRecordPresent: () => true,
 			forward,
 		});
 
@@ -154,7 +154,7 @@ describe('PluginHostViewRegistry', () => {
 		const registry = new PluginHostViewRegistry({
 			isEnabled: () => true,
 			getHostViews: () => [view],
-			isPluginRecordLoaded: () => true,
+			isPluginRecordPresent: () => true,
 			forward,
 		});
 
@@ -187,7 +187,7 @@ describe('PluginHostViewRegistry', () => {
 		const registry = new PluginHostViewRegistry({
 			isEnabled: () => true,
 			getHostViews: () => views,
-			isPluginRecordLoaded: () => true,
+			isPluginRecordPresent: () => true,
 			forward,
 		});
 
@@ -220,7 +220,7 @@ describe('PluginHostViewRegistry', () => {
 		const registry = new PluginHostViewRegistry({
 			isEnabled: () => true,
 			getHostViews: () => views,
-			isPluginRecordLoaded: () => true,
+			isPluginRecordPresent: () => true,
 			forward,
 		});
 
@@ -241,18 +241,18 @@ describe('PluginHostViewRegistry', () => {
 			title: 'Runtime status',
 		};
 		let views: readonly HostViewContribution[] = [view];
-		let pluginRecordLoaded = true;
+		let pluginRecordPresent = true;
 		const forward = vi.fn(() => true);
 		const registry = new PluginHostViewRegistry({
 			isEnabled: () => true,
 			getHostViews: () => views,
-			isPluginRecordLoaded: () => pluginRecordLoaded,
+			isPluginRecordPresent: () => pluginRecordPresent,
 			forward,
 		});
 
 		registry.update('com.example.runtime', 'status', [{ kind: 'text', text: 'Live' }]);
 		views = [];
-		pluginRecordLoaded = false;
+		pluginRecordPresent = false;
 		registry.sync();
 		registry.replay();
 
@@ -260,6 +260,35 @@ describe('PluginHostViewRegistry', () => {
 			2,
 			expect.objectContaining({ kind: 'upsert', view, blocks: [{ kind: 'text', text: 'Live' }] })
 		);
+		expect(forward).toHaveBeenCalledTimes(2);
+	});
+
+	it('purges a live runtime view when the record persists in a failed load state', () => {
+		// A reload that produces an `invalid`/`incompatible` record keeps the record
+		// PRESENT while dropping its declarations — that is a permanent failure, not
+		// a transient window, so the stale runtime view must not keep replaying.
+		const view: HostViewContribution = {
+			id: 'com.example.runtime/status',
+			localId: 'status',
+			pluginId: 'com.example.runtime',
+			surface: 'movement',
+			title: 'Runtime status',
+		};
+		let views: readonly HostViewContribution[] = [view];
+		const forward = vi.fn(() => true);
+		const registry = new PluginHostViewRegistry({
+			isEnabled: () => true,
+			getHostViews: () => views,
+			isPluginRecordPresent: () => true,
+			forward,
+		});
+
+		registry.update('com.example.runtime', 'status', [{ kind: 'text', text: 'Live' }]);
+		views = [];
+		registry.sync();
+		registry.replay();
+
+		expect(forward).toHaveBeenNthCalledWith(2, expect.objectContaining({ kind: 'remove' }));
 		expect(forward).toHaveBeenCalledTimes(2);
 	});
 
@@ -284,7 +313,7 @@ describe('PluginHostViewRegistry', () => {
 		const registry = new PluginHostViewRegistry({
 			isEnabled: () => true,
 			getHostViews: () => [view],
-			isPluginRecordLoaded: () => true,
+			isPluginRecordPresent: () => true,
 			forward,
 		});
 
@@ -318,7 +347,7 @@ describe('PluginHostViewRegistry', () => {
 				},
 			],
 			forward,
-			isPluginRecordLoaded: () => true,
+			isPluginRecordPresent: () => true,
 		});
 
 		expect(registry.update('com.example.disabled', 'status', [])).toBe(false);

--- a/src/__tests__/main/plugins/plugin-host-view-registry.test.ts
+++ b/src/__tests__/main/plugins/plugin-host-view-registry.test.ts
@@ -9,6 +9,7 @@ import {
 	PluginHostViewRegistry,
 	type HostViewMutation,
 } from '../../../main/plugins/plugin-host-view-registry';
+import { forwardPluginHostViewToRenderer } from '../../../main/plugins/plugin-host-view-forwarder';
 
 function tierZeroManifest(): PluginManifest {
 	return {
@@ -167,6 +168,72 @@ describe('PluginHostViewRegistry', () => {
 			2,
 			expect.objectContaining({ kind: 'remove', view, force: true })
 		);
+	});
+
+	it('removes a live runtime view when its declaration disappears on sync', () => {
+		const view: HostViewContribution = {
+			id: 'com.example.runtime/status',
+			localId: 'status',
+			pluginId: 'com.example.runtime',
+			surface: 'cadenza',
+			title: 'Runtime status',
+		};
+		let views: readonly HostViewContribution[] = [view];
+		const forward = vi.fn(() => true);
+		const registry = new PluginHostViewRegistry({
+			isEnabled: () => true,
+			getHostViews: () => views,
+			forward,
+		});
+
+		registry.update('com.example.runtime', 'status', [{ kind: 'text', text: 'Live' }]);
+		views = [];
+		registry.sync();
+		registry.purge('com.example.runtime');
+
+		expect(forward).toHaveBeenNthCalledWith(2, expect.objectContaining({ kind: 'remove', view }));
+		expect(forward.mock.calls[1][0]).not.toHaveProperty('force');
+		expect(forward).toHaveBeenCalledTimes(2);
+	});
+
+	it('forwards a Cadenza close to both an existing HUD and the main renderer', () => {
+		const view: HostViewContribution = {
+			id: 'com.example.runtime/status',
+			localId: 'status',
+			pluginId: 'com.example.runtime',
+			surface: 'cadenza',
+			title: 'Runtime status',
+		};
+		const sendToMain = vi.fn();
+		const deliverCadenzaToExistingHud = vi.fn(() => false);
+		const forward = (mutation: HostViewMutation) =>
+			forwardPluginHostViewToRenderer(mutation, {
+				sourcePlugin: view.pluginId,
+				isCadenzaEnabled: true,
+				sendToMain,
+				deliverCadenza: vi.fn(() => false),
+				deliverCadenzaToExistingHud,
+			});
+		const registry = new PluginHostViewRegistry({
+			isEnabled: () => true,
+			getHostViews: () => [view],
+			forward,
+		});
+
+		registry.update('com.example.runtime', 'status', [{ kind: 'text', text: 'Live' }]);
+		deliverCadenzaToExistingHud.mockReturnValue(true);
+		registry.purge('com.example.runtime');
+
+		expect(deliverCadenzaToExistingHud).toHaveBeenCalledWith({ op: 'close', id: view.id });
+		expect(sendToMain).toHaveBeenNthCalledWith(
+			1,
+			'remote:cadenza',
+			expect.objectContaining({ op: 'open', id: view.id })
+		);
+		expect(sendToMain).toHaveBeenNthCalledWith(2, 'remote:cadenza', {
+			op: 'close',
+			id: view.id,
+		});
 	});
 
 	it('does not forward or retain runtime updates while either feature gate is off', () => {

--- a/src/__tests__/main/plugins/plugin-host-view-registry.test.ts
+++ b/src/__tests__/main/plugins/plugin-host-view-registry.test.ts
@@ -63,6 +63,7 @@ describe('PluginHostViewRegistry', () => {
 		const registry = new PluginHostViewRegistry({
 			isEnabled: () => enabled,
 			getHostViews: () => (enabled ? views : []),
+			isPluginRecordLoaded: () => true,
 			forward: forwardToMovement,
 		});
 
@@ -87,6 +88,7 @@ describe('PluginHostViewRegistry', () => {
 		const registry = new PluginHostViewRegistry({
 			isEnabled: () => true,
 			getHostViews: () => views,
+			isPluginRecordLoaded: () => true,
 			forward,
 		});
 
@@ -126,6 +128,7 @@ describe('PluginHostViewRegistry', () => {
 		const registry = new PluginHostViewRegistry({
 			isEnabled: () => true,
 			getHostViews: () => views,
+			isPluginRecordLoaded: () => true,
 			forward,
 		});
 
@@ -151,6 +154,7 @@ describe('PluginHostViewRegistry', () => {
 		const registry = new PluginHostViewRegistry({
 			isEnabled: () => true,
 			getHostViews: () => [view],
+			isPluginRecordLoaded: () => true,
 			forward,
 		});
 
@@ -170,7 +174,7 @@ describe('PluginHostViewRegistry', () => {
 		);
 	});
 
-	it('removes a live runtime view when its declaration disappears on sync', () => {
+	it('removes a live runtime view when a loaded plugin replaces its declaration on sync', () => {
 		const view: HostViewContribution = {
 			id: 'com.example.runtime/status',
 			localId: 'status',
@@ -183,16 +187,79 @@ describe('PluginHostViewRegistry', () => {
 		const registry = new PluginHostViewRegistry({
 			isEnabled: () => true,
 			getHostViews: () => views,
+			isPluginRecordLoaded: () => true,
+			forward,
+		});
+
+		registry.update('com.example.runtime', 'status', [{ kind: 'text', text: 'Live' }]);
+		views = [
+			{
+				...view,
+				id: 'com.example.runtime/replacement',
+				localId: 'replacement',
+			},
+		];
+		registry.sync();
+		registry.purge('com.example.runtime');
+
+		expect(forward).toHaveBeenNthCalledWith(2, expect.objectContaining({ kind: 'remove', view }));
+		expect(forward.mock.calls[1][0]).not.toHaveProperty('force');
+		expect(forward).toHaveBeenCalledTimes(2);
+	});
+
+	it('removes a live runtime view when its loaded plugin has zero declarations', () => {
+		const view: HostViewContribution = {
+			id: 'com.example.runtime/status',
+			localId: 'status',
+			pluginId: 'com.example.runtime',
+			surface: 'cadenza',
+			title: 'Runtime status',
+		};
+		let views: readonly HostViewContribution[] = [view];
+		const forward = vi.fn(() => true);
+		const registry = new PluginHostViewRegistry({
+			isEnabled: () => true,
+			getHostViews: () => views,
+			isPluginRecordLoaded: () => true,
 			forward,
 		});
 
 		registry.update('com.example.runtime', 'status', [{ kind: 'text', text: 'Live' }]);
 		views = [];
 		registry.sync();
-		registry.purge('com.example.runtime');
 
 		expect(forward).toHaveBeenNthCalledWith(2, expect.objectContaining({ kind: 'remove', view }));
 		expect(forward.mock.calls[1][0]).not.toHaveProperty('force');
+	});
+
+	it('retains a live runtime view while its plugin record is transiently unavailable', () => {
+		const view: HostViewContribution = {
+			id: 'com.example.runtime/status',
+			localId: 'status',
+			pluginId: 'com.example.runtime',
+			surface: 'cadenza',
+			title: 'Runtime status',
+		};
+		let views: readonly HostViewContribution[] = [view];
+		let pluginRecordLoaded = true;
+		const forward = vi.fn(() => true);
+		const registry = new PluginHostViewRegistry({
+			isEnabled: () => true,
+			getHostViews: () => views,
+			isPluginRecordLoaded: () => pluginRecordLoaded,
+			forward,
+		});
+
+		registry.update('com.example.runtime', 'status', [{ kind: 'text', text: 'Live' }]);
+		views = [];
+		pluginRecordLoaded = false;
+		registry.sync();
+		registry.replay();
+
+		expect(forward).toHaveBeenNthCalledWith(
+			2,
+			expect.objectContaining({ kind: 'upsert', view, blocks: [{ kind: 'text', text: 'Live' }] })
+		);
 		expect(forward).toHaveBeenCalledTimes(2);
 	});
 
@@ -217,6 +284,7 @@ describe('PluginHostViewRegistry', () => {
 		const registry = new PluginHostViewRegistry({
 			isEnabled: () => true,
 			getHostViews: () => [view],
+			isPluginRecordLoaded: () => true,
 			forward,
 		});
 
@@ -250,6 +318,7 @@ describe('PluginHostViewRegistry', () => {
 				},
 			],
 			forward,
+			isPluginRecordLoaded: () => true,
 		});
 
 		expect(registry.update('com.example.disabled', 'status', [])).toBe(false);

--- a/src/__tests__/renderer/hooks/agent/useKnownAuthDirs.test.ts
+++ b/src/__tests__/renderer/hooks/agent/useKnownAuthDirs.test.ts
@@ -1,0 +1,33 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { EMPTY_KNOWN_AUTH_DIRS } from '../../../../shared/authPaths';
+import { useKnownAuthDirs } from '../../../../renderer/hooks/agent/useKnownAuthDirs';
+
+describe('useKnownAuthDirs', () => {
+	beforeEach(() => {
+		vi.mocked(window.maestro.agents.getKnownAuthDirs).mockReset();
+	});
+
+	it('clears local suggestions when disabled after loading them', async () => {
+		const knownAuthDirs = {
+			claudeConfigDirs: ['/Users/me/.claude'],
+			codexHomes: ['/Users/me/.codex'],
+		};
+		vi.mocked(window.maestro.agents.getKnownAuthDirs).mockResolvedValue(knownAuthDirs);
+
+		const { result, rerender } = renderHook((enabled: boolean) => useKnownAuthDirs(enabled), {
+			initialProps: true,
+		});
+
+		await waitFor(() => {
+			expect(result.current).toEqual(knownAuthDirs);
+		});
+
+		rerender(false);
+
+		await waitFor(() => {
+			expect(result.current).toEqual(EMPTY_KNOWN_AUTH_DIRS);
+		});
+		expect(window.maestro.agents.getKnownAuthDirs).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/__tests__/shared/groupHierarchy.test.ts
+++ b/src/__tests__/shared/groupHierarchy.test.ts
@@ -89,4 +89,27 @@ describe('group hierarchy', () => {
 			group('grandchild'),
 		]);
 	});
+
+	it('promotes every member of a persisted parent cycle to root', () => {
+		expect(normalizeGroupHierarchy([group('a', 'b'), group('b', 'a')])).toEqual([
+			group('a'),
+			group('b'),
+		]);
+	});
+
+	it('promotes every invalid link in chains longer than one parent-child edge', () => {
+		expect(
+			normalizeGroupHierarchy([
+				group('root'),
+				group('level-one', 'root'),
+				group('level-two', 'level-one'),
+				group('level-three', 'level-two'),
+			])
+		).toEqual([
+			group('root'),
+			group('level-one', 'root'),
+			group('level-two'),
+			group('level-three'),
+		]);
+	});
 });

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -58,8 +58,7 @@ import {
 	type PluginTabMetadata,
 } from './plugins/plugin-host-handlers';
 import { PluginHostViewRegistry, type HostViewMutation } from './plugins/plugin-host-view-registry';
-import type { MovementPayload } from '../shared/movement-types';
-import type { CadenzaPayload } from '../shared/cadenza-types';
+import { forwardPluginHostViewToRenderer } from './plugins/plugin-host-view-forwarder';
 import { ActionGuard } from './plugins/action-guard';
 import { PluginKvStore } from './plugins/plugin-kv-store';
 import { PluginEventBusImpl } from './plugins/plugin-event-bus';
@@ -683,58 +682,17 @@ function arePluginHostViewsEnabled(): boolean {
 function forwardPluginHostView(mutation: HostViewMutation): boolean {
 	if (!(mutation.kind === 'remove' && mutation.force) && !arePluginHostViewsEnabled()) return false;
 	if (!mainWindow || mainWindow.isDestroyed() || !isWebContentsAvailable(mainWindow)) return false;
+	const targetWindow = mainWindow;
 	const sourcePlugin =
 		pluginManager?.getRegistry().records.find((record) => record.id === mutation.view.pluginId)
 			?.manifest?.name ?? mutation.view.pluginId;
-	let body: string | undefined;
-	if (mutation.kind === 'upsert') {
-		try {
-			body = JSON.stringify(mutation.blocks);
-		} catch {
-			return false;
-		}
-	}
-
-	if (mutation.view.surface === 'movement') {
-		const payload: MovementPayload =
-			mutation.kind === 'upsert'
-				? {
-						op: 'add',
-						id: mutation.view.id,
-						title: mutation.view.title,
-						body,
-						sourcePlugin,
-					}
-				: { op: 'remove', id: mutation.view.id };
-		mainWindow.webContents.send('remote:movement', payload);
-		return true;
-	}
-
-	const payload: CadenzaPayload =
-		mutation.kind === 'upsert'
-			? {
-					op: 'open',
-					id: mutation.view.id,
-					viewType: 'view',
-					title: mutation.view.title,
-					body,
-					sourcePlugin,
-				}
-			: { op: 'close', id: mutation.view.id };
-
-	// Closing a view must never create a new always-on-top HUD. Deliver a close
-	// to an existing HUD (including its pre-ready queue) or the main fallback only.
-	if (mutation.kind === 'remove') {
-		if (deliverCadenzaToExistingHud(payload)) return true;
-		mainWindow.webContents.send('remote:cadenza', payload);
-		return true;
-	}
-
-	// Match the CLI cadenza bridge: open/upsert prefers the HUD and creates it
-	// lazily, then falls back to the main renderer.
-	if (store.get('encoreFeatures', {})?.concerto === true && deliverCadenza(payload)) return true;
-	mainWindow.webContents.send('remote:cadenza', payload);
-	return true;
+	return forwardPluginHostViewToRenderer(mutation, {
+		sourcePlugin,
+		isCadenzaEnabled: store.get('encoreFeatures', {})?.concerto === true,
+		sendToMain: (channel, payload) => targetWindow.webContents.send(channel, payload),
+		deliverCadenza,
+		deliverCadenzaToExistingHud,
+	});
 }
 
 const pluginHostViews = new PluginHostViewRegistry({

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -698,10 +698,8 @@ function forwardPluginHostView(mutation: HostViewMutation): boolean {
 const pluginHostViews = new PluginHostViewRegistry({
 	isEnabled: arePluginHostViewsEnabled,
 	getHostViews: () => pluginManager?.getContributions().hostViews ?? [],
-	isPluginRecordLoaded: (pluginId) =>
-		pluginManager
-			?.getRegistry()
-			.records.some((record) => record.id === pluginId && record.loadStatus === 'ok') ?? false,
+	isPluginRecordPresent: (pluginId) =>
+		pluginManager?.getRegistry().records.some((record) => record.id === pluginId) ?? false,
 	forward: forwardPluginHostView,
 });
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -698,6 +698,10 @@ function forwardPluginHostView(mutation: HostViewMutation): boolean {
 const pluginHostViews = new PluginHostViewRegistry({
 	isEnabled: arePluginHostViewsEnabled,
 	getHostViews: () => pluginManager?.getContributions().hostViews ?? [],
+	isPluginRecordLoaded: (pluginId) =>
+		pluginManager
+			?.getRegistry()
+			.records.some((record) => record.id === pluginId && record.loadStatus === 'ok') ?? false,
 	forward: forwardPluginHostView,
 });
 

--- a/src/main/ipc/handlers/agents.ts
+++ b/src/main/ipc/handlers/agents.ts
@@ -79,7 +79,7 @@ function isLocalSession(session: Record<string, unknown>): boolean {
 		sshRemoteConfig &&
 		typeof sshRemoteConfig === 'object' &&
 		'enabled' in sshRemoteConfig &&
-		sshRemoteConfig.enabled === true
+		Boolean(sshRemoteConfig.enabled)
 	) {
 		return false;
 	}

--- a/src/main/ipc/handlers/agents.ts
+++ b/src/main/ipc/handlers/agents.ts
@@ -70,6 +70,11 @@ function getCustomEnvVars(value: unknown): Record<string, unknown> {
 		: {};
 }
 
+function isSshEnabled(value: unknown): boolean {
+	if (value === true || value === 1) return true;
+	return typeof value === 'string' && (value === '1' || value.toLowerCase() === 'true');
+}
+
 function isLocalSession(session: Record<string, unknown>): boolean {
 	if (typeof session.sshRemoteId === 'string' && session.sshRemoteId.length > 0) {
 		return false;
@@ -79,7 +84,7 @@ function isLocalSession(session: Record<string, unknown>): boolean {
 		sshRemoteConfig &&
 		typeof sshRemoteConfig === 'object' &&
 		'enabled' in sshRemoteConfig &&
-		Boolean(sshRemoteConfig.enabled)
+		isSshEnabled(sshRemoteConfig.enabled)
 	) {
 		return false;
 	}

--- a/src/main/plugins/plugin-host-view-forwarder.ts
+++ b/src/main/plugins/plugin-host-view-forwarder.ts
@@ -1,0 +1,70 @@
+import type { CadenzaPayload } from '../../shared/cadenza-types';
+import type { MovementPayload } from '../../shared/movement-types';
+import type { HostViewMutation } from './plugin-host-view-registry';
+
+export interface PluginHostViewForwardingDeps {
+	sourcePlugin: string;
+	isCadenzaEnabled: boolean;
+	sendToMain: (
+		channel: 'remote:movement' | 'remote:cadenza',
+		payload: MovementPayload | CadenzaPayload
+	) => void;
+	deliverCadenza: (payload: CadenzaPayload) => boolean;
+	deliverCadenzaToExistingHud: (payload: CadenzaPayload) => boolean;
+}
+
+/**
+ * Delivers an authorized host-view mutation to Concerto's renderer channels.
+ * A Cadenza close reaches both the HUD and in-app renderer: the latter may
+ * retain a fallback card that was opened before a HUD existed.
+ */
+export function forwardPluginHostViewToRenderer(
+	mutation: HostViewMutation,
+	deps: PluginHostViewForwardingDeps
+): boolean {
+	let body: string | undefined;
+	if (mutation.kind === 'upsert') {
+		try {
+			body = JSON.stringify(mutation.blocks);
+		} catch {
+			return false;
+		}
+	}
+
+	if (mutation.view.surface === 'movement') {
+		const payload: MovementPayload =
+			mutation.kind === 'upsert'
+				? {
+						op: 'add',
+						id: mutation.view.id,
+						title: mutation.view.title,
+						body,
+						sourcePlugin: deps.sourcePlugin,
+					}
+				: { op: 'remove', id: mutation.view.id };
+		deps.sendToMain('remote:movement', payload);
+		return true;
+	}
+
+	const payload: CadenzaPayload =
+		mutation.kind === 'upsert'
+			? {
+					op: 'open',
+					id: mutation.view.id,
+					viewType: 'view',
+					title: mutation.view.title,
+					body,
+					sourcePlugin: deps.sourcePlugin,
+				}
+			: { op: 'close', id: mutation.view.id };
+
+	if (mutation.kind === 'remove') {
+		deps.deliverCadenzaToExistingHud(payload);
+		deps.sendToMain('remote:cadenza', payload);
+		return true;
+	}
+
+	if (deps.isCadenzaEnabled && deps.deliverCadenza(payload)) return true;
+	deps.sendToMain('remote:cadenza', payload);
+	return true;
+}

--- a/src/main/plugins/plugin-host-view-registry.ts
+++ b/src/main/plugins/plugin-host-view-registry.ts
@@ -70,9 +70,10 @@ export class PluginHostViewRegistry {
 		const declarations = this.deps.getHostViews();
 		const declaredById = new Map(declarations.map((view) => [view.id, view]));
 		for (const [id, live] of this.live) {
-			if (live.source !== 'static') continue;
 			const declaration = declaredById.get(id);
-			if (!declaration || declaration.blocks === undefined) this.removeLive(id, false);
+			if (!declaration || (live.source === 'static' && declaration.blocks === undefined)) {
+				this.removeLive(id, false);
+			}
 		}
 
 		for (const view of declarations) {

--- a/src/main/plugins/plugin-host-view-registry.ts
+++ b/src/main/plugins/plugin-host-view-registry.ts
@@ -27,8 +27,12 @@ export interface PluginHostViewRegistryDeps {
 	isEnabled: () => boolean;
 	/** Active declarations, normally PluginManager.getContributions().hostViews. */
 	getHostViews: () => readonly HostViewContribution[];
-	/** Whether a plugin record loaded a valid manifest for declaration reconciliation. */
-	isPluginRecordLoaded: (pluginId: string) => boolean;
+	/** Whether the plugin's registry record is PRESENT (any loadStatus). Presence —
+	 * including permanent failure states like `invalid`/`incompatible` — means the
+	 * declaration set is authoritative and undeclared runtime views are purged.
+	 * Absence means a transient reload window: retain runtime views until the
+	 * record reappears (plugin code cannot re-send them unprompted). */
+	isPluginRecordPresent: (pluginId: string) => boolean;
 	/** Host-owned bridge to Concerto's existing Movement/Cadenza payload channels. */
 	forward: (mutation: HostViewMutation) => boolean;
 }
@@ -74,7 +78,7 @@ export class PluginHostViewRegistry {
 		for (const [id, live] of this.live) {
 			const declaration = declaredById.get(id);
 			if (
-				(!declaration && this.deps.isPluginRecordLoaded(live.view.pluginId)) ||
+				(!declaration && this.deps.isPluginRecordPresent(live.view.pluginId)) ||
 				(live.source === 'static' && declaration?.blocks === undefined)
 			) {
 				this.removeLive(id, false);

--- a/src/main/plugins/plugin-host-view-registry.ts
+++ b/src/main/plugins/plugin-host-view-registry.ts
@@ -27,6 +27,8 @@ export interface PluginHostViewRegistryDeps {
 	isEnabled: () => boolean;
 	/** Active declarations, normally PluginManager.getContributions().hostViews. */
 	getHostViews: () => readonly HostViewContribution[];
+	/** Whether a plugin record loaded a valid manifest for declaration reconciliation. */
+	isPluginRecordLoaded: (pluginId: string) => boolean;
 	/** Host-owned bridge to Concerto's existing Movement/Cadenza payload channels. */
 	forward: (mutation: HostViewMutation) => boolean;
 }
@@ -71,7 +73,10 @@ export class PluginHostViewRegistry {
 		const declaredById = new Map(declarations.map((view) => [view.id, view]));
 		for (const [id, live] of this.live) {
 			const declaration = declaredById.get(id);
-			if (!declaration || (live.source === 'static' && declaration.blocks === undefined)) {
+			if (
+				(!declaration && this.deps.isPluginRecordLoaded(live.view.pluginId)) ||
+				(live.source === 'static' && declaration?.blocks === undefined)
+			) {
 				this.removeLive(id, false);
 			}
 		}

--- a/src/renderer/hooks/agent/useKnownAuthDirs.ts
+++ b/src/renderer/hooks/agent/useKnownAuthDirs.ts
@@ -16,7 +16,10 @@ export function useKnownAuthDirs(enabled = true): KnownAuthDirs {
 	const [knownAuthDirs, setKnownAuthDirs] = useState<KnownAuthDirs>(EMPTY_KNOWN_AUTH_DIRS);
 
 	useEffect(() => {
-		if (!enabled) return;
+		if (!enabled) {
+			setKnownAuthDirs(EMPTY_KNOWN_AUTH_DIRS);
+			return;
+		}
 		const getKnownAuthDirs = window.maestro?.agents?.getKnownAuthDirs;
 		if (!getKnownAuthDirs) return;
 


### PR DESCRIPTION
Follow-up fixes for review findings on already-merged #1191, #1193, #1195:

- **#1191** — `useKnownAuthDirs` now clears suggestions when the panel switches to SSH (stale local paths could be saved into a remote config), and `agents:getKnownAuthDirs` excludes SSH sessions on any truthy `enabled` (was `=== true`, letting migrated truthy values leak remote paths into the local dropdown).
- **#1195** — `PluginHostViewRegistry.sync()` now purges runtime-sourced views whose declaration disappeared on hot-reload (previously stuck: replayed forever, un-removable since `remove()` rejects undeclared ids), and cadenza host-view close is delivered to BOTH the HUD and the main renderer (an in-app fallback card opened pre-HUD survived purge/disable).
- **#1193** — the reported persisted-cycle normalization gap was **refuted**: rc's normalization already promotes cycle members to root (only links to an existing root parent survive). Added explicit A↔B and over-depth-chain regression tests to pin that behavior.

Verification: 4 files / 98 focused tests, typecheck ×3, eslint, prettier clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session “local vs non-local” detection by treating SSH enablement truthy values (e.g., `"true"`, `"TRUE"`, `"1"`, `1`) as enabled, not just strict booleans.
  * Fixed plugin host view forwarding/cleanup to properly remove outdated live Cadenza/HUD views and correctly propagate Cadenza close/open behavior.
  * Ensured known authentication directories are cleared when the feature is disabled.
  * Strengthened group hierarchy normalization for persisted parent cycles and invalid links.

* **Tests**
  * Expanded coverage for SSH enablement parsing, known auth dirs hook reset behavior, plugin host view lifecycle/forwarding (open/close, remove, purge), and group hierarchy normalization edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->