### PR TITLE
fix: reset composer selection state when decoration unmounts

### DIFF
--- a/src/__tests__/renderer/components/InputArea/components/InputTextarea.test.tsx
+++ b/src/__tests__/renderer/components/InputArea/components/InputTextarea.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
-import type { RefObject } from 'react';
+import type { ComponentProps, RefObject } from 'react';
 import { InputTextarea } from '../../../../../renderer/components/InputArea/components/InputTextarea';
 import { TEXTAREA_MAX_HEIGHT } from '../../../../../renderer/components/InputArea/utils/textareaSizing';
 import { createInputAreaSession, inputAreaTheme } from '../_fixtures';
@@ -33,9 +33,11 @@ function makeScrollable(el: HTMLElement, scrollHeight: number, clientHeight: num
 	};
 }
 
-function renderTextarea(overrides: Record<string, unknown> = {}) {
+type TextareaProps = ComponentProps<typeof InputTextarea>;
+
+function renderTextarea(overrides: Partial<TextareaProps> = {}) {
 	const inputRef: RefObject<HTMLTextAreaElement> = { current: null };
-	const props = {
+	const props: TextareaProps = {
 		session: createInputAreaSession(),
 		theme: inputAreaTheme,
 		isTerminalMode: false,
@@ -49,15 +51,20 @@ function renderTextarea(overrides: Record<string, unknown> = {}) {
 		handleDrop: vi.fn(),
 		...overrides,
 	};
-	const view = render(<InputTextarea {...(props as any)} />);
+	const view = render(<InputTextarea {...props} />);
 	const textarea = view.container.querySelector('textarea') as HTMLTextAreaElement;
 	const overlay = view.container.querySelector('.maestro-input-text-overlay') as HTMLDivElement;
 	return {
 		...view,
 		textarea,
 		overlay,
-		rerenderWith: (value: string) =>
-			view.rerender(<InputTextarea {...(props as any)} inputValue={value} />),
+		// Re-query after a rerender that unmounts/remounts the overlay (mode flip,
+		// last mention deleted) - the captured `overlay` node is stale by then.
+		getOverlay: () =>
+			view.container.querySelector('.maestro-input-text-overlay') as HTMLDivElement | null,
+		rerenderWith: (value: string) => view.rerender(<InputTextarea {...props} inputValue={value} />),
+		rerenderProps: (next: Partial<TextareaProps>) =>
+			view.rerender(<InputTextarea {...props} {...next} />),
 	};
 }
 
@@ -83,6 +90,43 @@ describe('InputTextarea', () => {
 
 		expect(container.querySelector('.maestro-input-text-overlay')).toBeNull();
 		expect(textarea.style.color).not.toBe('transparent');
+	});
+
+	it('restores mention decoration when the selected textarea loses focus', () => {
+		const { textarea, overlay } = renderTextarea({ inputValue: 'check @src/index.ts now' });
+
+		textarea.focus();
+		textarea.setSelectionRange(0, 5);
+		fireEvent(document, new Event('selectionchange'));
+
+		expect(overlay).toHaveStyle({ visibility: 'hidden' });
+
+		// Chromium stops painting the selection on blur, so the chip has to come
+		// back with it - nothing else fires until the user clicks back in.
+		fireEvent.blur(textarea);
+
+		expect(overlay).toHaveStyle({ visibility: 'visible' });
+	});
+
+	it('clears stale selection state while the decoration is unmounted', () => {
+		const { textarea, getOverlay, rerenderProps } = renderTextarea({
+			inputValue: 'check @src/index.ts now',
+		});
+
+		textarea.focus();
+		textarea.setSelectionRange(0, 5);
+		fireEvent(document, new Event('selectionchange'));
+
+		expect(getOverlay()).toHaveStyle({ visibility: 'hidden' });
+
+		// Terminal mode unmounts the overlay AND detaches the selectionchange
+		// listener, so nothing can clear `hasSelection` while it is gone. Coming
+		// back must not restore a permanently hidden decoration layer.
+		rerenderProps({ isTerminalMode: true });
+		expect(getOverlay()).toBeNull();
+
+		rerenderProps({ isTerminalMode: false });
+		expect(getOverlay()).toHaveStyle({ visibility: 'visible' });
 	});
 
 	it('re-syncs the overlay after the grown content commits, repairing the stale clamp', () => {

--- a/src/renderer/components/InputArea/components/InputTextarea.tsx
+++ b/src/renderer/components/InputArea/components/InputTextarea.tsx
@@ -1,4 +1,12 @@
-import React, { memo, useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import React, {
+	memo,
+	useCallback,
+	useEffect,
+	useLayoutEffect,
+	useMemo,
+	useRef,
+	useState,
+} from 'react';
 import type { Session, Group, Theme } from '../../../types';
 import { getProviderDisplayName } from '../../../utils/sessionValidation';
 import { useSettingsStore } from '../../../stores/settingsStore';
@@ -112,6 +120,16 @@ export const InputTextarea = memo(function InputTextarea({
 		const nextHasSelection = target.selectionStart !== target.selectionEnd;
 		setHasSelection((current) => (current === nextHasSelection ? current : nextHasSelection));
 	};
+
+	// `hasSelection` is only ever cleared by an event fired ON the focused
+	// textarea, so it would stay stuck `true` whenever the overlay stops
+	// listening while a range is selected: switching to terminal mode, or
+	// deleting the last mention out of the draft. The chip would then come back
+	// invisible on the next render. Clear the flag whenever the decorative layer
+	// is not rendered (blur is handled on the textarea's own onBlur).
+	useEffect(() => {
+		if (!overlayRendered) setHasSelection(false);
+	}, [overlayRendered]);
 
 	// React's textarea onSelect fires on mouseup, after a drag selection has
 	// already become visible. Track the document selectionchange event so the
@@ -267,7 +285,13 @@ export const InputTextarea = memo(function InputTextarea({
 				value={inputValue}
 				spellCheck={spellCheckEnabled}
 				onFocus={onInputFocus}
-				onBlur={onInputBlur}
+				onBlur={() => {
+					// Chromium stops painting the selection once the textarea loses focus,
+					// so the decoration has to come back with it. Without this the chip
+					// stays hidden until the user clicks back in and collapses the caret.
+					setHasSelection(false);
+					onInputBlur?.();
+				}}
 				onChange={(e) => {
 					updateSelectionState(e.currentTarget);
 					onChange(e);


### PR DESCRIPTION
## Summary

Small follow-up to #1329 (review nit). Branched off that PR's head, so this diff shows #1329's commits until it merges - after that it collapses to the two-line fix plus its tests.

`hasSelection` gates the mention decoration layer in `InputTextarea`, but it is only ever cleared by an event fired on the *focused* textarea. Two paths left it stuck `true`, so the mention chip stayed invisible until the user clicked back in and collapsed the caret.

## Reproduction

**Path 1 - blur**

1. Type a draft containing a recognized mention (`@src/index.ts`, `@SomeAgent`).
2. Select a range of the text.
3. Click somewhere else in the app.

Chromium stops painting the native selection on blur, but the decoration does not come back with it. The chip is gone.

**Path 2 - mode flip**

1. Same draft, select a range.
2. Switch the composer to terminal mode and back.

Terminal mode unmounts the overlay *and* detaches the `selectionchange` listener, so nothing can clear the flag while it is gone. The restored overlay renders permanently hidden. The same applies when the last mention is deleted out of the draft and then re-added.

Both are cosmetic and self-heal on the next caret move, which is why they did not block #1329.

## Fix

- Clear `hasSelection` in the textarea's `onBlur`.
- Clear it in an effect whenever `overlayRendered` is false, covering every unmount route (mode flip, last mention removed) in one place rather than per-path.

## Tests

Two regression tests, both verified to fail against #1329's head and pass with this change:

- `restores mention decoration when the selected textarea loses focus`
- `clears stale selection state while the decoration is unmounted`

The harness needed a `rerenderProps` helper to flip `isTerminalMode` mid-test. While adding it, `renderTextarea` is typed with `ComponentProps<typeof InputTextarea>` instead of `Record<string, unknown>`, which removes the three pre-existing `as any` casts rather than adding a fourth.

## Validation

- 137 scoped composer tests pass (`InputTextarea.test.tsx`, `InputArea.test.tsx`).
- New tests confirmed red without the component change.
- Prettier clean, ESLint clean, `tsc -p tsconfig.lint.json` clean.

## Risk

Very low. Touches only the visibility gate of a decorative layer. No change to input values, mention tokenization, caret behavior, or dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mention decoration behavior when changing selection (decorations now hide and correctly reappear after focus changes).
  * Prevented stale selection state from persisting when the decoration overlay stops rendering or when switching input modes.
* **Tests**
  * Strengthened type-safety for textarea test helpers and added coverage for mention decoration and selection lifecycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->