### PR TITLE
perf(session): stop App full sessions subscription during streaming

### DIFF
--- a/src/__tests__/main/cue/cue-reconciler.test.ts
+++ b/src/__tests__/main/cue/cue-reconciler.test.ts
@@ -273,9 +273,10 @@ describe('reconcileMissedTimeEvents', () => {
 		});
 
 		const sleepDuration = 60 * 60 * 1000; // 1 hour
+		const wakeTimeMs = Date.now();
 		const config = makeConfig({
-			sleepStartMs: Date.now() - sleepDuration,
-			wakeTimeMs: Date.now(),
+			sleepStartMs: wakeTimeMs - sleepDuration,
+			wakeTimeMs,
 			sessions,
 		});
 

--- a/src/__tests__/renderer/components/GroupChatInput.test.tsx
+++ b/src/__tests__/renderer/components/GroupChatInput.test.tsx
@@ -13,6 +13,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { GroupChatInput } from '../../../renderer/components/GroupChatInput';
+import { useSessionStore } from '../../../renderer/stores/sessionStore';
 import type { Session, Group, GroupChatParticipant } from '../../../renderer/types';
 import { createMockSession as baseCreateMockSession } from '../../helpers/mockSession';
 
@@ -53,17 +54,21 @@ function createMockGroup(id: string, name: string, emoji: string = '📁'): Grou
 }
 
 /**
- * Default props for GroupChatInput
+ * Default props for GroupChatInput.
+ * Pass `sessions` to seed the store (component self-sources mentions).
  */
-function createDefaultProps(overrides: Partial<Parameters<typeof GroupChatInput>[0]> = {}) {
+function createDefaultProps(
+	overrides: Partial<Parameters<typeof GroupChatInput>[0]> & { sessions?: Session[] } = {}
+) {
+	const { sessions = [], ...rest } = overrides;
+	useSessionStore.setState({ sessions });
 	return {
 		theme: createMockTheme(),
 		state: 'idle' as const,
 		onSend: vi.fn(),
 		participants: [],
-		sessions: [],
 		groupChatId: 'test-group-chat',
-		...overrides,
+		...rest,
 	};
 }
 
@@ -79,6 +84,10 @@ function typeInTextarea(textarea: HTMLTextAreaElement, value: string) {
 // =============================================================================
 
 describe('GroupChatInput', () => {
+	beforeEach(() => {
+		useSessionStore.setState({ sessions: [] });
+	});
+
 	afterEach(() => {
 		vi.useRealTimers();
 	});

--- a/src/__tests__/renderer/components/InputArea.test.tsx
+++ b/src/__tests__/renderer/components/InputArea.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent, act, within, waitFor } from '@testing-librar
 import userEvent from '@testing-library/user-event';
 import { InputArea } from '../../../renderer/components/InputArea';
 import { useComposerInputStore } from '../../../renderer/stores/composerInputStore';
+import { useSessionStore } from '../../../renderer/stores/sessionStore';
 import { formatEnterToSend } from '../../../renderer/utils/shortcutFormatter';
 import type { Session } from '../../../renderer/types';
 import { createMockSession as baseCreateMockSession } from '../../helpers/mockSession';
@@ -212,6 +213,7 @@ const createDefaultProps = (
 describe('InputArea', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		useSessionStore.setState({ sessions: [] });
 	});
 
 	afterEach(() => {
@@ -423,16 +425,16 @@ describe('InputArea', () => {
 		});
 
 		it('renders ThinkingStatusPill when items are thinking', () => {
-			// ThinkingStatusPill only renders when there are thinking items
-			// PERF: InputArea now expects pre-filtered thinkingItems prop
+			// ThinkingStatusPill only renders when there are thinking items.
+			// InputArea self-sources via useThinkingItems from the session store.
 			const thinkingSession = createMockSession({
 				inputMode: 'ai',
 				state: 'busy',
 				busySource: 'ai',
 			});
+			useSessionStore.setState({ sessions: [thinkingSession] });
 			const props = createDefaultProps({
 				session: thinkingSession,
-				thinkingItems: [{ session: thinkingSession, tab: null }],
 			});
 			render(<InputArea {...props} />);
 

--- a/src/__tests__/renderer/components/SymphonyModal/tabs/ActiveTab.test.tsx
+++ b/src/__tests__/renderer/components/SymphonyModal/tabs/ActiveTab.test.tsx
@@ -2,7 +2,7 @@
  * Tests for SymphonyModal/tabs/ActiveTab — empty state CTA, count display,
  * Check PR Status button, sync routing, session jump.
  */
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, fireEvent } from '@testing-library/react';
 
 vi.mock('lucide-react', () => {
@@ -34,13 +34,13 @@ vi.mock('../../../../../renderer/components/ui/Spinner', () => ({
 }));
 
 import { ActiveTab } from '../../../../../renderer/components/SymphonyModal/tabs/ActiveTab';
+import { useSessionStore } from '../../../../../renderer/stores/sessionStore';
 import { mockTheme, makeActiveContribution } from '../_fixtures';
 import type { Session } from '../../../../../renderer/types';
 
 const baseProps = (overrides: Partial<React.ComponentProps<typeof ActiveTab>> = {}) => ({
 	theme: mockTheme,
 	activeContributions: [],
-	sessions: [] as Session[],
 	prStatusMessage: null,
 	isCheckingPRStatuses: false,
 	syncingContributionId: null,
@@ -54,6 +54,10 @@ const baseProps = (overrides: Partial<React.ComponentProps<typeof ActiveTab>> = 
 });
 
 describe('ActiveTab', () => {
+	beforeEach(() => {
+		useSessionStore.setState({ sessions: [] });
+	});
+
 	it('renders the empty-state CTA when there are no contributions', () => {
 		const onSwitchToProjects = vi.fn();
 		const { getByText } = render(<ActiveTab {...baseProps({ onSwitchToProjects })} />);
@@ -104,11 +108,12 @@ describe('ActiveTab', () => {
 	it('resolves sessionName by sessionId and triggers select + close on jump', () => {
 		const onSelectSession = vi.fn();
 		const onCloseModal = vi.fn();
-		const sessions = [{ id: 'session-1', name: 'my-agent' } as unknown as Session];
+		useSessionStore.setState({
+			sessions: [{ id: 'session-1', name: 'my-agent' } as unknown as Session],
+		});
 		const { getByText } = render(
 			<ActiveTab
 				{...baseProps({
-					sessions,
 					onSelectSession,
 					onCloseModal,
 					activeContributions: [makeActiveContribution({ id: 'c1', sessionId: 'session-1' })],

--- a/src/__tests__/renderer/hooks/useCueAutoDiscovery.test.ts
+++ b/src/__tests__/renderer/hooks/useCueAutoDiscovery.test.ts
@@ -156,6 +156,46 @@ describe('useCueAutoDiscovery', () => {
 		});
 	});
 
+	describe('projectRoot moves', () => {
+		it('removes and refreshes when an existing session changes projectRoot', async () => {
+			const initialSessions = [makeSession('s1', '/project/a')];
+			const encoreFeatures = makeEncoreFeatures(true);
+
+			seedSessions(initialSessions, true);
+			renderHook(() => useCueAutoDiscovery(encoreFeatures));
+
+			mockRefreshSession.mockClear();
+			mockRemoveSession.mockClear();
+
+			act(() => {
+				seedSessions([makeSession('s1', '/project/moved')], true);
+			});
+
+			expect(mockRemoveSession).toHaveBeenCalledWith('s1');
+			await act(async () => {});
+			expect(mockRefreshSession).toHaveBeenCalledWith('s1', '/project/moved');
+		});
+
+		it('removes without refresh when projectRoot is cleared', async () => {
+			const initialSessions = [makeSession('s1', '/project/a')];
+			const encoreFeatures = makeEncoreFeatures(true);
+
+			seedSessions(initialSessions, true);
+			renderHook(() => useCueAutoDiscovery(encoreFeatures));
+
+			mockRefreshSession.mockClear();
+			mockRemoveSession.mockClear();
+
+			act(() => {
+				seedSessions([makeSession('s1', '')], true);
+			});
+
+			expect(mockRemoveSession).toHaveBeenCalledWith('s1');
+			await act(async () => {});
+			expect(mockRefreshSession).not.toHaveBeenCalled();
+		});
+	});
+
 	describe('encore feature toggle', () => {
 		it('should enable Cue and scan all sessions when maestroCue is toggled ON', async () => {
 			const sessions = [makeSession('s1', '/project/a'), makeSession('s2', '/project/b')];

--- a/src/__tests__/renderer/hooks/useCueAutoDiscovery.test.ts
+++ b/src/__tests__/renderer/hooks/useCueAutoDiscovery.test.ts
@@ -10,6 +10,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useCueAutoDiscovery } from '../../../renderer/hooks/useCueAutoDiscovery';
 import { useSessionStore } from '../../../renderer/stores/sessionStore';
+import { resetStore } from '../../helpers/resetStores';
 import type { Session, EncoreFeatureFlags } from '../../../renderer/types';
 
 // Mock Cue API
@@ -20,6 +21,7 @@ const mockDisable = vi.fn();
 
 beforeEach(() => {
 	vi.clearAllMocks();
+	resetStore(useSessionStore);
 
 	mockRefreshSession.mockResolvedValue(undefined);
 	mockRemoveSession.mockResolvedValue(undefined);
@@ -36,9 +38,6 @@ beforeEach(() => {
 			disable: mockDisable,
 		},
 	};
-
-	// Reset session store
-	useSessionStore.setState({ sessionsLoaded: false });
 });
 
 function makeSession(id: string, projectRoot: string): Session {
@@ -54,13 +53,18 @@ function makeEncoreFeatures(maestroCue: boolean): EncoreFeatureFlags {
 	return { maestroCue } as EncoreFeatureFlags;
 }
 
+function seedSessions(sessions: Session[], sessionsLoaded = false) {
+	useSessionStore.setState({ sessions, sessionsLoaded });
+}
+
 describe('useCueAutoDiscovery', () => {
 	describe('initial scan on app startup', () => {
 		it('should not call refreshSession before sessions are loaded', () => {
 			const sessions = [makeSession('s1', '/project/a')];
 			const encoreFeatures = makeEncoreFeatures(true);
 
-			renderHook(() => useCueAutoDiscovery(sessions, encoreFeatures));
+			seedSessions(sessions, false);
+			renderHook(() => useCueAutoDiscovery(encoreFeatures));
 
 			expect(mockRefreshSession).not.toHaveBeenCalled();
 		});
@@ -69,7 +73,8 @@ describe('useCueAutoDiscovery', () => {
 			const sessions = [makeSession('s1', '/project/a'), makeSession('s2', '/project/b')];
 			const encoreFeatures = makeEncoreFeatures(true);
 
-			renderHook(() => useCueAutoDiscovery(sessions, encoreFeatures));
+			seedSessions(sessions, false);
+			renderHook(() => useCueAutoDiscovery(encoreFeatures));
 
 			// Simulate sessions loaded
 			act(() => {
@@ -85,7 +90,8 @@ describe('useCueAutoDiscovery', () => {
 			const sessions = [makeSession('s1', '/project/a')];
 			const encoreFeatures = makeEncoreFeatures(false);
 
-			renderHook(() => useCueAutoDiscovery(sessions, encoreFeatures));
+			seedSessions(sessions, false);
+			renderHook(() => useCueAutoDiscovery(encoreFeatures));
 
 			act(() => {
 				useSessionStore.setState({ sessionsLoaded: true });
@@ -99,7 +105,8 @@ describe('useCueAutoDiscovery', () => {
 			const sessions = [makeSession('s1', '/project/a'), makeSession('s2', '')];
 			const encoreFeatures = makeEncoreFeatures(true);
 
-			renderHook(() => useCueAutoDiscovery(sessions, encoreFeatures));
+			seedSessions(sessions, false);
+			renderHook(() => useCueAutoDiscovery(encoreFeatures));
 
 			act(() => {
 				useSessionStore.setState({ sessionsLoaded: true });
@@ -115,18 +122,15 @@ describe('useCueAutoDiscovery', () => {
 			const initialSessions = [makeSession('s1', '/project/a')];
 			const encoreFeatures = makeEncoreFeatures(true);
 
-			useSessionStore.setState({ sessionsLoaded: true });
-
-			const { rerender } = renderHook(
-				({ sessions, encore }) => useCueAutoDiscovery(sessions, encore),
-				{ initialProps: { sessions: initialSessions, encore: encoreFeatures } }
-			);
+			seedSessions(initialSessions, true);
+			renderHook(() => useCueAutoDiscovery(encoreFeatures));
 
 			mockRefreshSession.mockClear();
 
 			// Add a new session
-			const updatedSessions = [...initialSessions, makeSession('s2', '/project/b')];
-			rerender({ sessions: updatedSessions, encore: encoreFeatures });
+			act(() => {
+				seedSessions([...initialSessions, makeSession('s2', '/project/b')], true);
+			});
 
 			expect(mockRefreshSession).toHaveBeenCalledWith('s2', '/project/b');
 		});
@@ -137,19 +141,16 @@ describe('useCueAutoDiscovery', () => {
 			const initialSessions = [makeSession('s1', '/project/a'), makeSession('s2', '/project/b')];
 			const encoreFeatures = makeEncoreFeatures(true);
 
-			useSessionStore.setState({ sessionsLoaded: true });
-
-			const { rerender } = renderHook(
-				({ sessions, encore }) => useCueAutoDiscovery(sessions, encore),
-				{ initialProps: { sessions: initialSessions, encore: encoreFeatures } }
-			);
+			seedSessions(initialSessions, true);
+			renderHook(() => useCueAutoDiscovery(encoreFeatures));
 
 			mockRefreshSession.mockClear();
 			mockRemoveSession.mockClear();
 
 			// Remove session s2
-			const updatedSessions = [makeSession('s1', '/project/a')];
-			rerender({ sessions: updatedSessions, encore: encoreFeatures });
+			act(() => {
+				seedSessions([makeSession('s1', '/project/a')], true);
+			});
 
 			expect(mockRemoveSession).toHaveBeenCalledWith('s2');
 		});
@@ -159,17 +160,17 @@ describe('useCueAutoDiscovery', () => {
 		it('should enable Cue and scan all sessions when maestroCue is toggled ON', async () => {
 			const sessions = [makeSession('s1', '/project/a'), makeSession('s2', '/project/b')];
 
-			useSessionStore.setState({ sessionsLoaded: true });
+			seedSessions(sessions, true);
 
-			const { rerender } = renderHook(({ sessions: s, encore }) => useCueAutoDiscovery(s, encore), {
-				initialProps: { sessions, encore: makeEncoreFeatures(false) },
+			const { rerender } = renderHook(({ encore }) => useCueAutoDiscovery(encore), {
+				initialProps: { encore: makeEncoreFeatures(false) },
 			});
 
 			mockRefreshSession.mockClear();
 			mockEnable.mockClear();
 
 			// Toggle maestroCue ON
-			rerender({ sessions, encore: makeEncoreFeatures(true) });
+			rerender({ encore: makeEncoreFeatures(true) });
 			await act(async () => {});
 
 			expect(mockEnable).toHaveBeenCalledTimes(1);
@@ -181,14 +182,14 @@ describe('useCueAutoDiscovery', () => {
 		it('should call disable when maestroCue is toggled OFF', async () => {
 			const sessions = [makeSession('s1', '/project/a')];
 
-			useSessionStore.setState({ sessionsLoaded: true });
+			seedSessions(sessions, true);
 
-			const { rerender } = renderHook(({ sessions: s, encore }) => useCueAutoDiscovery(s, encore), {
-				initialProps: { sessions, encore: makeEncoreFeatures(true) },
+			const { rerender } = renderHook(({ encore }) => useCueAutoDiscovery(encore), {
+				initialProps: { encore: makeEncoreFeatures(true) },
 			});
 
 			// Toggle maestroCue OFF
-			rerender({ sessions, encore: makeEncoreFeatures(false) });
+			rerender({ encore: makeEncoreFeatures(false) });
 			// Toggle calls are now serialized on a Promise chain, so the
 			// disable fires on the next microtask rather than synchronously.
 			await act(async () => {});
@@ -199,17 +200,17 @@ describe('useCueAutoDiscovery', () => {
 		it('should not trigger actions when feature toggle value unchanged', () => {
 			const sessions = [makeSession('s1', '/project/a')];
 
-			useSessionStore.setState({ sessionsLoaded: true });
+			seedSessions(sessions, true);
 
-			const { rerender } = renderHook(({ sessions: s, encore }) => useCueAutoDiscovery(s, encore), {
-				initialProps: { sessions, encore: makeEncoreFeatures(true) },
+			const { rerender } = renderHook(({ encore }) => useCueAutoDiscovery(encore), {
+				initialProps: { encore: makeEncoreFeatures(true) },
 			});
 
 			mockRefreshSession.mockClear();
 			mockDisable.mockClear();
 
 			// Rerender with same feature state
-			rerender({ sessions, encore: makeEncoreFeatures(true) });
+			rerender({ encore: makeEncoreFeatures(true) });
 
 			// Only the initial scan calls should exist, no toggle-related calls
 			expect(mockDisable).not.toHaveBeenCalled();
@@ -221,18 +222,15 @@ describe('useCueAutoDiscovery', () => {
 			const initialSessions = [makeSession('s1', '/project/a')];
 			const encoreFeatures = makeEncoreFeatures(false);
 
-			useSessionStore.setState({ sessionsLoaded: true });
-
-			const { rerender } = renderHook(
-				({ sessions, encore }) => useCueAutoDiscovery(sessions, encore),
-				{ initialProps: { sessions: initialSessions, encore: encoreFeatures } }
-			);
+			seedSessions(initialSessions, true);
+			renderHook(() => useCueAutoDiscovery(encoreFeatures));
 
 			mockRefreshSession.mockClear();
 
 			// Add a new session while feature is disabled — should still refresh
-			const updatedSessions = [...initialSessions, makeSession('s2', '/project/b')];
-			rerender({ sessions: updatedSessions, encore: encoreFeatures });
+			act(() => {
+				seedSessions([...initialSessions, makeSession('s2', '/project/b')], true);
+			});
 
 			expect(mockRefreshSession).toHaveBeenCalledWith('s2', '/project/b');
 		});
@@ -246,7 +244,7 @@ describe('useCueAutoDiscovery', () => {
 
 		it('serializes enable/disable calls in flag-change order even when IPC latency varies', async () => {
 			const sessions = [makeSession('s1', '/project/a')];
-			useSessionStore.setState({ sessionsLoaded: true });
+			seedSessions(sessions, true);
 
 			const callOrder: string[] = [];
 			let resolveEnable: (() => void) | undefined;
@@ -265,15 +263,15 @@ describe('useCueAutoDiscovery', () => {
 				callOrder.push('disable:resolve');
 			});
 
-			const { rerender } = renderHook(({ sessions: s, encore }) => useCueAutoDiscovery(s, encore), {
-				initialProps: { sessions, encore: makeEncoreFeatures(false) },
+			const { rerender } = renderHook(({ encore }) => useCueAutoDiscovery(encore), {
+				initialProps: { encore: makeEncoreFeatures(false) },
 			});
 
 			// ON → queues enable (which will hang until we resolve it)
-			rerender({ sessions, encore: makeEncoreFeatures(true) });
+			rerender({ encore: makeEncoreFeatures(true) });
 			await act(async () => {});
 			// OFF → queues disable. Must NOT execute until enable resolves.
-			rerender({ sessions, encore: makeEncoreFeatures(false) });
+			rerender({ encore: makeEncoreFeatures(false) });
 			await act(async () => {});
 
 			// Disable has not started yet; it's waiting in the chain.
@@ -296,16 +294,16 @@ describe('useCueAutoDiscovery', () => {
 
 		it('applies the final flag value when rapid toggles occur', async () => {
 			const sessions = [makeSession('s1', '/project/a')];
-			useSessionStore.setState({ sessionsLoaded: true });
+			seedSessions(sessions, true);
 
-			const { rerender } = renderHook(({ sessions: s, encore }) => useCueAutoDiscovery(s, encore), {
-				initialProps: { sessions, encore: makeEncoreFeatures(false) },
+			const { rerender } = renderHook(({ encore }) => useCueAutoDiscovery(encore), {
+				initialProps: { encore: makeEncoreFeatures(false) },
 			});
 
 			// OFF → ON → OFF → ON, firing 3 transitions back-to-back
-			rerender({ sessions, encore: makeEncoreFeatures(true) });
-			rerender({ sessions, encore: makeEncoreFeatures(false) });
-			rerender({ sessions, encore: makeEncoreFeatures(true) });
+			rerender({ encore: makeEncoreFeatures(true) });
+			rerender({ encore: makeEncoreFeatures(false) });
+			rerender({ encore: makeEncoreFeatures(true) });
 			await act(async () => {});
 			// Let the microtask chain drain across all three toggles.
 			await act(async () => {});

--- a/src/__tests__/renderer/hooks/useFileTreeManagement.test.ts
+++ b/src/__tests__/renderer/hooks/useFileTreeManagement.test.ts
@@ -76,7 +76,6 @@ const createDeps = (
 	state: ReturnType<typeof createSessionsState>,
 	overrides: Partial<UseFileTreeManagementDeps> = {}
 ): UseFileTreeManagementDeps => ({
-	sessions: state.getSessions(),
 	sessionsRef: state.sessionsRef,
 	setSessions: state.setSessions,
 	activeSessionId: state.getSessions()[0]?.id ?? null,

--- a/src/__tests__/renderer/hooks/useForkConversation.test.ts
+++ b/src/__tests__/renderer/hooks/useForkConversation.test.ts
@@ -45,6 +45,7 @@ vi.mock('../../../renderer/utils/spawnHelpers', () => ({
 // ============================================================================
 
 import { useForkConversation } from '../../../renderer/hooks/agent/useForkConversation';
+import { useSessionStore } from '../../../renderer/stores/sessionStore';
 
 // ============================================================================
 // Helpers
@@ -76,25 +77,26 @@ function buildSession(overrides: Partial<Session> = {}): Session {
 }
 
 /**
- * Drive the hook against a mutable session array that mirrors how App.tsx
- * wires it up. Returns the current snapshot, the fork handler, and setter.
+ * Seed the session store and mount the no-arg fork hook.
+ * Mutations go through the store; assert via getState().sessions.
  */
 function mountHook(initialSessions: Session[], activeSessionId: string | null) {
-	let sessions = initialSessions;
-	const setSessions = vi.fn((updater: (prev: Session[]) => Session[]) => {
-		sessions = updater(sessions);
+	const originalSetSessions = useSessionStore.getState().setSessions;
+	const setSessions = vi.fn((updater: Session[] | ((prev: Session[]) => Session[])) => {
+		originalSetSessions(updater);
+	});
+	useSessionStore.setState({
+		sessions: initialSessions,
+		activeSessionId,
+		setSessions: setSessions as typeof originalSetSessions,
 	});
 
-	const { result, rerender } = renderHook(
-		({ s, id }: { s: Session[]; id: string | null }) => useForkConversation(s, setSessions, id),
-		{ initialProps: { s: sessions, id: activeSessionId } }
-	);
+	const { result } = renderHook(() => useForkConversation());
 
 	return {
 		fork: (logId: string) => act(() => result.current(logId)),
-		getSessions: () => sessions,
+		getSessions: () => useSessionStore.getState().sessions,
 		setSessions,
-		rerender: () => rerender({ s: sessions, id: activeSessionId }),
 	};
 }
 
@@ -104,6 +106,9 @@ function mountHook(initialSessions: Session[], activeSessionId: string | null) {
 
 beforeEach(() => {
 	vi.clearAllMocks();
+	// Avoid resetStores here: this file mocks notificationStore without
+	// exporting useNotificationStore, which resetStores imports.
+	useSessionStore.setState(useSessionStore.getInitialState(), true);
 
 	(window as any).maestro = {
 		agents: {

--- a/src/__tests__/renderer/hooks/useMainKeyboardHandler.test.ts
+++ b/src/__tests__/renderer/hooks/useMainKeyboardHandler.test.ts
@@ -12,6 +12,15 @@ import { useSessionStore } from '../../../renderer/stores/sessionStore';
  * "is not a function" errors when processing keyboard events.
  */
 function createMockContext(overrides: Record<string, unknown> = {}) {
+	// Keyboard gates (toggleSidebar / quickAction / agentSwitcher) read
+	// session count via useSessionStore.getState(), not ctx.sessions.
+	// Only sync when the test explicitly provides `sessions` so other
+	// suites that pre-seed the store (e.g. output-search Cmd+F) are not wiped.
+	if ('sessions' in overrides) {
+		const sessions = Array.isArray(overrides.sessions) ? overrides.sessions : [];
+		useSessionStore.setState({ sessions: sessions as never });
+	}
+
 	return {
 		hasOpenLayers: () => false,
 		hasOpenModal: () => false,

--- a/src/__tests__/renderer/hooks/useSessionNavigation.test.ts
+++ b/src/__tests__/renderer/hooks/useSessionNavigation.test.ts
@@ -1,10 +1,12 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useSessionNavigation } from '../../../renderer/hooks/session/useSessionNavigation';
 import type { NavHistoryEntry } from '../../../renderer/hooks/session/useNavigationHistory';
 import type { Session } from '../../../renderer/types';
 import { createMockSession } from '../../helpers/mockSession';
 import { createMockAITab, createMockFileTab } from '../../helpers/mockTab';
+import { useSessionStore } from '../../../renderer/stores/sessionStore';
+import { resetStore } from '../../helpers/resetStores';
 
 /**
  * Codifies the breadcrumb restore behavior: navigateBack/navigateForward must
@@ -12,11 +14,17 @@ import { createMockAITab, createMockFileTab } from '../../helpers/mockTab';
  * terminal), not just AI tabs. Guards against regressing to AI-only restore.
  */
 describe('useSessionNavigation', () => {
+	beforeEach(() => {
+		resetStore(useSessionStore);
+	});
+
 	function setup(
 		sessions: Session[],
 		backEntry: NavHistoryEntry | null,
 		forwardEntry: NavHistoryEntry | null = null
 	) {
+		useSessionStore.setState({ sessions });
+
 		const navigateBack = vi.fn(() => backEntry);
 		const navigateForward = vi.fn(() => forwardEntry);
 		const setActiveSessionId = vi.fn();
@@ -33,7 +41,7 @@ describe('useSessionNavigation', () => {
 		const cyclePositionRef = { current: 0 };
 
 		const { result } = renderHook(() =>
-			useSessionNavigation(sessions, {
+			useSessionNavigation({
 				navigateBack,
 				navigateForward,
 				setActiveSessionId,

--- a/src/__tests__/renderer/hooks/utils/useDebouncedPersistence.test.ts
+++ b/src/__tests__/renderer/hooks/utils/useDebouncedPersistence.test.ts
@@ -13,6 +13,8 @@ import type {
 	TerminalTab,
 	BrowserTab,
 } from '../../../../renderer/types';
+import { useSessionStore } from '../../../../renderer/stores/sessionStore';
+import { resetStore } from '../../../helpers/resetStores';
 
 // The renderer sentry module only exports these two helpers, so a full mock is
 // safe and avoids pulling @sentry/electron/renderer into jsdom. Lets us assert
@@ -117,6 +119,18 @@ const makeSession = (overrides: Partial<Session> = {}): Session => {
 /** Create a ref that renderHook can use for initialLoadComplete */
 const makeInitialLoadRef = (value: boolean) => ({ current: value });
 
+function seedSessions(sessions: Session[]) {
+	useSessionStore.setState({ sessions });
+}
+
+function renderPersistence(initialLoadRef: { current: boolean }, delay?: number) {
+	return renderHook(() =>
+		delay === undefined
+			? useDebouncedPersistence(initialLoadRef)
+			: useDebouncedPersistence(initialLoadRef, delay)
+	);
+}
+
 // ---------------------------------------------------------------------------
 // Test suite
 // ---------------------------------------------------------------------------
@@ -125,6 +139,7 @@ describe('useDebouncedPersistence', () => {
 	beforeEach(() => {
 		vi.useFakeTimers();
 		vi.clearAllMocks();
+		resetStore(useSessionStore);
 	});
 
 	afterEach(() => {
@@ -167,11 +182,12 @@ describe('useDebouncedPersistence', () => {
 				});
 
 				const initialLoadRef = makeInitialLoadRef(true);
-				const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+				seedSessions([session]);
+				const { result } = renderPersistence(initialLoadRef);
 
 				// Force flush
 				act(() => {
-					result.current.flushNow();
+					result.current.flushNow(useSessionStore.getState().sessions);
 				});
 
 				const calls = vi.mocked(window.maestro.sessions.setAll).mock.calls;
@@ -202,10 +218,11 @@ describe('useDebouncedPersistence', () => {
 				});
 
 				const initialLoadRef = makeInitialLoadRef(true);
-				const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+				seedSessions([session]);
+				const { result } = renderPersistence(initialLoadRef);
 
 				act(() => {
-					result.current.flushNow();
+					result.current.flushNow(useSessionStore.getState().sessions);
 				});
 
 				const persisted = vi.mocked(window.maestro.sessions.setAll).mock.calls[0][0] as Session[];
@@ -221,10 +238,11 @@ describe('useDebouncedPersistence', () => {
 				});
 
 				const initialLoadRef = makeInitialLoadRef(true);
-				const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+				seedSessions([session]);
+				const { result } = renderPersistence(initialLoadRef);
 
 				act(() => {
-					result.current.flushNow();
+					result.current.flushNow(useSessionStore.getState().sessions);
 				});
 
 				const persisted = vi.mocked(window.maestro.sessions.setAll).mock.calls[0][0] as Session[];
@@ -267,10 +285,11 @@ describe('useDebouncedPersistence', () => {
 				});
 
 				const initialLoadRef = makeInitialLoadRef(true);
-				const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+				seedSessions([session]);
+				const { result } = renderPersistence(initialLoadRef);
 
 				act(() => {
-					result.current.flushNow();
+					result.current.flushNow(useSessionStore.getState().sessions);
 				});
 
 				const persisted = vi.mocked(window.maestro.sessions.setAll).mock.calls[0][0] as Session[];
@@ -308,10 +327,11 @@ describe('useDebouncedPersistence', () => {
 				});
 
 				const initialLoadRef = makeInitialLoadRef(true);
-				const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+				seedSessions([session]);
+				const { result } = renderPersistence(initialLoadRef);
 
 				act(() => {
-					result.current.flushNow();
+					result.current.flushNow(useSessionStore.getState().sessions);
 				});
 
 				const persisted = vi
@@ -357,10 +377,11 @@ describe('useDebouncedPersistence', () => {
 				});
 
 				const initialLoadRef = makeInitialLoadRef(true);
-				const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+				seedSessions([session]);
+				const { result } = renderPersistence(initialLoadRef);
 
 				act(() => {
-					result.current.flushNow();
+					result.current.flushNow(useSessionStore.getState().sessions);
 				});
 
 				const persisted = vi
@@ -392,10 +413,11 @@ describe('useDebouncedPersistence', () => {
 				});
 
 				const initialLoadRef = makeInitialLoadRef(true);
-				const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+				seedSessions([session]);
+				const { result } = renderPersistence(initialLoadRef);
 
 				act(() => {
-					result.current.flushNow();
+					result.current.flushNow(useSessionStore.getState().sessions);
 				});
 
 				const persisted = vi
@@ -428,10 +450,11 @@ describe('useDebouncedPersistence', () => {
 				});
 
 				const initialLoadRef = makeInitialLoadRef(true);
-				const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+				seedSessions([session]);
+				const { result } = renderPersistence(initialLoadRef);
 
 				act(() => {
-					result.current.flushNow();
+					result.current.flushNow(useSessionStore.getState().sessions);
 				});
 
 				const persisted = vi
@@ -457,10 +480,11 @@ describe('useDebouncedPersistence', () => {
 				});
 
 				const initialLoadRef = makeInitialLoadRef(true);
-				const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+				seedSessions([session]);
+				const { result } = renderPersistence(initialLoadRef);
 
 				act(() => {
-					result.current.flushNow();
+					result.current.flushNow(useSessionStore.getState().sessions);
 				});
 
 				const persisted = vi.mocked(window.maestro.sessions.setAll).mock.calls[0][0] as Session[];
@@ -476,10 +500,11 @@ describe('useDebouncedPersistence', () => {
 				});
 
 				const initialLoadRef = makeInitialLoadRef(true);
-				const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+				seedSessions([session]);
+				const { result } = renderPersistence(initialLoadRef);
 
 				act(() => {
-					result.current.flushNow();
+					result.current.flushNow(useSessionStore.getState().sessions);
 				});
 
 				const persisted = vi.mocked(window.maestro.sessions.setAll).mock.calls[0][0] as Session[];
@@ -498,10 +523,11 @@ describe('useDebouncedPersistence', () => {
 				});
 
 				const initialLoadRef = makeInitialLoadRef(true);
-				const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+				seedSessions([session]);
+				const { result } = renderPersistence(initialLoadRef);
 
 				act(() => {
-					result.current.flushNow();
+					result.current.flushNow(useSessionStore.getState().sessions);
 				});
 
 				const persisted = vi.mocked(window.maestro.sessions.setAll).mock.calls[0][0] as Session[];
@@ -518,10 +544,11 @@ describe('useDebouncedPersistence', () => {
 				});
 
 				const initialLoadRef = makeInitialLoadRef(true);
-				const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+				seedSessions([session]);
+				const { result } = renderPersistence(initialLoadRef);
 
 				act(() => {
-					result.current.flushNow();
+					result.current.flushNow(useSessionStore.getState().sessions);
 				});
 
 				const persisted = vi.mocked(window.maestro.sessions.setAll).mock.calls[0][0] as Session[];
@@ -538,10 +565,11 @@ describe('useDebouncedPersistence', () => {
 				});
 
 				const initialLoadRef = makeInitialLoadRef(true);
-				const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+				seedSessions([session]);
+				const { result } = renderPersistence(initialLoadRef);
 
 				act(() => {
-					result.current.flushNow();
+					result.current.flushNow(useSessionStore.getState().sessions);
 				});
 
 				const persisted = vi.mocked(window.maestro.sessions.setAll).mock.calls[0][0] as Session[];
@@ -556,10 +584,11 @@ describe('useDebouncedPersistence', () => {
 				});
 
 				const initialLoadRef = makeInitialLoadRef(true);
-				const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+				seedSessions([session]);
+				const { result } = renderPersistence(initialLoadRef);
 
 				act(() => {
-					result.current.flushNow();
+					result.current.flushNow(useSessionStore.getState().sessions);
 				});
 
 				const persisted = vi.mocked(window.maestro.sessions.setAll).mock.calls[0][0] as Session[];
@@ -582,10 +611,11 @@ describe('useDebouncedPersistence', () => {
 				});
 
 				const initialLoadRef = makeInitialLoadRef(true);
-				const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+				seedSessions([session]);
+				const { result } = renderPersistence(initialLoadRef);
 
 				act(() => {
-					result.current.flushNow();
+					result.current.flushNow(useSessionStore.getState().sessions);
 				});
 
 				const persisted = vi.mocked(window.maestro.sessions.setAll).mock.calls[0][0] as Session[];
@@ -614,10 +644,11 @@ describe('useDebouncedPersistence', () => {
 				});
 
 				const initialLoadRef = makeInitialLoadRef(true);
-				const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+				seedSessions([session]);
+				const { result } = renderPersistence(initialLoadRef);
 
 				act(() => {
-					result.current.flushNow();
+					result.current.flushNow(useSessionStore.getState().sessions);
 				});
 
 				const persisted = vi.mocked(window.maestro.sessions.setAll).mock.calls[0][0] as Session[];
@@ -633,10 +664,11 @@ describe('useDebouncedPersistence', () => {
 				});
 
 				const initialLoadRef = makeInitialLoadRef(true);
-				const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+				seedSessions([session]);
+				const { result } = renderPersistence(initialLoadRef);
 
 				act(() => {
-					result.current.flushNow();
+					result.current.flushNow(useSessionStore.getState().sessions);
 				});
 
 				const persisted = vi.mocked(window.maestro.sessions.setAll).mock.calls[0][0] as Session[];
@@ -654,10 +686,11 @@ describe('useDebouncedPersistence', () => {
 				});
 
 				const initialLoadRef = makeInitialLoadRef(true);
-				const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+				seedSessions([session]);
+				const { result } = renderPersistence(initialLoadRef);
 
 				act(() => {
-					result.current.flushNow();
+					result.current.flushNow(useSessionStore.getState().sessions);
 				});
 
 				const persisted = vi.mocked(window.maestro.sessions.setAll).mock.calls[0][0] as Session[];
@@ -670,10 +703,11 @@ describe('useDebouncedPersistence', () => {
 				});
 
 				const initialLoadRef = makeInitialLoadRef(true);
-				const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+				seedSessions([session]);
+				const { result } = renderPersistence(initialLoadRef);
 
 				act(() => {
-					result.current.flushNow();
+					result.current.flushNow(useSessionStore.getState().sessions);
 				});
 
 				const persisted = vi.mocked(window.maestro.sessions.setAll).mock.calls[0][0] as Session[];
@@ -686,10 +720,11 @@ describe('useDebouncedPersistence', () => {
 				});
 
 				const initialLoadRef = makeInitialLoadRef(true);
-				const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+				seedSessions([session]);
+				const { result } = renderPersistence(initialLoadRef);
 
 				act(() => {
-					result.current.flushNow();
+					result.current.flushNow(useSessionStore.getState().sessions);
 				});
 
 				const persisted = vi.mocked(window.maestro.sessions.setAll).mock.calls[0][0] as Session[];
@@ -702,10 +737,11 @@ describe('useDebouncedPersistence', () => {
 				});
 
 				const initialLoadRef = makeInitialLoadRef(true);
-				const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+				seedSessions([session]);
+				const { result } = renderPersistence(initialLoadRef);
 
 				act(() => {
-					result.current.flushNow();
+					result.current.flushNow(useSessionStore.getState().sessions);
 				});
 
 				const persisted = vi.mocked(window.maestro.sessions.setAll).mock.calls[0][0] as Session[];
@@ -721,10 +757,11 @@ describe('useDebouncedPersistence', () => {
 				});
 
 				const initialLoadRef = makeInitialLoadRef(true);
-				const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+				seedSessions([session]);
+				const { result } = renderPersistence(initialLoadRef);
 
 				act(() => {
-					result.current.flushNow();
+					result.current.flushNow(useSessionStore.getState().sessions);
 				});
 
 				const persisted = vi.mocked(window.maestro.sessions.setAll).mock.calls[0][0] as Session[];
@@ -744,10 +781,11 @@ describe('useDebouncedPersistence', () => {
 				});
 
 				const initialLoadRef = makeInitialLoadRef(true);
-				const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+				seedSessions([session]);
+				const { result } = renderPersistence(initialLoadRef);
 
 				act(() => {
-					result.current.flushNow();
+					result.current.flushNow(useSessionStore.getState().sessions);
 				});
 
 				const persisted = vi.mocked(window.maestro.sessions.setAll).mock.calls[0][0] as Session[];
@@ -769,10 +807,11 @@ describe('useDebouncedPersistence', () => {
 				});
 
 				const initialLoadRef = makeInitialLoadRef(true);
-				const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+				seedSessions([session]);
+				const { result } = renderPersistence(initialLoadRef);
 
 				act(() => {
-					result.current.flushNow();
+					result.current.flushNow(useSessionStore.getState().sessions);
 				});
 
 				const persisted = vi.mocked(window.maestro.sessions.setAll).mock.calls[0][0] as Session[];
@@ -809,10 +848,11 @@ describe('useDebouncedPersistence', () => {
 				});
 
 				const initialLoadRef = makeInitialLoadRef(true);
-				const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+				seedSessions([session]);
+				const { result } = renderPersistence(initialLoadRef);
 
 				act(() => {
-					result.current.flushNow();
+					result.current.flushNow(useSessionStore.getState().sessions);
 				});
 
 				const persisted = vi.mocked(window.maestro.sessions.setAll).mock.calls[0][0] as Session[];
@@ -836,10 +876,11 @@ describe('useDebouncedPersistence', () => {
 				});
 
 				const initialLoadRef = makeInitialLoadRef(true);
-				const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+				seedSessions([session]);
+				const { result } = renderPersistence(initialLoadRef);
 
 				act(() => {
-					result.current.flushNow();
+					result.current.flushNow(useSessionStore.getState().sessions);
 				});
 
 				const persisted = vi.mocked(window.maestro.sessions.setAll).mock.calls[0][0] as Session[];
@@ -862,10 +903,11 @@ describe('useDebouncedPersistence', () => {
 				});
 
 				const initialLoadRef = makeInitialLoadRef(true);
-				const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+				seedSessions([session]);
+				const { result } = renderPersistence(initialLoadRef);
 
 				act(() => {
-					result.current.flushNow();
+					result.current.flushNow(useSessionStore.getState().sessions);
 				});
 
 				const persisted = vi.mocked(window.maestro.sessions.setAll).mock.calls[0][0] as Session[];
@@ -890,10 +932,11 @@ describe('useDebouncedPersistence', () => {
 				});
 
 				const initialLoadRef = makeInitialLoadRef(true);
-				const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+				seedSessions([session]);
+				const { result } = renderPersistence(initialLoadRef);
 
 				act(() => {
-					result.current.flushNow();
+					result.current.flushNow(useSessionStore.getState().sessions);
 				});
 
 				const persisted = vi.mocked(window.maestro.sessions.setAll).mock.calls[0][0] as Session[];
@@ -909,10 +952,11 @@ describe('useDebouncedPersistence', () => {
 				const session = makeSession({ state: 'busy' });
 
 				const initialLoadRef = makeInitialLoadRef(true);
-				const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+				seedSessions([session]);
+				const { result } = renderPersistence(initialLoadRef);
 
 				act(() => {
-					result.current.flushNow();
+					result.current.flushNow(useSessionStore.getState().sessions);
 				});
 
 				const persisted = vi.mocked(window.maestro.sessions.setAll).mock.calls[0][0] as Session[];
@@ -923,10 +967,11 @@ describe('useDebouncedPersistence', () => {
 				const session = makeSession({ busySource: 'ai' });
 
 				const initialLoadRef = makeInitialLoadRef(true);
-				const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+				seedSessions([session]);
+				const { result } = renderPersistence(initialLoadRef);
 
 				act(() => {
-					result.current.flushNow();
+					result.current.flushNow(useSessionStore.getState().sessions);
 				});
 
 				const persisted = vi.mocked(window.maestro.sessions.setAll).mock.calls[0][0] as Session[];
@@ -937,10 +982,11 @@ describe('useDebouncedPersistence', () => {
 				const session = makeSession({ thinkingStartTime: Date.now() });
 
 				const initialLoadRef = makeInitialLoadRef(true);
-				const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+				seedSessions([session]);
+				const { result } = renderPersistence(initialLoadRef);
 
 				act(() => {
-					result.current.flushNow();
+					result.current.flushNow(useSessionStore.getState().sessions);
 				});
 
 				const persisted = vi.mocked(window.maestro.sessions.setAll).mock.calls[0][0] as Session[];
@@ -951,10 +997,11 @@ describe('useDebouncedPersistence', () => {
 				const session = makeSession({ currentCycleTokens: 5000 });
 
 				const initialLoadRef = makeInitialLoadRef(true);
-				const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+				seedSessions([session]);
+				const { result } = renderPersistence(initialLoadRef);
 
 				act(() => {
-					result.current.flushNow();
+					result.current.flushNow(useSessionStore.getState().sessions);
 				});
 
 				const persisted = vi.mocked(window.maestro.sessions.setAll).mock.calls[0][0] as Session[];
@@ -965,10 +1012,11 @@ describe('useDebouncedPersistence', () => {
 				const session = makeSession({ currentCycleBytes: 128000 });
 
 				const initialLoadRef = makeInitialLoadRef(true);
-				const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+				seedSessions([session]);
+				const { result } = renderPersistence(initialLoadRef);
 
 				act(() => {
-					result.current.flushNow();
+					result.current.flushNow(useSessionStore.getState().sessions);
 				});
 
 				const persisted = vi.mocked(window.maestro.sessions.setAll).mock.calls[0][0] as Session[];
@@ -979,10 +1027,11 @@ describe('useDebouncedPersistence', () => {
 				const session = makeSession({ statusMessage: 'Agent is thinking...' });
 
 				const initialLoadRef = makeInitialLoadRef(true);
-				const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+				seedSessions([session]);
+				const { result } = renderPersistence(initialLoadRef);
 
 				act(() => {
-					result.current.flushNow();
+					result.current.flushNow(useSessionStore.getState().sessions);
 				});
 
 				const persisted = vi.mocked(window.maestro.sessions.setAll).mock.calls[0][0] as Session[];
@@ -997,10 +1046,11 @@ describe('useDebouncedPersistence', () => {
 				});
 
 				const initialLoadRef = makeInitialLoadRef(true);
-				const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+				seedSessions([session]);
+				const { result } = renderPersistence(initialLoadRef);
 
 				act(() => {
-					result.current.flushNow();
+					result.current.flushNow(useSessionStore.getState().sessions);
 				});
 
 				const persisted = vi.mocked(window.maestro.sessions.setAll).mock.calls[0][0] as Session[];
@@ -1011,10 +1061,11 @@ describe('useDebouncedPersistence', () => {
 				const session = makeSession({ sshRemoteId: 'remote-1' });
 
 				const initialLoadRef = makeInitialLoadRef(true);
-				const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+				seedSessions([session]);
+				const { result } = renderPersistence(initialLoadRef);
 
 				act(() => {
-					result.current.flushNow();
+					result.current.flushNow(useSessionStore.getState().sessions);
 				});
 
 				const persisted = vi.mocked(window.maestro.sessions.setAll).mock.calls[0][0] as Session[];
@@ -1025,10 +1076,11 @@ describe('useDebouncedPersistence', () => {
 				const session = makeSession({ remoteCwd: '/remote/home/user/project' });
 
 				const initialLoadRef = makeInitialLoadRef(true);
-				const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+				seedSessions([session]);
+				const { result } = renderPersistence(initialLoadRef);
 
 				act(() => {
-					result.current.flushNow();
+					result.current.flushNow(useSessionStore.getState().sessions);
 				});
 
 				const persisted = vi.mocked(window.maestro.sessions.setAll).mock.calls[0][0] as Session[];
@@ -1059,10 +1111,11 @@ describe('useDebouncedPersistence', () => {
 				});
 
 				const initialLoadRef = makeInitialLoadRef(true);
-				const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+				seedSessions([session]);
+				const { result } = renderPersistence(initialLoadRef);
 
 				act(() => {
-					result.current.flushNow();
+					result.current.flushNow(useSessionStore.getState().sessions);
 				});
 
 				const persisted = vi.mocked(window.maestro.sessions.setAll).mock.calls[0][0] as Session[];
@@ -1079,10 +1132,11 @@ describe('useDebouncedPersistence', () => {
 				});
 
 				const initialLoadRef = makeInitialLoadRef(true);
-				const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+				seedSessions([session]);
+				const { result } = renderPersistence(initialLoadRef);
 
 				act(() => {
-					result.current.flushNow();
+					result.current.flushNow(useSessionStore.getState().sessions);
 				});
 
 				const persisted = vi.mocked(window.maestro.sessions.setAll).mock.calls[0][0] as Session[];
@@ -1110,10 +1164,11 @@ describe('useDebouncedPersistence', () => {
 				});
 
 				const initialLoadRef = makeInitialLoadRef(true);
-				const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+				seedSessions([session]);
+				const { result } = renderPersistence(initialLoadRef);
 
 				act(() => {
-					result.current.flushNow();
+					result.current.flushNow(useSessionStore.getState().sessions);
 				});
 
 				const persisted = vi.mocked(window.maestro.sessions.setAll).mock.calls[0][0] as Session[];
@@ -1133,10 +1188,11 @@ describe('useDebouncedPersistence', () => {
 				});
 
 				const initialLoadRef = makeInitialLoadRef(true);
-				const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+				seedSessions([session]);
+				const { result } = renderPersistence(initialLoadRef);
 
 				act(() => {
-					result.current.flushNow();
+					result.current.flushNow(useSessionStore.getState().sessions);
 				});
 
 				const persisted = vi.mocked(window.maestro.sessions.setAll).mock.calls[0][0] as Session[];
@@ -1161,10 +1217,11 @@ describe('useDebouncedPersistence', () => {
 				});
 
 				const initialLoadRef = makeInitialLoadRef(true);
-				const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+				seedSessions([session]);
+				const { result } = renderPersistence(initialLoadRef);
 
 				act(() => {
-					result.current.flushNow();
+					result.current.flushNow(useSessionStore.getState().sessions);
 				});
 
 				const persisted = vi.mocked(window.maestro.sessions.setAll).mock.calls[0][0] as Session[];
@@ -1190,10 +1247,11 @@ describe('useDebouncedPersistence', () => {
 				});
 
 				const initialLoadRef = makeInitialLoadRef(true);
-				const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+				seedSessions([session]);
+				const { result } = renderPersistence(initialLoadRef);
 
 				act(() => {
-					result.current.flushNow();
+					result.current.flushNow(useSessionStore.getState().sessions);
 				});
 
 				const persisted = vi.mocked(window.maestro.sessions.setAll).mock.calls[0][0] as Session[];
@@ -1222,12 +1280,11 @@ describe('useDebouncedPersistence', () => {
 				});
 
 				const initialLoadRef = makeInitialLoadRef(true);
-				const { result } = renderHook(() =>
-					useDebouncedPersistence([session1, session2], initialLoadRef)
-				);
+				seedSessions([session1, session2]);
+				const { result } = renderPersistence(initialLoadRef);
 
 				act(() => {
-					result.current.flushNow();
+					result.current.flushNow(useSessionStore.getState().sessions);
 				});
 
 				const persisted = vi.mocked(window.maestro.sessions.setAll).mock.calls[0][0] as Session[];
@@ -1255,7 +1312,10 @@ describe('useDebouncedPersistence', () => {
 				const session = makeSession();
 				const initialLoadRef = makeInitialLoadRef(false);
 
-				renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+				const hook = renderPersistence(initialLoadRef);
+				act(() => {
+					seedSessions([session]);
+				});
 
 				// Advance well past the debounce delay
 				act(() => {
@@ -1269,25 +1329,24 @@ describe('useDebouncedPersistence', () => {
 				const session = makeSession();
 				const initialLoadRef = makeInitialLoadRef(false);
 
-				const { rerender } = renderHook(
-					({ sessions, ref }) => useDebouncedPersistence(sessions, ref),
-					{
-						initialProps: { sessions: [session], ref: initialLoadRef },
-					}
-				);
+				renderPersistence(initialLoadRef);
 
-				// Initially should not persist
+				// Session change while load incomplete must not persist
+				act(() => {
+					seedSessions([session]);
+				});
 				act(() => {
 					vi.advanceTimersByTime(3000);
 				});
 				expect(window.maestro.sessions.setAll).not.toHaveBeenCalled();
 
-				// Mark initial load as complete and trigger re-render with new sessions array
+				// Mark initial load complete, then mutate sessions to schedule persist
 				initialLoadRef.current = true;
 				const updatedSession = makeSession({ id: session.id, name: 'Updated' });
-				rerender({ sessions: [updatedSession], ref: initialLoadRef });
+				act(() => {
+					seedSessions([updatedSession]);
+				});
 
-				// Advance past the debounce delay
 				act(() => {
 					vi.advanceTimersByTime(2000);
 				});
@@ -1301,7 +1360,10 @@ describe('useDebouncedPersistence', () => {
 				const session = makeSession();
 				const initialLoadRef = makeInitialLoadRef(true);
 
-				renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+				const hook = renderPersistence(initialLoadRef);
+				act(() => {
+					seedSessions([session]);
+				});
 
 				// Don't advance timers - it should not have been called yet
 				expect(window.maestro.sessions.setAll).not.toHaveBeenCalled();
@@ -1311,7 +1373,10 @@ describe('useDebouncedPersistence', () => {
 				const session = makeSession();
 				const initialLoadRef = makeInitialLoadRef(true);
 
-				renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+				const hook = renderPersistence(initialLoadRef);
+				act(() => {
+					seedSessions([session]);
+				});
 
 				act(() => {
 					vi.advanceTimersByTime(2000);
@@ -1324,10 +1389,10 @@ describe('useDebouncedPersistence', () => {
 				const session1 = makeSession({ id: 's1', name: 'First' });
 				const initialLoadRef = makeInitialLoadRef(true);
 
-				const { rerender } = renderHook(
-					({ sessions }) => useDebouncedPersistence(sessions, initialLoadRef),
-					{ initialProps: { sessions: [session1] } }
-				);
+				renderPersistence(initialLoadRef);
+				act(() => {
+					seedSessions([session1]);
+				});
 
 				// Advance 1500ms (not enough for debounce)
 				act(() => {
@@ -1337,7 +1402,9 @@ describe('useDebouncedPersistence', () => {
 
 				// Trigger a new session change which resets the timer
 				const session2 = makeSession({ id: 's1', name: 'Second' });
-				rerender({ sessions: [session2] });
+				act(() => {
+					seedSessions([session2]);
+				});
 
 				// Advance another 1500ms (total 3000ms from start, but only 1500ms from last change)
 				act(() => {
@@ -1356,7 +1423,10 @@ describe('useDebouncedPersistence', () => {
 				const session = makeSession();
 				const initialLoadRef = makeInitialLoadRef(true);
 
-				renderHook(() => useDebouncedPersistence([session], initialLoadRef, 500));
+				const hook = renderPersistence(initialLoadRef, 500);
+				act(() => {
+					seedSessions([session]);
+				});
 
 				act(() => {
 					vi.advanceTimersByTime(499);
@@ -1375,14 +1445,9 @@ describe('useDebouncedPersistence', () => {
 				const session = makeSession();
 				const initialLoadRef = makeInitialLoadRef(true);
 
-				const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
-
-				// The hook sets isPending in a useEffect, need to flush effects
-				// isPending won't be true until after the effect runs
-				// We need to advance to allow the effect to set isPending
+				const { result } = renderPersistence(initialLoadRef);
 				act(() => {
-					// trigger the effect by advancing minimally (not the full debounce)
-					vi.advanceTimersByTime(0);
+					seedSessions([session]);
 				});
 
 				act(() => {
@@ -1396,16 +1461,9 @@ describe('useDebouncedPersistence', () => {
 				const sessions = [makeSession()];
 				const initialLoadRef = makeInitialLoadRef(true);
 
-				// Use a stable sessions reference via initialProps to avoid
-				// creating a new array on each render (which would re-trigger
-				// the debounce effect)
-				const { result } = renderHook(({ s }) => useDebouncedPersistence(s, initialLoadRef), {
-					initialProps: { s: sessions },
-				});
-
-				// Allow effect to set isPending
+				const { result } = renderPersistence(initialLoadRef);
 				act(() => {
-					vi.advanceTimersByTime(0);
+					seedSessions(sessions);
 				});
 
 				vi.clearAllMocks();
@@ -1431,23 +1489,21 @@ describe('useDebouncedPersistence', () => {
 				const sessions = [makeSession({ id: 's1' })];
 				const initialLoadRef = makeInitialLoadRef(true);
 
-				const { result } = renderHook(({ s }) => useDebouncedPersistence(s, initialLoadRef), {
-					initialProps: { s: sessions },
-				});
+				seedSessions(sessions);
+				const { result } = renderPersistence(initialLoadRef);
 
 				// Seed the baseline with the initial setAll flush. Await the async
 				// persist so flushingRef settles before the next flush; clear mocks
 				// so the assertion only sees the snapshot-driven flush.
 				await act(async () => {
-					result.current.flushNow();
+					result.current.flushNow(sessions);
 					await Promise.resolve();
 				});
 				vi.clearAllMocks();
 
-				// Simulate a synchronous mutation the hook hasn't re-rendered for
-				// yet: a fresh sessions array the rendered `sessions` prop never
-				// carried. Passing it to flushNow must persist it via setMany even
-				// though isPending is false (no render happened).
+				// Simulate a synchronous mutation the hook hasn't observed via
+				// store subscribe yet. Passing it to flushNow must persist it via
+				// setMany even though isPending is false.
 				const mutated = [makeSession({ id: 's1', name: 'Renamed Via Snapshot' })];
 				act(() => {
 					result.current.flushNow(mutated);
@@ -1466,12 +1522,11 @@ describe('useDebouncedPersistence', () => {
 				const original = [makeSession({ id: 's1', name: 'Original' })];
 				const initialLoadRef = makeInitialLoadRef(true);
 
-				const { result } = renderHook(({ s }) => useDebouncedPersistence(s, initialLoadRef), {
-					initialProps: { s: original },
-				});
+				seedSessions(original);
+				const { result } = renderPersistence(initialLoadRef);
 
 				await act(async () => {
-					result.current.flushNow();
+					result.current.flushNow(original);
 					await Promise.resolve();
 				});
 				vi.clearAllMocks();
@@ -1491,7 +1546,8 @@ describe('useDebouncedPersistence', () => {
 				const session = makeSession();
 				const initialLoadRef = makeInitialLoadRef(false);
 
-				const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+				seedSessions([session]);
+				const { result } = renderPersistence(initialLoadRef);
 
 				expect(result.current.isPending).toBe(false);
 			});
@@ -1500,10 +1556,11 @@ describe('useDebouncedPersistence', () => {
 				const session = makeSession();
 				const initialLoadRef = makeInitialLoadRef(true);
 
-				const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+				const { result } = renderPersistence(initialLoadRef);
+				act(() => {
+					seedSessions([session]);
+				});
 
-				// The useEffect sets isPending to true
-				// It runs asynchronously after render
 				expect(result.current.isPending).toBe(true);
 			});
 
@@ -1511,9 +1568,9 @@ describe('useDebouncedPersistence', () => {
 				const sessions = [makeSession()];
 				const initialLoadRef = makeInitialLoadRef(true);
 
-				// Use stable sessions reference via initialProps
-				const { result } = renderHook(({ s }) => useDebouncedPersistence(s, initialLoadRef), {
-					initialProps: { s: sessions },
+				const { result } = renderPersistence(initialLoadRef);
+				act(() => {
+					seedSessions(sessions);
 				});
 
 				expect(result.current.isPending).toBe(true);
@@ -1531,9 +1588,9 @@ describe('useDebouncedPersistence', () => {
 				const sessions = [makeSession()];
 				const initialLoadRef = makeInitialLoadRef(true);
 
-				// Use stable sessions reference via initialProps
-				const { result } = renderHook(({ s }) => useDebouncedPersistence(s, initialLoadRef), {
-					initialProps: { s: sessions },
+				const { result } = renderPersistence(initialLoadRef);
+				act(() => {
+					seedSessions(sessions);
 				});
 
 				expect(result.current.isPending).toBe(true);
@@ -1554,7 +1611,8 @@ describe('useDebouncedPersistence', () => {
 				const session = makeSession();
 				const initialLoadRef = makeInitialLoadRef(true);
 
-				const { unmount } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+				seedSessions([session]);
+				const { unmount } = renderPersistence(initialLoadRef);
 
 				unmount();
 
@@ -1566,7 +1624,8 @@ describe('useDebouncedPersistence', () => {
 				const session = makeSession();
 				const initialLoadRef = makeInitialLoadRef(false);
 
-				const { unmount } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+				seedSessions([session]);
+				const { unmount } = renderPersistence(initialLoadRef);
 
 				unmount();
 
@@ -1598,10 +1657,11 @@ describe('useDebouncedPersistence', () => {
 				});
 
 				const initialLoadRef = makeInitialLoadRef(true);
-				const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+				seedSessions([session]);
+				const { result } = renderPersistence(initialLoadRef);
 
 				act(() => {
-					result.current.flushNow();
+					result.current.flushNow(useSessionStore.getState().sessions);
 				});
 
 				const persisted = vi.mocked(window.maestro.sessions.setAll).mock.calls[0][0] as Session[];
@@ -1625,10 +1685,11 @@ describe('useDebouncedPersistence', () => {
 				});
 
 				const initialLoadRef = makeInitialLoadRef(true);
-				const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+				seedSessions([session]);
+				const { result } = renderPersistence(initialLoadRef);
 
 				act(() => {
-					result.current.flushNow();
+					result.current.flushNow(useSessionStore.getState().sessions);
 				});
 
 				const persisted = vi.mocked(window.maestro.sessions.setAll).mock.calls[0][0] as Session[];
@@ -1646,10 +1707,11 @@ describe('useDebouncedPersistence', () => {
 				});
 
 				const initialLoadRef = makeInitialLoadRef(true);
-				const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+				seedSessions([session]);
+				const { result } = renderPersistence(initialLoadRef);
 
 				act(() => {
-					result.current.flushNow();
+					result.current.flushNow(useSessionStore.getState().sessions);
 				});
 
 				const persisted = vi.mocked(window.maestro.sessions.setAll).mock.calls[0][0] as Session[];
@@ -1669,10 +1731,11 @@ describe('useDebouncedPersistence', () => {
 				});
 
 				const initialLoadRef = makeInitialLoadRef(true);
-				const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+				seedSessions([session]);
+				const { result } = renderPersistence(initialLoadRef);
 
 				act(() => {
-					result.current.flushNow();
+					result.current.flushNow(useSessionStore.getState().sessions);
 				});
 
 				const persisted = vi.mocked(window.maestro.sessions.setAll).mock.calls[0][0] as Session[];
@@ -1691,10 +1754,11 @@ describe('useDebouncedPersistence', () => {
 				});
 
 				const initialLoadRef = makeInitialLoadRef(true);
-				const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+				seedSessions([session]);
+				const { result } = renderPersistence(initialLoadRef);
 
 				act(() => {
-					result.current.flushNow();
+					result.current.flushNow(useSessionStore.getState().sessions);
 				});
 
 				const persisted = vi.mocked(window.maestro.sessions.setAll).mock.calls[0][0] as Session[];
@@ -1715,10 +1779,11 @@ describe('useDebouncedPersistence', () => {
 				});
 
 				const initialLoadRef = makeInitialLoadRef(true);
-				const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+				seedSessions([session]);
+				const { result } = renderPersistence(initialLoadRef);
 
 				act(() => {
-					result.current.flushNow();
+					result.current.flushNow(useSessionStore.getState().sessions);
 				});
 
 				const persisted = vi.mocked(window.maestro.sessions.setAll).mock.calls[0][0] as Session[];
@@ -1741,12 +1806,11 @@ describe('useDebouncedPersistence', () => {
 				});
 
 				const initialLoadRef = makeInitialLoadRef(true);
-				const { result } = renderHook(() =>
-					useDebouncedPersistence([session1, session2], initialLoadRef)
-				);
+				seedSessions([session1, session2]);
+				const { result } = renderPersistence(initialLoadRef);
 
 				act(() => {
-					result.current.flushNow();
+					result.current.flushNow(useSessionStore.getState().sessions);
 				});
 
 				const persisted = vi.mocked(window.maestro.sessions.setAll).mock.calls[0][0] as Session[];
@@ -1772,10 +1836,11 @@ describe('useDebouncedPersistence', () => {
 				});
 
 				const initialLoadRef = makeInitialLoadRef(true);
-				const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+				seedSessions([session]);
+				const { result } = renderPersistence(initialLoadRef);
 
 				act(() => {
-					result.current.flushNow();
+					result.current.flushNow(useSessionStore.getState().sessions);
 				});
 
 				const persisted = vi.mocked(window.maestro.sessions.setAll).mock.calls[0][0] as Session[];
@@ -1794,10 +1859,11 @@ describe('useDebouncedPersistence', () => {
 				});
 
 				const initialLoadRef = makeInitialLoadRef(true);
-				const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+				seedSessions([session]);
+				const { result } = renderPersistence(initialLoadRef);
 
 				act(() => {
-					result.current.flushNow();
+					result.current.flushNow(useSessionStore.getState().sessions);
 				});
 
 				const persisted = vi.mocked(window.maestro.sessions.setAll).mock.calls[0][0] as Session[];
@@ -1811,10 +1877,11 @@ describe('useDebouncedPersistence', () => {
 				delete (session as Partial<Session>).filePreviewTabs;
 
 				const initialLoadRef = makeInitialLoadRef(true);
-				const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+				seedSessions([session]);
+				const { result } = renderPersistence(initialLoadRef);
 
 				act(() => {
-					result.current.flushNow();
+					result.current.flushNow(useSessionStore.getState().sessions);
 				});
 
 				const persisted = vi.mocked(window.maestro.sessions.setAll).mock.calls[0][0] as Session[];
@@ -1835,10 +1902,11 @@ describe('useDebouncedPersistence', () => {
 				});
 
 				const initialLoadRef = makeInitialLoadRef(true);
-				const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+				seedSessions([session]);
+				const { result } = renderPersistence(initialLoadRef);
 
 				act(() => {
-					result.current.flushNow();
+					result.current.flushNow(useSessionStore.getState().sessions);
 				});
 
 				const persisted = vi.mocked(window.maestro.sessions.setAll).mock.calls[0][0] as Session[];
@@ -1856,10 +1924,11 @@ describe('useDebouncedPersistence', () => {
 				});
 
 				const initialLoadRef = makeInitialLoadRef(true);
-				const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+				seedSessions([session]);
+				const { result } = renderPersistence(initialLoadRef);
 
 				act(() => {
-					result.current.flushNow();
+					result.current.flushNow(useSessionStore.getState().sessions);
 				});
 
 				const persisted = vi.mocked(window.maestro.sessions.setAll).mock.calls[0][0] as Session[];
@@ -1899,10 +1968,11 @@ describe('useDebouncedPersistence', () => {
 			});
 
 			const initialLoadRef = makeInitialLoadRef(true);
-			const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+			seedSessions([session]);
+			const { result } = renderPersistence(initialLoadRef);
 
 			act(() => {
-				result.current.flushNow();
+				result.current.flushNow(useSessionStore.getState().sessions);
 			});
 
 			const persisted = vi.mocked(window.maestro.sessions.setAll).mock.calls[0][0] as Session[];
@@ -1930,10 +2000,11 @@ describe('useDebouncedPersistence', () => {
 			});
 
 			const initialLoadRef = makeInitialLoadRef(true);
-			const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+			seedSessions([session]);
+			const { result } = renderPersistence(initialLoadRef);
 
 			act(() => {
-				result.current.flushNow();
+				result.current.flushNow(useSessionStore.getState().sessions);
 			});
 
 			const persisted = vi.mocked(window.maestro.sessions.setAll).mock.calls[0][0] as Session[];
@@ -1957,10 +2028,11 @@ describe('useDebouncedPersistence', () => {
 			});
 
 			const initialLoadRef = makeInitialLoadRef(true);
-			const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+			seedSessions([session]);
+			const { result } = renderPersistence(initialLoadRef);
 
 			act(() => {
-				result.current.flushNow();
+				result.current.flushNow(useSessionStore.getState().sessions);
 			});
 
 			const persisted = vi.mocked(window.maestro.sessions.setAll).mock.calls[0][0] as Session[];
@@ -1975,10 +2047,11 @@ describe('useDebouncedPersistence', () => {
 			});
 
 			const initialLoadRef = makeInitialLoadRef(true);
-			const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+			seedSessions([session]);
+			const { result } = renderPersistence(initialLoadRef);
 
 			act(() => {
-				result.current.flushNow();
+				result.current.flushNow(useSessionStore.getState().sessions);
 			});
 
 			const persisted = vi.mocked(window.maestro.sessions.setAll).mock.calls[0][0] as Session[];
@@ -1990,10 +2063,11 @@ describe('useDebouncedPersistence', () => {
 			delete (session as Partial<Session>).terminalTabs;
 
 			const initialLoadRef = makeInitialLoadRef(true);
-			const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+			seedSessions([session]);
+			const { result } = renderPersistence(initialLoadRef);
 
 			act(() => {
-				result.current.flushNow();
+				result.current.flushNow(useSessionStore.getState().sessions);
 			});
 
 			const persisted = vi.mocked(window.maestro.sessions.setAll).mock.calls[0][0] as Session[];
@@ -2007,10 +2081,11 @@ describe('useDebouncedPersistence', () => {
 			});
 
 			const initialLoadRef = makeInitialLoadRef(true);
-			const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+			seedSessions([session]);
+			const { result } = renderPersistence(initialLoadRef);
 
 			act(() => {
-				result.current.flushNow();
+				result.current.flushNow(useSessionStore.getState().sessions);
 			});
 
 			const persisted = vi.mocked(window.maestro.sessions.setAll).mock.calls[0][0] as Session[];
@@ -2024,10 +2099,11 @@ describe('useDebouncedPersistence', () => {
 			});
 
 			const initialLoadRef = makeInitialLoadRef(true);
-			const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+			seedSessions([session]);
+			const { result } = renderPersistence(initialLoadRef);
 
 			act(() => {
-				result.current.flushNow();
+				result.current.flushNow(useSessionStore.getState().sessions);
 			});
 
 			const persisted = vi.mocked(window.maestro.sessions.setAll).mock.calls[0][0] as Session[];
@@ -2041,10 +2117,11 @@ describe('useDebouncedPersistence', () => {
 			});
 
 			const initialLoadRef = makeInitialLoadRef(true);
-			const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+			seedSessions([session]);
+			const { result } = renderPersistence(initialLoadRef);
 
 			act(() => {
-				result.current.flushNow();
+				result.current.flushNow(useSessionStore.getState().sessions);
 			});
 
 			const persisted = vi.mocked(window.maestro.sessions.setAll).mock.calls[0][0] as Session[];
@@ -2061,10 +2138,11 @@ describe('useDebouncedPersistence', () => {
 			});
 
 			const initialLoadRef = makeInitialLoadRef(true);
-			const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+			seedSessions([session]);
+			const { result } = renderPersistence(initialLoadRef);
 
 			act(() => {
-				result.current.flushNow();
+				result.current.flushNow(useSessionStore.getState().sessions);
 			});
 
 			const persisted = vi.mocked(window.maestro.sessions.setAll).mock.calls[0][0] as Session[];
@@ -2094,7 +2172,10 @@ describe('useDebouncedPersistence', () => {
 			const s1 = makeSession({ id: 's1', name: 'One' });
 			const initialLoadRef = makeInitialLoadRef(true);
 
-			renderHook(() => useDebouncedPersistence([s1], initialLoadRef));
+			const hook = renderPersistence(initialLoadRef);
+			act(() => {
+				seedSessions([s1]);
+			});
 			act(() => {
 				vi.advanceTimersByTime(2000);
 			});
@@ -2108,10 +2189,10 @@ describe('useDebouncedPersistence', () => {
 			const s2 = makeSession({ id: 's2', name: 'Two' });
 			const initialLoadRef = makeInitialLoadRef(true);
 
-			const { rerender } = renderHook(
-				({ sessions }) => useDebouncedPersistence(sessions, initialLoadRef),
-				{ initialProps: { sessions: [s1, s2] } }
-			);
+			renderPersistence(initialLoadRef);
+			act(() => {
+				seedSessions([s1, s2]);
+			});
 			// First flush — establishes baseline via setAll. Async because
 			// persistInternal awaits the IPC; the baseline is only captured
 			// after the mock's resolved promise flushes through microtasks.
@@ -2122,7 +2203,9 @@ describe('useDebouncedPersistence', () => {
 
 			// Mutate s1 only — Zustand pattern produces a new session object
 			const s1Updated = { ...s1, name: 'One Updated' };
-			rerender({ sessions: [s1Updated, s2] });
+			act(() => {
+				seedSessions([s1Updated, s2]);
+			});
 			await act(async () => {
 				await vi.advanceTimersByTimeAsync(2000);
 			});
@@ -2142,19 +2225,20 @@ describe('useDebouncedPersistence', () => {
 			const s1 = makeSession({ id: 's1', name: 'One' });
 			const initialLoadRef = makeInitialLoadRef(true);
 
-			const { rerender } = renderHook(
-				({ sessions }) => useDebouncedPersistence(sessions, initialLoadRef),
-				{ initialProps: { sessions: [s1] } }
-			);
+			renderPersistence(initialLoadRef);
+			act(() => {
+				seedSessions([s1]);
+			});
 			await act(async () => {
 				await vi.advanceTimersByTimeAsync(2000);
 			});
 			vi.mocked(window.maestro.sessions.setAll).mockClear();
 			vi.mocked(window.maestro.sessions.setMany).mockClear();
 
-			// Same array reference — re-render forces effect to re-run but the
-			// diff finds nothing changed.
-			rerender({ sessions: [s1] });
+			// Same sessions reference — store subscribe sees no change, so no IPC.
+			act(() => {
+				seedSessions([s1]);
+			});
 			await act(async () => {
 				await vi.advanceTimersByTimeAsync(2000);
 			});
@@ -2168,16 +2252,18 @@ describe('useDebouncedPersistence', () => {
 			const s2 = makeSession({ id: 's2' });
 			const initialLoadRef = makeInitialLoadRef(true);
 
-			const { rerender } = renderHook(
-				({ sessions }) => useDebouncedPersistence(sessions, initialLoadRef),
-				{ initialProps: { sessions: [s1, s2] } }
-			);
+			renderPersistence(initialLoadRef);
+			act(() => {
+				seedSessions([s1, s2]);
+			});
 			await act(async () => {
 				await vi.advanceTimersByTimeAsync(2000);
 			});
 			vi.mocked(window.maestro.sessions.setMany).mockClear();
 
-			rerender({ sessions: [s1] });
+			act(() => {
+				seedSessions([s1]);
+			});
 			await act(async () => {
 				await vi.advanceTimersByTimeAsync(2000);
 			});
@@ -2196,16 +2282,18 @@ describe('useDebouncedPersistence', () => {
 			const s2 = makeSession({ id: 's2' });
 			const initialLoadRef = makeInitialLoadRef(true);
 
-			const { rerender } = renderHook(
-				({ sessions }) => useDebouncedPersistence(sessions, initialLoadRef),
-				{ initialProps: { sessions: [s1] } }
-			);
+			renderPersistence(initialLoadRef);
+			act(() => {
+				seedSessions([s1]);
+			});
 			await act(async () => {
 				await vi.advanceTimersByTimeAsync(2000);
 			});
 			vi.mocked(window.maestro.sessions.setMany).mockClear();
 
-			rerender({ sessions: [s1, s2] });
+			act(() => {
+				seedSessions([s1, s2]);
+			});
 			await act(async () => {
 				await vi.advanceTimersByTimeAsync(2000);
 			});
@@ -2225,10 +2313,10 @@ describe('useDebouncedPersistence', () => {
 			const s3 = makeSession({ id: 's3', name: 'Drop' });
 			const initialLoadRef = makeInitialLoadRef(true);
 
-			const { rerender } = renderHook(
-				({ sessions }) => useDebouncedPersistence(sessions, initialLoadRef),
-				{ initialProps: { sessions: [s1, s2, s3] } }
-			);
+			renderPersistence(initialLoadRef);
+			act(() => {
+				seedSessions([s1, s2, s3]);
+			});
 			await act(async () => {
 				await vi.advanceTimersByTimeAsync(2000);
 			});
@@ -2236,7 +2324,9 @@ describe('useDebouncedPersistence', () => {
 
 			const s2Updated = { ...s2, name: 'Mutated' };
 			const s4 = makeSession({ id: 's4', name: 'New' });
-			rerender({ sessions: [s1, s2Updated, s4] });
+			act(() => {
+				seedSessions([s1, s2Updated, s4]);
+			});
 			await act(async () => {
 				await vi.advanceTimersByTimeAsync(2000);
 			});
@@ -2253,25 +2343,31 @@ describe('useDebouncedPersistence', () => {
 			const s1 = makeSession({ id: 's1', name: 'A' });
 			const initialLoadRef = makeInitialLoadRef(true);
 
-			const { rerender } = renderHook(
-				({ sessions }) => useDebouncedPersistence(sessions, initialLoadRef),
-				{ initialProps: { sessions: [s1] } }
-			);
+			renderPersistence(initialLoadRef);
+			act(() => {
+				seedSessions([s1]);
+			});
 			await act(async () => {
 				await vi.advanceTimersByTimeAsync(2000);
 			});
 			vi.mocked(window.maestro.sessions.setMany).mockClear();
 
 			// Three rapid mutations within the debounce window
-			rerender({ sessions: [{ ...s1, name: 'B' }] });
+			act(() => {
+				seedSessions([{ ...s1, name: 'B' }]);
+			});
 			await act(async () => {
 				await vi.advanceTimersByTimeAsync(500);
 			});
-			rerender({ sessions: [{ ...s1, name: 'C' }] });
+			act(() => {
+				seedSessions([{ ...s1, name: 'C' }]);
+			});
 			await act(async () => {
 				await vi.advanceTimersByTimeAsync(500);
 			});
-			rerender({ sessions: [{ ...s1, name: 'D' }] });
+			act(() => {
+				seedSessions([{ ...s1, name: 'D' }]);
+			});
 			await act(async () => {
 				await vi.advanceTimersByTimeAsync(2000);
 			});
@@ -2288,16 +2384,18 @@ describe('useDebouncedPersistence', () => {
 			const s1 = makeSession({ id: 's1', name: 'A' });
 			const initialLoadRef = makeInitialLoadRef(true);
 
-			const { result, rerender } = renderHook(
-				({ sessions }) => useDebouncedPersistence(sessions, initialLoadRef),
-				{ initialProps: { sessions: [s1] } }
-			);
+			const { result } = renderPersistence(initialLoadRef);
+			act(() => {
+				seedSessions([s1]);
+			});
 			await act(async () => {
 				await vi.advanceTimersByTimeAsync(2000);
 			});
 			vi.mocked(window.maestro.sessions.setMany).mockClear();
 
-			rerender({ sessions: [{ ...s1, name: 'B' }] });
+			act(() => {
+				seedSessions([{ ...s1, name: 'B' }]);
+			});
 			await act(async () => {
 				result.current.flushNow();
 				await vi.advanceTimersByTimeAsync(0);
@@ -2310,17 +2408,19 @@ describe('useDebouncedPersistence', () => {
 			const s1 = makeSession({ id: 's1', name: 'A' });
 			const initialLoadRef = makeInitialLoadRef(true);
 
-			const { rerender, unmount } = renderHook(
-				({ sessions }) => useDebouncedPersistence(sessions, initialLoadRef),
-				{ initialProps: { sessions: [s1] } }
-			);
+			const { unmount } = renderPersistence(initialLoadRef);
+			act(() => {
+				seedSessions([s1]);
+			});
 			await act(async () => {
 				await vi.advanceTimersByTimeAsync(2000);
 			});
 			vi.mocked(window.maestro.sessions.setAll).mockClear();
 			vi.mocked(window.maestro.sessions.setMany).mockClear();
 
-			rerender({ sessions: [{ ...s1, name: 'B' }] });
+			act(() => {
+				seedSessions([{ ...s1, name: 'B' }]);
+			});
 			unmount();
 
 			expect(window.maestro.sessions.setMany).toHaveBeenCalledTimes(1);
@@ -2336,10 +2436,10 @@ describe('useDebouncedPersistence', () => {
 			const s1 = makeSession({ id: 's1', name: 'One' });
 			const initialLoadRef = makeInitialLoadRef(true);
 
-			const { result, rerender } = renderHook(
-				({ sessions }) => useDebouncedPersistence(sessions, initialLoadRef),
-				{ initialProps: { sessions: [s1] } }
-			);
+			const { result } = renderPersistence(initialLoadRef);
+			act(() => {
+				seedSessions([s1]);
+			});
 			// First flush succeeds (mock returns undefined, treated as truthy).
 			await act(async () => {
 				await vi.advanceTimersByTimeAsync(2000);
@@ -2349,7 +2449,9 @@ describe('useDebouncedPersistence', () => {
 
 			// Next flush hits a recoverable disk error.
 			vi.mocked(window.maestro.sessions.setMany).mockResolvedValueOnce(false);
-			rerender({ sessions: [{ ...s1, name: 'Two' }] });
+			act(() => {
+				seedSessions([{ ...s1, name: 'Two' }]);
+			});
 			await act(async () => {
 				await vi.advanceTimersByTimeAsync(2000);
 			});
@@ -2362,7 +2464,10 @@ describe('useDebouncedPersistence', () => {
 			// Recovery: next flush should re-ship the same dirty session
 			// because the baseline didn't advance on the previous failure.
 			vi.mocked(window.maestro.sessions.setMany).mockClear();
-			rerender({ sessions: [{ ...s1, name: 'Two' }] });
+			// Same name but new array/object refs so subscribe fires again.
+			act(() => {
+				seedSessions([{ ...s1, name: 'Two' }]);
+			});
 			await act(async () => {
 				await vi.advanceTimersByTimeAsync(2000);
 			});
@@ -2381,10 +2486,10 @@ describe('useDebouncedPersistence', () => {
 			const s1 = makeSession({ id: 's1', name: 'One' });
 			const initialLoadRef = makeInitialLoadRef(true);
 
-			const { result, rerender } = renderHook(
-				({ sessions }) => useDebouncedPersistence(sessions, initialLoadRef),
-				{ initialProps: { sessions: [s1] } }
-			);
+			const { result } = renderPersistence(initialLoadRef);
+			act(() => {
+				seedSessions([s1]);
+			});
 			await act(async () => {
 				await vi.advanceTimersByTimeAsync(2000);
 			});
@@ -2393,7 +2498,9 @@ describe('useDebouncedPersistence', () => {
 			vi.mocked(window.maestro.sessions.setMany).mockRejectedValueOnce(
 				new Error('IPC channel closed')
 			);
-			rerender({ sessions: [{ ...s1, name: 'Two' }] });
+			act(() => {
+				seedSessions([{ ...s1, name: 'Two' }]);
+			});
 			await act(async () => {
 				await vi.advanceTimersByTimeAsync(2000);
 			});
@@ -2401,21 +2508,24 @@ describe('useDebouncedPersistence', () => {
 			expect(result.current.isPending).toBe(true);
 		});
 
-		it('reference-equal session prop on rerender is treated as unchanged', () => {
+		it('reference-equal session array on setState is treated as unchanged', () => {
 			const s1 = makeSession({ id: 's1' });
+			const initial = [s1];
 			const initialLoadRef = makeInitialLoadRef(true);
 
-			const { rerender } = renderHook(
-				({ sessions }) => useDebouncedPersistence(sessions, initialLoadRef),
-				{ initialProps: { sessions: [s1] } }
-			);
+			renderPersistence(initialLoadRef);
+			act(() => {
+				seedSessions(initial);
+			});
 			act(() => {
 				vi.advanceTimersByTime(2000);
 			});
 			vi.mocked(window.maestro.sessions.setMany).mockClear();
 
-			// Same s1 reference inside a new array — the diff sees no per-session change
-			rerender({ sessions: [s1] });
+			// Same array reference — subscribe early-returns on === sessions
+			act(() => {
+				seedSessions(initial);
+			});
 			act(() => {
 				vi.advanceTimersByTime(2000);
 			});
@@ -2433,7 +2543,8 @@ describe('useDebouncedPersistence', () => {
 			vi.mocked(window.maestro.sessions.setAll).mockResolvedValueOnce(false);
 			const session = makeSession({ id: 'session-qf' });
 			const initialLoadRef = makeInitialLoadRef(true);
-			const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+			seedSessions([session]);
+			const { result } = renderPersistence(initialLoadRef);
 
 			await act(async () => {
 				result.current.flushNow([session]);
@@ -2448,7 +2559,8 @@ describe('useDebouncedPersistence', () => {
 			vi.mocked(window.maestro.sessions.setAll).mockRejectedValueOnce(new Error('boom'));
 			const session = makeSession({ id: 'session-qf-2' });
 			const initialLoadRef = makeInitialLoadRef(true);
-			const { result } = renderHook(() => useDebouncedPersistence([session], initialLoadRef));
+			seedSessions([session]);
+			const { result } = renderPersistence(initialLoadRef);
 
 			await act(async () => {
 				result.current.flushNow([session]);

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -162,7 +162,11 @@ import {
 	updateAiTab,
 } from './stores/sessionStore';
 import { useStoreWithEqualityFn } from 'zustand/traditional';
-import { sidebarSessionEquality, gitPollSessionEquality } from './stores/sessionEquality';
+import {
+	sidebarSessionEquality,
+	gitPollSessionEquality,
+	projectRootSessionEquality,
+} from './stores/sessionEquality';
 import { useActiveSession } from './hooks/session/useActiveSession';
 import { usePianolaAgent } from './hooks/session/usePianolaAgent';
 // useAgentStore moved to useQueueProcessing hook
@@ -522,7 +526,7 @@ function MaestroConsoleInner() {
 		sidebarSessionEquality
 	);
 	const hasSessions = useSessionStore((s) => s.sessions.length > 0);
-	const hasNoAgents = useSessionStore((s) => s.sessions.length === 0);
+	const hasNoAgents = !hasSessions;
 	const groups = useSessionStore((s) => s.groups);
 	const activeSessionId = useSessionStore((s) => s.activeSessionId);
 	// Whether the initial agent list has finished loading. On desktop the splash
@@ -2955,16 +2959,22 @@ function MaestroConsoleInner() {
 	}, [setLeftSidebarOpen, setRightPanelOpen]);
 
 	// Narrow map for GroupChatRightPanel: participant id → projectRoot.
-	// Uses sidebar-stable sessions so streaming does not rebuild the map.
+	// Dedicated equality (not sidebar): sidebar ignores projectRoot, so a
+	// directory change would otherwise leave this map stale.
+	const sessionsForProjectRoots = useStoreWithEqualityFn(
+		useSessionStore,
+		(s) => s.sessions,
+		projectRootSessionEquality
+	);
 	const participantSessionPaths = useMemo(() => {
 		if (!activeGroupChatId) return new Map<string, string>();
 		const chat = groupChats.find((c) => c.id === activeGroupChatId);
 		if (!chat) return new Map<string, string>();
 		const ids = new Set(chat.participants.map((p) => p.sessionId));
 		return new Map(
-			sessionsForSidebar.filter((s) => ids.has(s.id)).map((s) => [s.id, s.projectRoot])
+			sessionsForProjectRoots.filter((s) => ids.has(s.id)).map((s) => [s.id, s.projectRoot])
 		);
-	}, [activeGroupChatId, groupChats, sessionsForSidebar]);
+	}, [activeGroupChatId, groupChats, sessionsForProjectRoots]);
 
 	return (
 		<AppShell

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -162,7 +162,7 @@ import {
 	updateAiTab,
 } from './stores/sessionStore';
 import { useStoreWithEqualityFn } from 'zustand/traditional';
-import { sidebarSessionEquality } from './stores/sessionEquality';
+import { sidebarSessionEquality, gitPollSessionEquality } from './stores/sessionEquality';
 import { useActiveSession } from './hooks/session/useActiveSession';
 import { usePianolaAgent } from './hooks/session/usePianolaAgent';
 // useAgentStore moved to useQueueProcessing hook
@@ -176,7 +176,7 @@ import { usePluginKeybindings } from './hooks/usePluginKeybindings';
 
 // Import types and constants
 // Note: GroupChat, GroupChatState are imported from types (re-exported from shared)
-import type { RightPanelTab, Session, QueuedItem, CustomAICommand, ThinkingItem } from './types';
+import type { RightPanelTab, Session, QueuedItem, CustomAICommand } from './types';
 import { useResolvedTheme } from './hooks/ui/useResolvedTheme';
 import { getActiveOutputSearchKey } from './utils/outputSearch';
 import { reorderQueueItem } from './utils/executionQueue';
@@ -201,7 +201,6 @@ import {
 	getTabDisplayName,
 	isSoleAiTabReplacement,
 } from './utils/tabHelpers';
-import { buildThinkingItems } from './utils/thinkingItems';
 // validateNewSession moved to useSymphonyContribution, useSessionCrud hooks
 // formatLogsForClipboard moved to useTabExportHandlers hook
 // getSlashCommandDescription moved to useWizardHandlers
@@ -509,19 +508,21 @@ function MaestroConsoleInner() {
 
 	// --- SESSION STATE (migrated from useSession() to direct useSessionStore selectors) ---
 	// Reactive values — each selector triggers re-render only when its specific value changes
-	const sessions = useSessionStore((s) => s.sessions);
-	// PERF: Sidebar-stable view of `sessions` for the sort/navigation pipeline.
+	// PERF: Do NOT subscribe to the full `sessions` array here. Streaming log/token
+	// updates would re-render the entire console shell. Event-time readers use
+	// sessionsRef / getState(); paint leaves self-source with narrow selectors.
+	// Sidebar-stable view for the sort/navigation pipeline.
 	// `sidebarSessionEquality` ignores log/usage/cycle counters, so the array
 	// reference only flips when something the left bar actually displays
 	// changes. Plumbed into `useSortedSessions` so `sortedSessions` (and the
 	// SessionList tree) stops re-rendering on every 200ms streaming flush.
-	// `sessions` (full array) is still used for persistence, fork, and any
-	// consumer that needs the streaming-heavy fields.
 	const sessionsForSidebar = useStoreWithEqualityFn(
 		useSessionStore,
 		(s) => s.sessions,
 		sidebarSessionEquality
 	);
+	const hasSessions = useSessionStore((s) => s.sessions.length > 0);
+	const hasNoAgents = useSessionStore((s) => s.sessions.length === 0);
 	const groups = useSessionStore((s) => s.groups);
 	const activeSessionId = useSessionStore((s) => s.activeSessionId);
 	// Whether the initial agent list has finished loading. On desktop the splash
@@ -927,7 +928,7 @@ function MaestroConsoleInner() {
 	const { initialLoadComplete } = useSessionRestoration();
 
 	// --- CUE AUTO-DISCOVERY (gated by Encore Feature) ---
-	useCueAutoDiscovery(sessions, encoreFeatures);
+	useCueAutoDiscovery(encoreFeatures);
 
 	// --- PIANOLA AGENT (pinned manager agent, gated by Encore Feature) ---
 	// Ensures the single pinned Pianola agent exists once sessions are loaded and
@@ -1298,15 +1299,8 @@ function MaestroConsoleInner() {
 		prevAiTabIdsRef.current = activeSession ? activeSession.aiTabs.map((t) => t.id) : [];
 	}, [activeSession?.id, activeSession?.aiTabs]);
 
-	// PERF: Memoize sessions for NewInstanceModal validation (only recompute when modal is open)
-	// This prevents re-renders of the modal's validation logic on every session state change
-	const sessionsForValidation = useMemo(
-		() => (newInstanceModalOpen ? sessions : []),
-		[newInstanceModalOpen, sessions]
-	);
-
-	// PERF: Memoize hasNoAgents check for SettingsModal (only depends on session count)
-	const hasNoAgents = useMemo(() => sessions.length === 0, [sessions.length]);
+	// PERF: NewInstanceModal validation reads from the store when open (see AppSessionModals).
+	// Avoid keeping a reactive full-array slice at App level.
 
 	// Remote integration hook - handles web interface communication
 	useRemoteIntegration({
@@ -1366,7 +1360,7 @@ function MaestroConsoleInner() {
 	});
 
 	// Fork conversation hook - creates a new tab in the current session from a point in conversation history
-	const handleForkConversation = useForkConversation(sessions, setSessions, activeSessionId);
+	const handleForkConversation = useForkConversation();
 
 	// Summarize & Continue hook for context compaction (non-blocking, per-tab)
 	const {
@@ -1472,7 +1466,7 @@ function MaestroConsoleInner() {
 			: hasActiveSessionCapability('supportsImageInput');
 	}, [activeSession, isResumingSession, hasActiveSessionCapability]);
 	// Session navigation handlers (extracted to useSessionNavigation hook)
-	const { handleNavBack, handleNavForward } = useSessionNavigation(sessions, {
+	const { handleNavBack, handleNavForward } = useSessionNavigation({
 		navigateBack,
 		navigateForward,
 		setActiveSessionId, // Uses the wrapper that also dismisses active group chat
@@ -1481,22 +1475,10 @@ function MaestroConsoleInner() {
 		onNavigateToGroupChat: handleOpenGroupChat,
 	});
 
-	// PERF: Memoize thinkingItems at App level to avoid passing full sessions array to children.
-	// This prevents InputArea from re-rendering on unrelated session updates (e.g., terminal output).
-	// Flat list of (session, tab) pairs — one entry per busy tab across the agents this window owns.
-	// This allows the ThinkingStatusPill to show all active work, even when multiple tabs
-	// within the same agent are busy in parallel.
-	// Multi-window: gate on WindowContext.ownsSession so a window's pill never surfaces an agent
-	// (or its AutoRun) owned by another window - every renderer holds ALL agents because the main
-	// process broadcasts every agent's state to every window. Outside a WindowProvider (web /
-	// isolation tests) ownsSession is undefined, so buildThinkingItems includes every session.
+	// Multi-window: gate on WindowContext.ownsSession so a window's pill / cycling never
+	// surfaces an agent owned by another window. Outside a WindowProvider (web /
+	// isolation tests) ownsSession is undefined.
 	const ownsSession = windowCtx?.ownsSession;
-	const thinkingItems: ThinkingItem[] = useMemo(
-		() => buildThinkingItems(sessions, ownsSession),
-		[sessions, ownsSession]
-	);
-
-	// addLogToTab/addLogToActiveTab now used directly via store in useWizardHandlers
 
 	// --- AGENT EXECUTION ---
 	// Extracted hook for agent spawning and execution operations
@@ -2009,10 +1991,7 @@ function MaestroConsoleInner() {
 
 	// Persist sessions to electron-store using debounced persistence (reduces disk writes from 100+/sec to <1/sec during streaming)
 	// The hook handles: debouncing, flush-on-unmount, flush-on-visibility-change, flush-on-beforeunload
-	const { flushNow: flushSessionPersistence } = useDebouncedPersistence(
-		sessions,
-		initialLoadComplete
-	);
+	const { flushNow: flushSessionPersistence } = useDebouncedPersistence(initialLoadComplete);
 
 	// Session lifecycle operations (rename, delete, star, unread, groups persistence, nav tracking)
 	// — provided by useSessionLifecycle hook (Phase 2H)
@@ -2222,7 +2201,6 @@ function MaestroConsoleInner() {
 	// Extracted hook for file tree operations (refresh, git state, filtering)
 	const { refreshFileTree, refreshGitFileState, cancelFileTreeLoad, filteredFileTree } =
 		useFileTreeManagement({
-			sessions,
 			sessionsRef,
 			setSessions,
 			activeSessionId,
@@ -2390,7 +2368,6 @@ function MaestroConsoleInner() {
 		activeFocus,
 		activeRightTab,
 		handleOpenBatchRunner,
-		sessions,
 		selectedSidebarIndex,
 		activeSessionId,
 		quickActionOpen,
@@ -2617,7 +2594,6 @@ function MaestroConsoleInner() {
 		memoryViewerOpen,
 		activeAgentSessionId,
 		activeSession,
-		thinkingItems,
 		theme,
 		isMobileLandscape,
 		stagedImages,
@@ -2978,6 +2954,18 @@ function MaestroConsoleInner() {
 		setRightPanelOpen(false);
 	}, [setLeftSidebarOpen, setRightPanelOpen]);
 
+	// Narrow map for GroupChatRightPanel: participant id → projectRoot.
+	// Uses sidebar-stable sessions so streaming does not rebuild the map.
+	const participantSessionPaths = useMemo(() => {
+		if (!activeGroupChatId) return new Map<string, string>();
+		const chat = groupChats.find((c) => c.id === activeGroupChatId);
+		if (!chat) return new Map<string, string>();
+		const ids = new Set(chat.participants.map((p) => p.sessionId));
+		return new Map(
+			sessionsForSidebar.filter((s) => ids.has(s.id)).map((s) => [s.id, s.projectRoot])
+		);
+	}, [activeGroupChatId, groupChats, sessionsForSidebar]);
+
 	return (
 		<AppShell
 			theme={theme}
@@ -2992,7 +2980,7 @@ function MaestroConsoleInner() {
 			groupChats={groupChats}
 			groups={groups}
 			activeSession={activeSession}
-			sessions={sessions}
+			hasSessions={hasSessions}
 			sessionsLoaded={sessionsLoaded}
 			emptyStateProps={{
 				shortcuts,
@@ -3086,7 +3074,6 @@ function MaestroConsoleInner() {
 								rightPanelOpen={rightPanelOpen}
 								onToggleRightPanel={() => setRightPanelOpen(!rightPanelOpen)}
 								shortcuts={shortcuts}
-								sessions={sessions}
 								onDraftChange={handleGroupChatDraftChange}
 								onOpenPromptComposer={handleOpenGroupChatPromptComposer}
 								draftFlushRef={groupChatDraftFlushRef}
@@ -3120,17 +3107,7 @@ function MaestroConsoleInner() {
 							groupChatId={activeGroupChatId}
 							participants={groupChats.find((c) => c.id === activeGroupChatId)?.participants || []}
 							participantStates={participantStates}
-							participantSessionPaths={
-								new Map(
-									sessions
-										.filter((s) =>
-											groupChats
-												.find((c) => c.id === activeGroupChatId)
-												?.participants.some((p) => p.sessionId === s.id)
-										)
-										.map((s) => [s.id, s.projectRoot])
-								)
-							}
+							participantSessionPaths={participantSessionPaths}
 							sessionSshRemoteNames={sessionSshRemoteNames}
 							isOpen={rightPanelOpen}
 							onToggle={() => setRightPanelOpen(!rightPanelOpen)}
@@ -3197,7 +3174,6 @@ function MaestroConsoleInner() {
 					// AppSessionModals props
 					onCloseNewInstanceModal={handleCloseNewInstanceModal}
 					onCreateSession={createNewSession}
-					existingSessions={sessionsForValidation}
 					duplicatingSessionId={duplicatingSessionId}
 					newInstancePresetGroupId={newInstancePresetGroupId}
 					onCloseEditAgentModal={handleCloseEditAgentModal}
@@ -3492,7 +3468,6 @@ function MaestroConsoleInner() {
 					// Marketplace
 					onMarketplaceImportComplete={handleMarketplaceImportComplete}
 					// Symphony
-					sessions={sessions}
 					setActiveSessionId={setActiveSessionId}
 					onStartContribution={handleStartContribution}
 					encoreFeatures={encoreFeatures}
@@ -3551,9 +3526,16 @@ function MaestroConsoleInner() {
  * so GitStatusProvider can sit ABOVE MaestroConsoleInner. Required because
  * useModalHandlers (called inside MaestroConsoleInner) consumes useGitDetail,
  * and a context provider must wrap its consumer.
+ *
+ * PERF: Uses gitPollSessionEquality so streaming log/token updates do not
+ * re-render MaestroConsoleInner via this parent.
  */
 function GitStatusProviderFromStore({ children }: { children: ReactNode }) {
-	const sessions = useSessionStore((s) => s.sessions);
+	const sessions = useStoreWithEqualityFn(
+		useSessionStore,
+		(s) => s.sessions,
+		gitPollSessionEquality
+	);
 	const activeSessionId = useSessionStore((s) => s.activeSessionId);
 	return (
 		<GitStatusProvider sessions={sessions} activeSessionId={activeSessionId}>

--- a/src/renderer/components/AppModals/AppModals.tsx
+++ b/src/renderer/components/AppModals/AppModals.tsx
@@ -117,7 +117,6 @@ export interface AppModalsProps {
 		maestroPPath?: string,
 		maestroPMode?: 'interactive' | 'dynamic'
 	) => void;
-	existingSessions: Session[];
 	duplicatingSessionId?: string | null; // Session ID to duplicate from
 	newInstancePresetGroupId?: string | null; // Group to place the new agent in
 	onCloseEditAgentModal: () => void;
@@ -638,7 +637,6 @@ export const AppModals = memo(function AppModals(props: AppModalsProps) {
 		// Session modals
 		onCloseNewInstanceModal,
 		onCreateSession,
-		existingSessions,
 		duplicatingSessionId,
 		newInstancePresetGroupId,
 		onCloseEditAgentModal,
@@ -967,7 +965,7 @@ export const AppModals = memo(function AppModals(props: AppModalsProps) {
 				newInstanceModalOpen={newInstanceModalOpen}
 				onCloseNewInstanceModal={onCloseNewInstanceModal}
 				onCreateSession={onCreateSession}
-				existingSessions={existingSessions}
+				existingSessions={sessions}
 				sourceSession={sourceSession}
 				newInstancePresetGroupId={newInstancePresetGroupId}
 				editAgentModalOpen={editAgentModalOpen}

--- a/src/renderer/components/AppShell.tsx
+++ b/src/renderer/components/AppShell.tsx
@@ -53,7 +53,7 @@ export interface AppShellProps {
 	logViewer: ReactNode | null;
 	groupChatView: ReactNode | null;
 
-	sessions: Session[];
+	hasSessions: boolean;
 	sessionsLoaded: boolean;
 	emptyStateProps: Omit<EmptyStateViewProps, 'theme'>;
 
@@ -93,7 +93,7 @@ export function AppShell({
 	logViewerOpen,
 	logViewer,
 	groupChatView,
-	sessions,
+	hasSessions,
 	sessionsLoaded,
 	emptyStateProps,
 	sessionListProps,
@@ -193,15 +193,15 @@ export function AppShell({
 			{modals}
 			{standaloneModals}
 
-			{sessions.length === 0 && !sessionsLoaded && !isMobileLandscape ? (
+			{!hasSessions && !sessionsLoaded && !isMobileLandscape ? (
 				<AgentsLoadingView theme={theme} />
 			) : null}
 
-			{sessions.length === 0 && sessionsLoaded && !isMobileLandscape ? (
+			{!hasSessions && sessionsLoaded && !isMobileLandscape ? (
 				<EmptyStateView theme={theme} {...emptyStateProps} />
 			) : null}
 
-			{!isMobileLandscape && sessions.length > 0 && (
+			{!isMobileLandscape && hasSessions && (
 				<ErrorBoundary>
 					<SessionList {...sessionListProps} />
 				</ErrorBoundary>
@@ -213,7 +213,7 @@ export function AppShell({
 				className="flex flex-col shrink-0 overflow-hidden border-r w-[320px]"
 			/>
 
-			{isNarrowViewport && sessions.length > 0 && (leftSidebarOpen || rightPanelOpen) && (
+			{isNarrowViewport && hasSessions && (leftSidebarOpen || rightPanelOpen) && (
 				<div
 					className="maestro-mobile-backdrop"
 					onClick={onCloseDrawers}
@@ -241,7 +241,7 @@ export function AppShell({
 
 			{groupChatView}
 
-			{sessions.length > 0 && !activeGroupChatId && !logViewerOpen && (
+			{hasSessions && !activeGroupChatId && !logViewerOpen && (
 				<MainPanel ref={mainPanelRef} {...mainPanelProps} />
 			)}
 
@@ -251,7 +251,7 @@ export function AppShell({
 				className="flex flex-col flex-1 min-w-0 overflow-hidden"
 			/>
 
-			{!isMobileLandscape && sessions.length > 0 && !activeGroupChatId && !logViewerOpen && (
+			{!isMobileLandscape && hasSessions && !activeGroupChatId && !logViewerOpen && (
 				<ErrorBoundary>
 					<RightPanel ref={rightPanelRef} {...rightPanelProps} />
 				</ErrorBoundary>

--- a/src/renderer/components/AppStandaloneModals.tsx
+++ b/src/renderer/components/AppStandaloneModals.tsx
@@ -95,7 +95,6 @@ export interface AppStandaloneModalsProps {
 	onMarketplaceImportComplete: (folderName: string) => Promise<void>;
 
 	// --- Symphony ---
-	sessions: Session[];
 	setActiveSessionId: (id: string) => void;
 	onStartContribution: (data: SymphonyContributionData) => Promise<void>;
 	encoreFeatures: EncoreFeatureFlags;
@@ -175,7 +174,6 @@ function AppStandaloneModalsInner({
 	// Marketplace
 	onMarketplaceImportComplete,
 	// Symphony
-	sessions,
 	setActiveSessionId,
 	onStartContribution,
 	encoreFeatures,
@@ -370,7 +368,6 @@ function AppStandaloneModalsInner({
 						theme={theme}
 						isOpen={symphonyModalOpen}
 						onClose={() => setSymphonyModalOpen(false)}
-						sessions={sessions}
 						onSelectSession={(sessionId) => {
 							setActiveSessionId(sessionId);
 							setSymphonyModalOpen(false);

--- a/src/renderer/components/GroupChatInput.tsx
+++ b/src/renderer/components/GroupChatInput.tsx
@@ -13,13 +13,15 @@
  */
 
 import React, { useState, useRef, useCallback, useMemo, useEffect } from 'react';
+import { useStoreWithEqualityFn } from 'zustand/traditional';
 import { useSettingsStore } from '../stores/settingsStore';
+import { useSessionStore } from '../stores/sessionStore';
+import { mentionSessionEquality } from '../stores/sessionEquality';
 import { ArrowUp, Bell, ImageIcon, Eye, Keyboard, PenLine, Users } from 'lucide-react';
 import type {
 	Theme,
 	GroupChatParticipant,
 	GroupChatState,
-	Session,
 	Group,
 	QueuedItem,
 	Shortcut,
@@ -58,7 +60,6 @@ interface GroupChatInputProps {
 	state: GroupChatState;
 	onSend: (content: string, images?: string[], readOnly?: boolean) => void;
 	participants: GroupChatParticipant[];
-	sessions: Session[];
 	groups?: Group[];
 	groupChatId: string;
 	draftMessage?: string;
@@ -97,7 +98,6 @@ export const GroupChatInput = React.memo(function GroupChatInput({
 	state,
 	onSend,
 	participants: _participants,
-	sessions,
 	groups,
 	groupChatId,
 	draftMessage,
@@ -164,6 +164,13 @@ export const GroupChatInput = React.memo(function GroupChatInput({
 			if (draftFlushRef.current === flushDraft) draftFlushRef.current = null;
 		};
 	}, [draftFlushRef, flushDraft]);
+
+	// Narrow mention-shaped sessions so streaming logs do not rebuild @mentions.
+	const sessions = useStoreWithEqualityFn(
+		useSessionStore,
+		(s) => s.sessions,
+		mentionSessionEquality
+	);
 
 	// Build list of mentionable items: groups first, then individual agents
 	// Groups expand into all their member @mentions when selected

--- a/src/renderer/components/GroupChatPanel.tsx
+++ b/src/renderer/components/GroupChatPanel.tsx
@@ -13,7 +13,6 @@ import type {
 	GroupChatState,
 	Group,
 	Shortcut,
-	Session,
 	QueuedItem,
 } from '../types';
 import { GroupChatHeader } from './GroupChatHeader';
@@ -36,7 +35,6 @@ interface GroupChatPanelProps {
 	rightPanelOpen: boolean;
 	onToggleRightPanel: () => void;
 	shortcuts: Record<string, Shortcut>;
-	sessions: Session[];
 	groups?: Group[];
 	onDraftChange?: (draft: string, groupChatId: string) => void;
 	onOpenPromptComposer?: () => void;
@@ -92,7 +90,6 @@ export function GroupChatPanel({
 	rightPanelOpen,
 	onToggleRightPanel,
 	shortcuts,
-	sessions,
 	groups,
 	onDraftChange,
 	onOpenPromptComposer,
@@ -157,7 +154,6 @@ export function GroupChatPanel({
 				state={state}
 				onSend={onSendMessage}
 				participants={groupChat.participants}
-				sessions={sessions}
 				groups={groups}
 				groupChatId={groupChat.id}
 				draftMessage={groupChat.draftMessage}

--- a/src/renderer/components/InputArea/InputArea.tsx
+++ b/src/renderer/components/InputArea/InputArea.tsx
@@ -16,6 +16,8 @@ import { SummarizeProgressOverlay } from '../SummarizeProgressOverlay';
 import { WizardInputPanel } from '../InlineWizard';
 import { useImageAnnotatorStore } from '../ImageAnnotator/imageAnnotatorStore';
 import { useAgentCapabilities, useScrollIntoView, useVoiceInput } from '../../hooks';
+import { useThinkingItems } from '../../hooks/session/useThinkingItems';
+import { useWindowContextOptional } from '../../contexts/WindowContext';
 import { filterSlashCommands } from '../../utils/search';
 import { InputTextarea } from './components/InputTextarea';
 import { NotificationSendControls } from './components/NotificationSendControls';
@@ -81,7 +83,6 @@ export const InputArea = React.memo(function InputArea(props: InputAreaProps) {
 		setAtMentionCategory,
 		selectedAtMentionIndex = 0,
 		setSelectedAtMentionIndex,
-		thinkingItems = [],
 		namedSessions,
 		onSessionClick,
 		autoRunState,
@@ -129,6 +130,11 @@ export const InputArea = React.memo(function InputArea(props: InputAreaProps) {
 		onModelChange,
 		onEffortChange,
 	} = props;
+
+	// Self-source thinking items with a narrow store equality so App/MainPanel
+	// are not re-rendered on every streaming log flush.
+	const ownsSession = useWindowContextOptional()?.ownsSession;
+	const thinkingItems = useThinkingItems(ownsSession);
 
 	const spellCheckEnabled = useSettingsStore((state) => state.spellCheck);
 	const openAnnotator = useImageAnnotatorStore((state) => state.openAnnotator);
@@ -191,7 +197,7 @@ export const InputArea = React.memo(function InputArea(props: InputAreaProps) {
 		isTerminalMode ? selectTerminalComposerValue : selectAiComposerValue
 	);
 
-	// thinkingItems is now passed directly from App.tsx (pre-filtered) for better performance
+	// thinkingItems self-sourced via useThinkingItems (narrow store equality)
 
 	const currentCommandHistory = useMemo(
 		() => getCurrentCommandHistory(session, isTerminalMode),

--- a/src/renderer/components/InputArea/types.ts
+++ b/src/renderer/components/InputArea/types.ts
@@ -1,14 +1,7 @@
 import type React from 'react';
 import type { TabCompletionFilter, TabCompletionSuggestion } from '../../hooks';
 import type { MentionPickerItem, MentionCategory } from '../../hooks/input/useMentionPicker';
-import type {
-	BatchRunState,
-	Shortcut,
-	Session,
-	Theme,
-	ThinkingItem,
-	ThinkingMode,
-} from '../../types';
+import type { BatchRunState, Shortcut, Session, Theme, ThinkingMode } from '../../types';
 import type {
 	GroomingProgress,
 	MergeResult,
@@ -85,7 +78,6 @@ export interface InputAreaProps {
 	setAtMentionCategory?: (category: MentionCategory) => void;
 	selectedAtMentionIndex?: number;
 	setSelectedAtMentionIndex?: (index: number) => void;
-	thinkingItems?: ThinkingItem[];
 	namedSessions?: Record<string, string>;
 	onSessionClick?: (sessionId: string, tabId?: string) => void;
 	autoRunState?: BatchRunState;

--- a/src/renderer/components/MainPanel/MainPanel.tsx
+++ b/src/renderer/components/MainPanel/MainPanel.tsx
@@ -82,7 +82,6 @@ export const MainPanel = React.memo(
 			memoryViewerOpen,
 			activeAgentSessionId,
 			activeSession,
-			thinkingItems,
 			theme,
 			stagedImages,
 			commandHistoryOpen,
@@ -1319,7 +1318,6 @@ export const MainPanel = React.memo(
 									handleInputKeyDown={handleInputKeyDown}
 									handlePaste={handlePaste}
 									handleDrop={handleDrop}
-									thinkingItems={thinkingItems}
 									onStopBatchRun={onStopBatchRun}
 									onRemoveQueuedItem={onRemoveQueuedItem}
 									onTogglePauseQueuedItem={onTogglePauseQueuedItem}

--- a/src/renderer/components/MainPanel/MainPanelContent.tsx
+++ b/src/renderer/components/MainPanel/MainPanelContent.tsx
@@ -37,7 +37,6 @@ import type {
 	BatchRunState,
 	BrowserTab,
 	FilePreviewTab,
-	ThinkingItem,
 	QueuedItem,
 	UnifiedTabRef,
 	PaneRects,
@@ -179,7 +178,6 @@ export interface MainPanelContentProps {
 	handleInputKeyDown: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void;
 	handlePaste: (e: React.ClipboardEvent<HTMLTextAreaElement>) => void;
 	handleDrop: (e: React.DragEvent<HTMLElement>) => void;
-	thinkingItems: ThinkingItem[];
 	onStopBatchRun?: (sessionId?: string) => void;
 	onRemoveQueuedItem?: (itemId: string) => void;
 	onTogglePauseQueuedItem?: (itemId: string) => void;
@@ -371,7 +369,6 @@ export const MainPanelContent = React.memo(function MainPanelContent(props: Main
 		handleInputKeyDown,
 		handlePaste,
 		handleDrop,
-		thinkingItems,
 		onStopBatchRun,
 		onRemoveQueuedItem,
 		onTogglePauseQueuedItem,
@@ -937,7 +934,6 @@ export const MainPanelContent = React.memo(function MainPanelContent(props: Main
 						onInputFocus={handleInputFocus}
 						onInputBlur={onInputBlur}
 						isAutoModeActive={isCurrentSessionAutoMode}
-						thinkingItems={thinkingItems}
 						onSessionClick={handleSessionClick}
 						autoRunState={currentSessionBatchState || undefined}
 						onStopAutoRun={() => onStopBatchRun?.(activeSession.id)}

--- a/src/renderer/components/MainPanel/types.ts
+++ b/src/renderer/components/MainPanel/types.ts
@@ -6,7 +6,6 @@ import type {
 	UnifiedTab,
 	FilePreviewTab,
 	BrowserTab,
-	ThinkingItem,
 	AgentError,
 	QueuedItem,
 } from '../../types';
@@ -62,9 +61,6 @@ export interface MainPanelProps {
 	memoryViewerOpen: boolean;
 	activeAgentSessionId: string | null;
 	activeSession: Session | null;
-	// PERF: Receive pre-filtered thinkingItems instead of full sessions array.
-	// This prevents cascade re-renders when unrelated session updates occur.
-	thinkingItems: ThinkingItem[];
 	theme: Theme;
 	isMobileLandscape?: boolean;
 	stagedImages: string[];

--- a/src/renderer/components/SymphonyModal/SymphonyModal.tsx
+++ b/src/renderer/components/SymphonyModal/SymphonyModal.tsx
@@ -40,7 +40,6 @@ export function SymphonyModal({
 	isOpen,
 	onClose,
 	onStartContribution,
-	sessions,
 	onSelectSession,
 }: SymphonyModalProps) {
 	const onCloseRef = useRef(onClose);
@@ -377,7 +376,6 @@ export function SymphonyModal({
 								<ActiveTab
 									theme={theme}
 									activeContributions={activeContributions}
-									sessions={sessions}
 									prStatusMessage={prStatusSync.prStatusMessage}
 									isCheckingPRStatuses={prStatusSync.isCheckingPRStatuses}
 									syncingContributionId={prStatusSync.syncingContributionId}

--- a/src/renderer/components/SymphonyModal/tabs/ActiveTab.tsx
+++ b/src/renderer/components/SymphonyModal/tabs/ActiveTab.tsx
@@ -1,13 +1,23 @@
 import { memo } from 'react';
+import { useStoreWithEqualityFn } from 'zustand/traditional';
 import { RefreshCw, Music } from 'lucide-react';
-import type { Theme, Session } from '../../../types';
+import type { Theme } from '../../../types';
 import type { ActiveContribution } from '../../../../shared/symphony-types';
 import { ActiveContributionCard } from '../components/ActiveContributionCard';
+import { useSessionStore } from '../../../stores/sessionStore';
+
+function sessionNameMapEquality(a: Map<string, string>, b: Map<string, string>): boolean {
+	if (a === b) return true;
+	if (a.size !== b.size) return false;
+	for (const [k, v] of a) {
+		if (b.get(k) !== v) return false;
+	}
+	return true;
+}
 
 export interface ActiveTabProps {
 	theme: Theme;
 	activeContributions: ActiveContribution[];
-	sessions: Session[];
 	prStatusMessage: string | null;
 	isCheckingPRStatuses: boolean;
 	syncingContributionId: string | null;
@@ -22,7 +32,6 @@ export interface ActiveTabProps {
 export const ActiveTab = memo(function ActiveTab({
 	theme,
 	activeContributions,
-	sessions,
 	prStatusMessage,
 	isCheckingPRStatuses,
 	syncingContributionId,
@@ -33,6 +42,16 @@ export const ActiveTab = memo(function ActiveTab({
 	onSelectSession,
 	onCloseModal,
 }: ActiveTabProps) {
+	// Narrow id→name map so streaming logs do not re-render this tab.
+	const sessionNames = useStoreWithEqualityFn(
+		useSessionStore,
+		(s) => {
+			const map = new Map<string, string>();
+			for (const sess of s.sessions) map.set(sess.id, sess.name);
+			return map;
+		},
+		sessionNameMapEquality
+	);
 	return (
 		<div className="flex-1 flex flex-col overflow-hidden">
 			{/* Header with refresh button */}
@@ -91,7 +110,8 @@ export const ActiveTab = memo(function ActiveTab({
 				) : (
 					<div className="grid grid-cols-2 gap-4">
 						{activeContributions.map((contribution) => {
-							const session = sessions.find((s) => s.id === contribution.sessionId);
+							const sessionName = sessionNames.get(contribution.sessionId) ?? null;
+							const hasSession = sessionNames.has(contribution.sessionId);
 							return (
 								<ActiveContributionCard
 									key={contribution.id}
@@ -100,10 +120,10 @@ export const ActiveTab = memo(function ActiveTab({
 									onFinalize={() => onFinalize(contribution.id)}
 									onSync={() => onSyncContribution(contribution.id)}
 									isSyncing={syncingContributionId === contribution.id}
-									sessionName={session?.name ?? null}
+									sessionName={sessionName}
 									onNavigateToSession={() => {
-										if (session) {
-											onSelectSession(session.id);
+										if (hasSession) {
+											onSelectSession(contribution.sessionId);
 											onCloseModal();
 										}
 									}}

--- a/src/renderer/components/SymphonyModal/types.ts
+++ b/src/renderer/components/SymphonyModal/types.ts
@@ -1,4 +1,4 @@
-import type { Theme, Session } from '../../types';
+import type { Theme } from '../../types';
 import type { RegisteredRepository, SymphonyIssue } from '../../../shared/symphony-types';
 
 export interface SymphonyContributionData {
@@ -22,7 +22,6 @@ export interface SymphonyModalProps {
 	isOpen: boolean;
 	onClose: () => void;
 	onStartContribution: (data: SymphonyContributionData) => void;
-	sessions: Session[];
 	onSelectSession: (sessionId: string) => void;
 }
 

--- a/src/renderer/hooks/agent/useForkConversation.ts
+++ b/src/renderer/hooks/agent/useForkConversation.ts
@@ -1,79 +1,82 @@
 import { useCallback } from 'react';
-import type { Session, LogEntry } from '../../types';
+import type { LogEntry } from '../../types';
 import { createTabAtPosition, getTabDisplayName, getActiveTab } from '../../utils/tabHelpers';
 import { notifyToast } from '../../stores/notificationStore';
+import { useSessionStore } from '../../stores/sessionStore';
 import { captureException } from '../../utils/sentry';
 import { getStdinFlags, prepareMaestroSystemPrompt } from '../../utils/spawnHelpers';
 
-export function useForkConversation(
-	sessions: Session[],
-	setSessions: (updater: (prev: Session[]) => Session[]) => void,
-	activeSessionId: string | null
-) {
-	return useCallback(
-		(logId: string) => {
-			const session = sessions.find((s) => s.id === activeSessionId);
-			if (!session) return;
+/**
+ * Fork conversation at a log id into a new AI tab.
+ *
+ * PERF: Reads sessions / activeSessionId via getState() at click time so App
+ * does not need a reactive `sessions` subscription for this handler.
+ */
+export function useForkConversation() {
+	return useCallback((logId: string) => {
+		const { sessions, activeSessionId, setSessions } = useSessionStore.getState();
+		const session = sessions.find((s) => s.id === activeSessionId);
+		if (!session) return;
 
-			const sourceTab = getActiveTab(session);
-			if (!sourceTab) return;
+		const sourceTab = getActiveTab(session);
+		if (!sourceTab) return;
 
-			// 1. Resolve the raw log index from the log ID.
-			//    The caller passes a log ID (not a visual index) so that search-filtering
-			//    and consecutive-entry collapsing in the UI cannot shift the fork point.
-			const rawLogIndex = sourceTab.logs.findIndex((l) => l.id === logId);
-			if (rawLogIndex === -1) return;
+		// 1. Resolve the raw log index from the log ID.
+		//    The caller passes a log ID (not a visual index) so that search-filtering
+		//    and consecutive-entry collapsing in the UI cannot shift the fork point.
+		const rawLogIndex = sourceTab.logs.findIndex((l) => l.id === logId);
+		if (rawLogIndex === -1) return;
 
-			// AI responses may span multiple raw stdout entries when chunks arrive
-			// more than 500ms apart (see useBatchedSessionUpdates). The UI's
-			// `collapsedLogs` merges consecutive non-user/tool/thinking entries into
-			// one visual block keyed by the FIRST entry's id, so the clicked logId
-			// points at the first chunk. Extend endIndex forward through the rest of
-			// that block so the fork context includes the full AI response.
-			let endIndex = rawLogIndex;
-			const clickedSource = sourceTab.logs[rawLogIndex].source;
-			if (clickedSource !== 'user' && clickedSource !== 'tool' && clickedSource !== 'thinking') {
-				while (
-					endIndex + 1 < sourceTab.logs.length &&
-					sourceTab.logs[endIndex + 1].source !== 'user' &&
-					sourceTab.logs[endIndex + 1].source !== 'tool' &&
-					sourceTab.logs[endIndex + 1].source !== 'thinking'
-				) {
-					endIndex++;
-				}
+		// AI responses may span multiple raw stdout entries when chunks arrive
+		// more than 500ms apart (see useBatchedSessionUpdates). The UI's
+		// `collapsedLogs` merges consecutive non-user/tool/thinking entries into
+		// one visual block keyed by the FIRST entry's id, so the clicked logId
+		// points at the first chunk. Extend endIndex forward through the rest of
+		// that block so the fork context includes the full AI response.
+		let endIndex = rawLogIndex;
+		const clickedSource = sourceTab.logs[rawLogIndex].source;
+		if (clickedSource !== 'user' && clickedSource !== 'tool' && clickedSource !== 'thinking') {
+			while (
+				endIndex + 1 < sourceTab.logs.length &&
+				sourceTab.logs[endIndex + 1].source !== 'user' &&
+				sourceTab.logs[endIndex + 1].source !== 'tool' &&
+				sourceTab.logs[endIndex + 1].source !== 'thinking'
+			) {
+				endIndex++;
 			}
+		}
 
-			const slicedLogs = sourceTab.logs.slice(0, endIndex + 1);
-			if (slicedLogs.length === 0) return;
+		const slicedLogs = sourceTab.logs.slice(0, endIndex + 1);
+		if (slicedLogs.length === 0) return;
 
-			// 2. Format sliced logs as context (user, ai, stdout, and tool sources).
-			//    In AI mode, AI response text is stored with source='stdout'
-			//    (see useBatchedSessionUpdates), so stdout maps to 'Assistant' here.
-			//    Only source='tool' represents actual tool output.
-			const formattedContext = slicedLogs
-				.filter(
-					(log) =>
-						log.text &&
-						log.text.trim() &&
-						(log.source === 'user' ||
-							log.source === 'ai' ||
-							log.source === 'stdout' ||
-							log.source === 'tool')
-				)
-				.map((log) => {
-					const role =
-						log.source === 'user' ? 'User' : log.source === 'tool' ? 'Tool Output' : 'Assistant';
-					return `${role}: ${log.text}`;
-				})
-				.join('\n\n');
+		// 2. Format sliced logs as context (user, ai, stdout, and tool sources).
+		//    In AI mode, AI response text is stored with source='stdout'
+		//    (see useBatchedSessionUpdates), so stdout maps to 'Assistant' here.
+		//    Only source='tool' represents actual tool output.
+		const formattedContext = slicedLogs
+			.filter(
+				(log) =>
+					log.text &&
+					log.text.trim() &&
+					(log.source === 'user' ||
+						log.source === 'ai' ||
+						log.source === 'stdout' ||
+						log.source === 'tool')
+			)
+			.map((log) => {
+				const role =
+					log.source === 'user' ? 'User' : log.source === 'tool' ? 'Tool Output' : 'Assistant';
+				return `${role}: ${log.text}`;
+			})
+			.join('\n\n');
 
-			// 3. Build the context message (similar to Send-to-Agent)
-			const sourceDisplayName = getTabDisplayName(sourceTab);
-			const sessionName = session.name || session.projectRoot.split('/').pop() || 'Unknown';
-			const forkTabName = `Forked: ${sourceDisplayName}`;
+		// 3. Build the context message (similar to Send-to-Agent)
+		const sourceDisplayName = getTabDisplayName(sourceTab);
+		const sessionName = session.name || session.projectRoot.split('/').pop() || 'Unknown';
+		const forkTabName = `Forked: ${sourceDisplayName}`;
 
-			const contextMessage = formattedContext
-				? `# Forked Conversation
+		const contextMessage = formattedContext
+			? `# Forked Conversation
 
 The following is a conversation forked from "${sessionName}" (tab: "${sourceDisplayName}") at message ${rawLogIndex + 1} of ${sourceTab.logs.length}. This is the conversation history up to the fork point.
 
@@ -86,184 +89,182 @@ ${formattedContext}
 # Continue
 
 You are continuing this conversation from the fork point above. Briefly acknowledge the context and ask what the user would like to explore from here.`
-				: 'No context available from the forked conversation.';
+			: 'No context available from the forked conversation.';
 
-			// 4. Create a new AI tab within the existing session, right after the source tab
-			const forkNotice: LogEntry = {
-				id: `fork-notice-${Date.now()}`,
-				timestamp: Date.now(),
-				source: 'system',
-				text: `Forked from tab "${sourceDisplayName}" at message ${rawLogIndex + 1} of ${sourceTab.logs.length}`,
-			};
+		// 4. Create a new AI tab within the existing session, right after the source tab
+		const forkNotice: LogEntry = {
+			id: `fork-notice-${Date.now()}`,
+			timestamp: Date.now(),
+			source: 'system',
+			text: `Forked from tab "${sourceDisplayName}" at message ${rawLogIndex + 1} of ${sourceTab.logs.length}`,
+		};
 
-			const userContextLog: LogEntry = {
-				id: `fork-context-${Date.now()}`,
-				timestamp: Date.now(),
-				source: 'user',
-				text: contextMessage,
-			};
+		const userContextLog: LogEntry = {
+			id: `fork-context-${Date.now()}`,
+			timestamp: Date.now(),
+			source: 'user',
+			text: contextMessage,
+		};
 
-			const tabResult = createTabAtPosition(session, {
-				afterTabId: sourceTab.id,
-				name: forkTabName,
-				logs: [forkNotice, userContextLog],
-				saveToHistory: sourceTab.saveToHistory,
-			});
-			if (!tabResult) return;
+		const tabResult = createTabAtPosition(session, {
+			afterTabId: sourceTab.id,
+			name: forkTabName,
+			logs: [forkNotice, userContextLog],
+			saveToHistory: sourceTab.saveToHistory,
+		});
+		if (!tabResult) return;
 
-			const newTabId = tabResult.tab.id;
-			const sourceTabId = sourceTab.id;
+		const newTabId = tabResult.tab.id;
+		const sourceTabId = sourceTab.id;
 
-			// 5. Commit new tab onto the live session (avoid stale snapshot spread).
-			//    Mark the tab as busy since we're about to spawn.
-			setSessions((prev) =>
-				prev.map((s) => {
-					if (s.id !== session.id) return s;
-					const hasNewTab = s.aiTabs.some((t) => t.id === newTabId);
-					let updatedTabs = s.aiTabs;
-					const currentOrder = s.unifiedTabOrder || [];
-					let updatedOrder = currentOrder;
-					if (!hasNewTab) {
-						const sourceIdx = s.aiTabs.findIndex((t) => t.id === sourceTabId);
-						const insertIdx = sourceIdx >= 0 ? sourceIdx + 1 : s.aiTabs.length;
-						const busyTab = {
-							...tabResult.tab,
-							state: 'busy' as const,
-							thinkingStartTime: Date.now(),
-							awaitingSessionId: true,
-						};
-						updatedTabs = [...s.aiTabs.slice(0, insertIdx), busyTab, ...s.aiTabs.slice(insertIdx)];
-						const newTabRef = { type: 'ai' as const, id: newTabId };
-						if (!currentOrder.some((ref) => ref.type === 'ai' && ref.id === newTabId)) {
-							const sourceOrderIdx = currentOrder.findIndex(
-								(ref) => ref.type === 'ai' && ref.id === sourceTabId
-							);
-							updatedOrder =
-								sourceOrderIdx >= 0
-									? [
-											...currentOrder.slice(0, sourceOrderIdx + 1),
-											newTabRef,
-											...currentOrder.slice(sourceOrderIdx + 1),
-										]
-									: [...currentOrder, newTabRef];
-						}
-					}
-					return {
-						...s,
-						state: 'busy',
-						busySource: 'ai',
+		// 5. Commit new tab onto the live session (avoid stale snapshot spread).
+		//    Mark the tab as busy since we're about to spawn.
+		setSessions((prev) =>
+			prev.map((s) => {
+				if (s.id !== session.id) return s;
+				const hasNewTab = s.aiTabs.some((t) => t.id === newTabId);
+				let updatedTabs = s.aiTabs;
+				const currentOrder = s.unifiedTabOrder || [];
+				let updatedOrder = currentOrder;
+				if (!hasNewTab) {
+					const sourceIdx = s.aiTabs.findIndex((t) => t.id === sourceTabId);
+					const insertIdx = sourceIdx >= 0 ? sourceIdx + 1 : s.aiTabs.length;
+					const busyTab = {
+						...tabResult.tab,
+						state: 'busy' as const,
 						thinkingStartTime: Date.now(),
-						aiTabs: updatedTabs,
-						activeTabId: newTabId,
-						activeFileTabId: null,
-						activeBrowserTabId: null,
-						activeTerminalTabId: null,
-						inputMode: 'ai' as const,
-						unifiedTabOrder: updatedOrder,
+						awaitingSessionId: true,
 					};
-				})
-			);
-
-			// 6. Toast
-			const estimatedTokens = slicedLogs
-				.filter((log) => log.text && log.source !== 'system')
-				.reduce((sum, log) => sum + Math.round((log.text?.length || 0) / 4), 0);
-			const tokenInfo = estimatedTokens > 0 ? ` (~${estimatedTokens.toLocaleString()} tokens)` : '';
-
-			notifyToast({
-				type: 'success',
-				title: 'Conversation Forked',
-				message: `"${sourceDisplayName}" → "${forkTabName}"${tokenInfo}`,
-				sessionId: session.id,
-				tabId: newTabId,
-			});
-
-			// 7. Spawn agent async (follows Send-to-Agent pattern)
-			(async () => {
-				try {
-					const agent = await window.maestro.agents.get(session.toolType);
-					if (!agent) throw new Error(`${session.toolType} agent not found`);
-
-					const baseArgs = agent.args ?? [];
-					const commandToUse = agent.path || agent.command;
-					if (!commandToUse) {
-						throw new Error(`${session.toolType} agent has no command configured`);
+					updatedTabs = [...s.aiTabs.slice(0, insertIdx), busyTab, ...s.aiTabs.slice(insertIdx)];
+					const newTabRef = { type: 'ai' as const, id: newTabId };
+					if (!currentOrder.some((ref) => ref.type === 'ai' && ref.id === newTabId)) {
+						const sourceOrderIdx = currentOrder.findIndex(
+							(ref) => ref.type === 'ai' && ref.id === sourceTabId
+						);
+						updatedOrder =
+							sourceOrderIdx >= 0
+								? [
+										...currentOrder.slice(0, sourceOrderIdx + 1),
+										newTabRef,
+										...currentOrder.slice(sourceOrderIdx + 1),
+									]
+								: [...currentOrder, newTabRef];
 					}
-
-					const isSshSession = Boolean(session.sessionSshRemoteConfig?.enabled);
-					const { sendPromptViaStdin, sendPromptViaStdinRaw } = getStdinFlags({
-						isSshSession,
-						supportsStreamJsonInput: agent.capabilities?.supportsStreamJsonInput ?? false,
-						hasImages: false,
-					});
-
-					const effectivePrompt = contextMessage;
-
-					const appendSystemPrompt = await prepareMaestroSystemPrompt({
-						session,
-						activeTabId: newTabId,
-					});
-
-					const spawnSessionId = `${session.id}-ai-${newTabId}`;
-					await window.maestro.process.spawn({
-						sessionId: spawnSessionId,
-						toolType: session.toolType,
-						cwd: session.cwd,
-						command: commandToUse,
-						args: [...baseArgs],
-						prompt: effectivePrompt,
-						appendSystemPrompt,
-						sessionCustomPath: session.customPath,
-						sessionCustomArgs: session.customArgs,
-						sessionAdditionalDirectories: session.additionalDirectories,
-						sessionCustomEnvVars: session.customEnvVars,
-						sessionCustomModel: session.customModel,
-						sessionCustomEffort: session.customEffort,
-						sessionCustomContextWindow: session.customContextWindow,
-						sessionSshRemoteConfig: session.sessionSshRemoteConfig,
-						sendPromptViaStdin,
-						sendPromptViaStdinRaw,
-					});
-				} catch (error) {
-					captureException(error, {
-						extra: {
-							sessionId: session.id,
-							toolType: session.toolType,
-							newTabId,
-							operation: 'fork-conversation-spawn',
-						},
-					});
-					const errorLog: LogEntry = {
-						id: `error-${Date.now()}`,
-						timestamp: Date.now(),
-						source: 'system',
-						text: `Error: Failed to spawn agent - ${(error as Error).message}`,
-					};
-					setSessions((prev) =>
-						prev.map((s) => {
-							if (s.id !== session.id) return s;
-							return {
-								...s,
-								state: 'idle',
-								busySource: undefined,
-								thinkingStartTime: undefined,
-								aiTabs: s.aiTabs.map((tab) =>
-									tab.id === newTabId
-										? {
-												...tab,
-												state: 'idle' as const,
-												thinkingStartTime: undefined,
-												awaitingSessionId: false,
-												logs: [...tab.logs, errorLog],
-											}
-										: tab
-								),
-							};
-						})
-					);
 				}
-			})();
-		},
-		[sessions, activeSessionId, setSessions]
-	);
+				return {
+					...s,
+					state: 'busy',
+					busySource: 'ai',
+					thinkingStartTime: Date.now(),
+					aiTabs: updatedTabs,
+					activeTabId: newTabId,
+					activeFileTabId: null,
+					activeBrowserTabId: null,
+					activeTerminalTabId: null,
+					inputMode: 'ai' as const,
+					unifiedTabOrder: updatedOrder,
+				};
+			})
+		);
+
+		// 6. Toast
+		const estimatedTokens = slicedLogs
+			.filter((log) => log.text && log.source !== 'system')
+			.reduce((sum, log) => sum + Math.round((log.text?.length || 0) / 4), 0);
+		const tokenInfo = estimatedTokens > 0 ? ` (~${estimatedTokens.toLocaleString()} tokens)` : '';
+
+		notifyToast({
+			type: 'success',
+			title: 'Conversation Forked',
+			message: `"${sourceDisplayName}" → "${forkTabName}"${tokenInfo}`,
+			sessionId: session.id,
+			tabId: newTabId,
+		});
+
+		// 7. Spawn agent async (follows Send-to-Agent pattern)
+		(async () => {
+			try {
+				const agent = await window.maestro.agents.get(session.toolType);
+				if (!agent) throw new Error(`${session.toolType} agent not found`);
+
+				const baseArgs = agent.args ?? [];
+				const commandToUse = agent.path || agent.command;
+				if (!commandToUse) {
+					throw new Error(`${session.toolType} agent has no command configured`);
+				}
+
+				const isSshSession = Boolean(session.sessionSshRemoteConfig?.enabled);
+				const { sendPromptViaStdin, sendPromptViaStdinRaw } = getStdinFlags({
+					isSshSession,
+					supportsStreamJsonInput: agent.capabilities?.supportsStreamJsonInput ?? false,
+					hasImages: false,
+				});
+
+				const effectivePrompt = contextMessage;
+
+				const appendSystemPrompt = await prepareMaestroSystemPrompt({
+					session,
+					activeTabId: newTabId,
+				});
+
+				const spawnSessionId = `${session.id}-ai-${newTabId}`;
+				await window.maestro.process.spawn({
+					sessionId: spawnSessionId,
+					toolType: session.toolType,
+					cwd: session.cwd,
+					command: commandToUse,
+					args: [...baseArgs],
+					prompt: effectivePrompt,
+					appendSystemPrompt,
+					sessionCustomPath: session.customPath,
+					sessionCustomArgs: session.customArgs,
+					sessionAdditionalDirectories: session.additionalDirectories,
+					sessionCustomEnvVars: session.customEnvVars,
+					sessionCustomModel: session.customModel,
+					sessionCustomEffort: session.customEffort,
+					sessionCustomContextWindow: session.customContextWindow,
+					sessionSshRemoteConfig: session.sessionSshRemoteConfig,
+					sendPromptViaStdin,
+					sendPromptViaStdinRaw,
+				});
+			} catch (error) {
+				captureException(error, {
+					extra: {
+						sessionId: session.id,
+						toolType: session.toolType,
+						newTabId,
+						operation: 'fork-conversation-spawn',
+					},
+				});
+				const errorLog: LogEntry = {
+					id: `error-${Date.now()}`,
+					timestamp: Date.now(),
+					source: 'system',
+					text: `Error: Failed to spawn agent - ${(error as Error).message}`,
+				};
+				useSessionStore.getState().setSessions((prev) =>
+					prev.map((s) => {
+						if (s.id !== session.id) return s;
+						return {
+							...s,
+							state: 'idle',
+							busySource: undefined,
+							thinkingStartTime: undefined,
+							aiTabs: s.aiTabs.map((tab) =>
+								tab.id === newTabId
+									? {
+											...tab,
+											state: 'idle' as const,
+											thinkingStartTime: undefined,
+											awaitingSessionId: false,
+											logs: [...tab.logs, errorLog],
+										}
+									: tab
+							),
+						};
+					})
+				);
+			}
+		})();
+	}, []);
 }

--- a/src/renderer/hooks/git/useFileTreeManagement.ts
+++ b/src/renderer/hooks/git/useFileTreeManagement.ts
@@ -102,8 +102,6 @@ export type { SshContext } from '../../utils/fileExplorer';
  * Dependencies for the useFileTreeManagement hook.
  */
 export interface UseFileTreeManagementDeps {
-	/** Current sessions array */
-	sessions: Session[];
 	/** Ref to sessions for accessing latest state without triggering effect re-runs */
 	sessionsRef: React.MutableRefObject<Session[]>;
 	/** Session state setter */
@@ -172,7 +170,6 @@ export function useFileTreeManagement(
 	deps: UseFileTreeManagementDeps
 ): UseFileTreeManagementReturn {
 	const {
-		sessions,
 		sessionsRef,
 		setSessions,
 		activeSessionId,
@@ -521,7 +518,7 @@ export function useFileTreeManagement(
 	const refreshGitFileState = useCallback(
 		async (sessionId: string) => {
 			const seq = nextSeq(sessionId);
-			const session = sessions.find((s) => s.id === sessionId);
+			const session = sessionsRef.current.find((s) => s.id === sessionId);
 			if (!session) return;
 
 			// Use projectRoot for file tree (consistent with Files tab header)
@@ -637,7 +634,7 @@ export function useFileTreeManagement(
 			}
 		},
 		[
-			sessions,
+			sessionsRef,
 			setSessions,
 			rightPanelRef,
 			sshContextOptions,

--- a/src/renderer/hooks/keyboard/useMainKeyboardHandler.ts
+++ b/src/renderer/hooks/keyboard/useMainKeyboardHandler.ts
@@ -6,6 +6,7 @@ import {
 	toggleReadOnlyModeFields,
 } from '../../utils/tabHelpers';
 import { useModalStore } from '../../stores/modalStore';
+import { useSessionStore } from '../../stores/sessionStore';
 import { useSettingsStore } from '../../stores/settingsStore';
 import { isActiveOutputSearchOpen } from '../../utils/outputSearch';
 import { editClipboardImage } from '../../components/ImageAnnotator/editClipboardImage';
@@ -23,7 +24,7 @@ const FONT_SIZE_DEFAULT = 14;
  *
  * Key properties include:
  * - isShortcut, isTabShortcut: Shortcut matching functions
- * - sessions, activeSession, activeSessionId: Session state
+ * - sessions length (via getState), activeSession, activeSessionId: Session state
  * - activeFocus, activeRightTab: UI focus state
  * - Various modal open states (quickActionOpen, settingsModalOpen, etc.)
  * - hasOpenLayers, hasOpenModal: Layer stack functions
@@ -506,7 +507,7 @@ export function useMainKeyboardHandler(): UseMainKeyboardHandlerReturn {
 			// General shortcuts
 			// Only allow collapsing left sidebar when there are sessions (prevent collapse on empty state)
 			if (ctx.isShortcut(e, 'toggleSidebar')) {
-				if (ctx.sessions.length > 0 || !ctx.leftSidebarOpen) {
+				if (useSessionStore.getState().sessions.length > 0 || !ctx.leftSidebarOpen) {
 					ctx.setLeftSidebarOpen((p: boolean) => !p);
 					trackShortcut('toggleSidebar');
 				}
@@ -572,13 +573,13 @@ export function useMainKeyboardHandler(): UseMainKeyboardHandlerReturn {
 				trackShortcut('toggleMode');
 			} else if (ctx.isShortcut(e, 'agentSwitcher')) {
 				e.preventDefault();
-				if (ctx.sessions.length > 0) {
+				if (useSessionStore.getState().sessions.length > 0) {
 					ctx.setQuickActionOpen(true, 'agents');
 					trackShortcut('agentSwitcher');
 				}
 			} else if (ctx.isShortcut(e, 'quickAction')) {
 				e.preventDefault();
-				if (ctx.sessions.length > 0) {
+				if (useSessionStore.getState().sessions.length > 0) {
 					ctx.setQuickActionOpen(true, 'main');
 					trackShortcut('quickAction');
 				}

--- a/src/renderer/hooks/props/useMainPanelProps.ts
+++ b/src/renderer/hooks/props/useMainPanelProps.ts
@@ -20,7 +20,6 @@ import type {
 	AITab,
 	UnifiedTab,
 	FilePreviewTab,
-	ThinkingItem,
 	AgentError,
 	QueuedItem,
 } from '../../types';
@@ -47,7 +46,6 @@ export interface UseMainPanelPropsDeps {
 	memoryViewerOpen: boolean;
 	activeAgentSessionId: string | null;
 	activeSession: Session | null;
-	thinkingItems: ThinkingItem[];
 	theme: Theme;
 	isMobileLandscape: boolean;
 	stagedImages: string[];
@@ -336,7 +334,6 @@ export function useMainPanelProps(deps: UseMainPanelPropsDeps) {
 			memoryViewerOpen: deps.memoryViewerOpen,
 			activeAgentSessionId: deps.activeAgentSessionId,
 			activeSession: deps.activeSession,
-			thinkingItems: deps.thinkingItems,
 			theme: deps.theme,
 			isMobileLandscape: deps.isMobileLandscape,
 			stagedImages: deps.stagedImages,
@@ -580,7 +577,6 @@ export function useMainPanelProps(deps: UseMainPanelPropsDeps) {
 			// Without it, queue mutations while the agent is idle (no other tracked dep
 			// changing) leave the transcript showing a stale queued message.
 			deps.activeSession?.executionQueue,
-			deps.thinkingItems,
 			deps.theme,
 			deps.isMobileLandscape,
 			deps.stagedImages,

--- a/src/renderer/hooks/session/index.ts
+++ b/src/renderer/hooks/session/index.ts
@@ -69,3 +69,6 @@ export type {
 	UseSessionSwitchCallbacksDeps,
 	UseSessionSwitchCallbacksReturn,
 } from './useSessionSwitchCallbacks';
+
+// Thinking status pill items (narrow store subscription)
+export { useThinkingItems } from './useThinkingItems';

--- a/src/renderer/hooks/session/useSessionNavigation.ts
+++ b/src/renderer/hooks/session/useSessionNavigation.ts
@@ -1,6 +1,7 @@
 import { useCallback, MutableRefObject } from 'react';
 import type { Session } from '../../types';
 import { navigateToUnifiedTabById } from '../../utils/tabHelpers';
+import { useSessionStore } from '../../stores/sessionStore';
 import type { NavHistoryEntry } from './useNavigationHistory';
 
 /**
@@ -43,18 +44,13 @@ export interface UseSessionNavigationReturn {
  * Hook that provides session navigation handlers for back/forward navigation
  * through sessions and AI tabs.
  *
- * Extracted from App.tsx to reduce file size and improve maintainability.
- * Works with useNavigationHistory to implement browser-like back/forward
- * navigation across sessions and their AI conversation tabs.
+ * PERF: Session existence is checked via getState() at event time so App does
+ * not need a reactive `sessions` subscription for this handler.
  *
- * @param sessions - The current list of sessions
  * @param deps - Dependencies including navigation functions and state setters
  * @returns Object containing navigation handler functions
  */
-export function useSessionNavigation(
-	sessions: Session[],
-	deps: UseSessionNavigationDeps
-): UseSessionNavigationReturn {
+export function useSessionNavigation(deps: UseSessionNavigationDeps): UseSessionNavigationReturn {
 	const {
 		navigateBack,
 		navigateForward,
@@ -75,7 +71,9 @@ export function useSessionNavigation(
 
 			// Session entry
 			if (!entry.sessionId) return;
-			const sessionExists = sessions.some((s) => s.id === entry.sessionId);
+			const sessionExists = useSessionStore
+				.getState()
+				.sessions.some((s) => s.id === entry.sessionId);
 			if (!sessionExists) return;
 
 			setActiveSessionId(entry.sessionId);
@@ -96,7 +94,7 @@ export function useSessionNavigation(
 				);
 			}
 		},
-		[sessions, setActiveSessionId, cyclePositionRef, setSessions, onNavigateToGroupChat]
+		[setActiveSessionId, cyclePositionRef, setSessions, onNavigateToGroupChat]
 	);
 
 	// Navigate back in history (through sessions, tabs, and group chats)

--- a/src/renderer/hooks/session/useThinkingItems.ts
+++ b/src/renderer/hooks/session/useThinkingItems.ts
@@ -1,0 +1,88 @@
+/**
+ * useThinkingItems — narrow store subscription for the ThinkingStatusPill.
+ *
+ * PERF: Does not subscribe to the full `sessions` array reference. Uses
+ * `useStoreWithEqualityFn` so MaestroConsoleInner / MainPanel are not
+ * re-rendered on log streaming; only the leaf that paints the pill updates
+ * when busy/orphan/token fields that the pill displays actually change.
+ */
+
+import { useStoreWithEqualityFn } from 'zustand/traditional';
+import type { Session, ThinkingItem } from '../../types';
+import { useSessionStore } from '../../stores/sessionStore';
+import { buildThinkingItems } from '../../utils/thinkingItems';
+
+function thinkingSessionEqual(a: Session, b: Session): boolean {
+	if (a === b) return true;
+	if (
+		a.id !== b.id ||
+		a.name !== b.name ||
+		a.state !== b.state ||
+		a.busySource !== b.busySource ||
+		a.thinkingStartTime !== b.thinkingStartTime ||
+		a.currentCycleTokens !== b.currentCycleTokens
+	) {
+		return false;
+	}
+
+	const aTabs = a.aiTabs;
+	const bTabs = b.aiTabs;
+	if (aTabs !== bTabs) {
+		if (!aTabs || !bTabs || aTabs.length !== bTabs.length) return false;
+		for (let i = 0; i < aTabs.length; i++) {
+			const at = aTabs[i];
+			const bt = bTabs[i];
+			if (
+				at.id !== bt.id ||
+				at.name !== bt.name ||
+				at.state !== bt.state ||
+				at.thinkingStartTime !== bt.thinkingStartTime
+			) {
+				return false;
+			}
+		}
+	}
+
+	const aOrphans = a.orphanedThinkingTabs;
+	const bOrphans = b.orphanedThinkingTabs;
+	if (aOrphans !== bOrphans) {
+		if (!aOrphans || !bOrphans || aOrphans.length !== bOrphans.length) return false;
+		for (let i = 0; i < aOrphans.length; i++) {
+			const ao = aOrphans[i];
+			const bo = bOrphans[i];
+			if (
+				ao.id !== bo.id ||
+				ao.name !== bo.name ||
+				ao.state !== bo.state ||
+				ao.thinkingStartTime !== bo.thinkingStartTime
+			) {
+				return false;
+			}
+		}
+	}
+
+	return true;
+}
+
+function thinkingSessionsEquality(a: Session[], b: Session[]): boolean {
+	if (a === b) return true;
+	if (a.length !== b.length) return false;
+	for (let i = 0; i < a.length; i++) {
+		if (!thinkingSessionEqual(a[i], b[i])) return false;
+	}
+	return true;
+}
+
+/**
+ * Flat list of busy/orphan thinking items for the status pill.
+ *
+ * @param ownsSession Optional multi-window ownership predicate (from WindowContext).
+ */
+export function useThinkingItems(ownsSession?: (sessionId: string) => boolean): ThinkingItem[] {
+	const sessions = useStoreWithEqualityFn(
+		useSessionStore,
+		(s) => s.sessions,
+		thinkingSessionsEquality
+	);
+	return buildThinkingItems(sessions, ownsSession);
+}

--- a/src/renderer/hooks/useCueAutoDiscovery.ts
+++ b/src/renderer/hooks/useCueAutoDiscovery.ts
@@ -27,7 +27,8 @@ import { logger } from '../utils/logger';
 export function useCueAutoDiscovery(encoreFeatures: EncoreFeatureFlags) {
 	const sessionsLoaded = useSessionStore((s) => s.sessionsLoaded);
 	const cueDiscoverySignature = useSessionStore(selectCueDiscoverySignature);
-	const prevSessionIdsRef = useRef<Set<string>>(new Set());
+	// id → projectRoot so root moves (same id, new cwd) are detected.
+	const prevSessionRootsRef = useRef<Map<string, string>>(new Map());
 	const prevMaestroCueEnabledRef = useRef<boolean>(encoreFeatures.maestroCue);
 	const initialScanDoneRef = useRef(false);
 	// Serializes in-flight enable/disable IPC calls so rapid toggles
@@ -35,13 +36,14 @@ export function useCueAutoDiscovery(encoreFeatures: EncoreFeatureFlags) {
 	// that disagrees with the observed flag value.
 	const toggleChainRef = useRef<Promise<void>>(Promise.resolve());
 
-	// Track session additions and removals — always runs regardless of encore flag
+	// Track session additions, removals, and projectRoot moves — always runs
+	// regardless of encore flag
 	useEffect(() => {
 		if (!sessionsLoaded) return;
 
 		const sessions = useSessionStore.getState().sessions;
-		const currentIds = new Set(sessions.map((s) => s.id));
-		const prevIds = prevSessionIdsRef.current;
+		const currentRoots = new Map(sessions.map((s) => [s.id, s.projectRoot ?? '']));
+		const prevRoots = prevSessionRootsRef.current;
 
 		// --- Initial scan after sessions are loaded ---
 		if (!initialScanDoneRef.current) {
@@ -55,24 +57,44 @@ export function useCueAutoDiscovery(encoreFeatures: EncoreFeatureFlags) {
 						);
 				}
 			}
-			prevSessionIdsRef.current = currentIds;
+			prevSessionRootsRef.current = currentRoots;
 			return;
 		}
 
-		// --- Detect new sessions ---
+		// --- Detect new sessions and projectRoot moves ---
 		for (const session of sessions) {
-			if (!prevIds.has(session.id) && session.projectRoot) {
-				window.maestro.cue
-					.refreshSession(session.id, session.projectRoot)
-					.catch((err) =>
-						logger.error('[CueAutoDiscovery] Failed to refresh session:', undefined, err)
-					);
+			const root = session.projectRoot ?? '';
+			const prevRoot = prevRoots.get(session.id);
+
+			if (prevRoot === undefined) {
+				if (root) {
+					window.maestro.cue
+						.refreshSession(session.id, root)
+						.catch((err) =>
+							logger.error('[CueAutoDiscovery] Failed to refresh session:', undefined, err)
+						);
+				}
+				continue;
 			}
+
+			if (prevRoot === root) continue;
+
+			// Same agent id, different root: clear the old registration then
+			// refresh against the new path (or leave cleared if root is empty).
+			window.maestro.cue
+				.removeSession(session.id)
+				.then(() => {
+					if (!root) return;
+					return window.maestro.cue.refreshSession(session.id, root);
+				})
+				.catch((err) =>
+					logger.error('[CueAutoDiscovery] Failed to move session projectRoot:', undefined, err)
+				);
 		}
 
 		// --- Detect removed sessions ---
-		for (const prevId of prevIds) {
-			if (!currentIds.has(prevId)) {
+		for (const prevId of prevRoots.keys()) {
+			if (!currentRoots.has(prevId)) {
 				window.maestro.cue
 					.removeSession(prevId)
 					.catch((err) =>
@@ -81,7 +103,7 @@ export function useCueAutoDiscovery(encoreFeatures: EncoreFeatureFlags) {
 			}
 		}
 
-		prevSessionIdsRef.current = currentIds;
+		prevSessionRootsRef.current = currentRoots;
 	}, [cueDiscoverySignature, sessionsLoaded]);
 
 	// Track encore feature toggle. Queues enable/disable calls on a single

--- a/src/renderer/hooks/useCueAutoDiscovery.ts
+++ b/src/renderer/hooks/useCueAutoDiscovery.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
-import type { Session, EncoreFeatureFlags } from '../types';
+import type { EncoreFeatureFlags } from '../types';
 import { useSessionStore } from '../stores/sessionStore';
+import { selectCueDiscoverySignature } from '../stores/sessionEquality';
 import { notifyToast } from '../stores/notificationStore';
 import { captureException } from '../utils/sentry';
 import { logger } from '../utils/logger';
@@ -18,9 +19,14 @@ import { logger } from '../utils/logger';
  * Session discovery always runs so the Cue indicator shows in the Left Bar
  * whenever a .maestro/cue.yaml exists. The encore feature flag only gates
  * engine execution (start/stop), not config discovery.
+ *
+ * PERF: Subscribes to a compact id+projectRoot signature (not the full
+ * sessions array) so streaming log/token updates do not re-render App.
+ * Session objects are read via getState() inside effects at event time.
  */
-export function useCueAutoDiscovery(sessions: Session[], encoreFeatures: EncoreFeatureFlags) {
+export function useCueAutoDiscovery(encoreFeatures: EncoreFeatureFlags) {
 	const sessionsLoaded = useSessionStore((s) => s.sessionsLoaded);
+	const cueDiscoverySignature = useSessionStore(selectCueDiscoverySignature);
 	const prevSessionIdsRef = useRef<Set<string>>(new Set());
 	const prevMaestroCueEnabledRef = useRef<boolean>(encoreFeatures.maestroCue);
 	const initialScanDoneRef = useRef(false);
@@ -33,6 +39,7 @@ export function useCueAutoDiscovery(sessions: Session[], encoreFeatures: EncoreF
 	useEffect(() => {
 		if (!sessionsLoaded) return;
 
+		const sessions = useSessionStore.getState().sessions;
 		const currentIds = new Set(sessions.map((s) => s.id));
 		const prevIds = prevSessionIdsRef.current;
 
@@ -75,7 +82,7 @@ export function useCueAutoDiscovery(sessions: Session[], encoreFeatures: EncoreF
 		}
 
 		prevSessionIdsRef.current = currentIds;
-	}, [sessions, sessionsLoaded]);
+	}, [cueDiscoverySignature, sessionsLoaded]);
 
 	// Track encore feature toggle. Queues enable/disable calls on a single
 	// chain so rapid ON/OFF/ON toggles always apply in the order the user
@@ -89,7 +96,9 @@ export function useCueAutoDiscovery(sessions: Session[], encoreFeatures: EncoreF
 
 		if (wasEnabled === isEnabled) return;
 
-		const sessionsSnapshot = sessions.filter((session) => !!session.projectRoot);
+		const sessionsSnapshot = useSessionStore
+			.getState()
+			.sessions.filter((session) => !!session.projectRoot);
 
 		toggleChainRef.current = toggleChainRef.current.then(async () => {
 			if (isEnabled) {
@@ -133,5 +142,5 @@ export function useCueAutoDiscovery(sessions: Session[], encoreFeatures: EncoreF
 				}
 			}
 		});
-	}, [encoreFeatures.maestroCue, sessions, sessionsLoaded]);
+	}, [encoreFeatures.maestroCue, sessionsLoaded]);
 }

--- a/src/renderer/hooks/utils/useDebouncedPersistence.ts
+++ b/src/renderer/hooks/utils/useDebouncedPersistence.ts
@@ -37,6 +37,7 @@ import {
 	isEphemeralBrowserTab,
 	sanitizeBrowserTabForPersistence,
 } from '../../utils/browserTabPersistence';
+import { useSessionStore } from '../../stores/sessionStore';
 import { logger } from '../../utils/logger';
 import { captureException } from '../../utils/sentry';
 
@@ -324,22 +325,27 @@ function diffSessions(
 /**
  * Hook that debounces session persistence to reduce disk writes.
  *
- * @param sessions - Array of sessions to persist
+ * PERF: Owns its own `useSessionStore.subscribe` so App does not need a
+ * reactive `sessions` subscription. Streaming updates reset the debounce
+ * timer via the subscription without re-rendering App on every flush
+ * (`isPending` only flips false→true once per dirty streak).
+ *
  * @param initialLoadComplete - Ref indicating if initial load is done (prevents persisting on mount)
  * @param delay - Debounce delay in milliseconds (default 2000)
  * @returns Object with isPending state and flushNow function
  */
 export function useDebouncedPersistence(
-	sessions: Session[],
 	initialLoadComplete: React.MutableRefObject<boolean>,
 	delay: number = DEFAULT_DEBOUNCE_DELAY
 ): UseDebouncedPersistenceReturn {
 	// Track if there are pending changes
 	const [isPending, setIsPending] = useState(false);
+	// Mirror isPending so the store subscription can avoid setState on every
+	// streaming tick after the first dirty mark (would re-render App).
+	const isPendingRef = useRef(false);
 
 	// Store the latest sessions in a ref for access in flush callbacks
-	const sessionsRef = useRef<Session[]>(sessions);
-	sessionsRef.current = sessions;
+	const sessionsRef = useRef<Session[]>(useSessionStore.getState().sessions);
 
 	// Store the timer ID for cleanup
 	const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -417,6 +423,7 @@ export function useDebouncedPersistence(
 		flushingRef.current = true;
 		try {
 			await persistInternal();
+			isPendingRef.current = false;
 			setIsPending(false);
 		} catch (err) {
 			logger.warn(
@@ -471,41 +478,52 @@ export function useDebouncedPersistence(
 			}
 
 			// No snapshot: only flush if there are known pending changes.
-			if (isPending) {
+			if (isPendingRef.current) {
 				persistSessions();
 			}
 		},
-		[isPending, persistSessions]
+		[persistSessions]
 	);
 
-	// Debounced persistence effect
+	// Debounced persistence via store subscribe (no App-level sessions subscription)
 	useEffect(() => {
-		// Skip persistence during initial load
-		if (!initialLoadComplete.current) {
-			return;
-		}
+		const schedulePersist = () => {
+			// Skip persistence during initial load
+			if (!initialLoadComplete.current) {
+				return;
+			}
 
-		// Mark as pending
-		setIsPending(true);
+			// Mark pending once per dirty streak — avoid setState on every stream tick
+			if (!isPendingRef.current) {
+				isPendingRef.current = true;
+				setIsPending(true);
+			}
 
-		// Clear existing timer
-		if (timerRef.current) {
-			clearTimeout(timerRef.current);
-		}
+			// Clear existing timer
+			if (timerRef.current) {
+				clearTimeout(timerRef.current);
+			}
 
-		// Set new debounce timer
-		timerRef.current = setTimeout(() => {
-			persistSessions();
-			timerRef.current = null;
-		}, delay);
+			// Set new debounce timer
+			timerRef.current = setTimeout(() => {
+				persistSessions();
+				timerRef.current = null;
+			}, delay);
+		};
 
-		// Cleanup on unmount or when sessions change
+		const unsubscribe = useSessionStore.subscribe((state, prevState) => {
+			if (state.sessions === prevState.sessions) return;
+			sessionsRef.current = state.sessions;
+			schedulePersist();
+		});
+
 		return () => {
+			unsubscribe();
 			if (timerRef.current) {
 				clearTimeout(timerRef.current);
 			}
 		};
-	}, [sessions, delay, initialLoadComplete, persistSessions]);
+	}, [delay, initialLoadComplete, persistSessions]);
 
 	// Flush on unmount to prevent data loss
 	useEffect(() => {
@@ -531,7 +549,7 @@ export function useDebouncedPersistence(
 	// Flush on visibility change (user switching away from app)
 	useEffect(() => {
 		const handleVisibilityChange = () => {
-			if (document.hidden && isPending) {
+			if (document.hidden && isPendingRef.current) {
 				flushNow();
 			}
 		};
@@ -541,12 +559,12 @@ export function useDebouncedPersistence(
 		return () => {
 			document.removeEventListener('visibilitychange', handleVisibilityChange);
 		};
-	}, [isPending, flushNow]);
+	}, [flushNow]);
 
 	// Flush on beforeunload (app closing)
 	useEffect(() => {
 		const handleBeforeUnload = () => {
-			if (isPending) {
+			if (isPendingRef.current) {
 				// Synchronous flush for beforeunload — uses the same dirty-only
 				// path as the debounce timer (see persistInternal).
 				// Swallow rejections: the window is closing, there's no caller
@@ -562,7 +580,7 @@ export function useDebouncedPersistence(
 		return () => {
 			window.removeEventListener('beforeunload', handleBeforeUnload);
 		};
-	}, [isPending, persistInternal]);
+	}, [persistInternal]);
 
 	return { isPending, flushNow };
 }

--- a/src/renderer/stores/sessionEquality.ts
+++ b/src/renderer/stores/sessionEquality.ts
@@ -124,6 +124,28 @@ export function mentionSessionEquality(a: Session[], b: Session[]): boolean {
 }
 
 /**
+ * Fields that need a live id → projectRoot map (e.g. GroupChat participant paths).
+ * Ignores logs, tokens, and other streaming-heavy fields. Unlike
+ * `sidebarSessionEquality`, this *does* compare `projectRoot`.
+ */
+export function projectRootSessionEquality(a: Session[], b: Session[]): boolean {
+	if (a === b) return true;
+	if (a.length !== b.length) return false;
+
+	for (let i = 0; i < a.length; i++) {
+		const x = a[i];
+		const y = b[i];
+		if (x === y) continue;
+
+		if (x.id !== y.id || x.projectRoot !== y.projectRoot) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+/**
  * Compact signature of session id + projectRoot for Cue auto-discovery.
  * Changes only when agents are added/removed or their project root moves.
  */

--- a/src/renderer/stores/sessionEquality.ts
+++ b/src/renderer/stores/sessionEquality.ts
@@ -68,3 +68,65 @@ export function sidebarSessionEquality(a: Session[], b: Session[]): boolean {
 
 	return true;
 }
+
+/**
+ * Fields useGitStatusPolling reads for poll cwd / SSH / isGitRepo gating.
+ * Ignores logs, tokens, and other streaming-heavy fields.
+ */
+export function gitPollSessionEquality(a: Session[], b: Session[]): boolean {
+	if (a === b) return true;
+	if (a.length !== b.length) return false;
+
+	for (let i = 0; i < a.length; i++) {
+		const x = a[i];
+		const y = b[i];
+		if (x === y) continue;
+
+		if (
+			x.id !== y.id ||
+			x.isGitRepo !== y.isGitRepo ||
+			x.inputMode !== y.inputMode ||
+			x.cwd !== y.cwd ||
+			x.shellCwd !== y.shellCwd ||
+			x.sshRemoteId !== y.sshRemoteId ||
+			x.sessionSshRemoteConfig?.remoteId !== y.sessionSshRemoteConfig?.remoteId
+		) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+/**
+ * Fields GroupChat @mention autocomplete needs (id, name, toolType, groupId).
+ */
+export function mentionSessionEquality(a: Session[], b: Session[]): boolean {
+	if (a === b) return true;
+	if (a.length !== b.length) return false;
+
+	for (let i = 0; i < a.length; i++) {
+		const x = a[i];
+		const y = b[i];
+		if (x === y) continue;
+
+		if (
+			x.id !== y.id ||
+			x.name !== y.name ||
+			x.toolType !== y.toolType ||
+			x.groupId !== y.groupId
+		) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+/**
+ * Compact signature of session id + projectRoot for Cue auto-discovery.
+ * Changes only when agents are added/removed or their project root moves.
+ */
+export function selectCueDiscoverySignature(state: { sessions: Session[] }): string {
+	return state.sessions.map((s) => `${s.id}\0${s.projectRoot ?? ''}`).join('\n');
+}


### PR DESCRIPTION
Peel MaestroConsoleInner off useSessionStore(s => s.sessions) so log/token flushes do not re-render the console shell. Persistence, fork, nav, and cue read at event time; leaves self-source with narrow selectors. Sidebar equality and useActiveSession remain as follow-ups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Reduced re-render churn during streaming by switching session-driven UI to use targeted store subscriptions and stable equality checks.
  * Improved sidebar/session ordering and initialization of debounced session persistence.

* **Bug Fixes**
  * More reliable session navigation, conversation forking, cue auto-discovery, and session persistence (including flush and failure handling).
  * Stabilized timing for event payload validation and ensured mention autocomplete and thinking indicators stay in sync with current session state.

* **Tests**
  * Refreshed test setup to reset and seed shared session state for better isolation and correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->