### PR TITLE
fix(sidebar): unify the "needs attention" predicate across Left Bar surfaces

### DIFF
--- a/src/__tests__/helpers/seedSidebarNav.ts
+++ b/src/__tests__/helpers/seedSidebarNav.ts
@@ -32,6 +32,8 @@ export interface SeedSidebarNavFromSessions {
 	activeSessionId?: string | null;
 	bookmarksCollapsed?: boolean;
 	showUnreadAgentsOnly?: boolean;
+	activeBatchSessionIds?: string[];
+	stuckOutageSessionIds?: string[];
 	starredItems?: StarredItem[];
 	activateStarredItem?: ActivateStarred;
 }
@@ -54,6 +56,8 @@ export function seedSidebarNav(input: SeedSidebarNavInput): void {
 			bookmarksCollapsed: input.bookmarksCollapsed ?? ui.bookmarksCollapsed,
 			showUnreadAgentsOnly: input.showUnreadAgentsOnly ?? ui.showUnreadAgentsOnly,
 			activeSessionId: input.activeSessionId,
+			activeBatchSessionIds: input.activeBatchSessionIds,
+			stuckOutageSessionIds: input.stuckOutageSessionIds,
 		});
 		useSidebarNavStore.setState({
 			...projection,

--- a/src/__tests__/renderer/components/SessionList/SkinnySidebar.test.tsx
+++ b/src/__tests__/renderer/components/SessionList/SkinnySidebar.test.tsx
@@ -4,6 +4,7 @@ import { SkinnySidebar } from '../../../../renderer/components/SessionList/Skinn
 import type { Session, Group, Theme } from '../../../../renderer/types';
 
 import { mockTheme } from '../../../helpers/mockTheme';
+import { createMockSession } from '../../../helpers';
 
 let idCounter = 0;
 function makeSession(overrides: Partial<Session> = {}): Session {
@@ -47,6 +48,8 @@ function createProps(overrides: Partial<Parameters<typeof SkinnySidebar>[0]> = {
 		getFileCount: vi.fn(() => 0),
 		setActiveSessionId: vi.fn(),
 		handleContextMenu: vi.fn(),
+		showUnreadAgentsOnly: false,
+		stuckOutageSignature: '',
 		...overrides,
 	};
 }
@@ -174,5 +177,54 @@ describe('SkinnySidebar', () => {
 		const dot = container.querySelector('.w-3.h-3') as HTMLElement;
 		expect(dot.style.backgroundColor).toBe('transparent');
 		expect(dot.style.border).toContain('1.5px solid');
+	});
+	it('keeps an auto-running (batch) agent visible under the unread filter', () => {
+		const batch = createMockSession({ id: 'batch-s' });
+		const idle = createMockSession({ id: 'idle-s' });
+		const { container } = render(
+			<SkinnySidebar
+				{...createProps({
+					sortedSessions: [batch, idle],
+					activeSessionId: 'other',
+					activeBatchSessionIds: ['batch-s'],
+					showUnreadAgentsOnly: true,
+				})}
+			/>
+		);
+
+		expect(container.querySelectorAll('[aria-label^="Switch to "]').length).toBe(1);
+	});
+
+	it('keeps a stuck (outage) agent visible under the unread filter', () => {
+		const stuck = createMockSession({ id: 'stuck-s' });
+		const idle = createMockSession({ id: 'idle-s' });
+		const { container } = render(
+			<SkinnySidebar
+				{...createProps({
+					sortedSessions: [stuck, idle],
+					activeSessionId: 'other',
+					stuckOutageSignature: 'stuck-s',
+					showUnreadAgentsOnly: true,
+				})}
+			/>
+		);
+
+		expect(container.querySelectorAll('[aria-label^="Switch to "]').length).toBe(1);
+	});
+
+	it('hides idle agents under the unread filter', () => {
+		const idle1 = createMockSession({ id: 'idle-1' });
+		const idle2 = createMockSession({ id: 'idle-2' });
+		const { container } = render(
+			<SkinnySidebar
+				{...createProps({
+					sortedSessions: [idle1, idle2],
+					activeSessionId: 'other',
+					showUnreadAgentsOnly: true,
+				})}
+			/>
+		);
+
+		expect(container.querySelectorAll('[aria-label^="Switch to "]').length).toBe(0);
 	});
 });

--- a/src/__tests__/renderer/hooks/computeSortedSessions.test.ts
+++ b/src/__tests__/renderer/hooks/computeSortedSessions.test.ts
@@ -50,4 +50,68 @@ describe('computeSortedSessions - unread filter jump-badge visibility', () => {
 
 		expect(visibleSessions.map((s) => s.name)).not.toContain('Idle Alone');
 	});
+
+	it('keeps an auto-running (batch) agent in visibleSessions under the unread filter', () => {
+		const batch = createMockSession({ id: 'b1', name: 'AutoRunning' });
+		const idle = createMockSession({ id: 'i1', name: 'Idle' });
+
+		const { visibleSessions } = computeSortedSessions({
+			sessions: [batch, idle],
+			groups: [],
+			bookmarksCollapsed: false,
+			showUnreadAgentsOnly: true,
+			activeBatchSessionIds: ['b1'],
+		});
+
+		const names = visibleSessions.map((s) => s.name);
+		expect(names).toContain('AutoRunning');
+		expect(names).not.toContain('Idle');
+	});
+
+	it('keeps a stuck (outage) agent in visibleSessions under the unread filter', () => {
+		const stuck = createMockSession({ id: 's1', name: 'Stuck' });
+		const idle = createMockSession({ id: 'i1', name: 'Idle' });
+
+		const { visibleSessions } = computeSortedSessions({
+			sessions: [stuck, idle],
+			groups: [],
+			bookmarksCollapsed: false,
+			showUnreadAgentsOnly: true,
+			stuckOutageSessionIds: ['s1'],
+		});
+
+		const names = visibleSessions.map((s) => s.name);
+		expect(names).toContain('Stuck');
+		expect(names).not.toContain('Idle');
+	});
+
+	it('keeps a parent visible when a worktree child is auto-running a batch', () => {
+		const parent = createMockSession({ id: 'p1', name: 'Parent' });
+		const child = createMockSession({ id: 'c1', name: 'Child', parentSessionId: 'p1' });
+
+		const { visibleSessions } = computeSortedSessions({
+			sessions: [parent, child],
+			groups: [],
+			bookmarksCollapsed: false,
+			showUnreadAgentsOnly: true,
+			activeBatchSessionIds: ['c1'],
+		});
+
+		expect(visibleSessions.map((s) => s.name)).toContain('Parent');
+	});
+
+	it('keeps a parent visible when a worktree child is stuck in an outage', () => {
+		const parent = createMockSession({ id: 'p1', name: 'Parent' });
+		const child = createMockSession({ id: 'c1', name: 'Child', parentSessionId: 'p1' });
+
+		const { visibleSessions } = computeSortedSessions({
+			sessions: [parent, child],
+			groups: [],
+			bookmarksCollapsed: false,
+			showUnreadAgentsOnly: true,
+			stuckOutageSessionIds: ['c1'],
+		});
+
+		expect(visibleSessions.map((s) => s.name)).toContain('Parent');
+	});
 });

--- a/src/__tests__/renderer/hooks/useCycleSession.test.ts
+++ b/src/__tests__/renderer/hooks/useCycleSession.test.ts
@@ -44,7 +44,10 @@ import { useGroupChatStore } from '../../../renderer/stores/groupChatStore';
 import { useUIStore } from '../../../renderer/stores/uiStore';
 import { useSettingsStore } from '../../../renderer/stores/settingsStore';
 import type { Session } from '../../../renderer/types';
-import { resetStores } from '../../helpers';
+import { resetStores, createMockSession, createMockAITab } from '../../helpers';
+import { useBatchStore } from '../../../renderer/stores/batchStore';
+import { useRetryStore } from '../../../renderer/stores/retryStore';
+import { DEFAULT_BATCH_STATE } from '../../../renderer/hooks/batch/batchReducer';
 
 // ============================================================================
 // Helpers
@@ -138,7 +141,14 @@ function makeOpenStarred(parentSessionId: string, tabId: string, displayName: st
 
 beforeEach(() => {
 	vi.clearAllMocks();
-	resetStores(useSessionStore, useGroupChatStore, useUIStore, useSettingsStore);
+	resetStores(
+		useSessionStore,
+		useGroupChatStore,
+		useUIStore,
+		useSettingsStore,
+		useBatchStore,
+		useRetryStore
+	);
 });
 
 // ============================================================================
@@ -1793,6 +1803,159 @@ describe('cycleSession', () => {
 			cycleSession('next', deps);
 
 			// All sessions visible - Alpha → Beta
+			expect(useSessionStore.getState().activeSessionId).toBe('b');
+		});
+		it('includes auto-running (batch) sessions even if not unread', () => {
+			const sessA = createMockSession({
+				id: 'a',
+				name: 'Alpha',
+				aiTabs: [createMockAITab({ hasUnread: true })],
+			});
+			const sessB = createMockSession({ id: 'b', name: 'Beta' }); // idle, but auto-running
+			const sessC = createMockSession({ id: 'c', name: 'Gamma' }); // neither
+
+			useSessionStore.setState({
+				sessions: [sessA, sessB, sessC],
+				activeSessionId: 'a',
+				cyclePosition: -1,
+			});
+			useUIStore.setState({
+				leftSidebarOpen: true,
+				bookmarksCollapsed: true,
+				showUnreadAgentsOnly: true,
+			});
+			useSettingsStore.setState({ groupChatsExpanded: false });
+
+			const deps = makeDeps({ batchSessionIds: new Set(['b']) });
+
+			cycleSession('next', deps);
+
+			// Alpha -> Beta (auto-running counts as visible); Gamma skipped.
+			expect(useSessionStore.getState().activeSessionId).toBe('b');
+		});
+
+		it('includes stuck (outage) sessions even if not unread', () => {
+			const sessA = createMockSession({
+				id: 'a',
+				name: 'Alpha',
+				aiTabs: [createMockAITab({ hasUnread: true })],
+			});
+			const sessB = createMockSession({ id: 'b', name: 'Beta' }); // idle, but stuck
+			const sessC = createMockSession({ id: 'c', name: 'Gamma' }); // neither
+
+			useSessionStore.setState({
+				sessions: [sessA, sessB, sessC],
+				activeSessionId: 'a',
+				cyclePosition: -1,
+			});
+			useUIStore.setState({
+				leftSidebarOpen: true,
+				bookmarksCollapsed: true,
+				showUnreadAgentsOnly: true,
+			});
+			useSettingsStore.setState({ groupChatsExpanded: false });
+
+			const deps = makeDeps({ stuckOutageIds: new Set(['b']) });
+
+			cycleSession('next', deps);
+
+			// Alpha -> Beta (stuck counts as visible); Gamma skipped.
+			expect(useSessionStore.getState().activeSessionId).toBe('b');
+		});
+
+		it('includes parent when a worktree child is auto-running a batch', () => {
+			const parent = createMockSession({ id: 'p', name: 'Parent' }); // idle itself
+			const child = createMockSession({
+				id: 'child1',
+				name: 'Child',
+				parentSessionId: 'p',
+				worktreeBranch: 'feat',
+			});
+			const other = createMockSession({
+				id: 'o',
+				name: 'Other',
+				aiTabs: [createMockAITab({ hasUnread: true })],
+			});
+
+			useSessionStore.setState({
+				sessions: [parent, child, other],
+				activeSessionId: 'o',
+				cyclePosition: -1,
+			});
+			useUIStore.setState({
+				leftSidebarOpen: true,
+				bookmarksCollapsed: true,
+				showUnreadAgentsOnly: true,
+			});
+			useSettingsStore.setState({ groupChatsExpanded: false });
+
+			const deps = makeDeps({ batchSessionIds: new Set(['child1']) });
+
+			cycleSession('next', deps);
+
+			// Other -> Parent (parent kept because its worktree child is auto-running).
+			expect(useSessionStore.getState().activeSessionId).toBe('p');
+		});
+
+		it('reads auto-running sessions from batchStore when no deps override is given', () => {
+			const sessA = createMockSession({
+				id: 'a',
+				name: 'Alpha',
+				aiTabs: [createMockAITab({ hasUnread: true })],
+			});
+			const sessB = createMockSession({ id: 'b', name: 'Beta' });
+			const sessC = createMockSession({ id: 'c', name: 'Gamma' });
+
+			useSessionStore.setState({
+				sessions: [sessA, sessB, sessC],
+				activeSessionId: 'a',
+				cyclePosition: -1,
+			});
+			useUIStore.setState({
+				leftSidebarOpen: true,
+				bookmarksCollapsed: true,
+				showUnreadAgentsOnly: true,
+			});
+			useSettingsStore.setState({ groupChatsExpanded: false });
+			useBatchStore.setState({
+				batchRunStates: { b: { ...DEFAULT_BATCH_STATE, isRunning: true } },
+			});
+
+			const deps = makeDeps(); // no override -> event-time batchStore read
+
+			cycleSession('next', deps);
+
+			// Alpha -> Beta (batchStore marks 'b' auto-running); Gamma skipped.
+			expect(useSessionStore.getState().activeSessionId).toBe('b');
+		});
+
+		it('reads stuck sessions from retryStore when no deps override is given', () => {
+			const sessA = createMockSession({
+				id: 'a',
+				name: 'Alpha',
+				aiTabs: [createMockAITab({ hasUnread: true })],
+			});
+			const sessB = createMockSession({ id: 'b', name: 'Beta' });
+			const sessC = createMockSession({ id: 'c', name: 'Gamma' });
+
+			useSessionStore.setState({
+				sessions: [sessA, sessB, sessC],
+				activeSessionId: 'a',
+				cyclePosition: -1,
+			});
+			useUIStore.setState({
+				leftSidebarOpen: true,
+				bookmarksCollapsed: true,
+				showUnreadAgentsOnly: true,
+			});
+			useSettingsStore.setState({ groupChatsExpanded: false });
+			useRetryStore.getState().patchOutage('outage-b', { sessionId: 'b', status: 'active' });
+
+			const deps = makeDeps(); // no override -> event-time retryStore read
+
+			cycleSession('next', deps);
+
+			// Alpha -> Beta (retryStore marks 'b' stuck); Gamma skipped.
 			expect(useSessionStore.getState().activeSessionId).toBe('b');
 		});
 	});

--- a/src/__tests__/renderer/utils/sessionAttention.test.ts
+++ b/src/__tests__/renderer/utils/sessionAttention.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Unit tests for the shared Left Bar "needs attention" predicate that drives
+ * the unread-agents filter across categorization, the bell badge, rendered
+ * worktree children, jump badges, the collapsed rail, and keyboard cycling.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+	sessionNeedsAttention,
+	sessionOrChildrenNeedAttention,
+	outageIdsFromSignature,
+	type AttentionContext,
+} from '../../../renderer/utils/sessionAttention';
+import { createMockSession, createMockAITab } from '../../helpers';
+
+const EMPTY_CTX: AttentionContext = {
+	batchSessionIds: new Set(),
+	stuckOutageIds: new Set(),
+};
+
+describe('outageIdsFromSignature', () => {
+	it('returns an empty set for an empty signature (no phantom empty-string id)', () => {
+		const ids = outageIdsFromSignature('');
+		expect(ids.size).toBe(0);
+		expect(ids.has('')).toBe(false);
+	});
+
+	it('splits a comma-joined signature into ids', () => {
+		expect(outageIdsFromSignature('a,b,c')).toEqual(new Set(['a', 'b', 'c']));
+	});
+});
+
+describe('sessionNeedsAttention', () => {
+	it('is false for an idle, read agent with no batch or outage', () => {
+		expect(sessionNeedsAttention(createMockSession({ id: 'a' }), EMPTY_CTX)).toBe(false);
+	});
+
+	it('is true when any AI tab is unread', () => {
+		const session = createMockSession({ id: 'a', aiTabs: [createMockAITab({ hasUnread: true })] });
+		expect(sessionNeedsAttention(session, EMPTY_CTX)).toBe(true);
+	});
+
+	it('is true when busy', () => {
+		expect(sessionNeedsAttention(createMockSession({ id: 'a', state: 'busy' }), EMPTY_CTX)).toBe(
+			true
+		);
+	});
+
+	it('is true when in an error state', () => {
+		expect(sessionNeedsAttention(createMockSession({ id: 'a', state: 'error' }), EMPTY_CTX)).toBe(
+			true
+		);
+	});
+
+	it('is true when auto-running an Auto Run batch even though idle and read', () => {
+		const ctx: AttentionContext = { batchSessionIds: new Set(['b1']), stuckOutageIds: new Set() };
+		expect(sessionNeedsAttention(createMockSession({ id: 'b1' }), ctx)).toBe(true);
+	});
+
+	it('is true when stuck auto-retrying an outage', () => {
+		const ctx: AttentionContext = { batchSessionIds: new Set(), stuckOutageIds: new Set(['s1']) };
+		expect(sessionNeedsAttention(createMockSession({ id: 's1' }), ctx)).toBe(true);
+	});
+
+	it('matches batch/outage membership by id, not by another agent id', () => {
+		const ctx: AttentionContext = {
+			batchSessionIds: new Set(['other']),
+			stuckOutageIds: new Set(['nope']),
+		};
+		expect(sessionNeedsAttention(createMockSession({ id: 'a' }), ctx)).toBe(false);
+	});
+});
+
+describe('sessionOrChildrenNeedAttention', () => {
+	it('is false when neither the parent nor any child needs attention', () => {
+		const parent = createMockSession({ id: 'p' });
+		const child = createMockSession({ id: 'c', parentSessionId: 'p' });
+		expect(sessionOrChildrenNeedAttention(parent, [child], EMPTY_CTX)).toBe(false);
+	});
+
+	it('is true when the parent itself needs attention', () => {
+		const parent = createMockSession({ id: 'p', state: 'error' });
+		expect(sessionOrChildrenNeedAttention(parent, [], EMPTY_CTX)).toBe(true);
+	});
+
+	it('is true when a worktree child is busy', () => {
+		const parent = createMockSession({ id: 'p' });
+		const child = createMockSession({ id: 'c', parentSessionId: 'p', state: 'busy' });
+		expect(sessionOrChildrenNeedAttention(parent, [child], EMPTY_CTX)).toBe(true);
+	});
+
+	it('is true when a worktree child is auto-running a batch', () => {
+		const parent = createMockSession({ id: 'p' });
+		const child = createMockSession({ id: 'c', parentSessionId: 'p' });
+		const ctx: AttentionContext = { batchSessionIds: new Set(['c']), stuckOutageIds: new Set() };
+		expect(sessionOrChildrenNeedAttention(parent, [child], ctx)).toBe(true);
+	});
+
+	it('is true when a worktree child is stuck in an outage', () => {
+		const parent = createMockSession({ id: 'p' });
+		const child = createMockSession({ id: 'c', parentSessionId: 'p' });
+		const ctx: AttentionContext = { batchSessionIds: new Set(), stuckOutageIds: new Set(['c']) };
+		expect(sessionOrChildrenNeedAttention(parent, [child], ctx)).toBe(true);
+	});
+
+	it('handles an undefined children list', () => {
+		expect(
+			sessionOrChildrenNeedAttention(
+				createMockSession({ id: 'p', state: 'busy' }),
+				undefined,
+				EMPTY_CTX
+			)
+		).toBe(true);
+		expect(
+			sessionOrChildrenNeedAttention(createMockSession({ id: 'p2' }), undefined, EMPTY_CTX)
+		).toBe(false);
+	});
+});

--- a/src/renderer/components/SessionList/SessionList.tsx
+++ b/src/renderer/components/SessionList/SessionList.tsx
@@ -60,6 +60,11 @@ import { SkinnySidebar } from './SkinnySidebar';
 import { LiveOverlayPanel } from './LiveOverlayPanel';
 import { useSessionCategories } from '../../hooks/session/useSessionCategories';
 import { useSessionFilterMode } from '../../hooks/session/useSessionFilterMode';
+import {
+	sessionNeedsAttention,
+	outageIdsFromSignature,
+	type AttentionContext,
+} from '../../utils/sessionAttention';
 import { cueService } from '../../services/cue';
 import { captureException } from '../../utils/sentry';
 import { isWebDesktop } from '../../utils/runtimeContext';
@@ -485,12 +490,17 @@ function SessionListInner(props: SessionListProps) {
 	// Agent Resilience: agents stuck auto-retrying an outage count as "needs
 	// attention" and surface in the unread filter (see useSessionCategories).
 	const stuckOutageSignature = useActiveOutageSessionSignature();
+	// Shared "needs attention" context (batch + stuck ids) for the unread filter.
+	const attentionCtx = useMemo<AttentionContext>(
+		() => ({
+			batchSessionIds: new Set(activeBatchSessionIds),
+			stuckOutageIds: outageIdsFromSignature(stuckOutageSignature),
+		}),
+		[activeBatchSessionIds, stuckOutageSignature]
+	);
 	const hasUnreadAgents = useMemo(
-		() =>
-			sessions.some(
-				(s) => s.aiTabs?.some((tab) => tab.hasUnread) || s.state === 'busy' || s.state === 'error'
-			) || stuckOutageSignature !== '',
-		[sessions, stuckOutageSignature]
+		() => sessions.some((s) => sessionNeedsAttention(s, attentionCtx)),
+		[sessions, attentionCtx]
 	);
 	const [menuOpen, setMenuOpen] = useState(false);
 
@@ -959,16 +969,12 @@ function SessionListInner(props: SessionListProps) {
 		}
 	) => {
 		const allWorktreeChildren = getWorktreeChildren(session.id);
-		// When filtering unread, only show worktree children that are unread, busy,
-		// in an error state, or stuck auto-retrying an outage (all "needs attention").
+		// When filtering unread, only show worktree children that need attention:
+		// unread, busy, in an error state, auto-running an Auto Run batch, or stuck
+		// auto-retrying an outage (the shared predicate, plus the active child).
 		const worktreeChildren = showUnreadAgentsOnly
 			? allWorktreeChildren.filter(
-					(child) =>
-						child.id === activeSessionId ||
-						child.aiTabs?.some((tab) => tab.hasUnread) ||
-						child.state === 'busy' ||
-						child.state === 'error' ||
-						stuckOutageSignature.split(',').includes(child.id)
+					(child) => child.id === activeSessionId || sessionNeedsAttention(child, attentionCtx)
 				)
 			: allWorktreeChildren;
 		const hasWorktrees = worktreeChildren.length > 0;
@@ -2109,6 +2115,7 @@ function SessionListInner(props: SessionListProps) {
 					setActiveSessionId={setActiveSessionId}
 					handleContextMenu={handleContextMenu}
 					showUnreadAgentsOnly={showUnreadAgentsOnly}
+					stuckOutageSignature={stuckOutageSignature}
 				/>
 			)}
 

--- a/src/renderer/components/SessionList/SkinnySidebar.tsx
+++ b/src/renderer/components/SessionList/SkinnySidebar.tsx
@@ -4,6 +4,11 @@ import { getStatusColor } from '../../utils/theme';
 import { hasNoClaudeProviderSession } from '../SessionItem';
 import { SessionTooltipContent } from './SessionTooltipContent';
 import { PluginUiItemsSlot } from '../plugins/PluginUiItemsSlot';
+import {
+	sessionNeedsAttention,
+	outageIdsFromSignature,
+	type AttentionContext,
+} from '../../utils/sessionAttention';
 
 interface SkinnySidebarProps {
 	theme: Theme;
@@ -17,6 +22,8 @@ interface SkinnySidebarProps {
 	setActiveSessionId: (id: string) => void;
 	handleContextMenu: (e: React.MouseEvent, sessionId: string) => void;
 	showUnreadAgentsOnly: boolean;
+	/** Comma-joined signature of agents stuck auto-retrying an outage. */
+	stuckOutageSignature: string;
 }
 
 export const SkinnySidebar = memo(function SkinnySidebar({
@@ -31,14 +38,15 @@ export const SkinnySidebar = memo(function SkinnySidebar({
 	setActiveSessionId,
 	handleContextMenu,
 	showUnreadAgentsOnly,
+	stuckOutageSignature,
 }: SkinnySidebarProps) {
+	const attentionCtx: AttentionContext = {
+		batchSessionIds: new Set(activeBatchSessionIds),
+		stuckOutageIds: outageIdsFromSignature(stuckOutageSignature),
+	};
 	const visibleSessions = showUnreadAgentsOnly
 		? sortedSessions.filter(
-				(s) =>
-					s.id === activeSessionId ||
-					s.state === 'busy' ||
-					s.state === 'error' ||
-					s.aiTabs?.some((tab) => tab.hasUnread)
+				(s) => s.id === activeSessionId || sessionNeedsAttention(s, attentionCtx)
 			)
 		: sortedSessions;
 

--- a/src/renderer/hooks/session/SidebarNavSync.tsx
+++ b/src/renderer/hooks/session/SidebarNavSync.tsx
@@ -16,6 +16,9 @@ import { computeSortedSessions } from './computeSortedSessions';
 import { useStarredItems } from './useStarredItems';
 import { useWindowContextOptional } from '../../contexts/WindowContext';
 import { scopeSessionsToOwningWindow } from '../../utils/windowTargets';
+import { useShallow } from 'zustand/react/shallow';
+import { useBatchStore, selectActiveBatchSessionIds } from '../../stores/batchStore';
+import { useActiveOutageSessionSignature } from '../../stores/retryStore';
 
 function SidebarNavSyncInner() {
 	const windowCtx = useWindowContextOptional();
@@ -30,6 +33,11 @@ function SidebarNavSyncInner() {
 	const activeSessionId = useSessionStore((s) => s.activeSessionId);
 	const bookmarksCollapsed = useUIStore((s) => s.bookmarksCollapsed);
 	const showUnreadAgentsOnly = useUIStore((s) => s.showUnreadAgentsOnly);
+	// Batch (AUTO badge) and stuck-outage ids feed the shared "needs attention"
+	// predicate so auto-running / stuck agents survive the unread filter in the
+	// jump-badge / nav projection, matching the rendered list.
+	const activeBatchSessionIds = useBatchStore(useShallow(selectActiveBatchSessionIds));
+	const stuckOutageSignature = useActiveOutageSessionSignature();
 
 	const setSortedProjection = useSidebarNavStore((s) => s.setSortedProjection);
 	const setStarredItems = useSidebarNavStore((s) => s.setStarredItems);
@@ -52,6 +60,8 @@ function SidebarNavSyncInner() {
 				bookmarksCollapsed,
 				showUnreadAgentsOnly,
 				activeSessionId,
+				activeBatchSessionIds,
+				stuckOutageSessionIds: stuckOutageSignature ? stuckOutageSignature.split(',') : [],
 			})
 		);
 	}, [
@@ -60,6 +70,8 @@ function SidebarNavSyncInner() {
 		bookmarksCollapsed,
 		showUnreadAgentsOnly,
 		activeSessionId,
+		activeBatchSessionIds,
+		stuckOutageSignature,
 		setSortedProjection,
 	]);
 

--- a/src/renderer/hooks/session/computeSortedSessions.ts
+++ b/src/renderer/hooks/session/computeSortedSessions.ts
@@ -1,5 +1,9 @@
 import type { Session, Group } from '../../types';
 import { compareNamesIgnoringEmojis } from '../../../shared/emojiUtils';
+import {
+	sessionOrChildrenNeedAttention,
+	type AttentionContext,
+} from '../../utils/sessionAttention';
 
 /**
  * Inputs for {@link computeSortedSessions}. Pure - safe to call from a Zustand
@@ -11,6 +15,10 @@ export interface ComputeSortedSessionsInput {
 	bookmarksCollapsed: boolean;
 	showUnreadAgentsOnly?: boolean;
 	activeSessionId?: string | null;
+	/** Session ids auto-running an Auto Run batch (the AUTO badge). */
+	activeBatchSessionIds?: string[];
+	/** Session ids stuck auto-retrying an Agent Resilience outage. */
+	stuckOutageSessionIds?: string[];
 }
 
 /**
@@ -33,7 +41,19 @@ export interface SortedSessionsProjection {
  * 3. navSessions / navIndexMap - arrow-key visual order (bookmarks + group + ungrouped)
  */
 export function computeSortedSessions(input: ComputeSortedSessionsInput): SortedSessionsProjection {
-	const { sessions, groups, bookmarksCollapsed, showUnreadAgentsOnly, activeSessionId } = input;
+	const {
+		sessions,
+		groups,
+		bookmarksCollapsed,
+		showUnreadAgentsOnly,
+		activeSessionId,
+		activeBatchSessionIds,
+		stuckOutageSessionIds,
+	} = input;
+	const attentionCtx: AttentionContext = {
+		batchSessionIds: new Set(activeBatchSessionIds),
+		stuckOutageIds: new Set(stuckOutageSessionIds),
+	};
 
 	const worktreeChildrenByParent = new Map<string, Session[]>();
 	for (const s of sessions) {
@@ -130,17 +150,11 @@ export function computeSortedSessions(input: ComputeSortedSessionsInput): Sorted
 			worktreeChildrenByParent.get(session.id)?.some((child) => child.id === activeSessionId) ||
 			false;
 		if (isActiveOrParentOfActive) return true;
-		const hasUnread = session.aiTabs?.some((tab) => tab.hasUnread) ?? false;
-		const isBusyOrError = session.state === 'busy' || session.state === 'error';
-		const children = worktreeChildrenByParent.get(session.id);
-		const hasUnreadChildren =
-			children?.some(
-				(child) =>
-					child.aiTabs?.some((tab) => tab.hasUnread) ||
-					child.state === 'busy' ||
-					child.state === 'error'
-			) ?? false;
-		return hasUnread || isBusyOrError || hasUnreadChildren;
+		return sessionOrChildrenNeedAttention(
+			session,
+			worktreeChildrenByParent.get(session.id),
+			attentionCtx
+		);
 	};
 
 	const visibleSessions: Session[] = [];

--- a/src/renderer/hooks/session/useCycleSession.ts
+++ b/src/renderer/hooks/session/useCycleSession.ts
@@ -23,6 +23,12 @@ import { useSettingsStore } from '../../stores/settingsStore';
 import { compareNamesIgnoringEmojis } from './useSortedSessions';
 import type { StarredItem } from './useStarredItems';
 import { useSidebarNavStore } from '../../stores/sidebarNavStore';
+import { useBatchStore, selectActiveBatchSessionIds } from '../../stores/batchStore';
+import { getActiveOutageSessionIds } from '../../stores/retryStore';
+import {
+	sessionOrChildrenNeedAttention,
+	type AttentionContext,
+} from '../../utils/sessionAttention';
 
 // ============================================================================
 // Dependencies
@@ -48,6 +54,16 @@ export interface CycleSessionDeps {
 	 * for production (sidebarNavStore).
 	 */
 	navIndexMap?: Map<string, number>;
+	/**
+	 * Session ids auto-running an Auto Run batch (the AUTO badge). Prefer omitting
+	 * for production (read from batchStore at event time); tests may pass a fixture.
+	 */
+	batchSessionIds?: ReadonlySet<string>;
+	/**
+	 * Session ids stuck auto-retrying an outage. Prefer omitting for production
+	 * (read from retryStore at event time); tests may pass a fixture.
+	 */
+	stuckOutageIds?: ReadonlySet<string>;
 	/**
 	 * Multi-window: optional window-ownership predicate. When provided, cycling
 	 * includes only agent rows THIS window owns, so `Cmd+[` / `Cmd+]` never jumps
@@ -237,32 +253,27 @@ export function cycleSession(dir: 'next' | 'prev', deps: CycleSessionDeps): void
 		);
 	}
 
-	// When unread filter is active, restrict cycling to unread/busy agents only
-	// (plus the currently active agent so you don't get lost)
+	// When the unread filter is active, restrict cycling to agents that need
+	// attention (unread / busy / error / auto-running / stuck), plus the currently
+	// active agent so you don't get lost.
 	if (showUnreadAgentsOnly) {
+		const attentionCtx: AttentionContext = {
+			batchSessionIds:
+				deps.batchSessionIds ?? new Set(selectActiveBatchSessionIds(useBatchStore.getState())),
+			stuckOutageIds: deps.stuckOutageIds ?? getActiveOutageSessionIds(),
+		};
 		const currentActiveId = activeGroupChatId || activeSessionId;
 		const filteredOrder = visualOrder.filter((item) => {
 			// Always keep the currently active item
 			if (item.id === currentActiveId) return true;
 			// Group chats pass through (they have their own unread badges)
 			if (item.type === 'groupChat') return true;
-			// Check if session is unread, busy, or in an error state (all "needs attention")
+			// Defer to the shared predicate (unread / busy / error / auto-running /
+			// stuck), including worktree children, so cycling matches the rendered list.
 			const session = sessions.find((s) => s.id === item.id);
 			if (!session) return false;
-			if (session.aiTabs?.some((tab) => tab.hasUnread)) return true;
-			if (session.state === 'busy' || session.state === 'error') return true;
-			// Check worktree children for unread/busy/error
 			const children = sessions.filter((s) => s.parentSessionId === session.id);
-			if (
-				children.some(
-					(child) =>
-						child.aiTabs?.some((tab) => tab.hasUnread) ||
-						child.state === 'busy' ||
-						child.state === 'error'
-				)
-			)
-				return true;
-			return false;
+			return sessionOrChildrenNeedAttention(session, children, attentionCtx);
 		});
 		visualOrder.length = 0;
 		visualOrder.push(...filteredOrder);

--- a/src/renderer/hooks/session/useSessionCategories.ts
+++ b/src/renderer/hooks/session/useSessionCategories.ts
@@ -4,6 +4,10 @@ import type { Session, Group } from '../../types';
 import { useSessionStore } from '../../stores/sessionStore';
 import { sidebarSessionEquality } from '../../stores/sessionEquality';
 import { compareNamesIgnoringEmojis as compareSessionNames } from '../../../shared/emojiUtils';
+import {
+	sessionOrChildrenNeedAttention,
+	type AttentionContext,
+} from '../../utils/sessionAttention';
 
 export interface SessionCategories {
 	worktreeChildrenByParentId: Map<string, Session[]>;
@@ -130,6 +134,10 @@ export function useSessionCategories(
 		// the busy/unread checks below would drop them. Keep them visible in the
 		// unread filter using the same set that drives the badge.
 		const batchSessionIds = new Set(activeBatchSessionIds);
+		const attentionCtx: AttentionContext = {
+			batchSessionIds,
+			stuckOutageIds: stuckOutageSessionIds,
+		};
 
 		for (const s of sessions) {
 			// Exclude worktree children from main list (they appear under parent)
@@ -139,33 +147,19 @@ export function useSessionCategories(
 			// section, never in Bookmarks/Groups/Ungrouped, so exclude it here.
 			if (s.isPianola) continue;
 
-			// Apply unread agents filter (also keep busy/working agents visible)
-			// Always keep the active session (or its parent) visible so user doesn't lose their place
+			// Apply the unread-agents filter. Always keep the active session (or its
+			// parent) visible so the user doesn't lose their place; otherwise defer to
+			// the shared "needs attention" predicate (unread / busy / error /
+			// auto-running / stuck), including worktree children.
 			const isActiveOrParentOfActive =
 				s.id === activeSessionId ||
 				worktreeChildrenByParentId.get(s.id)?.some((child) => child.id === activeSessionId);
-			if (showUnreadAgentsOnly && !isActiveOrParentOfActive) {
-				const hasUnread = s.aiTabs?.some((tab) => tab.hasUnread);
-				const isBusy = s.state === 'busy';
-				// An agent in an error state needs attention, so keep it visible.
-				const isError = s.state === 'error';
-				const isAutoRunning = batchSessionIds.has(s.id);
-				// A stuck (auto-retrying) agent needs attention just like an unread
-				// one, so keep it visible under the unread filter.
-				const isStuck = stuckOutageSessionIds.has(s.id);
-				// Also check if any worktree children have unread, are busy, are
-				// auto-running, are stuck in an outage, or are in an error state.
-				const children = worktreeChildrenByParentId.get(s.id);
-				const hasActiveChildren = children?.some(
-					(child) =>
-						child.aiTabs?.some((tab) => tab.hasUnread) ||
-						child.state === 'busy' ||
-						child.state === 'error' ||
-						batchSessionIds.has(child.id) ||
-						stuckOutageSessionIds.has(child.id)
-				);
-				if (!hasUnread && !isBusy && !isError && !isAutoRunning && !isStuck && !hasActiveChildren)
-					continue;
+			if (
+				showUnreadAgentsOnly &&
+				!isActiveOrParentOfActive &&
+				!sessionOrChildrenNeedAttention(s, worktreeChildrenByParentId.get(s.id), attentionCtx)
+			) {
+				continue;
 			}
 
 			if (!query) {

--- a/src/renderer/stores/retryStore.ts
+++ b/src/renderer/stores/retryStore.ts
@@ -434,6 +434,29 @@ export function sessionHasActiveOutage(sessionId: string): boolean {
 	return false;
 }
 
+/**
+ * Collect the agent ids that currently have at least one active outage. Shared
+ * by the reactive signature and the non-reactive event-time getter so the two
+ * never diverge.
+ */
+function collectActiveOutageSessionIds(outages: Record<string, OutageRecord>): Set<string> {
+	const ids = new Set<string>();
+	for (const id in outages) {
+		const o = outages[id];
+		if (o.status === 'active') ids.add(o.sessionId);
+	}
+	return ids;
+}
+
+/**
+ * Non-reactive: all agent ids with at least one active outage. For event-time
+ * reads (e.g. keyboard cycling) that need the set outside React; the reactive
+ * `useActiveOutageSessionSignature` covers render-time subscribers.
+ */
+export function getActiveOutageSessionIds(): Set<string> {
+	return collectActiveOutageSessionIds(useRetryStore.getState().outages);
+}
+
 /** Reactive: whether a specific agent currently has an active outage (Left Bar light). */
 export function useSessionHasActiveOutage(sessionId: string): boolean {
 	return useRetryStore((s) => {
@@ -462,14 +485,9 @@ export function useTabHasActiveOutage(sessionId: string, tabId: string): boolean
  * Bar filter memo only recomputes when the set of stuck agents actually changes.
  */
 export function useActiveOutageSessionSignature(): string {
-	return useRetryStore((s) => {
-		const ids = new Set<string>();
-		for (const id in s.outages) {
-			const o = s.outages[id];
-			if (o.status === 'active') ids.add(o.sessionId);
-		}
-		return Array.from(ids).sort().join(',');
-	});
+	return useRetryStore((s) =>
+		Array.from(collectActiveOutageSessionIds(s.outages)).sort().join(',')
+	);
 }
 
 /**

--- a/src/renderer/utils/sessionAttention.ts
+++ b/src/renderer/utils/sessionAttention.ts
@@ -1,0 +1,63 @@
+import type { Session } from '../types';
+
+/**
+ * Inputs the "needs attention" predicate can't read off the Session itself:
+ * whether an agent is auto-running an Auto Run batch, and whether it is stuck
+ * auto-retrying an Agent Resilience outage. Both are tracked in separate stores
+ * (batchStore / retryStore), so the caller passes them in as id sets.
+ */
+export interface AttentionContext {
+	/** Session ids with an active Auto Run batch (the AUTO badge). */
+	batchSessionIds: ReadonlySet<string>;
+	/** Session ids stuck auto-retrying an outage. */
+	stuckOutageIds: ReadonlySet<string>;
+}
+
+/**
+ * Parse the comma-joined outage signature (see `useActiveOutageSessionSignature`
+ * in retryStore) into a lookup set. An empty signature yields an empty set (no
+ * phantom empty-string id).
+ */
+export function outageIdsFromSignature(signature: string): Set<string> {
+	return new Set(signature ? signature.split(',') : []);
+}
+
+/**
+ * Single source of truth for the Left Bar unread ("needs attention") filter.
+ *
+ * An agent needs attention when it has an unread AI tab, is busy, is in an
+ * error state, is auto-running an Auto Run batch, or is stuck auto-retrying an
+ * outage. Every Left Bar surface that filters by unread MUST route through here
+ * so they never diverge: categorization (`useSessionCategories`), the bell
+ * badge + rendered worktree children (`SessionList`), the jump-badge / nav
+ * projection (`computeSortedSessions` via `SidebarNavSync`), the collapsed rail
+ * (`SkinnySidebar`), and keyboard cycling (`useCycleSession`). A partial
+ * reimplementation is how an auto-running worktree child ends up hidden while
+ * its parent stays visible.
+ *
+ * The active-session carve-out is intentionally NOT here: each surface keeps
+ * its own "always show the active agent (or its parent)" rule because the
+ * semantics differ (parent-of-active rollup, active group chat, per-row), and
+ * an active idle agent does not "need attention".
+ */
+export function sessionNeedsAttention(session: Session, ctx: AttentionContext): boolean {
+	if (session.aiTabs?.some((tab) => tab.hasUnread)) return true;
+	if (session.state === 'busy' || session.state === 'error') return true;
+	if (ctx.batchSessionIds.has(session.id)) return true;
+	if (ctx.stuckOutageIds.has(session.id)) return true;
+	return false;
+}
+
+/**
+ * True when a parent agent should stay visible under the unread filter: it
+ * needs attention itself, or any of its worktree children do (a busy or
+ * auto-running worktree keeps the parent surfaced).
+ */
+export function sessionOrChildrenNeedAttention(
+	session: Session,
+	children: readonly Session[] | undefined,
+	ctx: AttentionContext
+): boolean {
+	if (sessionNeedsAttention(session, ctx)) return true;
+	return children?.some((child) => sessionNeedsAttention(child, ctx)) ?? false;
+}


### PR DESCRIPTION
## Problem

CodeRabbit flagged (Major) on #1256 that the Left Bar "needs attention" predicate is duplicated across ~5 surfaces and only the rendered list treats auto-running (AUTO badge) and stuck (outage auto-retry) agents as needing attention. The jump badges, collapsed rail, and keyboard cycling do not, so an auto-running or stuck agent shows in the full sidebar but is skipped by Opt+Cmd+number jumps, hidden in the skinny rail, and skipped by Cmd+[ / Cmd+]. This is a pre-existing systemic divergence that #1256 intentionally left out of its focused scope.

## Fix

Introduce one shared predicate and route every surface through it.

`src/renderer/utils/sessionAttention.ts` (new):

- `sessionNeedsAttention(session, ctx)` - unread | busy | error | batch | stuck
- `sessionOrChildrenNeedAttention(session, children, ctx)` - parent stays visible when a worktree child needs attention
- `outageIdsFromSignature(sig)` - parse the comma-joined outage signature into a lookup set
- `AttentionContext = { batchSessionIds, stuckOutageIds }`

Surfaces routed through the helper:

- `useSessionCategories` (rendered list): refactored onto the helper, no behavior change (it already covered all five states).
- `computeSortedSessions` (Opt+Cmd+number jump badges / nav): now accepts `activeBatchSessionIds` / `stuckOutageSessionIds`; `SidebarNavSync` subscribes to `batchStore` and the outage signature and threads them into the projection.
- `SkinnySidebar` (collapsed rail): now accepts `stuckOutageSignature`; `SessionList` passes it at the call site.
- `useCycleSession` (Cmd+[ / Cmd+]): reads batch/outage at event time via `getState()` (matching how it already reads sessions / UI / nav), with optional test-override deps. Adds a non-reactive `getActiveOutageSessionIds()` to `retryStore`.
- `SessionList`: the `hasUnreadAgents` bell badge and the worktree-child filter now include batch.

The active-session carve-out stays per-surface (the semantics differ: parent-of-active rollup, active group chat, per-row), so there is no behavior change for the rendered list; the other surfaces gain batch + stuck visibility to match it.

## Tests

- New `sessionAttention` unit suite covering the helper directly: idle / unread / busy / error / batch / stuck, the parent-or-child rollup, and empty-signature parsing.
- `computeSortedSessions`: auto-running and stuck cases for both a parent and a worktree child.
- `SkinnySidebar`: auto-running and stuck agents stay visible under the unread filter, and idle agents are hidden (the collapsed rail filters rows individually, so these are per-row cases).
- `useCycleSession`: auto-running and stuck via both the deps-override and the event-time store-read paths (the latter exercises `getActiveOutageSessionIds()` and `selectActiveBatchSessionIds`), plus a worktree-child rollup case (an auto-running child keeps its parent in the cycle).

## Validation

- Touched suites green: `npx vitest run` on `sessionAttention`, `computeSortedSessions`, `SkinnySidebar`, `useCycleSession`, `useSessionCategories`, and `SessionList` (311 tests).
- `prettier --check` and `eslint` clean on touched files.
- `tsc -p tsconfig.lint.json`: no new type errors in any touched file. The two pre-existing unrelated errors present on `rc` (`languageLoader.ts` nested `@codemirror` duplicate; `GitGraphView.tsx` missing `@gitgraph/*`) remain untouched. CI is the authoritative gate.

## Note on the stack

This was originally stacked on #1256, which adds the `error` state to the same predicates. #1256 has since merged into `rc`, and this branch has been rebased onto it, so the PR is now a single commit against `rc` containing only this change.

Follow-up resolving the CodeRabbit thread on #1256.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved the “Unread agents only” filter to keep sessions active in batch runs or affected by stuck outages.
  * Parent sessions remain visible when a related worktree child requires attention.
  * Sidebar session lists, categories, and session cycling now apply consistent attention rules.

* **Bug Fixes**
  * Sidebar visibility now updates when batch activity or outage status changes.

* **Tests**
  * Added coverage for unread filtering, batch sessions, stuck outages, worktree relationships, and session cycling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->