### PR TITLE
Resolve absolute omp binary so packaged app reports 1M context

### DIFF
--- a/src/__tests__/main/agents/detector.test.ts
+++ b/src/__tests__/main/agents/detector.test.ts
@@ -1576,6 +1576,55 @@ describe('agent-detector', () => {
 			expect(models).toEqual(['anthropic/claude-opus-4-8', 'openai-codex/gpt-5.2']);
 		});
 
+		it('runs omp model discovery with the prime env, not the shared expanded env', async () => {
+			// The `omp models --json` that feeds setOmpModelCatalog must run with the
+			// same env as the two prime sites (detection warm-up and spawn), i.e.
+			// buildOmpPrimeEnv: the binary's own dir first (co-located bun runtime)
+			// plus ~/.bun/bin. getExpandedEnv() omits ~/.bun/bin, so discovery could
+			// fail where the primes succeed and the catalogs would drift apart.
+			Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+			// Pin the inherited PATH so a dev machine that already has ~/.bun/bin
+			// exported cannot make the assertion below pass spuriously.
+			const originalPath = process.env.PATH;
+			process.env.PATH = '/inherited/only';
+
+			mockExecFileNoThrow.mockImplementation(async (cmd, args) => {
+				if (cmd === '/usr/bin/omp' && args[0] === 'models' && args[1] === '--json') {
+					return {
+						stdout: JSON.stringify({ models: [{ selector: 'anthropic/claude-opus-4-8' }] }),
+						stderr: '',
+						exitCode: 0,
+					};
+				}
+				if (args[0] === 'omp') {
+					return { stdout: '/usr/bin/omp\n', stderr: '', exitCode: 0 };
+				}
+				return { stdout: '', stderr: '', exitCode: 1 };
+			});
+
+			let discoveryEnv: NodeJS.ProcessEnv | undefined;
+			try {
+				detector.clearCache();
+				detector.clearModelCache();
+				await detector.detectAgents();
+				await detector.discoverModels('omp');
+
+				const discoveryCall = mockExecFileNoThrow.mock.calls.find(
+					(call) => call[0] === '/usr/bin/omp' && call[1][0] === 'models' && call[1][1] === '--json'
+				);
+				expect(discoveryCall).toBeDefined();
+				discoveryEnv = discoveryCall![3] as NodeJS.ProcessEnv | undefined;
+			} finally {
+				process.env.PATH = originalPath;
+			}
+
+			const pathEntries = (discoveryEnv?.PATH ?? '').split(path.delimiter);
+			// Binary's own dir first, so a co-located runtime resolves...
+			expect(pathEntries[0]).toBe(path.dirname('/usr/bin/omp'));
+			// ...and the bun install dir is on PATH (getExpandedEnv would not have it).
+			expect(pathEntries).toContain(`${os.homedir()}/.bun/bin`);
+		});
+
 		it('does not cache a transient empty omp discovery failure', async () => {
 			let attempt = 0;
 			mockExecFileNoThrow.mockImplementation(async (cmd, args) => {

--- a/src/__tests__/main/agents/omp-model-catalog.test.ts
+++ b/src/__tests__/main/agents/omp-model-catalog.test.ts
@@ -8,6 +8,17 @@ vi.mock('../../../main/utils/execFile', () => ({
 	execFileNoThrow: vi.fn(),
 }));
 
+// The prime's failure diagnostics (command + PATH + elapsed) are the packaged-app
+// debugging surface, so assert on them rather than letting warns hit the console.
+vi.mock('../../../main/utils/logger', () => ({
+	logger: {
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+		debug: vi.fn(),
+	},
+}));
+
 import {
 	setOmpModelCatalog,
 	getOmpModelContextWindow,
@@ -18,6 +29,7 @@ import {
 	type OmpCatalogEntry,
 } from '../../../main/agents/omp-model-catalog';
 import { execFileNoThrow } from '../../../main/utils/execFile';
+import { logger } from '../../../main/utils/logger';
 
 // Mirrors the shape `omp models --json` returns for a couple of models.
 const SAMPLE: OmpCatalogEntry[] = [
@@ -138,8 +150,14 @@ describe('omp-model-catalog', () => {
 	});
 
 	describe('primeOmpModelCatalog negative caching', () => {
+		// The PATH a failing prime ran with is the whole point of the diagnostics:
+		// in a packaged app it distinguishes "omp is broken" from "the packaged
+		// PATH lost ~/.bun/bin".
+		const PRIME_ENV = { PATH: ['/opt/x', '/usr/bin'].join(path.delimiter) };
+
 		beforeEach(() => {
 			vi.mocked(execFileNoThrow).mockReset();
+			vi.mocked(logger.warn).mockClear();
 		});
 
 		it('negative-caches a valid JSON payload without a models array', async () => {
@@ -151,13 +169,116 @@ describe('omp-model-catalog', () => {
 				stderr: '',
 				exitCode: 0,
 			});
-			await primeOmpModelCatalog('/opt/x/omp', {}, key);
+			await primeOmpModelCatalog('/opt/x/omp', PRIME_ENV, key);
 			// A second prime within the TTL is short-circuited by the failure cache
 			// rather than re-running the same bad command.
-			await primeOmpModelCatalog('/opt/x/omp', {}, key);
+			await primeOmpModelCatalog('/opt/x/omp', PRIME_ENV, key);
 			expect(execFileNoThrow).toHaveBeenCalledTimes(1);
 			// Nothing was cataloged for that identity.
 			expect(getOmpModelContextWindow('claude-opus-4-8', key)).toBeNull();
+			// The unusable-payload warn carries the same diagnostics as an outright
+			// failure (it previously carried no structured fields at all).
+			expect(logger.warn).toHaveBeenCalledWith(
+				expect.stringContaining('no models array'),
+				expect.any(String),
+				expect.objectContaining({
+					command: '/opt/x/omp',
+					path: PRIME_ENV.PATH,
+					elapsedMs: expect.any(Number),
+				})
+			);
+		});
+
+		it('logs the command, PATH and elapsed time when the prime exits non-zero', async () => {
+			const key = computeOmpCatalogKey('/opt/fail/omp', undefined);
+			vi.mocked(execFileNoThrow).mockResolvedValue({
+				stdout: '',
+				stderr: '  bun: command not found  ',
+				exitCode: 127,
+			});
+			await primeOmpModelCatalog('/opt/fail/omp', PRIME_ENV, key);
+			expect(logger.warn).toHaveBeenCalledWith(
+				expect.stringContaining('failed'),
+				expect.any(String),
+				expect.objectContaining({
+					command: '/opt/fail/omp',
+					path: PRIME_ENV.PATH,
+					elapsedMs: expect.any(Number),
+					exitCode: 127,
+					stderr: 'bun: command not found',
+				})
+			);
+		});
+
+		it('logs the command, PATH and elapsed time when the prime throws', async () => {
+			const key = computeOmpCatalogKey('/opt/throw/omp', undefined);
+			vi.mocked(execFileNoThrow).mockRejectedValue(new Error('spawn ENOENT'));
+			await primeOmpModelCatalog('/opt/throw/omp', PRIME_ENV, key);
+			expect(logger.warn).toHaveBeenCalledWith(
+				expect.any(String),
+				expect.any(String),
+				expect.objectContaining({
+					command: '/opt/throw/omp',
+					path: PRIME_ENV.PATH,
+					elapsedMs: expect.any(Number),
+					error: expect.stringContaining('spawn ENOENT'),
+				})
+			);
+		});
+
+		it('retryFailedPrime re-runs a prime the failure cache would have suppressed', async () => {
+			const key = computeOmpCatalogKey('/opt/retry/omp', undefined);
+			// First attempt fails (e.g. a cold packaged start) and is negative-cached.
+			vi.mocked(execFileNoThrow).mockResolvedValueOnce({
+				stdout: '',
+				stderr: 'boom',
+				exitCode: 1,
+			});
+			await primeOmpModelCatalog('/opt/retry/omp', PRIME_ENV, key);
+			expect(getOmpModelContextWindow('claude-opus-4-8', key)).toBeNull();
+
+			// Without the option, the negative cache still suppresses the re-prime.
+			await primeOmpModelCatalog('/opt/retry/omp', PRIME_ENV, key);
+			expect(execFileNoThrow).toHaveBeenCalledTimes(1);
+
+			// A spawn opts out, gets a fresh attempt, and the catalog resolves - so a
+			// single early failure can't pin the 200k fallback for the whole TTL.
+			vi.mocked(execFileNoThrow).mockResolvedValueOnce({
+				stdout: JSON.stringify({ models: SAMPLE }),
+				stderr: '',
+				exitCode: 0,
+			});
+			await primeOmpModelCatalog('/opt/retry/omp', PRIME_ENV, key, { retryFailedPrime: true });
+			expect(execFileNoThrow).toHaveBeenCalledTimes(2);
+			expect(getOmpModelContextWindow('claude-opus-4-8', key)).toBe(1_000_000);
+		});
+
+		it('retryFailedPrime still shares an in-flight prime and honors a fresh catalog', async () => {
+			const key = computeOmpCatalogKey('/opt/inflight/omp', undefined);
+			let release: (() => void) | undefined;
+			vi.mocked(execFileNoThrow).mockReturnValue(
+				new Promise((resolve) => {
+					release = () =>
+						resolve({ stdout: JSON.stringify({ models: SAMPLE }), stderr: '', exitCode: 0 });
+				})
+			);
+
+			// Concurrent spawns share the one fetch even with the option set.
+			const first = primeOmpModelCatalog('/opt/inflight/omp', PRIME_ENV, key, {
+				retryFailedPrime: true,
+			});
+			const second = primeOmpModelCatalog('/opt/inflight/omp', PRIME_ENV, key, {
+				retryFailedPrime: true,
+			});
+			expect(second).toBe(first);
+			expect(execFileNoThrow).toHaveBeenCalledTimes(1);
+			release?.();
+			await Promise.all([first, second]);
+			expect(getOmpModelContextWindow('claude-opus-4-8', key)).toBe(1_000_000);
+
+			// And a fresh catalog is still not re-fetched, option or not.
+			await primeOmpModelCatalog('/opt/inflight/omp', PRIME_ENV, key, { retryFailedPrime: true });
+			expect(execFileNoThrow).toHaveBeenCalledTimes(1);
 		});
 
 		it('re-primes and caches once a valid models array arrives', async () => {

--- a/src/__tests__/main/agents/path-prober.test.ts
+++ b/src/__tests__/main/agents/path-prober.test.ts
@@ -6,6 +6,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 
 // Mock dependencies before importing the module
@@ -58,13 +59,23 @@ describe('path-prober', () => {
 
 		it('should include common Unix paths on non-Windows', () => {
 			const originalPlatform = process.platform;
+			const originalPath = process.env.PATH;
 			Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
+			// Pin the inherited PATH: on a dev machine the real PATH already carries
+			// these dirs, which would make the assertions pass even if getExpandedEnv
+			// stopped adding them.
+			process.env.PATH = '/inherited/only';
 
 			try {
 				const env = getExpandedEnv();
 				expect(env.PATH).toContain('/opt/homebrew/bin');
 				expect(env.PATH).toContain('/usr/local/bin');
+				// ~/.bun/bin is where the bun-based omp binary installs; without it
+				// consumers of getExpandedEnv() cannot resolve omp even though the
+				// detection probe finds it there.
+				expect(env.PATH).toContain(`${os.homedir()}/.bun/bin`);
 			} finally {
+				process.env.PATH = originalPath;
 				Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
 			}
 		});

--- a/src/__tests__/main/process-listeners/plugin-event-listener.test.ts
+++ b/src/__tests__/main/process-listeners/plugin-event-listener.test.ts
@@ -242,6 +242,49 @@ describe('setupPluginEventListener', () => {
 			});
 		});
 
+		it('does NOT re-count a context-window correction (correctionOnly) into token/cost totals', () => {
+			const pm = makePm({ toolType: 'omp' });
+			const emit = vi.fn<(e: PluginEvent) => void>();
+			setupPluginEventListener(pm, { emitPluginEvent: emit });
+
+			// Real turn is counted once.
+			pm.emit('usage', 's1', {
+				inputTokens: 10,
+				outputTokens: 20,
+				cacheReadInputTokens: 1,
+				cacheCreationInputTokens: 2,
+				totalCostUsd: 0.1,
+				contextWindow: 200000,
+				reasoningTokens: 5,
+			});
+			// Correction replays the SAME turn purely to refresh the resolved window.
+			// pushResolvedOmpContextWindow zeroes token/cost at the source, but even a
+			// non-zero replay must never accumulate here (belt-and-braces guard).
+			pm.emit('usage', 's1', {
+				inputTokens: 10,
+				outputTokens: 20,
+				cacheReadInputTokens: 1,
+				cacheCreationInputTokens: 2,
+				totalCostUsd: 0.1,
+				contextWindow: 250000,
+				reasoningTokens: 5,
+				contextWindowResolved: true,
+				contextWindowCorrectionOnly: true,
+			});
+			pm.emit('exit', 's1', 0);
+
+			const completed = emit.mock.calls.map(([e]) => e).find((e) => e.topic === 'agent.completed');
+			expect(completed!.payload).toMatchObject({
+				inputTokens: 10,
+				outputTokens: 20,
+				cacheReadInputTokens: 1,
+				cacheCreationInputTokens: 2,
+				reasoningTokens: 5,
+				totalTokens: 10 + 20 + 1 + 2,
+				costUsd: expect.closeTo(0.1, 10),
+			});
+		});
+
 		it('uses the LAST reported cost (not the sum) for cumulative reporters', () => {
 			const pm = makePm({ toolType: 'claude-code', usageIsCumulative: true });
 			const emit = vi.fn<(e: PluginEvent) => void>();

--- a/src/__tests__/main/process-manager/handlers/StdoutHandler.test.ts
+++ b/src/__tests__/main/process-manager/handlers/StdoutHandler.test.ts
@@ -49,7 +49,10 @@ vi.mock('../../../../main/parsers/error-patterns', () => ({
 
 // ── Imports (after mocks) ──────────────────────────────────────────────────
 
-import { StdoutHandler } from '../../../../main/process-manager/handlers/StdoutHandler';
+import {
+	StdoutHandler,
+	pushResolvedOmpContextWindow,
+} from '../../../../main/process-manager/handlers/StdoutHandler';
 import { matchSshErrorPattern } from '../../../../main/parsers/error-patterns';
 import { ClaudeOutputParser } from '../../../../main/parsers/claude-output-parser';
 import { CopilotOutputParser } from '../../../../main/parsers/copilot-output-parser';
@@ -1341,6 +1344,55 @@ describe('StdoutHandler', () => {
 			const stats = usageSpy.mock.calls[0][1];
 			expect(stats.contextWindow).toBe(1_000_000);
 			expect(stats.contextWindowResolved).toBe(true);
+		});
+
+		it('pushes a corrected window once when a late catalog prime lands', () => {
+			__resetOmpModelCatalogForTests();
+			const catalogKey = computeOmpCatalogKey('/usr/local/bin/omp', undefined);
+			const parser = createOutputParserMock({
+				inputTokens: 1000,
+				outputTokens: 500,
+				cacheReadTokens: 0,
+				cacheCreationTokens: 0,
+				costUsd: 0.05,
+				contextWindow: 0,
+				model: 'claude-opus-4-8',
+			});
+
+			// The spawn stamped the key, but the prime exceeded the spawn cap so the
+			// catalog is still empty when the first turn's usage arrives.
+			const { handler, emitter, processes, sessionId, proc } = createTestContext({
+				isStreamJsonMode: true,
+				toolType: 'omp',
+				contextWindow: 200000,
+				ompModelCatalogKey: catalogKey,
+				outputParser: parser as unknown as AgentOutputParser,
+			});
+
+			const usageSpy = vi.fn();
+			emitter.on('usage', usageSpy);
+
+			sendJsonLine(handler, sessionId, { type: 'message', text: 'hi' });
+
+			expect(usageSpy).toHaveBeenCalledTimes(1);
+			expect(usageSpy.mock.calls[0][1].contextWindow).toBe(200000);
+			expect(usageSpy.mock.calls[0][1].contextWindowResolved).toBeUndefined();
+			expect(proc.pendingOmpUsagePush?.model).toBe('claude-opus-4-8');
+
+			// Late prime lands: the corrected window is pushed without a second turn.
+			setOmpModelCatalog([{ id: 'claude-opus-4-8', contextWindow: 1_000_000 }], catalogKey);
+			expect(pushResolvedOmpContextWindow(processes, emitter, sessionId, catalogKey)).toBe(true);
+
+			expect(usageSpy).toHaveBeenCalledTimes(2);
+			const corrected = usageSpy.mock.calls[1][1];
+			expect(corrected.contextWindow).toBe(1_000_000);
+			expect(corrected.contextWindowResolved).toBe(true);
+			expect(corrected.inputTokens).toBe(usageSpy.mock.calls[0][1].inputTokens);
+
+			// Pending payload is cleared, so a repeat call cannot double-emit.
+			expect(proc.pendingOmpUsagePush).toBeUndefined();
+			expect(pushResolvedOmpContextWindow(processes, emitter, sessionId, catalogKey)).toBe(false);
+			expect(usageSpy).toHaveBeenCalledTimes(2);
 		});
 
 		it('does not resolve a mismatched-identity catalog (different binary/env)', () => {

--- a/src/__tests__/main/process-manager/handlers/StdoutHandler.test.ts
+++ b/src/__tests__/main/process-manager/handlers/StdoutHandler.test.ts
@@ -1388,6 +1388,10 @@ describe('StdoutHandler', () => {
 			expect(corrected.contextWindow).toBe(1_000_000);
 			expect(corrected.contextWindowResolved).toBe(true);
 			expect(corrected.inputTokens).toBe(usageSpy.mock.calls[0][1].inputTokens);
+			// Flagged correction-only so accumulating consumers update the window
+			// without re-counting the replayed turn's tokens/cost.
+			expect(corrected.contextWindowCorrectionOnly).toBe(true);
+			expect(corrected.contextWindowModel).toBe('claude-opus-4-8');
 
 			// Pending payload is cleared, so a repeat call cannot double-emit.
 			expect(proc.pendingOmpUsagePush).toBeUndefined();

--- a/src/__tests__/main/process-manager/handlers/StdoutHandler.test.ts
+++ b/src/__tests__/main/process-manager/handlers/StdoutHandler.test.ts
@@ -1387,7 +1387,16 @@ describe('StdoutHandler', () => {
 			const corrected = usageSpy.mock.calls[1][1];
 			expect(corrected.contextWindow).toBe(1_000_000);
 			expect(corrected.contextWindowResolved).toBe(true);
-			expect(corrected.inputTokens).toBe(usageSpy.mock.calls[0][1].inputTokens);
+			// Token/cost fields are zeroed AT THE SOURCE: the correction re-emits
+			// through the ProcessManager EventEmitter, so every on('usage') consumer
+			// sees it. Zeroing here keeps the replayed (already-counted) turn from
+			// landing twice in any accumulating consumer.
+			expect(corrected.inputTokens).toBe(0);
+			expect(corrected.outputTokens).toBe(0);
+			expect(corrected.cacheReadInputTokens).toBe(0);
+			expect(corrected.cacheCreationInputTokens).toBe(0);
+			expect(corrected.totalCostUsd).toBe(0);
+			expect(corrected.reasoningTokens).toBe(0);
 			// Flagged correction-only so accumulating consumers update the window
 			// without re-counting the replayed turn's tokens/cost.
 			expect(corrected.contextWindowCorrectionOnly).toBe(true);

--- a/src/__tests__/renderer/hooks/session/useBatchedSessionUpdates.test.ts
+++ b/src/__tests__/renderer/hooks/session/useBatchedSessionUpdates.test.ts
@@ -75,4 +75,28 @@ describe('mergeContextWindow', () => {
 			)
 		).toEqual({ contextWindow: ONE_M, contextWindowResolved: true });
 	});
+
+	it('keeps a same-model resolved window across a transient unresolved delta', () => {
+		expect(
+			mergeContextWindow(
+				{ contextWindow: FALLBACK, contextWindowModel: 'opus' },
+				{ contextWindow: ONE_M, contextWindowResolved: true, contextWindowModel: 'opus' }
+			)
+		).toEqual({ contextWindow: ONE_M, contextWindowResolved: true, contextWindowModel: 'opus' });
+	});
+
+	it('does NOT keep a resolved window when a different model reports unresolved', () => {
+		// Model switch to a model absent from the primed omp catalog: the gauge must
+		// drop to the new model's fallback rather than stay on the old model's window.
+		expect(
+			mergeContextWindow(
+				{ contextWindow: FALLBACK, contextWindowModel: 'haiku' },
+				{ contextWindow: ONE_M, contextWindowResolved: true, contextWindowModel: 'opus' }
+			)
+		).toEqual({
+			contextWindow: FALLBACK,
+			contextWindowResolved: undefined,
+			contextWindowModel: 'haiku',
+		});
+	});
 });

--- a/src/__tests__/renderer/hooks/session/useBatchedSessionUpdates.test.ts
+++ b/src/__tests__/renderer/hooks/session/useBatchedSessionUpdates.test.ts
@@ -11,8 +11,14 @@
  * rather than through a hook harness.
  */
 
-import { describe, it, expect } from 'vitest';
-import { mergeContextWindow } from '../../../../renderer/hooks/session/useBatchedSessionUpdates';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import {
+	mergeContextWindow,
+	useBatchedSessionUpdates,
+} from '../../../../renderer/hooks/session/useBatchedSessionUpdates';
+import { useSessionStore } from '../../../../renderer/stores/sessionStore';
+import type { Session, UsageStats } from '../../../../renderer/types';
 
 const ONE_M = 1_000_000;
 const FALLBACK = 200_000;
@@ -98,5 +104,85 @@ describe('mergeContextWindow', () => {
 			contextWindowResolved: undefined,
 			contextWindowModel: 'haiku',
 		});
+	});
+});
+
+/**
+ * The in-batch accumulator (updateUsage) folds multiple usage events that arrive
+ * between flushes. It now routes its context-window through the same
+ * `mergeContextWindow` rule as the flush path, so a resolved window is preserved
+ * even when a same-model unresolved fallback delta accumulates on top of it
+ * before the batch commits. Token accounting is unchanged.
+ */
+describe('useBatchedSessionUpdates accumulator preserves resolved window', () => {
+	const resolved = (over: Partial<UsageStats> = {}): UsageStats => ({
+		inputTokens: 100,
+		outputTokens: 50,
+		cacheReadInputTokens: 0,
+		cacheCreationInputTokens: 0,
+		totalCostUsd: 0.02,
+		contextWindow: ONE_M,
+		contextWindowResolved: true,
+		contextWindowModel: 'opus',
+		...over,
+	});
+
+	// Same model, but the main process re-emits the 200k fallback (catalog not
+	// re-primed for this turn). Must NOT downgrade the gauge.
+	const unresolvedFallback = (over: Partial<UsageStats> = {}): UsageStats => ({
+		inputTokens: 20,
+		outputTokens: 10,
+		cacheReadInputTokens: 0,
+		cacheCreationInputTokens: 0,
+		totalCostUsd: 0.01,
+		contextWindow: FALLBACK,
+		contextWindowModel: 'opus',
+		...over,
+	});
+
+	beforeEach(() => {
+		useSessionStore.setState({ sessions: [] } as never);
+	});
+
+	it('keeps the resolved window when a same-model fallback delta accumulates (session-level)', () => {
+		useSessionStore.setState({
+			sessions: [{ id: 's1' } as unknown as Session],
+		} as never);
+
+		const { result } = renderHook(() => useBatchedSessionUpdates(10_000));
+		act(() => {
+			result.current.updateUsage('s1', null, resolved());
+			result.current.updateUsage('s1', null, unresolvedFallback());
+			result.current.flushNow();
+		});
+
+		const stats = useSessionStore.getState().sessions[0].usageStats;
+		expect(stats?.contextWindow).toBe(ONE_M);
+		expect(stats?.contextWindowResolved).toBe(true);
+		// Token accounting still accumulates both deltas at the session level.
+		expect(stats?.inputTokens).toBe(120);
+		expect(stats?.outputTokens).toBe(60);
+	});
+
+	it('keeps the resolved window when a same-model fallback delta accumulates (tab-level)', () => {
+		useSessionStore.setState({
+			sessions: [
+				{
+					id: 's1',
+					aiTabs: [{ id: 't1', logs: [] }],
+				} as unknown as Session,
+			],
+		} as never);
+
+		const { result } = renderHook(() => useBatchedSessionUpdates(10_000));
+		act(() => {
+			result.current.updateUsage('s1', 't1', resolved());
+			result.current.updateUsage('s1', 't1', unresolvedFallback());
+			result.current.flushNow();
+		});
+
+		const tab = useSessionStore.getState().sessions[0].aiTabs?.[0];
+		expect(tab?.usageStats?.contextWindow).toBe(ONE_M);
+		expect(tab?.usageStats?.contextWindowResolved).toBe(true);
 	});
 });

--- a/src/__tests__/renderer/hooks/session/useBatchedSessionUpdates.test.ts
+++ b/src/__tests__/renderer/hooks/session/useBatchedSessionUpdates.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Tests for mergeContextWindow - the context-window half of the usage merge in
+ * useBatchedSessionUpdates.
+ *
+ * The main process ALWAYS emits a context window (falling back to 200k when the
+ * omp model catalog has not primed yet), so an unresolved delta must never
+ * downgrade a gauge that already showed an authoritative resolved window. A
+ * resolved delta always wins, which keeps genuine model switches propagating.
+ *
+ * The merge decision is a pure exported helper, so it is unit-tested directly
+ * rather than through a hook harness.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { mergeContextWindow } from '../../../../renderer/hooks/session/useBatchedSessionUpdates';
+
+const ONE_M = 1_000_000;
+const FALLBACK = 200_000;
+
+describe('mergeContextWindow', () => {
+	it('keeps a resolved window when an unresolved delta arrives', () => {
+		expect(
+			mergeContextWindow(
+				{ contextWindow: FALLBACK },
+				{ contextWindow: ONE_M, contextWindowResolved: true }
+			)
+		).toEqual({ contextWindow: ONE_M, contextWindowResolved: true });
+	});
+
+	it('keeps a resolved window when the delta explicitly says unresolved', () => {
+		expect(
+			mergeContextWindow(
+				{ contextWindow: FALLBACK, contextWindowResolved: false },
+				{ contextWindow: ONE_M, contextWindowResolved: true }
+			)
+		).toEqual({ contextWindow: ONE_M, contextWindowResolved: true });
+	});
+
+	it('lets a resolved delta replace a previously resolved window (model switch)', () => {
+		expect(
+			mergeContextWindow(
+				{ contextWindow: FALLBACK, contextWindowResolved: true },
+				{ contextWindow: ONE_M, contextWindowResolved: true }
+			)
+		).toEqual({ contextWindow: FALLBACK, contextWindowResolved: true });
+	});
+
+	it('takes the delta window before anything has resolved', () => {
+		expect(mergeContextWindow({ contextWindow: FALLBACK }, undefined)).toEqual({
+			contextWindow: FALLBACK,
+			contextWindowResolved: undefined,
+		});
+		expect(mergeContextWindow({ contextWindow: FALLBACK }, { contextWindow: ONE_M })).toEqual({
+			contextWindow: FALLBACK,
+			contextWindowResolved: undefined,
+		});
+	});
+
+	it('falls back to the existing window when the delta carries none', () => {
+		expect(mergeContextWindow({ contextWindow: 0 }, { contextWindow: FALLBACK })).toEqual({
+			contextWindow: FALLBACK,
+			contextWindowResolved: undefined,
+		});
+		expect(mergeContextWindow({ contextWindow: 0 }, undefined)).toEqual({
+			contextWindow: 0,
+			contextWindowResolved: undefined,
+		});
+	});
+
+	it('promotes an unresolved existing window when a resolved delta lands', () => {
+		expect(
+			mergeContextWindow(
+				{ contextWindow: ONE_M, contextWindowResolved: true },
+				{ contextWindow: FALLBACK }
+			)
+		).toEqual({ contextWindow: ONE_M, contextWindowResolved: true });
+	});
+});

--- a/src/main/agents/detector.ts
+++ b/src/main/agents/detector.ts
@@ -506,7 +506,18 @@ export class AgentDetector {
 					// Oh My Pi: `omp models --json` returns { models: [{ id, selector, ... }] }
 					// across every configured provider. Prefer the provider-qualified `selector`
 					// (e.g. anthropic/claude-opus-4-8), which is unambiguous for --model.
-					const result = await execFileNoThrow(command, ['models', '--json'], undefined, env);
+					// Use the same env as the two prime sites (detection warm-up and spawn):
+					// `buildOmpPrimeEnv` expands the PATH with `~/.bun/bin` and prepends the
+					// binary's own directory so a co-located runtime resolves. Running this
+					// discovery with the shared `getExpandedEnv()` result instead would let
+					// it fail (or resolve differently) where the primes succeed, and it feeds
+					// `setOmpModelCatalog` below, so the catalogs must stay in lockstep.
+					const result = await execFileNoThrow(
+						command,
+						['models', '--json'],
+						undefined,
+						buildOmpPrimeEnv(command)
+					);
 					if (result.exitCode !== 0) {
 						logger.warn(
 							`CLI model discovery failed for ${agentId}: exit code ${result.exitCode}`,

--- a/src/main/agents/omp-model-catalog.ts
+++ b/src/main/agents/omp-model-catalog.ts
@@ -177,6 +177,21 @@ export function getOmpModelContextWindow(
 	return windows.get(normalizeKey(bareId(model))) ?? null;
 }
 
+/** Options for {@link primeOmpModelCatalog}. */
+export interface PrimeOmpModelCatalogOptions {
+	/**
+	 * Ignore the {@link primeFailures} negative cache and attempt the prime
+	 * anyway. Set by the agent-spawn path: a user starting an omp agent is an
+	 * explicit, low-frequency action that must get a fresh attempt rather than
+	 * inheriting a pinned 200k fallback from an earlier failure (e.g. a cold
+	 * packaged start where the binary's runtime wasn't yet resolvable). The
+	 * in-flight dedupe and the fresh-catalog TTL still apply, so this never
+	 * causes duplicate or redundant work; `agents:detect`/reprobe keep the
+	 * anti-log-noise behavior by leaving the option unset.
+	 */
+	retryFailedPrime?: boolean;
+}
+
 /**
  * Fetch `omp models --json` with the given command/env and populate the catalog
  * under `catalogKey`. Best-effort and deduped per identity: concurrent callers
@@ -186,7 +201,8 @@ export function getOmpModelContextWindow(
 export function primeOmpModelCatalog(
 	command: string,
 	env: NodeJS.ProcessEnv | undefined,
-	catalogKey: string
+	catalogKey: string,
+	options?: PrimeOmpModelCatalogOptions
 ): Promise<void> {
 	const inFlight = primingPromises.get(catalogKey);
 	if (inFlight) return inFlight;
@@ -195,17 +211,32 @@ export function primeOmpModelCatalog(
 		return Promise.resolve();
 	}
 	// Honor the same TTL for a recent failure so a broken install isn't re-primed
-	// (and re-warned) on every detect/reprobe pass within the window.
+	// (and re-warned) on every detect/reprobe pass within the window. A spawn
+	// opts out via `retryFailedPrime` so a single early failure can't pin the
+	// fallback window for the next five minutes of respawns.
 	const lastFailure = primeFailures.get(catalogKey);
-	if (lastFailure !== undefined && Date.now() - lastFailure < PRIME_TTL_MS) {
+	if (
+		!options?.retryFailedPrime &&
+		lastFailure !== undefined &&
+		Date.now() - lastFailure < PRIME_TTL_MS
+	) {
 		return Promise.resolve();
 	}
+	// Log the PATH the prime actually ran with (PATH only - the full env can hold
+	// provider secrets). In a packaged app this is the difference between "omp is
+	// broken" and "the packaged PATH lost ~/.bun/bin", which is invisible from an
+	// exit code alone.
+	const envPath = env?.PATH ?? process.env.PATH;
+	const startedAt = Date.now();
 	const promise = (async () => {
 		try {
 			const result = await execFileNoThrow(command, ['models', '--json'], undefined, env);
 			if (result.exitCode !== 0) {
 				primeFailures.set(catalogKey, Date.now());
 				logger.warn('omp models --json failed while priming catalog', LOG_CONTEXT, {
+					command,
+					path: envPath,
+					elapsedMs: Date.now() - startedAt,
 					exitCode: result.exitCode,
 					stderr: result.stderr?.trim(),
 				});
@@ -223,12 +254,18 @@ export function primeOmpModelCatalog(
 				primeFailures.set(catalogKey, Date.now());
 				logger.warn(
 					'omp models --json returned no models array while priming catalog',
-					LOG_CONTEXT
+					LOG_CONTEXT,
+					{ command, path: envPath, elapsedMs: Date.now() - startedAt }
 				);
 			}
 		} catch (error) {
 			primeFailures.set(catalogKey, Date.now());
-			logger.warn('Failed to prime omp model catalog', LOG_CONTEXT, { error: String(error) });
+			logger.warn('Failed to prime omp model catalog', LOG_CONTEXT, {
+				command,
+				path: envPath,
+				elapsedMs: Date.now() - startedAt,
+				error: String(error),
+			});
 		} finally {
 			primingPromises.delete(catalogKey);
 		}

--- a/src/main/agents/path-prober.ts
+++ b/src/main/agents/path-prober.ts
@@ -168,6 +168,7 @@ export function getExpandedEnv(): NodeJS.ProcessEnv {
 			'/usr/local/sbin',
 			`${home}/.local/bin`, // User local installs (pip, etc.)
 			`${home}/.npm-global/bin`, // npm global with custom prefix
+			`${home}/.bun/bin`, // Bun runtime and package manager (omp installs here)
 			`${home}/bin`, // User bin directory
 			`${home}/.claude/local`, // Claude local install location
 			`${home}/.opencode/bin`, // OpenCode installer default location

--- a/src/main/ipc/handlers/process/handle-spawn.ts
+++ b/src/main/ipc/handlers/process/handle-spawn.ts
@@ -772,6 +772,10 @@ export async function handleProcessSpawn(
 	// catalog is never served to another (see computeOmpCatalogKey). SSH remotes
 	// are skipped (their catalog may differ) and fall back to the configured window.
 	let ompModelCatalogKey: string | undefined;
+	// Set only when the prime outran the spawn cap: the spawn continues without a
+	// catalog, so the first turn emits the fallback window and we push a corrected
+	// one once this settles (see below, after the process exists).
+	let ompLatePrime: Promise<void> | undefined;
 	if (config.toolType === 'omp' && !sshRemoteUsed) {
 		// The prime needs an ABSOLUTE binary path (buildOmpPrimeEnv prepends its
 		// dirname, and the catalog key must identify one binary). A bare or
@@ -841,6 +845,7 @@ export async function handleProcessSpawn(
 					elapsedMs: Date.now() - primeStartedAt,
 					capMs: OMP_PRIME_SPAWN_CAP_MS,
 				});
+				ompLatePrime = prime;
 			}
 		}
 	}
@@ -885,6 +890,22 @@ export async function handleProcessSpawn(
 		// Extra dirs to prepend to spawn PATH (local non-SSH only)
 		extraPathDirs: localAgentBinDir ? [localAgentBinDir] : undefined,
 	});
+
+	// The prime outran the spawn cap, so the process started without a usable
+	// catalog and its first usage event carries the 200k fallback. Close the loop:
+	// when the prime lands, re-emit that turn's usage with the real window instead
+	// of leaving the gauge wrong until the next turn. Attached AFTER spawn so the
+	// managed process exists; the push itself no-ops if it already exited.
+	if (ompLatePrime && ompModelCatalogKey) {
+		const latePrimeCatalogKey = ompModelCatalogKey;
+		void ompLatePrime
+			.then(() => {
+				processManager.pushResolvedOmpContextWindow(config.sessionId, latePrimeCatalogKey);
+			})
+			.catch(() => {
+				// primeOmpModelCatalog already warn-logs its own failures.
+			});
+	}
 
 	logger.info(`Process spawned successfully`, LOG_CONTEXT, {
 		sessionId: config.sessionId,

--- a/src/main/ipc/handlers/process/handle-spawn.ts
+++ b/src/main/ipc/handlers/process/handle-spawn.ts
@@ -5,7 +5,7 @@ import * as fsp from 'fs/promises';
 import * as path from 'path';
 import { ProcessManager } from '../../../process-manager';
 import { AgentDetector } from '../../../agents';
-import { checkCustomPath } from '../../../agents/path-prober';
+import { checkBinaryExists, checkCustomPath } from '../../../agents/path-prober';
 import { resolveMaestroCliScriptPath } from '../../../cue/cue-cli-executor';
 import {
 	getActivePluginManager,
@@ -772,28 +772,77 @@ export async function handleProcessSpawn(
 	// catalog is never served to another (see computeOmpCatalogKey). SSH remotes
 	// are skipped (their catalog may differ) and fall back to the configured window.
 	let ompModelCatalogKey: string | undefined;
-	if (config.toolType === 'omp' && localAgentBinDir && localSpawnBinaryPath) {
-		// Identity uses the session's stable custom env overrides (not the
-		// platform-expanded `customEnvVarsToPass`, which on Windows is the whole
-		// env) so the same logical config maps to one catalog across platforms and
-		// matches the detector's default-identity warm-up.
-		ompModelCatalogKey = computeOmpCatalogKey(localSpawnBinaryPath, effectiveCustomEnvVars);
-		// Bounded await: block the spawn only briefly so the first turn resolves
-		// correctly on a warm/fast catalog, and proceed (letting the prime finish
-		// in the background for later turns) when it is slow or fails.
-		const OMP_PRIME_SPAWN_CAP_MS = 3500;
-		// Prime with the platform-expanded env (mirroring the Windows agent path
-		// above) so the bun-based `omp` binary resolves in a packaged app: packaged
-		// Electron apps do not inherit the shell PATH, so a raw `process.env` lacks
-		// user-local bin dirs like `~/.bun/bin`. buildOmpPrimeEnv also prepends the
-		// binary's own dir so a co-located runtime is found first, and the detector's
-		// warm-up shares it so both prime sites build an identical env.
-		const primeEnv = buildOmpPrimeEnv(localSpawnBinaryPath, customEnvVarsToPass);
-		const prime = primeOmpModelCatalog(localSpawnBinaryPath, primeEnv, ompModelCatalogKey);
-		await Promise.race([
-			prime,
-			new Promise<void>((resolve) => setTimeout(resolve, OMP_PRIME_SPAWN_CAP_MS)),
-		]);
+	if (config.toolType === 'omp' && !sshRemoteUsed) {
+		// The prime needs an ABSOLUTE binary path (buildOmpPrimeEnv prepends its
+		// dirname, and the catalog key must identify one binary). A bare or
+		// relative path used to skip the whole block silently, which left
+		// ompModelCatalogKey undefined and latched the 200k fallback for the life
+		// of the process. Resolve it instead, reusing the same probes detection
+		// uses (they already cover ~/.bun/bin), and warn if it still cannot be.
+		let ompPrimeBinaryPath =
+			localSpawnBinaryPath && path.isAbsolute(localSpawnBinaryPath)
+				? localSpawnBinaryPath
+				: undefined;
+		if (!ompPrimeBinaryPath) {
+			const relativeDetection = localSpawnBinaryPath
+				? await checkCustomPath(localSpawnBinaryPath)
+				: undefined;
+			if (relativeDetection?.exists && relativeDetection.path) {
+				ompPrimeBinaryPath = relativeDetection.path;
+			} else {
+				const probed = await checkBinaryExists(agent?.binaryName || localSpawnBinaryPath || 'omp');
+				if (probed.exists && probed.path && path.isAbsolute(probed.path)) {
+					ompPrimeBinaryPath = probed.path;
+				}
+			}
+		}
+
+		if (!ompPrimeBinaryPath) {
+			logger.warn(`Skipped omp model catalog prime: no absolute binary path`, LOG_CONTEXT, {
+				sessionId: config.sessionId,
+				sessionCustomPath: config.sessionCustomPath,
+				agentPath: agent?.path,
+				binaryName: agent?.binaryName,
+			});
+		} else {
+			// Identity uses the session's stable custom env overrides (not the
+			// platform-expanded `customEnvVarsToPass`, which on Windows is the whole
+			// env) so the same logical config maps to one catalog across platforms and
+			// matches the detector's default-identity warm-up.
+			ompModelCatalogKey = computeOmpCatalogKey(ompPrimeBinaryPath, effectiveCustomEnvVars);
+			// Bounded await: block the spawn only briefly so the first turn resolves
+			// correctly on a warm/fast catalog, and proceed (letting the prime finish
+			// in the background for later turns) when it is slow or fails.
+			const OMP_PRIME_SPAWN_CAP_MS = 3500;
+			// Prime with the platform-expanded env (mirroring the Windows agent path
+			// above) so the bun-based `omp` binary resolves in a packaged app: packaged
+			// Electron apps do not inherit the shell PATH, so a raw `process.env` lacks
+			// user-local bin dirs like `~/.bun/bin`. buildOmpPrimeEnv also prepends the
+			// binary's own dir so a co-located runtime is found first, and the detector's
+			// warm-up shares it so both prime sites build an identical env.
+			const primeEnv = buildOmpPrimeEnv(ompPrimeBinaryPath, customEnvVarsToPass);
+			const primeStartedAt = Date.now();
+			// retryFailedPrime: a user starting an agent must get a fresh attempt
+			// rather than inheriting a negative-cached failure (e.g. from a cold
+			// packaged start) that would pin the fallback window for 5 minutes.
+			const prime = primeOmpModelCatalog(ompPrimeBinaryPath, primeEnv, ompModelCatalogKey, {
+				retryFailedPrime: true,
+			});
+			const primeExceededCap = await Promise.race([
+				prime.then(() => false),
+				new Promise<boolean>((resolve) => setTimeout(() => resolve(true), OMP_PRIME_SPAWN_CAP_MS)),
+			]);
+			if (primeExceededCap) {
+				// Makes the cold-start theory checkable in the packaged app's log:
+				// the first turn will show the fallback window until the prime lands.
+				logger.warn(`omp prime exceeded spawn cap, continuing in background`, LOG_CONTEXT, {
+					sessionId: config.sessionId,
+					command: ompPrimeBinaryPath,
+					elapsedMs: Date.now() - primeStartedAt,
+					capMs: OMP_PRIME_SPAWN_CAP_MS,
+				});
+			}
+		}
 	}
 
 	const result = processManager.spawn({

--- a/src/main/process-listeners/plugin-event-listener.ts
+++ b/src/main/process-listeners/plugin-event-listener.ts
@@ -153,23 +153,31 @@ export function setupPluginEventListener(
 	// Token/cost usage - counts only. Also accumulated per session for the
 	// terminal agent.completed payload (cleared on exit).
 	processManager.on('usage', (sessionId: string, usage: UsageStats) => {
-		const totals = usageBySession.get(sessionId) ?? {
-			inputTokens: 0,
-			outputTokens: 0,
-			cacheReadInputTokens: 0,
-			cacheCreationInputTokens: 0,
-			reasoningTokens: 0,
-			costSum: 0,
-			lastCost: 0,
-		};
-		totals.inputTokens += usage.inputTokens;
-		totals.outputTokens += usage.outputTokens;
-		totals.cacheReadInputTokens += usage.cacheReadInputTokens;
-		totals.cacheCreationInputTokens += usage.cacheCreationInputTokens;
-		totals.reasoningTokens += usage.reasoningTokens ?? 0;
-		totals.costSum += usage.totalCostUsd;
-		totals.lastCost = usage.totalCostUsd;
-		usageBySession.set(sessionId, totals);
+		// A context-window correction replays an already-counted turn's tokens/cost
+		// purely to refresh the resolved window. The source
+		// (pushResolvedOmpContextWindow) already zeroes those fields; this guard is
+		// belt-and-braces so an accumulating consumer here never double-counts even if
+		// a future emitter forgets to zero. Skip the totals accumulation but still
+		// surface the corrected window on usage.updated below.
+		if (!usage.contextWindowCorrectionOnly) {
+			const totals = usageBySession.get(sessionId) ?? {
+				inputTokens: 0,
+				outputTokens: 0,
+				cacheReadInputTokens: 0,
+				cacheCreationInputTokens: 0,
+				reasoningTokens: 0,
+				costSum: 0,
+				lastCost: 0,
+			};
+			totals.inputTokens += usage.inputTokens;
+			totals.outputTokens += usage.outputTokens;
+			totals.cacheReadInputTokens += usage.cacheReadInputTokens;
+			totals.cacheCreationInputTokens += usage.cacheCreationInputTokens;
+			totals.reasoningTokens += usage.reasoningTokens ?? 0;
+			totals.costSum += usage.totalCostUsd;
+			totals.lastCost = usage.totalCostUsd;
+			usageBySession.set(sessionId, totals);
+		}
 
 		emit({
 			topic: 'usage.updated',

--- a/src/main/process-manager/ProcessManager.ts
+++ b/src/main/process-manager/ProcessManager.ts
@@ -14,6 +14,7 @@ import { PtySpawner } from './spawners/PtySpawner';
 import { ChildProcessSpawner } from './spawners/ChildProcessSpawner';
 import { OpencodeServerSpawner } from './spawners/OpencodeServerSpawner';
 import { DataBufferManager } from './handlers/DataBufferManager';
+import { pushResolvedOmpContextWindow } from './handlers/StdoutHandler';
 import { LocalCommandRunner } from './runners/LocalCommandRunner';
 import { SshCommandRunner } from './runners/SshCommandRunner';
 import { opencodeServerManager } from '../opencode-server/OpencodeServerManager';
@@ -544,6 +545,18 @@ export class ProcessManager extends EventEmitter {
 	 */
 	get(sessionId: string): ManagedProcess | undefined {
 		return this.processes.get(sessionId);
+	}
+
+	/**
+	 * Re-emit a corrected `usage` event for a local omp process whose model
+	 * context window could not be resolved when its first usage arrived, because
+	 * the catalog prime was still running. Called by the spawn handler when a
+	 * prime that exceeded the spawn cap finally lands.
+	 *
+	 * @returns true when a corrected event was emitted.
+	 */
+	pushResolvedOmpContextWindow(sessionId: string, catalogKey: string): boolean {
+		return pushResolvedOmpContextWindow(this.processes, this, sessionId, catalogKey);
 	}
 
 	/**

--- a/src/main/process-manager/handlers/StdoutHandler.ts
+++ b/src/main/process-manager/handlers/StdoutHandler.ts
@@ -297,10 +297,15 @@ export function pushResolvedOmpContextWindow(
 	}
 
 	managedProcess.pendingOmpUsagePush = undefined;
+	// Correction-only: the token/cost fields carried in pending.stats were already
+	// counted when the fallback usage event fired for this turn, so flag this
+	// replay. Accumulating consumers must update the window only and never re-add
+	// the tokens/cost (see mergeContextWindow + useAgentUsageListener).
 	emitter.emit('usage', sessionId, {
 		...pending.stats,
 		contextWindow: resolved,
 		contextWindowResolved: true,
+		contextWindowCorrectionOnly: true,
 	});
 	return true;
 }
@@ -834,6 +839,9 @@ export class StdoutHandler {
 		// default). Local runs only; remotes have their own catalog and keep the
 		// configured/fallback window.
 		if (managedProcess.toolType === 'omp' && !managedProcess.sshRemoteId && usage.model) {
+			// Stamp the model this window belongs to so a downstream resolved-window
+			// preservation can't survive a switch to a different omp model.
+			stats.contextWindowModel = usage.model;
 			const resolved = managedProcess.ompModelCatalogKey
 				? getOmpModelContextWindow(usage.model, managedProcess.ompModelCatalogKey)
 				: undefined;

--- a/src/main/process-manager/handlers/StdoutHandler.ts
+++ b/src/main/process-manager/handlers/StdoutHandler.ts
@@ -257,6 +257,55 @@ function resetOversizedCopilotJsonBuffer(sessionId: string, managedProcess: Mana
 }
 
 /**
+ * Push a corrected context window for a local omp process whose catalog prime
+ * landed AFTER its first usage event was already emitted with the fallback
+ * window.
+ *
+ * Without this the gauge stays at `FALLBACK_CONTEXT_WINDOW` until the next turn
+ * produces a usage event, which on a slow (packaged, cold) prime is the whole
+ * first turn. Called from the spawn handler once the background prime settles.
+ *
+ * No-ops (returning false) when the process has exited, was replaced by a
+ * respawn with a different catalog identity, has nothing pending, or the model
+ * still does not resolve. The pending payload is cleared on a successful push,
+ * so a second call can never emit twice.
+ *
+ * @returns true when a corrected `usage` event was emitted.
+ */
+export function pushResolvedOmpContextWindow(
+	processes: Map<string, ManagedProcess>,
+	emitter: EventEmitter,
+	sessionId: string,
+	catalogKey: string
+): boolean {
+	const managedProcess = processes.get(sessionId);
+	if (!managedProcess || managedProcess.toolType !== 'omp' || managedProcess.sshRemoteId) {
+		return false;
+	}
+	// Guard against a respawn having taken over this sessionId with a different
+	// binary/env identity while the prime was still running.
+	if (managedProcess.ompModelCatalogKey !== catalogKey) {
+		return false;
+	}
+	const pending = managedProcess.pendingOmpUsagePush;
+	if (!pending) {
+		return false;
+	}
+	const resolved = getOmpModelContextWindow(pending.model, catalogKey);
+	if (!resolved || resolved <= 0) {
+		return false;
+	}
+
+	managedProcess.pendingOmpUsagePush = undefined;
+	emitter.emit('usage', sessionId, {
+		...pending.stats,
+		contextWindow: resolved,
+		contextWindowResolved: true,
+	});
+	return true;
+}
+
+/**
  * Handles stdout data processing for child processes.
  * Extracts session IDs, usage stats, and result data from agent output.
  */
@@ -784,16 +833,20 @@ export class StdoutHandler {
 		// per-agent fallback/config (e.g. so opus's 1M isn't masked by the 200k
 		// default). Local runs only; remotes have their own catalog and keep the
 		// configured/fallback window.
-		if (
-			managedProcess.toolType === 'omp' &&
-			!managedProcess.sshRemoteId &&
-			usage.model &&
-			managedProcess.ompModelCatalogKey
-		) {
-			const resolved = getOmpModelContextWindow(usage.model, managedProcess.ompModelCatalogKey);
+		if (managedProcess.toolType === 'omp' && !managedProcess.sshRemoteId && usage.model) {
+			const resolved = managedProcess.ompModelCatalogKey
+				? getOmpModelContextWindow(usage.model, managedProcess.ompModelCatalogKey)
+				: undefined;
 			if (resolved && resolved > 0) {
 				stats.contextWindow = resolved;
 				stats.contextWindowResolved = true;
+				managedProcess.pendingOmpUsagePush = undefined;
+			} else {
+				// Catalog not primed (or this model missing from it): the stats above
+				// carry the static fallback. Remember them so a prime landing after
+				// the spawn cap can push a corrected window without waiting for the
+				// next turn (see pushResolvedOmpContextWindow).
+				managedProcess.pendingOmpUsagePush = { model: usage.model, stats };
 			}
 		}
 		return stats;

--- a/src/main/process-manager/handlers/StdoutHandler.ts
+++ b/src/main/process-manager/handlers/StdoutHandler.ts
@@ -298,11 +298,20 @@ export function pushResolvedOmpContextWindow(
 
 	managedProcess.pendingOmpUsagePush = undefined;
 	// Correction-only: the token/cost fields carried in pending.stats were already
-	// counted when the fallback usage event fired for this turn, so flag this
-	// replay. Accumulating consumers must update the window only and never re-add
-	// the tokens/cost (see mergeContextWindow + useAgentUsageListener).
+	// counted when the fallback usage event fired for this turn. This correction
+	// re-emits through the ProcessManager EventEmitter, so EVERY on('usage')
+	// consumer sees it - not just the renderer. Zero every token/cost field at the
+	// source so no present or future accumulating consumer can re-add this turn.
+	// Only the context-window fields carry meaning on a correction; the model tag
+	// rides along from pending.stats so same-model window merges still match.
 	emitter.emit('usage', sessionId, {
 		...pending.stats,
+		inputTokens: 0,
+		outputTokens: 0,
+		cacheReadInputTokens: 0,
+		cacheCreationInputTokens: 0,
+		totalCostUsd: 0,
+		reasoningTokens: 0,
 		contextWindow: resolved,
 		contextWindowResolved: true,
 		contextWindowCorrectionOnly: true,

--- a/src/main/process-manager/types.ts
+++ b/src/main/process-manager/types.ts
@@ -125,6 +125,12 @@ export interface ManagedProcess {
 	streamedText?: string;
 	contextWindow?: number;
 	ompModelCatalogKey?: string;
+	/** Last omp usage payload that was emitted WITHOUT a catalog-resolved context
+	 *  window (the catalog prime had not landed yet, so the stats carry the static
+	 *  fallback). Kept so a prime that completes after the spawn cap can re-emit a
+	 *  corrected `usage` event immediately instead of the gauge staying wrong until
+	 *  the next turn. Cleared once resolved or pushed, so no double emit. */
+	pendingOmpUsagePush?: { model: string; stats: UsageStats };
 	tempImageFiles?: string[];
 	command?: string;
 	args?: string[];

--- a/src/renderer/hooks/agent/internal/useAgentUsageListener.ts
+++ b/src/renderer/hooks/agent/internal/useAgentUsageListener.ts
@@ -110,6 +110,14 @@ export function useAgentUsageListener(deps: UseAgentUsageListenerDeps): void {
 										)
 									: 0;
 
+			// A context-window correction (omp's catalog primed after the first turn's
+			// fallback usage already emitted) replays an already-counted turn purely to
+			// fix the window. The batched updater applies it as window-only, but the
+			// per-turn side effects below (timeline point, cycle tokens) would still
+			// double-count, so they are skipped for corrections. The gauge percentage is
+			// still recomputed so the corrected window resizes the fill.
+			const isContextWindowCorrection = usageStats.contextWindowCorrectionOnly === true;
+
 			deps.batchedUpdater.updateUsage(actualSessionId, tabId, usageStats);
 			deps.batchedUpdater.updateUsage(actualSessionId, null, usageStats);
 
@@ -151,7 +159,12 @@ export function useAgentUsageListener(deps: UseAgentUsageListenerDeps): void {
 				(usageStats.cacheCreationInputTokens || 0) === 0 &&
 				usageStats.outputTokens === 0 &&
 				(usageStats.reasoningTokens || 0) === 0;
-			if (isInteractiveRun && !isOutputOnlyDelta && !hasNoTurnActivity) {
+			if (
+				isInteractiveRun &&
+				!isOutputOnlyDelta &&
+				!hasNoTurnActivity &&
+				!isContextWindowCorrection
+			) {
 				// For providers whose usage arrives as per-turn deltas of a cumulative
 				// session total (Codex), the delta undercounts the context that is
 				// actually occupying the window - plotting it makes a long run look
@@ -201,7 +214,9 @@ export function useAgentUsageListener(deps: UseAgentUsageListenerDeps): void {
 					deps.batchedUpdater.updateContextUsage(actualSessionId, Math.min(estimated, maxEstimate));
 				}
 			}
-			deps.batchedUpdater.updateCycleTokens(actualSessionId, usageStats.outputTokens);
+			if (!isContextWindowCorrection) {
+				deps.batchedUpdater.updateCycleTokens(actualSessionId, usageStats.outputTokens);
+			}
 		});
 
 		return () => {

--- a/src/renderer/hooks/session/useBatchedSessionUpdates.ts
+++ b/src/renderer/hooks/session/useBatchedSessionUpdates.ts
@@ -35,22 +35,36 @@ export const DEFAULT_BATCH_FLUSH_INTERVAL = 200;
  * 200k for the rest of the turn. So an unresolved delta never overwrites an
  * already-resolved window; a resolved delta always wins, which keeps genuine
  * model switches (they arrive resolved) propagating normally.
+ *
+ * Preservation is scoped to the SAME model (`contextWindowModel`): a switch to a
+ * different omp model that is absent from the primed catalog arrives unresolved,
+ * and must NOT keep showing the previous model's window. Providers with a single
+ * static window carry no model tag, so both sides are undefined and preservation
+ * applies as before.
  */
 export function mergeContextWindow(
-	delta: Pick<UsageStats, 'contextWindow' | 'contextWindowResolved'>,
-	existing: Pick<UsageStats, 'contextWindow' | 'contextWindowResolved'> | undefined
-): { contextWindow: number; contextWindowResolved?: boolean } {
-	if (existing?.contextWindowResolved && !delta.contextWindowResolved) {
+	delta: Pick<UsageStats, 'contextWindow' | 'contextWindowResolved' | 'contextWindowModel'>,
+	existing:
+		| Pick<UsageStats, 'contextWindow' | 'contextWindowResolved' | 'contextWindowModel'>
+		| undefined
+): { contextWindow: number; contextWindowResolved?: boolean; contextWindowModel?: string } {
+	const sameModel = delta.contextWindowModel === existing?.contextWindowModel;
+	if (existing?.contextWindowResolved && !delta.contextWindowResolved && sameModel) {
 		return {
 			contextWindow: existing.contextWindow,
 			contextWindowResolved: true,
+			contextWindowModel: existing.contextWindowModel,
 		};
 	}
+	// The winning window's model tag rides along so the next turn's same-model
+	// check compares against the model that actually produced the stored window.
+	const deltaWins = Boolean(delta.contextWindow);
 	return {
 		contextWindow: delta.contextWindow || existing?.contextWindow || 0,
-		contextWindowResolved: delta.contextWindow
+		contextWindowResolved: deltaWins
 			? delta.contextWindowResolved
 			: existing?.contextWindowResolved,
+		contextWindowModel: deltaWins ? delta.contextWindowModel : existing?.contextWindowModel,
 	};
 }
 
@@ -386,22 +400,35 @@ export function useBatchedSessionUpdates(
 					const sessionUsageDelta = acc.usageDeltas.get(null);
 					if (sessionUsageDelta) {
 						const existing = updatedSession.usageStats;
-						updatedSession = {
-							...updatedSession,
-							usageStats: {
-								inputTokens: (existing?.inputTokens || 0) + sessionUsageDelta.inputTokens,
-								outputTokens: (existing?.outputTokens || 0) + sessionUsageDelta.outputTokens,
-								cacheReadInputTokens:
-									(existing?.cacheReadInputTokens || 0) + sessionUsageDelta.cacheReadInputTokens,
-								cacheCreationInputTokens:
-									(existing?.cacheCreationInputTokens || 0) +
-									sessionUsageDelta.cacheCreationInputTokens,
-								totalCostUsd: (existing?.totalCostUsd || 0) + sessionUsageDelta.totalCostUsd,
-								reasoningTokens:
-									(existing?.reasoningTokens || 0) + (sessionUsageDelta.reasoningTokens || 0),
-								...mergeContextWindow(sessionUsageDelta, existing),
-							},
-						};
+						if (sessionUsageDelta.contextWindowCorrectionOnly) {
+							// Window-only correction: its token/cost fields replay an already-counted
+							// turn, so keep every accumulated total and update only the context window.
+							// No prior stats means nothing was counted, so the replay seeds it.
+							updatedSession = {
+								...updatedSession,
+								usageStats: {
+									...(existing ?? sessionUsageDelta),
+									...mergeContextWindow(sessionUsageDelta, existing),
+								},
+							};
+						} else {
+							updatedSession = {
+								...updatedSession,
+								usageStats: {
+									inputTokens: (existing?.inputTokens || 0) + sessionUsageDelta.inputTokens,
+									outputTokens: (existing?.outputTokens || 0) + sessionUsageDelta.outputTokens,
+									cacheReadInputTokens:
+										(existing?.cacheReadInputTokens || 0) + sessionUsageDelta.cacheReadInputTokens,
+									cacheCreationInputTokens:
+										(existing?.cacheCreationInputTokens || 0) +
+										sessionUsageDelta.cacheCreationInputTokens,
+									totalCostUsd: (existing?.totalCostUsd || 0) + sessionUsageDelta.totalCostUsd,
+									reasoningTokens:
+										(existing?.reasoningTokens || 0) + (sessionUsageDelta.reasoningTokens || 0),
+									...mergeContextWindow(sessionUsageDelta, existing),
+								},
+							};
+						}
 					}
 
 					// Tab-level usage
@@ -413,6 +440,17 @@ export function useBatchedSessionUpdates(
 								if (!tabUsageDelta) return tab;
 
 								const existing = tab.usageStats;
+								if (tabUsageDelta.contextWindowCorrectionOnly) {
+									// Window-only correction: preserve this tab's already-counted
+									// tokens/cost and update only the context window.
+									return {
+										...tab,
+										usageStats: {
+											...(existing ?? tabUsageDelta),
+											...mergeContextWindow(tabUsageDelta, existing),
+										},
+									};
+								}
 								// An "output-only" delta carries new output tokens but zero
 								// input/cache. Copilot CLI streams these per-turn (each
 								// assistant.message reports only outputTokens; the real
@@ -603,6 +641,38 @@ export function useBatchedSessionUpdates(
 			}
 
 			const existing = acc.usageDeltas.get(tabId);
+
+			// A context-window correction replays an already-counted turn, so it must
+			// never add tokens/cost. Fold its corrected window onto a real delta still
+			// pending in this batch (keeping that turn's tokens), or park a zero-token
+			// correction the flush applies as window-only against the committed stats.
+			if (usage.contextWindowCorrectionOnly) {
+				acc.usageDeltas.set(
+					tabId,
+					existing
+						? {
+								...existing,
+								contextWindow: usage.contextWindow,
+								contextWindowResolved: usage.contextWindowResolved,
+								contextWindowModel: usage.contextWindowModel,
+							}
+						: {
+								inputTokens: 0,
+								outputTokens: 0,
+								cacheReadInputTokens: 0,
+								cacheCreationInputTokens: 0,
+								totalCostUsd: 0,
+								reasoningTokens: 0,
+								contextWindow: usage.contextWindow,
+								contextWindowResolved: usage.contextWindowResolved,
+								contextWindowModel: usage.contextWindowModel,
+								contextWindowCorrectionOnly: true,
+							}
+				);
+				hasPendingRef.current = true;
+				return;
+			}
+
 			if (existing) {
 				// For tab-level: inputTokens etc. are current (not accumulated), but outputTokens and cost are accumulated
 				if (tabId !== null) {
@@ -612,6 +682,7 @@ export function useBatchedSessionUpdates(
 						cacheCreationInputTokens: usage.cacheCreationInputTokens,
 						contextWindow: usage.contextWindow,
 						contextWindowResolved: usage.contextWindowResolved,
+						contextWindowModel: usage.contextWindowModel,
 						outputTokens: usage.outputTokens,
 						totalCostUsd: existing.totalCostUsd + usage.totalCostUsd,
 						reasoningTokens: usage.reasoningTokens,
@@ -628,6 +699,7 @@ export function useBatchedSessionUpdates(
 						reasoningTokens: (existing.reasoningTokens || 0) + (usage.reasoningTokens || 0),
 						contextWindow: usage.contextWindow,
 						contextWindowResolved: usage.contextWindowResolved,
+						contextWindowModel: usage.contextWindowModel,
 					});
 				}
 			} else {

--- a/src/renderer/hooks/session/useBatchedSessionUpdates.ts
+++ b/src/renderer/hooks/session/useBatchedSessionUpdates.ts
@@ -26,6 +26,35 @@ import { logger } from '../../utils/logger';
 export const DEFAULT_BATCH_FLUSH_INTERVAL = 200;
 
 /**
+ * Merge the context-window half of a usage delta into the existing stats.
+ *
+ * `buildUsageStats` in the main process ALWAYS emits a context window, falling
+ * back to `FALLBACK_CONTEXT_WINDOW` (200k) when it could not resolve the real
+ * one (e.g. an omp model catalog that has not primed yet). Taking that value at
+ * face value downgrades a gauge that already showed an authoritative 1M back to
+ * 200k for the rest of the turn. So an unresolved delta never overwrites an
+ * already-resolved window; a resolved delta always wins, which keeps genuine
+ * model switches (they arrive resolved) propagating normally.
+ */
+export function mergeContextWindow(
+	delta: Pick<UsageStats, 'contextWindow' | 'contextWindowResolved'>,
+	existing: Pick<UsageStats, 'contextWindow' | 'contextWindowResolved'> | undefined
+): { contextWindow: number; contextWindowResolved?: boolean } {
+	if (existing?.contextWindowResolved && !delta.contextWindowResolved) {
+		return {
+			contextWindow: existing.contextWindow,
+			contextWindowResolved: true,
+		};
+	}
+	return {
+		contextWindow: delta.contextWindow || existing?.contextWindow || 0,
+		contextWindowResolved: delta.contextWindow
+			? delta.contextWindowResolved
+			: existing?.contextWindowResolved,
+	};
+}
+
+/**
  * Accumulated log data for efficient string concatenation
  */
 interface LogAccumulator {
@@ -370,8 +399,7 @@ export function useBatchedSessionUpdates(
 								totalCostUsd: (existing?.totalCostUsd || 0) + sessionUsageDelta.totalCostUsd,
 								reasoningTokens:
 									(existing?.reasoningTokens || 0) + (sessionUsageDelta.reasoningTokens || 0),
-								contextWindow: sessionUsageDelta.contextWindow,
-								contextWindowResolved: sessionUsageDelta.contextWindowResolved,
+								...mergeContextWindow(sessionUsageDelta, existing),
 							},
 						};
 					}
@@ -413,10 +441,7 @@ export function useBatchedSessionUpdates(
 										cacheCreationInputTokens: isOutputOnlyDelta
 											? (existing?.cacheCreationInputTokens ?? 0)
 											: tabUsageDelta.cacheCreationInputTokens,
-										contextWindow: tabUsageDelta.contextWindow || existing?.contextWindow || 0,
-										contextWindowResolved: tabUsageDelta.contextWindow
-											? tabUsageDelta.contextWindowResolved
-											: existing?.contextWindowResolved,
+										...mergeContextWindow(tabUsageDelta, existing),
 										outputTokens: tabUsageDelta.outputTokens, // Current (not accumulated)
 										totalCostUsd: (existing?.totalCostUsd || 0) + tabUsageDelta.totalCostUsd,
 										reasoningTokens: tabUsageDelta.reasoningTokens,

--- a/src/renderer/hooks/session/useBatchedSessionUpdates.ts
+++ b/src/renderer/hooks/session/useBatchedSessionUpdates.ts
@@ -652,9 +652,7 @@ export function useBatchedSessionUpdates(
 					existing
 						? {
 								...existing,
-								contextWindow: usage.contextWindow,
-								contextWindowResolved: usage.contextWindowResolved,
-								contextWindowModel: usage.contextWindowModel,
+								...mergeContextWindow(usage, existing),
 							}
 						: {
 								inputTokens: 0,
@@ -680,9 +678,7 @@ export function useBatchedSessionUpdates(
 						inputTokens: usage.inputTokens,
 						cacheReadInputTokens: usage.cacheReadInputTokens,
 						cacheCreationInputTokens: usage.cacheCreationInputTokens,
-						contextWindow: usage.contextWindow,
-						contextWindowResolved: usage.contextWindowResolved,
-						contextWindowModel: usage.contextWindowModel,
+						...mergeContextWindow(usage, existing),
 						outputTokens: usage.outputTokens,
 						totalCostUsd: existing.totalCostUsd + usage.totalCostUsd,
 						reasoningTokens: usage.reasoningTokens,
@@ -697,9 +693,7 @@ export function useBatchedSessionUpdates(
 							existing.cacheCreationInputTokens + usage.cacheCreationInputTokens,
 						totalCostUsd: existing.totalCostUsd + usage.totalCostUsd,
 						reasoningTokens: (existing.reasoningTokens || 0) + (usage.reasoningTokens || 0),
-						contextWindow: usage.contextWindow,
-						contextWindowResolved: usage.contextWindowResolved,
-						contextWindowModel: usage.contextWindowModel,
+						...mergeContextWindow(usage, existing),
 					});
 				}
 			} else {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -296,6 +296,24 @@ export interface UsageStats {
 	 */
 	contextWindowResolved?: boolean;
 	/**
+	 * The model whose window `contextWindow` describes, for providers whose window
+	 * is model-dependent (currently Oh My Pi). Consumers that preserve a resolved
+	 * window across an unresolved delta (see `mergeContextWindow`) scope that
+	 * preservation to the SAME model so a mid-session model switch to a model that
+	 * is absent from the primed catalog can't leave the gauge stuck on the previous
+	 * model's window. Undefined for providers with a single static window.
+	 */
+	contextWindowModel?: string;
+	/**
+	 * True when this usage event exists ONLY to correct a previously emitted
+	 * context window (Oh My Pi's catalog primed after the first turn's fallback
+	 * usage was already emitted - see `pushResolvedOmpContextWindow`). The token
+	 * and cost fields are a REPLAY of that already-counted turn, so accumulating
+	 * consumers must NOT add them again: update the context window and leave every
+	 * token/cost total untouched. Undefined for ordinary per-turn usage events.
+	 */
+	contextWindowCorrectionOnly?: boolean;
+	/**
 	 * Reasoning/thinking tokens (separate from outputTokens)
 	 * Some models like OpenAI o3/o4-mini report reasoning tokens separately.
 	 * These are already included in outputTokens but tracked separately for UI display.


### PR DESCRIPTION
## Finding N1 - omp context window 200k in packaged app (C1 was insufficient)

The omp agent reported a 200k context window in the packaged app but 1M from a terminal, because the model-catalog prime could not resolve the bun-based omp binary on the packaged PATH.

## Change
- Resolves omp's absolute binary path and runs discovery with the prime env (including `~/.bun/bin`).
- Retries past a failed prime.
- Pushes a corrected usage event so the renderer's batched-update merge rule swaps the placeholder 200k for the resolved 1M window.

## Validation
Type-check (main + lint), ESLint, Prettier clean. Scoped tests (omp-model-catalog, detector, path-prober, StdoutHandler, useBatchedSessionUpdates) -> 227 pass.

## ⚠️ Human verification required
Packaged-PATH-only failure, not reproducible from dev/test. Confirm in a rebuilt `.deb`: open an omp agent and verify the context gauge shows 1M, not 200k.

Base: upstream/rc. Playbook: `.maestro/playbooks/FIX-OMP-CONTEXT-01.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Oh My Pi model discovery and catalog priming by ensuring the same runtime PATH setup is used for loading and warm-up.
  * Enhanced PATH expansion to include Bun’s user bin directory, improving executable discovery in packaged environments.
  * Fixed context-window handling so late model info triggers a single corrected update with correct precedence, without double-counting token/cost totals.
  * Added safer retry behavior for failed model-catalog priming.
* **Diagnostics**
  * Improved catalog failure warnings with command details, PATH, and elapsed timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->