### PR TITLE
feat(files): add "New Agent Here" to the folder right-click menu

### DIFF
--- a/src/__tests__/renderer/components/FileExplorerPanel.test.tsx
+++ b/src/__tests__/renderer/components/FileExplorerPanel.test.tsx
@@ -160,6 +160,11 @@ vi.mock('lucide-react', () => ({
 			📁
 		</span>
 	),
+	Bot: ({ className, style }: { className?: string; style?: React.CSSProperties }) => (
+		<span data-testid="bot-icon" className={className} style={style}>
+			🤖
+		</span>
+	),
 	Files: ({ className, style }: { className?: string; style?: React.CSSProperties }) => (
 		<span data-testid="files-icon" className={className} style={style}>
 			🗂️

--- a/src/__tests__/renderer/components/FileExplorerPanel/components/FileTreeContextMenu.test.tsx
+++ b/src/__tests__/renderer/components/FileExplorerPanel/components/FileTreeContextMenu.test.tsx
@@ -62,6 +62,7 @@ const defaultProps = {
 	onOpenInExplorer: vi.fn(),
 	onOpenNewFile: vi.fn(),
 	onOpenNewFolder: vi.fn(),
+	onNewAgentHere: vi.fn(),
 	onPreviewFile: vi.fn(),
 	onPreviewAllInFolder: vi.fn(),
 	onPreviewMulti: vi.fn(),
@@ -102,6 +103,45 @@ describe('FileTreeContextMenu', () => {
 		expect(screen.getByText('Preview All 2 Files in Folder')).toBeTruthy();
 		expect(screen.getByText('Copy Path')).toBeTruthy();
 		expect(screen.queryByText('Preview')).toBeNull();
+	});
+
+	it('shows New Agent Here for a folder and fires the callback', () => {
+		const onNewAgentHere = vi.fn();
+		render(
+			<FileTreeContextMenu
+				{...defaultProps}
+				onNewAgentHere={onNewAgentHere}
+				contextMenu={makeContextMenu(folderNode)}
+			/>
+		);
+		fireEvent.click(screen.getByText('New Agent Here'));
+		expect(onNewAgentHere).toHaveBeenCalledTimes(1);
+	});
+
+	it('hides New Agent Here for files and for the empty-space root menu', () => {
+		const { unmount } = render(
+			<FileTreeContextMenu {...defaultProps} contextMenu={makeContextMenu(fileNode)} />
+		);
+		expect(screen.queryByText('New Agent Here')).toBeNull();
+		unmount();
+
+		render(
+			<FileTreeContextMenu {...defaultProps} contextMenu={{ x: 1, y: 2, node: null, path: '' }} />
+		);
+		expect(screen.queryByText('New Agent Here')).toBeNull();
+	});
+
+	it('hides New Agent Here over SSH, where the folder path is remote', () => {
+		render(
+			<FileTreeContextMenu
+				{...defaultProps}
+				sshRemoteId="remote-1"
+				contextMenu={makeContextMenu(folderNode)}
+			/>
+		);
+		expect(screen.queryByText('New Agent Here')).toBeNull();
+		// The rest of the folder menu is unaffected.
+		expect(screen.getByText('New Folder')).toBeTruthy();
 	});
 
 	it('pluralizes the preview-all label to singular for one previewable file', () => {

--- a/src/__tests__/renderer/components/FileExplorerPanel/hooks/useFileContextMenu.test.ts
+++ b/src/__tests__/renderer/components/FileExplorerPanel/hooks/useFileContextMenu.test.ts
@@ -402,6 +402,77 @@ describe('useFileContextMenu', () => {
 		expect(openNewFolderModal).toHaveBeenCalledWith('docs', '/project/docs');
 	});
 
+	it('handleNewAgentHere opens the newInstance modal seeded with the folder path', () => {
+		const openModal = vi.fn();
+		vi.mocked(modalStore.useModalStore.getState).mockReturnValueOnce({ openModal } as any);
+
+		const { result } = renderHook(() => useFileContextMenu(defaultArgs));
+		const e = {
+			clientX: 10,
+			clientY: 10,
+			preventDefault: vi.fn(),
+			stopPropagation: vi.fn(),
+		} as unknown as React.MouseEvent;
+		act(() => {
+			result.current.openContextMenu(e, folderNode, 'docs', 0);
+		});
+		act(() => {
+			result.current.handleNewAgentHere();
+		});
+		expect(openModal).toHaveBeenCalledWith('newInstance', {
+			duplicatingSessionId: null,
+			presetWorkingDir: '/project/docs',
+		});
+		expect(result.current.contextMenu).toBeNull();
+	});
+
+	it('handleNewAgentHere joins nested folder paths with the base separator', () => {
+		const openModal = vi.fn();
+		vi.mocked(modalStore.useModalStore.getState).mockReturnValueOnce({ openModal } as any);
+
+		const winSession = { ...session, fullPath: 'C:\\Users\\Test' };
+		const { result } = renderHook(() =>
+			useFileContextMenu({ ...defaultArgs, session: winSession })
+		);
+		const e = {
+			clientX: 10,
+			clientY: 10,
+			preventDefault: vi.fn(),
+			stopPropagation: vi.fn(),
+		} as unknown as React.MouseEvent;
+		act(() => {
+			result.current.openContextMenu(e, folderNode, 'src/renderer', 0);
+		});
+		act(() => {
+			result.current.handleNewAgentHere();
+		});
+		expect(openModal).toHaveBeenCalledWith('newInstance', {
+			duplicatingSessionId: null,
+			presetWorkingDir: 'C:\\Users\\Test\\src\\renderer',
+		});
+	});
+
+	it('handleNewAgentHere is a no-op for file rows', () => {
+		const openModal = vi.fn();
+		vi.mocked(modalStore.useModalStore.getState).mockReturnValue({ openModal } as any);
+
+		const { result } = renderHook(() => useFileContextMenu(defaultArgs));
+		const e = {
+			clientX: 10,
+			clientY: 10,
+			preventDefault: vi.fn(),
+			stopPropagation: vi.fn(),
+		} as unknown as React.MouseEvent;
+		act(() => {
+			result.current.openContextMenu(e, fileNode, 'App.tsx', 0);
+		});
+		act(() => {
+			result.current.handleNewAgentHere();
+		});
+		expect(openModal).not.toHaveBeenCalled();
+		expect(result.current.contextMenu).toBeNull();
+	});
+
 	it('handleOpenInMaestroBrowser encodes the file:// URL', () => {
 		const onOpenBrowserTabAt = vi.fn();
 		const { result } = renderHook(() => useFileContextMenu({ ...defaultArgs, onOpenBrowserTabAt }));

--- a/src/__tests__/renderer/components/NewInstanceModal.test.tsx
+++ b/src/__tests__/renderer/components/NewInstanceModal.test.tsx
@@ -3298,4 +3298,92 @@ describe('NewInstanceModal', () => {
 			});
 		});
 	});
+
+	describe('presetWorkingDir', () => {
+		it('seeds the working directory and derives the agent name from its basename', async () => {
+			render(
+				<NewInstanceModal
+					isOpen={true}
+					onClose={onClose}
+					onCreate={onCreate}
+					theme={theme}
+					existingSessions={[]}
+					presetWorkingDir="/project/src/renderer"
+				/>
+			);
+
+			await waitFor(() => {
+				expect(screen.getByLabelText('Working Directory')).toHaveValue('/project/src/renderer');
+			});
+			expect(screen.getByLabelText('Agent Name')).toHaveValue('renderer');
+		});
+
+		it('leaves the seeded fields editable', async () => {
+			render(
+				<NewInstanceModal
+					isOpen={true}
+					onClose={onClose}
+					onCreate={onCreate}
+					theme={theme}
+					existingSessions={[]}
+					presetWorkingDir="/project/docs"
+				/>
+			);
+
+			const nameInput = await screen.findByLabelText('Agent Name');
+			await waitFor(() => expect(nameInput).toHaveValue('docs'));
+			fireEvent.change(nameInput, { target: { value: 'my agent' } });
+			expect(nameInput).toHaveValue('my agent');
+		});
+
+		it('ignores presetWorkingDir when duplicating so the source cwd wins', async () => {
+			const source: Session = {
+				id: 'src-1',
+				name: 'Source',
+				toolType: 'claude-code',
+				cwd: '/source/project',
+				projectRoot: '/source/project',
+				fullPath: '/source/project',
+				state: 'idle',
+				inputMode: 'ai',
+				aiPid: 1,
+				terminalPid: 2,
+				port: 3000,
+				aiTabs: [],
+				activeTabId: 'tab-1',
+				closedTabHistory: [],
+				shellLogs: [],
+				executionQueue: [],
+				contextUsage: 0,
+				workLog: [],
+				isGitRepo: false,
+				changedFiles: [],
+				fileTree: [],
+				fileExplorerExpanded: [],
+				fileExplorerScrollPos: 0,
+				isLive: false,
+			} as Session;
+
+			vi.mocked(window.maestro.agents.detect).mockResolvedValue([
+				createAgentConfig({ id: 'claude-code', name: 'Claude Code', available: true }),
+			]);
+
+			render(
+				<NewInstanceModal
+					isOpen={true}
+					onClose={onClose}
+					onCreate={onCreate}
+					theme={theme}
+					existingSessions={[source]}
+					sourceSession={source}
+					presetWorkingDir="/project/docs"
+				/>
+			);
+
+			await waitFor(() => {
+				expect(screen.getByLabelText('Working Directory')).toHaveValue('/source/project');
+			});
+			expect(screen.getByLabelText('Agent Name')).toHaveValue('Source (Copy)');
+		});
+	});
 });

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -226,6 +226,7 @@ function MaestroConsoleInner() {
 		newInstanceModalOpen,
 		duplicatingSessionId,
 		newInstancePresetGroupId,
+		newInstancePresetWorkingDir,
 		// Edit Agent Modal
 		setEditAgentModalOpen,
 		editAgentSession,
@@ -3194,6 +3195,7 @@ function MaestroConsoleInner() {
 						onCreateSession={createNewSession}
 						duplicatingSessionId={duplicatingSessionId}
 						newInstancePresetGroupId={newInstancePresetGroupId}
+						newInstancePresetWorkingDir={newInstancePresetWorkingDir}
 						onCloseEditAgentModal={handleCloseEditAgentModal}
 						onSaveEditAgent={handleSaveEditAgent}
 						editAgentSession={editAgentSession}

--- a/src/renderer/components/AppModals/AppModals.tsx
+++ b/src/renderer/components/AppModals/AppModals.tsx
@@ -119,6 +119,7 @@ export interface AppModalsProps {
 	) => void;
 	duplicatingSessionId?: string | null; // Session ID to duplicate from
 	newInstancePresetGroupId?: string | null; // Group to place the new agent in
+	newInstancePresetWorkingDir?: string | null; // Working directory to seed the new agent with
 	onCloseEditAgentModal: () => void;
 	onSaveEditAgent: (
 		sessionId: string,
@@ -639,6 +640,7 @@ export const AppModals = memo(function AppModals(props: AppModalsProps) {
 		onCreateSession,
 		duplicatingSessionId,
 		newInstancePresetGroupId,
+		newInstancePresetWorkingDir,
 		onCloseEditAgentModal,
 		onSaveEditAgent,
 		editAgentSession,
@@ -968,6 +970,7 @@ export const AppModals = memo(function AppModals(props: AppModalsProps) {
 				existingSessions={sessions}
 				sourceSession={sourceSession}
 				newInstancePresetGroupId={newInstancePresetGroupId}
+				newInstancePresetWorkingDir={newInstancePresetWorkingDir}
 				editAgentModalOpen={editAgentModalOpen}
 				onCloseEditAgentModal={onCloseEditAgentModal}
 				onSaveEditAgent={onSaveEditAgent}

--- a/src/renderer/components/AppModals/AppSessionModals.tsx
+++ b/src/renderer/components/AppModals/AppSessionModals.tsx
@@ -54,6 +54,7 @@ export interface AppSessionModalsProps {
 	existingSessions: Session[];
 	sourceSession?: Session; // For agent duplication
 	newInstancePresetGroupId?: string | null; // Group to place the new agent in
+	newInstancePresetWorkingDir?: string | null; // Working directory to seed the new agent with
 
 	// EditAgentModal
 	editAgentModalOpen: boolean;
@@ -128,6 +129,7 @@ export const AppSessionModals = memo(function AppSessionModals({
 	existingSessions,
 	sourceSession,
 	newInstancePresetGroupId,
+	newInstancePresetWorkingDir,
 	// EditAgentModal
 	editAgentModalOpen,
 	onCloseEditAgentModal,
@@ -196,6 +198,7 @@ export const AppSessionModals = memo(function AppSessionModals({
 					existingSessions={existingSessions}
 					sourceSession={sourceSession}
 					presetGroupId={newInstancePresetGroupId}
+					presetWorkingDir={newInstancePresetWorkingDir}
 				/>
 			)}
 

--- a/src/renderer/components/FileExplorerPanel/FileExplorerPanel.tsx
+++ b/src/renderer/components/FileExplorerPanel/FileExplorerPanel.tsx
@@ -351,6 +351,7 @@ function FileExplorerPanelInner(props: FileExplorerPanelProps) {
 		handleOpenInExplorer,
 		handleOpenNewFile,
 		handleOpenNewFolder,
+		handleNewAgentHere,
 		handleOpenRename,
 		handleOpenDelete,
 		handleFocusInGraph,
@@ -938,6 +939,7 @@ function FileExplorerPanelInner(props: FileExplorerPanelProps) {
 					onOpenInExplorer={handleOpenInExplorer}
 					onOpenNewFile={handleOpenNewFile}
 					onOpenNewFolder={handleOpenNewFolder}
+					onNewAgentHere={handleNewAgentHere}
 					onPreviewFile={handlePreviewFile}
 					onPreviewAllInFolder={handlePreviewAllInFolder}
 					onPreviewMulti={handlePreviewMulti}

--- a/src/renderer/components/FileExplorerPanel/components/FileTreeContextMenu.tsx
+++ b/src/renderer/components/FileExplorerPanel/components/FileTreeContextMenu.tsx
@@ -12,6 +12,7 @@ import {
 	FolderPlus,
 	Files,
 	Download,
+	Bot,
 } from 'lucide-react';
 import { getRevealLabel } from '../../../utils/platformUtils';
 import { collectPreviewableFiles } from '../utils/pathHelpers';
@@ -36,6 +37,7 @@ interface FileTreeContextMenuProps {
 	onOpenInExplorer: () => void;
 	onOpenNewFile: () => void;
 	onOpenNewFolder: () => void;
+	onNewAgentHere: () => void;
 	onPreviewFile: () => void;
 	onPreviewAllInFolder: () => void;
 	onPreviewMulti: () => void;
@@ -64,6 +66,7 @@ export function FileTreeContextMenu({
 	onOpenInExplorer,
 	onOpenNewFile,
 	onOpenNewFolder,
+	onNewAgentHere,
 	onPreviewFile,
 	onPreviewAllInFolder,
 	onPreviewMulti,
@@ -166,6 +169,21 @@ export function FileTreeContextMenu({
 									<FolderPlus className="w-3.5 h-3.5" style={{ color: theme.colors.accent }} />
 									<span>New Folder</span>
 								</button>
+								{/* New Agent Here - opens the New Agent modal with this folder
+								    pre-filled as the working directory. Hidden over SSH: the
+								    path is remote, and a fresh agent starts out local, so
+								    seeding it would point the new agent at a local path that
+								    doesn't exist. */}
+								{!sshRemoteId && (
+									<button
+										onClick={onNewAgentHere}
+										className="w-full flex items-center gap-2 px-2 py-1.5 rounded text-xs hover:bg-white/10 transition-colors"
+										style={{ color: theme.colors.textMain }}
+									>
+										<Bot className="w-3.5 h-3.5" style={{ color: theme.colors.accent }} />
+										<span>New Agent Here</span>
+									</button>
+								)}
 								{previewableCount > 0 && (
 									<button
 										onClick={onPreviewAllInFolder}

--- a/src/renderer/components/FileExplorerPanel/hooks/useFileContextMenu.ts
+++ b/src/renderer/components/FileExplorerPanel/hooks/useFileContextMenu.ts
@@ -8,6 +8,7 @@ import { useModalStore } from '../../../stores/modalStore';
 import { safeClipboardWrite } from '../../../utils/clipboard';
 import { captureException } from '../../../utils/sentry';
 import { shouldOpenExternally } from '../../../utils/fileExplorer';
+import { joinPath } from '../../../../shared/formatters';
 import type { ContextMenuState, MultiDeleteModalState } from '../types';
 import { PREVIEW_ALL_CONFIRM_THRESHOLD } from '../types';
 import { collectPreviewableFiles, findNodeAtPath } from '../utils/pathHelpers';
@@ -58,6 +59,7 @@ interface UseFileContextMenuResult {
 	handleOpenInExplorer: () => void;
 	handleOpenNewFile: () => void;
 	handleOpenNewFolder: () => void;
+	handleNewAgentHere: () => void;
 	handleOpenRename: () => void;
 	handleOpenDelete: () => Promise<void>;
 	handleFocusInGraph: () => void;
@@ -492,6 +494,20 @@ export function useFileContextMenu({
 		setContextMenu(null);
 	}, [contextMenu, session.fullPath]);
 
+	// Open the New Agent modal pre-seeded with this folder as the working
+	// directory, giving a one-click path from browsing files to an agent scoped
+	// to a subfolder. Mirrors how the Left Bar's group menu opens the same modal
+	// with preset data rather than threading a callback down from App.
+	const handleNewAgentHere = useCallback(() => {
+		const menu = contextMenu;
+		setContextMenu(null);
+		if (!menu || !menu.node || menu.node.type !== 'folder') return;
+		useModalStore.getState().openModal('newInstance', {
+			duplicatingSessionId: null,
+			presetWorkingDir: joinPath(session.fullPath, menu.path),
+		});
+	}, [contextMenu, session.fullPath]);
+
 	// Resolve the folder that a "New File"/"New Folder" action should target from
 	// the current menu context. A folder row creates inside that folder; a file
 	// row or the empty-space root menu creates alongside it (the parent dir, which
@@ -560,6 +576,7 @@ export function useFileContextMenu({
 		handleOpenInExplorer,
 		handleOpenNewFile,
 		handleOpenNewFolder,
+		handleNewAgentHere,
 		handleOpenRename,
 		handleOpenDelete,
 		handleFocusInGraph,

--- a/src/renderer/components/NewInstanceModal/NewInstanceModal.tsx
+++ b/src/renderer/components/NewInstanceModal/NewInstanceModal.tsx
@@ -6,6 +6,7 @@ import { MODAL_PRIORITIES } from '../../constants/modalPriorities';
 import { validateNewSession } from '../../utils/sessionValidation';
 import { isAdaptiveModeDefaultOn, resilienceEnabled } from '../../../shared/agentConstants';
 import { normalizeAdditionalDirectories } from '../../../shared/additionalDirectories';
+import { getBasename } from '../../../shared/formatters';
 import { FormInput } from '../ui/FormInput';
 import { AdditionalDirectoriesSection } from '../shared/AdditionalDirectoriesSection';
 import { AgentResilienceSection } from './AgentResilienceSection';
@@ -32,6 +33,7 @@ export function NewInstanceModal({
 	existingSessions,
 	sourceSession,
 	presetGroupId,
+	presetWorkingDir,
 }: NewInstanceModalProps) {
 	const [agents, setAgents] = useState<AgentConfig[]>([]);
 	const [selectedAgent, setSelectedAgent] = useState('');
@@ -746,8 +748,16 @@ export function NewInstanceModal({
 			// Seed group selection: duplicate inherits source's group; otherwise
 			// honor any presetGroupId from the caller.
 			setSelectedGroupId(sourceSession?.groupId ?? presetGroupId ?? '');
+			// Seed the working directory from the caller (e.g. "New Agent Here" on a
+			// folder in the Files panel). Skipped when duplicating - loadAgents fills
+			// the working dir from the source session instead. The folder's basename
+			// is a sensible default name, and both fields stay editable.
+			if (!sourceSession && presetWorkingDir) {
+				handleWorkingDirChange(presetWorkingDir);
+				setInstanceName(getBasename(presetWorkingDir));
+			}
 		}
-	}, [isOpen, sourceSession?.id, presetGroupId]);
+	}, [isOpen, sourceSession?.id, presetGroupId, presetWorkingDir, handleWorkingDirChange]);
 
 	// Load SSH remote configurations independently of agent detection
 	// This ensures SSH remotes are available even if agent detection fails

--- a/src/renderer/components/NewInstanceModal/types.ts
+++ b/src/renderer/components/NewInstanceModal/types.ts
@@ -68,6 +68,7 @@ export interface NewInstanceModalProps {
 	existingSessions: Session[];
 	sourceSession?: Session; // Optional session to duplicate from
 	presetGroupId?: string | null; // Group to place the new agent in (ignored when duplicating - duplicate inherits source's group)
+	presetWorkingDir?: string | null; // Working directory to seed, plus a default name from its basename (ignored when duplicating - duplicate inherits source's cwd)
 }
 
 export interface EditAgentModalProps {

--- a/src/renderer/stores/modalStore.ts
+++ b/src/renderer/stores/modalStore.ts
@@ -88,6 +88,8 @@ export interface NewInstanceModalData {
 	duplicatingSessionId: string | null;
 	/** When set, the new agent is created inside this group (ignored if duplicatingSessionId is set - duplicates inherit the source's group). */
 	presetGroupId?: string | null;
+	/** When set, seeds the working directory (and a default name from its basename). Ignored if duplicatingSessionId is set - duplicates inherit the source's cwd. */
+	presetWorkingDir?: string | null;
 }
 
 /** Edit agent modal data */
@@ -1065,6 +1067,7 @@ export function useModalActions() {
 		newInstanceModalOpen,
 		duplicatingSessionId: newInstanceData?.duplicatingSessionId ?? null,
 		newInstancePresetGroupId: newInstanceData?.presetGroupId ?? null,
+		newInstancePresetWorkingDir: newInstanceData?.presetWorkingDir ?? null,
 
 		// Edit Agent Modal
 		editAgentModalOpen,


### PR DESCRIPTION
Closes #1300

## What

Right-clicking a folder in the Files panel (Right Bar) now offers **New Agent Here**. It opens the standard New Agent modal pre-filled with that folder as the working directory, and the folder's basename as a default agent name.

Both fields stay editable, and provider / group / SSH / nudge choices are unchanged - this only removes the manual re-typing of the path that the issue calls out.

## How

Plumbed via a new `presetWorkingDir` field on the `newInstance` modal data, mirroring how the Left Bar's group context menu already opens the same modal with `presetGroupId` rather than threading a callback down from `App.tsx`.

- `modalStore.ts` - `presetWorkingDir` on `NewInstanceModalData`, exposed as `newInstancePresetWorkingDir`
- `App.tsx` -> `AppModals.tsx` -> `AppSessionModals.tsx` -> `NewInstanceModal` - threaded alongside the existing `presetGroupId`
- `NewInstanceModal.tsx` - seeds working dir + name on open; skipped when duplicating so the source session's cwd still wins
- `useFileContextMenu.ts` - `handleNewAgentHere`, using `joinPath()` so the separator follows the workspace root (Windows-safe)
- `FileTreeContextMenu.tsx` - the menu item, folder rows only

## Notes

- **Folder rows only.** Not shown on file rows or the empty-space root menu (the root menu is already the agent's own working directory).
- **Hidden over SSH.** The folder path is remote, but a freshly created agent starts out local, so seeding it would silently point the new agent at a local path that doesn't exist. Making this work properly would mean pre-seeding the new agent's SSH remote config too, which felt like a separate change.

## Testing

- New unit tests: `useFileContextMenu` (folder path seeding incl. a Windows separator case, no-op on file rows), `FileTreeContextMenu` (shown for folders, hidden for files/root/SSH), `NewInstanceModal` (seeds dir + name, stays editable, ignored when duplicating).
- `npm run lint` clean, ESLint clean, full suite green: 34,656 passed / 108 skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “New Agent Here” option to folder context menus.
  * Automatically opens the new-agent modal with the selected folder as the working directory.
  * Pre-fills the agent name based on the selected folder.
  * Supports nested folders and Windows paths.

* **Bug Fixes**
  * Prevented the action from appearing for files, empty menus, and remote folders.
  * Preserved duplicated session settings when creating an agent from an existing session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->