### PR TITLE
fix(left-bar): show provider name instead of raw toolType under agent name

### DIFF
--- a/src/renderer/components/SessionItem.tsx
+++ b/src/renderer/components/SessionItem.tsx
@@ -21,6 +21,7 @@ import { useSettingsStore } from '../stores/settingsStore';
 import { useSessionHasActiveOutage } from '../stores/retryStore';
 import { COLORBLIND_STATUS_COLORS } from '../constants/colorblindPalettes';
 import { abbreviateGroupName } from '../../shared/formatters';
+import { getAgentDisplayName } from '../../shared/agentMetadata';
 import type { Session, Group, Theme } from '../types';
 
 // ============================================================================
@@ -424,7 +425,7 @@ export const SessionItem = memo(function SessionItem({
 								{jumpNumber}
 							</div>
 						)}
-						<Activity className="w-3 h-3" /> {session.toolType}
+						<Activity className="w-3 h-3" /> {getAgentDisplayName(session.toolType)}
 						{session.sessionSshRemoteConfig?.enabled ? ' (SSH)' : ''}
 					</div>
 				)}


### PR DESCRIPTION
## Summary

Addresses the Left Bar improvement requested in #1274: the secondary line under an agent's name in the Left Bar rendered the raw `toolType` id (e.g. `claude-code`) rather than a friendly provider name.

This renders the provider display name via the canonical `getAgentDisplayName()` helper, so the subtext now reads **Claude Code**, **Codex**, **OpenCode**, **Factory Droid**, etc.

## Change

- `src/renderer/components/SessionItem.tsx`: metadata row now shows `getAgentDisplayName(session.toolType)` instead of the raw `session.toolType`.

## Notes

The reporter described the subtext as showing the Git branch. In current code the parent-agent subtext already renders the provider (`toolType`), just as the raw lowercase id; worktree children separately show their branch. This change delivers the core ask - a clean, human-readable provider name - without touching worktree branch display. Open to also surfacing the provider on worktree rows if that's wanted.

## Testing

- `tsc --noEmit` clean for touched files
- `vitest run SessionItemCue.test.tsx` (14 passed)

Closes #1274

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Session entries now display friendly agent names instead of internal tool identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->