### PR TITLE
fix: make loaded tab navigation respond immediately

### DIFF
--- a/src/__tests__/performance/NavigationPerformance.test.tsx
+++ b/src/__tests__/performance/NavigationPerformance.test.tsx
@@ -1,0 +1,60 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { CollapsedSessionPillRows } from '../../renderer/components/SessionList/CollapsedSessionPill';
+import type { Session } from '../../renderer/types';
+import { createMockTheme } from '../helpers/mockTheme';
+
+function makeSession(index: number): Session {
+	return {
+		id: `session-${index}`,
+		name: `Session ${index}`,
+		toolType: 'codex',
+		state: 'idle',
+		cwd: '/tmp',
+		fullPath: '/tmp',
+		projectRoot: '/tmp',
+		aiLogs: [],
+		shellLogs: [],
+		workLog: [],
+		contextUsage: 0,
+		inputMode: 'ai',
+		aiPid: 0,
+		terminalPid: 0,
+		port: 0,
+		isLive: false,
+		changedFiles: [],
+		isGitRepo: false,
+		fileTree: [],
+		fileExplorerExpanded: [],
+		fileExplorerScrollPos: 0,
+	} as Session;
+}
+
+describe('NavigationPerformance', () => {
+	it('keeps a 70-session collapsed sidebar inside its idle DOM budget', () => {
+		const sessions = Array.from({ length: 70 }, (_, index) => makeSession(index));
+		const getFileCount = vi.fn(() => 0);
+		const startedAt = performance.now();
+		const { container } = render(
+			<CollapsedSessionPillRows
+				sessions={sessions}
+				keyPrefix="navigation-benchmark"
+				onContainerClick={vi.fn()}
+				theme={createMockTheme()}
+				activeBatchSessionIds={[]}
+				leftSidebarWidth={440}
+				contextWarningYellowThreshold={70}
+				contextWarningRedThreshold={90}
+				getFileCount={getFileCount}
+				getWorktreeChildren={() => []}
+				setActiveSessionId={vi.fn()}
+			/>
+		);
+		const elapsed = performance.now() - startedAt;
+
+		expect(container.querySelectorAll('[data-testid="collapsed-session-tooltip"]')).toHaveLength(0);
+		expect(container.querySelectorAll('*').length).toBeLessThan(400);
+		expect(getFileCount).not.toHaveBeenCalled();
+		expect(elapsed).toBeLessThan(250);
+	});
+});

--- a/src/__tests__/renderer/components/MainPanel/MainPanelContent.test.tsx
+++ b/src/__tests__/renderer/components/MainPanel/MainPanelContent.test.tsx
@@ -1,8 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import { MainPanelContent } from '../../../../renderer/components/MainPanel/MainPanelContent';
 import type { Session, Theme, AITab, FilePreviewTab } from '../../../../renderer/types';
+
+const { terminalOutputSessions } = vi.hoisted(() => ({
+	terminalOutputSessions: [] as Session[],
+}));
 
 import { mockTheme } from '../../../helpers/mockTheme';
 // Mock stores
@@ -52,13 +56,22 @@ vi.mock('../../../../renderer/contexts/LayerStackContext', () => ({
 
 // Mock child components
 vi.mock('../../../../renderer/components/TerminalOutput', () => ({
-	TerminalOutput: React.forwardRef((props: any, ref: any) =>
-		React.createElement('div', { 'data-testid': 'terminal-output', ref })
-	),
+	TerminalOutput: React.forwardRef((props: any, ref: any) => {
+		terminalOutputSessions.push(props.session);
+		return React.createElement('div', {
+			'data-testid': 'terminal-output',
+			'data-active-tab': props.session.activeTabId,
+			ref,
+		});
+	}),
 }));
 
 vi.mock('../../../../renderer/components/InputArea', () => ({
-	InputArea: (props: any) => React.createElement('div', { 'data-testid': 'input-area' }),
+	InputArea: (props: any) =>
+		React.createElement('div', {
+			'data-testid': 'input-area',
+			'data-active-tab': props.session.activeTabId,
+		}),
 }));
 
 vi.mock('../../../../renderer/components/FilePreview', () => ({
@@ -182,6 +195,7 @@ function makeDefaultProps() {
 describe('MainPanelContent', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		terminalOutputSessions.length = 0;
 		layerState.count = 0;
 	});
 
@@ -336,5 +350,48 @@ describe('MainPanelContent', () => {
 	it('renders data-tour attribute on input area', () => {
 		const { container } = render(<MainPanelContent {...makeDefaultProps()} />);
 		expect(container.querySelector('[data-tour="input-area"]')).toBeInTheDocument();
+	});
+
+	it('commits the selected tab before replacing its expensive transcript', () => {
+		const rafCallbacks: FrameRequestCallback[] = [];
+		const originalRaf = global.requestAnimationFrame;
+		const originalCancelRaf = global.cancelAnimationFrame;
+		global.requestAnimationFrame = vi.fn((callback: FrameRequestCallback) => {
+			rafCallbacks.push(callback);
+			return rafCallbacks.length;
+		});
+		global.cancelAnimationFrame = vi.fn();
+
+		try {
+			const firstProps = makeDefaultProps();
+			firstProps.activeSession = makeSession({
+				aiTabs: [{ id: 'tab-1' }, { id: 'tab-2' }] as AITab[],
+				activeTabId: 'tab-1',
+			});
+			const { rerender } = render(<MainPanelContent {...firstProps} />);
+
+			const secondProps = makeDefaultProps();
+			secondProps.activeSession = makeSession({
+				aiTabs: [{ id: 'tab-1' }, { id: 'tab-2' }] as AITab[],
+				activeTabId: 'tab-2',
+			});
+			secondProps.activeTab = { id: 'tab-2' } as AITab;
+			rerender(<MainPanelContent {...secondProps} />);
+
+			expect(screen.getByTestId('input-area')).toHaveAttribute('data-active-tab', 'tab-2');
+			expect(screen.getByTestId('terminal-output')).toHaveAttribute('data-active-tab', 'tab-1');
+			expect(terminalOutputSessions.at(-1)).toBe(firstProps.activeSession);
+			expect(screen.getByTestId('tab-content-pending')).toBeInTheDocument();
+
+			act(() => rafCallbacks.shift()?.(0));
+			expect(screen.getByTestId('terminal-output')).toHaveAttribute('data-active-tab', 'tab-1');
+
+			act(() => rafCallbacks.shift()?.(16));
+			expect(screen.getByTestId('terminal-output')).toHaveAttribute('data-active-tab', 'tab-2');
+			expect(screen.queryByTestId('tab-content-pending')).not.toBeInTheDocument();
+		} finally {
+			global.requestAnimationFrame = originalRaf;
+			global.cancelAnimationFrame = originalCancelRaf;
+		}
 	});
 });

--- a/src/__tests__/renderer/components/SessionList/CollapsedSessionPill.test.tsx
+++ b/src/__tests__/renderer/components/SessionList/CollapsedSessionPill.test.tsx
@@ -159,14 +159,36 @@ describe('CollapsedSessionPill', () => {
 		expect(segment.style.backgroundColor).toBe('transparent');
 	});
 
-	it('renders tooltip content within each segment', () => {
+	it('mounts tooltip content only while a segment is hovered', () => {
 		const session = makeSession({ name: 'My Test Agent' });
-		const props = createDefaultProps({ session });
+		const getFileCount = vi.fn(() => 3);
+		const props = createDefaultProps({ session, getFileCount });
 
-		render(<CollapsedSessionPill {...props} />);
+		const { container } = render(<CollapsedSessionPill {...props} />);
+		const segment = container.firstElementChild!.firstElementChild!;
 
-		// The tooltip content should include the session name
+		expect(screen.queryByText('My Test Agent')).not.toBeInTheDocument();
+		expect(getFileCount).not.toHaveBeenCalled();
+
+		fireEvent.mouseEnter(segment, { clientX: 10, clientY: 20 });
 		expect(screen.getByText('My Test Agent')).toBeTruthy();
+		expect(getFileCount).toHaveBeenCalledTimes(1);
+
+		fireEvent.mouseLeave(segment);
+		expect(screen.queryByText('My Test Agent')).not.toBeInTheDocument();
+	});
+
+	it('mounts tooltip content while a segment has keyboard focus', () => {
+		const session = makeSession({ name: 'Keyboard Agent' });
+		const props = createDefaultProps({ session });
+		const { container } = render(<CollapsedSessionPill {...props} />);
+		const segment = container.firstElementChild!.firstElementChild!;
+
+		fireEvent.focus(segment);
+		expect(screen.getByText('Keyboard Agent')).toBeInTheDocument();
+
+		fireEvent.blur(segment);
+		expect(screen.queryByText('Keyboard Agent')).not.toBeInTheDocument();
 	});
 
 	it('does not show unread dot on non-last segments in multi-segment pill', () => {

--- a/src/renderer/components/MainPanel/MainPanelContent.tsx
+++ b/src/renderer/components/MainPanel/MainPanelContent.tsx
@@ -450,6 +450,65 @@ export const MainPanelContent = React.memo(function MainPanelContent(props: Main
 		onEffortChange,
 	} = props;
 
+	// Keep the selected tab state urgent while moving the expensive transcript
+	// remount behind a guaranteed paint. Two animation frames let the tab bar and
+	// pending surface reach the screen before React parses and mounts the next
+	// conversation. Rapid tab changes cancel the stale target.
+	const [renderedAiTarget, setRenderedAiTarget] = React.useState(() => ({
+		sessionId: activeSession.id,
+		tabId: activeSession.activeTabId,
+	}));
+	React.useEffect(() => {
+		const nextTarget = {
+			sessionId: activeSession.id,
+			tabId: activeSession.activeTabId,
+		};
+		if (renderedAiTarget.sessionId !== activeSession.id) {
+			setRenderedAiTarget(nextTarget);
+			return;
+		}
+		if (renderedAiTarget.tabId === activeSession.activeTabId) return;
+
+		let contentFrame = 0;
+		const paintFrame = requestAnimationFrame(() => {
+			contentFrame = requestAnimationFrame(() => setRenderedAiTarget(nextTarget));
+		});
+		return () => {
+			cancelAnimationFrame(paintFrame);
+			if (contentFrame) cancelAnimationFrame(contentFrame);
+		};
+	}, [
+		activeSession.id,
+		activeSession.activeTabId,
+		renderedAiTarget.sessionId,
+		renderedAiTarget.tabId,
+	]);
+
+	const renderedAiTabId =
+		renderedAiTarget.sessionId === activeSession.id &&
+		activeSession.aiTabs?.some((tab) => tab.id === renderedAiTarget.tabId)
+			? renderedAiTarget.tabId
+			: activeSession.activeTabId;
+	const renderedActiveTab =
+		activeSession.aiTabs?.find((tab) => tab.id === renderedAiTabId) ?? activeTab;
+	// Preserve the exact session object while the selected tab is pending so the
+	// memoized TerminalOutput does not repeat its expensive render behind the
+	// loading surface. Once the deferred target commits, hand it the current
+	// session object and let the keyed remount render the selected transcript.
+	const renderedTranscriptSessionRef = React.useRef(activeSession);
+	if (
+		renderedTranscriptSessionRef.current.id !== activeSession.id ||
+		renderedAiTabId === activeSession.activeTabId
+	) {
+		renderedTranscriptSessionRef.current = activeSession;
+	}
+	const renderedTranscriptSession = renderedTranscriptSessionRef.current;
+	const isAiTabContentPending =
+		activeSession.inputMode === 'ai' &&
+		!activeFileTabId &&
+		!activeBrowserTabId &&
+		renderedAiTabId !== activeSession.activeTabId;
+
 	// Self-sourced from settingsStore. withMonoFallback guarantees the AI-output
 	// and terminal surfaces degrade to monospace instead of the browser's serif
 	// default when the stored font (a bare name from the picker) isn't installed.
@@ -766,56 +825,57 @@ export const MainPanelContent = React.memo(function MainPanelContent(props: Main
 					{/* User clicks "Exit Wizard" button in DocumentGenerationView which calls onWizardComplete to convert tab to normal session */}
 					<div className="flex-1 overflow-hidden flex flex-col relative" data-tour="main-terminal">
 						{activeSession.inputMode === 'ai' &&
-						(activeTab?.wizardState?.isGeneratingDocs ||
-							(activeTab?.wizardState?.generatedDocuments?.length ?? 0) > 0) ? (
+						(renderedActiveTab?.wizardState?.isGeneratingDocs ||
+							(renderedActiveTab?.wizardState?.generatedDocuments?.length ?? 0) > 0) ? (
 							<DocumentGenerationView
-								key={`wizard-gen-${activeSession.id}-${activeSession.activeTabId}`}
+								key={`wizard-gen-${activeSession.id}-${renderedAiTabId}`}
 								theme={theme}
-								documents={activeTab?.wizardState?.generatedDocuments ?? []}
-								currentDocumentIndex={activeTab?.wizardState?.currentDocumentIndex ?? 0}
-								isGenerating={activeTab?.wizardState?.isGeneratingDocs ?? false}
-								streamingContent={activeTab?.wizardState?.streamingContent}
+								documents={renderedActiveTab?.wizardState?.generatedDocuments ?? []}
+								currentDocumentIndex={renderedActiveTab?.wizardState?.currentDocumentIndex ?? 0}
+								isGenerating={renderedActiveTab?.wizardState?.isGeneratingDocs ?? false}
+								streamingContent={renderedActiveTab?.wizardState?.streamingContent}
 								onComplete={onWizardComplete || (() => {})}
 								onCompleteAndStartAutoRun={onWizardCompleteAndStartAutoRun}
 								onDocumentSelect={onWizardDocumentSelect || (() => {})}
 								folderPath={
-									activeTab?.wizardState?.subfolderPath ?? activeTab?.wizardState?.autoRunFolderPath
+									renderedActiveTab?.wizardState?.subfolderPath ??
+									renderedActiveTab?.wizardState?.autoRunFolderPath
 								}
 								onContentChange={onWizardContentChange}
-								progressMessage={activeTab?.wizardState?.progressMessage}
-								currentGeneratingIndex={activeTab?.wizardState?.currentGeneratingIndex}
-								totalDocuments={activeTab?.wizardState?.totalDocuments}
+								progressMessage={renderedActiveTab?.wizardState?.progressMessage}
+								currentGeneratingIndex={renderedActiveTab?.wizardState?.currentGeneratingIndex}
+								totalDocuments={renderedActiveTab?.wizardState?.totalDocuments}
 								onCancel={onWizardCancelGeneration}
-								subfolderName={activeTab?.wizardState?.subfolderName}
-								startedAt={activeTab?.wizardState?.docGenerationStartedAt}
+								subfolderName={renderedActiveTab?.wizardState?.subfolderName}
+								startedAt={renderedActiveTab?.wizardState?.docGenerationStartedAt}
 							/>
-						) : activeSession.inputMode === 'ai' && activeTab?.wizardState?.isActive ? (
+						) : activeSession.inputMode === 'ai' && renderedActiveTab?.wizardState?.isActive ? (
 							<WizardConversationView
-								key={`wizard-${activeSession.id}-${activeSession.activeTabId}`}
+								key={`wizard-${activeSession.id}-${renderedAiTabId}`}
 								theme={theme}
-								conversationHistory={activeTab.wizardState.conversationHistory}
-								isLoading={activeTab.wizardState.isWaiting ?? false}
+								conversationHistory={renderedActiveTab.wizardState.conversationHistory}
+								isLoading={renderedActiveTab.wizardState.isWaiting ?? false}
 								agentName={activeSession.name}
-								confidence={activeTab.wizardState.confidence}
-								ready={activeTab.wizardState.ready}
+								confidence={renderedActiveTab.wizardState.confidence}
+								ready={renderedActiveTab.wizardState.ready}
 								onLetsGo={onWizardLetsGo}
-								error={activeTab.wizardState.error}
+								error={renderedActiveTab.wizardState.error}
 								onRetry={onWizardRetry}
 								onClearError={onWizardClearError}
-								showThinking={activeTab.wizardState.showWizardThinking ?? false}
-								thinkingContent={activeTab.wizardState.thinkingContent ?? ''}
-								toolExecutions={activeTab.wizardState.toolExecutions ?? []}
+								showThinking={renderedActiveTab.wizardState.showWizardThinking ?? false}
+								thinkingContent={renderedActiveTab.wizardState.thinkingContent ?? ''}
+								toolExecutions={renderedActiveTab.wizardState.toolExecutions ?? []}
 								hasStartedGenerating={
-									activeTab.wizardState.isGeneratingDocs ||
-									(activeTab.wizardState.generatedDocuments?.length ?? 0) > 0
+									renderedActiveTab.wizardState.isGeneratingDocs ||
+									(renderedActiveTab.wizardState.generatedDocuments?.length ?? 0) > 0
 								}
 								setLightboxImage={setLightboxImage}
 							/>
 						) : (
 							<TerminalOutput
-								key={`${activeSession.id}-${activeSession.activeTabId}`}
+								key={`${activeSession.id}-${renderedAiTabId}`}
 								ref={terminalOutputRef}
-								session={activeSession}
+								session={renderedTranscriptSession}
 								theme={theme}
 								fontFamily={fontFamily}
 								activeFocus={activeFocus}
@@ -841,7 +901,7 @@ export const MainPanelContent = React.memo(function MainPanelContent(props: Main
 								onInterrupt={handleInterrupt}
 								onScrollPositionChange={onScrollPositionChange}
 								onAtBottomChange={onAtBottomChange}
-								initialScrollTop={activeTab?.scrollTop}
+								initialScrollTop={renderedActiveTab?.scrollTop}
 								markdownEditMode={chatRawTextMode}
 								setMarkdownEditMode={useSettingsStore.getState().setChatRawTextMode}
 								onReplayMessage={onReplayMessage}
@@ -866,6 +926,17 @@ export const MainPanelContent = React.memo(function MainPanelContent(props: Main
 								ghCliAvailable={ghCliAvailable}
 								onPublishMessageGist={onPublishMessageGist}
 							/>
+						)}
+						{isAiTabContentPending && (
+							<div
+								data-testid="tab-content-pending"
+								role="status"
+								aria-label="Loading selected tab"
+								className="absolute inset-0 z-[2] flex items-center justify-center"
+								style={{ backgroundColor: theme.colors.bgMain }}
+							>
+								<Spinner size={24} color={theme.colors.accent} />
+							</div>
 						)}
 					</div>
 				</>

--- a/src/renderer/components/SessionList/CollapsedSessionPill.tsx
+++ b/src/renderer/components/SessionList/CollapsedSessionPill.tsx
@@ -145,25 +145,28 @@ export const CollapsedSessionPill = memo(function CollapsedSessionPill({
 								style={{ backgroundColor: theme.colors.error }}
 							/>
 						)}
-						<div
-							className="fixed rounded px-3 py-2 z-[100] opacity-0 group-hover/segment:opacity-100 pointer-events-none transition-opacity shadow-xl"
-							style={{
-								minWidth: '240px',
-								left: `${leftSidebarWidth + 8}px`,
-								top: tooltipPosition ? `${tooltipPosition.y}px` : undefined,
-								backgroundColor: theme.colors.bgSidebar,
-								border: `1px solid ${theme.colors.border}`,
-							}}
-						>
-							<SessionTooltipContent
-								session={s}
-								theme={theme}
-								gitFileCount={getFileCount(s.id)}
-								isInBatch={isInBatch}
-								contextWarningYellowThreshold={contextWarningYellowThreshold}
-								contextWarningRedThreshold={contextWarningRedThreshold}
-							/>
-						</div>
+						{tooltipPosition && (
+							<div
+								data-testid="collapsed-session-tooltip"
+								className="fixed rounded px-3 py-2 z-[100] pointer-events-none shadow-xl"
+								style={{
+									minWidth: '240px',
+									left: `${leftSidebarWidth + 8}px`,
+									top: `${tooltipPosition.y}px`,
+									backgroundColor: theme.colors.bgSidebar,
+									border: `1px solid ${theme.colors.border}`,
+								}}
+							>
+								<SessionTooltipContent
+									session={s}
+									theme={theme}
+									gitFileCount={getFileCount(s.id)}
+									isInBatch={isInBatch}
+									contextWarningYellowThreshold={contextWarningYellowThreshold}
+									contextWarningRedThreshold={contextWarningRedThreshold}
+								/>
+							</div>
+						)}
 					</div>
 				);
 			})}


### PR DESCRIPTION
## Summary

- mount collapsed-session tooltips only on hover or keyboard focus instead of keeping every tooltip in the idle DOM
- paint the selected AI tab and pending surface before remounting its expensive transcript, while cancelling stale rapid switches
- add regression coverage and a 70-session collapsed-sidebar performance budget

## Verification

- `npm test`: 33,907 passed, 108 skipped, 0 failed
- `npm run lint`: passed
- `npm run lint:eslint`: passed
- `npm run build:renderer`: passed
- navigation benchmark: 28 ms, 0 idle tooltips, fewer than 400 DOM nodes

## Baseline note

The broader `npm run test:performance` command still has five unrelated pre-existing Auto Run failures outside this diff; the new navigation benchmark passes independently.

## Tracking

ClickUp: https://app.clickup.com/t/86ajg95h3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved navigation performance for sidebars with many collapsed sessions.
  * Reduced unnecessary rendering and deferred expensive session details until needed.

* **User Experience**
  * AI tab switching now provides a loading indicator while content updates.
  * Preserves previously selected transcript content during tab transitions.
  * Session tooltips now appear only on hover or keyboard focus, reducing unnecessary UI elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->