### PR TITLE
fix(prompts): guard renderer prompt init against a missing preload bridge

### DIFF
--- a/src/renderer/services/promptInit.test.ts
+++ b/src/renderer/services/promptInit.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Stub the sentry reporter and every prompt loader so importing promptInit does
+// not pull in the real (heavy) renderer graph and loader behavior is
+// controllable per test.
+vi.mock('../utils/sentry', () => ({ captureException: vi.fn() }));
+vi.mock('../stores/settingsStore', () => ({ loadSettingsStorePrompts: vi.fn() }));
+vi.mock('../hooks/input/useInputProcessing', () => ({ loadInputProcessingPrompts: vi.fn() }));
+vi.mock('../hooks/wizard/useWizardHandlers', () => ({ loadWizardHandlersPrompts: vi.fn() }));
+vi.mock('../hooks/agent/useAgentListeners', () => ({ loadAgentListenersPrompts: vi.fn() }));
+vi.mock('../hooks/batch/batchUtils', () => ({ loadBatchUtilsPrompts: vi.fn() }));
+vi.mock('./contextGroomer', () => ({ loadContextGroomerPrompts: vi.fn() }));
+vi.mock('./contextSummarizer', () => ({ loadContextSummarizerPrompts: vi.fn() }));
+vi.mock('./inlineWizardConversation', () => ({ loadInlineWizardConversationPrompts: vi.fn() }));
+vi.mock('./inlineWizardDocumentGeneration', () => ({ loadInlineWizardDocGenPrompts: vi.fn() }));
+vi.mock('../components/Wizard/services/wizardPrompts', () => ({ loadWizardPrompts: vi.fn() }));
+vi.mock('../components/Wizard/services/phaseGenerator', () => ({
+	loadPhaseGeneratorPrompts: vi.fn(),
+}));
+
+interface BridgeWindow {
+	maestro?: { prompts?: unknown };
+}
+
+function setBridge(present: boolean): void {
+	(window as unknown as BridgeWindow).maestro = present ? { prompts: {} } : undefined;
+}
+
+// Each test loads a fresh module instance. resetModules() clears promptInit's
+// module-level `initialized`/`initPromise` singletons so the cases are
+// independent and order-free; a static import would share that state. The
+// dynamic imports here exist solely for this test-isolation boundary
+// (ts-no-dynamic-import test exception) and resolve the same freshly-mocked
+// instances promptInit uses after the reset.
+async function loadFresh() {
+	vi.resetModules();
+	const promptInit = await import('./promptInit');
+	const { captureException } = await import('../utils/sentry');
+	const { loadSettingsStorePrompts } = await import('../stores/settingsStore');
+	return { ...promptInit, captureException, loadSettingsStorePrompts };
+}
+
+describe('initializeRendererPrompts bridge guard', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('degrades without reporting when the preload bridge never appears', async () => {
+		setBridge(false);
+		const {
+			initializeRendererPrompts,
+			areRendererPromptsInitialized,
+			captureException,
+			loadSettingsStorePrompts,
+		} = await loadFresh();
+
+		vi.useFakeTimers();
+		const pending = initializeRendererPrompts();
+		await vi.advanceTimersByTimeAsync(1100);
+		await expect(pending).resolves.toBeUndefined();
+
+		expect(captureException).not.toHaveBeenCalled();
+		expect(loadSettingsStorePrompts).not.toHaveBeenCalled();
+		expect(areRendererPromptsInitialized()).toBe(false);
+	});
+
+	it('reports and rethrows when a loader fails with the bridge present', async () => {
+		setBridge(true);
+		const {
+			initializeRendererPrompts,
+			areRendererPromptsInitialized,
+			captureException,
+			loadSettingsStorePrompts,
+		} = await loadFresh();
+		vi.mocked(loadSettingsStorePrompts).mockRejectedValueOnce(new Error('prompt boom'));
+
+		await expect(initializeRendererPrompts()).rejects.toThrow('prompt boom');
+
+		expect(captureException).toHaveBeenCalledTimes(1);
+		expect(areRendererPromptsInitialized()).toBe(false);
+	});
+
+	it('loads prompts and marks initialized when the bridge is present', async () => {
+		setBridge(true);
+		const {
+			initializeRendererPrompts,
+			areRendererPromptsInitialized,
+			captureException,
+			loadSettingsStorePrompts,
+		} = await loadFresh();
+
+		await expect(initializeRendererPrompts()).resolves.toBeUndefined();
+
+		expect(loadSettingsStorePrompts).toHaveBeenCalledTimes(1);
+		expect(captureException).not.toHaveBeenCalled();
+		expect(areRendererPromptsInitialized()).toBe(true);
+	});
+});

--- a/src/renderer/services/promptInit.ts
+++ b/src/renderer/services/promptInit.ts
@@ -50,6 +50,36 @@ async function loadAll(force = false): Promise<void> {
 }
 
 /**
+ * Milliseconds to wait for the preload bridge (`window.maestro`) before giving
+ * up. The bridge is typed as always present, but a renderer can run before it
+ * is injected; a short poll closes that race without stalling the gated app
+ * render when the bridge is genuinely absent (e.g. a window with no preload).
+ * Normal startups find the bridge on the first check and never wait.
+ */
+const PROMPT_BRIDGE_WAIT_MS = 1000;
+const PROMPT_BRIDGE_POLL_MS = 50;
+
+/**
+ * Resolve once the prompts bridge is available, or after PROMPT_BRIDGE_WAIT_MS.
+ * Returns whether the bridge became ready.
+ */
+function waitForPromptBridge(): Promise<boolean> {
+	if (window.maestro?.prompts !== undefined) return Promise.resolve(true);
+	return new Promise<boolean>((resolve) => {
+		const deadline = Date.now() + PROMPT_BRIDGE_WAIT_MS;
+		const timer = setInterval(() => {
+			if (window.maestro?.prompts !== undefined) {
+				clearInterval(timer);
+				resolve(true);
+			} else if (Date.now() >= deadline) {
+				clearInterval(timer);
+				resolve(false);
+			}
+		}, PROMPT_BRIDGE_POLL_MS);
+	});
+}
+
+/**
  * Initialize all renderer prompts. Safe to call multiple times (idempotent).
  * Must complete before the app renders components that use prompts.
  */
@@ -63,6 +93,18 @@ export async function initializeRendererPrompts(): Promise<void> {
 	// Start initialization
 	initPromise = (async () => {
 		try {
+			// The preload bridge (`window.maestro`) is typed as always present,
+			// but the renderer can run before it is injected, or in a window
+			// without a preload. Treat that as expected and recoverable: skip
+			// prompt loading so the app still renders (features degrade) and
+			// leave `initialized` false so a later call retries once the bridge
+			// exists. Previously this surfaced as an opaque "reading 'prompts'"
+			// TypeError reported to Sentry on every bridge-less startup
+			// (MAESTRO-W6).
+			if (!(await waitForPromptBridge())) {
+				initPromise = null;
+				return;
+			}
 			await loadAll();
 			initialized = true;
 		} catch (error) {


### PR DESCRIPTION
## Problem

`initializeRendererPrompts()` (called at renderer startup in `App.tsx`) fans out to prompt loaders that each call `window.maestro.prompts.get(...)`. `window.maestro` is typed as always present (`src/renderer/global.d.ts`), but at runtime it can be `undefined` when the preload bridge is unavailable (for example, a missing preload or startup timing). A loader then throws `TypeError: Cannot read properties of undefined (reading 'prompts')`, which is caught and reported to Sentry on every bridge-less startup.

Sentry: **MAESTRO-W6**, 153 events since 2026-07-11 across `0.17.3` (stable) and `0.18.5-RC`, `context: initializeRendererPrompts`.

## Fix

`src/renderer/services/promptInit.ts`: before loading, briefly wait for the bridge (`waitForPromptBridge`, a short 1s poll). Normal startups find it on the first check and never wait. If it never appears, skip prompt loading so the gated app render (`App.tsx` returns `null` until `promptsReady`) still proceeds with degraded prompt features, and leave `initialized` false so a later call retries once the bridge exists.

This mirrors the established `window.maestro?.` guard convention already used across the renderer (e.g. `CoworkingSetup.tsx`). Genuine per-prompt load failures (bridge present, a loader rejects) still surface via the existing `captureException` path, so real prompt bugs are not masked.

## Test

`src/renderer/services/promptInit.test.ts` (new) covers three paths:

- bridge never appears: resolves, no `captureException`, `initialized` stays false;
- bridge present but a loader rejects: rethrows and reports once;
- bridge present, happy path: loads and marks initialized.

Each case loads a fresh module instance (`resetModules`) so they are order-independent.

## Verification

- `tsc -p tsconfig.lint.json`: pass
- `vitest run src/renderer/services/promptInit.test.ts`: 3/3 pass
- `eslint`: clean

Fixes MAESTRO-W6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved prompt initialization when the preload bridge is temporarily unavailable.
  * Initialization now waits briefly for the bridge, exits safely if it does not appear, and allows a later retry.
  * Prompt-loading failures are reported appropriately without incorrectly marking initialization as complete.

* **Tests**
  * Added coverage for bridge timeouts, loading failures, successful initialization, retries, and error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->