### PR TITLE
fix(test): make token-usage account discovery test cross-platform (fixes windows CI)

### DIFF
--- a/src/__tests__/main/stats/token-usage/token-usage-accounts.test.ts
+++ b/src/__tests__/main/stats/token-usage/token-usage-accounts.test.ts
@@ -36,6 +36,19 @@ import { _internal } from '../../../../main/stats/token-usage/token-usage-access
 
 const { discoverClaudeAccounts } = _internal;
 
+// Build fixture paths through path.resolve/path.join so they match what the
+// accessor produces (`path.resolve(dir)`) on every platform. On POSIX these
+// stay `/home/u/.claude`; on Windows path.resolve rewrites a drive-less
+// absolute path to `<drive>:\home\u\.claude`, which is exactly what the
+// accessor normalizes its input to - so asserting native paths keeps the test
+// green on the Windows CI leg instead of hard-coding POSIX separators.
+const claude = path.resolve('/home/u/.claude');
+const claudeGmail = path.resolve('/home/u/.claude-gmail');
+const claudeSmash = path.resolve('/home/u/.claude-smash');
+const claudeWork = path.resolve('/home/u/.claude-work');
+const claudeFresh = path.resolve('/home/u/.claude-fresh');
+const projects = (dir: string) => path.join(dir, 'projects');
+
 /** Resolve each dir's projects/ to itself (i.e. no symlinks - genuinely separate). */
 function realpathIdentity() {
 	realpath.mockImplementation(async (p: string) => p);
@@ -47,64 +60,58 @@ beforeEach(() => {
 
 describe('discoverClaudeAccounts', () => {
 	it('collapses config dirs that symlink to a shared projects tree', async () => {
-		discoverClaudeConfigDirs.mockResolvedValue([
-			'/home/u/.claude',
-			'/home/u/.claude-gmail',
-			'/home/u/.claude-smash',
-		]);
+		discoverClaudeConfigDirs.mockResolvedValue([claude, claudeGmail, claudeSmash]);
 		// All three point their projects/ at the same real pool.
-		realpath.mockResolvedValue('/home/u/.claude/projects');
+		realpath.mockResolvedValue(projects(claude));
 
 		const accounts = await discoverClaudeAccounts();
 
 		// One shared pool -> read exactly once, not three times.
-		expect(accounts).toEqual(['/home/u/.claude']);
+		expect(accounts).toEqual([claude]);
 	});
 
 	it('keeps genuinely separate accounts distinct', async () => {
-		discoverClaudeConfigDirs.mockResolvedValue(['/home/u/.claude', '/home/u/.claude-work']);
+		discoverClaudeConfigDirs.mockResolvedValue([claude, claudeWork]);
 		realpathIdentity();
 
 		const accounts = await discoverClaudeAccounts();
 
 		expect(accounts).toHaveLength(2);
-		expect(accounts).toContain('/home/u/.claude');
-		expect(accounts).toContain('/home/u/.claude-work');
+		expect(accounts).toContain(claude);
+		expect(accounts).toContain(claudeWork);
 	});
 
 	it('reads a shared pool once while still reading a separate account', async () => {
 		discoverClaudeConfigDirs.mockResolvedValue([
-			'/home/u/.claude',
-			'/home/u/.claude-gmail', // symlinked to the shared pool
-			'/home/u/.claude-work', // its own pool
+			claude,
+			claudeGmail, // symlinked to the shared pool
+			claudeWork, // its own pool
 		]);
 		realpath.mockImplementation(async (p: string) =>
-			p.startsWith('/home/u/.claude-work')
-				? '/home/u/.claude-work/projects'
-				: '/home/u/.claude/projects'
+			p.startsWith(claudeWork) ? projects(claudeWork) : projects(claude)
 		);
 
 		const accounts = await discoverClaudeAccounts();
 
 		expect(accounts).toHaveLength(2);
-		expect(accounts).toContain('/home/u/.claude');
-		expect(accounts).toContain('/home/u/.claude-work');
-		expect(accounts).not.toContain('/home/u/.claude-gmail');
+		expect(accounts).toContain(claude);
+		expect(accounts).toContain(claudeWork);
+		expect(accounts).not.toContain(claudeGmail);
 	});
 
 	it('keeps an account whose projects tree does not exist yet', async () => {
-		discoverClaudeConfigDirs.mockResolvedValue(['/home/u/.claude', '/home/u/.claude-fresh']);
+		discoverClaudeConfigDirs.mockResolvedValue([claude, claudeFresh]);
 		realpath.mockImplementation(async (p: string) => {
-			if (p.startsWith('/home/u/.claude-fresh')) throw new Error('ENOENT');
-			return '/home/u/.claude/projects';
+			if (p.startsWith(claudeFresh)) throw new Error('ENOENT');
+			return projects(claude);
 		});
 
 		const accounts = await discoverClaudeAccounts();
 
 		// A brand-new account with no transcripts yet still appears rather than
 		// silently collapsing into another account.
-		expect(accounts).toContain('/home/u/.claude-fresh');
-		expect(accounts).toContain('/home/u/.claude');
+		expect(accounts).toContain(claudeFresh);
+		expect(accounts).toContain(claude);
 	});
 
 	it('falls back to the default ~/.claude when discovery finds nothing', async () => {


### PR DESCRIPTION
## Summary

Fixes the `Test (windows-latest, shard 1/2)` failure currently red on `rc` (and inherited by every PR branched off it, e.g. #1288).

`src/__tests__/main/stats/token-usage/token-usage-accounts.test.ts` fed literal POSIX paths (`/home/u/.claude`) as discovered config dirs and asserted them verbatim. But `discoverClaudeAccounts` normalizes each dir with `path.resolve(dir)`, which on Windows rewrites a drive-less absolute path to `<drive>:\home\u\.claude`. So the test passed on Linux/macOS and failed on the Windows leg:

```
AssertionError: expected [ 'D:\home\u\.claude' ] to deeply equal [ '/home/u/.claude' ]
```

This is a test-portability bug, not a product bug: in production `discoverClaudeConfigDirs` returns real platform-native paths, so `path.resolve` is a harmless normalization. The accessor is unchanged.

## Fix

- Build the fixtures through `path.resolve` / `path.join`, so they match the accessor's own normalization on whatever platform runs the test.
- Compare the `realpath` mock predicates against those native paths instead of hard-coded POSIX strings.

Behavior on POSIX is identical (`path.resolve('/home/u/.claude') === '/home/u/.claude'`); the Windows leg now agrees with the accessor's output.

## Testing

- `npm run lint` (all tsc configs): clean
- `npx prettier --check` on the file: clean
- `token-usage-accounts.test.ts`: 6/6 pass locally
- Verified the four discovery cases under Windows path semantics (`path.win32.resolve`/`join`) reproduce the accessor's dedup and satisfy every assertion.
- This PR's own `windows-latest` CI leg is the real proof.

## Note on #1288

#1288 (tool-call visibility) is currently red only because it inherits this same failure from `rc`. It will go green once this lands and #1288 is updated from `rc`; no change to #1288 itself is required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test portability by resolving fixture paths consistently across environments.
  * Preserved coverage for symlinked projects, separate accounts, shared resources, and missing project directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->