### PR TITLE
fix: stabilize web-desktop mobile bootstrap and composer

### DIFF
--- a/src/__tests__/renderer/components/InputArea.test.tsx
+++ b/src/__tests__/renderer/components/InputArea.test.tsx
@@ -227,6 +227,13 @@ describe('InputArea', () => {
 			expect(screen.getByRole('textbox')).toBeInTheDocument();
 		});
 
+		it('marks the AI mention overlay for mobile typography synchronization', () => {
+			const props = createDefaultProps();
+			const { container } = render(<InputArea {...props} />);
+
+			expect(container.querySelector('.maestro-input-text-overlay')).toBeInTheDocument();
+		});
+
 		it('renders the notification settings button', () => {
 			const props = createDefaultProps();
 			render(<InputArea {...props} />);

--- a/src/__tests__/web-desktop/bootstrap.test.ts
+++ b/src/__tests__/web-desktop/bootstrap.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../web/utils/serviceWorker', () => ({
+	registerServiceWorker: vi.fn(),
+}));
+vi.mock('../../main/preload/index', () => ({}));
+vi.mock('../../renderer/main', () => ({}));
+
+const { bootWebDesktop, ensureWebProcess } = await import('../../web-desktop/bootstrap');
+
+describe('web-desktop bootstrap process shim', () => {
+	it('supplies an empty argv array before evaluating the shared preload', async () => {
+		const browserWindow = {
+			process: {
+				env: { NODE_ENV: 'production' },
+				versions: { electron: '0.0.0-web', chrome: '0.0.0', node: '0.0.0' },
+				platform: 'linux',
+			},
+		} as Window;
+		const preload = vi.fn(async () => {
+			expect(browserWindow.process?.argv).toEqual([]);
+		});
+		const renderer = vi.fn(async () => {});
+
+		await bootWebDesktop(browserWindow, { preload, renderer });
+
+		expect(preload).toHaveBeenCalledOnce();
+		expect(renderer).toHaveBeenCalledOnce();
+	});
+
+	it('creates the complete process shim when the browser has no process', () => {
+		const browserWindow = {} as Window;
+
+		ensureWebProcess(browserWindow);
+
+		expect(browserWindow.process).toMatchObject({
+			env: { NODE_ENV: 'production' },
+			versions: { electron: '0.0.0-web', chrome: '0.0.0', node: '0.0.0' },
+			argv: [],
+		});
+		expect(['darwin', 'win32', 'linux']).toContain(browserWindow.process?.platform);
+	});
+
+	it('preserves existing browser launch arguments', () => {
+		const browserWindow = {
+			process: {
+				env: {},
+				versions: {},
+				platform: 'linux',
+				argv: ['--maestro-cli-path=/tmp/maestro-cli'],
+			},
+		} as Window;
+
+		ensureWebProcess(browserWindow);
+
+		expect(browserWindow.process?.argv).toEqual(['--maestro-cli-path=/tmp/maestro-cli']);
+	});
+});

--- a/src/renderer/components/InputArea/components/InputTextarea.tsx
+++ b/src/renderer/components/InputArea/components/InputTextarea.tsx
@@ -158,7 +158,7 @@ export const InputTextarea = memo(function InputTextarea({
 				<div
 					ref={overlayRef}
 					aria-hidden="true"
-					className="pointer-events-none absolute inset-0 overflow-hidden"
+					className="maestro-input-text-overlay pointer-events-none absolute inset-0 overflow-hidden"
 					style={{
 						// wordBreak comes from SHARED_TYPOGRAPHY so it stays in sync with
 						// the textarea; only overlay-specific props are set here.

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -1660,7 +1660,10 @@ html[data-runtime='web-desktop'] .overflow-y-scroll {
  * inputs are text-sm (14px). Force 16px only at xs/sm inside web-desktop so the
  * zoom never triggers, without touching the components' Tailwind classes or the
  * native desktop app. `!important` guarantees the 16px floor regardless of
- * utility-class specificity; line-height keeps the taller text readable.
+ * utility-class specificity; line-height keeps the taller text readable. The
+ * AI composer has a decorative mention overlay beneath its transparent textarea,
+ * so that overlay receives the same font size or its visible glyphs drift from
+ * the native caret on iOS.
  */
 html[data-runtime='web-desktop'][data-bp='xs'] textarea,
 html[data-runtime='web-desktop'][data-bp='xs'] input[type='text'],
@@ -1674,6 +1677,11 @@ html[data-runtime='web-desktop'][data-bp='sm'] input:not([type]),
 html[data-runtime='web-desktop'][data-bp='sm'] select {
 	font-size: 16px !important;
 	line-height: 1.4;
+}
+
+html[data-runtime='web-desktop'][data-bp='xs'] .maestro-input-text-overlay,
+html[data-runtime='web-desktop'][data-bp='sm'] .maestro-input-text-overlay {
+	font-size: 16px !important;
 }
 
 /*

--- a/src/web-desktop/bootstrap.ts
+++ b/src/web-desktop/bootstrap.ts
@@ -18,21 +18,35 @@ declare global {
 			env: Record<string, string | undefined>;
 			versions: Record<string, string>;
 			platform: string;
+			argv?: string[];
 		};
 	}
 }
 
-if (!window.process) {
-	window.process = {
-		env: { NODE_ENV: 'production' },
-		versions: { electron: '0.0.0-web', chrome: '0.0.0', node: '0.0.0' },
-		platform: navigator.userAgent.includes('Mac')
-			? 'darwin'
-			: navigator.userAgent.includes('Win')
-				? 'win32'
-				: 'linux',
-	};
+export function ensureWebProcess(target: Window): void {
+	if (!target.process) {
+		target.process = {
+			env: { NODE_ENV: 'production' },
+			versions: { electron: '0.0.0-web', chrome: '0.0.0', node: '0.0.0' },
+			platform: navigator.userAgent.includes('Mac')
+				? 'darwin'
+				: navigator.userAgent.includes('Win')
+					? 'win32'
+					: 'linux',
+			argv: [],
+		};
+		return;
+	}
+
+	// The shared preload reads process.argv to resolve Electron-only launch
+	// arguments. Browser builds have no argv, so provide the empty Node shape
+	// instead of failing while the preload module evaluates.
+	if (!Array.isArray(target.process.argv)) {
+		target.process.argv = [];
+	}
 }
+
+ensureWebProcess(window);
 
 // Also expose `global` as `window` for legacy code that checks it.
 if (!(globalThis as Record<string, unknown>).global) {
@@ -46,14 +60,26 @@ if (!(globalThis as Record<string, unknown>).global) {
 // already matches.
 document.documentElement.dataset.runtime = 'web-desktop';
 
-async function boot(): Promise<void> {
-	// Run preload first so window.maestro is populated.
-	await import('../main/preload/index');
-	// Then mount the renderer.
-	await import('../renderer/main');
+interface WebDesktopBootstrapDependencies {
+	preload: () => Promise<unknown>;
+	renderer: () => Promise<unknown>;
 }
 
-void boot()
+export async function bootWebDesktop(
+	target: Window,
+	dependencies: WebDesktopBootstrapDependencies
+): Promise<void> {
+	ensureWebProcess(target);
+	// Run preload first so window.maestro is populated.
+	await dependencies.preload();
+	// Then mount the renderer.
+	await dependencies.renderer();
+}
+
+void bootWebDesktop(window, {
+	preload: () => import('../main/preload/index'),
+	renderer: () => import('../renderer/main'),
+})
 	.then(() => {
 		// Register the PWA service worker once the app is mounted. The server
 		// injects window.__MAESTRO_CONFIG__ inline before any module runs, so the


### PR DESCRIPTION
## Summary
- initialize `process.argv` before the browser evaluates the shared preload
- keep the mobile composer mention overlay at the same 16px typography as its iOS textarea

## Validation
- `vitest run src/__tests__/web-desktop/bootstrap.test.ts src/__tests__/renderer/components/InputArea.test.tsx`
- `npm run lint`
- `npm run format:check`
- `npm run build:web-desktop` (local active worktree)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved mobile text input rendering by synchronizing the decorative text overlay with the native input font size.
  - Prevented unwanted iOS auto-zoom in smaller web-desktop layouts.
  - Improved web-desktop startup reliability by ensuring process settings are initialized consistently before loading the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->