### PR TITLE
fix(tab-naming): don't scrape a live TUI transcript for the tab name

### DIFF
--- a/src/__tests__/main/ipc/handlers/tabNaming.test.ts
+++ b/src/__tests__/main/ipc/handlers/tabNaming.test.ts
@@ -1158,6 +1158,80 @@ describe('Tab Naming IPC Handlers', () => {
 			await resultPromise;
 		});
 
+		// Regression for #1110: on the TUI path maestro-p strips the headless-only
+		// flags (including the `--tools ""` guard), so naming runs a real agentic
+		// turn and its raw terminal transcript is thinking/response prose, not
+		// stream-json. Scraping that buffer put a sentence fragment on the tab,
+		// which users saw as the response streaming into the tab name. Prose has no
+		// angle brackets, so STRUCTURAL_NOISE_RE can't catch it - we must decline.
+		it('returns null instead of scraping a plain-text TUI transcript for a name', async () => {
+			mockAgentDetector.getAgent.mockResolvedValue(interactiveClaudeAgent);
+			let onDataCallback: ((sessionId: string, data: string) => void) | undefined;
+			let onExitCallback: ((sessionId: string, code?: number) => void) | undefined;
+			mockProcessManager.on.mockImplementation(
+				(event: string, callback: (...args: any[]) => void) => {
+					if (event === 'data') onDataCallback = callback;
+					if (event === 'exit') onExitCallback = callback;
+				}
+			);
+
+			const resultPromise = invokeHandler('tabNaming:generateTabName', {
+				userMessage: 'Help me implement a login form',
+				agentType: 'claude-code',
+				cwd: '/test/project',
+				enableMaestroP: true,
+				maestroPMode: 'interactive',
+				maestroPPath: '/bundled/maestro-p.js',
+			});
+
+			await vi.waitFor(() => {
+				expect(mockProcessManager.spawn).toHaveBeenCalled();
+			});
+
+			// A realistic maestro-p TUI transcript: short prose lines that clear the
+			// 40-char filter and carry no structural noise.
+			onDataCallback?.(
+				'tab-naming-mock-uuid-1234',
+				'I should look at the auth flow\nLet me start with the form\n'
+			);
+			onExitCallback?.('tab-naming-mock-uuid-1234', 0);
+
+			await expect(resultPromise).resolves.toBeNull();
+		});
+
+		it('still accepts a stream-json name on the TUI path', async () => {
+			mockAgentDetector.getAgent.mockResolvedValue(interactiveClaudeAgent);
+			let onDataCallback: ((sessionId: string, data: string) => void) | undefined;
+			let onExitCallback: ((sessionId: string, code?: number) => void) | undefined;
+			mockProcessManager.on.mockImplementation(
+				(event: string, callback: (...args: any[]) => void) => {
+					if (event === 'data') onDataCallback = callback;
+					if (event === 'exit') onExitCallback = callback;
+				}
+			);
+
+			const resultPromise = invokeHandler('tabNaming:generateTabName', {
+				userMessage: 'Help me implement a login form',
+				agentType: 'claude-code',
+				cwd: '/test/project',
+				enableMaestroP: true,
+				maestroPMode: 'interactive',
+				maestroPPath: '/bundled/maestro-p.js',
+			});
+
+			await vi.waitFor(() => {
+				expect(mockProcessManager.spawn).toHaveBeenCalled();
+			});
+
+			onDataCallback?.(
+				'tab-naming-mock-uuid-1234',
+				`${JSON.stringify({ type: 'result', subtype: 'success', result: 'Login Form' })}\n`
+			);
+			onExitCallback?.('tab-naming-mock-uuid-1234', 0);
+
+			await expect(resultPromise).resolves.toBe('Login Form');
+		});
+
 		it('spawns plain claude when the agent is API-only (enableMaestroP false)', async () => {
 			mockAgentDetector.getAgent.mockResolvedValue(interactiveClaudeAgent);
 			const finish = wireProcessEvents();

--- a/src/main/ipc/handlers/tabNaming.ts
+++ b/src/main/ipc/handlers/tabNaming.ts
@@ -382,6 +382,13 @@ export function registerTabNamingHandlers(deps: TabNamingHandlerDependencies): v
 						});
 					}
 
+					// A TUI (maestro-p) naming spawn emits a plain terminal transcript,
+					// not stream-json, so the raw-output fallback in extraction would
+					// scrape live thinking/response prose onto the tab. Require
+					// structured output on that path. Covers both the local wrap above
+					// and the remote maestro-p case, which share the same decision mode.
+					const requireStructuredOutput = claudeSpawnDecision?.mode === 'interactive';
+
 					// Create a promise that resolves when we get the tab name
 					return new Promise<string | null>((resolve) => {
 						let output = '';
@@ -427,7 +434,11 @@ export function registerTabNamingHandlers(deps: TabNamingHandlerDependencies): v
 						// without waiting for the full process to exit.
 						const earlyExtractIntervalId = setInterval(() => {
 							if (resolved || !output.trim()) return;
-							const earlyResult = extractTabNameFromOutput(config.agentType, output);
+							const earlyResult = extractTabNameFromOutput(
+								config.agentType,
+								output,
+								requireStructuredOutput
+							);
 							if (earlyResult.name) {
 								resolveWith(earlyResult.name, 'resolved early from partial output');
 							}
@@ -467,7 +478,11 @@ export function registerTabNamingHandlers(deps: TabNamingHandlerDependencies): v
 								return;
 							}
 
-							const extraction = extractTabNameFromOutput(config.agentType, output);
+							const extraction = extractTabNameFromOutput(
+								config.agentType,
+								output,
+								requireStructuredOutput
+							);
 							if (!extraction.name) {
 								logger.warn('Tab naming extraction failed', LOG_CONTEXT, {
 									sessionId,
@@ -621,9 +636,27 @@ function extractAgentResponseText(agentType: string, output: string): string | n
  * Extract a tab name from raw agent process output, normalizing structured
  * (stream-json) output via the agent's parser first and falling back to
  * plain-text extraction over the raw output.
+ *
+ * `structuredOnly` disables that raw-output fallback. Pass it when the naming
+ * spawn drives the maestro-p TUI (Claude token mode = TUI/dynamic): maestro-p
+ * strips the headless-only flags, including the `--tools ""` guard, so the
+ * model runs a real agentic turn and `output` is a live terminal transcript of
+ * thinking and response prose rather than stream-json. Scraping that buffer
+ * lifts an arbitrary sentence fragment onto the tab, which is what users see as
+ * "the response is streaming into the tab name" (issue #1110). Prose has no
+ * angle brackets, so STRUCTURAL_NOISE_RE can't catch it - the only safe answer
+ * is to decline. Returning null costs nothing: the send-side trigger retries
+ * naming on the next message, so the tab keeps its placeholder and self-heals.
  */
-function extractTabNameFromOutput(agentType: string, output: string): TabNameExtractionResult {
+function extractTabNameFromOutput(
+	agentType: string,
+	output: string,
+	structuredOnly = false
+): TabNameExtractionResult {
 	const responseText = extractAgentResponseText(agentType, output);
+	if (responseText === null && structuredOnly) {
+		return { name: null, reason: 'structured_only_no_json' };
+	}
 	return extractTabName(responseText ?? output);
 }
 


### PR DESCRIPTION
Closes #1110

## Problem

On the maestro-p TUI path (Claude token mode = TUI/dynamic), maestro-p strips the headless-only flags, including the `--tools ""` guard that keeps tab naming from becoming a real agentic run. The naming spawn therefore runs a full turn and emits a plain terminal transcript rather than stream-json.

`extractTabNameFromOutput` tried the agent's parser first, and when that found no JSON it fell back to scraping the raw output. On this path the raw output is a live transcript of thinking and response prose, so an arbitrary sentence fragment landed on the tab. That is what the reporter saw as "the response is streaming into the tab name."

`STRUCTURAL_NOISE_RE` (added in 4a308b31) catches the tool-call markup and `(no content)` variants of this leak, but it cannot catch plain prose - a thinking fragment has no angle brackets and clears the 40-char line filter.

This also explains the reported local-vs-SSH asymmetry: an SSH remote without `maestro-p` on its PATH collapses back to `claude --print`, which yields clean stream-json.

## Fix

Require structured output when the spawn resolved to interactive mode. If the parser cannot lift a clean result there, return null instead of scraping the buffer. Returning null is cheap: the send-side trigger retries naming on the next message, so the tab keeps its placeholder and self-heals rather than sticking a fragment.

The gate is `claudeSpawnDecision?.mode === 'interactive'`, which covers both the local maestro-p wrap and the remote maestro-p case. Headless `claude --print` and non-Claude agents are untouched and keep the raw-output fallback.

## Note on scope

The issue also reports the chat body staying empty. I could not find a code path where stream chunks are routed away from the chat: `useAgentDataListener` is the sole consumer and only ever appends to the log, and the naming spawn runs under a disjoint `tab-naming-*` id that cannot match `REGEX_AI_TAB`. This PR fixes the tab-name half, which is the part I could reproduce from the code. If the empty chat body persists for the reporter after this lands, that is worth a separate issue with a debug package.

## Testing

- Two regression tests in the `Claude token-source resolution` block: a plain-text TUI transcript now resolves to null, and a stream-json result on the same path still yields the name.
- Full file: 46/46 passing. `npm run lint` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic tab naming for interactive sessions by using only structured results.
  * Prevented plain-text progress or conversation output from being incorrectly selected as a tab name.
  * Preserved valid tab names when structured result data is available.

* **Tests**
  * Added regression coverage for ignoring unstructured output and correctly handling structured results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->