### PR TITLE
fix(permissions): unset permissionMode now resolves to full access everywhere

### DIFF
--- a/src/__tests__/main/utils/agent-args.test.ts
+++ b/src/__tests__/main/utils/agent-args.test.ts
@@ -346,6 +346,32 @@ describe('buildAgentArgs', () => {
 		expect(result).not.toContain('--dangerously-bypass');
 	});
 
+	// -- real claude-code definition: full access is what grants the bypass --
+	it("claude-code with permissionMode 'full' adds --dangerously-skip-permissions", () => {
+		const claude = AGENT_DEFINITIONS.find((agent) => agent.id === 'claude-code');
+		expect(claude).toBeDefined();
+		const result = buildAgentArgs(claude!, {
+			baseArgs: ['--print'],
+			prompt: 'do the thing',
+			permissionMode: 'full',
+		});
+		expect(result).toContain('--dangerously-skip-permissions');
+	});
+
+	it('claude-code with an unset permissionMode (no yoloMode) does NOT add --dangerously-skip-permissions', () => {
+		// Resolution of an unset permissionMode -> full access now happens in the
+		// renderer (resolveTabPermissionMode), NOT here. buildAgentArgs still
+		// treats a literal undefined as non-full, so callers MUST resolve first.
+		const claude = AGENT_DEFINITIONS.find((agent) => agent.id === 'claude-code');
+		expect(claude).toBeDefined();
+		const result = buildAgentArgs(claude!, {
+			baseArgs: ['--print'],
+			prompt: 'do the thing',
+			permissionMode: undefined,
+		});
+		expect(result).not.toContain('--dangerously-skip-permissions');
+	});
+
 	it('deduplicates Codex bypass flag when batch and yolo args both include it', () => {
 		const agent = makeAgent({
 			batchModeArgs: ['--dangerously-bypass-approvals-and-sandbox', '--skip-git-repo-check'],

--- a/src/__tests__/renderer/hooks/useAgentExecution.test.ts
+++ b/src/__tests__/renderer/hooks/useAgentExecution.test.ts
@@ -210,6 +210,49 @@ describe('useAgentExecution', () => {
 		await spawnPromise;
 	});
 
+	it('spawns Auto Run batches with full-access permissionMode', async () => {
+		// Auto Run runs unattended in --print mode and must have the same
+		// permission level as an interactive "Full Access" tab. Without an
+		// explicit permissionMode: 'full', agents whose bypass is gated on full
+		// access (e.g. Claude Code) fall back to the default permission model,
+		// can't get non-interactive tool approvals, and deadlock the run.
+		const session = createMockSession({
+			state: 'busy',
+			aiTabs: [createMockTab({ state: 'busy' })],
+		});
+		const sessionsRef = { current: [session] };
+		const setSessions = vi.fn();
+		const processQueuedItemRef = { current: null };
+
+		const { result } = renderHook(() =>
+			useAgentExecution({
+				activeSession: session,
+				sessionsRef,
+				setSessions,
+				processQueuedItemRef,
+				setFlashNotification: vi.fn(),
+				setSuccessFlashNotification: vi.fn(),
+			})
+		);
+
+		const spawnPromise = result.current.spawnAgentForSession(session.id, 'Batch task');
+
+		await waitFor(() => {
+			expect(mockProcess.spawn).toHaveBeenCalledTimes(1);
+		});
+
+		const spawnConfig = mockProcess.spawn.mock.calls[0][0];
+		expect(spawnConfig.permissionMode).toBe('full');
+		expect(spawnConfig.readOnlyMode).toBe(false);
+
+		// Clean up
+		const targetSessionId = spawnConfig.sessionId as string;
+		act(() => {
+			onExitHandler?.(targetSessionId);
+		});
+		await spawnPromise;
+	});
+
 	it('uses raw stdin prompt delivery for local Windows batch runs when stream-json input is unsupported', async () => {
 		const originalPlatform = (window as any).maestro?.platform;
 		(window as any).maestro = { ...((window as any).maestro || {}), platform: 'win32' };

--- a/src/__tests__/renderer/hooks/useInputProcessing.test.ts
+++ b/src/__tests__/renderer/hooks/useInputProcessing.test.ts
@@ -1477,6 +1477,36 @@ describe('useInputProcessing', () => {
 			expect(spawnCall.permissionMode).toBe('full');
 		});
 
+		it('sends permissionMode "full" for a tab whose permissionMode was never set (matches the pill)', async () => {
+			// The core drift bug: an unset permissionMode rendered "Full Access" in
+			// the toolbar but previously spawned with an undefined permissionMode, so
+			// buildAgentArgs withheld the bypass and the agent was silently denied.
+			// resolveTabPermissionMode now maps unset -> 'full' on the spawn path too.
+			const unsetTab = createMockTab({
+				agentSessionId: 'existing-session-unset',
+			});
+			expect(unsetTab.permissionMode).toBeUndefined();
+			const session = createMockSession({
+				aiTabs: [unsetTab],
+				activeTabId: unsetTab.id,
+			});
+			const deps = createDeps({
+				activeSession: session,
+				sessionsRef: { current: [session] },
+				inputValue: 'run the build',
+			});
+			const { result } = renderHook(() => useInputProcessing(deps));
+
+			await act(async () => {
+				await result.current.processInput();
+			});
+
+			expect(window.maestro.process.spawn).toHaveBeenCalled();
+			const spawnCall = vi.mocked(window.maestro.process.spawn).mock.calls[0][0];
+			expect(spawnCall.permissionMode).toBe('full');
+			expect(spawnCall.readOnlyMode).toBeFalsy();
+		});
+
 		it('sends permissionMode "standard" when tab permissionMode is "standard"', async () => {
 			// standard mode must propagate to the spawn config so the main process
 			// can wire up the permission relay (rather than defaulting to full).

--- a/src/__tests__/renderer/hooks/useRemoteHandlers.test.ts
+++ b/src/__tests__/renderer/hooks/useRemoteHandlers.test.ts
@@ -1257,6 +1257,43 @@ describe('useRemoteHandlers', () => {
 			expect(spawnCall.permissionMode).toBe('readonly');
 		});
 
+		it('sends permissionMode "full" for a remote AI command on a tab with no permissionMode set', async () => {
+			// Same queued/non-interactive drift as the input path: a fresh tab shows
+			// Full Access in the toolbar, so the remote spawn must resolve to 'full'
+			// too or Claude Code loses --dangerously-skip-permissions and deadlocks.
+			const session = createMockSession({
+				inputMode: 'ai',
+				aiTabs: [
+					{
+						id: 'tab-1',
+						name: 'Tab 1',
+						inputValue: '',
+						data: [],
+						logs: [],
+						stagedImages: [],
+					},
+				],
+				activeTabId: 'tab-1',
+			});
+			useSessionStore.getState().setSessions([session]);
+			const deps = createMockDeps({ sessionsRef: { current: [session] } });
+
+			renderHook(() => useRemoteHandlers(deps));
+			const handler = getRemoteCommandHandler();
+
+			await act(async () => {
+				await handler(
+					new CustomEvent('maestro:remoteCommand', {
+						detail: { sessionId: 'session-1', command: 'explain code', inputMode: 'ai' },
+					})
+				);
+			});
+
+			const spawnCall = vi.mocked(window.maestro.process.spawn).mock.calls[0][0];
+			expect(spawnCall.readOnlyMode).toBe(false);
+			expect(spawnCall.permissionMode).toBe('full');
+		});
+
 		it('sets session state to busy with busySource=ai for AI commands', async () => {
 			const session = createMockSession({ inputMode: 'ai' });
 			useSessionStore.setState({ sessions: [session], activeSessionId: 'session-1' } as any);

--- a/src/__tests__/renderer/stores/agentStore.test.ts
+++ b/src/__tests__/renderer/stores/agentStore.test.ts
@@ -1407,6 +1407,44 @@ describe('agentStore', () => {
 			expect(spawnCall.permissionMode).toBe('readonly');
 		});
 
+		it('sends permissionMode "full" for a queued item on a tab with no permissionMode set', async () => {
+			// Regression for the queued-spawn drift (Greptile P1): a fresh tab resolves
+			// to Full Access in the toolbar, so its queued non-interactive spawn must
+			// also pass permissionMode: 'full' - otherwise buildAgentArgs withholds
+			// Claude Code's --dangerously-skip-permissions and the queued work deadlocks
+			// on denied tools.
+			const session = createMockSession({
+				id: 'session-1',
+				aiTabs: [
+					{
+						id: 'tab-1',
+						agentSessionId: 'conv-1',
+						name: null,
+						starred: false,
+						logs: [],
+						inputValue: '',
+						stagedImages: [],
+						createdAt: Date.now(),
+						state: 'idle',
+					},
+				],
+				activeTabId: 'tab-1',
+			});
+			useSessionStore.getState().setSessions([session]);
+
+			const item = createQueuedItem({
+				tabId: 'tab-1',
+				text: 'Do the thing',
+				readOnlyMode: false,
+			});
+
+			await useAgentStore.getState().processQueuedItem('session-1', item, defaultDeps);
+
+			const spawnCall = mockSpawn.mock.calls[0][0];
+			expect(spawnCall.readOnlyMode).toBe(false);
+			expect(spawnCall.permissionMode).toBe('full');
+		});
+
 		it('processes slash command and spawns agent', async () => {
 			const session = createMockSession({
 				id: 'session-1',

--- a/src/__tests__/renderer/stores/tabStore.test.ts
+++ b/src/__tests__/renderer/stores/tabStore.test.ts
@@ -405,10 +405,12 @@ describe('tabStore', () => {
 			useTabStore.getState().toggleReadOnly('tab-1');
 			let session = useSessionStore.getState().sessions[0];
 			expect(session.aiTabs[0].readOnlyMode).toBe(true);
+			expect(session.aiTabs[0].permissionMode).toBe('readonly');
 
 			useTabStore.getState().toggleReadOnly('tab-1');
 			session = useSessionStore.getState().sessions[0];
 			expect(session.aiTabs[0].readOnlyMode).toBe(false);
+			expect(session.aiTabs[0].permissionMode).toBe('full');
 		});
 
 		it('should toggle save to history', () => {

--- a/src/__tests__/renderer/utils/tabHelpers.test.ts
+++ b/src/__tests__/renderer/utils/tabHelpers.test.ts
@@ -61,6 +61,7 @@ import {
 	ensureInUnifiedTabOrder,
 	getRepairedUnifiedTabOrder,
 	moveActiveUnifiedTabToEdge,
+	toggleReadOnlyModeFields,
 	findNextUnreadSession,
 	resolveQueuedItemTarget,
 	markTabRunningQueuedItem,
@@ -68,6 +69,7 @@ import {
 	groupHasUnreadTabs,
 	computeUnreadGroupIds,
 } from '../../../renderer/utils/tabHelpers';
+import { resolveTabPermissionMode } from '../../../shared/agentMetadata';
 import type { LogEntry } from '../../../renderer/types';
 import type {
 	Session,
@@ -5114,6 +5116,39 @@ describe('tabHelpers', () => {
 				activeTabId: 'a1',
 			});
 			expect(moveActiveUnifiedTabToEdge(session, 'end')).toBe(session);
+		});
+	});
+
+	describe('toggleReadOnlyModeFields', () => {
+		it('toggles a non-read-only tab to readonly on both fields', () => {
+			expect(toggleReadOnlyModeFields({ readOnlyMode: false })).toEqual({
+				readOnlyMode: true,
+				permissionMode: 'readonly',
+			});
+		});
+
+		it('toggles a read-only tab back to full access on both fields', () => {
+			expect(toggleReadOnlyModeFields({ readOnlyMode: true })).toEqual({
+				readOnlyMode: false,
+				permissionMode: 'full',
+			});
+		});
+
+		it('treats an unset readOnlyMode as not-read-only', () => {
+			expect(toggleReadOnlyModeFields({})).toEqual({
+				readOnlyMode: true,
+				permissionMode: 'readonly',
+			});
+		});
+
+		it('keeps permissionMode coherent so resolveTabPermissionMode agrees after a toggle', () => {
+			// The invariant this fix protects: the toolbar pill and the spawn path
+			// both resolve through resolveTabPermissionMode, so after toggling a Full
+			// Access tab to read-only the pill can no longer keep saying "Full Access".
+			const afterOn = toggleReadOnlyModeFields({ readOnlyMode: false });
+			expect(resolveTabPermissionMode(afterOn)).toBe('readonly');
+			const afterOff = toggleReadOnlyModeFields(afterOn);
+			expect(resolveTabPermissionMode(afterOff)).toBe('full');
 		});
 	});
 });

--- a/src/__tests__/shared/agentMetadata.test.ts
+++ b/src/__tests__/shared/agentMetadata.test.ts
@@ -10,6 +10,7 @@ import {
 	getReadOnlyModeTooltip,
 	getPermissionModeLabel,
 	getPermissionModeTooltip,
+	resolveTabPermissionMode,
 	AGENT_DISPLAY_NAMES,
 	BETA_AGENTS,
 } from '../../shared/agentMetadata';
@@ -201,6 +202,32 @@ describe('agentMetadata', () => {
 			expect(getPermissionModeTooltip('readonly', 'claude-code')).toContain('plan mode');
 			expect(getPermissionModeTooltip('readonly', 'codex')).toContain('Read-Only');
 			expect(getPermissionModeTooltip('readonly', 'factory-droid')).toContain('Read-Only');
+		});
+	});
+
+	describe('resolveTabPermissionMode', () => {
+		it('treats a nullish tab as full access', () => {
+			expect(resolveTabPermissionMode(undefined)).toBe('full');
+			expect(resolveTabPermissionMode(null)).toBe('full');
+		});
+
+		it('treats a tab with no stored permissionMode as full access', () => {
+			expect(resolveTabPermissionMode({})).toBe('full');
+		});
+
+		it('falls back to readonly only when the legacy readOnlyMode boolean is set', () => {
+			expect(resolveTabPermissionMode({ readOnlyMode: true })).toBe('readonly');
+			expect(resolveTabPermissionMode({ readOnlyMode: false })).toBe('full');
+		});
+
+		it('passes an explicit permissionMode through unchanged', () => {
+			expect(resolveTabPermissionMode({ permissionMode: 'full' })).toBe('full');
+			expect(resolveTabPermissionMode({ permissionMode: 'standard' })).toBe('standard');
+			expect(resolveTabPermissionMode({ permissionMode: 'readonly' })).toBe('readonly');
+		});
+
+		it('prefers an explicit permissionMode over the legacy readOnlyMode boolean', () => {
+			expect(resolveTabPermissionMode({ permissionMode: 'full', readOnlyMode: true })).toBe('full');
 		});
 	});
 });

--- a/src/renderer/components/InputArea/components/ToolbarControls.tsx
+++ b/src/renderer/components/InputArea/components/ToolbarControls.tsx
@@ -17,7 +17,11 @@ import {
 	formatEnterToSendTooltip,
 	formatShortcutKeys,
 } from '../../../utils/shortcutFormatter';
-import { getPermissionModeLabel, getPermissionModeTooltip } from '../../../../shared/agentMetadata';
+import {
+	getPermissionModeLabel,
+	getPermissionModeTooltip,
+	resolveTabPermissionMode,
+} from '../../../../shared/agentMetadata';
 import { updateSessionWith } from '../../../stores/sessionStore';
 import { captureException } from '../../../utils/sentry';
 import { isCoarsePointer } from '../../../utils/touch';
@@ -113,8 +117,7 @@ export const ToolbarControls = memo(function ToolbarControls({
 	const showVoiceButton = isAiMode && !!voiceSupported && !!onToggleVoiceInput && isCoarsePointer();
 
 	const activeTab = session.aiTabs?.find((t) => t.id === session.activeTabId);
-	const rawPermissionMode: 'full' | 'standard' | 'readonly' =
-		activeTab?.permissionMode ?? (activeTab?.readOnlyMode ? 'readonly' : 'full');
+	const rawPermissionMode: 'full' | 'standard' | 'readonly' = resolveTabPermissionMode(activeTab);
 	// Hide `standard` for agents without a working relay: if a stale tab is
 	// somehow in `standard`, display it as `full` so we never surface a
 	// non-functional mode.

--- a/src/renderer/hooks/agent/useAgentExecution.ts
+++ b/src/renderer/hooks/agent/useAgentExecution.ts
@@ -603,6 +603,13 @@ export function useAgentExecution(deps: UseAgentExecutionDeps): UseAgentExecutio
 							prompt,
 							appendSystemPrompt,
 							readOnlyMode: false, // Auto Run needs to make changes, not plan
+							// Auto Run runs unattended in --print mode, so it must have full
+							// access - the same permission level as an interactive tab set to
+							// "full". Without this, agents whose bypass is gated on full access
+							// (e.g. Claude Code's --dangerously-skip-permissions in fullAccessArgs)
+							// fall back to the default permission model, can't get tool approvals
+							// non-interactively, and deadlock the run.
+							permissionMode: 'full',
 							// Per-session config overrides (if set)
 							sessionCustomPath: session.customPath,
 							sessionCustomArgs: session.customArgs,

--- a/src/renderer/hooks/input/useInputProcessing.ts
+++ b/src/renderer/hooks/input/useInputProcessing.ts
@@ -13,6 +13,7 @@ import { getStdinFlags, prepareMaestroSystemPrompt } from '../../utils/spawnHelp
 import { generateId, getInputBroadcastOriginId } from '../../utils/ids';
 import { substituteTemplateVariables } from '../../utils/templateVariables';
 import { prependNewSessionMessage } from '../../../shared/newSessionMessage';
+import { resolveTabPermissionMode } from '../../../shared/agentMetadata';
 import { filterYoloArgs } from '../../utils/agentArgs';
 import { hasCapabilityCached } from '../agent/useAgentCapabilities';
 import { gitService } from '../../services/git';
@@ -1163,7 +1164,7 @@ export function useInputProcessing(deps: UseInputProcessingDeps): UseInputProces
 							freshActiveTab?.permissionMode === 'readonly';
 						const effectivePermissionMode = isReadOnly
 							? 'readonly'
-							: freshActiveTab?.permissionMode;
+							: resolveTabPermissionMode(freshActiveTab);
 
 						// For read-only mode, filter out any YOLO/skip-permissions flags from base args
 						// (they would override the read-only mode we're requesting)

--- a/src/renderer/hooks/keyboard/useMainKeyboardHandler.ts
+++ b/src/renderer/hooks/keyboard/useMainKeyboardHandler.ts
@@ -1,6 +1,10 @@
 import { useEffect, useRef, useState } from 'react';
 import type { Session, AITab, ThinkingMode } from '../../types';
-import { getInitialRenameValue, moveActiveUnifiedTabToEdge } from '../../utils/tabHelpers';
+import {
+	getInitialRenameValue,
+	moveActiveUnifiedTabToEdge,
+	toggleReadOnlyModeFields,
+} from '../../utils/tabHelpers';
 import { useModalStore } from '../../stores/modalStore';
 import { useSettingsStore } from '../../stores/settingsStore';
 import { isActiveOutputSearchOpen } from '../../utils/outputSearch';
@@ -1113,7 +1117,7 @@ export function useMainKeyboardHandler(): UseMainKeyboardHandlerReturn {
 								return {
 									...s,
 									aiTabs: s.aiTabs.map((tab: AITab) =>
-										tab.id === s.activeTabId ? { ...tab, readOnlyMode: !tab.readOnlyMode } : tab
+										tab.id === s.activeTabId ? { ...tab, ...toggleReadOnlyModeFields(tab) } : tab
 									),
 								};
 							})

--- a/src/renderer/hooks/modal/usePromptComposerHandlers.ts
+++ b/src/renderer/hooks/modal/usePromptComposerHandlers.ts
@@ -14,7 +14,7 @@ import { useSessionStore, selectActiveSession } from '../../stores/sessionStore'
 import { useGroupChatStore } from '../../stores/groupChatStore';
 import { useSettingsStore } from '../../stores/settingsStore';
 import { useComposerInputStore } from '../../stores/composerInputStore';
-import { getActiveTab } from '../../utils/tabHelpers';
+import { getActiveTab, toggleReadOnlyModeFields } from '../../utils/tabHelpers';
 
 // ============================================================================
 // Dependencies interface
@@ -165,7 +165,7 @@ export function usePromptComposerHandlers(
 					return {
 						...s,
 						aiTabs: s.aiTabs.map((tab) =>
-							tab.id === activeTab.id ? { ...tab, readOnlyMode: !tab.readOnlyMode } : tab
+							tab.id === activeTab.id ? { ...tab, ...toggleReadOnlyModeFields(tab) } : tab
 						),
 					};
 				})

--- a/src/renderer/hooks/modal/useQuickActionsHandlers.ts
+++ b/src/renderer/hooks/modal/useQuickActionsHandlers.ts
@@ -16,7 +16,7 @@
 import { useCallback } from 'react';
 import { generateId } from '../../utils/ids';
 import { takeNextRunnableQueueItem } from '../../utils/executionQueue';
-import { resolveQueuedItemTarget } from '../../utils/tabHelpers';
+import { resolveQueuedItemTarget, toggleReadOnlyModeFields } from '../../utils/tabHelpers';
 import type { Session, ThinkingMode, UnifiedTabRef } from '../../types';
 import { useSessionStore, selectActiveSession } from '../../stores/sessionStore';
 import { useSettingsStore } from '../../stores/settingsStore';
@@ -151,7 +151,7 @@ export function useQuickActionsHandlers(
 					return {
 						...s,
 						aiTabs: s.aiTabs.map((tab) =>
-							tab.id === s.activeTabId ? { ...tab, readOnlyMode: !tab.readOnlyMode } : tab
+							tab.id === s.activeTabId ? { ...tab, ...toggleReadOnlyModeFields(tab) } : tab
 						),
 					};
 				})

--- a/src/renderer/hooks/remote/useRemoteHandlers.ts
+++ b/src/renderer/hooks/remote/useRemoteHandlers.ts
@@ -17,6 +17,7 @@ import { useSessionStore } from '../../stores/sessionStore';
 import { useSettingsStore } from '../../stores/settingsStore';
 import { useUIStore } from '../../stores/uiStore';
 import { getActiveTab } from '../../utils/tabHelpers';
+import { resolveTabPermissionMode } from '../../../shared/agentMetadata';
 import { generateId } from '../../utils/ids';
 import { substituteTemplateVariables } from '../../utils/templateVariables';
 import { gitService } from '../../services/git';
@@ -414,7 +415,9 @@ export function useRemoteHandlers(deps: UseRemoteHandlersDeps): UseRemoteHandler
 				const tabAgentSessionId = targetTab?.agentSessionId;
 				const isReadOnly =
 					targetTab?.readOnlyMode === true || targetTab?.permissionMode === 'readonly';
-				const effectivePermissionMode = isReadOnly ? 'readonly' : targetTab?.permissionMode;
+				const effectivePermissionMode = isReadOnly
+					? 'readonly'
+					: resolveTabPermissionMode(targetTab);
 
 				// Filter out YOLO/skip-permissions flags when read-only mode is active
 				const agentArgs = agent.args ?? [];

--- a/src/renderer/hooks/tabs/internal/useAITabHandlers.ts
+++ b/src/renderer/hooks/tabs/internal/useAITabHandlers.ts
@@ -20,6 +20,7 @@ import {
 	hasWizardInteraction,
 	restoreOrphanedTab,
 	setActiveTab,
+	toggleReadOnlyModeFields,
 } from '../../../utils/tabHelpers';
 import type { AITabHandlersReturn } from './types';
 
@@ -318,7 +319,7 @@ export function useAITabHandlers(): AITabHandlersReturn {
 		if (!currentActiveTab) return;
 		updateAiTab(session.id, currentActiveTab.id, (tab) => ({
 			...tab,
-			readOnlyMode: !tab.readOnlyMode,
+			...toggleReadOnlyModeFields(tab),
 		}));
 	}, []);
 

--- a/src/renderer/stores/agentStore.ts
+++ b/src/renderer/stores/agentStore.ts
@@ -31,6 +31,7 @@ import type {
 	AgentCapabilitiesSnapshotMap,
 } from '../../shared/agentCapabilities';
 import { buildSnapshotKey } from '../../shared/agentCapabilities';
+import { resolveTabPermissionMode } from '../../shared/agentMetadata';
 import { createTab, getActiveTab } from '../utils/tabHelpers';
 import { getStdinFlags, prepareMaestroSystemPrompt } from '../utils/spawnHelpers';
 import { generateId } from '../utils/ids';
@@ -384,7 +385,7 @@ export const useAgentStore = create<AgentStore>()((set, get) => ({
 				item.readOnlyMode === true ||
 				targetTab.readOnlyMode === true ||
 				targetTab.permissionMode === 'readonly';
-			const effectivePermissionMode = isReadOnly ? 'readonly' : targetTab.permissionMode;
+			const effectivePermissionMode = isReadOnly ? 'readonly' : resolveTabPermissionMode(targetTab);
 
 			// Filter out YOLO/skip-permissions flags when read-only mode is active
 			const spawnArgs = isReadOnly

--- a/src/renderer/stores/tabStore.ts
+++ b/src/renderer/stores/tabStore.ts
@@ -37,6 +37,7 @@ import {
 	navigateToPrevUnifiedTab as navigateToPrevHelper,
 	navigateToUnifiedTabByIndex as navigateToIndexHelper,
 	navigateToLastUnifiedTab as navigateToLastHelper,
+	toggleReadOnlyModeFields,
 	type CreateTabOptions,
 	type CreateTabResult,
 	type CloseTabOptions,
@@ -548,7 +549,7 @@ export const useTabStore = create<TabStore>()((set) => ({
 		if (!session) return;
 		const tab = session.aiTabs.find((t) => t.id === tabId);
 		if (!tab) return;
-		updateAiTab(tabId, { readOnlyMode: !tab.readOnlyMode });
+		updateAiTab(tabId, toggleReadOnlyModeFields(tab));
 	},
 
 	toggleSaveToHistory: (tabId) => {

--- a/src/renderer/utils/tabHelpers.ts
+++ b/src/renderer/utils/tabHelpers.ts
@@ -1940,6 +1940,28 @@ export function aiTabFocusFields(tabId?: string): Partial<Session> {
 }
 
 /**
+ * Field patch for flipping a tab's read-only state.
+ *
+ * Keeps the legacy `readOnlyMode` boolean and the 3-way `permissionMode` in
+ * lockstep, so the toolbar pill (resolved via resolveTabPermissionMode) and the
+ * spawn path can never drift: toggling read-only ON means `readonly`, OFF means
+ * full access. This mirrors what the toolbar's permission cycle already writes.
+ * Every read-only toggle entry point (keyboard shortcut, quick action, prompt
+ * composer, tab menu, tab store) spreads this instead of writing `readOnlyMode`
+ * alone - the old inline `readOnlyMode: !tab.readOnlyMode` left `permissionMode`
+ * stale, so a Full Access tab kept its pill after being switched to read-only.
+ * `standard` is reachable only through the toolbar cycle, so toggling read-only
+ * off lands on `full` (the non-readonly default).
+ */
+export function toggleReadOnlyModeFields(tab: Pick<AITab, 'readOnlyMode'>): {
+	readOnlyMode: boolean;
+	permissionMode: 'full' | 'readonly';
+} {
+	const nextReadOnly = !tab.readOnlyMode;
+	return { readOnlyMode: nextReadOnly, permissionMode: nextReadOnly ? 'readonly' : 'full' };
+}
+
+/**
  * Detects the "closed the last tab" transition produced by closeTab(): when the
  * sole remaining AI tab is closed, closeTab() replaces it with a brand-new empty
  * tab, so the session still has exactly one AI tab but its id changed. Callers use

--- a/src/shared/agentMetadata.ts
+++ b/src/shared/agentMetadata.ts
@@ -108,6 +108,23 @@ export function getPermissionModeTooltip(
 }
 
 /**
+ * Resolve a tab's effective permission mode from its stored fields.
+ *
+ * A tab whose `permissionMode` was never explicitly set is treated as full
+ * access (falling back to `readonly` only when the legacy `readOnlyMode` boolean
+ * is set). This is the SINGLE source of truth for "what does an unset
+ * permissionMode mean" - both the toolbar pill (display) and the spawn path
+ * (which flags get passed) must call this so they can never drift apart. When
+ * they did drift, an unset tab rendered "Full Access" yet spawned in standard
+ * mode, so the agent's tool calls were silently denied.
+ */
+export function resolveTabPermissionMode(
+	tab?: { permissionMode?: 'full' | 'standard' | 'readonly'; readOnlyMode?: boolean } | null
+): 'full' | 'standard' | 'readonly' {
+	return tab?.permissionMode ?? (tab?.readOnlyMode ? 'readonly' : 'full');
+}
+
+/**
  * Agents currently in beta/experimental status.
  * Used to render "(Beta)" badges throughout the UI.
  *


### PR DESCRIPTION
## The bug

Agent permissions are a 3-way `permissionMode: 'full' | 'standard' | 'readonly'` stored per AI tab (`AITab.permissionMode`, optional). Two code paths resolved an **unset** (`undefined`) `permissionMode` differently, so they drifted:

- **Display** (`ToolbarControls.tsx`) defaulted `undefined` -> `'full'`, so the toolbar pill rendered **"Full Access"**.
- **Spawn** (`useInputProcessing.ts`) passed `undefined` straight through to `buildAgentArgs`.

`buildAgentArgs` (`agent-args.ts`) grants the bypass only on a **literal** `'full'`:

```ts
const isFullAccess =
  options.permissionMode === 'full' ||
  (options.permissionMode === undefined && options.yoloMode === true);
```

So an unset tab resolved to NOT full access. Claude Code's bypass (`--dangerously-skip-permissions`) lives ONLY in `fullAccessArgs` (it has no `batchModeArgs`), so it spawned in the default/standard permission model. Under `--print` tool prompts can't be approved, so every command was denied and the agent self-reported a deadlock. The box said "Full Access" while the agent was actually denied.

Auto Run had a second instance of the same class of bug: its batch spawn (`useAgentExecution.ts`) passed only `readOnlyMode: false` and never set `permissionMode`, so it too resolved to non-full-access and **goal-driven / document Auto Run deadlocked**.

(Codex was unaffected: its bypass is in `batchModeArgs`, applied in batch mode regardless of full access.)

## The fix

An unset `permissionMode` means **full access** (matches what the pill already showed and restores pre-rc behavior). Introduce ONE canonical resolver and call it everywhere so display and spawn can never drift again:

```ts
export function resolveTabPermissionMode(
	tab?: { permissionMode?: 'full' | 'standard' | 'readonly'; readOnlyMode?: boolean } | null
): 'full' | 'standard' | 'readonly' {
	return tab?.permissionMode ?? (tab?.readOnlyMode ? 'readonly' : 'full');
}
```

- `agentMetadata.ts`: add `resolveTabPermissionMode()` (single source of truth).
- `ToolbarControls.tsx`: toolbar pill calls the resolver (display).
- `useInputProcessing.ts`: interactive spawn calls the resolver, so an unset tab spawns as `'full'`, matching the pill.
- `useAgentExecution.ts`: Auto Run has no active tab, so it hardcodes `permissionMode: 'full'` in its batch spawn.

## Fixes

- The interactive "Full Access but denied" report.
- The goal-driven / document Auto Run deadlock on "missing permissions".

## Tests

- `agent-args.test.ts`: real `claude-code` definition with `permissionMode: 'full'` -> output includes `--dangerously-skip-permissions`; with `permissionMode: undefined` (no yoloMode) -> it does NOT (documents that resolution now happens in the renderer, not in `buildAgentArgs`).
- `agentMetadata.test.ts`: `resolveTabPermissionMode` unset -> `'full'`; `{ readOnlyMode: true }` -> `'readonly'`; explicit `'full'`/`'standard'`/`'readonly'` pass through; explicit mode wins over legacy `readOnlyMode`.
- `useInputProcessing.test.ts`: a tab whose `permissionMode` was never set now spawns with `permissionMode: 'full'`.
- `useAgentExecution.test.ts`: Auto Run batch spawn payload now includes `permissionMode: 'full'`.

All 195 tests across the four touched files pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized resolution of AI tab permission mode (supports legacy read-only settings).
  * Tabs with no explicit permission setting now consistently default to Full Access.
* **Bug Fixes**
  * Auto Run/batch agent launches explicitly use Full Access.
  * Remote commands, queued message spawns, and read-only toggling now keep permission-related fields synchronized and aligned with the resolved mode.
* **Tests**
  * Expanded unit coverage for permission-mode resolution and verified spawn payload settings across key flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->