### PR TITLE
perf(session): peel App session subscriptions so streaming skips the console shell

### DIFF
--- a/src/__tests__/renderer/components/MainPanel.test.tsx
+++ b/src/__tests__/renderer/components/MainPanel.test.tsx
@@ -494,6 +494,26 @@ describe('MainPanel', () => {
 		onNewTab: vi.fn(),
 	};
 
+	function seedSessionStore(session: Session | null | undefined) {
+		useSessionStore.setState({
+			sessions: session ? [session] : [],
+			activeSessionId: session?.id ?? '',
+		} as never);
+	}
+
+	function renderMainPanel(overrides: Partial<typeof defaultProps> = {}) {
+		const props = { ...defaultProps, ...overrides };
+		const session = props.activeSession as Session | null | undefined;
+		seedSessionStore(session);
+		const result = render(<MainPanel {...(props as any)} />);
+		const rerenderMainPanel = (nextOverrides: Partial<typeof defaultProps> = {}) => {
+			const nextProps = { ...defaultProps, ...nextOverrides };
+			seedSessionStore(nextProps.activeSession as Session | null | undefined);
+			result.rerender(<MainPanel {...(nextProps as any)} />);
+		};
+		return { ...result, rerender: rerenderMainPanel };
+	}
+
 	beforeEach(() => {
 		vi.clearAllMocks();
 		vi.useFakeTimers({ shouldAdvanceTime: true });
@@ -569,7 +589,7 @@ describe('MainPanel', () => {
 
 	describe('Render conditions', () => {
 		it('should render LogViewer when logViewerOpen is true', () => {
-			render(<MainPanel {...defaultProps} logViewerOpen={true} />);
+			renderMainPanel({ logViewerOpen: true });
 
 			expect(screen.getByTestId('log-viewer')).toBeInTheDocument();
 			expect(screen.queryByTestId('terminal-output')).not.toBeInTheDocument();
@@ -577,9 +597,7 @@ describe('MainPanel', () => {
 
 		it('should close LogViewer and call setLogViewerOpen when close button is clicked', () => {
 			const setLogViewerOpen = vi.fn();
-			render(
-				<MainPanel {...defaultProps} logViewerOpen={true} setLogViewerOpen={setLogViewerOpen} />
-			);
+			renderMainPanel({ logViewerOpen: true, setLogViewerOpen: setLogViewerOpen });
 
 			fireEvent.click(screen.getByTestId('log-viewer-close'));
 
@@ -587,7 +605,7 @@ describe('MainPanel', () => {
 		});
 
 		it('should render AgentSessionsBrowser when agentSessionsOpen is true', () => {
-			render(<MainPanel {...defaultProps} agentSessionsOpen={true} />);
+			renderMainPanel({ agentSessionsOpen: true });
 
 			expect(screen.getByTestId('agent-sessions-browser')).toBeInTheDocument();
 			expect(screen.queryByTestId('terminal-output')).not.toBeInTheDocument();
@@ -595,13 +613,7 @@ describe('MainPanel', () => {
 
 		it('should close AgentSessionsBrowser when close button is clicked', () => {
 			const setAgentSessionsOpen = vi.fn();
-			render(
-				<MainPanel
-					{...defaultProps}
-					agentSessionsOpen={true}
-					setAgentSessionsOpen={setAgentSessionsOpen}
-				/>
-			);
+			renderMainPanel({ agentSessionsOpen: true, setAgentSessionsOpen: setAgentSessionsOpen });
 
 			fireEvent.click(screen.getByTestId('agent-sessions-close'));
 
@@ -609,14 +621,14 @@ describe('MainPanel', () => {
 		});
 
 		it('should render empty state when no activeSession', () => {
-			render(<MainPanel {...defaultProps} activeSession={null} />);
+			renderMainPanel({ activeSession: null });
 
 			expect(screen.getByText('No agents. Create one to get started.')).toBeInTheDocument();
 			expect(screen.queryByTestId('terminal-output')).not.toBeInTheDocument();
 		});
 
 		it('should render normal session view with terminal output and input area', () => {
-			render(<MainPanel {...defaultProps} />);
+			renderMainPanel();
 
 			expect(screen.getByTestId('terminal-output')).toBeInTheDocument();
 			expect(screen.getByTestId('input-area')).toBeInTheDocument();
@@ -637,6 +649,7 @@ describe('MainPanel', () => {
 				makeWindowState({ id: 'win-2', sessionIds: [], activeSessionId: null })
 			);
 
+			seedSessionStore(defaultProps.activeSession as Session);
 			render(
 				<WindowProvider>
 					<MainPanel {...defaultProps} />
@@ -656,6 +669,7 @@ describe('MainPanel', () => {
 			);
 			vi.mocked(window.maestro.windows.list).mockResolvedValue([]);
 
+			seedSessionStore(defaultProps.activeSession as Session);
 			render(
 				<WindowProvider>
 					<MainPanel {...defaultProps} />
@@ -670,21 +684,21 @@ describe('MainPanel', () => {
 	describe('Header display', () => {
 		it('should display session name in header', () => {
 			const session = createSession({ name: 'My Test Session' });
-			render(<MainPanel {...defaultProps} activeSession={session} />);
+			renderMainPanel({ activeSession: session });
 
 			expect(screen.getByText('My Test Session')).toBeInTheDocument();
 		});
 
 		it('should display LOCAL badge for non-git repos', () => {
 			const session = createSession({ isGitRepo: false });
-			render(<MainPanel {...defaultProps} activeSession={session} />);
+			renderMainPanel({ activeSession: session });
 
 			expect(screen.getByText('LOCAL')).toBeInTheDocument();
 		});
 
 		it('should display GIT badge with branch name for git repos', async () => {
 			const session = createSession({ isGitRepo: true });
-			render(<MainPanel {...defaultProps} activeSession={session} />);
+			renderMainPanel({ activeSession: session });
 
 			await waitFor(() => {
 				// Should show GIT initially, then branch name after info loads
@@ -693,7 +707,7 @@ describe('MainPanel', () => {
 		});
 
 		it('should hide header in mobile landscape mode', () => {
-			render(<MainPanel {...defaultProps} isMobileLandscape={true} />);
+			renderMainPanel({ isMobileLandscape: true });
 
 			// Header should not be visible
 			expect(screen.queryByText('Test Session')).not.toBeInTheDocument();
@@ -701,20 +715,20 @@ describe('MainPanel', () => {
 
 		it('should show bookmark indicator when session is bookmarked', () => {
 			const session = createSession({ bookmarked: true });
-			render(<MainPanel {...defaultProps} activeSession={session} />);
+			renderMainPanel({ activeSession: session });
 
 			expect(screen.getByTestId('bookmark-icon')).toBeInTheDocument();
 		});
 
 		it('should not show bookmark indicator when session is not bookmarked', () => {
 			const session = createSession({ bookmarked: false });
-			render(<MainPanel {...defaultProps} activeSession={session} />);
+			renderMainPanel({ activeSession: session });
 
 			expect(screen.queryByTestId('bookmark-icon')).not.toBeInTheDocument();
 		});
 
 		it('should show Agent Sessions button in header', () => {
-			render(<MainPanel {...defaultProps} />);
+			renderMainPanel();
 
 			const agentSessionsBtn = screen.getByTitle(/Agent Sessions/);
 			expect(agentSessionsBtn).toBeInTheDocument();
@@ -723,13 +737,10 @@ describe('MainPanel', () => {
 		it('should open Agent Sessions when button is clicked', () => {
 			const setAgentSessionsOpen = vi.fn();
 			const setActiveAgentSessionId = vi.fn();
-			render(
-				<MainPanel
-					{...defaultProps}
-					setAgentSessionsOpen={setAgentSessionsOpen}
-					setActiveAgentSessionId={setActiveAgentSessionId}
-				/>
-			);
+			renderMainPanel({
+				setAgentSessionsOpen: setAgentSessionsOpen,
+				setActiveAgentSessionId: setActiveAgentSessionId,
+			});
 
 			fireEvent.click(screen.getByTitle(/Agent Sessions/));
 
@@ -759,7 +770,7 @@ describe('MainPanel', () => {
 				supportsStreamJsonInput: true,
 			});
 
-			render(<MainPanel {...defaultProps} />);
+			renderMainPanel();
 
 			// Agent Sessions button should not be present
 			expect(screen.queryByTitle(/Agent Sessions/)).not.toBeInTheDocument();
@@ -787,7 +798,7 @@ describe('MainPanel', () => {
 				supportsStreamJsonInput: true,
 			});
 
-			render(<MainPanel {...defaultProps} agentSessionsOpen={true} />);
+			renderMainPanel({ agentSessionsOpen: true });
 
 			// AgentSessionsBrowser should not be shown even with agentSessionsOpen=true
 			expect(screen.queryByTestId('agent-sessions-browser')).not.toBeInTheDocument();
@@ -799,21 +810,21 @@ describe('MainPanel', () => {
 	describe('Right panel toggle', () => {
 		it('should show toggle button when rightPanelOpen is false', () => {
 			useUIStore.setState({ rightPanelOpen: false });
-			render(<MainPanel {...defaultProps} />);
+			renderMainPanel();
 
 			expect(screen.getByTitle(/Show right panel/)).toBeInTheDocument();
 		});
 
 		it('should hide toggle button when rightPanelOpen is true', () => {
 			useUIStore.setState({ rightPanelOpen: true });
-			render(<MainPanel {...defaultProps} />);
+			renderMainPanel();
 
 			expect(screen.queryByTitle(/Show right panel/)).not.toBeInTheDocument();
 		});
 
 		it('should call setRightPanelOpen when toggle button is clicked', () => {
 			useUIStore.setState({ rightPanelOpen: false });
-			render(<MainPanel {...defaultProps} />);
+			renderMainPanel();
 
 			fireEvent.click(screen.getByTitle(/Show right panel/));
 
@@ -840,9 +851,7 @@ describe('MainPanel', () => {
 
 		it('should render FilePreview when activeFileTab is set', async () => {
 			const activeFileTab = createFileTab();
-			render(
-				<MainPanel {...defaultProps} activeFileTabId="file-tab-1" activeFileTab={activeFileTab} />
-			);
+			renderMainPanel({ activeFileTabId: 'file-tab-1', activeFileTab: activeFileTab });
 
 			// FilePreview is React.lazy-loaded behind Suspense, so it mounts on a
 			// microtask rather than synchronously - await it the first time.
@@ -852,9 +861,7 @@ describe('MainPanel', () => {
 
 		it('should show TabBar when file preview tab is active (tabs remain visible)', () => {
 			const activeFileTab = createFileTab();
-			render(
-				<MainPanel {...defaultProps} activeFileTabId="file-tab-1" activeFileTab={activeFileTab} />
-			);
+			renderMainPanel({ activeFileTabId: 'file-tab-1', activeFileTab: activeFileTab });
 
 			// In the new tab system, TabBar remains visible when file tab is active
 			expect(screen.getByTestId('tab-bar')).toBeInTheDocument();
@@ -864,14 +871,11 @@ describe('MainPanel', () => {
 			const onFileTabClose = vi.fn();
 			const activeFileTab = createFileTab();
 
-			render(
-				<MainPanel
-					{...defaultProps}
-					activeFileTabId="file-tab-1"
-					activeFileTab={activeFileTab}
-					onFileTabClose={onFileTabClose}
-				/>
-			);
+			renderMainPanel({
+				activeFileTabId: 'file-tab-1',
+				activeFileTab: activeFileTab,
+				onFileTabClose: onFileTabClose,
+			});
 
 			fireEvent.click(screen.getByTestId('file-preview-close'));
 
@@ -889,7 +893,7 @@ describe('MainPanel', () => {
 				],
 			});
 
-			render(<MainPanel {...defaultProps} activeSession={session} />);
+			renderMainPanel({ activeSession: session });
 
 			expect(screen.getByTestId('tab-bar')).toBeInTheDocument();
 			expect(screen.getByTestId('tab-tab-1')).toBeInTheDocument();
@@ -899,7 +903,7 @@ describe('MainPanel', () => {
 		it('should render TabBar in terminal mode (unified tab system shows tabs in all modes)', () => {
 			const session = createSession({ inputMode: 'terminal' });
 
-			render(<MainPanel {...defaultProps} activeSession={session} />);
+			renderMainPanel({ activeSession: session });
 
 			// TabBar renders in both AI and terminal modes when aiTabs exist
 			expect(screen.queryByTestId('tab-bar')).toBeInTheDocument();
@@ -914,7 +918,7 @@ describe('MainPanel', () => {
 				],
 			});
 
-			render(<MainPanel {...defaultProps} activeSession={session} onTabSelect={onTabSelect} />);
+			renderMainPanel({ activeSession: session, onTabSelect: onTabSelect });
 
 			fireEvent.click(screen.getByTestId('tab-tab-2'));
 
@@ -925,7 +929,7 @@ describe('MainPanel', () => {
 			const onNewTab = vi.fn();
 			const session = createSession();
 
-			render(<MainPanel {...defaultProps} activeSession={session} onNewTab={onNewTab} />);
+			renderMainPanel({ activeSession: session, onNewTab: onNewTab });
 
 			fireEvent.click(screen.getByTestId('new-tab-btn'));
 
@@ -949,7 +953,7 @@ describe('MainPanel', () => {
 				activeTabId: 'tab-1',
 			});
 
-			render(<MainPanel {...defaultProps} activeSession={session} />);
+			renderMainPanel({ activeSession: session });
 
 			// Should show truncated UUID (first segment in uppercase)
 			expect(screen.getByText('ABC12345')).toBeInTheDocument();
@@ -973,7 +977,7 @@ describe('MainPanel', () => {
 				activeTabId: 'tab-1',
 			});
 
-			render(<MainPanel {...defaultProps} activeSession={session} />);
+			renderMainPanel({ activeSession: session });
 
 			fireEvent.click(screen.getByText('ABC12345'));
 
@@ -994,7 +998,7 @@ describe('MainPanel', () => {
 				],
 			});
 
-			render(<MainPanel {...defaultProps} activeSession={session} />);
+			renderMainPanel({ activeSession: session });
 
 			expect(screen.queryByText('ABC12345')).not.toBeInTheDocument();
 		});
@@ -1019,7 +1023,7 @@ describe('MainPanel', () => {
 				activeTabId: 'tab-1',
 			});
 
-			render(<MainPanel {...defaultProps} activeSession={session} />);
+			renderMainPanel({ activeSession: session });
 
 			expect(screen.queryByText('ABC12345')).not.toBeInTheDocument();
 		});
@@ -1060,7 +1064,7 @@ describe('MainPanel', () => {
 				activeTabId: 'tab-1',
 			});
 
-			render(<MainPanel {...defaultProps} activeSession={session} />);
+			renderMainPanel({ activeSession: session });
 
 			// Should NOT show the UUID pill when agent doesn't support session ID
 			expect(screen.queryByText('ABC12345')).not.toBeInTheDocument();
@@ -1104,7 +1108,7 @@ describe('MainPanel', () => {
 				activeTabId: 'tab-1',
 			});
 
-			render(<MainPanel {...defaultProps} activeSession={session} />);
+			renderMainPanel({ activeSession: session });
 
 			// Cost is displayed with fixed 2 decimals, look for the cost pattern
 			const costElements = screen.getAllByText(/\$0\.\d+/);
@@ -1119,7 +1123,7 @@ describe('MainPanel', () => {
 		it('should not display cost tracker in terminal mode', () => {
 			const session = createSession({ inputMode: 'terminal' });
 
-			render(<MainPanel {...defaultProps} activeSession={session} />);
+			renderMainPanel({ activeSession: session });
 
 			expect(screen.queryByText(/\$\d+\.\d+/)).not.toBeInTheDocument();
 		});
@@ -1178,7 +1182,7 @@ describe('MainPanel', () => {
 				activeTabId: 'tab-1',
 			});
 
-			render(<MainPanel {...defaultProps} activeSession={session} />);
+			renderMainPanel({ activeSession: session });
 
 			// Cost tracker should not be present even though panel is wide enough and we have usage stats
 			expect(screen.queryByText(/\$0\.15/)).not.toBeInTheDocument();
@@ -1192,7 +1196,7 @@ describe('MainPanel', () => {
 
 	describe('Context window widget', () => {
 		it('should display context window widget in AI mode', () => {
-			render(<MainPanel {...defaultProps} />);
+			renderMainPanel();
 
 			// Widget now shows a plain "X%" readout instead of a labeled gauge bar.
 			expect(screen.getByTestId('header-context-widget')).toBeInTheDocument();
@@ -1201,7 +1205,7 @@ describe('MainPanel', () => {
 		it('should not display context window in terminal mode', () => {
 			const session = createSession({ inputMode: 'terminal' });
 
-			render(<MainPanel {...defaultProps} activeSession={session} />);
+			renderMainPanel({ activeSession: session });
 
 			expect(screen.queryByTestId('header-context-widget')).not.toBeInTheDocument();
 		});
@@ -1228,7 +1232,7 @@ describe('MainPanel', () => {
 				supportsStreamJsonInput: true,
 			});
 
-			render(<MainPanel {...defaultProps} />);
+			renderMainPanel();
 
 			expect(screen.queryByTestId('header-context-widget')).not.toBeInTheDocument();
 		});
@@ -1256,7 +1260,7 @@ describe('MainPanel', () => {
 				sessionIds: [],
 			};
 
-			render(<MainPanel {...defaultProps} currentSessionBatchState={currentSessionBatchState} />);
+			renderMainPanel({ currentSessionBatchState: currentSessionBatchState });
 
 			expect(screen.getByText('Auto')).toBeInTheDocument();
 			expect(screen.getByText('2/5')).toBeInTheDocument();
@@ -1283,7 +1287,7 @@ describe('MainPanel', () => {
 				sessionIds: [],
 			};
 
-			render(<MainPanel {...defaultProps} currentSessionBatchState={currentSessionBatchState} />);
+			renderMainPanel({ currentSessionBatchState: currentSessionBatchState });
 
 			expect(screen.getByText('Stopping')).toBeInTheDocument();
 		});
@@ -1311,14 +1315,11 @@ describe('MainPanel', () => {
 				sessionIds: [],
 			};
 
-			render(
-				<MainPanel
-					{...defaultProps}
-					activeSession={session}
-					currentSessionBatchState={currentSessionBatchState}
-					onStopBatchRun={onStopBatchRun}
-				/>
-			);
+			renderMainPanel({
+				activeSession: session,
+				currentSessionBatchState: currentSessionBatchState,
+				onStopBatchRun: onStopBatchRun,
+			});
 
 			fireEvent.click(screen.getByText('Auto'));
 
@@ -1348,13 +1349,10 @@ describe('MainPanel', () => {
 				sessionIds: [],
 			};
 
-			render(
-				<MainPanel
-					{...defaultProps}
-					currentSessionBatchState={currentSessionBatchState}
-					onStopBatchRun={onStopBatchRun}
-				/>
-			);
+			renderMainPanel({
+				currentSessionBatchState: currentSessionBatchState,
+				onStopBatchRun: onStopBatchRun,
+			});
 
 			fireEvent.click(screen.getByText('Stopping'));
 
@@ -1362,14 +1360,14 @@ describe('MainPanel', () => {
 		});
 
 		it('should not display Auto mode button when currentSessionBatchState is null', () => {
-			render(<MainPanel {...defaultProps} currentSessionBatchState={null} />);
+			renderMainPanel({ currentSessionBatchState: null });
 
 			expect(screen.queryByText('Auto')).not.toBeInTheDocument();
 			expect(screen.queryByText('Stopping')).not.toBeInTheDocument();
 		});
 
 		it('should not display Auto mode button when currentSessionBatchState is undefined', () => {
-			render(<MainPanel {...defaultProps} currentSessionBatchState={undefined} />);
+			renderMainPanel({ currentSessionBatchState: undefined });
 
 			expect(screen.queryByText('Auto')).not.toBeInTheDocument();
 		});
@@ -1395,7 +1393,7 @@ describe('MainPanel', () => {
 				sessionIds: [],
 			};
 
-			render(<MainPanel {...defaultProps} currentSessionBatchState={currentSessionBatchState} />);
+			renderMainPanel({ currentSessionBatchState: currentSessionBatchState });
 
 			expect(screen.queryByText('Auto')).not.toBeInTheDocument();
 		});
@@ -1422,7 +1420,7 @@ describe('MainPanel', () => {
 				sessionIds: [],
 			};
 
-			render(<MainPanel {...defaultProps} currentSessionBatchState={currentSessionBatchState} />);
+			renderMainPanel({ currentSessionBatchState: currentSessionBatchState });
 
 			expect(screen.getByText('Auto')).toBeInTheDocument();
 			// Check for worktree title tooltip
@@ -1452,7 +1450,7 @@ describe('MainPanel', () => {
 				sessionIds: [],
 			};
 
-			render(<MainPanel {...defaultProps} currentSessionBatchState={currentSessionBatchState} />);
+			renderMainPanel({ currentSessionBatchState: currentSessionBatchState });
 
 			// Check for default worktree title tooltip
 			const worktreeIcon = screen.getByTitle('Worktree: active');
@@ -1480,7 +1478,7 @@ describe('MainPanel', () => {
 				sessionIds: [],
 			};
 
-			render(<MainPanel {...defaultProps} currentSessionBatchState={currentSessionBatchState} />);
+			renderMainPanel({ currentSessionBatchState: currentSessionBatchState });
 
 			expect(screen.getByText('Auto')).toBeInTheDocument();
 			expect(screen.queryByTitle(/Worktree:/)).not.toBeInTheDocument();
@@ -1507,7 +1505,7 @@ describe('MainPanel', () => {
 				sessionIds: [],
 			};
 
-			render(<MainPanel {...defaultProps} currentSessionBatchState={currentSessionBatchState} />);
+			renderMainPanel({ currentSessionBatchState: currentSessionBatchState });
 
 			const button = screen.getByText('Stopping').closest('button');
 			expect(button).toBeDisabled();
@@ -1534,7 +1532,7 @@ describe('MainPanel', () => {
 				sessionIds: [],
 			};
 
-			render(<MainPanel {...defaultProps} currentSessionBatchState={currentSessionBatchState} />);
+			renderMainPanel({ currentSessionBatchState: currentSessionBatchState });
 
 			const button = screen.getByText('Auto').closest('button');
 			expect(button).not.toBeDisabled();
@@ -1561,7 +1559,7 @@ describe('MainPanel', () => {
 				sessionIds: [],
 			};
 
-			render(<MainPanel {...defaultProps} currentSessionBatchState={currentSessionBatchState} />);
+			renderMainPanel({ currentSessionBatchState: currentSessionBatchState });
 
 			const button = screen.getByText('Auto').closest('button');
 			expect(button).toHaveAttribute('title', 'Click to stop auto-run');
@@ -1588,7 +1586,7 @@ describe('MainPanel', () => {
 				sessionIds: [],
 			};
 
-			render(<MainPanel {...defaultProps} currentSessionBatchState={currentSessionBatchState} />);
+			renderMainPanel({ currentSessionBatchState: currentSessionBatchState });
 
 			const button = screen.getByText('Stopping').closest('button');
 			expect(button).toHaveAttribute('title', 'Stopping after current task...');
@@ -1615,7 +1613,7 @@ describe('MainPanel', () => {
 				sessionIds: [],
 			};
 
-			render(<MainPanel {...defaultProps} currentSessionBatchState={currentSessionBatchState} />);
+			renderMainPanel({ currentSessionBatchState: currentSessionBatchState });
 
 			expect(screen.getByText('Auto')).toBeInTheDocument();
 			expect(screen.getByText('0/10')).toBeInTheDocument();
@@ -1642,7 +1640,7 @@ describe('MainPanel', () => {
 				sessionIds: [],
 			};
 
-			render(<MainPanel {...defaultProps} currentSessionBatchState={currentSessionBatchState} />);
+			renderMainPanel({ currentSessionBatchState: currentSessionBatchState });
 
 			expect(screen.getByText('Auto')).toBeInTheDocument();
 			expect(screen.getByText('8/8')).toBeInTheDocument();
@@ -1669,7 +1667,7 @@ describe('MainPanel', () => {
 				sessionIds: [],
 			};
 
-			render(<MainPanel {...defaultProps} currentSessionBatchState={currentSessionBatchState} />);
+			renderMainPanel({ currentSessionBatchState: currentSessionBatchState });
 
 			const button = screen.getByText('Auto').closest('button');
 			expect(button).toHaveStyle({ backgroundColor: theme.colors.error });
@@ -1696,7 +1694,7 @@ describe('MainPanel', () => {
 				sessionIds: [],
 			};
 
-			render(<MainPanel {...defaultProps} currentSessionBatchState={currentSessionBatchState} />);
+			renderMainPanel({ currentSessionBatchState: currentSessionBatchState });
 
 			const button = screen.getByText('Stopping').closest('button');
 			expect(button).toHaveClass('cursor-not-allowed');
@@ -1723,7 +1721,7 @@ describe('MainPanel', () => {
 				sessionIds: [],
 			};
 
-			render(<MainPanel {...defaultProps} currentSessionBatchState={currentSessionBatchState} />);
+			renderMainPanel({ currentSessionBatchState: currentSessionBatchState });
 
 			const button = screen.getByText('Auto').closest('button');
 			expect(button).toHaveClass('cursor-pointer');
@@ -1750,7 +1748,7 @@ describe('MainPanel', () => {
 				sessionIds: [],
 			};
 
-			render(<MainPanel {...defaultProps} currentSessionBatchState={currentSessionBatchState} />);
+			renderMainPanel({ currentSessionBatchState: currentSessionBatchState });
 
 			// The text should have uppercase class applied
 			const autoText = screen.getByText('Auto');
@@ -1779,13 +1777,10 @@ describe('MainPanel', () => {
 			};
 
 			// Render without onStopBatchRun callback
-			render(
-				<MainPanel
-					{...defaultProps}
-					currentSessionBatchState={currentSessionBatchState}
-					onStopBatchRun={undefined}
-				/>
-			);
+			renderMainPanel({
+				currentSessionBatchState: currentSessionBatchState,
+				onStopBatchRun: undefined,
+			});
 
 			// Click should not throw
 			expect(() => fireEvent.click(screen.getByText('Auto'))).not.toThrow();
@@ -1795,7 +1790,7 @@ describe('MainPanel', () => {
 	describe('Git tooltip', () => {
 		it('should show git tooltip on hover for git repos', async () => {
 			const session = createSession({ isGitRepo: true });
-			render(<MainPanel {...defaultProps} activeSession={session} />);
+			renderMainPanel({ activeSession: session });
 
 			await waitFor(() => {
 				expect(screen.getByText(/main|GIT/)).toBeInTheDocument();
@@ -1816,7 +1811,7 @@ describe('MainPanel', () => {
 			Object.assign(navigator, { clipboard: { writeText } });
 
 			const session = createSession({ isGitRepo: true });
-			render(<MainPanel {...defaultProps} activeSession={session} />);
+			renderMainPanel({ activeSession: session });
 
 			await waitFor(() => {
 				expect(screen.getByText(/main|GIT/)).toBeInTheDocument();
@@ -1851,7 +1846,7 @@ describe('MainPanel', () => {
 			});
 			vi.mocked(window.maestro.sshRemote.getConfigs).mockImplementation(mockGetConfigs);
 
-			render(<MainPanel {...defaultProps} activeSession={session} setGitLogOpen={setGitLogOpen} />);
+			renderMainPanel({ activeSession: session, setGitLogOpen: setGitLogOpen });
 
 			await waitFor(() => {
 				expect(screen.getByText('my-ssh-remote')).toBeInTheDocument();
@@ -1868,7 +1863,7 @@ describe('MainPanel', () => {
 				sessionSshRemoteConfig: { enabled: true, remoteId: 'ssh-remote-123' },
 			});
 
-			render(<MainPanel {...defaultProps} activeSession={session} />);
+			renderMainPanel({ activeSession: session });
 
 			fireEvent.click(screen.getByTestId('view-diff-btn'));
 
@@ -1883,7 +1878,7 @@ describe('MainPanel', () => {
 				sessionSshRemoteConfig: { enabled: false, remoteId: 'ssh-remote-123' },
 			});
 
-			render(<MainPanel {...defaultProps} activeSession={session} />);
+			renderMainPanel({ activeSession: session });
 
 			fireEvent.click(screen.getByTestId('view-diff-btn'));
 
@@ -1899,7 +1894,7 @@ describe('MainPanel', () => {
 				sessionSshRemoteConfig: { enabled: true, remoteId: 'ssh-remote-123' },
 			});
 
-			render(<MainPanel {...defaultProps} activeSession={session} setGitLogOpen={setGitLogOpen} />);
+			renderMainPanel({ activeSession: session, setGitLogOpen: setGitLogOpen });
 
 			fireEvent.click(screen.getByTestId('view-log-btn'));
 
@@ -1910,7 +1905,7 @@ describe('MainPanel', () => {
 			const setGitLogOpen = vi.fn();
 			const session = createSession({ isGitRepo: true });
 
-			render(<MainPanel {...defaultProps} activeSession={session} setGitLogOpen={setGitLogOpen} />);
+			renderMainPanel({ activeSession: session, setGitLogOpen: setGitLogOpen });
 
 			fireEvent.click(screen.getByTestId('view-log-btn'));
 
@@ -1920,7 +1915,7 @@ describe('MainPanel', () => {
 
 	describe('Context window tooltip', () => {
 		it('should show context tooltip on hover', async () => {
-			render(<MainPanel {...defaultProps} />);
+			renderMainPanel();
 
 			const contextWidget = screen.getByTestId('header-context-widget');
 			fireEvent.mouseEnter(contextWidget);
@@ -1931,7 +1926,7 @@ describe('MainPanel', () => {
 		});
 
 		it('should hide context tooltip on mouse leave after delay', async () => {
-			render(<MainPanel {...defaultProps} />);
+			renderMainPanel();
 
 			const contextWidget = screen.getByTestId('header-context-widget');
 			fireEvent.mouseEnter(contextWidget);
@@ -1952,7 +1947,7 @@ describe('MainPanel', () => {
 		});
 
 		it('should keep tooltip open when re-entering context widget quickly', async () => {
-			render(<MainPanel {...defaultProps} />);
+			renderMainPanel();
 
 			const contextContainer = screen.getByTestId('header-context-widget');
 
@@ -1993,7 +1988,7 @@ describe('MainPanel', () => {
 				activeTabId: 'tab-1',
 			});
 
-			render(<MainPanel {...defaultProps} activeSession={session} />);
+			renderMainPanel({ activeSession: session });
 
 			const contextWidget = screen.getByTestId('header-context-widget');
 			fireEvent.mouseEnter(contextWidget);
@@ -2022,7 +2017,7 @@ describe('MainPanel', () => {
 			// Set activeFocus to something other than 'main' so we can detect the change
 			useUIStore.setState({ activeFocus: 'sidebar' });
 
-			render(<MainPanel {...defaultProps} setActiveSessionId={setActiveSessionId} />);
+			renderMainPanel({ setActiveSessionId: setActiveSessionId });
 
 			fireEvent.focus(screen.getByTestId('input-field'));
 
@@ -2031,7 +2026,7 @@ describe('MainPanel', () => {
 		});
 
 		it('should hide input area in mobile landscape mode', () => {
-			render(<MainPanel {...defaultProps} isMobileLandscape={true} />);
+			renderMainPanel({ isMobileLandscape: true });
 
 			expect(screen.queryByTestId('input-area')).not.toBeInTheDocument();
 		});
@@ -2042,13 +2037,7 @@ describe('MainPanel', () => {
 			const setGitDiffPreview = vi.fn();
 			const session = createSession({ isGitRepo: true });
 
-			render(
-				<MainPanel
-					{...defaultProps}
-					activeSession={session}
-					setGitDiffPreview={setGitDiffPreview}
-				/>
-			);
+			renderMainPanel({ activeSession: session, setGitDiffPreview: setGitDiffPreview });
 
 			fireEvent.click(screen.getByTestId('view-diff-btn'));
 
@@ -2064,13 +2053,7 @@ describe('MainPanel', () => {
 				sessionSshRemoteConfig: { enabled: true, remoteId: 'ssh-remote-123' },
 			});
 
-			render(
-				<MainPanel
-					{...defaultProps}
-					activeSession={session}
-					setGitDiffPreview={setGitDiffPreview}
-				/>
-			);
+			renderMainPanel({ activeSession: session, setGitDiffPreview: setGitDiffPreview });
 
 			fireEvent.click(screen.getByTestId('view-diff-btn'));
 
@@ -2083,13 +2066,7 @@ describe('MainPanel', () => {
 			const setGitDiffPreview = vi.fn();
 			const session = createSession({ isGitRepo: true });
 
-			render(
-				<MainPanel
-					{...defaultProps}
-					activeSession={session}
-					setGitDiffPreview={setGitDiffPreview}
-				/>
-			);
+			renderMainPanel({ activeSession: session, setGitDiffPreview: setGitDiffPreview });
 
 			fireEvent.click(screen.getByTestId('view-diff-btn'));
 
@@ -2119,7 +2096,7 @@ describe('MainPanel', () => {
 				activeTabId: 'tab-1',
 			});
 
-			render(<MainPanel {...defaultProps} activeSession={session} />);
+			renderMainPanel({ activeSession: session });
 
 			fireEvent.click(screen.getByText('ABC12345'));
 
@@ -2150,7 +2127,7 @@ describe('MainPanel', () => {
 				activeTabId: 'tab-1',
 			});
 
-			render(<MainPanel {...defaultProps} activeSession={session} />);
+			renderMainPanel({ activeSession: session });
 
 			fireEvent.click(screen.getByText('ABC12345'));
 
@@ -2170,7 +2147,7 @@ describe('MainPanel', () => {
 	describe('Focus ring', () => {
 		it('should show focus ring when activeFocus is main', () => {
 			useUIStore.setState({ activeFocus: 'main' });
-			const { container } = render(<MainPanel {...defaultProps} />);
+			const { container } = renderMainPanel();
 
 			// MainPanel no longer uses ring-1 class; focus is tracked via activeFocus state only
 			// The component renders without a visible focus ring border
@@ -2180,7 +2157,7 @@ describe('MainPanel', () => {
 
 		it('should not show focus ring when activeFocus is not main', () => {
 			useUIStore.setState({ activeFocus: 'sidebar' });
-			const { container } = render(<MainPanel {...defaultProps} />);
+			const { container } = renderMainPanel();
 
 			const mainPanel = container.querySelector('.ring-1');
 			expect(mainPanel).not.toBeInTheDocument();
@@ -2189,7 +2166,7 @@ describe('MainPanel', () => {
 		it('should call setActiveFocus when main panel is clicked', () => {
 			useUIStore.setState({ activeFocus: 'sidebar' });
 
-			const { container } = render(<MainPanel {...defaultProps} />);
+			const { container } = renderMainPanel();
 
 			// Click on the main panel area
 			const mainArea = container.querySelector('[style*="backgroundColor"]');
@@ -2202,7 +2179,7 @@ describe('MainPanel', () => {
 
 	describe('Git status widget', () => {
 		it('should render GitStatusWidget', () => {
-			render(<MainPanel {...defaultProps} />);
+			renderMainPanel();
 
 			expect(screen.getByTestId('git-status-widget')).toBeInTheDocument();
 		});
@@ -2232,9 +2209,7 @@ describe('MainPanel', () => {
 				activeTabId: 'tab-1',
 			});
 
-			render(
-				<MainPanel {...defaultProps} activeSession={session} getContextColor={getContextColor} />
-			);
+			renderMainPanel({ activeSession: session, getContextColor: getContextColor });
 
 			// Context usage: (50000 + 25000 + 0) / 200000 * 100 = 38% (input + cacheRead + cacheCreation)
 			expect(getContextColor).toHaveBeenCalledWith(38, theme);
@@ -2248,7 +2223,7 @@ describe('MainPanel', () => {
 		it('should display git info from context when session is a git repo', async () => {
 			const session = createSession({ isGitRepo: true });
 
-			render(<MainPanel {...defaultProps} activeSession={session} />);
+			renderMainPanel({ activeSession: session });
 
 			// MainPanel should display the branch from context data
 			await waitFor(() => {
@@ -2259,7 +2234,7 @@ describe('MainPanel', () => {
 		it('should support refresh via context', async () => {
 			const session = createSession({ isGitRepo: true });
 
-			render(<MainPanel {...defaultProps} activeSession={session} />);
+			renderMainPanel({ activeSession: session });
 
 			// The component should have access to refreshGitStatus from context
 			// This is now triggered through the git badge click
@@ -2273,7 +2248,7 @@ describe('MainPanel', () => {
 		it('should not display git info when session is not a git repo', async () => {
 			const session = createSession({ isGitRepo: false });
 
-			render(<MainPanel {...defaultProps} activeSession={session} />);
+			renderMainPanel({ activeSession: session });
 
 			// Should show LOCAL badge instead of git branch
 			expect(screen.getByText('LOCAL')).toBeInTheDocument();
@@ -2283,7 +2258,7 @@ describe('MainPanel', () => {
 
 	describe('Panel width responsive behavior', () => {
 		it('should observe header resize', async () => {
-			render(<MainPanel {...defaultProps} />);
+			renderMainPanel();
 
 			// Wait for the effect to run and ResizeObserver to be set up
 			await waitFor(() => {
@@ -2295,7 +2270,7 @@ describe('MainPanel', () => {
 
 	describe('ErrorBoundary wrapping', () => {
 		it('should wrap main content in ErrorBoundary', () => {
-			render(<MainPanel {...defaultProps} />);
+			renderMainPanel();
 
 			// The content should render without errors
 			expect(screen.getByTestId('terminal-output')).toBeInTheDocument();
@@ -2308,13 +2283,7 @@ describe('MainPanel', () => {
 			const onTabSelect = vi.fn();
 
 			// This handler is passed to InputArea's ThinkingStatusPill
-			render(
-				<MainPanel
-					{...defaultProps}
-					setActiveSessionId={setActiveSessionId}
-					onTabSelect={onTabSelect}
-				/>
-			);
+			renderMainPanel({ setActiveSessionId: setActiveSessionId, onTabSelect: onTabSelect });
 
 			// The InputArea receives handleSessionClick, but we can't directly test it without accessing the mock
 			// This is tested through the integration with InputArea mock
@@ -2324,7 +2293,7 @@ describe('MainPanel', () => {
 
 	describe('Tooltip timeout cleanup', () => {
 		it('should cleanup tooltip timeouts on unmount', () => {
-			const { unmount } = render(<MainPanel {...defaultProps} />);
+			const { unmount } = renderMainPanel();
 
 			// Should unmount without errors (timeouts should be cleaned up)
 			expect(() => unmount()).not.toThrow();
@@ -2347,7 +2316,7 @@ describe('MainPanel', () => {
 			});
 
 			const session = createSession({ isGitRepo: true });
-			render(<MainPanel {...defaultProps} activeSession={session} />);
+			renderMainPanel({ activeSession: session });
 
 			await waitFor(() => {
 				expect(screen.getByText(/main|GIT/)).toBeInTheDocument();
@@ -2376,7 +2345,7 @@ describe('MainPanel', () => {
 			});
 
 			const session = createSession({ isGitRepo: true });
-			render(<MainPanel {...defaultProps} activeSession={session} />);
+			renderMainPanel({ activeSession: session });
 
 			await waitFor(() => {
 				expect(screen.getByText(/main|GIT/)).toBeInTheDocument();
@@ -2405,7 +2374,7 @@ describe('MainPanel', () => {
 			});
 
 			const session = createSession({ isGitRepo: true });
-			render(<MainPanel {...defaultProps} activeSession={session} />);
+			renderMainPanel({ activeSession: session });
 
 			await waitFor(() => {
 				expect(screen.getByText(/main|GIT/)).toBeInTheDocument();
@@ -2434,7 +2403,7 @@ describe('MainPanel', () => {
 			});
 
 			const session = createSession({ isGitRepo: true });
-			render(<MainPanel {...defaultProps} activeSession={session} />);
+			renderMainPanel({ activeSession: session });
 
 			await waitFor(() => {
 				expect(screen.getByText(/main|GIT/)).toBeInTheDocument();
@@ -2465,7 +2434,7 @@ describe('MainPanel', () => {
 			});
 
 			const session = createSession({ isGitRepo: true });
-			render(<MainPanel {...defaultProps} activeSession={session} />);
+			renderMainPanel({ activeSession: session });
 
 			await waitFor(() => {
 				expect(screen.getByText(/main|GIT/)).toBeInTheDocument();
@@ -2498,7 +2467,7 @@ describe('MainPanel', () => {
 			});
 
 			const session = createSession({ isGitRepo: true });
-			render(<MainPanel {...defaultProps} activeSession={session} />);
+			renderMainPanel({ activeSession: session });
 
 			await waitFor(() => {
 				expect(screen.getByText(/main|GIT/)).toBeInTheDocument();
@@ -2523,7 +2492,7 @@ describe('MainPanel', () => {
 		it('should handle session with no tabs gracefully', () => {
 			const session = createSession({ aiTabs: undefined });
 
-			render(<MainPanel {...defaultProps} activeSession={session} />);
+			renderMainPanel({ activeSession: session });
 
 			expect(screen.queryByTestId('tab-bar')).not.toBeInTheDocument();
 		});
@@ -2531,7 +2500,7 @@ describe('MainPanel', () => {
 		it('should handle empty tabs array gracefully', () => {
 			const session = createSession({ aiTabs: [] });
 
-			render(<MainPanel {...defaultProps} activeSession={session} />);
+			renderMainPanel({ activeSession: session });
 
 			expect(screen.queryByTestId('tab-bar')).not.toBeInTheDocument();
 		});
@@ -2551,7 +2520,7 @@ describe('MainPanel', () => {
 				activeTabId: 'tab-1',
 			});
 
-			render(<MainPanel {...defaultProps} activeSession={session} />);
+			renderMainPanel({ activeSession: session });
 
 			// Should render without crashing - Context Window widget is hidden when contextWindow is not configured
 			expect(screen.queryByTestId('header-context-widget')).not.toBeInTheDocument();
@@ -2563,7 +2532,7 @@ describe('MainPanel', () => {
 
 			const session = createSession({ isGitRepo: true });
 
-			render(<MainPanel {...defaultProps} activeSession={session} />);
+			renderMainPanel({ activeSession: session });
 
 			// Should render without crashing, showing GIT badge (without branch name since no data)
 			await waitFor(() => {
@@ -2589,7 +2558,7 @@ describe('MainPanel', () => {
 				activeTabId: 'tab-1',
 			});
 
-			render(<MainPanel {...defaultProps} activeSession={session} />);
+			renderMainPanel({ activeSession: session });
 
 			fireEvent.click(screen.getByText('ABC12345'));
 
@@ -2608,13 +2577,7 @@ describe('MainPanel', () => {
 			const setGitDiffPreview = vi.fn();
 			const session = createSession({ isGitRepo: true });
 
-			render(
-				<MainPanel
-					{...defaultProps}
-					activeSession={session}
-					setGitDiffPreview={setGitDiffPreview}
-				/>
-			);
+			renderMainPanel({ activeSession: session, setGitDiffPreview: setGitDiffPreview });
 
 			fireEvent.click(screen.getByTestId('view-diff-btn'));
 
@@ -2652,7 +2615,7 @@ describe('MainPanel', () => {
 				activeTabId: 'tab-1',
 			});
 
-			render(<MainPanel {...defaultProps} activeSession={session} />);
+			renderMainPanel({ activeSession: session });
 
 			// Context Window widget should be hidden when contextWindow is 0 (not configured)
 			expect(screen.queryByTestId('header-context-widget')).not.toBeInTheDocument();
@@ -2682,9 +2645,7 @@ describe('MainPanel', () => {
 				activeTabId: 'tab-1',
 			});
 
-			render(
-				<MainPanel {...defaultProps} activeSession={session} getContextColor={getContextColor} />
-			);
+			renderMainPanel({ activeSession: session, getContextColor: getContextColor });
 
 			// raw = 150000 + 100000 + 100000 = 350000 > 200000 (accumulated)
 			// Falls back to session.contextUsage = 45%
@@ -2695,7 +2656,7 @@ describe('MainPanel', () => {
 	describe('Hover bridge behavior', () => {
 		it('should keep git tooltip open when moving to bridge element', async () => {
 			const session = createSession({ isGitRepo: true });
-			render(<MainPanel {...defaultProps} activeSession={session} />);
+			renderMainPanel({ activeSession: session });
 
 			await waitFor(() => {
 				expect(screen.getByText(/main|GIT/)).toBeInTheDocument();
@@ -2732,7 +2693,7 @@ describe('MainPanel', () => {
 			});
 
 			const session = createSession({ isGitRepo: true });
-			render(<MainPanel {...defaultProps} activeSession={session} />);
+			renderMainPanel({ activeSession: session });
 
 			await waitFor(() => {
 				expect(screen.getByText(/main|GIT/)).toBeInTheDocument();
@@ -2782,7 +2743,7 @@ describe('MainPanel', () => {
 				activeTabId: 'tab-1',
 			});
 
-			render(<MainPanel {...defaultProps} activeSession={session} />);
+			renderMainPanel({ activeSession: session });
 
 			expect(
 				screen.getByText('Authentication token has expired. Please re-authenticate.')
@@ -2804,7 +2765,7 @@ describe('MainPanel', () => {
 				activeTabId: 'tab-1',
 			});
 
-			render(<MainPanel {...defaultProps} activeSession={session} />);
+			renderMainPanel({ activeSession: session });
 
 			expect(screen.queryByText(/error|expired|failed/i)).not.toBeInTheDocument();
 		});
@@ -2825,13 +2786,7 @@ describe('MainPanel', () => {
 				activeTabId: 'tab-1',
 			});
 
-			render(
-				<MainPanel
-					{...defaultProps}
-					activeSession={session}
-					onShowAgentErrorModal={onShowAgentErrorModal}
-				/>
-			);
+			renderMainPanel({ activeSession: session, onShowAgentErrorModal: onShowAgentErrorModal });
 
 			expect(screen.getByText('View Details')).toBeInTheDocument();
 		});
@@ -2852,13 +2807,7 @@ describe('MainPanel', () => {
 				activeTabId: 'tab-1',
 			});
 
-			render(
-				<MainPanel
-					{...defaultProps}
-					activeSession={session}
-					onShowAgentErrorModal={onShowAgentErrorModal}
-				/>
-			);
+			renderMainPanel({ activeSession: session, onShowAgentErrorModal: onShowAgentErrorModal });
 
 			fireEvent.click(screen.getByText('View Details'));
 
@@ -2880,9 +2829,7 @@ describe('MainPanel', () => {
 				activeTabId: 'tab-1',
 			});
 
-			render(
-				<MainPanel {...defaultProps} activeSession={session} onShowAgentErrorModal={undefined} />
-			);
+			renderMainPanel({ activeSession: session, onShowAgentErrorModal: undefined });
 
 			expect(screen.queryByText('View Details')).not.toBeInTheDocument();
 		});
@@ -2903,13 +2850,7 @@ describe('MainPanel', () => {
 				activeTabId: 'tab-1',
 			});
 
-			render(
-				<MainPanel
-					{...defaultProps}
-					activeSession={session}
-					onClearAgentError={onClearAgentError}
-				/>
-			);
+			renderMainPanel({ activeSession: session, onClearAgentError: onClearAgentError });
 
 			expect(screen.getByTitle('Dismiss error')).toBeInTheDocument();
 		});
@@ -2930,13 +2871,7 @@ describe('MainPanel', () => {
 				activeTabId: 'tab-1',
 			});
 
-			render(
-				<MainPanel
-					{...defaultProps}
-					activeSession={session}
-					onClearAgentError={onClearAgentError}
-				/>
-			);
+			renderMainPanel({ activeSession: session, onClearAgentError: onClearAgentError });
 
 			fireEvent.click(screen.getByTitle('Dismiss error'));
 
@@ -2959,13 +2894,7 @@ describe('MainPanel', () => {
 				activeTabId: 'tab-1',
 			});
 
-			render(
-				<MainPanel
-					{...defaultProps}
-					activeSession={session}
-					onClearAgentError={onClearAgentError}
-				/>
-			);
+			renderMainPanel({ activeSession: session, onClearAgentError: onClearAgentError });
 
 			// Error banner should be shown but dismiss button should not be present
 			expect(
@@ -2989,7 +2918,7 @@ describe('MainPanel', () => {
 				activeTabId: 'tab-1',
 			});
 
-			render(<MainPanel {...defaultProps} activeSession={session} onClearAgentError={undefined} />);
+			renderMainPanel({ activeSession: session, onClearAgentError: undefined });
 
 			expect(screen.queryByTitle('Dismiss error')).not.toBeInTheDocument();
 		});
@@ -3009,7 +2938,7 @@ describe('MainPanel', () => {
 				activeTabId: 'tab-1',
 			});
 
-			const { container } = render(<MainPanel {...defaultProps} activeSession={session} />);
+			const { container } = renderMainPanel({ activeSession: session });
 
 			// Check for the AlertCircle icon (lucide-react renders as SVG with lucide class)
 			// Look for an SVG within the error banner container (next to the error message)
@@ -3045,7 +2974,7 @@ describe('MainPanel', () => {
 					activeTabId: 'tab-1',
 				});
 
-				const { unmount } = render(<MainPanel {...defaultProps} activeSession={session} />);
+				const { unmount } = renderMainPanel({ activeSession: session });
 
 				expect(screen.getByText(message)).toBeInTheDocument();
 				unmount();
@@ -3074,7 +3003,7 @@ describe('MainPanel', () => {
 				activeTabId: 'tab-2', // Tab 2 is active
 			});
 
-			render(<MainPanel {...defaultProps} activeSession={session} />);
+			renderMainPanel({ activeSession: session });
 
 			// Should show tab-2's error, not tab-1's
 			expect(screen.getByText('Error on tab 2')).toBeInTheDocument();
@@ -3082,7 +3011,7 @@ describe('MainPanel', () => {
 		});
 
 		it('should not display error banner when session is null', () => {
-			render(<MainPanel {...defaultProps} activeSession={null} />);
+			renderMainPanel({ activeSession: null });
 
 			// Empty state should be shown, no error banner
 			expect(screen.getByText('No agents. Create one to get started.')).toBeInTheDocument();
@@ -3106,7 +3035,7 @@ describe('MainPanel', () => {
 				activeTabId: 'tab-1',
 			});
 
-			render(<MainPanel {...defaultProps} activeSession={session} />);
+			renderMainPanel({ activeSession: session });
 
 			// The error banner is shown regardless of inputMode to ensure visibility
 			expect(
@@ -3131,14 +3060,11 @@ describe('MainPanel', () => {
 				activeTabId: 'tab-1',
 			});
 
-			render(
-				<MainPanel
-					{...defaultProps}
-					activeSession={session}
-					onShowAgentErrorModal={onShowAgentErrorModal}
-					onClearAgentError={onClearAgentError}
-				/>
-			);
+			renderMainPanel({
+				activeSession: session,
+				onShowAgentErrorModal: onShowAgentErrorModal,
+				onClearAgentError: onClearAgentError,
+			});
 
 			expect(screen.getByText('View Details')).toBeInTheDocument();
 			expect(screen.getByTitle('Dismiss error')).toBeInTheDocument();
@@ -3159,7 +3085,7 @@ describe('MainPanel', () => {
 				activeTabId: 'tab-1',
 			});
 
-			const { container } = render(<MainPanel {...defaultProps} activeSession={session} />);
+			const { container } = renderMainPanel({ activeSession: session });
 
 			// Find the error banner element by looking for the error message container
 			const errorMessage = screen.getByText(
@@ -3187,7 +3113,7 @@ describe('MainPanel', () => {
 				activeTabId: 'tab-1',
 			});
 
-			const { rerender } = render(<MainPanel {...defaultProps} activeSession={sessionWithError} />);
+			const { rerender } = renderMainPanel({ activeSession: sessionWithError });
 
 			expect(screen.getByText('Error message')).toBeInTheDocument();
 
@@ -3206,7 +3132,7 @@ describe('MainPanel', () => {
 				activeTabId: 'tab-2',
 			});
 
-			rerender(<MainPanel {...defaultProps} activeSession={sessionWithoutError} />);
+			rerender({ activeSession: sessionWithoutError });
 
 			expect(screen.queryByText('Error message')).not.toBeInTheDocument();
 		});
@@ -3226,7 +3152,7 @@ describe('MainPanel', () => {
 				activeTabId: 'tab-1',
 			});
 
-			const { container } = render(<MainPanel {...defaultProps} activeSession={session} />);
+			const { container } = renderMainPanel({ activeSession: session });
 
 			// Tab bar should exist
 			expect(screen.getByTestId('tab-bar')).toBeInTheDocument();
@@ -3269,7 +3195,7 @@ describe('MainPanel', () => {
 				activeTabId: 'tab-1',
 			});
 
-			render(<MainPanel {...defaultProps} activeSession={session} />);
+			renderMainPanel({ activeSession: session });
 
 			// The error message should be displayed (the component doesn't truncate, but CSS might)
 			expect(screen.getByText(longMessage)).toBeInTheDocument();
@@ -3305,14 +3231,11 @@ describe('MainPanel', () => {
 				activeTabId: 'tab-1',
 			});
 
-			render(
-				<MainPanel
-					{...defaultProps}
-					activeSession={session}
-					activeFileTabId="file-tab-1"
-					activeFileTab={activeFileTab}
-				/>
-			);
+			renderMainPanel({
+				activeSession: session,
+				activeFileTabId: 'file-tab-1',
+				activeFileTab: activeFileTab,
+			});
 
 			// Both error banner and file preview should be visible
 			expect(
@@ -3343,7 +3266,7 @@ describe('MainPanel', () => {
 			});
 
 			// Should render without crashing
-			const { container } = render(<MainPanel {...defaultProps} activeSession={session} />);
+			const { container } = renderMainPanel({ activeSession: session });
 
 			// The banner should still render with an icon even if message is empty
 			// Look for the error banner structure - contains an SVG icon
@@ -3385,7 +3308,7 @@ describe('MainPanel', () => {
 				},
 			});
 
-			render(<MainPanel {...defaultProps} activeSession={session} />);
+			renderMainPanel({ activeSession: session });
 
 			expect(screen.getByTestId('wizard-conversation-view')).toBeInTheDocument();
 			expect(screen.getByText('Wizard Conversation (2 messages)')).toBeInTheDocument();
@@ -3395,7 +3318,7 @@ describe('MainPanel', () => {
 		it('should render TerminalOutput when wizard is not active', () => {
 			const session = createSessionWithTabWizardState(undefined);
 
-			render(<MainPanel {...defaultProps} activeSession={session} />);
+			renderMainPanel({ activeSession: session });
 
 			expect(screen.getByTestId('terminal-output')).toBeInTheDocument();
 			expect(screen.queryByTestId('wizard-conversation-view')).not.toBeInTheDocument();
@@ -3414,7 +3337,7 @@ describe('MainPanel', () => {
 				},
 			});
 
-			render(<MainPanel {...defaultProps} activeSession={session} />);
+			renderMainPanel({ activeSession: session });
 
 			expect(screen.getByTestId('terminal-output')).toBeInTheDocument();
 			expect(screen.queryByTestId('wizard-conversation-view')).not.toBeInTheDocument();
@@ -3436,7 +3359,7 @@ describe('MainPanel', () => {
 				},
 			});
 
-			render(<MainPanel {...defaultProps} activeSession={session} />);
+			renderMainPanel({ activeSession: session });
 
 			expect(screen.getByTestId('wizard-conversation-view')).toBeInTheDocument();
 			expect(screen.getByTestId('wizard-loading')).toBeInTheDocument();
@@ -3455,7 +3378,7 @@ describe('MainPanel', () => {
 				},
 			});
 
-			render(<MainPanel {...defaultProps} activeSession={session} />);
+			renderMainPanel({ activeSession: session });
 
 			// Header elements should still be visible
 			expect(screen.getByText('Test Session')).toBeInTheDocument();
@@ -3484,7 +3407,7 @@ describe('MainPanel', () => {
 				}
 			);
 
-			render(<MainPanel {...defaultProps} activeSession={session} />);
+			renderMainPanel({ activeSession: session });
 
 			// The mock component just shows message count, but the agentName is passed through
 			expect(screen.getByTestId('wizard-conversation-view')).toBeInTheDocument();
@@ -3519,10 +3442,7 @@ describe('MainPanel', () => {
 				activeTerminalTabId: tab.id,
 				unifiedTabOrder: [{ type: 'terminal' as const, id: tab.id }],
 			});
-			// Seed session store so the eviction effect keeps the session alive
-			useSessionStore.setState({ sessions: [session] });
-
-			render(<MainPanel {...defaultProps} activeSession={session} />);
+			renderMainPanel({ activeSession: session });
 
 			const view = screen.getByTestId('terminal-view-session-term');
 			expect(view).toBeInTheDocument();
@@ -3545,9 +3465,7 @@ describe('MainPanel', () => {
 				activeTerminalTabId: tab.id,
 				unifiedTabOrder: [{ type: 'terminal' as const, id: tab.id }],
 			});
-			useSessionStore.setState({ sessions: [sessionTerminal] });
-
-			const { rerender } = render(<MainPanel {...defaultProps} activeSession={sessionTerminal} />);
+			const { rerender } = renderMainPanel({ activeSession: sessionTerminal });
 
 			// Confirm it is visible
 			expect(screen.getByTestId('terminal-view-session-persist').getAttribute('data-visible')).toBe(
@@ -3556,7 +3474,7 @@ describe('MainPanel', () => {
 
 			// Simulate switching to AI mode (inputMode changes, terminalTabs unchanged)
 			await act(async () => {
-				rerender(<MainPanel {...defaultProps} activeSession={sessionAI} />);
+				rerender({ activeSession: sessionAI });
 			});
 
 			// TerminalView must still be in the DOM (not unmounted)
@@ -3582,18 +3500,16 @@ describe('MainPanel', () => {
 				activeTerminalTabId: tab.id,
 				unifiedTabOrder: [{ type: 'terminal' as const, id: tab.id }],
 			});
-			useSessionStore.setState({ sessions: [sessionTerminal] });
-
-			const { rerender } = render(<MainPanel {...defaultProps} activeSession={sessionTerminal} />);
+			const { rerender } = renderMainPanel({ activeSession: sessionTerminal });
 
 			// Switch to AI mode
 			await act(async () => {
-				rerender(<MainPanel {...defaultProps} activeSession={sessionAI} />);
+				rerender({ activeSession: sessionAI });
 			});
 
 			// Switch back to terminal mode
 			await act(async () => {
-				rerender(<MainPanel {...defaultProps} activeSession={sessionTerminal} />);
+				rerender({ activeSession: sessionTerminal });
 			});
 
 			const view = screen.getByTestId('terminal-view-session-roundtrip');
@@ -3602,8 +3518,7 @@ describe('MainPanel', () => {
 
 		it('does not render TerminalView when session has no terminal tabs', () => {
 			const session = createSession({ inputMode: 'ai', terminalTabs: [] });
-			useSessionStore.setState({ sessions: [session] });
-			render(<MainPanel {...defaultProps} activeSession={session} />);
+			renderMainPanel({ activeSession: session });
 			expect(screen.queryByTestId('terminal-view-session-1')).not.toBeInTheDocument();
 		});
 	});
@@ -3658,10 +3573,8 @@ describe('MainPanel', () => {
 			vi.mocked(window.maestro.agents.getConfigOptions).mockResolvedValue([]);
 			vi.mocked(window.maestro.agents.getConfig).mockResolvedValue({});
 
-			useSessionStore.setState({ sessions: [openCodeSession] });
-
 			// Render with OpenCode session — triggers getModels('opencode') which is pending
-			const { rerender } = render(<MainPanel {...defaultProps} activeSession={openCodeSession} />);
+			const { rerender } = renderMainPanel({ activeSession: openCodeSession });
 
 			// Switch to Claude session — triggers getModels('claude-code') which resolves fast
 			const claudeSession = createSession({
@@ -3669,10 +3582,8 @@ describe('MainPanel', () => {
 				toolType: 'claude-code',
 				name: 'Claude Session',
 			});
-			useSessionStore.setState({ sessions: [claudeSession] });
-
 			await act(async () => {
-				rerender(<MainPanel {...defaultProps} activeSession={claudeSession} />);
+				rerender({ activeSession: claudeSession });
 			});
 
 			// Wait for Claude models to be applied

--- a/src/__tests__/renderer/components/MainPanel.test.tsx
+++ b/src/__tests__/renderer/components/MainPanel.test.tsx
@@ -426,13 +426,13 @@ describe('MainPanel', () => {
 		...overrides,
 	});
 
+	const defaultSession = createSession();
 	const defaultProps = {
 		// State
 		logViewerOpen: false,
 		agentSessionsOpen: false,
 		memoryViewerOpen: false,
 		activeAgentSessionId: null,
-		activeSession: createSession(),
 		thinkingItems: [] as ThinkingItem[],
 		theme,
 		isMobileLandscape: false,
@@ -501,15 +501,21 @@ describe('MainPanel', () => {
 		} as never);
 	}
 
-	function renderMainPanel(overrides: Partial<typeof defaultProps> = {}) {
-		const props = { ...defaultProps, ...overrides };
-		const session = props.activeSession as Session | null | undefined;
+	function renderMainPanel(
+		overrides: Partial<typeof defaultProps> & { activeSession?: Session | null } = {}
+	) {
+		const { activeSession: sessionOverride, ...rest } = overrides;
+		const props = { ...defaultProps, ...rest };
+		const session = sessionOverride !== undefined ? sessionOverride : defaultSession;
 		seedSessionStore(session);
-		const result = render(<MainPanel {...(props as any)} />);
-		const rerenderMainPanel = (nextOverrides: Partial<typeof defaultProps> = {}) => {
-			const nextProps = { ...defaultProps, ...nextOverrides };
-			seedSessionStore(nextProps.activeSession as Session | null | undefined);
-			result.rerender(<MainPanel {...(nextProps as any)} />);
+		const result = render(<MainPanel {...(props as never)} />);
+		const rerenderMainPanel = (
+			nextOverrides: Partial<typeof defaultProps> & { activeSession?: Session | null } = {}
+		) => {
+			const { activeSession: nextSession, ...nextRest } = nextOverrides;
+			const nextProps = { ...defaultProps, ...nextRest };
+			seedSessionStore(nextSession !== undefined ? nextSession : session);
+			result.rerender(<MainPanel {...(nextProps as never)} />);
 		};
 		return { ...result, rerender: rerenderMainPanel };
 	}
@@ -649,7 +655,7 @@ describe('MainPanel', () => {
 				makeWindowState({ id: 'win-2', sessionIds: [], activeSessionId: null })
 			);
 
-			seedSessionStore(defaultProps.activeSession as Session);
+			seedSessionStore(defaultSession);
 			render(
 				<WindowProvider>
 					<MainPanel {...defaultProps} />
@@ -669,7 +675,7 @@ describe('MainPanel', () => {
 			);
 			vi.mocked(window.maestro.windows.list).mockResolvedValue([]);
 
-			seedSessionStore(defaultProps.activeSession as Session);
+			seedSessionStore(defaultSession);
 			render(
 				<WindowProvider>
 					<MainPanel {...defaultProps} />

--- a/src/__tests__/renderer/hooks/batch/useGoalRunner.test.ts
+++ b/src/__tests__/renderer/hooks/batch/useGoalRunner.test.ts
@@ -77,10 +77,13 @@ describe('useGoalRunner (Goal-Driven Auto Run engine)', () => {
 		goalConfig: { goal, exitCriteria, maxIterations },
 	});
 
-	const renderProcessor = (sessions: Session[], groups: Group[]) =>
-		renderHook(() =>
+	const renderProcessor = (sessions: Session[], groups: Group[]) => {
+		useSessionStore.setState({
+			sessions,
+			activeSessionId: sessions[0]?.id ?? '',
+		} as never);
+		return renderHook(() =>
 			useBatchProcessor({
-				sessions,
 				groups,
 				onUpdateSession: mockOnUpdateSession,
 				onSpawnAgent: mockOnSpawnAgent,
@@ -89,6 +92,7 @@ describe('useGoalRunner (Goal-Driven Auto Run engine)', () => {
 				onComplete: mockOnComplete,
 			})
 		);
+	};
 
 	/**
 	 * Find the final-summary history entry. Per-iteration entries now lead with

--- a/src/__tests__/renderer/hooks/props/useMainPanelProps.test.ts
+++ b/src/__tests__/renderer/hooks/props/useMainPanelProps.test.ts
@@ -1,14 +1,12 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import { useMainPanelProps, type UseMainPanelPropsDeps } from '../../../../renderer/hooks/props';
 import type { Session, QueuedItem } from '../../../../renderer/types';
 
-// The props object is memoized with a primitive dependency array (id, activeTabId,
-// inputMode, projectRoot, cwd, executionQueue, ...) rather than the full session
-// object. This test guards the specific regression where editing a queued item
-// left the inline QUEUED list stale because `executionQueue` was NOT tracked: the
-// memo kept returning the previous `activeSession` reference even though the store
-// had a fresh one with the edited text.
+// MainPanel self-sources the full Session for paint (including executionQueue).
+// useMainPanelProps must not re-export activeSession; doing so would either
+// reintroduce App-level streaming wakes or leave a stale chrome slice on the
+// prop bag. These tests guard that contract and the remaining session-field deps.
 
 function makeQueuedItem(overrides: Partial<QueuedItem> = {}): QueuedItem {
 	return {
@@ -21,56 +19,72 @@ function makeQueuedItem(overrides: Partial<QueuedItem> = {}): QueuedItem {
 	};
 }
 
-function makeSession(executionQueue: QueuedItem[]): Session {
+function makeSession(overrides: Partial<Session> = {}): Session {
 	return {
 		id: 's1',
 		activeTabId: 't1',
 		inputMode: 'ai',
 		projectRoot: '/repo',
 		cwd: '/repo',
-		executionQueue,
+		executionQueue: [makeQueuedItem()],
+		...overrides,
 	} as unknown as Session;
 }
 
-// Only `activeSession` matters for this regression; the rest of the (very large)
-// deps surface is intentionally omitted and read as undefined by the memo body.
+const stableCancelTab = vi.fn();
+const stableCancelMergeTab = vi.fn();
+
 function makeDeps(activeSession: Session): UseMainPanelPropsDeps {
-	return { activeSession } as unknown as UseMainPanelPropsDeps;
+	return {
+		activeSession,
+		cancelTab: stableCancelTab,
+		cancelMergeTab: stableCancelMergeTab,
+	} as unknown as UseMainPanelPropsDeps;
 }
 
 describe('useMainPanelProps', () => {
-	it('recomputes activeSession when the execution queue reference changes', () => {
-		const first = makeSession([makeQueuedItem({ text: 'original' })]);
+	it('does not pass activeSession (MainPanel self-sources for paint)', () => {
+		const session = makeSession();
+		const { result } = renderHook(() => useMainPanelProps(makeDeps(session)));
 
+		expect(result.current).not.toHaveProperty('activeSession');
+	});
+
+	it('does not recompute when only executionQueue changes', () => {
+		// Queue edits must not wake this memo - MainPanel's store subscription
+		// repaints the QUEUED list. Tracking executionQueue here would couple
+		// App chrome props to a field chrome equality ignores.
+		const first = makeSession({ executionQueue: [makeQueuedItem({ text: 'original' })] });
 		const { result, rerender } = renderHook(
 			(session: Session) => useMainPanelProps(makeDeps(session)),
-			{
-				initialProps: first,
-			}
+			{ initialProps: first }
 		);
+		const firstProps = result.current;
 
-		expect(result.current.activeSession).toBe(first);
-		expect(result.current.activeSession?.executionQueue?.[0]?.text).toBe('original');
+		rerender(makeSession({ executionQueue: [makeQueuedItem({ text: 'edited' })] }));
+		expect(result.current).toBe(firstProps);
+	});
 
-		// Simulate an in-place queue edit: same session id/tab, brand-new session
-		// object and a brand-new executionQueue array carrying the edited text.
-		const edited = makeSession([makeQueuedItem({ text: 'edited' })]);
-		rerender(edited);
+	it('recomputes when a tracked session field like activeTabId changes', () => {
+		const first = makeSession({ activeTabId: 't1' });
+		const { result, rerender } = renderHook(
+			(session: Session) => useMainPanelProps(makeDeps(session)),
+			{ initialProps: first }
+		);
+		const firstProps = result.current;
 
-		// Without executionQueue in the memo deps this would still be `first`.
-		expect(result.current.activeSession).toBe(edited);
-		expect(result.current.activeSession?.executionQueue?.[0]?.text).toBe('edited');
+		rerender(makeSession({ activeTabId: 't2' }));
+		expect(result.current).not.toBe(firstProps);
 	});
 
 	it('keeps the memoized props stable when nothing tracked changes', () => {
-		const session = makeSession([makeQueuedItem()]);
+		const session = makeSession();
 
 		const { result, rerender } = renderHook((s: Session) => useMainPanelProps(makeDeps(s)), {
 			initialProps: session,
 		});
 
 		const firstProps = result.current;
-		// Re-render with the exact same session reference: memo must not recompute.
 		rerender(session);
 		expect(result.current).toBe(firstProps);
 	});

--- a/src/__tests__/renderer/hooks/useBatchHandlers.test.ts
+++ b/src/__tests__/renderer/hooks/useBatchHandlers.test.ts
@@ -220,7 +220,7 @@ describe('useBatchHandlers', () => {
 			expect(result.current).toHaveProperty('handleSyncAutoRunStats');
 		});
 
-		it('calls useBatchProcessor with sessions and groups from stores', () => {
+		it('calls useBatchProcessor with groups from the store (sessions via getState)', () => {
 			const session = createMockSession();
 			useSessionStore.setState({
 				sessions: [session],
@@ -232,7 +232,7 @@ describe('useBatchHandlers', () => {
 
 			expect(useBatchProcessor).toHaveBeenCalled();
 			const callArgs = vi.mocked(useBatchProcessor).mock.calls[0][0];
-			expect(callArgs.sessions).toEqual([session]);
+			expect(callArgs.sessions).toBeUndefined();
 			expect(callArgs.groups).toEqual([{ id: 'g1', name: 'Group 1' }]);
 		});
 

--- a/src/__tests__/renderer/hooks/useBatchProcessor.test.ts
+++ b/src/__tests__/renderer/hooks/useBatchProcessor.test.ts
@@ -22,6 +22,7 @@ import type {
 // Import the exported functions directly
 import { countUnfinishedTasks, uncheckAllTasks, useBatchProcessor } from '../../../renderer/hooks';
 import { useBatchStore } from '../../../renderer/stores/batchStore';
+import { useSessionStore } from '../../../renderer/stores/sessionStore';
 import { useSettingsStore } from '../../../renderer/stores/settingsStore';
 import { createMockSession as baseCreateMockSession } from '../../helpers/mockSession';
 
@@ -702,9 +703,9 @@ describe('useBatchProcessor hook', () => {
 			const sessions = [createMockSession()];
 			const groups = [createMockGroup()];
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -724,9 +725,9 @@ describe('useBatchProcessor hook', () => {
 			const sessions = [createMockSession()];
 			const groups = [createMockGroup()];
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -762,9 +763,9 @@ describe('useBatchProcessor hook', () => {
 			const sessions = [createMockSession()];
 			const groups = [createMockGroup()];
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -784,9 +785,9 @@ describe('useBatchProcessor hook', () => {
 			const sessions = [createMockSession()];
 			const groups = [createMockGroup()];
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -807,9 +808,9 @@ describe('useBatchProcessor hook', () => {
 			];
 			const groups = [createMockGroup()];
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -834,9 +835,9 @@ describe('useBatchProcessor hook', () => {
 			const sessions = [createMockSession()];
 			const groups = [createMockGroup()];
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -855,9 +856,9 @@ describe('useBatchProcessor hook', () => {
 			const sessions = [createMockSession()];
 			const groups = [createMockGroup()];
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -885,9 +886,9 @@ describe('useBatchProcessor hook', () => {
 			];
 			const groups = [createMockGroup()];
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -911,9 +912,9 @@ describe('useBatchProcessor hook', () => {
 			const sessions = [createMockSession()];
 			const groups = [createMockGroup()];
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -944,9 +945,9 @@ describe('useBatchProcessor hook', () => {
 			const sessions: Session[] = [];
 			const groups: Group[] = [];
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -973,9 +974,9 @@ describe('useBatchProcessor hook', () => {
 			const sessions = [createMockSession()];
 			const groups = [createMockGroup()];
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -1005,9 +1006,9 @@ describe('useBatchProcessor hook', () => {
 			// Mock empty document with no tasks
 			mockReadDoc.mockResolvedValue({ success: true, content: '# Empty document\nNo tasks here.' });
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -1047,9 +1048,9 @@ describe('useBatchProcessor hook', () => {
 				}
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -1105,9 +1106,9 @@ describe('useBatchProcessor hook', () => {
 			// Mock agent failure
 			mockOnSpawnAgent.mockResolvedValue({ success: false });
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -1148,9 +1149,9 @@ describe('useBatchProcessor hook', () => {
 				return { success: true, content: '# Tasks\n- [x] Task 1' };
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -1187,9 +1188,9 @@ describe('useBatchProcessor hook', () => {
 			});
 			mockOnSpawnAgent.mockReturnValue(agentPromise);
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -1252,9 +1253,9 @@ describe('useBatchProcessor hook', () => {
 			});
 			mockOnSpawnAgent.mockReturnValue(agentPromise);
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -1338,9 +1339,9 @@ describe('useBatchProcessor hook', () => {
 			});
 			mockOnSpawnAgent.mockReturnValue(agentPromise);
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -1403,9 +1404,9 @@ describe('useBatchProcessor hook', () => {
 			});
 			mockOnSpawnAgent.mockReturnValue(agentPromise);
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -1472,9 +1473,9 @@ describe('useBatchProcessor hook', () => {
 				return { success: true, content: '- [x] Task' };
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -1516,9 +1517,9 @@ describe('useBatchProcessor hook', () => {
 			// Mock worktree setup failure
 			mockWorktreeSetup.mockResolvedValue({ success: false, error: 'Worktree setup failed' });
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -1563,9 +1564,9 @@ describe('useBatchProcessor hook', () => {
 				return { success: true, content: '- [x] Task' };
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -1613,9 +1614,9 @@ describe('useBatchProcessor hook', () => {
 				return { success: true, content: '- [x] Task' };
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -1667,9 +1668,9 @@ describe('useBatchProcessor hook', () => {
 				return { success: true, content: '- [x] Task' };
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -1717,9 +1718,9 @@ describe('useBatchProcessor hook', () => {
 				return { success: true, content: '- [x] Task' };
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -1786,9 +1787,9 @@ describe('useBatchProcessor hook', () => {
 				return { success: true, agentSessionId: `session-${spawnCount}` };
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -1837,9 +1838,9 @@ describe('useBatchProcessor hook', () => {
 				return { success: true, content: '- [x] Task 1' };
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -1884,9 +1885,9 @@ describe('useBatchProcessor hook', () => {
 				return { success: true, content: '- [x] Task' };
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -1926,9 +1927,9 @@ describe('useBatchProcessor hook', () => {
 				return { success: true, content: '- [x] Task' };
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -1967,9 +1968,9 @@ describe('useBatchProcessor hook', () => {
 				return { success: true, content: '- [x] Task' };
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -2012,9 +2013,9 @@ describe('useBatchProcessor hook', () => {
 				return { success: true, content: '- [x] Task' };
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -2073,9 +2074,9 @@ describe('useBatchProcessor hook', () => {
 				return { success: true, content: '- [x] Task' };
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -2131,9 +2132,9 @@ describe('useBatchProcessor hook', () => {
 				return { success: true, content: '- [x] Task' };
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -2184,9 +2185,9 @@ describe('useBatchProcessor hook', () => {
 				return { success: true, content: '- [x] Task' };
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -2240,9 +2241,9 @@ describe('useBatchProcessor hook', () => {
 				return { success: true, content: '- [x] Task' };
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -2297,9 +2298,9 @@ describe('useBatchProcessor hook', () => {
 				return { success: true, content: '- [x] Task' };
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -2354,9 +2355,9 @@ describe('useBatchProcessor hook', () => {
 				return { success: true, content: '- [x] Task' };
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -2395,9 +2396,9 @@ describe('useBatchProcessor hook', () => {
 				return { success: true, content: '- [x] Task' };
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -2437,9 +2438,9 @@ describe('useBatchProcessor hook', () => {
 				return { success: true, content: '- [x] Task for MySession' };
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -2480,9 +2481,9 @@ describe('useBatchProcessor hook', () => {
 				return { success: true, content: '- [x] Task' };
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -2523,9 +2524,9 @@ describe('useBatchProcessor hook', () => {
 				return { success: true, content: '- [x] Task' };
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -2563,9 +2564,9 @@ describe('useBatchProcessor hook', () => {
 				return { success: true, content: '- [x] Task' };
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -2601,9 +2602,9 @@ describe('useBatchProcessor hook', () => {
 				return { success: true, content: '- [x] Task' };
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -2641,9 +2642,9 @@ describe('useBatchProcessor hook', () => {
 				return { success: true, content: '- [x] Task' };
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -2706,9 +2707,9 @@ describe('useBatchProcessor hook', () => {
 				return { success: true, content: '' };
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -2750,9 +2751,9 @@ describe('useBatchProcessor hook', () => {
 				return { success: true, content: '' };
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -2803,9 +2804,9 @@ describe('useBatchProcessor hook', () => {
 				return { success: true, agentSessionId: 'session-2' };
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -2883,7 +2884,6 @@ describe('useBatchProcessor hook', () => {
 
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -2961,9 +2961,9 @@ describe('useBatchProcessor hook', () => {
 				throw new Error('Agent exited with error');
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -3050,7 +3050,6 @@ describe('useBatchProcessor hook', () => {
 
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -3147,7 +3146,6 @@ describe('useBatchProcessor hook', () => {
 
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -3231,9 +3229,9 @@ describe('useBatchProcessor hook', () => {
 				return { success: true, agentSessionId: 'session-1' };
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -3348,7 +3346,6 @@ describe('useBatchProcessor hook', () => {
 
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -3428,9 +3425,9 @@ describe('useBatchProcessor hook', () => {
 				return { success: true, agentSessionId: `claude-session-${spawnCount}` };
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -3478,9 +3475,9 @@ describe('useBatchProcessor hook', () => {
 			// Spawn succeeds but no claude session ID
 			mockOnSpawnAgent.mockResolvedValue({ success: true });
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -3532,9 +3529,9 @@ describe('useBatchProcessor hook', () => {
 				},
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -3586,9 +3583,9 @@ describe('useBatchProcessor hook', () => {
 				return { success: true, agentSessionId: 'test' };
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -3628,9 +3625,9 @@ describe('useBatchProcessor hook', () => {
 				return { success: true, content: '- [x] Task' };
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -3676,9 +3673,9 @@ describe('useBatchProcessor hook', () => {
 				return { success: true, content: '- [x] Task 1\n- [x] Task 2' };
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -3715,9 +3712,9 @@ describe('useBatchProcessor hook', () => {
 				return { success: true, content: '- [x] Task' };
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -3760,9 +3757,9 @@ describe('useBatchProcessor hook', () => {
 				return { success: true, content: '- [x] Task' };
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -3801,9 +3798,9 @@ describe('useBatchProcessor hook', () => {
 				return { success: true, content: '- [x] Task' };
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -3847,9 +3844,9 @@ describe('useBatchProcessor hook', () => {
 
 			mockOnSpawnAgent.mockResolvedValue({ success: true, agentSessionId: 'test' });
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -3894,9 +3891,9 @@ describe('useBatchProcessor hook', () => {
 
 			mockOnSpawnAgent.mockResolvedValue({ success: true, agentSessionId: 'test' });
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -3936,9 +3933,9 @@ describe('useBatchProcessor hook', () => {
 			});
 			window.maestro.git.worktreeSetup = mockWorktreeSetup;
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -3992,9 +3989,9 @@ describe('useBatchProcessor hook', () => {
 			});
 			window.maestro.git.worktreeCheckout = mockWorktreeCheckout;
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -4053,9 +4050,9 @@ describe('useBatchProcessor hook', () => {
 			});
 			window.maestro.git.worktreeCheckout = mockWorktreeCheckout;
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -4119,9 +4116,9 @@ describe('useBatchProcessor hook', () => {
 
 			const mockOnPRResult = vi.fn();
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -4189,9 +4186,9 @@ describe('useBatchProcessor hook', () => {
 
 			const mockOnPRResult = vi.fn();
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -4251,9 +4248,9 @@ describe('useBatchProcessor hook', () => {
 			});
 			window.maestro.git.createPR = mockCreatePR;
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -4321,9 +4318,9 @@ describe('useBatchProcessor hook', () => {
 			const mockSpeak = vi.fn().mockResolvedValue(undefined);
 			window.maestro.notification.speak = mockSpeak;
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -4369,9 +4366,9 @@ describe('useBatchProcessor hook', () => {
 
 			mockOnSpawnAgent.mockResolvedValue({ success: true, agentSessionId: 'test' });
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -4421,9 +4418,9 @@ describe('useBatchProcessor hook', () => {
 				agentSessionId: 'test-session',
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -4479,9 +4476,9 @@ describe('useBatchProcessor hook', () => {
 				agentSessionId: 'test-session',
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -4537,9 +4534,9 @@ describe('useBatchProcessor hook', () => {
 				agentSessionId: 'test-session',
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -4602,9 +4599,9 @@ describe('useBatchProcessor hook', () => {
 				response: '**Summary:** Fixed it\n\n**Details:** Done.',
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -4647,9 +4644,9 @@ describe('useBatchProcessor hook', () => {
 				agentSessionId: 'test-session',
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -4692,9 +4689,9 @@ describe('useBatchProcessor hook', () => {
 				agentSessionId: 'test-session',
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -4737,9 +4734,9 @@ describe('useBatchProcessor hook', () => {
 				agentSessionId: 'test-session',
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -4781,9 +4778,9 @@ describe('useBatchProcessor hook', () => {
 
 			mockReadDoc.mockResolvedValue({ success: true, content: '- [ ] Task' });
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -4827,9 +4824,9 @@ describe('useBatchProcessor hook', () => {
 
 			mockReadDoc.mockResolvedValue({ success: true, content: '- [ ] Task' });
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -4868,9 +4865,9 @@ describe('useBatchProcessor hook', () => {
 
 			mockReadDoc.mockResolvedValue({ success: true, content: '- [ ] Task' });
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -4922,9 +4919,9 @@ describe('useBatchProcessor hook', () => {
 				agentSessionId: 'test-session',
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -4986,9 +4983,9 @@ describe('useBatchProcessor hook', () => {
 				agentSessionId: 'test-session',
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -5045,9 +5042,9 @@ describe('useBatchProcessor hook', () => {
 				agentSessionId: 'test-session',
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -5092,9 +5089,9 @@ describe('useBatchProcessor hook', () => {
 				agentSessionId: 'test-session',
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -5140,9 +5137,9 @@ describe('useBatchProcessor hook', () => {
 				agentSessionId: 'new-claude-session-123',
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -5189,9 +5186,9 @@ describe('useBatchProcessor hook', () => {
 				agentSessionId: 'test-session',
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -5225,9 +5222,9 @@ describe('useBatchProcessor hook', () => {
 			// Document read fails (no content)
 			mockReadDoc.mockResolvedValue({ success: true, content: '' });
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -5258,9 +5255,9 @@ describe('useBatchProcessor hook', () => {
 
 			mockReadDoc.mockResolvedValue({ success: false });
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -5306,9 +5303,9 @@ describe('useBatchProcessor hook', () => {
 				agentSessionId: 'test-session',
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -5361,9 +5358,9 @@ describe('useBatchProcessor hook', () => {
 				response: '**Summary:** Done',
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -5411,9 +5408,9 @@ describe('useBatchProcessor hook', () => {
 				agentSessionId: 'test-session',
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -5468,9 +5465,9 @@ describe('useBatchProcessor hook', () => {
 
 			mockReadDoc.mockResolvedValue({ success: true, content: '- [x] Completed' });
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -5518,9 +5515,9 @@ describe('useBatchProcessor hook', () => {
 				return { success: true, content: '- [x] Task' };
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -5565,9 +5562,9 @@ describe('useBatchProcessor hook', () => {
 
 			mockReadDoc.mockResolvedValue({ success: true, content: '- [x] Completed' });
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -5614,9 +5611,9 @@ describe('useBatchProcessor hook', () => {
 				return { success: true, content: '- [x] Task' };
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -5663,9 +5660,9 @@ describe('useBatchProcessor hook', () => {
 
 			mockReadDoc.mockResolvedValue({ success: true, content: '- [x] Completed' });
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -5710,9 +5707,9 @@ describe('useBatchProcessor hook', () => {
 
 			mockReadDoc.mockResolvedValue({ success: true, content: '- [x] Done' });
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -5781,9 +5778,9 @@ describe('useBatchProcessor hook', () => {
 				prUrl: 'https://github.com/test/repo/pull/42',
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -5863,9 +5860,9 @@ describe('useBatchProcessor hook', () => {
 
 			mockGetDefaultBranch.mockResolvedValue({ success: true, branch: 'main' });
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -5929,9 +5926,9 @@ describe('useBatchProcessor hook', () => {
 				return { success: true, content: '- [x] Task' };
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -5985,9 +5982,9 @@ describe('useBatchProcessor hook', () => {
 				return { success: true, content: '- [x] Task' };
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -6047,9 +6044,9 @@ describe('useBatchProcessor hook', () => {
 				return { success: true, content: '- [x] Task' };
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -6111,9 +6108,9 @@ describe('useBatchProcessor hook', () => {
 				return { success: true, content: '- [x] Task 1\n- [x] Task 2' };
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -6186,9 +6183,9 @@ describe('useBatchProcessor hook', () => {
 				prUrl: 'https://github.com/test/repo/pull/99',
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,
@@ -6272,9 +6269,9 @@ describe('useBatchProcessor hook', () => {
 				error: 'gh: not authenticated',
 			});
 
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
 			const { result } = renderHook(() =>
 				useBatchProcessor({
-					sessions,
 					groups,
 					onUpdateSession: mockOnUpdateSession,
 					onSpawnAgent: mockOnSpawnAgent,

--- a/src/__tests__/renderer/hooks/useFileTreeManagement.test.ts
+++ b/src/__tests__/renderer/hooks/useFileTreeManagement.test.ts
@@ -783,4 +783,40 @@ describe('useFileTreeManagement', () => {
 			window.maestro.fs = originalFs;
 		}
 	});
+
+	it('repaints filteredFileTree when store fileTree refreshes without an injected activeSession', () => {
+		const initialTree: FileNode[] = [{ name: 'old.txt', type: 'file' }];
+		const nextTree: FileNode[] = [{ name: 'new.txt', type: 'file' }];
+		const session = createMockSession({ fileTree: initialTree });
+
+		useSessionStore.setState({
+			sessions: [session],
+			activeSessionId: session.id,
+			sessionsLoaded: true,
+		});
+
+		const state = createSessionsState([session]);
+		const { result } = renderHook(() =>
+			useFileTreeManagement({
+				sessionsRef: state.sessionsRef,
+				setSessions: state.setSessions,
+				activeSessionId: session.id,
+				// Omit activeSession: exercise the self-sourced store path.
+				rightPanelRef: {
+					current: { refreshHistoryPanel: vi.fn() },
+				} as RefObject<RightPanelHandle | null>,
+			})
+		);
+
+		expect(result.current.filteredFileTree).toEqual(initialTree);
+
+		act(() => {
+			useSessionStore.setState({
+				sessions: [{ ...session, fileTree: nextTree }],
+				activeSessionId: session.id,
+			});
+		});
+
+		expect(result.current.filteredFileTree).toEqual(nextTree);
+	});
 });

--- a/src/__tests__/renderer/hooks/useInputHandlers.test.ts
+++ b/src/__tests__/renderer/hooks/useInputHandlers.test.ts
@@ -294,6 +294,7 @@ describe('useInputHandlers', () => {
 			expect(result.current).toHaveProperty('processInput');
 			expect(result.current).toHaveProperty('processInputRef');
 			expect(result.current).toHaveProperty('handleInputKeyDown');
+			expect(result.current).toHaveProperty('handleMainPanelInputFocus');
 			expect(result.current).toHaveProperty('handleMainPanelInputBlur');
 			expect(result.current).toHaveProperty('handleReplayMessage');
 			expect(result.current).toHaveProperty('handlePaste');
@@ -1248,6 +1249,7 @@ describe('useInputHandlers', () => {
 
 			const firstRender = {
 				handleInputKeyDown: result.current.handleInputKeyDown,
+				handleMainPanelInputFocus: result.current.handleMainPanelInputFocus,
 				handleMainPanelInputBlur: result.current.handleMainPanelInputBlur,
 				handleReplayMessage: result.current.handleReplayMessage,
 				syncFileTreeToTabCompletion: result.current.syncFileTreeToTabCompletion,
@@ -1256,6 +1258,7 @@ describe('useInputHandlers', () => {
 			rerender();
 
 			expect(result.current.handleInputKeyDown).toBe(firstRender.handleInputKeyDown);
+			expect(result.current.handleMainPanelInputFocus).toBe(firstRender.handleMainPanelInputFocus);
 			expect(result.current.handleMainPanelInputBlur).toBe(firstRender.handleMainPanelInputBlur);
 			expect(result.current.handleReplayMessage).toBe(firstRender.handleReplayMessage);
 			expect(result.current.syncFileTreeToTabCompletion).toBe(
@@ -2271,7 +2274,10 @@ describe('useInputHandlers', () => {
 
 			// Draft should be restored after replay
 			expect(inputVal()).toBe('my draft message');
-			expect(mockProcessInput).toHaveBeenCalledWith('replayed message');
+			expect(mockProcessInput).toHaveBeenCalledWith('replayed message', {
+				sessionId: 'session-1',
+				tabId: 'tab-1',
+			});
 
 			// Clean up mock
 			mockProcessInput.mockReset();

--- a/src/__tests__/renderer/hooks/useInputProcessing.test.ts
+++ b/src/__tests__/renderer/hooks/useInputProcessing.test.ts
@@ -225,7 +225,10 @@ describe('useInputProcessing', () => {
 			expect(mockOnWizardCommand).toHaveBeenCalledWith('');
 			expect(mockSetInputValue).toHaveBeenCalledWith('');
 			expect(mockSetSlashCommandOpen).toHaveBeenCalledWith(false);
-			expect(mockSyncAiInputToSession).toHaveBeenCalledWith('');
+			expect(mockSyncAiInputToSession).toHaveBeenCalledWith('', {
+				sessionId: 'session-1',
+				tabId: 'tab-1',
+			});
 		});
 
 		it('intercepts /wizard with arguments and passes them to handler', async () => {
@@ -350,7 +353,10 @@ describe('useInputProcessing', () => {
 			// Should clear input
 			expect(mockSetInputValue).toHaveBeenCalledWith('');
 			expect(mockSetSlashCommandOpen).toHaveBeenCalledWith(false);
-			expect(mockSyncAiInputToSession).toHaveBeenCalledWith('');
+			expect(mockSyncAiInputToSession).toHaveBeenCalledWith('', {
+				sessionId: 'session-1',
+				tabId: 'tab-1',
+			});
 			vi.useRealTimers();
 		});
 

--- a/src/__tests__/renderer/hooks/useInterruptHandler.test.ts
+++ b/src/__tests__/renderer/hooks/useInterruptHandler.test.ts
@@ -357,8 +357,8 @@ describe('useInterruptHandler', () => {
 			});
 
 			const sessions = useSessionStore.getState().sessions;
-			expect(sessions[0].state).toBe('idle'); // active — interrupted
-			expect(sessions[1].state).toBe('busy'); // other — unchanged
+			expect(sessions[0].state).toBe('idle'); // active - interrupted
+			expect(sessions[1].state).toBe('busy'); // other - unchanged
 		});
 	});
 

--- a/src/__tests__/renderer/stores/sessionEquality.test.ts
+++ b/src/__tests__/renderer/stores/sessionEquality.test.ts
@@ -15,7 +15,10 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { sidebarSessionEquality } from '../../../renderer/stores/sessionEquality';
+import {
+	sidebarSessionEquality,
+	activeSessionChromeEquality,
+} from '../../../renderer/stores/sessionEquality';
 import { createMockSession } from '../../helpers/mockSession';
 import type { AITab, Session } from '../../../renderer/types';
 
@@ -142,5 +145,39 @@ describe('sidebarSessionEquality', () => {
 		const a = [createMockSession({ id: 'a', aiTabs: [tab({ id: 't1' })] })];
 		const b = [createMockSession({ id: 'a', aiTabs: [tab({ id: 't1' }), tab({ id: 't2' })] })];
 		expect(sidebarSessionEquality(a, b)).toBe(false);
+	});
+});
+
+describe('activeSessionChromeEquality', () => {
+	it('returns false when isGeneratingName flips', () => {
+		const a = createMockSession({ aiTabs: [tab({ id: 't1', isGeneratingName: false })] });
+		const b = createMockSession({ aiTabs: [tab({ id: 't1', isGeneratingName: true })] });
+		expect(activeSessionChromeEquality(a, b)).toBe(false);
+	});
+
+	it('returns false when browser customTitle changes', () => {
+		const a = createMockSession({
+			browserTabs: [{ id: 'b1', title: 'Docs', url: 'https://x', customTitle: undefined } as any],
+		});
+		const b = createMockSession({
+			browserTabs: [{ id: 'b1', title: 'Docs', url: 'https://x', customTitle: 'Pinned' } as any],
+		});
+		expect(activeSessionChromeEquality(a, b)).toBe(false);
+	});
+
+	it('returns true when only logs change', () => {
+		const a = createMockSession({
+			aiTabs: [tab({ id: 't1', logs: [] })],
+		});
+		const b: Session = {
+			...a,
+			aiTabs: [
+				{
+					...a.aiTabs[0],
+					logs: [{ id: 'log-1', timestamp: 0, source: 'stdout', text: 'streamed' }],
+				},
+			],
+		};
+		expect(activeSessionChromeEquality(a, b)).toBe(true);
 	});
 });

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1732,6 +1732,7 @@ function MaestroConsoleInner() {
 		processInput,
 		processInputRef,
 		handleInputKeyDown,
+		handleMainPanelInputFocus,
 		handleMainPanelInputBlur,
 		handleReplayMessage,
 		handlePaste,
@@ -2770,6 +2771,7 @@ function MaestroConsoleInner() {
 		handleScrollPositionChange,
 		handleAtBottomChange,
 		handleMainPanelInputBlur,
+		handleMainPanelInputFocus,
 		handleOpenPromptComposer,
 		handleReplayMessage,
 		handleForkConversation,
@@ -3304,14 +3306,15 @@ function MaestroConsoleInner() {
 					onOpenCreatePR={handleQuickActionsOpenCreatePR}
 					onSummarizeAndContinue={handleQuickActionsSummarizeAndContinue}
 					onRunPromptMacro={handleRunPromptMacro}
-					canSummarizeActiveTab={
-						activeSession
-							? canSummarize(
-									activeSession.contextUsage,
-									activeSession.aiTabs.find((t) => t.id === activeSession.activeTabId)?.logs
-								)
-							: false
-					}
+					canSummarizeActiveTab={(() => {
+						// Fresh snapshot: chrome equality ignores contextUsage / logs.
+						const session = selectActiveSession(useSessionStore.getState());
+						if (!session) return false;
+						return canSummarize(
+							session.contextUsage,
+							session.aiTabs.find((t) => t.id === session.activeTabId)?.logs
+						);
+					})()}
 					onToggleRemoteControl={handleQuickActionsToggleRemoteControl}
 					autoRunSelectedDocument={activeSession?.autoRunSelectedFile ?? null}
 					autoRunCompletedTaskCount={rightPanelRef.current?.getAutoRunCompletedTaskCount() ?? 0}

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1385,6 +1385,14 @@ function MaestroConsoleInner() {
 		handleSummarizeAndContinue,
 	} = useSummarizeAndContinue(activeSession ?? null);
 
+	// Fresh store snapshot - chrome equality ignores contextUsage / logs.
+	const computeCanSummarizeActiveTab = () => {
+		const session = selectActiveSession(useSessionStore.getState());
+		if (!session?.activeTabId) return false;
+		const tab = session.aiTabs.find((t) => t.id === session.activeTabId);
+		return canSummarize(session.contextUsage, tab?.logs);
+	};
+
 	// Combine custom AI commands with bundled methodology commands for input processing.
 	const allCustomCommands = useMemo((): CustomAICommand[] => {
 		const speckitAsCustom: CustomAICommand[] = speckitCommands.map((cmd) => ({
@@ -2216,7 +2224,8 @@ function MaestroConsoleInner() {
 			sessionsRef,
 			setSessions,
 			activeSessionId,
-			activeSession,
+			// PERF: Omit activeSession - hook self-sources fileTree. Chrome equality
+			// deliberately excludes fileTree; passing that slice would stale the panel.
 			rightPanelRef,
 			sshRemoteIgnorePatterns: settings.sshRemoteIgnorePatterns,
 			sshRemoteHonorGitignore: settings.sshRemoteHonorGitignore,
@@ -2512,10 +2521,7 @@ function MaestroConsoleInner() {
 		setSendToAgentModalOpen,
 		// Summarize and continue (getter: evaluated lazily only when shortcut fires)
 		get canSummarizeActiveTab() {
-			const session = selectActiveSession(useSessionStore.getState());
-			if (!session?.activeTabId) return false;
-			const tab = session.aiTabs.find((t) => t.id === session.activeTabId);
-			return canSummarize(session.contextUsage, tab?.logs);
+			return computeCanSummarizeActiveTab();
 		},
 		summarizeAndContinue: handleSummarizeAndContinue,
 
@@ -3306,15 +3312,7 @@ function MaestroConsoleInner() {
 					onOpenCreatePR={handleQuickActionsOpenCreatePR}
 					onSummarizeAndContinue={handleQuickActionsSummarizeAndContinue}
 					onRunPromptMacro={handleRunPromptMacro}
-					canSummarizeActiveTab={(() => {
-						// Fresh snapshot: chrome equality ignores contextUsage / logs.
-						const session = selectActiveSession(useSessionStore.getState());
-						if (!session) return false;
-						return canSummarize(
-							session.contextUsage,
-							session.aiTabs.find((t) => t.id === session.activeTabId)?.logs
-						);
-					})()}
+					canSummarizeActiveTab={computeCanSummarizeActiveTab()}
 					onToggleRemoteControl={handleQuickActionsToggleRemoteControl}
 					autoRunSelectedDocument={activeSession?.autoRunSelectedFile ?? null}
 					autoRunCompletedTaskCount={rightPanelRef.current?.getAutoRunCompletedTaskCount() ?? 0}

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -166,8 +166,8 @@ import {
 	sidebarSessionEquality,
 	gitPollSessionEquality,
 	projectRootSessionEquality,
+	activeSessionChromeEquality,
 } from './stores/sessionEquality';
-import { useActiveSession } from './hooks/session/useActiveSession';
 import { usePianolaAgent } from './hooks/session/usePianolaAgent';
 // useAgentStore moved to useQueueProcessing hook
 import { InlineWizardProvider, useInlineWizardContext } from './contexts/InlineWizardContext';
@@ -534,7 +534,14 @@ function MaestroConsoleInner() {
 	// to show a loading spinner instead of flashing the empty "create your first
 	// agent" state while sessions stream in over the WebSocket bridge.
 	const sessionsLoaded = useSessionStore((s) => s.sessionsLoaded);
-	const activeSession = useActiveSession();
+	// PERF: Chrome equality ignores logs/tokens/contextUsage. Streaming must not
+	// re-render MaestroConsoleInner. MainPanel self-sources the full Session for
+	// live chat; App keeps this slice only for shell chrome / prop assembly.
+	const activeSession = useStoreWithEqualityFn(
+		useSessionStore,
+		selectActiveSession,
+		activeSessionChromeEquality
+	);
 
 	// Actions — stable references from store, never trigger re-renders
 	const {
@@ -2504,9 +2511,10 @@ function MaestroConsoleInner() {
 		setSendToAgentModalOpen,
 		// Summarize and continue (getter: evaluated lazily only when shortcut fires)
 		get canSummarizeActiveTab() {
-			if (!activeSession || !activeSession.activeTabId) return false;
-			const activeTab = activeSession.aiTabs.find((t) => t.id === activeSession.activeTabId);
-			return canSummarize(activeSession.contextUsage, activeTab?.logs);
+			const session = selectActiveSession(useSessionStore.getState());
+			if (!session?.activeTabId) return false;
+			const tab = session.aiTabs.find((t) => t.id === session.activeTabId);
+			return canSummarize(session.contextUsage, tab?.logs);
 		},
 		summarizeAndContinue: handleSummarizeAndContinue,
 

--- a/src/renderer/components/MainPanel/MainPanel.tsx
+++ b/src/renderer/components/MainPanel/MainPanel.tsx
@@ -858,11 +858,12 @@ export const MainPanel = React.memo(
 		// Handler for input focus - select session in sidebar
 		// Memoized to avoid recreating on every render
 		const handleInputFocus = useCallback(() => {
+			props.onComposerFocus?.();
 			if (activeSession) {
 				setActiveSessionId(activeSession.id);
 				useUIStore.getState().setActiveFocus('main');
 			}
-		}, [activeSession, setActiveSessionId]);
+		}, [activeSession, setActiveSessionId, props.onComposerFocus]);
 
 		// Memoized session click handler for InputArea's ThinkingStatusPill
 		// Avoids creating new function reference on every render

--- a/src/renderer/components/MainPanel/MainPanel.tsx
+++ b/src/renderer/components/MainPanel/MainPanel.tsx
@@ -78,8 +78,6 @@ export const MainPanel = React.memo(
 	forwardRef<MainPanelHandle, MainPanelProps>(function MainPanel(props, ref) {
 		// PERF: Self-source the full active Session so streaming log/token updates
 		// re-render MainPanel without requiring MaestroConsoleInner to re-render.
-		// App may still pass `activeSession` (chrome-equality slice) for prop-memo
-		// deps; ignore it for paint.
 		const activeSession = useSessionStore(selectActiveSession);
 
 		const {
@@ -87,7 +85,6 @@ export const MainPanel = React.memo(
 			agentSessionsOpen,
 			memoryViewerOpen,
 			activeAgentSessionId,
-			activeSession: _activeSessionFromApp,
 			theme,
 			stagedImages,
 			commandHistoryOpen,

--- a/src/renderer/components/MainPanel/MainPanel.tsx
+++ b/src/renderer/components/MainPanel/MainPanel.tsx
@@ -76,12 +76,18 @@ function EmptyMainPanel({ theme }: { theme: Theme }) {
 // due to input value changes. The component will only re-render when its props actually change.
 export const MainPanel = React.memo(
 	forwardRef<MainPanelHandle, MainPanelProps>(function MainPanel(props, ref) {
+		// PERF: Self-source the full active Session so streaming log/token updates
+		// re-render MainPanel without requiring MaestroConsoleInner to re-render.
+		// App may still pass `activeSession` (chrome-equality slice) for prop-memo
+		// deps; ignore it for paint.
+		const activeSession = useSessionStore(selectActiveSession);
+
 		const {
 			logViewerOpen,
 			agentSessionsOpen,
 			memoryViewerOpen,
 			activeAgentSessionId,
-			activeSession,
+			activeSession: _activeSessionFromApp,
 			theme,
 			stagedImages,
 			commandHistoryOpen,

--- a/src/renderer/components/MainPanel/types.ts
+++ b/src/renderer/components/MainPanel/types.ts
@@ -226,6 +226,8 @@ export interface MainPanelProps {
 	onAtBottomChange?: (isAtBottom: boolean) => void;
 	// Input blur handler for persisting AI input state
 	onInputBlur?: () => void;
+	/** Capture composer owner on focus so blur can pin the write target */
+	onComposerFocus?: () => void;
 	// Prompt composer modal
 	onOpenPromptComposer?: () => void;
 	// Replay a user message (AI mode)

--- a/src/renderer/components/MainPanel/types.ts
+++ b/src/renderer/components/MainPanel/types.ts
@@ -60,7 +60,6 @@ export interface MainPanelProps {
 	agentSessionsOpen: boolean;
 	memoryViewerOpen: boolean;
 	activeAgentSessionId: string | null;
-	activeSession: Session | null;
 	theme: Theme;
 	isMobileLandscape?: boolean;
 	stagedImages: string[];

--- a/src/renderer/hooks/agent/useInterruptHandler.ts
+++ b/src/renderer/hooks/agent/useInterruptHandler.ts
@@ -1,5 +1,5 @@
 /**
- * useInterruptHandler — extracted from App.tsx
+ * useInterruptHandler - extracted from App.tsx
  *
  * Handles interrupting/stopping running AI processes:
  *   - Sends SIGINT to active process (AI or terminal mode)
@@ -8,10 +8,14 @@
  *   - Processes execution queue after interruption
  *   - Falls back to force-kill if graceful interrupt fails
  *
- * Reads from: sessionStore (activeSession, sessions)
+ * PERF: Reads activeSession via getState() at interrupt time so App does not
+ * re-render when the active session / session list changes. Non-store deps are
+ * kept in a ref so handleInterrupt keeps a stable identity.
+ *
+ * Reads from: sessionStore (activeSession, sessions) at event time
  */
 
-import { useCallback } from 'react';
+import { useCallback, useRef } from 'react';
 import type { Session, LogEntry, QueuedItem, SessionState } from '../../types';
 import { useSessionStore, selectActiveSession } from '../../stores/sessionStore';
 import { generateId } from '../../utils/ids';
@@ -50,19 +54,18 @@ export interface UseInterruptHandlerReturn {
 // ============================================================================
 
 export function useInterruptHandler(deps: UseInterruptHandlerDeps): UseInterruptHandlerReturn {
-	const { sessionsRef, cancelPendingSynopsis, processQueuedItem } = deps;
-
-	// --- Reactive subscriptions ---
-	const activeSession = useSessionStore(selectActiveSession);
-
-	// --- Store actions (stable via getState) ---
-	const { setSessions } = useSessionStore.getState();
+	const depsRef = useRef(deps);
+	depsRef.current = deps;
 
 	// ========================================================================
-	// handleInterrupt — interrupt the active process
+	// handleInterrupt - interrupt the active process
 	// ========================================================================
 	const handleInterrupt = useCallback(async () => {
+		const activeSession = selectActiveSession(useSessionStore.getState());
 		if (!activeSession) return;
+
+		const { sessionsRef, cancelPendingSynopsis, processQueuedItem } = depsRef.current;
+		const { setSessions } = useSessionStore.getState();
 
 		const currentMode = activeSession.inputMode;
 		const activeTab = getActiveTab(activeSession);
@@ -99,7 +102,7 @@ export function useInterruptHandler(deps: UseInterruptHandlerDeps): UseInterrupt
 						interruptPromises.push((window as any).maestro.process.interrupt(fp.sessionId));
 					}
 				} catch {
-					// Non-critical — forced parallel lookup failure shouldn't block interrupt
+					// Non-critical - forced parallel lookup failure shouldn't block interrupt
 				}
 			}
 
@@ -499,7 +502,7 @@ export function useInterruptHandler(deps: UseInterruptHandlerDeps): UseInterrupt
 				}
 			}
 		}
-	}, [activeSession, setSessions, cancelPendingSynopsis, sessionsRef, processQueuedItem]);
+	}, []);
 
 	return { handleInterrupt };
 }

--- a/src/renderer/hooks/agent/useSessionRecovery.ts
+++ b/src/renderer/hooks/agent/useSessionRecovery.ts
@@ -35,7 +35,10 @@ export interface StartRecoveryOptions {
 
 export interface UseSessionRecoveryDeps {
 	processInputRef: React.MutableRefObject<
-		(text?: string, options?: { forceParallel?: boolean; images?: string[] }) => void
+		(
+			text?: string,
+			options?: { forceParallel?: boolean; images?: string[]; sessionId?: string; tabId?: string }
+		) => void
 	>;
 }
 
@@ -135,7 +138,9 @@ ${conversationText}
 				// Defer one tick so the store update flushes before processInput reads it.
 				await new Promise((resolve) => setTimeout(resolve, 0));
 
-				deps.processInputRef.current(lastUserPrompt);
+				// Pin session/tab from recovery start - the user may have switched focus
+				// during grooming.
+				deps.processInputRef.current(lastUserPrompt, { sessionId, tabId });
 			} catch (err) {
 				const message = err instanceof Error ? err.message : 'Unknown recovery error';
 				setRecoveryError(message);

--- a/src/renderer/hooks/batch/internal/useBatchRunner.ts
+++ b/src/renderer/hooks/batch/internal/useBatchRunner.ts
@@ -58,7 +58,7 @@ type SpawnAgentFn = (
 
 export interface UseBatchRunnerDeps {
 	// Refs
-	sessionsRef: MutableRefObject<Session[]>;
+	getSessions: () => Session[];
 	audioFeedbackEnabledRef: MutableRefObject<boolean | undefined>;
 	audioFeedbackCommandRef: MutableRefObject<string | undefined>;
 	autoRunFlushStateRefs: AutoRunFlushStateRefs;
@@ -106,7 +106,7 @@ export interface UseBatchRunnerReturn {
  * remains a ref so the long-running async loop survives HMR re-renders.
  */
 export function useBatchRunner({
-	sessionsRef,
+	getSessions,
 	audioFeedbackEnabledRef,
 	audioFeedbackCommandRef,
 	autoRunFlushStateRefs,
@@ -163,10 +163,9 @@ export function useBatchRunner({
 				worktreeEnabled: config.worktree?.enabled,
 			});
 
-			// Use sessionsRef first, then fall back to Zustand store for sessions just created
-			// (sessionsRef updates on React re-render, but Zustand store updates synchronously)
+			// Prefer getSessions(), then the store for just-created sessions.
 			const session =
-				sessionsRef.current.find((s) => s.id === sessionId) ||
+				getSessions().find((s) => s.id === sessionId) ||
 				selectSessionById(sessionId)(useSessionStore.getState());
 			if (!session) {
 				const worktreeInfo = config.worktreeTarget
@@ -185,7 +184,7 @@ export function useBatchRunner({
 					{
 						sessionId,
 						worktreeTargetMode: config.worktreeTarget?.mode,
-						availableSessionIds: sessionsRef.current.map((s) => s.id),
+						availableSessionIds: getSessions().map((s) => s.id),
 					}
 				);
 				return;
@@ -768,7 +767,7 @@ export function useBatchRunner({
 							readDocAndCountTasks,
 							updateBatchState: (sid, updater, immediate) =>
 								updateBatchStateAndBroadcastRef.current!(sid, updater, immediate),
-							getSessions: () => sessionsRef.current,
+							getSessions,
 							onUpdateSession,
 						});
 						await progressPoll.start();
@@ -1394,7 +1393,7 @@ export function useBatchRunner({
 			) {
 				// For worktree-dispatched runs, the main repo is the parent session's cwd
 				const mainRepoCwd = config.worktreeTarget
-					? sessionsRef.current.find((s) => s.id === session.parentSessionId)?.cwd || session.cwd
+					? getSessions().find((s) => s.id === session.parentSessionId)?.cwd || session.cwd
 					: session.cwd;
 
 				const prResult = await worktreeManager.createPR({
@@ -1599,7 +1598,7 @@ export function useBatchRunner({
 			onUpdateSession,
 			pauseBatchOnError,
 			readDocAndCountTasks,
-			sessionsRef,
+			getSessions,
 			stopRequestedRefs,
 			timeTracking,
 			updateBatchStateAndBroadcastRef,

--- a/src/renderer/hooks/batch/internal/useGoalRunner.ts
+++ b/src/renderer/hooks/batch/internal/useGoalRunner.ts
@@ -99,7 +99,7 @@ type SpawnBackgroundSynopsisFn = (
 
 export interface UseGoalRunnerDeps {
 	// Refs (shared with useBatchRunner so lifecycle behavior stays consistent)
-	sessionsRef: MutableRefObject<Session[]>;
+	getSessions: () => Session[];
 	audioFeedbackEnabledRef: MutableRefObject<boolean | undefined>;
 	audioFeedbackCommandRef: MutableRefObject<string | undefined>;
 	autoRunFlushStateRefs: AutoRunFlushStateRefs;
@@ -194,7 +194,7 @@ function exitReasonLabel(reason: GoalExitReason): string {
  * completion / deadlock / max-iterations / stall / user-stop.
  */
 export function useGoalRunner({
-	sessionsRef,
+	getSessions,
 	audioFeedbackEnabledRef,
 	audioFeedbackCommandRef,
 	autoRunFlushStateRefs,
@@ -240,14 +240,14 @@ export function useGoalRunner({
 				return;
 			}
 
-			// Resolve the session (sessionsRef first, then the store for just-created sessions).
+			// Prefer getSessions(), then the store for just-created sessions.
 			const session =
-				sessionsRef.current.find((s) => s.id === sessionId) ||
+				getSessions().find((s) => s.id === sessionId) ||
 				selectSessionById(sessionId)(useSessionStore.getState());
 			if (!session) {
 				window.maestro.logger.log('error', 'Session not found for goal run', 'GoalRunner', {
 					sessionId,
-					availableSessionIds: sessionsRef.current.map((s) => s.id),
+					availableSessionIds: getSessions().map((s) => s.id),
 				});
 				return;
 			}
@@ -877,7 +877,7 @@ export function useGoalRunner({
 			onProcessQueueAfterCompletion,
 			onSpawnAgent,
 			spawnBackgroundSynopsis,
-			sessionsRef,
+			getSessions,
 			stopRequestedRefs,
 			timeTracking,
 			updateBatchStateAndBroadcastRef,

--- a/src/renderer/hooks/batch/useBatchHandlers.ts
+++ b/src/renderer/hooks/batch/useBatchHandlers.ts
@@ -9,6 +9,9 @@
  *   - Owning the quit confirmation effect (prevents quit during active runs)
  *   - Providing handleSyncAutoRunStats for leaderboard server sync
  *
+ * PERF: Does not subscribe to full sessions / active Session. Streaming session
+ * updates must not re-render App via this hook.
+ *
  * Reads from: sessionStore, settingsStore, modalStore
  */
 
@@ -162,7 +165,6 @@ export interface UseBatchHandlersReturn {
 // Selectors
 // ============================================================================
 
-const selectSessions = (s: ReturnType<typeof useSessionStore.getState>) => s.sessions;
 const selectGroups = (s: ReturnType<typeof useSessionStore.getState>) => s.groups;
 const selectAudioFeedbackEnabled = (s: ReturnType<typeof useSettingsStore.getState>) =>
 	s.audioFeedbackEnabled;
@@ -183,10 +185,11 @@ export function useBatchHandlers(deps: UseBatchHandlersDeps): UseBatchHandlersRe
 		handleClearAgentError,
 	} = deps;
 
-	// --- Store subscriptions (reactive) ---
-	const sessions = useSessionStore(selectSessions);
+	// PERF: Do not subscribe to full `sessions` / active Session. Streaming would
+	// re-render App. useBatchProcessor reads sessions via getState(); handlers
+	// resolve the active agent with a primitive id selector.
 	const groups = useSessionStore(selectGroups);
-	const activeSession = useSessionStore(selectActiveSession);
+	const activeSessionId = useSessionStore((s) => s.activeSessionId);
 	const audioFeedbackEnabled = useSettingsStore(selectAudioFeedbackEnabled);
 	const audioFeedbackCommand = useSettingsStore(selectAudioFeedbackCommand);
 	const autoRunStats = useSettingsStore(selectAutoRunStats);
@@ -220,7 +223,6 @@ export function useBatchHandlers(deps: UseBatchHandlersDeps): UseBatchHandlersRe
 		resumeAfterError,
 		abortBatchOnError,
 	} = useBatchProcessor({
-		sessions,
 		groups,
 		onUpdateSession: (sessionId, updates) => {
 			useSessionStore
@@ -663,8 +665,8 @@ export function useBatchHandlers(deps: UseBatchHandlersDeps): UseBatchHandlersRe
 
 	// Batch state for the current session - used for locking the AutoRun editor
 	const currentSessionBatchState = useMemo(() => {
-		return activeSession ? getBatchState(activeSession.id) : null;
-	}, [activeSession, getBatchState]);
+		return activeSessionId ? getBatchState(activeSessionId) : null;
+	}, [activeSessionId, getBatchState]);
 
 	// Display batch state - prioritize session with active batch run,
 	// falling back to active session's state
@@ -672,8 +674,8 @@ export function useBatchHandlers(deps: UseBatchHandlersDeps): UseBatchHandlersRe
 		if (activeBatchSessionIds.length > 0) {
 			return getBatchState(activeBatchSessionIds[0]);
 		}
-		return activeSession ? getBatchState(activeSession.id) : getBatchState('');
-	}, [activeBatchSessionIds, activeSession, getBatchState]);
+		return activeSessionId ? getBatchState(activeSessionId) : getBatchState('');
+	}, [activeBatchSessionIds, activeSessionId, getBatchState]);
 
 	// ====================================================================
 	// Handler callbacks
@@ -681,9 +683,10 @@ export function useBatchHandlers(deps: UseBatchHandlersDeps): UseBatchHandlersRe
 
 	const handleStopBatchRun = useCallback(
 		(targetSessionId?: string) => {
+			// Treat empty activeSessionId as unset (same as former activeSession?.id).
 			const sessionId =
 				targetSessionId ??
-				activeSession?.id ??
+				(activeSessionId ? activeSessionId : undefined) ??
 				(activeBatchSessionIds.length > 0 ? activeBatchSessionIds[0] : undefined);
 			logger.info('[App:handleStopBatchRun] targetSessionId:', undefined, [
 				targetSessionId,
@@ -691,7 +694,7 @@ export function useBatchHandlers(deps: UseBatchHandlersDeps): UseBatchHandlersRe
 				sessionId,
 			]);
 			if (!sessionId) return;
-			const session = sessions.find((s) => s.id === sessionId);
+			const session = useSessionStore.getState().sessions.find((s) => s.id === sessionId);
 			const agentName = session?.name || 'this session';
 			useModalStore.getState().openModal('confirm', {
 				message: `Stop Auto Run for "${agentName}" after the current task completes?`,
@@ -705,7 +708,7 @@ export function useBatchHandlers(deps: UseBatchHandlersDeps): UseBatchHandlersRe
 				},
 			});
 		},
-		[activeBatchSessionIds, activeSession, sessions, stopBatchRun]
+		[activeBatchSessionIds, activeSessionId, stopBatchRun]
 	);
 
 	const handleKillBatchRun = useCallback(
@@ -720,34 +723,34 @@ export function useBatchHandlers(deps: UseBatchHandlersDeps): UseBatchHandlersRe
 		// Reads batchRunStates imperatively at call time
 		const sessionId = resolveBatchSessionIdForPausedError(
 			useBatchStore.getState().batchRunStates,
-			activeSession?.id
+			activeSessionId
 		);
 		if (!sessionId) return;
 		skipCurrentDocument(sessionId);
 		handleClearAgentError(sessionId);
-	}, [activeSession, skipCurrentDocument, handleClearAgentError]);
+	}, [activeSessionId, skipCurrentDocument, handleClearAgentError]);
 
 	const handleResumeAfterError = useCallback(() => {
 		// Reads batchRunStates imperatively at call time
 		const sessionId = resolveBatchSessionIdForPausedError(
 			useBatchStore.getState().batchRunStates,
-			activeSession?.id
+			activeSessionId
 		);
 		if (!sessionId) return;
 		resumeAfterError(sessionId);
 		handleClearAgentError(sessionId);
-	}, [activeSession, resumeAfterError, handleClearAgentError]);
+	}, [activeSessionId, resumeAfterError, handleClearAgentError]);
 
 	const handleAbortBatchOnError = useCallback(() => {
 		// Reads batchRunStates imperatively at call time
 		const sessionId = resolveBatchSessionIdForPausedError(
 			useBatchStore.getState().batchRunStates,
-			activeSession?.id
+			activeSessionId
 		);
 		if (!sessionId) return;
 		abortBatchOnError(sessionId);
 		handleClearAgentError(sessionId);
-	}, [activeSession, abortBatchOnError, handleClearAgentError]);
+	}, [activeSessionId, abortBatchOnError, handleClearAgentError]);
 
 	// sessionId-targeted variants for use from the web remote layer. These mirror
 	// the handle* helpers above but accept an explicit sessionId instead of

--- a/src/renderer/hooks/batch/useBatchProcessor.ts
+++ b/src/renderer/hooks/batch/useBatchProcessor.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useEffect } from 'react';
+import { useCallback, useRef, useEffect, useMemo, type MutableRefObject } from 'react';
 import type {
 	BatchRunState,
 	BatchRunConfig,
@@ -12,6 +12,7 @@ import type {
 // Extracted batch processing modules
 import { countUnfinishedTasks, uncheckAllTasks } from './batchUtils';
 import { useBatchStore } from '../../stores/batchStore';
+import { useSessionStore } from '../../stores/sessionStore';
 import { useTimeTracking } from './useTimeTracking';
 import { useWorktreeManager } from './useWorktreeManager';
 import { useDocumentProcessor } from './useDocumentProcessor';
@@ -55,7 +56,6 @@ export interface PRResultInfo {
 }
 
 export interface UseBatchProcessorProps {
-	sessions: Session[];
 	groups: Group[];
 	onUpdateSession: (sessionId: string, updates: Partial<Session>) => void;
 	onSpawnAgent: (
@@ -137,7 +137,6 @@ export { countUnfinishedTasks, uncheckAllTasks };
  * - Extracted hooks (useSessionDebounce, useTimeTracking) handle their own cleanup
  */
 export function useBatchProcessor({
-	sessions,
 	groups,
 	onUpdateSession,
 	onSpawnAgent,
@@ -170,9 +169,23 @@ export function useBatchProcessor({
 	// Refs for tracking stop requests per session
 	const stopRequestedRefs = useRef<Record<string, boolean>>({});
 
-	// Ref to always have access to latest sessions (fixes stale closure in startBatchRun)
-	const sessionsRef = useRef(sessions);
-	sessionsRef.current = sessions;
+	// PERF: Read sessions at event time via getState() so App (this hook's
+	// caller) does not re-render on streaming session updates. Downstream
+	// runners already fall back to the store when a session is missing.
+	// Setter is a no-op so accidental `sessionsRef.current = ...` writes cannot
+	// replace the getter.
+	const sessionsRef = useMemo(
+		() =>
+			({
+				get current(): Session[] {
+					return useSessionStore.getState().sessions;
+				},
+				set current(_value: Session[]) {
+					/* store is the source of truth */
+				},
+			}) as MutableRefObject<Session[]>,
+		[]
+	);
 
 	// Refs to always have access to latest audio feedback settings (fixes stale closure during batch run)
 	// Without refs, toggling settings off during a batch run won't take effect until the next run

--- a/src/renderer/hooks/batch/useBatchProcessor.ts
+++ b/src/renderer/hooks/batch/useBatchProcessor.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useEffect, useMemo, type MutableRefObject } from 'react';
+import { useCallback, useRef, useEffect } from 'react';
 import type {
 	BatchRunState,
 	BatchRunConfig,
@@ -172,20 +172,7 @@ export function useBatchProcessor({
 	// PERF: Read sessions at event time via getState() so App (this hook's
 	// caller) does not re-render on streaming session updates. Downstream
 	// runners already fall back to the store when a session is missing.
-	// Setter is a no-op so accidental `sessionsRef.current = ...` writes cannot
-	// replace the getter.
-	const sessionsRef = useMemo(
-		() =>
-			({
-				get current(): Session[] {
-					return useSessionStore.getState().sessions;
-				},
-				set current(_value: Session[]) {
-					/* store is the source of truth */
-				},
-			}) as MutableRefObject<Session[]>,
-		[]
-	);
+	const getSessions = useCallback(() => useSessionStore.getState().sessions, []);
 
 	// Refs to always have access to latest audio feedback settings (fixes stale closure during batch run)
 	// Without refs, toggling settings off during a batch run won't take effect until the next run
@@ -304,7 +291,7 @@ export function useBatchProcessor({
 
 	// Document/task-driven Auto Run orchestrator.
 	const { startBatchRun: startDocumentBatchRun } = useBatchRunner({
-		sessionsRef,
+		getSessions,
 		audioFeedbackEnabledRef,
 		audioFeedbackCommandRef,
 		autoRunFlushStateRefs,
@@ -332,7 +319,7 @@ export function useBatchProcessor({
 	// Goal-Driven Auto Run orchestrator. Shares the same lifecycle dependency
 	// surface so stop/kill/pause controls and state behavior stay consistent.
 	const { startGoalRun } = useGoalRunner({
-		sessionsRef,
+		getSessions,
 		audioFeedbackEnabledRef,
 		audioFeedbackCommandRef,
 		autoRunFlushStateRefs,

--- a/src/renderer/hooks/git/useFileTreeManagement.ts
+++ b/src/renderer/hooks/git/useFileTreeManagement.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useStoreWithEqualityFn } from 'zustand/traditional';
 import type { RightPanelHandle } from '../../components/RightPanel';
 import type { Session } from '../../types';
 import type { FileNode } from '../../types/fileTree';
@@ -18,7 +19,7 @@ import { fuzzyMatch } from '../../utils/search';
 import { gitService } from '../../services/git';
 import { logger } from '../../utils/logger';
 import { useFileExplorerStore } from '../../stores/fileExplorerStore';
-import { useSessionStore } from '../../stores/sessionStore';
+import { useSessionStore, selectActiveSession } from '../../stores/sessionStore';
 import {
 	DEFAULT_SSH_REDUCE_ENTRY_CAP_FRACTION,
 	FILE_EXPLORER_MIN_ENTRIES,
@@ -38,6 +39,33 @@ const FILE_TREE_RETRY_DELAY_MS = 20000;
  */
 const EMPTY_FILE_TREE: FileTreeNode[] = [];
 
+/**
+ * Equality for the active Session slice this hook self-subscribes to.
+ *
+ * Compares fileTree by reference (refresh replaces the array) plus the load /
+ * SSH fields effects need. Ignores logs/tokens so App (this hook's host) does
+ * not re-render on streaming flushes - those are omitted from
+ * activeSessionChromeEquality and must not ride that slice either.
+ */
+function fileTreeActiveSessionEquality(a: Session | null, b: Session | null): boolean {
+	if (a === b) return true;
+	if (!a || !b) return false;
+	return (
+		a.id === b.id &&
+		a.cwd === b.cwd &&
+		a.projectRoot === b.projectRoot &&
+		a.fileTree === b.fileTree &&
+		a.fileTreeStats === b.fileTreeStats &&
+		a.fileTreeLoading === b.fileTreeLoading &&
+		a.fileTreeError === b.fileTreeError &&
+		a.fileTreeRetryAt === b.fileTreeRetryAt &&
+		a.fileTreeTruncated === b.fileTreeTruncated &&
+		a.fileTreeLoadedCap === b.fileTreeLoadedCap &&
+		a.sshRemoteId === b.sshRemoteId &&
+		a.sessionSshRemoteConfig?.remoteId === b.sessionSshRemoteConfig?.remoteId &&
+		a.sessionSshRemoteConfig?.enabled === b.sessionSshRemoteConfig?.enabled
+	);
+}
 /**
  * Options for building SSH context
  */
@@ -108,8 +136,13 @@ export interface UseFileTreeManagementDeps {
 	setSessions: React.Dispatch<React.SetStateAction<Session[]>>;
 	/** Currently active session ID */
 	activeSessionId: string | null;
-	/** Currently active session (derived from sessions) */
-	activeSession: Session | null;
+	/**
+	 * Optional injected active session (tests). Prefer omitting so this hook
+	 * self-sources fileTree from the store with fileTreeActiveSessionEquality;
+	 * do not pass App's chrome-equality slice (fileTree is deliberately omitted
+	 * there and would go stale after refresh).
+	 */
+	activeSession?: Session | null;
 	/** Ref to RightPanel for refreshing history */
 	rightPanelRef: React.RefObject<RightPanelHandle | null>;
 	/** SSH remote ignore patterns (glob patterns) */
@@ -173,7 +206,7 @@ export function useFileTreeManagement(
 		sessionsRef,
 		setSessions,
 		activeSessionId,
-		activeSession,
+		activeSession: activeSessionProp,
 		rightPanelRef,
 		sshRemoteIgnorePatterns,
 		sshRemoteHonorGitignore,
@@ -184,6 +217,16 @@ export function useFileTreeManagement(
 		sshReduceEntryCapEnabled,
 		sshReduceEntryCapFraction,
 	} = deps;
+
+	// PERF: Self-source when App omits activeSession. Narrow equality includes
+	// fileTree by reference so refresh/create/delete repaint the Files panel
+	// without waking App on streaming log/token flushes.
+	const storeActiveSession = useStoreWithEqualityFn(
+		useSessionStore,
+		selectActiveSession,
+		fileTreeActiveSessionEquality
+	);
+	const activeSession = activeSessionProp !== undefined ? activeSessionProp : storeActiveSession;
 
 	// Fall back to the canonical defaults from settingsStore when deps omit these values
 	// (e.g. in tests that don't wire the full settings state through).
@@ -1028,7 +1071,7 @@ export function useFileTreeManagement(
 	 */
 	const filteredFileTree = useMemo(() => {
 		if (!activeSession || !fileTreeFilter || !activeSession.fileTree) {
-			return activeSession?.fileTree || [];
+			return activeSession?.fileTree || EMPTY_FILE_TREE;
 		}
 
 		const filterTree = (nodes: FileNode[]): FileNode[] => {

--- a/src/renderer/hooks/input/useAtMentionCompletion.ts
+++ b/src/renderer/hooks/input/useAtMentionCompletion.ts
@@ -55,7 +55,6 @@ const EARLY_EXIT_EXACT_MATCH_THRESHOLD = 50;
 export function useAtMentionCompletion(session?: Session | null): UseAtMentionCompletionReturn {
 	const injected = session !== undefined;
 
-	const storeActiveId = useSessionStore((s) => (injected ? undefined : s.activeSessionId));
 	const storeFileTree = useSessionStore((s) =>
 		injected ? undefined : selectActiveSession(s)?.fileTree
 	);
@@ -64,13 +63,9 @@ export function useAtMentionCompletion(session?: Session | null): UseAtMentionCo
 		injected ? undefined : selectActiveSession(s)?.autoRunFolderPath
 	);
 
-	const fileTree = injected ? session?.fileTree : storeActiveId ? storeFileTree : undefined;
-	const sessionCwd = injected ? session?.cwd : storeActiveId ? storeCwd : undefined;
-	const autoRunFolderPath = injected
-		? session?.autoRunFolderPath
-		: storeActiveId
-			? storeAutoRunFolderPath
-			: undefined;
+	const fileTree = injected ? session?.fileTree : storeFileTree;
+	const sessionCwd = injected ? session?.cwd : storeCwd;
+	const autoRunFolderPath = injected ? session?.autoRunFolderPath : storeAutoRunFolderPath;
 
 	// State for Auto Run folder files (fetched asynchronously)
 	const [autoRunFiles, setAutoRunFiles] = useState<

--- a/src/renderer/hooks/input/useAtMentionCompletion.ts
+++ b/src/renderer/hooks/input/useAtMentionCompletion.ts
@@ -3,6 +3,7 @@ import type { Session } from '../../types';
 import type { FileNode } from '../../types/fileTree';
 import type { AutoRunTreeNode } from '../batch/useAutoRunHandlers';
 import { fuzzyMatchWithScore } from '../../utils/search';
+import { useSessionStore, selectActiveSession } from '../../stores/sessionStore';
 
 export interface AtMentionSuggestion {
 	value: string; // Full path to insert
@@ -35,7 +36,7 @@ const MAX_SUGGESTION_RESULTS = 15;
  * PERF: Once this many exact substring matches are found (and we have MAX_SUGGESTION_RESULTS),
  * stop searching. Exact matches score highest in fuzzyMatchWithScore (they receive a +50
  * bonus in search.ts), so once we have 50 exact substring matches the top-15 results are
- * virtually guaranteed to be optimal — any remaining files would only contribute weaker
+ * virtually guaranteed to be optimal - any remaining files would only contribute weaker
  * fuzzy-only matches that cannot outscore them. 50 provides a comfortable margin over
  * MAX_SUGGESTION_RESULTS (15) to account for score ties and type-based sorting.
  */
@@ -44,17 +45,39 @@ const EARLY_EXIT_EXACT_MATCH_THRESHOLD = 50;
 /**
  * Hook for providing @ mention file completion in AI mode.
  * Uses fuzzy matching to find files in the project tree and Auto Run folder.
+ *
+ * PERF: Prefer calling with no args. Then this hook subscribes only to
+ * non-streaming fields (fileTree, cwd, autoRunFolderPath). Passing a Session
+ * (or null) keeps the injected-session API for tests and PromptComposerModal;
+ * when injected, store selectors return stable sentinels so streaming updates
+ * do not re-render through those subscriptions.
  */
-export function useAtMentionCompletion(session: Session | null): UseAtMentionCompletionReturn {
+export function useAtMentionCompletion(session?: Session | null): UseAtMentionCompletionReturn {
+	const injected = session !== undefined;
+
+	const storeActiveId = useSessionStore((s) => (injected ? undefined : s.activeSessionId));
+	const storeFileTree = useSessionStore((s) =>
+		injected ? undefined : selectActiveSession(s)?.fileTree
+	);
+	const storeCwd = useSessionStore((s) => (injected ? undefined : selectActiveSession(s)?.cwd));
+	const storeAutoRunFolderPath = useSessionStore((s) =>
+		injected ? undefined : selectActiveSession(s)?.autoRunFolderPath
+	);
+
+	const fileTree = injected ? session?.fileTree : storeActiveId ? storeFileTree : undefined;
+	const sessionCwd = injected ? session?.cwd : storeActiveId ? storeCwd : undefined;
+	const autoRunFolderPath = injected
+		? session?.autoRunFolderPath
+		: storeActiveId
+			? storeAutoRunFolderPath
+			: undefined;
+
 	// State for Auto Run folder files (fetched asynchronously)
 	const [autoRunFiles, setAutoRunFiles] = useState<
 		{ name: string; type: 'file' | 'folder'; path: string }[]
 	>([]);
 
 	// Fetch Auto Run folder files when the path changes
-	const autoRunFolderPath = session?.autoRunFolderPath;
-	const sessionCwd = session?.cwd;
-
 	useEffect(() => {
 		// Clear if no Auto Run folder configured
 		if (!autoRunFolderPath) {
@@ -119,7 +142,7 @@ export function useAtMentionCompletion(session: Session | null): UseAtMentionCom
 	// Build a flat list of all files/folders from the file tree
 	// PERF: Capped at MAX_FILE_TREE_ENTRIES to avoid blocking the main thread on huge repos
 	const projectFiles = useMemo(() => {
-		if (!session?.fileTree) return [];
+		if (!fileTree) return [];
 
 		const files: { name: string; type: 'file' | 'folder'; path: string }[] = [];
 
@@ -139,9 +162,9 @@ export function useAtMentionCompletion(session: Session | null): UseAtMentionCom
 			}
 		};
 
-		traverse(session.fileTree);
+		traverse(fileTree);
 		return files;
-	}, [session?.fileTree]);
+	}, [fileTree]);
 
 	// Combine project files with Auto Run files
 	const allFiles = useMemo(() => {

--- a/src/renderer/hooks/input/useInputHandlers.ts
+++ b/src/renderer/hooks/input/useInputHandlers.ts
@@ -1,5 +1,5 @@
 /**
- * useInputHandlers — extracted from App.tsx (Phase 2J)
+ * useInputHandlers - extracted from App.tsx (Phase 2J)
  *
  * Orchestrates all input-related state and handlers by:
  *   - Managing dual input state (AI per-tab + terminal per-session)
@@ -8,6 +8,12 @@
  *   - Computing memoized completion suggestions
  *   - Owning tab/session switching effects for input persistence
  *   - Providing paste, drop, blur, and replay handlers
+ *
+ * PERF: Does not subscribe to the full active Session. Streaming log / token
+ * updates must not re-render MaestroConsoleInner via this hook. Reactive
+ * subscriptions are limited to primitives (activeSessionId, inputMode,
+ * activeTabId) and stable field refs (stagedImages). Handlers and sync
+ * callbacks resolve the live session via getState() / sessionsRef at event time.
  *
  * Reads from: sessionStore, settingsStore, groupChatStore, uiStore,
  *             fileExplorerStore, InputContext
@@ -56,6 +62,7 @@ function isImagePath(path: string): boolean {
 // value on every render while the `@` picker is closed - no re-render churn.
 const EMPTY_SESSIONS: Session[] = [];
 const EMPTY_GROUPS: Group[] = [];
+const EMPTY_STAGED_IMAGES: string[] = [];
 
 /**
  * Convert an absolute filesystem path into the form used inside an `@` mention:
@@ -208,11 +215,25 @@ export function useInputHandlers(deps: UseInputHandlersDeps): UseInputHandlersRe
 		spawnBackgroundSynopsis,
 	} = deps;
 
-	// --- Store subscriptions (reactive) ---
-	const activeSession = useSessionStore(selectActiveSession);
+	// --- Store subscriptions (reactive, narrow) ---
+	// PERF: Never useSessionStore(selectActiveSession). Streamed logs/tokens would
+	// re-render MaestroConsoleInner on every chunk.
 	const activeSessionId = useSessionStore((s) => s.activeSessionId);
+	const activeSessionInputMode = useSessionStore((s) => selectActiveSession(s)?.inputMode);
+	const activeTabId = useSessionStore((s) => {
+		const session = selectActiveSession(s);
+		return session ? getActiveTab(session)?.id : undefined;
+	});
+	const stagedImages = useSessionStore((s) => {
+		const session = selectActiveSession(s);
+		if (!session || session.inputMode !== 'ai') return EMPTY_STAGED_IMAGES;
+		const images = getActiveTab(session)?.stagedImages;
+		// Empty arrays are truthy - without this, every stream flush that rebuilds
+		// the tab with `stagedImages: []` returns a new [] ref and re-renders App.
+		if (!images || images.length === 0) return EMPTY_STAGED_IMAGES;
+		return images;
+	});
 	const setSessions = useMemo(() => useSessionStore.getState().setSessions, []);
-	const activeGroupChatId = useGroupChatStore((s) => s.activeGroupChatId);
 	const setGroupChatStagedImages = useMemo(
 		() => useGroupChatStore.getState().setGroupChatStagedImages,
 		[]
@@ -249,9 +270,7 @@ export function useInputHandlers(deps: UseInputHandlersDeps): UseInputHandlersRe
 	const groups = useSessionStore((s) => (atMentionOpen ? s.groups : EMPTY_GROUPS));
 
 	// --- Derived values ---
-	const activeTab = activeSession ? getActiveTab(activeSession) : null;
-	const isAiMode = activeSession?.inputMode === 'ai';
-	const activeSessionInputMode = activeSession?.inputMode;
+	const isAiMode = activeSessionInputMode === 'ai';
 
 	// ====================================================================
 	// Input State
@@ -267,7 +286,7 @@ export function useInputHandlers(deps: UseInputHandlersDeps): UseInputHandlersRe
 	// Ref-mirror of activeTab.id so the live-draft mirror attributes text to the
 	// correct tab, and the tab-switch effect can flush the OLD tab's text without
 	// re-triggering on tab-switch alone.
-	const activeTabIdRef = useRef<string | undefined>(activeTab?.id);
+	const activeTabIdRef = useRef<string | undefined>(activeTabId);
 
 	// Ref-mirror of the current mode so non-reactive readers (getInputValue) pick
 	// the right slice at call time without subscribing.
@@ -280,7 +299,7 @@ export function useInputHandlers(deps: UseInputHandlersDeps): UseInputHandlersRe
 	// on screen for the active tab (tab.inputValue only updates on blur/submit).
 	// Subscribing outside React render keeps this off the re-render path.
 	useEffect(() => {
-		activeTabIdRef.current = activeTab?.id;
+		activeTabIdRef.current = activeTabId;
 		const mirror = (aiValue: string) => {
 			const currentTabId = activeTabIdRef.current;
 			if (currentTabId) setLiveDraft(currentTabId, aiValue);
@@ -289,7 +308,7 @@ export function useInputHandlers(deps: UseInputHandlersDeps): UseInputHandlersRe
 		return useComposerInputStore.subscribe((state, prev) => {
 			if (state.aiValue !== prev.aiValue) mirror(state.aiValue);
 		});
-	}, [activeTab?.id]);
+	}, [activeTabId]);
 
 	// Read the live value non-reactively (at call time) for handlers and sub-hooks
 	// so they never need a reactive `inputValue` dependency.
@@ -301,26 +320,22 @@ export function useInputHandlers(deps: UseInputHandlersDeps): UseInputHandlersRe
 	// Memoized setter that dispatches to the correct slice based on current mode.
 	const setInputValue = useCallback(
 		(value: string | ((prev: string) => string)) => {
-			if (activeSession?.inputMode === 'ai') {
+			if (activeSessionInputMode === 'ai') {
 				setAiValue(value);
 			} else {
 				setTerminalValue(value);
 			}
 		},
-		[activeSession?.inputMode, setAiValue, setTerminalValue]
+		[activeSessionInputMode, setAiValue, setTerminalValue]
 	);
 
 	// ====================================================================
 	// Staged Images
 	// ====================================================================
 
-	const stagedImages = useMemo(() => {
-		if (!activeSession || activeSession.inputMode !== 'ai') return [];
-		return activeTab?.stagedImages || [];
-	}, [activeTab?.stagedImages, activeSession?.inputMode]);
-
 	const setStagedImages = useCallback(
 		(imagesOrUpdater: string[] | ((prev: string[]) => string[])) => {
+			const activeSession = selectActiveSession(useSessionStore.getState());
 			if (!activeSession) return;
 			setSessions((prev) =>
 				prev.map((s) => {
@@ -340,48 +355,49 @@ export function useInputHandlers(deps: UseInputHandlersDeps): UseInputHandlersRe
 				})
 			);
 		},
-		[activeSession]
+		[setSessions]
 	);
 
 	// ====================================================================
 	// Sub-hook calls
 	// ====================================================================
 
-	// Input sync handlers
-	const { syncAiInputToSession, syncTerminalInputToSession } = useInputSync(activeSession, {
+	// Input sync handlers (resolve session via getState inside callbacks)
+	const { syncAiInputToSession, syncTerminalInputToSession } = useInputSync({
 		setSessions,
 	});
 
-	// Tab completion
-	const { getSuggestions: getTabCompletionSuggestions } = useTabCompletion(activeSession);
-
-	// @ mention completion
-	const { getSuggestions: getAtMentionSuggestions } = useAtMentionCompletion(activeSession);
+	// Tab / @mention completion: no-arg form subscribes only to non-streaming fields
+	const { getSuggestions: getTabCompletionSuggestions } = useTabCompletion();
+	const { getSuggestions: getAtMentionSuggestions } = useAtMentionCompletion();
 
 	// ====================================================================
 	// Tab/Session switching effects
 	// ====================================================================
 
-	const prevActiveTabIdRef = useRef<string | undefined>(activeTab?.id);
-	const prevActiveSessionIdRef = useRef<string | undefined>(activeSession?.id);
+	const prevActiveTabIdRef = useRef<string | undefined>(activeTabId);
+	const prevActiveSessionIdRef = useRef<string | undefined>(activeSessionId ?? undefined);
 	const didHydrateAiInputRef = useRef(false);
 	const didHydrateTerminalInputRef = useRef(false);
 
 	useEffect(() => {
-		if (!activeTab || didHydrateAiInputRef.current) return;
-		setAiValue(activeTab.inputValue ?? '');
+		if (!activeTabId || didHydrateAiInputRef.current) return;
+		const session = selectActiveSession(useSessionStore.getState());
+		const tab = session ? getActiveTab(session) : null;
+		setAiValue(tab?.inputValue ?? '');
 		didHydrateAiInputRef.current = true;
-	}, [activeTab?.id, setAiValue]);
+	}, [activeTabId, setAiValue]);
 
 	useEffect(() => {
-		if (!activeSession || didHydrateTerminalInputRef.current) return;
-		setTerminalValue(activeSession.terminalDraftInput ?? '');
+		if (!activeSessionId || didHydrateTerminalInputRef.current) return;
+		const session = selectActiveSession(useSessionStore.getState());
+		setTerminalValue(session?.terminalDraftInput ?? '');
 		didHydrateTerminalInputRef.current = true;
-	}, [activeSession?.id, setTerminalValue]);
+	}, [activeSessionId, setTerminalValue]);
 
 	// Sync local AI input with tab's persisted value when switching tabs
 	useEffect(() => {
-		if (activeTab && activeTab.id !== prevActiveTabIdRef.current) {
+		if (activeTabId && activeTabId !== prevActiveTabIdRef.current) {
 			const prevTabId = prevActiveTabIdRef.current;
 
 			// Save current AI input to the PREVIOUS tab
@@ -398,28 +414,30 @@ export function useInputHandlers(deps: UseInputHandlersDeps): UseInputHandlersRe
 			}
 
 			// Load new tab's persisted input value
-			setAiValue(activeTab.inputValue ?? '');
-			prevActiveTabIdRef.current = activeTab.id;
+			const session = selectActiveSession(useSessionStore.getState());
+			const activeTab = session ? getActiveTab(session) : null;
+			setAiValue(activeTab?.inputValue ?? '');
+			prevActiveTabIdRef.current = activeTabId;
 
 			// Clear hasUnread indicator on newly active tab
-			if (activeTab.hasUnread && activeSession) {
+			if (activeTab?.hasUnread && session) {
 				setSessions((prev) =>
 					prev.map((s) => {
-						if (s.id !== activeSession.id) return s;
+						if (s.id !== session.id) return s;
 						return {
 							...s,
-							aiTabs: s.aiTabs.map((t) => (t.id === activeTab.id ? { ...t, hasUnread: false } : t)),
+							aiTabs: s.aiTabs.map((t) => (t.id === activeTabId ? { ...t, hasUnread: false } : t)),
 						};
 					})
 				);
 			}
 		}
-		// Intentionally only depend on activeTab?.id, NOT inputValue
-	}, [activeTab?.id]);
+		// Intentionally only depend on activeTabId, NOT inputValue
+	}, [activeTabId]);
 
 	// Sync terminal input when switching sessions
 	useEffect(() => {
-		if (activeSession && activeSession.id !== prevActiveSessionIdRef.current) {
+		if (activeSessionId && activeSessionId !== prevActiveSessionIdRef.current) {
 			const prevSessionId = prevActiveSessionIdRef.current;
 
 			// Save terminal input to the previous session (including empty string to persist cleared input)
@@ -433,10 +451,11 @@ export function useInputHandlers(deps: UseInputHandlersDeps): UseInputHandlersRe
 			}
 
 			// Load terminal input from the new session
-			setTerminalValue(activeSession.terminalDraftInput ?? '');
-			prevActiveSessionIdRef.current = activeSession.id;
+			const session = selectActiveSession(useSessionStore.getState());
+			setTerminalValue(session?.terminalDraftInput ?? '');
+			prevActiveSessionIdRef.current = activeSessionId;
 		}
-	}, [activeSession?.id]);
+	}, [activeSessionId]);
 
 	// ====================================================================
 	// Completion suggestions (memoized)
@@ -563,7 +582,7 @@ export function useInputHandlers(deps: UseInputHandlersDeps): UseInputHandlersRe
 	);
 
 	const { processInput, processInputRef: _hookProcessInputRef } = useInputProcessing({
-		activeSession,
+		// PERF: Omit activeSession; processInput resolves via sessionsRef / getState.
 		activeSessionId,
 		setSessions,
 		getInputValue,
@@ -591,7 +610,7 @@ export function useInputHandlers(deps: UseInputHandlersDeps): UseInputHandlersRe
 		onCrossAgentMentions: handleCrossAgentMentions,
 	});
 
-	// processInputRef — maintained for access in memoized callbacks without stale closures
+	// processInputRef - maintained for access in memoized callbacks without stale closures
 	const processInputRef = useRef<
 		(text?: string, options?: { forceParallel?: boolean; images?: string[] }) => void
 	>(() => {});
@@ -600,7 +619,7 @@ export function useInputHandlers(deps: UseInputHandlersDeps): UseInputHandlersRe
 	}, [processInput]);
 
 	// ====================================================================
-	// useInputKeyDown (absorb — keyboard handler for input textarea)
+	// useInputKeyDown (absorb - keyboard handler for input textarea)
 	// ====================================================================
 
 	const { handleInputKeyDown } = useInputKeyDown({
@@ -635,6 +654,8 @@ export function useInputHandlers(deps: UseInputHandlersDeps): UseInputHandlersRe
 		(text: string, images?: string[]) => {
 			// Preserve draft input so replay doesn't clobber what the user was typing
 			const draftInput = useComposerInputStore.getState().aiValue;
+			const activeSession = selectActiveSession(useSessionStore.getState());
+			const activeTab = activeSession ? getActiveTab(activeSession) : null;
 			const draftImages = activeTab?.stagedImages ? [...activeTab.stagedImages] : [];
 
 			if (images && images.length > 0) {
@@ -652,12 +673,13 @@ export function useInputHandlers(deps: UseInputHandlersDeps): UseInputHandlersRe
 				}
 			}, 0);
 		},
-		[setStagedImages, setInputValue, syncAiInputToSession, activeTab?.stagedImages]
+		[setStagedImages, setInputValue, syncAiInputToSession]
 	);
 
 	const handlePaste = useCallback(
 		(e: React.ClipboardEvent) => {
-			const isGroupChatActive = !!activeGroupChatId;
+			const activeSession = selectActiveSession(useSessionStore.getState());
+			const isGroupChatActive = !!useGroupChatStore.getState().activeGroupChatId;
 			const isDirectAIMode = activeSession && activeSession.inputMode === 'ai';
 
 			const items = e.clipboardData.items;
@@ -722,7 +744,7 @@ export function useInputHandlers(deps: UseInputHandlersDeps): UseInputHandlersRe
 				}
 			}
 		},
-		[activeGroupChatId, activeSession, setInputValue, setStagedImages]
+		[setInputValue, setStagedImages]
 	);
 
 	const appendMentionsToAiInput = useCallback(
@@ -765,7 +787,8 @@ export function useInputHandlers(deps: UseInputHandlersDeps): UseInputHandlersRe
 			dragCounterRef.current = 0;
 			setIsDraggingFile(false);
 
-			const isGroupChatActive = !!activeGroupChatId;
+			const activeSession = selectActiveSession(useSessionStore.getState());
+			const isGroupChatActive = !!useGroupChatStore.getState().activeGroupChatId;
 			const isDirectAIMode = activeSession && activeSession.inputMode === 'ai';
 
 			// Files-panel drag: image files are staged as image attachments;
@@ -790,7 +813,7 @@ export function useInputHandlers(deps: UseInputHandlersDeps): UseInputHandlersRe
 							internalPaths = parsed.filter((p): p is string => typeof p === 'string');
 						}
 					} catch {
-						// Malformed payload — fall back to the single path below.
+						// Malformed payload - fall back to the single path below.
 					}
 				}
 				if (internalPaths.length === 0 && internalSingle) internalPaths = [internalSingle];
@@ -894,13 +917,7 @@ export function useInputHandlers(deps: UseInputHandlersDeps): UseInputHandlersRe
 				}
 			}
 		},
-		[
-			activeGroupChatId,
-			activeSession,
-			setStagedImages,
-			appendMentionsToAiInput,
-			appendMentionsToGroupChatDraft,
-		]
+		[setStagedImages, appendMentionsToAiInput, appendMentionsToGroupChatDraft]
 	);
 
 	// ====================================================================

--- a/src/renderer/hooks/input/useInputHandlers.ts
+++ b/src/renderer/hooks/input/useInputHandlers.ts
@@ -157,13 +157,21 @@ export interface UseInputHandlersReturn {
 	/** Set staged images for the current message */
 	setStagedImages: (images: string[] | ((prev: string[]) => string[])) => void;
 	/** Process and send the current input */
-	processInput: (text?: string, options?: { forceParallel?: boolean; images?: string[] }) => void;
+	processInput: (
+		text?: string,
+		options?: { forceParallel?: boolean; images?: string[]; sessionId?: string; tabId?: string }
+	) => void;
 	/** Ref to latest processInput for use in memoized callbacks */
 	processInputRef: React.MutableRefObject<
-		(text?: string, options?: { forceParallel?: boolean; images?: string[] }) => void
+		(
+			text?: string,
+			options?: { forceParallel?: boolean; images?: string[]; sessionId?: string; tabId?: string }
+		) => void
 	>;
 	/** Keyboard event handler for the input textarea */
 	handleInputKeyDown: (e: React.KeyboardEvent) => void;
+	/** Capture the agent/tab that owns the composer when the input gains focus */
+	handleMainPanelInputFocus: () => void;
 	/** Handler for input blur (persists input to session state) */
 	handleMainPanelInputBlur: () => void;
 	/** Replay a message (optionally with images) */
@@ -612,7 +620,10 @@ export function useInputHandlers(deps: UseInputHandlersDeps): UseInputHandlersRe
 
 	// processInputRef - maintained for access in memoized callbacks without stale closures
 	const processInputRef = useRef<
-		(text?: string, options?: { forceParallel?: boolean; images?: string[] }) => void
+		(
+			text?: string,
+			options?: { forceParallel?: boolean; images?: string[]; sessionId?: string; tabId?: string }
+		) => void
 	>(() => {});
 	useEffect(() => {
 		processInputRef.current = processInput;
@@ -639,14 +650,30 @@ export function useInputHandlers(deps: UseInputHandlersDeps): UseInputHandlersRe
 	// Handlers
 	// ====================================================================
 
+	// Agent/tab that owned the composer when it last gained focus. Blur must write
+	// here - not to the live active agent (click can switch focus before blur runs).
+	const composerFocusTargetRef = useRef<{ sessionId: string; tabId?: string } | null>(null);
+
+	const handleMainPanelInputFocus = useCallback(() => {
+		const session = selectActiveSession(useSessionStore.getState());
+		const tab = session ? getActiveTab(session) : null;
+		composerFocusTargetRef.current = session ? { sessionId: session.id, tabId: tab?.id } : null;
+	}, []);
+
 	const handleMainPanelInputBlur = useCallback(() => {
+		const target = composerFocusTargetRef.current;
+		const blurSessionId = target?.sessionId ?? activeSessionIdRef.current;
 		const currentIsAiMode =
-			sessionsRef.current.find((s) => s.id === activeSessionIdRef.current)?.inputMode === 'ai';
+			sessionsRef.current.find((s) => s.id === blurSessionId)?.inputMode === 'ai';
 		const composer = useComposerInputStore.getState();
 		if (currentIsAiMode) {
-			syncAiInputToSession(composer.aiValue);
+			if (target?.sessionId) {
+				syncAiInputToSession(composer.aiValue, target);
+			} else {
+				syncAiInputToSession(composer.aiValue);
+			}
 		} else {
-			syncTerminalInputToSession(composer.terminalValue);
+			syncTerminalInputToSession(composer.terminalValue, blurSessionId || undefined);
 		}
 	}, [syncAiInputToSession, syncTerminalInputToSession]);
 
@@ -657,16 +684,23 @@ export function useInputHandlers(deps: UseInputHandlersDeps): UseInputHandlersRe
 			const activeSession = selectActiveSession(useSessionStore.getState());
 			const activeTab = activeSession ? getActiveTab(activeSession) : null;
 			const draftImages = activeTab?.stagedImages ? [...activeTab.stagedImages] : [];
+			const pin = activeSession ? { sessionId: activeSession.id, tabId: activeTab?.id } : undefined;
 
 			if (images && images.length > 0) {
 				setStagedImages(images);
 			}
 			setTimeout(() => {
-				processInputRef.current(text);
+				// Pin the agent/tab from click time so a focus change before the
+				// timeout cannot retarget the replay. Images were staged above.
+				processInputRef.current(text, pin);
 				// Restore draft input after processInput clears it
 				if (draftInput) {
 					setInputValue(draftInput);
-					syncAiInputToSession(draftInput);
+					if (pin) {
+						syncAiInputToSession(draftInput, pin);
+					} else {
+						syncAiInputToSession(draftInput);
+					}
 				}
 				if (draftImages.length > 0) {
 					setStagedImages(draftImages);
@@ -931,6 +965,7 @@ export function useInputHandlers(deps: UseInputHandlersDeps): UseInputHandlersRe
 		processInput,
 		processInputRef,
 		handleInputKeyDown,
+		handleMainPanelInputFocus,
 		handleMainPanelInputBlur,
 		handleReplayMessage,
 		handlePaste,

--- a/src/renderer/hooks/input/useInputProcessing.ts
+++ b/src/renderer/hooks/input/useInputProcessing.ts
@@ -78,7 +78,7 @@ export interface UseInputProcessingDeps {
 	/** Slash command menu open state setter */
 	setSlashCommandOpen: (open: boolean) => void;
 	/** Sync AI input value to session state (for persistence) */
-	syncAiInputToSession: (value: string) => void;
+	syncAiInputToSession: (value: string, target?: { sessionId: string; tabId?: string }) => void;
 	/** Sync terminal input value to session state (for persistence) */
 	syncTerminalInputToSession: (value: string) => void;
 	/** Whether the active session is in AI mode */
@@ -131,19 +131,22 @@ export type BatchState = BatchRunState;
 /**
  * Return type for useInputProcessing hook.
  */
+/** Optional pins for deferred sends (replay / recovery) so a late timeout cannot retarget. */
+export type ProcessInputOptions = {
+	forceParallel?: boolean;
+	images?: string[];
+	/** Prefer this agent over the live activeSessionId when the callback runs. */
+	sessionId?: string;
+	/** Prefer this AI tab over the session's current activeTabId. */
+	tabId?: string;
+};
+
 export interface UseInputProcessingReturn {
 	/** Process the current input (send message or execute command) */
-	processInput: (
-		overrideInputValue?: string,
-		options?: { forceParallel?: boolean; images?: string[] }
-	) => Promise<void>;
+	processInput: (overrideInputValue?: string, options?: ProcessInputOptions) => Promise<void>;
 	/** Ref to processInput for use in callbacks that need latest version */
 	processInputRef: React.MutableRefObject<
-		| ((
-				overrideInputValue?: string,
-				options?: { forceParallel?: boolean; images?: string[] }
-		  ) => Promise<void>)
-		| null
+		((overrideInputValue?: string, options?: ProcessInputOptions) => Promise<void>) | null
 	>;
 }
 
@@ -192,35 +195,50 @@ export function useInputProcessing(deps: UseInputProcessingDeps): UseInputProces
 
 	// Ref for the processInput function so external code can access the latest version
 	const processInputRef = useRef<
-		| ((
-				overrideInputValue?: string,
-				options?: { forceParallel?: boolean; images?: string[] }
-		  ) => Promise<void>)
-		| null
+		((overrideInputValue?: string, options?: ProcessInputOptions) => Promise<void>) | null
 	>(null);
 
 	/**
 	 * Process user input - handles slash commands, queuing, and message sending.
 	 */
 	const processInput = useCallback(
-		async (
-			overrideInputValue?: string,
-			options?: { forceParallel?: boolean; images?: string[] }
-		) => {
+		async (overrideInputValue?: string, options?: ProcessInputOptions) => {
 			// Flush any pending batched updates before processing user input
 			// This ensures AI output appears before the user's new message
 			flushBatchedUpdates?.();
 
-			// PERF: When activeSession is omitted, resolve the live session at
-			// submit time via sessionsRef / getState so callers need not pass a
-			// React-subscribed Session (streaming would re-render App). Explicit
-			// null means "no session" (tests).
+			// Prefer an explicit pin (replay / recovery) over the live active id so a
+			// deferred setTimeout cannot send into a different agent after a fast switch.
+			const resolvedSessionId =
+				options?.sessionId ||
+				activeSessionId ||
+				selectActiveSession(useSessionStore.getState())?.id ||
+				'';
+
+			// PERF: When activeSession is omitted, resolve at submit time via
+			// sessionsRef / getState so callers need not pass a React-subscribed
+			// Session (streaming would re-render App). Explicit null means "no
+			// session" (tests).
 			const activeSession =
 				activeSessionProp !== undefined
 					? activeSessionProp
-					: ((activeSessionId
-							? sessionsRef.current.find((s) => s.id === activeSessionId)
+					: ((resolvedSessionId
+							? sessionsRef.current.find((s) => s.id === resolvedSessionId)
 							: undefined) ?? selectActiveSession(useSessionStore.getState()));
+
+			const resolveTargetTab = (session: Session) => {
+				if (options?.tabId) {
+					return session.aiTabs.find((t) => t.id === options.tabId) ?? getActiveTab(session);
+				}
+				return getActiveTab(session);
+			};
+
+			const syncTarget = activeSession
+				? {
+						sessionId: activeSession.id,
+						tabId: resolveTargetTab(activeSession)?.id,
+					}
+				: undefined;
 
 			const effectiveInputValue = overrideInputValue ?? getInputValue();
 			// When the caller passes explicit images (e.g. Force Send button replaying a
@@ -256,7 +274,7 @@ export function useInputProcessing(deps: UseInputProcessingDeps): UseInputProces
 				if (!isTerminalMode && commandText === '/history' && onHistoryCommand) {
 					setInputValue('');
 					setSlashCommandOpen(false);
-					syncAiInputToSession('');
+					syncAiInputToSession('', syncTarget);
 					if (inputRef.current) inputRef.current.style.height = 'auto';
 
 					// Execute the history command handler asynchronously
@@ -277,7 +295,7 @@ export function useInputProcessing(deps: UseInputProcessingDeps): UseInputProces
 
 					setInputValue('');
 					setSlashCommandOpen(false);
-					syncAiInputToSession('');
+					syncAiInputToSession('', syncTarget);
 					if (inputRef.current) inputRef.current.style.height = 'auto';
 
 					// Execute the wizard command handler with the argument text
@@ -295,7 +313,7 @@ export function useInputProcessing(deps: UseInputProcessingDeps): UseInputProces
 				) {
 					setInputValue('');
 					setSlashCommandOpen(false);
-					syncAiInputToSession('');
+					syncAiInputToSession('', syncTarget);
 					if (inputRef.current) inputRef.current.style.height = 'auto';
 
 					// Execute the skills command handler asynchronously
@@ -331,7 +349,7 @@ export function useInputProcessing(deps: UseInputProcessingDeps): UseInputProces
 						// Execute the custom AI command by sending its prompt
 						setInputValue('');
 						setSlashCommandOpen(false);
-						syncAiInputToSession(''); // We're in AI mode here (isTerminalMode === false)
+						syncAiInputToSession('', syncTarget); // We're in AI mode here (isTerminalMode === false)
 						if (inputRef.current) inputRef.current.style.height = 'auto';
 
 						// Substitute template variables and send to the AI agent
@@ -355,7 +373,7 @@ export function useInputProcessing(deps: UseInputProcessingDeps): UseInputProces
 
 							// ALWAYS queue slash commands - they execute in order like write messages
 							// This ensures commands are processed sequentially through the queue
-							const activeTab = getActiveTab(activeSession);
+							const activeTab = resolveTargetTab(activeSession);
 							const isReadOnlyMode = activeTab?.readOnlyMode === true;
 							// Check both session busy state AND AutoRun state
 							// AutoRun runs in isolation and doesn't set session to busy, so we check it explicitly
@@ -395,7 +413,7 @@ export function useInputProcessing(deps: UseInputProcessingDeps): UseInputProces
 								// and adding it would cause duplicate display (once as sent message, once in queue section)
 								setSessions((prev) =>
 									prev.map((s) => {
-										if (s.id !== activeSessionId) return s;
+										if (s.id !== resolvedSessionId) return s;
 
 										// Set the target tab to busy
 										const updatedAiTabs = s.aiTabs.map((tab) =>
@@ -424,13 +442,13 @@ export function useInputProcessing(deps: UseInputProcessingDeps): UseInputProces
 								// 50ms delay allows React to flush the setState above, ensuring the session
 								// is marked 'busy' before processQueuedItem runs (prevents duplicate processing)
 								setTimeout(() => {
-									processQueuedItemRef.current?.(activeSessionId, queuedItem);
+									processQueuedItemRef.current?.(resolvedSessionId, queuedItem);
 								}, 50);
 							} else {
 								// Session is busy - just add to queue
 								setSessions((prev) =>
 									prev.map((s) => {
-										if (s.id !== activeSessionId) return s;
+										if (s.id !== resolvedSessionId) return s;
 										return {
 											...s,
 											executionQueue: [...s.executionQueue, queuedItem],
@@ -473,7 +491,7 @@ export function useInputProcessing(deps: UseInputProcessingDeps): UseInputProces
 				// Clear input
 				setInputValue('');
 				if (!usingOverrideImages) setStagedImages([]);
-				syncAiInputToSession('');
+				syncAiInputToSession('', syncTarget);
 				if (inputRef.current) inputRef.current.style.height = 'auto';
 
 				// Send to wizard (with images if any were staged)
@@ -491,7 +509,7 @@ export function useInputProcessing(deps: UseInputProcessingDeps): UseInputProces
 			// === undefined` so it fires exactly once, on a real input-box submit -
 			// not on queued replays / force-sends, which pass an override value.
 			if (currentMode === 'ai' && overrideInputValue === undefined && onCrossAgentMentions) {
-				const sourceTab = getActiveTab(activeSession);
+				const sourceTab = resolveTargetTab(activeSession);
 				const suppressLocal = onCrossAgentMentions(
 					effectiveInputValue,
 					activeSession,
@@ -514,8 +532,8 @@ export function useInputProcessing(deps: UseInputProcessingDeps): UseInputProces
 
 					setSessions((prev) =>
 						prev.map((s) => {
-							if (s.id !== activeSessionId) return s;
-							const tab = getActiveTab(s);
+							if (s.id !== resolvedSessionId) return s;
+							const tab = resolveTargetTab(s);
 							if (!tab) return s;
 							const trimmed = effectiveInputValue.trim();
 							const priorHistory = s.aiCommandHistory || [];
@@ -554,7 +572,7 @@ export function useInputProcessing(deps: UseInputProcessingDeps): UseInputProces
 					// Clear the composer.
 					setInputValue('');
 					if (!usingOverrideImages) setStagedImages([]);
-					syncAiInputToSession('');
+					syncAiInputToSession('', syncTarget);
 					if (inputRef.current) inputRef.current.style.height = 'auto';
 					return;
 				}
@@ -566,7 +584,7 @@ export function useInputProcessing(deps: UseInputProcessingDeps): UseInputProces
 			// EXCEPTION: Write commands can bypass the queue and run in parallel if ALL busy tabs
 			// and ALL queued items are read-only
 			if (currentMode === 'ai') {
-				const activeTab = getActiveTab(activeSession);
+				const activeTab = resolveTargetTab(activeSession);
 				const isReadOnlyMode = activeTab?.readOnlyMode === true;
 
 				// Check if write command can bypass queue (all running/queued items are read-only)
@@ -651,7 +669,7 @@ export function useInputProcessing(deps: UseInputProcessingDeps): UseInputProces
 					// to complete to prevent file conflicts.
 					setSessions((prev) =>
 						prev.map((s) => {
-							if (s.id !== activeSessionId) return s;
+							if (s.id !== resolvedSessionId) return s;
 							return {
 								...s,
 								executionQueue: [...s.executionQueue, queuedItem],
@@ -662,7 +680,7 @@ export function useInputProcessing(deps: UseInputProcessingDeps): UseInputProces
 					// Clear input
 					setInputValue('');
 					if (!usingOverrideImages) setStagedImages([]);
-					syncAiInputToSession(''); // Sync empty value to session state
+					syncAiInputToSession('', syncTarget); // Sync empty value to session state
 					if (inputRef.current) inputRef.current.style.height = 'auto';
 					return;
 				}
@@ -671,7 +689,7 @@ export function useInputProcessing(deps: UseInputProcessingDeps): UseInputProces
 			// Check if we're in read-only mode for the log entry (tab setting OR Auto Run without worktree).
 			// Force Send (Cmd+Shift+Enter / the Force Send button on a queued item) is an explicit user
 			// override — skip the Auto Run gate, but still honor the tab's own readOnlyMode setting.
-			const activeTabForEntry = currentMode === 'ai' ? getActiveTab(activeSession) : null;
+			const activeTabForEntry = currentMode === 'ai' ? resolveTargetTab(activeSession) : null;
 			const currentBatchState = getBatchState(activeSession.id);
 			const isForceParallelEntry =
 				options?.forceParallel === true && useSettingsStore.getState().forcedParallelExecution;
@@ -802,7 +820,7 @@ export function useInputProcessing(deps: UseInputProcessingDeps): UseInputProces
 
 			setSessions((prev) =>
 				prev.map((s) => {
-					if (s.id !== activeSessionId) return s;
+					if (s.id !== resolvedSessionId) return s;
 
 					// Add command to history (separate histories for AI and terminal modes)
 					const historyKey = currentMode === 'ai' ? 'aiCommandHistory' : 'shellCommandHistory';
@@ -832,8 +850,8 @@ export function useInputProcessing(deps: UseInputProcessingDeps): UseInputProces
 						};
 					}
 
-					// For AI mode, add to ACTIVE TAB's logs
-					const activeTab = getActiveTab(s);
+					// For AI mode, add to the target tab's logs (pinned tabId or active)
+					const activeTab = resolveTargetTab(s);
 					if (!activeTab) {
 						// No tabs exist - this is a bug, sessions must have aiTabs
 						logger.error(
@@ -888,7 +906,7 @@ export function useInputProcessing(deps: UseInputProcessingDeps): UseInputProces
 			// Trigger automatic tab naming. Retries on every send until the tab has a name,
 			// so a failed/timed-out first attempt doesn't leave the tab permanently unnamed.
 			// Skip while a previous attempt is still in flight to avoid duplicate spawns.
-			const activeTabForNaming = getActiveTab(activeSession);
+			const activeTabForNaming = resolveTargetTab(activeSession);
 			const isAiTab = currentMode === 'ai' && !!activeTabForNaming;
 			const hasTextMessage = effectiveInputValue.trim().length > 0;
 			const hasNoCustomName = !activeTabForNaming?.name;
@@ -939,7 +957,7 @@ export function useInputProcessing(deps: UseInputProcessingDeps): UseInputProces
 					});
 					setSessions((prev) =>
 						prev.map((s) => {
-							if (s.id !== activeSessionId) return s;
+							if (s.id !== resolvedSessionId) return s;
 							return {
 								...s,
 								aiTabs: s.aiTabs.map((t) =>
@@ -952,7 +970,7 @@ export function useInputProcessing(deps: UseInputProcessingDeps): UseInputProces
 					// Set isGeneratingName to show spinner in tab
 					setSessions((prev) =>
 						prev.map((s) => {
-							if (s.id !== activeSessionId) return s;
+							if (s.id !== resolvedSessionId) return s;
 							return {
 								...s,
 								aiTabs: s.aiTabs.map((t) =>
@@ -988,7 +1006,7 @@ export function useInputProcessing(deps: UseInputProcessingDeps): UseInputProces
 							// Clear the generating indicator
 							setSessions((prev) =>
 								prev.map((s) => {
-									if (s.id !== activeSessionId) return s;
+									if (s.id !== resolvedSessionId) return s;
 									return {
 										...s,
 										aiTabs: s.aiTabs.map((t) =>
@@ -1009,7 +1027,7 @@ export function useInputProcessing(deps: UseInputProcessingDeps): UseInputProces
 							// Update the tab name only if it's still null (user hasn't manually renamed it)
 							setSessions((prev) =>
 								prev.map((s) => {
-									if (s.id !== activeSessionId) return s;
+									if (s.id !== resolvedSessionId) return s;
 									const tab = s.aiTabs.find((t) => t.id === activeTabForNaming.id);
 									if (!tab || tab.name !== null) {
 										window.maestro.logger.log(
@@ -1052,7 +1070,7 @@ export function useInputProcessing(deps: UseInputProcessingDeps): UseInputProces
 							// Clear the generating indicator on error
 							setSessions((prev) =>
 								prev.map((s) => {
-									if (s.id !== activeSessionId) return s;
+									if (s.id !== resolvedSessionId) return s;
 									return {
 										...s,
 										aiTabs: s.aiTabs.map((t) =>
@@ -1077,7 +1095,7 @@ export function useInputProcessing(deps: UseInputProcessingDeps): UseInputProces
 						undefined;
 					const isGitRepo = await gitService.isRepo(cwdToCheck, sshIdForGit);
 					setSessions((prev) =>
-						prev.map((s) => (s.id === activeSessionId ? { ...s, isGitRepo } : s))
+						prev.map((s) => (s.id === resolvedSessionId ? { ...s, isGitRepo } : s))
 					);
 				})();
 			}
@@ -1104,7 +1122,7 @@ export function useInputProcessing(deps: UseInputProcessingDeps): UseInputProces
 
 			// Sync empty value to session state (prevents stale input restoration on blur)
 			if (isAiMode) {
-				syncAiInputToSession('');
+				syncAiInputToSession('', syncTarget);
 			} else {
 				syncTerminalInputToSession('');
 			}
@@ -1117,7 +1135,7 @@ export function useInputProcessing(deps: UseInputProcessingDeps): UseInputProces
 			const targetPid = currentMode === 'ai' ? activeSession.aiPid : activeSession.terminalPid;
 			// For batch mode (Claude), include tab ID in session ID to prevent process collision
 			// This ensures each tab's process has a unique identifier
-			const activeTabForSpawn = getActiveTab(activeSession);
+			const activeTabForSpawn = resolveTargetTab(activeSession);
 			const isForceParallel =
 				options?.forceParallel === true && useSettingsStore.getState().forcedParallelExecution;
 			const targetSessionId =
@@ -1148,11 +1166,11 @@ export function useInputProcessing(deps: UseInputProcessingDeps): UseInputProces
 
 						// IMPORTANT: Get fresh session state from ref to avoid stale closure bug
 						// If user switches tabs quickly, activeSession from closure may have wrong activeTabId
-						const freshSession = sessionsRef.current.find((s) => s.id === activeSessionId);
+						const freshSession = sessionsRef.current.find((s) => s.id === resolvedSessionId);
 						if (!freshSession) throw new Error('Session not found');
 
 						// Use the ACTIVE TAB's agentSessionId (not the deprecated session-level one)
-						const freshActiveTab = getActiveTab(freshSession);
+						const freshActiveTab = resolveTargetTab(freshSession);
 						const tabAgentSessionId = freshActiveTab?.agentSessionId;
 
 						if (!tabAgentSessionId && freshActiveTab?.logs && freshActiveTab.logs.length > 0) {
@@ -1161,7 +1179,7 @@ export function useInputProcessing(deps: UseInputProcessingDeps): UseInputProces
 								{
 									tabId: freshActiveTab.id,
 									logCount: freshActiveTab.logs.length,
-									sessionId: activeSessionId,
+									sessionId: resolvedSessionId,
 								}
 							);
 						}
@@ -1170,7 +1188,7 @@ export function useInputProcessing(deps: UseInputProcessingDeps): UseInputProces
 						// Force Send (Cmd+Shift+Enter / the Force Send button on a queued item) is an
 						// explicit override — skip the Auto Run gate, but still honor the tab's own
 						// readOnlyMode setting.
-						const currentSessionBatchState = getBatchState(activeSessionId);
+						const currentSessionBatchState = getBatchState(resolvedSessionId);
 						const isAutoRunReadOnly =
 							currentSessionBatchState.isRunning &&
 							!currentSessionBatchState.worktreeActive &&
@@ -1224,7 +1242,7 @@ export function useInputProcessing(deps: UseInputProcessingDeps): UseInputProces
 							// Clear the pending merged context from the tab
 							setSessions((prev) =>
 								prev.map((s) => {
-									if (s.id !== activeSessionId) return s;
+									if (s.id !== resolvedSessionId) return s;
 									return {
 										...s,
 										aiTabs: s.aiTabs.map((tab) =>
@@ -1301,12 +1319,13 @@ export function useInputProcessing(deps: UseInputProcessingDeps): UseInputProces
 						};
 						setSessions((prev) =>
 							prev.map((s) => {
-								if (s.id !== activeSessionId) return s;
-								// Reset active tab's state to 'idle' and add error log
+								if (s.id !== resolvedSessionId) return s;
+								const errorTabId = options?.tabId ?? s.activeTabId;
+								// Reset target tab's state to 'idle' and add error log
 								const updatedAiTabs =
 									s.aiTabs?.length > 0
 										? s.aiTabs.map((tab) =>
-												tab.id === s.activeTabId
+												tab.id === errorTabId
 													? {
 															...tab,
 															state: 'idle' as const,
@@ -1333,7 +1352,7 @@ export function useInputProcessing(deps: UseInputProcessingDeps): UseInputProces
 				if (trimmedCommand === 'clear') {
 					setSessions((prev) =>
 						prev.map((s) => {
-							if (s.id !== activeSessionId) return s;
+							if (s.id !== resolvedSessionId) return s;
 							return {
 								...s,
 								state: 'idle',
@@ -1369,7 +1388,7 @@ export function useInputProcessing(deps: UseInputProcessingDeps): UseInputProces
 						logger.error('Failed to run command:', undefined, error);
 						setSessions((prev) =>
 							prev.map((s) => {
-								if (s.id !== activeSessionId) return s;
+								if (s.id !== resolvedSessionId) return s;
 								return {
 									...s,
 									state: 'idle',
@@ -1403,7 +1422,7 @@ export function useInputProcessing(deps: UseInputProcessingDeps): UseInputProces
 					};
 					setSessions((prev) =>
 						prev.map((s) => {
-							if (s.id !== activeSessionId) return s;
+							if (s.id !== resolvedSessionId) return s;
 							// Reset active tab's state to 'idle' and add error log
 							const updatedAiTabs =
 								s.aiTabs?.length > 0

--- a/src/renderer/hooks/input/useInputProcessing.ts
+++ b/src/renderer/hooks/input/useInputProcessing.ts
@@ -18,6 +18,7 @@ import { filterYoloArgs } from '../../utils/agentArgs';
 import { hasCapabilityCached } from '../agent/useAgentCapabilities';
 import { gitService } from '../../services/git';
 import { useSettingsStore } from '../../stores/settingsStore';
+import { useSessionStore, selectActiveSession } from '../../stores/sessionStore';
 import { logger } from '../../utils/logger';
 
 let cachedImageOnlyPrompt: string = '';
@@ -51,8 +52,13 @@ export let DEFAULT_IMAGE_ONLY_PROMPT: string = getImageOnlyPrompt();
  * Dependencies for the useInputProcessing hook.
  */
 export interface UseInputProcessingDeps {
-	/** Current active session (null if none selected) */
-	activeSession: Session | null;
+	/**
+	 * Current active session. When omitted, processInput resolves the live
+	 * session via sessionsRef / getState at submit time (preferred for App so
+	 * streaming does not require a React-subscribed Session). Pass null to mean
+	 * "no session" (tests).
+	 */
+	activeSession?: Session | null;
 	/** Active session ID (may be different from activeSession.id during transitions) */
 	activeSessionId: string;
 	/** Session state setter */
@@ -156,7 +162,7 @@ export interface UseInputProcessingReturn {
  */
 export function useInputProcessing(deps: UseInputProcessingDeps): UseInputProcessingReturn {
 	const {
-		activeSession,
+		activeSession: activeSessionProp,
 		activeSessionId,
 		setSessions,
 		getInputValue,
@@ -204,6 +210,17 @@ export function useInputProcessing(deps: UseInputProcessingDeps): UseInputProces
 			// Flush any pending batched updates before processing user input
 			// This ensures AI output appears before the user's new message
 			flushBatchedUpdates?.();
+
+			// PERF: When activeSession is omitted, resolve the live session at
+			// submit time via sessionsRef / getState so callers need not pass a
+			// React-subscribed Session (streaming would re-render App). Explicit
+			// null means "no session" (tests).
+			const activeSession =
+				activeSessionProp !== undefined
+					? activeSessionProp
+					: ((activeSessionId
+							? sessionsRef.current.find((s) => s.id === activeSessionId)
+							: undefined) ?? selectActiveSession(useSessionStore.getState()));
 
 			const effectiveInputValue = overrideInputValue ?? getInputValue();
 			// When the caller passes explicit images (e.g. Force Send button replaying a
@@ -1414,7 +1431,7 @@ export function useInputProcessing(deps: UseInputProcessingDeps): UseInputProces
 			}
 		},
 		[
-			activeSession,
+			activeSessionProp,
 			activeSessionId,
 			getInputValue,
 			stagedImages,

--- a/src/renderer/hooks/input/useInputSync.ts
+++ b/src/renderer/hooks/input/useInputSync.ts
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 import type { Session } from '../../types';
+import { useSessionStore, selectActiveSession } from '../../stores/sessionStore';
 import { getActiveTab } from '../../utils/tabHelpers';
 
 /**
@@ -32,22 +33,23 @@ export interface UseInputSyncReturn {
  * Hook that provides input synchronization functions for persisting
  * local input state to session state.
  *
+ * PERF: Resolves the active session via getState() inside each sync callback.
+ * Callers must not pass a React-subscribed Session - that would re-render
+ * App / MaestroConsoleInner on every streaming log or token update.
+ *
  * Extracted from App.tsx to reduce file size and improve maintainability.
  * These are simple session state updates with no async operations.
  *
- * @param activeSession - The currently active session (can be null)
  * @param deps - Dependencies including state setters
  * @returns Object containing input sync functions
  */
-export function useInputSync(
-	activeSession: Session | null,
-	deps: UseInputSyncDeps
-): UseInputSyncReturn {
+export function useInputSync(deps: UseInputSyncDeps): UseInputSyncReturn {
 	const { setSessions } = deps;
 
 	// Function to persist AI input to session state (called on blur/submit)
 	const syncAiInputToSession = useCallback(
 		(value: string) => {
+			const activeSession = selectActiveSession(useSessionStore.getState());
 			if (!activeSession) return;
 			setSessions((prev) =>
 				prev.map((s) => {
@@ -63,19 +65,20 @@ export function useInputSync(
 				})
 			);
 		},
-		[activeSession, setSessions]
+		[setSessions]
 	);
 
 	// Function to persist terminal input to session state (called on blur/session switch)
 	const syncTerminalInputToSession = useCallback(
 		(value: string, sessionId?: string) => {
+			const activeSession = selectActiveSession(useSessionStore.getState());
 			const targetSessionId = sessionId || activeSession?.id;
 			if (!targetSessionId) return;
 			setSessions((prev) =>
 				prev.map((s) => (s.id === targetSessionId ? { ...s, terminalDraftInput: value } : s))
 			);
 		},
-		[activeSession?.id, setSessions]
+		[setSessions]
 	);
 
 	return {

--- a/src/renderer/hooks/input/useInputSync.ts
+++ b/src/renderer/hooks/input/useInputSync.ts
@@ -12,14 +12,25 @@ export interface UseInputSyncDeps {
 }
 
 /**
+ * Optional pin so blur/replay restore write to the composer that owned the draft,
+ * not whichever agent is active when the callback runs (focus can move first).
+ */
+export interface InputSyncTarget {
+	sessionId: string;
+	tabId?: string;
+}
+
+/**
  * Return type for the useInputSync hook
  */
 export interface UseInputSyncReturn {
 	/**
-	 * Persist AI input value to the active session's active tab.
+	 * Persist AI input value to a session tab.
 	 * Called on blur/submit to sync local input state to session state.
+	 * Prefer passing `target` when the write must follow a prior focus/replay
+	 * (live getState can point at a different agent after a fast switch).
 	 */
-	syncAiInputToSession: (value: string) => void;
+	syncAiInputToSession: (value: string, target?: InputSyncTarget) => void;
 	/**
 	 * Persist terminal input value to a session.
 	 * Called on blur/session switch to sync local input state to session state.
@@ -33,9 +44,9 @@ export interface UseInputSyncReturn {
  * Hook that provides input synchronization functions for persisting
  * local input state to session state.
  *
- * PERF: Resolves the active session via getState() inside each sync callback.
- * Callers must not pass a React-subscribed Session - that would re-render
- * App / MaestroConsoleInner on every streaming log or token update.
+ * PERF: Resolves the active session via getState() when no explicit target is
+ * passed. Callers must not pass a React-subscribed Session - that would
+ * re-render App / MaestroConsoleInner on every streaming log or token update.
  *
  * Extracted from App.tsx to reduce file size and improve maintainability.
  * These are simple session state updates with no async operations.
@@ -48,19 +59,19 @@ export function useInputSync(deps: UseInputSyncDeps): UseInputSyncReturn {
 
 	// Function to persist AI input to session state (called on blur/submit)
 	const syncAiInputToSession = useCallback(
-		(value: string) => {
-			const activeSession = selectActiveSession(useSessionStore.getState());
-			if (!activeSession) return;
+		(value: string, target?: InputSyncTarget) => {
+			const live = selectActiveSession(useSessionStore.getState());
+			const sessionId = target?.sessionId ?? live?.id;
+			if (!sessionId) return;
+
 			setSessions((prev) =>
 				prev.map((s) => {
-					if (s.id !== activeSession.id) return s;
-					const currentActiveTab = getActiveTab(s);
-					if (!currentActiveTab) return s;
+					if (s.id !== sessionId) return s;
+					const tabId = target?.tabId ?? getActiveTab(s)?.id;
+					if (!tabId) return s;
 					return {
 						...s,
-						aiTabs: s.aiTabs.map((tab) =>
-							tab.id === currentActiveTab.id ? { ...tab, inputValue: value } : tab
-						),
+						aiTabs: s.aiTabs.map((tab) => (tab.id === tabId ? { ...tab, inputValue: value } : tab)),
 					};
 				})
 			);

--- a/src/renderer/hooks/input/useTabCompletion.ts
+++ b/src/renderer/hooks/input/useTabCompletion.ts
@@ -67,7 +67,6 @@ export function useTabCompletion(session?: Session | null): UseTabCompletionRetu
 	// Narrow store selectors (ignored when a session is injected). When injected,
 	// each selector returns a stable undefined so Object.is bails out on stream
 	// updates and this hook does not re-render solely due to store notifications.
-	const storeActiveId = useSessionStore((s) => (injected ? undefined : s.activeSessionId));
 	const storeCwd = useSessionStore((s) => (injected ? undefined : selectActiveSession(s)?.cwd));
 	const storeShellCwd = useSessionStore((s) =>
 		injected ? undefined : selectActiveSession(s)?.shellCwd
@@ -92,17 +91,15 @@ export function useTabCompletion(session?: Session | null): UseTabCompletionRetu
 		? session
 			? pickTabCompletionFields(session)
 			: null
-		: storeActiveId
-			? {
-					cwd: storeCwd ?? '',
-					shellCwd: storeShellCwd,
-					fileTree: storeFileTree ?? [],
-					shellCommandHistory: storeShellHistory,
-					isGitRepo: storeIsGitRepo ?? false,
-					gitBranches: storeGitBranches,
-					gitTags: storeGitTags,
-				}
-			: null;
+		: {
+				cwd: storeCwd ?? '',
+				shellCwd: storeShellCwd,
+				fileTree: storeFileTree ?? [],
+				shellCommandHistory: storeShellHistory,
+				isGitRepo: storeIsGitRepo ?? false,
+				gitBranches: storeGitBranches,
+				gitTags: storeGitTags,
+			};
 
 	// Compute relative path from project root (cwd) to shell working directory (shellCwd)
 	const shellRelativePath = useMemo(() => {

--- a/src/renderer/hooks/input/useTabCompletion.ts
+++ b/src/renderer/hooks/input/useTabCompletion.ts
@@ -18,6 +18,9 @@ export type TabCompletionFilter = 'all' | 'history' | 'branch' | 'tag' | 'file';
  */
 const MAX_FILE_TREE_ENTRIES = 50_000;
 
+/** Stable empty tree so `storeFileTree ?? EMPTY_FILE_TREE` does not allocate per render. */
+const EMPTY_FILE_TREE: FileNode[] = [];
+
 export interface UseTabCompletionReturn {
 	getSuggestions: (input: string, filter?: TabCompletionFilter) => TabCompletionSuggestion[];
 }
@@ -94,7 +97,7 @@ export function useTabCompletion(session?: Session | null): UseTabCompletionRetu
 		: {
 				cwd: storeCwd ?? '',
 				shellCwd: storeShellCwd,
-				fileTree: storeFileTree ?? [],
+				fileTree: storeFileTree ?? EMPTY_FILE_TREE,
 				shellCommandHistory: storeShellHistory,
 				isGitRepo: storeIsGitRepo ?? false,
 				gitBranches: storeGitBranches,

--- a/src/renderer/hooks/input/useTabCompletion.ts
+++ b/src/renderer/hooks/input/useTabCompletion.ts
@@ -1,6 +1,7 @@
 import { useMemo, useCallback } from 'react';
 import type { Session } from '../../types';
 import type { FileNode } from '../../types/fileTree';
+import { useSessionStore, selectActiveSession } from '../../stores/sessionStore';
 
 export interface TabCompletionSuggestion {
 	value: string;
@@ -22,24 +23,94 @@ export interface UseTabCompletionReturn {
 }
 
 /**
+ * Non-streaming session fields used for tab completion.
+ * Callers must not rely on a full Session with logs / tokens.
+ */
+export type TabCompletionSessionFields = Pick<
+	Session,
+	'cwd' | 'shellCwd' | 'fileTree' | 'shellCommandHistory' | 'isGitRepo' | 'gitBranches' | 'gitTags'
+>;
+
+function pickTabCompletionFields(session: Session): TabCompletionSessionFields {
+	return {
+		cwd: session.cwd,
+		shellCwd: session.shellCwd,
+		fileTree: session.fileTree,
+		shellCommandHistory: session.shellCommandHistory,
+		isGitRepo: session.isGitRepo,
+		gitBranches: session.gitBranches,
+		gitTags: session.gitTags,
+	};
+}
+
+/**
  * Hook for providing tab completion suggestions from:
  * 1. Shell command history
  * 2. Current directory file tree (relative to shell CWD)
  * 3. Git branches and tags (for git commands in git repos)
+ *
+ * PERF: Prefer calling with no args. Then this hook subscribes only to
+ * non-streaming fields on the active session (cwd, shellCwd, fileTree,
+ * shellCommandHistory, isGitRepo, gitBranches, gitTags). Passing a Session
+ * (or null) keeps the injected-session API for tests and other call sites;
+ * when injected, store selectors return stable sentinels so streaming updates
+ * do not re-render through those subscriptions.
  *
  * Performance optimizations:
  * - fileNames is memoized to avoid re-traversing tree on every render
  * - shellHistory is memoized separately to avoid recreating on file tree changes
  * - getSuggestions is wrapped in useCallback to maintain referential equality
  */
-export function useTabCompletion(session: Session | null): UseTabCompletionReturn {
+export function useTabCompletion(session?: Session | null): UseTabCompletionReturn {
+	const injected = session !== undefined;
+
+	// Narrow store selectors (ignored when a session is injected). When injected,
+	// each selector returns a stable undefined so Object.is bails out on stream
+	// updates and this hook does not re-render solely due to store notifications.
+	const storeActiveId = useSessionStore((s) => (injected ? undefined : s.activeSessionId));
+	const storeCwd = useSessionStore((s) => (injected ? undefined : selectActiveSession(s)?.cwd));
+	const storeShellCwd = useSessionStore((s) =>
+		injected ? undefined : selectActiveSession(s)?.shellCwd
+	);
+	const storeFileTree = useSessionStore((s) =>
+		injected ? undefined : selectActiveSession(s)?.fileTree
+	);
+	const storeShellHistory = useSessionStore((s) =>
+		injected ? undefined : selectActiveSession(s)?.shellCommandHistory
+	);
+	const storeIsGitRepo = useSessionStore((s) =>
+		injected ? undefined : selectActiveSession(s)?.isGitRepo
+	);
+	const storeGitBranches = useSessionStore((s) =>
+		injected ? undefined : selectActiveSession(s)?.gitBranches
+	);
+	const storeGitTags = useSessionStore((s) =>
+		injected ? undefined : selectActiveSession(s)?.gitTags
+	);
+
+	const fields: TabCompletionSessionFields | null = injected
+		? session
+			? pickTabCompletionFields(session)
+			: null
+		: storeActiveId
+			? {
+					cwd: storeCwd ?? '',
+					shellCwd: storeShellCwd,
+					fileTree: storeFileTree ?? [],
+					shellCommandHistory: storeShellHistory,
+					isGitRepo: storeIsGitRepo ?? false,
+					gitBranches: storeGitBranches,
+					gitTags: storeGitTags,
+				}
+			: null;
+
 	// Compute relative path from project root (cwd) to shell working directory (shellCwd)
 	const shellRelativePath = useMemo(() => {
-		if (!session?.cwd || !session?.shellCwd) return '';
+		if (!fields?.cwd || !fields?.shellCwd) return '';
 
 		// Normalize paths
-		const projectRoot = session.cwd.replace(/\/$/, '');
-		const shellDir = session.shellCwd.replace(/\/$/, '');
+		const projectRoot = fields.cwd.replace(/\/$/, '');
+		const shellDir = fields.shellCwd.replace(/\/$/, '');
 
 		// If shell is at project root, no relative path needed
 		if (shellDir === projectRoot) return '';
@@ -51,12 +122,12 @@ export function useTabCompletion(session: Session | null): UseTabCompletionRetur
 
 		// Shell is outside project root - can't use file tree
 		return null;
-	}, [session?.cwd, session?.shellCwd]);
+	}, [fields?.cwd, fields?.shellCwd]);
 
 	// Build a flat list of file/folder names from the file tree
 	// Filtered to show only files relative to the shell's current working directory
 	const fileNames = useMemo(() => {
-		if (!session?.fileTree) return [];
+		if (!fields?.fileTree) return [];
 		// If shell is outside project, return empty
 		if (shellRelativePath === null) return [];
 
@@ -82,7 +153,7 @@ export function useTabCompletion(session: Session | null): UseTabCompletionRetur
 		// If we have a relative path, find that subtree first
 		if (shellRelativePath) {
 			const pathParts = shellRelativePath.split('/');
-			let currentNodes: FileNode[] = session.fileTree;
+			let currentNodes: FileNode[] = fields.fileTree;
 
 			// Navigate to the shell's current directory in the tree
 			for (const part of pathParts) {
@@ -99,21 +170,21 @@ export function useTabCompletion(session: Session | null): UseTabCompletionRetur
 			traverse(currentNodes);
 		} else {
 			// Shell is at project root - traverse entire tree
-			traverse(session.fileTree);
+			traverse(fields.fileTree);
 		}
 
 		return names;
-	}, [session?.fileTree, shellRelativePath]);
+	}, [fields?.fileTree, shellRelativePath]);
 
 	// Memoize shell history reference to avoid unnecessary getSuggestions re-creation
 	const shellHistory = useMemo(() => {
-		return session?.shellCommandHistory || [];
-	}, [session?.shellCommandHistory]);
+		return fields?.shellCommandHistory || [];
+	}, [fields?.shellCommandHistory]);
 
 	// PERF: Memoize git-related data separately to avoid getSuggestions re-creation
-	const isGitRepo = session?.isGitRepo ?? false;
-	const gitBranches = useMemo(() => session?.gitBranches || [], [session?.gitBranches]);
-	const gitTags = useMemo(() => session?.gitTags || [], [session?.gitTags]);
+	const isGitRepo = fields?.isGitRepo ?? false;
+	const gitBranches = useMemo(() => fields?.gitBranches || [], [fields?.gitBranches]);
+	const gitTags = useMemo(() => fields?.gitTags || [], [fields?.gitTags]);
 
 	// PERF: Only depend on memoized values, NOT the session object itself
 	// This prevents callback recreation on every session state change

--- a/src/renderer/hooks/props/useMainPanelProps.ts
+++ b/src/renderer/hooks/props/useMainPanelProps.ts
@@ -231,6 +231,7 @@ export interface UseMainPanelPropsDeps {
 	handleScrollPositionChange: (scrollTop: number) => void;
 	handleAtBottomChange: (isAtBottom: boolean) => void;
 	handleMainPanelInputBlur: () => void;
+	handleMainPanelInputFocus: () => void;
 	handleOpenPromptComposer: () => void;
 	handleReplayMessage: (text: string, images?: string[]) => void;
 	handleForkConversation: (logId: string) => void;
@@ -450,6 +451,7 @@ export function useMainPanelProps(deps: UseMainPanelPropsDeps) {
 			onScrollPositionChange: deps.handleScrollPositionChange,
 			onAtBottomChange: deps.handleAtBottomChange,
 			onInputBlur: deps.handleMainPanelInputBlur,
+			onComposerFocus: deps.handleMainPanelInputFocus,
 			onOpenPromptComposer: deps.handleOpenPromptComposer,
 			onReplayMessage: deps.handleReplayMessage,
 			onForkConversation: deps.handleForkConversation,
@@ -709,6 +711,7 @@ export function useMainPanelProps(deps: UseMainPanelPropsDeps) {
 			deps.handleScrollPositionChange,
 			deps.handleAtBottomChange,
 			deps.handleMainPanelInputBlur,
+			deps.handleMainPanelInputFocus,
 			deps.handleOpenPromptComposer,
 			deps.handleReplayMessage,
 			deps.handleForkConversation,

--- a/src/renderer/hooks/props/useMainPanelProps.ts
+++ b/src/renderer/hooks/props/useMainPanelProps.ts
@@ -334,7 +334,6 @@ export function useMainPanelProps(deps: UseMainPanelPropsDeps) {
 			agentSessionsOpen: deps.agentSessionsOpen,
 			memoryViewerOpen: deps.memoryViewerOpen,
 			activeAgentSessionId: deps.activeAgentSessionId,
-			activeSession: deps.activeSession,
 			theme: deps.theme,
 			isMobileLandscape: deps.isMobileLandscape,
 			stagedImages: deps.stagedImages,
@@ -574,11 +573,8 @@ export function useMainPanelProps(deps: UseMainPanelPropsDeps) {
 			deps.activeSession?.inputMode,
 			deps.activeSession?.projectRoot,
 			deps.activeSession?.cwd,
-			// Track the execution-queue reference so editing/removing/pausing/reordering
-			// a queued item recomputes this memo and the inline QUEUED list re-renders.
-			// Without it, queue mutations while the agent is idle (no other tracked dep
-			// changing) leave the transcript showing a stale queued message.
-			deps.activeSession?.executionQueue,
+			// executionQueue is NOT tracked here: MainPanel self-sources the full
+			// Session for paint, so queue edits repaint without this memo.
 			deps.theme,
 			deps.isMobileLandscape,
 			deps.stagedImages,

--- a/src/renderer/hooks/tabs/internal/useTabDerivedState.ts
+++ b/src/renderer/hooks/tabs/internal/useTabDerivedState.ts
@@ -1,11 +1,22 @@
 import { useMemo } from 'react';
+import { useStoreWithEqualityFn } from 'zustand/traditional';
 import { selectActiveSession, useSessionStore } from '../../../stores/sessionStore';
+import { activeSessionChromeEquality } from '../../../stores/sessionEquality';
 import type { BrowserTab, FilePreviewTab, UnifiedTab } from '../../../types';
 import { buildUnifiedTabs, getActiveTab } from '../../../utils/tabHelpers';
 import type { TabDerivedState } from './types';
 
+/**
+ * PERF: Subscribe with activeSessionChromeEquality so streaming log/token
+ * updates do not re-render MaestroConsoleInner (this hook is App-mounted via
+ * useTabHandlers). MainPanel self-sources the full session for live chat.
+ */
 export function useTabDerivedState(): TabDerivedState {
-	const activeSession = useSessionStore(selectActiveSession);
+	const activeSession = useStoreWithEqualityFn(
+		useSessionStore,
+		selectActiveSession,
+		activeSessionChromeEquality
+	);
 
 	const activeFileTabHistory = useMemo(() => {
 		if (!activeSession?.activeFileTabId) return [];

--- a/src/renderer/stores/sessionEquality.ts
+++ b/src/renderer/stores/sessionEquality.ts
@@ -152,3 +152,162 @@ export function projectRootSessionEquality(a: Session[], b: Session[]): boolean 
 export function selectCueDiscoverySignature(state: { sessions: Session[] }): string {
 	return state.sessions.map((s) => `${s.id}\0${s.projectRoot ?? ''}`).join('\n');
 }
+
+/**
+ * AI-tab fields needed for App shell chrome, tab strip, and AppModals flags.
+ * Deliberately omits `logs` / thinking chunks so streaming does not bust equality.
+ */
+function aiTabChromeEqual(a: AITab, b: AITab): boolean {
+	if (a === b) return true;
+	return (
+		a.id === b.id &&
+		a.name === b.name &&
+		a.state === b.state &&
+		a.starred === b.starred &&
+		a.hasUnread === b.hasUnread &&
+		a.readOnlyMode === b.readOnlyMode &&
+		a.saveToHistory === b.saveToHistory &&
+		a.showThinking === b.showThinking &&
+		a.enterToSend === b.enterToSend &&
+		a.agentSessionId === b.agentSessionId &&
+		a.autoSendOnActivate === b.autoSendOnActivate &&
+		a.customModel === b.customModel &&
+		a.customEffort === b.customEffort
+	);
+}
+
+/**
+ * Equality for the active agent when held by MaestroConsoleInner / tab chrome.
+ *
+ * Returns true when nothing the shell needs for layout, tab strip, title bar, or
+ * modal flags has changed. Streaming fields (logs, tokens, contextUsage, fileTree,
+ * workLog, etc.) are ignored so log/token flushes do not re-render the whole console.
+ *
+ * Paint leaves that need live logs (MainPanel chat) must self-subscribe with
+ * `selectActiveSession` (default Object.is) instead of this equality.
+ */
+export function activeSessionChromeEquality(a: Session | null, b: Session | null): boolean {
+	if (a === b) return true;
+	if (!a || !b) return false;
+
+	if (
+		a.id !== b.id ||
+		a.name !== b.name ||
+		a.groupId !== b.groupId ||
+		a.toolType !== b.toolType ||
+		a.inputMode !== b.inputMode ||
+		a.cwd !== b.cwd ||
+		a.shellCwd !== b.shellCwd ||
+		a.state !== b.state ||
+		a.parentSessionId !== b.parentSessionId ||
+		a.isGitRepo !== b.isGitRepo ||
+		a.isPianola !== b.isPianola ||
+		a.activeTabId !== b.activeTabId ||
+		a.activeFileTabId !== b.activeFileTabId ||
+		a.activeBrowserTabId !== b.activeBrowserTabId ||
+		a.activeTerminalTabId !== b.activeTerminalTabId ||
+		a.activeGroupId !== b.activeGroupId ||
+		a.autoRunFolderPath !== b.autoRunFolderPath ||
+		a.autoRunSelectedFile !== b.autoRunSelectedFile ||
+		a.fileExplorerExpanded !== b.fileExplorerExpanded ||
+		a.customModel !== b.customModel ||
+		a.customEffort !== b.customEffort ||
+		a.projectRoot !== b.projectRoot ||
+		a.fullPath !== b.fullPath ||
+		a.sshRemoteId !== b.sshRemoteId ||
+		a.sessionSshRemoteConfig?.remoteId !== b.sessionSshRemoteConfig?.remoteId ||
+		a.sessionSshRemoteConfig?.enabled !== b.sessionSshRemoteConfig?.enabled
+	) {
+		return false;
+	}
+
+	const aiA = a.aiTabs;
+	const aiB = b.aiTabs;
+	if (aiA !== aiB) {
+		if (!aiA || !aiB || aiA.length !== aiB.length) return false;
+		for (let i = 0; i < aiA.length; i++) {
+			if (!aiTabChromeEqual(aiA[i], aiB[i])) return false;
+		}
+	}
+
+	if (a.filePreviewTabs !== b.filePreviewTabs) {
+		const fa = a.filePreviewTabs;
+		const fb = b.filePreviewTabs;
+		if (!fa || !fb || fa.length !== fb.length) return false;
+		for (let i = 0; i < fa.length; i++) {
+			const x = fa[i];
+			const y = fb[i];
+			if (
+				x.id !== y.id ||
+				x.name !== y.name ||
+				x.path !== y.path ||
+				x.editMode !== y.editMode ||
+				x.navigationIndex !== y.navigationIndex ||
+				(x.navigationHistory?.length ?? 0) !== (y.navigationHistory?.length ?? 0)
+			) {
+				return false;
+			}
+		}
+	}
+
+	if (a.browserTabs !== b.browserTabs) {
+		const ba = a.browserTabs;
+		const bb = b.browserTabs;
+		if ((ba?.length ?? 0) !== (bb?.length ?? 0)) return false;
+		if (ba && bb) {
+			for (let i = 0; i < ba.length; i++) {
+				if (ba[i].id !== bb[i].id || ba[i].title !== bb[i].title || ba[i].url !== bb[i].url) {
+					return false;
+				}
+			}
+		}
+	}
+
+	if (a.terminalTabs !== b.terminalTabs) {
+		const ta = a.terminalTabs;
+		const tb = b.terminalTabs;
+		if ((ta?.length ?? 0) !== (tb?.length ?? 0)) return false;
+		if (ta && tb) {
+			for (let i = 0; i < ta.length; i++) {
+				if (ta[i].id !== tb[i].id || ta[i].name !== tb[i].name) return false;
+			}
+		}
+	}
+
+	if (a.unifiedTabOrder !== b.unifiedTabOrder) {
+		const ua = a.unifiedTabOrder;
+		const ub = b.unifiedTabOrder;
+		if ((ua?.length ?? 0) !== (ub?.length ?? 0)) return false;
+		if (ua && ub) {
+			for (let i = 0; i < ua.length; i++) {
+				if (ua[i].type !== ub[i].type || ua[i].id !== ub[i].id) return false;
+			}
+		}
+	}
+
+	if (a.tabGroups !== b.tabGroups) {
+		const ga = a.tabGroups;
+		const gb = b.tabGroups;
+		if ((ga?.length ?? 0) !== (gb?.length ?? 0)) return false;
+		if (ga && gb) {
+			for (let i = 0; i < ga.length; i++) {
+				if (ga[i].id !== gb[i].id || ga[i].name !== gb[i].name) return false;
+			}
+		}
+	}
+
+	if (a.agentCommands !== b.agentCommands) {
+		const ca = a.agentCommands;
+		const cb = b.agentCommands;
+		if ((ca?.length ?? 0) !== (cb?.length ?? 0)) return false;
+		if (ca && cb) {
+			for (let i = 0; i < ca.length; i++) {
+				if (ca[i].command !== cb[i].command || ca[i].description !== cb[i].description) {
+					return false;
+				}
+			}
+		}
+	}
+
+	return true;
+}

--- a/src/renderer/stores/sessionEquality.ts
+++ b/src/renderer/stores/sessionEquality.ts
@@ -187,12 +187,15 @@ function aiTabChromeEqual(a: AITab, b: AITab): boolean {
  * modal flags has changed. Streaming fields (logs, tokens, contextUsage, fileTree,
  * workLog, etc.) are ignored so log/token flushes do not re-render the whole console.
  *
+ * Invariant: any consumer of this chrome-gated slice must not read fields absent
+ * from this comparator (or those fields go silently stale). Paint/data leaves that
+ * need omitted fields (MainPanel logs, useFileTreeManagement.fileTree, summarize
+ * eligibility via contextUsage/logs) must self-subscribe with their own selector
+ * or read getState() at event time - same pattern as MainPanel.
+ *
  * Tab-strip chrome includes `isGeneratingName`, tab `agentError`, presence of
  * `pendingMergedContext`, and browser `customTitle` so rename / error / naming
  * spinners stay live under this equality.
- *
- * Paint leaves that need live logs (MainPanel chat) must self-subscribe with
- * `selectActiveSession` (default Object.is) instead of this equality.
  */
 export function activeSessionChromeEquality(a: Session | null, b: Session | null): boolean {
 	if (a === b) return true;

--- a/src/renderer/stores/sessionEquality.ts
+++ b/src/renderer/stores/sessionEquality.ts
@@ -172,7 +172,11 @@ function aiTabChromeEqual(a: AITab, b: AITab): boolean {
 		a.agentSessionId === b.agentSessionId &&
 		a.autoSendOnActivate === b.autoSendOnActivate &&
 		a.customModel === b.customModel &&
-		a.customEffort === b.customEffort
+		a.customEffort === b.customEffort &&
+		a.isGeneratingName === b.isGeneratingName &&
+		!!a.pendingMergedContext === !!b.pendingMergedContext &&
+		a.agentError?.timestamp === b.agentError?.timestamp &&
+		a.agentError?.message === b.agentError?.message
 	);
 }
 
@@ -182,6 +186,10 @@ function aiTabChromeEqual(a: AITab, b: AITab): boolean {
  * Returns true when nothing the shell needs for layout, tab strip, title bar, or
  * modal flags has changed. Streaming fields (logs, tokens, contextUsage, fileTree,
  * workLog, etc.) are ignored so log/token flushes do not re-render the whole console.
+ *
+ * Tab-strip chrome includes `isGeneratingName`, tab `agentError`, presence of
+ * `pendingMergedContext`, and browser `customTitle` so rename / error / naming
+ * spinners stay live under this equality.
  *
  * Paint leaves that need live logs (MainPanel chat) must self-subscribe with
  * `selectActiveSession` (default Object.is) instead of this equality.
@@ -256,7 +264,12 @@ export function activeSessionChromeEquality(a: Session | null, b: Session | null
 		if ((ba?.length ?? 0) !== (bb?.length ?? 0)) return false;
 		if (ba && bb) {
 			for (let i = 0; i < ba.length; i++) {
-				if (ba[i].id !== bb[i].id || ba[i].title !== bb[i].title || ba[i].url !== bb[i].url) {
+				if (
+					ba[i].id !== bb[i].id ||
+					ba[i].title !== bb[i].title ||
+					ba[i].url !== bb[i].url ||
+					ba[i].customTitle !== bb[i].customTitle
+				) {
 					return false;
 				}
 			}


### PR DESCRIPTION
## Summary
- Peel App-mounted input, interrupt, and batch hooks off full `selectActiveSession` / `sessions` subscriptions (event-time `getState()` or narrow field selectors) so streaming log/token flushes do not re-render `MaestroConsoleInner` through those paths.
- Hold App's active agent with `activeSessionChromeEquality`; MainPanel self-sources the full session for live chat; `useTabDerivedState` uses the same chrome equality.
- Stabilize empty `stagedImages` on a module-level empty array so stream rebuilds of `[]` do not wake App.
- Update MainPanel and GoalRunner tests to seed `useSessionStore` now that paint/batch no longer rely on injected full session arrays.


## Follow-ups (not in this PR)
- Remaining App-mounted `selectActiveSession` hooks (`useModalHandlers`, lifecycle, etc.)
- Relocate hook mounts out of App into leaf hosts; shrink chrome equality over time

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced unnecessary UI updates while sessions stream logs and responses, especially across the main panel, tab strip, and input handling.
  * Improved responsiveness for interruptions, submissions, and tab completion by using the latest session state at action time.

* **Bug Fixes**
  * Improved session consistency during terminal persistence, multi-window interactions, and batch workflows.
  * Fixed focus/selection behavior related to composer input so the correct target is preserved.

* **Tests**
  * Updated and expanded automated coverage to match the streamlined session-state handling and rendering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->