### PR TITLE
Snap transcript to bottom on re-focus when following

### DIFF
--- a/src/__tests__/renderer/components/TerminalOutput/useTerminalOutputScroll.test.ts
+++ b/src/__tests__/renderer/components/TerminalOutput/useTerminalOutputScroll.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useTerminalOutputScroll } from '../../../../renderer/components/TerminalOutput/hooks/useTerminalOutputScroll';
 
@@ -80,5 +80,158 @@ describe('useTerminalOutputScroll follow-on-count-growth', () => {
 		expect(result.current.hasNewMessages).toBe(true);
 		expect(result.current.newMessageCount).toBe(2);
 		expect(result.current.isAtBottom).toBe(false);
+	});
+});
+
+/**
+ * Coverage for the J1 mount-time restore gate: the restore effect must only
+ * re-apply a saved absolute offset when the user had DELIBERATELY scrolled up
+ * (initialIsAtBottom === false). When they were following the bottom (true) or
+ * on a legacy tab that never persisted the flag (undefined), it must skip the
+ * restore and let the mount-time bottom jump snap to and follow the live
+ * bottom.
+ *
+ * A container whose scrollTo clamps into scrollTop lets us observe the
+ * mount-time bottom jump (jumpToBottom scrolls to scrollHeight, which the
+ * browser clamps to maxScroll). requestAnimationFrame is stubbed into a manual
+ * queue so both the observer's bottom jump and the restore's rAF are flushed
+ * deterministically.
+ */
+function makeRestoreContainer(maxScroll: number, clientHeight = 200): HTMLDivElement {
+	const scrollHeight = maxScroll + clientHeight;
+	const el = document.createElement('div');
+	Object.defineProperty(el, 'scrollHeight', { value: scrollHeight, configurable: true });
+	Object.defineProperty(el, 'clientHeight', { value: clientHeight, configurable: true });
+	Object.defineProperty(el, 'scrollTo', {
+		value: (opts: number | { top?: number }) => {
+			const top = typeof opts === 'object' ? (opts.top ?? 0) : opts;
+			el.scrollTop = Math.min(Math.max(0, top), maxScroll);
+		},
+		configurable: true,
+	});
+	el.scrollTop = 0;
+	return el;
+}
+
+describe('useTerminalOutputScroll mount-time restore gate (J1)', () => {
+	let rafQueue: FrameRequestCallback[] = [];
+
+	beforeEach(() => {
+		rafQueue = [];
+		vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+			rafQueue.push(cb);
+			return rafQueue.length;
+		});
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	// Drain the rAF queue inside act(), looping so any rAF scheduled by a
+	// re-render triggered from within a callback also runs. Terminates because
+	// the snap-to-bottom / restore paths schedule at most one follow-up frame.
+	function flushRaf() {
+		act(() => {
+			let guard = 0;
+			while (rafQueue.length > 0 && guard++ < 20) {
+				const cbs = rafQueue.splice(0);
+				cbs.forEach((cb) => cb(0));
+			}
+		});
+	}
+
+	it('Case 1: restores the saved offset when the user deliberately scrolled up', () => {
+		const ref = { current: makeRestoreContainer(9000) };
+
+		const { result } = renderHook(() =>
+			useTerminalOutputScroll({
+				scrollContainerRef: ref,
+				initialScrollTop: 5000,
+				initialIsAtBottom: false,
+				sessionId: 's1',
+				activeTabId: 't1',
+				filteredLogsLength: 3,
+			})
+		);
+
+		flushRaf();
+
+		expect(ref.current.scrollTop).toBe(5000);
+		expect(result.current.isAtBottom).toBe(false);
+		expect(result.current.autoScrollPaused).toBe(true);
+	});
+
+	it('Case 2: snaps to the live bottom when the user was following', () => {
+		const ref = { current: makeRestoreContainer(9000) };
+
+		const { result } = renderHook(() =>
+			useTerminalOutputScroll({
+				scrollContainerRef: ref,
+				initialScrollTop: 5000,
+				initialIsAtBottom: true,
+				sessionId: 's1',
+				activeTabId: 't1',
+				filteredLogsLength: 3,
+			})
+		);
+
+		flushRaf();
+
+		// The restore body never ran: scrollTop is the mount jump's bottom, not
+		// the saved 5000 offset.
+		expect(ref.current.scrollTop).toBe(9000);
+		expect(result.current.isAtBottom).toBe(true);
+		expect(result.current.autoScrollPaused).toBe(false);
+	});
+
+	it('Case 3: legacy tab (initialIsAtBottom undefined) also snaps to the bottom', () => {
+		const ref = { current: makeRestoreContainer(9000) };
+
+		const { result } = renderHook(() =>
+			useTerminalOutputScroll({
+				scrollContainerRef: ref,
+				initialScrollTop: 5000,
+				initialIsAtBottom: undefined,
+				sessionId: 's1',
+				activeTabId: 't1',
+				filteredLogsLength: 3,
+			})
+		);
+
+		flushRaf();
+
+		expect(ref.current.scrollTop).toBe(9000);
+		expect(result.current.isAtBottom).toBe(true);
+		expect(result.current.autoScrollPaused).toBe(false);
+	});
+
+	it('Case 4: keeps following the bottom when the count grows after a snap-to-bottom (#1263)', () => {
+		const ref = { current: makeRestoreContainer(9000) };
+
+		const { result, rerender } = renderHook(
+			({ len }) =>
+				useTerminalOutputScroll({
+					scrollContainerRef: ref,
+					initialScrollTop: 5000,
+					initialIsAtBottom: true,
+					sessionId: 's1',
+					activeTabId: 't1',
+					filteredLogsLength: len,
+				}),
+			{ initialProps: { len: 3 } }
+		);
+
+		flushRaf();
+		expect(result.current.isAtBottom).toBe(true);
+
+		// New streamed entries arrive while following: must keep following, no pill.
+		rerender({ len: 6 });
+		flushRaf();
+
+		expect(result.current.isAtBottom).toBe(true);
+		expect(result.current.autoScrollPaused).toBe(false);
+		expect(result.current.hasNewMessages).toBe(false);
+		expect(result.current.newMessageCount).toBe(0);
 	});
 });

--- a/src/__tests__/renderer/components/TerminalOutput/useTerminalOutputScroll.test.ts
+++ b/src/__tests__/renderer/components/TerminalOutput/useTerminalOutputScroll.test.ts
@@ -234,4 +234,39 @@ describe('useTerminalOutputScroll mount-time restore gate (J1)', () => {
 		expect(result.current.hasNewMessages).toBe(false);
 		expect(result.current.newMessageCount).toBe(0);
 	});
+
+	it('Case 5: an isAtBottom flip with a stale saved offset must not re-fire the restore', () => {
+		// Mounts following the bottom with a stale saved offset (8000 vs the live
+		// 9000 bottom). onAtBottomChange writes isAtBottom synchronously while
+		// onScrollPositionChange is debounced, so a user scroll-up flips
+		// initialIsAtBottom to false while initialScrollTop is still the old 8000.
+		// The restore effect's latch must survive the commit (reset effect declared
+		// first) so this flip cannot re-run the restore and yank the user back. (J1)
+		const ref = { current: makeRestoreContainer(9000) };
+
+		const { rerender } = renderHook(
+			({ atBottom }) =>
+				useTerminalOutputScroll({
+					scrollContainerRef: ref,
+					initialScrollTop: 8000,
+					initialIsAtBottom: atBottom,
+					sessionId: 's1',
+					activeTabId: 't1',
+					filteredLogsLength: 3,
+				}),
+			{ initialProps: { atBottom: true } }
+		);
+
+		flushRaf();
+		// The fix works on mount: snapped to the live bottom, not the stale 8000.
+		expect(ref.current.scrollTop).toBe(9000);
+
+		// User scrolls up; isAtBottom persists immediately, scrollTop is still debounced.
+		ref.current.scrollTop = 2000;
+		rerender({ atBottom: false });
+		flushRaf();
+
+		// Must stay where the user scrolled, NOT be yanked back to the stale 8000.
+		expect(ref.current.scrollTop).toBe(2000);
+	});
 });

--- a/src/renderer/components/MainPanel/MainPanelContent.tsx
+++ b/src/renderer/components/MainPanel/MainPanelContent.tsx
@@ -845,6 +845,7 @@ export const MainPanelContent = React.memo(function MainPanelContent(props: Main
 								onScrollPositionChange={onScrollPositionChange}
 								onAtBottomChange={onAtBottomChange}
 								initialScrollTop={activeTab?.scrollTop}
+								initialIsAtBottom={activeTab?.isAtBottom}
 								markdownEditMode={chatRawTextMode}
 								setMarkdownEditMode={useSettingsStore.getState().setChatRawTextMode}
 								onReplayMessage={onReplayMessage}

--- a/src/renderer/components/TerminalOutput/TerminalOutput.tsx
+++ b/src/renderer/components/TerminalOutput/TerminalOutput.tsx
@@ -55,6 +55,7 @@ export const TerminalOutput = memo(
 			onScrollPositionChange,
 			onAtBottomChange,
 			initialScrollTop,
+			initialIsAtBottom,
 			markdownEditMode,
 			setMarkdownEditMode,
 			onReplayMessage,
@@ -192,6 +193,7 @@ export const TerminalOutput = memo(
 		} = useTerminalOutputScroll({
 			scrollContainerRef,
 			initialScrollTop,
+			initialIsAtBottom,
 			sessionId: session.id,
 			activeTabId,
 			filteredLogsLength: filteredLogs.length,

--- a/src/renderer/components/TerminalOutput/hooks/useTerminalOutputScroll.ts
+++ b/src/renderer/components/TerminalOutput/hooks/useTerminalOutputScroll.ts
@@ -216,6 +216,16 @@ export function useTerminalOutputScroll({
 		return () => observer.disconnect();
 	}, [autoScrollPaused, scrollContainerRef, jumpToBottom]);
 
+	// Declared BEFORE the restore effect on purpose. React runs effects in
+	// declaration order, so on mount and every tab switch this clears the latch
+	// first and the restore effect below then latches it for good. Reversing the
+	// order would leave the ref unlatched after commit, letting a later prop
+	// change (e.g. a synchronous isAtBottom flip while initialScrollTop is still
+	// the debounced-stale offset) re-fire the restore and yank the user. (J1)
+	useEffect(() => {
+		hasRestoredScrollRef.current = false;
+	}, [sessionId, activeTabId]);
+
 	useEffect(() => {
 		if (initialScrollTop !== undefined && initialScrollTop > 0 && !hasRestoredScrollRef.current) {
 			hasRestoredScrollRef.current = true;
@@ -224,8 +234,9 @@ export function useTerminalOutputScroll({
 			// were following the bottom (true) - or on a legacy tab that never
 			// persisted the flag (undefined) - skip the restore and let the
 			// mount-time bottom jump + MutationObserver snap to and follow the live
-			// bottom. hasRestoredScrollRef is already latched above so a later prop
-			// change cannot re-trigger this. (J1)
+			// bottom. hasRestoredScrollRef is latched above and the reset effect
+			// runs earlier in declaration order, so a later prop change cannot
+			// re-trigger this. (J1)
 			if (initialIsAtBottom !== false) return;
 			requestAnimationFrame(() => {
 				if (scrollContainerRef.current) {
@@ -244,10 +255,6 @@ export function useTerminalOutputScroll({
 			});
 		}
 	}, [initialScrollTop, initialIsAtBottom, scrollContainerRef]);
-
-	useEffect(() => {
-		hasRestoredScrollRef.current = false;
-	}, [sessionId, activeTabId]);
 
 	useEffect(() => {
 		return () => {

--- a/src/renderer/components/TerminalOutput/hooks/useTerminalOutputScroll.ts
+++ b/src/renderer/components/TerminalOutput/hooks/useTerminalOutputScroll.ts
@@ -9,6 +9,7 @@ const PROGRAMMATIC_TARGET_EPSILON_PX = 4;
 interface UseTerminalOutputScrollOptions {
 	scrollContainerRef: React.RefObject<HTMLDivElement>;
 	initialScrollTop?: number;
+	initialIsAtBottom?: boolean;
 	sessionId: string;
 	activeTabId: string | undefined;
 	filteredLogsLength: number;

--- a/src/renderer/components/TerminalOutput/hooks/useTerminalOutputScroll.ts
+++ b/src/renderer/components/TerminalOutput/hooks/useTerminalOutputScroll.ts
@@ -20,6 +20,7 @@ interface UseTerminalOutputScrollOptions {
 export function useTerminalOutputScroll({
 	scrollContainerRef,
 	initialScrollTop,
+	initialIsAtBottom,
 	sessionId,
 	activeTabId,
 	filteredLogsLength,
@@ -218,6 +219,14 @@ export function useTerminalOutputScroll({
 	useEffect(() => {
 		if (initialScrollTop !== undefined && initialScrollTop > 0 && !hasRestoredScrollRef.current) {
 			hasRestoredScrollRef.current = true;
+			// Only restore a saved absolute offset when the user had deliberately
+			// scrolled up when they left (initialIsAtBottom === false). When they
+			// were following the bottom (true) - or on a legacy tab that never
+			// persisted the flag (undefined) - skip the restore and let the
+			// mount-time bottom jump + MutationObserver snap to and follow the live
+			// bottom. hasRestoredScrollRef is already latched above so a later prop
+			// change cannot re-trigger this. (J1)
+			if (initialIsAtBottom !== false) return;
 			requestAnimationFrame(() => {
 				if (scrollContainerRef.current) {
 					const { scrollHeight, clientHeight } = scrollContainerRef.current;
@@ -234,7 +243,7 @@ export function useTerminalOutputScroll({
 				}
 			});
 		}
-	}, [initialScrollTop, scrollContainerRef]);
+	}, [initialScrollTop, initialIsAtBottom, scrollContainerRef]);
 
 	useEffect(() => {
 		hasRestoredScrollRef.current = false;

--- a/src/renderer/components/TerminalOutput/types.ts
+++ b/src/renderer/components/TerminalOutput/types.ts
@@ -136,6 +136,7 @@ export interface TerminalOutputProps {
 	onScrollPositionChange?: (scrollTop: number) => void; // Callback to save scroll position
 	onAtBottomChange?: (isAtBottom: boolean) => void; // Callback when user scrolls to/away from bottom
 	initialScrollTop?: number; // Initial scroll position to restore
+	initialIsAtBottom?: boolean; // Whether the tab was following the bottom when it lost focus; undefined means legacy tab / treated as "was at bottom"
 	markdownEditMode: boolean; // Whether to show raw markdown or rendered markdown for AI responses
 	setMarkdownEditMode: (value: boolean) => void; // Toggle markdown mode
 	onReplayMessage?: (text: string, images?: string[]) => void; // Replay a user message


### PR DESCRIPTION
## Finding J1 - transcript does not restore to bottom on re-focus

On session/tab re-focus the transcript restored a stale absolute pixel offset instead of snapping to the live bottom, even when the user was following the bottom when they left.

## Change
- The mount-time restore effect now consults the persisted `isAtBottom` flag: it latches `hasRestoredScrollRef` first, then early-returns when `initialIsAtBottom !== false`, so a followed transcript snaps to the live bottom on re-focus.
- A deliberate scroll-up (`isAtBottom === false`) still restores its saved offset. Legacy tabs (`undefined`) are treated as at-bottom.
- The `initialIsAtBottom` prop is threaded types.ts -> MainPanelContent -> TerminalOutput -> hook.
- Stick-to-bottom-during-streaming (#1263 / #1233 / #1140) is preserved and covered by new gated tests.

## Validation
Type check, ESLint, Prettier clean. Scoped test `useTerminalOutputScroll.test.ts` -> 6/6 pass.

Fix plan: `.maestro/FIX-J1-01.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed terminal output scroll restoration when switching tabs by using the tab’s initial “at bottom” state to decide whether to restore the saved offset or snap to live output.
  * Prevented unwanted scroll jumps in cases where the user had paused following after a restore.
  * Ensured the terminal continues auto-following the bottom as new entries arrive when appropriate.
* **Tests**
  * Added deterministic coverage for mount-time restore and auto-follow behavior using controlled animation-frame flushing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->