### PR TITLE
feat(pianola): add a "Watched by Pianola" section to the Dashboard

### DIFF
--- a/src/__tests__/renderer/components/PianolaDashboard/deriveWatchState.test.ts
+++ b/src/__tests__/renderer/components/PianolaDashboard/deriveWatchState.test.ts
@@ -1,0 +1,133 @@
+/**
+ * @file deriveWatchState.test.ts
+ * @description Tests for the pure watch-state derivation: mapping live sessions
+ * + the supervisor snapshot into watched rows and the "watchable" picker list.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { deriveWatchState } from '../../../../renderer/components/PianolaDashboard/usePianolaSupervisor';
+import type { Session, SessionState } from '../../../../renderer/types';
+import type { PianolaSupervisedTarget } from '../../../../shared/pianola/storage';
+import type { PianolaSupervisorHealth } from '../../../../main/pianola/pianola-supervisor';
+
+function session(o: Partial<Session> & { id: string }): Session {
+	return {
+		cwd: '',
+		name: o.id,
+		state: 'idle' as SessionState,
+		aiTabs: [],
+		activeTabId: '',
+		...o,
+	} as Session;
+}
+
+function target(o: Partial<PianolaSupervisedTarget> & { id: string }): PianolaSupervisedTarget {
+	return { kind: 'watch', enabled: true, createdAt: 0, ...o } as PianolaSupervisedTarget;
+}
+
+function health(o: Partial<PianolaSupervisorHealth> & { id: string }): PianolaSupervisorHealth {
+	return {
+		kind: 'watch',
+		state: 'running',
+		restarts: 0,
+		recentLogs: [],
+		...o,
+	} as PianolaSupervisorHealth;
+}
+
+describe('deriveWatchState', () => {
+	it('lists watch targets enriched with name, enabled, and live health', () => {
+		const sessions = [session({ id: 'a', name: 'Backend' })];
+		const targets = [target({ id: 't1', agentId: 'a', tabId: 'tab1', enabled: true })];
+		const { watched } = deriveWatchState(sessions, targets, [
+			health({ id: 't1', state: 'running' }),
+		]);
+		expect(watched).toHaveLength(1);
+		expect(watched[0]).toMatchObject({
+			targetId: 't1',
+			agentId: 'a',
+			agentName: 'Backend',
+			enabled: true,
+			state: 'running',
+		});
+	});
+
+	it('falls back to a short id when the watched agent is no longer loaded', () => {
+		const targets = [target({ id: 't1', agentId: 'abcdef123456', tabId: 'x' })];
+		const { watched } = deriveWatchState([], targets, []);
+		expect(watched[0].agentName).toBe('abcdef');
+	});
+
+	it('surfaces the daemon lastError on a failed target', () => {
+		const targets = [target({ id: 't1', agentId: 'a', tabId: 'x' })];
+		const healths = [health({ id: 't1', state: 'failed', lastError: 'boom' })];
+		const { watched } = deriveWatchState([session({ id: 'a' })], targets, healths);
+		expect(watched[0].state).toBe('failed');
+		expect(watched[0].lastError).toBe('boom');
+	});
+
+	it('ignores non-watch (orchestrate) targets', () => {
+		const targets = [target({ id: 't1', kind: 'orchestrate', planId: 'p1', agentId: undefined })];
+		expect(deriveWatchState([], targets, []).watched).toHaveLength(0);
+	});
+
+	it('offers top-level agents with an AI tab, excluding Pianola, children, and already-watched', () => {
+		const sessions = [
+			session({
+				id: 'a',
+				name: 'A',
+				aiTabs: [{ id: 'a1', name: 'x' }] as Session['aiTabs'],
+				activeTabId: 'a1',
+			}),
+			session({
+				id: 'watched',
+				name: 'W',
+				aiTabs: [{ id: 'w1', name: 'x' }] as Session['aiTabs'],
+				activeTabId: 'w1',
+			}),
+			session({
+				id: 'pia',
+				isPianola: true,
+				aiTabs: [{ id: 'p1', name: 'x' }] as Session['aiTabs'],
+				activeTabId: 'p1',
+			}),
+			session({
+				id: 'child',
+				parentSessionId: 'a',
+				aiTabs: [{ id: 'c1', name: 'x' }] as Session['aiTabs'],
+				activeTabId: 'c1',
+			}),
+			session({ id: 'notab', name: 'NoTab', aiTabs: [] }),
+		];
+		const targets = [target({ id: 't1', agentId: 'watched', tabId: 'w1' })];
+		const { watchable } = deriveWatchState(sessions, targets, []);
+		expect(watchable.map((w) => w.agentId)).toEqual(['a']);
+		expect(watchable[0]).toMatchObject({ agentId: 'a', tabId: 'a1', agentName: 'A' });
+	});
+
+	it('targets the active AI tab when set, else the first AI tab', () => {
+		const withActive = [
+			session({
+				id: 'a',
+				aiTabs: [
+					{ id: 'a1', name: 'x' },
+					{ id: 'a2', name: 'y' },
+				] as Session['aiTabs'],
+				activeTabId: 'a2',
+			}),
+		];
+		expect(deriveWatchState(withActive, [], []).watchable[0].tabId).toBe('a2');
+		// activeTabId points at a non-AI (file/terminal) tab: fall back to the first AI tab.
+		const nonAiActive = [
+			session({
+				id: 'b',
+				aiTabs: [
+					{ id: 'b1', name: 'x' },
+					{ id: 'b2', name: 'y' },
+				] as Session['aiTabs'],
+				activeTabId: 'file-xyz',
+			}),
+		];
+		expect(deriveWatchState(nonAiActive, [], []).watchable[0].tabId).toBe('b1');
+	});
+});

--- a/src/__tests__/renderer/components/PianolaDashboard/usePianolaSupervisor.test.ts
+++ b/src/__tests__/renderer/components/PianolaDashboard/usePianolaSupervisor.test.ts
@@ -107,13 +107,26 @@ describe('usePianolaSupervisor', () => {
 		expect(result.current.watched).toHaveLength(1);
 	});
 
-	it('surfaces a toast and reports to Sentry when a mutation fails', async () => {
+	it('reports an unexpected mutation failure (toast + Sentry) but resolves', async () => {
+		// A watch toggle is a recoverable user action: it surfaces + reports the
+		// error, then RESOLVES rather than rejecting (mirroring PianolaModal's
+		// handlers) so a fire-and-forget click never becomes an unhandled rejection.
 		addImpl = () => Promise.reject(new Error('disk full'));
+		const { result } = renderHook(() => usePianolaSupervisor());
+		await act(async () => {
+			await expect(result.current.watch('a', 'x')).resolves.toBeUndefined();
+		});
+		expect(notifyToast).toHaveBeenCalledWith(expect.objectContaining({ color: 'red' }));
+		expect(captureException).toHaveBeenCalled();
+	});
+
+	it('toasts but does not report an expected PianolaDisabled mutation failure', async () => {
+		addImpl = () => Promise.reject(new Error('PianolaDisabled'));
 		const { result } = renderHook(() => usePianolaSupervisor());
 		await act(async () => {
 			await result.current.watch('a', 'x');
 		});
 		expect(notifyToast).toHaveBeenCalledWith(expect.objectContaining({ color: 'red' }));
-		expect(captureException).toHaveBeenCalled();
+		expect(captureException).not.toHaveBeenCalled();
 	});
 });

--- a/src/__tests__/renderer/components/PianolaDashboard/usePianolaSupervisor.test.ts
+++ b/src/__tests__/renderer/components/PianolaDashboard/usePianolaSupervisor.test.ts
@@ -9,6 +9,11 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { usePianolaSupervisor } from '../../../../renderer/components/PianolaDashboard/usePianolaSupervisor';
 import type { PianolaSupervisorSnapshot } from '../../../../main/ipc/handlers/pianola';
+import { notifyToast } from '../../../../renderer/stores/notificationStore';
+import { captureException } from '../../../../renderer/utils/sentry';
+
+vi.mock('../../../../renderer/stores/notificationStore', () => ({ notifyToast: vi.fn() }));
+vi.mock('../../../../renderer/utils/sentry', () => ({ captureException: vi.fn() }));
 
 function deferred<T>(): { promise: Promise<T>; resolve: (v: T) => void } {
 	let resolve!: (v: T) => void;
@@ -100,5 +105,15 @@ describe('usePianolaSupervisor', () => {
 		});
 		// The mutation result must survive the late, stale poll.
 		expect(result.current.watched).toHaveLength(1);
+	});
+
+	it('surfaces a toast and reports to Sentry when a mutation fails', async () => {
+		addImpl = () => Promise.reject(new Error('disk full'));
+		const { result } = renderHook(() => usePianolaSupervisor());
+		await act(async () => {
+			await result.current.watch('a', 'x');
+		});
+		expect(notifyToast).toHaveBeenCalledWith(expect.objectContaining({ color: 'red' }));
+		expect(captureException).toHaveBeenCalled();
 	});
 });

--- a/src/__tests__/renderer/components/PianolaDashboard/usePianolaSupervisor.test.ts
+++ b/src/__tests__/renderer/components/PianolaDashboard/usePianolaSupervisor.test.ts
@@ -1,0 +1,104 @@
+/**
+ * @file usePianolaSupervisor.test.ts
+ * @description State-reconciliation tests for the watch hook: a disabled Pianola
+ * clears stale rows, a transient IPC error keeps the last snapshot, and a slow
+ * poll can never clobber a newer mutation's result.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { usePianolaSupervisor } from '../../../../renderer/components/PianolaDashboard/usePianolaSupervisor';
+import type { PianolaSupervisorSnapshot } from '../../../../main/ipc/handlers/pianola';
+
+function deferred<T>(): { promise: Promise<T>; resolve: (v: T) => void } {
+	let resolve!: (v: T) => void;
+	const promise = new Promise<T>((res) => {
+		resolve = res;
+	});
+	return { promise, resolve };
+}
+
+const watchSnap: PianolaSupervisorSnapshot = {
+	targets: [{ id: 't1', kind: 'watch', enabled: true, createdAt: 0, agentId: 'a', tabId: 'x' }],
+	health: [],
+};
+const emptySnap: PianolaSupervisorSnapshot = { targets: [], health: [] };
+
+// Behavior is steered per-test through these impl vars; the mocks just call them.
+let listImpl: () => Promise<PianolaSupervisorSnapshot>;
+let addImpl: () => Promise<PianolaSupervisorSnapshot>;
+let originalMaestro: typeof window.maestro;
+
+beforeEach(() => {
+	listImpl = () => Promise.resolve(emptySnap);
+	addImpl = () => Promise.resolve(watchSnap);
+	originalMaestro = window.maestro;
+	window.maestro = {
+		...window.maestro,
+		pianola: {
+			...window.maestro?.pianola,
+			supervisor: {
+				list: vi.fn(() => listImpl()),
+				add: vi.fn(() => addImpl()),
+				remove: vi.fn(() => Promise.resolve(emptySnap)),
+				setEnabled: vi.fn(() => Promise.resolve(emptySnap)),
+			},
+		},
+	} as typeof window.maestro;
+});
+
+afterEach(() => {
+	window.maestro = originalMaestro;
+	vi.clearAllMocks();
+});
+
+describe('usePianolaSupervisor', () => {
+	it('clears watched rows when Pianola becomes disabled', async () => {
+		listImpl = () => Promise.resolve(watchSnap);
+		const { result } = renderHook(() => usePianolaSupervisor());
+		await waitFor(() => expect(result.current.watched).toHaveLength(1));
+
+		// The gated channel now rejects (Electron wraps the message).
+		listImpl = () =>
+			Promise.reject(
+				new Error("Error invoking remote method 'pianola:supervisor-list': Error: PianolaDisabled")
+			);
+		await act(async () => {
+			result.current.refresh();
+		});
+		await waitFor(() => expect(result.current.watched).toHaveLength(0));
+	});
+
+	it('keeps the last snapshot on a transient IPC error (no flicker)', async () => {
+		listImpl = () => Promise.resolve(watchSnap);
+		const { result } = renderHook(() => usePianolaSupervisor());
+		await waitFor(() => expect(result.current.watched).toHaveLength(1));
+
+		listImpl = () => Promise.reject(new Error('ETIMEDOUT'));
+		await act(async () => {
+			result.current.refresh();
+		});
+		expect(result.current.watched).toHaveLength(1);
+	});
+
+	it('does not let a slow poll clobber a newer mutation', async () => {
+		const slowPoll = deferred<PianolaSupervisorSnapshot>();
+		listImpl = () => slowPoll.promise; // mount poll: stays pending
+		addImpl = () => Promise.resolve(watchSnap);
+
+		const { result } = renderHook(() => usePianolaSupervisor());
+		// A watch mutation resolves while the mount poll is still in flight.
+		await act(async () => {
+			await result.current.watch('a', 'x');
+		});
+		expect(result.current.watched).toHaveLength(1);
+
+		// The stale mount poll now resolves with pre-mutation (empty) state.
+		await act(async () => {
+			slowPoll.resolve(emptySnap);
+			await slowPoll.promise;
+		});
+		// The mutation result must survive the late, stale poll.
+		expect(result.current.watched).toHaveLength(1);
+	});
+});

--- a/src/renderer/components/PianolaDashboard/PianolaDashboard.tsx
+++ b/src/renderer/components/PianolaDashboard/PianolaDashboard.tsx
@@ -19,6 +19,9 @@ import {
 	MessageSquareReply,
 	EyeOff,
 	GitBranch,
+	Eye,
+	Plus,
+	X,
 } from 'lucide-react';
 import type { Theme } from '../../types';
 import { formatRelativeTime } from '../../../shared/formatters';
@@ -27,19 +30,23 @@ import {
 	type DashboardAgentRow,
 	type DashboardActivityRow,
 } from './usePianolaDashboardData';
+import { usePianolaSupervisor, type PianolaSupervisorState } from './usePianolaSupervisor';
+import type { PianolaSupervisedState } from '../../../main/pianola/pianola-supervisor';
 
 interface PianolaDashboardProps {
 	theme: Theme;
 	onJumpToAgent: (sessionId: string) => void;
 }
 
-/** A titled, icon-led section with a count and an empty-state line. */
+/** A titled, icon-led section with a count, an empty-state line, and an optional
+ * right-aligned header action. */
 function Section({
 	theme,
 	icon,
 	title,
 	count,
 	emptyLabel,
+	headerAction,
 	children,
 }: {
 	theme: Theme;
@@ -47,6 +54,7 @@ function Section({
 	title: string;
 	count: number;
 	emptyLabel: string;
+	headerAction?: React.ReactNode;
 	children: React.ReactNode;
 }): React.ReactElement {
 	return (
@@ -58,6 +66,7 @@ function Section({
 				{icon}
 				<span>{title}</span>
 				<span className="opacity-60">({count})</span>
+				{headerAction && <div className="ml-auto">{headerAction}</div>}
 			</div>
 			{count === 0 ? (
 				<div className="text-sm italic px-3 py-2" style={{ color: theme.colors.textDim }}>
@@ -207,11 +216,160 @@ function ActivityRow({
 	);
 }
 
+/** Status-dot color for a watched target's live daemon state. */
+function watchStateColor(theme: Theme, state?: PianolaSupervisedState): string {
+	switch (state) {
+		case 'running':
+			return theme.colors.success;
+		case 'backing-off':
+			return theme.colors.warning;
+		case 'failed':
+			return theme.colors.error;
+		default:
+			return theme.colors.textDim;
+	}
+}
+
+/**
+ * "Watched by Pianola": the live watch targets plus a "+ Watch an agent" picker
+ * that adds one through the same supervisor path the CLI uses. This is the
+ * in-app home for adding agents to Pianola's watch list.
+ */
+function WatchedSection({
+	theme,
+	onJumpToAgent,
+	supervisor,
+}: {
+	theme: Theme;
+	onJumpToAgent: (sessionId: string) => void;
+	supervisor: PianolaSupervisorState;
+}): React.ReactElement {
+	const { watched, watchable, watch, unwatch, setEnabled } = supervisor;
+	const [pickerOpen, setPickerOpen] = React.useState(false);
+
+	const addButton = (
+		<div className="relative">
+			<button
+				type="button"
+				disabled={watchable.length === 0}
+				onClick={() => setPickerOpen((o) => !o)}
+				className="flex items-center gap-1 text-xs px-2 py-1 rounded hover:bg-white/5 transition-colors disabled:opacity-40 disabled:cursor-default normal-case"
+				style={{ color: theme.colors.textDim }}
+				title={watchable.length === 0 ? 'No unwatched agents' : 'Watch an agent with Pianola'}
+			>
+				<Plus className="w-3.5 h-3.5" />
+				Watch an agent
+			</button>
+			{pickerOpen && watchable.length > 0 && (
+				<>
+					<button
+						type="button"
+						aria-hidden
+						tabIndex={-1}
+						className="fixed inset-0 z-40 cursor-default"
+						onClick={() => setPickerOpen(false)}
+					/>
+					<div
+						className="absolute right-0 mt-1 z-50 rounded shadow-lg overflow-y-auto scrollbar-thin whitespace-nowrap normal-case py-1"
+						style={{
+							minWidth: '12rem',
+							maxWidth: '20rem',
+							maxHeight: '15rem',
+							backgroundColor: theme.colors.bgSidebar,
+							border: `1px solid ${theme.colors.border}`,
+						}}
+					>
+						{watchable.map((a) => (
+							<button
+								key={a.agentId}
+								type="button"
+								onClick={() => {
+									setPickerOpen(false);
+									void watch(a.agentId, a.tabId);
+								}}
+								className="w-full text-left px-3 py-1.5 text-sm flex items-center gap-2 hover:bg-white/5 transition-colors"
+								style={{ color: theme.colors.textMain }}
+							>
+								<Eye className="w-3.5 h-3.5 shrink-0" style={{ color: theme.colors.textDim }} />
+								<span className="truncate">{a.agentName}</span>
+							</button>
+						))}
+					</div>
+				</>
+			)}
+		</div>
+	);
+
+	return (
+		<Section
+			theme={theme}
+			icon={<Eye className="w-3.5 h-3.5" style={{ color: theme.colors.accent }} />}
+			title="Watched by Pianola"
+			count={watched.length}
+			emptyLabel="No agents watched yet. Add one and Pianola babysits its questions."
+			headerAction={addButton}
+		>
+			{watched.map((row) => (
+				<div
+					key={row.targetId}
+					className="rounded px-3 py-2 flex items-center gap-3"
+					style={{
+						backgroundColor: theme.colors.bgSidebar,
+						borderLeft: `2px solid ${theme.colors.accent}`,
+					}}
+				>
+					<span
+						className="w-2 h-2 rounded-full shrink-0"
+						style={{ backgroundColor: watchStateColor(theme, row.state) }}
+						title={row.enabled ? (row.state ?? 'starting') : 'disabled'}
+					/>
+					<button
+						type="button"
+						onClick={() => onJumpToAgent(row.agentId)}
+						className="text-sm font-medium truncate flex-1 text-left hover:underline"
+						style={{ color: theme.colors.textMain }}
+						title={`Jump to ${row.agentName}`}
+					>
+						{row.agentName}
+					</button>
+					{row.lastError && (
+						<span
+							className="text-xs truncate max-w-[30%]"
+							style={{ color: theme.colors.error }}
+							title={row.lastError}
+						>
+							{row.lastError}
+						</span>
+					)}
+					<button
+						type="button"
+						onClick={() => void setEnabled(row.targetId, !row.enabled)}
+						className="text-xs px-2 py-0.5 rounded hover:bg-white/5 transition-colors shrink-0"
+						style={{ color: theme.colors.textDim }}
+						title={row.enabled ? 'Pause watching' : 'Resume watching'}
+					>
+						{row.enabled ? 'Disable' : 'Enable'}
+					</button>
+					<button
+						type="button"
+						onClick={() => void unwatch(row.targetId)}
+						className="p-1 rounded hover:bg-white/5 transition-colors shrink-0"
+						style={{ color: theme.colors.textDim }}
+						title="Stop watching"
+					>
+						<X className="w-3.5 h-3.5" />
+					</button>
+				</div>
+			))}
+		</Section>
+	);
+}
 export function PianolaDashboard({
 	theme,
 	onJumpToAgent,
 }: PianolaDashboardProps): React.ReactElement {
 	const { data, refresh } = usePianolaDashboardData();
+	const supervisor = usePianolaSupervisor();
 
 	return (
 		<div
@@ -224,7 +382,10 @@ export function PianolaDashboard({
 				</h2>
 				<button
 					type="button"
-					onClick={refresh}
+					onClick={() => {
+						refresh();
+						supervisor.refresh();
+					}}
 					className="flex items-center gap-1.5 text-xs px-2 py-1 rounded hover:bg-white/5 transition-colors"
 					style={{ color: theme.colors.textDim }}
 					title="Refresh"
@@ -233,6 +394,8 @@ export function PianolaDashboard({
 					Refresh
 				</button>
 			</div>
+
+			<WatchedSection theme={theme} onJumpToAgent={onJumpToAgent} supervisor={supervisor} />
 
 			<Section
 				theme={theme}

--- a/src/renderer/components/PianolaDashboard/usePianolaSupervisor.ts
+++ b/src/renderer/components/PianolaDashboard/usePianolaSupervisor.ts
@@ -177,12 +177,17 @@ export function usePianolaSupervisor(): PianolaSupervisorState {
 			} catch (err) {
 				mutationEpochRef.current += 1;
 				const error = err instanceof Error ? err : new Error(String(err));
+				// A watch toggle is a recoverable user action: surface the failure and,
+				// for unexpected errors, report it - then resolve rather than reject so a
+				// fire-and-forget click never becomes an unhandled rejection. Mirrors the
+				// PianolaModal rule/suggestion handlers (toast + gated captureException).
 				notifyToast({
 					color: 'red',
 					title: 'Pianola watch action failed',
 					message: `Could not ${action}: ${error.message}`,
 				});
-				captureException(error, { extra: { operation: 'pianola-supervisor-mutate', action } });
+				if (!isPianolaDisabled(error))
+					captureException(error, { tags: { feature: 'pianola' }, extra: { action } });
 			}
 		},
 		[]

--- a/src/renderer/components/PianolaDashboard/usePianolaSupervisor.ts
+++ b/src/renderer/components/PianolaDashboard/usePianolaSupervisor.ts
@@ -1,0 +1,173 @@
+/**
+ * Pianola supervisor (watch) state for the dashboard.
+ *
+ * The desktop `PianolaSupervisor` daemon keeps a "watch" child alive per
+ * supervised (tab, agent). The same registry is what `maestro-cli pianola
+ * supervise watch ...` writes; this hook is the in-app way to add/remove those
+ * watches from the Pianola Dashboard instead of the CLI.
+ *
+ * Pure derivation lives in `deriveWatchState` (testable without IPC); the hook
+ * adds the session-store subscription, the polled `supervisor.list()` fetch, and
+ * the add/remove/toggle actions. Every channel rejects with 'PianolaDisabled'
+ * when the Encore flag is off, which we treat as "nothing watched".
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useSessionStore } from '../../stores/sessionStore';
+import type { Session } from '../../types';
+import type { PianolaSupervisedTarget } from '../../../shared/pianola/storage';
+import type {
+	PianolaSupervisorHealth,
+	PianolaSupervisedState,
+} from '../../../main/pianola/pianola-supervisor';
+
+/** A currently-watched agent, with live daemon health when a child is running. */
+export interface WatchedAgentRow {
+	/** Supervisor target id, for setEnabled/remove. */
+	targetId: string;
+	agentId: string;
+	agentName: string;
+	enabled: boolean;
+	/** Live child state, when the daemon currently has one for this target. */
+	state?: PianolaSupervisedState;
+	lastError?: string;
+}
+
+/** An agent that can be watched: not Pianola, not already watched, has an AI tab. */
+export interface WatchableAgent {
+	agentId: string;
+	/** The AI tab the watch will babysit (active AI tab, else the first). */
+	tabId: string;
+	agentName: string;
+}
+
+/** Short id fallback for an agent whose session is no longer loaded. */
+function shortId(id: string): string {
+	return id.slice(0, 6);
+}
+
+/** The AI tab a watch should target: the active tab when it's an AI tab, else the first. */
+function watchableTabId(session: Session): string | undefined {
+	const aiTabIds = new Set(session.aiTabs.map((t) => t.id));
+	if (session.activeTabId && aiTabIds.has(session.activeTabId)) return session.activeTabId;
+	return session.aiTabs[0]?.id;
+}
+
+/**
+ * Pure derivation of the watch UI state from live sessions + the supervisor
+ * snapshot. `watched` lists existing watch targets (enriched with name + live
+ * health); `watchable` lists top-level, non-Pianola agents that have an AI tab
+ * and are not already watched, ready for the "+ Watch an agent" picker.
+ */
+export function deriveWatchState(
+	sessions: readonly Session[],
+	targets: readonly PianolaSupervisedTarget[],
+	health: readonly PianolaSupervisorHealth[]
+): { watched: WatchedAgentRow[]; watchable: WatchableAgent[] } {
+	const nameById = new Map(sessions.map((s) => [s.id, s.name] as const));
+	const healthById = new Map(health.map((h) => [h.id, h] as const));
+
+	const watchTargets = targets.filter(
+		(t) => t.kind === 'watch' && typeof t.agentId === 'string' && t.agentId.length > 0
+	);
+	const watched: WatchedAgentRow[] = watchTargets.map((t) => {
+		const agentId = t.agentId as string;
+		const h = healthById.get(t.id);
+		return {
+			targetId: t.id,
+			agentId,
+			agentName: nameById.get(agentId) ?? shortId(agentId),
+			enabled: t.enabled,
+			...(h ? { state: h.state } : {}),
+			...(h?.lastError ? { lastError: h.lastError } : {}),
+		};
+	});
+
+	const watchedAgentIds = new Set(watchTargets.map((t) => t.agentId));
+	const watchable: WatchableAgent[] = [];
+	for (const s of sessions) {
+		if (s.isPianola || s.parentSessionId || watchedAgentIds.has(s.id)) continue;
+		const tabId = watchableTabId(s);
+		if (!tabId) continue; // no AI tab -> nothing to babysit
+		watchable.push({ agentId: s.id, tabId, agentName: s.name });
+	}
+
+	return { watched, watchable };
+}
+
+const POLL_MS = 4000;
+
+export interface PianolaSupervisorState {
+	watched: WatchedAgentRow[];
+	watchable: WatchableAgent[];
+	watch: (agentId: string, tabId: string) => Promise<void>;
+	unwatch: (targetId: string) => Promise<void>;
+	setEnabled: (targetId: string, enabled: boolean) => Promise<void>;
+	refresh: () => void;
+}
+
+/**
+ * Live watch state. Subscribes to the session store and polls the supervisor
+ * registry; the mutators write through `window.maestro.pianola.supervisor` and
+ * apply the returned snapshot immediately so the UI updates without waiting for
+ * the next poll.
+ */
+export function usePianolaSupervisor(): PianolaSupervisorState {
+	const sessions = useSessionStore((s) => s.sessions);
+	const [targets, setTargets] = useState<PianolaSupervisedTarget[]>([]);
+	const [health, setHealth] = useState<PianolaSupervisorHealth[]>([]);
+	const [nonce, setNonce] = useState(0);
+
+	const refresh = useCallback(() => setNonce((n) => n + 1), []);
+
+	useEffect(() => {
+		let cancelled = false;
+		const tick = async () => {
+			try {
+				const snap = await window.maestro.pianola.supervisor.list();
+				if (!cancelled) {
+					setTargets(snap.targets);
+					setHealth(snap.health);
+				}
+			} catch {
+				// 'PianolaDisabled' or transient IPC error: leave the last snapshot.
+			}
+		};
+		void tick();
+		const id = setInterval(tick, POLL_MS);
+		return () => {
+			cancelled = true;
+			clearInterval(id);
+		};
+	}, [nonce]);
+
+	const { watched, watchable } = useMemo(
+		() => deriveWatchState(sessions, targets, health),
+		[sessions, targets, health]
+	);
+
+	const watch = useCallback(async (agentId: string, tabId: string) => {
+		const snap = await window.maestro.pianola.supervisor.add({
+			kind: 'watch',
+			agentId,
+			tabId,
+			enabled: true,
+		});
+		setTargets(snap.targets);
+		setHealth(snap.health);
+	}, []);
+
+	const unwatch = useCallback(async (targetId: string) => {
+		const snap = await window.maestro.pianola.supervisor.remove(targetId);
+		setTargets(snap.targets);
+		setHealth(snap.health);
+	}, []);
+
+	const setEnabled = useCallback(async (targetId: string, enabled: boolean) => {
+		const snap = await window.maestro.pianola.supervisor.setEnabled(targetId, enabled);
+		setTargets(snap.targets);
+		setHealth(snap.health);
+	}, []);
+
+	return { watched, watchable, watch, unwatch, setEnabled, refresh };
+}

--- a/src/renderer/components/PianolaDashboard/usePianolaSupervisor.ts
+++ b/src/renderer/components/PianolaDashboard/usePianolaSupervisor.ts
@@ -12,7 +12,7 @@
  * when the Encore flag is off, which we treat as "nothing watched".
  */
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useSessionStore } from '../../stores/sessionStore';
 import type { Session } from '../../types';
 import type { PianolaSupervisedTarget } from '../../../shared/pianola/storage';
@@ -20,6 +20,7 @@ import type {
 	PianolaSupervisorHealth,
 	PianolaSupervisedState,
 } from '../../../main/pianola/pianola-supervisor';
+import type { PianolaSupervisorSnapshot } from '../../../main/ipc/handlers/pianola';
 
 /** A currently-watched agent, with live daemon health when a child is running. */
 export interface WatchedAgentRow {
@@ -106,6 +107,12 @@ export interface PianolaSupervisorState {
 	refresh: () => void;
 }
 
+/** True when an IPC rejection is the gated 'PianolaDisabled' error (feature off). */
+function isPianolaDisabled(err: unknown): boolean {
+	const message = err instanceof Error ? err.message : String(err);
+	return message.includes('PianolaDisabled');
+}
+
 /**
  * Live watch state. Subscribes to the session store and polls the supervisor
  * registry; the mutators write through `window.maestro.pianola.supervisor` and
@@ -116,58 +123,78 @@ export function usePianolaSupervisor(): PianolaSupervisorState {
 	const sessions = useSessionStore((s) => s.sessions);
 	const [targets, setTargets] = useState<PianolaSupervisedTarget[]>([]);
 	const [health, setHealth] = useState<PianolaSupervisorHealth[]>([]);
-	const [nonce, setNonce] = useState(0);
+	// Mutations (add/remove/setEnabled) are authoritative: each bumps this epoch
+	// before and after its IPC call and always applies its returned snapshot. A
+	// poll captures the epoch when it starts and applies only if it is unchanged
+	// on resolve, so a poll overlapping a mutation can never clobber the newer
+	// mutation result with a stale snapshot.
+	const mutationEpochRef = useRef(0);
+	const mountedRef = useRef(true);
+	useEffect(() => {
+		mountedRef.current = true;
+		return () => {
+			mountedRef.current = false;
+		};
+	}, []);
 
-	const refresh = useCallback(() => setNonce((n) => n + 1), []);
+	const load = useCallback(async () => {
+		const epoch = mutationEpochRef.current;
+		try {
+			const snap = await window.maestro.pianola.supervisor.list();
+			if (mountedRef.current && mutationEpochRef.current === epoch) {
+				setTargets(snap.targets);
+				setHealth(snap.health);
+			}
+		} catch (err) {
+			// Feature turned off -> clear stale watched rows (nothing is watched when
+			// Pianola is disabled). A transient IPC error keeps the last snapshot so
+			// the list does not flicker; a mutation during the poll wins (epoch moved).
+			if (mountedRef.current && mutationEpochRef.current === epoch && isPianolaDisabled(err)) {
+				setTargets([]);
+				setHealth([]);
+			}
+		}
+	}, []);
 
 	useEffect(() => {
-		let cancelled = false;
-		const tick = async () => {
-			try {
-				const snap = await window.maestro.pianola.supervisor.list();
-				if (!cancelled) {
-					setTargets(snap.targets);
-					setHealth(snap.health);
-				}
-			} catch {
-				// 'PianolaDisabled' or transient IPC error: leave the last snapshot.
-			}
-		};
-		void tick();
-		const id = setInterval(tick, POLL_MS);
-		return () => {
-			cancelled = true;
-			clearInterval(id);
-		};
-	}, [nonce]);
+		void load();
+		const id = setInterval(() => void load(), POLL_MS);
+		return () => clearInterval(id);
+	}, [load]);
+
+	const mutate = useCallback(async (op: Promise<PianolaSupervisorSnapshot>): Promise<void> => {
+		mutationEpochRef.current += 1; // invalidate polls issued before this mutation
+		const snap = await op;
+		mutationEpochRef.current += 1; // invalidate polls issued during this mutation
+		if (mountedRef.current) {
+			setTargets(snap.targets);
+			setHealth(snap.health);
+		}
+	}, []);
+
+	const watch = useCallback(
+		(agentId: string, tabId: string) =>
+			mutate(
+				window.maestro.pianola.supervisor.add({ kind: 'watch', agentId, tabId, enabled: true })
+			),
+		[mutate]
+	);
+	const unwatch = useCallback(
+		(targetId: string) => mutate(window.maestro.pianola.supervisor.remove(targetId)),
+		[mutate]
+	);
+	const setEnabled = useCallback(
+		(targetId: string, enabled: boolean) =>
+			mutate(window.maestro.pianola.supervisor.setEnabled(targetId, enabled)),
+		[mutate]
+	);
 
 	const { watched, watchable } = useMemo(
 		() => deriveWatchState(sessions, targets, health),
 		[sessions, targets, health]
 	);
 
-	const watch = useCallback(async (agentId: string, tabId: string) => {
-		const snap = await window.maestro.pianola.supervisor.add({
-			kind: 'watch',
-			agentId,
-			tabId,
-			enabled: true,
-		});
-		setTargets(snap.targets);
-		setHealth(snap.health);
-	}, []);
-
-	const unwatch = useCallback(async (targetId: string) => {
-		const snap = await window.maestro.pianola.supervisor.remove(targetId);
-		setTargets(snap.targets);
-		setHealth(snap.health);
-	}, []);
-
-	const setEnabled = useCallback(async (targetId: string, enabled: boolean) => {
-		const snap = await window.maestro.pianola.supervisor.setEnabled(targetId, enabled);
-		setTargets(snap.targets);
-		setHealth(snap.health);
-	}, []);
+	const refresh = useCallback(() => void load(), [load]);
 
 	return { watched, watchable, watch, unwatch, setEnabled, refresh };
 }

--- a/src/renderer/components/PianolaDashboard/usePianolaSupervisor.ts
+++ b/src/renderer/components/PianolaDashboard/usePianolaSupervisor.ts
@@ -21,6 +21,8 @@ import type {
 	PianolaSupervisedState,
 } from '../../../main/pianola/pianola-supervisor';
 import type { PianolaSupervisorSnapshot } from '../../../main/ipc/handlers/pianola';
+import { notifyToast } from '../../stores/notificationStore';
+import { captureException } from '../../utils/sentry';
 
 /** A currently-watched agent, with live daemon health when a child is running. */
 export interface WatchedAgentRow {
@@ -162,30 +164,49 @@ export function usePianolaSupervisor(): PianolaSupervisorState {
 		return () => clearInterval(id);
 	}, [load]);
 
-	const mutate = useCallback(async (op: Promise<PianolaSupervisorSnapshot>): Promise<void> => {
-		mutationEpochRef.current += 1; // invalidate polls issued before this mutation
-		const snap = await op;
-		mutationEpochRef.current += 1; // invalidate polls issued during this mutation
-		if (mountedRef.current) {
-			setTargets(snap.targets);
-			setHealth(snap.health);
-		}
-	}, []);
+	const mutate = useCallback(
+		async (op: Promise<PianolaSupervisorSnapshot>, action: string): Promise<void> => {
+			mutationEpochRef.current += 1; // invalidate polls issued before this mutation
+			try {
+				const snap = await op;
+				mutationEpochRef.current += 1; // invalidate polls issued during this mutation
+				if (mountedRef.current) {
+					setTargets(snap.targets);
+					setHealth(snap.health);
+				}
+			} catch (err) {
+				mutationEpochRef.current += 1;
+				const error = err instanceof Error ? err : new Error(String(err));
+				notifyToast({
+					color: 'red',
+					title: 'Pianola watch action failed',
+					message: `Could not ${action}: ${error.message}`,
+				});
+				captureException(error, { extra: { operation: 'pianola-supervisor-mutate', action } });
+			}
+		},
+		[]
+	);
 
 	const watch = useCallback(
 		(agentId: string, tabId: string) =>
 			mutate(
-				window.maestro.pianola.supervisor.add({ kind: 'watch', agentId, tabId, enabled: true })
+				window.maestro.pianola.supervisor.add({ kind: 'watch', agentId, tabId, enabled: true }),
+				'start watching the agent'
 			),
 		[mutate]
 	);
 	const unwatch = useCallback(
-		(targetId: string) => mutate(window.maestro.pianola.supervisor.remove(targetId)),
+		(targetId: string) =>
+			mutate(window.maestro.pianola.supervisor.remove(targetId), 'stop watching the agent'),
 		[mutate]
 	);
 	const setEnabled = useCallback(
 		(targetId: string, enabled: boolean) =>
-			mutate(window.maestro.pianola.supervisor.setEnabled(targetId, enabled)),
+			mutate(
+				window.maestro.pianola.supervisor.setEnabled(targetId, enabled),
+				enabled ? 'resume watching' : 'pause watching'
+			),
 		[mutate]
 	);
 


### PR DESCRIPTION
## Problem
Adding an agent to Pianola's watch list was **CLI-only** (`maestro-cli pianola supervise watch <tabId> --agent <id>`). The supervisor IPC and preload bridge (`window.maestro.pianola.supervisor.{list,add,setEnabled,remove}`) already existed and are typed in `global.d.ts`, but nothing in the renderer called them, so there was no in-app way to see or manage what Pianola watches.

## Change
A pinned **"Watched by Pianola"** section at the top of the Pianola Dashboard (answering "where do we put the button?" - it lives right where you manage the workspace's agents):

- Lists current `watch` targets with the agent name, a **live health dot** (running / backing-off / failed / disabled from the daemon snapshot), the daemon `lastError` when present, an **enable/disable** toggle, and an **unwatch** button. Rows click-to-jump to the agent.
- A **`+ Watch an agent`** picker (rem-sized, `whitespace-nowrap`, click-away) lists top-level, non-Pianola agents that **have an AI tab** and **aren't already watched**; selecting one calls `supervisor.add({ kind: 'watch', agentId, tabId, enabled: true })`. It targets the agent's **active AI tab** (falling back to the first) - agents with no AI tab are excluded since a `watch` needs a `tabId`.
- The Dashboard's top **Refresh** now refreshes the watch snapshot too (the hook is lifted to `PianolaDashboard`).

All through the **same supervisor path the CLI uses** - deterministic, reuses the existing gated IPC, no new backend.

## Files
- `usePianolaSupervisor.ts` (new) - polled `supervisor.list()` hook + add/remove/toggle mutators; pure `deriveWatchState(sessions, targets, health)` returning `{ watched, watchable }`.
- `PianolaDashboard.tsx` - `Section` gains an optional `headerAction`; new `WatchedSection`; hook lifted to the top component so Refresh covers both.
- `deriveWatchState.test.ts` (new) - name/health/enabled enrichment, short-id fallback, `lastError`, orchestrate-target exclusion, watchable filtering (Pianola / children / already-watched / no-tab), and active-vs-first tab selection.

## Test
`deriveWatchState.test.ts` 6/6 green; full `npm run lint` typecheck clean; ESLint clean. Like the sibling Pianola PRs, its shard 2/2 inherits the pre-existing broken `SessionList` test on `rc` until #1269 merges and I rebase.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Watched by Pianola” section to the dashboard with live status indicators and health/error details.
  * Added controls to enable/disable monitoring, stop watching, and manage watched agents via a “Watch an agent” picker.
  * Updated refresh to reload both dashboard data and watched-agent state.
* **Bug Fixes**
  * Prevented UI flicker during transient supervisor/list failures and avoided stale polling overwriting recent changes.
* **Tests**
  * Added Vitest coverage for watch-state derivation and the supervisor hook, including success and failure scenarios (toasts/error reporting).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->