### PR TITLE
fix(directors-notes): never render the raw structured output as the report

### DIFF
--- a/docs/agent-guides/SHARED-UTILS.md
+++ b/docs/agent-guides/SHARED-UTILS.md
@@ -265,6 +265,20 @@ UI: use `<AdditionalDirectoriesSection>` (`src/renderer/components/shared/`) - d
 
 ---
 
+## Director's Notes Narrative (`src/shared/directorNotesNarrative.ts` - Both)
+
+The Director's Notes synopsis agent emits a structured JSON narrative. This module is the ONLY place that turns that raw string into a `DirectorNotesNarrative` or back into prose. Do not hand-roll JSON extraction, repair, or markdown conversion at a call site.
+
+| Function / Constant                  | Signature                            | Purpose                                                                                                                                                                         |
+| ------------------------------------ | ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `parseDirectorNotesNarrative(raw)`   | `(string) => ParseNarrativeResult`   | Strict parse. Tolerates a code fence or stray prose around the object; rejects any structural deviation with a precise error. Never throws.                                     |
+| `recoverDirectorNotesNarrative(raw)` | `(string) => RecoverNarrativeResult` | Best-effort salvage, called ONLY after a strict failure: repairs a cut-off response and raw control characters, drops malformed items, and returns a `reason` the UI must show. |
+| `narrativeToMarkdown(narrative)`     | `(DirectorNotesNarrative) => string` | Render the narrative as markdown prose (`##` section headings + bullets). Used by Plain Mode, Copy, Save, and the CLI's markdown/text output.                                   |
+
+Rendering rule: no surface may display the raw structured output as if it were the report. Show the narrative (or the salvaged one plus `NarrativeParseError`'s recovery banner); on total failure show the banner with the raw text behind its disclosure.
+
+---
+
 ## History Utilities (`src/shared/history.ts` - Both)
 
 | Function / Constant                  | Signature                                            | Purpose                                                      |

--- a/docs/director-notes.md
+++ b/docs/director-notes.md
@@ -101,6 +101,10 @@ The AI Overview renders the same synopsis two ways, switchable with the **Rich /
 
 You can set which mode opens by default in **Settings > Encore Features > Director's Notes**; the in-tab toggle overrides it for the current session.
 
+#### When the AI's output cannot be parsed
+
+The synopsis agent returns a structured narrative, and both reading modes render from it. If a run comes back malformed (cut off mid-response, or with formatting the parser rejects), Maestro salvages the readable portion and shows it with a banner saying what had to be recovered - a partial report is never presented as a complete one. When nothing usable survives, both modes show a parse-failure banner with the raw output preserved behind **View raw output**. Neither mode ever renders the raw structured output as if it were the report.
+
 **Provider Configuration:**
 Configure which AI provider generates the synopsis in **Settings > Encore Features**. Any installed agent (Claude Code, Codex, OpenCode) can be used. The default lookback window is also configurable there.
 

--- a/src/__tests__/renderer/components/DirectorNotes/AIOverviewTab.test.tsx
+++ b/src/__tests__/renderer/components/DirectorNotes/AIOverviewTab.test.tsx
@@ -803,4 +803,114 @@ describe('AIOverviewTab', () => {
 			expect(content).not.toContain('"version"');
 		});
 	});
+
+	// When the structured output cannot be parsed at all, Plain Mode used to feed
+	// the raw string straight to the markdown renderer - which meant a wall of raw
+	// JSON where the report should be. It must fail as loudly as Rich Mode does.
+	describe('Plain Mode with an unparseable narrative', () => {
+		const rawJson = '{"version":1,"sections":[{"kind":"accomplishments","title":"Accomp';
+
+		beforeEach(() => {
+			mockGenerateSynopsis.mockResolvedValue({
+				success: true,
+				synopsis: rawJson,
+				narrativeError: 'No JSON object found in the response.',
+				stats: { agentCount: 2, entryCount: 9, durationMs: 5000 },
+			});
+		});
+
+		it('shows the parse-failure banner instead of dumping the raw output', async () => {
+			render(<AIOverviewTab theme={mockTheme} />);
+
+			await waitFor(() => {
+				expect(screen.getByTestId('rich-overview')).toBeInTheDocument();
+			});
+
+			fireEvent.click(screen.getByRole('button', { name: /^plain$/i }));
+
+			expect(screen.getByRole('alert')).toHaveTextContent(
+				/could not parse the AI's structured output/i
+			);
+			expect(screen.getByText('No JSON object found in the response.')).toBeInTheDocument();
+			// The raw output is reachable behind the disclosure, never rendered as
+			// if it were the report.
+			expect(screen.queryByTestId('markdown-renderer')).not.toBeInTheDocument();
+		});
+
+		it('keeps the raw output reachable behind the disclosure', async () => {
+			render(<AIOverviewTab theme={mockTheme} />);
+
+			await waitFor(() => {
+				expect(screen.getByTestId('rich-overview')).toBeInTheDocument();
+			});
+
+			fireEvent.click(screen.getByRole('button', { name: /^plain$/i }));
+			fireEvent.click(screen.getByText('View raw output'));
+
+			expect(screen.getByText(rawJson)).toBeInTheDocument();
+		});
+	});
+
+	// A salvaged narrative is still shown - a run costs minutes - but never
+	// silently: the banner says what had to be recovered.
+	describe('Plain Mode with a salvaged narrative', () => {
+		beforeEach(() => {
+			mockGenerateSynopsis.mockResolvedValue({
+				success: true,
+				synopsis:
+					'{"version":1,"sections":[{"kind":"challenges","title":"Challenges","items":[{"tex',
+				narrative: {
+					version: 1 as const,
+					sections: [
+						{
+							kind: 'accomplishments' as const,
+							title: 'Accomplishments',
+							items: [{ text: 'Recovered bullet', severity: 'info' as const }],
+						},
+					],
+				},
+				narrativeError: 'No JSON object found in the response.',
+				narrativeRecovery:
+					'Recovered what could be read: the response was cut off before it finished.',
+				stats: { agentCount: 2, entryCount: 9, durationMs: 5000 },
+			});
+		});
+
+		it('renders the recovered prose alongside the partial-recovery banner', async () => {
+			render(<AIOverviewTab theme={mockTheme} />);
+
+			await waitFor(() => {
+				expect(screen.getByTestId('rich-overview')).toBeInTheDocument();
+			});
+
+			fireEvent.click(screen.getByRole('button', { name: /^plain$/i }));
+
+			expect(screen.getByRole('alert')).toHaveTextContent(/cut off before it finished/i);
+			expect(screen.getByRole('alert')).toHaveTextContent(
+				/Part of the AI's structured output could not be parsed/i
+			);
+
+			const md = screen.getByTestId('markdown-renderer');
+			expect(md.textContent).toContain('## Accomplishments');
+			expect(md.textContent).toContain('- Recovered bullet');
+			expect(md.textContent).not.toContain('"version"');
+		});
+
+		it('Copy exports the recovered prose rather than the unparseable raw output', async () => {
+			render(<AIOverviewTab theme={mockTheme} />);
+
+			await waitFor(() => {
+				expect(screen.getByTestId('rich-overview')).toBeInTheDocument();
+			});
+
+			fireEvent.click(screen.getByText('Copy'));
+
+			await waitFor(() => {
+				expect(mockWriteText).toHaveBeenCalled();
+			});
+			const copied = mockWriteText.mock.calls[0][0] as string;
+			expect(copied).toContain('- Recovered bullet');
+			expect(copied).not.toContain('"version"');
+		});
+	});
 });

--- a/src/__tests__/renderer/components/DirectorNotes/NarrativeParseError.test.tsx
+++ b/src/__tests__/renderer/components/DirectorNotes/NarrativeParseError.test.tsx
@@ -1,8 +1,10 @@
 /**
- * Tests for NarrativeParseError - the OVERT failure surface for Rich Mode.
+ * Tests for NarrativeParseError - the OVERT failure surface shared by Rich and
+ * Plain Mode.
  *
  * Verifies it:
  * - renders a loud, unmissable banner (role="alert" + heading + the precise error)
+ * - switches to the partial-recovery wording when a narrative WAS salvaged
  * - keeps the raw agent output hidden behind a "View raw output" disclosure that
  *   toggles (and tracks aria-expanded)
  * - copies the raw output verbatim and confirms with "Copied!"
@@ -43,8 +45,24 @@ describe('NarrativeParseError', () => {
 		const banner = screen.getByRole('alert');
 		expect(banner).toBeInTheDocument();
 		expect(
-			screen.getByText("Rich Mode could not parse the AI's structured output")
+			screen.getByText("Maestro could not parse the AI's structured output")
 		).toBeInTheDocument();
+		expect(screen.getByText(ERROR)).toBeInTheDocument();
+	});
+
+	it('switches to partial-recovery wording when a narrative was salvaged', () => {
+		const reason = 'Recovered what could be read: the response was cut off before it finished.';
+		render(
+			<NarrativeParseError theme={mockTheme} error={ERROR} rawOutput={RAW} recovery={reason} />
+		);
+
+		expect(
+			screen.getByText("Part of the AI's structured output could not be parsed")
+		).toBeInTheDocument();
+		// The reason is stated out loud so a partial report never reads as complete.
+		expect(screen.getByRole('alert')).toHaveTextContent(/cut off before it finished/i);
+		expect(screen.getByRole('alert')).toHaveTextContent(/may be incomplete/i);
+		// The precise parse error stays visible in both states.
 		expect(screen.getByText(ERROR)).toBeInTheDocument();
 	});
 

--- a/src/__tests__/shared/directorNotesNarrative.test.ts
+++ b/src/__tests__/shared/directorNotesNarrative.test.ts
@@ -18,6 +18,7 @@
 import { describe, it, expect } from 'vitest';
 import {
 	parseDirectorNotesNarrative,
+	recoverDirectorNotesNarrative,
 	narrativeToMarkdown,
 	type DirectorNotesNarrative,
 } from '../../shared/directorNotesNarrative';
@@ -389,5 +390,165 @@ describe('parseDirectorNotesNarrative', () => {
 			expect(md).not.toContain('"kind"');
 			expect(md).not.toContain('"items"');
 		});
+	});
+});
+
+/**
+ * `recoverDirectorNotesNarrative` is the salvage path taken ONLY after the
+ * strict parser rejects the output. A synopsis run costs minutes of agent time,
+ * so the failures that actually happen in the field (a response cut off
+ * mid-stream, a raw line break inside a bullet, one malformed item) must not
+ * cost the whole report. The contract these tests pin down:
+ *   - it recovers the readable portion of a truncated response,
+ *   - it drops individual bad items instead of the document,
+ *   - it always explains what it salvaged (never silently partial),
+ *   - it still refuses output with no narrative content in it.
+ */
+describe('recoverDirectorNotesNarrative', () => {
+	/** Build a full narrative response, then cut it at `chars` to simulate truncation. */
+	const fullResponse = JSON.stringify({
+		version: 1,
+		sections: [
+			{
+				kind: 'accomplishments',
+				title: 'Accomplishments',
+				items: [
+					{ text: 'Shipped the tab-tiling restore', severity: 'info', agent: 'rc' },
+					{ text: 'Fixed the platform detection bug', severity: 'info', agent: 'Maestro' },
+				],
+			},
+			{
+				kind: 'challenges',
+				title: 'Challenges',
+				items: [{ text: 'CI stayed red all week', severity: 'critical', agent: 'rc' }],
+			},
+		],
+	});
+
+	it('recovers the readable sections when the response is cut off mid-string', () => {
+		const truncated = fullResponse.slice(0, fullResponse.indexOf('Fixed the platform') + 8);
+		// Precondition: the strict parser must have failed for recovery to matter.
+		expect(parseDirectorNotesNarrative(truncated).ok).toBe(false);
+
+		const result = recoverDirectorNotesNarrative(truncated);
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.narrative.sections).toHaveLength(1);
+		expect(result.narrative.sections[0].items).toEqual([
+			{ text: 'Shipped the tab-tiling restore', severity: 'info', agent: 'rc' },
+		]);
+		expect(result.reason).toContain('cut off');
+	});
+
+	it('recovers a response cut off between two complete items', () => {
+		const truncated = fullResponse.slice(0, fullResponse.indexOf('},{', 40) + 1);
+		const result = recoverDirectorNotesNarrative(truncated);
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.narrative.sections[0].items[0].text).toBe('Shipped the tab-tiling restore');
+	});
+
+	it('recovers bullets containing a raw line break (invalid JSON the prompt forbids)', () => {
+		const raw =
+			'{"version":1,"sections":[{"kind":"accomplishments","title":"Accomplishments",' +
+			'"items":[{"text":"First line\nsecond line"}]}]}';
+		expect(parseDirectorNotesNarrative(raw).ok).toBe(false);
+
+		const result = recoverDirectorNotesNarrative(raw);
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.narrative.sections[0].items[0].text).toBe('First line\nsecond line');
+		expect(result.reason).toContain('line breaks');
+	});
+
+	it('drops a malformed bullet and keeps the rest of the section', () => {
+		const raw = JSON.stringify({
+			version: 1,
+			sections: [
+				{
+					kind: 'accomplishments',
+					title: 'Accomplishments',
+					items: [{ text: 'Kept this one' }, { agent: 'no text field' }, { text: '   ' }],
+				},
+			],
+		});
+		const result = recoverDirectorNotesNarrative(raw);
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.narrative.sections[0].items).toEqual([{ text: 'Kept this one' }]);
+		expect(result.reason).toContain('2 bullets were malformed and dropped');
+	});
+
+	it('keeps a bullet whose severity is invalid, dropping only that field', () => {
+		const raw = JSON.stringify({
+			version: 1,
+			sections: [
+				{
+					kind: 'accomplishments',
+					title: 'Accomplishments',
+					items: [{ text: 'Still readable', severity: 'catastrophic', agent: 'rc' }],
+				},
+			],
+		});
+		const result = recoverDirectorNotesNarrative(raw);
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.narrative.sections[0].items[0]).toEqual({
+			text: 'Still readable',
+			agent: 'rc',
+		});
+	});
+
+	it('drops a section with an unknown kind rather than the whole document', () => {
+		const raw = JSON.stringify({
+			version: 1,
+			sections: [
+				{ kind: 'vibes', title: 'Vibes', items: [{ text: 'Not a real section' }] },
+				{ kind: 'nextSteps', title: 'Next Steps', items: [{ text: 'Keep going' }] },
+			],
+		});
+		const result = recoverDirectorNotesNarrative(raw);
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.narrative.sections).toHaveLength(1);
+		expect(result.narrative.sections[0].kind).toBe('nextSteps');
+	});
+
+	it('falls back to the canonical title when a salvaged section has none', () => {
+		const raw = '{"version":1,"sections":[{"kind":"challenges","items":[{"text":"A blocker"}]}';
+		const result = recoverDirectorNotesNarrative(raw);
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.narrative.sections[0].title).toBe('Challenges');
+	});
+
+	it('converts a recovered narrative to prose with no JSON left in it', () => {
+		const truncated = fullResponse.slice(0, fullResponse.indexOf('Fixed the platform') + 8);
+		const result = recoverDirectorNotesNarrative(truncated);
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		const md = narrativeToMarkdown(result.narrative);
+		expect(md).toContain('## Accomplishments');
+		expect(md).not.toContain('"version"');
+		expect(md).not.toContain('"sections"');
+	});
+
+	it('refuses output with no narrative content in it', () => {
+		for (const raw of [
+			'',
+			'   ',
+			'Sorry, I could not read the history files.',
+			'{"version":1,"sections":[]}',
+			'{"unrelated":{"nested":true}}',
+		]) {
+			const result = recoverDirectorNotesNarrative(raw);
+			expect(result.ok).toBe(false);
+		}
+	});
+
+	it('never throws, whatever the input', () => {
+		for (const raw of ['{', '{{{{', '[]', 'null', '{"sections":"nope"}', '{"sections":[{']) {
+			expect(() => recoverDirectorNotesNarrative(raw)).not.toThrow();
+		}
 	});
 });

--- a/src/cli/commands/director-notes-synopsis.ts
+++ b/src/cli/commands/director-notes-synopsis.ts
@@ -7,6 +7,7 @@ import { readSettings } from '../services/storage';
 import { formatError } from '../output/formatter';
 import {
 	parseDirectorNotesNarrative,
+	recoverDirectorNotesNarrative,
 	narrativeToMarkdown,
 } from '../../shared/directorNotesNarrative';
 
@@ -60,13 +61,21 @@ function checkEncoreFeatureEnabled(): void {
 /**
  * The agent emits the structured JSON narrative now. For the human-readable
  * `markdown`/`text` formats, convert it back to markdown prose (the pre-Rich-Mode
- * output). Falls back to the raw string for legacy markdown or unparseable
- * output, so this never makes the CLI output worse than the raw synopsis.
- * (`-f json` stays untouched - it intentionally returns the raw `synopsis`.)
+ * output). Output the strict parser rejects gets the same best-effort salvage the
+ * desktop surfaces use, with the reason noted inline so a partial report never
+ * reads as a complete one. Falls back to the raw string for legacy markdown, so
+ * this never makes the CLI output worse than the raw synopsis. (`-f json` stays
+ * untouched - it intentionally returns the raw `synopsis`.)
  */
 function synopsisToReadableMarkdown(synopsis: string): string {
 	const parsed = parseDirectorNotesNarrative(synopsis);
-	return parsed.ok ? narrativeToMarkdown(parsed.narrative) : synopsis;
+	if (parsed.ok) return narrativeToMarkdown(parsed.narrative);
+
+	const recovered = recoverDirectorNotesNarrative(synopsis);
+	if (recovered.ok) {
+		return `> ${recovered.reason}\n\n${narrativeToMarkdown(recovered.narrative)}`;
+	}
+	return synopsis;
 }
 
 function stripMarkdownFormatting(md: string): string {

--- a/src/main/ipc/handlers/director-notes.ts
+++ b/src/main/ipc/handlers/director-notes.ts
@@ -27,6 +27,7 @@ import { groomContext } from '../../utils/context-groomer';
 import { buildDirectorNotesSynopsisPrompt } from '../../utils/director-notes-prompt';
 import {
 	parseDirectorNotesNarrative,
+	recoverDirectorNotesNarrative,
 	type DirectorNotesNarrative,
 } from '../../../shared/directorNotesNarrative';
 import { getPrompt } from '../../prompt-manager';
@@ -225,9 +226,10 @@ export interface SynopsisResult {
 	stats?: SynopsisStats;
 	error?: string;
 	/**
-	 * Parsed structured narrative for Rich Mode. Present only when the raw
-	 * `synopsis` parsed cleanly. Plain Mode and copy/save never read this - they
-	 * use `synopsis` verbatim.
+	 * Parsed structured narrative. Rich Mode renders it as section cards and
+	 * Plain Mode renders it as markdown prose, so this is what every reading
+	 * surface consumes; `synopsis` stays the verbatim raw output. Present on a
+	 * clean parse AND on a successful salvage (see `narrativeRecovery`).
 	 */
 	narrative?: DirectorNotesNarrative;
 	/**
@@ -237,6 +239,13 @@ export interface SynopsisResult {
 	 * reachable. Never a reason to fail the whole call.
 	 */
 	narrativeError?: string;
+	/**
+	 * Set when `narrative` came from a salvage of output the strict parser
+	 * rejected (a cut-off response, stray control characters, malformed bullets).
+	 * Explains what was recovered so the UI can say so rather than passing a
+	 * partial report off as a complete one.
+	 */
+	narrativeRecovery?: string;
 }
 
 /**
@@ -766,17 +775,30 @@ export function registerDirectorNotesHandlers(deps: DirectorNotesHandlerDependen
 						completionReason: result.completionReason,
 					});
 
-					// Parse the raw output into the structured narrative for Rich Mode.
-					// `synopsis` stays the verbatim raw string (Plain Mode + copy/save
-					// depend on that). A parse failure is NOT a synopsis failure: we
-					// still return success with the raw text and a populated
-					// `narrativeError` so the renderer can show an overt error while
-					// keeping the raw output reachable.
+					// Parse the raw output into the structured narrative every reading
+					// surface renders. `synopsis` stays the verbatim raw string. A parse
+					// failure is NOT a synopsis failure: fall back to a best-effort
+					// salvage (a run costs minutes, so a cut-off response should still
+					// be readable), and only when nothing survives do we return the bare
+					// `narrativeError` for the overt failure banner.
 					const parsed = parseDirectorNotesNarrative(synopsis);
-					if (!parsed.ok) {
+					let narrativeFields: Partial<SynopsisResult>;
+					if (parsed.ok) {
+						narrativeFields = { narrative: parsed.narrative };
+					} else {
+						const recovered = recoverDirectorNotesNarrative(synopsis);
 						logger.warn('Synopsis narrative parse failed', LOG_CONTEXT, {
 							narrativeError: parsed.error,
+							recovered: recovered.ok,
+							recoveryReason: recovered.ok ? recovered.reason : undefined,
 						});
+						narrativeFields = recovered.ok
+							? {
+									narrative: recovered.narrative,
+									narrativeError: parsed.error,
+									narrativeRecovery: recovered.reason,
+								}
+							: { narrativeError: parsed.error };
 					}
 
 					return {
@@ -788,7 +810,7 @@ export function registerDirectorNotesHandlers(deps: DirectorNotesHandlerDependen
 							entryCount,
 							durationMs: result.durationMs,
 						},
-						...(parsed.ok ? { narrative: parsed.narrative } : { narrativeError: parsed.error }),
+						...narrativeFields,
 					};
 				} catch (err) {
 					const errorMsg = err instanceof Error ? err.message : String(err);

--- a/src/main/preload/directorNotes.ts
+++ b/src/main/preload/directorNotes.ts
@@ -106,10 +106,12 @@ export interface SynopsisResult {
 	generatedAt?: number; // Unix ms timestamp of when the synopsis was generated
 	stats?: SynopsisStats;
 	error?: string;
-	/** Parsed structured narrative for Rich Mode (present only on clean parse). */
+	/** Parsed structured narrative, from a clean parse or a salvage. */
 	narrative?: DirectorNotesNarrative;
 	/** Set when the raw synopsis could not be parsed into a structured narrative. */
 	narrativeError?: string;
+	/** Set when `narrative` was salvaged; explains what had to be recovered. */
+	narrativeRecovery?: string;
 }
 
 /**

--- a/src/renderer/components/DirectorNotes/AIOverviewTab.tsx
+++ b/src/renderer/components/DirectorNotes/AIOverviewTab.tsx
@@ -15,6 +15,7 @@ import { Spinner } from '../ui/Spinner';
 import type { Theme } from '../../types';
 import { MarkdownRenderer } from '../MarkdownRenderer';
 import { RichOverview } from './RichOverview';
+import { NarrativeParseError } from './NarrativeParseError';
 import { SaveMarkdownModal } from '../SaveMarkdownModal';
 import { useSettings } from '../../hooks';
 import { generateTerminalProseStyles } from '../../utils/markdownConfig';
@@ -85,6 +86,7 @@ let cachedSynopsis: {
 	stats?: SynopsisStats;
 	narrative?: DirectorNotesNarrative | null;
 	narrativeError?: string | null;
+	narrativeRecovery?: string | null;
 } | null = null;
 
 // Exported for testing only – allows resetting the module-level cache between test runs
@@ -121,14 +123,18 @@ export function AIOverviewTab({ theme, onSynopsisReady }: AIOverviewTabProps) {
 	const { directorNotesSettings, bionifyReadingMode } = useSettings();
 	const [lookbackDays, setLookbackDays] = useState(directorNotesSettings.defaultLookbackDays);
 	const [synopsis, setSynopsis] = useState<string>(cachedSynopsis?.content ?? '');
-	// Structured narrative (Rich Mode) and its overt parse-failure detail, both
-	// derived from the synopsis result. Plain Mode ignores these and renders the
-	// raw `synopsis` markdown.
+	// Structured narrative and its overt parse-failure detail, both derived from
+	// the synopsis result. BOTH reading modes render from the narrative: Rich as
+	// section cards, Plain as markdown prose. `narrativeRecovery` is set when the
+	// narrative had to be salvaged, and drives the partial-recovery banner.
 	const [narrative, setNarrative] = useState<DirectorNotesNarrative | null>(
 		cachedSynopsis?.narrative ?? null
 	);
 	const [narrativeError, setNarrativeError] = useState<string | null>(
 		cachedSynopsis?.narrativeError ?? null
+	);
+	const [narrativeRecovery, setNarrativeRecovery] = useState<string | null>(
+		cachedSynopsis?.narrativeRecovery ?? null
 	);
 	const [generatedAt, setGeneratedAt] = useState<number | null>(
 		cachedSynopsis?.generatedAt ?? null
@@ -160,6 +166,23 @@ export function AIOverviewTab({ theme, onSynopsisReady }: AIOverviewTabProps) {
 		setViewMode(mode);
 		localStorage.setItem(VIEW_MODE_STORAGE_KEY, mode);
 	}, []);
+
+	// Three paths consume a synopsis result (fresh generation, attaching to an
+	// in-flight run, restoring the cache) and each has to apply the same narrative
+	// triple. Applying it in one place is what keeps a surface from silently
+	// missing a field.
+	const applyNarrative = useCallback(
+		(source: {
+			narrative?: DirectorNotesNarrative | null;
+			narrativeError?: string | null;
+			narrativeRecovery?: string | null;
+		}) => {
+			setNarrative(source.narrative ?? null);
+			setNarrativeError(source.narrativeError ?? null);
+			setNarrativeRecovery(source.narrativeRecovery ?? null);
+		},
+		[]
+	);
 	const isGeneratingRef = useRef(false);
 
 	// Base prose styling for the Plain-mode markdown block. (Rich mode frames the
@@ -244,6 +267,7 @@ export function AIOverviewTab({ theme, onSynopsisReady }: AIOverviewTabProps) {
 					stats: result.stats,
 					narrative: result.narrative ?? null,
 					narrativeError: result.narrativeError ?? null,
+					narrativeRecovery: result.narrativeRecovery ?? null,
 				};
 			}
 
@@ -258,8 +282,7 @@ export function AIOverviewTab({ theme, onSynopsisReady }: AIOverviewTabProps) {
 			if (result.success) {
 				const ts = result.generatedAt ?? Date.now();
 				setSynopsis(result.synopsis);
-				setNarrative(result.narrative ?? null);
-				setNarrativeError(result.narrativeError ?? null);
+				applyNarrative(result);
 				setGeneratedAt(ts);
 				setStats(result.stats ?? null);
 				onSynopsisReady?.();
@@ -279,15 +302,14 @@ export function AIOverviewTab({ theme, onSynopsisReady }: AIOverviewTabProps) {
 				setIsGenerating(false);
 			}
 		}
-	}, [lookbackDays, directorNotesSettings, onSynopsisReady]);
+	}, [lookbackDays, directorNotesSettings, onSynopsisReady, applyNarrative]);
 
 	// On mount: use cache if available, attach to in-flight generation, or start fresh
 	useEffect(() => {
 		mountedRef.current = true;
 		if (cachedSynopsis) {
 			setSynopsis(cachedSynopsis.content);
-			setNarrative(cachedSynopsis.narrative ?? null);
-			setNarrativeError(cachedSynopsis.narrativeError ?? null);
+			applyNarrative(cachedSynopsis);
 			setGeneratedAt(cachedSynopsis.generatedAt);
 			setStats(cachedSynopsis.stats ?? null);
 			setLookbackDays(cachedSynopsis.lookbackDays);
@@ -305,8 +327,7 @@ export function AIOverviewTab({ theme, onSynopsisReady }: AIOverviewTabProps) {
 					if (result.success) {
 						const ts = result.generatedAt ?? Date.now();
 						setSynopsis(result.synopsis);
-						setNarrative(result.narrative ?? null);
-						setNarrativeError(result.narrativeError ?? null);
+						applyNarrative(result);
 						setGeneratedAt(ts);
 						setStats(result.stats ?? null);
 						if (cachedSynopsis) setLookbackDays(cachedSynopsis.lookbackDays);
@@ -555,6 +576,7 @@ export function AIOverviewTab({ theme, onSynopsisReady }: AIOverviewTabProps) {
 							synopsis={synopsis}
 							narrative={narrative}
 							narrativeError={narrativeError}
+							narrativeRecovery={narrativeRecovery}
 							lookbackDays={lookbackDays}
 							enableBionifyReadingMode={bionifyReadingMode}
 							chatMath
@@ -562,15 +584,31 @@ export function AIOverviewTab({ theme, onSynopsisReady }: AIOverviewTabProps) {
 					) : (
 						// Content-driven AI output: opt back into text selection under
 						// the modal's select-none (see CLAUDE.md modal text rules).
-						<div className="director-notes-content select-text">
+						<div className="director-notes-content select-text flex flex-col gap-4">
 							<style>{proseStyles}</style>
-							<MarkdownRenderer
-								content={plainContent}
-								theme={theme}
-								onCopy={(text) => safeClipboardWrite(text)}
-								enableBionifyReadingMode={bionifyReadingMode}
-								chatMath
-							/>
+							{/* Plain Mode fails as loudly as Rich Mode. Dumping the raw
+							    structured output into the markdown renderer would show a
+							    wall of JSON where a report should be. */}
+							{narrativeError && (
+								<NarrativeParseError
+									theme={theme}
+									error={narrativeError}
+									rawOutput={synopsis}
+									recovery={narrativeRecovery}
+								/>
+							)}
+							{/* Prose from the narrative, or the raw string when there is no
+							    narrative to build from and nothing failed (legacy markdown
+							    synopses and the "no history files" message). */}
+							{(narrative || !narrativeError) && (
+								<MarkdownRenderer
+									content={plainContent}
+									theme={theme}
+									onCopy={(text) => safeClipboardWrite(text)}
+									enableBionifyReadingMode={bionifyReadingMode}
+									chatMath
+								/>
+							)}
 						</div>
 					)
 				) : isGenerating ? (

--- a/src/renderer/components/DirectorNotes/NarrativeParseError.tsx
+++ b/src/renderer/components/DirectorNotes/NarrativeParseError.tsx
@@ -1,16 +1,22 @@
 /**
  * NarrativeParseError
  *
- * The OVERT failure surface for Rich Mode. When the AI's structured output
- * cannot be parsed into a `DirectorNotesNarrative`, Rich Mode must fail loudly
- * instead of silently degrading to plain text: this banner makes the failure
- * unmissable (error-colored border + background + alert icon, full width) and
- * still keeps the raw output reachable behind a "View raw output" disclosure
- * with a Copy button.
+ * The OVERT failure surface shared by BOTH reading modes. When the AI's
+ * structured output cannot be parsed into a `DirectorNotesNarrative`, Rich and
+ * Plain Mode must fail loudly instead of silently degrading: neither may dump
+ * the raw JSON object into a markdown renderer and call it a report. This banner
+ * makes the failure unmissable (colored border + background + alert icon, full
+ * width) and keeps the raw output reachable behind a "View raw output"
+ * disclosure with a Copy button.
  *
- * It deliberately does NOT render the markdown as if nothing went wrong. The
- * deterministic stat widgets above it keep rendering (the numbers are unaffected
- * by a narrative parse failure); only the narrative area shows this error.
+ * Two states:
+ * - Failure (default): nothing usable survived; this banner is all there is.
+ * - Recovered (`recovery` set): a salvaged narrative renders alongside it, so
+ *   the banner takes the softer warning tone and says what was recovered rather
+ *   than passing a partial report off as a complete one.
+ *
+ * The deterministic stat widgets are unaffected either way (their numbers never
+ * come from the LLM); only the narrative area shows this banner.
  */
 
 import { useState } from 'react';
@@ -24,9 +30,20 @@ interface NarrativeParseErrorProps {
 	error: string;
 	/** The raw agent output, preserved verbatim and shown on disclosure. */
 	rawOutput: string;
+	/**
+	 * Set when a narrative WAS salvaged from this output: the human-readable
+	 * reason from `recoverDirectorNotesNarrative`. Switches the banner to the
+	 * partial-recovery state.
+	 */
+	recovery?: string | null;
 }
 
-export function NarrativeParseError({ theme, error, rawOutput }: NarrativeParseErrorProps) {
+export function NarrativeParseError({
+	theme,
+	error,
+	rawOutput,
+	recovery,
+}: NarrativeParseErrorProps) {
 	const [showRaw, setShowRaw] = useState(false);
 	const [copied, setCopied] = useState(false);
 
@@ -39,30 +56,37 @@ export function NarrativeParseError({ theme, error, rawOutput }: NarrativeParseE
 		}
 	};
 
+	// A recovered run still produced a readable narrative, so it warns rather
+	// than errors; a total failure keeps the full error treatment.
+	const accent = recovery ? theme.colors.warning : theme.colors.error;
+
 	return (
 		<div
 			className="w-full rounded-lg border overflow-hidden"
 			style={{
-				backgroundColor: theme.colors.error + '14',
-				borderColor: theme.colors.error + '66',
+				backgroundColor: accent + '14',
+				borderColor: accent + '66',
 			}}
 			role="alert"
 		>
 			<div className="flex items-start gap-3 p-4">
 				<AlertTriangle
 					className="w-5 h-5 shrink-0 mt-0.5"
-					style={{ color: theme.colors.error }}
+					style={{ color: accent }}
 					aria-hidden="true"
 				/>
 				<div className="flex-1 min-w-0 select-text">
-					<h3 className="text-sm font-bold" style={{ color: theme.colors.error }}>
-						Rich Mode could not parse the AI's structured output
+					<h3 className="text-sm font-bold" style={{ color: accent }}>
+						{recovery
+							? "Part of the AI's structured output could not be parsed"
+							: "Maestro could not parse the AI's structured output"}
 					</h3>
 					<p className="text-xs mt-1" style={{ color: theme.colors.textMain }}>
-						The deterministic stats above are unaffected, but the narrative could not be built. The
-						raw output is preserved below and in Plain Mode / Copy / Save.
+						{recovery
+							? `${recovery} The narrative shown was rebuilt from the readable part, so it may be incomplete.`
+							: 'The activity stats are unaffected, but the narrative could not be built from this run. The raw output is preserved below, and Copy / Save export it verbatim.'}
 					</p>
-					<p className="text-xs mt-2 font-mono break-words" style={{ color: theme.colors.error }}>
+					<p className="text-xs mt-2 font-mono break-words" style={{ color: accent }}>
 						{error}
 					</p>
 

--- a/src/renderer/components/DirectorNotes/RichOverview.tsx
+++ b/src/renderer/components/DirectorNotes/RichOverview.tsx
@@ -67,6 +67,8 @@ interface RichOverviewProps {
 	narrative?: DirectorNotesNarrative | null;
 	/** Set when the structured output failed to parse; renders the overt error banner. */
 	narrativeError?: string | null;
+	/** Set when `narrative` was salvaged from unparseable output; renders the banner alongside it. */
+	narrativeRecovery?: string | null;
 	/** Lookback window in days; drives the IPC query. */
 	lookbackDays: number;
 	/** Forwarded to the narrative MarkdownRenderer (matches Plain-mode behavior). */
@@ -81,6 +83,7 @@ export function RichOverview({
 	synopsis,
 	narrative,
 	narrativeError,
+	narrativeRecovery,
 	lookbackDays,
 	enableBionifyReadingMode = false,
 	chatMath = false,
@@ -244,9 +247,20 @@ export function RichOverview({
 			{/* AI narrative slot. Priority: structured narrative -> overt parse
 			    failure -> legacy markdown fallback (e.g. a cached result that only
 			    has markdown). A parse failure surfaces loudly here while the
-			    deterministic widgets above keep rendering normally. */}
+			    deterministic widgets above keep rendering normally. A salvaged
+			    narrative renders with the banner above it, never silently. */}
 			{narrative ? (
-				<NarrativeSections theme={theme} narrative={narrative} />
+				<>
+					{narrativeError && (
+						<NarrativeParseError
+							theme={theme}
+							error={narrativeError}
+							rawOutput={synopsis}
+							recovery={narrativeRecovery}
+						/>
+					)}
+					<NarrativeSections theme={theme} narrative={narrative} />
+				</>
 			) : narrativeError ? (
 				<NarrativeParseError theme={theme} error={narrativeError} rawOutput={synopsis} />
 			) : (

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -3853,10 +3853,12 @@ interface MaestroAPI {
 				durationMs: number;
 			};
 			error?: string;
-			/** Parsed structured narrative for Rich Mode (present only on clean parse). */
+			/** Parsed structured narrative, from a clean parse or a salvage. */
 			narrative?: import('../shared/directorNotesNarrative').DirectorNotesNarrative;
 			/** Set when the raw synopsis could not be parsed into a structured narrative. */
 			narrativeError?: string;
+			/** Set when `narrative` was salvaged; explains what had to be recovered. */
+			narrativeRecovery?: string;
 		}>;
 		/** Subscribe to synopsis generation progress updates. Returns cleanup function. */
 		onSynopsisProgress: (

--- a/src/shared/directorNotesNarrative.ts
+++ b/src/shared/directorNotesNarrative.ts
@@ -50,11 +50,26 @@ export type ParseNarrativeResult =
 	| { ok: true; narrative: DirectorNotesNarrative }
 	| { ok: false; error: string };
 
+/**
+ * Discriminated result of {@link recoverDirectorNotesNarrative}. `reason`
+ * explains what had to be salvaged so the UI can say so out loud.
+ */
+export type RecoverNarrativeResult =
+	| { ok: true; narrative: DirectorNotesNarrative; reason: string }
+	| { ok: false; error: string };
+
 const VALID_KINDS: ReadonlySet<string> = new Set<NarrativeSectionKind>([
 	'accomplishments',
 	'challenges',
 	'nextSteps',
 ]);
+
+/** Fallback headings when a salvaged section is missing its `title`. */
+const DEFAULT_SECTION_TITLES: Record<NarrativeSectionKind, string> = {
+	accomplishments: 'Accomplishments',
+	challenges: 'Challenges',
+	nextSteps: 'Next Steps',
+};
 
 const VALID_SEVERITIES: ReadonlySet<string> = new Set<NarrativeItemSeverity>([
 	'info',
@@ -230,6 +245,219 @@ export function parseDirectorNotesNarrative(raw: string): ParseNarrativeResult {
 	}
 
 	return { ok: true, narrative: { version: 1, sections } };
+}
+
+/**
+ * Rebuild a JSON object whose tail was cut off mid-stream.
+ *
+ * A synopsis run costs minutes of agent time and emits one very long single-line
+ * object, so a response that dies partway through is the difference between a
+ * readable report and nothing at all. Scan to the last COMPLETE nested container
+ * (an item or a section object), cut there, and close the containers that are
+ * still open. Cutting at a completed `}`/`]` is what makes this safe: it drops
+ * any half-written string, dangling key, or trailing comma along with it.
+ *
+ * Returns `null` when the input is not truncated (the top-level object closes on
+ * its own, so the strict path already had its shot) or when nothing completed.
+ */
+function closeTruncatedJsonObject(raw: string): string | null {
+	const start = raw.indexOf('{');
+	if (start === -1) return null;
+
+	const stack: string[] = [];
+	let inString = false;
+	let escaped = false;
+	// Index of the last `}`/`]` that closed a NESTED container, plus the frames
+	// still open at that point - the cut site and the closers it needs.
+	let cutIndex = -1;
+	let cutStack: string[] = [];
+
+	for (let i = start; i < raw.length; i++) {
+		const char = raw[i];
+
+		if (inString) {
+			if (escaped) escaped = false;
+			else if (char === '\\') escaped = true;
+			else if (char === '"') inString = false;
+			continue;
+		}
+
+		if (char === '"') inString = true;
+		else if (char === '{' || char === '[') stack.push(char);
+		else if (char === '}' || char === ']') {
+			stack.pop();
+			// The top-level object closed: this response is not truncated.
+			if (stack.length === 0) return null;
+			cutIndex = i;
+			cutStack = [...stack];
+		}
+	}
+
+	if (cutIndex === -1) return null;
+
+	const closers = cutStack
+		.reverse()
+		.map((open) => (open === '{' ? '}' : ']'))
+		.join('');
+	return raw.slice(start, cutIndex + 1) + closers;
+}
+
+/**
+ * Escape raw control characters that appear INSIDE strings. A literal newline in
+ * a bullet is invalid JSON (the prompt forbids it, models do it anyway) and is
+ * otherwise a total loss for an entire report.
+ */
+function escapeControlCharsInStrings(jsonText: string): string {
+	const ESCAPES: Record<string, string> = {
+		'\n': '\\n',
+		'\r': '\\r',
+		'\t': '\\t',
+		'\b': '\\b',
+		'\f': '\\f',
+	};
+
+	let out = '';
+	let inString = false;
+	let escaped = false;
+
+	for (const char of jsonText) {
+		if (inString) {
+			if (escaped) escaped = false;
+			else if (char === '\\') escaped = true;
+			else if (char === '"') inString = false;
+
+			if (!escaped && char < ' ') {
+				out += ESCAPES[char] ?? `\\u${char.charCodeAt(0).toString(16).padStart(4, '0')}`;
+				continue;
+			}
+		} else if (char === '"') {
+			inString = true;
+		}
+
+		out += char;
+	}
+
+	return out;
+}
+
+/**
+ * Validate leniently: keep every item and section that is usable and DROP the
+ * rest, rather than failing the whole document the way
+ * {@link parseDirectorNotesNarrative} does. Returns `null` only when the value
+ * is not narrative-shaped at all.
+ */
+function validateNarrativeLenient(
+	parsed: unknown
+): { narrative: DirectorNotesNarrative; dropped: number } | null {
+	if (!isPlainObject(parsed) || !Array.isArray(parsed.sections)) return null;
+
+	let dropped = 0;
+	const sections: NarrativeSection[] = [];
+
+	for (const rawSection of parsed.sections) {
+		if (!isPlainObject(rawSection) || typeof rawSection.kind !== 'string') {
+			dropped++;
+			continue;
+		}
+		if (!VALID_KINDS.has(rawSection.kind)) {
+			dropped++;
+			continue;
+		}
+		const kind = rawSection.kind as NarrativeSectionKind;
+
+		const items: NarrativeItem[] = [];
+		for (const rawItem of Array.isArray(rawSection.items) ? rawSection.items : []) {
+			if (!isPlainObject(rawItem) || typeof rawItem.text !== 'string' || !rawItem.text.trim()) {
+				dropped++;
+				continue;
+			}
+			const item: NarrativeItem = { text: rawItem.text };
+			// A bad severity/agent only costs that field, never the bullet.
+			if (typeof rawItem.severity === 'string' && VALID_SEVERITIES.has(rawItem.severity)) {
+				item.severity = rawItem.severity as NarrativeItemSeverity;
+			}
+			if (typeof rawItem.agent === 'string') item.agent = rawItem.agent;
+			items.push(item);
+		}
+
+		sections.push({
+			kind,
+			title: typeof rawSection.title === 'string' ? rawSection.title : DEFAULT_SECTION_TITLES[kind],
+			items,
+		});
+	}
+
+	if (sections.length === 0) return null;
+	return { narrative: { version: 1, sections }, dropped };
+}
+
+/**
+ * Best-effort salvage of output the strict parser rejected.
+ *
+ * Call this ONLY after {@link parseDirectorNotesNarrative} returns `{ ok: false }`.
+ * It repairs the two failures that actually cost users a report - a response cut
+ * off mid-stream and raw control characters inside strings - then validates
+ * leniently, dropping individual malformed bullets instead of the document.
+ *
+ * Recovery is never silent: `reason` states what was salvaged so the surfaces
+ * can show it next to the narrative. When nothing usable survives, this returns
+ * `{ ok: false }` and the caller shows the strict parse error instead.
+ */
+export function recoverDirectorNotesNarrative(raw: string): RecoverNarrativeResult {
+	if (typeof raw !== 'string' || raw.trim().length === 0) {
+		return { ok: false, error: 'Response was empty.' };
+	}
+
+	// Ordered by fidelity: the untouched object first, then each repair. Each
+	// candidate remembers which repairs produced it so the reason we report is
+	// the one that actually applied.
+	const candidates: Array<{ text: string; wasTruncated: boolean; wasEscaped: boolean }> = [];
+	for (const [text, wasTruncated] of [
+		[extractFirstJsonObject(raw), false],
+		[closeTruncatedJsonObject(raw), true],
+	] as const) {
+		if (text === null) continue;
+		candidates.push({ text, wasTruncated, wasEscaped: false });
+		candidates.push({
+			text: escapeControlCharsInStrings(text),
+			wasTruncated,
+			wasEscaped: true,
+		});
+	}
+
+	for (const candidate of candidates) {
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(candidate.text);
+		} catch {
+			continue;
+		}
+
+		const lenient = validateNarrativeLenient(parsed);
+		if (!lenient) continue;
+
+		const reasons: string[] = [];
+		if (candidate.wasTruncated) {
+			reasons.push('the response was cut off before it finished');
+		}
+		if (candidate.wasEscaped) {
+			reasons.push('the response contained line breaks that are not valid inside JSON');
+		}
+		if (lenient.dropped > 0) {
+			reasons.push(
+				`${lenient.dropped} ${lenient.dropped === 1 ? 'bullet was' : 'bullets were'} malformed and dropped`
+			);
+		}
+		if (reasons.length === 0) reasons.push('the response did not match the expected shape exactly');
+
+		return {
+			ok: true,
+			narrative: lenient.narrative,
+			reason: `Recovered what could be read: ${reasons.join(', and ')}.`,
+		};
+	}
+
+	return { ok: false, error: 'No recoverable narrative content found in the response.' };
 }
 
 /** Render one bullet as Markdown, mirroring Rich Mode's emphasis without colors. */


### PR DESCRIPTION
## What broke

Director's Notes Plain Mode showed a wall of raw JSON instead of a report:

```
{"version":1,"sections":[{"kind":"accomplishments","title":"Accomplishments","items":[{"text":"Ran the Signal, iMessage, ...
```

The synopsis agent emits a structured JSON narrative. Plain Mode renders `narrative ? narrativeToMarkdown(narrative) : synopsis`, so whenever the strict parser rejected a run there was no narrative and the raw string went straight to the markdown renderer. Rich Mode already failed loudly for that same input (`NarrativeParseError`); Plain Mode silently dumped the object.

Reproduced against the live 0.18.5-RC app: a fresh 10-day run (19 agents, 15,003 entries, 2m52s) parsed clean, so the failure is per-run, not a broken pipeline. That is exactly why the raw fallback was invisible until it wasn't.

## What this changes

**Plain Mode never renders the raw structured output.** It shows the narrative as prose, or the shared parse-failure banner with the raw text behind its "View raw output" disclosure.

**A rejected run no longer costs the whole report.** `recoverDirectorNotesNarrative()` runs only after the strict parser fails and handles the failures that actually happen in the field:

- response cut off mid-stream: cut back to the last complete item, close what is still open
- raw line breaks inside a bullet (invalid JSON the prompt forbids, models do anyway)
- one malformed bullet or section: dropped individually, not the document

Recovery is never silent. It returns a reason ("the response was cut off before it finished") and both modes render `NarrativeParseError` in a softer partial-recovery state above the salvaged narrative, so a partial report never reads as a complete one. The strict parser's contract is unchanged.

The CLI's `-f markdown` / `-f text` output takes the same salvage with the reason noted inline. `-f json` still returns the raw synopsis untouched.

## Notes

- `narrativeRecovery` is threaded through the IPC result, preload type, and `global.d.ts`.
- `applyNarrative()` collapses the three places (fresh run, in-flight attach, cache restore) that had to apply the narrative fields by hand.
- Docs: reading-modes section in `docs/director-notes.md`, plus a `SHARED-UTILS.md` entry so nobody hand-rolls JSON repair at a call site.

## Testing

- `directorNotesNarrative.test.ts`: 46 pass, including truncation at two cut points, raw line breaks, dropped items/sections, title fallback, refusal on non-narrative input, never-throws.
- All Director's Notes component tests: 128 pass, with new coverage for both Plain Mode failure surfaces (banner instead of JSON, raw reachable, salvaged prose alongside the banner, Copy exporting prose).
- `npm run lint` and `npm run lint:eslint` clean; full suite green via the pre-push hook.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added best-effort recovery for malformed Director’s Notes AI output.
  - Displays recovered readable content with a recovery warning when possible.
  - Shows a parse-failure alert when recovery is unsuccessful, with raw output available on demand.
  - Ensures Plain and Rich modes avoid displaying raw structured output as the final report.
  - Copy actions now export recovered readable prose when available.

- **Documentation**
  - Documented parsing, recovery, rendering, and failure-state behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->