### PR TITLE
feat(cli): add --visible flag to goal-run for desktop-owned Auto Runs

### DIFF
--- a/src/__tests__/cli/commands/goalRunVisible.test.ts
+++ b/src/__tests__/cli/commands/goalRunVisible.test.ts
@@ -1,0 +1,130 @@
+/**
+ * @file goalRunVisible.test.ts
+ * @description Tests for `maestro-cli goal-run --visible`, which hands the run
+ * to the desktop app so it appears as a live Auto Run (parity with the UI Go
+ * button) instead of running headless in the CLI process.
+ */
+
+import { describe, it, expect, vi, beforeEach, type MockInstance } from 'vitest';
+
+vi.mock('../../../cli/services/maestro-client', () => ({
+	withMaestroClient: vi.fn(),
+}));
+
+import { runVisibleGoalRun } from '../../../cli/commands/goal-run';
+import { withMaestroClient } from '../../../cli/services/maestro-client';
+
+const GOAL_CONFIG = { goal: 'Ship the thing', exitCriteria: 'tests pass', maxIterations: 5 };
+
+describe('goal-run --visible (runVisibleGoalRun)', () => {
+	let logSpy: MockInstance;
+	let errorSpy: MockInstance;
+	let exitSpy: MockInstance;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+		errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+		exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+	});
+
+	function mockDesktop(response: unknown): MockInstance {
+		const sendCommand = vi.fn().mockResolvedValue(response);
+		vi.mocked(withMaestroClient).mockImplementation(async (action) =>
+			action({ sendCommand } as never)
+		);
+		return sendCommand;
+	}
+
+	it('sends launch_goal_run and prints stable JSON identifiers with a deep link', async () => {
+		const sendCommand = mockDesktop({
+			type: 'launch_goal_run_result',
+			success: true,
+			tabId: 'tab-77',
+		});
+
+		await runVisibleGoalRun('agent-1', GOAL_CONFIG, true);
+
+		expect(sendCommand).toHaveBeenCalledWith(
+			{
+				type: 'launch_goal_run',
+				sessionId: 'agent-1',
+				goal: 'Ship the thing',
+				exitCriteria: 'tests pass',
+				maxIterations: 5,
+			},
+			'launch_goal_run_result'
+		);
+
+		const output = JSON.parse(logSpy.mock.calls[0][0]);
+		expect(output).toMatchObject({
+			ok: true,
+			mode: 'visible',
+			visible: true,
+			agent_id: 'agent-1',
+			tab_id: 'tab-77',
+			status: 'launched',
+			uri: 'maestro://session/agent-1/tab/tab-77',
+		});
+		expect(exitSpy).not.toHaveBeenCalled();
+	});
+
+	it('returns tab_id null and a session-only deep link when the desktop omits a tab id', async () => {
+		mockDesktop({ type: 'launch_goal_run_result', success: true });
+
+		await runVisibleGoalRun('agent-1', GOAL_CONFIG, true);
+
+		const output = JSON.parse(logSpy.mock.calls[0][0]);
+		expect(output.tab_id).toBeNull();
+		expect(output.uri).toBe('maestro://session/agent-1');
+	});
+
+	it('fails closed with MAESTRO_NOT_RUNNING when the desktop app is unreachable', async () => {
+		vi.mocked(withMaestroClient).mockRejectedValue(new Error('Maestro desktop app is not running'));
+
+		await runVisibleGoalRun('agent-1', GOAL_CONFIG, true);
+
+		const output = JSON.parse(logSpy.mock.calls[0][0]);
+		expect(output.type).toBe('error');
+		expect(output.code).toBe('MAESTRO_NOT_RUNNING');
+		expect(exitSpy).toHaveBeenCalledWith(1);
+	});
+
+	it('maps a busy rejection to AGENT_BUSY', async () => {
+		mockDesktop({
+			type: 'launch_goal_run_result',
+			success: false,
+			error: 'Agent "Worker" is busy',
+		});
+
+		await runVisibleGoalRun('agent-1', GOAL_CONFIG, true);
+
+		const output = JSON.parse(logSpy.mock.calls[0][0]);
+		expect(output.code).toBe('AGENT_BUSY');
+		expect(exitSpy).toHaveBeenCalledWith(1);
+	});
+
+	it('maps a non-busy rejection to VISIBLE_LAUNCH_REJECTED', async () => {
+		mockDesktop({
+			type: 'launch_goal_run_result',
+			success: false,
+			error: 'Session agent-1 not found',
+		});
+
+		await runVisibleGoalRun('agent-1', GOAL_CONFIG, true);
+
+		const output = JSON.parse(logSpy.mock.calls[0][0]);
+		expect(output.code).toBe('VISIBLE_LAUNCH_REJECTED');
+		expect(exitSpy).toHaveBeenCalledWith(1);
+	});
+
+	it('prints human-readable output (not JSON) when useJson is false', async () => {
+		mockDesktop({ type: 'launch_goal_run_result', success: true, tabId: 'tab-9' });
+
+		await runVisibleGoalRun('agent-1', GOAL_CONFIG, false);
+
+		const printed = logSpy.mock.calls.map((c) => String(c[0])).join('\n');
+		expect(printed).toContain('maestro://session/agent-1/tab/tab-9');
+		expect(errorSpy).not.toHaveBeenCalled();
+	});
+});

--- a/src/__tests__/main/web-server/web-server-factory.test.ts
+++ b/src/__tests__/main/web-server/web-server-factory.test.ts
@@ -53,6 +53,7 @@ vi.mock('../../../main/web-server/WebServer', () => {
 			setRefreshFileTreeCallback = vi.fn();
 			setRefreshAutoRunDocsCallback = vi.fn();
 			setConfigureAutoRunCallback = vi.fn();
+			setLaunchGoalRunCallback = vi.fn();
 			setSessionAutoRunFolderCallback = vi.fn();
 			setGetAutoRunDocsCallback = vi.fn();
 			setGetAutoRunDocContentCallback = vi.fn();

--- a/src/__tests__/renderer/hooks/useRemoteIntegration.test.ts
+++ b/src/__tests__/renderer/hooks/useRemoteIntegration.test.ts
@@ -141,11 +141,15 @@ describe('useRemoteIntegration', () => {
 		onRemoteConfigureAutoRun: vi.fn().mockImplementation(() => {
 			return () => {};
 		}),
+		onRemoteLaunchGoalRun: vi.fn().mockImplementation(() => {
+			return () => {};
+		}),
 		onRemoteSetAutoRunFolder: vi.fn().mockImplementation(() => {
 			return () => {};
 		}),
 		sendRemoteNewTabResponse: vi.fn(),
 		sendRemoteConfigureAutoRunResponse: vi.fn(),
+		sendRemoteLaunchGoalRunResponse: vi.fn(),
 		sendRemoteSetAutoRunFolderResponse: vi.fn(),
 		onRemoteGetAutoRunDocs: vi.fn().mockImplementation(() => {
 			return () => {};

--- a/src/cli/commands/goal-run.ts
+++ b/src/cli/commands/goal-run.ts
@@ -8,6 +8,8 @@ import { emitError } from '../output/jsonl';
 import { formatRunEvent, formatError, formatInfo, RunEvent } from '../output/formatter';
 import { checkAgentBusy } from '../services/agent-busy';
 import { runGoal } from '../services/goal-runner';
+import { withMaestroClient } from '../services/maestro-client';
+import { buildSessionDeepLink } from '../../shared/deep-link-urls';
 import type { GoalRunConfig } from '../../shared/goalDriven/types';
 
 interface GoalRunOptions {
@@ -16,6 +18,122 @@ interface GoalRunOptions {
 	json?: boolean;
 	verbose?: boolean;
 	history?: boolean; // --no-history -> history: false
+	/**
+	 * Hand the run to the running desktop app so it appears as a live Auto Run
+	 * in the same UI surface as the Go/Spec buttons, instead of running headless
+	 * in this CLI process. Fails closed when the desktop app is unreachable.
+	 */
+	visible?: boolean;
+}
+
+/**
+ * Substring signature of MaestroClient / socket-level failures that mean the
+ * desktop app is down or unreachable (as opposed to a command it rejected).
+ * Mirrors the mapping in `dispatch.ts` so `--visible` can fail closed with a
+ * dedicated code instead of a generic error.
+ */
+function isMaestroUnreachable(message: string): boolean {
+	const lower = message.toLowerCase();
+	return (
+		lower.includes('econnrefused') ||
+		lower.includes('connection refused') ||
+		lower.includes('websocket') ||
+		lower.includes('enotfound') ||
+		lower.includes('etimedout') ||
+		lower.includes('maestro desktop app is not running') ||
+		lower.includes('discovery file is stale') ||
+		lower.includes('not connected to maestro') ||
+		lower.includes('connection to maestro timed out')
+	);
+}
+
+/**
+ * Response envelope for the `launch_goal_run` desktop command.
+ */
+interface LaunchGoalRunResponse {
+	success?: boolean;
+	tabId?: string;
+	error?: string;
+}
+
+/**
+ * Hand a Goal-Driven Auto Run to the running desktop app so it runs as a
+ * visible, desktop-owned Auto Run (parity with the UI Go button) instead of
+ * headlessly in this CLI process.
+ *
+ * Fails closed: if the desktop app is unreachable we exit non-zero rather than
+ * silently falling back to a headless run, because the user explicitly opted
+ * into a visible run and their goal shouldn't run somewhere they can't see it.
+ */
+export async function runVisibleGoalRun(
+	agentId: string,
+	goalConfig: GoalRunConfig,
+	useJson: boolean
+): Promise<void> {
+	let result: LaunchGoalRunResponse;
+	try {
+		result = await withMaestroClient(async (client) => {
+			return client.sendCommand<LaunchGoalRunResponse>(
+				{
+					type: 'launch_goal_run',
+					sessionId: agentId,
+					goal: goalConfig.goal,
+					exitCriteria: goalConfig.exitCriteria,
+					maxIterations: goalConfig.maxIterations,
+				},
+				'launch_goal_run_result'
+			);
+		});
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		const unreachable = isMaestroUnreachable(message);
+		const code = unreachable ? 'MAESTRO_NOT_RUNNING' : 'VISIBLE_LAUNCH_FAILED';
+		const friendly = unreachable
+			? 'Maestro desktop is not running or not reachable. --visible requires the desktop app; re-run without --visible for a headless goal run.'
+			: `Failed to launch visible goal run: ${message}`;
+		if (useJson) {
+			emitError(friendly, code);
+		} else {
+			console.error(formatError(friendly));
+		}
+		process.exit(1);
+		return;
+	}
+
+	if (!result.success) {
+		const message = result.error || 'The desktop app rejected the visible goal run.';
+		// A busy agent surfaces here deterministically as a clear error so
+		// orchestrators can branch on it instead of guessing.
+		const code = /busy/i.test(message) ? 'AGENT_BUSY' : 'VISIBLE_LAUNCH_REJECTED';
+		if (useJson) {
+			emitError(message, code);
+		} else {
+			console.error(formatError(message));
+		}
+		process.exit(1);
+		return;
+	}
+
+	const tabId = result.tabId;
+	const uri = buildSessionDeepLink(agentId, tabId);
+	if (useJson) {
+		console.log(
+			JSON.stringify({
+				ok: true,
+				mode: 'visible',
+				visible: true,
+				agent_id: agentId,
+				session_id: agentId,
+				tab_id: tabId ?? null,
+				status: 'launched',
+				uri,
+			})
+		);
+	} else {
+		console.log(formatInfo('Visible Goal-Driven Auto Run launched in Maestro.'));
+		console.log(formatInfo(`Agent: ${agentId}`));
+		console.log(formatInfo(`Open: ${uri}`));
+	}
 }
 
 /**
@@ -77,6 +195,22 @@ export async function goalRun(
 				console.error(formatError(message));
 			}
 			process.exit(1);
+		}
+
+		// --visible hands the run to the desktop app, which owns spawning (using the
+		// agent's configured binary, SSH, etc.) and busy arbitration. Skip the
+		// headless-only preflight below (detectAgent / checkAgentBusy / runGoal).
+		if (options.visible) {
+			await runVisibleGoalRun(
+				agent.id,
+				{
+					goal: trimmedGoal,
+					exitCriteria: options.exitCriteria?.trim() ?? '',
+					maxIterations: parseMaxIterations(options.maxIterations, useJson),
+				},
+				useJson
+			);
+			return;
 		}
 
 		const detection = await detectAgent(agent.toolType);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -273,6 +273,10 @@ program
 	.option('--exit-criteria <text>', 'What "done" looks like and when to declare a deadlock')
 	.option('--max-iterations <n>', 'Cap iterations (default: infinite)')
 	.option('--no-history', 'Do not write history entries')
+	.option(
+		'--visible',
+		'Launch as a desktop-visible Auto Run (parity with the UI Go button); requires the running desktop app'
+	)
 	.option('--json', 'Output as JSON lines (for scripting)')
 	.option('--verbose', 'Show full prompt sent to agent on each iteration')
 	.action(async (agentId: string, goal: string, options: Record<string, unknown>) => {

--- a/src/main/preload/process.ts
+++ b/src/main/preload/process.ts
@@ -880,6 +880,54 @@ export function createProcessApi() {
 		},
 
 		/**
+		 * Subscribe to remote launch-goal-run from the CLI (`goal-run --visible`).
+		 * The renderer starts a visible Goal-Driven Auto Run and must ack via
+		 * sendRemoteLaunchGoalRunResponse with the AI tab it attached to.
+		 */
+		onRemoteLaunchGoalRun: (
+			callback: (
+				sessionId: string,
+				config: { goal: string; exitCriteria: string; maxIterations: number | null },
+				responseChannel: string
+			) => void
+		): (() => void) => {
+			const handler = (
+				_: unknown,
+				sessionId: string,
+				config: { goal: string; exitCriteria: string; maxIterations: number | null },
+				responseChannel: string
+			) => {
+				try {
+					// callback may return a promise even though typed as void
+					Promise.resolve(callback(sessionId, config, responseChannel)).catch((error) => {
+						ipcRenderer.send(responseChannel, {
+							success: false,
+							error: error instanceof Error ? error.message : String(error),
+						});
+					});
+				} catch (error) {
+					ipcRenderer.send(responseChannel, {
+						success: false,
+						error: error instanceof Error ? error.message : String(error),
+					});
+				}
+			};
+			ipcRenderer.on('remote:launchGoalRun', handler);
+			return () => ipcRenderer.removeListener('remote:launchGoalRun', handler);
+		},
+
+		/**
+		 * Send response for remote launch-goal-run. `tabId` is the AI tab the
+		 * visible run attached to, so the CLI can build a `maestro://` deep link.
+		 */
+		sendRemoteLaunchGoalRunResponse: (
+			responseChannel: string,
+			result: { success: boolean; tabId?: string; error?: string }
+		): void => {
+			ipcRenderer.send(responseChannel, result);
+		},
+
+		/**
 		 * Subscribe to remote create-worktree-agent from the CLI. Creates a new
 		 * agent in a git worktree branched off a parent agent, without Auto Run.
 		 */

--- a/src/main/web-server/WebServer.ts
+++ b/src/main/web-server/WebServer.ts
@@ -73,6 +73,7 @@ import type {
 	NewAITabWithPromptCallback,
 	RefreshAutoRunDocsCallback,
 	ConfigureAutoRunCallback,
+	LaunchGoalRunCallback,
 	SetSessionAutoRunFolderCallback,
 	GetThemeCallback,
 	GetBionifyReadingModeCallback,
@@ -466,6 +467,10 @@ export class WebServer {
 
 	setConfigureAutoRunCallback(callback: ConfigureAutoRunCallback): void {
 		this.callbackRegistry.setConfigureAutoRunCallback(callback);
+	}
+
+	setLaunchGoalRunCallback(callback: LaunchGoalRunCallback): void {
+		this.callbackRegistry.setLaunchGoalRunCallback(callback);
 	}
 
 	setSessionAutoRunFolderCallback(callback: SetSessionAutoRunFolderCallback): void {
@@ -917,6 +922,10 @@ export class WebServer {
 				sessionId: string,
 				config: Parameters<CallbackRegistry['configureAutoRun']>[1]
 			) => this.callbackRegistry.configureAutoRun(sessionId, config),
+			launchGoalRun: async (
+				sessionId: string,
+				config: Parameters<CallbackRegistry['launchGoalRun']>[1]
+			) => this.callbackRegistry.launchGoalRun(sessionId, config),
 			setSessionAutoRunFolder: async (sessionId: string, folderPath: string) =>
 				this.callbackRegistry.setSessionAutoRunFolder(sessionId, folderPath),
 			getSessions: () => this.callbackRegistry.getSessions(),

--- a/src/main/web-server/handlers/messageHandlers.ts
+++ b/src/main/web-server/handlers/messageHandlers.ts
@@ -249,6 +249,10 @@ export interface MessageHandlerCallbacks {
 			};
 		}
 	) => Promise<{ success: boolean; playbookId?: string; error?: string }>;
+	launchGoalRun: (
+		sessionId: string,
+		config: { goal: string; exitCriteria: string; maxIterations: number | null }
+	) => Promise<{ success: boolean; tabId?: string; error?: string }>;
 	setSessionAutoRunFolder: (
 		sessionId: string,
 		folderPath: string
@@ -559,6 +563,9 @@ export class WebSocketMessageHandler {
 				this.handleRefreshAutoRunDocs(client, message);
 				break;
 
+			case 'launch_goal_run':
+				this.handleLaunchGoalRun(client, message);
+				break;
 			case 'configure_auto_run':
 				this.handleConfigureAutoRun(client, message);
 				break;
@@ -1659,6 +1666,74 @@ export class WebSocketMessageHandler {
 			})
 			.catch((error) => {
 				this.sendError(client, `Failed to refresh auto-run docs: ${error.message}`);
+			});
+	}
+
+	/**
+	 * Handle launch_goal_run message - start a desktop-visible Goal-Driven Auto
+	 * Run on an agent so it appears in the same UI surface as the Go/Spec buttons.
+	 * Powers `maestro-cli goal-run --visible`.
+	 */
+	private handleLaunchGoalRun(client: WebClient, message: WebClientMessage): void {
+		const sessionId = typeof message.sessionId === 'string' ? message.sessionId : '';
+		const goal = typeof message.goal === 'string' ? message.goal.trim() : '';
+		// Goals can contain user-authored content with secrets or PII — log length only.
+		logger.info(
+			`[Web] Received launch_goal_run message: session=${sessionId}, goalLength=${goal.length}`,
+			LOG_CONTEXT
+		);
+
+		const sendErrorResult = (error: string) => {
+			this.send(client, {
+				type: 'launch_goal_run_result',
+				success: false,
+				error,
+				sessionId,
+				requestId: message.requestId,
+			});
+		};
+
+		if (!sessionId) {
+			sendErrorResult('Missing sessionId');
+			return;
+		}
+		if (!goal) {
+			sendErrorResult('Missing or empty goal');
+			return;
+		}
+
+		// maxIterations: null/undefined => infinite; otherwise a finite positive int.
+		let maxIterations: number | null = null;
+		if (message.maxIterations !== undefined && message.maxIterations !== null) {
+			const n = Number(message.maxIterations);
+			if (!Number.isFinite(n) || n < 1) {
+				sendErrorResult('maxIterations must be a positive integer or null');
+				return;
+			}
+			maxIterations = Math.floor(n);
+		}
+
+		const exitCriteria = typeof message.exitCriteria === 'string' ? message.exitCriteria : '';
+
+		if (!this.callbacks.launchGoalRun) {
+			sendErrorResult('Visible goal run not configured');
+			return;
+		}
+
+		this.callbacks
+			.launchGoalRun(sessionId, { goal, exitCriteria, maxIterations })
+			.then((result) => {
+				this.send(client, {
+					type: 'launch_goal_run_result',
+					success: result.success,
+					sessionId,
+					...(result.tabId ? { tabId: result.tabId } : {}),
+					...(result.error ? { error: result.error } : {}),
+					requestId: message.requestId,
+				});
+			})
+			.catch((error) => {
+				sendErrorResult(`Failed to launch goal run: ${error.message}`);
 			});
 	}
 

--- a/src/main/web-server/managers/CallbackRegistry.ts
+++ b/src/main/web-server/managers/CallbackRegistry.ts
@@ -29,6 +29,7 @@ import type {
 	NewAITabWithPromptCallback,
 	RefreshAutoRunDocsCallback,
 	ConfigureAutoRunCallback,
+	LaunchGoalRunCallback,
 	SetSessionAutoRunFolderCallback,
 	GetThemeCallback,
 	GetBionifyReadingModeCallback,
@@ -148,6 +149,7 @@ export interface WebServerCallbacks {
 	newAITabWithPrompt: NewAITabWithPromptCallback | null;
 	refreshAutoRunDocs: RefreshAutoRunDocsCallback | null;
 	configureAutoRun: ConfigureAutoRunCallback | null;
+	launchGoalRun: LaunchGoalRunCallback | null;
 	setSessionAutoRunFolder: SetSessionAutoRunFolderCallback | null;
 	getHistory: GetHistoryCallback | null;
 	getAutoRunDocs: GetAutoRunDocsCallback | null;
@@ -235,6 +237,7 @@ export class CallbackRegistry {
 		newAITabWithPrompt: null,
 		refreshAutoRunDocs: null,
 		configureAutoRun: null,
+		launchGoalRun: null,
 		setSessionAutoRunFolder: null,
 		getHistory: null,
 		getAutoRunDocs: null,
@@ -436,6 +439,14 @@ export class CallbackRegistry {
 	): Promise<{ success: boolean; playbookId?: string; error?: string }> {
 		if (!this.callbacks.configureAutoRun) return { success: false, error: 'Not configured' };
 		return this.callbacks.configureAutoRun(sessionId, config);
+	}
+
+	async launchGoalRun(
+		sessionId: string,
+		config: { goal: string; exitCriteria: string; maxIterations: number | null }
+	): Promise<{ success: boolean; tabId?: string; error?: string }> {
+		if (!this.callbacks.launchGoalRun) return { success: false, error: 'Not configured' };
+		return this.callbacks.launchGoalRun(sessionId, config);
 	}
 
 	async setSessionAutoRunFolder(
@@ -941,6 +952,10 @@ export class CallbackRegistry {
 
 	setConfigureAutoRunCallback(callback: ConfigureAutoRunCallback): void {
 		this.callbacks.configureAutoRun = callback;
+	}
+
+	setLaunchGoalRunCallback(callback: LaunchGoalRunCallback): void {
+		this.callbacks.launchGoalRun = callback;
 	}
 
 	setSessionAutoRunFolderCallback(callback: SetSessionAutoRunFolderCallback): void {

--- a/src/main/web-server/types.ts
+++ b/src/main/web-server/types.ts
@@ -490,6 +490,18 @@ export type ConfigureAutoRunCallback = (
 ) => Promise<{ success: boolean; playbookId?: string; error?: string }>;
 
 /**
+ * Callback type for launching a desktop-visible Goal-Driven Auto Run. Powers
+ * `maestro-cli goal-run --visible`: the desktop app starts the goal loop in the
+ * same UI surface as the Go/Spec buttons and returns the AI tab it attached to
+ * so the caller can build an addressable `maestro://` deep link.
+ */
+export type LaunchGoalRunResult = { success: boolean; tabId?: string; error?: string };
+export type LaunchGoalRunCallback = (
+	sessionId: string,
+	config: { goal: string; exitCriteria: string; maxIterations: number | null }
+) => Promise<LaunchGoalRunResult>;
+
+/**
  * Callback type for fetching current theme.
  */
 export type GetThemeCallback = () => Theme | null;

--- a/src/main/web-server/web-server-factory.ts
+++ b/src/main/web-server/web-server-factory.ts
@@ -1173,6 +1173,50 @@ export function createWebServerFactory(deps: WebServerFactoryDependencies) {
 			});
 		});
 
+		// Bridge for launching a desktop-visible Goal-Driven Auto Run (parity with
+		// the UI Go button) from `maestro-cli goal-run --visible`. Mirrors the
+		// `configureAutoRun` bridge but returns the AI tab id the run attached to so
+		// the CLI can hand back an addressable `maestro://` deep link.
+		server.setLaunchGoalRunCallback(async (sessionId, config) => {
+			const mainWindow = getMainWindow();
+			if (!mainWindow) {
+				logger.warn('mainWindow is null for launchGoalRun', 'WebServer');
+				return { success: false, error: 'Main window not available' };
+			}
+
+			return new Promise<{ success: boolean; tabId?: string; error?: string }>((resolve) => {
+				const responseChannel = `remote:launchGoalRun:response:${randomUUID()}`;
+				let resolved = false;
+
+				const handleResponse = (
+					_event: Electron.IpcMainEvent,
+					result: { success: boolean; tabId?: string; error?: string } | undefined
+				) => {
+					if (resolved) return;
+					resolved = true;
+					clearTimeout(timeoutId);
+					resolve(result || { success: false, error: 'No response' });
+				};
+
+				ipcMain.once(responseChannel, handleResponse);
+				if (!isWebContentsAvailable(mainWindow)) {
+					logger.warn('webContents is not available for launchGoalRun', 'WebServer');
+					ipcMain.removeListener(responseChannel, handleResponse);
+					resolve({ success: false, error: 'Web contents not available' });
+					return;
+				}
+				mainWindow.webContents.send('remote:launchGoalRun', sessionId, config, responseChannel);
+
+				const timeoutId = setTimeout(() => {
+					if (resolved) return;
+					resolved = true;
+					ipcMain.removeListener(responseChannel, handleResponse);
+					logger.warn(`launchGoalRun callback timed out for session ${sessionId}`, 'WebServer');
+					resolve({ success: false, error: 'Timeout' });
+				}, 10000);
+			});
+		});
+
 		// Set up callback for web server to update the Auto Run folder on a session.
 		// Mirrors `configureAutoRun` IPC pattern: bridge to renderer via remote IPC,
 		// renderer-side `handleAutoRunFolderSelected` reloads docs and persists the

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -508,6 +508,17 @@ interface MaestroAPI {
 			responseChannel: string,
 			result: { success: boolean; playbookId?: string; error?: string }
 		) => void;
+		onRemoteLaunchGoalRun: (
+			callback: (
+				sessionId: string,
+				config: { goal: string; exitCriteria: string; maxIterations: number | null },
+				responseChannel: string
+			) => void
+		) => () => void;
+		sendRemoteLaunchGoalRunResponse: (
+			responseChannel: string,
+			result: { success: boolean; tabId?: string; error?: string }
+		) => void;
 		onRemoteCreateWorktreeSession: (
 			callback: (
 				parentSessionId: string,

--- a/src/renderer/hooks/remote/useAppRemoteEventListeners.ts
+++ b/src/renderer/hooks/remote/useAppRemoteEventListeners.ts
@@ -576,6 +576,92 @@ export function useAppRemoteEventListeners(deps: UseAppRemoteEventListenersDeps)
 		}
 	});
 
+	// Handle remote launch-goal-run from the CLI (`goal-run --visible`). Starts a
+	// desktop-visible Goal-Driven Auto Run via the SAME entry point the UI Go
+	// button uses (startBatchRun with a goalConfig), so the run is owned by the
+	// desktop app and appears in the same Auto Run surface. Returns the AI tab it
+	// attached to so the CLI can build an addressable maestro:// deep link.
+	useEventListener('maestro:launchGoalRun', async (e: Event) => {
+		const { sessionId, config, responseChannel } = (e as CustomEvent).detail as {
+			sessionId: string;
+			config: { goal: string; exitCriteria: string; maxIterations: number | null };
+			responseChannel: string;
+		};
+
+		try {
+			const session =
+				sessionsRef.current.find((s) => s.id === sessionId) ||
+				selectSessionById(sessionId)(useSessionStore.getState());
+			if (!session) {
+				window.maestro.process.sendRemoteLaunchGoalRunResponse(responseChannel, {
+					success: false,
+					error: `Session ${sessionId} not found`,
+				});
+				return;
+			}
+
+			// Deterministic busy handling: refuse rather than queue behind existing
+			// work, mirroring the CLI's checkAgentBusy gate for headless goal runs.
+			if (session.state === 'busy' || session.state === 'connecting') {
+				window.maestro.process.sendRemoteLaunchGoalRunResponse(responseChannel, {
+					success: false,
+					error: `Agent "${session.name || session.id}" is busy`,
+				});
+				return;
+			}
+
+			const goal = config.goal?.trim() ?? '';
+			if (!goal) {
+				window.maestro.process.sendRemoteLaunchGoalRunResponse(responseChannel, {
+					success: false,
+					error: 'Missing or empty goal',
+				});
+				return;
+			}
+
+			// Resolve the AI tab the run is associated with so we can return an
+			// addressable id. Prefer the active tab when it's an AI tab; otherwise
+			// fall back to the first AI tab (goal runs are per-agent, so any AI tab
+			// surfaces the run).
+			const activeAiTab = session.aiTabs?.find((t) => t.id === session.activeTabId);
+			const tabId = activeAiTab?.id ?? session.aiTabs?.[0]?.id;
+
+			const batchConfig: BatchRunConfig = {
+				documents: [],
+				prompt: DEFAULT_BATCH_PROMPT,
+				loopEnabled: false,
+				maxLoops: null,
+				goalConfig: {
+					goal,
+					exitCriteria: config.exitCriteria ?? '',
+					maxIterations: config.maxIterations ?? null,
+				},
+			};
+
+			// Focus the agent so the run is immediately visible, matching the UI
+			// Go button (which runs on the focused agent).
+			setActiveSessionId(sessionId);
+
+			// Ack before starting: startBatchRun is long-running and would exceed the
+			// IPC/CLI timeout if awaited (same pattern as maestro:configureAutoRun).
+			window.maestro.process.sendRemoteLaunchGoalRunResponse(responseChannel, {
+				success: true,
+				...(tabId ? { tabId } : {}),
+			});
+
+			// Goal mode is document-less; folderPath is only stored in batch state.
+			startBatchRun(sessionId, batchConfig, session.autoRunFolderPath || '').catch((err) => {
+				logger.error('[Remote] Failed to start visible goal run:', undefined, err);
+			});
+		} catch (error) {
+			captureException(error, { extra: { sessionId, responseChannel } });
+			window.maestro.process.sendRemoteLaunchGoalRunResponse(responseChannel, {
+				success: false,
+				error: error instanceof Error ? error.message : String(error),
+			});
+		}
+	});
+
 	// Handle remote create-worktree-agent from the CLI. Creates a new agent in a
 	// git worktree branched off a parent agent, without an Auto Run playbook.
 	// Reuses spawnWorktreeAgentAndDispatch (the same helper the Auto Run launch

--- a/src/renderer/hooks/remote/useRemoteIntegration.ts
+++ b/src/renderer/hooks/remote/useRemoteIntegration.ts
@@ -774,6 +774,27 @@ export function useRemoteIntegration(deps: UseRemoteIntegrationDeps): UseRemoteI
 		};
 	}, []);
 
+	// Handle remote launch-goal-run from the CLI (`goal-run --visible`). Starts a
+	// desktop-visible Goal-Driven Auto Run in the same UI surface as the Go button.
+	useEffect(() => {
+		const unsubscribe = window.maestro.process.onRemoteLaunchGoalRun(
+			(
+				sessionId: string,
+				config: { goal: string; exitCriteria: string; maxIterations: number | null },
+				responseChannel: string
+			) => {
+				window.dispatchEvent(
+					new CustomEvent('maestro:launchGoalRun', {
+						detail: { sessionId, config, responseChannel },
+					})
+				);
+			}
+		);
+		return () => {
+			unsubscribe();
+		};
+	}, []);
+
 	// Handle remote create-worktree-agent from the CLI. Creates a new agent in a
 	// git worktree branched off a parent agent, without an Auto Run playbook.
 	useEffect(() => {


### PR DESCRIPTION
Closes #1286

## What

Adds `--visible` to `maestro-cli goal-run`:

```
maestro-cli goal-run --visible [--exit-criteria "..."] [--max-iterations N] [--json] <agent-id> "<goal>"
```

With `--visible`, the Goal-Driven Auto Run is handed to the **running desktop app** so it executes as a live, desktop-owned Auto Run in the **same UI surface as the Go/Spec buttons**, instead of running headless in the CLI process. This lets a root/orchestrator agent launch a monitored, UI-visible free-text Goal worker without handing control back to the user.

## How

The visible path threads a new `launch_goal_run` message through the **existing** CLI → desktop WebSocket bridge (the same four-layer path `dispatch --new-tab` and `auto-run --launch` already use) and terminates in the renderer at the exact `startBatchRun({ goalConfig })` entry point the UI **Go** button uses. There is no new run engine: the desktop owns spawning, busy arbitration, `stop-auto-run`, and `session list` visibility, so those requirements come for free.

Layers touched (all additive):
- **CLI**: `--visible` flag + `runVisibleGoalRun()` in `goal-run.ts`, registration in `index.ts`
- **Web server**: `launch_goal_run` message handler, callback registry/types, WebServer wiring
- **Main → renderer**: `remote:launchGoalRun` IPC bridge in `web-server-factory.ts`, preload subscription
- **Renderer**: `maestro:launchGoalRun` remote event listener that builds a `goalConfig` and calls `startBatchRun`

## Behavior / contract

- **Backward compatible**: headless `goal-run` stays the default; `--visible` is purely additive (no deletions).
- **Fails closed**: `--visible` errors with `MAESTRO_NOT_RUNNING` when the desktop app is unreachable rather than silently falling back to headless.
- **Deterministic busy handling**: a busy agent returns a clear `AGENT_BUSY` error.
- **`--json`** returns stable identifiers plus a deep link:
  ```json
  { "ok": true, "mode": "visible", "visible": true, "agent_id": "...", "session_id": "...", "tab_id": "...", "status": "launched", "uri": "maestro://session/<id>/tab/<id>" }
  ```

## Scope notes / open questions for the author

The issue's "recommended" API also listed `--new-tab` / `--tab` / `--focus/--no-focus` / `--wait` and a `run_id`. This PR intentionally implements the **core UI-parity MVP** the issue calls the key requirement, and leaves those out for now because:
- Goal-Driven Auto Runs are modeled **per-agent** (batch state keyed by session/agent id), not per-tab, so `--new-tab`/`--tab` don't map cleanly onto the existing engine. The run attaches to the agent and surfaces on its active AI tab, which is what we return as `tab_id`.
- `run_id` / provider `session_id` aren't known synchronously at launch (the provider session is assigned after the first agent turn), so they're omitted rather than faked.
- Busy is handled as a deterministic clear error, which the issue lists as acceptable in lieu of `--wait`.

Happy to extend any of these if you'd prefer the fuller surface.

## Tests

- New `src/__tests__/cli/commands/goalRunVisible.test.ts` covers the visible path: message shape, JSON identifiers + deep link, fail-closed (`MAESTRO_NOT_RUNNING`), `AGENT_BUSY`, generic rejection, and human-readable output.
- Updated existing web-server-factory and useRemoteIntegration mocks for the new bridge method.
- `npm run lint` (all tsconfigs) and the CLI + web-server + goalDriven + remote-integration suites pass locally.

> Note: local validation is single-OS; CI (ubuntu + windows) is the source of truth before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `goal-run --visible` to launch Goal-Driven Auto Runs in the desktop interface.
  * Displays a deep link to the launched run in JSON or human-readable format.
  * Added validation and clear errors for unavailable, busy, or rejected launches.
  * Added desktop-to-CLI communication for starting visible runs and reporting results.

* **Tests**
  * Added coverage for successful launches, deep-link formatting, missing sessions, busy agents, desktop connectivity, and rejection errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->