### PR TITLE
feat(thinking): open live Thought Stream from the status pill (#1231)

### DIFF
--- a/src/__tests__/renderer/components/ThinkingStatusPill.test.tsx
+++ b/src/__tests__/renderer/components/ThinkingStatusPill.test.tsx
@@ -15,6 +15,8 @@ import React from 'react';
 import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ThinkingStatusPill } from '../../../renderer/components/ThinkingStatusPill';
+import { useThoughtStreamStore } from '../../../renderer/stores/thoughtStreamStore';
+import { useUIStore } from '../../../renderer/stores/uiStore';
 import type { Session, Theme, BatchRunState, AITab, ThinkingItem } from '../../../renderer/types';
 import { createMockAITab as createBaseMockAITab } from '../../helpers/mockTab';
 import { createMockSession } from '../../helpers/mockSession';
@@ -321,6 +323,57 @@ describe('ThinkingStatusPill', () => {
 			fireEvent.click(claudeIdButton);
 
 			expect(onSessionClick).toHaveBeenCalledWith('session-abc', 'tab-999');
+		});
+	});
+
+	// Clicking the (previously inert) status pill opens the live Thought Stream for that
+	// session and un-collapses the Right Panel it's docked in - the "zoom in and see what
+	// the agent is doing" affordance requested in #1231.
+	describe('thought stream integration', () => {
+		beforeEach(() => {
+			useThoughtStreamStore.setState({
+				panelSessionId: null,
+				minimized: false,
+				buffers: {},
+				capturing: {},
+			});
+			useUIStore.setState({ rightPanelOpen: false });
+		});
+
+		it('opens the thought stream for the primary session when the task name is clicked', () => {
+			const item = createThinkingItem({
+				id: 'session-xyz',
+				name: 'Live Agent',
+				agentSessionId: 'claude-789',
+			});
+			render(<ThinkingStatusPill thinkingItems={[item]} theme={mockTheme} />);
+
+			// agentSessionId 'claude-789' -> displayClaudeId 'CLAUDE-7'
+			fireEvent.click(screen.getByText('CLAUDE-7'));
+
+			const streamState = useThoughtStreamStore.getState();
+			expect(streamState.panelSessionId).toBe('session-xyz');
+			expect(streamState.capturing['session-xyz']).toBe(true);
+			// Panel is docked in the Right Panel, so opening it must also reveal that panel.
+			expect(useUIStore.getState().rightPanelOpen).toBe(true);
+		});
+
+		it('opens the thought stream for a session picked from the dropdown', () => {
+			const items = [
+				createThinkingItem({ id: 'sess-1', name: 'Primary' }),
+				createThinkingItem({ id: 'sess-2', name: 'Secondary' }),
+			];
+			render(<ThinkingStatusPill thinkingItems={items} theme={mockTheme} />);
+
+			fireEvent.mouseEnter(screen.getByText('+1').parentElement!);
+			const secondaryRow = screen
+				.getAllByRole('button')
+				.find((row) => row.textContent?.includes('Secondary'));
+			expect(secondaryRow).toBeDefined();
+			fireEvent.click(secondaryRow!);
+
+			expect(useThoughtStreamStore.getState().panelSessionId).toBe('sess-2');
+			expect(useUIStore.getState().rightPanelOpen).toBe(true);
 		});
 	});
 

--- a/src/renderer/components/ThinkingStatusPill.tsx
+++ b/src/renderer/components/ThinkingStatusPill.tsx
@@ -9,6 +9,25 @@ import { memo, useState, useEffect, useRef } from 'react';
 import { GitBranch } from 'lucide-react';
 import type { Session, Theme, AITab, BatchRunState, ThinkingItem } from '../types';
 import { formatTokensCompact } from '../utils/formatters';
+import { useThoughtStreamStore } from '../stores/thoughtStreamStore';
+import { useUIStore } from '../stores/uiStore';
+
+/**
+ * Open the live Thought Stream for a session and make sure it's visible.
+ *
+ * The Thought Stream is docked inside the Right Panel and renders nothing while
+ * that panel is collapsed (see ThoughtStreamPanel), so we open the Right Panel
+ * too. Capture itself is session-agnostic (useThoughtStreamCaptureListener taps
+ * the raw thinking stream for any owned session), so this works for a regular
+ * interactive "thinking" session, not just an Auto Run - it's what turns the
+ * previously inert status pill into a "zoom in and see what the agent is doing"
+ * affordance. Uses getState() so wiring a click handler doesn't add a store
+ * subscription to the memoized pill.
+ */
+function openThoughtStreamForSession(sessionId: string): void {
+	useUIStore.getState().setRightPanelOpen(true);
+	useThoughtStreamStore.getState().openPanel(sessionId);
+}
 
 interface ThinkingStatusPillProps {
 	/** Pre-filtered flat list of (session, tab) pairs — one entry per busy tab across all agents.
@@ -121,7 +140,10 @@ const ThinkingItemRow = memo(
 
 		return (
 			<button
-				onClick={() => onSessionClick?.(session.id, tab?.id)}
+				onClick={() => {
+					onSessionClick?.(session.id, tab?.id);
+					openThoughtStreamForSession(session.id);
+				}}
 				className="flex items-center justify-between gap-3 w-full px-3 py-2 text-left hover:bg-white/5 transition-colors"
 				style={{ color: theme.colors.textMain }}
 			>
@@ -671,10 +693,17 @@ function ThinkingStatusPillInner({
 					<div className="pill-seg-claude-id flex items-center gap-2 min-w-0">
 						<div className="w-px h-4 shrink-0" style={{ backgroundColor: theme.colors.border }} />
 						<button
-							onClick={() => onSessionClick?.(primarySession.id, primaryTab?.id)}
+							onClick={() => {
+								onSessionClick?.(primarySession.id, primaryTab?.id);
+								openThoughtStreamForSession(primarySession.id);
+							}}
 							className="text-xs font-mono hover:underline cursor-pointer truncate min-w-0"
 							style={{ color: theme.colors.accent }}
-							title={agentSessionId ? `Claude Session: ${agentSessionId}` : 'Claude Session'}
+							title={
+								agentSessionId
+									? `View live thoughts · Claude Session: ${agentSessionId}`
+									: 'View live thoughts'
+							}
 						>
 							{displayClaudeId}
 						</button>


### PR DESCRIPTION
## Summary

Addresses the core ask in #1231: give the user a way to "zoom in and see what the agent is actually doing" during a long-running "thinking" task.

The status pill above the input renders the session/tab name as a `<button>` styled to look clickable (`cursor-pointer`, `hover:underline`), but its click only re-focused the already-active session, so in the common case it did nothing - exactly the "looks and acts like a clickable element but doesn't do anything" the reporter described.

## What this does

- Wires that pill button (and the `+N` "running processes" dropdown rows) to open the **live Thought Stream** for that session.
- The Thought Stream taps the raw thinking stream and shows, in real time, what the agent is reasoning about - a live "replicate what you see in the terminal" view.
- Opening it also un-collapses the Right Panel it docks in (the panel renders nothing while that panel is collapsed).

## Why this was low-risk

The Thought Stream capture pipeline (`useThoughtStreamCaptureListener`) is already session-agnostic and mounted app-wide - it just resolves interactive `-ai-{tabId}` stream IDs to the base session. The only prior entry point was the Auto Run card, so interactive sessions had no way in. This reuses that infrastructure rather than adding a new one.

## Not covered here

This is a focused first step. The issue also mentions a count of background shell commands / running tool calls and "almost done thinking" style status text - those would be follow-ups; this PR deliberately keeps scope to making the inert-looking pill actually reveal live activity.

## Testing

- Added tests covering the new open-on-click behavior (primary pill + dropdown row) in `ThinkingStatusPill.test.tsx`.
- `ThinkingStatusPill` suite: 93 passing.
- `tsc --noEmit` and ESLint clean on changed files.

Closes #1231


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Clicking the Thinking Status Pill now opens the live Thought Stream for the selected session.
  * Selecting a session from the dropdown opens its live thoughts and expands the Right Panel.
  * Updated tooltips clarify that session controls let you view live thoughts.

* **Tests**
  * Added coverage for Thought Stream and Right Panel behavior when selecting sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->