### PR TITLE
Add Indigo Blue theme

### DIFF
--- a/src/__tests__/renderer/constants/themes.test.ts
+++ b/src/__tests__/renderer/constants/themes.test.ts
@@ -52,12 +52,12 @@ describe('THEMES constant', () => {
 			}
 		});
 
-		it('should have exactly 20 themes (sync check with ThemeId type)', () => {
+		it('should have exactly 21 themes (sync check with ThemeId type)', () => {
 			// This count should match the number of IDs in ThemeId union type.
 			// If a new theme is added to THEMES without updating ThemeId, TypeScript errors.
 			// If ThemeId is updated without adding to isValidThemeId array, other tests fail.
 			// This test serves as an explicit reminder when themes are added/removed.
-			expect(themeIds.length).toBe(20);
+			expect(themeIds.length).toBe(21);
 		});
 
 		it('should have theme.id matching its key', () => {

--- a/src/__tests__/shared/theme-types.test.ts
+++ b/src/__tests__/shared/theme-types.test.ts
@@ -9,7 +9,15 @@ import { isValidThemeId, type ThemeId } from '../../shared/theme-types';
 
 describe('isValidThemeId', () => {
 	// Sample of valid theme IDs (not exhaustive - that would couple tests to implementation)
-	const sampleValidIds = ['dracula', 'monokai', 'github-light', 'nord', 'olive-nights', 'pedurple'];
+	const sampleValidIds = [
+		'dracula',
+		'monokai',
+		'github-light',
+		'nord',
+		'olive-nights',
+		'indigo-blue',
+		'pedurple',
+	];
 
 	it('should return true for valid theme IDs', () => {
 		for (const id of sampleValidIds) {

--- a/src/shared/theme-types.ts
+++ b/src/shared/theme-types.ts
@@ -25,6 +25,7 @@ export type ThemeId =
 	| 'catppuccin-mocha'
 	| 'gruvbox-dark'
 	| 'olive-nights'
+	| 'indigo-blue'
 	| 'catppuccin-latte'
 	| 'ayu-light'
 	| 'pedurple'
@@ -134,6 +135,7 @@ export function isValidThemeId(id: string): id is ThemeId {
 		'catppuccin-mocha',
 		'gruvbox-dark',
 		'olive-nights',
+		'indigo-blue',
 		'catppuccin-latte',
 		'ayu-light',
 		'pedurple',

--- a/src/shared/themes.ts
+++ b/src/shared/themes.ts
@@ -571,6 +571,27 @@ export const THEMES: Record<ThemeId, Theme> = {
 			error: '#ff5555',
 		},
 	},
+	'indigo-blue': {
+		id: 'indigo-blue',
+		name: 'Indigo Blue',
+		mode: 'dark',
+		colors: {
+			bgMain: '#010204',
+			bgTitleBar: '#010204',
+			bgSidebar: '#020203',
+			bgActivity: '#030507',
+			border: '#06070a',
+			textMain: '#f2ebc0',
+			textDim: '#c7c2b3',
+			accent: '#1f2f63',
+			accentDim: 'rgba(14, 22, 46, 1)',
+			accentText: '#a9b8df',
+			accentForeground: '#ffffff',
+			success: '#a5b0ca',
+			warning: '#d0a795',
+			error: '#ff5555',
+		},
+	},
 	// Light themes
 	'github-light': {
 		id: 'github-light',


### PR DESCRIPTION
Adds Indigo Blue as a built-in dark theme, following the same pattern as the Olive Nights theme (#1038).

Changes:
- Adds the `indigo-blue` theme to the shared theme registry.
- Registers `indigo-blue` as a valid `ThemeId`.
- Updates theme count and valid ID tests.

Validation:
- npm run test -- src/__tests__/renderer/constants/themes.test.ts src/__tests__/shared/theme-types.test.ts src/__tests__/main/themes.test.ts
- npx prettier --check src/shared/themes.ts src/shared/theme-types.ts src/__tests__/renderer/constants/themes.test.ts src/__tests__/shared/theme-types.test.ts
- npm run lint:eslint (scoped to the changed files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new dark “Indigo Blue” theme with coordinated background, text, accent, and status colors.
  * The new theme can be selected and is recognized as a valid theme option.

* **Tests**
  * Updated theme coverage to include the new theme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->