### PR TITLE
fix(autorun): wrap the active-run action row instead of overflowing the card

### DIFF
--- a/src/__tests__/renderer/components/RightPanel.test.tsx
+++ b/src/__tests__/renderer/components/RightPanel.test.tsx
@@ -1284,6 +1284,74 @@ describe('RightPanel', () => {
 
 			expect(screen.queryByText('View History')).not.toBeInTheDocument();
 		});
+
+		// Every control on the action row is whitespace-nowrap, so a non-wrapping
+		// row overflowed the card and pushed Stop past its right border once the
+		// Right Panel got narrow (issue #1333). jsdom has no layout engine, so
+		// assert on the classes that let the row reflow instead.
+		describe('Action row wrapping at narrow widths', () => {
+			const runningState: BatchRunState = {
+				isRunning: true,
+				isStopping: false,
+				documents: ['doc1'],
+				currentDocumentIndex: 0,
+				totalTasks: 10,
+				completedTasks: 5,
+				currentDocTasksTotal: 10,
+				currentDocTasksCompleted: 5,
+				totalTasksAcrossAllDocs: 10,
+				completedTasksAcrossAllDocs: 5,
+				loopEnabled: true,
+				loopIteration: 0,
+				maxLoops: 5,
+			};
+
+			const getControlsGroup = () =>
+				screen.getByTitle('Stop auto-run after the current task finishes')
+					.parentElement as HTMLElement;
+
+			it('should let the action row wrap so controls stay inside the card', () => {
+				const props = createDefaultProps({ currentSessionBatchState: runningState });
+				render(<RightPanel {...props} />);
+
+				const actionRow = getControlsGroup().parentElement as HTMLElement;
+				expect(actionRow).toHaveClass('flex-wrap');
+				// justify-end (not justify-between) so a wrapped controls line still
+				// hugs the right edge instead of jumping to the left.
+				expect(actionRow).toHaveClass('justify-end');
+				expect(actionRow).not.toHaveClass('justify-between');
+			});
+
+			it('should push the follow-task toggle away from the controls with mr-auto', () => {
+				const props = createDefaultProps({ currentSessionBatchState: runningState });
+				render(<RightPanel {...props} />);
+
+				const toggle = screen.getByText('Follow active task').closest('label') as HTMLElement;
+				expect(toggle).toHaveClass('mr-auto');
+			});
+
+			it('should let the controls group wrap internally rather than overflow', () => {
+				const props = createDefaultProps({ currentSessionBatchState: runningState });
+				render(<RightPanel {...props} />);
+
+				const controls = getControlsGroup();
+				expect(controls).toHaveClass('flex-wrap');
+				expect(controls).toHaveClass('justify-end');
+				// shrink-0 would pin the group at its max-content width and re-introduce
+				// the overflow the wrapping is meant to prevent.
+				expect(controls).not.toHaveClass('shrink-0');
+			});
+
+			it('should keep controls right-aligned in goal mode where the toggle is hidden', () => {
+				const props = createDefaultProps({
+					currentSessionBatchState: { ...runningState, goalMode: true, goalProgress: 40 },
+				});
+				render(<RightPanel {...props} />);
+
+				expect(screen.queryByText('Follow active task')).not.toBeInTheDocument();
+				expect(getControlsGroup().parentElement).toHaveClass('justify-end');
+			});
+		});
 	});
 
 	describe('Imperative handle', () => {

--- a/src/renderer/components/RightPanel.tsx
+++ b/src/renderer/components/RightPanel.tsx
@@ -805,16 +805,18 @@ export const RightPanel = memo(
 
 						{/* Action row - left: the (spec-only) follow-task toggle; right: the
 						    action links + Stop, all on one plane to keep the card compact.
-						    Kept off the status-line row so a long rationale can't clip it. */}
-						<div className="mt-1.5 flex items-center justify-between gap-2">
+						    Kept off the status-line row so a long rationale can't clip it.
+						    Every control here is whitespace-nowrap and must stay legible, so
+						    the row wraps instead of overflowing when the Right Panel is
+						    narrow: `justify-end` + `mr-auto` on the toggle keeps the controls
+						    hard against the right edge on one line, and drops them onto their
+						    own right-aligned line once they no longer fit beside the toggle. */}
+						<div className="mt-1.5 flex flex-wrap items-center justify-end gap-x-2 gap-y-1.5">
 							{/* "Follow active task" only applies to task-based runs that step
 							    through a document. Goal mode iterates a single goal with no
-							    discrete task list to follow, so hide the checkbox there (empty
-							    spacer keeps the controls right-aligned). */}
-							{currentSessionBatchState.goalMode ? (
-								<div />
-							) : (
-								<label className="flex items-center gap-1.5 cursor-pointer shrink-0">
+							    discrete task list to follow, so hide the checkbox there. */}
+							{!currentSessionBatchState.goalMode && (
+								<label className="flex items-center gap-1.5 cursor-pointer shrink-0 mr-auto">
 									<input
 										type="checkbox"
 										checked={autoFollowEnabled}
@@ -827,7 +829,9 @@ export const RightPanel = memo(
 									</span>
 								</label>
 							)}
-							<div className="flex items-center gap-2 shrink-0">
+							{/* Wraps internally too, so the links/Stop stay inside the card even
+							    at the narrowest panel width where they alone can't fit a line. */}
+							<div className="flex flex-wrap items-center justify-end gap-x-2 gap-y-1.5 min-w-0">
 								{/* Loop iteration indicator */}
 								{currentSessionBatchState.loopEnabled && (
 									<span


### PR DESCRIPTION
Closes #1333

## Problem

The Auto Run active-run card (bottom of the Right Panel, shown on every tab) laid out its action row as a single non-wrapping flex line:

```
[ Follow active task ]              [ Loop 1 of 5 ][ View Thoughts ][ View History ][ Stop ]
```

Both sides carried `shrink-0` and every control is `whitespace-nowrap`, so the row had no way to give. Once the Right Panel narrowed past the point where the combined content exceeded the card's inner width, the content overflowed to the right and the Stop button ended up rendered outside the card's border - which is what the reporter saw as the buttons "drifting too far right."

## Fix

`src/renderer/components/RightPanel.tsx` - let the row reflow:

- The action row is now `flex-wrap` with `justify-end`, and the follow-task toggle gets `mr-auto`. Auto margins absorb free space before `justify-content` applies, so at normal widths this renders identically to the old `justify-between` (toggle left, controls hard right). Once the two no longer fit on one line, the controls drop onto their own line and `justify-end` keeps them right-aligned instead of jumping to the left, which is what plain `flex-wrap` + `justify-between` would have done.
- The controls group itself is now wrappable and shrinkable (`flex-wrap justify-end min-w-0`, no `shrink-0`), so at the narrowest panel width the links and Stop wrap among themselves rather than spilling past the card.
- Flex line-breaking uses hypothetical main size, so the group moves to line 2 rather than getting squeezed on line 1 - the labels stay legible.
- Dropped the goal-mode empty `<div />` spacer: it existed only to keep the controls right-aligned under `justify-between`, and `justify-end` does that on its own.

`gap-2` became `gap-x-2 gap-y-1.5` so wrapped lines get sane vertical spacing; horizontal spacing is unchanged.

## Note on base branch

This targets **`rc`, not `main`**. The combined action row is rc-only - `main` still has the older two-row card with no View Thoughts control and no overflow risk. The reporter is on 0.18.5-RC.

## Testing

- Added a `Action row wrapping at narrow widths` block to `src/__tests__/renderer/components/RightPanel.test.tsx` covering the wrap/alignment classes on the row, `mr-auto` on the toggle, the controls group staying shrinkable, and goal-mode right-alignment. jsdom has no layout engine, so these assert on the classes that permit the reflow rather than on measured geometry.
- `npx vitest run src/__tests__/renderer/components/RightPanel.test.tsx` - 94 passed.
- `npm run lint` clean, prettier clean, eslint clean.

Not verified in a running app - the change is CSS-class-only and the reasoning above is from the flexbox layout rules, so a visual check at a narrow Right Panel width is worth doing before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the batch run action layout for narrow panels.
  * Action buttons now wrap cleanly while remaining right-aligned.
  * The “Follow active task” toggle stays left-aligned and maintains spacing across responsive layouts.
  * Improved alignment when goal mode hides the toggle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->