### PR TITLE
fix(sentry): stop paging on expected batch-JSON, marketplace, scan, and startup-stats conditions

### DIFF
--- a/src/__tests__/main/ipc/handlers/git.test.ts
+++ b/src/__tests__/main/ipc/handlers/git.test.ts
@@ -9,6 +9,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ipcMain } from 'electron';
 import { registerGitHandlers } from '../../../../main/ipc/handlers/git';
 import * as execFile from '../../../../main/utils/execFile';
+import { captureException } from '../../../../main/utils/sentry';
 import path from 'path';
 
 // Mock electron's ipcMain
@@ -140,6 +141,11 @@ vi.mock('child_process', () => {
 	// Also expose as default for modules that import via CJS interop
 	return { ...mock, default: mock };
 });
+
+vi.mock('../../../../main/utils/sentry', () => ({
+	captureException: vi.fn(),
+	captureMessage: vi.fn(),
+}));
 
 describe('Git IPC handlers', () => {
 	let handlers: Map<string, Function>;
@@ -4061,6 +4067,39 @@ branch refs/heads/bugfix-123
 				gitSubdirs: [],
 				scanFailed: true,
 			});
+		});
+
+		// Regression (MAESTRO-VQ): the parent path is user-supplied and can sit
+		// behind macOS TCC (Documents, Desktop) or simply carry permissions we
+		// don't hold, so readdir rejects with EPERM/EACCES. The renderer still
+		// needs scanFailed, but there is no bug of ours to report.
+		it.each(['EPERM', 'EACCES'])(
+			'reports scanFailed without a Sentry report when readdir fails with %s',
+			async (code) => {
+				vi.mocked(mockFs.readdir).mockRejectedValue(
+					Object.assign(new Error(`${code}: operation not permitted, scandir '/protected'`), {
+						code,
+					})
+				);
+
+				const handler = handlers.get('git:scanWorktreeDirectory');
+				const result = await handler!({} as any, '/protected');
+
+				expect(result).toEqual({ success: true, gitSubdirs: [], scanFailed: true });
+				expect(captureException).not.toHaveBeenCalled();
+			}
+		);
+
+		it('still reports an unexpected scan failure to Sentry', async () => {
+			vi.mocked(mockFs.readdir).mockRejectedValue(
+				Object.assign(new Error('EIO: i/o error, scandir'), { code: 'EIO' })
+			);
+
+			const handler = handlers.get('git:scanWorktreeDirectory');
+			const result = await handler!({} as any, '/failing/disk');
+
+			expect(result).toEqual({ success: true, gitSubdirs: [], scanFailed: true });
+			expect(captureException).toHaveBeenCalled();
 		});
 
 		it('should handle null branch when git branch command fails', async () => {

--- a/src/__tests__/main/ipc/handlers/stats.test.ts
+++ b/src/__tests__/main/ipc/handlers/stats.test.ts
@@ -578,6 +578,20 @@ describe('stats IPC handlers', () => {
 				expect(mockStatsDB.recordSessionCreated).toHaveBeenCalled();
 				expect(mockMainWindow.webContents.send).not.toHaveBeenCalled();
 			});
+
+			it('should skip silently when the stats DB is not yet initialized', async () => {
+				vi.mocked(mockStatsDB.isReady!).mockReturnValue(false);
+				const handler = handlers.get('stats:record-session-created');
+
+				const result = await handler!({} as any, {
+					sessionId: 'session-1',
+					agentType: 'claude-code',
+					createdAt: Date.now(),
+				});
+
+				expect(result).toBeNull();
+				expect(mockStatsDB.recordSessionCreated).not.toHaveBeenCalled();
+			});
 		});
 
 		describe('stats:record-session-closed', () => {
@@ -592,6 +606,16 @@ describe('stats IPC handlers', () => {
 				expect(mockStatsDB.recordSessionClosed).toHaveBeenCalledWith(sessionId, closedAt);
 				expect(mockMainWindow.webContents.send).toHaveBeenCalledWith('stats:updated');
 				expect(mockMainWindow.webContents.send).toHaveBeenCalledTimes(1);
+			});
+
+			it('should skip silently when the stats DB is not yet initialized', async () => {
+				vi.mocked(mockStatsDB.isReady!).mockReturnValue(false);
+				const handler = handlers.get('stats:record-session-closed');
+
+				const result = await handler!({} as any, 'session-1', Date.now());
+
+				expect(result).toBe(false);
+				expect(mockStatsDB.recordSessionClosed).not.toHaveBeenCalled();
 			});
 
 			it('should broadcast stats:updated even when session not found', async () => {

--- a/src/__tests__/main/process-manager/handlers/ExitHandler.test.ts
+++ b/src/__tests__/main/process-manager/handlers/ExitHandler.test.ts
@@ -40,6 +40,10 @@ vi.mock('../../../../main/process-manager/utils/imageUtils', () => ({
 	cleanupTempFiles: vi.fn(),
 }));
 
+vi.mock('../../../../main/utils/sentry', () => ({
+	captureException: vi.fn(),
+}));
+
 // SSH config resolution: real getters require initialized stores, which don't
 // exist in unit tests. Mock so each test controls whether the remote resolves.
 vi.mock('../../../../main/stores/getters', () => ({
@@ -57,6 +61,7 @@ vi.mock('../../../../main/utils/remote-fs', () => ({
 
 import { ExitHandler } from '../../../../main/process-manager/handlers/ExitHandler';
 import { DataBufferManager } from '../../../../main/process-manager/handlers/DataBufferManager';
+import { captureException } from '../../../../main/utils/sentry';
 import { matchSshErrorPattern } from '../../../../main/parsers/error-patterns';
 import { getSshRemoteById } from '../../../../main/stores/getters';
 import { readFileRemote, readFileTailRemote } from '../../../../main/utils/remote-fs';
@@ -224,6 +229,57 @@ describe('ExitHandler', () => {
 			await exitHandler.handleExit('test-session', 0);
 
 			expect(dataEvents).toContain(invalidJson);
+		});
+
+		// Regression (MAESTRO-V9): in plain batch mode the whole jsonBuffer is
+		// JSON.parse'd at exit. Agents that ignore the JSON output flag answer with
+		// prose or a box-drawing TUI frame instead, which threw a SyntaxError that
+		// we reported to Sentry on every occurrence — even though the raw-buffer
+		// fallback below already recovers the output for the user.
+		describe('batch mode exit with non-JSON output', () => {
+			beforeEach(() => {
+				vi.mocked(captureException).mockClear();
+			});
+
+			it.each([
+				['plain prose', "Hello. I'm Claude, an AI assistant."],
+				['a box-drawing TUI frame', '┌────────────┐\n│ review doc │\n└────────────┘'],
+			])('emits %s as raw data without reporting to Sentry', async (_label, output) => {
+				const proc = createMockProcess({
+					isBatchMode: true,
+					isStreamJsonMode: false,
+					jsonBuffer: output,
+				});
+				processes.set('test-session', proc);
+
+				const dataEvents: string[] = [];
+				emitter.on('data', (_sid: string, data: string) => dataEvents.push(data));
+
+				await exitHandler.handleExit('test-session', 0);
+
+				expect(dataEvents).toContain(output);
+				expect(captureException).not.toHaveBeenCalled();
+			});
+
+			it('still reports a non-SyntaxError fault raised while handling valid JSON', async () => {
+				// A genuine bug downstream of the parse (here: a throwing usage
+				// aggregator) must keep reaching Sentry — only SyntaxError is expected.
+				const { aggregateModelUsage } = await import('../../../../main/parsers/usage-aggregator');
+				vi.mocked(aggregateModelUsage).mockImplementationOnce(() => {
+					throw new TypeError('usage aggregation blew up');
+				});
+
+				const proc = createMockProcess({
+					isBatchMode: true,
+					isStreamJsonMode: false,
+					jsonBuffer: '{"result":"done","total_cost_usd":0.01}',
+				});
+				processes.set('test-session', proc);
+
+				await exitHandler.handleExit('test-session', 0);
+
+				expect(captureException).toHaveBeenCalledWith(expect.any(TypeError));
+			});
 		});
 
 		it('should use streamedText as fallback when result event has no text', async () => {

--- a/src/__tests__/shared/sentryFilters.test.ts
+++ b/src/__tests__/shared/sentryFilters.test.ts
@@ -160,6 +160,47 @@ describe('shouldDropSentryEvent', () => {
 			).toBe(true);
 		});
 
+		// Regression (MAESTRO-MR): MarketplaceFetchError carries the original failure
+		// as its `cause`, so Sentry's LinkedErrors integration ships TWO exception
+		// values ordered root-cause-first. The classifier used to read values[0]
+		// only, saw the bare `TypeError: fetch failed`, and let the event through —
+		// the rule above looked correct but never fired in the field.
+		it('drops marketplace fetch failures when Sentry expanded the cause chain', () => {
+			expect(
+				shouldDropSentryEvent({
+					exception: {
+						values: [
+							{ type: 'TypeError', value: 'fetch failed' },
+							{
+								type: 'MarketplaceFetchError',
+								value: 'Network error fetching document: fetch failed',
+							},
+						],
+					},
+				})
+			).toBe(true);
+		});
+
+		// Regression (MAESTRO-TY): GitHub raw rate-limits playbook imports.
+		it('drops marketplace fetches rejected by GitHub rate limiting or a 5xx', () => {
+			expect(
+				shouldDropSentryEvent(
+					exceptionEvent('MarketplaceFetchError', 'Failed to fetch document: 429 Too Many Requests')
+				)
+			).toBe(true);
+			expect(
+				shouldDropSentryEvent(
+					exceptionEvent('MarketplaceFetchError', 'Failed to fetch asset: 503 Service Unavailable')
+				)
+			).toBe(true);
+		});
+
+		it('does NOT drop a marketplace document that is genuinely missing', () => {
+			expect(
+				shouldDropSentryEvent(exceptionEvent('MarketplaceFetchError', 'Document not found: setup'))
+			).toBe(false);
+		});
+
 		it('drops GitHub CLI network failures when the user is offline', () => {
 			expect(
 				shouldDropSentryEvent(

--- a/src/main/ipc/handlers/git.ts
+++ b/src/main/ipc/handlers/git.ts
@@ -40,6 +40,19 @@ import { markStaleForDeletedWorktreeUsingStore } from '../../agent-run/worktree-
 const LOG_CONTEXT = '[Git]';
 
 /**
+ * Directory-scan failures that are environmental rather than bugs: the path was
+ * moved or deleted out from under us (ENOENT/ENOTDIR), or we don't hold read
+ * permission on it (EACCES, or EPERM for macOS TCC-protected locations like
+ * Documents and Desktop). The scan skips the directory and reports `scanFailed`;
+ * none of these are worth a Sentry report.
+ */
+const EXPECTED_SCAN_ERROR_CODES = new Set(['ENOENT', 'ENOTDIR', 'EACCES', 'EPERM']);
+
+function isExpectedScanError(code: string | undefined): boolean {
+	return code !== undefined && EXPECTED_SCAN_ERROR_CODES.has(code);
+}
+
+/**
  * Dependencies for Git handlers
  */
 export interface GitHandlerDependencies {
@@ -1370,7 +1383,7 @@ export function registerGitHandlers(deps: GitHandlerDependencies): void {
 									return await scanLevel(subdirPath, depthRemaining - 1);
 								} catch (err) {
 									const code = (err as NodeJS.ErrnoException | undefined)?.code;
-									if (code !== 'ENOENT' && code !== 'EACCES' && code !== 'ENOTDIR') {
+									if (!isExpectedScanError(code)) {
 										logger.warn(`${LOG_CONTEXT} Failed to recurse into ${subdirPath}: ${err}`);
 									}
 									return [];
@@ -1387,10 +1400,13 @@ export function registerGitHandlers(deps: GitHandlerDependencies): void {
 					const gitSubdirs = await scanLevel(parentPath, MAX_DEPTH);
 					return { gitSubdirs };
 				} catch (err) {
-					// ENOENT is expected when the configured parent path has been moved
-					// or deleted from disk — surface to logs but don't pollute Sentry.
+					// The configured parent path is user-supplied, so failing to read it is
+					// an environment condition rather than a bug: ENOENT when it's been moved
+					// or deleted, and EPERM/EACCES when it sits behind macOS TCC (Documents,
+					// Desktop) or has permissions we simply don't hold. Both surface to logs
+					// and to `scanFailed` below; neither should pollute Sentry. (MAESTRO-VQ)
 					const code = (err as NodeJS.ErrnoException | undefined)?.code;
-					if (code !== 'ENOENT') {
+					if (!isExpectedScanError(code)) {
 						void captureException(err);
 					}
 					logger.error(`Failed to scan directory ${parentPath}: ${err}`, LOG_CONTEXT);

--- a/src/main/ipc/handlers/stats.ts
+++ b/src/main/ipc/handlers/stats.ts
@@ -302,6 +302,14 @@ export function registerStatsHandlers(deps: StatsHandlerDependencies): void {
 				}
 
 				const db = getStatsDB();
+				// Fire-and-forget analytics: an agent can be created (restored on boot,
+				// spawned by the wizard) before the stats DB has finished initializing.
+				// Skip that window rather than throwing "Database not initialized", an
+				// unactionable error that otherwise crosses the IPC bridge into Sentry.
+				// (MAESTRO-2S, same startup race as MAESTRO-SP below.)
+				if (!db.isReady()) {
+					return null;
+				}
 				const id = db.recordSessionCreated(event);
 				logger.debug(`Recorded session created: ${event.sessionId}`, LOG_CONTEXT, {
 					agentType: event.agentType,
@@ -320,6 +328,12 @@ export function registerStatsHandlers(deps: StatsHandlerDependencies): void {
 			handlerOpts('recordSessionClosed'),
 			async (sessionId: string, closedAt: number) => {
 				const db = getStatsDB();
+				// Same fire-and-forget startup race as record-session-created: agents torn
+				// down during early boot would otherwise throw "Database not initialized".
+				// (MAESTRO-2Z)
+				if (!db.isReady()) {
+					return false;
+				}
 				const updated = db.recordSessionClosed(sessionId, closedAt);
 				if (updated) {
 					logger.debug(`Recorded session closed: ${sessionId}`, LOG_CONTEXT);

--- a/src/main/process-manager/handlers/ExitHandler.ts
+++ b/src/main/process-manager/handlers/ExitHandler.ts
@@ -396,8 +396,17 @@ export class ExitHandler {
 				this.emitter.emit('usage', sessionId, usageStats);
 			}
 		} catch (error) {
-			void captureException(error);
-			logger.error('[ProcessManager] Failed to parse JSON response', 'ProcessManager', {
+			// A SyntaxError here just means the agent didn't answer with JSON: in
+			// batch mode some agents fall back to plain prose ("Hello. I'm ...") or
+			// emit a TUI frame with box-drawing characters when they can't honor
+			// the JSON output flag. That's an expected shape we already recover
+			// from by emitting the raw buffer below, so it isn't worth a Sentry
+			// report. Anything else thrown out of the block above (a real fault in
+			// aggregateModelUsage or an emit handler) still gets captured. (MAESTRO-V9)
+			if (!(error instanceof SyntaxError)) {
+				void captureException(error);
+			}
+			logger.warn('[ProcessManager] Failed to parse JSON response', 'ProcessManager', {
 				sessionId,
 				error: String(error),
 			});

--- a/src/shared/sentryFilters.ts
+++ b/src/shared/sentryFilters.ts
@@ -28,11 +28,18 @@ interface MinimalSentryEvent {
  * (OS env issues, native crashes, user-typed bad paths, third-party JS injection).
  */
 export function shouldDropSentryEvent(event: MinimalSentryEvent): boolean {
-	const firstException = event.exception?.values?.[0];
+	const values = event.exception?.values ?? [];
+	const firstException = values[0];
 	const value = firstException?.value ?? '';
 	const type = firstException?.type ?? '';
 	const message = event.message ?? '';
-	const haystack = `${type}: ${value}\n${message}`;
+	// Match against EVERY exception in the chain, not just values[0]. Sentry's
+	// LinkedErrors integration expands an Error's `cause` into extra entries and
+	// orders them root-cause-first, so when we wrap a low-level failure the
+	// wrapper we actually named a rule after lands at the END of the array. That
+	// made the MarketplaceFetchError rule in section 5 dead on arrival: it only
+	// ever saw the underlying `TypeError: fetch failed` at values[0]. (MAESTRO-MR)
+	const haystack = [...values.map((v) => `${v.type ?? ''}: ${v.value ?? ''}`), message].join('\n');
 
 	// ---- 1. OS / filesystem environment ----
 
@@ -130,6 +137,11 @@ export function shouldDropSentryEvent(event: MinimalSentryEvent): boolean {
 	// ---- 5. Network failures (user offline) ----
 
 	if (/MarketplaceFetchError: Network error fetching .*: fetch failed/i.test(haystack)) return true;
+
+	// GitHub raw rate-limits us (429) and serves 5xx during its own incidents.
+	// The import still fails visibly in the UI; there's nothing to fix on our
+	// side, and a 404 is raised as a distinct "not found" error. (MAESTRO-TY)
+	if (/MarketplaceFetchError: Failed to fetch [^:]+: (429|5\d\d) /i.test(haystack)) return true;
 	if (
 		/error connecting to api\.github\.com/i.test(haystack) ||
 		/check your internet connection/i.test(haystack) ||


### PR DESCRIPTION
Sentry triage scoped to the `rc` channel (releases 0.18.3-RC through 0.18.5-RC; current `rc` is 0.18.5-RC). Every issue below was confirmed `channel:rc` and validated against the code before anything was touched.

Four are the familiar "telemetry noise on an expected condition" family. One (MAESTRO-MR) turned out to be a genuine bug in the noise filter itself.

## Fixed

### MAESTRO-V9 - `SyntaxError: ... is not valid JSON` (54 events, still firing)
`ExitHandler.handleBatchModeExit` runs `JSON.parse` over the entire `jsonBuffer` at process exit. Agents that ignore the JSON output flag answer with prose (`"Hello. I'm ..."`) or a box-drawing TUI frame (`┌`, `┊`), which throws a `SyntaxError`. The code already recovers by emitting the raw buffer, so the `captureException` was pure noise on a path we handle.

Now only non-`SyntaxError` throws are reported, so a real fault in `aggregateModelUsage` or an emit handler still surfaces.

### MAESTRO-MR - marketplace `fetch failed` (10 events) - filter bug
`shouldDropSentryEvent` only ever inspected `exception.values[0]`. `MarketplaceFetchError` takes the underlying failure as its `cause`, so Sentry's LinkedErrors integration expands it into **two** exception values ordered root-cause-first. The classifier therefore saw a bare `TypeError: fetch failed` and never matched the `MarketplaceFetchError: Network error fetching ...` rule written for precisely this event.

That rule shipped in v0.16.17-RC (2026-05-12) and has been dead ever since; field events kept flowing through 2026-07-04. The classifier now matches against every exception in the chain, which also makes the other rules cause-chain aware.

Worth calling out: the existing unit test passed the whole time because it constructed a single-value event, which is not the shape Sentry actually sends. The new test uses the real two-value shape.

### MAESTRO-TY - marketplace `429 Too Many Requests` (10 events)
GitHub raw rate-limits playbook imports and serves 5xx during its own incidents. The import still fails visibly in the UI; there is nothing to fix on our side. A 404 is raised as a distinct "not found" error and keeps reporting.

### MAESTRO-VQ - `EPERM: operation not permitted, scandir` (6 events, new)
The worktree directory scan quieted only `ENOENT`, so a user-configured parent path behind macOS TCC (Documents, Desktop) rejected `readdir` with `EPERM` and paged. The renderer still gets `scanFailed`, so behavior is unchanged. Consolidated the code list into `isExpectedScanError`, since the inner recursion catch was already carrying its own inline copy (minus `EPERM`).

### MAESTRO-2S / MAESTRO-2Z - `stats:record-session-created/-closed: Database not initialized`
Missing the `db.isReady()` guard that `stats:record-shortcut-usage` got in MAESTRO-SP. Sessions are restored at launch, so this races DB init, and the callers are fire-and-forget: the throw became an unhandled rejection carrying no actionable information.

**These two hunks are mirrored byte-for-byte from #1213** (the `main`-side triage that landed today), so the rc<->main merge converges with no conflict. Verified with a dry-run merge of that branch into this one: clean auto-merge, and the union of both branches' changes passes all 59 tests in the two shared suites.

## Testing
- 8 new regression tests. **Each was verified to fail against the unfixed source** and pass with the fix.
- `npm run lint` (typecheck) clean; ESLint clean; Prettier clean.
- Full run over the touched areas (`process-manager`, `ipc/handlers`, `shared`, `stats`): 159 files / 4371 tests pass.

## Deliberately not addressed
- **MAESTRO-VA** (`claude /api/oauth/usage sample failed`, 43 events) - the emitting string exists at **no ref in this repo** (`git log --all -S` finds nothing). There is no code to fix; it looks like a feature that never landed on `rc`.
- **MAESTRO-Q2** (`maestro-p --status sample failed`, ~1.2k events) - still the noisiest, deferred for the 4th time. `reportFailure` fires on every sampler tick and `exit: 1` is a generic code with no clean expected-boundary. Needs a human call on `maestro-p` exit semantics; the likely fix is report-on-state-transition rather than every tick.
- **MAESTRO-R0** (`spawn EINVAL`) - genuine spawn failures, real signal.
- **MAESTRO-RS** (better-sqlite3 `GLIBC_2.38`) - Linux build/CI glibc target, not app code.
- Native/GPU crashes (Y, HQ, 9K, RB, VY, SZ, GK, 1J, VS), `Window unresponsive` (62), `Preload script error` (BC).
- **M9, JB, QF, RR** - guards from prior PRs (#1114/#1141/#1142) are all still intact; residual events are from older builds. M9's `RangeError` carve-out has regressed once before, so I re-verified both loops in `agentSessions.ts` still have it. They do.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved worktree scanning on inaccessible/missing/invalid paths (including permission/TCC cases), avoiding unnecessary Sentry reporting while still marking scans as failed when appropriate.
  - Prevented session statistics IPC errors during early startup when the stats database is not ready.
  - Batch-mode exits now treat non-JSON plain-text output as expected, only reporting unexpected failures to Sentry.
  - Marketplace/Sentry noise filtering now accounts for deeper cause chains and rate-limit/server-error responses, without suppressing true missing-document issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->