### PR TITLE
fix(omp): recoverable no-output error + OmpSessionStorage History parity

### DIFF
--- a/src/__tests__/main/process-manager/handlers/ExitHandler.test.ts
+++ b/src/__tests__/main/process-manager/handlers/ExitHandler.test.ts
@@ -595,4 +595,109 @@ describe('ExitHandler', () => {
 			expect(elapsed).toBeLessThan(200);
 		});
 	});
+
+	describe('omp silent-exit hardening', () => {
+		function ompProc(overrides: Partial<ManagedProcess> = {}): ManagedProcess {
+			return createMockProcess({
+				toolType: 'omp',
+				isStreamJsonMode: true,
+				outputParser: createMockOutputParser({ agentId: 'omp' }),
+				resultEmitted: false,
+				errorEmitted: false,
+				streamedText: '',
+				...overrides,
+			});
+		}
+
+		it('surfaces a recoverable agent_crashed error when omp exits clean with no result, error, or output', async () => {
+			processes.set('sess-ai-tab1', ompProc());
+
+			const errors: Array<{ type: string; recoverable: boolean; message: string }> = [];
+			const exitEvents: number[] = [];
+			emitter.on('agent-error', (_sid: string, err) => errors.push(err));
+			emitter.on('exit', (_sid: string, code: number) => exitEvents.push(code));
+
+			await exitHandler.handleExit('sess-ai-tab1', 0);
+
+			expect(errors).toHaveLength(1);
+			expect(errors[0].type).toBe('agent_crashed');
+			expect(errors[0].recoverable).toBe(true);
+			expect(errors[0].message).toContain('without producing a response');
+			// The exit event still fires so the tab leaves the busy state.
+			expect(exitEvents).toEqual([0]);
+		});
+
+		it('does not fire when the user interrupted the turn (null signal coerced to code 0)', async () => {
+			processes.set('sess-ai-tab1', ompProc({ interrupted: true }));
+
+			const errors: unknown[] = [];
+			emitter.on('agent-error', (_sid: string, err) => errors.push(err));
+
+			await exitHandler.handleExit('sess-ai-tab1', 0);
+
+			expect(errors).toHaveLength(0);
+		});
+
+		it('does not fire when omp streamed text that the exit fallback flushes as the result', async () => {
+			processes.set('sess-ai-tab1', ompProc({ streamedText: 'here is my answer' }));
+
+			const errors: unknown[] = [];
+			const dataEvents: string[] = [];
+			emitter.on('agent-error', (_sid: string, err) => errors.push(err));
+			emitter.on('data', (_sid: string, data: string) => dataEvents.push(data));
+
+			await exitHandler.handleExit('sess-ai-tab1', 0);
+
+			expect(errors).toHaveLength(0);
+			expect(dataEvents).toContain('here is my answer');
+		});
+
+		it('does not fire for non-omp agents that exit clean with no output', async () => {
+			processes.set('sess-ai-tab1', ompProc({ toolType: 'claude-code' }));
+
+			const errors: unknown[] = [];
+			emitter.on('agent-error', (_sid: string, err) => errors.push(err));
+
+			await exitHandler.handleExit('sess-ai-tab1', 0);
+
+			expect(errors).toHaveLength(0);
+		});
+
+		it('does not fire for background omp synopsis or tab-naming sessions', async () => {
+			processes.set('sess-synopsis-123', ompProc());
+			processes.set('tab-naming-abc', ompProc());
+
+			const errors: unknown[] = [];
+			emitter.on('agent-error', (_sid: string, err) => errors.push(err));
+
+			await exitHandler.handleExit('sess-synopsis-123', 0);
+			await exitHandler.handleExit('tab-naming-abc', 0);
+
+			expect(errors).toHaveLength(0);
+		});
+
+		it('does not double-report when a non-zero exit already emitted an error', async () => {
+			// detectErrorFromExit fires for non-zero codes; the guard must see
+			// errorEmitted and stay quiet so only one error surfaces.
+			const parser = createMockOutputParser({
+				agentId: 'omp',
+				detectErrorFromExit: vi.fn(() => ({
+					type: 'agent_crashed',
+					message: 'Oh My Pi exited with code 1',
+					recoverable: true,
+					agentId: 'omp',
+					timestamp: Date.now(),
+				})) as unknown as AgentOutputParser['detectErrorFromExit'],
+			});
+			processes.set('sess-ai-tab1', ompProc({ outputParser: parser }));
+
+			const errors: Array<{ message: string }> = [];
+			emitter.on('agent-error', (_sid: string, err) => errors.push(err));
+
+			await exitHandler.handleExit('sess-ai-tab1', 1);
+
+			expect(errors).toHaveLength(1);
+			expect(errors[0].message).toContain('code 1');
+		});
+	});
 });

--- a/src/__tests__/main/storage/omp-session-storage.test.ts
+++ b/src/__tests__/main/storage/omp-session-storage.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import os from 'os';
+import path from 'path';
+import { promises as fs } from 'fs';
+
+vi.mock('../../../main/utils/logger', () => ({
+	logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('../../../main/utils/sentry', () => ({
+	captureException: vi.fn(),
+}));
+
+import { OmpSessionStorage } from '../../../main/storage/omp-session-storage';
+import type { SshRemoteConfig } from '../../../shared/types';
+
+/**
+ * These tests exercise OmpSessionStorage against REAL temp transcript files
+ * (os.homedir spied to a temp root) so they are deterministic and never touch a
+ * developer's `~/.omp`. The on-disk shape mirrors omp's actual JSONL layout:
+ * `~/.omp/agent/sessions/<cwd-slug>/<ISO-ts>_<id>.jsonl`.
+ */
+describe('OmpSessionStorage', () => {
+	let tmpHome: string;
+	let projectPath: string;
+	let storage: OmpSessionStorage;
+
+	const sshConfig: SshRemoteConfig = {
+		enabled: true,
+		remoteId: 'remote-1',
+	} as SshRemoteConfig;
+
+	beforeEach(async () => {
+		tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), 'omp-store-'));
+		vi.spyOn(os, 'homedir').mockReturnValue(tmpHome);
+		projectPath = path.join(tmpHome, 'code', 'proj'); // slug -> "-code-proj"
+		storage = new OmpSessionStorage();
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		await fs.rm(tmpHome, { recursive: true, force: true });
+	});
+
+	async function writeTranscript(
+		slug: string,
+		filename: string,
+		events: Record<string, unknown>[]
+	): Promise<void> {
+		const dir = path.join(tmpHome, '.omp', 'agent', 'sessions', slug);
+		await fs.mkdir(dir, { recursive: true });
+		await fs.writeFile(
+			path.join(dir, filename),
+			events.map((e) => JSON.stringify(e)).join('\n') + '\n'
+		);
+	}
+
+	function fullTranscript(cwd: string, sessionId: string): Record<string, unknown>[] {
+		return [
+			{ type: 'title', title: 'Fix the parser bug' },
+			{ type: 'session', id: sessionId, cwd, timestamp: '2026-07-14T06:38:15.818Z' },
+			{ type: 'model_change', model: 'anthropic/claude-opus-4-8' },
+			{
+				type: 'message',
+				id: 'm0',
+				timestamp: '2026-07-14T06:38:16.000Z',
+				message: {
+					role: 'user',
+					content: [{ type: 'text', text: '# Maestro System Context\n\nYou are ...' }],
+				},
+			},
+			{
+				type: 'message',
+				id: 'm1',
+				timestamp: '2026-07-14T06:39:00.000Z',
+				message: { role: 'user', content: [{ type: 'text', text: 'Please fix the parser' }] },
+			},
+			{
+				type: 'message',
+				id: 'm2',
+				timestamp: '2026-07-14T06:40:00.000Z',
+				message: {
+					role: 'assistant',
+					model: 'anthropic/claude-opus-4-8',
+					content: [
+						{ type: 'thinking', thinking: 'internal reasoning' },
+						{ type: 'text', text: 'Done, fixed it.' },
+					],
+					usage: { input: 100, output: 50, cacheRead: 10, cacheWrite: 5, cost: 0.02 },
+				},
+			},
+			{ type: 'message', id: 'm3', message: { role: 'toolResult', content: 'tool output' } },
+		];
+	}
+
+	it('lists a session for the matching project with metadata, usage, and title', async () => {
+		await writeTranscript(
+			'-code-proj',
+			'2026-07-14T06-38-15_sess-1.jsonl',
+			fullTranscript(projectPath, 'sess-1')
+		);
+
+		const sessions = await storage.listSessions(projectPath);
+
+		expect(sessions).toHaveLength(1);
+		const s = sessions[0];
+		expect(s.sessionId).toBe('sess-1');
+		expect(s.sessionName).toBe('Fix the parser bug');
+		// System-context turn is skipped for the preview; real request wins.
+		expect(s.firstMessage).toBe('Please fix the parser');
+		// user (system) + user + assistant = 3; toolResult excluded.
+		expect(s.messageCount).toBe(3);
+		expect(s.inputTokens).toBe(100);
+		expect(s.outputTokens).toBe(50);
+		expect(s.cacheReadTokens).toBe(10);
+		expect(s.cacheCreationTokens).toBe(5);
+		expect(s.costUsd).toBeCloseTo(0.02);
+		expect(s.byModel && s.byModel.length).toBeGreaterThan(0);
+	});
+
+	it('excludes sessions whose transcript cwd does not match the project', async () => {
+		await writeTranscript('-code-proj', 'a_sess-1.jsonl', fullTranscript(projectPath, 'sess-1'));
+		await writeTranscript(
+			'-code-proj',
+			'b_sess-2.jsonl',
+			fullTranscript('/somewhere/else', 'sess-2')
+		);
+
+		const sessions = await storage.listSessions(projectPath);
+
+		expect(sessions.map((s) => s.sessionId)).toEqual(['sess-1']);
+	});
+
+	it('finds the matching session even when another dir holds unrelated transcripts', async () => {
+		// A non-matching transcript sits in the dir that a slug guess would target;
+		// the real match lives elsewhere. Always-scan + authoritative cwd filter
+		// must still surface it (no fast-path short-circuit hides sessions).
+		await writeTranscript(
+			'-code-proj',
+			'stale_sess-0.jsonl',
+			fullTranscript('/other/project', 'sess-0')
+		);
+		await writeTranscript('legacy-slug', 'x_sess-9.jsonl', fullTranscript(projectPath, 'sess-9'));
+
+		const sessions = await storage.listSessions(projectPath);
+
+		expect(sessions.map((s) => s.sessionId)).toEqual(['sess-9']);
+	});
+
+	it('reads user + assistant messages, extracts text, and skips thinking/toolResult', async () => {
+		await writeTranscript('-code-proj', 'a_sess-1.jsonl', fullTranscript(projectPath, 'sess-1'));
+
+		const result = await storage.readSessionMessages(projectPath, 'sess-1');
+
+		expect(result.total).toBe(3);
+		const roles = result.messages.map((m) => m.role);
+		expect(roles).toEqual(['user', 'user', 'assistant']);
+		const assistant = result.messages.find((m) => m.role === 'assistant');
+		expect(assistant?.content).toBe('Done, fixed it.'); // thinking block excluded
+	});
+
+	it('deletes a user message and its following assistant turn, stopping at the next user', async () => {
+		const events: Record<string, unknown>[] = [
+			{ type: 'session', id: 'sess-1', cwd: projectPath, timestamp: '2026-07-14T06:38:15.818Z' },
+			{
+				type: 'message',
+				id: 'u1',
+				message: { role: 'user', content: [{ type: 'text', text: 'first' }] },
+			},
+			{
+				type: 'message',
+				id: 'a1',
+				message: { role: 'assistant', content: [{ type: 'text', text: 'reply 1' }] },
+			},
+			{ type: 'message', id: 'tr', message: { role: 'toolResult', content: 'tool' } },
+			{
+				type: 'message',
+				id: 'u2',
+				message: { role: 'user', content: [{ type: 'text', text: 'second' }] },
+			},
+			{
+				type: 'message',
+				id: 'a2',
+				message: { role: 'assistant', content: [{ type: 'text', text: 'reply 2' }] },
+			},
+		];
+		await writeTranscript('-code-proj', 'a_sess-1.jsonl', events);
+
+		const del = await storage.deleteMessagePair(projectPath, 'sess-1', 'u1');
+		expect(del.success).toBe(true);
+		expect(del.linesRemoved).toBe(3); // u1 + a1 + toolResult, stop at u2
+
+		const result = await storage.readSessionMessages(projectPath, 'sess-1');
+		expect(result.messages.map((m) => m.uuid)).toEqual(['u2', 'a2']);
+	});
+
+	it('degrades to empty for SSH-remote sessions (local-only v1)', async () => {
+		await writeTranscript('-code-proj', 'a_sess-1.jsonl', fullTranscript(projectPath, 'sess-1'));
+
+		const sessions = await storage.listSessions(projectPath, sshConfig);
+		expect(sessions).toEqual([]);
+
+		const messages = await storage.readSessionMessages(projectPath, 'sess-1', undefined, sshConfig);
+		expect(messages.messages).toEqual([]);
+	});
+});

--- a/src/__tests__/main/storage/omp-session-storage.test.ts
+++ b/src/__tests__/main/storage/omp-session-storage.test.ts
@@ -202,5 +202,37 @@ describe('OmpSessionStorage', () => {
 
 		const messages = await storage.readSessionMessages(projectPath, 'sess-1', undefined, sshConfig);
 		expect(messages.messages).toEqual([]);
+
+		const del = await storage.deleteMessagePair(projectPath, 'sess-1', 'm1', undefined, sshConfig);
+		expect(del.success).toBe(false);
+	});
+
+	it('does not read or delete a same-id transcript that belongs to another project', async () => {
+		// A transcript whose cwd is a DIFFERENT project. read/delete scoped to
+		// projectPath must not resolve it - project-boundary isolation (Greptile P1).
+		await writeTranscript('other', 'x_sess-b.jsonl', fullTranscript('/other/project', 'sess-b'));
+
+		const read = await storage.readSessionMessages(projectPath, 'sess-b');
+		expect(read.messages).toEqual([]);
+		expect(read.total).toBe(0);
+
+		const del = await storage.deleteMessagePair(projectPath, 'sess-b', 'm1');
+		expect(del.success).toBe(false);
+	});
+
+	it('matches a cwd differing only in casing on case-insensitive platforms', async () => {
+		const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+		Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
+		try {
+			// Transcript cwd differs from the requested project only in casing; on a
+			// case-insensitive platform (darwin) it must still be listed.
+			const casedCwd = path.join(tmpHome, 'code', 'PROJ');
+			await writeTranscript('-code-PROJ', 'a_sess-c.jsonl', fullTranscript(casedCwd, 'sess-c'));
+
+			const sessions = await storage.listSessions(projectPath); // projectPath ends in .../code/proj
+			expect(sessions.map((s) => s.sessionId)).toEqual(['sess-c']);
+		} finally {
+			if (originalPlatform) Object.defineProperty(process, 'platform', originalPlatform);
+		}
 	});
 });

--- a/src/main/agents/capabilities.ts
+++ b/src/main/agents/capabilities.ts
@@ -289,7 +289,7 @@ export const AGENT_CAPABILITIES: Record<string, AgentCapabilities> = {
 		supportsImageInput: true,
 		supportsImageInputOnResume: true,
 		supportsSlashCommands: false,
-		supportsSessionStorage: false,
+		supportsSessionStorage: true, // ~/.omp/agent/sessions/<cwd-slug>/*.jsonl (local; SSH is a follow-up)
 		supportsCostTracking: true,
 		supportsUsageStats: true,
 		supportsBatchMode: true,

--- a/src/main/process-manager/ProcessManager.ts
+++ b/src/main/process-manager/ProcessManager.ts
@@ -270,6 +270,13 @@ export class ProcessManager extends EventEmitter {
 		const process = this.processes.get(sessionId);
 		if (!process) return false;
 
+		// Mark the turn as user-interrupted BEFORE signalling. `interrupt()` (unlike
+		// `kill()`) leaves the process in the map, so its `close` still reaches
+		// ExitHandler - which coerces the null signal code to 0. Without this flag,
+		// an instant stop (no output yet) would look identical to a clean silent
+		// crash and trip the "exited without producing a response" guard.
+		process.interrupted = true;
+
 		try {
 			if (process.sdkController) {
 				// Server-backed (OpenCode SDK) process: abort the in-flight turn.

--- a/src/main/process-manager/handlers/ExitHandler.ts
+++ b/src/main/process-manager/handlers/ExitHandler.ts
@@ -226,6 +226,49 @@ export class ExitHandler {
 			}
 		}
 
+		// omp silent-exit hardening. Oh My Pi can exit cleanly (code 0) right after
+		// startup / TTSR-rule registration having emitted NO `agent_end`, no result,
+		// and no streamed text (observed: the main-turn process went silent while
+		// the paired tab-namer turn completed normally). Every branch above then
+		// no-ops - `detectErrorFromExit` returns null on code 0, and the streamed-
+		// text fallback has nothing to flush - so the tab clears its busy pill to an
+		// empty "done" state with no answer and no error, indistinguishable from
+		// success. That is the reported "started, never went busy, appeared done,
+		// no answer" turn. Surface a recoverable, non-auto-retrying `agent_crashed`
+		// (see NON_RETRYABLE_TYPES) so the turn visibly fails and the user can
+		// resend. Scoped to omp to avoid tripping legitimate empty helper turns of
+		// other agents. User stops are excluded: `kill()` removes the process before
+		// `close` (early return above), and `interrupt()` sets `interrupted`.
+		if (
+			toolType === 'omp' &&
+			isStreamJsonMode &&
+			!managedProcess.resultEmitted &&
+			!managedProcess.errorEmitted &&
+			!managedProcess.interrupted &&
+			!managedProcess.streamedText?.trim() &&
+			!sessionId.endsWith('-terminal') &&
+			!sessionId.includes('-synopsis-') &&
+			!sessionId.startsWith('tab-naming-')
+		) {
+			managedProcess.errorEmitted = true;
+			const agentError: AgentError = {
+				type: 'agent_crashed',
+				message:
+					'Oh My Pi exited without producing a response. The agent process ended early (for example right after startup) before sending any output. Please send your message again.',
+				recoverable: true,
+				agentId: toolType,
+				sessionId,
+				timestamp: Date.now(),
+				raw: { exitCode: code },
+			};
+			logger.warn(
+				'[ProcessManager] omp exited with no result, error, or output - surfacing recoverable error',
+				'ProcessManager',
+				{ sessionId, exitCode: code }
+			);
+			this.emitter.emit('agent-error', sessionId, agentError);
+		}
+
 		// Clean up temp image files if any
 		if (managedProcess.tempImageFiles && managedProcess.tempImageFiles.length > 0) {
 			cleanupTempFiles(managedProcess.tempImageFiles);

--- a/src/main/process-manager/handlers/ExitHandler.ts
+++ b/src/main/process-manager/handlers/ExitHandler.ts
@@ -258,6 +258,7 @@ export class ExitHandler {
 				recoverable: true,
 				agentId: toolType,
 				sessionId,
+				sshRemoteId: managedProcess.sshRemoteId,
 				timestamp: Date.now(),
 				raw: { exitCode: code },
 			};

--- a/src/main/process-manager/types.ts
+++ b/src/main/process-manager/types.ts
@@ -105,6 +105,12 @@ export interface ManagedProcess {
 	agentSessionId?: string;
 	resultEmitted?: boolean;
 	errorEmitted?: boolean;
+	/** Set by `ProcessManager.interrupt()` before it sends SIGINT (or writes
+	 *  Ctrl+C). Lets the exit path tell a user-initiated stop apart from a real
+	 *  silent crash: an interrupted turn that exits with a null signal code
+	 *  (coerced to 0 by the spawner's `close` handler) must NOT be surfaced as an
+	 *  "exited without producing a response" error. */
+	interrupted?: boolean;
 	startTime: number;
 	outputParser?: AgentOutputParser;
 	stderrBuffer?: string;

--- a/src/main/storage/index.ts
+++ b/src/main/storage/index.ts
@@ -10,6 +10,7 @@ export { OpenCodeSessionStorage } from './opencode-session-storage';
 export { CodexSessionStorage } from './codex-session-storage';
 export { FactoryDroidSessionStorage } from './factory-droid-session-storage';
 export { CopilotSessionStorage } from './copilot-session-storage';
+export { OmpSessionStorage } from './omp-session-storage';
 
 import Store from 'electron-store';
 import { registerSessionStorage } from '../agents';
@@ -18,6 +19,7 @@ import { OpenCodeSessionStorage } from './opencode-session-storage';
 import { CodexSessionStorage } from './codex-session-storage';
 import { FactoryDroidSessionStorage } from './factory-droid-session-storage';
 import { CopilotSessionStorage } from './copilot-session-storage';
+import { OmpSessionStorage } from './omp-session-storage';
 
 /**
  * Options for initializing session storages
@@ -39,4 +41,5 @@ export function initializeSessionStorages(options?: InitializeSessionStoragesOpt
 	registerSessionStorage(new CodexSessionStorage());
 	registerSessionStorage(new FactoryDroidSessionStorage());
 	registerSessionStorage(new CopilotSessionStorage());
+	registerSessionStorage(new OmpSessionStorage());
 }

--- a/src/main/storage/omp-session-storage.ts
+++ b/src/main/storage/omp-session-storage.ts
@@ -1,0 +1,501 @@
+/**
+ * Oh My Pi (omp) Session Storage Implementation
+ *
+ * Provides access to omp's local session transcripts so omp sessions appear in
+ * History and can be resumed / reconstructed on any Maestro frontend (desktop
+ * AND web-desktop), matching the parity every other storage-backed agent has.
+ *
+ * On-disk layout (all platforms - omp uses the dotfile convention):
+ *
+ *   ~/.omp/agent/sessions/<cwd-slug>/<ISO-timestamp>_<sessionId>.jsonl
+ *
+ * The `<cwd-slug>` directory name is omp-internal (roughly the cwd with the home
+ * prefix stripped and `/` replaced by `-`), so this storage never relies on
+ * reproducing that derivation for correctness: it uses the slug only as a fast
+ * path and always filters candidate sessions by the authoritative `cwd` carried
+ * in each transcript's `session` event. A slug-rule drift therefore degrades to
+ * a full scan, never to silently missing sessions.
+ *
+ * JSONL event vocabulary (one JSON object per line):
+ *   { type: 'title' | 'title_change', title }       - human-readable session name
+ *   { type: 'session', id, cwd, timestamp }         - session header (authoritative cwd)
+ *   { type: 'message', id, timestamp, message: {    - a conversation turn
+ *       role: 'user' | 'assistant' | 'toolResult',
+ *       content: string | ContentBlock[],           - text / thinking / tool blocks
+ *       usage?, model? } }                           - per-turn usage (assistant only)
+ *   { type: 'model_change' | 'thinking_level_change' | 'custom' | 'custom_message' } - ignored here
+ */
+
+import path from 'path';
+import os from 'os';
+import { promises as fs } from 'fs';
+import { logger } from '../utils/logger';
+import { captureException } from '../utils/sentry';
+import { BaseSessionStorage, type SearchableMessage } from './base-session-storage';
+import { ModelUsageAccumulator } from '../../shared/modelUsage';
+import type {
+	AgentSessionInfo,
+	SessionMessage,
+	SessionMessagesResult,
+	SessionReadOptions,
+} from '../agents/session-storage';
+import type { ToolType, SshRemoteConfig } from '../../shared/types';
+
+const LOG_CONTEXT = '[OmpSessionStorage]';
+
+/** Cap on how much of a single transcript we parse, guarding against a runaway file. */
+const MAX_SESSION_FILE_SIZE = 100 * 1024 * 1024; // 100 MB
+
+interface OmpContentBlock {
+	type: string;
+	text?: string;
+	thinking?: string;
+	[key: string]: unknown;
+}
+
+interface OmpUsage {
+	input?: number;
+	output?: number;
+	cacheRead?: number;
+	cacheWrite?: number;
+	cost?: number | { total?: number };
+}
+
+interface OmpRawMessage {
+	role?: string;
+	content?: OmpContentBlock[] | string;
+	usage?: OmpUsage;
+	model?: string;
+	timestamp?: string;
+}
+
+interface OmpEvent {
+	type?: string;
+	id?: string;
+	timestamp?: string;
+	cwd?: string;
+	title?: string;
+	message?: OmpRawMessage;
+}
+
+/** Fully parsed transcript: the session header, title, and ordered events. */
+interface OmpTranscript {
+	sessionId: string;
+	cwd: string | null;
+	createdAt: string | null;
+	title: string | null;
+	events: OmpEvent[];
+	filePath: string;
+}
+
+/** Extract the sessionId from a transcript filename: `<ISO-timestamp>_<sessionId>.jsonl`. */
+function extractSessionIdFromFilename(filename: string): string | null {
+	const base = filename.endsWith('.jsonl') ? filename.slice(0, -'.jsonl'.length) : filename;
+	const underscore = base.indexOf('_');
+	if (underscore < 0) return null;
+	const id = base.slice(underscore + 1);
+	return id.length > 0 ? id : null;
+}
+
+/** Join the `text` blocks of an omp message; thinking/tool blocks are excluded from content. */
+function extractText(content: OmpContentBlock[] | string | undefined): string {
+	if (typeof content === 'string') return content;
+	if (!Array.isArray(content)) return '';
+	return content
+		.filter((block) => block.type === 'text' && typeof block.text === 'string')
+		.map((block) => block.text || '')
+		.join('');
+}
+
+/** Pull the tool_use / tool_result blocks (if any) so the History renderer can show them. */
+function extractToolUse(content: OmpContentBlock[] | string | undefined): unknown {
+	if (!Array.isArray(content)) return undefined;
+	const toolBlocks = content.filter(
+		(block) => block.type === 'tool_use' || block.type === 'tool_result'
+	);
+	return toolBlocks.length > 0 ? toolBlocks : undefined;
+}
+
+/** Normalize an omp cost value (number or `{ total }`) to USD. */
+function normalizeCost(cost: OmpUsage['cost']): number {
+	if (typeof cost === 'number') return cost;
+	if (cost && typeof cost === 'object' && typeof cost.total === 'number') return cost.total;
+	return 0;
+}
+
+/**
+ * Oh My Pi Session Storage.
+ *
+ * Local transcripts only for v1: SSH-remote omp History is not yet wired and
+ * degrades to empty/no-op (never throws). This is a deliberate gap vs. storages
+ * that already implement remote list/read (e.g. Factory Droid) - tracked as a
+ * follow-up so remote omp History/resume returns nothing rather than erroring.
+ */
+export class OmpSessionStorage extends BaseSessionStorage {
+	readonly agentId: ToolType = 'omp';
+
+	private async parseTranscript(filePath: string): Promise<OmpTranscript | null> {
+		let raw: string;
+		try {
+			const stat = await fs.stat(filePath);
+			if (stat.size > MAX_SESSION_FILE_SIZE) {
+				logger.warn(`Skipping oversized omp transcript: ${filePath}`, LOG_CONTEXT, {
+					size: stat.size,
+				});
+				return null;
+			}
+			raw = await fs.readFile(filePath, 'utf-8');
+		} catch (error) {
+			logger.debug(`Failed to read omp transcript: ${filePath}`, LOG_CONTEXT, { error });
+			return null;
+		}
+
+		const events: OmpEvent[] = [];
+		let cwd: string | null = null;
+		let createdAt: string | null = null;
+		let title: string | null = null;
+		let sessionId: string | null = null;
+
+		for (const line of raw.split('\n')) {
+			const trimmed = line.trim();
+			if (!trimmed) continue;
+			let event: OmpEvent;
+			try {
+				event = JSON.parse(trimmed) as OmpEvent;
+			} catch {
+				continue;
+			}
+			events.push(event);
+
+			if (event.type === 'session') {
+				cwd = typeof event.cwd === 'string' ? event.cwd : cwd;
+				createdAt = typeof event.timestamp === 'string' ? event.timestamp : createdAt;
+				sessionId = typeof event.id === 'string' ? event.id : sessionId;
+			} else if (event.type === 'title' || event.type === 'title_change') {
+				if (typeof event.title === 'string' && event.title.trim()) title = event.title.trim();
+			}
+		}
+
+		if (!sessionId) sessionId = extractSessionIdFromFilename(path.basename(filePath));
+		if (!sessionId) return null;
+
+		return { sessionId, cwd, createdAt, title, events, filePath };
+	}
+
+	/**
+	 * Every omp transcript path across all session directories. Listing and
+	 * lookup then filter by the authoritative `cwd` (or sessionId) carried inside
+	 * each transcript, so correctness never depends on reproducing omp's internal
+	 * directory-slug scheme - a stale or unexpected slug dir can never hide a
+	 * matching session. Reads all directories per call; an mtime cache is a
+	 * follow-up if omp session volume grows (cf. Codex storage).
+	 */
+	private async collectTranscriptFiles(): Promise<string[]> {
+		// omp sessions root: ~/.omp/agent/sessions (dotfile convention on every platform).
+		const root = path.join(os.homedir(), '.omp', 'agent', 'sessions');
+
+		let subdirs: string[];
+		try {
+			const entries = await fs.readdir(root, { withFileTypes: true });
+			subdirs = entries.filter((e) => e.isDirectory()).map((e) => path.join(root, e.name));
+		} catch {
+			return [];
+		}
+
+		const perDir = await Promise.all(
+			subdirs.map(async (dir) => {
+				try {
+					const entries = await fs.readdir(dir);
+					return entries.filter((e) => e.endsWith('.jsonl')).map((e) => path.join(dir, e));
+				} catch {
+					return [];
+				}
+			})
+		);
+		return perDir.flat();
+	}
+
+	async listSessions(
+		projectPath: string,
+		sshConfig?: SshRemoteConfig
+	): Promise<AgentSessionInfo[]> {
+		if (sshConfig) {
+			logger.debug('omp History over SSH is not supported yet; returning no sessions', LOG_CONTEXT);
+			return [];
+		}
+
+		const target = path.resolve(projectPath);
+		const files = await this.collectTranscriptFiles();
+		const sessions: AgentSessionInfo[] = [];
+
+		for (const filePath of files) {
+			try {
+				const transcript = await this.parseTranscript(filePath);
+				if (!transcript || !transcript.cwd) continue;
+				// Authoritative filter: only sessions whose header cwd matches the project.
+				if (path.resolve(transcript.cwd) !== target) continue;
+
+				const stat = await fs.stat(filePath);
+				const info = this.buildSessionInfo(transcript, target, stat.size, stat.mtime);
+				sessions.push(info);
+			} catch (error) {
+				captureException(error, { operation: 'ompStorage:listSessions', filePath });
+				logger.warn(`Error reading omp session: ${filePath}`, LOG_CONTEXT, { error });
+			}
+		}
+
+		sessions.sort((a, b) => new Date(b.modifiedAt).getTime() - new Date(a.modifiedAt).getTime());
+		logger.info(`Found ${sessions.length} omp sessions for project: ${projectPath}`, LOG_CONTEXT);
+		return sessions;
+	}
+
+	private buildSessionInfo(
+		transcript: OmpTranscript,
+		projectPath: string,
+		sizeBytes: number,
+		mtime: Date
+	): AgentSessionInfo {
+		let firstMessage = '';
+		let messageCount = 0;
+		let inputTokens = 0;
+		let outputTokens = 0;
+		let cacheReadTokens = 0;
+		let cacheCreationTokens = 0;
+		let costUsd = 0;
+		let lastTimestamp: string | null = null;
+		const modelAcc = new ModelUsageAccumulator();
+
+		for (const event of transcript.events) {
+			if (event.type !== 'message' || !event.message) continue;
+			const role = event.message.role;
+			if (role !== 'user' && role !== 'assistant') continue;
+
+			messageCount++;
+			if (event.timestamp) lastTimestamp = event.timestamp;
+
+			if (!firstMessage && role === 'user') {
+				const text = extractText(event.message.content).trim();
+				// Skip the injected Maestro system-context turn so the preview shows
+				// the user's actual first request, not the boilerplate prompt.
+				if (text && !text.startsWith('# Maestro System Context')) {
+					firstMessage = text.slice(0, 200);
+				}
+			}
+
+			const usage = event.message.usage;
+			if (role === 'assistant' && usage) {
+				const input = usage.input || 0;
+				const output = usage.output || 0;
+				const cacheRead = usage.cacheRead || 0;
+				const cacheWrite = usage.cacheWrite || 0;
+				inputTokens += input;
+				outputTokens += output;
+				cacheReadTokens += cacheRead;
+				cacheCreationTokens += cacheWrite;
+				costUsd += normalizeCost(usage.cost);
+				if (input || output || cacheRead || cacheWrite) {
+					modelAcc.add(event.message.model, {
+						inputTokens: input,
+						outputTokens: output,
+						cacheReadTokens: cacheRead,
+						cacheCreationTokens: cacheWrite,
+					});
+				}
+			}
+		}
+
+		const createdAt = transcript.createdAt || mtime.toISOString();
+		const modifiedAt = lastTimestamp || mtime.toISOString();
+		const durationSeconds = lastTimestamp
+			? Math.max(
+					0,
+					Math.floor((new Date(modifiedAt).getTime() - new Date(createdAt).getTime()) / 1000)
+				)
+			: 0;
+
+		return {
+			sessionId: transcript.sessionId,
+			projectPath,
+			timestamp: createdAt,
+			modifiedAt,
+			firstMessage: firstMessage || transcript.title || 'Oh My Pi session',
+			messageCount,
+			sizeBytes,
+			costUsd: costUsd > 0 ? costUsd : undefined,
+			inputTokens,
+			outputTokens,
+			cacheReadTokens,
+			cacheCreationTokens,
+			byModel: modelAcc.isEmpty ? undefined : modelAcc.finalize(),
+			durationSeconds,
+			sessionName: transcript.title || undefined,
+		};
+	}
+
+	/** Resolve the on-disk transcript path for a sessionId (searches candidate dirs). */
+	private async findTranscriptPath(projectPath: string, sessionId: string): Promise<string | null> {
+		const files = await this.collectTranscriptFiles();
+		for (const filePath of files) {
+			if (extractSessionIdFromFilename(path.basename(filePath)) === sessionId) return filePath;
+		}
+		// Fall back to matching the session header id (filename scheme could differ).
+		for (const filePath of files) {
+			const transcript = await this.parseTranscript(filePath);
+			if (transcript?.sessionId === sessionId) return filePath;
+		}
+		return null;
+	}
+
+	async readSessionMessages(
+		projectPath: string,
+		sessionId: string,
+		options?: SessionReadOptions,
+		sshConfig?: SshRemoteConfig
+	): Promise<SessionMessagesResult> {
+		if (sshConfig) {
+			return { messages: [], total: 0, hasMore: false };
+		}
+
+		const filePath = await this.findTranscriptPath(projectPath, sessionId);
+		if (!filePath) return { messages: [], total: 0, hasMore: false };
+
+		const transcript = await this.parseTranscript(filePath);
+		if (!transcript) return { messages: [], total: 0, hasMore: false };
+
+		const messages: SessionMessage[] = [];
+		for (const event of transcript.events) {
+			if (event.type !== 'message' || !event.message) continue;
+			const role = event.message.role;
+			if (role !== 'user' && role !== 'assistant') continue;
+
+			const content = extractText(event.message.content);
+			const toolUse = extractToolUse(event.message.content);
+			if (!content && !toolUse) continue;
+
+			messages.push({
+				type: role,
+				role,
+				content,
+				timestamp: event.timestamp || transcript.createdAt || '',
+				uuid: event.id || `${transcript.sessionId}-${messages.length}`,
+				toolUse,
+			});
+		}
+
+		return BaseSessionStorage.applyMessagePagination(messages, options);
+	}
+
+	protected async getSearchableMessages(
+		sessionId: string,
+		projectPath: string,
+		sshConfig?: SshRemoteConfig
+	): Promise<SearchableMessage[]> {
+		if (sshConfig) return [];
+		const filePath = await this.findTranscriptPath(projectPath, sessionId);
+		if (!filePath) return [];
+		const transcript = await this.parseTranscript(filePath);
+		if (!transcript) return [];
+
+		const out: SearchableMessage[] = [];
+		for (const event of transcript.events) {
+			if (event.type !== 'message' || !event.message) continue;
+			const role = event.message.role;
+			if (role !== 'user' && role !== 'assistant') continue;
+			const textContent = extractText(event.message.content);
+			if (textContent.length > 0) out.push({ role, textContent });
+		}
+		return out;
+	}
+
+	getSessionPath(): string | null {
+		// omp transcripts are addressed by a timestamped filename, not a stable
+		// path derivable from sessionId alone (findTranscriptPath resolves it
+		// asynchronously). The sync accessor is best-effort null; History uses the
+		// async read/list paths above.
+		return null;
+	}
+
+	async deleteMessagePair(
+		projectPath: string,
+		sessionId: string,
+		userMessageUuid: string,
+		fallbackContent?: string,
+		sshConfig?: SshRemoteConfig
+	): Promise<{ success: boolean; error?: string; linesRemoved?: number }> {
+		if (sshConfig) {
+			return { success: false, error: 'Delete not supported for remote omp sessions' };
+		}
+
+		const filePath = await this.findTranscriptPath(projectPath, sessionId);
+		if (!filePath) return { success: false, error: 'Session not found' };
+
+		try {
+			const content = await fs.readFile(filePath, 'utf-8');
+			const lines = content.split('\n');
+			const newLines: string[] = [];
+			let linesRemoved = 0;
+			let foundUserMessage = false;
+			let skipUntilNextUser = false;
+
+			for (const line of lines) {
+				if (!line.trim()) {
+					newLines.push(line);
+					continue;
+				}
+				let parsed: OmpEvent;
+				try {
+					parsed = JSON.parse(line) as OmpEvent;
+				} catch {
+					newLines.push(line);
+					continue;
+				}
+
+				const isMessage = parsed.type === 'message' && !!parsed.message;
+				const role = parsed.message?.role;
+
+				if (!foundUserMessage && isMessage && role === 'user') {
+					const byUuid = parsed.id === userMessageUuid;
+					const byContent =
+						!!fallbackContent &&
+						extractText(parsed.message?.content).trim().toLowerCase() ===
+							fallbackContent.trim().toLowerCase();
+					if (byUuid || byContent) {
+						foundUserMessage = true;
+						skipUntilNextUser = true;
+						linesRemoved++;
+						continue;
+					}
+				}
+
+				if (skipUntilNextUser) {
+					// Stop skipping at the next user turn; everything between (assistant
+					// replies, tool results) belongs to the removed pair.
+					if (isMessage && role === 'user') {
+						skipUntilNextUser = false;
+						newLines.push(line);
+					} else {
+						linesRemoved++;
+					}
+				} else {
+					newLines.push(line);
+				}
+			}
+
+			if (!foundUserMessage) return { success: false, error: 'User message not found' };
+
+			await fs.writeFile(filePath, newLines.join('\n'), 'utf-8');
+			logger.info('Deleted message pair from omp session', LOG_CONTEXT, {
+				sessionId,
+				linesRemoved,
+			});
+			return { success: true, linesRemoved };
+		} catch (error) {
+			captureException(error, { operation: 'ompStorage:deleteMessagePair', sessionId });
+			logger.error('Error deleting message pair from omp session', LOG_CONTEXT, {
+				sessionId,
+				error,
+			});
+			return { success: false, error: String(error) };
+		}
+	}
+}

--- a/src/main/storage/omp-session-storage.ts
+++ b/src/main/storage/omp-session-storage.ts
@@ -40,11 +40,28 @@ import type {
 	SessionReadOptions,
 } from '../agents/session-storage';
 import type { ToolType, SshRemoteConfig } from '../../shared/types';
+import { isWindows, isMacOS } from '../../shared/platformDetection';
 
 const LOG_CONTEXT = '[OmpSessionStorage]';
 
 /** Cap on how much of a single transcript we parse, guarding against a runaway file. */
 const MAX_SESSION_FILE_SIZE = 100 * 1024 * 1024; // 100 MB
+
+/**
+ * True when two paths resolve to the same location, comparing case-insensitively
+ * on Windows and default macOS filesystems (both case-insensitive) so a cwd that
+ * differs only in casing - drive-letter casing is the classic example - is not
+ * wrongly treated as a different project. Kept as a shared helper so listSessions
+ * and findTranscriptPath scope by cwd in lockstep.
+ */
+function samePath(a: string, b: string): boolean {
+	const resolvedA = path.resolve(a);
+	const resolvedB = path.resolve(b);
+	if (isWindows() || isMacOS()) {
+		return resolvedA.toLowerCase() === resolvedB.toLowerCase();
+	}
+	return resolvedA === resolvedB;
+}
 
 interface OmpContentBlock {
 	type: string;
@@ -233,7 +250,7 @@ export class OmpSessionStorage extends BaseSessionStorage {
 				const transcript = await this.parseTranscript(filePath);
 				if (!transcript || !transcript.cwd) continue;
 				// Authoritative filter: only sessions whose header cwd matches the project.
-				if (path.resolve(transcript.cwd) !== target) continue;
+				if (!samePath(transcript.cwd, projectPath)) continue;
 
 				const stat = await fs.stat(filePath);
 				const info = this.buildSessionInfo(transcript, target, stat.size, stat.mtime);
@@ -332,16 +349,20 @@ export class OmpSessionStorage extends BaseSessionStorage {
 		};
 	}
 
-	/** Resolve the on-disk transcript path for a sessionId (searches candidate dirs). */
+	/**
+	 * Resolve the transcript path for a sessionId WITHIN a project. Parses each
+	 * candidate and requires BOTH the session id and the authoritative `cwd` to
+	 * match, so a same-id transcript belonging to another project is never
+	 * returned - read/delete stay project-scoped, matching listSessions().
+	 */
 	private async findTranscriptPath(projectPath: string, sessionId: string): Promise<string | null> {
 		const files = await this.collectTranscriptFiles();
 		for (const filePath of files) {
-			if (extractSessionIdFromFilename(path.basename(filePath)) === sessionId) return filePath;
-		}
-		// Fall back to matching the session header id (filename scheme could differ).
-		for (const filePath of files) {
 			const transcript = await this.parseTranscript(filePath);
-			if (transcript?.sessionId === sessionId) return filePath;
+			if (!transcript || !transcript.cwd) continue;
+			if (transcript.sessionId !== sessionId) continue;
+			if (!samePath(transcript.cwd, projectPath)) continue;
+			return filePath;
 		}
 		return null;
 	}
@@ -408,10 +429,16 @@ export class OmpSessionStorage extends BaseSessionStorage {
 	}
 
 	getSessionPath(): string | null {
-		// omp transcripts are addressed by a timestamped filename, not a stable
-		// path derivable from sessionId alone (findTranscriptPath resolves it
-		// asynchronously). The sync accessor is best-effort null; History uses the
-		// async read/list paths above.
+		// Deliberately null (a considered call, not an oversight): an omp transcript
+		// lives at a timestamped filename under a cwd-slug dir, so it is not
+		// derivable synchronously from a sessionId. This matches Codex's storage,
+		// which returns null here for the same reason and resolves paths via an
+		// async search instead. A synchronous directory scan would be an O(n^2)
+		// blocking footgun in the agentSessions.ts loop callers. Consequence, same
+		// as Codex: the starred-transcript mirror cannot snapshot an omp session
+		// and getSessionPath-based name backfill skips omp - omp History itself is
+		// unaffected (served by listSessions/readSessionMessages). Tracked as a
+		// follow-up (a list/read-warmed path cache would enable starred snapshots).
 		return null;
 	}
 


### PR DESCRIPTION
## Summary

Two related omp reliability fixes surfaced while diagnosing the recurring
"OMP session started from web-desktop, never went busy, appeared done, no
answer" report.

### 1. `fix(omp)`: recoverable error when a turn exits with no output

An omp turn can exit cleanly (code 0) right after startup / TTSR-rule
registration having emitted **no `agent_end`, no result, and no streamed
text**. Every existing exit branch then no-ops:

- `detectErrorFromExit` returns `null` on code 0, and
- the streamed-text exit fallback has nothing to flush,

so the tab clears its busy pill to an empty "done" state - **no answer and no
error**, indistinguishable from success. That is the reported turn.

`ExitHandler` now emits a recoverable, **non-auto-retrying** `agent_crashed`
error in that exact case, so the turn visibly fails and the user can resend.

- Scoped to `omp` to avoid tripping legitimate empty helper turns of other agents.
- User stops are excluded: `kill()` removes the process before `close`, and
  `interrupt()` now sets a new `ManagedProcess.interrupted` flag the guard
  checks (SIGINT `close` codes are coerced to `0`, so without the flag an
  instant Stop would masquerade as a crash).
- `agent_crashed` is in `NON_RETRYABLE_TYPES`, so this shows a clear error with
  manual resend rather than an auto-retry loop.

### 2. `feat(omp)`: register `OmpSessionStorage` for History/resume parity

omp had **no registered session storage**, so omp `.jsonl` transcripts under
`~/.omp/agent/sessions` were invisible to History/resume and the peer-frontend
transcript reconstruction path (`agentSessions.read('omp', ...)`) returned
empty, unlike every other storage-backed agent. That is why omp AI-tab
transcripts did not self-heal / sync across frontends (e.g. web-desktop after a
reload).

`OmpSessionStorage` (extends `BaseSessionStorage`) is added, registered, and
omp's `supportsSessionStorage` capability is flipped on. Listing scans every
session directory and filters by the **authoritative `cwd`** carried in each
transcript's `session` event, so it never depends on reproducing omp's internal
directory-slug scheme (a stale or unexpected slug dir can't hide a match).
Usage, cost, per-model split, title, and a system-context-skipping first-message
preview are recovered from the JSONL.

**Known v1 limitation:** local transcripts only; SSH-remote omp History degrades
to empty (no throw). Remote list/read (as Factory Droid does) is a documented
follow-up.

## Testing

- `ExitHandler.test.ts`: +6 cases (fire / interrupted / streamed-text present /
  non-omp / synopsis+tab-naming / no-double-report). Full ExitHandler suite: 24 passed.
- `omp-session-storage.test.ts`: +6 cases over **real temp fixtures** (no reliance
  on a developer's `~/.omp`): listing + metadata/usage, cwd filtering,
  cross-directory scan, message extraction (skips thinking/toolResult),
  delete-message-pair, SSH degradation.
- Full `process-manager` suite: 283 passed. ESLint clean on all touched files.
- `tsc -p tsconfig.main.json`: my changes add **zero** new type errors (verified
  by stash comparison against clean `rc`). The 5 pre-existing
  `@opencode-ai/sdk` moduleResolution errors in `src/main/opencode-server/*`
  are present on unmodified `rc` in a bare local worktree and are unrelated to
  this PR (resolved under CI's dependency install).

## Not included (scoping)

- **TTSR rule interrupts misclassified as session errors** - already merged via
  #1210; nothing to do here.
- **Agent-agnostic live session/transcript sync + stale-client `sessions:setMany`
  clobber** - a separate, load-bearing cross-renderer change whose root cause
  was not fully confirmed (needs the web-desktop console diagnostics from the
  prior investigation). Deliberately excluded to keep this PR focused and
  reviewable; happy to open a dedicated PR once the source is confirmed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added local Oh My Pi (omp) session history support, including listing sessions, reading messages, searching text, and deleting message pairs from transcripts.
  * Enabled omp sessions storage support for session history.
* **Bug Fixes**
  * Hardened omp “silent exit” handling to surface a recoverable crash error when no output/result is produced.
  * Properly treats user interruptions as non-crash stops and avoids duplicate/false error reporting.
* **Tests**
  * Extended exit-handling and omp session storage coverage for scoping, cwd matching, and remote/ssh scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->