### PR TITLE
feat(cli): dispatch backgrounds by default, add --focus opt-in

### DIFF
--- a/src/__tests__/cli/commands/dispatch.test.ts
+++ b/src/__tests__/cli/commands/dispatch.test.ts
@@ -204,6 +204,34 @@ describe('dispatch command', () => {
 				'new_ai_tab_with_prompt_result'
 			);
 		});
+
+		it('forwards tabId but omits background when --tab is combined with --focus', async () => {
+			vi.mocked(resolveAgentId).mockReturnValue('agent-abc-123');
+			const mockSendCommand = vi.fn().mockResolvedValue({
+				type: 'command_result',
+				success: true,
+				tabId: 'tab-xyz',
+			});
+			vi.mocked(withMaestroClient).mockImplementation(async (action) => {
+				const mockClient = { sendCommand: mockSendCommand };
+				return action(mockClient as never);
+			});
+
+			// The options.tab spread runs alongside the background omission; this
+			// covers that distinct payload-building path (tabId present, no background).
+			await dispatch('agent-abc', 'Follow up', { tab: 'tab-xyz', focus: true });
+
+			expect(mockSendCommand).toHaveBeenCalledWith(
+				{
+					type: 'send_command',
+					sessionId: 'agent-abc-123',
+					command: 'Follow up',
+					inputMode: 'ai',
+					tabId: 'tab-xyz',
+				},
+				'command_result'
+			);
+		});
 	});
 
 	describe('--tab <tabId> flow', () => {

--- a/src/__tests__/cli/commands/dispatch.test.ts
+++ b/src/__tests__/cli/commands/dispatch.test.ts
@@ -33,7 +33,7 @@ describe('dispatch command', () => {
 	});
 
 	describe('default (active tab) flow', () => {
-		it('sends send_command with no tabId and surfaces the desktop-supplied tabId', async () => {
+		it('sends send_command in the background by default (no tabId) and surfaces the desktop-supplied tabId', async () => {
 			vi.mocked(resolveAgentId).mockReturnValue('agent-abc-123');
 			const mockSendCommand = vi.fn().mockResolvedValue({
 				type: 'command_result',
@@ -53,6 +53,7 @@ describe('dispatch command', () => {
 					sessionId: 'agent-abc-123',
 					command: 'Hello world',
 					inputMode: 'ai',
+					background: true,
 				},
 				'command_result'
 			);
@@ -87,7 +88,7 @@ describe('dispatch command', () => {
 	});
 
 	describe('--new-tab flow', () => {
-		it('sends new_ai_tab_with_prompt and returns the freshly-created tabId', async () => {
+		it('sends new_ai_tab_with_prompt in the background by default and returns the freshly-created tabId', async () => {
 			vi.mocked(resolveAgentId).mockReturnValue('agent-abc-123');
 			const mockSendCommand = vi.fn().mockResolvedValue({
 				type: 'new_ai_tab_with_prompt_result',
@@ -106,6 +107,7 @@ describe('dispatch command', () => {
 					type: 'new_ai_tab_with_prompt',
 					sessionId: 'agent-abc-123',
 					prompt: 'Open a new conversation',
+					background: true,
 				},
 				'new_ai_tab_with_prompt_result'
 			);
@@ -152,6 +154,58 @@ describe('dispatch command', () => {
 		});
 	});
 
+	describe('--focus (foreground opt-in)', () => {
+		it('omits background from send_command when --focus is passed', async () => {
+			vi.mocked(resolveAgentId).mockReturnValue('agent-abc-123');
+			const mockSendCommand = vi.fn().mockResolvedValue({
+				type: 'command_result',
+				success: true,
+				tabId: 'tab-active-99',
+			});
+			vi.mocked(withMaestroClient).mockImplementation(async (action) => {
+				const mockClient = { sendCommand: mockSendCommand };
+				return action(mockClient as never);
+			});
+
+			// Commander sets `focus: true` when `--focus` is passed.
+			await dispatch('agent-abc', 'Hello world', { focus: true });
+
+			expect(mockSendCommand).toHaveBeenCalledWith(
+				{
+					type: 'send_command',
+					sessionId: 'agent-abc-123',
+					command: 'Hello world',
+					inputMode: 'ai',
+				},
+				'command_result'
+			);
+		});
+
+		it('omits background from new_ai_tab_with_prompt when --focus is combined with --new-tab', async () => {
+			vi.mocked(resolveAgentId).mockReturnValue('agent-abc-123');
+			const mockSendCommand = vi.fn().mockResolvedValue({
+				type: 'new_ai_tab_with_prompt_result',
+				success: true,
+				tabId: 'tab-fresh-42',
+			});
+			vi.mocked(withMaestroClient).mockImplementation(async (action) => {
+				const mockClient = { sendCommand: mockSendCommand };
+				return action(mockClient as never);
+			});
+
+			await dispatch('agent-abc', 'Open a new conversation', { newTab: true, focus: true });
+
+			expect(mockSendCommand).toHaveBeenCalledWith(
+				{
+					type: 'new_ai_tab_with_prompt',
+					sessionId: 'agent-abc-123',
+					prompt: 'Open a new conversation',
+				},
+				'new_ai_tab_with_prompt_result'
+			);
+		});
+	});
+
 	describe('--tab <tabId> flow', () => {
 		it('forwards the requested tabId in send_command so the desktop targets that tab', async () => {
 			vi.mocked(resolveAgentId).mockReturnValue('agent-abc-123');
@@ -174,6 +228,7 @@ describe('dispatch command', () => {
 					command: 'Follow up',
 					inputMode: 'ai',
 					tabId: 'tab-xyz',
+					background: true,
 				},
 				'command_result'
 			);
@@ -238,6 +293,7 @@ describe('dispatch command', () => {
 					command: 'Concurrent message',
 					inputMode: 'ai',
 					force: true,
+					background: true,
 				},
 				'command_result'
 			);

--- a/src/__tests__/main/preload/process.test.ts
+++ b/src/__tests__/main/preload/process.test.ts
@@ -307,7 +307,7 @@ describe('Process Preload API', () => {
 	});
 
 	describe('onRemoteCommand', () => {
-		it('should register listener and invoke callback with all parameters including tabId, force, and images', () => {
+		it('should register listener and invoke callback with all parameters including tabId, force, images, and background', () => {
 			const callback = vi.fn();
 			let registeredHandler: (
 				event: unknown,
@@ -316,7 +316,8 @@ describe('Process Preload API', () => {
 				inputMode?: 'ai' | 'terminal',
 				tabId?: string,
 				force?: boolean,
-				images?: string[]
+				images?: string[],
+				background?: boolean
 			) => void;
 
 			mockOn.mockImplementation((channel: string, handler: typeof registeredHandler) => {
@@ -327,7 +328,7 @@ describe('Process Preload API', () => {
 
 			api.onRemoteCommand(callback);
 			const images = ['data:image/png;base64,abc'];
-			registeredHandler!({}, 'session-123', 'test command', 'ai', 'tab-7', true, images);
+			registeredHandler!({}, 'session-123', 'test command', 'ai', 'tab-7', true, images, true);
 
 			expect(callback).toHaveBeenCalledWith(
 				'session-123',
@@ -335,11 +336,12 @@ describe('Process Preload API', () => {
 				'ai',
 				'tab-7',
 				true,
-				images
+				images,
+				true
 			);
 		});
 
-		it('forwards undefined tabId/force/images when the IPC sender omits them (legacy callers)', () => {
+		it('forwards undefined tabId/force/images/background when the IPC sender omits them (legacy callers)', () => {
 			const callback = vi.fn();
 			let registeredHandler: (
 				event: unknown,
@@ -348,7 +350,8 @@ describe('Process Preload API', () => {
 				inputMode?: 'ai' | 'terminal',
 				tabId?: string,
 				force?: boolean,
-				images?: string[]
+				images?: string[],
+				background?: boolean
 			) => void;
 
 			mockOn.mockImplementation((channel: string, handler: typeof registeredHandler) => {
@@ -364,6 +367,7 @@ describe('Process Preload API', () => {
 				'session-123',
 				'test command',
 				'ai',
+				undefined,
 				undefined,
 				undefined,
 				undefined

--- a/src/__tests__/main/web-server/handlers/messageHandlers.test.ts
+++ b/src/__tests__/main/web-server/handlers/messageHandlers.test.ts
@@ -292,7 +292,8 @@ describe('WebSocketMessageHandler', () => {
 					'ai',
 					undefined,
 					false,
-					undefined
+					undefined,
+					false
 				);
 			});
 
@@ -316,7 +317,8 @@ describe('WebSocketMessageHandler', () => {
 					'terminal',
 					undefined,
 					false,
-					undefined
+					undefined,
+					false
 				);
 			});
 		});
@@ -381,7 +383,8 @@ describe('WebSocketMessageHandler', () => {
 					'ai',
 					'tab-explicit',
 					false,
-					undefined
+					undefined,
+					false
 				);
 			});
 
@@ -411,7 +414,8 @@ describe('WebSocketMessageHandler', () => {
 					'ai',
 					undefined,
 					false,
-					images
+					images,
+					false
 				);
 			});
 
@@ -449,7 +453,8 @@ describe('WebSocketMessageHandler', () => {
 					'ai',
 					undefined,
 					false,
-					images
+					images,
+					false
 				);
 			});
 		});
@@ -472,13 +477,36 @@ describe('WebSocketMessageHandler', () => {
 					'ai',
 					undefined,
 					true,
-					undefined
+					undefined,
+					false
 				);
 			});
 
 			const response = JSON.parse((client.socket.send as any).mock.calls[0][0]);
 			expect(response.type).toBe('command_result');
 			expect(response.success).toBe(true);
+		});
+
+		it('forwards background=true to executeCommand (dispatch backgrounds by default)', async () => {
+			handler.handleMessage(client, {
+				type: 'send_command',
+				sessionId: 'session-1',
+				command: 'quietly',
+				inputMode: 'ai',
+				background: true,
+			});
+
+			await vi.waitFor(() => {
+				expect(callbacks.executeCommand).toHaveBeenCalledWith(
+					'session-1',
+					'quietly',
+					'ai',
+					undefined,
+					false,
+					undefined,
+					true
+				);
+			});
 		});
 
 		it('should reject command when session not found', () => {
@@ -1269,7 +1297,8 @@ describe('WebSocketMessageHandler', () => {
 			await vi.waitFor(() => {
 				expect(callbacks.newAITabWithPrompt).toHaveBeenCalledWith(
 					'session-1',
-					'Summarize the repo'
+					'Summarize the repo',
+					false
 				);
 			});
 
@@ -1280,6 +1309,23 @@ describe('WebSocketMessageHandler', () => {
 			// PR1: surface the freshly-created tabId so `dispatch --new-tab`
 			// can return an addressable id without owning a persistent channel.
 			expect(response.tabId).toBe('tab-mock-123');
+		});
+
+		it('forwards background=true to newAITabWithPrompt (dispatch --new-tab backgrounds by default)', async () => {
+			handler.handleMessage(client, {
+				type: 'new_ai_tab_with_prompt',
+				sessionId: 'session-1',
+				prompt: 'Summarize the repo',
+				background: true,
+			});
+
+			await vi.waitFor(() => {
+				expect(callbacks.newAITabWithPrompt).toHaveBeenCalledWith(
+					'session-1',
+					'Summarize the repo',
+					true
+				);
+			});
 		});
 
 		it('should reject missing sessionId', () => {

--- a/src/__tests__/main/web-server/managers/CallbackRegistry.test.ts
+++ b/src/__tests__/main/web-server/managers/CallbackRegistry.test.ts
@@ -373,6 +373,7 @@ describe('CallbackRegistry', () => {
 				undefined,
 				undefined,
 				undefined,
+				undefined,
 				undefined
 			);
 		});
@@ -387,6 +388,7 @@ describe('CallbackRegistry', () => {
 				'session-5',
 				'npm test',
 				'terminal',
+				undefined,
 				undefined,
 				undefined,
 				undefined
@@ -405,6 +407,7 @@ describe('CallbackRegistry', () => {
 				'ai',
 				undefined,
 				undefined,
+				undefined,
 				undefined
 			);
 		});
@@ -420,6 +423,7 @@ describe('CallbackRegistry', () => {
 				'follow up',
 				'ai',
 				'tab-xyz',
+				undefined,
 				undefined,
 				undefined
 			);
@@ -437,6 +441,7 @@ describe('CallbackRegistry', () => {
 				'ai',
 				undefined,
 				true,
+				undefined,
 				undefined
 			);
 		});
@@ -461,7 +466,8 @@ describe('CallbackRegistry', () => {
 				'ai',
 				undefined,
 				undefined,
-				images
+				images,
+				undefined
 			);
 		});
 	});

--- a/src/__tests__/main/web-server/web-server-factory.test.ts
+++ b/src/__tests__/main/web-server/web-server-factory.test.ts
@@ -694,6 +694,7 @@ describe('web-server/web-server-factory', () => {
 				'ai',
 				undefined,
 				undefined,
+				undefined,
 				undefined
 			);
 		});
@@ -714,6 +715,7 @@ describe('web-server/web-server-factory', () => {
 				'follow up',
 				'ai',
 				'tab-7',
+				undefined,
 				undefined,
 				undefined
 			);
@@ -736,6 +738,7 @@ describe('web-server/web-server-factory', () => {
 				'ai',
 				undefined,
 				true,
+				undefined,
 				undefined
 			);
 		});
@@ -765,7 +768,8 @@ describe('web-server/web-server-factory', () => {
 				'ai',
 				undefined,
 				undefined,
-				images
+				images,
+				undefined
 			);
 		});
 

--- a/src/__tests__/renderer/hooks/useRemoteIntegration.test.ts
+++ b/src/__tests__/renderer/hooks/useRemoteIntegration.test.ts
@@ -47,11 +47,14 @@ describe('useRemoteIntegration', () => {
 	let onRemoteNewTabHandler: ((sessionId: string, responseChannel: string) => void) | undefined;
 	let onRemoteCloseTabHandler: ((sessionId: string, tabId: string) => void) | undefined;
 	let onRemoteRenameTabHandler:
-		((sessionId: string, tabId: string, newName: string) => void) | undefined;
+		| ((sessionId: string, tabId: string, newName: string) => void)
+		| undefined;
 	let onRemoteStarTabHandler:
-		((sessionId: string, tabId: string, starred: boolean) => void) | undefined;
+		| ((sessionId: string, tabId: string, starred: boolean) => void)
+		| undefined;
 	let onRemoteReorderTabHandler:
-		((sessionId: string, fromIndex: number, toIndex: number) => void) | undefined;
+		| ((sessionId: string, fromIndex: number, toIndex: number) => void)
+		| undefined;
 	let onRemoteToggleBookmarkHandler: ((sessionId: string) => void) | undefined;
 	let onRemoteNewAITabWithPromptHandler:
 		| ((sessionId: string, prompt: string, responseChannel: string, background?: boolean) => void)

--- a/src/__tests__/renderer/hooks/useRemoteIntegration.test.ts
+++ b/src/__tests__/renderer/hooks/useRemoteIntegration.test.ts
@@ -30,7 +30,15 @@ describe('useRemoteIntegration', () => {
 	const originalMaestro = { ...window.maestro };
 
 	let onRemoteCommandHandler:
-		| ((sessionId: string, command: string, inputMode?: 'ai' | 'terminal') => void)
+		| ((
+				sessionId: string,
+				command: string,
+				inputMode?: 'ai' | 'terminal',
+				tabId?: string,
+				force?: boolean,
+				images?: string[],
+				background?: boolean
+		  ) => void)
 		| undefined;
 	let onRemoteSwitchModeHandler: ((sessionId: string, mode: 'ai' | 'terminal') => void) | undefined;
 	let onRemoteInterruptHandler: ((sessionId: string) => void) | undefined;
@@ -39,17 +47,14 @@ describe('useRemoteIntegration', () => {
 	let onRemoteNewTabHandler: ((sessionId: string, responseChannel: string) => void) | undefined;
 	let onRemoteCloseTabHandler: ((sessionId: string, tabId: string) => void) | undefined;
 	let onRemoteRenameTabHandler:
-		| ((sessionId: string, tabId: string, newName: string) => void)
-		| undefined;
+		((sessionId: string, tabId: string, newName: string) => void) | undefined;
 	let onRemoteStarTabHandler:
-		| ((sessionId: string, tabId: string, starred: boolean) => void)
-		| undefined;
+		((sessionId: string, tabId: string, starred: boolean) => void) | undefined;
 	let onRemoteReorderTabHandler:
-		| ((sessionId: string, fromIndex: number, toIndex: number) => void)
-		| undefined;
+		((sessionId: string, fromIndex: number, toIndex: number) => void) | undefined;
 	let onRemoteToggleBookmarkHandler: ((sessionId: string) => void) | undefined;
 	let onRemoteNewAITabWithPromptHandler:
-		| ((sessionId: string, prompt: string, responseChannel: string) => void)
+		| ((sessionId: string, prompt: string, responseChannel: string, background?: boolean) => void)
 		| undefined;
 	let onRemoteNotifyToastHandler:
 		| ((params: {
@@ -414,6 +419,38 @@ describe('useRemoteIntegration', () => {
 				expect.objectContaining({
 					type: 'maestro:remoteCommand',
 					detail: expect.objectContaining({ force: true }),
+				})
+			);
+
+			dispatchEventSpy.mockRestore();
+		});
+
+		it('does NOT switch the active session when background=true (background dispatch)', () => {
+			const session = createMockSession({ id: 'session-1', state: 'idle' });
+			const deps = createDeps({ sessions: [session], activeSessionId: 'other-session' });
+			const dispatchEventSpy = vi.spyOn(window, 'dispatchEvent');
+
+			renderHook(() => useRemoteIntegration(deps));
+
+			act(() => {
+				// (sessionId, command, inputMode, tabId, force, images, background)
+				onRemoteCommandHandler?.(
+					'session-1',
+					'quietly',
+					'ai',
+					undefined,
+					undefined,
+					undefined,
+					true
+				);
+			});
+
+			// Focus side effect suppressed, but the command still runs.
+			expect(deps.setActiveSessionId).not.toHaveBeenCalled();
+			expect(dispatchEventSpy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					type: 'maestro:remoteCommand',
+					detail: expect.objectContaining({ sessionId: 'session-1', command: 'quietly' }),
 				})
 			);
 
@@ -789,6 +826,44 @@ describe('useRemoteIntegration', () => {
 				'chan-busy',
 				false
 			);
+
+			dispatchEventSpy.mockRestore();
+		});
+
+		it('creates the tab in the background without focusing when background=true (background new-tab dispatch)', () => {
+			const session = createMockSession({ id: 'session-1', state: 'idle' });
+			const originalActiveTabId = session.activeTabId;
+			const originalTabCount = session.aiTabs.length;
+			const deps = createDeps({ sessions: [session], activeSessionId: 'other-session' });
+			const dispatchEventSpy = vi.spyOn(window, 'dispatchEvent');
+
+			renderHook(() => useRemoteIntegration(deps));
+
+			act(() => {
+				onRemoteNewAITabWithPromptHandler?.('session-1', 'Hello', 'chan-bg', true);
+			});
+
+			// Tab was created and the prompt still dispatched...
+			expect(deps.setSessions).toHaveBeenCalled();
+			expect(dispatchEventSpy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					type: 'maestro:remoteCommand',
+					detail: expect.objectContaining({
+						sessionId: 'session-1',
+						command: 'Hello',
+						tabId: expect.any(String),
+					}),
+				})
+			);
+			// ...but the agent is NOT brought to the foreground.
+			expect(deps.setActiveSessionId).not.toHaveBeenCalled();
+
+			// The new tab is appended but NOT made active: the previously-active
+			// tab is preserved so the user's visible view never changes.
+			const updater = deps.setSessions.mock.calls[0][0];
+			const [updated] = updater([session]);
+			expect(updated.aiTabs).toHaveLength(originalTabCount + 1);
+			expect(updated.activeTabId).toBe(originalActiveTabId);
 
 			dispatchEventSpy.mockRestore();
 		});

--- a/src/__tests__/renderer/utils/tabHelpers.test.ts
+++ b/src/__tests__/renderer/utils/tabHelpers.test.ts
@@ -279,6 +279,35 @@ describe('tabHelpers', () => {
 			expect(result.session.activeTabId).toBe(result.tab.id);
 		});
 
+		it('does NOT change the active tab or view when activate is false (background create)', () => {
+			const existingTab = createMockTab({ id: 'existing-tab' });
+			const session = createMockSession({
+				aiTabs: [existingTab],
+				activeTabId: 'existing-tab',
+				activeBrowserTabId: 'browser-1',
+				activeFileTabId: 'file-1',
+				activeTerminalTabId: 'term-1',
+				inputMode: 'terminal',
+				activeGroupId: 'group-1',
+			});
+
+			const result = createTab(session, { activate: false })!;
+
+			// The new tab is appended and ordered, but every focus-related field
+			// is preserved so the user's visible view never changes.
+			expect(result.session.aiTabs).toHaveLength(2);
+			expect(result.session.aiTabs[1]).toBe(result.tab);
+			expect(result.session.unifiedTabOrder).toContainEqual({ type: 'ai', id: result.tab.id });
+			expect(result.session.activeTabId).toBe('existing-tab');
+			expect(result.session.activeBrowserTabId).toBe('browser-1');
+			expect(result.session.activeFileTabId).toBe('file-1');
+			expect(result.session.activeTerminalTabId).toBe('term-1');
+			expect(result.session.inputMode).toBe('terminal');
+			// activeGroupId is preserved too: a background create must not leave the
+			// active tiled group (doing so would let the group steal the panel).
+			expect(result.session.activeGroupId).toBe('group-1');
+		});
+
 		it('clears activeBrowserTabId when creating a new AI tab', () => {
 			const existingTab = createMockTab({ id: 'existing-tab' });
 			const session = createMockSession({

--- a/src/cli/commands/dispatch.ts
+++ b/src/cli/commands/dispatch.ts
@@ -11,6 +11,11 @@ export interface DispatchOptions {
 	/** Tab id within the target agent. Mutually exclusive with --new-tab. */
 	tab?: string;
 	force?: boolean;
+	/** Commander sets this to `true` when `--focus` is passed. Unset/false is the
+	 *  default and dispatches in the background: the desktop delivers the prompt
+	 *  without switching to or focusing the target agent/tab. Only `focus === true`
+	 *  brings the target to the foreground. */
+	focus?: boolean;
 }
 
 export interface DispatchResponse {
@@ -82,11 +87,21 @@ export async function runDispatch(
 		return { success: false, error: msg, code: 'AGENT_NOT_FOUND' };
 	}
 
+	// Dispatch runs in the background by default (no focus stealing); only an
+	// explicit `--focus` (Commander: focus === true) tells the desktop to switch
+	// to and focus the target agent/tab. The `background` bit is threaded to both
+	// the new-tab and existing-tab command paths.
+	const background = options.focus !== true;
 	try {
 		const tabId = await withMaestroClient(async (client) => {
 			if (options.newTab) {
 				const result = await client.sendCommand<{ tabId?: string }>(
-					{ type: 'new_ai_tab_with_prompt', sessionId: agentId, prompt: message },
+					{
+						type: 'new_ai_tab_with_prompt',
+						sessionId: agentId,
+						prompt: message,
+						...(background ? { background: true } : {}),
+					},
 					'new_ai_tab_with_prompt_result'
 				);
 				// `--new-tab`'s sole purpose is to surface a fresh tab id for
@@ -108,6 +123,7 @@ export async function runDispatch(
 					inputMode: 'ai',
 					...(options.tab ? { tabId: options.tab } : {}),
 					...(options.force ? { force: true } : {}),
+					...(background ? { background: true } : {}),
 				},
 				'command_result'
 			);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -348,6 +348,10 @@ program
 		'-f, --force',
 		'Bypass the busy-state guard when writing to a busy tab; requires allowConcurrentSend (cannot be combined with --new-tab - a fresh tab is never busy)'
 	)
+	.option(
+		'--focus',
+		'Switch to and focus the target agent/tab when dispatching (by default dispatch runs in the background without stealing focus)'
+	)
 	.action(dispatch);
 
 // Session inspection commands - read-only access to desktop conversation state.

--- a/src/main/preload/process.ts
+++ b/src/main/preload/process.ts
@@ -400,7 +400,8 @@ export function createProcessApi() {
 				inputMode?: 'ai' | 'terminal',
 				tabId?: string,
 				force?: boolean,
-				images?: string[]
+				images?: string[],
+				background?: boolean
 			) => void
 		): (() => void) => {
 			log('Registering onRemoteCommand listener');
@@ -411,7 +412,8 @@ export function createProcessApi() {
 				inputMode?: 'ai' | 'terminal',
 				tabId?: string,
 				force?: boolean,
-				images?: string[]
+				images?: string[],
+				background?: boolean
 			) => {
 				log('Received remote:executeCommand IPC', {
 					sessionId,
@@ -420,9 +422,10 @@ export function createProcessApi() {
 					tabId,
 					force,
 					imageCount: images?.length ?? 0,
+					background,
 				});
 				try {
-					callback(sessionId, command, inputMode, tabId, force, images);
+					callback(sessionId, command, inputMode, tabId, force, images, background);
 				} catch (error) {
 					ipcRenderer.invoke(
 						'logger:log',
@@ -806,11 +809,22 @@ export function createProcessApi() {
 		 * doesn't wait for the 5s response timeout.
 		 */
 		onRemoteNewAITabWithPrompt: (
-			callback: (sessionId: string, prompt: string, responseChannel: string) => void
+			callback: (
+				sessionId: string,
+				prompt: string,
+				responseChannel: string,
+				background?: boolean
+			) => void
 		): (() => void) => {
-			const handler = (_: unknown, sessionId: string, prompt: string, responseChannel: string) => {
+			const handler = (
+				_: unknown,
+				sessionId: string,
+				prompt: string,
+				responseChannel: string,
+				background?: boolean
+			) => {
 				try {
-					callback(sessionId, prompt, responseChannel);
+					callback(sessionId, prompt, responseChannel, background);
 				} catch (error) {
 					ipcRenderer.send(responseChannel, false);
 					throw error;

--- a/src/main/web-server/WebServer.ts
+++ b/src/main/web-server/WebServer.ts
@@ -363,7 +363,8 @@ export class WebServer {
 
 	private writeToTerminalCallback: ((sessionId: string, data: string) => boolean) | null = null;
 	private resizeTerminalCallback:
-		((sessionId: string, cols: number, rows: number) => boolean) | null = null;
+		| ((sessionId: string, cols: number, rows: number) => boolean)
+		| null = null;
 	private spawnTerminalForWebCallback:
 		| ((
 				sessionId: string,

--- a/src/main/web-server/WebServer.ts
+++ b/src/main/web-server/WebServer.ts
@@ -363,8 +363,7 @@ export class WebServer {
 
 	private writeToTerminalCallback: ((sessionId: string, data: string) => boolean) | null = null;
 	private resizeTerminalCallback:
-		| ((sessionId: string, cols: number, rows: number) => boolean)
-		| null = null;
+		((sessionId: string, cols: number, rows: number) => boolean) | null = null;
 	private spawnTerminalForWebCallback:
 		| ((
 				sessionId: string,
@@ -880,9 +879,18 @@ export class WebServer {
 				inputMode?: 'ai' | 'terminal',
 				tabId?: string,
 				force?: boolean,
-				images?: string[]
+				images?: string[],
+				background?: boolean
 			) =>
-				this.callbackRegistry.executeCommand(sessionId, command, inputMode, tabId, force, images),
+				this.callbackRegistry.executeCommand(
+					sessionId,
+					command,
+					inputMode,
+					tabId,
+					force,
+					images,
+					background
+				),
 			switchMode: async (sessionId: string, mode: 'ai' | 'terminal') =>
 				this.callbackRegistry.switchMode(sessionId, mode),
 			selectSession: async (sessionId: string, tabId?: string, focus?: boolean) =>
@@ -909,8 +917,8 @@ export class WebServer {
 				sessionId: string,
 				config: { cwd?: string; shell?: string; name?: string | null }
 			) => this.callbackRegistry.openTerminalTab(sessionId, config),
-			newAITabWithPrompt: async (sessionId: string, prompt: string) =>
-				this.callbackRegistry.newAITabWithPrompt(sessionId, prompt),
+			newAITabWithPrompt: async (sessionId: string, prompt: string, background?: boolean) =>
+				this.callbackRegistry.newAITabWithPrompt(sessionId, prompt, background),
 			refreshAutoRunDocs: async (sessionId: string) =>
 				this.callbackRegistry.refreshAutoRunDocs(sessionId),
 			configureAutoRun: async (

--- a/src/main/web-server/handlers/messageHandlers.ts
+++ b/src/main/web-server/handlers/messageHandlers.ts
@@ -161,6 +161,7 @@ export interface WebClientMessage {
 	filePath?: string;
 	focus?: boolean;
 	force?: boolean;
+	background?: boolean;
 	[key: string]: unknown;
 }
 
@@ -207,7 +208,8 @@ export interface MessageHandlerCallbacks {
 		inputMode?: 'ai' | 'terminal',
 		tabId?: string,
 		force?: boolean,
-		images?: string[]
+		images?: string[],
+		background?: boolean
 	) => Promise<boolean>;
 	switchMode: (sessionId: string, mode: 'ai' | 'terminal') => Promise<boolean>;
 	selectSession: (sessionId: string, tabId?: string, focus?: boolean) => Promise<boolean>;
@@ -227,7 +229,8 @@ export interface MessageHandlerCallbacks {
 	) => Promise<boolean>;
 	newAITabWithPrompt: (
 		sessionId: string,
-		prompt: string
+		prompt: string,
+		background?: boolean
 	) => Promise<{ success: boolean; tabId?: string }>;
 	refreshAutoRunDocs: (sessionId: string) => Promise<boolean>;
 	configureAutoRun: (
@@ -909,6 +912,10 @@ export class WebSocketMessageHandler {
 		// dispatch concurrent writes to an already-running agent. Used by
 		// `maestro-cli dispatch --force`.
 		const force = message.force === true;
+		// background=true suppresses the desktop's focus side effect (switching
+		// to the target agent/tab). `maestro-cli dispatch` sets this by default;
+		// passing `--focus` clears it to bring the target to the foreground.
+		const background = message.background === true;
 		// Optional base64 data URLs pasted from the web client. Threaded through
 		// to the renderer so AI tabs can include them in the agent prompt.
 		const images = Array.isArray(message.images)
@@ -987,7 +994,15 @@ export class WebSocketMessageHandler {
 		// Pass clientInputMode so renderer uses the web's intended mode
 		if (this.callbacks.executeCommand) {
 			this.callbacks
-				.executeCommand(sessionId, effectiveCommand, clientInputMode, requestedTabId, force, images)
+				.executeCommand(
+					sessionId,
+					effectiveCommand,
+					clientInputMode,
+					requestedTabId,
+					force,
+					images,
+					background
+				)
 				.then((success) => {
 					this.send(client, {
 						type: 'command_result',
@@ -1668,8 +1683,7 @@ export class WebSocketMessageHandler {
 	private handleConfigureAutoRun(client: WebClient, message: WebClientMessage): void {
 		const sessionId = message.sessionId as string;
 		const documents = message.documents as
-			| Array<{ filename: string; resetOnCompletion?: boolean }>
-			| undefined;
+			Array<{ filename: string; resetOnCompletion?: boolean }> | undefined;
 		logger.info(
 			`[Web] Received configure_auto_run message: session=${sessionId}, documents=${documents?.length || 0}`,
 			LOG_CONTEXT
@@ -2124,6 +2138,9 @@ export class WebSocketMessageHandler {
 	private handleNewAITabWithPrompt(client: WebClient, message: WebClientMessage): void {
 		const sessionId = typeof message.sessionId === 'string' ? message.sessionId : '';
 		const prompt = typeof message.prompt === 'string' ? message.prompt : '';
+		// background=true creates the tab without switching to/focusing it.
+		// `maestro-cli dispatch --new-tab` sets this by default; `--focus` clears it.
+		const background = message.background === true;
 		// Prompts can contain user-authored content with secrets or PII -
 		// log length only rather than a raw preview.
 		logger.info(
@@ -2158,7 +2175,7 @@ export class WebSocketMessageHandler {
 		}
 
 		this.callbacks
-			.newAITabWithPrompt(sessionId, prompt)
+			.newAITabWithPrompt(sessionId, prompt, background)
 			.then((result) => {
 				this.send(client, {
 					type: 'new_ai_tab_with_prompt_result',

--- a/src/main/web-server/handlers/messageHandlers.ts
+++ b/src/main/web-server/handlers/messageHandlers.ts
@@ -1683,7 +1683,8 @@ export class WebSocketMessageHandler {
 	private handleConfigureAutoRun(client: WebClient, message: WebClientMessage): void {
 		const sessionId = message.sessionId as string;
 		const documents = message.documents as
-			Array<{ filename: string; resetOnCompletion?: boolean }> | undefined;
+			| Array<{ filename: string; resetOnCompletion?: boolean }>
+			| undefined;
 		logger.info(
 			`[Web] Received configure_auto_run message: session=${sessionId}, documents=${documents?.length || 0}`,
 			LOG_CONTEXT

--- a/src/main/web-server/managers/CallbackRegistry.ts
+++ b/src/main/web-server/managers/CallbackRegistry.ts
@@ -328,10 +328,19 @@ export class CallbackRegistry {
 		inputMode?: 'ai' | 'terminal',
 		tabId?: string,
 		force?: boolean,
-		images?: string[]
+		images?: string[],
+		background?: boolean
 	): Promise<boolean> {
 		if (!this.callbacks.executeCommand) return false;
-		return this.callbacks.executeCommand(sessionId, command, inputMode, tabId, force, images);
+		return this.callbacks.executeCommand(
+			sessionId,
+			command,
+			inputMode,
+			tabId,
+			force,
+			images,
+			background
+		);
 	}
 
 	async interruptSession(sessionId: string): Promise<boolean> {
@@ -405,10 +414,11 @@ export class CallbackRegistry {
 
 	async newAITabWithPrompt(
 		sessionId: string,
-		prompt: string
+		prompt: string,
+		background?: boolean
 	): Promise<{ success: boolean; tabId?: string }> {
 		if (!this.callbacks.newAITabWithPrompt) return { success: false };
-		return this.callbacks.newAITabWithPrompt(sessionId, prompt);
+		return this.callbacks.newAITabWithPrompt(sessionId, prompt, background);
 	}
 
 	async refreshAutoRunDocs(sessionId: string): Promise<boolean> {

--- a/src/main/web-server/types.ts
+++ b/src/main/web-server/types.ts
@@ -287,7 +287,8 @@ export type ExecuteCommandCallback = (
 	inputMode?: 'ai' | 'terminal',
 	tabId?: string,
 	force?: boolean,
-	images?: string[]
+	images?: string[],
+	background?: boolean
 ) => Promise<boolean>;
 
 /**
@@ -350,7 +351,8 @@ export type RefreshFileTreeCallback = (sessionId: string) => Promise<boolean>;
 export type NewAITabWithPromptResult = { success: boolean; tabId?: string };
 export type NewAITabWithPromptCallback = (
 	sessionId: string,
-	prompt: string
+	prompt: string,
+	background?: boolean
 ) => Promise<NewAITabWithPromptResult>;
 export type OpenBrowserTabCallback = (sessionId: string, url: string) => Promise<boolean>;
 export interface OpenTerminalTabConfig {

--- a/src/main/web-server/web-server-factory.ts
+++ b/src/main/web-server/web-server-factory.ts
@@ -612,7 +612,8 @@ export function createWebServerFactory(deps: WebServerFactoryDependencies) {
 				inputMode?: 'ai' | 'terminal',
 				tabId?: string,
 				force?: boolean,
-				images?: string[]
+				images?: string[],
+				background?: boolean
 			) => {
 				const mainWindow = getMainWindow();
 				if (!mainWindow) {
@@ -630,7 +631,7 @@ export function createWebServerFactory(deps: WebServerFactoryDependencies) {
 				// proprietary code, or PII; the full prompt goes to debug, which is
 				// only enabled by users who have explicitly opted in.
 				logger.info(
-					`[Web → Renderer] Forwarding command | Maestro: ${sessionId} | Claude: ${agentSessionId} | Mode: ${inputMode || 'auto'} | Tab: ${tabId || 'active'} | Force: ${force ? 'yes' : 'no'} | Images: ${images?.length ?? 0} | CommandLength: ${command.length}`,
+					`[Web → Renderer] Forwarding command | Maestro: ${sessionId} | Claude: ${agentSessionId} | Mode: ${inputMode || 'auto'} | Tab: ${tabId || 'active'} | Force: ${force ? 'yes' : 'no'} | Focus: ${background ? 'no' : 'yes'} | Images: ${images?.length ?? 0} | CommandLength: ${command.length}`,
 					'WebServer'
 				);
 				logger.debug(
@@ -648,7 +649,8 @@ export function createWebServerFactory(deps: WebServerFactoryDependencies) {
 					inputMode,
 					tabId,
 					force,
-					images
+					images,
+					background
 				);
 				return true;
 			}
@@ -1065,61 +1067,64 @@ export function createWebServerFactory(deps: WebServerFactoryDependencies) {
 			}
 		);
 
-		server.setNewAITabWithPromptCallback(async (sessionId: string, prompt: string) => {
-			const mainWindow = getMainWindow();
-			if (!mainWindow) {
-				logger.warn('mainWindow is null for newAITabWithPrompt', 'WebServer');
-				return { success: false };
-			}
-
-			return new Promise<{ success: boolean; tabId?: string }>((resolve) => {
-				const responseChannel = `remote:newAITabWithPrompt:response:${randomUUID()}`;
-				let resolved = false;
-
-				const handleResponse = (_event: Electron.IpcMainEvent, result: unknown) => {
-					if (resolved) return;
-					resolved = true;
-					clearTimeout(timeoutId);
-					// Renderer was updated to ack with `{ success, tabId? }`. Older
-					// renderers that still send a bare boolean stay supported via
-					// the `result === true` fallback.
-					if (typeof result === 'object' && result !== null) {
-						const r = result as { success?: unknown; tabId?: unknown };
-						resolve({
-							success: r.success === true,
-							tabId: typeof r.tabId === 'string' ? r.tabId : undefined,
-						});
-					} else {
-						resolve({ success: result === true });
-					}
-				};
-
-				ipcMain.once(responseChannel, handleResponse);
-				if (!isWebContentsAvailable(mainWindow)) {
-					logger.warn('webContents is not available for newAITabWithPrompt', 'WebServer');
-					ipcMain.removeListener(responseChannel, handleResponse);
-					resolve({ success: false });
-					return;
+		server.setNewAITabWithPromptCallback(
+			async (sessionId: string, prompt: string, background?: boolean) => {
+				const mainWindow = getMainWindow();
+				if (!mainWindow) {
+					logger.warn('mainWindow is null for newAITabWithPrompt', 'WebServer');
+					return { success: false };
 				}
-				mainWindow.webContents.send(
-					'remote:newAITabWithPrompt',
-					sessionId,
-					prompt,
-					responseChannel
-				);
 
-				const timeoutId = setTimeout(() => {
-					if (resolved) return;
-					resolved = true;
-					ipcMain.removeListener(responseChannel, handleResponse);
-					logger.warn(
-						`newAITabWithPrompt callback timed out for session ${sessionId}`,
-						'WebServer'
+				return new Promise<{ success: boolean; tabId?: string }>((resolve) => {
+					const responseChannel = `remote:newAITabWithPrompt:response:${randomUUID()}`;
+					let resolved = false;
+
+					const handleResponse = (_event: Electron.IpcMainEvent, result: unknown) => {
+						if (resolved) return;
+						resolved = true;
+						clearTimeout(timeoutId);
+						// Renderer was updated to ack with `{ success, tabId? }`. Older
+						// renderers that still send a bare boolean stay supported via
+						// the `result === true` fallback.
+						if (typeof result === 'object' && result !== null) {
+							const r = result as { success?: unknown; tabId?: unknown };
+							resolve({
+								success: r.success === true,
+								tabId: typeof r.tabId === 'string' ? r.tabId : undefined,
+							});
+						} else {
+							resolve({ success: result === true });
+						}
+					};
+
+					ipcMain.once(responseChannel, handleResponse);
+					if (!isWebContentsAvailable(mainWindow)) {
+						logger.warn('webContents is not available for newAITabWithPrompt', 'WebServer');
+						ipcMain.removeListener(responseChannel, handleResponse);
+						resolve({ success: false });
+						return;
+					}
+					mainWindow.webContents.send(
+						'remote:newAITabWithPrompt',
+						sessionId,
+						prompt,
+						responseChannel,
+						background
 					);
-					resolve({ success: false });
-				}, 5000);
-			});
-		});
+
+					const timeoutId = setTimeout(() => {
+						if (resolved) return;
+						resolved = true;
+						ipcMain.removeListener(responseChannel, handleResponse);
+						logger.warn(
+							`newAITabWithPrompt callback timed out for session ${sessionId}`,
+							'WebServer'
+						);
+						resolve({ success: false });
+					}, 5000);
+				});
+			}
+		);
 
 		server.setRefreshAutoRunDocsCallback(async (sessionId: string) => {
 			const mainWindow = getMainWindow();

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -382,7 +382,8 @@ interface MaestroAPI {
 				inputMode?: 'ai' | 'terminal',
 				tabId?: string,
 				force?: boolean,
-				images?: string[]
+				images?: string[],
+				background?: boolean
 			) => void
 		) => () => void;
 		onRemoteSwitchMode: (
@@ -482,7 +483,12 @@ interface MaestroAPI {
 		) => () => void;
 		sendRemoteOpenTerminalTabResponse: (responseChannel: string, success: boolean) => void;
 		onRemoteNewAITabWithPrompt: (
-			callback: (sessionId: string, prompt: string, responseChannel: string) => void
+			callback: (
+				sessionId: string,
+				prompt: string,
+				responseChannel: string,
+				background?: boolean
+			) => void
 		) => () => void;
 		sendRemoteNewAITabWithPromptResponse: (
 			responseChannel: string,

--- a/src/renderer/hooks/remote/useRemoteIntegration.ts
+++ b/src/renderer/hooks/remote/useRemoteIntegration.ts
@@ -91,7 +91,8 @@ export function useRemoteIntegration(deps: UseRemoteIntegrationDeps): UseRemoteI
 				inputMode?: 'ai' | 'terminal',
 				tabId?: string,
 				force?: boolean,
-				images?: string[]
+				images?: string[],
+				background?: boolean
 			) => {
 				// Log metadata only at info level - remote commands can carry
 				// secrets, proprietary code, or PII. Mirror the redaction the
@@ -156,9 +157,13 @@ export function useRemoteIntegration(deps: UseRemoteIntegrationDeps): UseRemoteI
 					);
 				}
 
-				// Switch to the target session (for visual feedback)
-				setActiveSessionId(sessionId);
-				logger.info('[useRemoteIntegration] Switched active session to:', undefined, sessionId);
+				// Switch to the target session (for visual feedback) unless this is a
+				// background dispatch. Background is the default for `dispatch`; passing
+				// `--focus` re-enables switching to the target agent/tab.
+				if (!background) {
+					setActiveSessionId(sessionId);
+					logger.info('[useRemoteIntegration] Switched active session to:', undefined, sessionId);
+				}
 
 				// Dispatch event directly - handleRemoteCommand handles all the logic
 				// Don't set inputValue - we don't want command text to appear in the input bar
@@ -353,17 +358,19 @@ export function useRemoteIntegration(deps: UseRemoteIntegrationDeps): UseRemoteI
 			}
 		);
 
-		// Handle remote "new AI tab with prompt" from CLI (send --live --new-tab).
-		// Atomically creates a fresh AI tab, makes it active, and dispatches the
-		// prompt through the same maestro:remoteCommand event path that --live
-		// uses - so downstream spawn/history/state flows are identical.
-		// flushSync forces React to commit the new tab as active before we fire
-		// the event; without it the downstream handler reads stale activeTabId
-		// and writes the prompt into the previously-active tab.
+		// Handle remote "new AI tab with prompt" from CLI (dispatch --new-tab).
+		// Atomically creates a fresh AI tab and dispatches the prompt through the
+		// same maestro:remoteCommand event path that a plain dispatch uses, so
+		// downstream spawn/history/state flows are identical. A background dispatch
+		// (the default) creates the new tab without focus so the user's current view
+		// is preserved; `dispatch --focus` makes the new tab active instead. flushSync
+		// forces React to commit the new tab into session state before we fire the event,
+		// so the downstream handler can resolve the freshly-created tabId (which we
+		// always pass explicitly) instead of racing on a stale snapshot.
 		// Ack the renderer result on responseChannel so the CLI only reports
 		// success when a tab was actually created.
 		const unsubscribeNewTabWithPrompt = window.maestro.process.onRemoteNewAITabWithPrompt(
-			(sessionId: string, prompt: string, responseChannel: string) => {
+			(sessionId: string, prompt: string, responseChannel: string, background?: boolean) => {
 				// Guard: the downstream maestro:remoteCommand handler drops commands
 				// for missing or busy sessions. Check here so we don't create an
 				// orphan tab and falsely ack success.
@@ -390,13 +397,17 @@ export function useRemoteIntegration(deps: UseRemoteIntegrationDeps): UseRemoteI
 							const result = createTab(s, {
 								saveToHistory: defaultSaveToHistory,
 								showThinking: defaultShowThinking,
+								// Background dispatch is the default (`--focus` opts into the
+								// foreground): create the tab without making it active so the
+								// user's current view is preserved.
+								activate: !background,
 							});
 							if (!result) return s;
 							createdTabId = result.tab.id;
 							return result.session;
 						})
 					);
-					if (createdTabId) {
+					if (createdTabId && !background) {
 						setActiveSessionId(sessionId);
 					}
 				});

--- a/src/renderer/utils/tabHelpers.ts
+++ b/src/renderer/utils/tabHelpers.ts
@@ -810,6 +810,10 @@ export interface CreateTabOptions {
 	usageStats?: UsageStats; // Token usage stats
 	saveToHistory?: boolean; // Whether to save synopsis to history after completions
 	showThinking?: ThinkingMode; // Thinking display mode: 'off' | 'on' (temporary) | 'sticky' (persistent)
+	/** When false, append the tab without making it active (background create).
+	 *  The current active tab/file/browser/terminal/group and inputMode are all
+	 *  preserved so the user's visible view never changes. Default true. */
+	activate?: boolean;
 }
 
 /**
@@ -857,6 +861,7 @@ export function createTab(
 		usageStats,
 		saveToHistory = true,
 		showThinking = 'off',
+		activate = true,
 	} = options;
 
 	// Create the new tab with default values
@@ -875,24 +880,29 @@ export function createTab(
 		showThinking,
 	};
 
-	// Update the session with the new tab added and set as active.
-	// Clear activeFileTabId and activeTerminalTabId so the new AI tab is shown in the
-	// main panel, and set inputMode to 'ai' so callers don't need to patch it manually.
-	// activeGroupId is cleared too: a new tab is a fresh standalone view, so it must
-	// leave any active tiled group - otherwise the group keeps taking over the panel
-	// and the new tab opens in the background (never gets focus). Insert the new tab
-	// into unifiedTabOrder directly to the right of the currently active tab so "new
-	// tab" actions feel positional regardless of which tab type is currently focused.
+	// Update the session with the new tab added. When `activate` is true (the
+	// default), make the new AI tab active: clear activeFileTabId/activeTerminalTabId
+	// so it's shown in the main panel, set inputMode to 'ai', and clear activeGroupId
+	// (a new tab is a fresh standalone view; leaving an active tiled group would keep
+	// the group taking over the panel so the new tab never gets focus). When `activate`
+	// is false (background create, e.g. the default `dispatch --new-tab`), leave every
+	// active-tab id, activeGroupId, and inputMode untouched so the user's visible view
+	// never changes. Either way, insert the new tab into unifiedTabOrder directly to
+	// the right of the currently active tab so "new tab" actions feel positional.
 	const newTabRef = { type: 'ai' as const, id: newTab.id };
 	const updatedSession: Session = {
 		...session,
 		aiTabs: [...(session.aiTabs || []), newTab],
-		activeTabId: newTab.id,
-		activeFileTabId: null,
-		activeBrowserTabId: null,
-		activeTerminalTabId: null,
-		activeGroupId: null,
-		inputMode: 'ai' as const,
+		...(activate
+			? {
+					activeTabId: newTab.id,
+					activeFileTabId: null,
+					activeBrowserTabId: null,
+					activeTerminalTabId: null,
+					activeGroupId: null,
+					inputMode: 'ai' as const,
+				}
+			: {}),
 		unifiedTabOrder: insertAfterActiveInUnifiedTabOrder(session, newTabRef),
 	};
 


### PR DESCRIPTION
## What

`maestro-cli dispatch` now delivers a prompt **in the background by default**: it no longer switches to or focuses the target agent/tab. Pass the new `--focus` flag to bring the target to the foreground (the previous default). `--new-tab` likewise creates the fresh tab in the background unless `--focus` is given.

```bash
dispatch <agent> <msg>                     # background (default), no focus
dispatch <agent> <msg> --focus             # foreground, switches to & focuses the tab
dispatch <agent> <msg> --new-tab           # fresh tab, background
dispatch <agent> <msg> --new-tab --focus   # fresh tab, focused
```

## Why

Dispatching (especially from automation like Cue, Pianola, and the orchestrator) was yanking the user's view to the target agent on every call. Background delivery is the sensible default for autonomous, non-interactive dispatch; foregrounding becomes an explicit opt-in.

## How

A `background` bit is threaded end to end and only its final consumers act on it:

- **CLI** (`src/cli/index.ts`, `src/cli/commands/dispatch.ts`): `--focus` maps to Commander `focus === true`; `runDispatch` sets `background = options.focus !== true` and adds `background: true` to the `send_command` / `new_ai_tab_with_prompt` payloads.
- **Transport** (`web-server/handlers/messageHandlers.ts`, `types.ts`, `managers/CallbackRegistry.ts`, `WebServer.ts`, `web-server-factory.ts`, `preload/process.ts`, `renderer/global.d.ts`): optional `background` param on `ExecuteCommandCallback` / `NewAITabWithPromptCallback` and the IPC bridges.
- **Renderer** (`renderer/hooks/remote/useRemoteIntegration.ts`): when `background`, skips `setActiveSessionId` and creates the new tab via `createTab({ activate: false })`.
- **`createTab`** (`renderer/utils/tabHelpers.ts`): new `activate?: boolean` option (default `true`); when `false`, appends the tab but preserves every active-tab id, `activeGroupId`, and `inputMode` so the visible view never changes.

Programmatic `runDispatch` callers (Pianola watcher, orchestrator) pass no focus preference, so they now background by default too, which is the desired behavior for autonomous dispatch.

## Testing

Extended and passing: `dispatch`, `messageHandlers`, preload `process`, `useRemoteIntegration`, and `tabHelpers` suites (payloads now carry `background: true` by default; `--focus` omits it; renderer suppresses focus and background-creates tabs; `createTab({ activate: false })` preserves focus fields). Prettier and ESLint clean on all touched files; the 16 changed files add zero TypeScript errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled background-by-default dispatch for CLI and remote command flows, keeping the current view in place.
  * Added `--focus` to switch to and focus the target agent/tab during dispatch.
  * Added background creation for new AI tabs, inserting them without changing the user-visible active panel state.
* **Bug Fixes**
  * Made “background” behavior consistent across command execution, image-based sends, and remote integrations, including correct foreground behavior when `--focus` is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->