### PR TITLE
Fix lost agent responses during stale idle reconciliation

### DIFF
--- a/src/__tests__/main/ipc/handlers/process.test.ts
+++ b/src/__tests__/main/ipc/handlers/process.test.ts
@@ -21,6 +21,7 @@ import {
 import { getDefaultShell } from '../../../../main/stores/defaults';
 import { stripThinkingFromTranscript } from '../../../../main/agents/claude-transcript-sanitizer';
 import { checkCustomPath } from '../../../../main/agents/path-prober';
+import { getChildProcesses } from '../../../../main/process-manager/utils/childProcessInfo';
 
 // Mock electron's ipcMain
 vi.mock('electron', () => ({
@@ -1391,6 +1392,28 @@ describe('process IPC handlers', () => {
 			const result = await handler!({} as any);
 
 			expect(result).toEqual([]);
+		});
+
+		it('should skip terminal child-process inspection when requested', async () => {
+			mockProcessManager.getAll.mockReturnValue([
+				{
+					sessionId: 'session-2-terminal',
+					toolType: 'terminal',
+					pid: 5678,
+					cwd: '/project2',
+					isTerminal: true,
+					isBatchMode: false,
+					startTime: 1700000001000,
+					command: '/bin/zsh',
+					args: [],
+				},
+			]);
+
+			const handler = handlers.get('process:getActiveProcesses');
+			const result = await handler!({} as any, { includeChildProcesses: false });
+
+			expect(result).toHaveLength(1);
+			expect(getChildProcesses).not.toHaveBeenCalled();
 		});
 
 		it('should strip non-serializable properties from process objects', async () => {

--- a/src/__tests__/main/preload/process.test.ts
+++ b/src/__tests__/main/preload/process.test.ts
@@ -188,6 +188,16 @@ describe('Process Preload API', () => {
 			expect(mockInvoke).toHaveBeenCalledWith('process:getActiveProcesses');
 			expect(result).toEqual(mockProcesses);
 		});
+
+		it('should pass active-process query options', async () => {
+			mockInvoke.mockResolvedValue([]);
+
+			await api.getActiveProcesses({ includeChildProcesses: false });
+
+			expect(mockInvoke).toHaveBeenCalledWith('process:getActiveProcesses', {
+				includeChildProcesses: false,
+			});
+		});
 	});
 
 	describe('isTerminalBusy', () => {

--- a/src/__tests__/main/process-manager.test.ts
+++ b/src/__tests__/main/process-manager.test.ts
@@ -699,7 +699,7 @@ describe('process-manager.ts', () => {
 			});
 		});
 
-		describe('spawn() kill-before-spawn guard', () => {
+		describe('spawn() existing process guard', () => {
 			afterEach(() => {
 				mockIsWindows.mockImplementation(() => process.platform === 'win32');
 			});
@@ -741,6 +741,39 @@ describe('process-manager.ts', () => {
 				}
 
 				expect(mockPtyKill).toHaveBeenCalledWith('SIGTERM');
+			});
+
+			it('should refuse to replace a live agent process with the same sessionId', () => {
+				const processes = (processManager as any).processes as Map<string, any>;
+				const liveChildProcess = {
+					pid: 32828,
+					exitCode: null,
+					signalCode: null,
+					kill: vi.fn(),
+				};
+				const liveProcess = {
+					sessionId: 'dup-agent-session',
+					toolType: 'codex',
+					isTerminal: false,
+					pid: 32828,
+					cwd: '/tmp',
+					startTime: Date.now(),
+					childProcess: liveChildProcess,
+				};
+				processes.set('dup-agent-session', liveProcess);
+
+				expect(() =>
+					processManager.spawn({
+						sessionId: 'dup-agent-session',
+						toolType: 'codex',
+						cwd: '/tmp',
+						command: 'codex',
+						args: ['exec', '--json'],
+						prompt: 'second turn',
+					})
+				).toThrow('Agent process already running for session dup-agent-session');
+				expect(liveChildProcess.kill).not.toHaveBeenCalled();
+				expect(processManager.get('dup-agent-session')).toBe(liveProcess);
 			});
 		});
 

--- a/src/__tests__/main/process-manager.test.ts
+++ b/src/__tests__/main/process-manager.test.ts
@@ -775,6 +775,39 @@ describe('process-manager.ts', () => {
 				expect(liveChildProcess.kill).not.toHaveBeenCalled();
 				expect(processManager.get('dup-agent-session')).toBe(liveProcess);
 			});
+
+			it('should retain an exited agent until close cleanup drains its output', () => {
+				const processes = (processManager as any).processes as Map<string, any>;
+				const exitingChildProcess = {
+					pid: 32829,
+					exitCode: 0,
+					signalCode: null,
+					kill: vi.fn(),
+				};
+				const exitingProcess = {
+					sessionId: 'draining-agent-session',
+					toolType: 'codex',
+					isTerminal: false,
+					pid: 32829,
+					cwd: '/tmp',
+					startTime: Date.now(),
+					childProcess: exitingChildProcess,
+				};
+				processes.set('draining-agent-session', exitingProcess);
+
+				expect(() =>
+					processManager.spawn({
+						sessionId: 'draining-agent-session',
+						toolType: 'codex',
+						cwd: '/tmp',
+						command: 'codex',
+						args: ['exec', '--json'],
+						prompt: 'replayed turn',
+					})
+				).toThrow('Agent process already running for session draining-agent-session');
+				expect(exitingChildProcess.kill).not.toHaveBeenCalled();
+				expect(processManager.get('draining-agent-session')).toBe(exitingProcess);
+			});
 		});
 
 		describe('killAll() map safety', () => {

--- a/src/__tests__/main/process-manager/handlers/ExitHandler.test.ts
+++ b/src/__tests__/main/process-manager/handlers/ExitHandler.test.ts
@@ -399,6 +399,16 @@ describe('ExitHandler', () => {
 
 			expect(exitEvents).toEqual([{ sessionId: 'unknown-session', code: 1 }]);
 		});
+
+		it('should not delete a newer process registered under the same sessionId', async () => {
+			const exitingProcess = createMockProcess({ pid: 11111 });
+			const replacementProcess = createMockProcess({ pid: 22222 });
+			processes.set('test-session', replacementProcess);
+
+			await exitHandler.handleExit('test-session', 0, exitingProcess);
+
+			expect(processes.get('test-session')).toBe(replacementProcess);
+		});
 	});
 
 	describe('SSH error pattern false-positive prevention', () => {

--- a/src/__tests__/main/process-manager/handlers/ExitHandler.test.ts
+++ b/src/__tests__/main/process-manager/handlers/ExitHandler.test.ts
@@ -391,6 +391,20 @@ describe('ExitHandler', () => {
 			expect(processes.has('test-session')).toBe(false);
 		});
 
+		it('should release the session before exit listeners run', async () => {
+			const proc = createMockProcess();
+			processes.set('test-session', proc);
+
+			let processAtExit: ManagedProcess | undefined;
+			emitter.on('exit', () => {
+				processAtExit = processes.get('test-session');
+			});
+
+			await exitHandler.handleExit('test-session', 0);
+
+			expect(processAtExit).toBeUndefined();
+		});
+
 		it('should emit exit event for unknown sessions', async () => {
 			const exitEvents: Array<{ sessionId: string; code: number }> = [];
 			emitter.on('exit', (sid: string, code: number) => exitEvents.push({ sessionId: sid, code }));
@@ -401,13 +415,20 @@ describe('ExitHandler', () => {
 		});
 
 		it('should not delete a newer process registered under the same sessionId', async () => {
-			const exitingProcess = createMockProcess({ pid: 11111 });
-			const replacementProcess = createMockProcess({ pid: 22222 });
+			const exitingProcess = createMockProcess({ pid: 11111, dataBuffer: 'old tail' });
+			const replacementProcess = createMockProcess({ pid: 22222, dataBuffer: 'new output' });
 			processes.set('test-session', replacementProcess);
+			const dataEvents: string[] = [];
+			const exitEvents: number[] = [];
+			emitter.on('data', (_sid: string, data: string) => dataEvents.push(data));
+			emitter.on('exit', (_sid: string, code: number) => exitEvents.push(code));
 
 			await exitHandler.handleExit('test-session', 0, exitingProcess);
 
 			expect(processes.get('test-session')).toBe(replacementProcess);
+			expect(replacementProcess.dataBuffer).toBe('new output');
+			expect(dataEvents).toEqual(['old tail']);
+			expect(exitEvents).toEqual([]);
 		});
 	});
 

--- a/src/__tests__/main/process-manager/spawners/PtySpawner.test.ts
+++ b/src/__tests__/main/process-manager/spawners/PtySpawner.test.ts
@@ -245,7 +245,7 @@ describe('PtySpawner', () => {
 			expect(processes.get('my-session')?.pid).toBe(99999);
 		});
 
-		it('sets isTerminal=true for all PTY processes', () => {
+		it('records terminal identity independently of the PTY transport', () => {
 			const { spawner, processes } = createTestContext();
 
 			// Shell terminal
@@ -262,6 +262,18 @@ describe('PtySpawner', () => {
 				})
 			);
 			expect(processes.get('ssh-session')?.isTerminal).toBe(true);
+
+			// AI agent that requires a PTY
+			spawner.spawn(
+				createBaseConfig({
+					sessionId: 'agent-pty-session',
+					toolType: 'claude-code',
+					command: 'claude',
+					args: [],
+					shell: undefined,
+				})
+			);
+			expect(processes.get('agent-pty-session')?.isTerminal).toBe(false);
 		});
 	});
 });

--- a/src/__tests__/main/process-manager/spawners/PtySpawner.test.ts
+++ b/src/__tests__/main/process-manager/spawners/PtySpawner.test.ts
@@ -276,4 +276,56 @@ describe('PtySpawner', () => {
 			expect(processes.get('agent-pty-session')?.isTerminal).toBe(false);
 		});
 	});
+
+	describe('exit ownership', () => {
+		it('releases an AI process before notifying synchronous replay listeners', () => {
+			const { spawner, processes, emitter } = createTestContext();
+			const config = createBaseConfig({
+				sessionId: 'agent-pty-session',
+				toolType: 'claude-code',
+				command: 'claude',
+				shell: undefined,
+			});
+
+			spawner.spawn(config);
+			const exitingProcess = processes.get(config.sessionId);
+			const onExit = mockPtyProcess.onExit.mock.calls[0][0];
+			emitter.on('exit', () => spawner.spawn(config));
+
+			expect(() => onExit({ exitCode: 0, signal: 0 })).not.toThrow();
+			expect(processes.get(config.sessionId)).not.toBe(exitingProcess);
+		});
+
+		it('ignores an exit from a stale terminal generation', () => {
+			const { spawner, processes, emitter } = createTestContext();
+			const config = createBaseConfig({ sessionId: 'restarted-terminal' });
+			const exitListener = vi.fn();
+			emitter.on('exit', exitListener);
+
+			spawner.spawn(config);
+			const staleOnExit = mockPtyProcess.onExit.mock.calls[0][0];
+			spawner.spawn(config);
+			const replacement = processes.get(config.sessionId);
+
+			staleOnExit({ exitCode: 0, signal: 0 });
+
+			expect(processes.get(config.sessionId)).toBe(replacement);
+			expect(exitListener).not.toHaveBeenCalled();
+		});
+
+		it('emits exit when an explicit kill already removed the process entry', () => {
+			const { spawner, processes, emitter } = createTestContext();
+			const config = createBaseConfig({ sessionId: 'killed-terminal' });
+			const exitListener = vi.fn();
+			emitter.on('exit', exitListener);
+
+			spawner.spawn(config);
+			const onExit = mockPtyProcess.onExit.mock.calls[0][0];
+			processes.delete(config.sessionId);
+
+			onExit({ exitCode: 143, signal: 15 });
+
+			expect(exitListener).toHaveBeenCalledWith(config.sessionId, 143, 15);
+		});
+	});
 });

--- a/src/__tests__/renderer/hooks/useInputProcessing.test.ts
+++ b/src/__tests__/renderer/hooks/useInputProcessing.test.ts
@@ -942,6 +942,82 @@ describe('useInputProcessing', () => {
 			expect(updatedSession.executionQueue).toHaveLength(1);
 			expect(updatedSession.executionQueue[0].text).toBe('where is my answer');
 		});
+
+		it('queues when active process reconciliation fails', async () => {
+			const readOnlyTab = createMockTab({ readOnlyMode: true });
+			const session = createMockSession({
+				state: 'idle',
+				aiTabs: [readOnlyTab],
+				activeTabId: readOnlyTab.id,
+			});
+			vi.mocked(window.maestro.process.getActiveProcesses).mockRejectedValue(
+				new Error('process IPC unavailable')
+			);
+			const deps = createDeps({
+				activeSession: session,
+				sessionsRef: { current: [session] },
+				inputValue: 'preserve this message',
+			});
+			const { result } = renderHook(() => useInputProcessing(deps));
+
+			await act(async () => {
+				await result.current.processInput();
+			});
+
+			expect(window.maestro.process.spawn).not.toHaveBeenCalled();
+			const updateSessions = mockSetSessions.mock.calls[0][0];
+			const [updatedSession] = updateSessions([session]);
+			expect(updatedSession.state).toBe('busy');
+			expect(updatedSession.aiTabs[0].state).toBe('busy');
+			expect(updatedSession.executionQueue).toHaveLength(1);
+			expect(updatedSession.executionQueue[0].text).toBe('preserve this message');
+		});
+
+		it('keeps the submitted tab pinned when the active tab changes during reconciliation', async () => {
+			const submittedTab = createMockTab({
+				id: 'submitted-tab',
+				agentSessionId: 'provider-session-submitted',
+			});
+			const switchedTab = createMockTab({
+				id: 'switched-tab',
+				agentSessionId: 'provider-session-switched',
+			});
+			const session = createMockSession({
+				state: 'idle',
+				aiTabs: [submittedTab, switchedTab],
+				activeTabId: submittedTab.id,
+			});
+			const sessionsRef = { current: [session] };
+			vi.mocked(window.maestro.process.getActiveProcesses).mockImplementation(async () => {
+				sessionsRef.current = [{ ...session, activeTabId: switchedTab.id }];
+				return [];
+			});
+			const deps = createDeps({
+				activeSession: session,
+				sessionsRef,
+				inputValue: 'send this to the submitted tab',
+			});
+			const { result } = renderHook(() => useInputProcessing(deps));
+
+			await act(async () => {
+				await result.current.processInput();
+			});
+
+			expect(window.maestro.process.spawn).toHaveBeenCalledWith(
+				expect.objectContaining({
+					sessionId: `${session.id}-ai-${submittedTab.id}`,
+					agentSessionId: submittedTab.agentSessionId,
+				})
+			);
+			const updateSessions = mockSetSessions.mock.calls[0][0];
+			const [loggedSession] = updateSessions(sessionsRef.current);
+			expect(
+				loggedSession.aiTabs.find((tab: AITab) => tab.id === submittedTab.id)?.logs.at(-1)?.text
+			).toBe('send this to the submitted tab');
+			expect(
+				loggedSession.aiTabs.find((tab: AITab) => tab.id === switchedTab.id)?.logs
+			).toHaveLength(0);
+		});
 	});
 
 	describe('Auto Run blocking', () => {

--- a/src/__tests__/renderer/hooks/useInputProcessing.test.ts
+++ b/src/__tests__/renderer/hooks/useInputProcessing.test.ts
@@ -94,6 +94,7 @@ describe('useInputProcessing', () => {
 				spawn: vi.fn().mockResolvedValue(undefined),
 				write: vi.fn().mockResolvedValue(undefined),
 				runCommand: vi.fn().mockResolvedValue(undefined),
+				getActiveProcesses: vi.fn().mockResolvedValue([]),
 				broadcastUserInput: vi.fn().mockResolvedValue(undefined),
 				onUserInput: vi.fn().mockReturnValue(() => {}),
 			},
@@ -902,6 +903,44 @@ describe('useInputProcessing', () => {
 			// Should match the override value, not the inputValue
 			expect(mockSetInputValue).toHaveBeenCalledWith('');
 			vi.useRealTimers();
+		});
+	});
+
+	describe('active process reconciliation', () => {
+		it('queues instead of replacing a live process when renderer state is stale idle', async () => {
+			const session = createMockSession({ state: 'idle' });
+			vi.mocked(window.maestro.process.getActiveProcesses).mockResolvedValue([
+				{
+					sessionId: `${session.id}-ai-${session.activeTabId}`,
+					toolType: session.toolType,
+					pid: 32828,
+					cwd: session.cwd,
+					isTerminal: false,
+					isBatchMode: true,
+					startTime: 1700000000000,
+				},
+			]);
+			const deps = createDeps({
+				activeSession: session,
+				sessionsRef: { current: [session] },
+				inputValue: 'where is my answer',
+			});
+			const { result } = renderHook(() => useInputProcessing(deps));
+
+			await act(async () => {
+				await result.current.processInput();
+			});
+
+			expect(window.maestro.process.spawn).not.toHaveBeenCalled();
+			expect(window.maestro.process.getActiveProcesses).toHaveBeenCalledWith({
+				includeChildProcesses: false,
+			});
+			const updateSessions = mockSetSessions.mock.calls[0][0];
+			const [updatedSession] = updateSessions([session]);
+			expect(updatedSession.state).toBe('busy');
+			expect(updatedSession.aiTabs[0].state).toBe('busy');
+			expect(updatedSession.executionQueue).toHaveLength(1);
+			expect(updatedSession.executionQueue[0].text).toBe('where is my answer');
 		});
 	});
 

--- a/src/main/ipc/handlers/process.ts
+++ b/src/main/ipc/handlers/process.ts
@@ -66,6 +66,10 @@ export interface CueProcessEntry {
 	sshRemoteCommand?: string;
 }
 
+interface ProcessQuery {
+	includeChildProcesses?: boolean;
+}
+
 export interface ProcessHandlerDependencies {
 	getProcessManager: () => ProcessManager | null;
 	getAgentDetector: () => AgentDetector | null;
@@ -232,7 +236,7 @@ export function registerProcessHandlers(deps: ProcessHandlerDependencies): void 
 	// Get all active processes managed by the ProcessManager (and Cue runs if available)
 	ipcMain.handle(
 		'process:getActiveProcesses',
-		withIpcErrorLogging(handlerOpts('getActiveProcesses'), async () => {
+		withIpcErrorLogging(handlerOpts('getActiveProcesses'), async (options?: ProcessQuery) => {
 			const processManager = requireProcessManager(getProcessManager);
 			const processes = processManager.getAll();
 			// Return serializable process info (exclude non-serializable PTY/child process objects)
@@ -252,7 +256,7 @@ export function registerProcessHandlers(deps: ProcessHandlerDependencies): void 
 						maestroEnvVars: p.maestroEnvVars,
 						sshRemoteCommand: p.sshRemoteCommand,
 					};
-					if (p.isTerminal && p.pid) {
+					if (options?.includeChildProcesses !== false && p.isTerminal && p.pid) {
 						const children = await getChildProcesses(p.pid);
 						if (children.length > 0) {
 							entry.childProcesses = children;

--- a/src/main/preload/process.ts
+++ b/src/main/preload/process.ts
@@ -236,8 +236,12 @@ export function createProcessApi() {
 		/**
 		 * Get all active processes from ProcessManager
 		 */
-		getActiveProcesses: (): Promise<ActiveProcess[]> =>
-			ipcRenderer.invoke('process:getActiveProcesses'),
+		getActiveProcesses: (options?: {
+			includeChildProcesses?: boolean;
+		}): Promise<ActiveProcess[]> =>
+			options === undefined
+				? ipcRenderer.invoke('process:getActiveProcesses')
+				: ipcRenderer.invoke('process:getActiveProcesses', options),
 
 		/**
 		 * Check whether a terminal tab's PTY has a non-shell foreground process

--- a/src/main/process-manager/ProcessManager.ts
+++ b/src/main/process-manager/ProcessManager.ts
@@ -99,9 +99,11 @@ export class ProcessManager extends EventEmitter {
 			}
 		}
 
-		// Never replace a live AI process. Renderer state can briefly lag process
-		// state, and destructive replacement loses the first turn's final output.
-		// Exited entries may be replaced for flows such as Claude limit replay.
+		// Never replace an AI process while it still owns the session entry. Node's
+		// `exit` event can set exitCode before `close` drains stdout, so exitCode is
+		// not enough to prove that the final response has been reconciled. The exit
+		// handler removes the entry before emitting `exit`, which lets replay flows
+		// start the next process without racing the old process's trailing output.
 		// Terminals intentionally keep their existing restart behavior.
 		const existing = this.processes.get(config.sessionId);
 		if (existing) {
@@ -115,8 +117,8 @@ export class ProcessManager extends EventEmitter {
 				existing.ptyProcess !== undefined ||
 				existing.sdkController !== undefined;
 
-			if (!existing.isTerminal && existingProcessRunning) {
-				logger.warn('[ProcessManager] Refusing to replace live agent process', 'ProcessManager', {
+			if (!existing.isTerminal) {
+				logger.warn('[ProcessManager] Refusing to replace owned agent process', 'ProcessManager', {
 					sessionId: config.sessionId,
 					existingPid: existing.pid,
 					existingToolType: existing.toolType,

--- a/src/main/process-manager/ProcessManager.ts
+++ b/src/main/process-manager/ProcessManager.ts
@@ -79,8 +79,8 @@ export class ProcessManager extends EventEmitter {
 	/**
 	 * Spawn a new process for a session.
 	 *
-	 * If a process already exists for the given sessionId, it is killed first
-	 * to prevent orphaned PTY/child processes that are no longer tracked.
+	 * Live AI processes own their sessionId until they exit. Terminal processes
+	 * retain replacement semantics so shell restarts continue to work.
 	 */
 	spawn(config: ProcessConfig): SpawnResult {
 		// Expand a leading `~` in the working directory before spawning. node-pty
@@ -99,16 +99,41 @@ export class ProcessManager extends EventEmitter {
 			}
 		}
 
-		// Kill any existing process for this sessionId to prevent orphans.
-		// This guards against double-spawn race conditions where a second spawn
-		// overwrites the map entry and the first process becomes untracked.
+		// Never replace a live AI process. Renderer state can briefly lag process
+		// state, and destructive replacement loses the first turn's final output.
+		// Exited entries may be replaced for flows such as Claude limit replay.
+		// Terminals intentionally keep their existing restart behavior.
 		const existing = this.processes.get(config.sessionId);
 		if (existing) {
-			logger.warn('[ProcessManager] Killing existing process before re-spawn', 'ProcessManager', {
-				sessionId: config.sessionId,
-				existingPid: existing.pid,
-			});
-			this.kill(config.sessionId);
+			const childProcessRunning =
+				existing.childProcess !== undefined &&
+				existing.childProcess.exitCode === null &&
+				(existing.childProcess.signalCode === null ||
+					existing.childProcess.signalCode === undefined);
+			const existingProcessRunning =
+				childProcessRunning ||
+				existing.ptyProcess !== undefined ||
+				existing.sdkController !== undefined;
+
+			if (!existing.isTerminal && existingProcessRunning) {
+				logger.warn('[ProcessManager] Refusing to replace live agent process', 'ProcessManager', {
+					sessionId: config.sessionId,
+					existingPid: existing.pid,
+					existingToolType: existing.toolType,
+					requestedToolType: config.toolType,
+				});
+				throw new Error(`Agent process already running for session ${config.sessionId}`);
+			}
+
+			if (existingProcessRunning) {
+				logger.warn('[ProcessManager] Restarting existing terminal process', 'ProcessManager', {
+					sessionId: config.sessionId,
+					existingPid: existing.pid,
+				});
+				this.kill(config.sessionId);
+			} else {
+				this.processes.delete(config.sessionId);
+			}
 		}
 
 		// Decide the OpenCode SDK-serve path on the RAW config, before any coworking

--- a/src/main/process-manager/handlers/DataBufferManager.ts
+++ b/src/main/process-manager/handlers/DataBufferManager.ts
@@ -17,8 +17,8 @@ export class DataBufferManager {
 	 * Buffer data and emit in batches.
 	 * Data is accumulated and flushed every 50ms or when buffer exceeds 8KB.
 	 */
-	emitDataBuffered(sessionId: string, data: string): void {
-		const managedProcess = this.processes.get(sessionId);
+	emitDataBuffered(sessionId: string, data: string, process?: ManagedProcess): void {
+		const managedProcess = process ?? this.processes.get(sessionId);
 		if (!managedProcess) {
 			this.emitter.emit('data', sessionId, data);
 			return;
@@ -27,13 +27,13 @@ export class DataBufferManager {
 		managedProcess.dataBuffer = (managedProcess.dataBuffer || '') + data;
 
 		if (managedProcess.dataBuffer.length > DATA_BUFFER_SIZE_THRESHOLD) {
-			this.flushDataBuffer(sessionId);
+			this.flushDataBuffer(sessionId, managedProcess);
 			return;
 		}
 
 		if (!managedProcess.dataBufferTimeout) {
 			managedProcess.dataBufferTimeout = setTimeout(() => {
-				this.flushDataBuffer(sessionId);
+				this.flushDataBuffer(sessionId, managedProcess);
 			}, DATA_BUFFER_FLUSH_INTERVAL);
 		}
 	}
@@ -41,8 +41,8 @@ export class DataBufferManager {
 	/**
 	 * Flush the data buffer for a session
 	 */
-	flushDataBuffer(sessionId: string): void {
-		const managedProcess = this.processes.get(sessionId);
+	flushDataBuffer(sessionId: string, process?: ManagedProcess): void {
+		const managedProcess = process ?? this.processes.get(sessionId);
 		if (!managedProcess) return;
 
 		if (managedProcess.dataBufferTimeout) {

--- a/src/main/process-manager/handlers/ExitHandler.ts
+++ b/src/main/process-manager/handlers/ExitHandler.ts
@@ -47,8 +47,12 @@ export class ExitHandler {
 	 * done (currently: Copilot CLI - see `awaitCopilotShutdown`).
 	 * Callers fire-and-forget, so errors are caught internally.
 	 */
-	async handleExit(sessionId: string, code: number): Promise<void> {
-		const managedProcess = this.processes.get(sessionId);
+	async handleExit(
+		sessionId: string,
+		code: number,
+		exitingProcess?: ManagedProcess
+	): Promise<void> {
+		const managedProcess = exitingProcess ?? this.processes.get(sessionId);
 		if (!managedProcess) {
 			this.emitter.emit('exit', sessionId, code);
 			return;
@@ -300,7 +304,9 @@ export class ExitHandler {
 		this.bufferManager.flushDataBuffer(sessionId);
 
 		this.emitter.emit('exit', sessionId, code);
-		this.processes.delete(sessionId);
+		if (this.processes.get(sessionId) === managedProcess) {
+			this.processes.delete(sessionId);
+		}
 	}
 
 	/**

--- a/src/main/process-manager/handlers/ExitHandler.ts
+++ b/src/main/process-manager/handlers/ExitHandler.ts
@@ -61,7 +61,7 @@ export class ExitHandler {
 		const { isBatchMode, isStreamJsonMode, outputParser, toolType } = managedProcess;
 
 		// Flush any remaining buffered data before exit
-		this.bufferManager.flushDataBuffer(sessionId);
+		this.bufferManager.flushDataBuffer(sessionId, managedProcess);
 
 		logger.debug('[ProcessManager] Child process exit event', 'ProcessManager', {
 			sessionId,
@@ -121,12 +121,12 @@ export class ExitHandler {
 					managedProcess.resultEmitted = true;
 					const resultText = event.text || managedProcess.streamedText || '';
 					if (resultText) {
-						this.bufferManager.emitDataBuffered(sessionId, resultText);
+						this.bufferManager.emitDataBuffered(sessionId, resultText, managedProcess);
 					}
 				}
 			} catch {
 				// If parsing fails, emit the raw line as data
-				this.bufferManager.emitDataBuffered(sessionId, remainingLine);
+				this.bufferManager.emitDataBuffered(sessionId, remainingLine, managedProcess);
 			}
 		}
 
@@ -142,7 +142,7 @@ export class ExitHandler {
 					streamedTextLength: managedProcess.streamedText.length,
 				}
 			);
-			this.bufferManager.emitDataBuffered(sessionId, managedProcess.streamedText);
+			this.bufferManager.emitDataBuffered(sessionId, managedProcess.streamedText, managedProcess);
 		}
 
 		// Check for errors using the parser (if not already emitted)
@@ -301,12 +301,25 @@ export class ExitHandler {
 		// Final flush: ensure any data buffered during exit processing
 		// (e.g., from jsonBuffer remainder or streamedText fallback) is emitted
 		// before the exit event, so listeners see all data before exit fires.
-		this.bufferManager.flushDataBuffer(sessionId);
+		this.bufferManager.flushDataBuffer(sessionId, managedProcess);
 
-		this.emitter.emit('exit', sessionId, code);
-		if (this.processes.get(sessionId) === managedProcess) {
+		const currentProcess = this.processes.get(sessionId);
+		if (currentProcess && currentProcess !== managedProcess) {
+			logger.warn('[ProcessManager] Ignoring stale process exit', 'ProcessManager', {
+				sessionId,
+				exitingPid: managedProcess.pid,
+				currentPid: currentProcess.pid,
+			});
+			return;
+		}
+
+		// Release ownership before notifying listeners. Replay handlers can spawn
+		// the next process synchronously from `exit` without replacing this one
+		// before its final buffered data has been emitted.
+		if (currentProcess === managedProcess) {
 			this.processes.delete(sessionId);
 		}
+		this.emitter.emit('exit', sessionId, code);
 	}
 
 	/**

--- a/src/main/process-manager/spawners/ChildProcessSpawner.ts
+++ b/src/main/process-manager/spawners/ChildProcessSpawner.ts
@@ -549,7 +549,7 @@ export class ChildProcessSpawner {
 			// emitted near the end of stdout (e.g., tab-naming, batch operations).
 			// The 'close' event guarantees all stdio streams are closed first.
 			childProcess.on('close', (code) => {
-				void this.exitHandler.handleExit(sessionId, code || 0).catch((err) => {
+				void this.exitHandler.handleExit(sessionId, code || 0, managedProcess).catch((err) => {
 					logger.error('[ProcessManager] handleExit threw', 'ProcessManager', {
 						sessionId,
 						error: String(err),

--- a/src/main/process-manager/spawners/OpencodeServerSpawner.ts
+++ b/src/main/process-manager/spawners/OpencodeServerSpawner.ts
@@ -115,20 +115,6 @@ export class OpencodeServerSpawner {
 		// SSE aborter for the kill path, plus a one-shot exit guard.
 		const streamAbort = new AbortController();
 		let finished = false;
-		const lifecycle: Lifecycle = {
-			isFinished: () => finished,
-			finish: (code: number) => {
-				if (finished) return;
-				finished = true;
-				void this.exitHandler.handleExit(sessionId, code).catch((err) => {
-					logger.error('[OpencodeServerSpawner] handleExit threw', 'OpencodeServer', {
-						sessionId,
-						error: String(err),
-					});
-				});
-			},
-		};
-
 		const managedProcess: ManagedProcess = {
 			sessionId,
 			toolType,
@@ -163,6 +149,19 @@ export class OpencodeServerSpawner {
 					this.abortActiveSession(managedProcess);
 					streamAbort.abort();
 				},
+			},
+		};
+		const lifecycle: Lifecycle = {
+			isFinished: () => finished,
+			finish: (code: number) => {
+				if (finished) return;
+				finished = true;
+				void this.exitHandler.handleExit(sessionId, code, managedProcess).catch((err) => {
+					logger.error('[OpencodeServerSpawner] handleExit threw', 'OpencodeServer', {
+						sessionId,
+						error: String(err),
+					});
+				});
 			},
 		};
 

--- a/src/main/process-manager/spawners/PtySpawner.ts
+++ b/src/main/process-manager/spawners/PtySpawner.ts
@@ -191,10 +191,10 @@ export class PtySpawner {
 				});
 				// Forward `signal` so consumers can tell a shell the user exited from
 				// one that was killed out from under them (OOM killer, SIGHUP, crash).
+				const currentProcess = this.processes.get(sessionId);
+				if (currentProcess && currentProcess !== managedProcess) return;
+				if (currentProcess === managedProcess) this.processes.delete(sessionId);
 				this.emitter.emit('exit', sessionId, exitCode, signal);
-				if (this.processes.get(sessionId) === managedProcess) {
-					this.processes.delete(sessionId);
-				}
 			});
 
 			logger.debug('[ProcessManager] PTY process created', 'ProcessManager', {

--- a/src/main/process-manager/spawners/PtySpawner.ts
+++ b/src/main/process-manager/spawners/PtySpawner.ts
@@ -133,7 +133,7 @@ export class PtySpawner {
 				ptyProcess,
 				cwd,
 				pid: ptyProcess.pid,
-				isTerminal: true,
+				isTerminal,
 				startTime: Date.now(),
 				command: ptyCommand,
 				args: ptyArgs,
@@ -163,7 +163,7 @@ export class PtySpawner {
 							pid: ptyProcess.pid,
 							dataLength: data.length,
 						});
-						this.bufferManager.emitDataBuffered(sessionId, data);
+						this.bufferManager.emitDataBuffered(sessionId, data, managedProcess);
 					}
 				} else {
 					const managedProc = this.processes.get(sessionId);
@@ -175,14 +175,14 @@ export class PtySpawner {
 					});
 					// Only emit if there's actual content after filtering
 					if (cleanedData.trim()) {
-						this.bufferManager.emitDataBuffered(sessionId, cleanedData);
+						this.bufferManager.emitDataBuffered(sessionId, cleanedData, managedProcess);
 					}
 				}
 			});
 
 			ptyProcess.onExit(({ exitCode, signal }) => {
 				// Flush any remaining buffered data before exit
-				this.bufferManager.flushDataBuffer(sessionId);
+				this.bufferManager.flushDataBuffer(sessionId, managedProcess);
 
 				logger.debug('[ProcessManager] PTY onExit', 'ProcessManager', {
 					sessionId,

--- a/src/main/process-manager/spawners/PtySpawner.ts
+++ b/src/main/process-manager/spawners/PtySpawner.ts
@@ -192,7 +192,9 @@ export class PtySpawner {
 				// Forward `signal` so consumers can tell a shell the user exited from
 				// one that was killed out from under them (OOM killer, SIGHUP, crash).
 				this.emitter.emit('exit', sessionId, exitCode, signal);
-				this.processes.delete(sessionId);
+				if (this.processes.get(sessionId) === managedProcess) {
+					this.processes.delete(sessionId);
+				}
 			});
 
 			logger.debug('[ProcessManager] PTY process created', 'ProcessManager', {

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -294,7 +294,7 @@ interface MaestroAPI {
 				syncHistory?: boolean;
 			};
 		}) => Promise<{ exitCode: number }>;
-		getActiveProcesses: () => Promise<
+		getActiveProcesses: (options?: { includeChildProcesses?: boolean }) => Promise<
 			Array<{
 				sessionId: string;
 				toolType: string;

--- a/src/renderer/hooks/input/useInputProcessing.ts
+++ b/src/renderer/hooks/input/useInputProcessing.ts
@@ -586,6 +586,48 @@ export function useInputProcessing(deps: UseInputProcessingDeps): UseInputProces
 			if (currentMode === 'ai') {
 				const activeTab = resolveTargetTab(activeSession);
 				const isReadOnlyMode = activeTab?.readOnlyMode === true;
+				const targetProcessSessionId = `${activeSession.id}-ai-${activeTab?.id || 'default'}`;
+				const sessionProcessPrefix = `${activeSession.id}-ai-`;
+				let sameTabProcessActive = false;
+				let anySessionAiProcessActive = false;
+				let activeProcessStartTime: number | undefined;
+
+				// The renderer can briefly say "idle" before the process exit event has
+				// reconciled into session state. Main-process ownership is authoritative:
+				// spawning another turn with the same id would otherwise replace the live
+				// process and discard its eventual response.
+				try {
+					const activeProcesses = await window.maestro.process.getActiveProcesses({
+						includeChildProcesses: false,
+					});
+					const sessionAiProcesses = activeProcesses.filter(
+						(process) =>
+							!process.isTerminal &&
+							!process.isCueRun &&
+							process.sessionId.startsWith(sessionProcessPrefix)
+					);
+					anySessionAiProcessActive = sessionAiProcesses.length > 0;
+					sameTabProcessActive = sessionAiProcesses.some(
+						(process) =>
+							process.sessionId === targetProcessSessionId ||
+							process.sessionId.startsWith(`${targetProcessSessionId}-fp-`)
+					);
+					activeProcessStartTime = sessionAiProcesses.reduce<number | undefined>(
+						(earliest, process) => {
+							if (process.startTime === undefined) return earliest;
+							return earliest === undefined
+								? process.startTime
+								: Math.min(earliest, process.startTime);
+						},
+						undefined
+					);
+				} catch (error) {
+					logger.warn(
+						'[processInput] Failed to reconcile active processes before queue decision:',
+						undefined,
+						error
+					);
+				}
 
 				// Check if write command can bypass queue (all running/queued items are read-only)
 				const canWriteBypassQueue = (): boolean => {
@@ -626,11 +668,19 @@ export function useInputProcessing(deps: UseInputProcessingDeps): UseInputProces
 				// ALSO: Always queue write commands when AutoRun is active (to prevent file conflicts)
 				// FORCE PARALLEL: queues only when THIS tab is busy (skips cross-tab and AutoRun wait).
 				// When the tab finishes, the queued item dispatches immediately without waiting for other tabs.
-				const shouldQueue = forceParallel
-					? activeTab?.state === 'busy' // Force parallel: only queue if THIS tab is busy
-					: isReadOnlyMode
-						? activeTab?.state === 'busy' // Read-only: only queue if THIS tab is busy
-						: (activeSession.state === 'busy' && !canWriteBypassQueue()) || isAutoRunActive; // Write mode: queue if busy OR AutoRun active
+				const processStateRequiresQueue =
+					sameTabProcessActive ||
+					(!forceParallel &&
+						!isReadOnlyMode &&
+						activeSession.state !== 'busy' &&
+						anySessionAiProcessActive);
+				const shouldQueue =
+					processStateRequiresQueue ||
+					(forceParallel
+						? activeTab?.state === 'busy' // Force parallel: only queue if THIS tab is busy
+						: isReadOnlyMode
+							? activeTab?.state === 'busy' // Read-only: only queue if THIS tab is busy
+							: (activeSession.state === 'busy' && !canWriteBypassQueue()) || isAutoRunActive); // Write mode: queue if busy OR AutoRun active
 
 				// Debug logging to diagnose queue issues
 				logger.info('[processInput] Queue decision:', undefined, {
@@ -640,6 +690,9 @@ export function useInputProcessing(deps: UseInputProcessingDeps): UseInputProces
 					isReadOnlyMode,
 					isAutoRunActive,
 					forceParallel,
+					sameTabProcessActive,
+					anySessionAiProcessActive,
+					processStateRequiresQueue,
 					shouldQueue,
 					queueLength: activeSession.executionQueue.length,
 				});
@@ -670,8 +723,26 @@ export function useInputProcessing(deps: UseInputProcessingDeps): UseInputProces
 					setSessions((prev) =>
 						prev.map((s) => {
 							if (s.id !== resolvedSessionId) return s;
+							const reconciledAiTabs = sameTabProcessActive
+								? s.aiTabs.map((tab) =>
+										tab.id === queuedItem.tabId
+											? {
+													...tab,
+													state: 'busy' as const,
+													thinkingStartTime:
+														tab.thinkingStartTime || activeProcessStartTime || Date.now(),
+												}
+											: tab
+									)
+								: s.aiTabs;
 							return {
 								...s,
+								...(processStateRequiresQueue && {
+									state: 'busy' as SessionState,
+									busySource: 'ai' as const,
+									thinkingStartTime: s.thinkingStartTime || activeProcessStartTime || Date.now(),
+									aiTabs: reconciledAiTabs,
+								}),
 								executionQueue: [...s.executionQueue, queuedItem],
 							};
 						})

--- a/src/renderer/hooks/input/useInputProcessing.ts
+++ b/src/renderer/hooks/input/useInputProcessing.ts
@@ -226,12 +226,16 @@ export function useInputProcessing(deps: UseInputProcessingDeps): UseInputProces
 							? sessionsRef.current.find((s) => s.id === resolvedSessionId)
 							: undefined) ?? selectActiveSession(useSessionStore.getState()));
 
-			const resolveTargetTab = (session: Session) => {
-				if (options?.tabId) {
-					return session.aiTabs.find((t) => t.id === options.tabId) ?? getActiveTab(session);
-				}
-				return getActiveTab(session);
-			};
+			// Pin the target tab before any async work. The user can switch tabs while
+			// process reconciliation or agent configuration is in flight, but this send
+			// must keep using the tab that owned the submitted input.
+			const targetTabId = activeSession
+				? options?.tabId && activeSession.aiTabs.some((tab) => tab.id === options.tabId)
+					? options.tabId
+					: getActiveTab(activeSession)?.id
+				: undefined;
+			const resolveTargetTab = (session: Session) =>
+				targetTabId ? session.aiTabs.find((tab) => tab.id === targetTabId) : getActiveTab(session);
 
 			const syncTarget = activeSession
 				? {
@@ -627,6 +631,10 @@ export function useInputProcessing(deps: UseInputProcessingDeps): UseInputProces
 						undefined,
 						error
 					);
+					// Preserve the input when process ownership is unknown. Treating an IPC
+					// failure as idle can retry the same process id and lose the live response.
+					sameTabProcessActive = true;
+					anySessionAiProcessActive = true;
 				}
 
 				// Check if write command can bypass queue (all running/queued items are read-only)
@@ -1206,12 +1214,11 @@ export function useInputProcessing(deps: UseInputProcessingDeps): UseInputProces
 			const targetPid = currentMode === 'ai' ? activeSession.aiPid : activeSession.terminalPid;
 			// For batch mode (Claude), include tab ID in session ID to prevent process collision
 			// This ensures each tab's process has a unique identifier
-			const activeTabForSpawn = resolveTargetTab(activeSession);
 			const isForceParallel =
 				options?.forceParallel === true && useSettingsStore.getState().forcedParallelExecution;
 			const targetSessionId =
 				currentMode === 'ai'
-					? `${activeSession.id}-ai-${activeTabForSpawn?.id || 'default'}`
+					? `${activeSession.id}-ai-${targetTabId || 'default'}`
 					: `${activeSession.id}-terminal`;
 
 			// Check if this is an AI agent in batch mode
@@ -1235,13 +1242,14 @@ export function useInputProcessing(deps: UseInputProcessingDeps): UseInputProces
 						const agent = await window.maestro.agents.get(activeSession.toolType);
 						if (!agent) throw new Error(`${activeSession.toolType} agent not found`);
 
-						// IMPORTANT: Get fresh session state from ref to avoid stale closure bug
-						// If user switches tabs quickly, activeSession from closure may have wrong activeTabId
+						// Read mutable session fields from the ref, but keep the submitted tab pinned.
 						const freshSession = sessionsRef.current.find((s) => s.id === resolvedSessionId);
 						if (!freshSession) throw new Error('Session not found');
 
-						// Use the ACTIVE TAB's agentSessionId (not the deprecated session-level one)
 						const freshActiveTab = resolveTargetTab(freshSession);
+						if (!freshActiveTab) throw new Error('Target tab not found');
+
+						// Use the target tab's agentSessionId (not the deprecated session-level one)
 						const tabAgentSessionId = freshActiveTab?.agentSessionId;
 
 						if (!tabAgentSessionId && freshActiveTab?.logs && freshActiveTab.logs.length > 0) {
@@ -1339,7 +1347,7 @@ export function useInputProcessing(deps: UseInputProcessingDeps): UseInputProces
 						//    turn; on resume the prompt is already in the transcript.
 						const appendSystemPrompt = await prepareMaestroSystemPrompt({
 							session: freshSession,
-							activeTabId: freshSession.activeTabId,
+							activeTabId: targetTabId,
 						});
 
 						const { sendPromptViaStdin, sendPromptViaStdinRaw } = getStdinFlags({
@@ -1391,7 +1399,7 @@ export function useInputProcessing(deps: UseInputProcessingDeps): UseInputProces
 						setSessions((prev) =>
 							prev.map((s) => {
 								if (s.id !== resolvedSessionId) return s;
-								const errorTabId = options?.tabId ?? s.activeTabId;
+								const errorTabId = targetTabId ?? s.activeTabId;
 								// Reset target tab's state to 'idle' and add error log
 								const updatedAiTabs =
 									s.aiTabs?.length > 0


### PR DESCRIPTION
## Summary

- Reconcile renderer queue decisions against live ProcessManager state.
- Refuse to replace a live AI agent process with a duplicate session ID.
- Bind exit cleanup to the exact process generation so an older exit cannot delete a newer replay.
- Support lightweight active-process queries without terminal child-process inspection.

## Root cause

The renderer could briefly report an idle session while its agent process was still running. A follow-up message then spawned with the same composite session ID, and ProcessManager killed and unregistered the live process before starting a resume. If that resume exited early, the UI showed exit code 1, while the original process's eventual response was discarded because it no longer owned the map entry.

## Test plan

- `npx vitest run` for input processing, ProcessManager, ExitHandler, preload, and process IPC: 272 tests passed.
- `npx vitest run` for ChildProcessSpawner, PtySpawner, and ProcessManager: 95 tests passed.
- `npm run lint` passed.
- Focused ESLint and Prettier checks passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Active-process queries can now optionally exclude child processes (for faster, focused status checks).
  * Input handling now reconciles running processes with renderer session state before queueing work.

* **Bug Fixes**
  * Prevented active AI processes from being unintentionally replaced; improved handling of stale/running process ownership.
  * Improved exit cleanup ordering and buffered-output flushing, preserving newer processes and avoiding incorrect exit emissions.
  * PTY sessions now more accurately distinguish terminal vs agent processes.

* **Tests**
  * Added/updated regression coverage for active-process reconciliation, IPC forwarding options, and process replacement/exit edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->