### PR TITLE
fix: keep prompt caret and mention highlights aligned

### DIFF
--- a/src/__tests__/renderer/components/InputArea.test.tsx
+++ b/src/__tests__/renderer/components/InputArea.test.tsx
@@ -291,6 +291,29 @@ describe('InputArea', () => {
 			expect((mentionDecoration as HTMLElement).style.color).toBe('transparent');
 		});
 
+		it('preserves a trailing empty caret line in the mention overlay', () => {
+			const session = createMockSession({ id: 'session-1', inputMode: 'ai' });
+			const peer = createMockSession({ id: 'session-2', name: 'Maestro' });
+			const draft = [
+				'Mas agora, foi corrigido.',
+				'',
+				'Acho que é só s',
+				'',
+				'@Maestro  o que acha?',
+				'',
+			].join('\n');
+			useSessionStore.setState({ sessions: [session, peer], groups: [] });
+
+			const { container } = render(
+				<InputArea {...createDefaultProps({ session, inputValue: draft })} />
+			);
+			const overlay = container.querySelector('.maestro-input-text-overlay') as HTMLDivElement;
+			const trailingLine = screen.getByTestId('maestro-input-overlay-trailing-line');
+
+			expect(overlay.textContent).toBe(`${draft}\u200b`);
+			expect(trailingLine).toHaveTextContent('\u200b');
+		});
+
 		it('shows native text and hides the mention overlay during selection changes', () => {
 			const props = createDefaultProps({ inputValue: 'check @src/index.ts now' });
 			const { container } = render(<InputArea {...props} />);

--- a/src/__tests__/renderer/components/InputArea.test.tsx
+++ b/src/__tests__/renderer/components/InputArea.test.tsx
@@ -257,6 +257,40 @@ describe('InputArea', () => {
 			expect(textarea).toHaveStyle({ color: mockTheme.colors.textMain });
 		});
 
+		it('keeps long wrapped text and an agent mention on the native textarea glyph run', () => {
+			const session = createMockSession({ id: 'session-1', inputMode: 'ai' });
+			const peer = createMockSession({ id: 'session-2', name: 'maestro-omp' });
+			const longDraft = [
+				'Olhasó',
+				'',
+				'oakoekfapoekfpaokef',
+				'apokfpaoefpokaepofkapokfopkaopkefoakepfokapoekfpoakeopfkaopk',
+				'kAPOKFPAKEOPFKAPOKFOKA',
+				'',
+				'@maestro-omp ',
+				'amoma',
+				'oakkkkkkkefae',
+			].join('\n');
+			useSessionStore.setState({ sessions: [session, peer], groups: [] });
+
+			const { container } = render(
+				<InputArea {...createDefaultProps({ session, inputValue: longDraft })} />
+			);
+			const textarea = screen.getByRole('textbox');
+			const overlay = container.querySelector('.maestro-input-text-overlay') as HTMLDivElement;
+			const mentionDecoration = Array.from(overlay.querySelectorAll('span')).find(
+				(element) => element.textContent === '@maestro-omp'
+			);
+
+			expect(textarea).toHaveValue(longDraft);
+			expect(textarea).toHaveStyle({ color: mockTheme.colors.textMain });
+			expect((textarea as HTMLTextAreaElement).style.wordBreak).toBe('break-word');
+			expect(overlay.textContent).toBe(longDraft);
+			expect(overlay.style.color).toBe('transparent');
+			expect(overlay.style.wordBreak).toBe('break-word');
+			expect((mentionDecoration as HTMLElement).style.color).toBe('transparent');
+		});
+
 		it('shows native text and hides the mention overlay during selection changes', () => {
 			const props = createDefaultProps({ inputValue: 'check @src/index.ts now' });
 			const { container } = render(<InputArea {...props} />);

--- a/src/__tests__/renderer/components/InputArea.test.tsx
+++ b/src/__tests__/renderer/components/InputArea.test.tsx
@@ -213,7 +213,7 @@ const createDefaultProps = (
 describe('InputArea', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
-		useSessionStore.setState({ sessions: [] });
+		useSessionStore.setState({ sessions: [], groups: [] });
 	});
 
 	afterEach(() => {
@@ -229,11 +229,54 @@ describe('InputArea', () => {
 			expect(screen.getByRole('textbox')).toBeInTheDocument();
 		});
 
-		it('marks the AI mention overlay for mobile typography synchronization', () => {
-			const props = createDefaultProps();
+		it('uses native textarea text when the AI draft has no recognized mention', () => {
+			const props = createDefaultProps({ inputValue: 'plain text with unknown @todo token' });
 			const { container } = render(<InputArea {...props} />);
+			const textarea = screen.getByRole('textbox');
 
-			expect(container.querySelector('.maestro-input-text-overlay')).toBeInTheDocument();
+			expect(container.querySelector('.maestro-input-text-overlay')).not.toBeInTheDocument();
+			expect(textarea).toHaveStyle({ color: mockTheme.colors.textMain });
+		});
+
+		it('renders decoration only for a recognized mention while keeping native text', () => {
+			const session = createMockSession({ id: 'session-1', inputMode: 'ai' });
+			const peer = createMockSession({ id: 'session-2', name: 'reviewer' });
+			useSessionStore.setState({ sessions: [session, peer], groups: [] });
+			const props = createDefaultProps({ session, inputValue: 'ask @reviewer to check' });
+			const { container } = render(<InputArea {...props} />);
+			const textarea = screen.getByRole('textbox');
+
+			const overlay = container.querySelector('.maestro-input-text-overlay');
+			const mentionDecoration = Array.from(overlay?.querySelectorAll('span') ?? []).find(
+				(element) => element.textContent === '@reviewer'
+			);
+
+			expect(overlay).toBeInTheDocument();
+			expect((overlay as HTMLElement).style.color).toBe('transparent');
+			expect((mentionDecoration as HTMLElement).style.color).toBe('transparent');
+			expect(textarea).toHaveStyle({ color: mockTheme.colors.textMain });
+		});
+
+		it('shows native text and hides the mention overlay during selection changes', () => {
+			const props = createDefaultProps({ inputValue: 'check @src/index.ts now' });
+			const { container } = render(<InputArea {...props} />);
+			const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+			const overlay = container.querySelector('.maestro-input-text-overlay');
+
+			expect(overlay).toBeInTheDocument();
+
+			textarea.focus();
+			textarea.setSelectionRange(0, 5);
+			fireEvent(document, new Event('selectionchange'));
+
+			expect(overlay).toHaveStyle({ visibility: 'hidden' });
+			expect(textarea).toHaveStyle({ color: mockTheme.colors.textMain });
+
+			textarea.setSelectionRange(5, 5);
+			fireEvent(document, new Event('selectionchange'));
+
+			expect(overlay).toHaveStyle({ visibility: 'visible' });
+			expect(textarea).toHaveStyle({ color: mockTheme.colors.textMain });
 		});
 
 		it('renders the notification settings button', () => {

--- a/src/__tests__/renderer/components/InputArea/components/InputTextarea.test.tsx
+++ b/src/__tests__/renderer/components/InputArea/components/InputTextarea.test.tsx
@@ -71,12 +71,11 @@ describe('InputTextarea', () => {
 		expect(textarea.style.maxHeight).toBe('176px');
 	});
 
-	it('renders every glyph in the overlay over a transparent textarea in AI mode', () => {
+	it('keeps native text visible and skips decoration without a recognized mention', () => {
 		const { textarea, overlay } = renderTextarea({ inputValue: 'plain text, no mention' });
 
-		expect(overlay).not.toBeNull();
-		expect(overlay.textContent).toBe('plain text, no mention');
-		expect(textarea.style.color).toBe('transparent');
+		expect(overlay).toBeNull();
+		expect(textarea).toHaveStyle({ color: inputAreaTheme.colors.textMain });
 	});
 
 	it('does not render the overlay in terminal mode', () => {
@@ -87,7 +86,9 @@ describe('InputTextarea', () => {
 	});
 
 	it('re-syncs the overlay after the grown content commits, repairing the stale clamp', () => {
-		const { textarea, overlay, rerenderWith } = renderTextarea({ inputValue: 'line one' });
+		const { textarea, overlay, rerenderWith } = renderTextarea({
+			inputValue: 'line one @src/index.ts',
+		});
 
 		// Text region is 8 rows of 20px. The textarea has already outgrown it; the
 		// overlay is still rendering the shorter, pre-keystroke content.
@@ -106,14 +107,14 @@ describe('InputTextarea', () => {
 		// Commit the taller overlay content. The layout effect keyed on the rendered
 		// segments re-copies the scroll position once the overlay can actually reach it.
 		overlayScroll.grow(220);
-		rerenderWith('line one\nline two');
+		rerenderWith('line one @src/index.ts\nline two');
 
 		expect(overlay.scrollTop).toBe(60);
 		expect(overlay.scrollTop).toBe(textarea.scrollTop);
 	});
 
 	it('keeps syncing the overlay on user-driven scrolling', () => {
-		const { textarea, overlay } = renderTextarea({ inputValue: 'line one' });
+		const { textarea, overlay } = renderTextarea({ inputValue: 'line one @src/index.ts' });
 
 		makeScrollable(textarea, 400, 160);
 		makeScrollable(overlay, 400, 160);

--- a/src/renderer/components/InputArea/components/InputTextarea.tsx
+++ b/src/renderer/components/InputArea/components/InputTextarea.tsx
@@ -246,6 +246,9 @@ export const InputTextarea = memo(function InputTextarea({
 							</span>
 						);
 					})}
+					{inputValue.endsWith('\n') && (
+						<span data-testid="maestro-input-overlay-trailing-line">{'\u200b'}</span>
+					)}
 				</div>
 			)}
 			<textarea

--- a/src/renderer/components/InputArea/components/InputTextarea.tsx
+++ b/src/renderer/components/InputArea/components/InputTextarea.tsx
@@ -1,4 +1,11 @@
-import React, { memo, useCallback, useLayoutEffect, useMemo, useRef } from 'react';
+import React, {
+	memo,
+	useCallback,
+	useLayoutEffect,
+	useMemo,
+	useRef,
+	useState,
+} from 'react';
 import type { Session, Group, Theme } from '../../../types';
 import { getProviderDisplayName } from '../../../utils/sessionValidation';
 import { useSettingsStore } from '../../../stores/settingsStore';
@@ -11,6 +18,7 @@ import {
 import { useSessionStore } from '../../../stores/sessionStore';
 import { buildKnownMentionNameSet } from '../../../hooks/input/useAgentMentionCompletion';
 import { TEXTAREA_MAX_HEIGHT } from '../utils/textareaSizing';
+import { useEventListener } from '../../../hooks/utils/useEventListener';
 
 interface InputTextareaProps {
 	session: Session;
@@ -28,7 +36,7 @@ interface InputTextareaProps {
 }
 
 /**
- * Typography the transparent textarea and the highlight overlay MUST share
+ * Typography the native textarea and the decorative overlay MUST share
  * exactly, or the mention highlights drift away from the caret. Pulled into one
  * constant so the two layers can never disagree (font size / line height /
  * family / letter spacing). Padding is kept in sync separately: the textarea
@@ -76,6 +84,7 @@ export const InputTextarea = memo(function InputTextarea({
 	const overlayEnabled = !isTerminalMode;
 
 	const overlayRef = useRef<HTMLDivElement>(null);
+	const [hasSelection, setHasSelection] = useState(false);
 
 	// The mentionable agent/group roster (from this agent's vantage point).
 	// A bare `@word` only lights up when it names a known agent/group; unknown
@@ -102,6 +111,29 @@ export const InputTextarea = memo(function InputTextarea({
 	const segments = useMemo(
 		() => (overlayEnabled ? tokenizeMentions(inputValue, knownMentionNames) : []),
 		[overlayEnabled, inputValue, knownMentionNames]
+	);
+	const overlayRendered = overlayEnabled && segments.some((segment) => segment.kind !== 'text');
+	const overlayVisible = overlayRendered && !hasSelection;
+
+	const updateSelectionState = (target: HTMLTextAreaElement) => {
+		const nextHasSelection = target.selectionStart !== target.selectionEnd;
+		setHasSelection((current) => (current === nextHasSelection ? current : nextHasSelection));
+	};
+
+	// React's textarea onSelect fires on mouseup, after a drag selection has
+	// already become visible. Track the document selectionchange event so the
+	// decorative layer disappears during the drag itself.
+	useEventListener(
+		'selectionchange',
+		() => {
+			const textarea = inputRef.current;
+			if (!textarea || document.activeElement !== textarea) return;
+			updateSelectionState(textarea);
+		},
+		{
+			target: typeof document !== 'undefined' ? document : null,
+			enabled: overlayRendered,
+		}
 	);
 
 	// Keep the decorative overlay pinned to the textarea's scroll position so the
@@ -133,9 +165,10 @@ export const InputTextarea = memo(function InputTextarea({
 	// it back in a bubble.
 	const chipColors = useMemo(() => getMentionChipColors(theme), [theme]);
 
-	// Style for a single mention chip in the LIVE overlay. The overlay sits over a
-	// transparent <textarea> whose native caret is positioned by the RAW glyphs, so
-	// the decoration must add ZERO inline advance or the caret drifts off the text
+	// Style for a single mention chip in the LIVE overlay. The overlay sits behind
+	// the native <textarea>, so it draws only the chip background and border while
+	// the textarea remains the sole source of visible glyphs, caret, and selection.
+	// The decoration must add ZERO inline advance or it drifts off the native text
 	// (measured >200px on a long path). Two tricks keep it width-exact:
 	//   1. The border is drawn with `inset box-shadow`, never `border`/`outline`,
 	//      because box-shadow does not participate in layout.
@@ -154,7 +187,7 @@ export const InputTextarea = memo(function InputTextarea({
 	// box-decoration-break keeps the fill/border intact if a long mention wraps.
 	const mentionChipStyle = (typeColor: string): React.CSSProperties => ({
 		backgroundColor: chipColors.bg,
-		color: chipColors.text,
+		color: 'transparent',
 		borderRadius: '6px',
 		padding: '0 3px',
 		margin: '0 -3px',
@@ -173,7 +206,7 @@ export const InputTextarea = memo(function InputTextarea({
 					$
 				</span>
 			)}
-			{overlayEnabled && (
+			{overlayRendered && (
 				<div
 					ref={overlayRef}
 					aria-hidden="true"
@@ -187,17 +220,20 @@ export const InputTextarea = memo(function InputTextarea({
 						// Must stay identical to the textarea's `pt-3 pr-3 pb-1 pl-3`, or the
 						// chip overlay drifts off the caret (see SHARED_TYPOGRAPHY).
 						padding: '0.75rem 0.75rem 0.25rem 0.75rem',
-						color: theme.colors.textMain,
+						// The overlay paints decoration only. Keeping every glyph transparent
+						// prevents doubled text during typing and selection.
+						color: 'transparent',
+						visibility: overlayVisible ? 'visible' : 'hidden',
 					}}
 				>
 					{segments.map((seg, i) => {
 						if (seg.kind === 'text') {
 							return <span key={i}>{seg.value}</span>;
 						}
-						// Render the mention as a width-EXACT chip over the raw token
+						// Render the mention as a width-EXACT chip behind the raw token
 						// (`@path` / `@name`). It keeps the sent pill's fill + border + a
 						// type-color accent, but NOT its icon or truncated label: those change
-						// the glyph advance and drift the native caret (see mentionChipStyle).
+						// the glyph advance and drift from the native caret (see mentionChipStyle).
 						// The compact icon+truncation pill still renders in the sent transcript
 						// (RenderedMentionChip), where there is no caret to keep aligned.
 						const typeColor =
@@ -217,13 +253,15 @@ export const InputTextarea = memo(function InputTextarea({
 				className={`relative flex-1 bg-transparent text-sm outline-none ${isTerminalMode ? 'pl-1.5' : 'pl-3'} pt-3 pr-3 pb-1 resize-none min-h-[3.5rem] scrollbar-thin`}
 				style={{
 					...SHARED_TYPOGRAPHY,
-					color: overlayEnabled ? 'transparent' : theme.colors.textMain,
+					// Native text is always visible. The overlay underneath contributes only
+					// the mention chip decoration, never a second copy of the glyphs.
+					color: theme.colors.textMain,
 					caretColor: theme.colors.textMain,
 					// Single source of truth with the resize logic: the CSS cap and
 					// resizeTextareaToContent's clamp can never disagree.
 					maxHeight: `${TEXTAREA_MAX_HEIGHT}px`,
 					// Sit above the decorative overlay so the caret + native selection win.
-					zIndex: overlayEnabled ? 1 : undefined,
+					zIndex: overlayRendered ? 1 : undefined,
 				}}
 				placeholder={
 					isTerminalMode
@@ -234,8 +272,12 @@ export const InputTextarea = memo(function InputTextarea({
 				spellCheck={spellCheckEnabled}
 				onFocus={onInputFocus}
 				onBlur={onInputBlur}
-				onChange={onChange}
-				onScroll={overlayEnabled ? (e) => syncOverlayScroll(e.currentTarget) : undefined}
+				onChange={(e) => {
+					updateSelectionState(e.currentTarget);
+					onChange(e);
+				}}
+				onSelect={(e) => updateSelectionState(e.currentTarget)}
+				onScroll={overlayRendered ? (e) => syncOverlayScroll(e.currentTarget) : undefined}
 				onKeyDown={handleInputKeyDown}
 				onPaste={handlePaste}
 				onDrop={(e) => {

--- a/src/renderer/components/InputArea/components/InputTextarea.tsx
+++ b/src/renderer/components/InputArea/components/InputTextarea.tsx
@@ -1,11 +1,4 @@
-import React, {
-	memo,
-	useCallback,
-	useLayoutEffect,
-	useMemo,
-	useRef,
-	useState,
-} from 'react';
+import React, { memo, useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import type { Session, Group, Theme } from '../../../types';
 import { getProviderDisplayName } from '../../../utils/sessionValidation';
 import { useSettingsStore } from '../../../stores/settingsStore';


### PR DESCRIPTION
## Summary

Fixes two related alignment bugs in the AI prompt composer:

1. The visible draft could drift away from the native textarea caret after long input, line wrapping, scrolling, or selection.
2. A recognized agent or file mention highlight could drift away from its token, including appearing one full line below after a trailing newline.

The fix makes the native textarea the single source of visible text, caret placement, and selection. The overlay now paints mention decoration only.

## User-visible symptoms

Before this change, users could encounter the following behavior:

- After typing a longer multiline prompt, the visible text wrapped differently from the real caret position.
- Newly typed characters could appear at a different visual position from the native cursor.
- A recognized mention such as `@maestro-omp` or `@Maestro` could have its background chip drawn away from the token.
- Pressing Enter after a mention could move the mention decoration one row below the actual mention.
- Selecting text could reveal doubled or overlapping glyphs because both the textarea and overlay participated in rendering the draft.

These were separate visual symptoms of the same architecture: two independent text layers were trying to represent one editable draft.

## Reproduction

1. Open an AI-mode prompt composer.
2. Enter several lines of text, including a long unbroken token that forces wrapping.
3. Insert a recognized agent or file mention.
4. Press Enter so the draft ends with an empty caret line.
5. Continue typing, move the caret, scroll the composer, or select part of the text.

### Previous result

- The visible glyph run could diverge from the native textarea caret.
- The mention decoration could shift horizontally or vertically.
- With a trailing newline, the decoration could appear one full row below the real token.
- Native selection could expose duplicate or overlapping text.

### Expected result

- Visible text, wrapping, caret placement, and selection remain controlled by one native textarea.
- Mention decoration stays directly behind the matching token.
- The final empty caret line is represented consistently in both layers.
- Scrolling and selection do not create a second visible copy of the draft.

## Root cause

The AI composer previously used two visible glyph runs:

- A transparent native textarea owned the real caret, selection, browser wrapping, and scroll position.
- A visible overlay rendered the draft text plus mention chips.

Even with matching typography, the two layers could diverge when the browser wrapped long text, scrolled the textarea, displayed a native selection, or represented a trailing empty line. A `pre-wrap` overlay can also omit the final empty line box when content ends with `\n`, while a textarea still keeps that line for the caret.

## Fix

- Keep the native textarea text visible at all times.
- Use the textarea as the sole source of visible glyphs, caret placement, and selection.
- Render the overlay only when the draft contains a recognized mention.
- Make all overlay glyphs transparent so the overlay paints decoration only.
- Keep typography, padding, line height, word breaking, and wrapping shared between both layers.
- Keep mention decoration width-neutral by using inset shadows and balanced padding with negative margins.
- Preserve a trailing empty caret line with a zero-width sentinel in the overlay.
- Hide mention decoration while native text selection is active.
- Preserve the current RC post-render and user-driven scroll synchronization.

## Scope

- Changes are limited to the AI prompt composer and its regression tests.
- Terminal mode continues to use the native textarea without an overlay.
- Mention parsing and dispatch behavior are unchanged.
- Sent transcript mention chips are unchanged.

## Regression coverage

The tests now cover:

- Plain drafts using native textarea text without an overlay.
- Recognized mentions using a decoration-only overlay.
- Long wrapped text with `@maestro-omp` remaining on the native glyph run.
- A trailing newline after `@Maestro` preserving the final empty caret line.
- Native text selection hiding and restoring mention decoration.
- Post-render overlay scroll repair after content growth.
- User-driven vertical and horizontal scroll synchronization.
- Terminal mode remaining unaffected.

## Validation

- Manually validated in the packaged macOS application by the reporter for both original symptoms.
- 155 focused prompt editor tests passed.
- 34,832 tests passed in the complete local pre-push gate.
- Prettier passed.
- TypeScript passed.
- ESLint passed.
- Full production build passed.

## Risk

Low and localized. The change affects only prompt rendering in `InputTextarea`; input values, mention tokenization, message dispatch, and terminal input behavior remain unchanged.