### PR TITLE
fix(director-notes): stop the synopsis agent answering without reading history

### DIFF
--- a/src/prompts/director-notes.md
+++ b/src/prompts/director-notes.md
@@ -28,7 +28,7 @@ You will receive a list of session history file paths below. Each file is a JSON
 
 ## Analysis Strategy
 
-1. **Read each history file** listed in the session manifest below.
+1. **Read each history file** listed in the session manifest below. This is mandatory and it is the first thing you do: the paths are absolute and readable, so open them with your file tools before writing anything. Every bullet you emit must trace back to entries you actually read.
 2. **Filter by timestamp**: Only consider entries with `timestamp` >= the cutoff value provided below.
 3. **Skim summaries first**: Scan the `summary` field of each entry to understand the overall work pattern.
 4. **Drill into detail selectively**: For entries that seem particularly important (failures, large features, repeated patterns), read the `fullResponse` field for more context.
@@ -92,7 +92,7 @@ Shape rules:
 - Keep each item to a single, specific bullet.
 - Include specific details when available (file names, feature names).
 - If there's limited data, provide what insights you can; it is fine for a section's `items` to be empty when there is nothing to report.
-- If a history file cannot be read, skip it and continue with available files.
+- If an individual history file genuinely fails to open after you attempt it, skip that file and continue with the rest. This is not permission to skip the reading step: never report that the files could not be read without having actually tried each path.
 - The lookback period and stats are displayed separately in the UI - do not repeat them in the items.
 
 ## Item Text Rules
@@ -107,10 +107,12 @@ Every `text` value is rendered as a plain string in a styled bullet. It is NOT a
 
 ## CRITICAL: Output Format Rules
 
-- Your response must start IMMEDIATELY with `{` - no text, prose, or code fences before it.
-- Your response must end with `}` - nothing after it.
+These rules govern your FINAL MESSAGE only. They place NO limit on the work you do to produce it: read every history file with your file tools first, taking as many turns as that needs. Answering in a single turn without opening the files is the one failure mode this task cannot tolerate - a synopsis assembled from session names alone is worse than useless, because it reads as authoritative while being invented.
+
+- Your final message must start IMMEDIATELY with `{` - no text, prose, or code fences before it.
+- Your final message must end with `}` - nothing after it.
 - Do NOT wrap the JSON in a markdown code fence.
-- Do NOT include ANY thinking, reasoning, or analysis preamble.
-- Do NOT narrate your process (e.g., "Let me identify the qualifying entries...", "Now I can generate...", "I see X agents with Y entries...").
+- Do NOT include ANY thinking, reasoning, or analysis preamble in the final message.
+- Do NOT narrate your process there (e.g., "Let me identify the qualifying entries...", "Now I can generate...", "I see X agents with Y entries...").
 - Do NOT echo timestamps, cutoff values, entry counts, or intermediate calculations.
-- Your ENTIRE response must be a single valid JSON object and nothing else. Before answering, verify it would survive `JSON.parse`.
+- Your ENTIRE final message must be a single valid JSON object and nothing else. Before answering, verify it would survive `JSON.parse`.


### PR DESCRIPTION
## Symptom

Director's Notes returns in 5-9 seconds with a synopsis that says the history files could not be read, while the stats bar above it shows 15.3K entries across 21 agents. Accomplishments is empty; Challenges says "Session history files could not be read from the Maestro history directory."

## It is not a permissions or path problem

The main process reads the same files fine (that is where the stat widgets come from), and the manifest paths are correct and readable. Tracing the actual batch spawn:

```
claude --print --verbose --output-format stream-json --model opus[1m] --effort high -- <prompt>
```

replayed verbatim against the live 17-session manifest:

```
RESULT success turns=1 toolCalls=0
```

**One turn, zero tool calls.** The agent never opens a file. It then honestly reports that it had nothing to work from, which is the message that reaches the UI.

The cause is the prompt's own `## CRITICAL: Output Format Rules` block. Read as written, it forbids doing any work: respond immediately starting with `{`, no preamble, no narration of process, "your ENTIRE response must be a single valid JSON object and nothing else." The model complies literally, answers from the session display names in the manifest, and reports the gap.

## Fix

Prompt only, no code:

- Scope the output rules to the **final message** and state explicitly that they place no limit on tool use, that reading every file first is mandatory, and that a one-turn answer built from session names is the one unacceptable outcome.
- Make step 1 of Analysis Strategy explicit that the paths are absolute and readable and must be opened before writing anything.
- Tighten the "if a history file cannot be read, skip it" guideline, which was serving as blanket permission to skip the reading step entirely.

## Verification

Same spawn args, same live 17-session manifest, before and after:

| | turns | tool calls | result |
|---|---|---|---|
| before | 1 | 0 | "files could not be read" |
| after | 6 | 5 | 56 items (28 accomplishments, 14 challenges, 14 next steps), valid JSON |

Sample bullet from the passing run: *"Ran the SANS AI Pentesting message-ingest pass on a 3-minute cadence, and after the Gmail token was re-authorized out of band it broke a six-run blind..."* - real content from the entries.

Suites touched by this area pass (134 tests across `director-notes-prompt`, `director-notes-first-party`, and the DirectorNotes components); `npm run lint` clean.

## Residual risk

This is a compliance fix, so it depends on the model following the clarified instruction. It held across runs here, but the deterministic backstop would be to count `tool_use` events in the stream and treat a zero-read synopsis as a failed run rather than a result. Worth doing separately if this recurs.

Independent of #1331, which fixes how the resulting narrative is rendered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved analysis reliability by requiring all history files to be reviewed before processing.
  * Ensured final responses are returned as a single valid JSON object without extra narration or preamble.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->