### PR TITLE
fix(file-preview): stop stats bar hide/show jitter on barely overflowing content

### DIFF
--- a/src/__tests__/renderer/components/FilePreview.test.tsx
+++ b/src/__tests__/renderer/components/FilePreview.test.tsx
@@ -1667,7 +1667,7 @@ print("world")
 			const container = document.querySelector('.overflow-y-auto') as HTMLElement;
 			expect(container).not.toBeNull();
 
-			// Barely overflowing — hiding the stats chrome would clamp scrollTop to 0
+			// Barely overflowing - hiding the stats chrome would clamp scrollTop to 0
 			// and re-show the bar (the jitter loop). Stay visible instead.
 			Object.defineProperty(container, 'scrollHeight', { configurable: true, value: 520 });
 			Object.defineProperty(container, 'clientHeight', { configurable: true, value: 500 });
@@ -1681,7 +1681,7 @@ print("world")
 			expect(screen.getByText('Lines:')).toBeInTheDocument();
 		});
 
-		it('hides the stats bar when scrolled with enough leftover overflow', () => {
+		it('hides the stats bar when scrolled past the chrome height with enough overflow', () => {
 			render(
 				<FilePreview
 					{...defaultProps}
@@ -1704,6 +1704,65 @@ print("world")
 			fireEvent.scroll(container);
 
 			expect(screen.queryByText('Lines:')).not.toBeInTheDocument();
+		});
+
+		it('does not hide the stats bar on a shallow scroll that would bounce after collapse', () => {
+			render(
+				<FilePreview
+					{...defaultProps}
+					file={{ name: 'test.md', content: 'Some content\n'.repeat(20), path: '/test/test.md' }}
+				/>
+			);
+
+			expect(screen.getByText('Lines:')).toBeInTheDocument();
+
+			const container = document.querySelector('.overflow-y-auto') as HTMLElement;
+			expect(container).not.toBeNull();
+
+			// Large overflow, but scrollTop is still inside the chrome band. Hiding
+			// here would collapse the header and clamp scrollTop back to "at top".
+			Object.defineProperty(container, 'scrollHeight', { configurable: true, value: 800 });
+			Object.defineProperty(container, 'clientHeight', { configurable: true, value: 500 });
+			Object.defineProperty(container, 'scrollTop', {
+				configurable: true,
+				writable: true,
+				value: 40,
+			});
+			fireEvent.scroll(container);
+
+			expect(screen.getByText('Lines:')).toBeInTheDocument();
+		});
+
+		it('resets the stats bar visible when switching to a new file at the top', () => {
+			const { rerender } = render(
+				<FilePreview
+					{...defaultProps}
+					file={{ name: 'tall.md', content: 'Some content\n'.repeat(20), path: '/test/tall.md' }}
+				/>
+			);
+
+			const container = document.querySelector('.overflow-y-auto') as HTMLElement;
+			expect(container).not.toBeNull();
+
+			Object.defineProperty(container, 'scrollHeight', { configurable: true, value: 800 });
+			Object.defineProperty(container, 'clientHeight', { configurable: true, value: 500 });
+			Object.defineProperty(container, 'scrollTop', {
+				configurable: true,
+				writable: true,
+				value: 100,
+			});
+			fireEvent.scroll(container);
+			expect(screen.queryByText('Lines:')).not.toBeInTheDocument();
+
+			rerender(
+				<FilePreview
+					{...defaultProps}
+					file={{ name: 'small.md', content: 'Short\n', path: '/test/small.md' }}
+					initialScrollTop={0}
+				/>
+			);
+
+			expect(screen.getByText('Lines:')).toBeInTheDocument();
 		});
 	});
 

--- a/src/__tests__/renderer/components/FilePreview.test.tsx
+++ b/src/__tests__/renderer/components/FilePreview.test.tsx
@@ -1653,6 +1653,58 @@ print("world")
 
 			vi.useRealTimers();
 		});
+
+		it('keeps the stats bar visible when overflow is too small to hide safely', () => {
+			render(
+				<FilePreview
+					{...defaultProps}
+					file={{ name: 'test.md', content: 'Some content\n'.repeat(20), path: '/test/test.md' }}
+				/>
+			);
+
+			expect(screen.getByText('Lines:')).toBeInTheDocument();
+
+			const container = document.querySelector('.overflow-y-auto') as HTMLElement;
+			expect(container).not.toBeNull();
+
+			// Barely overflowing — hiding the stats chrome would clamp scrollTop to 0
+			// and re-show the bar (the jitter loop). Stay visible instead.
+			Object.defineProperty(container, 'scrollHeight', { configurable: true, value: 520 });
+			Object.defineProperty(container, 'clientHeight', { configurable: true, value: 500 });
+			Object.defineProperty(container, 'scrollTop', {
+				configurable: true,
+				writable: true,
+				value: 15,
+			});
+			fireEvent.scroll(container);
+
+			expect(screen.getByText('Lines:')).toBeInTheDocument();
+		});
+
+		it('hides the stats bar when scrolled with enough leftover overflow', () => {
+			render(
+				<FilePreview
+					{...defaultProps}
+					file={{ name: 'test.md', content: 'Some content\n'.repeat(20), path: '/test/test.md' }}
+				/>
+			);
+
+			expect(screen.getByText('Lines:')).toBeInTheDocument();
+
+			const container = document.querySelector('.overflow-y-auto') as HTMLElement;
+			expect(container).not.toBeNull();
+
+			Object.defineProperty(container, 'scrollHeight', { configurable: true, value: 800 });
+			Object.defineProperty(container, 'clientHeight', { configurable: true, value: 500 });
+			Object.defineProperty(container, 'scrollTop', {
+				configurable: true,
+				writable: true,
+				value: 100,
+			});
+			fireEvent.scroll(container);
+
+			expect(screen.queryByText('Lines:')).not.toBeInTheDocument();
+		});
 	});
 
 	describe('CSV file rendering', () => {

--- a/src/renderer/components/FilePreview/FilePreview.tsx
+++ b/src/renderer/components/FilePreview/FilePreview.tsx
@@ -2,6 +2,7 @@ import React, {
 	useState,
 	useRef,
 	useEffect,
+	useLayoutEffect,
 	useMemo,
 	useCallback,
 	forwardRef,
@@ -154,7 +155,20 @@ export const FilePreview = React.memo(
 	) {
 		const [showTocOverlay, setShowTocOverlay] = useState(false);
 		const [fileStats, setFileStats] = useState<FileStats | null>(null);
-		const [showStatsBar, setShowStatsBar] = useState(true);
+		const [showStatsBar, setShowStatsBar] = useState(
+			() => initialScrollTop === undefined || initialScrollTop <= 10
+		);
+		// Track which file last drove showStatsBar so we can reset during render
+		// (before paint) when the reused scroll container switches files. An
+		// effect-only reset flashes one frame of the previous file's hidden state.
+		const showStatsBarPathRef = useRef<string | undefined>(file?.path);
+		if (file?.path !== showStatsBarPathRef.current) {
+			showStatsBarPathRef.current = file?.path;
+			const atTop = initialScrollTop === undefined || initialScrollTop <= 10;
+			if (showStatsBar !== atTop) {
+				setShowStatsBar(atTop);
+			}
+		}
 		const [tokenCount, setTokenCount] = useState<number | null>(null);
 		const [showRemoteImages, setShowRemoteImages] = useState(false);
 		const [showFullContent, setShowFullContent] = useState(false);
@@ -1054,23 +1068,29 @@ export const FilePreview = React.memo(
 		);
 
 		// Track scroll position to show/hide stats bar and report changes.
-		// Hysteresis: only hide when overflow is larger than the collapsing chrome
-		// (stats row + path line). When content is just barely taller than the
-		// viewport, hiding that chrome grows clientHeight, clamps scrollTop to 0,
-		// re-shows the bar, and the cycle jitters forever.
+		// Collapsing the stats row + path grows the viewport. Hide only when both
+		// overflow and scrollTop clear that chrome height with room to spare, so
+		// the layout change can't clamp scrollTop back into the "show" band and
+		// bounce the bar once (or forever on barely overflowing files).
 		useEffect(() => {
 			const contentEl = contentRef.current;
 			if (!contentEl) return;
 
 			// Stats subbar (~28px) + directory path row (~20px) + cushion.
-			const STATS_CHROME_HIDE_MIN_OVERFLOW = 64;
+			const STATS_CHROME_PX = 64;
+			const AT_TOP_PX = 10;
 
 			const handleScroll = () => {
 				const { scrollTop, scrollHeight, clientHeight } = contentEl;
 				const overflow = scrollHeight - clientHeight;
 				setShowStatsBar((prev) => {
-					if (scrollTop <= 10) return true;
-					if (overflow > STATS_CHROME_HIDE_MIN_OVERFLOW) return false;
+					if (scrollTop <= AT_TOP_PX) return true;
+					// Require scrollTop past chrome+at-top so after the header
+					// collapses we remain below the show threshold even if the
+					// browser preserves content position by reducing scrollTop.
+					if (overflow > STATS_CHROME_PX && scrollTop > STATS_CHROME_PX + AT_TOP_PX) {
+						return false;
+					}
 					return prev;
 				});
 
@@ -1098,9 +1118,11 @@ export const FilePreview = React.memo(
 		}, [onScrollPositionChange]);
 
 		// Restore scroll position when initialScrollTop is provided (file tab switching)
-		// Use a ref to track if we've already restored for this file to avoid re-scrolling on re-renders
+		// Use a ref to track if we've already restored for this file to avoid re-scrolling on re-renders.
+		// useLayoutEffect so leftover scrollTop from the previous file is cleared
+		// before paint (the container is reused and was not previously reset).
 		const hasRestoredScrollRef = useRef<string | null>(null);
-		useEffect(() => {
+		useLayoutEffect(() => {
 			const contentEl = contentRef.current;
 			if (!contentEl || !file?.path) return;
 
@@ -1110,13 +1132,11 @@ export const FilePreview = React.memo(
 				initialScrollTop > 0 &&
 				hasRestoredScrollRef.current !== file.path
 			) {
-				// Use requestAnimationFrame to ensure DOM is ready
-				requestAnimationFrame(() => {
-					contentEl.scrollTop = initialScrollTop;
-				});
+				contentEl.scrollTop = initialScrollTop;
 				hasRestoredScrollRef.current = file.path;
 			} else if (hasRestoredScrollRef.current !== file.path) {
 				// New file without saved scroll position - reset to top
+				contentEl.scrollTop = 0;
 				hasRestoredScrollRef.current = file.path;
 			}
 		}, [file?.path, initialScrollTop]);

--- a/src/renderer/components/FilePreview/FilePreview.tsx
+++ b/src/renderer/components/FilePreview/FilePreview.tsx
@@ -1053,14 +1053,26 @@ export const FilePreview = React.memo(
 			[file, siblingImagePath, writeEditedImage]
 		);
 
-		// Track scroll position to show/hide stats bar and report changes
+		// Track scroll position to show/hide stats bar and report changes.
+		// Hysteresis: only hide when overflow is larger than the collapsing chrome
+		// (stats row + path line). When content is just barely taller than the
+		// viewport, hiding that chrome grows clientHeight, clamps scrollTop to 0,
+		// re-shows the bar, and the cycle jitters forever.
 		useEffect(() => {
 			const contentEl = contentRef.current;
 			if (!contentEl) return;
 
+			// Stats subbar (~28px) + directory path row (~20px) + cushion.
+			const STATS_CHROME_HIDE_MIN_OVERFLOW = 64;
+
 			const handleScroll = () => {
-				// Show stats bar when scrolled to top (within 10px), hide otherwise
-				setShowStatsBar(contentEl.scrollTop <= 10);
+				const { scrollTop, scrollHeight, clientHeight } = contentEl;
+				const overflow = scrollHeight - clientHeight;
+				setShowStatsBar((prev) => {
+					if (scrollTop <= 10) return true;
+					if (overflow > STATS_CHROME_HIDE_MIN_OVERFLOW) return false;
+					return prev;
+				});
 
 				// Throttled scroll position save (200ms) - same timing as TerminalOutput
 				if (onScrollPositionChange) {

--- a/src/renderer/components/FilePreview/FilePreviewHeader.tsx
+++ b/src/renderer/components/FilePreview/FilePreviewHeader.tsx
@@ -403,7 +403,7 @@ export const FilePreviewHeader = React.memo(function FilePreviewHeader({
 					</div>
 				)}
 			</div>
-			{/* File Stats subbar - hidden on scroll */}
+			{/* File Stats subbar - hidden on scroll when overflow allows (see FilePreview) */}
 			{((fileStats || lineCount !== null || tokenCount !== null || taskCounts) && showStatsBar) ||
 			canGoBack ||
 			canGoForward ? (


### PR DESCRIPTION
Hiding the Size/Lines/Modified chrome on scroll grew the viewport enough that tiny overflow collapsed, scrollTop snapped to 0, and the bar reappeared in a loop. Only collapse that chrome when leftover overflow is larger than the header chrome.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file preview stats bar behavior while scrolling.
  * Prevented unnecessary hiding or scroll jitter when content has limited overflow.
  * Ensured the stats bar resets correctly when switching between files.
  * Improved scroll position restoration when opening files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->