### PR TITLE
perf(session): peel App hooks off activeSession subscription

### DIFF
--- a/src/__tests__/renderer/hooks/agent/useAgentSessionManagement.test.tsx
+++ b/src/__tests__/renderer/hooks/agent/useAgentSessionManagement.test.tsx
@@ -26,9 +26,16 @@ beforeEach(() => {
 	};
 });
 
-function makeDeps(activeSession: Session | null): UseAgentSessionManagementDeps {
+function seedActiveSession(session: Session | null) {
+	if (session) {
+		useSessionStore.setState({ sessions: [session], activeSessionId: session.id } as never);
+	} else {
+		useSessionStore.setState({ sessions: [], activeSessionId: null } as never);
+	}
+}
+
+function makeDeps(_activeSession?: Session | null): UseAgentSessionManagementDeps {
 	return {
-		activeSession,
 		setSessions: vi.fn(),
 		setActiveAgentSessionId: vi.fn(),
 		setAgentSessionsOpen: vi.fn(),
@@ -53,6 +60,7 @@ describe('useAgentSessionManagement - history token source capture', () => {
 			claudeInteractive: { mode: 'interactive', modeReason: 'auto' },
 		} as Partial<Session>);
 
+		seedActiveSession(activeSession);
 		const { result } = renderHook(() => useAgentSessionManagement(makeDeps(activeSession)));
 		await act(async () => {
 			await result.current.addHistoryEntry({ type: 'USER', summary: 'a turn' });
@@ -71,6 +79,7 @@ describe('useAgentSessionManagement - history token source capture', () => {
 			claudeInteractive: undefined,
 		} as Partial<Session>);
 
+		seedActiveSession(activeSession);
 		const { result } = renderHook(() => useAgentSessionManagement(makeDeps(activeSession)));
 		await act(async () => {
 			await result.current.addHistoryEntry({ type: 'USER', summary: 'a turn' });
@@ -91,6 +100,7 @@ describe('useAgentSessionManagement - history token source capture', () => {
 			claudeInteractive: { mode: 'interactive', modeReason: 'auto' },
 		} as Partial<Session>);
 
+		seedActiveSession(activeSession);
 		const { result } = renderHook(() => useAgentSessionManagement(makeDeps(activeSession)));
 		await act(async () => {
 			await result.current.addHistoryEntry({ type: 'USER', summary: 'a turn' });
@@ -107,6 +117,7 @@ describe('useAgentSessionManagement - history token source capture', () => {
 			claudeInteractive: { mode: 'interactive', modeReason: 'auto' },
 		} as Partial<Session>);
 
+		seedActiveSession(activeSession);
 		const { result } = renderHook(() => useAgentSessionManagement(makeDeps(activeSession)));
 		await act(async () => {
 			await result.current.addHistoryEntry({

--- a/src/__tests__/renderer/hooks/batch/useAutoRunHandlers.worktree.test.ts
+++ b/src/__tests__/renderer/hooks/batch/useAutoRunHandlers.worktree.test.ts
@@ -79,6 +79,21 @@ const createMockSession = (overrides: Partial<Session> = {}): Session =>
 		...overrides,
 	});
 
+/** Seed useSessionStore so handlers resolve Session via selectActiveSession(getState()). */
+function seedActiveSession(session: Session | null, extraSessions: Session[] = []) {
+	if (!session) {
+		useSessionStore.setState({ sessions: [], activeSessionId: null } as any);
+		return;
+	}
+	const byId = new Map<string, Session>();
+	for (const s of extraSessions) byId.set(s.id, s);
+	byId.set(session.id, session);
+	useSessionStore.setState({
+		sessions: Array.from(byId.values()),
+		activeSessionId: session.id,
+	} as any);
+}
+
 const createMockDeps = () => ({
 	setSessions: vi.fn(),
 	setAutoRunDocumentList: vi.fn(),
@@ -132,7 +147,8 @@ describe('handleStartBatchRun - worktree dispatch integration', () => {
 				loopEnabled: false,
 			};
 
-			const { result } = renderHook(() => useAutoRunHandlers(session, deps));
+			seedActiveSession(session);
+			const { result } = renderHook(() => useAutoRunHandlers(deps));
 
 			await act(async () => {
 				await result.current.handleStartBatchRun(config);
@@ -159,7 +175,8 @@ describe('handleStartBatchRun - worktree dispatch integration', () => {
 				loopEnabled: false,
 			};
 
-			const { result } = renderHook(() => useAutoRunHandlers(session, deps));
+			seedActiveSession(session);
+			const { result } = renderHook(() => useAutoRunHandlers(deps));
 
 			await act(async () => {
 				await result.current.handleStartBatchRun(config);
@@ -201,7 +218,7 @@ describe('handleStartBatchRun - worktree dispatch integration', () => {
 				},
 			};
 
-			const { result } = renderHook(() => useAutoRunHandlers(session, deps));
+			const { result } = renderHook(() => useAutoRunHandlers(deps));
 
 			await act(async () => {
 				await result.current.handleStartBatchRun(config);
@@ -243,7 +260,7 @@ describe('handleStartBatchRun - worktree dispatch integration', () => {
 				},
 			};
 
-			const { result } = renderHook(() => useAutoRunHandlers(session, deps));
+			const { result } = renderHook(() => useAutoRunHandlers(deps));
 
 			await act(async () => {
 				await result.current.handleStartBatchRun(config);
@@ -280,7 +297,7 @@ describe('handleStartBatchRun - worktree dispatch integration', () => {
 				},
 			};
 
-			const { result } = renderHook(() => useAutoRunHandlers(session, deps));
+			const { result } = renderHook(() => useAutoRunHandlers(deps));
 
 			await act(async () => {
 				await result.current.handleStartBatchRun(config);
@@ -310,7 +327,8 @@ describe('handleStartBatchRun - worktree dispatch integration', () => {
 				},
 			};
 
-			const { result } = renderHook(() => useAutoRunHandlers(session, deps));
+			seedActiveSession(session);
+			const { result } = renderHook(() => useAutoRunHandlers(deps));
 
 			await act(async () => {
 				await result.current.handleStartBatchRun(config);
@@ -359,7 +377,7 @@ describe('handleStartBatchRun - worktree dispatch integration', () => {
 				},
 			};
 
-			const { result } = renderHook(() => useAutoRunHandlers(session, deps));
+			const { result } = renderHook(() => useAutoRunHandlers(deps));
 
 			await act(async () => {
 				await result.current.handleStartBatchRun(config);
@@ -407,7 +425,7 @@ describe('handleStartBatchRun - worktree dispatch integration', () => {
 				},
 			};
 
-			const { result } = renderHook(() => useAutoRunHandlers(session, deps));
+			const { result } = renderHook(() => useAutoRunHandlers(deps));
 
 			await act(async () => {
 				await result.current.handleStartBatchRun(config);
@@ -449,7 +467,7 @@ describe('handleStartBatchRun - worktree dispatch integration', () => {
 				},
 			};
 
-			const { result } = renderHook(() => useAutoRunHandlers(session, deps));
+			const { result } = renderHook(() => useAutoRunHandlers(deps));
 
 			await act(async () => {
 				await result.current.handleStartBatchRun(config);
@@ -486,7 +504,7 @@ describe('handleStartBatchRun - worktree dispatch integration', () => {
 				},
 			};
 
-			const { result } = renderHook(() => useAutoRunHandlers(session, deps));
+			const { result } = renderHook(() => useAutoRunHandlers(deps));
 
 			await act(async () => {
 				await result.current.handleStartBatchRun(config);
@@ -522,7 +540,7 @@ describe('handleStartBatchRun - worktree dispatch integration', () => {
 				},
 			};
 
-			const { result } = renderHook(() => useAutoRunHandlers(session, deps));
+			const { result } = renderHook(() => useAutoRunHandlers(deps));
 
 			await act(async () => {
 				await result.current.handleStartBatchRun(config);
@@ -558,7 +576,8 @@ describe('handleStartBatchRun - worktree dispatch integration', () => {
 				},
 			};
 
-			const { result } = renderHook(() => useAutoRunHandlers(session, deps));
+			seedActiveSession(session);
+			const { result } = renderHook(() => useAutoRunHandlers(deps));
 
 			await act(async () => {
 				await result.current.handleStartBatchRun(config);
@@ -596,7 +615,8 @@ describe('handleStartBatchRun - worktree dispatch integration', () => {
 				},
 			};
 
-			const { result } = renderHook(() => useAutoRunHandlers(session, deps));
+			seedActiveSession(session);
+			const { result } = renderHook(() => useAutoRunHandlers(deps));
 
 			await act(async () => {
 				await result.current.handleStartBatchRun(config);
@@ -632,7 +652,8 @@ describe('handleStartBatchRun - worktree dispatch integration', () => {
 				},
 			};
 
-			const { result } = renderHook(() => useAutoRunHandlers(session, deps));
+			seedActiveSession(session);
+			const { result } = renderHook(() => useAutoRunHandlers(deps));
 
 			await act(async () => {
 				await result.current.handleStartBatchRun(config);
@@ -668,7 +689,8 @@ describe('handleStartBatchRun - worktree dispatch integration', () => {
 				},
 			};
 
-			const { result } = renderHook(() => useAutoRunHandlers(session, deps));
+			seedActiveSession(session);
+			const { result } = renderHook(() => useAutoRunHandlers(deps));
 
 			await act(async () => {
 				await result.current.handleStartBatchRun(config);
@@ -709,7 +731,8 @@ describe('handleStartBatchRun - worktree dispatch integration', () => {
 				},
 			};
 
-			const { result } = renderHook(() => useAutoRunHandlers(session, deps));
+			seedActiveSession(session);
+			const { result } = renderHook(() => useAutoRunHandlers(deps));
 
 			await act(async () => {
 				await result.current.handleStartBatchRun(config);
@@ -748,7 +771,8 @@ describe('handleStartBatchRun - worktree dispatch integration', () => {
 				},
 			};
 
-			const { result } = renderHook(() => useAutoRunHandlers(session, deps));
+			seedActiveSession(session);
+			const { result } = renderHook(() => useAutoRunHandlers(deps));
 
 			await act(async () => {
 				await result.current.handleStartBatchRun(config);
@@ -809,7 +833,7 @@ describe('handleStartBatchRun - worktree dispatch integration', () => {
 				},
 			};
 
-			const { result } = renderHook(() => useAutoRunHandlers(session, deps));
+			const { result } = renderHook(() => useAutoRunHandlers(deps));
 
 			await act(async () => {
 				await result.current.handleStartBatchRun(config);
@@ -864,7 +888,7 @@ describe('handleStartBatchRun - worktree dispatch integration', () => {
 				},
 			};
 
-			const { result } = renderHook(() => useAutoRunHandlers(session, deps));
+			const { result } = renderHook(() => useAutoRunHandlers(deps));
 
 			await act(async () => {
 				await result.current.handleStartBatchRun(config);
@@ -924,7 +948,7 @@ describe('handleStartBatchRun - worktree dispatch integration', () => {
 				},
 			};
 
-			const { result } = renderHook(() => useAutoRunHandlers(session, deps));
+			const { result } = renderHook(() => useAutoRunHandlers(deps));
 
 			await act(async () => {
 				await result.current.handleStartBatchRun(config);
@@ -977,7 +1001,7 @@ describe('handleStartBatchRun - worktree dispatch integration', () => {
 				},
 			};
 
-			const { result } = renderHook(() => useAutoRunHandlers(session, deps));
+			const { result } = renderHook(() => useAutoRunHandlers(deps));
 
 			await act(async () => {
 				await result.current.handleStartBatchRun(config);
@@ -1016,7 +1040,8 @@ describe('handleStartBatchRun - worktree dispatch integration', () => {
 				},
 			};
 
-			const { result } = renderHook(() => useAutoRunHandlers(session, deps));
+			seedActiveSession(session);
+			const { result } = renderHook(() => useAutoRunHandlers(deps));
 
 			await act(async () => {
 				await result.current.handleStartBatchRun(config);
@@ -1052,7 +1077,8 @@ describe('handleStartBatchRun - worktree dispatch integration', () => {
 				},
 			};
 
-			const { result } = renderHook(() => useAutoRunHandlers(session, deps));
+			seedActiveSession(session);
+			const { result } = renderHook(() => useAutoRunHandlers(deps));
 
 			await act(async () => {
 				await result.current.handleStartBatchRun(config);
@@ -1082,7 +1108,8 @@ describe('handleStartBatchRun - worktree dispatch integration', () => {
 				},
 			};
 
-			const { result } = renderHook(() => useAutoRunHandlers(session, deps));
+			seedActiveSession(session);
+			const { result } = renderHook(() => useAutoRunHandlers(deps));
 
 			await act(async () => {
 				await result.current.handleStartBatchRun(config);
@@ -1118,7 +1145,8 @@ describe('handleStartBatchRun - worktree dispatch integration', () => {
 				},
 			};
 
-			const { result } = renderHook(() => useAutoRunHandlers(session, deps));
+			seedActiveSession(session);
+			const { result } = renderHook(() => useAutoRunHandlers(deps));
 
 			await act(async () => {
 				await result.current.handleStartBatchRun(config);
@@ -1147,7 +1175,8 @@ describe('handleStartBatchRun - worktree dispatch integration', () => {
 				},
 			};
 
-			const { result } = renderHook(() => useAutoRunHandlers(session, deps));
+			seedActiveSession(session);
+			const { result } = renderHook(() => useAutoRunHandlers(deps));
 
 			await act(async () => {
 				await result.current.handleStartBatchRun(config);
@@ -1182,14 +1211,18 @@ describe('handleStartBatchRun - worktree dispatch integration', () => {
 				},
 			};
 
-			const { result } = renderHook(() => useAutoRunHandlers(session, deps));
+			seedActiveSession(session);
+			const { result } = renderHook(() => useAutoRunHandlers(deps));
 
 			await act(async () => {
 				await result.current.handleStartBatchRun(config);
 			});
 
 			const sessions = useSessionStore.getState().sessions;
-			expect(sessions).toHaveLength(0);
+			// Parent must be seeded for the handler; failure must not spawn a worktree child.
+			expect(sessions).toHaveLength(1);
+			expect(sessions[0].id).toBe(session.id);
+			expect(sessions[0].parentSessionId).toBeUndefined();
 		});
 
 		it('handles unexpected exception from worktreeSetup gracefully', async () => {
@@ -1211,7 +1244,8 @@ describe('handleStartBatchRun - worktree dispatch integration', () => {
 				},
 			};
 
-			const { result } = renderHook(() => useAutoRunHandlers(session, deps));
+			seedActiveSession(session);
+			const { result } = renderHook(() => useAutoRunHandlers(deps));
 
 			await act(async () => {
 				await result.current.handleStartBatchRun(config);
@@ -1250,7 +1284,8 @@ describe('handleStartBatchRun - worktree dispatch integration', () => {
 				},
 			};
 
-			const { result } = renderHook(() => useAutoRunHandlers(session, deps));
+			seedActiveSession(session);
+			const { result } = renderHook(() => useAutoRunHandlers(deps));
 
 			await act(async () => {
 				await result.current.handleStartBatchRun(config);
@@ -1288,7 +1323,8 @@ describe('handleStartBatchRun - worktree dispatch integration', () => {
 				},
 			};
 
-			const { result } = renderHook(() => useAutoRunHandlers(session, deps));
+			seedActiveSession(session);
+			const { result } = renderHook(() => useAutoRunHandlers(deps));
 
 			await act(async () => {
 				await result.current.handleStartBatchRun(config);
@@ -1319,7 +1355,8 @@ describe('handleStartBatchRun - worktree dispatch integration', () => {
 				},
 			};
 
-			const { result } = renderHook(() => useAutoRunHandlers(session, deps));
+			seedActiveSession(session);
+			const { result } = renderHook(() => useAutoRunHandlers(deps));
 
 			await act(async () => {
 				await result.current.handleStartBatchRun(config);
@@ -1351,7 +1388,8 @@ describe('handleStartBatchRun - worktree dispatch integration', () => {
 				},
 			};
 
-			const { result } = renderHook(() => useAutoRunHandlers(session, deps));
+			seedActiveSession(session);
+			const { result } = renderHook(() => useAutoRunHandlers(deps));
 
 			await act(async () => {
 				await result.current.handleStartBatchRun(config);
@@ -1392,7 +1430,8 @@ describe('handleStartBatchRun - worktree dispatch integration', () => {
 				},
 			};
 
-			const { result } = renderHook(() => useAutoRunHandlers(session, deps));
+			seedActiveSession(session);
+			const { result } = renderHook(() => useAutoRunHandlers(deps));
 
 			await act(async () => {
 				await result.current.handleStartBatchRun(config);
@@ -1440,7 +1479,8 @@ describe('handleStartBatchRun - worktree dispatch integration', () => {
 				},
 			};
 
-			const { result } = renderHook(() => useAutoRunHandlers(session, deps));
+			seedActiveSession(session);
+			const { result } = renderHook(() => useAutoRunHandlers(deps));
 
 			await act(async () => {
 				await result.current.handleStartBatchRun(config);
@@ -1479,7 +1519,8 @@ describe('handleStartBatchRun - worktree dispatch integration', () => {
 				},
 			};
 
-			const { result } = renderHook(() => useAutoRunHandlers(session, deps));
+			seedActiveSession(session);
+			const { result } = renderHook(() => useAutoRunHandlers(deps));
 
 			await act(async () => {
 				await result.current.handleStartBatchRun(config);
@@ -1507,7 +1548,8 @@ describe('handleStartBatchRun - worktree dispatch integration', () => {
 				},
 			};
 
-			const { result } = renderHook(() => useAutoRunHandlers(session, deps));
+			seedActiveSession(session);
+			const { result } = renderHook(() => useAutoRunHandlers(deps));
 
 			await act(async () => {
 				await result.current.handleStartBatchRun(config);
@@ -1545,7 +1587,8 @@ describe('handleStartBatchRun - worktree dispatch integration', () => {
 				},
 			};
 
-			const { result } = renderHook(() => useAutoRunHandlers(session, deps));
+			seedActiveSession(session);
+			const { result } = renderHook(() => useAutoRunHandlers(deps));
 
 			await act(async () => {
 				await result.current.handleStartBatchRun(config);
@@ -1589,7 +1632,8 @@ describe('handleStartBatchRun - worktree dispatch integration', () => {
 				},
 			};
 
-			const { result } = renderHook(() => useAutoRunHandlers(session, deps));
+			seedActiveSession(session);
+			const { result } = renderHook(() => useAutoRunHandlers(deps));
 
 			await act(async () => {
 				await result.current.handleStartBatchRun(config);
@@ -1646,7 +1690,7 @@ describe('handleStartBatchRun - worktree dispatch integration', () => {
 				},
 			};
 
-			const { result } = renderHook(() => useAutoRunHandlers(child, deps));
+			const { result } = renderHook(() => useAutoRunHandlers(deps));
 
 			await act(async () => {
 				await result.current.handleStartBatchRun(config);
@@ -1701,7 +1745,7 @@ describe('handleStartBatchRun - worktree dispatch integration', () => {
 				},
 			};
 
-			const { result } = renderHook(() => useAutoRunHandlers(child, deps));
+			const { result } = renderHook(() => useAutoRunHandlers(deps));
 
 			await act(async () => {
 				await result.current.handleStartBatchRun(config);

--- a/src/__tests__/renderer/hooks/useAgentExecution.test.ts
+++ b/src/__tests__/renderer/hooks/useAgentExecution.test.ts
@@ -115,7 +115,7 @@ describe('useAgentExecution', () => {
 
 		const { result } = renderHook(() =>
 			useAgentExecution({
-				activeSession: session,
+				activeSessionId: session.id,
 				sessionsRef,
 				setSessions,
 				processQueuedItemRef,
@@ -182,7 +182,7 @@ describe('useAgentExecution', () => {
 
 		const { result } = renderHook(() =>
 			useAgentExecution({
-				activeSession: session,
+				activeSessionId: session.id,
 				sessionsRef,
 				setSessions,
 				processQueuedItemRef,
@@ -226,7 +226,7 @@ describe('useAgentExecution', () => {
 
 		const { result } = renderHook(() =>
 			useAgentExecution({
-				activeSession: session,
+				activeSessionId: session.id,
 				sessionsRef,
 				setSessions,
 				processQueuedItemRef,
@@ -270,7 +270,7 @@ describe('useAgentExecution', () => {
 
 		const { result } = renderHook(() =>
 			useAgentExecution({
-				activeSession: session,
+				activeSessionId: session.id,
 				sessionsRef,
 				setSessions,
 				processQueuedItemRef,
@@ -316,7 +316,7 @@ describe('useAgentExecution', () => {
 
 		const { result } = renderHook(() =>
 			useAgentExecution({
-				activeSession: session,
+				activeSessionId: session.id,
 				sessionsRef,
 				setSessions,
 				processQueuedItemRef,
@@ -360,7 +360,7 @@ describe('useAgentExecution', () => {
 
 		const { result } = renderHook(() =>
 			useAgentExecution({
-				activeSession: session,
+				activeSessionId: session.id,
 				sessionsRef,
 				setSessions,
 				processQueuedItemRef,
@@ -407,7 +407,7 @@ describe('useAgentExecution', () => {
 
 		const { result } = renderHook(() =>
 			useAgentExecution({
-				activeSession: session,
+				activeSessionId: session.id,
 				sessionsRef,
 				setSessions,
 				processQueuedItemRef,
@@ -474,7 +474,7 @@ describe('useAgentExecution', () => {
 
 		const { result } = renderHook(() =>
 			useAgentExecution({
-				activeSession: session,
+				activeSessionId: session.id,
 				sessionsRef,
 				setSessions: vi.fn(),
 				processQueuedItemRef: { current: null },
@@ -509,7 +509,7 @@ describe('useAgentExecution', () => {
 
 		const { result } = renderHook(() =>
 			useAgentExecution({
-				activeSession: session,
+				activeSessionId: session.id,
 				sessionsRef,
 				setSessions,
 				processQueuedItemRef: { current: null },
@@ -559,7 +559,7 @@ describe('useAgentExecution', () => {
 
 		const { result } = renderHook(() =>
 			useAgentExecution({
-				activeSession: session,
+				activeSessionId: session.id,
 				sessionsRef,
 				setSessions: vi.fn(),
 				processQueuedItemRef: { current: null },
@@ -591,7 +591,7 @@ describe('useAgentExecution', () => {
 		function renderForWatchdog(session: Session) {
 			return renderHook(() =>
 				useAgentExecution({
-					activeSession: session,
+					activeSessionId: session.id,
 					sessionsRef: { current: [session] },
 					setSessions: vi.fn(),
 					processQueuedItemRef: { current: null },

--- a/src/__tests__/renderer/hooks/useAgentSessionManagement.test.ts
+++ b/src/__tests__/renderer/hooks/useAgentSessionManagement.test.ts
@@ -33,6 +33,14 @@ const createMockSession = (overrides: Partial<Session> = {}): Session => {
 	});
 };
 
+function seedActiveSession(session: Session | null) {
+	if (session) {
+		useSessionStore.setState({ sessions: [session], activeSessionId: session.id } as any);
+	} else {
+		useSessionStore.setState({ sessions: [], activeSessionId: null } as any);
+	}
+}
+
 describe('useAgentSessionManagement', () => {
 	const originalMaestro = { ...window.maestro };
 
@@ -80,9 +88,9 @@ describe('useAgentSessionManagement', () => {
 		const rightPanelRef = createRightPanelRef();
 		const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1700000000123);
 
+		seedActiveSession(activeSession);
 		const { result } = renderHook(() =>
 			useAgentSessionManagement({
-				activeSession,
 				setSessions: vi.fn(),
 				setActiveAgentSessionId: vi.fn(),
 				setAgentSessionsOpen: vi.fn(),
@@ -132,9 +140,9 @@ describe('useAgentSessionManagement', () => {
 
 		const rightPanelRef = createRightPanelRef();
 
+		seedActiveSession(activeSession);
 		const { result } = renderHook(() =>
 			useAgentSessionManagement({
-				activeSession,
 				setSessions: vi.fn(),
 				setActiveAgentSessionId: vi.fn(),
 				setAgentSessionsOpen: vi.fn(),
@@ -174,9 +182,9 @@ describe('useAgentSessionManagement', () => {
 
 		const rightPanelRef = createRightPanelRef();
 
+		seedActiveSession(activeSession);
 		const { result } = renderHook(() =>
 			useAgentSessionManagement({
-				activeSession,
 				setSessions: vi.fn(),
 				setActiveAgentSessionId: vi.fn(),
 				setAgentSessionsOpen: vi.fn(),
@@ -216,9 +224,9 @@ describe('useAgentSessionManagement', () => {
 		const setSessions = vi.fn();
 		const setActiveAgentSessionId = vi.fn();
 
+		seedActiveSession(activeSession);
 		const { result } = renderHook(() =>
 			useAgentSessionManagement({
-				activeSession,
 				setSessions,
 				setActiveAgentSessionId,
 				setAgentSessionsOpen: vi.fn(),
@@ -257,9 +265,9 @@ describe('useAgentSessionManagement', () => {
 		});
 		const setSessions = vi.fn();
 
+		seedActiveSession(activeSession);
 		const { result } = renderHook(() =>
 			useAgentSessionManagement({
-				activeSession,
 				setSessions,
 				setActiveAgentSessionId: vi.fn(),
 				setAgentSessionsOpen: vi.fn(),
@@ -313,9 +321,9 @@ describe('useAgentSessionManagement', () => {
 			hasMore: false,
 		});
 
+		seedActiveSession(activeSession);
 		const { result } = renderHook(() =>
 			useAgentSessionManagement({
-				activeSession,
 				setSessions,
 				setActiveAgentSessionId,
 				setAgentSessionsOpen: vi.fn(),
@@ -365,9 +373,9 @@ describe('useAgentSessionManagement', () => {
 			hasMore: false,
 		});
 
+		seedActiveSession(activeSession);
 		const { result } = renderHook(() =>
 			useAgentSessionManagement({
-				activeSession,
 				setSessions,
 				setActiveAgentSessionId: vi.fn(),
 				setAgentSessionsOpen: vi.fn(),
@@ -415,9 +423,9 @@ describe('useAgentSessionManagement', () => {
 			hasMore: false,
 		});
 
+		seedActiveSession(activeSession);
 		const { result } = renderHook(() =>
 			useAgentSessionManagement({
-				activeSession,
 				setSessions,
 				setActiveAgentSessionId: vi.fn(),
 				setAgentSessionsOpen: vi.fn(),
@@ -464,9 +472,9 @@ describe('useAgentSessionManagement', () => {
 			'agent-456': { sessionName: 'Loaded Session', starred: true },
 		});
 
+		seedActiveSession(activeSession);
 		const { result } = renderHook(() =>
 			useAgentSessionManagement({
-				activeSession,
 				setSessions,
 				setActiveAgentSessionId,
 				setAgentSessionsOpen: vi.fn(),
@@ -551,9 +559,9 @@ describe('useAgentSessionManagement', () => {
 
 		window.maestro.claude.getSessionOrigins = vi.fn().mockResolvedValue({});
 
+		seedActiveSession(activeSession);
 		const { result } = renderHook(() =>
 			useAgentSessionManagement({
-				activeSession,
 				setSessions,
 				setActiveAgentSessionId,
 				setAgentSessionsOpen: vi.fn(),
@@ -583,9 +591,9 @@ describe('useAgentSessionManagement', () => {
 		const activeSession = createMockSession({ projectRoot: '/test/project' });
 		const setSessions = vi.fn();
 
+		seedActiveSession(activeSession);
 		const { result } = renderHook(() =>
 			useAgentSessionManagement({
-				activeSession,
 				setSessions,
 				setActiveAgentSessionId: vi.fn(),
 				setAgentSessionsOpen: vi.fn(),
@@ -654,9 +662,9 @@ describe('useAgentSessionManagement', () => {
 		});
 		window.maestro.claude.getSessionOrigins = vi.fn().mockResolvedValue({});
 
+		seedActiveSession(activeSession);
 		const { result } = renderHook(() =>
 			useAgentSessionManagement({
-				activeSession,
 				setSessions,
 				setActiveAgentSessionId,
 				setAgentSessionsOpen: vi.fn(),
@@ -693,9 +701,9 @@ describe('useAgentSessionManagement', () => {
 			.mockRejectedValue(new Error('ENOENT: no such file or directory'));
 		window.maestro.claude.getSessionOrigins = vi.fn().mockResolvedValue({});
 
+		seedActiveSession(activeSession);
 		const { result } = renderHook(() =>
 			useAgentSessionManagement({
-				activeSession,
 				setSessions,
 				setActiveAgentSessionId: vi.fn(),
 				setAgentSessionsOpen: vi.fn(),
@@ -745,9 +753,9 @@ describe('useAgentSessionManagement', () => {
 		});
 		window.maestro.claude.getSessionOrigins = vi.fn().mockResolvedValue({});
 
+		seedActiveSession(activeSession);
 		const { result } = renderHook(() =>
 			useAgentSessionManagement({
-				activeSession,
 				setSessions,
 				setActiveAgentSessionId: vi.fn(),
 				setAgentSessionsOpen: vi.fn(),
@@ -777,9 +785,9 @@ describe('useAgentSessionManagement', () => {
 		});
 		window.maestro.claude.getSessionOrigins = vi.fn().mockResolvedValue({});
 
+		seedActiveSession(activeSession);
 		const { result } = renderHook(() =>
 			useAgentSessionManagement({
-				activeSession,
 				setSessions: vi.fn(),
 				setActiveAgentSessionId: vi.fn(),
 				setAgentSessionsOpen: vi.fn(),
@@ -806,9 +814,9 @@ describe('useAgentSessionManagement', () => {
 			.mockResolvedValue({ messages: [], total: 0, hasMore: false });
 		window.maestro.claude.getSessionOrigins = vi.fn().mockResolvedValue({});
 
+		seedActiveSession(activeSession);
 		const { result } = renderHook(() =>
 			useAgentSessionManagement({
-				activeSession,
 				setSessions: vi.fn(),
 				setActiveAgentSessionId: vi.fn(),
 				setAgentSessionsOpen: vi.fn(),
@@ -850,7 +858,10 @@ describe('useAgentSessionManagement', () => {
 		});
 
 		const previousStore = useSessionStore.getState();
-		useSessionStore.setState({ sessions: [activeSession, targetSession] });
+		useSessionStore.setState({
+			sessions: [activeSession, targetSession],
+			activeSessionId: activeSession.id,
+		});
 
 		const setActiveAgentSessionId = vi.fn();
 		window.maestro.agentSessions.read = vi.fn().mockResolvedValue({
@@ -865,12 +876,12 @@ describe('useAgentSessionManagement', () => {
 		try {
 			const { result } = renderHook(() =>
 				useAgentSessionManagement({
-					activeSession,
 					setSessions: vi.fn(),
 					setActiveAgentSessionId,
 					setAgentSessionsOpen: vi.fn(),
 					rightPanelRef: createRightPanelRef(),
 					defaultSaveToHistory: true,
+					defaultShowThinking: 'off',
 				})
 			);
 

--- a/src/__tests__/renderer/hooks/useAutoRunHandlers.test.ts
+++ b/src/__tests__/renderer/hooks/useAutoRunHandlers.test.ts
@@ -59,6 +59,15 @@ const createMockSession = (overrides: Partial<Session> = {}): Session =>
 		...overrides,
 	});
 
+/** Seed useSessionStore so handlers resolve Session via selectActiveSession(getState()). */
+function seedActiveSession(session: Session | null) {
+	if (session) {
+		useSessionStore.setState({ sessions: [session], activeSessionId: session.id } as any);
+	} else {
+		useSessionStore.setState({ sessions: [], activeSessionId: null } as any);
+	}
+}
+
 const createMockDeps = () => ({
 	setSessions: vi.fn(),
 	setAutoRunDocumentList: vi.fn(),
@@ -99,7 +108,8 @@ describe('useAutoRunHandlers', () => {
 			const mockSession = createMockSession();
 			const mockDeps = createMockDeps();
 
-			const { result } = renderHook(() => useAutoRunHandlers(mockSession, mockDeps));
+			seedActiveSession(mockSession);
+			const { result } = renderHook(() => useAutoRunHandlers(mockDeps));
 
 			await act(async () => {
 				await result.current.handleAutoRunContentChange('Updated content');
@@ -115,7 +125,8 @@ describe('useAutoRunHandlers', () => {
 			const mockSession = createMockSession();
 			const mockDeps = createMockDeps();
 
-			const { result } = renderHook(() => useAutoRunHandlers(mockSession, mockDeps));
+			seedActiveSession(mockSession);
+			const { result } = renderHook(() => useAutoRunHandlers(mockDeps));
 
 			await act(async () => {
 				await result.current.handleAutoRunContentChange('New content');
@@ -128,7 +139,8 @@ describe('useAutoRunHandlers', () => {
 		it('should do nothing when activeSession is null', async () => {
 			const mockDeps = createMockDeps();
 
-			const { result } = renderHook(() => useAutoRunHandlers(null, mockDeps));
+			seedActiveSession(null);
+			const { result } = renderHook(() => useAutoRunHandlers(mockDeps));
 
 			await act(async () => {
 				await result.current.handleAutoRunContentChange('Content');
@@ -141,7 +153,8 @@ describe('useAutoRunHandlers', () => {
 			const mockSession = createMockSession({ id: 'session-2' });
 			const mockDeps = createMockDeps();
 
-			const { result } = renderHook(() => useAutoRunHandlers(mockSession, mockDeps));
+			seedActiveSession(mockSession);
+			const { result } = renderHook(() => useAutoRunHandlers(mockDeps));
 
 			await act(async () => {
 				await result.current.handleAutoRunContentChange('Session 2 content');
@@ -164,7 +177,8 @@ describe('useAutoRunHandlers', () => {
 			const mockSession = createMockSession();
 			const mockDeps = createMockDeps();
 
-			const { result } = renderHook(() => useAutoRunHandlers(mockSession, mockDeps));
+			seedActiveSession(mockSession);
+			const { result } = renderHook(() => useAutoRunHandlers(mockDeps));
 
 			await act(async () => {
 				await result.current.handleAutoRunContentChange('');
@@ -185,7 +199,8 @@ describe('useAutoRunHandlers', () => {
 			const mockSession = createMockSession({ autoRunMode: 'preview' });
 			const mockDeps = createMockDeps();
 
-			const { result } = renderHook(() => useAutoRunHandlers(mockSession, mockDeps));
+			seedActiveSession(mockSession);
+			const { result } = renderHook(() => useAutoRunHandlers(mockDeps));
 
 			act(() => {
 				result.current.handleAutoRunModeChange('edit');
@@ -200,7 +215,8 @@ describe('useAutoRunHandlers', () => {
 			const mockSession = createMockSession({ autoRunMode: 'edit' });
 			const mockDeps = createMockDeps();
 
-			const { result } = renderHook(() => useAutoRunHandlers(mockSession, mockDeps));
+			seedActiveSession(mockSession);
+			const { result } = renderHook(() => useAutoRunHandlers(mockDeps));
 
 			act(() => {
 				result.current.handleAutoRunModeChange('preview');
@@ -214,7 +230,8 @@ describe('useAutoRunHandlers', () => {
 		it('should do nothing when activeSession is null', () => {
 			const mockDeps = createMockDeps();
 
-			const { result } = renderHook(() => useAutoRunHandlers(null, mockDeps));
+			seedActiveSession(null);
+			const { result } = renderHook(() => useAutoRunHandlers(mockDeps));
 
 			act(() => {
 				result.current.handleAutoRunModeChange('edit');
@@ -227,7 +244,8 @@ describe('useAutoRunHandlers', () => {
 			const mockSession = createMockSession({ id: 'session-2', autoRunMode: 'edit' });
 			const mockDeps = createMockDeps();
 
-			const { result } = renderHook(() => useAutoRunHandlers(mockSession, mockDeps));
+			seedActiveSession(mockSession);
+			const { result } = renderHook(() => useAutoRunHandlers(mockDeps));
 
 			act(() => {
 				result.current.handleAutoRunModeChange('preview');
@@ -254,7 +272,8 @@ describe('useAutoRunHandlers', () => {
 			const mockSession = createMockSession();
 			const mockDeps = createMockDeps();
 
-			const { result } = renderHook(() => useAutoRunHandlers(mockSession, mockDeps));
+			seedActiveSession(mockSession);
+			const { result } = renderHook(() => useAutoRunHandlers(mockDeps));
 
 			act(() => {
 				result.current.handleAutoRunStateChange({
@@ -276,7 +295,8 @@ describe('useAutoRunHandlers', () => {
 		it('should do nothing when activeSession is null', () => {
 			const mockDeps = createMockDeps();
 
-			const { result } = renderHook(() => useAutoRunHandlers(null, mockDeps));
+			seedActiveSession(null);
+			const { result } = renderHook(() => useAutoRunHandlers(mockDeps));
 
 			act(() => {
 				result.current.handleAutoRunStateChange({
@@ -305,7 +325,8 @@ describe('useAutoRunHandlers', () => {
 				content: '# Phase 2\n\nNew document content',
 			});
 
-			const { result } = renderHook(() => useAutoRunHandlers(mockSession, mockDeps));
+			seedActiveSession(mockSession);
+			const { result } = renderHook(() => useAutoRunHandlers(mockDeps));
 
 			await act(async () => {
 				await result.current.handleAutoRunSelectDocument('Phase 2');
@@ -333,7 +354,8 @@ describe('useAutoRunHandlers', () => {
 				content: undefined,
 			});
 
-			const { result } = renderHook(() => useAutoRunHandlers(mockSession, mockDeps));
+			seedActiveSession(mockSession);
+			const { result } = renderHook(() => useAutoRunHandlers(mockDeps));
 
 			await act(async () => {
 				await result.current.handleAutoRunSelectDocument('Missing Doc');
@@ -348,7 +370,8 @@ describe('useAutoRunHandlers', () => {
 		it('should do nothing when activeSession is null', async () => {
 			const mockDeps = createMockDeps();
 
-			const { result } = renderHook(() => useAutoRunHandlers(null, mockDeps));
+			seedActiveSession(null);
+			const { result } = renderHook(() => useAutoRunHandlers(mockDeps));
 
 			await act(async () => {
 				await result.current.handleAutoRunSelectDocument('Phase 1');
@@ -362,7 +385,8 @@ describe('useAutoRunHandlers', () => {
 			const mockSession = createMockSession({ autoRunFolderPath: undefined });
 			const mockDeps = createMockDeps();
 
-			const { result } = renderHook(() => useAutoRunHandlers(mockSession, mockDeps));
+			seedActiveSession(mockSession);
+			const { result } = renderHook(() => useAutoRunHandlers(mockDeps));
 
 			await act(async () => {
 				await result.current.handleAutoRunSelectDocument('Phase 1');
@@ -381,7 +405,8 @@ describe('useAutoRunHandlers', () => {
 				content: 'Content',
 			});
 
-			const { result } = renderHook(() => useAutoRunHandlers(mockSession, mockDeps));
+			seedActiveSession(mockSession);
+			const { result } = renderHook(() => useAutoRunHandlers(mockDeps));
 
 			await act(async () => {
 				await result.current.handleAutoRunSelectDocument('Phase 2');
@@ -409,7 +434,8 @@ describe('useAutoRunHandlers', () => {
 				tree: [],
 			});
 
-			const { result } = renderHook(() => useAutoRunHandlers(mockSession, mockDeps));
+			seedActiveSession(mockSession);
+			const { result } = renderHook(() => useAutoRunHandlers(mockDeps));
 
 			await act(async () => {
 				await result.current.handleAutoRunRefresh();
@@ -438,7 +464,8 @@ describe('useAutoRunHandlers', () => {
 				tree: [],
 			});
 
-			const { result } = renderHook(() => useAutoRunHandlers(mockSession, mockDeps));
+			seedActiveSession(mockSession);
+			const { result } = renderHook(() => useAutoRunHandlers(mockDeps));
 
 			await act(async () => {
 				await result.current.handleAutoRunRefresh();
@@ -458,7 +485,8 @@ describe('useAutoRunHandlers', () => {
 				tree: [],
 			});
 
-			const { result } = renderHook(() => useAutoRunHandlers(mockSession, mockDeps));
+			seedActiveSession(mockSession);
+			const { result } = renderHook(() => useAutoRunHandlers(mockDeps));
 
 			await act(async () => {
 				await result.current.handleAutoRunRefresh();
@@ -478,7 +506,8 @@ describe('useAutoRunHandlers', () => {
 				tree: [],
 			});
 
-			const { result } = renderHook(() => useAutoRunHandlers(mockSession, mockDeps));
+			seedActiveSession(mockSession);
+			const { result } = renderHook(() => useAutoRunHandlers(mockDeps));
 
 			await act(async () => {
 				await result.current.handleAutoRunRefresh();
@@ -499,7 +528,8 @@ describe('useAutoRunHandlers', () => {
 				tree: [],
 			});
 
-			const { result } = renderHook(() => useAutoRunHandlers(mockSession, mockDeps));
+			seedActiveSession(mockSession);
+			const { result } = renderHook(() => useAutoRunHandlers(mockDeps));
 
 			await act(async () => {
 				await result.current.handleAutoRunRefresh();
@@ -519,7 +549,8 @@ describe('useAutoRunHandlers', () => {
 		it('should do nothing when activeSession is null', async () => {
 			const mockDeps = createMockDeps();
 
-			const { result } = renderHook(() => useAutoRunHandlers(null, mockDeps));
+			seedActiveSession(null);
+			const { result } = renderHook(() => useAutoRunHandlers(mockDeps));
 
 			await act(async () => {
 				await result.current.handleAutoRunRefresh();
@@ -532,7 +563,8 @@ describe('useAutoRunHandlers', () => {
 			const mockSession = createMockSession({ autoRunFolderPath: undefined });
 			const mockDeps = createMockDeps();
 
-			const { result } = renderHook(() => useAutoRunHandlers(mockSession, mockDeps));
+			seedActiveSession(mockSession);
+			const { result } = renderHook(() => useAutoRunHandlers(mockDeps));
 
 			await act(async () => {
 				await result.current.handleAutoRunRefresh();
@@ -551,7 +583,8 @@ describe('useAutoRunHandlers', () => {
 				tree: [],
 			});
 
-			const { result } = renderHook(() => useAutoRunHandlers(mockSession, mockDeps));
+			seedActiveSession(mockSession);
+			const { result } = renderHook(() => useAutoRunHandlers(mockDeps));
 
 			await act(async () => {
 				await result.current.handleAutoRunRefresh();
@@ -577,7 +610,8 @@ describe('useAutoRunHandlers', () => {
 				tree: [],
 			});
 
-			const { result } = renderHook(() => useAutoRunHandlers(mockSession, mockDeps));
+			seedActiveSession(mockSession);
+			const { result } = renderHook(() => useAutoRunHandlers(mockDeps));
 
 			let success: boolean = false;
 			await act(async () => {
@@ -604,7 +638,8 @@ describe('useAutoRunHandlers', () => {
 				tree: [{ name: 'Phase 1', type: 'file', path: 'Phase 1.md' }],
 			});
 
-			const { result } = renderHook(() => useAutoRunHandlers(mockSession, mockDeps));
+			seedActiveSession(mockSession);
+			const { result } = renderHook(() => useAutoRunHandlers(mockDeps));
 
 			await act(async () => {
 				await result.current.handleAutoRunCreateDocument('New Doc');
@@ -628,7 +663,8 @@ describe('useAutoRunHandlers', () => {
 				tree: [],
 			});
 
-			const { result } = renderHook(() => useAutoRunHandlers(mockSession, mockDeps));
+			seedActiveSession(mockSession);
+			const { result } = renderHook(() => useAutoRunHandlers(mockDeps));
 
 			await act(async () => {
 				await result.current.handleAutoRunCreateDocument('New Doc');
@@ -652,7 +688,8 @@ describe('useAutoRunHandlers', () => {
 				tree: [],
 			});
 
-			const { result } = renderHook(() => useAutoRunHandlers(mockSession, mockDeps));
+			seedActiveSession(mockSession);
+			const { result } = renderHook(() => useAutoRunHandlers(mockDeps));
 
 			await act(async () => {
 				await result.current.handleAutoRunCreateDocument('New Doc');
@@ -669,7 +706,8 @@ describe('useAutoRunHandlers', () => {
 
 			vi.mocked(window.maestro.autorun.writeDoc).mockResolvedValue({ success: false });
 
-			const { result } = renderHook(() => useAutoRunHandlers(mockSession, mockDeps));
+			seedActiveSession(mockSession);
+			const { result } = renderHook(() => useAutoRunHandlers(mockDeps));
 
 			let success: boolean = true;
 			await act(async () => {
@@ -683,7 +721,8 @@ describe('useAutoRunHandlers', () => {
 		it('should return false when activeSession is null', async () => {
 			const mockDeps = createMockDeps();
 
-			const { result } = renderHook(() => useAutoRunHandlers(null, mockDeps));
+			seedActiveSession(null);
+			const { result } = renderHook(() => useAutoRunHandlers(mockDeps));
 
 			let success: boolean = true;
 			await act(async () => {
@@ -698,7 +737,8 @@ describe('useAutoRunHandlers', () => {
 			const mockSession = createMockSession({ autoRunFolderPath: undefined });
 			const mockDeps = createMockDeps();
 
-			const { result } = renderHook(() => useAutoRunHandlers(mockSession, mockDeps));
+			seedActiveSession(mockSession);
+			const { result } = renderHook(() => useAutoRunHandlers(mockDeps));
 
 			let success: boolean = true;
 			await act(async () => {
@@ -715,7 +755,8 @@ describe('useAutoRunHandlers', () => {
 
 			vi.mocked(window.maestro.autorun.writeDoc).mockRejectedValue(new Error('Write failed'));
 
-			const { result } = renderHook(() => useAutoRunHandlers(mockSession, mockDeps));
+			seedActiveSession(mockSession);
+			const { result } = renderHook(() => useAutoRunHandlers(mockDeps));
 
 			let success: boolean = true;
 			await act(async () => {
@@ -744,7 +785,8 @@ describe('useAutoRunHandlers', () => {
 - [ ] Task three`,
 			});
 
-			const { result } = renderHook(() => useAutoRunHandlers(mockSession, mockDeps));
+			seedActiveSession(mockSession);
+			const { result } = renderHook(() => useAutoRunHandlers(mockDeps));
 
 			let count: number = 0;
 			await act(async () => {
@@ -768,7 +810,8 @@ describe('useAutoRunHandlers', () => {
 				content: '# Just a heading\n\nSome text without tasks.',
 			});
 
-			const { result } = renderHook(() => useAutoRunHandlers(mockSession, mockDeps));
+			seedActiveSession(mockSession);
+			const { result } = renderHook(() => useAutoRunHandlers(mockDeps));
 
 			let count: number = 99;
 			await act(async () => {
@@ -790,7 +833,8 @@ describe('useAutoRunHandlers', () => {
 - [x] Done 3`,
 			});
 
-			const { result } = renderHook(() => useAutoRunHandlers(mockSession, mockDeps));
+			seedActiveSession(mockSession);
+			const { result } = renderHook(() => useAutoRunHandlers(mockDeps));
 
 			let count: number = 99;
 			await act(async () => {
@@ -809,7 +853,8 @@ describe('useAutoRunHandlers', () => {
 				content: undefined,
 			});
 
-			const { result } = renderHook(() => useAutoRunHandlers(mockSession, mockDeps));
+			seedActiveSession(mockSession);
+			const { result } = renderHook(() => useAutoRunHandlers(mockDeps));
 
 			let count: number = 99;
 			await act(async () => {
@@ -823,7 +868,8 @@ describe('useAutoRunHandlers', () => {
 			const mockSession = createMockSession({ autoRunFolderPath: undefined });
 			const mockDeps = createMockDeps();
 
-			const { result } = renderHook(() => useAutoRunHandlers(mockSession, mockDeps));
+			seedActiveSession(mockSession);
+			const { result } = renderHook(() => useAutoRunHandlers(mockDeps));
 
 			let count: number = 99;
 			await act(async () => {
@@ -846,7 +892,8 @@ describe('useAutoRunHandlers', () => {
     - [ ] Grandchild`,
 			});
 
-			const { result } = renderHook(() => useAutoRunHandlers(mockSession, mockDeps));
+			seedActiveSession(mockSession);
+			const { result } = renderHook(() => useAutoRunHandlers(mockDeps));
 
 			let count: number = 0;
 			await act(async () => {
@@ -869,7 +916,8 @@ describe('useAutoRunHandlers', () => {
 - [ ] Task with [link](url)`,
 			});
 
-			const { result } = renderHook(() => useAutoRunHandlers(mockSession, mockDeps));
+			seedActiveSession(mockSession);
+			const { result } = renderHook(() => useAutoRunHandlers(mockDeps));
 
 			let count: number = 0;
 			await act(async () => {
@@ -888,7 +936,8 @@ describe('useAutoRunHandlers', () => {
 				content: '',
 			});
 
-			const { result } = renderHook(() => useAutoRunHandlers(mockSession, mockDeps));
+			seedActiveSession(mockSession);
+			const { result } = renderHook(() => useAutoRunHandlers(mockDeps));
 
 			let count: number = 99;
 			await act(async () => {
@@ -918,7 +967,8 @@ describe('useAutoRunHandlers', () => {
 				content: '# Phase 1 Content',
 			});
 
-			const { result } = renderHook(() => useAutoRunHandlers(mockSession, mockDeps));
+			seedActiveSession(mockSession);
+			const { result } = renderHook(() => useAutoRunHandlers(mockDeps));
 
 			await act(async () => {
 				await result.current.handleAutoRunFolderSelected('/new/folder');
@@ -947,7 +997,8 @@ describe('useAutoRunHandlers', () => {
 				content: '# First Doc Content',
 			});
 
-			const { result } = renderHook(() => useAutoRunHandlers(mockSession, mockDeps));
+			seedActiveSession(mockSession);
+			const { result } = renderHook(() => useAutoRunHandlers(mockDeps));
 
 			await act(async () => {
 				await result.current.handleAutoRunFolderSelected('/folder');
@@ -976,7 +1027,8 @@ describe('useAutoRunHandlers', () => {
 				tree: [],
 			});
 
-			const { result } = renderHook(() => useAutoRunHandlers(mockSession, mockDeps));
+			seedActiveSession(mockSession);
+			const { result } = renderHook(() => useAutoRunHandlers(mockDeps));
 
 			await act(async () => {
 				await result.current.handleAutoRunFolderSelected('/empty/folder');
@@ -1002,7 +1054,8 @@ describe('useAutoRunHandlers', () => {
 				tree: [],
 			});
 
-			const { result } = renderHook(() => useAutoRunHandlers(mockSession, mockDeps));
+			seedActiveSession(mockSession);
+			const { result } = renderHook(() => useAutoRunHandlers(mockDeps));
 
 			await act(async () => {
 				await result.current.handleAutoRunFolderSelected('/bad/folder');
@@ -1020,7 +1073,8 @@ describe('useAutoRunHandlers', () => {
 		it('should do nothing when activeSession is null', async () => {
 			const mockDeps = createMockDeps();
 
-			const { result } = renderHook(() => useAutoRunHandlers(null, mockDeps));
+			seedActiveSession(null);
+			const { result } = renderHook(() => useAutoRunHandlers(mockDeps));
 
 			await act(async () => {
 				await result.current.handleAutoRunFolderSelected('/folder');
@@ -1044,7 +1098,8 @@ describe('useAutoRunHandlers', () => {
 				content: 'Content',
 			});
 
-			const { result } = renderHook(() => useAutoRunHandlers(mockSession, mockDeps));
+			seedActiveSession(mockSession);
+			const { result } = renderHook(() => useAutoRunHandlers(mockDeps));
 
 			await act(async () => {
 				await result.current.handleAutoRunFolderSelected('/folder');
@@ -1071,7 +1126,8 @@ describe('useAutoRunHandlers', () => {
 				loopEnabled: false,
 			};
 
-			const { result } = renderHook(() => useAutoRunHandlers(mockSession, mockDeps));
+			seedActiveSession(mockSession);
+			const { result } = renderHook(() => useAutoRunHandlers(mockDeps));
 
 			await act(async () => {
 				await result.current.handleStartBatchRun(config);
@@ -1094,7 +1150,8 @@ describe('useAutoRunHandlers', () => {
 				loopEnabled: false,
 			};
 
-			const { result } = renderHook(() => useAutoRunHandlers(null, mockDeps));
+			seedActiveSession(null);
+			const { result } = renderHook(() => useAutoRunHandlers(mockDeps));
 
 			await act(async () => {
 				await result.current.handleStartBatchRun(config);
@@ -1113,7 +1170,8 @@ describe('useAutoRunHandlers', () => {
 				loopEnabled: false,
 			};
 
-			const { result } = renderHook(() => useAutoRunHandlers(mockSession, mockDeps));
+			seedActiveSession(mockSession);
+			const { result } = renderHook(() => useAutoRunHandlers(mockDeps));
 
 			await act(async () => {
 				await result.current.handleStartBatchRun(config);
@@ -1150,7 +1208,7 @@ describe('useAutoRunHandlers', () => {
 				},
 			};
 
-			const { result } = renderHook(() => useAutoRunHandlers(mockSession, mockDeps));
+			const { result } = renderHook(() => useAutoRunHandlers(mockDeps));
 
 			await act(async () => {
 				await result.current.handleStartBatchRun(config);
@@ -1192,7 +1250,8 @@ describe('useAutoRunHandlers', () => {
 				},
 			};
 
-			const { result } = renderHook(() => useAutoRunHandlers(mockSession, mockDeps));
+			seedActiveSession(mockSession);
+			const { result } = renderHook(() => useAutoRunHandlers(mockDeps));
 
 			await act(async () => {
 				await result.current.handleStartBatchRun(config);
@@ -1248,7 +1307,8 @@ describe('useAutoRunHandlers', () => {
 				},
 			};
 
-			const { result } = renderHook(() => useAutoRunHandlers(mockSession, mockDeps));
+			seedActiveSession(mockSession);
+			const { result } = renderHook(() => useAutoRunHandlers(mockDeps));
 
 			await act(async () => {
 				await result.current.handleStartBatchRun(config);
@@ -1286,7 +1346,8 @@ describe('useAutoRunHandlers', () => {
 				},
 			};
 
-			const { result } = renderHook(() => useAutoRunHandlers(mockSession, mockDeps));
+			seedActiveSession(mockSession);
+			const { result } = renderHook(() => useAutoRunHandlers(mockDeps));
 
 			await act(async () => {
 				await result.current.handleStartBatchRun(config);
@@ -1330,7 +1391,8 @@ describe('useAutoRunHandlers', () => {
 				},
 			};
 
-			const { result } = renderHook(() => useAutoRunHandlers(mockSession, mockDeps));
+			seedActiveSession(mockSession);
+			const { result } = renderHook(() => useAutoRunHandlers(mockDeps));
 
 			await act(async () => {
 				await result.current.handleStartBatchRun(config);
@@ -1368,7 +1430,8 @@ describe('useAutoRunHandlers', () => {
 				},
 			};
 
-			const { result } = renderHook(() => useAutoRunHandlers(mockSession, mockDeps));
+			seedActiveSession(mockSession);
+			const { result } = renderHook(() => useAutoRunHandlers(mockDeps));
 
 			await act(async () => {
 				await result.current.handleStartBatchRun(config);
@@ -1412,7 +1475,8 @@ describe('useAutoRunHandlers', () => {
 				},
 			};
 
-			const { result } = renderHook(() => useAutoRunHandlers(mockSession, mockDeps));
+			seedActiveSession(mockSession);
+			const { result } = renderHook(() => useAutoRunHandlers(mockDeps));
 
 			await act(async () => {
 				await result.current.handleStartBatchRun(config);
@@ -1456,7 +1520,8 @@ describe('useAutoRunHandlers', () => {
 				},
 			};
 
-			const { result } = renderHook(() => useAutoRunHandlers(mockSession, mockDeps));
+			seedActiveSession(mockSession);
+			const { result } = renderHook(() => useAutoRunHandlers(mockDeps));
 
 			await act(async () => {
 				await result.current.handleStartBatchRun(config);
@@ -1482,7 +1547,8 @@ describe('useAutoRunHandlers', () => {
 			const mockSession = createMockSession();
 			const mockDeps = createMockDeps();
 
-			const { result } = renderHook(() => useAutoRunHandlers(mockSession, mockDeps));
+			seedActiveSession(mockSession);
+			const { result } = renderHook(() => useAutoRunHandlers(mockDeps));
 
 			act(() => {
 				result.current.handleAutoRunOpenSetup();
@@ -1501,7 +1567,8 @@ describe('useAutoRunHandlers', () => {
 			const mockSession = createMockSession();
 			const mockDeps = createMockDeps();
 
-			const { result, rerender } = renderHook(() => useAutoRunHandlers(mockSession, mockDeps));
+			seedActiveSession(mockSession);
+			const { result, rerender } = renderHook(() => useAutoRunHandlers(mockDeps));
 
 			const firstRender = { ...result.current };
 			rerender();
@@ -1513,22 +1580,31 @@ describe('useAutoRunHandlers', () => {
 			expect(firstRender.handleAutoRunOpenSetup).toBe(secondRender.handleAutoRunOpenSetup);
 		});
 
-		it('should update handlers when session changes', () => {
+		it('should keep stable handlers when active session changes (getState at call time)', async () => {
 			const mockSession1 = createMockSession({ id: 'session-1' });
 			const mockSession2 = createMockSession({ id: 'session-2' });
 			const mockDeps = createMockDeps();
 
-			const { result, rerender } = renderHook(
-				({ session }) => useAutoRunHandlers(session, mockDeps),
-				{ initialProps: { session: mockSession1 } }
-			);
+			seedActiveSession(mockSession1);
+			const { result } = renderHook(() => useAutoRunHandlers(mockDeps));
 
 			const firstHandler = result.current.handleAutoRunContentChange;
-			rerender({ session: mockSession2 });
-			const secondHandler = result.current.handleAutoRunContentChange;
 
-			// Handler should change when session changes
-			expect(firstHandler).not.toBe(secondHandler);
+			// Switch active session in the store without re-creating the hook
+			seedActiveSession(mockSession2);
+
+			expect(result.current.handleAutoRunContentChange).toBe(firstHandler);
+
+			await act(async () => {
+				await result.current.handleAutoRunContentChange('from-session-2');
+			});
+
+			const updateFn = mockDeps.setSessions.mock.calls[0][0];
+			const updated = updateFn([mockSession1, mockSession2]);
+			const session2 = updated.find((s: Session) => s.id === 'session-2');
+			expect(session2?.autoRunContent).toBe('from-session-2');
+			const session1 = updated.find((s: Session) => s.id === 'session-1');
+			expect(session1?.autoRunContent).toBe(mockSession1.autoRunContent);
 		});
 	});
 });

--- a/src/__tests__/renderer/hooks/useMainKeyboardHandler.test.ts
+++ b/src/__tests__/renderer/hooks/useMainKeyboardHandler.test.ts
@@ -10,15 +10,63 @@ import { useSessionStore } from '../../../renderer/stores/sessionStore';
  * Creates a minimal mock context with all required handler functions.
  * The keyboard handler requires these functions to be present to avoid
  * "is not a function" errors when processing keyboard events.
+ *
+ * Active Session is resolved at event time via selectActiveSession(getState()).
+ * Passing `activeSession` (or `sessions`) seeds useSessionStore; it is not
+ * kept on the keyboardHandlerRef context object.
  */
 function createMockContext(overrides: Record<string, unknown> = {}) {
-	// Keyboard gates (toggleSidebar / quickAction / agentSwitcher) read
-	// session count via useSessionStore.getState(), not ctx.sessions.
-	// Only sync when the test explicitly provides `sessions` so other
-	// suites that pre-seed the store (e.g. output-search Cmd+F) are not wiped.
-	if ('sessions' in overrides) {
-		const sessions = Array.isArray(overrides.sessions) ? overrides.sessions : [];
-		useSessionStore.setState({ sessions: sessions as never });
+	const { activeSession: activeSessionOverride, ...rest } = overrides;
+
+	// Seed the store for event-time Session reads. Only sync when the test
+	// explicitly provides `sessions` or `activeSession` so suites that
+	// pre-seed the store (e.g. output-search Cmd+F) are not wiped.
+	// When both are provided, merge activeSession into the matching list entry
+	// so thin `sessions` arrays (used for length gates) do not wipe chrome fields
+	// like inputMode that shortcuts read via selectActiveSession.
+	if ('sessions' in rest) {
+		const sessions = Array.isArray(rest.sessions) ? [...rest.sessions] : [];
+		if (
+			activeSessionOverride &&
+			typeof activeSessionOverride === 'object' &&
+			activeSessionOverride !== null
+		) {
+			const session = activeSessionOverride as { id: string };
+			const idx = sessions.findIndex(
+				(s) => s && typeof s === 'object' && (s as { id?: string }).id === session.id
+			);
+			if (idx >= 0) {
+				sessions[idx] = { ...(sessions[idx] as object), ...session };
+			} else {
+				sessions.push(session);
+			}
+		}
+		const activeSessionId =
+			'activeSessionId' in rest
+				? (rest.activeSessionId as string | null)
+				: activeSessionOverride &&
+					  typeof activeSessionOverride === 'object' &&
+					  activeSessionOverride !== null &&
+					  'id' in activeSessionOverride
+					? String((activeSessionOverride as { id: string }).id)
+					: undefined;
+		useSessionStore.setState({
+			sessions: sessions as never,
+			...(activeSessionId !== undefined ? { activeSessionId } : {}),
+		});
+	} else if (
+		activeSessionOverride &&
+		typeof activeSessionOverride === 'object' &&
+		activeSessionOverride !== null
+	) {
+		const session = activeSessionOverride as { id: string };
+		useSessionStore.setState({
+			sessions: [session] as never,
+			activeSessionId:
+				'activeSessionId' in rest ? (rest.activeSessionId as string | null) : session.id,
+		});
+	} else if (activeSessionOverride === null) {
+		useSessionStore.setState({ sessions: [], activeSessionId: null });
 	}
 
 	return {
@@ -33,10 +81,9 @@ function createMockContext(overrides: Record<string, unknown> = {}) {
 		isShortcut: () => false,
 		isTabShortcut: () => false,
 		sessions: [],
-		activeSession: null,
 		activeSessionId: null,
 		activeGroupChatId: null,
-		...overrides,
+		...rest,
 	};
 }
 
@@ -71,6 +118,7 @@ describe('useMainKeyboardHandler', () => {
 		// Reset modal store so draft/wizard confirmation tests start clean
 		useModalStore.getState().closeModal('confirm');
 		useModalStore.getState().closeModal('promptComposer');
+		useSessionStore.setState({ sessions: [], activeSessionId: null });
 	});
 
 	afterEach(() => {
@@ -1299,7 +1347,7 @@ describe('useMainKeyboardHandler', () => {
 				);
 			});
 
-			it('should use current session from store, not stale ref (stale-state safety)', () => {
+			it('should use current session from setSessions updater, not a stale snapshot (stale-state safety)', () => {
 				const { result } = renderHook(() => useMainKeyboardHandler());
 
 				const staleSession = {
@@ -1325,11 +1373,13 @@ describe('useMainKeyboardHandler', () => {
 					}
 				});
 
+				// Seed store with stale snapshot so event-time selectActiveSession passes
+				// the outer gate; navigation must still read freshness from setSessions(prev).
 				result.current.keyboardHandlerRef.current = createUnifiedTabContext({
 					isTabShortcut: (_e: KeyboardEvent, actionId: string) => actionId === 'nextTab',
 					navigateToNextUnifiedTab: mockNavigateToNextUnifiedTab,
 					setSessions: mockSetSessions,
-					activeSession: staleSession, // Stale session in the ref
+					activeSession: staleSession,
 				});
 
 				act(() => {
@@ -1343,7 +1393,7 @@ describe('useMainKeyboardHandler', () => {
 					);
 				});
 
-				// Navigation should use the FRESH session from the store, not the stale ref
+				// Navigation should use the FRESH session from the setSessions updater, not the seed
 				expect(mockNavigateToNextUnifiedTab).toHaveBeenCalledWith(freshSession, false);
 			});
 		});

--- a/src/__tests__/renderer/hooks/useMainKeyboardHandler.test.ts
+++ b/src/__tests__/renderer/hooks/useMainKeyboardHandler.test.ts
@@ -43,7 +43,7 @@ function createMockContext(overrides: Record<string, unknown> = {}) {
 		}
 		const activeSessionId =
 			'activeSessionId' in rest
-				? (rest.activeSessionId as string | null)
+				? (rest.activeSessionId as string)
 				: activeSessionOverride &&
 					  typeof activeSessionOverride === 'object' &&
 					  activeSessionOverride !== null &&
@@ -62,11 +62,10 @@ function createMockContext(overrides: Record<string, unknown> = {}) {
 		const session = activeSessionOverride as { id: string };
 		useSessionStore.setState({
 			sessions: [session] as never,
-			activeSessionId:
-				'activeSessionId' in rest ? (rest.activeSessionId as string | null) : session.id,
+			activeSessionId: 'activeSessionId' in rest ? (rest.activeSessionId as string) : session.id,
 		});
 	} else if (activeSessionOverride === null) {
-		useSessionStore.setState({ sessions: [], activeSessionId: null });
+		useSessionStore.setState({ sessions: [], activeSessionId: '' });
 	}
 
 	return {
@@ -81,7 +80,7 @@ function createMockContext(overrides: Record<string, unknown> = {}) {
 		isShortcut: () => false,
 		isTabShortcut: () => false,
 		sessions: [],
-		activeSessionId: null,
+		activeSessionId: '',
 		activeGroupChatId: null,
 		...rest,
 	};
@@ -118,7 +117,7 @@ describe('useMainKeyboardHandler', () => {
 		// Reset modal store so draft/wizard confirmation tests start clean
 		useModalStore.getState().closeModal('confirm');
 		useModalStore.getState().closeModal('promptComposer');
-		useSessionStore.setState({ sessions: [], activeSessionId: null });
+		useSessionStore.setState({ sessions: [], activeSessionId: '' });
 	});
 
 	afterEach(() => {

--- a/src/__tests__/renderer/hooks/useSummarizeHandler.test.ts
+++ b/src/__tests__/renderer/hooks/useSummarizeHandler.test.ts
@@ -99,6 +99,20 @@ function createMockSession(overrides: Partial<Session> = {}): Session {
 	});
 }
 
+function seedActiveSession(session: Session | null) {
+	if (session) {
+		useSessionStore.setState({
+			sessions: [session],
+			activeSessionId: session.id,
+		} as any);
+	} else {
+		useSessionStore.setState({
+			sessions: [],
+			activeSessionId: null,
+		} as any);
+	}
+}
+
 // ============================================================================
 // Setup / Teardown
 // ============================================================================
@@ -129,7 +143,8 @@ afterEach(() => {
 
 describe('handleSummarizeAndContinue (Tier 3E)', () => {
 	it('returns when no session is provided', async () => {
-		const { result } = renderHook(() => useSummarizeAndContinue(null));
+		seedActiveSession(null);
+		const { result } = renderHook(() => useSummarizeAndContinue());
 
 		await act(async () => {
 			result.current.handleSummarizeAndContinue();
@@ -142,7 +157,8 @@ describe('handleSummarizeAndContinue (Tier 3E)', () => {
 	it('returns when inputMode is terminal', async () => {
 		const session = createMockSession({ inputMode: 'terminal' });
 
-		const { result } = renderHook(() => useSummarizeAndContinue(session));
+		seedActiveSession(session);
+		const { result } = renderHook(() => useSummarizeAndContinue());
 
 		await act(async () => {
 			result.current.handleSummarizeAndContinue();
@@ -157,7 +173,8 @@ describe('handleSummarizeAndContinue (Tier 3E)', () => {
 
 		const session = createMockSession();
 
-		const { result } = renderHook(() => useSummarizeAndContinue(session));
+		seedActiveSession(session);
+		const { result } = renderHook(() => useSummarizeAndContinue());
 
 		await act(async () => {
 			result.current.handleSummarizeAndContinue();
@@ -178,7 +195,8 @@ describe('handleSummarizeAndContinue (Tier 3E)', () => {
 			activeSessionId: session.id,
 		});
 
-		const { result } = renderHook(() => useSummarizeAndContinue(session));
+		seedActiveSession(session);
+		const { result } = renderHook(() => useSummarizeAndContinue());
 
 		await act(async () => {
 			result.current.handleSummarizeAndContinue();
@@ -205,7 +223,8 @@ describe('handleSummarizeAndContinue (Tier 3E)', () => {
 			activeSessionId: session.id,
 		});
 
-		const { result } = renderHook(() => useSummarizeAndContinue(session));
+		seedActiveSession(session);
+		const { result } = renderHook(() => useSummarizeAndContinue());
 
 		await act(async () => {
 			result.current.handleSummarizeAndContinue();
@@ -233,7 +252,8 @@ describe('handleSummarizeAndContinue (Tier 3E)', () => {
 			activeSessionId: session.id,
 		});
 
-		const { result } = renderHook(() => useSummarizeAndContinue(session));
+		seedActiveSession(session);
+		const { result } = renderHook(() => useSummarizeAndContinue());
 
 		await act(async () => {
 			result.current.handleSummarizeAndContinue();
@@ -255,7 +275,8 @@ describe('handleSummarizeAndContinue (Tier 3E)', () => {
 			activeSessionId: session.id,
 		});
 
-		const { result } = renderHook(() => useSummarizeAndContinue(session));
+		seedActiveSession(session);
+		const { result } = renderHook(() => useSummarizeAndContinue());
 
 		await act(async () => {
 			result.current.handleSummarizeAndContinue();
@@ -280,7 +301,8 @@ describe('handleSummarizeAndContinue (Tier 3E)', () => {
 			activeSessionId: session.id,
 		});
 
-		const { result } = renderHook(() => useSummarizeAndContinue(session));
+		seedActiveSession(session);
+		const { result } = renderHook(() => useSummarizeAndContinue());
 
 		await act(async () => {
 			result.current.handleSummarizeAndContinue('tab-2');
@@ -312,7 +334,8 @@ describe('handleSummarizeAndContinue (Tier 3E)', () => {
 
 		const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
-		const { result } = renderHook(() => useSummarizeAndContinue(session));
+		seedActiveSession(session);
+		const { result } = renderHook(() => useSummarizeAndContinue());
 
 		await act(async () => {
 			result.current.handleSummarizeAndContinue();

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1271,8 +1271,6 @@ function MaestroConsoleInner() {
 		expandAllFolders,
 		collapseAllFolders,
 	} = useAppHandlers({
-		activeSession,
-		activeSessionId,
 		setSessions,
 		setActiveFocus,
 		setConfirmModalMessage,
@@ -1413,7 +1411,7 @@ function MaestroConsoleInner() {
 		cancelTab,
 		canSummarize,
 		handleSummarizeAndContinue,
-	} = useSummarizeAndContinue(activeSession ?? null);
+	} = useSummarizeAndContinue();
 
 	// Fresh store snapshot - chrome equality ignores contextUsage / logs.
 	const computeCanSummarizeActiveTab = () => {
@@ -1553,7 +1551,6 @@ function MaestroConsoleInner() {
 	// Extracted hook for agent-specific session operations (history, session clear, resume)
 	const { addHistoryEntry, addHistoryEntryRef, handleJumpToAgentSession, handleResumeSession } =
 		useAgentSessionManagement({
-			activeSession,
 			setSessions,
 			setActiveAgentSessionId,
 			setAgentSessionsOpen,
@@ -1965,7 +1962,7 @@ function MaestroConsoleInner() {
 		handleAutoRunRefresh,
 		handleAutoRunOpenSetup,
 		handleAutoRunCreateDocument,
-	} = useAutoRunHandlers(activeSession, {
+	} = useAutoRunHandlers({
 		setSessions,
 		setAutoRunDocumentList,
 		setAutoRunDocumentTree,
@@ -2101,7 +2098,7 @@ function MaestroConsoleInner() {
 	// Tab tiling (split panes): Ctrl+Cmd pane focus / split / close / zoom /
 	// rebalance handlers. All act only on the active window's active tab group and
 	// no-op when nothing is tiled. Dispatched by the main keyboard handler.
-	const tilingShortcuts = useTilingShortcuts(activeSession);
+	const tilingShortcuts = useTilingShortcuts();
 
 	// --- KEYBOARD NAVIGATION ---
 	// Sidebar arrow-key navigation, panel focus, Enter-to-activate. Placed after

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1541,7 +1541,7 @@ function MaestroConsoleInner() {
 		showSuccessFlash,
 		cancelPendingSynopsis,
 	} = useAgentExecution({
-		activeSession,
+		activeSessionId,
 		sessionsRef,
 		setSessions,
 		processQueuedItemRef,
@@ -2432,7 +2432,7 @@ function MaestroConsoleInner() {
 		confirmModalOpen,
 		renameInstanceModalOpen,
 		renameGroupModalOpen,
-		activeSession,
+		// activeSession resolved at event time via selectActiveSession(getState())
 		fileTreeFilter,
 		fileTreeFilterOpen,
 		fileTreeFilterInputRef,

--- a/src/renderer/hooks/agent/useAgentExecution.ts
+++ b/src/renderer/hooks/agent/useAgentExecution.ts
@@ -50,8 +50,8 @@ const BATCH_WATCHDOG_CHECK_MS = 15 * 1000; // Check every 15 seconds
  * Dependencies for the useAgentExecution hook.
  */
 export interface UseAgentExecutionDeps {
-	/** Current active session (null if none selected) */
-	activeSession: Session | null;
+	/** Active session id (null if none selected). Session fields are read from sessionsRef at call time. */
+	activeSessionId: string | null;
 	/** Ref to sessions for accessing latest state without re-renders */
 	sessionsRef: React.MutableRefObject<Session[]>;
 	/** Session state setter */
@@ -156,7 +156,7 @@ export interface UseAgentExecutionReturn {
  */
 export function useAgentExecution(deps: UseAgentExecutionDeps): UseAgentExecutionReturn {
 	const {
-		activeSession,
+		activeSessionId,
 		sessionsRef,
 		setSessions,
 		processQueuedItemRef,
@@ -650,10 +650,10 @@ export function useAgentExecution(deps: UseAgentExecutionDeps): UseAgentExecutio
 	 */
 	const spawnAgentWithPrompt = useCallback(
 		async (prompt: string): Promise<AgentSpawnResult> => {
-			if (!activeSession) return { success: false };
-			return spawnAgentForSession(activeSession.id, prompt, undefined, { isAutoRun: false });
+			if (!activeSessionId) return { success: false };
+			return spawnAgentForSession(activeSessionId, prompt, undefined, { isAutoRun: false });
 		},
-		[activeSession, spawnAgentForSession]
+		[activeSessionId, spawnAgentForSession]
 	);
 
 	/**

--- a/src/renderer/hooks/agent/useAgentSessionManagement.ts
+++ b/src/renderer/hooks/agent/useAgentSessionManagement.ts
@@ -1,6 +1,6 @@
 import { useCallback, useRef } from 'react';
 import type { Session, LogEntry, UsageStats, ThinkingMode } from '../../types';
-import { useSessionStore, selectSessionById } from '../../stores/sessionStore';
+import { useSessionStore, selectSessionById, selectActiveSession } from '../../stores/sessionStore';
 import { aiTabFocusFields, createTab, getActiveTab } from '../../utils/tabHelpers';
 import { generateId } from '../../utils/ids';
 import { buildSharedHistoryContext } from '../../utils/sessionHelpers';
@@ -69,8 +69,6 @@ export interface HistoryEntryInput {
  * Dependencies for the useAgentSessionManagement hook.
  */
 export interface UseAgentSessionManagementDeps {
-	/** Current active session (null if none selected) */
-	activeSession: Session | null;
 	/** Session state setter */
 	setSessions: React.Dispatch<React.SetStateAction<Session[]>>;
 	/** Agent session ID setter */
@@ -120,9 +118,9 @@ export interface UseAgentSessionManagementReturn {
 export interface ResumeSessionOptions {
 	/**
 	 * Resume into a specific Maestro agent (Session.id) resolved fresh from the
-	 * store, rather than the closure's active session. Required when jumping
-	 * across agents (e.g. the Left Bar "Starred Sessions" list), where the active
-	 * session has just switched and the closure value is stale.
+	 * store, rather than the current active session. Required when jumping
+	 * across agents (e.g. the Left Bar "Starred Sessions" list), where the target
+	 * agent isn't the one currently active.
 	 */
 	targetSessionId?: string;
 	/**
@@ -141,6 +139,10 @@ export interface ResumeSessionOptions {
  * - Jumping to Agent sessions in the browser
  * - Resuming saved Agent sessions as tabs
  *
+ * The active session is not passed in as a dep; each callback resolves it
+ * fresh from the store (`selectActiveSession(useSessionStore.getState())`) at
+ * call time, so callers never risk acting on a stale closure value.
+ *
  * @param deps - Hook dependencies
  * @returns Session management functions and refs
  */
@@ -148,7 +150,6 @@ export function useAgentSessionManagement(
 	deps: UseAgentSessionManagementDeps
 ): UseAgentSessionManagementReturn {
 	const {
-		activeSession,
 		setSessions,
 		setActiveAgentSessionId,
 		setAgentSessionsOpen,
@@ -167,6 +168,8 @@ export function useAgentSessionManagement(
 	 */
 	const addHistoryEntry = useCallback(
 		async (entry: HistoryEntryInput) => {
+			const activeSession = selectActiveSession(useSessionStore.getState());
+
 			// Use provided values or fall back to activeSession
 			const targetSessionId = entry.sessionId || activeSession?.id;
 			const targetProjectPath = entry.projectPath || activeSession?.cwd;
@@ -247,7 +250,7 @@ export function useAgentSessionManagement(
 			// Refresh history panel to show the new entry
 			rightPanelRef.current?.refreshHistoryPanel();
 		},
-		[activeSession, rightPanelRef]
+		[rightPanelRef]
 	);
 
 	/**
@@ -255,6 +258,8 @@ export function useAgentSessionManagement(
 	 */
 	const handleJumpToAgentSession = useCallback(
 		(agentSessionId: string) => {
+			const activeSession = selectActiveSession(useSessionStore.getState());
+
 			// Set the agent session ID and load its messages
 			if (activeSession) {
 				setActiveAgentSessionId(agentSessionId);
@@ -262,7 +267,7 @@ export function useAgentSessionManagement(
 				setAgentSessionsOpen(true);
 			}
 		},
-		[activeSession, setActiveAgentSessionId, setAgentSessionsOpen]
+		[setActiveAgentSessionId, setAgentSessionsOpen]
 	);
 
 	/**
@@ -281,8 +286,9 @@ export function useAgentSessionManagement(
 		): Promise<boolean> => {
 			// Resolve the agent to resume into. When a targetSessionId is provided
 			// (cross-agent jump, e.g. starred sessions), read it fresh from the store
-			// because the active session may have just switched and the `activeSession`
-			// closure is stale. Otherwise operate on the current active session.
+			// by id. Otherwise fall back to the current active session, also resolved
+			// fresh so it can't be a stale closure value.
+			const activeSession = selectActiveSession(useSessionStore.getState());
 			const targetSession = opts?.targetSessionId
 				? (selectSessionById(opts.targetSessionId)(useSessionStore.getState()) ?? null)
 				: activeSession;
@@ -501,17 +507,7 @@ export function useAgentSessionManagement(
 				return false;
 			}
 		},
-		[
-			activeSession?.projectRoot,
-			activeSession?.id,
-			activeSession?.aiTabs,
-			activeSession?.toolType,
-			setSessions,
-			setActiveAgentSessionId,
-			defaultSaveToHistory,
-			defaultShowThinking,
-			showFlash,
-		]
+		[setSessions, setActiveAgentSessionId, defaultSaveToHistory, defaultShowThinking, showFlash]
 	);
 
 	// Update refs for slash command functions (so other handlers can access latest versions)

--- a/src/renderer/hooks/agent/useSummarizeAndContinue.ts
+++ b/src/renderer/hooks/agent/useSummarizeAndContinue.ts
@@ -21,7 +21,7 @@ import type { SummarizeProgress, SummarizeResult } from '../../types/contextMerg
 import { contextSummarizationService } from '../../services/contextSummarizer';
 import { createTabAtPosition } from '../../utils/tabHelpers';
 import { useOperationStore, selectIsAnySummarizing } from '../../stores/operationStore';
-import { useSessionStore } from '../../stores/sessionStore';
+import { useSessionStore, selectActiveSession } from '../../stores/sessionStore';
 import { notifyToast } from '../../stores/notificationStore';
 import type { SummarizeState, TabSummarizeState } from '../../stores/operationStore';
 import { logger } from '../../utils/logger';
@@ -73,11 +73,16 @@ export interface UseSummarizeAndContinueResult {
  * Tracks per-tab state to allow non-blocking operations. While one tab is
  * summarizing, other tabs remain fully interactive.
  *
- * @param session - The Maestro session containing the tabs
+ * Takes no arguments. The active session is not a prop or param: reactive UI
+ * (the active tab's summarize chrome) subscribes to `activeTabId` alone, and
+ * imperative work (`startSummarize`, `handleSummarizeAndContinue`) resolves
+ * the session fresh via `selectActiveSession(useSessionStore.getState())` at
+ * call time, so callers never act on a stale closure value.
+ *
  * @returns Object with summarization state and control functions
  *
  * @example
- * function MyComponent({ session }) {
+ * function MyComponent() {
  *   const {
  *     summarizeState,
  *     progress,
@@ -86,11 +91,12 @@ export interface UseSummarizeAndContinueResult {
  *     startSummarize,
  *     canSummarize,
  *     getTabSummarizeState,
- *   } = useSummarizeAndContinue(session);
+ *   } = useSummarizeAndContinue();
  *
  *   const handleSummarize = async () => {
- *     const activeTab = getActiveTab(session);
- *     if (activeTab && canSummarize(session.contextUsage)) {
+ *     const session = selectActiveSession(useSessionStore.getState());
+ *     const activeTab = session && getActiveTab(session);
+ *     if (session && activeTab && canSummarize(session.contextUsage)) {
  *       const result = await startSummarize(activeTab.id);
  *       if (result) {
  *         // Update session and add system log entry
@@ -100,7 +106,7 @@ export interface UseSummarizeAndContinueResult {
  *   };
  *
  *   // Check if current tab is summarizing
- *   const tabState = getTabSummarizeState(session.activeTabId);
+ *   const tabState = getTabSummarizeState(activeTabId);
  *   const isTabSummarizing = tabState?.state === 'summarizing';
  *
  *   return (
@@ -110,13 +116,13 @@ export interface UseSummarizeAndContinueResult {
  *   );
  * }
  */
-export function useSummarizeAndContinue(session: Session | null): UseSummarizeAndContinueResult {
+export function useSummarizeAndContinue(): UseSummarizeAndContinueResult {
 	// Per-tab state lives in operationStore
 	const tabStates = useOperationStore((s) => s.summarizeStates);
 	const cancelRefs = useRef<Map<string, boolean>>(new Map());
 
-	// Get state for the active tab (for backwards compatibility)
-	const activeTabId = session?.activeTabId;
+	// Reactive UI only needs the active tab id, not the whole session object.
+	const activeTabId = useSessionStore((s) => selectActiveSession(s)?.activeTabId);
 	const activeTabState = activeTabId ? tabStates.get(activeTabId) : null;
 
 	// Selector: any tab currently summarizing?
@@ -155,6 +161,7 @@ export function useSummarizeAndContinue(session: Session | null): UseSummarizeAn
 		async (
 			sourceTabId: string
 		): Promise<{ newTabId: string; updatedSession: Session; systemLogEntry: LogEntry } | null> => {
+			const session = selectActiveSession(useSessionStore.getState());
 			if (!session) {
 				return null;
 			}
@@ -293,7 +300,7 @@ export function useSummarizeAndContinue(session: Session | null): UseSummarizeAn
 				return null;
 			}
 		},
-		[session, createSystemLogEntry]
+		[createSystemLogEntry]
 	);
 
 	/**
@@ -338,6 +345,7 @@ export function useSummarizeAndContinue(session: Session | null): UseSummarizeAn
 	 */
 	const handleSummarizeAndContinue = useCallback(
 		(tabId?: string) => {
+			const session = selectActiveSession(useSessionStore.getState());
 			if (!session || session.inputMode !== 'ai') return;
 
 			const targetTabId = tabId || session.activeTabId;
@@ -438,7 +446,7 @@ export function useSummarizeAndContinue(session: Session | null): UseSummarizeAn
 					clearTabState(targetTabId);
 				});
 		},
-		[session, canSummarize, startSummarize, clearTabState]
+		[canSummarize, startSummarize, clearTabState]
 	);
 
 	return {

--- a/src/renderer/hooks/batch/useAutoRunHandlers.ts
+++ b/src/renderer/hooks/batch/useAutoRunHandlers.ts
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 import type { Session, BatchRunConfig } from '../../types';
-import { useSessionStore, selectSessionById } from '../../stores/sessionStore';
+import { useSessionStore, selectActiveSession, selectSessionById } from '../../stores/sessionStore';
 import { notifyToast } from '../../stores/notificationStore';
 import { spawnWorktreeAgentAndDispatch } from '../../utils/worktreeSpawn';
 import { countMarkdownTasks } from './batchUtils';
@@ -86,14 +86,15 @@ function getSshRemoteId(session: Session | null): string | undefined {
  * Hook that provides handlers for Auto Run operations.
  * Extracted from App.tsx to reduce file size and improve maintainability.
  *
- * @param activeSession - The currently active session (can be null)
+ * Each handler resolves the active session fresh from the store at call time
+ * (via `selectActiveSession(useSessionStore.getState())`) instead of closing
+ * over a prop, so handlers always see the latest session even if they were
+ * memoized before the active session changed.
+ *
  * @param deps - Dependencies including state setters and values
  * @returns Object containing all Auto Run handler functions
  */
-export function useAutoRunHandlers(
-	activeSession: Session | null,
-	deps: UseAutoRunHandlersDeps
-): UseAutoRunHandlersReturn {
+export function useAutoRunHandlers(deps: UseAutoRunHandlersDeps): UseAutoRunHandlersReturn {
 	const {
 		setSessions,
 		setAutoRunDocumentList,
@@ -112,6 +113,7 @@ export function useAutoRunHandlers(
 	// Handler for auto run folder selection from setup modal
 	const handleAutoRunFolderSelected = useCallback(
 		async (folderPath: string) => {
+			const activeSession = selectActiveSession(useSessionStore.getState());
 			if (!activeSession) return;
 
 			const sshRemoteId = getSshRemoteId(activeSession);
@@ -179,7 +181,6 @@ export function useAutoRunHandlers(
 			setActiveFocus('right');
 		},
 		[
-			activeSession,
 			setSessions,
 			setAutoRunDocumentList,
 			setAutoRunDocumentTree,
@@ -193,6 +194,7 @@ export function useAutoRunHandlers(
 	// Handler to start batch run from modal with multi-document support
 	const handleStartBatchRun = useCallback(
 		async (config: BatchRunConfig) => {
+			const activeSession = selectActiveSession(useSessionStore.getState());
 			window.maestro.logger.log('info', 'handleStartBatchRun called', 'AutoRunHandlers', {
 				hasActiveSession: !!activeSession,
 				sessionId: activeSession?.id,
@@ -304,51 +306,46 @@ export function useAutoRunHandlers(
 			// Documents stay with the parent session's autoRunFolderPath; execution targets the worktree agent
 			startBatchRun(targetSessionId, config, activeSession.autoRunFolderPath);
 		},
-		[activeSession, startBatchRun, setBatchRunnerModalOpen]
+		[startBatchRun, setBatchRunnerModalOpen]
 	);
 
 	// Memoized function to get task count for a document (used by BatchRunnerModal)
-	const getDocumentTaskCount = useCallback(
-		async (filename: string) => {
-			if (!activeSession?.autoRunFolderPath) return 0;
-			const sshRemoteId = getSshRemoteId(activeSession);
-			const result = await window.maestro.autorun.readDoc(
-				activeSession.autoRunFolderPath,
-				filename + '.md',
-				sshRemoteId
-			);
-			if (!result.success || !result.content) return 0;
-			return countMarkdownTasks(result.content).unchecked;
-			// Note: Use primitive values (remoteId) not object refs (sessionSshRemoteConfig) to avoid infinite re-render loops
-		},
-		[
-			activeSession?.autoRunFolderPath,
-			activeSession?.sshRemoteId,
-			activeSession?.sessionSshRemoteConfig?.remoteId,
-		]
-	);
+	const getDocumentTaskCount = useCallback(async (filename: string) => {
+		const activeSession = selectActiveSession(useSessionStore.getState());
+		if (!activeSession?.autoRunFolderPath) return 0;
+		const sshRemoteId = getSshRemoteId(activeSession);
+		const result = await window.maestro.autorun.readDoc(
+			activeSession.autoRunFolderPath,
+			filename + '.md',
+			sshRemoteId
+		);
+		if (!result.success || !result.content) return 0;
+		return countMarkdownTasks(result.content).unchecked;
+	}, []);
 
 	// Auto Run document content change handler
 	// Updates content in the session state (per-session, not global)
 	const handleAutoRunContentChange = useCallback(
 		async (content: string) => {
+			const activeSession = selectActiveSession(useSessionStore.getState());
 			if (!activeSession) return;
 			setSessions((prev) =>
 				prev.map((s) => (s.id === activeSession.id ? { ...s, autoRunContent: content } : s))
 			);
 		},
-		[activeSession, setSessions]
+		[setSessions]
 	);
 
 	// Auto Run mode change handler
 	const handleAutoRunModeChange = useCallback(
 		(mode: 'edit' | 'preview') => {
+			const activeSession = selectActiveSession(useSessionStore.getState());
 			if (!activeSession) return;
 			setSessions((prev) =>
 				prev.map((s) => (s.id === activeSession.id ? { ...s, autoRunMode: mode } : s))
 			);
 		},
-		[activeSession, setSessions]
+		[setSessions]
 	);
 
 	// Auto Run state change handler (scroll/cursor positions)
@@ -359,6 +356,7 @@ export function useAutoRunHandlers(
 			editScrollPos: number;
 			previewScrollPos: number;
 		}) => {
+			const activeSession = selectActiveSession(useSessionStore.getState());
 			if (!activeSession) return;
 			setSessions((prev) =>
 				prev.map((s) =>
@@ -374,13 +372,14 @@ export function useAutoRunHandlers(
 				)
 			);
 		},
-		[activeSession, setSessions]
+		[setSessions]
 	);
 
 	// Auto Run document selection handler
 	// Updates both selectedFile AND content atomically in session state
 	const handleAutoRunSelectDocument = useCallback(
 		async (filename: string) => {
+			const activeSession = selectActiveSession(useSessionStore.getState());
 			if (!activeSession?.autoRunFolderPath) return;
 
 			const sshRemoteId = getSshRemoteId(activeSession);
@@ -407,11 +406,12 @@ export function useAutoRunHandlers(
 				)
 			);
 		},
-		[activeSession, setSessions]
+		[setSessions]
 	);
 
 	// Auto Run refresh handler - reload document list and show flash notification
 	const handleAutoRunRefresh = useCallback(async () => {
+		const activeSession = selectActiveSession(useSessionStore.getState());
 		if (!activeSession?.autoRunFolderPath) return;
 		const sshRemoteId = getSshRemoteId(activeSession);
 		const previousCount = autoRunDocumentList.length;
@@ -443,11 +443,7 @@ export function useAutoRunHandlers(
 		} finally {
 			setAutoRunIsLoadingDocuments(false);
 		}
-		// Note: Use primitive values (remoteId) not object refs (sessionSshRemoteConfig) to avoid infinite re-render loops
 	}, [
-		activeSession?.autoRunFolderPath,
-		activeSession?.sshRemoteId,
-		activeSession?.sessionSshRemoteConfig?.remoteId,
 		autoRunDocumentList.length,
 		setAutoRunDocumentList,
 		setAutoRunDocumentTree,
@@ -459,6 +455,7 @@ export function useAutoRunHandlers(
 	// If no folder is configured, directly open folder picker
 	// If folder exists, open modal to allow changing it
 	const handleAutoRunOpenSetup = useCallback(async () => {
+		const activeSession = selectActiveSession(useSessionStore.getState());
 		if (activeSession?.autoRunFolderPath) {
 			// Folder exists - open modal to change it
 			setAutoRunSetupModalOpen(true);
@@ -476,16 +473,12 @@ export function useAutoRunHandlers(
 				}
 			}
 		}
-	}, [
-		activeSession?.autoRunFolderPath,
-		activeSession,
-		setAutoRunSetupModalOpen,
-		handleAutoRunFolderSelected,
-	]);
+	}, [setAutoRunSetupModalOpen, handleAutoRunFolderSelected]);
 
 	// Auto Run create new document handler
 	const handleAutoRunCreateDocument = useCallback(
 		async (filename: string): Promise<boolean> => {
+			const activeSession = selectActiveSession(useSessionStore.getState());
 			if (!activeSession?.autoRunFolderPath) return false;
 
 			const sshRemoteId = getSshRemoteId(activeSession);
@@ -532,7 +525,7 @@ export function useAutoRunHandlers(
 				return false;
 			}
 		},
-		[activeSession, setSessions, setAutoRunDocumentList, setAutoRunDocumentTree]
+		[setSessions, setAutoRunDocumentList, setAutoRunDocumentTree]
 	);
 
 	return {

--- a/src/renderer/hooks/keyboard/useMainKeyboardHandler.ts
+++ b/src/renderer/hooks/keyboard/useMainKeyboardHandler.ts
@@ -6,7 +6,7 @@ import {
 	toggleReadOnlyModeFields,
 } from '../../utils/tabHelpers';
 import { useModalStore } from '../../stores/modalStore';
-import { useSessionStore } from '../../stores/sessionStore';
+import { selectActiveSession, useSessionStore } from '../../stores/sessionStore';
 import { useSettingsStore } from '../../stores/settingsStore';
 import { isActiveOutputSearchOpen } from '../../utils/outputSearch';
 import { editClipboardImage } from '../../components/ImageAnnotator/editClipboardImage';
@@ -24,7 +24,7 @@ const FONT_SIZE_DEFAULT = 14;
  *
  * Key properties include:
  * - isShortcut, isTabShortcut: Shortcut matching functions
- * - sessions length (via getState), activeSession, activeSessionId: Session state
+ * - sessions length / active Session (via getState at event time), activeSessionId: Session state
  * - activeFocus, activeRightTab: UI focus state
  * - Various modal open states (quickActionOpen, settingsModalOpen, etc.)
  * - hasOpenLayers, hasOpenModal: Layer stack functions
@@ -96,16 +96,18 @@ export function useMainKeyboardHandler(): UseMainKeyboardHandlerReturn {
 			}
 
 			// Read all values from ref - this allows the handler to stay attached while still
-			// accessing current state values
+			// accessing current state values. Active Session is resolved at event time from
+			// the store so App does not need to push a live Session object onto this ref.
 			const ctx = keyboardHandlerRef.current;
 			if (!ctx) return;
+			const activeSession = selectActiveSession(useSessionStore.getState());
 
 			// Terminal focus recovery: if a key event reaches this window handler while in
 			// terminal mode, xterm's textarea likely lost focus. Recover early (before any
 			// global shortcut/navigation logic) so arrow keys and editor escape paths still
 			// work in interactive TUIs like vi/vim/nano.
 			const isTerminalRecoveryContext =
-				ctx.activeSession?.inputMode === 'terminal' &&
+				activeSession?.inputMode === 'terminal' &&
 				!ctx.activeGroupChatId &&
 				!ctx.hasOpenLayers() &&
 				!e.defaultPrevented &&
@@ -116,9 +118,9 @@ export function useMainKeyboardHandler(): UseMainKeyboardHandlerReturn {
 				const isExplicitAppShortcut =
 					e.metaKey || e.altKey || (e.ctrlKey && e.shiftKey && e.code === 'Backquote');
 				if (!isExplicitAppShortcut) {
-					const tabId = ctx.activeSession.activeTerminalTabId;
+					const tabId = activeSession.activeTerminalTabId;
 					if (tabId) {
-						const termSid = `${ctx.activeSession.id}-terminal-${tabId}`;
+						const termSid = `${activeSession.id}-terminal-${tabId}`;
 						let data: string | null = null;
 						const isNavigationKey =
 							e.key === 'ArrowUp' ||
@@ -180,7 +182,7 @@ export function useMainKeyboardHandler(): UseMainKeyboardHandlerReturn {
 			const isMac = navigator.platform.toUpperCase().includes('MAC');
 			if (
 				isMac &&
-				ctx.activeSession?.inputMode === 'terminal' &&
+				activeSession?.inputMode === 'terminal' &&
 				!ctx.activeGroupChatId &&
 				!isXtermTarget &&
 				e.ctrlKey &&
@@ -192,12 +194,12 @@ export function useMainKeyboardHandler(): UseMainKeyboardHandlerReturn {
 				// (xterm normally stopPropagation's handled Ctrl events). Re-focus and forward
 				// the control character so Ctrl+C/D/Z still work in vim/vi/nano.
 				ctx.mainPanelRef?.current?.focusActiveTerminal?.();
-				const tabId = ctx.activeSession.activeTerminalTabId;
+				const tabId = activeSession.activeTerminalTabId;
 				if (tabId && e.key.length === 1) {
 					const code = e.key.toUpperCase().charCodeAt(0);
 					if (code >= 65 && code <= 90) {
 						e.preventDefault();
-						const termSid = `${ctx.activeSession.id}-terminal-${tabId}`;
+						const termSid = `${activeSession.id}-terminal-${tabId}`;
 						window.maestro?.process?.write(termSid, String.fromCharCode(code - 64));
 					}
 				}
@@ -274,7 +276,7 @@ export function useMainKeyboardHandler(): UseMainKeyboardHandlerReturn {
 				const isToggleModeShortcut = ctx.isShortcut(e, 'toggleMode');
 				// Allow focusBrowserAddress (Cmd+L) to focus address bar when browser tab is active overlay
 				const isBrowserAddressShortcut =
-					ctx.isTabShortcut(e, 'focusBrowserAddress') && !!ctx.activeSession?.activeBrowserTabId;
+					ctx.isTabShortcut(e, 'focusBrowserAddress') && !!activeSession?.activeBrowserTabId;
 				// Allow browser-tab Cmd+F (in-page find) to reach its handler even when
 				// modals/overlays are open. The find bar is locally-scoped to the
 				// browser tab; the overlay-guard's broader "block app shortcuts"
@@ -284,7 +286,7 @@ export function useMainKeyboardHandler(): UseMainKeyboardHandlerReturn {
 					!e.altKey &&
 					!e.shiftKey &&
 					e.key.toLowerCase() === 'f' &&
-					!!ctx.activeSession?.activeBrowserTabId;
+					!!activeSession?.activeBrowserTabId;
 				// Allow Cmd+Left / Cmd+Right (browser history back/forward) to fall
 				// through when a browser tab is active. The address/find bar inputs
 				// still preserve macOS line navigation via the target check below.
@@ -293,7 +295,7 @@ export function useMainKeyboardHandler(): UseMainKeyboardHandlerReturn {
 					!e.altKey &&
 					!e.shiftKey &&
 					(e.key === 'ArrowLeft' || e.key === 'ArrowRight') &&
-					!!ctx.activeSession?.activeBrowserTabId;
+					!!activeSession?.activeBrowserTabId;
 				// Allow Cmd+F to fall through and re-focus the file-tree filter input
 				// when the filter is already open and the files panel is focused. The
 				// open filter registers an overlay layer, so without this exception the
@@ -445,9 +447,9 @@ export function useMainKeyboardHandler(): UseMainKeyboardHandlerReturn {
 			// Every handler is window-scoped and no-ops when there's no active group,
 			// so it's safe to only preventDefault when a group is actually present.
 			const hasActiveGroup =
-				!!ctx.activeSession?.activeGroupId &&
-				(ctx.activeSession.tabGroups ?? []).some(
-					(g: { id: string }) => g.id === ctx.activeSession.activeGroupId
+				!!activeSession?.activeGroupId &&
+				(activeSession.tabGroups ?? []).some(
+					(g: { id: string }) => g.id === activeSession.activeGroupId
 				);
 			if (hasActiveGroup && ctx.isPaneShortcut(e, 'paneFocusLeft')) {
 				e.preventDefault();
@@ -533,7 +535,7 @@ export function useMainKeyboardHandler(): UseMainKeyboardHandlerReturn {
 					trackShortcut('killInstance');
 				}
 			} else if (ctx.isShortcut(e, 'moveToGroup')) {
-				if (ctx.activeSession) {
+				if (activeSession) {
 					ctx.setQuickActionOpen(true, 'move-to-group');
 					trackShortcut('moveToGroup');
 				}
@@ -583,10 +585,7 @@ export function useMainKeyboardHandler(): UseMainKeyboardHandlerReturn {
 					ctx.setQuickActionOpen(true, 'main');
 					trackShortcut('quickAction');
 				}
-			} else if (
-				ctx.isShortcut(e, 'clearTerminal') &&
-				ctx.activeSession?.inputMode === 'terminal'
-			) {
+			} else if (ctx.isShortcut(e, 'clearTerminal') && activeSession?.inputMode === 'terminal') {
 				// Clears the active xterm buffer in terminal mode
 				e.preventDefault();
 				ctx.mainPanelRef?.current?.clearActiveTerminal();
@@ -608,8 +607,8 @@ export function useMainKeyboardHandler(): UseMainKeyboardHandlerReturn {
 						groupChatId: ctx.activeGroupChatId,
 					});
 					trackShortcut('agentSettings');
-				} else if (ctx.activeSession) {
-					ctx.setEditAgentSession(ctx.activeSession);
+				} else if (activeSession) {
+					ctx.setEditAgentSession(activeSession);
 					trackShortcut('agentSettings');
 				}
 			} else if (ctx.isShortcut(e, 'goToFiles')) {
@@ -643,14 +642,14 @@ export function useMainKeyboardHandler(): UseMainKeyboardHandlerReturn {
 				trackShortcut('goToAutoRun');
 			} else if (ctx.isShortcut(e, 'fuzzyFileSearch')) {
 				e.preventDefault();
-				if (ctx.activeSession) {
+				if (activeSession) {
 					ctx.setFuzzyFileSearchOpen(true);
 					trackShortcut('fuzzyFileSearch');
 				}
 			} else if (ctx.isShortcut(e, 'toggleBookmark')) {
 				e.preventDefault();
-				if (ctx.activeSession) {
-					ctx.toggleBookmark(ctx.activeSession.id);
+				if (activeSession) {
+					ctx.toggleBookmark(activeSession.id);
 					trackShortcut('toggleBookmark');
 				}
 			} else if (ctx.isShortcut(e, 'openImageCarousel')) {
@@ -674,7 +673,7 @@ export function useMainKeyboardHandler(): UseMainKeyboardHandlerReturn {
 				// Only act in AI mode - the composer is AI-only. While it's already
 				// open, the hotkey cycles between windowed and full-screen instead of
 				// being a no-op.
-				if (ctx.activeSession?.inputMode === 'ai') {
+				if (activeSession?.inputMode === 'ai') {
 					const composerOpen = useModalStore.getState().modals.get('promptComposer')?.open === true;
 					if (ctx.activeGroupChatId && !composerOpen) ctx.flushGroupChatDraft?.();
 					useModalStore.getState().cyclePromptComposer();
@@ -688,7 +687,7 @@ export function useMainKeyboardHandler(): UseMainKeyboardHandlerReturn {
 				e.preventDefault();
 				// In terminal mode, Cmd+. focuses the active xterm instance so the user
 				// can resume typing shell commands - mirrors AI mode's input focus toggle.
-				if (ctx.activeSession?.inputMode === 'terminal') {
+				if (activeSession?.inputMode === 'terminal') {
 					ctx.setActiveFocus('main');
 					ctx.mainPanelRef?.current?.focusActiveTerminal();
 				} else {
@@ -725,7 +724,7 @@ export function useMainKeyboardHandler(): UseMainKeyboardHandlerReturn {
 				trackShortcut('viewGitDiff');
 			} else if (ctx.isShortcut(e, 'viewGitLog') && !ctx.activeGroupChatId) {
 				e.preventDefault();
-				if (ctx.activeSession?.isGitRepo) {
+				if (activeSession?.isGitRepo) {
 					ctx.setGitLogOpen(true);
 					trackShortcut('viewGitLog');
 				}
@@ -813,7 +812,7 @@ export function useMainKeyboardHandler(): UseMainKeyboardHandlerReturn {
 				// Open the Auto Run run modal (BatchRunnerModal) - works from anywhere
 				e.preventDefault();
 				if (useSettingsStore.getState().autoRunDisabled) return;
-				if (ctx.activeSession) {
+				if (activeSession) {
 					ctx.handleOpenBatchRunner();
 					trackShortcut('openBatchRunner');
 				}
@@ -826,11 +825,11 @@ export function useMainKeyboardHandler(): UseMainKeyboardHandlerReturn {
 				trackShortcut('toggleAutoRunExpanded');
 			} else if (ctx.isShortcut(e, 'jumpToTerminal')) {
 				e.preventDefault();
-				if (ctx.activeSession && !ctx.activeGroupChatId) {
-					const result = ctx.navigateToClosestTerminalTab(ctx.activeSession);
+				if (activeSession && !ctx.activeGroupChatId) {
+					const result = ctx.navigateToClosestTerminalTab(activeSession);
 					if (result) {
 						ctx.setSessions((prev: Session[]) =>
-							prev.map((s: Session) => (s.id === ctx.activeSession!.id ? result.session : s))
+							prev.map((s: Session) => (s.id === activeSession!.id ? result.session : s))
 						);
 						// Focus the terminal after switching
 						setTimeout(() => ctx.mainPanelRef?.current?.focusActiveTerminal(), 100);
@@ -905,7 +904,7 @@ export function useMainKeyboardHandler(): UseMainKeyboardHandlerReturn {
 			// (navigateToNextUnifiedTab, etc.) handle inputMode switching automatically.
 			// Some shortcuts only apply in AI mode (e.g., newTab, toggleReadOnly) - those
 			// are individually gated below. Navigation shortcuts work in ALL modes.
-			if (ctx.activeSessionId && ctx.activeSession && !ctx.activeGroupChatId) {
+			if (ctx.activeSessionId && activeSession && !ctx.activeGroupChatId) {
 				if (ctx.isTabShortcut(e, 'tabSwitcher')) {
 					e.preventDefault();
 					ctx.setTabSwitcherOpen(true);
@@ -914,14 +913,14 @@ export function useMainKeyboardHandler(): UseMainKeyboardHandlerReturn {
 				// Cmd+T: New AI tab (works in any mode including terminal)
 				if (ctx.isTabShortcut(e, 'newTab')) {
 					e.preventDefault();
-					const result = ctx.createTab(ctx.activeSession, {
+					const result = ctx.createTab(activeSession, {
 						saveToHistory: ctx.defaultSaveToHistory,
 						showThinking: ctx.defaultShowThinking,
 					});
 					if (result) {
 						const newSession = { ...result.session, inputMode: 'ai' as const };
 						ctx.setSessions((prev: Session[]) =>
-							prev.map((s: Session) => (s.id === ctx.activeSession!.id ? newSession : s))
+							prev.map((s: Session) => (s.id === activeSession!.id ? newSession : s))
 						);
 						// Auto-focus the input so user can start typing immediately
 						ctx.setActiveFocus('main');
@@ -942,7 +941,7 @@ export function useMainKeyboardHandler(): UseMainKeyboardHandlerReturn {
 					trackShortcut('newBrowserTab');
 				}
 				// Cmd+L: Focus browser address bar (only when a browser tab is active)
-				if (ctx.isTabShortcut(e, 'focusBrowserAddress') && ctx.activeSession?.activeBrowserTabId) {
+				if (ctx.isTabShortcut(e, 'focusBrowserAddress') && activeSession?.activeBrowserTabId) {
 					e.preventDefault();
 					ctx.mainPanelRef?.current?.focusBrowserAddressBar();
 					trackShortcut('focusBrowserAddress');
@@ -959,7 +958,7 @@ export function useMainKeyboardHandler(): UseMainKeyboardHandlerReturn {
 					!e.altKey &&
 					!e.shiftKey &&
 					(e.key === 'ArrowLeft' || e.key === 'ArrowRight') &&
-					ctx.activeSession?.activeBrowserTabId &&
+					activeSession?.activeBrowserTabId &&
 					!isEditableTarget
 				) {
 					e.preventDefault();
@@ -974,7 +973,7 @@ export function useMainKeyboardHandler(): UseMainKeyboardHandlerReturn {
 				// Cmd+R: Reload active browser tab (when a browser tab is active)
 				if (
 					ctx.isTabShortcut(e, 'toggleReadOnlyMode') &&
-					ctx.activeSession?.activeBrowserTabId &&
+					activeSession?.activeBrowserTabId &&
 					!e.shiftKey
 				) {
 					e.preventDefault();
@@ -1022,7 +1021,7 @@ export function useMainKeyboardHandler(): UseMainKeyboardHandlerReturn {
 					// 'prevented' or 'none' - do nothing
 				}
 				// Bulk close shortcuts (AI mode only - terminal tabs don't have bulk close)
-				if (ctx.activeSession.inputMode === 'ai') {
+				if (activeSession.inputMode === 'ai') {
 					if (ctx.isTabShortcut(e, 'closeAllTabs')) {
 						e.preventDefault();
 						ctx.handleCloseAllTabs();
@@ -1030,15 +1029,15 @@ export function useMainKeyboardHandler(): UseMainKeyboardHandlerReturn {
 					}
 					if (ctx.isTabShortcut(e, 'closeOtherTabs')) {
 						e.preventDefault();
-						if (ctx.activeSession.aiTabs.length > 1) {
+						if (activeSession.aiTabs.length > 1) {
 							ctx.handleCloseOtherTabs();
 							trackShortcut('closeOtherTabs');
 						}
 					}
 					if (ctx.isTabShortcut(e, 'closeTabsLeft')) {
 						e.preventDefault();
-						const activeTabIndex = ctx.activeSession.aiTabs.findIndex(
-							(t: AITab) => t.id === ctx.activeSession.activeTabId
+						const activeTabIndex = activeSession.aiTabs.findIndex(
+							(t: AITab) => t.id === activeSession.activeTabId
 						);
 						if (activeTabIndex > 0) {
 							ctx.handleCloseTabsLeft();
@@ -1047,10 +1046,10 @@ export function useMainKeyboardHandler(): UseMainKeyboardHandlerReturn {
 					}
 					if (ctx.isTabShortcut(e, 'closeTabsRight')) {
 						e.preventDefault();
-						const activeTabIndex = ctx.activeSession.aiTabs.findIndex(
-							(t: AITab) => t.id === ctx.activeSession.activeTabId
+						const activeTabIndex = activeSession.aiTabs.findIndex(
+							(t: AITab) => t.id === activeSession.activeTabId
 						);
-						if (activeTabIndex < ctx.activeSession.aiTabs.length - 1) {
+						if (activeTabIndex < activeSession.aiTabs.length - 1) {
 							ctx.handleCloseTabsRight();
 							trackShortcut('closeTabsRight');
 						}
@@ -1058,19 +1057,19 @@ export function useMainKeyboardHandler(): UseMainKeyboardHandlerReturn {
 				}
 				if (ctx.isTabShortcut(e, 'reopenClosedTab')) {
 					e.preventDefault();
-					const result = ctx.reopenUnifiedClosedTab(ctx.activeSession);
+					const result = ctx.reopenUnifiedClosedTab(activeSession);
 					if (result) {
 						ctx.setSessions((prev: Session[]) =>
-							prev.map((s: Session) => (s.id === ctx.activeSession!.id ? result.session : s))
+							prev.map((s: Session) => (s.id === activeSession!.id ? result.session : s))
 						);
 						trackShortcut('reopenClosedTab');
 					}
 				}
 				if (ctx.isTabShortcut(e, 'renameTab')) {
 					e.preventDefault();
-					if (ctx.activeSession.inputMode === 'terminal') {
-						const activeTerminalTabId = ctx.activeSession.activeTerminalTabId;
-						const terminalTab = ctx.activeSession.terminalTabs?.find(
+					if (activeSession.inputMode === 'terminal') {
+						const activeTerminalTabId = activeSession.activeTerminalTabId;
+						const terminalTab = activeSession.terminalTabs?.find(
 							(t: { id: string }) => t.id === activeTerminalTabId
 						);
 						if (activeTerminalTabId && terminalTab) {
@@ -1079,9 +1078,9 @@ export function useMainKeyboardHandler(): UseMainKeyboardHandlerReturn {
 							ctx.setRenameTabModalOpen(true);
 							trackShortcut('renameTab');
 						}
-					} else if (ctx.activeSession.activeBrowserTabId) {
-						const browserTab = ctx.activeSession.browserTabs?.find(
-							(t: { id: string }) => t.id === ctx.activeSession.activeBrowserTabId
+					} else if (activeSession.activeBrowserTabId) {
+						const browserTab = activeSession.browserTabs?.find(
+							(t: { id: string }) => t.id === activeSession.activeBrowserTabId
 						);
 						if (browserTab) {
 							ctx.setRenameTabId(browserTab.id);
@@ -1090,7 +1089,7 @@ export function useMainKeyboardHandler(): UseMainKeyboardHandlerReturn {
 							trackShortcut('renameTab');
 						}
 					} else {
-						const activeTab = ctx.getActiveTab(ctx.activeSession);
+						const activeTab = ctx.getActiveTab(activeSession);
 						if (activeTab) {
 							ctx.setRenameTabId(activeTab.id);
 							ctx.setRenameTabInitialName(getInitialRenameValue(activeTab));
@@ -1106,15 +1105,15 @@ export function useMainKeyboardHandler(): UseMainKeyboardHandlerReturn {
 				// excluding active file/browser tabs these shortcuts would silently
 				// mutate the last-visited AI tab while the user is looking at a file.
 				const isAiChatTabActive =
-					ctx.activeSession.inputMode === 'ai' &&
-					!ctx.activeSession.activeFileTabId &&
-					!ctx.activeSession.activeBrowserTabId;
+					activeSession.inputMode === 'ai' &&
+					!activeSession.activeFileTabId &&
+					!activeSession.activeBrowserTabId;
 				if (isAiChatTabActive) {
 					if (ctx.isTabShortcut(e, 'toggleReadOnlyMode')) {
 						e.preventDefault();
 						ctx.setSessions((prev: Session[]) =>
 							prev.map((s: Session) => {
-								if (s.id !== ctx.activeSession!.id) return s;
+								if (s.id !== activeSession!.id) return s;
 								return {
 									...s,
 									aiTabs: s.aiTabs.map((tab: AITab) =>
@@ -1129,7 +1128,7 @@ export function useMainKeyboardHandler(): UseMainKeyboardHandlerReturn {
 						e.preventDefault();
 						ctx.setSessions((prev: Session[]) =>
 							prev.map((s: Session) => {
-								if (s.id !== ctx.activeSession!.id) return s;
+								if (s.id !== activeSession!.id) return s;
 								return {
 									...s,
 									aiTabs: s.aiTabs.map((tab: AITab) =>
@@ -1149,7 +1148,7 @@ export function useMainKeyboardHandler(): UseMainKeyboardHandlerReturn {
 						};
 						ctx.setSessions((prev: Session[]) =>
 							prev.map((s: Session) => {
-								if (s.id !== ctx.activeSession!.id) return s;
+								if (s.id !== activeSession!.id) return s;
 								return {
 									...s,
 									aiTabs: s.aiTabs.map((tab: AITab) => {
@@ -1284,7 +1283,7 @@ export function useMainKeyboardHandler(): UseMainKeyboardHandlerReturn {
 				// Browser-tab in-page find takes precedence whenever a browser tab is
 				// the active tab. Routed both here (when webview isn't focused) and via
 				// `onBrowserTabShortcutKey` (when it is).
-				if (ctx.activeSession?.activeBrowserTabId && !e.altKey) {
+				if (activeSession?.activeBrowserTabId && !e.altKey) {
 					e.preventDefault();
 					ctx.mainPanelRef?.current?.openBrowserFind();
 					trackShortcut('searchOutput');
@@ -1312,7 +1311,7 @@ export function useMainKeyboardHandler(): UseMainKeyboardHandlerReturn {
 				} else if (ctx.activeFocus === 'right' && ctx.activeRightTab === 'history') {
 					// History filter - handled by HistoryPanel component, just track here
 					trackShortcut('filterHistory');
-				} else if (ctx.activeSession?.inputMode === 'terminal') {
+				} else if (activeSession?.inputMode === 'terminal') {
 					// Terminal search - works whether xterm is focused or not. xterm forwards
 					// Cmd+F via attachCustomKeyEventHandler (re-dispatching a synthetic event on
 					// window) so this branch handles both the direct and forwarded cases.
@@ -1345,7 +1344,8 @@ export function useMainKeyboardHandler(): UseMainKeyboardHandlerReturn {
 			// re-dispatching through the main handler (which may be blocked
 			// by the overlay/modal shortcut guard).
 			const ctx = keyboardHandlerRef.current;
-			if (ctx?.activeSession?.activeBrowserTabId) {
+			const activeSession = selectActiveSession(useSessionStore.getState());
+			if (activeSession?.activeBrowserTabId) {
 				const probe = new KeyboardEvent('keydown', {
 					key: input.key,
 					code: input.code,
@@ -1354,7 +1354,7 @@ export function useMainKeyboardHandler(): UseMainKeyboardHandlerReturn {
 					altKey: input.alt,
 					shiftKey: input.shift,
 				});
-				if (ctx.isTabShortcut(probe, 'focusBrowserAddress')) {
+				if (ctx?.isTabShortcut(probe, 'focusBrowserAddress')) {
 					ctx.mainPanelRef?.current?.focusBrowserAddressBar();
 					return;
 				}
@@ -1368,7 +1368,7 @@ export function useMainKeyboardHandler(): UseMainKeyboardHandlerReturn {
 					!input.shift &&
 					(input.key === 'f' || input.key === 'F')
 				) {
-					ctx.mainPanelRef?.current?.openBrowserFind();
+					ctx?.mainPanelRef?.current?.openBrowserFind();
 					return;
 				}
 				// Cmd+Left / Cmd+Right forwarded from the webview guest → browser
@@ -1381,9 +1381,9 @@ export function useMainKeyboardHandler(): UseMainKeyboardHandlerReturn {
 					(input.key === 'ArrowLeft' || input.key === 'ArrowRight')
 				) {
 					if (input.key === 'ArrowLeft') {
-						ctx.mainPanelRef?.current?.browserBack();
+						ctx?.mainPanelRef?.current?.browserBack();
 					} else {
-						ctx.mainPanelRef?.current?.browserForward();
+						ctx?.mainPanelRef?.current?.browserForward();
 					}
 					return;
 				}
@@ -1391,11 +1391,11 @@ export function useMainKeyboardHandler(): UseMainKeyboardHandlerReturn {
 				// breadcrumb back/forward through visited tabs. Handled directly
 				// because a synthetic window event from a focused webview doesn't
 				// reliably reach the navBack/navForward branch of the window handler.
-				if (ctx.isShortcut(probe, 'navBack')) {
+				if (ctx?.isShortcut(probe, 'navBack')) {
 					ctx.handleNavBack();
 					return;
 				}
-				if (ctx.isShortcut(probe, 'navForward')) {
+				if (ctx?.isShortcut(probe, 'navForward')) {
 					ctx.handleNavForward();
 					return;
 				}

--- a/src/renderer/hooks/keyboard/useMainKeyboardHandler.ts
+++ b/src/renderer/hooks/keyboard/useMainKeyboardHandler.ts
@@ -904,7 +904,9 @@ export function useMainKeyboardHandler(): UseMainKeyboardHandlerReturn {
 			// (navigateToNextUnifiedTab, etc.) handle inputMode switching automatically.
 			// Some shortcuts only apply in AI mode (e.g., newTab, toggleReadOnly) - those
 			// are individually gated below. Navigation shortcuts work in ALL modes.
-			if (ctx.activeSessionId && activeSession && !ctx.activeGroupChatId) {
+			// Use event-time activeSession only - do not mix with ctx.activeSessionId
+			// from the last App render, which can lag a store switch by one frame.
+			if (activeSession && !ctx.activeGroupChatId) {
 				if (ctx.isTabShortcut(e, 'tabSwitcher')) {
 					e.preventDefault();
 					ctx.setTabSwitcherOpen(true);
@@ -1199,7 +1201,7 @@ export function useMainKeyboardHandler(): UseMainKeyboardHandlerReturn {
 				if (ctx.isTabShortcut(e, 'nextTab')) {
 					e.preventDefault();
 					ctx.setSessions((prev: Session[]) => {
-						const current = prev.find((s: Session) => s.id === ctx.activeSessionId);
+						const current = prev.find((s: Session) => s.id === activeSession.id);
 						if (!current) return prev;
 						const result = ctx.navigateToNextUnifiedTab(current, ctx.showUnreadOnly);
 						if (!result) return prev;
@@ -1210,7 +1212,7 @@ export function useMainKeyboardHandler(): UseMainKeyboardHandlerReturn {
 				if (ctx.isTabShortcut(e, 'prevTab')) {
 					e.preventDefault();
 					ctx.setSessions((prev: Session[]) => {
-						const current = prev.find((s: Session) => s.id === ctx.activeSessionId);
+						const current = prev.find((s: Session) => s.id === activeSession.id);
 						if (!current) return prev;
 						const result = ctx.navigateToPrevUnifiedTab(current, ctx.showUnreadOnly);
 						if (!result) return prev;
@@ -1224,7 +1226,7 @@ export function useMainKeyboardHandler(): UseMainKeyboardHandlerReturn {
 				if (ctx.isTabShortcut(e, 'moveTabToStart')) {
 					e.preventDefault();
 					ctx.setSessions((prev: Session[]) => {
-						const current = prev.find((s: Session) => s.id === ctx.activeSessionId);
+						const current = prev.find((s: Session) => s.id === activeSession.id);
 						if (!current) return prev;
 						const updated = moveActiveUnifiedTabToEdge(current, 'start');
 						if (updated === current) return prev;
@@ -1235,7 +1237,7 @@ export function useMainKeyboardHandler(): UseMainKeyboardHandlerReturn {
 				if (ctx.isTabShortcut(e, 'moveTabToEnd')) {
 					e.preventDefault();
 					ctx.setSessions((prev: Session[]) => {
-						const current = prev.find((s: Session) => s.id === ctx.activeSessionId);
+						const current = prev.find((s: Session) => s.id === activeSession.id);
 						if (!current) return prev;
 						const updated = moveActiveUnifiedTabToEdge(current, 'end');
 						if (updated === current) return prev;
@@ -1254,7 +1256,7 @@ export function useMainKeyboardHandler(): UseMainKeyboardHandlerReturn {
 					if (ctx.isTabShortcut(e, `goToTab${i}`)) {
 						e.preventDefault();
 						ctx.setSessions((prev: Session[]) => {
-							const current = prev.find((s: Session) => s.id === ctx.activeSessionId);
+							const current = prev.find((s: Session) => s.id === activeSession.id);
 							if (!current) return prev;
 							const result = ctx.navigateToUnifiedTabByIndex(current, i - 1, ctx.showUnreadOnly);
 							if (!result) return prev;
@@ -1268,7 +1270,7 @@ export function useMainKeyboardHandler(): UseMainKeyboardHandlerReturn {
 				if (ctx.isTabShortcut(e, lastTabActionId)) {
 					e.preventDefault();
 					ctx.setSessions((prev: Session[]) => {
-						const current = prev.find((s: Session) => s.id === ctx.activeSessionId);
+						const current = prev.find((s: Session) => s.id === activeSession.id);
 						if (!current) return prev;
 						const result = ctx.navigateToLastUnifiedTab(current, ctx.showUnreadOnly);
 						if (!result) return prev;

--- a/src/renderer/hooks/keyboard/useTilingShortcuts.ts
+++ b/src/renderer/hooks/keyboard/useTilingShortcuts.ts
@@ -10,11 +10,14 @@
  * These are wired into the main keyboard handler (see useMainKeyboardHandler),
  * which matches the keys with isPaneShortcut and dispatches to the matching
  * handler. Kept out of App.tsx's body to keep that file's ctx assembly lean.
+ *
+ * Active Session is resolved at call time via selectActiveSession(getState()) so
+ * App does not need to pass a live Session into this hook.
  */
 
 import { useCallback, useMemo } from 'react';
 
-import { updateSessionWith } from '../../stores/sessionStore';
+import { selectActiveSession, updateSessionWith, useSessionStore } from '../../stores/sessionStore';
 import { useUIStore } from '../../stores/uiStore';
 import { notifyCenterFlash } from '../../stores/centerFlashStore';
 import {
@@ -61,95 +64,91 @@ function isEligibleStandalone(ref: UnifiedTabRef): boolean {
 	return ref.type === 'ai' || ref.type === 'file';
 }
 
-export function useTilingShortcuts(
-	activeSession: Session | null | undefined
-): TilingShortcutHandlers {
-	const sessionId = activeSession?.id ?? null;
+/** Resolve the active agent id at call time (identity-split: selectActiveSession, not raw activeSessionId). */
+function resolveActiveSessionId(): string | null {
+	return selectActiveSession(useSessionStore.getState())?.id ?? null;
+}
 
+export function useTilingShortcuts(): TilingShortcutHandlers {
 	// Move focus to the spatially nearest pane in `direction`. No-op when there is
 	// no active group, no focused pane, or no neighbor that way (edge of layout).
-	const focusPane = useCallback(
-		(direction: 'left' | 'right' | 'up' | 'down') => {
-			if (!sessionId) return;
-			updateSessionWith(sessionId, (s) => {
-				const group = activeGroupOf(s);
-				if (!group || !group.focusedPaneId) return s;
-				const neighbor = findPaneInDirection(group, group.focusedPaneId, direction);
-				if (!neighbor) return s;
-				return focusPaneInSession(s, group.id, neighbor);
-			});
-		},
-		[sessionId]
-	);
+	const focusPane = useCallback((direction: 'left' | 'right' | 'up' | 'down') => {
+		const sessionId = resolveActiveSessionId();
+		if (!sessionId) return;
+		updateSessionWith(sessionId, (s) => {
+			const group = activeGroupOf(s);
+			if (!group || !group.focusedPaneId) return s;
+			const neighbor = findPaneInDirection(group, group.focusedPaneId, direction);
+			if (!neighbor) return s;
+			return focusPaneInSession(s, group.id, neighbor);
+		});
+	}, []);
 
 	// Cycle focus through the group's panes in document order (Alt+[ prev, Alt+] next)
 	// with wrap-around. Unlike focusPane (spatial), this visits every pane in a fixed
 	// order so a user can round-robin through all panes regardless of geometry. No-op
 	// with no active group or fewer than two panes.
-	const cyclePane = useCallback(
-		(direction: 'prev' | 'next') => {
-			if (!sessionId) return;
-			updateSessionWith(sessionId, (s) => {
-				const group = activeGroupOf(s);
-				if (!group) return s;
-				const ids: string[] = [];
-				collectLeafIdsOrdered(group.layout, ids);
-				if (ids.length < 2) return s;
-				const currentIdx = group.focusedPaneId ? ids.indexOf(group.focusedPaneId) : -1;
-				// From no/unknown focus: next -> first pane, prev -> last pane.
-				const step = direction === 'next' ? 1 : -1;
-				const base = currentIdx === -1 ? (direction === 'next' ? -1 : 0) : currentIdx;
-				const nextIdx = (base + step + ids.length) % ids.length;
-				return focusPaneInSession(s, group.id, ids[nextIdx]);
-			});
-		},
-		[sessionId]
-	);
+	const cyclePane = useCallback((direction: 'prev' | 'next') => {
+		const sessionId = resolveActiveSessionId();
+		if (!sessionId) return;
+		updateSessionWith(sessionId, (s) => {
+			const group = activeGroupOf(s);
+			if (!group) return s;
+			const ids: string[] = [];
+			collectLeafIdsOrdered(group.layout, ids);
+			if (ids.length < 2) return s;
+			const currentIdx = group.focusedPaneId ? ids.indexOf(group.focusedPaneId) : -1;
+			// From no/unknown focus: next -> first pane, prev -> last pane.
+			const step = direction === 'next' ? 1 : -1;
+			const base = currentIdx === -1 ? (direction === 'next' ? -1 : 0) : currentIdx;
+			const nextIdx = (base + step + ids.length) % ids.length;
+			return focusPaneInSession(s, group.id, ids[nextIdx]);
+		});
+	}, []);
 
 	// Split the focused pane, pulling the next standalone AI/file tab out of the
 	// tab strip into the new pane. Full content selection lands with drag-and-drop
 	// in Phase 03; here we take the first eligible standalone tab if one exists,
 	// otherwise flash a hint and leave the layout untouched.
-	const splitFocusedPane = useCallback(
-		(direction: 'row' | 'column') => {
-			if (!sessionId) return;
-			let flashNoTab = false;
-			updateSessionWith(sessionId, (s) => {
-				const group = activeGroupOf(s);
-				if (!group || !group.focusedPaneId) return s;
-				const nextRef = (s.unifiedTabOrder ?? []).find(isEligibleStandalone);
-				if (!nextRef) {
-					flashNoTab = true;
-					return s;
-				}
-				const newLayout = splitLeaf(group.layout, group.focusedPaneId, direction, nextRef);
-				// The new leaf is the one referencing nextRef that wasn't in the old tree.
-				const newLeaf = collectNewLeafFor(newLayout, group.layout, nextRef);
-				const withLayout = updateGroupInSession(s, group.id, (g) => ({ ...g, layout: newLayout }));
-				// Drop the moved tab from the standalone strip (it now lives in a pane).
-				const cleaned: Session = {
-					...withLayout,
-					unifiedTabOrder: (withLayout.unifiedTabOrder ?? []).filter(
-						(ref) => !(ref.type === nextRef.type && ref.id === nextRef.id)
-					),
-				};
-				// Focus the freshly inserted pane so input immediately targets it.
-				return newLeaf ? focusPaneInSession(cleaned, group.id, newLeaf.id) : cleaned;
-			});
-			if (flashNoTab) {
-				notifyCenterFlash({
-					message: 'No standalone tab to split into',
-					color: 'yellow',
-				});
+	const splitFocusedPane = useCallback((direction: 'row' | 'column') => {
+		const sessionId = resolveActiveSessionId();
+		if (!sessionId) return;
+		let flashNoTab = false;
+		updateSessionWith(sessionId, (s) => {
+			const group = activeGroupOf(s);
+			if (!group || !group.focusedPaneId) return s;
+			const nextRef = (s.unifiedTabOrder ?? []).find(isEligibleStandalone);
+			if (!nextRef) {
+				flashNoTab = true;
+				return s;
 			}
-		},
-		[sessionId]
-	);
+			const newLayout = splitLeaf(group.layout, group.focusedPaneId, direction, nextRef);
+			// The new leaf is the one referencing nextRef that wasn't in the old tree.
+			const newLeaf = collectNewLeafFor(newLayout, group.layout, nextRef);
+			const withLayout = updateGroupInSession(s, group.id, (g) => ({ ...g, layout: newLayout }));
+			// Drop the moved tab from the standalone strip (it now lives in a pane).
+			const cleaned: Session = {
+				...withLayout,
+				unifiedTabOrder: (withLayout.unifiedTabOrder ?? []).filter(
+					(ref) => !(ref.type === nextRef.type && ref.id === nextRef.id)
+				),
+			};
+			// Focus the freshly inserted pane so input immediately targets it.
+			return newLeaf ? focusPaneInSession(cleaned, group.id, newLeaf.id) : cleaned;
+		});
+		if (flashNoTab) {
+			notifyCenterFlash({
+				message: 'No standalone tab to split into',
+				color: 'yellow',
+			});
+		}
+	}, []);
 
 	// Close the focused pane: promote its tab back to a standalone strip chip, move
 	// focus to a neighbor, rebalance the remaining panes. If that leaves a single
 	// pane, auto-dissolve the whole group (promoting the last tab too).
 	const closeFocusedPane = useCallback(() => {
+		const sessionId = resolveActiveSessionId();
 		if (!sessionId) return;
 		// Closing a pane changes the leaf set, so drop any stale maximize/zoom that
 		// might point at the pane being removed. Cheap and keeps the view consistent.
@@ -186,19 +185,21 @@ export function useTilingShortcuts(
 			// focusPaneInSession moves focusedPaneId to the neighbor and syncs activeTabId.
 			return focusTarget ? focusPaneInSession(promoted, group.id, focusTarget) : promoted;
 		});
-	}, [sessionId]);
+	}, []);
 
 	// Toggle maximize/zoom for the focused pane. Transient UI-store state, not the
 	// Session. Toggling again (or when already zoomed) restores the full layout.
 	const toggleZoom = useCallback(() => {
-		const group = activeGroupOf(activeSession);
+		const session = selectActiveSession(useSessionStore.getState());
+		const group = activeGroupOf(session);
 		if (!group || !group.focusedPaneId) return;
 		const { zoomedPaneId, setZoomedPaneId } = useUIStore.getState();
 		setZoomedPaneId(zoomedPaneId ? null : group.focusedPaneId);
-	}, [activeSession]);
+	}, []);
 
 	// Equal-split: reset every split node's sizes to equal fractions.
 	const rebalance = useCallback(() => {
+		const sessionId = resolveActiveSessionId();
 		if (!sessionId) return;
 		updateSessionWith(sessionId, (s) => {
 			const group = activeGroupOf(s);
@@ -208,7 +209,7 @@ export function useTilingShortcuts(
 				layout: rebalanceLayout(g.layout),
 			}));
 		});
-	}, [sessionId]);
+	}, []);
 
 	return useMemo(
 		() => ({ focusPane, cyclePane, splitFocusedPane, closeFocusedPane, toggleZoom, rebalance }),

--- a/src/renderer/hooks/ui/useAppHandlers.ts
+++ b/src/renderer/hooks/ui/useAppHandlers.ts
@@ -486,15 +486,17 @@ export function useAppHandlers(deps: UseAppHandlersDeps): UseAppHandlersReturn {
 	);
 
 	const updateSessionWorkingDirectory = useCallback(async () => {
+		// Pin before the folder dialog awaits - switching agents while the
+		// picker is open must not retarget the cwd update.
+		const initiatingSessionId = selectActiveSession(useSessionStore.getState())?.id;
+		if (!initiatingSessionId) return;
+
 		const newPath = await window.maestro.dialog.selectFolder();
 		if (!newPath) return;
 
-		const activeSessionId = selectActiveSession(useSessionStore.getState())?.id;
-		if (!activeSessionId) return;
-
 		setSessions((prev) =>
 			prev.map((s) => {
-				if (s.id !== activeSessionId) return s;
+				if (s.id !== initiatingSessionId) return s;
 				return {
 					...s,
 					cwd: newPath,

--- a/src/renderer/hooks/ui/useAppHandlers.ts
+++ b/src/renderer/hooks/ui/useAppHandlers.ts
@@ -7,7 +7,7 @@ import {
 } from '../../utils/fileExplorer';
 import type { FileNode } from '../../types/fileTree';
 import { useModalStore } from '../../stores/modalStore';
-import { useSessionStore } from '../../stores/sessionStore';
+import { selectActiveSession, useSessionStore } from '../../stores/sessionStore';
 import { useUIStore } from '../../stores/uiStore';
 import { generateId } from '../../utils/ids';
 import { isAbsolutePath } from '../../../shared/formatters';
@@ -65,10 +65,6 @@ export interface FileTabOpenOptions {
 }
 
 export interface UseAppHandlersDeps {
-	/** Currently active session */
-	activeSession: Session | null;
-	/** ID of the currently active session */
-	activeSessionId: string | null;
 	/** Session state setter */
 	setSessions: React.Dispatch<React.SetStateAction<Session[]>>;
 	/** Focus area setter */
@@ -189,8 +185,6 @@ function findSubtreeFolders(
  */
 export function useAppHandlers(deps: UseAppHandlersDeps): UseAppHandlersReturn {
 	const {
-		activeSession,
-		activeSessionId,
 		setSessions,
 		setActiveFocus,
 		setConfirmModalMessage,
@@ -337,6 +331,7 @@ export function useAppHandlers(deps: UseAppHandlersDeps): UseAppHandlersReturn {
 
 	const handleFileClick = useCallback(
 		async (node: FileNode, path: string) => {
+			const activeSession = selectActiveSession(useSessionStore.getState());
 			if (!activeSession) return; // Guard against null session
 			if (node.type !== 'file') return;
 
@@ -482,7 +477,6 @@ export function useAppHandlers(deps: UseAppHandlersDeps): UseAppHandlersReturn {
 			}
 		},
 		[
-			activeSession,
 			setConfirmModalMessage,
 			setConfirmModalOnConfirm,
 			setConfirmModalOpen,
@@ -494,6 +488,9 @@ export function useAppHandlers(deps: UseAppHandlersDeps): UseAppHandlersReturn {
 	const updateSessionWorkingDirectory = useCallback(async () => {
 		const newPath = await window.maestro.dialog.selectFolder();
 		if (!newPath) return;
+
+		const activeSessionId = selectActiveSession(useSessionStore.getState())?.id;
+		if (!activeSessionId) return;
 
 		setSessions((prev) =>
 			prev.map((s) => {
@@ -516,7 +513,7 @@ export function useAppHandlers(deps: UseAppHandlersDeps): UseAppHandlersReturn {
 				};
 			})
 		);
-	}, [activeSessionId, setSessions]);
+	}, [setSessions]);
 
 	// --- FOLDER HANDLERS ---
 


### PR DESCRIPTION
- Resolve the active Session at call/event time via `selectActiveSession(getState())` in the main keyboard handler, tiling shortcuts, App handlers, Auto Run handlers, agent session management, and Summarize & Continue.
- Pass only `activeSessionId` into `useAgentExecution` so App no longer refreshes those hooks on every Session object change.
- Keeps chrome Session in App for remaining effects/assembly; behavior should be unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of keyboard shortcuts, terminal actions, tab navigation, pane controls, Auto Run, and session management when switching sessions.
  * Prevented actions from using outdated session information during rapid session or tab changes, including summarization, agent execution, and file operations.
  * Adjusted Auto Run worktree failure behavior to preserve the seeded parent session state.
* **Refactor**
  * Updated session-related actions to resolve the currently active session at execution time rather than relying on passed-in session props.
* **Tests**
  * Expanded and updated hook tests to seed the active session via store state, including handler stability and session switching edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->