### PR TITLE
fix(sentry): don't report expected group-chat grooming failures (MAESTRO-KA)

### DIFF
--- a/src/__tests__/main/ipc/handlers/groupChat.test.ts
+++ b/src/__tests__/main/ipc/handlers/groupChat.test.ts
@@ -11,6 +11,7 @@ import {
 	registerGroupChatHandlers,
 	GroupChatHandlerDependencies,
 	groupChatEmitters,
+	isExpectedGroomingFailure,
 } from '../../../../main/ipc/handlers/groupChat';
 
 // Import types we need for mocking
@@ -1315,5 +1316,33 @@ describe('groupChat IPC handlers', () => {
 				});
 			}).not.toThrow();
 		});
+	});
+});
+
+describe('isExpectedGroomingFailure', () => {
+	// resetContext grooms a participant for a context summary and always recovers
+	// by starting a fresh session. Failures caused by the user's environment are
+	// therefore expected and must not reach Sentry.
+	it('treats a deleted provider session as expected (MAESTRO-JB)', () => {
+		expect(isExpectedGroomingFailure(new Error('Session not found: abc-123'))).toBe(true);
+	});
+
+	it('treats an uninstalled agent as expected (MAESTRO-KA)', () => {
+		expect(isExpectedGroomingFailure(new Error('Agent claude-code is not available'))).toBe(true);
+	});
+
+	it('matches regardless of message casing', () => {
+		expect(isExpectedGroomingFailure(new Error('session NOT FOUND'))).toBe(true);
+		expect(isExpectedGroomingFailure(new Error('Agent codex IS NOT AVAILABLE'))).toBe(true);
+	});
+
+	it('handles non-Error throwables', () => {
+		expect(isExpectedGroomingFailure('Agent opencode is not available')).toBe(true);
+		expect(isExpectedGroomingFailure(undefined)).toBe(false);
+	});
+
+	it('still reports genuine grooming faults', () => {
+		expect(isExpectedGroomingFailure(new Error('Grooming timed out after 60000ms'))).toBe(false);
+		expect(isExpectedGroomingFailure(new Error('spawn ENOENT'))).toBe(false);
 	});
 });

--- a/src/main/ipc/handlers/groupChat.ts
+++ b/src/main/ipc/handlers/groupChat.ts
@@ -128,6 +128,24 @@ const handlerOpts = (operation: string): Pick<CreateHandlerOptions, 'context' | 
 export type GroupChatState = 'idle' | 'moderator-thinking' | 'agent-working';
 
 /**
+ * Grooming failures that are expected, user-environment conditions rather than
+ * Maestro bugs. `resetContext` below always recovers from them by starting the
+ * participant on a fresh session, so reporting them to Sentry is pure noise.
+ *
+ * - "Session not found ..." - the participant's provider session was deleted
+ *   mid-summary (MAESTRO-JB).
+ * - "Agent <id> is not available" - the participant's agent binary isn't
+ *   installed or detected on this machine (MAESTRO-KA).
+ *
+ * Anything else still reports, so a genuine fault in the grooming path keeps
+ * surfacing.
+ */
+export function isExpectedGroomingFailure(error: unknown): boolean {
+	const message = error instanceof Error ? error.message : String(error);
+	return /Session not found/i.test(message) || /is not available/i.test(message);
+}
+
+/**
  * Generic process manager interface that matches both IProcessManager and ProcessManager
  */
 interface GenericProcessManager {
@@ -779,13 +797,10 @@ Respond with ONLY the summary text, no additional commentary.`;
 						durationMs: result.durationMs,
 					});
 				} catch (error) {
-					// A summary that fails because the participant's session was already
-					// deleted ("Session not found ...") is an expected, fully-recovered
-					// condition - we fall back to a fresh session just below. Don't
-					// report that to Sentry (MAESTRO-JB); only surface unexpected
-					// grooming failures.
-					const message = error instanceof Error ? error.message : String(error);
-					if (!/Session not found/i.test(message)) {
+					// Expected grooming failures are fully recovered by the fresh-session
+					// fallback just below, so they aren't worth a Sentry breadcrumb. Only
+					// unexpected grooming failures get reported.
+					if (!isExpectedGroomingFailure(error)) {
 						void captureException(error);
 					}
 					logger.warn(`Summary generation failed for ${participantName}: ${error}`, LOG_CONTEXT);


### PR DESCRIPTION
## Summary

Sentry triage pass over `channel:stable` (the `main` branch). One issue turned out to be genuinely unfixed at HEAD with an obvious resolution; everything else on stable was already fixed, not our code, or out of scope (details below).

**MAESTRO-KA** - `Error: Agent claude-code is not available`, culprit `groomContext(dist.main.utils:context-groomer)`, `channel:stable` / `release:0.17.3`, ongoing since 2026-04-28.

Stack:
```
dist/main/utils/ipcHandler.js:170       return await handler(...args);
dist/main/ipc/handlers/groupChat.js:420 const result = await groomContext({...
dist/main/utils/context-groomer.js:82   throw new Error(`Agent ${agentType} is not available`);
```

`resetContext` grooms a participant for a context summary, then starts it on a fresh session. When the participant's agent binary isn't installed or detected on that machine, `groomContext` throws at the availability check (`context-groomer.ts:212`). That's a user-environment condition which the `'No summary available - starting fresh session.'` fallback already fully recovers from, but it was still reported to Sentry as a crash.

Same telemetry-noise-on-an-expected-condition family as the MAESTRO-JB carve-out already sitting in that very `catch` block.

## Change

- Extract the inline `Session not found` regex into a named `isExpectedGroomingFailure()` predicate, matching the `isExpectedFsError` / `isExpectedConnectionFailure` / `isExpectedSqliteError` convention already used in `src/main/`.
- Extend it to cover the uninstalled-agent case. Genuine grooming faults (timeouts, `spawn ENOENT`, ...) still report.

The other `groomContext` call sites (`context.ts`, `director-notes.ts`) are **deliberately left alone**: those are user-initiated, so the error correctly surfaces to the user rather than being swallowed.

## Tests

5 regression tests on the predicate. Verified non-vacuous: reverting the predicate body to the old `Session not found`-only logic turns 3 of them red.

```
Test Files  1 passed (1)
     Tests  62 passed (62)
```

`npm run lint` reports **104** errors both with and without this change (pre-existing missing `@codemirror/lang-*` optional deps); none in the touched files.

## Triage notes - why this is the only fix here

The rest of the stable-channel volume was checked and deliberately excluded:

| Issue | Volume | Disposition |
|---|---|---|
| MAESTRO-RS | 1037 | better-sqlite3 built against GLIBC_2.38. Linux build-infra/CI target, needs a human decision. |
| MAESTRO-BC | 483 | `ENOENT, dist\main\preload.js not found in ...app.asar` - a corrupt install (app at `G:\Maestro`), not our code. |
| MAESTRO-W2 / W7 / WB / WA | ~330 | Downstream cascade of the above (`window.maestro` undefined -> `reading 'git'`). Per-issue channel breakdown is **96% `channel:rc`**, so not a `main` issue. |
| MAESTRO-1G, 2S, RR, M9, JB | - | **Already fixed at HEAD, just unshipped.** `v0.17.3` is the newest tag and `main` is 661 commits ahead of it, so the whole stable field population predates those fixes. Re-verified each guard is still intact (M9's `RangeError` carve-out has regressed once before). |
| MAESTRO-WP | 5 | `verifySignedPluginArtifact` exists only on the unmerged `feature/maestro-omp-deep-integration` branch. |
| MAESTRO-RE | ~99 | Known non-bug: the bmad prompts *are* shipped correctly; one broken install amplified 33x. |
| SG / 1F / QG / RD / 4V / 2C / 1J / TF / 5A / 1C / 62 / 23 | - | Native / GPU / renderer crashes, no app frames. |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of expected session and agent availability issues during group chat participant setup.
  * Prevented expected environment-related failures from being reported as unexpected errors.
  * Continued recovering gracefully by starting a fresh session when appropriate.
* **Tests**
  * Added coverage for recognized grooming failures, message casing variations, non-error values, and unrelated errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->