### PR TITLE
Re-pin transcript to live bottom after agent swap

### DIFF
--- a/src/__tests__/renderer/components/TerminalOutput/TerminalOutput.scrollContainer.test.tsx
+++ b/src/__tests__/renderer/components/TerminalOutput/TerminalOutput.scrollContainer.test.tsx
@@ -1,0 +1,65 @@
+import React, { createRef } from 'react';
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { TerminalOutput } from '../../../../renderer/components/TerminalOutput/TerminalOutput';
+import type { TerminalOutputProps } from '../../../../renderer/components/TerminalOutput/types';
+import { LayerStackProvider } from '../../../../renderer/contexts/LayerStackContext';
+import { createMockSession } from '../../../helpers/mockSession';
+import { mockTheme } from '../../../helpers/mockTheme';
+
+/**
+ * Regression coverage for the Alt+J "Jump to Bottom" contract.
+ *
+ * useMainKeyboardHandler resolves the transcript scroll target via
+ * `logsEndRef.current.parentElement` (one level up from the end marker). That
+ * only works while the marker is a DIRECT child of the `overflow-y-auto` scroll
+ * container. The content-resize re-pin work added a `contentRef` wrapper around
+ * the log entries; if the end marker gets pulled inside that wrapper,
+ * `parentElement` lands on an unscrollable block and Alt+J silently no-ops.
+ *
+ * This asserts the DOM relationship the keyboard handler depends on so nobody
+ * re-nests the marker while refactoring this subtree.
+ */
+function makeProps(logsEndRef: React.RefObject<HTMLDivElement>): TerminalOutputProps {
+	const noop = () => {};
+	return {
+		session: createMockSession(),
+		theme: mockTheme,
+		fontFamily: 'monospace',
+		activeFocus: 'main',
+		outputSearchOpen: false,
+		outputSearchQuery: '',
+		outputSearchRegex: false,
+		setOutputSearchOpen: noop,
+		setOutputSearchQuery: noop,
+		setOutputSearchRegex: noop,
+		setActiveFocus: noop,
+		setLightboxImage: noop,
+		inputRef: createRef<HTMLTextAreaElement>(),
+		logsEndRef,
+		maxOutputLines: 1000,
+		markdownEditMode: false,
+		setMarkdownEditMode: noop,
+	};
+}
+
+describe('TerminalOutput scroll-container / end-marker contract', () => {
+	it('renders logsEndRef as a direct child of the overflow-y-auto scroll container', () => {
+		const logsEndRef = createRef<HTMLDivElement>();
+		render(
+			<LayerStackProvider>
+				<TerminalOutput {...makeProps(logsEndRef)} />
+			</LayerStackProvider>
+		);
+
+		const marker = logsEndRef.current;
+		expect(marker).not.toBeNull();
+
+		// Alt+J resolves the scroll target as the marker's parentElement, so the
+		// parent MUST be the scroll container (the overflow-y-auto element), not the
+		// unstyled contentRef wrapper that holds the log entries.
+		const parent = marker!.parentElement;
+		expect(parent).not.toBeNull();
+		expect(parent!.className).toContain('overflow-y-auto');
+	});
+});

--- a/src/__tests__/renderer/components/TerminalOutput/useTerminalOutputScroll.test.ts
+++ b/src/__tests__/renderer/components/TerminalOutput/useTerminalOutputScroll.test.ts
@@ -270,3 +270,202 @@ describe('useTerminalOutputScroll mount-time restore gate (J1)', () => {
 		expect(ref.current.scrollTop).toBe(2000);
 	});
 });
+
+/**
+ * Coverage for the O1 content-resize re-pin: content can grow WITHOUT any DOM
+ * mutation (image decode, web font load, markdown or tool-badge layout settling
+ * after the initial commit). The MutationObserver is blind to that, and for a
+ * freshly swapped-in idle agent no mutations arrive at all, so the mount-time
+ * jump's one-frame scrollHeight reading used to be the last word and the view
+ * landed above the live bottom. A ResizeObserver on the content wrapper must
+ * re-pin while the user is following, and must never yank a user who scrolled
+ * up deliberately.
+ *
+ * jsdom has no ResizeObserver, so we install a manual-trigger stub that records
+ * its instances and lets the tests fire the callbacks deterministically.
+ */
+interface ResizeObserverStubInstance {
+	fire: () => void;
+	targets: Element[];
+}
+
+function makeGrowableContainer(initialMaxScroll: number, clientHeight = 200) {
+	const el = document.createElement('div');
+	let maxScroll = initialMaxScroll;
+	Object.defineProperty(el, 'scrollHeight', {
+		get: () => maxScroll + clientHeight,
+		configurable: true,
+	});
+	Object.defineProperty(el, 'clientHeight', { value: clientHeight, configurable: true });
+	Object.defineProperty(el, 'scrollTo', {
+		value: (opts: number | { top?: number }) => {
+			const top = typeof opts === 'object' ? (opts.top ?? 0) : opts;
+			el.scrollTop = Math.min(Math.max(0, top), maxScroll);
+		},
+		configurable: true,
+	});
+	el.scrollTop = 0;
+	return {
+		el,
+		/** Simulate late content growth (image decode, font load, layout settling). */
+		grow(newMaxScroll: number) {
+			maxScroll = newMaxScroll;
+		},
+	};
+}
+
+describe('useTerminalOutputScroll content-resize re-pin (O1)', () => {
+	let rafQueue: FrameRequestCallback[] = [];
+	let resizeObservers: ResizeObserverStubInstance[] = [];
+
+	beforeEach(() => {
+		rafQueue = [];
+		resizeObservers = [];
+
+		vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+			rafQueue.push(cb);
+			return rafQueue.length;
+		});
+
+		class ResizeObserverStub {
+			private targets: Element[] = [];
+			private entry: ResizeObserverStubInstance;
+
+			constructor(private callback: () => void) {
+				this.entry = { fire: () => this.callback(), targets: this.targets };
+				resizeObservers.push(this.entry);
+			}
+
+			observe(target: Element) {
+				this.targets.push(target);
+			}
+
+			unobserve(target: Element) {
+				const i = this.targets.indexOf(target);
+				if (i >= 0) this.targets.splice(i, 1);
+			}
+
+			disconnect() {
+				this.targets.length = 0;
+				const i = resizeObservers.indexOf(this.entry);
+				if (i >= 0) resizeObservers.splice(i, 1);
+			}
+		}
+
+		vi.stubGlobal('ResizeObserver', ResizeObserverStub);
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	function flushRaf() {
+		act(() => {
+			let guard = 0;
+			while (rafQueue.length > 0 && guard++ < 20) {
+				const cbs = rafQueue.splice(0);
+				cbs.forEach((cb) => cb(0));
+			}
+		});
+	}
+
+	/** Fire every live ResizeObserver stub, as the browser would on content growth. */
+	function fireResize() {
+		act(() => {
+			resizeObservers.slice().forEach((o) => o.fire());
+		});
+	}
+
+	function mountFollowing(initialIsAtBottom: boolean | undefined) {
+		const container = makeGrowableContainer(1000);
+		const ref = { current: container.el };
+		const contentRef = { current: document.createElement('div') as HTMLElement | null };
+
+		const hook = renderHook(() =>
+			useTerminalOutputScroll({
+				scrollContainerRef: ref,
+				contentRef,
+				initialScrollTop: 500,
+				initialIsAtBottom,
+				sessionId: 's1',
+				activeTabId: 't1',
+				filteredLogsLength: 3,
+			})
+		);
+
+		return { container, ref, contentRef, hook };
+	}
+
+	it('observes the content wrapper, not the scroll container', () => {
+		const { contentRef } = mountFollowing(true);
+		flushRaf();
+
+		expect(resizeObservers).toHaveLength(1);
+		expect(resizeObservers[0].targets).toEqual([contentRef.current]);
+	});
+
+	it('Case 6: re-pins to the new bottom when content grows without a DOM mutation', () => {
+		const { container, ref, hook } = mountFollowing(true);
+
+		// Mount-time jump parks at the stale bottom that the first frame could see.
+		flushRaf();
+		expect(ref.current.scrollTop).toBe(1000);
+
+		// Late growth: no childList/characterData mutation, only a size change.
+		container.grow(5000);
+		fireResize();
+		flushRaf();
+
+		expect(ref.current.scrollTop).toBe(5000);
+		expect(hook.result.current.isAtBottom).toBe(true);
+		expect(hook.result.current.autoScrollPaused).toBe(false);
+	});
+
+	it('Case 7: legacy tab (initialIsAtBottom undefined) also re-pins on content growth', () => {
+		const { container, ref, hook } = mountFollowing(undefined);
+
+		flushRaf();
+		expect(ref.current.scrollTop).toBe(1000);
+
+		container.grow(5000);
+		fireResize();
+		flushRaf();
+
+		expect(ref.current.scrollTop).toBe(5000);
+		expect(hook.result.current.isAtBottom).toBe(true);
+	});
+
+	it('Case 8: does NOT yank a user who deliberately scrolled up', () => {
+		const { container, ref, hook } = mountFollowing(true);
+
+		flushRaf();
+		expect(ref.current.scrollTop).toBe(1000);
+
+		// Genuine user scroll-up: the container reports a position well above the
+		// recorded programmatic target, so this is handled as a real position change.
+		ref.current.scrollTop = 200;
+		act(() => {
+			hook.result.current.handleScroll();
+		});
+		expect(hook.result.current.isAtBottom).toBe(false);
+		expect(hook.result.current.autoScrollPaused).toBe(true);
+
+		// Same growth sequence as Case 6: the resize must be ignored.
+		container.grow(5000);
+		fireResize();
+		flushRaf();
+
+		expect(ref.current.scrollTop).toBe(200);
+		expect(hook.result.current.isAtBottom).toBe(false);
+	});
+
+	it('disconnects the ResizeObserver on unmount', () => {
+		const { hook } = mountFollowing(true);
+		flushRaf();
+		expect(resizeObservers).toHaveLength(1);
+
+		hook.unmount();
+
+		expect(resizeObservers).toHaveLength(0);
+	});
+});

--- a/src/renderer/components/TerminalOutput/TerminalOutput.tsx
+++ b/src/renderer/components/TerminalOutput/TerminalOutput.tsx
@@ -85,6 +85,12 @@ export const TerminalOutput = memo(
 
 		// Scroll container ref for native scrolling
 		const scrollContainerRef = useRef<HTMLDivElement>(null);
+		// Single inner wrapper whose border-box height equals the scrollable content
+		// height. The scroll container itself only resizes with the viewport, so a
+		// ResizeObserver needs this element to see content growth (image decode,
+		// async font load, markdown/tool-badge layout settling) that arrives without
+		// a DOM mutation.
+		const contentRef = useRef<HTMLDivElement>(null);
 
 		const activeTabId = session.activeTabId;
 
@@ -192,6 +198,7 @@ export const TerminalOutput = memo(
 			scrollToBottomAndResume,
 		} = useTerminalOutputScroll({
 			scrollContainerRef,
+			contentRef,
 			initialScrollTop,
 			initialIsAtBottom,
 			sessionId: session.id,
@@ -365,92 +372,97 @@ export const TerminalOutput = memo(
 					}}
 					onScroll={handleScroll}
 				>
-					{/* Log entries */}
-					{filteredLogs.map((log, index) => (
-						<LogItem
-							key={log.id}
-							log={log}
-							index={index}
-							isTerminal={isTerminal}
-							isAIMode={isAIMode}
-							theme={theme}
-							fontFamily={fontFamily}
-							maxOutputLines={maxOutputLines}
-							lastUserCommand={
-								isTerminal && log.source !== 'user' ? getLastUserCommand(index) : undefined
-							}
-							isExpanded={expandedLogs.has(log.id)}
-							onToggleExpanded={toggleExpanded}
-							subagentLogs={childrenByParentId.get(log.id)}
-							localFilterQuery={localFilters.get(log.id) || ''}
-							filterMode={filterModes.get(log.id) || { mode: 'include', regex: false }}
-							activeLocalFilter={activeLocalFilter}
-							onToggleLocalFilter={toggleLocalFilter}
-							onSetLocalFilterQuery={setLocalFilterQuery}
-							onSetFilterMode={setFilterModeForLog}
-							onClearLocalFilter={clearLocalFilter}
-							deleteConfirmLogId={deleteConfirmLogId}
-							onDeleteLog={onDeleteLog}
-							onSetDeleteConfirmLogId={setDeleteConfirmLogId}
-							scrollContainerRef={scrollContainerRef}
-							setLightboxImage={setLightboxImage}
-							copyToClipboard={copyToClipboard}
-							ansiConverter={ansiConverter}
-							markdownEditMode={markdownEditMode}
-							onToggleMarkdownEditMode={toggleMarkdownEditMode}
-							onReplayMessage={onReplayMessage}
-							onForkConversation={onForkConversation}
-							sessionId={session.id}
-							onSessionRecover={onSessionRecover}
-							isRecoveringSession={isRecoveringSession}
-							sessionRecoveryError={sessionRecoveryError}
-							fileTree={fileTree}
-							cwd={cwd}
-							projectRoot={projectRoot}
-							onFileClick={onFileClick}
-							sshRemoteId={
-								session.sessionSshRemoteConfig?.enabled
-									? (session.sessionSshRemoteConfig?.remoteId ?? undefined)
-									: undefined
-							}
-							onShowErrorDetails={onShowErrorDetails}
-							onSaveToFile={handleSaveToFile}
-							ghCliAvailable={ghCliAvailable}
-							onPublishGist={onPublishMessageGist}
-							publishedGistUrl={publishedGists[log.id]?.gistUrl}
-							bionifyReadingMode={globalBionifyReadingMode}
-							bionifyIntensity={globalBionifyIntensity}
-							bionifyAlgorithm={globalBionifyAlgorithm}
-							userMessageAlignment={userMessageAlignment}
-							isClaudeCode={session.toolType === 'claude-code'}
-							isAdaptiveMode={getClaudeTokenMode(session) === 'dynamic'}
-						/>
-					))}
+					{/* Content wrapper: unstyled block so its height tracks the scrollable
+					    content exactly, giving the scroll hook's ResizeObserver something
+					    that grows when late content settles. */}
+					<div ref={contentRef}>
+						{/* Log entries */}
+						{filteredLogs.map((log, index) => (
+							<LogItem
+								key={log.id}
+								log={log}
+								index={index}
+								isTerminal={isTerminal}
+								isAIMode={isAIMode}
+								theme={theme}
+								fontFamily={fontFamily}
+								maxOutputLines={maxOutputLines}
+								lastUserCommand={
+									isTerminal && log.source !== 'user' ? getLastUserCommand(index) : undefined
+								}
+								isExpanded={expandedLogs.has(log.id)}
+								onToggleExpanded={toggleExpanded}
+								subagentLogs={childrenByParentId.get(log.id)}
+								localFilterQuery={localFilters.get(log.id) || ''}
+								filterMode={filterModes.get(log.id) || { mode: 'include', regex: false }}
+								activeLocalFilter={activeLocalFilter}
+								onToggleLocalFilter={toggleLocalFilter}
+								onSetLocalFilterQuery={setLocalFilterQuery}
+								onSetFilterMode={setFilterModeForLog}
+								onClearLocalFilter={clearLocalFilter}
+								deleteConfirmLogId={deleteConfirmLogId}
+								onDeleteLog={onDeleteLog}
+								onSetDeleteConfirmLogId={setDeleteConfirmLogId}
+								scrollContainerRef={scrollContainerRef}
+								setLightboxImage={setLightboxImage}
+								copyToClipboard={copyToClipboard}
+								ansiConverter={ansiConverter}
+								markdownEditMode={markdownEditMode}
+								onToggleMarkdownEditMode={toggleMarkdownEditMode}
+								onReplayMessage={onReplayMessage}
+								onForkConversation={onForkConversation}
+								sessionId={session.id}
+								onSessionRecover={onSessionRecover}
+								isRecoveringSession={isRecoveringSession}
+								sessionRecoveryError={sessionRecoveryError}
+								fileTree={fileTree}
+								cwd={cwd}
+								projectRoot={projectRoot}
+								onFileClick={onFileClick}
+								sshRemoteId={
+									session.sessionSshRemoteConfig?.enabled
+										? (session.sessionSshRemoteConfig?.remoteId ?? undefined)
+										: undefined
+								}
+								onShowErrorDetails={onShowErrorDetails}
+								onSaveToFile={handleSaveToFile}
+								ghCliAvailable={ghCliAvailable}
+								onPublishGist={onPublishMessageGist}
+								publishedGistUrl={publishedGists[log.id]?.gistUrl}
+								bionifyReadingMode={globalBionifyReadingMode}
+								bionifyIntensity={globalBionifyIntensity}
+								bionifyAlgorithm={globalBionifyAlgorithm}
+								userMessageAlignment={userMessageAlignment}
+								isClaudeCode={session.toolType === 'claude-code'}
+								isAdaptiveMode={getClaudeTokenMode(session) === 'dynamic'}
+							/>
+						))}
 
-					{/* Queued items section - filtered to active tab */}
-					{session.executionQueue && session.executionQueue.length > 0 && (
-						<QueuedItemsList
-							executionQueue={session.executionQueue}
-							theme={theme}
-							onRemoveQueuedItem={onRemoveQueuedItem}
-							onTogglePauseQueuedItem={onTogglePauseQueuedItem}
-							onEditQueuedItem={onEditQueuedItem}
-							onReorderItems={
-								onReorderQueuedItem
-									? (fromIndex, toIndex) =>
-											onReorderQueuedItem(fromIndex, toIndex, activeTabId || undefined)
-									: undefined
-							}
-							onForceSendQueuedItem={onForceSendQueuedItem}
-							forcedParallelEnabled={forcedParallelEnabled}
-							getForceSendContext={getForceSendContext}
-							activeTabId={activeTabId || undefined}
-							onOpenLightbox={setLightboxImage}
-						/>
-					)}
+						{/* Queued items section - filtered to active tab */}
+						{session.executionQueue && session.executionQueue.length > 0 && (
+							<QueuedItemsList
+								executionQueue={session.executionQueue}
+								theme={theme}
+								onRemoveQueuedItem={onRemoveQueuedItem}
+								onTogglePauseQueuedItem={onTogglePauseQueuedItem}
+								onEditQueuedItem={onEditQueuedItem}
+								onReorderItems={
+									onReorderQueuedItem
+										? (fromIndex, toIndex) =>
+												onReorderQueuedItem(fromIndex, toIndex, activeTabId || undefined)
+										: undefined
+								}
+								onForceSendQueuedItem={onForceSendQueuedItem}
+								forcedParallelEnabled={forcedParallelEnabled}
+								getForceSendContext={getForceSendContext}
+								activeTabId={activeTabId || undefined}
+								onOpenLightbox={setLightboxImage}
+							/>
+						)}
 
-					{/* End ref for scrolling - always rendered so Cmd+Shift+J works even when busy */}
-					<div ref={logsEndRef} />
+						{/* End ref for scrolling - always rendered so Cmd+Shift+J works even when busy */}
+						<div ref={logsEndRef} />
+					</div>
 				</div>
 
 				{/* Scroll-to-bottom / auto-scroll resume (AI mode only) */}

--- a/src/renderer/components/TerminalOutput/TerminalOutput.tsx
+++ b/src/renderer/components/TerminalOutput/TerminalOutput.tsx
@@ -459,10 +459,15 @@ export const TerminalOutput = memo(
 								onOpenLightbox={setLightboxImage}
 							/>
 						)}
-
-						{/* End ref for scrolling - always rendered so Cmd+Shift+J works even when busy */}
-						<div ref={logsEndRef} />
 					</div>
+
+					{/* End ref for scrolling - always rendered so Cmd+Shift+J works even when busy.
+					    LOAD-BEARING: this marker MUST stay a direct child of the scroll container
+					    (the overflow-y-auto element above), NOT nested inside the contentRef wrapper.
+					    useMainKeyboardHandler's Alt+J "Jump to Bottom" resolves the scroll target via
+					    logsEndRef.current.parentElement, so if you wrap this marker in another subtree
+					    parentElement lands on an unscrollable element and Alt+J silently no-ops. */}
+					<div ref={logsEndRef} />
 				</div>
 
 				{/* Scroll-to-bottom / auto-scroll resume (AI mode only) */}

--- a/src/renderer/components/TerminalOutput/hooks/useTerminalOutputScroll.ts
+++ b/src/renderer/components/TerminalOutput/hooks/useTerminalOutputScroll.ts
@@ -289,6 +289,14 @@ export function useTerminalOutputScroll({
 
 	useEffect(() => {
 		return () => {
+			// The pending 200ms scrollTop save is DROPPED here, not flushed, on
+			// purpose. `onScrollPositionChange` (see useScrollLogHandlers) resolves
+			// its target from `selectActiveSession` AT CALL TIME, and during an agent
+			// swap the store already points at the NEW session by the time this
+			// component unmounts - so flushing would write the outgoing agent's
+			// offset into the incoming agent's tab. The cost is that up to the last
+			// ~200ms of scrolling is not persisted; the fix would need the callback
+			// to carry the owning sessionId/tabId, which is out of scope here.
 			if (scrollSaveTimerRef.current) {
 				clearTimeout(scrollSaveTimerRef.current);
 			}

--- a/src/renderer/components/TerminalOutput/hooks/useTerminalOutputScroll.ts
+++ b/src/renderer/components/TerminalOutput/hooks/useTerminalOutputScroll.ts
@@ -8,6 +8,13 @@ const PROGRAMMATIC_TARGET_EPSILON_PX = 4;
 
 interface UseTerminalOutputScrollOptions {
 	scrollContainerRef: React.RefObject<HTMLDivElement>;
+	/**
+	 * Inner wrapper whose height equals the scrollable content height. Optional so
+	 * callers (and tests) that do not render one keep the previous behaviour; when
+	 * present it gets a ResizeObserver that re-pins the bottom on content growth
+	 * that arrives without a DOM mutation (image decode, font load, late layout).
+	 */
+	contentRef?: React.RefObject<HTMLElement | null>;
 	initialScrollTop?: number;
 	initialIsAtBottom?: boolean;
 	sessionId: string;
@@ -19,6 +26,7 @@ interface UseTerminalOutputScrollOptions {
 
 export function useTerminalOutputScroll({
 	scrollContainerRef,
+	contentRef,
 	initialScrollTop,
 	initialIsAtBottom,
 	sessionId,
@@ -213,8 +221,31 @@ export function useTerminalOutputScroll({
 			characterData: true,
 		});
 
-		return () => observer.disconnect();
-	}, [autoScrollPaused, scrollContainerRef, jumpToBottom]);
+		// Content can grow WITHOUT any DOM mutation - an image decoding, a web font
+		// loading, markdown or tool-badge layout settling after the initial commit.
+		// The MutationObserver above is blind to that, and for a freshly swapped-in
+		// idle agent no mutations arrive at all, so the mount-time jump's one-frame
+		// scrollHeight reading is all we would ever get and the view lands above the
+		// live bottom. Watch the content wrapper instead: it is the only element
+		// whose height tracks the scrollable content (observing the scroll container
+		// would only fire on viewport resize). Same gate, same rAF, same
+		// jumpToBottom choke point, so the #1140 guard bookkeeping stays in one place.
+		const content = contentRef?.current;
+		let resizeObserver: ResizeObserver | undefined;
+		if (content && typeof ResizeObserver !== 'undefined') {
+			resizeObserver = new ResizeObserver(() => {
+				if (isAtBottomRef.current) {
+					scrollToBottom();
+				}
+			});
+			resizeObserver.observe(content);
+		}
+
+		return () => {
+			observer.disconnect();
+			resizeObserver?.disconnect();
+		};
+	}, [autoScrollPaused, scrollContainerRef, contentRef, jumpToBottom]);
 
 	// Declared BEFORE the restore effect on purpose. React runs effects in
 	// declaration order, so on mount and every tab switch this clears the latch


### PR DESCRIPTION
## Finding O1 - transcript not at bottom on agent swap (J1 was insufficient)

The transcript failed to land at the live bottom after swapping agents because the snap-to-bottom fired before async content (image decode, font load, late markdown/tool-badge layout) settled, snapping to a stale shorter bottom.

## Change
- Adds a ResizeObserver on the content wrapper that re-pins to the bottom on content growth, through the existing `jumpToBottom` guard.
- Documents why the pending scrollTop save is dropped rather than flushed on unmount.

## Validation
Type-check, ESLint, Prettier clean. Scoped test `useTerminalOutputScroll.test` -> 12 pass.

Recommended: visual spot-check (swap agents, confirm the transcript settles at the bottom once late content renders).

Base: upstream/rc. Playbook: `.maestro/playbooks/FIX-TRANSCRIPT-SCROLL-01.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Terminal output now remains pinned to the latest content when its height changes due to async layout updates (e.g., image decoding, font rendering) without DOM mutations.
  * Scrolling up to pause “follow” no longer gets overridden by these dynamic height changes.
  * Improved unmount/view-switch cleanup to avoid persisting scroll offsets to the wrong session.
* **Tests**
  * Added regression coverage for content-resize re-pinning behavior and for the “Jump to Bottom” scroll target structure required by keyboard navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->