### PR TITLE
feat(pianola): group busy worktree agents under their parent in the Dashboard

### DIFF
--- a/src/__tests__/renderer/components/PianolaDashboard/deriveDashboard.test.ts
+++ b/src/__tests__/renderer/components/PianolaDashboard/deriveDashboard.test.ts
@@ -86,11 +86,14 @@ describe('deriveDashboard', () => {
 	});
 
 	it('excludes the Pianola agent from every bucket', () => {
-		const { working } = deriveDashboard(
+		const { needsInput, working, recentlyDone, activity } = deriveDashboard(
 			[session({ id: 'pia', state: 'busy', isPianola: true })],
 			[]
 		);
+		expect(needsInput).toHaveLength(0);
 		expect(working).toHaveLength(0);
+		expect(recentlyDone).toHaveLength(0);
+		expect(activity).toHaveLength(0);
 	});
 
 	it('groups a busy worktree child under its parent in Working, even when the parent is idle', () => {

--- a/src/__tests__/renderer/components/PianolaDashboard/deriveDashboard.test.ts
+++ b/src/__tests__/renderer/components/PianolaDashboard/deriveDashboard.test.ts
@@ -85,12 +85,46 @@ describe('deriveDashboard', () => {
 		expect(recentlyDone.find((r) => r.sessionId === 'e')).toBeUndefined();
 	});
 
-	it('excludes the Pianola agent and worktree children from every bucket', () => {
+	it('excludes the Pianola agent from every bucket', () => {
+		const { working } = deriveDashboard(
+			[session({ id: 'pia', state: 'busy', isPianola: true })],
+			[]
+		);
+		expect(working).toHaveLength(0);
+	});
+
+	it('groups a busy worktree child under its parent in Working, even when the parent is idle', () => {
 		const sessions = [
-			session({ id: 'pia', state: 'busy', isPianola: true }),
-			session({ id: 'wt', state: 'busy', parentSessionId: 'parent' }),
+			session({ id: 'parent', state: 'idle', name: 'Parent' }),
+			session({
+				id: 'child',
+				state: 'busy',
+				parentSessionId: 'parent',
+				name: 'Child',
+				activeTabId: 't1',
+				aiTabs: [{ id: 't1', name: 'fixing tests' }] as Session['aiTabs'],
+			}),
 		];
-		const { working } = deriveDashboard(sessions, []);
+		// Parent has prior decision history, so absent the busy child it would land
+		// in recentlyDone; surfacing it via the child must move it to Working only.
+		const decisions = [decision('parent', 'earlier work')];
+		const { working, recentlyDone } = deriveDashboard(sessions, decisions);
+
+		expect(working).toHaveLength(1);
+		expect(working[0].sessionId).toBe('parent');
+		expect(working[0].worktreeChildren?.map((c) => c.sessionId)).toEqual(['child']);
+		expect(working[0].worktreeChildren?.[0].description).toBe('fixing tests');
+		// The busy child is not also a separate top-level row.
+		expect(working.filter((r) => r.sessionId === 'child')).toHaveLength(0);
+		// ...and the parent isn't double-listed in recentlyDone.
+		expect(recentlyDone.find((r) => r.sessionId === 'parent')).toBeUndefined();
+	});
+
+	it('adds no Working row for a busy worktree child whose parent is absent', () => {
+		const { working } = deriveDashboard(
+			[session({ id: 'wt', state: 'busy', parentSessionId: 'ghost' })],
+			[]
+		);
 		expect(working).toHaveLength(0);
 	});
 

--- a/src/__tests__/renderer/components/PianolaDashboard/deriveDashboard.test.ts
+++ b/src/__tests__/renderer/components/PianolaDashboard/deriveDashboard.test.ts
@@ -85,14 +85,15 @@ describe('deriveDashboard', () => {
 		expect(recentlyDone.find((r) => r.sessionId === 'e')).toBeUndefined();
 	});
 
-	it('excludes the Pianola agent from every bucket', () => {
+	it('excludes the Pianola agent and its own decisions from every bucket', () => {
 		const { needsInput, working, recentlyDone, activity } = deriveDashboard(
 			[session({ id: 'pia', state: 'busy', isPianola: true })],
-			[]
+			[decision('pia', 'internal self-check')]
 		);
 		expect(needsInput).toHaveLength(0);
 		expect(working).toHaveLength(0);
 		expect(recentlyDone).toHaveLength(0);
+		// Recent decisions must not surface the Pianola session's own decisions.
 		expect(activity).toHaveLength(0);
 	});
 
@@ -129,6 +130,38 @@ describe('deriveDashboard', () => {
 			[]
 		);
 		expect(working).toHaveLength(0);
+	});
+
+	it('nests a busy child under a waiting parent in needsInput, not in Working', () => {
+		const sessions = [
+			session({ id: 'parent', state: 'waiting_input', name: 'Parent' }),
+			session({
+				id: 'child',
+				state: 'busy',
+				parentSessionId: 'parent',
+				name: 'Child',
+				activeTabId: 't1',
+				aiTabs: [{ id: 't1', name: 'fixing tests' }] as Session['aiTabs'],
+			}),
+		];
+		const { needsInput, working } = deriveDashboard(sessions, []);
+		// The waiting parent stays in needsInput, with the busy child nested there.
+		expect(needsInput).toHaveLength(1);
+		expect(needsInput[0].sessionId).toBe('parent');
+		expect(needsInput[0].worktreeChildren?.map((c) => c.sessionId)).toEqual(['child']);
+		// It must NOT also appear in Working (no double-listing).
+		expect(working.find((r) => r.sessionId === 'parent')).toBeUndefined();
+		expect(working).toHaveLength(0);
+	});
+
+	it('sorts busy worktree children by name, ignoring leading emojis', () => {
+		const sessions = [
+			session({ id: 'parent', state: 'idle', name: 'Parent' }),
+			session({ id: 'a', state: 'busy', parentSessionId: 'parent', name: 'Beta' }),
+			session({ id: 'z', state: 'busy', parentSessionId: 'parent', name: '🐛 Alpha' }),
+		];
+		const { working } = deriveDashboard(sessions, []);
+		expect(working[0].worktreeChildren?.map((c) => c.agentName)).toEqual(['🐛 Alpha', 'Beta']);
 	});
 
 	it('feeds activity newest-first and splits handoffs out from escalations', () => {

--- a/src/renderer/components/PianolaDashboard/PianolaDashboard.tsx
+++ b/src/renderer/components/PianolaDashboard/PianolaDashboard.tsx
@@ -18,6 +18,7 @@ import {
 	ShieldQuestion,
 	MessageSquareReply,
 	EyeOff,
+	GitBranch,
 } from 'lucide-react';
 import type { Theme } from '../../types';
 import { formatRelativeTime } from '../../../shared/formatters';
@@ -82,30 +83,59 @@ function AgentRow({
 	onJump: (sessionId: string) => void;
 }): React.ReactElement {
 	const clickable = !!row.sessionId;
+	const children = row.worktreeChildren ?? [];
 	return (
-		<button
-			type="button"
-			disabled={!clickable}
-			onClick={() => row.sessionId && onJump(row.sessionId)}
-			className="w-full text-left rounded px-3 py-2 flex items-center gap-3 transition-colors hover:bg-white/5 disabled:cursor-default"
-			style={{ backgroundColor: theme.colors.bgSidebar, borderLeft: `2px solid ${accent}` }}
-			title={clickable ? `Jump to ${row.agentName}` : row.agentName}
-		>
-			<span
-				className="text-sm font-medium truncate shrink-0 max-w-[40%]"
-				style={{ color: theme.colors.textMain }}
+		<div className="flex flex-col gap-1">
+			<button
+				type="button"
+				disabled={!clickable}
+				onClick={() => row.sessionId && onJump(row.sessionId)}
+				className="w-full text-left rounded px-3 py-2 flex items-center gap-3 transition-colors hover:bg-white/5 disabled:cursor-default"
+				style={{ backgroundColor: theme.colors.bgSidebar, borderLeft: `2px solid ${accent}` }}
+				title={clickable ? `Jump to ${row.agentName}` : row.agentName}
 			>
-				{row.agentName}
-			</span>
-			<span className="text-sm truncate flex-1" style={{ color: theme.colors.textDim }}>
-				{row.description}
-			</span>
-			{row.timestamp !== undefined && (
-				<span className="text-xs shrink-0" style={{ color: theme.colors.textDim }}>
-					{formatRelativeTime(row.timestamp)}
+				<span
+					className="text-sm font-medium truncate shrink-0 max-w-[40%]"
+					style={{ color: theme.colors.textMain }}
+				>
+					{row.agentName}
 				</span>
+				<span className="text-sm truncate flex-1" style={{ color: theme.colors.textDim }}>
+					{row.description}
+				</span>
+				{row.timestamp !== undefined && (
+					<span className="text-xs shrink-0" style={{ color: theme.colors.textDim }}>
+						{formatRelativeTime(row.timestamp)}
+					</span>
+				)}
+			</button>
+			{children.length > 0 && (
+				<div className="flex flex-col gap-1 pl-4">
+					{children.map((child) => (
+						<button
+							key={child.key}
+							type="button"
+							disabled={!child.sessionId}
+							onClick={() => child.sessionId && onJump(child.sessionId)}
+							className="w-full text-left rounded px-3 py-1.5 flex items-center gap-2 transition-colors hover:bg-white/5 disabled:cursor-default"
+							style={{ backgroundColor: theme.colors.bgSidebar, borderLeft: `2px solid ${accent}` }}
+							title={child.sessionId ? `Jump to ${child.agentName}` : child.agentName}
+						>
+							<GitBranch className="w-3 h-3 shrink-0" style={{ color: theme.colors.textDim }} />
+							<span
+								className="text-xs font-medium truncate shrink-0 max-w-[45%]"
+								style={{ color: theme.colors.textMain }}
+							>
+								{child.agentName}
+							</span>
+							<span className="text-xs truncate flex-1" style={{ color: theme.colors.textDim }}>
+								{child.description}
+							</span>
+						</button>
+					))}
+				</div>
 			)}
-		</button>
+		</div>
 	);
 }
 

--- a/src/renderer/components/PianolaDashboard/usePianolaDashboardData.ts
+++ b/src/renderer/components/PianolaDashboard/usePianolaDashboardData.ts
@@ -83,8 +83,9 @@ export function deriveDashboard(
 	sessions: readonly Session[],
 	decisions: readonly PianolaDecisionRecord[]
 ): DashboardData {
-	// Real agents only: never the Pianola agent itself, never worktree children
-	// (they show under their parent in the Left Bar; listing them here is noise).
+	// Top-level agents only (never the Pianola agent itself). Worktree children get
+	// no row of their own here; busy ones are nested under their parent in the
+	// Working bucket below, mirroring the Left Bar.
 	const agents = sessions.filter((s) => !s.isPianola && !s.parentSessionId);
 	const nameById = new Map(sessions.map((s) => [s.id, s.name] as const));
 

--- a/src/renderer/components/PianolaDashboard/usePianolaDashboardData.ts
+++ b/src/renderer/components/PianolaDashboard/usePianolaDashboardData.ts
@@ -28,6 +28,9 @@ export interface DashboardAgentRow {
 	description: string;
 	/** Epoch ms of the relevant moment, when known. */
 	timestamp?: number;
+	/** Busy worktree children grouped under this parent agent, mirroring the Left
+	 * Bar. Only set on Working-section rows. */
+	worktreeChildren?: DashboardAgentRow[];
 }
 
 /** A row in the recent-activity feed. */
@@ -112,14 +115,41 @@ export function deriveDashboard(
 			};
 		});
 
+	// Working now: busy top-level agents, plus any parent with busy worktree
+	// children (shown even when the parent itself is idle, mirroring the Left Bar),
+	// with those busy children nested under it.
+	const busyChildrenByParent = new Map<string, Session[]>();
+	for (const s of sessions) {
+		if (!s.isPianola && s.parentSessionId && s.state === 'busy') {
+			const siblings = busyChildrenByParent.get(s.parentSessionId);
+			if (siblings) siblings.push(s);
+			else busyChildrenByParent.set(s.parentSessionId, [s]);
+		}
+	}
 	const working: DashboardAgentRow[] = agents
-		.filter((s) => s.state === 'busy')
-		.map((s) => ({
-			key: s.id,
-			sessionId: s.id,
-			agentName: s.name,
-			description: activeTaskLabel(s, 'Working...'),
-		}));
+		.filter((s) => s.state === 'busy' || busyChildrenByParent.has(s.id))
+		.map((s) => {
+			const children = busyChildrenByParent.get(s.id) ?? [];
+			return {
+				key: s.id,
+				sessionId: s.id,
+				agentName: s.name,
+				description:
+					s.state === 'busy'
+						? activeTaskLabel(s, 'Working...')
+						: `${children.length} worktree${children.length === 1 ? '' : 's'} working`,
+				...(children.length > 0
+					? {
+							worktreeChildren: children.map((c) => ({
+								key: c.id,
+								sessionId: c.id,
+								agentName: c.name,
+								description: activeTaskLabel(c, 'Working...'),
+							})),
+						}
+					: {}),
+			};
+		});
 
 	// Recently done: idle agents Pianola has actually worked with (they appear in
 	// the decision log), so we do not list every dormant agent as "done". Sorted

--- a/src/renderer/components/PianolaDashboard/usePianolaDashboardData.ts
+++ b/src/renderer/components/PianolaDashboard/usePianolaDashboardData.ts
@@ -17,6 +17,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { useSessionStore } from '../../stores/sessionStore';
 import type { Session } from '../../types';
 import type { PianolaDecisionRecord } from '../../../shared/pianola/storage';
+import { compareNamesIgnoringEmojis } from '../../../shared/emojiUtils';
 
 /** A row in one of the agent-status sections. */
 export interface DashboardAgentRow {
@@ -28,8 +29,8 @@ export interface DashboardAgentRow {
 	description: string;
 	/** Epoch ms of the relevant moment, when known. */
 	timestamp?: number;
-	/** Busy worktree children grouped under this parent agent, mirroring the Left
-	 * Bar. Only set on Working-section rows. */
+	/** Busy worktree children grouped under this parent, mirroring the Left Bar.
+	 * Set on the parent's row in whichever bucket its own state places it. */
 	worktreeChildren?: DashboardAgentRow[];
 }
 
@@ -88,6 +89,7 @@ export function deriveDashboard(
 	// Working bucket below, mirroring the Left Bar.
 	const agents = sessions.filter((s) => !s.isPianola && !s.parentSessionId);
 	const nameById = new Map(sessions.map((s) => [s.id, s.name] as const));
+	const pianolaIds = new Set(sessions.filter((s) => s.isPianola).map((s) => s.id));
 
 	// Newest first. The audit log is stored oldest-last, so reverse a shallow copy.
 	const newestFirst = [...decisions].sort((a, b) => ms(b.timestamp) - ms(a.timestamp));
@@ -103,22 +105,9 @@ export function deriveDashboard(
 		}
 	}
 
-	const needsInput: DashboardAgentRow[] = agents
-		.filter((s) => s.state === 'waiting_input')
-		.map((s) => {
-			const latest = latestTopicByAgent.get(s.id);
-			return {
-				key: s.id,
-				sessionId: s.id,
-				agentName: s.name,
-				description: latest?.topic ?? 'Waiting for your input',
-				timestamp: latest?.timestamp,
-			};
-		});
-
-	// Working now: busy top-level agents, plus any parent with busy worktree
-	// children (shown even when the parent itself is idle, mirroring the Left Bar),
-	// with those busy children nested under it.
+	// Busy worktree children grouped under their parent id (sorted by name so the
+	// Dashboard mirrors the Left Bar's ordering). A parent is listed in whichever
+	// bucket its own state places it, with these children nested beneath it.
 	const busyChildrenByParent = new Map<string, Session[]>();
 	for (const s of sessions) {
 		if (!s.isPianola && s.parentSessionId && s.state === 'busy') {
@@ -127,10 +116,46 @@ export function deriveDashboard(
 			else busyChildrenByParent.set(s.parentSessionId, [s]);
 		}
 	}
-	const working: DashboardAgentRow[] = agents
-		.filter((s) => s.state === 'busy' || busyChildrenByParent.has(s.id))
+	const childRowsFor = (parentId: string): DashboardAgentRow[] | undefined => {
+		const kids = busyChildrenByParent.get(parentId);
+		if (!kids || kids.length === 0) return undefined;
+		return kids
+			.slice()
+			.sort((a, b) => compareNamesIgnoringEmojis(a.name, b.name))
+			.map((c) => ({
+				key: c.id,
+				sessionId: c.id,
+				agentName: c.name,
+				description: activeTaskLabel(c, 'Working...'),
+			}));
+	};
+
+	const needsInput: DashboardAgentRow[] = agents
+		.filter((s) => s.state === 'waiting_input')
 		.map((s) => {
-			const children = busyChildrenByParent.get(s.id) ?? [];
+			const latest = latestTopicByAgent.get(s.id);
+			const worktreeChildren = childRowsFor(s.id);
+			return {
+				key: s.id,
+				sessionId: s.id,
+				agentName: s.name,
+				description: latest?.topic ?? 'Waiting for your input',
+				timestamp: latest?.timestamp,
+				...(worktreeChildren ? { worktreeChildren } : {}),
+			};
+		});
+
+	// Working now: busy top-level agents, plus any parent with busy worktree
+	// children that is not itself waiting on the user. A waiting parent stays in
+	// "Needs your input" (with its busy children nested there), so no agent is
+	// listed in two buckets. Mirrors the Left Bar.
+	const working: DashboardAgentRow[] = agents
+		.filter(
+			(s) => s.state === 'busy' || (s.state !== 'waiting_input' && busyChildrenByParent.has(s.id))
+		)
+		.map((s) => {
+			const worktreeChildren = childRowsFor(s.id);
+			const childCount = worktreeChildren?.length ?? 0;
 			return {
 				key: s.id,
 				sessionId: s.id,
@@ -138,17 +163,8 @@ export function deriveDashboard(
 				description:
 					s.state === 'busy'
 						? activeTaskLabel(s, 'Working...')
-						: `${children.length} worktree${children.length === 1 ? '' : 's'} working`,
-				...(children.length > 0
-					? {
-							worktreeChildren: children.map((c) => ({
-								key: c.id,
-								sessionId: c.id,
-								agentName: c.name,
-								description: activeTaskLabel(c, 'Working...'),
-							})),
-						}
-					: {}),
+						: `${childCount} worktree${childCount === 1 ? '' : 's'} working`,
+				...(worktreeChildren ? { worktreeChildren } : {}),
 			};
 		});
 
@@ -170,15 +186,17 @@ export function deriveDashboard(
 		})
 		.sort((a, b) => (b.timestamp ?? 0) - (a.timestamp ?? 0));
 
-	const activity: DashboardActivityRow[] = newestFirst.map((d) => ({
-		id: d.id + (d.dispatched ? ':done' : ':intent'),
-		sessionId: nameById.has(d.agentId) ? d.agentId : undefined,
-		agentName: agentNameFor(d.agentId, nameById),
-		action: isHandoff(d) ? 'handoff' : d.decision.action,
-		topic: d.classification.topic,
-		timestamp: ms(d.timestamp),
-		dispatched: d.dispatched,
-	}));
+	const activity: DashboardActivityRow[] = newestFirst
+		.filter((d) => !pianolaIds.has(d.agentId))
+		.map((d) => ({
+			id: d.id + (d.dispatched ? ':done' : ':intent'),
+			sessionId: nameById.has(d.agentId) ? d.agentId : undefined,
+			agentName: agentNameFor(d.agentId, nameById),
+			action: isHandoff(d) ? 'handoff' : d.decision.action,
+			topic: d.classification.topic,
+			timestamp: ms(d.timestamp),
+			dispatched: d.dispatched,
+		}));
 
 	return { needsInput, working, recentlyDone, activity };
 }


### PR DESCRIPTION
## Problem
The Pianola Dashboard's **Working now** bucket only listed top-level agents. Busy **worktree children** were dropped entirely (`deriveDashboard` filtered out everything with a `parentSessionId`), so a worktree running a task was invisible in Pianola's workspace even though the Left Bar shows it.

## Change
Mirror the Left Bar's parent/child grouping in the Dashboard:

- A parent with a **busy** worktree child now appears in **Working** - **even when the parent itself is idle** - with the busy child **nested and indented** beneath it (git-branch icon, click-to-jump).
- The busy child is **not** rendered as a separate top-level row.
- A busy worktree child whose parent is **absent** adds no phantom row.
- **Needs your input** and **Recently done** are unchanged.

Top-level agents remain the only own-rows; children are grouped in only.

## Files
- `usePianolaDashboardData.ts` - `deriveDashboard` groups busy worktree children under their parent; new `worktreeChildren?` on `DashboardAgentRow`.
- `PianolaDashboard.tsx` - `AgentRow` renders nested children.
- `deriveDashboard.test.ts` - grouping (idle parent + busy child), no-phantom-row, and all-bucket Pianola-exclusion cases.

## Test
`deriveDashboard.test.ts` 9/9 green; full `npm run lint` typecheck clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added nested worktree child entries to the “Working now” dashboard.
  - Child entries show branch icons and details, and can be selected to jump to the associated session.
  - Busy worktree children are grouped beneath their parent agent, including when the parent agent is idle.

- **Bug Fixes**
  - Improved dashboard grouping to prevent misleading or duplicated top-level entries.
  - Excluded Pianola agents from dashboard buckets where they should not appear.

- **Tests**
  - Strengthened dashboard derivation coverage with more targeted scenarios around busy/absent worktree parents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->