### PR TITLE
fix(chat): keep AI transcript stuck to the bottom during tool streaming

### DIFF
--- a/src/__tests__/renderer/components/TerminalOutput/useTerminalOutputScroll.test.ts
+++ b/src/__tests__/renderer/components/TerminalOutput/useTerminalOutputScroll.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useTerminalOutputScroll } from '../../../../renderer/components/TerminalOutput/hooks/useTerminalOutputScroll';
+
+/**
+ * Regression coverage for the stick-to-bottom follow behaviour when the log
+ * COUNT grows (a new tool badge or message appears) mid-stream.
+ *
+ * The container is stubbed to report "not at bottom" (an instantaneous,
+ * pre-scroll measurement). The count-effect must NOT use that measurement to
+ * pause a user who is already following: doing so is what made a tall tool
+ * badge kill auto-follow (the MutationObserver's rAF jump had not run yet). It
+ * must trust the tracked follow state instead.
+ */
+function makeContainer(
+	scrollHeight: number,
+	clientHeight: number,
+	scrollTop: number
+): HTMLDivElement {
+	const el = document.createElement('div');
+	Object.defineProperty(el, 'scrollHeight', { value: scrollHeight, configurable: true });
+	Object.defineProperty(el, 'clientHeight', { value: clientHeight, configurable: true });
+	Object.defineProperty(el, 'scrollTo', { value: () => {}, configurable: true });
+	el.scrollTop = scrollTop;
+	return el;
+}
+
+describe('useTerminalOutputScroll follow-on-count-growth', () => {
+	it('keeps following when the count grows while at bottom, even for a tall new entry', () => {
+		// Measures 800px "below bottom", but the user is following.
+		const ref = { current: makeContainer(1000, 200, 0) };
+
+		const { result, rerender } = renderHook(
+			({ len }) =>
+				useTerminalOutputScroll({
+					scrollContainerRef: ref,
+					sessionId: 's1',
+					activeTabId: 't1',
+					filteredLogsLength: len,
+				}),
+			{ initialProps: { len: 3 } }
+		);
+
+		expect(result.current.isAtBottom).toBe(true);
+		expect(result.current.hasNewMessages).toBe(false);
+
+		// A new (tall) tool badge appears while following: must not pause follow.
+		rerender({ len: 4 });
+
+		expect(result.current.isAtBottom).toBe(true);
+		expect(result.current.autoScrollPaused).toBe(false);
+		expect(result.current.hasNewMessages).toBe(false);
+		expect(result.current.newMessageCount).toBe(0);
+	});
+
+	it('raises the new-messages pill when the count grows while the user is scrolled up', () => {
+		const ref = { current: makeContainer(1000, 200, 0) };
+
+		const { result, rerender } = renderHook(
+			({ len }) =>
+				useTerminalOutputScroll({
+					scrollContainerRef: ref,
+					sessionId: 's1',
+					activeTabId: 't1',
+					filteredLogsLength: len,
+				}),
+			{ initialProps: { len: 3 } }
+		);
+
+		// A genuine scroll event with the container not at bottom pauses follow.
+		act(() => {
+			result.current.handleScroll();
+		});
+		expect(result.current.isAtBottom).toBe(false);
+		expect(result.current.autoScrollPaused).toBe(true);
+
+		// New content while paused increments the unread pill.
+		rerender({ len: 5 });
+
+		expect(result.current.hasNewMessages).toBe(true);
+		expect(result.current.newMessageCount).toBe(2);
+		expect(result.current.isAtBottom).toBe(false);
+	});
+});

--- a/src/renderer/components/TerminalOutput/hooks/useTerminalOutputScroll.ts
+++ b/src/renderer/components/TerminalOutput/hooks/useTerminalOutputScroll.ts
@@ -156,24 +156,25 @@ export function useTerminalOutputScroll({
 	useEffect(() => {
 		const currentCount = filteredLogsLength;
 		if (currentCount > lastLogCountRef.current) {
-			const container = scrollContainerRef.current;
-			let actuallyAtBottom = isAtBottom;
-			if (container) {
-				const { scrollTop, scrollHeight, clientHeight } = container;
-				actuallyAtBottom = scrollHeight - scrollTop - clientHeight < 50;
-			}
-
-			if (!actuallyAtBottom) {
+			// A newly-appended entry (e.g. a tall tool badge) must not pause a user
+			// who is already following the bottom. Re-measuring the container here
+			// would read the PRE-scroll position - the MutationObserver's rAF jump
+			// has not run yet - so any entry taller than the 50px slack looks like a
+			// scroll-up and spuriously pauses follow, and the stream then stops
+			// sticking to the bottom. Trust the tracked follow state instead: while
+			// following, mark the new content read and let the observer pin to the new
+			// bottom; only raise the "new messages" pill when genuinely paused.
+			if (isAtBottomRef.current) {
+				if (activeTabId) tabReadStateRef.current.set(activeTabId, currentCount);
+			} else {
 				const newCount = currentCount - lastLogCountRef.current;
 				setHasNewMessages(true);
 				setNewMessageCount((prev) => prev + newCount);
 				setIsAtBottom(false);
-			} else if (activeTabId) {
-				tabReadStateRef.current.set(activeTabId, currentCount);
 			}
 		}
 		lastLogCountRef.current = currentCount;
-	}, [filteredLogsLength, isAtBottom, activeTabId, scrollContainerRef]);
+	}, [filteredLogsLength, activeTabId]);
 
 	useEffect(() => {
 		const container = scrollContainerRef.current;


### PR DESCRIPTION
## Problem
In claude-code chats the AI transcript stops following the bottom when new messages and tool badges stream in. Follow-up to #1253 (which made claude-code emit tool badges).

## Root cause
`useTerminalOutputScroll`'s count-effect re-measured the scroll container the instant the log **count** grew. That runs before the `MutationObserver`'s rAF scroll, so a newly appended entry taller than the 50px slack (a `running`/`completed` tool badge) reads as "not at bottom" and calls `setIsAtBottom(false)`, pausing auto-follow. On `rc` before #1253 claude-code emitted no such badges, so this latent bug stayed hidden.

## Fix
Trust the tracked follow state (`isAtBottomRef.current`) instead of an instantaneous pre-scroll measurement. While following, mark the new content read and let the observer pin to the new bottom; only raise the "new messages" pill when genuinely scrolled up.

## Tests
Adds `useTerminalOutputScroll.test.ts`: (1) stays following when a tall entry arrives at bottom, (2) raises the pill when scrolled up. Typecheck + touched suites green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal output scrolling behavior when new log entries arrive.
  * Auto-scroll stays enabled for users already at the bottom, even with newly added tall entries.
  * When scrolling up, the “new messages” indicator and unread count now update reliably.
* **Tests**
  * Added a regression test covering mid-stream updates to ensure scrolling follow/paused states behave consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->