### PR TITLE
Warm omp model catalog with expanded env so context window resolves

### DIFF
--- a/src/__tests__/main/agents/detector.test.ts
+++ b/src/__tests__/main/agents/detector.test.ts
@@ -87,7 +87,6 @@ vi.mock('fs', async () => {
 import { execFileNoThrow } from '../../../main/utils/execFile';
 import { logger } from '../../../main/utils/logger';
 import { primeOmpModelCatalog, computeOmpCatalogKey } from '../../../main/agents/omp-model-catalog';
-import { getExpandedEnv } from '../../../main/agents/path-prober';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -403,7 +402,8 @@ describe('agent-detector', () => {
 			// default-identity context-window catalog so a user's first prompt
 			// already has the real per-turn window (killing the cold-start race
 			// against the spawn-time prime cap). It must run with the expanded env
-			// (getExpandedEnv) and the default-identity key (no env overrides).
+			// and the binary's own dir first on PATH (so a bun-based omp resolves
+			// its co-located runtime), under the default-identity key.
 			mockExecFileNoThrow.mockImplementation(async (cmd, args) => {
 				if (args[0] === 'omp') {
 					return { stdout: '/usr/bin/omp\n', stderr: '', exitCode: 0 };
@@ -419,8 +419,11 @@ describe('agent-detector', () => {
 			expect(command).toBe('/usr/bin/omp');
 			// ...under the default identity (env overrides undefined)...
 			expect(key).toBe(computeOmpCatalogKey('/usr/bin/omp', undefined));
-			// ...with the expanded env, not a raw process.env.
-			expect(env?.PATH).toBe(getExpandedEnv().PATH);
+			// ...with the binary's own dir first on PATH (co-located runtime),
+			// not a raw process.env.
+			const pathEntries = (env?.PATH ?? '').split(path.delimiter);
+			expect(pathEntries[0]).toBe(path.dirname('/usr/bin/omp'));
+			expect(pathEntries.length).toBeGreaterThan(1);
 		});
 
 		it('does not warm the omp catalog when omp is not installed', async () => {

--- a/src/__tests__/main/agents/detector.test.ts
+++ b/src/__tests__/main/agents/detector.test.ts
@@ -31,6 +31,21 @@ vi.mock('../../../main/agents/opencode-config', async () => {
 	};
 });
 
+// Spy on the omp catalog prime at the module boundary so the detector's
+// detection-time warm-up is observable without firing the real `omp models
+// --json` fetch. Keep every other export real (setOmpModelCatalog and
+// computeOmpCatalogKey are used by the discoverModels path and by the
+// default-identity key assertion below).
+vi.mock('../../../main/agents/omp-model-catalog', async () => {
+	const actual = await vi.importActual<typeof import('../../../main/agents/omp-model-catalog')>(
+		'../../../main/agents/omp-model-catalog'
+	);
+	return {
+		...actual,
+		primeOmpModelCatalog: vi.fn().mockResolvedValue(undefined),
+	};
+});
+
 // Make readFileSync mockable for ESM - vi.spyOn on ESM namespace fails
 // Also mock fs.promises.access to prevent real filesystem probing
 const { _readFileSync, _fsAccess } = vi.hoisted(() => ({
@@ -71,6 +86,8 @@ vi.mock('fs', async () => {
 // Get mocked modules
 import { execFileNoThrow } from '../../../main/utils/execFile';
 import { logger } from '../../../main/utils/logger';
+import { primeOmpModelCatalog, computeOmpCatalogKey } from '../../../main/agents/omp-model-catalog';
+import { getExpandedEnv } from '../../../main/agents/path-prober';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -379,6 +396,40 @@ describe('agent-detector', () => {
 			expect(agents.find((a) => a.id === 'hermes')?.available).toBe(true);
 			expect(agents.find((a) => a.id === 'codex')?.available).toBe(false);
 			expect(agents.find((a) => a.id === 'pi')?.available).toBe(false);
+		});
+
+		it('warms the default-identity omp catalog when omp detection succeeds', async () => {
+			// When omp is detected, the detector fires a non-blocking prime of the
+			// default-identity context-window catalog so a user's first prompt
+			// already has the real per-turn window (killing the cold-start race
+			// against the spawn-time prime cap). It must run with the expanded env
+			// (getExpandedEnv) and the default-identity key (no env overrides).
+			mockExecFileNoThrow.mockImplementation(async (cmd, args) => {
+				if (args[0] === 'omp') {
+					return { stdout: '/usr/bin/omp\n', stderr: '', exitCode: 0 };
+				}
+				return { stdout: '', stderr: 'not found', exitCode: 1 };
+			});
+
+			await detector.detectAgents();
+
+			expect(primeOmpModelCatalog).toHaveBeenCalledTimes(1);
+			const [command, env, key] = vi.mocked(primeOmpModelCatalog).mock.calls[0];
+			// Primed against the resolved omp binary...
+			expect(command).toBe('/usr/bin/omp');
+			// ...under the default identity (env overrides undefined)...
+			expect(key).toBe(computeOmpCatalogKey('/usr/bin/omp', undefined));
+			// ...with the expanded env, not a raw process.env.
+			expect(env?.PATH).toBe(getExpandedEnv().PATH);
+		});
+
+		it('does not warm the omp catalog when omp is not installed', async () => {
+			// Default mock: no binaries found. omp detection fails, so no prime fires.
+			mockExecFileNoThrow.mockResolvedValue({ stdout: '', stderr: 'not found', exitCode: 1 });
+
+			await detector.detectAgents();
+
+			expect(primeOmpModelCatalog).not.toHaveBeenCalled();
 		});
 
 		it('should detect Hermes using the shared CLI metadata', async () => {

--- a/src/__tests__/main/agents/omp-model-catalog.test.ts
+++ b/src/__tests__/main/agents/omp-model-catalog.test.ts
@@ -1,11 +1,23 @@
-import { describe, expect, it, beforeEach } from 'vitest';
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import * as path from 'path';
+
+// Mock the omp subprocess at the module boundary so priming behavior (success,
+// failure, and unusable-payload negative caching) is observable without running
+// a real `omp models --json`.
+vi.mock('../../../main/utils/execFile', () => ({
+	execFileNoThrow: vi.fn(),
+}));
+
 import {
 	setOmpModelCatalog,
 	getOmpModelContextWindow,
 	computeOmpCatalogKey,
+	buildOmpPrimeEnv,
+	primeOmpModelCatalog,
 	__resetOmpModelCatalogForTests,
 	type OmpCatalogEntry,
 } from '../../../main/agents/omp-model-catalog';
+import { execFileNoThrow } from '../../../main/utils/execFile';
 
 // Mirrors the shape `omp models --json` returns for a couple of models.
 const SAMPLE: OmpCatalogEntry[] = [
@@ -106,5 +118,60 @@ describe('omp-model-catalog', () => {
 		setOmpModelCatalog(SAMPLE, KEY);
 		expect(getOmpModelContextWindow('gone-model', KEY)).toBeNull();
 		expect(getOmpModelContextWindow('claude-opus-4-8', KEY)).toBe(1_000_000);
+	});
+
+	describe('buildOmpPrimeEnv', () => {
+		it('drops empty PATH components when prepending the binary dir', () => {
+			// A PATH with a trailing/interior delimiter yields empty components after
+			// split; on POSIX an empty entry means "search the CWD", so the prime
+			// probe must never carry one.
+			const env = buildOmpPrimeEnv('/opt/tester/.bun/bin/omp', {
+				PATH: ['/usr/local/bin', '', '/usr/bin', ''].join(path.delimiter),
+			});
+			const entries = (env.PATH ?? '').split(path.delimiter);
+			expect(entries).not.toContain('');
+			// The binary's own dir leads so a co-located runtime resolves first.
+			expect(entries[0]).toBe(path.dirname('/opt/tester/.bun/bin/omp'));
+			expect(entries).toContain('/usr/local/bin');
+			expect(entries).toContain('/usr/bin');
+		});
+	});
+
+	describe('primeOmpModelCatalog negative caching', () => {
+		beforeEach(() => {
+			vi.mocked(execFileNoThrow).mockReset();
+		});
+
+		it('negative-caches a valid JSON payload without a models array', async () => {
+			const key = computeOmpCatalogKey('/opt/x/omp', undefined);
+			// Command runs and exits 0, but the payload has no `models` array - it is
+			// unusable, so it must be treated like a failure for the TTL.
+			vi.mocked(execFileNoThrow).mockResolvedValue({
+				stdout: '{"notModels":[]}',
+				stderr: '',
+				exitCode: 0,
+			});
+			await primeOmpModelCatalog('/opt/x/omp', {}, key);
+			// A second prime within the TTL is short-circuited by the failure cache
+			// rather than re-running the same bad command.
+			await primeOmpModelCatalog('/opt/x/omp', {}, key);
+			expect(execFileNoThrow).toHaveBeenCalledTimes(1);
+			// Nothing was cataloged for that identity.
+			expect(getOmpModelContextWindow('claude-opus-4-8', key)).toBeNull();
+		});
+
+		it('re-primes and caches once a valid models array arrives', async () => {
+			const key = computeOmpCatalogKey('/opt/y/omp', undefined);
+			vi.mocked(execFileNoThrow).mockResolvedValue({
+				stdout: JSON.stringify({ models: SAMPLE }),
+				stderr: '',
+				exitCode: 0,
+			});
+			await primeOmpModelCatalog('/opt/y/omp', {}, key);
+			expect(getOmpModelContextWindow('claude-opus-4-8', key)).toBe(1_000_000);
+			// Cached: a second call within the TTL doesn't re-run the command.
+			await primeOmpModelCatalog('/opt/y/omp', {}, key);
+			expect(execFileNoThrow).toHaveBeenCalledTimes(1);
+		});
 	});
 });

--- a/src/__tests__/main/ipc/handlers/process.test.ts
+++ b/src/__tests__/main/ipc/handlers/process.test.ts
@@ -22,6 +22,10 @@ import { getDefaultShell } from '../../../../main/stores/defaults';
 import { stripThinkingFromTranscript } from '../../../../main/agents/claude-transcript-sanitizer';
 import { checkCustomPath } from '../../../../main/agents/path-prober';
 import { getChildProcesses } from '../../../../main/process-manager/utils/childProcessInfo';
+import {
+	primeOmpModelCatalog,
+	computeOmpCatalogKey,
+} from '../../../../main/agents/omp-model-catalog';
 
 // Mock electron's ipcMain
 vi.mock('electron', () => ({
@@ -217,6 +221,16 @@ vi.mock('../../../../shared/platformDetection', () => ({
 
 vi.mock('../../../../main/process-manager/utils/childProcessInfo', () => ({
 	getChildProcesses: vi.fn().mockResolvedValue([]),
+}));
+
+// Mock the omp model catalog so the spawn handler's catalog prime can be
+// asserted at the module boundary without launching a real `omp` subprocess.
+// computeOmpCatalogKey returns a stable sentinel so the prime's third arg is
+// deterministic; primeOmpModelCatalog resolves immediately so the bounded
+// Promise.race in the handler proceeds without waiting on the real cap.
+vi.mock('../../../../main/agents/omp-model-catalog', () => ({
+	primeOmpModelCatalog: vi.fn().mockResolvedValue(undefined),
+	computeOmpCatalogKey: vi.fn(() => 'omp-catalog-key'),
 }));
 
 // Mock fs/promises so the new temp-file tests can assert on writeFile/unlink
@@ -501,6 +515,55 @@ describe('process IPC handlers', () => {
 			});
 
 			expect(mockProcessManager.spawn).toHaveBeenCalled();
+		});
+
+		it('primes the omp model catalog with an expanded env whose PATH lists the binary dir first', async () => {
+			// The bun-based `omp` binary lives next to a co-located `bun` runtime;
+			// in a packaged Electron app the shell PATH is not inherited, so the
+			// prime must run with an expanded env (buildExpandedEnv) and prepend the
+			// binary's own dir. Assert the env handed to primeOmpModelCatalog reflects
+			// both: binary dir first, then the expanded standard entries.
+			const binaryPath = '/opt/tester/.bun/bin/omp';
+			const binDir = path.dirname(binaryPath);
+
+			const mockAgent = {
+				id: 'omp',
+				requiresPty: false,
+				path: binaryPath,
+			};
+
+			mockAgentDetector.getAgent.mockResolvedValue(mockAgent);
+			mockProcessManager.spawn.mockReturnValue({ pid: 4242, success: true });
+
+			const handler = handlers.get('process:spawn');
+			await handler!({} as any, {
+				sessionId: 'session-omp',
+				toolType: 'omp',
+				cwd: '/test/project',
+				command: 'omp',
+				args: [],
+			});
+
+			expect(primeOmpModelCatalog).toHaveBeenCalledTimes(1);
+			const [passedBinaryPath, passedEnv, passedKey] =
+				vi.mocked(primeOmpModelCatalog).mock.calls[0];
+			expect(passedBinaryPath).toBe(binaryPath);
+			expect(passedKey).toBe('omp-catalog-key');
+			expect(computeOmpCatalogKey).toHaveBeenCalledWith(binaryPath, undefined);
+
+			// The prime env's PATH must lead with the binary dir (so the co-located
+			// bun runtime resolves first), followed by the expanded standard entries.
+			expect(typeof passedEnv?.PATH).toBe('string');
+			const pathEntries = (passedEnv!.PATH as string).split(path.delimiter);
+			expect(pathEntries[0]).toBe(binDir);
+			// Expansion added entries beyond just the prepended binary dir, and the
+			// process's own PATH survived the expansion (proving it is the expanded
+			// env, not a bare { PATH: binDir }).
+			expect(pathEntries.length).toBeGreaterThan(1);
+			const currentPathEntries = (process.env.PATH || '').split(path.delimiter).filter(Boolean);
+			if (currentPathEntries.length > 0) {
+				expect(pathEntries).toEqual(expect.arrayContaining([currentPathEntries[0]]));
+			}
 		});
 
 		it('should apply readOnlyEnvOverrides when readOnlyMode is true', async () => {

--- a/src/__tests__/main/ipc/handlers/process.test.ts
+++ b/src/__tests__/main/ipc/handlers/process.test.ts
@@ -227,11 +227,19 @@ vi.mock('../../../../main/process-manager/utils/childProcessInfo', () => ({
 // asserted at the module boundary without launching a real `omp` subprocess.
 // computeOmpCatalogKey returns a stable sentinel so the prime's third arg is
 // deterministic; primeOmpModelCatalog resolves immediately so the bounded
-// Promise.race in the handler proceeds without waiting on the real cap.
-vi.mock('../../../../main/agents/omp-model-catalog', () => ({
-	primeOmpModelCatalog: vi.fn().mockResolvedValue(undefined),
-	computeOmpCatalogKey: vi.fn(() => 'omp-catalog-key'),
-}));
+// Promise.race in the handler proceeds without waiting on the real cap. The
+// real buildOmpPrimeEnv is retained (it's a pure env builder) so the test can
+// assert the actual PATH the handler hands to the prime.
+vi.mock('../../../../main/agents/omp-model-catalog', async () => {
+	const actual = await vi.importActual<typeof import('../../../../main/agents/omp-model-catalog')>(
+		'../../../../main/agents/omp-model-catalog'
+	);
+	return {
+		...actual,
+		primeOmpModelCatalog: vi.fn().mockResolvedValue(undefined),
+		computeOmpCatalogKey: vi.fn(() => 'omp-catalog-key'),
+	};
+});
 
 // Mock fs/promises so the new temp-file tests can assert on writeFile/unlink
 // without touching the real filesystem. Other tests in this file don't use

--- a/src/main/agents/detector.ts
+++ b/src/main/agents/detector.ts
@@ -30,6 +30,7 @@ import {
 	setOmpModelCatalog,
 	computeOmpCatalogKey,
 	primeOmpModelCatalog,
+	buildOmpPrimeEnv,
 } from './omp-model-catalog';
 
 const LOG_CONTEXT = 'AgentDetector';
@@ -235,9 +236,14 @@ export class AgentDetector {
 			// guards against repeated primes, and custom-path/env sessions still
 			// prime their own identity at spawn time.
 			if (agentDef.id === 'omp' && detection.exists && detection.path) {
+				// Prime with the same env-construction the spawn path uses
+				// (expanded PATH + the binary's own dir first) so a bun-based
+				// `omp` at ~/.bun/bin resolves its co-located runtime here too.
+				// getExpandedEnv() alone omits ~/.bun/bin, so the eager warm-up
+				// would lose the very cold-start race it exists to win.
 				primeOmpModelCatalog(
 					detection.path,
-					getExpandedEnv(),
+					buildOmpPrimeEnv(detection.path),
 					computeOmpCatalogKey(detection.path, undefined)
 				);
 			}

--- a/src/main/agents/detector.ts
+++ b/src/main/agents/detector.ts
@@ -26,7 +26,11 @@ import { discoverModelsFromLocalConfigs } from './opencode-config';
 import { isWindows } from '../../shared/platformDetection';
 import { parseJsonWithBom } from '../../shared/jsonUtils';
 import { capabilitySnapshots } from './capability-snapshot';
-import { setOmpModelCatalog, computeOmpCatalogKey, primeOmpModelCatalog } from './omp-model-catalog';
+import {
+	setOmpModelCatalog,
+	computeOmpCatalogKey,
+	primeOmpModelCatalog,
+} from './omp-model-catalog';
 
 const LOG_CONTEXT = 'AgentDetector';
 

--- a/src/main/agents/detector.ts
+++ b/src/main/agents/detector.ts
@@ -26,7 +26,7 @@ import { discoverModelsFromLocalConfigs } from './opencode-config';
 import { isWindows } from '../../shared/platformDetection';
 import { parseJsonWithBom } from '../../shared/jsonUtils';
 import { capabilitySnapshots } from './capability-snapshot';
-import { setOmpModelCatalog, computeOmpCatalogKey } from './omp-model-catalog';
+import { setOmpModelCatalog, computeOmpCatalogKey, primeOmpModelCatalog } from './omp-model-catalog';
 
 const LOG_CONTEXT = 'AgentDetector';
 
@@ -222,6 +222,20 @@ export class AgentDetector {
 				} else if (existing?.status !== 'not_installed') {
 					capabilitySnapshots.markNotInstalled(agentDef.id);
 				}
+			}
+
+			// Warm the default-identity omp context-window catalog the moment omp
+			// is detected, so a user's first prompt already has the real per-turn
+			// window resolved instead of losing a cold-start race against the
+			// spawn-time prime cap. Non-blocking: the catalog's own TTL/dedupe
+			// guards against repeated primes, and custom-path/env sessions still
+			// prime their own identity at spawn time.
+			if (agentDef.id === 'omp' && detection.exists && detection.path) {
+				primeOmpModelCatalog(
+					detection.path,
+					getExpandedEnv(),
+					computeOmpCatalogKey(detection.path, undefined)
+				);
 			}
 		}
 

--- a/src/main/agents/omp-model-catalog.ts
+++ b/src/main/agents/omp-model-catalog.ts
@@ -83,7 +83,12 @@ export function buildOmpPrimeEnv(
 	const env = buildExpandedEnv(customEnvVars);
 	const binDir = path.isAbsolute(binaryPath) ? path.dirname(binaryPath) : undefined;
 	if (binDir) {
-		env.PATH = [binDir, env.PATH].filter(Boolean).join(path.delimiter);
+		// Drop empty PATH components before prepending: an entry like
+		// `/usr/local/bin:` (or a leading/trailing delimiter) leaves an empty
+		// string after split, and POSIX reads an empty PATH entry as the current
+		// directory - a CWD-search hazard for the spawned `omp models` probe.
+		const pathEntries = (env.PATH ?? '').split(path.delimiter).filter(Boolean);
+		env.PATH = [binDir, ...pathEntries].join(path.delimiter);
 	}
 	return env;
 }
@@ -210,6 +215,16 @@ export function primeOmpModelCatalog(
 			if (Array.isArray(parsed.models)) {
 				setOmpModelCatalog(parsed.models, catalogKey);
 				primeFailures.delete(catalogKey);
+			} else {
+				// Valid JSON but no `models` array: the command ran yet returned an
+				// unusable payload. Negative-cache it like an outright failure so the
+				// TTL applies and every later detect/spawn doesn't re-run the same bad
+				// command within the window.
+				primeFailures.set(catalogKey, Date.now());
+				logger.warn(
+					'omp models --json returned no models array while priming catalog',
+					LOG_CONTEXT
+				);
 			}
 		} catch (error) {
 			primeFailures.set(catalogKey, Date.now());

--- a/src/main/agents/omp-model-catalog.ts
+++ b/src/main/agents/omp-model-catalog.ts
@@ -25,8 +25,10 @@
  */
 
 import { createHash } from 'crypto';
+import * as path from 'path';
 import { execFileNoThrow } from '../utils/execFile';
 import { parseJsonWithBom } from '../../shared/jsonUtils';
+import { buildExpandedEnv } from '../../shared/pathUtils';
 import { logger } from '../utils/logger';
 
 const LOG_CONTEXT = 'OmpModelCatalog';
@@ -54,8 +56,37 @@ interface CatalogState {
 const catalogs = new Map<string, CatalogState>();
 /** identity -> in-flight prime, so concurrent spawns share one fetch. */
 const primingPromises = new Map<string, Promise<void>>();
+/**
+ * identity -> last failed-prime timestamp. Failures are negative-cached so the
+ * TTL applies to them too: without this, a broken install (e.g. `omp` present
+ * but its runtime unresolvable) would re-prime and re-warn on every
+ * `agents:detect` / `agents:reprobe` / debug-package run, turning a genuine
+ * first-failure warning into recurring log noise for the already-broken user.
+ */
+const primeFailures = new Map<string, number>();
 /** Re-fetch at most this often; the catalog is effectively static per install. */
 const PRIME_TTL_MS = 5 * 60 * 1000;
+
+/**
+ * Build the environment for an `omp models --json` prime. Packaged Electron apps
+ * do not inherit the shell PATH, so a raw `process.env` lacks user-local bin dirs
+ * like `~/.bun/bin` where the bun-based `omp` binary (and its co-located runtime)
+ * may live. Expand the PATH the same way agent spawning does, then prepend the
+ * binary's own directory so a co-located runtime is found first. Both prime sites
+ * (detection and spawn) MUST route through this so their discovery results, and
+ * therefore the catalogs they produce, stay in lockstep.
+ */
+export function buildOmpPrimeEnv(
+	binaryPath: string,
+	customEnvVars?: Record<string, string>
+): NodeJS.ProcessEnv {
+	const env = buildExpandedEnv(customEnvVars);
+	const binDir = path.isAbsolute(binaryPath) ? path.dirname(binaryPath) : undefined;
+	if (binDir) {
+		env.PATH = [binDir, env.PATH].filter(Boolean).join(path.delimiter);
+	}
+	return env;
+}
 
 function normalizeKey(model: string): string {
 	return model.trim().toLowerCase();
@@ -158,10 +189,17 @@ export function primeOmpModelCatalog(
 	if (existing && Date.now() - existing.primedAt < PRIME_TTL_MS) {
 		return Promise.resolve();
 	}
+	// Honor the same TTL for a recent failure so a broken install isn't re-primed
+	// (and re-warned) on every detect/reprobe pass within the window.
+	const lastFailure = primeFailures.get(catalogKey);
+	if (lastFailure !== undefined && Date.now() - lastFailure < PRIME_TTL_MS) {
+		return Promise.resolve();
+	}
 	const promise = (async () => {
 		try {
 			const result = await execFileNoThrow(command, ['models', '--json'], undefined, env);
 			if (result.exitCode !== 0) {
+				primeFailures.set(catalogKey, Date.now());
 				logger.warn('omp models --json failed while priming catalog', LOG_CONTEXT, {
 					exitCode: result.exitCode,
 					stderr: result.stderr?.trim(),
@@ -171,8 +209,10 @@ export function primeOmpModelCatalog(
 			const parsed = parseJsonWithBom<{ models?: OmpCatalogEntry[] }>(result.stdout);
 			if (Array.isArray(parsed.models)) {
 				setOmpModelCatalog(parsed.models, catalogKey);
+				primeFailures.delete(catalogKey);
 			}
 		} catch (error) {
+			primeFailures.set(catalogKey, Date.now());
 			logger.warn('Failed to prime omp model catalog', LOG_CONTEXT, { error: String(error) });
 		} finally {
 			primingPromises.delete(catalogKey);
@@ -186,4 +226,5 @@ export function primeOmpModelCatalog(
 export function __resetOmpModelCatalogForTests(): void {
 	catalogs.clear();
 	primingPromises.clear();
+	primeFailures.clear();
 }

--- a/src/main/agents/omp-model-catalog.ts
+++ b/src/main/agents/omp-model-catalog.ts
@@ -162,8 +162,9 @@ export function primeOmpModelCatalog(
 		try {
 			const result = await execFileNoThrow(command, ['models', '--json'], undefined, env);
 			if (result.exitCode !== 0) {
-				logger.debug('omp models --json failed while priming catalog', LOG_CONTEXT, {
+				logger.warn('omp models --json failed while priming catalog', LOG_CONTEXT, {
 					exitCode: result.exitCode,
+					stderr: result.stderr?.trim(),
 				});
 				return;
 			}
@@ -172,7 +173,7 @@ export function primeOmpModelCatalog(
 				setOmpModelCatalog(parsed.models, catalogKey);
 			}
 		} catch (error) {
-			logger.debug('Failed to prime omp model catalog', LOG_CONTEXT, { error: String(error) });
+			logger.warn('Failed to prime omp model catalog', LOG_CONTEXT, { error: String(error) });
 		} finally {
 			primingPromises.delete(catalogKey);
 		}

--- a/src/main/ipc/handlers/process/handle-spawn.ts
+++ b/src/main/ipc/handlers/process/handle-spawn.ts
@@ -777,7 +777,7 @@ export async function handleProcessSpawn(
 		// Bounded await: block the spawn only briefly so the first turn resolves
 		// correctly on a warm/fast catalog, and proceed (letting the prime finish
 		// in the background for later turns) when it is slow or fails.
-		const OMP_PRIME_SPAWN_CAP_MS = 2000;
+		const OMP_PRIME_SPAWN_CAP_MS = 3500;
 		// Prime with the platform-expanded env (mirroring the Windows agent path
 		// above) so the bun-based `omp` binary resolves in a packaged app: packaged
 		// Electron apps do not inherit the shell PATH, so a raw `process.env` lacks

--- a/src/main/ipc/handlers/process/handle-spawn.ts
+++ b/src/main/ipc/handlers/process/handle-spawn.ts
@@ -778,11 +778,14 @@ export async function handleProcessSpawn(
 		// correctly on a warm/fast catalog, and proceed (letting the prime finish
 		// in the background for later turns) when it is slow or fails.
 		const OMP_PRIME_SPAWN_CAP_MS = 2000;
-		const prime = primeOmpModelCatalog(
-			localSpawnBinaryPath,
-			{ ...process.env, ...customEnvVarsToPass },
-			ompModelCatalogKey
-		);
+		// Prime with the platform-expanded env (mirroring the Windows agent path
+		// above) so the bun-based `omp` binary resolves in a packaged app: packaged
+		// Electron apps do not inherit the shell PATH, so a raw `process.env` lacks
+		// user-local bin dirs like `~/.bun/bin`. Prepend the binary's own dir so a
+		// co-located runtime is found first, matching the agent spawn's extraPathDirs.
+		const primeEnv = buildExpandedEnv(customEnvVarsToPass);
+		primeEnv.PATH = `${localAgentBinDir}${path.delimiter}${primeEnv.PATH ?? ''}`;
+		const prime = primeOmpModelCatalog(localSpawnBinaryPath, primeEnv, ompModelCatalogKey);
 		await Promise.race([
 			prime,
 			new Promise<void>((resolve) => setTimeout(resolve, OMP_PRIME_SPAWN_CAP_MS)),

--- a/src/main/ipc/handlers/process/handle-spawn.ts
+++ b/src/main/ipc/handlers/process/handle-spawn.ts
@@ -42,7 +42,11 @@ import { applyLocalInteractiveSpawnDecision } from './apply-local-interactive-sp
 import { persistClaudeInteractiveMode } from './persist-claude-interactive-mode';
 import { wrapSpawnForSsh } from './wrap-spawn-for-ssh';
 import { preparePermissionRelayArgs } from '../../../permission-relay';
-import { primeOmpModelCatalog, computeOmpCatalogKey } from '../../../agents/omp-model-catalog';
+import {
+	primeOmpModelCatalog,
+	computeOmpCatalogKey,
+	buildOmpPrimeEnv,
+} from '../../../agents/omp-model-catalog';
 import type { SpawnProcessConfig } from './spawn-types';
 
 const LOG_CONTEXT = '[ProcessManager]';
@@ -781,10 +785,10 @@ export async function handleProcessSpawn(
 		// Prime with the platform-expanded env (mirroring the Windows agent path
 		// above) so the bun-based `omp` binary resolves in a packaged app: packaged
 		// Electron apps do not inherit the shell PATH, so a raw `process.env` lacks
-		// user-local bin dirs like `~/.bun/bin`. Prepend the binary's own dir so a
-		// co-located runtime is found first, matching the agent spawn's extraPathDirs.
-		const primeEnv = buildExpandedEnv(customEnvVarsToPass);
-		primeEnv.PATH = `${localAgentBinDir}${path.delimiter}${primeEnv.PATH ?? ''}`;
+		// user-local bin dirs like `~/.bun/bin`. buildOmpPrimeEnv also prepends the
+		// binary's own dir so a co-located runtime is found first, and the detector's
+		// warm-up shares it so both prime sites build an identical env.
+		const primeEnv = buildOmpPrimeEnv(localSpawnBinaryPath, customEnvVarsToPass);
 		const prime = primeOmpModelCatalog(localSpawnBinaryPath, primeEnv, ompModelCatalogKey);
 		await Promise.race([
 			prime,


### PR DESCRIPTION
## Finding C1 - omp context window

The omp context-window gauge showed the 200k fallback instead of the real per-turn window (e.g. 1M on Opus) because the catalog prime ran with an unexpanded PATH that could not find the bun-based omp binary in a packaged app, and the cold prime lost a first-turn race.

## Change
- Primes the omp model catalog with the platform-expanded env (binary dir first, via `path.delimiter`) at spawn (`handle-spawn.ts`).
- Eagerly warms the default identity at detection time (`detector.ts`), non-blocking.
- Raises `OMP_PRIME_SPAWN_CAP_MS` 2000 -> 3500 for cold-prime margin.
- Upgrades silent prime failures to warn-level logs with trimmed stderr (`omp-model-catalog.ts`).

## Validation
Type check (3 tsc configs), ESLint, Prettier clean. Scoped tests (`process.test.ts`, `detector.test.ts`, `omp-model-catalog.test.ts`, `StdoutHandler.test.ts`) -> 289/289 pass.

Fix plan: `.maestro/FIX-C1-01.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OMP model catalogs now warm up automatically when an OMP agent is detected and when it’s launched.
  * Environment setup now prioritizes co-located/local OMP binaries during initialization.
* **Bug Fixes**
  * OMP startup applies expanded environment settings more consistently, including PATH ordering.
  * Initialization waiting time for OMP warm-up is increased.
* **Diagnostics**
  * OMP warm-up failures are handled more clearly and are negatively cached to avoid repeated re-attempts within a short cooldown.
* **Tests**
  * Added/extended coverage for OMP warm-up during both detection and process spawn, including negative-caching scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->