### PR TITLE
fix(sidebar): show errored agents in the unread agents filter

### DIFF
--- a/src/__tests__/renderer/hooks/computeSortedSessions.test.ts
+++ b/src/__tests__/renderer/hooks/computeSortedSessions.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { computeSortedSessions } from '../../../renderer/hooks/session/computeSortedSessions';
+import { createMockSession } from '../../helpers';
+
+describe('computeSortedSessions - unread filter jump-badge visibility', () => {
+	it('keeps an errored agent in visibleSessions under the unread filter', () => {
+		const errored = createMockSession({ id: 'e1', name: 'Errored', state: 'error' });
+		const idle = createMockSession({ id: 'i1', name: 'Idle' });
+
+		const { visibleSessions } = computeSortedSessions({
+			sessions: [errored, idle],
+			groups: [],
+			bookmarksCollapsed: false,
+			showUnreadAgentsOnly: true,
+		});
+
+		const names = visibleSessions.map((s) => s.name);
+		expect(names).toContain('Errored');
+		expect(names).not.toContain('Idle');
+	});
+
+	it('keeps a parent visible when one of its worktree children is errored', () => {
+		const parent = createMockSession({ id: 'p1', name: 'Parent' });
+		const child = createMockSession({
+			id: 'c1',
+			name: 'Worktree Child',
+			parentSessionId: 'p1',
+			state: 'error',
+		});
+
+		const { visibleSessions } = computeSortedSessions({
+			sessions: [parent, child],
+			groups: [],
+			bookmarksCollapsed: false,
+			showUnreadAgentsOnly: true,
+		});
+
+		expect(visibleSessions.map((s) => s.name)).toContain('Parent');
+	});
+
+	it('excludes idle agents with no unread/errored children under the unread filter', () => {
+		const idle = createMockSession({ id: 'a1', name: 'Idle Alone' });
+
+		const { visibleSessions } = computeSortedSessions({
+			sessions: [idle],
+			groups: [],
+			bookmarksCollapsed: false,
+			showUnreadAgentsOnly: true,
+		});
+
+		expect(visibleSessions.map((s) => s.name)).not.toContain('Idle Alone');
+	});
+});

--- a/src/__tests__/renderer/hooks/useSessionCategories.test.ts
+++ b/src/__tests__/renderer/hooks/useSessionCategories.test.ts
@@ -293,6 +293,35 @@ describe('useSessionCategories', () => {
 			expect(names).toContain('Busy Agent');
 		});
 
+		it('includes agents in an error state even without unread tabs when showUnreadAgentsOnly is true', () => {
+			const s1 = makeSession({
+				name: 'Errored Agent',
+				state: 'error',
+			});
+			const s2 = makeSession({ name: 'Idle No Unread' });
+			resetStore([s1, s2]);
+
+			const { result } = renderHook(() => useSessionCategories('', [s1, s2], true));
+
+			expect(result.current.sortedFilteredSessions).toHaveLength(1);
+			expect(result.current.sortedFilteredSessions[0].name).toBe('Errored Agent');
+		});
+
+		it('keeps parent visible when a worktree child is in an error state', () => {
+			const parent = makeSession({ name: 'Parent' });
+			const child = makeSession({
+				name: 'Worktree Child',
+				parentSessionId: parent.id,
+				state: 'error',
+			});
+			resetStore([parent, child]);
+
+			const { result } = renderHook(() => useSessionCategories('', [parent, child], true));
+
+			expect(result.current.sortedFilteredSessions).toHaveLength(1);
+			expect(result.current.sortedFilteredSessions[0].name).toBe('Parent');
+		});
+
 		it('includes auto-running agents (AUTO badge) even when idle without unread tabs', () => {
 			const s1 = makeSession({
 				name: 'Has Unread',

--- a/src/renderer/components/SessionList/SessionList.tsx
+++ b/src/renderer/components/SessionList/SessionList.tsx
@@ -487,8 +487,9 @@ function SessionListInner(props: SessionListProps) {
 	const stuckOutageSignature = useActiveOutageSessionSignature();
 	const hasUnreadAgents = useMemo(
 		() =>
-			sessions.some((s) => s.aiTabs?.some((tab) => tab.hasUnread) || s.state === 'busy') ||
-			stuckOutageSignature !== '',
+			sessions.some(
+				(s) => s.aiTabs?.some((tab) => tab.hasUnread) || s.state === 'busy' || s.state === 'error'
+			) || stuckOutageSignature !== '',
 		[sessions, stuckOutageSignature]
 	);
 	const [menuOpen, setMenuOpen] = useState(false);
@@ -959,13 +960,14 @@ function SessionListInner(props: SessionListProps) {
 	) => {
 		const allWorktreeChildren = getWorktreeChildren(session.id);
 		// When filtering unread, only show worktree children that are unread, busy,
-		// or stuck auto-retrying an outage (all "needs attention").
+		// in an error state, or stuck auto-retrying an outage (all "needs attention").
 		const worktreeChildren = showUnreadAgentsOnly
 			? allWorktreeChildren.filter(
 					(child) =>
 						child.id === activeSessionId ||
 						child.aiTabs?.some((tab) => tab.hasUnread) ||
 						child.state === 'busy' ||
+						child.state === 'error' ||
 						stuckOutageSignature.split(',').includes(child.id)
 				)
 			: allWorktreeChildren;
@@ -1418,7 +1420,7 @@ function SessionListInner(props: SessionListProps) {
 							style={{ color: theme.colors.textDim }}
 						>
 							<Bot className="w-8 h-8 opacity-30" />
-							<span className="text-xs italic">No unread or working agents</span>
+							<span className="text-xs italic">No unread, working, or errored agents</span>
 						</div>
 					)}
 

--- a/src/renderer/components/SessionList/SkinnySidebar.tsx
+++ b/src/renderer/components/SessionList/SkinnySidebar.tsx
@@ -35,7 +35,10 @@ export const SkinnySidebar = memo(function SkinnySidebar({
 	const visibleSessions = showUnreadAgentsOnly
 		? sortedSessions.filter(
 				(s) =>
-					s.id === activeSessionId || s.state === 'busy' || s.aiTabs?.some((tab) => tab.hasUnread)
+					s.id === activeSessionId ||
+					s.state === 'busy' ||
+					s.state === 'error' ||
+					s.aiTabs?.some((tab) => tab.hasUnread)
 			)
 		: sortedSessions;
 

--- a/src/renderer/hooks/session/computeSortedSessions.ts
+++ b/src/renderer/hooks/session/computeSortedSessions.ts
@@ -131,13 +131,16 @@ export function computeSortedSessions(input: ComputeSortedSessionsInput): Sorted
 			false;
 		if (isActiveOrParentOfActive) return true;
 		const hasUnread = session.aiTabs?.some((tab) => tab.hasUnread) ?? false;
-		const isBusy = session.state === 'busy';
+		const isBusyOrError = session.state === 'busy' || session.state === 'error';
 		const children = worktreeChildrenByParent.get(session.id);
 		const hasUnreadChildren =
 			children?.some(
-				(child) => child.aiTabs?.some((tab) => tab.hasUnread) || child.state === 'busy'
+				(child) =>
+					child.aiTabs?.some((tab) => tab.hasUnread) ||
+					child.state === 'busy' ||
+					child.state === 'error'
 			) ?? false;
-		return hasUnread || isBusy || hasUnreadChildren;
+		return hasUnread || isBusyOrError || hasUnreadChildren;
 	};
 
 	const visibleSessions: Session[] = [];

--- a/src/renderer/hooks/session/useCycleSession.ts
+++ b/src/renderer/hooks/session/useCycleSession.ts
@@ -246,16 +246,19 @@ export function cycleSession(dir: 'next' | 'prev', deps: CycleSessionDeps): void
 			if (item.id === currentActiveId) return true;
 			// Group chats pass through (they have their own unread badges)
 			if (item.type === 'groupChat') return true;
-			// Check if session is unread or busy
+			// Check if session is unread, busy, or in an error state (all "needs attention")
 			const session = sessions.find((s) => s.id === item.id);
 			if (!session) return false;
 			if (session.aiTabs?.some((tab) => tab.hasUnread)) return true;
-			if (session.state === 'busy') return true;
-			// Check worktree children for unread/busy
+			if (session.state === 'busy' || session.state === 'error') return true;
+			// Check worktree children for unread/busy/error
 			const children = sessions.filter((s) => s.parentSessionId === session.id);
 			if (
 				children.some(
-					(child) => child.aiTabs?.some((tab) => tab.hasUnread) || child.state === 'busy'
+					(child) =>
+						child.aiTabs?.some((tab) => tab.hasUnread) ||
+						child.state === 'busy' ||
+						child.state === 'error'
 				)
 			)
 				return true;

--- a/src/renderer/hooks/session/useSessionCategories.ts
+++ b/src/renderer/hooks/session/useSessionCategories.ts
@@ -147,21 +147,25 @@ export function useSessionCategories(
 			if (showUnreadAgentsOnly && !isActiveOrParentOfActive) {
 				const hasUnread = s.aiTabs?.some((tab) => tab.hasUnread);
 				const isBusy = s.state === 'busy';
+				// An agent in an error state needs attention, so keep it visible.
+				const isError = s.state === 'error';
 				const isAutoRunning = batchSessionIds.has(s.id);
 				// A stuck (auto-retrying) agent needs attention just like an unread
 				// one, so keep it visible under the unread filter.
 				const isStuck = stuckOutageSessionIds.has(s.id);
 				// Also check if any worktree children have unread, are busy, are
-				// auto-running, or are stuck in an outage.
+				// auto-running, are stuck in an outage, or are in an error state.
 				const children = worktreeChildrenByParentId.get(s.id);
 				const hasActiveChildren = children?.some(
 					(child) =>
 						child.aiTabs?.some((tab) => tab.hasUnread) ||
 						child.state === 'busy' ||
+						child.state === 'error' ||
 						batchSessionIds.has(child.id) ||
 						stuckOutageSessionIds.has(child.id)
 				);
-				if (!hasUnread && !isBusy && !isAutoRunning && !isStuck && !hasActiveChildren) continue;
+				if (!hasUnread && !isBusy && !isError && !isAutoRunning && !isStuck && !hasActiveChildren)
+					continue;
 			}
 
 			if (!query) {


### PR DESCRIPTION
## Problem

Turning on **Filter unread agents** (the bell in the Left Bar) hid any agent in an `error` state. The filter keeps agents visible when they are unread, busy, auto-running, or stuck auto-retrying an outage; an errored agent matched none of those predicates, so it silently disappeared exactly when the user most needs to see it.

## Fix

Add `state === 'error'` alongside the existing `busy` check in every parallel "needs attention" predicate, for both parents and worktree children, so the rendered list, bell badge, jump numbers, and keyboard cycling all agree:

- `useSessionCategories` - core sidebar filter (parent + worktree children)
- `computeSortedSessions` - Opt+Cmd+number jump-badge / nav visibility
- `SessionList` - `hasUnreadAgents` bell badge, worktree-child filter, and empty-state copy ("No unread, working, or errored agents")
- `SkinnySidebar` - collapsed sidebar visibility
- `useCycleSession` - Cmd+[/] cycling order under the filter

Keeping all of these in sync matters: otherwise an errored agent could appear in the sidebar but be skipped by keyboard navigation, or vice versa.

Scope note: only the `error` state is added. `connecting` and `waiting_input` are intentionally left out.

## Tests

- `useSessionCategories.test.ts`: an errored agent (no unread tabs) stays visible; an errored worktree child keeps its parent visible.
- `computeSortedSessions.test.ts` (new): errored agent appears in `visibleSessions` (jump-badge path); errored worktree child keeps parent visible; idle agent is excluded.

## Validation

- Affected suites green locally: `useSessionCategories`, `computeSortedSessions`, `useCycleSession`, `SessionList` (272 tests).
- `prettier --check` and `eslint` clean on all touched files.
- Rebased onto latest `rc` and adapted to the sidebarNavStore refactor (#1235): the `useSortedSessions` predicate now lives in `computeSortedSessions`.

_Note: the full local `validate:push` / repo-wide `tsc` is not green due to two pre-existing, unrelated dependency errors (`languageLoader.ts` nested `@codemirror` duplicate; `GitGraphView.tsx` missing `@gitgraph/*` modules) present on `rc` and untouched here; none of the changed files produce type errors. CI is the authoritative gate._
