### PR TITLE
test: add isolated Group Chat load demo

### DIFF
--- a/e2e/fixtures/electron-app.ts
+++ b/e2e/fixtures/electron-app.ts
@@ -21,6 +21,7 @@ interface ElectronTestFixtures {
 	window: Page;
 	appPath: string;
 	testDataDir: string;
+	electronLaunchEnv: Record<string, string>;
 }
 
 /**
@@ -68,6 +69,12 @@ export const test = base.extend<ElectronTestFixtures>({
 		}
 	},
 
+	// Optional per-suite environment overrides for the Electron main process
+	// eslint-disable-next-line no-empty-pattern
+	electronLaunchEnv: async ({}, use) => {
+		await use({});
+	},
+
 	// Path to the main entry point
 	// eslint-disable-next-line no-empty-pattern
 	appPath: async ({}, use) => {
@@ -85,13 +92,15 @@ export const test = base.extend<ElectronTestFixtures>({
 	},
 
 	// Launch Electron application
-	electronApp: async ({ appPath, testDataDir }, use) => {
+	electronApp: async ({ appPath, testDataDir, electronLaunchEnv }, use) => {
 		// Launch the Electron app
 		const app = await electron.launch({
 			args: [appPath],
 			env: {
 				...process.env,
-				// Use isolated data directory for tests
+				// Use the app's real demo-mode redirect so every persisted store,
+				// including Group Chats, resolves inside this test directory.
+				MAESTRO_DEMO_DIR: testDataDir,
 				MAESTRO_DATA_DIR: testDataDir,
 				// Disable hardware acceleration for CI
 				ELECTRON_DISABLE_GPU: '1',
@@ -99,6 +108,7 @@ export const test = base.extend<ElectronTestFixtures>({
 				NODE_ENV: 'test',
 				// Ensure we're in a testing context
 				MAESTRO_E2E_TEST: 'true',
+				...electronLaunchEnv,
 			},
 			// Increase timeout for slow CI environments
 			timeout: 30000,

--- a/e2e/group-chat-load-demo.spec.ts
+++ b/e2e/group-chat-load-demo.spec.ts
@@ -1,0 +1,130 @@
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { test as electronTest, expect } from './fixtures/electron-app';
+
+const GROUP_CHAT_ID = '00000000-0000-4000-8000-000000000423';
+const EXPECTED_COUNTS = {
+	groups: 32,
+	sessions: 93,
+	aiTabs: 361,
+	largestGroupSessions: 17,
+	participants: 8,
+	messages: 423,
+};
+
+const test = electronTest.extend({
+	// eslint-disable-next-line no-empty-pattern
+	electronLaunchEnv: async ({}, use) => {
+		await use({ MAESTRO_DISABLE_GROUP_CHAT_PROVIDERS: '1' });
+	},
+	// eslint-disable-next-line no-empty-pattern
+	testDataDir: async ({}, use) => {
+		const runtimeDir = path.join(__dirname, '../artifacts/runtime');
+		fs.mkdirSync(runtimeDir, { recursive: true });
+		const demoDir = fs.mkdtempSync(path.join(runtimeDir, 'maestro-group-chat-load-e2e-'));
+		fs.rmSync(demoDir, { recursive: true, force: true });
+		execFileSync(
+			process.execPath,
+			[path.join(__dirname, '../scripts/group-chat-load-demo.mjs'), '--seed-only', demoDir],
+			{ cwd: path.join(__dirname, '..'), stdio: 'pipe' }
+		);
+		await use(demoDir);
+		fs.rmSync(demoDir, { recursive: true, force: true });
+	},
+});
+
+test('loads the synthetic cardinalities through real stores in an isolated demo', async ({
+	electronApp,
+	window,
+	testDataDir,
+}) => {
+	const userDataPath = await electronApp.evaluate(({ app }) => app.getPath('userData'));
+	expect(path.resolve(userDataPath)).toBe(path.resolve(testDataDir));
+
+	const snapshot = await window.evaluate(async (groupChatId) => {
+		const [groups, sessions, chats, messages] = await Promise.all([
+			window.maestro.groups.getAll(),
+			window.maestro.sessions.getAll(),
+			window.maestro.groupChat.list(),
+			window.maestro.groupChat.getMessages(groupChatId),
+		]);
+		const sessionsPerGroup = new Map(groups.map((group) => [group.id, 0]));
+		for (const session of sessions) {
+			sessionsPerGroup.set(session.groupId, (sessionsPerGroup.get(session.groupId) ?? 0) + 1);
+		}
+		const chat = chats.find((candidate) => candidate.id === groupChatId);
+		return {
+			groups: groups.length,
+			sessions: sessions.length,
+			aiTabs: sessions.reduce((total, session) => total + session.aiTabs.length, 0),
+			largestGroupSessions: Math.max(...sessionsPerGroup.values()),
+			participants: chat?.participants.length ?? 0,
+			messages: messages.length,
+			moderatorAgentId: chat?.moderatorAgentId,
+		};
+	}, GROUP_CHAT_ID);
+
+	expect(snapshot).toEqual({ ...EXPECTED_COUNTS, moderatorAgentId: 'e2e-null-agent' });
+
+	const groupChatItem = window.locator(`[data-nav-key="groupchat:${GROUP_CHAT_ID}"]`);
+	await expect(groupChatItem).toBeVisible({ timeout: 30_000 });
+	await groupChatItem.click();
+
+	const input = window.locator('textarea[placeholder*="Type a message"]');
+	await expect(input).toBeVisible();
+	await window.waitForTimeout(300);
+	const groupChatProviderProcesses = await window.evaluate(async (groupChatId) => {
+		const processes = await window.maestro.process.getActiveProcesses();
+		return processes.filter(
+			(process) => process.toolType === 'e2e-null-agent' || process.sessionId.includes(groupChatId)
+		);
+	}, GROUP_CHAT_ID);
+	expect(groupChatProviderProcesses).toEqual([]);
+	await input.focus();
+	const draft = 'Synthetic manual typing probe';
+	await input.pressSequentially(draft, { delay: 5 });
+	await expect(input).toHaveValue(draft);
+	const disabledSendError = await window.evaluate(async (groupChatId) => {
+		try {
+			await window.maestro.groupChat.sendToModerator(groupChatId, 'Synthetic blocked send');
+			return null;
+		} catch (error) {
+			return String(error);
+		}
+	}, GROUP_CHAT_ID);
+	expect(disabledSendError).toContain('provider processes are disabled');
+	const groupChatProviderProcessesAfterBlockedSend = await window.evaluate(async (groupChatId) => {
+		const processes = await window.maestro.process.getActiveProcesses();
+		return processes.filter(
+			(process) => process.toolType === 'e2e-null-agent' || process.sessionId.includes(groupChatId)
+		);
+	}, GROUP_CHAT_ID);
+	expect(groupChatProviderProcessesAfterBlockedSend).toEqual([]);
+
+	// Move through the real session store and reopen the chat. The draft is
+	// intentionally hot renderer state, so this proves it survives navigation
+	// without requiring a disk write for every keypress.
+	await window.locator('[data-nav-key^="idx:"]').first().click();
+	await expect(input).toBeHidden();
+	await groupChatItem.click();
+	await expect(input).toHaveValue(draft);
+
+	const messageCountAfterTyping = await window.evaluate(
+		async (groupChatId) => (await window.maestro.groupChat.getMessages(groupChatId)).length,
+		GROUP_CHAT_ID
+	);
+	expect(messageCountAfterTyping).toBe(EXPECTED_COUNTS.messages);
+
+	const manifest = JSON.parse(
+		fs.readFileSync(path.join(testDataDir, 'group-chat-load-manifest.json'), 'utf8')
+	);
+	expect(manifest).toMatchObject({
+		kind: 'synthetic-group-chat-load',
+		providerProcessesEnabled: false,
+		counts: EXPECTED_COUNTS,
+	});
+	expect(
+		fs.readFileSync(path.join(testDataDir, 'group-chats', GROUP_CHAT_ID, 'history.jsonl'), 'utf8')
+	).toBe('');
+});

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
 		"dev": "node scripts/dev.mjs",
 		"dev:prod-data": "cross-env USE_PROD_DATA=1 node scripts/dev.mjs",
 		"dev:demo": "node scripts/dev-demo.mjs",
+		"dev:group-chat-load": "node scripts/group-chat-load-demo.mjs",
 		"dev:main": "tsc -p tsconfig.main.json && npm run build:preload && cross-env NODE_ENV=development electron .",
 		"dev:main:prod-data": "tsc -p tsconfig.main.json && npm run build:preload && cross-env NODE_ENV=development USE_PROD_DATA=1 electron .",
 		"dev:renderer": "vite",

--- a/scripts/group-chat-load-demo.mjs
+++ b/scripts/group-chat-load-demo.mjs
@@ -1,0 +1,461 @@
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { findAvailablePort } from './dev-port.mjs';
+
+export const GROUP_CHAT_LOAD_DEMO_ID = '00000000-0000-4000-8000-000000000423';
+export const GROUP_CHAT_LOAD_DEMO_NAME = 'Synthetic Group Chat Load';
+export const GROUP_CHAT_LOAD_DEMO_COUNTS = Object.freeze({
+	groups: 32,
+	sessions: 93,
+	aiTabs: 361,
+	largestGroupSessions: 17,
+	participants: 8,
+	messages: 423,
+});
+
+const SCRIPT_PATH = fileURLToPath(import.meta.url);
+const SCRIPTS_DIR = path.dirname(SCRIPT_PATH);
+const REPO_ROOT = path.dirname(SCRIPTS_DIR);
+const RUNTIME_ROOT = path.join(REPO_ROOT, 'artifacts', 'runtime');
+const NULL_AGENT_ID = 'e2e-null-agent';
+const GROUP_SESSION_COUNTS = [17, ...Array(14).fill(3), ...Array(17).fill(2)];
+const PARTICIPANT_COLORS = [
+	'#60a5fa',
+	'#34d399',
+	'#fbbf24',
+	'#f472b6',
+	'#a78bfa',
+	'#fb7185',
+	'#22d3ee',
+	'#a3e635',
+];
+
+function writeJson(filePath, value) {
+	fs.writeFileSync(filePath, `${JSON.stringify(value, null, '\t')}\n`, 'utf8');
+}
+
+function createTemporaryDemoDir(prefix) {
+	fs.mkdirSync(RUNTIME_ROOT, { recursive: true });
+	return fs.mkdtempSync(path.join(RUNTIME_ROOT, prefix));
+}
+
+function escapeGroupChatContent(content) {
+	return content.replace(/\\/g, '\\\\').replace(/\|/g, '\\|').replace(/\n/g, '\\n');
+}
+
+function createAiTab(sessionIndex, tabIndex, now) {
+	const id = `synthetic-tab-${String(sessionIndex + 1).padStart(3, '0')}-${String(tabIndex + 1).padStart(2, '0')}`;
+	return {
+		id,
+		agentSessionId: null,
+		name: `Synthetic Tab ${String(tabIndex + 1).padStart(2, '0')}`,
+		starred: false,
+		logs: [],
+		inputValue: '',
+		stagedImages: [],
+		createdAt: now + tabIndex,
+		state: 'idle',
+	};
+}
+
+function createSession(demoDir, sessionIndex, groupId, now) {
+	const sessionNumber = String(sessionIndex + 1).padStart(3, '0');
+	const workspace = path.join(demoDir, 'workspaces', `synthetic-session-${sessionNumber}`);
+	fs.mkdirSync(workspace, { recursive: true });
+
+	const tabCount = sessionIndex < 11 ? 3 : 4;
+	const aiTabs = Array.from({ length: tabCount }, (_, tabIndex) =>
+		createAiTab(sessionIndex, tabIndex, now)
+	);
+
+	return {
+		id: `synthetic-session-${sessionNumber}`,
+		groupId,
+		name: `Synthetic Agent ${sessionNumber}`,
+		toolType: NULL_AGENT_ID,
+		state: 'idle',
+		cwd: workspace,
+		fullPath: workspace,
+		projectRoot: workspace,
+		createdAt: now + sessionIndex,
+		updatedAt: now + sessionIndex,
+		aiLogs: [],
+		shellLogs: [],
+		workLog: [],
+		contextUsage: 0,
+		inputMode: 'ai',
+		aiPid: 0,
+		terminalPid: 0,
+		port: 0,
+		isLive: false,
+		changedFiles: [],
+		isGitRepo: false,
+		fileTree: [],
+		fileExplorerExpanded: [],
+		fileExplorerScrollPos: 0,
+		executionQueue: [],
+		activeTimeMs: 0,
+		aiTabs,
+		activeTabId: aiTabs[0].id,
+		closedTabHistory: [],
+		filePreviewTabs: [],
+		activeFileTabId: null,
+		browserTabs: [],
+		activeBrowserTabId: null,
+		terminalTabs: [],
+		activeTerminalTabId: null,
+		unifiedTabOrder: aiTabs.map((tab) => ({ type: 'ai', id: tab.id })),
+		unifiedClosedTabHistory: [],
+		tabGroups: [],
+		activeGroupId: null,
+	};
+}
+
+function createSyntheticMessage(index) {
+	const messageNumber = String(index + 1).padStart(3, '0');
+	let content = `Synthetic load message ${messageNumber}. This deterministic content exercises wrapping, timestamps, markdown, and virtualized scrolling without using production text.`;
+
+	if ((index + 1) % 7 === 0) {
+		content += '\n\n- synthetic state update\n- synthetic verification item';
+	}
+	if ((index + 1) % 19 === 0) {
+		content += `\n\nInline sample: \`synthetic-${messageNumber}\` with a literal pipe | and path C:\\synthetic.`;
+	}
+
+	return content;
+}
+
+function assertEmptyTarget(demoDir) {
+	fs.mkdirSync(demoDir, { recursive: true });
+	const existing = fs.readdirSync(demoDir);
+	if (existing.length > 0) {
+		throw new Error(`Refusing to seed non-empty MAESTRO_DEMO_DIR: ${demoDir}`);
+	}
+}
+
+export function seedGroupChatLoadDemo(demoDir) {
+	const resolvedDemoDir = path.resolve(demoDir);
+	assertEmptyTarget(resolvedDemoDir);
+
+	const now = Date.UTC(2026, 0, 1, 12, 0, 0);
+	const groups = GROUP_SESSION_COUNTS.map((_, groupIndex) => ({
+		id: `synthetic-group-${String(groupIndex + 1).padStart(2, '0')}`,
+		name: `Synthetic Group ${String(groupIndex + 1).padStart(2, '0')}`,
+		emoji: 'G',
+		collapsed: groupIndex !== 0,
+	}));
+
+	const sessions = [];
+	let sessionIndex = 0;
+	for (let groupIndex = 0; groupIndex < groups.length; groupIndex += 1) {
+		for (let memberIndex = 0; memberIndex < GROUP_SESSION_COUNTS[groupIndex]; memberIndex += 1) {
+			sessions.push(createSession(resolvedDemoDir, sessionIndex, groups[groupIndex].id, now));
+			sessionIndex += 1;
+		}
+	}
+
+	writeJson(path.join(resolvedDemoDir, 'maestro-settings.json'), {
+		activeThemeId: 'dracula',
+		groupChatsExpanded: true,
+		suppressWindowsWarning: true,
+	});
+	writeJson(path.join(resolvedDemoDir, 'maestro-groups.json'), { groups });
+	writeJson(path.join(resolvedDemoDir, 'maestro-sessions.json'), {
+		sessions,
+		activeSessionId: sessions[0].id,
+	});
+
+	const groupChatDir = path.join(resolvedDemoDir, 'group-chats', GROUP_CHAT_LOAD_DEMO_ID);
+	const imagesDir = path.join(groupChatDir, 'images');
+	const logPath = path.join(groupChatDir, 'chat.log');
+	fs.mkdirSync(imagesDir, { recursive: true });
+
+	const participants = Array.from(
+		{ length: GROUP_CHAT_LOAD_DEMO_COUNTS.participants },
+		(_, participantIndex) => ({
+			name: `Synthetic Participant ${String(participantIndex + 1).padStart(2, '0')}`,
+			agentId: NULL_AGENT_ID,
+			sessionId: sessions[participantIndex].id,
+			addedAt: now + participantIndex,
+			lastActivity: now + participantIndex,
+			contextUsage: 0,
+			color: PARTICIPANT_COLORS[participantIndex],
+			tokenCount: 0,
+			messageCount: 0,
+			processingTimeMs: 0,
+			totalCost: 0,
+		})
+	);
+
+	writeJson(path.join(groupChatDir, 'metadata.json'), {
+		id: GROUP_CHAT_LOAD_DEMO_ID,
+		name: GROUP_CHAT_LOAD_DEMO_NAME,
+		createdAt: now,
+		updatedAt: now,
+		moderatorAgentId: NULL_AGENT_ID,
+		moderatorSessionId: `group-chat-${GROUP_CHAT_LOAD_DEMO_ID}-moderator-synthetic`,
+		participants,
+		logPath,
+		imagesDir,
+		draftMessage: '',
+		archived: false,
+	});
+
+	const logLines = Array.from(
+		{ length: GROUP_CHAT_LOAD_DEMO_COUNTS.messages },
+		(_, messageIndex) => {
+			const sender =
+				messageIndex % 11 === 0
+					? 'user'
+					: messageIndex % 5 === 0
+						? 'moderator'
+						: participants[messageIndex % participants.length].name;
+			const timestamp = new Date(now + messageIndex * 60_000).toISOString();
+			return `${timestamp}|${sender}|${escapeGroupChatContent(createSyntheticMessage(messageIndex))}`;
+		}
+	);
+	fs.writeFileSync(logPath, `${logLines.join('\n')}\n`, 'utf8');
+	fs.writeFileSync(path.join(groupChatDir, 'history.jsonl'), '', 'utf8');
+
+	const manifest = validateGroupChatLoadDemo(resolvedDemoDir);
+	writeJson(path.join(resolvedDemoDir, 'group-chat-load-manifest.json'), manifest);
+	return manifest;
+}
+
+export function validateGroupChatLoadDemo(demoDir) {
+	const resolvedDemoDir = path.resolve(demoDir);
+	const { groups } = JSON.parse(
+		fs.readFileSync(path.join(resolvedDemoDir, 'maestro-groups.json'), 'utf8')
+	);
+	const { sessions } = JSON.parse(
+		fs.readFileSync(path.join(resolvedDemoDir, 'maestro-sessions.json'), 'utf8')
+	);
+	const metadata = JSON.parse(
+		fs.readFileSync(
+			path.join(resolvedDemoDir, 'group-chats', GROUP_CHAT_LOAD_DEMO_ID, 'metadata.json'),
+			'utf8'
+		)
+	);
+	const messageCount = fs
+		.readFileSync(
+			path.join(resolvedDemoDir, 'group-chats', GROUP_CHAT_LOAD_DEMO_ID, 'chat.log'),
+			'utf8'
+		)
+		.split('\n')
+		.filter(Boolean).length;
+	const sessionsPerGroup = new Map(groups.map((group) => [group.id, 0]));
+	for (const session of sessions) {
+		sessionsPerGroup.set(session.groupId, (sessionsPerGroup.get(session.groupId) ?? 0) + 1);
+	}
+
+	const actual = {
+		groups: groups.length,
+		sessions: sessions.length,
+		aiTabs: sessions.reduce((total, session) => total + session.aiTabs.length, 0),
+		largestGroupSessions: Math.max(...sessionsPerGroup.values()),
+		participants: metadata.participants.length,
+		messages: messageCount,
+	};
+
+	for (const [key, expected] of Object.entries(GROUP_CHAT_LOAD_DEMO_COUNTS)) {
+		if (actual[key] !== expected) {
+			throw new Error(
+				`Invalid synthetic load cardinality for ${key}: ${actual[key]} != ${expected}`
+			);
+		}
+	}
+
+	return {
+		schemaVersion: 1,
+		kind: 'synthetic-group-chat-load',
+		groupChatId: GROUP_CHAT_LOAD_DEMO_ID,
+		groupChatName: GROUP_CHAT_LOAD_DEMO_NAME,
+		providerProcessesEnabled: false,
+		counts: actual,
+	};
+}
+
+function waitForExit(child) {
+	return new Promise((resolve, reject) => {
+		child.once('error', reject);
+		child.once('exit', (code, signal) => resolve({ code: code ?? 0, signal }));
+	});
+}
+
+async function cleanupAfterParent(parentPidValue, demoDir) {
+	const parentPid = Number(parentPidValue);
+	const resolvedDemoDir = path.resolve(demoDir);
+	const isManagedDemoDir =
+		Number.isInteger(parentPid) &&
+		parentPid > 0 &&
+		resolvedDemoDir.startsWith(`${RUNTIME_ROOT}${path.sep}`) &&
+		path.basename(resolvedDemoDir).startsWith('maestro-group-chat-load-');
+	if (!isManagedDemoDir) {
+		throw new Error('Refusing unsafe Group Chat load demo cleanup request');
+	}
+	while (true) {
+		try {
+			process.kill(parentPid, 0);
+		} catch {
+			break;
+		}
+		await new Promise((resolve) => setTimeout(resolve, 500));
+	}
+	await new Promise((resolve) => setTimeout(resolve, 5_000));
+	fs.rmSync(resolvedDemoDir, { recursive: true, force: true });
+}
+
+async function waitForCdp(port, timeoutMs = 30_000) {
+	const startedAt = Date.now();
+	while (Date.now() - startedAt < timeoutMs) {
+		try {
+			const response = await fetch(`http://127.0.0.1:${port}/json/list`);
+			if (response.ok) return;
+		} catch {
+			// Electron has not opened the CDP endpoint yet.
+		}
+		await new Promise((resolve) => setTimeout(resolve, 250));
+	}
+	throw new Error(`Timed out waiting for Electron CDP on port ${port}`);
+}
+
+async function openSeededGroupChat() {
+	const port = process.env.MAESTRO_CDP_PORT;
+	if (!port) throw new Error('MAESTRO_CDP_PORT is required to open the seeded Group Chat');
+	await waitForCdp(port);
+
+	const selector = `[data-nav-key="groupchat:${GROUP_CHAT_LOAD_DEMO_ID}"]`;
+	const actions = [
+		{
+			a: 'eval',
+			expr: `for (let i = 0; i < 300; i += 1) { if (document.querySelector(${JSON.stringify(selector)})) return true; await new Promise((resolve) => setTimeout(resolve, 100)); } throw new Error('Synthetic Group Chat did not appear');`,
+		},
+		{ a: 'sleep', ms: 1_000 },
+		{ a: 'clickSel', sel: selector },
+		{
+			a: 'eval',
+			expr: `for (let i = 0; i < 120; i += 1) { const input = document.querySelector('textarea[placeholder*="Type a message"]'); if (input) return true; await new Promise((resolve) => setTimeout(resolve, 100)); } throw new Error('Group Chat input did not appear');`,
+		},
+		{ a: 'focusSel', sel: 'textarea[placeholder*="Type a message"]' },
+	];
+
+	const driver = spawn(
+		process.execPath,
+		[path.join(SCRIPTS_DIR, 'cdp-drive.mjs'), JSON.stringify(actions)],
+		{
+			cwd: REPO_ROOT,
+			env: process.env,
+			stdio: ['ignore', 'pipe', 'inherit'],
+		}
+	);
+	let driverOutput = '';
+	driver.stdout.setEncoding('utf8');
+	driver.stdout.on('data', (chunk) => {
+		driverOutput += chunk;
+	});
+	const result = await waitForExit(driver);
+	if (result.code !== 0) {
+		throw new Error(`CDP Group Chat opener exited with code ${result.code}`);
+	}
+	const actionResults = JSON.parse(driverOutput);
+	const failedAction = actionResults.find(
+		(action) => action.error || action.value?.error || (action.a === 'focusSel' && !action.rect)
+	);
+	if (failedAction) {
+		throw new Error(`CDP Group Chat opener failed: ${JSON.stringify(failedAction)}`);
+	}
+	console.log(
+		'[group-chat-load-demo] Group Chat visible and input focused. Type manually; do not press Enter.'
+	);
+}
+
+async function launchDemo() {
+	// Always allocate a fresh directory here. Maestro-managed shells can inherit
+	// MAESTRO_DEMO_DIR from the parent app, and reusing it would mix this load
+	// fixture with another running instance.
+	const demoDir = createTemporaryDemoDir('maestro-group-chat-load-');
+	const cleanupDemoDir = () => fs.rmSync(demoDir, { recursive: true, force: true });
+	process.once('exit', cleanupDemoDir);
+	const cdpPort = String(await findAvailablePort(12345, 100));
+	const manifest = seedGroupChatLoadDemo(demoDir);
+	const env = {
+		...process.env,
+		MAESTRO_DEMO_DIR: demoDir,
+		MAESTRO_CDP_PORT: cdpPort,
+		MAESTRO_DISABLE_GROUP_CHAT_PROVIDERS: '1',
+	};
+
+	console.log(`[group-chat-load-demo] MAESTRO_DEMO_DIR=${demoDir}`);
+	console.log(`[group-chat-load-demo] Seeded ${JSON.stringify(manifest.counts)}`);
+	const cleanupWatchdog = spawn(
+		process.execPath,
+		[SCRIPT_PATH, '--cleanup-after', String(process.pid), demoDir],
+		{
+			cwd: REPO_ROOT,
+			detached: true,
+			stdio: 'ignore',
+		}
+	);
+	cleanupWatchdog.unref();
+
+	const opener = spawn(process.execPath, [SCRIPT_PATH, '--open-seeded-chat'], {
+		cwd: REPO_ROOT,
+		env,
+		stdio: 'inherit',
+	});
+	const dev = spawn(process.execPath, [path.join(SCRIPTS_DIR, 'dev.mjs')], {
+		cwd: REPO_ROOT,
+		env,
+		stdio: 'inherit',
+	});
+
+	let shuttingDown = false;
+	let forcedCleanupTimer;
+	let requestedExitCode;
+	const shutdown = (signal) => {
+		if (shuttingDown) return;
+		shuttingDown = true;
+		requestedExitCode = signal === 'SIGINT' ? 130 : 143;
+		cleanupDemoDir();
+		if (opener.exitCode === null) opener.kill(signal);
+		if (dev.exitCode === null) dev.kill(signal);
+		forcedCleanupTimer = setTimeout(() => {
+			cleanupDemoDir();
+			process.exit(requestedExitCode);
+		}, 3_000);
+	};
+	process.once('SIGINT', () => shutdown('SIGINT'));
+	process.once('SIGTERM', () => shutdown('SIGTERM'));
+
+	opener.once('exit', (code) => {
+		if (code && dev.exitCode === null) {
+			console.error(`[group-chat-load-demo] Failed to open the seeded Group Chat (code ${code})`);
+			dev.kill('SIGTERM');
+		}
+	});
+
+	const result = await waitForExit(dev);
+	if (forcedCleanupTimer) clearTimeout(forcedCleanupTimer);
+	await new Promise((resolve) => setTimeout(resolve, 500));
+	cleanupDemoDir();
+	process.exitCode = requestedExitCode ?? result.code;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+	const mode = process.argv[2];
+	if (mode === '--seed-only') {
+		const targetDir = process.argv[3]
+			? path.resolve(process.argv[3])
+			: createTemporaryDemoDir('maestro-group-chat-load-seed-');
+		const manifest = seedGroupChatLoadDemo(targetDir);
+		console.log(JSON.stringify({ demoDir: targetDir, ...manifest }, null, 2));
+	} else if (mode === '--open-seeded-chat') {
+		await openSeededGroupChat();
+	} else if (mode === '--cleanup-after') {
+		await cleanupAfterParent(process.argv[3], process.argv[4]);
+	} else {
+		await launchDemo();
+	}
+}

--- a/src/main/ipc/handlers/groupChat.ts
+++ b/src/main/ipc/handlers/groupChat.ts
@@ -80,6 +80,15 @@ import { captureException } from '../../utils/sentry';
 
 const LOG_CONTEXT = '[GroupChat]';
 
+const areGroupChatProviderProcessesDisabled = (): boolean =>
+	process.env.MAESTRO_DISABLE_GROUP_CHAT_PROVIDERS === '1';
+
+const assertGroupChatProviderProcessesEnabled = (): void => {
+	if (areGroupChatProviderProcessesDisabled()) {
+		throw new Error('Group Chat provider processes are disabled for this load demo');
+	}
+};
+
 /**
  * Moderator usage stats for display in the moderator card.
  */
@@ -209,7 +218,7 @@ export function registerGroupChatHandlers(deps: GroupChatHandlerDependencies): v
 				// Initialize the moderator immediately so it's "hot and ready"
 				// This spawns the session ID prefix so the UI doesn't show "pending"
 				const processManager = getProcessManager();
-				if (processManager) {
+				if (processManager && !areGroupChatProviderProcessesDisabled()) {
 					logger.info(`Initializing moderator for group chat: ${chat.id}`, LOG_CONTEXT);
 					await spawnModerator(chat, processManager);
 					// Reload the chat to get the updated moderatorSessionId
@@ -331,7 +340,7 @@ export function registerGroupChatHandlers(deps: GroupChatHandlerDependencies): v
 					updates.moderatorAgentId && updates.moderatorAgentId !== chat.moderatorAgentId;
 
 				// Kill existing moderator if agent is changing
-				if (moderatorChanged) {
+				if (moderatorChanged && !areGroupChatProviderProcessesDisabled()) {
 					const processManager = getProcessManager();
 					await killModerator(id, processManager ?? undefined);
 				}
@@ -344,7 +353,7 @@ export function registerGroupChatHandlers(deps: GroupChatHandlerDependencies): v
 				});
 
 				// Restart moderator if agent changed
-				if (moderatorChanged) {
+				if (moderatorChanged && !areGroupChatProviderProcessesDisabled()) {
 					const processManager = getProcessManager();
 					if (processManager) {
 						logger.info(
@@ -449,6 +458,10 @@ export function registerGroupChatHandlers(deps: GroupChatHandlerDependencies): v
 			if (!chat) {
 				throw new Error(`Group chat not found: ${id}`);
 			}
+			if (areGroupChatProviderProcessesDisabled()) {
+				logger.info(`Moderator process disabled for group chat load demo: ${id}`, LOG_CONTEXT);
+				return chat.moderatorSessionId || `group-chat-${id}-moderator-disabled`;
+			}
 
 			const processManager = getProcessManager();
 			if (!processManager) {
@@ -468,6 +481,7 @@ export function registerGroupChatHandlers(deps: GroupChatHandlerDependencies): v
 		withIpcErrorLogging(
 			handlerOpts('sendToModerator'),
 			async (id: string, message: string, images?: string[], readOnly?: boolean): Promise<void> => {
+				assertGroupChatProviderProcessesEnabled();
 				logger.info(`[GroupChat:Debug] ========== USER MESSAGE RECEIVED ==========`);
 				logger.info(`[GroupChat:Debug] Group Chat ID: ${id}`);
 				logger.info(
@@ -564,6 +578,7 @@ export function registerGroupChatHandlers(deps: GroupChatHandlerDependencies): v
 		withIpcErrorLogging(
 			handlerOpts('reportAutoRunComplete'),
 			async (groupChatId: string, participantName: string, summary: string): Promise<void> => {
+				assertGroupChatProviderProcessesEnabled();
 				logger.info(
 					`Auto Run complete for participant ${participantName} in ${groupChatId}`,
 					LOG_CONTEXT
@@ -630,6 +645,7 @@ export function registerGroupChatHandlers(deps: GroupChatHandlerDependencies): v
 				agentId: string,
 				cwd?: string
 			): Promise<GroupChatParticipant> => {
+				assertGroupChatProviderProcessesEnabled();
 				const processManager = getProcessManager();
 				if (!processManager) {
 					throw new Error('Process manager not initialized');
@@ -662,6 +678,7 @@ export function registerGroupChatHandlers(deps: GroupChatHandlerDependencies): v
 		withIpcErrorLogging(
 			handlerOpts('sendToParticipant'),
 			async (id: string, name: string, message: string, images?: string[]): Promise<void> => {
+				assertGroupChatProviderProcessesEnabled();
 				const processManager = getProcessManager();
 				await sendToParticipant(id, name, message, processManager ?? undefined);
 
@@ -714,6 +731,7 @@ export function registerGroupChatHandlers(deps: GroupChatHandlerDependencies): v
 				participantName: string,
 				cwd?: string
 			): Promise<{ newAgentSessionId: string }> => {
+				assertGroupChatProviderProcessesEnabled();
 				logger.info(
 					`Resetting context for participant ${participantName} in ${groupChatId}`,
 					LOG_CONTEXT


### PR DESCRIPTION
## Summary

Adds a deterministic Group Chat load demo that exercises the real Maestro stores and Electron UI with synthetic, isolated data.

The scenario contains:

- 32 groups
- 93 sessions
- 361 AI tabs
- 8 Group Chat participants
- 423 messages

## Isolation and safety

- All data is synthetic and contains no production chat content, credentials, or user history.
- The demo runs in a temporary MAESTRO_DEMO_DIR and cleans it up after the run.
- Group Chat provider processes are explicitly disabled for this scenario.
- The E2E test verifies that no provider process starts and that attempted sends are blocked.

## Validation

- Prettier check passed for all changed files.
- Targeted ESLint passed with no errors.
- Main, preload, and renderer builds passed.
- Group Chat IPC handler unit tests passed: 57/57.
- Targeted Electron E2E passed: 1/1.
- The repository pre-push validation hook completed successfully before the branch was pushed.

## Scope

This PR contains only the isolated load-demo change cherry-picked from commit 374d77190. It does not include the older browser bootstrap or mobile composer commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a synthetic Group Chat load demo that creates deterministic sample groups, sessions, participants, tabs, and messages.
  - Added commands to seed, validate, launch, and clean up the demo environment.
  - Added an option to open a seeded Group Chat directly in the app.

- **Improvements**
  - Added support for running Group Chat scenarios without provider processes.
  - Improved isolation of Electron demo and test data between runs.

- **Tests**
  - Added end-to-end coverage for data counts, disabled provider behavior, message handling, and draft persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->