### PR TITLE
fix(left-bar): keep busy/auto-running worktree children visible under the unread filter

### DIFF
--- a/docs/agent-guides/SHARED-UTILS.md
+++ b/docs/agent-guides/SHARED-UTILS.md
@@ -439,6 +439,17 @@ Per-model token pricing is the single source of truth in `src/shared/modelPricin
 | `getSessionSshRemoteId(session)`          | `(SessionSshInfo?) => string \| undefined`                                       | Get effective SSH remote ID. Handles the sshRemoteId vs sessionSshRemoteConfig pitfall. |
 | `isSessionRemote(session)`                | `(SessionSshInfo?) => boolean`                                                   | Check if session is SSH remote. Works for both AI and terminal-only sessions.           |
 
+### Session Attention Filter (`src/renderer/utils/sessionAttention.ts`)
+
+Single source of truth for the Left Bar "unread agents only" (a.k.a. "needs attention") filter. Every surface that filters by unread MUST route through these so they never diverge: categorization (`useSessionCategories`), rendered worktree children (`SessionList`), the skinny sidebar (`SkinnySidebar`), jump badges + `Alt+Cmd+N` (`useSortedSessions`), the bell badge (`hasUnreadAgents`), and keyboard cycling (`useCycleSession`). Do NOT re-inline the checks - a partial copy is how an auto-running worktree child ends up hidden while its parent stays visible.
+
+| Function / Type                                          | Signature                                                                       | Purpose                                                                                                                         |
+| -------------------------------------------------------- | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `AttentionContext`                                       | `{ batchSessionIds: ReadonlySet<string>; stuckOutageIds: ReadonlySet<string> }` | Store-derived inputs the predicate can't read off the Session: Auto Run batch ids (batchStore) + stuck outage ids (retryStore). |
+| `sessionNeedsAttention(session, ctx)`                    | `(Session, AttentionContext) => boolean`                                        | True when an agent has an unread AI tab, is busy, is auto-running an Auto Run batch, or is stuck retrying an outage.            |
+| `sessionOrChildrenNeedAttention(session, children, ctx)` | `(Session, readonly Session[] \| undefined, AttentionContext) => boolean`       | Keep a parent visible when it or any worktree child needs attention.                                                            |
+| `outageIdsFromSignature(signature)`                      | `(string) => Set<string>`                                                       | Parse the comma-joined outage signature (`useActiveOutageSessionSignature`) into a lookup set; guards the empty-string case.    |
+
 ### Sentry (`src/renderer/utils/sentry.ts`)
 
 | Function                                   | Signature                                 | Purpose                                 |

--- a/src/__tests__/renderer/components/SessionList.test.tsx
+++ b/src/__tests__/renderer/components/SessionList.test.tsx
@@ -32,6 +32,7 @@ const enableGroupsPlus = () =>
 import { useBatchStore } from '../../../renderer/stores/batchStore';
 import { useModalStore } from '../../../renderer/stores/modalStore';
 import type { BatchRunState } from '../../../renderer/types';
+import { DEFAULT_BATCH_STATE } from '../../../renderer/hooks/batch/batchReducer';
 
 const LEGACY_WORKTREE_EMOJI = String.fromCodePoint(0x1f333);
 
@@ -3928,6 +3929,45 @@ describe('SessionList', () => {
 			});
 
 			expect(screen.queryByTestId('icon-zap')).not.toBeInTheDocument();
+		});
+	});
+
+	describe('Worktree children under unread filter', () => {
+		it('renders an auto-running worktree child (and its parent) even when both are idle and read', () => {
+			const parent = createMockSession({ id: 'p1', name: 'Parent Agent' });
+			const child = createMockSession({
+				id: 'child-1',
+				name: 'Worktree Child',
+				parentSessionId: 'p1',
+			});
+			useSessionStore.setState({ sessions: [parent, child] });
+			useUIStore.setState({ leftSidebarOpen: true, showUnreadAgentsOnly: true });
+			// child-1 is auto-running an Auto Run batch (idle between prompts, no unread).
+			useBatchStore.setState({
+				batchRunStates: { 'child-1': { ...DEFAULT_BATCH_STATE, isRunning: true } },
+			});
+
+			render(<SessionList {...createDefaultProps({ sortedSessions: [parent, child] })} />);
+
+			expect(screen.getByText('Parent Agent')).toBeInTheDocument();
+			expect(screen.getByText('Worktree Child')).toBeInTheDocument();
+		});
+
+		it('hides an idle, read worktree child (and its parent) when nothing needs attention', () => {
+			const parent = createMockSession({ id: 'p1', name: 'Parent Agent' });
+			const child = createMockSession({
+				id: 'child-1',
+				name: 'Worktree Child',
+				parentSessionId: 'p1',
+			});
+			useSessionStore.setState({ sessions: [parent, child] });
+			useUIStore.setState({ leftSidebarOpen: true, showUnreadAgentsOnly: true });
+			useBatchStore.setState({ batchRunStates: {} });
+
+			render(<SessionList {...createDefaultProps({ sortedSessions: [parent, child] })} />);
+
+			expect(screen.queryByText('Parent Agent')).toBeNull();
+			expect(screen.queryByText('Worktree Child')).toBeNull();
 		});
 	});
 });

--- a/src/__tests__/renderer/components/SessionList/SkinnySidebar.test.tsx
+++ b/src/__tests__/renderer/components/SessionList/SkinnySidebar.test.tsx
@@ -42,6 +42,8 @@ function createProps(overrides: Partial<Parameters<typeof SkinnySidebar>[0]> = {
 		activeSessionId: '',
 		groups: [] as Group[],
 		activeBatchSessionIds: [] as string[],
+		showUnreadAgentsOnly: false,
+		stuckOutageSignature: '',
 		contextWarningYellowThreshold: 70,
 		contextWarningRedThreshold: 90,
 		getFileCount: vi.fn(() => 0),

--- a/src/__tests__/renderer/hooks/useCycleSession.test.ts
+++ b/src/__tests__/renderer/hooks/useCycleSession.test.ts
@@ -43,6 +43,9 @@ import { useSessionStore } from '../../../renderer/stores/sessionStore';
 import { useGroupChatStore } from '../../../renderer/stores/groupChatStore';
 import { useUIStore } from '../../../renderer/stores/uiStore';
 import { useSettingsStore } from '../../../renderer/stores/settingsStore';
+import { useBatchStore } from '../../../renderer/stores/batchStore';
+import { useRetryStore } from '../../../renderer/stores/retryStore';
+import { DEFAULT_BATCH_STATE } from '../../../renderer/hooks/batch/batchReducer';
 import type { Session } from '../../../renderer/types';
 import { resetStores } from '../../helpers';
 
@@ -138,7 +141,14 @@ function makeOpenStarred(parentSessionId: string, tabId: string, displayName: st
 
 beforeEach(() => {
 	vi.clearAllMocks();
-	resetStores(useSessionStore, useGroupChatStore, useUIStore, useSettingsStore);
+	resetStores(
+		useSessionStore,
+		useGroupChatStore,
+		useUIStore,
+		useSettingsStore,
+		useBatchStore,
+		useRetryStore
+	);
 });
 
 // ============================================================================
@@ -1769,6 +1779,40 @@ describe('cycleSession', () => {
 			cycleSession('next', deps);
 
 			// Other → Parent (parent included because child has unread)
+			expect(useSessionStore.getState().activeSessionId).toBe('p');
+		});
+
+		it('includes parent when worktree child is auto-running (AUTO badge)', () => {
+			const parent = makeSession({ id: 'p', name: 'Parent' }); // idle, no unread
+			const child = makeSession({
+				id: 'child1',
+				name: 'Child',
+				parentSessionId: 'p',
+				worktreeBranch: 'feat',
+			}); // idle + read, but auto-running via the batch store below
+			const other = makeSession({ id: 'o', name: 'Other', state: 'busy' });
+
+			useSessionStore.setState({
+				sessions: [parent, child, other],
+				activeSessionId: 'o',
+				cyclePosition: -1,
+			});
+			useUIStore.setState({
+				leftSidebarOpen: true,
+				bookmarksCollapsed: true,
+				showUnreadAgentsOnly: true,
+			});
+			useSettingsStore.setState({ groupChatsExpanded: false });
+			useBatchStore.setState({
+				batchRunStates: { child1: { ...DEFAULT_BATCH_STATE, isRunning: true } },
+			});
+
+			const deps = makeDeps();
+
+			cycleSession('next', deps);
+
+			// Other → Parent (parent kept in the cycle because its worktree child
+			// is auto-running, even though the parent itself is idle and read).
 			expect(useSessionStore.getState().activeSessionId).toBe('p');
 		});
 

--- a/src/__tests__/renderer/utils/sessionAttention.test.ts
+++ b/src/__tests__/renderer/utils/sessionAttention.test.ts
@@ -1,0 +1,111 @@
+/**
+ * @file sessionAttention.test.ts
+ * @description Unit tests for the shared Left Bar "needs attention" predicate
+ * that drives the unread-agents filter across categorization, rendered worktree
+ * children, jump badges, and keyboard cycling.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { Session } from '../../../renderer/types';
+import {
+	sessionNeedsAttention,
+	sessionOrChildrenNeedAttention,
+	outageIdsFromSignature,
+	type AttentionContext,
+} from '../../../renderer/utils/sessionAttention';
+
+let idCounter = 0;
+function makeSession(overrides: Partial<Session> = {}): Session {
+	idCounter++;
+	return {
+		id: `s${idCounter}`,
+		name: `Session ${idCounter}`,
+		toolType: 'claude-code',
+		state: 'idle',
+		aiTabs: [],
+		...overrides,
+	} as Session;
+}
+
+const EMPTY_CTX: AttentionContext = {
+	batchSessionIds: new Set(),
+	stuckOutageIds: new Set(),
+};
+
+describe('outageIdsFromSignature', () => {
+	it('returns an empty set for an empty signature (no phantom empty-string id)', () => {
+		const ids = outageIdsFromSignature('');
+		expect(ids.size).toBe(0);
+		expect(ids.has('')).toBe(false);
+	});
+
+	it('splits a comma-joined signature into ids', () => {
+		const ids = outageIdsFromSignature('a,b,c');
+		expect([...ids].sort()).toEqual(['a', 'b', 'c']);
+	});
+});
+
+describe('sessionNeedsAttention', () => {
+	it('is false for an idle, read agent with no batch or outage', () => {
+		const s = makeSession({ state: 'idle', aiTabs: [{ id: 't', hasUnread: false } as never] });
+		expect(sessionNeedsAttention(s, EMPTY_CTX)).toBe(false);
+	});
+
+	it('is true when any AI tab is unread', () => {
+		const s = makeSession({ aiTabs: [{ id: 't', hasUnread: true } as never] });
+		expect(sessionNeedsAttention(s, EMPTY_CTX)).toBe(true);
+	});
+
+	it('is true when busy', () => {
+		expect(sessionNeedsAttention(makeSession({ state: 'busy' }), EMPTY_CTX)).toBe(true);
+	});
+
+	it('is true when auto-running an Auto Run batch even though idle and read', () => {
+		const s = makeSession({ id: 'auto', state: 'idle' });
+		const ctx: AttentionContext = { batchSessionIds: new Set(['auto']), stuckOutageIds: new Set() };
+		expect(sessionNeedsAttention(s, ctx)).toBe(true);
+	});
+
+	it('is true when stuck auto-retrying an outage', () => {
+		const s = makeSession({ id: 'stuck', state: 'idle' });
+		const ctx: AttentionContext = {
+			batchSessionIds: new Set(),
+			stuckOutageIds: new Set(['stuck']),
+		};
+		expect(sessionNeedsAttention(s, ctx)).toBe(true);
+	});
+});
+
+describe('sessionOrChildrenNeedAttention', () => {
+	it('keeps an idle parent visible when a worktree child is auto-running', () => {
+		const parent = makeSession({ id: 'parent', state: 'idle' });
+		const child = makeSession({ id: 'child', state: 'idle', parentSessionId: 'parent' });
+		const ctx: AttentionContext = {
+			batchSessionIds: new Set(['child']),
+			stuckOutageIds: new Set(),
+		};
+		expect(sessionOrChildrenNeedAttention(parent, [child], ctx)).toBe(true);
+	});
+
+	it('keeps an idle parent visible when a worktree child is busy', () => {
+		const parent = makeSession({ id: 'parent', state: 'idle' });
+		const child = makeSession({ id: 'child', state: 'busy', parentSessionId: 'parent' });
+		expect(sessionOrChildrenNeedAttention(parent, [child], EMPTY_CTX)).toBe(true);
+	});
+
+	it('is false when neither parent nor any child needs attention', () => {
+		const parent = makeSession({ id: 'parent', state: 'idle' });
+		const child = makeSession({ id: 'child', state: 'idle', parentSessionId: 'parent' });
+		expect(sessionOrChildrenNeedAttention(parent, [child], EMPTY_CTX)).toBe(false);
+	});
+
+	it('is true when the parent itself needs attention regardless of children', () => {
+		const parent = makeSession({ id: 'parent', state: 'busy' });
+		expect(sessionOrChildrenNeedAttention(parent, undefined, EMPTY_CTX)).toBe(true);
+	});
+
+	it('is false for an idle parent with no children', () => {
+		const parent = makeSession({ id: 'parent', state: 'idle' });
+		expect(sessionOrChildrenNeedAttention(parent, undefined, EMPTY_CTX)).toBe(false);
+	});
+});

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -153,7 +153,7 @@ import { WindowProvider, useWindowContextOptional } from './contexts/WindowConte
 import { InputProvider, useInputContext } from './contexts/InputContext';
 import { useGroupChatStore, isGroupChatVisibleInWindow } from './stores/groupChatStore';
 import { useBatchStore } from './stores/batchStore';
-import { registerBatchResumer } from './stores/retryStore';
+import { registerBatchResumer, useActiveOutageSessionSignature } from './stores/retryStore';
 // All session state is read directly from useSessionStore in MaestroConsoleInner.
 import {
 	useSessionStore,
@@ -2010,6 +2010,10 @@ function MaestroConsoleInner() {
 
 	// --- SESSION SORTING ---
 	// Extracted hook for sorted and visible session lists (ignores leading emojis for alphabetization)
+	// Stuck (auto-retry outage) agents count as "needs attention" too - thread the
+	// signature into the sorted-session filter so their parents keep jump badges
+	// and stay cyclable, matching the rendered Left Bar.
+	const stuckOutageSignature = useActiveOutageSessionSignature();
 	const { sortedSessions, visibleSessions, navSessions, bookmarkNavSize, navIndexMap } =
 		useSortedSessions({
 			// Use the sidebar-stable projection so log streaming doesn't recompute
@@ -2019,6 +2023,8 @@ function MaestroConsoleInner() {
 			bookmarksCollapsed,
 			showUnreadAgentsOnly,
 			activeSessionId,
+			activeBatchSessionIds,
+			stuckOutageSignature,
 		});
 
 	// --- KEYBOARD NAVIGATION ---

--- a/src/renderer/components/SessionList/SessionList.tsx
+++ b/src/renderer/components/SessionList/SessionList.tsx
@@ -40,6 +40,7 @@ import { useSessionStore } from '../../stores/sessionStore';
 import { selectGroupsPlusEnabled, useSettingsStore } from '../../stores/settingsStore';
 import { useBatchStore, selectActiveBatchSessionIds } from '../../stores/batchStore';
 import { useActiveOutageSessionSignature } from '../../stores/retryStore';
+import { sessionNeedsAttention, outageIdsFromSignature } from '../../utils/sessionAttention';
 import { useShallow } from 'zustand/react/shallow';
 import { useStoreWithEqualityFn } from 'zustand/traditional';
 import { sidebarSessionEquality } from '../../stores/sessionEquality';
@@ -480,11 +481,16 @@ function SessionListInner(props: SessionListProps) {
 	// Agent Resilience: agents stuck auto-retrying an outage count as "needs
 	// attention" and surface in the unread filter (see useSessionCategories).
 	const stuckOutageSignature = useActiveOutageSessionSignature();
+	const attentionCtx = useMemo(
+		() => ({
+			batchSessionIds: new Set(activeBatchSessionIds),
+			stuckOutageIds: outageIdsFromSignature(stuckOutageSignature),
+		}),
+		[activeBatchSessionIds, stuckOutageSignature]
+	);
 	const hasUnreadAgents = useMemo(
-		() =>
-			sessions.some((s) => s.aiTabs?.some((tab) => tab.hasUnread) || s.state === 'busy') ||
-			stuckOutageSignature !== '',
-		[sessions, stuckOutageSignature]
+		() => sessions.some((s) => sessionNeedsAttention(s, attentionCtx)),
+		[sessions, attentionCtx]
 	);
 	const [menuOpen, setMenuOpen] = useState(false);
 
@@ -953,15 +959,12 @@ function SessionListInner(props: SessionListProps) {
 		}
 	) => {
 		const allWorktreeChildren = getWorktreeChildren(session.id);
-		// When filtering unread, only show worktree children that are unread, busy,
-		// or stuck auto-retrying an outage (all "needs attention").
+		// When filtering unread, only show worktree children that need attention:
+		// unread, busy, auto-running an Auto Run batch, or stuck auto-retrying an
+		// outage (plus the active child so you don't lose it).
 		const worktreeChildren = showUnreadAgentsOnly
 			? allWorktreeChildren.filter(
-					(child) =>
-						child.id === activeSessionId ||
-						child.aiTabs?.some((tab) => tab.hasUnread) ||
-						child.state === 'busy' ||
-						stuckOutageSignature.split(',').includes(child.id)
+					(child) => child.id === activeSessionId || sessionNeedsAttention(child, attentionCtx)
 				)
 			: allWorktreeChildren;
 		const hasWorktrees = worktreeChildren.length > 0;
@@ -2102,6 +2105,7 @@ function SessionListInner(props: SessionListProps) {
 					setActiveSessionId={setActiveSessionId}
 					handleContextMenu={handleContextMenu}
 					showUnreadAgentsOnly={showUnreadAgentsOnly}
+					stuckOutageSignature={stuckOutageSignature}
 				/>
 			)}
 

--- a/src/renderer/components/SessionList/SkinnySidebar.tsx
+++ b/src/renderer/components/SessionList/SkinnySidebar.tsx
@@ -4,6 +4,7 @@ import { getStatusColor } from '../../utils/theme';
 import { hasNoClaudeProviderSession } from '../SessionItem';
 import { SessionTooltipContent } from './SessionTooltipContent';
 import { PluginUiItemsSlot } from '../plugins/PluginUiItemsSlot';
+import { sessionNeedsAttention, outageIdsFromSignature } from '../../utils/sessionAttention';
 
 interface SkinnySidebarProps {
 	theme: Theme;
@@ -17,6 +18,7 @@ interface SkinnySidebarProps {
 	setActiveSessionId: (id: string) => void;
 	handleContextMenu: (e: React.MouseEvent, sessionId: string) => void;
 	showUnreadAgentsOnly: boolean;
+	stuckOutageSignature: string;
 }
 
 export const SkinnySidebar = memo(function SkinnySidebar({
@@ -31,11 +33,15 @@ export const SkinnySidebar = memo(function SkinnySidebar({
 	setActiveSessionId,
 	handleContextMenu,
 	showUnreadAgentsOnly,
+	stuckOutageSignature,
 }: SkinnySidebarProps) {
+	const attentionCtx = {
+		batchSessionIds: new Set(activeBatchSessionIds),
+		stuckOutageIds: outageIdsFromSignature(stuckOutageSignature),
+	};
 	const visibleSessions = showUnreadAgentsOnly
 		? sortedSessions.filter(
-				(s) =>
-					s.id === activeSessionId || s.state === 'busy' || s.aiTabs?.some((tab) => tab.hasUnread)
+				(s) => s.id === activeSessionId || sessionNeedsAttention(s, attentionCtx)
 			)
 		: sortedSessions;
 

--- a/src/renderer/hooks/session/useCycleSession.ts
+++ b/src/renderer/hooks/session/useCycleSession.ts
@@ -20,6 +20,9 @@ import { useSessionStore } from '../../stores/sessionStore';
 import { useGroupChatStore } from '../../stores/groupChatStore';
 import { useUIStore } from '../../stores/uiStore';
 import { useSettingsStore } from '../../stores/settingsStore';
+import { useBatchStore, selectActiveBatchSessionIds } from '../../stores/batchStore';
+import { useRetryStore, selectActiveOutageSessionIds } from '../../stores/retryStore';
+import { sessionOrChildrenNeedAttention } from '../../utils/sessionAttention';
 import { compareNamesIgnoringEmojis } from './useSortedSessions';
 import type { StarredItem } from './useStarredItems';
 
@@ -242,25 +245,22 @@ export function cycleSession(dir: 'next' | 'prev', deps: CycleSessionDeps): void
 	// (plus the currently active agent so you don't get lost)
 	if (showUnreadAgentsOnly) {
 		const currentActiveId = activeGroupChatId || activeSessionId;
+		// Auto-running (Auto Run batch) and stuck (outage) agents are "needs
+		// attention" too. Read them at event time - no React subscription here.
+		const attentionCtx = {
+			batchSessionIds: new Set(selectActiveBatchSessionIds(useBatchStore.getState())),
+			stuckOutageIds: selectActiveOutageSessionIds(useRetryStore.getState()),
+		};
 		const filteredOrder = visualOrder.filter((item) => {
 			// Always keep the currently active item
 			if (item.id === currentActiveId) return true;
 			// Group chats pass through (they have their own unread badges)
 			if (item.type === 'groupChat') return true;
-			// Check if session is unread or busy
 			const session = sessions.find((s) => s.id === item.id);
 			if (!session) return false;
-			if (session.aiTabs?.some((tab) => tab.hasUnread)) return true;
-			if (session.state === 'busy') return true;
-			// Check worktree children for unread/busy
+			// Unread / busy / error / auto-running / stuck - self or any worktree child.
 			const children = sessions.filter((s) => s.parentSessionId === session.id);
-			if (
-				children.some(
-					(child) => child.aiTabs?.some((tab) => tab.hasUnread) || child.state === 'busy'
-				)
-			)
-				return true;
-			return false;
+			return sessionOrChildrenNeedAttention(session, children, attentionCtx);
 		});
 		visualOrder.length = 0;
 		visualOrder.push(...filteredOrder);

--- a/src/renderer/hooks/session/useSessionCategories.ts
+++ b/src/renderer/hooks/session/useSessionCategories.ts
@@ -4,6 +4,10 @@ import type { Session, Group } from '../../types';
 import { useSessionStore } from '../../stores/sessionStore';
 import { sidebarSessionEquality } from '../../stores/sessionEquality';
 import { compareNamesIgnoringEmojis as compareSessionNames } from '../../../shared/emojiUtils';
+import {
+	sessionOrChildrenNeedAttention,
+	outageIdsFromSignature,
+} from '../../utils/sessionAttention';
 
 export interface SessionCategories {
 	worktreeChildrenByParentId: Map<string, Session[]>;
@@ -117,7 +121,7 @@ export function useSessionCategories(
 	// Stable Set of stuck (outage) agent ids, recomputed only when the signature
 	// changes so the categorization memo isn't invalidated on unrelated renders.
 	const stuckOutageSessionIds = useMemo(
-		() => new Set(stuckOutageSignature ? stuckOutageSignature.split(',') : []),
+		() => outageIdsFromSignature(stuckOutageSignature),
 		[stuckOutageSignature]
 	);
 
@@ -130,6 +134,7 @@ export function useSessionCategories(
 		// the busy/unread checks below would drop them. Keep them visible in the
 		// unread filter using the same set that drives the badge.
 		const batchSessionIds = new Set(activeBatchSessionIds);
+		const attentionCtx = { batchSessionIds, stuckOutageIds: stuckOutageSessionIds };
 
 		for (const s of sessions) {
 			// Exclude worktree children from main list (they appear under parent)
@@ -145,23 +150,8 @@ export function useSessionCategories(
 				s.id === activeSessionId ||
 				worktreeChildrenByParentId.get(s.id)?.some((child) => child.id === activeSessionId);
 			if (showUnreadAgentsOnly && !isActiveOrParentOfActive) {
-				const hasUnread = s.aiTabs?.some((tab) => tab.hasUnread);
-				const isBusy = s.state === 'busy';
-				const isAutoRunning = batchSessionIds.has(s.id);
-				// A stuck (auto-retrying) agent needs attention just like an unread
-				// one, so keep it visible under the unread filter.
-				const isStuck = stuckOutageSessionIds.has(s.id);
-				// Also check if any worktree children have unread, are busy, are
-				// auto-running, or are stuck in an outage.
 				const children = worktreeChildrenByParentId.get(s.id);
-				const hasActiveChildren = children?.some(
-					(child) =>
-						child.aiTabs?.some((tab) => tab.hasUnread) ||
-						child.state === 'busy' ||
-						batchSessionIds.has(child.id) ||
-						stuckOutageSessionIds.has(child.id)
-				);
-				if (!hasUnread && !isBusy && !isAutoRunning && !isStuck && !hasActiveChildren) continue;
+				if (!sessionOrChildrenNeedAttention(s, children, attentionCtx)) continue;
 			}
 
 			if (!query) {

--- a/src/renderer/hooks/session/useSortedSessions.ts
+++ b/src/renderer/hooks/session/useSortedSessions.ts
@@ -1,6 +1,10 @@
 import { useCallback, useMemo } from 'react';
 import type { Session, Group } from '../../types';
 import { stripLeadingEmojis, compareNamesIgnoringEmojis } from '../../../shared/emojiUtils';
+import {
+	sessionOrChildrenNeedAttention,
+	outageIdsFromSignature,
+} from '../../utils/sessionAttention';
 
 // Re-export for backwards compatibility with existing imports
 export { stripLeadingEmojis, compareNamesIgnoringEmojis };
@@ -24,6 +28,10 @@ export interface UseSortedSessionsDeps {
 	showUnreadAgentsOnly?: boolean;
 	/** Active session id - kept visible even when the unread filter would exclude it */
 	activeSessionId?: string | null;
+	/** Session ids with an active Auto Run batch - kept visible under the unread filter. */
+	activeBatchSessionIds?: string[];
+	/** Comma-joined signature of agent ids stuck auto-retrying an outage. */
+	stuckOutageSignature?: string;
 }
 
 /**
@@ -68,7 +76,15 @@ export interface UseSortedSessionsReturn {
  * @returns Sorted and visible session arrays
  */
 export function useSortedSessions(deps: UseSortedSessionsDeps): UseSortedSessionsReturn {
-	const { sessions, groups, bookmarksCollapsed, showUnreadAgentsOnly, activeSessionId } = deps;
+	const {
+		sessions,
+		groups,
+		bookmarksCollapsed,
+		showUnreadAgentsOnly,
+		activeSessionId,
+		activeBatchSessionIds,
+		stuckOutageSignature,
+	} = deps;
 
 	// Memoize worktree children lookup for O(1) access instead of O(n) per parent
 	// This reduces complexity from O(n²) to O(n) when building sorted sessions
@@ -200,24 +216,29 @@ export function useSortedSessions(deps: UseSortedSessionsDeps): UseSortedSession
 
 	// Matches the unread-filter logic in useSessionCategories so visibleSessions (used for
 	// jump badges + Alt+Cmd+N shortcuts) stays in sync with the Left Bar's rendered list.
+	const attentionCtx = useMemo(
+		() => ({
+			batchSessionIds: new Set(activeBatchSessionIds ?? []),
+			stuckOutageIds: outageIdsFromSignature(stuckOutageSignature ?? ''),
+		}),
+		[activeBatchSessionIds, stuckOutageSignature]
+	);
+
 	const passesUnreadFilter = useCallback(
 		(session: Session): boolean => {
 			if (!showUnreadAgentsOnly) return true;
 			const isActiveOrParentOfActive =
 				session.id === activeSessionId ||
-				childrenByParentId.get(session.id)?.some((child) => child.id === activeSessionId) ||
-				false;
+				(childrenByParentId.get(session.id)?.some((child) => child.id === activeSessionId) ??
+					false);
 			if (isActiveOrParentOfActive) return true;
-			const hasUnread = session.aiTabs?.some((tab) => tab.hasUnread) ?? false;
-			const isBusy = session.state === 'busy';
-			const children = childrenByParentId.get(session.id);
-			const hasUnreadChildren =
-				children?.some(
-					(child) => child.aiTabs?.some((tab) => tab.hasUnread) || child.state === 'busy'
-				) ?? false;
-			return hasUnread || isBusy || hasUnreadChildren;
+			return sessionOrChildrenNeedAttention(
+				session,
+				childrenByParentId.get(session.id),
+				attentionCtx
+			);
 		},
-		[showUnreadAgentsOnly, activeSessionId, childrenByParentId]
+		[showUnreadAgentsOnly, activeSessionId, childrenByParentId, attentionCtx]
 	);
 
 	// Create visible sessions array for session jump shortcuts (Opt+Cmd+NUMBER)

--- a/src/renderer/stores/retryStore.ts
+++ b/src/renderer/stores/retryStore.ts
@@ -457,19 +457,27 @@ export function useTabHasActiveOutage(sessionId: string, tabId: string): boolean
 }
 
 /**
+ * Set of agent ids that currently have an active outage. Event-time selector for
+ * non-reactive callers (e.g. `cycleSession`'s getState() path); the reactive
+ * `useActiveOutageSessionSignature` below derives its signature from this so the
+ * two never diverge.
+ */
+export function selectActiveOutageSessionIds(s: Pick<RetryStore, 'outages'>): Set<string> {
+	const ids = new Set<string>();
+	for (const id in s.outages) {
+		const o = s.outages[id];
+		if (o.status === 'active') ids.add(o.sessionId);
+	}
+	return ids;
+}
+
+/**
  * Reactive: a stable, comma-joined signature of all agent ids that currently
  * have an active outage. Primitive return → referential stability, so the Left
  * Bar filter memo only recomputes when the set of stuck agents actually changes.
  */
 export function useActiveOutageSessionSignature(): string {
-	return useRetryStore((s) => {
-		const ids = new Set<string>();
-		for (const id in s.outages) {
-			const o = s.outages[id];
-			if (o.status === 'active') ids.add(o.sessionId);
-		}
-		return Array.from(ids).sort().join(',');
-	});
+	return useRetryStore((s) => Array.from(selectActiveOutageSessionIds(s)).sort().join(','));
 }
 
 /**

--- a/src/renderer/utils/sessionAttention.ts
+++ b/src/renderer/utils/sessionAttention.ts
@@ -1,0 +1,56 @@
+import type { Session } from '../types';
+
+/**
+ * Inputs the "needs attention" predicate can't read off the Session itself:
+ * whether an agent is auto-running an Auto Run batch, and whether it is stuck
+ * auto-retrying an outage. Both are tracked in separate stores (batchStore /
+ * retryStore), so the caller passes them in as id sets.
+ */
+export interface AttentionContext {
+	/** Session ids with an active Auto Run batch (the AUTO badge). */
+	batchSessionIds: ReadonlySet<string>;
+	/** Session ids stuck auto-retrying an outage. */
+	stuckOutageIds: ReadonlySet<string>;
+}
+
+/**
+ * Parse the comma-joined outage signature (see
+ * `useActiveOutageSessionSignature` in retryStore) into a lookup set.
+ */
+export function outageIdsFromSignature(signature: string): Set<string> {
+	return new Set(signature ? signature.split(',') : []);
+}
+
+/**
+ * Single source of truth for the Left Bar unread ("needs attention") filter.
+ *
+ * An agent needs attention when it has an unread AI tab, is busy, is
+ * auto-running an Auto Run batch, or is stuck auto-retrying an outage. Every
+ * Left Bar surface that filters by unread - categorization
+ * (`useSessionCategories`), rendered worktree children (`SessionList`), the
+ * skinny sidebar (`SkinnySidebar`), jump badges + Alt+Cmd+N
+ * (`useSortedSessions`), and keyboard cycling (`useCycleSession`) - MUST route
+ * through here so they never diverge. A partial reimplementation is how an
+ * auto-running worktree child ends up hidden while its parent stays visible.
+ */
+export function sessionNeedsAttention(session: Session, ctx: AttentionContext): boolean {
+	if (session.aiTabs?.some((tab) => tab.hasUnread)) return true;
+	if (session.state === 'busy') return true;
+	if (ctx.batchSessionIds.has(session.id)) return true;
+	if (ctx.stuckOutageIds.has(session.id)) return true;
+	return false;
+}
+
+/**
+ * True when a parent agent should stay visible under the unread filter: it
+ * needs attention itself, or any of its worktree children do (a busy or
+ * auto-running worktree keeps the parent surfaced).
+ */
+export function sessionOrChildrenNeedAttention(
+	session: Session,
+	children: readonly Session[] | undefined,
+	ctx: AttentionContext
+): boolean {
+	if (sessionNeedsAttention(session, ctx)) return true;
+	return children?.some((child) => sessionNeedsAttention(child, ctx)) ?? false;
+}


### PR DESCRIPTION
## Problem

With **"show unread agents only"** active, a worktree child that is **working (busy)** or **auto-running (Auto Run)** was hidden from the Left Bar. The parent row stayed visible (categorization already accounted for it) but rendered with no visible child, got no jump badge, and was skipped by `Cmd+[` / `Cmd+]`.

## Root cause

The "unread agents only" ("needs attention") filter was reimplemented independently in **six** places and had drifted. Only `useSessionCategories` (which keeps the parent row) knew about auto-running and stuck (outage) agents. The surfaces that render the worktree child, number it, and cycle to it did not:

| Surface | Missing |
| --- | --- |
| `SessionList` worktree child render filter | auto-running |
| `SessionList` `hasUnreadAgents` (bell badge) | auto-running |
| `SkinnySidebar` per-icon filter | auto-running + stuck |
| `useSortedSessions` `passesUnreadFilter` (jump badges + `Alt+Cmd+N`) | auto-running + stuck |
| `useCycleSession` (`Cmd+[` / `Cmd+]`) | auto-running + stuck |

## Fix

Introduce one shared predicate as the single source of truth and route every unread-filter surface through it.

- **New** `src/renderer/utils/sessionAttention.ts`
  - `sessionNeedsAttention(session, ctx)` and `sessionOrChildrenNeedAttention(session, children, ctx)` over `{ unread, busy, auto-running, stuck }`.
  - `outageIdsFromSignature(signature)` (guards the empty-string case).
- `SessionList` - worktree child render filter + `hasUnreadAgents`.
- `SkinnySidebar` - per-icon filter (new `stuckOutageSignature` prop).
- `useSortedSessions` - `passesUnreadFilter`; new optional `activeBatchSessionIds` / `stuckOutageSignature` deps threaded from `App`.
- `useCycleSession` - reads batch/outage sets at event time (`getState()`), no new subscription.
- `useSessionCategories` - de-duplicated onto the shared predicate.
- `retryStore` - `selectActiveOutageSessionIds` selector (event-time set); the reactive `useActiveOutageSessionSignature` now derives from it.

The predicate is scoped to states that already exist in the codebase's most-complete surface (`useSessionCategories`): unread, busy, auto-running, stuck. Error-state handling is intentionally left out (it is not part of any current Left Bar filter surface) - if desired later, it is a one-line extension in `sessionNeedsAttention`.

## Testing

- Unit tests for the predicate, including the auto-running-worktree-child case.
- Cycling test: `Cmd+]` lands on a parent whose worktree child is auto-running.
- `SessionList` render tests: an auto-running worktree child (and its parent) render under the filter, plus a negative control.
- Touched suites pass (`sessionAttention`, `useCycleSession`, `useSessionCategories`, `SessionList`, `SkinnySidebar`, `retryStore`); `tsc` and ESLint clean for the touched files.

Documented the new util in `docs/agent-guides/SHARED-UTILS.md`.

> Note: the repo-wide `format:check:all` pre-push hook currently reports pre-existing Prettier issues in ~74 unrelated files on `rc`; none are touched by this PR (all 13 changed files pass `prettier --check`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved the “Unread agents only” filter to include sessions with active Auto Run tasks or stuck outage retries.
  - Parent sessions remain visible when their worktree children need attention.
  - Session cycling now includes relevant parent sessions under the unread filter.
  - Unified attention detection across the sidebar, session lists, categories, and navigation.

- **Documentation**
  - Added reference documentation for session attention filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->