### PR TITLE
refactor(auto-run): decompose BatchRunnerModal into focused hooks

### DIFF
--- a/src/renderer/components/BatchRunnerModal.tsx
+++ b/src/renderer/components/BatchRunnerModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
+import { useState, useRef, useCallback } from 'react';
 import {
 	X,
 	RotateCcw,
@@ -19,13 +19,7 @@ import {
 	Target,
 } from 'lucide-react';
 import { Spinner } from './ui/Spinner';
-import type {
-	Theme,
-	BatchDocumentEntry,
-	BatchRunConfig,
-	TaskSelectionMode,
-	WorktreeRunTarget,
-} from '../types';
+import type { Theme, BatchDocumentEntry, BatchRunConfig, TaskSelectionMode } from '../types';
 import { useModalLayer } from '../hooks/ui/useModalLayer';
 import { useResizableModal } from '../hooks/ui/useResizableModal';
 import { useBracketTabCycle } from '../hooks/utils/useBracketTabCycle';
@@ -39,37 +33,24 @@ import { GoalConfigPanel } from './GoalConfigPanel';
 import { ToggleButtonGroup } from './ToggleButtonGroup';
 import { WorktreeRunSection } from './WorktreeRunSection';
 import { AutoRunnerHelpModal } from './AutoRun/AutoRunnerHelpModal';
-import { useSessionStore, selectSessionById, updateSessionWith } from '../stores/sessionStore';
-import { useDebouncedCallback } from '../hooks/utils/useThrottle';
+import { useSessionStore, selectSessionById } from '../stores/sessionStore';
 import { useBatchStore } from '../stores/batchStore';
 import { useUIStore } from '../stores/uiStore';
-import { getModalActions } from '../stores/modalStore';
 import {
 	usePlaybookManagement,
-	DEFAULT_BATCH_PROMPT,
+	useTaskSelectionRecommendation,
+	useGoalDrivenConfig,
+	usePromptComposerState,
+	useSpecDrivenConfig,
+	useWorktreeRunTarget,
 	validateAgentPromptHasTaskReference,
 } from '../hooks';
-import { generateId } from '../utils/ids';
 import { formatMetaKey } from '../utils/shortcutFormatter';
 import { logger } from '../utils/logger';
-import { resolveEffectiveContextWindow } from '../utils/contextWindowResolver';
-import { getModelContextWindowOverride } from '../../shared/agentConstants';
-import { formatTokens } from '../../shared/formatters';
 import { ResizeHandles } from './ui/ResizeHandles';
 
 // Re-export for external consumers
 export { DEFAULT_BATCH_PROMPT, validateAgentPromptHasTaskReference } from '../hooks';
-
-// Tasks-per-document threshold that flips the recommendation between
-// Document mode (below the threshold - share context) and Task mode
-// (at/above - fresh context per task). Scales linearly with the agent's
-// resolved context window so wider windows can absorb more tasks before
-// the recommendation tips over. Reference anchors: 256K → 5, 512K → 10,
-// 1M → 20. Floors at 5 so tiny windows still get a sensible default.
-function computeTasksPerDocThreshold(contextWindow: number): number {
-	if (!contextWindow || contextWindow <= 0) return 5;
-	return Math.max(5, Math.round((contextWindow / 256_000) * 5));
-}
 
 interface BatchRunnerModalProps {
 	theme: Theme;
@@ -148,151 +129,83 @@ export function BatchRunnerModal(props: BatchRunnerModalProps) {
 	const autoFollowEnabled = useUIStore((s) => s.autoFollowEnabled);
 	const setAutoFollowEnabled = useUIStore((s) => s.setAutoFollowEnabled);
 
-	// Worktree run target state
-	const [worktreeTarget, setWorktreeTarget] = useState<WorktreeRunTarget | null>(null);
-	const [isPreparingWorktree, setIsPreparingWorktree] = useState(false);
 	const activeSession = useSessionStore(selectSessionById(sessionId));
 	const sessions = useSessionStore((state) => state.sessions);
-	// When the current session is a worktree child, worktree config lives on its parent.
-	// Resolve the parent so the WorktreeRunSection can read basePath and list siblings.
-	const worktreeParentSession = useMemo(() => {
-		if (!activeSession) return null;
-		if (activeSession.parentSessionId) {
-			return sessions.find((s) => s.id === activeSession.parentSessionId) ?? activeSession;
-		}
-		return activeSession;
-	}, [activeSession, sessions]);
-	const worktreeChildren = useMemo(
-		() =>
-			worktreeParentSession
-				? sessions.filter(
-						(s) => s.parentSessionId === worktreeParentSession.id && s.id !== sessionId
-					)
-				: [],
-		[sessions, worktreeParentSession, sessionId]
-	);
 
-	const handleOpenWorktreeConfig = useCallback(() => {
-		// Open worktree config on top of the batch runner (WORKTREE_CONFIG priority 752 > BATCH_RUNNER 720).
-		// The batch runner stays open underneath so the user returns to it after configuring.
-		getModalActions().setWorktreeConfigModalOpen(true);
-	}, []);
+	// Which worktree (if any) this run dispatches to.
+	const {
+		worktreeTarget,
+		setWorktreeTarget,
+		isPreparingWorktree,
+		setIsPreparingWorktree,
+		worktreeParentSession,
+		worktreeChildren,
+		handleOpenWorktreeConfig,
+	} = useWorktreeRunTarget({ activeSession, sessions, sessionId });
 
-	// Document list state. Opens empty unless the inline wizard's "Start Auto
-	// Run" pre-seeded it with freshly generated docs via `presetDocuments`.
-	const [documents, setDocuments] = useState<BatchDocumentEntry[]>(() => {
-		if (presetDocuments && presetDocuments.length > 0) {
-			return presetDocuments.map((filename) => ({
-				id: generateId(),
-				filename,
-				resetOnCompletion: false,
-				isDuplicate: false,
-			}));
-		}
-		return [];
-	});
-
-	// Track initial document state for dirty checking. Mirrors the run-list
-	// initialization above so dirty detection is correct for preset opens too.
-	const initialDocumentsRef = useRef<string[]>(
-		presetDocuments && presetDocuments.length > 0 ? [...presetDocuments] : []
-	);
-
-	// Task counts per document (keyed by filename, value = unchecked task count).
-	// Seeded synchronously from the batch store, which is already populated by
-	// useAutoRunDocumentLoader. This avoids redundant per-document SSH `cat`
-	// reads in the modal - critical for SSH-remote sessions where the modal
-	// otherwise stays stuck on "..." while sequential SSH reads pile up.
-	const documentTaskCountsFromStore = useBatchStore((s) => s.documentTaskCounts);
-	const isLoadingDocumentsFromStore = useBatchStore((s) => s.isLoadingDocuments);
-	const seededTaskCounts = useMemo(() => {
-		const out: Record<string, number> = {};
-		documentTaskCountsFromStore.forEach((entry, filename) => {
-			out[filename] = Math.max(0, entry.total - entry.completed);
-		});
-		return out;
-	}, [documentTaskCountsFromStore]);
-	const [taskCounts, setTaskCounts] = useState<Record<string, number>>(seededTaskCounts);
-	const [loadingTaskCounts, setLoadingTaskCounts] = useState(
-		// Only show the loading badge if the store hasn't surfaced any counts yet
-		// AND it's still loading - otherwise we have stale-but-usable data to render.
-		() => isLoadingDocumentsFromStore && Object.keys(seededTaskCounts).length === 0
-	);
-
-	// Loop mode state
-	const [loopEnabled, setLoopEnabled] = useState(false);
-	const [maxLoops, setMaxLoops] = useState<number | null>(null); // null = infinite
-
-	// Track initial loop settings for dirty checking
-	const initialLoopEnabledRef = useRef(false);
-	const initialMaxLoopsRef = useRef<number | null>(null);
+	// Spec-Driven Auto Run: documents, task counts, loop mode.
+	const {
+		documents,
+		setDocuments,
+		initialDocumentsRef,
+		taskCounts,
+		loadingTaskCounts,
+		loopEnabled,
+		setLoopEnabled,
+		maxLoops,
+		setMaxLoops,
+		initialLoopEnabledRef,
+		initialMaxLoopsRef,
+		totalTaskCount,
+		hasNoTasks,
+		missingDocCount,
+	} = useSpecDrivenConfig({ presetDocuments, allDocuments, getDocumentTaskCount });
 
 	// Fresh-context-per mode. Default 'task' preserves legacy behavior (one
 	// agent invocation per unchecked task). 'document' makes the agent walk
 	// every task in a single invocation, sharing context across them.
+	//
+	// Declared here (not inside useTaskSelectionRecommendation) because
+	// usePlaybookManagement's config needs the current value before that hook
+	// runs, and useTaskSelectionRecommendation needs usePlaybookManagement's
+	// loadedPlaybook output - neither hook can own this state without a
+	// circular call-order problem. See useTaskSelectionRecommendation.ts.
 	const [taskSelectionMode, setTaskSelectionMode] = useState<TaskSelectionMode>('task');
 	const initialTaskSelectionModeRef = useRef<TaskSelectionMode>('task');
-	// Set true when the user explicitly clicks the toggle. Sticky: once the
-	// user has expressed a preference we stop auto-applying recommendations and
-	// instead surface a warning if the recommendation disagrees.
-	const [userOverrodeMode, setUserOverrodeMode] = useState(false);
-	// Resolved context window for the active agent. Drives the tasks/doc
-	// threshold that recommendedMode uses. Null until the resolver finishes
-	// (or there's no active session) - recommendations wait for it.
-	const [effectiveContextWindow, setEffectiveContextWindow] = useState<number | null>(null);
 
-	// Goal-Driven mode state. Seeded once from the session's persisted goal config
-	// (see Session.autoRunDriveMode / autoRunGoalConfig) so reopening the modal
-	// restores the tab and the goal inputs. Spec mode is the default.
-	const [autoRunMode, setAutoRunMode] = useState<'spec' | 'goal'>(
-		() => activeSession?.autoRunDriveMode ?? 'spec'
-	);
-	const [goal, setGoal] = useState(() => activeSession?.autoRunGoalConfig?.goal ?? '');
-	const [exitCriteria, setExitCriteria] = useState(
-		() => activeSession?.autoRunGoalConfig?.exitCriteria ?? ''
-	);
-	const [maxIterations, setMaxIterations] = useState<number | null>(
-		() => activeSession?.autoRunGoalConfig?.maxIterations ?? null
-	);
+	// Goal-Driven Auto Run: tab, goal, exit criteria, max iterations, and
+	// debounced persistence back onto the session.
+	const {
+		autoRunMode,
+		setAutoRunMode,
+		goal,
+		setGoal,
+		exitCriteria,
+		setExitCriteria,
+		maxIterations,
+		setMaxIterations,
+		flushGoalConfig,
+	} = useGoalDrivenConfig({ sessionId, activeSession });
 
 	// Auto Run help guide overlay (same content as the Auto Run panel's Help
 	// button). Renders above this modal; closing it returns here.
 	const [showHelp, setShowHelp] = useState(false);
 
-	// Prompt state
-	const [prompt, setPrompt] = useState(initialPrompt || DEFAULT_BATCH_PROMPT);
-	const [variablesExpanded, setVariablesExpanded] = useState(false);
-	const [savedPrompt, setSavedPrompt] = useState(initialPrompt || '');
-	const [promptComposerOpen, setPromptComposerOpen] = useState(false);
-	const textareaRef = useRef<HTMLTextAreaElement>(null);
-
-	// Track initial prompt for dirty checking
-	const initialPromptRef = useRef(initialPrompt || DEFAULT_BATCH_PROMPT);
-
-	// Persist the goal config + selected Auto Run tab back onto the session so the
-	// modal reopens in the same mode with the same inputs. Uses the canonical
-	// updateSessionWith helper (NOT a hand-rolled setSessions map). Debounced so
-	// typing into the goal/exit fields doesn't thrash the session store.
-	const { debouncedCallback: debouncedPersistGoalConfig, flush: flushGoalConfig } =
-		useDebouncedCallback(() => {
-			updateSessionWith(sessionId, (s) => ({
-				...s,
-				autoRunDriveMode: autoRunMode,
-				autoRunGoalConfig: { goal, exitCriteria, maxIterations },
-			}));
-		}, 500);
-
-	// Save shortly after the user stops editing or switches tabs. Skip the very
-	// first run so seeding from the session doesn't immediately write the same
-	// values straight back.
-	const didSeedGoalConfigRef = useRef(false);
-	useEffect(() => {
-		if (!didSeedGoalConfigRef.current) {
-			didSeedGoalConfigRef.current = true;
-			return;
-		}
-		debouncedPersistGoalConfig();
-	}, [autoRunMode, goal, exitCriteria, maxIterations, debouncedPersistGoalConfig]);
+	// Agent prompt: text, saved/default flags, composer, template variables.
+	const {
+		prompt,
+		setPrompt,
+		variablesExpanded,
+		setVariablesExpanded,
+		promptComposerOpen,
+		setPromptComposerOpen,
+		textareaRef,
+		initialPromptRef,
+		handleReset,
+		handleSave,
+		isModified,
+		hasUnsavedChanges,
+	} = usePromptComposerState({ initialPrompt, showConfirmation, onSave });
 
 	// Compute if there are unsaved configuration changes
 	// This checks if documents, loop settings, or prompt have changed from initial values
@@ -390,207 +303,22 @@ export function BatchRunnerModal(props: BatchRunnerModalProps) {
 		onApplyPlaybook: handleApplyPlaybook,
 	});
 
-	// Resolve the active agent's context window the first time the modal opens on
-	// a blank config (no loaded playbook). The resolved window drives the
-	// task-count recommendation's scaling threshold; the Task/Document choice
-	// itself is owned by that recommendation (see the auto-apply effect below),
-	// not a raw window-size cutoff.
-	const autoModeAppliedRef = useRef(false);
-	useEffect(() => {
-		if (autoModeAppliedRef.current) return;
-		// A playbook supplies its own mode - don't second-guess it.
-		if (loadedPlaybook) {
-			autoModeAppliedRef.current = true;
-			return;
-		}
-		if (!activeSession) return;
-
-		let active = true;
-		(async () => {
-			const configured = await resolveEffectiveContextWindow(activeSession);
-			// Also honor a window the agent reported at runtime (e.g. Claude's 1M
-			// beta) even when the configured value was left at the default.
-			const reported = activeSession.aiTabs.reduce(
-				(max, tab) => Math.max(max, tab.usageStats?.contextWindow ?? 0),
-				0
-			);
-			// Honor a per-tab `[1m]` model selection before any usage is reported;
-			// the resolver already covers session- and agent-level model overrides.
-			const tabModelWindow = activeSession.aiTabs.reduce(
-				(max, tab) => Math.max(max, getModelContextWindowOverride(tab.customModel) ?? 0),
-				0
-			);
-			const contextWindow = Math.max(configured, reported, tabModelWindow);
-			if (!active) return;
-			// Expose the resolved window so the task-count recommendation can
-			// scale its tasks/doc threshold (5 at 256K → 20 at 1M).
-			setEffectiveContextWindow(contextWindow);
-			autoModeAppliedRef.current = true;
-		})();
-		return () => {
-			active = false;
-		};
-	}, [activeSession, loadedPlaybook]);
-
-	// Use ref for getDocumentTaskCount to avoid dependency issues
-	const getDocumentTaskCountRef = useRef(getDocumentTaskCount);
-	getDocumentTaskCountRef.current = getDocumentTaskCount;
-
-	// Reflect updates from the store (e.g., when a doc's tasks get checked
-	// after the modal opened). For docs covered by the store, this is the
-	// fast path - no IPC needed.
-	useEffect(() => {
-		setTaskCounts((prev) => {
-			let changed = false;
-			const next = { ...prev };
-			for (const [filename, count] of Object.entries(seededTaskCounts)) {
-				if (next[filename] !== count) {
-					next[filename] = count;
-					changed = true;
-				}
-			}
-			return changed ? next : prev;
-		});
-	}, [seededTaskCounts]);
-
-	// IPC fallback: read counts only for documents NOT already covered by the
-	// store. On SSH-remote sessions the store is normally pre-populated by
-	// useAutoRunDocumentLoader, so this loop runs zero IPC calls in practice.
-	useEffect(() => {
-		const missing = allDocuments.filter((doc) => !(doc in seededTaskCounts));
-		if (missing.length === 0) {
-			setLoadingTaskCounts(false);
-			return;
-		}
-
-		let cancelled = false;
-		const loadMissing = async () => {
-			setLoadingTaskCounts(true);
-			const additions: Record<string, number> = {};
-			for (const doc of missing) {
-				if (cancelled) return;
-				try {
-					additions[doc] = await getDocumentTaskCountRef.current(doc);
-				} catch {
-					additions[doc] = 0;
-				}
-			}
-			if (cancelled) return;
-			setTaskCounts((prev) => ({ ...prev, ...additions }));
-			setLoadingTaskCounts(false);
-		};
-
-		loadMissing();
-		return () => {
-			cancelled = true;
-		};
-	}, [allDocuments, seededTaskCounts]);
-
-	// Calculate total tasks across selected documents (excluding missing documents)
-	const totalTaskCount = documents.reduce((sum, doc) => {
-		// Don't count tasks from missing documents
-		if (doc.isMissing) return sum;
-		return sum + (taskCounts[doc.filename] || 0);
-	}, 0);
-	const hasNoTasks = totalTaskCount === 0;
-
-	// Count missing documents for warning display
-	const missingDocCount = documents.filter((doc) => doc.isMissing).length;
-
-	// Recommend a fresh-context mode based on average tasks per selected doc,
-	// using a threshold that scales with the agent's resolved context window.
-	// Small docs benefit from a shared agent across tasks (less spawn overhead,
-	// no repeated context priming); large docs do better with a fresh context
-	// per task so tool output from earlier tasks doesn't crowd later ones.
-	const tasksPerDocThreshold = useMemo(
-		() =>
-			effectiveContextWindow === null ? null : computeTasksPerDocThreshold(effectiveContextWindow),
-		[effectiveContextWindow]
-	);
-	const recommendation = useMemo<{
-		mode: TaskSelectionMode;
-		averageTasks: number;
-		docCount: number;
-		threshold: number;
-	} | null>(() => {
-		// Wait for the context window resolver - its value drives the threshold.
-		if (tasksPerDocThreshold === null) return null;
-		const validDocs = documents.filter((d) => !d.isMissing);
-		if (validDocs.length === 0) return null;
-		// Wait until at least one selected doc has a task count loaded -
-		// recommending against zeros would lock us into 'document' on first paint.
-		const knownCounts = validDocs
-			.map((d) => taskCounts[d.filename])
-			.filter((n): n is number => typeof n === 'number');
-		if (knownCounts.length === 0) return null;
-		const averageTasks = knownCounts.reduce((a, b) => a + b, 0) / knownCounts.length;
-		return {
-			mode: averageTasks < tasksPerDocThreshold ? 'document' : 'task',
-			averageTasks,
-			docCount: validDocs.length,
-			threshold: tasksPerDocThreshold,
-		};
-	}, [documents, taskCounts, tasksPerDocThreshold]);
-	const recommendedMode = recommendation?.mode ?? null;
-
-	// Auto-apply the task-count recommendation when documents/counts change.
-	// Skips if a playbook is loaded (it owns the mode) or the user has
-	// manually overridden - once they've picked, we respect it and warn
-	// instead of fighting them.
-	useEffect(() => {
-		if (userOverrodeMode) return;
-		if (loadedPlaybook) return;
-		if (recommendedMode === null) return;
-		if (recommendedMode === taskSelectionMode) return;
-		setTaskSelectionMode(recommendedMode);
-		// Keep the dirty check honest: an automatic mode shift shouldn't
-		// mark the form as having unsaved changes.
-		initialTaskSelectionModeRef.current = recommendedMode;
-	}, [recommendedMode, loadedPlaybook, userOverrodeMode, taskSelectionMode]);
-
-	// Wrapped setter for the toggle: any manual click flips the override flag
-	// so future doc-selection changes don't yank the mode back.
-	const handleTaskSelectionModeChange = useCallback((mode: TaskSelectionMode) => {
-		setUserOverrodeMode(true);
-		setTaskSelectionMode(mode);
-	}, []);
-
-	const showRecommendationWarning =
-		userOverrodeMode && recommendedMode !== null && recommendedMode !== taskSelectionMode;
-
-	// Noun for the "sent to the AI agent for each ___ in the queue" helper text.
-	// `taskSelectionMode` always holds a concrete value ('task' default), but a
-	// real selection only exists once the user clicks the toggle OR the
-	// auto-recommendation resolves from actual doc/task counts. Until then the
-	// value is just the un-vetted default, so show the combined "task/document".
-	const hasSelectedMode = userOverrodeMode || recommendedMode !== null;
-	const queueItemNoun = !hasSelectedMode
-		? 'task/document'
-		: taskSelectionMode === 'document'
-			? 'document'
-			: 'task';
-
-	// Human-readable explanation of the dynamic mode choice: average task count
-	// across selected docs + the resolved context window + the threshold that
-	// scales with it. Drives the copy shown above the Task/Document toggle.
-	const recommendationExplanation = useMemo<string | null>(() => {
-		if (recommendation === null || effectiveContextWindow === null) return null;
-		const { averageTasks, docCount, threshold, mode } = recommendation;
-		const avgLabel = Number.isInteger(averageTasks) ? `${averageTasks}` : averageTasks.toFixed(1);
-		const docLabel = docCount === 1 ? '1 document' : `${docCount} documents`;
-		const taskLabel = avgLabel === '1' ? '1 task' : `${avgLabel} tasks`;
-		const windowLabel = formatTokens(effectiveContextWindow);
-		const recommendedLabel = mode === 'task' ? 'Task' : 'Document';
-		const reason =
-			mode === 'task'
-				? `that's at or above the ${threshold}-task cutoff for a ${windowLabel} context window, so a clean context per task avoids crowding the window`
-				: `that's under the ${threshold}-task cutoff for a ${windowLabel} context window, so one shared session can hold the whole document`;
-		if (showRecommendationWarning) {
-			const currentLabel = taskSelectionMode === 'task' ? 'Task' : 'Document';
-			return `Heads up: your ${docLabel} average ${taskLabel} each; ${reason}, so ${recommendedLabel} is the better fit. You've chosen ${currentLabel} - if you know what you're doing, go for it.`;
-		}
-		return `Your ${docLabel} average ${taskLabel} each - ${reason}. Defaulted to ${recommendedLabel}.`;
-	}, [recommendation, effectiveContextWindow, showRecommendationWarning, taskSelectionMode]);
+	// Task/Document fresh-context recommendation engine (context window
+	// resolution, threshold, recommendation, auto-apply, override tracking).
+	const {
+		handleTaskSelectionModeChange,
+		showRecommendationWarning,
+		recommendationExplanation,
+		queueItemNoun,
+	} = useTaskSelectionRecommendation({
+		documents,
+		taskCounts,
+		activeSession,
+		loadedPlaybook,
+		taskSelectionMode,
+		setTaskSelectionMode,
+		initialTaskSelectionModeRef,
+	});
 
 	// Validate agent prompt has task references
 	const hasValidPrompt = validateAgentPromptHasTaskReference(prompt);
@@ -651,24 +379,6 @@ export function BatchRunnerModal(props: BatchRunnerModalProps) {
 		onChange: setAutoRunMode,
 	});
 
-	// Focus textarea on mount
-	useEffect(() => {
-		setTimeout(() => textareaRef.current?.focus(), 100);
-	}, []);
-
-	const handleReset = () => {
-		showConfirmation('Reset the prompt to the default? Your customizations will be lost.', () => {
-			setPrompt(DEFAULT_BATCH_PROMPT);
-		});
-	};
-
-	const handleSave = () => {
-		onSave(prompt);
-		setSavedPrompt(prompt);
-		// Update initial ref so hasUnsavedConfigChanges doesn't flag a saved prompt as dirty
-		initialPromptRef.current = prompt;
-	};
-
 	const handleGo = async () => {
 		// Also save when running
 		onSave(prompt);
@@ -728,8 +438,6 @@ export function BatchRunnerModal(props: BatchRunnerModalProps) {
 		}
 	};
 
-	const isModified = prompt !== DEFAULT_BATCH_PROMPT;
-	const hasUnsavedChanges = prompt !== savedPrompt && prompt !== DEFAULT_BATCH_PROMPT;
 	const resizableModal = useResizableModal({
 		resizeKey: 'batch-runner',
 		defaultSize: { width: 720, height: 720 },

--- a/src/renderer/hooks/batch/index.ts
+++ b/src/renderer/hooks/batch/index.ts
@@ -111,6 +111,32 @@ export type {
 	UseWorktreeValidationDeps,
 } from './useWorktreeValidation';
 
+// Task/Document fresh-context recommendation engine
+export { useTaskSelectionRecommendation } from './useTaskSelectionRecommendation';
+export type {
+	UseTaskSelectionRecommendationReturn,
+	UseTaskSelectionRecommendationDeps,
+} from './useTaskSelectionRecommendation';
+
+// Goal-Driven Auto Run config (tab, goal, exit criteria, max iterations)
+export { useGoalDrivenConfig } from './useGoalDrivenConfig';
+export type { UseGoalDrivenConfigReturn, UseGoalDrivenConfigDeps } from './useGoalDrivenConfig';
+
+// Agent prompt state (text, saved/default flags, composer, template variables)
+export { usePromptComposerState } from './usePromptComposerState';
+export type {
+	UsePromptComposerStateReturn,
+	UsePromptComposerStateDeps,
+} from './usePromptComposerState';
+
+// Spec-Driven Auto Run config (documents, task counts, loop mode)
+export { useSpecDrivenConfig } from './useSpecDrivenConfig';
+export type { UseSpecDrivenConfigReturn, UseSpecDrivenConfigDeps } from './useSpecDrivenConfig';
+
+// Worktree run-target selection (which worktree a run dispatches to)
+export { useWorktreeRunTarget } from './useWorktreeRunTarget';
+export type { UseWorktreeRunTargetReturn, UseWorktreeRunTargetDeps } from './useWorktreeRunTarget';
+
 // Auto Run achievements/badges
 export { useAchievements, queueAchievement } from './useAchievements';
 export type {

--- a/src/renderer/hooks/batch/useGoalDrivenConfig.ts
+++ b/src/renderer/hooks/batch/useGoalDrivenConfig.ts
@@ -1,0 +1,87 @@
+/**
+ * useGoalDrivenConfig Hook
+ *
+ * Extracted from BatchRunnerModal.tsx to manage Goal-Driven Auto Run state:
+ * the active tab (Spec vs Goal), the goal text, exit criteria, and max
+ * iterations, plus debounced persistence back onto the session so the modal
+ * reopens with the same inputs.
+ */
+
+import { useState, useRef, useEffect } from 'react';
+import type { Session } from '../../types';
+import { useDebouncedCallback } from '../utils/useThrottle';
+import { updateSessionWith } from '../../stores/sessionStore';
+
+export interface UseGoalDrivenConfigDeps {
+	sessionId: string;
+	activeSession: Session | undefined;
+}
+
+export interface UseGoalDrivenConfigReturn {
+	autoRunMode: 'spec' | 'goal';
+	setAutoRunMode: React.Dispatch<React.SetStateAction<'spec' | 'goal'>>;
+	goal: string;
+	setGoal: React.Dispatch<React.SetStateAction<string>>;
+	exitCriteria: string;
+	setExitCriteria: React.Dispatch<React.SetStateAction<string>>;
+	maxIterations: number | null;
+	setMaxIterations: React.Dispatch<React.SetStateAction<number | null>>;
+	/** Flush a pending debounced save immediately (e.g. before close/launch). */
+	flushGoalConfig: () => void;
+}
+
+export function useGoalDrivenConfig({
+	sessionId,
+	activeSession,
+}: UseGoalDrivenConfigDeps): UseGoalDrivenConfigReturn {
+	// Seeded once from the session's persisted goal config (see
+	// Session.autoRunDriveMode / autoRunGoalConfig) so reopening the modal
+	// restores the tab and the goal inputs. Spec mode is the default.
+	const [autoRunMode, setAutoRunMode] = useState<'spec' | 'goal'>(
+		() => activeSession?.autoRunDriveMode ?? 'spec'
+	);
+	const [goal, setGoal] = useState(() => activeSession?.autoRunGoalConfig?.goal ?? '');
+	const [exitCriteria, setExitCriteria] = useState(
+		() => activeSession?.autoRunGoalConfig?.exitCriteria ?? ''
+	);
+	const [maxIterations, setMaxIterations] = useState<number | null>(
+		() => activeSession?.autoRunGoalConfig?.maxIterations ?? null
+	);
+
+	// Persist the goal config + selected Auto Run tab back onto the session so the
+	// modal reopens in the same mode with the same inputs. Uses the canonical
+	// updateSessionWith helper (NOT a hand-rolled setSessions map). Debounced so
+	// typing into the goal/exit fields doesn't thrash the session store.
+	const { debouncedCallback: debouncedPersistGoalConfig, flush: flushGoalConfig } =
+		useDebouncedCallback(() => {
+			updateSessionWith(sessionId, (s) => ({
+				...s,
+				autoRunDriveMode: autoRunMode,
+				autoRunGoalConfig: { goal, exitCriteria, maxIterations },
+			}));
+		}, 500);
+
+	// Save shortly after the user stops editing or switches tabs. Skip the very
+	// first run so seeding from the session doesn't immediately write the same
+	// values straight back.
+	const didSeedGoalConfigRef = useRef(false);
+	useEffect(() => {
+		if (!didSeedGoalConfigRef.current) {
+			didSeedGoalConfigRef.current = true;
+			return;
+		}
+		debouncedPersistGoalConfig();
+	}, [autoRunMode, goal, exitCriteria, maxIterations, debouncedPersistGoalConfig]);
+
+	return {
+		autoRunMode,
+		setAutoRunMode,
+		goal,
+		setGoal,
+		exitCriteria,
+		setExitCriteria,
+		maxIterations,
+		setMaxIterations,
+		flushGoalConfig,
+	};
+}

--- a/src/renderer/hooks/batch/usePromptComposerState.ts
+++ b/src/renderer/hooks/batch/usePromptComposerState.ts
@@ -1,0 +1,87 @@
+/**
+ * usePromptComposerState Hook
+ *
+ * Extracted from BatchRunnerModal.tsx to manage the agent prompt: its text,
+ * the saved/default comparison flags, the template-variables panel, the
+ * composer overlay, and focus-on-mount.
+ */
+
+import { useState, useRef, useEffect, useCallback } from 'react';
+import { DEFAULT_BATCH_PROMPT } from './batchUtils';
+
+export interface UsePromptComposerStateDeps {
+	initialPrompt?: string;
+	showConfirmation: (message: string, onConfirm: () => void) => void;
+	onSave: (prompt: string) => void;
+}
+
+export interface UsePromptComposerStateReturn {
+	prompt: string;
+	setPrompt: React.Dispatch<React.SetStateAction<string>>;
+	variablesExpanded: boolean;
+	setVariablesExpanded: React.Dispatch<React.SetStateAction<boolean>>;
+	savedPrompt: string;
+	setSavedPrompt: React.Dispatch<React.SetStateAction<string>>;
+	promptComposerOpen: boolean;
+	setPromptComposerOpen: React.Dispatch<React.SetStateAction<boolean>>;
+	textareaRef: React.RefObject<HTMLTextAreaElement>;
+	/** Tracks the prompt at the time the modal opened / was last saved, for dirty-checking. */
+	initialPromptRef: React.MutableRefObject<string>;
+	handleReset: () => void;
+	handleSave: () => void;
+	isModified: boolean;
+	hasUnsavedChanges: boolean;
+}
+
+export function usePromptComposerState({
+	initialPrompt,
+	showConfirmation,
+	onSave,
+}: UsePromptComposerStateDeps): UsePromptComposerStateReturn {
+	const [prompt, setPrompt] = useState(initialPrompt || DEFAULT_BATCH_PROMPT);
+	const [variablesExpanded, setVariablesExpanded] = useState(false);
+	const [savedPrompt, setSavedPrompt] = useState(initialPrompt || '');
+	const [promptComposerOpen, setPromptComposerOpen] = useState(false);
+	const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+	// Track initial prompt for dirty checking
+	const initialPromptRef = useRef(initialPrompt || DEFAULT_BATCH_PROMPT);
+
+	// Focus textarea on mount
+	useEffect(() => {
+		setTimeout(() => textareaRef.current?.focus(), 100);
+	}, []);
+
+	const handleReset = useCallback(() => {
+		showConfirmation('Reset the prompt to the default? Your customizations will be lost.', () => {
+			setPrompt(DEFAULT_BATCH_PROMPT);
+		});
+	}, [showConfirmation]);
+
+	const handleSave = useCallback(() => {
+		onSave(prompt);
+		setSavedPrompt(prompt);
+		// Update initial ref so hasUnsavedConfigChanges doesn't flag a saved prompt as dirty
+		initialPromptRef.current = prompt;
+	}, [onSave, prompt]);
+
+	const isModified = prompt !== DEFAULT_BATCH_PROMPT;
+	const hasUnsavedChanges = prompt !== savedPrompt && prompt !== DEFAULT_BATCH_PROMPT;
+
+	return {
+		prompt,
+		setPrompt,
+		variablesExpanded,
+		setVariablesExpanded,
+		savedPrompt,
+		setSavedPrompt,
+		promptComposerOpen,
+		setPromptComposerOpen,
+		textareaRef,
+		initialPromptRef,
+		handleReset,
+		handleSave,
+		isModified,
+		hasUnsavedChanges,
+	};
+}

--- a/src/renderer/hooks/batch/useSpecDrivenConfig.ts
+++ b/src/renderer/hooks/batch/useSpecDrivenConfig.ts
@@ -1,0 +1,176 @@
+/**
+ * useSpecDrivenConfig Hook
+ *
+ * Extracted from BatchRunnerModal.tsx to manage Spec-Driven Auto Run state:
+ * the selected documents, their task counts (seeded from the batch store,
+ * with an IPC fallback for anything the store hasn't covered yet), and loop
+ * mode.
+ */
+
+import { useState, useRef, useMemo, useEffect } from 'react';
+import type { BatchDocumentEntry } from '../../types';
+import { useBatchStore } from '../../stores/batchStore';
+import { generateId } from '../../utils/ids';
+
+export interface UseSpecDrivenConfigDeps {
+	presetDocuments?: string[];
+	allDocuments: string[];
+	getDocumentTaskCount: (filename: string) => Promise<number>;
+}
+
+export interface UseSpecDrivenConfigReturn {
+	documents: BatchDocumentEntry[];
+	setDocuments: React.Dispatch<React.SetStateAction<BatchDocumentEntry[]>>;
+	/** Tracks the document list at the time the modal opened, for dirty-checking. */
+	initialDocumentsRef: React.MutableRefObject<string[]>;
+	taskCounts: Record<string, number>;
+	loadingTaskCounts: boolean;
+	loopEnabled: boolean;
+	setLoopEnabled: React.Dispatch<React.SetStateAction<boolean>>;
+	maxLoops: number | null;
+	setMaxLoops: React.Dispatch<React.SetStateAction<number | null>>;
+	/** Tracks loop settings at the time the modal opened, for dirty-checking. */
+	initialLoopEnabledRef: React.MutableRefObject<boolean>;
+	initialMaxLoopsRef: React.MutableRefObject<number | null>;
+	/** Total unchecked tasks across selected documents, excluding missing ones. */
+	totalTaskCount: number;
+	hasNoTasks: boolean;
+	missingDocCount: number;
+}
+
+export function useSpecDrivenConfig({
+	presetDocuments,
+	allDocuments,
+	getDocumentTaskCount,
+}: UseSpecDrivenConfigDeps): UseSpecDrivenConfigReturn {
+	// Document list state. Opens empty unless the inline wizard's "Start Auto
+	// Run" pre-seeded it with freshly generated docs via `presetDocuments`.
+	const [documents, setDocuments] = useState<BatchDocumentEntry[]>(() => {
+		if (presetDocuments && presetDocuments.length > 0) {
+			return presetDocuments.map((filename) => ({
+				id: generateId(),
+				filename,
+				resetOnCompletion: false,
+				isDuplicate: false,
+			}));
+		}
+		return [];
+	});
+
+	// Track initial document state for dirty checking. Mirrors the run-list
+	// initialization above so dirty detection is correct for preset opens too.
+	const initialDocumentsRef = useRef<string[]>(
+		presetDocuments && presetDocuments.length > 0 ? [...presetDocuments] : []
+	);
+
+	// Task counts per document (keyed by filename, value = unchecked task count).
+	// Seeded synchronously from the batch store, which is already populated by
+	// useAutoRunDocumentLoader. This avoids redundant per-document SSH `cat`
+	// reads in the modal - critical for SSH-remote sessions where the modal
+	// otherwise stays stuck on "..." while sequential SSH reads pile up.
+	const documentTaskCountsFromStore = useBatchStore((s) => s.documentTaskCounts);
+	const isLoadingDocumentsFromStore = useBatchStore((s) => s.isLoadingDocuments);
+	const seededTaskCounts = useMemo(() => {
+		const out: Record<string, number> = {};
+		documentTaskCountsFromStore.forEach((entry, filename) => {
+			out[filename] = Math.max(0, entry.total - entry.completed);
+		});
+		return out;
+	}, [documentTaskCountsFromStore]);
+	const [taskCounts, setTaskCounts] = useState<Record<string, number>>(seededTaskCounts);
+	const [loadingTaskCounts, setLoadingTaskCounts] = useState(
+		// Only show the loading badge if the store hasn't surfaced any counts yet
+		// AND it's still loading - otherwise we have stale-but-usable data to render.
+		() => isLoadingDocumentsFromStore && Object.keys(seededTaskCounts).length === 0
+	);
+
+	// Loop mode state
+	const [loopEnabled, setLoopEnabled] = useState(false);
+	const [maxLoops, setMaxLoops] = useState<number | null>(null); // null = infinite
+
+	// Track initial loop settings for dirty checking
+	const initialLoopEnabledRef = useRef(false);
+	const initialMaxLoopsRef = useRef<number | null>(null);
+
+	// Use ref for getDocumentTaskCount to avoid dependency issues
+	const getDocumentTaskCountRef = useRef(getDocumentTaskCount);
+	getDocumentTaskCountRef.current = getDocumentTaskCount;
+
+	// Reflect updates from the store (e.g., when a doc's tasks get checked
+	// after the modal opened). For docs covered by the store, this is the
+	// fast path - no IPC needed.
+	useEffect(() => {
+		setTaskCounts((prev) => {
+			let changed = false;
+			const next = { ...prev };
+			for (const [filename, count] of Object.entries(seededTaskCounts)) {
+				if (next[filename] !== count) {
+					next[filename] = count;
+					changed = true;
+				}
+			}
+			return changed ? next : prev;
+		});
+	}, [seededTaskCounts]);
+
+	// IPC fallback: read counts only for documents NOT already covered by the
+	// store. On SSH-remote sessions the store is normally pre-populated by
+	// useAutoRunDocumentLoader, so this loop runs zero IPC calls in practice.
+	useEffect(() => {
+		const missing = allDocuments.filter((doc) => !(doc in seededTaskCounts));
+		if (missing.length === 0) {
+			setLoadingTaskCounts(false);
+			return;
+		}
+
+		let cancelled = false;
+		const loadMissing = async () => {
+			setLoadingTaskCounts(true);
+			const additions: Record<string, number> = {};
+			for (const doc of missing) {
+				if (cancelled) return;
+				try {
+					additions[doc] = await getDocumentTaskCountRef.current(doc);
+				} catch {
+					additions[doc] = 0;
+				}
+			}
+			if (cancelled) return;
+			setTaskCounts((prev) => ({ ...prev, ...additions }));
+			setLoadingTaskCounts(false);
+		};
+
+		loadMissing();
+		return () => {
+			cancelled = true;
+		};
+	}, [allDocuments, seededTaskCounts]);
+
+	// Calculate total tasks across selected documents (excluding missing documents)
+	const totalTaskCount = documents.reduce((sum, doc) => {
+		// Don't count tasks from missing documents
+		if (doc.isMissing) return sum;
+		return sum + (taskCounts[doc.filename] || 0);
+	}, 0);
+	const hasNoTasks = totalTaskCount === 0;
+
+	// Count missing documents for warning display
+	const missingDocCount = documents.filter((doc) => doc.isMissing).length;
+
+	return {
+		documents,
+		setDocuments,
+		initialDocumentsRef,
+		taskCounts,
+		loadingTaskCounts,
+		loopEnabled,
+		setLoopEnabled,
+		maxLoops,
+		setMaxLoops,
+		initialLoopEnabledRef,
+		initialMaxLoopsRef,
+		totalTaskCount,
+		hasNoTasks,
+		missingDocCount,
+	};
+}

--- a/src/renderer/hooks/batch/useTaskSelectionRecommendation.ts
+++ b/src/renderer/hooks/batch/useTaskSelectionRecommendation.ts
@@ -1,0 +1,230 @@
+/**
+ * useTaskSelectionRecommendation Hook
+ *
+ * Extracted from BatchRunnerModal.tsx to manage the Task/Document
+ * fresh-context recommendation engine for Spec-Driven Auto Run.
+ *
+ * This hook encapsulates:
+ * - Resolving the active agent's effective context window
+ * - Computing the tasks-per-document threshold that scales with it
+ * - Recommending Task vs Document mode based on average tasks per selected doc
+ * - Auto-applying the recommendation (unless a playbook owns the mode, or the
+ *   user has manually overridden it)
+ * - The sticky manual-override flag and its warning copy
+ *
+ * Dependencies:
+ * - documents / taskCounts: to compute the average tasks per selected doc
+ * - activeSession: to resolve the agent's context window
+ * - loadedPlaybook: a loaded playbook owns the mode, so auto-apply is skipped
+ */
+
+import { useState, useRef, useEffect, useMemo, useCallback } from 'react';
+import type { Session, Playbook, BatchDocumentEntry, TaskSelectionMode } from '../../types';
+import { resolveEffectiveContextWindow } from '../../utils/contextWindowResolver';
+import { getModelContextWindowOverride } from '../../../shared/agentConstants';
+import { formatTokens } from '../../../shared/formatters';
+
+// Tasks-per-document threshold that flips the recommendation between
+// Document mode (below the threshold - share context) and Task mode
+// (at/above - fresh context per task). Scales linearly with the agent's
+// resolved context window so wider windows can absorb more tasks before
+// the recommendation tips over. Reference anchors: 256K → 5, 512K → 10,
+// 1M → 20. Floors at 5 so tiny windows still get a sensible default.
+function computeTasksPerDocThreshold(contextWindow: number): number {
+	if (!contextWindow || contextWindow <= 0) return 5;
+	return Math.max(5, Math.round((contextWindow / 256_000) * 5));
+}
+
+export interface UseTaskSelectionRecommendationDeps {
+	documents: BatchDocumentEntry[];
+	taskCounts: Record<string, number>;
+	activeSession: Session | undefined;
+	loadedPlaybook: Playbook | null;
+	/**
+	 * Controlled from the caller (currently BatchRunnerModal, still declared
+	 * alongside `documents`/`loopEnabled` since usePlaybookManagement's config
+	 * needs the current value before this hook runs). This hook only computes
+	 * the recommendation and calls the setter - it does not own the state,
+	 * since usePlaybookManagement needs `taskSelectionMode` and this hook needs
+	 * usePlaybookManagement's `loadedPlaybook` output, so neither can own the
+	 * other's dependency without a circular call-order problem.
+	 */
+	taskSelectionMode: TaskSelectionMode;
+	setTaskSelectionMode: React.Dispatch<React.SetStateAction<TaskSelectionMode>>;
+	initialTaskSelectionModeRef: React.MutableRefObject<TaskSelectionMode>;
+}
+
+export interface UseTaskSelectionRecommendationReturn {
+	/** Wrapped setter for a manual user toggle - flips the sticky override flag. */
+	handleTaskSelectionModeChange: (mode: TaskSelectionMode) => void;
+	showRecommendationWarning: boolean;
+	recommendationExplanation: string | null;
+	queueItemNoun: string;
+}
+
+/**
+ * Hook for managing the Task/Document fresh-context recommendation engine
+ * in BatchRunnerModal.
+ */
+export function useTaskSelectionRecommendation({
+	documents,
+	taskCounts,
+	activeSession,
+	loadedPlaybook,
+	taskSelectionMode,
+	setTaskSelectionMode,
+	initialTaskSelectionModeRef,
+}: UseTaskSelectionRecommendationDeps): UseTaskSelectionRecommendationReturn {
+	// Set true when the user explicitly clicks the toggle. Sticky: once the
+	// user has expressed a preference we stop auto-applying recommendations and
+	// instead surface a warning if the recommendation disagrees.
+	const [userOverrodeMode, setUserOverrodeMode] = useState(false);
+	// Resolved context window for the active agent. Drives the tasks/doc
+	// threshold that recommendedMode uses. Null until the resolver finishes
+	// (or there's no active session) - recommendations wait for it.
+	const [effectiveContextWindow, setEffectiveContextWindow] = useState<number | null>(null);
+
+	// Resolve the active agent's context window the first time the modal opens on
+	// a blank config (no loaded playbook). The resolved window drives the
+	// task-count recommendation's scaling threshold; the Task/Document choice
+	// itself is owned by that recommendation (see the auto-apply effect below),
+	// not a raw window-size cutoff.
+	const autoModeAppliedRef = useRef(false);
+	useEffect(() => {
+		if (autoModeAppliedRef.current) return;
+		// A playbook supplies its own mode - don't second-guess it.
+		if (loadedPlaybook) {
+			autoModeAppliedRef.current = true;
+			return;
+		}
+		if (!activeSession) return;
+
+		let active = true;
+		(async () => {
+			const configured = await resolveEffectiveContextWindow(activeSession);
+			// Also honor a window the agent reported at runtime (e.g. Claude's 1M
+			// beta) even when the configured value was left at the default.
+			const reported = activeSession.aiTabs.reduce(
+				(max, tab) => Math.max(max, tab.usageStats?.contextWindow ?? 0),
+				0
+			);
+			// Honor a per-tab `[1m]` model selection before any usage is reported;
+			// the resolver already covers session- and agent-level model overrides.
+			const tabModelWindow = activeSession.aiTabs.reduce(
+				(max, tab) => Math.max(max, getModelContextWindowOverride(tab.customModel) ?? 0),
+				0
+			);
+			const contextWindow = Math.max(configured, reported, tabModelWindow);
+			if (!active) return;
+			// Expose the resolved window so the task-count recommendation can
+			// scale its tasks/doc threshold (5 at 256K → 20 at 1M).
+			setEffectiveContextWindow(contextWindow);
+			autoModeAppliedRef.current = true;
+		})();
+		return () => {
+			active = false;
+		};
+	}, [activeSession, loadedPlaybook]);
+
+	// Recommend a fresh-context mode based on average tasks per selected doc,
+	// using a threshold that scales with the agent's resolved context window.
+	// Small docs benefit from a shared agent across tasks (less spawn overhead,
+	// no repeated context priming); large docs do better with a fresh context
+	// per task so tool output from earlier tasks doesn't crowd later ones.
+	const tasksPerDocThreshold = useMemo(
+		() =>
+			effectiveContextWindow === null ? null : computeTasksPerDocThreshold(effectiveContextWindow),
+		[effectiveContextWindow]
+	);
+	const recommendation = useMemo<{
+		mode: TaskSelectionMode;
+		averageTasks: number;
+		docCount: number;
+		threshold: number;
+	} | null>(() => {
+		// Wait for the context window resolver - its value drives the threshold.
+		if (tasksPerDocThreshold === null) return null;
+		const validDocs = documents.filter((d) => !d.isMissing);
+		if (validDocs.length === 0) return null;
+		// Wait until at least one selected doc has a task count loaded -
+		// recommending against zeros would lock us into 'document' on first paint.
+		const knownCounts = validDocs
+			.map((d) => taskCounts[d.filename])
+			.filter((n): n is number => typeof n === 'number');
+		if (knownCounts.length === 0) return null;
+		const averageTasks = knownCounts.reduce((a, b) => a + b, 0) / knownCounts.length;
+		return {
+			mode: averageTasks < tasksPerDocThreshold ? 'document' : 'task',
+			averageTasks,
+			docCount: validDocs.length,
+			threshold: tasksPerDocThreshold,
+		};
+	}, [documents, taskCounts, tasksPerDocThreshold]);
+	const recommendedMode = recommendation?.mode ?? null;
+
+	// Auto-apply the task-count recommendation when documents/counts change.
+	// Skips if a playbook is loaded (it owns the mode) or the user has
+	// manually overridden - once they've picked, we respect it and warn
+	// instead of fighting them.
+	useEffect(() => {
+		if (userOverrodeMode) return;
+		if (loadedPlaybook) return;
+		if (recommendedMode === null) return;
+		if (recommendedMode === taskSelectionMode) return;
+		setTaskSelectionMode(recommendedMode);
+		// Keep the dirty check honest: an automatic mode shift shouldn't
+		// mark the form as having unsaved changes.
+		initialTaskSelectionModeRef.current = recommendedMode;
+	}, [recommendedMode, loadedPlaybook, userOverrodeMode, taskSelectionMode]);
+
+	// Wrapped setter for the toggle: any manual click flips the override flag
+	// so future doc-selection changes don't yank the mode back.
+	const handleTaskSelectionModeChange = useCallback((mode: TaskSelectionMode) => {
+		setUserOverrodeMode(true);
+		setTaskSelectionMode(mode);
+	}, []);
+
+	const showRecommendationWarning =
+		userOverrodeMode && recommendedMode !== null && recommendedMode !== taskSelectionMode;
+
+	// Noun for the "sent to the AI agent for each ___ in the queue" helper text.
+	// `taskSelectionMode` always holds a concrete value ('task' default), but a
+	// real selection only exists once the user clicks the toggle OR the
+	// auto-recommendation resolves from actual doc/task counts. Until then the
+	// value is just the un-vetted default, so show the combined "task/document".
+	const hasSelectedMode = userOverrodeMode || recommendedMode !== null;
+	const queueItemNoun = !hasSelectedMode
+		? 'task/document'
+		: taskSelectionMode === 'document'
+			? 'document'
+			: 'task';
+
+	// Human-readable explanation of the dynamic mode choice: average task count
+	// across selected docs + the resolved context window + the threshold that
+	// scales with it. Drives the copy shown above the Task/Document toggle.
+	const recommendationExplanation = useMemo<string | null>(() => {
+		if (recommendation === null || effectiveContextWindow === null) return null;
+		const { averageTasks, docCount, threshold, mode } = recommendation;
+		const avgLabel = Number.isInteger(averageTasks) ? `${averageTasks}` : averageTasks.toFixed(1);
+		const docLabel = docCount === 1 ? '1 document' : `${docCount} documents`;
+		const taskLabel = avgLabel === '1' ? '1 task' : `${avgLabel} tasks`;
+		const windowLabel = formatTokens(effectiveContextWindow);
+		const recommendedLabel = mode === 'task' ? 'Task' : 'Document';
+		const reason =
+			mode === 'task'
+				? `that's at or above the ${threshold}-task cutoff for a ${windowLabel} context window, so a clean context per task avoids crowding the window`
+				: `that's under the ${threshold}-task cutoff for a ${windowLabel} context window, so one shared session can hold the whole document`;
+		if (showRecommendationWarning) {
+			const currentLabel = taskSelectionMode === 'task' ? 'Task' : 'Document';
+			return `Heads up: your ${docLabel} average ${taskLabel} each; ${reason}, so ${recommendedLabel} is the better fit. You've chosen ${currentLabel} - if you know what you're doing, go for it.`;
+		}
+		return `Your ${docLabel} average ${taskLabel} each - ${reason}. Defaulted to ${recommendedLabel}.`;
+	}, [recommendation, effectiveContextWindow, showRecommendationWarning, taskSelectionMode]);
+
+	return {
+		handleTaskSelectionModeChange,
+		showRecommendationWarning,
+		recommendationExplanation,
+		queueItemNoun,
+	};
+}

--- a/src/renderer/hooks/batch/useWorktreeRunTarget.ts
+++ b/src/renderer/hooks/batch/useWorktreeRunTarget.ts
@@ -1,0 +1,73 @@
+/**
+ * useWorktreeRunTarget Hook
+ *
+ * Extracted from BatchRunnerModal.tsx to manage which worktree (if any) a
+ * run should dispatch to: the selected target, the parent/child session
+ * lookup for the WorktreeRunSection UI, and opening the worktree config
+ * overlay. Complements useWorktreeValidation, which validates a path rather
+ * than choosing a target.
+ */
+
+import { useState, useMemo, useCallback } from 'react';
+import type { Session, WorktreeRunTarget } from '../../types';
+import { getModalActions } from '../../stores/modalStore';
+
+export interface UseWorktreeRunTargetDeps {
+	activeSession: Session | undefined;
+	sessions: Session[];
+	sessionId: string;
+}
+
+export interface UseWorktreeRunTargetReturn {
+	worktreeTarget: WorktreeRunTarget | null;
+	setWorktreeTarget: React.Dispatch<React.SetStateAction<WorktreeRunTarget | null>>;
+	isPreparingWorktree: boolean;
+	setIsPreparingWorktree: React.Dispatch<React.SetStateAction<boolean>>;
+	worktreeParentSession: Session | null;
+	worktreeChildren: Session[];
+	handleOpenWorktreeConfig: () => void;
+}
+
+export function useWorktreeRunTarget({
+	activeSession,
+	sessions,
+	sessionId,
+}: UseWorktreeRunTargetDeps): UseWorktreeRunTargetReturn {
+	const [worktreeTarget, setWorktreeTarget] = useState<WorktreeRunTarget | null>(null);
+	const [isPreparingWorktree, setIsPreparingWorktree] = useState(false);
+
+	// When the current session is a worktree child, worktree config lives on its parent.
+	// Resolve the parent so the WorktreeRunSection can read basePath and list siblings.
+	const worktreeParentSession = useMemo(() => {
+		if (!activeSession) return null;
+		if (activeSession.parentSessionId) {
+			return sessions.find((s) => s.id === activeSession.parentSessionId) ?? activeSession;
+		}
+		return activeSession;
+	}, [activeSession, sessions]);
+	const worktreeChildren = useMemo(
+		() =>
+			worktreeParentSession
+				? sessions.filter(
+						(s) => s.parentSessionId === worktreeParentSession.id && s.id !== sessionId
+					)
+				: [],
+		[sessions, worktreeParentSession, sessionId]
+	);
+
+	const handleOpenWorktreeConfig = useCallback(() => {
+		// Open worktree config on top of the batch runner (WORKTREE_CONFIG priority 752 > BATCH_RUNNER 720).
+		// The batch runner stays open underneath so the user returns to it after configuring.
+		getModalActions().setWorktreeConfigModalOpen(true);
+	}, []);
+
+	return {
+		worktreeTarget,
+		setWorktreeTarget,
+		isPreparingWorktree,
+		setIsPreparingWorktree,
+		worktreeParentSession,
+		worktreeChildren,
+		handleOpenWorktreeConfig,
+	};
+}

--- a/src/shared/templateVariables.ts
+++ b/src/shared/templateVariables.ts
@@ -423,7 +423,6 @@ export const TEMPLATE_VARIABLES = [
 		autoRunOnly: true,
 	},
 	{ variable: '{{MONTH}}', description: 'Month (01-12)' },
-	{ variable: '{{MAESTRO_CLI_PATH}}', description: 'Path to maestro-cli' },
 	{ variable: '{{TAB_DEEP_LINK}}', description: 'Deep link to agent + active tab (maestro://)' },
 	{ variable: '{{TIME}}', description: 'Time (HH:MM:SS)' },
 	{ variable: '{{TIMESTAMP}}', description: 'Unix timestamp (ms)' },


### PR DESCRIPTION
- Extract task-selection recommendation, Goal-Driven config, prompt composer state, Spec-Driven config, and worktree run-target selection into src/renderer/hooks/batch/.
- Each extraction is intended to preserve existing behavior; verified against the existing 131-test BatchRunnerModal suite and the broader 715-test batch hook suite.
- Fix a duplicate {{MAESTRO_CLI_PATH}} entry in shared/templateVariables.ts, found during manual testing and unrelated to the extraction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer recommendations for choosing task- or document-based fresh-context modes during batch runs.
  * Added support for configuring goal-driven and spec-driven auto-run settings.
  * Improved worktree target selection and prompt editing, including save, reset, and unsaved-change handling.

* **Documentation**
  * Removed the `MAESTRO_CLI_PATH` template variable from the documented variable list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->