### PR TITLE
feat(plugins): trusted bundled first-party plugins + Agent Flow seeding

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,6 +141,10 @@
 				{
 					"from": "src/prompts/bmad",
 					"to": "prompts/bmad"
+				},
+				{
+					"from": "examples/plugins/agent-flow",
+					"to": "plugins/agent-flow"
 				}
 			]
 		},
@@ -192,6 +196,10 @@
 				{
 					"from": "src/prompts/bmad",
 					"to": "prompts/bmad"
+				},
+				{
+					"from": "examples/plugins/agent-flow",
+					"to": "plugins/agent-flow"
 				}
 			]
 		},
@@ -235,6 +243,10 @@
 				{
 					"from": "src/prompts/bmad",
 					"to": "prompts/bmad"
+				},
+				{
+					"from": "examples/plugins/agent-flow",
+					"to": "plugins/agent-flow"
 				}
 			]
 		},

--- a/src/__tests__/main/plugins/bundled-plugins.test.ts
+++ b/src/__tests__/main/plugins/bundled-plugins.test.ts
@@ -21,6 +21,13 @@ vi.mock('../../../main/plugins/plugin-store-main', () => ({
 	isSafePluginFolderName: (name: string) => /^[a-z][a-z0-9._-]*$/i.test(name),
 }));
 
+// Real fs everywhere, but a controllable cpSync so a copy failure can be forced
+// to exercise the atomic-replace rollback.
+vi.mock('fs', async (importOriginal) => {
+	const actual = await importOriginal<typeof fs>();
+	return { ...actual, cpSync: vi.fn(actual.cpSync) };
+});
+
 import { seedBundledPlugins } from '../../../main/plugins/bundled-plugins';
 
 let tmp = '';
@@ -109,5 +116,32 @@ describe('seedBundledPlugins', () => {
 		h.sigStatus[dest] = 'trusted';
 		seedBundledPlugins({ trustedKeys });
 		expect(fs.existsSync(path.join(dest, 'stale.txt'))).toBe(false);
+	});
+
+	it('skips a bundle whose directory name does not match its declared id', () => {
+		const src = path.join(bundledRoot, 'plugins', 'innocent-name');
+		writePlugin(src, 'evil-plugin', '0.1.0');
+		h.sigStatus[src] = 'trusted';
+		seedBundledPlugins({ trustedKeys });
+		expect(fs.existsSync(path.join(h.target.dir, 'evil-plugin'))).toBe(false);
+		expect(fs.existsSync(path.join(h.target.dir, 'innocent-name'))).toBe(false);
+	});
+
+	it('preserves the existing install when the copy fails (atomic replace)', () => {
+		bundle('agent-flow', '0.2.0', 'trusted'); // newer -> a replace is attempted
+		const dest = path.join(h.target.dir, 'agent-flow');
+		writePlugin(dest, 'agent-flow', '0.1.0');
+		fs.writeFileSync(path.join(dest, 'live.txt'), 'in use');
+		h.sigStatus[dest] = 'trusted';
+		const errors: unknown[] = [];
+		const cpSync = vi.mocked(fs.cpSync);
+		cpSync.mockImplementationOnce(() => {
+			throw new Error('disk full');
+		});
+		seedBundledPlugins({ trustedKeys, onError: (e) => errors.push(e) });
+		// The failed copy staged into a temp sibling first, so the live install
+		// and its file are untouched, and the error surfaced.
+		expect(fs.existsSync(path.join(dest, 'live.txt'))).toBe(true);
+		expect(errors.length).toBeGreaterThan(0);
 	});
 });

--- a/src/__tests__/main/plugins/bundled-plugins.test.ts
+++ b/src/__tests__/main/plugins/bundled-plugins.test.ts
@@ -135,13 +135,18 @@ describe('seedBundledPlugins', () => {
 		h.sigStatus[dest] = 'trusted';
 		const errors: unknown[] = [];
 		const cpSync = vi.mocked(fs.cpSync);
-		cpSync.mockImplementationOnce(() => {
+		cpSync.mockImplementationOnce((_source, destination) => {
+			// Partial copy: write bytes into the staging dir, then fail. A non-atomic
+			// direct copy into dest would corrupt the live install here; the
+			// temp-sibling + rollback must leave the live copy untouched.
+			const staging = String(destination);
+			fs.mkdirSync(staging, { recursive: true });
+			fs.writeFileSync(path.join(staging, 'live.txt'), 'partial');
 			throw new Error('disk full');
 		});
 		seedBundledPlugins({ trustedKeys, onError: (e) => errors.push(e) });
-		// The failed copy staged into a temp sibling first, so the live install
-		// and its file are untouched, and the error surfaced.
-		expect(fs.existsSync(path.join(dest, 'live.txt'))).toBe(true);
-		expect(errors.length).toBeGreaterThan(0);
+		// The live install and its file survive byte-for-byte, and the error surfaced.
+		expect(fs.readFileSync(path.join(dest, 'live.txt'), 'utf8')).toBe('in use');
+		expect(errors).toContainEqual(expect.objectContaining({ message: 'disk full' }));
 	});
 });

--- a/src/__tests__/main/plugins/bundled-plugins.test.ts
+++ b/src/__tests__/main/plugins/bundled-plugins.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// Hoisted so the vi.mock factories can reference them safely. `sigStatus` maps a
+// plugin dir to the verdict verifyPluginSignature should return; `target.dir` is
+// where pluginsDir() points. Together they let the seed logic (trust gate,
+// replace-untrusted, version, symlink skip) run over real fs without real crypto
+// or Electron.
+const h = vi.hoisted(() => ({
+	sigStatus: {} as Record<string, string>,
+	target: { dir: '' },
+}));
+
+vi.mock('../../../main/plugins/plugin-signature', () => ({
+	verifyPluginSignature: (dir: string) => ({ status: h.sigStatus[dir] ?? 'unsigned' }),
+}));
+vi.mock('../../../main/plugins/plugin-store-main', () => ({
+	pluginsDir: () => h.target.dir,
+	isSafePluginFolderName: (name: string) => /^[a-z][a-z0-9._-]*$/i.test(name),
+}));
+
+import { seedBundledPlugins } from '../../../main/plugins/bundled-plugins';
+
+let tmp = '';
+let bundledRoot = '';
+const originalResourcesPath = process.resourcesPath;
+const trustedKeys = () => ['publisher-key'];
+
+function writePlugin(dir: string, id: string, version: string): void {
+	fs.mkdirSync(dir, { recursive: true });
+	fs.writeFileSync(
+		path.join(dir, 'plugin.json'),
+		JSON.stringify({
+			id,
+			name: id,
+			version,
+			tier: 1,
+			entry: 'main.js',
+			maestro: { minHostApi: '1.0.0' },
+		})
+	);
+	fs.writeFileSync(path.join(dir, 'main.js'), '// entry');
+}
+
+function bundle(id: string, version: string, status: string): string {
+	const src = path.join(bundledRoot, 'plugins', id);
+	writePlugin(src, id, version);
+	h.sigStatus[src] = status;
+	return src;
+}
+
+beforeEach(() => {
+	h.sigStatus = {};
+	tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'seed-bundled-'));
+	bundledRoot = path.join(tmp, 'resources');
+	h.target.dir = path.join(tmp, 'userData', 'plugins');
+	fs.mkdirSync(path.join(bundledRoot, 'plugins'), { recursive: true });
+	Object.defineProperty(process, 'resourcesPath', { value: bundledRoot, configurable: true });
+});
+
+afterEach(() => {
+	Object.defineProperty(process, 'resourcesPath', {
+		value: originalResourcesPath,
+		configurable: true,
+	});
+	fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+describe('seedBundledPlugins', () => {
+	it('does not seed an untrusted bundled plugin (empty anchor stays safe)', () => {
+		bundle('agent-flow', '0.1.0', 'untrusted');
+		seedBundledPlugins({ trustedKeys });
+		expect(fs.existsSync(path.join(h.target.dir, 'agent-flow'))).toBe(false);
+	});
+
+	it('seeds a trusted bundled plugin when none is installed', () => {
+		bundle('agent-flow', '0.1.0', 'trusted');
+		seedBundledPlugins({ trustedKeys });
+		expect(fs.existsSync(path.join(h.target.dir, 'agent-flow', 'plugin.json'))).toBe(true);
+	});
+
+	it('replaces a same-version install that is not itself trusted', () => {
+		bundle('agent-flow', '0.1.0', 'trusted');
+		const dest = path.join(h.target.dir, 'agent-flow');
+		writePlugin(dest, 'agent-flow', '0.1.0');
+		fs.writeFileSync(path.join(dest, 'manual.txt'), 'user copy');
+		h.sigStatus[dest] = 'unsigned';
+		seedBundledPlugins({ trustedKeys });
+		expect(fs.existsSync(path.join(dest, 'manual.txt'))).toBe(false);
+	});
+
+	it('leaves an already-trusted install at the same version untouched', () => {
+		bundle('agent-flow', '0.1.0', 'trusted');
+		const dest = path.join(h.target.dir, 'agent-flow');
+		writePlugin(dest, 'agent-flow', '0.1.0');
+		fs.writeFileSync(path.join(dest, 'keep.txt'), 'unchanged');
+		h.sigStatus[dest] = 'trusted';
+		seedBundledPlugins({ trustedKeys });
+		expect(fs.existsSync(path.join(dest, 'keep.txt'))).toBe(true);
+	});
+
+	it('refreshes a trusted install when the bundled version is newer', () => {
+		bundle('agent-flow', '0.2.0', 'trusted');
+		const dest = path.join(h.target.dir, 'agent-flow');
+		writePlugin(dest, 'agent-flow', '0.1.0');
+		fs.writeFileSync(path.join(dest, 'stale.txt'), 'old');
+		h.sigStatus[dest] = 'trusted';
+		seedBundledPlugins({ trustedKeys });
+		expect(fs.existsSync(path.join(dest, 'stale.txt'))).toBe(false);
+	});
+});

--- a/src/__tests__/shared/plugins/publisher-keys.test.ts
+++ b/src/__tests__/shared/plugins/publisher-keys.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { MAESTRO_PUBLISHER_KEYS, resolveTrustedKeys } from '../../../shared/plugins/publisher-keys';
+
+describe('resolveTrustedKeys', () => {
+	it('unions the built-in publisher anchor with user keys, trimmed and de-duplicated', () => {
+		expect(resolveTrustedKeys(['userA', '  userB  ', 'userA', ''])).toEqual([
+			...MAESTRO_PUBLISHER_KEYS,
+			'userA',
+			'userB',
+		]);
+	});
+
+	it('returns just the anchor when there are no user keys', () => {
+		expect(resolveTrustedKeys([])).toEqual([...MAESTRO_PUBLISHER_KEYS]);
+	});
+
+	it('drops blank and whitespace-only user keys', () => {
+		expect(resolveTrustedKeys(['', '   '])).toEqual([...MAESTRO_PUBLISHER_KEYS]);
+	});
+});

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -42,6 +42,8 @@ import type { DecisionPair } from '../shared/pianola/transcript-mining';
 import type { PianolaRule } from '../shared/pianola/types';
 import { spawn, execFile, type ChildProcess } from 'child_process';
 import { PluginManager } from './plugins/plugin-manager';
+import { resolveTrustedKeys } from '../shared/plugins/publisher-keys';
+import { seedBundledPlugins } from './plugins/bundled-plugins';
 import { SpawnBinaryRegistry } from './plugins/spawn-binary-registry';
 import { transcriptReadEgressConflict } from '../shared/plugins/capability-policy';
 import { evaluateScheduledDispatch } from '../shared/plugins/plugin-dispatch-gate';
@@ -1571,7 +1573,12 @@ app
 		pluginAuthStore = authStore;
 		const trustedKeysFor = (): string[] => {
 			const keys = store.get('pluginTrustedKeys', []) as unknown;
-			return Array.isArray(keys) ? keys.filter((k): k is string => typeof k === 'string') : [];
+			const userKeys = Array.isArray(keys)
+				? keys.filter((k): k is string => typeof k === 'string')
+				: [];
+			// Merge the built-in publisher anchor so a signed, bundled first-party
+			// plugin is trusted without the user adding a key (publisher-keys.ts).
+			return resolveTrustedKeys(userKeys);
 		};
 		// The live grant source every enforcement seam now reads (sealed, identity-
 		// bound, anti-rollback) instead of the forgeable on-disk store.
@@ -2444,10 +2451,7 @@ app
 				const ef = store.get('encoreFeatures', {}) as Record<string, boolean>;
 				return ef.plugins === true;
 			},
-			trustedKeys: () => {
-				const keys = store.get('pluginTrustedKeys', []) as unknown;
-				return Array.isArray(keys) ? keys.filter((k): k is string => typeof k === 'string') : [];
-			},
+			trustedKeys: trustedKeysFor,
 			sandbox: sandboxHost,
 			// Gate capability-scoped contributions by the SAME live grant source the
 			// broker uses: the sealed authorization ledger.
@@ -2863,6 +2867,13 @@ app
 		// so this is safe to call unconditionally.
 		if (pluginManager) {
 			try {
+				// Copy trusted bundled first-party plugins into the plugins dir before
+				// discovery. Trust-gated + idempotent, so it is safe to run every boot.
+				seedBundledPlugins({
+					trustedKeys: trustedKeysFor,
+					onLog: (message) => logger.info(message, 'Startup'),
+					onError: (error) => void captureException(error),
+				});
 				pluginManager.refresh();
 				pluginManager.startWatching();
 			} catch (err) {

--- a/src/main/plugins/bundled-plugins.ts
+++ b/src/main/plugins/bundled-plugins.ts
@@ -86,6 +86,13 @@ export function seedBundledPlugins(deps: SeedBundledPluginsDeps): void {
 		const bundled = readManifest(src);
 		const id = bundled?.id;
 		if (!id || !isSafePluginFolderName(id)) continue;
+		// Identity guard: the bundled folder name must equal the declared id, so a
+		// signed bundle can never target a DIFFERENT plugin's directory in the
+		// writable plugins tree.
+		if (entry.name !== id) {
+			deps.onLog?.(`bundled plugin dir "${entry.name}" declares id "${id}"; skipped`);
+			continue;
+		}
 		try {
 			// Trust gate: only seed a bundled plugin that verifies `trusted`.
 			const sig = verifyPluginSignature(src, trusted);
@@ -109,14 +116,30 @@ export function seedBundledPlugins(deps: SeedBundledPluginsDeps): void {
 					!!semver.valid(installed.version) &&
 					semver.gt(bundled.version, installed.version));
 			if (!shouldSeed) continue;
-			// Never copy a symlink: a link in the bundled tree must not become a
-			// live link inside the writable plugins dir (mirrors install()'s guard).
+			// Stage a full copy into a temp sibling, then atomically swap it in with a
+			// backup + rollback, so a failed copy (disk full, permissions) never
+			// leaves the install destroyed. Temp names start with '.' so discovery
+			// (isSafePluginFolderName) never picks them up. Never copy a symlink: a
+			// link in the bundled tree must not become a live link in the writable
+			// plugins dir (mirrors install()'s guard).
 			fs.mkdirSync(targetRoot, { recursive: true });
-			fs.rmSync(dest, { recursive: true, force: true });
-			fs.cpSync(src, dest, {
+			const staging = path.join(targetRoot, `.${id}.seed-tmp`);
+			const backup = path.join(targetRoot, `.${id}.seed-bak`);
+			fs.rmSync(staging, { recursive: true, force: true });
+			fs.rmSync(backup, { recursive: true, force: true });
+			fs.cpSync(src, staging, {
 				recursive: true,
 				filter: (from) => !fs.lstatSync(from).isSymbolicLink(),
 			});
+			const hadDest = fs.existsSync(dest);
+			if (hadDest) fs.renameSync(dest, backup);
+			try {
+				fs.renameSync(staging, dest);
+			} catch (swapError) {
+				if (hadDest) fs.renameSync(backup, dest);
+				throw swapError;
+			}
+			fs.rmSync(backup, { recursive: true, force: true });
 			deps.onLog?.(`seeded bundled plugin "${id}" (${bundled.version ?? 'unknown'})`);
 		} catch (error) {
 			deps.onError?.(error);

--- a/src/main/plugins/bundled-plugins.ts
+++ b/src/main/plugins/bundled-plugins.ts
@@ -48,12 +48,23 @@ export function bundledPluginsRoot(): string | null {
 	return null;
 }
 
-/** Parse + validate a plugin dir's manifest, or null when unreadable/invalid. */
+/** Parse + validate a plugin dir's manifest. Returns null for an absent or
+ * malformed/invalid manifest (both normal "not a usable plugin dir" cases) and
+ * rethrows unexpected I/O errors so they reach the caller's onError/Sentry. */
 function readManifest(dir: string): PluginManifest | null {
+	let raw: string;
 	try {
-		const raw = JSON.parse(fs.readFileSync(path.join(dir, MANIFEST_FILENAME), 'utf-8')) as unknown;
-		return validatePluginManifest(raw).manifest;
+		raw = fs.readFileSync(path.join(dir, MANIFEST_FILENAME), 'utf-8');
+	} catch (error) {
+		// An absent manifest just means "not a plugin dir". Any other I/O failure
+		// (permissions, etc.) is unexpected: surface it rather than skip silently.
+		if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null;
+		throw error;
+	}
+	try {
+		return validatePluginManifest(JSON.parse(raw) as unknown).manifest;
 	} catch {
+		// Malformed JSON -> no usable manifest (validation returns null on its own).
 		return null;
 	}
 }
@@ -83,17 +94,17 @@ export function seedBundledPlugins(deps: SeedBundledPluginsDeps): void {
 	for (const entry of entries) {
 		if (!entry.isDirectory()) continue;
 		const src = path.join(root, entry.name);
-		const bundled = readManifest(src);
-		const id = bundled?.id;
-		if (!id || !isSafePluginFolderName(id)) continue;
-		// Identity guard: the bundled folder name must equal the declared id, so a
-		// signed bundle can never target a DIFFERENT plugin's directory in the
-		// writable plugins tree.
-		if (entry.name !== id) {
-			deps.onLog?.(`bundled plugin dir "${entry.name}" declares id "${id}"; skipped`);
-			continue;
-		}
 		try {
+			const bundled = readManifest(src);
+			const id = bundled?.id;
+			if (!id || !isSafePluginFolderName(id)) continue;
+			// Identity guard: the bundled folder name must equal the declared id, so a
+			// signed bundle can never target a DIFFERENT plugin's directory in the
+			// writable plugins tree.
+			if (entry.name !== id) {
+				deps.onLog?.(`bundled plugin dir "${entry.name}" declares id "${id}"; skipped`);
+				continue;
+			}
 			// Trust gate: only seed a bundled plugin that verifies `trusted`.
 			const sig = verifyPluginSignature(src, trusted);
 			if (sig.status !== 'trusted') {

--- a/src/main/plugins/bundled-plugins.ts
+++ b/src/main/plugins/bundled-plugins.ts
@@ -61,12 +61,16 @@ function readManifest(dir: string): PluginManifest | null {
 		if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null;
 		throw error;
 	}
+	let parsed: unknown;
 	try {
-		return validatePluginManifest(JSON.parse(raw) as unknown).manifest;
+		parsed = JSON.parse(raw);
 	} catch {
-		// Malformed JSON -> no usable manifest (validation returns null on its own).
+		// Malformed JSON -> no usable manifest.
 		return null;
 	}
+	// validatePluginManifest returns { manifest: null } for an invalid shape; an
+	// actual throw here would be an unexpected bug, so let it reach onError/Sentry.
+	return validatePluginManifest(parsed).manifest;
 }
 
 export interface SeedBundledPluginsDeps {

--- a/src/main/plugins/bundled-plugins.ts
+++ b/src/main/plugins/bundled-plugins.ts
@@ -1,0 +1,125 @@
+/**
+ * Seeds BUNDLED first-party plugins into the user's plugins dir at startup.
+ *
+ * Plugins shipped inside the app (extraResources -> <resources>/plugins/<id>)
+ * are copied into `pluginsDir()/<id>` so a normal discovery/refresh picks them
+ * up - but ONLY when their signature verifies `trusted` against the baked
+ * publisher anchor (see `publisher-keys.ts`). That trust gate is what keeps an
+ * empty anchor safe: nothing is auto-installed until a real publisher key +
+ * signature exist, so the user never gets an orphaned, auto-installed-but-
+ * non-runnable plugin they did not choose.
+ *
+ * Symlinks are never copied (preserves the plugin-dir escape guard). Idempotent:
+ * install when absent, when the bundled version is semver-newer, or when the
+ * installed copy is not itself trusted (replacing a manual unsigned install).
+ * Per-plugin failures are non-fatal. The runtime `trusted` + enable/consent
+ * gates still apply after seeding.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import semver from 'semver';
+import { validatePluginManifest, type PluginManifest } from '../../shared/plugins/plugin-manifest';
+import { verifyPluginSignature } from './plugin-signature';
+import { pluginsDir, isSafePluginFolderName } from './plugin-store-main';
+
+const MANIFEST_FILENAME = 'plugin.json';
+
+/**
+ * Root of plugins bundled inside the app.
+ * - Packaged: extraResources lands them at `<resources>/plugins`.
+ * - Dev: the repo's `examples/plugins` tree (this file compiles to
+ *   `dist/main/plugins/bundled-plugins.js`).
+ * Returns null when no bundled root exists.
+ */
+export function bundledPluginsRoot(): string | null {
+	const candidates: string[] = [];
+	if (typeof process.resourcesPath === 'string' && process.resourcesPath.length > 0) {
+		candidates.push(path.join(process.resourcesPath, 'plugins'));
+	}
+	candidates.push(path.resolve(__dirname, '..', '..', '..', 'examples', 'plugins'));
+	for (const dir of candidates) {
+		try {
+			if (fs.statSync(dir).isDirectory()) return dir;
+		} catch {
+			// Not present at this candidate; try the next.
+		}
+	}
+	return null;
+}
+
+/** Parse + validate a plugin dir's manifest, or null when unreadable/invalid. */
+function readManifest(dir: string): PluginManifest | null {
+	try {
+		const raw = JSON.parse(fs.readFileSync(path.join(dir, MANIFEST_FILENAME), 'utf-8')) as unknown;
+		return validatePluginManifest(raw).manifest;
+	} catch {
+		return null;
+	}
+}
+
+export interface SeedBundledPluginsDeps {
+	/** Trusted keys (baked publisher anchor + user keys) to verify against. */
+	trustedKeys: () => string[];
+	onLog?: (message: string) => void;
+	onError?: (error: unknown) => void;
+}
+
+/**
+ * Copy trusted bundled plugins into the user's plugins dir. See file header.
+ */
+export function seedBundledPlugins(deps: SeedBundledPluginsDeps): void {
+	const root = bundledPluginsRoot();
+	if (!root) return;
+	const trusted = deps.trustedKeys();
+	let entries: fs.Dirent[];
+	try {
+		entries = fs.readdirSync(root, { withFileTypes: true });
+	} catch (error) {
+		deps.onError?.(error);
+		return;
+	}
+	const targetRoot = pluginsDir();
+	for (const entry of entries) {
+		if (!entry.isDirectory()) continue;
+		const src = path.join(root, entry.name);
+		const bundled = readManifest(src);
+		const id = bundled?.id;
+		if (!id || !isSafePluginFolderName(id)) continue;
+		try {
+			// Trust gate: only seed a bundled plugin that verifies `trusted`.
+			const sig = verifyPluginSignature(src, trusted);
+			if (sig.status !== 'trusted') {
+				deps.onLog?.(`bundled plugin "${id}" not seeded (signature: ${sig.status})`);
+				continue;
+			}
+			const dest = path.join(targetRoot, id);
+			const installed = fs.existsSync(dest) ? readManifest(dest) : null;
+			// Re-verify the INSTALLED copy too: a manual unsigned/untrusted install
+			// of the same id (even the same version) must be replaced by the trusted
+			// bundled copy - not only an absent or older one.
+			const installedTrusted =
+				!!installed && verifyPluginSignature(dest, trusted).status === 'trusted';
+			const shouldSeed =
+				!installed ||
+				!installedTrusted ||
+				(!!bundled.version &&
+					!!installed.version &&
+					!!semver.valid(bundled.version) &&
+					!!semver.valid(installed.version) &&
+					semver.gt(bundled.version, installed.version));
+			if (!shouldSeed) continue;
+			// Never copy a symlink: a link in the bundled tree must not become a
+			// live link inside the writable plugins dir (mirrors install()'s guard).
+			fs.mkdirSync(targetRoot, { recursive: true });
+			fs.rmSync(dest, { recursive: true, force: true });
+			fs.cpSync(src, dest, {
+				recursive: true,
+				filter: (from) => !fs.lstatSync(from).isSymbolicLink(),
+			});
+			deps.onLog?.(`seeded bundled plugin "${id}" (${bundled.version ?? 'unknown'})`);
+		} catch (error) {
+			deps.onError?.(error);
+		}
+	}
+}

--- a/src/shared/plugins/publisher-keys.ts
+++ b/src/shared/plugins/publisher-keys.ts
@@ -1,0 +1,36 @@
+/**
+ * Built-in publisher trust anchor for BUNDLED first-party plugins.
+ *
+ * A plugin shipped inside the Maestro app bundle (see the bundled-plugin seeding
+ * in `src/main/plugins/bundled-plugins.ts`) is signed by Maestro's publisher
+ * key. Baking the matching PUBLIC key here lets that bundled, signed plugin
+ * resolve to `trusted` - and therefore run its sandboxed code (`isRunnable`) -
+ * without the user manually adding a key. This is the ONLY built-in trust
+ * anchor; every other trusted key is a user-supplied `pluginTrustedKeys` entry.
+ *
+ * SHIPPING CONTRACT:
+ * - The matching PRIVATE key is a maintainer/CI secret and is NEVER committed.
+ *   Release tooling signs the bundled plugin(s) with it at build time.
+ * - Until a real publisher key is added here this list is EMPTY. The seeder is
+ *   trust-gated (it only installs a bundled plugin that verifies `trusted`), so
+ *   an empty anchor means bundled plugins are simply not auto-installed - never
+ *   an orphaned, auto-installed-but-untrusted plugin the user did not choose.
+ * - Base64 SPKI DER, one entry per publisher key, matching the `publicKey`
+ *   field a `signature.json` carries (see `signing.ts`).
+ */
+export const MAESTRO_PUBLISHER_KEYS: readonly string[] = [];
+
+/**
+ * Union of the built-in publisher anchor and the user's configured trusted keys,
+ * trimmed and de-duplicated. This is the single set every signature check should
+ * resolve trust against, so a bundled first-party plugin and a user-trusted
+ * community plugin are judged by the same rule.
+ */
+export function resolveTrustedKeys(userKeys: readonly string[]): string[] {
+	const merged: string[] = [];
+	for (const key of [...MAESTRO_PUBLISHER_KEYS, ...userKeys]) {
+		const trimmed = typeof key === 'string' ? key.trim() : '';
+		if (trimmed && !merged.includes(trimmed)) merged.push(trimmed);
+	}
+	return merged;
+}


### PR DESCRIPTION
## What
Follow-up to #1254. Establishes how a **sandboxed folder plugin shipped inside the app** (Agent Flow) becomes `trusted` - and therefore runnable - without a manual install. Today no sandboxed plugin can be trusted (`pluginTrustedKeys` defaults empty; only native first-party features are trusted-by-construction), so this is the first bundled trusted plugin.

## How
- **`src/shared/plugins/publisher-keys.ts`** - a baked `MAESTRO_PUBLISHER_KEYS` anchor, merged with the user's `pluginTrustedKeys` via `resolveTrustedKeys()`. This is the only built-in trust anchor.
- **`src/main/plugins/bundled-plugins.ts`** - `seedBundledPlugins()` copies bundled plugins (`extraResources -> <resources>/plugins/<id>`) into `pluginsDir()` at startup, **only when the signature verifies `trusted`**. Symlink-safe, version-aware, idempotent; also replaces a manual unsigned install of the same id with the trusted bundled copy.
- **`src/main/index.ts`** - merges the anchor into `trustedKeys`, seeds before `pluginManager.refresh()`.
- **`package.json`** - bundles `examples/plugins/agent-flow` for mac/win/linux.

## Security / key handling
The matching **private** key is a maintainer/CI secret and is **never committed**. `MAESTRO_PUBLISHER_KEYS` ships **empty** here, and the seeder is **trust-gated**, so with an empty anchor **nothing is auto-installed** - no orphaned, auto-installed-but-non-runnable plugin. Agent Flow activates once a release signs it with the publisher key and adds that public key to the anchor.

## Tests
`publisher-keys.test.ts` (merge/dedupe) and `bundled-plugins.test.ts` (trust gate, replace-untrusted-same-version, skip-trusted-same, refresh-on-newer). `tsc` main + lint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bundled first-party plugins are now included in desktop app builds for macOS, Windows, and Linux.
  * On startup, trusted bundled plugins are automatically seeded into the user plugins directory when missing or outdated.
  * Configured plugin trust keys are merged with built-in publisher trust keys (whitespace/duplicates/empty values ignored).
* **Security**
  * Untrusted bundled plugins are not installed; trusted ones are installed or refreshed only when the bundled version is newer.
  * Updates avoid symlinks and use safe replace/rollback to reduce risk of failed installs.
* **Tests**
  * Added coverage for bundled plugin seeding behavior and trusted-key resolution edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->