### PR TITLE
fix(browser-tab): right-click context menu inside embedded webview tabs

### DIFF
--- a/src/__tests__/main/app-lifecycle/window-manager.test.ts
+++ b/src/__tests__/main/app-lifecycle/window-manager.test.ts
@@ -18,6 +18,13 @@ let windowCloseHandler: (() => void) | null = null;
 const webContentsEventHandlers = new Map<string, (...args: any[]) => void>();
 const guestWebContentsEventHandlers = new Map<string, (...args: any[]) => void>();
 
+const mockGuestNavigationHistory = {
+	canGoBack: vi.fn(() => false),
+	goBack: vi.fn(),
+	canGoForward: vi.fn(() => false),
+	goForward: vi.fn(),
+};
+
 const mockGuestWebContents = {
 	getType: vi.fn(() => 'webview'),
 	setWindowOpenHandler: vi.fn(),
@@ -26,6 +33,17 @@ const mockGuestWebContents = {
 	}),
 	executeJavaScript: vi.fn().mockResolvedValue(undefined),
 	paste: vi.fn(),
+	// Edit + navigation surface used by the browser-tab context menu (#1065)
+	cut: vi.fn(),
+	copy: vi.fn(),
+	selectAll: vi.fn(),
+	copyImageAt: vi.fn(),
+	reload: vi.fn(),
+	replaceMisspelling: vi.fn(),
+	navigationHistory: mockGuestNavigationHistory,
+	session: {
+		addWordToSpellCheckerDictionary: vi.fn(),
+	},
 };
 
 // Per-partition panel session double for the plugin render-host branch.
@@ -147,13 +165,25 @@ const { mockScreen } = vi.hoisted(() => {
 	};
 });
 
+// Mock Menu / shell / clipboard for the browser-tab context menu (#1065)
+const mockMenuPopup = vi.fn();
+const mockBuildFromTemplate = vi.fn(() => ({ popup: mockMenuPopup }));
+const mockShellOpenExternal = vi.fn((..._args: unknown[]) => Promise.resolve());
+const mockClipboardWriteText = vi.fn();
+
 vi.mock('electron', () => ({
 	BrowserWindow: MockBrowserWindow,
 	ipcMain: {
 		handle: (...args: unknown[]) => mockHandle(...args),
 	},
 	Menu: {
-		buildFromTemplate: vi.fn(() => ({ popup: vi.fn() })),
+		buildFromTemplate: (...args: unknown[]) => mockBuildFromTemplate(...(args as [])),
+	},
+	shell: {
+		openExternal: (...args: unknown[]) => mockShellOpenExternal(...args),
+	},
+	clipboard: {
+		writeText: (...args: unknown[]) => mockClipboardWriteText(...args),
 	},
 	screen: {
 		getAllDisplays: () => mockScreen.getAllDisplays(),
@@ -225,6 +255,11 @@ describe('app-lifecycle/window-manager', () => {
 		// never bleeds between tests (a reused object would skip re-hardening).
 		mockPanelSessions.clear();
 		mockScreen.reset();
+		// Browser-tab context menu (#1065): restore default nav state + popup shape
+		// after clearAllMocks / restoreAllMocks strip the vi.fn implementations.
+		mockGuestNavigationHistory.canGoBack.mockReturnValue(false);
+		mockGuestNavigationHistory.canGoForward.mockReturnValue(false);
+		mockBuildFromTemplate.mockReturnValue({ popup: mockMenuPopup });
 
 		mockWindowStateStore = {
 			store: {
@@ -1803,6 +1838,261 @@ describe('app-lifecycle/window-manager', () => {
 					)
 				);
 			});
+		});
+	});
+
+	// Browser-tab right-click context menu (#1065). The guest <webview> gets no
+	// default context menu from Electron, so guest-webview-security wires one onto
+	// the attached guest webContents. All actions target the guest, not the host.
+	describe('browser-tab context menu (#1065)', () => {
+		const baseDeps = {
+			isDevelopment: false,
+			preloadPath: '/path/to/preload.js',
+			rendererProductionUrl: 'app://app/index.html',
+			devServerUrl: 'http://localhost:5173',
+			useNativeTitleBar: false,
+			autoHideMenuBar: false,
+		};
+
+		// Attaches a browser-tab guest and returns its `context-menu` handler.
+		async function attachGuestAndGetContextMenuHandler() {
+			const { createWindowManager } = await import('../../../main/app-lifecycle/window-manager');
+			const windowManager = createWindowManager({
+				windowStateStore: mockWindowStateStore as unknown as Parameters<
+					typeof createWindowManager
+				>[0]['windowStateStore'],
+				...baseDeps,
+			});
+			windowManager.createWindow();
+			const attachHandler = webContentsEventHandlers.get('did-attach-webview');
+			attachHandler?.({} as any, mockGuestWebContents as any);
+			return guestWebContentsEventHandlers.get('context-menu');
+		}
+
+		function makeParams(overrides: Record<string, unknown> = {}): any {
+			return {
+				isEditable: false,
+				editFlags: {
+					canCut: true,
+					canCopy: true,
+					canPaste: true,
+					canSelectAll: true,
+					canUndo: false,
+					canRedo: false,
+					canDelete: true,
+					canEditRichly: true,
+				},
+				misspelledWord: '',
+				dictionarySuggestions: [],
+				linkURL: '',
+				srcURL: '',
+				mediaType: 'none',
+				selectionText: '',
+				x: 0,
+				y: 0,
+				...overrides,
+			};
+		}
+
+		// Pull the template handed to Menu.buildFromTemplate on the latest popup.
+		function lastTemplate(): any[] {
+			const calls = mockBuildFromTemplate.mock.calls;
+			return calls[calls.length - 1][0] as unknown as any[];
+		}
+
+		function findItem(template: any[], label: string): any {
+			return template.find((item) => item.label === label);
+		}
+
+		it('registers a context-menu handler on the attached browser-tab guest', async () => {
+			const handler = await attachGuestAndGetContextMenuHandler();
+			expect(handler).toBeTruthy();
+		});
+
+		it('builds Cut/Copy/Paste/Select All for editable fields and acts on the guest', async () => {
+			const handler = await attachGuestAndGetContextMenuHandler();
+			handler?.({} as any, makeParams({ isEditable: true }));
+
+			const template = lastTemplate();
+			expect(findItem(template, 'Cut')).toBeTruthy();
+			expect(findItem(template, 'Copy')).toBeTruthy();
+			expect(findItem(template, 'Paste')).toBeTruthy();
+			expect(findItem(template, 'Select All')).toBeTruthy();
+
+			// Actions target the guest webContents, not the host window.
+			findItem(template, 'Paste').click();
+			expect(mockGuestWebContents.paste).toHaveBeenCalledTimes(1);
+			findItem(template, 'Cut').click();
+			expect(mockGuestWebContents.cut).toHaveBeenCalledTimes(1);
+			findItem(template, 'Select All').click();
+			expect(mockGuestWebContents.selectAll).toHaveBeenCalledTimes(1);
+
+			// The menu is popped over the host window.
+			expect(mockMenuPopup).toHaveBeenCalledWith(
+				expect.objectContaining({ window: expect.any(MockBrowserWindow) })
+			);
+		});
+
+		it('disables edit items when editFlags forbid the action', async () => {
+			const handler = await attachGuestAndGetContextMenuHandler();
+			handler?.(
+				{} as any,
+				makeParams({
+					isEditable: true,
+					editFlags: {
+						canCut: false,
+						canCopy: false,
+						canPaste: false,
+						canSelectAll: false,
+						canUndo: false,
+						canRedo: false,
+						canDelete: false,
+						canEditRichly: false,
+					},
+				})
+			);
+
+			const template = lastTemplate();
+			expect(findItem(template, 'Cut').enabled).toBe(false);
+			expect(findItem(template, 'Copy').enabled).toBe(false);
+			expect(findItem(template, 'Paste').enabled).toBe(false);
+			expect(findItem(template, 'Select All').enabled).toBe(false);
+		});
+
+		it('offers spellcheck suggestions and Add to Dictionary for a misspelled word', async () => {
+			const handler = await attachGuestAndGetContextMenuHandler();
+			handler?.(
+				{} as any,
+				makeParams({
+					isEditable: true,
+					misspelledWord: 'teh',
+					dictionarySuggestions: ['the', 'ten'],
+				})
+			);
+
+			const template = lastTemplate();
+			findItem(template, 'the').click();
+			expect(mockGuestWebContents.replaceMisspelling).toHaveBeenCalledWith('the');
+
+			findItem(template, 'Add to Dictionary').click();
+			expect(mockGuestWebContents.session.addWordToSpellCheckerDictionary).toHaveBeenCalledWith(
+				'teh'
+			);
+		});
+
+		it('shows "No suggestions" (disabled) when a misspelled word has none', async () => {
+			const handler = await attachGuestAndGetContextMenuHandler();
+			handler?.(
+				{} as any,
+				makeParams({ isEditable: true, misspelledWord: 'zzxq', dictionarySuggestions: [] })
+			);
+
+			const template = lastTemplate();
+			expect(findItem(template, 'No suggestions').enabled).toBe(false);
+		});
+
+		it('copies a link via clipboard and opens allowed http/https/mailto links externally', async () => {
+			const handler = await attachGuestAndGetContextMenuHandler();
+
+			for (const url of ['https://example.com/', 'http://example.com/', 'mailto:a@b.com']) {
+				mockShellOpenExternal.mockClear();
+				mockClipboardWriteText.mockClear();
+				handler?.({} as any, makeParams({ linkURL: url }));
+				const template = lastTemplate();
+
+				findItem(template, 'Copy Link').click();
+				expect(mockClipboardWriteText).toHaveBeenCalledWith(url);
+
+				const openItem = findItem(template, 'Open Link in Browser');
+				expect(openItem).toBeTruthy();
+				openItem.click();
+				expect(mockShellOpenExternal).toHaveBeenCalledWith(url);
+			}
+		});
+
+		it('never routes dangerous link schemes to shell.openExternal', async () => {
+			const handler = await attachGuestAndGetContextMenuHandler();
+
+			for (const url of [
+				'file:///etc/passwd',
+				'javascript:alert(1)',
+				'data:text/html,<script>1</script>',
+				'chrome://settings',
+				'not-a-url',
+			]) {
+				mockShellOpenExternal.mockClear();
+				handler?.({} as any, makeParams({ linkURL: url }));
+				const template = lastTemplate();
+
+				// Copy Link is still offered, but Open Link in Browser is withheld.
+				expect(findItem(template, 'Copy Link')).toBeTruthy();
+				expect(findItem(template, 'Open Link in Browser')).toBeUndefined();
+				expect(mockShellOpenExternal).not.toHaveBeenCalled();
+			}
+		});
+
+		it('offers Copy Image and Copy Image Address for images', async () => {
+			const handler = await attachGuestAndGetContextMenuHandler();
+			handler?.(
+				{} as any,
+				makeParams({ mediaType: 'image', srcURL: 'https://example.com/a.png', x: 12, y: 34 })
+			);
+
+			const template = lastTemplate();
+			findItem(template, 'Copy Image').click();
+			expect(mockGuestWebContents.copyImageAt).toHaveBeenCalledWith(12, 34);
+
+			findItem(template, 'Copy Image Address').click();
+			expect(mockClipboardWriteText).toHaveBeenCalledWith('https://example.com/a.png');
+		});
+
+		it('offers Copy for a text selection and acts on the guest', async () => {
+			const handler = await attachGuestAndGetContextMenuHandler();
+			handler?.({} as any, makeParams({ selectionText: 'hello world' }));
+
+			const template = lastTemplate();
+			findItem(template, 'Copy').click();
+			expect(mockGuestWebContents.copy).toHaveBeenCalledTimes(1);
+		});
+
+		it('always offers navigation and reflects back/forward availability', async () => {
+			const handler = await attachGuestAndGetContextMenuHandler();
+			mockGuestNavigationHistory.canGoBack.mockReturnValue(true);
+			mockGuestNavigationHistory.canGoForward.mockReturnValue(false);
+			handler?.({} as any, makeParams());
+
+			const template = lastTemplate();
+			const back = findItem(template, 'Back');
+			const forward = findItem(template, 'Forward');
+			expect(back.enabled).toBe(true);
+			expect(forward.enabled).toBe(false);
+
+			back.click();
+			expect(mockGuestNavigationHistory.goBack).toHaveBeenCalledTimes(1);
+			findItem(template, 'Reload').click();
+			expect(mockGuestWebContents.reload).toHaveBeenCalledTimes(1);
+		});
+
+		it('joins sections with separators without leading/trailing/doubled dividers', async () => {
+			const handler = await attachGuestAndGetContextMenuHandler();
+			handler?.(
+				{} as any,
+				makeParams({
+					linkURL: 'https://example.com/',
+					mediaType: 'image',
+					srcURL: 'https://example.com/a.png',
+					selectionText: 'sel',
+				})
+			);
+
+			const template = lastTemplate();
+			expect(template[0].type).not.toBe('separator');
+			expect(template[template.length - 1].type).not.toBe('separator');
+			for (let i = 1; i < template.length; i++) {
+				if (template[i].type === 'separator') {
+					expect(template[i - 1].type).not.toBe('separator');
+				}
+			}
 		});
 	});
 

--- a/src/main/app-lifecycle/guest-webview-security.ts
+++ b/src/main/app-lifecycle/guest-webview-security.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import type { BrowserWindow } from 'electron';
+import { Menu, shell, clipboard, type BrowserWindow } from 'electron';
 import { logger } from '../utils/logger';
 import { isAllowedBrowserTabPartition } from '../../shared/browserTabPartition';
 import {
@@ -117,6 +117,149 @@ function attachBrowserTabGuestSecurity(guestContents: BrowserTabGuestContents): 
 	});
 }
 
+// Protocols we're willing to hand to the system browser from a browser-tab
+// link's "Open Link in Browser" action. Anything else (file:, javascript:,
+// custom schemes) is dropped so a malicious page can't smuggle a dangerous URL
+// into shell.openExternal via the context menu.
+const EXTERNAL_LINK_PROTOCOLS = new Set(['http:', 'https:', 'mailto:']);
+
+function isExternallyOpenableLink(rawUrl: string): boolean {
+	try {
+		return EXTERNAL_LINK_PROTOCOLS.has(new URL(rawUrl).protocol);
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Builds the right-click context-menu template for embedded browser-tab
+ * (`<webview>`) content. Electron does not render any default context menu for
+ * guest webContents, so without this the right-click does nothing inside a
+ * browser tab (issue #1065).
+ *
+ * All actions operate on the *guest* webContents, not the host app window:
+ * edit roles can't be used here because a menu popped over the main window
+ * would target the wrong webContents, so each item calls the guest's edit /
+ * navigation methods directly. The privileged `guest.paste()` mirrors the
+ * Cmd/Ctrl+V handler above, which bypasses the web-facing clipboard-read
+ * permission the permission handler denies to webviews (issue #1063).
+ */
+function buildBrowserTabContextMenuTemplate(
+	guest: Electron.WebContents,
+	params: Electron.ContextMenuParams
+): Electron.MenuItemConstructorOptions[] {
+	const flags = params.editFlags;
+
+	// Editable fields get the full text-editing menu (plus spellcheck
+	// suggestions when Chromium flags a misspelled word). This is the path that
+	// matters most for login/form workflows inside browser tabs.
+	if (params.isEditable) {
+		const template: Electron.MenuItemConstructorOptions[] = [];
+
+		const suggestions = params.dictionarySuggestions ?? [];
+		if (params.misspelledWord) {
+			if (suggestions.length === 0) {
+				template.push({ label: 'No suggestions', enabled: false });
+			} else {
+				for (const suggestion of suggestions) {
+					template.push({
+						label: suggestion,
+						click: () => guest.replaceMisspelling(suggestion),
+					});
+				}
+			}
+			template.push(
+				{
+					label: 'Add to Dictionary',
+					click: () => guest.session.addWordToSpellCheckerDictionary(params.misspelledWord),
+				},
+				{ type: 'separator' }
+			);
+		}
+
+		template.push(
+			{ label: 'Cut', enabled: flags.canCut, click: () => guest.cut() },
+			{ label: 'Copy', enabled: flags.canCopy, click: () => guest.copy() },
+			{ label: 'Paste', enabled: flags.canPaste, click: () => guest.paste() },
+			{ type: 'separator' },
+			{ label: 'Select All', enabled: flags.canSelectAll, click: () => guest.selectAll() }
+		);
+		return template;
+	}
+
+	// Non-editable content: assemble independent sections (link, image,
+	// selection, navigation) and join them with separators so we never emit a
+	// leading, trailing, or doubled divider.
+	const sections: Electron.MenuItemConstructorOptions[][] = [];
+
+	if (params.linkURL) {
+		const linkURL = params.linkURL;
+		const linkSection: Electron.MenuItemConstructorOptions[] = [
+			{ label: 'Copy Link', click: () => clipboard.writeText(linkURL) },
+		];
+		if (isExternallyOpenableLink(linkURL)) {
+			linkSection.push({
+				label: 'Open Link in Browser',
+				click: () => {
+					void shell.openExternal(linkURL).catch((err) => {
+						logger.warn(`Failed to open link in browser: ${linkURL}`, 'Window', {
+							error: err instanceof Error ? err.message : String(err),
+						});
+					});
+				},
+			});
+		}
+		sections.push(linkSection);
+	}
+
+	if (params.mediaType === 'image' && params.srcURL) {
+		const srcURL = params.srcURL;
+		sections.push([
+			{ label: 'Copy Image', click: () => guest.copyImageAt(params.x, params.y) },
+			{ label: 'Copy Image Address', click: () => clipboard.writeText(srcURL) },
+		]);
+	}
+
+	if (params.selectionText.trim().length > 0) {
+		sections.push([{ label: 'Copy', enabled: flags.canCopy, click: () => guest.copy() }]);
+	}
+
+	// Navigation actions are always offered so right-clicking blank page
+	// background still produces a useful menu. canGoBack/goBack live on
+	// navigationHistory (the WebContents-level methods are deprecated).
+	const nav = guest.navigationHistory;
+	sections.push([
+		{ label: 'Back', enabled: nav.canGoBack(), click: () => nav.goBack() },
+		{ label: 'Forward', enabled: nav.canGoForward(), click: () => nav.goForward() },
+		{ label: 'Reload', click: () => guest.reload() },
+	]);
+
+	const template: Electron.MenuItemConstructorOptions[] = [];
+	sections.forEach((section, index) => {
+		if (index > 0) template.push({ type: 'separator' });
+		template.push(...section);
+	});
+	return template;
+}
+
+/**
+ * Wires a context-menu handler onto an attached browser-tab guest so
+ * right-clicking inside the embedded page shows a native menu whose actions
+ * target the guest webContents.
+ */
+function attachBrowserTabContextMenu(
+	guest: Electron.WebContents,
+	browserWindow: BrowserWindow
+): void {
+	guest.on('context-menu', (_event, params) => {
+		const template = buildBrowserTabContextMenuTemplate(guest, params);
+		// Defensive: the builder always emits a navigation section today, but guard
+		// against a future code path returning [] so we never popup() an empty menu.
+		if (template.length === 0) return;
+		Menu.buildFromTemplate(template).popup({ window: browserWindow });
+	});
+}
+
 /**
  * Restrict renderer-created webviews to the two sanctioned surfaces:
  * browser tabs (persist:maestro-browser-session-*) and plugin panels
@@ -179,6 +322,11 @@ export function attachGuestWebviewSecurity(
 		}
 
 		attachBrowserTabGuestSecurity(guestContents as BrowserTabGuestContents);
+
+		// Electron renders no default context menu for guest <webview> content,
+		// so right-click is dead inside browser tabs until we wire one up against
+		// the guest webContents (issue #1065).
+		attachBrowserTabContextMenu(guestContents as unknown as Electron.WebContents, browserWindow);
 
 		// Forward app shortcuts from the webview guest process to the renderer.
 		// When a <webview> has focus, keyboard events are trapped in its guest


### PR DESCRIPTION
Closes #1065

Fresh reimplementation of #1066 on the latest `rc`. The original PR could not be rebased: the rc multi-window refactor moved the `did-attach-webview` handler out of `window-manager.ts` into new modules, so the old branch's anchor no longer exists.

## Problem

Right-clicking inside an embedded Maestro browser tab did nothing. Electron renders no default context menu for guest `<webview>` content, so right-click was dead inside browser-tab pages.

## Fix

Wire a `context-menu` handler onto the guest webContents. Re-homed onto `src/main/app-lifecycle/guest-webview-security.ts`, which is where the rc refactor now owns the `did-attach-webview` browser-tab branch (alongside the existing `will-navigate`/`will-redirect` hardening and the privileged Cmd/Ctrl+V paste handler). All menu actions operate on the guest webContents, not the host window:

- **Editable fields:** Cut / Copy / Paste / Select All (enabled via `editFlags`), plus spellcheck suggestions and Add to Dictionary. Paste uses the privileged `guest.paste()`, mirroring the Cmd/Ctrl+V handler that bypasses the `clipboard-read` permission denied to webviews (#1063).
- **Selection:** Copy
- **Links:** Copy Link, Open Link in Browser
- **Images:** Copy Image, Copy Image Address
- **Background:** Back / Forward / Reload (state read from `navigationHistory`)

## Security: strict openExternal allowlist

"Open Link in Browser" routes through `shell.openExternal` only behind a strict protocol allowlist checked with `new URL().protocol`: `http:`, `https:`, `mailto:` are allowed; `file:`, `javascript:`, `data:`, custom schemes, and unparseable strings are dropped so a malicious page can't smuggle a dangerous URL into `shell.openExternal`. Copy actions use `clipboard.writeText` only. The item is withheld entirely (not just disabled) for disallowed schemes. Existing `will-navigate`/`will-redirect` navigation hardening is untouched.

## Tests

Adds 13 tests to `window-manager.test.ts` (which already exercises the guest `did-attach` security path) covering: handler registration, the editable menu + `editFlags` enable/disable, spellcheck suggestions and "No suggestions", link copy/open, the openExternal allowlist (allow http/https/mailto, reject file/javascript/data/custom/unparseable), image copy, selection copy, navigation state, and separator hygiene.

## Validation

- `tsc -p tsconfig.main.json`, `-p tsconfig.json`, `-p tsconfig.lint.json` all clean
- eslint clean on changed source
- Full pre-push suite green (34,597 passed)

Ready for review. Do not merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added right-click context menus to embedded browser tabs.
  * Added editing actions including cut, copy, paste, select all, spellcheck suggestions, and dictionary updates.
  * Added link, image, text-selection, and navigation actions.
  * Restricted external link opening to safe URL schemes.

* **Tests**
  * Added comprehensive coverage for context-menu actions, navigation controls, and unsafe-link handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->