### PR TITLE
test(sidebar): fix stale Pianola empty-state assertion (rc CI red)

### DIFF
--- a/src/__tests__/renderer/components/SessionList.test.tsx
+++ b/src/__tests__/renderer/components/SessionList.test.tsx
@@ -851,7 +851,7 @@ describe('SessionList', () => {
 			render(<SessionList {...createDefaultProps({ sortedSessions: [pianola] })} />);
 
 			const pianolaRow = screen.getByText('Maestro Pianola');
-			const emptyState = screen.getByText('No unread or working agents');
+			const emptyState = screen.getByText('No unread, working, or errored agents');
 			// Pianola (a plain block) must come before the flex-1 empty state in DOM
 			// order; otherwise the empty state grows and shoves Pianola to the bottom.
 			expect(


### PR DESCRIPTION
## Problem
`SessionList.test.tsx > Pianola Pinned Agent > renders Pianola above the unread-filter empty state` fails on **clean `upstream/rc`** (shard 2/2), so every open PR branched from `rc` inherits a red `Test` check.

## Cause
The unread-filter empty state now renders **"No unread, working, or errored agents"** (errored agents were folded into the filter), but this test still asserted the old **"No unread or working agents"** copy, so `getByText` threw. The component behavior it checks (Pianola block rendered before the empty state) is unchanged and correct.

## Fix
Update the expected text to the current copy. One-line, test-only.

Verified: the test passes; no component change.

Merging this unblocks the shard 2/2 check for the follow-up PRs #1263-#1266 (they only go red on this inherited assertion).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated coverage for the unread-agent empty state to reflect the revised message.
  * Continued verifying that the Pianola entry appears before the empty-state message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->