### PR TITLE
fix(git-graph): monospace font + branch-colored text in Git graph

### DIFF
--- a/src/__tests__/renderer/components/GitGraphView.test.tsx
+++ b/src/__tests__/renderer/components/GitGraphView.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import {
+	buildGitGraphTemplate,
+	GIT_GRAPH_BRANCH_COLORS,
+} from '../../../renderer/components/GitGraphView';
+import type { Theme } from '../../../renderer/types';
+
+// Minimal theme stub - only the color fields the template reads.
+const theme = {
+	colors: {
+		accent: 'rgb(1, 2, 3)',
+		bgSidebar: 'rgb(10, 11, 12)',
+		textMain: 'rgb(255, 255, 255)',
+		border: 'rgb(50, 50, 50)',
+	},
+} as unknown as Theme;
+
+describe('buildGitGraphTemplate (issue #1278)', () => {
+	const template = buildGitGraphTemplate(theme);
+
+	it('uses the Maestro monospace stack for message, branch label, and tag fonts', () => {
+		expect(template.commit.message.font).toContain('JetBrains Mono');
+		expect(template.commit.message.font).toContain('monospace');
+		expect(template.branch.label.font).toContain('monospace');
+		expect(template.tag.font).toContain('monospace');
+		// No sans-serif should remain anywhere in the typography.
+		expect(template.commit.message.font).not.toContain('sans-serif');
+		expect(template.branch.label.font).not.toContain('sans-serif');
+	});
+
+	it('does not hardcode a flat message color, so text inherits its branch color', () => {
+		// @gitgraph only fills the message with the branch color when it is left
+		// undefined (withDefaultColor). A static textMain would break branch coloring.
+		expect(template.commit.message.color).toBeUndefined();
+		expect(template.commit.message.color).not.toBe(theme.colors.textMain);
+	});
+
+	it('leaves branch label text/stroke unset so the pill matches its branch color', () => {
+		expect(template.branch.label.color).toBeUndefined();
+		expect(template.branch.label.strokeColor).toBeUndefined();
+		// The pill background stays themed for legibility.
+		expect(template.branch.label.bgColor).toBe(theme.colors.bgSidebar);
+	});
+
+	it('drives every branch color from the shared palette (line + text single source)', () => {
+		const palette = GIT_GRAPH_BRANCH_COLORS(theme);
+		expect(template.colors).toEqual(palette);
+		// Theme accent leads the palette so the primary lane matches the app accent.
+		expect(template.colors[0]).toBe(theme.colors.accent);
+	});
+});

--- a/src/renderer/components/GitGraphView.tsx
+++ b/src/renderer/components/GitGraphView.tsx
@@ -10,6 +10,10 @@ import type { GitGraphNode } from '../services/git';
 // userland-built `GitgraphCore` instance type-checks against the `graph` prop.
 type ReactSvgElement = ReactElement<SVGElement>;
 
+// Maestro's monospace stack (mirrors `--font-mono` in index.css / tailwind.config).
+// SVG font strings need a size prefix, so callers build `<px>px ${MONO_FONT}`.
+const MONO_FONT = "'JetBrains Mono', 'Fira Code', 'Courier New', monospace";
+
 interface GitGraphViewProps {
 	nodes: GitGraphNode[];
 	theme: Theme;
@@ -28,62 +32,74 @@ function pickBranchFromRefs(refs: string[]): string | null {
 	return local || cleaned[0];
 }
 
+// Branch/lane color palette. Every branch line, dot, message and label pill
+// picks its color from here (via the branch's column), so a single source keeps
+// text and its branch line in sync.
+export const GIT_GRAPH_BRANCH_COLORS = (theme: Theme): string[] => [
+	theme.colors.accent,
+	'rgb(34, 197, 94)',
+	'rgb(59, 130, 246)',
+	'rgb(234, 179, 8)',
+	'rgb(168, 85, 247)',
+	'rgb(244, 63, 94)',
+	'rgb(20, 184, 166)',
+	'rgb(236, 72, 153)',
+];
+
+// Build the @gitgraph template from the active Maestro theme. Kept as a pure,
+// exported helper so its typography/color choices are unit-testable without
+// mounting an SVG (jsdom lacks getBBox, which @gitgraph's label layout needs).
+export function buildGitGraphTemplate(theme: Theme) {
+	return templateExtend(TemplateName.Metro, {
+		colors: GIT_GRAPH_BRANCH_COLORS(theme),
+		branch: {
+			lineWidth: 2,
+			spacing: 14,
+			label: {
+				display: true,
+				bgColor: theme.colors.bgSidebar,
+				// Leave `color`/`strokeColor` unset so @gitgraph falls back to the
+				// commit's branch color (see BranchLabel in @gitgraph/react), keeping
+				// each branch pill in sync with its line/dot color.
+				borderRadius: 4,
+				font: `10px ${MONO_FONT}`,
+			},
+		},
+		commit: {
+			// Slightly tighter than the Metro default for a denser, neater log.
+			spacing: 24,
+			hasTooltipInCompactMode: false,
+			dot: {
+				size: 5,
+				strokeWidth: 0,
+			},
+			message: {
+				display: true,
+				displayAuthor: false,
+				displayHash: false,
+				// Leave `color` unset so each commit message inherits its branch
+				// color (@gitgraph's withDefaultColor fills it from the same source
+				// as the branch line), instead of a flat textMain.
+				font: `12px ${MONO_FONT}`,
+			},
+		},
+		tag: {
+			bgColor: 'rgba(234, 179, 8, 0.2)',
+			color: 'rgb(234, 179, 8)',
+			strokeColor: 'rgb(234, 179, 8)',
+			borderRadius: 3,
+			font: `9px ${MONO_FONT}`,
+		},
+	});
+}
+
 export const GitGraphView = memo(function GitGraphView({
 	nodes,
 	theme,
 	onCommitClick,
 	selectedHash,
 }: GitGraphViewProps) {
-	const template = useMemo(
-		() =>
-			templateExtend(TemplateName.Metro, {
-				colors: [
-					theme.colors.accent,
-					'rgb(34, 197, 94)',
-					'rgb(59, 130, 246)',
-					'rgb(234, 179, 8)',
-					'rgb(168, 85, 247)',
-					'rgb(244, 63, 94)',
-					'rgb(20, 184, 166)',
-					'rgb(236, 72, 153)',
-				],
-				branch: {
-					lineWidth: 2,
-					spacing: 14,
-					label: {
-						display: true,
-						bgColor: theme.colors.bgSidebar,
-						color: theme.colors.textMain,
-						strokeColor: theme.colors.border,
-						borderRadius: 4,
-						font: '10px sans-serif',
-					},
-				},
-				commit: {
-					spacing: 26,
-					hasTooltipInCompactMode: false,
-					dot: {
-						size: 5,
-						strokeWidth: 0,
-					},
-					message: {
-						display: true,
-						displayAuthor: false,
-						displayHash: false,
-						color: theme.colors.textMain,
-						font: '12px sans-serif',
-					},
-				},
-				tag: {
-					bgColor: 'rgba(234, 179, 8, 0.2)',
-					color: 'rgb(234, 179, 8)',
-					strokeColor: 'rgb(234, 179, 8)',
-					borderRadius: 3,
-					font: '9px sans-serif',
-				},
-			}),
-		[theme]
-	);
+	const template = useMemo(() => buildGitGraphTemplate(theme), [theme]);
 
 	// Sort oldest → newest so we can build branches forward.
 	const ordered = useMemo(


### PR DESCRIPTION
## What

Typography + color polish for the Git graph (Git Log → **Graph** view), addressing the three asks in #1278:

1. **Monospace font** - the graph now uses Maestro's monospace stack (`JetBrains Mono` / `Fira Code` / `Courier New`) for commit messages, branch-label pills, and tags, matching the rest of the app instead of `sans-serif`.
2. **Branch-colored text** - each commit message (and its dot and branch-label pill) now inherits its branch's color, so the text and its branch line share one color. Previously all message text was a flat `textMain`.
3. **Layout polish** - commit spacing tightened slightly (26 → 24) for a denser, neater log.

## How

`@gitgraph` fills a commit's message/label color from the branch's color source **only when those fields are left unset** (`withDefaultColor` in `@gitgraph/core`; the `BranchLabel` fallback in `@gitgraph/react`). The template was explicitly setting `message.color`, `label.color`, and `label.strokeColor` to fixed theme colors, which is exactly what suppressed branch coloring. Removing those lets the library reuse the same per-branch color it already draws the line/dot with - a single source of truth, no manual color bookkeeping.

The template builder was extracted into a pure `buildGitGraphTemplate(theme)` helper so its typography/color choices are unit-testable without mounting SVG (jsdom lacks `getBBox`, which `@gitgraph`'s label layout needs).

## Base branch

Targets `rc`: the Git graph (Graph view) is an in-flight RC feature and does not exist on `main`.

## Tests

- New `GitGraphView.test.tsx`: asserts monospace fonts, no hardcoded message/label colors, and palette-driven branch colors.
- Existing `GitLogViewer.test.tsx` (78 tests) still green; `tsc` and ESLint clean.

## Validation note

This is a visual change - worth an eyeball on the Graph view to confirm the coloring/spacing reads well against a busy `--all` range.

closes #1278


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved Git graph typography with a consistent monospace font.
  * Refined commit spacing and branch label styling for better readability.
  * Updated branch colors to consistently follow the application theme.
  * Improved color inheritance so commit messages and labels better match their branches.

* **Tests**
  * Added coverage to verify Git graph typography, colors, and theme-based styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->