### PR TITLE
feat(web-desktop): resolve web clients to a live window for window-scoped IPC

### DIFF
--- a/src/__tests__/main/web-server/handlers/bridgeHandlers.test.ts
+++ b/src/__tests__/main/web-server/handlers/bridgeHandlers.test.ts
@@ -167,11 +167,11 @@ describe('handleBridgeInvoke', () => {
 		expect(callArgs.slice(1)).toEqual(['session-123', 'echo hello']);
 	});
 
-	// Regression: FAKE_EVENT used to omit `sender` entirely. Handlers that
+	// Regression: FAKE_EVENT used to omit `sender` entirely, so handlers that
 	// resolve the calling window via BrowserWindow.fromWebContents(event.sender)
-	// — windows:getState is the one web-desktop calls during boot — then made
-	// Electron throw "Cannot read properties of undefined (reading
-	// 'getOwnerBrowserWindow')", and the remote page hung on the splash forever.
+	// saw no caller. windows:getState, which web-desktop calls during boot, is
+	// the one that matters: it returned null for every web client, leaving the
+	// remote page without the window state it mirrors.
 	it('passes a live window webContents as event.sender', async () => {
 		const webContents = { id: 7 };
 		windows.push({ isDestroyed: () => false, webContents });

--- a/src/__tests__/main/web-server/handlers/bridgeHandlers.test.ts
+++ b/src/__tests__/main/web-server/handlers/bridgeHandlers.test.ts
@@ -21,13 +21,18 @@ type Handler = (event: unknown, ...args: unknown[]) => unknown;
 // `vi.hoisted` runs before the module factory so the map is initialized in
 // time for vi.mock - top-level consts would be in the temporal dead zone
 // at hoist time and the mock factory would throw.
-const { invokeHandlers } = vi.hoisted(() => ({
+const { invokeHandlers, windows } = vi.hoisted(() => ({
 	invokeHandlers: new Map<string, Handler>(),
+	// Stand-ins for live BrowserWindows; FAKE_EVENT.sender resolves through these.
+	windows: [] as { isDestroyed: () => boolean; webContents: unknown }[],
 }));
 
 vi.mock('electron', () => ({
 	ipcMain: {
 		_invokeHandlers: invokeHandlers,
+	},
+	BrowserWindow: {
+		getAllWindows: () => windows,
 	},
 }));
 
@@ -55,6 +60,7 @@ function lastSend(client: ReturnType<typeof makeClient>): Record<string, unknown
 
 beforeEach(() => {
 	invokeHandlers.clear();
+	windows.length = 0;
 });
 
 describe('handleBridgeInvoke', () => {
@@ -159,6 +165,60 @@ describe('handleBridgeInvoke', () => {
 		// First arg is the FAKE_EVENT object, then the user args.
 		const callArgs = spy.mock.calls[0];
 		expect(callArgs.slice(1)).toEqual(['session-123', 'echo hello']);
+	});
+
+	// Regression: FAKE_EVENT used to omit `sender` entirely. Handlers that
+	// resolve the calling window via BrowserWindow.fromWebContents(event.sender)
+	// — windows:getState is the one web-desktop calls during boot — then made
+	// Electron throw "Cannot read properties of undefined (reading
+	// 'getOwnerBrowserWindow')", and the remote page hung on the splash forever.
+	it('passes a live window webContents as event.sender', async () => {
+		const webContents = { id: 7 };
+		windows.push({ isDestroyed: () => false, webContents });
+
+		const spy = vi.fn().mockResolvedValue(null);
+		invokeHandlers.set('windows:getState', spy);
+
+		await handleBridgeInvoke(
+			makeClient(),
+			{ type: 'bridge.invoke', requestId: 1, channel: 'windows:getState' },
+			vi.fn()
+		);
+
+		const event = spy.mock.calls[0][0] as { sender?: unknown };
+		expect(event.sender).toBe(webContents);
+	});
+
+	it('skips destroyed windows when resolving event.sender', async () => {
+		const liveContents = { id: 2 };
+		windows.push({ isDestroyed: () => true, webContents: { id: 1 } });
+		windows.push({ isDestroyed: () => false, webContents: liveContents });
+
+		const spy = vi.fn().mockResolvedValue(null);
+		invokeHandlers.set('windows:getState', spy);
+
+		await handleBridgeInvoke(
+			makeClient(),
+			{ type: 'bridge.invoke', requestId: 1, channel: 'windows:getState' },
+			vi.fn()
+		);
+
+		const event = spy.mock.calls[0][0] as { sender?: unknown };
+		expect(event.sender).toBe(liveContents);
+	});
+
+	it('leaves event.sender undefined when no window is open', async () => {
+		const spy = vi.fn().mockResolvedValue(null);
+		invokeHandlers.set('windows:getState', spy);
+
+		await handleBridgeInvoke(
+			makeClient(),
+			{ type: 'bridge.invoke', requestId: 1, channel: 'windows:getState' },
+			vi.fn()
+		);
+
+		const event = spy.mock.calls[0][0] as { sender?: unknown };
+		expect(event.sender).toBeUndefined();
 	});
 
 	void lastSend; // helper kept available for future tests; tsc would warn if unused.

--- a/src/main/web-server/handlers/bridgeHandlers.ts
+++ b/src/main/web-server/handlers/bridgeHandlers.ts
@@ -42,20 +42,23 @@ interface BridgeFakeEvent {
 
 const FAKE_EVENT: BridgeFakeEvent = {
 	/**
-	 * A web client has no `webContents` of its own, but handlers that need to
-	 * know which window called them resolve it via
+	 * A web client has no `webContents` of its own. Handlers that need to know
+	 * which window called them go through
 	 * `BrowserWindow.fromWebContents(event.sender)` (see `resolveCallingWindow`
-	 * in `ipc/handlers/windows.ts`). Leaving `sender` undefined made Electron
-	 * throw "Cannot read properties of undefined (reading
-	 * 'getOwnerBrowserWindow')" on `windows:getState`, which web-desktop treats
-	 * as fatal — the remote page hung on the splash screen forever.
+	 * in `ipc/handlers/windows.ts`), so with no `sender` every window-scoped
+	 * handler resolves to "unknown caller" and quietly degrades: `windows:getState`
+	 * returns null, and claiming an agent or setting panel state becomes a no-op.
 	 *
-	 * A web client mirrors the desktop UI, so it resolves to the oldest live
-	 * window — `getAllWindows()` is creation-ordered, making that the main
-	 * window. Must be a getter, not a value: this module is evaluated before any
+	 * Resolving to a live window instead lets a web client act as the mirror of
+	 * the desktop that it is, so those features work remotely. Electron does not
+	 * document a stable ordering for `getAllWindows()`, so this deliberately
+	 * picks *a* live window rather than claiming to pick the main one; with a
+	 * single window open, the common case, they are the same window.
+	 *
+	 * Must be a getter, not a value: this module is evaluated before any
 	 * BrowserWindow exists, and the resolved window changes over the app's life.
 	 * Still `undefined` when no window is open (headless/tray), so callers keep
-	 * their existing "unknown caller" path rather than crashing.
+	 * their existing "unknown caller" path.
 	 */
 	get sender(): Electron.WebContents | undefined {
 		return BrowserWindow.getAllWindows().find((w) => !w.isDestroyed())?.webContents;

--- a/src/main/web-server/handlers/bridgeHandlers.ts
+++ b/src/main/web-server/handlers/bridgeHandlers.ts
@@ -14,7 +14,7 @@
  * out to all WS clients as bridge.event. Clients filter via their own ipcRenderer.on.
  */
 
-import { ipcMain } from 'electron';
+import { BrowserWindow, ipcMain } from 'electron';
 import { logger } from '../../utils/logger';
 import type { WebClient } from '../types';
 import type { BroadcastService } from '../services';
@@ -33,6 +33,7 @@ interface IpcMainInternal {
 }
 
 interface BridgeFakeEvent {
+	readonly sender: Electron.WebContents | undefined;
 	senderFrame: null;
 	frameId: number;
 	processId: number;
@@ -40,6 +41,25 @@ interface BridgeFakeEvent {
 }
 
 const FAKE_EVENT: BridgeFakeEvent = {
+	/**
+	 * A web client has no `webContents` of its own, but handlers that need to
+	 * know which window called them resolve it via
+	 * `BrowserWindow.fromWebContents(event.sender)` (see `resolveCallingWindow`
+	 * in `ipc/handlers/windows.ts`). Leaving `sender` undefined made Electron
+	 * throw "Cannot read properties of undefined (reading
+	 * 'getOwnerBrowserWindow')" on `windows:getState`, which web-desktop treats
+	 * as fatal — the remote page hung on the splash screen forever.
+	 *
+	 * A web client mirrors the desktop UI, so it resolves to the oldest live
+	 * window — `getAllWindows()` is creation-ordered, making that the main
+	 * window. Must be a getter, not a value: this module is evaluated before any
+	 * BrowserWindow exists, and the resolved window changes over the app's life.
+	 * Still `undefined` when no window is open (headless/tray), so callers keep
+	 * their existing "unknown caller" path rather than crashing.
+	 */
+	get sender(): Electron.WebContents | undefined {
+		return BrowserWindow.getAllWindows().find((w) => !w.isDestroyed())?.webContents;
+	},
 	senderFrame: null,
 	frameId: -1,
 	processId: -1,


### PR DESCRIPTION
## What this does

`FAKE_EVENT`, the synthetic `IpcMainInvokeEvent` that web-desktop clients
invoke `ipcMain` handlers through, defines `senderFrame`, `frameId`,
`processId` and `type`, but no `sender`. This adds a lazily-resolved
`sender` pointing at a live window's `webContents`.

## Why (revised, please read)

This PR was opened as a crash fix. That framing was wrong for this base
branch, and I would rather correct it than let it merge under a stale
description.

The crash I originally hit is real, but it is already handled on `rc` by
4765edae1a (2026-07-04), which added to `resolveCallingWindow`:

```ts
// A web client is not a window; resolve to "no window" instead of letting
// BrowserWindow.fromWebContents throw on the missing WebContents.
if (!event?.sender) return undefined;
```

My installed 0.19.0-RC build predates that commit, which is why I saw
`Cannot read properties of undefined (reading 'getOwnerBrowserWindow')`
and the remote page hanging on the splash screen. On current `rc` that
cannot happen.

So what is left is not a crash but a behavioral gap. With no `sender`,
every window-scoped handler resolves to "unknown caller" and silently
degrades for web clients:

- `windows:getState` returns `null`
- claiming a freshly-created agent for the calling window is a no-op
- `setPanelState` and window naming are no-ops

Giving the bridge a `sender` makes those work remotely, on the theory
that a web client is a mirror of the desktop and should act as the window
it mirrors.

**That directly contradicts the intent stated in 4765edae1a** ("a web
client is not a window"), so this is your call, not mine. If the
degradation is deliberate, close this and I will not object. I have left
the guard in `resolveCallingWindow` untouched either way, so nothing here
depends on removing it.

## Implementation notes

`sender` is a getter, not a value: the module is evaluated before any
`BrowserWindow` exists, and the correct answer changes over the app's
lifetime. It still yields `undefined` when no window is open
(headless/tray), so every handler's existing "unknown caller" path stays
intact.

Per review feedback, the comment no longer claims `getAllWindows()` is
creation-ordered, since Electron does not document that. It picks *a*
live window; with a single window open, the common case, that is the main
window. I looked at using `getMainWindow` instead, but it is dependency
injected at every call site (`web-server-factory.ts`) and is not
importable from a module-level const.

## Testing

Three regression tests: sender resolves to a live window, destroyed
windows are skipped, no-windows still yields `undefined`. Verified by
mutation (reverting the getter fails two). Full file: 11/11 passing.

Manually verified against a local web server over loopback with a CDP
probe. Zero failed `windows:getState` responses out of 11,803 successful
`bridge.response` frames, no `getOwnerBrowserWindow` in console, and the
DOM renders the real UI. The only remaining failures are pre-existing
`fs:readDir` EPERM against Windows junction points
(`My Music`/`My Pictures`/`My Videos`), unrelated to this change.

## Review feedback addressed

- Em dashes removed from the production and test comments (flagged by
  CodeRabbit, Greptile, and Codex).
- `getAllWindows()` ordering claim dropped (CodeRabbit).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability for web-initiated window actions by ensuring requests can be associated with an available application window.
  * Prevented errors when the previously active window has been closed or is unavailable.
  * Added safeguards for scenarios where no usable window exists, leaving sender information unset when appropriate.
  * Expanded test coverage to verify sender selection and skipped destroyed windows for bridge invoke handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->