### PR TITLE
fix(sentry): drop `write EPIPE` noise, guard stats writes against startup race

### DIFF
--- a/src/__tests__/main/ipc/handlers/stats.test.ts
+++ b/src/__tests__/main/ipc/handlers/stats.test.ts
@@ -527,6 +527,20 @@ describe('stats IPC handlers', () => {
 				expect(mockStatsDB.recordSessionCreated).toHaveBeenCalled();
 				expect(mockMainWindow.webContents.send).not.toHaveBeenCalled();
 			});
+
+			it('should skip silently when the stats DB is not yet initialized', async () => {
+				vi.mocked(mockStatsDB.isReady!).mockReturnValue(false);
+				const handler = handlers.get('stats:record-session-created');
+
+				const result = await handler!({} as any, {
+					sessionId: 'session-1',
+					agentType: 'claude-code',
+					createdAt: Date.now(),
+				});
+
+				expect(result).toBeNull();
+				expect(mockStatsDB.recordSessionCreated).not.toHaveBeenCalled();
+			});
 		});
 
 		describe('stats:record-session-closed', () => {
@@ -541,6 +555,16 @@ describe('stats IPC handlers', () => {
 				expect(mockStatsDB.recordSessionClosed).toHaveBeenCalledWith(sessionId, closedAt);
 				expect(mockMainWindow.webContents.send).toHaveBeenCalledWith('stats:updated');
 				expect(mockMainWindow.webContents.send).toHaveBeenCalledTimes(1);
+			});
+
+			it('should skip silently when the stats DB is not yet initialized', async () => {
+				vi.mocked(mockStatsDB.isReady!).mockReturnValue(false);
+				const handler = handlers.get('stats:record-session-closed');
+
+				const result = await handler!({} as any, 'session-1', Date.now());
+
+				expect(result).toBe(false);
+				expect(mockStatsDB.recordSessionClosed).not.toHaveBeenCalled();
 			});
 
 			it('should broadcast stats:updated even when session not found', async () => {

--- a/src/__tests__/shared/sentryFilters.test.ts
+++ b/src/__tests__/shared/sentryFilters.test.ts
@@ -30,6 +30,17 @@ describe('shouldDropSentryEvent', () => {
 			);
 		});
 
+		// The libuv `EPIPE: broken pipe` spelling above is not what Node emits for a
+		// stream/socket write to a dead pipe - that surfaces as a bare `write EPIPE`,
+		// which slipped past the filter and was the single noisiest issue in the field.
+		it('drops bare `write EPIPE` stream errors (Node stream spelling)', () => {
+			expect(shouldDropSentryEvent(exceptionEvent('Error', 'write EPIPE'))).toBe(true);
+		});
+
+		it('drops bare `read EPIPE` stream errors', () => {
+			expect(shouldDropSentryEvent(exceptionEvent('Error', 'read EPIPE'))).toBe(true);
+		});
+
 		it('drops Windows rename races (EPERM rename)', () => {
 			expect(
 				shouldDropSentryEvent(
@@ -100,12 +111,36 @@ describe('shouldDropSentryEvent', () => {
 			).toBe(true);
 		});
 
+		it('drops EACCES on the sessions file bubbling up through sessions:setMany', () => {
+			expect(
+				shouldDropSentryEvent(
+					exceptionEvent(
+						'Error',
+						"Error invoking remote method 'sessions:setMany': Error: EACCES: permission denied, open '/Users/x/Library/Application Support/maestro/maestro-sessions.json'"
+					)
+				)
+			).toBe(true);
+		});
+
 		it('does NOT drop a generic IPC failure that is not a known noise pattern', () => {
 			expect(
 				shouldDropSentryEvent(
 					exceptionEvent(
 						'Error',
 						"Error invoking remote method 'sessions:create': TypeError: Cannot read properties of undefined (reading 'name')"
+					)
+				)
+			).toBe(false);
+		});
+
+		// A write failure that is *not* an environment/permissions problem still needs to
+		// reach us - the EACCES carve-out above must not swallow real persistence bugs.
+		it('does NOT drop a non-environment failure on the same sessions:setMany method', () => {
+			expect(
+				shouldDropSentryEvent(
+					exceptionEvent(
+						'Error',
+						"Error invoking remote method 'sessions:setMany': TypeError: sessions.map is not a function"
 					)
 				)
 			).toBe(false);

--- a/src/main/ipc/handlers/stats.ts
+++ b/src/main/ipc/handlers/stats.ts
@@ -312,6 +312,14 @@ export function registerStatsHandlers(deps: StatsHandlerDependencies): void {
 				}
 
 				const db = getStatsDB();
+				// Fire-and-forget analytics: an agent can be created (restored on boot,
+				// spawned by the wizard) before the stats DB has finished initializing.
+				// Skip that window rather than throwing "Database not initialized", an
+				// unactionable error that otherwise crosses the IPC bridge into Sentry.
+				// (MAESTRO-2S, same startup race as MAESTRO-SP below.)
+				if (!db.isReady()) {
+					return null;
+				}
 				const id = db.recordSessionCreated(event);
 				logger.debug(`Recorded session created: ${event.sessionId}`, LOG_CONTEXT, {
 					agentType: event.agentType,
@@ -330,6 +338,12 @@ export function registerStatsHandlers(deps: StatsHandlerDependencies): void {
 			handlerOpts('recordSessionClosed'),
 			async (sessionId: string, closedAt: number) => {
 				const db = getStatsDB();
+				// Same fire-and-forget startup race as record-session-created: agents torn
+				// down during early boot would otherwise throw "Database not initialized".
+				// (MAESTRO-2Z)
+				if (!db.isReady()) {
+					return false;
+				}
 				const updated = db.recordSessionClosed(sessionId, closedAt);
 				if (updated) {
 					logger.debug(`Recorded session closed: ${sessionId}`, LOG_CONTEXT);

--- a/src/shared/sentryFilters.ts
+++ b/src/shared/sentryFilters.ts
@@ -40,7 +40,12 @@ export function shouldDropSentryEvent(event: MinimalSentryEvent): boolean {
 	if (/ENOSPC: no space left on device/i.test(haystack)) return true;
 
 	// Broken pipe writing to a closed stdout/stderr (process torn down underneath us).
+	// Two message shapes reach us: libuv fs-style writes surface as `EPIPE: broken pipe`,
+	// while Node stream/socket writes (console.* into a stdout pipe whose reader already
+	// exited) surface as `write EPIPE`. Both are the same unfixable teardown race, so
+	// match both - the stream form is by far the more common one in the field.
 	if (/EPIPE: broken pipe/i.test(haystack)) return true;
+	if (/\b(write|read) EPIPE\b/i.test(haystack)) return true;
 
 	// Windows rename races with antivirus / OneDrive holding the tmp file open.
 	if (/EPERM: operation not permitted, rename /i.test(haystack)) return true;
@@ -80,13 +85,17 @@ export function shouldDropSentryEvent(event: MinimalSentryEvent): boolean {
 		if (/Path does not exist:/i.test(haystack)) return true;
 	}
 
-	// ENOSPC / EPERM rename bubbling up through settings / sessions writes (same as
-	// rule 1 but the IPC wrapper changes the message prefix).
+	// ENOSPC / EPERM / EACCES bubbling up through settings / sessions writes (same as
+	// rule 1 but the IPC wrapper changes the message prefix). EACCES means the userData
+	// file itself is not writable (broken permissions, security software holding it);
+	// the persistence layer already degrades to a recoverable disk error the user sees,
+	// and no code change on our side can grant the process write access.
 	if (
-		/Error invoking remote method '(settings:set|sessions:setActiveSessionId|history:add|settings:get)'/.test(
+		/Error invoking remote method '(settings:set|sessions:setActiveSessionId|sessions:setMany|sessions:setAll|history:add|settings:get)'/.test(
 			haystack
 		) &&
 		(/ENOSPC: no space left on device/i.test(haystack) ||
+			/EACCES: permission denied/i.test(haystack) ||
 			/EPERM: operation not permitted, rename /i.test(haystack))
 	) {
 		return true;


### PR DESCRIPTION
Sentry triage for the **stable channel (`main`)**. Each issue below was confirmed via a per-issue channel/release breakdown (`search_events ... fields:[channel,release,count()]`) to be live on stable 0.17.2/0.17.3, not rc-only.

## MAESTRO-1G - `Error: write EPIPE` (the big one)

4,645 occurrences all-time, still ingesting today (31 events on 0.17.3, 26 on 0.17.2).

`shouldDropSentryEvent` already *intended* to drop broken-pipe noise, but the rule only matched the libuv fs-style spelling `EPIPE: broken pipe`. Node emits a bare **`write EPIPE`** for a stream/socket write to a dead pipe - in the field this is `console.*` writing into a stdout pipe whose reader already exited (`afterWriteDispatched(stream_base_commons)`). So the rule never fired.

The existing unit test asserted `'EPIPE: broken pipe, write'` - a message shape Node never actually produces - which is exactly why the gap survived review. Now we match both spellings and pin the real field message with a test.

The issue is already `archived_forever` in Sentry, confirming the team's intent is to drop it; it was still being ingested regardless.

## MAESTRO-2S / MAESTRO-2Z - stats "Database not initialized"

`stats:record-session-created` and `stats:record-session-closed` throw `Database not initialized` when an agent is created or torn down before the stats DB finishes initializing (restore-on-boot, wizard-spawned agents).

Both are fire-and-forget analytics - the renderer call sites (`useSessionCrud.ts`, `useSessionLifecycle.ts`) ignore the return value and don't even await the promise - so skipping the write in that startup window is safe. This mirrors the `db.isReady()` guard already shipped for `stats:record-shortcut-usage` (MAESTRO-SP) and used in `stats-listener.ts`.

## MAESTRO-V5 - `sessions:setMany` EACCES

`EACCES: permission denied, open '.../maestro-sessions.json'`. The userData file not being writable is an environment/permissions problem (broken perms, security software) that no code change can fix, and the persistence layer already degrades to a user-visible "recoverable disk error". Extends the existing ENOSPC/EPERM IPC-write rule to cover `EACCES` and the `sessions:setMany`/`sessions:setAll` methods.

A companion test asserts a *genuine* persistence bug on the same method (a `TypeError`) still reports, so the carve-out can't swallow real failures.

## Investigated and deliberately NOT fixed

- **MAESTRO-RE** (`ENOENT ... Resources/prompts/bmad/*.md`, 99 events, stable-only). Looked like a packaging bug, but it is **not**. I read the central directory of the actually-shipped v0.17.3 mac artifacts (both arm64 and x64) over HTTP range requests: all 33 `bmad.*.md` files are present at exactly the path the code reads. The 99 events are 33 commands x 3 invocations, i.e. one user whose `Resources/prompts/bmad` is missing - a broken/partial install, not a code defect. No speculative fix shipped. Worth noting `getBundledPrompts()` fires one `captureException` **per missing file**, so a single broken install amplifies into 33 events per invocation; aggregating that into one report is a reasonable follow-up but is noise hygiene, not a crash fix.
- **MAESTRO-T5** (`read ENOTCONN`) - stack is 100% Node internals (`execFile` -> `spawn` -> `createSocket`), zero app frames. No obvious fix.
- **MAESTRO-QB / MAESTRO-VM** (marketplace) - VM already matches an existing filter rule; QB's 404 is arguably real signal about the marketplace repo. Left alone.
- **MAESTRO-RS** (GLIBC_2.38 / better-sqlite3, 103 events) - Linux build/CI glibc target, needs a human decision.
- Native/GPU/renderer crashes (SG, 5A, 1F, 62, 2C, 23, 38, V1/V2, Y) - unchanged.

## Testing

- `src/__tests__/shared/sentryFilters.test.ts` - 3 new tests (bare `write EPIPE`, `read EPIPE`, EACCES-through-`sessions:setMany`) + a negative test.
- `src/__tests__/main/ipc/handlers/stats.test.ts` - 2 new tests (both lifecycle handlers skip when `isReady()` is false).
- All 54 tests in the two suites pass. Verified the new filter tests genuinely fail against the old regexes (not tautological).
- Typecheck: 112 pre-existing errors repo-wide (missing `@codemirror/lang-*` optional deps), identical count on clean `main`; **zero** in the changed files. ESLint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented session statistics actions from failing during early startup when the statistics database is not yet ready.
  - Reduced unnecessary error reporting for expected broken-pipe and permission-related IPC failures.
  - Preserved reporting for unrelated session errors.

- **Tests**
  - Added coverage for unavailable statistics storage and expanded error-filtering scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->