### PR TITLE
feat(plugins): add a hide/collapse control for docked plugin panels

### DIFF
--- a/src/renderer/components/plugins/PluginPanelSlot.tsx
+++ b/src/renderer/components/plugins/PluginPanelSlot.tsx
@@ -12,14 +12,21 @@
  * Renders nothing when the `plugins` Encore flag is off (then
  * `usePluginContributions` returns empty buckets) or when no panel targets this
  * slot, so the slot stays invisible until a plugin docks here.
+ *
+ * Each docked panel carries a host-drawn header with a hide control; hidden
+ * panels collapse to a slim reopen rail. The set of collapsed panel ids lives
+ * in `uiStore.hiddenPluginPanels` (persisted). The frame's non-suppressible
+ * provenance line stays in `PluginPanelFrame` and is never touched here.
  */
 
 import { useMemo } from 'react';
+import { PanelRightClose, PanelRightOpen } from 'lucide-react';
 import type { Theme } from '../../types';
 import type { PanelContribution, PanelPlacement } from '../../../shared/plugins/contributions';
 import { usePluginContributions } from '../../hooks/usePluginContributions';
 import { mergePluginContributions } from '../../utils/pluginContributionMerge';
 import { MODAL_PRIORITIES } from '../../constants/modalPriorities';
+import { useUIStore } from '../../stores/uiStore';
 import { PluginPanelFrame } from './PluginPanelFrame';
 
 /** Every placement except `modal` docks inline through this slot. */
@@ -34,6 +41,8 @@ interface PluginPanelSlotProps {
 
 export function PluginPanelSlot({ theme, placement, className }: PluginPanelSlotProps) {
 	const contributions = usePluginContributions();
+	const hiddenPluginPanels = useUIStore((s) => s.hiddenPluginPanels);
+	const toggleHiddenPluginPanel = useUIStore((s) => s.toggleHiddenPluginPanel);
 
 	const panels = useMemo(() => {
 		const matching = contributions.panels.filter((p) => p.placement === placement);
@@ -46,21 +55,101 @@ export function PluginPanelSlot({ theme, placement, className }: PluginPanelSlot
 
 	if (panels.length === 0) return null;
 
+	const visible = panels.filter(({ item }) => !hiddenPluginPanels.includes(item.id));
+	const hidden = panels.filter(({ item }) => hiddenPluginPanels.includes(item.id));
+
+	// Clamp strictly below first-party modals/consent dialogs.
+	const slotStyle = {
+		position: 'relative' as const,
+		zIndex: MODAL_PRIORITIES.PLUGIN_PANEL_BASE,
+		borderColor: theme.colors.border,
+		backgroundColor: theme.colors.bgMain,
+	};
+	const borderSide = placement === 'left' ? 'border-r' : placement === 'right' ? 'border-l' : '';
+
+	// Every docked panel hidden: collapse the whole slot to a slim reopen rail so
+	// it stops consuming horizontal space but stays one click from returning.
+	if (visible.length === 0) {
+		return (
+			<div
+				className={`flex flex-col shrink-0 overflow-hidden w-9 ${borderSide}`}
+				style={slotStyle}
+				data-plugin-panel-slot={placement}
+				data-plugin-panel-collapsed="true"
+			>
+				{hidden.map(({ item }) => (
+					<button
+						key={item.id}
+						type="button"
+						onClick={() => toggleHiddenPluginPanel(item.id)}
+						className="flex flex-col items-center gap-1.5 py-2 w-full transition-colors hover:bg-white/5"
+						style={{ color: theme.colors.textDim }}
+						title={`Show ${item.title} (from ${item.pluginId})`}
+						aria-label={`Show ${item.title} panel`}
+					>
+						<PanelRightOpen className="w-4 h-4 shrink-0" />
+						<span
+							className="text-[10px] whitespace-nowrap rotate-180"
+							style={{ writingMode: 'vertical-rl' }}
+						>
+							{item.title}
+						</span>
+					</button>
+				))}
+			</div>
+		);
+	}
+
 	return (
 		<div
 			className={className ?? 'flex flex-col shrink-0 overflow-hidden border-l w-[320px]'}
-			style={{
-				// Clamp strictly below first-party modals/consent dialogs.
-				position: 'relative',
-				zIndex: MODAL_PRIORITIES.PLUGIN_PANEL_BASE,
-				borderColor: theme.colors.border,
-				backgroundColor: theme.colors.bgMain,
-			}}
+			style={slotStyle}
 			data-plugin-panel-slot={placement}
 		>
-			{panels.map(({ item }) => (
+			{/* Reopen chips for panels hidden while others remain docked. */}
+			{hidden.map(({ item }) => (
+				<button
+					key={item.id}
+					type="button"
+					onClick={() => toggleHiddenPluginPanel(item.id)}
+					className="flex items-center gap-1.5 px-2.5 py-1 text-[11px] shrink-0 border-b transition-colors hover:bg-white/5"
+					style={{ color: theme.colors.textDim, borderColor: theme.colors.border }}
+					title={`Show ${item.title} (from ${item.pluginId})`}
+				>
+					<PanelRightOpen className="w-3 h-3 shrink-0" />
+					<span className="truncate">Show {item.title}</span>
+				</button>
+			))}
+			{visible.map(({ item }) => (
 				<div key={item.id} className="flex flex-col flex-1 min-h-0">
-					<PluginPanelFrame theme={theme} panel={item} />
+					{/* Host-drawn header + hide control, kept in the slot (not
+					    PluginPanelFrame) so the modal host and the frame's
+					    non-suppressible provenance line stay unchanged. */}
+					<div
+						className="flex items-center justify-between gap-1.5 px-2.5 py-1 shrink-0 select-none border-b"
+						style={{ borderColor: theme.colors.border }}
+					>
+						<span
+							className="truncate text-[11px]"
+							style={{ color: theme.colors.textMain }}
+							title={item.title}
+						>
+							{item.title}
+						</span>
+						<button
+							type="button"
+							onClick={() => toggleHiddenPluginPanel(item.id)}
+							className="shrink-0 p-0.5 rounded transition-colors hover:bg-white/10"
+							style={{ color: theme.colors.textDim }}
+							title={`Hide ${item.title}`}
+							aria-label={`Hide ${item.title} panel`}
+						>
+							<PanelRightClose className="w-3.5 h-3.5" />
+						</button>
+					</div>
+					<div className="flex-1 min-h-0">
+						<PluginPanelFrame theme={theme} panel={item} />
+					</div>
 				</div>
 			))}
 		</div>

--- a/src/renderer/components/plugins/__tests__/PluginPanelSlot.test.tsx
+++ b/src/renderer/components/plugins/__tests__/PluginPanelSlot.test.tsx
@@ -1,12 +1,13 @@
 import '@testing-library/jest-dom';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import { render, screen, waitFor, cleanup, fireEvent } from '@testing-library/react';
 import { PluginPanelSlot } from '../PluginPanelSlot';
 import { THEMES } from '../../../constants/themes';
 import type {
 	AggregatedContributions,
 	PanelContribution,
 } from '../../../../shared/plugins/contributions';
+import { useUIStore } from '../../../stores/uiStore';
 
 const theme = THEMES.dracula;
 
@@ -55,6 +56,9 @@ beforeEach(() => {
 	window.maestro.plugins = pluginBridge as unknown as typeof window.maestro.plugins;
 	pluginBridge.contributions.mockReset().mockResolvedValue(EMPTY);
 	pluginBridge.onChanged.mockClear();
+	// The collapsed-panel set is a module-level store singleton; reset it so one
+	// test's hide choice never leaks into the next.
+	useUIStore.setState({ hiddenPluginPanels: [] });
 });
 
 afterEach(() => cleanup());
@@ -122,5 +126,45 @@ describe('PluginPanelSlot', () => {
 		await waitFor(() => expect(screen.getByText('from first')).toBeInTheDocument());
 		expect(container.querySelectorAll('webview')).toHaveLength(1);
 		expect(screen.queryByText('from second')).not.toBeInTheDocument();
+	});
+
+	it('hides a docked panel to a reopen rail and restores it', async () => {
+		pluginBridge.contributions.mockResolvedValue({ ...EMPTY, panels: [panel()] });
+
+		const { container } = render(<PluginPanelSlot theme={theme} placement="left" />);
+		await waitFor(() => expect(container.querySelector('webview')).not.toBeNull());
+
+		// Hide: the frame unmounts and the slot collapses to the reopen rail.
+		fireEvent.click(screen.getByLabelText('Hide Acme Board panel'));
+		await waitFor(() =>
+			expect(container.querySelector('[data-plugin-panel-collapsed="true"]')).not.toBeNull()
+		);
+		expect(container.querySelector('webview')).toBeNull();
+		expect(useUIStore.getState().hiddenPluginPanels).toContain('acme.tools/board');
+
+		// Restore: the rail's show control remounts the frame.
+		fireEvent.click(screen.getByLabelText('Show Acme Board panel'));
+		await waitFor(() => expect(container.querySelector('webview')).not.toBeNull());
+		expect(container.querySelector('[data-plugin-panel-collapsed="true"]')).toBeNull();
+		expect(useUIStore.getState().hiddenPluginPanels).not.toContain('acme.tools/board');
+	});
+
+	it('hides one panel via a reopen chip while another stays docked', async () => {
+		pluginBridge.contributions.mockResolvedValue({
+			...EMPTY,
+			panels: [panel(), panel({ id: 'acme.tools/side', localId: 'side', title: 'Acme Side' })],
+		});
+
+		const { container } = render(<PluginPanelSlot theme={theme} placement="left" />);
+		await waitFor(() => expect(container.querySelectorAll('webview')).toHaveLength(2));
+
+		fireEvent.click(screen.getByLabelText('Hide Acme Board panel'));
+
+		// The other panel keeps rendering; the slot stays a full column, not the rail.
+		await waitFor(() => expect(container.querySelectorAll('webview')).toHaveLength(1));
+		expect(container.querySelector('[data-plugin-panel-collapsed="true"]')).toBeNull();
+		// A reopen chip appears for the hidden panel; the docked panel is untouched.
+		expect(screen.getByTitle('Show Acme Board (from acme.tools)')).toBeInTheDocument();
+		expect(screen.getByLabelText('Hide Acme Side panel')).toBeInTheDocument();
 	});
 });

--- a/src/renderer/stores/settingsStore.ts
+++ b/src/renderer/stores/settingsStore.ts
@@ -2641,6 +2641,13 @@ export async function loadAllSettings(): Promise<void> {
 				hiddenQuotaAccounts: allSettings['hiddenQuotaAccounts'] as Record<string, string[]>,
 			});
 
+		// Collapsed docked plugin panels live in uiStore (toggled from the panel
+		// slot header), so its persisted id list hydrates directly there.
+		if (allSettings['hiddenPluginPanels'] !== undefined)
+			useUIStore.setState({
+				hiddenPluginPanels: allSettings['hiddenPluginPanels'] as string[],
+			});
+
 		// Usage Dashboard auto-refresh intervals live in uiStore alongside the
 		// hidden-account map (both are provider-panel state), so the persisted map
 		// hydrates directly there too.

--- a/src/renderer/stores/settingsStore.ts
+++ b/src/renderer/stores/settingsStore.ts
@@ -2642,10 +2642,14 @@ export async function loadAllSettings(): Promise<void> {
 			});
 
 		// Collapsed docked plugin panels live in uiStore (toggled from the panel
-		// slot header), so its persisted id list hydrates directly there.
-		if (allSettings['hiddenPluginPanels'] !== undefined)
+		// slot header), so its persisted id list hydrates directly there. Validate
+		// it is an array of strings first: a malformed stored value (null/object)
+		// would otherwise reach PluginPanelSlot, which calls `.includes()` on it.
+		if (Array.isArray(allSettings['hiddenPluginPanels']))
 			useUIStore.setState({
-				hiddenPluginPanels: allSettings['hiddenPluginPanels'] as string[],
+				hiddenPluginPanels: (allSettings['hiddenPluginPanels'] as unknown[]).filter(
+					(id): id is string => typeof id === 'string'
+				),
 			});
 
 		// Usage Dashboard auto-refresh intervals live in uiStore alongside the

--- a/src/renderer/stores/uiStore.ts
+++ b/src/renderer/stores/uiStore.ts
@@ -130,6 +130,13 @@ export interface UIStoreState {
 	// scheduler (usage-refresh-scheduler.ts) reads the same persisted map and is
 	// the sole driver of background sampling on this cadence.
 	usageRefreshIntervals: Record<string, number>;
+
+	// Namespaced ids (`<pluginId>/<panelId>`) of docked plugin panels the user
+	// collapsed to the reopen rail (PluginPanelSlot). Dock-only affordance; the
+	// frame's non-suppressible provenance line is untouched. Persisted via
+	// settings write-through (mirrors hiddenQuotaAccounts) and hydrated by
+	// loadAllSettings on startup.
+	hiddenPluginPanels: string[];
 }
 
 export interface UIStoreActions {
@@ -221,6 +228,9 @@ export interface UIStoreActions {
 
 	// Set the auto-refresh interval (ms; 0 = off) for a provider quota panel.
 	setUsageRefreshInterval: (providerId: string, ms: number) => void;
+
+	// Toggle a docked plugin panel between shown and collapsed (reopen rail).
+	toggleHiddenPluginPanel: (panelId: string) => void;
 }
 
 export type UIStore = UIStoreState & UIStoreActions;
@@ -283,6 +293,15 @@ function persistUsageRefreshIntervals(value: Record<string, number>): void {
 	window.maestro?.settings?.set('usageRefreshIntervals', value);
 }
 
+/**
+ * Persist the collapsed docked-plugin-panel id list so a user's hide choice
+ * survives app restarts. Hydrated back into this store on startup by
+ * loadAllSettings in settingsStore.
+ */
+function persistHiddenPluginPanels(value: string[]): void {
+	window.maestro?.settings?.set('hiddenPluginPanels', value);
+}
+
 export const useUIStore = create<UIStore>()((set) => ({
 	// --- State ---
 	leftSidebarOpen: true,
@@ -312,6 +331,7 @@ export const useUIStore = create<UIStore>()((set) => ({
 	usageDashboardViewMode: 'overview',
 	hiddenQuotaAccounts: {},
 	usageRefreshIntervals: {},
+	hiddenPluginPanels: [],
 
 	// --- Actions ---
 	setLeftSidebarOpen: (v) => set((s) => ({ leftSidebarOpen: resolve(v, s.leftSidebarOpen) })),
@@ -432,5 +452,14 @@ export const useUIStore = create<UIStore>()((set) => ({
 			const nextMap = { ...s.usageRefreshIntervals, [providerId]: ms };
 			persistUsageRefreshIntervals(nextMap);
 			return { usageRefreshIntervals: nextMap };
+		}),
+
+	toggleHiddenPluginPanel: (panelId) =>
+		set((s) => {
+			const next = s.hiddenPluginPanels.includes(panelId)
+				? s.hiddenPluginPanels.filter((id) => id !== panelId)
+				: [...s.hiddenPluginPanels, panelId];
+			persistHiddenPluginPanels(next);
+			return { hiddenPluginPanels: next };
 		}),
 }));


### PR DESCRIPTION
## Problem
Follow-up to #1254. A plugin panel with `placement:'right'` (e.g. Agent Flow) docks as a full-height column via `PluginPanelSlot` with no chrome, so the only way to stop showing it was disabling the whole plugin.

## Change
- Host-drawn header per docked panel with a hide control.
- Hidden panels collapse to a slim vertical **reopen rail** (one click to restore); when other panels stay docked, the hidden one becomes a "Show <title>" chip.
- Collapsed panel ids persist in `uiStore.hiddenPluginPanels` (settings write-through, mirrors `hiddenQuotaAccounts`) and hydrate on startup.
- The shared `PluginPanelFrame` and its non-suppressible provenance line are untouched, so the trusted-chrome guarantees (`PROTECTED_UI_SURFACES`) are preserved.

## Tests
`PluginPanelSlot.test.tsx`: hide -> collapse-rail -> restore; and hide-one-while-another-stays-docked (reopen chip). Store reset in `beforeEach`. Typecheck + suite green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added hide/show controls for docked plugin panels, including compact reopen chips.
  * If all panels in a slot are hidden, the slot collapses into a slim reopen rail.
  * Hidden panel visibility now persists across restarts.
* **Bug Fixes**
  * Improved multi-panel hide/reopen behavior so only the intended panel collapses/restores.
  * Added validation for persisted hidden-panel settings to avoid malformed data breaking panel visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->