### PR TITLE
fix(sentry): stop paging on expected sidecar, bridge, and signal conditions

### DIFF
--- a/src/__tests__/main/cue/cue-config-repository.test.ts
+++ b/src/__tests__/main/cue/cue-config-repository.test.ts
@@ -120,6 +120,51 @@ describe('cue-config-repository', () => {
 			expect(readCueConfigFile(PROJECT_ROOT)).toBeNull();
 			expect(mockReadFileSync).not.toHaveBeenCalled();
 		});
+
+		// MAESTRO-X9: readFileSync surfaces EINTR instead of restarting the
+		// syscall, which aborted CueEngine.start('system-boot') and left Cue
+		// disabled for the whole session.
+		it('retries when the read is interrupted by a signal (EINTR)', () => {
+			mockExistsSync.mockImplementation((p: string) => p === CANONICAL);
+			const eintr = Object.assign(new Error('EINTR: interrupted system call, read'), {
+				code: 'EINTR',
+			});
+			mockReadFileSync.mockImplementationOnce(() => {
+				throw eintr;
+			});
+			mockReadFileSync.mockReturnValue('subscriptions: []\n');
+
+			const result = readCueConfigFile(PROJECT_ROOT);
+
+			expect(result).toEqual({ filePath: CANONICAL, raw: 'subscriptions: []\n' });
+			expect(mockReadFileSync).toHaveBeenCalledTimes(2);
+		});
+
+		it('gives up after the retry bound when EINTR persists', () => {
+			mockExistsSync.mockImplementation((p: string) => p === CANONICAL);
+			const eintr = Object.assign(new Error('EINTR: interrupted system call, read'), {
+				code: 'EINTR',
+			});
+			mockReadFileSync.mockImplementation(() => {
+				throw eintr;
+			});
+
+			expect(() => readCueConfigFile(PROJECT_ROOT)).toThrow(/EINTR/);
+			expect(mockReadFileSync).toHaveBeenCalledTimes(3);
+		});
+
+		it('does not retry non-EINTR read errors', () => {
+			mockExistsSync.mockImplementation((p: string) => p === CANONICAL);
+			const eacces = Object.assign(new Error('EACCES: permission denied, read'), {
+				code: 'EACCES',
+			});
+			mockReadFileSync.mockImplementation(() => {
+				throw eacces;
+			});
+
+			expect(() => readCueConfigFile(PROJECT_ROOT)).toThrow(/EACCES/);
+			expect(mockReadFileSync).toHaveBeenCalledTimes(1);
+		});
 	});
 
 	describe('writeCueConfigFile', () => {

--- a/src/__tests__/main/stats/stale-wal-cleanup.test.ts
+++ b/src/__tests__/main/stats/stale-wal-cleanup.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Regression tests for stale WAL/SHM sidecar cleanup (MAESTRO-TX).
+ *
+ * `removeStaleWalFiles` runs before the database is opened so a leftover WAL
+ * from a crashed run can't trigger a false corruption verdict. It is
+ * best-effort: SQLite recovers from a live WAL on its own, so a failed unlink
+ * must not fail startup and must not page us. EBUSY is the normal Windows
+ * result when a second instance still holds the database open.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as path from 'path';
+import * as os from 'os';
+
+const mockDb = {
+	pragma: vi.fn(() => [{ user_version: 0 }]),
+	prepare: vi.fn(() => ({ run: vi.fn(), get: vi.fn(), all: vi.fn(() => []) })),
+	close: vi.fn(),
+	transaction: vi.fn((fn: () => void) => () => fn()),
+};
+
+vi.mock('better-sqlite3', () => ({
+	default: class MockDatabase {
+		pragma = mockDb.pragma;
+		prepare = mockDb.prepare;
+		close = mockDb.close;
+		transaction = mockDb.transaction;
+	},
+}));
+
+const mockUserDataPath = path.join(os.tmpdir(), 'maestro-test-stale-wal');
+vi.mock('electron', () => ({
+	app: { getPath: vi.fn(() => mockUserDataPath) },
+}));
+
+const mockFsExistsSync = vi.fn(() => true);
+const mockFsUnlinkSync = vi.fn();
+
+vi.mock('fs', () => ({
+	existsSync: (...args: unknown[]) => mockFsExistsSync(...args),
+	mkdirSync: vi.fn(),
+	copyFileSync: vi.fn(),
+	unlinkSync: (...args: unknown[]) => mockFsUnlinkSync(...args),
+	renameSync: vi.fn(),
+	statSync: vi.fn(() => ({ size: 1024 })),
+	readFileSync: vi.fn(() => String(Date.now())),
+	writeFileSync: vi.fn(),
+	readdirSync: vi.fn(() => [] as string[]),
+}));
+
+vi.mock('../../../main/utils/logger', () => ({
+	logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+const mockCaptureException = vi.fn();
+vi.mock('../../../main/utils/sentry', () => ({
+	captureException: (...args: unknown[]) => mockCaptureException(...args),
+}));
+
+vi.mock('../../../main/stats/migrations', () => ({
+	runMigrations: vi.fn(),
+	getMigrationHistory: vi.fn(() => []),
+	getCurrentVersion: vi.fn(() => 1),
+	getTargetVersion: vi.fn(() => 1),
+	hasPendingMigrations: vi.fn(() => false),
+}));
+
+import { StatsDB } from '../../../main/stats/stats-db';
+
+function errnoError(code: string): NodeJS.ErrnoException {
+	return Object.assign(new Error(`${code}: sidecar unlink failed`), { code });
+}
+
+describe('stale WAL/SHM sidecar cleanup', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockFsExistsSync.mockReturnValue(true);
+		mockDb.pragma.mockReturnValue([{ integrity_check: 'ok' }] as never);
+	});
+
+	it.each(['EBUSY', 'EPERM', 'EACCES', 'EROFS', 'ENOENT'])(
+		'does not report %s to Sentry - the sidecar is held or protected, not corrupt',
+		(code) => {
+			mockFsUnlinkSync.mockImplementation(() => {
+				throw errnoError(code);
+			});
+
+			const db = new StatsDB();
+			expect(() => db.initialize()).not.toThrow();
+
+			expect(mockCaptureException).not.toHaveBeenCalled();
+		}
+	);
+
+	it('still reports an unexpected sidecar failure to Sentry', () => {
+		mockFsUnlinkSync.mockImplementation(() => {
+			throw errnoError('EIO');
+		});
+
+		const db = new StatsDB();
+		db.initialize();
+
+		expect(mockCaptureException).toHaveBeenCalledTimes(1);
+		expect(mockCaptureException.mock.calls[0][0]).toMatchObject({ code: 'EIO' });
+	});
+});

--- a/src/main/cue/config/cue-config-repository.ts
+++ b/src/main/cue/config/cue-config-repository.ts
@@ -33,6 +33,39 @@ export function resolveCueConfigPath(projectRoot: string): string | null {
 }
 
 /**
+ * How many times to retry a config read interrupted by a signal. EINTR is
+ * transient by definition - the retry succeeds on the next attempt in practice,
+ * so a small bound is enough to absorb it without risking a spin.
+ */
+const EINTR_MAX_ATTEMPTS = 3;
+
+/**
+ * Read a file, retrying when the syscall is interrupted by a signal.
+ *
+ * `fs.readFileSync` surfaces EINTR to the caller instead of restarting the read
+ * itself. Electron's main process takes signals during startup, so a config read
+ * on the boot path can fail for a reason that has nothing to do with the file.
+ * That aborted `CueEngine.start('system-boot')` outright and left Cue disabled
+ * for the whole session until the user retried from Settings (MAESTRO-X9).
+ */
+function readFileRetryingOnEintr(filePath: string): string {
+	for (let attempt = 1; ; attempt++) {
+		try {
+			return fs.readFileSync(filePath, 'utf-8');
+		} catch (error) {
+			const code = (error as NodeJS.ErrnoException | null)?.code;
+			if (code !== 'EINTR' || attempt >= EINTR_MAX_ATTEMPTS) {
+				throw error;
+			}
+			logger.warn(
+				`[Cue] Config read interrupted (EINTR) for ${filePath}, retrying (${attempt}/${EINTR_MAX_ATTEMPTS})`,
+				'CueConfig'
+			);
+		}
+	}
+}
+
+/**
  * Read the raw YAML for a project's Cue config. Returns `null` if no config
  * file exists. Throws on filesystem read errors (other than missing file).
  */
@@ -44,7 +77,7 @@ export function readCueConfigFile(projectRoot: string): { filePath: string; raw:
 
 	return {
 		filePath,
-		raw: fs.readFileSync(filePath, 'utf-8'),
+		raw: readFileRetryingOnEintr(filePath),
 	};
 }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -3251,9 +3251,17 @@ function setupIpcHandlers() {
 					),
 			});
 		} catch (err) {
-			void captureException(err instanceof Error ? err : new Error(String(err)), {
-				operation: 'startup:coworkingBridge',
-			});
+			// EADDRINUSE means another Maestro process already owns the bridge
+			// socket/pipe for this userData slug. Bridge startup is deliberately
+			// non-fatal (the feature degrades to "not available" until the next
+			// launch), so a second instance losing the race is an expected
+			// outcome rather than a defect worth reporting (MAESTRO-WH).
+			const code = (err as NodeJS.ErrnoException | null)?.code;
+			if (code !== 'EADDRINUSE') {
+				void captureException(err instanceof Error ? err : new Error(String(err)), {
+					operation: 'startup:coworkingBridge',
+				});
+			}
 			logger.warn(`Failed to start coworking bridge: ${String(err)}`, 'Startup');
 		}
 	})();

--- a/src/main/stats/stats-db.ts
+++ b/src/main/stats/stats-db.ts
@@ -74,6 +74,22 @@ import type { ShortcutUsageDay, MultiWindowUsage } from '../../shared/stats-type
 import { captureException } from '../utils/sentry';
 
 /**
+ * Errno codes that mean a WAL/SHM sidecar could not be removed for an
+ * environmental reason rather than a Maestro defect: the file is still held
+ * open by another process (EBUSY - the usual Windows result when a second
+ * instance or a worktree build has the database open), we lack permission to
+ * unlink it (EPERM/EACCES/EROFS), or it vanished between the existsSync check
+ * and the unlink (ENOENT). Removal is best-effort, so none of these deserve a
+ * Sentry report (MAESTRO-TX).
+ */
+const EXPECTED_SIDECAR_ERROR_CODES = new Set(['EBUSY', 'EPERM', 'EACCES', 'EROFS', 'ENOENT']);
+
+function isExpectedSidecarError(error: unknown): boolean {
+	const code = (error as NodeJS.ErrnoException | null)?.code;
+	return typeof code === 'string' && EXPECTED_SIDECAR_ERROR_CODES.has(code);
+}
+
+/**
  * StatsDB manages the SQLite database for usage statistics.
  */
 export class StatsDB {
@@ -660,7 +676,15 @@ export class StatsDB {
 				logger.debug(`Removed stale SHM file: ${shmPath}`, LOG_CONTEXT);
 			}
 		} catch (error) {
-			void captureException(error);
+			// Best-effort cleanup: the sidecars are only removed to avoid a false
+			// corruption verdict, and SQLite recovers from a live WAL on its own.
+			// The listed codes all mean "another process still holds these files"
+			// or "we may not touch them" - environmental, never a Maestro bug.
+			// EBUSY in particular is the normal Windows result when a second
+			// instance (or a worktree build) has the database open (MAESTRO-TX).
+			if (!isExpectedSidecarError(error)) {
+				void captureException(error);
+			}
 			logger.warn(`Failed to remove stale WAL/SHM files for ${dbFilePath}: ${error}`, LOG_CONTEXT);
 		}
 	}


### PR DESCRIPTION
Sentry triage on the `rc` channel. Three field issues, all cases where a best-effort or transient condition was being reported as a defect. Same telemetry-noise-on-expected-condition family as #1094 / #1141 / #1214, plus one genuine functional fix.

## MAESTRO-TX - `EBUSY ... unlink 'stats.db-wal'` (16 events)

`StatsDB.removeStaleWalFiles` captured *every* unlink failure. The WAL/SHM sidecars are removed only so a leftover WAL from a crashed run can't trigger a false corruption verdict, and SQLite recovers from a live WAL on its own - a failed unlink is harmless. `EBUSY` is the normal Windows result when a second instance still holds the database open.

Skips Sentry for `EBUSY`/`EPERM`/`EACCES`/`EROFS`/`ENOENT`, keeps the local warn, and still reports anything else (verified with an `EIO` case).

## MAESTRO-X9 - `EINTR: interrupted system call, read` (readCueConfigFile)

**This one is a real bug, not just noise.** `fs.readFileSync` surfaces `EINTR` to the caller instead of restarting the syscall. Electron's main process takes signals during startup, so a config read on the boot path could fail for a reason unrelated to the file - which aborted `CueEngine.start('system-boot')` outright and left Cue disabled for the entire session until the user manually retried from Settings.

Retries the read up to 3 times on `EINTR`. Other errno codes still propagate immediately and unchanged.

## MAESTRO-WH - `EADDRINUSE ... \\.\pipe\maestro-coworking-*` (5 events)

Coworking bridge startup is deliberately non-fatal - the surrounding comment already says the feature "degrades to not available until next launch". A second instance losing the race for the socket/pipe is therefore an expected outcome, not a defect. Skips Sentry for `EADDRINUSE` only.

## Tests

Regression tests for the sidecar carve-out (each expected code, plus an `EIO` control that must still report) and the EINTR retry (retries then succeeds / gives up at the bound / does not retry `EACCES`).

Both suites confirmed **failing against the unfixed source** (`git stash` of the source files only): 7 failed / 30 passed before, 37 passed after. Full `stats/` + `cue/` suites: 1920 passed. `tsc` error count identical to clean `rc` (2 pre-existing).

## Investigated and deliberately not fixed

- **MAESTRO-XB/XC/XD/XE/X5** (OMP: `activeOmpWorkspaceRoot is not defined`, supervisor/runtime resource errors) - all originate from a `.worktrees/maestro-omp-deep-integration` dev build. None of that code exists on `rc`; nothing to fix here.
- **MAESTRO-XH/XG/XF** (`v?.current?.focus is not a function`, Modal chunk) - audited every `.focus()` call site in `src/renderer`, all 9 refs passed to custom components, and every recent change. Could not find a truthy-but-not-focusable ref. The error text requires a literal `?.current?.focus()`, and the only 6 such sites all run in `setTimeout`/`rAF`/event handlers, which doesn't reconcile with the React commit-phase frames. Needs the real `0.18.5-RC` sourcemap before guessing; adding a defensive guard would suppress the symptom without proving the cause.
- **MAESTRO-WM/WK** (`Failed to resolve module specifier "rehype-sanitize"`) - not a repo bug. The dependency, its import, and the lockfile entry all landed in one commit; there is no `rollupOptions.external`, no `build.lib`, no inline module script. The symptom requires a `vite build` against a `node_modules` missing the package, i.e. a broken local/partial install. Both issues are the same failure double-reported (splash.js echoes the console error).
- **MAESTRO-Q2** (`maestro-p --status`, now ~3.7k events) - deferred a 5th time; still needs a human call on maestro-p exit semantics.
- **MAESTRO-RS** (GLIBC 2.38), native/GPU crashes (VS/XA/X8/X7/X6), **MAESTRO-JS**/**R0** (genuine spawn failures = real signal).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when reading configuration files after interrupted file-system operations.
  * Prevented expected WAL/SHM cleanup conditions from generating unnecessary error reports.
  * Avoided reporting bridge startup conflicts when another app instance is already using the bridge.
* **Tests**
  * Added coverage for interrupted reads, retry limits, permission errors, and database sidecar cleanup scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->