### PR TITLE
fix(tools): stop tool-badge flicker by render-gating the per-tab Tools toggle

### DIFF
--- a/src/__tests__/renderer/components/TerminalOutput.test.tsx
+++ b/src/__tests__/renderer/components/TerminalOutput.test.tsx
@@ -134,6 +134,7 @@ const createDefaultSession = (overrides: Partial<Session> = {}): Session => ({
 			agentSessionId: 'claude-123',
 			logs: [],
 			isUnread: false,
+			showTools: true,
 		},
 	],
 	activeTabId: 'tab-1',
@@ -214,7 +215,9 @@ describe('TerminalOutput', () => {
 			];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -228,7 +231,9 @@ describe('TerminalOutput', () => {
 			const logs: LogEntry[] = [createLogEntry({ text: 'User input here', source: 'user' })];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -248,7 +253,9 @@ describe('TerminalOutput', () => {
 			];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -264,7 +271,9 @@ describe('TerminalOutput', () => {
 			];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -278,7 +287,9 @@ describe('TerminalOutput', () => {
 			const logs: LogEntry[] = [createLogEntry({ text: 'Regular message', source: 'user' })];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -296,7 +307,9 @@ describe('TerminalOutput', () => {
 			const logs: LogEntry[] = [createLogEntry({ text: errorText, source: 'error' })];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -324,7 +337,9 @@ describe('TerminalOutput', () => {
 			];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -344,7 +359,9 @@ describe('TerminalOutput', () => {
 			];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -398,7 +415,9 @@ describe('TerminalOutput', () => {
 			];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -663,7 +682,9 @@ describe('TerminalOutput', () => {
 			const logs: LogEntry[] = [createLogEntry({ text: 'Copy this text', source: 'stdout' })];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -1114,7 +1135,9 @@ describe('TerminalOutput', () => {
 			];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -1133,7 +1156,15 @@ describe('TerminalOutput', () => {
 			const newLogs = [...logs, createLogEntry({ text: 'New message', source: 'stdout' })];
 			const newSession = {
 				...session,
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs: newLogs, isUnread: false }],
+				tabs: [
+					{
+						id: 'tab-1',
+						agentSessionId: 'claude-123',
+						logs: newLogs,
+						isUnread: false,
+						showTools: true,
+					},
+				],
 			};
 
 			rerender(<TerminalOutput {...createDefaultProps({ session: newSession })} />);
@@ -1151,7 +1182,9 @@ describe('TerminalOutput', () => {
 			const logs: LogEntry[] = [createLogEntry({ text: 'User message', source: 'user' })];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -1169,7 +1202,9 @@ describe('TerminalOutput', () => {
 			const logs: LogEntry[] = [createLogEntry({ text: 'User message', source: 'user' })];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -1195,7 +1230,9 @@ describe('TerminalOutput', () => {
 			];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -1225,7 +1262,9 @@ describe('TerminalOutput', () => {
 			const logs: LogEntry[] = [createLogEntry({ text: 'User message', source: 'user' })];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -1247,7 +1286,9 @@ describe('TerminalOutput', () => {
 			];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -1279,7 +1320,9 @@ describe('TerminalOutput', () => {
 			const logs: LogEntry[] = [createLogEntry({ text: 'AI response', source: 'stdout' })];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -1298,7 +1341,9 @@ describe('TerminalOutput', () => {
 			const logs: LogEntry[] = [createLogEntry({ text: 'Error output', source: 'stderr' })];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -1322,7 +1367,9 @@ describe('TerminalOutput', () => {
 			];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -1342,7 +1389,9 @@ describe('TerminalOutput', () => {
 			const logs: LogEntry[] = [createLogEntry({ text: 'User message', source: 'user' })];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -1372,7 +1421,9 @@ describe('TerminalOutput', () => {
 			];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -1405,7 +1456,9 @@ describe('TerminalOutput', () => {
 			];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -1424,7 +1477,9 @@ describe('TerminalOutput', () => {
 			const logs: LogEntry[] = [createLogEntry({ text: '# Heading', source: 'stdout' })];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -1450,7 +1505,9 @@ describe('TerminalOutput', () => {
 			];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -1469,7 +1526,9 @@ describe('TerminalOutput', () => {
 			const logs: LogEntry[] = [createLogEntry({ text: '# Heading', source: 'stdout' })];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -1496,7 +1555,9 @@ describe('TerminalOutput', () => {
 			];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -1538,7 +1599,9 @@ describe('TerminalOutput', () => {
 			];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -1559,7 +1622,9 @@ describe('TerminalOutput', () => {
 			];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -1582,7 +1647,9 @@ describe('TerminalOutput', () => {
 			const logs: LogEntry[] = [createLogEntry({ text: '# Heading', source: 'stdout' })];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -1602,7 +1669,9 @@ describe('TerminalOutput', () => {
 			const logs: LogEntry[] = [createLogEntry({ text: '# Heading', source: 'stdout' })];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -1623,7 +1692,9 @@ describe('TerminalOutput', () => {
 			const logs: LogEntry[] = [createLogEntry({ text: codeBlockText, source: 'stdout' })];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -1645,7 +1716,9 @@ describe('TerminalOutput', () => {
 			];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -1666,7 +1739,9 @@ describe('TerminalOutput', () => {
 			];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -1689,7 +1764,9 @@ describe('TerminalOutput', () => {
 			];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -1710,7 +1787,9 @@ describe('TerminalOutput', () => {
 			const logs: LogEntry[] = [createLogEntry({ text: '# Heading', source: 'stdout' })];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -1731,7 +1810,9 @@ describe('TerminalOutput', () => {
 			const logs: LogEntry[] = [createLogEntry({ text: '# Heading', source: 'stdout' })];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -1752,7 +1833,9 @@ describe('TerminalOutput', () => {
 			const logs: LogEntry[] = [createLogEntry({ text: '# Heading', source: 'stdout' })];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -1775,7 +1858,9 @@ describe('TerminalOutput', () => {
 			];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -1796,7 +1881,9 @@ describe('TerminalOutput', () => {
 			];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -1819,7 +1906,9 @@ describe('TerminalOutput', () => {
 			];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -1840,7 +1929,9 @@ describe('TerminalOutput', () => {
 			];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -1862,7 +1953,9 @@ describe('TerminalOutput', () => {
 			];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -1902,7 +1995,9 @@ describe('TerminalOutput', () => {
 			];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -1938,7 +2033,9 @@ describe('TerminalOutput', () => {
 			];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -1964,7 +2061,9 @@ describe('TerminalOutput', () => {
 			];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -1973,6 +2072,30 @@ describe('TerminalOutput', () => {
 
 			expect(screen.getByText('Bash')).toBeInTheDocument();
 			expect(screen.getByText('npm run test')).toBeInTheDocument();
+		});
+
+		it('hides tool logs at render when the tab has showTools:false', () => {
+			const logs: LogEntry[] = [
+				createLogEntry({
+					text: 'Bash',
+					source: 'tool',
+					metadata: { toolState: { status: 'running', input: { command: 'npm run test' } } },
+				}),
+			];
+
+			const session = createDefaultSession({
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: false },
+				],
+				activeTabId: 'tab-1',
+			});
+
+			render(<TerminalOutput {...createDefaultProps({ session })} />);
+
+			// Tool events stay recorded in state; the tab hid them, so the badge must
+			// not render. Visibility is a pure render concern (no log mutation).
+			expect(screen.queryByText('Bash')).not.toBeInTheDocument();
+			expect(screen.queryByText('npm run test')).not.toBeInTheDocument();
 		});
 
 		it('collapses subagent tool calls behind a count under the Task badge', () => {
@@ -2004,7 +2127,9 @@ describe('TerminalOutput', () => {
 			];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -2039,7 +2164,9 @@ describe('TerminalOutput', () => {
 			];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -2061,7 +2188,9 @@ describe('TerminalOutput', () => {
 			];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -2091,7 +2220,9 @@ describe('TerminalOutput', () => {
 			];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -2121,7 +2252,9 @@ describe('TerminalOutput', () => {
 			];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -2155,7 +2288,9 @@ describe('TerminalOutput', () => {
 				];
 
 				const session = createDefaultSession({
-					tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+					tabs: [
+						{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+					],
 					activeTabId: 'tab-1',
 				});
 
@@ -2185,7 +2320,9 @@ describe('TerminalOutput', () => {
 				];
 
 				const session = createDefaultSession({
-					tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+					tabs: [
+						{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+					],
 					activeTabId: 'tab-1',
 				});
 
@@ -2211,7 +2348,9 @@ describe('TerminalOutput', () => {
 			];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -2237,7 +2376,9 @@ describe('TerminalOutput', () => {
 			];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -2264,7 +2405,9 @@ describe('TerminalOutput', () => {
 			];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -2286,7 +2429,9 @@ describe('TerminalOutput', () => {
 			];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -2309,7 +2454,9 @@ describe('TerminalOutput', () => {
 			];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -2339,7 +2486,9 @@ describe('TerminalOutput', () => {
 			];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -2364,7 +2513,9 @@ describe('TerminalOutput', () => {
 			];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -2389,7 +2540,9 @@ describe('TerminalOutput', () => {
 			];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -2409,7 +2562,15 @@ describe('TerminalOutput', () => {
 			];
 			const newSession = {
 				...session,
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs: newLogs, isUnread: false }],
+				tabs: [
+					{
+						id: 'tab-1',
+						agentSessionId: 'claude-123',
+						logs: newLogs,
+						isUnread: false,
+						showTools: true,
+					},
+				],
 			};
 
 			rerender(<TerminalOutput {...createDefaultProps({ session: newSession })} />);
@@ -2430,7 +2591,9 @@ describe('TerminalOutput', () => {
 			];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -2461,7 +2624,15 @@ describe('TerminalOutput', () => {
 			];
 			const newSession = {
 				...session,
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs: newLogs, isUnread: false }],
+				tabs: [
+					{
+						id: 'tab-1',
+						agentSessionId: 'claude-123',
+						logs: newLogs,
+						isUnread: false,
+						showTools: true,
+					},
+				],
 			};
 
 			rerender(<TerminalOutput {...createDefaultProps({ session: newSession })} />);
@@ -2478,7 +2649,9 @@ describe('TerminalOutput', () => {
 			const logs: LogEntry[] = [createLogEntry({ id: 'user-1', text: 'Hello', source: 'user' })];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -2498,7 +2671,15 @@ describe('TerminalOutput', () => {
 			];
 			const newSession = {
 				...session,
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs: newLogs, isUnread: false }],
+				tabs: [
+					{
+						id: 'tab-1',
+						agentSessionId: 'claude-123',
+						logs: newLogs,
+						isUnread: false,
+						showTools: true,
+					},
+				],
 			};
 
 			rerender(<TerminalOutput {...createDefaultProps({ session: newSession })} />);
@@ -2557,7 +2738,9 @@ describe('TerminalOutput', () => {
 				createLogEntry({ id: 'resp-1', text: 'Response', source: 'stdout' }),
 			];
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -2609,7 +2792,15 @@ describe('TerminalOutput', () => {
 			];
 			const newSession = {
 				...session,
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs: newLogs, isUnread: false }],
+				tabs: [
+					{
+						id: 'tab-1',
+						agentSessionId: 'claude-123',
+						logs: newLogs,
+						isUnread: false,
+						showTools: true,
+					},
+				],
 			};
 			rerender(<TerminalOutput {...createDefaultProps({ session: newSession })} />);
 			await act(async () => {
@@ -2632,7 +2823,9 @@ describe('TerminalOutput', () => {
 				createLogEntry({ id: 'resp-1', text: 'Response', source: 'stdout' }),
 			];
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -2742,7 +2935,9 @@ describe('TerminalOutput', () => {
 			];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -2759,7 +2954,9 @@ describe('TerminalOutput', () => {
 			];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -2790,7 +2987,9 @@ describe('TerminalOutput', () => {
 			];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -2822,7 +3021,9 @@ describe('TerminalOutput', () => {
 			];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -2852,7 +3053,9 @@ describe('TerminalOutput', () => {
 
 			const session = createDefaultSession({
 				enableMaestroP: true,
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -2887,7 +3090,9 @@ describe('TerminalOutput', () => {
 			const session = createDefaultSession({
 				enableMaestroP: true,
 				maestroPMode: 'interactive',
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -2910,7 +3115,9 @@ describe('TerminalOutput', () => {
 			];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -2959,7 +3166,9 @@ describe('helper function behaviors (tested via component)', () => {
 			const logs: LogEntry[] = [createLogEntry({ text: markdownText, source: 'stdout' })];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -2980,7 +3189,9 @@ describe('helper function behaviors (tested via component)', () => {
 			const logs: LogEntry[] = [createLogEntry({ text: markdownText, source: 'stdout' })];
 
 			const session = createDefaultSession({
-				tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true },
+				],
 				activeTabId: 'tab-1',
 			});
 
@@ -3011,7 +3222,7 @@ describe('memoization behavior', () => {
 		const logs: LogEntry[] = [createLogEntry({ id: 'log-1', text: 'Test', source: 'stdout' })];
 
 		const session = createDefaultSession({
-			tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+			tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true }],
 			activeTabId: 'tab-1',
 		});
 
@@ -3033,7 +3244,7 @@ describe('memoization behavior', () => {
 		];
 
 		const session = createDefaultSession({
-			tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false }],
+			tabs: [{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: true }],
 			activeTabId: 'tab-1',
 		});
 

--- a/src/__tests__/renderer/components/TerminalOutput.test.tsx
+++ b/src/__tests__/renderer/components/TerminalOutput.test.tsx
@@ -2098,6 +2098,35 @@ describe('TerminalOutput', () => {
 			expect(screen.queryByText('npm run test')).not.toBeInTheDocument();
 		});
 
+		it('keeps response segments separate when a hidden tool call sat between them', () => {
+			// collapseAiResponseLogs treats a tool entry as a boundary. If tools were
+			// filtered BEFORE collapse, the two replies would merge into one bubble
+			// ("First replySecond reply"). Collapsing first preserves the boundary.
+			const logs: LogEntry[] = [
+				createLogEntry({ text: 'First reply', source: 'stdout' }),
+				createLogEntry({
+					text: 'Bash',
+					source: 'tool',
+					metadata: { toolState: { status: 'completed' } },
+				}),
+				createLogEntry({ text: 'Second reply', source: 'stdout' }),
+			];
+
+			const session = createDefaultSession({
+				tabs: [
+					{ id: 'tab-1', agentSessionId: 'claude-123', logs, isUnread: false, showTools: false },
+				],
+				activeTabId: 'tab-1',
+			});
+
+			render(<TerminalOutput {...createDefaultProps({ session })} />);
+
+			// The tool badge is hidden, but the two replies stay separate.
+			expect(screen.getByText('First reply')).toBeInTheDocument();
+			expect(screen.getByText('Second reply')).toBeInTheDocument();
+			expect(screen.queryByText('Bash')).not.toBeInTheDocument();
+		});
+
 		it('collapses subagent tool calls behind a count under the Task badge', () => {
 			const logs: LogEntry[] = [
 				createLogEntry({

--- a/src/__tests__/renderer/hooks/agent/internal/useAgentToolExecutionListener.test.tsx
+++ b/src/__tests__/renderer/hooks/agent/internal/useAgentToolExecutionListener.test.tsx
@@ -73,7 +73,7 @@ describe('useAgentToolExecutionListener', () => {
 		expect(tabAfter.logs[0].metadata?.toolState?.output).toBe('ok');
 	});
 
-	it('skips when tab.showThinking is off', () => {
+	it('records tool events even when showThinking is off (hidden at render)', () => {
 		const tab = createMockAITab({ id: 'tab-1', showThinking: 'off' });
 		const session = createMockSession({ id: 'sess-1', aiTabs: [tab] });
 		useSessionStore.setState({ sessions: [session] } as any);
@@ -86,7 +86,7 @@ describe('useAgentToolExecutionListener', () => {
 			toolCallId: 'c1',
 		});
 
-		expect(useSessionStore.getState().sessions[0].aiTabs[0].logs).toHaveLength(0);
+		expect(useSessionStore.getState().sessions[0].aiTabs[0].logs).toHaveLength(1);
 	});
 
 	it('records tool logs when showTools is true even if showThinking is off', () => {
@@ -105,7 +105,7 @@ describe('useAgentToolExecutionListener', () => {
 		expect(useSessionStore.getState().sessions[0].aiTabs[0].logs).toHaveLength(1);
 	});
 
-	it('skips when showTools is false even if showThinking is on', () => {
+	it('records tool events even when showTools is false (hidden at render, never dropped)', () => {
 		const tab = createMockAITab({ id: 'tab-1', showThinking: 'on', showTools: false });
 		const session = createMockSession({ id: 'sess-1', aiTabs: [tab] });
 		useSessionStore.setState({ sessions: [session] } as any);
@@ -118,11 +118,11 @@ describe('useAgentToolExecutionListener', () => {
 			toolCallId: 'c1',
 		});
 
-		expect(useSessionStore.getState().sessions[0].aiTabs[0].logs).toHaveLength(0);
+		expect(useSessionStore.getState().sessions[0].aiTabs[0].logs).toHaveLength(1);
 	});
 
-	it('falls back to showThinking when showTools is absent', () => {
-		const tab = createMockAITab({ id: 'tab-1', showThinking: 'on' });
+	it('records tool events when neither showTools nor showThinking is set', () => {
+		const tab = createMockAITab({ id: 'tab-1' });
 		const session = createMockSession({ id: 'sess-1', aiTabs: [tab] });
 		useSessionStore.setState({ sessions: [session] } as any);
 

--- a/src/__tests__/renderer/hooks/useAgentListeners.test.ts
+++ b/src/__tests__/renderer/hooks/useAgentListeners.test.ts
@@ -1418,7 +1418,7 @@ describe('useAgentListeners', () => {
 	// ========================================================================
 
 	describe('onToolExecution', () => {
-		it('does not emit tool logs when thinking is hidden', () => {
+		it('records tool logs regardless of thinking visibility (hidden at render, not here)', () => {
 			const deps = createMockDeps();
 			const session = createMockSession({
 				id: 'sess-1',
@@ -1439,7 +1439,11 @@ describe('useAgentListeners', () => {
 			});
 
 			const updated = useSessionStore.getState().sessions.find((s) => s.id === 'sess-1');
-			expect(updated?.aiTabs[0]?.logs).toEqual([]);
+			// Tool events are always recorded now; visibility is a render concern
+			// (TerminalOutput hides source:'tool' when tools are off), so the log is
+			// present here even with thinking off.
+			expect(updated?.aiTabs[0]?.logs).toHaveLength(1);
+			expect(updated?.aiTabs[0]?.logs[0]?.source).toBe('tool');
 		});
 
 		// Copilot-CLI emits paired `tool.execution_start` and `tool.execution_complete`

--- a/src/__tests__/renderer/hooks/useQuickActionsHandlers.test.ts
+++ b/src/__tests__/renderer/hooks/useQuickActionsHandlers.test.ts
@@ -387,7 +387,7 @@ describe('useQuickActionsHandlers', () => {
 			expect(updatedTab.showThinking).toBe('on');
 		});
 
-		it('clears thinking and tool logs when cycling to off', () => {
+		it('clears thinking logs but keeps tool logs (render-gated) when cycling to off', () => {
 			const tab = createTab({
 				id: 'tab-1',
 				showThinking: 'sticky',
@@ -415,8 +415,10 @@ describe('useQuickActionsHandlers', () => {
 
 			const updatedTab = useSessionStore.getState().sessions[0].aiTabs[0];
 			const sources = updatedTab.logs.map((l: any) => l.source);
+			// Thinking logs are storage-gated; tool logs are always recorded and hidden
+			// only at render, so they must survive a thinking-off toggle.
 			expect(sources).not.toContain('thinking');
-			expect(sources).not.toContain('tool');
+			expect(sources).toContain('tool');
 			expect(sources).toContain('user');
 			expect(sources).toContain('ai');
 		});

--- a/src/__tests__/renderer/hooks/useTabHandlers.test.ts
+++ b/src/__tests__/renderer/hooks/useTabHandlers.test.ts
@@ -1907,7 +1907,7 @@ describe('useTabHandlers', () => {
 	// ========================================================================
 
 	describe('handleToggleTabShowThinking log clearing', () => {
-		it('clears thinking and tool logs when cycling to off', () => {
+		it('clears thinking logs but keeps tool logs when cycling to off', () => {
 			const tab = createMockAITab({
 				id: 'tab-1',
 				showThinking: 'sticky',
@@ -1927,10 +1927,11 @@ describe('useTabHandlers', () => {
 
 			const session = getSession();
 			expect(session.aiTabs[0].showThinking).toBe('off');
-			// thinking and tool logs should be filtered out
+			// Thinking logs are removed; tool logs are always recorded and render-gated,
+			// so they survive a thinking-off toggle.
 			const logSources = session.aiTabs[0].logs.map((l) => l.source);
 			expect(logSources).not.toContain('thinking');
-			expect(logSources).not.toContain('tool');
+			expect(logSources).toContain('tool');
 			expect(logSources).toContain('user');
 			expect(logSources).toContain('ai');
 		});

--- a/src/renderer/components/TerminalOutput/TerminalOutput.tsx
+++ b/src/renderer/components/TerminalOutput/TerminalOutput.tsx
@@ -126,18 +126,20 @@ export const TerminalOutput = memo(
 
 		const activeTab = useMemo(() => getActiveTab(session), [session.aiTabs, session.activeTabId]);
 		const activeLogs = useMemo((): LogEntry[] => activeTab?.logs ?? [], [activeTab?.logs]);
-		// Tool visibility is a pure render concern: tool events are always recorded
-		// (useAgentToolExecutionListener), so hide them here when the tab's effective
-		// tools setting is off. Keeps toggling from mutating log storage (the flicker
-		// bug) and preserves running->completed correlation.
+		// Collapse FIRST so tool logs still act as response boundaries
+		// (collapseAiResponseLogs treats source:'tool' as a boundary between
+		// assistant segments); only THEN hide them. Tool visibility is a pure render
+		// concern: tool events are always recorded (useAgentToolExecutionListener),
+		// so hiding here keeps toggling from mutating log storage (the flicker bug)
+		// and preserves running->completed correlation.
+		const collapsedAll = useMemo(() => collapseAiResponseLogs(activeLogs), [activeLogs]);
 		const toolsVisible = activeTab
 			? toolLogsRecorded(activeTab.showTools, activeTab.showThinking)
 			: true;
-		const visibleLogs = useMemo(
-			() => (toolsVisible ? activeLogs : activeLogs.filter((l) => l.source !== 'tool')),
-			[activeLogs, toolsVisible]
+		const collapsedLogs = useMemo(
+			() => (toolsVisible ? collapsedAll : collapsedAll.filter((l) => l.source !== 'tool')),
+			[collapsedAll, toolsVisible]
 		);
-		const collapsedLogs = useMemo(() => collapseAiResponseLogs(visibleLogs), [visibleLogs]);
 		// Nest subagent tool badges (claude-code Task) under the tool entry that
 		// spawned them; orphans and non-claude agents pass through untouched.
 		const { logs: filteredLogs, childrenByParentId } = useMemo(

--- a/src/renderer/components/TerminalOutput/TerminalOutput.tsx
+++ b/src/renderer/components/TerminalOutput/TerminalOutput.tsx
@@ -14,6 +14,7 @@ import { useSettingsStore } from '../../stores/settingsStore';
 import { useMessageGistStore } from '../../stores/messageGistStore';
 import { getClaudeTokenMode } from '../../../shared/claudeTokenMode';
 import { collapseAiResponseLogs } from './utils/collapseAiResponseLogs';
+import { toolLogsRecorded } from '../../hooks/agent/internal/helpers/thinkingLogs';
 import { groupSubagentToolLogs } from './utils/groupSubagentToolLogs';
 import { LogItem } from './components/LogItem';
 import { OutputSearchBar } from './components/OutputSearchBar';
@@ -125,7 +126,18 @@ export const TerminalOutput = memo(
 
 		const activeTab = useMemo(() => getActiveTab(session), [session.aiTabs, session.activeTabId]);
 		const activeLogs = useMemo((): LogEntry[] => activeTab?.logs ?? [], [activeTab?.logs]);
-		const collapsedLogs = useMemo(() => collapseAiResponseLogs(activeLogs), [activeLogs]);
+		// Tool visibility is a pure render concern: tool events are always recorded
+		// (useAgentToolExecutionListener), so hide them here when the tab's effective
+		// tools setting is off. Keeps toggling from mutating log storage (the flicker
+		// bug) and preserves running->completed correlation.
+		const toolsVisible = activeTab
+			? toolLogsRecorded(activeTab.showTools, activeTab.showThinking)
+			: true;
+		const visibleLogs = useMemo(
+			() => (toolsVisible ? activeLogs : activeLogs.filter((l) => l.source !== 'tool')),
+			[activeLogs, toolsVisible]
+		);
+		const collapsedLogs = useMemo(() => collapseAiResponseLogs(visibleLogs), [visibleLogs]);
 		// Nest subagent tool badges (claude-code Task) under the tool entry that
 		// spawned them; orphans and non-claude agents pass through untouched.
 		const { logs: filteredLogs, childrenByParentId } = useMemo(

--- a/src/renderer/hooks/agent/internal/useAgentToolExecutionListener.ts
+++ b/src/renderer/hooks/agent/internal/useAgentToolExecutionListener.ts
@@ -18,7 +18,6 @@
 import { useEffect } from 'react';
 import { useSessionStore } from '../../../stores/sessionStore';
 import { REGEX_AI_TAB } from '../../../utils/sessionIdParser';
-import { toolLogsRecorded } from './helpers/thinkingLogs';
 import { useOwnedSessionGate } from './useOwnedSessionGate';
 import type { LogEntry } from '../../../types';
 
@@ -59,7 +58,12 @@ export function useAgentToolExecutionListener(): void {
 
 						const targetTab = s.aiTabs.find((t) => t.id === tabId);
 						if (!targetTab) return s;
-						if (!toolLogsRecorded(targetTab.showTools, targetTab.showThinking)) return s;
+						// Always record tool events regardless of the tab's `showTools`
+						// setting. Visibility is a pure render concern (TerminalOutput
+						// hides `source:'tool'` entries when tools are off), so recording
+						// unconditionally keeps running->completed correlation intact
+						// across a mid-run toggle and avoids the transcript churn that
+						// dropping events / deleting logs caused (the flicker bug).
 
 						const newState = toolEvent.state as
 							| NonNullable<LogEntry['metadata']>['toolState']

--- a/src/renderer/hooks/keyboard/useMainKeyboardHandler.ts
+++ b/src/renderer/hooks/keyboard/useMainKeyboardHandler.ts
@@ -1172,9 +1172,7 @@ export function useMainKeyboardHandler(): UseMainKeyboardHandlerReturn {
 											return {
 												...tab,
 												showThinking: 'off',
-												logs: tab.logs.filter(
-													(l) => l.source !== 'thinking' && l.source !== 'tool'
-												),
+												logs: tab.logs.filter((l) => l.source !== 'thinking'),
 											};
 										}
 										return { ...tab, showThinking: newMode };

--- a/src/renderer/hooks/modal/useQuickActionsHandlers.ts
+++ b/src/renderer/hooks/modal/useQuickActionsHandlers.ts
@@ -196,12 +196,12 @@ export function useQuickActionsHandlers(
 						aiTabs: s.aiTabs.map((tab) => {
 							if (tab.id !== s.activeTabId) return tab;
 							const newMode = cycleThinkingMode(tab.showThinking);
-							// When turning OFF, clear any thinking/tool logs
+							// When turning OFF, clear thinking logs; tool logs are render-gated.
 							if (newMode === 'off') {
 								return {
 									...tab,
 									showThinking: 'off',
-									logs: tab.logs.filter((l) => l.source !== 'thinking' && l.source !== 'tool'),
+									logs: tab.logs.filter((l) => l.source !== 'thinking'),
 								};
 							}
 							return { ...tab, showThinking: newMode };

--- a/src/renderer/hooks/tabs/internal/useAITabHandlers.ts
+++ b/src/renderer/hooks/tabs/internal/useAITabHandlers.ts
@@ -350,16 +350,13 @@ export function useAITabHandlers(): AITabHandlersReturn {
 		updateAiTab(session.id, currentActiveTab.id, (tab) => {
 			const newMode = cycleThinkingMode(tab.showThinking);
 			if (newMode === 'off') {
-				// Tool visibility is controlled independently via `showTools`; only
-				// strip tool logs here when the tab does not explicitly want them
-				// shown. Thinking logs always go when thinking is turned off.
-				const keepTools = tab.showTools === true;
+				// Only thinking logs are storage-gated. Tool logs are always recorded
+				// and hidden purely at render (see `showTools` + TerminalOutput), so
+				// turning thinking off must never drop them.
 				return {
 					...tab,
 					showThinking: 'off',
-					logs: tab.logs.filter(
-						(l) => l.source !== 'thinking' && (keepTools || l.source !== 'tool')
-					),
+					logs: tab.logs.filter((l) => l.source !== 'thinking'),
 				};
 			}
 			return { ...tab, showThinking: newMode };
@@ -375,18 +372,12 @@ export function useAITabHandlers(): AITabHandlersReturn {
 		updateAiTab(session.id, currentActiveTab.id, (tab) => {
 			// Flip the effective value: when showTools is absent it inherits the
 			// tab's thinking on/off state, so the first click toggles that.
+			// Visibility is a pure render concern (TerminalOutput filters
+			// `source:'tool'`); tool events are always recorded, so this only flips
+			// the flag and never mutates logs - a mid-run toggle no longer churns the
+			// transcript (the flicker bug) and running->completed correlation survives.
 			const effective = toolLogsRecorded(tab.showTools, tab.showThinking);
-			const next = !effective;
-			if (!next) {
-				// Turning tools off drops the recorded tool logs, mirroring how
-				// turning thinking off clears thinking/tool logs.
-				return {
-					...tab,
-					showTools: false,
-					logs: tab.logs.filter((l) => l.source !== 'tool'),
-				};
-			}
-			return { ...tab, showTools: true };
+			return { ...tab, showTools: !effective };
 		});
 	}, []);
 


### PR DESCRIPTION
## Problem
Follow-up to #1253. Disabling and re-enabling the per-tab **Tools** toggle during an active run makes the chat flicker on tool calls.

## Root cause
The toggle physically **deleted** `source:'tool'` logs on disable (`useAITabHandlers`), and `useAgentToolExecutionListener` **dropped** tool events while off. So an off/on cycle mid-run churned the transcript (badges deleted, then re-appended out of order as events streamed) and broke `running`->`completed` correlation.

## Fix
Move to **always record, hide at render**:
- `useAgentToolExecutionListener` always records tool events (correlation survives a mid-run toggle).
- `TerminalOutput` filters `source:'tool'` at render time via the tab's effective setting (`toolLogsRecorded(showTools, showThinking)`).
- The Tools toggle and the three thinking-cycle surfaces (toolbar, quick-actions, keyboard) flip flags without mutating logs.
- Exit/interrupt/batched lifecycle cleanup is intentionally unchanged.

Also resolves the greptile/CodeRabbit P1s on #1253 (lost tool events when off; thinking-toggle wiping tool logs).

## Tests
Updated `useAgentToolExecutionListener.test.tsx` to the always-record contract; added a `showTools:false` render test in `TerminalOutput.test.tsx` (tools hidden, not dropped). Typecheck + touched suites green (156 tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Tool execution events are now consistently recorded even when tool and/or thinking visibility is hidden.
  - Collapsed terminal output now omits tool-origin entries when the active tab’s tool visibility is off.
  - Toggling thinking to **off** clears only thinking logs (tool logs are retained).
  - Toggling tools updates display visibility without removing previously recorded tool events.
- **Tests**
  - Updated/expanded coverage for showTools/showThinking rendering, hidden tool boundaries, and log-recording expectations across terminal output and agent/tool listeners.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->