### PR TITLE
fix(cli): place Codex -C working-dir flag before exec subcommand

### DIFF
--- a/src/__tests__/cli/services/agent-spawner.test.ts
+++ b/src/__tests__/cli/services/agent-spawner.test.ts
@@ -2275,6 +2275,16 @@ Some text with [x] in it that's not a checkbox
 			// resume args are ['resume', '<id>']
 			expect(args).toContain('resume');
 			expect(args).toContain('codex-thread-123');
+
+			// Ordering is load-bearing: `-C` is a ROOT-level global flag that MUST
+			// precede the `exec` subcommand, which in turn precedes `resume <id>`.
+			// Placing `-C` after `resume` makes Codex hard-fail with
+			// "unexpected argument '-C' found", breaking Relay follow-up messages
+			// to Codex agents (regression of #960). Enforce -C < exec < resume.
+			const execIdx = args.indexOf('exec');
+			const resumeIdx = args.indexOf('resume');
+			expect(c).toBeLessThan(execIdx);
+			expect(execIdx).toBeLessThan(resumeIdx);
 		});
 
 		it('unsupported agent type returns a failure result', async () => {

--- a/src/cli/services/agent-spawner.ts
+++ b/src/cli/services/agent-spawner.ts
@@ -809,6 +809,18 @@ async function spawnJsonLineAgent(
 	// Build args from agent definition (without the prompt or model/customArgs —
 	// those come from applyAgentConfigOverrides via configOptions).
 	const preOverrideArgs: string[] = [];
+
+	// Codex requires `-C <dir>` as a ROOT-level global flag that MUST precede the
+	// `exec` subcommand (and therefore everything after it, including
+	// `resume <id>`). Placed later, Codex silently ignores it on fresh runs (#959)
+	// and HARD-FAILS on resume with "unexpected argument '-C' found", which broke
+	// Maestro Relay follow-up messages to Codex agents. Mirror the desktop path
+	// (`src/main/utils/agent-args.ts`), which prepends workingDirArgs before the
+	// batchModePrefix. See #960.
+	if (toolType === 'codex' && def?.workingDirArgs) {
+		preOverrideArgs.push(...def.workingDirArgs(cwd));
+	}
+
 	if (def?.batchModePrefix) preOverrideArgs.push(...def.batchModePrefix);
 
 	// In read-only mode, filter out YOLO/bypass args from batchModeArgs
@@ -829,11 +841,6 @@ async function spawnJsonLineAgent(
 
 	if (agentSessionId && def?.resumeArgs) {
 		preOverrideArgs.push(...def.resumeArgs(agentSessionId));
-	}
-
-	// Codex requires explicit working directory arg (other agents use process cwd)
-	if (toolType === 'codex' && def?.workingDirArgs) {
-		preOverrideArgs.push(...def.workingDirArgs(cwd));
 	}
 
 	// Native Additional Directories grants (e.g. `--add-dir`). Shares the exact


### PR DESCRIPTION
## Problem

`maestro-cli send` (and Maestro Relay follow-up messages) route Codex through `spawnJsonLineAgent` in `src/cli/services/agent-spawner.ts`. That function pushed `workingDirArgs` (`-C <dir>`) onto the arg list **last**, after the `exec` subcommand and after `resume <id>`:

```
codex exec --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check --json resume <id> -C <dir> -- "prompt"
```

Codex requires `-C` as a **root-level global flag** that must precede the `exec` subcommand. On a resume it lands after `resume <id>`, where the `resume` subcommand rejects it and Codex hard-fails:

```
error: unexpected argument '-C' found
```

This broke Relay follow-up messages to Codex agents. Fresh spawns tolerated the misplaced flag (though `exec` may silently ignore the cwd per #959); only the resume path crashed.

The desktop path (`src/main/utils/agent-args.ts`) already prepends `workingDirArgs` before the batch-mode prefix; only the CLI spawner diverged. This is a regression of #960, reintroduced during the additional-directories refactor.

## Fix

Move the Codex `workingDirArgs` push to the front of `preOverrideArgs`, before `batchModePrefix`. Final order is now `-C <dir> exec ... resume <id> -- "prompt"`, matching the desktop path.

## Verification

Reproduced against `codex-cli 0.142.5`:

- **Old order** (`... resume <id> -C <dir>`): `error: unexpected argument '-C' found` (matches the report).
- **New order** (`-C <dir> exec ... resume <id>`): clears argument parsing (fails only on a non-existent test session id, as expected).

Strengthened the existing spawner test to enforce the `-C < exec < resume` ordering invariant. The prior test only checked that `-C` was present, so it passed while the ordering was broken; the new assertion fails against the old ordering and passes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Codex working-directory handling by placing the directory option before the command and resume arguments.
  * Improved Codex startup and resume reliability when running from a specified working directory.
  * Added regression coverage to verify command-line argument ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->