### PR TITLE
feat(worktree): merge and rebase actions in the worktree context menu

### DIFF
--- a/src/__tests__/main/ipc/handlers/git.test.ts
+++ b/src/__tests__/main/ipc/handlers/git.test.ts
@@ -197,6 +197,8 @@ describe('Git IPC handlers', () => {
 				'git:isRepo',
 				'git:init',
 				'git:commitAll',
+				'git:mergeBranch',
+				'git:rebaseBranch',
 				'git:numstat',
 				'git:branch',
 				'git:remote',
@@ -228,6 +230,198 @@ describe('Git IPC handlers', () => {
 			for (const channel of expectedChannels) {
 				expect(handlers.has(channel)).toBe(true);
 			}
+		});
+	});
+
+	describe('git:mergeBranch', () => {
+		const WORKTREE_LIST = [
+			'worktree /repo',
+			'HEAD abc123',
+			'branch refs/heads/main',
+			'',
+			'worktree /repo-wt/feature',
+			'HEAD def456',
+			'branch refs/heads/feature',
+		].join('\n');
+
+		/**
+		 * Drive execFileNoThrow off the git subcommand so each test only has to
+		 * describe the calls it cares about; everything else succeeds silently.
+		 */
+		const mockGit = (overrides: Record<string, { stdout?: string; exitCode?: number }>) => {
+			vi.mocked(execFile.execFileNoThrow).mockImplementation(async (_cmd, args) => {
+				const key = (args as string[]).join(' ');
+				const match = Object.keys(overrides).find((k) => key.startsWith(k));
+				const o = match ? overrides[match] : {};
+				return {
+					stdout: o.stdout ?? '',
+					stderr: '',
+					exitCode: o.exitCode ?? 0,
+				};
+			});
+		};
+
+		it('merges in the worktree that has the target branch checked out', async () => {
+			mockGit({
+				'worktree list': { stdout: WORKTREE_LIST },
+				'status --porcelain': { stdout: '' },
+				merge: { stdout: 'Fast-forward\n' },
+			});
+
+			const handler = handlers.get('git:mergeBranch');
+			const result = await handler!({} as any, '/repo-wt/feature', 'feature', 'main');
+
+			expect(result).toEqual({
+				success: true,
+				mergedIn: '/repo',
+				alreadyUpToDate: false,
+			});
+			// The merge itself must run in /repo, where `main` lives - not in the
+			// source worktree, where git refuses to check `main` out again.
+			expect(execFile.execFileNoThrow).toHaveBeenCalledWith('git', ['merge', 'feature'], '/repo');
+		});
+
+		it('reports alreadyUpToDate when there is nothing to merge', async () => {
+			mockGit({
+				'worktree list': { stdout: WORKTREE_LIST },
+				'status --porcelain': { stdout: '' },
+				merge: { stdout: 'Already up to date.\n' },
+			});
+
+			const handler = handlers.get('git:mergeBranch');
+			const result = await handler!({} as any, '/repo-wt/feature', 'feature', 'main');
+
+			expect(result.success).toBe(true);
+			expect(result.alreadyUpToDate).toBe(true);
+		});
+
+		it('refuses to merge into a checkout with uncommitted changes', async () => {
+			mockGit({
+				'worktree list': { stdout: WORKTREE_LIST },
+				'status --porcelain': { stdout: ' M src/index.ts\n' },
+			});
+
+			const handler = handlers.get('git:mergeBranch');
+			const result = await handler!({} as any, '/repo-wt/feature', 'feature', 'main');
+
+			expect(result.success).toBe(false);
+			expect(result.error).toContain('uncommitted changes');
+			expect(execFile.execFileNoThrow).not.toHaveBeenCalledWith(
+				'git',
+				['merge', 'feature'],
+				expect.anything()
+			);
+		});
+
+		it('aborts the merge and returns conflicting paths', async () => {
+			mockGit({
+				'worktree list': { stdout: WORKTREE_LIST },
+				'status --porcelain': { stdout: '' },
+				merge: { exitCode: 1 },
+				'diff --name-only': { stdout: 'src/a.ts\nsrc/b.ts\n' },
+			});
+
+			const handler = handlers.get('git:mergeBranch');
+			const result = await handler!({} as any, '/repo-wt/feature', 'feature', 'main');
+
+			expect(result).toEqual({
+				success: false,
+				mergedIn: '/repo',
+				conflicts: ['src/a.ts', 'src/b.ts'],
+			});
+			// A half-merged main checkout from one button press would be hostile.
+			expect(execFile.execFileNoThrow).toHaveBeenCalledWith('git', ['merge', '--abort'], '/repo');
+		});
+
+		it('errors when the target branch is not checked out anywhere', async () => {
+			mockGit({ 'worktree list': { stdout: WORKTREE_LIST } });
+
+			const handler = handlers.get('git:mergeBranch');
+			const result = await handler!({} as any, '/repo-wt/feature', 'feature', 'release');
+
+			expect(result.success).toBe(false);
+			expect(result.error).toContain('not checked out in any worktree');
+		});
+
+		it('rejects branch names that git would read as options', async () => {
+			const handler = handlers.get('git:mergeBranch');
+			const result = await handler!({} as any, '/repo-wt/feature', 'feature', '--hard');
+
+			expect(result).toEqual({ success: false, error: 'Invalid branch name' });
+			expect(execFile.execFileNoThrow).not.toHaveBeenCalled();
+		});
+
+		it('rejects merging a branch into itself', async () => {
+			const handler = handlers.get('git:mergeBranch');
+			const result = await handler!({} as any, '/repo-wt/feature', 'feature', 'feature');
+
+			expect(result.success).toBe(false);
+			expect(result.error).toContain('same');
+		});
+	});
+
+	describe('git:rebaseBranch', () => {
+		it('rebases the worktree onto the given branch', async () => {
+			vi.mocked(execFile.execFileNoThrow).mockResolvedValue({
+				stdout: '',
+				stderr: '',
+				exitCode: 0,
+			});
+
+			const handler = handlers.get('git:rebaseBranch');
+			const result = await handler!({} as any, '/repo-wt/feature', 'main');
+
+			expect(result.success).toBe(true);
+			expect(execFile.execFileNoThrow).toHaveBeenCalledWith(
+				'git',
+				['rebase', 'main'],
+				'/repo-wt/feature'
+			);
+		});
+
+		it('refuses to rebase a dirty worktree', async () => {
+			vi.mocked(execFile.execFileNoThrow).mockResolvedValue({
+				stdout: ' M src/index.ts\n',
+				stderr: '',
+				exitCode: 0,
+			});
+
+			const handler = handlers.get('git:rebaseBranch');
+			const result = await handler!({} as any, '/repo-wt/feature', 'main');
+
+			expect(result.success).toBe(false);
+			expect(result.error).toContain('uncommitted changes');
+		});
+
+		it('aborts the rebase and returns conflicting paths', async () => {
+			vi.mocked(execFile.execFileNoThrow).mockImplementation(async (_cmd, args) => {
+				const key = (args as string[]).join(' ');
+				if (key.startsWith('rebase ')) {
+					return { stdout: '', stderr: 'CONFLICT', exitCode: 1 };
+				}
+				if (key.startsWith('diff --name-only')) {
+					return { stdout: 'src/a.ts\n', stderr: '', exitCode: 0 };
+				}
+				return { stdout: '', stderr: '', exitCode: 0 };
+			});
+
+			const handler = handlers.get('git:rebaseBranch');
+			const result = await handler!({} as any, '/repo-wt/feature', 'main');
+
+			expect(result).toEqual({ success: false, conflicts: ['src/a.ts'] });
+			expect(execFile.execFileNoThrow).toHaveBeenCalledWith(
+				'git',
+				['rebase', '--abort'],
+				'/repo-wt/feature'
+			);
+		});
+
+		it('rejects branch names that git would read as options', async () => {
+			const handler = handlers.get('git:rebaseBranch');
+			const result = await handler!({} as any, '/repo-wt/feature', '-i');
+
+			expect(result).toEqual({ success: false, error: 'Invalid branch name' });
+			expect(execFile.execFileNoThrow).not.toHaveBeenCalled();
 		});
 	});
 

--- a/src/__tests__/renderer/components/WorktreeMergeModal.test.tsx
+++ b/src/__tests__/renderer/components/WorktreeMergeModal.test.tsx
@@ -1,0 +1,160 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { WorktreeMergeModal } from '../../../renderer/components/WorktreeMergeModal';
+import { createMockSession } from '../../helpers/mockSession';
+import { mockTheme } from '../../helpers/mockTheme';
+import { gitService } from '../../../renderer/services/git';
+
+vi.mock('../../../renderer/hooks/ui/useModalLayer', () => ({
+	useModalLayer: vi.fn(),
+}));
+
+vi.mock('../../../renderer/services/git', () => ({
+	gitService: {
+		getBranches: vi.fn(),
+		getStatus: vi.fn(),
+		commitAll: vi.fn(),
+		mergeBranch: vi.fn(),
+		rebaseBranch: vi.fn(),
+	},
+}));
+
+const worktreeSession = () =>
+	createMockSession({
+		cwd: '/repo-wt/feature',
+		parentSessionId: 'parent-1',
+		worktreeBranch: 'feature',
+	});
+
+describe('WorktreeMergeModal', () => {
+	beforeEach(() => {
+		// The gitService mock is module-level, so call history survives between
+		// tests unless cleared - which would make "not.toHaveBeenCalled" lie.
+		vi.clearAllMocks();
+		vi.mocked(gitService.getBranches).mockResolvedValue(['feature', 'main', 'release']);
+		vi.mocked(gitService.getStatus).mockResolvedValue({ files: [], branch: 'feature' });
+		vi.mocked(gitService.commitAll).mockResolvedValue({ success: true, committed: true });
+		vi.mocked(gitService.mergeBranch).mockResolvedValue({ success: true, mergedIn: '/repo' });
+		vi.mocked(gitService.rebaseBranch).mockResolvedValue({ success: true });
+		window.maestro.git.getDefaultBranch = vi
+			.fn()
+			.mockResolvedValue({ success: true, branch: 'main' });
+	});
+
+	const renderModal = (mode: 'merge' | 'rebase' = 'merge') =>
+		render(
+			<WorktreeMergeModal
+				isOpen
+				mode={mode}
+				onClose={vi.fn()}
+				theme={mockTheme}
+				session={worktreeSession()}
+			/>
+		);
+
+	it('preselects the default branch and never offers the worktree branch itself', async () => {
+		renderModal();
+
+		const select = (await screen.findByLabelText('Merge Into')) as HTMLSelectElement;
+		await waitFor(() => expect(select.value).toBe('main'));
+
+		const options = Array.from(select.options).map((o) => o.value);
+		expect(options).toEqual(['main', 'release']);
+	});
+
+	it('merges the worktree branch into the selected branch', async () => {
+		renderModal();
+
+		await screen.findByLabelText('Merge Into');
+		fireEvent.click(screen.getByRole('button', { name: 'Merge' }));
+
+		await waitFor(() =>
+			expect(gitService.mergeBranch).toHaveBeenCalledWith(
+				'/repo-wt/feature',
+				'feature',
+				'main',
+				undefined
+			)
+		);
+		expect(await screen.findByText('Merged feature into main.')).toBeInTheDocument();
+	});
+
+	it('rebases onto the selected branch', async () => {
+		renderModal('rebase');
+
+		await screen.findByLabelText('Rebase Onto');
+		fireEvent.click(screen.getByRole('button', { name: 'Rebase' }));
+
+		await waitFor(() =>
+			expect(gitService.rebaseBranch).toHaveBeenCalledWith('/repo-wt/feature', 'main', undefined)
+		);
+	});
+
+	it('commits uncommitted changes first, using the message the user confirms', async () => {
+		vi.mocked(gitService.getStatus).mockResolvedValue({
+			files: [{ path: 'src/a.ts', status: 'M' }],
+			branch: 'feature',
+		});
+		renderModal();
+
+		const messageBox = await screen.findByPlaceholderText('Commit message');
+		fireEvent.change(messageBox, { target: { value: 'feat: add the thing' } });
+		fireEvent.click(screen.getByRole('button', { name: 'Merge' }));
+
+		await waitFor(() =>
+			expect(gitService.commitAll).toHaveBeenCalledWith(
+				'/repo-wt/feature',
+				'feat: add the thing',
+				undefined
+			)
+		);
+		expect(gitService.mergeBranch).toHaveBeenCalled();
+	});
+
+	it('does not merge when the pre-merge commit fails', async () => {
+		vi.mocked(gitService.getStatus).mockResolvedValue({
+			files: [{ path: 'src/a.ts', status: 'M' }],
+			branch: 'feature',
+		});
+		vi.mocked(gitService.commitAll).mockResolvedValue({
+			success: false,
+			committed: false,
+			error: 'no git identity configured',
+		});
+		renderModal();
+
+		await screen.findByPlaceholderText('Commit message');
+		fireEvent.click(screen.getByRole('button', { name: 'Merge' }));
+
+		expect(await screen.findByText('no git identity configured')).toBeInTheDocument();
+		expect(gitService.mergeBranch).not.toHaveBeenCalled();
+	});
+
+	it('lists conflicting files when the merge is aborted', async () => {
+		vi.mocked(gitService.mergeBranch).mockResolvedValue({
+			success: false,
+			conflicts: ['src/a.ts', 'src/b.ts'],
+		});
+		renderModal();
+
+		await screen.findByLabelText('Merge Into');
+		fireEvent.click(screen.getByRole('button', { name: 'Merge' }));
+
+		expect(await screen.findByText(/conflicts in 2 files/)).toBeInTheDocument();
+		expect(screen.getByText('src/a.ts')).toBeInTheDocument();
+		expect(screen.getByText('src/b.ts')).toBeInTheDocument();
+	});
+
+	it('surfaces a merge error verbatim', async () => {
+		vi.mocked(gitService.mergeBranch).mockResolvedValue({
+			success: false,
+			error: '"main" has uncommitted changes in /repo.',
+		});
+		renderModal();
+
+		await screen.findByLabelText('Merge Into');
+		fireEvent.click(screen.getByRole('button', { name: 'Merge' }));
+
+		expect(await screen.findByText('"main" has uncommitted changes in /repo.')).toBeInTheDocument();
+	});
+});

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -304,6 +304,8 @@ const mockMaestro = {
 		diff: vi.fn().mockResolvedValue(''),
 		isRepo: vi.fn().mockResolvedValue(true),
 		commitAll: vi.fn().mockResolvedValue({ success: true, committed: true, commitHash: 'abc1234' }),
+		mergeBranch: vi.fn().mockResolvedValue({ success: true, mergedIn: '/repo' }),
+		rebaseBranch: vi.fn().mockResolvedValue({ success: true }),
 		numstat: vi.fn().mockResolvedValue([]),
 		getStatus: vi.fn().mockResolvedValue({ branch: 'main', status: [] }),
 		worktreeSetup: vi.fn().mockResolvedValue({ success: true }),

--- a/src/main/ipc/handlers/git.ts
+++ b/src/main/ipc/handlers/git.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import chokidar, { FSWatcher } from 'chokidar';
 import { execFileNoThrow, execFileBufferNoThrow } from '../../utils/execFile';
 import { execGit } from '../../utils/remote-git';
+import type { SshRemoteConfig } from '../../../shared/types';
 import { logger } from '../../utils/logger';
 import { getSshRemoteById } from '../../stores';
 import { createSafeSend } from '../../utils/safe-send';
@@ -110,6 +111,57 @@ async function findLocalWorktreeForBranch(
 	} catch {
 		return null;
 	}
+}
+
+/**
+ * SSH-aware variant of {@link findLocalWorktreeForBranch}.
+ *
+ * Merge has to run in the directory where the target branch is checked out -
+ * git refuses to check a branch out twice, so we can't just switch inside the
+ * worktree. This locates that directory. The on-disk staleness check only
+ * applies locally; over SSH we trust the porcelain listing since we have no
+ * cheap way to stat the remote path.
+ */
+async function findWorktreeForBranch(
+	cwd: string,
+	branchName: string,
+	sshRemote: SshRemoteConfig | null | undefined,
+	remoteCwd: string | undefined
+): Promise<string | null> {
+	if (!sshRemote) return findLocalWorktreeForBranch(cwd, branchName);
+	const result = await execGit(['worktree', 'list', '--porcelain'], cwd, sshRemote, remoteCwd);
+	if (result.exitCode !== 0) return null;
+	return parseWorktreePathForBranch(result.stdout, branchName);
+}
+
+/**
+ * Reject refs that git would parse as an option.
+ *
+ * Branch names reaching these handlers come from `git branch` output via the
+ * renderer, so this is belt-and-braces: execGit uses execFile (no shell), but a
+ * leading dash would still be read as a flag rather than a ref.
+ */
+function isSafeRefName(ref: string): boolean {
+	return ref.length > 0 && !ref.startsWith('-');
+}
+
+/** List paths left conflicted by an in-progress merge/rebase. */
+async function listConflictedPaths(
+	cwd: string,
+	sshRemote: SshRemoteConfig | null | undefined,
+	remoteCwd: string | undefined
+): Promise<string[]> {
+	const result = await execGit(
+		['diff', '--name-only', '--diff-filter=U'],
+		cwd,
+		sshRemote,
+		remoteCwd
+	);
+	if (result.exitCode !== 0) return [];
+	return result.stdout
+		.split('\n')
+		.map((line) => line.trim())
+		.filter(Boolean);
 }
 
 /**
@@ -275,6 +327,170 @@ export function registerGitHandlers(deps: GitHandlerDependencies): void {
 				);
 				const commitHash = hashResult.exitCode === 0 ? hashResult.stdout.trim() : undefined;
 				return { success: true, committed: true, commitHash };
+			}
+		)
+	);
+
+	// Merge a worktree's branch into another branch (typically main).
+	//
+	// The merge runs in whichever worktree currently has `targetBranch` checked
+	// out, because git will not check the same branch out twice - we cannot just
+	// switch branches inside the source worktree. Conflicts abort the merge
+	// rather than leaving the user's main checkout in a half-merged state from a
+	// single button press; the conflicting paths come back so the UI can tell
+	// them what to resolve by hand.
+	ipcMain.handle(
+		'git:mergeBranch',
+		withIpcErrorLogging(
+			handlerOpts('mergeBranch'),
+			async (
+				cwd: string,
+				sourceBranch: string,
+				targetBranch: string,
+				sshRemoteId?: string,
+				remoteCwd?: string
+			) => {
+				const sshRemote = sshRemoteId ? getSshRemoteById(sshRemoteId) : undefined;
+				// Fail loudly rather than merging in the wrong (local) repo.
+				if (sshRemoteId && !sshRemote) {
+					return { success: false, error: `SSH remote not found: ${sshRemoteId}` };
+				}
+				if (!isSafeRefName(sourceBranch) || !isSafeRefName(targetBranch)) {
+					return { success: false, error: 'Invalid branch name' };
+				}
+				if (sourceBranch === targetBranch) {
+					return { success: false, error: 'Source and target branches are the same' };
+				}
+				const effectiveRemoteCwd = sshRemote ? remoteCwd || cwd : undefined;
+
+				const targetCwd = await findWorktreeForBranch(
+					cwd,
+					targetBranch,
+					sshRemote,
+					effectiveRemoteCwd
+				);
+				if (!targetCwd) {
+					return {
+						success: false,
+						error: `"${targetBranch}" is not checked out in any worktree. Check it out in your main repo first, then merge.`,
+					};
+				}
+				// When merging over SSH the target worktree lives on the remote too,
+				// so the remote cwd has to follow it - not stay on the source path.
+				const targetRemoteCwd = sshRemote ? targetCwd : undefined;
+
+				const statusResult = await execGit(
+					['status', '--porcelain'],
+					targetCwd,
+					sshRemote,
+					targetRemoteCwd
+				);
+				if (statusResult.exitCode !== 0) {
+					return {
+						success: false,
+						error: statusResult.stderr?.trim() || `Could not read git status in ${targetCwd}`,
+					};
+				}
+				if (statusResult.stdout.trim() !== '') {
+					return {
+						success: false,
+						error: `"${targetBranch}" has uncommitted changes in ${targetCwd}. Commit or stash them before merging.`,
+					};
+				}
+
+				const mergeResult = await execGit(
+					['merge', sourceBranch],
+					targetCwd,
+					sshRemote,
+					targetRemoteCwd
+				);
+				if (mergeResult.exitCode !== 0) {
+					const conflicts = await listConflictedPaths(targetCwd, sshRemote, targetRemoteCwd);
+					if (conflicts.length > 0) {
+						// Roll back so the target checkout is left exactly as we found it.
+						await execGit(['merge', '--abort'], targetCwd, sshRemote, targetRemoteCwd);
+						return { success: false, mergedIn: targetCwd, conflicts };
+					}
+					return {
+						success: false,
+						mergedIn: targetCwd,
+						error: mergeResult.stderr?.trim() || mergeResult.stdout?.trim() || 'git merge failed',
+					};
+				}
+
+				return {
+					success: true,
+					mergedIn: targetCwd,
+					alreadyUpToDate: /already up to date/i.test(mergeResult.stdout),
+				};
+			}
+		)
+	);
+
+	// Rebase the branch checked out in `cwd` onto another branch, pulling new
+	// upstream commits into a worktree. Unlike merge this runs in place - the
+	// base branch only needs to exist as a ref, not be checked out. Conflicts
+	// abort so the worktree never ends up stuck mid-rebase from a button press.
+	ipcMain.handle(
+		'git:rebaseBranch',
+		withIpcErrorLogging(
+			handlerOpts('rebaseBranch'),
+			async (cwd: string, ontoBranch: string, sshRemoteId?: string, remoteCwd?: string) => {
+				const sshRemote = sshRemoteId ? getSshRemoteById(sshRemoteId) : undefined;
+				if (sshRemoteId && !sshRemote) {
+					return { success: false, error: `SSH remote not found: ${sshRemoteId}` };
+				}
+				if (!isSafeRefName(ontoBranch)) {
+					return { success: false, error: 'Invalid branch name' };
+				}
+				const effectiveRemoteCwd = sshRemote ? remoteCwd || cwd : undefined;
+
+				const statusResult = await execGit(
+					['status', '--porcelain'],
+					cwd,
+					sshRemote,
+					effectiveRemoteCwd
+				);
+				if (statusResult.exitCode !== 0) {
+					return {
+						success: false,
+						error: statusResult.stderr?.trim() || 'Could not read git status',
+					};
+				}
+				if (statusResult.stdout.trim() !== '') {
+					return {
+						success: false,
+						error: 'This worktree has uncommitted changes. Commit or stash them before rebasing.',
+					};
+				}
+
+				const rebaseResult = await execGit(
+					['rebase', ontoBranch],
+					cwd,
+					sshRemote,
+					effectiveRemoteCwd
+				);
+				if (rebaseResult.exitCode !== 0) {
+					const conflicts = await listConflictedPaths(cwd, sshRemote, effectiveRemoteCwd);
+					// --abort is a no-op-with-error when no rebase is in progress (e.g.
+					// the ref simply did not resolve), so it is safe to always attempt.
+					await execGit(['rebase', '--abort'], cwd, sshRemote, effectiveRemoteCwd);
+					if (conflicts.length > 0) {
+						return { success: false, conflicts };
+					}
+					return {
+						success: false,
+						error:
+							rebaseResult.stderr?.trim() || rebaseResult.stdout?.trim() || 'git rebase failed',
+					};
+				}
+
+				return {
+					success: true,
+					alreadyUpToDate: /is up to date|current branch .* is up to date/i.test(
+						rebaseResult.stdout
+					),
+				};
 			}
 		)
 	);

--- a/src/main/preload/git.ts
+++ b/src/main/preload/git.ts
@@ -170,6 +170,49 @@ export function createGitApi() {
 		}> => ipcRenderer.invoke('git:commitAll', cwd, message, sshRemoteId, remoteCwd),
 
 		/**
+		 * Merge `sourceBranch` into `targetBranch`. Runs in whichever worktree has
+		 * `targetBranch` checked out. On conflict the merge is aborted and the
+		 * conflicting paths come back in `conflicts`.
+		 */
+		mergeBranch: (
+			cwd: string,
+			sourceBranch: string,
+			targetBranch: string,
+			sshRemoteId?: string,
+			remoteCwd?: string
+		): Promise<{
+			success: boolean;
+			mergedIn?: string;
+			conflicts?: string[];
+			alreadyUpToDate?: boolean;
+			error?: string;
+		}> =>
+			ipcRenderer.invoke(
+				'git:mergeBranch',
+				cwd,
+				sourceBranch,
+				targetBranch,
+				sshRemoteId,
+				remoteCwd
+			),
+
+		/**
+		 * Rebase the branch checked out in `cwd` onto `ontoBranch`. On conflict
+		 * the rebase is aborted and the conflicting paths come back.
+		 */
+		rebaseBranch: (
+			cwd: string,
+			ontoBranch: string,
+			sshRemoteId?: string,
+			remoteCwd?: string
+		): Promise<{
+			success: boolean;
+			conflicts?: string[];
+			alreadyUpToDate?: boolean;
+			error?: string;
+		}> => ipcRenderer.invoke('git:rebaseBranch', cwd, ontoBranch, sshRemoteId, remoteCwd),
+
+		/**
 		 * Get git diff numstat
 		 */
 		numstat: (

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1244,6 +1244,9 @@ function MaestroConsoleInner() {
 		handleQuickCreateWorktree,
 		handleOpenWorktreeConfigSession,
 		handleDeleteWorktreeSession,
+		handleMergeWorktreeSession,
+		handleRebaseWorktreeSession,
+		handleCloseWorktreeMergeModal,
 		handleToggleWorktreeExpanded,
 		handleCloseWorktreeConfigModal,
 		handleSaveWorktreeConfig,
@@ -2877,6 +2880,8 @@ function MaestroConsoleInner() {
 		handleQuickCreateWorktree,
 		handleOpenWorktreeConfigSession,
 		handleDeleteWorktreeSession,
+		handleMergeWorktreeSession,
+		handleRebaseWorktreeSession,
 		handleToggleWorktreeExpanded,
 		handleConfigureCue,
 		maestroCueEnabled: encoreFeatures.maestroCue,
@@ -3237,6 +3242,8 @@ function MaestroConsoleInner() {
 						onCloseDeleteWorktreeModal={handleCloseDeleteWorktreeModal}
 						onConfirmDeleteWorktree={handleConfirmDeleteWorktree}
 						onConfirmAndDeleteWorktreeOnDisk={handleConfirmAndDeleteWorktreeOnDisk}
+						onCloseWorktreeMergeModal={handleCloseWorktreeMergeModal}
+						onWorktreeMergeCompleted={refreshWorktreeState}
 						// AppUtilityModals props
 						quickActionInitialMode={quickActionInitialMode}
 						setQuickActionOpen={setQuickActionOpen}

--- a/src/renderer/components/AppModals/AppModals.tsx
+++ b/src/renderer/components/AppModals/AppModals.tsx
@@ -4,7 +4,7 @@ import type { MainPanelHandle } from '../MainPanel/types';
 import { useShallow } from 'zustand/react/shallow';
 import { useSessionStore, selectActiveSession } from '../../stores/sessionStore';
 import { useGroupChatStore } from '../../stores/groupChatStore';
-import { useModalStore } from '../../stores/modalStore';
+import { useModalStore, type WorktreeMergeModalData } from '../../stores/modalStore';
 import type {
 	Theme,
 	Session,
@@ -184,6 +184,8 @@ export interface AppModalsProps {
 	onCloseDeleteWorktreeModal: () => void;
 	onConfirmDeleteWorktree: () => void;
 	onConfirmAndDeleteWorktreeOnDisk: () => Promise<void>;
+	onCloseWorktreeMergeModal: () => void;
+	onWorktreeMergeCompleted?: () => void;
 
 	// --- AppUtilityModals props ---
 	quickActionInitialMode: 'main' | 'move-to-group' | 'agents';
@@ -506,6 +508,9 @@ export const AppModals = memo(function AppModals(props: AppModalsProps) {
 		createWorktreeModalOpen,
 		createPRModalOpen,
 		deleteWorktreeModalOpen,
+		worktreeMergeModalOpen,
+		worktreeMergeSession,
+		worktreeMergeMode,
 		quickActionOpen,
 		tabSwitcherOpen,
 		fuzzyFileSearchOpen,
@@ -581,6 +586,13 @@ export const AppModals = memo(function AppModals(props: AppModalsProps) {
 			createWorktreeModalOpen: s.modals.get('createWorktree')?.open ?? false,
 			createPRModalOpen: s.modals.get('createPR')?.open ?? false,
 			deleteWorktreeModalOpen: s.modals.get('deleteWorktree')?.open ?? false,
+			worktreeMergeModalOpen: s.modals.get('worktreeMerge')?.open ?? false,
+			worktreeMergeSession:
+				(s.modals.get('worktreeMerge')?.data as WorktreeMergeModalData | undefined)?.session ??
+				null,
+			worktreeMergeMode:
+				(s.modals.get('worktreeMerge')?.data as WorktreeMergeModalData | undefined)?.mode ??
+				'merge',
 			quickActionOpen: s.modals.get('quickAction')?.open ?? false,
 			tabSwitcherOpen: s.modals.get('tabSwitcher')?.open ?? false,
 			fuzzyFileSearchOpen: s.modals.get('fuzzyFileSearch')?.open ?? false,
@@ -682,6 +694,8 @@ export const AppModals = memo(function AppModals(props: AppModalsProps) {
 		onCloseDeleteWorktreeModal,
 		onConfirmDeleteWorktree,
 		onConfirmAndDeleteWorktreeOnDisk,
+		onCloseWorktreeMergeModal,
+		onWorktreeMergeCompleted,
 		// Utility modals
 		quickActionInitialMode,
 		setQuickActionOpen,
@@ -1036,6 +1050,11 @@ export const AppModals = memo(function AppModals(props: AppModalsProps) {
 				onCloseDeleteWorktreeModal={onCloseDeleteWorktreeModal}
 				onConfirmDeleteWorktree={onConfirmDeleteWorktree}
 				onConfirmAndDeleteWorktreeOnDisk={onConfirmAndDeleteWorktreeOnDisk}
+				worktreeMergeModalOpen={worktreeMergeModalOpen}
+				worktreeMergeSession={worktreeMergeSession}
+				worktreeMergeMode={worktreeMergeMode}
+				onCloseWorktreeMergeModal={onCloseWorktreeMergeModal}
+				onWorktreeMergeCompleted={onWorktreeMergeCompleted}
 			/>
 
 			{/* Utility/Workflow Modals */}

--- a/src/renderer/components/AppModals/AppWorktreeModals.tsx
+++ b/src/renderer/components/AppModals/AppWorktreeModals.tsx
@@ -7,6 +7,7 @@ import { WorktreeConfigModal } from '../WorktreeConfigModal';
 import { CreateWorktreeModal } from '../CreateWorktreeModal';
 import { CreatePRModal } from '../CreatePRModal';
 import { DeleteWorktreeModal } from '../DeleteWorktreeModal';
+import { WorktreeMergeModal, type WorktreeMergeMode } from '../WorktreeMergeModal';
 
 /**
  * Props for the AppWorktreeModals component
@@ -40,6 +41,14 @@ export interface AppWorktreeModalsProps {
 	onCloseDeleteWorktreeModal: () => void;
 	onConfirmDeleteWorktree: () => void;
 	onConfirmAndDeleteWorktreeOnDisk: () => Promise<void>;
+
+	// WorktreeMergeModal (merge / rebase a worktree branch)
+	worktreeMergeModalOpen: boolean;
+	worktreeMergeSession: Session | null;
+	worktreeMergeMode: WorktreeMergeMode;
+	onCloseWorktreeMergeModal: () => void;
+	/** Refresh git state after a merge or rebase lands. */
+	onWorktreeMergeCompleted?: () => void;
 }
 
 /**
@@ -50,6 +59,7 @@ export interface AppWorktreeModalsProps {
  * - CreateWorktreeModal: Quick create worktree from context menu
  * - CreatePRModal: Create a pull request from a worktree branch
  * - DeleteWorktreeModal: Remove a worktree session (optionally delete on disk)
+ * - WorktreeMergeModal: Merge a worktree branch into another, or rebase it
  */
 export const AppWorktreeModals = memo(function AppWorktreeModals({
 	theme,
@@ -76,6 +86,12 @@ export const AppWorktreeModals = memo(function AppWorktreeModals({
 	onCloseDeleteWorktreeModal,
 	onConfirmDeleteWorktree,
 	onConfirmAndDeleteWorktreeOnDisk,
+	// WorktreeMergeModal
+	worktreeMergeModalOpen,
+	worktreeMergeSession,
+	worktreeMergeMode,
+	onCloseWorktreeMergeModal,
+	onWorktreeMergeCompleted,
 }: AppWorktreeModalsProps) {
 	// Determine session for PR modal - uses createPRSession if set, otherwise activeSession
 	const prSession = createPRSession || activeSession;
@@ -127,6 +143,18 @@ export const AppWorktreeModals = memo(function AppWorktreeModals({
 					onClose={onCloseDeleteWorktreeModal}
 					onConfirm={onConfirmDeleteWorktree}
 					onConfirmAndDelete={onConfirmAndDeleteWorktreeOnDisk}
+				/>
+			)}
+
+			{/* --- MERGE / REBASE WORKTREE MODAL --- */}
+			{worktreeMergeModalOpen && worktreeMergeSession && (
+				<WorktreeMergeModal
+					isOpen={worktreeMergeModalOpen}
+					mode={worktreeMergeMode}
+					onClose={onCloseWorktreeMergeModal}
+					theme={theme}
+					session={worktreeMergeSession}
+					onCompleted={onWorktreeMergeCompleted}
 				/>
 			)}
 		</>

--- a/src/renderer/components/SessionList/SessionContextMenu.tsx
+++ b/src/renderer/components/SessionList/SessionContextMenu.tsx
@@ -8,6 +8,7 @@ import {
 	FolderPlus,
 	Folder,
 	GitBranch,
+	GitMerge,
 	GitPullRequest,
 	Trash2,
 	Edit3,
@@ -42,6 +43,8 @@ interface SessionContextMenuProps {
 	onCreatePR?: () => void;
 	onQuickCreateWorktree?: () => void;
 	onConfigureWorktrees?: () => void;
+	onMergeWorktree?: () => void;
+	onRebaseWorktree?: () => void;
 	onDeleteWorktree?: () => void;
 	onCreateGroup?: () => void;
 	/** Hide persisted-group mutation controls in a virtual grouping mode. */
@@ -141,6 +144,8 @@ export function SessionContextMenu({
 	onCreatePR,
 	onQuickCreateWorktree,
 	onConfigureWorktrees,
+	onMergeWorktree,
+	onRebaseWorktree,
 	onDeleteWorktree,
 	onCreateGroup,
 	showGroupActions = true,
@@ -211,7 +216,9 @@ export function SessionContextMenu({
 		((onQuickCreateWorktree && session.worktreeConfig) || onConfigureWorktrees);
 
 	const showWorktreeChildSection =
-		session.parentSessionId && session.worktreeBranch && (onCreatePR || onDeleteWorktree);
+		session.parentSessionId &&
+		session.worktreeBranch &&
+		(onCreatePR || onMergeWorktree || onRebaseWorktree || onDeleteWorktree);
 
 	return (
 		<div
@@ -619,6 +626,34 @@ export function SessionContextMenu({
 						>
 							<GitPullRequest className="w-3.5 h-3.5" />
 							Create Pull Request
+						</button>
+					)}
+					{onMergeWorktree && (
+						<button
+							type="button"
+							onClick={() => {
+								onMergeWorktree();
+								onDismiss();
+							}}
+							className="w-full text-left px-3 py-1.5 text-xs hover:bg-white/5 transition-colors flex items-center gap-2"
+							style={{ color: theme.colors.accent }}
+						>
+							<GitMerge className="w-3.5 h-3.5" />
+							Merge Branch Into...
+						</button>
+					)}
+					{onRebaseWorktree && (
+						<button
+							type="button"
+							onClick={() => {
+								onRebaseWorktree();
+								onDismiss();
+							}}
+							className="w-full text-left px-3 py-1.5 text-xs hover:bg-white/5 transition-colors flex items-center gap-2"
+							style={{ color: theme.colors.accent }}
+						>
+							<GitBranch className="w-3.5 h-3.5" />
+							Rebase Branch Onto...
 						</button>
 					)}
 					{onDeleteWorktree && (

--- a/src/renderer/components/SessionList/SessionList.tsx
+++ b/src/renderer/components/SessionList/SessionList.tsx
@@ -128,6 +128,8 @@ interface SessionListProps {
 	onOpenCreatePR?: (session: Session) => void;
 	onQuickCreateWorktree?: (session: Session) => void;
 	onOpenWorktreeConfig?: (session: Session) => void;
+	onMergeWorktree?: (session: Session) => void;
+	onRebaseWorktree?: (session: Session) => void;
 	onDeleteWorktree?: (session: Session) => void;
 
 	// Wizard props
@@ -434,6 +436,8 @@ function SessionListInner(props: SessionListProps) {
 		onOpenCreatePR,
 		onQuickCreateWorktree,
 		onOpenWorktreeConfig,
+		onMergeWorktree,
+		onRebaseWorktree,
 		onDeleteWorktree,
 		onConfigureCue,
 		showSessionJumpNumbers = false,
@@ -2173,6 +2177,16 @@ function SessionListInner(props: SessionListProps) {
 					onConfigureWorktrees={
 						onOpenWorktreeConfig && !contextMenuSession.parentSessionId
 							? () => onOpenWorktreeConfig(contextMenuSession)
+							: undefined
+					}
+					onMergeWorktree={
+						onMergeWorktree && contextMenuSession.parentSessionId
+							? () => onMergeWorktree(contextMenuSession)
+							: undefined
+					}
+					onRebaseWorktree={
+						onRebaseWorktree && contextMenuSession.parentSessionId
+							? () => onRebaseWorktree(contextMenuSession)
 							: undefined
 					}
 					onDeleteWorktree={

--- a/src/renderer/components/WorktreeMergeModal.tsx
+++ b/src/renderer/components/WorktreeMergeModal.tsx
@@ -1,0 +1,412 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { X, GitMerge, GitPullRequestArrow, AlertTriangle, Check } from 'lucide-react';
+import { GhostIconButton } from './ui/GhostIconButton';
+import { Spinner } from './ui/Spinner';
+import type { Theme, Session } from '../types';
+import { useModalLayer } from '../hooks/ui/useModalLayer';
+import { MODAL_PRIORITIES } from '../constants/modalPriorities';
+import { gitService } from '../services/git';
+import { captureException } from '../utils/sentry';
+
+export type WorktreeMergeMode = 'merge' | 'rebase';
+
+interface WorktreeMergeModalProps {
+	isOpen: boolean;
+	mode: WorktreeMergeMode;
+	onClose: () => void;
+	theme: Theme;
+	session: Session;
+	/** Called after a merge or rebase lands, so callers can refresh git state. */
+	onCompleted?: () => void;
+}
+
+/** Outcome of the git operation, used to pick the result banner. */
+type Result =
+	| { kind: 'success'; message: string }
+	| { kind: 'conflicts'; paths: string[] }
+	| { kind: 'error'; message: string };
+
+/**
+ * WorktreeMergeModal - Confirm and run a merge or rebase for a worktree agent.
+ *
+ * Merge takes the worktree's branch into a branch you pick (usually main).
+ * Rebase replays the worktree's branch on top of a branch you pick, which is
+ * how you pull new upstream work into a long-running worktree.
+ *
+ * Both operations refuse to run against a dirty tree, so when the worktree has
+ * uncommitted changes the modal offers to commit them first with a message you
+ * can edit. Conflicts abort the operation and are listed here for manual
+ * resolution - a button press should never leave a checkout mid-merge.
+ */
+export function WorktreeMergeModal({
+	isOpen,
+	mode,
+	onClose,
+	theme,
+	session,
+	onCompleted,
+}: WorktreeMergeModalProps) {
+	const onCloseRef = useRef(onClose);
+	onCloseRef.current = onClose;
+
+	useModalLayer(MODAL_PRIORITIES.WORKTREE_MERGE, undefined, () => onCloseRef.current(), {
+		focusTrap: 'lenient',
+		enabled: isOpen,
+	});
+
+	const [branches, setBranches] = useState<string[]>([]);
+	const [targetBranch, setTargetBranch] = useState('');
+	const [branchLoadError, setBranchLoadError] = useState(false);
+	const [dirtyFileCount, setDirtyFileCount] = useState(0);
+	const [commitMessage, setCommitMessage] = useState('');
+	const [isRunning, setIsRunning] = useState(false);
+	const [result, setResult] = useState<Result | null>(null);
+
+	const sshRemoteId = session.sshRemoteId || session.sessionSshRemoteConfig?.remoteId || undefined;
+	const sourceBranch = session.worktreeBranch || '';
+	const isMerge = mode === 'merge';
+
+	// Reset transient state whenever the modal opens so a previous run's result
+	// or stale commit message never bleeds into the next one.
+	useEffect(() => {
+		if (!isOpen) return;
+		setBranches([]);
+		setTargetBranch('');
+		setBranchLoadError(false);
+		setDirtyFileCount(0);
+		setResult(null);
+		setCommitMessage(sourceBranch ? `Work in progress on ${sourceBranch}` : 'Work in progress');
+	}, [isOpen, sourceBranch]);
+
+	// Load the branch list, the repo's default branch, and the worktree's dirty
+	// state together. The default branch is preselected because merging into (or
+	// rebasing onto) main is overwhelmingly the common case.
+	useEffect(() => {
+		if (!isOpen) return;
+
+		let cancelled = false;
+		Promise.all([
+			gitService.getBranches(session.cwd, sshRemoteId),
+			window.maestro.git.getDefaultBranch(session.cwd),
+			gitService.getStatus(session.cwd, sshRemoteId),
+		])
+			.then(([allBranches, defaultBranchResult, status]) => {
+				if (cancelled) return;
+				// The worktree's own branch is never a valid merge target or rebase
+				// base - merging a branch into itself is a no-op at best.
+				const selectable = allBranches.filter((b) => b !== sourceBranch);
+				const defaultBranch = defaultBranchResult.branch || '';
+				const sorted = [...selectable].sort((a, b) => {
+					if (a === defaultBranch && b !== defaultBranch) return -1;
+					if (a !== defaultBranch && b === defaultBranch) return 1;
+					return a.localeCompare(b);
+				});
+				setBranches(sorted);
+				setTargetBranch(sorted[0] || '');
+				setDirtyFileCount(status.files.length);
+			})
+			.catch((err) => {
+				if (cancelled) return;
+				captureException(err, { extra: { cwd: session.cwd, sshRemoteId, mode } });
+				setBranchLoadError(true);
+			});
+
+		return () => {
+			cancelled = true;
+		};
+	}, [isOpen, session.cwd, sshRemoteId, sourceBranch, mode]);
+
+	const handleRun = useCallback(async () => {
+		if (!targetBranch || !sourceBranch) return;
+
+		setIsRunning(true);
+		setResult(null);
+		try {
+			// Both git merge and git rebase refuse to run against a dirty tree, so
+			// commit first when the user asked for it via the message field.
+			if (dirtyFileCount > 0) {
+				const commit = await gitService.commitAll(
+					session.cwd,
+					commitMessage.trim() || 'Work in progress',
+					sshRemoteId
+				);
+				if (!commit.success) {
+					setResult({ kind: 'error', message: commit.error || 'Failed to commit changes' });
+					return;
+				}
+				setDirtyFileCount(0);
+			}
+
+			const op = isMerge
+				? await gitService.mergeBranch(session.cwd, sourceBranch, targetBranch, sshRemoteId)
+				: await gitService.rebaseBranch(session.cwd, targetBranch, sshRemoteId);
+
+			if (op.conflicts && op.conflicts.length > 0) {
+				setResult({ kind: 'conflicts', paths: op.conflicts });
+				return;
+			}
+			if (!op.success) {
+				setResult({
+					kind: 'error',
+					message: op.error || `git ${mode} failed`,
+				});
+				return;
+			}
+
+			if (op.alreadyUpToDate) {
+				setResult({ kind: 'success', message: 'Already up to date - nothing to do.' });
+			} else if (isMerge) {
+				setResult({
+					kind: 'success',
+					message: `Merged ${sourceBranch} into ${targetBranch}.`,
+				});
+			} else {
+				setResult({
+					kind: 'success',
+					message: `Rebased ${sourceBranch} onto ${targetBranch}.`,
+				});
+			}
+			onCompleted?.();
+		} finally {
+			setIsRunning(false);
+		}
+	}, [
+		targetBranch,
+		sourceBranch,
+		dirtyFileCount,
+		commitMessage,
+		session.cwd,
+		sshRemoteId,
+		isMerge,
+		mode,
+		onCompleted,
+	]);
+
+	if (!isOpen) return null;
+
+	const title = isMerge ? 'Merge Worktree Branch' : 'Rebase Worktree Branch';
+	const Icon = isMerge ? GitMerge : GitPullRequestArrow;
+	const branchLabel = isMerge ? 'Merge Into' : 'Rebase Onto';
+	const actionLabel = isMerge ? 'Merge' : 'Rebase';
+	const runningLabel = isMerge ? 'Merging…' : 'Rebasing…';
+	const canRun = !isRunning && !!sourceBranch && !!targetBranch && result?.kind !== 'success';
+
+	return (
+		<div className="fixed inset-0 z-50 flex items-center justify-center">
+			{/* Backdrop */}
+			<div className="absolute inset-0 bg-black/60" onClick={onClose} />
+
+			{/* Modal */}
+			<div
+				className="relative w-full max-w-md rounded-lg shadow-2xl border"
+				style={{
+					backgroundColor: theme.colors.bgSidebar,
+					borderColor: theme.colors.border,
+				}}
+			>
+				{/* Header */}
+				<div
+					className="flex items-center justify-between px-4 py-3 border-b"
+					style={{ borderColor: theme.colors.border }}
+				>
+					<div className="flex items-center gap-2">
+						<Icon className="w-5 h-5" style={{ color: theme.colors.accent }} />
+						<h2 className="font-bold" style={{ color: theme.colors.textMain }}>
+							{title}
+						</h2>
+					</div>
+					<GhostIconButton onClick={onClose} ariaLabel="Close">
+						<X className="w-4 h-4" style={{ color: theme.colors.textDim }} />
+					</GhostIconButton>
+				</div>
+
+				{/* Content */}
+				<div className="p-4 space-y-4">
+					{/* Source branch (fixed - it is this worktree's branch) */}
+					<div>
+						<label
+							className="text-xs font-bold uppercase mb-1.5 block"
+							style={{ color: theme.colors.textDim }}
+						>
+							Worktree Branch
+						</label>
+						<div
+							className="px-3 py-2 rounded border text-sm font-mono truncate"
+							style={{
+								backgroundColor: theme.colors.bgMain,
+								borderColor: theme.colors.border,
+								color: theme.colors.textMain,
+							}}
+						>
+							{sourceBranch || 'unknown'}
+						</div>
+					</div>
+
+					{/* Target branch */}
+					<div>
+						<label
+							htmlFor="worktree-merge-target"
+							className="text-xs font-bold uppercase mb-1.5 block"
+							style={{ color: theme.colors.textDim }}
+						>
+							{branchLabel}
+						</label>
+						<select
+							id="worktree-merge-target"
+							value={targetBranch}
+							onChange={(e) => setTargetBranch(e.target.value)}
+							disabled={isRunning || branchLoadError || branches.length === 0}
+							className="w-full px-3 py-2 rounded border outline-none text-sm"
+							style={{
+								backgroundColor: theme.colors.bgMain,
+								borderColor: branchLoadError ? theme.colors.error : theme.colors.border,
+								color: theme.colors.textMain,
+							}}
+						>
+							{branches.length === 0 && !branchLoadError && (
+								<option value="">Loading branches…</option>
+							)}
+							{branches.map((b) => (
+								<option key={b} value={b}>
+									{b}
+								</option>
+							))}
+						</select>
+						{branchLoadError && (
+							<p className="text-xs mt-1" style={{ color: theme.colors.error }}>
+								Could not load branches.
+							</p>
+						)}
+						<p className="text-[10px] mt-1" style={{ color: theme.colors.textDim }}>
+							{isMerge
+								? 'Runs in whichever worktree has this branch checked out. It must have a clean tree.'
+								: 'Replays this worktree onto the selected branch.'}
+						</p>
+					</div>
+
+					{/* Uncommitted changes - offer to commit first, since neither
+					    merge nor rebase will run against a dirty tree. */}
+					{dirtyFileCount > 0 && (
+						<div
+							className="p-3 rounded border space-y-2"
+							style={{
+								backgroundColor: theme.colors.warning + '10',
+								borderColor: theme.colors.warning,
+							}}
+						>
+							<div className="flex items-start gap-2">
+								<AlertTriangle
+									className="w-4 h-4 mt-0.5 shrink-0"
+									style={{ color: theme.colors.warning }}
+								/>
+								<p className="text-sm" style={{ color: theme.colors.warning }}>
+									{dirtyFileCount} uncommitted {dirtyFileCount === 1 ? 'change' : 'changes'} will be
+									committed first.
+								</p>
+							</div>
+							<textarea
+								value={commitMessage}
+								onChange={(e) => setCommitMessage(e.target.value)}
+								rows={2}
+								placeholder="Commit message"
+								disabled={isRunning}
+								className="w-full px-3 py-2 rounded border bg-transparent outline-none text-sm resize-none"
+								style={{
+									borderColor: theme.colors.border,
+									color: theme.colors.textMain,
+								}}
+							/>
+						</div>
+					)}
+
+					{/* Result */}
+					{result?.kind === 'success' && (
+						<div
+							className="flex items-start gap-2 p-3 rounded border"
+							style={{
+								backgroundColor: theme.colors.success + '10',
+								borderColor: theme.colors.success,
+							}}
+						>
+							<Check className="w-4 h-4 mt-0.5 shrink-0" style={{ color: theme.colors.success }} />
+							<p className="text-sm" style={{ color: theme.colors.success }}>
+								{result.message}
+							</p>
+						</div>
+					)}
+
+					{result?.kind === 'conflicts' && (
+						<div
+							className="p-3 rounded border space-y-1"
+							style={{
+								backgroundColor: theme.colors.error + '10',
+								borderColor: theme.colors.error,
+							}}
+						>
+							<p className="text-sm" style={{ color: theme.colors.error }}>
+								{actionLabel} aborted - conflicts in {result.paths.length}{' '}
+								{result.paths.length === 1 ? 'file' : 'files'}. Nothing was changed; resolve these
+								by hand.
+							</p>
+							<ul
+								className="text-xs font-mono max-h-28 overflow-y-auto"
+								style={{ color: theme.colors.textDim }}
+							>
+								{result.paths.map((p) => (
+									<li key={p} className="truncate">
+										{p}
+									</li>
+								))}
+							</ul>
+						</div>
+					)}
+
+					{result?.kind === 'error' && (
+						<div
+							className="flex items-start gap-2 p-3 rounded border"
+							style={{
+								backgroundColor: theme.colors.error + '10',
+								borderColor: theme.colors.error,
+							}}
+						>
+							<AlertTriangle
+								className="w-4 h-4 mt-0.5 shrink-0"
+								style={{ color: theme.colors.error }}
+							/>
+							<p className="text-sm" style={{ color: theme.colors.error }}>
+								{result.message}
+							</p>
+						</div>
+					)}
+				</div>
+
+				{/* Footer */}
+				<div
+					className="flex justify-end gap-2 px-4 py-3 border-t"
+					style={{ borderColor: theme.colors.border }}
+				>
+					<button
+						type="button"
+						onClick={onClose}
+						className="px-3 py-1.5 rounded border hover:bg-white/5 transition-colors outline-none text-xs"
+						style={{ borderColor: theme.colors.border, color: theme.colors.textMain }}
+					>
+						{result?.kind === 'success' ? 'Close' : 'Cancel'}
+					</button>
+					{result?.kind !== 'success' && (
+						<button
+							type="button"
+							onClick={handleRun}
+							disabled={!canRun}
+							className="px-3 py-1.5 rounded transition-colors outline-none text-xs flex items-center gap-1.5 disabled:opacity-50"
+							style={{ backgroundColor: theme.colors.accent, color: '#ffffff' }}
+						>
+							{isRunning && <Spinner size={12} />}
+							{isRunning ? runningLabel : actionLabel}
+						</button>
+					)}
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/src/renderer/constants/modalPriorities.ts
+++ b/src/renderer/constants/modalPriorities.ts
@@ -104,6 +104,9 @@ export const MODAL_PRIORITIES = {
 	/** Create worktree modal (quick create from context menu) */
 	CREATE_WORKTREE: 753,
 
+	/** Merge / rebase a worktree branch (from worktree context menu) */
+	WORKTREE_MERGE: 754,
+
 	/** Worktree configuration modal */
 	WORKTREE_CONFIG: 752,
 

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -1079,6 +1079,30 @@ interface MaestroAPI {
 			sshRemoteId?: string,
 			remoteCwd?: string
 		) => Promise<{ success: boolean; committed: boolean; commitHash?: string; error?: string }>;
+		mergeBranch: (
+			cwd: string,
+			sourceBranch: string,
+			targetBranch: string,
+			sshRemoteId?: string,
+			remoteCwd?: string
+		) => Promise<{
+			success: boolean;
+			mergedIn?: string;
+			conflicts?: string[];
+			alreadyUpToDate?: boolean;
+			error?: string;
+		}>;
+		rebaseBranch: (
+			cwd: string,
+			ontoBranch: string,
+			sshRemoteId?: string,
+			remoteCwd?: string
+		) => Promise<{
+			success: boolean;
+			conflicts?: string[];
+			alreadyUpToDate?: boolean;
+			error?: string;
+		}>;
 		numstat: (
 			cwd: string,
 			sshRemoteId?: string,

--- a/src/renderer/hooks/props/useSessionListProps.ts
+++ b/src/renderer/hooks/props/useSessionListProps.ts
@@ -49,6 +49,8 @@ export interface UseSessionListPropsDeps {
 	handleQuickCreateWorktree: (session: Session) => void;
 	handleOpenWorktreeConfigSession: (session: Session) => void;
 	handleDeleteWorktreeSession: (session: Session) => void;
+	handleMergeWorktreeSession: (session: Session) => void;
+	handleRebaseWorktreeSession: (session: Session) => void;
 	handleToggleWorktreeExpanded: (sessionId: string) => void;
 	handleConfigureCue: (session: Session) => void;
 	/** Whether the Maestro Cue Encore Feature is enabled. Gates the "Configure Maestro Cue" context-menu action. */
@@ -107,6 +109,8 @@ export function useSessionListProps(deps: UseSessionListPropsDeps) {
 			onOpenCreatePR: deps.handleOpenCreatePRSession,
 			onQuickCreateWorktree: deps.handleQuickCreateWorktree,
 			onOpenWorktreeConfig: deps.handleOpenWorktreeConfigSession,
+			onMergeWorktree: deps.handleMergeWorktreeSession,
+			onRebaseWorktree: deps.handleRebaseWorktreeSession,
 			onDeleteWorktree: deps.handleDeleteWorktreeSession,
 			onConfigureCue: deps.maestroCueEnabled ? deps.handleConfigureCue : undefined,
 			openWizard: deps.openWizardModal,
@@ -150,6 +154,8 @@ export function useSessionListProps(deps: UseSessionListPropsDeps) {
 			deps.handleQuickCreateWorktree,
 			deps.handleOpenWorktreeConfigSession,
 			deps.handleDeleteWorktreeSession,
+			deps.handleMergeWorktreeSession,
+			deps.handleRebaseWorktreeSession,
 			deps.handleConfigureCue,
 			deps.maestroCueEnabled,
 			deps.handleToggleWorktreeExpanded,

--- a/src/renderer/hooks/worktree/useWorktreeHandlers.ts
+++ b/src/renderer/hooks/worktree/useWorktreeHandlers.ts
@@ -52,6 +52,9 @@ export interface WorktreeHandlersReturn {
 	handleQuickCreateWorktree: (session: Session) => void;
 	handleOpenWorktreeConfigSession: (session: Session) => void;
 	handleDeleteWorktreeSession: (session: Session) => void;
+	handleMergeWorktreeSession: (session: Session) => void;
+	handleRebaseWorktreeSession: (session: Session) => void;
+	handleCloseWorktreeMergeModal: () => void;
 	handleToggleWorktreeExpanded: (sessionId: string) => void;
 	handleCloseWorktreeConfigModal: () => void;
 	handleSaveWorktreeConfig: (config: { basePath: string; watchEnabled: boolean }) => Promise<void>;
@@ -193,6 +196,18 @@ export function useWorktreeHandlers(deps: UseWorktreeHandlersDeps = {}): Worktre
 
 	const handleDeleteWorktreeSession = useCallback((session: Session) => {
 		getModalActions().setDeleteWorktreeSession(session);
+	}, []);
+
+	const handleMergeWorktreeSession = useCallback((session: Session) => {
+		getModalActions().openWorktreeMergeModal(session, 'merge');
+	}, []);
+
+	const handleRebaseWorktreeSession = useCallback((session: Session) => {
+		getModalActions().openWorktreeMergeModal(session, 'rebase');
+	}, []);
+
+	const handleCloseWorktreeMergeModal = useCallback(() => {
+		getModalActions().closeWorktreeMergeModal();
 	}, []);
 
 	const handleToggleWorktreeExpanded = useCallback((sessionId: string) => {
@@ -1234,6 +1249,9 @@ export function useWorktreeHandlers(deps: UseWorktreeHandlersDeps = {}): Worktre
 		handleQuickCreateWorktree,
 		handleOpenWorktreeConfigSession,
 		handleDeleteWorktreeSession,
+		handleMergeWorktreeSession,
+		handleRebaseWorktreeSession,
+		handleCloseWorktreeMergeModal,
 		handleToggleWorktreeExpanded,
 		handleCloseWorktreeConfigModal,
 		handleSaveWorktreeConfig,

--- a/src/renderer/services/git.ts
+++ b/src/renderer/services/git.ts
@@ -97,6 +97,58 @@ export const gitService = {
 	},
 
 	/**
+	 * Merge a worktree branch into another branch. The merge runs wherever
+	 * `targetBranch` is checked out; conflicts abort it and come back in
+	 * `conflicts` rather than leaving that checkout half-merged.
+	 * @param cwd Worktree path (used to locate the repo)
+	 * @param sourceBranch Branch to merge from
+	 * @param targetBranch Branch to merge into
+	 * @param sshRemoteId Optional SSH remote ID for remote execution
+	 */
+	async mergeBranch(
+		cwd: string,
+		sourceBranch: string,
+		targetBranch: string,
+		sshRemoteId?: string
+	): Promise<{
+		success: boolean;
+		mergedIn?: string;
+		conflicts?: string[];
+		alreadyUpToDate?: boolean;
+		error?: string;
+	}> {
+		return createIpcMethod({
+			call: () => window.maestro.git.mergeBranch(cwd, sourceBranch, targetBranch, sshRemoteId),
+			errorContext: 'Git mergeBranch',
+			defaultValue: { success: false, error: 'git merge failed' },
+		});
+	},
+
+	/**
+	 * Rebase the branch checked out in `cwd` onto `ontoBranch`, pulling new
+	 * upstream commits into a worktree. Conflicts abort the rebase.
+	 * @param cwd Worktree path
+	 * @param ontoBranch Branch to rebase onto
+	 * @param sshRemoteId Optional SSH remote ID for remote execution
+	 */
+	async rebaseBranch(
+		cwd: string,
+		ontoBranch: string,
+		sshRemoteId?: string
+	): Promise<{
+		success: boolean;
+		conflicts?: string[];
+		alreadyUpToDate?: boolean;
+		error?: string;
+	}> {
+		return createIpcMethod({
+			call: () => window.maestro.git.rebaseBranch(cwd, ontoBranch, sshRemoteId),
+			errorContext: 'Git rebaseBranch',
+			defaultValue: { success: false, error: 'git rebase failed' },
+		});
+	},
+
+	/**
 	 * Get git status (porcelain format) and current branch
 	 * @param cwd Working directory path
 	 * @param sshRemoteId Optional SSH remote ID for remote execution

--- a/src/renderer/stores/modalStore.ts
+++ b/src/renderer/stores/modalStore.ts
@@ -188,6 +188,12 @@ export interface WorktreeModalData {
 	session: Session;
 }
 
+/** Worktree merge/rebase modal data - one modal serves both operations */
+export interface WorktreeMergeModalData {
+	session: Session;
+	mode: 'merge' | 'rebase';
+}
+
 /** Group chat modal data (delete/rename/edit) */
 export interface GroupChatModalData {
 	groupChatId: string;
@@ -264,6 +270,7 @@ export type ModalId =
 	| 'createWorktree'
 	| 'createPR'
 	| 'deleteWorktree'
+	| 'worktreeMerge'
 	// Group Chat
 	| 'newGroupChat'
 	| 'deleteGroupChat'
@@ -331,6 +338,7 @@ export interface ModalDataMap {
 	createWorktree: WorktreeModalData;
 	createPR: WorktreeModalData;
 	deleteWorktree: WorktreeModalData;
+	worktreeMerge: WorktreeMergeModalData;
 	deleteGroupChat: GroupChatModalData;
 	renameGroupChat: GroupChatModalData;
 	editGroupChat: GroupChatModalData;
@@ -878,6 +886,9 @@ export function getModalActions() {
 			open ? openModal('deleteWorktree') : closeModal('deleteWorktree'),
 		setDeleteWorktreeSession: (session: Session | null) =>
 			session ? openModal('deleteWorktree', { session }) : closeModal('deleteWorktree'),
+		openWorktreeMergeModal: (session: Session, mode: 'merge' | 'rebase') =>
+			openModal('worktreeMerge', { session, mode }),
+		closeWorktreeMergeModal: () => closeModal('worktreeMerge'),
 
 		// Tab Switcher Modal
 		setTabSwitcherOpen: (open: boolean) =>
@@ -1027,6 +1038,8 @@ export function useModalActions() {
 	const createPRData = useModalStore(selectModalData('createPR'));
 	const deleteWorktreeModalOpen = useModalStore(selectModalOpen('deleteWorktree'));
 	const deleteWorktreeData = useModalStore(selectModalData('deleteWorktree'));
+	const worktreeMergeModalOpen = useModalStore(selectModalOpen('worktreeMerge'));
+	const worktreeMergeData = useModalStore(selectModalData('worktreeMerge'));
 	const tabSwitcherOpen = useModalStore(selectModalOpen('tabSwitcher'));
 	const fuzzyFileSearchOpen = useModalStore(selectModalOpen('fuzzyFileSearch'));
 	const promptComposerOpen = useModalStore(selectModalOpen('promptComposer'));
@@ -1195,6 +1208,9 @@ export function useModalActions() {
 		createPRSession: createPRData?.session ?? null,
 		deleteWorktreeModalOpen,
 		deleteWorktreeSession: deleteWorktreeData?.session ?? null,
+		worktreeMergeModalOpen,
+		worktreeMergeSession: worktreeMergeData?.session ?? null,
+		worktreeMergeMode: worktreeMergeData?.mode ?? 'merge',
 
 		// Tab Switcher Modal
 		tabSwitcherOpen,


### PR DESCRIPTION
Closes #263

## What

Worktree sub-agents could already create a PR or be removed, but there was no way to land their work without dropping to a terminal. This adds two entries to the right-click menu on a worktree agent:

- **Merge Branch Into...** - merge this worktree's branch into a branch you pick
- **Rebase Branch Onto...** - replay this worktree's branch on top of a branch you pick, to pull in new upstream work

Both open a confirmation modal with a branch picker that defaults to the repo's default branch. This follows the direction in the issue thread: "Adding these as options on the right-click menu for worktrees does sound like a nice idea."

## How

Two new SSH-aware IPC handlers in `src/main/ipc/handlers/git.ts`:

**`git:mergeBranch`** runs in whichever worktree currently has the target branch checked out, located via `git worktree list --porcelain`. That indirection is necessary: git will not check the same branch out twice, so the merge cannot just happen inside the source worktree. It refuses to run when that checkout has uncommitted changes, and on conflict it runs `git merge --abort` and returns the conflicting paths. A single button press should never leave someone's main checkout stuck half-merged.

**`git:rebaseBranch`** runs in place in the worktree - the base branch only needs to exist as a ref, no checkout required. Same clean-tree requirement, same abort-on-conflict behavior.

Because neither operation runs against a dirty tree, `WorktreeMergeModal` detects uncommitted changes in the worktree and offers to commit them first with an editable message, reusing the existing `git:commitAll` handler. That covers the issue's ask for "a pop-up window to allow me to confirm the message content".

Branch names get a leading-dash check before reaching git. `execGit` already uses `execFile` (no shell), so this only stops a name being parsed as a flag rather than as a ref.

## Not in this PR

Two parts of the original request are deliberately left out, and I'd rather confirm the shape before building them:

- **Auto-commit when a task completes.** This needs a decision about where it hooks in (agent-idle transition? Auto Run iteration boundary?) and whether it is opt-in per agent. Worth its own issue.
- **Generating commit messages with a cheaper model (e.g. DeepSeek).** Maestro has no separate "utility model" configuration today, so this means new settings surface rather than a small addition. The modal's message field is hand-editable in the meantime.

Choosing the base branch when *creating* a worktree already works (`CreateWorktreeModal` has a Base Branch picker); this PR adds the matching choice on the merge/rebase side.

## Testing

- 11 new handler tests in `src/__tests__/main/ipc/handlers/git.test.ts` covering: merging in the target's worktree, already-up-to-date, refusing a dirty target, abort-and-report on conflict, target branch not checked out anywhere, self-merge, and flag-like branch names - plus the rebase equivalents.
- 7 new component tests in `src/__tests__/renderer/components/WorktreeMergeModal.test.tsx` covering default-branch preselection, excluding the worktree's own branch from the picker, merge and rebase dispatch, commit-first with the confirmed message, not merging when that commit fails, and conflict/error rendering.
- Full suite: 34,665 passed, 108 skipped. `npm run lint`, `npm run lint:eslint`, and `prettier --check .` all clean.

Note: validated on macOS only. Needs both CI matrix legs green before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added options to merge a worktree branch into another branch or rebase it onto a selected branch.
  * Added a guided modal for selecting branches, committing pending changes, and reviewing operation results.
  * Added conflict reporting with affected file paths and clear success, error, and up-to-date messages.
  * Added support for performing merge and rebase operations on remote worktrees.
* **Bug Fixes**
  * Prevented operations on uncommitted worktrees, invalid branch names, missing branches, and self-merges.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->