### PR TITLE
Fix Codex Desktop path rotation

### DIFF
--- a/src/__tests__/cli/services/agent-spawner.test.ts
+++ b/src/__tests__/cli/services/agent-spawner.test.ts
@@ -73,6 +73,7 @@ vi.mock('fs', async () => {
 			...actual.promises,
 			stat: vi.fn(),
 			access: vi.fn(),
+			readdir: vi.fn(),
 		},
 		constants: {
 			X_OK: 1,
@@ -742,6 +743,57 @@ Some text with [x] in it that's not a checkbox
 			expect(result.available).toBe(true);
 			expect(result.path).toBe('/custom/path/to/codex');
 			expect(result.source).toBe('settings');
+		});
+
+		it('should resolve a rotated Codex Desktop path from settings', async () => {
+			const originalPlatform = process.platform;
+			const originalLocalAppData = process.env.LOCALAPPDATA;
+			Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+			process.env.LOCALAPPDATA = 'C:\\Users\\test\\AppData\\Local';
+			const stalePath = path.win32.join(
+				process.env.LOCALAPPDATA,
+				'OpenAI',
+				'Codex',
+				'bin',
+				'old-version',
+				'codex.exe'
+			);
+			const currentPath = path.win32.join(
+				process.env.LOCALAPPDATA,
+				'OpenAI',
+				'Codex',
+				'bin',
+				'current-version',
+				'codex.exe'
+			);
+			mockGetAgentCustomPath.mockReturnValue(stalePath);
+			vi.mocked(fs.promises.readdir).mockResolvedValue([
+				{ name: 'current-version', isDirectory: () => true },
+			] as any);
+			vi.mocked(fs.promises.stat).mockImplementation(async (filePath) => {
+				if (filePath === currentPath) {
+					return { isFile: () => true, mtimeMs: 200 } as fs.Stats;
+				}
+				throw new Error('ENOENT');
+			});
+
+			try {
+				const { detectAgent: freshDetectAgent } =
+					await import('../../../cli/services/agent-spawner');
+				const result = await freshDetectAgent('codex');
+
+				expect(result).toEqual({
+					available: true,
+					path: currentPath,
+					source: 'settings',
+				});
+			} finally {
+				process.env.LOCALAPPDATA = originalLocalAppData;
+				Object.defineProperty(process, 'platform', {
+					value: originalPlatform,
+					configurable: true,
+				});
+			}
 		});
 
 		it('should fall back to PATH detection when custom path is invalid', async () => {

--- a/src/__tests__/cli/services/agent-spawner.test.ts
+++ b/src/__tests__/cli/services/agent-spawner.test.ts
@@ -772,7 +772,7 @@ Some text with [x] in it that's not a checkbox
 			] as any);
 			vi.mocked(fs.promises.stat).mockImplementation(async (filePath) => {
 				if (filePath === currentPath) {
-					return { isFile: () => true, mtimeMs: 200 } as fs.Stats;
+					return { isFile: () => true, birthtimeMs: 200 } as fs.Stats;
 				}
 				throw new Error('ENOENT');
 			});
@@ -788,7 +788,11 @@ Some text with [x] in it that's not a checkbox
 					source: 'settings',
 				});
 			} finally {
-				process.env.LOCALAPPDATA = originalLocalAppData;
+				if (originalLocalAppData === undefined) {
+					delete process.env.LOCALAPPDATA;
+				} else {
+					process.env.LOCALAPPDATA = originalLocalAppData;
+				}
 				Object.defineProperty(process, 'platform', {
 					value: originalPlatform,
 					configurable: true,

--- a/src/__tests__/main/agents/detector.test.ts
+++ b/src/__tests__/main/agents/detector.test.ts
@@ -655,6 +655,7 @@ describe('agent-detector', () => {
 			const claude = agents.find((a) => a.id === 'claude-code');
 			expect(claude?.available).toBe(true);
 			expect(claude?.path).toBe('/usr/bin/claude');
+			expect(claude?.customPath).toBeUndefined();
 
 			expect(logger.warn).toHaveBeenCalledWith(
 				expect.stringContaining('custom path not valid'),

--- a/src/__tests__/main/agents/detector.test.ts
+++ b/src/__tests__/main/agents/detector.test.ts
@@ -680,7 +680,9 @@ describe('agent-detector', () => {
 		});
 
 		it('should log when falling back to PATH after invalid custom path', async () => {
-			vi.spyOn(fs.promises, 'stat').mockRejectedValue(new Error('ENOENT'));
+			vi.spyOn(fs.promises, 'stat').mockRejectedValue(
+				Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+			);
 			mockExecFileNoThrow.mockImplementation(async (cmd, args) => {
 				if (args[0] === 'claude') {
 					return { stdout: '/usr/bin/claude\n', stderr: '', exitCode: 0 };

--- a/src/__tests__/main/agents/path-prober.test.ts
+++ b/src/__tests__/main/agents/path-prober.test.ts
@@ -6,6 +6,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs';
+import * as path from 'path';
 
 // Mock dependencies before importing the module
 vi.mock('../../../main/utils/execFile', () => ({
@@ -216,6 +217,92 @@ describe('path-prober', () => {
 				Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
 			}
 		});
+
+		it('should recover a rotated Codex Desktop executable path', async () => {
+			const originalPlatform = process.platform;
+			const originalLocalAppData = process.env.LOCALAPPDATA;
+			const readdirMock = vi.spyOn(fs.promises, 'readdir');
+			Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+			process.env.LOCALAPPDATA = 'C:\\Users\\test\\AppData\\Local';
+
+			const stalePath = path.win32.join(
+				process.env.LOCALAPPDATA,
+				'OpenAI',
+				'Codex',
+				'bin',
+				'old-version',
+				'codex.exe'
+			);
+			const olderPath = path.win32.join(
+				process.env.LOCALAPPDATA,
+				'OpenAI',
+				'Codex',
+				'bin',
+				'older-version',
+				'codex.exe'
+			);
+			const currentPath = path.win32.join(
+				process.env.LOCALAPPDATA,
+				'OpenAI',
+				'Codex',
+				'bin',
+				'current-version',
+				'codex.exe'
+			);
+
+			try {
+				readdirMock.mockResolvedValue([
+					{ name: 'older-version', isDirectory: () => true },
+					{ name: 'current-version', isDirectory: () => true },
+				] as any);
+				statMock.mockImplementation(async (filePath) => {
+					if (filePath === stalePath) throw new Error('ENOENT');
+					if (filePath === olderPath) {
+						return { isFile: () => true, mtimeMs: 100 } as fs.Stats;
+					}
+					if (filePath === currentPath) {
+						return { isFile: () => true, mtimeMs: 200 } as fs.Stats;
+					}
+					throw new Error('ENOENT');
+				});
+
+				const result = await checkCustomPath(stalePath);
+				expect(result).toEqual({ exists: true, path: currentPath });
+				expect(logger.info).toHaveBeenCalledWith(
+					'Recovered rotated Codex Desktop path',
+					'PathProber',
+					expect.objectContaining({ original: stalePath, resolved: currentPath })
+				);
+			} finally {
+				readdirMock.mockRestore();
+				process.env.LOCALAPPDATA = originalLocalAppData;
+				Object.defineProperty(process, 'platform', {
+					value: originalPlatform,
+					configurable: true,
+				});
+			}
+		});
+
+		it('should not redirect an arbitrary missing custom path', async () => {
+			const originalPlatform = process.platform;
+			const readdirMock = vi.spyOn(fs.promises, 'readdir');
+			Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+
+			try {
+				statMock.mockRejectedValue(new Error('ENOENT'));
+
+				expect(await checkCustomPath('C:\\custom\\missing-codex.exe')).toEqual({
+					exists: false,
+				});
+				expect(readdirMock).not.toHaveBeenCalled();
+			} finally {
+				readdirMock.mockRestore();
+				Object.defineProperty(process, 'platform', {
+					value: originalPlatform,
+					configurable: true,
+				});
+			}
+		});
 	});
 
 	describe('probeWindowsPaths', () => {
@@ -252,6 +339,37 @@ describe('path-prober', () => {
 
 			expect(await probeWindowsPaths(binaryName)).toBeNull();
 			expect(accessMock).toHaveBeenCalled();
+		});
+
+		it('should probe the current Codex Desktop executable', async () => {
+			const originalLocalAppData = process.env.LOCALAPPDATA;
+			const readdirMock = vi.spyOn(fs.promises, 'readdir');
+			const statMock = vi.spyOn(fs.promises, 'stat');
+			process.env.LOCALAPPDATA = 'C:\\Users\\test\\AppData\\Local';
+			const currentPath = path.win32.join(
+				process.env.LOCALAPPDATA,
+				'OpenAI',
+				'Codex',
+				'bin',
+				'current-version',
+				'codex.exe'
+			);
+
+			try {
+				readdirMock.mockResolvedValue([
+					{ name: 'current-version', isDirectory: () => true },
+				] as any);
+				statMock.mockResolvedValue({ isFile: () => true, mtimeMs: 200 } as fs.Stats);
+				accessMock.mockImplementation(async (filePath) => {
+					if (filePath !== currentPath) throw new Error('ENOENT');
+				});
+
+				expect(await probeWindowsPaths('codex')).toBe(currentPath);
+			} finally {
+				readdirMock.mockRestore();
+				statMock.mockRestore();
+				process.env.LOCALAPPDATA = originalLocalAppData;
+			}
 		});
 	});
 

--- a/src/__tests__/main/agents/path-prober.test.ts
+++ b/src/__tests__/main/agents/path-prober.test.ts
@@ -27,6 +27,10 @@ vi.mock('../../../shared/pathUtils', () => ({
 	detectNodeVersionManagerBinPaths: vi.fn(() => []),
 }));
 
+vi.mock('../../../main/utils/sentry', () => ({
+	captureException: vi.fn(),
+}));
+
 // Import after mocking
 import {
 	getExpandedEnv,
@@ -38,6 +42,7 @@ import {
 } from '../../../main/agents';
 import { execFileNoThrow } from '../../../main/utils/execFile';
 import { logger } from '../../../main/utils/logger';
+import { captureException } from '../../../main/utils/sentry';
 
 describe('path-prober', () => {
 	beforeEach(() => {
@@ -258,10 +263,10 @@ describe('path-prober', () => {
 				statMock.mockImplementation(async (filePath) => {
 					if (filePath === stalePath) throw new Error('ENOENT');
 					if (filePath === olderPath) {
-						return { isFile: () => true, mtimeMs: 100 } as fs.Stats;
+						return { isFile: () => true, birthtimeMs: 100, mtimeMs: 300 } as fs.Stats;
 					}
 					if (filePath === currentPath) {
-						return { isFile: () => true, mtimeMs: 200 } as fs.Stats;
+						return { isFile: () => true, birthtimeMs: 200, mtimeMs: 100 } as fs.Stats;
 					}
 					throw new Error('ENOENT');
 				});
@@ -275,7 +280,50 @@ describe('path-prober', () => {
 				);
 			} finally {
 				readdirMock.mockRestore();
-				process.env.LOCALAPPDATA = originalLocalAppData;
+				if (originalLocalAppData === undefined) {
+					delete process.env.LOCALAPPDATA;
+				} else {
+					process.env.LOCALAPPDATA = originalLocalAppData;
+				}
+				Object.defineProperty(process, 'platform', {
+					value: originalPlatform,
+					configurable: true,
+				});
+			}
+		});
+
+		it('should report unexpected errors while discovering Codex Desktop executables', async () => {
+			const originalPlatform = process.platform;
+			const originalLocalAppData = process.env.LOCALAPPDATA;
+			const readdirMock = vi.spyOn(fs.promises, 'readdir');
+			const permissionError = Object.assign(new Error('permission denied'), { code: 'EACCES' });
+			Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+			process.env.LOCALAPPDATA = 'C:\\Users\\test\\AppData\\Local';
+
+			const stalePath = path.win32.join(
+				process.env.LOCALAPPDATA,
+				'OpenAI',
+				'Codex',
+				'bin',
+				'old-version',
+				'codex.exe'
+			);
+
+			try {
+				readdirMock.mockResolvedValue([
+					{ name: 'current-version', isDirectory: () => true },
+				] as any);
+				statMock.mockRejectedValue(permissionError);
+
+				expect(await checkCustomPath(stalePath)).toEqual({ exists: false });
+				expect(captureException).toHaveBeenCalledWith(permissionError);
+			} finally {
+				readdirMock.mockRestore();
+				if (originalLocalAppData === undefined) {
+					delete process.env.LOCALAPPDATA;
+				} else {
+					process.env.LOCALAPPDATA = originalLocalAppData;
+				}
 				Object.defineProperty(process, 'platform', {
 					value: originalPlatform,
 					configurable: true,
@@ -359,7 +407,7 @@ describe('path-prober', () => {
 				readdirMock.mockResolvedValue([
 					{ name: 'current-version', isDirectory: () => true },
 				] as any);
-				statMock.mockResolvedValue({ isFile: () => true, mtimeMs: 200 } as fs.Stats);
+				statMock.mockResolvedValue({ isFile: () => true, birthtimeMs: 200 } as fs.Stats);
 				accessMock.mockImplementation(async (filePath) => {
 					if (filePath !== currentPath) throw new Error('ENOENT');
 				});
@@ -368,7 +416,11 @@ describe('path-prober', () => {
 			} finally {
 				readdirMock.mockRestore();
 				statMock.mockRestore();
-				process.env.LOCALAPPDATA = originalLocalAppData;
+				if (originalLocalAppData === undefined) {
+					delete process.env.LOCALAPPDATA;
+				} else {
+					process.env.LOCALAPPDATA = originalLocalAppData;
+				}
 			}
 		});
 	});

--- a/src/__tests__/main/ipc/handlers/process.test.ts
+++ b/src/__tests__/main/ipc/handlers/process.test.ts
@@ -20,6 +20,7 @@ import {
 } from '../../../../main/ipc/handlers/process';
 import { getDefaultShell } from '../../../../main/stores/defaults';
 import { stripThinkingFromTranscript } from '../../../../main/agents/claude-transcript-sanitizer';
+import { checkCustomPath } from '../../../../main/agents/path-prober';
 
 // Mock electron's ipcMain
 vi.mock('electron', () => ({
@@ -37,6 +38,10 @@ vi.mock('../../../../main/utils/logger', () => ({
 		error: vi.fn(),
 		debug: vi.fn(),
 	},
+}));
+
+vi.mock('../../../../main/agents/path-prober', () => ({
+	checkCustomPath: vi.fn(async (customPath: string) => ({ exists: true, path: customPath })),
 }));
 
 // Mock the agent-args utilities
@@ -281,6 +286,10 @@ describe('process IPC handlers', () => {
 	beforeEach(() => {
 		// Clear mocks
 		vi.clearAllMocks();
+		vi.mocked(checkCustomPath).mockImplementation(async (customPath) => ({
+			exists: true,
+			path: customPath,
+		}));
 
 		// Create mock process manager
 		mockProcessManager = {
@@ -593,6 +602,71 @@ describe('process IPC handlers', () => {
 			expect(mockProcessManager.spawn).toHaveBeenCalledWith(
 				expect.objectContaining({
 					command: '/home/user/my-claude-wrapper',
+				})
+			);
+		});
+
+		it('should resolve a rotated local custom path before spawning', async () => {
+			const mockAgent = {
+				id: 'codex',
+				name: 'Codex',
+				binaryName: 'codex',
+				path: '/detected/codex',
+				requiresPty: false,
+			};
+			mockAgentDetector.getAgent.mockResolvedValue(mockAgent);
+			mockProcessManager.spawn.mockReturnValue({ pid: 12345, success: true });
+			vi.mocked(checkCustomPath).mockResolvedValueOnce({
+				exists: true,
+				path: '/current/codex',
+			});
+
+			const handler = handlers.get('process:spawn');
+			await handler!({} as any, {
+				sessionId: 'session-rotated-path',
+				toolType: 'codex',
+				cwd: '/test/project',
+				command: '/detected/codex',
+				args: ['exec'],
+				sessionCustomPath: '/stale/codex',
+			});
+
+			expect(mockProcessManager.spawn).toHaveBeenCalledWith(
+				expect.objectContaining({
+					command: '/current/codex',
+					extraPathDirs: ['/current'],
+					sessionCustomPath: '/current/codex',
+				})
+			);
+		});
+
+		it('should fall back to the detected path when a local custom path is invalid', async () => {
+			const mockAgent = {
+				id: 'codex',
+				name: 'Codex',
+				binaryName: 'codex',
+				path: '/detected/codex',
+				requiresPty: false,
+			};
+			mockAgentDetector.getAgent.mockResolvedValue(mockAgent);
+			mockProcessManager.spawn.mockReturnValue({ pid: 12345, success: true });
+			vi.mocked(checkCustomPath).mockResolvedValueOnce({ exists: false });
+
+			const handler = handlers.get('process:spawn');
+			await handler!({} as any, {
+				sessionId: 'session-invalid-path',
+				toolType: 'codex',
+				cwd: '/test/project',
+				command: 'codex',
+				args: ['exec'],
+				sessionCustomPath: '/missing/codex',
+			});
+
+			expect(mockProcessManager.spawn).toHaveBeenCalledWith(
+				expect.objectContaining({
+					command: '/detected/codex',
+					extraPathDirs: ['/detected'],
+					sessionCustomPath: undefined,
 				})
 			);
 		});
@@ -2452,6 +2526,7 @@ describe('process IPC handlers', () => {
 			// Should use the custom path in the stdin script, not binaryName or local path
 			expect(spawnCall.sshStdinScript).toContain('/usr/local/bin/codex');
 			expect(spawnCall.sshStdinScript).not.toContain('/opt/homebrew/bin/codex');
+			expect(checkCustomPath).not.toHaveBeenCalled();
 		});
 
 		it('should pass images via stream-json stdin for SSH with stream-json agents (regression: images dropped over SSH)', async () => {

--- a/src/__tests__/renderer/components/NewInstanceModal.test.tsx
+++ b/src/__tests__/renderer/components/NewInstanceModal.test.tsx
@@ -1335,6 +1335,41 @@ describe('NewInstanceModal', () => {
 	});
 
 	describe('Custom agent paths', () => {
+		it('should prefer the validated local custom path over stale stored config', async () => {
+			vi.mocked(window.maestro.agents.detect).mockResolvedValue([
+				createAgentConfig({
+					id: 'codex',
+					name: 'Codex',
+					binaryName: 'codex',
+					path: '/detected/codex',
+					customPath: '/current/codex',
+				}),
+			]);
+			vi.mocked(window.maestro.agents.getConfig).mockResolvedValue({
+				customPath: '/stale/codex',
+			});
+
+			render(
+				<NewInstanceModal
+					isOpen={true}
+					onClose={onClose}
+					onCreate={onCreate}
+					theme={theme}
+					existingSessions={[]}
+				/>
+			);
+
+			await waitFor(() => {
+				expect(screen.getByText('Codex')).toBeInTheDocument();
+			});
+			fireEvent.click(screen.getByText('Codex'));
+
+			await waitFor(() => {
+				expect(screen.getByDisplayValue('/current/codex')).toBeInTheDocument();
+			});
+			expect(screen.queryByDisplayValue('/stale/codex')).not.toBeInTheDocument();
+		});
+
 		it('should display path input for Claude Code agent', async () => {
 			vi.mocked(window.maestro.agents.detect).mockResolvedValue([
 				createAgentConfig({ id: 'claude-code', name: 'Claude Code', available: true }),

--- a/src/cli/services/agent-spawner.ts
+++ b/src/cli/services/agent-spawner.ts
@@ -15,6 +15,7 @@ import { createOutputParser } from '../../main/parsers/parser-factory';
 import { aggregateModelUsage } from '../../main/parsers/usage-aggregator';
 import { getAgentDefinition } from '../../main/agents/definitions';
 import { hasCapability } from '../../main/agents/capabilities';
+import { checkCustomPath } from '../../main/agents/path-prober';
 import { getAgentCustomPath, readAgentConfig, readSshRemotes } from './storage';
 import { generateUUID } from '../../shared/uuid';
 import { sanitizeSessionId } from '../../shared/history';
@@ -290,25 +291,11 @@ function getExpandedPath(): string {
 }
 
 /**
- * Check if a file exists and is executable
+ * Resolve a configured executable path, including known rotating install locations.
  */
-async function isExecutable(filePath: string): Promise<boolean> {
-	try {
-		const stats = await fs.promises.stat(filePath);
-		if (!stats.isFile()) return false;
-
-		// On Unix, check executable permission
-		if (!isWindows()) {
-			try {
-				await fs.promises.access(filePath, fs.constants.X_OK);
-			} catch {
-				return false;
-			}
-		}
-		return true;
-	} catch {
-		return false;
-	}
+async function resolveExecutablePath(filePath: string): Promise<string | undefined> {
+	const detection = await checkCustomPath(filePath);
+	return detection.exists ? detection.path : undefined;
 }
 
 /**
@@ -356,9 +343,10 @@ export async function detectAgent(toolType: ToolType): Promise<DetectResult> {
 	// 1. Check for custom path in settings
 	const customPath = getAgentCustomPath(toolType);
 	if (customPath) {
-		if (await isExecutable(customPath)) {
-			cachedPaths.set(toolType, customPath);
-			return { available: true, path: customPath, source: 'settings' };
+		const resolvedCustomPath = await resolveExecutablePath(customPath);
+		if (resolvedCustomPath) {
+			cachedPaths.set(toolType, resolvedCustomPath);
+			return { available: true, path: resolvedCustomPath, source: 'settings' };
 		}
 		console.error(
 			`Warning: Custom ${def?.name || toolType} path "${customPath}" is not executable, falling back to PATH detection`

--- a/src/main/agents/detector.ts
+++ b/src/main/agents/detector.ts
@@ -154,11 +154,13 @@ export class AgentDetector {
 		for (const agentDef of AGENT_DEFINITIONS) {
 			const customPath = this.customPaths[agentDef.id];
 			let detection: { exists: boolean; path?: string };
+			let resolvedCustomPath: string | undefined;
 
 			// If user has specified a custom path, check that first
 			if (customPath) {
 				detection = await checkCustomPath(customPath);
 				if (detection.exists) {
+					resolvedCustomPath = detection.path || customPath;
 					logger.info(
 						`Agent "${agentDef.name}" found at custom path: ${detection.path}`,
 						LOG_CONTEXT
@@ -193,7 +195,7 @@ export class AgentDetector {
 				...agentDef,
 				available: detection.exists,
 				path: detection.path,
-				customPath: customPath || undefined,
+				customPath: resolvedCustomPath,
 				capabilities: getAgentCapabilities(agentDef.id),
 			});
 

--- a/src/main/agents/path-prober.ts
+++ b/src/main/agents/path-prober.ts
@@ -49,6 +49,11 @@ function isCodexDesktopBinaryPath(binaryPath: string): boolean {
 	);
 }
 
+function isMissingPathError(error: unknown): boolean {
+	const code = (error as NodeJS.ErrnoException | undefined)?.code;
+	return code === 'ENOENT' || code === 'ENOTDIR';
+}
+
 async function findLatestCodexDesktopBinary(): Promise<string | null> {
 	const binRoot = getCodexDesktopBinRoot();
 
@@ -61,9 +66,10 @@ async function findLatestCodexDesktopBinary(): Promise<string | null> {
 					const candidatePath = path.win32.join(binRoot, entry.name, 'codex.exe');
 					try {
 						const stats = await fs.promises.stat(candidatePath);
-						return stats.isFile() ? { path: candidatePath, modifiedAt: stats.mtimeMs } : null;
-					} catch {
-						return null;
+						return stats.isFile() ? { path: candidatePath, installedAt: stats.birthtimeMs } : null;
+					} catch (error) {
+						if (isMissingPathError(error)) return null;
+						throw error;
 					}
 				})
 		);
@@ -71,13 +77,14 @@ async function findLatestCodexDesktopBinary(): Promise<string | null> {
 		return (
 			candidates
 				.filter(
-					(candidate): candidate is { path: string; modifiedAt: number } => candidate !== null
+					(candidate): candidate is { path: string; installedAt: number } => candidate !== null
 				)
-				.sort((a, b) => b.modifiedAt - a.modifiedAt || b.path.localeCompare(a.path))[0]?.path ||
+				.sort((a, b) => b.installedAt - a.installedAt || b.path.localeCompare(a.path))[0]?.path ||
 			null
 		);
-	} catch {
-		return null;
+	} catch (error) {
+		if (isMissingPathError(error)) return null;
+		throw error;
 	}
 }
 

--- a/src/main/agents/path-prober.ts
+++ b/src/main/agents/path-prober.ts
@@ -33,6 +33,54 @@ export interface BinaryDetectionResult {
 	path?: string;
 }
 
+function getCodexDesktopBinRoot(): string {
+	const home = os.homedir();
+	const localAppData = process.env.LOCALAPPDATA || path.win32.join(home, 'AppData', 'Local');
+	return path.win32.join(localAppData, 'OpenAI', 'Codex', 'bin');
+}
+
+function isCodexDesktopBinaryPath(binaryPath: string): boolean {
+	const normalizedPath = path.win32.normalize(binaryPath);
+	const binRoot = path.win32.normalize(getCodexDesktopBinRoot());
+
+	return (
+		path.win32.basename(normalizedPath).toLowerCase() === 'codex.exe' &&
+		path.win32.dirname(path.win32.dirname(normalizedPath)).toLowerCase() === binRoot.toLowerCase()
+	);
+}
+
+async function findLatestCodexDesktopBinary(): Promise<string | null> {
+	const binRoot = getCodexDesktopBinRoot();
+
+	try {
+		const entries = await fs.promises.readdir(binRoot, { withFileTypes: true });
+		const candidates = await Promise.all(
+			entries
+				.filter((entry) => entry.isDirectory())
+				.map(async (entry) => {
+					const candidatePath = path.win32.join(binRoot, entry.name, 'codex.exe');
+					try {
+						const stats = await fs.promises.stat(candidatePath);
+						return stats.isFile() ? { path: candidatePath, modifiedAt: stats.mtimeMs } : null;
+					} catch {
+						return null;
+					}
+				})
+		);
+
+		return (
+			candidates
+				.filter(
+					(candidate): candidate is { path: string; modifiedAt: number } => candidate !== null
+				)
+				.sort((a, b) => b.modifiedAt - a.modifiedAt || b.path.localeCompare(a.path))[0]?.path ||
+			null
+		);
+	} catch {
+		return null;
+	}
+}
+
 // ============ Environment Expansion ============
 
 /**
@@ -245,6 +293,20 @@ export async function checkCustomPath(customPath: string): Promise<BinaryDetecti
 					return { exists: true, path: cmdPath };
 				}
 			}
+
+			// Codex Desktop rotates the version directory containing codex.exe on update.
+			// Recover only this known path shape so arbitrary missing overrides are not
+			// silently redirected to a different executable.
+			if (isCodexDesktopBinaryPath(expandedPath)) {
+				const currentCodexPath = await findLatestCodexDesktopBinary();
+				if (currentCodexPath) {
+					logger.info(`Recovered rotated Codex Desktop path`, LOG_CONTEXT, {
+						original: customPath,
+						resolved: currentCodexPath,
+					});
+					return { exists: true, path: currentCodexPath };
+				}
+			}
 		}
 
 		return { exists: false };
@@ -383,6 +445,12 @@ function getWindowsKnownPaths(binaryName: string): string[] {
  */
 export async function probeWindowsPaths(binaryName: string): Promise<string | null> {
 	const pathsToCheck = getWindowsKnownPaths(binaryName);
+	if (binaryName === 'codex') {
+		const codexDesktopPath = await findLatestCodexDesktopBinary();
+		if (codexDesktopPath) {
+			pathsToCheck.push(codexDesktopPath);
+		}
+	}
 
 	if (pathsToCheck.length === 0) {
 		return null;

--- a/src/main/ipc/handlers/process/handle-spawn.ts
+++ b/src/main/ipc/handlers/process/handle-spawn.ts
@@ -5,6 +5,7 @@ import * as fsp from 'fs/promises';
 import * as path from 'path';
 import { ProcessManager } from '../../../process-manager';
 import { AgentDetector } from '../../../agents';
+import { checkCustomPath } from '../../../agents/path-prober';
 import { resolveMaestroCliScriptPath } from '../../../cue/cue-cli-executor';
 import {
 	getActivePluginManager,
@@ -79,6 +80,27 @@ export async function handleProcessSpawn(
 
 	// Get agent definition to access config options and argument builders
 	const agent = await agentDetector.getAgent(config.toolType);
+	let invalidLocalCustomPath = false;
+	if (config.sessionCustomPath && !config.sessionSshRemoteConfig?.enabled) {
+		const requestedCustomPath = config.sessionCustomPath;
+		const detection = await checkCustomPath(requestedCustomPath);
+		if (detection.exists && detection.path) {
+			config = { ...config, sessionCustomPath: detection.path };
+			if (detection.path !== requestedCustomPath) {
+				logger.info(`Resolved updated local custom path for ${config.toolType}`, LOG_CONTEXT, {
+					requestedCustomPath,
+					resolvedCustomPath: detection.path,
+				});
+			}
+		} else {
+			invalidLocalCustomPath = true;
+			config = { ...config, sessionCustomPath: undefined };
+			logger.warn(`Ignoring invalid local custom path for ${config.toolType}`, LOG_CONTEXT, {
+				requestedCustomPath,
+				fallbackPath: agent?.path || config.command,
+			});
+		}
+	}
 	// Use INFO level on Windows for better visibility in logs
 
 	const logFn = isWindows() ? logger.info.bind(logger) : logger.debug.bind(logger);
@@ -598,7 +620,10 @@ export async function handleProcessSpawn(
 	// so PATH and other environment variables are available. This ensures cross-platform
 	// compatibility and correct agent behavior.
 	// ========================================================================
-	let commandToSpawn = config.sessionCustomPath || config.command;
+	let commandToSpawn =
+		config.sessionCustomPath ||
+		(invalidLocalCustomPath ? agent?.path : undefined) ||
+		config.command;
 	let argsToSpawn = finalArgs;
 	let useShell = false;
 	let sshRemoteUsed: SshRemoteConfig | null = null;

--- a/src/renderer/components/NewInstanceModal/NewInstanceModal.tsx
+++ b/src/renderer/components/NewInstanceModal/NewInstanceModal.tsx
@@ -224,8 +224,11 @@ export function NewInstanceModal({
 				configs[agent.id] = config;
 
 				// Extract per-agent settings from the loaded config
-				if (config.customPath) {
-					paths[agent.id] = config.customPath;
+				// Local detection validates and recovers rotating binary paths. SSH paths
+				// belong to the remote host and must not be validated against the local filesystem.
+				const customPath = sshRemoteId ? config.customPath : agent.customPath;
+				if (customPath) {
+					paths[agent.id] = customPath;
 				}
 				if (config.customArgs) {
 					args[agent.id] = config.customArgs;


### PR DESCRIPTION
## What changed

- Detects the newest valid Codex Desktop binary when its versioned install directory rotates.
- Resolves stored local custom paths through the shared path prober in desktop and CLI launch flows.
- Falls back to the detected agent path when a saved local override is invalid.
- Keeps SSH custom paths untouched because they belong to the remote host.
- Updates new-instance defaults to use the resolved local path.
- Adds coverage for path recovery, detector behavior, spawning, CLI detection, and modal defaults.

## Why

Codex Desktop updates rotate the version directory containing `codex.exe`. Maestro could retain the previous absolute path and then fail to detect or launch Codex even though the updated binary was installed normally.

## Impact

Existing Codex Desktop sessions recover automatically after an application update. Local launches use the current executable, while explicit remote SSH paths preserve their existing behavior.

## Root cause

Configured custom paths were treated as fixed executable locations. Detection and spawn paths validated only the stale file itself and did not recognize the known rotating Codex Desktop installation layout.

## Validation

- 5 focused Vitest suites passed.
- 435 tests passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows Codex Desktop detection by recovering from rotated version directories and successfully probing the current `codex.exe`.
  - Validated custom agent paths now resolve to the latest available executable when the original path is stale.
  - Invalid local custom paths are cleared and safely fall back to the detected agent command/path.
  - Agent configurations no longer retain invalid custom paths.
  - New instance setup now prefills the correct validated local path or keeps the configured remote SSH path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->