### PR TITLE
fix(group-chat): stop moderator auto-add from reverting participant removal

### DIFF
--- a/src/__tests__/main/group-chat/group-chat-router.test.ts
+++ b/src/__tests__/main/group-chat/group-chat-router.test.ts
@@ -89,6 +89,7 @@ import {
 } from '../../../main/group-chat/group-chat-moderator';
 import {
 	addParticipant,
+	removeParticipant,
 	clearAllParticipantSessionsGlobal,
 } from '../../../main/group-chat/group-chat-agent';
 import {
@@ -828,6 +829,49 @@ describe('group-chat-router', () => {
 					name: 'CIA Agent (Super Cool)',
 				}),
 			]);
+		});
+
+		it('does not re-add a participant the user just removed (issue #1100)', async () => {
+			// Regression: a moderator turn that finishes after the user removes a
+			// participant must not resurrect them via an @mention. This is the
+			// large-group-chat "removal does not persist" bug.
+			const chat = await createTestChatWithModerator('Removed Participant Guard Test');
+			await addParticipant(chat.id, 'Client', 'claude-code', mockProcessManager);
+			setGetSessionsCallback(() => [
+				{
+					id: 'session-client',
+					name: 'Client',
+					toolType: 'claude-code',
+					cwd: '/tmp/project',
+				},
+			]);
+
+			await removeParticipant(chat.id, 'Client', mockProcessManager);
+
+			// Moderator output mentions the just-removed participant.
+			await routeModeratorResponse(
+				chat.id,
+				'@Client: keep working on the login form',
+				mockProcessManager,
+				mockAgentDetector
+			);
+
+			const updatedChat = await loadGroupChat(chat.id);
+			expect(updatedChat?.participants.map((p) => p.name)).not.toContain('Client');
+		});
+
+		it('clears the removal guard when the user explicitly re-adds the participant', async () => {
+			// The guard must not permanently suppress a participant: an explicit
+			// re-add restores them, and only a fresh removal re-arms the guard.
+			const chat = await createTestChatWithModerator('Removed Participant Reset Test');
+			await addParticipant(chat.id, 'Client', 'claude-code', mockProcessManager);
+
+			await removeParticipant(chat.id, 'Client', mockProcessManager);
+			// Explicit re-add clears the guard and restores the participant.
+			await addParticipant(chat.id, 'Client', 'claude-code', mockProcessManager);
+
+			const updatedChat = await loadGroupChat(chat.id);
+			expect(updatedChat?.participants.map((p) => p.name)).toContain('Client');
 		});
 
 		it('auto-adds a stronger-matching session despite a weak existing participant alias', async () => {

--- a/src/main/group-chat/group-chat-agent.ts
+++ b/src/main/group-chat/group-chat-agent.ts
@@ -39,6 +39,38 @@ function getParticipantKey(groupChatId: string, participantName: string): string
 }
 
 /**
+ * Participants the user has explicitly removed this session, keyed like
+ * activeParticipantSessions. The moderator's turn-completion handler auto-adds
+ * any @mentioned session that isn't currently a participant. Without this
+ * guard, a moderator turn that was already in flight when the user removed a
+ * participant would re-add them the moment it finished (and its output almost
+ * always @mentions that participant), silently reverting the removal on disk.
+ * The race window is wider the larger the chat - long moderator turns and a
+ * removed participant that is more likely to be mentioned - which is why the
+ * removal appeared not to persist in large group chats (issue #1100). The
+ * entry is cleared once the participant is added back through any path.
+ */
+const recentlyRemovedParticipants = new Set<string>();
+
+/**
+ * Record that the user explicitly removed a participant so an in-flight or
+ * subsequent moderator turn cannot auto-add them before the user re-adds them.
+ */
+export function markParticipantRemoved(groupChatId: string, participantName: string): void {
+	recentlyRemovedParticipants.add(getParticipantKey(groupChatId, participantName));
+}
+
+/**
+ * Whether the user explicitly removed this participant and has not re-added them.
+ */
+export function wasParticipantRecentlyRemoved(
+	groupChatId: string,
+	participantName: string
+): boolean {
+	return recentlyRemovedParticipants.has(getParticipantKey(groupChatId, participantName));
+}
+
+/**
  * Generate the system prompt for a participant.
  * Uses template from src/prompts/group-chat-participant.md
  */
@@ -137,6 +169,11 @@ export async function addParticipant(
 
 	// Add participant to the group chat
 	await addParticipantToChat(groupChatId, participant);
+	// The participant is a member again, so drop any removal guard. This keeps
+	// the guard from going stale and lets an explicit re-add (or a user @mention)
+	// override an earlier removal. The moderator auto-add path checks the guard
+	// before it ever reaches here, so this cannot defeat that block.
+	recentlyRemovedParticipants.delete(getParticipantKey(groupChatId, name));
 	logger.debug(`[GroupChat:Debug] Participant added to chat storage`);
 	logger.debug(`[GroupChat:Debug] =====================================`);
 
@@ -238,7 +275,11 @@ export async function removeParticipant(
 	// Preserve the idempotent "chat-missing is a no-op" contract rather than
 	// leaking that race to IPC callers.
 	try {
-		return await removeParticipantFromChatWithResult(groupChatId, participantName);
+		const result = await removeParticipantFromChatWithResult(groupChatId, participantName);
+		// Guard against the moderator's turn-completion auto-add re-adding this
+		// participant before the user re-adds them (issue #1100).
+		markParticipantRemoved(groupChatId, participantName);
+		return result;
 	} catch (error) {
 		if (error instanceof Error && error.message === `Group chat not found: ${groupChatId}`) {
 			return null;

--- a/src/main/group-chat/group-chat-router.ts
+++ b/src/main/group-chat/group-chat-router.ts
@@ -39,6 +39,7 @@ import {
 	addParticipant,
 	setActiveParticipantSession,
 	clearActiveParticipantSession,
+	wasParticipantRecentlyRemoved,
 } from './group-chat-agent';
 import { AgentDetector } from '../agents';
 import { powerManager } from '../power-manager';
@@ -1105,6 +1106,16 @@ export async function routeModeratorResponse(
 			);
 
 			if (matchingSession) {
+				// Respect an explicit user removal: a moderator turn that was in
+				// flight when the user removed this participant (or any later turn)
+				// must not silently re-add them via an @mention (issue #1100). The
+				// guard clears once the user re-adds the participant.
+				if (wasParticipantRecentlyRemoved(groupChatId, matchingSession.name)) {
+					logger.debug(
+						`[GroupChatRouter] Skipping auto-add of @${matchingSession.name}: recently removed by user`
+					);
+					continue;
+				}
 				try {
 					// Use the original session name as the participant name
 					const participantName = matchingSession.name;


### PR DESCRIPTION
closes #1100

## Problem

Removing a participant from a **large** group chat appeared not to persist: the UI confirmed the removal, but the participant returned after refreshing the app. It worked correctly in small chats, and the failure correlated with group size / conversation volume.

## Root cause

This is a re-add race, not a persistence failure. The removal write itself is robust (atomic write + per-chat serialized write queue, and message history lives in separate files so the participant-list payload stays tiny regardless of chat size).

The culprit is auto-add on moderator turn completion. When the moderator finishes a turn, `routeModeratorResponse` extracts every `@mention` from its output and auto-adds any mentioned session that isn't currently a participant. If a participant is removed while a moderator turn is in flight, that turn's completion re-adds them and rewrites `metadata.json` with the participant restored, so after a refresh they reappear.

Why it correlates with size:

1. **Wider race window** - a larger chat means a larger moderator context, so moderator turns run longer and a removal is far more likely to land *during* an in-flight turn. Small chats finish turns quickly, so removals land cleanly between turns.
2. **More likely to be mentioned** - with extensive history the removed participant is part of the ongoing thread, so the moderator's output routinely `@mentions` them, reliably re-triggering auto-add.

## Fix

Record explicit user removals in a small in-memory guard (`recentlyRemovedParticipants`, keyed by group-chat id + participant name). The moderator auto-add path checks the guard and skips a name the user just removed. The guard is cleared whenever the participant is added back through any path, so:

- an explicit re-add (or a user `@mention`) still works, and
- the guard can't go stale (a name that is a current participant is never in the guard).

The user-message auto-add path is intentionally left untouched - a user typing `@Name` is explicit intent to bring them in, and that path clears the guard.

## Tests

Adds two regression tests in `group-chat-router.test.ts`:
- a moderator turn that `@mentions` a just-removed participant does **not** re-add them, and
- an explicit re-add clears the guard and restores the participant.

All 90 router tests and 28 agent tests pass; `npm run lint` is clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented participants who were recently removed from being automatically re-added by later moderator messages.
  * Ensured participants can be added again after the user explicitly re-adds them.
  * Improved group chat behavior when participant removal overlaps with an in-progress moderator response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->