### PR TITLE
perf(session): move Left Bar sort/starred into sidebarNavStore

### DIFF
--- a/docs/agent-guides/STATE-PATTERNS.md
+++ b/docs/agent-guides/STATE-PATTERNS.md
@@ -20,19 +20,20 @@ All stores are in `src/renderer/stores/`.
 
 ## Store Inventory
 
-| Store                 | File                   | Hook                   | Purpose                                                                                     |
-| --------------------- | ---------------------- | ---------------------- | ------------------------------------------------------------------------------------------- |
-| **sessionStore**      | `sessionStore.ts`      | `useSessionStore`      | Sessions, groups, active session, bookmarks, worktree tracking, initialization              |
-| **uiStore**           | `uiStore.ts`           | `useUIStore`           | UI layout: sidebars, focus, notifications, search, drag-and-drop, editing                   |
-| **tabStore**          | `tabStore.ts`          | `useTabStore`          | Tab operations (CRUD, navigation, metadata), gist state. Wraps tabHelpers.ts + sessionStore |
-| **agentStore**        | `agentStore.ts`        | `useAgentStore`        | Agent detection cache, error recovery, queue processing, agent lifecycle                    |
-| **modalStore**        | `modalStore.ts`        | `useModalStore`        | Modal visibility via registry pattern. Single Map replaces 90+ boolean fields               |
-| **groupChatStore**    | `groupChatStore.ts`    | `useGroupChatStore`    | Group chat state: chats list, messages, moderator, participants, execution queue            |
-| **settingsStore**     | `settingsStore.ts`     | `useSettingsStore`     | App settings (theme, font, shortcuts, agent configs, per-modal `modalSizes`, etc.)          |
-| **fileExplorerStore** | `fileExplorerStore.ts` | `useFileExplorerStore` | File explorer panel state                                                                   |
-| **batchStore**        | `batchStore.ts`        | `useBatchStore`        | Batch/Auto Run execution state                                                              |
-| **notificationStore** | `notificationStore.ts` | `useNotificationStore` | In-app notification queue                                                                   |
-| **operationStore**    | `operationStore.ts`    | `useOperationStore`    | Long-running operation tracking                                                             |
+| Store                 | File                   | Hook                   | Purpose                                                                                           |
+| --------------------- | ---------------------- | ---------------------- | ------------------------------------------------------------------------------------------------- |
+| **sessionStore**      | `sessionStore.ts`      | `useSessionStore`      | Sessions, groups, active session, bookmarks, worktree tracking, initialization                    |
+| **uiStore**           | `uiStore.ts`           | `useUIStore`           | UI layout: sidebars, focus, notifications, search, drag-and-drop, editing                         |
+| **tabStore**          | `tabStore.ts`          | `useTabStore`          | Tab operations (CRUD, navigation, metadata), gist state. Wraps tabHelpers.ts + sessionStore       |
+| **agentStore**        | `agentStore.ts`        | `useAgentStore`        | Agent detection cache, error recovery, queue processing, agent lifecycle                          |
+| **modalStore**        | `modalStore.ts`        | `useModalStore`        | Modal visibility via registry pattern. Single Map replaces 90+ boolean fields                     |
+| **groupChatStore**    | `groupChatStore.ts`    | `useGroupChatStore`    | Group chat state: chats list, messages, moderator, participants, execution queue                  |
+| **settingsStore**     | `settingsStore.ts`     | `useSettingsStore`     | App settings (theme, font, shortcuts, agent configs, per-modal `modalSizes`, etc.)                |
+| **fileExplorerStore** | `fileExplorerStore.ts` | `useFileExplorerStore` | File explorer panel state                                                                         |
+| **sidebarNavStore**   | `sidebarNavStore.ts`   | `useSidebarNavStore`   | Left Bar sort/nav/starred projections (`SidebarNavSync` host writes; SessionList + keyboard read) |
+| **batchStore**        | `batchStore.ts`        | `useBatchStore`        | Batch/Auto Run execution state                                                                    |
+| **notificationStore** | `notificationStore.ts` | `useNotificationStore` | In-app notification queue                                                                         |
+| **operationStore**    | `operationStore.ts`    | `useOperationStore`    | Long-running operation tracking                                                                   |
 
 ---
 

--- a/src/__tests__/helpers/resetStores.ts
+++ b/src/__tests__/helpers/resetStores.ts
@@ -35,6 +35,7 @@ import { useRestartPendingStore } from '../../renderer/stores/restartPendingStor
 import { useRetryStore } from '../../renderer/stores/retryStore';
 import { useSessionStore } from '../../renderer/stores/sessionStore';
 import { useSettingsStore } from '../../renderer/stores/settingsStore';
+import { useSidebarNavStore } from '../../renderer/stores/sidebarNavStore';
 import { useTabStore } from '../../renderer/stores/tabStore';
 import { useThoughtStreamStore } from '../../renderer/stores/thoughtStreamStore';
 import { useUIStore } from '../../renderer/stores/uiStore';
@@ -106,6 +107,7 @@ export function resetStore(store: ResettableStore): void {
 /** All renderer Zustand stores that tests commonly seed or assert against. */
 export const ALL_RENDERER_STORES: ResettableStore[] = [
 	useSessionStore,
+	useSidebarNavStore,
 	useUIStore,
 	useSettingsStore,
 	useModalStore,

--- a/src/__tests__/helpers/seedSidebarNav.ts
+++ b/src/__tests__/helpers/seedSidebarNav.ts
@@ -1,0 +1,89 @@
+/**
+ * Seed / reset {@link useSidebarNavStore} for Left Bar tests.
+ *
+ * SessionList no longer takes sorted/starred as required props; tests that used
+ * to pass those must publish them into the store (or compute from sessions).
+ */
+
+import type { Group, Session } from '../../renderer/types';
+import type { StarredItem } from '../../renderer/hooks/session/useStarredItems';
+import { computeSortedSessions } from '../../renderer/hooks/session/computeSortedSessions';
+import { useSidebarNavStore } from '../../renderer/stores/sidebarNavStore';
+import { useUIStore } from '../../renderer/stores/uiStore';
+
+type ActivateStarred = (item: StarredItem) => void | Promise<void>;
+
+/** Direct projection seed (unit tests that build sorted lists by hand). */
+export interface SeedSidebarNavProjection {
+	sortedSessions?: Session[];
+	visibleSessions?: Session[];
+	navSessions?: Session[];
+	bookmarkNavSize?: number;
+	navIndexMap?: Map<string, number>;
+	starredItems?: StarredItem[];
+	/** Optional mock; overrides the store's real activateStarredItem for assertions. */
+	activateStarredItem?: ActivateStarred;
+}
+
+/** Compute projection from sessions (integration harnesses). */
+export interface SeedSidebarNavFromSessions {
+	sessions: Session[];
+	groups?: Group[];
+	activeSessionId?: string | null;
+	bookmarksCollapsed?: boolean;
+	showUnreadAgentsOnly?: boolean;
+	starredItems?: StarredItem[];
+	activateStarredItem?: ActivateStarred;
+}
+
+export type SeedSidebarNavInput = SeedSidebarNavProjection | SeedSidebarNavFromSessions;
+
+function isFromSessions(input: SeedSidebarNavInput): input is SeedSidebarNavFromSessions {
+	return 'sessions' in input && Array.isArray(input.sessions);
+}
+
+/**
+ * Write Left Bar nav / starred slices into sidebarNavStore.
+ */
+export function seedSidebarNav(input: SeedSidebarNavInput): void {
+	if (isFromSessions(input)) {
+		const ui = useUIStore.getState();
+		const projection = computeSortedSessions({
+			sessions: input.sessions,
+			groups: input.groups ?? [],
+			bookmarksCollapsed: input.bookmarksCollapsed ?? ui.bookmarksCollapsed,
+			showUnreadAgentsOnly: input.showUnreadAgentsOnly ?? ui.showUnreadAgentsOnly,
+			activeSessionId: input.activeSessionId,
+		});
+		useSidebarNavStore.setState({
+			...projection,
+			...(input.starredItems !== undefined ? { starredItems: input.starredItems } : {}),
+			...(input.activateStarredItem
+				? {
+						activateStarredItem: input.activateStarredItem as (item: StarredItem) => Promise<void>,
+					}
+				: {}),
+		});
+		return;
+	}
+
+	const sorted = input.sortedSessions ?? [];
+	useSidebarNavStore.setState({
+		sortedSessions: sorted,
+		visibleSessions: input.visibleSessions ?? sorted,
+		navSessions: input.navSessions ?? sorted,
+		bookmarkNavSize: input.bookmarkNavSize ?? 0,
+		navIndexMap: input.navIndexMap ?? new Map(),
+		starredItems: input.starredItems ?? [],
+		...(input.activateStarredItem
+			? {
+					activateStarredItem: input.activateStarredItem as (item: StarredItem) => Promise<void>,
+				}
+			: {}),
+	});
+}
+
+/** Restore sidebarNavStore to its module initial state (replace). */
+export function resetSidebarNavStore(): void {
+	useSidebarNavStore.setState(useSidebarNavStore.getInitialState(), true);
+}

--- a/src/__tests__/integration/AutoRunSessionList.test.tsx
+++ b/src/__tests__/integration/AutoRunSessionList.test.tsx
@@ -21,7 +21,6 @@ import { seedSidebarNav, resetSidebarNavStore } from '../helpers/seedSidebarNav'
 import { useSessionStore } from '../../renderer/stores/sessionStore';
 import { useUIStore } from '../../renderer/stores/uiStore';
 import { useSettingsStore } from '../../renderer/stores/settingsStore';
-import { useEffect } from 'react';
 
 // Helper to wrap component in LayerStackProvider with custom rerender
 const renderWithProviders = (ui: React.ReactElement) => {
@@ -383,8 +382,10 @@ const IntegrationTestWrapper = ({
 	// SessionList reads Zustand; keep local harness state mirrored into stores.
 	useEffect(() => {
 		useSessionStore.setState({ sessions, groups, activeSessionId });
-		seedSidebarNav({ sessions, groups, activeSessionId });
-	}, [sessions, groups, activeSessionId]);
+		// Pass bookmarksCollapsed explicitly: this effect can run before the UI
+		// store mirror below, and seedSidebarNav must not read a stale value.
+		seedSidebarNav({ sessions, groups, activeSessionId, bookmarksCollapsed });
+	}, [sessions, groups, activeSessionId, bookmarksCollapsed]);
 
 	useEffect(() => {
 		useUIStore.setState({

--- a/src/__tests__/integration/AutoRunSessionList.test.tsx
+++ b/src/__tests__/integration/AutoRunSessionList.test.tsx
@@ -10,13 +10,18 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import { SessionList } from '../../renderer/components/SessionList';
 import { AutoRun, AutoRunHandle } from '../../renderer/components/AutoRun';
 import { LayerStackProvider } from '../../renderer/contexts/LayerStackContext';
 import { createMockTheme } from '../helpers/mockTheme';
 import type { Session, Group, Shortcut, BatchRunState, SessionState } from '../../renderer/types';
 import { createMockSession as baseCreateMockSession } from '../helpers/mockSession';
+import { seedSidebarNav, resetSidebarNavStore } from '../helpers/seedSidebarNav';
+import { useSessionStore } from '../../renderer/stores/sessionStore';
+import { useUIStore } from '../../renderer/stores/uiStore';
+import { useSettingsStore } from '../../renderer/stores/settingsStore';
+import { useEffect } from 'react';
 
 // Helper to wrap component in LayerStackProvider with custom rerender
 const renderWithProviders = (ui: React.ReactElement) => {
@@ -375,6 +380,53 @@ const IntegrationTestWrapper = ({
 		setShowConfirmDialog({ message, onConfirm });
 	}, []);
 
+	// SessionList reads Zustand; keep local harness state mirrored into stores.
+	useEffect(() => {
+		useSessionStore.setState({ sessions, groups, activeSessionId });
+		seedSidebarNav({ sessions, groups, activeSessionId });
+	}, [sessions, groups, activeSessionId]);
+
+	useEffect(() => {
+		useUIStore.setState({
+			leftSidebarOpen,
+			activeFocus,
+			selectedSidebarIndex,
+			editingGroupId,
+			editingSessionId,
+			draggingSessionId,
+			bookmarksCollapsed,
+		});
+		useSettingsStore.setState({
+			leftSidebarWidth,
+			ungroupedCollapsed,
+		});
+	}, [
+		leftSidebarOpen,
+		activeFocus,
+		selectedSidebarIndex,
+		editingGroupId,
+		editingSessionId,
+		draggingSessionId,
+		bookmarksCollapsed,
+		leftSidebarWidth,
+		ungroupedCollapsed,
+	]);
+
+	// SessionList selection updates the store; mirror back for Auto Run panel.
+	useEffect(() => {
+		return useSessionStore.subscribe((state) => {
+			if (state.activeSessionId && state.activeSessionId !== activeSessionId) {
+				handleSessionSelect(state.activeSessionId);
+			}
+			if (state.sessions !== sessions) {
+				setSessions(state.sessions);
+			}
+			if (state.groups !== groups) {
+				setGroups(state.groups);
+			}
+		});
+	});
+
 	const theme = createMockTheme();
 	const shortcuts = createMockShortcuts();
 
@@ -384,38 +436,10 @@ const IntegrationTestWrapper = ({
 				{/* Session List */}
 				<SessionList
 					theme={theme}
-					sessions={sessions}
-					groups={groups}
-					sortedSessions={sessions}
-					starredItems={[]}
-					activateStarredItem={() => {}}
-					activeSessionId={activeSessionId}
-					leftSidebarOpen={leftSidebarOpen}
-					leftSidebarWidthState={leftSidebarWidth}
-					activeFocus={activeFocus}
-					selectedSidebarIndex={selectedSidebarIndex}
-					editingGroupId={editingGroupId}
-					editingSessionId={editingSessionId}
-					draggingSessionId={draggingSessionId}
-					shortcuts={shortcuts}
 					isLiveMode={false}
 					webInterfaceUrl={null}
 					toggleGlobalLive={() => {}}
-					bookmarksCollapsed={bookmarksCollapsed}
-					setBookmarksCollapsed={setBookmarksCollapsed}
-					ungroupedCollapsed={ungroupedCollapsed}
-					setUngroupedCollapsed={setUngroupedCollapsed}
-					setActiveFocus={(focus) => setActiveFocus(focus as 'sidebar' | 'main' | 'right')}
-					setActiveSessionId={handleSessionSelect}
-					setLeftSidebarOpen={setLeftSidebarOpen}
-					setLeftSidebarWidthState={setLeftSidebarWidth}
-					setShortcutsHelpOpen={() => {}}
-					setSettingsModalOpen={() => {}}
-					setSettingsTab={() => {}}
-					setAboutModalOpen={() => {}}
-					setUpdateCheckModalOpen={() => {}}
-					setLogViewerOpen={() => {}}
-					setProcessMonitorOpen={() => {}}
+					restartWebServer={async () => null}
 					toggleGroup={(groupId) => {
 						setGroups((prev) =>
 							prev.map((g) => (g.id === groupId ? { ...g, collapsed: !g.collapsed } : g))
@@ -450,8 +474,6 @@ const IntegrationTestWrapper = ({
 					startRenamingGroup={(groupId) => setEditingGroupId(groupId)}
 					startRenamingSession={(sessId) => setEditingSessionId(sessId)}
 					showConfirmation={handleConfirmation}
-					setGroups={setGroups}
-					setSessions={setSessions}
 					createNewGroup={() => {
 						const newGroup: Group = {
 							id: `group-${Date.now()}`,
@@ -461,6 +483,7 @@ const IntegrationTestWrapper = ({
 						};
 						setGroups((prev) => [...prev, newGroup]);
 					}}
+					setGroupParent={() => {}}
 					addNewSession={() => {
 						const newSession = createMockSession({
 							id: `session-${Date.now()}`,
@@ -472,9 +495,9 @@ const IntegrationTestWrapper = ({
 						setSessions((prev) => [...prev, newSession]);
 						setActiveSessionId(newSession.id);
 					}}
-					setRenameInstanceModalOpen={() => {}}
-					setRenameInstanceValue={() => {}}
-					setRenameInstanceSessionId={() => {}}
+					onDeleteSession={handleDeleteSession}
+					onEditAgent={() => {}}
+					onNewAgentSession={() => {}}
 				/>
 
 				{/* Auto Run Panel (only render if active session exists) */}
@@ -550,6 +573,7 @@ describe('Auto Run + Session List Integration', () => {
 	let mockMaestro: ReturnType<typeof setupMaestroMock>;
 
 	beforeEach(() => {
+		resetSidebarNavStore();
 		mockMaestro = setupMaestroMock();
 		vi.useFakeTimers({ shouldAdvanceTime: true });
 		vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {

--- a/src/__tests__/renderer/components/SessionList.test.tsx
+++ b/src/__tests__/renderer/components/SessionList.test.tsx
@@ -16,6 +16,7 @@ import { render, screen, fireEvent, act, waitFor } from '@testing-library/react'
 import { SessionList } from '../../../renderer/components/SessionList';
 import type { Session, Group, Theme } from '../../../renderer/types';
 import { createMockSession as baseCreateMockSession } from '../../helpers/mockSession';
+import { seedSidebarNav, resetSidebarNavStore } from '../../helpers/seedSidebarNav';
 import { useUIStore } from '../../../renderer/stores/uiStore';
 import { useSessionStore } from '../../../renderer/stores/sessionStore';
 import { useSettingsStore } from '../../../renderer/stores/settingsStore';
@@ -231,52 +232,74 @@ const createMockGroup = (overrides: Partial<Group> = {}): Group => ({
 });
 
 // Create default handler props (state is read from stores)
-const createDefaultProps = (overrides: Partial<Parameters<typeof SessionList>[0]> = {}) => ({
-	theme: defaultTheme,
-	sortedSessions: [] as Session[],
-	isLiveMode: false,
-	webInterfaceUrl: null,
-	showSessionJumpNumbers: false,
-	visibleSessions: [] as Session[],
-	starredItems: [],
-	activateStarredItem: vi.fn(),
-	toggleGlobalLive: vi.fn(),
-	restartWebServer: vi.fn().mockResolvedValue(null),
-	toggleGroup: vi.fn(),
-	handleDragStart: vi.fn(),
-	handleDragOver: vi.fn(),
-	handleDropOnGroup: vi.fn(),
-	handleDropOnUngrouped: vi.fn(),
-	finishRenamingGroup: vi.fn(),
-	finishRenamingSession: vi.fn(),
-	startRenamingGroup: vi.fn(),
-	startRenamingSession: vi.fn(),
-	showConfirmation: vi.fn(),
-	createNewGroup: vi.fn(),
-	setGroupParent: vi.fn(),
-	onCreateGroupAndMove: vi.fn(),
-	addNewSession: vi.fn(),
-	onDeleteWorktreeGroup: vi.fn(),
-	onEditAgent: vi.fn(),
-	onNewAgentSession: vi.fn(),
-	onToggleWorktreeExpanded: vi.fn(),
-	onOpenCreatePR: vi.fn(),
-	onQuickCreateWorktree: vi.fn(),
-	onOpenWorktreeConfig: vi.fn(),
-	onDeleteWorktree: vi.fn(),
-	openWizard: vi.fn(),
-	startTour: vi.fn(),
-	onOpenGroupChat: vi.fn(),
-	onNewGroupChat: vi.fn(),
-	onEditGroupChat: vi.fn(),
-	onRenameGroupChat: vi.fn(),
-	onDeleteGroupChat: vi.fn(),
-	...overrides,
-});
+type SessionListNavOverrides = {
+	sortedSessions?: Session[];
+	visibleSessions?: Session[];
+	starredItems?: any[];
+	activateStarredItem?: (...args: any[]) => any;
+};
+
+const createDefaultProps = (
+	overrides: Partial<Parameters<typeof SessionList>[0]> & SessionListNavOverrides = {}
+) => {
+	const {
+		sortedSessions = [],
+		visibleSessions = sortedSessions,
+		starredItems = [],
+		activateStarredItem = vi.fn(),
+		...rest
+	} = overrides;
+	seedSidebarNav({
+		sortedSessions,
+		visibleSessions,
+		navSessions: sortedSessions,
+		starredItems,
+		activateStarredItem,
+	});
+	return {
+		theme: defaultTheme,
+		isLiveMode: false,
+		webInterfaceUrl: null,
+		showSessionJumpNumbers: false,
+		toggleGlobalLive: vi.fn(),
+		restartWebServer: vi.fn().mockResolvedValue(null),
+		toggleGroup: vi.fn(),
+		handleDragStart: vi.fn(),
+		handleDragOver: vi.fn(),
+		handleDropOnGroup: vi.fn(),
+		handleDropOnUngrouped: vi.fn(),
+		finishRenamingGroup: vi.fn(),
+		finishRenamingSession: vi.fn(),
+		startRenamingGroup: vi.fn(),
+		startRenamingSession: vi.fn(),
+		showConfirmation: vi.fn(),
+		createNewGroup: vi.fn(),
+		setGroupParent: vi.fn(),
+		onCreateGroupAndMove: vi.fn(),
+		addNewSession: vi.fn(),
+		onDeleteWorktreeGroup: vi.fn(),
+		onEditAgent: vi.fn(),
+		onNewAgentSession: vi.fn(),
+		onToggleWorktreeExpanded: vi.fn(),
+		onOpenCreatePR: vi.fn(),
+		onQuickCreateWorktree: vi.fn(),
+		onOpenWorktreeConfig: vi.fn(),
+		onDeleteWorktree: vi.fn(),
+		openWizard: vi.fn(),
+		startTour: vi.fn(),
+		onOpenGroupChat: vi.fn(),
+		onNewGroupChat: vi.fn(),
+		onEditGroupChat: vi.fn(),
+		onRenameGroupChat: vi.fn(),
+		onDeleteGroupChat: vi.fn(),
+		...rest,
+	};
+};
 
 describe('SessionList', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		resetSidebarNavStore();
 		vi.mocked(window.maestro.plugins.contributions).mockResolvedValue(EMPTY_PLUGIN_CONTRIBUTIONS);
 		vi.mocked(window.maestro.plugins.getGroupings).mockResolvedValue([]);
 		vi.mocked(window.maestro.plugins.onChanged).mockImplementation(() => () => {});

--- a/src/__tests__/renderer/hooks/props/useSessionListProps.test.ts
+++ b/src/__tests__/renderer/hooks/props/useSessionListProps.test.ts
@@ -9,14 +9,9 @@ import { mockTheme } from '../../../helpers/mockTheme';
 function createDeps(overrides: Partial<UseSessionListPropsDeps> = {}): UseSessionListPropsDeps {
 	return {
 		theme: mockTheme,
-		sortedSessions: [],
 		isLiveMode: false,
 		webInterfaceUrl: null,
 		showSessionJumpNumbers: false,
-		visibleSessions: [],
-		navIndexMap: new Map(),
-		starredItems: [],
-		activateStarredItem: vi.fn(),
 		sidebarContainerRef: { current: null },
 		toggleGlobalLive: vi.fn().mockResolvedValue(undefined),
 		restartWebServer: vi.fn().mockResolvedValue(null),
@@ -44,7 +39,6 @@ function createDeps(overrides: Partial<UseSessionListPropsDeps> = {}): UseSessio
 		handleToggleWorktreeExpanded: vi.fn(),
 		handleConfigureCue: vi.fn(),
 		maestroCueEnabled: false,
-		handleJumpToStarredSession: vi.fn().mockResolvedValue(false),
 		openWizardModal: vi.fn(),
 		handleOpenFeedbackModal: vi.fn(),
 		handleStartTour: vi.fn(),

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -48,7 +48,6 @@ import {
 	useHandsOnTimeTracker,
 	useNavigationHistory,
 	useSessionNavigation,
-	useSortedSessions,
 	useGroupManagement,
 	// Input processing
 	useInputHandlers,
@@ -126,8 +125,6 @@ import {
 	useQuickActionsHandlers,
 	// Session cycling (Cmd+Shift+[/])
 	useCycleSession,
-	// Starred Sessions list + activation (shared by Left Bar render and cycling)
-	useStarredItems,
 	// Input mode toggle (Tier 3A)
 	useInputMode,
 	// Live mode management (Tier 3B)
@@ -135,6 +132,8 @@ import {
 	// Session switching callbacks (navigate to session/tab from various UI surfaces)
 	useSessionSwitchCallbacks,
 } from './hooks';
+import { SidebarNavSync } from './hooks/session/SidebarNavSync';
+import { useSidebarNavStore } from './stores/sidebarNavStore';
 import { useChatFileDropZone } from './hooks/ui/useChatFileDropZone';
 import { useMainPanelProps, useSessionListProps, useRightPanelProps } from './hooks/props';
 import { useAgentListeners } from './hooks/agent/useAgentListeners';
@@ -163,7 +162,6 @@ import {
 } from './stores/sessionStore';
 import { useStoreWithEqualityFn } from 'zustand/traditional';
 import {
-	sidebarSessionEquality,
 	gitPollSessionEquality,
 	projectRootSessionEquality,
 	activeSessionChromeEquality,
@@ -515,16 +513,7 @@ function MaestroConsoleInner() {
 	// PERF: Do NOT subscribe to the full `sessions` array here. Streaming log/token
 	// updates would re-render the entire console shell. Event-time readers use
 	// sessionsRef / getState(); paint leaves self-source with narrow selectors.
-	// Sidebar-stable view for the sort/navigation pipeline.
-	// `sidebarSessionEquality` ignores log/usage/cycle counters, so the array
-	// reference only flips when something the left bar actually displays
-	// changes. Plumbed into `useSortedSessions` so `sortedSessions` (and the
-	// SessionList tree) stops re-rendering on every 200ms streaming flush.
-	const sessionsForSidebar = useStoreWithEqualityFn(
-		useSessionStore,
-		(s) => s.sessions,
-		sidebarSessionEquality
-	);
+	// Left Bar sort/nav/starred live in sidebarNavStore (SidebarNavSync host).
 	const hasSessions = useSessionStore((s) => s.sessions.length > 0);
 	const hasNoAgents = !hasSessions;
 	const groups = useSessionStore((s) => s.groups);
@@ -2008,23 +1997,13 @@ function MaestroConsoleInner() {
 
 	// handleToastSessionClick, deep link navigation - now in useSessionSwitchCallbacks hook
 
-	// --- SESSION SORTING ---
-	// Extracted hook for sorted and visible session lists (ignores leading emojis for alphabetization)
-	const { sortedSessions, visibleSessions, navSessions, bookmarkNavSize, navIndexMap } =
-		useSortedSessions({
-			// Use the sidebar-stable projection so log streaming doesn't recompute
-			// the sort/navigation tree every 200ms.
-			sessions: sessionsForSidebar,
-			groups,
-			bookmarksCollapsed,
-			showUnreadAgentsOnly,
-			activeSessionId,
-		});
+	// --- SESSION SORTING / STARRED (sidebarNavStore) ---
+	// SidebarNavSync (mounted below) owns sidebarSessionEquality + sort/star
+	// computation. SessionList and keyboard cycle/nav read the store.
 
 	// --- KEYBOARD NAVIGATION ---
-	// NOTE: useKeyboardNavigation is called further down, after useStarredItems,
-	// so arrow-key navigation can traverse the Starred Sessions + Group Chats
-	// sections (which depend on starredItems / activateStarredItem).
+	// NOTE: useKeyboardNavigation is called further down, after showConfirmation
+	// is available so starred jump handlers can be registered on the store.
 
 	// --- MAIN KEYBOARD HANDLER ---
 	// Extracted hook for main keyboard event listener (empty deps, uses ref pattern)
@@ -2057,6 +2036,14 @@ function MaestroConsoleInner() {
 		pushNavigation,
 	});
 
+	// Register jump/confirm for closed starred activation (store.activateStarredItem).
+	useEffect(() => {
+		useSidebarNavStore.getState().registerStarredHandlers({
+			onJumpToStarredSession: handleJumpToStarredSession,
+			showConfirmation,
+		});
+	}, [handleJumpToStarredSession, showConfirmation]);
+
 	// NOTE: Theme CSS variables and scrollbar fade animations are now handled by useThemeStyles hook
 	// NOTE: Main keyboard handler is now provided by useMainKeyboardHandler hook
 	// NOTE: Sync selectedSidebarIndex with activeSessionId is now handled by useKeyboardNavigation hook
@@ -2071,27 +2058,9 @@ function MaestroConsoleInner() {
 	// NOTE: Auto Run document loading and file watching are now handled by useAutoRunDocumentLoader hook
 
 	// --- ACTIONS ---
-	// Starred Sessions list + activation - single owner shared by the Left Bar
-	// render (SessionList) and Cmd+[ / Cmd+] cycling so both traverse the same rows.
-	const { starredItems, activateStarredItem } = useStarredItems({
-		onJumpToStarredSession: handleJumpToStarredSession,
-		showConfirmation,
-		// Multi-window: scope the Starred section to agents this window owns (same
-		// ownsSession the thinking pill / cycling use). Undefined outside a
-		// WindowProvider, so single-window/web behaviour is unchanged.
-		ownsSession,
-	});
-
-	// cycleSession - event-time getState() via useCycleSession (no store subscriptions)
+	// cycleSession - event-time getState() via useCycleSession (nav/starred from sidebarNavStore)
 	const { cycleSession } = useCycleSession({
-		sortedSessions,
 		handleOpenGroupChat,
-		starredItems,
-		activateStarredItem,
-		navIndexMap,
-		// Multi-window: scope Cmd+[/] cycling to agents THIS window owns. Reuses the
-		// same ownsSession predicate the thinking pill uses (line ~1422); undefined
-		// outside a WindowProvider, so single-window/web cycling is unchanged.
 		ownsSession,
 	});
 
@@ -2101,9 +2070,8 @@ function MaestroConsoleInner() {
 	const tilingShortcuts = useTilingShortcuts();
 
 	// --- KEYBOARD NAVIGATION ---
-	// Sidebar arrow-key navigation, panel focus, Enter-to-activate. Placed after
-	// useStarredItems so it can traverse the Starred Sessions (top) and Group
-	// Chats (bottom) sections in addition to the agent list.
+	// Sidebar arrow-key navigation, panel focus, Enter-to-activate. Sort/nav/starred
+	// come from sidebarNavStore (no App subscription).
 	const groupChatsExpanded = useSettingsStore((s) => s.groupChatsExpanded);
 	const groupChatSortAlphabetical = useSettingsStore((s) => s.groupChatSortAlphabetical);
 	const starredSessionsCollapsed = useSettingsStore((s) => s.starredSessionsCollapsed);
@@ -2114,9 +2082,6 @@ function MaestroConsoleInner() {
 		handleEnterToActivate,
 		handleEscapeInMain,
 	} = useKeyboardNavigation({
-		sortedSessions,
-		navSessions,
-		bookmarkNavSize,
 		selectedSidebarIndex,
 		setSelectedSidebarIndex,
 		sidebarExtraSelection,
@@ -2131,8 +2096,6 @@ function MaestroConsoleInner() {
 		setBookmarksCollapsed,
 		inputRef,
 		terminalOutputRef,
-		starredItems,
-		activateStarredItem,
 		starredSectionCollapsed: starredSessionsCollapsed,
 		setStarredSectionCollapsed: setStarredSessionsCollapsed,
 		groupChats,
@@ -2146,6 +2109,7 @@ function MaestroConsoleInner() {
 	// goToNextUnreadTab - jump to the next agent with unread tabs, clearing current agent's unreads
 	const goToNextUnreadTab = useCallback(() => {
 		const currentActiveId = useSessionStore.getState().activeSessionId;
+		const sortedSessions = useSidebarNavStore.getState().sortedSessions;
 		// Treat a tab with an active inline wizard as a draft target: an unfinished
 		// wizard is meant to be completed into an Auto Run doc, so the navigation
 		// should stop on it just like any other draft.
@@ -2178,7 +2142,7 @@ function MaestroConsoleInner() {
 		} else {
 			showSuccessFlash('No unread or draft tabs');
 		}
-	}, [sortedSessions, setSessions, setActiveSessionId, showSuccessFlash, isWizardActiveForTab]);
+	}, [setSessions, setActiveSessionId, showSuccessFlash, isWizardActiveForTab]);
 
 	// showConfirmation, performDeleteSession - provided by useSessionLifecycle hook (Phase 2H)
 	// deleteSession, deleteWorktreeGroup - provided by useSessionCrud hook
@@ -2438,8 +2402,13 @@ function MaestroConsoleInner() {
 		lightboxImage,
 		hasOpenLayers,
 		hasOpenModal,
-		visibleSessions,
-		sortedSessions,
+		// visibleSessions / sortedSessions: event-time via sidebarNavStore (see handler)
+		get visibleSessions() {
+			return useSidebarNavStore.getState().visibleSessions;
+		},
+		get sortedSessions() {
+			return useSidebarNavStore.getState().sortedSessions;
+		},
 		groups,
 		bookmarksCollapsed,
 		leftSidebarOpen,
@@ -2861,17 +2830,9 @@ function MaestroConsoleInner() {
 		// Theme (computed externally from settingsStore + themeId)
 		theme,
 
-		// Computed values (not raw store fields)
-		sortedSessions,
 		isLiveMode,
 		webInterfaceUrl,
 		showSessionJumpNumbers,
-		visibleSessions,
-		navIndexMap,
-
-		// Starred Sessions (shared with Cmd+[ / Cmd+] cycling via useStarredItems)
-		starredItems,
-		activateStarredItem,
 
 		// Ref
 		sidebarContainerRef,
@@ -2903,7 +2864,6 @@ function MaestroConsoleInner() {
 		handleToggleWorktreeExpanded,
 		handleConfigureCue,
 		maestroCueEnabled: encoreFeatures.maestroCue,
-		handleJumpToStarredSession,
 		openWizardModal,
 		handleOpenFeedbackModal,
 		handleStartTour,
@@ -3004,543 +2964,552 @@ function MaestroConsoleInner() {
 	}, [activeGroupChatId, groupChats, sessionsForProjectRoots]);
 
 	return (
-		<AppShell
-			theme={theme}
-			fontFamily={fontFamily}
-			fontSize={fontSize}
-			keyboardShellOffset={keyboardShellOffset}
-			isMobileLandscape={isMobileLandscape}
-			useNativeTitleBar={useNativeTitleBar}
-			isMdDownViewport={isMdDownViewport}
-			concertoEnabled={encoreFeatures.concerto === true}
-			activeGroupChatId={activeGroupChatId}
-			groupChats={groupChats}
-			groups={groups}
-			hasSessions={hasSessions}
-			sessionsLoaded={sessionsLoaded}
-			emptyStateProps={{
-				shortcuts,
-				onNewAgent: addNewSession,
-				onOpenWizard: openWizardModal,
-				onOpenSettings: () => setSettingsModalOpen(true),
-				onOpenShortcutsHelp: () => setShortcutsHelpOpen(true),
-				onOpenAbout: () => setAboutModalOpen(true),
-				onCheckForUpdates: () => setUpdateCheckModalOpen(true),
-			}}
-			sessionListProps={sessionListProps}
-			mainPanelRef={mainPanelRef}
-			mainPanelProps={mainPanelProps}
-			rightPanelRef={rightPanelRef}
-			rightPanelProps={rightPanelProps}
-			isNarrowViewport={isNarrowViewport}
-			leftSidebarOpen={leftSidebarOpen}
-			rightPanelOpen={rightPanelOpen}
-			onCloseDrawers={handleCloseDrawers}
-			drawerCloseSwipeHandlers={drawerCloseSwipe.handlers}
-			drawerSwipeEnabled={drawerSwipeEnabled}
-			leftEdgeSwipeHandlers={leftEdgeSwipe.handlers}
-			rightEdgeSwipeHandlers={rightEdgeSwipe.handlers}
-			logViewerOpen={logViewerOpen}
-			onToastSessionClick={handleToastSessionClick}
-			logViewer={
-				logViewerOpen ? (
-					<div
-						className="flex-1 flex flex-col min-w-0"
-						style={{ backgroundColor: theme.colors.bgMain }}
-					>
-						<Suspense fallback={null}>
-							<LogViewer
-								theme={theme}
-								onClose={handleCloseLogViewer}
-								logLevel={logLevel}
-								savedSelectedLevels={logViewerSelectedLevels}
-								onSelectedLevelsChange={setLogViewerSelectedLevels}
-								onShortcutUsed={handleLogViewerShortcutUsed}
-								onSessionClick={(sessionId, tabId) => {
-									handleCloseLogViewer();
-									handleToastSessionClick(sessionId, tabId);
-								}}
-							/>
-						</Suspense>
-					</div>
-				) : null
-			}
-			groupChatView={
-				!logViewerOpen &&
-				activeGroupChatId &&
-				isGroupChatVisibleInWindow(groupChatInitiatorWindowId, currentWindowId) &&
-				groupChats.find((c) => c.id === activeGroupChatId) ? (
-					<>
+		<>
+			{/* Owns Left Bar sort/nav/starred subscriptions; memoized so App wakes
+			    do not re-run this host. Must sit under WindowProvider (ownsSession). */}
+			<SidebarNavSync />
+			<AppShell
+				theme={theme}
+				fontFamily={fontFamily}
+				fontSize={fontSize}
+				keyboardShellOffset={keyboardShellOffset}
+				isMobileLandscape={isMobileLandscape}
+				useNativeTitleBar={useNativeTitleBar}
+				isMdDownViewport={isMdDownViewport}
+				concertoEnabled={encoreFeatures.concerto === true}
+				activeGroupChatId={activeGroupChatId}
+				groupChats={groupChats}
+				groups={groups}
+				hasSessions={hasSessions}
+				sessionsLoaded={sessionsLoaded}
+				emptyStateProps={{
+					shortcuts,
+					onNewAgent: addNewSession,
+					onOpenWizard: openWizardModal,
+					onOpenSettings: () => setSettingsModalOpen(true),
+					onOpenShortcutsHelp: () => setShortcutsHelpOpen(true),
+					onOpenAbout: () => setAboutModalOpen(true),
+					onCheckForUpdates: () => setUpdateCheckModalOpen(true),
+				}}
+				sessionListProps={sessionListProps}
+				mainPanelRef={mainPanelRef}
+				mainPanelProps={mainPanelProps}
+				rightPanelRef={rightPanelRef}
+				rightPanelProps={rightPanelProps}
+				isNarrowViewport={isNarrowViewport}
+				leftSidebarOpen={leftSidebarOpen}
+				rightPanelOpen={rightPanelOpen}
+				onCloseDrawers={handleCloseDrawers}
+				drawerCloseSwipeHandlers={drawerCloseSwipe.handlers}
+				drawerSwipeEnabled={drawerSwipeEnabled}
+				leftEdgeSwipeHandlers={leftEdgeSwipe.handlers}
+				rightEdgeSwipeHandlers={rightEdgeSwipe.handlers}
+				logViewerOpen={logViewerOpen}
+				onToastSessionClick={handleToastSessionClick}
+				logViewer={
+					logViewerOpen ? (
 						<div
-							className="flex-1 flex flex-col min-w-0 relative"
-							{...groupChatDropZone.dragHandlers}
+							className="flex-1 flex flex-col min-w-0"
+							style={{ backgroundColor: theme.colors.bgMain }}
 						>
-							{groupChatDropZone.overlay}
-							<GroupChatPanel
-								theme={theme}
-								groupChat={groupChats.find((c) => c.id === activeGroupChatId)!}
-								messages={groupChatMessages}
-								state={groupChatState}
-								groups={groups}
-								onStopAll={handleGroupChatStopAll}
-								totalCost={(() => {
-									const chat = groupChats.find((c) => c.id === activeGroupChatId);
-									const participantsCost = (chat?.participants || []).reduce(
-										(sum, p) => sum + (p.totalCost || 0),
-										0
-									);
-									const modCost = moderatorUsage?.totalCost || 0;
-									return participantsCost + modCost;
-								})()}
-								costIncomplete={(() => {
-									const chat = groupChats.find((c) => c.id === activeGroupChatId);
-									const participants = chat?.participants || [];
-									const anyParticipantMissingCost = participants.some(
-										(p) => p.totalCost === undefined || p.totalCost === null
-									);
-									const moderatorMissingCost =
-										moderatorUsage?.totalCost === undefined || moderatorUsage?.totalCost === null;
-									return anyParticipantMissingCost || moderatorMissingCost;
-								})()}
-								onSendMessage={handleSendGroupChatMessage}
-								onRename={() =>
-									activeGroupChatId && handleOpenRenameGroupChatModal(activeGroupChatId)
-								}
-								onShowInfo={() => useModalStore.getState().openModal('groupChatInfo')}
-								rightPanelOpen={rightPanelOpen}
-								onToggleRightPanel={() => setRightPanelOpen(!rightPanelOpen)}
-								shortcuts={shortcuts}
-								onDraftChange={handleGroupChatDraftChange}
-								onOpenPromptComposer={handleOpenGroupChatPromptComposer}
-								draftFlushRef={groupChatDraftFlushRef}
-								stagedImages={groupChatStagedImages}
-								setStagedImages={setGroupChatStagedImages}
-								readOnlyMode={groupChatReadOnlyMode}
-								setReadOnlyMode={setGroupChatReadOnlyMode}
-								inputRef={groupChatInputRef}
-								handlePaste={handlePaste}
-								handleDrop={handleGroupChatDrop}
-								onOpenLightbox={handleSetLightboxImage}
-								executionQueue={groupChatExecutionQueue.filter(
-									(item) => item.tabId === activeGroupChatId
-								)}
-								onRemoveQueuedItem={handleRemoveGroupChatQueueItem}
-								onReorderQueuedItems={handleReorderGroupChatQueueItems}
-								markdownEditMode={chatRawTextMode}
-								onToggleMarkdownEditMode={handleToggleGroupChatMarkdownMode}
-								maxOutputLines={maxOutputLines}
-								enterToSendAI={enterToSendAI}
-								setEnterToSendAI={setEnterToSendAI}
-								showFlashNotification={handleGroupChatFlashNotification}
-								participantColors={groupChatParticipantColors}
-								messagesRef={groupChatMessagesRef}
-								ghCliAvailable={ghCliAvailable}
-								onPublishMessageGist={handlePublishGroupChatMessageGist}
-							/>
+							<Suspense fallback={null}>
+								<LogViewer
+									theme={theme}
+									onClose={handleCloseLogViewer}
+									logLevel={logLevel}
+									savedSelectedLevels={logViewerSelectedLevels}
+									onSelectedLevelsChange={setLogViewerSelectedLevels}
+									onShortcutUsed={handleLogViewerShortcutUsed}
+									onSessionClick={(sessionId, tabId) => {
+										handleCloseLogViewer();
+										handleToastSessionClick(sessionId, tabId);
+									}}
+								/>
+							</Suspense>
 						</div>
-						<GroupChatRightPanel
-							theme={theme}
-							groupChatId={activeGroupChatId}
-							participants={groupChats.find((c) => c.id === activeGroupChatId)?.participants || []}
-							participantStates={participantStates}
-							participantSessionPaths={participantSessionPaths}
-							sessionSshRemoteNames={sessionSshRemoteNames}
-							isOpen={rightPanelOpen}
-							onToggle={() => setRightPanelOpen(!rightPanelOpen)}
-							width={rightPanelWidth}
-							setWidthState={setRightPanelWidth}
-							shortcuts={shortcuts}
-							moderatorAgentId={
-								groupChats.find((c) => c.id === activeGroupChatId)?.moderatorAgentId ||
-								'claude-code'
-							}
-							moderatorSessionId={
-								groupChats.find((c) => c.id === activeGroupChatId)?.moderatorSessionId || ''
-							}
-							moderatorAgentSessionId={
-								groupChats.find((c) => c.id === activeGroupChatId)?.moderatorAgentSessionId
-							}
-							moderatorState={groupChatState === 'moderator-thinking' ? 'busy' : 'idle'}
-							moderatorUsage={moderatorUsage}
-							activeTab={groupChatRightTab}
-							onTabChange={handleGroupChatRightTabChange}
-							onJumpToMessage={handleJumpToGroupChatMessage}
-							onColorsComputed={setGroupChatParticipantColors}
-						/>
-					</>
-				) : null
-			}
-			modals={
-				<AppModals
-					// Common props (sessions/groups/groupChats + modal booleans self-sourced from stores - Tier 1B)
-					theme={theme}
-					shortcuts={shortcuts}
-					tabShortcuts={tabShortcuts}
-					// AppInfoModals props
-					onCloseShortcutsHelp={handleCloseShortcutsHelp}
-					hasNoAgents={hasNoAgents}
-					keyboardMasteryStats={keyboardMasteryStats}
-					onCloseAboutModal={handleCloseAboutModal}
-					feedbackModalOpen={feedbackModalOpen}
-					onCloseFeedbackModal={handleCloseFeedbackModal}
-					autoRunStats={autoRunStats}
-					usageStats={usageStats}
-					handsOnTimeMs={totalActiveTimeMs}
-					onOpenLeaderboardRegistration={handleOpenLeaderboardRegistrationFromAbout}
-					onSwitchToSession={setActiveSessionId}
-					isLeaderboardRegistered={isLeaderboardRegistered}
-					onCloseUpdateCheckModal={handleCloseUpdateCheckModal}
-					onCloseProcessMonitor={handleCloseProcessMonitor}
-					onNavigateToSession={handleProcessMonitorNavigateToSession}
-					onNavigateToGroupChat={handleProcessMonitorNavigateToGroupChat}
-					onCloseUsageDashboard={() => setUsageDashboardOpen(false)}
-					onCloseAgentRunDashboard={() => setAgentRunDashboardOpen(false)}
-					defaultStatsTimeRange={defaultStatsTimeRange}
-					colorBlindMode={colorBlindMode}
-					// AppConfirmModals props
-					confirmModalMessage={confirmModalMessage}
-					confirmModalOnConfirm={confirmModalOnConfirm}
-					confirmModalTitle={confirmModalTitle}
-					confirmModalDestructive={confirmModalDestructive}
-					onCloseConfirmModal={handleCloseConfirmModal}
-					onConfirmQuit={handleConfirmQuit}
-					onCancelQuit={handleCancelQuit}
-					onQuitWhenIdle={handleQuitWhenIdle}
-					activeBatchSessionIds={activeBatchSessionIds}
-					// AppSessionModals props
-					onCloseNewInstanceModal={handleCloseNewInstanceModal}
-					onCreateSession={createNewSession}
-					duplicatingSessionId={duplicatingSessionId}
-					newInstancePresetGroupId={newInstancePresetGroupId}
-					onCloseEditAgentModal={handleCloseEditAgentModal}
-					onSaveEditAgent={handleSaveEditAgent}
-					editAgentSession={editAgentSession}
-					renameSessionValue={renameInstanceValue}
-					setRenameSessionValue={setRenameInstanceValue}
-					onCloseRenameSessionModal={handleCloseRenameSessionModal}
-					renameSessionTargetId={renameInstanceSessionId}
-					onAfterRename={flushSessionPersistence}
-					renameTabId={renameTabId}
-					renameTabInitialName={renameTabInitialName}
-					onCloseRenameTabModal={handleCloseRenameTabModal}
-					onRenameTab={handleRenameTab}
-					onAutoNameTab={handleAutoNameTab}
-					// AppGroupModals props
-					createGroupModalOpen={createGroupModalOpen}
-					createGroupParentId={createGroupParentId}
-					onCloseCreateGroupModal={handleCloseGroupCreation}
-					onGroupCreated={handleGroupCreated}
-					renameGroupId={renameGroupId}
-					renameGroupValue={renameGroupValue}
-					setRenameGroupValue={setRenameGroupValue}
-					renameGroupEmoji={renameGroupEmoji}
-					setRenameGroupEmoji={setRenameGroupEmoji}
-					renameGroupIcon={renameGroupIcon}
-					setRenameGroupIcon={setRenameGroupIcon}
-					renameGroupColor={renameGroupColor}
-					setRenameGroupColor={setRenameGroupColor}
-					onCloseRenameGroupModal={handleCloseRenameGroupModal}
-					// AppWorktreeModals props
-					onCloseWorktreeConfigModal={handleCloseWorktreeConfigModal}
-					onSaveWorktreeConfig={handleSaveWorktreeConfig}
-					onCreateWorktreeFromConfig={handleCreateWorktreeFromConfig}
-					onDisableWorktreeConfig={handleDisableWorktreeConfig}
-					createWorktreeSession={createWorktreeSession}
-					onCloseCreateWorktreeModal={handleCloseCreateWorktreeModal}
-					onCreateWorktree={handleCreateWorktree}
-					createPRSession={createPRSession}
-					onCloseCreatePRModal={handleCloseCreatePRModal}
-					onPRCreated={handlePRCreated}
-					deleteWorktreeSession={deleteWorktreeSession}
-					onCloseDeleteWorktreeModal={handleCloseDeleteWorktreeModal}
-					onConfirmDeleteWorktree={handleConfirmDeleteWorktree}
-					onConfirmAndDeleteWorktreeOnDisk={handleConfirmAndDeleteWorktreeOnDisk}
-					// AppUtilityModals props
-					quickActionInitialMode={quickActionInitialMode}
-					setQuickActionOpen={setQuickActionOpen}
-					setActiveSessionId={setActiveSessionId}
-					addNewSession={addNewSession}
-					setRenameInstanceValue={setRenameInstanceValue}
-					setRenameInstanceModalOpen={setRenameInstanceModalOpen}
-					setRenameGroupId={setRenameGroupId}
-					setRenameGroupValueForQuickActions={setRenameGroupValue}
-					setRenameGroupEmojiForQuickActions={setRenameGroupEmoji}
-					setRenameGroupIconForQuickActions={setRenameGroupIcon}
-					setRenameGroupColorForQuickActions={setRenameGroupColor}
-					setRenameGroupModalOpenForQuickActions={setRenameGroupModalOpen}
-					setCreateGroupModalOpenForQuickActions={setCreateGroupModalOpen}
-					setLeftSidebarOpen={setLeftSidebarOpen}
-					setRightPanelOpen={setRightPanelOpen}
-					toggleInputMode={toggleInputMode}
-					deleteSession={deleteSession}
-					setSettingsModalOpen={setSettingsModalOpen}
-					setSettingsTab={setSettingsTab}
-					setShortcutsHelpOpen={setShortcutsHelpOpen}
-					setAboutModalOpen={setAboutModalOpen}
-					setFeedbackModalOpen={setFeedbackModalOpen}
-					setLogViewerOpen={setLogViewerOpen}
-					setProcessMonitorOpen={setProcessMonitorOpen}
-					setUsageDashboardOpen={encoreFeatures.usageStats ? setUsageDashboardOpen : undefined}
-					setAgentRunDashboardOpen={setAgentRunDashboardOpen}
-					setActiveRightTab={setActiveRightTab}
-					setAgentSessionsOpen={setAgentSessionsOpen}
-					setMemoryViewerOpen={setMemoryViewerOpen}
-					setActiveAgentSessionId={setActiveAgentSessionId}
-					setGitDiffPreview={setGitDiffPreview}
-					setGitLogOpen={setGitLogOpen}
-					isAiMode={activeSession?.inputMode === 'ai'}
-					onQuickActionsRenameTab={handleQuickActionsRenameTab}
-					onQuickActionsToggleReadOnlyMode={handleQuickActionsToggleReadOnlyMode}
-					onQuickActionsToggleTabShowThinking={handleQuickActionsToggleTabShowThinking}
-					onQuickActionsToggleTabEnterToSend={handleQuickActionsToggleTabEnterToSend}
-					onQuickActionsOpenTabSwitcher={handleQuickActionsOpenTabSwitcher}
-					onCloseAllTabs={handleCloseAllTabs}
-					onCloseOtherTabs={handleCloseOtherTabs}
-					onCloseTabsLeft={handleCloseTabsLeft}
-					onCloseTabsRight={handleCloseTabsRight}
-					setPlaygroundOpen={setPlaygroundOpen}
-					onQuickActionsRefreshGitFileState={handleQuickActionsRefreshGitFileState}
-					onQuickActionsDebugReleaseQueuedItem={handleQuickActionsDebugReleaseQueuedItem}
-					markdownEditMode={activeSession?.activeFileTabId ? markdownEditMode : chatRawTextMode}
-					onQuickActionsToggleMarkdownEditMode={handleQuickActionsToggleMarkdownEditMode}
-					setUpdateCheckModalOpenForQuickActions={setUpdateCheckModalOpen}
-					openWizard={openWizardModal}
-					wizardGoToStep={wizardGoToStep}
-					setDebugPackageModalOpen={setDebugPackageModalOpen}
-					setDebugApplicationStatsOpen={setDebugApplicationStatsOpen}
-					startTour={handleQuickActionsStartTour}
-					setFuzzyFileSearchOpen={setFuzzyFileSearchOpen}
-					onEditAgent={handleQuickActionsEditAgent}
-					onNewGroupChat={handleNewGroupChat}
-					onOpenGroupChat={handleOpenGroupChat}
-					onCloseGroupChat={handleCloseGroupChat}
-					onDeleteGroupChat={deleteGroupChatWithConfirmation}
-					hasActiveSessionCapability={hasActiveSessionCapability}
-					onOpenMergeSession={handleQuickActionsOpenMergeSession}
-					onOpenSendToAgent={handleQuickActionsOpenSendToAgent}
-					onQuickCreateWorktree={handleQuickCreateWorktree}
-					onOpenCreatePR={handleQuickActionsOpenCreatePR}
-					onSummarizeAndContinue={handleQuickActionsSummarizeAndContinue}
-					onRunPromptMacro={handleRunPromptMacro}
-					canSummarizeActiveTab={computeCanSummarizeActiveTab()}
-					onToggleRemoteControl={handleQuickActionsToggleRemoteControl}
-					autoRunSelectedDocument={activeSession?.autoRunSelectedFile ?? null}
-					autoRunCompletedTaskCount={rightPanelRef.current?.getAutoRunCompletedTaskCount() ?? 0}
-					onAutoRunResetTasks={handleQuickActionsAutoRunResetTasks}
-					onToggleAutoRunExpanded={handleQuickActionsToggleAutoRunExpanded}
-					onClearActiveTerminal={handleQuickActionsClearActiveTerminal}
-					onCloseCurrentTab={handleQuickActionsCloseCurrentTab}
-					onMoveTabToFirst={handleQuickActionsMoveTabToFirst}
-					onMoveTabToLast={handleQuickActionsMoveTabToLast}
-					onFocusActiveTab={handleQuickActionsFocusActiveTab}
-					onCopyTabContext={handleQuickActionsCopyTabContext}
-					onExportTabHtml={handleQuickActionsExportTabHtml}
-					onPublishTabGist={handleQuickActionsPublishTabGist}
-					mainPanelRef={mainPanelRef}
-					isFilePreviewOpen={!!activeSession?.activeFileTabId}
-					ghCliAvailable={ghCliAvailable}
-					onPublishGist={() => setGistPublishModalOpen(true)}
-					lastGraphFocusFile={lastGraphFocusFilePath}
-					onOpenLastDocumentGraph={handleOpenLastDocumentGraph}
-					currentGraphFile={currentGraphFileName}
-					onOpenCurrentFileInGraph={mainPanelProps.onOpenInGraph}
-					lightboxImage={lightboxImage}
-					lightboxImages={lightboxImages}
-					stagedImages={stagedImages}
-					onCloseLightbox={handleCloseLightbox}
-					onNavigateLightbox={handleNavigateLightbox}
-					onDeleteLightboxImage={lightboxAllowDelete ? handleDeleteLightboxImage : undefined}
-					onUpdateLightboxImage={lightboxAllowDelete ? handleUpdateLightboxImage : undefined}
-					gitDiffPreview={gitDiffPreview}
-					gitViewerCwd={gitViewerCwd}
-					onCloseGitDiff={handleCloseGitDiff}
-					onCloseGitLog={handleCloseGitLog}
-					onOpenGitFile={handleOpenGitFile}
-					onCloseAutoRunSetup={handleCloseAutoRunSetup}
-					onAutoRunFolderSelected={handleAutoRunFolderSelected}
-					onCloseBatchRunner={handleCloseBatchRunner}
-					onStartBatchRun={handleStartBatchRun}
-					onSaveBatchPrompt={handleSaveBatchPrompt}
-					showConfirmation={showConfirmation}
-					autoRunDocumentList={autoRunDocumentList}
-					autoRunDocumentTree={autoRunDocumentTree}
-					getDocumentTaskCount={getDocumentTaskCount}
-					onAutoRunRefresh={handleAutoRunRefresh}
-					onOpenMarketplace={handleOpenMarketplace}
-					onOpenSymphony={encoreFeatures.symphony ? () => setSymphonyModalOpen(true) : undefined}
-					onOpenDirectorNotes={
-						encoreFeatures.directorNotes ? () => setDirectorNotesOpen(true) : undefined
-					}
-					onOpenMaestroCue={encoreFeatures.maestroCue ? () => setCueModalOpen(true) : undefined}
-					onOpenPianola={encoreFeatures.pianola ? () => setPianolaModalOpen(true) : undefined}
-					onConfigureCue={encoreFeatures.maestroCue ? handleConfigureCue : undefined}
-					onCloseTabSwitcher={handleCloseTabSwitcher}
-					onTabSelect={handleUtilityTabSelect}
-					onFileTabSelect={handleUtilityFileTabSelect}
-					onTerminalTabSelect={handleSelectTerminalTab}
-					onBrowserTabSelect={handleSelectBrowserTab}
-					onNamedSessionSelect={handleNamedSessionSelect}
-					filteredFileTree={filteredFileTree}
-					fileExplorerExpanded={activeSession?.fileExplorerExpanded}
-					onCloseFileSearch={handleCloseFileSearch}
-					onFileSearchSelect={handleFileSearchSelect}
-					onClosePromptComposer={handleClosePromptComposer}
-					onPromptComposerSubmit={handlePromptComposerSubmit}
-					onPromptComposerSend={handlePromptComposerSend}
-					promptComposerSessionName={
-						activeGroupChatId
-							? groupChats.find((c) => c.id === activeGroupChatId)?.name
-							: activeSession?.name
-					}
-					promptComposerStagedImages={
-						activeGroupChatId ? groupChatStagedImages : canAttachImages ? stagedImages : []
-					}
-					setPromptComposerStagedImages={
-						activeGroupChatId
-							? setGroupChatStagedImages
-							: canAttachImages
-								? setStagedImages
-								: undefined
-					}
-					onPromptOpenLightbox={handleSetLightboxImage}
-					promptTabSaveToHistory={activeGroupChatId ? false : promptTabSaveToHistory}
-					onPromptToggleTabSaveToHistory={
-						activeGroupChatId ? undefined : handlePromptToggleTabSaveToHistory
-					}
-					promptTabReadOnlyMode={activeGroupChatId ? groupChatReadOnlyMode : promptTabReadOnlyMode}
-					onPromptToggleTabReadOnlyMode={handlePromptToggleTabReadOnlyMode}
-					promptTabShowThinking={activeGroupChatId ? 'off' : promptTabShowThinking}
-					onPromptToggleTabShowThinking={
-						activeGroupChatId ? undefined : handlePromptToggleTabShowThinking
-					}
-					promptSupportsThinking={
-						!activeGroupChatId && hasActiveSessionCapability('supportsThinkingDisplay')
-					}
-					promptEnterToSend={enterToSendAIExpanded}
-					onPromptToggleEnterToSend={handlePromptToggleEnterToSend}
-					onOpenQueueBrowser={handleOpenQueueBrowser}
-					onCloseQueueBrowser={handleCloseQueueBrowser}
-					onQuickActionsNewTab={handleNewTab}
-					onQuickActionsNewFileTab={handleNewFileTab}
-					onQuickActionsNewBrowserTab={handleNewBrowserTab}
-					onQuickActionsNewTerminalTab={handleOpenTerminalTab}
-					onGoToNextUnread={goToNextUnreadTab}
-					onNavBack={handleNavBack}
-					onNavForward={handleNavForward}
-					onRemoveQueueItem={handleRemoveQueueItem}
-					onSwitchQueueSession={handleSwitchQueueSession}
-					onReorderQueueItems={handleReorderQueueItems}
-					onTogglePauseQueueItem={handleTogglePauseQueueItem}
-					onEditQueueItem={handleEditQueueItem}
-					// AppGroupChatModals props
-					onCloseNewGroupChatModal={handleCloseNewGroupChatModal}
-					onCreateGroupChat={handleCreateGroupChat}
-					showDeleteGroupChatModal={showDeleteGroupChatModal}
-					onCloseDeleteGroupChatModal={handleCloseDeleteGroupChatModal}
-					onConfirmDeleteGroupChat={handleConfirmDeleteGroupChat}
-					showRenameGroupChatModal={showRenameGroupChatModal}
-					onCloseRenameGroupChatModal={handleCloseRenameGroupChatModal}
-					onRenameGroupChatFromModal={handleRenameGroupChatFromModal}
-					showEditGroupChatModal={showEditGroupChatModal}
-					onCloseEditGroupChatModal={handleCloseEditGroupChatModal}
-					onUpdateGroupChat={handleUpdateGroupChat}
-					groupChatMessages={groupChatMessages}
-					onCloseGroupChatInfo={handleCloseGroupChatInfo}
-					onOpenModeratorSession={handleOpenModeratorSession}
-					// AppAgentModals props
-					onCloseLeaderboardRegistration={handleCloseLeaderboardRegistration}
-					leaderboardRegistration={leaderboardRegistration}
-					onSaveLeaderboardRegistration={handleSaveLeaderboardRegistration}
-					onLeaderboardOptOut={handleLeaderboardOptOut}
-					onSyncAutoRunStats={handleSyncAutoRunStats}
-					errorSession={errorSession}
-					effectiveAgentError={effectiveAgentError}
-					recoveryActions={recoveryActions}
-					onDismissAgentError={handleCloseAgentErrorModal}
-					onJumpToAgent={handleJumpToFailingAgent}
-					groupChatError={groupChatError}
-					groupChatRecoveryActions={groupChatRecoveryActions}
-					onClearGroupChatError={handleClearGroupChatError}
-					onCloseMergeSession={handleCloseMergeSession}
-					onMerge={handleMerge}
-					transferState={transferState}
-					transferProgress={transferProgress}
-					transferSourceAgent={transferSourceAgent}
-					transferTargetAgent={transferTargetAgent}
-					onCancelTransfer={handleCancelTransfer}
-					onCompleteTransfer={handleCompleteTransfer}
-					onCloseSendToAgent={handleCloseSendToAgent}
-					onSendToAgent={handleSendToAgent}
-				/>
-			}
-			standaloneModals={
-				<AppStandaloneModals
-					theme={theme}
-					// Debug / Playground
-					onCloseDebugPackage={handleCloseDebugPackage}
-					setSuppressWindowsWarning={setSuppressWindowsWarning}
-					enableBetaUpdates={enableBetaUpdates}
-					setEnableBetaUpdates={setEnableBetaUpdates}
-					// AppOverlays
-					autoRunStats={autoRunStats}
-					onStandingOvationClose={handleStandingOvationClose}
-					onOpenLeaderboardRegistration={handleOpenLeaderboardRegistration}
-					isLeaderboardRegistered={isLeaderboardRegistered}
-					onFirstRunCelebrationClose={handleFirstRunCelebrationClose}
-					onKeyboardMasteryCelebrationClose={handleKeyboardMasteryCelebrationClose}
-					// Marketplace
-					onMarketplaceImportComplete={handleMarketplaceImportComplete}
-					// Symphony
-					setActiveSessionId={setActiveSessionId}
-					onStartContribution={handleStartContribution}
-					encoreFeatures={encoreFeatures}
-					// Director's Notes
-					onDirectorNotesResumeSession={handleDirectorNotesResumeSession}
-					onFileClick={handleFileClick}
-					// Cue
-					shortcuts={shortcuts}
-					// GistPublish
-					gistPublishModalOpen={gistPublishModalOpen}
-					setGistPublishModalOpen={setGistPublishModalOpen}
-					activeFileTab={activeFileTab}
-					saveFileGistUrl={saveFileGistUrl}
-					fileGistUrls={fileGistUrls}
-					// DocumentGraph
-					onOpenFileTab={handleOpenFileTab}
-					mainPanelRef={mainPanelRef}
-					documentGraphShowExternalLinks={documentGraphShowExternalLinks}
-					onExternalLinksChange={settings.setDocumentGraphShowExternalLinks}
-					documentGraphMaxNodes={documentGraphMaxNodes}
-					documentGraphPreviewCharLimit={documentGraphPreviewCharLimit}
-					onPreviewCharLimitChange={settings.setDocumentGraphPreviewCharLimit}
-					documentGraphLayoutType={documentGraphLayoutType}
-					onLayoutTypeChange={settings.setDocumentGraphLayoutType}
-					// DeleteAgent
-					onPerformDeleteSession={performDeleteSession}
-					onCloseDeleteAgentModal={handleCloseDeleteAgentModal}
-					// Settings
-					onCloseSettings={handleCloseSettings}
-					hasNoAgents={hasNoAgents}
-					setFlashNotification={setFlashNotification}
-					// Wizard
-					wizardIsOpen={wizardState.isOpen}
-					onWizardLaunchSession={handleWizardLaunchSession}
-					recordWizardStart={recordWizardStart}
-					recordWizardResume={recordWizardResume}
-					recordWizardAbandon={recordWizardAbandon}
-					recordWizardComplete={recordWizardComplete}
-					onWizardResume={handleWizardResume}
-					onWizardStartFresh={handleWizardStartFresh}
-					onWizardResumeClose={handleWizardResumeClose}
-					// Tour
-					setTourCompleted={setTourCompleted}
-					tabShortcuts={tabShortcuts}
-					recordTourStart={recordTourStart}
-					recordTourComplete={recordTourComplete}
-					recordTourSkip={recordTourSkip}
-				/>
-			}
-		/>
+					) : null
+				}
+				groupChatView={
+					!logViewerOpen &&
+					activeGroupChatId &&
+					isGroupChatVisibleInWindow(groupChatInitiatorWindowId, currentWindowId) &&
+					groupChats.find((c) => c.id === activeGroupChatId) ? (
+						<>
+							<div
+								className="flex-1 flex flex-col min-w-0 relative"
+								{...groupChatDropZone.dragHandlers}
+							>
+								{groupChatDropZone.overlay}
+								<GroupChatPanel
+									theme={theme}
+									groupChat={groupChats.find((c) => c.id === activeGroupChatId)!}
+									messages={groupChatMessages}
+									state={groupChatState}
+									groups={groups}
+									onStopAll={handleGroupChatStopAll}
+									totalCost={(() => {
+										const chat = groupChats.find((c) => c.id === activeGroupChatId);
+										const participantsCost = (chat?.participants || []).reduce(
+											(sum, p) => sum + (p.totalCost || 0),
+											0
+										);
+										const modCost = moderatorUsage?.totalCost || 0;
+										return participantsCost + modCost;
+									})()}
+									costIncomplete={(() => {
+										const chat = groupChats.find((c) => c.id === activeGroupChatId);
+										const participants = chat?.participants || [];
+										const anyParticipantMissingCost = participants.some(
+											(p) => p.totalCost === undefined || p.totalCost === null
+										);
+										const moderatorMissingCost =
+											moderatorUsage?.totalCost === undefined || moderatorUsage?.totalCost === null;
+										return anyParticipantMissingCost || moderatorMissingCost;
+									})()}
+									onSendMessage={handleSendGroupChatMessage}
+									onRename={() =>
+										activeGroupChatId && handleOpenRenameGroupChatModal(activeGroupChatId)
+									}
+									onShowInfo={() => useModalStore.getState().openModal('groupChatInfo')}
+									rightPanelOpen={rightPanelOpen}
+									onToggleRightPanel={() => setRightPanelOpen(!rightPanelOpen)}
+									shortcuts={shortcuts}
+									onDraftChange={handleGroupChatDraftChange}
+									onOpenPromptComposer={handleOpenGroupChatPromptComposer}
+									draftFlushRef={groupChatDraftFlushRef}
+									stagedImages={groupChatStagedImages}
+									setStagedImages={setGroupChatStagedImages}
+									readOnlyMode={groupChatReadOnlyMode}
+									setReadOnlyMode={setGroupChatReadOnlyMode}
+									inputRef={groupChatInputRef}
+									handlePaste={handlePaste}
+									handleDrop={handleGroupChatDrop}
+									onOpenLightbox={handleSetLightboxImage}
+									executionQueue={groupChatExecutionQueue.filter(
+										(item) => item.tabId === activeGroupChatId
+									)}
+									onRemoveQueuedItem={handleRemoveGroupChatQueueItem}
+									onReorderQueuedItems={handleReorderGroupChatQueueItems}
+									markdownEditMode={chatRawTextMode}
+									onToggleMarkdownEditMode={handleToggleGroupChatMarkdownMode}
+									maxOutputLines={maxOutputLines}
+									enterToSendAI={enterToSendAI}
+									setEnterToSendAI={setEnterToSendAI}
+									showFlashNotification={handleGroupChatFlashNotification}
+									participantColors={groupChatParticipantColors}
+									messagesRef={groupChatMessagesRef}
+									ghCliAvailable={ghCliAvailable}
+									onPublishMessageGist={handlePublishGroupChatMessageGist}
+								/>
+							</div>
+							<GroupChatRightPanel
+								theme={theme}
+								groupChatId={activeGroupChatId}
+								participants={
+									groupChats.find((c) => c.id === activeGroupChatId)?.participants || []
+								}
+								participantStates={participantStates}
+								participantSessionPaths={participantSessionPaths}
+								sessionSshRemoteNames={sessionSshRemoteNames}
+								isOpen={rightPanelOpen}
+								onToggle={() => setRightPanelOpen(!rightPanelOpen)}
+								width={rightPanelWidth}
+								setWidthState={setRightPanelWidth}
+								shortcuts={shortcuts}
+								moderatorAgentId={
+									groupChats.find((c) => c.id === activeGroupChatId)?.moderatorAgentId ||
+									'claude-code'
+								}
+								moderatorSessionId={
+									groupChats.find((c) => c.id === activeGroupChatId)?.moderatorSessionId || ''
+								}
+								moderatorAgentSessionId={
+									groupChats.find((c) => c.id === activeGroupChatId)?.moderatorAgentSessionId
+								}
+								moderatorState={groupChatState === 'moderator-thinking' ? 'busy' : 'idle'}
+								moderatorUsage={moderatorUsage}
+								activeTab={groupChatRightTab}
+								onTabChange={handleGroupChatRightTabChange}
+								onJumpToMessage={handleJumpToGroupChatMessage}
+								onColorsComputed={setGroupChatParticipantColors}
+							/>
+						</>
+					) : null
+				}
+				modals={
+					<AppModals
+						// Common props (sessions/groups/groupChats + modal booleans self-sourced from stores - Tier 1B)
+						theme={theme}
+						shortcuts={shortcuts}
+						tabShortcuts={tabShortcuts}
+						// AppInfoModals props
+						onCloseShortcutsHelp={handleCloseShortcutsHelp}
+						hasNoAgents={hasNoAgents}
+						keyboardMasteryStats={keyboardMasteryStats}
+						onCloseAboutModal={handleCloseAboutModal}
+						feedbackModalOpen={feedbackModalOpen}
+						onCloseFeedbackModal={handleCloseFeedbackModal}
+						autoRunStats={autoRunStats}
+						usageStats={usageStats}
+						handsOnTimeMs={totalActiveTimeMs}
+						onOpenLeaderboardRegistration={handleOpenLeaderboardRegistrationFromAbout}
+						onSwitchToSession={setActiveSessionId}
+						isLeaderboardRegistered={isLeaderboardRegistered}
+						onCloseUpdateCheckModal={handleCloseUpdateCheckModal}
+						onCloseProcessMonitor={handleCloseProcessMonitor}
+						onNavigateToSession={handleProcessMonitorNavigateToSession}
+						onNavigateToGroupChat={handleProcessMonitorNavigateToGroupChat}
+						onCloseUsageDashboard={() => setUsageDashboardOpen(false)}
+						onCloseAgentRunDashboard={() => setAgentRunDashboardOpen(false)}
+						defaultStatsTimeRange={defaultStatsTimeRange}
+						colorBlindMode={colorBlindMode}
+						// AppConfirmModals props
+						confirmModalMessage={confirmModalMessage}
+						confirmModalOnConfirm={confirmModalOnConfirm}
+						confirmModalTitle={confirmModalTitle}
+						confirmModalDestructive={confirmModalDestructive}
+						onCloseConfirmModal={handleCloseConfirmModal}
+						onConfirmQuit={handleConfirmQuit}
+						onCancelQuit={handleCancelQuit}
+						onQuitWhenIdle={handleQuitWhenIdle}
+						activeBatchSessionIds={activeBatchSessionIds}
+						// AppSessionModals props
+						onCloseNewInstanceModal={handleCloseNewInstanceModal}
+						onCreateSession={createNewSession}
+						duplicatingSessionId={duplicatingSessionId}
+						newInstancePresetGroupId={newInstancePresetGroupId}
+						onCloseEditAgentModal={handleCloseEditAgentModal}
+						onSaveEditAgent={handleSaveEditAgent}
+						editAgentSession={editAgentSession}
+						renameSessionValue={renameInstanceValue}
+						setRenameSessionValue={setRenameInstanceValue}
+						onCloseRenameSessionModal={handleCloseRenameSessionModal}
+						renameSessionTargetId={renameInstanceSessionId}
+						onAfterRename={flushSessionPersistence}
+						renameTabId={renameTabId}
+						renameTabInitialName={renameTabInitialName}
+						onCloseRenameTabModal={handleCloseRenameTabModal}
+						onRenameTab={handleRenameTab}
+						onAutoNameTab={handleAutoNameTab}
+						// AppGroupModals props
+						createGroupModalOpen={createGroupModalOpen}
+						createGroupParentId={createGroupParentId}
+						onCloseCreateGroupModal={handleCloseGroupCreation}
+						onGroupCreated={handleGroupCreated}
+						renameGroupId={renameGroupId}
+						renameGroupValue={renameGroupValue}
+						setRenameGroupValue={setRenameGroupValue}
+						renameGroupEmoji={renameGroupEmoji}
+						setRenameGroupEmoji={setRenameGroupEmoji}
+						renameGroupIcon={renameGroupIcon}
+						setRenameGroupIcon={setRenameGroupIcon}
+						renameGroupColor={renameGroupColor}
+						setRenameGroupColor={setRenameGroupColor}
+						onCloseRenameGroupModal={handleCloseRenameGroupModal}
+						// AppWorktreeModals props
+						onCloseWorktreeConfigModal={handleCloseWorktreeConfigModal}
+						onSaveWorktreeConfig={handleSaveWorktreeConfig}
+						onCreateWorktreeFromConfig={handleCreateWorktreeFromConfig}
+						onDisableWorktreeConfig={handleDisableWorktreeConfig}
+						createWorktreeSession={createWorktreeSession}
+						onCloseCreateWorktreeModal={handleCloseCreateWorktreeModal}
+						onCreateWorktree={handleCreateWorktree}
+						createPRSession={createPRSession}
+						onCloseCreatePRModal={handleCloseCreatePRModal}
+						onPRCreated={handlePRCreated}
+						deleteWorktreeSession={deleteWorktreeSession}
+						onCloseDeleteWorktreeModal={handleCloseDeleteWorktreeModal}
+						onConfirmDeleteWorktree={handleConfirmDeleteWorktree}
+						onConfirmAndDeleteWorktreeOnDisk={handleConfirmAndDeleteWorktreeOnDisk}
+						// AppUtilityModals props
+						quickActionInitialMode={quickActionInitialMode}
+						setQuickActionOpen={setQuickActionOpen}
+						setActiveSessionId={setActiveSessionId}
+						addNewSession={addNewSession}
+						setRenameInstanceValue={setRenameInstanceValue}
+						setRenameInstanceModalOpen={setRenameInstanceModalOpen}
+						setRenameGroupId={setRenameGroupId}
+						setRenameGroupValueForQuickActions={setRenameGroupValue}
+						setRenameGroupEmojiForQuickActions={setRenameGroupEmoji}
+						setRenameGroupIconForQuickActions={setRenameGroupIcon}
+						setRenameGroupColorForQuickActions={setRenameGroupColor}
+						setRenameGroupModalOpenForQuickActions={setRenameGroupModalOpen}
+						setCreateGroupModalOpenForQuickActions={setCreateGroupModalOpen}
+						setLeftSidebarOpen={setLeftSidebarOpen}
+						setRightPanelOpen={setRightPanelOpen}
+						toggleInputMode={toggleInputMode}
+						deleteSession={deleteSession}
+						setSettingsModalOpen={setSettingsModalOpen}
+						setSettingsTab={setSettingsTab}
+						setShortcutsHelpOpen={setShortcutsHelpOpen}
+						setAboutModalOpen={setAboutModalOpen}
+						setFeedbackModalOpen={setFeedbackModalOpen}
+						setLogViewerOpen={setLogViewerOpen}
+						setProcessMonitorOpen={setProcessMonitorOpen}
+						setUsageDashboardOpen={encoreFeatures.usageStats ? setUsageDashboardOpen : undefined}
+						setAgentRunDashboardOpen={setAgentRunDashboardOpen}
+						setActiveRightTab={setActiveRightTab}
+						setAgentSessionsOpen={setAgentSessionsOpen}
+						setMemoryViewerOpen={setMemoryViewerOpen}
+						setActiveAgentSessionId={setActiveAgentSessionId}
+						setGitDiffPreview={setGitDiffPreview}
+						setGitLogOpen={setGitLogOpen}
+						isAiMode={activeSession?.inputMode === 'ai'}
+						onQuickActionsRenameTab={handleQuickActionsRenameTab}
+						onQuickActionsToggleReadOnlyMode={handleQuickActionsToggleReadOnlyMode}
+						onQuickActionsToggleTabShowThinking={handleQuickActionsToggleTabShowThinking}
+						onQuickActionsToggleTabEnterToSend={handleQuickActionsToggleTabEnterToSend}
+						onQuickActionsOpenTabSwitcher={handleQuickActionsOpenTabSwitcher}
+						onCloseAllTabs={handleCloseAllTabs}
+						onCloseOtherTabs={handleCloseOtherTabs}
+						onCloseTabsLeft={handleCloseTabsLeft}
+						onCloseTabsRight={handleCloseTabsRight}
+						setPlaygroundOpen={setPlaygroundOpen}
+						onQuickActionsRefreshGitFileState={handleQuickActionsRefreshGitFileState}
+						onQuickActionsDebugReleaseQueuedItem={handleQuickActionsDebugReleaseQueuedItem}
+						markdownEditMode={activeSession?.activeFileTabId ? markdownEditMode : chatRawTextMode}
+						onQuickActionsToggleMarkdownEditMode={handleQuickActionsToggleMarkdownEditMode}
+						setUpdateCheckModalOpenForQuickActions={setUpdateCheckModalOpen}
+						openWizard={openWizardModal}
+						wizardGoToStep={wizardGoToStep}
+						setDebugPackageModalOpen={setDebugPackageModalOpen}
+						setDebugApplicationStatsOpen={setDebugApplicationStatsOpen}
+						startTour={handleQuickActionsStartTour}
+						setFuzzyFileSearchOpen={setFuzzyFileSearchOpen}
+						onEditAgent={handleQuickActionsEditAgent}
+						onNewGroupChat={handleNewGroupChat}
+						onOpenGroupChat={handleOpenGroupChat}
+						onCloseGroupChat={handleCloseGroupChat}
+						onDeleteGroupChat={deleteGroupChatWithConfirmation}
+						hasActiveSessionCapability={hasActiveSessionCapability}
+						onOpenMergeSession={handleQuickActionsOpenMergeSession}
+						onOpenSendToAgent={handleQuickActionsOpenSendToAgent}
+						onQuickCreateWorktree={handleQuickCreateWorktree}
+						onOpenCreatePR={handleQuickActionsOpenCreatePR}
+						onSummarizeAndContinue={handleQuickActionsSummarizeAndContinue}
+						onRunPromptMacro={handleRunPromptMacro}
+						canSummarizeActiveTab={computeCanSummarizeActiveTab()}
+						onToggleRemoteControl={handleQuickActionsToggleRemoteControl}
+						autoRunSelectedDocument={activeSession?.autoRunSelectedFile ?? null}
+						autoRunCompletedTaskCount={rightPanelRef.current?.getAutoRunCompletedTaskCount() ?? 0}
+						onAutoRunResetTasks={handleQuickActionsAutoRunResetTasks}
+						onToggleAutoRunExpanded={handleQuickActionsToggleAutoRunExpanded}
+						onClearActiveTerminal={handleQuickActionsClearActiveTerminal}
+						onCloseCurrentTab={handleQuickActionsCloseCurrentTab}
+						onMoveTabToFirst={handleQuickActionsMoveTabToFirst}
+						onMoveTabToLast={handleQuickActionsMoveTabToLast}
+						onFocusActiveTab={handleQuickActionsFocusActiveTab}
+						onCopyTabContext={handleQuickActionsCopyTabContext}
+						onExportTabHtml={handleQuickActionsExportTabHtml}
+						onPublishTabGist={handleQuickActionsPublishTabGist}
+						mainPanelRef={mainPanelRef}
+						isFilePreviewOpen={!!activeSession?.activeFileTabId}
+						ghCliAvailable={ghCliAvailable}
+						onPublishGist={() => setGistPublishModalOpen(true)}
+						lastGraphFocusFile={lastGraphFocusFilePath}
+						onOpenLastDocumentGraph={handleOpenLastDocumentGraph}
+						currentGraphFile={currentGraphFileName}
+						onOpenCurrentFileInGraph={mainPanelProps.onOpenInGraph}
+						lightboxImage={lightboxImage}
+						lightboxImages={lightboxImages}
+						stagedImages={stagedImages}
+						onCloseLightbox={handleCloseLightbox}
+						onNavigateLightbox={handleNavigateLightbox}
+						onDeleteLightboxImage={lightboxAllowDelete ? handleDeleteLightboxImage : undefined}
+						onUpdateLightboxImage={lightboxAllowDelete ? handleUpdateLightboxImage : undefined}
+						gitDiffPreview={gitDiffPreview}
+						gitViewerCwd={gitViewerCwd}
+						onCloseGitDiff={handleCloseGitDiff}
+						onCloseGitLog={handleCloseGitLog}
+						onOpenGitFile={handleOpenGitFile}
+						onCloseAutoRunSetup={handleCloseAutoRunSetup}
+						onAutoRunFolderSelected={handleAutoRunFolderSelected}
+						onCloseBatchRunner={handleCloseBatchRunner}
+						onStartBatchRun={handleStartBatchRun}
+						onSaveBatchPrompt={handleSaveBatchPrompt}
+						showConfirmation={showConfirmation}
+						autoRunDocumentList={autoRunDocumentList}
+						autoRunDocumentTree={autoRunDocumentTree}
+						getDocumentTaskCount={getDocumentTaskCount}
+						onAutoRunRefresh={handleAutoRunRefresh}
+						onOpenMarketplace={handleOpenMarketplace}
+						onOpenSymphony={encoreFeatures.symphony ? () => setSymphonyModalOpen(true) : undefined}
+						onOpenDirectorNotes={
+							encoreFeatures.directorNotes ? () => setDirectorNotesOpen(true) : undefined
+						}
+						onOpenMaestroCue={encoreFeatures.maestroCue ? () => setCueModalOpen(true) : undefined}
+						onOpenPianola={encoreFeatures.pianola ? () => setPianolaModalOpen(true) : undefined}
+						onConfigureCue={encoreFeatures.maestroCue ? handleConfigureCue : undefined}
+						onCloseTabSwitcher={handleCloseTabSwitcher}
+						onTabSelect={handleUtilityTabSelect}
+						onFileTabSelect={handleUtilityFileTabSelect}
+						onTerminalTabSelect={handleSelectTerminalTab}
+						onBrowserTabSelect={handleSelectBrowserTab}
+						onNamedSessionSelect={handleNamedSessionSelect}
+						filteredFileTree={filteredFileTree}
+						fileExplorerExpanded={activeSession?.fileExplorerExpanded}
+						onCloseFileSearch={handleCloseFileSearch}
+						onFileSearchSelect={handleFileSearchSelect}
+						onClosePromptComposer={handleClosePromptComposer}
+						onPromptComposerSubmit={handlePromptComposerSubmit}
+						onPromptComposerSend={handlePromptComposerSend}
+						promptComposerSessionName={
+							activeGroupChatId
+								? groupChats.find((c) => c.id === activeGroupChatId)?.name
+								: activeSession?.name
+						}
+						promptComposerStagedImages={
+							activeGroupChatId ? groupChatStagedImages : canAttachImages ? stagedImages : []
+						}
+						setPromptComposerStagedImages={
+							activeGroupChatId
+								? setGroupChatStagedImages
+								: canAttachImages
+									? setStagedImages
+									: undefined
+						}
+						onPromptOpenLightbox={handleSetLightboxImage}
+						promptTabSaveToHistory={activeGroupChatId ? false : promptTabSaveToHistory}
+						onPromptToggleTabSaveToHistory={
+							activeGroupChatId ? undefined : handlePromptToggleTabSaveToHistory
+						}
+						promptTabReadOnlyMode={
+							activeGroupChatId ? groupChatReadOnlyMode : promptTabReadOnlyMode
+						}
+						onPromptToggleTabReadOnlyMode={handlePromptToggleTabReadOnlyMode}
+						promptTabShowThinking={activeGroupChatId ? 'off' : promptTabShowThinking}
+						onPromptToggleTabShowThinking={
+							activeGroupChatId ? undefined : handlePromptToggleTabShowThinking
+						}
+						promptSupportsThinking={
+							!activeGroupChatId && hasActiveSessionCapability('supportsThinkingDisplay')
+						}
+						promptEnterToSend={enterToSendAIExpanded}
+						onPromptToggleEnterToSend={handlePromptToggleEnterToSend}
+						onOpenQueueBrowser={handleOpenQueueBrowser}
+						onCloseQueueBrowser={handleCloseQueueBrowser}
+						onQuickActionsNewTab={handleNewTab}
+						onQuickActionsNewFileTab={handleNewFileTab}
+						onQuickActionsNewBrowserTab={handleNewBrowserTab}
+						onQuickActionsNewTerminalTab={handleOpenTerminalTab}
+						onGoToNextUnread={goToNextUnreadTab}
+						onNavBack={handleNavBack}
+						onNavForward={handleNavForward}
+						onRemoveQueueItem={handleRemoveQueueItem}
+						onSwitchQueueSession={handleSwitchQueueSession}
+						onReorderQueueItems={handleReorderQueueItems}
+						onTogglePauseQueueItem={handleTogglePauseQueueItem}
+						onEditQueueItem={handleEditQueueItem}
+						// AppGroupChatModals props
+						onCloseNewGroupChatModal={handleCloseNewGroupChatModal}
+						onCreateGroupChat={handleCreateGroupChat}
+						showDeleteGroupChatModal={showDeleteGroupChatModal}
+						onCloseDeleteGroupChatModal={handleCloseDeleteGroupChatModal}
+						onConfirmDeleteGroupChat={handleConfirmDeleteGroupChat}
+						showRenameGroupChatModal={showRenameGroupChatModal}
+						onCloseRenameGroupChatModal={handleCloseRenameGroupChatModal}
+						onRenameGroupChatFromModal={handleRenameGroupChatFromModal}
+						showEditGroupChatModal={showEditGroupChatModal}
+						onCloseEditGroupChatModal={handleCloseEditGroupChatModal}
+						onUpdateGroupChat={handleUpdateGroupChat}
+						groupChatMessages={groupChatMessages}
+						onCloseGroupChatInfo={handleCloseGroupChatInfo}
+						onOpenModeratorSession={handleOpenModeratorSession}
+						// AppAgentModals props
+						onCloseLeaderboardRegistration={handleCloseLeaderboardRegistration}
+						leaderboardRegistration={leaderboardRegistration}
+						onSaveLeaderboardRegistration={handleSaveLeaderboardRegistration}
+						onLeaderboardOptOut={handleLeaderboardOptOut}
+						onSyncAutoRunStats={handleSyncAutoRunStats}
+						errorSession={errorSession}
+						effectiveAgentError={effectiveAgentError}
+						recoveryActions={recoveryActions}
+						onDismissAgentError={handleCloseAgentErrorModal}
+						onJumpToAgent={handleJumpToFailingAgent}
+						groupChatError={groupChatError}
+						groupChatRecoveryActions={groupChatRecoveryActions}
+						onClearGroupChatError={handleClearGroupChatError}
+						onCloseMergeSession={handleCloseMergeSession}
+						onMerge={handleMerge}
+						transferState={transferState}
+						transferProgress={transferProgress}
+						transferSourceAgent={transferSourceAgent}
+						transferTargetAgent={transferTargetAgent}
+						onCancelTransfer={handleCancelTransfer}
+						onCompleteTransfer={handleCompleteTransfer}
+						onCloseSendToAgent={handleCloseSendToAgent}
+						onSendToAgent={handleSendToAgent}
+					/>
+				}
+				standaloneModals={
+					<AppStandaloneModals
+						theme={theme}
+						// Debug / Playground
+						onCloseDebugPackage={handleCloseDebugPackage}
+						setSuppressWindowsWarning={setSuppressWindowsWarning}
+						enableBetaUpdates={enableBetaUpdates}
+						setEnableBetaUpdates={setEnableBetaUpdates}
+						// AppOverlays
+						autoRunStats={autoRunStats}
+						onStandingOvationClose={handleStandingOvationClose}
+						onOpenLeaderboardRegistration={handleOpenLeaderboardRegistration}
+						isLeaderboardRegistered={isLeaderboardRegistered}
+						onFirstRunCelebrationClose={handleFirstRunCelebrationClose}
+						onKeyboardMasteryCelebrationClose={handleKeyboardMasteryCelebrationClose}
+						// Marketplace
+						onMarketplaceImportComplete={handleMarketplaceImportComplete}
+						// Symphony
+						setActiveSessionId={setActiveSessionId}
+						onStartContribution={handleStartContribution}
+						encoreFeatures={encoreFeatures}
+						// Director's Notes
+						onDirectorNotesResumeSession={handleDirectorNotesResumeSession}
+						onFileClick={handleFileClick}
+						// Cue
+						shortcuts={shortcuts}
+						// GistPublish
+						gistPublishModalOpen={gistPublishModalOpen}
+						setGistPublishModalOpen={setGistPublishModalOpen}
+						activeFileTab={activeFileTab}
+						saveFileGistUrl={saveFileGistUrl}
+						fileGistUrls={fileGistUrls}
+						// DocumentGraph
+						onOpenFileTab={handleOpenFileTab}
+						mainPanelRef={mainPanelRef}
+						documentGraphShowExternalLinks={documentGraphShowExternalLinks}
+						onExternalLinksChange={settings.setDocumentGraphShowExternalLinks}
+						documentGraphMaxNodes={documentGraphMaxNodes}
+						documentGraphPreviewCharLimit={documentGraphPreviewCharLimit}
+						onPreviewCharLimitChange={settings.setDocumentGraphPreviewCharLimit}
+						documentGraphLayoutType={documentGraphLayoutType}
+						onLayoutTypeChange={settings.setDocumentGraphLayoutType}
+						// DeleteAgent
+						onPerformDeleteSession={performDeleteSession}
+						onCloseDeleteAgentModal={handleCloseDeleteAgentModal}
+						// Settings
+						onCloseSettings={handleCloseSettings}
+						hasNoAgents={hasNoAgents}
+						setFlashNotification={setFlashNotification}
+						// Wizard
+						wizardIsOpen={wizardState.isOpen}
+						onWizardLaunchSession={handleWizardLaunchSession}
+						recordWizardStart={recordWizardStart}
+						recordWizardResume={recordWizardResume}
+						recordWizardAbandon={recordWizardAbandon}
+						recordWizardComplete={recordWizardComplete}
+						onWizardResume={handleWizardResume}
+						onWizardStartFresh={handleWizardStartFresh}
+						onWizardResumeClose={handleWizardResumeClose}
+						// Tour
+						setTourCompleted={setTourCompleted}
+						tabShortcuts={tabShortcuts}
+						recordTourStart={recordTourStart}
+						recordTourComplete={recordTourComplete}
+						recordTourSkip={recordTourSkip}
+					/>
+				}
+			/>
+		</>
 	);
 }
 

--- a/src/renderer/components/SessionList/SessionList.tsx
+++ b/src/renderer/components/SessionList/SessionList.tsx
@@ -44,6 +44,7 @@ import { useShallow } from 'zustand/react/shallow';
 import { useStoreWithEqualityFn } from 'zustand/traditional';
 import { sidebarSessionEquality } from '../../stores/sessionEquality';
 import { useGroupChatStore } from '../../stores/groupChatStore';
+import { useSidebarNavStore } from '../../stores/sidebarNavStore';
 import { useInlineWizardContext } from '../../contexts/InlineWizardContext';
 import { useWindowContextOptional } from '../../contexts/WindowContext';
 import { getModalActions, useModalStore } from '../../stores/modalStore';
@@ -72,19 +73,20 @@ import { buildVirtualGrouping } from '../../utils/pluginGroupings';
 // ============================================================================
 
 interface SessionListProps {
-	// Computed values (not in stores - remain as props)
+	// Computed values (not in stores - remain as props). Sort/nav/starred default
+	// to sidebarNavStore when omitted so App need not plumb them.
 	theme: Theme;
-	sortedSessions: Session[];
+	sortedSessions?: Session[];
 	navIndexMap?: Map<string, number>;
 	isLiveMode: boolean;
 	webInterfaceUrl: string | null;
 	showSessionJumpNumbers?: boolean;
 	visibleSessions?: Session[];
 
-	// Starred Sessions rows + activation. Computed in App by useStarredItems so the
-	// Left Bar render and Cmd+[ / Cmd+] cycling traverse the exact same list.
-	starredItems: StarredItem[];
-	activateStarredItem: (item: StarredItem) => void | Promise<void>;
+	/** @deprecated Prefer sidebarNavStore; optional when sync host is mounted. */
+	starredItems?: StarredItem[];
+	/** @deprecated Prefer sidebarNavStore; optional when sync host is mounted. */
+	activateStarredItem?: (item: StarredItem) => void | Promise<void>;
 
 	// Ref for the sidebar container (for focus management)
 	sidebarContainerRef?: React.RefObject<HTMLDivElement>;
@@ -132,15 +134,8 @@ interface SessionListProps {
 	// Maestro Cue
 	onConfigureCue?: (session: Session) => void;
 
-	// Starred sessions cross-agent jump. Resolves to `false` when the session can
-	// no longer be loaded (aged out), so the click handler can offer to unstar it.
-	onJumpToStarredSession?: (
-		agentId: string,
-		projectPath: string,
-		agentSessionId: string,
-		sessionName: string,
-		parentSessionId: string
-	) => Promise<boolean>;
+	// Starred Sessions: activation uses sidebarNavStore (jump registered from App).
+	// Do not plumb onJumpToStarredSession - unused and unstable identity busts memo.
 
 	// Group Chat handlers
 	onOpenGroupChat?: (id: string) => void;
@@ -331,10 +326,12 @@ function SessionListInner(props: SessionListProps) {
 		};
 		// Re-fetch when sessions change so newly added agents show their Cue indicator
 	}, [sessions.length]);
-	// Starred Sessions rows + activation come from App (useStarredItems) so the
-	// Left Bar render and Cmd+[ / Cmd+] cycling share one list. Only the section's
-	// collapse toggle is local UI state.
-	const { starredItems, activateStarredItem } = props;
+	// Starred Sessions: prefer sidebarNavStore (shared with Cmd+[ / ] cycling).
+	// Props remain for tests that inject fixtures without mounting SidebarNavSync.
+	const storeStarredItems = useSidebarNavStore((s) => s.starredItems);
+	const storeActivateStarredItem = useSidebarNavStore((s) => s.activateStarredItem);
+	const starredItems = props.starredItems ?? storeStarredItems;
+	const activateStarredItem = props.activateStarredItem ?? storeActivateStarredItem;
 	const setStarredSectionCollapsed = useSettingsStore.getState().setStarredSessionsCollapsed;
 
 	const groupChats = useGroupChatStore((s) => s.groupChats);
@@ -397,10 +394,14 @@ function SessionListInner(props: SessionListProps) {
 		setRenameInstanceSessionId,
 	} = getModalActions();
 
+	const storeSortedSessions = useSidebarNavStore((s) => s.sortedSessions);
+	const storeNavIndexMap = useSidebarNavStore((s) => s.navIndexMap);
+	const storeVisibleSessions = useSidebarNavStore((s) => s.visibleSessions);
+
 	const {
 		theme,
-		sortedSessions: sortedSessionsAll,
-		navIndexMap,
+		sortedSessions: sortedSessionsProp,
+		navIndexMap: navIndexMapProp,
 		isLiveMode,
 		webInterfaceUrl,
 		toggleGlobalLive,
@@ -430,7 +431,7 @@ function SessionListInner(props: SessionListProps) {
 		onDeleteWorktree,
 		onConfigureCue,
 		showSessionJumpNumbers = false,
-		visibleSessions = [],
+		visibleSessions: visibleSessionsProp,
 		openWizard,
 		startTour,
 		sidebarContainerRef,
@@ -442,6 +443,10 @@ function SessionListInner(props: SessionListProps) {
 		onArchiveGroupChat,
 		onDeleteAllArchivedGroupChats,
 	} = props;
+
+	const sortedSessionsAll = sortedSessionsProp ?? storeSortedSessions;
+	const navIndexMap = navIndexMapProp ?? storeNavIndexMap;
+	const visibleSessions = visibleSessionsProp ?? storeVisibleSessions;
 
 	// Scope the sorted agent list the same way as the store list (see
 	// scopeSessionsToWindow above): a secondary window only categorizes/renders the

--- a/src/renderer/hooks/keyboard/useKeyboardNavigation.ts
+++ b/src/renderer/hooks/keyboard/useKeyboardNavigation.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef } from 'react';
 import type { Session, Group, FocusArea } from '../../types';
 import type { SidebarExtraSelection } from '../../stores/uiStore';
 import type { StarredItem } from '../session/useStarredItems';
@@ -203,7 +203,8 @@ export function useKeyboardNavigation(
 	showUnreadAgentsOnlyRef.current = showUnreadAgentsOnly;
 
 	// When App omits nav/starred props, keep refs fresh without re-rendering App.
-	useEffect(() => {
+	// useLayoutEffect: run after SidebarNavSync's layout publish, sync refs before paint.
+	useLayoutEffect(() => {
 		if (
 			sortedSessionsProp !== undefined &&
 			navSessionsProp !== undefined &&
@@ -213,7 +214,8 @@ export function useKeyboardNavigation(
 		) {
 			return;
 		}
-		return useSidebarNavStore.subscribe((state) => {
+
+		const syncFromStore = (state: ReturnType<typeof useSidebarNavStore.getState>) => {
 			if (sortedSessionsProp === undefined) {
 				sortedSessionsRef.current = state.sortedSessions;
 			}
@@ -229,7 +231,12 @@ export function useKeyboardNavigation(
 			if (activateStarredItemProp === undefined) {
 				activateStarredItemRef.current = state.activateStarredItem;
 			}
-		});
+		};
+
+		// Subscribe alone misses the projection SidebarNavSync already published
+		// in layout (subscribe only fires on later writes). Sync once immediately.
+		syncFromStore(useSidebarNavStore.getState());
+		return useSidebarNavStore.subscribe(syncFromStore);
 	}, [
 		sortedSessionsProp,
 		navSessionsProp,

--- a/src/renderer/hooks/keyboard/useKeyboardNavigation.ts
+++ b/src/renderer/hooks/keyboard/useKeyboardNavigation.ts
@@ -3,6 +3,7 @@ import type { Session, Group, FocusArea } from '../../types';
 import type { SidebarExtraSelection } from '../../stores/uiStore';
 import type { StarredItem } from '../session/useStarredItems';
 import { orderGroupChatsForDisplay } from '../../utils/groupChatOrdering';
+import { useSidebarNavStore } from '../../stores/sidebarNavStore';
 
 /**
  * Minimal group-chat shape the sidebar navigation needs. Mirrors the fields
@@ -21,67 +22,42 @@ export interface NavGroupChat {
  *
  * Note: editingSessionId/editingGroupId are checked in useMainKeyboardHandler.ts
  * before any navigation handlers are called, so they are not needed here.
+ *
+ * Left Bar sort/nav/starred fields are optional: when omitted, handlers read
+ * {@link useSidebarNavStore} via refs (no App subscription to those slices).
  */
 export interface UseKeyboardNavigationDeps {
-	/** All sessions sorted in visual display order */
-	sortedSessions: Session[];
-	/** Sessions in visual navigation order (bookmarks first, then groups, then ungrouped) */
-	navSessions: Session[];
-	/** Number of items in the bookmarks section of navSessions */
-	bookmarkNavSize: number;
-	/** Current selected sidebar index (into navSessions; -1 when an extra section is selected) */
+	/** @deprecated Prefer sidebarNavStore; optional for App. */
+	sortedSessions?: Session[];
+	/** @deprecated Prefer sidebarNavStore; optional for App. */
+	navSessions?: Session[];
+	/** @deprecated Prefer sidebarNavStore; optional for App. */
+	bookmarkNavSize?: number;
 	selectedSidebarIndex: number;
-	/** Setter for selected sidebar index */
 	setSelectedSidebarIndex: React.Dispatch<React.SetStateAction<number>>;
-	/**
-	 * Keyboard cursor when it lands on a Starred / Group Chat row (the two Left
-	 * Bar sections that are not plain agents). null when the cursor is on a plain
-	 * agent row, in which case selectedSidebarIndex is authoritative.
-	 */
 	sidebarExtraSelection: SidebarExtraSelection | null;
-	/** Setter for the extra-section cursor */
 	setSidebarExtraSelection: (selection: SidebarExtraSelection | null) => void;
-	/** Active session ID */
 	activeSessionId: string | null;
-	/** Setter for active session ID */
 	setActiveSessionId: (id: string) => void;
-	/** Current focus area */
 	activeFocus: FocusArea;
-	/** Setter for focus area */
 	setActiveFocus: React.Dispatch<React.SetStateAction<FocusArea>>;
-	/** Session groups */
 	groups: Group[];
-	/** Setter for groups (for collapse/expand) */
 	setGroups: React.Dispatch<React.SetStateAction<Group[]>>;
-	/** Whether bookmarks section is collapsed */
 	bookmarksCollapsed: boolean;
-	/** Setter for bookmarks collapsed state */
 	setBookmarksCollapsed: React.Dispatch<React.SetStateAction<boolean>>;
-	/** Input ref for focus management */
 	inputRef: React.RefObject<HTMLTextAreaElement | null>;
-	/** Terminal output ref for escape handling */
 	terminalOutputRef: React.RefObject<HTMLDivElement | null>;
-
-	// --- Starred Sessions + Group Chats sections (top and bottom of the Left Bar) ---
-	/** Starred rows in rendered (display-name) order. */
-	starredItems: StarredItem[];
-	/** Activate a starred row (focus its tab, or resume a closed session). */
-	activateStarredItem: (item: StarredItem) => void | Promise<void>;
-	/** Whether the Starred Sessions section is collapsed. */
+	/** @deprecated Prefer sidebarNavStore; optional for App. */
+	starredItems?: StarredItem[];
+	/** @deprecated Prefer sidebarNavStore; optional for App. */
+	activateStarredItem?: (item: StarredItem) => void | Promise<void>;
 	starredSectionCollapsed: boolean;
-	/** Setter for the Starred Sessions collapsed state. */
 	setStarredSectionCollapsed: (collapsed: boolean) => void;
-	/** Group chats (unsorted; this hook applies the same sort GroupChatList uses). */
 	groupChats: NavGroupChat[];
-	/** Open/activate a group chat. */
 	handleOpenGroupChat: (id: string) => void;
-	/** Whether the Group Chats section is expanded. */
 	groupChatsExpanded: boolean;
-	/** Setter for the Group Chats expanded state. */
 	setGroupChatsExpanded: (expanded: boolean) => void;
-	/** Whether group chats sort alphabetically (vs most-recent) - matches the toggle. */
 	groupChatSortAlphabetical: boolean;
-	/** Unread-agents filter: hides the starred + group-chat sections when active. */
 	showUnreadAgentsOnly: boolean;
 }
 
@@ -144,9 +120,9 @@ export function useKeyboardNavigation(
 	deps: UseKeyboardNavigationDeps
 ): UseKeyboardNavigationReturn {
 	const {
-		sortedSessions,
-		navSessions,
-		bookmarkNavSize,
+		sortedSessions: sortedSessionsProp,
+		navSessions: navSessionsProp,
+		bookmarkNavSize: bookmarkNavSizeProp,
 		selectedSidebarIndex,
 		setSelectedSidebarIndex,
 		sidebarExtraSelection,
@@ -161,8 +137,8 @@ export function useKeyboardNavigation(
 		setBookmarksCollapsed,
 		inputRef,
 		terminalOutputRef,
-		starredItems,
-		activateStarredItem,
+		starredItems: starredItemsProp,
+		activateStarredItem: activateStarredItemProp,
 		starredSectionCollapsed,
 		setStarredSectionCollapsed,
 		groupChats,
@@ -172,6 +148,13 @@ export function useKeyboardNavigation(
 		groupChatSortAlphabetical,
 		showUnreadAgentsOnly,
 	} = deps;
+
+	const navSnap = useSidebarNavStore.getState();
+	const sortedSessions = sortedSessionsProp ?? navSnap.sortedSessions;
+	const navSessions = navSessionsProp ?? navSnap.navSessions;
+	const bookmarkNavSize = bookmarkNavSizeProp ?? navSnap.bookmarkNavSize;
+	const starredItems = starredItemsProp ?? navSnap.starredItems;
+	const activateStarredItem = activateStarredItemProp ?? navSnap.activateStarredItem;
 
 	// Use refs for values that change frequently to avoid stale closures
 	const sortedSessionsRef = useRef(sortedSessions);
@@ -201,6 +184,9 @@ export function useKeyboardNavigation(
 	const starredItemsRef = useRef(starredItems);
 	starredItemsRef.current = starredItems;
 
+	const activateStarredItemRef = useRef(activateStarredItem);
+	activateStarredItemRef.current = activateStarredItem;
+
 	const starredSectionCollapsedRef = useRef(starredSectionCollapsed);
 	starredSectionCollapsedRef.current = starredSectionCollapsed;
 
@@ -215,6 +201,42 @@ export function useKeyboardNavigation(
 
 	const showUnreadAgentsOnlyRef = useRef(showUnreadAgentsOnly);
 	showUnreadAgentsOnlyRef.current = showUnreadAgentsOnly;
+
+	// When App omits nav/starred props, keep refs fresh without re-rendering App.
+	useEffect(() => {
+		if (
+			sortedSessionsProp !== undefined &&
+			navSessionsProp !== undefined &&
+			bookmarkNavSizeProp !== undefined &&
+			starredItemsProp !== undefined &&
+			activateStarredItemProp !== undefined
+		) {
+			return;
+		}
+		return useSidebarNavStore.subscribe((state) => {
+			if (sortedSessionsProp === undefined) {
+				sortedSessionsRef.current = state.sortedSessions;
+			}
+			if (navSessionsProp === undefined) {
+				navSessionsRef.current = state.navSessions;
+			}
+			if (bookmarkNavSizeProp === undefined) {
+				bookmarkNavSizeRef.current = state.bookmarkNavSize;
+			}
+			if (starredItemsProp === undefined) {
+				starredItemsRef.current = state.starredItems;
+			}
+			if (activateStarredItemProp === undefined) {
+				activateStarredItemRef.current = state.activateStarredItem;
+			}
+		});
+	}, [
+		sortedSessionsProp,
+		navSessionsProp,
+		bookmarkNavSizeProp,
+		starredItemsProp,
+		activateStarredItemProp,
+	]);
 
 	/**
 	 * Build the full top-to-bottom Left Bar order. Starred rows and group chats
@@ -572,7 +594,7 @@ export function useKeyboardNavigation(
 			if (extra) {
 				if (extra.kind === 'starred') {
 					const item = starredItemsRef.current.find((s) => s.key === extra.key);
-					if (item) void activateStarredItem(item);
+					if (item) void activateStarredItemRef.current(item);
 				} else {
 					handleOpenGroupChat(extra.id);
 				}
@@ -586,7 +608,7 @@ export function useKeyboardNavigation(
 			}
 			return true;
 		},
-		[setActiveSessionId, activateStarredItem, handleOpenGroupChat]
+		[setActiveSessionId, handleOpenGroupChat]
 	);
 
 	/**

--- a/src/renderer/hooks/props/useSessionListProps.ts
+++ b/src/renderer/hooks/props/useSessionListProps.ts
@@ -2,14 +2,13 @@
  * useSessionListProps Hook
  *
  * Assembles handler props for the SessionList component.
- * Data/state props are now read directly from Zustand stores inside SessionList.
- * This hook only passes computed values that aren't raw store fields, plus
+ * Data/state props (including sort/nav/starred) are read from Zustand stores
+ * inside SessionList. This hook only passes theme, live-mode flags, and
  * domain-logic handlers.
  */
 
 import { useMemo } from 'react';
 import type { Session, Theme } from '../../types';
-import type { StarredItem } from '../session/useStarredItems';
 
 /**
  * Dependencies for computing SessionList props.
@@ -19,17 +18,9 @@ export interface UseSessionListPropsDeps {
 	// Theme (computed from settingsStore by App.tsx - not a raw store value)
 	theme: Theme;
 
-	// Computed values (not raw store fields)
-	sortedSessions: Session[];
 	isLiveMode: boolean;
 	webInterfaceUrl: string | null;
 	showSessionJumpNumbers: boolean;
-	visibleSessions: Session[];
-	navIndexMap: Map<string, number>;
-
-	// Starred Sessions (computed in App via useStarredItems, shared with cycling)
-	starredItems: StarredItem[];
-	activateStarredItem: (item: StarredItem) => void | Promise<void>;
 
 	// Ref
 	sidebarContainerRef: React.RefObject<HTMLDivElement>;
@@ -62,13 +53,6 @@ export interface UseSessionListPropsDeps {
 	handleConfigureCue: (session: Session) => void;
 	/** Whether the Maestro Cue Encore Feature is enabled. Gates the "Configure Maestro Cue" context-menu action. */
 	maestroCueEnabled: boolean;
-	handleJumpToStarredSession: (
-		agentId: string,
-		projectPath: string,
-		agentSessionId: string,
-		sessionName: string,
-		parentSessionId: string
-	) => Promise<boolean>;
 	openWizardModal: () => void;
 	handleOpenFeedbackModal: () => void;
 	handleStartTour: () => void;
@@ -92,21 +76,13 @@ export interface UseSessionListPropsDeps {
 export function useSessionListProps(deps: UseSessionListPropsDeps) {
 	return useMemo(
 		() => ({
-			// Theme & computed values
 			theme: deps.theme,
-			sortedSessions: deps.sortedSessions,
-			navIndexMap: deps.navIndexMap,
 			isLiveMode: deps.isLiveMode,
 			webInterfaceUrl: deps.webInterfaceUrl,
 			showSessionJumpNumbers: deps.showSessionJumpNumbers,
-			visibleSessions: deps.visibleSessions,
-			starredItems: deps.starredItems,
-			activateStarredItem: deps.activateStarredItem,
 
-			// Ref
 			sidebarContainerRef: deps.sidebarContainerRef,
 
-			// Domain handlers
 			toggleGlobalLive: deps.toggleGlobalLive,
 			restartWebServer: deps.restartWebServer,
 			toggleGroup: deps.toggleGroup,
@@ -132,16 +108,11 @@ export function useSessionListProps(deps: UseSessionListPropsDeps) {
 			onQuickCreateWorktree: deps.handleQuickCreateWorktree,
 			onOpenWorktreeConfig: deps.handleOpenWorktreeConfigSession,
 			onDeleteWorktree: deps.handleDeleteWorktreeSession,
-			// Gate on the Encore Feature flag: when Cue is disabled, leave this
-			// undefined so the "Configure Maestro Cue" context-menu item is hidden
-			// (the item renders only when onConfigureCue is defined).
 			onConfigureCue: deps.maestroCueEnabled ? deps.handleConfigureCue : undefined,
-			onJumpToStarredSession: deps.handleJumpToStarredSession,
 			openWizard: deps.openWizardModal,
 			openFeedback: deps.handleOpenFeedbackModal,
 			startTour: deps.handleStartTour,
 
-			// Group Chat handlers
 			onOpenGroupChat: deps.handleOpenGroupChat,
 			onNewGroupChat: deps.handleNewGroupChat,
 			onEditGroupChat: deps.handleEditGroupChat,
@@ -152,16 +123,10 @@ export function useSessionListProps(deps: UseSessionListPropsDeps) {
 		}),
 		[
 			deps.theme,
-			deps.sortedSessions,
-			deps.navIndexMap,
 			deps.isLiveMode,
 			deps.webInterfaceUrl,
 			deps.showSessionJumpNumbers,
-			deps.visibleSessions,
-			deps.starredItems,
-			deps.activateStarredItem,
 			deps.sidebarContainerRef,
-			// Stable callbacks
 			deps.toggleGlobalLive,
 			deps.restartWebServer,
 			deps.toggleGroup,
@@ -187,7 +152,6 @@ export function useSessionListProps(deps: UseSessionListPropsDeps) {
 			deps.handleDeleteWorktreeSession,
 			deps.handleConfigureCue,
 			deps.maestroCueEnabled,
-			deps.handleJumpToStarredSession,
 			deps.handleToggleWorktreeExpanded,
 			deps.openWizardModal,
 			deps.handleOpenFeedbackModal,

--- a/src/renderer/hooks/session/SidebarNavSync.tsx
+++ b/src/renderer/hooks/session/SidebarNavSync.tsx
@@ -6,7 +6,7 @@
  * body; only its own store subscriptions wake it.
  */
 
-import { memo, useCallback, useEffect } from 'react';
+import { memo, useCallback, useLayoutEffect, useMemo } from 'react';
 import { useStoreWithEqualityFn } from 'zustand/traditional';
 import { useSessionStore } from '../../stores/sessionStore';
 import { useUIStore } from '../../stores/uiStore';
@@ -15,6 +15,7 @@ import { sidebarSessionEquality } from '../../stores/sessionEquality';
 import { computeSortedSessions } from './computeSortedSessions';
 import { useStarredItems } from './useStarredItems';
 import { useWindowContextOptional } from '../../contexts/WindowContext';
+import { scopeSessionsToOwningWindow } from '../../utils/windowTargets';
 
 function SidebarNavSyncInner() {
 	const windowCtx = useWindowContextOptional();
@@ -33,10 +34,20 @@ function SidebarNavSyncInner() {
 	const setSortedProjection = useSidebarNavStore((s) => s.setSortedProjection);
 	const setStarredItems = useSidebarNavStore((s) => s.setStarredItems);
 
-	useEffect(() => {
+	// Same window scope SessionList applies so keyboard / unread / cycle read the
+	// agents this window actually shows (primary catch-all / secondary claimed).
+	const sessionsForWindow = useMemo(
+		() => scopeSessionsToOwningWindow(sessions, ownsSession),
+		[sessions, ownsSession]
+	);
+
+	// useLayoutEffect (not useEffect): publish before paint and before parent
+	// passive effects so the first committed frame and same-tick nav commands
+	// see the current projection instead of the store's empty/previous one.
+	useLayoutEffect(() => {
 		setSortedProjection(
 			computeSortedSessions({
-				sessions,
+				sessions: sessionsForWindow,
 				groups,
 				bookmarksCollapsed,
 				showUnreadAgentsOnly,
@@ -44,7 +55,7 @@ function SidebarNavSyncInner() {
 			})
 		);
 	}, [
-		sessions,
+		sessionsForWindow,
 		groups,
 		bookmarksCollapsed,
 		showUnreadAgentsOnly,
@@ -81,7 +92,7 @@ function SidebarNavSyncInner() {
 		ownsSession,
 	});
 
-	useEffect(() => {
+	useLayoutEffect(() => {
 		setStarredItems(starredItems);
 	}, [starredItems, setStarredItems]);
 

--- a/src/renderer/hooks/session/SidebarNavSync.tsx
+++ b/src/renderer/hooks/session/SidebarNavSync.tsx
@@ -1,0 +1,91 @@
+/**
+ * SidebarNavSync - always-mounted host that owns Left Bar sort/nav/starred
+ * subscriptions and writes {@link useSidebarNavStore}.
+ *
+ * Memoized with no props so MaestroConsoleInner re-renders do not re-run this
+ * body; only its own store subscriptions wake it.
+ */
+
+import { memo, useCallback, useEffect } from 'react';
+import { useStoreWithEqualityFn } from 'zustand/traditional';
+import { useSessionStore } from '../../stores/sessionStore';
+import { useUIStore } from '../../stores/uiStore';
+import { useSidebarNavStore } from '../../stores/sidebarNavStore';
+import { sidebarSessionEquality } from '../../stores/sessionEquality';
+import { computeSortedSessions } from './computeSortedSessions';
+import { useStarredItems } from './useStarredItems';
+import { useWindowContextOptional } from '../../contexts/WindowContext';
+
+function SidebarNavSyncInner() {
+	const windowCtx = useWindowContextOptional();
+	const ownsSession = windowCtx?.ownsSession;
+
+	const sessions = useStoreWithEqualityFn(
+		useSessionStore,
+		(s) => s.sessions,
+		sidebarSessionEquality
+	);
+	const groups = useSessionStore((s) => s.groups);
+	const activeSessionId = useSessionStore((s) => s.activeSessionId);
+	const bookmarksCollapsed = useUIStore((s) => s.bookmarksCollapsed);
+	const showUnreadAgentsOnly = useUIStore((s) => s.showUnreadAgentsOnly);
+
+	const setSortedProjection = useSidebarNavStore((s) => s.setSortedProjection);
+	const setStarredItems = useSidebarNavStore((s) => s.setStarredItems);
+
+	useEffect(() => {
+		setSortedProjection(
+			computeSortedSessions({
+				sessions,
+				groups,
+				bookmarksCollapsed,
+				showUnreadAgentsOnly,
+				activeSessionId,
+			})
+		);
+	}, [
+		sessions,
+		groups,
+		bookmarksCollapsed,
+		showUnreadAgentsOnly,
+		activeSessionId,
+		setSortedProjection,
+	]);
+
+	// Event-time handlers - do not subscribe to sidebarNavStore jump/confirm
+	// fields (those update when App re-registers and would wake this host).
+	const onJumpToStarredSession = useCallback(
+		(
+			agentId: string,
+			projectPath: string,
+			agentSessionId: string,
+			sessionName: string,
+			parentSessionId: string
+		) => {
+			const fn = useSidebarNavStore.getState().onJumpToStarredSession;
+			return fn
+				? fn(agentId, projectPath, agentSessionId, sessionName, parentSessionId)
+				: Promise.resolve(false);
+		},
+		[]
+	);
+	const showConfirmation = useCallback((message: string, onConfirm: () => void | Promise<void>) => {
+		useSidebarNavStore.getState().showConfirmation?.(message, onConfirm);
+	}, []);
+
+	// Star list still uses the hook (async named-session load + star signature).
+	// Results are mirrored into the store for SessionList / cycle / keyboard.
+	const { starredItems } = useStarredItems({
+		onJumpToStarredSession,
+		showConfirmation,
+		ownsSession,
+	});
+
+	useEffect(() => {
+		setStarredItems(starredItems);
+	}, [starredItems, setStarredItems]);
+
+	return null;
+}
+
+export const SidebarNavSync = memo(SidebarNavSyncInner);

--- a/src/renderer/hooks/session/computeSortedSessions.ts
+++ b/src/renderer/hooks/session/computeSortedSessions.ts
@@ -1,0 +1,167 @@
+import type { Session, Group } from '../../types';
+import { compareNamesIgnoringEmojis } from '../../../shared/emojiUtils';
+
+/**
+ * Inputs for {@link computeSortedSessions}. Pure - safe to call from a Zustand
+ * sync host or tests without React.
+ */
+export interface ComputeSortedSessionsInput {
+	sessions: Session[];
+	groups: Group[];
+	bookmarksCollapsed: boolean;
+	showUnreadAgentsOnly?: boolean;
+	activeSessionId?: string | null;
+}
+
+/**
+ * Sorted / nav / jump-badge projections for the Left Bar.
+ * Same shape as the former `useSortedSessions` return value.
+ */
+export interface SortedSessionsProjection {
+	sortedSessions: Session[];
+	visibleSessions: Session[];
+	navSessions: Session[];
+	bookmarkNavSize: number;
+	navIndexMap: Map<string, number>;
+}
+
+/**
+ * Compute Left Bar session order projections.
+ *
+ * 1. sortedSessions - group then alpha (ignoring leading emojis), with worktrees
+ * 2. visibleSessions - Opt+Cmd+NUMBER jump targets
+ * 3. navSessions / navIndexMap - arrow-key visual order (bookmarks + group + ungrouped)
+ */
+export function computeSortedSessions(input: ComputeSortedSessionsInput): SortedSessionsProjection {
+	const { sessions, groups, bookmarksCollapsed, showUnreadAgentsOnly, activeSessionId } = input;
+
+	const worktreeChildrenByParent = new Map<string, Session[]>();
+	for (const s of sessions) {
+		if (s.parentSessionId) {
+			const existing = worktreeChildrenByParent.get(s.parentSessionId);
+			if (existing) {
+				existing.push(s);
+			} else {
+				worktreeChildrenByParent.set(s.parentSessionId, [s]);
+			}
+		}
+	}
+	for (const [, children] of worktreeChildrenByParent) {
+		children.sort((a, b) => compareNamesIgnoringEmojis(a.name, b.name));
+	}
+
+	const sortedSessions: Session[] = [];
+	const addSessionWithWorktrees = (session: Session) => {
+		if (session.parentSessionId) return;
+		sortedSessions.push(session);
+		if (session.worktreesExpanded !== false) {
+			const children = worktreeChildrenByParent.get(session.id);
+			if (children) {
+				sortedSessions.push(...children);
+			}
+		}
+	};
+
+	const sortedGroups = [...groups].sort((a, b) => compareNamesIgnoringEmojis(a.name, b.name));
+	sortedGroups.forEach((group) => {
+		const groupSessions = sessions
+			.filter((s) => s.groupId === group.id && !s.parentSessionId)
+			.sort((a, b) => compareNamesIgnoringEmojis(a.name, b.name));
+		groupSessions.forEach(addSessionWithWorktrees);
+	});
+
+	const ungroupedSessions = sessions
+		.filter((s) => !s.groupId && !s.parentSessionId)
+		.sort((a, b) => compareNamesIgnoringEmojis(a.name, b.name));
+	ungroupedSessions.forEach(addSessionWithWorktrees);
+
+	const groupsById = new Map<string, Group>();
+	for (const g of groups) {
+		groupsById.set(g.id, g);
+	}
+
+	const navSessions: Session[] = [];
+	const navIndexMap = new Map<string, number>();
+	let idx = 0;
+
+	const addWithWorktrees = (session: Session, keyPrefix: string) => {
+		if (session.parentSessionId) return;
+		navSessions.push(session);
+		navIndexMap.set(`${keyPrefix}:${session.id}`, idx++);
+		if (session.worktreesExpanded !== false) {
+			const children = worktreeChildrenByParent.get(session.id);
+			if (children) {
+				for (const child of children) {
+					navSessions.push(child);
+					navIndexMap.set(`${keyPrefix}:wt:${child.id}`, idx++);
+				}
+			}
+		}
+	};
+
+	const bookmarkedParents = sessions
+		.filter((s) => s.bookmarked && !s.parentSessionId)
+		.sort((a, b) => compareNamesIgnoringEmojis(a.name, b.name));
+	for (const session of bookmarkedParents) {
+		addWithWorktrees(session, 'bookmark');
+	}
+	const bookmarkNavSize = idx;
+
+	for (const group of sortedGroups) {
+		const groupSessions = sessions
+			.filter((s) => s.groupId === group.id && !s.parentSessionId)
+			.sort((a, b) => compareNamesIgnoringEmojis(a.name, b.name));
+		for (const session of groupSessions) {
+			addWithWorktrees(session, `group:${group.id}`);
+		}
+	}
+
+	const navUngrouped = sessions
+		.filter((s) => !s.groupId && !s.parentSessionId)
+		.sort((a, b) => compareNamesIgnoringEmojis(a.name, b.name));
+	for (const session of navUngrouped) {
+		addWithWorktrees(session, 'ungrouped');
+	}
+
+	const passesUnreadFilter = (session: Session): boolean => {
+		if (!showUnreadAgentsOnly) return true;
+		const isActiveOrParentOfActive =
+			session.id === activeSessionId ||
+			worktreeChildrenByParent.get(session.id)?.some((child) => child.id === activeSessionId) ||
+			false;
+		if (isActiveOrParentOfActive) return true;
+		const hasUnread = session.aiTabs?.some((tab) => tab.hasUnread) ?? false;
+		const isBusy = session.state === 'busy';
+		const children = worktreeChildrenByParent.get(session.id);
+		const hasUnreadChildren =
+			children?.some(
+				(child) => child.aiTabs?.some((tab) => tab.hasUnread) || child.state === 'busy'
+			) ?? false;
+		return hasUnread || isBusy || hasUnreadChildren;
+	};
+
+	const visibleSessions: Session[] = [];
+	if (!bookmarksCollapsed) {
+		const bookmarkedSessions = sessions
+			.filter((s) => s.bookmarked && !s.parentSessionId && passesUnreadFilter(s))
+			.sort((a, b) => compareNamesIgnoringEmojis(a.name, b.name));
+		visibleSessions.push(...bookmarkedSessions);
+	}
+
+	const groupAndUngrouped = sortedSessions.filter((session) => {
+		if (session.parentSessionId) return false;
+		if (!passesUnreadFilter(session)) return false;
+		if (!session.groupId) return true;
+		const group = groupsById.get(session.groupId);
+		return group && !group.collapsed;
+	});
+	visibleSessions.push(...groupAndUngrouped);
+
+	return {
+		sortedSessions,
+		visibleSessions,
+		navSessions,
+		bookmarkNavSize,
+		navIndexMap,
+	};
+}

--- a/src/renderer/hooks/session/index.ts
+++ b/src/renderer/hooks/session/index.ts
@@ -20,6 +20,9 @@ export {
 	compareNamesIgnoringEmojis,
 } from './useSortedSessions';
 export type { UseSortedSessionsDeps, UseSortedSessionsReturn } from './useSortedSessions';
+export { computeSortedSessions } from './computeSortedSessions';
+export type { ComputeSortedSessionsInput, SortedSessionsProjection } from './computeSortedSessions';
+export { SidebarNavSync } from './SidebarNavSync';
 
 // Group management
 export { useGroupManagement } from './useGroupManagement';

--- a/src/renderer/hooks/session/useCycleSession.ts
+++ b/src/renderer/hooks/session/useCycleSession.ts
@@ -22,31 +22,32 @@ import { useUIStore } from '../../stores/uiStore';
 import { useSettingsStore } from '../../stores/settingsStore';
 import { compareNamesIgnoringEmojis } from './useSortedSessions';
 import type { StarredItem } from './useStarredItems';
+import { useSidebarNavStore } from '../../stores/sidebarNavStore';
 
 // ============================================================================
 // Dependencies
 // ============================================================================
 
 export interface CycleSessionDeps {
-	/** Sorted sessions array (used when sidebar is collapsed) */
-	sortedSessions: Session[];
+	/**
+	 * Sorted sessions (sidebar collapsed). Prefer omitting and letting event-time
+	 * code read {@link useSidebarNavStore}; tests may pass an explicit list.
+	 */
+	sortedSessions?: Session[];
 	/** Open a group chat (loads messages etc.) */
 	handleOpenGroupChat: (groupChatId: string) => void;
 	/**
-	 * Starred Sessions rows (open starred tabs + closed starred sessions), in the
-	 * same display order as the Left Bar's "Starred Sessions" section. Cycling
-	 * traverses these at the top of the visual order when the section is shown.
+	 * Starred Sessions rows. Prefer omitting for production (sidebarNavStore);
+	 * tests may pass fixtures.
 	 */
-	starredItems: StarredItem[];
-	/** Activate a starred row (focus its tab, or resume a closed session). */
-	activateStarredItem: (item: StarredItem) => void | Promise<void>;
+	starredItems?: StarredItem[];
+	/** Activate a starred row. Prefer omitting for production (sidebarNavStore). */
+	activateStarredItem?: (item: StarredItem) => void | Promise<void>;
 	/**
-	 * Maps a render-context navKey (`bookmark:{id}`, `group:{gid}:{id}`,
-	 * `ungrouped:{id}`, plus `:wt:` child variants) to its index in navSessions.
-	 * Lets cycling highlight the EXACT occurrence it landed on (e.g. a bookmarked
-	 * agent's group row) instead of the first navSessions occurrence.
+	 * Maps a render-context navKey to its index in navSessions. Prefer omitting
+	 * for production (sidebarNavStore).
 	 */
-	navIndexMap: Map<string, number>;
+	navIndexMap?: Map<string, number>;
 	/**
 	 * Multi-window: optional window-ownership predicate. When provided, cycling
 	 * includes only agent rows THIS window owns, so `Cmd+[` / `Cmd+]` never jumps
@@ -80,14 +81,12 @@ type VisualOrderItem =
  * Left Bar order. Reads all store state at call time.
  */
 export function cycleSession(dir: 'next' | 'prev', deps: CycleSessionDeps): void {
-	const {
-		sortedSessions,
-		handleOpenGroupChat,
-		starredItems,
-		activateStarredItem,
-		navIndexMap,
-		ownsSession,
-	} = deps;
+	const nav = useSidebarNavStore.getState();
+	const sortedSessions = deps.sortedSessions ?? nav.sortedSessions;
+	const starredItems = deps.starredItems ?? nav.starredItems;
+	const activateStarredItem = deps.activateStarredItem ?? nav.activateStarredItem;
+	const navIndexMap = deps.navIndexMap ?? nav.navIndexMap;
+	const { handleOpenGroupChat, ownsSession } = deps;
 
 	const {
 		sessions,

--- a/src/renderer/hooks/session/useSessionCrud.ts
+++ b/src/renderer/hooks/session/useSessionCrud.ts
@@ -19,7 +19,7 @@ import type { AdditionalDirectory, ToolType, Session, AITab } from '../../types'
 import { useSessionStore, selectSessionById } from '../../stores/sessionStore';
 import { useSettingsStore } from '../../stores/settingsStore';
 import { useUIStore } from '../../stores/uiStore';
-import { getModalActions, useModalStore } from '../../stores/modalStore';
+import { useModalStore } from '../../stores/modalStore';
 import { useWindowContextOptional } from '../../contexts/WindowContext';
 import { notifyToast } from '../../stores/notificationStore';
 import { generateId } from '../../utils/ids';
@@ -121,7 +121,8 @@ export function useSessionCrud(deps: UseSessionCrudDeps): UseSessionCrudReturn {
 	// --- Store actions (stable via getState) ---
 	const { setSessions, setActiveSessionId, setGroups } = useSessionStore.getState();
 	const { setEditingSessionId, setDraggingSessionId, setActiveFocus } = useUIStore.getState();
-	const { setDeleteAgentSession } = getModalActions();
+	// PERF: Do not call getModalActions() at render time for deleteSession deps -
+	// it returns fresh wrapper functions every call and would bust SessionList memo.
 
 	// Multi-window: claim a newly-created agent for the window that created it so
 	// it never momentarily surfaces in the primary's catch-all (spawn flicker).
@@ -339,14 +340,12 @@ export function useSessionCrud(deps: UseSessionCrudDeps): UseSessionCrudReturn {
 	// ========================================================================
 	// deleteSession - opens the delete agent confirmation modal
 	// ========================================================================
-	const deleteSession = useCallback(
-		(id: string) => {
-			const session = selectSessionById(id)(useSessionStore.getState());
-			if (!session) return;
-			setDeleteAgentSession(session);
-		},
-		[setDeleteAgentSession]
-	);
+	const deleteSession = useCallback((id: string) => {
+		const session = selectSessionById(id)(useSessionStore.getState());
+		if (!session) return;
+		// Event-time modal open - stable callback identity for SessionList memo.
+		useModalStore.getState().openModal('deleteAgent', { session });
+	}, []);
 
 	// ========================================================================
 	// deleteWorktreeGroup - removes group + all agents

--- a/src/renderer/hooks/session/useSessionFilterMode.ts
+++ b/src/renderer/hooks/session/useSessionFilterMode.ts
@@ -22,12 +22,14 @@ export interface SessionFilterModeState {
  *   - Temporarily expands groups containing matching sessions
  *   - Expands bookmarks if any bookmarked sessions match
  *   - Collapses groups when filter text is cleared (but filter input still open)
+ *
+ * PERF: Do not subscribe to `sessions` / `groups` here. SessionList already uses
+ * `sidebarSessionEquality`; a bare sessions subscription undoes that shield and
+ * re-renders the Left Bar on every log/token flush. Effects read getState() at
+ * open/filter-text time (deps are only UI open + filter string).
  */
 export function useSessionFilterMode(): SessionFilterModeState {
 	const sessionFilterOpen = useUIStore((s) => s.sessionFilterOpen);
-	const bookmarksCollapsed = useUIStore((s) => s.bookmarksCollapsed);
-	const sessions = useSessionStore((s) => s.sessions);
-	const groups = useSessionStore((s) => s.groups);
 
 	const [sessionFilter, setSessionFilter] = useState('');
 
@@ -46,13 +48,15 @@ export function useSessionFilterMode(): SessionFilterModeState {
 	);
 	const [filterModeInitialized, setFilterModeInitialized] = useState(false);
 
-	// Stable store actions
 	const setGroups = useSessionStore.getState().setGroups;
 	const setBookmarksCollapsed = useUIStore.getState().setBookmarksCollapsed;
 
 	// When filter opens, apply filter mode preferences (or defaults on first open)
 	// When filter closes, save current states as filter mode preferences and restore original states
 	useEffect(() => {
+		const groups = useSessionStore.getState().groups;
+		const bookmarksCollapsed = useUIStore.getState().bookmarksCollapsed;
+
 		if (sessionFilterOpen) {
 			// Save current (non-filter) states when filter opens
 			if (preFilterGroupStates.size === 0) {
@@ -106,10 +110,14 @@ export function useSessionFilterMode(): SessionFilterModeState {
 				setPreFilterBookmarksCollapsed(null);
 			}
 		}
+		// Intentionally omit groups/bookmarksCollapsed - snapshot at open/close only.
 	}, [sessionFilterOpen]);
 
 	// Temporarily expand groups when filtering to show matching sessions
 	useEffect(() => {
+		const sessionFilterOpenNow = useUIStore.getState().sessionFilterOpen;
+		const sessions = useSessionStore.getState().sessions;
+
 		if (sessionFilter) {
 			// Find groups that contain matching sessions (search session name AND AI tab names)
 			const groupsWithMatches = new Set<string>();
@@ -141,11 +149,12 @@ export function useSessionFilterMode(): SessionFilterModeState {
 			if (hasMatchingBookmarks) {
 				setBookmarksCollapsed(false);
 			}
-		} else if (sessionFilterOpen) {
+		} else if (sessionFilterOpenNow) {
 			// Filter cleared but filter input still open - collapse groups again, keep bookmarks expanded
 			setGroups((prev) => prev.map((g) => ({ ...g, collapsed: true })));
 			setBookmarksCollapsed(false);
 		}
+		// sessions read at filter-text change time only - do not subscribe (streaming).
 	}, [sessionFilter]);
 
 	return {

--- a/src/renderer/hooks/session/useSortedSessions.ts
+++ b/src/renderer/hooks/session/useSortedSessions.ts
@@ -1,262 +1,44 @@
-import { useCallback, useMemo } from 'react';
+import { useMemo } from 'react';
 import type { Session, Group } from '../../types';
 import { stripLeadingEmojis, compareNamesIgnoringEmojis } from '../../../shared/emojiUtils';
+import { computeSortedSessions, type SortedSessionsProjection } from './computeSortedSessions';
 
 // Re-export for backwards compatibility with existing imports
 export { stripLeadingEmojis, compareNamesIgnoringEmojis };
+export type { SortedSessionsProjection };
 
 /**
  * Dependencies for the useSortedSessions hook.
+ * Prefer {@link computeSortedSessions} + {@link useSidebarNavStore} for new code.
  */
 export interface UseSortedSessionsDeps {
-	/** All sessions */
 	sessions: Session[];
-	/** All groups */
 	groups: Group[];
-	/** Whether the bookmarks folder is collapsed */
 	bookmarksCollapsed: boolean;
-	/**
-	 * When true, visibleSessions excludes agents that have no unread AI tabs and aren't busy
-	 * (and whose worktree children likewise have none). The active session (or its parent) is
-	 * always kept visible so the user doesn't lose their place. Mirrors the filter applied in
-	 * useSessionCategories so jump numbers and Alt+Cmd+N shortcuts match the rendered list.
-	 */
 	showUnreadAgentsOnly?: boolean;
-	/** Active session id - kept visible even when the unread filter would exclude it */
 	activeSessionId?: string | null;
 }
 
-/**
- * Return type for useSortedSessions hook.
- */
-export interface UseSortedSessionsReturn {
-	/** All sessions sorted by group then alphabetically (ignoring leading emojis) */
-	sortedSessions: Session[];
-	/**
-	 * Sessions visible for jump shortcuts (Opt+Cmd+NUMBER).
-	 * Order: Bookmarked sessions first (if bookmarks expanded), then expanded groups/ungrouped.
-	 * Note: A session may appear twice if bookmarked and in an expanded group.
-	 */
-	visibleSessions: Session[];
-	/**
-	 * Sessions in visual navigation order for keyboard arrow-key navigation.
-	 * Order: Bookmarked sessions first (with worktree children), then group sessions,
-	 * then ungrouped sessions. Bookmarked sessions appear in BOTH positions (bookmark
-	 * section and their group) so they're navigable from either context.
-	 */
-	navSessions: Session[];
-	/** Number of items in the bookmarks section of navSessions (including worktree children) */
-	bookmarkNavSize: number;
-	/**
-	 * Maps render context keys to indices in navSessions for keyboard selection highlighting.
-	 * Key format: 'bookmark:{id}', 'bookmark:wt:{childId}', 'group:{groupId}:{id}',
-	 * 'group:{groupId}:wt:{childId}', 'ungrouped:{id}', 'ungrouped:wt:{childId}'
-	 */
-	navIndexMap: Map<string, number>;
-}
+/** @deprecated Prefer SortedSessionsProjection from computeSortedSessions */
+export type UseSortedSessionsReturn = SortedSessionsProjection;
 
 /**
- * Hook for computing sorted and visible session lists.
- *
- * This hook handles:
- * 1. sortedSessions - All sessions sorted by group membership, then alphabetically
- *    (ignoring leading emojis for proper alphabetization)
- * 2. visibleSessions - Sessions visible for keyboard shortcuts (Opt+Cmd+NUMBER),
- *    respecting bookmarks folder state and group collapse states
- *
- * @param deps - Hook dependencies containing sessions, groups, and collapse state
- * @returns Sorted and visible session arrays
+ * React wrapper around {@link computeSortedSessions}.
+ * Left Bar consumers should read {@link useSidebarNavStore} instead; App no
+ * longer mounts this hook.
  */
-export function useSortedSessions(deps: UseSortedSessionsDeps): UseSortedSessionsReturn {
+export function useSortedSessions(deps: UseSortedSessionsDeps): SortedSessionsProjection {
 	const { sessions, groups, bookmarksCollapsed, showUnreadAgentsOnly, activeSessionId } = deps;
 
-	// Memoize worktree children lookup for O(1) access instead of O(n) per parent
-	// This reduces complexity from O(n²) to O(n) when building sorted sessions
-	const worktreeChildrenByParent = useMemo(() => {
-		const map = new Map<string, Session[]>();
-		for (const s of sessions) {
-			if (s.parentSessionId) {
-				const existing = map.get(s.parentSessionId);
-				if (existing) {
-					existing.push(s);
-				} else {
-					map.set(s.parentSessionId, [s]);
-				}
-			}
-		}
-		// Sort each group once
-		for (const [, children] of map) {
-			children.sort((a, b) => compareNamesIgnoringEmojis(a.name, b.name));
-		}
-		return map;
-	}, [sessions]);
-
-	// Create sorted sessions array that matches visual display order (includes ALL sessions)
-	// Note: sorting ignores leading emojis for proper alphabetization
-	// Worktree children are inserted after their parent when the parent's worktrees are expanded
-	const sortedSessions = useMemo(() => {
-		const sorted: Session[] = [];
-
-		// Helper to add session with its worktree children - now O(1) lookup
-		const addSessionWithWorktrees = (session: Session) => {
-			// Skip worktree children - they're added with their parent
-			if (session.parentSessionId) return;
-
-			sorted.push(session);
-
-			// Add worktree children if expanded
-			if (session.worktreesExpanded !== false) {
-				const children = worktreeChildrenByParent.get(session.id);
-				if (children) {
-					sorted.push(...children);
-				}
-			}
-		};
-
-		// First, add sessions from sorted groups (ignoring leading emojis)
-		const sortedGroups = [...groups].sort((a, b) => compareNamesIgnoringEmojis(a.name, b.name));
-		sortedGroups.forEach((group) => {
-			const groupSessions = sessions
-				.filter((s) => s.groupId === group.id && !s.parentSessionId)
-				.sort((a, b) => compareNamesIgnoringEmojis(a.name, b.name));
-			groupSessions.forEach(addSessionWithWorktrees);
-		});
-
-		// Then, add ungrouped sessions (sorted alphabetically, ignoring leading emojis)
-		const ungroupedSessions = sessions
-			.filter((s) => !s.groupId && !s.parentSessionId)
-			.sort((a, b) => compareNamesIgnoringEmojis(a.name, b.name));
-		ungroupedSessions.forEach(addSessionWithWorktrees);
-
-		return sorted;
-	}, [sessions, groups, worktreeChildrenByParent]);
-
-	// Create a Map for O(1) group lookup instead of O(n) find() calls
-	const groupsById = useMemo(() => {
-		const map = new Map<string, Group>();
-		for (const g of groups) {
-			map.set(g.id, g);
-		}
-		return map;
-	}, [groups]);
-
-	// Build navSessions: matches visual rendering order for keyboard navigation.
-	// Bookmarked sessions first (with worktree children), then group sessions, then ungrouped.
-	// Bookmarked sessions that belong to a group appear in BOTH positions.
-	const { navSessions, navIndexMap, bookmarkNavSize } = useMemo(() => {
-		const result: Session[] = [];
-		const indexMap = new Map<string, number>();
-		let idx = 0;
-
-		const addWithWorktrees = (session: Session, keyPrefix: string) => {
-			if (session.parentSessionId) return;
-			result.push(session);
-			indexMap.set(`${keyPrefix}:${session.id}`, idx++);
-			if (session.worktreesExpanded !== false) {
-				const children = worktreeChildrenByParent.get(session.id);
-				if (children) {
-					for (const child of children) {
-						result.push(child);
-						indexMap.set(`${keyPrefix}:wt:${child.id}`, idx++);
-					}
-				}
-			}
-		};
-
-		// 1. Bookmarked sessions first
-		const bookmarkedParents = sessions
-			.filter((s) => s.bookmarked && !s.parentSessionId)
-			.sort((a, b) => compareNamesIgnoringEmojis(a.name, b.name));
-		for (const session of bookmarkedParents) {
-			addWithWorktrees(session, 'bookmark');
-		}
-		const bmSize = idx;
-
-		// 2. Group sessions (same order as sortedSessions - all members including bookmarked)
-		const navSortedGroups = [...groups].sort((a, b) => compareNamesIgnoringEmojis(a.name, b.name));
-		for (const group of navSortedGroups) {
-			const groupSessions = sessions
-				.filter((s) => s.groupId === group.id && !s.parentSessionId)
-				.sort((a, b) => compareNamesIgnoringEmojis(a.name, b.name));
-			for (const session of groupSessions) {
-				addWithWorktrees(session, `group:${group.id}`);
-			}
-		}
-
-		// 3. Ungrouped sessions
-		const navUngrouped = sessions
-			.filter((s) => !s.groupId && !s.parentSessionId)
-			.sort((a, b) => compareNamesIgnoringEmojis(a.name, b.name));
-		for (const session of navUngrouped) {
-			addWithWorktrees(session, 'ungrouped');
-		}
-
-		return { navSessions: result, navIndexMap: indexMap, bookmarkNavSize: bmSize };
-	}, [sessions, groups, worktreeChildrenByParent]);
-
-	// Build a lookup of worktree children by parent id for unread-filter checks.
-	// Reuses the same child list already computed above.
-	const childrenByParentId = worktreeChildrenByParent;
-
-	// Matches the unread-filter logic in useSessionCategories so visibleSessions (used for
-	// jump badges + Alt+Cmd+N shortcuts) stays in sync with the Left Bar's rendered list.
-	const passesUnreadFilter = useCallback(
-		(session: Session): boolean => {
-			if (!showUnreadAgentsOnly) return true;
-			const isActiveOrParentOfActive =
-				session.id === activeSessionId ||
-				childrenByParentId.get(session.id)?.some((child) => child.id === activeSessionId) ||
-				false;
-			if (isActiveOrParentOfActive) return true;
-			const hasUnread = session.aiTabs?.some((tab) => tab.hasUnread) ?? false;
-			const isBusy = session.state === 'busy';
-			const children = childrenByParentId.get(session.id);
-			const hasUnreadChildren =
-				children?.some(
-					(child) => child.aiTabs?.some((tab) => tab.hasUnread) || child.state === 'busy'
-				) ?? false;
-			return hasUnread || isBusy || hasUnreadChildren;
-		},
-		[showUnreadAgentsOnly, activeSessionId, childrenByParentId]
+	return useMemo(
+		() =>
+			computeSortedSessions({
+				sessions,
+				groups,
+				bookmarksCollapsed,
+				showUnreadAgentsOnly,
+				activeSessionId,
+			}),
+		[sessions, groups, bookmarksCollapsed, showUnreadAgentsOnly, activeSessionId]
 	);
-
-	// Create visible sessions array for session jump shortcuts (Opt+Cmd+NUMBER)
-	// Order: Bookmarked sessions first (if bookmarks folder expanded), then groups/ungrouped
-	// Note: A session can appear twice if it's both bookmarked and in an expanded group
-	// Note: Worktree children are excluded - they don't display jump numbers and shouldn't consume slots
-	const visibleSessions = useMemo(() => {
-		const result: Session[] = [];
-
-		// Add bookmarked sessions first (if bookmarks folder is expanded)
-		// Exclude worktree children (they don't show jump numbers)
-		if (!bookmarksCollapsed) {
-			const bookmarkedSessions = sessions
-				.filter((s) => s.bookmarked && !s.parentSessionId && passesUnreadFilter(s))
-				.sort((a, b) => compareNamesIgnoringEmojis(a.name, b.name));
-			result.push(...bookmarkedSessions);
-		}
-
-		// Add sessions from expanded groups and ungrouped sessions
-		// Exclude worktree children (they don't show jump numbers)
-		// Use Map for O(1) group lookup instead of O(n) find()
-		const groupAndUngrouped = sortedSessions.filter((session) => {
-			// Exclude worktree children - they're nested under parent and don't show jump badges
-			if (session.parentSessionId) return false;
-			if (!passesUnreadFilter(session)) return false;
-			if (!session.groupId) return true; // Ungrouped sessions always visible
-			const group = groupsById.get(session.groupId);
-			return group && !group.collapsed; // Only show if group is expanded
-		});
-		result.push(...groupAndUngrouped);
-
-		return result;
-	}, [sortedSessions, groupsById, sessions, bookmarksCollapsed, passesUnreadFilter]);
-
-	return {
-		sortedSessions,
-		visibleSessions,
-		navSessions,
-		bookmarkNavSize,
-		navIndexMap,
-	};
 }

--- a/src/renderer/stores/sidebarNavStore.ts
+++ b/src/renderer/stores/sidebarNavStore.ts
@@ -1,0 +1,130 @@
+/**
+ * sidebarNavStore - Left Bar sort/nav/starred projections shared by SessionList
+ * and keyboard cycle/nav.
+ *
+ * A sync host (`SidebarNavSync`) owns the subscriptions and writes here so
+ * MaestroConsoleInner does not re-run useSortedSessions / useStarredItems on
+ * every shell wake. Consumers subscribe narrowly or read getState() at event time.
+ */
+
+import { create } from 'zustand';
+import type { Session } from '../types';
+import type { StarredItem } from '../hooks/session/useStarredItems';
+import { useGroupChatStore } from './groupChatStore';
+import { useSessionStore, updateSessionWith } from './sessionStore';
+import { notifyStarredSessionsChanged } from '../utils/starredSessions';
+
+export type JumpToStarredSessionFn = (
+	agentId: string,
+	projectPath: string,
+	agentSessionId: string,
+	sessionName: string,
+	parentSessionId: string
+) => Promise<boolean>;
+
+export type ShowConfirmationFn = (message: string, onConfirm: () => void | Promise<void>) => void;
+
+export interface SidebarNavStoreState {
+	sortedSessions: Session[];
+	visibleSessions: Session[];
+	navSessions: Session[];
+	bookmarkNavSize: number;
+	navIndexMap: Map<string, number>;
+	starredItems: StarredItem[];
+	/** Injected by App once jump/confirm handlers exist. */
+	onJumpToStarredSession: JumpToStarredSessionFn | null;
+	showConfirmation: ShowConfirmationFn | null;
+}
+
+export interface SidebarNavStoreActions {
+	setSortedProjection: (projection: {
+		sortedSessions: Session[];
+		visibleSessions: Session[];
+		navSessions: Session[];
+		bookmarkNavSize: number;
+		navIndexMap: Map<string, number>;
+	}) => void;
+	setStarredItems: (items: StarredItem[]) => void;
+	registerStarredHandlers: (handlers: {
+		onJumpToStarredSession?: JumpToStarredSessionFn;
+		showConfirmation?: ShowConfirmationFn;
+	}) => void;
+	activateStarredItem: (item: StarredItem) => Promise<void>;
+}
+
+export type SidebarNavStore = SidebarNavStoreState & SidebarNavStoreActions;
+
+const EMPTY_MAP = new Map<string, number>();
+
+export const useSidebarNavStore = create<SidebarNavStore>()((set, get) => ({
+	sortedSessions: [],
+	visibleSessions: [],
+	navSessions: [],
+	bookmarkNavSize: 0,
+	navIndexMap: EMPTY_MAP,
+	starredItems: [],
+	onJumpToStarredSession: null,
+	showConfirmation: null,
+
+	setSortedProjection: (projection) => set(projection),
+
+	setStarredItems: (items) => set({ starredItems: items }),
+
+	registerStarredHandlers: (handlers) =>
+		set({
+			onJumpToStarredSession: handlers.onJumpToStarredSession ?? get().onJumpToStarredSession,
+			showConfirmation: handlers.showConfirmation ?? get().showConfirmation,
+		}),
+
+	activateStarredItem: async (item) => {
+		// Same activation path as useStarredItems so cycle/nav can call
+		// getState().activateStarredItem without holding a React callback.
+		useGroupChatStore.getState().setActiveGroupChatId(null);
+		useSessionStore.getState().setActiveSessionId(item.parentSessionId);
+		if (item.kind === 'open') {
+			updateSessionWith(item.parentSessionId, (s) => ({
+				...s,
+				activeTabId: item.tabId,
+				activeFileTabId: null,
+				activeTerminalTabId: null,
+				activeBrowserTabId: null,
+				inputMode: 'ai',
+			}));
+			return;
+		}
+
+		const { onJumpToStarredSession, showConfirmation } = get();
+		const opened = await onJumpToStarredSession?.(
+			item.agentId,
+			item.projectPath,
+			item.agentSessionId,
+			item.sessionName,
+			item.parentSessionId
+		);
+		if (opened === false) {
+			showConfirmation?.(
+				`"${item.sessionName}" is no longer available. It has aged out and its conversation could not be loaded. Remove the star?`,
+				async () => {
+					await window.maestro.agentSessions.setSessionStarred(
+						item.agentId,
+						item.projectPath,
+						item.agentSessionId,
+						false
+					);
+					set({
+						starredItems: get().starredItems.filter(
+							(s) =>
+								!(
+									s.kind === 'closed' &&
+									s.agentId === item.agentId &&
+									s.agentSessionId === item.agentSessionId &&
+									s.projectPath === item.projectPath
+								)
+						),
+					});
+					notifyStarredSessionsChanged();
+				}
+			);
+		}
+	},
+}));


### PR DESCRIPTION
- Move Left Bar sorted/nav/starred projections into `sidebarNavStore`, owned by `SidebarNavSync`, so App no longer mounts `useSortedSessions` / `useStarredItems` or subscribes to `sessionsForSidebar`.
- SessionList, cycle, and keyboard nav read the store (or getState at event time) instead of App prop plumbing.
- Stop `useSessionFilterMode` from subscribing to the full `sessions` array (restores the Left Bar streaming shield).
- Stabilize `deleteSession` and drop unused `onJumpToStarredSession` props so SessionList `memo` is not busted by App handler churn.
- Add `seedSidebarNav` test helper for SessionList / Auto Run harnesses.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized left sidebar session sorting, visibility, navigation ordering, and starred-session activation for more consistent behavior.
  * Added unread-only filtering that keeps the active session (and its related worktrees) visible.
  * Improved keyboard navigation and session cycling using the sidebar’s current state.
* **Bug Fixes**
  * Reduced unnecessary UI updates by syncing sidebar state without relying on App-level props/subscriptions.
  * Improved delete-session modal wiring and filter-state handling.
* **Documentation**
  * Updated state-management guidance for the sidebar navigation store.
* **Tests**
  * Extended and rewired integration/component tests to seed and reset the new sidebar navigation state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->