### PR TITLE
Clamp window minimum size to the work area so maximize works on small/scaled screens

### DIFF
--- a/src/__tests__/main/app-lifecycle/window-manager.test.ts
+++ b/src/__tests__/main/app-lifecycle/window-manager.test.ts
@@ -15,7 +15,7 @@ import type { WindowManagerDependencies } from '../../../main/app-lifecycle/wind
 
 // Track event handlers
 let windowCloseHandler: (() => void) | null = null;
-// The window's `move` listener (drives the cross-display min-size re-clamp).
+// The window's `moved` listener (drives the cross-display min-size re-clamp).
 let windowMoveHandler: (() => void) | null = null;
 // The factory registers several `closed` listeners; collect them all so a test
 // can fire the full close sequence rather than guessing which one is last.
@@ -89,7 +89,12 @@ const mockWindowInstance = {
 	on: vi.fn((event: string, handler: () => void) => {
 		if (event === 'close') windowCloseHandler = handler;
 		if (event === 'closed') windowClosedHandlers.push(handler);
-		if (event === 'move') windowMoveHandler = handler;
+		if (event === 'moved') windowMoveHandler = handler;
+	}),
+	// The reclamp cleanup on 'closed' removes the window's own `moved` listener,
+	// so the mock must expose removeListener to mirror Electron's EventEmitter.
+	removeListener: vi.fn((event: string) => {
+		if (event === 'moved') windowMoveHandler = null;
 	}),
 };
 
@@ -110,6 +115,7 @@ class MockBrowserWindow {
 	getBounds = mockWindowInstance.getBounds;
 	webContents = mockWindowInstance.webContents;
 	on = mockWindowInstance.on;
+	removeListener = mockWindowInstance.removeListener;
 
 	constructor(options: unknown) {
 		lastBrowserWindowOptions = options as Record<string, unknown>;
@@ -513,35 +519,68 @@ describe('app-lifecycle/window-manager', () => {
 
 			it('re-clamps the minimum size when the window moves onto a smaller display', async () => {
 				// Dragging onto an already-connected smaller display does NOT fire
-				// display-metrics-changed, so the window's own move event must re-clamp.
-				vi.useFakeTimers();
-				try {
-					const windowManager = await makeManager();
-					windowManager.createWindow();
-					expect(windowMoveHandler).not.toBeNull();
-					mockWindowInstance.setMinimumSize.mockClear();
+				// display-metrics-changed, so the window's own `moved` event must
+				// re-clamp against the destination work area.
+				const windowManager = await makeManager();
+				windowManager.createWindow();
+				expect(windowMoveHandler).not.toBeNull();
+				mockWindowInstance.setMinimumSize.mockClear();
 
-					// A second, smaller display exists; the window drags onto it.
-					mockScreen.state.displays = [
-						{ workArea: { x: 0, y: 0, width: 1920, height: 1080 } },
-						{ workArea: { x: 1920, y: 0, width: 1093, height: 593 } },
-					];
-					mockWindowInstance.getBounds.mockReturnValue({
-						x: 1920,
-						y: 0,
-						width: 1093,
-						height: 593,
-					});
+				// A second, smaller display exists; the window drags onto it.
+				mockScreen.state.displays = [
+					{ workArea: { x: 0, y: 0, width: 1920, height: 1080 } },
+					{ workArea: { x: 1920, y: 0, width: 1093, height: 593 } },
+				];
+				mockWindowInstance.getBounds.mockReturnValue({
+					x: 1920,
+					y: 0,
+					width: 1093,
+					height: 593,
+				});
 
-					windowMoveHandler!();
-					// Debounced: nothing until the drag settles.
-					expect(mockWindowInstance.setMinimumSize).not.toHaveBeenCalled();
-					vi.runAllTimers();
+				windowMoveHandler!();
 
-					expect(mockWindowInstance.setMinimumSize).toHaveBeenCalledWith(1000, 593);
-				} finally {
-					vi.useRealTimers();
-				}
+				expect(mockWindowInstance.setMinimumSize).toHaveBeenCalledWith(1000, 593);
+			});
+
+			it('re-asserts the minimum only once while the same-bounds move repeats', async () => {
+				// On GTK the `moved` event fires repeatedly through a single drag.
+				// The change-guard must collapse identical re-clamps into one
+				// setMinimumSize call so we do not churn on every tick.
+				const windowManager = await makeManager();
+				windowManager.createWindow();
+				expect(windowMoveHandler).not.toBeNull();
+				mockWindowInstance.setMinimumSize.mockClear();
+
+				mockScreen.state.displays = [
+					{ workArea: { x: 0, y: 0, width: 1920, height: 1080 } },
+					{ workArea: { x: 1920, y: 0, width: 1093, height: 593 } },
+				];
+				mockWindowInstance.getBounds.mockReturnValue({
+					x: 1920,
+					y: 0,
+					width: 1093,
+					height: 593,
+				});
+
+				windowMoveHandler!();
+				windowMoveHandler!();
+
+				expect(mockWindowInstance.setMinimumSize).toHaveBeenCalledTimes(1);
+				expect(mockWindowInstance.setMinimumSize).toHaveBeenCalledWith(1000, 593);
+			});
+
+			it('re-clamps the minimum size once immediately after window creation', async () => {
+				// Constraints computed from raw saved x/y can resolve against a
+				// different display than the window opens on; the post-creation
+				// reclamp corrects the minimum against the true getBounds() position.
+				const windowManager = await makeManager();
+				windowManager.createWindow();
+
+				// Default getBounds (1200x800 on the 1920x1080 display) yields the
+				// design minimum, applied once as the window comes up.
+				expect(mockWindowInstance.setMinimumSize).toHaveBeenCalledTimes(1);
+				expect(mockWindowInstance.setMinimumSize).toHaveBeenCalledWith(1000, 600);
 			});
 
 			it('stops re-clamping after the window is closed', async () => {

--- a/src/__tests__/main/app-lifecycle/window-manager.test.ts
+++ b/src/__tests__/main/app-lifecycle/window-manager.test.ts
@@ -15,6 +15,9 @@ import type { WindowManagerDependencies } from '../../../main/app-lifecycle/wind
 
 // Track event handlers
 let windowCloseHandler: (() => void) | null = null;
+// The factory registers several `closed` listeners; collect them all so a test
+// can fire the full close sequence rather than guessing which one is last.
+let windowClosedHandlers: Array<() => void> = [];
 const webContentsEventHandlers = new Map<string, (...args: any[]) => void>();
 const guestWebContentsEventHandlers = new Map<string, (...args: any[]) => void>();
 
@@ -74,13 +77,16 @@ const mockWindowInstance = {
 	loadFile: vi.fn(),
 	maximize: vi.fn(),
 	setFullScreen: vi.fn(),
+	setMinimumSize: vi.fn(),
 	isMaximized: vi.fn().mockReturnValue(false),
 	isFullScreen: vi.fn().mockReturnValue(false),
 	isMinimized: vi.fn().mockReturnValue(false),
+	isDestroyed: vi.fn().mockReturnValue(false),
 	getBounds: vi.fn().mockReturnValue({ x: 100, y: 100, width: 1200, height: 800 }),
 	webContents: mockWebContents,
 	on: vi.fn((event: string, handler: () => void) => {
 		if (event === 'close') windowCloseHandler = handler;
+		if (event === 'closed') windowClosedHandlers.push(handler);
 	}),
 };
 
@@ -93,9 +99,11 @@ class MockBrowserWindow {
 	loadFile = mockWindowInstance.loadFile;
 	maximize = mockWindowInstance.maximize;
 	setFullScreen = mockWindowInstance.setFullScreen;
+	setMinimumSize = mockWindowInstance.setMinimumSize;
 	isMaximized = mockWindowInstance.isMaximized;
 	isFullScreen = mockWindowInstance.isFullScreen;
 	isMinimized = mockWindowInstance.isMinimized;
+	isDestroyed = mockWindowInstance.isDestroyed;
 	getBounds = mockWindowInstance.getBounds;
 	webContents = mockWindowInstance.webContents;
 	on = mockWindowInstance.on;
@@ -115,8 +123,12 @@ const mockHandle = vi.fn();
 type MockWorkAreaRect = { x: number; y: number; width: number; height: number };
 const { mockScreen } = vi.hoisted(() => {
 	const DEFAULT_DISPLAY = { workArea: { x: 0, y: 0, width: 1920, height: 1080 } };
-	const state: { displays: Array<{ workArea: MockWorkAreaRect }> } = {
+	const state: {
+		displays: Array<{ workArea: MockWorkAreaRect }>;
+		metricsListeners: Array<() => void>;
+	} = {
 		displays: [DEFAULT_DISPLAY],
+		metricsListeners: [],
 	};
 	const intersectionArea = (a: MockWorkAreaRect, b: MockWorkAreaRect): number => {
 		const ix = Math.max(0, Math.min(a.x + a.width, b.x + b.width) - Math.max(a.x, b.x));
@@ -128,6 +140,7 @@ const { mockScreen } = vi.hoisted(() => {
 			state,
 			reset: () => {
 				state.displays = [{ workArea: { x: 0, y: 0, width: 1920, height: 1080 } }];
+				state.metricsListeners = [];
 			},
 			getAllDisplays: () => state.displays,
 			getPrimaryDisplay: () => state.displays[0],
@@ -142,6 +155,17 @@ const { mockScreen } = vi.hoisted(() => {
 					}
 				}
 				return best;
+			},
+			on: (event: string, handler: () => void) => {
+				if (event === 'display-metrics-changed') state.metricsListeners.push(handler);
+			},
+			removeListener: (event: string, handler: () => void) => {
+				if (event !== 'display-metrics-changed') return;
+				state.metricsListeners = state.metricsListeners.filter((h) => h !== handler);
+			},
+			// Fire all registered display-metrics-changed listeners (test helper).
+			emitDisplayMetricsChanged: () => {
+				for (const h of [...state.metricsListeners]) h();
 			},
 		},
 	};
@@ -159,6 +183,9 @@ vi.mock('electron', () => ({
 		getAllDisplays: () => mockScreen.getAllDisplays(),
 		getPrimaryDisplay: () => mockScreen.getPrimaryDisplay(),
 		getDisplayMatching: (rect: MockWorkAreaRect) => mockScreen.getDisplayMatching(rect),
+		on: (event: string, handler: () => void) => mockScreen.on(event, handler),
+		removeListener: (event: string, handler: () => void) =>
+			mockScreen.removeListener(event, handler),
 	},
 	session: {
 		fromPartition: (partition: string) => mockFromPartition(partition),
@@ -242,9 +269,12 @@ describe('app-lifecycle/window-manager', () => {
 		mockWindowInstance.isMaximized.mockReturnValue(false);
 		mockWindowInstance.isFullScreen.mockReturnValue(false);
 		mockWindowInstance.isMinimized.mockReturnValue(false);
+		mockWindowInstance.isDestroyed.mockReturnValue(false);
+		mockWindowInstance.setMinimumSize.mockClear();
 		mockWindowInstance.getBounds.mockReturnValue({ x: 100, y: 100, width: 1200, height: 800 });
 		mockWebContents.getType.mockReturnValue('window');
 		mockGuestWebContents.getType.mockReturnValue('webview');
+		windowClosedHandlers = [];
 	});
 
 	afterEach(() => {
@@ -404,6 +434,93 @@ describe('app-lifecycle/window-manager', () => {
 			// Centered on the primary 1920x1080 work area for a 1000x600 window.
 			expect(lastBrowserWindowOptions?.x).toBe(460);
 			expect(lastBrowserWindowOptions?.y).toBe(240);
+		});
+
+		const makeManager = async () => {
+			const { createWindowManager } = await import('../../../main/app-lifecycle/window-manager');
+			return createWindowManager({
+				windowStateStore: mockWindowStateStore as unknown as Parameters<
+					typeof createWindowManager
+				>[0]['windowStateStore'],
+				isDevelopment: false,
+				preloadPath: '/path/to/preload.js',
+				rendererProductionUrl: 'app://app/index.html',
+				devServerUrl: 'http://localhost:5173',
+				useNativeTitleBar: false,
+				autoHideMenuBar: false,
+			});
+		};
+
+		describe('window size constraints', () => {
+			it('keeps the design minimum on a display large enough to hold it', async () => {
+				// Default display is 1920x1080; the 1000x600 design minimum fits.
+				const windowManager = await makeManager();
+				windowManager.createWindow();
+
+				expect(lastBrowserWindowOptions?.minWidth).toBe(1000);
+				expect(lastBrowserWindowOptions?.minHeight).toBe(600);
+				// Saved 1400x900 fits, so it is used unchanged.
+				expect(lastBrowserWindowOptions?.width).toBe(1400);
+				expect(lastBrowserWindowOptions?.height).toBe(900);
+			});
+
+			it('relaxes the minimum height to the work area on a small scaled display', async () => {
+				// A 1366x768 screen at 125% scale reports a ~1093x593 DIP work area
+				// (panel subtracted). The 600 design-min height exceeds 593, which is
+				// what makes native maximize no-op. It must be clamped to 593.
+				mockScreen.state.displays = [{ workArea: { x: 0, y: 0, width: 1093, height: 593 } }];
+
+				const windowManager = await makeManager();
+				windowManager.createWindow();
+
+				expect(lastBrowserWindowOptions?.minHeight).toBe(593);
+				// Width design-min (1000) still fits inside 1093, so it is unchanged.
+				expect(lastBrowserWindowOptions?.minWidth).toBe(1000);
+				// The saved 1400x900 size is clamped to the work area so the window
+				// does not spawn larger than the screen.
+				expect(lastBrowserWindowOptions?.width).toBe(1093);
+				expect(lastBrowserWindowOptions?.height).toBe(593);
+			});
+
+			it('relaxes both minimums on a display smaller than the design minimum', async () => {
+				mockScreen.state.displays = [{ workArea: { x: 0, y: 0, width: 900, height: 500 } }];
+
+				const windowManager = await makeManager();
+				windowManager.createWindow();
+
+				expect(lastBrowserWindowOptions?.minWidth).toBe(900);
+				expect(lastBrowserWindowOptions?.minHeight).toBe(500);
+			});
+
+			it('re-clamps the minimum size when the display metrics change', async () => {
+				const windowManager = await makeManager();
+				windowManager.createWindow();
+				mockWindowInstance.setMinimumSize.mockClear();
+
+				// Simulate the user rescaling their display so the work area shrinks
+				// below the design minimum while the app is running.
+				mockScreen.state.displays = [{ workArea: { x: 0, y: 0, width: 1093, height: 593 } }];
+				// getBounds reports the window on that display.
+				mockWindowInstance.getBounds.mockReturnValue({ x: 0, y: 0, width: 1093, height: 593 });
+				mockScreen.emitDisplayMetricsChanged();
+
+				expect(mockWindowInstance.setMinimumSize).toHaveBeenCalledWith(1000, 593);
+			});
+
+			it('stops re-clamping after the window is closed', async () => {
+				const windowManager = await makeManager();
+				windowManager.createWindow();
+				expect(windowClosedHandlers.length).toBeGreaterThan(0);
+
+				// The window is gone; its metrics listener must be removed so it does
+				// not fire against a destroyed window.
+				for (const handler of windowClosedHandlers) handler();
+				mockWindowInstance.setMinimumSize.mockClear();
+				mockScreen.state.displays = [{ workArea: { x: 0, y: 0, width: 800, height: 500 } }];
+				mockScreen.emitDisplayMetricsChanged();
+
+				expect(mockWindowInstance.setMinimumSize).not.toHaveBeenCalled();
+			});
 		});
 
 		it('does not persist bounds while the window is minimized', async () => {

--- a/src/__tests__/main/app-lifecycle/window-manager.test.ts
+++ b/src/__tests__/main/app-lifecycle/window-manager.test.ts
@@ -15,6 +15,8 @@ import type { WindowManagerDependencies } from '../../../main/app-lifecycle/wind
 
 // Track event handlers
 let windowCloseHandler: (() => void) | null = null;
+// The window's `move` listener (drives the cross-display min-size re-clamp).
+let windowMoveHandler: (() => void) | null = null;
 // The factory registers several `closed` listeners; collect them all so a test
 // can fire the full close sequence rather than guessing which one is last.
 let windowClosedHandlers: Array<() => void> = [];
@@ -87,6 +89,7 @@ const mockWindowInstance = {
 	on: vi.fn((event: string, handler: () => void) => {
 		if (event === 'close') windowCloseHandler = handler;
 		if (event === 'closed') windowClosedHandlers.push(handler);
+		if (event === 'move') windowMoveHandler = handler;
 	}),
 };
 
@@ -245,6 +248,7 @@ describe('app-lifecycle/window-manager', () => {
 		vi.clearAllMocks();
 		vi.resetModules(); // Reset module cache to clear devStubsRegistered flag
 		windowCloseHandler = null;
+		windowMoveHandler = null;
 		lastBrowserWindowOptions = null;
 		webContentsEventHandlers.clear();
 		guestWebContentsEventHandlers.clear();
@@ -505,6 +509,39 @@ describe('app-lifecycle/window-manager', () => {
 				mockScreen.emitDisplayMetricsChanged();
 
 				expect(mockWindowInstance.setMinimumSize).toHaveBeenCalledWith(1000, 593);
+			});
+
+			it('re-clamps the minimum size when the window moves onto a smaller display', async () => {
+				// Dragging onto an already-connected smaller display does NOT fire
+				// display-metrics-changed, so the window's own move event must re-clamp.
+				vi.useFakeTimers();
+				try {
+					const windowManager = await makeManager();
+					windowManager.createWindow();
+					expect(windowMoveHandler).not.toBeNull();
+					mockWindowInstance.setMinimumSize.mockClear();
+
+					// A second, smaller display exists; the window drags onto it.
+					mockScreen.state.displays = [
+						{ workArea: { x: 0, y: 0, width: 1920, height: 1080 } },
+						{ workArea: { x: 1920, y: 0, width: 1093, height: 593 } },
+					];
+					mockWindowInstance.getBounds.mockReturnValue({
+						x: 1920,
+						y: 0,
+						width: 1093,
+						height: 593,
+					});
+
+					windowMoveHandler!();
+					// Debounced: nothing until the drag settles.
+					expect(mockWindowInstance.setMinimumSize).not.toHaveBeenCalled();
+					vi.runAllTimers();
+
+					expect(mockWindowInstance.setMinimumSize).toHaveBeenCalledWith(1000, 593);
+				} finally {
+					vi.useRealTimers();
+				}
 			});
 
 			it('stops re-clamping after the window is closed', async () => {

--- a/src/main/app-lifecycle/window-manager.ts
+++ b/src/main/app-lifecycle/window-manager.ts
@@ -207,28 +207,49 @@ export function createWindowManager(deps: WindowManagerDependencies): WindowMana
 		// Electron caches the minimum size set at creation, so a display change
 		// while the app runs (the user rescales their display, or drags the window
 		// to a smaller monitor) would leave a stale minimum that can again exceed
-		// the new work area and block maximize. Re-clamp on display-metrics-changed
-		// against the window's current display so the fix survives live changes.
+		// the new work area and block maximize. Re-clamp against the window's
+		// current display, read from getBounds() which is authoritative once the
+		// window exists, so the fix survives live changes.
+		//
+		// Track the last-applied minimum and only re-assert it when it actually
+		// changes. On GTK the `moved` event fires repeatedly through a single drag,
+		// so calling setMinimumSize with the same values every tick would be pure
+		// churn; the guard collapses it to one call per real change.
+		let lastAppliedMinWidth: number | undefined;
+		let lastAppliedMinHeight: number | undefined;
 		const reclampMinimumSize = () => {
 			if (browserWindow.isDestroyed()) return;
 			const { minWidth: nextMinWidth, minHeight: nextMinHeight } = resolveWindowSizeConstraints(
 				browserWindow.getBounds()
 			);
+			if (nextMinWidth === lastAppliedMinWidth && nextMinHeight === lastAppliedMinHeight) return;
+			lastAppliedMinWidth = nextMinWidth;
+			lastAppliedMinHeight = nextMinHeight;
 			browserWindow.setMinimumSize(nextMinWidth, nextMinHeight);
 		};
+		// display-metrics-changed fires only when a display's OWN geometry or scale
+		// changes, NOT when the window is dragged from a large monitor onto an
+		// already-connected smaller one - in that case the stale (larger) minimum
+		// would linger and keep blocking maximize on the destination display. So
+		// re-clamp on the window's own `moved` event too. The change-guard above
+		// absorbs the flood of `moved` events a live drag produces.
+		//
+		// createBrowserWindow is shared by createSecondaryWindow, so each window
+		// registers its own per-window `display-metrics-changed` listener here
+		// (removed on 'closed' below). This is intentional: past ~10 concurrent
+		// windows Node emits a MaxListenersExceededWarning, which is acceptable.
 		screen.on('display-metrics-changed', reclampMinimumSize);
-		// Dragging a window onto an already-connected display whose work area is
-		// smaller does NOT fire display-metrics-changed, so the stale (larger)
-		// minimum would linger and keep blocking maximize on that display. Re-clamp
-		// on the window's own move too, debounced so a live drag (which fires a
-		// flood of move events) collapses into one recompute once it settles on the
-		// new display.
-		const reclampMinimumSizeOnMove = debounce(reclampMinimumSize, WINDOW_STATE_SAVE_DEBOUNCE_MS);
-		browserWindow.on('move', reclampMinimumSizeOnMove);
+		browserWindow.on('moved', reclampMinimumSize);
 		browserWindow.on('closed', () => {
 			screen.removeListener('display-metrics-changed', reclampMinimumSize);
-			reclampMinimumSizeOnMove.cancel();
+			browserWindow.removeListener('moved', reclampMinimumSize);
 		});
+		// Re-clamp once now that the window exists. The constraints computed above
+		// come from the raw saved x/y, which can resolve against a different display
+		// than the window actually opens on (e.g. the Windows -32000 minimized
+		// sentinel matches the leftmost display); getBounds() is the truth once the
+		// window is real, so this corrects the minimum for the true opening display.
+		reclampMinimumSize();
 
 		logger.info('Browser window created', 'Window', {
 			size: `${width}x${height}`,

--- a/src/main/app-lifecycle/window-manager.ts
+++ b/src/main/app-lifecycle/window-manager.ts
@@ -10,7 +10,7 @@
  * `createSecondaryWindow` callers around that factory.
  */
 
-import { BrowserWindow } from 'electron';
+import { BrowserWindow, screen } from 'electron';
 import type Store from 'electron-store';
 import type { SettingsStoreInterface, WindowState } from '../stores/types';
 import type { WindowState as SharedWindowState } from '../../shared/window-types';
@@ -27,7 +27,7 @@ import { attachMainWindowNavigationGuards } from './main-window-navigation';
 import { attachSpellCheckContextMenu } from './spell-check-menu';
 import { attachWindowCrashHandlers } from './window-crash-handlers';
 import { registerDevAutoUpdaterStubs } from './dev-auto-updater-stubs';
-import { resolveVisibleWindowPosition } from './window-position';
+import { resolveVisibleWindowPosition, resolveWindowSizeConstraints } from './window-position';
 import { resolveBundledCliPathSync } from '../maestro-cli-manager';
 import { MAESTRO_CLI_PATH_ARG_PREFIX } from '../../shared/maestro-cli';
 
@@ -161,8 +161,18 @@ export function createWindowManager(deps: WindowManagerDependencies): WindowMana
 		// Restore saved window state, discarding off-screen coordinates so the
 		// window can never spawn invisible (saved while minimized -> -32000 on
 		// Windows, or on an unplugged monitor); fall back to a centered window.
-		const width = bounds?.width ?? WINDOW_STATE_DEFAULTS.width;
-		const height = bounds?.height ?? WINDOW_STATE_DEFAULTS.height;
+		const rawWidth = bounds?.width ?? WINDOW_STATE_DEFAULTS.width;
+		const rawHeight = bounds?.height ?? WINDOW_STATE_DEFAULTS.height;
+		// Clamp the size and the minimum size to the target display's work area so
+		// the window fits (and can be maximized) on small or heavily-scaled
+		// screens, where a fixed 1000x600 minimum can exceed the work area and make
+		// native maximize silently no-op. See resolveWindowSizeConstraints.
+		const { width, height, minWidth, minHeight } = resolveWindowSizeConstraints({
+			x: bounds?.x,
+			y: bounds?.y,
+			width: rawWidth,
+			height: rawHeight,
+		});
 		const position = resolveVisibleWindowPosition({ x: bounds?.x, y: bounds?.y, width, height });
 
 		const browserWindow = new BrowserWindow({
@@ -170,8 +180,8 @@ export function createWindowManager(deps: WindowManagerDependencies): WindowMana
 			y: position.y,
 			width,
 			height,
-			minWidth: 1000,
-			minHeight: 600,
+			minWidth,
+			minHeight,
 			backgroundColor: '#0b0b0d',
 			...(useNativeTitleBar ? {} : { titleBarStyle: 'hiddenInset' as const }),
 			...(autoHideMenuBar ? { autoHideMenuBar: true } : {}),
@@ -193,6 +203,23 @@ export function createWindowManager(deps: WindowManagerDependencies): WindowMana
 		} else if (bounds?.isMaximized) {
 			browserWindow.maximize();
 		}
+
+		// Electron caches the minimum size set at creation, so a display change
+		// while the app runs (the user rescales their display, or drags the window
+		// to a smaller monitor) would leave a stale minimum that can again exceed
+		// the new work area and block maximize. Re-clamp on display-metrics-changed
+		// against the window's current display so the fix survives live changes.
+		const reclampMinimumSize = () => {
+			if (browserWindow.isDestroyed()) return;
+			const { minWidth: nextMinWidth, minHeight: nextMinHeight } = resolveWindowSizeConstraints(
+				browserWindow.getBounds()
+			);
+			browserWindow.setMinimumSize(nextMinWidth, nextMinHeight);
+		};
+		screen.on('display-metrics-changed', reclampMinimumSize);
+		browserWindow.on('closed', () => {
+			screen.removeListener('display-metrics-changed', reclampMinimumSize);
+		});
 
 		logger.info('Browser window created', 'Window', {
 			size: `${width}x${height}`,

--- a/src/main/app-lifecycle/window-manager.ts
+++ b/src/main/app-lifecycle/window-manager.ts
@@ -217,8 +217,17 @@ export function createWindowManager(deps: WindowManagerDependencies): WindowMana
 			browserWindow.setMinimumSize(nextMinWidth, nextMinHeight);
 		};
 		screen.on('display-metrics-changed', reclampMinimumSize);
+		// Dragging a window onto an already-connected display whose work area is
+		// smaller does NOT fire display-metrics-changed, so the stale (larger)
+		// minimum would linger and keep blocking maximize on that display. Re-clamp
+		// on the window's own move too, debounced so a live drag (which fires a
+		// flood of move events) collapses into one recompute once it settles on the
+		// new display.
+		const reclampMinimumSizeOnMove = debounce(reclampMinimumSize, WINDOW_STATE_SAVE_DEBOUNCE_MS);
+		browserWindow.on('move', reclampMinimumSizeOnMove);
 		browserWindow.on('closed', () => {
 			screen.removeListener('display-metrics-changed', reclampMinimumSize);
+			reclampMinimumSizeOnMove.cancel();
 		});
 
 		logger.info('Browser window created', 'Window', {

--- a/src/main/app-lifecycle/window-position.ts
+++ b/src/main/app-lifecycle/window-position.ts
@@ -4,6 +4,61 @@ import { screen } from 'electron';
 type DisplayWorkArea = { x: number; y: number; width: number; height: number };
 
 /**
+ * The app's preferred minimum window size, in DIPs. This is the floor a window
+ * uses on any display large enough to hold it. See `resolveWindowSizeConstraints`
+ * for how it is relaxed on smaller displays.
+ */
+export const DESIGN_MIN_WINDOW_WIDTH = 1000;
+export const DESIGN_MIN_WINDOW_HEIGHT = 600;
+
+/**
+ * Resolves the size and minimum-size constraints for a window, clamped to the
+ * work area of the display it will occupy.
+ *
+ * A fixed `minWidth`/`minHeight` (the previous behavior) can exceed a real
+ * display's work area on small or heavily-scaled screens. `workArea` is reported
+ * in DIPs with the panel/dock already subtracted, so on a 1366x768 screen at
+ * 125% scale it is only ~1093x593 DIPs - smaller than the 1000x600 design
+ * minimum in height. When the enforced minimum is taller than the work area the
+ * window can never shrink to fit, so the native "maximize" (which targets the
+ * work area) silently no-ops. Relaxing the minimum to the work area lets the
+ * window fit and be maximized on such displays, while leaving the design minimum
+ * intact on every display large enough to hold it.
+ *
+ * The returned `width`/`height` are likewise clamped down to the work area so a
+ * saved (or default) size larger than the current screen does not spawn
+ * oversized. They are only ever clamped down, never enlarged: a smaller saved
+ * size is preserved, and the resolved `minWidth`/`minHeight` (which Electron
+ * enforces when the window realizes) supplies the floor, exactly as before.
+ */
+export function resolveWindowSizeConstraints(state: {
+	x?: number;
+	y?: number;
+	width: number;
+	height: number;
+}): { width: number; height: number; minWidth: number; minHeight: number } {
+	// Match the display the window will actually occupy (same rule the position
+	// resolver uses) so a window on a small secondary monitor is clamped to that
+	// monitor, not the primary. With no saved position, Electron places the
+	// window on the primary display, so clamp against that.
+	const workArea =
+		typeof state.x === 'number' && typeof state.y === 'number'
+			? screen.getDisplayMatching({
+					x: state.x,
+					y: state.y,
+					width: state.width,
+					height: state.height,
+				}).workArea
+			: screen.getPrimaryDisplay().workArea;
+
+	const minWidth = Math.min(DESIGN_MIN_WINDOW_WIDTH, workArea.width);
+	const minHeight = Math.min(DESIGN_MIN_WINDOW_HEIGHT, workArea.height);
+	const width = Math.min(state.width, workArea.width);
+	const height = Math.min(state.height, workArea.height);
+	return { width, height, minWidth, minHeight };
+}
+
+/**
  * Centers a window of the given size inside a display's work area. The offset is
  * clamped to zero so a window larger than the work area still pins to its
  * top-left corner (its title bar) rather than spilling above/left of it.


### PR DESCRIPTION
## Problem

On a small or heavily-scaled display, the main window cannot be maximized - the native "maximize" control silently does nothing.

**Root cause:** the window is created with a fixed `minWidth: 1000, minHeight: 600` (`src/main/app-lifecycle/window-manager.ts`). Those are logical (DIP) values, but a real display's *work area* (screen minus panel/dock, also in DIPs) can be smaller. A 1366x768 laptop at 125% scale has a work area of only ~1093x593 DIPs. Since the design-min height (600) exceeds the work-area height (593), the window can never shrink to fit, and native maximize (which resizes the window to the work area) has no satisfiable size, so it no-ops.

Reproduced live on Linux/XFCE at `Xft.dpi 120`: the WM's `_NET_WM_ALLOWED_ACTIONS` *does* include maximize, and Maestro sets no `maximizable: false` - the pure size conflict is the whole cause. Setting `Xft.dpi 96` (work area 1366x741 > 600) makes maximize work again, confirming the diagnosis.

## Fix

Add `resolveWindowSizeConstraints()` in `window-position.ts` (mirrors the existing `resolveVisibleWindowPosition` helper, uses `screen`):

- **Relax the minimum to the work area.** `minWidth = min(1000, workArea.width)`, `minHeight = min(600, workArea.height)`, computed against the display the window will actually occupy (`screen.getDisplayMatching`, same rule the position resolver uses, so a window on a small secondary monitor is clamped to that monitor). On any display large enough to hold the design minimum, it is unchanged - **no behavior change for the common case.**
- **Clamp the initial size down to the work area** so a saved (or default) size larger than the current screen does not spawn oversized. Clamped down only, never enlarged - a smaller saved size is preserved and Electron's `minWidth`/`minHeight` supplies the floor exactly as before.
- **Re-clamp on `display-metrics-changed`** so a live rescale, or dragging the window to a smaller monitor, cannot leave a stale minimum that blocks maximize again. The listener is removed on window `closed`.

`workAreaSize` is already in DIPs with the panel subtracted, so this needs no manual DPI math and is correct cross-platform and multi-monitor.

## Not done (deliberately)
- The design minimum stays 1000x600 as the aspiration; it is only relaxed when the hardware forces it. A squished-but-usable window beats an unmaximizable one.
- No switch to a frameless/custom titlebar - out of scope for a sizing bug.

## Tests
Extended `src/__tests__/main/app-lifecycle/window-manager.test.ts` (79 pass, 5 new): design minimum kept on a large display; min height relaxed + size clamped on a 1093x593 scaled display; both minimums relaxed on a tiny display; re-clamp fires `setMinimumSize` on `display-metrics-changed`; and the metrics listener is removed after `closed`. Type-check (main + lint configs), ESLint, and Prettier are clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved window sizing by calculating initial and minimum dimensions from the target display’s work-area constraints.
  * Ensured minimum sizes never exceed available screen space, with reclamping when display metrics change or when the window moves to a smaller display.
  * Added safeguards to avoid redundant minimum-size updates and to stop reclamping after the window is closed.
* **Tests**
  * Expanded Electron/window and screen mocks for deterministic shutdown and metrics-driven scenarios.
  * Added coverage for initial clamping, reclamping on metrics/work-area changes, move behavior, and post-close listener cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->