### PR TITLE
Fix composer clipping last line and caret row desync past height cap

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3761,9 +3761,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3781,9 +3778,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3801,9 +3795,6 @@
 				"ppc64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3821,9 +3812,6 @@
 				"s390x"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3841,9 +3829,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3861,9 +3846,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -3761,6 +3761,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3778,6 +3781,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3795,6 +3801,9 @@
 				"ppc64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3812,6 +3821,9 @@
 				"s390x"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3829,6 +3841,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3846,6 +3861,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [

--- a/src/__tests__/renderer/components/InputArea/components/InputTextarea.test.tsx
+++ b/src/__tests__/renderer/components/InputArea/components/InputTextarea.test.tsx
@@ -1,0 +1,128 @@
+import { fireEvent, render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { RefObject } from 'react';
+import { InputTextarea } from '../../../../../renderer/components/InputArea/components/InputTextarea';
+import { TEXTAREA_MAX_HEIGHT } from '../../../../../renderer/components/InputArea/utils/textareaSizing';
+import { createInputAreaSession, inputAreaTheme } from '../_fixtures';
+
+/**
+ * jsdom performs no layout, so the browser's scroll clamping (scrollTop can
+ * never exceed scrollHeight - clientHeight) does not exist here. Install it by
+ * hand: that clamp IS the bug being reproduced. While the overlay is still one
+ * row short, a copied scrollTop gets clamped and the glyphs sit above the caret.
+ */
+function makeScrollable(el: HTMLElement, scrollHeight: number, clientHeight: number) {
+	let scrollTop = 0;
+	let currentScrollHeight = scrollHeight;
+	Object.defineProperty(el, 'clientHeight', { value: clientHeight, configurable: true });
+	Object.defineProperty(el, 'scrollHeight', {
+		get: () => currentScrollHeight,
+		configurable: true,
+	});
+	Object.defineProperty(el, 'scrollTop', {
+		get: () => scrollTop,
+		set: (v: number) => {
+			scrollTop = Math.max(0, Math.min(v, currentScrollHeight - clientHeight));
+		},
+		configurable: true,
+	});
+	return {
+		grow: (nextScrollHeight: number) => {
+			currentScrollHeight = nextScrollHeight;
+		},
+	};
+}
+
+function renderTextarea(overrides: Record<string, unknown> = {}) {
+	const inputRef: RefObject<HTMLTextAreaElement> = { current: null };
+	const props = {
+		session: createInputAreaSession(),
+		theme: inputAreaTheme,
+		isTerminalMode: false,
+		inputValue: 'first line',
+		spellCheckEnabled: false,
+		inputRef,
+		onInputFocus: vi.fn(),
+		onChange: vi.fn(),
+		handleInputKeyDown: vi.fn(),
+		handlePaste: vi.fn(),
+		handleDrop: vi.fn(),
+		...overrides,
+	};
+	const view = render(<InputTextarea {...(props as any)} />);
+	const textarea = view.container.querySelector('textarea') as HTMLTextAreaElement;
+	const overlay = view.container.querySelector('.maestro-input-text-overlay') as HTMLDivElement;
+	return {
+		...view,
+		textarea,
+		overlay,
+		rerenderWith: (value: string) =>
+			view.rerender(<InputTextarea {...(props as any)} inputValue={value} />),
+	};
+}
+
+describe('InputTextarea', () => {
+	it('caps the textarea with the shared TEXTAREA_MAX_HEIGHT constant', () => {
+		const { textarea } = renderTextarea();
+
+		// Locks the dedupe in: the CSS cap must stay the same value the resize
+		// logic clamps to, never a re-hard-coded `11rem`.
+		expect(textarea.style.maxHeight).toBe(`${TEXTAREA_MAX_HEIGHT}px`);
+		expect(textarea.style.maxHeight).toBe('176px');
+	});
+
+	it('renders every glyph in the overlay over a transparent textarea in AI mode', () => {
+		const { textarea, overlay } = renderTextarea({ inputValue: 'plain text, no mention' });
+
+		expect(overlay).not.toBeNull();
+		expect(overlay.textContent).toBe('plain text, no mention');
+		expect(textarea.style.color).toBe('transparent');
+	});
+
+	it('does not render the overlay in terminal mode', () => {
+		const { container, textarea } = renderTextarea({ isTerminalMode: true });
+
+		expect(container.querySelector('.maestro-input-text-overlay')).toBeNull();
+		expect(textarea.style.color).not.toBe('transparent');
+	});
+
+	it('re-syncs the overlay after the grown content commits, repairing the stale clamp', () => {
+		const { textarea, overlay, rerenderWith } = renderTextarea({ inputValue: 'line one' });
+
+		// Text region is 8 rows of 20px. The textarea has already outgrown it; the
+		// overlay is still rendering the shorter, pre-keystroke content.
+		makeScrollable(textarea, 220, 160);
+		const overlayScroll = makeScrollable(overlay, 160, 160);
+
+		// Native caret auto-scroll happens BEFORE React commits the taller overlay.
+		textarea.scrollTop = 60;
+		fireEvent.scroll(textarea);
+
+		// The stale overlay cannot reach 60, so the browser clamps it: this is the
+		// desync the user sees as a clipped final row.
+		expect(overlay.scrollTop).toBe(0);
+		expect(overlay.scrollTop).not.toBe(textarea.scrollTop);
+
+		// Commit the taller overlay content. The layout effect keyed on the rendered
+		// segments re-copies the scroll position once the overlay can actually reach it.
+		overlayScroll.grow(220);
+		rerenderWith('line one\nline two');
+
+		expect(overlay.scrollTop).toBe(60);
+		expect(overlay.scrollTop).toBe(textarea.scrollTop);
+	});
+
+	it('keeps syncing the overlay on user-driven scrolling', () => {
+		const { textarea, overlay } = renderTextarea({ inputValue: 'line one' });
+
+		makeScrollable(textarea, 400, 160);
+		makeScrollable(overlay, 400, 160);
+
+		textarea.scrollTop = 90;
+		textarea.scrollLeft = 7;
+		fireEvent.scroll(textarea);
+
+		expect(overlay.scrollTop).toBe(90);
+		expect(overlay.scrollLeft).toBe(7);
+	});
+});

--- a/src/__tests__/renderer/components/InputArea/hooks/useInputAreaAutosize.test.tsx
+++ b/src/__tests__/renderer/components/InputArea/hooks/useInputAreaAutosize.test.tsx
@@ -52,21 +52,34 @@ describe('useInputAreaAutosize', () => {
 		});
 	});
 
-	it('leaves the scroll position untouched when the caret is before the end of the value', async () => {
+	it('leaves the scroll position untouched when the caret is on an earlier line', async () => {
 		const { getByLabelText } = render(
-			<Harness value="hello world" selectionEnd={2} initialScrollTop={42} />
+			<Harness value={'hello\nworld'} selectionEnd={2} initialScrollTop={42} />
 		);
 
 		await waitFor(() => {
 			expect((getByLabelText('input') as HTMLTextAreaElement).style.height).toBe('176px');
 		});
-		// Exercises scrollTextareaToCaretEnd's contract directly: with selectionEnd
-		// before value.length it is a no-op, so the prior scroll position survives the
-		// resize. NOTE: this harness pins selectionEnd via Object.defineProperty. The
+		// Exercises scrollTextareaToCaretEnd's contract directly: with selectionEnd on a
+		// line before the final one it is a no-op, so the prior scroll position survives
+		// the resize. NOTE: this harness pins selectionEnd via Object.defineProperty. The
 		// real deferred @-mention / template flows place their caret in a later rAF, so
 		// they do NOT reach the helper in this mid-text state during the commit-phase
 		// effect (see PR #1294 discussion) - this only documents the helper itself.
 		expect((getByLabelText('input') as HTMLTextAreaElement).scrollTop).toBe(42);
+	});
+
+	it('scrolls when the caret is mid-way through the final line', async () => {
+		// Widened gate: a caret anywhere in the last logical line still snaps that row
+		// into view, so a programmatic insertion that lands before trailing characters
+		// no longer leaves the caret row clipped.
+		const { getByLabelText } = render(
+			<Harness value={'hello\nworld'} selectionEnd={8} initialScrollTop={42} />
+		);
+
+		await waitFor(() => {
+			expect((getByLabelText('input') as HTMLTextAreaElement).scrollTop).toBe(200);
+		});
 	});
 
 	it('scrolls a restored shorter draft with the caret at the end', async () => {

--- a/src/__tests__/renderer/components/InputArea/hooks/useInputAreaAutosize.test.tsx
+++ b/src/__tests__/renderer/components/InputArea/hooks/useInputAreaAutosize.test.tsx
@@ -69,17 +69,19 @@ describe('useInputAreaAutosize', () => {
 		expect((getByLabelText('input') as HTMLTextAreaElement).scrollTop).toBe(42);
 	});
 
-	it('scrolls when the caret is mid-way through the final line', async () => {
-		// Widened gate: a caret anywhere in the last logical line still snaps that row
-		// into view, so a programmatic insertion that lands before trailing characters
-		// no longer leaves the caret row clipped.
+	it('leaves the scroll untouched when the caret is mid-way through the final line', async () => {
+		// A final logical line can soft-wrap past the height cap, so a caret before its
+		// trailing characters is not guaranteed to be on the bottom visual row. Snapping
+		// to scrollHeight would scroll that row out of view, so the gate keys off the
+		// true end of the value and this mid-line caret is a no-op.
 		const { getByLabelText } = render(
 			<Harness value={'hello\nworld'} selectionEnd={8} initialScrollTop={42} />
 		);
 
 		await waitFor(() => {
-			expect((getByLabelText('input') as HTMLTextAreaElement).scrollTop).toBe(200);
+			expect((getByLabelText('input') as HTMLTextAreaElement).style.height).toBe('176px');
 		});
+		expect((getByLabelText('input') as HTMLTextAreaElement).scrollTop).toBe(42);
 	});
 
 	it('scrolls a restored shorter draft with the caret at the end', async () => {

--- a/src/__tests__/renderer/components/InputArea/hooks/useInputAreaTextChange.test.tsx
+++ b/src/__tests__/renderer/components/InputArea/hooks/useInputAreaTextChange.test.tsx
@@ -118,7 +118,7 @@ describe('useInputAreaTextChange', () => {
 		expect(textarea.scrollTop).toBe(640);
 	});
 
-	it('scrolls past the cap when the caret sits before trailing text on the final line', () => {
+	it('preserves the restored scroll when the caret sits before trailing text on the final line', () => {
 		const handlers = createHandlers();
 		const runAnimationFrame = vi.fn((callback: FrameRequestCallback): number => {
 			callback(0);
@@ -127,12 +127,15 @@ describe('useInputAreaTextChange', () => {
 		vi.stubGlobal('requestAnimationFrame', runAnimationFrame);
 		render(<Harness handlers={handlers} />);
 		const textarea = screen.getByLabelText('input') as HTMLTextAreaElement;
-		// Content well past TEXTAREA_MAX_HEIGHT, caret in the middle of the last row
-		// (what an inserted mention or trailing whitespace leaves behind). That row is
-		// the one being typed on, so it has to end up visible.
+		// Content well past TEXTAREA_MAX_HEIGHT, caret in the middle of the final logical
+		// line (what an inserted mention or trailing whitespace leaves behind). That line
+		// can soft-wrap across several visual rows, so the caret is not guaranteed to be
+		// on the bottom row; snapping to scrollHeight would scroll it out of view. The
+		// gate keys off the true end of the value, so this mid-line caret is a no-op and
+		// the scroll resizeTextareaToContent restored survives.
 		const value = `${'line\n'.repeat(80)}trailing`;
 		const caret = value.length - 4;
-		textarea.scrollTop = 0;
+		textarea.scrollTop = 96;
 		Object.defineProperty(textarea, 'scrollHeight', { value: 640, configurable: true });
 		Object.defineProperty(textarea, 'selectionEnd', { value: caret, configurable: true });
 
@@ -142,7 +145,7 @@ describe('useInputAreaTextChange', () => {
 
 		expect(runAnimationFrame).toHaveBeenCalledTimes(1);
 		expect(textarea.style.height).toBe('176px');
-		expect(textarea.scrollTop).toBe(640);
+		expect(textarea.scrollTop).toBe(96);
 	});
 
 	it('leaves the scroll position alone when editing an earlier line', () => {
@@ -158,8 +161,8 @@ describe('useInputAreaTextChange', () => {
 		textarea.scrollTop = 42;
 		Object.defineProperty(textarea, 'scrollHeight', { value: 640, configurable: true });
 		// Caret parked on the FIRST line: scrollTextareaToCaretEnd only snaps when the
-		// caret is in the final logical line, so the keystroke resize must preserve the
-		// scroll rather than jump the viewport to the bottom.
+		// caret is at the very end of the value, so the keystroke resize must preserve
+		// the scroll rather than jump the viewport to the bottom.
 		Object.defineProperty(textarea, 'selectionEnd', { value: 2, configurable: true });
 
 		fireEvent.change(textarea, {

--- a/src/__tests__/renderer/components/InputArea/hooks/useInputAreaTextChange.test.tsx
+++ b/src/__tests__/renderer/components/InputArea/hooks/useInputAreaTextChange.test.tsx
@@ -118,7 +118,34 @@ describe('useInputAreaTextChange', () => {
 		expect(textarea.scrollTop).toBe(640);
 	});
 
-	it('leaves the scroll position alone when editing mid-text', () => {
+	it('scrolls past the cap when the caret sits before trailing text on the final line', () => {
+		const handlers = createHandlers();
+		const runAnimationFrame = vi.fn((callback: FrameRequestCallback): number => {
+			callback(0);
+			return 1;
+		});
+		vi.stubGlobal('requestAnimationFrame', runAnimationFrame);
+		render(<Harness handlers={handlers} />);
+		const textarea = screen.getByLabelText('input') as HTMLTextAreaElement;
+		// Content well past TEXTAREA_MAX_HEIGHT, caret in the middle of the last row
+		// (what an inserted mention or trailing whitespace leaves behind). That row is
+		// the one being typed on, so it has to end up visible.
+		const value = `${'line\n'.repeat(80)}trailing`;
+		const caret = value.length - 4;
+		textarea.scrollTop = 0;
+		Object.defineProperty(textarea, 'scrollHeight', { value: 640, configurable: true });
+		Object.defineProperty(textarea, 'selectionEnd', { value: caret, configurable: true });
+
+		fireEvent.change(textarea, {
+			target: { value, selectionStart: caret },
+		});
+
+		expect(runAnimationFrame).toHaveBeenCalledTimes(1);
+		expect(textarea.style.height).toBe('176px');
+		expect(textarea.scrollTop).toBe(640);
+	});
+
+	it('leaves the scroll position alone when editing an earlier line', () => {
 		const handlers = createHandlers();
 		const runAnimationFrame = vi.fn((callback: FrameRequestCallback): number => {
 			callback(0);
@@ -130,8 +157,9 @@ describe('useInputAreaTextChange', () => {
 		const value = `${'line\n'.repeat(80)}end`;
 		textarea.scrollTop = 42;
 		Object.defineProperty(textarea, 'scrollHeight', { value: 640, configurable: true });
-		// Caret parked mid-text: scrollTextareaToCaretEnd keys off selectionEnd, so
-		// the keystroke resize must preserve the scroll rather than jump to bottom.
+		// Caret parked on the FIRST line: scrollTextareaToCaretEnd only snaps when the
+		// caret is in the final logical line, so the keystroke resize must preserve the
+		// scroll rather than jump the viewport to the bottom.
 		Object.defineProperty(textarea, 'selectionEnd', { value: 2, configurable: true });
 
 		fireEvent.change(textarea, {

--- a/src/__tests__/renderer/components/InputArea/utils/textareaSizing.test.ts
+++ b/src/__tests__/renderer/components/InputArea/utils/textareaSizing.test.ts
@@ -38,11 +38,13 @@ describe('InputArea textareaSizing utils', () => {
 		expect(textarea.scrollTop).toBe(240);
 	});
 
-	it('scrolls to the bottom when the caret is mid-way through the final line', () => {
+	it('leaves scroll untouched when the caret is mid-way through the final logical line', () => {
 		const textarea = document.createElement('textarea');
-		// Caret sits before the trailing characters of the last line, which is what an
-		// inserted mention or trailing whitespace leaves behind. That row still has to
-		// stay visible, so the gate keys off the final logical line, not value.length.
+		// Regression for the soft-wrap edge case: a long final logical line can wrap
+		// across several visual rows past the height cap. A caret before the trailing
+		// characters (e.g. an inserted mention) belongs to an earlier visual row, so
+		// snapping to scrollHeight would scroll it out of view. The gate keys off the
+		// true end of the value, not the final logical line, precisely to avoid that.
 		textarea.value = 'first\nsecond\nlast line';
 		textarea.scrollTop = 12;
 		Object.defineProperty(textarea, 'scrollHeight', { value: 240, configurable: true });
@@ -53,12 +55,14 @@ describe('InputArea textareaSizing utils', () => {
 
 		scrollTextareaToCaretEnd(textarea);
 
-		expect(textarea.scrollTop).toBe(240);
+		expect(textarea.scrollTop).toBe(12);
 	});
 
-	it('scrolls to the bottom when the caret is mid-text in a single-line value', () => {
+	it('leaves scroll untouched when the caret is mid-text in a single-line value', () => {
 		const textarea = document.createElement('textarea');
-		// No newline at all: the whole value IS the final line, so any caret qualifies.
+		// A single logical line can still soft-wrap beyond the cap, so a mid-text caret
+		// is not guaranteed to be on the bottom visual row. Only a caret at value.length
+		// qualifies for the bottom snap.
 		textarea.value = 'hello';
 		textarea.scrollTop = 12;
 		Object.defineProperty(textarea, 'scrollHeight', { value: 240, configurable: true });
@@ -66,7 +70,7 @@ describe('InputArea textareaSizing utils', () => {
 
 		scrollTextareaToCaretEnd(textarea);
 
-		expect(textarea.scrollTop).toBe(240);
+		expect(textarea.scrollTop).toBe(12);
 	});
 
 	it('leaves textarea scroll position untouched when the caret is on an earlier line', () => {

--- a/src/__tests__/renderer/components/InputArea/utils/textareaSizing.test.ts
+++ b/src/__tests__/renderer/components/InputArea/utils/textareaSizing.test.ts
@@ -38,12 +38,60 @@ describe('InputArea textareaSizing utils', () => {
 		expect(textarea.scrollTop).toBe(240);
 	});
 
-	it('leaves textarea scroll position untouched when the caret is mid-text', () => {
+	it('scrolls to the bottom when the caret is mid-way through the final line', () => {
 		const textarea = document.createElement('textarea');
+		// Caret sits before the trailing characters of the last line, which is what an
+		// inserted mention or trailing whitespace leaves behind. That row still has to
+		// stay visible, so the gate keys off the final logical line, not value.length.
+		textarea.value = 'first\nsecond\nlast line';
+		textarea.scrollTop = 12;
+		Object.defineProperty(textarea, 'scrollHeight', { value: 240, configurable: true });
+		Object.defineProperty(textarea, 'selectionEnd', {
+			value: textarea.value.indexOf('last line') + 4,
+			configurable: true,
+		});
+
+		scrollTextareaToCaretEnd(textarea);
+
+		expect(textarea.scrollTop).toBe(240);
+	});
+
+	it('scrolls to the bottom when the caret is mid-text in a single-line value', () => {
+		const textarea = document.createElement('textarea');
+		// No newline at all: the whole value IS the final line, so any caret qualifies.
 		textarea.value = 'hello';
 		textarea.scrollTop = 12;
 		Object.defineProperty(textarea, 'scrollHeight', { value: 240, configurable: true });
 		Object.defineProperty(textarea, 'selectionEnd', { value: 2, configurable: true });
+
+		scrollTextareaToCaretEnd(textarea);
+
+		expect(textarea.scrollTop).toBe(240);
+	});
+
+	it('leaves textarea scroll position untouched when the caret is on an earlier line', () => {
+		const textarea = document.createElement('textarea');
+		textarea.value = 'first\nsecond\nlast line';
+		textarea.scrollTop = 12;
+		Object.defineProperty(textarea, 'scrollHeight', { value: 240, configurable: true });
+		Object.defineProperty(textarea, 'selectionEnd', { value: 2, configurable: true });
+
+		scrollTextareaToCaretEnd(textarea);
+
+		expect(textarea.scrollTop).toBe(12);
+	});
+
+	it('leaves scroll untouched with the caret exactly on the last newline', () => {
+		const textarea = document.createElement('textarea');
+		// selectionEnd === lastIndexOf('\n') means the caret ends the second-to-last
+		// line, so it belongs to an earlier row and must not jump the viewport.
+		textarea.value = 'first\nsecond';
+		textarea.scrollTop = 12;
+		Object.defineProperty(textarea, 'scrollHeight', { value: 240, configurable: true });
+		Object.defineProperty(textarea, 'selectionEnd', {
+			value: textarea.value.lastIndexOf('\n'),
+			configurable: true,
+		});
 
 		scrollTextareaToCaretEnd(textarea);
 

--- a/src/renderer/components/InputArea/components/InputTextarea.tsx
+++ b/src/renderer/components/InputArea/components/InputTextarea.tsx
@@ -10,6 +10,7 @@ import {
 } from '../../../utils/mentionChipResolve';
 import { useSessionStore } from '../../../stores/sessionStore';
 import { buildKnownMentionNameSet } from '../../../hooks/input/useAgentMentionCompletion';
+import { TEXTAREA_MAX_HEIGHT } from '../utils/textareaSizing';
 
 interface InputTextareaProps {
 	session: Session;
@@ -31,7 +32,10 @@ interface InputTextareaProps {
  * exactly, or the mention highlights drift away from the caret. Pulled into one
  * constant so the two layers can never disagree (font size / line height /
  * family / letter spacing). Padding is kept in sync separately: the textarea
- * uses `pt-3 pl-3 pr-3` classes; the overlay mirrors them as `0.75rem` below.
+ * uses `pt-3 pl-3 pr-3 pb-1` classes; the overlay mirrors them as
+ * `0.75rem 0.75rem 0.25rem 0.75rem` below. The 12px top + 4px bottom padding is
+ * deliberate: it leaves exactly 160px of text inside the 176px cap, i.e. 8 whole
+ * 20px rows, so bottom-snapping can never leave a partially sliced row.
  */
 const SHARED_TYPOGRAPHY: React.CSSProperties = {
 	fontSize: '0.875rem',
@@ -180,7 +184,9 @@ export const InputTextarea = memo(function InputTextarea({
 						...SHARED_TYPOGRAPHY,
 						zIndex: 0,
 						whiteSpace: 'pre-wrap',
-						padding: '0.75rem 0.75rem 0 0.75rem',
+						// Must stay identical to the textarea's `pt-3 pr-3 pb-1 pl-3`, or the
+						// chip overlay drifts off the caret (see SHARED_TYPOGRAPHY).
+						padding: '0.75rem 0.75rem 0.25rem 0.75rem',
 						color: theme.colors.textMain,
 					}}
 				>
@@ -208,12 +214,14 @@ export const InputTextarea = memo(function InputTextarea({
 			)}
 			<textarea
 				ref={inputRef}
-				className={`relative flex-1 bg-transparent text-sm outline-none ${isTerminalMode ? 'pl-1.5' : 'pl-3'} pt-3 pr-3 resize-none min-h-[3.5rem] scrollbar-thin`}
+				className={`relative flex-1 bg-transparent text-sm outline-none ${isTerminalMode ? 'pl-1.5' : 'pl-3'} pt-3 pr-3 pb-1 resize-none min-h-[3.5rem] scrollbar-thin`}
 				style={{
 					...SHARED_TYPOGRAPHY,
 					color: overlayEnabled ? 'transparent' : theme.colors.textMain,
 					caretColor: theme.colors.textMain,
-					maxHeight: '11rem',
+					// Single source of truth with the resize logic: the CSS cap and
+					// resizeTextareaToContent's clamp can never disagree.
+					maxHeight: `${TEXTAREA_MAX_HEIGHT}px`,
 					// Sit above the decorative overlay so the caret + native selection win.
 					zIndex: overlayEnabled ? 1 : undefined,
 				}}

--- a/src/renderer/components/InputArea/components/InputTextarea.tsx
+++ b/src/renderer/components/InputArea/components/InputTextarea.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useMemo, useRef } from 'react';
+import React, { memo, useCallback, useLayoutEffect, useMemo, useRef } from 'react';
 import type { Session, Group, Theme } from '../../../types';
 import { getProviderDisplayName } from '../../../utils/sessionValidation';
 import { useSettingsStore } from '../../../stores/settingsStore';
@@ -102,12 +102,27 @@ export const InputTextarea = memo(function InputTextarea({
 
 	// Keep the decorative overlay pinned to the textarea's scroll position so the
 	// mention highlights track the text as the input grows past one line.
-	const syncOverlayScroll = (target: HTMLTextAreaElement) => {
+	const syncOverlayScroll = useCallback((target: HTMLTextAreaElement) => {
 		const el = overlayRef.current;
 		if (!el) return;
 		el.scrollTop = target.scrollTop;
 		el.scrollLeft = target.scrollLeft;
-	};
+	}, []);
+
+	// Re-sync AFTER the taller overlay has been committed. A keystroke that wraps a
+	// new line makes the browser natively scroll the textarea BEFORE React commits
+	// the grown overlay content, so the `onScroll` sync assigns a scrollTop the
+	// overlay cannot reach yet and the browser clamps it one row short - leaving the
+	// glyphs above the caret and the newest line clipped, with no later event to
+	// repair it. Running the copy in a layout effect keyed on the rendered segments
+	// means the overlay already has its full scrollHeight, so the same scrollTop now
+	// lands unclamped. `onScroll` still owns user-driven scrolling.
+	useLayoutEffect(() => {
+		if (!overlayEnabled) return;
+		const textarea = inputRef.current;
+		if (!textarea || !overlayRef.current) return;
+		syncOverlayScroll(textarea);
+	}, [segments, overlayEnabled, inputRef, syncOverlayScroll]);
 
 	// Chip palette shared with the sent-transcript pill (same fill + border), so
 	// the mention reads as the same object whether the user is typing it or reading

--- a/src/renderer/components/InputArea/utils/textareaSizing.ts
+++ b/src/renderer/components/InputArea/utils/textareaSizing.ts
@@ -15,16 +15,19 @@ export function resizeTextareaToContent(textarea: HTMLTextAreaElement, maxHeight
  * Keep the caret visible after a keystroke resize. resizeTextareaToContent sets
  * height:'auto' first, which resets the textarea's scrollTop, so once the box hits
  * its max height and scrolls internally the freshly typed text at the end would
- * otherwise fall out of view. Snap the scroll to the bottom whenever the caret sits
- * anywhere in the FINAL LOGICAL LINE of the value (the continuous-typing case, plus
- * typing before trailing characters on that line such as an inserted mention or
- * trailing whitespace); leave it untouched for edits on earlier lines so the
- * viewport does not jump. See issue #1169.
+ * otherwise fall out of view. Snap the scroll to the bottom only in the guaranteed
+ * post-insertion case: the caret parked at the very END of the value. There the
+ * caret is on the last visual row by definition, so scrollHeight always reveals it.
+ *
+ * We deliberately do NOT snap for a caret merely sitting on the final LOGICAL line
+ * (e.g. before trailing characters). A long final logical line can soft-wrap across
+ * several visual rows, so a caret near its start belongs to an EARLIER row; snapping
+ * to scrollHeight would scroll that row out of view. Those mid-line edits fall back
+ * to the scrollTop resizeTextareaToContent already restored, which keeps the
+ * pre-edit viewport intact. See issue #1169.
  */
 export function scrollTextareaToCaretEnd(textarea: HTMLTextAreaElement): void {
-	// A value with no newline is entirely one line: lastIndexOf returns -1, so any
-	// caret position qualifies.
-	if (textarea.selectionEnd > textarea.value.lastIndexOf('\n')) {
+	if (textarea.selectionEnd === textarea.value.length) {
 		textarea.scrollTop = textarea.scrollHeight;
 	}
 }

--- a/src/renderer/components/InputArea/utils/textareaSizing.ts
+++ b/src/renderer/components/InputArea/utils/textareaSizing.ts
@@ -15,12 +15,16 @@ export function resizeTextareaToContent(textarea: HTMLTextAreaElement, maxHeight
  * Keep the caret visible after a keystroke resize. resizeTextareaToContent sets
  * height:'auto' first, which resets the textarea's scrollTop, so once the box hits
  * its max height and scrolls internally the freshly typed text at the end would
- * otherwise fall out of view. Snap the scroll to the bottom when the caret sits at
- * the end of the content (the continuous-typing case); leave it untouched for
- * mid-text edits so the viewport does not jump. See issue #1169.
+ * otherwise fall out of view. Snap the scroll to the bottom whenever the caret sits
+ * anywhere in the FINAL LOGICAL LINE of the value (the continuous-typing case, plus
+ * typing before trailing characters on that line such as an inserted mention or
+ * trailing whitespace); leave it untouched for edits on earlier lines so the
+ * viewport does not jump. See issue #1169.
  */
 export function scrollTextareaToCaretEnd(textarea: HTMLTextAreaElement): void {
-	if (textarea.selectionEnd >= textarea.value.length) {
+	// A value with no newline is entirely one line: lastIndexOf returns -1, so any
+	// caret position qualifies.
+	if (textarea.selectionEnd > textarea.value.lastIndexOf('\n')) {
 		textarea.scrollTop = textarea.scrollHeight;
 	}
 }


### PR DESCRIPTION
## Finding M1 - composer caret/scroll clipping (E1 was insufficient)

When typing past the 176px composer cap, the last line(s) got clipped and the caret row desynced by one line: the native textarea scrolled before React committed the grown overlay, so the onScroll copy landed one row short and the browser clamped it.

## Change
- Re-syncs overlay scroll in a `useLayoutEffect` keyed on rendered segments. This covers the case that would otherwise stay broken forever: when the follow-up `scrollTextareaToCaretEnd` assigns the same `scrollTop` the textarea already has, no scroll event fires, so there is no later event to repair the clamp.
- Makes the text region exactly 8 whole 20px rows via `pb-1` (12px top + 4px bottom inside the 176px cap = 160px) so bottom-snapping never slices a row.
- **Keeps the bottom snap gated on the true end of the value.** An earlier revision broadened this to snap anywhere on the final logical line; commit `e3f4d4e` reversed that because it is unsafe under soft wrap. The net change to `textareaSizing.ts` versus rc is `>=` becoming `===` (semantically identical, since `selectionEnd` can never exceed `value.length`); the real value is the comment rewrite documenting why the final-logical-line broadening is unsafe, plus four new regression tests that lock that gate shut.
- Dedupes the height cap to a single `TEXTAREA_MAX_HEIGHT` constant (wired to the CSS `maxHeight`), closing a drift risk between the cap and `resizeTextareaToContent`'s clamp.

## Validation
Type-check, ESLint, Prettier clean. Scoped tests (`InputTextarea`, `useInputAreaAutosize`, `useInputAreaTextChange`, `textareaSizing`) -> 25 pass. The new `makeScrollable` test reproduces the browser's clamp by hand and genuinely fails without the layout effect.

## Human verification required
This is a live-rendering caret bug. Confirm in a rebuilt `.deb` by typing past the height cap: the last line must not clip and the caret row must stay aligned. Also worth eyeballing the pre-existing 6px `scrollbar-thin` on the textarea vs the full-width overlay - a `scrollbar-gutter: stable` follow-up may be warranted if any residual chip drift appears past the cap.

Base: upstream/rc. Playbook: `.maestro/playbooks/FIX-COMPOSER-CARET-01.md`.
