### PR TITLE
feat(autorun): schedule an Auto Run to start at a specific date/time

### DIFF
--- a/docs/agent-guides/STATE-PATTERNS.md
+++ b/docs/agent-guides/STATE-PATTERNS.md
@@ -20,20 +20,21 @@ All stores are in `src/renderer/stores/`.
 
 ## Store Inventory
 
-| Store                 | File                   | Hook                   | Purpose                                                                                           |
-| --------------------- | ---------------------- | ---------------------- | ------------------------------------------------------------------------------------------------- |
-| **sessionStore**      | `sessionStore.ts`      | `useSessionStore`      | Sessions, groups, active session, bookmarks, worktree tracking, initialization                    |
-| **uiStore**           | `uiStore.ts`           | `useUIStore`           | UI layout: sidebars, focus, notifications, search, drag-and-drop, editing                         |
-| **tabStore**          | `tabStore.ts`          | `useTabStore`          | Tab operations (CRUD, navigation, metadata), gist state. Wraps tabHelpers.ts + sessionStore       |
-| **agentStore**        | `agentStore.ts`        | `useAgentStore`        | Agent detection cache, error recovery, queue processing, agent lifecycle                          |
-| **modalStore**        | `modalStore.ts`        | `useModalStore`        | Modal visibility via registry pattern. Single Map replaces 90+ boolean fields                     |
-| **groupChatStore**    | `groupChatStore.ts`    | `useGroupChatStore`    | Group chat state: chats list, messages, moderator, participants, execution queue                  |
-| **settingsStore**     | `settingsStore.ts`     | `useSettingsStore`     | App settings (theme, font, shortcuts, agent configs, per-modal `modalSizes`, etc.)                |
-| **fileExplorerStore** | `fileExplorerStore.ts` | `useFileExplorerStore` | File explorer panel state                                                                         |
-| **sidebarNavStore**   | `sidebarNavStore.ts`   | `useSidebarNavStore`   | Left Bar sort/nav/starred projections (`SidebarNavSync` host writes; SessionList + keyboard read) |
-| **batchStore**        | `batchStore.ts`        | `useBatchStore`        | Batch/Auto Run execution state                                                                    |
-| **notificationStore** | `notificationStore.ts` | `useNotificationStore` | In-app notification queue                                                                         |
-| **operationStore**    | `operationStore.ts`    | `useOperationStore`    | Long-running operation tracking                                                                   |
+| Store                     | File                       | Hook                       | Purpose                                                                                                                                                                             |
+| ------------------------- | -------------------------- | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **sessionStore**          | `sessionStore.ts`          | `useSessionStore`          | Sessions, groups, active session, bookmarks, worktree tracking, initialization                                                                                                      |
+| **uiStore**               | `uiStore.ts`               | `useUIStore`               | UI layout: sidebars, focus, notifications, search, drag-and-drop, editing                                                                                                           |
+| **tabStore**              | `tabStore.ts`              | `useTabStore`              | Tab operations (CRUD, navigation, metadata), gist state. Wraps tabHelpers.ts + sessionStore                                                                                         |
+| **agentStore**            | `agentStore.ts`            | `useAgentStore`            | Agent detection cache, error recovery, queue processing, agent lifecycle                                                                                                            |
+| **modalStore**            | `modalStore.ts`            | `useModalStore`            | Modal visibility via registry pattern. Single Map replaces 90+ boolean fields                                                                                                       |
+| **groupChatStore**        | `groupChatStore.ts`        | `useGroupChatStore`        | Group chat state: chats list, messages, moderator, participants, execution queue                                                                                                    |
+| **settingsStore**         | `settingsStore.ts`         | `useSettingsStore`         | App settings (theme, font, shortcuts, agent configs, per-modal `modalSizes`, etc.)                                                                                                  |
+| **fileExplorerStore**     | `fileExplorerStore.ts`     | `useFileExplorerStore`     | File explorer panel state                                                                                                                                                           |
+| **sidebarNavStore**       | `sidebarNavStore.ts`       | `useSidebarNavStore`       | Left Bar sort/nav/starred projections (`SidebarNavSync` host writes; SessionList + keyboard read)                                                                                   |
+| **batchStore**            | `batchStore.ts`            | `useBatchStore`            | Batch/Auto Run execution state                                                                                                                                                      |
+| **scheduledAutoRunStore** | `scheduledAutoRunStore.ts` | `useScheduledAutoRunStore` | One-shot Auto Runs parked for a future date/time. One pending run per agent; mirrored to the settings KV so a schedule survives a restart. Fired by `useScheduledAutoRunDispatcher` |
+| **notificationStore**     | `notificationStore.ts`     | `useNotificationStore`     | In-app notification queue                                                                                                                                                           |
+| **operationStore**        | `operationStore.ts`        | `useOperationStore`        | Long-running operation tracking                                                                                                                                                     |
 
 ---
 

--- a/src/__tests__/renderer/components/ScheduleRunSection.test.ts
+++ b/src/__tests__/renderer/components/ScheduleRunSection.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Tests for the `datetime-local` <-> epoch-ms helpers behind the Auto Run
+ * "Start" control (issue #716).
+ *
+ * The critical property is local-timezone round-tripping: `toISOString()` would
+ * shift the value by the UTC offset and silently schedule the run at the wrong
+ * wall-clock time.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+	toDateTimeLocalValue,
+	parseDateTimeLocalValue,
+} from '../../../renderer/components/ScheduleRunSection';
+
+describe('toDateTimeLocalValue', () => {
+	it('formats a Date as YYYY-MM-DDTHH:mm in local time', () => {
+		expect(toDateTimeLocalValue(new Date(2026, 4, 22, 14, 30))).toBe('2026-05-22T14:30');
+	});
+
+	it('zero-pads single-digit month, day, hour, and minute', () => {
+		expect(toDateTimeLocalValue(new Date(2026, 0, 5, 9, 7))).toBe('2026-01-05T09:07');
+	});
+});
+
+describe('parseDateTimeLocalValue', () => {
+	it('parses a value as local wall-clock time', () => {
+		expect(parseDateTimeLocalValue('2026-05-22T14:30')).toBe(
+			new Date(2026, 4, 22, 14, 30, 0, 0).getTime()
+		);
+	});
+
+	it('round-trips through toDateTimeLocalValue without a timezone shift', () => {
+		const original = new Date(2026, 10, 1, 23, 59, 0, 0);
+		const parsed = parseDateTimeLocalValue(toDateTimeLocalValue(original));
+		expect(parsed).toBe(original.getTime());
+	});
+
+	it('tolerates surrounding whitespace', () => {
+		expect(parseDateTimeLocalValue('  2026-05-22T14:30  ')).toBe(
+			new Date(2026, 4, 22, 14, 30, 0, 0).getTime()
+		);
+	});
+
+	it('returns null for empty or malformed values', () => {
+		expect(parseDateTimeLocalValue('')).toBeNull();
+		expect(parseDateTimeLocalValue('2026-05-22')).toBeNull();
+		expect(parseDateTimeLocalValue('tomorrow at 3')).toBeNull();
+		// Seconds are not part of the datetime-local format the input emits.
+		expect(parseDateTimeLocalValue('2026-05-22T14:30:00')).toBeNull();
+	});
+});

--- a/src/__tests__/renderer/hooks/batch/useScheduledAutoRunDispatcher.test.tsx
+++ b/src/__tests__/renderer/hooks/batch/useScheduledAutoRunDispatcher.test.tsx
@@ -1,0 +1,315 @@
+/**
+ * @file useScheduledAutoRunDispatcher.test.tsx
+ * @description Tests the one-shot Auto Run scheduling flow (issue #716) end to
+ * end across the two halves that own it:
+ *
+ *   1. handleStartBatchRun parks a run with a future `scheduledFor` instead of
+ *      launching it, and launches normally otherwise.
+ *   2. useScheduledAutoRunDispatcher fires parked runs once the wall clock
+ *      passes them, defers while the agent is occupied, and drops runs missed
+ *      by more than the grace window.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useAutoRunHandlers } from '../../../../renderer/hooks';
+import { useScheduledAutoRunDispatcher } from '../../../../renderer/hooks/batch/useScheduledAutoRunDispatcher';
+import type { Session, BatchRunConfig } from '../../../../renderer/types';
+import { createMockSession as baseCreateMockSession } from '../../../helpers/mockSession';
+import { useSessionStore } from '../../../../renderer/stores/sessionStore';
+import { useBatchStore } from '../../../../renderer/stores/batchStore';
+import {
+	useScheduledAutoRunStore,
+	SCHEDULED_AUTO_RUN_GRACE_MS,
+} from '../../../../renderer/stores/scheduledAutoRunStore';
+
+vi.mock('../../../../renderer/stores/notificationStore', async () => {
+	const actual = await vi.importActual('../../../../renderer/stores/notificationStore');
+	return { ...actual, notifyToast: vi.fn() };
+});
+
+const createMockSession = (overrides: Partial<Session> = {}): Session =>
+	baseCreateMockSession({
+		id: 'session-1',
+		name: 'Docs Agent',
+		cwd: '/projects/my-repo',
+		autoRunFolderPath: '/projects/autorun-docs',
+		...overrides,
+	});
+
+function seedActiveSession(session: Session) {
+	useSessionStore.setState({
+		sessions: [session],
+		activeSessionId: session.id,
+	} as never);
+}
+
+const createMockDeps = () => ({
+	setSessions: vi.fn(),
+	setAutoRunDocumentList: vi.fn(),
+	setAutoRunDocumentTree: vi.fn(),
+	setAutoRunIsLoadingDocuments: vi.fn(),
+	setAutoRunSetupModalOpen: vi.fn(),
+	setBatchRunnerModalOpen: vi.fn(),
+	setActiveRightTab: vi.fn(),
+	setRightPanelOpen: vi.fn(),
+	setActiveFocus: vi.fn(),
+	setSuccessFlashNotification: vi.fn(),
+	autoRunDocumentList: ['Phase 1'],
+	startBatchRun: vi.fn(),
+});
+
+const baseConfig: BatchRunConfig = {
+	documents: [{ id: '1', filename: 'Phase 1', resetOnCompletion: false, isDuplicate: false }],
+	prompt: 'Work the next - [ ] task',
+	loopEnabled: false,
+};
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	useSessionStore.setState({ sessions: [], activeSessionId: '' } as never);
+	useBatchStore.setState({ batchRunStates: {} } as never);
+	// Pre-hydrated so the dispatcher's tick runs without awaiting settings IPC.
+	useScheduledAutoRunStore.setState({ scheduled: {}, hydrated: true });
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+describe('handleStartBatchRun - scheduling', () => {
+	it('parks a run with a future scheduledFor instead of launching it', async () => {
+		const session = createMockSession();
+		seedActiveSession(session);
+		const deps = createMockDeps();
+		const { result } = renderHook(() => useAutoRunHandlers(deps));
+
+		const scheduledFor = Date.now() + 60 * 60 * 1000;
+		await act(async () => {
+			await result.current.handleStartBatchRun({ ...baseConfig, scheduledFor });
+		});
+
+		expect(deps.startBatchRun).not.toHaveBeenCalled();
+		expect(deps.setBatchRunnerModalOpen).toHaveBeenCalledWith(false);
+
+		const parked = useScheduledAutoRunStore.getState().scheduled['session-1'];
+		expect(parked).toMatchObject({
+			sessionId: 'session-1',
+			folderPath: '/projects/autorun-docs',
+			scheduledFor,
+		});
+	});
+
+	it('launches immediately when scheduledFor is already in the past', async () => {
+		const session = createMockSession();
+		seedActiveSession(session);
+		const deps = createMockDeps();
+		const { result } = renderHook(() => useAutoRunHandlers(deps));
+
+		await act(async () => {
+			await result.current.handleStartBatchRun({
+				...baseConfig,
+				scheduledFor: Date.now() - 1_000,
+			});
+		});
+
+		expect(useScheduledAutoRunStore.getState().scheduled).toEqual({});
+		expect(deps.startBatchRun).toHaveBeenCalledTimes(1);
+		// The timestamp must not leak into the config the runner receives.
+		expect(deps.startBatchRun.mock.calls[0][1]).not.toHaveProperty('scheduledFor');
+	});
+
+	it('targets the session passed via options rather than the active one', async () => {
+		const active = createMockSession({ id: 'active-session' });
+		const other = createMockSession({ id: 'other-session', name: 'Other Agent' });
+		useSessionStore.setState({
+			sessions: [active, other],
+			activeSessionId: active.id,
+		} as never);
+		const deps = createMockDeps();
+		const { result } = renderHook(() => useAutoRunHandlers(deps));
+
+		await act(async () => {
+			await result.current.handleStartBatchRun(baseConfig, { session: other });
+		});
+
+		expect(deps.startBatchRun).toHaveBeenCalledWith(
+			'other-session',
+			expect.anything(),
+			'/projects/autorun-docs'
+		);
+	});
+});
+
+describe('useScheduledAutoRunDispatcher', () => {
+	it('launches a parked run once its timestamp passes', async () => {
+		vi.useFakeTimers();
+		const session = createMockSession();
+		seedActiveSession(session);
+		useScheduledAutoRunStore.setState({
+			hydrated: true,
+			scheduled: {
+				'session-1': {
+					sessionId: 'session-1',
+					folderPath: '/projects/autorun-docs',
+					config: { ...baseConfig, scheduledFor: Date.now() - 1_000 },
+					scheduledFor: Date.now() - 1_000,
+					createdAt: Date.now() - 10_000,
+				},
+			},
+		});
+
+		const onLaunch = vi.fn();
+		renderHook(() => useScheduledAutoRunDispatcher({ onLaunch }));
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(20_000);
+		});
+
+		expect(onLaunch).toHaveBeenCalledTimes(1);
+		const [config, options] = onLaunch.mock.calls[0];
+		expect(config).not.toHaveProperty('scheduledFor');
+		expect(options.session.id).toBe('session-1');
+		// Cleared so a later tick can't fire it twice.
+		expect(useScheduledAutoRunStore.getState().scheduled).toEqual({});
+	});
+
+	it('leaves a future schedule parked', async () => {
+		vi.useFakeTimers();
+		const session = createMockSession();
+		seedActiveSession(session);
+		useScheduledAutoRunStore.setState({
+			hydrated: true,
+			scheduled: {
+				'session-1': {
+					sessionId: 'session-1',
+					folderPath: '/projects/autorun-docs',
+					config: baseConfig,
+					scheduledFor: Date.now() + 60 * 60 * 1000,
+					createdAt: Date.now(),
+				},
+			},
+		});
+
+		const onLaunch = vi.fn();
+		renderHook(() => useScheduledAutoRunDispatcher({ onLaunch }));
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(60_000);
+		});
+
+		expect(onLaunch).not.toHaveBeenCalled();
+		expect(useScheduledAutoRunStore.getState().scheduled['session-1']).toBeDefined();
+	});
+
+	it('defers a due run while the agent is busy, then fires when it frees up', async () => {
+		vi.useFakeTimers();
+		const session = createMockSession({ state: 'busy' });
+		seedActiveSession(session);
+		useScheduledAutoRunStore.setState({
+			hydrated: true,
+			scheduled: {
+				'session-1': {
+					sessionId: 'session-1',
+					folderPath: '/projects/autorun-docs',
+					config: baseConfig,
+					scheduledFor: Date.now() - 1_000,
+					createdAt: Date.now() - 10_000,
+				},
+			},
+		});
+
+		const onLaunch = vi.fn();
+		renderHook(() => useScheduledAutoRunDispatcher({ onLaunch }));
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(20_000);
+		});
+		expect(onLaunch).not.toHaveBeenCalled();
+		expect(useScheduledAutoRunStore.getState().scheduled['session-1']).toBeDefined();
+
+		seedActiveSession(createMockSession({ state: 'ready' }));
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(20_000);
+		});
+		expect(onLaunch).toHaveBeenCalledTimes(1);
+	});
+
+	it('defers while an Auto Run is already in flight for that agent', async () => {
+		vi.useFakeTimers();
+		seedActiveSession(createMockSession());
+		useBatchStore.setState({
+			batchRunStates: { 'session-1': { isRunning: true } },
+		} as never);
+		useScheduledAutoRunStore.setState({
+			hydrated: true,
+			scheduled: {
+				'session-1': {
+					sessionId: 'session-1',
+					folderPath: '/projects/autorun-docs',
+					config: baseConfig,
+					scheduledFor: Date.now() - 1_000,
+					createdAt: Date.now() - 10_000,
+				},
+			},
+		});
+
+		const onLaunch = vi.fn();
+		renderHook(() => useScheduledAutoRunDispatcher({ onLaunch }));
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(20_000);
+		});
+
+		expect(onLaunch).not.toHaveBeenCalled();
+		expect(useScheduledAutoRunStore.getState().scheduled['session-1']).toBeDefined();
+	});
+
+	it('drops a run missed by more than the grace window without firing it', async () => {
+		vi.useFakeTimers();
+		seedActiveSession(createMockSession());
+		useScheduledAutoRunStore.setState({
+			hydrated: true,
+			scheduled: {
+				'session-1': {
+					sessionId: 'session-1',
+					folderPath: '/projects/autorun-docs',
+					config: baseConfig,
+					scheduledFor: Date.now() - SCHEDULED_AUTO_RUN_GRACE_MS - 60_000,
+					createdAt: Date.now() - SCHEDULED_AUTO_RUN_GRACE_MS - 120_000,
+				},
+			},
+		});
+
+		const onLaunch = vi.fn();
+		renderHook(() => useScheduledAutoRunDispatcher({ onLaunch }));
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(20_000);
+		});
+
+		expect(onLaunch).not.toHaveBeenCalled();
+		expect(useScheduledAutoRunStore.getState().scheduled).toEqual({});
+	});
+
+	it('drops a schedule whose agent no longer exists', async () => {
+		vi.useFakeTimers();
+		useSessionStore.setState({ sessions: [], activeSessionId: '' } as never);
+		useScheduledAutoRunStore.setState({
+			hydrated: true,
+			scheduled: {
+				'ghost-session': {
+					sessionId: 'ghost-session',
+					folderPath: '/projects/autorun-docs',
+					config: baseConfig,
+					scheduledFor: Date.now() - 1_000,
+					createdAt: Date.now() - 10_000,
+				},
+			},
+		});
+
+		const onLaunch = vi.fn();
+		renderHook(() => useScheduledAutoRunDispatcher({ onLaunch }));
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(20_000);
+		});
+
+		expect(onLaunch).not.toHaveBeenCalled();
+		expect(useScheduledAutoRunStore.getState().scheduled).toEqual({});
+	});
+});

--- a/src/__tests__/renderer/stores/scheduledAutoRunStore.test.ts
+++ b/src/__tests__/renderer/stores/scheduledAutoRunStore.test.ts
@@ -1,0 +1,160 @@
+/**
+ * scheduledAutoRunStore tests
+ *
+ * Covers the one-shot Auto Run scheduling store (issue #716):
+ * - schedule / cancel and the one-pending-run-per-agent invariant
+ * - settings persistence + hydration, including rejecting malformed entries
+ * - partitionScheduledAutoRuns timing policy (due vs. expired vs. pending)
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+	useScheduledAutoRunStore,
+	partitionScheduledAutoRuns,
+	SCHEDULED_AUTO_RUNS_SETTINGS_KEY,
+	SCHEDULED_AUTO_RUN_GRACE_MS,
+	type ScheduledAutoRun,
+} from '../../../renderer/stores/scheduledAutoRunStore';
+import type { BatchRunConfig } from '../../../renderer/types';
+
+const CONFIG: BatchRunConfig = {
+	documents: [{ id: 'doc-1', filename: 'plan', resetOnCompletion: false, isDuplicate: false }],
+	prompt: 'Work the next - [ ] task',
+	loopEnabled: false,
+	maxLoops: null,
+};
+
+function makeEntry(overrides: Partial<ScheduledAutoRun> = {}): ScheduledAutoRun {
+	return {
+		sessionId: 'session-1',
+		folderPath: '/tmp/docs',
+		config: CONFIG,
+		scheduledFor: 5_000,
+		createdAt: 1_000,
+		...overrides,
+	};
+}
+
+const settingsGet = vi.fn();
+const settingsSet = vi.fn();
+
+beforeEach(() => {
+	settingsGet.mockReset().mockResolvedValue(null);
+	settingsSet.mockReset().mockResolvedValue(true);
+	(globalThis as unknown as { window: unknown }).window = globalThis;
+	(globalThis as { maestro?: unknown }).maestro = {
+		settings: { get: settingsGet, set: settingsSet },
+		logger: { log: vi.fn() },
+	};
+	useScheduledAutoRunStore.setState({ scheduled: {}, hydrated: false });
+});
+
+describe('scheduledAutoRunStore', () => {
+	it('stores one pending schedule per agent, replacing the previous one', () => {
+		const { schedule } = useScheduledAutoRunStore.getState();
+		schedule(makeEntry({ scheduledFor: 5_000 }));
+		schedule(makeEntry({ scheduledFor: 9_000 }));
+		schedule(makeEntry({ sessionId: 'session-2', scheduledFor: 7_000 }));
+
+		const { scheduled } = useScheduledAutoRunStore.getState();
+		expect(Object.keys(scheduled).sort()).toEqual(['session-1', 'session-2']);
+		expect(scheduled['session-1'].scheduledFor).toBe(9_000);
+	});
+
+	it('persists the schedule list to settings on schedule and cancel', () => {
+		const { schedule, cancel } = useScheduledAutoRunStore.getState();
+		schedule(makeEntry());
+		expect(settingsSet).toHaveBeenCalledWith(SCHEDULED_AUTO_RUNS_SETTINGS_KEY, [
+			expect.objectContaining({ sessionId: 'session-1', scheduledFor: 5_000 }),
+		]);
+
+		cancel('session-1');
+		expect(settingsSet).toHaveBeenLastCalledWith(SCHEDULED_AUTO_RUNS_SETTINGS_KEY, []);
+	});
+
+	it('ignores a cancel for an agent with no pending schedule', () => {
+		useScheduledAutoRunStore.getState().cancel('nobody');
+		expect(settingsSet).not.toHaveBeenCalled();
+	});
+
+	it('hydrates persisted entries and drops malformed ones', async () => {
+		settingsGet.mockResolvedValue([
+			makeEntry(),
+			{ sessionId: 'bad-1' }, // missing config/scheduledFor
+			{ ...makeEntry({ sessionId: 'bad-2' }), scheduledFor: 'soon' },
+			null,
+		]);
+
+		await useScheduledAutoRunStore.getState().hydrate();
+
+		const { scheduled, hydrated } = useScheduledAutoRunStore.getState();
+		expect(hydrated).toBe(true);
+		expect(Object.keys(scheduled)).toEqual(['session-1']);
+	});
+
+	it('hydrates only once', async () => {
+		settingsGet.mockResolvedValue([makeEntry()]);
+		await useScheduledAutoRunStore.getState().hydrate();
+		await useScheduledAutoRunStore.getState().hydrate();
+		expect(settingsGet).toHaveBeenCalledTimes(1);
+	});
+
+	it('hydrates to an empty map when settings reads fail', async () => {
+		settingsGet.mockRejectedValue(new Error('disk on fire'));
+		await useScheduledAutoRunStore.getState().hydrate();
+		expect(useScheduledAutoRunStore.getState().scheduled).toEqual({});
+		expect(useScheduledAutoRunStore.getState().hydrated).toBe(true);
+	});
+});
+
+describe('partitionScheduledAutoRuns', () => {
+	const now = 1_000_000;
+
+	it('leaves future schedules alone', () => {
+		const result = partitionScheduledAutoRuns(
+			{ a: makeEntry({ sessionId: 'a', scheduledFor: now + 1 }) },
+			now
+		);
+		expect(result.due).toEqual([]);
+		expect(result.expired).toEqual([]);
+	});
+
+	it('marks a schedule due the moment its timestamp passes', () => {
+		const result = partitionScheduledAutoRuns(
+			{ a: makeEntry({ sessionId: 'a', scheduledFor: now }) },
+			now
+		);
+		expect(result.due.map((e) => e.sessionId)).toEqual(['a']);
+	});
+
+	it('keeps a schedule due through the whole grace window', () => {
+		const result = partitionScheduledAutoRuns(
+			{ a: makeEntry({ sessionId: 'a', scheduledFor: now - SCHEDULED_AUTO_RUN_GRACE_MS }) },
+			now
+		);
+		expect(result.due.map((e) => e.sessionId)).toEqual(['a']);
+		expect(result.expired).toEqual([]);
+	});
+
+	it('expires a schedule missed by more than the grace window', () => {
+		const result = partitionScheduledAutoRuns(
+			{ a: makeEntry({ sessionId: 'a', scheduledFor: now - SCHEDULED_AUTO_RUN_GRACE_MS - 1 }) },
+			now
+		);
+		expect(result.due).toEqual([]);
+		expect(result.expired.map((e) => e.sessionId)).toEqual(['a']);
+	});
+
+	it('partitions a mixed set independently', () => {
+		const result = partitionScheduledAutoRuns(
+			{
+				future: makeEntry({ sessionId: 'future', scheduledFor: now + 60_000 }),
+				due: makeEntry({ sessionId: 'due', scheduledFor: now - 60_000 }),
+				gone: makeEntry({ sessionId: 'gone', scheduledFor: now - SCHEDULED_AUTO_RUN_GRACE_MS * 2 }),
+			},
+			now
+		);
+		expect(result.due.map((e) => e.sessionId)).toEqual(['due']);
+		expect(result.expired.map((e) => e.sessionId)).toEqual(['gone']);
+	});
+});

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -82,6 +82,7 @@ import {
 	useAppHandlers,
 	// Auto Run
 	useAutoRunHandlers,
+	useScheduledAutoRunDispatcher,
 	// Tab handlers
 	useTabHandlers,
 	useTerminalTabHandlers,
@@ -1980,6 +1981,9 @@ function MaestroConsoleInner() {
 		autoRunDocumentList,
 		startBatchRun,
 	});
+
+	// Fires Auto Runs the user parked for a future date/time (issue #716).
+	useScheduledAutoRunDispatcher({ onLaunch: handleStartBatchRun });
 
 	// Wire up refs for useWizardHandlers (circular dep resolution)
 	handleAutoRunRefreshRef.current = handleAutoRunRefresh;

--- a/src/renderer/components/AutoRun/AutoRun.tsx
+++ b/src/renderer/components/AutoRun/AutoRun.tsx
@@ -45,6 +45,7 @@ import { AutoRunLightbox } from './AutoRunLightbox';
 import { AutoRunSearchBar } from './AutoRunSearchBar';
 import { AutoRunToolbar } from './AutoRunToolbar';
 import { AutoRunErrorBanner } from './AutoRunErrorBanner';
+import { AutoRunScheduledBanner } from './AutoRunScheduledBanner';
 import { AutoRunBottomPanel } from './AutoRunBottomPanel';
 import { NoFolderState, EmptyFolderState } from './AutoRunEmptyStates';
 import { useBatchStore } from '../../stores/batchStore';
@@ -603,6 +604,9 @@ const AutoRunInner = forwardRef<AutoRunHandle, AutoRunProps>(function AutoRunInn
 					onFileSelect={handleFileSelect}
 				/>
 			)}
+
+			{/* Pending one-shot schedule - renders itself null when there isn't one */}
+			{folderPath && <AutoRunScheduledBanner theme={theme} sessionId={sessionId} />}
 
 			{/* Document Selector */}
 			{folderPath && (

--- a/src/renderer/components/AutoRun/AutoRunScheduledBanner.tsx
+++ b/src/renderer/components/AutoRun/AutoRunScheduledBanner.tsx
@@ -1,0 +1,65 @@
+/**
+ * AutoRunScheduledBanner.tsx
+ *
+ * Shown in the Auto Run panel while this agent has a run parked for a future
+ * date/time (see scheduledAutoRunStore). Without it a schedule is invisible
+ * once the modal closes, and the user has no way to cancel it.
+ */
+
+import { memo } from 'react';
+import { CalendarClock, X } from 'lucide-react';
+import type { Theme } from '../../types';
+import {
+	useScheduledAutoRunStore,
+	selectScheduledAutoRun,
+} from '../../stores/scheduledAutoRunStore';
+import { formatFutureTime } from '../../../shared/formatters';
+
+interface AutoRunScheduledBannerProps {
+	theme: Theme;
+	sessionId: string;
+}
+
+export const AutoRunScheduledBanner = memo(function AutoRunScheduledBanner({
+	theme,
+	sessionId,
+}: AutoRunScheduledBannerProps) {
+	const scheduled = useScheduledAutoRunStore(selectScheduledAutoRun(sessionId));
+	const cancel = useScheduledAutoRunStore((s) => s.cancel);
+
+	if (!scheduled) return null;
+
+	const documentCount = scheduled.config.documents.length;
+	const summary = scheduled.config.goalConfig
+		? 'Goal-Driven run'
+		: `${documentCount} document${documentCount === 1 ? '' : 's'}`;
+
+	return (
+		<div
+			className="mx-2 mb-2 px-2.5 py-2 rounded border flex items-center gap-2"
+			style={{
+				borderColor: theme.colors.accent + '40',
+				backgroundColor: theme.colors.accent + '15',
+			}}
+		>
+			<CalendarClock className="w-3.5 h-3.5 shrink-0" style={{ color: theme.colors.accent }} />
+			<div className="flex-1 min-w-0">
+				<div className="text-xs font-medium truncate" style={{ color: theme.colors.textMain }}>
+					Auto Run scheduled {formatFutureTime(scheduled.scheduledFor)}
+				</div>
+				<div className="text-[10px] truncate" style={{ color: theme.colors.textDim }}>
+					{summary} - {new Date(scheduled.scheduledFor).toLocaleString()}
+				</div>
+			</div>
+			<button
+				onClick={() => cancel(sessionId)}
+				className="p-1 rounded hover:bg-white/10 transition-colors shrink-0"
+				style={{ color: theme.colors.textDim }}
+				title="Cancel the scheduled Auto Run"
+				aria-label="Cancel scheduled Auto Run"
+			>
+				<X className="w-3.5 h-3.5" />
+			</button>
+		</div>
+	);
+});

--- a/src/renderer/components/AutoRun/AutoRunnerHelpModal.tsx
+++ b/src/renderer/components/AutoRun/AutoRunnerHelpModal.tsx
@@ -21,6 +21,7 @@ import {
 	Layers,
 	Target,
 	Brain,
+	CalendarClock,
 } from 'lucide-react';
 import type { Theme } from '../../types';
 import { MODAL_PRIORITIES } from '../../constants/modalPriorities';
@@ -755,6 +756,34 @@ export function AutoRunnerHelpModal({ theme, onClose, zIndex = 50 }: AutoRunnerH
 							without read-only restrictions, create a worktree session from the git branch menu in
 							the session list. Worktree sessions operate in isolated directories, allowing Auto Run
 							and manual work to happen simultaneously.
+						</p>
+					</div>
+				</section>
+
+				{/* Scheduling */}
+				<section>
+					<div className="flex items-center gap-2 mb-3">
+						<CalendarClock className="w-5 h-5" style={{ color: theme.colors.accent }} />
+						<h3 className="font-bold">Scheduling a Run</h3>
+					</div>
+					<div className="text-sm space-y-2 pl-7" style={{ color: theme.colors.textDim }}>
+						<p>
+							The <strong style={{ color: theme.colors.textMain }}>Start</strong> control in the
+							Auto Run window chooses between{' '}
+							<strong style={{ color: theme.colors.textMain }}>Now</strong> (the default) and{' '}
+							<strong style={{ color: theme.colors.textMain }}>At a set time</strong>. Pick a future
+							date and time and the run is parked until then, firing once. Handy for kicking work
+							off the moment a token limit resets.
+						</p>
+						<p>
+							A pending schedule shows as a banner at the top of the Auto Run panel, with an X to
+							cancel it. Scheduling while the agent is busy is fine - the run waits for it to go
+							idle.
+						</p>
+						<p>
+							Maestro has to be running when the time comes. If it was closed, the run still starts
+							when you reopen the app within 6 hours of the scheduled time; past that it's skipped
+							and you get a notification.
 						</p>
 					</div>
 				</section>

--- a/src/renderer/components/BatchRunnerModal.tsx
+++ b/src/renderer/components/BatchRunnerModal.tsx
@@ -17,6 +17,7 @@ import {
 	PlayCircle,
 	HelpCircle,
 	Target,
+	CalendarClock,
 } from 'lucide-react';
 import { Spinner } from './ui/Spinner';
 import type {
@@ -38,6 +39,12 @@ import { DocumentsPanel } from './DocumentsPanel';
 import { GoalConfigPanel } from './GoalConfigPanel';
 import { ToggleButtonGroup } from './ToggleButtonGroup';
 import { WorktreeRunSection } from './WorktreeRunSection';
+import {
+	ScheduleRunSection,
+	parseDateTimeLocalValue,
+	toDateTimeLocalValue,
+	type RunStartMode,
+} from './ScheduleRunSection';
 import { AutoRunnerHelpModal } from './AutoRun/AutoRunnerHelpModal';
 import { useSessionStore, selectSessionById, updateSessionWith } from '../stores/sessionStore';
 import { useDebouncedCallback } from '../hooks/utils/useThrottle';
@@ -151,6 +158,19 @@ export function BatchRunnerModal(props: BatchRunnerModalProps) {
 	// Worktree run target state
 	const [worktreeTarget, setWorktreeTarget] = useState<WorktreeRunTarget | null>(null);
 	const [isPreparingWorktree, setIsPreparingWorktree] = useState(false);
+
+	// One-shot schedule state. Defaults to 'now' so the modal behaves exactly as
+	// before unless the user opts in. The picker seeds to an hour out - close
+	// enough to edit, far enough to be valid on first paint.
+	const [startMode, setStartMode] = useState<RunStartMode>('now');
+	const [scheduledAtLocal, setScheduledAtLocal] = useState(() =>
+		toDateTimeLocalValue(new Date(Date.now() + 60 * 60 * 1000))
+	);
+	const isScheduling = startMode === 'scheduled';
+	const scheduledFor = isScheduling ? parseDateTimeLocalValue(scheduledAtLocal) : null;
+	// Blocks Go while the picker is empty/malformed or points at the past.
+	const isScheduleInvalid = isScheduling && (scheduledFor === null || scheduledFor <= Date.now());
+
 	const activeSession = useSessionStore(selectSessionById(sessionId));
 	const sessions = useSessionStore((state) => state.sessions);
 	// When the current session is a worktree child, worktree config lives on its parent.
@@ -619,10 +639,12 @@ export function BatchRunnerModal(props: BatchRunnerModalProps) {
 	const blocksLaunchWhileBusy = isAgentBusy && worktreeTarget === null;
 
 	// Whether the Go button should be disabled, branching on the active mode.
+	// The two "agent is occupied right now" gates don't apply when scheduling:
+	// the run starts later, and the dispatcher re-checks both at fire time.
 	const isGoDisabled =
 		isPreparingWorktree ||
-		blocksLaunchWhileBusy ||
-		isBatchRunningForSession ||
+		isScheduleInvalid ||
+		(!isScheduling && (blocksLaunchWhileBusy || isBatchRunningForSession)) ||
 		(goalMode
 			? isGoalEmpty
 			: hasNoTasks ||
@@ -702,15 +724,24 @@ export function BatchRunnerModal(props: BatchRunnerModalProps) {
 						...(worktreeTarget && { worktreeTarget }),
 					};
 
+		// One-shot schedule. `isScheduleInvalid` already gates Go, so a non-null
+		// `scheduledFor` here is guaranteed to be in the future.
+		if (isScheduling && scheduledFor !== null) {
+			config.scheduledFor = scheduledFor;
+		}
+
 		logger.info('[BatchRunnerModal] handleGo - calling onGo with config:', undefined, config);
 		window.maestro.logger.log('info', 'Go button clicked', 'BatchRunnerModal', {
 			documentsCount: validDocuments.length,
 			autoRunMode,
+			scheduledFor: config.scheduledFor,
 		});
 
-		// Worktree creation/opening requires async work - show loading state
+		// Worktree creation/opening requires async work - show loading state. Skipped
+		// when scheduling: the worktree is created at fire time, not now.
 		const needsWorktreePrep =
-			worktreeTarget?.mode === 'create-new' || worktreeTarget?.mode === 'existing-closed';
+			!isScheduling &&
+			(worktreeTarget?.mode === 'create-new' || worktreeTarget?.mode === 'existing-closed');
 
 		if (needsWorktreePrep) {
 			setIsPreparingWorktree(true);
@@ -1087,6 +1118,16 @@ export function BatchRunnerModal(props: BatchRunnerModalProps) {
 						/>
 					)}
 
+					{/* Start now vs. one-shot schedule. Applies to both Spec- and
+					    Goal-Driven runs, so it sits outside the goalMode branch. */}
+					<ScheduleRunSection
+						theme={theme}
+						startMode={startMode}
+						onStartModeChange={setStartMode}
+						scheduledAtLocal={scheduledAtLocal}
+						onScheduledAtLocalChange={setScheduledAtLocal}
+					/>
+
 					{/* Spec-Driven config: Fresh-context selector + Agent Prompt. Hidden in
 					    goal mode, where the agent prompt is built internally by the goal
 					    runner and "Fresh context per" has no meaning without documents. */}
@@ -1371,29 +1412,39 @@ export function BatchRunnerModal(props: BatchRunnerModalProps) {
 							title={
 								isPreparingWorktree
 									? 'Preparing worktree...'
-									: isBatchRunningForSession
-										? 'An Auto Run is already active for this agent - stop it before launching another'
-										: blocksLaunchWhileBusy
-											? 'Agent is thinking - finish or interrupt the current task before launching auto-run'
-											: goalMode
-												? isGoalEmpty
-													? 'Enter a goal to launch a Goal-Driven run'
-													: 'Start goal-driven auto-run'
-												: isPromptEmpty
-													? 'Agent prompt cannot be empty'
-													: !hasValidPrompt
-														? 'Agent prompt must reference Markdown tasks (e.g., checkbox syntax "- [ ]")'
-														: documents.length === 0
-															? 'No documents selected'
-															: documents.length === missingDocCount
-																? 'All selected documents are missing'
-																: hasNoTasks
-																	? 'No unchecked tasks in documents'
-																	: 'Start auto-run'
+									: isScheduleInvalid
+										? 'Pick a start date and time in the future'
+										: !isScheduling && isBatchRunningForSession
+											? 'An Auto Run is already active for this agent - stop it before launching another'
+											: !isScheduling && blocksLaunchWhileBusy
+												? 'Agent is thinking - finish or interrupt the current task before launching auto-run'
+												: goalMode
+													? isGoalEmpty
+														? 'Enter a goal to launch a Goal-Driven run'
+														: 'Start goal-driven auto-run'
+													: isPromptEmpty
+														? 'Agent prompt cannot be empty'
+														: !hasValidPrompt
+															? 'Agent prompt must reference Markdown tasks (e.g., checkbox syntax "- [ ]")'
+															: documents.length === 0
+																? 'No documents selected'
+																: documents.length === missingDocCount
+																	? 'All selected documents are missing'
+																	: hasNoTasks
+																		? 'No unchecked tasks in documents'
+																		: isScheduling
+																			? 'Schedule this auto-run to start later'
+																			: 'Start auto-run'
 							}
 						>
-							{isPreparingWorktree ? <Spinner size={16} /> : <Play className="w-4 h-4" />}
-							{isPreparingWorktree ? 'Preparing Worktree...' : 'Go'}
+							{isPreparingWorktree ? (
+								<Spinner size={16} />
+							) : isScheduling ? (
+								<CalendarClock className="w-4 h-4" />
+							) : (
+								<Play className="w-4 h-4" />
+							)}
+							{isPreparingWorktree ? 'Preparing Worktree...' : isScheduling ? 'Schedule' : 'Go'}
 						</button>
 					</div>
 				</div>

--- a/src/renderer/components/ScheduleRunSection.tsx
+++ b/src/renderer/components/ScheduleRunSection.tsx
@@ -1,0 +1,142 @@
+/**
+ * ScheduleRunSection.tsx
+ *
+ * "Start" control for the Auto Run modal: run now (default) or once at a
+ * specific future date/time. Sits alongside the worktree toggle so both
+ * launch-shaping options live in the same place.
+ *
+ * Owns only the picker; the actual firing lives in scheduledAutoRunStore +
+ * useScheduledAutoRunDispatcher.
+ */
+
+import { memo, useMemo } from 'react';
+import { CalendarClock } from 'lucide-react';
+import type { Theme } from '../types';
+import { ToggleButtonGroup } from './ToggleButtonGroup';
+import { formatFutureTime } from '../../shared/formatters';
+
+export type RunStartMode = 'now' | 'scheduled';
+
+interface ScheduleRunSectionProps {
+	theme: Theme;
+	startMode: RunStartMode;
+	onStartModeChange: (mode: RunStartMode) => void;
+	/** Raw `datetime-local` value (local wall clock, no timezone suffix). */
+	scheduledAtLocal: string;
+	onScheduledAtLocalChange: (value: string) => void;
+}
+
+/**
+ * Format a Date as the `YYYY-MM-DDTHH:mm` string `<input type="datetime-local">`
+ * expects. Built from local getters (not toISOString) so the value matches the
+ * user's wall clock rather than UTC.
+ */
+export function toDateTimeLocalValue(date: Date): string {
+	const pad = (n: number) => String(n).padStart(2, '0');
+	return (
+		`${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}` +
+		`T${pad(date.getHours())}:${pad(date.getMinutes())}`
+	);
+}
+
+/**
+ * Parse a `datetime-local` value into epoch ms, interpreting it in the local
+ * timezone. Returns null when the value is empty or malformed.
+ */
+export function parseDateTimeLocalValue(value: string): number | null {
+	const match = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})$/.exec(value.trim());
+	if (!match) return null;
+	const [, year, month, day, hour, minute] = match;
+	const parsed = new Date(
+		Number(year),
+		Number(month) - 1,
+		Number(day),
+		Number(hour),
+		Number(minute),
+		0,
+		0
+	);
+	const time = parsed.getTime();
+	return Number.isFinite(time) ? time : null;
+}
+
+export const ScheduleRunSection = memo(function ScheduleRunSection({
+	theme,
+	startMode,
+	onStartModeChange,
+	scheduledAtLocal,
+	onScheduledAtLocalChange,
+}: ScheduleRunSectionProps) {
+	const isScheduled = startMode === 'scheduled';
+	const scheduledFor = useMemo(
+		() => (isScheduled ? parseDateTimeLocalValue(scheduledAtLocal) : null),
+		[isScheduled, scheduledAtLocal]
+	);
+	const isPast = scheduledFor !== null && scheduledFor <= Date.now();
+
+	return (
+		<div className="mb-6">
+			{/* Section header - matches "DOCUMENTS TO RUN" / "RUN IN WORKTREE" style */}
+			<div className="flex items-center justify-between mb-3">
+				<label className="text-xs font-bold uppercase" style={{ color: theme.colors.textDim }}>
+					Start
+				</label>
+			</div>
+
+			<div
+				className="rounded-lg border transition-colors px-3 py-2.5"
+				style={{
+					borderColor: isScheduled ? theme.colors.accent + '40' : theme.colors.border,
+					backgroundColor: isScheduled ? theme.colors.accent + '08' : 'transparent',
+				}}
+			>
+				<div className="flex items-center gap-3">
+					<CalendarClock
+						className="w-3.5 h-3.5 shrink-0"
+						style={{ color: isScheduled ? theme.colors.accent : theme.colors.textDim }}
+					/>
+					<ToggleButtonGroup<RunStartMode>
+						options={[
+							{ value: 'now', label: 'Now' },
+							{ value: 'scheduled', label: 'At a set time' },
+						]}
+						value={startMode}
+						onChange={onStartModeChange}
+						theme={theme}
+					/>
+				</div>
+
+				{isScheduled && (
+					<div className="mt-3">
+						<input
+							type="datetime-local"
+							value={scheduledAtLocal}
+							min={toDateTimeLocalValue(new Date())}
+							onChange={(e) => onScheduledAtLocalChange(e.target.value)}
+							className="w-full px-2 py-1.5 rounded border bg-transparent outline-none text-sm font-mono"
+							style={{
+								borderColor: isPast ? theme.colors.error : theme.colors.border,
+								color: theme.colors.textMain,
+								// Tell Chromium which palette to draw the native calendar/clock
+								// picker with, otherwise it renders a light picker over a dark modal.
+								colorScheme: theme.mode === 'light' ? 'light' : 'dark',
+							}}
+							aria-label="Scheduled start time"
+						/>
+						<p
+							className="text-[10px] mt-1.5"
+							style={{ color: isPast ? theme.colors.error : theme.colors.textDim }}
+						>
+							{scheduledFor === null
+								? 'Pick the date and time this Auto Run should start.'
+								: isPast
+									? 'Pick a time in the future.'
+									: `Runs once ${formatFutureTime(scheduledFor)}. Maestro must be running then - ` +
+										'if it was closed for more than 6 hours past the start time, the run is skipped.'}
+						</p>
+					</div>
+				)}
+			</div>
+		</div>
+	);
+});

--- a/src/renderer/hooks/batch/index.ts
+++ b/src/renderer/hooks/batch/index.ts
@@ -85,6 +85,10 @@ export type {
 	AutoRunTreeNode,
 } from './useAutoRunHandlers';
 
+// One-shot scheduled Auto Runs (start at a specific date/time)
+export { useScheduledAutoRunDispatcher } from './useScheduledAutoRunDispatcher';
+export type { UseScheduledAutoRunDispatcherDeps } from './useScheduledAutoRunDispatcher';
+
 // Auto Run image handling
 export { useAutoRunImageHandling, imageCache } from './useAutoRunImageHandling';
 export type {

--- a/src/renderer/hooks/batch/useAutoRunHandlers.ts
+++ b/src/renderer/hooks/batch/useAutoRunHandlers.ts
@@ -2,9 +2,11 @@ import { useCallback } from 'react';
 import type { Session, BatchRunConfig } from '../../types';
 import { useSessionStore, selectActiveSession, selectSessionById } from '../../stores/sessionStore';
 import { notifyToast } from '../../stores/notificationStore';
+import { getScheduledAutoRunActions } from '../../stores/scheduledAutoRunStore';
 import { spawnWorktreeAgentAndDispatch } from '../../utils/worktreeSpawn';
 import { countMarkdownTasks } from './batchUtils';
 import { logger } from '../../utils/logger';
+import { formatFutureTime } from '../../../shared/formatters';
 
 /**
  * Tree node structure for Auto Run document tree
@@ -45,8 +47,13 @@ export interface UseAutoRunHandlersDeps {
 export interface UseAutoRunHandlersReturn {
 	/** Handle folder selection from Auto Run setup modal */
 	handleAutoRunFolderSelected: (folderPath: string) => Promise<void>;
-	/** Start a batch run with the given configuration */
-	handleStartBatchRun: (config: BatchRunConfig) => Promise<void>;
+	/**
+	 * Start a batch run with the given configuration. Defaults to the active
+	 * agent; pass `options.session` to target a specific one (scheduled runs).
+	 * When `config.scheduledFor` is in the future the run is parked rather than
+	 * launched - see scheduledAutoRunStore.
+	 */
+	handleStartBatchRun: (config: BatchRunConfig, options?: { session?: Session }) => Promise<void>;
 	/** Get the number of unchecked tasks in a document */
 	getDocumentTaskCount: (filename: string) => Promise<number>;
 	/** Handle content changes in the Auto Run editor */
@@ -191,10 +198,13 @@ export function useAutoRunHandlers(deps: UseAutoRunHandlersDeps): UseAutoRunHand
 		]
 	);
 
-	// Handler to start batch run from modal with multi-document support
+	// Handler to start batch run from modal with multi-document support.
+	// `options.session` overrides the active-agent default - used by the scheduled
+	// dispatcher, which fires runs for agents the user may have navigated away from.
 	const handleStartBatchRun = useCallback(
-		async (config: BatchRunConfig) => {
-			const activeSession = selectActiveSession(useSessionStore.getState());
+		async (config: BatchRunConfig, options?: { session?: Session }) => {
+			const activeSession =
+				options?.session ?? selectActiveSession(useSessionStore.getState()) ?? null;
 			window.maestro.logger.log('info', 'handleStartBatchRun called', 'AutoRunHandlers', {
 				hasActiveSession: !!activeSession,
 				sessionId: activeSession?.id,
@@ -203,6 +213,7 @@ export function useAutoRunHandlers(deps: UseAutoRunHandlersDeps): UseAutoRunHand
 				worktreePath: config.worktree?.path,
 				worktreeBranch: config.worktree?.branchName,
 				worktreeTargetMode: config.worktreeTarget?.mode,
+				scheduledFor: config.scheduledFor,
 			});
 			if (!activeSession || !activeSession.autoRunFolderPath) {
 				window.maestro.logger.log(
@@ -210,6 +221,28 @@ export function useAutoRunHandlers(deps: UseAutoRunHandlersDeps): UseAutoRunHand
 					'handleStartBatchRun early return - missing session or folder',
 					'AutoRunHandlers'
 				);
+				return;
+			}
+
+			// One-shot schedule: park the config instead of launching. The dispatcher
+			// (useScheduledAutoRunDispatcher) fires it once the timestamp passes. A
+			// timestamp already in the past falls through and starts immediately.
+			if (typeof config.scheduledFor === 'number' && config.scheduledFor > Date.now()) {
+				const { scheduledFor } = config;
+				getScheduledAutoRunActions().schedule({
+					sessionId: activeSession.id,
+					folderPath: activeSession.autoRunFolderPath,
+					config,
+					scheduledFor,
+					createdAt: Date.now(),
+				});
+				setBatchRunnerModalOpen(false);
+				notifyToast({
+					color: 'theme',
+					title: 'Auto Run Scheduled',
+					message: `${activeSession.name} will start this Auto Run ${formatFutureTime(scheduledFor)}.`,
+					sessionId: activeSession.id,
+				});
 				return;
 			}
 
@@ -303,8 +336,11 @@ export function useAutoRunHandlers(deps: UseAutoRunHandlersDeps): UseAutoRunHand
 				isWorktreeTarget: targetSessionId !== activeSession.id,
 			});
 			setBatchRunnerModalOpen(false);
+			// `scheduledFor` has served its purpose by now (either it was in the past
+			// or the dispatcher already stripped it) - don't hand it to the runner.
+			const { scheduledFor: _scheduledFor, ...runConfig } = config;
 			// Documents stay with the parent session's autoRunFolderPath; execution targets the worktree agent
-			startBatchRun(targetSessionId, config, activeSession.autoRunFolderPath);
+			startBatchRun(targetSessionId, runConfig, activeSession.autoRunFolderPath);
 		},
 		[startBatchRun, setBatchRunnerModalOpen]
 	);

--- a/src/renderer/hooks/batch/useScheduledAutoRunDispatcher.ts
+++ b/src/renderer/hooks/batch/useScheduledAutoRunDispatcher.ts
@@ -1,0 +1,120 @@
+/**
+ * useScheduledAutoRunDispatcher.ts
+ *
+ * Fires Auto Runs that the user parked for a future date/time in the Auto Run
+ * modal (see scheduledAutoRunStore). Mounted once from App.tsx.
+ *
+ * Polling (rather than a per-entry setTimeout) is deliberate: a long timer
+ * silently under-fires when the machine sleeps, and schedules here are routinely
+ * hours out ("start this when my token limit resets"). A cheap 15s tick against
+ * the wall clock is correct across sleep/wake and across a hot reload.
+ */
+
+import { useEffect, useRef } from 'react';
+import type { BatchRunConfig, Session } from '../../types';
+import { useSessionStore, selectSessionById } from '../../stores/sessionStore';
+import { useBatchStore } from '../../stores/batchStore';
+import {
+	useScheduledAutoRunStore,
+	partitionScheduledAutoRuns,
+	type ScheduledAutoRun,
+} from '../../stores/scheduledAutoRunStore';
+import { notifyToast } from '../../stores/notificationStore';
+import { formatFutureTime } from '../../../shared/formatters';
+
+/** How often the wall clock is checked against pending schedules. */
+export const SCHEDULED_AUTO_RUN_TICK_MS = 15_000;
+
+export interface UseScheduledAutoRunDispatcherDeps {
+	/**
+	 * Launches a run immediately. Wired to `handleStartBatchRun` from
+	 * useAutoRunHandlers, which owns worktree dispatch and folder resolution.
+	 * The config passed here never carries `scheduledFor`.
+	 */
+	onLaunch: (config: BatchRunConfig, options: { session: Session }) => void | Promise<void>;
+}
+
+/** True when the agent can't accept a run right now (mirrors the modal's Go gate). */
+function isBlocked(session: Session, entry: ScheduledAutoRun): boolean {
+	// Dispatching to a separate worktree spawns/uses a different agent, so this
+	// agent being mid-thought is irrelevant - same carve-out the modal makes.
+	const busyBlocks =
+		(session.state === 'busy' || session.state === 'connecting') && !entry.config.worktreeTarget;
+	const alreadyRunning = !!useBatchStore.getState().batchRunStates[session.id]?.isRunning;
+	return busyBlocks || alreadyRunning;
+}
+
+export function useScheduledAutoRunDispatcher({ onLaunch }: UseScheduledAutoRunDispatcherDeps) {
+	// Keep the launcher in a ref so the polling effect never re-subscribes when
+	// App.tsx re-renders (handleStartBatchRun is not referentially stable).
+	const onLaunchRef = useRef(onLaunch);
+	onLaunchRef.current = onLaunch;
+
+	useEffect(() => {
+		const { hydrate } = useScheduledAutoRunStore.getState();
+		let disposed = false;
+
+		const tick = () => {
+			if (disposed) return;
+			const store = useScheduledAutoRunStore.getState();
+			if (!store.hydrated) return;
+
+			const { due, expired } = partitionScheduledAutoRuns(store.scheduled, Date.now());
+
+			// Missed by more than the grace window (app was closed/asleep). Drop
+			// rather than surprising the user with a run hours after they expected it.
+			for (const entry of expired) {
+				store.cancel(entry.sessionId);
+				notifyToast({
+					color: 'yellow',
+					title: 'Scheduled Auto Run Missed',
+					message: `Maestro was not running at the scheduled time, so the Auto Run for this agent was skipped.`,
+					sessionId: entry.sessionId,
+				});
+			}
+
+			for (const entry of due) {
+				const session = selectSessionById(entry.sessionId)(useSessionStore.getState());
+				if (!session) {
+					store.cancel(entry.sessionId);
+					notifyToast({
+						color: 'yellow',
+						title: 'Scheduled Auto Run Cancelled',
+						message: 'The agent this run was scheduled for no longer exists.',
+					});
+					continue;
+				}
+
+				// Busy / already running: leave the entry parked and retry on the next
+				// tick. It stays eligible until the grace window closes.
+				if (isBlocked(session, entry)) continue;
+
+				// Clear before launching so a slow launch can't be double-fired by the
+				// next tick.
+				store.cancel(entry.sessionId);
+				const { scheduledFor: _scheduledFor, ...config } = entry.config;
+				void Promise.resolve(onLaunchRef.current(config, { session })).catch(() => {
+					// handleStartBatchRun surfaces its own failures via toasts.
+				});
+				notifyToast({
+					color: 'green',
+					title: 'Scheduled Auto Run Started',
+					message: `Starting the Auto Run you scheduled for ${session.name}.`,
+					sessionId: session.id,
+				});
+			}
+		};
+
+		void hydrate().then(() => tick());
+		const interval = setInterval(tick, SCHEDULED_AUTO_RUN_TICK_MS);
+		return () => {
+			disposed = true;
+			clearInterval(interval);
+		};
+	}, []);
+}
+
+/** Human-readable "starts ..." label for a pending schedule. */
+export function formatScheduledAutoRunLabel(entry: ScheduledAutoRun): string {
+	return formatFutureTime(entry.scheduledFor);
+}

--- a/src/renderer/stores/scheduledAutoRunStore.ts
+++ b/src/renderer/stores/scheduledAutoRunStore.ts
@@ -1,0 +1,159 @@
+/**
+ * scheduledAutoRunStore.ts
+ *
+ * Holds one-shot Auto Run schedules: a run the user configured in the Auto Run
+ * modal but asked to start at a future date/time rather than immediately. One
+ * pending schedule per agent (scheduling again replaces the previous one).
+ *
+ * The dispatcher (useScheduledAutoRunDispatcher) polls this store and launches
+ * each entry once its `scheduledFor` passes. Entries are mirrored into the
+ * generic settings KV store so a schedule survives an app restart - the primary
+ * use case is "kick this off when my token limit resets in 5 hours", which
+ * routinely outlives a single app session.
+ */
+
+import { create } from 'zustand';
+import type { BatchRunConfig } from '../types';
+import { logger } from '../utils/logger';
+
+/** Settings KV key holding the persisted schedule list. */
+export const SCHEDULED_AUTO_RUNS_SETTINGS_KEY = 'scheduledAutoRuns';
+
+/**
+ * How long after `scheduledFor` a missed schedule is still worth firing.
+ * Mirrors the Cue `time.once` default grace window (6h) so both scheduling
+ * surfaces behave the same when the app was closed at the fire time.
+ */
+export const SCHEDULED_AUTO_RUN_GRACE_MS = 6 * 60 * 60 * 1000;
+
+export interface ScheduledAutoRun {
+	/** Agent the run belongs to (the run's launch target may still be a worktree). */
+	sessionId: string;
+	/** Auto Run folder the documents were resolved against at schedule time. */
+	folderPath: string;
+	/** Full run config, minus `scheduledFor` (the timestamp lives below). */
+	config: BatchRunConfig;
+	/** Epoch ms at which the run should start. */
+	scheduledFor: number;
+	/** Epoch ms the schedule was created - used only for display/debugging. */
+	createdAt: number;
+}
+
+interface ScheduledAutoRunState {
+	/** Pending schedules keyed by sessionId. */
+	scheduled: Record<string, ScheduledAutoRun>;
+	/** True once the persisted list has been read back from settings. */
+	hydrated: boolean;
+	/** Load persisted schedules. Safe to call more than once; only the first wins. */
+	hydrate: () => Promise<void>;
+	/** Park a run for later. Replaces any existing schedule for the same agent. */
+	schedule: (entry: ScheduledAutoRun) => void;
+	/** Drop the pending schedule for an agent (user cancel, fired, or expired). */
+	cancel: (sessionId: string) => void;
+}
+
+/** Write the current map back to the settings KV store. Fire-and-forget. */
+function persist(scheduled: Record<string, ScheduledAutoRun>): void {
+	// Guard for non-Electron contexts (tests, web-desktop bootstrap ordering).
+	if (typeof window === 'undefined' || !window.maestro?.settings) return;
+	void window.maestro.settings
+		.set(SCHEDULED_AUTO_RUNS_SETTINGS_KEY, Object.values(scheduled))
+		.catch((err: unknown) => {
+			logger.warn('[scheduledAutoRunStore] Failed to persist schedules', undefined, err);
+		});
+}
+
+/** Shape-check a persisted entry - stored JSON is untrusted across versions. */
+function isValidEntry(value: unknown): value is ScheduledAutoRun {
+	if (!value || typeof value !== 'object') return false;
+	const entry = value as Partial<ScheduledAutoRun>;
+	return (
+		typeof entry.sessionId === 'string' &&
+		typeof entry.folderPath === 'string' &&
+		typeof entry.scheduledFor === 'number' &&
+		Number.isFinite(entry.scheduledFor) &&
+		!!entry.config &&
+		typeof entry.config === 'object'
+	);
+}
+
+export const useScheduledAutoRunStore = create<ScheduledAutoRunState>((set, get) => ({
+	scheduled: {},
+	hydrated: false,
+
+	hydrate: async () => {
+		if (get().hydrated) return;
+		let stored: unknown = null;
+		if (typeof window !== 'undefined' && window.maestro?.settings) {
+			try {
+				stored = await window.maestro.settings.get(SCHEDULED_AUTO_RUNS_SETTINGS_KEY);
+			} catch (err) {
+				logger.warn('[scheduledAutoRunStore] Failed to read schedules', undefined, err);
+			}
+		}
+		const next: Record<string, ScheduledAutoRun> = {};
+		if (Array.isArray(stored)) {
+			for (const entry of stored) {
+				if (isValidEntry(entry)) {
+					next[entry.sessionId] = { ...entry, createdAt: entry.createdAt ?? entry.scheduledFor };
+				}
+			}
+		}
+		set({ scheduled: next, hydrated: true });
+	},
+
+	schedule: (entry) => {
+		const scheduled = { ...get().scheduled, [entry.sessionId]: entry };
+		set({ scheduled });
+		persist(scheduled);
+	},
+
+	cancel: (sessionId) => {
+		const current = get().scheduled;
+		if (!(sessionId in current)) return;
+		const scheduled = { ...current };
+		delete scheduled[sessionId];
+		set({ scheduled });
+		persist(scheduled);
+	},
+}));
+
+/** Non-React accessor for callers outside components (handlers, dispatchers). */
+export const getScheduledAutoRunActions = () => {
+	const { hydrate, schedule, cancel } = useScheduledAutoRunStore.getState();
+	return { hydrate, schedule, cancel };
+};
+
+/** Selector: the pending schedule for one agent, or undefined. */
+export const selectScheduledAutoRun =
+	(sessionId: string | null | undefined) =>
+	(state: ScheduledAutoRunState): ScheduledAutoRun | undefined =>
+		sessionId ? state.scheduled[sessionId] : undefined;
+
+/**
+ * Partition schedules against the clock.
+ *
+ * - `due`: fire now (the timestamp passed and we're inside the grace window).
+ * - `expired`: the app was closed/asleep past the grace window - drop without
+ *   firing rather than surprising the user with a run hours after they expected
+ *   it. Mirrors the Cue `time.once` missed-fire policy.
+ *
+ * Pure so the timing policy is unit-testable without fake timers.
+ */
+export function partitionScheduledAutoRuns(
+	scheduled: Record<string, ScheduledAutoRun>,
+	now: number,
+	graceMs: number = SCHEDULED_AUTO_RUN_GRACE_MS
+): { due: ScheduledAutoRun[]; expired: ScheduledAutoRun[] } {
+	const due: ScheduledAutoRun[] = [];
+	const expired: ScheduledAutoRun[] = [];
+	for (const entry of Object.values(scheduled)) {
+		if (entry.scheduledFor > now) continue;
+		if (now - entry.scheduledFor > graceMs) {
+			expired.push(entry);
+		} else {
+			due.push(entry);
+		}
+	}
+	return { due, expired };
+}

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -385,6 +385,11 @@ export interface BatchRunConfig {
 	// over the document/task-driven spec mode. When set, the run pursues a free-text
 	// goal instead of checking off `- [ ]` tasks. See src/shared/goalDriven/types.ts.
 	goalConfig?: import('../../shared/goalDriven/types').GoalRunConfig;
+	// One-shot schedule. When set to a future epoch-ms timestamp, the run is parked
+	// in scheduledAutoRunStore instead of launching, and the dispatcher
+	// (useScheduledAutoRunDispatcher) fires it once the timestamp passes. Stripped
+	// from the config before the run actually starts.
+	scheduledFor?: number;
 }
 
 // Import BatchProcessingState for state machine integration


### PR DESCRIPTION
Closes #716

## What

Auto Run documents could only be launched immediately. This adds a **Start** control to the Auto Run window, sitting alongside the worktree toggle exactly as the issue suggested:

- **Now** - the default, unchanged behavior.
- **At a set time** - pick a future date and time; the run fires once, then the schedule is gone.

One-shot only. No recurring schedules, per the issue.

The Go button becomes **Schedule** when a time is set. A pending schedule shows as a banner at the top of the Auto Run panel with an X to cancel it, so it isn't invisible once the modal closes.

## How

| Piece | Role |
| --- | --- |
| `scheduledAutoRunStore.ts` | One pending run per agent. Mirrored into the settings KV store, so a schedule survives an app restart - the driving use case ("start this when my token limit resets in 5 hours") routinely outlives a single app session. |
| `useScheduledAutoRunDispatcher.ts` | Mounted once from `App.tsx`. Polls the wall clock every 15s and launches due runs. |
| `ScheduleRunSection.tsx` | The Now / At-a-set-time control plus local-timezone `datetime-local` helpers. |
| `AutoRunScheduledBanner.tsx` | Pending-schedule banner + cancel, in the Auto Run panel. |

`handleStartBatchRun` parks a config carrying a future `scheduledFor` instead of launching it, and now accepts an explicit target session so the dispatcher can fire runs for agents the user has navigated away from.

## Decisions worth a second opinion

- **Polling, not `setTimeout`.** A multi-hour timer silently under-fires when the machine sleeps. A 15s tick against the wall clock is correct across sleep/wake and across a hot reload.
- **6h grace window on a missed schedule.** If Maestro was closed at the fire time, the run still starts when you reopen within 6h; past that it's dropped with a notification rather than kicking off hours late. That 6h matches the existing Cue `time.once` `grace_minutes` default, so both scheduling surfaces behave the same.
- **Busy agent doesn't block scheduling.** The "agent is thinking" and "an Auto Run is already active" gates are skipped while scheduling, since the run starts later; the dispatcher re-checks both at fire time and defers (retrying each tick) until the agent frees up.
- **Worktree prep is deferred too.** Scheduling with a create-new worktree target creates the worktree at fire time, not at schedule time.

## Testing

- `scheduledAutoRunStore.test.ts` - schedule/cancel, persistence, hydration incl. malformed entries, and the due/expired timing policy.
- `useScheduledAutoRunDispatcher.test.tsx` - parks vs. launches, fires on time, defers while busy or mid-run, drops past-grace and orphaned schedules, and confirms `scheduledFor` never reaches the runner.
- `ScheduleRunSection.test.ts` - local-timezone round-tripping of the picker value (a `toISOString()` here would shift the run by the UTC offset).
- Full suite green locally: 1401 files, 34673 tests. `npm run lint` and eslint clean.

Windows CI leg still needs to confirm - nothing here touches paths, but the local run is a single OS.

## Not included

Issue #716 also drew a comment asking for a watched folder where new documents are auto-discovered and executed. That's a different feature and Maestro Cue already covers that shape, so it's out of scope here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added one-shot Auto Run scheduling for a future date and time.
  * Added “Now” and “At a set time” options with local date/time validation.
  * Scheduled runs persist across restarts and can be cancelled from the Auto Run panel.
  * Runs automatically start when due, while waiting if the agent is busy.

* **Documentation**
  * Added scheduling guidance to the Auto Runner help modal and store documentation.

* **Tests**
  * Added coverage for scheduling, persistence, timing, cancellation, and dispatch behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->