### PR TITLE
test: reduce unit suite scheduling overhead

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,13 @@ jobs:
       - run: npm run lint # TypeScript type checking
 
   test:
+    name: Test (${{ matrix.os }}, shard ${{ matrix.shard }}/2)
     strategy:
       # Run the suite on both platforms; don't cancel one when the other fails.
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
+        shard: [1, 2]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
@@ -34,4 +36,4 @@ jobs:
           node-version: '22'
           cache: 'npm'
       - run: npm ci
-      - run: npm run test
+      - run: npm run test -- --shard=${{ matrix.shard }}/2

--- a/src/__tests__/maestro-p/jsonl-tailer.test.ts
+++ b/src/__tests__/maestro-p/jsonl-tailer.test.ts
@@ -5,13 +5,12 @@
  * `entry` / `parse-error` events.
  *
  * Strategy: drive against real temp files with `fs.mkdtempSync` for
- * isolation and a 10ms poll interval for snappy assertions. No fake timers
- * - the tailer's contract is about real filesystem behavior, and these
- * tests should fail if cross-platform fs semantics change in an
- * incompatible way.
+ * isolation and a 10ms poll interval for snappy assertions. Tests retain
+ * real filesystem I/O; schedule-only polling and backoff waits use fake
+ * timers so their timing does not dominate the suite.
  */
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -105,10 +104,15 @@ describe('JsonlTailer', () => {
 		it('ignores pre-existing content', async () => {
 			const { tailer, filePath, entries } = makeHarness('skip.jsonl', { skipExisting: true });
 			fs.writeFileSync(filePath, '{"i":1}\n{"i":2}\n');
-			await tailer.start();
-			// Give the poller several ticks to confirm nothing leaks through.
-			await sleep(FAST_POLL_MS * 5);
-			expect(entries).toEqual([]);
+			vi.useFakeTimers();
+			try {
+				await tailer.start();
+				// Drive several scheduler ticks to confirm nothing leaks through.
+				await vi.advanceTimersByTimeAsync(FAST_POLL_MS * 5);
+				expect(entries).toEqual([]);
+			} finally {
+				vi.useRealTimers();
+			}
 		});
 
 		it('emits only entries appended after start()', async () => {
@@ -158,12 +162,16 @@ describe('JsonlTailer', () => {
 		it('skips empty lines silently (no entries, no parse-errors)', async () => {
 			const { tailer, filePath, entries, parseErrors } = makeHarness('empties.jsonl');
 			fs.writeFileSync(filePath, '\n\n{"present":true}\n\n');
-			await tailer.start();
-			await waitUntil(() => entries.length === 1);
-			// Let any erroneous trailing-empty emissions land before snapshotting.
-			await sleep(FAST_POLL_MS * 3);
-			expect(entries).toEqual([{ present: true }]);
-			expect(parseErrors).toEqual([]);
+			vi.useFakeTimers();
+			try {
+				await tailer.start();
+				// Let scheduler ticks process the real file and expose any erroneous trailing empties.
+				await vi.advanceTimersByTimeAsync(FAST_POLL_MS * 3);
+				expect(entries).toEqual([{ present: true }]);
+				expect(parseErrors).toEqual([]);
+			} finally {
+				vi.useRealTimers();
+			}
 		});
 	});
 
@@ -202,7 +210,14 @@ describe('JsonlTailer', () => {
 				existsTimeoutMs: 100,
 			});
 			activeTailer = tailer;
-			await expect(tailer.start()).rejects.toThrow(/did not appear/);
+			vi.useFakeTimers();
+			try {
+				const rejection = expect(tailer.start()).rejects.toThrow(/did not appear/);
+				await vi.advanceTimersByTimeAsync(175);
+				await rejection;
+			} finally {
+				vi.useRealTimers();
+			}
 		});
 	});
 
@@ -210,16 +225,21 @@ describe('JsonlTailer', () => {
 		it('halts polling - no further events fire after stop(), even on new appends', async () => {
 			const { tailer, filePath, entries } = makeHarness('stop.jsonl');
 			fs.writeFileSync(filePath, '{"i":1}\n');
-			await tailer.start();
-			await waitUntil(() => entries.length === 1);
+			vi.useFakeTimers();
+			try {
+				await tailer.start();
+				await vi.advanceTimersByTimeAsync(FAST_POLL_MS);
+				expect(entries).toEqual([{ i: 1 }]);
 
-			tailer.stop();
-			const snapshotCount = entries.length;
-			fs.appendFileSync(filePath, '{"i":2}\n{"i":3}\n');
-			// Wait several poll cycles to be confident the stopped tailer
-			// genuinely never picks the appends up.
-			await sleep(FAST_POLL_MS * 8);
-			expect(entries.length).toBe(snapshotCount);
+				tailer.stop();
+				const snapshotCount = entries.length;
+				fs.appendFileSync(filePath, '{"i":2}\n{"i":3}\n');
+				// Drive several poll cycles to prove the stopped tailer ignores the append.
+				await vi.advanceTimersByTimeAsync(FAST_POLL_MS * 8);
+				expect(entries.length).toBe(snapshotCount);
+			} finally {
+				vi.useRealTimers();
+			}
 		});
 	});
 
@@ -248,10 +268,15 @@ describe('JsonlTailer', () => {
 		it('does not advance when no new bytes are read', async () => {
 			const { tailer, filePath } = makeHarness('idle.jsonl');
 			fs.writeFileSync(filePath, '');
-			await tailer.start();
-			const before = tailer.getLastByteAt();
-			await sleep(FAST_POLL_MS * 5);
-			expect(tailer.getLastByteAt()).toBe(before);
+			vi.useFakeTimers();
+			try {
+				await tailer.start();
+				const before = tailer.getLastByteAt();
+				await vi.advanceTimersByTimeAsync(FAST_POLL_MS * 5);
+				expect(tailer.getLastByteAt()).toBe(before);
+			} finally {
+				vi.useRealTimers();
+			}
 		});
 	});
 });

--- a/src/__tests__/maestro-p/session-watcher.test.ts
+++ b/src/__tests__/maestro-p/session-watcher.test.ts
@@ -6,14 +6,12 @@
  * whose creation time is at or after the recorded spawn timestamp.
  *
  * Strategy: drive against real temp directories with `fs.mkdtempSync`
- * for isolation and a small poll interval for snappy assertions. No
- * fake timers - the watcher's contract is fundamentally about real
- * filesystem behavior (birthtime, readdir, ENOENT recovery), and these
- * tests should fail if cross-platform fs semantics change in an
- * incompatible way.
+ * for isolation and a small poll interval for snappy assertions. Terminal
+ * timeout cases fake only scheduler time; positive filesystem behavior keeps
+ * native timers so birthtime, readdir, and ENOENT recovery stay exercised.
  */
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -207,16 +205,23 @@ describe('session-watcher', () => {
 			const spawnTimestamp = Date.now();
 			// A different session shows up, but never the expected one.
 			writeJsonl('some-other-id');
-			await expect(
-				discoverSessionId({
-					configDir,
-					cwd,
-					spawnTimestamp,
-					expectSessionId: 'never-written-id',
-					timeoutMs: 250,
-					pollIntervalMs: FAST_POLL_MS,
-				})
-			).rejects.toThrow(/never-written-id\.jsonl did not appear/);
+			vi.useFakeTimers();
+			try {
+				const rejection = expect(
+					discoverSessionId({
+						configDir,
+						cwd,
+						spawnTimestamp,
+						expectSessionId: 'never-written-id',
+						timeoutMs: 250,
+						pollIntervalMs: FAST_POLL_MS,
+					})
+				).rejects.toThrow(/never-written-id\.jsonl did not appear/);
+				await vi.advanceTimersByTimeAsync(250);
+				await rejection;
+			} finally {
+				vi.useRealTimers();
+			}
 		});
 
 		it('tolerates the projects dir not existing yet - picks up the file once it appears', async () => {
@@ -282,15 +287,22 @@ describe('session-watcher', () => {
 
 		it('rejects with a descriptive error when no file appears within the timeout', async () => {
 			const spawnTimestamp = Date.now();
-			await expect(
-				discoverSessionId({
-					configDir,
-					cwd,
-					spawnTimestamp,
-					timeoutMs: 100,
-					pollIntervalMs: FAST_POLL_MS,
-				})
-			).rejects.toThrow(/no new \.jsonl appeared/);
+			vi.useFakeTimers();
+			try {
+				const rejection = expect(
+					discoverSessionId({
+						configDir,
+						cwd,
+						spawnTimestamp,
+						timeoutMs: 100,
+						pollIntervalMs: FAST_POLL_MS,
+					})
+				).rejects.toThrow(/no new \.jsonl appeared/);
+				await vi.advanceTimersByTimeAsync(100);
+				await rejection;
+			} finally {
+				vi.useRealTimers();
+			}
 		});
 
 		it('rejects when only pre-spawn files exist (i.e., none satisfy the timestamp filter)', async () => {
@@ -298,15 +310,22 @@ describe('session-watcher', () => {
 			writeJsonl('stale-session');
 			await sleep(20);
 			const spawnTimestamp = Date.now();
-			await expect(
-				discoverSessionId({
-					configDir,
-					cwd,
-					spawnTimestamp,
-					timeoutMs: 100,
-					pollIntervalMs: FAST_POLL_MS,
-				})
-			).rejects.toThrow(/no new \.jsonl appeared/);
+			vi.useFakeTimers();
+			try {
+				const rejection = expect(
+					discoverSessionId({
+						configDir,
+						cwd,
+						spawnTimestamp,
+						timeoutMs: 100,
+						pollIntervalMs: FAST_POLL_MS,
+					})
+				).rejects.toThrow(/no new \.jsonl appeared/);
+				await vi.advanceTimersByTimeAsync(100);
+				await rejection;
+			} finally {
+				vi.useRealTimers();
+			}
 		});
 
 		it('builds the watch path from configDir + projects/ + cwdSlug(cwd)', async () => {
@@ -317,31 +336,40 @@ describe('session-watcher', () => {
 			await sleep(5);
 			fs.writeFileSync(path.join(otherSlugDir, 'wrong-session.jsonl'), '');
 
-			await expect(
-				discoverSessionId({
-					configDir,
-					cwd,
-					spawnTimestamp,
-					timeoutMs: 100,
-					pollIntervalMs: FAST_POLL_MS,
-				})
-			).rejects.toThrow(/no new \.jsonl appeared/);
-
-			// And the error mentions the correct (expected) directory.
-			let caught: Error | null = null;
+			vi.useFakeTimers();
 			try {
-				await discoverSessionId({
+				const wrongPathRejection = expect(
+					discoverSessionId({
+						configDir,
+						cwd,
+						spawnTimestamp,
+						timeoutMs: 100,
+						pollIntervalMs: FAST_POLL_MS,
+					})
+				).rejects.toThrow(/no new \.jsonl appeared/);
+				await vi.advanceTimersByTimeAsync(100);
+				await wrongPathRejection;
+
+				// And the error mentions the correct (expected) directory.
+				let caught: Error | null = null;
+				const expectedPathRejection = discoverSessionId({
 					configDir,
 					cwd,
 					spawnTimestamp,
 					timeoutMs: 50,
 					pollIntervalMs: FAST_POLL_MS,
 				});
-			} catch (err) {
-				caught = err as Error;
+				await vi.advanceTimersByTimeAsync(50);
+				try {
+					await expectedPathRejection;
+				} catch (err) {
+					caught = err as Error;
+				}
+				expect(caught).not.toBeNull();
+				expect(caught!.message).toContain(expectedSlug);
+			} finally {
+				vi.useRealTimers();
 			}
-			expect(caught).not.toBeNull();
-			expect(caught!.message).toContain(expectedSlug);
 		});
 	});
 });

--- a/src/__tests__/maestro-p/session-watcher.test.ts
+++ b/src/__tests__/maestro-p/session-watcher.test.ts
@@ -29,6 +29,23 @@ async function sleep(ms: number): Promise<void> {
 	await new Promise<void>((resolve) => setTimeout(resolve, ms));
 }
 
+function expectDiscoveryRejection(
+	promise: Promise<unknown>,
+	message: RegExp | string
+): Promise<void> {
+	return promise.then(
+		() => {
+			throw new Error('Expected session discovery to reject');
+		},
+		(error: unknown) => {
+			expect(error).toBeInstanceOf(Error);
+			if (error instanceof Error) {
+				expect(error.message).toMatch(message);
+			}
+		}
+	);
+}
+
 describe('session-watcher', () => {
 	let tempDir: string;
 	let configDir: string;
@@ -207,16 +224,18 @@ describe('session-watcher', () => {
 			writeJsonl('some-other-id');
 			vi.useFakeTimers();
 			try {
-				const rejection = expect(
-					discoverSessionId({
-						configDir,
-						cwd,
-						spawnTimestamp,
-						expectSessionId: 'never-written-id',
-						timeoutMs: 250,
-						pollIntervalMs: FAST_POLL_MS,
-					})
-				).rejects.toThrow(/never-written-id\.jsonl did not appear/);
+				const discoveryPromise = discoverSessionId({
+					configDir,
+					cwd,
+					spawnTimestamp,
+					expectSessionId: 'never-written-id',
+					timeoutMs: 250,
+					pollIntervalMs: FAST_POLL_MS,
+				});
+				const rejection = expectDiscoveryRejection(
+					discoveryPromise,
+					/never-written-id\.jsonl did not appear/
+				);
 				await vi.advanceTimersByTimeAsync(250);
 				await rejection;
 			} finally {
@@ -289,15 +308,14 @@ describe('session-watcher', () => {
 			const spawnTimestamp = Date.now();
 			vi.useFakeTimers();
 			try {
-				const rejection = expect(
-					discoverSessionId({
-						configDir,
-						cwd,
-						spawnTimestamp,
-						timeoutMs: 100,
-						pollIntervalMs: FAST_POLL_MS,
-					})
-				).rejects.toThrow(/no new \.jsonl appeared/);
+				const discoveryPromise = discoverSessionId({
+					configDir,
+					cwd,
+					spawnTimestamp,
+					timeoutMs: 100,
+					pollIntervalMs: FAST_POLL_MS,
+				});
+				const rejection = expectDiscoveryRejection(discoveryPromise, /no new \.jsonl appeared/);
 				await vi.advanceTimersByTimeAsync(100);
 				await rejection;
 			} finally {
@@ -312,15 +330,14 @@ describe('session-watcher', () => {
 			const spawnTimestamp = Date.now();
 			vi.useFakeTimers();
 			try {
-				const rejection = expect(
-					discoverSessionId({
-						configDir,
-						cwd,
-						spawnTimestamp,
-						timeoutMs: 100,
-						pollIntervalMs: FAST_POLL_MS,
-					})
-				).rejects.toThrow(/no new \.jsonl appeared/);
+				const discoveryPromise = discoverSessionId({
+					configDir,
+					cwd,
+					spawnTimestamp,
+					timeoutMs: 100,
+					pollIntervalMs: FAST_POLL_MS,
+				});
+				const rejection = expectDiscoveryRejection(discoveryPromise, /no new \.jsonl appeared/);
 				await vi.advanceTimersByTimeAsync(100);
 				await rejection;
 			} finally {
@@ -338,35 +355,31 @@ describe('session-watcher', () => {
 
 			vi.useFakeTimers();
 			try {
-				const wrongPathRejection = expect(
-					discoverSessionId({
-						configDir,
-						cwd,
-						spawnTimestamp,
-						timeoutMs: 100,
-						pollIntervalMs: FAST_POLL_MS,
-					})
-				).rejects.toThrow(/no new \.jsonl appeared/);
+				const wrongPathPromise = discoverSessionId({
+					configDir,
+					cwd,
+					spawnTimestamp,
+					timeoutMs: 100,
+					pollIntervalMs: FAST_POLL_MS,
+				});
+				const wrongPathRejection = expectDiscoveryRejection(
+					wrongPathPromise,
+					/no new \.jsonl appeared/
+				);
 				await vi.advanceTimersByTimeAsync(100);
 				await wrongPathRejection;
 
 				// And the error mentions the correct (expected) directory.
-				let caught: Error | null = null;
-				const expectedPathRejection = discoverSessionId({
+				const expectedPathPromise = discoverSessionId({
 					configDir,
 					cwd,
 					spawnTimestamp,
 					timeoutMs: 50,
 					pollIntervalMs: FAST_POLL_MS,
 				});
+				const expectedPathRejection = expectDiscoveryRejection(expectedPathPromise, expectedSlug);
 				await vi.advanceTimersByTimeAsync(50);
-				try {
-					await expectedPathRejection;
-				} catch (err) {
-					caught = err as Error;
-				}
-				expect(caught).not.toBeNull();
-				expect(caught!.message).toContain(expectedSlug);
+				await expectedPathRejection;
 			} finally {
 				vi.useRealTimers();
 			}

--- a/src/__tests__/main/process-manager.test.ts
+++ b/src/__tests__/main/process-manager.test.ts
@@ -12,6 +12,16 @@ vi.mock('node-pty', () => ({
 	spawn: vi.fn(),
 }));
 
+const { mockExecFile, mockExecFileSync } = vi.hoisted(() => ({
+	mockExecFile: vi.fn(),
+	mockExecFileSync: vi.fn(),
+}));
+
+vi.mock('child_process', async (importOriginal) => {
+	const actual = await importOriginal();
+	return { ...actual, execFile: mockExecFile, execFileSync: mockExecFileSync };
+});
+
 // Mock logger to avoid any side effects
 vi.mock('../../main/utils/logger', () => ({
 	logger: {
@@ -34,6 +44,7 @@ vi.mock('../../shared/platformDetection', () => ({
 }));
 
 import * as fs from 'fs';
+import { logger } from '../../main/utils/logger';
 
 import {
 	aggregateModelUsage,
@@ -368,6 +379,8 @@ describe('process-manager.ts', () => {
 
 		beforeEach(() => {
 			processManager = new ProcessManager();
+			mockExecFile.mockClear();
+			mockExecFileSync.mockClear();
 		});
 
 		describe('error detection exports', () => {
@@ -591,6 +604,33 @@ describe('process-manager.ts', () => {
 
 				expect(killWindowsTreeSpy).toHaveBeenCalledWith(12345, 'pty-session', false);
 				expect(mockPtyProcess.kill).not.toHaveBeenCalled();
+
+				killWindowsTreeSpy.mockRestore();
+				const error = new Error('taskkill failed');
+				mockExecFile.mockImplementationOnce(
+					(_command: string, _arguments: string[], callback: (callbackError: Error) => void) =>
+						callback(error)
+				);
+				// The private helper is the behavior selected by the public Windows kill path.
+				const managerWithPrivateKill = processManager as unknown as {
+					killWindowsProcessTree: (pid: number, sessionId: string, sync?: boolean) => void;
+				};
+				expect(() =>
+					managerWithPrivateKill.killWindowsProcessTree(12345, 'async-session')
+				).not.toThrow();
+				expect(mockExecFile).toHaveBeenCalledWith(
+					'taskkill',
+					['/pid', '12345', '/t', '/f'],
+					expect.any(Function)
+				);
+				expect(logger.debug).toHaveBeenCalledWith(
+					'[ProcessManager] taskkill exited with error (process may already be terminated)',
+					'ProcessManager',
+					{ sessionId: 'async-session', pid: 12345, error: String(error) }
+				);
+				killWindowsTreeSpy = vi
+					.spyOn(ProcessManager.prototype as never, 'killWindowsProcessTree' as never)
+					.mockImplementation(() => {});
 			});
 
 			it('should use SIGTERM for PTY processes on non-Windows', () => {
@@ -741,6 +781,10 @@ describe('process-manager.ts', () => {
 
 				expect(kills).toEqual(expect.arrayContaining(['a', 'b', 'c']));
 				expect(kills).toHaveLength(3);
+				expect(mockExecFileSync).toHaveBeenCalledTimes(3);
+				expect(mockExecFileSync).toHaveBeenCalledWith('taskkill', ['/pid', '1', '/t', '/f'], {
+					timeout: 5000,
+				});
 			});
 
 			it('should pass sync: true to kill() so Windows taskkill blocks until complete', () => {
@@ -767,6 +811,9 @@ describe('process-manager.ts', () => {
 				processManager.killAll();
 
 				expect(killSpy).toHaveBeenCalledWith('sync-test', { sync: true, shutdown: false });
+				expect(mockExecFileSync).toHaveBeenCalledWith('taskkill', ['/pid', '1', '/t', '/f'], {
+					timeout: 5000,
+				});
 				killSpy.mockRestore();
 			});
 

--- a/src/__tests__/main/process-manager.test.ts
+++ b/src/__tests__/main/process-manager.test.ts
@@ -750,6 +750,7 @@ describe('process-manager.ts', () => {
 			});
 
 			it('should kill all processes even when kill() deletes from the map', () => {
+				mockIsWindows.mockReturnValue(true);
 				const kills: string[] = [];
 				const originalKill = processManager.kill.bind(processManager);
 				processManager.kill = (sessionId: string, opts?: { sync?: boolean }) => {
@@ -788,6 +789,7 @@ describe('process-manager.ts', () => {
 			});
 
 			it('should pass sync: true to kill() so Windows taskkill blocks until complete', () => {
+				mockIsWindows.mockReturnValue(true);
 				const killSpy = vi.spyOn(processManager, 'kill');
 
 				const processes = (processManager as any).processes as Map<string, any>;
@@ -849,6 +851,8 @@ describe('process-manager.ts', () => {
 				expect(mockPtyKill).toHaveBeenCalledTimes(1);
 				expect(mockPtyKill).toHaveBeenCalledWith('SIGKILL');
 				expect(mockOnExit).not.toHaveBeenCalled();
+				expect(mockExecFile).not.toHaveBeenCalled();
+				expect(mockExecFileSync).not.toHaveBeenCalled();
 			});
 		});
 	});

--- a/src/__tests__/shared/pathUtils.test.ts
+++ b/src/__tests__/shared/pathUtils.test.ts
@@ -256,7 +256,8 @@ describe('buildExpandedPath', () => {
 		it('should prepend detected Node version manager bin paths', () => {
 			process.env.PATH = '/usr/bin';
 			const originalNvmDir = process.env.NVM_DIR;
-			const tempNvmDir = fs.mkdtempSync(path.join(os.tmpdir(), 'maestro-nvm-'));
+			const realTempParent = fs.realpathSync(process.env.TEMP ?? process.env.TMP ?? process.cwd());
+			const tempNvmDir = fs.mkdtempSync(path.join(realTempParent, 'maestro-nvm-'));
 			process.env.NVM_DIR = tempNvmDir;
 			fs.mkdirSync(path.join(tempNvmDir, 'current', 'bin'), { recursive: true });
 			fs.mkdirSync(path.join(tempNvmDir, 'versions', 'node', 'v22.10.0', 'bin'), {

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -41,7 +41,6 @@ export default defineConfig({
 		// one process can segfault the whole run.
 		pool: 'forks',
 		maxWorkers: 4,
-		setupFiles: ['./src/__tests__/setup.ts'],
 		testTimeout: 10000,
 		hookTimeout: 10000,
 		teardownTimeout: 5000,
@@ -54,6 +53,7 @@ export default defineConfig({
 				test: {
 					name: 'jsdom',
 					environment: 'jsdom',
+					setupFiles: ['./src/__tests__/setup.ts'],
 					// NOTE: stays on the forks pool. threads is ~19% faster here but
 					// intermittently SEGFAULTS the run (native addons loaded from
 					// multiple worker threads in one process are not context-aware).


### PR DESCRIPTION
## Summary

- split the complete Vitest suite into two concurrent shards on both Ubuntu and Windows
- scope heavyweight renderer setup to the jsdom Vitest project
- mock Windows taskkill boundaries instead of launching real processes in unit tests
- drive terminal session-watcher and JSONL scheduler waits with deterministic fake time
- repair two hidden test-order dependencies exposed by sharding

No production files changed. Local `bun run test` and `npm run test` remain unsharded; the extra shard processes exist only on separate GitHub-hosted runners.

## Focused verification

- process-manager: 44 passed; median test phase 2330ms to 20ms
- session-watcher: 18 passed; median test phase 910.5ms to 299.5ms
- jsonl-tailer: 15 passed; median test phase 630.5ms to 237.5ms
- representative node preload suite: 19 passed with setup 0ms
- pathUtils: 46 passed in three consecutive focused runs
- `bunx tsc -p tsconfig.lint.json --noEmit` passed

## Shard completeness

Actual Ubuntu run totals prove the shard partition is complete and non-overlapping by aggregate count:

| Metric | Shard 1/2 | Shard 2/2 | Sum | Unsharded |
|---|---:|---:|---:|---:|
| Test files total | 688 | 688 | 1,376 | 1,376 |
| Test files passed | 688 | 687 | 1,375 | 1,375 |
| Test files skipped | 0 | 1 | 1 | 1 |
| Tests passed | 17,469 | 16,691 | 34,160 | 34,160 |
| Tests skipped | 40 | 69 | 109 | 109 |
| Tests total | 17,509 | 16,760 | 34,269 | 34,269 |
| Failed | 0 | 0 | 0 | 0 |

## Actual CI performance

Unsharded optimized run [#29612324048](https://github.com/RunMaestro/Maestro/actions/runs/29612324048): Ubuntu 11m21s test step, Windows 21m53s.

Sharded run [#29617783627](https://github.com/RunMaestro/Maestro/actions/runs/29617783627) passed twice in full on Ubuntu and Windows, plus lint/format.

| Platform | Unsharded test step | Sharded critical test step, attempt 1 | Attempt 2 | Median reduction |
|---|---:|---:|---:|---:|
| Ubuntu | 11m21s | 5m51s | 5m58s | 48.0% |
| Windows | 21m53s | 10m38s | 11m48s | 48.7% |

End-to-end test-job readiness, including duplicated checkout/install:

| Platform | Unsharded | Sharded attempt 1 | Attempt 2 | Median reduction |
|---|---:|---:|---:|---:|
| Ubuntu | 12m00s | 6m32s | 6m33s | 45.6% |
| Windows | 24m25s | 12m42s | 14m11s | 44.9% |

Sharding increases aggregate hosted runner minutes because checkout/install run twice. It does not increase local developer process count.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by replacing timing-dependent waits with controlled virtual timers.
  * Expanded coverage for session discovery timeouts, file polling, Windows process termination, and shutdown behavior.
  * Improved cross-platform temporary directory handling.

* **Chores**
  * CI tests now run in parallel across operating systems and test shards.
  * Restricted browser-specific test setup to browser-based test suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->