### PR TITLE
Add optional beta flag to plugin manifest for Agent Flow badge

### DIFF
--- a/docs/agent-guides/PLUGIN-DEVELOPMENT.md
+++ b/docs/agent-guides/PLUGIN-DEVELOPMENT.md
@@ -88,21 +88,21 @@ One folder per plugin. The folder name and the manifest `id` must agree on insta
 
 `PluginManifest` (`src/shared/plugins/plugin-manifest.ts`):
 
-| Field         | Type                     | Required  | Notes                                                           |
-| ------------- | ------------------------ | --------- | --------------------------------------------------------------- |
-| `id`          | string                   | yes       | `^[a-z][a-z0-9]*([._-][a-z0-9]+)*$`, 3-100 chars                |
-| `name`        | string                   | yes       | display name                                                    |
-| `version`     | string                   | yes       | semver (distinct from `minHostApi`)                             |
-| `tier`        | `0 \| 1 \| 2`            | yes       | trust/capability tier                                           |
-| `maestro`     | `{ minHostApi: string }` | yes       | minimum host API (current host is `1.9.0`)                      |
-| `description` | string                   | no        |                                                                 |
-| `author`      | string                   | no        |                                                                 |
-| `license`     | string                   | no        |                                                                 |
-| `homepage`    | string                   | no        |                                                                 |
+| Field         | Type                     | Required  | Notes                                                                                                                                                                                                              |
+| ------------- | ------------------------ | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `id`          | string                   | yes       | `^[a-z][a-z0-9]*([._-][a-z0-9]+)*$`, 3-100 chars                                                                                                                                                                   |
+| `name`        | string                   | yes       | display name                                                                                                                                                                                                       |
+| `version`     | string                   | yes       | semver (distinct from `minHostApi`)                                                                                                                                                                                |
+| `tier`        | `0 \| 1 \| 2`            | yes       | trust/capability tier                                                                                                                                                                                              |
+| `maestro`     | `{ minHostApi: string }` | yes       | minimum host API (current host is `1.9.0`)                                                                                                                                                                         |
+| `description` | string                   | no        |                                                                                                                                                                                                                    |
+| `author`      | string                   | no        |                                                                                                                                                                                                                    |
+| `license`     | string                   | no        |                                                                                                                                                                                                                    |
+| `homepage`    | string                   | no        |                                                                                                                                                                                                                    |
 | `beta`        | boolean                  | no        | presentation-only marketplace flag; surfaces a warning-colored BETA pill on the tile and details pane. Additive and backward-compatible; no `minHostApi` bump. Omitted from the normalized manifest unless `true`. |
-| `contributes` | object                   | no        | declarative contributions (see catalog)                         |
-| `entry`       | string                   | tier >= 1 | relative path to the sandboxed code entry; FORBIDDEN for tier 0 |
-| `permissions` | `PermissionRequest[]`    | no        | only meaningful for tier >= 1                                   |
+| `contributes` | object                   | no        | declarative contributions (see catalog)                                                                                                                                                                            |
+| `entry`       | string                   | tier >= 1 | relative path to the sandboxed code entry; FORBIDDEN for tier 0                                                                                                                                                    |
+| `permissions` | `PermissionRequest[]`    | no        | only meaningful for tier >= 1                                                                                                                                                                                      |
 
 `minHostApi` is checked same-major and `host >= min`. A v2-targeted plugin will not load on a v1 host and vice versa.
 

--- a/docs/agent-guides/PLUGIN-DEVELOPMENT.md
+++ b/docs/agent-guides/PLUGIN-DEVELOPMENT.md
@@ -99,6 +99,7 @@ One folder per plugin. The folder name and the manifest `id` must agree on insta
 | `author`      | string                   | no        |                                                                 |
 | `license`     | string                   | no        |                                                                 |
 | `homepage`    | string                   | no        |                                                                 |
+| `beta`        | boolean                  | no        | presentation-only marketplace flag; surfaces a warning-colored BETA pill on the tile and details pane. Additive and backward-compatible; no `minHostApi` bump. Omitted from the normalized manifest unless `true`. |
 | `contributes` | object                   | no        | declarative contributions (see catalog)                         |
 | `entry`       | string                   | tier >= 1 | relative path to the sandboxed code entry; FORBIDDEN for tier 0 |
 | `permissions` | `PermissionRequest[]`    | no        | only meaningful for tier >= 1                                   |

--- a/examples/plugins/agent-flow/plugin.json
+++ b/examples/plugins/agent-flow/plugin.json
@@ -6,6 +6,7 @@
 	"maestro": { "minHostApi": "1.14.0" },
 	"description": "Live per-session execution-graph visualization built from host tool + agent lifecycle events.",
 	"category": "insights",
+	"beta": true,
 	"entry": "main.js",
 	"permissions": [
 		{

--- a/packages/plugin-sdk/src/__tests__/drift.test.ts
+++ b/packages/plugin-sdk/src/__tests__/drift.test.ts
@@ -203,6 +203,30 @@ describe('@maestro/plugin-sdk vendored-contract drift guard', () => {
 		);
 	});
 
+	it('validatePluginManifest agrees with the source on the optional beta flag', () => {
+		const base = {
+			id: 'com.example.transcript-reader',
+			name: 'Transcript Reader',
+			version: '0.1.0',
+			tier: 1,
+			maestro: { minHostApi: HOST_API_VERSION },
+			entry: 'dist/entry.js',
+			permissions: [{ capability: 'transcripts:read', reason: 'Summarize the active session.' }],
+		};
+
+		const betaTrue = { ...base, beta: true };
+		expect(validatePluginManifest(betaTrue)).toEqual(srcValidatePluginManifest(betaTrue));
+		expect(validatePluginManifest(betaTrue).manifest?.beta).toBe(true);
+
+		const betaFalse = { ...base, beta: false };
+		expect(validatePluginManifest(betaFalse)).toEqual(srcValidatePluginManifest(betaFalse));
+		expect(validatePluginManifest(betaFalse).manifest?.beta).toBeUndefined();
+
+		const betaInvalid = { ...base, beta: 'yes' };
+		expect(validatePluginManifest(betaInvalid)).toEqual(srcValidatePluginManifest(betaInvalid));
+		expect(validatePluginManifest(betaInvalid).manifest).toBeNull();
+	});
+
 	it('validatePluginManifest agrees with the source on allowlist-scoped act verbs (Phase-4 promotion)', () => {
 		const base = {
 			id: 'com.example.act-plugin',

--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -581,6 +581,12 @@ export interface PluginManifest {
 	homepage?: string;
 	/** Coarse marketplace category for grouping/filtering. Defaults to 'other'. */
 	category?: PluginCategory;
+	/**
+	 * Marketplace-presentation flag. When true, the extension's tile and details
+	 * pane surface a warning-colored BETA pill. Presentation-only and additive;
+	 * requires no minHostApi bump.
+	 */
+	beta?: boolean;
 	/** Declarative contributions. Structurally validated; semantics land later. */
 	contributes?: Record<string, unknown>;
 	/** Relative path to the sandboxed code entrypoint. Required tier >= 1; forbidden tier 0. */
@@ -621,6 +627,7 @@ export function validatePluginManifest(input: unknown): ManifestValidationResult
 		license,
 		homepage,
 		category,
+		beta,
 		contributes,
 		entry,
 		permissions,
@@ -688,6 +695,9 @@ export function validatePluginManifest(input: unknown): ManifestValidationResult
 			normalizedCategory = category;
 		}
 	}
+	if (beta !== undefined && typeof beta !== 'boolean') {
+		errors.push('beta, when present, must be a boolean');
+	}
 	if (contributes !== undefined && !isPlainObject(contributes)) {
 		errors.push('contributes, when present, must be an object');
 	}
@@ -737,6 +747,7 @@ export function validatePluginManifest(input: unknown): ManifestValidationResult
 		...(isNonEmptyString(license) ? { license: (license as string).trim() } : {}),
 		...(isNonEmptyString(homepage) ? { homepage: (homepage as string).trim() } : {}),
 		...(normalizedCategory ? { category: normalizedCategory } : {}),
+		...(beta === true ? { beta: true } : {}),
 		...(isPlainObject(contributes) ? { contributes } : {}),
 		...(safeEntry ? { entry: safeEntry } : {}),
 		...(parsedPermissions.requests.length > 0 ? { permissions: parsedPermissions.requests } : {}),

--- a/src/__tests__/renderer/components/Settings/Extensions/extensionModel.test.ts
+++ b/src/__tests__/renderer/components/Settings/Extensions/extensionModel.test.ts
@@ -8,6 +8,7 @@ import {
 import {
 	buildExtensions,
 	builtinExtension,
+	pluginExtension,
 	BUILTIN_FEATURES,
 } from '../../../../../renderer/components/Settings/Extensions/extensionModel';
 import type { EncoreFeatureFlags } from '../../../../../renderer/types';
@@ -159,5 +160,29 @@ describe('extensionModel first-party projection (all Encore features)', () => {
 		for (const ext of extensions) {
 			expect(ext.state).toBe('not-installed');
 		}
+	});
+});
+
+describe('extensionModel plugin beta projection', () => {
+	it('projects a manifest beta: true onto the tile as beta === true', () => {
+		const record = pluginRecord('com.example.beta');
+		record.manifest = { ...record.manifest!, beta: true };
+		expect(pluginExtension(record).beta).toBe(true);
+	});
+
+	it('projects a manifest without beta as beta === undefined', () => {
+		const ext = pluginExtension(pluginRecord('com.example.stable'));
+		expect(ext.beta).toBeUndefined();
+	});
+
+	it('leaves built-in beta-list projection unchanged', () => {
+		const cueDef = BUILTIN_FEATURES.find((def) => def.flag === 'maestroCue');
+		expect(cueDef).toBeDefined();
+		// maestroCue is on the builtin beta list, so its tile stays beta: true.
+		expect(builtinExtension(cueDef!, flags()).beta).toBe(true);
+		const usageDef = BUILTIN_FEATURES.find((def) => def.flag === 'usageStats');
+		expect(usageDef).toBeDefined();
+		// usageStats is not on the beta list, so its tile stays non-beta.
+		expect(builtinExtension(usageDef!, flags()).beta).toBe(false);
 	});
 });

--- a/src/__tests__/shared/plugins/plugin-manifest.test.ts
+++ b/src/__tests__/shared/plugins/plugin-manifest.test.ts
@@ -93,6 +93,25 @@ describe('validatePluginManifest', () => {
 		expect(badCategory.errors.some((e) => e.includes('category'))).toBe(true);
 	});
 
+	it('keeps beta only when true, omits it when false or absent, and rejects a non-boolean', () => {
+		const withBeta = validatePluginManifest(validManifest({ beta: true }));
+		expect(withBeta.errors).toEqual([]);
+		expect(withBeta.manifest?.beta).toBe(true);
+
+		const betaFalse = validatePluginManifest(validManifest({ beta: false }));
+		expect(betaFalse.errors).toEqual([]);
+		expect(betaFalse.manifest).not.toBeNull();
+		expect('beta' in (betaFalse.manifest as Record<string, unknown>)).toBe(false);
+
+		const withoutBeta = validatePluginManifest(validManifest());
+		expect(withoutBeta.manifest).not.toBeNull();
+		expect('beta' in (withoutBeta.manifest as Record<string, unknown>)).toBe(false);
+
+		const badBeta = validatePluginManifest(validManifest({ beta: 'yes' }));
+		expect(badBeta.manifest).toBeNull();
+		expect(badBeta.errors).toContain('beta, when present, must be a boolean');
+	});
+
 	it('does not treat host incompatibility as a validation error', () => {
 		const { manifest, errors } = validatePluginManifest(
 			validManifest({ maestro: { minHostApi: '2.0.0' } })

--- a/src/renderer/components/Settings/Extensions/extensionModel.ts
+++ b/src/renderer/components/Settings/Extensions/extensionModel.ts
@@ -161,6 +161,7 @@ export function pluginExtension(record: PluginRecord): UnifiedExtension {
 		state: record.enabled ? 'enabled' : 'installed',
 		tier: m?.tier,
 		trust: record.signature?.status,
+		beta: m?.beta,
 		version: m?.version,
 		author: m?.author,
 		loadStatus: record.loadStatus,

--- a/src/shared/plugins/plugin-manifest.ts
+++ b/src/shared/plugins/plugin-manifest.ts
@@ -159,6 +159,7 @@ export function validatePluginManifest(input: unknown): ManifestValidationResult
 		license,
 		homepage,
 		category,
+		beta,
 		contributes,
 		entry,
 		permissions,
@@ -226,6 +227,9 @@ export function validatePluginManifest(input: unknown): ManifestValidationResult
 			normalizedCategory = category;
 		}
 	}
+	if (beta !== undefined && typeof beta !== 'boolean') {
+		errors.push('beta, when present, must be a boolean');
+	}
 	if (contributes !== undefined && !isPlainObject(contributes)) {
 		errors.push('contributes, when present, must be an object');
 	}
@@ -275,6 +279,7 @@ export function validatePluginManifest(input: unknown): ManifestValidationResult
 		...(isNonEmptyString(license) ? { license: (license as string).trim() } : {}),
 		...(isNonEmptyString(homepage) ? { homepage: (homepage as string).trim() } : {}),
 		...(normalizedCategory ? { category: normalizedCategory } : {}),
+		...(beta === true ? { beta: true } : {}),
 		...(isPlainObject(contributes) ? { contributes } : {}),
 		...(safeEntry ? { entry: safeEntry } : {}),
 		...(parsedPermissions.requests.length > 0 ? { permissions: parsedPermissions.requests } : {}),

--- a/src/shared/plugins/plugin-manifest.ts
+++ b/src/shared/plugins/plugin-manifest.ts
@@ -85,6 +85,12 @@ export interface PluginManifest {
 	homepage?: string;
 	/** Coarse marketplace category for grouping/filtering. Defaults to 'other'. */
 	category?: PluginCategory;
+	/**
+	 * Marketplace-presentation flag. When true, the extension's tile and details
+	 * pane surface a warning-colored BETA pill. Presentation-only and additive;
+	 * requires no minHostApi bump.
+	 */
+	beta?: boolean;
 	/** Declarative contributions. Structurally validated; semantics land later. */
 	contributes?: Record<string, unknown>;
 	/**


### PR DESCRIPTION
## Finding B1 - Agent Flow beta badge

Threads an optional, presentation-only `beta?: boolean` flag through the plugin manifest so a plugin can render a BETA pill on its Extensions tile.

## Change (additive, backward-compatible)
- `beta?: boolean` added to the `PluginManifest` interface and its validator (`src/shared/plugins/plugin-manifest.ts`).
- Mirrored into the vendored plugin-sdk (`packages/plugin-sdk/src/index.ts`) with matching shape and validation message.
- Projected into the Extension tile via `pluginExtension()` (`extensionModel.ts`) -> warning-colored BETA pill.
- `"beta": true` set in the Agent Flow plugin manifest.
- No `minHostApi` bump.

## Validation
Type check (3 tsc configs), ESLint clean. Prettier reflowed one doc table (whitespace only). Scoped tests `extensionModel.test.ts` + `plugin-manifest.test.ts` -> 23/23 pass. SDK mirror parity verified by hand (parity is only enforced on the publish workflow, not normal CI).

## Human follow-up
Editing `examples/plugins/agent-flow/plugin.json` changes its SHA-256, so the Agent Flow bundle must be re-signed relative to the A1 signing step (#1297) or integrity verification reports `status: modified` and blocks seeding.

Fix plan: `.maestro/FIX-B1-01.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plugin manifests can now include a `beta` flag to mark extensions as beta.
  * Beta status is shown on plugin extension tiles and in marketplace listings.
  * The example agent-flow plugin now demonstrates the beta flag.
* **Bug Fixes**
  * Manifest validation rejects non-boolean `beta` values.
* **Documentation**
  * Updated plugin development guidance to document the new `beta` field and clarified related manifest field behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->