### PR TITLE
Add per-Auto-Run model and effort override

### DIFF
--- a/docs/agent-guides/CLI-PLAYBOOKS.md
+++ b/docs/agent-guides/CLI-PLAYBOOKS.md
@@ -164,7 +164,7 @@ maestro-cli show playbook <id> [--json]
 Run a playbook (batch execution of Auto Run documents).
 
 ```bash
-maestro-cli playbook <playbook-id> [--dry-run] [--no-history] [--json] [--debug] [--verbose] [--wait]
+maestro-cli playbook <playbook-id> [--dry-run] [--no-history] [--json] [--debug] [--verbose] [--wait] [--model <model>] [--effort <effort>]
 ```
 
 Options:
@@ -175,6 +175,7 @@ Options:
 - `--debug` - Detailed debug output
 - `--verbose` - Show full prompt sent to agent on each iteration
 - `--wait` - Wait for agent to become available if busy
+- `--model <model>` / `--effort <effort>` - Run-scoped model/effort override (see [Per-run model override](#per-run-model-override))
 
 This command is lazy-loaded to avoid eager resolution of prompt templates.
 
@@ -183,7 +184,7 @@ This command is lazy-loaded to avoid eager resolution of prompt templates.
 Launch a Goal-Driven Auto Run: instead of working through a checklist of documents (the `playbook` command), pursue a single free-text objective. Each iteration spawns a FRESH agent that makes one increment of progress, self-reports how far along it is via Maestro markers, and exits, repeating until the goal is reached, a deadlock is declared, the iteration limit is hit, or progress stalls.
 
 ```bash
-maestro-cli goal-run <agent-id> "<goal>" [--exit-criteria <text>] [--max-iterations <n>] [--no-history] [--json] [--verbose]
+maestro-cli goal-run <agent-id> "<goal>" [--exit-criteria <text>] [--max-iterations <n>] [--no-history] [--json] [--verbose] [--model <model>] [--effort <effort>]
 ```
 
 Options:
@@ -193,6 +194,7 @@ Options:
 - `--no-history` - Skip writing history entries
 - `--json` - Output as JSON Lines (events: `goal_start`, `goal_iteration_start`, `goal_iteration_complete`, `goal_complete`)
 - `--verbose` - Show full prompt sent to agent on each iteration
+- `--model <model>` / `--effort <effort>` - Run-scoped model/effort override (see [Per-run model override](#per-run-model-override))
 
 Implemented by `services/goal-runner.ts` (`runGoal`), the CLI counterpart to the desktop `useGoalRunner` hook. Both drive the SAME pure engine in `src/shared/goalDriven/*` (marker parsing + exit evaluation) so CLI and desktop behave identically. Like `playbook`, it is lazy-loaded, refuses to start when the agent is busy (`services/agent-busy.ts`), and threads per-agent SSH remote + model/effort/args/env overrides into every spawn.
 
@@ -201,7 +203,7 @@ Implemented by `services/goal-runner.ts` (`runGoal`), the CLI counterpart to the
 Run one or more raw Auto Run `.md` documents without a saved playbook. Mirrors `playbook` but builds an ephemeral `Playbook` on the fly (`src/cli/commands/run-doc.ts`), then drives it through the same `batch-processor` generator. Headless and self-contained - it does **not** route through the desktop renderer (unlike `auto-run --launch`), so it runs whether or not the Maestro window is open. This is the path group-chat participants use to execute a document they just wrote.
 
 ```bash
-maestro-cli run-doc <docs...> --agent <id-or-name> [--prompt <text>] [--loop] [--max-loops <n>] [--reset-on-completion] [--dry-run] [--no-history] [--json] [--debug] [--verbose] [--no-synopsis] [--wait]
+maestro-cli run-doc <docs...> --agent <id-or-name> [--prompt <text>] [--loop] [--max-loops <n>] [--reset-on-completion] [--dry-run] [--no-history] [--json] [--debug] [--verbose] [--no-synopsis] [--wait] [--model <model>] [--effort <effort>]
 ```
 
 - `-a, --agent <id>` (required) - target agent by ID (full/partial) or display name
@@ -210,6 +212,21 @@ maestro-cli run-doc <docs...> --agent <id-or-name> [--prompt <text>] [--loop] [-
 - Busy-state detection and `--wait` are shared with `playbook` via `src/cli/services/agent-busy.ts` (`checkAgentBusy`, `waitForAgentAvailable`).
 
 Note: `resolveAgentId()` in `src/cli/services/storage.ts` resolves `--agent` by ID first, then falls back to an exact case-insensitive display-name match, so name targeting works across `run-doc`, `playbook` lookups, `list playbooks`, and `auto-run`.
+
+### Per-run model override
+
+`--model <model>` and `--effort <effort>` are registered on all four Auto Run entry points (`playbook`, `run-doc`, `goal-run`, `auto-run` in `src/cli/index.ts`). The value is **run-scoped**: it wins over `session.customModel` / `session.customEffort` for every spawn the run makes, and nothing is ever written back to the session, so the agent's interactive tabs are unaffected and the override dies with the run. Resolution order for an Auto Run spawn is `run override -> session.customModel -> agent default`.
+
+Threading, by entry point:
+
+- **Headless (`playbook`, `run-doc`, `goal-run`)** - the flag rides the command's options object into `services/goal-runner.ts` (`RunGoalOptions`) or `services/batch-processor.ts` (`runPlaybook` options), and both pass `runModel ?? session.customModel` / `runEffort ?? session.customEffort` at every `spawnAgent` call site. `agent-spawner.ts` already accepted `customModel` / `customEffort`, so it needed no change. Note the synopsis and goal-handoff spawns take the override too, so the summary runs on the same model as the work it summarizes.
+- **Desktop-routed (`auto-run`)** - the flags travel in the `configure_auto_run` WebSocket message (`commands/auto-run.ts`), are validated as optional non-empty strings in `handleConfigureAutoRun` (`src/main/web-server/handlers/messageHandlers.ts`), pass through `ConfigureAutoRunCallback` (`src/main/web-server/types.ts`) and `CallbackRegistry.configureAutoRun`, and land on the `BatchRunConfig` built in `useAppRemoteEventListeners.ts`. From there the desktop runners apply them via `spawnAgentForSession`'s `modelOverride` / `effortOverride` options.
+
+Conventions to preserve when touching this:
+
+- **Spread-when-set everywhere.** Producers use `...(model && { model })` so an unset override is absent, never an empty string. The CLI trims first (`options.model?.trim() || undefined`), so `--model "   "` reads as unset.
+- **No CLI-side validation.** Valid model names are provider-specific and only the desktop/provider layer knows them, so the CLI passes the value through. The WebSocket boundary rejects non-strings and blank strings, nothing more.
+- **The override is config, not session state.** In particular `buildWorktreeSession` (`src/renderer/utils/worktreeSession.ts`) still copies the PARENT session's `customModel` into a worktree child - do not "fix" that to use the run override. Worktree dispatch gets the override for free because it hands the same `BatchRunConfig` to the same runners.
 
 ### `send <agent-id> <message>`
 

--- a/docs/autorun-playbooks.md
+++ b/docs/autorun-playbooks.md
@@ -75,6 +75,12 @@ Auto Run supports running multiple documents in sequence:
 5. Enable **Loop Mode** to cycle back to the first document after completing the last
 6. Click **Go** to start running documents
 
+## Model Override
+
+The run configuration modal has **Model** and **Effort** pickers, both defaulting to **Use agent default**. Picking a value runs _this Auto Run only_ on that model: every task spawn in the run uses it, the agent's own configured model is left alone (its interactive tabs keep using the default), and the override is forgotten when the run ends. The pickers reset to the default each time the modal opens, and are hidden for providers that expose no model or effort options. Worktree runs honor the override too, without changing the child worktree agent's own configured model.
+
+The same override is available from the CLI as `--model` / `--effort` on `auto-run`, `playbook`, `run-doc`, and `goal-run`. See [CLI](cli.md#per-run-model-override).
+
 ## Fresh Context: Task vs Document
 
 The run configuration modal has a **Fresh context per** toggle that controls how context is scoped as the runner works through a document. This is distinct from [task granularity](#task-granularity-two-approaches) above - granularity is how you _structure_ a document, while this is how Maestro _executes_ it.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -149,46 +149,52 @@ Show detailed information about a playbook
 
 Run a playbook
 
-| Option          | Description                                                 | Default |
-| --------------- | ----------------------------------------------------------- | ------- |
-| `--dry-run`     | Show what would be executed without running                 | -       |
-| `--no-history`  | Do not write history entries                                | -       |
-| `--json`        | Output as JSON lines (for scripting)                        | -       |
-| `--debug`       | Show detailed debug output for troubleshooting              | -       |
-| `--verbose`     | Show full prompt sent to agent on each iteration            | -       |
-| `--no-synopsis` | Skip synopsis generation after each task (reduces overhead) | -       |
-| `--wait`        | Wait for agent to become available if busy                  | -       |
+| Option              | Description                                                                   | Default |
+| ------------------- | ----------------------------------------------------------------------------- | ------- |
+| `--dry-run`         | Show what would be executed without running                                   | -       |
+| `--no-history`      | Do not write history entries                                                  | -       |
+| `--json`            | Output as JSON lines (for scripting)                                          | -       |
+| `--debug`           | Show detailed debug output for troubleshooting                                | -       |
+| `--verbose`         | Show full prompt sent to agent on each iteration                              | -       |
+| `--no-synopsis`     | Skip synopsis generation after each task (reduces overhead)                   | -       |
+| `--wait`            | Wait for agent to become available if busy                                    | -       |
+| `--model <model>`   | Model to use for this run only, overriding the agent's configured default     | -       |
+| `--effort <effort>` | Reasoning effort for this run only, overriding the agent's configured default | -       |
 
 ## `maestro-cli goal-run <agent-id> <goal>`
 
 Launch a Goal-Driven Auto Run: pursue a free-text goal until done
 
-| Option                   | Description                                           | Default |
-| ------------------------ | ----------------------------------------------------- | ------- |
-| `--exit-criteria <text>` | What "done" looks like and when to declare a deadlock | -       |
-| `--max-iterations <n>`   | Cap iterations (default: infinite)                    | -       |
-| `--no-history`           | Do not write history entries                          | -       |
-| `--json`                 | Output as JSON lines (for scripting)                  | -       |
-| `--verbose`              | Show full prompt sent to agent on each iteration      | -       |
+| Option                   | Description                                                                   | Default |
+| ------------------------ | ----------------------------------------------------------------------------- | ------- |
+| `--exit-criteria <text>` | What "done" looks like and when to declare a deadlock                         | -       |
+| `--max-iterations <n>`   | Cap iterations (default: infinite)                                            | -       |
+| `--no-history`           | Do not write history entries                                                  | -       |
+| `--json`                 | Output as JSON lines (for scripting)                                          | -       |
+| `--verbose`              | Show full prompt sent to agent on each iteration                              | -       |
+| `--model <model>`        | Model to use for this run only, overriding the agent's configured default     | -       |
+| `--effort <effort>`      | Reasoning effort for this run only, overriding the agent's configured default | -       |
 
 ## `maestro-cli run-doc <docs>`
 
 Run one or more Auto Run documents headlessly (no saved playbook required)
 
-| Option                  | Description                                                               | Default |
-| ----------------------- | ------------------------------------------------------------------------- | ------- |
-| `-a, --agent <id>`      | Target agent by ID or name (use "maestro-cli list agents" to find agents) | -       |
-| `-p, --prompt <text>`   | Custom prompt for the run (defaults to the Auto Run prompt)               | -       |
-| `--loop`                | Enable looping                                                            | -       |
-| `--max-loops <n>`       | Maximum loop count (implies --loop)                                       | -       |
-| `--reset-on-completion` | Enable reset-on-completion for all documents                              | -       |
-| `--dry-run`             | Show what would be executed without running                               | -       |
-| `--no-history`          | Do not write history entries                                              | -       |
-| `--json`                | Output as JSON lines (for scripting)                                      | -       |
-| `--debug`               | Show detailed debug output for troubleshooting                            | -       |
-| `--verbose`             | Show full prompt sent to agent on each iteration                          | -       |
-| `--no-synopsis`         | Skip synopsis generation after each task (reduces overhead)               | -       |
-| `--wait`                | Wait for agent to become available if busy                                | -       |
+| Option                  | Description                                                                   | Default |
+| ----------------------- | ----------------------------------------------------------------------------- | ------- |
+| `-a, --agent <id>`      | Target agent by ID or name (use "maestro-cli list agents" to find agents)     | -       |
+| `-p, --prompt <text>`   | Custom prompt for the run (defaults to the Auto Run prompt)                   | -       |
+| `--loop`                | Enable looping                                                                | -       |
+| `--max-loops <n>`       | Maximum loop count (implies --loop)                                           | -       |
+| `--reset-on-completion` | Enable reset-on-completion for all documents                                  | -       |
+| `--dry-run`             | Show what would be executed without running                                   | -       |
+| `--no-history`          | Do not write history entries                                                  | -       |
+| `--json`                | Output as JSON lines (for scripting)                                          | -       |
+| `--debug`               | Show detailed debug output for troubleshooting                                | -       |
+| `--verbose`             | Show full prompt sent to agent on each iteration                              | -       |
+| `--no-synopsis`         | Skip synopsis generation after each task (reduces overhead)                   | -       |
+| `--wait`                | Wait for agent to become available if busy                                    | -       |
+| `--model <model>`       | Model to use for this run only, overriding the agent's configured default     | -       |
+| `--effort <effort>`     | Reasoning effort for this run only, overriding the agent's configured default | -       |
 
 ## `maestro-cli clean`
 
@@ -218,11 +224,34 @@ Send a message to an agent and get a JSON response
 
 Dispatch a prompt to an agent in the Maestro desktop app and return its tab/session ID
 
-| Option           | Description                                                                                                                                          | Default |
-| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| `--new-tab`      | Create a fresh AI tab and dispatch the prompt into it                                                                                                | -       |
-| `-t, --tab <id>` | Target an existing tab by its tab id (mutually exclusive with --new-tab)                                                                             | -       |
-| `-f, --force`    | Bypass the busy-state guard when writing to a busy tab; requires allowConcurrentSend (cannot be combined with --new-tab - a fresh tab is never busy) | -       |
+| Option           | Description                                                                                                                                                                                                           | Default |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `--new-tab`      | Create a fresh AI tab and dispatch the prompt into it                                                                                                                                                                 | -       |
+| `-t, --tab <id>` | Target an existing tab by its tab id (mutually exclusive with --new-tab)                                                                                                                                              | -       |
+| `-f, --force`    | Bypass the busy-state guard when writing to a busy tab; requires allowConcurrentSend (cannot be combined with --new-tab - a fresh tab is never busy)                                                                  | -       |
+| `--focus`        | Switch to and focus the target agent/tab when dispatching (by default dispatch runs in the background without stealing focus)                                                                                         | -       |
+| `--queue`        | If the target tab is busy, queue the prompt into the execution queue (FIFO) instead of rejecting it; an idle target dispatches immediately. Cannot be combined with --new-tab or --force. Returns the queue position. | -       |
+| `--wait`         | Alias for --queue                                                                                                                                                                                                     | -       |
+
+## `maestro-cli queue`
+
+Inspect and manage the desktop execution queue (from dispatch --queue)
+
+## `maestro-cli queue list`
+
+List queued execution items as JSON (all agents, or one with --agent)
+
+| Option             | Description                                                             | Default |
+| ------------------ | ----------------------------------------------------------------------- | ------- |
+| `-a, --agent <id>` | Only list items for this agent (default: every agent with queued items) | -       |
+
+## `maestro-cli queue remove <item-id>`
+
+Remove a queued item by its id (from dispatch --queue output or queue list)
+
+| Option             | Description                                      | Default |
+| ------------------ | ------------------------------------------------ | ------- |
+| `-a, --agent <id>` | Agent whose queue the item belongs to (required) | -       |
 
 ## `maestro-cli session`
 
@@ -314,6 +343,8 @@ Configure and optionally launch an auto-run with documents
 | `--worktree-path <path>`      | Filesystem path for the worktree (must be a sibling of the repo)                                                        | -       |
 | `--create-pr`                 | Open a GitHub PR when the auto-run completes successfully                                                               | -       |
 | `--pr-target-branch <branch>` | Target branch for the PR (defaults to the repo default branch)                                                          | -       |
+| `--model <model>`             | Model to use for this run only, overriding the agent's configured default                                               | -       |
+| `--effort <effort>`           | Reasoning effort for this run only, overriding the agent's configured default                                           | -       |
 
 ## `maestro-cli stop-auto-run`
 
@@ -1200,6 +1231,19 @@ Close a cadenza view by id
 
 Compose the agent-driven movement (free-placed data views) in the Maestro main window
 
+## `maestro-cli movement begin <id>`
+
+Immediately show a host-rendered Concerto shell before its HTML is ready
+
+| Option           | Description                                  | Default |
+| ---------------- | -------------------------------------------- | ------- |
+| `--title <text>` | Concerto title shown in its frame            | -       |
+| `--x <px>`       | X position (px from the Concerto stage left) | -       |
+| `--y <px>`       | Y position (px from the Concerto stage top)  | -       |
+| `--width <px>`   | Shell width in px (default: 880)             | -       |
+| `--height <px>`  | Shell height in px (default: 560)            | -       |
+| `--json`         | Output as JSON (for scripting)               | -       |
+
 ## `maestro-cli movement add <id>`
 
 Add (or replace by id) a native data view or interactive HTML mockup
@@ -1259,6 +1303,19 @@ Remove all movement items
 | Option   | Description                    | Default |
 | -------- | ------------------------------ | ------- |
 | `--json` | Output as JSON (for scripting) | -       |
+
+## `maestro-cli movement progress <id>`
+
+Report one Concerto track's current design phase and subdivision
+
+| Option              | Description                                                                           | Default |
+| ------------------- | ------------------------------------------------------------------------------------- | ------- |
+| `--title <text>`    | Concerto title shown in the pipeline                                                  | -       |
+| `--phase <phase>`   | composing \| refining \| arranging \| reviewing \| testing                            | -       |
+| `--step <n>`        | Active one-based substep (default: 1)                                                 | -       |
+| `--steps <n>`       | Planned substeps in this phase, 1 through 8 (default: 1)                              | -       |
+| `--notes <pattern>` | Comma-separated quarter/eighth/sixteenth notes with optional +dotted, +triad, or +tie | -       |
+| `--json`            | Output as JSON (for scripting)                                                        | -       |
 
 ## `maestro-cli movement state`
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -576,6 +576,9 @@ maestro-cli playbook <playbook-id> --wait --verbose
 # Debug mode for troubleshooting
 maestro-cli playbook <playbook-id> --debug
 
+# Run this playbook on a different model than the agent's default
+maestro-cli playbook <playbook-id> --model opus --effort high
+
 # Clean orphaned playbooks (for deleted sessions)
 maestro-cli clean playbooks
 maestro-cli clean playbooks --dry-run
@@ -604,15 +607,20 @@ maestro-cli goal-run <agent-id> "Tidy the codebase" --verbose
 
 # Run without writing history entries
 maestro-cli goal-run <agent-id> "Quick experiment" --no-history
+
+# Pursue the goal on a different model than the agent's default
+maestro-cli goal-run <agent-id> "Port the parser to the new API" --model opus --effort high
 ```
 
-| Option                   | Description                                              | Default    |
-| ------------------------ | -------------------------------------------------------- | ---------- |
-| `--exit-criteria <text>` | What "done" looks like and when to declare a deadlock    | _(none)_   |
-| `--max-iterations <n>`   | Cap the number of iterations                             | Infinite   |
-| `--no-history`           | Do not write history entries                             | Writes     |
-| `--json`                 | Output as JSON lines (for scripting)                     | Human text |
-| `--verbose`              | Show the full prompt sent to the agent on each iteration | Off        |
+| Option                   | Description                                                                   | Default       |
+| ------------------------ | ----------------------------------------------------------------------------- | ------------- |
+| `--exit-criteria <text>` | What "done" looks like and when to declare a deadlock                         | _(none)_      |
+| `--max-iterations <n>`   | Cap the number of iterations                                                  | Infinite      |
+| `--no-history`           | Do not write history entries                                                  | Writes        |
+| `--json`                 | Output as JSON lines (for scripting)                                          | Human text    |
+| `--verbose`              | Show the full prompt sent to the agent on each iteration                      | Off           |
+| `--model <model>`        | Model to use for this run only, overriding the agent's configured default     | Agent default |
+| `--effort <effort>`      | Reasoning effort for this run only, overriding the agent's configured default | Agent default |
 
 The run writes an immediate "started" history entry (recording the goal and exit criteria), one entry per iteration, and a final summary with the stop reason and final progress. Goal-Driven runs honor the same per-agent SSH remote and model/effort/args overrides as `playbook`, and refuse to start if the agent is already busy in the desktop app or another CLI instance.
 
@@ -635,9 +643,45 @@ maestro-cli run-doc plans/migrate.md --agent <agent-id> --wait --loop
 
 # JSON output for scripting; skip history writes
 maestro-cli run-doc plans/spec.md --agent <agent-id> --json --no-history
+
+# Run this document on a different model than the agent's default
+maestro-cli run-doc plans/spec.md --agent <agent-id> --model opus --effort high
 ```
 
-`run-doc` accepts the same execution flags as `playbook` (`--dry-run`, `--no-history`, `--json`, `--debug`, `--verbose`, `--no-synopsis`, `--wait`) plus `--prompt`, `--loop`, `--max-loops`, and `--reset-on-completion`. When no `--prompt` is given it uses the default Auto Run prompt.
+`run-doc` accepts the same execution flags as `playbook` (`--dry-run`, `--no-history`, `--json`, `--debug`, `--verbose`, `--no-synopsis`, `--wait`, `--model`, `--effort`) plus `--prompt`, `--loop`, `--max-loops`, and `--reset-on-completion`. When no `--prompt` is given it uses the default Auto Run prompt.
+
+#### Per-run model override
+
+All four Auto Run entry points - `playbook`, `run-doc`, `goal-run`, and
+`auto-run` - accept `--model <model>` and `--effort <effort>`. Both are
+**run-scoped**: they apply to every agent spawn the run makes (including the
+per-task synopsis and goal-handoff spawns) and take precedence over the agent's
+configured model, but nothing is written back to the agent. When the run ends,
+the agent is exactly as it was.
+
+```bash
+maestro-cli playbook <playbook-id> --model opus
+maestro-cli run-doc plans/spec.md --agent <agent-id> --model opus
+maestro-cli goal-run <agent-id> "Ship the migration" --model opus --effort high
+maestro-cli auto-run doc1.md --agent <agent-id> --launch --model opus
+```
+
+Notes:
+
+- Omitting the flags keeps the existing behavior exactly: the run uses the
+  agent's configured model and effort.
+- Valid values are provider-specific (for example `sonnet` / `opus` for Claude
+  Code). The CLI passes the value through rather than validating it against the
+  provider's model list.
+- `--effort` only does something on providers that expose a reasoning-effort
+  setting; it is ignored elsewhere.
+- The headless commands (`playbook`, `run-doc`, `goal-run`) print a
+  `Model: <value> (this run only)` line in human-readable (non-`--json`) output
+  so you can confirm which model the run used. JSONL output is unchanged.
+  `auto-run` hands the run to the desktop app, so confirm that one in the
+  desktop UI instead.
+- The desktop Auto Run launch modal has the same two pickers, both defaulting to
+  "Use agent default". See [Auto Run](autorun-playbooks.md).
 
 > **`playbook` vs `run-doc` vs `auto-run --launch`:** use `playbook <id>` for a saved playbook and `run-doc <docs>` for raw documents - both run headlessly with no desktop dependency. `auto-run --launch` instead hands the run to the running desktop app (needed only when you want the run to appear and be controlled in the desktop UI).
 
@@ -1170,6 +1214,12 @@ maestro-cli auto-run doc1.md --agent <agent-id> --launch \
 maestro-cli auto-run doc1.md --agent <agent-id> --launch \
   --worktree --branch feature/auto-x --worktree-path ../repo-auto-x \
   --create-pr --pr-target-branch develop
+
+# Run this one auto-run on a different model than the agent's default
+maestro-cli auto-run doc1.md --agent <agent-id> --launch --model opus
+
+# Override the reasoning effort too (provider-dependent)
+maestro-cli auto-run doc1.md --agent <agent-id> --launch --model opus --effort high
 ```
 
 | Flag                          | Description                                                                                     |
@@ -1186,6 +1236,15 @@ maestro-cli auto-run doc1.md --agent <agent-id> --launch \
 | `--worktree-path <path>`      | Filesystem path for the worktree (must be a sibling of the repo, not nested inside it)          |
 | `--create-pr`                 | Open a GitHub PR when the auto-run completes successfully                                       |
 | `--pr-target-branch <branch>` | Target branch for the PR (defaults to the repo's default branch)                                |
+| `--model <model>`             | Model to use for this run only, overriding the agent's configured default                       |
+| `--effort <effort>`           | Reasoning effort for this run only, overriding the agent's configured default                   |
+
+`--model` and `--effort` are **run-scoped**: they apply to every task spawn in
+this auto-run and are never written back to the agent. The agent's interactive
+tabs keep using its configured default, and the override disappears when the run
+ends. Omit them to use the agent default. They are honored in worktree mode too,
+without changing the child worktree session's own configured model. See
+[Per-run model override](#per-run-model-override) for the full picture.
 
 Worktree mode reuses the desktop app's Auto Run pipeline: the app creates the
 worktree (or reuses an existing one on the same repo), checks out the requested

--- a/src/__tests__/cli/commands/auto-run.test.ts
+++ b/src/__tests__/cli/commands/auto-run.test.ts
@@ -464,6 +464,91 @@ describe('auto-run command', () => {
 		expect(sentMessage!.worktree).toBeUndefined();
 	});
 
+	describe('per-run model/effort override', () => {
+		/**
+		 * Wire up a client whose sendCommand captures the outgoing message, so a
+		 * test can assert on the `configure_auto_run` payload the CLI ships.
+		 */
+		const captureSentMessage = (): (() => Record<string, unknown> | undefined) => {
+			let sentMessage: Record<string, unknown> | undefined;
+			vi.mocked(existsSync).mockReturnValue(true);
+			vi.mocked(resolveTargetSessionId).mockReturnValue('agent-123');
+			vi.mocked(withMaestroClient).mockImplementation(async (action) => {
+				const mockClient = {
+					sendCommand: vi.fn().mockImplementation((msg) => {
+						sentMessage = msg;
+						return Promise.resolve({
+							type: 'configure_auto_run_result',
+							success: true,
+						});
+					}),
+				};
+				return action(mockClient as never);
+			});
+			return () => sentMessage;
+		};
+
+		it('should send model and effort when --model and --effort are provided', async () => {
+			const getSent = captureSentMessage();
+
+			await autoRun(['/path/to/doc.md'], {
+				agent: 'agent-123',
+				launch: true,
+				model: 'opus',
+				effort: 'high',
+			});
+
+			const sentMessage = getSent();
+			expect(sentMessage).toBeDefined();
+			expect(sentMessage!.model).toBe('opus');
+			expect(sentMessage!.effort).toBe('high');
+		});
+
+		it('should omit model and effort entirely when the flags are not provided', async () => {
+			const getSent = captureSentMessage();
+
+			await autoRun(['/path/to/doc.md'], { agent: 'agent-123', launch: true });
+
+			const sentMessage = getSent();
+			expect(sentMessage).toBeDefined();
+			// Absent (not `undefined`) so an unset flag never serializes across the
+			// WebSocket boundary and the agent default stays in effect.
+			expect('model' in sentMessage!).toBe(false);
+			expect('effort' in sentMessage!).toBe(false);
+		});
+
+		it('should treat whitespace-only --model/--effort as unset', async () => {
+			const getSent = captureSentMessage();
+
+			await autoRun(['/path/to/doc.md'], {
+				agent: 'agent-123',
+				launch: true,
+				model: '   ',
+				effort: '\t',
+			});
+
+			const sentMessage = getSent();
+			expect(sentMessage).toBeDefined();
+			expect('model' in sentMessage!).toBe(false);
+			expect('effort' in sentMessage!).toBe(false);
+		});
+
+		it('should send model without effort when only --model is provided', async () => {
+			const getSent = captureSentMessage();
+
+			await autoRun(['/path/to/doc.md'], {
+				agent: 'agent-123',
+				launch: true,
+				model: 'sonnet',
+			});
+
+			const sentMessage = getSent();
+			expect(sentMessage).toBeDefined();
+			expect(sentMessage!.model).toBe('sonnet');
+			expect('effort' in sentMessage!).toBe(false);
+		});
+	});
+
 	it('should error when server returns failure', async () => {
 		vi.mocked(existsSync).mockReturnValue(true);
 		vi.mocked(resolveTargetSessionId).mockReturnValue('agent-123');

--- a/src/__tests__/cli/services/batch-processor.test.ts
+++ b/src/__tests__/cli/services/batch-processor.test.ts
@@ -464,6 +464,87 @@ describe('batch-processor', () => {
 			expect(promptArg).toContain('My task');
 		});
 
+		describe('per-run model/effort override', () => {
+			/** Feed the loop exactly one task, then report the document as drained. */
+			const singleTask = (): void => {
+				let callCount = 0;
+				vi.mocked(readDocAndCountTasks).mockImplementation(() => {
+					callCount++;
+					if (callCount <= 3) return { content: '- [ ] My task', taskCount: 1 };
+					return { content: '', taskCount: 0 };
+				});
+			};
+
+			it('lets the run model/effort win over the session values on the task spawn', async () => {
+				singleTask();
+				const session = mockSession({ customModel: 'opus', customEffort: 'high' });
+
+				await collectEvents(
+					runPlaybook(session, mockPlaybook(), '/playbooks', {
+						model: 'sonnet',
+						effort: 'low',
+					})
+				);
+
+				const taskSpawnOpts = vi.mocked(spawnAgent).mock.calls[0][4];
+				expect(taskSpawnOpts).toMatchObject({ customModel: 'sonnet', customEffort: 'low' });
+				// Run-scoped: the session object is never rewritten.
+				expect(session.customModel).toBe('opus');
+				expect(session.customEffort).toBe('high');
+			});
+
+			it('falls back to the session values when no run override is given', async () => {
+				singleTask();
+
+				await collectEvents(
+					runPlaybook(
+						mockSession({ customModel: 'opus', customEffort: 'high' }),
+						mockPlaybook(),
+						'/playbooks'
+					)
+				);
+
+				const taskSpawnOpts = vi.mocked(spawnAgent).mock.calls[0][4];
+				expect(taskSpawnOpts).toMatchObject({ customModel: 'opus', customEffort: 'high' });
+			});
+
+			it('falls back per field when only the model is overridden', async () => {
+				singleTask();
+
+				await collectEvents(
+					runPlaybook(
+						mockSession({ customModel: 'opus', customEffort: 'high' }),
+						mockPlaybook(),
+						'/playbooks',
+						{ model: 'sonnet' }
+					)
+				);
+
+				const taskSpawnOpts = vi.mocked(spawnAgent).mock.calls[0][4];
+				expect(taskSpawnOpts).toMatchObject({ customModel: 'sonnet', customEffort: 'high' });
+			});
+
+			it('applies the run override to the synopsis spawn too', async () => {
+				singleTask();
+				vi.mocked(spawnAgent).mockResolvedValue({
+					success: true,
+					response: '**Summary:** ok\n**Details:** ok',
+					agentSessionId: 'claude-session-123',
+				});
+
+				await collectEvents(
+					runPlaybook(mockSession({ customModel: 'opus' }), mockPlaybook(), '/playbooks', {
+						model: 'sonnet',
+					})
+				);
+
+				// Index 0 = task spawn, index 1 = synopsis resume.
+				expect(vi.mocked(spawnAgent).mock.calls.length).toBeGreaterThanOrEqual(2);
+				const synopsisSpawnOpts = vi.mocked(spawnAgent).mock.calls[1][4];
+				expect(synopsisSpawnOpts).toMatchObject({ customModel: 'sonnet' });
+			});
+		});
+
 		it('should track usage statistics', async () => {
 			const usageStats: UsageStats = {
 				inputTokens: 1000,

--- a/src/__tests__/cli/services/goal-runner.test.ts
+++ b/src/__tests__/cli/services/goal-runner.test.ts
@@ -310,4 +310,62 @@ describe('goal-runner (runGoal)', () => {
 			sshRemoteConfig: { enabled: true, remoteId: 'remote-1' },
 		});
 	});
+
+	describe('per-run model/effort override', () => {
+		it('lets the run model/effort win over the session values', async () => {
+			const session = mockSession({ customModel: 'opus', customEffort: 'high' });
+
+			await collectEvents(runGoal(session, goalConfig(), { model: 'sonnet', effort: 'low' }));
+
+			const opts = vi.mocked(spawnAgent).mock.calls[0][4];
+			expect(opts).toMatchObject({ customModel: 'sonnet', customEffort: 'low' });
+			// The override is run-scoped: the session object itself is untouched.
+			expect(session.customModel).toBe('opus');
+			expect(session.customEffort).toBe('high');
+		});
+
+		it('falls back to the session values when no run override is given', async () => {
+			await collectEvents(
+				runGoal(mockSession({ customModel: 'opus', customEffort: 'high' }), goalConfig())
+			);
+
+			const opts = vi.mocked(spawnAgent).mock.calls[0][4];
+			expect(opts).toMatchObject({ customModel: 'opus', customEffort: 'high' });
+		});
+
+		it('falls back per field when only the model is overridden', async () => {
+			await collectEvents(
+				runGoal(mockSession({ customModel: 'opus', customEffort: 'high' }), goalConfig(), {
+					model: 'sonnet',
+				})
+			);
+
+			const opts = vi.mocked(spawnAgent).mock.calls[0][4];
+			expect(opts).toMatchObject({ customModel: 'sonnet', customEffort: 'high' });
+		});
+
+		it('applies the run override to the handoff synopsis spawn too', async () => {
+			const responses = [progressResponse(40, 'phase 1'), progressResponse(100, 'done')];
+			let iterCall = 0;
+			vi.mocked(spawnAgent).mockImplementation(async (_tool, _cwd, _prompt, agentSessionId) => {
+				if (agentSessionId) {
+					return { success: true, response: 'handoff note', agentSessionId };
+				}
+				return {
+					success: true,
+					response: responses[iterCall++],
+					agentSessionId: `agent-${iterCall}`,
+				};
+			});
+
+			await collectEvents(
+				runGoal(mockSession({ customModel: 'opus' }), goalConfig(), { model: 'sonnet' })
+			);
+
+			// Call 1 is the handoff resume - it must summarize on the same model the
+			// iteration it summarizes actually ran on.
+			const handoffOpts = vi.mocked(spawnAgent).mock.calls[1][4];
+			expect(handoffOpts).toMatchObject({ customModel: 'sonnet' });
+		});
+	});
 });

--- a/src/__tests__/main/web-server/handlers/messageHandlers.test.ts
+++ b/src/__tests__/main/web-server/handlers/messageHandlers.test.ts
@@ -1847,6 +1847,100 @@ describe('WebSocketMessageHandler', () => {
 			expect(callbacks.configureAutoRun).not.toHaveBeenCalled();
 		});
 
+		it('should forward per-run model and effort overrides', async () => {
+			(callbacks.configureAutoRun as any).mockResolvedValue({ success: true });
+
+			handler.handleMessage(client, {
+				type: 'configure_auto_run',
+				sessionId: 'session-1',
+				documents: [{ filename: 'doc1.md' }],
+				launch: true,
+				model: 'opus',
+				effort: 'high',
+			});
+
+			await vi.waitFor(() => {
+				expect(callbacks.configureAutoRun).toHaveBeenCalledWith(
+					'session-1',
+					expect.objectContaining({ model: 'opus', effort: 'high' })
+				);
+			});
+		});
+
+		it('should leave model and effort undefined when not provided', async () => {
+			(callbacks.configureAutoRun as any).mockResolvedValue({ success: true });
+
+			handler.handleMessage(client, {
+				type: 'configure_auto_run',
+				sessionId: 'session-1',
+				documents: [{ filename: 'doc1.md' }],
+				launch: true,
+			});
+
+			await vi.waitFor(() => {
+				expect(callbacks.configureAutoRun).toHaveBeenCalled();
+			});
+			const config = (callbacks.configureAutoRun as any).mock.calls[0][1];
+			expect(config.model).toBeUndefined();
+			expect(config.effort).toBeUndefined();
+		});
+
+		it('should reject non-string model', () => {
+			handler.handleMessage(client, {
+				type: 'configure_auto_run',
+				sessionId: 'session-1',
+				documents: [{ filename: 'doc1.md' }],
+				model: 42,
+			});
+
+			const response = JSON.parse((client.socket.send as any).mock.calls[0][0]);
+			expect(response.type).toBe('error');
+			expect(response.message).toContain('model must be a non-empty string');
+			expect(callbacks.configureAutoRun).not.toHaveBeenCalled();
+		});
+
+		it('should reject empty/whitespace model', () => {
+			handler.handleMessage(client, {
+				type: 'configure_auto_run',
+				sessionId: 'session-1',
+				documents: [{ filename: 'doc1.md' }],
+				model: '   ',
+			});
+
+			const response = JSON.parse((client.socket.send as any).mock.calls[0][0]);
+			expect(response.type).toBe('error');
+			expect(response.message).toContain('model must be a non-empty string');
+			expect(callbacks.configureAutoRun).not.toHaveBeenCalled();
+		});
+
+		it('should reject non-string effort', () => {
+			handler.handleMessage(client, {
+				type: 'configure_auto_run',
+				sessionId: 'session-1',
+				documents: [{ filename: 'doc1.md' }],
+				effort: { level: 'high' },
+			});
+
+			const response = JSON.parse((client.socket.send as any).mock.calls[0][0]);
+			expect(response.type).toBe('error');
+			expect(response.message).toContain('effort must be a non-empty string');
+			expect(callbacks.configureAutoRun).not.toHaveBeenCalled();
+		});
+
+		it('should reject empty effort', () => {
+			handler.handleMessage(client, {
+				type: 'configure_auto_run',
+				sessionId: 'session-1',
+				documents: [{ filename: 'doc1.md' }],
+				effort: '',
+			});
+
+			const response = JSON.parse((client.socket.send as any).mock.calls[0][0]);
+			expect(response.type).toBe('error');
+			expect(response.message).toContain('effort must be a non-empty string');
+			expect(callbacks.configureAutoRun).not.toHaveBeenCalled();
+		});
+
 		it('should handle missing configureAutoRun callback', () => {
 			const handlerNoCallbacks = new WebSocketMessageHandler();
 			handlerNoCallbacks.setCallbacks({

--- a/src/__tests__/renderer/components/BatchRunnerModal.test.tsx
+++ b/src/__tests__/renderer/components/BatchRunnerModal.test.tsx
@@ -3143,3 +3143,121 @@ describe('Auto Run Fresh-Context Mode Auto-Selection', () => {
 		).toBeInTheDocument();
 	});
 });
+
+describe('BatchRunnerModal - per-run model/effort override', () => {
+	// The pickers are ephemeral by design: they open on "Use agent default" every
+	// time and only reach the launched config when the user picks something.
+	const setupSession = async (toolType = 'claude-code') => {
+		const { useSessionStore } = await import('../../../renderer/stores/sessionStore');
+		const session = {
+			id: 'session-123',
+			name: 'Test Agent',
+			toolType,
+			cwd: '/project',
+			fullPath: '/project',
+			projectRoot: '/project',
+			state: 'idle',
+			tabs: [],
+			aiTabs: [],
+			activeTabIndex: 0,
+			isGitRepo: true,
+			isLive: false,
+			changedFiles: [],
+			fileTree: [],
+			fileExplorerExpanded: [],
+			fileExplorerScrollPos: 0,
+		};
+		useSessionStore.setState({ sessions: [session as never], activeSessionId: 'session-123' });
+	};
+
+	beforeEach(async () => {
+		vi.clearAllMocks();
+		await setupSession();
+		(window.maestro as Record<string, unknown>).playbooks = {
+			list: vi.fn().mockResolvedValue({ success: true, playbooks: [] }),
+			create: vi.fn().mockResolvedValue({ success: true, playbook: createMockPlaybook() }),
+			update: vi.fn().mockResolvedValue({ success: true, playbook: createMockPlaybook() }),
+			delete: vi.fn().mockResolvedValue({ success: true }),
+			export: vi.fn().mockResolvedValue({ success: true }),
+			import: vi.fn().mockResolvedValue({ success: true, playbook: createMockPlaybook() }),
+		};
+		window.maestro.agents.getModels = vi.fn().mockResolvedValue(['sonnet', 'opus']);
+		window.maestro.agents.getConfigOptions = vi
+			.fn()
+			.mockImplementation(async (_agentId: string, key: string) =>
+				key === 'effort' ? ['low', 'high'] : []
+			);
+	});
+
+	afterEach(async () => {
+		const { useSessionStore } = await import('../../../renderer/stores/sessionStore');
+		useSessionStore.setState({ sessions: [], activeSessionId: '' });
+		vi.restoreAllMocks();
+	});
+
+	it('omits model and effort from the launched config when both pickers are untouched', async () => {
+		const props = createDefaultProps();
+		render(<BatchRunnerModal {...props} />);
+
+		await waitFor(() => {
+			expect(screen.getByLabelText('Model for this run')).toHaveValue('');
+		});
+		expect(screen.getByLabelText('Reasoning effort for this run')).toHaveValue('');
+
+		fireEvent.click(screen.getByRole('button', { name: 'Go' }));
+
+		const config = (props.onGo as ReturnType<typeof vi.fn>).mock.calls[0][0];
+		expect(config).not.toHaveProperty('model');
+		expect(config).not.toHaveProperty('effort');
+	});
+
+	it('includes the picked model and effort in the launched config', async () => {
+		const props = createDefaultProps();
+		render(<BatchRunnerModal {...props} />);
+
+		await waitFor(() => {
+			expect(screen.getByLabelText('Model for this run')).toBeInTheDocument();
+		});
+
+		fireEvent.change(screen.getByLabelText('Model for this run'), { target: { value: 'opus' } });
+		fireEvent.change(screen.getByLabelText('Reasoning effort for this run'), {
+			target: { value: 'high' },
+		});
+
+		fireEvent.click(screen.getByRole('button', { name: 'Go' }));
+
+		expect(props.onGo).toHaveBeenCalledWith(
+			expect.objectContaining({ model: 'opus', effort: 'high' })
+		);
+	});
+
+	it('includes only the field the user picked', async () => {
+		const props = createDefaultProps();
+		render(<BatchRunnerModal {...props} />);
+
+		await waitFor(() => {
+			expect(screen.getByLabelText('Model for this run')).toBeInTheDocument();
+		});
+
+		fireEvent.change(screen.getByLabelText('Model for this run'), { target: { value: 'opus' } });
+		fireEvent.click(screen.getByRole('button', { name: 'Go' }));
+
+		const config = (props.onGo as ReturnType<typeof vi.fn>).mock.calls[0][0];
+		expect(config.model).toBe('opus');
+		expect(config).not.toHaveProperty('effort');
+	});
+
+	it('hides the whole section when the provider exposes no models or efforts', async () => {
+		window.maestro.agents.getModels = vi.fn().mockResolvedValue([]);
+		window.maestro.agents.getConfigOptions = vi.fn().mockResolvedValue([]);
+
+		const props = createDefaultProps();
+		render(<BatchRunnerModal {...props} />);
+
+		await waitFor(() => {
+			expect(window.maestro.agents.getModels).toHaveBeenCalled();
+		});
+		expect(screen.queryByLabelText('Model for this run')).not.toBeInTheDocument();
+		expect(screen.queryByLabelText('Reasoning effort for this run')).not.toBeInTheDocument();
+	});
+});

--- a/src/__tests__/renderer/hooks/agent/internal/useAgentExitListener.test.tsx
+++ b/src/__tests__/renderer/hooks/agent/internal/useAgentExitListener.test.tsx
@@ -203,8 +203,9 @@ describe('useAgentExitListener', () => {
 		expect(processQueuedItem).not.toHaveBeenCalled();
 	});
 
-	// Desktop document/spec-mode Auto Run synopsizes each task from this exit path
-	// (not spawnBackgroundSynopsis), so the run-scoped model override must reach the
+	// Desktop document/spec-mode Auto Run synopsizes each task from this exit path,
+	// which sets up the synopsis and dispatches it via runExitSynopsis (reaching
+	// spawnBackgroundSynopsisRef), so the run-scoped model override must reach the
 	// synopsis spawn config here for parity with the CLI batch processor.
 	function setupSynopsisRun(opts: { sessionCustomModel?: string; runModelOverride?: string }) {
 		const tab = createMockAITab({

--- a/src/__tests__/renderer/hooks/agent/internal/useAgentExitListener.test.tsx
+++ b/src/__tests__/renderer/hooks/agent/internal/useAgentExitListener.test.tsx
@@ -2,6 +2,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useAgentExitListener } from '../../../../../renderer/hooks/agent/internal/useAgentExitListener';
 import { useSessionStore } from '../../../../../renderer/stores/sessionStore';
+import { DEFAULT_BATCH_STATE } from '../../../../../renderer/hooks/batch/batchReducer';
+import type { BatchRunState } from '../../../../../renderer/types';
 import { createMockSession } from '../../../../helpers/mockSession';
 import { createMockAITab } from '../../../../helpers/mockTab';
 
@@ -199,6 +201,84 @@ describe('useAgentExitListener', () => {
 		expect(updated.orphanedThinkingTabs).toBeUndefined();
 		expect(updated.state).toBe('idle');
 		expect(processQueuedItem).not.toHaveBeenCalled();
+	});
+
+	// Desktop document/spec-mode Auto Run synopsizes each task from this exit path
+	// (not spawnBackgroundSynopsis), so the run-scoped model override must reach the
+	// synopsis spawn config here for parity with the CLI batch processor.
+	function setupSynopsisRun(opts: { sessionCustomModel?: string; runModelOverride?: string }) {
+		const tab = createMockAITab({
+			id: 'tab-1',
+			state: 'busy',
+			thinkingStartTime: 0,
+			agentSessionId: 'asid-1',
+			// Auto Run tabs opt into the exit-path synopsis via saveToHistory.
+			saveToHistory: true,
+			// Thinking on -> tool logs are recorded, so the activity gate trusts the
+			// tool log below as evidence of meaningful work.
+			showThinking: 'on',
+			logs: [
+				{ id: 'l-user', timestamp: 1, source: 'user', text: 'do the task' },
+				{ id: 'l-tool', timestamp: 2, source: 'tool', text: 'Edit(file.ts)' },
+			],
+		} as any);
+		const session = createMockSession({
+			id: 'sess-1',
+			aiTabs: [tab],
+			activeTabId: 'tab-1',
+			state: 'busy',
+			customModel: opts.sessionCustomModel,
+		});
+		useSessionStore.setState({ sessions: [session] } as any);
+
+		const spawn = vi.fn().mockResolvedValue({ success: false });
+		const deps = makeDeps();
+		deps.spawnBackgroundSynopsisRef.current = spawn as any;
+		// runExitSynopsis bails before spawning unless a history-entry sink exists.
+		deps.addHistoryEntryRef.current = vi.fn() as any;
+		// The active run exposes its per-run model override via getBatchStateRef.
+		const batchState: BatchRunState = {
+			...DEFAULT_BATCH_STATE,
+			isRunning: true,
+			runModelOverride: opts.runModelOverride,
+		};
+		deps.getBatchStateRef.current = (() => batchState) as any;
+		return { deps, spawn };
+	}
+
+	it('spawns the exit-path synopsis under the run model override, not the session model', async () => {
+		const { deps, spawn } = setupSynopsisRun({
+			sessionCustomModel: 'session-sonnet',
+			runModelOverride: 'run-opus',
+		});
+
+		renderHook(() => useAgentExitListener(deps));
+		await act(async () => {
+			await handler!('sess-1-ai-tab-1', 0);
+			await new Promise((r) => setTimeout(r, 0));
+		});
+
+		expect(spawn).toHaveBeenCalledTimes(1);
+		// 6th arg is the synopsis sessionConfig.
+		const sessionConfig = spawn.mock.calls[0][5];
+		expect(sessionConfig.customModel).toBe('run-opus');
+	});
+
+	it('falls back to the session model when the run has no model override', async () => {
+		const { deps, spawn } = setupSynopsisRun({
+			sessionCustomModel: 'session-sonnet',
+			runModelOverride: undefined,
+		});
+
+		renderHook(() => useAgentExitListener(deps));
+		await act(async () => {
+			await handler!('sess-1-ai-tab-1', 0);
+			await new Promise((r) => setTimeout(r, 0));
+		});
+
+		expect(spawn).toHaveBeenCalledTimes(1);
+		const sessionConfig = spawn.mock.calls[0][5];
+		expect(sessionConfig.customModel).toBe('session-sonnet');
 	});
 
 	it('deletes activeHiddenToolRef entry on AI exit', async () => {

--- a/src/__tests__/renderer/hooks/useAgentExecution.test.ts
+++ b/src/__tests__/renderer/hooks/useAgentExecution.test.ts
@@ -253,6 +253,131 @@ describe('useAgentExecution', () => {
 		await spawnPromise;
 	});
 
+	describe('per-run model/effort overrides', () => {
+		// The Auto Run spawn path has no active tab, so a run-scoped override
+		// simply has to win over the session's configured model/effort. Nothing
+		// is written back to the session: the override dies with the run.
+		const renderExecution = (session: Session) => {
+			const sessionsRef = { current: [session] };
+			return renderHook(() =>
+				useAgentExecution({
+					activeSessionId: session.id,
+					sessionsRef,
+					setSessions: vi.fn(),
+					processQueuedItemRef: { current: null },
+					setFlashNotification: vi.fn(),
+					setSuccessFlashNotification: vi.fn(),
+				})
+			);
+		};
+
+		it('lets modelOverride/effortOverride win over the session values', async () => {
+			const session = createMockSession({
+				state: 'busy',
+				customModel: 'session-model',
+				customEffort: 'low',
+				aiTabs: [createMockTab({ state: 'busy' })],
+			});
+
+			const { result } = renderExecution(session);
+
+			const spawnPromise = result.current.spawnAgentForSession(
+				session.id,
+				'Batch task',
+				undefined,
+				{
+					isAutoRun: true,
+					modelOverride: 'run-model',
+					effortOverride: 'high',
+				}
+			);
+
+			await waitFor(() => {
+				expect(mockProcess.spawn).toHaveBeenCalledTimes(1);
+			});
+
+			const spawnConfig = mockProcess.spawn.mock.calls[0][0];
+			expect(spawnConfig.sessionCustomModel).toBe('run-model');
+			expect(spawnConfig.sessionCustomEffort).toBe('high');
+
+			act(() => {
+				onExitHandler?.(spawnConfig.sessionId as string);
+			});
+			await spawnPromise;
+
+			// The override is spawn-scoped only, never persisted back.
+			expect(session.customModel).toBe('session-model');
+			expect(session.customEffort).toBe('low');
+		});
+
+		it('keeps the session values when no overrides are supplied', async () => {
+			const session = createMockSession({
+				state: 'busy',
+				customModel: 'session-model',
+				customEffort: 'low',
+				aiTabs: [createMockTab({ state: 'busy' })],
+			});
+
+			const { result } = renderExecution(session);
+
+			const spawnPromise = result.current.spawnAgentForSession(
+				session.id,
+				'Batch task',
+				undefined,
+				{
+					isAutoRun: true,
+				}
+			);
+
+			await waitFor(() => {
+				expect(mockProcess.spawn).toHaveBeenCalledTimes(1);
+			});
+
+			const spawnConfig = mockProcess.spawn.mock.calls[0][0];
+			expect(spawnConfig.sessionCustomModel).toBe('session-model');
+			expect(spawnConfig.sessionCustomEffort).toBe('low');
+
+			act(() => {
+				onExitHandler?.(spawnConfig.sessionId as string);
+			});
+			await spawnPromise;
+		});
+
+		it('falls back per-field when only one override is set', async () => {
+			const session = createMockSession({
+				state: 'busy',
+				customModel: 'session-model',
+				customEffort: 'low',
+				aiTabs: [createMockTab({ state: 'busy' })],
+			});
+
+			const { result } = renderExecution(session);
+
+			const spawnPromise = result.current.spawnAgentForSession(
+				session.id,
+				'Batch task',
+				undefined,
+				{
+					isAutoRun: true,
+					modelOverride: 'run-model',
+				}
+			);
+
+			await waitFor(() => {
+				expect(mockProcess.spawn).toHaveBeenCalledTimes(1);
+			});
+
+			const spawnConfig = mockProcess.spawn.mock.calls[0][0];
+			expect(spawnConfig.sessionCustomModel).toBe('run-model');
+			expect(spawnConfig.sessionCustomEffort).toBe('low');
+
+			act(() => {
+				onExitHandler?.(spawnConfig.sessionId as string);
+			});
+			await spawnPromise;
+		});
+	});
+
 	it('queues the next item and logs queued messages', async () => {
 		const queuedItem: QueuedItem = {
 			id: 'queued-1',

--- a/src/__tests__/renderer/hooks/useBatchProcessor.test.ts
+++ b/src/__tests__/renderer/hooks/useBatchProcessor.test.ts
@@ -3740,8 +3740,14 @@ describe('useBatchProcessor hook', () => {
 				);
 			});
 
-			// Should have called spawn with cwd override
-			expect(mockOnSpawnAgent).toHaveBeenCalledWith('test-session-id', 'Test', '/custom/worktree');
+			// Should have called spawn with cwd override. The 4th arg is the run-scoped
+			// model/effort override, undefined for a run that uses the agent default.
+			expect(mockOnSpawnAgent).toHaveBeenCalledWith(
+				'test-session-id',
+				'Test',
+				'/custom/worktree',
+				undefined
+			);
 		});
 	});
 
@@ -4026,8 +4032,14 @@ describe('useBatchProcessor hook', () => {
 				undefined // sshRemoteId (undefined for local sessions)
 			);
 
-			// Should have spawned agent with worktree path
-			expect(mockOnSpawnAgent).toHaveBeenCalledWith('test-session-id', 'Test', '/test/worktree');
+			// Should have spawned agent with worktree path. The 4th arg is the run-scoped
+			// model/effort override, undefined for a run that uses the agent default.
+			expect(mockOnSpawnAgent).toHaveBeenCalledWith(
+				'test-session-id',
+				'Test',
+				'/test/worktree',
+				undefined
+			);
 		});
 
 		it('should handle worktree checkout failure with uncommitted changes', async () => {

--- a/src/__tests__/renderer/hooks/useBatchProcessor.test.ts
+++ b/src/__tests__/renderer/hooks/useBatchProcessor.test.ts
@@ -6339,4 +6339,70 @@ describe('useBatchProcessor hook', () => {
 			expect(prEntry.fullResponse).toContain('gh: not authenticated');
 		});
 	});
+
+	describe('per-run model/effort override', () => {
+		// The override lives on the BatchRunConfig and has to survive the
+		// startBatchRun -> useBatchRunner -> useDocumentProcessor delegation chain
+		// to reach onSpawnAgent as the 4th argument.
+		const startRun = async (
+			extraConfig: Partial<{ model: string; effort: string }>
+		): Promise<void> => {
+			const sessions = [createMockSession()];
+			const groups = [createMockGroup()];
+
+			mockReadDoc.mockResolvedValue({ success: true, content: '- [ ] Task' });
+
+			useSessionStore.setState({ sessions: sessions, activeSessionId: sessions[0]?.id ?? '' });
+			const { result } = renderHook(() =>
+				useBatchProcessor({
+					groups,
+					onUpdateSession: mockOnUpdateSession,
+					onSpawnAgent: mockOnSpawnAgent,
+					onAddHistoryEntry: mockOnAddHistoryEntry,
+					onComplete: mockOnComplete,
+				})
+			);
+
+			await act(async () => {
+				await result.current.startBatchRun(
+					'test-session-id',
+					{
+						documents: [{ filename: 'tasks', resetOnCompletion: false }],
+						prompt: 'Test',
+						loopEnabled: false,
+						...extraConfig,
+					},
+					'/test/folder'
+				);
+			});
+		};
+
+		it('forwards config.model and config.effort to onSpawnAgent', async () => {
+			await startRun({ model: 'opus', effort: 'high' });
+
+			expect(mockOnSpawnAgent).toHaveBeenCalledWith('test-session-id', 'Test', undefined, {
+				modelOverride: 'opus',
+				effortOverride: 'high',
+			});
+		});
+
+		it('forwards only the field that was set', async () => {
+			await startRun({ model: 'opus' });
+
+			expect(mockOnSpawnAgent).toHaveBeenCalledWith('test-session-id', 'Test', undefined, {
+				modelOverride: 'opus',
+			});
+		});
+
+		it('passes no overrides at all when the config omits both fields', async () => {
+			await startRun({});
+
+			expect(mockOnSpawnAgent).toHaveBeenCalledWith(
+				'test-session-id',
+				'Test',
+				undefined,
+				undefined
+			);
+		});
+	});
 });

--- a/src/cli/commands/auto-run.ts
+++ b/src/cli/commands/auto-run.ts
@@ -18,6 +18,10 @@ interface AutoRunOptions {
 	worktreePath?: string;
 	createPr?: boolean;
 	prTargetBranch?: string;
+	// Run-scoped overrides: they win over the agent's configured model/effort for
+	// this run only and are never written back to the session.
+	model?: string;
+	effort?: string;
 }
 
 export async function autoRun(docs: string[], options: AutoRunOptions): Promise<void> {
@@ -110,6 +114,11 @@ export async function autoRun(docs: string[], options: AutoRunOptions): Promise<
 		process.exit(1);
 	}
 
+	// Run-scoped model/effort overrides. Sent only when set so an omitted flag
+	// leaves the agent's configured default untouched.
+	const runModel = options.model?.trim() || undefined;
+	const runEffort = options.effort?.trim() || undefined;
+
 	try {
 		const result = await withMaestroClient(async (client) => {
 			return client.sendCommand<{
@@ -128,6 +137,8 @@ export async function autoRun(docs: string[], options: AutoRunOptions): Promise<
 					saveAsPlaybook: options.saveAs,
 					launch: options.launch,
 					worktree,
+					...(runModel && { model: runModel }),
+					...(runEffort && { effort: runEffort }),
 				},
 				'configure_auto_run_result'
 			);

--- a/src/cli/commands/goal-run.ts
+++ b/src/cli/commands/goal-run.ts
@@ -16,6 +16,13 @@ interface GoalRunOptions {
 	json?: boolean;
 	verbose?: boolean;
 	history?: boolean; // --no-history -> history: false
+	/**
+	 * Run-scoped model/effort overrides. When set they win over the agent's
+	 * configured `customModel` / `customEffort` for this run's spawns only and
+	 * are never written back to the stored session.
+	 */
+	model?: string;
+	effort?: string;
 }
 
 /**
@@ -122,12 +129,18 @@ export async function goalRun(
 					`Iterations: ${maxIterations === null ? '∞ (infinite)' : `max ${maxIterations}`}`
 				)
 			);
+			const runModel = options.model?.trim();
+			const runEffort = options.effort?.trim();
+			if (runModel) console.log(formatInfo(`Model: ${runModel} (this run only)`));
+			if (runEffort) console.log(formatInfo(`Effort: ${runEffort} (this run only)`));
 			console.log('');
 		}
 
 		const generator = runGoal(agent, goalConfig, {
 			writeHistory: options.history !== false, // --no-history sets history to false
 			verbose: options.verbose,
+			model: options.model?.trim() || undefined,
+			effort: options.effort?.trim() || undefined,
 		});
 
 		for await (const event of generator) {

--- a/src/cli/commands/run-doc.ts
+++ b/src/cli/commands/run-doc.ts
@@ -30,6 +30,13 @@ interface RunDocOptions {
 	verbose?: boolean;
 	synopsis?: boolean; // --no-synopsis => synopsis: false
 	wait?: boolean;
+	/**
+	 * Run-scoped model/effort overrides. When set they win over the agent's
+	 * configured `customModel` / `customEffort` for this run's spawns only and
+	 * are never written back to the stored session.
+	 */
+	model?: string;
+	effort?: string;
 }
 
 /**
@@ -200,6 +207,10 @@ export async function runDoc(docs: string[], options: RunDocOptions): Promise<vo
 				const loopInfo = maxLoops ? `max ${maxLoops}` : '∞';
 				console.log(formatInfo(`Loop: enabled (${loopInfo})`));
 			}
+			const runModel = options.model?.trim();
+			const runEffort = options.effort?.trim();
+			if (runModel) console.log(formatInfo(`Model: ${runModel} (this run only)`));
+			if (runEffort) console.log(formatInfo(`Effort: ${runEffort} (this run only)`));
 			if (options.dryRun) {
 				console.log(formatInfo('Dry run mode - no changes will be made'));
 			}
@@ -213,6 +224,8 @@ export async function runDoc(docs: string[], options: RunDocOptions): Promise<vo
 			debug: options.debug,
 			verbose: options.verbose,
 			skipSynopsis: options.synopsis === false,
+			model: options.model?.trim() || undefined,
+			effort: options.effort?.trim() || undefined,
 		});
 
 		for await (const event of generator) {

--- a/src/cli/commands/run-playbook.ts
+++ b/src/cli/commands/run-playbook.ts
@@ -18,6 +18,13 @@ interface RunPlaybookOptions {
 	verbose?: boolean;
 	synopsis?: boolean; // commander uses --no-synopsis which becomes synopsis: false
 	wait?: boolean;
+	/**
+	 * Run-scoped model/effort overrides. When set they win over the agent's
+	 * configured `customModel` / `customEffort` for this run's spawns only and
+	 * are never written back to the stored session.
+	 */
+	model?: string;
+	effort?: string;
 }
 
 export async function runPlaybook(playbookId: string, options: RunPlaybookOptions): Promise<void> {
@@ -108,6 +115,10 @@ export async function runPlaybook(playbookId: string, options: RunPlaybookOption
 				const loopInfo = playbook.maxLoops ? `max ${playbook.maxLoops}` : '∞';
 				console.log(formatInfo(`Loop: enabled (${loopInfo})`));
 			}
+			const runModel = options.model?.trim();
+			const runEffort = options.effort?.trim();
+			if (runModel) console.log(formatInfo(`Model: ${runModel} (this run only)`));
+			if (runEffort) console.log(formatInfo(`Effort: ${runEffort} (this run only)`));
 			if (options.dryRun) {
 				console.log(formatInfo('Dry run mode - no changes will be made'));
 			}
@@ -121,6 +132,8 @@ export async function runPlaybook(playbookId: string, options: RunPlaybookOption
 			debug: options.debug,
 			verbose: options.verbose,
 			skipSynopsis: options.synopsis === false, // --no-synopsis sets synopsis to false
+			model: options.model?.trim() || undefined,
+			effort: options.effort?.trim() || undefined,
 		});
 
 		for await (const event of generator) {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -266,6 +266,14 @@ program
 	.option('--verbose', 'Show full prompt sent to agent on each iteration')
 	.option('--no-synopsis', 'Skip synopsis generation after each task (reduces overhead)')
 	.option('--wait', 'Wait for agent to become available if busy')
+	.option(
+		'--model <model>',
+		"Model to use for this run only, overriding the agent's configured default"
+	)
+	.option(
+		'--effort <effort>',
+		"Reasoning effort for this run only, overriding the agent's configured default"
+	)
 	.action(async (playbookId: string, options: Record<string, unknown>) => {
 		const { runPlaybook } = await import('./commands/run-playbook');
 		return runPlaybook(playbookId, options);
@@ -315,6 +323,14 @@ program
 	.option('--verbose', 'Show full prompt sent to agent on each iteration')
 	.option('--no-synopsis', 'Skip synopsis generation after each task (reduces overhead)')
 	.option('--wait', 'Wait for agent to become available if busy')
+	.option(
+		'--model <model>',
+		"Model to use for this run only, overriding the agent's configured default"
+	)
+	.option(
+		'--effort <effort>',
+		"Reasoning effort for this run only, overriding the agent's configured default"
+	)
 	.action(async (docs: string[], options: Record<string, unknown>) => {
 		const { runDoc } = await import('./commands/run-doc');
 		return runDoc(docs, options as never);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -280,6 +280,14 @@ program
 	.option('--no-history', 'Do not write history entries')
 	.option('--json', 'Output as JSON lines (for scripting)')
 	.option('--verbose', 'Show full prompt sent to agent on each iteration')
+	.option(
+		'--model <model>',
+		"Model to use for this run only, overriding the agent's configured default"
+	)
+	.option(
+		'--effort <effort>',
+		"Reasoning effort for this run only, overriding the agent's configured default"
+	)
 	.action(async (agentId: string, goal: string, options: Record<string, unknown>) => {
 		const { goalRun } = await import('./commands/goal-run');
 		return goalRun(agentId, goal, options);
@@ -483,6 +491,14 @@ program
 	.option(
 		'--pr-target-branch <branch>',
 		'Target branch for the PR (defaults to the repo default branch)'
+	)
+	.option(
+		'--model <model>',
+		"Model to use for this run only, overriding the agent's configured default"
+	)
+	.option(
+		'--effort <effort>',
+		"Reasoning effort for this run only, overriding the agent's configured default"
 	)
 	.action(autoRun);
 

--- a/src/cli/services/batch-processor.ts
+++ b/src/cli/services/batch-processor.ts
@@ -43,6 +43,13 @@ export async function* runPlaybook(
 		debug?: boolean;
 		verbose?: boolean;
 		skipSynopsis?: boolean;
+		/**
+		 * Run-scoped model override. Wins over `session.customModel` for every
+		 * spawn this run makes; the stored session is never modified.
+		 */
+		model?: string;
+		/** Run-scoped reasoning effort override (same contract as `model`). */
+		effort?: string;
 	} = {}
 ): AsyncGenerator<JsonlEvent> {
 	const {
@@ -51,6 +58,8 @@ export async function* runPlaybook(
 		debug = false,
 		verbose = false,
 		skipSynopsis = false,
+		model: runModel,
+		effort: runEffort,
 	} = options;
 	const batchStartTime = Date.now();
 
@@ -477,8 +486,8 @@ export async function* runPlaybook(
 						},
 						() =>
 							spawnAgent(session.toolType, session.cwd, finalPrompt, undefined, {
-								customModel: session.customModel,
-								customEffort: session.customEffort,
+								customModel: runModel ?? session.customModel,
+								customEffort: runEffort ?? session.customEffort,
 								customArgs: session.customArgs,
 								additionalDirectories: session.additionalDirectories,
 								customEnvVars: session.customEnvVars,
@@ -538,8 +547,8 @@ export async function* runPlaybook(
 									await getCliPrompt(PROMPT_IDS.AUTORUN_SYNOPSIS),
 									result.agentSessionId,
 									{
-										customModel: session.customModel,
-										customEffort: session.customEffort,
+										customModel: runModel ?? session.customModel,
+										customEffort: runEffort ?? session.customEffort,
 										customArgs: session.customArgs,
 										additionalDirectories: session.additionalDirectories,
 										customEnvVars: session.customEnvVars,

--- a/src/cli/services/goal-runner.ts
+++ b/src/cli/services/goal-runner.ts
@@ -45,6 +45,13 @@ export interface RunGoalOptions {
 	writeHistory?: boolean;
 	/** Emit a `verbose` event carrying the full per-iteration prompt. */
 	verbose?: boolean;
+	/**
+	 * Run-scoped model override. Wins over `session.customModel` for every spawn
+	 * this run makes; the stored session is never modified.
+	 */
+	model?: string;
+	/** Run-scoped reasoning effort override (same contract as `model`). */
+	effort?: string;
 }
 
 /** Human label for a goal run's exit reason (mirrors the desktop wording). */
@@ -83,7 +90,8 @@ function iterationSynopsis(response: string | undefined, iteration: number): str
 async function requestHandoffBlurb(
 	session: SessionInfo,
 	agentSessionId: string,
-	appendSystemPrompt: string | undefined
+	appendSystemPrompt: string | undefined,
+	runOverrides: { model?: string; effort?: string } = {}
 ): Promise<{ blurb: string; usageStats?: UsageStats }> {
 	try {
 		const result = await captureCliRun(
@@ -96,8 +104,8 @@ async function requestHandoffBlurb(
 			},
 			() =>
 				spawnAgent(session.toolType, session.cwd, GOAL_SYNOPSIS_REQUEST_PROMPT, agentSessionId, {
-					customModel: session.customModel,
-					customEffort: session.customEffort,
+					customModel: runOverrides.model ?? session.customModel,
+					customEffort: runOverrides.effort ?? session.customEffort,
 					customArgs: session.customArgs,
 					customEnvVars: session.customEnvVars,
 					sshRemoteConfig: session.sessionSshRemoteConfig,
@@ -127,7 +135,7 @@ export async function* runGoal(
 	goalConfig: GoalRunConfig,
 	options: RunGoalOptions = {}
 ): AsyncGenerator<JsonlEvent> {
-	const { writeHistory = true, verbose = false } = options;
+	const { writeHistory = true, verbose = false, model: runModel, effort: runEffort } = options;
 	const runStartTime = Date.now();
 
 	const gitBranch = getGitBranch(session.cwd);
@@ -236,8 +244,8 @@ export async function* runGoal(
 				},
 				() =>
 					spawnAgent(session.toolType, session.cwd, prompt, undefined, {
-						customModel: session.customModel,
-						customEffort: session.customEffort,
+						customModel: runModel ?? session.customModel,
+						customEffort: runEffort ?? session.customEffort,
 						customArgs: session.customArgs,
 						customEnvVars: session.customEnvVars,
 						sshRemoteConfig: session.sessionSshRemoteConfig,
@@ -346,7 +354,8 @@ export async function* runGoal(
 				const handoff = await requestHandoffBlurb(
 					session,
 					result.agentSessionId,
-					appendSystemPrompt
+					appendSystemPrompt,
+					{ model: runModel, effort: runEffort }
 				);
 				if (handoff.usageStats) {
 					totalInputTokens += handoff.usageStats.inputTokens || 0;

--- a/src/main/web-server/handlers/messageHandlers.ts
+++ b/src/main/web-server/handlers/messageHandlers.ts
@@ -1805,6 +1805,23 @@ export class WebSocketMessageHandler {
 			this.sendError(client, 'saveAsPlaybook must be a non-empty string');
 			return;
 		}
+		// Per-run model/effort override. Optional, but when present it must be a
+		// non-empty string: an empty value would pin the run to a nonexistent model
+		// instead of falling back to the agent default.
+		if (
+			message.model !== undefined &&
+			(typeof message.model !== 'string' || message.model.trim() === '')
+		) {
+			this.sendError(client, 'model must be a non-empty string');
+			return;
+		}
+		if (
+			message.effort !== undefined &&
+			(typeof message.effort !== 'string' || message.effort.trim() === '')
+		) {
+			this.sendError(client, 'effort must be a non-empty string');
+			return;
+		}
 
 		// Validate optional worktree config - desktop app uses this to create a
 		// git worktree, checkout the branch, and optionally open a PR on completion.
@@ -1865,6 +1882,8 @@ export class WebSocketMessageHandler {
 			maxLoops: message.maxLoops !== undefined ? Number(message.maxLoops) : undefined,
 			saveAsPlaybook: message.saveAsPlaybook as string | undefined,
 			launch: message.launch as boolean | undefined,
+			model: message.model as string | undefined,
+			effort: message.effort as string | undefined,
 			worktree,
 		};
 

--- a/src/main/web-server/managers/CallbackRegistry.ts
+++ b/src/main/web-server/managers/CallbackRegistry.ts
@@ -476,6 +476,9 @@ export class CallbackRegistry {
 			maxLoops?: number;
 			saveAsPlaybook?: string;
 			launch?: boolean;
+			/** Per-run model/effort override - wins over the session model for this run only. */
+			model?: string;
+			effort?: string;
 			worktree?: {
 				enabled: boolean;
 				path: string;

--- a/src/main/web-server/types.ts
+++ b/src/main/web-server/types.ts
@@ -560,6 +560,13 @@ export type ConfigureAutoRunCallback = (
 		maxLoops?: number;
 		saveAsPlaybook?: string;
 		launch?: boolean;
+		/**
+		 * Per-run model/effort override (CLI `--model` / `--effort`). Wins over the
+		 * session's configured model for this run's spawns only; never written back
+		 * to the session. Absent means "use the agent default".
+		 */
+		model?: string;
+		effort?: string;
 		worktree?: {
 			enabled: boolean;
 			path: string;

--- a/src/renderer/components/BatchRunnerModal.tsx
+++ b/src/renderer/components/BatchRunnerModal.tsx
@@ -178,6 +178,66 @@ export function BatchRunnerModal(props: BatchRunnerModalProps) {
 		getModalActions().setWorktreeConfigModalOpen(true);
 	}, []);
 
+	// Per-run model / effort override. Empty string means "Use agent default",
+	// which is the state the modal always opens in: the override is scoped to a
+	// single run and is deliberately NOT persisted anywhere (no session field,
+	// no setting). A persisted per-run model would be indistinguishable from
+	// changing the agent's own model, which Session settings already does.
+	const [runModel, setRunModel] = useState('');
+	const [runEffort, setRunEffort] = useState('');
+	const [availableModels, setAvailableModels] = useState<string[]>([]);
+	const [availableEfforts, setAvailableEfforts] = useState<string[]>([]);
+
+	// Fetch the model and effort options for the agent behind this run. Uses a
+	// stale flag so a slow response (e.g. `opencode models` shelling out) for a
+	// previously selected agent can't overwrite the current agent's list. Same
+	// pattern as MainPanel's model pill.
+	useEffect(() => {
+		const agentId = activeSession?.toolType;
+		if (!agentId) {
+			setAvailableModels([]);
+			setAvailableEfforts([]);
+			return;
+		}
+		let stale = false;
+		window.maestro.agents
+			.getModels(agentId)
+			.then((models) => {
+				if (!stale) setAvailableModels(models);
+			})
+			.catch(() => {
+				if (!stale) setAvailableModels([]);
+			});
+		// Agents expose reasoning effort under either `effort` (Claude Code) or
+		// `reasoningEffort` (Codex, Copilot-CLI, Factory Droid) - probe both and
+		// use whichever the agent defines.
+		Promise.all([
+			window.maestro.agents.getConfigOptions(agentId, 'effort').catch(() => [] as string[]),
+			window.maestro.agents
+				.getConfigOptions(agentId, 'reasoningEffort')
+				.catch(() => [] as string[]),
+		])
+			.then(([effortOpts, reasoningOpts]) => {
+				if (stale) return;
+				setAvailableEfforts(effortOpts.length > 0 ? effortOpts : reasoningOpts);
+			})
+			.catch(() => {
+				if (!stale) setAvailableEfforts([]);
+			});
+		return () => {
+			stale = true;
+		};
+	}, [activeSession?.toolType]);
+
+	// Drop a picked value that the newly fetched option list no longer offers,
+	// so switching agents can't leave a stale model in the launched config.
+	useEffect(() => {
+		if (runModel && !availableModels.includes(runModel)) setRunModel('');
+	}, [availableModels, runModel]);
+	useEffect(() => {
+		if (runEffort && !availableEfforts.includes(runEffort)) setRunEffort('');
+	}, [availableEfforts, runEffort]);
+
 	// Document list state. Opens empty unless the inline wizard's "Start Auto
 	// Run" pre-seeded it with freshly generated docs via `presetDocuments`.
 	const [documents, setDocuments] = useState<BatchDocumentEntry[]>(() => {
@@ -692,6 +752,8 @@ export function BatchRunnerModal(props: BatchRunnerModalProps) {
 						maxLoops: null,
 						goalConfig: { goal: goal.trim(), exitCriteria: exitCriteria.trim(), maxIterations },
 						...(worktreeTarget && { worktreeTarget }),
+						...(runModel && { model: runModel }),
+						...(runEffort && { effort: runEffort }),
 					}
 				: {
 						documents: validDocuments,
@@ -700,6 +762,8 @@ export function BatchRunnerModal(props: BatchRunnerModalProps) {
 						maxLoops: loopEnabled ? maxLoops : null,
 						taskSelectionMode,
 						...(worktreeTarget && { worktreeTarget }),
+						...(runModel && { model: runModel }),
+						...(runEffort && { effort: runEffort }),
 					};
 
 		logger.info('[BatchRunnerModal] handleGo - calling onGo with config:', undefined, config);
@@ -1085,6 +1149,67 @@ export function BatchRunnerModal(props: BatchRunnerModalProps) {
 							onWorktreeTargetChange={setWorktreeTarget}
 							onOpenWorktreeConfig={handleOpenWorktreeConfig}
 						/>
+					)}
+
+					{/* Per-run model / effort override. Applies to every agent spawn this
+					    run makes (both modes, and worktree-dispatched runs), and dies with
+					    the run - the agent's own configured model is left alone. Each
+					    picker is hidden when its provider exposes no options. */}
+					{(availableModels.length > 0 || availableEfforts.length > 0) && (
+						<div className="flex flex-col gap-2">
+							<div
+								className="text-[10px] font-bold uppercase"
+								style={{ color: theme.colors.textDim }}
+							>
+								Model for this run
+							</div>
+							<div className="flex items-center gap-2">
+								{availableModels.length > 0 && (
+									<select
+										value={runModel}
+										onChange={(e) => setRunModel(e.target.value)}
+										aria-label="Model for this run"
+										className="flex-1 rounded-lg border px-3 py-1.5 text-sm outline-none"
+										style={{
+											backgroundColor: theme.colors.bgMain,
+											borderColor: theme.colors.border,
+											color: theme.colors.textMain,
+										}}
+									>
+										<option value="">Use agent default</option>
+										{availableModels.map((m) => (
+											<option key={m} value={m}>
+												{m}
+											</option>
+										))}
+									</select>
+								)}
+								{availableEfforts.length > 0 && (
+									<select
+										value={runEffort}
+										onChange={(e) => setRunEffort(e.target.value)}
+										aria-label="Reasoning effort for this run"
+										className="flex-1 rounded-lg border px-3 py-1.5 text-sm outline-none"
+										style={{
+											backgroundColor: theme.colors.bgMain,
+											borderColor: theme.colors.border,
+											color: theme.colors.textMain,
+										}}
+									>
+										<option value="">Default effort</option>
+										{availableEfforts.map((e) => (
+											<option key={e} value={e}>
+												{e}
+											</option>
+										))}
+									</select>
+								)}
+							</div>
+							<p className="text-[10px]" style={{ color: theme.colors.textDim }}>
+								Overrides the agent&apos;s configured model for this run only. The agent&apos;s own
+								settings and its interactive tabs are unchanged.
+							</p>
+						</div>
 					)}
 
 					{/* Spec-Driven config: Fresh-context selector + Agent Prompt. Hidden in

--- a/src/renderer/hooks/agent/internal/useAgentExitListener.ts
+++ b/src/renderer/hooks/agent/internal/useAgentExitListener.ts
@@ -325,6 +325,16 @@ export function useAgentExitListener(deps: UseAgentExitListenerDeps): void {
 							!!currentSession.pendingAICommandForSynopsis,
 							thinkingLogsRecorded(completedTab?.showThinking)
 						);
+						// Desktop document/spec-mode Auto Run synopsizes each task from this
+						// exit path (not spawnBackgroundSynopsis). Honor the active run's
+						// per-run model override so the synopsis spawns under the same model
+						// as the run's tasks, matching the CLI batch processor. Same
+						// precedence as every other spawn this run makes: run override wins
+						// over the session default. Effort is intentionally not threaded:
+						// SynopsisData.sessionConfig has no effort field.
+						const runModelOverride = deps.getBatchStateRef.current?.(
+							actualSessionId
+						)?.runModelOverride;
 						synopsisData = {
 							sessionId: actualSessionId,
 							cwd: currentSession.cwd,
@@ -342,7 +352,7 @@ export function useAgentExitListener(deps: UseAgentExitListenerDeps): void {
 								customPath: currentSession.customPath,
 								customArgs: currentSession.customArgs,
 								customEnvVars: currentSession.customEnvVars,
-								customModel: currentSession.customModel,
+								customModel: runModelOverride ?? currentSession.customModel,
 								customContextWindow: currentSession.customContextWindow,
 								// Carry the agent's Claude token source into the synopsis spawn so
 								// it resolves the same TUI/Dynamic/API mode as a normal turn.

--- a/src/renderer/hooks/agent/internal/useAgentExitListener.ts
+++ b/src/renderer/hooks/agent/internal/useAgentExitListener.ts
@@ -332,9 +332,8 @@ export function useAgentExitListener(deps: UseAgentExitListenerDeps): void {
 						// precedence as every other spawn this run makes: run override wins
 						// over the session default. Effort is intentionally not threaded:
 						// SynopsisData.sessionConfig has no effort field.
-						const runModelOverride = deps.getBatchStateRef.current?.(
-							actualSessionId
-						)?.runModelOverride;
+						const runModelOverride =
+							deps.getBatchStateRef.current?.(actualSessionId)?.runModelOverride;
 						synopsisData = {
 							sessionId: actualSessionId,
 							cwd: currentSession.cwd,

--- a/src/renderer/hooks/agent/internal/useAgentExitListener.ts
+++ b/src/renderer/hooks/agent/internal/useAgentExitListener.ts
@@ -326,7 +326,10 @@ export function useAgentExitListener(deps: UseAgentExitListenerDeps): void {
 							thinkingLogsRecorded(completedTab?.showThinking)
 						);
 						// Desktop document/spec-mode Auto Run synopsizes each task from this
-						// exit path (not spawnBackgroundSynopsis). Honor the active run's
+						// exit path: the synopsis is set up here and dispatched via
+						// runExitSynopsis/dispatchSynopsis (which ultimately calls
+						// spawnBackgroundSynopsisRef), rather than the batch runner invoking
+						// the synopsis spawn directly per task. Honor the active run's
 						// per-run model override so the synopsis spawns under the same model
 						// as the run's tasks, matching the CLI batch processor. Same
 						// precedence as every other spawn this run makes: run override wins

--- a/src/renderer/hooks/agent/useAgentExecution.ts
+++ b/src/renderer/hooks/agent/useAgentExecution.ts
@@ -37,6 +37,28 @@ export interface AgentSpawnResult {
 	errorKind?: AgentSpawnErrorKind;
 }
 
+/**
+ * Per-spawn options for `spawnAgentForSession`.
+ *
+ * The model/effort overrides are run-scoped: an Auto Run can use a different
+ * model than the agent's configured default without writing anything back to
+ * the session. They win over `session.customModel` / `session.customEffort`
+ * because the Auto Run spawn path has no active tab to consult.
+ */
+export interface SpawnAgentOptions {
+	isAutoRun?: boolean;
+	/** Overrides session.customModel for this spawn only */
+	modelOverride?: string;
+	/** Overrides session.customEffort for this spawn only */
+	effortOverride?: string;
+}
+
+/**
+ * The subset of spawn options the batch/goal runners forward from a
+ * `BatchRunConfig`. `isAutoRun` is supplied by the wiring layer, not the runner.
+ */
+export type SpawnAgentRunOverrides = Pick<SpawnAgentOptions, 'modelOverride' | 'effortOverride'>;
+
 export type AgentSpawnErrorKind =
 	| 'watchdog-stalled'
 	| 'watchdog-timeout'
@@ -75,9 +97,7 @@ export interface UseAgentExecutionReturn {
 		sessionId: string,
 		prompt: string,
 		cwdOverride?: string,
-		options?: {
-			isAutoRun?: boolean;
-		}
+		options?: SpawnAgentOptions
 	) => Promise<AgentSpawnResult>;
 	/** Spawn an agent with a prompt for the active session */
 	spawnAgentWithPrompt: (prompt: string) => Promise<AgentSpawnResult>;
@@ -199,15 +219,14 @@ export function useAgentExecution(deps: UseAgentExecutionDeps): UseAgentExecutio
 	 * @param sessionId - The session ID to spawn the agent for
 	 * @param prompt - The prompt to send to the agent
 	 * @param cwdOverride - Optional override for working directory (e.g., for worktree mode)
+	 * @param options - Per-spawn options, including the run-scoped model/effort overrides
 	 */
 	const spawnAgentForSession = useCallback(
 		async (
 			sessionId: string,
 			prompt: string,
 			cwdOverride?: string,
-			options?: {
-				isAutoRun?: boolean;
-			}
+			options?: SpawnAgentOptions
 		): Promise<AgentSpawnResult> => {
 			// Use sessionsRef to get latest sessions (fixes stale closure when called right after session creation)
 			const session = sessionsRef.current.find((s) => s.id === sessionId);
@@ -607,13 +626,17 @@ export function useAgentExecution(deps: UseAgentExecutionDeps): UseAgentExecutio
 							sessionCustomArgs: session.customArgs,
 							sessionAdditionalDirectories: session.additionalDirectories,
 							sessionCustomEnvVars: session.customEnvVars,
-							sessionCustomModel: session.customModel,
+							// A per-run override (Auto Run model picker, CLI --model) wins over the
+							// session's configured model. There is no active tab in this path, so
+							// the override sits directly above session.customModel and never
+							// touches the session itself - it dies when the run ends.
+							sessionCustomModel: options?.modelOverride ?? session.customModel,
 							// Auto Run is session-level (no active tab), so the session's effort
 							// is the source. Interactive spawns pass this too; omitting it here
 							// dropped the user's configured reasoning effort in Auto Run, which for
 							// Codex meant no reasoning summary was streamed (Thought Stream stayed
 							// stuck on "Waiting for the agent to start thinking...") - see #1147.
-							sessionCustomEffort: session.customEffort,
+							sessionCustomEffort: options?.effortOverride ?? session.customEffort,
 							sessionCustomContextWindow: session.customContextWindow,
 							// Per-session SSH remote config (takes precedence over agent-level SSH config)
 							sessionSshRemoteConfig: session.sessionSshRemoteConfig,

--- a/src/renderer/hooks/agent/useAgentExecution.ts
+++ b/src/renderer/hooks/agent/useAgentExecution.ts
@@ -691,6 +691,7 @@ export function useAgentExecution(deps: UseAgentExecutionDeps): UseAgentExecutio
 				customArgs?: string;
 				customEnvVars?: Record<string, string>;
 				customModel?: string;
+				customEffort?: string;
 				customContextWindow?: number;
 				// Claude token-source selection. The synopsis spawns under a synthetic
 				// sessionId, so the process:spawn handler can't resolve the token mode
@@ -819,6 +820,7 @@ export function useAgentExecution(deps: UseAgentExecutionDeps): UseAgentExecutio
 							sessionCustomArgs: sessionConfig?.customArgs,
 							sessionCustomEnvVars: sessionConfig?.customEnvVars,
 							sessionCustomModel: sessionConfig?.customModel,
+							sessionCustomEffort: sessionConfig?.customEffort,
 							sessionCustomContextWindow: sessionConfig?.customContextWindow,
 							// Forward the agent's Claude token source. The synopsis runs under a
 							// synthetic sessionId, so the process:spawn handler can't hydrate the

--- a/src/renderer/hooks/batch/batchReducer.ts
+++ b/src/renderer/hooks/batch/batchReducer.ts
@@ -171,6 +171,8 @@ export interface StartBatchPayload {
 	worktreePath?: string;
 	worktreeBranch?: string;
 	customPrompt?: string;
+	// Per-run model override chosen in the launch modal (absent = session default).
+	runModelOverride?: string;
 	startTime: number;
 	// Time tracking
 	cumulativeTaskTimeMs: number;
@@ -294,6 +296,7 @@ export function batchReducer(state: BatchState, action: BatchAction): BatchState
 					currentTaskIndex: 0,
 					originalContent: '',
 					customPrompt: payload.customPrompt,
+					runModelOverride: payload.runModelOverride,
 					sessionIds: [],
 					startTime: payload.startTime,
 					// Time tracking

--- a/src/renderer/hooks/batch/internal/useBatchRunner.ts
+++ b/src/renderer/hooks/batch/internal/useBatchRunner.ts
@@ -10,7 +10,7 @@ import type {
 	AutoRunStats,
 	AgentError,
 } from '../../../types';
-import type { AgentSpawnErrorKind } from '../../agent/useAgentExecution';
+import type { AgentSpawnErrorKind, SpawnAgentRunOverrides } from '../../agent/useAgentExecution';
 import { gitService } from '../../../services/git';
 import { logger } from '../../../utils/logger';
 import { notifyToast } from '../../../stores/notificationStore';
@@ -45,7 +45,9 @@ type UpdateBatchStateFn = (
 type SpawnAgentFn = (
 	sessionId: string,
 	prompt: string,
-	cwdOverride?: string
+	cwdOverride?: string,
+	/** Run-scoped model/effort override from the BatchRunConfig, when the run set one */
+	options?: SpawnAgentRunOverrides
 ) => Promise<{
 	success: boolean;
 	response?: string;
@@ -191,6 +193,18 @@ export function useBatchRunner({
 			}
 
 			const { documents, prompt, loopEnabled, maxLoops, taskSelectionMode, worktree } = config;
+
+			// Run-scoped model/effort override, built only when the run picked one so
+			// default runs pass no spawn options at all. An absent override means the
+			// spawn uses the session's configured model, then the agent default.
+			// Nothing here is written back to the session.
+			const runOverrides: SpawnAgentRunOverrides | undefined =
+				config.model || config.effort
+					? {
+							...(config.model && { modelOverride: config.model }),
+							...(config.effort && { effortOverride: config.effort }),
+						}
+					: undefined;
 
 			if (documents.length === 0) {
 				window.maestro.logger.log(
@@ -784,6 +798,7 @@ export function useBatchRunner({
 									customPrompt: prompt,
 									taskSelectionMode,
 									sshRemoteId,
+									runOverrides,
 								},
 								effectiveFilename, // Use working copy path for reset-on-completion docs
 								docCheckedCount,

--- a/src/renderer/hooks/batch/internal/useBatchRunner.ts
+++ b/src/renderer/hooks/batch/internal/useBatchRunner.ts
@@ -328,9 +328,11 @@ export function useBatchRunner({
 					worktreePath,
 					worktreeBranch,
 					customPrompt: prompt !== '' ? prompt : undefined,
-					// Persist the run-scoped model override so the exit-path synopsis can
-					// spawn per-task synopses under the run's model (CLI parity). Only the
-					// model is stored: SynopsisData.sessionConfig has no effort field.
+					// Persist the run-scoped model override so useAgentExitListener can read
+					// it back (via getBatchStateRef) and build each per-task exit-path
+					// synopsis under the run's model instead of the session default, for
+					// parity with the CLI batch processor. Only the model is stored:
+					// SynopsisData.sessionConfig has no effort field.
 					runModelOverride: config.model || undefined,
 					startTime: batchStartTime,
 					// Time tracking

--- a/src/renderer/hooks/batch/internal/useBatchRunner.ts
+++ b/src/renderer/hooks/batch/internal/useBatchRunner.ts
@@ -328,6 +328,10 @@ export function useBatchRunner({
 					worktreePath,
 					worktreeBranch,
 					customPrompt: prompt !== '' ? prompt : undefined,
+					// Persist the run-scoped model override so the exit-path synopsis can
+					// spawn per-task synopses under the run's model (CLI parity). Only the
+					// model is stored: SynopsisData.sessionConfig has no effort field.
+					runModelOverride: config.model || undefined,
 					startTime: batchStartTime,
 					// Time tracking
 					cumulativeTaskTimeMs: 0, // Sum of actual task durations (most accurate)

--- a/src/renderer/hooks/batch/internal/useGoalRunner.ts
+++ b/src/renderer/hooks/batch/internal/useGoalRunner.ts
@@ -81,6 +81,7 @@ type SpawnBackgroundSynopsisFn = (
 		customArgs?: string;
 		customEnvVars?: Record<string, string>;
 		customModel?: string;
+		customEffort?: string;
 		customContextWindow?: number;
 		enableMaestroP?: boolean;
 		maestroPMode?: 'interactive' | 'dynamic';
@@ -741,7 +742,11 @@ export function useGoalRunner({
 								customPath: session.customPath,
 								customArgs: session.customArgs,
 								customEnvVars: session.customEnvVars,
-								customModel: session.customModel,
+								// Mirror the primary iteration's effective config: the run-scoped
+								// model/effort override wins over the session default so the handoff
+								// synopsis spawns under the same configuration as the goal run itself.
+								customModel: config.model ?? session.customModel,
+								customEffort: config.effort ?? session.customEffort,
 								customContextWindow: session.customContextWindow,
 								enableMaestroP: session.enableMaestroP,
 								maestroPMode: session.maestroPMode,

--- a/src/renderer/hooks/batch/internal/useGoalRunner.ts
+++ b/src/renderer/hooks/batch/internal/useGoalRunner.ts
@@ -8,7 +8,7 @@ import type {
 	UsageStats,
 	Group,
 } from '../../../types';
-import type { AgentSpawnErrorKind } from '../../agent/useAgentExecution';
+import type { AgentSpawnErrorKind, SpawnAgentRunOverrides } from '../../agent/useAgentExecution';
 import type {
 	GoalIterationRecord,
 	GoalExitReason,
@@ -51,7 +51,9 @@ type UpdateBatchStateFn = (
 type SpawnAgentFn = (
 	sessionId: string,
 	prompt: string,
-	cwdOverride?: string
+	cwdOverride?: string,
+	/** Run-scoped model/effort override from the BatchRunConfig, when the run set one */
+	options?: SpawnAgentRunOverrides
 ) => Promise<{
 	success: boolean;
 	response?: string;
@@ -230,6 +232,18 @@ export function useGoalRunner({
 				});
 				return;
 			}
+
+			// Run-scoped model/effort override, built only when the run picked one so
+			// default runs pass no spawn options at all. An absent override means the
+			// spawn uses the session's configured model, then the agent default.
+			// Nothing here is written back to the session.
+			const runOverrides: SpawnAgentRunOverrides | undefined =
+				config.model || config.effort
+					? {
+							...(config.model && { modelOverride: config.model }),
+							...(config.effort && { effortOverride: config.effort }),
+						}
+					: undefined;
 
 			const goalConfig: GoalRunConfig | undefined = config.goalConfig;
 			if (!goalConfig) {
@@ -488,7 +502,8 @@ export function useGoalRunner({
 					result = await onSpawnAgent(
 						sessionId,
 						prompt,
-						effectiveCwd !== session.cwd ? effectiveCwd : undefined
+						effectiveCwd !== session.cwd ? effectiveCwd : undefined,
+						runOverrides
 					);
 				} catch (error) {
 					logger.error('[GoalRunner] Agent spawn threw:', undefined, error);

--- a/src/renderer/hooks/batch/useBatchHandlers.ts
+++ b/src/renderer/hooks/batch/useBatchHandlers.ts
@@ -37,7 +37,7 @@ import { useBatchProcessor, type UseBatchProcessorProps } from './useBatchProces
 import { useBatchStore } from '../../stores/batchStore';
 import { consumeGroupChatAutoRun } from '../../utils/groupChatAutoRunRegistry';
 import type { RightPanelHandle } from '../../components/RightPanel';
-import type { AgentSpawnResult } from '../agent/useAgentExecution';
+import type { AgentSpawnResult, SpawnAgentOptions } from '../agent/useAgentExecution';
 import * as Sentry from '@sentry/electron/renderer';
 import { logger } from '../../utils/logger';
 
@@ -85,9 +85,7 @@ export interface UseBatchHandlersDeps {
 		sessionId: string,
 		prompt: string,
 		cwdOverride?: string,
-		options?: {
-			isAutoRun?: boolean;
-		}
+		options?: SpawnAgentOptions
 	) => Promise<AgentSpawnResult>;
 	/**
 	 * Resume an existing provider session and run a prompt (threaded to the goal
@@ -229,8 +227,10 @@ export function useBatchHandlers(deps: UseBatchHandlersDeps): UseBatchHandlersRe
 				.getState()
 				.setSessions((prev) => prev.map((s) => (s.id === sessionId ? { ...s, ...updates } : s)));
 		},
-		onSpawnAgent: (sessionId, prompt, cwdOverride) =>
-			spawnAgentForSession(sessionId, prompt, cwdOverride, { isAutoRun: true }),
+		// `options` carries the run-scoped model/effort override from BatchRunConfig
+		// (undefined for runs that use the agent default).
+		onSpawnAgent: (sessionId, prompt, cwdOverride, options) =>
+			spawnAgentForSession(sessionId, prompt, cwdOverride, { ...options, isAutoRun: true }),
 		spawnBackgroundSynopsis,
 		onAddHistoryEntry: async (entry) => {
 			await window.maestro.history.add({

--- a/src/renderer/hooks/batch/useBatchProcessor.ts
+++ b/src/renderer/hooks/batch/useBatchProcessor.ts
@@ -16,7 +16,7 @@ import { useSessionStore } from '../../stores/sessionStore';
 import { useTimeTracking } from './useTimeTracking';
 import { useWorktreeManager } from './useWorktreeManager';
 import { useDocumentProcessor } from './useDocumentProcessor';
-import type { AgentSpawnErrorKind } from '../agent/useAgentExecution';
+import type { AgentSpawnErrorKind, SpawnAgentRunOverrides } from '../agent/useAgentExecution';
 // Decomposed internal hooks (see ./internal/)
 import type { BatchAction } from './batchReducer';
 import { type AutoRunFlushState } from './internal/batchFlushState';
@@ -61,7 +61,9 @@ export interface UseBatchProcessorProps {
 	onSpawnAgent: (
 		sessionId: string,
 		prompt: string,
-		cwdOverride?: string
+		cwdOverride?: string,
+		/** Run-scoped model/effort override from the BatchRunConfig, when the run set one */
+		options?: SpawnAgentRunOverrides
 	) => Promise<{
 		success: boolean;
 		response?: string;

--- a/src/renderer/hooks/batch/useDocumentProcessor.ts
+++ b/src/renderer/hooks/batch/useDocumentProcessor.ts
@@ -17,7 +17,7 @@ import type { Session, TaskSelectionMode, UsageStats } from '../../types';
 import { substituteTemplateVariables, TemplateContext } from '../../utils/templateVariables';
 import { prependNewSessionMessage } from '../../../shared/newSessionMessage';
 import { countMarkdownTasks, getTaskSelectionBlock } from './batchUtils';
-import type { AgentSpawnErrorKind } from '../agent/useAgentExecution';
+import type { AgentSpawnErrorKind, SpawnAgentRunOverrides } from '../agent/useAgentExecution';
 import { logger } from '../../utils/logger';
 
 /**
@@ -69,6 +69,13 @@ export interface DocumentProcessorConfig {
 	 * SSH remote ID for remote file operations (when session is SSH-enabled)
 	 */
 	sshRemoteId?: string;
+
+	/**
+	 * Run-scoped model/effort override from the BatchRunConfig. Absent (or with
+	 * absent members) means the spawn falls back to the session's configured
+	 * model/effort, then the agent default.
+	 */
+	runOverrides?: SpawnAgentRunOverrides;
 }
 
 /**
@@ -188,7 +195,9 @@ export interface DocumentProcessorCallbacks {
 	onSpawnAgent: (
 		sessionId: string,
 		prompt: string,
-		cwdOverride?: string
+		cwdOverride?: string,
+		/** Run-scoped model/effort override from the BatchRunConfig, when the run set one */
+		options?: SpawnAgentRunOverrides
 	) => Promise<{
 		success: boolean;
 		response?: string;
@@ -310,6 +319,7 @@ export function useDocumentProcessor(): UseDocumentProcessorReturn {
 				customPrompt,
 				taskSelectionMode,
 				sshRemoteId,
+				runOverrides,
 			} = config;
 
 			const docFilePath = `${folderPath}/${filename}.md`;
@@ -375,7 +385,8 @@ export function useDocumentProcessor(): UseDocumentProcessorReturn {
 			const result = await callbacks.onSpawnAgent(
 				session.id,
 				finalPrompt,
-				effectiveCwd !== session.cwd ? effectiveCwd : undefined
+				effectiveCwd !== session.cwd ? effectiveCwd : undefined,
+				runOverrides
 			);
 
 			// Capture elapsed time

--- a/src/renderer/hooks/remote/useAppRemoteEventListeners.ts
+++ b/src/renderer/hooks/remote/useAppRemoteEventListeners.ts
@@ -454,11 +454,17 @@ export function useAppRemoteEventListeners(deps: UseAppRemoteEventListenersDeps)
 				// helper writes the resolved values back into config.worktree when
 				// createPROnCompletion is true; we mirror that result onto batchConfig
 				// below so PR creation downstream sees the correct path/branch.
+				// Per-run model/effort override (CLI `--model` / `--effort`). Spread
+				// only when set so an omitted flag never serializes as an empty string,
+				// which would pin the run to a nonexistent model instead of falling
+				// through to the agent default.
 				const batchConfig: BatchRunConfig = {
 					documents,
 					prompt: config.prompt || DEFAULT_BATCH_PROMPT,
 					loopEnabled: config.loopEnabled || false,
 					maxLoops: config.maxLoops,
+					...(config.model && { model: config.model }),
+					...(config.effort && { effort: config.effort }),
 				};
 
 				// Mirror desktop's useAutoRunHandlers: when worktree dispatch is enabled,

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -381,6 +381,11 @@ export interface BatchRunConfig {
 	taskSelectionMode?: TaskSelectionMode; // 'task' (default) or 'document' - controls {{TASK_SELECTION_BLOCK}}
 	worktree?: WorktreeConfig; // Optional worktree configuration
 	worktreeTarget?: WorktreeRunTarget; // Optional target for dispatching to a worktree agent
+	// Per-run model override. Wins over session.customModel for this run's spawns
+	// only - the session and its interactive tabs are never modified, and the
+	// override dies with the run. Absent means "use the agent default".
+	model?: string;
+	effort?: string; // Per-run reasoning effort override, same run-scoped rules as `model`
 	// Goal-Driven mode. Its presence is the discriminator that selects goal mode
 	// over the document/task-driven spec mode. When set, the run pursues a free-text
 	// goal instead of checking off `- [ ]` tasks. See src/shared/goalDriven/types.ts.

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -439,6 +439,11 @@ export interface BatchRunState {
 
 	// Prompt configuration
 	customPrompt?: string; // User's custom prompt if modified
+	// Per-run model override chosen in the launch modal (empty/absent = use the
+	// session's configured model). Scoped to this run only and never persisted to
+	// the session. Read by the exit-path synopsis so per-task synopses spawn under
+	// the same model as the run's tasks, matching the CLI batch processor.
+	runModelOverride?: string;
 	sessionIds: string[]; // Claude session IDs from each iteration
 	startTime?: number; // Timestamp when batch run started
 	cumulativeTaskTimeMs?: number; // Sum of actual task durations (most accurate work time measure)


### PR DESCRIPTION
## Feature F4 - choose a different model for the Auto Run itself

Auto Run previously inherited the model from the session/agent (per-tab -> session -> agent default), with no way to run a specific playbook on a different model without changing the agent globally.

## Change
- Adds `model?` / `effort?` to `BatchRunConfig` (`src/renderer/types/index.ts`).
- Selectable in the Auto Run launch modal (defaults to 'use agent default').
- CLI `--model` / `--effort` flags on `auto-run` and `goal-run`.
- The run-scoped override wins over per-tab/session/agent for that run's spawns ONLY, never written back to the session (`useAgentExecution.ts`: `sessionCustomModel: options?.modelOverride ?? session.customModel`).
- Threaded through the desktop batch/goal runners, the CLI spawner, and the remote/worktree dispatch chain.

## Validation
Type-check (main + lint + cli), ESLint (19 files), Prettier (30 files) clean. Scoped tests (auto-run, batch-processor, goal-runner, messageHandlers, BatchRunnerModal, useAgentExecution, useBatchProcessor) -> 661 pass.

Recommended: an in-app check of the launch-modal model/effort pickers (UI picker not covered by headless tests).

Base: upstream/rc. Playbook: `.maestro/playbooks/FEAT-AUTORUN-MODEL-01.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added run-scoped **Model** and **Reasoning effort** overrides for Auto Run, playbook runs, goal-run, and run-doc, including UI selectors in the run modal.
  * Overrides are applied to agent spawns and synopsis generation for the current run only (synopsis respects the run’s model override).
* **Documentation**
  * Updated CLI reference/guides with `--model <model>` / `--effort <effort>` and clarified run-scoped behavior.
  * Expanded CLI docs for dispatch queueing (including focus/queue/wait) and added movement and queue command documentation.
* **Bug Fixes**
  * Strengthened validation so overrides must be non-empty strings; empty/whitespace values are omitted/rejected appropriately.
* **Tests**
  * Added coverage for precedence, trimming/omission, correct payload forwarding, and rejection cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->