### PR TITLE
ci(release): build Linux x64 on ubuntu-22.04 and guard the glibc floor

### DIFF
--- a/.github/scripts/verify-glibc-floor.sh
+++ b/.github/scripts/verify-glibc-floor.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# verify-glibc-floor.sh - Fail the build if any shipped x86-64 native module
+# requires a glibc symbol version newer than the supported floor.
+#
+# Why this exists: the Linux native modules (better-sqlite3, node-pty, ...) are
+# compiled from source on the CI runner, so their glibc floor is whatever the
+# runner's toolchain happens to provide. If the runner base image drifts to a
+# newer glibc, the shipped .node files start requiring newer versioned symbols
+# and silently fail to load on older-but-still-supported distros. That is what
+# broke Ubuntu 22.04 (glibc 2.35): better_sqlite3.node ended up needing a
+# GLIBC_2.38 symbol, so the Cue and stats databases failed to initialize.
+#
+# This guard is a cheap insurance net that runs regardless of which runner built
+# the package: it inspects the actual packaged binaries and fails loudly if the
+# floor was exceeded.
+#
+# Usage: ./verify-glibc-floor.sh <max-glibc> <search-dir>
+#   max-glibc:  highest allowed glibc version, e.g. 2.35 (Ubuntu 22.04)
+#   search-dir: directory scanned recursively for *.node files
+
+set -euo pipefail
+
+MAX_GLIBC="${1:?Usage: $0 <max-glibc> <search-dir>}"
+SEARCH_DIR="${2:?Usage: $0 <max-glibc> <search-dir>}"
+
+if ! command -v readelf >/dev/null 2>&1; then
+	echo "✗ ERROR: readelf not found (install binutils)" >&2
+	exit 1
+fi
+if [ ! -d "$SEARCH_DIR" ]; then
+	echo "✗ ERROR: search dir not found: $SEARCH_DIR" >&2
+	exit 1
+fi
+
+# ver_gt A B -> success (0) when A > B, using version-aware ordering.
+ver_gt() {
+	[ "$1" != "$2" ] && [ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | tail -n1)" = "$1" ]
+}
+
+mapfile -t NODES < <(find "$SEARCH_DIR" -name '*.node' -type f 2>/dev/null | sort)
+if [ "${#NODES[@]}" -eq 0 ]; then
+	echo "✗ ERROR: no .node files found under $SEARCH_DIR" >&2
+	exit 1
+fi
+
+echo "Checking glibc floor (max allowed: GLIBC_${MAX_GLIBC}) across ${#NODES[@]} native module(s)..."
+FAIL=0
+CHECKED=0
+for bin in "${NODES[@]}"; do
+	rel="${bin#"$SEARCH_DIR"/}"
+	# Only x86-64 ELF objects matter for the x64 glibc floor. Skip Windows PE
+	# prebuilds and foreign-arch (arm64) prebuilds that node-pty bundles.
+	info=$(file -b "$bin" 2>/dev/null || echo "")
+	case "$info" in
+		*ELF*x86-64* | *ELF*x86_64*) ;;
+		*)
+			echo "  - skip (not x86-64 ELF): $rel"
+			continue
+			;;
+	esac
+	# Highest GLIBC_x.y[.z] versioned symbol this binary requires. Empty for
+	# musl-linked or statically linked objects (no glibc symbol versioning).
+	max_req=$(readelf -V "$bin" 2>/dev/null \
+		| grep -oE 'GLIBC_[0-9]+(\.[0-9]+)+' \
+		| sed 's/^GLIBC_//' \
+		| sort -V \
+		| tail -n1 || true)
+	if [ -z "$max_req" ]; then
+		echo "  - skip (no glibc symbol versions, musl/static): $rel"
+		continue
+	fi
+	CHECKED=$((CHECKED + 1))
+	if ver_gt "$max_req" "$MAX_GLIBC"; then
+		echo "  ✗ $rel requires GLIBC_${max_req} (> floor GLIBC_${MAX_GLIBC})"
+		FAIL=1
+	else
+		echo "  ✓ $rel: max GLIBC_${max_req} (<= GLIBC_${MAX_GLIBC})"
+	fi
+done
+
+if [ "$CHECKED" -eq 0 ]; then
+	echo "✗ ERROR: no x86-64 glibc-linked .node files were inspected under $SEARCH_DIR" >&2
+	exit 1
+fi
+
+if [ "$FAIL" -ne 0 ]; then
+	echo ""
+	echo "✗ One or more native modules exceed the GLIBC_${MAX_GLIBC} floor."
+	echo "  This package would fail to load on Ubuntu 22.04 (glibc 2.35) with a"
+	echo "  \"version 'GLIBC_x.y' not found\" error at native-module load time."
+	echo "  Fix: build the native modules against an older glibc - pin the release"
+	echo "  runner to ubuntu-22.04 or build inside an older-glibc container."
+	exit 1
+fi
+
+echo "All x86-64 native modules are within the GLIBC_${MAX_GLIBC} floor."

--- a/.github/scripts/verify-glibc-floor.sh
+++ b/.github/scripts/verify-glibc-floor.sh
@@ -37,7 +37,19 @@ ver_gt() {
 	[ "$1" != "$2" ] && [ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | tail -n1)" = "$1" ]
 }
 
-mapfile -t NODES < <(find "$SEARCH_DIR" -name '*.node' -type f 2>/dev/null | sort)
+# List candidate modules, failing closed on any scan error: a partial scan that
+# silently drops a binary (e.g. a permission error on a subdir) must not let an
+# over-floor module slip through undetected.
+find_out="$(mktemp)"
+find_err="$(mktemp)"
+if ! find "$SEARCH_DIR" -name '*.node' -type f >"$find_out" 2>"$find_err" || [ -s "$find_err" ]; then
+	echo "✗ ERROR: scanning $SEARCH_DIR for .node files failed:" >&2
+	sed 's/^/    /' "$find_err" >&2
+	rm -f "$find_out" "$find_err"
+	exit 1
+fi
+mapfile -t NODES < <(sort "$find_out")
+rm -f "$find_out" "$find_err"
 if [ "${#NODES[@]}" -eq 0 ]; then
 	echo "✗ ERROR: no .node files found under $SEARCH_DIR" >&2
 	exit 1
@@ -58,9 +70,21 @@ for bin in "${NODES[@]}"; do
 			continue
 			;;
 	esac
-	# Highest GLIBC_x.y[.z] versioned symbol this binary requires. Empty for
-	# musl-linked or statically linked objects (no glibc symbol versioning).
-	max_req=$(readelf -V "$bin" 2>/dev/null \
+	# Read the ELF version info once, failing closed on a readelf error. A bare
+	# `readelf ... || true` would turn a parse failure into an empty result and
+	# skip the binary as "musl/static" - an x86-64 .node we cannot inspect must
+	# fail the guard instead of slipping through.
+	if ! readelf_out=$(readelf -V "$bin" 2>&1); then
+		echo "  ✗ ERROR: readelf failed on $rel (failing closed):" >&2
+		printf '%s\n' "$readelf_out" | sed 's/^/      /' >&2
+		FAIL=1
+		continue
+	fi
+	# Highest GLIBC_x.y[.z] version this binary requires, taken ONLY from the
+	# version-needs section (.gnu.version_r) so the symbol/def tables can't skew
+	# the result. Empty for musl-linked or statically linked objects.
+	max_req=$(printf '%s\n' "$readelf_out" \
+		| awk "/Version needs section/{needs=1; next} /section '/{needs=0} needs" \
 		| grep -oE 'GLIBC_[0-9]+(\.[0-9]+)+' \
 		| sed 's/^GLIBC_//' \
 		| sort -V \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,16 @@ jobs:
           - os: macos-15
             platform: mac
             arch: universal
-          - os: ubuntu-latest
+          # Pinned to ubuntu-22.04 (not ubuntu-latest). The x64 native modules
+          # (better-sqlite3, node-pty) are compiled from source on this runner,
+          # so the runner's glibc sets the floor for the shipped binaries.
+          # ubuntu-latest is a moving label (now 24.04, glibc 2.39); building on a
+          # newer glibc can raise that floor above Ubuntu 22.04's glibc 2.35, which
+          # makes the native modules fail to load there with "version 'GLIBC_x.y'
+          # not found" (this has broken the Cue and stats databases on 22.04 before).
+          # 22.04 is the oldest supported target, so keep this pinned. Enforced per
+          # build by .github/scripts/verify-glibc-floor.sh.
+          - os: ubuntu-22.04
             platform: linux
             arch: x64
           # ARM64 Linux requires native ARM64 runner for node-pty native module
@@ -405,6 +414,14 @@ jobs:
             find "$UNPACKED_DIR" -name "*.node" 2>/dev/null || echo "Directory not found"
             exit 1
           fi
+
+      # Guard the glibc floor: fail the build if any shipped x64 native module
+      # requires a glibc newer than Ubuntu 22.04 provides (glibc 2.35). This is a
+      # backstop against runner/toolchain drift silently re-breaking 22.04 users,
+      # and runs regardless of which image built the package.
+      - name: Verify GLIBC floor (Linux x64)
+        if: matrix.platform == 'linux'
+        run: .github/scripts/verify-glibc-floor.sh 2.35 release/linux-unpacked/resources/app.asar.unpacked
 
       # Verify native modules are correctly included in unpacked resources (Linux ARM64)
       - name: Verify native modules in package (Linux ARM64)


### PR DESCRIPTION
## Problem

The Linux x64 native modules (`better-sqlite3`, `node-pty`) are compiled from source on the release runner (`npm run postinstall` -> `electron-rebuild`, with prebuilds deliberately removed to force from-source), so **the runner's glibc sets the symbol-version floor of the shipped binaries**.

The x64 release leg runs on `ubuntu-latest`, a moving label that now points at Ubuntu 24.04 (glibc 2.39). Building native modules on a newer glibc can raise their floor above what Ubuntu 22.04 provides (glibc 2.35). When that happens the modules fail to load at runtime with:

```
/lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.38' not found
(required by .../better-sqlite3/build/Release/better_sqlite3.node)
```

Because both the Cue database (`src/main/cue/cue-db.ts`) and the stats database (`src/main/stats/stats-db.ts`) load `better-sqlite3`, this takes out both. `cue-recovery-service.ts` catches the init failure and logs `[CUE] Failed to initialize Cue database - engine will not start`, and `cue-engine.ts` bails out of `start()` on that failure, so the engine never runs and the UI shows paused/disabled with the toggle doing nothing. It is a system-library mismatch, not a config problem, so no `cue.yaml` change can fix it.

## Fix

1. **Pin the x64 release leg to `ubuntu-22.04`** (the oldest supported target, glibc 2.35) so the floor cannot drift. This mirrors the existing deliberate pins for `macos-15` and `ubuntu-24.04-arm`.
2. **Add `.github/scripts/verify-glibc-floor.sh`** and run it after the x64 packaging/verify step. It scans every shipped x86-64 `.node` in the unpacked resources and fails the build if any requires a glibc newer than 2.35. It skips musl-linked and foreign-arch (arm64 / Windows PE) prebuilds that `node-pty` bundles. This is a backstop that holds regardless of which image built the package.

## Verification

Ran the guard against the actual packaged binaries from a current Linux build:

- Floor `2.35`: **passes** (exit 0). Checks `better_sqlite3.node`, `pty.node`, `node-pty/bin`, `prebuilds/linux-x64/pty.node`, `keyring-linux-x64-gnu`; correctly skips the musl keyring and the darwin/arm64/win32 prebuilds.
- Floor `2.33`: **fails** (exit 1) on the `GLIBC_2.34` binaries, proving it catches violations rather than passing vacuously.

`release.yml` parses as valid YAML; the script passes `bash -n`. No em/en dashes introduced.

## Scope / follow-up

ARM64 (`ubuntu-24.04-arm`) is intentionally left unchanged in this PR to avoid destabilizing that carefully-tuned runner (fpm/ruby setup), and because the reported failure is x86_64. It has the same theoretical exposure; a matching pin (`ubuntu-22.04-arm`) plus the same guard is a sensible follow-up if ARM 22.04 support is required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux release compatibility by ensuring shipped native modules remain compatible with the GLIBC version provided by Ubuntu 22.04.
  * Added automated packaging checks that verify native `.node` modules won’t require a newer GLIBC than the release target supports before a release is published.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->