### PR TITLE
fix(omp): empty-text agent_end no longer defeats the silent-exit guard

### DIFF
--- a/src/__tests__/main/parsers/omp-output-parser.test.ts
+++ b/src/__tests__/main/parsers/omp-output-parser.test.ts
@@ -107,6 +107,47 @@ describe('OmpOutputParser', () => {
 		expect(event!.type).toBe('system');
 		expect(parser.isResultMessage(event!)).toBe(false);
 	});
+
+	it('does not emit a result when agent_end final assistant message has empty text', () => {
+		const event = parser.parseJsonObject({
+			type: 'agent_end',
+			messages: [
+				{ role: 'user', content: [{ type: 'text', text: 'hi' }] },
+				{ role: 'assistant', content: [{ type: 'text', text: '' }] },
+			],
+		});
+
+		expect(event).not.toBeNull();
+		expect(event!.type).toBe('system');
+		expect(parser.isResultMessage(event!)).toBe(false);
+	});
+
+	it('does not emit a result when agent_end final assistant message is whitespace-only', () => {
+		const event = parser.parseJsonObject({
+			type: 'agent_end',
+			messages: [{ role: 'assistant', content: [{ type: 'text', text: '   \n\t' }] }],
+		});
+
+		expect(event).not.toBeNull();
+		expect(event!.type).toBe('system');
+		expect(parser.isResultMessage(event!)).toBe(false);
+	});
+
+	it('does not emit a result when agent_end final assistant message carries no text block', () => {
+		const event = parser.parseJsonObject({
+			type: 'agent_end',
+			messages: [
+				{
+					role: 'assistant',
+					content: [{ type: 'toolCall', toolName: 'edit', args: {} }],
+				},
+			],
+		});
+
+		expect(event).not.toBeNull();
+		expect(event!.type).toBe('system');
+		expect(parser.isResultMessage(event!)).toBe(false);
+	});
 	it('does not surface a retrying agent_end as a user-facing error', () => {
 		const retrying = {
 			type: 'agent_end',

--- a/src/__tests__/main/parsers/omp-output-parser.test.ts
+++ b/src/__tests__/main/parsers/omp-output-parser.test.ts
@@ -148,6 +148,7 @@ describe('OmpOutputParser', () => {
 		expect(event!.type).toBe('system');
 		expect(parser.isResultMessage(event!)).toBe(false);
 	});
+
 	it('does not surface a retrying agent_end as a user-facing error', () => {
 		const retrying = {
 			type: 'agent_end',

--- a/src/__tests__/main/process-manager/handlers/StdoutHandler.test.ts
+++ b/src/__tests__/main/process-manager/handlers/StdoutHandler.test.ts
@@ -52,6 +52,7 @@ vi.mock('../../../../main/parsers/error-patterns', () => ({
 import { StdoutHandler } from '../../../../main/process-manager/handlers/StdoutHandler';
 import { matchSshErrorPattern } from '../../../../main/parsers/error-patterns';
 import { CopilotOutputParser } from '../../../../main/parsers/copilot-output-parser';
+import { OmpOutputParser } from '../../../../main/parsers/omp-output-parser';
 import type { ManagedProcess } from '../../../../main/process-manager/types';
 import { logger } from '../../../../main/utils/logger';
 
@@ -694,6 +695,49 @@ describe('StdoutHandler', () => {
 			);
 			expect(resultCalls).toHaveLength(1);
 			expect(resultCalls[0][1]).toBe('First answer.');
+		});
+
+		it('does not mark resultEmitted for an omp agent_end whose final message has empty text', () => {
+			// Regression: an omp turn that reaches agent_end but whose final assistant
+			// message carries no text must NOT be recorded as a real result. Emitting an
+			// empty result would flip resultEmitted with nothing shown, silently
+			// defeating the ExitHandler omp silent-exit guard (which keys off
+			// !resultEmitted) - the reported "done after a second, nothing happened" turn.
+			const { handler, bufferManager, sessionId, proc } = createTestContext({
+				isStreamJsonMode: true,
+				toolType: 'omp',
+				outputParser: new OmpOutputParser(),
+			});
+
+			sendJsonLine(handler, sessionId, {
+				type: 'agent_end',
+				messages: [
+					{ role: 'user', content: [{ type: 'text', text: 'hi' }] },
+					{ role: 'assistant', content: [{ type: 'text', text: '' }] },
+				],
+			});
+
+			expect(proc.resultEmitted).toBe(false);
+			expect(bufferManager.emitDataBuffered).not.toHaveBeenCalled();
+		});
+
+		it('marks resultEmitted and emits text for an omp agent_end with a real final answer', () => {
+			const { handler, bufferManager, sessionId, proc } = createTestContext({
+				isStreamJsonMode: true,
+				toolType: 'omp',
+				outputParser: new OmpOutputParser(),
+			});
+
+			sendJsonLine(handler, sessionId, {
+				type: 'agent_end',
+				messages: [
+					{ role: 'user', content: [{ type: 'text', text: 'hi' }] },
+					{ role: 'assistant', content: [{ type: 'text', text: 'the answer' }] },
+				],
+			});
+
+			expect(proc.resultEmitted).toBe(true);
+			expect(bufferManager.emitDataBuffered).toHaveBeenCalledWith(sessionId, 'the answer');
 		});
 
 		it('should extract session_id and emit session-id event', () => {

--- a/src/main/parsers/omp-output-parser.ts
+++ b/src/main/parsers/omp-output-parser.ts
@@ -190,9 +190,24 @@ export class OmpOutputParser implements AgentOutputParser {
 					// then flushes the assembled streamed text the user already saw.
 					return { type: 'system', sessionId, raw: event };
 				}
+				const resultText = this.extractMessageText(finalMessage);
+				if (!resultText.trim()) {
+					// Assistant message present but carrying no text (empty or
+					// whitespace-only content, e.g. a final message that is only tool
+					// calls or was cut short before any text). Same hazard as the
+					// empty-transcript case above: a `result` with empty text makes
+					// `StdoutHandler` set `resultEmitted` WITHOUT emitting anything,
+					// which then defeats the ExitHandler silent-exit guard (it keys off
+					// `!resultEmitted`) - the turn would clear its busy pill showing no
+					// answer and no error, the reported "done after a second, nothing
+					// happened" turn. Return a non-result event so either the streamed-
+					// text exit fallback flushes what the user already saw, or the guard
+					// surfaces a recoverable "no response" error to resend.
+					return { type: 'system', sessionId, raw: event };
+				}
 				return {
 					type: 'result',
-					text: this.extractMessageText(finalMessage),
+					text: resultText,
 					sessionId,
 					raw: event,
 				};


### PR DESCRIPTION
## Problem

Follow-on to #1218 (merged), which added an `ExitHandler` guard that surfaces a recoverable `agent_crashed` error when an omp turn exits with no result, error, or output (the "started, went briefly busy, appeared done, no answer" turn).

There is a second path to the same silent turn that the guard does not cover: omp reaches `agent_end` with a final assistant message that carries **no text** (empty or whitespace-only content, for example a final message that is only tool calls, or was cut short before any text). `OmpOutputParser` parsed that as a `result` with empty text. `StdoutHandler` then set `resultEmitted = true` before its `if (resultText)` check, so it emitted nothing AND flipped the flag, which defeats the merged silent-exit guard (it keys off `!resultEmitted`). The tab clears its busy pill with no answer and no error, indistinguishable from success. This is the "done after a second, nothing happened" turn reported against omp on web-desktop (the mechanism is frontend-agnostic; it reproduces on desktop too).

## Fix

`OmpOutputParser.parseJsonObject` now returns a non-result `system` event when the final assistant message's extracted text is empty/whitespace-only, mirroring the existing empty-transcript (`!finalMessage`) handling immediately above it. With `resultEmitted` left false:

- if omp streamed text during the turn, the `ExitHandler` streamed-text fallback flushes it (the user still sees their answer), or
- if the turn produced nothing at all, the merged silent-exit guard fires and surfaces the recoverable "no response, resend" error.

Verified that normal omp turns (including tool-using turns) always end with a non-empty final text message, so this does not false-positive on healthy turns.

## Tests

- `omp-output-parser.test.ts`: 3 cases (empty text, whitespace-only, tool-only final message) assert a non-result `system` event.
- `StdoutHandler.test.ts`: 2 end-to-end cases (empty final text keeps `resultEmitted` false; a real final answer still emits).

`tsc -p tsconfig.main.json` clean; affected suites green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented empty or whitespace-only assistant responses from being reported as successful results.
  * Improved handling of `agent_end` when the final assistant message has no usable text.
  * Ensured valid non-empty assistant completions still emit the expected output.
* **Tests**
  * Added regression coverage for OMP stream-JSON behavior to confirm result emission rules for empty vs. non-empty final assistant text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->